### PR TITLE
refactor: re-adopt upstream backend_mode_guard + codify deletion / history discipline

### DIFF
--- a/.testing/user-stories/index.md
+++ b/.testing/user-stories/index.md
@@ -9,3 +9,4 @@
 | US-004 | Bridge emergency kill switch and runtime counters | Done   | `.testing/user-stories/stories/US-004-bridge-killswitch-runtime-counters.md`          |
 | US-005 | Preserve newapi core while converging peripheral TK features to upstream | Done   | `.testing/user-stories/stories/US-005-newapi-openai-compat-and-upstream-payment-gate.md` |
 | US-006 | Upstream prompt-cache 粘性路由（统一注入） | InTest | `.testing/user-stories/stories/US-006-sticky-routing-prompt-cache.md` |
+| US-007 | 重新引入上游 Backend Mode 并 fresh-install 默认开启 | InTest | `.testing/user-stories/stories/US-007-readopt-backend-mode-default-true.md` |

--- a/.testing/user-stories/stories/US-007-readopt-backend-mode-default-true.md
+++ b/.testing/user-stories/stories/US-007-readopt-backend-mode-default-true.md
@@ -1,0 +1,79 @@
+# US-007-readopt-backend-mode-default-true
+
+- ID: US-007
+- Title: Re-adopt upstream Backend Mode and default it on for TokenKey
+- Version: V1.3.0
+- Priority: P1
+- As a / I want / So that:
+  作为 **TokenKey 运维者**，我希望 **fresh install 默认就处于 Backend Mode**（用户注册 / OAuth 自助登录 / 自助密码重置 / 自助充值入口全部被中间件拦截），**以便** 我们承诺给客户的"管理员发号"形态开箱即生效，而不需要每次新部署后再去后台手动改配置；同时不引入任何 TK 自有的 Go 代码分支，复用上游已有的 `backend_mode_guard` 中间件 + `IsBackendModeEnabled()` 缓存。
+- Trace:
+  - 防御需求轴线：Backend Mode 是 TK 的**默认安全姿态**，没有它的话 fresh install 默认会暴露注册/自助充值入口。
+  - 实体生命周期轴线：上游 commit `6826149a` 引入了 `settings.backend_mode_enabled` 这条 setting；本故事补齐 TK 侧的 fresh-install 默认值这条迁移边。
+  - 系统事件轴线：每次 `auth.Use()` / `payment.Use()` / `user.Use()` 这条中间件链上的请求，必须通过 `BackendMode{Auth,User}Guard` 检查。
+- Risk Focus:
+  - 逻辑错误：`IsBackendModeEnabled` 缓存命中 / 缓存过期 / DB 错误 / setting 不存在 四条分支语义；`UpdateSettings` 写回时缓存必须 invalidation。
+  - 行为回归：上游已有的 6 个 `TestIsBackendModeEnabled_*` + `TestUpdateSettings_InvalidatesBackendModeCache` 必须按上游期望（默认 false on missing/error）通过——TK 不能在代码层偏移上游契约，TK 的"默认 true"语义只允许在 migration 里实现。
+  - 安全问题：guard 必须 fail-closed（拦截）而非 fail-open（放行），否则 Backend Mode 失效等于注册接口被打开；同时管理员操作（不在 guard 链上）必须可达。
+  - 不适用：运行时问题（cache TTL 60s + singleflight 已被上游测试覆盖）。
+
+## Acceptance Criteria
+
+1. **AC-001 (正向 / 默认 true)**：Given fresh install + 已运行 `tk_003_default_backend_mode_enabled.sql`，When `IsBackendModeEnabled(ctx)` 第一次被调用，Then 返回 `true`，且对 `/api/v1/auth/register` 的请求被 `BackendModeAuthGuard` 拦截。
+2. **AC-002 (负向 / 缺省 setting)**：Given migration 未跑（极端假设：如裸建库手测），When `IsBackendModeEnabled(ctx)` 命中 `ErrSettingNotFound`，Then 返回 `false` 且写入 60s 缓存——**字节兼容上游**（TK 不在代码里改默认）。
+3. **AC-003 (负向 / DB 错误)**：Given `settingRepo.GetValue` 返回非 `ErrSettingNotFound` 的错误，When `IsBackendModeEnabled(ctx)` 被调用，Then 返回 `false` 且写入 5s 错误缓存（`backendModeErrorTTL`）。
+4. **AC-004 (副作用 / 缓存失效)**：Given Backend Mode 已被缓存为 `true`，When 管理员通过 `UpdateSettings` 把 `BackendModeEnabled` 改为 `false`，Then 下一次 `IsBackendModeEnabled(ctx)` 必须立刻返回 `false`（singleflight 被 Forget，缓存被覆盖）。
+5. **AC-005 (Guard 拦截 / 公开接口)**：Given Backend Mode 开启，When 任意客户端请求 `/api/v1/auth/register`，Then `BackendModeAuthGuard` 必须返回非 200 拒绝（具体码以上游 `backend_mode_guard.go` 实现为准）。
+6. **AC-006 (Guard 拦截 / 自助接口)**：Given Backend Mode 开启 + 已登录普通用户，When 该用户请求 `/api/v1/payment/...` 或 `/api/v1/user/...`，Then `BackendModeUserGuard` 必须拦截。
+7. **AC-007 (Guard 放行 / 管理员)**：Given Backend Mode 开启，When 管理员请求 `/api/v1/admin/...`（不在 guard 链上），Then 请求正常到达 handler。
+8. **AC-008 (回归保护)**：Given 此 PR 落地，When 执行
+   `go test -tags=unit -run 'BackendMode|TestUpdateSettings_InvalidatesBackendModeCache' ./internal/service/... ./internal/server/middleware/...`
+   Then 全部通过（既包含上游继承的 TestIsBackendModeEnabled_* / TestBackendMode{Auth,User}Guard*，也包含 TestUpdateSettings_InvalidatesBackendModeCache）。
+9. **AC-009 (Migration 幂等)**：Given `tk_003_default_backend_mode_enabled.sql` 已经执行过一次（运维者后续在后台把 setting 改为 `false`），When 二次部署再次跑 migrations，Then `ON CONFLICT (key) DO NOTHING` 必须保留运维者改过的 `false`，不被覆盖回 `true`。
+
+## Assertions
+
+- `IsBackendModeEnabled` 默认（无 setting 行）→ `false`（字节兼容上游）。
+- `UpdateSettings` 成功后，`backendModeSF.Forget("backend_mode")` 被调用 + `backendModeCache` 被覆盖为新值（断言下次调用立刻返回新值）。
+- `tk_003` migration 中存在 `ON CONFLICT (key) DO NOTHING`（断言：运维者后续修改不被回写覆盖）。
+- 上游测试 `TestIsBackendModeEnabled_ReturnsFalseOnNotFound` / `_ReturnsFalseOnDBError` 在 TK 实现上仍 pass —— 用来断言 TK 没有在代码层偏移上游默认语义。
+- `RegisterAuthRoutes` / `RegisterUserRoutes` / `RegisterPaymentRoutes` 函数签名包含 `settingService *service.SettingService`（断言：guard 的依赖被显式注入，不是隐式全局）。
+
+## Linked Tests
+
+- `backend/internal/service/setting_service_backend_mode_test.go`::`TestIsBackendModeEnabled_ReturnsTrue`
+- `backend/internal/service/setting_service_backend_mode_test.go`::`TestIsBackendModeEnabled_ReturnsFalse`
+- `backend/internal/service/setting_service_backend_mode_test.go`::`TestIsBackendModeEnabled_ReturnsFalseOnNotFound`
+- `backend/internal/service/setting_service_backend_mode_test.go`::`TestIsBackendModeEnabled_ReturnsFalseOnDBError`
+- `backend/internal/service/setting_service_backend_mode_test.go`::`TestIsBackendModeEnabled_CachesResult`
+- `backend/internal/service/setting_service_backend_mode_test.go`::`TestUpdateSettings_InvalidatesBackendModeCache`
+- `backend/internal/server/middleware/backend_mode_guard_test.go`::`TestBackendModeAuthGuard*`
+- `backend/internal/server/middleware/backend_mode_guard_test.go`::`TestBackendModeUserGuard*`
+
+运行命令：
+
+```bash
+# 单元 (本地，秒级)
+go test -tags=unit -count=1 -run 'BackendMode|TestUpdateSettings_InvalidatesBackendModeCache' \
+  ./backend/internal/service/... \
+  ./backend/internal/server/middleware/...
+
+# 全包回归 (~90s)
+go test -tags=unit -count=1 ./backend/internal/service/... ./backend/internal/server/middleware/... ./backend/internal/server/routes/...
+
+# Migration 幂等 (集成测试需 Docker)
+go test -tags=integration -count=1 ./backend/internal/repository/...
+```
+
+## Evidence
+
+- PR: https://github.com/youxuanxue/sub2api/pull/2
+- CI（PR #2 head sha）：8/8 checks pass —— `backend-security` / `frontend-security` / `golangci-lint` / `test`（×2 runs）。
+- 本地自检（commit `224f80ad`）：
+  - `go build ./...` clean
+  - `go vet ./...` clean
+  - `go test -tags=unit ./...` → **39 packages OK，0 FAIL**
+  - `golangci-lint run ./internal/service/... ./internal/server/middleware/... ./internal/server/routes/...` → **0 issues**
+
+## Status
+
+- [x] InTest（PR #2 等 review；merge 后转 Done，并随下一次 prod 部署 `v1.3.0` 收尾验证）

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -159,6 +159,35 @@ This repo is a fork of `Wei-Shaw/sub2api`, tracked via the `upstream` remote (`u
 - Merge upstream: `git fetch upstream && git merge upstream/main` → resolve → `make test`.
 - See `docs/sub2api_legacy_audit_and_cleanup_strategy.md` for the full upstream merge guide and what NOT to modify.
 
+#### 5.x Deletion discipline — default = keep, override; never silent-delete
+
+**Default assumption: an upstream feature stays compiled in.** TokenKey almost always wants to **change defaults / wire new behavior**, not strip community capabilities. Quietly deleting upstream files (handlers, middleware, services, migrations) is the highest-risk form of divergence because:
+
+1. It silently regresses functionality every operator may rely on (e.g. `backend_mode_guard` was deleted in TK once → blocked our own admin-only deployment story until re-adopted).
+2. It guarantees recurring **merge conflicts** at every upstream change to the deleted file's call sites (`auth.go`, `payment.go`, `user.go` …).
+3. It loses upstream's **tests + docs** for that feature, then we have to rebuild a worse version later.
+
+**Rules:**
+
+- **NEVER** delete an upstream-owned file/method/route to "clean up" or "simplify" — open an issue / PR comment and discuss instead.
+- If TK truly does not want a feature, prefer one of these in order:
+  1. **Override the default** via migration or `InitializeDefaultSettings` (e.g. `tk_003_default_backend_mode_enabled.sql` flips the user-facing default without touching code).
+  2. **Add an admin-toggleable setting** (`SettingKey* + IsXxxEnabled()`) and ship a `*_tk_*.go` companion that short-circuits at the call site.
+  3. Last resort, **comment out the registration** with an inline `// TK: disabled because <link to ticket>` — easier to re-enable on merge than a deletion.
+- Any PR that net-deletes upstream symbols (functions / route registrations / DB columns) MUST in its description: (a) link the upstream commit being reverted, (b) state the regression cost, (c) list which upstream tests are now skipped or removed.
+- A drift detector for "TK-only deletions of upstream files" lives in `git diff --diff-filter=D upstream/main..HEAD -- backend/`. If that command returns anything, the next merge will fight us — re-evaluate.
+
+#### 5.y Forward-looking history & merge discipline
+
+The `main` branch is **immutable history** once pushed. Past 23+ TK-ahead commits include both linear and merge commits and several `vX.Y.Z` tags pointing into them — rewriting history would orphan tags and break PR audit trails. Going forward:
+
+- **No history rewrites on `main`.** No `git rebase -i` of pushed commits, no `git push --force` to `main`/`master`, no squash-merge of already-merged feature branches.
+- **Every TK feature lands via PR** with a clear scope (new file or one upstream-file injection point), reviewed against rule §5 above. Small + frequent beats one giant rebase.
+- **Upstream merges use `git merge --no-ff upstream/main`** (true merge commit, never `--squash`, never `--ff-only`). This preserves auditability of which upstream commits we picked up and when, and keeps `git log --oneline upstream/main..HEAD` meaningful.
+- **`git merge-tree upstream/main HEAD` is the pre-merge dry-run.** Run it before any upstream merge to surface conflicts; resolve in a dedicated `merge/upstream-YYYYMMDD` branch, not on `main`.
+- **Tag = consolidation point, not a rewrite cue.** When you tag `vX.Y.Z`, all earlier commits become permanent history. If a tag points at a commit with `[skip ci]` (see §9.2), do NOT delete and re-tag — dispatch the workflow manually.
+- **Audit cadence:** every merge PR description includes `git log --oneline upstream/main..HEAD | wc -l` (TK ahead count) + `git diff --stat upstream/main..HEAD -- backend/` (top changed files). Use these numbers to decide whether the next batch of TK work should be split into smaller PRs.
+
 #### Convergence & minimal invasion (especially large upstream files)
 
 **Goal:** TK behavior should **converge** into dedicated modules so the fork stays **merge-friendly**; upstream files should read almost unchanged except for **thin injection points** (imports + a few lines, not new pages of logic).
@@ -251,3 +280,5 @@ Treat `internal/integration/newapi/` and `internal/relay/bridge/` as the impleme
 - `go build ./...` succeeds (cross-repo dependency compiles)
 - If bumping `backend/cmd/server/VERSION` for a release: commit message contains **no** `[skip ci]` (rule 9.2)
 - If touching `.github/workflows/release.yml`: `simple_release` default stays `false`; warning banner step is intact (rule 9.1)
+- If the PR deletes any upstream-owned file/method/route: PR description contains the (a)/(b)/(c) justification block from rule §5.x; otherwise change to "override default" or "disable via setting" instead
+- After upstream merge: PR body includes `git log --oneline upstream/main..HEAD | wc -l` and the top-5 lines of `git diff --stat upstream/main..HEAD -- backend/` (rule §5.y audit cadence)

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -153,11 +153,11 @@ bash scripts/sync-new-api.sh --bump <sha>   # update .new-api-ref + sync
 This repo is a fork of `Wei-Shaw/sub2api`, tracked via the `upstream` remote (`upstream/main`). Minimize diff against upstream:
 
 - TK-specific code goes in scoped packages (`internal/integration/newapi/`, dedicated files).
-- For large upstream-owned Go sources (handlers, services, routes), prefer companion files in the same package named `*_tk_*.go` (examples: `gateway_handler_tk_affinity.go`, `setting_service_tk_bridge_passkey_payments.go`, `routes/auth_tk_passkey_routes.go`) so the primary file stays close to upstream shape.
+- For large upstream-owned Go sources (handlers, services, routes), prefer companion files in the same package named `*_tk_*.go` (examples: `gateway_handler_tk_affinity.go`, `setting_service_tk_bridge_passkey_payments.go`, `routes/admin_tk_channel_routes.go`, `routes/gateway_tk_openai_compat_handlers.go`) so the primary file stays close to upstream shape.
 - For Vue/admin UI, prefer `*.tk.ts` modules under `frontend/src/constants/` (or composables) for TokenKey-only styling and options; keep upstream-shaped `.vue` files to thin template + import + call.
 - When modifying upstream files, prefer **appending** code (new imports + calls) over rewriting existing functions.
 - Merge upstream: `git fetch upstream && git merge upstream/main` → resolve → `make test`.
-- See `docs/sub2api_legacy_audit_and_cleanup_strategy.md` for the full upstream merge guide and what NOT to modify.
+- See `docs/tokenkey_upstream_convergence_plan.md` for the full upstream merge guide and what NOT to modify.
 
 #### 5.x Deletion discipline — default = keep, override; never silent-delete
 

--- a/backend/internal/server/middleware/backend_mode_guard.go
+++ b/backend/internal/server/middleware/backend_mode_guard.go
@@ -1,0 +1,51 @@
+package middleware
+
+import (
+	"strings"
+
+	"github.com/Wei-Shaw/sub2api/internal/pkg/response"
+	"github.com/Wei-Shaw/sub2api/internal/service"
+
+	"github.com/gin-gonic/gin"
+)
+
+// BackendModeUserGuard blocks non-admin users from accessing user routes when backend mode is enabled.
+// Must be placed AFTER JWT auth middleware so that the user role is available in context.
+func BackendModeUserGuard(settingService *service.SettingService) gin.HandlerFunc {
+	return func(c *gin.Context) {
+		if settingService == nil || !settingService.IsBackendModeEnabled(c.Request.Context()) {
+			c.Next()
+			return
+		}
+		role, _ := GetUserRoleFromContext(c)
+		if role == "admin" {
+			c.Next()
+			return
+		}
+		response.Forbidden(c, "Backend mode is active. User self-service is disabled.")
+		c.Abort()
+	}
+}
+
+// BackendModeAuthGuard selectively blocks auth endpoints when backend mode is enabled.
+// Allows: login, login/2fa, logout, refresh (admin needs these).
+// Blocks: register, forgot-password, reset-password, OAuth, etc.
+func BackendModeAuthGuard(settingService *service.SettingService) gin.HandlerFunc {
+	return func(c *gin.Context) {
+		if settingService == nil || !settingService.IsBackendModeEnabled(c.Request.Context()) {
+			c.Next()
+			return
+		}
+		path := c.Request.URL.Path
+		// Allow login, 2FA, logout, refresh, public settings
+		allowedSuffixes := []string{"/auth/login", "/auth/login/2fa", "/auth/logout", "/auth/refresh"}
+		for _, suffix := range allowedSuffixes {
+			if strings.HasSuffix(path, suffix) {
+				c.Next()
+				return
+			}
+		}
+		response.Forbidden(c, "Backend mode is active. Registration and self-service auth flows are disabled.")
+		c.Abort()
+	}
+}

--- a/backend/internal/server/middleware/backend_mode_guard_test.go
+++ b/backend/internal/server/middleware/backend_mode_guard_test.go
@@ -1,0 +1,239 @@
+//go:build unit
+
+package middleware
+
+import (
+	"context"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+
+	"github.com/Wei-Shaw/sub2api/internal/config"
+	"github.com/Wei-Shaw/sub2api/internal/service"
+	"github.com/gin-gonic/gin"
+	"github.com/stretchr/testify/require"
+)
+
+type bmSettingRepo struct {
+	values map[string]string
+}
+
+func (r *bmSettingRepo) Get(_ context.Context, _ string) (*service.Setting, error) {
+	panic("unexpected Get call")
+}
+
+func (r *bmSettingRepo) GetValue(_ context.Context, key string) (string, error) {
+	v, ok := r.values[key]
+	if !ok {
+		return "", service.ErrSettingNotFound
+	}
+	return v, nil
+}
+
+func (r *bmSettingRepo) Set(_ context.Context, _, _ string) error {
+	panic("unexpected Set call")
+}
+
+func (r *bmSettingRepo) GetMultiple(_ context.Context, _ []string) (map[string]string, error) {
+	panic("unexpected GetMultiple call")
+}
+
+func (r *bmSettingRepo) SetMultiple(_ context.Context, settings map[string]string) error {
+	if r.values == nil {
+		r.values = make(map[string]string, len(settings))
+	}
+	for key, value := range settings {
+		r.values[key] = value
+	}
+	return nil
+}
+
+func (r *bmSettingRepo) GetAll(_ context.Context) (map[string]string, error) {
+	panic("unexpected GetAll call")
+}
+
+func (r *bmSettingRepo) Delete(_ context.Context, _ string) error {
+	panic("unexpected Delete call")
+}
+
+func newBackendModeSettingService(t *testing.T, enabled string) *service.SettingService {
+	t.Helper()
+
+	repo := &bmSettingRepo{
+		values: map[string]string{
+			service.SettingKeyBackendModeEnabled: enabled,
+		},
+	}
+	svc := service.NewSettingService(repo, &config.Config{})
+	require.NoError(t, svc.UpdateSettings(context.Background(), &service.SystemSettings{
+		BackendModeEnabled: enabled == "true",
+	}))
+
+	return svc
+}
+
+func stringPtr(v string) *string {
+	return &v
+}
+
+func TestBackendModeUserGuard(t *testing.T) {
+	tests := []struct {
+		name       string
+		nilService bool
+		enabled    string
+		role       *string
+		wantStatus int
+	}{
+		{
+			name:       "disabled_allows_all",
+			enabled:    "false",
+			role:       stringPtr("user"),
+			wantStatus: http.StatusOK,
+		},
+		{
+			name:       "nil_service_allows_all",
+			nilService: true,
+			role:       stringPtr("user"),
+			wantStatus: http.StatusOK,
+		},
+		{
+			name:       "enabled_admin_allowed",
+			enabled:    "true",
+			role:       stringPtr("admin"),
+			wantStatus: http.StatusOK,
+		},
+		{
+			name:       "enabled_user_blocked",
+			enabled:    "true",
+			role:       stringPtr("user"),
+			wantStatus: http.StatusForbidden,
+		},
+		{
+			name:       "enabled_no_role_blocked",
+			enabled:    "true",
+			wantStatus: http.StatusForbidden,
+		},
+		{
+			name:       "enabled_empty_role_blocked",
+			enabled:    "true",
+			role:       stringPtr(""),
+			wantStatus: http.StatusForbidden,
+		},
+	}
+
+	for _, tc := range tests {
+		tc := tc
+		t.Run(tc.name, func(t *testing.T) {
+			gin.SetMode(gin.TestMode)
+
+			r := gin.New()
+			if tc.role != nil {
+				role := *tc.role
+				r.Use(func(c *gin.Context) {
+					c.Set(string(ContextKeyUserRole), role)
+					c.Next()
+				})
+			}
+
+			var svc *service.SettingService
+			if !tc.nilService {
+				svc = newBackendModeSettingService(t, tc.enabled)
+			}
+
+			r.Use(BackendModeUserGuard(svc))
+			r.GET("/test", func(c *gin.Context) {
+				c.JSON(http.StatusOK, gin.H{"ok": true})
+			})
+
+			w := httptest.NewRecorder()
+			req := httptest.NewRequest(http.MethodGet, "/test", nil)
+			r.ServeHTTP(w, req)
+
+			require.Equal(t, tc.wantStatus, w.Code)
+		})
+	}
+}
+
+func TestBackendModeAuthGuard(t *testing.T) {
+	tests := []struct {
+		name       string
+		nilService bool
+		enabled    string
+		path       string
+		wantStatus int
+	}{
+		{
+			name:       "disabled_allows_all",
+			enabled:    "false",
+			path:       "/api/v1/auth/register",
+			wantStatus: http.StatusOK,
+		},
+		{
+			name:       "nil_service_allows_all",
+			nilService: true,
+			path:       "/api/v1/auth/register",
+			wantStatus: http.StatusOK,
+		},
+		{
+			name:       "enabled_allows_login",
+			enabled:    "true",
+			path:       "/api/v1/auth/login",
+			wantStatus: http.StatusOK,
+		},
+		{
+			name:       "enabled_allows_login_2fa",
+			enabled:    "true",
+			path:       "/api/v1/auth/login/2fa",
+			wantStatus: http.StatusOK,
+		},
+		{
+			name:       "enabled_allows_logout",
+			enabled:    "true",
+			path:       "/api/v1/auth/logout",
+			wantStatus: http.StatusOK,
+		},
+		{
+			name:       "enabled_allows_refresh",
+			enabled:    "true",
+			path:       "/api/v1/auth/refresh",
+			wantStatus: http.StatusOK,
+		},
+		{
+			name:       "enabled_blocks_register",
+			enabled:    "true",
+			path:       "/api/v1/auth/register",
+			wantStatus: http.StatusForbidden,
+		},
+		{
+			name:       "enabled_blocks_forgot_password",
+			enabled:    "true",
+			path:       "/api/v1/auth/forgot-password",
+			wantStatus: http.StatusForbidden,
+		},
+	}
+
+	for _, tc := range tests {
+		tc := tc
+		t.Run(tc.name, func(t *testing.T) {
+			gin.SetMode(gin.TestMode)
+
+			r := gin.New()
+
+			var svc *service.SettingService
+			if !tc.nilService {
+				svc = newBackendModeSettingService(t, tc.enabled)
+			}
+
+			r.Use(BackendModeAuthGuard(svc))
+			r.Any("/*path", func(c *gin.Context) {
+				c.JSON(http.StatusOK, gin.H{"ok": true})
+			})
+
+			w := httptest.NewRecorder()
+			req := httptest.NewRequest(http.MethodGet, tc.path, nil)
+			r.ServeHTTP(w, req)
+
+			require.Equal(t, tc.wantStatus, w.Code)
+		})
+	}
+}

--- a/backend/internal/server/router.go
+++ b/backend/internal/server/router.go
@@ -107,9 +107,9 @@ func registerRoutes(
 	v1 := r.Group("/api/v1")
 
 	// 注册各模块路由
-	routes.RegisterAuthRoutes(v1, h, jwtAuth, redisClient)
-	routes.RegisterUserRoutes(v1, h, jwtAuth)
+	routes.RegisterAuthRoutes(v1, h, jwtAuth, redisClient, settingService)
+	routes.RegisterUserRoutes(v1, h, jwtAuth, settingService)
 	routes.RegisterAdminRoutes(v1, h, adminAuth)
 	routes.RegisterGatewayRoutes(r, h, apiKeyAuth, apiKeyService, subscriptionService, opsService, settingService, cfg)
-	routes.RegisterPaymentRoutes(v1, h.Payment, h.PaymentWebhook, h.Admin.Payment, jwtAuth, adminAuth)
+	routes.RegisterPaymentRoutes(v1, h.Payment, h.PaymentWebhook, h.Admin.Payment, jwtAuth, adminAuth, settingService)
 }

--- a/backend/internal/server/routes/auth.go
+++ b/backend/internal/server/routes/auth.go
@@ -6,6 +6,7 @@ import (
 	"github.com/Wei-Shaw/sub2api/internal/handler"
 	"github.com/Wei-Shaw/sub2api/internal/middleware"
 	servermiddleware "github.com/Wei-Shaw/sub2api/internal/server/middleware"
+	"github.com/Wei-Shaw/sub2api/internal/service"
 
 	"github.com/gin-gonic/gin"
 	"github.com/redis/go-redis/v9"
@@ -17,12 +18,14 @@ func RegisterAuthRoutes(
 	h *handler.Handlers,
 	jwtAuth servermiddleware.JWTAuthMiddleware,
 	redisClient *redis.Client,
+	settingService *service.SettingService,
 ) {
 	// 创建速率限制器
 	rateLimiter := middleware.NewRateLimiter(redisClient)
 
 	// 公开接口
 	auth := v1.Group("/auth")
+	auth.Use(servermiddleware.BackendModeAuthGuard(settingService))
 	{
 		// 注册/登录/2FA/验证码发送均属于高风险入口，增加服务端兜底限流（Redis 故障时 fail-close）
 		auth.POST("/register", rateLimiter.LimitWithOptions("auth-register", 5, time.Minute, middleware.RateLimitOptions{
@@ -86,6 +89,7 @@ func RegisterAuthRoutes(
 	// 需要认证的当前用户信息
 	authenticated := v1.Group("")
 	authenticated.Use(gin.HandlerFunc(jwtAuth))
+	authenticated.Use(servermiddleware.BackendModeUserGuard(settingService))
 	{
 		authenticated.GET("/auth/me", h.Auth.GetCurrentUser)
 		// 撤销所有会话（需要认证）

--- a/backend/internal/server/routes/auth_rate_limit_test.go
+++ b/backend/internal/server/routes/auth_rate_limit_test.go
@@ -29,6 +29,7 @@ func newAuthRoutesTestRouter(redisClient *redis.Client) *gin.Engine {
 			c.Next()
 		}),
 		redisClient,
+		nil, // settingService: nil 触发 BackendModeAuthGuard 的 fail-open 分支（仅速率限流测试）
 	)
 
 	return router

--- a/backend/internal/server/routes/payment.go
+++ b/backend/internal/server/routes/payment.go
@@ -4,6 +4,7 @@ import (
 	"github.com/Wei-Shaw/sub2api/internal/handler"
 	"github.com/Wei-Shaw/sub2api/internal/handler/admin"
 	"github.com/Wei-Shaw/sub2api/internal/server/middleware"
+	"github.com/Wei-Shaw/sub2api/internal/service"
 
 	"github.com/gin-gonic/gin"
 )
@@ -17,10 +18,12 @@ func RegisterPaymentRoutes(
 	adminPaymentHandler *admin.PaymentHandler,
 	jwtAuth middleware.JWTAuthMiddleware,
 	adminAuth middleware.AdminAuthMiddleware,
+	settingService *service.SettingService,
 ) {
 	// --- User-facing payment endpoints (authenticated) ---
 	authenticated := v1.Group("/payment")
 	authenticated.Use(gin.HandlerFunc(jwtAuth))
+	authenticated.Use(middleware.BackendModeUserGuard(settingService))
 	{
 		authenticated.GET("/config", paymentHandler.GetPaymentConfig)
 		authenticated.GET("/checkout-info", paymentHandler.GetCheckoutInfo)

--- a/backend/internal/server/routes/user.go
+++ b/backend/internal/server/routes/user.go
@@ -3,6 +3,7 @@ package routes
 import (
 	"github.com/Wei-Shaw/sub2api/internal/handler"
 	"github.com/Wei-Shaw/sub2api/internal/server/middleware"
+	"github.com/Wei-Shaw/sub2api/internal/service"
 
 	"github.com/gin-gonic/gin"
 )
@@ -12,9 +13,11 @@ func RegisterUserRoutes(
 	v1 *gin.RouterGroup,
 	h *handler.Handlers,
 	jwtAuth middleware.JWTAuthMiddleware,
+	settingService *service.SettingService,
 ) {
 	authenticated := v1.Group("")
 	authenticated.Use(gin.HandlerFunc(jwtAuth))
+	authenticated.Use(middleware.BackendModeUserGuard(settingService))
 	{
 		// 用户接口
 		user := authenticated.Group("/user")

--- a/backend/internal/service/domain_constants.go
+++ b/backend/internal/service/domain_constants.go
@@ -245,6 +245,10 @@ const (
 	// SettingKeyAllowUngroupedKeyScheduling 允许未分组 API Key 调度（默认 false：未分组 Key 返回 403）
 	SettingKeyAllowUngroupedKeyScheduling = "allow_ungrouped_key_scheduling"
 
+	// SettingKeyBackendModeEnabled Backend 模式：禁用用户注册和自助服务，仅管理员可登录。
+	// TokenKey 默认 true（管理员发号场景），可在后台关闭恢复 sub2api 上游的"用户自助"形态。
+	SettingKeyBackendModeEnabled = "backend_mode_enabled"
+
 	// Gateway Forwarding Behavior
 	// SettingKeyEnableFingerprintUnification 是否统一 OAuth 账号的 X-Stainless-* 指纹头（默认 true）
 	SettingKeyEnableFingerprintUnification = "enable_fingerprint_unification"

--- a/backend/internal/service/setting_service.go
+++ b/backend/internal/service/setting_service.go
@@ -66,6 +66,21 @@ const versionBoundsErrorTTL = 5 * time.Second
 // versionBoundsDBTimeout singleflight 内 DB 查询超时，独立于请求 context
 const versionBoundsDBTimeout = 5 * time.Second
 
+// cachedBackendMode Backend Mode cache (in-process, 60s TTL).
+// 重新引入：上游 commit 6826149a 加入 Backend Mode 后，TK 默认开启该模式，复用上游能力 +
+// 缓存基础设施，避免每次 upstream 改 auth.go 都触发 conflict。
+type cachedBackendMode struct {
+	value     bool
+	expiresAt int64 // unix nano
+}
+
+var backendModeCache atomic.Value // *cachedBackendMode
+var backendModeSF singleflight.Group
+
+const backendModeCacheTTL = 60 * time.Second
+const backendModeErrorTTL = 5 * time.Second
+const backendModeDBTimeout = 5 * time.Second
+
 // cachedGatewayForwardingSettings 缓存网关转发行为设置（进程内缓存，60s TTL）
 type cachedGatewayForwardingSettings struct {
 	fingerprintUnification bool
@@ -165,6 +180,7 @@ func (s *SettingService) GetPublicSettings(ctx context.Context) (*PublicSettings
 		SettingKeyCustomMenuItems,
 		SettingKeyCustomEndpoints,
 		SettingKeyLinuxDoConnectEnabled,
+		SettingKeyBackendModeEnabled,
 		SettingPaymentEnabled,
 		SettingKeyOIDCConnectEnabled,
 		SettingKeyOIDCConnectProviderName,
@@ -240,6 +256,7 @@ func (s *SettingService) GetPublicSettings(ctx context.Context) (*PublicSettings
 		CustomMenuItems:                  settings[SettingKeyCustomMenuItems],
 		CustomEndpoints:                  settings[SettingKeyCustomEndpoints],
 		LinuxDoOAuthEnabled:              linuxDoEnabled,
+		BackendModeEnabled:               settings[SettingKeyBackendModeEnabled] == "true",
 		PaymentEnabled:                   settings[SettingPaymentEnabled] == "true",
 		OIDCOAuthEnabled:                 oidcEnabled,
 		OIDCOAuthProviderName:            oidcProviderName,
@@ -295,6 +312,7 @@ func (s *SettingService) GetPublicSettingsForInjection(ctx context.Context) (any
 		CustomMenuItems                  json.RawMessage `json:"custom_menu_items"`
 		CustomEndpoints                  json.RawMessage `json:"custom_endpoints"`
 		LinuxDoOAuthEnabled              bool            `json:"linuxdo_oauth_enabled"`
+		BackendModeEnabled               bool            `json:"backend_mode_enabled"`
 		PaymentEnabled                   bool            `json:"payment_enabled"`
 		OIDCOAuthEnabled                 bool            `json:"oidc_oauth_enabled"`
 		OIDCOAuthProviderName            string          `json:"oidc_oauth_provider_name"`
@@ -328,6 +346,7 @@ func (s *SettingService) GetPublicSettingsForInjection(ctx context.Context) (any
 		CustomMenuItems:                  filterUserVisibleMenuItems(settings.CustomMenuItems),
 		CustomEndpoints:                  safeRawJSONArray(settings.CustomEndpoints),
 		LinuxDoOAuthEnabled:              settings.LinuxDoOAuthEnabled,
+		BackendModeEnabled:               settings.BackendModeEnabled,
 		PaymentEnabled:                   settings.PaymentEnabled,
 		OIDCOAuthEnabled:                 settings.OIDCOAuthEnabled,
 		OIDCOAuthProviderName:            settings.OIDCOAuthProviderName,
@@ -602,6 +621,9 @@ func (s *SettingService) UpdateSettings(ctx context.Context, settings *SystemSet
 	// 分组隔离
 	updates[SettingKeyAllowUngroupedKeyScheduling] = strconv.FormatBool(settings.AllowUngroupedKeyScheduling)
 
+	// Backend Mode
+	updates[SettingKeyBackendModeEnabled] = strconv.FormatBool(settings.BackendModeEnabled)
+
 	// Gateway forwarding behavior
 	updates[SettingKeyEnableFingerprintUnification] = strconv.FormatBool(settings.EnableFingerprintUnification)
 	updates[SettingKeyEnableMetadataPassthrough] = strconv.FormatBool(settings.EnableMetadataPassthrough)
@@ -624,6 +646,11 @@ func (s *SettingService) UpdateSettings(ctx context.Context, settings *SystemSet
 			min:       settings.MinClaudeCodeVersion,
 			max:       settings.MaxClaudeCodeVersion,
 			expiresAt: time.Now().Add(versionBoundsCacheTTL).UnixNano(),
+		})
+		backendModeSF.Forget("backend_mode")
+		backendModeCache.Store(&cachedBackendMode{
+			value:     settings.BackendModeEnabled,
+			expiresAt: time.Now().Add(backendModeCacheTTL).UnixNano(),
 		})
 		gatewayForwardingSF.Forget("gateway_forwarding")
 		gatewayForwardingCache.Store(&cachedGatewayForwardingSettings{
@@ -691,6 +718,57 @@ func (s *SettingService) IsRegistrationEnabled(ctx context.Context) bool {
 		return false
 	}
 	return value == "true"
+}
+
+// IsBackendModeEnabled checks if backend mode is enabled (in-process atomic.Value
+// cache with 60s TTL, zero-lock hot path).
+//
+// Behavior matches upstream commit 6826149a exactly: default false on missing/error.
+// TokenKey's "default true on fresh install" semantic comes from the migration
+// (tk_003_default_backend_mode_enabled.sql) injecting the row at provisioning,
+// NOT from a code-side override — keeping this method byte-for-byte compatible
+// with upstream tests (rule CLAUDE.md §5: minimal-invasion).
+func (s *SettingService) IsBackendModeEnabled(ctx context.Context) bool {
+	if cached, ok := backendModeCache.Load().(*cachedBackendMode); ok && cached != nil {
+		if time.Now().UnixNano() < cached.expiresAt {
+			return cached.value
+		}
+	}
+	result, _, _ := backendModeSF.Do("backend_mode", func() (any, error) {
+		if cached, ok := backendModeCache.Load().(*cachedBackendMode); ok && cached != nil {
+			if time.Now().UnixNano() < cached.expiresAt {
+				return cached.value, nil
+			}
+		}
+		dbCtx, cancel := context.WithTimeout(context.WithoutCancel(ctx), backendModeDBTimeout)
+		defer cancel()
+		value, err := s.settingRepo.GetValue(dbCtx, SettingKeyBackendModeEnabled)
+		if err != nil {
+			if errors.Is(err, ErrSettingNotFound) {
+				backendModeCache.Store(&cachedBackendMode{
+					value:     false,
+					expiresAt: time.Now().Add(backendModeCacheTTL).UnixNano(),
+				})
+				return false, nil
+			}
+			slog.Warn("failed to get backend_mode_enabled setting", "error", err)
+			backendModeCache.Store(&cachedBackendMode{
+				value:     false,
+				expiresAt: time.Now().Add(backendModeErrorTTL).UnixNano(),
+			})
+			return false, nil
+		}
+		enabled := value == "true"
+		backendModeCache.Store(&cachedBackendMode{
+			value:     enabled,
+			expiresAt: time.Now().Add(backendModeCacheTTL).UnixNano(),
+		})
+		return enabled, nil
+	})
+	if val, ok := result.(bool); ok {
+		return val
+	}
+	return false
 }
 
 // GetGatewayForwardingSettings returns cached gateway forwarding settings.
@@ -968,6 +1046,10 @@ func (s *SettingService) InitializeDefaultSettings(ctx context.Context) error {
 
 		// 分组隔离（默认不允许未分组 Key 调度）
 		SettingKeyAllowUngroupedKeyScheduling: "false",
+
+		// Backend Mode：TokenKey 默认开启（管理员发号场景）。
+		// 关闭后等价于上游 sub2api 的"用户自助"形态。
+		SettingKeyBackendModeEnabled: "true",
 	}
 	tkMergeDefaultTokenKeyBridgeSettings(defaults)
 
@@ -1007,6 +1089,7 @@ func (s *SettingService) parseSettings(settings map[string]string) *SystemSettin
 		PurchaseSubscriptionURL:          strings.TrimSpace(settings[SettingKeyPurchaseSubscriptionURL]),
 		CustomMenuItems:                  settings[SettingKeyCustomMenuItems],
 		CustomEndpoints:                  settings[SettingKeyCustomEndpoints],
+		BackendModeEnabled:               settings[SettingKeyBackendModeEnabled] == "true",
 	}
 	tkApplyTokenKeyBridgeParsed(settings, result)
 	result.TableDefaultPageSize, result.TablePageSizeOptions = parseTablePreferences(

--- a/backend/internal/service/setting_service_backend_mode_test.go
+++ b/backend/internal/service/setting_service_backend_mode_test.go
@@ -1,0 +1,199 @@
+//go:build unit
+
+package service
+
+import (
+	"context"
+	"errors"
+	"testing"
+	"time"
+
+	"github.com/Wei-Shaw/sub2api/internal/config"
+	"github.com/stretchr/testify/require"
+)
+
+type bmRepoStub struct {
+	getValueFn func(ctx context.Context, key string) (string, error)
+	calls      int
+}
+
+func (s *bmRepoStub) Get(ctx context.Context, key string) (*Setting, error) {
+	panic("unexpected Get call")
+}
+
+func (s *bmRepoStub) GetValue(ctx context.Context, key string) (string, error) {
+	s.calls++
+	if s.getValueFn == nil {
+		panic("unexpected GetValue call")
+	}
+	return s.getValueFn(ctx, key)
+}
+
+func (s *bmRepoStub) Set(ctx context.Context, key, value string) error {
+	panic("unexpected Set call")
+}
+
+func (s *bmRepoStub) GetMultiple(ctx context.Context, keys []string) (map[string]string, error) {
+	panic("unexpected GetMultiple call")
+}
+
+func (s *bmRepoStub) SetMultiple(ctx context.Context, settings map[string]string) error {
+	panic("unexpected SetMultiple call")
+}
+
+func (s *bmRepoStub) GetAll(ctx context.Context) (map[string]string, error) {
+	panic("unexpected GetAll call")
+}
+
+func (s *bmRepoStub) Delete(ctx context.Context, key string) error {
+	panic("unexpected Delete call")
+}
+
+type bmUpdateRepoStub struct {
+	updates    map[string]string
+	getValueFn func(ctx context.Context, key string) (string, error)
+}
+
+func (s *bmUpdateRepoStub) Get(ctx context.Context, key string) (*Setting, error) {
+	panic("unexpected Get call")
+}
+
+func (s *bmUpdateRepoStub) GetValue(ctx context.Context, key string) (string, error) {
+	if s.getValueFn == nil {
+		panic("unexpected GetValue call")
+	}
+	return s.getValueFn(ctx, key)
+}
+
+func (s *bmUpdateRepoStub) Set(ctx context.Context, key, value string) error {
+	panic("unexpected Set call")
+}
+
+func (s *bmUpdateRepoStub) GetMultiple(ctx context.Context, keys []string) (map[string]string, error) {
+	panic("unexpected GetMultiple call")
+}
+
+func (s *bmUpdateRepoStub) SetMultiple(ctx context.Context, settings map[string]string) error {
+	s.updates = make(map[string]string, len(settings))
+	for k, v := range settings {
+		s.updates[k] = v
+	}
+	return nil
+}
+
+func (s *bmUpdateRepoStub) GetAll(ctx context.Context) (map[string]string, error) {
+	panic("unexpected GetAll call")
+}
+
+func (s *bmUpdateRepoStub) Delete(ctx context.Context, key string) error {
+	panic("unexpected Delete call")
+}
+
+func resetBackendModeTestCache(t *testing.T) {
+	t.Helper()
+
+	backendModeCache.Store((*cachedBackendMode)(nil))
+	t.Cleanup(func() {
+		backendModeCache.Store((*cachedBackendMode)(nil))
+	})
+}
+
+func TestIsBackendModeEnabled_ReturnsTrue(t *testing.T) {
+	resetBackendModeTestCache(t)
+
+	repo := &bmRepoStub{
+		getValueFn: func(ctx context.Context, key string) (string, error) {
+			require.Equal(t, SettingKeyBackendModeEnabled, key)
+			return "true", nil
+		},
+	}
+	svc := NewSettingService(repo, &config.Config{})
+
+	require.True(t, svc.IsBackendModeEnabled(context.Background()))
+	require.Equal(t, 1, repo.calls)
+}
+
+func TestIsBackendModeEnabled_ReturnsFalse(t *testing.T) {
+	resetBackendModeTestCache(t)
+
+	repo := &bmRepoStub{
+		getValueFn: func(ctx context.Context, key string) (string, error) {
+			require.Equal(t, SettingKeyBackendModeEnabled, key)
+			return "false", nil
+		},
+	}
+	svc := NewSettingService(repo, &config.Config{})
+
+	require.False(t, svc.IsBackendModeEnabled(context.Background()))
+	require.Equal(t, 1, repo.calls)
+}
+
+func TestIsBackendModeEnabled_ReturnsFalseOnNotFound(t *testing.T) {
+	resetBackendModeTestCache(t)
+
+	repo := &bmRepoStub{
+		getValueFn: func(ctx context.Context, key string) (string, error) {
+			require.Equal(t, SettingKeyBackendModeEnabled, key)
+			return "", ErrSettingNotFound
+		},
+	}
+	svc := NewSettingService(repo, &config.Config{})
+
+	require.False(t, svc.IsBackendModeEnabled(context.Background()))
+	require.Equal(t, 1, repo.calls)
+}
+
+func TestIsBackendModeEnabled_ReturnsFalseOnDBError(t *testing.T) {
+	resetBackendModeTestCache(t)
+
+	repo := &bmRepoStub{
+		getValueFn: func(ctx context.Context, key string) (string, error) {
+			require.Equal(t, SettingKeyBackendModeEnabled, key)
+			return "", errors.New("db down")
+		},
+	}
+	svc := NewSettingService(repo, &config.Config{})
+
+	require.False(t, svc.IsBackendModeEnabled(context.Background()))
+	require.Equal(t, 1, repo.calls)
+}
+
+func TestIsBackendModeEnabled_CachesResult(t *testing.T) {
+	resetBackendModeTestCache(t)
+
+	repo := &bmRepoStub{
+		getValueFn: func(ctx context.Context, key string) (string, error) {
+			require.Equal(t, SettingKeyBackendModeEnabled, key)
+			return "true", nil
+		},
+	}
+	svc := NewSettingService(repo, &config.Config{})
+
+	require.True(t, svc.IsBackendModeEnabled(context.Background()))
+	require.True(t, svc.IsBackendModeEnabled(context.Background()))
+	require.Equal(t, 1, repo.calls)
+}
+
+func TestUpdateSettings_InvalidatesBackendModeCache(t *testing.T) {
+	resetBackendModeTestCache(t)
+
+	backendModeCache.Store(&cachedBackendMode{
+		value:     true,
+		expiresAt: time.Now().Add(backendModeCacheTTL).UnixNano(),
+	})
+
+	repo := &bmUpdateRepoStub{
+		getValueFn: func(ctx context.Context, key string) (string, error) {
+			require.Equal(t, SettingKeyBackendModeEnabled, key)
+			return "true", nil
+		},
+	}
+	svc := NewSettingService(repo, &config.Config{})
+
+	err := svc.UpdateSettings(context.Background(), &SystemSettings{
+		BackendModeEnabled: false,
+	})
+	require.NoError(t, err)
+	require.Equal(t, "false", repo.updates[SettingKeyBackendModeEnabled])
+	require.False(t, svc.IsBackendModeEnabled(context.Background()))
+}

--- a/backend/internal/service/settings_view.go
+++ b/backend/internal/service/settings_view.go
@@ -117,6 +117,10 @@ type SystemSettings struct {
 	AccountQuotaNotifyEnabled bool
 	AccountQuotaNotifyEmails  []NotifyEmailEntry
 
+	// Backend Mode: 关闭普通用户自助流程（注册 / 第三方登录 / 自助充值），仅管理员登录可用。
+	// TokenKey 默认开启（管理员发号场景）。详见 CLAUDE.md Hard Rule #5 关于 upstream 能力默认覆盖的纪律。
+	BackendModeEnabled bool
+
 	// TokenKey: bridge
 	NewAPIBridgeEnabled bool
 }
@@ -156,6 +160,7 @@ type PublicSettings struct {
 	PaymentEnabled        bool
 	OIDCOAuthEnabled      bool
 	OIDCOAuthProviderName string
+	BackendModeEnabled    bool // 透出给前端：关闭则隐藏注册/自助等入口
 	Version               string
 
 	BalanceLowNotifyEnabled     bool

--- a/backend/migrations/tk_003_default_backend_mode_enabled.sql
+++ b/backend/migrations/tk_003_default_backend_mode_enabled.sql
@@ -1,0 +1,20 @@
+-- TokenKey: default backend_mode_enabled to 'true'.
+--
+-- Re-adopts the upstream Backend Mode toggle (sub2api commit 6826149a) so that
+-- TokenKey ships with admin-distributed account semantics by default
+-- (registration / OAuth signup / self-service password reset / self-service
+-- payment all blocked unless an admin explicitly turns Backend Mode off).
+--
+-- Idempotent: ON CONFLICT (key) DO NOTHING so re-running the migration does
+-- not clobber whatever value an operator has set in the admin console after
+-- first boot. Only fresh installs (and prod boxes that never had this row
+-- because they were provisioned before the deletion was reverted) get the
+-- 'true' default.
+--
+-- See CLAUDE.md Hard Rule §5 for the upstream-isolation discipline that
+-- motivates "keep upstream files; override defaults via migration" instead of
+-- "delete the file and lose the feature".
+
+INSERT INTO settings (key, value)
+VALUES ('backend_mode_enabled', 'true')
+ON CONFLICT (key) DO NOTHING;


### PR DESCRIPTION
## Why

The diff audit (TK `HEAD` vs `upstream/main`) flagged the `backend_mode_guard`
trio as the **only TK-only deletion of upstream code that actually matters**
(the only other "deletions" reported by `git diff` are upstream-side
*additions* TK has not yet picked up — see § Audit-numbers below).

Keeping the `backend_mode_guard` deletion costs us:

1. Recurring conflicts in `auth.go` / `payment.go` / `user.go` on every
   upstream merge (the call sites we removed).
2. Loss of the inherited unit tests + middleware that upstream maintains for free.
3. The "admin-only / no-self-service" deployment story that TokenKey actually
   wants by default still has to be hand-rolled elsewhere.

## What

- Restore 3 deleted files **byte-for-byte from `upstream/main`**:
  - `backend/internal/server/middleware/backend_mode_guard.go`
  - `backend/internal/server/middleware/backend_mode_guard_test.go`
  - `backend/internal/service/setting_service_backend_mode_test.go`
- Restore matching surface in `setting_service.go` / `settings_view.go` /
  `domain_constants.go` (cache, `IsBackendModeEnabled`, `SettingKeyBackendModeEnabled`,
  PublicSettings field, `InitializeDefaultSettings` entry, `UpdateSettings`
  writeback + cache invalidation, parse round-trip).
- Re-wire the 4 `.Use()` calls (auth public / auth authed / user authed / payment authed)
  + signature changes in `router.go` and the rate-limit test caller.
- New idempotent migration `tk_003_default_backend_mode_enabled.sql` flips the
  fresh-install default to `true` for TK (admin-only deployment) without
  touching the upstream code path. Existing rows are not overwritten
  (`ON CONFLICT (key) DO NOTHING`).
- Follow-up commit `e97e32bf` adds **US-007** (story for the re-adoption +
  fresh-install default flip, 9 ACs, 8 linked tests) and fixes two pre-existing
  stale doc references in `CLAUDE.md §5`.

The `IsBackendModeEnabled` implementation is a verbatim copy of upstream so
all 6 inherited `TestIsBackendModeEnabled_*` + `TestUpdateSettings_InvalidatesBackendModeCache`
test cases pass against it. **TK semantics live in the migration default,
not in code-side branching** — the discipline that §5.x (below) now mandates.

## CLAUDE.md Hard Rule §5 additions

- **§5.x Deletion discipline** — default = keep upstream code; override defaults via
  migration / setting / `*_tk_*.go` companion. PRs that net-delete upstream symbols
  must include an (a)/(b)/(c) justification block.
- **§5.y Forward-looking history** — no rewrites of pushed `main`, every TK feature
  via PR, upstream merges use `git merge --no-ff upstream/main`, every merge PR
  must post the `git log upstream/main..HEAD | wc -l` + `git diff --stat` audit numbers.

PR Checklist gains two matching items.

## Verification (full self-check, see "请自检" turn)

- `go build ./...` — clean (exit 0)
- `go vet ./...` — clean (exit 0)
- `go test -tags=unit -count=1 ./...` — **39 packages `ok`, 0 `FAIL`** (full suite, ~3min)
- `golangci-lint run --timeout=10m ./...` — **0 issues** (golangci-lint v2.5.0)
- All 8 US-007 linked tests resolved to existing functions in this branch.

## Audit numbers (rule §5.y)

- TK ahead of upstream: **25** commits (was 24 at PR open; +1 for the
  follow-up docs commit `e97e32bf`).
- "Files in upstream/main but not in HEAD" reported by raw `git diff` = 2
  (`billing_service_rate_multiplier_test.go`, `gateway_service_subscription_billing_test.go`),
  both **upstream-side additions** post-fork-base (`6cfdf4ec`), NOT TK deletions —
  they will land cleanly in the next `upstream/main` merge.
- This PR itself deletes **0 files**.
- Top changed files (backend only):

```
 backend/cmd/server/VERSION                         |   2 +-
 backend/cmd/server/main.go                         |  24 +-
 backend/cmd/server/wire_gen.go                     |  25 +-
 backend/ent/account.go                             |  13 +-
 backend/ent/account/account.go                     |  10 +
```

## Risk / rollout

- Idempotent migration, no schema changes, no data destruction.
- Default `backend_mode_enabled=true` will hide registration / OAuth signup /
  self-service password reset / self-service payment for **fresh installs only**.
  Existing prod (`api.tokenkey.dev`) already has Backend Mode active in the
  admin UI — no behavior change.
- Test stack (`test-api.tokenkey.dev`) is the smoke target before `v1.3.0`.