### PR TITLE
fix: bump dev-rules submodule to pick up preflight § 2 GIT_DIR isolation

### DIFF
--- a/docs/preflight-debt.md
+++ b/docs/preflight-debt.md
@@ -73,17 +73,27 @@
 - **不再发生的依据**：design doc §11.2 现在提供按文件 `grep -cE "^func Test"` 的可复算明细；下次任何人加测试时，只要本 PR 的覆盖矩阵列表与统计一起改即可。
 - **未来门禁**：可在 `docs/approved/*.md` 中新增 `<!-- stat:newapi-tests -->34<!-- /stat -->` 块，由 `dev-rules/sync-stats.sh --check`（preflight § 8）机械核对——目前未做，因为只有一处数字、人工 audit 成本低于建表本身。
 
-### 7. dev-rules `templates/preflight.sh § 2` 在 worktree 内 commit hook 中假 fail
+### 7. dev-rules `templates/preflight.sh § 2` 在 worktree 内 commit hook 中假 fail — **closed (2026-04-20)**
 
-- **现象**：本 worktree (`/Users/xuejiao/Codes/token/tk/sub2api-newapi-fifth`) 是从主仓库 `git worktree add` 出来的；`./scripts/preflight.sh` 直接跑 PASS，但通过 `git commit` 触发 pre-commit hook 时 § 2 (`dev-rules submodule pointer is reachable on remote`) 报 `FAIL: submodule SHA ... not found in dev-rules — submodule was not committed first`。
-- **根因**（2026-04-20 复现确认）：git 在 commit 阶段把 `GIT_DIR=/path/to/sub2api/.git/worktrees/sub2api-newapi-fifth` / `GIT_INDEX_FILE=...` 注入 hook 子进程；`templates/preflight.sh § 2` 内 `(cd dev-rules && git cat-file -e "$sub_sha" 2>/dev/null)` 子 shell 不 unset GIT_DIR，git 仍按上级 worktree 的 GIT_DIR 解析对象库，找不到子模块对象。脚本 `bash -c '... env -i ... cd dev-rules && git cat-file -e $sha'` 复现稳定（exit=1），unset GIT_DIR 后 PASS。
-- **影响**：
-  - 阻塞所有从 worktree 发起的合法 commit（手动 preflight 全绿但 hook 假 fail）。
-  - 本 PR 在 audit 阶段被迫使用 `git commit --no-verify`（手动 preflight 已 PASS 作为补偿），违反"hook 必须通过"软规则。
-- **决策**：上修到 dev-rules 仓库（`templates/preflight.sh § 2` 在 `cd dev-rules` 子 shell 前 `unset GIT_DIR GIT_INDEX_FILE GIT_WORK_TREE`）。本 PR 范围内仅登记 + worktree commit 用 `--no-verify`。
-- **门禁**：dev-rules 修复后，本仓库 `git submodule update --remote dev-rules` 拉新 SHA 即自动恢复 hook 拦截。
-- **截止日期**：2026-04-26（一周内推 dev-rules 修复 PR）。
-- **临时缓解**：从 sub2api **主仓库** 目录（非 worktree）做 commit 不受影响（GIT_DIR 直接指向主 .git）；或用 `git -c core.hooksPath=/dev/null commit ...` 显式跳 hook（与 `--no-verify` 等价但更显式）。
+- **现象**：worktree (`git worktree add`) 内 `./scripts/preflight.sh` 直接跑 PASS，但 `git commit` 触发 pre-commit hook 时 § 2 报 `FAIL: submodule SHA ... not found in dev-rules — submodule was not committed first`。
+- **根因**（2026-04-20 复现确认）：git 在 hook 阶段把 `GIT_DIR=/path/to/sub2api/.git/worktrees/<name>` / `GIT_INDEX_FILE=...` 注入子进程；`templates/preflight.sh § 2` 内 `(cd dev-rules && git cat-file -e $sub_sha)` 子 shell 不 unset GIT_DIR，git 仍按上级 worktree 的 GIT_DIR 解析对象库 —— 而那个对象库是 sub2api 的，不存在 dev-rules 子模块的 SHA，所以 cat-file 必然 fail。复现脚本：`(export GIT_DIR=/.../sub2api/.git GIT_INDEX_FILE=... && bash dev-rules/templates/preflight.sh)` → §2 FAIL；unset GIT_DIR 后 PASS。
+- **影响**（修复前）：
+  - 所有从 worktree 发起的合法 commit 被 false fail 卡死。
+  - 三次 sub2api commit（feature/newapi-fifth-platform 期间）被迫使用 `git commit --no-verify`，违反"hook 必须通过"硬规则；后续 PR 一直用"手动 preflight 已 PASS"作为脆弱补偿。
+- **整改**（2026-04-20）：
+  - 上修到 dev-rules 仓库 [PR #2](https://github.com/youxuanxue/dev-rules/pull/2) — 提取 `git_sub <subdir> <args...>` 辅助函数，在 subshell 内 `unset` 全部 8 个 git context env vars (`GIT_DIR / GIT_WORK_TREE / GIT_INDEX_FILE / GIT_NAMESPACE / GIT_OBJECT_DIRECTORY / GIT_ALTERNATE_OBJECT_DIRECTORIES / GIT_COMMON_DIR / GIT_PREFIX`) 再调 git；§ 2 三处子 shell 调用全部走 helper。
+  - dev-rules main HEAD = `7b69490`（从 `5fc8988`→`7b69490`，仅 1 个 fix commit）。
+  - sub2api 本 PR bump submodule pointer 到 `7b69490`，hook 拦截恢复硬门禁，今后 worktree commit 不再需要 `--no-verify`。
+- **回归矩阵**（在 sub2api 实测）：
+
+  | 上下文 | 修前 | 修后 |
+  |---|---|---|
+  | 正常 CLI（无 GIT_DIR） | PASS | PASS（无 regression） |
+  | Hook 上下文（GIT_DIR 已 set） | **FAIL（false fail）** | **PASS** |
+  | dev-rules `verify-rules.sh` 自检 | PASS | PASS（8/8） |
+
+- **不再发生的依据**：`git_sub()` 是结构性修复，所有未来需要在 hook 上下文调用子模块 git 的检查段都可以复用，不会再忘 unset。
+- **附记**：修复后 `git -c core.hooksPath=/dev/null commit ...` 与 `--no-verify` 不再是"日常工具"，仅保留作 emergency override。
 
 ### 8. commit message body 提及 skip-marker 字面触发 GitHub Actions skip — **closed (2026-04-20)**
 


### PR DESCRIPTION
## What

Bumps `dev-rules` submodule from `5fc8988` → `7b69490` to pick up
[dev-rules#2](https://github.com/youxuanxue/dev-rules/pull/2) which fixes
the worktree / hook-context false-fail in `templates/preflight.sh § 2`.

Closes `docs/preflight-debt.md § 7` (deadline 2026-04-26, met 6 days early).

## Why

When git invokes a hook (pre-commit, commit-msg, …) it exports
`GIT_DIR` / `GIT_WORK_TREE` / `GIT_INDEX_FILE` pointing at the OUTER
repo. The previous § 2 code did `(cd dev-rules && git cat-file -e
$sub_sha)`; the subshell inherited those env vars, asked the OUTER repo
for the inner submodule's SHA, and naturally got "not found" — even
though the SHA was correctly recorded and reachable on `dev-rules
origin/main`.

Symptom: every worktree-based commit failed § 2 spuriously, and the only
way to get work done was `git commit --no-verify`. This eroded the
entire preflight gate and three earlier sub2api commits had to use
`--no-verify` as a result. PR #15's commit body explicitly noted this
as `preflight-debt § 7` with the 2026-04-26 deadline.

The dev-rules fix extracts a generic `git_sub <subdir> <args...>` helper
that `unset`s every git-context env var documented in `git --help
environment` (8 vars total) before invoking git in the subshell. § 2's
three calls (`cat-file -e`, `fetch`, `merge-base --is-ancestor`) all
route through the helper.

## Verification

This is the regression test:

| Context | Before | After |
|---|---|---|
| Normal CLI (no `GIT_DIR`) | PASS | PASS (no regression) |
| Hook context (`GIT_DIR` exported) | **FAIL** (false fail) | **PASS** |
| `dev-rules verify-rules.sh` self-check | PASS | PASS (8/8) |
| **This very commit through real pre-commit hook (no `--no-verify`)** | n/a | **PASS** |

Reproduction (run from any project that uses dev-rules):

```sh
(
  export GIT_DIR=$(pwd)/.git
  export GIT_INDEX_FILE=$(pwd)/.git/index
  export GIT_WORK_TREE=$(pwd)
  bash dev-rules/templates/preflight.sh 2>&1 | grep -A1 'submodule pointer'
)
# Before dev-rules#2: FAIL: submodule SHA <sha> not found in dev-rules
# After  dev-rules#2: ok: submodule SHA reachable on dev-rules origin/main
```

## Diff scope

- `dev-rules`: submodule pointer `5fc8988` → `7b69490` (1 commit, dev-rules#2).
- `docs/preflight-debt.md`: § 7 marked closed with full root-cause /
  remediation / regression-matrix narrative; future readers can audit
  exactly what changed and why.
- No project code touched. `scripts/preflight.sh` wrapper unchanged —
  only the dev-rules template's internals changed.

## Operational impact

After merge, every dev-rules consumer (sub2api, zw-brain, etc.) that
syncs the new submodule pointer regains the hard `git commit` pre-commit
gate from any worktree. `--no-verify` and `git -c core.hooksPath=/dev/null`
revert to genuine emergency overrides instead of daily workarounds.


Made with [Cursor](https://cursor.com)