### PR TITLE
chore: merge upstream/main (7 commits) into TK fork

### DIFF
--- a/.cursor/rules/product-dev.mdc
+++ b/.cursor/rules/product-dev.mdc
@@ -103,6 +103,8 @@ alwaysApply: true
 - 原型分支命名：`prototype/[issue-id]-[描述]`
 - 功能分支命名：`feature/[issue-id]-[描述]`
 - 修复分支命名：`fix/[issue-id]-[描述]`
+- 文档分支命名：`docs/[描述]`
+- 上游合并分支命名：`merge/upstream-YYYY-MM-DD`（消费 fork 的项目使用，受 PR shape 工作流验证）
 - 提交消息聚焦"为什么"而非"改了什么"
 - 每个 PR 只解决一个问题，不混合无关变更
 

--- a/LICENSE
+++ b/LICENSE
@@ -1,21 +1,165 @@
-MIT License
+                   GNU LESSER GENERAL PUBLIC LICENSE
+                       Version 3, 29 June 2007
 
-Copyright (c) 2025 Wesley Liddick
+ Copyright (C) 2007 Free Software Foundation, Inc. <https://fsf.org/>
+ Everyone is permitted to copy and distribute verbatim copies
+ of this license document, but changing it is not allowed.
 
-Permission is hereby granted, free of charge, to any person obtaining a copy
-of this software and associated documentation files (the "Software"), to deal
-in the Software without restriction, including without limitation the rights
-to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
-copies of the Software, and to permit persons to whom the Software is
-furnished to do so, subject to the following conditions:
 
-The above copyright notice and this permission notice shall be included in all
-copies or substantial portions of the Software.
+  This version of the GNU Lesser General Public License incorporates
+the terms and conditions of version 3 of the GNU General Public
+License, supplemented by the additional permissions listed below.
 
-THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
-IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
-FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
-AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
-LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
-OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
-SOFTWARE.
+  0. Additional Definitions.
+
+  As used herein, "this License" refers to version 3 of the GNU Lesser
+General Public License, and the "GNU GPL" refers to version 3 of the GNU
+General Public License.
+
+  "The Library" refers to a covered work governed by this License,
+other than an Application or a Combined Work as defined below.
+
+  An "Application" is any work that makes use of an interface provided
+by the Library, but which is not otherwise based on the Library.
+Defining a subclass of a class defined by the Library is deemed a mode
+of using an interface provided by the Library.
+
+  A "Combined Work" is a work produced by combining or linking an
+Application with the Library.  The particular version of the Library
+with which the Combined Work was made is also called the "Linked
+Version".
+
+  The "Minimal Corresponding Source" for a Combined Work means the
+Corresponding Source for the Combined Work, excluding any source code
+for portions of the Combined Work that, considered in isolation, are
+based on the Application, and not on the Linked Version.
+
+  The "Corresponding Application Code" for a Combined Work means the
+object code and/or source code for the Application, including any data
+and utility programs needed for reproducing the Combined Work from the
+Application, but excluding the System Libraries of the Combined Work.
+
+  1. Exception to Section 3 of the GNU GPL.
+
+  You may convey a covered work under sections 3 and 4 of this License
+without being bound by section 3 of the GNU GPL.
+
+  2. Conveying Modified Versions.
+
+  If you modify a copy of the Library, and, in your modifications, a
+facility refers to a function or data to be supplied by an Application
+that uses the facility (other than as an argument passed when the
+facility is invoked), then you may convey a copy of the modified
+version:
+
+   a) under this License, provided that you make a good faith effort to
+   ensure that, in the event an Application does not supply the
+   function or data, the facility still operates, and performs
+   whatever part of its purpose remains meaningful, or
+
+   b) under the GNU GPL, with none of the additional permissions of
+   this License applicable to that copy.
+
+  3. Object Code Incorporating Material from Library Header Files.
+
+  The object code form of an Application may incorporate material from
+a header file that is part of the Library.  You may convey such object
+code under terms of your choice, provided that, if the incorporated
+material is not limited to numerical parameters, data structure
+layouts and accessors, or small macros, inline functions and templates
+(ten or fewer lines in length), you do both of the following:
+
+   a) Give prominent notice with each copy of the object code that the
+   Library is used in it and that the Library and its use are
+   covered by this License.
+
+   b) Accompany the object code with a copy of the GNU GPL and this license
+   document.
+
+  4. Combined Works.
+
+  You may convey a Combined Work under terms of your choice that,
+taken together, effectively do not restrict modification of the
+portions of the Library contained in the Combined Work and reverse
+engineering for debugging such modifications, if you also do each of
+the following:
+
+   a) Give prominent notice with each copy of the Combined Work that
+   the Library is used in it and that the Library and its use are
+   covered by this License.
+
+   b) Accompany the Combined Work with a copy of the GNU GPL and this license
+   document.
+
+   c) For a Combined Work that displays copyright notices during
+   execution, include the copyright notice for the Library among
+   these notices, as well as a reference directing the user to the
+   copies of the GNU GPL and this license document.
+
+   d) Do one of the following:
+
+       0) Convey the Minimal Corresponding Source under the terms of this
+       License, and the Corresponding Application Code in a form
+       suitable for, and under terms that permit, the user to
+       recombine or relink the Application with a modified version of
+       the Linked Version to produce a modified Combined Work, in the
+       manner specified by section 6 of the GNU GPL for conveying
+       Corresponding Source.
+
+       1) Use a suitable shared library mechanism for linking with the
+       Library.  A suitable mechanism is one that (a) uses at run time
+       a copy of the Library already present on the user's computer
+       system, and (b) will operate properly with a modified version
+       of the Library that is interface-compatible with the Linked
+       Version.
+
+   e) Provide Installation Information, but only if you would otherwise
+   be required to provide such information under section 6 of the
+   GNU GPL, and only to the extent that such information is
+   necessary to install and execute a modified version of the
+   Combined Work produced by recombining or relinking the
+   Application with a modified version of the Linked Version. (If
+   you use option 4d0, the Installation Information must accompany
+   the Minimal Corresponding Source and Corresponding Application
+   Code. If you use option 4d1, you must provide the Installation
+   Information in the manner specified by section 6 of the GNU GPL
+   for conveying Corresponding Source.)
+
+  5. Combined Libraries.
+
+  You may place library facilities that are a work based on the
+Library side by side in a single library together with other library
+facilities that are not Applications and are not covered by this
+License, and convey such a combined library under terms of your
+choice, if you do both of the following:
+
+   a) Accompany the combined library with a copy of the same work based
+   on the Library, uncombined with any other library facilities,
+   conveyed under the terms of this License.
+
+   b) Give prominent notice with the combined library that part of it
+   is a work based on the Library, and explaining where to find the
+   accompanying uncombined form of the same work.
+
+  6. Revised Versions of the GNU Lesser General Public License.
+
+  The Free Software Foundation may publish revised and/or new versions
+of the GNU Lesser General Public License from time to time. Such new
+versions will be similar in spirit to the present version, but may
+differ in detail to address new problems or concerns.
+
+  Each version is given a distinguishing version number. If the
+Library as you received it specifies that a certain numbered version
+of the GNU Lesser General Public License "or any later version"
+applies to it, you have the option of following the terms and
+conditions either of that published version or of any later version
+published by the Free Software Foundation. If the Library as you
+received it does not specify a version number of the GNU Lesser
+General Public License, you may choose any version of the GNU Lesser
+General Public License ever published by the Free Software Foundation.
+
+  If the Library as you received it specifies that a proxy can decide
+whether future versions of the GNU Lesser General Public License shall
+apply, that proxy's public statement of acceptance of any version is
+permanent authorization for you to choose that version for the
+Library.

--- a/README.md
+++ b/README.md
@@ -618,7 +618,9 @@ sub2api/
 
 ## License
 
-MIT License
+This project is licensed under the [GNU Lesser General Public License v3.0](LICENSE) (or later).
+
+Copyright (c) 2026 Wesley Liddick
 
 ---
 

--- a/README_CN.md
+++ b/README_CN.md
@@ -679,7 +679,9 @@ sub2api/
 
 ## 许可证
 
-MIT License
+本项目基于 [GNU 宽通用公共许可证 v3.0](LICENSE)（或更高版本）授权。
+
+Copyright (c) 2026 Wesley Liddick
 
 ---
 

--- a/README_JA.md
+++ b/README_JA.md
@@ -617,7 +617,9 @@ sub2api/
 
 ## ライセンス
 
-MIT License
+本プロジェクトは [GNU Lesser General Public License v3.0](LICENSE)（またはそれ以降のバージョン）の下でライセンスされています。
+
+Copyright (c) 2026 Wesley Liddick
 
 ---
 

--- a/backend/internal/repository/account_repo.go
+++ b/backend/internal/repository/account_repo.go
@@ -438,6 +438,9 @@ func (r *accountRepository) Delete(ctx context.Context, id int64) error {
 	if _, err := txClient.AccountGroup.Delete().Where(dbaccountgroup.AccountIDEQ(id)).Exec(ctx); err != nil {
 		return err
 	}
+	if _, err := txClient.ExecContext(ctx, "DELETE FROM scheduled_test_plans WHERE account_id = $1", id); err != nil {
+		return err
+	}
 	if _, err := txClient.Account.Delete().Where(dbaccount.IDEQ(id)).Exec(ctx); err != nil {
 		return err
 	}

--- a/backend/internal/service/account.go
+++ b/backend/internal/service/account.go
@@ -121,6 +121,9 @@ func (a *Account) IsSchedulable() bool {
 	if a.TempUnschedulableUntil != nil && now.Before(*a.TempUnschedulableUntil) {
 		return false
 	}
+	if a.IsAPIKeyOrBedrock() && a.IsQuotaExceeded() {
+		return false
+	}
 	return true
 }
 

--- a/backend/internal/service/account_quota_schedulable_test.go
+++ b/backend/internal/service/account_quota_schedulable_test.go
@@ -1,0 +1,123 @@
+//go:build unit
+
+package service
+
+import (
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/require"
+)
+
+func TestAccountIsSchedulable_QuotaExceeded(t *testing.T) {
+	now := time.Now()
+
+	tests := []struct {
+		name    string
+		account *Account
+		want    bool
+	}{
+		{
+			name: "apikey daily quota exceeded",
+			account: &Account{
+				Status:      StatusActive,
+				Schedulable: true,
+				Type:        AccountTypeAPIKey,
+				Extra: map[string]any{
+					"quota_daily_limit": 10.0,
+					"quota_daily_used":  10.0,
+					"quota_daily_start": now.Add(-1 * time.Hour).Format(time.RFC3339),
+				},
+			},
+			want: false,
+		},
+		{
+			name: "apikey weekly quota exceeded",
+			account: &Account{
+				Status:      StatusActive,
+				Schedulable: true,
+				Type:        AccountTypeAPIKey,
+				Extra: map[string]any{
+					"quota_weekly_limit": 50.0,
+					"quota_weekly_used":  50.0,
+					"quota_weekly_start": now.Add(-2 * 24 * time.Hour).Format(time.RFC3339),
+				},
+			},
+			want: false,
+		},
+		{
+			name: "apikey total quota exceeded",
+			account: &Account{
+				Status:      StatusActive,
+				Schedulable: true,
+				Type:        AccountTypeAPIKey,
+				Extra: map[string]any{
+					"quota_limit": 100.0,
+					"quota_used":  100.0,
+				},
+			},
+			want: false,
+		},
+		{
+			name: "apikey quota not exceeded",
+			account: &Account{
+				Status:      StatusActive,
+				Schedulable: true,
+				Type:        AccountTypeAPIKey,
+				Extra: map[string]any{
+					"quota_daily_limit": 10.0,
+					"quota_daily_used":  5.0,
+					"quota_daily_start": now.Add(-1 * time.Hour).Format(time.RFC3339),
+				},
+			},
+			want: true,
+		},
+		{
+			name: "apikey expired daily period restores schedulable",
+			account: &Account{
+				Status:      StatusActive,
+				Schedulable: true,
+				Type:        AccountTypeAPIKey,
+				Extra: map[string]any{
+					"quota_daily_limit": 10.0,
+					"quota_daily_used":  10.0,
+					"quota_daily_start": now.Add(-25 * time.Hour).Format(time.RFC3339),
+				},
+			},
+			want: true,
+		},
+		{
+			name: "oauth ignores quota exceeded",
+			account: &Account{
+				Status:      StatusActive,
+				Schedulable: true,
+				Type:        AccountTypeOAuth,
+				Extra: map[string]any{
+					"quota_daily_limit": 10.0,
+					"quota_daily_used":  10.0,
+					"quota_daily_start": now.Add(-1 * time.Hour).Format(time.RFC3339),
+				},
+			},
+			want: true,
+		},
+		{
+			name: "bedrock quota exceeded",
+			account: &Account{
+				Status:      StatusActive,
+				Schedulable: true,
+				Type:        AccountTypeBedrock,
+				Extra: map[string]any{
+					"quota_limit": 200.0,
+					"quota_used":  200.0,
+				},
+			},
+			want: false,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			require.Equal(t, tt.want, tt.account.IsSchedulable())
+		})
+	}
+}

--- a/backend/internal/service/gateway_request.go
+++ b/backend/internal/service/gateway_request.go
@@ -962,7 +962,7 @@ func NormalizeClaudeOutputEffort(raw string) *string {
 		return nil
 	}
 	switch value {
-	case "low", "medium", "high", "max":
+	case "low", "medium", "high", "xhigh", "max":
 		return &value
 	default:
 		return nil

--- a/backend/internal/service/gateway_request_test.go
+++ b/backend/internal/service/gateway_request_test.go
@@ -1150,6 +1150,11 @@ func TestParseGatewayRequest_OutputEffort(t *testing.T) {
 			wantEffort: "max",
 		},
 		{
+			name:       "output_config.effort xhigh",
+			body:       `{"model":"claude-opus-4-7","output_config":{"effort":"xhigh"},"messages":[]}`,
+			wantEffort: "xhigh",
+		},
+		{
 			name:       "output_config without effort",
 			body:       `{"model":"claude-opus-4-6","output_config":{},"messages":[]}`,
 			wantEffort: "",
@@ -1186,9 +1191,10 @@ func TestNormalizeClaudeOutputEffort(t *testing.T) {
 		{"LOW", strPtr("low")},
 		{"Max", strPtr("max")},
 		{" medium ", strPtr("medium")},
+		{"xhigh", strPtr("xhigh")},
+		{"XHIGH", strPtr("xhigh")},
 		{"", nil},
 		{"unknown", nil},
-		{"xhigh", nil},
 	}
 	for _, tt := range tests {
 		t.Run(tt.input, func(t *testing.T) {

--- a/backend/internal/service/gateway_service.go
+++ b/backend/internal/service/gateway_service.go
@@ -435,26 +435,19 @@ func prefetchedStickyAccountIDFromContext(ctx context.Context, groupID *int64) i
 }
 
 // shouldClearStickySession 检查账号是否处于不可调度状态，需要清理粘性会话绑定。
-// 当账号状态为错误、禁用、不可调度、处于临时不可调度期间，
-// 或请求的模型处于限流状态时，返回 true。
-// 这确保后续请求不会继续使用不可用的账号。
+// 委托 IsSchedulable() 判断账号级可调度性（状态、配额、过载、限流等），
+// 额外检查模型级限流。
 //
 // shouldClearStickySession checks if an account is in an unschedulable state
 // and the sticky session binding should be cleared.
-// Returns true when account status is error/disabled, schedulable is false,
-// within temporary unschedulable period, or the requested model is rate-limited.
-// This ensures subsequent requests won't continue using unavailable accounts.
+// Delegates to IsSchedulable() for account-level checks, plus model-level rate limiting.
 func shouldClearStickySession(account *Account, requestedModel string) bool {
 	if account == nil {
 		return false
 	}
-	if account.Status == StatusError || account.Status == StatusDisabled || !account.Schedulable {
+	if !account.IsSchedulable() {
 		return true
 	}
-	if account.TempUnschedulableUntil != nil && time.Now().Before(*account.TempUnschedulableUntil) {
-		return true
-	}
-	// 检查模型限流和 scope 限流，有限流即清除粘性会话
 	if remaining := account.GetRateLimitRemainingTimeWithContext(context.Background(), requestedModel); remaining > 0 {
 		return true
 	}

--- a/backend/internal/service/sticky_session_test.go
+++ b/backend/internal/service/sticky_session_test.go
@@ -15,20 +15,8 @@ import (
 	"github.com/stretchr/testify/require"
 )
 
-// TestShouldClearStickySession 测试粘性会话清理判断逻辑。
-// 验证在以下情况下是否正确判断需要清理粘性会话：
-//   - nil 账号：不清理（返回 false）
-//   - 状态为错误或禁用：清理
-//   - 不可调度：清理
-//   - 临时不可调度且未过期：清理
-//   - 临时不可调度已过期：不清理
-//   - 正常可调度状态：不清理
-//   - 模型限流（任意时长）：清理
-//
-// TestShouldClearStickySession tests the sticky session clearing logic.
-// Verifies correct behavior for various account states including:
-// nil account, error/disabled status, unschedulable, temporary unschedulable,
-// and model rate limiting scenarios.
+// TestShouldClearStickySession tests sticky session clearing via IsSchedulable() delegation
+// plus model-level rate limiting.
 func TestShouldClearStickySession(t *testing.T) {
 	now := time.Now()
 	future := now.Add(1 * time.Hour)
@@ -100,6 +88,56 @@ func TestShouldClearStickySession(t *testing.T) {
 			},
 			requestedModel: "claude-opus-4", // 请求不同模型
 			want:           false,           // 不同模型不受影响
+		},
+		{
+			name: "apikey quota exceeded",
+			account: &Account{
+				Status:      StatusActive,
+				Schedulable: true,
+				Type:        AccountTypeAPIKey,
+				Extra: map[string]any{
+					"quota_daily_limit": 10.0,
+					"quota_daily_used":  10.0,
+					"quota_daily_start": now.Add(-1 * time.Hour).Format(time.RFC3339),
+				},
+			},
+			requestedModel: "",
+			want:           true,
+		},
+		{
+			name: "oauth quota exceeded not cleared",
+			account: &Account{
+				Status:      StatusActive,
+				Schedulable: true,
+				Type:        AccountTypeOAuth,
+				Extra: map[string]any{
+					"quota_daily_limit": 10.0,
+					"quota_daily_used":  10.0,
+					"quota_daily_start": now.Add(-1 * time.Hour).Format(time.RFC3339),
+				},
+			},
+			requestedModel: "",
+			want:           false,
+		},
+		{
+			name: "overloaded account",
+			account: &Account{
+				Status:       StatusActive,
+				Schedulable:  true,
+				OverloadUntil: &future,
+			},
+			requestedModel: "",
+			want:           true,
+		},
+		{
+			name: "account-level rate limited",
+			account: &Account{
+				Status:           StatusActive,
+				Schedulable:      true,
+				RateLimitResetAt: &future,
+			},
+			requestedModel: "",
+			want:           true,
 		},
 	}
 

--- a/frontend/src/components/account/AccountStatusIndicator.vue
+++ b/frontend/src/components/account/AccountStatusIndicator.vue
@@ -284,6 +284,16 @@ const hasError = computed(() => {
   return props.account.status === 'error'
 })
 
+const isQuotaExceeded = computed(() => {
+  const exceeded = (used?: number | null, limit?: number | null) =>
+    typeof limit === 'number' && limit > 0 && typeof used === 'number' && used >= limit
+  return (
+    exceeded(props.account.quota_used, props.account.quota_limit) ||
+    exceeded(props.account.quota_daily_used, props.account.quota_daily_limit) ||
+    exceeded(props.account.quota_weekly_used, props.account.quota_weekly_limit)
+  )
+})
+
 // Computed: countdown text for rate limit (429)
 const rateLimitCountdown = computed(() => {
   return formatCountdown(props.account.rate_limit_reset_at)
@@ -307,19 +317,16 @@ const statusClass = computed(() => {
   if (isTempUnschedulable.value) {
     return 'badge-warning'
   }
+  if (props.account.status !== 'active') {
+    return props.account.status === 'error' ? 'badge-danger' : 'badge-gray'
+  }
+  if (isQuotaExceeded.value) {
+    return 'badge-warning'
+  }
   if (!props.account.schedulable) {
     return 'badge-gray'
   }
-  switch (props.account.status) {
-    case 'active':
-      return 'badge-success'
-    case 'inactive':
-      return 'badge-gray'
-    case 'error':
-      return 'badge-danger'
-    default:
-      return 'badge-gray'
-  }
+  return 'badge-success'
 })
 
 // Computed: status text
@@ -329,6 +336,12 @@ const statusText = computed(() => {
   }
   if (isTempUnschedulable.value) {
     return t('admin.accounts.status.tempUnschedulable')
+  }
+  if (props.account.status !== 'active') {
+    return t(`admin.accounts.status.${props.account.status}`)
+  }
+  if (isQuotaExceeded.value) {
+    return t('admin.accounts.status.quotaExceeded')
   }
   if (!props.account.schedulable) {
     return t('admin.accounts.status.paused')

--- a/frontend/src/i18n/locales/en.ts
+++ b/frontend/src/i18n/locales/en.ts
@@ -2126,6 +2126,7 @@ export default {
         rateLimited: 'Rate Limited',
         overloaded: 'Overloaded',
         tempUnschedulable: 'Temp Unschedulable',
+        quotaExceeded: 'Quota Exceeded',
         unschedulable: 'Unschedulable',
         rateLimitedUntil: 'Rate limited and removed from scheduling. Auto resumes at {time}',
         rateLimitedAutoResume: 'Auto resumes in {time}',

--- a/frontend/src/i18n/locales/zh.ts
+++ b/frontend/src/i18n/locales/zh.ts
@@ -2315,6 +2315,7 @@ export default {
         rateLimited: '限流中',
         overloaded: '过载中',
         tempUnschedulable: '临时不可调度',
+        quotaExceeded: '配额超限',
         unschedulable: '不可调度',
         rateLimitedUntil: '限流中，当前不参与调度，预计 {time} 自动恢复',
         rateLimitedAutoResume: '{time} 自动恢复',

--- a/frontend/src/utils/format.ts
+++ b/frontend/src/utils/format.ts
@@ -193,7 +193,9 @@ export function formatReasoningEffort(effort: string | null | undefined): string
       return 'High'
     case 'xhigh':
     case 'extrahigh':
-      return 'Xhigh'
+      return 'XHigh'
+    case 'max':
+      return 'Max'
     case 'none':
     case 'minimal':
       return '-'


### PR DESCRIPTION
Closes #12. Brings TK fork up to upstream HEAD `23def40b` per CLAUDE.md §5.y.

## Audit cadence (rule §5.y)

- TK ahead of upstream/main: **44** commits (`git log --oneline upstream/main..HEAD | wc -l`)
- TK behind before merge: 7 commits (now 0)
- Top changed files vs upstream:

```
 backend/cmd/server/VERSION                         |   2 +-
 backend/cmd/server/main.go                         |  24 +-
 backend/cmd/server/wire_gen.go                     |  25 +-
 backend/ent/account.go                             |  13 +-
 backend/ent/account/account.go                     |  10 +
```

## Upstream commits picked up (7)

| SHA | Subject |
|---|---|
| `23def40b` | chore: change license from MIT to LGPL v3.0 |
| `f5ee9379` | Merge PR #1753: feat/fix-orphaned-scheduled-tests |
| `e8be4344` | Merge PR #1752: fix/quota-exceeded-scheduling |
| `061fd48d` | Merge PR #1749: fix/xhigh-reasoning-effort |
| `6579f28b` | fix: delete scheduled test plans when account is deleted |
| `258fd145` | fix(account): prevent quota-exceeded API key/Bedrock accounts from being scheduled |
| `6530776a` | fix: support xhigh reasoning effort in usage records for Claude Messages API |

## Conflict status

Clean `--no-ff` merge via ort strategy. **No real conflicts.** 5 files auto-merged:
- `backend/internal/repository/account_repo.go`
- `backend/internal/service/account.go`
- `backend/internal/service/gateway_service.go`
- `frontend/src/i18n/locales/en.ts`
- `frontend/src/i18n/locales/zh.ts`

## Side-effect: dev-rules submodule bump (commit 2 of this PR)

Per CLAUDE.md §10, this PR also bumps `dev-rules` to `6ab4a9b` to add `merge/*` to the preflight branch-naming whitelist. Without it, preflight § 1 rejects the canonical `merge/upstream-YYYY-MM-DD` branch name and forces `--no-verify` on every commit in this PR — exactly the failure mode preflight-debt §7 was designed to prevent. The dev-rules upstream PR also documents `merge/upstream-YYYY-MM-DD` in `product-dev.mdc` alongside the existing prefixes.

## License notice (LGPL v3.0 transition)

Upstream commit `23def40b` changes the license from **MIT** to **LGPL v3.0**. Downstream operators distributing TokenKey binaries should re-read the new `LICENSE` file:
- LGPL v3.0 requires source disclosure for modifications to the licensed code itself.
- Since TK is a fork (not just a consumer), our entire fork is now under LGPL v3.0.
- TokenKey-specific additions (under `internal/integration/newapi/`, `*_tk_*.go`, `*.tk.ts`) inherit LGPL v3.0 from this point on.

This is acknowledged for awareness; we are not blocking on it.

## Test plan

- [x] `make test` (backend `go test ./...` + `golangci-lint run ./...` + frontend `pnpm lint:check` + `pnpm typecheck`) — all PASS
- [x] `bash dev-rules/templates/preflight.sh` + project § 9 — all PASS
- [x] No conflicts requiring manual resolution
- [x] Reviewer must use **"Create a merge commit"** (NOT "Squash and merge") per §5.y; the `upstream-merge-pr-shape.yml` workflow will validate this.

## Out of scope

- Deeper audit of `258fd145` quota-exceeded scheduling fix vs TK's OpenAI-compat pool predicates (newapi 五元化 PR landed our own scheduler; will run a focused regression as a follow-up if the new logic surfaces drift).
- LGPL v3.0 supply-chain audit (separate concern).

Made with [Cursor](https://cursor.com)