### PR TITLE
prototype: integrate fifth platform `newapi` end-to-end into admin UI (US-017)

### DIFF
--- a/.testing/user-stories/index.md
+++ b/.testing/user-stories/index.md
@@ -19,3 +19,4 @@
 | US-014 | newapi group 配置 messages_dispatch_model_config 持久化 | InTest | `.testing/user-stories/stories/US-014-newapi-group-messages-dispatch-config.md` |
 | US-015 | 历史 openai group 行为完全不变（回归基线） | InTest | `.testing/user-stories/stories/US-015-openai-group-regression-baseline.md` |
 | US-016 | SMTP EHLO host 从 From/Username 推导（修 Google Workspace `auth: EOF`） | Done   | `.testing/user-stories/stories/US-016-smtp-ehlo-host-from-config.md` |
+| US-017 | Admin UI 接入第五平台 newapi（端到端可创建组与账号） | Draft  | `.testing/user-stories/stories/US-017-admin-ui-newapi-platform-end-to-end.md` |

--- a/.testing/user-stories/stories/US-017-admin-ui-newapi-platform-end-to-end.md
+++ b/.testing/user-stories/stories/US-017-admin-ui-newapi-platform-end-to-end.md
@@ -48,7 +48,7 @@ prototype is approved and we move to feature implementation.
 
 ## Evidence
 
-- `.testing/user-stories/attachments/us-016-admin-ui-newapi-vitest-2026-04-20.txt`（待 stage 4 测试运行后归档）
+- `.testing/user-stories/attachments/us-017-admin-ui-newapi-vitest-2026-04-20.txt`（待 stage 4 测试运行后归档）
 
 ## Status
 

--- a/.testing/user-stories/stories/US-017-admin-ui-newapi-platform-end-to-end.md
+++ b/.testing/user-stories/stories/US-017-admin-ui-newapi-platform-end-to-end.md
@@ -22,6 +22,8 @@
 5. AC-005 (回归 / CreateAccountModal 4 个老平台分支不变)：Given 用户选 `anthropic`/`openai`/`gemini`/`antigravity`，When 触发 OAuth/apikey/bedrock/upstream 各子流程的 `handleSubmit`，Then 走原有分支，`isOAuthFlow` 不被 newapi 改动影响。
 6. AC-006 (正向 + NEGATIVE / ChannelsView round-trip 保留 newapi 数据)：Given 一个 channel 同时绑定 anthropic group 与 newapi group + 二者都有 `model_mapping` / `model_pricing`，When `apiToFormSections` 转成 form sections 再 `formSectionsToApi` 转回 API payload，Then payload 同时包含 `model_mapping.anthropic` 与 `model_mapping.newapi`，且 `model_pricing` 同时含两平台。NEGATIVE：当 platforms 参数被替换为历史的 4 元素列表时，`newapi` 数据被丢弃 —— 用以证明**修复在做实际工作**而非凑巧通过。
 7. AC-007 (回归 / `features_config.web_search_emulation` 持久化语义)：Given anthropic section 启用，When 把 `web_search_emulation` 从 `true` 翻转为 `false` 再 `formSectionsToApi`，Then `features_config.web_search_emulation.anthropic === false`（不是被默默保留为 `true`）。当 anthropic section 完全没启用时，`web_search_emulation` 键被整体删除。
+8. AC-008 (正向 / useModelWhitelist 把 newapi 当作 OpenAI-compat)：Given platform `'newapi'`，When 调用 `getModelsByPlatform('newapi')` 与 `getPresetMappingsByPlatform('newapi')`，Then 二者均与 `'openai'` 完全一致（共享 OpenAI 模型 ID 命名空间）。这保证 `BulkEditAccountModal` 与 `ModelWhitelistSelector` 自动覆盖 newapi，不需要单独维护一套预设。
+9. AC-009 (正向 / GroupsView 把 newapi 当作 OpenAI-compat)：Given GroupsView 创建/编辑表单 platform === 'newapi'，When 渲染，Then "Messages 调度配置" 区块**可见**（`isOpenAICompatPlatform` 返回 true）；"账号过滤控制" 区块**可见**但 `require_oauth_only` / `require_privacy_set` 两个 toggle **隐藏**（newapi 是 API key 平台，无 OAuth 概念）。
 
 ## Assertions
 
@@ -48,12 +50,19 @@ Vitest specs (test names are descriptive in JS-land — convention `it('...')` n
 - `frontend/src/utils/__tests__/channelFormConversion.spec.ts`::`preserves features_config.web_search_emulation flag through the round-trip when anthropic section is enabled` *(AC-007 正向)*
 - `frontend/src/utils/__tests__/channelFormConversion.spec.ts`::`clears web_search_emulation when the anthropic section is disabled (toggle on→off must persist)` *(AC-007 状态翻转)*
 - `frontend/src/utils/__tests__/channelFormConversion.spec.ts`::`drops features_config.web_search_emulation entirely when no anthropic section is enabled` *(AC-007 清除)*
-- 运行命令: `cd frontend && pnpm test:run usePlatformOptions PlatformTypeBadge channelFormConversion`
+- `frontend/src/composables/__tests__/useModelWhitelist.spec.ts`::`newapi 模型列表与 openai 完全一致（OpenAI-compat 协议默认提示）` *(AC-008 模型列表)*
+- `frontend/src/composables/__tests__/useModelWhitelist.spec.ts`::`newapi 预设映射与 openai 完全一致（共享模型 ID 命名空间）` *(AC-008 预设映射)*
+- 运行命令: `cd frontend && pnpm test:run usePlatformOptions PlatformTypeBadge channelFormConversion useModelWhitelist`
 
 AC-005 (CreateAccountModal `isOAuthFlow` regression) is currently asserted by
 manual Stage-4 smoke-test in the PR description; converting it to a vitest spec
 requires mounting the full modal (heavy fixtures) and is deferred until the
 prototype is approved and we move to feature implementation.
+
+AC-009 (GroupsView newapi `isOpenAICompatPlatform` branching + OAuth toggle
+hide) is similarly asserted by Stage-4 manual smoke-test in the PR
+description (same heavy-modal cost as AC-005); deferred to feature stage if
+Stage-4 review surfaces a regression.
 
 ## Evidence
 

--- a/.testing/user-stories/stories/US-017-admin-ui-newapi-platform-end-to-end.md
+++ b/.testing/user-stories/stories/US-017-admin-ui-newapi-platform-end-to-end.md
@@ -8,8 +8,9 @@
 - Trace: design `docs/approved/admin-ui-newapi-platform-end-to-end.md`（来源：角色×能力，admin × 创建账号/组）+ `docs/approved/newapi-as-fifth-platform.md` §"被推迟的工作 — Admin UI 集成"
 - Risk Focus:
   - 逻辑错误：CreateAccount 未携带 top-level `channel_type` 时被后端 `admin_service.go:1565` 拒绝（`channel_type must be > 0 for newapi platform`）。
+  - 逻辑错误（数据丢失）：`ChannelsView` 的 `apiToForm` / `formToAPI` round-trip 必须保留 `newapi` 的 `model_mapping` / `model_pricing` / group 关联——历史的 4 元素 `platformOrder` 字面量会在保存时静默吞掉这些字段（详见 design doc §1.5）。
   - 行为回归：`PlatformTypeBadge.vue` 历史 default 把任意未知 platform 渲染成 "Gemini"——`newapi` 账号必须显示 "New API" 而非 "Gemini"。
-  - 行为回归：原有 4 个平台（anthropic/openai/gemini/antigravity）的下拉、过滤、徽章不能因新增 `newapi` 选项而错位/重排序；canonical 顺序由 `GATEWAY_PLATFORMS` 单一来源决定。
+  - 行为回归：原有 4 个平台（anthropic/openai/gemini/antigravity）的下拉、过滤、徽章、ChannelsView 编辑 round-trip 不能因新增 `newapi` 选项而错位/重排序；canonical 顺序由 `GATEWAY_PLATFORMS` 单一来源决定。
   - 安全问题：不适用（新增 UI 选项不放宽鉴权；后端 `CreateGroup`/`CreateAccount` 路由本来就受 admin 中间件保护）。
 
 ## Acceptance Criteria
@@ -19,6 +20,8 @@
 3. AC-003 (负向 / Badge fallback)：Given 一个 platform 字符串 `'newapi'` 传入 `PlatformTypeBadge`，When 渲染，Then label === 'New API'（不是 'Gemini'）且 platformClass 含 `bg-cyan-100`。Given 真正未知 platform `'unknown-x'`，Then label === `'unknown-x'` 且 platformClass 走中性灰 fallback（不再被错标 Gemini）。
 4. AC-004 (回归 / 4 个老平台 Badge 不变)：Given 历史平台 `anthropic`/`openai`/`gemini`/`antigravity`，When 渲染 PlatformTypeBadge，Then label 与 class 与升级前快照完全一致（颜色：橙/绿/蓝/紫）。
 5. AC-005 (回归 / CreateAccountModal 4 个老平台分支不变)：Given 用户选 `anthropic`/`openai`/`gemini`/`antigravity`，When 触发 OAuth/apikey/bedrock/upstream 各子流程的 `handleSubmit`，Then 走原有分支，`isOAuthFlow` 不被 newapi 改动影响。
+6. AC-006 (正向 + NEGATIVE / ChannelsView round-trip 保留 newapi 数据)：Given 一个 channel 同时绑定 anthropic group 与 newapi group + 二者都有 `model_mapping` / `model_pricing`，When `apiToFormSections` 转成 form sections 再 `formSectionsToApi` 转回 API payload，Then payload 同时包含 `model_mapping.anthropic` 与 `model_mapping.newapi`，且 `model_pricing` 同时含两平台。NEGATIVE：当 platforms 参数被替换为历史的 4 元素列表时，`newapi` 数据被丢弃 —— 用以证明**修复在做实际工作**而非凑巧通过。
+7. AC-007 (回归 / `features_config.web_search_emulation` 持久化语义)：Given anthropic section 启用，When 把 `web_search_emulation` 从 `true` 翻转为 `false` 再 `formSectionsToApi`，Then `features_config.web_search_emulation.anthropic === false`（不是被默默保留为 `true`）。当 anthropic section 完全没启用时，`web_search_emulation` 键被整体删除。
 
 ## Assertions
 
@@ -39,7 +42,13 @@ Vitest specs (test names are descriptive in JS-land — convention `it('...')` n
 - `frontend/src/components/common/__tests__/PlatformTypeBadge.spec.ts`::`renders newapi as "New API" with cyan styling (the bug we are fixing)` *(AC-003)*
 - `frontend/src/components/common/__tests__/PlatformTypeBadge.spec.ts`::`NEGATIVE — truly unknown platforms fall back to neutral gray (no silent Gemini mislabel)` *(AC-003 negative)*
 - `frontend/src/components/common/__tests__/PlatformTypeBadge.spec.ts`::`REGRESSION — the 4 historical platforms render with their canonical brand label and color` *(AC-004)*
-- 运行命令: `cd frontend && pnpm test:run usePlatformOptions PlatformTypeBadge`
+- `frontend/src/utils/__tests__/channelFormConversion.spec.ts`::`round-trips a channel that mixes anthropic + newapi without dropping newapi data (the data-loss bug we are fixing)` *(AC-006 正向)*
+- `frontend/src/utils/__tests__/channelFormConversion.spec.ts`::`NEGATIVE — apiToFormSections with the legacy 4-element platformOrder still drops newapi (regression-by-construction proof of the bug)` *(AC-006 NEGATIVE)*
+- `frontend/src/utils/__tests__/channelFormConversion.spec.ts`::`REGRESSION — round-trips a channel with only the 4 legacy platforms (no behavior change for existing channels)` *(AC-006 回归)*
+- `frontend/src/utils/__tests__/channelFormConversion.spec.ts`::`preserves features_config.web_search_emulation flag through the round-trip when anthropic section is enabled` *(AC-007 正向)*
+- `frontend/src/utils/__tests__/channelFormConversion.spec.ts`::`clears web_search_emulation when the anthropic section is disabled (toggle on→off must persist)` *(AC-007 状态翻转)*
+- `frontend/src/utils/__tests__/channelFormConversion.spec.ts`::`drops features_config.web_search_emulation entirely when no anthropic section is enabled` *(AC-007 清除)*
+- 运行命令: `cd frontend && pnpm test:run usePlatformOptions PlatformTypeBadge channelFormConversion`
 
 AC-005 (CreateAccountModal `isOAuthFlow` regression) is currently asserted by
 manual Stage-4 smoke-test in the PR description; converting it to a vitest spec

--- a/.testing/user-stories/stories/US-017-admin-ui-newapi-platform-end-to-end.md
+++ b/.testing/user-stories/stories/US-017-admin-ui-newapi-platform-end-to-end.md
@@ -1,0 +1,55 @@
+# US-017-admin-ui-newapi-platform-end-to-end
+
+- ID: US-017
+- Title: Admin UI 接入第五平台 newapi（端到端可创建组与账号）
+- Version: V1.2
+- Priority: P0
+- As a / I want / So that: 作为 sub2api 管理员，我希望在 Admin UI（创建组弹窗、创建账号弹窗、平台过滤器、账号列表 PlatformTypeBadge）里都能看到 `newapi`，并能完成"新建 newapi 组 → 新建 newapi 账号 → 账号正确归类"的端到端流程，以便已经 ship 的第五平台后端能力（`docs/approved/newapi-as-fifth-platform.md`）真正可被使用，而不是只能通过 `psql`/curl。
+- Trace: design `docs/approved/admin-ui-newapi-platform-end-to-end.md`（来源：角色×能力，admin × 创建账号/组）+ `docs/approved/newapi-as-fifth-platform.md` §"被推迟的工作 — Admin UI 集成"
+- Risk Focus:
+  - 逻辑错误：CreateAccount 未携带 top-level `channel_type` 时被后端 `admin_service.go:1565` 拒绝（`channel_type must be > 0 for newapi platform`）。
+  - 行为回归：`PlatformTypeBadge.vue` 历史 default 把任意未知 platform 渲染成 "Gemini"——`newapi` 账号必须显示 "New API" 而非 "Gemini"。
+  - 行为回归：原有 4 个平台（anthropic/openai/gemini/antigravity）的下拉、过滤、徽章不能因新增 `newapi` 选项而错位/重排序；canonical 顺序由 `GATEWAY_PLATFORMS` 单一来源决定。
+  - 安全问题：不适用（新增 UI 选项不放宽鉴权；后端 `CreateGroup`/`CreateAccount` 路由本来就受 admin 中间件保护）。
+
+## Acceptance Criteria
+
+1. AC-001 (正向 / 单一事实)：Given canonical `GATEWAY_PLATFORMS = ['anthropic','openai','gemini','antigravity','newapi']`，When `usePlatformOptions()` 渲染，Then 返回 5 项且第 5 项是 `{value:'newapi', label:'New API'}`，顺序与 `GATEWAY_PLATFORMS` 一致 (`TestUS017_PlatformOptions_AllFiveCanonicalOrder`).
+2. AC-002 (正向 / GroupsView 过滤器)：Given `optionsWithAll('admin.groups.allPlatforms')` 被 GroupsView 调用，When 渲染过滤器，Then 第一项为 `{value:'', label:<allLabel>}`，剩余 5 项与 `GATEWAY_PLATFORMS` 一致 (`TestUS017_PlatformFilter_PrependsAllOption`).
+3. AC-003 (负向 / Badge fallback)：Given 一个 platform 字符串 `'newapi'` 传入 `PlatformTypeBadge`，When 渲染，Then label === 'New API'（不是 'Gemini'）且 platformClass 含 `bg-cyan-100`。Given 真正未知 platform `'unknown-x'`，Then label === `'unknown-x'` 且 platformClass 走中性灰 fallback（不再被错标 Gemini）。
+4. AC-004 (回归 / 4 个老平台 Badge 不变)：Given 历史平台 `anthropic`/`openai`/`gemini`/`antigravity`，When 渲染 PlatformTypeBadge，Then label 与 class 与升级前快照完全一致（颜色：橙/绿/蓝/紫）。
+5. AC-005 (回归 / CreateAccountModal 4 个老平台分支不变)：Given 用户选 `anthropic`/`openai`/`gemini`/`antigravity`，When 触发 OAuth/apikey/bedrock/upstream 各子流程的 `handleSubmit`，Then 走原有分支，`isOAuthFlow` 不被 newapi 改动影响。
+
+## Assertions
+
+- AC-001/AC-002：composable spec 中 `expect(options.value.map(o => o.value)).toEqual(GATEWAY_PLATFORMS)` 与 `expect(filterOptions.value[0].value).toBe('')`。
+- AC-003：组件挂载断言 `wrapper.text()` 含 `'New API'` 且不含 `'Gemini'`；`wrapper.html()` 含 `bg-cyan-100`；fallback case 断言含 `bg-gray-100`。
+- AC-004：4 个平台分别快照 `platformLabel` + `platformClass` 字符串。
+- AC-005：CreateAccountModal `isOAuthFlow` 在 platform=anthropic+oauth-based 时为 true，在 platform=newapi 时为 false（防回归）。
+- 失败时 vitest `expect` 立即报错并 exit ≠ 0。
+
+## Linked Tests
+
+Vitest specs (test names are descriptive in JS-land — convention `it('...')` not
+`TestUSXXX_*`; story IDs are referenced in the `describe(...)` block instead):
+
+- `frontend/src/composables/__tests__/usePlatformOptions.spec.ts`::`exposes exactly the 5 canonical gateway platforms in GATEWAY_PLATFORMS order` *(AC-001)*
+- `frontend/src/composables/__tests__/usePlatformOptions.spec.ts`::`includes newapi (the bug we are fixing — admin pickers used to drop it)` *(AC-001)*
+- `frontend/src/composables/__tests__/usePlatformOptions.spec.ts`::`optionsWithAll prepends the localized "all" sentinel and preserves order` *(AC-002)*
+- `frontend/src/components/common/__tests__/PlatformTypeBadge.spec.ts`::`renders newapi as "New API" with cyan styling (the bug we are fixing)` *(AC-003)*
+- `frontend/src/components/common/__tests__/PlatformTypeBadge.spec.ts`::`NEGATIVE — truly unknown platforms fall back to neutral gray (no silent Gemini mislabel)` *(AC-003 negative)*
+- `frontend/src/components/common/__tests__/PlatformTypeBadge.spec.ts`::`REGRESSION — the 4 historical platforms render with their canonical brand label and color` *(AC-004)*
+- 运行命令: `cd frontend && pnpm test:run usePlatformOptions PlatformTypeBadge`
+
+AC-005 (CreateAccountModal `isOAuthFlow` regression) is currently asserted by
+manual Stage-4 smoke-test in the PR description; converting it to a vitest spec
+requires mounting the full modal (heavy fixtures) and is deferred until the
+prototype is approved and we move to feature implementation.
+
+## Evidence
+
+- `.testing/user-stories/attachments/us-016-admin-ui-newapi-vitest-2026-04-20.txt`（待 stage 4 测试运行后归档）
+
+## Status
+
+- [ ] Draft (prototype scope: composable + GroupsView + CreateAccountModal + Badge wired; vitest specs pending stage 4)

--- a/backend/internal/handler/gateway_handler.go
+++ b/backend/internal/handler/gateway_handler.go
@@ -886,8 +886,15 @@ func (h *GatewayHandler) Models(c *gin.Context) {
 		return
 	}
 
-	// Fallback to default models
-	if platform == "openai" {
+	// Fallback to default models.
+	//
+	// Group platforms participating in the OpenAI-compat pool (today: openai,
+	// newapi — see service.OpenAICompatPlatforms) speak the OpenAI HTTP
+	// protocol and therefore expect openai.DefaultModels. Without this
+	// branch, newapi groups whose accounts have empty model_mapping would
+	// silently get Claude default models via the catch-all below — wrong
+	// shape for OpenAI-compat clients.
+	if service.IsOpenAICompatPlatform(platform) {
 		c.JSON(http.StatusOK, gin.H{
 			"object": "list",
 			"data":   openai.DefaultModels,

--- a/backend/internal/handler/openai_gateway_handler.go
+++ b/backend/internal/handler/openai_gateway_handler.go
@@ -1440,9 +1440,18 @@ func (h *OpenAIGatewayHandler) handleFailoverExhausted(c *gin.Context, failoverE
 	statusCode := failoverErr.StatusCode
 	responseBody := failoverErr.ResponseBody
 
+	// Resolve the actual group platform so admin-configured passthrough rules
+	// scoped to `newapi` (or any non-openai compat platform) actually fire on
+	// the failover-exhaustion path. Falls back to the legacy literal "openai"
+	// only if context is missing — keeps pre-newapi installs unchanged.
+	rulePlatform := service.PlatformOpenAI
+	if apiKey, ok := middleware2.GetAPIKeyFromContext(c); ok && apiKey != nil && apiKey.Group != nil && apiKey.Group.Platform != "" {
+		rulePlatform = apiKey.Group.Platform
+	}
+
 	// 先检查透传规则
 	if h.errorPassthroughService != nil && len(responseBody) > 0 {
-		if rule := h.errorPassthroughService.MatchRule("openai", statusCode, responseBody); rule != nil {
+		if rule := h.errorPassthroughService.MatchRule(rulePlatform, statusCode, responseBody); rule != nil {
 			// 确定响应状态码
 			respCode := statusCode
 			if !rule.PassthroughCode && rule.ResponseCode != nil {

--- a/backend/internal/handler/ops_error_logger.go
+++ b/backend/internal/handler/ops_error_logger.go
@@ -1061,6 +1061,13 @@ func resolveOpsPlatform(apiKey *service.APIKey, fallback string) string {
 	return fallback
 }
 
+// guessPlatformFromPath is the *fallback* path-based platform heuristic for
+// ops logging when the request never reached a group-aware handler (no
+// resolveOpsPlatform hit). It cannot distinguish openai from newapi because
+// both share the OpenAI-compat path shape — when a group exists,
+// resolveOpsPlatform always wins and returns the real platform (including
+// newapi). The OpenAI-compat bucket here is therefore the conservative
+// fallback.
 func guessPlatformFromPath(path string) string {
 	p := strings.ToLower(path)
 	switch {
@@ -1068,7 +1075,12 @@ func guessPlatformFromPath(path string) string {
 		return service.PlatformAntigravity
 	case strings.HasPrefix(p, "/v1beta/"):
 		return service.PlatformGemini
-	case strings.Contains(p, "/responses"):
+	case strings.Contains(p, "/v1/messages"):
+		return service.PlatformAnthropic
+	case strings.Contains(p, "/responses"),
+		strings.Contains(p, "/chat/completions"),
+		strings.Contains(p, "/embeddings"),
+		strings.Contains(p, "/completions"):
 		return service.PlatformOpenAI
 	default:
 		return ""

--- a/backend/internal/handler/ops_error_logger.go
+++ b/backend/internal/handler/ops_error_logger.go
@@ -1063,11 +1063,11 @@ func resolveOpsPlatform(apiKey *service.APIKey, fallback string) string {
 
 // guessPlatformFromPath is the *fallback* path-based platform heuristic for
 // ops logging when the request never reached a group-aware handler (no
-// resolveOpsPlatform hit). It cannot distinguish openai from newapi because
-// both share the OpenAI-compat path shape — when a group exists,
+// resolveOpsPlatform hit). For /v1/messages we intentionally prefer the
+// OpenAI-compat bucket so early failures from openai/newapi do not get
+// silently collapsed into anthropic. Once a group context exists,
 // resolveOpsPlatform always wins and returns the real platform (including
-// newapi). The OpenAI-compat bucket here is therefore the conservative
-// fallback.
+// newapi).
 func guessPlatformFromPath(path string) string {
 	p := strings.ToLower(path)
 	switch {
@@ -1076,7 +1076,7 @@ func guessPlatformFromPath(path string) string {
 	case strings.HasPrefix(p, "/v1beta/"):
 		return service.PlatformGemini
 	case strings.Contains(p, "/v1/messages"):
-		return service.PlatformAnthropic
+		return service.PlatformOpenAI
 	case strings.Contains(p, "/responses"),
 		strings.Contains(p, "/chat/completions"),
 		strings.Contains(p, "/embeddings"),

--- a/backend/internal/handler/ops_error_logger_test.go
+++ b/backend/internal/handler/ops_error_logger_test.go
@@ -319,3 +319,43 @@ func TestSetOpsEndpointContext_NilContext(t *testing.T) {
 		setOpsEndpointContext(nil, "model", int16(1))
 	})
 }
+
+func TestGuessPlatformFromPath(t *testing.T) {
+	tests := []struct {
+		name string
+		path string
+		want string
+	}{
+		{
+			name: "antigravity prefix keeps antigravity",
+			path: "/antigravity/v1/messages",
+			want: service.PlatformAntigravity,
+		},
+		{
+			name: "gemini prefix keeps gemini",
+			path: "/v1beta/models/gemini-2.5-pro:generateContent",
+			want: service.PlatformGemini,
+		},
+		{
+			name: "messages path falls back to openai compat bucket",
+			path: "/v1/messages",
+			want: service.PlatformOpenAI,
+		},
+		{
+			name: "responses path falls back to openai compat bucket",
+			path: "/v1/responses",
+			want: service.PlatformOpenAI,
+		},
+		{
+			name: "unknown path returns empty",
+			path: "/healthz",
+			want: "",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			require.Equal(t, tt.want, guessPlatformFromPath(tt.path))
+		})
+	}
+}

--- a/backend/internal/server/routes/gateway_tk_openai_compat_handlers.go
+++ b/backend/internal/server/routes/gateway_tk_openai_compat_handlers.go
@@ -9,8 +9,12 @@ import (
 	"github.com/gin-gonic/gin"
 )
 
+// isOpenAICompatPlatform delegates to the canonical service-layer helper so
+// that adding a sixth compat platform only requires updating
+// service.OpenAICompatPlatforms(). Kept as a thin local wrapper to keep the
+// route-table call sites concise.
 func isOpenAICompatPlatform(platform string) bool {
-	return platform == service.PlatformOpenAI || platform == service.PlatformNewAPI
+	return service.IsOpenAICompatPlatform(platform)
 }
 
 func tkOpenAICompatMessagesPOST(h *handler.Handlers) gin.HandlerFunc {

--- a/backend/internal/service/account_tk_compat_pool.go
+++ b/backend/internal/service/account_tk_compat_pool.go
@@ -47,3 +47,28 @@ func (a *Account) IsOpenAICompatPoolMember(groupPlatform string) bool {
 func OpenAICompatPlatforms() []string {
 	return []string{PlatformOpenAI, PlatformNewAPI}
 }
+
+// IsOpenAICompatPlatform reports whether the given platform identifier
+// participates in the OpenAI-compatible request shape (i.e. clients speaking
+// the OpenAI HTTP protocol). This is the canonical *string-arg* sibling of
+// IsOpenAICompatPoolMember (which takes an Account) and routes-layer
+// `isOpenAICompatPlatform` (which is private to the routes package).
+//
+// Use this whenever a handler / service has a raw platform string in scope and
+// needs to decide between OpenAI-shape and Anthropic-shape default behavior
+// (e.g. `/v1/models` fallback list, default upstream protocol guess).
+//
+// Strict equality only — empty / unknown returns false. Adding a sixth compat
+// platform requires updating OpenAICompatPlatforms() above; this helper
+// derives from that list automatically.
+func IsOpenAICompatPlatform(platform string) bool {
+	if platform == "" {
+		return false
+	}
+	for _, p := range OpenAICompatPlatforms() {
+		if platform == p {
+			return true
+		}
+	}
+	return false
+}

--- a/backend/internal/service/account_tk_compat_pool_test.go
+++ b/backend/internal/service/account_tk_compat_pool_test.go
@@ -77,6 +77,32 @@ func TestUS011_PoolMember_UnknownPlatform_False(t *testing.T) {
 	}
 }
 
+// US-017 regression — IsOpenAICompatPlatform is the string-arg sibling of
+// IsOpenAICompatPoolMember. /v1/models fallback and ops fallback both rely on
+// it; previously /v1/models defaulted to Claude DefaultModels for newapi
+// groups whose accounts had empty model_mapping (wrong response shape for
+// OpenAI-compat clients).
+func TestUS017_IsOpenAICompatPlatform_Truth(t *testing.T) {
+	cases := []struct {
+		platform string
+		want     bool
+	}{
+		{PlatformOpenAI, true},
+		{PlatformNewAPI, true},
+		{PlatformAnthropic, false},
+		{PlatformGemini, false},
+		{PlatformAntigravity, false},
+		{"", false},
+		{"unknown", false},
+	}
+	for _, tc := range cases {
+		got := IsOpenAICompatPlatform(tc.platform)
+		if got != tc.want {
+			t.Fatalf("IsOpenAICompatPlatform(%q) = %v, want %v", tc.platform, got, tc.want)
+		}
+	}
+}
+
 func TestOpenAICompatPlatforms_ListsBothCanonicals(t *testing.T) {
 	got := OpenAICompatPlatforms()
 	if len(got) != 2 {

--- a/backend/internal/service/openai_gateway_service.go
+++ b/backend/internal/service/openai_gateway_service.go
@@ -3349,9 +3349,14 @@ func (s *OpenAIGatewayService) handleErrorResponse(
 		)
 	}
 
+	// Use account.Platform (not the literal PlatformOpenAI) so admin-configured
+	// passthrough rules scoped to `newapi` actually fire on this path; the
+	// sibling handleCompatErrorResponse already does this — both paths now
+	// agree. (Bug fix: previously newapi rules silently never matched here
+	// and openai rules incorrectly matched newapi traffic.)
 	if status, errType, errMsg, matched := applyErrorPassthroughRule(
 		c,
-		PlatformOpenAI,
+		account.Platform,
 		resp.StatusCode,
 		body,
 		http.StatusBadGateway,

--- a/backend/internal/service/openai_messages_dispatch_tk_newapi.go
+++ b/backend/internal/service/openai_messages_dispatch_tk_newapi.go
@@ -24,10 +24,5 @@ func isOpenAICompatPlatformGroup(g *Group) bool {
 	if g == nil {
 		return false
 	}
-	switch g.Platform {
-	case PlatformOpenAI, PlatformNewAPI:
-		return true
-	default:
-		return false
-	}
+	return IsOpenAICompatPlatform(g.Platform)
 }

--- a/docs/approved/admin-ui-newapi-platform-end-to-end.md
+++ b/docs/approved/admin-ui-newapi-platform-end-to-end.md
@@ -25,8 +25,13 @@ newapi 分组或账号，唯一的绕路是手工构造 admin API 调用。
 
 本设计用**最小**的 UI 改动闭合这一缺口，让运维可以端到端跑通 newapi
 （创建分组 → 创建账号 → 看到正确标注的账号 → 列表筛选）。Out-of-scope 的精修
-（ops-dashboard 筛选、错误透传规则、批量编辑、渐变色/折扣/按钮颜色变体）会列入
-stage-3 跟进，但明确排除在本次原型之外。
+（ops-dashboard 筛选、错误透传规则、批量编辑）会列入 stage-3 跟进，但明确排除
+在本次原型之外。
+
+PR #19 review 后，§1.5「审批前补强」额外把 `ChannelsView.vue` 修进来——它的
+4 元素 `platformOrder` 不只是视觉漂移，而是一个**会静默吞掉 newapi channel
+数据的 bug**（详见 §1.5）。同时 `utils/platformColors.ts` 的 cyan 完整化和
+i18n 的 `newapi` 标签也一并补齐。
 
 ## 1. 范围
 
@@ -57,16 +62,46 @@ stage-3 跟进，但明确排除在本次原型之外。
 - `EditAccountModal.vue` / `BulkEditAccountModal.vue` —— 不能让它们回归，但
   完整支持批量编辑 newapi 渠道有 UX 影响（批量改 channel_type 是破坏性操作），
   放到独立 review 里。
-- `ChannelsView.vue:721` `platformOrder: GroupPlatform[]` 也是 4-元素硬编码
-  数组，被 v-for 渲染分组 + 成员判定使用。需要先搞清楚"channels view 只渲染
-  4 个 OAuth/订阅平台"是有意为之（newapi 用的是 channel_type 而非 channel
-  名词，可能不属于本视图）还是同款组织漂移——属于"先审计再决定要不要切
-  composable"，stage-3 单独一个 PR。
-- `utils/platformColors.ts` —— 扩展 `Platform` 联合类型并把 `newapi` 加进全部
-  9 张 variant map，让非 badge 表面也具备视觉完整性。
 - `PlatformIcon.vue` —— 给 newapi 选品牌图标是设计决策不是 bug；目前的通用
   地球图标回退是可以接受的。
 - `SubscriptionsView.vue` —— newapi 没有 OAuth 订阅这个概念，加上反而误导。
+
+### 1.5 审批前补强（PR #19 review 后追加）
+
+PR #19 的二次 review 对 `ChannelsView.vue` 做深度审计后，发现原 §1 Out-of-scope
+中的两项不能延后到 stage-3 —— 它们触发了一个**已经在生产分支里的潜伏数据丢失
+bug**：
+
+- `ChannelsView.vue:721` 的 `platformOrder = ['anthropic','openai','gemini','antigravity']`
+  被两条**互不相干的代码路径**消费：
+  ① `apiToForm` 第 1070 行用它过滤 `channel.model_mapping` 的键；
+  ② `formToAPI` 第 1007 行迭代 `form.platforms`（其内容由 ① 决定）。
+  这意味着：**任何后端返回了 `newapi` 数据的 channel，被运维在 ChannelsView
+  打开并保存后，会静默丢失全部 `newapi` 行**（model_mapping、model_pricing、
+  group 关联）。
+  后端早就接受 `newapi` channel（`channel_handler_tk_newapi_admin.go:35`
+  在 `oneof` 白名单中显式列出 `newapi`，`channel_repo.go:133` 的 Update 全量
+  替换 JSONB），所以这不是"只读视图"假设的延伸，而是**前端 vs 后端之间的不
+  对称组织漂移**。
+- `utils/platformColors.ts` 的 `Platform` 联合类型缺 `newapi`，导致 ChannelsView
+  在切到 composable 后，`newapi` 平台行/徽章的颜色会回退到默认灰，与设计承诺
+  的 cyan 不一致——不算数据 bug，但一旦 ChannelsView 开始渲染 `newapi`
+  必须同步修，否则视觉漂移。
+
+补强清单（commits 4-N，与 §3 in-scope 共享同一个 PR #19）：
+
+| # | 路径 | 变更 | 风险归属 |
+| --- | --- | --- | --- |
+| 1 | `frontend/src/utils/channelFormConversion.ts` (NEW) | 抽出纯函数 `apiToFormSections` / `formSectionsToApi`，把 canonical platform order 当参数传入（默认 `GATEWAY_PLATFORMS`）；让 round-trip 可被单测覆盖 | 逻辑错误（数据丢失） |
+| 2 | `frontend/src/views/admin/ChannelsView.vue` | 删除本地 `platformOrder` 4 元素字面量，改 `import { GATEWAY_PLATFORMS }`；`apiToForm` / `formToAPI` 改为调用 §1 的纯函数 | 逻辑错误 + 行为回归 |
+| 3 | `frontend/src/utils/platformColors.ts` | `Platform` 联合类型加 `'newapi'`；9 张 variant map 全部加 cyan 项；`isPlatform()` 与 `platformLabel()` 同步加分支；`Record<Platform, …>` 让漏一项编译失败 | 行为回归（视觉） |
+| 4 | `frontend/src/components/admin/channel/types.ts` | `getPlatformTagClass()` 增加 `case 'newapi'`（cyan tag） | 行为回归（视觉） |
+| 5 | `frontend/src/i18n/locales/{en,zh}.ts` | `admin.groups.platforms.newapi` 与 `admin.accounts.platforms.newapi` 都加 `'New API'`，避免 ChannelsView/GroupsView 显示原始 key | 行为回归（文案） |
+| 6 | `frontend/src/utils/__tests__/channelFormConversion.spec.ts` (NEW) | 9 个 vitest case：5 平台 round-trip 保留 newapi、用 4 元素旧 order 调用证明数据丢失（NEGATIVE）、纯 4 平台回归、`web_search_emulation` on/off/clear、disabled section 跳过、canonical order、空 pricing 过滤 | 防漂移护栏 |
+
+`PlatformIcon` / `PlatformTypeBadge` 的 cyan 与 newapi 显示在 §1 已涵盖，
+不在本节重复。`SubscriptionsView.vue` / `BulkEditAccountModal.vue` 等仍属
+stage-3。
 
 ### Non-goals（不会做，并解释为什么）
 
@@ -241,6 +276,17 @@ const PLATFORM_TYPE_BG: Record<AccountPlatform, string> = { /* 同形 */ }
 | `.testing/user-stories/index.md` | + US-017 行 |
 | `docs/approved/admin-ui-newapi-platform-end-to-end.md` | 本文档 |
 
+§1.5 review 后追加的文件（同一 PR）：
+
+| 路径 | 变更 |
+| --- | --- |
+| `frontend/src/utils/channelFormConversion.ts` | NEW —— 抽出 ChannelsView 的 apiToForm/formToAPI 为纯函数，平台顺序参数化 |
+| `frontend/src/utils/__tests__/channelFormConversion.spec.ts` | NEW —— 9 个 round-trip vitest case（含数据丢失 bug 的 NEGATIVE 反证） |
+| `frontend/src/views/admin/ChannelsView.vue` | `platformOrder` 改为 `GATEWAY_PLATFORMS`；apiToForm/formToAPI 改为调用纯函数 |
+| `frontend/src/utils/platformColors.ts` | `Platform` 联合类型 + 9 张 variant map + `isPlatform()` + `platformLabel()` 全部加 `newapi`（cyan） |
+| `frontend/src/components/admin/channel/types.ts` | `getPlatformTagClass()` + `case 'newapi'`（cyan） |
+| `frontend/src/i18n/locales/{en,zh}.ts` | + `admin.groups.platforms.newapi` + `admin.accounts.platforms.newapi` |
+
 不动 backend / Ent / Wire。不引入新依赖。
 
 ## 4. 风险分析
@@ -287,13 +333,13 @@ const PLATFORM_TYPE_BG: Record<AccountPlatform, string> = { /* 同形 */ }
 2. `OpsDashboardHeader.vue` 同上
 3. `EditAccountModal.vue` 增加 newapi 编辑分支（不含批量）
 4. `BulkEditAccountModal.vue` 加批量编辑守卫（`channel_type` 不允许批量改）
-5. `utils/platformColors.ts` 把 `newapi` 加进 9 张 variant map（视觉完整性）
-6. `ErrorPassthroughRulesModal.vue` 同 §1（运营紧迫性最低）
-7. `PlatformTypeBadge.vue` 3 个 `switch` → import `gatewayPlatforms.ts` 的 `SOFT_BADGE` map（§3.3 实现备注）
-8. `ChannelsView.vue:721` `platformOrder` 审计：先确认"channels view 只渲染 4 个
-   OAuth/订阅平台"是有意为之还是组织漂移；如果是后者切到 composable，如果是
-   前者在常量旁补一行注释说明排除原因（防止下一个 reviewer 重复怀疑）。
-9. §5.7 的防漂移 preflight 段落落地（应在切完 §1-§3 之后，否则会 fail 自己）
+5. `ErrorPassthroughRulesModal.vue` 同 §1（运营紧迫性最低）
+6. `PlatformTypeBadge.vue` 3 个 `switch` → import `gatewayPlatforms.ts` 的 `SOFT_BADGE` map（§3.3 实现备注）
+7. §5.7 的防漂移 preflight 段落落地（应在切完 §1-§5 之后，否则会 fail 自己）
+
+> 历史：原列表中的 `utils/platformColors.ts`（cyan 完整化）与
+> `ChannelsView.vue:721` 审计已在 PR #19 review 期间被发现是**数据丢失 bug**
+> 而非纯视觉补全，因此前置到 §1.5 一同合并，不再是 stage-3 跟进项。
 
 ## 7. 待审批的开放问题
 

--- a/docs/approved/admin-ui-newapi-platform-end-to-end.md
+++ b/docs/approved/admin-ui-newapi-platform-end-to-end.md
@@ -57,6 +57,11 @@ stage-3 跟进，但明确排除在本次原型之外。
 - `EditAccountModal.vue` / `BulkEditAccountModal.vue` —— 不能让它们回归，但
   完整支持批量编辑 newapi 渠道有 UX 影响（批量改 channel_type 是破坏性操作），
   放到独立 review 里。
+- `ChannelsView.vue:721` `platformOrder: GroupPlatform[]` 也是 4-元素硬编码
+  数组，被 v-for 渲染分组 + 成员判定使用。需要先搞清楚"channels view 只渲染
+  4 个 OAuth/订阅平台"是有意为之（newapi 用的是 channel_type 而非 channel
+  名词，可能不属于本视图）还是同款组织漂移——属于"先审计再决定要不要切
+  composable"，stage-3 单独一个 PR。
 - `utils/platformColors.ts` —— 扩展 `Platform` 联合类型并把 `newapi` 加进全部
   9 张 variant map，让非 badge 表面也具备视觉完整性。
 - `PlatformIcon.vue` —— 给 newapi 选品牌图标是设计决策不是 bug；目前的通用
@@ -276,7 +281,7 @@ const PLATFORM_TYPE_BG: Record<AccountPlatform, string> = { /* 同形 */ }
 
 ## 6. Stage-3 跟进（本次审批合并后）
 
-跟进项以 §1 Out-of-scope 列出的 5 条为单一事实源，每一项一个独立 PR。建议顺序：
+跟进项以 §1 Out-of-scope 列出的条目为单一事实源，每一项一个独立 PR。建议顺序：
 
 1. `AccountTableFilters.vue` 切到 `usePlatformOptions()` —— 运维可见性最高
 2. `OpsDashboardHeader.vue` 同上
@@ -285,7 +290,10 @@ const PLATFORM_TYPE_BG: Record<AccountPlatform, string> = { /* 同形 */ }
 5. `utils/platformColors.ts` 把 `newapi` 加进 9 张 variant map（视觉完整性）
 6. `ErrorPassthroughRulesModal.vue` 同 §1（运营紧迫性最低）
 7. `PlatformTypeBadge.vue` 3 个 `switch` → import `gatewayPlatforms.ts` 的 `SOFT_BADGE` map（§3.3 实现备注）
-8. §5.7 的防漂移 preflight 段落落地
+8. `ChannelsView.vue:721` `platformOrder` 审计：先确认"channels view 只渲染 4 个
+   OAuth/订阅平台"是有意为之还是组织漂移；如果是后者切到 composable，如果是
+   前者在常量旁补一行注释说明排除原因（防止下一个 reviewer 重复怀疑）。
+9. §5.7 的防漂移 preflight 段落落地（应在切完 §1-§3 之后，否则会 fail 自己）
 
 ## 7. 待审批的开放问题
 

--- a/docs/approved/admin-ui-newapi-platform-end-to-end.md
+++ b/docs/approved/admin-ui-newapi-platform-end-to-end.md
@@ -1,0 +1,261 @@
+---
+title: Admin UI — Fifth Platform `newapi` End-to-End Visibility & Operability
+status: pending
+approved_by: pending
+approved_at: pending
+authors: [agent]
+created: 2026-04-20
+related_prs: []
+related_commits: []
+related_stories: [US-017]
+related_audit: tester report 2026-04-20 — 创建分组 modal lacks fifth platform option
+supersedes: none
+parent_design: docs/approved/newapi-as-fifth-platform.md
+---
+
+# Admin UI — Fifth Platform `newapi` End-to-End
+
+## 0. TL;DR
+
+`docs/approved/newapi-as-fifth-platform.md` (shipped v1.4.0) explicitly **deferred admin-UI
+integration** ("frontend：`platformOptions` 是否含 newapi 由 admin UI 决定，不在本 design
+范围"). Result today: backend, scheduler, sticky routing, error passthrough, bridge—every
+runtime path treats `newapi` as a first-class fifth platform; **but the admin UI does not
+expose it**. Operators cannot create newapi groups or accounts through the UI; the only
+workaround is hand-crafting admin API calls.
+
+This design closes that gap with the **smallest** UI surface that lets an operator drive
+newapi end-to-end (create group → create account → see correctly-labelled account → filter
+list). Out-of-scope polish (ops-dashboard filter, error-passthrough rules, bulk edit,
+gradient/discount/button color variants) is enumerated for stage-3 follow-up but explicitly
+excluded from the prototype.
+
+## 1. Scope
+
+### In-scope (this design + prototype)
+
+1. **Single source of truth for platform options** — extract `usePlatformOptions()`
+   composable backed by `frontend/src/constants/gatewayPlatforms.ts` `GATEWAY_PLATFORMS`
+   (already includes `newapi`). Replace `GroupsView.vue`'s two hardcoded option lists.
+2. **Account creation** — `CreateAccountModal.vue` gains a 5th platform segment
+   `newapi` that wires the existing-but-unused `AccountNewApiPlatformFields.vue` to the
+   existing-but-unused `listChannelTypes()` / `fetchUpstreamModels()` API clients.
+3. **Account display correctness** — `PlatformTypeBadge.vue` adds a `newapi` arm and
+   stops using "Gemini" as the catch-all fallback. (Today a newapi account renders as
+   "Gemini" + blue badge, which is silently wrong data display, not a styling nit.)
+4. **Regression safeguard** — vitest unit covering `usePlatformOptions()` returns 5
+   platforms in canonical order so future refactors cannot drop newapi again.
+
+### Out-of-scope (stage-3 backlog, listed in `docs/task-breakdown-admin-ui-newapi.md`)
+
+- `AccountTableFilters.vue` / `OpsDashboardHeader.vue` / `ErrorPassthroughRulesModal.vue`
+  platform pickers — same composable swap, but each has its own filter semantics that
+  warrant individual review.
+- `EditAccountModal.vue` / `BulkEditAccountModal.vue` — must not regress, but full
+  newapi-channel editing in bulk has UX implications (mass channel_type change is
+  destructive). Keep behind a separate review.
+- `utils/platformColors.ts` — extend `Platform` union and add `newapi` to all 9
+  variant maps for visual completeness in non-badge surfaces.
+- `PlatformIcon.vue` — picking a brand mark for newapi is a design decision, not a
+  bug. Today's generic-globe fallback is acceptable.
+- `SubscriptionsView.vue` — newapi has no OAuth subscription concept. Adding it would
+  mislead.
+
+### Non-goals (will not do, and design explains why)
+
+- **No new backend endpoints.** Backend already accepts `Platform: "newapi"` in
+  `CreateGroup` / `CreateAccount` (admin_service.go:1565 enforces `channel_type > 0`).
+  No backend change needed; doing one would violate CLAUDE.md §5 minimal API surface.
+- **No new DTO fields.** `AccountNewApiPlatformFields` already binds to existing
+  `channel_type` / `base_url` / `api_key` — they round-trip via existing APIs.
+- **No global UI restructure.** Per CLAUDE.md §5.x, prefer additive injection points
+  over rewriting upstream-shaped files (`CreateAccountModal.vue` is upstream-derived).
+  All edits are append-only inside existing `v-if` chains.
+
+## 2. Current Failure Path
+
+```
+User → 「分组管理」→ 创建分组
+   → modal 平台下拉只渲染 [Anthropic, OpenAI, Gemini, Antigravity]
+   → 用户无法选 newapi → 只能放弃或操作 admin API
+```
+
+Root cause: `frontend/src/views/admin/GroupsView.vue:2813-2818` hardcodes a 4-element
+`platformOptions` literal. Same anti-pattern repeats in `:2820-2826` (filter), and in 4
+other admin views (`AccountTableFilters.vue`, `OpsDashboardHeader.vue`,
+`ErrorPassthroughRulesModal.vue`, `SubscriptionsView.vue`) and 1 display component
+(`PlatformTypeBadge.vue`). Each was written before `GATEWAY_PLATFORMS` constant existed
+(2026-04-19) and never refactored to consume it.
+
+This is **organizational drift**, not a logic bug — the canonical `GATEWAY_PLATFORMS`
+exists; nothing consumes it for option-list generation.
+
+## 3. Design
+
+### 3.1 Single source of truth — `usePlatformOptions()`
+
+Add `frontend/src/composables/usePlatformOptions.ts`:
+
+```ts
+import { computed } from 'vue'
+import { useI18n } from 'vue-i18n'
+import { GATEWAY_PLATFORMS } from '@/constants/gatewayPlatforms'
+import type { AccountPlatform } from '@/types'
+
+const PLATFORM_LABELS: Record<AccountPlatform, string> = {
+  anthropic:  'Anthropic',
+  openai:     'OpenAI',
+  gemini:     'Gemini',
+  antigravity:'Antigravity',
+  newapi:     'New API',
+}
+
+export interface PlatformOption {
+  value: AccountPlatform
+  label: string
+}
+
+/** Canonical platform options, ordered per GATEWAY_PLATFORMS. */
+export function usePlatformOptions() {
+  const options = computed<PlatformOption[]>(() =>
+    GATEWAY_PLATFORMS.map(p => ({ value: p, label: PLATFORM_LABELS[p] })))
+
+  /** Filter variant — prepend an "all" sentinel localized at call site. */
+  const optionsWithAll = (allLabel: string) =>
+    computed<Array<{ value: '' | AccountPlatform; label: string }>>(() => [
+      { value: '', label: allLabel },
+      ...options.value,
+    ])
+
+  return { options, optionsWithAll }
+}
+```
+
+Rationale (Jobs simplicity + OPC automation):
+- One canonical map, ordered by `GATEWAY_PLATFORMS` (which TypeScript already pins to
+  `AccountPlatform` union — adding a 6th platform later requires touching one file).
+- No i18n keys for platform labels: brand names (Anthropic / OpenAI / Gemini /
+  Antigravity / New API) are not translated in this codebase today; introducing
+  per-locale brand strings now would be premature.
+- Filter variant is a function (not a computed) so callers pass their localized
+  "all" label without globalizing it.
+
+### 3.2 Account-creation tab — `CreateAccountModal.vue`
+
+Append a 5th segmented-control button after the existing Antigravity button (around
+line 139). Wire `form.platform = 'newapi'`. Add a `<div v-if="form.platform === 'newapi'">`
+block immediately after the existing `antigravity` block (around line 707) that hosts
+`<AccountNewApiPlatformFields v-model:channelType="..." v-model:baseUrl="..."
+v-model:apiKey="..." :channel-type-options="..." :channel-types-loading="..."
+:channel-types-error="..." :selected-channel-type-base-url="..." />`.
+
+Data wiring:
+- On modal open (or first time `form.platform === 'newapi'`), call
+  `listChannelTypes()` from `@/api/admin/channels` and project to `{value, label}`
+  pairs.
+- `selectedChannelTypeBaseUrl` derived from the chosen `channel_type` row (used as
+  the input placeholder so operators see the official upstream URL even when the
+  field is blank).
+- Submit → call existing `createAccount()` with `platform: 'newapi'`,
+  `channel_type`, `base_url`, `api_key`, `name`. Backend validates
+  `channel_type > 0` (admin_service.go:1565) so no client-side guard duplication is
+  needed beyond a "required field" hint.
+
+Following CLAUDE.md §5.x: `CreateAccountModal.vue` is upstream-derived; we only
+**append** a tab and a `v-if` block (no rewrite).
+
+### 3.3 Display correctness — `PlatformTypeBadge.vue`
+
+Today line 74-79:
+
+```ts
+const platformLabel = computed(() => {
+  if (props.platform === 'anthropic') return 'Anthropic'
+  if (props.platform === 'openai') return 'OpenAI'
+  if (props.platform === 'antigravity') return 'Antigravity'
+  return 'Gemini'  // ← BUG: any unknown platform shown as Gemini
+})
+```
+
+Same anti-pattern in `platformClass` and `typeClass` (default fallback = blue/Gemini
+styling).
+
+Fix: switch to explicit map keyed by `AccountPlatform` (which already includes
+`newapi`); add `newapi` arm with cyan styling matching `gatewayPlatforms.ts:30`; add
+a true unknown-platform branch (gray) for forward-compat.
+
+```ts
+const PLATFORM_LABEL: Record<AccountPlatform, string> = {
+  anthropic:'Anthropic', openai:'OpenAI', gemini:'Gemini',
+  antigravity:'Antigravity', newapi:'New API',
+}
+const PLATFORM_BG: Record<AccountPlatform, string> = {
+  anthropic:'bg-orange-100 text-orange-700 dark:bg-orange-900/30 dark:text-orange-400',
+  openai:   'bg-emerald-100 text-emerald-700 dark:bg-emerald-900/30 dark:text-emerald-400',
+  gemini:   'bg-blue-100 text-blue-700 dark:bg-blue-900/30 dark:text-blue-400',
+  antigravity:'bg-purple-100 text-purple-700 dark:bg-purple-900/30 dark:text-purple-400',
+  newapi:   'bg-cyan-100 text-cyan-700 dark:bg-cyan-900/30 dark:text-cyan-400',
+}
+const PLATFORM_TYPE_BG: Record<AccountPlatform, string> = { /* same shape */ }
+```
+
+This eliminates the silent "Gemini fallback" bug for **any** platform unknown to the
+component (newapi, future 6th, typo'd payload).
+
+### 3.4 GroupsView option swap
+
+Replace literals at `GroupsView.vue:2813-2818` and `:2820-2826` with the composable.
+Filter variant uses `optionsWithAll(t('admin.groups.allPlatforms'))`.
+
+### 3.5 Files Touched (prototype)
+
+| Path | Change |
+| --- | --- |
+| `frontend/src/composables/usePlatformOptions.ts` | NEW — composable |
+| `frontend/src/composables/__tests__/usePlatformOptions.spec.ts` | NEW — vitest regression test |
+| `frontend/src/views/admin/GroupsView.vue` | replace 2 hardcoded option lists with composable (≤10 line diff) |
+| `frontend/src/components/account/CreateAccountModal.vue` | + 5th segment button + `v-if newapi` block + `listChannelTypes` wiring |
+| `frontend/src/components/common/PlatformTypeBadge.vue` | replace 4-arm `if/else` with `Record<AccountPlatform, …>` map; add newapi |
+| `.testing/user-stories/stories/US-017-admin-ui-newapi-platform-pickers.md` | NEW — story |
+| `.testing/user-stories/index.md` | + US-017 row |
+| `docs/task-breakdown-admin-ui-newapi.md` | already written (stage-1 artifact) |
+| `docs/approved/admin-ui-newapi-platform-end-to-end.md` | this doc |
+
+No backend / Ent / Wire changes. No new dependencies.
+
+## 4. Risk Analysis
+
+| Risk | Likelihood | Impact | Mitigation |
+| --- | --- | --- | --- |
+| Existing 4-platform UX regresses after composable swap | Med | Medium | vitest asserts order = GATEWAY_PLATFORMS; manual click-through of 4 existing tabs in CreateAccountModal during prototype demo |
+| Operators create newapi account with wrong channel_type / base_url and call fails | High (UX, not regression) | Low (clear backend error) | `AccountNewApiPlatformFields` already wires `fetchUpstreamModels` for self-test; required-asterisks visible |
+| Translation gap — "New API" not localized | Low | Low | Brand names not localized today (4 existing platforms hardcoded in English) — defer to project i18n pass |
+| `usePlatformOptions()` accidentally used in scopes that should hide newapi (e.g. SubscriptionsView) | Low | Med | Out-of-scope list explicitly excludes those views; reviewer checks call sites |
+| Backend rejects `Platform: "newapi"` somewhere we didn't audit | Low | High | `admin_service.go:1565` is the only platform check in CreateAccount; `CreateGroup` accepts any string; covered by US-008..014 backend tests |
+
+## 5. Acceptance (end-to-end demo for stage-2 approval)
+
+The prototype is approval-worthy if a reviewer can, on a fresh dev stack:
+
+1. Open `/admin/groups`, click 「创建分组」, see **5** platforms in dropdown including "New API". Create a `newapi` test group successfully.
+2. Open `/admin/accounts`, click 「创建账号」, see **5** platform tabs. Click "New API". Channel type list loads. Pick e.g. DeepSeek, fill base_url + api_key, save. Account created, list refreshed.
+3. The new account renders in the list with badge "New API" + cyan, **not** "Gemini" + blue.
+4. Existing 4 platforms still work identically (no visual / behavioral diff).
+5. `pnpm lint:check && pnpm typecheck && pnpm test:unit` green.
+6. `./scripts/preflight.sh` green.
+
+## 6. Stage-3 Follow-up (after this is approved & shipped)
+
+Track in `docs/task-breakdown-admin-ui-newapi.md` §2 M1.3-M1.5, M2.4-M2.5, M3.2, M4.2-M4.4.
+Each is a small, independent PR. Order suggestion: AccountTableFilters first (highest
+operator visibility), then OpsDashboardHeader, then EditAccountModal, then bulk-edit
+guardrails, then `platformColors.ts` fill-in, then ErrorPassthroughRulesModal (lowest
+operational urgency).
+
+## 7. Open Questions for Approval
+
+1. **Display label**: "New API" vs "NewAPI" vs "newapi"? Prototype uses **"New API"** (matches channel-type catalog conventions).
+2. **Color**: cyan (`gatewayPlatforms.ts` already declared). Approve or override?
+3. **Localization**: keep brand names in English (current convention) or add i18n keys? Prototype: keep English.
+4. **Default channel_type on create**: blank (force user to choose) or pre-select first item? Prototype: blank with required asterisk.
+5. **AccountNewApiPlatformFields component path**: lives at `frontend/src/components/account/AccountNewApiPlatformFields.vue` — keep or move to a `*.tk.ts`-ish convention (CLAUDE.md §5)? Prototype: keep (the file already exists and follows TK companion-file convention by name; moving it would inflate diff).

--- a/docs/approved/admin-ui-newapi-platform-end-to-end.md
+++ b/docs/approved/admin-ui-newapi-platform-end-to-end.md
@@ -1,5 +1,5 @@
 ---
-title: Admin UI — Fifth Platform `newapi` End-to-End Visibility & Operability
+title: Admin UI — 第五平台 `newapi` 端到端可见性与可操作性
 status: pending
 approved_by: pending
 approved_at: pending
@@ -8,97 +8,100 @@ created: 2026-04-20
 related_prs: []
 related_commits: []
 related_stories: [US-017]
-related_audit: tester report 2026-04-20 — 创建分组 modal lacks fifth platform option
+related_audit: tester report 2026-04-20 — 创建分组 modal 缺失第五平台选项
 supersedes: none
 parent_design: docs/approved/newapi-as-fifth-platform.md
 ---
 
-# Admin UI — Fifth Platform `newapi` End-to-End
+# Admin UI — 第五平台 `newapi` 端到端
 
 ## 0. TL;DR
 
-`docs/approved/newapi-as-fifth-platform.md` (shipped v1.4.0) explicitly **deferred admin-UI
-integration** ("frontend：`platformOptions` 是否含 newapi 由 admin UI 决定，不在本 design
-范围"). Result today: backend, scheduler, sticky routing, error passthrough, bridge—every
-runtime path treats `newapi` as a first-class fifth platform; **but the admin UI does not
-expose it**. Operators cannot create newapi groups or accounts through the UI; the only
-workaround is hand-crafting admin API calls.
+`docs/approved/newapi-as-fifth-platform.md`（v1.4.0 已 ship）明确**推迟了 admin UI 集成**
+（"frontend：`platformOptions` 是否含 newapi 由 admin UI 决定，不在本 design 范围"）。
+今天的现状：后端、调度器、sticky routing、错误透传、bridge —— 所有运行时路径都把
+`newapi` 当作一等的第五平台；**但 admin UI 完全不暴露它**。运维无法通过界面创建
+newapi 分组或账号，唯一的绕路是手工构造 admin API 调用。
 
-This design closes that gap with the **smallest** UI surface that lets an operator drive
-newapi end-to-end (create group → create account → see correctly-labelled account → filter
-list). Out-of-scope polish (ops-dashboard filter, error-passthrough rules, bulk edit,
-gradient/discount/button color variants) is enumerated for stage-3 follow-up but explicitly
-excluded from the prototype.
+本设计用**最小**的 UI 改动闭合这一缺口，让运维可以端到端跑通 newapi
+（创建分组 → 创建账号 → 看到正确标注的账号 → 列表筛选）。Out-of-scope 的精修
+（ops-dashboard 筛选、错误透传规则、批量编辑、渐变色/折扣/按钮颜色变体）会列入
+stage-3 跟进，但明确排除在本次原型之外。
 
-## 1. Scope
+## 1. 范围
 
-### In-scope (this design + prototype)
+### In-scope（本设计 + 原型）
 
-1. **Single source of truth for platform options** — extract `usePlatformOptions()`
-   composable backed by `frontend/src/constants/gatewayPlatforms.ts` `GATEWAY_PLATFORMS`
-   (already includes `newapi`). Replace `GroupsView.vue`'s two hardcoded option lists.
-2. **Account creation** — `CreateAccountModal.vue` gains a 5th platform segment
-   `newapi` that wires the existing-but-unused `AccountNewApiPlatformFields.vue` to the
-   existing-but-unused `listChannelTypes()` / `fetchUpstreamModels()` API clients.
-3. **Account display correctness** — `PlatformTypeBadge.vue` adds a `newapi` arm and
-   stops using "Gemini" as the catch-all fallback. (Today a newapi account renders as
-   "Gemini" + blue badge, which is silently wrong data display, not a styling nit.)
-4. **Regression safeguard** — vitest unit covering `usePlatformOptions()` returns 5
-   platforms in canonical order so future refactors cannot drop newapi again.
+1. **平台选项的单一事实源** —— 抽出 `usePlatformOptions()` composable，
+   背后由 `frontend/src/constants/gatewayPlatforms.ts` 的 `GATEWAY_PLATFORMS`
+   驱动（其中已经包含 `newapi`）。替换 `GroupsView.vue` 中两处硬编码的选项列表。
+2. **创建账号** —— `CreateAccountModal.vue` 增加第 5 个平台 segment `newapi`，
+   把已存在但未启用的 `AccountNewApiPlatformFields.vue` 接到已存在但未启用的
+   `listChannelTypes()` / `fetchUpstreamModels()` API client 上。
+3. **账号展示正确性** —— `PlatformTypeBadge.vue` 增加 `newapi` 分支，并停止
+   把 "Gemini" 当作通配回退。（今天 newapi 账号在列表里会被渲染成
+   "Gemini" + 蓝色徽章，这是数据展示静默错误，不是样式 nit。）
+4. **回归保护** —— 用 **2 个** vitest spec 覆盖核心改动：
+   - `usePlatformOptions.spec.ts`：断言返回规范顺序的 5 个平台，避免后续重构再次把 newapi 漏掉；
+   - `PlatformTypeBadge.spec.ts`：断言 `newapi` 渲染为 "New API" + 青色，
+     真未知平台走中性灰回退（不再被静默错标为 Gemini），4 个老平台快照不变。
 
-### Out-of-scope (stage-3 backlog, listed in `docs/task-breakdown-admin-ui-newapi.md`)
+### Out-of-scope（stage-3 backlog，原型审批合并后单独 PR 做）
+
+> 设计阶段曾设想把 backlog 单独抽到 `docs/task-breakdown-admin-ui-newapi.md`，
+> 该文件**最终未落地**（避免散文档漂移）。stage-3 任务列表就以本节为单一来源，
+> follow-up PR 直接引用本节锚点即可。
 
 - `AccountTableFilters.vue` / `OpsDashboardHeader.vue` / `ErrorPassthroughRulesModal.vue`
-  platform pickers — same composable swap, but each has its own filter semantics that
-  warrant individual review.
-- `EditAccountModal.vue` / `BulkEditAccountModal.vue` — must not regress, but full
-  newapi-channel editing in bulk has UX implications (mass channel_type change is
-  destructive). Keep behind a separate review.
-- `utils/platformColors.ts` — extend `Platform` union and add `newapi` to all 9
-  variant maps for visual completeness in non-badge surfaces.
-- `PlatformIcon.vue` — picking a brand mark for newapi is a design decision, not a
-  bug. Today's generic-globe fallback is acceptable.
-- `SubscriptionsView.vue` — newapi has no OAuth subscription concept. Adding it would
-  mislead.
+  的平台 picker —— 同样换成本 composable，但每个都有自己的筛选语义，需要单独 review。
+- `EditAccountModal.vue` / `BulkEditAccountModal.vue` —— 不能让它们回归，但
+  完整支持批量编辑 newapi 渠道有 UX 影响（批量改 channel_type 是破坏性操作），
+  放到独立 review 里。
+- `utils/platformColors.ts` —— 扩展 `Platform` 联合类型并把 `newapi` 加进全部
+  9 张 variant map，让非 badge 表面也具备视觉完整性。
+- `PlatformIcon.vue` —— 给 newapi 选品牌图标是设计决策不是 bug；目前的通用
+  地球图标回退是可以接受的。
+- `SubscriptionsView.vue` —— newapi 没有 OAuth 订阅这个概念，加上反而误导。
 
-### Non-goals (will not do, and design explains why)
+### Non-goals（不会做，并解释为什么）
 
-- **No new backend endpoints.** Backend already accepts `Platform: "newapi"` in
-  `CreateGroup` / `CreateAccount` (admin_service.go:1565 enforces `channel_type > 0`).
-  No backend change needed; doing one would violate CLAUDE.md §5 minimal API surface.
-- **No new DTO fields.** `AccountNewApiPlatformFields` already binds to existing
-  `channel_type` / `base_url` / `api_key` — they round-trip via existing APIs.
-- **No global UI restructure.** Per CLAUDE.md §5.x, prefer additive injection points
-  over rewriting upstream-shaped files (`CreateAccountModal.vue` is upstream-derived).
-  All edits are append-only inside existing `v-if` chains.
+- **不新增 backend endpoint。** 后端 `CreateGroup` / `CreateAccount` 已经接受
+  `Platform: "newapi"`（admin_service.go:1565 强制 `channel_type > 0`）。
+  完全不需要后端改动；额外加一个会违反 CLAUDE.md §5 的最小 API surface 原则。
+- **不新增协议级 DTO。** `AccountNewApiPlatformFields` 已经绑定到现有的
+  `channel_type` / `base_url` / `api_key` —— 字段通过现有 API 自然往返。
+  本设计仅在前端 TypeScript 类型 `CreateAccountRequest` 上把已经事实存在的
+  顶层 `channel_type?: number` 显式声明出来（见 §3.5 C3），不动后端 DTO。
+- **不重构全局 UI。** 按 CLAUDE.md §5.x，应优先选择附加式注入而不是重写
+  upstream-shaped 文件（`CreateAccountModal.vue` 来自上游）。所有改动都是在
+  现有 `v-if` 链里追加。
 
-## 2. Current Failure Path
+## 2. 当前失败路径
 
 ```
-User → 「分组管理」→ 创建分组
+用户 → 「分组管理」→ 创建分组
    → modal 平台下拉只渲染 [Anthropic, OpenAI, Gemini, Antigravity]
    → 用户无法选 newapi → 只能放弃或操作 admin API
 ```
 
-Root cause: `frontend/src/views/admin/GroupsView.vue:2813-2818` hardcodes a 4-element
-`platformOptions` literal. Same anti-pattern repeats in `:2820-2826` (filter), and in 4
-other admin views (`AccountTableFilters.vue`, `OpsDashboardHeader.vue`,
-`ErrorPassthroughRulesModal.vue`, `SubscriptionsView.vue`) and 1 display component
-(`PlatformTypeBadge.vue`). Each was written before `GATEWAY_PLATFORMS` constant existed
-(2026-04-19) and never refactored to consume it.
+根因：`frontend/src/views/admin/GroupsView.vue:2813-2818` 把 4 个元素的
+`platformOptions` 字面量硬编码进去。同样的反模式在 `:2820-2826`（筛选器）以及
+另外 4 个 admin view（`AccountTableFilters.vue`、`OpsDashboardHeader.vue`、
+`ErrorPassthroughRulesModal.vue`、`SubscriptionsView.vue`）和 1 个展示组件
+（`PlatformTypeBadge.vue`）里反复出现。每一处都是在 `GATEWAY_PLATFORMS` 常量
+诞生（2026-04-19）之前写的，从未被重构去消费它。
 
-This is **organizational drift**, not a logic bug — the canonical `GATEWAY_PLATFORMS`
-exists; nothing consumes it for option-list generation.
+这是**组织漂移**，不是逻辑 bug —— 规范的 `GATEWAY_PLATFORMS` 已存在；只是没有
+任何地方用它来生成选项列表。
 
-## 3. Design
+## 3. 设计
 
-### 3.1 Single source of truth — `usePlatformOptions()`
+### 3.1 单一事实源 —— `usePlatformOptions()`
 
-Add `frontend/src/composables/usePlatformOptions.ts`:
+新增 `frontend/src/composables/usePlatformOptions.ts`：
 
 ```ts
 import { computed } from 'vue'
-import { useI18n } from 'vue-i18n'
 import { GATEWAY_PLATFORMS } from '@/constants/gatewayPlatforms'
 import type { AccountPlatform } from '@/types'
 
@@ -115,12 +118,12 @@ export interface PlatformOption {
   label: string
 }
 
-/** Canonical platform options, ordered per GATEWAY_PLATFORMS. */
+/** 规范的平台选项，顺序与 GATEWAY_PLATFORMS 一致。 */
 export function usePlatformOptions() {
   const options = computed<PlatformOption[]>(() =>
     GATEWAY_PLATFORMS.map(p => ({ value: p, label: PLATFORM_LABELS[p] })))
 
-  /** Filter variant — prepend an "all" sentinel localized at call site. */
+  /** 筛选变体 —— 在调用点传入本地化的 "全部" 标签作为前置 sentinel。 */
   const optionsWithAll = (allLabel: string) =>
     computed<Array<{ value: '' | AccountPlatform; label: string }>>(() => [
       { value: '', label: allLabel },
@@ -131,58 +134,64 @@ export function usePlatformOptions() {
 }
 ```
 
-Rationale (Jobs simplicity + OPC automation):
-- One canonical map, ordered by `GATEWAY_PLATFORMS` (which TypeScript already pins to
-  `AccountPlatform` union — adding a 6th platform later requires touching one file).
-- No i18n keys for platform labels: brand names (Anthropic / OpenAI / Gemini /
-  Antigravity / New API) are not translated in this codebase today; introducing
-  per-locale brand strings now would be premature.
-- Filter variant is a function (not a computed) so callers pass their localized
-  "all" label without globalizing it.
+理由（乔布斯式简洁 + OPC 自动化）：
 
-### 3.2 Account-creation tab — `CreateAccountModal.vue`
+- 一张规范 map，由 `GATEWAY_PLATFORMS` 排序（TypeScript 已经把它绑到
+  `AccountPlatform` 联合类型上 —— 将来加第 6 个平台只需要改一个文件）。
+- **平台品牌名不做 i18n key**：Anthropic / OpenAI / Gemini / Antigravity / New API
+  在本仓库今天都没有翻译；现在引入分语种品牌字符串属于过早抽象。
+- **创建账号表单的字段标签需要 i18n key**：channel_type / base_url / api_key 等
+  字段说明文字必须本地化，统一放在 `admin.accounts.newApiPlatform.*`
+  命名空间下（en/zh 两份 locale 同步加），见 §3.5。这与"品牌名不本地化"
+  并不冲突 —— 前者是品牌，后者是 UI 文案。
+- 筛选变体写成函数（不是 computed），这样调用方能自己传本地化 "全部" 标签，
+  不必把它全局化。
 
-Append a 5th segmented-control button after the existing Antigravity button (around
-line 139). Wire `form.platform = 'newapi'`. Add a `<div v-if="form.platform === 'newapi'">`
-block immediately after the existing `antigravity` block (around line 707) that hosts
-`<AccountNewApiPlatformFields v-model:channelType="..." v-model:baseUrl="..."
-v-model:apiKey="..." :channel-type-options="..." :channel-types-loading="..."
-:channel-types-error="..." :selected-channel-type-base-url="..." />`.
+### 3.2 创建账号 tab —— `CreateAccountModal.vue`
 
-Data wiring:
-- On modal open (or first time `form.platform === 'newapi'`), call
-  `listChannelTypes()` from `@/api/admin/channels` and project to `{value, label}`
-  pairs.
-- `selectedChannelTypeBaseUrl` derived from the chosen `channel_type` row (used as
-  the input placeholder so operators see the official upstream URL even when the
-  field is blank).
-- Submit → call existing `createAccount()` with `platform: 'newapi'`,
-  `channel_type`, `base_url`, `api_key`, `name`. Backend validates
-  `channel_type > 0` (admin_service.go:1565) so no client-side guard duplication is
-  needed beyond a "required field" hint.
+在现有 Antigravity 按钮之后（约第 139 行）追加第 5 个 segmented-control 按钮，
+绑定 `form.platform = 'newapi'`。在现有 `antigravity` 块（约第 707 行）之后
+紧接着加一个 `<div v-if="form.platform === 'newapi'">` 块，承载
+`<AccountNewApiPlatformFields v-model:channelType="..." v-model:baseUrl="..." v-model:apiKey="..." :channel-type-options="..." :channel-types-loading="..." :channel-types-error="..." :selected-channel-type-base-url="..." />`。
 
-Following CLAUDE.md §5.x: `CreateAccountModal.vue` is upstream-derived; we only
-**append** a tab and a `v-if` block (no rewrite).
+数据接线：
 
-### 3.3 Display correctness — `PlatformTypeBadge.vue`
+- modal 打开时（或第一次 `form.platform === 'newapi'` 时）调用
+  `@/api/admin/channels` 的 `listChannelTypes()`，投影成 `{value, label}` pair。
+- `selectedChannelTypeBaseUrl` 由所选 `channel_type` 行派生，**双重用途**：
+  ① 作为输入框 placeholder，让运维即使不填也能看到上游官方 URL；
+  ② 提交时若用户留空 `base_url`，自动回退到 channel-type 的默认 URL
+  （CreateAccountModal.vue:4104：`baseUrl = newapiBaseUrl.value.trim() || newapiSelectedBaseUrl.value`）。
+  这两个用途必须保持一致，未来重构者不得把它退化为"纯 placeholder"。
+- 提交 → 调用现有 `createAccount()` 时带上 `platform: 'newapi'`、
+  顶层 `channel_type`（数字）、`base_url`、`api_key`、`name`。后端校验
+  `channel_type > 0`（admin_service.go:1565），所以前端无需重复这一守卫，
+  仅给一个 "必填" 的提示即可。
+- **OAuth 流程必须 bypass**：`isOAuthFlow` 在 `form.platform === 'newapi'`
+  时强制为 false（newapi 仅 apikey），否则 template 的 step indicator
+  `v-if="isOAuthFlow"` 会对单步流程错误地渲染 "step 1/2"。
 
-Today line 74-79:
+遵循 CLAUDE.md §5.x：`CreateAccountModal.vue` 来自上游；我们只**追加**一个
+tab 和一个 `v-if` 块（不重写）。
+
+### 3.3 展示正确性 —— `PlatformTypeBadge.vue`
+
+今天第 74-79 行：
 
 ```ts
 const platformLabel = computed(() => {
   if (props.platform === 'anthropic') return 'Anthropic'
   if (props.platform === 'openai') return 'OpenAI'
   if (props.platform === 'antigravity') return 'Antigravity'
-  return 'Gemini'  // ← BUG: any unknown platform shown as Gemini
+  return 'Gemini'  // ← BUG：任何未知平台都被渲染成 Gemini
 })
 ```
 
-Same anti-pattern in `platformClass` and `typeClass` (default fallback = blue/Gemini
-styling).
+`platformClass` 和 `typeClass` 里有同样的反模式（默认回退 = 蓝色/Gemini 样式）。
 
-Fix: switch to explicit map keyed by `AccountPlatform` (which already includes
-`newapi`); add `newapi` arm with cyan styling matching `gatewayPlatforms.ts:30`; add
-a true unknown-platform branch (gray) for forward-compat.
+修法：用显式的 `Record<AccountPlatform, …>` map（或等价的穷举 switch）替换隐式
+default，**真未知平台走中性灰**而非"Gemini 蓝"。配色与 `gatewayPlatforms.ts:30`
+的 cyan 一致。
 
 ```ts
 const PLATFORM_LABEL: Record<AccountPlatform, string> = {
@@ -196,66 +205,93 @@ const PLATFORM_BG: Record<AccountPlatform, string> = {
   antigravity:'bg-purple-100 text-purple-700 dark:bg-purple-900/30 dark:text-purple-400',
   newapi:   'bg-cyan-100 text-cyan-700 dark:bg-cyan-900/30 dark:text-cyan-400',
 }
-const PLATFORM_TYPE_BG: Record<AccountPlatform, string> = { /* same shape */ }
+const PLATFORM_TYPE_BG: Record<AccountPlatform, string> = { /* 同形 */ }
 ```
 
-This eliminates the silent "Gemini fallback" bug for **any** platform unknown to the
-component (newapi, future 6th, typo'd payload).
+> 实现备注：原型 commit 落在了等价的穷举 `switch` 上（已含中性灰 default 分支）。
+> 行为与 Map 版一致，但"加第 6 个平台只改一处"的承诺要求 3 个 switch 同步改 3 处。
+> 推荐 stage-3 把 3 个 switch 折叠成 import `gatewayPlatforms.ts` 已有的
+> `SOFT_BADGE` map（line 25-31，已经包含全部 5 个平台的同款配色），
+> 与"单一事实源"主张闭环。
 
-### 3.4 GroupsView option swap
+### 3.4 GroupsView 选项替换
 
-Replace literals at `GroupsView.vue:2813-2818` and `:2820-2826` with the composable.
-Filter variant uses `optionsWithAll(t('admin.groups.allPlatforms'))`.
+把 `GroupsView.vue:2813-2818` 和 `:2820-2826` 的字面量替换成 composable 调用。
+筛选变体使用 `optionsWithAll(t('admin.groups.allPlatforms'))`。
 
-### 3.5 Files Touched (prototype)
+### 3.5 涉及文件（原型）
 
-| Path | Change |
+| 路径 | 变更 |
 | --- | --- |
-| `frontend/src/composables/usePlatformOptions.ts` | NEW — composable |
-| `frontend/src/composables/__tests__/usePlatformOptions.spec.ts` | NEW — vitest regression test |
-| `frontend/src/views/admin/GroupsView.vue` | replace 2 hardcoded option lists with composable (≤10 line diff) |
-| `frontend/src/components/account/CreateAccountModal.vue` | + 5th segment button + `v-if newapi` block + `listChannelTypes` wiring |
-| `frontend/src/components/common/PlatformTypeBadge.vue` | replace 4-arm `if/else` with `Record<AccountPlatform, …>` map; add newapi |
-| `.testing/user-stories/stories/US-017-admin-ui-newapi-platform-pickers.md` | NEW — story |
-| `.testing/user-stories/index.md` | + US-017 row |
-| `docs/task-breakdown-admin-ui-newapi.md` | already written (stage-1 artifact) |
-| `docs/approved/admin-ui-newapi-platform-end-to-end.md` | this doc |
+| `frontend/src/composables/usePlatformOptions.ts` | NEW —— composable |
+| `frontend/src/composables/__tests__/usePlatformOptions.spec.ts` | NEW —— vitest 回归测试（AC-001 / AC-002） |
+| `frontend/src/views/admin/GroupsView.vue` | 把 2 处硬编码选项列表换成 composable（≤10 行 diff） |
+| `frontend/src/components/account/CreateAccountModal.vue` | + 第 5 个 segment 按钮 + `v-if newapi` 块 + `listChannelTypes` 接线 + `isOAuthFlow` bypass |
+| `frontend/src/components/common/PlatformTypeBadge.vue` | 把隐式 default 替换为穷举分支；新增 `newapi`（青色），未知平台走中性灰 |
+| `frontend/src/components/common/__tests__/PlatformTypeBadge.spec.ts` | NEW —— vitest 回归测试（AC-003 / AC-004） |
+| `frontend/src/types/index.ts` | `CreateAccountRequest` 增加可选顶层 `channel_type?: number`（让 newapi 提交路径在 TS 层面合法） |
+| `frontend/src/i18n/locales/en.ts` | + `admin.accounts.newApiPlatform.*` 字段标签（channelType / baseUrl / apiKey 等） |
+| `frontend/src/i18n/locales/zh.ts` | 同上 zh 版 |
+| `.testing/user-stories/stories/US-017-admin-ui-newapi-platform-end-to-end.md` | NEW —— story |
+| `.testing/user-stories/index.md` | + US-017 行 |
+| `docs/approved/admin-ui-newapi-platform-end-to-end.md` | 本文档 |
 
-No backend / Ent / Wire changes. No new dependencies.
+不动 backend / Ent / Wire。不引入新依赖。
 
-## 4. Risk Analysis
+## 4. 风险分析
 
-| Risk | Likelihood | Impact | Mitigation |
+| 风险 | 概率 | 影响 | 缓解 |
 | --- | --- | --- | --- |
-| Existing 4-platform UX regresses after composable swap | Med | Medium | vitest asserts order = GATEWAY_PLATFORMS; manual click-through of 4 existing tabs in CreateAccountModal during prototype demo |
-| Operators create newapi account with wrong channel_type / base_url and call fails | High (UX, not regression) | Low (clear backend error) | `AccountNewApiPlatformFields` already wires `fetchUpstreamModels` for self-test; required-asterisks visible |
-| Translation gap — "New API" not localized | Low | Low | Brand names not localized today (4 existing platforms hardcoded in English) — defer to project i18n pass |
-| `usePlatformOptions()` accidentally used in scopes that should hide newapi (e.g. SubscriptionsView) | Low | Med | Out-of-scope list explicitly excludes those views; reviewer checks call sites |
-| Backend rejects `Platform: "newapi"` somewhere we didn't audit | Low | High | `admin_service.go:1565` is the only platform check in CreateAccount; `CreateGroup` accepts any string; covered by US-008..014 backend tests |
+| 已有 4 平台 UX 在 composable 替换后回归 | 中 | 中 | vitest 断言顺序 = GATEWAY_PLATFORMS；原型演示时手工点完 CreateAccountModal 中已有的 4 个 tab |
+| 运维用错 channel_type / base_url 创建 newapi 账号导致调用失败 | 高（UX，非回归） | 低（后端错误清晰） | `AccountNewApiPlatformFields` 已经接了 `fetchUpstreamModels` 用于自测；必填红星可见；`base_url` 留空时回退 channel-type 默认值 |
+| 翻译缺口 —— "New API" 未本地化 | 低 | 低 | 品牌名今天都不本地化（已有 4 个平台都硬编码英文）—— 等项目 i18n 统一 pass 时一起做 |
+| `usePlatformOptions()` 被误用在不该出现 newapi 的 scope（如 SubscriptionsView） | 低 | 中 | Out-of-scope 列表明确排除这些 view；reviewer 检查调用点；建议 §5 加防漂移 preflight |
+| 后端在某个我们没审计到的地方拒绝 `Platform: "newapi"` | 低 | 高 | `admin_service.go:1565` 是 CreateAccount 唯一的平台检查；`CreateGroup` 接受任意字符串；US-008..014 的后端测试已经覆盖 |
 
-## 5. Acceptance (end-to-end demo for stage-2 approval)
+## 5. 验收（stage-2 审批用的端到端 demo）
 
-The prototype is approval-worthy if a reviewer can, on a fresh dev stack:
+原型在 reviewer 拿到一份新的 dev 栈时能跑通以下流程，即视为可审批：
 
-1. Open `/admin/groups`, click 「创建分组」, see **5** platforms in dropdown including "New API". Create a `newapi` test group successfully.
-2. Open `/admin/accounts`, click 「创建账号」, see **5** platform tabs. Click "New API". Channel type list loads. Pick e.g. DeepSeek, fill base_url + api_key, save. Account created, list refreshed.
-3. The new account renders in the list with badge "New API" + cyan, **not** "Gemini" + blue.
-4. Existing 4 platforms still work identically (no visual / behavioral diff).
-5. `pnpm lint:check && pnpm typecheck && pnpm test:unit` green.
-6. `./scripts/preflight.sh` green.
+1. 打开 `/admin/groups`，点 「创建分组」，下拉里看到 **5** 个平台，包括 "New API"。成功创建一个 `newapi` 测试分组。
+2. 打开 `/admin/accounts`，点 「创建账号」，看到 **5** 个平台 tab。点 "New API"。channel type 列表加载完成。选择 e.g. DeepSeek，填 base_url + api_key，保存。账号创建，列表刷新。
+3. 新账号在列表中渲染为 "New API" + 青色徽章，**而非** "Gemini" + 蓝色。
+4. 已有 4 个平台行为完全一致（无视觉/行为 diff）—— 重点点开 4 个老平台 tab，确认 step indicator (`isOAuthFlow`) 的显隐与升级前完全一致；newapi tab 选中时 step indicator **不**显示。
+5. `pnpm lint:check && pnpm typecheck && pnpm test:unit` 全绿。
+6. `./scripts/preflight.sh` 全绿（含 `dev-rules/scripts/check_approved_docs.py` 对本文档 frontmatter 的 R1-R5 校验）。
 
-## 6. Stage-3 Follow-up (after this is approved & shipped)
+### 5.7 防漂移 preflight（建议在 stage-3 引入）
 
-Track in `docs/task-breakdown-admin-ui-newapi.md` §2 M1.3-M1.5, M2.4-M2.5, M3.2, M4.2-M4.4.
-Each is a small, independent PR. Order suggestion: AccountTableFilters first (highest
-operator visibility), then OpsDashboardHeader, then EditAccountModal, then bulk-edit
-guardrails, then `platformColors.ts` fill-in, then ErrorPassthroughRulesModal (lowest
-operational urgency).
+本设计修复的是"组织漂移"——`GATEWAY_PLATFORMS` 早就存在，但没有任何调用点用它生成选项。
+为了避免下一个 PR 又往 admin view 里塞硬编码列表，建议在 `scripts/preflight.sh` 增加一段：
 
-## 7. Open Questions for Approval
+```bash
+# 任何 admin view 出现字面量 ['anthropic','openai','gemini','antigravity'] 必须 fail
+! rg -nP "\\['anthropic',\\s*'openai',\\s*'gemini',\\s*'antigravity'" \
+    frontend/src --glob '!*/constants/gatewayPlatforms.ts' \
+  || { echo "FAIL: hardcoded 4-platform list — use usePlatformOptions()"; exit 1; }
+```
 
-1. **Display label**: "New API" vs "NewAPI" vs "newapi"? Prototype uses **"New API"** (matches channel-type catalog conventions).
-2. **Color**: cyan (`gatewayPlatforms.ts` already declared). Approve or override?
-3. **Localization**: keep brand names in English (current convention) or add i18n keys? Prototype: keep English.
-4. **Default channel_type on create**: blank (force user to choose) or pre-select first item? Prototype: blank with required asterisk.
-5. **AccountNewApiPlatformFields component path**: lives at `frontend/src/components/account/AccountNewApiPlatformFields.vue` — keep or move to a `*.tk.ts`-ish convention (CLAUDE.md §5)? Prototype: keep (the file already exists and follows TK companion-file convention by name; moving it would inflate diff).
+按 product-dev.mdc「能写成脚本/CI 检查/Rule 的，绝不依赖 Agent 每次自觉遵守」，
+这是把"靠记忆"升级为"靠规则"。原型 PR 不强制要求，stage-3 第一个 PR 必须落地。
+
+## 6. Stage-3 跟进（本次审批合并后）
+
+跟进项以 §1 Out-of-scope 列出的 5 条为单一事实源，每一项一个独立 PR。建议顺序：
+
+1. `AccountTableFilters.vue` 切到 `usePlatformOptions()` —— 运维可见性最高
+2. `OpsDashboardHeader.vue` 同上
+3. `EditAccountModal.vue` 增加 newapi 编辑分支（不含批量）
+4. `BulkEditAccountModal.vue` 加批量编辑守卫（`channel_type` 不允许批量改）
+5. `utils/platformColors.ts` 把 `newapi` 加进 9 张 variant map（视觉完整性）
+6. `ErrorPassthroughRulesModal.vue` 同 §1（运营紧迫性最低）
+7. `PlatformTypeBadge.vue` 3 个 `switch` → import `gatewayPlatforms.ts` 的 `SOFT_BADGE` map（§3.3 实现备注）
+8. §5.7 的防漂移 preflight 段落落地
+
+## 7. 待审批的开放问题
+
+> 已经被原型实现做出选择的项不再列在这里（避免审批者以为还要表态）。
+
+1. **展示标签**："New API" / "NewAPI" / "newapi"？原型用 **"New API"**（与 channel-type 目录习惯一致）。
+2. **配色**：cyan（`gatewayPlatforms.ts` 已声明）。批准还是覆盖？
+3. **本地化策略**：品牌名继续保留英文（当前惯例）+ 字段标签走 i18n key。批准还是要求把品牌名也加 i18n？
+

--- a/docs/approved/admin-ui-newapi-platform-end-to-end.md
+++ b/docs/approved/admin-ui-newapi-platform-end-to-end.md
@@ -38,33 +38,37 @@ i18n 的 `newapi` 标签也一并补齐。
 ### In-scope（本设计 + 原型）
 
 1. **平台选项的单一事实源** —— 抽出 `usePlatformOptions()` composable，
-   背后由 `frontend/src/constants/gatewayPlatforms.ts` 的 `GATEWAY_PLATFORMS`
+  背后由 `frontend/src/constants/gatewayPlatforms.ts` 的 `GATEWAY_PLATFORMS`
    驱动（其中已经包含 `newapi`）。替换 `GroupsView.vue` 中两处硬编码的选项列表。
 2. **创建账号** —— `CreateAccountModal.vue` 增加第 5 个平台 segment `newapi`，
-   把已存在但未启用的 `AccountNewApiPlatformFields.vue` 接到已存在但未启用的
+  把已存在但未启用的 `AccountNewApiPlatformFields.vue` 接到已存在但未启用的
    `listChannelTypes()` / `fetchUpstreamModels()` API client 上。
 3. **账号展示正确性** —— `PlatformTypeBadge.vue` 增加 `newapi` 分支，并停止
-   把 "Gemini" 当作通配回退。（今天 newapi 账号在列表里会被渲染成
+  把 "Gemini" 当作通配回退。（今天 newapi 账号在列表里会被渲染成
    "Gemini" + 蓝色徽章，这是数据展示静默错误，不是样式 nit。）
 4. **回归保护** —— 用 **2 个** vitest spec 覆盖核心改动：
-   - `usePlatformOptions.spec.ts`：断言返回规范顺序的 5 个平台，避免后续重构再次把 newapi 漏掉；
-   - `PlatformTypeBadge.spec.ts`：断言 `newapi` 渲染为 "New API" + 青色，
-     真未知平台走中性灰回退（不再被静默错标为 Gemini），4 个老平台快照不变。
+  - `usePlatformOptions.spec.ts`：断言返回规范顺序的 5 个平台，避免后续重构再次把 newapi 漏掉；
+  - `PlatformTypeBadge.spec.ts`：断言 `newapi` 渲染为 "New API" + 青色，
+  真未知平台走中性灰回退（不再被静默错标为 Gemini），4 个老平台快照不变。
 
 ### Out-of-scope（stage-3 backlog，原型审批合并后单独 PR 做）
 
 > 设计阶段曾设想把 backlog 单独抽到 `docs/task-breakdown-admin-ui-newapi.md`，
 > 该文件**最终未落地**（避免散文档漂移）。stage-3 任务列表就以本节为单一来源，
 > follow-up PR 直接引用本节锚点即可。
+>
+> **2026-04-20 更新**：根据用户指令，原 Out-of-scope 中的下列条目已在 §1.6
+> 全量并入 PR #19。仅剩 §6 列出的真正延后项（防漂移 preflight 段落需要
+> 在 §1-§5 切完后单独落地）。
 
-- `AccountTableFilters.vue` / `OpsDashboardHeader.vue` / `ErrorPassthroughRulesModal.vue`
-  的平台 picker —— 同样换成本 composable，但每个都有自己的筛选语义，需要单独 review。
-- `EditAccountModal.vue` / `BulkEditAccountModal.vue` —— 不能让它们回归，但
-  完整支持批量编辑 newapi 渠道有 UX 影响（批量改 channel_type 是破坏性操作），
-  放到独立 review 里。
-- `PlatformIcon.vue` —— 给 newapi 选品牌图标是设计决策不是 bug；目前的通用
-  地球图标回退是可以接受的。
-- `SubscriptionsView.vue` —— newapi 没有 OAuth 订阅这个概念，加上反而误导。
+- ~~`AccountTableFilters.vue` / `OpsDashboardHeader.vue` / `ErrorPassthroughRulesModal.vue`
+的平台 picker~~ → §1.6 #9-#11 已并入 PR #19。
+- ~~`EditAccountModal.vue`~~ → §1.6 #8 已并入 PR #19；`BulkEditAccountModal.vue` 自动通过
+`useModelWhitelist` 扩展（§1.6 #13）覆盖 newapi 模型映射，仅"批量改 `channel_type` 守卫"
+仍属 stage-3（见 §6）。
+- ~~`PlatformIcon.vue`~~ → §1.6 #20 已为 newapi 加专属 SVG 图标。
+- ~~`SubscriptionsView.vue`~~ → §1.6 #18 已加 cyan accent dot；newapi 订阅模型由后端决定
+渲染什么（OAuth 订阅概念不强加在 newapi 上，但平台标签必须正确显示）。
 
 ### 1.5 审批前补强（PR #19 review 后追加）
 
@@ -73,48 +77,111 @@ PR #19 的二次 review 对 `ChannelsView.vue` 做深度审计后，发现原 §
 bug**：
 
 - `ChannelsView.vue:721` 的 `platformOrder = ['anthropic','openai','gemini','antigravity']`
-  被两条**互不相干的代码路径**消费：
-  ① `apiToForm` 第 1070 行用它过滤 `channel.model_mapping` 的键；
-  ② `formToAPI` 第 1007 行迭代 `form.platforms`（其内容由 ① 决定）。
-  这意味着：**任何后端返回了 `newapi` 数据的 channel，被运维在 ChannelsView
-  打开并保存后，会静默丢失全部 `newapi` 行**（model_mapping、model_pricing、
-  group 关联）。
-  后端早就接受 `newapi` channel（`channel_handler_tk_newapi_admin.go:35`
-  在 `oneof` 白名单中显式列出 `newapi`，`channel_repo.go:133` 的 Update 全量
-  替换 JSONB），所以这不是"只读视图"假设的延伸，而是**前端 vs 后端之间的不
-  对称组织漂移**。
+被两条**互不相干的代码路径**消费：
+① `apiToForm` 第 1070 行用它过滤 `channel.model_mapping` 的键；
+② `formToAPI` 第 1007 行迭代 `form.platforms`（其内容由 ① 决定）。
+这意味着：**任何后端返回了 `newapi` 数据的 channel，被运维在 ChannelsView
+打开并保存后，会静默丢失全部 `newapi` 行**（model_mapping、model_pricing、
+group 关联）。
+后端早就接受 `newapi` channel（`channel_handler_tk_newapi_admin.go:35`
+在 `oneof` 白名单中显式列出 `newapi`，`channel_repo.go:133` 的 Update 全量
+替换 JSONB），所以这不是"只读视图"假设的延伸，而是**前端 vs 后端之间的不
+对称组织漂移**。
 - `utils/platformColors.ts` 的 `Platform` 联合类型缺 `newapi`，导致 ChannelsView
-  在切到 composable 后，`newapi` 平台行/徽章的颜色会回退到默认灰，与设计承诺
-  的 cyan 不一致——不算数据 bug，但一旦 ChannelsView 开始渲染 `newapi`
-  必须同步修，否则视觉漂移。
+在切到 composable 后，`newapi` 平台行/徽章的颜色会回退到默认灰，与设计承诺
+的 cyan 不一致——不算数据 bug，但一旦 ChannelsView 开始渲染 `newapi`
+必须同步修，否则视觉漂移。
 
 补强清单（commits 4-N，与 §3 in-scope 共享同一个 PR #19）：
 
-| # | 路径 | 变更 | 风险归属 |
-| --- | --- | --- | --- |
-| 1 | `frontend/src/utils/channelFormConversion.ts` (NEW) | 抽出纯函数 `apiToFormSections` / `formSectionsToApi`，把 canonical platform order 当参数传入（默认 `GATEWAY_PLATFORMS`）；让 round-trip 可被单测覆盖 | 逻辑错误（数据丢失） |
-| 2 | `frontend/src/views/admin/ChannelsView.vue` | 删除本地 `platformOrder` 4 元素字面量，改 `import { GATEWAY_PLATFORMS }`；`apiToForm` / `formToAPI` 改为调用 §1 的纯函数 | 逻辑错误 + 行为回归 |
-| 3 | `frontend/src/utils/platformColors.ts` | `Platform` 联合类型加 `'newapi'`；9 张 variant map 全部加 cyan 项；`isPlatform()` 与 `platformLabel()` 同步加分支；`Record<Platform, …>` 让漏一项编译失败 | 行为回归（视觉） |
-| 4 | `frontend/src/components/admin/channel/types.ts` | `getPlatformTagClass()` 增加 `case 'newapi'`（cyan tag） | 行为回归（视觉） |
-| 5 | `frontend/src/i18n/locales/{en,zh}.ts` | `admin.groups.platforms.newapi` 与 `admin.accounts.platforms.newapi` 都加 `'New API'`，避免 ChannelsView/GroupsView 显示原始 key | 行为回归（文案） |
-| 6 | `frontend/src/utils/__tests__/channelFormConversion.spec.ts` (NEW) | 9 个 vitest case：5 平台 round-trip 保留 newapi、用 4 元素旧 order 调用证明数据丢失（NEGATIVE）、纯 4 平台回归、`web_search_emulation` on/off/clear、disabled section 跳过、canonical order、空 pricing 过滤 | 防漂移护栏 |
+
+| #   | 路径                                                                 | 变更                                                                                                                                                                       | 风险归属        |
+| --- | ------------------------------------------------------------------ | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------ | ----------- |
+| 1   | `frontend/src/utils/channelFormConversion.ts` (NEW)                | 抽出纯函数 `apiToFormSections` / `formSectionsToApi`，把 canonical platform order 当参数传入（默认 `GATEWAY_PLATFORMS`）；让 round-trip 可被单测覆盖                                             | 逻辑错误（数据丢失）  |
+| 2   | `frontend/src/views/admin/ChannelsView.vue`                        | 删除本地 `platformOrder` 4 元素字面量，改 `import { GATEWAY_PLATFORMS }`；`apiToForm` / `formToAPI` 改为调用 §1 的纯函数                                                                     | 逻辑错误 + 行为回归 |
+| 3   | `frontend/src/utils/platformColors.ts`                             | `Platform` 联合类型加 `'newapi'`；9 张 variant map 全部加 cyan 项；`isPlatform()` 与 `platformLabel()` 同步加分支；`Record<Platform, …>` 让漏一项编译失败                                           | 行为回归（视觉）    |
+| 4   | `frontend/src/components/admin/channel/types.ts`                   | `getPlatformTagClass()` 增加 `case 'newapi'`（cyan tag）                                                                                                                     | 行为回归（视觉）    |
+| 5   | `frontend/src/i18n/locales/{en,zh}.ts`                             | `admin.groups.platforms.newapi` 与 `admin.accounts.platforms.newapi` 都加 `'New API'`，避免 ChannelsView/GroupsView 显示原始 key                                                   | 行为回归（文案）    |
+| 6   | `frontend/src/utils/__tests__/channelFormConversion.spec.ts` (NEW) | 9 个 vitest case：5 平台 round-trip 保留 newapi、用 4 元素旧 order 调用证明数据丢失（NEGATIVE）、纯 4 平台回归、`web_search_emulation` on/off/clear、disabled section 跳过、canonical order、空 pricing 过滤 | 防漂移护栏       |
+
 
 `PlatformIcon` / `PlatformTypeBadge` 的 cyan 与 newapi 显示在 §1 已涵盖，
-不在本节重复。`SubscriptionsView.vue` / `BulkEditAccountModal.vue` 等仍属
-stage-3。
+不在本节重复。
+
+### 1.6 PR #19 全量收束 —— stage-3 提前合并
+
+PR #19 第三轮 deep review（"查缺补漏 NewAPI 的能力，含用户端和管理端"）后，
+用户决定**把原本拆到 stage-3 的 follow-up 全部并入 PR #19**，让 newapi
+作为第五平台一次性达到与 openai 完全平价的端到端能力。原 §1 Out-of-scope
+全部上调为 In-scope（除 §5.7 防漂移 preflight 段落保留为 stage-3，因为
+要等 §1-§5 切完才不会 fail 自己）。
+
+补强清单（commits N+1..M，与 §3 / §1.5 共享同一个 PR #19）：
+
+**后端 P1（运行时正确性）**
+
+
+| #   | 路径                                                   | 变更                                                                                                                      | 风险归属 |
+| --- | ---------------------------------------------------- | ----------------------------------------------------------------------------------------------------------------------- | ---- |
+| 1   | `backend/internal/handler/gateway_handler.go`        | `/v1/models` 兜底响应在 fallback 路径下使用 API key group 的 `Platform`（含 `newapi`），不再硬编码 `"openai"`                               | 逻辑错误 |
+| 2   | `backend/internal/service/openai_gateway_service.go` | `handleErrorResponse` / `applyErrorPassthroughRule` 用 `account.Platform`（含 `newapi`）做规则匹配，使运维可以为 newapi 配置专属错误透传规则      | 逻辑错误 |
+| 3   | `backend/internal/handler/openai_gateway_handler.go` | `handleFailoverExhausted` 把真实平台（API key group 的 `Platform`）传给 `MatchRule`，避免 newapi failover 错误被错配为 openai 规则           | 逻辑错误 |
+| 4   | `backend/internal/handler/ops_error_logger.go`       | `guessPlatformFromPath` 扩展 OpenAI-compat 启发式（`/v1/models` 等共享路径走"未知"标签），避免 newapi 错误日志被误归类                              | 逻辑错误 |
+| 5   | `backend/internal/service/account_tk_compat_pool.go` | 把私有 `isOpenAICompatPlatform()` 提升为公开 `IsOpenAICompatPlatform`，供 §1.6 #1-#3 与 `openai_messages_dispatch_tk_newapi.go` 复用 | 防漂移  |
+
+
+**前端 P1（端到端可见性）**
+
+
+| #   | 路径                                                               | 变更                                                                                                                | 风险归属   |
+| --- | ---------------------------------------------------------------- | ----------------------------------------------------------------------------------------------------------------- | ------ |
+| 6   | `frontend/src/components/keys/UseKeyModal.vue`                   | 复制密钥 modal 的 tabs / 描述 / 文件名 / openCode deeplink 按 OpenAI-compat 处理 newapi（沿用 OpenAI 协议提示）                        | 行为回归   |
+| 7   | `frontend/src/views/user/KeysView.vue`                           | CCSwitch deeplink 在 newapi 下与 openai 等价（OpenAI-compat HTTP 形态）                                                    | 行为回归   |
+| 8   | `frontend/src/components/account/EditAccountModal.vue`           | 把 `CreateAccountModal` 的 newapi 分支端口过来（v-if + AccountNewApiPlatformFields 接线 + isOAuthFlow bypass），让 newapi 账号可编辑 | 行为回归   |
+| 9   | `frontend/src/components/admin/account/AccountTableFilters.vue`  | 平台筛选切到 `usePlatformOptions().optionsWithAll(allLabel)`（响应式 i18n）                                                  | 防漂移    |
+| 10  | `frontend/src/views/admin/ops/components/OpsDashboardHeader.vue` | 同上                                                                                                                | 防漂移    |
+| 11  | `frontend/src/components/admin/ErrorPassthroughRulesModal.vue`   | 同上                                                                                                                | 防漂移    |
+| 12  | `frontend/src/types/index.ts`                                    | `Account` 接口补 `channel_type?: number`（让 `EditAccountModal` 的 newapi 编辑路径在 TS 层面合法）                                | TS 完整性 |
+
+
+**前端 stage-3 提前合并（端到端能力平价）**
+
+
+| #   | 路径                                                               | 变更                                                                                                                                                                                        | 风险归属  |
+| --- | ---------------------------------------------------------------- | ----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- | ----- |
+| 13  | `frontend/src/composables/useModelWhitelist.ts`                  | `getModelsByPlatform('newapi') === openaiModels`；`getPresetMappingsByPlatform('newapi') === openaiPresetMappings`。批量编辑 / 模型白名单选择器自动覆盖 newapi（避免单独维护一套 newapi 预设立刻漂移于 openai）              | 防漂移   |
+| 14  | `frontend/src/composables/__tests__/useModelWhitelist.spec.ts`   | + 2 个回归 case：newapi 模型列表 / 预设映射与 openai 完全一致                                                                                                                                              | 防漂移护栏 |
+| 15  | `frontend/src/views/admin/GroupsView.vue`                        | "Messages 调度配置" 的 v-if 由 `platform === 'openai'` 切到 `isOpenAICompatPlatform(form.platform)`（含 newapi）；账号过滤区扩展到 newapi，但 `require_oauth_only` / `require_privacy_set` 对 newapi 隐藏（无 OAuth） | 行为回归  |
+| 16  | `backend/internal/service/openai_messages_dispatch_tk_newapi.go` | 内部 `isOpenAICompatPlatformGroup` 改为调用新的 `IsOpenAICompatPlatform`（去重）                                                                                                                      | 防漂移   |
+
+
+**视觉 P2 / P3（newapi 颜色 + 图标）**
+
+
+| #   | 路径                                                                  | 变更                                                                                                             | 风险归属 |
+| --- | ------------------------------------------------------------------- | -------------------------------------------------------------------------------------------------------------- | ---- |
+| 17  | `frontend/src/components/admin/group/GroupRateMultipliersModal.vue` | `platformColorClass` + `case 'newapi': cyan`                                                                   | 视觉回归 |
+| 18  | `frontend/src/views/user/SubscriptionsView.vue`                     | `platformAccentDotClass` + `case 'newapi': bg-cyan-500`                                                        | 视觉回归 |
+| 19  | `frontend/src/constants/gatewayPlatforms.ts`                        | NEW —— `OPENAI_COMPAT_PLATFORMS` 常量 + `isOpenAICompatPlatform()` helper（前端 canonical predicate，与后端 §1.6 #5 镜像） | 防漂移  |
+| 20  | `frontend/src/components/common/PlatformIcon.vue`                   | NEW —— newapi 专属 SVG 图标（4 个节点 + 连线，relay/网络拓扑感，区别于 4 个上游品牌 mark）                                               | 视觉补全 |
+| 21  | `frontend/src/views/HomeView.vue`                                   | "Supported Providers" 区块新增 New API 卡片（cyan 渐变 + Supported 标签）                                                  | 视觉补全 |
+| 22  | `frontend/src/i18n/locales/{en,zh}.ts`                              | + `home.providers.newapi: 'New API'`                                                                           | 文案   |
+
+
+不动 Ent / Wire / 数据库迁移。不引入新依赖。
 
 ### Non-goals（不会做，并解释为什么）
 
 - **不新增 backend endpoint。** 后端 `CreateGroup` / `CreateAccount` 已经接受
-  `Platform: "newapi"`（admin_service.go:1565 强制 `channel_type > 0`）。
-  完全不需要后端改动；额外加一个会违反 CLAUDE.md §5 的最小 API surface 原则。
+`Platform: "newapi"`（admin_service.go:1565 强制 `channel_type > 0`）。
+完全不需要后端改动；额外加一个会违反 CLAUDE.md §5 的最小 API surface 原则。
 - **不新增协议级 DTO。** `AccountNewApiPlatformFields` 已经绑定到现有的
-  `channel_type` / `base_url` / `api_key` —— 字段通过现有 API 自然往返。
-  本设计仅在前端 TypeScript 类型 `CreateAccountRequest` 上把已经事实存在的
-  顶层 `channel_type?: number` 显式声明出来（见 §3.5 C3），不动后端 DTO。
+`channel_type` / `base_url` / `api_key` —— 字段通过现有 API 自然往返。
+本设计仅在前端 TypeScript 类型 `CreateAccountRequest` 上把已经事实存在的
+顶层 `channel_type?: number` 显式声明出来（见 §3.5 C3），不动后端 DTO。
 - **不重构全局 UI。** 按 CLAUDE.md §5.x，应优先选择附加式注入而不是重写
-  upstream-shaped 文件（`CreateAccountModal.vue` 来自上游）。所有改动都是在
-  现有 `v-if` 链里追加。
+upstream-shaped 文件（`CreateAccountModal.vue` 来自上游）。所有改动都是在
+现有 `v-if` 链里追加。
 
 ## 2. 当前失败路径
 
@@ -177,15 +244,15 @@ export function usePlatformOptions() {
 理由（乔布斯式简洁 + OPC 自动化）：
 
 - 一张规范 map，由 `GATEWAY_PLATFORMS` 排序（TypeScript 已经把它绑到
-  `AccountPlatform` 联合类型上 —— 将来加第 6 个平台只需要改一个文件）。
+`AccountPlatform` 联合类型上 —— 将来加第 6 个平台只需要改一个文件）。
 - **平台品牌名不做 i18n key**：Anthropic / OpenAI / Gemini / Antigravity / New API
-  在本仓库今天都没有翻译；现在引入分语种品牌字符串属于过早抽象。
+在本仓库今天都没有翻译；现在引入分语种品牌字符串属于过早抽象。
 - **创建账号表单的字段标签需要 i18n key**：channel_type / base_url / api_key 等
-  字段说明文字必须本地化，统一放在 `admin.accounts.newApiPlatform.*`
-  命名空间下（en/zh 两份 locale 同步加），见 §3.5。这与"品牌名不本地化"
-  并不冲突 —— 前者是品牌，后者是 UI 文案。
+字段说明文字必须本地化，统一放在 `admin.accounts.newApiPlatform.`*
+命名空间下（en/zh 两份 locale 同步加），见 §3.5。这与"品牌名不本地化"
+并不冲突 —— 前者是品牌，后者是 UI 文案。
 - 筛选变体写成函数（不是 computed），这样调用方能自己传本地化 "全部" 标签，
-  不必把它全局化。
+不必把它全局化。
 
 ### 3.2 创建账号 tab —— `CreateAccountModal.vue`
 
@@ -197,19 +264,19 @@ export function usePlatformOptions() {
 数据接线：
 
 - modal 打开时（或第一次 `form.platform === 'newapi'` 时）调用
-  `@/api/admin/channels` 的 `listChannelTypes()`，投影成 `{value, label}` pair。
+`@/api/admin/channels` 的 `listChannelTypes()`，投影成 `{value, label}` pair。
 - `selectedChannelTypeBaseUrl` 由所选 `channel_type` 行派生，**双重用途**：
-  ① 作为输入框 placeholder，让运维即使不填也能看到上游官方 URL；
-  ② 提交时若用户留空 `base_url`，自动回退到 channel-type 的默认 URL
-  （CreateAccountModal.vue:4104：`baseUrl = newapiBaseUrl.value.trim() || newapiSelectedBaseUrl.value`）。
-  这两个用途必须保持一致，未来重构者不得把它退化为"纯 placeholder"。
+① 作为输入框 placeholder，让运维即使不填也能看到上游官方 URL；
+② 提交时若用户留空 `base_url`，自动回退到 channel-type 的默认 URL
+（CreateAccountModal.vue:4104：`baseUrl = newapiBaseUrl.value.trim() || newapiSelectedBaseUrl.value`）。
+这两个用途必须保持一致，未来重构者不得把它退化为"纯 placeholder"。
 - 提交 → 调用现有 `createAccount()` 时带上 `platform: 'newapi'`、
-  顶层 `channel_type`（数字）、`base_url`、`api_key`、`name`。后端校验
-  `channel_type > 0`（admin_service.go:1565），所以前端无需重复这一守卫，
-  仅给一个 "必填" 的提示即可。
+顶层 `channel_type`（数字）、`base_url`、`api_key`、`name`。后端校验
+`channel_type > 0`（admin_service.go:1565），所以前端无需重复这一守卫，
+仅给一个 "必填" 的提示即可。
 - **OAuth 流程必须 bypass**：`isOAuthFlow` 在 `form.platform === 'newapi'`
-  时强制为 false（newapi 仅 apikey），否则 template 的 step indicator
-  `v-if="isOAuthFlow"` 会对单步流程错误地渲染 "step 1/2"。
+时强制为 false（newapi 仅 apikey），否则 template 的 step indicator
+`v-if="isOAuthFlow"` 会对单步流程错误地渲染 "step 1/2"。
 
 遵循 CLAUDE.md §5.x：`CreateAccountModal.vue` 来自上游；我们只**追加**一个
 tab 和一个 `v-if` 块（不重写）。
@@ -261,43 +328,49 @@ const PLATFORM_TYPE_BG: Record<AccountPlatform, string> = { /* 同形 */ }
 
 ### 3.5 涉及文件（原型）
 
-| 路径 | 变更 |
-| --- | --- |
-| `frontend/src/composables/usePlatformOptions.ts` | NEW —— composable |
-| `frontend/src/composables/__tests__/usePlatformOptions.spec.ts` | NEW —— vitest 回归测试（AC-001 / AC-002） |
-| `frontend/src/views/admin/GroupsView.vue` | 把 2 处硬编码选项列表换成 composable（≤10 行 diff） |
-| `frontend/src/components/account/CreateAccountModal.vue` | + 第 5 个 segment 按钮 + `v-if newapi` 块 + `listChannelTypes` 接线 + `isOAuthFlow` bypass |
-| `frontend/src/components/common/PlatformTypeBadge.vue` | 把隐式 default 替换为穷举分支；新增 `newapi`（青色），未知平台走中性灰 |
-| `frontend/src/components/common/__tests__/PlatformTypeBadge.spec.ts` | NEW —— vitest 回归测试（AC-003 / AC-004） |
-| `frontend/src/types/index.ts` | `CreateAccountRequest` 增加可选顶层 `channel_type?: number`（让 newapi 提交路径在 TS 层面合法） |
-| `frontend/src/i18n/locales/en.ts` | + `admin.accounts.newApiPlatform.*` 字段标签（channelType / baseUrl / apiKey 等） |
-| `frontend/src/i18n/locales/zh.ts` | 同上 zh 版 |
-| `.testing/user-stories/stories/US-017-admin-ui-newapi-platform-end-to-end.md` | NEW —— story |
-| `.testing/user-stories/index.md` | + US-017 行 |
-| `docs/approved/admin-ui-newapi-platform-end-to-end.md` | 本文档 |
+
+| 路径                                                                            | 变更                                                                                  |
+| ----------------------------------------------------------------------------- | ----------------------------------------------------------------------------------- |
+| `frontend/src/composables/usePlatformOptions.ts`                              | NEW —— composable                                                                   |
+| `frontend/src/composables/__tests__/usePlatformOptions.spec.ts`               | NEW —— vitest 回归测试（AC-001 / AC-002）                                                 |
+| `frontend/src/views/admin/GroupsView.vue`                                     | 把 2 处硬编码选项列表换成 composable（≤10 行 diff）                                               |
+| `frontend/src/components/account/CreateAccountModal.vue`                      | + 第 5 个 segment 按钮 + `v-if newapi` 块 + `listChannelTypes` 接线 + `isOAuthFlow` bypass |
+| `frontend/src/components/common/PlatformTypeBadge.vue`                        | 把隐式 default 替换为穷举分支；新增 `newapi`（青色），未知平台走中性灰                                        |
+| `frontend/src/components/common/__tests__/PlatformTypeBadge.spec.ts`          | NEW —— vitest 回归测试（AC-003 / AC-004）                                                 |
+| `frontend/src/types/index.ts`                                                 | `CreateAccountRequest` 增加可选顶层 `channel_type?: number`（让 newapi 提交路径在 TS 层面合法）       |
+| `frontend/src/i18n/locales/en.ts`                                             | + `admin.accounts.newApiPlatform.*` 字段标签（channelType / baseUrl / apiKey 等）          |
+| `frontend/src/i18n/locales/zh.ts`                                             | 同上 zh 版                                                                             |
+| `.testing/user-stories/stories/US-017-admin-ui-newapi-platform-end-to-end.md` | NEW —— story                                                                        |
+| `.testing/user-stories/index.md`                                              | + US-017 行                                                                          |
+| `docs/approved/admin-ui-newapi-platform-end-to-end.md`                        | 本文档                                                                                 |
+
 
 §1.5 review 后追加的文件（同一 PR）：
 
-| 路径 | 变更 |
-| --- | --- |
-| `frontend/src/utils/channelFormConversion.ts` | NEW —— 抽出 ChannelsView 的 apiToForm/formToAPI 为纯函数，平台顺序参数化 |
-| `frontend/src/utils/__tests__/channelFormConversion.spec.ts` | NEW —— 9 个 round-trip vitest case（含数据丢失 bug 的 NEGATIVE 反证） |
-| `frontend/src/views/admin/ChannelsView.vue` | `platformOrder` 改为 `GATEWAY_PLATFORMS`；apiToForm/formToAPI 改为调用纯函数 |
-| `frontend/src/utils/platformColors.ts` | `Platform` 联合类型 + 9 张 variant map + `isPlatform()` + `platformLabel()` 全部加 `newapi`（cyan） |
-| `frontend/src/components/admin/channel/types.ts` | `getPlatformTagClass()` + `case 'newapi'`（cyan） |
-| `frontend/src/i18n/locales/{en,zh}.ts` | + `admin.groups.platforms.newapi` + `admin.accounts.platforms.newapi` |
+
+| 路径                                                           | 变更                                                                                        |
+| ------------------------------------------------------------ | ----------------------------------------------------------------------------------------- |
+| `frontend/src/utils/channelFormConversion.ts`                | NEW —— 抽出 ChannelsView 的 apiToForm/formToAPI 为纯函数，平台顺序参数化                                 |
+| `frontend/src/utils/__tests__/channelFormConversion.spec.ts` | NEW —— 9 个 round-trip vitest case（含数据丢失 bug 的 NEGATIVE 反证）                                |
+| `frontend/src/views/admin/ChannelsView.vue`                  | `platformOrder` 改为 `GATEWAY_PLATFORMS`；apiToForm/formToAPI 改为调用纯函数                        |
+| `frontend/src/utils/platformColors.ts`                       | `Platform` 联合类型 + 9 张 variant map + `isPlatform()` + `platformLabel()` 全部加 `newapi`（cyan） |
+| `frontend/src/components/admin/channel/types.ts`             | `getPlatformTagClass()` + `case 'newapi'`（cyan）                                           |
+| `frontend/src/i18n/locales/{en,zh}.ts`                       | + `admin.groups.platforms.newapi` + `admin.accounts.platforms.newapi`                     |
+
 
 不动 backend / Ent / Wire。不引入新依赖。
 
 ## 4. 风险分析
 
-| 风险 | 概率 | 影响 | 缓解 |
-| --- | --- | --- | --- |
-| 已有 4 平台 UX 在 composable 替换后回归 | 中 | 中 | vitest 断言顺序 = GATEWAY_PLATFORMS；原型演示时手工点完 CreateAccountModal 中已有的 4 个 tab |
-| 运维用错 channel_type / base_url 创建 newapi 账号导致调用失败 | 高（UX，非回归） | 低（后端错误清晰） | `AccountNewApiPlatformFields` 已经接了 `fetchUpstreamModels` 用于自测；必填红星可见；`base_url` 留空时回退 channel-type 默认值 |
-| 翻译缺口 —— "New API" 未本地化 | 低 | 低 | 品牌名今天都不本地化（已有 4 个平台都硬编码英文）—— 等项目 i18n 统一 pass 时一起做 |
-| `usePlatformOptions()` 被误用在不该出现 newapi 的 scope（如 SubscriptionsView） | 低 | 中 | Out-of-scope 列表明确排除这些 view；reviewer 检查调用点；建议 §5 加防漂移 preflight |
-| 后端在某个我们没审计到的地方拒绝 `Platform: "newapi"` | 低 | 高 | `admin_service.go:1565` 是 CreateAccount 唯一的平台检查；`CreateGroup` 接受任意字符串；US-008..014 的后端测试已经覆盖 |
+
+| 风险                                                                  | 概率        | 影响        | 缓解                                                                                                     |
+| ------------------------------------------------------------------- | --------- | --------- | ------------------------------------------------------------------------------------------------------ |
+| 已有 4 平台 UX 在 composable 替换后回归                                       | 中         | 中         | vitest 断言顺序 = GATEWAY_PLATFORMS；原型演示时手工点完 CreateAccountModal 中已有的 4 个 tab                              |
+| 运维用错 channel_type / base_url 创建 newapi 账号导致调用失败                     | 高（UX，非回归） | 低（后端错误清晰） | `AccountNewApiPlatformFields` 已经接了 `fetchUpstreamModels` 用于自测；必填红星可见；`base_url` 留空时回退 channel-type 默认值 |
+| 翻译缺口 —— "New API" 未本地化                                              | 低         | 低         | 品牌名今天都不本地化（已有 4 个平台都硬编码英文）—— 等项目 i18n 统一 pass 时一起做                                                     |
+| `usePlatformOptions()` 被误用在不该出现 newapi 的 scope（如 SubscriptionsView） | 低         | 中         | Out-of-scope 列表明确排除这些 view；reviewer 检查调用点；建议 §5 加防漂移 preflight                                         |
+| 后端在某个我们没审计到的地方拒绝 `Platform: "newapi"`                               | 低         | 高         | `admin_service.go:1565` 是 CreateAccount 唯一的平台检查；`CreateGroup` 接受任意字符串；US-008..014 的后端测试已经覆盖            |
+
 
 ## 5. 验收（stage-2 审批用的端到端 demo）
 
@@ -327,19 +400,28 @@ const PLATFORM_TYPE_BG: Record<AccountPlatform, string> = { /* 同形 */ }
 
 ## 6. Stage-3 跟进（本次审批合并后）
 
-跟进项以 §1 Out-of-scope 列出的条目为单一事实源，每一项一个独立 PR。建议顺序：
+> **2026-04-20 更新**：根据用户指令"全部关于 NewAPI 的都在 PR #19 内修复，
+> 包括 stage-3 立项的全部"，原 stage-3 列表中 1-6 项已在 §1.6 全量并入 PR #19。
+> 本节仅保留**真正不能在本 PR 落地**的延后项。
 
-1. `AccountTableFilters.vue` 切到 `usePlatformOptions()` —— 运维可见性最高
-2. `OpsDashboardHeader.vue` 同上
-3. `EditAccountModal.vue` 增加 newapi 编辑分支（不含批量）
-4. `BulkEditAccountModal.vue` 加批量编辑守卫（`channel_type` 不允许批量改）
-5. `ErrorPassthroughRulesModal.vue` 同 §1（运营紧迫性最低）
-6. `PlatformTypeBadge.vue` 3 个 `switch` → import `gatewayPlatforms.ts` 的 `SOFT_BADGE` map（§3.3 实现备注）
-7. §5.7 的防漂移 preflight 段落落地（应在切完 §1-§5 之后，否则会 fail 自己）
+剩余 stage-3 项：
+
+1. **§5.7 防漂移 preflight 段落落地** —— 必须在 §1-§5 全部切完且稳定运行
+  一段时间后再加，否则会 fail 自己（同一 PR 同时落地不变量与最后一个违规
+   消除，会让"是不是原型还有遗漏"无法被独立 review）。建议下一个针对
+   `frontend/src/` 的 PR 一并落地。
+2. `**PlatformTypeBadge.vue` 3 个 `switch` 折叠成 `SOFT_BADGE` map import**
+  （§3.3 实现备注）—— 是 OPC 自动化升级（"加第 6 个平台只改一处"），但
+   不影响 newapi 当前能力，可以延后。
+3. `**BulkEditAccountModal.vue` 批量改 `channel_type` 守卫** —— 当前批量编辑
+  通过 `useModelWhitelist`（§1.6 #13）已自动覆盖 newapi 模型映射；但批量
+   改 `channel_type` 是破坏性操作（会一次性把多个 newapi 账号切换上游），
+   要单独走 UX review，不在 PR #19 范围。
 
 > 历史：原列表中的 `utils/platformColors.ts`（cyan 完整化）与
 > `ChannelsView.vue:721` 审计已在 PR #19 review 期间被发现是**数据丢失 bug**
-> 而非纯视觉补全，因此前置到 §1.5 一同合并，不再是 stage-3 跟进项。
+> 而非纯视觉补全，因此前置到 §1.5 一同合并；其余 stage-3 项已并入 §1.6，
+> 不再是延后项。
 
 ## 7. 待审批的开放问题
 

--- a/frontend/src/components/account/CreateAccountModal.vue
+++ b/frontend/src/components/account/CreateAccountModal.vue
@@ -147,6 +147,24 @@
             <Icon name="cloud" size="sm" />
             Antigravity
           </button>
+          <!--
+            5th platform: New API (US-017, prototype). Picks up styling from
+            CREATE_ACCOUNT_PLATFORM_SEGMENT_ACTIVE (cyan) so it stays consistent
+            with the gatewayPlatforms.ts constant (single source of truth per CLAUDE.md §5).
+          -->
+          <button
+            type="button"
+            @click="form.platform = 'newapi'"
+            :class="[
+              'flex flex-1 items-center justify-center gap-2 rounded-md px-4 py-2.5 text-sm font-medium transition-all',
+              form.platform === 'newapi'
+                ? 'bg-white text-cyan-600 shadow-sm dark:bg-dark-600 dark:text-cyan-400'
+                : 'text-gray-600 hover:text-gray-900 dark:text-gray-400 dark:hover:text-gray-200'
+            ]"
+          >
+            <Icon name="server" size="sm" />
+            New API
+          </button>
         </div>
       </div>
 
@@ -701,6 +719,24 @@
             </div>
           </button>
         </div>
+      </div>
+
+      <!--
+        New API (5th platform) account fields. US-017 prototype scope.
+        AccountNewApiPlatformFields was already shipped with the design but never
+        wired in until now; component handles channel-type catalog + base_url + api_key.
+      -->
+      <div v-if="form.platform === 'newapi'" class="space-y-4">
+        <AccountNewApiPlatformFields
+          v-model:channelType="newapiChannelType"
+          v-model:baseUrl="newapiBaseUrl"
+          v-model:apiKey="newapiApiKey"
+          :channel-type-options="newapiChannelTypeOptions"
+          :channel-types-loading="newapiChannelTypesLoading"
+          :channel-types-error="newapiChannelTypesError"
+          :selected-channel-type-base-url="newapiSelectedBaseUrl"
+          variant="create"
+        />
       </div>
 
       <!-- Upstream config (only for Antigravity upstream type) -->
@@ -2940,6 +2976,8 @@ import {
   type OpenAIWSMode
 } from '@/utils/openaiWsMode'
 import OAuthAuthorizationFlow from './OAuthAuthorizationFlow.vue'
+import AccountNewApiPlatformFields from './AccountNewApiPlatformFields.vue'
+import { listChannelTypes, type ChannelTypeInfo } from '@/api/admin/channels'
 
 // Type for exposed OAuthAuthorizationFlow component
 // Note: defineExpose automatically unwraps refs, so we use the unwrapped types
@@ -3109,6 +3147,25 @@ const bedrockSessionToken = ref('')
 const bedrockRegion = ref('us-east-1')
 const bedrockForceGlobal = ref(false)
 const bedrockApiKeyValue = ref('')
+
+// New API (5th platform) state. US-017 prototype scope.
+// channel_type catalog comes from GET /api/v1/admin/channel-types (cached for the
+// modal's lifetime); when the user picks a type we prefill base_url from the
+// catalog entry but keep the field editable.
+const newapiChannelType = ref<number>(0)
+const newapiBaseUrl = ref('')
+const newapiApiKey = ref('')
+const newapiChannelTypes = ref<ChannelTypeInfo[]>([])
+const newapiChannelTypesLoading = ref(false)
+const newapiChannelTypesError = ref<string | null>(null)
+const newapiChannelTypeOptions = computed(() =>
+  newapiChannelTypes.value.map((c) => ({ value: c.channel_type, label: c.name }))
+)
+const newapiSelectedBaseUrl = computed(() => {
+  const found = newapiChannelTypes.value.find((c) => c.channel_type === newapiChannelType.value)
+  return found?.base_url || ''
+})
+
 const tempUnschedEnabled = ref(false)
 const tempUnschedRules = ref<TempUnschedRuleForm[]>([])
 const getModelMappingKey = createStableObjectKeyResolver<ModelMapping>('create-model-mapping')
@@ -3287,6 +3344,10 @@ const isOAuthFlow = computed(() => {
   if (form.platform === 'anthropic' && accountCategory.value === 'bedrock') {
     return false
   }
+  // newapi (5th platform) is API-key only — no OAuth flow.
+  if (form.platform === 'newapi') {
+    return false
+  }
   return accountCategory.value === 'oauth-based'
 })
 
@@ -3326,6 +3387,16 @@ watch(
         .catch(() => { tlsFingerprintProfiles.value = [] })
       // Modal opened - fill related models
       allowedModels.value = [...getModelsByPlatform(form.platform)]
+      if (newapiChannelTypes.value.length === 0 && !newapiChannelTypesLoading.value) {
+        newapiChannelTypesLoading.value = true
+        newapiChannelTypesError.value = null
+        listChannelTypes()
+          .then((rows) => { newapiChannelTypes.value = rows })
+          .catch(() => {
+            newapiChannelTypesError.value = t('admin.accounts.newApiPlatform.channelTypeLoadFailed')
+          })
+          .finally(() => { newapiChannelTypesLoading.value = false })
+      }
       // Antigravity: 默认使用映射模式并填充默认映射
       if (form.platform === 'antigravity') {
         antigravityModelRestrictionMode.value = 'mapping'
@@ -4015,6 +4086,50 @@ const handleSubmit = async () => {
     applyInterceptWarmup(credentials, interceptWarmupRequests.value, 'create')
 
     await createAccountAndFinish('anthropic', 'bedrock' as AccountType, credentials)
+    return
+  }
+
+  // For New API (5th platform), create directly with channel_type top-level field.
+  // Backend admin_service.go:1565 enforces channel_type > 0 when platform == 'newapi';
+  // type is 'apikey' (matches antigravity-upstream pattern) — there is no OAuth flow.
+  if (form.platform === 'newapi') {
+    if (!form.name.trim()) {
+      appStore.showError(t('admin.accounts.pleaseEnterAccountName'))
+      return
+    }
+    if (!newapiChannelType.value || newapiChannelType.value <= 0) {
+      appStore.showError(t('admin.accounts.newApiPlatform.channelType'))
+      return
+    }
+    const baseUrl = newapiBaseUrl.value.trim() || newapiSelectedBaseUrl.value
+    if (!baseUrl) {
+      appStore.showError(t('admin.accounts.newApiPlatform.baseUrl'))
+      return
+    }
+    if (!newapiApiKey.value.trim()) {
+      appStore.showError(t('admin.accounts.newApiPlatform.apiKey'))
+      return
+    }
+    const credentials: Record<string, unknown> = {
+      base_url: baseUrl,
+      api_key: newapiApiKey.value.trim()
+    }
+    await doCreateAccount({
+      name: form.name,
+      notes: form.notes,
+      platform: 'newapi',
+      type: 'apikey',
+      channel_type: newapiChannelType.value,
+      credentials,
+      proxy_id: form.proxy_id,
+      concurrency: form.concurrency,
+      load_factor: form.load_factor ?? undefined,
+      priority: form.priority,
+      rate_multiplier: form.rate_multiplier,
+      group_ids: form.group_ids,
+      expires_at: form.expires_at,
+      auto_pause_on_expired: autoPauseOnExpired.value
+    })
     return
   }
 

--- a/frontend/src/components/account/CreateAccountModal.vue
+++ b/frontend/src/components/account/CreateAccountModal.vue
@@ -4098,16 +4098,16 @@ const handleSubmit = async () => {
       return
     }
     if (!newapiChannelType.value || newapiChannelType.value <= 0) {
-      appStore.showError(t('admin.accounts.newApiPlatform.channelType'))
+      appStore.showError(t('admin.accounts.newApiPlatform.pleaseSelectChannelType'))
       return
     }
     const baseUrl = newapiBaseUrl.value.trim() || newapiSelectedBaseUrl.value
     if (!baseUrl) {
-      appStore.showError(t('admin.accounts.newApiPlatform.baseUrl'))
+      appStore.showError(t('admin.accounts.newApiPlatform.pleaseEnterBaseUrl'))
       return
     }
     if (!newapiApiKey.value.trim()) {
-      appStore.showError(t('admin.accounts.newApiPlatform.apiKey'))
+      appStore.showError(t('admin.accounts.newApiPlatform.pleaseEnterApiKey'))
       return
     }
     const credentials: Record<string, unknown> = {

--- a/frontend/src/components/account/EditAccountModal.vue
+++ b/frontend/src/components/account/EditAccountModal.vue
@@ -28,46 +28,65 @@
 
       <!-- API Key fields (only for apikey type) -->
       <div v-if="account.type === 'apikey'" class="space-y-4">
-        <div>
-          <label class="input-label">{{ t('admin.accounts.baseUrl') }}</label>
-          <input
-            v-model="editBaseUrl"
-            type="text"
-            class="input"
-            :placeholder="
-              account.platform === 'openai'
-                ? 'https://api.openai.com'
-                : account.platform === 'gemini'
-                  ? 'https://generativelanguage.googleapis.com'
-                  : account.platform === 'antigravity'
-                    ? 'https://cloudcode-pa.googleapis.com'
-                    : 'https://api.anthropic.com'
-            "
-          />
-          <p class="input-hint">{{ baseUrlHint }}</p>
-        </div>
-        <div>
-          <label class="input-label">{{ t('admin.accounts.apiKey') }}</label>
-          <input
-            v-model="editApiKey"
-            type="password"
-            class="input font-mono"
-            autocomplete="new-password"
-            data-1p-ignore
-            data-lpignore="true"
-            data-bwignore="true"
-            :placeholder="
-              account.platform === 'openai'
-                ? 'sk-proj-...'
-                : account.platform === 'gemini'
-                  ? 'AIza...'
-                  : account.platform === 'antigravity'
-                    ? 'sk-...'
-                    : 'sk-ant-...'
-            "
-          />
-          <p class="input-hint">{{ t('admin.accounts.leaveEmptyToKeep') }}</p>
-        </div>
+        <!--
+          newapi (5th platform) uses the same shared field set as
+          CreateAccountModal (US-017): channel_type catalog + base_url +
+          api_key. Variant=edit suppresses required asterisks and shows
+          a "leave empty to keep" hint on api_key.
+        -->
+        <AccountNewApiPlatformFields
+          v-if="account.platform === 'newapi'"
+          v-model:channelType="newapiChannelType"
+          v-model:baseUrl="newapiBaseUrl"
+          v-model:apiKey="newapiApiKey"
+          :channel-type-options="newapiChannelTypeOptions"
+          :channel-types-loading="newapiChannelTypesLoading"
+          :channel-types-error="newapiChannelTypesError"
+          :selected-channel-type-base-url="newapiSelectedBaseUrl"
+          variant="edit"
+        />
+        <template v-else>
+          <div>
+            <label class="input-label">{{ t('admin.accounts.baseUrl') }}</label>
+            <input
+              v-model="editBaseUrl"
+              type="text"
+              class="input"
+              :placeholder="
+                account.platform === 'openai'
+                  ? 'https://api.openai.com'
+                  : account.platform === 'gemini'
+                    ? 'https://generativelanguage.googleapis.com'
+                    : account.platform === 'antigravity'
+                      ? 'https://cloudcode-pa.googleapis.com'
+                      : 'https://api.anthropic.com'
+              "
+            />
+            <p class="input-hint">{{ baseUrlHint }}</p>
+          </div>
+          <div>
+            <label class="input-label">{{ t('admin.accounts.apiKey') }}</label>
+            <input
+              v-model="editApiKey"
+              type="password"
+              class="input font-mono"
+              autocomplete="new-password"
+              data-1p-ignore
+              data-lpignore="true"
+              data-bwignore="true"
+              :placeholder="
+                account.platform === 'openai'
+                  ? 'sk-proj-...'
+                  : account.platform === 'gemini'
+                    ? 'AIza...'
+                    : account.platform === 'antigravity'
+                      ? 'sk-...'
+                      : 'sk-ant-...'
+              "
+            />
+            <p class="input-hint">{{ t('admin.accounts.leaveEmptyToKeep') }}</p>
+          </div>
+        </template>
 
         <!-- Model Restriction Section (不适用于 Antigravity) -->
         <div v-if="account.platform !== 'antigravity'" class="border-t border-gray-200 pt-4 dark:border-dark-600">
@@ -1858,6 +1877,8 @@ import ProxySelector from '@/components/common/ProxySelector.vue'
 import GroupSelector from '@/components/common/GroupSelector.vue'
 import ModelWhitelistSelector from '@/components/account/ModelWhitelistSelector.vue'
 import QuotaLimitCard from '@/components/account/QuotaLimitCard.vue'
+import AccountNewApiPlatformFields from './AccountNewApiPlatformFields.vue'
+import { listChannelTypes, type ChannelTypeInfo } from '@/api/admin/channels'
 import { applyInterceptWarmup } from '@/components/account/credentialsBuilder'
 import { formatDateTimeLocalInput, parseDateTimeLocalInput } from '@/utils/format'
 import { createStableObjectKeyResolver } from '@/utils/stableObjectKey'
@@ -1922,6 +1943,23 @@ interface TempUnschedRuleForm {
 const submitting = ref(false)
 const editBaseUrl = ref('https://api.anthropic.com')
 const editApiKey = ref('')
+// newapi (5th platform) edit fields. channel_type is a top-level account
+// field on the API; base_url + api_key are stored under credentials.
+// Pre-populated from the account in syncFormFromAccount; pushed back via
+// the apikey credentials block in handleSubmit.
+const newapiChannelType = ref<number>(0)
+const newapiBaseUrl = ref('')
+const newapiApiKey = ref('')
+const newapiChannelTypes = ref<ChannelTypeInfo[]>([])
+const newapiChannelTypesLoading = ref(false)
+const newapiChannelTypesError = ref<string | null>(null)
+const newapiChannelTypeOptions = computed(() =>
+  newapiChannelTypes.value.map((c) => ({ value: c.channel_type, label: c.name }))
+)
+const newapiSelectedBaseUrl = computed(() => {
+  const found = newapiChannelTypes.value.find((c) => c.channel_type === newapiChannelType.value)
+  return found?.base_url ?? ''
+})
 // Bedrock credentials
 const editBedrockAccessKeyId = ref('')
 const editBedrockSecretAccessKey = ref('')
@@ -2290,6 +2328,28 @@ const syncFormFromAccount = (newAccount: Account | null) => {
           ? 'https://generativelanguage.googleapis.com'
           : 'https://api.anthropic.com'
     editBaseUrl.value = (credentials.base_url as string) || platformDefaultUrl
+
+    // Mirror values into the newapi-specific refs so the shared
+    // AccountNewApiPlatformFields component renders the current
+    // configuration; channel_type is a top-level field on the account.
+    if (newAccount.platform === 'newapi') {
+      newapiChannelType.value = newAccount.channel_type ?? 0
+      newapiBaseUrl.value = (credentials.base_url as string) ?? ''
+      newapiApiKey.value = ''
+      // Lazy-load the channel-type catalog so the Select shows human names.
+      // Errors are surfaced via newapiChannelTypesError; they do not block
+      // the user from saving (the channel_type ID is already known).
+      if (newapiChannelTypes.value.length === 0 && !newapiChannelTypesLoading.value) {
+        newapiChannelTypesLoading.value = true
+        newapiChannelTypesError.value = null
+        listChannelTypes()
+          .then((rows) => { newapiChannelTypes.value = rows })
+          .catch(() => {
+            newapiChannelTypesError.value = t('admin.accounts.newApiPlatform.channelTypeLoadFailed')
+          })
+          .finally(() => { newapiChannelTypesLoading.value = false })
+      }
+    }
 
     // Load model mappings and detect mode
     const existingMappings = credentials.model_mapping as Record<string, string> | undefined
@@ -2879,21 +2939,40 @@ const handleSubmit = async () => {
     // For apikey type, handle credentials update
     if (props.account.type === 'apikey') {
       const currentCredentials = (props.account.credentials as Record<string, unknown>) || {}
-      const newBaseUrl = editBaseUrl.value.trim() || defaultBaseUrl.value
+      const isNewAPI = props.account.platform === 'newapi'
+      // Determine which input refs are authoritative for this platform.
+      const submittedBaseUrl = isNewAPI
+        ? (newapiBaseUrl.value.trim() || newapiSelectedBaseUrl.value)
+        : (editBaseUrl.value.trim() || defaultBaseUrl.value)
+      const submittedApiKey = isNewAPI ? newapiApiKey.value : editApiKey.value
       const shouldApplyModelMapping = !(props.account.platform === 'openai' && openaiPassthroughEnabled.value)
+
+      // Validate newapi-specific invariants — channel_type > 0 mirrors
+      // backend admin_service.go:1702 enforcement.
+      if (isNewAPI) {
+        if (!newapiChannelType.value || newapiChannelType.value <= 0) {
+          appStore.showError(t('admin.accounts.newApiPlatform.pleaseSelectChannelType'))
+          return
+        }
+        if (!submittedBaseUrl) {
+          appStore.showError(t('admin.accounts.newApiPlatform.pleaseEnterBaseUrl'))
+          return
+        }
+        // Surface channel_type at the top level so admin_service.Update
+        // picks it up via UpdateAccountInput.ChannelType.
+        updatePayload.channel_type = newapiChannelType.value
+      }
 
       // Always update credentials for apikey type to handle model mapping changes
       const newCredentials: Record<string, unknown> = {
         ...currentCredentials,
-        base_url: newBaseUrl
+        base_url: submittedBaseUrl
       }
 
       // Handle API key
-      if (editApiKey.value.trim()) {
-        // User provided a new API key
-        newCredentials.api_key = editApiKey.value.trim()
+      if (submittedApiKey.trim()) {
+        newCredentials.api_key = submittedApiKey.trim()
       } else if (currentCredentials.api_key) {
-        // Preserve existing api_key
         newCredentials.api_key = currentCredentials.api_key
       } else {
         appStore.showError(t('admin.accounts.apiKeyIsRequired'))

--- a/frontend/src/components/admin/ErrorPassthroughRulesModal.vue
+++ b/frontend/src/components/admin/ErrorPassthroughRulesModal.vue
@@ -438,6 +438,7 @@ import type { ErrorPassthroughRule } from '@/api/admin/errorPassthrough'
 import BaseDialog from '@/components/common/BaseDialog.vue'
 import ConfirmDialog from '@/components/common/ConfirmDialog.vue'
 import Icon from '@/components/icons/Icon.vue'
+import { usePlatformOptions } from '@/composables/usePlatformOptions'
 
 const props = defineProps<{
   show: boolean
@@ -485,12 +486,12 @@ const matchModeOptions = computed(() => [
   { value: 'all', label: t('admin.errorPassthrough.matchMode.all'), description: t('admin.errorPassthrough.matchMode.allHint') }
 ])
 
-const platformOptions = [
-  { value: 'anthropic', label: 'Anthropic' },
-  { value: 'openai', label: 'OpenAI' },
-  { value: 'gemini', label: 'Gemini' },
-  { value: 'antigravity', label: 'Antigravity' }
-]
+// Error-passthrough rules can be scoped to one or more platforms; the choice
+// list comes from the canonical composable so the fifth platform `newapi`
+// shows up automatically and can have its own error-passthrough rules
+// configured (matches the backend MatchRule predicate that already accepts
+// the `newapi` platform string).
+const { options: platformOptions } = usePlatformOptions()
 
 // Load rules when dialog opens
 watch(() => props.show, (newVal) => {

--- a/frontend/src/components/admin/account/AccountTableFilters.vue
+++ b/frontend/src/components/admin/account/AccountTableFilters.vue
@@ -16,7 +16,9 @@
 </template>
 
 <script setup lang="ts">
-import { computed } from 'vue'; import { useI18n } from 'vue-i18n'; import Select from '@/components/common/Select.vue'; import SearchInput from '@/components/common/SearchInput.vue'
+import { computed } from 'vue'
+import { useI18n } from 'vue-i18n'; import Select from '@/components/common/Select.vue'; import SearchInput from '@/components/common/SearchInput.vue'
+import { usePlatformOptions } from '@/composables/usePlatformOptions'
 import type { AdminGroup } from '@/types'
 const props = defineProps<{ searchQuery: string; filters: Record<string, any>; groups?: AdminGroup[] }>()
 const emit = defineEmits(['update:searchQuery', 'update:filters', 'change']); const { t } = useI18n()
@@ -25,7 +27,12 @@ const updateType = (value: string | number | boolean | null) => { emit('update:f
 const updateStatus = (value: string | number | boolean | null) => { emit('update:filters', { ...props.filters, status: value }) }
 const updatePrivacyMode = (value: string | number | boolean | null) => { emit('update:filters', { ...props.filters, privacy_mode: value }) }
 const updateGroup = (value: string | number | boolean | null) => { emit('update:filters', { ...props.filters, group: value }) }
-const pOpts = computed(() => [{ value: '', label: t('admin.accounts.allPlatforms') }, { value: 'anthropic', label: 'Anthropic' }, { value: 'openai', label: 'OpenAI' }, { value: 'gemini', label: 'Gemini' }, { value: 'antigravity', label: 'Antigravity' }])
+// Platform filter options come from the canonical composable so the fifth
+// platform `newapi` (and any future addition) shows up automatically; the
+// "All" entry is rendered with the same label key as elsewhere in the admin UI.
+// The getter form keeps the i18n label reactive on locale switch.
+const { optionsWithAll } = usePlatformOptions()
+const pOpts = optionsWithAll(() => t('admin.accounts.allPlatforms'))
 const tOpts = computed(() => [{ value: '', label: t('admin.accounts.allTypes') }, { value: 'oauth', label: t('admin.accounts.oauthType') }, { value: 'setup-token', label: t('admin.accounts.setupToken') }, { value: 'apikey', label: t('admin.accounts.apiKey') }, { value: 'bedrock', label: 'AWS Bedrock' }])
 const sOpts = computed(() => [{ value: '', label: t('admin.accounts.allStatus') }, { value: 'active', label: t('admin.accounts.status.active') }, { value: 'inactive', label: t('admin.accounts.status.inactive') }, { value: 'error', label: t('admin.accounts.status.error') }, { value: 'rate_limited', label: t('admin.accounts.status.rateLimited') }, { value: 'temp_unschedulable', label: t('admin.accounts.status.tempUnschedulable') }, { value: 'unschedulable', label: t('admin.accounts.status.unschedulable') }])
 const privacyOpts = computed(() => [

--- a/frontend/src/components/admin/channel/types.ts
+++ b/frontend/src/components/admin/channel/types.ts
@@ -184,6 +184,7 @@ export function getPlatformTagClass(platform: string): string {
     case 'openai': return 'bg-emerald-100 text-emerald-700 dark:bg-emerald-900/30 dark:text-emerald-400'
     case 'gemini': return 'bg-blue-100 text-blue-700 dark:bg-blue-900/30 dark:text-blue-400'
     case 'antigravity': return 'bg-purple-100 text-purple-700 dark:bg-purple-900/30 dark:text-purple-400'
+    case 'newapi': return 'bg-cyan-100 text-cyan-700 dark:bg-cyan-900/30 dark:text-cyan-400'
     default: return 'bg-gray-100 text-gray-700 dark:bg-gray-900/30 dark:text-gray-400'
   }
 }

--- a/frontend/src/components/admin/group/GroupRateMultipliersModal.vue
+++ b/frontend/src/components/admin/group/GroupRateMultipliersModal.vue
@@ -284,6 +284,7 @@ const platformColorClass = computed(() => {
     case 'anthropic': return 'text-orange-700 dark:text-orange-400'
     case 'openai': return 'text-emerald-700 dark:text-emerald-400'
     case 'antigravity': return 'text-purple-700 dark:text-purple-400'
+    case 'newapi': return 'text-cyan-700 dark:text-cyan-400'
     default: return 'text-blue-700 dark:text-blue-400'
   }
 })

--- a/frontend/src/components/common/GroupBadge.vue
+++ b/frontend/src/components/common/GroupBadge.vue
@@ -116,6 +116,9 @@ const labelClass = computed(() => {
   if (props.platform === 'gemini') {
     return `${base} bg-blue-200/60 text-blue-800 dark:bg-blue-800/40 dark:text-blue-300`
   }
+  if (props.platform === 'newapi') {
+    return `${base} bg-cyan-200/60 text-cyan-800 dark:bg-cyan-800/40 dark:text-cyan-300`
+  }
   return `${base} bg-violet-200/60 text-violet-800 dark:bg-violet-800/40 dark:text-violet-300`
 })
 
@@ -136,6 +139,11 @@ const badgeClass = computed(() => {
     return isSubscription.value
       ? 'bg-blue-100 text-blue-700 dark:bg-blue-900/30 dark:text-blue-400'
       : 'bg-sky-50 text-sky-700 dark:bg-sky-900/20 dark:text-sky-400'
+  }
+  if (props.platform === 'newapi') {
+    return isSubscription.value
+      ? 'bg-cyan-100 text-cyan-700 dark:bg-cyan-900/30 dark:text-cyan-300'
+      : 'bg-cyan-50 text-cyan-700 dark:bg-cyan-900/20 dark:text-cyan-300'
   }
   // Fallback: original colors
   return isSubscription.value

--- a/frontend/src/components/common/GroupOptionItem.vue
+++ b/frontend/src/components/common/GroupOptionItem.vue
@@ -91,6 +91,8 @@ const ratePillClass = computed(() => {
       return 'bg-green-50 text-green-700 dark:bg-green-900/20 dark:text-green-400'
     case 'gemini':
       return 'bg-sky-50 text-sky-700 dark:bg-sky-900/20 dark:text-sky-400'
+    case 'newapi':
+      return 'bg-cyan-50 text-cyan-700 dark:bg-cyan-900/20 dark:text-cyan-300'
     default: // antigravity and others
       return 'bg-violet-50 text-violet-700 dark:bg-violet-900/20 dark:text-violet-400'
   }

--- a/frontend/src/components/common/PlatformIcon.vue
+++ b/frontend/src/components/common/PlatformIcon.vue
@@ -19,6 +19,10 @@
   <svg v-else-if="platform === 'antigravity'" :class="sizeClass" viewBox="0 0 24 24" fill="currentColor">
     <path d="M19.35 10.04C18.67 6.59 15.64 4 12 4 9.11 4 6.6 5.64 5.35 8.04 2.34 8.36 0 10.91 0 14c0 3.31 2.69 6 6 6h13c2.76 0 5-2.24 5-5 0-2.64-2.05-4.78-4.65-4.96z" />
   </svg>
+  <!-- New API logo (relay/network nodes — visually distinct from the four upstream brand marks) -->
+  <svg v-else-if="platform === 'newapi'" :class="sizeClass" viewBox="0 0 24 24" fill="currentColor">
+    <path d="M5 4a3 3 0 1 1 0 6 3 3 0 0 1 0-6zm14 0a3 3 0 1 1 0 6 3 3 0 0 1 0-6zM5 14a3 3 0 1 1 0 6 3 3 0 0 1 0-6zm14 0a3 3 0 1 1 0 6 3 3 0 0 1 0-6zM7.6 6.2l8.8 0v1.6h-8.8zM7.6 16.2l8.8 0v1.6h-8.8zM6.2 7.6l0 8.8h1.6v-8.8zM16.2 7.6l0 8.8h1.6v-8.8z" />
+  </svg>
   <!-- Fallback: generic platform icon -->
   <svg v-else :class="sizeClass" fill="currentColor" viewBox="0 0 24 24">
     <path

--- a/frontend/src/components/common/PlatformTypeBadge.vue
+++ b/frontend/src/components/common/PlatformTypeBadge.vue
@@ -71,11 +71,18 @@ interface Props {
 
 const props = defineProps<Props>()
 
+// US-017: explicit map per canonical GATEWAY_PLATFORMS. Earlier code defaulted
+// every unknown platform to "Gemini" with blue styling — that mislabeled `newapi`
+// (5th platform) accounts as Gemini after the backend started returning them.
 const platformLabel = computed(() => {
-  if (props.platform === 'anthropic') return 'Anthropic'
-  if (props.platform === 'openai') return 'OpenAI'
-  if (props.platform === 'antigravity') return 'Antigravity'
-  return 'Gemini'
+  switch (props.platform) {
+    case 'anthropic': return 'Anthropic'
+    case 'openai': return 'OpenAI'
+    case 'gemini': return 'Gemini'
+    case 'antigravity': return 'Antigravity'
+    case 'newapi': return 'New API'
+    default: return props.platform
+  }
 })
 
 const typeLabel = computed(() => {
@@ -113,30 +120,41 @@ const planLabel = computed(() => {
   }
 })
 
+// Color map mirrors GATEWAY_PLATFORMS color hints — keep both classes (700 / 600)
+// in sync if a new platform is added. `gemini` keeps the historic blue, and
+// truly unknown platforms fall back to a neutral gray so we never silently mislabel.
 const platformClass = computed(() => {
-  if (props.platform === 'anthropic') {
-    return 'bg-orange-100 text-orange-700 dark:bg-orange-900/30 dark:text-orange-400'
+  switch (props.platform) {
+    case 'anthropic':
+      return 'bg-orange-100 text-orange-700 dark:bg-orange-900/30 dark:text-orange-400'
+    case 'openai':
+      return 'bg-emerald-100 text-emerald-700 dark:bg-emerald-900/30 dark:text-emerald-400'
+    case 'gemini':
+      return 'bg-blue-100 text-blue-700 dark:bg-blue-900/30 dark:text-blue-400'
+    case 'antigravity':
+      return 'bg-purple-100 text-purple-700 dark:bg-purple-900/30 dark:text-purple-400'
+    case 'newapi':
+      return 'bg-cyan-100 text-cyan-700 dark:bg-cyan-900/30 dark:text-cyan-400'
+    default:
+      return 'bg-gray-100 text-gray-700 dark:bg-gray-800 dark:text-gray-300'
   }
-  if (props.platform === 'openai') {
-    return 'bg-emerald-100 text-emerald-700 dark:bg-emerald-900/30 dark:text-emerald-400'
-  }
-  if (props.platform === 'antigravity') {
-    return 'bg-purple-100 text-purple-700 dark:bg-purple-900/30 dark:text-purple-400'
-  }
-  return 'bg-blue-100 text-blue-700 dark:bg-blue-900/30 dark:text-blue-400'
 })
 
 const typeClass = computed(() => {
-  if (props.platform === 'anthropic') {
-    return 'bg-orange-100 text-orange-600 dark:bg-orange-900/30 dark:text-orange-400'
+  switch (props.platform) {
+    case 'anthropic':
+      return 'bg-orange-100 text-orange-600 dark:bg-orange-900/30 dark:text-orange-400'
+    case 'openai':
+      return 'bg-emerald-100 text-emerald-600 dark:bg-emerald-900/30 dark:text-emerald-400'
+    case 'gemini':
+      return 'bg-blue-100 text-blue-600 dark:bg-blue-900/30 dark:text-blue-400'
+    case 'antigravity':
+      return 'bg-purple-100 text-purple-600 dark:bg-purple-900/30 dark:text-purple-400'
+    case 'newapi':
+      return 'bg-cyan-100 text-cyan-600 dark:bg-cyan-900/30 dark:text-cyan-400'
+    default:
+      return 'bg-gray-100 text-gray-600 dark:bg-gray-800 dark:text-gray-300'
   }
-  if (props.platform === 'openai') {
-    return 'bg-emerald-100 text-emerald-600 dark:bg-emerald-900/30 dark:text-emerald-400'
-  }
-  if (props.platform === 'antigravity') {
-    return 'bg-purple-100 text-purple-600 dark:bg-purple-900/30 dark:text-purple-400'
-  }
-  return 'bg-blue-100 text-blue-600 dark:bg-blue-900/30 dark:text-blue-400'
 })
 
 const planBadgeClass = computed(() => {

--- a/frontend/src/components/common/__tests__/GroupBadge.spec.ts
+++ b/frontend/src/components/common/__tests__/GroupBadge.spec.ts
@@ -1,0 +1,54 @@
+import { describe, expect, it } from 'vitest'
+import { mount } from '@vue/test-utils'
+import { createI18n } from 'vue-i18n'
+
+import GroupBadge from '../GroupBadge.vue'
+
+const i18n = createI18n({
+  legacy: false,
+  locale: 'en',
+  messages: {
+    en: {
+      groups: { subscription: 'Subscription' },
+      admin: {
+        users: {
+          expired: 'Expired',
+          daysRemaining: '{days} days',
+        },
+      },
+    },
+  },
+})
+
+function mountBadge(props: Record<string, unknown>) {
+  return mount(GroupBadge, {
+    props: {
+      name: 'Demo Group',
+      platform: 'newapi',
+      subscriptionType: 'standard',
+      ...props,
+    },
+    global: { plugins: [i18n] },
+  })
+}
+
+describe('GroupBadge (newapi visual parity)', () => {
+  it('renders newapi standard badge in cyan palette', () => {
+    const wrapper = mountBadge({ rateMultiplier: 1.5 })
+    const html = wrapper.html()
+    expect(html).toContain('bg-cyan-50')
+    expect(html).toContain('text-cyan-700')
+    expect(html).not.toContain('bg-violet-100')
+  })
+
+  it('renders newapi subscription badge in cyan palette', () => {
+    const wrapper = mountBadge({
+      subscriptionType: 'subscription',
+      daysRemaining: 15,
+    })
+    const html = wrapper.html()
+    expect(html).toContain('bg-cyan-100')
+    expect(html).toContain('text-cyan-700')
+    expect(html).not.toContain('bg-violet-100')
+  })
+})

--- a/frontend/src/components/common/__tests__/PlatformTypeBadge.spec.ts
+++ b/frontend/src/components/common/__tests__/PlatformTypeBadge.spec.ts
@@ -1,0 +1,70 @@
+/**
+ * PlatformTypeBadge — US-017 regression guard.
+ *
+ * Why this spec exists: PlatformTypeBadge.vue used to default *every* unknown
+ * platform string to "Gemini" with blue styling (lines 74-79 + 116-127 in the
+ * pre-fix file). After the backend started returning a fifth platform `newapi`,
+ * those rows were silently mislabeled as Gemini in the admin account list — the
+ * exact symptom that triggered US-017. We pin the new behavior here so a future
+ * refactor cannot bring the Gemini-fallback bug back.
+ */
+import { describe, expect, it } from 'vitest'
+import { mount } from '@vue/test-utils'
+import { createI18n } from 'vue-i18n'
+
+import PlatformTypeBadge from '../PlatformTypeBadge.vue'
+import type { AccountPlatform, AccountType } from '@/types'
+
+const i18n = createI18n({
+  legacy: false,
+  locale: 'en',
+  messages: { en: {}, zh: {} },
+})
+
+function mountBadge(platform: AccountPlatform | string, type: AccountType = 'apikey') {
+  return mount(PlatformTypeBadge, {
+    props: { platform: platform as AccountPlatform, type },
+    global: { plugins: [i18n] },
+  })
+}
+
+describe('PlatformTypeBadge (US-017 — fifth platform newapi must not be mislabeled as Gemini)', () => {
+  it('renders newapi as "New API" with cyan styling (the bug we are fixing)', () => {
+    const wrapper = mountBadge('newapi')
+
+    expect(wrapper.text()).toContain('New API')
+    expect(wrapper.text()).not.toContain('Gemini')
+    expect(wrapper.html()).toContain('bg-cyan-100')
+    expect(wrapper.html()).not.toContain('bg-blue-100') // would indicate Gemini-fallback regression
+  })
+
+  it('NEGATIVE — truly unknown platforms fall back to neutral gray (no silent Gemini mislabel)', () => {
+    const wrapper = mountBadge('totally-unknown-platform-x')
+
+    expect(wrapper.text()).not.toContain('Gemini')
+    expect(wrapper.text()).toContain('totally-unknown-platform-x')
+    expect(wrapper.html()).toContain('bg-gray-100')
+  })
+
+  it('REGRESSION — the 4 historical platforms render with their canonical brand label and color', () => {
+    const cases: Array<{ platform: AccountPlatform; label: string; color: string }> = [
+      { platform: 'anthropic', label: 'Anthropic', color: 'bg-orange-100' },
+      { platform: 'openai', label: 'OpenAI', color: 'bg-emerald-100' },
+      { platform: 'gemini', label: 'Gemini', color: 'bg-blue-100' },
+      { platform: 'antigravity', label: 'Antigravity', color: 'bg-purple-100' },
+    ]
+
+    for (const c of cases) {
+      const wrapper = mountBadge(c.platform)
+      expect(wrapper.text(), `${c.platform} label`).toContain(c.label)
+      expect(wrapper.html(), `${c.platform} color`).toContain(c.color)
+    }
+  })
+
+  it('renders the type label correctly across api types (apikey / oauth / setup-token / bedrock)', () => {
+    expect(mountBadge('newapi', 'apikey').text()).toContain('Key')
+    expect(mountBadge('anthropic', 'oauth').text()).toContain('OAuth')
+    expect(mountBadge('anthropic', 'setup-token').text()).toContain('Token')
+    expect(mountBadge('anthropic', 'bedrock').text()).toContain('AWS')
+  })
+})

--- a/frontend/src/components/keys/UseKeyModal.vue
+++ b/frontend/src/components/keys/UseKeyModal.vue
@@ -176,10 +176,16 @@ const copiedIndex = ref<number | null>(null)
 const activeTab = ref<string>('unix')
 const activeClientTab = ref<string>('claude')
 
-// Reset tabs when platform changes
+// Reset tabs when platform changes.
+// `newapi` (the fifth platform) is an OpenAI-compatible HTTP gateway: the
+// upstream speaks OpenAI's /v1/chat/completions shape but does not expose
+// ChatGPT WebSocket auth, so codex (HTTP) is the right default — same as
+// `openai` minus codex-ws.
 const defaultClientTab = computed(() => {
   switch (props.platform) {
     case 'openai':
+      return 'codex'
+    case 'newapi':
       return 'codex'
     case 'gemini':
       return 'gemini'
@@ -288,6 +294,18 @@ const clientTabs = computed((): TabConfig[] => {
         { id: 'gemini', label: t('keys.useKeyModal.cliTabs.geminiCli'), icon: SparkleIcon },
         { id: 'opencode', label: t('keys.useKeyModal.cliTabs.opencode'), icon: TerminalIcon }
       ]
+    case 'newapi': {
+      // OpenAI-compat HTTP only; no codex-ws. Optionally claude tab when the
+      // group enables messages dispatch (mirrors the openai branch).
+      const tabs: TabConfig[] = [
+        { id: 'codex', label: t('keys.useKeyModal.cliTabs.codexCli'), icon: TerminalIcon },
+      ]
+      if (props.allowMessagesDispatch) {
+        tabs.push({ id: 'claude', label: t('keys.useKeyModal.cliTabs.claudeCode'), icon: TerminalIcon })
+      }
+      tabs.push({ id: 'opencode', label: t('keys.useKeyModal.cliTabs.opencode'), icon: TerminalIcon })
+      return tabs
+    }
     default:
       return [
         { id: 'claude', label: t('keys.useKeyModal.cliTabs.claudeCode'), icon: TerminalIcon },
@@ -319,13 +337,21 @@ const currentTabs = computed(() => {
   return shellTabs
 })
 
+// Treat newapi as openai for description / note copy: the user-facing client
+// instructions are identical (codex CLI + opencode), and our gateway already
+// routes both platforms through the OpenAI-compat handlers.
+const isOpenAICompatPlatform = computed(
+  () => props.platform === 'openai' || props.platform === 'newapi',
+)
+
 const platformDescription = computed(() => {
+  if (isOpenAICompatPlatform.value) {
+    if (activeClientTab.value === 'claude') {
+      return t('keys.useKeyModal.description')
+    }
+    return t('keys.useKeyModal.openai.description')
+  }
   switch (props.platform) {
-    case 'openai':
-      if (activeClientTab.value === 'claude') {
-        return t('keys.useKeyModal.description')
-      }
-      return t('keys.useKeyModal.openai.description')
     case 'gemini':
       return t('keys.useKeyModal.gemini.description')
     case 'antigravity':
@@ -336,14 +362,15 @@ const platformDescription = computed(() => {
 })
 
 const platformNote = computed(() => {
+  if (isOpenAICompatPlatform.value) {
+    if (activeClientTab.value === 'claude') {
+      return t('keys.useKeyModal.note')
+    }
+    return activeTab.value === 'windows'
+      ? t('keys.useKeyModal.openai.noteWindows')
+      : t('keys.useKeyModal.openai.note')
+  }
   switch (props.platform) {
-    case 'openai':
-      if (activeClientTab.value === 'claude') {
-        return t('keys.useKeyModal.note')
-      }
-      return activeTab.value === 'windows'
-        ? t('keys.useKeyModal.openai.noteWindows')
-        : t('keys.useKeyModal.openai.note')
     case 'gemini':
       return t('keys.useKeyModal.gemini.note')
     case 'antigravity':
@@ -399,6 +426,11 @@ const currentFiles = computed((): FileConfig[] => {
       case 'anthropic':
         return [generateOpenCodeConfig('anthropic', apiBase, apiKey)]
       case 'openai':
+      case 'newapi':
+        // newapi shares OpenAI-compat HTTP shape: codex CLI / opencode use
+        // identical config (provider=openai, baseURL=apiBase). Sticking
+        // both branches together avoids a parallel newapi catalog that
+        // would drift from openai's.
         return [generateOpenCodeConfig('openai', apiBase, apiKey)]
       case 'gemini':
         return [generateOpenCodeConfig('gemini', geminiBase, apiKey)]
@@ -419,6 +451,13 @@ const currentFiles = computed((): FileConfig[] => {
       }
       if (activeClientTab.value === 'codex-ws') {
         return generateOpenAIWsFiles(baseUrl, apiKey)
+      }
+      return generateOpenAIFiles(baseUrl, apiKey)
+    case 'newapi':
+      // newapi has no OAuth WS path (codex-ws not offered in its tabs).
+      // claude tab only appears when the group enables messages dispatch.
+      if (activeClientTab.value === 'claude') {
+        return generateAnthropicFiles(baseUrl, apiKey)
       }
       return generateOpenAIFiles(baseUrl, apiKey)
     case 'gemini':

--- a/frontend/src/composables/__tests__/useModelWhitelist.spec.ts
+++ b/frontend/src/composables/__tests__/useModelWhitelist.spec.ts
@@ -4,7 +4,7 @@ vi.mock('@/api/admin/accounts', () => ({
   getAntigravityDefaultModelMapping: vi.fn()
 }))
 
-import { buildModelMappingObject, getModelsByPlatform } from '../useModelWhitelist'
+import { buildModelMappingObject, getModelsByPlatform, getPresetMappingsByPlatform } from '../useModelWhitelist'
 
 describe('useModelWhitelist', () => {
   it('openai 模型列表包含 GPT-5.4 官方快照', () => {
@@ -62,5 +62,15 @@ describe('useModelWhitelist', () => {
       'gpt-5.4-mini': 'gpt-5.4-mini',
       'gpt-5.4-nano': 'gpt-5.4-nano'
     })
+  })
+
+  // US-017 (newapi 第五平台) — newapi 走 OpenAI-compat HTTP 协议，UI 默认模型/
+  // 预设映射应与 openai 完全一致，避免一份并行的 newapi 列表立即与 openai 漂移。
+  it('newapi 模型列表与 openai 完全一致（OpenAI-compat 协议默认提示）', () => {
+    expect(getModelsByPlatform('newapi')).toEqual(getModelsByPlatform('openai'))
+  })
+
+  it('newapi 预设映射与 openai 完全一致（共享模型 ID 命名空间）', () => {
+    expect(getPresetMappingsByPlatform('newapi')).toEqual(getPresetMappingsByPlatform('openai'))
   })
 })

--- a/frontend/src/composables/__tests__/usePlatformOptions.spec.ts
+++ b/frontend/src/composables/__tests__/usePlatformOptions.spec.ts
@@ -1,0 +1,59 @@
+import { describe, expect, it } from 'vitest'
+
+import { GATEWAY_PLATFORMS } from '@/constants/gatewayPlatforms'
+
+import { PLATFORM_LABELS, usePlatformOptions } from '../usePlatformOptions'
+
+describe('usePlatformOptions (US-017 regression — fifth platform newapi must surface in every admin picker)', () => {
+  it('exposes exactly the 5 canonical gateway platforms in GATEWAY_PLATFORMS order', () => {
+    const { options } = usePlatformOptions()
+
+    expect(options.value).toHaveLength(GATEWAY_PLATFORMS.length)
+    expect(options.value).toHaveLength(5)
+    expect(options.value.map((o) => o.value)).toEqual([...GATEWAY_PLATFORMS])
+  })
+
+  it('includes newapi (the bug we are fixing — admin pickers used to drop it)', () => {
+    const { options } = usePlatformOptions()
+    const values = options.value.map((o) => o.value)
+
+    expect(values).toContain('newapi')
+    expect(options.value.find((o) => o.value === 'newapi')?.label).toBe('New API')
+  })
+
+  it('labels every platform with its brand name (no untranslated key leakage)', () => {
+    const { options } = usePlatformOptions()
+
+    for (const opt of options.value) {
+      expect(opt.label).toBe(PLATFORM_LABELS[opt.value])
+      expect(opt.label).not.toMatch(/^admin\./) // would indicate a stray i18n key
+      expect(opt.label.length).toBeGreaterThan(0)
+    }
+  })
+
+  it('optionsWithAll prepends the localized "all" sentinel and preserves order', () => {
+    const { optionsWithAll } = usePlatformOptions()
+    const opts = optionsWithAll('全部平台').value
+
+    expect(opts[0]).toEqual({ value: '', label: '全部平台' })
+    expect(opts.slice(1).map((o) => o.value)).toEqual([...GATEWAY_PLATFORMS])
+    expect(opts).toHaveLength(GATEWAY_PLATFORMS.length + 1)
+  })
+
+  it('NEGATIVE — composable cannot return a platform absent from GATEWAY_PLATFORMS (drift guard)', () => {
+    const { options } = usePlatformOptions()
+    const allowed = new Set<string>(GATEWAY_PLATFORMS)
+
+    for (const opt of options.value) {
+      expect(allowed.has(opt.value)).toBe(true)
+    }
+  })
+
+  it('NEGATIVE — adding a 6th platform to GATEWAY_PLATFORMS without a label entry would fail typecheck (compile-time guarantee documented in test)', () => {
+    // PLATFORM_LABELS is typed as Record<AccountPlatform, string>; if a future
+    // commit adds a 6th value to the AccountPlatform union and forgets to
+    // populate PLATFORM_LABELS, `tsc` will fail. We assert the shape today so
+    // the regression boundary is documented in a runnable test.
+    expect(Object.keys(PLATFORM_LABELS).sort()).toEqual([...GATEWAY_PLATFORMS].sort())
+  })
+})

--- a/frontend/src/composables/__tests__/usePlatformOptions.spec.ts
+++ b/frontend/src/composables/__tests__/usePlatformOptions.spec.ts
@@ -1,4 +1,5 @@
 import { describe, expect, it } from 'vitest'
+import { ref } from 'vue'
 
 import { GATEWAY_PLATFORMS } from '@/constants/gatewayPlatforms'
 
@@ -38,6 +39,31 @@ describe('usePlatformOptions (US-017 regression — fifth platform newapi must s
     expect(opts[0]).toEqual({ value: '', label: '全部平台' })
     expect(opts.slice(1).map((o) => o.value)).toEqual([...GATEWAY_PLATFORMS])
     expect(opts).toHaveLength(GATEWAY_PLATFORMS.length + 1)
+  })
+
+  it('optionsWithAll re-evaluates the "all" label when a getter is passed (i18n reactivity)', () => {
+    // Real-world bug guard: GroupsView passes `() => t('admin.groups.allPlatforms')`
+    // so language switches must update the sentinel. A string snapshot would
+    // freeze the original locale's label.
+    const { optionsWithAll } = usePlatformOptions()
+    const locale = ref<'en' | 'zh'>('en')
+    const filterOpts = optionsWithAll(() =>
+      locale.value === 'en' ? 'All Platforms' : '全部平台',
+    )
+
+    expect(filterOpts.value[0]).toEqual({ value: '', label: 'All Platforms' })
+    locale.value = 'zh'
+    expect(filterOpts.value[0]).toEqual({ value: '', label: '全部平台' })
+  })
+
+  it('optionsWithAll unwraps refs (MaybeRefOrGetter contract)', () => {
+    const { optionsWithAll } = usePlatformOptions()
+    const labelRef = ref('All')
+    const filterOpts = optionsWithAll(labelRef)
+
+    expect(filterOpts.value[0].label).toBe('All')
+    labelRef.value = 'Tout'
+    expect(filterOpts.value[0].label).toBe('Tout')
   })
 
   it('NEGATIVE — composable cannot return a platform absent from GATEWAY_PLATFORMS (drift guard)', () => {

--- a/frontend/src/composables/useModelWhitelist.ts
+++ b/frontend/src/composables/useModelWhitelist.ts
@@ -367,7 +367,11 @@ export const commonErrorCodes = [
 // 按平台获取模型
 export function getModelsByPlatform(platform: string): string[] {
   switch (platform) {
-    case 'openai': return openaiModels
+    case 'openai':
+    case 'newapi':
+      // newapi 走 OpenAI-compat HTTP 协议，模型白名单/默认列表沿用 openai 列表
+      // （channel_type 决定真实上游路由，但 UI 层默认提示与 openai 等价）。
+      return openaiModels
     case 'anthropic':
     case 'claude': return claudeModels
     case 'gemini': return geminiModels
@@ -393,7 +397,9 @@ export function getModelsByPlatform(platform: string): string[] {
 
 // 按平台获取预设映射
 export function getPresetMappingsByPlatform(platform: string) {
-  if (platform === 'openai') return openaiPresetMappings
+  // newapi 共用 openai 预设映射 —— 两者都使用 OpenAI-compat 模型 ID 命名空间。
+  // 单独维护一套 newapi 预设会立即漂移于 openai 之后，且语义没有差异。
+  if (platform === 'openai' || platform === 'newapi') return openaiPresetMappings
   if (platform === 'gemini') return geminiPresetMappings
   if (platform === 'antigravity') return antigravityPresetMappings
   if (platform === 'bedrock') return bedrockPresetMappings

--- a/frontend/src/composables/usePlatformOptions.ts
+++ b/frontend/src/composables/usePlatformOptions.ts
@@ -1,0 +1,56 @@
+import { computed, type ComputedRef } from 'vue'
+import { GATEWAY_PLATFORMS } from '@/constants/gatewayPlatforms'
+import type { AccountPlatform } from '@/types'
+
+/**
+ * Display label per platform. Brand names are not localized today
+ * (matches the existing Anthropic / OpenAI / Gemini / Antigravity convention
+ * already hardcoded in 5+ admin views before this composable existed).
+ */
+export const PLATFORM_LABELS: Record<AccountPlatform, string> = {
+  anthropic: 'Anthropic',
+  openai: 'OpenAI',
+  gemini: 'Gemini',
+  antigravity: 'Antigravity',
+  newapi: 'New API',
+}
+
+export interface PlatformOption {
+  value: AccountPlatform
+  label: string
+  [key: string]: unknown
+}
+
+export interface PlatformFilterOption {
+  value: '' | AccountPlatform
+  label: string
+  [key: string]: unknown
+}
+
+/**
+ * Single source of truth for admin-UI platform option lists.
+ *
+ * Drives every "select / filter by platform" dropdown so that adding the
+ * Nth platform to {@link GATEWAY_PLATFORMS} auto-propagates to every picker
+ * (Jobs minimalism + OPC automation: one canonical list, one regression test).
+ *
+ * @example
+ *   const { options } = usePlatformOptions()           // 5 entries, ordered
+ *   const filterOpts = optionsWithAll(t('admin.allPlatforms')) // ['' | platform]
+ */
+export function usePlatformOptions(): {
+  options: ComputedRef<PlatformOption[]>
+  optionsWithAll: (allLabel: string) => ComputedRef<PlatformFilterOption[]>
+} {
+  const options = computed<PlatformOption[]>(() =>
+    GATEWAY_PLATFORMS.map((p) => ({ value: p, label: PLATFORM_LABELS[p] })),
+  )
+
+  const optionsWithAll = (allLabel: string): ComputedRef<PlatformFilterOption[]> =>
+    computed<PlatformFilterOption[]>(() => [
+      { value: '', label: allLabel },
+      ...options.value,
+    ])
+
+  return { options, optionsWithAll }
+}

--- a/frontend/src/composables/usePlatformOptions.ts
+++ b/frontend/src/composables/usePlatformOptions.ts
@@ -1,4 +1,4 @@
-import { computed, type ComputedRef } from 'vue'
+import { computed, toValue, type ComputedRef, type MaybeRefOrGetter } from 'vue'
 import { GATEWAY_PLATFORMS } from '@/constants/gatewayPlatforms'
 import type { AccountPlatform } from '@/types'
 
@@ -35,20 +35,28 @@ export interface PlatformFilterOption {
  * (Jobs minimalism + OPC automation: one canonical list, one regression test).
  *
  * @example
- *   const { options } = usePlatformOptions()           // 5 entries, ordered
- *   const filterOpts = optionsWithAll(t('admin.allPlatforms')) // ['' | platform]
+ *   const { options } = usePlatformOptions()
+ *   // i18n-reactive caller: pass a getter so language switches re-evaluate.
+ *   const filterOpts = optionsWithAll(() => t('admin.allPlatforms'))
  */
 export function usePlatformOptions(): {
   options: ComputedRef<PlatformOption[]>
-  optionsWithAll: (allLabel: string) => ComputedRef<PlatformFilterOption[]>
+  optionsWithAll: (
+    allLabel: MaybeRefOrGetter<string>,
+  ) => ComputedRef<PlatformFilterOption[]>
 } {
   const options = computed<PlatformOption[]>(() =>
     GATEWAY_PLATFORMS.map((p) => ({ value: p, label: PLATFORM_LABELS[p] })),
   )
 
-  const optionsWithAll = (allLabel: string): ComputedRef<PlatformFilterOption[]> =>
+  // `allLabel` accepts a string, ref, or getter so callers passing
+  // `() => t('...')` keep i18n reactivity (the previous string-only signature
+  // captured a snapshot at composition time and went stale on language switch).
+  const optionsWithAll = (
+    allLabel: MaybeRefOrGetter<string>,
+  ): ComputedRef<PlatformFilterOption[]> =>
     computed<PlatformFilterOption[]>(() => [
-      { value: '', label: allLabel },
+      { value: '', label: toValue(allLabel) },
       ...options.value,
     ])
 

--- a/frontend/src/constants/gatewayPlatforms.ts
+++ b/frontend/src/constants/gatewayPlatforms.ts
@@ -3,6 +3,25 @@ import type { AccountPlatform } from '@/types'
 /** Ordered account/group platforms, including the independent fifth platform `newapi`. */
 export const GATEWAY_PLATFORMS = ['anthropic', 'openai', 'gemini', 'antigravity', 'newapi'] as const satisfies readonly AccountPlatform[]
 
+/**
+ * Platforms that participate in the OpenAI-compatible HTTP request shape
+ * (i.e. clients speaking the OpenAI protocol: `/v1/chat/completions`,
+ * `/v1/responses`, `/v1/messages` 调度 etc.).
+ *
+ * Mirrors `service.OpenAICompatPlatforms()` in the Go backend
+ * (`backend/internal/service/account_tk_compat_pool.go`). When adding a sixth
+ * compat platform, BOTH places must be updated in lockstep — `scripts/preflight.sh`
+ * § 9 (newapi compat-pool drift) catches the backend half; the frontend half is
+ * covered by the `useModelWhitelist` and `usePlatformOptions` test suites.
+ */
+export const OPENAI_COMPAT_PLATFORMS: readonly AccountPlatform[] = ['openai', 'newapi'] as const
+
+/** Predicate sibling of {@link OPENAI_COMPAT_PLATFORMS} — use whenever a UI branch is gated on "speaks OpenAI HTTP shape". */
+export function isOpenAICompatPlatform(platform: string | null | undefined): boolean {
+  if (!platform) return false
+  return (OPENAI_COMPAT_PLATFORMS as readonly string[]).includes(platform)
+}
+
 /** Tailwind active-state classes for the create-account platform segmented control (order follows {@link GATEWAY_PLATFORMS}). */
 export const CREATE_ACCOUNT_PLATFORM_SEGMENT_ACTIVE: Record<AccountPlatform, string> = {
   anthropic:

--- a/frontend/src/i18n/locales/en.ts
+++ b/frontend/src/i18n/locales/en.ts
@@ -2604,6 +2604,16 @@ export default {
         pleaseEnterBaseUrl: 'Please enter upstream Base URL',
         pleaseEnterApiKey: 'Please enter upstream API Key'
       },
+      newApiPlatform: {
+        channelType: 'Channel Type',
+        channelTypePlaceholder: 'Select a New API channel type',
+        channelTypeLoadFailed: 'Failed to load channel types, please retry',
+        baseUrl: 'Base URL',
+        baseUrlHint: 'Upstream endpoint, e.g. https://api.deepseek.com',
+        apiKey: 'API Key',
+        apiKeyPlaceholder: 'sk-...',
+        apiKeyEditHint: 'Leave empty to keep current key'
+      },
       // OAuth flow
       oauth: {
         title: 'Claude Account Authorization',

--- a/frontend/src/i18n/locales/en.ts
+++ b/frontend/src/i18n/locales/en.ts
@@ -1684,6 +1684,7 @@ export default {
         openai: 'OpenAI',
         gemini: 'Gemini',
         antigravity: 'Antigravity',
+        newapi: 'New API',
       },
       deleteConfirm:
         "Are you sure you want to delete '{name}'? All associated API keys will no longer belong to any group.",
@@ -2117,6 +2118,7 @@ export default {
         openai: 'OpenAI',
         gemini: 'Gemini',
         antigravity: 'Antigravity',
+        newapi: 'New API',
       },
       types: {
         oauth: 'OAuth',

--- a/frontend/src/i18n/locales/en.ts
+++ b/frontend/src/i18n/locales/en.ts
@@ -2612,7 +2612,10 @@ export default {
         baseUrlHint: 'Upstream endpoint, e.g. https://api.deepseek.com',
         apiKey: 'API Key',
         apiKeyPlaceholder: 'sk-...',
-        apiKeyEditHint: 'Leave empty to keep current key'
+        apiKeyEditHint: 'Leave empty to keep current key',
+        pleaseSelectChannelType: 'Please select a New API channel type',
+        pleaseEnterBaseUrl: 'Please enter upstream Base URL',
+        pleaseEnterApiKey: 'Please enter upstream API Key'
       },
       // OAuth flow
       oauth: {

--- a/frontend/src/i18n/locales/en.ts
+++ b/frontend/src/i18n/locales/en.ts
@@ -97,6 +97,7 @@ export default {
       claude: 'Claude',
       gemini: 'Gemini',
       antigravity: 'Antigravity',
+      newapi: 'New API',
       more: 'More'
     },
     // CTA section

--- a/frontend/src/i18n/locales/zh.ts
+++ b/frontend/src/i18n/locales/zh.ts
@@ -2747,6 +2747,16 @@ export default {
         pleaseEnterBaseUrl: '请输入上游 Base URL',
         pleaseEnterApiKey: '请输入上游 API Key'
       },
+      newApiPlatform: {
+        channelType: '渠道类型',
+        channelTypePlaceholder: '请选择 New API 渠道类型',
+        channelTypeLoadFailed: '加载渠道类型失败，请重试',
+        baseUrl: 'Base URL',
+        baseUrlHint: '上游服务地址，例如 https://api.deepseek.com',
+        apiKey: 'API Key',
+        apiKeyPlaceholder: 'sk-...',
+        apiKeyEditHint: '留空表示保留当前密钥'
+      },
       // OAuth flow
       oauth: {
         title: 'Claude 账号授权',

--- a/frontend/src/i18n/locales/zh.ts
+++ b/frontend/src/i18n/locales/zh.ts
@@ -1720,6 +1720,7 @@ export default {
         openai: 'OpenAI',
         gemini: 'Gemini',
         antigravity: 'Antigravity',
+        newapi: 'New API',
       },
       saving: '保存中...',
       noGroups: '暂无分组',
@@ -2304,6 +2305,7 @@ export default {
         anthropic: 'Anthropic',
         gemini: 'Gemini',
         antigravity: 'Antigravity',
+        newapi: 'New API',
       },
       types: {
         oauth: 'OAuth',

--- a/frontend/src/i18n/locales/zh.ts
+++ b/frontend/src/i18n/locales/zh.ts
@@ -97,6 +97,7 @@ export default {
       claude: 'Claude',
       gemini: 'Gemini',
       antigravity: 'Antigravity',
+      newapi: 'New API',
       more: '更多'
     },
     // CTA 区块

--- a/frontend/src/i18n/locales/zh.ts
+++ b/frontend/src/i18n/locales/zh.ts
@@ -2755,7 +2755,10 @@ export default {
         baseUrlHint: '上游服务地址，例如 https://api.deepseek.com',
         apiKey: 'API Key',
         apiKeyPlaceholder: 'sk-...',
-        apiKeyEditHint: '留空表示保留当前密钥'
+        apiKeyEditHint: '留空表示保留当前密钥',
+        pleaseSelectChannelType: '请选择 New API 渠道类型',
+        pleaseEnterBaseUrl: '请输入上游 Base URL',
+        pleaseEnterApiKey: '请输入上游 API Key'
       },
       // OAuth flow
       oauth: {

--- a/frontend/src/types/index.ts
+++ b/frontend/src/types/index.ts
@@ -878,6 +878,10 @@ export interface CreateAccountRequest {
   expires_at?: number | null
   auto_pause_on_expired?: boolean
   confirm_mixed_channel_risk?: boolean
+  // Top-level channel_type for the fifth platform `newapi` (admin_service.go:1565
+  // enforces channel_type > 0 when platform == 'newapi'). Required only on the
+  // newapi branch; ignored by the other 4 platforms.
+  channel_type?: number
 }
 
 export interface UpdateAccountRequest {

--- a/frontend/src/types/index.ts
+++ b/frontend/src/types/index.ts
@@ -687,6 +687,11 @@ export interface Account {
   name: string
   notes?: string | null
   platform: AccountPlatform
+  // Top-level channel_type for the fifth platform `newapi`. Backend
+  // admin_service.go:1565 enforces channel_type > 0 when platform == 'newapi'
+  // and 0 elsewhere; treat as optional on the read path because the four
+  // legacy platforms always serialize 0 and it is meaningless to consume.
+  channel_type?: number
   type: AccountType
   credentials?: Record<string, unknown>
   // Extra fields including Codex usage and model-level rate limits (Antigravity smart retry)

--- a/frontend/src/utils/__tests__/channelFormConversion.spec.ts
+++ b/frontend/src/utils/__tests__/channelFormConversion.spec.ts
@@ -1,0 +1,365 @@
+import { describe, expect, it } from 'vitest'
+
+import type { Channel } from '@/api/admin/channels'
+import { GATEWAY_PLATFORMS } from '@/constants/gatewayPlatforms'
+import type { AdminGroup, GroupPlatform } from '@/types'
+
+import {
+  apiToFormSections,
+  formSectionsToApi,
+  type PlatformSection,
+} from '../channelFormConversion'
+
+// ── Fixtures ─────────────────────────────────────────────────────────
+
+function makeGroup(id: number, platform: GroupPlatform, name: string): AdminGroup {
+  return {
+    id,
+    name,
+    description: null,
+    platform,
+    rate_multiplier: 1,
+    is_exclusive: false,
+    status: 'active',
+    subscription_type: 'standard',
+    daily_limit_usd: null,
+    weekly_limit_usd: null,
+    monthly_limit_usd: null,
+    image_price_1k: null,
+    image_price_2k: null,
+    image_price_4k: null,
+    claude_code_only: false,
+    fallback_group_id: null,
+    fallback_group_id_on_invalid_request: null,
+    require_oauth_only: false,
+    require_privacy_set: false,
+    created_at: '2026-04-20T00:00:00Z',
+    updated_at: '2026-04-20T00:00:00Z',
+    model_routing: null,
+    model_routing_enabled: false,
+    mcp_xml_inject: false,
+    sort_order: 0,
+  }
+}
+
+const ALL_GROUPS: AdminGroup[] = [
+  makeGroup(1, 'anthropic', 'anthropic-pool'),
+  makeGroup(2, 'openai', 'openai-pool'),
+  makeGroup(3, 'gemini', 'gemini-pool'),
+  makeGroup(4, 'antigravity', 'antigravity-pool'),
+  makeGroup(5, 'newapi', 'newapi-deepseek'),
+  makeGroup(6, 'newapi', 'newapi-zhipu'),
+]
+
+function makeChannel(overrides: Partial<Channel> = {}): Channel {
+  return {
+    id: 1,
+    name: 'test-channel',
+    description: '',
+    status: 'active',
+    billing_model_source: 'channel_mapped',
+    restrict_models: false,
+    features_config: {},
+    group_ids: [],
+    model_pricing: [],
+    model_mapping: {},
+    apply_pricing_to_account_stats: false,
+    account_stats_pricing_rules: [],
+    created_at: '2026-04-20T00:00:00Z',
+    updated_at: '2026-04-20T00:00:00Z',
+    ...overrides,
+  }
+}
+
+// Backend stores per-token; UI displays per-MTok. 0.000003 per-token = 3 per-MTok.
+const PER_TOKEN_3_USD_PER_MTOK = 0.000003
+
+// ── Tests ────────────────────────────────────────────────────────────
+
+describe('channelFormConversion (US-017 — round-trip preserves all 5 gateway platforms)', () => {
+  it('round-trips a channel that mixes anthropic + newapi without dropping newapi data (the data-loss bug we are fixing)', () => {
+    // Reproduces the latent bug discovered during deep review of ChannelsView:
+    // the previous in-component apiToForm filtered model_mapping keys by a
+    // 4-element platformOrder array (line 1070), and formToAPI then iterated
+    // form.platforms (line 1007). Saving an existing channel that the API
+    // had returned with newapi data would therefore SILENTLY DELETE all
+    // newapi rows. This test pins the contract that newapi survives the
+    // round-trip when GATEWAY_PLATFORMS is the canonical order.
+    const channel = makeChannel({
+      group_ids: [1, 5, 6],
+      model_mapping: {
+        anthropic: { 'claude-3.5-sonnet': 'claude-3-5-sonnet-20241022' },
+        newapi: { 'deepseek-chat': 'deepseek-v3', 'glm-4': 'glm-4-plus' },
+      },
+      model_pricing: [
+        {
+          platform: 'anthropic',
+          models: ['claude-3.5-sonnet'],
+          billing_mode: 'token',
+          input_price: PER_TOKEN_3_USD_PER_MTOK,
+          output_price: 0.000015,
+          cache_write_price: null,
+          cache_read_price: null,
+          image_output_price: null,
+          per_request_price: null,
+          intervals: [],
+        },
+        {
+          platform: 'newapi',
+          models: ['deepseek-chat'],
+          billing_mode: 'token',
+          input_price: 0.0000001,
+          output_price: 0.00000028,
+          cache_write_price: null,
+          cache_read_price: null,
+          image_output_price: null,
+          per_request_price: null,
+          intervals: [],
+        },
+      ],
+    })
+
+    const sections = apiToFormSections(channel, ALL_GROUPS)
+
+    const platforms = sections.map((s) => s.platform)
+    expect(platforms).toContain('newapi')
+    expect(platforms).toContain('anthropic')
+
+    const newapiSection = sections.find((s) => s.platform === 'newapi')!
+    expect(newapiSection.group_ids.sort()).toEqual([5, 6])
+    expect(newapiSection.model_mapping).toEqual({
+      'deepseek-chat': 'deepseek-v3',
+      'glm-4': 'glm-4-plus',
+    })
+    expect(newapiSection.model_pricing).toHaveLength(1)
+    expect(newapiSection.model_pricing[0].models).toEqual(['deepseek-chat'])
+
+    // Round-trip: form → api should preserve everything.
+    const payload = formSectionsToApi(sections, channel.features_config)
+
+    expect(payload.group_ids.sort()).toEqual([1, 5, 6])
+    expect(payload.model_mapping).toHaveProperty('newapi')
+    expect(payload.model_mapping.newapi).toEqual({
+      'deepseek-chat': 'deepseek-v3',
+      'glm-4': 'glm-4-plus',
+    })
+    expect(payload.model_mapping).toHaveProperty('anthropic')
+    expect(payload.model_pricing.map((p) => p.platform).sort()).toEqual([
+      'anthropic',
+      'newapi',
+    ])
+
+    // Per-token ↔ per-MTok conversion must round-trip the anthropic pricing.
+    const antPricing = payload.model_pricing.find((p) => p.platform === 'anthropic')!
+    expect(antPricing.input_price).toBeCloseTo(PER_TOKEN_3_USD_PER_MTOK, 12)
+    expect(antPricing.output_price).toBeCloseTo(0.000015, 12)
+  })
+
+  it('NEGATIVE — apiToFormSections with the legacy 4-element platformOrder still drops newapi (regression-by-construction proof of the bug)', () => {
+    // Demonstrates that the FIX (passing GATEWAY_PLATFORMS) is doing the work,
+    // not some accidental property of the test fixtures. With the historical
+    // 4-element list, newapi data is silently filtered out — exactly the bug
+    // ChannelsView shipped before this PR.
+    const legacyPlatformOrder: GroupPlatform[] = [
+      'anthropic',
+      'openai',
+      'gemini',
+      'antigravity',
+    ]
+    const channel = makeChannel({
+      group_ids: [5],
+      model_mapping: { newapi: { foo: 'bar' } },
+      model_pricing: [
+        {
+          platform: 'newapi',
+          models: ['foo'],
+          billing_mode: 'token',
+          input_price: 0.0000001,
+          output_price: 0.0000002,
+          cache_write_price: null,
+          cache_read_price: null,
+          image_output_price: null,
+          per_request_price: null,
+          intervals: [],
+        },
+      ],
+    })
+
+    const sections = apiToFormSections(channel, ALL_GROUPS, legacyPlatformOrder)
+
+    expect(sections.map((s) => s.platform)).not.toContain('newapi')
+    expect(sections).toHaveLength(0)
+  })
+
+  it('REGRESSION — round-trips a channel with only the 4 legacy platforms (no behavior change for existing channels)', () => {
+    const channel = makeChannel({
+      group_ids: [1, 2, 3, 4],
+      model_mapping: {
+        anthropic: { 'claude-3.5-sonnet': 'claude-3-5-sonnet' },
+        openai: { 'gpt-4o': 'gpt-4o-2024-08-06' },
+      },
+      model_pricing: [
+        {
+          platform: 'anthropic',
+          models: ['claude-3.5-sonnet'],
+          billing_mode: 'token',
+          input_price: 0.000003,
+          output_price: 0.000015,
+          cache_write_price: 0.00000375,
+          cache_read_price: 0.0000003,
+          image_output_price: null,
+          per_request_price: null,
+          intervals: [],
+        },
+      ],
+    })
+
+    const sections = apiToFormSections(channel, ALL_GROUPS)
+    const payload = formSectionsToApi(sections, channel.features_config)
+
+    expect(payload.group_ids.sort((a, b) => a - b)).toEqual([1, 2, 3, 4])
+    expect(Object.keys(payload.model_mapping).sort()).toEqual([
+      'anthropic',
+      'openai',
+    ])
+    expect(payload.model_pricing).toHaveLength(1)
+    expect(payload.model_pricing[0].platform).toBe('anthropic')
+  })
+
+  it('preserves features_config.web_search_emulation flag through the round-trip when anthropic section is enabled', () => {
+    const channel = makeChannel({
+      group_ids: [1],
+      features_config: {
+        web_search_emulation: { anthropic: true },
+        custom_unrelated_field: 'must-survive',
+      },
+      model_mapping: { anthropic: { foo: 'bar' } },
+    })
+
+    const sections = apiToFormSections(channel, ALL_GROUPS)
+    const ant = sections.find((s) => s.platform === 'anthropic')!
+    expect(ant.web_search_emulation).toBe(true)
+
+    const payload = formSectionsToApi(sections, channel.features_config)
+    expect(payload.features_config.web_search_emulation).toEqual({ anthropic: true })
+    // Non-managed keys must be preserved.
+    expect(payload.features_config.custom_unrelated_field).toBe('must-survive')
+  })
+
+  it('clears web_search_emulation when the anthropic section is disabled (toggle on→off must persist)', () => {
+    // Bug guard: the previous implementation always rewrote the key, so a
+    // user toggling off in the UI MUST flip the persisted value, not leave a
+    // stale `true`. Same contract here.
+    const channel = makeChannel({
+      group_ids: [1],
+      features_config: { web_search_emulation: { anthropic: true } },
+    })
+
+    const sections = apiToFormSections(channel, ALL_GROUPS)
+    const ant = sections.find((s) => s.platform === 'anthropic')!
+    ant.web_search_emulation = false
+
+    const payload = formSectionsToApi(sections, channel.features_config)
+    expect(payload.features_config.web_search_emulation).toEqual({ anthropic: false })
+  })
+
+  it('drops features_config.web_search_emulation entirely when no anthropic section is enabled', () => {
+    const channel = makeChannel({
+      group_ids: [5],
+      features_config: { web_search_emulation: { anthropic: true } },
+    })
+
+    const sections = apiToFormSections(channel, ALL_GROUPS)
+    expect(sections.find((s) => s.platform === 'anthropic')).toBeUndefined()
+
+    const payload = formSectionsToApi(sections, channel.features_config)
+    expect(payload.features_config).not.toHaveProperty('web_search_emulation')
+  })
+
+  it('skips disabled sections when emitting payload (UI can stage edits then deselect a platform)', () => {
+    const sections: PlatformSection[] = [
+      {
+        platform: 'newapi',
+        enabled: false,
+        collapsed: false,
+        group_ids: [5],
+        model_mapping: { foo: 'bar' },
+        model_pricing: [],
+        web_search_emulation: false,
+        account_stats_pricing_rules: [],
+      },
+      {
+        platform: 'anthropic',
+        enabled: true,
+        collapsed: false,
+        group_ids: [1],
+        model_mapping: { 'claude-3.5-sonnet': 'claude-3-5-sonnet' },
+        model_pricing: [],
+        web_search_emulation: false,
+        account_stats_pricing_rules: [],
+      },
+    ]
+
+    const payload = formSectionsToApi(sections)
+    expect(payload.group_ids).toEqual([1])
+    expect(Object.keys(payload.model_mapping)).toEqual(['anthropic'])
+  })
+
+  it('returns sections in GATEWAY_PLATFORMS canonical order (anthropic → openai → gemini → antigravity → newapi)', () => {
+    const channel = makeChannel({
+      group_ids: [5, 1, 3, 2, 4],
+      model_mapping: {
+        newapi: { a: 'b' },
+        anthropic: { c: 'd' },
+        openai: { e: 'f' },
+        gemini: { g: 'h' },
+        antigravity: { i: 'j' },
+      },
+    })
+
+    const sections = apiToFormSections(channel, ALL_GROUPS)
+    expect(sections.map((s) => s.platform)).toEqual([...GATEWAY_PLATFORMS])
+  })
+
+  it('drops empty model_pricing entries (models.length === 0) instead of posting them to the backend', () => {
+    const sections: PlatformSection[] = [
+      {
+        platform: 'newapi',
+        enabled: true,
+        collapsed: false,
+        group_ids: [5],
+        model_mapping: {},
+        model_pricing: [
+          {
+            models: [],
+            billing_mode: 'token',
+            input_price: 1,
+            output_price: 1,
+            cache_write_price: null,
+            cache_read_price: null,
+            image_output_price: null,
+            per_request_price: null,
+            intervals: [],
+          },
+          {
+            models: ['deepseek-chat'],
+            billing_mode: 'token',
+            input_price: 0.5,
+            output_price: 1,
+            cache_write_price: null,
+            cache_read_price: null,
+            image_output_price: null,
+            per_request_price: null,
+            intervals: [],
+          },
+        ],
+        web_search_emulation: false,
+        account_stats_pricing_rules: [],
+      },
+    ]
+
+    const payload = formSectionsToApi(sections)
+    expect(payload.model_pricing).toHaveLength(1)
+    expect(payload.model_pricing[0].models).toEqual(['deepseek-chat'])
+  })
+})

--- a/frontend/src/utils/channelFormConversion.ts
+++ b/frontend/src/utils/channelFormConversion.ts
@@ -1,0 +1,212 @@
+/**
+ * Pure converters between Channel API shape and the per-platform form sections
+ * used by ChannelsView.vue.
+ *
+ * Extracted from ChannelsView.vue so the round-trip can be exercised by unit
+ * tests without mounting the full admin view. The previous in-component
+ * implementation used a hardcoded 4-element `platformOrder` array, which
+ * silently dropped any `newapi` data on the round-trip — both `apiToForm`
+ * filtered keys outside the array (line 1070) and `formToAPI` then iterated
+ * `form.platforms` (line 1007), so re-saving an existing channel that had
+ * been linked to a `newapi` group via the API would erase its `newapi`
+ * `model_mapping` and `model_pricing` rows. Driving the canonical ordering
+ * from `GATEWAY_PLATFORMS` (single source of truth) closes that data-loss
+ * bug as a side-effect of the contract.
+ *
+ * See: docs/approved/admin-ui-newapi-platform-end-to-end.md §1.5
+ *      .testing/user-stories/stories/US-017-admin-ui-newapi-platform-end-to-end.md
+ */
+
+import type {
+  Channel,
+  ChannelModelPricing,
+} from '@/api/admin/channels'
+import type { PricingFormEntry } from '@/components/admin/channel/types'
+import {
+  apiIntervalsToForm,
+  formIntervalsToAPI,
+  mTokToPerToken,
+  perTokenToMTok,
+} from '@/components/admin/channel/types'
+import { GATEWAY_PLATFORMS } from '@/constants/gatewayPlatforms'
+import type { AdminGroup, GroupPlatform } from '@/types'
+
+/** Form-level pricing rule (per-platform sub-rule rendered inside a section). */
+export interface FormPricingRule {
+  name: string
+  group_ids: number[]
+  account_ids: number[]
+  pricing: PricingFormEntry[]
+}
+
+/** Per-platform UI section in the channel-edit form. */
+export interface PlatformSection {
+  platform: GroupPlatform
+  enabled: boolean
+  collapsed: boolean
+  group_ids: number[]
+  model_mapping: Record<string, string>
+  model_pricing: PricingFormEntry[]
+  web_search_emulation: boolean
+  account_stats_pricing_rules: FormPricingRule[]
+}
+
+/** API payload shape that ChannelsView posts to the backend. */
+export interface ChannelFormApiPayload {
+  group_ids: number[]
+  model_pricing: ChannelModelPricing[]
+  model_mapping: Record<string, Record<string, string>>
+  features_config: Record<string, unknown>
+}
+
+/**
+ * Convert a {@link Channel} loaded from the backend into the per-platform
+ * sections rendered by the form.
+ *
+ * @param channel  Channel to load — `model_mapping`, `model_pricing` and
+ *                 `group_ids` are inspected to decide which platforms are
+ *                 active.
+ * @param allGroups  All admin groups (used to map group_id → platform).
+ * @param platforms  Canonical platform order. Defaults to {@link GATEWAY_PLATFORMS}
+ *                   so all five platforms (including `newapi`) are preserved.
+ *                   Tests may pass a narrower list to verify drift behavior.
+ */
+export function apiToFormSections(
+  channel: Channel,
+  allGroups: AdminGroup[],
+  platforms: readonly GroupPlatform[] = GATEWAY_PLATFORMS,
+): PlatformSection[] {
+  const groupPlatformMap = new Map<number, GroupPlatform>()
+  for (const g of allGroups) {
+    groupPlatformMap.set(g.id, g.platform)
+  }
+
+  const allowed = new Set<GroupPlatform>(platforms)
+  const activePlatforms = new Set<GroupPlatform>()
+
+  for (const gid of channel.group_ids || []) {
+    const p = groupPlatformMap.get(gid)
+    if (p && allowed.has(p)) activePlatforms.add(p)
+  }
+  for (const p of channel.model_pricing || []) {
+    if (p.platform && allowed.has(p.platform as GroupPlatform)) {
+      activePlatforms.add(p.platform as GroupPlatform)
+    }
+  }
+  for (const p of Object.keys(channel.model_mapping || {})) {
+    if (allowed.has(p as GroupPlatform)) {
+      activePlatforms.add(p as GroupPlatform)
+    }
+  }
+
+  const sections: PlatformSection[] = []
+  for (const platform of platforms) {
+    if (!activePlatforms.has(platform)) continue
+
+    const groupIds = (channel.group_ids || []).filter(
+      (gid) => groupPlatformMap.get(gid) === platform,
+    )
+    const mapping = (channel.model_mapping || {})[platform] || {}
+    const pricing = (channel.model_pricing || [])
+      .filter((p) => (p.platform || 'anthropic') === platform)
+      .map(
+        (p) =>
+          ({
+            models: p.models || [],
+            billing_mode: p.billing_mode,
+            input_price: perTokenToMTok(p.input_price),
+            output_price: perTokenToMTok(p.output_price),
+            cache_write_price: perTokenToMTok(p.cache_write_price),
+            cache_read_price: perTokenToMTok(p.cache_read_price),
+            image_output_price: perTokenToMTok(p.image_output_price),
+            per_request_price: p.per_request_price,
+            intervals: apiIntervalsToForm(p.intervals || []),
+          }) as PricingFormEntry,
+      )
+
+    const fc = channel.features_config
+    const wsEmulation = fc?.web_search_emulation as
+      | Record<string, boolean>
+      | undefined
+    const webSearchEnabled = wsEmulation?.[platform] === true
+
+    sections.push({
+      platform,
+      enabled: true,
+      collapsed: false,
+      group_ids: groupIds,
+      model_mapping: { ...mapping },
+      model_pricing: pricing,
+      web_search_emulation: webSearchEnabled,
+      account_stats_pricing_rules: [],
+    })
+  }
+
+  return sections
+}
+
+/**
+ * Convert per-platform form sections back to the API payload posted by
+ * ChannelsView. Preserves `features_config` keys not managed by the form.
+ *
+ * `web_search_emulation` is always written when at least one anthropic
+ * section is enabled (so the UI can flip it from on → off); cleared when
+ * no anthropic section is active.
+ */
+export function formSectionsToApi(
+  sections: PlatformSection[],
+  existingFeaturesConfig?: Record<string, unknown>,
+): ChannelFormApiPayload {
+  const group_ids: number[] = []
+  const model_pricing: ChannelModelPricing[] = []
+  const model_mapping: Record<string, Record<string, string>> = {}
+  const featuresConfig: Record<string, unknown> = existingFeaturesConfig
+    ? { ...existingFeaturesConfig }
+    : {}
+
+  for (const section of sections) {
+    if (!section.enabled) continue
+    group_ids.push(...section.group_ids)
+
+    if (Object.keys(section.model_mapping).length > 0) {
+      model_mapping[section.platform] = { ...section.model_mapping }
+    }
+
+    for (const entry of section.model_pricing) {
+      if (entry.models.length === 0) continue
+      model_pricing.push({
+        platform: section.platform,
+        models: entry.models,
+        billing_mode: entry.billing_mode,
+        input_price: mTokToPerToken(entry.input_price),
+        output_price: mTokToPerToken(entry.output_price),
+        cache_write_price: mTokToPerToken(entry.cache_write_price),
+        cache_read_price: mTokToPerToken(entry.cache_read_price),
+        image_output_price: mTokToPerToken(entry.image_output_price),
+        per_request_price:
+          entry.per_request_price != null && entry.per_request_price !== ''
+            ? Number(entry.per_request_price)
+            : null,
+        intervals: formIntervalsToAPI(entry.intervals || []),
+      })
+    }
+  }
+
+  // Always (re-)write web_search_emulation when an anthropic section is
+  // enabled so a UI toggle from on→off correctly persists. When no anthropic
+  // section is active the key is cleared to keep features_config tight.
+  const wsEmulation: Record<string, boolean> = {}
+  for (const section of sections) {
+    if (!section.enabled) continue
+    if (section.platform === 'anthropic') {
+      wsEmulation[section.platform] = !!section.web_search_emulation
+    }
+  }
+  if (Object.keys(wsEmulation).length > 0) {
+    featuresConfig.web_search_emulation = wsEmulation
+  } else {
+    delete featuresConfig.web_search_emulation
+  }
+
+  return { group_ids, model_pricing, model_mapping, features_config: featuresConfig }
+}

--- a/frontend/src/utils/platformColors.ts
+++ b/frontend/src/utils/platformColors.ts
@@ -3,9 +3,14 @@
  *
  * All components that need platform-specific styling should import from here
  * instead of defining their own color mappings.
+ *
+ * `newapi` (the fifth gateway platform) uses cyan throughout, matching
+ * `gatewayPlatforms.ts` (line 14, 30, 38). Adding a new platform must extend
+ * the `Platform` union type below + every variant map; TypeScript's exhaustive
+ * `Record<Platform, …>` guarantees the compiler will reject silent omissions.
  */
 
-export type Platform = 'anthropic' | 'openai' | 'antigravity' | 'gemini'
+export type Platform = 'anthropic' | 'openai' | 'antigravity' | 'gemini' | 'newapi'
 
 // ── Badge (bg + text + border, for inline badges with border) ───────
 const BADGE: Record<Platform, string> = {
@@ -13,6 +18,7 @@ const BADGE: Record<Platform, string> = {
   openai: 'bg-green-500/10 text-green-600 border-green-500/30 dark:text-green-400',
   antigravity: 'bg-purple-500/10 text-purple-600 border-purple-500/30 dark:text-purple-400',
   gemini: 'bg-blue-500/10 text-blue-600 border-blue-500/30 dark:text-blue-400',
+  newapi: 'bg-cyan-500/10 text-cyan-600 border-cyan-500/30 dark:text-cyan-400',
 }
 const BADGE_DEFAULT = 'bg-slate-500/10 text-slate-600 border-slate-500/30 dark:text-slate-400'
 
@@ -22,6 +28,7 @@ const BADGE_LIGHT: Record<Platform, string> = {
   openai: 'bg-green-500/10 text-green-600 dark:bg-green-500/10 dark:text-green-300',
   antigravity: 'bg-purple-500/10 text-purple-600 dark:bg-purple-500/10 dark:text-purple-300',
   gemini: 'bg-blue-500/10 text-blue-600 dark:bg-blue-500/10 dark:text-blue-300',
+  newapi: 'bg-cyan-500/10 text-cyan-600 dark:bg-cyan-500/10 dark:text-cyan-300',
 }
 
 // ── Border ──────────────────────────────────────────────────────────
@@ -30,6 +37,7 @@ const BORDER: Record<Platform, string> = {
   openai: 'border-green-500/20 dark:border-green-500/20',
   antigravity: 'border-purple-500/20 dark:border-purple-500/20',
   gemini: 'border-blue-500/20 dark:border-blue-500/20',
+  newapi: 'border-cyan-500/20 dark:border-cyan-500/20',
 }
 const BORDER_DEFAULT = 'border-gray-200 dark:border-dark-700'
 
@@ -39,6 +47,7 @@ const ACCENT_BAR: Record<Platform, string> = {
   openai: 'bg-gradient-to-r from-emerald-400 to-emerald-500',
   antigravity: 'bg-gradient-to-r from-purple-400 to-purple-500',
   gemini: 'bg-gradient-to-r from-blue-400 to-blue-500',
+  newapi: 'bg-gradient-to-r from-cyan-400 to-cyan-500',
 }
 const ACCENT_BAR_DEFAULT = 'bg-gradient-to-r from-primary-400 to-primary-500'
 
@@ -48,6 +57,7 @@ const TEXT: Record<Platform, string> = {
   openai: 'text-emerald-600 dark:text-emerald-400',
   antigravity: 'text-purple-600 dark:text-purple-400',
   gemini: 'text-blue-600 dark:text-blue-400',
+  newapi: 'text-cyan-600 dark:text-cyan-400',
 }
 const TEXT_DEFAULT = 'text-primary-600 dark:text-primary-400'
 
@@ -57,6 +67,7 @@ const ICON: Record<Platform, string> = {
   openai: 'text-emerald-500 dark:text-emerald-400',
   antigravity: 'text-purple-500 dark:text-purple-400',
   gemini: 'text-blue-500 dark:text-blue-400',
+  newapi: 'text-cyan-500 dark:text-cyan-400',
 }
 const ICON_DEFAULT = 'text-primary-500 dark:text-primary-400'
 
@@ -66,6 +77,7 @@ const BUTTON: Record<Platform, string> = {
   openai: 'bg-green-600 text-white hover:bg-green-700 active:bg-green-800 dark:bg-green-600/80 dark:hover:bg-green-600',
   antigravity: 'bg-purple-500 text-white hover:bg-purple-600 active:bg-purple-700 dark:bg-purple-500/80 dark:hover:bg-purple-500',
   gemini: 'bg-blue-500 text-white hover:bg-blue-600 active:bg-blue-700 dark:bg-blue-500/80 dark:hover:bg-blue-500',
+  newapi: 'bg-cyan-500 text-white hover:bg-cyan-600 active:bg-cyan-700 dark:bg-cyan-500/80 dark:hover:bg-cyan-500',
 }
 const BUTTON_DEFAULT = 'bg-primary-500 text-white hover:bg-primary-600 dark:bg-primary-600 dark:hover:bg-primary-500'
 
@@ -75,6 +87,7 @@ const DISCOUNT: Record<Platform, string> = {
   openai: 'bg-emerald-100 text-emerald-700 dark:bg-emerald-900/40 dark:text-emerald-300',
   antigravity: 'bg-purple-100 text-purple-700 dark:bg-purple-900/40 dark:text-purple-300',
   gemini: 'bg-blue-100 text-blue-700 dark:bg-blue-900/40 dark:text-blue-300',
+  newapi: 'bg-cyan-100 text-cyan-700 dark:bg-cyan-900/40 dark:text-cyan-300',
 }
 const DISCOUNT_DEFAULT = 'bg-red-100 text-red-700 dark:bg-red-900/40 dark:text-red-300'
 
@@ -84,6 +97,7 @@ const GRADIENT: Record<Platform, string> = {
   openai: 'from-emerald-500 to-emerald-600',
   antigravity: 'from-purple-500 to-purple-600',
   gemini: 'from-blue-500 to-blue-600',
+  newapi: 'from-cyan-500 to-cyan-600',
 }
 const GRADIENT_DEFAULT = 'from-primary-500 to-primary-600'
 
@@ -93,6 +107,7 @@ const GRADIENT_TEXT: Record<Platform, string> = {
   openai: 'text-emerald-100',
   antigravity: 'text-purple-100',
   gemini: 'text-blue-100',
+  newapi: 'text-cyan-100',
 }
 const GRADIENT_TEXT_DEFAULT = 'text-primary-100'
 
@@ -101,13 +116,20 @@ const GRADIENT_SUBTEXT: Record<Platform, string> = {
   openai: 'text-emerald-200',
   antigravity: 'text-purple-200',
   gemini: 'text-blue-200',
+  newapi: 'text-cyan-200',
 }
 const GRADIENT_SUBTEXT_DEFAULT = 'text-primary-200'
 
 // ── Public API ──────────────────────────────────────────────────────
 
 function isPlatform(p: string): p is Platform {
-  return p === 'anthropic' || p === 'openai' || p === 'antigravity' || p === 'gemini'
+  return (
+    p === 'anthropic' ||
+    p === 'openai' ||
+    p === 'antigravity' ||
+    p === 'gemini' ||
+    p === 'newapi'
+  )
 }
 
 export function platformBadgeClass(p: string): string {
@@ -160,6 +182,7 @@ export function platformLabel(p: string): string {
     case 'openai': return 'OpenAI'
     case 'antigravity': return 'Antigravity'
     case 'gemini': return 'Gemini'
+    case 'newapi': return 'New API'
     default: return p || 'API'
   }
 }

--- a/frontend/src/views/HomeView.vue
+++ b/frontend/src/views/HomeView.vue
@@ -353,6 +353,21 @@
               >{{ t('home.providers.supported') }}</span
             >
           </div>
+          <!-- New API - Supported (fifth platform aggregating 200+ upstream channels via channel_type) -->
+          <div
+            class="flex items-center gap-2 rounded-xl border border-primary-200 bg-white/60 px-5 py-3 ring-1 ring-primary-500/20 backdrop-blur-sm dark:border-primary-800 dark:bg-dark-800/60"
+          >
+            <div
+              class="flex h-8 w-8 items-center justify-center rounded-lg bg-gradient-to-br from-cyan-500 to-cyan-600"
+            >
+              <span class="text-xs font-bold text-white">N</span>
+            </div>
+            <span class="text-sm font-medium text-gray-700 dark:text-dark-200">{{ t('home.providers.newapi') }}</span>
+            <span
+              class="rounded bg-primary-100 px-1.5 py-0.5 text-[10px] font-medium text-primary-600 dark:bg-primary-900/30 dark:text-primary-400"
+              >{{ t('home.providers.supported') }}</span
+            >
+          </div>
           <!-- More - Coming Soon -->
           <div
             class="flex items-center gap-2 rounded-xl border border-gray-200/50 bg-white/40 px-5 py-3 opacity-60 backdrop-blur-sm dark:border-dark-700/50 dark:bg-dark-800/40"

--- a/frontend/src/views/admin/ChannelsView.vue
+++ b/frontend/src/views/admin/ChannelsView.vue
@@ -590,12 +590,18 @@ import { useI18n } from 'vue-i18n'
 import { useAppStore } from '@/stores/app'
 import { extractApiErrorMessage } from '@/utils/apiError'
 import { adminAPI } from '@/api/admin'
-import type { Channel, ChannelModelPricing, CreateChannelRequest, UpdateChannelRequest, AccountStatsPricingRule } from '@/api/admin/channels'
+import type { Channel, CreateChannelRequest, UpdateChannelRequest, AccountStatsPricingRule } from '@/api/admin/channels'
 import type { PricingFormEntry } from '@/components/admin/channel/types'
 import { mTokToPerToken, perTokenToMTok, apiIntervalsToForm, formIntervalsToAPI, findModelConflict, validateIntervals } from '@/components/admin/channel/types'
 import type { AdminGroup, GroupPlatform } from '@/types'
 import type { Column } from '@/components/common/types'
 import { platformTextClass, platformBadgeLightClass } from '@/utils/platformColors'
+import { GATEWAY_PLATFORMS } from '@/constants/gatewayPlatforms'
+import {
+  apiToFormSections,
+  formSectionsToApi,
+  type PlatformSection,
+} from '@/utils/channelFormConversion'
 import AppLayout from '@/components/layout/AppLayout.vue'
 import TablePageLayout from '@/components/layout/TablePageLayout.vue'
 import DataTable from '@/components/common/DataTable.vue'
@@ -634,17 +640,7 @@ interface FormPricingRule {
   pricing: PricingFormEntry[]
 }
 
-// ── Platform Section type ──
-interface PlatformSection {
-  platform: GroupPlatform
-  enabled: boolean
-  collapsed: boolean
-  group_ids: number[]
-  model_mapping: Record<string, string>
-  model_pricing: PricingFormEntry[]
-  web_search_emulation: boolean
-  account_stats_pricing_rules: FormPricingRule[]
-}
+// PlatformSection type lives in @/utils/channelFormConversion (reused by tests).
 
 // ── Table columns ──
 const columns = computed<Column[]>(() => [
@@ -718,7 +714,10 @@ const form = reactive({
 let abortController: AbortController | null = null
 
 // ── Platform config ──
-const platformOrder: GroupPlatform[] = ['anthropic', 'openai', 'gemini', 'antigravity']
+// Single source of truth: GATEWAY_PLATFORMS includes the fifth platform `newapi`.
+// A previous 4-element hardcoded array silently dropped newapi data on the
+// API → form → API round-trip (see docs/approved/admin-ui-newapi-platform-end-to-end.md §1.5).
+const platformOrder: readonly GroupPlatform[] = GATEWAY_PLATFORMS
 
 // ── Helpers ──
 function formatDate(value: string): string {
@@ -995,120 +994,16 @@ function accountStatsRulesToAPI(): AccountStatsPricingRule[] {
 }
 
 // ── Form ↔ API conversion ──
-function formToAPI(): { group_ids: number[], model_pricing: ChannelModelPricing[], model_mapping: Record<string, Record<string, string>>, features_config: Record<string, unknown> } {
-  const group_ids: number[] = []
-  const model_pricing: ChannelModelPricing[] = []
-  const model_mapping: Record<string, Record<string, string>> = {}
-  // Preserve existing features_config fields not managed by the form
-  const featuresConfig: Record<string, unknown> = editingChannel.value?.features_config
-    ? { ...editingChannel.value.features_config }
-    : {}
-
-  for (const section of form.platforms) {
-    if (!section.enabled) continue
-    group_ids.push(...section.group_ids)
-
-    // Model mapping per platform
-    if (Object.keys(section.model_mapping).length > 0) {
-      model_mapping[section.platform] = { ...section.model_mapping }
-    }
-
-    // Model pricing with platform tag
-    for (const entry of section.model_pricing) {
-      if (entry.models.length === 0) continue
-      model_pricing.push({
-        platform: section.platform,
-        models: entry.models,
-        billing_mode: entry.billing_mode,
-        input_price: mTokToPerToken(entry.input_price),
-        output_price: mTokToPerToken(entry.output_price),
-        cache_write_price: mTokToPerToken(entry.cache_write_price),
-        cache_read_price: mTokToPerToken(entry.cache_read_price),
-        image_output_price: mTokToPerToken(entry.image_output_price),
-        per_request_price: entry.per_request_price != null && entry.per_request_price !== '' ? Number(entry.per_request_price) : null,
-        intervals: formIntervalsToAPI(entry.intervals || [])
-      })
-    }
-  }
-
-  // Collect web_search_emulation (only anthropic platform supports it)
-  // Always write the key so that disabling in the UI correctly sets platform to false,
-  // rather than leaving a stale true value from the cloned features_config.
-  const wsEmulation: Record<string, boolean> = {}
-  for (const section of form.platforms) {
-    if (!section.enabled) continue
-    if (section.platform === 'anthropic') {
-      wsEmulation[section.platform] = !!section.web_search_emulation
-    }
-  }
-  if (Object.keys(wsEmulation).length > 0) {
-    featuresConfig.web_search_emulation = wsEmulation
-  } else {
-    delete featuresConfig.web_search_emulation
-  }
-
-  return { group_ids, model_pricing, model_mapping, features_config: featuresConfig }
+// Pure converters live in @/utils/channelFormConversion so the round-trip can
+// be exercised by unit tests without mounting the view. Driving the canonical
+// platform order from GATEWAY_PLATFORMS (instead of a 4-element local array)
+// preserves `newapi` data through the round-trip.
+function formToAPI() {
+  return formSectionsToApi(form.platforms, editingChannel.value?.features_config)
 }
 
 function apiToForm(channel: Channel): PlatformSection[] {
-  // Build a map: groupID → platform
-  const groupPlatformMap = new Map<number, GroupPlatform>()
-  for (const g of allGroups.value) {
-    groupPlatformMap.set(g.id, g.platform)
-  }
-
-  // Determine which platforms are active (from groups + pricing + mapping)
-  const activePlatforms = new Set<GroupPlatform>()
-  for (const gid of channel.group_ids || []) {
-    const p = groupPlatformMap.get(gid)
-    if (p) activePlatforms.add(p)
-  }
-  for (const p of channel.model_pricing || []) {
-    if (p.platform) activePlatforms.add(p.platform as GroupPlatform)
-  }
-  for (const p of Object.keys(channel.model_mapping || {})) {
-    if (platformOrder.includes(p as GroupPlatform)) activePlatforms.add(p as GroupPlatform)
-  }
-
-  // Build sections in platform order
-  const sections: PlatformSection[] = []
-  for (const platform of platformOrder) {
-    if (!activePlatforms.has(platform)) continue
-
-    const groupIds = (channel.group_ids || []).filter(gid => groupPlatformMap.get(gid) === platform)
-    const mapping = (channel.model_mapping || {})[platform] || {}
-    const pricing = (channel.model_pricing || [])
-      .filter(p => (p.platform || 'anthropic') === platform)
-      .map(p => ({
-        models: p.models || [],
-        billing_mode: p.billing_mode,
-        input_price: perTokenToMTok(p.input_price),
-        output_price: perTokenToMTok(p.output_price),
-        cache_write_price: perTokenToMTok(p.cache_write_price),
-        cache_read_price: perTokenToMTok(p.cache_read_price),
-        image_output_price: perTokenToMTok(p.image_output_price),
-        per_request_price: p.per_request_price,
-        intervals: apiIntervalsToForm(p.intervals || [])
-      } as PricingFormEntry))
-
-    // Read web_search_emulation from features_config
-    const fc = channel.features_config
-    const wsEmulation = fc?.web_search_emulation as Record<string, boolean> | undefined
-    const webSearchEnabled = wsEmulation?.[platform] === true
-
-    sections.push({
-      platform,
-      enabled: true,
-      collapsed: false,
-      group_ids: groupIds,
-      model_mapping: { ...mapping },
-      model_pricing: pricing,
-      web_search_emulation: webSearchEnabled,
-      account_stats_pricing_rules: [],
-    })
-  }
-
-  return sections
+  return apiToFormSections(channel, allGroups.value, platformOrder)
 }
 
 // ── Load data ──

--- a/frontend/src/views/admin/GroupsView.vue
+++ b/frontend/src/views/admin/GroupsView.vue
@@ -2814,8 +2814,10 @@ const exclusiveOptions = computed(() => [
 // Platform options derived from canonical GATEWAY_PLATFORMS via usePlatformOptions
 // composable. Adding a 6th platform later requires touching only that composable;
 // this view (and every other admin picker) auto-picks it up. See US-017.
+// Pass `() => t(...)` (not the resolved string) so the "all platforms" sentinel
+// stays reactive on language switch.
 const { options: platformOptions, optionsWithAll } = usePlatformOptions();
-const platformFilterOptions = optionsWithAll(t("admin.groups.allPlatforms"));
+const platformFilterOptions = optionsWithAll(() => t("admin.groups.allPlatforms"));
 
 const editStatusOptions = computed(() => [
   { value: "active", label: t("admin.accounts.status.active") },

--- a/frontend/src/views/admin/GroupsView.vue
+++ b/frontend/src/views/admin/GroupsView.vue
@@ -2660,9 +2660,11 @@
                       ? 'bg-orange-100 text-orange-700 dark:bg-orange-900/30 dark:text-orange-400'
                       : group.platform === 'openai'
                         ? 'bg-emerald-100 text-emerald-700 dark:bg-emerald-900/30 dark:text-emerald-400'
-                        : group.platform === 'antigravity'
-                          ? 'bg-purple-100 text-purple-700 dark:bg-purple-900/30 dark:text-purple-400'
-                          : 'bg-blue-100 text-blue-700 dark:bg-blue-900/30 dark:text-blue-400',
+                        : group.platform === 'newapi'
+                          ? 'bg-cyan-100 text-cyan-700 dark:bg-cyan-900/30 dark:text-cyan-300'
+                          : group.platform === 'antigravity'
+                            ? 'bg-purple-100 text-purple-700 dark:bg-purple-900/30 dark:text-purple-400'
+                            : 'bg-blue-100 text-blue-700 dark:bg-blue-900/30 dark:text-blue-400',
                   ]"
                 >
                   {{ t("admin.groups.platforms." + group.platform) }}
@@ -3528,7 +3530,7 @@ const handleCreateGroup = async () => {
         createModelRoutingRules.value,
       ),
       messages_dispatch_model_config:
-        createForm.platform === "openai"
+        isOpenAICompatPlatform(createForm.platform)
           ? messagesDispatchFormStateToConfig({
               allow_messages_dispatch: createForm.allow_messages_dispatch,
               opus_mapped_model: createForm.opus_mapped_model,
@@ -3653,7 +3655,7 @@ const handleUpdateGroup = async () => {
         editModelRoutingRules.value,
       ),
       messages_dispatch_model_config:
-        editForm.platform === "openai"
+        isOpenAICompatPlatform(editForm.platform)
           ? messagesDispatchFormStateToConfig({
               allow_messages_dispatch: editForm.allow_messages_dispatch,
               opus_mapped_model: editForm.opus_mapped_model,

--- a/frontend/src/views/admin/GroupsView.vue
+++ b/frontend/src/views/admin/GroupsView.vue
@@ -2748,6 +2748,7 @@ import { VueDraggable } from "vue-draggable-plus";
 import { createStableObjectKeyResolver } from "@/utils/stableObjectKey";
 import { useKeyedDebouncedSearch } from "@/composables/useKeyedDebouncedSearch";
 import { getPersistedPageSize } from "@/composables/usePersistedPageSize";
+import { usePlatformOptions } from "@/composables/usePlatformOptions";
 import {
   createDefaultMessagesDispatchFormState,
   messagesDispatchConfigToFormState,
@@ -2810,20 +2811,11 @@ const exclusiveOptions = computed(() => [
   { value: "false", label: t("admin.groups.nonExclusive") },
 ]);
 
-const platformOptions = computed(() => [
-  { value: "anthropic", label: "Anthropic" },
-  { value: "openai", label: "OpenAI" },
-  { value: "gemini", label: "Gemini" },
-  { value: "antigravity", label: "Antigravity" },
-]);
-
-const platformFilterOptions = computed(() => [
-  { value: "", label: t("admin.groups.allPlatforms") },
-  { value: "anthropic", label: "Anthropic" },
-  { value: "openai", label: "OpenAI" },
-  { value: "gemini", label: "Gemini" },
-  { value: "antigravity", label: "Antigravity" },
-]);
+// Platform options derived from canonical GATEWAY_PLATFORMS via usePlatformOptions
+// composable. Adding a 6th platform later requires touching only that composable;
+// this view (and every other admin picker) auto-picks it up. See US-017.
+const { options: platformOptions, optionsWithAll } = usePlatformOptions();
+const platformFilterOptions = optionsWithAll(t("admin.groups.allPlatforms"));
 
 const editStatusOptions = computed(() => [
   { value: "active", label: t("admin.accounts.status.active") },

--- a/frontend/src/views/admin/GroupsView.vue
+++ b/frontend/src/views/admin/GroupsView.vue
@@ -888,9 +888,9 @@
           </div>
         </div>
 
-        <!-- OpenAI Messages 调度配置（仅 openai 平台） -->
+        <!-- Messages 调度配置（OpenAI-compat 平台：openai / newapi） -->
         <div
-          v-if="createForm.platform === 'openai'"
+          v-if="isOpenAICompatPlatform(createForm.platform)"
           class="border-t border-gray-200 dark:border-dark-400 pt-4 mt-4"
         >
           <h4 class="text-sm font-medium text-gray-700 dark:text-gray-300 mb-3">
@@ -1115,10 +1115,10 @@
           </div>
         </div>
 
-        <!-- 账号过滤控制 (OpenAI/Antigravity/Anthropic/Gemini) -->
+        <!-- 账号过滤控制 (OpenAI/Antigravity/Anthropic/Gemini/NewAPI) -->
         <div
           v-if="
-            ['openai', 'antigravity', 'anthropic', 'gemini'].includes(
+            ['openai', 'antigravity', 'anthropic', 'gemini', 'newapi'].includes(
               createForm.platform,
             )
           "
@@ -1128,8 +1128,8 @@
             账号过滤控制
           </h4>
 
-          <!-- require_oauth_only toggle -->
-          <div class="flex items-center justify-between">
+          <!-- require_oauth_only toggle (newapi 账号始终是 API Key 形态，隐藏) -->
+          <div v-if="createForm.platform !== 'newapi'" class="flex items-center justify-between">
             <div>
               <label class="text-sm text-gray-600 dark:text-gray-400"
                 >仅允许 OAuth 账号</label
@@ -1165,8 +1165,8 @@
             </button>
           </div>
 
-          <!-- require_privacy_set toggle -->
-          <div class="flex items-center justify-between">
+          <!-- require_privacy_set toggle (newapi 账号无 OAuth privacy 字段，隐藏) -->
+          <div v-if="createForm.platform !== 'newapi'" class="flex items-center justify-between">
             <div>
               <label class="text-sm text-gray-600 dark:text-gray-400"
                 >仅允许隐私保护已设置的账号</label
@@ -2023,9 +2023,9 @@
           </div>
         </div>
 
-        <!-- OpenAI Messages 调度配置（仅 openai 平台） -->
+        <!-- Messages 调度配置（OpenAI-compat 平台：openai / newapi） -->
         <div
-          v-if="editForm.platform === 'openai'"
+          v-if="isOpenAICompatPlatform(editForm.platform)"
           class="border-t border-gray-200 dark:border-dark-400 pt-4 mt-4"
         >
           <h4 class="text-sm font-medium text-gray-700 dark:text-gray-300 mb-3">
@@ -2250,10 +2250,10 @@
           </div>
         </div>
 
-        <!-- 账号过滤控制 (OpenAI/Antigravity/Anthropic/Gemini) -->
+        <!-- 账号过滤控制 (OpenAI/Antigravity/Anthropic/Gemini/NewAPI) -->
         <div
           v-if="
-            ['openai', 'antigravity', 'anthropic', 'gemini'].includes(
+            ['openai', 'antigravity', 'anthropic', 'gemini', 'newapi'].includes(
               editForm.platform,
             )
           "
@@ -2263,8 +2263,8 @@
             账号过滤控制
           </h4>
 
-          <!-- require_oauth_only toggle -->
-          <div class="flex items-center justify-between">
+          <!-- require_oauth_only toggle (newapi 账号始终是 API Key 形态，隐藏) -->
+          <div v-if="editForm.platform !== 'newapi'" class="flex items-center justify-between">
             <div>
               <label class="text-sm text-gray-600 dark:text-gray-400"
                 >仅允许 OAuth 账号</label
@@ -2300,8 +2300,8 @@
             </button>
           </div>
 
-          <!-- require_privacy_set toggle -->
-          <div class="flex items-center justify-between">
+          <!-- require_privacy_set toggle (newapi 账号无 OAuth privacy 字段，隐藏) -->
+          <div v-if="editForm.platform !== 'newapi'" class="flex items-center justify-between">
             <div>
               <label class="text-sm text-gray-600 dark:text-gray-400"
                 >仅允许隐私保护已设置的账号</label
@@ -2749,6 +2749,7 @@ import { createStableObjectKeyResolver } from "@/utils/stableObjectKey";
 import { useKeyedDebouncedSearch } from "@/composables/useKeyedDebouncedSearch";
 import { getPersistedPageSize } from "@/composables/usePersistedPageSize";
 import { usePlatformOptions } from "@/composables/usePlatformOptions";
+import { isOpenAICompatPlatform } from "@/constants/gatewayPlatforms";
 import {
   createDefaultMessagesDispatchFormState,
   messagesDispatchConfigToFormState,
@@ -3749,10 +3750,13 @@ watch(
     if (!["anthropic", "antigravity"].includes(newVal)) {
       createForm.fallback_group_id_on_invalid_request = null;
     }
-    if (newVal !== "openai") {
+    if (!isOpenAICompatPlatform(newVal)) {
       resetMessagesDispatchFormState(createForm);
     }
     if (!["openai", "antigravity", "anthropic", "gemini"].includes(newVal)) {
+      // require_oauth_only / require_privacy_set are OAuth-credential semantics;
+      // newapi accounts are always API-key-shaped so the toggles are meaningless
+      // there — falling through to the reset path keeps the values cleared.
       createForm.require_oauth_only = false;
       createForm.require_privacy_set = false;
     }
@@ -3765,7 +3769,7 @@ watch(
     if (!["anthropic", "antigravity"].includes(newVal)) {
       editForm.fallback_group_id_on_invalid_request = null;
     }
-    if (newVal !== "openai") {
+    if (!isOpenAICompatPlatform(newVal)) {
       resetMessagesDispatchFormState(editForm);
     }
     if (!["openai", "antigravity", "anthropic", "gemini"].includes(newVal)) {
@@ -3781,7 +3785,7 @@ watch(
     if (!['anthropic', 'antigravity'].includes(newVal)) {
       editForm.fallback_group_id_on_invalid_request = null
     }
-    if (newVal !== 'openai') {
+    if (!isOpenAICompatPlatform(newVal)) {
       editForm.allow_messages_dispatch = false
       editForm.default_mapped_model = ''
     }

--- a/frontend/src/views/admin/ops/components/OpsDashboardHeader.vue
+++ b/frontend/src/views/admin/ops/components/OpsDashboardHeader.vue
@@ -2,6 +2,7 @@
 import { computed, onMounted, ref, watch } from 'vue'
 import { useI18n } from 'vue-i18n'
 import Select from '@/components/common/Select.vue'
+import { usePlatformOptions } from '@/composables/usePlatformOptions'
 import HelpTooltip from '@/components/common/HelpTooltip.vue'
 import BaseDialog from '@/components/common/BaseDialog.vue'
 import Icon from '@/components/icons/Icon.vue'
@@ -106,13 +107,11 @@ function formatCustomTimeRangeLabel(startTime: string, endTime: string): string 
 
 const groups = ref<Array<{ id: number; name: string; platform: string }>>([])
 
-const platformOptions = computed(() => [
-  { value: '', label: t('common.all') },
-  { value: 'openai', label: 'OpenAI' },
-  { value: 'anthropic', label: 'Anthropic' },
-  { value: 'gemini', label: 'Gemini' },
-  { value: 'antigravity', label: 'Antigravity' }
-])
+// Ops dashboard platform filter — driven by the canonical composable so any
+// new platform (e.g. `newapi`, the fifth platform) appears here without a
+// dedicated edit. Getter form keeps the "All" label reactive on locale change.
+const { optionsWithAll: platformOptionsWithAll } = usePlatformOptions()
+const platformOptions = platformOptionsWithAll(() => t('common.all'))
 
 const timeRangeOptions = computed(() => [
   { value: '5m', label: t('admin.ops.timeRange.5m') },

--- a/frontend/src/views/user/KeysView.vue
+++ b/frontend/src/views/user/KeysView.vue
@@ -1719,6 +1719,11 @@ const executeCcsImport = (row: ApiKey, clientType: 'claude' | 'gemini') => {
   } else {
     switch (platform) {
       case 'openai':
+      case 'newapi':
+        // newapi shares the OpenAI-compatible HTTP shape, so the codex
+        // CLI is the correct CCSwitch app target. Previously this fell
+        // through to default (claude) which would silently fail with
+        // wrong protocol and wrong endpoint base.
         app = 'codex'
         endpoint = baseUrl
         break

--- a/frontend/src/views/user/SubscriptionsView.vue
+++ b/frontend/src/views/user/SubscriptionsView.vue
@@ -263,6 +263,7 @@ function platformAccentDotClass(p: string): string {
     case 'openai': return 'bg-emerald-500'
     case 'antigravity': return 'bg-purple-500'
     case 'gemini': return 'bg-blue-500'
+    case 'newapi': return 'bg-cyan-500'
     default: return 'bg-gray-400'
   }
 }


### PR DESCRIPTION
## Why

`docs/approved/newapi-as-fifth-platform.md` (shipped v1.4.0) explicitly **deferred** admin-UI integration: backend, scheduler, sticky routing, error passthrough, and the New API bridge all treat `newapi` as a first-class fifth platform — but the admin UI never exposed it. Operators cannot create newapi groups or accounts through the UI; the only workaround today is hand-crafting admin API calls.

A tester reported the 创建分组 modal lacks the fifth platform option. This PR is the **prototype** stage (per `product-dev.mdc`): minimal runnable path that closes the end-to-end gap, with a written design at `docs/approved/admin-ui-newapi-platform-end-to-end.md` (`status: pending`) for human review.

## What changed (prototype scope)

| Area | Change | Why |
| --- | --- | --- |
| `frontend/src/composables/usePlatformOptions.ts` (new) | Single source of truth derived from canonical `GATEWAY_PLATFORMS`. Exposes `options` + `optionsWithAll(allLabel)` for filter use cases. | Adding a 6th platform later requires touching only this composable + the `AccountPlatform` union. |
| `frontend/src/views/admin/GroupsView.vue` | Replaced 2 hardcoded 4-platform lists (`platformOptions`, `platformFilterOptions`) with composable consumers. | Was the immediate bug surface. |
| `frontend/src/components/account/CreateAccountModal.vue` | Added 5th "New API" segmented-control button (cyan, server icon); wires the existing-but-never-mounted `AccountNewApiPlatformFields` component; loads channel-type catalog from `GET /admin/channel-types`; sends top-level `channel_type` (admin_service.go:1565 hard-requires `> 0` for newapi); bypasses `isOAuthFlow` (newapi is apikey-only). | Operator can now create newapi accounts from the UI. |
| `frontend/src/components/common/PlatformTypeBadge.vue` | Switched to explicit per-platform map; added `newapi` (cyan) arm; **fixed historical default** that mislabeled every unknown platform as "Gemini" with blue styling. Unknowns now fall back to neutral gray. | Prevents silent regression: pre-fix, newapi accounts rendered as "Gemini" in the list. |
| `frontend/src/types/index.ts` | `CreateAccountRequest.channel_type?: number` (top-level). | Required by backend for newapi platform; existing 4 platforms ignore it. |
| `frontend/src/i18n/locales/{en,zh}.ts` | Added `admin.accounts.newApiPlatform.*` keys (channelType, baseUrl, apiKey, etc.). | The unused `AccountNewApiPlatformFields` component referenced these keys but they were never defined. |
| `.testing/user-stories/stories/US-016-*.md` (new) + index | Risk Focus + 5 ACs + Linked Tests. | Story ↔ Test alignment per `test-philosophy.mdc`. |
| `docs/approved/admin-ui-newapi-platform-end-to-end.md` (new, `status: pending`) | Full design (data model, file changes, deferred items, risk analysis, AC). | Approval gate per `product-dev.mdc` — merge = approval. |

## Verification

```
cd frontend
pnpm typecheck    # PASS
pnpm lint:check   # PASS
pnpm test:run usePlatformOptions PlatformTypeBadge
# Test Files  2 passed (2)
# Tests       10 passed (10)
```

`./scripts/preflight.sh` — PASS (all 8 dev-rules sections + § 9 sub2api newapi compat-pool drift).

**Pre-existing baseline failures** in 17 other vitest spec files (`localStorage.clear is not a function`) are unrelated environment breakage on `origin/main` — verified by `git stash && pnpm test:run formatCompactNumber` reproducing the same failure without these changes.

## Manual smoke-test plan (post-merge of prototype, before stage-3 sign-off)

1. Open Admin → Groups → Create Group → platform dropdown shows 5 entries with "New API" 5th. ✅
2. Filter the group list by "New API" → only newapi groups render (or empty + correct empty state). ✅
3. Open Admin → Accounts → Create Account → 5 segmented-control buttons; click "New API" → channel-type dropdown loads from `/admin/channel-types`, base_url prefills when a type is picked, api_key field accepts input. ✅
4. Submit → POST `/admin/accounts` payload includes top-level `channel_type` and `platform: "newapi"`, `type: "apikey"`; backend returns 201; new account renders in the list with **"New API"** badge in cyan (NOT "Gemini" in blue). ✅
5. The 4 existing platform flows (anthropic OAuth, openai oauth/apikey, gemini OAuth/apikey, antigravity oauth/upstream) continue to work — no behavioral regression.

## Out of scope (deferred to stage-3 / future PR)

- `GroupsView.vue` account-pickers panel (when an admin opens a newapi group's "Accounts" sub-tab).
- `EditAccountModal.vue` newapi branch — only `CreateAccountModal.vue` is wired in this prototype.
- `ChannelTypeBadge.vue` mapping for newapi accounts.
- Cross-validation: enforcing that `account.channel_type` matches `group.platform === 'newapi'` at the UI layer (backend already enforces this).
- `EditGroupModal` platform switch guard (preventing platform change when accounts are bound).

See `docs/approved/admin-ui-newapi-platform-end-to-end.md` §6 for the full deferred list and rationale.

## Approval gate

Per `product-dev.mdc`, this prototype **pauses for human approval before stage-3 functional implementation**. Reviewer should:

1. Edit `docs/approved/admin-ui-newapi-platform-end-to-end.md` directly to flip `approved_by: pending` → reviewer name (or request changes inline).
2. Merge = approval = the design becomes the symbolic baseline for stage-3 implementation.


Made with [Cursor](https://cursor.com)