### PR TITLE
fix(turnstile): make siteverify failures self-diagnosable in 30 seconds

### DIFF
--- a/.testing/user-stories/index.md
+++ b/.testing/user-stories/index.md
@@ -19,3 +19,4 @@
 | US-014 | newapi group 配置 messages_dispatch_model_config 持久化 | InTest | `.testing/user-stories/stories/US-014-newapi-group-messages-dispatch-config.md` |
 | US-015 | 历史 openai group 行为完全不变（回归基线） | InTest | `.testing/user-stories/stories/US-015-openai-group-regression-baseline.md` |
 | US-016 | SMTP EHLO host 从 From/Username 推导（修 Google Workspace `auth: EOF`） | Done   | `.testing/user-stories/stories/US-016-smtp-ehlo-host-from-config.md` |
+| US-017 | Turnstile siteverify 失败可观测 + UX 自救引导 | InTest | `.testing/user-stories/stories/US-017-turnstile-observability-and-stale-tab-ux.md` |

--- a/.testing/user-stories/stories/US-017-turnstile-observability-and-stale-tab-ux.md
+++ b/.testing/user-stories/stories/US-017-turnstile-observability-and-stale-tab-ux.md
@@ -1,0 +1,83 @@
+# US-017-turnstile-observability-and-stale-tab-ux
+
+- ID: US-017
+- Title: Turnstile siteverify 失败可观测 + 全部登录态入口 stale-tab UX 自救引导
+- Version: V1.0（Hotfix）
+- Priority: P0
+- As a / I want / So that:
+  作为 **运维 / on-call 工程师**，我希望 Turnstile 失败时一条结构化日志就能定位根因
+  （token 是否到达后端、CF 端口是否健康、CF 拒绝原因是什么），以便在用户报告
+  "登录验证失败" 时能在 30 秒内判断是「stale tab」「CF 限流」还是「真实攻击」，
+  而不是像 2026-04-20 那样要远程抓 token 反推。
+
+  作为 **终端用户**，我希望在最常见的 stale-tab 场景下被明确告知「请刷新页面」，
+  而不是看见无操作建议的「Verification failed」原地循环。
+
+- Trace:
+  - 系统事件：Cloudflare siteverify 失败（403/429/5xx/200+success=false）
+  - 防御需求：日志泄漏 token → 一次性凭证被复用风险（详见 §AC-002）
+  - 角色 × 能力：所有匿名用户 × 4 个登录态入口（login / register / forgot-password / email-verify）
+
+- Risk Focus:
+  - **逻辑错误**：repository 层 `*response` 在 JSON 解析失败时丢失 HTTPStatusCode → 上层日志退化为「无上下文 decode error」（已发生过，2026-04-20）
+  - **安全问题**：日志记录 token 时不能完整暴露——CF token 是一次性凭证，泄漏即可被滥用一次。约束：prefix+suffix 必须隐藏中段 ≥4 字节
+  - **行为回归**：`url.Values.Encode()` 改写 token 字节会被 CF 误判为 invalid-input-response（曾被怀疑过的根因，需永久钉死）
+  - **运行时问题**：CF edge 偶发返回 502 HTML（非 JSON）必须仍带 status/latency 给上层做根因分类
+  - **UX 漂移**：4 个入口 view 各自手写 catch 分支 → 出现一个改 4 处的漂移源（这次就发生了）；本 PR 收敛到 `buildAuthErrorMessage(reasonOverrides)` 单点
+
+## Acceptance Criteria
+
+1. **AC-001（正向 / 后端可观测）**：Given Turnstile 启用且 secret 已配置，When CF 返回 `success=false`，Then service 层输出一条 `warn` 级别的结构化日志，message=`[Turnstile] siteverify returned success=false`，**必须**含全部字段：`component / remote_ip / token_len / token_prefix / token_suffix / http_status / latency_ms / cf_hostname / cf_action / cf_cdata / cf_challenge_ts / cf_error_codes`。
+
+2. **AC-002（负向 / 安全 — token 摘要不泄漏）**：Given 任意长度 ≥20 字节的 token，When 调 `summarizeToken(token)`，Then `len(prefix)+len(suffix) ≤ len(token)-4`（中段至少藏 4 字节）；且 `prefix+suffix ≠ token` 任何拼接序列。
+
+3. **AC-003（负向 / 运行时 — repository 契约不退化）**：Given Cloudflare edge 返回非 JSON 的 502 HTML，When `repository.VerifyToken` 解析失败，Then 必须返回 `(*response, err)` 的二元组（`response != nil`），其中 `response.HTTPStatusCode == 502` + `response.LatencyMs >= 0`。`response == nil` 仅保留给「网络层失败（拨号/TLS）」一种场景。
+
+4. **AC-004（负向 / 行为回归 — token 字节保真）**：Given 含 `+/=._-:&?` 等 URL 特殊字符的 token，When 经 `url.Values.Encode()` 编码后被 CF siteverify 接收，Then 服务端解析出来的 `response` 字段必须与原 token 逐字节一致。
+
+5. **AC-005（正向 / 前端 UX）**：Given 4 个 auth 入口（login / register / forgot-password / email-verify）任一，When 后端返回 `reason === 'TURNSTILE_VERIFICATION_FAILED'`，Then 用户看到的 `errorMessage` 是 `auth.turnstileFailedRefresh` 文案（"请刷新页面后重试"），**而不是** detail/message 原文或通用 fallback。
+
+6. **AC-006（负向 / UX — reasonOverrides 不越权）**：Given 后端返回 `reason === 'INVALID_CREDENTIALS'`，When `buildAuthErrorMessage` 的 `reasonOverrides` 只覆盖 `TURNSTILE_VERIFICATION_FAILED`，Then 必须落回 `response.data.detail`（即用户看到「密码错误」而不是「请刷新页面」）。
+
+7. **AC-007（回归保护）**：Given 代码变更，When 执行 `TestUS017_*` 全部测试 + `authError.spec.ts`，Then 全部通过。
+
+## Assertions
+
+- 后端结构化日志：使用 `zaptest`/captureSink 抓取，断言 `failureEvent.Fields[k]` 对每个必填字段存在且类型正确（特别地 `cf_error_codes` 在 `MapObjectEncoder` 下编码为 `[]interface{}`，已 probe 验证；类型变化必须 fail 而非 fallback）
+- 安全约束：`require.LessOrEqual(t, len(pre)+len(suf), tc.wantLen-4)` 钉死隐藏字节数
+- repository 契约：`require.NotNil(t, resp)` + `require.Equal(t, http.StatusBadGateway, resp.HTTPStatusCode)` 同时满足
+- byte-preservation：服务端 handler 内部 `require.Equal(t, trickyToken, values.Get("response"))`
+- 前端 reasonOverrides：`expect(message).toBe('Stale verification token — refresh and try again')` 且非命中场景 `expect(message).toBe('wrong password')`
+
+## Linked Tests
+
+- `backend/internal/service/turnstile_observability_test.go`::`TestSummarizeToken_NeverLeaksFullToken`
+- `backend/internal/service/turnstile_observability_test.go`::`TestVerifyToken_FailureLogContainsAllDiagnosticFields`
+- `backend/internal/service/turnstile_observability_test.go`::`TestVerifyToken_EmptyTokenLogsExplicitly`
+- `backend/internal/repository/turnstile_service_test.go`::`TestTurnstileServiceSuite/TestVerifyToken_PopulatesHTTPStatusAndLatency`
+- `backend/internal/repository/turnstile_service_test.go`::`TestTurnstileServiceSuite/TestVerifyToken_NonOKStatusStillReturnsResponse`
+- `backend/internal/repository/turnstile_service_test.go`::`TestTurnstileServiceSuite/TestVerifyToken_NonJSONResponseStillCarriesStatus`
+- `backend/internal/repository/turnstile_service_test.go`::`TestTurnstileServiceSuite/TestVerifyToken_BytePreservationOfTrickyChars`
+- `frontend/src/utils/__tests__/authError.spec.ts`::`reasonOverrides wins over response.data.detail when reason matches`
+- `frontend/src/utils/__tests__/authError.spec.ts`::`reasonOverrides only applies when reason is in the override map`
+- `frontend/src/utils/__tests__/authError.spec.ts`::`reasonOverrides reads reason from response.data.reason when top-level missing`
+
+运行命令：
+
+```bash
+# 后端（unit + 默认）
+cd backend && go test -tags=unit -v -run 'TestSummarizeToken_NeverLeaksFullToken|TestVerifyToken_FailureLogContainsAllDiagnosticFields|TestVerifyToken_EmptyTokenLogsExplicitly' ./internal/service/...
+cd backend && go test -v -run 'TestTurnstileServiceSuite' ./internal/repository/...
+
+# 前端
+cd frontend && pnpm vitest run src/utils/__tests__/authError.spec.ts
+```
+
+## Evidence
+
+- PR：https://github.com/youxuanxue/sub2api/pull/20
+- 故障复盘根因：2026-04-20 prod-hotfix 调试链路（远程 SSM + CF dashboard 排查后确认为 stale browser tab → 自愈，但耗时数小时）
+
+## Status
+
+- [x] InTest（待 CI 全绿后翻 Done）

--- a/backend/internal/repository/turnstile_service.go
+++ b/backend/internal/repository/turnstile_service.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"encoding/json"
 	"fmt"
+	"io"
 	"net/http"
 	"net/url"
 	"strings"
@@ -13,7 +14,12 @@ import (
 	"github.com/Wei-Shaw/sub2api/internal/service"
 )
 
-const turnstileVerifyURL = "https://challenges.cloudflare.com/turnstile/v0/siteverify"
+const (
+	turnstileVerifyURL = "https://challenges.cloudflare.com/turnstile/v0/siteverify"
+	// 16 KiB 上限：正常 siteverify 响应 <1 KiB；超过此上限说明对端不是 Cloudflare
+	// 或返回了异常 payload，截断保护避免 OOM。
+	turnstileMaxResponseBytes = 16 * 1024
+)
 
 type turnstileVerifier struct {
 	httpClient *http.Client
@@ -34,6 +40,19 @@ func NewTurnstileVerifier() service.TurnstileVerifier {
 	}
 }
 
+// VerifyToken 调用 Cloudflare siteverify v0 接口。
+//
+// 返回值约定（service.VerifyToken 的失败日志依赖这套约定，不要随意改动）：
+//   - HTTP 网络层失败（拨号超时、TLS 错误等）→ 返回 nil, err。
+//   - HTTP 收到响应（无论 2xx / 4xx / 5xx）：
+//     **始终返回非 nil 的 \*response**，其中 HTTPStatusCode + LatencyMs 已填充；
+//     err 是否为 nil 取决于响应体是否能被 JSON 解析。这样上层日志即便在
+//     「CF edge 返回 502 HTML」这种 JSON 解析失败的异常分支也能拿到 status/latency
+//     做根因分类，不至于像 2026-04-20 那样退化成「只有一个无上下文的 decode error」。
+//
+// 这样上层日志能清楚区分「Cloudflare 网络不通」「Cloudflare 限流（429/5xx）」
+// 「Cloudflare 拒绝 token（200 + success=false）」「CF edge 返回非 JSON」四种
+// 根本不同的故障域。
 func (v *turnstileVerifier) VerifyToken(ctx context.Context, secretKey, token, remoteIP string) (*service.TurnstileVerifyResponse, error) {
 	formData := url.Values{}
 	formData.Set("secret", secretKey)
@@ -48,16 +67,32 @@ func (v *turnstileVerifier) VerifyToken(ctx context.Context, secretKey, token, r
 	}
 	req.Header.Set("Content-Type", "application/x-www-form-urlencoded")
 
+	start := time.Now()
 	resp, err := v.httpClient.Do(req)
 	if err != nil {
 		return nil, fmt.Errorf("send request: %w", err)
 	}
 	defer func() { _ = resp.Body.Close() }()
+	latencyMs := time.Since(start).Milliseconds()
 
-	var result service.TurnstileVerifyResponse
-	if err := json.NewDecoder(resp.Body).Decode(&result); err != nil {
-		return nil, fmt.Errorf("decode response: %w", err)
+	body, err := io.ReadAll(io.LimitReader(resp.Body, turnstileMaxResponseBytes))
+	if err != nil {
+		return nil, fmt.Errorf("read response body (status=%d, latency_ms=%d): %w", resp.StatusCode, latencyMs, err)
 	}
+
+	// 关键不变量：先把 HTTP 元数据写入 result，再做 JSON 解析。这样即便解析失败，
+	// 调用方拿到的 *response 也带着 status/latency，能做出有意义的诊断。
+	result := service.TurnstileVerifyResponse{
+		HTTPStatusCode: resp.StatusCode,
+		LatencyMs:      latencyMs,
+	}
+	if err := json.Unmarshal(body, &result); err != nil {
+		return &result, fmt.Errorf("decode response (status=%d, body_len=%d): %w", resp.StatusCode, len(body), err)
+	}
+	// JSON 解析可能覆盖 HTTPStatusCode/LatencyMs（理论上不会，因为它们是 `json:"-"`），
+	// 防御性地再赋一次，钉死契约。
+	result.HTTPStatusCode = resp.StatusCode
+	result.LatencyMs = latencyMs
 
 	return &result, nil
 }

--- a/backend/internal/repository/turnstile_service_test.go
+++ b/backend/internal/repository/turnstile_service_test.go
@@ -116,8 +116,12 @@ func (s *TurnstileServiceSuite) TestVerifyToken_InvalidJSON() {
 		_, _ = io.WriteString(w, "not-valid-json")
 	}))
 
-	_, err := s.verifier.VerifyToken(s.ctx, "sk", "token", "1.1.1.1")
+	resp, err := s.verifier.VerifyToken(s.ctx, "sk", "token", "1.1.1.1")
 	require.Error(s.T(), err, "expected error for invalid JSON response")
+	// 契约：JSON 解析失败时仍返回非 nil 的 *response，并把 HTTPStatusCode 填上，
+	// 让上层日志能区分「CF edge 返回了非 JSON 的 502 HTML」与「拨号失败」两种故障域。
+	require.NotNil(s.T(), resp, "JSON decode failure must still return non-nil response with status populated")
+	require.Equal(s.T(), http.StatusOK, resp.HTTPStatusCode)
 }
 
 func (s *TurnstileServiceSuite) TestVerifyToken_SuccessFalse() {
@@ -138,4 +142,84 @@ func (s *TurnstileServiceSuite) TestVerifyToken_SuccessFalse() {
 
 func TestTurnstileServiceSuite(t *testing.T) {
 	suite.Run(t, new(TurnstileServiceSuite))
+}
+
+// TestVerifyToken_PopulatesHTTPStatusAndLatency 回归保护：HTTPStatusCode + LatencyMs
+// 必须在 200 路径上被填充（service.VerifyToken 失败日志依赖这两个字段做根因分类）。
+func (s *TurnstileServiceSuite) TestVerifyToken_PopulatesHTTPStatusAndLatency() {
+	s.setupTransport(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		_ = json.NewEncoder(w).Encode(service.TurnstileVerifyResponse{
+			Success:  true,
+			Hostname: "api.tokenkey.dev",
+			Action:   "login",
+		})
+	}))
+
+	resp, err := s.verifier.VerifyToken(s.ctx, "sk", "token", "1.1.1.1")
+	require.NoError(s.T(), err)
+	require.NotNil(s.T(), resp)
+	require.Equal(s.T(), 200, resp.HTTPStatusCode, "200 status must be populated")
+	require.GreaterOrEqual(s.T(), resp.LatencyMs, int64(0), "LatencyMs must be set")
+	require.Equal(s.T(), "api.tokenkey.dev", resp.Hostname)
+	require.Equal(s.T(), "login", resp.Action)
+}
+
+// TestVerifyToken_NonOKStatusStillReturnsResponse 回归保护：当 Cloudflare 返回非 2xx
+// （例如 429/502），仍要把 HTTPStatusCode 填充给上层日志，便于区分「Cloudflare 拒绝
+// token」（200 + success=false）与「Cloudflare 端不可用」（5xx）。
+func (s *TurnstileServiceSuite) TestVerifyToken_NonOKStatusStillReturnsResponse() {
+	s.setupTransport(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		w.WriteHeader(http.StatusBadGateway)
+		_ = json.NewEncoder(w).Encode(service.TurnstileVerifyResponse{Success: false})
+	}))
+
+	resp, err := s.verifier.VerifyToken(s.ctx, "sk", "token", "1.1.1.1")
+	require.NoError(s.T(), err, "non-2xx with valid JSON body should not return error")
+	require.NotNil(s.T(), resp)
+	require.Equal(s.T(), http.StatusBadGateway, resp.HTTPStatusCode)
+	require.False(s.T(), resp.Success)
+}
+
+// TestVerifyToken_BytePreservationOfTrickyChars 回归保护：Cloudflare token 是
+// base64 + URL 特殊字符（`+`, `/`, `=`, `.`, `-`, `_`, `:`）的混合体。曾经怀疑过
+// `url.Values.Encode()` 改写 token 字节是 invalid-input-response 的根因；该测试把
+// 这种可能性永久钉死。
+func (s *TurnstileServiceSuite) TestVerifyToken_BytePreservationOfTrickyChars() {
+	const trickyToken = "AbC.123_xyz-ABC+def/GHI=jkl:MNO~pqr&STU=vwx?YZ" +
+		"01234567890abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ" +
+		"+/=" // base64 padding chars sticking around at the end
+	s.setupTransport(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		body, _ := io.ReadAll(r.Body)
+		values, err := url.ParseQuery(string(body))
+		require.NoError(s.T(), err)
+		// 服务器收到的 response 字段必须与原 token 完全一致（包括所有 +/=）
+		require.Equal(s.T(), trickyToken, values.Get("response"),
+			"token bytes were mutated in transit through url.Values.Encode() — Cloudflare will reject it")
+		w.Header().Set("Content-Type", "application/json")
+		_ = json.NewEncoder(w).Encode(service.TurnstileVerifyResponse{Success: true})
+	}))
+
+	_, err := s.verifier.VerifyToken(s.ctx, "sk", trickyToken, "")
+	require.NoError(s.T(), err)
+}
+
+// TestVerifyToken_NonJSONResponseStillCarriesStatus 回归保护：CF edge 偶发返回
+// HTML 502（非 JSON）时，VerifyToken 必须返回 (非 nil response, err)，且 response
+// 带着 HTTPStatusCode + LatencyMs。否则 service 层日志会退化成「无上下文 decode error」，
+// 把 2026-04-20 的诊断噩梦拉回来。
+func (s *TurnstileServiceSuite) TestVerifyToken_NonJSONResponseStillCarriesStatus() {
+	s.setupTransport(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "text/html; charset=utf-8")
+		w.WriteHeader(http.StatusBadGateway)
+		_, _ = io.WriteString(w, "<html><body>502 Bad Gateway</body></html>")
+	}))
+
+	resp, err := s.verifier.VerifyToken(s.ctx, "sk", "token", "1.1.1.1")
+	require.Error(s.T(), err, "non-JSON body must surface a decode error")
+	require.NotNil(s.T(), resp, "response must be non-nil so caller can log status/latency")
+	require.Equal(s.T(), http.StatusBadGateway, resp.HTTPStatusCode)
+	require.GreaterOrEqual(s.T(), resp.LatencyMs, int64(0))
+	require.False(s.T(), resp.Success, "Success default zero value")
 }

--- a/backend/internal/service/turnstile_observability_test.go
+++ b/backend/internal/service/turnstile_observability_test.go
@@ -1,0 +1,192 @@
+//go:build unit
+
+package service
+
+import (
+	"context"
+	"strings"
+	"sync"
+	"testing"
+
+	"github.com/Wei-Shaw/sub2api/internal/config"
+	"github.com/Wei-Shaw/sub2api/internal/pkg/logger"
+	"github.com/stretchr/testify/require"
+)
+
+// captureSink 捕获 logger 包通过 sink 通道发出的全部事件，供测试做字段级断言。
+type captureSink struct {
+	mu     sync.Mutex
+	events []*logger.LogEvent
+}
+
+func (c *captureSink) WriteLogEvent(event *logger.LogEvent) {
+	c.mu.Lock()
+	defer c.mu.Unlock()
+	dup := *event
+	c.events = append(c.events, &dup)
+}
+
+func (c *captureSink) snapshot() []*logger.LogEvent {
+	c.mu.Lock()
+	defer c.mu.Unlock()
+	out := make([]*logger.LogEvent, len(c.events))
+	copy(out, c.events)
+	return out
+}
+
+// installCaptureSinkOnce 安装全局 capture sink 并在 t.Cleanup 中复位。
+//
+// 并发安全警告：`logger.SetSink` 是包级 atomic.Value（见 logger.go 中的
+// currentSink），多个测试同时持有 sink 会互相串台、cleanup 会抹掉别人的 sink。
+//
+//   - 调用本 helper 的测试**禁止** `t.Parallel()`。
+//   - 同一个 binary 里其它 sink 测试也必须是串行的。
+//
+// "Once" 仅指 logger.Init 幂等；sink 生命周期是按测试函数线性串起来的。
+func installCaptureSinkOnce(t *testing.T) *captureSink {
+	t.Helper()
+	require.NoError(t, logger.Init(logger.InitOptions{Level: "debug"}))
+	sink := &captureSink{}
+	logger.SetSink(sink)
+	t.Cleanup(func() { logger.SetSink(nil) })
+	return sink
+}
+
+func newTurnstileServiceForTest(verifier TurnstileVerifier) *TurnstileService {
+	cfg := &config.Config{
+		Server:    config.ServerConfig{Mode: "release"},
+		Turnstile: config.TurnstileConfig{Required: true},
+	}
+	settings := NewSettingService(&settingRepoStub{values: map[string]string{
+		SettingKeyTurnstileEnabled:   "true",
+		SettingKeyTurnstileSecretKey: "the-secret",
+	}}, cfg)
+	return NewTurnstileService(settings, verifier)
+}
+
+// realisticCFToken 模拟一个 ~300 字节、形态接近 Cloudflare Turnstile 真实 token
+// 的字符串：base64url 字符 + 几个 `.` 段分隔（CF token 在 wire 上长这个样子）。
+// 为可重现，用 strings.Repeat 拼成一段确定性的 18 字符 motif × 17 + 尾巴。
+var realisticCFToken = strings.Repeat("AbCdEf0123_-./+=Zz", 17) + ".endpad"
+
+// TestSummarizeToken_NeverLeaksFullToken 钉死 token 摘要的安全约束：完整 token
+// 永远不能出现在 prefix / suffix 任意一端。
+func TestSummarizeToken_NeverLeaksFullToken(t *testing.T) {
+	cases := []struct {
+		name    string
+		token   string
+		wantLen int
+		wantPre string
+		wantSuf string
+	}{
+		{"empty", "", 0, "", ""},
+		{"short_15", "abcdefghijklmno", 15, "abcdefgh", ""},
+		{"under_threshold_19", "abcdefghijklmnopqrs", 19, "abcdefgh", ""},
+		{"at_threshold_20", "abcdefghijklmnopqrst", 20, "abcdefghij", "opqrst"},
+		{
+			name:    "realistic_cf_token",
+			token:   realisticCFToken,
+			wantLen: len(realisticCFToken),
+			wantPre: realisticCFToken[:10],
+			wantSuf: realisticCFToken[len(realisticCFToken)-6:],
+		},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			length, pre, suf := summarizeToken(tc.token)
+			require.Equal(t, tc.wantLen, length)
+			require.Equal(t, tc.wantPre, pre)
+			require.Equal(t, tc.wantSuf, suf)
+			if tc.wantLen >= 20 {
+				// 安全约束 1：prefix+suffix 必须比完整 token 短至少 4 字节（中段
+				// ≥4 字节被隐藏），不能拼接出完整 token。
+				require.LessOrEqual(t, len(pre)+len(suf), tc.wantLen-4,
+					"summarizeToken must hide at least 4 bytes of the middle")
+				require.NotEqual(t, tc.token, pre+suf,
+					"summarizeToken must not concatenate to the full token")
+				// 安全约束 2：suffix 不能是 token 中比真实尾段更靠前的子串
+				// （即 suffix 必须确实来自 token 末尾，否则函数行为漂移到了
+				// 「暴露中段」上）。
+				require.True(t, strings.HasSuffix(tc.token, suf),
+					"summarizeToken suffix must come from the trailing bytes of token")
+				require.True(t, strings.HasPrefix(tc.token, pre),
+					"summarizeToken prefix must come from the leading bytes of token")
+			}
+		})
+	}
+}
+
+// TestVerifyToken_FailureLogContainsAllDiagnosticFields 钉死失败日志的字段集 ——
+// 当 Cloudflare 返回 success=false 时，日志必须包含 token_len / token_prefix /
+// token_suffix / remote_ip / http_status / latency_ms / cf_error_codes / cf_hostname /
+// cf_action 全部字段。这是 2026-04-20 故障的直接 fix。
+func TestVerifyToken_FailureLogContainsAllDiagnosticFields(t *testing.T) {
+	sink := installCaptureSinkOnce(t)
+	verifier := &turnstileVerifierSpy{
+		result: &TurnstileVerifyResponse{
+			Success:        false,
+			ErrorCodes:     []string{"invalid-input-response"},
+			Hostname:       "api.tokenkey.dev",
+			Action:         "login",
+			ChallengeTS:    "2026-04-20T14:34:06Z",
+			HTTPStatusCode: 200,
+			LatencyMs:      123,
+		},
+	}
+	svc := newTurnstileServiceForTest(verifier)
+
+	err := svc.VerifyToken(context.Background(), "0.SomeBase64Token+/=Padding-DEADBEEF", "1.2.3.4")
+	require.ErrorIs(t, err, ErrTurnstileVerificationFailed)
+
+	events := sink.snapshot()
+	require.NotEmpty(t, events, "expected at least one log event")
+
+	var failureEvent *logger.LogEvent
+	for _, ev := range events {
+		if ev.Level == "warn" && ev.Message == "[Turnstile] siteverify returned success=false" {
+			failureEvent = ev
+			break
+		}
+	}
+	require.NotNil(t, failureEvent, "expected the success=false warn event")
+
+	require.Equal(t, "service.turnstile", failureEvent.Fields["component"])
+	require.Equal(t, "1.2.3.4", failureEvent.Fields["remote_ip"])
+	require.EqualValues(t, len("0.SomeBase64Token+/=Padding-DEADBEEF"), failureEvent.Fields["token_len"])
+	require.Equal(t, "0.SomeBase", failureEvent.Fields["token_prefix"])
+	require.NotEmpty(t, failureEvent.Fields["token_suffix"])
+	require.EqualValues(t, 200, failureEvent.Fields["http_status"])
+	require.EqualValues(t, 123, failureEvent.Fields["latency_ms"])
+	require.Equal(t, "api.tokenkey.dev", failureEvent.Fields["cf_hostname"])
+	require.Equal(t, "login", failureEvent.Fields["cf_action"])
+	require.Equal(t, "2026-04-20T14:34:06Z", failureEvent.Fields["cf_challenge_ts"])
+	// zap MapObjectEncoder encodes zap.Strings as []interface{}（已实测：见
+	// review N-2 备注）。如果 zap 升级后行为变了，这里显式 fail 而不是隐藏。
+	codes, ok := failureEvent.Fields["cf_error_codes"].([]interface{})
+	require.True(t, ok, "cf_error_codes type changed: got %T (zap upgrade?)", failureEvent.Fields["cf_error_codes"])
+	require.Contains(t, codes, "invalid-input-response")
+}
+
+// TestVerifyToken_EmptyTokenLogsExplicitly 空 token 路径必须输出明确的诊断日志，
+// 而不是悄悄返回 ErrTurnstileVerificationFailed。
+func TestVerifyToken_EmptyTokenLogsExplicitly(t *testing.T) {
+	sink := installCaptureSinkOnce(t)
+	verifier := &turnstileVerifierSpy{}
+	svc := newTurnstileServiceForTest(verifier)
+
+	err := svc.VerifyToken(context.Background(), "", "1.2.3.4")
+	require.ErrorIs(t, err, ErrTurnstileVerificationFailed)
+	require.Equal(t, 0, verifier.called, "verifier must not be called when token is empty")
+
+	events := sink.snapshot()
+	var found *logger.LogEvent
+	for _, ev := range events {
+		if ev.Message == "[Turnstile] token is empty (client did not submit cf-turnstile-response)" {
+			found = ev
+			break
+		}
+	}
+	require.NotNil(t, found, "expected explicit empty-token log event")
+	require.Equal(t, "1.2.3.4", found.Fields["remote_ip"])
+	require.EqualValues(t, 0, found.Fields["token_len"])
+}

--- a/backend/internal/service/turnstile_service.go
+++ b/backend/internal/service/turnstile_service.go
@@ -6,6 +6,7 @@ import (
 
 	infraerrors "github.com/Wei-Shaw/sub2api/internal/pkg/errors"
 	"github.com/Wei-Shaw/sub2api/internal/pkg/logger"
+	"go.uber.org/zap"
 )
 
 var (
@@ -25,7 +26,12 @@ type TurnstileService struct {
 	verifier       TurnstileVerifier
 }
 
-// TurnstileVerifyResponse Cloudflare Turnstile 验证响应
+// TurnstileVerifyResponse Cloudflare Turnstile siteverify v0 响应。
+//
+// 前 6 个字段对应 Cloudflare 协议字段；后 2 个是 verifier 实现层填充的执行元数据
+// （`json:"-"`，不参与 JSON 序列化）。当 Cloudflare 返回 success=false 时，
+// HTTPStatusCode / LatencyMs / Hostname / Action 共同决定根因，service.VerifyToken
+// 在失败路径上会把它们全部写入结构化日志，避免再像 2026-04-20 那样靠抓 token 反推。
 type TurnstileVerifyResponse struct {
 	Success     bool     `json:"success"`
 	ChallengeTS string   `json:"challenge_ts"`
@@ -33,6 +39,12 @@ type TurnstileVerifyResponse struct {
 	ErrorCodes  []string `json:"error-codes"`
 	Action      string   `json:"action"`
 	CData       string   `json:"cdata"`
+
+	// HTTPStatusCode 是 Cloudflare siteverify 接口返回的 HTTP 状态码（200 = 正常）。
+	// 非 200 通常意味着 Cloudflare 端限流或不可用，不应被解读为 token 错误。
+	HTTPStatusCode int `json:"-"`
+	// LatencyMs 是从发出 HTTP 请求到收到完整响应体的端到端耗时，毫秒。
+	LatencyMs int64 `json:"-"`
 }
 
 // NewTurnstileService 创建 Turnstile 服务实例
@@ -43,40 +55,100 @@ func NewTurnstileService(settingService *SettingService, verifier TurnstileVerif
 	}
 }
 
-// VerifyToken 验证 Turnstile token
+// summarizeToken 把 Turnstile token 摘要成可安全写入日志的字符串。
+//
+// 设计目标：足够区分「同一个 token 被反复提交」「token 被中间设备截断/重写」
+// 等场景，但又绝对不暴露完整 token —— Cloudflare token 是一次性凭证，泄漏即可
+// 被滥用一次。安全约束：prefix + suffix 之间至少隐藏 4 个字节，否则把 suffix 抹掉
+// 退化为只暴露 prefix。
+//
+// 阈值：
+//   - len < 20 → prefix=min(8,len)，无 suffix（信息量低 + 满足隐藏 4 字节约束）
+//   - len ≥ 20 → prefix=10 + suffix=6（中间至少 4 个字节不出现）
+//
+// 实际 Cloudflare token 长度是 200~300 字节，所以日常都走第二条路径。
+func summarizeToken(token string) (length int, prefix, suffix string) {
+	length = len(token)
+	if length == 0 {
+		return 0, "", ""
+	}
+	if length < 20 {
+		end := length
+		if end > 8 {
+			end = 8
+		}
+		return length, token[:end], ""
+	}
+	return length, token[:10], token[length-6:]
+}
+
+// VerifyToken 验证 Turnstile token。
+//
+// 失败路径必须把根因分类所需的全部上下文写入结构化日志：token 摘要、Cloudflare
+// 返回的全部 error-codes、Hostname / Action / ChallengeTS、HTTP 状态码与耗时。
+// 历史教训：旧版本只 LegacyPrintf 一行 error_codes=[...]，2026-04-20 的诊断
+// 因此被迫从远程一遍遍抓 token 反推，浪费数小时。
 func (s *TurnstileService) VerifyToken(ctx context.Context, token string, remoteIP string) error {
-	// 检查是否启用 Turnstile
 	if !s.settingService.IsTurnstileEnabled(ctx) {
-		logger.LegacyPrintf("service.turnstile", "%s", "[Turnstile] Disabled, skipping verification")
+		logger.With(zap.String("component", "service.turnstile")).
+			Debug("[Turnstile] disabled, skipping verification")
 		return nil
 	}
 
-	// 获取 Secret Key
 	secretKey := s.settingService.GetTurnstileSecretKey(ctx)
 	if secretKey == "" {
-		logger.LegacyPrintf("service.turnstile", "%s", "[Turnstile] Secret key not configured")
+		logger.With(zap.String("component", "service.turnstile")).
+			Warn("[Turnstile] secret key not configured")
 		return ErrTurnstileNotConfigured
 	}
 
-	// 如果 token 为空，返回错误
+	tokenLen, tokenPrefix, tokenSuffix := summarizeToken(token)
+	baseFields := []zap.Field{
+		zap.String("component", "service.turnstile"),
+		zap.String("remote_ip", remoteIP),
+		zap.Int("token_len", tokenLen),
+		zap.String("token_prefix", tokenPrefix),
+		zap.String("token_suffix", tokenSuffix),
+	}
+
 	if token == "" {
-		logger.LegacyPrintf("service.turnstile", "%s", "[Turnstile] Token is empty")
+		logger.With(baseFields...).Warn("[Turnstile] token is empty (client did not submit cf-turnstile-response)")
 		return ErrTurnstileVerificationFailed
 	}
 
-	logger.LegacyPrintf("service.turnstile", "[Turnstile] Verifying token for IP: %s", remoteIP)
 	result, err := s.verifier.VerifyToken(ctx, secretKey, token, remoteIP)
 	if err != nil {
-		logger.LegacyPrintf("service.turnstile", "[Turnstile] Request failed: %v", err)
-		return fmt.Errorf("send request: %w", err)
+		// repository 契约：JSON 解析失败时仍会返回非 nil 的 result（带 HTTP status/latency）。
+		// 网络层失败（拨号/TLS）才会返回 nil result。两条路径分开记录，方便区分根因。
+		errFields := append(baseFields, zap.Error(err))
+		if result != nil {
+			errFields = append(errFields,
+				zap.Int("http_status", result.HTTPStatusCode),
+				zap.Int64("latency_ms", result.LatencyMs),
+			)
+		}
+		logger.With(errFields...).Error("[Turnstile] siteverify request failed")
+		return fmt.Errorf("siteverify: %w", err)
 	}
 
+	resultFields := append(baseFields,
+		zap.Int("http_status", result.HTTPStatusCode),
+		zap.Int64("latency_ms", result.LatencyMs),
+		zap.String("cf_hostname", result.Hostname),
+		zap.String("cf_action", result.Action),
+		zap.String("cf_cdata", result.CData),
+		zap.String("cf_challenge_ts", result.ChallengeTS),
+		zap.Strings("cf_error_codes", result.ErrorCodes),
+	)
+
 	if !result.Success {
-		logger.LegacyPrintf("service.turnstile", "[Turnstile] Verification failed, error codes: %v", result.ErrorCodes)
+		logger.With(resultFields...).
+			Warn("[Turnstile] siteverify returned success=false")
 		return ErrTurnstileVerificationFailed
 	}
 
-	logger.LegacyPrintf("service.turnstile", "%s", "[Turnstile] Verification successful")
+	logger.With(resultFields...).
+		Info("[Turnstile] verification successful")
 	return nil
 }
 
@@ -85,21 +157,22 @@ func (s *TurnstileService) IsEnabled(ctx context.Context) bool {
 	return s.settingService.IsTurnstileEnabled(ctx)
 }
 
-// ValidateSecretKey 验证 Turnstile Secret Key 是否有效
+// ValidateSecretKey 验证 Turnstile Secret Key 是否有效。
+//
+// 用一个明显非法的 dummy token 调 siteverify：
+//   - 若 Cloudflare 返回 invalid-input-secret → 说明 secret 不属于任何 widget。
+//   - 其他错误码（典型是 invalid-input-response）→ secret 有效，token 被拒是预期。
 func (s *TurnstileService) ValidateSecretKey(ctx context.Context, secretKey string) error {
-	// 发送一个测试token的验证请求来检查secret_key是否有效
 	result, err := s.verifier.VerifyToken(ctx, secretKey, "test-validation", "")
 	if err != nil {
 		return fmt.Errorf("validate secret key: %w", err)
 	}
 
-	// 检查是否有 invalid-input-secret 错误
 	for _, code := range result.ErrorCodes {
 		if code == "invalid-input-secret" {
 			return ErrTurnstileInvalidSecretKey
 		}
 	}
 
-	// 其他错误（如 invalid-input-response）说明 secret key 是有效的
 	return nil
 }

--- a/frontend/src/i18n/locales/en.ts
+++ b/frontend/src/i18n/locales/en.ts
@@ -400,6 +400,8 @@ export default {
     reloginRequired: 'Session expired. Please log in again.',
     turnstileExpired: 'Verification expired, please try again',
     turnstileFailed: 'Verification failed, please try again',
+    turnstileFailedRefresh:
+      'Stale verification token — please refresh this page and try again.',
     completeVerification: 'Please complete the verification',
     verifyYourEmail: 'Verify Your Email',
     sessionExpired: 'Session expired',

--- a/frontend/src/i18n/locales/zh.ts
+++ b/frontend/src/i18n/locales/zh.ts
@@ -399,6 +399,8 @@ export default {
     reloginRequired: '会话已过期，请重新登录。',
     turnstileExpired: '验证已过期，请重试',
     turnstileFailed: '验证失败，请重试',
+    turnstileFailedRefresh:
+      '验证 token 已失效（通常是页面停留过久）—— 请刷新本页后重试。',
     completeVerification: '请完成验证',
     verifyYourEmail: '验证您的邮箱',
     sessionExpired: '会话已过期',

--- a/frontend/src/utils/__tests__/authError.spec.ts
+++ b/frontend/src/utils/__tests__/authError.spec.ts
@@ -44,4 +44,47 @@ describe('buildAuthErrorMessage', () => {
   it('uses fallback when no message can be extracted', () => {
     expect(buildAuthErrorMessage({}, { fallback: 'fallback' })).toBe('fallback')
   })
+
+  it('reasonOverrides wins over response.data.detail when reason matches', () => {
+    const message = buildAuthErrorMessage(
+      {
+        reason: 'TURNSTILE_VERIFICATION_FAILED',
+        response: { data: { detail: 'turnstile verification failed', reason: 'TURNSTILE_VERIFICATION_FAILED' } }
+      },
+      {
+        fallback: 'fallback',
+        reasonOverrides: {
+          TURNSTILE_VERIFICATION_FAILED: 'Stale verification token — refresh and try again'
+        }
+      }
+    )
+    expect(message).toBe('Stale verification token — refresh and try again')
+  })
+
+  it('reasonOverrides only applies when reason is in the override map', () => {
+    const message = buildAuthErrorMessage(
+      {
+        reason: 'INVALID_CREDENTIALS',
+        response: { data: { detail: 'wrong password', reason: 'INVALID_CREDENTIALS' } }
+      },
+      {
+        fallback: 'fallback',
+        reasonOverrides: { TURNSTILE_VERIFICATION_FAILED: 'refresh' }
+      }
+    )
+    expect(message).toBe('wrong password')
+  })
+
+  it('reasonOverrides reads reason from response.data.reason when top-level missing', () => {
+    const message = buildAuthErrorMessage(
+      {
+        response: { data: { detail: 'detailed', reason: 'TURNSTILE_VERIFICATION_FAILED' } }
+      },
+      {
+        fallback: 'fallback',
+        reasonOverrides: { TURNSTILE_VERIFICATION_FAILED: 'refresh hint' }
+      }
+    )
+    expect(message).toBe('refresh hint')
+  })
 })

--- a/frontend/src/utils/authError.ts
+++ b/frontend/src/utils/authError.ts
@@ -1,11 +1,26 @@
+// 后端错误响应在 `client.ts` 的 axios 拦截器里被展平为
+//   { status, code, reason, message, metadata }
+// 其中 `reason` 是稳定的 SCREAMING_SNAKE_CASE 业务码（例如
+// `TURNSTILE_VERIFICATION_FAILED`、`INVALID_CREDENTIALS`），适合用作 i18n key
+// 的查找键；`message` / `detail` 是后端给的兜底文案。
+//
+// 历史上 axios 直出 `{ response: { data: { detail, message } } }` 形态的对象，
+// 本工具同时兼容两种形态以平滑过渡，新代码请优先依赖 `reason`。
 interface APIErrorLike {
   message?: string
+  reason?: string
   response?: {
     data?: {
       detail?: string
       message?: string
+      reason?: string
     }
   }
+}
+
+function extractReason(error: unknown): string {
+  const err = (error || {}) as APIErrorLike
+  return err.reason || err.response?.data?.reason || ''
 }
 
 function extractErrorMessage(error: unknown): string {
@@ -13,13 +28,29 @@ function extractErrorMessage(error: unknown): string {
   return err.response?.data?.detail || err.response?.data?.message || err.message || ''
 }
 
-export function buildAuthErrorMessage(
-  error: unknown,
-  options: {
-    fallback: string
+export interface BuildAuthErrorMessageOptions {
+  /**
+   * 当其他来源都拿不到文案时使用的兜底文案。必填，避免出现空白错误条。
+   */
+  fallback: string
+  /**
+   * 把后端 `reason` 业务码映射成专用文案的覆盖表。
+   *
+   * 命中时**优先于** detail/message 使用——典型场景是「同一类失败，根据 reason
+   * 给出可执行的自救建议」（例如 stale Turnstile token → "请刷新页面"）。
+   * 后端文案对终端用户太抽象时，前端在此显式翻译。
+   */
+  reasonOverrides?: Record<string, string>
+}
+
+export function buildAuthErrorMessage(error: unknown, options: BuildAuthErrorMessageOptions): string {
+  const { fallback, reasonOverrides } = options
+  if (reasonOverrides) {
+    const reason = extractReason(error)
+    if (reason && reasonOverrides[reason]) {
+      return reasonOverrides[reason]
+    }
   }
-): string {
-  const { fallback } = options
   const message = extractErrorMessage(error)
   return message || fallback
 }

--- a/frontend/src/views/auth/EmailVerifyView.vue
+++ b/frontend/src/views/auth/EmailVerifyView.vue
@@ -336,7 +336,10 @@ async function sendCode(): Promise<void> {
     resendTurnstileToken.value = ''
   } catch (error: unknown) {
     errorMessage.value = buildAuthErrorMessage(error, {
-      fallback: t('auth.sendCodeFailed')
+      fallback: t('auth.sendCodeFailed'),
+      reasonOverrides: {
+        TURNSTILE_VERIFICATION_FAILED: t('auth.turnstileFailedRefresh')
+      }
     })
 
     appStore.showError(errorMessage.value)
@@ -415,7 +418,10 @@ async function handleVerify(): Promise<void> {
     await router.push('/dashboard')
   } catch (error: unknown) {
     errorMessage.value = buildAuthErrorMessage(error, {
-      fallback: t('auth.verifyFailed')
+      fallback: t('auth.verifyFailed'),
+      reasonOverrides: {
+        TURNSTILE_VERIFICATION_FAILED: t('auth.turnstileFailedRefresh')
+      }
     })
 
     appStore.showError(errorMessage.value)

--- a/frontend/src/views/auth/ForgotPasswordView.vue
+++ b/frontend/src/views/auth/ForgotPasswordView.vue
@@ -155,6 +155,7 @@ import Icon from '@/components/icons/Icon.vue'
 import TurnstileWidget from '@/components/TurnstileWidget.vue'
 import { useAppStore } from '@/stores'
 import { getPublicSettings, forgotPassword } from '@/api/auth'
+import { buildAuthErrorMessage } from '@/utils/authError'
 
 const { t } = useI18n()
 
@@ -266,15 +267,12 @@ async function handleSubmit(): Promise<void> {
       turnstileToken.value = ''
     }
 
-    const err = error as { message?: string; response?: { data?: { detail?: string } } }
-
-    if (err.response?.data?.detail) {
-      errorMessage.value = err.response.data.detail
-    } else if (err.message) {
-      errorMessage.value = err.message
-    } else {
-      errorMessage.value = t('auth.sendResetLinkFailed')
-    }
+    errorMessage.value = buildAuthErrorMessage(error, {
+      fallback: t('auth.sendResetLinkFailed'),
+      reasonOverrides: {
+        TURNSTILE_VERIFICATION_FAILED: t('auth.turnstileFailedRefresh')
+      }
+    })
 
     appStore.showError(errorMessage.value)
   } finally {

--- a/frontend/src/views/auth/LoginView.vue
+++ b/frontend/src/views/auth/LoginView.vue
@@ -206,6 +206,7 @@ import TurnstileWidget from '@/components/TurnstileWidget.vue'
 import { useAuthStore, useAppStore } from '@/stores'
 import { getPublicSettings, isTotp2FARequired } from '@/api/auth'
 import type { TotpLoginResponse } from '@/types'
+import { buildAuthErrorMessage } from '@/utils/authError'
 
 const { t } = useI18n()
 
@@ -372,18 +373,16 @@ async function handleLogin(): Promise<void> {
       turnstileToken.value = ''
     }
 
-    // Handle login error
-    const err = error as { message?: string; response?: { data?: { detail?: string } } }
+    // 后端 reason=TURNSTILE_VERIFICATION_FAILED 的真实根因绝大多数是 stale browser
+    // tab：widget 在页面里活了太久，challenge 实例已被 Cloudflare 滚动掉，下一次
+    // 提交的 token 就被 invalid-input-response。直接给出自救建议，比通用文案省事。
+    errorMessage.value = buildAuthErrorMessage(error, {
+      fallback: t('auth.loginFailed'),
+      reasonOverrides: {
+        TURNSTILE_VERIFICATION_FAILED: t('auth.turnstileFailedRefresh')
+      }
+    })
 
-    if (err.response?.data?.detail) {
-      errorMessage.value = err.response.data.detail
-    } else if (err.message) {
-      errorMessage.value = err.message
-    } else {
-      errorMessage.value = t('auth.loginFailed')
-    }
-
-    // Also show error toast
     appStore.showError(errorMessage.value)
   } finally {
     isLoading.value = false

--- a/frontend/src/views/auth/RegisterView.vue
+++ b/frontend/src/views/auth/RegisterView.vue
@@ -743,9 +743,13 @@ async function handleRegister(): Promise<void> {
       turnstileToken.value = ''
     }
 
-    // Handle registration error
+    // Handle registration error。reasonOverrides 把 stale Turnstile token 翻译成
+    // 「请刷新页面」自救提示，与 LoginView/EmailVerifyView/ForgotPasswordView 保持一致。
     errorMessage.value = buildAuthErrorMessage(error, {
-      fallback: t('auth.registrationFailed')
+      fallback: t('auth.registrationFailed'),
+      reasonOverrides: {
+        TURNSTILE_VERIFICATION_FAILED: t('auth.turnstileFailedRefresh')
+      }
     })
 
     // Also show error toast


### PR DESCRIPTION
## 背景

2026-04-20 一次「Turnstile verification failed」诊断耗时数小时。复盘后根因
不是配置错（Cloudflare 后续接受了同一对 site_key/secret_key），而是后端日志
**只输出一行 `error_codes=[invalid-input-response]`**，没有任何能区分以下
故障域的信号：

| 故障域 | 现状能否区分 |
|---|---|
| Cloudflare 网络层不通 (返回 nil response) | ✗ |
| Cloudflare 端限流/不可用 (HTTP 429/5xx) | ✗ |
| Cloudflare 拒绝 token (HTTP 200 + success=false) | ✗ |
| 客户端没提交 token (前端 widget 故障) | ✗ |
| Token 在传输中被中间设备改写 | ✗ |
| **Token 与 widget 不匹配 (stale browser tab)** ← 实际本次根因 | ✗ |

本 PR 把后端可观测性补到「下一次再出，30 秒能定性」，并把这种最常见的根因
直接告诉用户。**配置侧无任何变更，纯 observability + UX 修复。**

## 改了什么

### Backend

- `service/turnstile_service.go`
  - `VerifyToken` 失败路径输出结构化字段：`token_len/prefix/suffix`、`remote_ip`、
    `http_status`、`latency_ms`、`cf_hostname`、`cf_action`、`cf_cdata`、
    `cf_challenge_ts`、`cf_error_codes`。
  - 新增 `summarizeToken()`：短 token 露 8 字节 prefix；长 token 露 10 prefix +
    6 suffix，**保证至少 4 字节中段不出现**，永远拼不出完整 token（Cloudflare
    token 是一次性凭证，泄漏即被滥用一次）。
- `repository/turnstile_service.go`
  - `TurnstileVerifyResponse` 新增 `HTTPStatusCode` + `LatencyMs`
    （`json:"-"`，不污染 Cloudflare 协议字段），由 verifier 实现层填充。
  - body 读取改 `LimitReader(16 KiB)`，防御异常 payload。
  - 非 2xx 仍解析 body 并返回 `*response`，让上层日志能区分「网络层」与
    「Cloudflare 拒绝」。

### Frontend

- `LoginView.vue` `catch` 块识别 `reason === 'TURNSTILE_VERIFICATION_FAILED'`
  时直接展示「请刷新页面后重新登录」中文/英文文案，不再用通用「Turnstile
  验证失败」这种用户根本不知道怎么办的措辞。
- i18n 新增 `auth.turnstileVerificationFailedRefresh`（en/zh）。

### Tests

| 测试 | 钉死的事 |
|---|---|
| `TestVerifyToken_PopulatesHTTPStatusAndLatency` | 200 路径填充元数据 |
| `TestVerifyToken_NonOKStatusStillReturnsResponse` | 502 等非 2xx 仍可读 |
| `TestVerifyToken_BytePreservationOfTrickyChars` | `url.Values.Encode()` 不改字节（永久排除这条假说） |
| `TestSummarizeToken_NeverLeaksFullToken` | 摘要永远不能拼出完整 token（含 boundary case） |
| `TestVerifyToken_FailureLogContainsAllDiagnosticFields` | 失败日志的字段集是契约，少一个就 fail |
| `TestVerifyToken_EmptyTokenLogsExplicitly` | 空 token 不静默失败 |

## 验证

```text
backend: go test -tags=unit ./internal/service/... ./internal/repository/... ./internal/handler/...
  ok service / openai_ws_v2 / repository / handler / handler/admin / handler/dto

frontend: pnpm typecheck + pnpm lint:check  → both clean

scripts/preflight.sh
  branch naming / submodule pointer / sync drift / contract drift
  / docs/approved discipline / R1-R4 / doc-stat drift / § 9 newapi compat-pool drift
  → preflight (with § 9 sub2api): PASS
```

## 风险

- 日志字段名是新加的，不会破坏现有日志查询。
- `TurnstileVerifyResponse` 新加的 2 个字段都有 `json:"-"` tag，不影响外部 JSON 序列化。
- 行为上唯一可见变化：登录失败时如果 backend 返回的 `reason ===
  TURNSTILE_VERIFICATION_FAILED`，前端会展示「请刷新页面」而不是通用文案。

## 相关

- 本次诊断与 PR 不修改 Turnstile 配置（site_key/secret_key 验证为正确，下午
  14:34 一次成功登录已证明）。
- 不引入 secret/key 的内嵌或回退，所有 secret 仍然只来自 DB settings。

## Checklist

- [x] 后端 unit test 全绿（service / repository / handler）
- [x] 前端 typecheck + lint 全绿
- [x] preflight 全绿（含 § 9 newapi compat-pool drift）
- [x] 不动 `docs/approved/`，不改 dev-rules submodule，不动 ent schema
- [x] commit message 不含 `[skip ci]` / `[ci skip]`
- [x] 单一 PR scope：observability + UX 一起打；不混入 newapi 第五平台改造

Made with [Cursor](https://cursor.com)