### PR TITLE
fix(email): explicit EHLO from config so Google Workspace SMTP relay accepts AUTH

### DIFF
--- a/.testing/user-stories/index.md
+++ b/.testing/user-stories/index.md
@@ -18,3 +18,4 @@
 | US-013 | newapi group + sticky session 命中 recheck / 漂移降级 | InTest | `.testing/user-stories/stories/US-013-newapi-group-sticky-session.md` |
 | US-014 | newapi group 配置 messages_dispatch_model_config 持久化 | InTest | `.testing/user-stories/stories/US-014-newapi-group-messages-dispatch-config.md` |
 | US-015 | 历史 openai group 行为完全不变（回归基线） | InTest | `.testing/user-stories/stories/US-015-openai-group-regression-baseline.md` |
+| US-016 | SMTP EHLO host 从 From/Username 推导（修 Google Workspace `auth: EOF`） | InTest | `.testing/user-stories/stories/US-016-smtp-ehlo-host-from-config.md` |

--- a/.testing/user-stories/stories/US-016-smtp-ehlo-host-from-config.md
+++ b/.testing/user-stories/stories/US-016-smtp-ehlo-host-from-config.md
@@ -1,0 +1,68 @@
+# US-016-smtp-ehlo-host-from-config
+
+- ID: US-016
+- Title: Explicit EHLO host derived from From/Username so Google Workspace SMTP relay accepts AUTH
+- Version: V1.3.x (hot-fix)
+- Priority: P0 (prod outage: Google Workspace SMTP not usable)
+- As a / I want / So that:
+  作为 **TokenKey 运维者**，我希望 **后台 SMTP 配置使用 Google Workspace SMTP relay (`smtp-relay.gmail.com:465` + App Password) 时测试发信不再报 `smtp auth: EOF`**，**以便** 我们能在 AWS SES 不批准提额的情况下，立刻切到企业邮箱（`admin@orbitlogic.dev`）发系统邮件，不必逐项重试和怀疑密码 / 网络。
+
+- Trace:
+  - 防御需求轴线：Go stdlib `net/smtp.Client` 默认 `EHLO localhost`，Google Workspace SMTP relay 把这视作 open-relay 探测并在 AUTH 阶段静默断开 TCP（实测：`openssl` 手工 EHLO 一个真实域名 → `235 Accepted`；Go 程序 EHLO localhost → `EOF`）。这是发信链路上的反滥用边界。
+  - 实体生命周期轴线：SMTP 会话 = `dial → EHLO → (STARTTLS) → AUTH → MAIL → RCPT → DATA → QUIT`。本故事补齐 EHLO 这条迁移边的"不能用 localhost"约束。
+  - 系统事件轴线：每次「后台 SMTP 测试连接」按钮 + 每次系统发信（验证码、密码重置、欠费提醒）。
+
+- Risk Focus:
+  - 逻辑错误：EHLO host 推导优先级（From → Username → Host）必须按业务实际填写顺序，不能在 `From` 已填的情况下回落到 `Host`；`localhost` 必须被 fallback 拒绝；malformed 邮箱（`@example.com`、`user@`、`not-an-email`）的等价类必须有定义。
+  - 行为回归：`SendEmailWithConfig` 的对外签名保持不变（handler 层 0 改动）；`TestSMTPConnectionWithConfig` 的对外签名保持不变（admin 设置页 0 改动）；STARTTLS 的"先 Hello → 再 Extension/StartTLS → 再 Auth"顺序与 stdlib 兼容（错误的顺序会导致 `Extension` 触发隐式 EHLO localhost，等于没修）。
+  - 安全问题：EHLO 推导出来的域名会被发到对端 SMTP 服务器，必须是我们已经在 `From` 字段公开承认的域名（不会泄漏其他内部信息）；对配置注入（CR/LF）已有 `sanitizeEmailHeader` 兜底，本故事不重做。
+  - 不适用：运行时问题——SMTP 会话短连接，无并发/重启/超时新增。
+
+## Acceptance Criteria
+
+1. **AC-001 (正向 / EHLO 推导)**：Given `SMTPConfig{From: "noreply@orbitlogic.dev", Username: "admin@orbitlogic.dev", Host: "smtp-relay.gmail.com"}`，When 调用 `ehloHostFromConfig(cfg)`，Then 返回 `"orbitlogic.dev"`。
+2. **AC-002 (正向 / Username fallback)**：Given `From=""` 但 `Username="admin@orbitlogic.dev"`，When 调用 `ehloHostFromConfig`，Then 返回 `"orbitlogic.dev"`。
+3. **AC-003 (正向 / Host fallback)**：Given `From=""` 且 `Username=""` 且 `Host="smtp-relay.gmail.com"`，When 调用 `ehloHostFromConfig`，Then 返回 `"smtp-relay.gmail.com"`（last-resort 但非 localhost）。
+4. **AC-004 (负向 / localhost 拒绝)**：Given `From=""`、`Username=""`、`Host="localhost"`，When 调用 `ehloHostFromConfig`，Then **不得**返回 `"localhost"`，必须返回 `"tokenkey.invalid"` 标记值，让远端 SMTP 拒收成可见错误而不是退化为原 bug。
+5. **AC-005 (回归 / Picky-mock 接受)**：Given 一个本地 mock TCP 服务器，行为与 Google Workspace SMTP relay 一致——收到 `EHLO localhost` 直接 close TCP，收到 `EHLO <真实域名>` 完成 250 + AUTH PLAIN + MAIL/RCPT/DATA/QUIT 全流程；When 调用 `SendEmailWithConfig` 用 `From=noreply@orbitlogic.dev`，Then 返回 `nil` 且 mock 服务器记录的 `LastEHLOHost == "orbitlogic.dev"`。
+6. **AC-006 (负向 / Pre-fix mock 行为复现)**：Given 同一个 mock 服务器，When 测试代码绕过 fix 直接发 `EHLO localhost\r\n`，Then mock 必须 close TCP（subsequent read 返回错误），证明 mock 真实复现了 Google 的反滥用行为——这条 AC 是「mock 不退化」的元保护。
+7. **AC-007 (回归 / 接口签名)**：Given 此 PR 落地，When 阅读 `email_service.go` 的对外导出函数 `SendEmailWithConfig` / `TestSMTPConnectionWithConfig`，Then 签名 0 变更（仅内部 `sendMailTLS` / `sendMailPlain` 增加 `ehloHost` 参数，且仅在同包内被 `SendEmailWithConfig` 调用）。
+8. **AC-008 (回归 / 全量单元测试)**：Given 此 PR 落地，When 执行 `go test -tags=unit -count=1 ./internal/service/...`，Then 全部包通过，无新增 FAIL。
+
+## Assertions
+
+- `ehloHostFromConfig(&SMTPConfig{From:"noreply@orbitlogic.dev", Host:"smtp-relay.gmail.com"})` → `"orbitlogic.dev"`（断言 From 优先级）。
+- `ehloHostFromConfig(&SMTPConfig{Host:"localhost"})` → `"tokenkey.invalid"`（断言 fallback 拒绝 localhost，且**不**返回空串——否则 `client.Hello("")` 会被 stdlib 拒绝并把 bug 埋到 `smtp hello:` 错误里）。
+- `sendMailPlain` / `sendMailTLS` / `TestSMTPConnectionWithConfig`（TLS 分支与 STARTTLS 分支）四处代码路径**都**在 `client.Auth` 之前调用了 `client.Hello(ehloHost)`（不是只修一处——遗漏任何一条都会让"测试连接"按钮和"实际发信"行为不一致）。
+- mock 服务器收到 `EHLO orbitlogic.dev` 后回复 `250-AUTH PLAIN LOGIN`，AUTH PLAIN 后回复 `235 Accepted`；收到 `EHLO localhost` 直接 close TCP（不发 5xx）——断言 mock 与 prod 实测行为同构。
+- `TestSendEmail_RejectsEHLOLocalhost.LastEHLOHost == "orbitlogic.dev"`（断言副作用：fix 后实际发出的 EHLO host 就是从 From 推导出来的那个，不是 stdlib 默认的 localhost，也不是 SMTP host `127.0.0.1`）。
+
+## Linked Tests
+
+- `backend/internal/service/email_service_ehlo_test.go`::`TestEHLOHostFromConfig` (8 个子用例覆盖 AC-001..AC-004 + 边界等价类)
+- `backend/internal/service/email_service_ehlo_test.go`::`TestSendEmail_RejectsEHLOLocalhost` (AC-005)
+- `backend/internal/service/email_service_ehlo_test.go`::`TestSendEmail_PreFixBehaviorReproduces` (AC-006)
+
+运行命令：
+
+```bash
+# 仅本故事的回归 (秒级)
+go test -tags=unit -count=1 -v -run 'TestEHLOHostFromConfig|TestSendEmail_RejectsEHLOLocalhost|TestSendEmail_PreFixBehaviorReproduces' \
+  ./backend/internal/service/...
+
+# 全 service 包回归 (~80s)
+go test -tags=unit -count=1 ./backend/internal/service/...
+```
+
+## Evidence
+
+- Prod 复现：从 EC2 (`34.194.234.88`) 到 `smtp-relay.gmail.com:465`，`openssl s_client` 手工 `EHLO orbitlogic.dev` + AUTH PLAIN（真实 App Password）→ `235 2.7.0 Accepted`。
+- Go 复现：在同一台 EC2，`go run smtp_repro.go`（mirror `email_service.sendMailTLS`）→ `smtp auth: EOF`；改成 `client.Hello("orbitlogic.dev")` 后 → `AUTH OK`。
+- 本地 (worktree) 自检：
+  - `go build ./...` clean。
+  - `go test -tags=unit -count=1 -v -run 'TestEHLOHostFromConfig|TestSendEmail_RejectsEHLOLocalhost|TestSendEmail_PreFixBehaviorReproduces' ./internal/service/...` → 3 个测试 + 8 个子用例全 PASS。
+  - `go test -tags=unit -count=1 ./internal/service/...` → 包通过（`ok ... 80.666s`），无新增 FAIL。
+
+## Status
+
+- [ ] InTest（PR 等 review；merge 后转 Done，并随下一次 prod 部署在 admin SMTP 设置页用 `admin@orbitlogic.dev` + App Password 实测「测试连接」+ 收到测试信收尾验证）。

--- a/backend/internal/service/email_service.go
+++ b/backend/internal/service/email_service.go
@@ -198,6 +198,16 @@ func (s *EmailService) SendEmailWithConfig(config *SMTPConfig, to, subject, body
 //  1. Domain part of the From address  (admin@orbitlogic.dev → orbitlogic.dev)
 //  2. Domain part of the SMTP username (same shape)
 //  3. SMTP host as last resort (e.g. smtp-relay.gmail.com — verified accepted)
+//
+// RFC 5321 §4.1.4 caveat: strictly speaking the EHLO argument is supposed to
+// be the *client's own* fully-qualified domain (or address literal), not the
+// mail domain. We use the mail domain because (a) Google Workspace SMTP relay
+// only enforces "not localhost" and authenticates the tenant via the App
+// Password rather than the EHLO name, and (b) we don't have a stable public
+// hostname (containers, autoscaling, no PTR for the From-domain on EC2).
+// If a future relay performs forward-confirmed reverse DNS validation against
+// the EHLO argument we'll need to surface this as an explicit operator
+// setting; track that work behind US-016 follow-ups, not in this helper.
 func ehloHostFromConfig(config *SMTPConfig) string {
 	for _, candidate := range []string{config.From, config.Username} {
 		if d := domainFromEmail(candidate); d != "" {

--- a/backend/internal/service/email_service.go
+++ b/backend/internal/service/email_service.go
@@ -176,16 +176,56 @@ func (s *EmailService) SendEmailWithConfig(config *SMTPConfig, to, subject, body
 
 	addr := fmt.Sprintf("%s:%d", config.Host, config.Port)
 	auth := smtp.PlainAuth("", config.Username, config.Password, config.Host)
+	ehloHost := ehloHostFromConfig(config)
 
 	if config.UseTLS {
-		return s.sendMailTLS(addr, auth, config.From, to, []byte(msg), config.Host)
+		return s.sendMailTLS(addr, auth, config.From, to, []byte(msg), config.Host, ehloHost)
 	}
 
-	return s.sendMailPlain(addr, auth, config.From, to, []byte(msg), config.Host)
+	return s.sendMailPlain(addr, auth, config.From, to, []byte(msg), config.Host, ehloHost)
+}
+
+// ehloHostFromConfig derives a non-localhost hostname for the EHLO command.
+//
+// Background: Go stdlib net/smtp.Client defaults its EHLO/HELO local name to
+// "localhost" when Hello() is not called explicitly. Strict relays — most
+// notably Google Workspace SMTP relay (smtp-relay.gmail.com) — drop the TCP
+// connection at AUTH stage when greeted with "EHLO localhost" as part of
+// anti-abuse / anti-open-relay protection, surfacing as `smtp auth: EOF`
+// to the caller. We must always EHLO with a real domain we own.
+//
+// Priority (first non-empty wins, "localhost" is rejected as last-resort fallback):
+//  1. Domain part of the From address  (admin@orbitlogic.dev → orbitlogic.dev)
+//  2. Domain part of the SMTP username (same shape)
+//  3. SMTP host as last resort (e.g. smtp-relay.gmail.com — verified accepted)
+func ehloHostFromConfig(config *SMTPConfig) string {
+	for _, candidate := range []string{config.From, config.Username} {
+		if d := domainFromEmail(candidate); d != "" {
+			return d
+		}
+	}
+	if h := strings.TrimSpace(config.Host); h != "" && !strings.EqualFold(h, "localhost") {
+		return h
+	}
+	// Should not happen in practice (config.Host is required upstream of this
+	// helper). Returning a marker rather than empty/"localhost" keeps the
+	// failure mode loud rather than silently regressing to the original bug.
+	return "tokenkey.invalid"
+}
+
+// domainFromEmail extracts the domain portion of an email address ("user@host"
+// → "host"). Returns "" when the input is not a well-formed address.
+func domainFromEmail(addr string) string {
+	addr = strings.TrimSpace(addr)
+	i := strings.LastIndex(addr, "@")
+	if i < 0 || i == len(addr)-1 {
+		return ""
+	}
+	return addr[i+1:]
 }
 
 // sendMailPlain sends mail without TLS using a dialer with timeout.
-func (s *EmailService) sendMailPlain(addr string, auth smtp.Auth, from, to string, msg []byte, host string) error {
+func (s *EmailService) sendMailPlain(addr string, auth smtp.Auth, from, to string, msg []byte, host, ehloHost string) error {
 	dialer := &net.Dialer{Timeout: smtpDialTimeout}
 	conn, err := dialer.Dial("tcp", addr)
 	if err != nil {
@@ -199,6 +239,13 @@ func (s *EmailService) sendMailPlain(addr string, auth smtp.Auth, from, to strin
 		return fmt.Errorf("new smtp client: %w", err)
 	}
 	defer func() { _ = client.Close() }()
+
+	// EHLO with our real domain BEFORE Extension/StartTLS/Auth. See
+	// ehloHostFromConfig docstring — Google Workspace SMTP relay drops the
+	// connection at AUTH when greeted with the stdlib default "EHLO localhost".
+	if err = client.Hello(ehloHost); err != nil {
+		return fmt.Errorf("smtp hello: %w", err)
+	}
 
 	// Opportunistic STARTTLS: upgrade to encrypted connection if the server supports it.
 	// This mirrors the behavior of smtp.SendMail which we replaced for timeout support.
@@ -232,7 +279,7 @@ func (s *EmailService) sendMailPlain(addr string, auth smtp.Auth, from, to strin
 }
 
 // sendMailTLS 使用TLS发送邮件
-func (s *EmailService) sendMailTLS(addr string, auth smtp.Auth, from, to string, msg []byte, host string) error {
+func (s *EmailService) sendMailTLS(addr string, auth smtp.Auth, from, to string, msg []byte, host, ehloHost string) error {
 	tlsConfig := &tls.Config{
 		ServerName: host,
 		// 强制 TLS 1.2+，避免协议降级导致的弱加密风险。
@@ -252,6 +299,11 @@ func (s *EmailService) sendMailTLS(addr string, auth smtp.Auth, from, to string,
 		return fmt.Errorf("new smtp client: %w", err)
 	}
 	defer func() { _ = client.Close() }()
+
+	// EHLO with our real domain BEFORE Auth — see ehloHostFromConfig docstring.
+	if err = client.Hello(ehloHost); err != nil {
+		return fmt.Errorf("smtp hello: %w", err)
+	}
 
 	if err = client.Auth(auth); err != nil {
 		return fmt.Errorf("smtp auth: %w", err)
@@ -417,6 +469,7 @@ func (s *EmailService) buildVerifyCodeEmailBody(code, siteName string) string {
 // TestSMTPConnectionWithConfig 使用指定配置测试SMTP连接
 func (s *EmailService) TestSMTPConnectionWithConfig(config *SMTPConfig) error {
 	addr := fmt.Sprintf("%s:%d", config.Host, config.Port)
+	ehloHost := ehloHostFromConfig(config)
 
 	if config.UseTLS {
 		tlsConfig := &tls.Config{
@@ -436,6 +489,11 @@ func (s *EmailService) TestSMTPConnectionWithConfig(config *SMTPConfig) error {
 		}
 		defer func() { _ = client.Close() }()
 
+		// EHLO with our real domain BEFORE Auth — see ehloHostFromConfig docstring.
+		if err = client.Hello(ehloHost); err != nil {
+			return fmt.Errorf("smtp hello failed: %w", err)
+		}
+
 		auth := smtp.PlainAuth("", config.Username, config.Password, config.Host)
 		if err = client.Auth(auth); err != nil {
 			return fmt.Errorf("smtp authentication failed: %w", err)
@@ -454,6 +512,11 @@ func (s *EmailService) TestSMTPConnectionWithConfig(config *SMTPConfig) error {
 		return fmt.Errorf("smtp connection failed: %w", err)
 	}
 	defer func() { _ = client.Close() }()
+
+	// EHLO with our real domain BEFORE Extension/StartTLS/Auth.
+	if err = client.Hello(ehloHost); err != nil {
+		return fmt.Errorf("smtp hello failed: %w", err)
+	}
 
 	if ok, _ := client.Extension("STARTTLS"); ok {
 		if err = client.StartTLS(&tls.Config{ServerName: config.Host, MinVersion: tls.VersionTLS12}); err != nil {

--- a/backend/internal/service/email_service_ehlo_test.go
+++ b/backend/internal/service/email_service_ehlo_test.go
@@ -1,0 +1,297 @@
+//go:build unit
+
+package service
+
+import (
+	"bufio"
+	"errors"
+	"net"
+	"strings"
+	"sync"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/require"
+)
+
+// TestEHLOHostFromConfig validates the EHLO host derivation order:
+// From-domain > Username-domain > Host. We must never default to "localhost"
+// because Google Workspace SMTP relay drops AUTH on EHLO localhost (see
+// ehloHostFromConfig docstring + US-016 root cause analysis).
+func TestEHLOHostFromConfig(t *testing.T) {
+	tests := []struct {
+		name string
+		cfg  *SMTPConfig
+		want string
+	}{
+		{
+			name: "from-address-wins",
+			cfg:  &SMTPConfig{From: "noreply@orbitlogic.dev", Username: "ignored@example.com", Host: "smtp-relay.gmail.com"},
+			want: "orbitlogic.dev",
+		},
+		{
+			name: "fallback-to-username-domain",
+			cfg:  &SMTPConfig{From: "", Username: "admin@orbitlogic.dev", Host: "smtp-relay.gmail.com"},
+			want: "orbitlogic.dev",
+		},
+		{
+			name: "fallback-to-username-when-from-malformed",
+			cfg:  &SMTPConfig{From: "not-an-email", Username: "admin@orbitlogic.dev", Host: "smtp-relay.gmail.com"},
+			want: "orbitlogic.dev",
+		},
+		{
+			name: "fallback-to-host-when-no-email",
+			cfg:  &SMTPConfig{From: "", Username: "", Host: "smtp-relay.gmail.com"},
+			want: "smtp-relay.gmail.com",
+		},
+		{
+			name: "trailing-at-treated-as-malformed",
+			cfg:  &SMTPConfig{From: "user@", Username: "", Host: "smtp.example.com"},
+			want: "smtp.example.com",
+		},
+		{
+			name: "leading-at-treated-as-malformed",
+			cfg:  &SMTPConfig{From: "@example.com", Username: "", Host: "smtp.example.com"},
+			// "@example.com" has @ at index 0, domain part is "example.com" (non-empty) → wins.
+			want: "example.com",
+		},
+		{
+			name: "host-localhost-rejected-uses-marker",
+			cfg:  &SMTPConfig{From: "", Username: "", Host: "localhost"},
+			want: "tokenkey.invalid",
+		},
+		{
+			name: "trims-whitespace-around-from",
+			cfg:  &SMTPConfig{From: "  noreply@orbitlogic.dev  ", Host: "smtp.example.com"},
+			want: "orbitlogic.dev",
+		},
+	}
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			got := ehloHostFromConfig(tc.cfg)
+			require.Equal(t, tc.want, got)
+		})
+	}
+}
+
+// TestSendEmail_RejectsEHLOLocalhost is the regression test for the
+// `smtp auth: EOF` bug against Google Workspace SMTP relay. It runs a tiny
+// TCP server that mimics Google's anti-abuse behavior:
+//   - greeting (220 OK)
+//   - if first command is "EHLO localhost" → close TCP connection (no 5xx)
+//   - if first command is "EHLO <real-domain>" → respond 250 OK + accept
+//     subsequent AUTH/MAIL/RCPT/DATA/QUIT minimally
+//
+// Before the fix, sendMailPlain would EHLO with "localhost" (Go stdlib
+// default) and the server would drop the connection during AUTH, surfacing as
+// `smtp auth: EOF`. After the fix, sendMailPlain calls client.Hello() with the
+// derived domain ("orbitlogic.dev") before AUTH, so the mock server accepts
+// the session and the test returns nil.
+func TestSendEmail_RejectsEHLOLocalhost(t *testing.T) {
+	srv := newPickyEHLOServer(t)
+	defer srv.Close()
+
+	svc := &EmailService{}
+	cfg := &SMTPConfig{
+		Host:     srv.Host(),
+		Port:     srv.Port(),
+		Username: "admin@orbitlogic.dev",
+		Password: "fake-app-password-for-mock",
+		From:     "noreply@orbitlogic.dev",
+		FromName: "TokenKey",
+		UseTLS:   false, // mock is plaintext; we still exercise the EHLO path.
+	}
+
+	err := svc.SendEmailWithConfig(cfg, "user@example.com", "subject", "<p>body</p>")
+	require.NoError(t, err, "post-fix: explicit EHLO with From-domain must succeed against picky mock server")
+
+	require.Equal(t, "orbitlogic.dev", srv.LastEHLOHost(), "must EHLO with the From address domain, not 'localhost'")
+}
+
+// TestSendEmail_PreFixBehaviorReproduces confirms that bypassing the fix
+// (sending the raw stdlib default EHLO "localhost") still triggers the
+// connection drop, proving the mock server faithfully reproduces the
+// Google Workspace SMTP relay behavior we observed in production.
+//
+// This is a guard-rail test: if someone "simplifies" the mock and removes the
+// localhost-rejection branch, this test will start failing — flagging that the
+// regression suite no longer protects against the original bug.
+func TestSendEmail_PreFixBehaviorReproduces(t *testing.T) {
+	srv := newPickyEHLOServer(t)
+	defer srv.Close()
+
+	conn, err := net.DialTimeout("tcp", srv.Addr(), 2*time.Second)
+	require.NoError(t, err)
+	defer func() { _ = conn.Close() }()
+	_ = conn.SetDeadline(time.Now().Add(3 * time.Second))
+
+	rd := bufio.NewReader(conn)
+	greeting, err := rd.ReadString('\n')
+	require.NoError(t, err)
+	require.True(t, strings.HasPrefix(greeting, "220"), "expected 220 greeting, got %q", greeting)
+
+	// Send the offending stdlib-default EHLO that triggered the prod bug.
+	_, err = conn.Write([]byte("EHLO localhost\r\n"))
+	require.NoError(t, err)
+
+	// Server should drop connection: subsequent read returns io.EOF (or wrapped).
+	_, err = rd.ReadString('\n')
+	require.Error(t, err, "mock server must drop connection on EHLO localhost (mirrors smtp-relay.gmail.com behavior)")
+	require.Equal(t, "localhost", srv.LastEHLOHost())
+}
+
+// pickyEHLOServer is a minimal TCP SMTP-ish server that drops on EHLO
+// localhost and otherwise speaks just enough SMTP to let net/smtp.Client
+// complete a Plain-auth send-mail flow.
+type pickyEHLOServer struct {
+	t        *testing.T
+	listener net.Listener
+	mu       sync.Mutex
+	lastEHLO string
+	wg       sync.WaitGroup
+}
+
+func newPickyEHLOServer(t *testing.T) *pickyEHLOServer {
+	t.Helper()
+	ln, err := net.Listen("tcp", "127.0.0.1:0")
+	require.NoError(t, err)
+	srv := &pickyEHLOServer{t: t, listener: ln}
+	srv.wg.Add(1)
+	go srv.acceptLoop()
+	return srv
+}
+
+func (s *pickyEHLOServer) Addr() string { return s.listener.Addr().String() }
+
+func (s *pickyEHLOServer) Host() string {
+	host, _, _ := net.SplitHostPort(s.Addr())
+	return host
+}
+
+func (s *pickyEHLOServer) Port() int {
+	_, port, _ := net.SplitHostPort(s.Addr())
+	var p int
+	for _, c := range port {
+		p = p*10 + int(c-'0')
+	}
+	return p
+}
+
+func (s *pickyEHLOServer) LastEHLOHost() string {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	return s.lastEHLO
+}
+
+func (s *pickyEHLOServer) Close() {
+	_ = s.listener.Close()
+	s.wg.Wait()
+}
+
+func (s *pickyEHLOServer) acceptLoop() {
+	defer s.wg.Done()
+	for {
+		conn, err := s.listener.Accept()
+		if err != nil {
+			return
+		}
+		s.wg.Add(1)
+		go s.handle(conn)
+	}
+}
+
+func (s *pickyEHLOServer) handle(conn net.Conn) {
+	defer s.wg.Done()
+	defer func() { _ = conn.Close() }()
+	_ = conn.SetDeadline(time.Now().Add(5 * time.Second))
+
+	rd := bufio.NewReader(conn)
+	if _, err := conn.Write([]byte("220 mock.example.com ESMTP picky-mock\r\n")); err != nil {
+		return
+	}
+
+	for {
+		line, err := rd.ReadString('\n')
+		if err != nil {
+			return
+		}
+		line = strings.TrimRight(line, "\r\n")
+		cmd, arg := splitCmd(line)
+
+		switch strings.ToUpper(cmd) {
+		case "EHLO", "HELO":
+			s.mu.Lock()
+			s.lastEHLO = arg
+			s.mu.Unlock()
+			if strings.EqualFold(arg, "localhost") {
+				// Mirror Google Workspace SMTP relay: drop connection silently.
+				return
+			}
+			// Multi-line 250 response advertising AUTH PLAIN.
+			_, _ = conn.Write([]byte("250-mock.example.com Hello " + arg + "\r\n"))
+			_, _ = conn.Write([]byte("250-AUTH PLAIN LOGIN\r\n"))
+			_, _ = conn.Write([]byte("250 OK\r\n"))
+		case "AUTH":
+			_, _ = conn.Write([]byte("235 2.7.0 Accepted\r\n"))
+		case "MAIL":
+			_, _ = conn.Write([]byte("250 2.1.0 OK\r\n"))
+		case "RCPT":
+			_, _ = conn.Write([]byte("250 2.1.5 OK\r\n"))
+		case "DATA":
+			_, _ = conn.Write([]byte("354 End data with <CR><LF>.<CR><LF>\r\n"))
+			// Drain until "\r\n.\r\n".
+			if err := drainData(rd); err != nil {
+				return
+			}
+			_, _ = conn.Write([]byte("250 2.0.0 OK queued\r\n"))
+		case "QUIT":
+			_, _ = conn.Write([]byte("221 2.0.0 closing\r\n"))
+			return
+		case "NOOP":
+			_, _ = conn.Write([]byte("250 OK\r\n"))
+		case "RSET":
+			_, _ = conn.Write([]byte("250 OK\r\n"))
+		default:
+			_, _ = conn.Write([]byte("502 5.5.2 Command not implemented\r\n"))
+		}
+	}
+}
+
+func splitCmd(line string) (string, string) {
+	idx := strings.IndexAny(line, " \t")
+	if idx < 0 {
+		return line, ""
+	}
+	return line[:idx], strings.TrimSpace(line[idx+1:])
+}
+
+func drainData(rd *bufio.Reader) error {
+	var prevDot, prevCR bool
+	for {
+		b, err := rd.ReadByte()
+		if err != nil {
+			if errors.Is(err, net.ErrClosed) {
+				return nil
+			}
+			return err
+		}
+		// Look for sequence "\r\n.\r\n" terminator.
+		if b == '\r' {
+			prevCR = true
+			continue
+		}
+		if b == '\n' && prevCR {
+			prevCR = false
+			if prevDot {
+				return nil
+			}
+			continue
+		}
+		if b == '.' {
+			prevDot = true
+			continue
+		}
+		prevDot = false
+		prevCR = false
+	}
+}

--- a/backend/internal/service/email_service_ehlo_test.go
+++ b/backend/internal/service/email_service_ehlo_test.go
@@ -6,6 +6,7 @@ import (
 	"bufio"
 	"errors"
 	"net"
+	"strconv"
 	"strings"
 	"sync"
 	"testing"
@@ -50,9 +51,12 @@ func TestEHLOHostFromConfig(t *testing.T) {
 			want: "smtp.example.com",
 		},
 		{
-			name: "leading-at-treated-as-malformed",
+			// "@example.com" has @ at index 0, domain part is "example.com"
+			// (non-empty) so it wins. We accept this as "extract whatever the
+			// user typed after the @"; rejecting it would force operators with
+			// quirky From values into the localhost-fallback trap.
+			name: "leading-at-still-extracts-domain",
 			cfg:  &SMTPConfig{From: "@example.com", Username: "", Host: "smtp.example.com"},
-			// "@example.com" has @ at index 0, domain part is "example.com" (non-empty) → wins.
 			want: "example.com",
 		},
 		{
@@ -144,7 +148,6 @@ func TestSendEmail_PreFixBehaviorReproduces(t *testing.T) {
 // localhost and otherwise speaks just enough SMTP to let net/smtp.Client
 // complete a Plain-auth send-mail flow.
 type pickyEHLOServer struct {
-	t        *testing.T
 	listener net.Listener
 	mu       sync.Mutex
 	lastEHLO string
@@ -155,7 +158,7 @@ func newPickyEHLOServer(t *testing.T) *pickyEHLOServer {
 	t.Helper()
 	ln, err := net.Listen("tcp", "127.0.0.1:0")
 	require.NoError(t, err)
-	srv := &pickyEHLOServer{t: t, listener: ln}
+	srv := &pickyEHLOServer{listener: ln}
 	srv.wg.Add(1)
 	go srv.acceptLoop()
 	return srv
@@ -170,10 +173,7 @@ func (s *pickyEHLOServer) Host() string {
 
 func (s *pickyEHLOServer) Port() int {
 	_, port, _ := net.SplitHostPort(s.Addr())
-	var p int
-	for _, c := range port {
-		p = p*10 + int(c-'0')
-	}
+	p, _ := strconv.Atoi(port)
 	return p
 }
 


### PR DESCRIPTION
## Why

AWS SES rejected our sending-limit increase, so prod needs to fall back to the operator's existing Google Workspace mailbox (`admin@orbitlogic.dev`) for system mail (verification codes, password reset, billing alerts).

When configured against `smtp-relay.gmail.com:465` with a real App Password, the admin "测试连接" button (and any actual send) returned `Failed to send test email: smtp auth: EOF` — a non-actionable error that wasted hours of credential / network triage.

## Root cause

Go stdlib `net/smtp.Client` defaults its EHLO/HELO local name to `"localhost"` when `Hello()` is not called explicitly. Strict relays — most notably **Google Workspace SMTP relay** — silently drop the TCP connection at AUTH stage when greeted with `EHLO localhost`, as part of anti-abuse / anti-open-relay protection. The drop surfaces to callers as a bare `smtp auth: EOF` because `client.Auth()` reads from a half-closed socket.

## Diagnostic chain (full evidence in US-016)

1. `openssl s_client -connect smtp-relay.gmail.com:465` from EC2 + manual `EHLO orbitlogic.dev` + AUTH PLAIN with the real App Password → `235 2.7.0 Accepted` + full MAIL/RCPT/DATA/QUIT happy path. Network, App Password, and Workspace IP-allowlist all confirmed correct.
2. Go reproducer on the same EC2 instance, code identical to `email_service.sendMailTLS` → `smtp auth: EOF`. Bug isolated to our Go client.
3. Reproducer + explicit `client.Hello("orbitlogic.dev")` before `client.Auth()` → AUTH OK. Fix confirmed.

## Fix

`backend/internal/service/email_service.go`:

- New helper `ehloHostFromConfig(*SMTPConfig) string` derives a non-localhost EHLO hostname with priority `From-domain → Username-domain → Host` (with `localhost` rejected and replaced by a `tokenkey.invalid` marker so the failure mode stays loud rather than silently regressing to the original bug).
- All four SMTP code paths now call `client.Hello(ehloHost)` explicitly before `Extension/StartTLS/Auth`:
  - `sendMailPlain` (port 25/587, opportunistic STARTTLS)
  - `sendMailTLS` (port 465, implicit TLS)
  - `TestSMTPConnectionWithConfig` TLS branch
  - `TestSMTPConnectionWithConfig` plaintext+STARTTLS branch
- Public exported API surface is unchanged (`SendEmailWithConfig` / `TestSMTPConnectionWithConfig` signatures untouched). Internal `sendMailTLS` / `sendMailPlain` gain an `ehloHost` parameter; both are package-private and only called from `SendEmailWithConfig` in this same file. Handler / admin-settings page need 0 edits.

## Tests

`backend/internal/service/email_service_ehlo_test.go` (new, build tag `unit`):

- `TestEHLOHostFromConfig` — 8 subtests covering the From → Username → Host derivation order plus localhost-rejection fallback and edge cases (malformed addresses, leading/trailing `@`, whitespace).
- `TestSendEmail_RejectsEHLOLocalhost` — runs an in-process TCP server that **mirrors Google's relay behavior** (drop on `EHLO localhost`, accept everything else with full AUTH/MAIL/RCPT/DATA flow) and asserts `SendEmailWithConfig` succeeds with `LastEHLOHost == "orbitlogic.dev"`.
- `TestSendEmail_PreFixBehaviorReproduces` — guard-rail test that proves the mock faithfully reproduces the prod EOF behavior. If anyone "simplifies" the mock and removes the localhost-drop branch, this test fails first, flagging that the regression suite no longer protects against the original bug.

User Story: `.testing/user-stories/stories/US-016-smtp-ehlo-host-from-config.md` (8 ACs, 5 assertion clusters, 4-risk-class coverage).

## Local validation

- `go build ./...` clean
- `go vet ./internal/service/... ./internal/handler/...` clean
- `go test -tags=unit -count=1 -v -run 'TestEHLOHostFromConfig|TestSendEmail_RejectsEHLOLocalhost|TestSendEmail_PreFixBehaviorReproduces' ./internal/service/...` → 3 tests + 8 subtests PASS
- `go test -tags=unit -count=1 ./internal/service/...` → ok 80.7s, no new FAIL
- `scripts/preflight.sh` → PASS (all sections incl. § 9 sub2api newapi compat-pool drift)

## Test plan (post-merge prod verification — US-016 收尾)

- [ ] In prod admin SMTP settings page: switch host to `smtp-relay.gmail.com`, port `465`, Use TLS = on, From = `admin@orbitlogic.dev`, Username = `admin@orbitlogic.dev`, Password = newly rotated App Password.
- [ ] Click "测试连接" → expect `200 OK`, no more `smtp auth: EOF`.
- [ ] Send a test email to a Gmail inbox → arrives within 30s, From shows `TokenKey <admin@orbitlogic.dev>`, DKIM/SPF pass.

## Operator note (security)

An App Password used during local triage was disclosed in the dev chat. **Revoke it in Google Account → Security → App Passwords** and generate a new one before re-testing in prod. The fix here works for any valid App Password — rotation is purely hygiene.