### PR TITLE
fix(cicd-oidc): retain GitHub OIDC provider on stack changes

### DIFF
--- a/deploy/aws/README.md
+++ b/deploy/aws/README.md
@@ -421,7 +421,12 @@ GitHub Actions 不再用长期 AWS 凭证，**OIDC 临时换 STS** → `ssm:Send
        CreateOIDCProvider=false   # 已在 step 1 手动创建
    ```
 
-   首次 PR 自验时可临时把 `AllowedSubjects` 加上当前分支 ref，验完缩回 main。
+   首次 PR 自验时可临时把 `AllowedSubjects` 加上当前分支 ref，验完后**用同样的命令** redeploy 把它去掉即可（`AllowedSubjects` 是普通参数，可以反复改；只有 `CreateOIDCProvider` 不能反复 flip，见下方坑位）。
+
+   > **坑位（2026-04-22 真实事故）**：`CreateOIDCProvider` 参数**只在第一次 deploy 时选定一次**，之后每次 redeploy 都必须保持同值。
+   > - 如果首次用 `true`（让本栈创建 provider），之后所有 redeploy 都必须保持 `true`，否则 CFN 会把 provider 当成「资源被移除」直接删除（已加 `DeletionPolicy: Retain` 兜底，但仍会脱离栈管理，下一次再 flip 回 `true` 会因为 provider 已存在而 `EntityAlreadyExists` 失败）。
+   > - 如果首次用 `false`（手动 step 1 已创建 provider），之后保持 `false` 即可。
+   > 简言之：**首次定一次，后续不改这个参数**。要改 `AllowedSubjects` / `TargetInstanceId` / `GitHubRepo` 都没问题。
 
 3. **GitHub repo variables（Settings → Secrets and variables → Actions → Variables）**：
 

--- a/deploy/aws/cloudformation/cicd-oidc.yaml
+++ b/deploy/aws/cloudformation/cicd-oidc.yaml
@@ -31,9 +31,13 @@ Parameters:
     Default: "true"
     AllowedValues: ["true", "false"]
     Description: >-
-      Create the GitHub OIDC provider in this account. Set to "false" if the
-      provider was already created (e.g. by another stack); the role will then
-      reference the existing provider ARN derived from this account.
+      Create the GitHub OIDC provider in this account. Set to "false" ONLY on
+      the very first deploy if the provider already exists (e.g. another stack
+      in the account already owns it). DO NOT flip this from "true" to "false"
+      on a subsequent deploy of the same stack: even with the Retain policy
+      below, that drops the provider out of stack management and any future
+      flip back to "true" will fail with "EntityAlreadyExists". Pick a value
+      at first deploy and keep it.
 
 Conditions:
   ShouldCreateOIDC: !Equals [!Ref CreateOIDCProvider, "true"]
@@ -42,6 +46,13 @@ Resources:
   GitHubOIDCProvider:
     Type: AWS::IAM::OIDCProvider
     Condition: ShouldCreateOIDC
+    # Retain on stack delete OR on resource removal from the template (the
+    # CreateOIDCProvider=false path), so we never accidentally tear down the
+    # account-wide GitHub OIDC trust by deploying this stack with the wrong
+    # parameter value. Real teardown must be deliberate (manual aws iam
+    # delete-open-id-connect-provider).
+    DeletionPolicy: Retain
+    UpdateReplacePolicy: Retain
     Properties:
       Url: https://token.actions.githubusercontent.com
       ClientIdList:


### PR DESCRIPTION
## Summary

After PR #30 merged, redeploying `tokenkey-cicd-oidc` with `CreateOIDCProvider=false` (intent: narrow `AllowedSubjects` back to main only) silently triggered `iam:DeleteOpenIDConnectProvider`. CFN treated the conditional resource being absent from the rendered template as "delete this resource" and the next workflow on main failed with `No OpenIDConnect provider found`.

This PR closes that footgun:

- `DeletionPolicy: Retain` + `UpdateReplacePolicy: Retain` on `GitHubOIDCProvider` so dropping the conditional resource from the template no longer deletes the IAM provider.
- Parameter description + README explicitly: `CreateOIDCProvider` is a one-time-pick parameter; `AllowedSubjects` / `TargetInstanceId` / `GitHubRepo` can change freely on redeploy.

## Risk

Low. Template-only change; no runtime resource is altered. Operationally we already manually re-deployed with `CreateOIDCProvider=true` to restore the deleted provider — main is currently green (run [24785359330](https://github.com/youxuanxue/sub2api/actions/runs/24785359330)).

## Validation

- `./scripts/preflight.sh` PASS
- After this PR merges, redeploy `tokenkey-cicd-oidc` once more (with the same `CreateOIDCProvider=true` we currently have) so the new `Retain` policies take effect on the existing resource. Future `AllowedSubjects` flips will then be safe.


Made with [Cursor](https://cursor.com)