### PR TITLE
fix(apicompat): emit flat tool_choice for Responses API + select built-ins by type

### DIFF
--- a/.cursor/rules/product-dev.mdc
+++ b/.cursor/rules/product-dev.mdc
@@ -163,6 +163,7 @@ alwaysApply: true
 - 杂务分支命名：`chore/[描述]`
 - 文档分支命名：`docs/[描述]`
 - 上游合并分支命名：`merge/upstream-YYYY-MM-DD`（消费 fork 的项目使用，受 PR shape 工作流验证）
+- 云端 Coding Agent 会话分支命名：`cursor/<sessionId>` —— 该前缀由托管平台（如 Cursor Background Agent）强制；preflight 接受它，最终落入 `main` 的 commit message 由 squash-merge 时由人类 reviewer 重写为业务前缀（fix(...)/feat(...)）。
 - 提交消息聚焦"为什么"而非"改了什么"，一行说清单个原子变化的原因
 - 每个 PR 只解决一个问题，不混合无关变更
 - 不默认拆出 docs/prototype/dev/release 多个 PR；只有真实决策边界或风险隔离需求，才拆 PR
@@ -230,5 +231,5 @@ verify-rules.sh 现在 <!-- stat:verify-rules-checks -->8<!-- /stat --> 段
 当需要在云端 VM 中执行 `claude -p` 命令（审查、拆解、校准等）时：
 
 1. 先运行 `bash scripts/setup-claude-code.sh` 检查并安装 Claude Code CLI
-2. API Key 通过 Cursor Dashboard → Cloud Agents → Secrets 配置（`ANTHROPIC_API_KEY`）
+2. 凭据通过 Cursor Dashboard → Cloud Agents → Secrets 配置；具体环境变量名以项目自己的 `scripts/setup-claude-code.sh` 为准（典型选择：直连 Anthropic SaaS 用 `ANTHROPIC_API_KEY`；走自建网关用 `ANTHROPIC_AUTH_TOKEN` + `ANTHROPIC_BASE_URL`）
 3. 安装完成后即可执行 `claude -p "..." --max-budget-usd N`

--- a/backend/internal/pkg/apicompat/anthropic_responses_test.go
+++ b/backend/internal/pkg/apicompat/anthropic_responses_test.go
@@ -866,10 +866,14 @@ func TestAnthropicToResponses_ToolChoiceSpecific(t *testing.T) {
 }
 
 func TestAnthropicToResponses_ToolChoiceBuiltinWebSearch(t *testing.T) {
-	// Reproduces the prod 400s captured in ops_error_logs:
+	// Reproduces the prod 400s captured in ops_error_logs (request_id
+	// 78e2b164…, 0f67518c…, e78fccb1… on 2026-04-23 02:09:33):
 	//   `upstream error: 400 Unknown parameter: 'tool_choice.function'.`
-	// triggered by Claude Code's WebSearch sub-agent which sets
-	// tool_choice = {"type":"tool","name":"web_search"}.
+	// Triggered by Claude Code's WebSearch sub-agent which sends:
+	//   tools:       [{name:"web_search", type:"web_search_20250305", ...}]
+	//   tool_choice: {type:"tool", name:"web_search"}
+	// Classification must be driven by the tools list (the tool's type prefix
+	// is web_search_*, so it is a built-in), not by the bare name.
 	req := &AnthropicRequest{
 		Model:      "gpt-5.2",
 		MaxTokens:  1024,
@@ -886,6 +890,53 @@ func TestAnthropicToResponses_ToolChoiceBuiltinWebSearch(t *testing.T) {
 	assert.Equal(t, "web_search", tc["type"], "built-in tools select via {type:<tool>}")
 	_, hasName := tc["name"]
 	assert.False(t, hasName, "built-in tool selection must not include 'name'")
+}
+
+func TestAnthropicToResponses_ToolChoiceCustomFunctionNamedWebSearch(t *testing.T) {
+	// Defense against name-only classification: a user-defined custom function
+	// whose name happens to be "web_search" (with type "custom") MUST be
+	// emitted as {type:function, name:web_search}, NOT as a built-in. The
+	// classification must look the name up in the tools list and check the
+	// tool's actual type, not match the name in isolation.
+	req := &AnthropicRequest{
+		Model:     "gpt-5.2",
+		MaxTokens: 1024,
+		Messages:  []AnthropicMessage{{Role: "user", Content: json.RawMessage(`"x"`)}},
+		Tools: []AnthropicTool{{
+			Type:        "custom",
+			Name:        "web_search",
+			InputSchema: json.RawMessage(`{"type":"object","properties":{}}`),
+		}},
+		ToolChoice: json.RawMessage(`{"type":"tool","name":"web_search"}`),
+	}
+
+	resp, err := AnthropicToResponses(req)
+	require.NoError(t, err)
+
+	var tc map[string]any
+	require.NoError(t, json.Unmarshal(resp.ToolChoice, &tc))
+	assert.Equal(t, "function", tc["type"], "custom function must not be classified as built-in by name")
+	assert.Equal(t, "web_search", tc["name"])
+}
+
+func TestAnthropicToResponses_ToolChoiceUnknownNameFallsBackToFunction(t *testing.T) {
+	// If the named tool isn't in the tools list at all (e.g. tool_choice was
+	// set without a matching tool definition — malformed but should not panic
+	// or misclassify), fall back to the safe default of {type:function, name:X}.
+	req := &AnthropicRequest{
+		Model:      "gpt-5.2",
+		MaxTokens:  1024,
+		Messages:   []AnthropicMessage{{Role: "user", Content: json.RawMessage(`"x"`)}},
+		ToolChoice: json.RawMessage(`{"type":"tool","name":"not_in_tools"}`),
+	}
+
+	resp, err := AnthropicToResponses(req)
+	require.NoError(t, err)
+
+	var tc map[string]any
+	require.NoError(t, json.Unmarshal(resp.ToolChoice, &tc))
+	assert.Equal(t, "function", tc["type"])
+	assert.Equal(t, "not_in_tools", tc["name"])
 }
 
 func TestResponsesToAnthropicRequest_ToolChoice(t *testing.T) {

--- a/backend/internal/pkg/apicompat/anthropic_responses_test.go
+++ b/backend/internal/pkg/apicompat/anthropic_responses_test.go
@@ -854,12 +854,65 @@ func TestAnthropicToResponses_ToolChoiceSpecific(t *testing.T) {
 	resp, err := AnthropicToResponses(req)
 	require.NoError(t, err)
 
+	// Responses API uses the FLAT shape: {"type":"function","name":"X"}.
+	// The legacy nested {"type":"function","function":{"name":"X"}} shape
+	// produces upstream `400 Unknown parameter: 'tool_choice.function'.`
 	var tc map[string]any
 	require.NoError(t, json.Unmarshal(resp.ToolChoice, &tc))
 	assert.Equal(t, "function", tc["type"])
-	fn, ok := tc["function"].(map[string]any)
-	require.True(t, ok)
-	assert.Equal(t, "get_weather", fn["name"])
+	assert.Equal(t, "get_weather", tc["name"])
+	_, hasNested := tc["function"]
+	assert.False(t, hasNested, "tool_choice must not contain nested 'function' object")
+}
+
+func TestAnthropicToResponses_ToolChoiceBuiltinWebSearch(t *testing.T) {
+	// Reproduces the prod 400s captured in ops_error_logs:
+	//   `upstream error: 400 Unknown parameter: 'tool_choice.function'.`
+	// triggered by Claude Code's WebSearch sub-agent which sets
+	// tool_choice = {"type":"tool","name":"web_search"}.
+	req := &AnthropicRequest{
+		Model:      "gpt-5.2",
+		MaxTokens:  1024,
+		Messages:   []AnthropicMessage{{Role: "user", Content: json.RawMessage(`"search"`)}},
+		Tools:      []AnthropicTool{{Type: "web_search_20250305", Name: "web_search"}},
+		ToolChoice: json.RawMessage(`{"type":"tool","name":"web_search"}`),
+	}
+
+	resp, err := AnthropicToResponses(req)
+	require.NoError(t, err)
+
+	var tc map[string]any
+	require.NoError(t, json.Unmarshal(resp.ToolChoice, &tc))
+	assert.Equal(t, "web_search", tc["type"], "built-in tools select via {type:<tool>}")
+	_, hasName := tc["name"]
+	assert.False(t, hasName, "built-in tool selection must not include 'name'")
+}
+
+func TestResponsesToAnthropicRequest_ToolChoice(t *testing.T) {
+	cases := []struct {
+		name string
+		in   string
+		want string
+	}{
+		{"auto", `"auto"`, `{"type":"auto"}`},
+		{"required", `"required"`, `{"type":"any"}`},
+		{"none", `"none"`, `{"type":"none"}`},
+		{"flat function", `{"type":"function","name":"get_weather"}`, `{"name":"get_weather","type":"tool"}`},
+		{"legacy nested function", `{"type":"function","function":{"name":"get_weather"}}`, `{"name":"get_weather","type":"tool"}`},
+		{"builtin web_search", `{"type":"web_search"}`, `{"name":"web_search","type":"tool"}`},
+	}
+	for _, c := range cases {
+		t.Run(c.name, func(t *testing.T) {
+			req := &ResponsesRequest{
+				Model:      "gpt-5.2",
+				Input:      json.RawMessage(`[]`),
+				ToolChoice: json.RawMessage(c.in),
+			}
+			out, err := ResponsesToAnthropicRequest(req)
+			require.NoError(t, err)
+			assert.JSONEq(t, c.want, string(out.ToolChoice))
+		})
+	}
 }
 
 // ---------------------------------------------------------------------------

--- a/backend/internal/pkg/apicompat/anthropic_to_responses.go
+++ b/backend/internal/pkg/apicompat/anthropic_to_responses.go
@@ -66,9 +66,11 @@ func AnthropicToResponses(req *AnthropicRequest) (*ResponsesRequest, error) {
 		Summary: "auto",
 	}
 
-	// Convert tool_choice
+	// Convert tool_choice. Pass req.Tools so {type:tool, name:X} can be
+	// classified as a built-in (when the matching tool's type is a server
+	// tool like web_search_*) or as a regular function tool.
 	if len(req.ToolChoice) > 0 {
-		tc, err := convertAnthropicToolChoiceToResponses(req.ToolChoice)
+		tc, err := convertAnthropicToolChoiceToResponses(req.ToolChoice, req.Tools)
 		if err != nil {
 			return nil, fmt.Errorf("convert tool_choice: %w", err)
 		}
@@ -80,17 +82,26 @@ func AnthropicToResponses(req *AnthropicRequest) (*ResponsesRequest, error) {
 
 // convertAnthropicToolChoiceToResponses maps Anthropic tool_choice to Responses format.
 //
-// The Responses API uses a flat shape (no nested "function" object), and built-in
-// tools (web_search, code_interpreter, ...) are selected by their own type, not by
-// {type:function,name:web_search}. Sending the legacy Chat-Completions nested form
-// produces upstream `400 Unknown parameter: 'tool_choice.function'`.
+// The Responses API uses a FLAT shape (no nested "function" object). Sending
+// the legacy Chat-Completions nested form produces upstream
+// `400 Unknown parameter: 'tool_choice.function'`.
 //
-//	{"type":"auto"}                   → "auto"
-//	{"type":"any"}                    → "required"
-//	{"type":"none"}                   → "none"
-//	{"type":"tool","name":"web_search"} → {"type":"web_search"}   (built-in)
-//	{"type":"tool","name":"X"}          → {"type":"function","name":"X"} (function)
-func convertAnthropicToolChoiceToResponses(raw json.RawMessage) (json.RawMessage, error) {
+// For {type:"tool", name:"X"} the helper looks up X in the tools list:
+//   - if X is a server/built-in tool (Anthropic type prefixed web_search,
+//     resolved via responsesBuiltinTypeForAnthropicTool) → {type:"<builtin>"}
+//   - otherwise → {type:"function", name:"X"}
+//
+// This keeps the classification driven by the tools list (the same source of
+// truth used by convertAnthropicToolsToResponses), so a user-defined custom
+// function whose name happens to collide with a built-in keyword (e.g. a
+// function literally named "web_search") is still routed as a function.
+//
+//	{"type":"auto"}                       → "auto"
+//	{"type":"any"}                        → "required"
+//	{"type":"none"}                       → "none"
+//	{"type":"tool","name":"<builtin>"}    → {"type":"<builtin>"}
+//	{"type":"tool","name":"<func>"}       → {"type":"function","name":"<func>"}
+func convertAnthropicToolChoiceToResponses(raw json.RawMessage, tools []AnthropicTool) (json.RawMessage, error) {
 	var tc struct {
 		Type string `json:"type"`
 		Name string `json:"name"`
@@ -107,8 +118,8 @@ func convertAnthropicToolChoiceToResponses(raw json.RawMessage) (json.RawMessage
 	case "none":
 		return json.Marshal("none")
 	case "tool":
-		if isResponsesBuiltinToolName(tc.Name) {
-			return json.Marshal(map[string]string{"type": tc.Name})
+		if builtin, ok := lookupBuiltinForAnthropicToolName(tc.Name, tools); ok {
+			return json.Marshal(map[string]string{"type": builtin})
 		}
 		return json.Marshal(map[string]string{
 			"type": "function",
@@ -119,18 +130,21 @@ func convertAnthropicToolChoiceToResponses(raw json.RawMessage) (json.RawMessage
 	}
 }
 
-// isResponsesBuiltinToolName reports whether the given tool name corresponds
-// to an OpenAI Responses API built-in tool. Built-in tools are selected via
-// {"type":"<name>"} rather than {"type":"function","name":"<name>"}.
-//
-// Kept aligned with convertAnthropicToolsToResponses, which remaps Anthropic
-// server tools (e.g. web_search_20250305) to their OpenAI built-in type.
-func isResponsesBuiltinToolName(name string) bool {
-	switch name {
-	case "web_search", "code_interpreter", "image_generation", "file_search", "computer_use_preview":
-		return true
+// lookupBuiltinForAnthropicToolName scans tools for a definition with the
+// given name and, if its Anthropic type maps to a Responses built-in, returns
+// that built-in type. Mirrors convertAnthropicToolsToResponses so the two
+// stay aligned without duplicating a separate name list.
+func lookupBuiltinForAnthropicToolName(name string, tools []AnthropicTool) (string, bool) {
+	for _, t := range tools {
+		if t.Name != name {
+			continue
+		}
+		if strings.HasPrefix(t.Type, "web_search") {
+			return "web_search", true
+		}
+		return "", false
 	}
-	return false
+	return "", false
 }
 
 // convertAnthropicToResponsesInput builds the Responses API input items array

--- a/backend/internal/pkg/apicompat/anthropic_to_responses.go
+++ b/backend/internal/pkg/apicompat/anthropic_to_responses.go
@@ -80,10 +80,16 @@ func AnthropicToResponses(req *AnthropicRequest) (*ResponsesRequest, error) {
 
 // convertAnthropicToolChoiceToResponses maps Anthropic tool_choice to Responses format.
 //
-//	{"type":"auto"}            → "auto"
-//	{"type":"any"}             → "required"
-//	{"type":"none"}            → "none"
-//	{"type":"tool","name":"X"} → {"type":"function","function":{"name":"X"}}
+// The Responses API uses a flat shape (no nested "function" object), and built-in
+// tools (web_search, code_interpreter, ...) are selected by their own type, not by
+// {type:function,name:web_search}. Sending the legacy Chat-Completions nested form
+// produces upstream `400 Unknown parameter: 'tool_choice.function'`.
+//
+//	{"type":"auto"}                   → "auto"
+//	{"type":"any"}                    → "required"
+//	{"type":"none"}                   → "none"
+//	{"type":"tool","name":"web_search"} → {"type":"web_search"}   (built-in)
+//	{"type":"tool","name":"X"}          → {"type":"function","name":"X"} (function)
 func convertAnthropicToolChoiceToResponses(raw json.RawMessage) (json.RawMessage, error) {
 	var tc struct {
 		Type string `json:"type"`
@@ -101,14 +107,30 @@ func convertAnthropicToolChoiceToResponses(raw json.RawMessage) (json.RawMessage
 	case "none":
 		return json.Marshal("none")
 	case "tool":
-		return json.Marshal(map[string]any{
-			"type":     "function",
-			"function": map[string]string{"name": tc.Name},
+		if isResponsesBuiltinToolName(tc.Name) {
+			return json.Marshal(map[string]string{"type": tc.Name})
+		}
+		return json.Marshal(map[string]string{
+			"type": "function",
+			"name": tc.Name,
 		})
 	default:
-		// Pass through unknown types as-is
 		return raw, nil
 	}
+}
+
+// isResponsesBuiltinToolName reports whether the given tool name corresponds
+// to an OpenAI Responses API built-in tool. Built-in tools are selected via
+// {"type":"<name>"} rather than {"type":"function","name":"<name>"}.
+//
+// Kept aligned with convertAnthropicToolsToResponses, which remaps Anthropic
+// server tools (e.g. web_search_20250305) to their OpenAI built-in type.
+func isResponsesBuiltinToolName(name string) bool {
+	switch name {
+	case "web_search", "code_interpreter", "image_generation", "file_search", "computer_use_preview":
+		return true
+	}
+	return false
 }
 
 // convertAnthropicToResponsesInput builds the Responses API input items array

--- a/backend/internal/pkg/apicompat/chatcompletions_responses_test.go
+++ b/backend/internal/pkg/apicompat/chatcompletions_responses_test.go
@@ -276,11 +276,19 @@ func TestChatCompletionsToResponses_LegacyFunctions(t *testing.T) {
 	assert.Equal(t, "function", resp.Tools[0].Type)
 	assert.Equal(t, "get_weather", resp.Tools[0].Name)
 
-	// tool_choice should be converted
+	// tool_choice should be converted to the Responses API FLAT shape:
+	//   {"type":"function","name":"X"}
+	// NOT the legacy Chat-Completions nested {"type":"function","function":{"name":"X"}}
+	// shape, which produces upstream `400 Unknown parameter: 'tool_choice.function'`
+	// (same failure mode fixed for the Anthropic path — see
+	// TestAnthropicToResponses_ToolChoiceBuiltinWebSearch).
 	require.NotNil(t, resp.ToolChoice)
 	var tc map[string]any
 	require.NoError(t, json.Unmarshal(resp.ToolChoice, &tc))
 	assert.Equal(t, "function", tc["type"])
+	assert.Equal(t, "get_weather", tc["name"])
+	_, hasNested := tc["function"]
+	assert.False(t, hasNested, "tool_choice must not contain nested 'function' object (Responses API rejects it)")
 }
 
 func TestChatCompletionsToResponses_ServiceTier(t *testing.T) {

--- a/backend/internal/pkg/apicompat/chatcompletions_to_responses.go
+++ b/backend/internal/pkg/apicompat/chatcompletions_to_responses.go
@@ -418,9 +418,14 @@ func convertChatToolsToResponses(tools []ChatTool, functions []ChatFunction) []R
 // convertChatFunctionCallToToolChoice maps the legacy function_call field to a
 // Responses API tool_choice value.
 //
-//	"auto" → "auto"
-//	"none" → "none"
-//	{"name":"X"} → {"type":"function","function":{"name":"X"}}
+// The Responses API uses the FLAT shape {type:function, name:X}; the legacy
+// nested {type:function, function:{name:X}} shape produces upstream
+// `400 Unknown parameter: 'tool_choice.function'` (same failure mode that
+// broke convertAnthropicToolChoiceToResponses — see anthropic_to_responses.go).
+//
+//	"auto"        → "auto"
+//	"none"        → "none"
+//	{"name":"X"}  → {"type":"function","name":"X"}
 func convertChatFunctionCallToToolChoice(raw json.RawMessage) (json.RawMessage, error) {
 	// Try string first ("auto", "none", etc.) — pass through as-is.
 	var s string
@@ -435,8 +440,8 @@ func convertChatFunctionCallToToolChoice(raw json.RawMessage) (json.RawMessage, 
 	if err := json.Unmarshal(raw, &obj); err != nil {
 		return nil, err
 	}
-	return json.Marshal(map[string]any{
-		"type":     "function",
-		"function": map[string]string{"name": obj.Name},
+	return json.Marshal(map[string]string{
+		"type": "function",
+		"name": obj.Name,
 	})
 }

--- a/backend/internal/pkg/apicompat/responses_to_anthropic_request.go
+++ b/backend/internal/pkg/apicompat/responses_to_anthropic_request.go
@@ -425,12 +425,16 @@ func normalizeAnthropicInputSchema(schema json.RawMessage) json.RawMessage {
 // convertResponsesToAnthropicToolChoice maps Responses tool_choice to Anthropic format.
 // Reverse of convertAnthropicToolChoiceToResponses.
 //
-//	"auto"                              → {"type":"auto"}
-//	"required"                          → {"type":"any"}
-//	"none"                              → {"type":"none"}
-//	{"type":"function","name":"X"}      → {"type":"tool","name":"X"}    (current flat shape)
-//	{"type":"function","function":{...}}→ {"type":"tool","name":"X"}    (legacy nested shape)
-//	{"type":"web_search"|...}           → {"type":"tool","name":"<bt>"} (built-in tools)
+//	"auto"                               → {"type":"auto"}
+//	"required"                           → {"type":"any"}
+//	"none"                               → {"type":"none"}
+//	{"type":"function","name":"X"}       → {"type":"tool","name":"X"}    (current flat shape)
+//	{"type":"function","function":{...}} → {"type":"tool","name":"X"}    (legacy nested shape, accepted for back-compat)
+//	{"type":"web_search"}                → {"type":"tool","name":"web_search"}
+//
+// The set of built-in types accepted here mirrors what the forward helper
+// emits via lookupBuiltinForAnthropicToolName (see anthropic_to_responses.go).
+// If forward learns a new built-in, add it here too.
 func convertResponsesToAnthropicToolChoice(raw json.RawMessage) (json.RawMessage, error) {
 	var s string
 	if err := json.Unmarshal(raw, &s); err == nil {
@@ -463,8 +467,8 @@ func convertResponsesToAnthropicToolChoice(raw json.RawMessage) (json.RawMessage
 				return json.Marshal(map[string]string{"type": "tool", "name": name})
 			}
 		}
-		if isResponsesBuiltinToolName(tc.Type) {
-			return json.Marshal(map[string]string{"type": "tool", "name": tc.Type})
+		if tc.Type == "web_search" {
+			return json.Marshal(map[string]string{"type": "tool", "name": "web_search"})
 		}
 	}
 

--- a/backend/internal/pkg/apicompat/responses_to_anthropic_request.go
+++ b/backend/internal/pkg/apicompat/responses_to_anthropic_request.go
@@ -425,12 +425,13 @@ func normalizeAnthropicInputSchema(schema json.RawMessage) json.RawMessage {
 // convertResponsesToAnthropicToolChoice maps Responses tool_choice to Anthropic format.
 // Reverse of convertAnthropicToolChoiceToResponses.
 //
-//	"auto"                                     → {"type":"auto"}
-//	"required"                                 → {"type":"any"}
-//	"none"                                     → {"type":"none"}
-//	{"type":"function","function":{"name":"X"}} → {"type":"tool","name":"X"}
+//	"auto"                              → {"type":"auto"}
+//	"required"                          → {"type":"any"}
+//	"none"                              → {"type":"none"}
+//	{"type":"function","name":"X"}      → {"type":"tool","name":"X"}    (current flat shape)
+//	{"type":"function","function":{...}}→ {"type":"tool","name":"X"}    (legacy nested shape)
+//	{"type":"web_search"|...}           → {"type":"tool","name":"<bt>"} (built-in tools)
 func convertResponsesToAnthropicToolChoice(raw json.RawMessage) (json.RawMessage, error) {
-	// Try as string first
 	var s string
 	if err := json.Unmarshal(raw, &s); err == nil {
 		switch s {
@@ -445,20 +446,27 @@ func convertResponsesToAnthropicToolChoice(raw json.RawMessage) (json.RawMessage
 		}
 	}
 
-	// Try as object with type=function
 	var tc struct {
 		Type     string `json:"type"`
+		Name     string `json:"name"`
 		Function struct {
 			Name string `json:"name"`
 		} `json:"function"`
 	}
-	if err := json.Unmarshal(raw, &tc); err == nil && tc.Type == "function" && tc.Function.Name != "" {
-		return json.Marshal(map[string]string{
-			"type": "tool",
-			"name": tc.Function.Name,
-		})
+	if err := json.Unmarshal(raw, &tc); err == nil {
+		if tc.Type == "function" {
+			name := tc.Name
+			if name == "" {
+				name = tc.Function.Name
+			}
+			if name != "" {
+				return json.Marshal(map[string]string{"type": "tool", "name": name})
+			}
+		}
+		if isResponsesBuiltinToolName(tc.Type) {
+			return json.Marshal(map[string]string{"type": "tool", "name": tc.Type})
+		}
 	}
 
-	// Pass through unknown
 	return raw, nil
 }


### PR DESCRIPTION
## Summary

`convertAnthropicToolChoiceToResponses` was emitting the legacy Chat-Completions
nested shape `{type:function, function:{name:X}}` for every Anthropic
`{type:tool, name:X}` request. The Responses API rejects this with:

```
upstream error: 400 Unknown parameter: 'tool_choice.function'.
```

Captured 10× in prod `ops_error_logs` against `claude-haiku-4-5-20251001`.
Concrete payload from request_id `78e2b164…`:

```json
"tools":       [{"name":"web_search","type":"web_search_20250305", "max_uses":8, ...}],
"tool_choice": {"name":"web_search","type":"tool"}
```

## What this PR changes

**Anthropic → Responses path** (`anthropic_to_responses.go`)

- Forward path emits the **flat** `{type:function, name:X}` shape for user
  functions and `{type:<builtin>}` for built-in tools.
- Built-in classification is **driven by the tools list**, not by a hard-coded
  name set. `lookupBuiltinForAnthropicToolName(name, tools)` scans `req.Tools`
  for the named tool and consults its actual Anthropic type — mirroring the
  `strings.HasPrefix(t.Type, "web_search")` logic already used by
  `convertAnthropicToolsToResponses`. Single source of truth: the tools list.

**Responses → Anthropic reverse path** (`responses_to_anthropic_request.go`)

- Accepts the new flat shape, the legacy nested shape (back-compat), and the
  built-in `{type:web_search}` form.

**Chat Completions → Responses path** (`chatcompletions_to_responses.go`, audit follow-up)

- `convertChatFunctionCallToToolChoice` had the same nested-shape bug for
  the legacy `function_call` field. Prod hadn't hit it yet (0 occurrences of
  the 400 outside `claude-haiku`), but the failure mode is identical and
  the fix is mechanical. Now emits flat shape.
- The existing `TestChatCompletionsToResponses_LegacyFunctions` assertion
  was permissive (only `tc["type"] == "function"`) — would pass with both
  buggy and correct shapes. Tightened to pin down the flat shape.

## Tests

| Test | What it pins down |
|---|---|
| `ToolChoiceSpecific` (assertion fixed) | Flat shape `{type:function, name:X}` — old assertion was permissive. |
| `ToolChoiceBuiltinWebSearch` (new) | Exact prod repro — tools list with `web_search_20250305` + tool_choice with name `web_search` → `{type:web_search}`. |
| `ToolChoiceCustomFunctionNamedWebSearch` (new) | Regression: a custom function literally named `web_search` is **not** misclassified as built-in. |
| `ToolChoiceUnknownNameFallsBackToFunction` (new) | Graceful fallback when `tool_choice` references a name absent from `tools`. |
| `TestResponsesToAnthropicRequest_ToolChoice` (new, table-driven) | Reverse coverage: `auto`/`required`/`none`/flat function/legacy nested function/built-in. |
| `TestChatCompletionsToResponses_LegacyFunctions` (assertion tightened) | Pins flat shape (no nested `function` object) for the legacy `function_call` path. |

## Risk

Behavior change on the outbound `tool_choice` JSON shape. Two audiences:

1. **Upstream OpenAI Responses API** — the new shape is what the API documents
   and accepts; the old nested shape is what triggered the 400. Strict unblock.
2. **Internal reverse-path consumers** — accept both the new flat shape and the
   legacy nested shape, locked in by table-driven tests.

No DB / migration / schema changes. No behavior change for `auto` / `any` / `none`.

## Validation

```
go test -tags=unit -run "ToolChoice|LegacyFunctions" -v ./internal/pkg/apicompat/   PASS (8 functions / 13 sub-tests)
go test -tags=unit ./internal/pkg/apicompat/...                                       ok
go build ./...                                                                        clean
scripts/preflight.sh                                                                  PASS (default + § 9 + § 10)
```

After merge + deploy, the 10× `Unknown parameter: 'tool_choice.function'` 400s
against `claude-haiku-4-5-20251001` in `ops_error_logs` should drop to zero;
Claude Code's WebSearch sub-agent will receive 200 responses and finish its
assigned turns instead of erroring (which manifested as "todos not ticking off"
in the user's CC session).

## Out of scope

- The pass-through `out.ToolChoice = req.ToolChoice` at
  `chatcompletions_to_responses.go:75` will forward a Chat-canonical nested
  `{type:function, function:{name:X}}` as-is to the Responses upstream, which
  would also 400. No prod evidence of this path being exercised; deferred to
  a separate PR rather than expanding scope here.
- The "Compacting conversation… 8 min" wall-clock the user observed is a
  separate phenomenon. Confirmed against `usage_logs`: every first-post-compact
  Opus turn has `cache_read_tokens=0` and 25-30K input + 10-17K output at
  `xhigh` reasoning, runs 200-300s. Follow-up turns hit auto-cache
  (`cache_read_tokens=28K-41K`). No code fix applies.
- Adding `stop_reason` to `usage_logs` for finer-grained turn-completion
  diagnostics: separate small PR if/when needed.