### PR TITLE
ci(cla): correct allowlist to cursoragent (GitHub login, not display …

### DIFF
--- a/.github/workflows/cla.yml
+++ b/.github/workflows/cla.yml
@@ -43,13 +43,20 @@ jobs:
           # commits show up with author.user.login = "youxuanxue", remove
           # this entry.
           #
-          # `Cursor Agent` is the git author NAME automatically set on commits
-          # made by the Cursor Background Agent (cloud Coding Agent). Like
-          # `bot*` patterns, it is a non-human contributor whose commits
-          # ultimately get squashed under the maintainer's authorship at PR
-          # merge time, but during the open-PR phase the CLA bot must accept
-          # it as already-signed to avoid blocking every cloud-agent PR.
-          allowlist: "dependabot[bot],renovate[bot],bot*,yyy,Cursor Agent"
+          # `cursoragent` is the GitHub LOGIN of the Cursor Background Agent
+          # service account (https://github.com/cursoragent). The action's
+          # extractUserFromCommit prefers commit.author.user.login when the
+          # GitHub backend can resolve the commit author email to a real
+          # account. cursoragent <cursoragent@cursor.com> resolves to the
+          # github.com/cursoragent user, so the allowlist must match that
+          # login (case-sensitive), NOT the git author display name
+          # ("Cursor Agent" with a space) which is only the fallback when no
+          # GitHub user is linked. Like `bot*` patterns, this is a non-human
+          # contributor whose commits ultimately get squashed under the
+          # maintainer's authorship at PR merge time, but during the open-PR
+          # phase the CLA bot must accept it as already-signed to avoid
+          # blocking every cloud-agent PR.
+          allowlist: "dependabot[bot],renovate[bot],bot*,yyy,cursoragent"
           lock-pullrequest-aftermerge: false
           custom-notsigned-prcomment: |
             Thank you for your contribution! Before we can merge this PR, we need $you to sign our [Contributor License Agreement (CLA)](https://github.com/Wei-Shaw/sub2api/blob/main/CLA.md).
@@ -74,5 +81,5 @@ jobs:
           path-to-signatures: "cla.json"
           path-to-document: "https://github.com/Wei-Shaw/sub2api/blob/main/CLA.md"
           branch: "cla-signatures"
-          allowlist: "dependabot[bot],renovate[bot],bot*,yyy,Cursor Agent"
+          allowlist: "dependabot[bot],renovate[bot],bot*,yyy,cursoragent"
           lock-pullrequest-aftermerge: true


### PR DESCRIPTION
…name)

The previous fix in #36 added "Cursor Agent" (the git author display name) to the CLA allowlist, but PR #35 still failed cla-check. Root cause: the contributor-assistant action prefers commit.author.user.login when the GitHub backend resolves the commit email to a real account. The Cursor Background Agent's commits are authored by cursoragent@cursor.com which resolves to https://github.com/cursoragent (login=cursoragent), so the action checks the allowlist for "cursoragent" — not the display name "Cursor Agent". Allowlist match is case-sensitive and exact for non-glob entries.

This commit replaces "Cursor Agent" with "cursoragent" in both the cla-check and cla-lock allowlists and updates the inline comment to explain the GitHub-login vs display-name distinction so the next reader doesn't need to re-discover it.

Verified locally: gh api /repos/.../commits/<sha> --jq '.author' returns {login:"cursoragent", id:199161495, ...}.

Once merged to main, PR #35 cla-check will pass on the next push.