### PR TITLE
feat(cloud-agent): switch Claude Code auth to TokenKey gateway (drop ANTHROPIC_API_KEY)

### DIFF
--- a/.cursor/cloud-agent-install.sh
+++ b/.cursor/cloud-agent-install.sh
@@ -1,0 +1,58 @@
+#!/usr/bin/env bash
+#
+# .cursor/cloud-agent-install.sh — bootstrap script run once per Cursor
+# Cloud Agent session (referenced by .cursor/environment.json).
+#
+# What this script is for:
+#   1. Initialize the dev-rules submodule (preflight depends on it).
+#   2. Sync the sibling new-api repo to the pinned SHA so backend Go
+#      builds resolve the `replace` directive in backend/go.mod.
+#   3. Install Claude Code CLI and write ~/.claude/settings.json so the
+#      agent's `claude` invocations talk to the TokenKey gateway with
+#      the same knobs we use locally.
+#
+# What this script is NOT for:
+#   - Backend runtime config (DB / Redis / payment keys). The cloud agent
+#     does not start the backend; it only reads/writes code and runs
+#     preflight + tests that don't need a live datastore.
+#
+# Required Cursor Cloud Agents secret (Dashboard → Cloud Agents → Secrets):
+#   ANTHROPIC_AUTH_TOKEN   sk-... TokenKey gateway token
+#
+# Non-secret defaults are baked in here on purpose — they are project
+# policy, not credentials, and changing them deserves a PR diff.
+set -euo pipefail
+
+REPO_ROOT="$(cd "$(dirname "$0")/.." && pwd)"
+cd "$REPO_ROOT"
+
+echo "[cloud-agent] initializing dev-rules submodule"
+git submodule update --init --recursive
+
+echo "[cloud-agent] syncing sibling new-api to pinned SHA"
+bash scripts/sync-new-api.sh
+
+echo "[cloud-agent] installing Claude Code CLI + writing ~/.claude/settings.json"
+: "${ANTHROPIC_AUTH_TOKEN:?ANTHROPIC_AUTH_TOKEN must be set in Cursor Cloud Agents Secrets}"
+
+mkdir -p "$HOME/.claude"
+# 0600 on settings.json — token must not be world-readable on shared hosts.
+umask 077
+cat > "$HOME/.claude/settings.json" <<EOF
+{
+  "effortLevel": "high",
+  "env": {
+    "ANTHROPIC_BASE_URL": "https://api.tokenkey.dev",
+    "ANTHROPIC_AUTH_TOKEN": "${ANTHROPIC_AUTH_TOKEN}",
+    "CLAUDE_CODE_DISABLE_ADAPTIVE_THINKING": "1",
+    "MAX_THINKING_TOKENS": "31999",
+    "CLAUDE_CODE_DISABLE_1M_CONTEXT": "1",
+    "CLAUDE_CODE_AUTO_COMPACT_WINDOW": "200000",
+    "CLAUDE_CODE_ATTRIBUTION_HEADER": "0"
+  }
+}
+EOF
+
+bash scripts/setup-claude-code.sh
+
+echo "[cloud-agent] install complete"

--- a/.cursor/environment.json
+++ b/.cursor/environment.json
@@ -1,0 +1,4 @@
+{
+  "install": "bash .cursor/cloud-agent-install.sh",
+  "terminals": []
+}

--- a/.cursor/rules/product-dev.mdc
+++ b/.cursor/rules/product-dev.mdc
@@ -231,5 +231,5 @@ verify-rules.sh 现在 <!-- stat:verify-rules-checks -->8<!-- /stat --> 段
 当需要在云端 VM 中执行 `claude -p` 命令（审查、拆解、校准等）时：
 
 1. 先运行 `bash scripts/setup-claude-code.sh` 检查并安装 Claude Code CLI
-2. API Key 通过 Cursor Dashboard → Cloud Agents → Secrets 配置（`ANTHROPIC_API_KEY`）
+2. 凭据通过 Cursor Dashboard → Cloud Agents → Secrets 配置；具体环境变量名以项目自己的 `scripts/setup-claude-code.sh` 为准（典型选择：直连 Anthropic SaaS 用 `ANTHROPIC_API_KEY`；走自建网关用 `ANTHROPIC_AUTH_TOKEN` + `ANTHROPIC_BASE_URL`）
 3. 安装完成后即可执行 `claude -p "..." --max-budget-usd N`

--- a/.github/actions/agent-draft-pr/action.yml
+++ b/.github/actions/agent-draft-pr/action.yml
@@ -10,9 +10,13 @@ inputs:
   workflow:
     description: Source workflow name
     required: true
-  claude_api_key:
-    description: Claude API key
+  claude_auth_token:
+    description: TokenKey gateway auth token (sk-...) consumed by Claude Code CLI as ANTHROPIC_AUTH_TOKEN
     required: true
+  claude_base_url:
+    description: Claude Code gateway base URL
+    required: false
+    default: "https://api.tokenkey.dev"
   max_budget_usd:
     description: Max budget for a single agent run
     default: "2.00"
@@ -25,6 +29,8 @@ runs:
 
     - name: Install Claude Code CLI
       shell: bash
+      env:
+        ANTHROPIC_AUTH_TOKEN: ${{ inputs.claude_auth_token }}
       run: |
         if [ -x scripts/setup-claude-code.sh ]; then
           bash scripts/setup-claude-code.sh
@@ -92,7 +98,16 @@ runs:
       if: steps.cooldown.outputs.skip == 'false'
       shell: bash
       env:
-        ANTHROPIC_API_KEY: ${{ inputs.claude_api_key }}
+        # TokenKey gateway path — mirrors ~/.claude/settings.json on the
+        # cloud Cursor Agent (see .cursor/cloud-agent-install.sh). Keep this
+        # block in sync with that file so CI and Agent share one config.
+        ANTHROPIC_AUTH_TOKEN: ${{ inputs.claude_auth_token }}
+        ANTHROPIC_BASE_URL: ${{ inputs.claude_base_url }}
+        CLAUDE_CODE_DISABLE_ADAPTIVE_THINKING: "1"
+        MAX_THINKING_TOKENS: "31999"
+        CLAUDE_CODE_DISABLE_1M_CONTEXT: "1"
+        CLAUDE_CODE_AUTO_COMPACT_WINDOW: "200000"
+        CLAUDE_CODE_ATTRIBUTION_HEADER: "0"
       run: |
         claude -p "$(cat /tmp/agent-prompt.txt)" \
           --max-budget-usd "${{ inputs.max_budget_usd }}" \

--- a/.github/workflows/error-clustering-daily.yml
+++ b/.github/workflows/error-clustering-daily.yml
@@ -209,7 +209,7 @@ jobs:
           report_path: report.md
           report_json: report.json
           workflow: error-clustering
-          claude_api_key: ${{ secrets.ANTHROPIC_API_KEY }}
+          claude_auth_token: ${{ secrets.ANTHROPIC_AUTH_TOKEN }}
 
       - name: Notify Feishu
         if: always()

--- a/.gitignore
+++ b/.gitignore
@@ -129,6 +129,7 @@ scripts/*
 !scripts/check_approved_docs.py
 !scripts/newapi-sentinels.json
 !scripts/check-newapi-sentinels.py
+!scripts/setup-claude-code.sh
 !scripts/error_clustering/
 !scripts/error_clustering/**
 !scripts/build-error-clustering-binary.sh

--- a/scripts/setup-claude-code.sh
+++ b/scripts/setup-claude-code.sh
@@ -1,0 +1,31 @@
+#!/usr/bin/env bash
+#
+# setup-claude-code.sh — install Claude Code CLI and verify auth is wired.
+#
+# Auth model (TokenKey):
+#   We do NOT use Anthropic's SaaS API key path. The CLI talks to the
+#   self-hosted gateway (https://api.tokenkey.dev) via:
+#     ANTHROPIC_BASE_URL  + ANTHROPIC_AUTH_TOKEN
+#   These are normally set in ~/.claude/settings.json (see
+#   .cursor/cloud-agent-install.sh for the canonical layout). CI workflows
+#   pass them as environment variables instead, so this script accepts
+#   either path.
+#
+# Exit non-zero only when the CLI cannot authenticate at all.
+set -euo pipefail
+
+if ! command -v claude >/dev/null 2>&1; then
+  npm install -g @anthropic-ai/claude-code
+fi
+
+if [ -z "${ANTHROPIC_AUTH_TOKEN:-}" ] && [ ! -s "${HOME}/.claude/settings.json" ]; then
+  echo "Claude Code CLI auth missing." >&2
+  echo "  Set ANTHROPIC_AUTH_TOKEN in the environment, OR provide" >&2
+  echo "  ~/.claude/settings.json (see .cursor/cloud-agent-install.sh)." >&2
+  exit 1
+fi
+
+claude --version >/dev/null 2>&1 || {
+  echo "Claude Code CLI install check failed" >&2
+  exit 1
+}


### PR DESCRIPTION
## Summary

Removes every `ANTHROPIC_API_KEY` reference and wires the existing TokenKey-gateway auth (`ANTHROPIC_BASE_URL` + `ANTHROPIC_AUTH_TOKEN`, the same shape humans already keep in `~/.claude/settings.json`) end to end across:

- `scripts/setup-claude-code.sh` — accept either `ANTHROPIC_AUTH_TOKEN` env or non-empty `~/.claude/settings.json`; legacy `ANTHROPIC_API_KEY` is no longer recognized. Also adds the script to the `.gitignore` allow-list — it was never tracked, so CI's `if [ -x scripts/setup-claude-code.sh ]` always silently fell to the npm fallback and the auth gate never ran.
- `.github/actions/agent-draft-pr/action.yml` — input renamed `claude_api_key` → `claude_auth_token`; CI now exports the same `ANTHROPIC_BASE_URL` + `ANTHROPIC_AUTH_TOKEN` + `CLAUDE_CODE_*` block we keep in `~/.claude/settings.json`, so CI and the cloud Cursor Agent share one config surface.
- `.github/workflows/error-clustering-daily.yml` — passes `secrets.ANTHROPIC_AUTH_TOKEN`.
- `.cursor/environment.json` + `.cursor/cloud-agent-install.sh` (new) — cloud Cursor Agent bootstrap: init `dev-rules` submodule, sync sibling `new-api` to the pinned SHA, install Claude Code CLI, render `~/.claude/settings.json` from the single secret, run `setup-claude-code.sh` to verify.

## Risk

Common (auth-config rewire). No business logic touched.

- Any downstream caller still expecting input `claude_api_key` on `agent-draft-pr` will fail loudly with "unknown input" — there is exactly one caller (`error-clustering-daily.yml`) and it is migrated in the same diff.
- The legacy `ANTHROPIC_API_KEY` path is now actively rejected by `setup-claude-code.sh`; this is intentional so a half-migrated environment fails fast instead of silently routing to Anthropic SaaS.

## Operator action required after merge

1. **Cursor Dashboard → Cloud Agents → Secrets**: add `ANTHROPIC_AUTH_TOKEN` (`sk-...` from the TokenKey gateway). Remove `ANTHROPIC_API_KEY` if previously set.
2. **GitHub repo Secrets**: add `ANTHROPIC_AUTH_TOKEN`; the old `ANTHROPIC_API_KEY` secret can be deleted once `error-clustering-daily` has run once on `main`.

## Validation

- `bash -n` on both new shell scripts; `python yaml.safe_load` on the modified Action and workflow; `python json.load` on `.cursor/environment.json`.
- Stub-binary smoke test of `scripts/setup-claude-code.sh` over four branches:
  - no auth → exit 1 (helpful error)
  - `ANTHROPIC_AUTH_TOKEN` set → exit 0
  - only `~/.claude/settings.json` present → exit 0
  - only legacy `ANTHROPIC_API_KEY` → exit 1 (deprecated path is dead)
- `./scripts/preflight.sh` PASS — all 10 sections (8 dev-rules + § 9 newapi compat-pool + § 10 newapi sentinel registry).

Made with [Cursor](https://cursor.com)