### PR TITLE
chore: auto-run environment consistency bootstrap in cloud install

### DIFF
--- a/.cursor/cloud-agent-install.sh
+++ b/.cursor/cloud-agent-install.sh
@@ -10,6 +10,13 @@
 #   3. Install Claude Code CLI and write ~/.claude/settings.json so the
 #      agent's `claude` invocations talk to the TokenKey gateway with
 #      the same knobs we use locally.
+#   4. Run the local/cloud consistency bootstrap template automatically:
+#      - git pull origin main
+#      - git submodule update --init --recursive
+#      - bash scripts/sync-new-api.sh --check || bash scripts/sync-new-api.sh
+#      - pnpm --dir frontend install
+#      - bash scripts/preflight.sh (non-blocking check)
+#      - make test (non-blocking check)
 #
 # What this script is NOT for:
 #   - Backend runtime config (DB / Redis / payment keys). The cloud agent
@@ -26,11 +33,27 @@ set -euo pipefail
 REPO_ROOT="$(cd "$(dirname "$0")/.." && pwd)"
 cd "$REPO_ROOT"
 
+warn() {
+  echo "[cloud-agent][warn] $*" >&2
+}
+
 echo "[cloud-agent] initializing dev-rules submodule"
 git submodule update --init --recursive
 
 echo "[cloud-agent] syncing sibling new-api to pinned SHA"
-bash scripts/sync-new-api.sh
+bash scripts/sync-new-api.sh --check || bash scripts/sync-new-api.sh
+
+echo "[cloud-agent] syncing local branch with origin/main"
+# Cloud agents normally start from a fresh clone, but pulling here keeps
+# behavior aligned with local "start-of-session" workflows.
+git pull --ff-only origin main || warn "git pull origin main failed; continuing with checked-out revision"
+
+echo "[cloud-agent] installing frontend dependencies via pnpm"
+pnpm --dir frontend install --frozen-lockfile
+
+echo "[cloud-agent] running consistency checks (non-blocking)"
+bash scripts/preflight.sh || warn "preflight failed; see logs above"
+make test || warn "make test failed; investigate before merge"
 
 echo "[cloud-agent] installing Claude Code CLI + writing ~/.claude/settings.json"
 : "${ANTHROPIC_AUTH_TOKEN:?ANTHROPIC_AUTH_TOKEN must be set in Cursor Cloud Agents Secrets}"


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary
- Update `.cursor/cloud-agent-install.sh` to automatically run the local/cloud consistency bootstrap template on each Cloud Agent session:
  - `git submodule update --init --recursive`
  - `bash scripts/sync-new-api.sh --check || bash scripts/sync-new-api.sh`
  - `git pull --ff-only origin main` (warn-only on failure)
  - `pnpm --dir frontend install --frozen-lockfile`
  - `bash scripts/preflight.sh` (warn-only)
  - `make test` (warn-only)
- Keep critical install steps (`setup-claude-code.sh` + `~/.claude/settings.json`) intact.

## Risk
- Low risk: only changes Cloud Agent bootstrap behavior.
- Preflight and test are non-blocking in install path to avoid session hard-fail due to optional tooling gaps (e.g. `golangci-lint` missing).

## Validation
- `bash -n .cursor/cloud-agent-install.sh`
- `ANTHROPIC_AUTH_TOKEN=dummy-token bash .cursor/cloud-agent-install.sh`
  - confirms bootstrap steps execute
  - confirms preflight runs
  - confirms install continues even if `make test` warns (missing `golangci-lint` in base VM)

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-6166343a-7531-4266-9265-9b2d38f48dfd"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-6166343a-7531-4266-9265-9b2d38f48dfd"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

