### PR TITLE
chore: gitignore .prod-logs/ and .error-clusters/

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -105,6 +105,11 @@ backend/internal/web/dist/*
 # 后端运行时缓存数据
 backend/data/
 
+# Cloud Agent 拉取的 prod 运行时数据（包含真实日志行 / 错误聚合，禁止入库）
+# 由 scripts/fetch-prod-logs.sh 与 scripts/fetch-prod-error-clusters.sh 生成
+.prod-logs/
+.error-clusters/
+
 # ===================
 # 本地配置文件（包含敏感信息）
 # ===================


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Add `.prod-logs/` and `.error-clusters/` to `.gitignore`. Both are local artifact sinks for the cloud-agent prod diagnostic scripts:

- `scripts/fetch-prod-logs.sh`           → `.prod-logs/logs.txt`
- `scripts/fetch-prod-error-clusters.sh` → `.error-clusters/{report.json,report.md}`

Discovered while verifying the `fetch-prod-logs.sh` end-to-end pipeline (GitHub Actions `prod-log-dump.yml` → OIDC → SSM → docker logs → artifact download): the script left an untracked `.prod-logs/` directory that `git status` flagged for commit.

## Risk

The log dump contains live `request_id` / `client_ip` / request `path` tuples and pricing-service internals — same security class as `backend/config.yaml`. Without this gate, an inattentive `git add .` would publish prod runtime data to a public repo. Pure additive `.gitignore` change; no code or workflow impact.

## Validation

- `git check-ignore -v .prod-logs/ .error-clusters/` → both matched by the new lines
- `git status` → no longer lists `.prod-logs/` after running `fetch-prod-logs.sh`
- `bash scripts/preflight.sh` → PASS (all default + § 9 + § 10 sub2api gates)
- End-to-end log fetch verified: `SINCE=10m TAIL_LINES=200 bash scripts/fetch-prod-logs.sh` returned 15 lines / 7275 bytes from prod EC2 in ~30s
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-a89858df-b38f-45b4-9e7c-e6fa23a3d80b"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-a89858df-b38f-45b4-9e7c-e6fa23a3d80b"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

