### PR TITLE
fix(cloud-agent): provision /new-api sibling dir + de-double-slash path

### DIFF
--- a/.cursor/cloud-agent-install.sh
+++ b/.cursor/cloud-agent-install.sh
@@ -58,6 +58,34 @@ warn() {
 echo "[cloud-agent] initializing dev-rules submodule"
 git submodule update --init --recursive
 
+# scripts/sync-new-api.sh expects to clone QuantumNous/new-api as a *sibling*
+# of this repo (per CLAUDE.md §4 + backend/go.mod's `replace ../../new-api`).
+# On the Cursor cloud-agent VM the workspace lives at /workspace, so the
+# sibling target becomes /new-api — root-owned and not writable by the
+# `ubuntu` agent user. Without preparing it here, sync-new-api.sh fails with
+# `fatal: could not create work tree dir '/new-api': Permission denied` and
+# every later step that needs the new-api code (Go build, preflight § 9/§ 10,
+# `make test`) silently degrades.
+#
+# We don't push this workaround into sync-new-api.sh itself: local developer
+# machines arrange their own sibling layout (typically under ~/Codes/tk/),
+# and giving the sync script implicit `sudo mkdir` powers there would be
+# surprising. The cloud-agent install script is the right layer.
+SIBLING_PARENT="$(dirname -- "$REPO_ROOT")"
+if [ "$SIBLING_PARENT" = "/" ]; then
+  SIBLING_DIR="/new-api"
+else
+  SIBLING_DIR="$SIBLING_PARENT/new-api"
+fi
+if [ ! -d "$SIBLING_DIR/.git" ] && [ ! -w "$SIBLING_PARENT" ]; then
+  echo "[cloud-agent] preparing sibling new-api dir at $SIBLING_DIR (parent $SIBLING_PARENT not writable by $(id -un))"
+  if command -v sudo >/dev/null 2>&1 && sudo -n true 2>/dev/null; then
+    sudo install -d -o "$(id -un)" -g "$(id -gn)" -m 0755 "$SIBLING_DIR"
+  else
+    warn "no passwordless sudo available; sync-new-api.sh will likely fail at git clone"
+  fi
+fi
+
 echo "[cloud-agent] syncing sibling new-api to pinned SHA"
 bash scripts/sync-new-api.sh --check || bash scripts/sync-new-api.sh
 

--- a/scripts/sync-new-api.sh
+++ b/scripts/sync-new-api.sh
@@ -25,7 +25,17 @@ set -euo pipefail
 SCRIPT_DIR="$(cd -- "$(dirname -- "${BASH_SOURCE[0]}")" &>/dev/null && pwd)"
 SUB2API_ROOT="$(cd -- "${SCRIPT_DIR}/.." &>/dev/null && pwd)"
 PIN_FILE="${SUB2API_ROOT}/.new-api-ref"
-SIBLING_DIR="$(cd -- "${SUB2API_ROOT}/.." &>/dev/null && pwd)/new-api"
+# Resolve sibling dir without leaking a double-slash when ${SUB2API_ROOT}
+# sits directly under filesystem root (e.g. /workspace on Cursor cloud-agent
+# VMs): `dirname /workspace` → `/`, and `/` + `/new-api` would naively
+# produce `//new-api`, which propagates into every error message and stack
+# trace from this script.
+SIBLING_PARENT="$(dirname -- "${SUB2API_ROOT}")"
+if [ "${SIBLING_PARENT}" = "/" ]; then
+  SIBLING_DIR="/new-api"
+else
+  SIBLING_DIR="${SIBLING_PARENT}/new-api"
+fi
 REMOTE_URL="https://github.com/QuantumNous/new-api.git"
 
 mode="sync"


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Fixes the Cursor cloud-agent **"Environment ready (update script failed)"** banner caused by `scripts/sync-new-api.sh` not being able to create the `new-api` sibling directory.

Observed banner output:

```
[cloud-agent] initializing dev-rules submodule
Submodule 'dev-rules' (...) registered for path 'dev-rules'
[cloud-agent] syncing sibling new-api to pinned SHA
ERROR: sibling clone missing at //new-api
       run: bash scripts/sync-new-api.sh
Cloning new-api into //new-api ...
fatal: could not create work tree dir '//new-api': Permission denied
```

Two distinct problems, two layers:

1. **`.cursor/cloud-agent-install.sh`** — the cloud-agent VM hosts the workspace at `/workspace`, so the layout mandated by `CLAUDE.md §4` (and `backend/go.mod`'s `replace ../../new-api`) forces the sibling clone target to be `/new-api`. That target lives directly under filesystem root, owned by `root`, so the `ubuntu` agent user cannot `git clone` into it. Bootstrap now detects a non-writable sibling parent and uses `sudo install -d -o $user` to pre-create the dir before calling `sync-new-api.sh`. Kept cloud-agent-only on purpose: local devs arrange their own `~/Codes/tk/{sub2api,new-api}` layout and giving `sync-new-api.sh` implicit sudo powers there would be surprising.

2. **`scripts/sync-new-api.sh`** — used `cd "${SUB2API_ROOT}/.." && pwd` to resolve the sibling parent. When `SUB2API_ROOT=/workspace` that returns `/`, then `/` + `/new-api` literally produces `//new-api` in every clone command and error message. Switched to `dirname` + an explicit `/` normalization so the path is `/new-api` on top-level workspaces and unchanged everywhere else.

## Risk

- **Cloud-agent install**: additive guard — only runs when the sibling parent is non-writable AND no `.git` already exists there. On local devs / CI (where the parent is always writable) this branch is skipped entirely. If passwordless sudo isn't available, we now print a clear warning instead of silently failing later.
- **`sync-new-api.sh`**: `dirname` + explicit `/` normalization is semantically identical to the old `cd .. && pwd` for any non-root parent. The only behavior change is on top-level workspaces, where `//new-api` becomes `/new-api` — which is what the script always intended.
- No upstream-owned files touched (CLAUDE.md §5 deletion discipline N/A).

## Validation

End-to-end replay on a fresh state on this cloud-agent VM (with `/new-api` removed first to simulate a brand-new clone):

```
$ bash scripts/sync-new-api.sh
Cloning new-api into /new-api ...
HEAD is now at f995a868 Merge pull request #4089 from seefs001/feature/waffo-pay
OK: new-api sibling at f995a868e4551e3180c7d836561a5a257dae93dc

$ bash scripts/sync-new-api.sh --check
OK: new-api sibling at pinned f995a868e4551e3180c7d836561a5a257dae93dc

$ cd backend && go build ./...
BUILD_OK   # replace ../../new-api resolves correctly

$ bash scripts/preflight.sh
=== preflight: PASS ===
=== § 9  sub2api: newapi compat-pool drift ===  ok
=== § 10 sub2api: newapi sentinel registry  ===  ok
=== preflight (with § 9 + § 10 sub2api): PASS ===
```

Note: paths in the new error messages are now `/new-api` instead of `//new-api`, confirming the cosmetic fix.
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-a89858df-b38f-45b4-9e7c-e6fa23a3d80b"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-a89858df-b38f-45b4-9e7c-e6fa23a3d80b"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

