### PR TITLE
fix(approved-doc): flip approved_by from pending after PR #53 squash-merge (R5 hotfix)

### DIFF
--- a/docs/approved/deploy-stage0-workflow.md
+++ b/docs/approved/deploy-stage0-workflow.md
@@ -1,14 +1,16 @@
 ---
 title: Cloud-Agent-Driven Tag-and-Deploy Workflow
 status: pending
-approved_by: pending
-approved_at: pending
+approved_by: youxuanxue (PR #53 squash-merge)
+approved_at: 2026-04-24
 created: 2026-04-23
 owners: [tk-platform]
 related_prs: []
 # NOTE: deliberately empty while status=pending to satisfy R3.
-# After merge + first successful deploy, flip status=shipped and
-# add ["#53", "<first-deploy-commit>"] here.
+# Status flips to `shipped` only after first successful deploy via the
+# new workflow; at that point add ["#53", "<first-deploy-commit>"] here.
+# `approved_by` was flipped at merge time (PR #53) to satisfy R5
+# (main/master禁止 approved_by: pending).
 scope: ".github/workflows/deploy-stage0.yml + IAM scope expansion in deploy/aws/cloudformation/cicd-oidc.yaml"
 ---
 


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

After PR #53 squash-merged, `main` started failing preflight § 7 R5 because `docs/approved/deploy-stage0-workflow.md` still has `approved_by: pending`. R5 (`approved_by: pending` is forbidden on main/master) only runs against the active branch, so PR #53's CI was correctly green at merge time but main's preflight now breaks. Every subsequent PR's preflight against main would inherit this failure until fixed.

This PR flips just the metadata, no body change:

```diff
-approved_by: pending
-approved_at: pending
+approved_by: youxuanxue (PR #53 squash-merge)
+approved_at: 2026-04-24
```

## Why split `approved_by` from `status`

The dev-rules state model deliberately separates two events:

| Field | Decided at | Current value |
|---|---|---|
| `approved_by` | PR merge time (the merge button click IS the approval action) | flipped now → `youxuanxue (PR #53 squash-merge)` |
| `status: pending → shipped` | first successful deploy via the new workflow | stays `pending` (blocked on operator §5 setup + first deploy) |
| `related_prs` | both flip together with status | stays `[]` to keep R3 happy (`pending + related_prs non-empty` = "shipped under pending" smell) |

Both fields flip together when the first deploy commit lands.

## Risk

Trivial — frontmatter-only metadata, no behavior change, no code path touched. preflight `docs/approved/ change discipline` will warn (changed outside `prototype/*`) — that warn is correct and expected for this kind of post-merge metadata flip.

## Validation

- `bash scripts/preflight.sh` — PASS (all gates including R5 now green).
- No other files touched.

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-ef6a0ae5-fcd3-4e96-a202-5955c354c033"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-ef6a0ae5-fcd3-4e96-a202-5955c354c033"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

