### PR TITLE
fix(cloud-agent): restore stable bootstrap entrypoint

### DIFF
--- a/.cursor/cloud-agent-install.sh
+++ b/.cursor/cloud-agent-install.sh
@@ -1,0 +1,31 @@
+#!/usr/bin/env bash
+#
+# .cursor/cloud-agent-install.sh — stable cloud bootstrap entrypoint.
+#
+# Why this wrapper exists:
+# - `.cursor/environment.json` is executed before submodules are guaranteed
+#   to be initialized in a fresh cloud session.
+# - We now use `dev-rules/templates/cloud-agent-bootstrap.sh` as the real
+#   installer, but that path lives inside the `dev-rules` submodule.
+# - If the submodule is absent, pointing environment.json directly at the
+#   template fails with:
+#     "bash: dev-rules/templates/cloud-agent-bootstrap.sh: No such file or directory"
+#
+# This wrapper keeps backward compatibility and guarantees the template exists
+# before delegating.
+set -euo pipefail
+
+REPO_ROOT="$(cd "$(dirname "$0")/.." && pwd)"
+cd "$REPO_ROOT"
+
+echo "[cloud-agent-install] ensuring dev-rules submodule is initialized"
+git submodule update --init --recursive
+
+BOOTSTRAP="dev-rules/templates/cloud-agent-bootstrap.sh"
+if [ ! -x "$BOOTSTRAP" ]; then
+  echo "[cloud-agent-install] ERROR: missing bootstrap template: $BOOTSTRAP" >&2
+  exit 1
+fi
+
+echo "[cloud-agent-install] delegating to $BOOTSTRAP"
+exec bash "$BOOTSTRAP"

--- a/.cursor/cloud-agent-install.sh
+++ b/.cursor/cloud-agent-install.sh
@@ -19,13 +19,13 @@ REPO_ROOT="$(cd "$(dirname "$0")/.." && pwd)"
 cd "$REPO_ROOT"
 
 echo "[cloud-agent-install] ensuring dev-rules submodule is initialized"
-git submodule update --init --recursive
+git submodule update --init --recursive dev-rules
 
 BOOTSTRAP="dev-rules/templates/cloud-agent-bootstrap.sh"
-if [ ! -x "$BOOTSTRAP" ]; then
+if [ ! -f "$BOOTSTRAP" ]; then
   echo "[cloud-agent-install] ERROR: missing bootstrap template: $BOOTSTRAP" >&2
   exit 1
 fi
 
 echo "[cloud-agent-install] delegating to $BOOTSTRAP"
-exec bash "$BOOTSTRAP"
+exec bash "$BOOTSTRAP" "$@"

--- a/.cursor/cloud-agent-project-hook.sh
+++ b/.cursor/cloud-agent-project-hook.sh
@@ -8,15 +8,13 @@
 # token, secret presence checks) live in the dev-rules template; this
 # file only carries what is actually specific to sub2api:
 #
-#   1. Initialize the dev-rules submodule (preflight depends on it).
-#   2. Ensure /new-api sibling dir exists + sync to the pinned SHA so
+#   1. Ensure /new-api sibling dir exists + sync to the pinned SHA so
 #      backend Go builds resolve `replace ../../new-api` (CLAUDE.md §4).
-#   3. Pull the latest origin/main so cloud sessions start from HEAD.
-#   4. Install frontend dependencies via pnpm.
-#   5. Layer TokenKey's opinionated Claude Code knobs on top of the
+#   2. Install frontend dependencies via pnpm.
+#   3. Layer TokenKey's opinionated Claude Code knobs on top of the
 #      minimal settings.json the dev-rules template wrote.
-#   6. Self-test the prod-data fetch path when GH_TOKEN is set.
-#   7. Non-blocking preflight + make test sanity.
+#   4. Self-test the prod-data fetch path when GH_TOKEN is set.
+#   5. Non-blocking preflight + make test sanity.
 #
 # Intentionally non-fatal: any non-zero exit becomes a warning in the
 # dev-rules bootstrap (so a stale step never locks the agent out of
@@ -28,8 +26,7 @@ cd "$REPO_ROOT"
 
 warn() { echo "[project-hook][warn] $*" >&2; }
 
-echo "[project-hook] initializing dev-rules submodule"
-git submodule update --init --recursive
+echo "[project-hook] using prepared dev-rules submodule from .cursor/cloud-agent-install.sh"
 
 # Sibling new-api setup. On Cursor's cloud-agent VM the workspace lives at
 # /workspace, so the sibling target becomes /new-api — root-owned and not
@@ -52,9 +49,6 @@ fi
 
 echo "[project-hook] syncing sibling new-api to pinned SHA"
 bash scripts/sync-new-api.sh --check || bash scripts/sync-new-api.sh || warn "sync-new-api.sh failed"
-
-echo "[project-hook] pulling origin/main"
-git pull --ff-only origin main || warn "git pull origin main failed; continuing on checked-out revision"
 
 echo "[project-hook] installing frontend dependencies via pnpm"
 if command -v pnpm >/dev/null 2>&1; then

--- a/.cursor/environment.json
+++ b/.cursor/environment.json
@@ -1,4 +1,4 @@
 {
-  "install": "bash dev-rules/templates/cloud-agent-bootstrap.sh",
+  "install": "bash .cursor/cloud-agent-install.sh",
   "terminals": []
 }


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary
- restore a stable cloud-agent install entrypoint via `.cursor/cloud-agent-install.sh` so bootstrap no longer depends on submodule init ordering
- eliminate duplicated `dev-rules` submodule initialization from project hook
- remove `git pull` side effect from project hook to keep setup deterministic and single-responsibility
- keep bootstrap delegation simple: initialize `dev-rules`, verify template exists, forward args, execute

## Risk
- low: affects only cloud/local agent bootstrap scripts and not runtime service code
- behavior change is intentionally reducing side effects during setup

## Validation
- run bootstrap wrapper in check mode to verify script chain resolves correctly
- run dev-rules bootstrap check mode through wrapper to verify argument passthrough
- run project preflight wrapper to ensure no rule regression
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-6166343a-7531-4266-9265-9b2d38f48dfd"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-6166343a-7531-4266-9265-9b2d38f48dfd"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

