### PR TITLE
fix: persist upstream model in QA captures

### DIFF
--- a/.testing/user-stories/stories/US-033-qa-self-export-and-synth-fields.md
+++ b/.testing/user-stories/stories/US-033-qa-self-export-and-synth-fields.md
@@ -81,6 +81,16 @@
     Then `upstream_model` 非空；若 mapping 后模型与请求模型相同，也写入请求模型，
     避免 M0 C1/C3/C5 把 null 当作无法计价模型。
 
+11. **AC-011 (回归 / usage 与平台分类)**：Given gateway 成功 forward 后已有 usage
+    token 与 inbound endpoint，When QA capture middleware 持久化 `qa_records`，
+    Then `input_tokens` / `output_tokens` / `cached_tokens` 来自 usage context，
+    且 `/v1/messages` 归类为 `anthropic` 而非默认 `openai`。
+
+12. **AC-012 (回归 / 导出默认值归一化)**：Given ent schema 声明默认值的字段
+    在导出行里是零值，When `ExportUserData` 写 `qa_records.jsonl`，Then
+    `cached_tokens` / `tool_calls_present` / `multimodal_present` / `tags`
+    均存在且为 `0` / `false` / `[]`，不向外部消费者暴露 null/missing。
+
 ## Assertions
 
 - HTTP 状态码：401（无 auth）、503（service disabled）、400（坏 JSON）、
@@ -90,12 +100,14 @@
   `download_url` 对外部客户端为 HTTP(S)，不暴露容器内 `file://` 路径。
 - DB 行为：导出 SQL 始终带 `user_id = ?`；`synth_session_id` 设置时
   覆盖时间窗（M0 session 可能跨默认 24h）。
-- Capture 行为：gateway 成功转发后把实际 upstream model 回填到 ops/QA context，
-  QA middleware 从同一 context 写入 `qa_records.upstream_model`。
+- Capture 行为：gateway 成功转发后把实际 upstream model 与 usage tokens
+  回填到 ops/QA context，QA middleware 从同一 context 写入
+  `qa_records.upstream_model` / token 字段，并按 inbound endpoint 归类 platform。
 - 字段完整性：导出 zip 内 `qa_records.jsonl` 单行记录包含
-  `synth_session_id`、`synth_role`（与 ent JSON tag 一致），M0 端
-  `verify_c2_keys.py` 读 `api_key_id`、`verify_c3_model.py` 读
-  `upstream_model` 不需要适配。
+  `synth_session_id`、`synth_role`（与 ent JSON tag 一致）；ent 默认字段
+  `cached_tokens` / `tool_calls_present` / `multimodal_present` / `tags`
+  对外稳定为非 null 默认值；M0 端 `verify_c2_keys.py` 读 `api_key_id`、
+  `verify_c3_model.py` 读 `upstream_model` 不需要适配。
 
 ## Linked Tests
 
@@ -110,6 +122,7 @@
 - `backend/internal/observability/qa/middleware_synth_test.go`::`TestUS059_CaptureSynthHeaders_BoundedLength`
 - `backend/internal/observability/qa/middleware_synth_test.go`::`TestUS070_MiddlewarePersistsUpstreamModelFromOpsContext`
 - `backend/internal/observability/qa/service_export_test.go`::`TestUS070_PersistCapture_WritesUpstreamModel`
+- `backend/internal/observability/qa/service_export_test.go`::`TestUS074_ExportUserData_FillsDefaultValuedFields`
 - `backend/internal/handler/qa_handler_test.go`::`TestUS059_ExportSelf_Unauthenticated_401`
 - `backend/internal/handler/qa_handler_test.go`::`TestUS059_ExportSelf_DisabledService_503`
 - `backend/internal/handler/qa_handler_test.go`::`TestUS059_ExportSelf_BySynthSessionID_200`

--- a/.testing/user-stories/stories/US-033-qa-self-export-and-synth-fields.md
+++ b/.testing/user-stories/stories/US-033-qa-self-export-and-synth-fields.md
@@ -76,6 +76,11 @@
    Then 返回 403，且不读取 storage；When 请求 key 内时间戳已超过 24h 的
    export zip，Then 返回 404，不让 localfs 的 `expires_at` 成为假信号。
 
+10. **AC-010 (回归 / 上游模型落库)**：Given gateway 完成 channel/model mapping
+    并得到真实 upstream model，When QA capture middleware 持久化 `qa_records`，
+    Then `upstream_model` 非空；若 mapping 后模型与请求模型相同，也写入请求模型，
+    避免 M0 C1/C3/C5 把 null 当作无法计价模型。
+
 ## Assertions
 
 - HTTP 状态码：401（无 auth）、503（service disabled）、400（坏 JSON）、
@@ -85,6 +90,8 @@
   `download_url` 对外部客户端为 HTTP(S)，不暴露容器内 `file://` 路径。
 - DB 行为：导出 SQL 始终带 `user_id = ?`；`synth_session_id` 设置时
   覆盖时间窗（M0 session 可能跨默认 24h）。
+- Capture 行为：gateway 成功转发后把实际 upstream model 回填到 ops/QA context，
+  QA middleware 从同一 context 写入 `qa_records.upstream_model`。
 - 字段完整性：导出 zip 内 `qa_records.jsonl` 单行记录包含
   `synth_session_id`、`synth_role`（与 ent JSON tag 一致），M0 端
   `verify_c2_keys.py` 读 `api_key_id`、`verify_c3_model.py` 读
@@ -101,6 +108,8 @@
 - `backend/internal/observability/qa/middleware_synth_test.go`::`TestUS059_CaptureSynthHeaders_PipelineAloneFlipsDialogSynth`
 - `backend/internal/observability/qa/middleware_synth_test.go`::`TestUS059_CaptureSynthHeaders_AbsentReturnsEmpty`
 - `backend/internal/observability/qa/middleware_synth_test.go`::`TestUS059_CaptureSynthHeaders_BoundedLength`
+- `backend/internal/observability/qa/middleware_synth_test.go`::`TestUS070_MiddlewarePersistsUpstreamModelFromOpsContext`
+- `backend/internal/observability/qa/service_export_test.go`::`TestUS070_PersistCapture_WritesUpstreamModel`
 - `backend/internal/handler/qa_handler_test.go`::`TestUS059_ExportSelf_Unauthenticated_401`
 - `backend/internal/handler/qa_handler_test.go`::`TestUS059_ExportSelf_DisabledService_503`
 - `backend/internal/handler/qa_handler_test.go`::`TestUS059_ExportSelf_BySynthSessionID_200`

--- a/backend/internal/handler/gateway_handler.go
+++ b/backend/internal/handler/gateway_handler.go
@@ -457,6 +457,7 @@ func (h *GatewayHandler) Messages(c *gin.Context) {
 					reqLog.Warn("gateway.rpm_increment_failed", zap.Int64("account_id", account.ID), zap.Error(err))
 				}
 			}
+			setOpsForwardResultContext(c, result.UpstreamModel, reqModel)
 
 			// 捕获请求信息（用于异步记录，避免在 goroutine 中访问 gin.Context）
 			userAgent := c.GetHeader("User-Agent")
@@ -799,6 +800,7 @@ func (h *GatewayHandler) Messages(c *gin.Context) {
 					reqLog.Warn("gateway.rpm_increment_failed", zap.Int64("account_id", account.ID), zap.Error(err))
 				}
 			}
+			setOpsForwardResultContext(c, result.UpstreamModel, reqModel)
 
 			// 捕获请求信息（用于异步记录，避免在 goroutine 中访问 gin.Context）
 			userAgent := c.GetHeader("User-Agent")

--- a/backend/internal/handler/gateway_handler.go
+++ b/backend/internal/handler/gateway_handler.go
@@ -458,6 +458,7 @@ func (h *GatewayHandler) Messages(c *gin.Context) {
 				}
 			}
 			setOpsForwardResultContext(c, result.UpstreamModel, reqModel)
+			setOpsClaudeUsageContext(c, result.Usage)
 
 			// 捕获请求信息（用于异步记录，避免在 goroutine 中访问 gin.Context）
 			userAgent := c.GetHeader("User-Agent")
@@ -801,6 +802,7 @@ func (h *GatewayHandler) Messages(c *gin.Context) {
 				}
 			}
 			setOpsForwardResultContext(c, result.UpstreamModel, reqModel)
+			setOpsClaudeUsageContext(c, result.Usage)
 
 			// 捕获请求信息（用于异步记录，避免在 goroutine 中访问 gin.Context）
 			userAgent := c.GetHeader("User-Agent")

--- a/backend/internal/handler/gateway_handler_chat_completions.go
+++ b/backend/internal/handler/gateway_handler_chat_completions.go
@@ -243,6 +243,7 @@ func (h *GatewayHandler) ChatCompletions(c *gin.Context) {
 		}
 
 		// 6. Record usage
+		setOpsForwardResultContext(c, result.UpstreamModel, reqModel)
 		userAgent := c.GetHeader("User-Agent")
 		clientIP := ip.GetClientIP(c)
 		requestPayloadHash := service.HashUsageRequestPayload(body)

--- a/backend/internal/handler/gateway_handler_chat_completions.go
+++ b/backend/internal/handler/gateway_handler_chat_completions.go
@@ -243,6 +243,7 @@ func (h *GatewayHandler) ChatCompletions(c *gin.Context) {
 		}
 
 		// 6. Record usage
+		setOpsClaudeUsageContext(c, result.Usage)
 		setOpsForwardResultContext(c, result.UpstreamModel, reqModel)
 		userAgent := c.GetHeader("User-Agent")
 		clientIP := ip.GetClientIP(c)

--- a/backend/internal/handler/gateway_handler_responses.go
+++ b/backend/internal/handler/gateway_handler_responses.go
@@ -249,6 +249,7 @@ func (h *GatewayHandler) Responses(c *gin.Context) {
 		}
 
 		// 6. Record usage
+		setOpsForwardResultContext(c, result.UpstreamModel, reqModel)
 		userAgent := c.GetHeader("User-Agent")
 		clientIP := ip.GetClientIP(c)
 		requestPayloadHash := service.HashUsageRequestPayload(body)

--- a/backend/internal/handler/gateway_handler_responses.go
+++ b/backend/internal/handler/gateway_handler_responses.go
@@ -250,6 +250,7 @@ func (h *GatewayHandler) Responses(c *gin.Context) {
 
 		// 6. Record usage
 		setOpsForwardResultContext(c, result.UpstreamModel, reqModel)
+		setOpsClaudeUsageContext(c, result.Usage)
 		userAgent := c.GetHeader("User-Agent")
 		clientIP := ip.GetClientIP(c)
 		requestPayloadHash := service.HashUsageRequestPayload(body)

--- a/backend/internal/handler/gemini_v1beta_handler.go
+++ b/backend/internal/handler/gemini_v1beta_handler.go
@@ -492,6 +492,7 @@ func (h *GatewayHandler) GeminiV1BetaModels(c *gin.Context) {
 		}
 
 		setOpsForwardResultContext(c, result.UpstreamModel, reqModel)
+		setOpsClaudeUsageContext(c, result.Usage)
 
 		// 捕获请求信息（用于异步记录，避免在 goroutine 中访问 gin.Context）
 		userAgent := c.GetHeader("User-Agent")

--- a/backend/internal/handler/gemini_v1beta_handler.go
+++ b/backend/internal/handler/gemini_v1beta_handler.go
@@ -491,6 +491,8 @@ func (h *GatewayHandler) GeminiV1BetaModels(c *gin.Context) {
 			return
 		}
 
+		setOpsForwardResultContext(c, result.UpstreamModel, reqModel)
+
 		// 捕获请求信息（用于异步记录，避免在 goroutine 中访问 gin.Context）
 		userAgent := c.GetHeader("User-Agent")
 		clientIP := ip.GetClientIP(c)

--- a/backend/internal/handler/openai_chat_completions.go
+++ b/backend/internal/handler/openai_chat_completions.go
@@ -269,6 +269,7 @@ func (h *OpenAIGatewayHandler) ChatCompletions(c *gin.Context) {
 		}
 		if result != nil {
 			setOpsForwardResultContext(c, result.UpstreamModel, reqModel)
+			setOpsOpenAIUsageContext(c, result.Usage)
 			h.gatewayService.ReportOpenAIAccountScheduleResult(account.ID, true, result.FirstTokenMs)
 		} else {
 			h.gatewayService.ReportOpenAIAccountScheduleResult(account.ID, true, nil)

--- a/backend/internal/handler/openai_chat_completions.go
+++ b/backend/internal/handler/openai_chat_completions.go
@@ -268,6 +268,7 @@ func (h *OpenAIGatewayHandler) ChatCompletions(c *gin.Context) {
 			return
 		}
 		if result != nil {
+			setOpsForwardResultContext(c, result.UpstreamModel, reqModel)
 			h.gatewayService.ReportOpenAIAccountScheduleResult(account.ID, true, result.FirstTokenMs)
 		} else {
 			h.gatewayService.ReportOpenAIAccountScheduleResult(account.ID, true, nil)

--- a/backend/internal/handler/openai_gateway_embeddings_images.go
+++ b/backend/internal/handler/openai_gateway_embeddings_images.go
@@ -260,6 +260,7 @@ func (h *OpenAIGatewayHandler) Embeddings(c *gin.Context) {
 		}
 		if result != nil {
 			setOpsForwardResultContext(c, result.UpstreamModel, reqModel)
+			setOpsOpenAIUsageContext(c, result.Usage)
 			h.gatewayService.ReportOpenAIAccountScheduleResult(account.ID, true, result.FirstTokenMs)
 		} else {
 			h.gatewayService.ReportOpenAIAccountScheduleResult(account.ID, true, nil)
@@ -549,6 +550,7 @@ func (h *OpenAIGatewayHandler) ImageGenerations(c *gin.Context) {
 		}
 		if result != nil {
 			setOpsForwardResultContext(c, result.UpstreamModel, reqModel)
+			setOpsOpenAIUsageContext(c, result.Usage)
 			h.gatewayService.ReportOpenAIAccountScheduleResult(account.ID, true, result.FirstTokenMs)
 		} else {
 			h.gatewayService.ReportOpenAIAccountScheduleResult(account.ID, true, nil)

--- a/backend/internal/handler/openai_gateway_embeddings_images.go
+++ b/backend/internal/handler/openai_gateway_embeddings_images.go
@@ -259,6 +259,7 @@ func (h *OpenAIGatewayHandler) Embeddings(c *gin.Context) {
 			return
 		}
 		if result != nil {
+			setOpsForwardResultContext(c, result.UpstreamModel, reqModel)
 			h.gatewayService.ReportOpenAIAccountScheduleResult(account.ID, true, result.FirstTokenMs)
 		} else {
 			h.gatewayService.ReportOpenAIAccountScheduleResult(account.ID, true, nil)
@@ -547,6 +548,7 @@ func (h *OpenAIGatewayHandler) ImageGenerations(c *gin.Context) {
 			return
 		}
 		if result != nil {
+			setOpsForwardResultContext(c, result.UpstreamModel, reqModel)
 			h.gatewayService.ReportOpenAIAccountScheduleResult(account.ID, true, result.FirstTokenMs)
 		} else {
 			h.gatewayService.ReportOpenAIAccountScheduleResult(account.ID, true, nil)

--- a/backend/internal/handler/openai_gateway_handler.go
+++ b/backend/internal/handler/openai_gateway_handler.go
@@ -389,6 +389,7 @@ func (h *OpenAIGatewayHandler) Responses(c *gin.Context) {
 		}
 		if result != nil {
 			setOpsForwardResultContext(c, result.UpstreamModel, reqModel)
+			setOpsOpenAIUsageContext(c, result.Usage)
 			if account.Type == service.AccountTypeOAuth {
 				h.gatewayService.UpdateCodexUsageSnapshotFromHeaders(c.Request.Context(), account.ID, result.ResponseHeaders)
 			}
@@ -764,6 +765,7 @@ func (h *OpenAIGatewayHandler) Messages(c *gin.Context) {
 		}
 		if result != nil {
 			setOpsForwardResultContext(c, result.UpstreamModel, reqModel)
+			setOpsOpenAIUsageContext(c, result.Usage)
 			h.gatewayService.ReportOpenAIAccountScheduleResult(account.ID, true, result.FirstTokenMs)
 		} else {
 			h.gatewayService.ReportOpenAIAccountScheduleResult(account.ID, true, nil)
@@ -1274,6 +1276,7 @@ func (h *OpenAIGatewayHandler) ResponsesWebSocket(c *gin.Context) {
 				return
 			}
 			setOpsForwardResultContext(c, result.UpstreamModel, reqModel)
+			setOpsOpenAIUsageContext(c, result.Usage)
 			if account.Type == service.AccountTypeOAuth {
 				h.gatewayService.UpdateCodexUsageSnapshotFromHeaders(ctx, account.ID, result.ResponseHeaders)
 			}

--- a/backend/internal/handler/openai_gateway_handler.go
+++ b/backend/internal/handler/openai_gateway_handler.go
@@ -388,6 +388,7 @@ func (h *OpenAIGatewayHandler) Responses(c *gin.Context) {
 			return
 		}
 		if result != nil {
+			setOpsForwardResultContext(c, result.UpstreamModel, reqModel)
 			if account.Type == service.AccountTypeOAuth {
 				h.gatewayService.UpdateCodexUsageSnapshotFromHeaders(c.Request.Context(), account.ID, result.ResponseHeaders)
 			}
@@ -762,6 +763,7 @@ func (h *OpenAIGatewayHandler) Messages(c *gin.Context) {
 			return
 		}
 		if result != nil {
+			setOpsForwardResultContext(c, result.UpstreamModel, reqModel)
 			h.gatewayService.ReportOpenAIAccountScheduleResult(account.ID, true, result.FirstTokenMs)
 		} else {
 			h.gatewayService.ReportOpenAIAccountScheduleResult(account.ID, true, nil)
@@ -1271,6 +1273,7 @@ func (h *OpenAIGatewayHandler) ResponsesWebSocket(c *gin.Context) {
 			if turnErr != nil || result == nil {
 				return
 			}
+			setOpsForwardResultContext(c, result.UpstreamModel, reqModel)
 			if account.Type == service.AccountTypeOAuth {
 				h.gatewayService.UpdateCodexUsageSnapshotFromHeaders(ctx, account.ID, result.ResponseHeaders)
 			}

--- a/backend/internal/handler/openai_gateway_tk_video.go
+++ b/backend/internal/handler/openai_gateway_tk_video.go
@@ -203,6 +203,7 @@ func (h *OpenAIGatewayHandler) VideoSubmit(c *gin.Context) {
 		)
 	}
 
+	setOpsForwardResultContext(c, outcome.UpstreamModel, reqModel)
 	openAIRecordAffinitySuccess(c, account.ID)
 
 	userAgent := c.GetHeader("User-Agent")

--- a/backend/internal/handler/openai_gateway_tk_video.go
+++ b/backend/internal/handler/openai_gateway_tk_video.go
@@ -205,6 +205,8 @@ func (h *OpenAIGatewayHandler) VideoSubmit(c *gin.Context) {
 
 	setOpsForwardResultContext(c, outcome.UpstreamModel, reqModel)
 	openAIRecordAffinitySuccess(c, account.ID)
+	setOpsOpenAIUsageContext(c, service.OpenAIUsage{})
+	setOpsForwardResultContext(c, outcome.UpstreamModel, reqModel)
 
 	userAgent := c.GetHeader("User-Agent")
 	clientIP := ip.GetClientIP(c)

--- a/backend/internal/handler/ops_error_logger.go
+++ b/backend/internal/handler/ops_error_logger.go
@@ -29,6 +29,9 @@ const (
 
 	opsUpstreamModelKey = "ops_upstream_model"
 	opsRequestTypeKey   = "ops_request_type"
+	opsInputTokensKey   = "ops_input_tokens"
+	opsOutputTokensKey  = "ops_output_tokens"
+	opsCachedTokensKey  = "ops_cached_tokens"
 
 	// 错误过滤匹配常量 — shouldSkipOpsErrorLog 和错误分类共用
 	opsErrContextCanceled            = "context canceled"
@@ -372,6 +375,23 @@ func setOpsForwardResultContext(c *gin.Context, upstreamModel, requestedModel st
 		upstreamModel = requestedModel
 	}
 	setOpsUpstreamModelContext(c, upstreamModel)
+}
+
+func setOpsTokenUsageContext(c *gin.Context, inputTokens, outputTokens, cachedTokens int) {
+	if c == nil {
+		return
+	}
+	c.Set(opsInputTokensKey, inputTokens)
+	c.Set(opsOutputTokensKey, outputTokens)
+	c.Set(opsCachedTokensKey, cachedTokens)
+}
+
+func setOpsClaudeUsageContext(c *gin.Context, usage service.ClaudeUsage) {
+	setOpsTokenUsageContext(c, usage.InputTokens, usage.OutputTokens, usage.CacheReadInputTokens)
+}
+
+func setOpsOpenAIUsageContext(c *gin.Context, usage service.OpenAIUsage) {
+	setOpsTokenUsageContext(c, usage.InputTokens, usage.OutputTokens, usage.CacheReadInputTokens)
 }
 
 func attachOpsRequestBodyToEntry(c *gin.Context, entry *service.OpsInsertErrorLogInput) {

--- a/backend/internal/handler/ops_error_logger.go
+++ b/backend/internal/handler/ops_error_logger.go
@@ -354,10 +354,24 @@ func setOpsEndpointContext(c *gin.Context, upstreamModel string, requestType int
 	if c == nil {
 		return
 	}
+	setOpsUpstreamModelContext(c, upstreamModel)
+	c.Set(opsRequestTypeKey, requestType)
+}
+
+func setOpsUpstreamModelContext(c *gin.Context, upstreamModel string) {
+	if c == nil {
+		return
+	}
 	if upstreamModel = strings.TrimSpace(upstreamModel); upstreamModel != "" {
 		c.Set(opsUpstreamModelKey, upstreamModel)
 	}
-	c.Set(opsRequestTypeKey, requestType)
+}
+
+func setOpsForwardResultContext(c *gin.Context, upstreamModel, requestedModel string) {
+	if strings.TrimSpace(upstreamModel) == "" {
+		upstreamModel = requestedModel
+	}
+	setOpsUpstreamModelContext(c, upstreamModel)
 }
 
 func attachOpsRequestBodyToEntry(c *gin.Context, entry *service.OpsInsertErrorLogInput) {

--- a/backend/internal/observability/qa/middleware_synth_test.go
+++ b/backend/internal/observability/qa/middleware_synth_test.go
@@ -11,10 +11,15 @@ package qa
 // docs/projects/auto-traj-from-supply-demand.md §6.1).
 
 import (
+	"context"
 	"net/http/httptest"
 	"strings"
 	"testing"
+	"time"
 
+	"github.com/Wei-Shaw/sub2api/internal/pkg/ctxkey"
+	"github.com/Wei-Shaw/sub2api/internal/server/middleware"
+	"github.com/Wei-Shaw/sub2api/internal/service"
 	"github.com/gin-gonic/gin"
 	"github.com/stretchr/testify/require"
 )
@@ -72,4 +77,39 @@ func TestUS059_CaptureSynthHeaders_BoundedLength(t *testing.T) {
 
 	session, _, _, _ := captureSynthHeaders(c)
 	require.Len(t, session, 256)
+}
+
+func TestUS070_MiddlewarePersistsUpstreamModelFromOpsContext(t *testing.T) {
+	svc, client, _ := newQAExportTestService(t)
+	gin.SetMode(gin.TestMode)
+	r := gin.New()
+	r.Use(func(c *gin.Context) {
+		c.Set(string(middleware.ContextKeyAPIKey), &service.APIKey{
+			ID:     5,
+			UserID: 7,
+			User:   &service.User{ID: 7},
+			Group:  &service.Group{Platform: service.PlatformAnthropic},
+		})
+		c.Set("ops_upstream_model", "claude-sonnet-4-5")
+		c.Next()
+	})
+	r.Use(svc.Middleware())
+	r.POST("/v1/messages", func(c *gin.Context) {
+		c.JSON(200, gin.H{"ok": true})
+	})
+
+	ctx := context.WithValue(context.Background(), ctxkey.RequestID, "us070-upstream-model")
+	req := httptest.NewRequest("POST", "/v1/messages", strings.NewReader(`{"model":"claude-sonnet-4-5"}`)).WithContext(ctx)
+	req.Header.Set("Content-Type", "application/json")
+	w := httptest.NewRecorder()
+	r.ServeHTTP(w, req)
+
+	require.Equal(t, 200, w.Code)
+	require.Eventually(t, func() bool {
+		record, err := client.QARecord.Query().Only(req.Context())
+		if err != nil {
+			return false
+		}
+		return record.UpstreamModel != nil && *record.UpstreamModel == "claude-sonnet-4-5"
+	}, 2*time.Second, 10*time.Millisecond)
 }

--- a/backend/internal/observability/qa/middleware_synth_test.go
+++ b/backend/internal/observability/qa/middleware_synth_test.go
@@ -91,6 +91,9 @@ func TestUS070_MiddlewarePersistsUpstreamModelFromOpsContext(t *testing.T) {
 			Group:  &service.Group{Platform: service.PlatformAnthropic},
 		})
 		c.Set("ops_upstream_model", "claude-sonnet-4-5")
+		c.Set("ops_input_tokens", 123)
+		c.Set("ops_output_tokens", 45)
+		c.Set("ops_cached_tokens", 6)
 		c.Next()
 	})
 	r.Use(svc.Middleware())
@@ -110,6 +113,11 @@ func TestUS070_MiddlewarePersistsUpstreamModelFromOpsContext(t *testing.T) {
 		if err != nil {
 			return false
 		}
-		return record.UpstreamModel != nil && *record.UpstreamModel == "claude-sonnet-4-5"
+		return record.UpstreamModel != nil &&
+			*record.UpstreamModel == "claude-sonnet-4-5" &&
+			record.InputTokens == 123 &&
+			record.OutputTokens == 45 &&
+			record.CachedTokens == 6 &&
+			record.Platform == "anthropic"
 	}, 2*time.Second, 10*time.Millisecond)
 }

--- a/backend/internal/observability/qa/middleware_synth_test.go
+++ b/backend/internal/observability/qa/middleware_synth_test.go
@@ -80,6 +80,11 @@ func TestUS059_CaptureSynthHeaders_BoundedLength(t *testing.T) {
 }
 
 func TestUS070_MiddlewarePersistsUpstreamModelFromOpsContext(t *testing.T) {
+	const (
+		sentinelInputTokens  = 123
+		sentinelOutputTokens = 45
+		sentinelCachedTokens = 6
+	)
 	svc, client, _ := newQAExportTestService(t)
 	gin.SetMode(gin.TestMode)
 	r := gin.New()
@@ -91,9 +96,11 @@ func TestUS070_MiddlewarePersistsUpstreamModelFromOpsContext(t *testing.T) {
 			Group:  &service.Group{Platform: service.PlatformAnthropic},
 		})
 		c.Set("ops_upstream_model", "claude-sonnet-4-5")
-		c.Set("ops_input_tokens", 123)
-		c.Set("ops_output_tokens", 45)
-		c.Set("ops_cached_tokens", 6)
+		// Sentinel values prove QA capture propagates usage from ops context
+		// unchanged. Production sets these from the gateway forward result.
+		c.Set("ops_input_tokens", sentinelInputTokens)
+		c.Set("ops_output_tokens", sentinelOutputTokens)
+		c.Set("ops_cached_tokens", sentinelCachedTokens)
 		c.Next()
 	})
 	r.Use(svc.Middleware())
@@ -115,9 +122,9 @@ func TestUS070_MiddlewarePersistsUpstreamModelFromOpsContext(t *testing.T) {
 		}
 		return record.UpstreamModel != nil &&
 			*record.UpstreamModel == "claude-sonnet-4-5" &&
-			record.InputTokens == 123 &&
-			record.OutputTokens == 45 &&
-			record.CachedTokens == 6 &&
+			record.InputTokens == sentinelInputTokens &&
+			record.OutputTokens == sentinelOutputTokens &&
+			record.CachedTokens == sentinelCachedTokens &&
 			record.Platform == "anthropic"
 	}, 2*time.Second, 10*time.Millisecond)
 }

--- a/backend/internal/observability/qa/service.go
+++ b/backend/internal/observability/qa/service.go
@@ -177,6 +177,7 @@ func (s *Service) CaptureFromContext(c *gin.Context) {
 		AccountID:          accountID,
 		Platform:           strings.TrimSpace(platform),
 		RequestedModel:     captureRequestedModel(requestBody),
+		UpstreamModel:      captureUpstreamModel(c),
 		InboundEndpoint:    captureInboundEndpoint(c),
 		StatusCode:         status,
 		DurationMs:         durationMs,
@@ -554,6 +555,18 @@ func sanitizeQABytes(raw []byte, maxBytes int) any {
 
 func captureRequestedModel(body []byte) string {
 	return strings.TrimSpace(gjson.GetBytes(body, "model").String())
+}
+
+func captureUpstreamModel(c *gin.Context) string {
+	if c == nil {
+		return ""
+	}
+	if value, ok := c.Get("ops_upstream_model"); ok {
+		if model, ok := value.(string); ok {
+			return strings.TrimSpace(model)
+		}
+	}
+	return ""
 }
 
 func captureToolCallsPresent(body []byte) bool {

--- a/backend/internal/observability/qa/service.go
+++ b/backend/internal/observability/qa/service.go
@@ -159,10 +159,12 @@ func (s *Service) CaptureFromContext(c *gin.Context) {
 		}
 	}
 
+	inboundEndpoint := captureInboundEndpoint(c)
 	platform, _ := c.Request.Context().Value(ctxkey.Platform).(string)
 	if platform == "" && apiKey.Group != nil {
 		platform = apiKey.Group.Platform
 	}
+	platform = capturePlatform(platform, inboundEndpoint)
 	status := c.Writer.Status()
 	durationMs := int64(0)
 	if tee != nil {
@@ -170,6 +172,7 @@ func (s *Service) CaptureFromContext(c *gin.Context) {
 	}
 
 	synthSession, synthRole, synthLevel, dialogSynth := captureSynthHeaders(c)
+	inputTokens, outputTokens, cachedTokens := captureTokenUsage(c)
 	input := CaptureInput{
 		RequestID:          strings.TrimSpace(requestID),
 		UserID:             apiKey.UserID,
@@ -178,7 +181,7 @@ func (s *Service) CaptureFromContext(c *gin.Context) {
 		Platform:           strings.TrimSpace(platform),
 		RequestedModel:     captureRequestedModel(requestBody),
 		UpstreamModel:      captureUpstreamModel(c),
-		InboundEndpoint:    captureInboundEndpoint(c),
+		InboundEndpoint:    inboundEndpoint,
 		StatusCode:         status,
 		DurationMs:         durationMs,
 		FirstTokenMs:       firstTokenMs,
@@ -187,6 +190,9 @@ func (s *Service) CaptureFromContext(c *gin.Context) {
 		ResponseBody:       responseBody,
 		ResponseHeaders:    captureResponseHeaders(c),
 		StreamChunks:       streamChunks,
+		InputTokens:        inputTokens,
+		OutputTokens:       outputTokens,
+		CachedTokens:       cachedTokens,
 		ToolCallsPresent:   captureToolCallsPresent(requestBody),
 		MultimodalPresent:  captureMultimodalPresent(requestBody),
 		Tags:               captureTags(requestBody, responseBody, status, responseTruncated),
@@ -348,6 +354,14 @@ func exportQARecordRow(record *ent.QARecord) map[string]any {
 	row["upstream_model"] = record.UpstreamModel
 	row["input_tokens"] = record.InputTokens
 	row["output_tokens"] = record.OutputTokens
+	row["cached_tokens"] = record.CachedTokens
+	row["tool_calls_present"] = record.ToolCallsPresent
+	row["multimodal_present"] = record.MultimodalPresent
+	if record.Tags == nil {
+		row["tags"] = []string{}
+	} else {
+		row["tags"] = record.Tags
+	}
 	row["synth_session_id"] = record.SynthSessionID
 	return row
 }
@@ -569,6 +583,32 @@ func captureUpstreamModel(c *gin.Context) string {
 	return ""
 }
 
+func captureTokenUsage(c *gin.Context) (int, int, int) {
+	if c == nil {
+		return 0, 0, 0
+	}
+	return captureIntContextValue(c, "ops_input_tokens"),
+		captureIntContextValue(c, "ops_output_tokens"),
+		captureIntContextValue(c, "ops_cached_tokens")
+}
+
+func captureIntContextValue(c *gin.Context, key string) int {
+	value, ok := c.Get(key)
+	if !ok {
+		return 0
+	}
+	switch v := value.(type) {
+	case int:
+		return v
+	case int64:
+		return int(v)
+	case float64:
+		return int(v)
+	default:
+		return 0
+	}
+}
+
 func captureToolCallsPresent(body []byte) bool {
 	if len(body) == 0 {
 		return false
@@ -590,6 +630,29 @@ func captureInboundEndpoint(c *gin.Context) string {
 		return ""
 	}
 	return c.Request.URL.Path
+}
+
+func capturePlatform(current, inboundEndpoint string) string {
+	current = strings.TrimSpace(current)
+	switch {
+	case inboundEndpoint == "/v1/messages":
+		return "anthropic"
+	case strings.HasPrefix(inboundEndpoint, "/v1beta/models/"):
+		return "gemini"
+	case strings.HasPrefix(inboundEndpoint, "/antigravity/"):
+		return "antigravity"
+	case strings.HasPrefix(inboundEndpoint, "/v1/chat/completions"),
+		strings.HasPrefix(inboundEndpoint, "/v1/responses"),
+		strings.HasPrefix(inboundEndpoint, "/v1/embeddings"),
+		strings.HasPrefix(inboundEndpoint, "/v1/images/"),
+		strings.HasPrefix(inboundEndpoint, "/v1/video/"),
+		strings.HasPrefix(inboundEndpoint, "/v1/videos"):
+		return "openai"
+	}
+	if current != "" {
+		return current
+	}
+	return "unknown"
 }
 
 func captureStreamFlag(c *gin.Context, chunks []RawSSEChunk) bool {

--- a/backend/internal/observability/qa/service_export_test.go
+++ b/backend/internal/observability/qa/service_export_test.go
@@ -237,6 +237,11 @@ func TestUS059_ExportUserData_UnknownSession_EmptyNotError(t *testing.T) {
 func TestUS070_PersistCapture_WritesUpstreamModel(t *testing.T) {
 	svc, client, _ := newQAExportTestService(t)
 	ctx := context.Background()
+	const (
+		sentinelInputTokens  = 123
+		sentinelOutputTokens = 45
+		sentinelCachedTokens = 6
+	)
 
 	err := svc.persistCapture(ctx, CaptureInput{
 		RequestID:      "capture-upstream-model",
@@ -246,10 +251,12 @@ func TestUS070_PersistCapture_WritesUpstreamModel(t *testing.T) {
 		RequestedModel: "claude-sonnet-4-5",
 		UpstreamModel:  "claude-sonnet-4-5-20250929",
 		StatusCode:     200,
-		InputTokens:    123,
-		OutputTokens:   45,
-		CachedTokens:   6,
-		CreatedAt:      time.Now().UTC(),
+		// Sentinel values prove persistCapture stores caller-provided usage
+		// exactly; production callers populate them from forward result usage.
+		InputTokens:  sentinelInputTokens,
+		OutputTokens: sentinelOutputTokens,
+		CachedTokens: sentinelCachedTokens,
+		CreatedAt:    time.Now().UTC(),
 	})
 	require.NoError(t, err)
 
@@ -257,9 +264,9 @@ func TestUS070_PersistCapture_WritesUpstreamModel(t *testing.T) {
 	require.NoError(t, err)
 	require.NotNil(t, record.UpstreamModel)
 	require.Equal(t, "claude-sonnet-4-5-20250929", *record.UpstreamModel)
-	require.Equal(t, 123, record.InputTokens)
-	require.Equal(t, 45, record.OutputTokens)
-	require.Equal(t, 6, record.CachedTokens)
+	require.Equal(t, sentinelInputTokens, record.InputTokens)
+	require.Equal(t, sentinelOutputTokens, record.OutputTokens)
+	require.Equal(t, sentinelCachedTokens, record.CachedTokens)
 }
 
 func TestUS074_ExportUserData_FillsDefaultValuedFields(t *testing.T) {

--- a/backend/internal/observability/qa/service_export_test.go
+++ b/backend/internal/observability/qa/service_export_test.go
@@ -246,6 +246,9 @@ func TestUS070_PersistCapture_WritesUpstreamModel(t *testing.T) {
 		RequestedModel: "claude-sonnet-4-5",
 		UpstreamModel:  "claude-sonnet-4-5-20250929",
 		StatusCode:     200,
+		InputTokens:    123,
+		OutputTokens:   45,
+		CachedTokens:   6,
 		CreatedAt:      time.Now().UTC(),
 	})
 	require.NoError(t, err)
@@ -254,6 +257,38 @@ func TestUS070_PersistCapture_WritesUpstreamModel(t *testing.T) {
 	require.NoError(t, err)
 	require.NotNil(t, record.UpstreamModel)
 	require.Equal(t, "claude-sonnet-4-5-20250929", *record.UpstreamModel)
+	require.Equal(t, 123, record.InputTokens)
+	require.Equal(t, 45, record.OutputTokens)
+	require.Equal(t, 6, record.CachedTokens)
+}
+
+func TestUS074_ExportUserData_FillsDefaultValuedFields(t *testing.T) {
+	svc, client, store := newQAExportTestService(t)
+	ctx := context.Background()
+	now := time.Now().UTC()
+	mustInsertQARecord(t, ctx, client, qaRecordBuilder{requestID: "defaults", userID: 7, apiKeyID: 1, createdAt: now})
+
+	_, err := svc.ExportUserData(ctx, 7, ExportFilter{Since: now.Add(-1 * time.Hour), Until: now})
+	require.NoError(t, err)
+
+	var blob []byte
+	for _, v := range store.objects {
+		blob = v
+	}
+	zr, err := zip.NewReader(bytes.NewReader(blob), int64(len(blob)))
+	require.NoError(t, err)
+	rc, err := zr.File[0].Open()
+	require.NoError(t, err)
+	defer func() { _ = rc.Close() }()
+	raw, err := io.ReadAll(rc)
+	require.NoError(t, err)
+
+	var row map[string]any
+	require.NoError(t, json.Unmarshal(bytes.TrimSpace(raw), &row))
+	require.Equal(t, float64(0), row["cached_tokens"])
+	require.Equal(t, false, row["tool_calls_present"])
+	require.Equal(t, false, row["multimodal_present"])
+	require.Equal(t, []any{}, row["tags"])
 }
 
 func TestUS033_DownloadUserExport_OwnedKeyOnly(t *testing.T) {

--- a/backend/internal/observability/qa/service_export_test.go
+++ b/backend/internal/observability/qa/service_export_test.go
@@ -234,6 +234,28 @@ func TestUS059_ExportUserData_UnknownSession_EmptyNotError(t *testing.T) {
 	require.NotEmpty(t, res.DownloadURL, "even an empty export gets a download URL (zip with empty jsonl)")
 }
 
+func TestUS070_PersistCapture_WritesUpstreamModel(t *testing.T) {
+	svc, client, _ := newQAExportTestService(t)
+	ctx := context.Background()
+
+	err := svc.persistCapture(ctx, CaptureInput{
+		RequestID:      "capture-upstream-model",
+		UserID:         7,
+		APIKeyID:       1,
+		Platform:       "anthropic",
+		RequestedModel: "claude-sonnet-4-5",
+		UpstreamModel:  "claude-sonnet-4-5-20250929",
+		StatusCode:     200,
+		CreatedAt:      time.Now().UTC(),
+	})
+	require.NoError(t, err)
+
+	record, err := client.QARecord.Query().Only(ctx)
+	require.NoError(t, err)
+	require.NotNil(t, record.UpstreamModel)
+	require.Equal(t, "claude-sonnet-4-5-20250929", *record.UpstreamModel)
+}
+
 func TestUS033_DownloadUserExport_OwnedKeyOnly(t *testing.T) {
 	svc, client, store := newQAExportTestService(t)
 	ctx := context.Background()

--- a/backend/internal/service/gateway_anthropic_apikey_passthrough_test.go
+++ b/backend/internal/service/gateway_anthropic_apikey_passthrough_test.go
@@ -1185,16 +1185,20 @@ func TestGatewayService_AnthropicAPIKeyPassthrough_StreamingTimeoutAfterClientDi
 		Body:       pr,
 	}
 
+	releaseUpstream := make(chan struct{})
 	done := make(chan struct{})
 	go func() {
 		defer close(done)
 		_, _ = pw.Write([]byte(`data: {"type":"message_start","message":{"usage":{"input_tokens":9}}}` + "\n"))
-		// 保持上游连接静默，触发数据间隔超时分支。
-		time.Sleep(1500 * time.Millisecond)
+		// Keep the upstream connection open and silent until the handler
+		// returns. Closing it on a wall-clock sleep races CI scheduling and
+		// can hit the "missing terminal event" branch before the timeout branch.
+		<-releaseUpstream
 		_ = pw.Close()
 	}()
 
 	result, err := svc.handleStreamingResponseAnthropicAPIKeyPassthrough(context.Background(), resp, c, &Account{ID: 7}, time.Now(), "claude-3-7-sonnet-20250219")
+	close(releaseUpstream)
 	_ = pr.Close()
 	<-done
 


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary
- Backfill the actual upstream model into the ops/QA context after successful gateway forwards across Anthropic, OpenAI-compatible, Gemini, image/embedding/video, and websocket paths.
- Backfill usage token counts into QA capture (`input_tokens`, `output_tokens`, `cached_tokens`) from the same forward results.
- Classify QA `platform` by inbound endpoint shape so `/v1/messages` captures as `anthropic` instead of inherited `openai` group platform.
- Normalize export JSONL defaults for `cached_tokens`, `tool_calls_present`, `multimodal_present`, and `tags` so external consumers do not see null/missing values for schema-defaulted fields.
- Add regression coverage for issues #70, #72, #73, and #74, and update US-033 links.
- Clarify token test fixture values as named sentinels; production token values come from gateway forward result usage, not constants.
- Make the Anthropic passthrough stream-timeout unit test deterministic so CI does not race into the missing-terminal-event branch.

## Risk
- Moderate: touches shared gateway success paths, but only adds context metadata used by observability/QA capture and preserves existing usage accounting behavior.
- Fallback behavior stores the requested model if a forward result does not report a distinct upstream model, avoiding empty QA rows for unmapped models.

## Validation
- `cd backend && go test -tags=unit -timeout 120s ./internal/service -run 'TestGatewayService_AnthropicAPIKeyPassthrough_StreamingTimeoutAfterClientDisconnect'`
- `cd backend && go test -tags=unit -timeout 120s ./internal/observability/qa/... ./internal/handler/...`
- `python3 scripts/export_agent_contract.py && python3 scripts/export_agent_contract.py --check`
- `./scripts/preflight.sh`
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-fd0f315f-5fbe-4427-bcb3-5077667db8c0"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-fd0f315f-5fbe-4427-bcb3-5077667db8c0"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

