### PR TITLE
feat(qa-export): self-contained session zip + 1MiB QA body default

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -162,6 +162,7 @@ docs/*
 !docs/bugs/
 !docs/deploy/
 !docs/preflight-debt.md
+!docs/qa_export_contract.md
 .serena/
 .codex/
 frontend/coverage/

--- a/backend/internal/config/config.go
+++ b/backend/internal/config/config.go
@@ -1376,7 +1376,7 @@ func setDefaults() {
 
 	// QA capture
 	viper.SetDefault("qa_capture.enabled", true)
-	viper.SetDefault("qa_capture.body_max_bytes", 256*1024)
+	viper.SetDefault("qa_capture.body_max_bytes", 1024*1024)
 	viper.SetDefault("qa_capture.retention_days", 60)
 	viper.SetDefault("qa_capture.worker_count", 8)
 	viper.SetDefault("qa_capture.queue_size", 2048)

--- a/backend/internal/handler/qa_handler.go
+++ b/backend/internal/handler/qa_handler.go
@@ -61,6 +61,10 @@ type ExportSelfResponse struct {
 	DownloadURL string    `json:"download_url"`
 	ExpiresAt   time.Time `json:"expires_at"`
 	RecordCount int       `json:"record_count"`
+	// ExportFormatVersion matches manifest.json when present (issue #79); empty for legacy-only zips.
+	ExportFormatVersion string `json:"export_format_version,omitempty"`
+	// ExportIncomplete is true when manifest.incomplete is true (time-window exports); omitted when false.
+	ExportIncomplete bool `json:"export_incomplete,omitempty"`
 }
 
 // ExportSelf handles POST /api/v1/users/me/qa/export.
@@ -104,9 +108,11 @@ func (h *QAHandler) ExportSelf(c *gin.Context) {
 	}
 
 	response.Success(c, ExportSelfResponse{
-		DownloadURL: h.clientDownloadURL(c, result),
-		ExpiresAt:   result.ExpiresAt,
-		RecordCount: result.RecordCount,
+		DownloadURL:         h.clientDownloadURL(c, result),
+		ExpiresAt:           result.ExpiresAt,
+		RecordCount:         result.RecordCount,
+		ExportFormatVersion: result.ExportFormatVersion,
+		ExportIncomplete:    result.ExportIncomplete,
 	})
 }
 

--- a/backend/internal/handler/qa_handler_test.go
+++ b/backend/internal/handler/qa_handler_test.go
@@ -24,6 +24,7 @@ import (
 	"context"
 	"database/sql"
 	"encoding/json"
+	"fmt"
 	"io"
 	"io/fs"
 	"net/http"
@@ -41,6 +42,7 @@ import (
 	"entgo.io/ent/dialect"
 	entsql "entgo.io/ent/dialect/sql"
 	"github.com/gin-gonic/gin"
+	"github.com/klauspost/compress/zstd"
 	"github.com/stretchr/testify/require"
 )
 
@@ -76,6 +78,11 @@ func (m *qaLocalFSLikeBlobStore) PresignURL(_ context.Context, key string, _ tim
 }
 
 func newQAHandlerTestEnv(t *testing.T, withAuth bool, userID int64) (*gin.Engine, *dbent.Client, *QAHandler) {
+	r, client, h, _ := newQAHandlerTestEnvWithStore(t, withAuth, userID)
+	return r, client, h
+}
+
+func newQAHandlerTestEnvWithStore(t *testing.T, withAuth bool, userID int64) (*gin.Engine, *dbent.Client, *QAHandler, *qaMemBlobStore) {
 	t.Helper()
 	gin.SetMode(gin.TestMode)
 
@@ -90,7 +97,47 @@ func newQAHandlerTestEnv(t *testing.T, withAuth bool, userID int64) (*gin.Engine
 
 	store := &qaMemBlobStore{}
 	r, h := newQAHandlerRouterWithStore(userID, withAuth, client, store)
-	return r, client, h
+	return r, client, h, store
+}
+
+func readHandlerZipFile(t *testing.T, zr *zip.Reader, name string) []byte {
+	t.Helper()
+	for _, f := range zr.File {
+		if f.Name == name {
+			rc, err := f.Open()
+			require.NoError(t, err)
+			b, err := io.ReadAll(rc)
+			_ = rc.Close()
+			require.NoError(t, err)
+			return b
+		}
+	}
+	t.Fatalf("zip missing %q", name)
+	return nil
+}
+
+func qaBlobStoreKeyForRequestID(createdAt time.Time, requestID string) string {
+	prefix := "00"
+	if len(requestID) >= 2 {
+		prefix = requestID[:2]
+	}
+	return fmt.Sprintf("%04d/%02d/%02d/%s/%s.json.zst",
+		createdAt.Year(), int(createdAt.Month()), createdAt.Day(), prefix, requestID)
+}
+
+func putQAZstdBlob(t *testing.T, store *qaMemBlobStore, createdAt time.Time, requestID string) string {
+	t.Helper()
+	if store.objects == nil {
+		store.objects = map[string][]byte{}
+	}
+	enc, err := zstd.NewWriter(nil)
+	require.NoError(t, err)
+	payload := []byte(`{"request_id":"` + requestID + `","captured_at":"` + createdAt.UTC().Format(time.RFC3339) + `","request":{"path":"/v1/messages","body":{}},"response":{"status_code":200,"headers":{},"body":{}},"stream":{"chunks":[]},"redactions":["logredact"]}`)
+	zst := enc.EncodeAll(payload, nil)
+	_ = enc.Close()
+	key := qaBlobStoreKeyForRequestID(createdAt, requestID)
+	store.objects[key] = zst
+	return "mem://" + key
 }
 
 func newQAHandlerRouterWithStore(
@@ -145,12 +192,11 @@ func TestUS059_ExportSelf_DisabledService_503(t *testing.T) {
 }
 
 func TestUS059_ExportSelf_BySynthSessionID_200(t *testing.T) {
-	r, client, _ := newQAHandlerTestEnv(t, true, 7)
+	r, client, _, store := newQAHandlerTestEnvWithStore(t, true, 7)
 	ctx := context.Background()
 	now := time.Now().UTC()
 
-	// One record under user 7 in the target session, plus one un-tagged
-	// record (must NOT be exported).
+	blobURI := putQAZstdBlob(t, store, now, "r1")
 	_, err := client.QARecord.Create().
 		SetRequestID("r1").
 		SetUserID(7).
@@ -159,6 +205,7 @@ func TestUS059_ExportSelf_BySynthSessionID_200(t *testing.T) {
 		SetSynthSessionID("m0-XYZ").
 		SetSynthRole("user-simulator").
 		SetDialogSynth(true).
+		SetBlobURI(blobURI).
 		SetCreatedAt(now).
 		SetRetentionUntil(now.Add(7 * 24 * time.Hour)).
 		Save(ctx)
@@ -246,17 +293,18 @@ func TestUS059_ExportSelf_BadRequest_InvalidJSON(t *testing.T) {
 // belonging to a different user, the service-layer `WHERE user_id =`
 // predicate must return zero records (and the handler must not 500).
 func TestUS059_ExportSelf_CannotEscapeUserScope(t *testing.T) {
-	r, client, _ := newQAHandlerTestEnv(t, true, 100)
+	r, client, _, store := newQAHandlerTestEnvWithStore(t, true, 100)
 	ctx := context.Background()
 	now := time.Now().UTC()
 
-	// Record owned by user 200, NOT 100.
+	// Victim row would be exportable if user scope were wrong — it must not surface to user 100.
 	_, err := client.QARecord.Create().
 		SetRequestID("victim").
 		SetUserID(200).
 		SetAPIKeyID(2).
 		SetPlatform("anthropic").
 		SetSynthSessionID("m0-VICTIM").
+		SetBlobURI(putQAZstdBlob(t, store, now, "victim")).
 		SetCreatedAt(now).
 		SetRetentionUntil(now.Add(7 * 24 * time.Hour)).
 		Save(ctx)
@@ -289,6 +337,8 @@ func TestUS033_ExportSelf_LocalFSDownloadURLIsHTTPReachable(t *testing.T) {
 
 	ctx := context.Background()
 	now := time.Now().UTC()
+	store := &qaLocalFSLikeBlobStore{qaMemBlobStore{objects: map[string][]byte{}}}
+	blobURI := putQAZstdBlob(t, &store.qaMemBlobStore, now, "localfs-row")
 	_, err = client.QARecord.Create().
 		SetRequestID("localfs-row").
 		SetUserID(7).
@@ -300,12 +350,12 @@ func TestUS033_ExportSelf_LocalFSDownloadURLIsHTTPReachable(t *testing.T) {
 		SetUpstreamModel("claude-sonnet-4-5").
 		SetInputTokens(3).
 		SetOutputTokens(5).
+		SetBlobURI(blobURI).
 		SetCreatedAt(now).
 		SetRetentionUntil(now.Add(7 * 24 * time.Hour)).
 		Save(ctx)
 	require.NoError(t, err)
 
-	store := &qaLocalFSLikeBlobStore{qaMemBlobStore{objects: map[string][]byte{}}}
 	r, _ := newQAHandlerRouterWithStore(7, true, client, store)
 
 	body := bytes.NewBufferString(`{"synth_session_id":"m0-HTTP"}`)
@@ -334,12 +384,8 @@ func TestUS033_ExportSelf_LocalFSDownloadURLIsHTTPReachable(t *testing.T) {
 	require.Equal(t, "application/zip", downloadW.Header().Get("Content-Type"))
 	zr, err := zip.NewReader(bytes.NewReader(downloadW.Body.Bytes()), int64(downloadW.Body.Len()))
 	require.NoError(t, err)
-	require.Len(t, zr.File, 1)
-	rc, err := zr.File[0].Open()
-	require.NoError(t, err)
-	defer func() { _ = rc.Close() }()
-	raw, err := io.ReadAll(rc)
-	require.NoError(t, err)
+	require.GreaterOrEqual(t, len(zr.File), 3, "manifest + jsonl + blob")
+	raw := readHandlerZipFile(t, zr, "qa_records.jsonl")
 	var row map[string]any
 	require.NoError(t, json.Unmarshal(bytes.TrimSpace(raw), &row))
 	for _, field := range []string{"api_key_id", "upstream_model", "input_tokens", "output_tokens", "synth_session_id"} {

--- a/backend/internal/observability/qa/service.go
+++ b/backend/internal/observability/qa/service.go
@@ -29,6 +29,10 @@ import (
 	"github.com/tidwall/gjson"
 )
 
+// QAExportFormatVersion is the manifest + zip layout revision for self-contained
+// synth-session exports (issue #79). Bump when changing manifest or jsonl fields.
+const QAExportFormatVersion = "qa_export_v1"
+
 type Service struct {
 	client        *ent.Client
 	cfg           config.QACaptureConfig
@@ -300,34 +304,24 @@ func (s *Service) ExportUserData(ctx context.Context, userID int64, filter Expor
 
 	records, err := s.client.QARecord.Query().
 		Where(predicates...).
-		Order(ent.Asc(qarecord.FieldCreatedAt)).
+		Order(
+			ent.Asc(qarecord.FieldCreatedAt),
+			ent.Asc(qarecord.FieldRequestID),
+		).
 		All(ctx)
 	if err != nil {
 		return nil, err
 	}
 
-	var buf bytes.Buffer
-	zipWriter := zip.NewWriter(&buf)
-	indexWriter, err := zipWriter.Create("qa_records.jsonl")
+	selfContained := strings.TrimSpace(filter.SynthSessionID) != ""
+	zipBytes, exportIncomplete, err := s.buildExportZip(ctx, records, selfContained)
 	if err != nil {
-		return nil, err
-	}
-	for _, record := range records {
-		row, err := json.Marshal(exportQARecordRow(record))
-		if err != nil {
-			return nil, err
-		}
-		if _, err := indexWriter.Write(append(row, '\n')); err != nil {
-			return nil, err
-		}
-	}
-	if err := zipWriter.Close(); err != nil {
 		return nil, err
 	}
 
 	key := fmt.Sprintf("exports/%d/%d.zip", userID, time.Now().UnixNano())
 	signedAt := time.Now().UTC()
-	if _, err := s.store.Put(ctx, key, buf.Bytes(), "application/zip"); err != nil {
+	if _, err := s.store.Put(ctx, key, zipBytes, "application/zip"); err != nil {
 		return nil, err
 	}
 	url, err := s.store.PresignURL(ctx, key, presignedURLTTL)
@@ -335,11 +329,147 @@ func (s *Service) ExportUserData(ctx context.Context, userID int64, filter Expor
 		return nil, err
 	}
 	return &ExportResult{
-		DownloadURL: url,
-		ExpiresAt:   signedAt.Add(presignedURLTTL),
-		RecordCount: len(records),
-		StorageKey:  key,
+		DownloadURL:         url,
+		ExpiresAt:           signedAt.Add(presignedURLTTL),
+		RecordCount:         len(records),
+		StorageKey:          key,
+		ExportFormatVersion: QAExportFormatVersion,
+		ExportIncomplete:    exportIncomplete,
 	}, nil
+}
+
+// buildExportZip writes qa_records.jsonl, optional per-record blobs under blobs/,
+// and manifest.json. When requireSelfContainedBlobs is true (synth_session_id export),
+// any missing blob, fetch error, or body_truncated tag fails the whole export (issue #79 E5).
+func (s *Service) buildExportZip(ctx context.Context, records []*ent.QARecord, requireSelfContainedBlobs bool) ([]byte, bool, error) {
+	var buf bytes.Buffer
+	zipWriter := zip.NewWriter(&buf)
+
+	manifestIncomplete := false
+	type rowBlob struct {
+		row  map[string]any
+		blob []byte
+		path string
+	}
+	prepared := make([]rowBlob, 0, len(records))
+
+	for _, record := range records {
+		if qaRecordHasTag(record, "body_truncated") {
+			manifestIncomplete = true
+			if requireSelfContainedBlobs {
+				_ = zipWriter.Close()
+				return nil, false, fmt.Errorf("qa export: incomplete capture (body_truncated) for request_id=%s", record.RequestID)
+			}
+		}
+
+		row := exportQARecordRow(record)
+		rb := rowBlob{row: row}
+
+		if requireSelfContainedBlobs {
+			uri := ""
+			if record.BlobURI != nil {
+				uri = strings.TrimSpace(*record.BlobURI)
+			}
+			key := s.keyFromBlobURI(uri)
+			if key == "" {
+				_ = zipWriter.Close()
+				return nil, false, fmt.Errorf("qa export: record %s has no fetchable blob_uri for self-contained export", record.RequestID)
+			}
+			blobBytes, err := s.store.Get(ctx, key)
+			if err != nil {
+				_ = zipWriter.Close()
+				return nil, false, fmt.Errorf("qa export: cannot read blob for request_id=%s: %w", record.RequestID, err)
+			}
+			rb.blob = blobBytes
+			rb.path = qaExportBlobZipPath(record.RequestID)
+			row["capture_archive_path"] = rb.path
+			row["capture_encoding"] = "application/zstd+json"
+			// Offline consumers use capture_archive_path; drop remote-only pointer.
+			delete(row, "blob_uri")
+		}
+
+		prepared = append(prepared, rb)
+	}
+
+	indexWriter, err := zipWriter.Create("qa_records.jsonl")
+	if err != nil {
+		_ = zipWriter.Close()
+		return nil, false, err
+	}
+	for _, rb := range prepared {
+		line, err := json.Marshal(rb.row)
+		if err != nil {
+			_ = zipWriter.Close()
+			return nil, false, err
+		}
+		if _, err := indexWriter.Write(append(line, '\n')); err != nil {
+			_ = zipWriter.Close()
+			return nil, false, err
+		}
+	}
+
+	if requireSelfContainedBlobs {
+		for _, rb := range prepared {
+			if rb.path == "" || len(rb.blob) == 0 {
+				_ = zipWriter.Close()
+				return nil, false, fmt.Errorf("qa export: internal error: missing blob payload for zip entry")
+			}
+			w, err := zipWriter.Create(rb.path)
+			if err != nil {
+				_ = zipWriter.Close()
+				return nil, false, err
+			}
+			if _, err := w.Write(rb.blob); err != nil {
+				_ = zipWriter.Close()
+				return nil, false, err
+			}
+		}
+	}
+
+	manifest := map[string]any{
+		"export_format_version": QAExportFormatVersion,
+		"includes_blobs":        requireSelfContainedBlobs,
+		"record_count":          len(records),
+		"incomplete":            manifestIncomplete,
+	}
+	mw, err := zipWriter.Create("manifest.json")
+	if err != nil {
+		_ = zipWriter.Close()
+		return nil, false, err
+	}
+	enc := json.NewEncoder(mw)
+	enc.SetIndent("", "  ")
+	if err := enc.Encode(manifest); err != nil {
+		_ = zipWriter.Close()
+		return nil, false, err
+	}
+
+	if err := zipWriter.Close(); err != nil {
+		return nil, false, err
+	}
+	return buf.Bytes(), manifestIncomplete, nil
+}
+
+func qaRecordHasTag(record *ent.QARecord, want string) bool {
+	if record == nil {
+		return false
+	}
+	for _, t := range record.Tags {
+		if strings.TrimSpace(t) == want {
+			return true
+		}
+	}
+	return false
+}
+
+func qaExportBlobZipPath(requestID string) string {
+	id := strings.TrimSpace(requestID)
+	id = strings.ReplaceAll(id, "/", "_")
+	id = strings.ReplaceAll(id, "\\", "_")
+	if id == "" || id == "." || id == ".." {
+		id = "unknown"
+	}
+	return "blobs/" + id + ".json.zst"
 }
 
 func exportQARecordRow(record *ent.QARecord) map[string]any {
@@ -524,6 +654,10 @@ func (s *Service) keyFromBlobURI(blobURI string) string {
 		}
 	case strings.HasPrefix(blobURI, "file://"):
 		return strings.TrimPrefix(blobURI, "file://")
+	case strings.HasPrefix(blobURI, "mem://"):
+		return strings.TrimPrefix(blobURI, "mem://")
+	case strings.HasPrefix(blobURI, "dlq://"):
+		return strings.TrimPrefix(blobURI, "dlq://")
 	}
 	return ""
 }

--- a/backend/internal/observability/qa/service.go
+++ b/backend/internal/observability/qa/service.go
@@ -92,7 +92,7 @@ func (s *Service) Enabled() bool {
 
 func (s *Service) BodyMaxBytes() int {
 	if s == nil || s.bodyMaxBytes <= 0 {
-		return 256 * 1024
+		return 1024 * 1024
 	}
 	return s.bodyMaxBytes
 }

--- a/backend/internal/observability/qa/service_export_test.go
+++ b/backend/internal/observability/qa/service_export_test.go
@@ -34,6 +34,7 @@ import (
 
 	"entgo.io/ent/dialect"
 	entsql "entgo.io/ent/dialect/sql"
+	"github.com/klauspost/compress/zstd"
 )
 
 // memBlobStore is a minimal in-memory BlobStore used only by export tests.
@@ -143,9 +144,28 @@ func TestUS059_ExportUserData_BySynthSessionID(t *testing.T) {
 	now := time.Now().UTC()
 	farPast := now.Add(-72 * time.Hour) // OUTSIDE the default 24h window
 
-	// Two distinct synth sessions for user 7, plus one un-tagged turn.
-	mustInsertQARecord(t, ctx, client, qaRecordBuilder{requestID: "s1-a", userID: 7, apiKeyID: 1, createdAt: farPast, synthSession: "m0-AAA", synthRole: "user-simulator", dialogSynth: true})
-	mustInsertQARecord(t, ctx, client, qaRecordBuilder{requestID: "s1-b", userID: 7, apiKeyID: 1, createdAt: farPast.Add(1 * time.Second), synthSession: "m0-AAA", synthRole: "assistant-worker", dialogSynth: true})
+	// Self-contained session export requires persisted blobs (issue #79).
+	msgUser := `{"model":"claude-sonnet-4-5","messages":[{"role":"user","content":"ping"}],"tools":[{"name":"demo_tool","description":"d","input_schema":{"type":"object","properties":{}}}]}`
+
+	err := svc.persistCapture(ctx, CaptureInput{
+		RequestID: "s1-a", UserID: 7, APIKeyID: 1, Platform: "anthropic",
+		StatusCode: 200, InboundEndpoint: "/v1/messages",
+		RequestBody:    []byte(msgUser),
+		ResponseBody:   []byte(`{"type":"message","role":"assistant","content":[{"type":"tool_use","id":"tu1","name":"demo_tool","input":{}}]}`),
+		CreatedAt:      farPast,
+		SynthSessionID: "m0-AAA", SynthRole: "user-simulator", DialogSynth: true,
+	})
+	require.NoError(t, err)
+	err = svc.persistCapture(ctx, CaptureInput{
+		RequestID: "s1-b", UserID: 7, APIKeyID: 1, Platform: "anthropic",
+		StatusCode: 200, InboundEndpoint: "/v1/messages",
+		RequestBody: []byte(`{"model":"claude-sonnet-4-5","messages":[{"role":"user","content":[{"type":"tool_result","tool_use_id":"tu1","content":"ok"}]}]}`),
+		ResponseBody:   []byte(`{"type":"message","role":"assistant","content":[{"type":"text","text":"done"}]}`),
+		CreatedAt:      farPast.Add(1 * time.Second),
+		SynthSessionID: "m0-AAA", SynthRole: "assistant-worker", DialogSynth: true,
+	})
+	require.NoError(t, err)
+	// Other sessions / untagged traffic must not appear in m0-AAA export.
 	mustInsertQARecord(t, ctx, client, qaRecordBuilder{requestID: "s2-a", userID: 7, apiKeyID: 1, createdAt: farPast, synthSession: "m0-BBB", synthRole: "user-simulator", dialogSynth: true})
 	mustInsertQARecord(t, ctx, client, qaRecordBuilder{requestID: "non", userID: 7, apiKeyID: 1, createdAt: now.Add(-1 * time.Hour)})
 
@@ -154,48 +174,96 @@ func TestUS059_ExportUserData_BySynthSessionID(t *testing.T) {
 	res, err := svc.ExportUserData(ctx, 7, ExportFilter{SynthSessionID: "m0-AAA"})
 	require.NoError(t, err)
 	require.Equal(t, 2, res.RecordCount, "session filter must not be capped by time window")
+	require.Equal(t, QAExportFormatVersion, res.ExportFormatVersion)
+	require.False(t, res.ExportIncomplete)
+	require.NotEmpty(t, res.StorageKey)
 
-	// Verify the produced zip contains qa_records.jsonl with both
-	// records, request_ids in chronological order. We resolve the key
-	// from the URL — the in-memory store keys by the same slug.
-	require.NotEmpty(t, store.objects)
-	var blob []byte
-	for _, v := range store.objects {
-		blob = v
+	zipBytes := store.objects[res.StorageKey]
+	require.NotEmpty(t, zipBytes, "export zip must be written to blob store")
+
+	zr, err := zip.NewReader(bytes.NewReader(zipBytes), int64(len(zipBytes)))
+	require.NoError(t, err)
+	names := make([]string, 0, len(zr.File))
+	for _, f := range zr.File {
+		names = append(names, f.Name)
 	}
-	zr, err := zip.NewReader(bytes.NewReader(blob), int64(len(blob)))
-	require.NoError(t, err)
-	require.Len(t, zr.File, 1)
-	require.Equal(t, "qa_records.jsonl", zr.File[0].Name)
+	require.Contains(t, names, "qa_records.jsonl")
+	require.Contains(t, names, "manifest.json")
+	require.Contains(t, names, "blobs/s1-a.json.zst")
+	require.Contains(t, names, "blobs/s1-b.json.zst")
 
-	rc, err := zr.File[0].Open()
-	require.NoError(t, err)
-	defer func() { _ = rc.Close() }()
-	body, err := io.ReadAll(rc)
-	require.NoError(t, err)
+	manifestRaw := readZipFile(t, zr, "manifest.json")
+	var manifest map[string]any
+	require.NoError(t, json.Unmarshal(manifestRaw, &manifest))
+	require.Equal(t, QAExportFormatVersion, manifest["export_format_version"])
+	require.Equal(t, true, manifest["includes_blobs"])
+	require.Equal(t, float64(2), manifest["record_count"])
 
-	lines := strings.Split(strings.TrimRight(string(body), "\n"), "\n")
+	jsonl := readZipFile(t, zr, "qa_records.jsonl")
+	lines := strings.Split(strings.TrimRight(string(jsonl), "\n"), "\n")
 	require.Len(t, lines, 2)
 	var first map[string]any
 	require.NoError(t, json.Unmarshal([]byte(lines[0]), &first))
-	require.Equal(t, "s1-a", first["request_id"], "rows must be ASC by created_at")
+	require.Equal(t, "s1-a", first["request_id"], "rows must be ASC by created_at + request_id")
 	require.Equal(t, "m0-AAA", first["synth_session_id"], "synth_session_id must be present in the exported jsonl (so M0 verify_c2_keys.py can read it)")
 	require.Equal(t, "user-simulator", first["synth_role"])
+	require.Equal(t, "blobs/s1-a.json.zst", first["capture_archive_path"])
+	_, hasBlob := first["blob_uri"]
+	require.False(t, hasBlob, "self-contained export must not rely on blob_uri in jsonl")
 	for _, field := range []string{"api_key_id", "upstream_model", "input_tokens", "output_tokens", "synth_session_id"} {
 		require.Contains(t, first, field, "M0 D6 requires exported qa_records.jsonl to keep ent snake_case JSON fields")
 	}
 	require.Nil(t, first["upstream_model"], "nil optional fields must remain present as JSON null")
+
+	zstdBlob := readZipFile(t, zr, "blobs/s1-a.json.zst")
+	dec, err := zstd.NewReader(nil)
+	require.NoError(t, err)
+	defer dec.Close()
+	raw, err := dec.DecodeAll(zstdBlob, nil)
+	require.NoError(t, err)
+	var capPayload map[string]any
+	require.NoError(t, json.Unmarshal(raw, &capPayload))
+	req := capPayload["request"].(map[string]any)
+	body := req["body"].(map[string]any)
+	msgs := body["messages"].([]any)
+	require.NotEmpty(t, msgs)
+}
+
+func readZipFile(t *testing.T, zr *zip.Reader, name string) []byte {
+	t.Helper()
+	for _, f := range zr.File {
+		if f.Name == name {
+			rc, err := f.Open()
+			require.NoError(t, err)
+			b, err := io.ReadAll(rc)
+			_ = rc.Close()
+			require.NoError(t, err)
+			return b
+		}
+	}
+	t.Fatalf("zip missing %q", name)
+	return nil
 }
 
 // ----- US-059 AC-003: synth_role narrows further when both set. ----------
 
 func TestUS059_ExportUserData_RoleNarrows(t *testing.T) {
-	svc, client, _ := newQAExportTestService(t)
+	svc, _, _ := newQAExportTestService(t)
 	ctx := context.Background()
 	now := time.Now().UTC()
 
-	mustInsertQARecord(t, ctx, client, qaRecordBuilder{requestID: "u", userID: 7, apiKeyID: 1, createdAt: now, synthSession: "m0-X", synthRole: "user-simulator", dialogSynth: true})
-	mustInsertQARecord(t, ctx, client, qaRecordBuilder{requestID: "a", userID: 7, apiKeyID: 1, createdAt: now, synthSession: "m0-X", synthRole: "assistant-worker", dialogSynth: true})
+	err := svc.persistCapture(ctx, CaptureInput{
+		RequestID: "u", UserID: 7, APIKeyID: 1, Platform: "anthropic",
+		StatusCode: 200, RequestBody: []byte(`{"model":"m"}`), ResponseBody: []byte(`{}`),
+		CreatedAt: now, SynthSessionID: "m0-X", SynthRole: "user-simulator", DialogSynth: true,
+	})
+	require.NoError(t, err)
+	err = svc.persistCapture(ctx, CaptureInput{
+		RequestID: "a", UserID: 7, APIKeyID: 1, Platform: "anthropic",
+		StatusCode: 200, RequestBody: []byte(`{"model":"m"}`), ResponseBody: []byte(`{}`),
+		CreatedAt: now, SynthSessionID: "m0-X", SynthRole: "assistant-worker", DialogSynth: true,
+	})
+	require.NoError(t, err)
 
 	res, err := svc.ExportUserData(ctx, 7, ExportFilter{SynthSessionID: "m0-X", SynthRole: "user-simulator"})
 	require.NoError(t, err)
@@ -223,6 +291,95 @@ func TestUS059_ExportUserData_TimeWindowOnly(t *testing.T) {
 // an error. The M0 client uses RecordCount==0 as the "session not yet
 // captured, retry" signal; surfacing an error here would block the
 // retry loop. ------------------------------------------------------------
+
+// Issue #79 — at least three QA rows in one synth_session_id; zip alone must
+// yield decodable Messages-style JSON from each blob (tool_use / tool_result chain).
+func TestUS079_ExportSynthSession_SelfContainedThreeTurns(t *testing.T) {
+	svc, _, store := newQAExportTestService(t)
+	ctx := context.Background()
+	base := time.Now().UTC().Add(-10 * time.Minute)
+	session := "synth-chain-79"
+
+	toolUseResp := `{"type":"message","role":"assistant","content":[{"type":"tool_use","id":"call_1","name":"lookup","input":{"q":"x"}}]}`
+	toolResultReq := `{"model":"claude-sonnet-4-5","messages":[{"role":"user","content":[{"type":"tool_result","tool_use_id":"call_1","content":"found"}]}]}`
+	finalResp := `{"type":"message","role":"assistant","content":[{"type":"text","text":"thanks"}]}`
+
+	for i, rid := range []string{"turn-1", "turn-2", "turn-3"} {
+		var reqBody, respBody []byte
+		switch i {
+		case 0:
+			reqBody = []byte(`{"model":"claude-sonnet-4-5","messages":[{"role":"user","content":"go"}],"tools":[{"name":"lookup","description":"d","input_schema":{"type":"object","properties":{}}}]}`)
+			respBody = []byte(toolUseResp)
+		case 1:
+			reqBody = []byte(toolResultReq)
+			respBody = []byte(`{"type":"message","role":"assistant","content":[]}`)
+		case 2:
+			reqBody = []byte(`{"model":"claude-sonnet-4-5","messages":[{"role":"user","content":"wrap"}]}`)
+			respBody = []byte(finalResp)
+		}
+		err := svc.persistCapture(ctx, CaptureInput{
+			RequestID: rid, UserID: 7, APIKeyID: 1, Platform: "anthropic",
+			StatusCode: 200, InboundEndpoint: "/v1/messages",
+			RequestBody: reqBody, ResponseBody: respBody,
+			CreatedAt: base.Add(time.Duration(i) * time.Second),
+			SynthSessionID: session, SynthRole: "cli", DialogSynth: true,
+		})
+		require.NoError(t, err)
+	}
+
+	res, err := svc.ExportUserData(ctx, 7, ExportFilter{SynthSessionID: session})
+	require.NoError(t, err)
+	require.Equal(t, 3, res.RecordCount)
+	require.False(t, res.ExportIncomplete)
+
+	zipBytes := store.objects[res.StorageKey]
+	zr, err := zip.NewReader(bytes.NewReader(zipBytes), int64(len(zipBytes)))
+	require.NoError(t, err)
+
+	for _, rid := range []string{"turn-1", "turn-2", "turn-3"} {
+		zpath := "blobs/" + rid + ".json.zst"
+		rawZ := readZipFile(t, zr, zpath)
+		dec, err := zstd.NewReader(nil)
+		require.NoError(t, err)
+		payload, err := dec.DecodeAll(rawZ, nil)
+		dec.Close()
+		require.NoError(t, err)
+		var root map[string]any
+		require.NoError(t, json.Unmarshal(payload, &root))
+		req := root["request"].(map[string]any)
+		body := req["body"].(map[string]any)
+		require.Contains(t, body, "messages")
+	}
+
+	lines := strings.Split(strings.TrimSpace(string(readZipFile(t, zr, "qa_records.jsonl"))), "\n")
+	require.Len(t, lines, 3)
+}
+
+func TestUS079_ExportSynthSession_BodyTruncatedFails(t *testing.T) {
+	svc, client, _ := newQAExportTestService(t)
+	ctx := context.Background()
+	now := time.Now().UTC()
+	session := "synth-trunc-79"
+
+	_, err := client.QARecord.Create().
+		SetRequestID("bad-trunc").
+		SetUserID(7).
+		SetAPIKeyID(1).
+		SetPlatform("anthropic").
+		SetSynthSessionID(session).
+		SetSynthRole("cli").
+		SetDialogSynth(true).
+		SetTags([]string{"body_truncated"}).
+		SetCreatedAt(now).
+		SetRetentionUntil(now.Add(24 * time.Hour)).
+		SetBlobURI("mem://2026/01/01/ba/bad-trunc.json.zst").
+		Save(ctx)
+	require.NoError(t, err)
+
+	_, err = svc.ExportUserData(ctx, 7, ExportFilter{SynthSessionID: session})
+	require.Error(t, err)
+	require.Contains(t, err.Error(), "body_truncated")
+}
 
 func TestUS059_ExportUserData_UnknownSession_EmptyNotError(t *testing.T) {
 	svc, _, _ := newQAExportTestService(t)
@@ -284,11 +441,7 @@ func TestUS074_ExportUserData_FillsDefaultValuedFields(t *testing.T) {
 	}
 	zr, err := zip.NewReader(bytes.NewReader(blob), int64(len(blob)))
 	require.NoError(t, err)
-	rc, err := zr.File[0].Open()
-	require.NoError(t, err)
-	defer func() { _ = rc.Close() }()
-	raw, err := io.ReadAll(rc)
-	require.NoError(t, err)
+	raw := readZipFile(t, zr, "qa_records.jsonl")
 
 	var row map[string]any
 	require.NoError(t, json.Unmarshal(bytes.TrimSpace(raw), &row))

--- a/backend/internal/observability/qa/types.go
+++ b/backend/internal/observability/qa/types.go
@@ -47,6 +47,10 @@ type ExportResult struct {
 	ExpiresAt   time.Time `json:"expires_at"`
 	RecordCount int       `json:"record_count"`
 	StorageKey  string    `json:"-"`
+	// ExportFormatVersion is set when the zip includes manifest.json (issue #79).
+	ExportFormatVersion string `json:"-"`
+	// ExportIncomplete is true when any included row lost blob payload or is tagged body_truncated.
+	ExportIncomplete bool `json:"-"`
 }
 
 // ExportFilter narrows the qa_records covered by an export run. Zero-value

--- a/docs/qa_export_contract.md
+++ b/docs/qa_export_contract.md
@@ -1,0 +1,57 @@
+# QA export contract (synth session / self-contained zip)
+
+This document is the canonical consumer contract for user-initiated QA exports (`POST /api/v1/users/me/qa/export`). It aligns with GitHub issue #79 and the implementation in `internal/observability/qa`.
+
+## E1 Session keys
+
+- **`synth_session_id`**: Logical session id from the caller (e.g. header `X-Synth-Session`), stored on each `qa_record`. When present in the export request body, the export is scoped to rows where `synth_session_id` matches exactly (still subject to `user_id = authenticated user`).
+- **`synth_role`**: Optional sub-scope within a session. When set together with `synth_session_id`, only rows with both fields matching are exported.
+- **Time window**: When `synth_session_id` is **empty**, the server applies a bounded default window on `created_at` (see handler). When `synth_session_id` is **set**, `since` / `until` from the client are ignored so a long session is not truncated by the default window.
+
+## E2 Ordering
+
+- Rows are ordered by **`created_at ASC`**, then **`request_id ASC`** as a stable secondary key when timestamps collide.
+
+## E3 Row semantics
+
+- **`qa_records.jsonl`**: one JSON object per line. Each line corresponds to **one HTTP capture** (one gateway request/response pair). Multiple lines represent multiple turns, tool loops, or retries in the same `synth_session_id`.
+
+## E4 Payload placement
+
+Every export zip contains:
+
+- **`qa_records.jsonl`**: metadata per capture (Ent row fields in snake_case, plus export-specific fields below).
+- **`manifest.json`**: version and aggregate flags (see E6).
+
+When **`synth_session_id` is set** (session export), the zip is **self-contained**:
+
+- For each line, **`capture_archive_path`** is a zip-internal relative path (under `blobs/`) to the **zstd-compressed JSON** capture payload (same on-disk format as live QA blobs: JSON object with `request`, `response`, `stream`, `redactions`, etc.).
+- **`capture_encoding`** is always **`application/zstd+json`** for these embedded files.
+- **`blob_uri` is omitted** from jsonl lines in this mode so consumers do not depend on external object storage.
+
+When **`synth_session_id` is empty** (time-window export), **`manifest.includes_blobs` is `false`**. Jsonl lines keep **`blob_uri`** for backward compatibility with operators who can still reach the configured blob store; embedded `blobs/` entries are not added.
+
+## E5 Completeness (`incomplete` vs hard failure)
+
+- **`manifest.incomplete`**: `true` if **any** exported row has the tag **`body_truncated`** (response buffer hit `qa_capture.body_max_bytes` at capture time). Redaction is always applied at capture; the presence of `"redactions":["logredact"]` in the blob payload documents that policy — it does not by itself set `incomplete`.
+- **Session exports** (`synth_session_id` set): if **any** included row is incomplete as above, **or** the blob cannot be read from storage, **or** `blob_uri` is missing / uses an unsupported scheme, the **entire export fails** with an error (no zip is written). This is the “fail closed” branch of issue #79 E5.
+- **Time-window exports**: incomplete rows still produce a zip; **`manifest.incomplete`** is `true` and the HTTP JSON response sets **`export_incomplete: true`** when applicable.
+
+## E6 Manifest
+
+`manifest.json` fields:
+
+| Field | Type | Meaning |
+| ----- | ---- | ------- |
+| `export_format_version` | string | Constant `qa_export_v1` (bump only when breaking zip/jsonl/manifest shape). |
+| `includes_blobs` | bool | `true` when session export embedded `blobs/`; `false` for time-window export. |
+| `record_count` | int | Number of lines in `qa_records.jsonl`. |
+| `incomplete` | bool | See E5. |
+
+The HTTP **`export_format_version`** field mirrors `manifest.export_format_version` whenever a manifest is present.
+
+## Consumer algorithm (minimal)
+
+1. Unzip; read **`manifest.json`**; verify **`export_format_version`**.
+2. Stream **`qa_records.jsonl`** in order.
+3. If **`includes_blobs`**, for each line open **`capture_archive_path`**, decompress zstd, parse JSON — that object is the full capture.


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Implements [issue #79](https://github.com/youxuanxue/sub2api/issues/79): synth-session QA exports are **self-contained** zips with `manifest.json`, embedded `blobs/<request_id>.json.zst` captures, and `qa_records.jsonl` rows that reference `capture_archive_path` instead of remote-only `blob_uri`. Session exports **fail closed** on missing blob, unreadable storage, or `body_truncated` tags. Time-window exports keep `blob_uri` for backward compatibility and set `manifest.incomplete` when any row has `body_truncated`.

Also raises default `qa_capture.body_max_bytes` from 256 KiB to **1 MiB** (prior commit on this branch).

## Contract

- `docs/qa_export_contract.md` (E1–E6) — unignored via `.gitignore` exception.

## API

`POST /api/v1/users/me/qa/export` response adds optional `export_format_version` and `export_incomplete` (mirrors manifest / incomplete policy).

## Risk

- Session export now requires every matching row to have a fetchable blob in the configured store; old rows without `blob_uri` will error instead of producing an empty-looking zip.
- Memory profile for QA capture unchanged by export work; 1 MiB default increases per-request capture buffers vs 256 KiB.

## Validation

- `go test -tags=unit ./internal/observability/qa/... ./internal/handler/...`
- `./scripts/preflight.sh`
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-ed2aad5a-c86b-4531-8af5-e6247c15ad1d"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-ed2aad5a-c86b-4531-8af5-e6247c15ad1d"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

