### PR TITLE
ops: Prod QA stats via GHA + SSM (counts + qa_blobs disk)

### DIFF
--- a/.github/workflows/prod-qa-stats.yml
+++ b/.github/workflows/prod-qa-stats.yml
@@ -1,0 +1,143 @@
+name: Prod QA Stats
+
+# Read-only QA capture footprint on prod EC2: qa_records counts + qa_blobs disk use.
+# Same transport as error-clustering-daily / prod-log-dump: OIDC → SSM Run-Command.
+#
+# Repo variables (same as other prod SSM workflows):
+#   AWS_OIDC_ROLE_ARN
+#   AWS_REGION          (optional, default us-east-1)
+#   PROD_STACK_NAME     (optional, default tokenkey-prod-stage0)
+
+on:
+  workflow_dispatch:
+
+permissions:
+  contents: read
+  id-token: write
+
+concurrency:
+  group: prod-qa-stats
+  cancel-in-progress: false
+
+jobs:
+  stats:
+    runs-on: ubuntu-latest
+    env:
+      AWS_REGION: ${{ vars.AWS_REGION || 'us-east-1' }}
+      OIDC_ROLE_ARN: ${{ vars.AWS_OIDC_ROLE_ARN }}
+      STACK_NAME: ${{ vars.PROD_STACK_NAME || 'tokenkey-prod-stage0' }}
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Precheck OIDC role
+        id: precheck
+        run: |
+          if [ -z "${OIDC_ROLE_ARN:-}" ]; then
+            echo "::error::AWS_OIDC_ROLE_ARN repo variable is not set"
+            echo "skip=true" >> "$GITHUB_OUTPUT"
+          else
+            echo "skip=false" >> "$GITHUB_OUTPUT"
+          fi
+
+      - name: Configure AWS credentials via OIDC
+        if: steps.precheck.outputs.skip == 'false'
+        uses: aws-actions/configure-aws-credentials@v4
+        with:
+          role-to-assume: ${{ env.OIDC_ROLE_ARN }}
+          aws-region: ${{ env.AWS_REGION }}
+
+      - name: Resolve prod instance ID
+        if: steps.precheck.outputs.skip == 'false'
+        id: instance
+        run: |
+          ID=$(aws cloudformation describe-stacks --stack-name "$STACK_NAME" \
+            --query 'Stacks[0].Outputs[?OutputKey==`InstanceId`].OutputValue' --output text)
+          if [ -z "$ID" ] || [ "$ID" = "None" ]; then
+            echo "could not resolve InstanceId from stack $STACK_NAME" >&2
+            exit 1
+          fi
+          echo "id=$ID" >> "$GITHUB_OUTPUT"
+
+      - name: Collect qa_records + qa_blobs stats via SSM
+        if: steps.precheck.outputs.skip == 'false'
+        env:
+          INSTANCE_ID: ${{ steps.instance.outputs.id }}
+        run: |
+          set -euo pipefail
+          REMOTE_SCRIPT=$(cat <<'EOS'
+          set -euo pipefail
+          TOTAL=$(sudo docker exec tokenkey-postgres psql -U tokenkey -d tokenkey -t -A -c "SELECT count(*) FROM qa_records;" | tr -d ' \t\r\n')
+          LAST24=$(sudo docker exec tokenkey-postgres psql -U tokenkey -d tokenkey -t -A -c "SELECT count(*) FROM qa_records WHERE created_at >= now() - interval '24 hours';" | tr -d ' \t\r\n')
+          BLOB_ROOT=/var/lib/tokenkey/app/qa_blobs
+          if [ -d "$BLOB_ROOT" ]; then
+            BYTES=$(sudo du -sb "$BLOB_ROOT" | awk '{print $1}')
+            FILES=$(sudo find "$BLOB_ROOT" -type f 2>/dev/null | wc -l)
+          else
+            BYTES=0
+            FILES=0
+          fi
+          RATE=$(awk -v n="$LAST24" 'BEGIN{nn=n+0; if (nn<0) nn=0; printf "%.6f", nn/24}')
+          JSON=$(printf '{"qa_records_total":%s,"qa_records_last_24h":%s,"qa_blobs_bytes":%s,"qa_blobs_file_count":%s,"qa_blobs_host_path":"/var/lib/tokenkey/app/qa_blobs","inserts_per_hour_last_24h_avg":%s}' "$TOTAL" "$LAST24" "$BYTES" "$FILES" "$RATE")
+          echo ===BEGIN_QA_STATS_JSON===
+          printf '%s' "$JSON" | base64 -w0 2>/dev/null || printf '%s' "$JSON" | base64 | tr -d '\n'
+          echo
+          echo ===END_QA_STATS_JSON===
+          EOS
+          )
+          REMOTE_B64=$(printf '%s' "$REMOTE_SCRIPT" | base64 -w0 2>/dev/null || printf '%s' "$REMOTE_SCRIPT" | base64 | tr -d '\n')
+          jq -n --arg b64 "$REMOTE_B64" '{commands:["set -euo pipefail",("echo " + $b64 + " | base64 -d | bash")]}' > ssm-params.json
+
+          CMD_ID=$(aws ssm send-command \
+            --instance-ids "$INSTANCE_ID" \
+            --document-name AWS-RunShellScript \
+            --comment "prod qa capture stats read-only" \
+            --parameters file://ssm-params.json \
+            --query 'Command.CommandId' --output text)
+          echo "ssm command-id=$CMD_ID"
+
+          DEADLINE=$(( $(date +%s) + 180 ))
+          while true; do
+            STATUS=$(aws ssm get-command-invocation \
+              --command-id "$CMD_ID" --instance-id "$INSTANCE_ID" \
+              --query 'Status' --output text 2>/dev/null || echo InProgress)
+            case "$STATUS" in Success|Failed|TimedOut|Cancelled) break ;; esac
+            [ "$(date +%s)" -lt "$DEADLINE" ] || { STATUS=TimedOut; break; }
+            sleep 5
+          done
+
+          aws ssm get-command-invocation \
+            --command-id "$CMD_ID" --instance-id "$INSTANCE_ID" \
+            --query 'StandardOutputContent' --output text > stdout.txt
+          aws ssm get-command-invocation \
+            --command-id "$CMD_ID" --instance-id "$INSTANCE_ID" \
+            --query 'StandardErrorContent' --output text > stderr.txt
+
+          if [ "$STATUS" != "Success" ]; then
+            echo "::error::ssm command status=$STATUS"
+            cat stderr.txt
+            cat stdout.txt
+            exit 1
+          fi
+
+          awk '/^===BEGIN_QA_STATS_JSON===$/{f=1;next} /^===END_QA_STATS_JSON===$/{f=0} f' stdout.txt | tr -d '\n' | base64 -d > qa-stats.json
+
+          if ! jq empty qa-stats.json 2>/dev/null; then
+            echo "::error::qa-stats.json is not valid JSON"
+            cat stdout.txt
+            exit 1
+          fi
+          jq . qa-stats.json
+          echo "## Prod QA capture stats" >> "$GITHUB_STEP_SUMMARY"
+          echo '```json' >> "$GITHUB_STEP_SUMMARY"
+          jq . qa-stats.json >> "$GITHUB_STEP_SUMMARY"
+          echo '```' >> "$GITHUB_STEP_SUMMARY"
+
+      - name: Write skip artifact
+        if: steps.precheck.outputs.skip == 'true'
+        run: |
+          echo '{"error":"AWS_OIDC_ROLE_ARN not configured"}' > qa-stats.json
+
+      - uses: actions/upload-artifact@v4
+        with:
+          name: prod-qa-stats-${{ github.run_id }}
+          path: qa-stats.json

--- a/.gitignore
+++ b/.gitignore
@@ -148,6 +148,7 @@ scripts/*
 !scripts/deploy-error-clustering-binary.sh
 !scripts/fetch-prod-error-clusters.sh
 !scripts/fetch-prod-logs.sh
+!scripts/fetch-prod-qa-stats.sh
 .code-review-state
 #openspec/
 code-reviews/

--- a/deploy/aws/README.md
+++ b/deploy/aws/README.md
@@ -503,9 +503,18 @@ SINCE_HOURS=72 bash scripts/fetch-prod-error-clusters.sh    # 自定义窗口
 bash scripts/fetch-prod-error-clusters.sh --check           # 只校验 env + 工具，不 dispatch
 ```
 
-脚本会：dispatch workflow → 轮询新 run id（默认 10 min 超时）→ `gh run watch` 等待完成
-→ `gh run download` 取 artifact → 打印 `report.json` 的 `summary` 字段。`gh` CLI 由
-`dev-rules/templates/cloud-agent-bootstrap.sh`（`.cursor/cloud-agent.env` 把它列在
+**QA 采集体量（总条数 / 近 24h 插入 / `qa_blobs` 磁盘）**：dispatch `prod-qa-stats.yml`，artifact `qa-stats.json`。
+
+```bash
+bash scripts/fetch-prod-qa-stats.sh                         # 输出到 ./.prod-qa-stats/
+WORKFLOW_REF=cursor/branch-name bash scripts/fetch-prod-qa-stats.sh   # workflow 尚未合入 main 时指定 ref
+bash scripts/fetch-prod-qa-stats.sh --check
+```
+
+`fetch-prod-error-clusters.sh`：`gh run download` → 打印 `report.json` 的 `summary`。  
+`fetch-prod-qa-stats.sh`：`gh run download` → 打印 `qa-stats.json`（`qa_records_total`、`qa_records_last_24h`、`inserts_per_hour_last_24h_avg`、`qa_blobs_bytes`、`qa_blobs_file_count`）。
+
+`gh` CLI 由 `dev-rules/templates/cloud-agent-bootstrap.sh`（`.cursor/cloud-agent.env` 把它列在
 `CLOUD_AGENT_TOOLS` 里）在会话引导时 best-effort 安装；缺失时脚本会报错并指出安装方式。
 
 **会话引导自检**：`.cursor/cloud-agent-project-hook.sh` 在每次 Cloud Agent 启动时会检查

--- a/deploy/aws/README.md
+++ b/deploy/aws/README.md
@@ -503,12 +503,20 @@ SINCE_HOURS=72 bash scripts/fetch-prod-error-clusters.sh    # 自定义窗口
 bash scripts/fetch-prod-error-clusters.sh --check           # 只校验 env + 工具，不 dispatch
 ```
 
-**QA 采集体量（总条数 / 近 24h 插入 / `qa_blobs` 磁盘）**：dispatch `prod-qa-stats.yml`，artifact `qa-stats.json`。
+**QA 采集体量（总条数 / 近 24h 插入 / `qa_blobs` 磁盘）**：合并 `prod-qa-stats.yml` 到默认分支后，artifact `qa-stats.json`。
 
 ```bash
-bash scripts/fetch-prod-qa-stats.sh                         # 输出到 ./.prod-qa-stats/
-WORKFLOW_REF=cursor/branch-name bash scripts/fetch-prod-qa-stats.sh   # workflow 尚未合入 main 时指定 ref
+bash scripts/fetch-prod-qa-stats.sh           # → ./.prod-qa-stats/qa-stats.json
 bash scripts/fetch-prod-qa-stats.sh --check
+```
+
+在 workflow 尚未出现在 `main` 之前，或需要当场核对时，SSM 进 prod 实例执行（只读）：
+
+```bash
+sudo docker exec tokenkey-postgres psql -U tokenkey -d tokenkey -t -A -c "SELECT count(*) FROM qa_records;"
+sudo docker exec tokenkey-postgres psql -U tokenkey -d tokenkey -t -A -c "SELECT count(*) FROM qa_records WHERE created_at >= now() - interval '24 hours';"
+sudo du -sh /var/lib/tokenkey/app/qa_blobs 2>/dev/null || echo '(no qa_blobs dir)'
+sudo find /var/lib/tokenkey/app/qa_blobs -type f 2>/dev/null | wc -l
 ```
 
 `fetch-prod-error-clusters.sh`：`gh run download` → 打印 `report.json` 的 `summary`。  

--- a/scripts/fetch-prod-qa-stats.sh
+++ b/scripts/fetch-prod-qa-stats.sh
@@ -1,0 +1,107 @@
+#!/usr/bin/env bash
+#
+# scripts/fetch-prod-qa-stats.sh — dispatch prod-qa-stats.yml and download qa-stats.json
+#
+# Uses the same GH_TOKEN pattern as fetch-prod-error-clusters.sh (no AWS keys on the agent).
+#
+# Required env:
+#   GH_TOKEN   — same scopes as fetch-prod-error-clusters.sh (actions:write/read, contents:read)
+#
+# Optional:
+#   GH_REPO           default: youxuanxue/sub2api
+#   OUT_DIR           default: ./.prod-qa-stats
+#   POLL_TIMEOUT_S    default: 600
+#   WORKFLOW_REF      git ref to run workflow from (default: empty = repo default branch).
+#                     Use 'cursor/.../branch-name' before the workflow is merged to main.
+#
+set -euo pipefail
+
+GH_REPO="${GH_REPO:-youxuanxue/sub2api}"
+OUT_DIR="${OUT_DIR:-./.prod-qa-stats}"
+POLL_TIMEOUT_S="${POLL_TIMEOUT_S:-600}"
+WORKFLOW="prod-qa-stats.yml"
+
+MODE="run"
+if [ "${1:-}" = "--check" ]; then
+  MODE="check"
+fi
+
+err() { echo "[fetch-prod-qa-stats] error: $*" >&2; }
+log() { echo "[fetch-prod-qa-stats] $*"; }
+
+require_tool() {
+  local tool="$1"
+  if ! command -v "$tool" >/dev/null 2>&1; then
+    err "$tool is not installed (required)."
+    return 1
+  fi
+}
+
+validate_env() {
+  local ok=0
+  require_tool gh || ok=1
+  require_tool jq || ok=1
+  if [ -z "${GH_TOKEN:-}" ]; then
+    err "GH_TOKEN is not set."
+    ok=1
+  fi
+  return $ok
+}
+
+if ! validate_env; then
+  exit 1
+fi
+
+if [ "$MODE" = "check" ]; then
+  log "env + tools OK (repo=$GH_REPO)"
+  exit 0
+fi
+
+mkdir -p "$OUT_DIR"
+
+log "snapshotting last run id on $GH_REPO/$WORKFLOW"
+PREV_ID=$(gh run list --workflow="$WORKFLOW" --repo "$GH_REPO" --limit 1 \
+  --json databaseId --jq '.[0].databaseId // 0')
+log "previous run id: $PREV_ID"
+
+DISPATCH_ARGS=(workflow run "$WORKFLOW" --repo "$GH_REPO")
+if [ -n "${WORKFLOW_REF:-}" ]; then
+  DISPATCH_ARGS+=(--ref "$WORKFLOW_REF")
+fi
+log "dispatching $WORKFLOW${WORKFLOW_REF:+ (ref=$WORKFLOW_REF)}"
+gh "${DISPATCH_ARGS[@]}"
+
+log "polling for new run id (timeout ${POLL_TIMEOUT_S}s)"
+DEADLINE=$(( $(date +%s) + POLL_TIMEOUT_S ))
+RUN_ID="$PREV_ID"
+while [ "$RUN_ID" = "$PREV_ID" ] || [ "$RUN_ID" = "0" ]; do
+  sleep 4
+  RUN_ID=$(gh run list --workflow="$WORKFLOW" --repo "$GH_REPO" --limit 1 \
+    --json databaseId --jq '.[0].databaseId // 0')
+  if [ "$(date +%s)" -ge "$DEADLINE" ]; then
+    err "timed out waiting for workflow to start"
+    exit 2
+  fi
+done
+log "new run id: $RUN_ID"
+
+WATCH_RC=0
+gh run watch "$RUN_ID" --repo "$GH_REPO" --exit-status || WATCH_RC=$?
+
+ART_NAME="prod-qa-stats-$RUN_ID"
+log "downloading artifact $ART_NAME → $OUT_DIR"
+if ! gh run download "$RUN_ID" --repo "$GH_REPO" --name "$ART_NAME" --dir "$OUT_DIR"; then
+  err "artifact download failed (run exit=$WATCH_RC). Try: gh run view $RUN_ID --repo $GH_REPO --log"
+  exit 1
+fi
+
+if [ -s "$OUT_DIR/qa-stats.json" ]; then
+  jq . "$OUT_DIR/qa-stats.json"
+fi
+
+if [ "$WATCH_RC" -ne 0 ]; then
+  err "workflow run $RUN_ID did not succeed (exit=$WATCH_RC)"
+  exit 1
+fi
+
+log "done: $OUT_DIR/qa-stats.json"

--- a/scripts/fetch-prod-qa-stats.sh
+++ b/scripts/fetch-prod-qa-stats.sh
@@ -11,15 +11,22 @@
 #   GH_REPO           default: youxuanxue/sub2api
 #   OUT_DIR           default: ./.prod-qa-stats
 #   POLL_TIMEOUT_S    default: 600
-#   WORKFLOW_REF      git ref to run workflow from (default: empty = repo default branch).
-#                     Use 'cursor/.../branch-name' before the workflow is merged to main.
+#
+# Note: GitHub only registers workflow_dispatch files that exist on the repo default
+# branch. After merging `.github/workflows/prod-qa-stats.yml` to main, this script works
+# without extra flags.
 #
 set -euo pipefail
 
 GH_REPO="${GH_REPO:-youxuanxue/sub2api}"
 OUT_DIR="${OUT_DIR:-./.prod-qa-stats}"
 POLL_TIMEOUT_S="${POLL_TIMEOUT_S:-600}"
-WORKFLOW="prod-qa-stats.yml"
+WORKFLOW_FILE="prod-qa-stats.yml"
+
+latest_prod_qa_run_id() {
+  gh run list --repo "$GH_REPO" --workflow="$WORKFLOW_FILE" --limit 1 \
+    --json databaseId --jq '.[0].databaseId // 0' 2>/dev/null || echo 0
+}
 
 MODE="run"
 if [ "${1:-}" = "--check" ]; then
@@ -59,25 +66,22 @@ fi
 
 mkdir -p "$OUT_DIR"
 
-log "snapshotting last run id on $GH_REPO/$WORKFLOW"
-PREV_ID=$(gh run list --workflow="$WORKFLOW" --repo "$GH_REPO" --limit 1 \
-  --json databaseId --jq '.[0].databaseId // 0')
+log "snapshotting last prod-qa-stats run id"
+PREV_ID=$(latest_prod_qa_run_id)
 log "previous run id: $PREV_ID"
 
-DISPATCH_ARGS=(workflow run "$WORKFLOW" --repo "$GH_REPO")
-if [ -n "${WORKFLOW_REF:-}" ]; then
-  DISPATCH_ARGS+=(--ref "$WORKFLOW_REF")
+if ! gh workflow run "$WORKFLOW_FILE" --repo "$GH_REPO" 2>/dev/null; then
+  err "dispatch failed — is $WORKFLOW_FILE merged to the default branch yet?"
+  err "Until then, run the SQL / du commands in deploy/aws/README.md (Prod QA stats) on the EC2 host."
+  exit 1
 fi
-log "dispatching $WORKFLOW${WORKFLOW_REF:+ (ref=$WORKFLOW_REF)}"
-gh "${DISPATCH_ARGS[@]}"
 
 log "polling for new run id (timeout ${POLL_TIMEOUT_S}s)"
 DEADLINE=$(( $(date +%s) + POLL_TIMEOUT_S ))
 RUN_ID="$PREV_ID"
 while [ "$RUN_ID" = "$PREV_ID" ] || [ "$RUN_ID" = "0" ]; do
   sleep 4
-  RUN_ID=$(gh run list --workflow="$WORKFLOW" --repo "$GH_REPO" --limit 1 \
-    --json databaseId --jq '.[0].databaseId // 0')
+  RUN_ID=$(latest_prod_qa_run_id)
   if [ "$(date +%s)" -ge "$DEADLINE" ]; then
     err "timed out waiting for workflow to start"
     exit 2


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Adds `prod-qa-stats.yml`: OIDC → SSM on prod EC2 runs read-only PostgreSQL counts on `qa_records` (total + last 24h) and `du`/`find` on `/var/lib/tokenkey/app/qa_blobs`. Uploads `qa-stats.json` as artifact.

Adds `scripts/fetch-prod-qa-stats.sh` (same pattern as error-clusters fetch). Documents GitHub constraint: `workflow_dispatch` files must exist on **default branch** before `gh workflow run` works; includes copy-paste SSM commands for immediate manual checks.

## Risk

Low — read-only queries and filesystem stats; same IAM surface as existing SSM workflows.

## Validation

- `./scripts/preflight.sh` pass

## After merge

Run `bash scripts/fetch-prod-qa-stats.sh` to pull live numbers without SSH keys.
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-7aee685f-9af4-4960-9d08-c206da942a24"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-7aee685f-9af4-4960-9d08-c206da942a24"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

