### PR TITLE
feat(frontend): pricing page — model search (fuzzy + exact)

### DIFF
--- a/frontend/src/i18n/locales/en.ts
+++ b/frontend/src/i18n/locales/en.ts
@@ -25,7 +25,15 @@ export default {
     },
     errorTitle: 'Failed to load pricing',
     errorHint: 'Please refresh the page or try again later.',
-    retry: 'Retry'
+    retry: 'Retry',
+    search: {
+      placeholder: 'Search by model name…',
+      modeLabel: 'Match mode',
+      modeFuzzy: 'Contains',
+      modeExact: 'Exact name',
+      resultCount: '{count} models',
+      noMatches: 'No models match your search. Try fuzzy mode or a shorter query.'
+    }
   },
 
   // Home Page

--- a/frontend/src/i18n/locales/en.ts
+++ b/frontend/src/i18n/locales/en.ts
@@ -5,7 +5,13 @@ export default {
     subtitle: 'Pay-as-you-go pricing for every supported model',
     description:
       'Prices are per 1,000 tokens, in USD. Cache Read / Write columns apply only to models that bill cached tokens separately. Capabilities reflect upstream-declared features (vision, tools, …).',
-    backHome: 'Back to home',
+    nav: {
+      aria: 'Leave pricing page',
+      home: 'Home',
+      console: 'Console',
+      consoleTitleAuthed: 'Go to your dashboard',
+      consoleTitleGuest: 'Sign in to open the console'
+    },
     columns: {
       model: 'Model',
       vendor: 'Vendor',

--- a/frontend/src/i18n/locales/zh.ts
+++ b/frontend/src/i18n/locales/zh.ts
@@ -25,7 +25,15 @@ export default {
     },
     errorTitle: '加载价格失败',
     errorHint: '请刷新页面或稍后重试。',
-    retry: '重试'
+    retry: '重试',
+    search: {
+      placeholder: '按模型名称搜索…',
+      modeLabel: '匹配方式',
+      modeFuzzy: '模糊（包含）',
+      modeExact: '精准（全名）',
+      resultCount: '{count} 个模型',
+      noMatches: '没有匹配的模型。可切换到模糊搜索或缩短关键词。'
+    }
   },
 
   // Home Page

--- a/frontend/src/i18n/locales/zh.ts
+++ b/frontend/src/i18n/locales/zh.ts
@@ -5,7 +5,13 @@ export default {
     subtitle: '所有支持的模型，按调用量计费',
     description:
       '价格以美元 (USD) 计价，单位为每 1,000 tokens。Cache Read / Write 仅对单独计费缓存的模型生效；能力标签来自上游声明（视觉、工具调用等）。',
-    backHome: '返回首页',
+    nav: {
+      aria: '离开价格页',
+      home: '首页',
+      console: '控制台',
+      consoleTitleAuthed: '前往您的控制台',
+      consoleTitleGuest: '登录后进入控制台'
+    },
     columns: {
       model: '模型',
       vendor: '厂商',

--- a/frontend/src/utils/__tests__/pricingCatalogSearch.spec.ts
+++ b/frontend/src/utils/__tests__/pricingCatalogSearch.spec.ts
@@ -1,0 +1,47 @@
+import { describe, expect, it } from 'vitest'
+import type { PublicCatalogModel } from '@/api/pricing'
+import { filterPricingCatalogByModel } from '../pricingCatalogSearch'
+
+function model(id: string): PublicCatalogModel {
+  return {
+    model_id: id,
+    pricing: {
+      currency: 'USD',
+      input_per_1k_tokens: 0,
+      output_per_1k_tokens: 0
+    },
+    capabilities: []
+  }
+}
+
+describe('filterPricingCatalogByModel', () => {
+  const rows = [model('claude-sonnet-4'), model('gpt-4o-mini'), model('GPT-4-Turbo')]
+
+  it('returns all rows when query is empty or whitespace', () => {
+    expect(filterPricingCatalogByModel(rows, '', 'fuzzy')).toEqual(rows)
+    expect(filterPricingCatalogByModel(rows, '   ', 'exact')).toEqual(rows)
+  })
+
+  it('fuzzy mode matches case-insensitive substring', () => {
+    expect(filterPricingCatalogByModel(rows, 'sonnet', 'fuzzy').map((m) => m.model_id)).toEqual([
+      'claude-sonnet-4'
+    ])
+    expect(filterPricingCatalogByModel(rows, 'gpt', 'fuzzy').map((m) => m.model_id)).toEqual([
+      'gpt-4o-mini',
+      'GPT-4-Turbo'
+    ])
+  })
+
+  it('exact mode matches case-insensitive full model_id', () => {
+    expect(filterPricingCatalogByModel(rows, 'gpt-4o-mini', 'exact').map((m) => m.model_id)).toEqual([
+      'gpt-4o-mini'
+    ])
+    expect(filterPricingCatalogByModel(rows, 'GPT-4-TURBO', 'exact').map((m) => m.model_id)).toEqual([
+      'GPT-4-Turbo'
+    ])
+  })
+
+  it('exact mode does not use substring semantics', () => {
+    expect(filterPricingCatalogByModel(rows, 'gpt', 'exact')).toEqual([])
+  })
+})

--- a/frontend/src/utils/pricingCatalogSearch.ts
+++ b/frontend/src/utils/pricingCatalogSearch.ts
@@ -1,0 +1,28 @@
+/**
+ * Client-side filtering for the public pricing catalog (model_id search).
+ */
+
+import type { PublicCatalogModel } from '@/api/pricing'
+
+export type PricingCatalogSearchMode = 'fuzzy' | 'exact'
+
+/**
+ * Filters catalog rows by model_id.
+ * - fuzzy: case-insensitive substring match (partial / "模糊")
+ * - exact: case-insensitive full string equality after trim ("精准")
+ */
+export function filterPricingCatalogByModel(
+  models: PublicCatalogModel[],
+  rawQuery: string,
+  mode: PricingCatalogSearchMode
+): PublicCatalogModel[] {
+  const q = rawQuery.trim()
+  if (!q) {
+    return models
+  }
+  const lower = q.toLowerCase()
+  if (mode === 'exact') {
+    return models.filter((m) => m.model_id.trim().toLowerCase() === lower)
+  }
+  return models.filter((m) => m.model_id.toLowerCase().includes(lower))
+}

--- a/frontend/src/views/PricingView.vue
+++ b/frontend/src/views/PricingView.vue
@@ -81,7 +81,55 @@
           class="overflow-hidden rounded-2xl border border-gray-200 bg-white shadow-sm dark:border-dark-800 dark:bg-dark-900"
           data-tk="cold-start-pricing-table"
         >
-          <div class="overflow-x-auto">
+          <div
+            class="flex flex-col gap-3 border-b border-gray-100 bg-gray-50/80 px-4 py-3 dark:border-dark-800 dark:bg-dark-800/40 sm:flex-row sm:items-center sm:justify-between"
+          >
+            <label class="sr-only" for="pricing-model-search">{{ t('pricing.search.placeholder') }}</label>
+            <div class="relative min-w-0 flex-1 sm:max-w-md">
+              <Icon
+                name="search"
+                size="sm"
+                class="pointer-events-none absolute left-3 top-1/2 -translate-y-1/2 text-gray-400 dark:text-dark-500"
+              />
+              <input
+                id="pricing-model-search"
+                v-model="modelSearchQuery"
+                type="search"
+                autocomplete="off"
+                :placeholder="t('pricing.search.placeholder')"
+                class="w-full rounded-lg border border-gray-200 bg-white py-2 pl-9 pr-3 text-sm text-gray-900 placeholder:text-gray-400 focus:border-primary-500 focus:outline-none focus:ring-2 focus:ring-primary-500/20 dark:border-dark-700 dark:bg-dark-900 dark:text-white dark:placeholder:text-dark-500"
+              />
+            </div>
+            <div class="flex shrink-0 flex-wrap items-center gap-4">
+              <fieldset class="flex items-center gap-3 text-xs">
+                <legend class="sr-only">{{ t('pricing.search.modeLabel') }}</legend>
+                <label class="inline-flex cursor-pointer items-center gap-1.5 text-gray-700 dark:text-dark-200">
+                  <input v-model="modelSearchMode" type="radio" value="fuzzy" class="text-primary-600" />
+                  {{ t('pricing.search.modeFuzzy') }}
+                </label>
+                <label class="inline-flex cursor-pointer items-center gap-1.5 text-gray-700 dark:text-dark-200">
+                  <input v-model="modelSearchMode" type="radio" value="exact" class="text-primary-600" />
+                  {{ t('pricing.search.modeExact') }}
+                </label>
+              </fieldset>
+              <span
+                v-if="modelSearchQuery.trim()"
+                class="text-xs tabular-nums text-gray-500 dark:text-dark-400"
+              >
+                {{ t('pricing.search.resultCount', { count: filteredCatalogRows.length }) }}
+              </span>
+            </div>
+          </div>
+          <div
+            v-if="filteredCatalogRows.length === 0 && modelSearchQuery.trim()"
+            class="border-t border-gray-100 px-4 py-12 text-center dark:border-dark-800"
+          >
+            <Icon name="inbox" size="xl" class="mx-auto text-gray-400 dark:text-dark-500" />
+            <p class="mt-3 text-sm font-medium text-gray-700 dark:text-dark-200">
+              {{ t('pricing.search.noMatches') }}
+            </p>
+          </div>
+          <div v-else class="overflow-x-auto">
             <table class="min-w-full divide-y divide-gray-200 dark:divide-dark-800">
               <thead class="bg-gray-50 dark:bg-dark-800/60">
                 <tr>
@@ -141,7 +189,7 @@
                 class="divide-y divide-gray-100 bg-white dark:divide-dark-800/60 dark:bg-dark-900"
               >
                 <tr
-                  v-for="model in catalog.data"
+                  v-for="model in filteredCatalogRows"
                   :key="model.model_id"
                   class="hover:bg-primary-50/30 dark:hover:bg-dark-800/40"
                 >
@@ -236,12 +284,27 @@ import { useI18n } from 'vue-i18n'
 import { getPublicPricing, type PublicCatalogResponse } from '@/api/pricing'
 import Icon from '@/components/icons/Icon.vue'
 import LocaleSwitcher from '@/components/common/LocaleSwitcher.vue'
+import {
+  filterPricingCatalogByModel,
+  type PricingCatalogSearchMode
+} from '@/utils/pricingCatalogSearch'
 
 const { t } = useI18n()
 
 const catalog = ref<PublicCatalogResponse | null>(null)
 const loading = ref(true)
 const errorMessage = ref('')
+const modelSearchQuery = ref('')
+const modelSearchMode = ref<PricingCatalogSearchMode>('fuzzy')
+
+const filteredCatalogRows = computed(() => {
+  if (!catalog.value) return []
+  return filterPricingCatalogByModel(
+    catalog.value.data,
+    modelSearchQuery.value,
+    modelSearchMode.value
+  )
+})
 
 const hasCacheColumns = computed(() => {
   if (!catalog.value) return false

--- a/frontend/src/views/PricingView.vue
+++ b/frontend/src/views/PricingView.vue
@@ -8,27 +8,12 @@
         :aria-label="t('pricing.nav.aria')"
       >
         <div class="flex flex-wrap items-center gap-2">
-          <router-link
-            to="/home"
-            class="group inline-flex items-center gap-2 rounded-xl border border-gray-200/80 bg-white/90 px-3.5 py-2 text-sm font-medium text-gray-700 shadow-sm backdrop-blur transition-colors hover:border-primary-200 hover:bg-primary-50/80 hover:text-primary-800 dark:border-dark-700 dark:bg-dark-900/70 dark:text-dark-200 dark:hover:border-primary-700/60 dark:hover:bg-primary-950/40 dark:hover:text-primary-200"
-          >
-            <Icon
-              name="home"
-              size="sm"
-              class="text-gray-500 transition-colors group-hover:text-primary-600 dark:text-dark-400 dark:group-hover:text-primary-300"
-            />
+          <router-link to="/home" :class="NAV_LINK_CLASS">
+            <Icon name="home" size="sm" :class="NAV_ICON_CLASS" />
             <span>{{ t('pricing.nav.home') }}</span>
           </router-link>
-          <router-link
-            :to="consolePath"
-            class="group inline-flex items-center gap-2 rounded-xl border border-gray-200/80 bg-white/90 px-3.5 py-2 text-sm font-medium text-gray-700 shadow-sm backdrop-blur transition-colors hover:border-primary-200 hover:bg-primary-50/80 hover:text-primary-800 dark:border-dark-700 dark:bg-dark-900/70 dark:text-dark-200 dark:hover:border-primary-700/60 dark:hover:bg-primary-950/40 dark:hover:text-primary-200"
-            :title="consoleLinkTitle"
-          >
-            <Icon
-              name="grid"
-              size="sm"
-              class="text-gray-500 transition-colors group-hover:text-primary-600 dark:text-dark-400 dark:group-hover:text-primary-300"
-            />
+          <router-link :to="consolePath" :class="NAV_LINK_CLASS" :title="consoleLinkTitle">
+            <Icon name="grid" size="sm" :class="NAV_ICON_CLASS" />
             <span>{{ t('pricing.nav.console') }}</span>
           </router-link>
         </div>
@@ -313,6 +298,12 @@ import {
 
 const { t } = useI18n()
 const authStore = useAuthStore()
+
+/** Shared nav pill styles — single source to reduce churn vs upstream-style pages. */
+const NAV_LINK_CLASS =
+  'group inline-flex items-center gap-2 rounded-xl border border-gray-200/80 bg-white/90 px-3.5 py-2 text-sm font-medium text-gray-700 shadow-sm backdrop-blur transition-colors hover:border-primary-200 hover:bg-primary-50/80 hover:text-primary-800 dark:border-dark-700 dark:bg-dark-900/70 dark:text-dark-200 dark:hover:border-primary-700/60 dark:hover:bg-primary-950/40 dark:hover:text-primary-200'
+const NAV_ICON_CLASS =
+  'text-gray-500 transition-colors group-hover:text-primary-600 dark:text-dark-400 dark:group-hover:text-primary-300'
 
 const consolePath = computed(() => {
   if (!authStore.isAuthenticated) {

--- a/frontend/src/views/PricingView.vue
+++ b/frontend/src/views/PricingView.vue
@@ -3,14 +3,35 @@
     class="relative flex min-h-screen flex-col bg-gradient-to-br from-gray-50 via-primary-50/30 to-gray-100 dark:from-dark-950 dark:via-dark-900 dark:to-dark-950"
   >
     <header class="relative z-20 px-6 py-4">
-      <nav class="mx-auto flex max-w-6xl items-center justify-between">
-        <router-link
-          to="/home"
-          class="flex items-center gap-2 text-gray-700 transition-colors hover:text-primary-600 dark:text-dark-300 dark:hover:text-primary-300"
-        >
-          <Icon name="arrowLeft" size="sm" />
-          <span class="text-sm font-medium">{{ t('pricing.backHome') }}</span>
-        </router-link>
+      <nav
+        class="mx-auto flex max-w-6xl flex-wrap items-center justify-between gap-4"
+        :aria-label="t('pricing.nav.aria')"
+      >
+        <div class="flex flex-wrap items-center gap-2">
+          <router-link
+            to="/home"
+            class="group inline-flex items-center gap-2 rounded-xl border border-gray-200/80 bg-white/90 px-3.5 py-2 text-sm font-medium text-gray-700 shadow-sm backdrop-blur transition-colors hover:border-primary-200 hover:bg-primary-50/80 hover:text-primary-800 dark:border-dark-700 dark:bg-dark-900/70 dark:text-dark-200 dark:hover:border-primary-700/60 dark:hover:bg-primary-950/40 dark:hover:text-primary-200"
+          >
+            <Icon
+              name="home"
+              size="sm"
+              class="text-gray-500 transition-colors group-hover:text-primary-600 dark:text-dark-400 dark:group-hover:text-primary-300"
+            />
+            <span>{{ t('pricing.nav.home') }}</span>
+          </router-link>
+          <router-link
+            :to="consolePath"
+            class="group inline-flex items-center gap-2 rounded-xl border border-gray-200/80 bg-white/90 px-3.5 py-2 text-sm font-medium text-gray-700 shadow-sm backdrop-blur transition-colors hover:border-primary-200 hover:bg-primary-50/80 hover:text-primary-800 dark:border-dark-700 dark:bg-dark-900/70 dark:text-dark-200 dark:hover:border-primary-700/60 dark:hover:bg-primary-950/40 dark:hover:text-primary-200"
+            :title="consoleLinkTitle"
+          >
+            <Icon
+              name="grid"
+              size="sm"
+              class="text-gray-500 transition-colors group-hover:text-primary-600 dark:text-dark-400 dark:group-hover:text-primary-300"
+            />
+            <span>{{ t('pricing.nav.console') }}</span>
+          </router-link>
+        </div>
         <LocaleSwitcher />
       </nav>
     </header>
@@ -284,12 +305,25 @@ import { useI18n } from 'vue-i18n'
 import { getPublicPricing, type PublicCatalogResponse } from '@/api/pricing'
 import Icon from '@/components/icons/Icon.vue'
 import LocaleSwitcher from '@/components/common/LocaleSwitcher.vue'
+import { useAuthStore } from '@/stores/auth'
 import {
   filterPricingCatalogByModel,
   type PricingCatalogSearchMode
 } from '@/utils/pricingCatalogSearch'
 
 const { t } = useI18n()
+const authStore = useAuthStore()
+
+const consolePath = computed(() => {
+  if (!authStore.isAuthenticated) {
+    return { path: '/login', query: { redirect: '/dashboard' } }
+  }
+  return authStore.isAdmin ? '/admin/dashboard' : '/dashboard'
+})
+
+const consoleLinkTitle = computed(() =>
+  authStore.isAuthenticated ? t('pricing.nav.consoleTitleAuthed') : t('pricing.nav.consoleTitleGuest')
+)
 
 const catalog = ref<PublicCatalogResponse | null>(null)
 const loading = ref(true)


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

- Public `/pricing`: model name search (**Contains** vs **Exact**) with empty state when no rows match.
- Header navigation redesigned: **Home** (marketing landing) and **Console** (dashboard). Logged-in users go to `/dashboard` or `/admin/dashboard`; guests go to **Login** with `redirect=/dashboard` so after sign-in they land in the console. Card-style buttons with **home** + **grid** icons.

## Risk

Low — frontend-only UX.

## Validation

- `pnpm lint:check && pnpm typecheck`
- `./scripts/preflight.sh`

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-11417f7c-baad-4b96-9b3a-2b0f9bc403d1"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-11417f7c-baad-4b96-9b3a-2b0f9bc403d1"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

