### PR TITLE
fix(frontend): improve public pricing page layout and catalog details

### DIFF
--- a/frontend/src/i18n/locales/en.ts
+++ b/frontend/src/i18n/locales/en.ts
@@ -19,8 +19,15 @@ export default {
       output: 'Output',
       cacheRead: 'Cache Read',
       cacheWrite: 'Cache Write',
-      contextWindow: 'Context Window',
+      contextWindow: 'Context window',
+      maxOutput: 'Max output',
       capabilities: 'Capabilities'
+    },
+    tableHint:
+      'Swipe horizontally or scroll below to see all columns. Model names wrap in the left column.',
+    footer: {
+      total: '{count} models listed',
+      filtered: 'Showing {shown} of {total} models'
     },
     perThousandTokens: '/ 1K tokens',
     contextTokens: '{count} tokens',

--- a/frontend/src/i18n/locales/zh.ts
+++ b/frontend/src/i18n/locales/zh.ts
@@ -20,7 +20,13 @@ export default {
       cacheRead: '缓存读取',
       cacheWrite: '缓存写入',
       contextWindow: '上下文窗口',
+      maxOutput: '最大输出',
       capabilities: '能力'
+    },
+    tableHint: '可左右滑动或横向滚动查看全部列；左侧模型名称支持换行显示。',
+    footer: {
+      total: '共 {count} 个模型',
+      filtered: '显示 {shown} / {total} 个模型'
     },
     perThousandTokens: '/ 1K tokens',
     contextTokens: '{count} tokens',

--- a/frontend/src/views/PricingView.vue
+++ b/frontend/src/views/PricingView.vue
@@ -308,12 +308,12 @@
                 {{
                   t('pricing.footer.filtered', {
                     shown: filteredCatalogRows.length,
-                    total: catalog?.data.length ?? 0
+                    total: catalogRowTotal
                   })
                 }}
               </template>
               <template v-else>
-                {{ t('pricing.footer.total', { count: catalog?.data.length ?? 0 }) }}
+                {{ t('pricing.footer.total', { count: catalogRowTotal }) }}
               </template>
             </p>
             <p class="text-left sm:text-right">
@@ -413,6 +413,9 @@ const hasMaxOutputColumn = computed(() => {
   if (!catalog.value) return false
   return catalog.value.data.some((m) => (m.max_output_tokens ?? 0) > 0)
 })
+
+/** Footer total row count (full catalog, not filtered). */
+const catalogRowTotal = computed(() => catalog.value?.data.length ?? 0)
 
 const formattedUpdatedAt = computed(() => {
   if (!catalog.value?.updated_at) return ''

--- a/frontend/src/views/PricingView.vue
+++ b/frontend/src/views/PricingView.vue
@@ -2,9 +2,9 @@
   <div
     class="relative flex min-h-screen flex-col bg-gradient-to-br from-gray-50 via-primary-50/30 to-gray-100 dark:from-dark-950 dark:via-dark-900 dark:to-dark-950"
   >
-    <header class="relative z-20 px-6 py-4">
+    <header class="relative z-20 px-4 py-4 sm:px-6">
       <nav
-        class="mx-auto flex max-w-6xl flex-wrap items-center justify-between gap-4"
+        class="mx-auto flex max-w-[90rem] flex-wrap items-center justify-between gap-4"
         :aria-label="t('pricing.nav.aria')"
       >
         <div class="flex flex-wrap items-center gap-2">
@@ -21,8 +21,8 @@
       </nav>
     </header>
 
-    <main class="relative z-10 flex-1 px-6 pb-16 pt-8">
-      <div class="mx-auto max-w-6xl">
+    <main class="relative z-10 flex-1 px-4 pb-16 pt-8 sm:px-6">
+      <div class="mx-auto max-w-[90rem]">
         <div class="mb-8 text-center">
           <h1
             class="text-3xl font-bold tracking-tight text-gray-900 dark:text-white sm:text-4xl"
@@ -103,7 +103,7 @@
             class="flex flex-col gap-3 border-b border-gray-100 bg-gray-50/80 px-4 py-3 dark:border-dark-800 dark:bg-dark-800/40 sm:flex-row sm:items-center sm:justify-between"
           >
             <label class="sr-only" for="pricing-model-search">{{ t('pricing.search.placeholder') }}</label>
-            <div class="relative min-w-0 flex-1 sm:max-w-md">
+            <div class="relative min-w-0 flex-1 xl:max-w-xl">
               <Icon
                 name="search"
                 size="sm"
@@ -138,6 +138,11 @@
               </span>
             </div>
           </div>
+          <p
+            class="border-b border-gray-100 bg-gray-50/50 px-4 py-2 text-xs text-gray-500 dark:border-dark-800 dark:bg-dark-800/30 dark:text-dark-400 lg:hidden"
+          >
+            {{ t('pricing.tableHint') }}
+          </p>
           <div
             v-if="filteredCatalogRows.length === 0 && modelSearchQuery.trim()"
             class="border-t border-gray-100 px-4 py-12 text-center dark:border-dark-800"
@@ -147,57 +152,64 @@
               {{ t('pricing.search.noMatches') }}
             </p>
           </div>
-          <div v-else class="overflow-x-auto">
-            <table class="min-w-full divide-y divide-gray-200 dark:divide-dark-800">
+          <div v-else class="overflow-x-auto [-webkit-overflow-scrolling:touch]">
+            <table class="min-w-[72rem] w-full divide-y divide-gray-200 dark:divide-dark-800">
               <thead class="bg-gray-50 dark:bg-dark-800/60">
                 <tr>
                   <th
                     scope="col"
-                    class="px-4 py-3 text-left text-xs font-semibold uppercase tracking-wider text-gray-500 dark:text-dark-300"
+                    class="sticky left-0 z-20 min-w-[14rem] max-w-[28rem] border-r border-gray-200 bg-gray-50 px-3 py-3 text-left text-xs font-semibold uppercase tracking-wider text-gray-500 shadow-[4px_0_12px_-8px_rgba(0,0,0,0.15)] dark:border-dark-700 dark:bg-dark-800/60 dark:text-dark-300 dark:shadow-[4px_0_12px_-8px_rgba(0,0,0,0.4)]"
                   >
                     {{ t('pricing.columns.model') }}
                   </th>
                   <th
                     scope="col"
-                    class="px-4 py-3 text-left text-xs font-semibold uppercase tracking-wider text-gray-500 dark:text-dark-300"
+                    class="min-w-[7rem] px-3 py-3 text-left text-xs font-semibold uppercase tracking-wider text-gray-500 dark:text-dark-300"
                   >
                     {{ t('pricing.columns.vendor') }}
                   </th>
                   <th
                     scope="col"
-                    class="px-4 py-3 text-right text-xs font-semibold uppercase tracking-wider text-gray-500 dark:text-dark-300"
+                    class="px-3 py-3 text-right text-xs font-semibold uppercase tracking-wider text-gray-500 dark:text-dark-300"
                   >
                     {{ t('pricing.columns.input') }}
                   </th>
                   <th
                     scope="col"
-                    class="px-4 py-3 text-right text-xs font-semibold uppercase tracking-wider text-gray-500 dark:text-dark-300"
+                    class="px-3 py-3 text-right text-xs font-semibold uppercase tracking-wider text-gray-500 dark:text-dark-300"
                   >
                     {{ t('pricing.columns.output') }}
                   </th>
                   <th
                     v-if="hasCacheColumns"
                     scope="col"
-                    class="px-4 py-3 text-right text-xs font-semibold uppercase tracking-wider text-gray-500 dark:text-dark-300"
+                    class="px-3 py-3 text-right text-xs font-semibold uppercase tracking-wider text-gray-500 dark:text-dark-300"
                   >
                     {{ t('pricing.columns.cacheRead') }}
                   </th>
                   <th
                     v-if="hasCacheColumns"
                     scope="col"
-                    class="px-4 py-3 text-right text-xs font-semibold uppercase tracking-wider text-gray-500 dark:text-dark-300"
+                    class="px-3 py-3 text-right text-xs font-semibold uppercase tracking-wider text-gray-500 dark:text-dark-300"
                   >
                     {{ t('pricing.columns.cacheWrite') }}
                   </th>
                   <th
                     scope="col"
-                    class="px-4 py-3 text-right text-xs font-semibold uppercase tracking-wider text-gray-500 dark:text-dark-300"
+                    class="px-3 py-3 text-right text-xs font-semibold uppercase tracking-wider text-gray-500 dark:text-dark-300"
                   >
                     {{ t('pricing.columns.contextWindow') }}
                   </th>
                   <th
+                    v-if="hasMaxOutputColumn"
                     scope="col"
-                    class="px-4 py-3 text-left text-xs font-semibold uppercase tracking-wider text-gray-500 dark:text-dark-300"
+                    class="px-3 py-3 text-right text-xs font-semibold uppercase tracking-wider text-gray-500 dark:text-dark-300"
+                  >
+                    {{ t('pricing.columns.maxOutput') }}
+                  </th>
+                  <th
+                    scope="col"
+                    class="min-w-[10rem] px-3 py-3 text-left text-xs font-semibold uppercase tracking-wider text-gray-500 dark:text-dark-300"
                   >
                     {{ t('pricing.columns.capabilities') }}
                   </th>
@@ -209,21 +221,25 @@
                 <tr
                   v-for="model in filteredCatalogRows"
                   :key="model.model_id"
-                  class="hover:bg-primary-50/30 dark:hover:bg-dark-800/40"
+                  class="group hover:bg-primary-50/30 dark:hover:bg-dark-800/40"
                 >
-                  <td class="whitespace-nowrap px-4 py-3 font-mono text-sm text-gray-900 dark:text-white">
+                  <td
+                    class="sticky left-0 z-10 min-w-[14rem] max-w-[28rem] border-r border-gray-200 bg-white px-3 py-3 align-top font-mono text-sm leading-snug text-gray-900 shadow-[4px_0_12px_-8px_rgba(0,0,0,0.12)] break-words group-hover:bg-primary-50/30 dark:border-dark-700 dark:bg-dark-900 dark:text-white dark:shadow-[4px_0_12px_-8px_rgba(0,0,0,0.45)] dark:group-hover:bg-dark-800/40"
+                  >
                     {{ model.model_id }}
                   </td>
-                  <td class="whitespace-nowrap px-4 py-3 text-sm text-gray-600 dark:text-dark-300">
+                  <td
+                    class="min-w-[7rem] px-3 py-3 align-top text-sm leading-snug text-gray-600 break-words dark:text-dark-300"
+                  >
                     {{ model.vendor || '—' }}
                   </td>
-                  <td class="whitespace-nowrap px-4 py-3 text-right text-sm tabular-nums text-gray-900 dark:text-white">
+                  <td class="whitespace-nowrap px-3 py-3 text-right text-sm tabular-nums text-gray-900 dark:text-white">
                     {{ formatPrice(model.pricing.input_per_1k_tokens) }}
                     <span class="ml-0.5 text-xs text-gray-400">{{
                       t('pricing.perThousandTokens')
                     }}</span>
                   </td>
-                  <td class="whitespace-nowrap px-4 py-3 text-right text-sm tabular-nums text-gray-900 dark:text-white">
+                  <td class="whitespace-nowrap px-3 py-3 text-right text-sm tabular-nums text-gray-900 dark:text-white">
                     {{ formatPrice(model.pricing.output_per_1k_tokens) }}
                     <span class="ml-0.5 text-xs text-gray-400">{{
                       t('pricing.perThousandTokens')
@@ -231,7 +247,7 @@
                   </td>
                   <td
                     v-if="hasCacheColumns"
-                    class="whitespace-nowrap px-4 py-3 text-right text-sm tabular-nums text-gray-700 dark:text-dark-200"
+                    class="whitespace-nowrap px-3 py-3 text-right text-sm tabular-nums text-gray-700 dark:text-dark-200"
                   >
                     {{
                       model.pricing.cache_read_per_1k != null
@@ -241,7 +257,7 @@
                   </td>
                   <td
                     v-if="hasCacheColumns"
-                    class="whitespace-nowrap px-4 py-3 text-right text-sm tabular-nums text-gray-700 dark:text-dark-200"
+                    class="whitespace-nowrap px-3 py-3 text-right text-sm tabular-nums text-gray-700 dark:text-dark-200"
                   >
                     {{
                       model.pricing.cache_write_per_1k != null
@@ -249,13 +265,22 @@
                         : '—'
                     }}
                   </td>
-                  <td class="whitespace-nowrap px-4 py-3 text-right text-sm tabular-nums text-gray-600 dark:text-dark-300">
+                  <td class="whitespace-nowrap px-3 py-3 text-right text-sm tabular-nums text-gray-600 dark:text-dark-300">
                     <template v-if="model.context_window && model.context_window > 0">
                       {{ formatNumber(model.context_window) }}
                     </template>
                     <template v-else>—</template>
                   </td>
-                  <td class="px-4 py-3">
+                  <td
+                    v-if="hasMaxOutputColumn"
+                    class="whitespace-nowrap px-3 py-3 text-right text-sm tabular-nums text-gray-600 dark:text-dark-300"
+                  >
+                    <template v-if="model.max_output_tokens && model.max_output_tokens > 0">
+                      {{ formatNumber(model.max_output_tokens) }}
+                    </template>
+                    <template v-else>—</template>
+                  </td>
+                  <td class="px-3 py-3 align-top">
                     <div class="flex flex-wrap gap-1">
                       <span
                         v-for="cap in model.capabilities"
@@ -276,9 +301,24 @@
             </table>
           </div>
           <div
-            class="border-t border-gray-100 bg-gray-50/60 px-4 py-2 text-right text-xs text-gray-500 dark:border-dark-800 dark:bg-dark-800/40 dark:text-dark-400"
+            class="flex flex-col gap-2 border-t border-gray-100 bg-gray-50/60 px-4 py-3 text-xs text-gray-500 sm:flex-row sm:items-center sm:justify-between dark:border-dark-800 dark:bg-dark-800/40 dark:text-dark-400"
           >
-            {{ t('pricing.updatedAt', { time: formattedUpdatedAt }) }}
+            <p class="text-left tabular-nums">
+              <template v-if="modelSearchQuery.trim()">
+                {{
+                  t('pricing.footer.filtered', {
+                    shown: filteredCatalogRows.length,
+                    total: catalog?.data.length ?? 0
+                  })
+                }}
+              </template>
+              <template v-else>
+                {{ t('pricing.footer.total', { count: catalog?.data.length ?? 0 }) }}
+              </template>
+            </p>
+            <p class="text-left sm:text-right">
+              {{ t('pricing.updatedAt', { time: formattedUpdatedAt }) }}
+            </p>
           </div>
         </div>
       </div>
@@ -366,6 +406,12 @@ const hasCacheColumns = computed(() => {
       (m.pricing.cache_read_per_1k != null && m.pricing.cache_read_per_1k > 0) ||
       (m.pricing.cache_write_per_1k != null && m.pricing.cache_write_per_1k > 0)
   )
+})
+
+/** Show column when catalog has max-output metadata (often unset for slim entries). */
+const hasMaxOutputColumn = computed(() => {
+  if (!catalog.value) return false
+  return catalog.value.data.some((m) => (m.max_output_tokens ?? 0) > 0)
 })
 
 const formattedUpdatedAt = computed(() => {

--- a/frontend/src/views/__tests__/PricingView.spec.ts
+++ b/frontend/src/views/__tests__/PricingView.spec.ts
@@ -1,0 +1,122 @@
+import { describe, expect, it, vi, beforeEach } from 'vitest'
+import { flushPromises, mount } from '@vue/test-utils'
+
+import PricingView from '../PricingView.vue'
+import type { PublicCatalogResponse } from '@/api/pricing'
+
+const { getPublicPricing } = vi.hoisted(() => ({
+  getPublicPricing: vi.fn(),
+}))
+
+vi.mock('@/api/pricing', () => ({
+  getPublicPricing,
+}))
+
+vi.mock('@/stores/auth', () => ({
+  useAuthStore: () => ({
+    isAuthenticated: false,
+    isAdmin: false,
+  }),
+}))
+
+vi.mock('@/stores/app', () => ({
+  useAppStore: () => ({
+    cachedPublicSettings: {
+      pricing_catalog_public: true,
+      registration_enabled: false,
+      signup_bonus_enabled: false,
+      signup_bonus_balance_usd: 0,
+      backend_mode_enabled: false,
+    },
+    fetchPublicSettings: vi.fn(),
+  }),
+}))
+
+vi.mock('vue-i18n', async () => {
+  const actual = await vi.importActual<typeof import('vue-i18n')>('vue-i18n')
+  return {
+    ...actual,
+    useI18n: () => ({
+      t: (key: string, params?: Record<string, unknown>) => {
+        if (key === 'pricing.footer.total' && params && typeof params.count === 'number') {
+          return `${params.count} models`
+        }
+        return key
+      },
+    }),
+  }
+})
+
+describe('PricingView', () => {
+  beforeEach(() => {
+    getPublicPricing.mockReset()
+  })
+
+  it('shows max output column when catalog includes max_output_tokens', async () => {
+    const catalog: PublicCatalogResponse = {
+      object: 'list',
+      updated_at: '2025-01-01T00:00:00Z',
+      data: [
+        {
+          model_id: 'gpt-test',
+          vendor: 'openai',
+          pricing: {
+            currency: 'USD',
+            input_per_1k_tokens: 0.001,
+            output_per_1k_tokens: 0.002,
+          },
+          context_window: 128000,
+          max_output_tokens: 16384,
+          capabilities: [],
+        },
+      ],
+    }
+    getPublicPricing.mockResolvedValue(catalog)
+
+    const wrapper = mount(PricingView, {
+      global: {
+        stubs: {
+          RouterLink: { template: '<a><slot /></a>' },
+          LocaleSwitcher: true,
+          Icon: true,
+        },
+      },
+    })
+    await flushPromises()
+
+    expect(wrapper.text()).toContain('pricing.columns.maxOutput')
+    expect(wrapper.text()).toContain('16,384')
+  })
+
+  it('uses wider layout wrapper (full catalog width)', async () => {
+    const catalog: PublicCatalogResponse = {
+      object: 'list',
+      updated_at: '2025-01-01T00:00:00Z',
+      data: [
+        {
+          model_id: 'x',
+          pricing: {
+            currency: 'USD',
+            input_per_1k_tokens: 0,
+            output_per_1k_tokens: 0,
+          },
+          capabilities: [],
+        },
+      ],
+    }
+    getPublicPricing.mockResolvedValue(catalog)
+
+    const wrapper = mount(PricingView, {
+      global: {
+        stubs: {
+          RouterLink: { template: '<a><slot /></a>' },
+          LocaleSwitcher: true,
+          Icon: true,
+        },
+      },
+    })
+    await flushPromises()
+
+    expect(wrapper.html()).toContain('max-w-[90rem]')
+  })
+})

--- a/frontend/src/views/__tests__/PricingView.spec.ts
+++ b/frontend/src/views/__tests__/PricingView.spec.ts
@@ -34,14 +34,45 @@ vi.mock('@/stores/app', () => ({
 
 vi.mock('vue-i18n', async () => {
   const actual = await vi.importActual<typeof import('vue-i18n')>('vue-i18n')
+  /** Minimal EN strings so assertions match production UI text, not raw keys. */
+  const pricingEn: Record<string, string> = {
+    'pricing.columns.maxOutput': 'Max output',
+    'pricing.footer.total': '{count} models listed',
+    'pricing.footer.filtered': 'Showing {shown} of {total} models',
+    'pricing.nav.aria': 'Leave pricing page',
+    'pricing.nav.home': 'Home',
+    'pricing.nav.console': 'Console',
+    'pricing.nav.consoleTitleGuest': '',
+    'pricing.nav.consoleTitleAuthed': '',
+    'pricing.title': 'Model Pricing',
+    'pricing.subtitle': '',
+    'pricing.description': '',
+    'pricing.columns.model': 'Model',
+    'pricing.columns.vendor': 'Vendor',
+    'pricing.columns.input': 'Input',
+    'pricing.columns.output': 'Output',
+    'pricing.columns.contextWindow': 'Context window',
+    'pricing.columns.capabilities': 'Capabilities',
+    'pricing.perThousandTokens': '/ 1K tokens',
+    'pricing.updatedAt': 'Last updated {time}',
+    'pricing.search.placeholder': '',
+    'pricing.search.modeLabel': '',
+    'pricing.search.modeFuzzy': '',
+    'pricing.search.modeExact': '',
+    'pricing.tableHint': '',
+    'pricing.search.noMatches': '',
+    'common.loading': 'Loading'
+  }
   return {
     ...actual,
     useI18n: () => ({
       t: (key: string, params?: Record<string, unknown>) => {
-        if (key === 'pricing.footer.total' && params && typeof params.count === 'number') {
-          return `${params.count} models`
-        }
-        return key
+        let base = pricingEn[key] ?? key
+        base = base.replace(/\{count\}/g, String(params?.count ?? ''))
+        base = base.replace(/\{shown\}/g, String(params?.shown ?? ''))
+        base = base.replace(/\{total\}/g, String(params?.total ?? ''))
+        base = base.replace(/\{time\}/g, String(params?.time ?? ''))
+        return base
       },
     }),
   }
@@ -84,7 +115,7 @@ describe('PricingView', () => {
     })
     await flushPromises()
 
-    expect(wrapper.text()).toContain('pricing.columns.maxOutput')
+    expect(wrapper.text()).toContain('Max output')
     expect(wrapper.text()).toContain('16,384')
   })
 


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

The public `/pricing` page felt narrow and long model IDs were clipped. The API already returns `max_output_tokens` but the UI did not show it.

## Changes

- Widen the page content from `max-w-6xl` (~72rem) to `max-w-[90rem]` so the table uses more width on large screens.
- Give the catalog table a minimum width (`min-w-[72rem]`) with horizontal scroll and **sticky first column** (model id) so scrolling wide tables keeps the row key visible.
- Replace `whitespace-nowrap` on model + vendor cells with wrapping (`break-words`) so full model ids and vendor names display instead of overflowing.
- Show **Max output** when the catalog includes non-zero `max_output_tokens`.
- Footer: total model count (and filtered count when searching); mobile hint to scroll horizontally.
- Relax search bar width cap on xl screens (`xl:max-w-xl`).

## Risk

Low — presentation-only on the public pricing route; API unchanged.

## Validation

- `pnpm exec vue-tsc --noEmit`
- `pnpm exec vitest run src/views/__tests__/PricingView.spec.ts`
- `./scripts/preflight.sh`
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-9a68f204-65c9-41af-bd84-96ca8f694a6c"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-9a68f204-65c9-41af-bd84-96ca8f694a6c"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

