### PR TITLE
feat(frontend): Playground 微信式气泡 + Pricing 顶部固定滚动

### DIFF
--- a/frontend/src/i18n/locales/en.ts
+++ b/frontend/src/i18n/locales/en.ts
@@ -71,6 +71,8 @@ export default {
     pickModelPlaceholder: 'Select a model…',
     roleUser: 'You',
     roleAssistant: 'Assistant',
+    avatarUser: 'Me',
+    avatarAssistant: 'AI',
     limitsHint: 'Up to {turns} turns in memory; max output tokens capped at {maxTok}; 60s timeout per request.',
     lastUsage: 'Last response usage',
     promptTokens: 'Prompt tokens',

--- a/frontend/src/i18n/locales/zh.ts
+++ b/frontend/src/i18n/locales/zh.ts
@@ -70,6 +70,8 @@ export default {
     pickModelPlaceholder: '请选择模型…',
     roleUser: '你',
     roleAssistant: '助手',
+    avatarUser: '我',
+    avatarAssistant: 'AI',
     limitsHint: '浏览器内最多保留 {turns} 轮对话；单次输出上限 {maxTok} tokens；单次请求超时 60 秒。',
     lastUsage: '上次响应用量',
     promptTokens: '输入 tokens',

--- a/frontend/src/views/PricingView.vue
+++ b/frontend/src/views/PricingView.vue
@@ -1,10 +1,15 @@
 <template>
   <div
-    class="relative flex min-h-screen flex-col bg-gradient-to-br from-gray-50 via-primary-50/30 to-gray-100 dark:from-dark-950 dark:via-dark-900 dark:to-dark-950"
+    class="relative flex flex-col bg-gradient-to-br from-gray-50 via-primary-50/30 to-gray-100 dark:from-dark-950 dark:via-dark-900 dark:to-dark-950"
+    :class="
+      pricingCatalogScrollMode
+        ? 'h-[100dvh] max-h-[100dvh] overflow-hidden'
+        : 'min-h-screen'
+    "
   >
     <main
-      class="relative z-10 flex flex-1 flex-col px-4 pb-16 pt-8 sm:px-6"
-      :class="pricingCatalogScrollMode ? 'min-h-0 overflow-hidden' : ''"
+      class="relative z-10 flex min-h-0 flex-1 flex-col px-4 pt-8 sm:px-6"
+      :class="pricingCatalogScrollMode ? 'overflow-hidden pb-4' : 'pb-16'"
     >
       <!-- Sticky chrome: nav + hero (when catalog table is shown, only tbody scrolls) -->
       <div class="mx-auto w-full max-w-[90rem] shrink-0 pb-4">
@@ -160,7 +165,7 @@
           </div>
           <div v-else class="flex min-h-0 flex-1 flex-col overflow-hidden">
             <div
-              class="min-h-0 flex-1 overflow-x-auto overflow-y-auto [-webkit-overflow-scrolling:touch]"
+              class="min-h-0 flex-1 overflow-x-auto overflow-y-auto overscroll-y-contain [-webkit-overflow-scrolling:touch]"
             >
               <table class="min-w-[72rem] w-full border-collapse divide-y divide-gray-200 dark:divide-dark-800">
                 <thead class="bg-gray-50 dark:bg-dark-800/60">

--- a/frontend/src/views/PricingView.vue
+++ b/frontend/src/views/PricingView.vue
@@ -2,28 +2,32 @@
   <div
     class="relative flex min-h-screen flex-col bg-gradient-to-br from-gray-50 via-primary-50/30 to-gray-100 dark:from-dark-950 dark:via-dark-900 dark:to-dark-950"
   >
-    <header class="relative z-20 px-4 py-4 sm:px-6">
-      <nav
-        class="mx-auto flex max-w-[90rem] flex-wrap items-center justify-between gap-4"
-        :aria-label="t('pricing.nav.aria')"
-      >
-        <div class="flex flex-wrap items-center gap-2">
-          <router-link to="/home" :class="NAV_LINK_CLASS">
-            <Icon name="home" size="sm" :class="NAV_ICON_CLASS" />
-            <span>{{ t('pricing.nav.home') }}</span>
-          </router-link>
-          <router-link :to="consolePath" :class="NAV_LINK_CLASS" :title="consoleLinkTitle">
-            <Icon name="grid" size="sm" :class="NAV_ICON_CLASS" />
-            <span>{{ t('pricing.nav.console') }}</span>
-          </router-link>
-        </div>
-        <LocaleSwitcher />
-      </nav>
-    </header>
+    <main
+      class="relative z-10 flex flex-1 flex-col px-4 pb-16 pt-8 sm:px-6"
+      :class="pricingCatalogScrollMode ? 'min-h-0 overflow-hidden' : ''"
+    >
+      <!-- Sticky chrome: nav + hero (when catalog table is shown, only tbody scrolls) -->
+      <div class="mx-auto w-full max-w-[90rem] shrink-0 pb-4">
+        <header class="relative z-20 py-4 sm:py-0">
+          <nav
+            class="mx-auto flex max-w-[90rem] flex-wrap items-center justify-between gap-4"
+            :aria-label="t('pricing.nav.aria')"
+          >
+            <div class="flex flex-wrap items-center gap-2">
+              <router-link to="/home" :class="NAV_LINK_CLASS">
+                <Icon name="home" size="sm" :class="NAV_ICON_CLASS" />
+                <span>{{ t('pricing.nav.home') }}</span>
+              </router-link>
+              <router-link :to="consolePath" :class="NAV_LINK_CLASS" :title="consoleLinkTitle">
+                <Icon name="grid" size="sm" :class="NAV_ICON_CLASS" />
+                <span>{{ t('pricing.nav.console') }}</span>
+              </router-link>
+            </div>
+            <LocaleSwitcher />
+          </nav>
+        </header>
 
-    <main class="relative z-10 flex-1 px-4 pb-16 pt-8 sm:px-6">
-      <div class="mx-auto max-w-[90rem]">
-        <div class="mb-8 text-center">
+        <div class="mt-6 text-center sm:mt-8">
           <h1
             class="text-3xl font-bold tracking-tight text-gray-900 dark:text-white sm:text-4xl"
           >
@@ -48,7 +52,9 @@
             <p class="text-xs text-gray-600 dark:text-dark-400">{{ t('pricing.ctaBonusHint') }}</p>
           </div>
         </div>
+      </div>
 
+      <div class="mx-auto flex min-h-0 w-full max-w-[90rem] flex-1 flex-col">
         <div
           v-if="loading"
           class="flex items-center justify-center rounded-2xl bg-white/80 py-24 shadow-sm backdrop-blur dark:bg-dark-900/60"
@@ -96,11 +102,11 @@
 
         <div
           v-else
-          class="overflow-hidden rounded-2xl border border-gray-200 bg-white shadow-sm dark:border-dark-800 dark:bg-dark-900"
+          class="flex min-h-0 flex-1 flex-col overflow-hidden rounded-2xl border border-gray-200 bg-white shadow-sm dark:border-dark-800 dark:bg-dark-900"
           data-tk="cold-start-pricing-table"
         >
           <div
-            class="flex flex-col gap-3 border-b border-gray-100 bg-gray-50/80 px-4 py-3 dark:border-dark-800 dark:bg-dark-800/40 sm:flex-row sm:items-center sm:justify-between"
+            class="flex shrink-0 flex-col gap-3 border-b border-gray-100 bg-gray-50/80 px-4 py-3 dark:border-dark-800 dark:bg-dark-800/40 sm:flex-row sm:items-center sm:justify-between"
           >
             <label class="sr-only" for="pricing-model-search">{{ t('pricing.search.placeholder') }}</label>
             <div class="relative min-w-0 flex-1 xl:max-w-xl">
@@ -139,7 +145,7 @@
             </div>
           </div>
           <p
-            class="border-b border-gray-100 bg-gray-50/50 px-4 py-2 text-xs text-gray-500 dark:border-dark-800 dark:bg-dark-800/30 dark:text-dark-400 lg:hidden"
+            class="shrink-0 border-b border-gray-100 bg-gray-50/50 px-4 py-2 text-xs text-gray-500 dark:border-dark-800 dark:bg-dark-800/30 dark:text-dark-400 lg:hidden"
           >
             {{ t('pricing.tableHint') }}
           </p>
@@ -152,173 +158,177 @@
               {{ t('pricing.search.noMatches') }}
             </p>
           </div>
-          <div v-else class="overflow-x-auto [-webkit-overflow-scrolling:touch]">
-            <table class="min-w-[72rem] w-full divide-y divide-gray-200 dark:divide-dark-800">
-              <thead class="bg-gray-50 dark:bg-dark-800/60">
-                <tr>
-                  <th
-                    scope="col"
-                    class="sticky left-0 z-20 min-w-[14rem] max-w-[28rem] border-r border-gray-200 bg-gray-50 px-3 py-3 text-left text-xs font-semibold uppercase tracking-wider text-gray-500 shadow-[4px_0_12px_-8px_rgba(0,0,0,0.15)] dark:border-dark-700 dark:bg-dark-800/60 dark:text-dark-300 dark:shadow-[4px_0_12px_-8px_rgba(0,0,0,0.4)]"
-                  >
-                    {{ t('pricing.columns.model') }}
-                  </th>
-                  <th
-                    scope="col"
-                    class="min-w-[7rem] px-3 py-3 text-left text-xs font-semibold uppercase tracking-wider text-gray-500 dark:text-dark-300"
-                  >
-                    {{ t('pricing.columns.vendor') }}
-                  </th>
-                  <th
-                    scope="col"
-                    class="px-3 py-3 text-right text-xs font-semibold uppercase tracking-wider text-gray-500 dark:text-dark-300"
-                  >
-                    {{ t('pricing.columns.input') }}
-                  </th>
-                  <th
-                    scope="col"
-                    class="px-3 py-3 text-right text-xs font-semibold uppercase tracking-wider text-gray-500 dark:text-dark-300"
-                  >
-                    {{ t('pricing.columns.output') }}
-                  </th>
-                  <th
-                    v-if="hasCacheColumns"
-                    scope="col"
-                    class="px-3 py-3 text-right text-xs font-semibold uppercase tracking-wider text-gray-500 dark:text-dark-300"
-                  >
-                    {{ t('pricing.columns.cacheRead') }}
-                  </th>
-                  <th
-                    v-if="hasCacheColumns"
-                    scope="col"
-                    class="px-3 py-3 text-right text-xs font-semibold uppercase tracking-wider text-gray-500 dark:text-dark-300"
-                  >
-                    {{ t('pricing.columns.cacheWrite') }}
-                  </th>
-                  <th
-                    scope="col"
-                    class="px-3 py-3 text-right text-xs font-semibold uppercase tracking-wider text-gray-500 dark:text-dark-300"
-                  >
-                    {{ t('pricing.columns.contextWindow') }}
-                  </th>
-                  <th
-                    v-if="hasMaxOutputColumn"
-                    scope="col"
-                    class="px-3 py-3 text-right text-xs font-semibold uppercase tracking-wider text-gray-500 dark:text-dark-300"
-                  >
-                    {{ t('pricing.columns.maxOutput') }}
-                  </th>
-                  <th
-                    scope="col"
-                    class="min-w-[10rem] px-3 py-3 text-left text-xs font-semibold uppercase tracking-wider text-gray-500 dark:text-dark-300"
-                  >
-                    {{ t('pricing.columns.capabilities') }}
-                  </th>
-                </tr>
-              </thead>
-              <tbody
-                class="divide-y divide-gray-100 bg-white dark:divide-dark-800/60 dark:bg-dark-900"
-              >
-                <tr
-                  v-for="model in filteredCatalogRows"
-                  :key="model.model_id"
-                  class="group hover:bg-primary-50/30 dark:hover:bg-dark-800/40"
+          <div v-else class="flex min-h-0 flex-1 flex-col overflow-hidden">
+            <div
+              class="min-h-0 flex-1 overflow-x-auto overflow-y-auto [-webkit-overflow-scrolling:touch]"
+            >
+              <table class="min-w-[72rem] w-full border-collapse divide-y divide-gray-200 dark:divide-dark-800">
+                <thead class="bg-gray-50 dark:bg-dark-800/60">
+                  <tr>
+                    <th
+                      scope="col"
+                      class="sticky left-0 top-0 z-[45] min-w-[14rem] max-w-[28rem] border-r border-gray-200 bg-gray-50 px-3 py-3 text-left text-xs font-semibold uppercase tracking-wider text-gray-500 shadow-[4px_0_12px_-8px_rgba(0,0,0,0.15)] dark:border-dark-700 dark:bg-dark-800/60 dark:text-dark-300 dark:shadow-[4px_0_12px_-8px_rgba(0,0,0,0.4)]"
+                    >
+                      {{ t('pricing.columns.model') }}
+                    </th>
+                    <th
+                      scope="col"
+                      class="sticky top-0 z-40 min-w-[7rem] bg-gray-50 px-3 py-3 text-left text-xs font-semibold uppercase tracking-wider text-gray-500 dark:bg-dark-800/60 dark:text-dark-300"
+                    >
+                      {{ t('pricing.columns.vendor') }}
+                    </th>
+                    <th
+                      scope="col"
+                      class="sticky top-0 z-40 bg-gray-50 px-3 py-3 text-right text-xs font-semibold uppercase tracking-wider text-gray-500 dark:bg-dark-800/60 dark:text-dark-300"
+                    >
+                      {{ t('pricing.columns.input') }}
+                    </th>
+                    <th
+                      scope="col"
+                      class="sticky top-0 z-40 bg-gray-50 px-3 py-3 text-right text-xs font-semibold uppercase tracking-wider text-gray-500 dark:bg-dark-800/60 dark:text-dark-300"
+                    >
+                      {{ t('pricing.columns.output') }}
+                    </th>
+                    <th
+                      v-if="hasCacheColumns"
+                      scope="col"
+                      class="sticky top-0 z-40 bg-gray-50 px-3 py-3 text-right text-xs font-semibold uppercase tracking-wider text-gray-500 dark:bg-dark-800/60 dark:text-dark-300"
+                    >
+                      {{ t('pricing.columns.cacheRead') }}
+                    </th>
+                    <th
+                      v-if="hasCacheColumns"
+                      scope="col"
+                      class="sticky top-0 z-40 bg-gray-50 px-3 py-3 text-right text-xs font-semibold uppercase tracking-wider text-gray-500 dark:bg-dark-800/60 dark:text-dark-300"
+                    >
+                      {{ t('pricing.columns.cacheWrite') }}
+                    </th>
+                    <th
+                      scope="col"
+                      class="sticky top-0 z-40 bg-gray-50 px-3 py-3 text-right text-xs font-semibold uppercase tracking-wider text-gray-500 dark:bg-dark-800/60 dark:text-dark-300"
+                    >
+                      {{ t('pricing.columns.contextWindow') }}
+                    </th>
+                    <th
+                      v-if="hasMaxOutputColumn"
+                      scope="col"
+                      class="sticky top-0 z-40 bg-gray-50 px-3 py-3 text-right text-xs font-semibold uppercase tracking-wider text-gray-500 dark:bg-dark-800/60 dark:text-dark-300"
+                    >
+                      {{ t('pricing.columns.maxOutput') }}
+                    </th>
+                    <th
+                      scope="col"
+                      class="sticky top-0 z-40 min-w-[10rem] bg-gray-50 px-3 py-3 text-left text-xs font-semibold uppercase tracking-wider text-gray-500 dark:bg-dark-800/60 dark:text-dark-300"
+                    >
+                      {{ t('pricing.columns.capabilities') }}
+                    </th>
+                  </tr>
+                </thead>
+                <tbody
+                  class="divide-y divide-gray-100 bg-white dark:divide-dark-800/60 dark:bg-dark-900"
                 >
-                  <td
-                    class="sticky left-0 z-10 min-w-[14rem] max-w-[28rem] border-r border-gray-200 bg-white px-3 py-3 align-top font-mono text-sm leading-snug text-gray-900 shadow-[4px_0_12px_-8px_rgba(0,0,0,0.12)] break-words group-hover:bg-primary-50/30 dark:border-dark-700 dark:bg-dark-900 dark:text-white dark:shadow-[4px_0_12px_-8px_rgba(0,0,0,0.45)] dark:group-hover:bg-dark-800/40"
+                  <tr
+                    v-for="model in filteredCatalogRows"
+                    :key="model.model_id"
+                    class="group hover:bg-primary-50/30 dark:hover:bg-dark-800/40"
                   >
-                    {{ model.model_id }}
-                  </td>
-                  <td
-                    class="min-w-[7rem] px-3 py-3 align-top text-sm leading-snug text-gray-600 break-words dark:text-dark-300"
-                  >
-                    {{ model.vendor || '—' }}
-                  </td>
-                  <td class="whitespace-nowrap px-3 py-3 text-right text-sm tabular-nums text-gray-900 dark:text-white">
-                    {{ formatPrice(model.pricing.input_per_1k_tokens) }}
-                    <span class="ml-0.5 text-xs text-gray-400">{{
-                      t('pricing.perThousandTokens')
-                    }}</span>
-                  </td>
-                  <td class="whitespace-nowrap px-3 py-3 text-right text-sm tabular-nums text-gray-900 dark:text-white">
-                    {{ formatPrice(model.pricing.output_per_1k_tokens) }}
-                    <span class="ml-0.5 text-xs text-gray-400">{{
-                      t('pricing.perThousandTokens')
-                    }}</span>
-                  </td>
-                  <td
-                    v-if="hasCacheColumns"
-                    class="whitespace-nowrap px-3 py-3 text-right text-sm tabular-nums text-gray-700 dark:text-dark-200"
-                  >
-                    {{
-                      model.pricing.cache_read_per_1k != null
-                        ? formatPrice(model.pricing.cache_read_per_1k)
-                        : '—'
-                    }}
-                  </td>
-                  <td
-                    v-if="hasCacheColumns"
-                    class="whitespace-nowrap px-3 py-3 text-right text-sm tabular-nums text-gray-700 dark:text-dark-200"
-                  >
-                    {{
-                      model.pricing.cache_write_per_1k != null
-                        ? formatPrice(model.pricing.cache_write_per_1k)
-                        : '—'
-                    }}
-                  </td>
-                  <td class="whitespace-nowrap px-3 py-3 text-right text-sm tabular-nums text-gray-600 dark:text-dark-300">
-                    <template v-if="model.context_window && model.context_window > 0">
-                      {{ formatNumber(model.context_window) }}
-                    </template>
-                    <template v-else>—</template>
-                  </td>
-                  <td
-                    v-if="hasMaxOutputColumn"
-                    class="whitespace-nowrap px-3 py-3 text-right text-sm tabular-nums text-gray-600 dark:text-dark-300"
-                  >
-                    <template v-if="model.max_output_tokens && model.max_output_tokens > 0">
-                      {{ formatNumber(model.max_output_tokens) }}
-                    </template>
-                    <template v-else>—</template>
-                  </td>
-                  <td class="px-3 py-3 align-top">
-                    <div class="flex flex-wrap gap-1">
-                      <span
-                        v-for="cap in model.capabilities"
-                        :key="cap"
-                        class="inline-flex items-center rounded-full bg-primary-50 px-2 py-0.5 text-xs font-medium text-primary-700 dark:bg-primary-900/30 dark:text-primary-300"
-                      >
-                        {{ cap }}
-                      </span>
-                      <span
-                        v-if="!model.capabilities || model.capabilities.length === 0"
-                        class="text-xs text-gray-400"
-                        >—</span
-                      >
-                    </div>
-                  </td>
-                </tr>
-              </tbody>
-            </table>
-          </div>
-          <div
-            class="flex flex-col gap-2 border-t border-gray-100 bg-gray-50/60 px-4 py-3 text-xs text-gray-500 sm:flex-row sm:items-center sm:justify-between dark:border-dark-800 dark:bg-dark-800/40 dark:text-dark-400"
-          >
-            <p class="text-left tabular-nums">
-              <template v-if="modelSearchQuery.trim()">
-                {{
-                  t('pricing.footer.filtered', {
-                    shown: filteredCatalogRows.length,
-                    total: catalogRowTotal
-                  })
-                }}
-              </template>
-              <template v-else>
-                {{ t('pricing.footer.total', { count: catalogRowTotal }) }}
-              </template>
-            </p>
-            <p class="text-left sm:text-right">
-              {{ t('pricing.updatedAt', { time: formattedUpdatedAt }) }}
-            </p>
+                    <td
+                      class="sticky left-0 z-10 min-w-[14rem] max-w-[28rem] border-r border-gray-200 bg-white px-3 py-3 align-top font-mono text-sm leading-snug text-gray-900 shadow-[4px_0_12px_-8px_rgba(0,0,0,0.12)] break-words group-hover:bg-primary-50/30 dark:border-dark-700 dark:bg-dark-900 dark:text-white dark:shadow-[4px_0_12px_-8px_rgba(0,0,0,0.45)] dark:group-hover:bg-dark-800/40"
+                    >
+                      {{ model.model_id }}
+                    </td>
+                    <td
+                      class="min-w-[7rem] px-3 py-3 align-top text-sm leading-snug text-gray-600 break-words dark:text-dark-300"
+                    >
+                      {{ model.vendor || '—' }}
+                    </td>
+                    <td class="whitespace-nowrap px-3 py-3 text-right text-sm tabular-nums text-gray-900 dark:text-white">
+                      {{ formatPrice(model.pricing.input_per_1k_tokens) }}
+                      <span class="ml-0.5 text-xs text-gray-400">{{
+                        t('pricing.perThousandTokens')
+                      }}</span>
+                    </td>
+                    <td class="whitespace-nowrap px-3 py-3 text-right text-sm tabular-nums text-gray-900 dark:text-white">
+                      {{ formatPrice(model.pricing.output_per_1k_tokens) }}
+                      <span class="ml-0.5 text-xs text-gray-400">{{
+                        t('pricing.perThousandTokens')
+                      }}</span>
+                    </td>
+                    <td
+                      v-if="hasCacheColumns"
+                      class="whitespace-nowrap px-3 py-3 text-right text-sm tabular-nums text-gray-700 dark:text-dark-200"
+                    >
+                      {{
+                        model.pricing.cache_read_per_1k != null
+                          ? formatPrice(model.pricing.cache_read_per_1k)
+                          : '—'
+                      }}
+                    </td>
+                    <td
+                      v-if="hasCacheColumns"
+                      class="whitespace-nowrap px-3 py-3 text-right text-sm tabular-nums text-gray-700 dark:text-dark-200"
+                    >
+                      {{
+                        model.pricing.cache_write_per_1k != null
+                          ? formatPrice(model.pricing.cache_write_per_1k)
+                          : '—'
+                      }}
+                    </td>
+                    <td class="whitespace-nowrap px-3 py-3 text-right text-sm tabular-nums text-gray-600 dark:text-dark-300">
+                      <template v-if="model.context_window && model.context_window > 0">
+                        {{ formatNumber(model.context_window) }}
+                      </template>
+                      <template v-else>—</template>
+                    </td>
+                    <td
+                      v-if="hasMaxOutputColumn"
+                      class="whitespace-nowrap px-3 py-3 text-right text-sm tabular-nums text-gray-600 dark:text-dark-300"
+                    >
+                      <template v-if="model.max_output_tokens && model.max_output_tokens > 0">
+                        {{ formatNumber(model.max_output_tokens) }}
+                      </template>
+                      <template v-else>—</template>
+                    </td>
+                    <td class="px-3 py-3 align-top">
+                      <div class="flex flex-wrap gap-1">
+                        <span
+                          v-for="cap in model.capabilities"
+                          :key="cap"
+                          class="inline-flex items-center rounded-full bg-primary-50 px-2 py-0.5 text-xs font-medium text-primary-700 dark:bg-primary-900/30 dark:text-primary-300"
+                        >
+                          {{ cap }}
+                        </span>
+                        <span
+                          v-if="!model.capabilities || model.capabilities.length === 0"
+                          class="text-xs text-gray-400"
+                          >—</span
+                        >
+                      </div>
+                    </td>
+                  </tr>
+                </tbody>
+              </table>
+            </div>
+            <div
+              class="flex shrink-0 flex-col gap-2 border-t border-gray-100 bg-gray-50/60 px-4 py-3 text-xs text-gray-500 sm:flex-row sm:items-center sm:justify-between dark:border-dark-800 dark:bg-dark-800/40 dark:text-dark-400"
+            >
+              <p class="text-left tabular-nums">
+                <template v-if="modelSearchQuery.trim()">
+                  {{
+                    t('pricing.footer.filtered', {
+                      shown: filteredCatalogRows.length,
+                      total: catalogRowTotal
+                    })
+                  }}
+                </template>
+                <template v-else>
+                  {{ t('pricing.footer.total', { count: catalogRowTotal }) }}
+                </template>
+              </p>
+              <p class="text-left sm:text-right">
+                {{ t('pricing.updatedAt', { time: formattedUpdatedAt }) }}
+              </p>
+            </div>
           </div>
         </div>
       </div>
@@ -424,6 +434,12 @@ const formattedUpdatedAt = computed(() => {
   } catch {
     return catalog.value.updated_at
   }
+})
+
+/** Lock main to viewport height when the catalog table is shown so nav + hero stay fixed and only the grid scrolls. */
+const pricingCatalogScrollMode = computed(() => {
+  if (loading.value || errorMessage.value) return false
+  return Boolean(catalog.value && catalog.value.data.length > 0)
 })
 
 function formatPrice(value: number): string {

--- a/frontend/src/views/user/PlaygroundView.vue
+++ b/frontend/src/views/user/PlaygroundView.vue
@@ -69,14 +69,53 @@
             <div v-if="!displayMessages.length" class="py-16 text-center text-sm text-gray-500 dark:text-dark-400">
               {{ t('playground.emptyHint') }}
             </div>
-            <div v-for="(msg, idx) in displayMessages" :key="idx" class="space-y-1">
-              <div class="text-xs font-semibold uppercase tracking-wide text-gray-400 dark:text-dark-500">
-                {{ roleLabel(msg.role) }}
+            <!-- WeChat-style: assistant left + user right, with side avatars -->
+            <div
+              v-for="(msg, idx) in displayMessages"
+              :key="idx"
+              :class="[
+                'flex gap-2.5',
+                msg.role === 'user' ? 'flex-row-reverse justify-end' : 'flex-row justify-start'
+              ]"
+            >
+              <div
+                class="flex h-9 w-9 shrink-0 items-center justify-center rounded-full text-xs font-semibold text-white shadow-sm"
+                :class="
+                  msg.role === 'user'
+                    ? 'bg-primary-600 dark:bg-primary-500'
+                    : 'bg-dark-600 dark:bg-dark-500'
+                "
+                aria-hidden="true"
+              >
+                {{ msg.role === 'user' ? '我' : 'AI' }}
               </div>
               <div
-                class="max-w-none whitespace-pre-wrap break-words rounded-lg bg-gray-50 px-3 py-2 text-sm text-gray-900 dark:bg-dark-800 dark:text-dark-100"
-                v-html="msg.role === 'assistant' ? renderMarkdown(msg.content) : escapeHtml(msg.content)"
-              />
+                :class="[
+                  'flex min-w-0 max-w-[min(85%,28rem)] flex-col gap-0.5',
+                  msg.role === 'user' ? 'items-end text-right' : 'items-start text-left'
+                ]"
+              >
+                <div
+                  class="text-[11px] font-medium uppercase tracking-wide text-gray-400 dark:text-dark-500"
+                >
+                  {{ roleLabel(msg.role) }}
+                </div>
+                <div
+                  class="max-w-none whitespace-pre-wrap break-words px-3.5 py-2.5 text-sm shadow-sm"
+                  :class="
+                    msg.role === 'user'
+                      ? 'rounded-2xl rounded-tr-md bg-primary-600 text-white dark:bg-primary-600'
+                      : 'rounded-2xl rounded-tl-md bg-gray-50 text-gray-900 dark:bg-dark-800 dark:text-dark-100'
+                  "
+                >
+                  <div
+                    v-if="msg.role === 'assistant'"
+                    class="prose prose-sm max-w-none dark:prose-invert prose-p:my-1 prose-pre:my-2 [&_a]:text-primary-600 dark:[&_a]:text-primary-300"
+                    v-html="renderMarkdown(msg.content)"
+                  />
+                  <span v-else>{{ escapeHtml(msg.content) }}</span>
+                </div>
+              </div>
             </div>
           </div>
           <div class="border-t border-gray-100 p-4 dark:border-dark-700">

--- a/frontend/src/views/user/PlaygroundView.vue
+++ b/frontend/src/views/user/PlaygroundView.vue
@@ -87,7 +87,7 @@
                 "
                 aria-hidden="true"
               >
-                {{ msg.role === 'user' ? '我' : 'AI' }}
+                {{ msg.role === 'user' ? t('playground.avatarUser') : t('playground.avatarAssistant') }}
               </div>
               <div
                 :class="[


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

- **Playground**：用户消息右侧对齐，圆形头像 + 主色气泡；助手左侧对齐，Markdown 预览保留在气泡内。
- **Pricing**：在成功加载目录数据时，根容器使用 **`h-[100dvh] max-h-[100dvh] overflow-hidden`** 锁定视口（不再用 `min-h-screen` 撑高整页），`main` 使用 **`min-h-0 flex-1`**，仅中间表格区域 **`overflow-y-auto`** + `overscroll-y-contain`，这样 **body 不随长表增长**，顶部导航/标题/搜索条保持可见，表体在卡片内滚动，表头在滚动区内 sticky。

## Risk

- 极老浏览器若不支持 `dvh`，可回退为 `100vh`；一般现网可接受。

## Validation

- `pnpm exec vue-tsc --noEmit`
- `pnpm exec vitest run src/views/__tests__/PricingView.spec.ts`
- 全量 preflight 在本环境因缺失 `ANTHROPIC_AUTH_TOKEN` 未通过 cloud-agent 段
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-c3360597-5f3a-4143-882a-96534ffd8196"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-c3360597-5f3a-4143-882a-96534ffd8196"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

