### PR TITLE
Align traj export plan with prod purge flow

### DIFF
--- a/.github/workflows/deploy-stage0.yml
+++ b/.github/workflows/deploy-stage0.yml
@@ -180,7 +180,7 @@ jobs:
               "set -euo pipefail",
               ("echo === deploy stage0 to tag=" + $tag + " ==="),
               ("sudo cp -a /var/lib/tokenkey/.env /var/lib/tokenkey/.env.before-" + $tag),
-              ("sudo sed -i \u0027s|sub2api:[0-9.]*|sub2api:" + $tag + "|\u0027 /var/lib/tokenkey/.env"),
+              ("sudo sed -i \u0027s|sub2api:[^[:space:]]*|sub2api:" + $tag + "|\u0027 /var/lib/tokenkey/.env"),
               "cd /var/lib/tokenkey && sudo docker compose --env-file .env pull tokenkey",
               "cd /var/lib/tokenkey && sudo docker compose --env-file .env up -d --no-deps tokenkey",
               "for i in 1 2 3 4 5 6 7 8 9 10 11 12; do s=$(sudo docker inspect tokenkey --format \u0027{{.State.Health.Status}}\u0027 2>/dev/null || echo missing); echo \"try $i: $s\"; [ \"$s\" = healthy ] && break; sleep 5; done",
@@ -261,6 +261,20 @@ jobs:
             exit 1
           fi
           echo "ok: $API_URL/health returned 200 under 5s"
+
+      - name: Post-deploy gateway smoke (API + Claude paths)
+        env:
+          TOKENKEY_BASE_URL: ${{ steps.instance.outputs.api_url }}
+          POST_DEPLOY_SMOKE_API_KEY: ${{ secrets.POST_DEPLOY_SMOKE_API_KEY }}
+        run: |
+          set -euo pipefail
+          if [ -z "${POST_DEPLOY_SMOKE_API_KEY:-}" ]; then
+            echo "::error::POST_DEPLOY_SMOKE_API_KEY repository secret is not set."
+            echo "Add a TokenKey user API key (sk-...) that is valid for this stack's gateway."
+            echo "See deploy/aws/README.md (post-deploy smoke) and docs/approved/deploy-stage0-workflow.md §5."
+            exit 1
+          fi
+          bash scripts/tk_post_deploy_smoke.sh
 
       - name: Job summary
         if: always()

--- a/deploy/aws/README.md
+++ b/deploy/aws/README.md
@@ -431,7 +431,7 @@ aws cloudformation delete-stack --region us-east-1 --stack-name <旧栈名>
 
 ### Prod QA 全量导出与清理（operator IAM）
 
-用于把 **Stage-0 单机上** 的 `qa_records`（PostgreSQL 分区表）与 **`/var/lib/tokenkey/app/qa_blobs`**（含用户自助导出的 `exports/` 树）一次性拉到本地 `./.dump_trajs/`，在**本地校验非空**之后，再 **TRUNCATE 表 + 清空 blob 目录 + 删除 S3 暂存 tar**，避免 EBS 与 staging bucket 长期堆积。
+用于把 **Stage-0 单机上** 的 `qa_records`（PostgreSQL 分区表）与 **`/var/lib/tokenkey/app/qa_blobs`**（含用户自助导出的 `exports/` 树）一次性拉到本地 `./.dump_trajs/`，在**本地校验非空、manifest 计数与 checksum** 之后，再 **TRUNCATE 表 + 清空 blob 目录 + 删除 S3 暂存 tar**，避免 EBS 与 staging bucket 长期堆积。
 
 - **脚本**：`scripts/fetch-prod-qa-dump.sh`（仅导出）；`scripts/prod-qa-export-and-purge.sh`（导出 + 清理）。
 - **凭证**：与 `deploy-error-clustering-binary.sh` 同类 — 操作员 IAM 需 `ssm:SendCommand` / `GetCommandInvocation`，以及 staging bucket 的 `s3:PutObject`（预签名 PUT 由本机 boto3 生成）、`s3:GetObject`（下载）、`s3:DeleteObject`（清理暂存对象）。

--- a/deploy/aws/README.md
+++ b/deploy/aws/README.md
@@ -246,8 +246,10 @@ gh run watch $(gh run list --workflow=release.yml --limit 1 --json databaseId -q
 Release workflow 全绿后（`gh run list --workflow=release.yml --limit 1` 看 `success`），
 GHCR 已经有 `:X.Y.Z` 多架构镜像。**首选路径是 dispatch `deploy-stage0.yml`**——
 封装了下方手工 SSM SOP 全流程，跑前做 multi-arch manifest 强校验（防 §9.1
-amd64-only 镜像撞 Graviton 崩溃），跑后做外部 `/health` 验证；prod 环境通过
-GitHub Environment 的 Required reviewers 门禁触发人工审批。
+amd64-only 镜像撞 Graviton 崩溃），跑后做外部 `/health` 验证，并**强制**跑
+`scripts/tk_post_deploy_smoke.sh`（public 配置、`/v1/models`、`/v1/chat/completions`、
+`/v1/messages` / Claude Code 路径）；prod 环境通过 GitHub Environment 的
+Required reviewers 门禁触发人工审批。
 
 ```bash
 TAG=X.Y.Z
@@ -259,6 +261,23 @@ gh run watch $(gh run list --workflow=deploy-stage0.yml --limit 1 --json databas
 # 测试通过后再 prod（点 Approve 后才会跑 SSM）
 gh workflow run deploy-stage0.yml -f environment=prod -f tag=$TAG
 gh run watch $(gh run list --workflow=deploy-stage0.yml --limit 1 --json databaseId -q '.[0].databaseId')
+```
+
+#### deploy-stage0 发版后网关烟测（强制）
+
+Workflow 在 `/health` 之后会执行 `scripts/tk_post_deploy_smoke.sh`。必须在仓库
+**Settings → Secrets and variables → Actions** 中配置 **`POST_DEPLOY_SMOKE_API_KEY`**
+（值为在该栈 `ApiUrl` 下有效的用户 API Key，`sk-...`，与 Claude Code 使用的
+`ANTHROPIC_AUTH_TOKEN` 同类）。未配置则 deploy **失败**（避免容器健康但网关路径已坏仍显示成功）。
+
+测试栈与生产若租户隔离，应使用各自环境下能过鉴权的 Key（同一 secret 在两边各能访问对应网关即可，或拆成两个 workflow 再扩展；当前为单一 repo secret，通常填**两边均有效**的运维用 Key）。
+
+本地复现：
+
+```bash
+export TOKENKEY_BASE_URL=https://api.tokenkey.dev   # 或测试栈域名
+export POST_DEPLOY_SMOKE_API_KEY=sk-...
+bash scripts/tk_post_deploy_smoke.sh
 ```
 
 设计、IAM 范围扩张、运维启用步骤见 `docs/approved/deploy-stage0-workflow.md`。
@@ -289,7 +308,7 @@ aws ssm send-command --region us-east-1 \
   --document-name AWS-RunShellScript \
   --parameters "commands=[
     \"sudo cp -a /var/lib/tokenkey/.env /var/lib/tokenkey/.env.before-${TAG}\",
-    \"sudo sed -i 's|sub2api:[0-9.]*|sub2api:${TAG}|' /var/lib/tokenkey/.env\",
+    \"sudo sed -i 's|sub2api:[^[:space:]]*|sub2api:${TAG}|' /var/lib/tokenkey/.env\",
     \"cd /var/lib/tokenkey && sudo docker compose --env-file .env pull tokenkey\",
     \"cd /var/lib/tokenkey && sudo docker compose --env-file .env up -d --no-deps tokenkey\",
     \"for i in 1 2 3 4 5 6 7 8 9 10 11 12; do s=\\$(sudo docker inspect tokenkey --format '{{.State.Health.Status}}'); echo \\\"try \\$i: \\$s\\\"; [ \\\"\\$s\\\" = healthy ] && break; sleep 5; done\",

--- a/deploy/aws/cloudformation/cicd-oidc.yaml
+++ b/deploy/aws/cloudformation/cicd-oidc.yaml
@@ -94,7 +94,7 @@ Resources:
       Description: >-
         Assumed by repo workflows via GitHub OIDC to dispatch SSM Run-Command
         on the prod (and now optionally test) EC2 instance. Originally scoped
-        to error-clustering only — name retained for back-compat with
+        to error-clustering only - name retained for back-compat with
         vars.AWS_OIDC_ROLE_ARN consumers; current consumers include
         error-clustering-daily.yml, prod-log-dump.yml, and deploy-stage0.yml.
       MaxSessionDuration: 3600

--- a/docs/approved/deploy-stage0-workflow.md
+++ b/docs/approved/deploy-stage0-workflow.md
@@ -13,7 +13,7 @@ related_prs: ["#53"]
 # Adversarial fail-closed gate also verified:
 #   GHA run https://github.com/youxuanxue/sub2api/actions/runs/24872388875
 #   (tag=99.99.99 → exited at GHCR manifest precheck before any AWS call).
-scope: ".github/workflows/deploy-stage0.yml + IAM scope expansion in deploy/aws/cloudformation/cicd-oidc.yaml"
+scope: ".github/workflows/deploy-stage0.yml + scripts/tk_post_deploy_smoke.sh + IAM scope expansion in deploy/aws/cloudformation/cicd-oidc.yaml"
 ---
 
 # Cloud-Agent-Driven Tag-and-Deploy Workflow
@@ -114,7 +114,13 @@ Steps:
    not reach `healthy`.
 6. **External health-check** — `curl ${ApiUrl}/health`, three attempts
    spaced 10 s apart, require HTTP 200 within 5 s.
-7. **Job summary** — write the deployed tag, the SSM command id, and a
+7. **Post-deploy gateway smoke** — `scripts/tk_post_deploy_smoke.sh` against
+   `${ApiUrl}`: public settings, authenticated `/v1/models`,
+   `/v1/chat/completions`, and `/v1/messages` (Claude Code-style `x-api-key`).
+   Requires repository secret `POST_DEPLOY_SMOKE_API_KEY` (a user `sk-...`
+   valid on that stack). Fail-closed if the secret is missing or any step
+   returns non-200 / unexpected body markers.
+8. **Job summary** — write the deployed tag, the SSM command id, and a
    one-liner re-dispatch command for rollback. No auto-rollback (would
    mask transient failures).
 
@@ -149,6 +155,12 @@ After this PR merges, before the first dispatch:
 
 3. **(Optional) Override repo variables** if defaults don't fit:
    `vars.PROD_STACK_NAME`, `vars.TEST_STACK_NAME`, `vars.AWS_REGION`.
+
+4. **Repository secret `POST_DEPLOY_SMOKE_API_KEY`** — a TokenKey user API key
+   (`sk-...`) that can authenticate to the gateway at the stack's `ApiUrl`
+   (same class of credential as Claude Code's `ANTHROPIC_AUTH_TOKEN`). The
+   deploy workflow fails if this secret is unset. See `deploy/aws/README.md`
+   (deploy-stage0 发版后网关烟测).
 
 ## 6. Explicitly out of scope
 

--- a/docs/traj/tokenkey-traj-final-goal-plan.md
+++ b/docs/traj/tokenkey-traj-final-goal-plan.md
@@ -1,0 +1,378 @@
+# TokenKey × traj 最终目标达成计划
+
+## Context
+
+最终目标不是做一套“专门给 traj 的旁路系统”，而是让 **真实用户调用** 与 **traj 合成用户/助手回合调度调用** 尽可能走同一条 TokenKey 产品路径：同一套网关、同一套鉴权、同一套路由、同一套调度、同一套 QA capture、同一套导出与清理机制。差异只保留在最小必要处：合成流量需要可识别、可隔离、可清理、可追溯。
+
+这更符合乔布斯式产品哲学：好的系统不是堆功能，而是把复杂性藏在一个清晰、端到端一致的体验背后。也符合 OPC 哲学：一个人维护 N 个 Agent 的系统，必须压缩分叉路径，减少特殊逻辑，减少长期运维面，让真实生产路径天然成为合成数据路径的验证面。
+
+因此，本计划的主线调整为：
+
+1. **TokenKey 不为 traj 发明第二套调用链路。** traj 的 user/assistant 调用尽量模拟真实用户经过 TokenKey 的标准路径。
+2. **traj 维护 transcript 真相，但不是为了替代 TokenKey evidence。** 它维护的是“对话意图与回合编排真相”，TokenKey 维护的是“生产网关观测证据”。
+3. **TokenKey 只做采集、导出、基础结构性校验和极低成本清理。** 深度质量分级、清洗、分档、提升，放到 traj 更合理。
+4. **线上存储成本必须接近 0。** 从 AWS prod 容器导出到本地成功后，自动清理过程文件、线上 DB 记录、S3/对象存储临时文件。
+5. **assistant 侧优先走 Claude Code headless 非交互模式。** `claude -p` 可通过 session persistence、`--resume`、`--continue` 支持多轮上下文；traj 需要显式管理每条 synthetic session 对应的 Claude session id。
+
+## Product principles
+
+### 1. 真实调用与合成调用尽量同构
+
+真实用户调用和 traj 合成调用的差异越大，越容易产生两类坏结果：
+
+- 真实生产问题无法被合成数据覆盖；
+- 合成数据看似质量高，但训练/评测时学到的是一条旁路系统的行为。
+
+乔布斯视角下，产品体验应该是一条“自然路径”，而不是工程师为了内部方便搭出来的多条岔路。OPC 视角下，每多一条特殊链路，就多一倍未来合并、排障、校验、文档和心智负担。
+
+因此，traj 合成 user/assistant 调用应尽量复用真实调用路径：
+
+- 走 TokenKey 标准公网/内网网关入口；
+- 走标准 API key/JWT 鉴权；
+- 走标准 group/account/platform 调度；
+- 走标准 upstream relay 与响应解析；
+- 走标准 QA capture 与 evidence blob；
+- 走标准 self/prod export 流程。
+
+允许的差异只包括：
+
+- `X-Synth-*` 元数据头，用于识别合成流量；
+- 专用 API key / group / account 池，用于成本隔离和模型隔离；
+- 专用 `trajectory_id` / `synth_session_id`，用于回合归并；
+- 导出成功后的线上清理策略，用于成本最小化；
+- assistant 侧 Claude Code headless session 管理，用于复现真实 coding agent 的多轮行为。
+
+### 2. 最小 upstream 冲突面
+
+TokenKey 是 upstream fork，所有改动都要避免把 traj 专用逻辑灌进 upstream-owned 大文件。实现原则：
+
+- 优先新增 `*_tk_*.go` companion 文件；
+- upstream 文件只保留薄注入点，例如一行 middleware、一个 helper 调用、一个 route registration；
+- 不删除 upstream 功能；
+- 不把 traj 的调度、分级、清洗逻辑放进 TokenKey；
+- TokenKey 侧只沉淀“生产网关也需要”的通用能力：correlation、capture、export、purge、contract check。
+
+## Why traj owns transcript truth
+
+### 价值判断
+
+traj 维护 transcript 真相的必要性，不在于“TokenKey 不能导出消息”，而在于两者记录的是不同层面的真相：
+
+- **traj transcript**：谁在第几轮说了什么、为什么进入下一轮、何时终止、assistant 工具调用如何被编排。这是“对话产品真相”。
+- **TokenKey QA evidence**：真实 HTTP 请求/响应、流式片段、header、模型、token、状态码、错误、上游响应。这是“生产观测真相”。
+
+如果只依赖 TokenKey evidence 反推 transcript，会出现几个问题：
+
+1. 网关看到的是协议层请求/响应，不一定知道调度器为什么进入下一轮。
+2. Claude Code/agent 的本地工具执行、session resume、用户模拟器决策，很多发生在网关之外。
+3. 多 provider 协议形态不同，从 evidence 反推统一 turns 容易变成一堆启发式和特殊分支。
+4. 训练数据需要的是干净的回合意图结构；审计需要的是原始证据。两者混在一起会损害两边质量。
+
+### 乔布斯视角
+
+乔布斯式设计强调“端到端体验的主线”。traj transcript 就是合成对话产品的主线：从需求、persona、用户追问、assistant 执行、工具使用、验收到终止，形成一条人能理解、机器能复现的故事线。
+
+如果让 TokenKey evidence 反向拼这个故事线，等于让底层日志系统决定产品叙事。这不是简洁，而是把产品体验交给偶然的实现细节。
+
+### OPC 视角
+
+OPC 要求系统可自动化、可审计、可低人力维护。traj transcript 作为真相有三点杠杆价值：
+
+1. **可重放**：调度器可以基于 transcript 明确恢复 session，而不是猜测网关日志。
+2. **可分层验证**：traj 验证“对话是否像一个高质量工程过程”，TokenKey 验证“生产路径是否真实捕获”。
+3. **可替换底层**：未来 assistant 从 Messages API shim 切到 Claude Code `-p`，或 user 从 API shim 切到 Cursor Agent CLI，transcript contract 不需要跟着生产 evidence 改。
+
+结论：traj 必须维护 transcript 真相，但它不应该复制 TokenKey 的生产 evidence。两者互补，不互相替代。
+
+## What TokenKey should validate
+
+### TokenKey 质量校验的边界
+
+TokenKey 做质量校验的价值，不是给 traj 数据打分、分档、清洗、提升；这些更适合 traj。TokenKey 只应做“生产网关 substrate 必须保证”的低层结构性校验：
+
+- route/capture hook 没有漂移；
+- `trajectory_id` / `request_id` / `synth_session_id` 可关联；
+- export JSONL 可解析；
+- session/turn 基本连续；
+- tool call/result 基本配对；
+- 必填字段存在；
+- 导出文件完整且可下载；
+- purge 后线上过程数据确实被清掉。
+
+这些检查的意义是证明 TokenKey 这条生产链路“可被信任”。它不负责判断一次合成对话是不是 P7 水平、是不是高训练价值、是否需要清洗重写。
+
+### 为什么深度质量应放到 traj
+
+深度质量判断依赖合成目标和训练策略，例如：
+
+- persona 是否稳定；
+- 用户是否像真实工程 owner；
+- assistant 是否有效使用工具；
+- 是否出现无效循环；
+- 需求是否被收敛；
+- 回合是否有足够工程密度；
+- 数据应该进入 bronze/silver/gold 哪一档；
+- 是否需要清洗、裁剪、增强、拒收。
+
+这些是 traj 的产品域，不是网关域。放在 TokenKey 会带来三类问题：
+
+1. **upstream 冲突面扩大**：网关代码被迫理解合成数据质量。
+2. **职责污染**：TokenKey 从 API gateway 变成 dataset judge。
+3. **成本上升**：线上服务承载离线分析逻辑，不符合极简生产路径。
+
+### 乔布斯与 OPC 结论
+
+乔布斯式产品会把“体验判断”放在产品层，而不是基础设施层。OPC 会把重计算、重清洗、重分级放到离线可替换模块，而不是放进线上 gateway。
+
+所以最终分工应为：
+
+- **TokenKey**：证明生产调用链路真实、完整、可导出、可清理。
+- **traj**：判断数据是否好、属于哪一档、是否要清洗提升、是否进入训练集。
+
+## Prod export and purge philosophy
+
+TokenKey 的导出链路应体现“极致减少在线存储成本”：线上只保留生成数据所需的短生命周期过程状态；一旦离线导出成功，线上应自动清理。
+
+推荐复用当前仓库已有链路，不新增 traj-only 导出脚本：
+
+```text
+traj run
+  → calls TokenKey prod gateway with synth metadata
+  → TokenKey captures QA/evidence in prod DB + qa_blobs
+  → scripts/fetch-prod-qa-dump.sh exports qa_records + qa_blobs to ./.dump_trajs/
+  → local manifest/count/checksum validation passes
+  → scripts/prod-qa-export-and-purge.sh purges prod QA buffer:
+       - TRUNCATE qa_records
+       - remove /var/lib/tokenkey/app/qa_blobs contents
+       - remove /var/lib/tokenkey/app/qa_dlq contents if present
+       - delete S3 staging tarball
+       - optionally delete local tarball after extract
+  → traj consumes local artifact for grading/cleaning/training
+```
+
+当前脚本的语义是 **prod QA buffer 全量导出 + 全量清理**，不是按单个 `synth_session_id` 精确删除。短期最小冲突路径是复用它：在专用 synth 采集窗口或低峰窗口运行，接受“QA buffer 是短生命周期缓存”的产品语义。若未来必须保留真实用户 QA 数据更久，再在 companion 脚本中新增按 manifest/request id/blob uri 精确清理，不能把复杂清洗逻辑塞进 TokenKey 服务主路径。
+
+### 当前仓库已有资产
+
+| 文件 | 当前用途 | 结论 |
+|---|---|---|
+| `scripts/fetch-prod-qa-dump.sh` | 通过 SSM 在 Stage-0 EC2 打包 `qa_records` 与 `qa_blobs`，经 S3 presigned PUT 暂存后下载到本地 `./.dump_trajs/`，生成 `.last-prod-qa-export.json` manifest | **保留并复用**；已作为只导出入口 |
+| `scripts/prod-qa-export-and-purge.sh` | 调用 `fetch-prod-qa-dump.sh`，本地校验后执行 prod `qa_records`/`qa_blobs`/`qa_dlq`/S3 staging 清理 | **保留并复用**；作为低成本 export+purge 主入口 |
+| `deploy/aws/README.md` | operator runbook，已有 “Prod QA 全量导出与清理” 章节 | **保留并同步**；作为人工操作权威说明 |
+| `scripts/check-traj-dataset.py` | 对导出 trajectory dataset 做 H1/H2/H3/D1 与结构性检查 | **保留**；定位为 substrate structural gate，不做深度质量评分 |
+| `scripts/check-trajectory-hooks.py` + `scripts/trajectory-sentinels.json` | 防止 gateway trajectory/QA capture hook 漂移 | **保留**；后续可演进为更语义化检查 |
+| `backend/internal/observability/qa/service_traj_export.go` | 用户自助 trajectory zip 导出服务层 | **保留**；用于 self-service/API 导出，不替代 prod QA dump 链路 |
+| `exports/cursor-transcripts-*` | 历史导出结果/报告，不是自动化脚本 | **不作为当前链路复用**；不在本计划中继续引用 |
+
+本轮清理原则：不删除仍有审计价值的历史数据/approved 文档，不新增第二套脚本；只把计划文档和 operator README 收敛到上述现有主链路。真正过时的是“需要新建 prod export + purge 脚本”的表述，因为仓库已经有可复用脚本。
+
+设计要点：
+
+1. **导出成功之前不清理。** 必须先完成本地落盘、manifest、计数与 checksum 校验。
+2. **当前清理粒度是全量 QA buffer。** 运行窗口应选择低峰或专用 synth 采集窗口；如需精确 scope purge，后续只能在脚本层按 manifest 增量演进。
+3. **线上不做长期数据湖。** TokenKey prod 只承担短期 capture buffer，不承担训练数据仓库。
+4. **失败可重试。** 导出失败、manifest 缺失、checksum 失败、本地文件不完整时不清理线上数据。
+5. **成功后默认清理。** 这符合 OPC 的成本纪律，减少 DB/S3/EBS 长期膨胀和隐私/合规暴露面。
+
+这比在 TokenKey 长期保存 traj 数据更符合乔布斯和 OPC：产品路径清晰、运营成本低、失败模式少、长期心智负担小。
+
+## Claude Code headless assistant adapter
+
+assistant 侧应尽量使用 Claude Code 的真实 headless 能力，而不是长期停留在 Messages API shim。
+
+### 能力判断
+
+`claude -p` 非交互模式支持多轮上下文，但需要显式管理 session：
+
+- `claude -p` / `--print`：非交互输出；
+- `--output-format json`：便于捕获 `session_id`；
+- `--resume <session-id>` / `-r`：恢复指定 session；
+- `--continue` / `-c`：继续当前目录最近 session；
+- `--fork-session`：从已有 session 分叉；
+- 默认 session persistence 开启；如使用 `--no-session-persistence` 则不能依赖本地 resume。
+
+### 推荐用法
+
+traj 应为每条 synthetic session 维护一条 Claude Code session id：
+
+```text
+first assistant turn:
+  claude --bare -p --output-format json <prompt>
+  → capture claude_session_id
+
+next assistant turns:
+  claude --bare -p --resume <claude_session_id> --output-format json <next_user_msg>
+```
+
+建议使用 `--bare`，减少本地 hooks、skills、MCP 自动发现、memory 等对合成数据的非预期影响。若未来需要更强的跨机器稳定性，可升级到 Claude Agent SDK 的显式 session 管理；但第一阶段应优先用 Claude Code CLI，贴近真实 assistant coding agent 行为。
+
+### 注意事项
+
+- CLI session persistence 是本地状态，和 cwd/运行机器有关；并发 synthetic sessions 必须各自记录 session id。
+- session 恢复的是对话与工具历史，不是文件系统快照；sandbox 目录仍需由 traj 管理。
+- 如果在容器/临时 runner 中运行，需要把 session 存储位置、sandbox、artifact 路径作为同一 session bundle 管理。
+- 不应让 TokenKey 管理 Claude Code session；TokenKey 只观察经过网关的模型请求。
+
+## Recommended implementation path
+
+### Phase 1 — 收敛调用路径与元数据边界
+
+目标：让 traj 合成调用尽可能像真实用户调用。
+
+TokenKey 侧：
+
+1. 保持真实用户路径不变，只确认 synth metadata 不破坏现有 API 行为。
+2. 将 `X-Synth-*` 视为可选观测元数据，不改变调度逻辑。
+3. 用专用 key/group/account 池做隔离，而不是新增 traj-only 路由。
+4. 明确 `trajectory_id`、`request_id`、`synth_session_id` 的关联关系。
+
+traj 侧：
+
+1. user adapter 和 assistant adapter 都走 TokenKey 标准入口。
+2. assistant adapter 从 Messages API shim 演进到 Claude Code `-p` headless。
+3. 每个 synthetic session 显式记录：TokenKey synth session id、Claude Code session id、sandbox path、export artifact path。
+
+### Phase 2 — TokenKey 做 substrate 级契约与低成本导出清理
+
+目标：TokenKey 只保证生产路径可信、导出可信、清理可信。
+
+TokenKey 侧：
+
+1. 固化 `trajectory.jsonl` 基础 schema/version，但只覆盖 export substrate，不覆盖深度质量分级。
+2. 将 `scripts/check-traj-dataset.py` 定位为结构性 gate，而不是最终质量 gate。
+3. 强化 hook/capture drift check，优先放在脚本和 companion 中，减少 upstream 文件改动。
+4. 复用并小幅加固现有 prod export + purge 操作链路：导出到本地成功、manifest/count/checksum 校验通过后清理在线 DB/S3/EBS 过程文件。
+
+traj 侧：
+
+1. 只消费 TokenKey 导出的本地 artifact。
+2. 不要求 TokenKey 长期保存训练数据。
+3. 对导出 manifest/checksum 做二次确认，再进入 grading/cleaning pipeline。
+
+### Phase 3 — traj 承接质量分级、分档、清洗提升
+
+目标：把数据好坏判断全部收敛到 traj。
+
+traj 侧：
+
+1. 保持 transcript 为回合编排真相。
+2. 将 TokenKey QA/export 作为 evidence/meta 输入，而不是 turn reconstruction 输入。
+3. 建立 bronze/silver/gold 或等价分档策略。
+4. 将 C1–C5 扩展为“结构 + 行为 + 成本 + 质量”分层 gate。
+5. 对低质量 session 做清洗、裁剪、拒收或重跑。
+
+TokenKey 侧：
+
+1. 不引入分档/清洗/评分业务逻辑。
+2. 只提供足够稳定的 raw evidence 和基础投影。
+
+### Phase 4 — 双仓 E2E 回归
+
+目标：一条 synthetic session 能以最少差异走完整生产路径，并在本地完成质量闭环。
+
+验收链路：
+
+```text
+需求/spec
+  → traj user adapter calls TokenKey
+  → traj assistant adapter uses Claude Code -p and calls TokenKey
+  → TokenKey captures production evidence
+  → prod export script copies artifact to local
+  → successful local validation triggers prod purge
+  → traj builds transcript-centered dataset
+  → traj grades/cleans/tiers dataset
+```
+
+## Repo-specific improvement list
+
+### TokenKey / sub2api
+
+1. 保持真实调用与 synth 调用同构：不新增 traj-only gateway path。
+2. 将 `X-Synth-*` 作为可选观测元数据，不改变真实调度语义。
+3. 明确并校验 `trajectory_id` / `request_id` / `synth_session_id` 的最低关联保证。
+4. 将 `trajectory.jsonl` schema/version 定位为基础导出契约，而不是完整训练数据契约。
+5. 保留 H1/H2/H3/D1 等结构性 gate，但不要扩展成深度质量评分器。
+6. 复用 `scripts/fetch-prod-qa-dump.sh` + `scripts/prod-qa-export-and-purge.sh`，形成 prod QA buffer → local artifact → manifest/count/checksum → prod purge 的极简操作链路。
+7. 当前 purge 是全量 QA buffer 清理，必须在专用 synth 采集窗口或低峰窗口运行；未来精确 scope purge 只能在脚本层按 manifest 演进，避免污染服务主路径。
+8. hook/capture drift check 尽量脚本化、语义化，减少 upstream-owned Go 文件变更。
+
+### traj
+
+1. user/assistant adapter 都走 TokenKey 标准调用路径，只通过 metadata 标记 synth。
+2. assistant adapter 迁移到 Claude Code `-p` headless，并显式维护每条 synthetic session 的 Claude session id。
+3. 保持 transcript 为唯一回合编排真相；TokenKey evidence 只补 meta/evidence。
+4. 承接深度质量校验、分级分档、清洗提升、拒收/重跑策略。
+5. 将 C1–C5 从基础 verify 扩展为面向训练价值的离线质量 pipeline。
+6. 消费本地导出 artifact，而不是依赖 TokenKey prod 长期保存数据。
+7. 管理 sandbox、Claude Code session、TokenKey synth session、export artifact 之间的 manifest。
+
+## Key files and minimal-conflict extension points
+
+### TokenKey
+
+- `backend/internal/server/routes/gateway.go`
+  - 仅保留薄注入点：`middleware.TrajectoryID()`、`h.QACapture.Middleware()`。
+- `backend/internal/observability/qa/sse_tee.go`
+  - 维持 terminal capture：`Service.CaptureFromContext(...)`。
+- `backend/internal/observability/trajectory/projection.go`
+  - 维持基础 export projection，不承载深度质量评分。
+- `backend/internal/observability/qa/service_traj_export.go`
+  - self/prod export 的服务层入口。
+- `scripts/check-traj-dataset.py`
+  - 结构性 gate。
+- `scripts/check-trajectory-hooks.py`
+  - hook/capture drift gate。
+- `scripts/fetch-prod-qa-dump.sh`
+  - 现有 prod QA 只导出入口：SSM 打包 `qa_records` + `qa_blobs`，S3 presigned staging，本地解压到 `./.dump_trajs/`，写 manifest/count/checksum。
+- `scripts/prod-qa-export-and-purge.sh`
+  - 现有 prod export + cleanup 主入口：复用导出脚本，本地校验通过后清理 prod `qa_records`、`qa_blobs`、`qa_dlq` 与 S3 staging object。
+
+### traj
+
+- `../traj/pipeline/runtime/orchestrator.py`
+  - session/turn lifecycle 真相。
+- `../traj/pipeline/runtime/cursor_user.py`
+  - user-side adapter，可继续向真实 Cursor Agent CLI 演进。
+- `../traj/pipeline/runtime/claude_assistant.py`
+  - assistant-side adapter，应向 Claude Code `-p` headless 演进。
+- `../traj/pipeline/runtime/build_traj.py`
+  - transcript-centered dataset builder。
+- `../traj/pipeline/verify.sh`
+  - 离线质量 gate 总入口。
+- `../traj/pipeline/schemas/traj_v1.json`
+  - traj dataset schema。
+
+## Verification
+
+### TokenKey substrate verification
+
+- trajectory hook/capture drift check 通过。
+- dataset structural gate 通过。
+- prod export 生成本地 artifact 后 manifest/count/checksum 校验通过。
+- purge dry-run 与真实执行均符合当前脚本语义：全量 QA buffer 清理只在专用 synth/低峰窗口运行，失败时 prod 数据保持不变。
+- purge 后线上 DB/S3/过程文件不再保留已导出 synth 数据。
+
+### traj orchestration and quality verification
+
+- transcript 从 user 开始、assistant 结束，turns 连续且可重放。
+- Claude Code `-p` session id 能跨 assistant turns resume。
+- sandbox 与 Claude session 一一对应，不串 session。
+- C1–C5 通过，并能输出质量分档/拒收原因。
+- 清洗/提升后的 dataset 仍保留原始 manifest 与 evidence reference。
+
+### End-to-end verification
+
+- synth user 与 assistant 均走 TokenKey 标准调用路径。
+- TokenKey 能捕获两类调用的 QA evidence。
+- 本地 artifact 可被 traj 消费并完成 build/grade/clean。
+- 成功导出后 prod 数据被清理，失败时不清理。
+- 整条链路没有 traj-only gateway path，没有 TokenKey-side dataset judge。
+
+## Risks and controls
+
+- **风险：为了方便给 traj 开旁路。** 控制：强制走真实 TokenKey 调用路径，只加 metadata。
+- **风险：TokenKey 变成质量评分系统。** 控制：TokenKey 只做结构性 substrate gate，深度质量放 traj。
+- **风险：traj transcript 与 TokenKey evidence 分叉。** 控制：定义 manifest，将 transcript session、TokenKey request/trajectory、Claude session id 绑定。
+- **风险：prod purge 误删或漏导 QA buffer 新增数据。** 控制：当前脚本按全量 QA buffer 清理，必须在专用 synth/低峰窗口运行；先 dry-run，必要时设置 `PURGE_MAX_EXTRA_ROWS=0`，未来精确 scope purge 只能在脚本层按 manifest 演进。
+- **风险：Claude Code CLI session 本地态导致并发串线。** 控制：每条 synthetic session 独立 cwd/sandbox/session id，禁止依赖 `--continue` 处理并发，优先使用 `--resume <session_id>`。
+- **风险：upstream merge 冲突扩大。** 控制：TokenKey 改动优先脚本、companion、薄注入点，不改 upstream 大段逻辑。

--- a/scripts/fetch-prod-qa-dump.sh
+++ b/scripts/fetch-prod-qa-dump.sh
@@ -3,7 +3,7 @@
 #
 # Flow: SSM builds a tarball on the instance (metadata/qa_records.jsonl + qa_blobs/),
 # uploads it with curl + S3 presigned PUT (no EC2 instance S3 IAM required), then
-# downloads and extracts locally.
+# downloads, extracts locally, and writes a manifest with line/file counts plus checksums.
 #
 # Requires (operator IAM):
 #   - ssm:SendCommand, ssm:GetCommandInvocation on the prod instance
@@ -40,12 +40,25 @@ RM_LOCAL_TAR="${RM_LOCAL_TAR_AFTER_EXTRACT:-0}"
 
 err() { echo "[fetch-prod-qa-dump] error: $*" >&2; }
 log() { echo "[fetch-prod-qa-dump] $*"; }
+sha256_file() {
+  if command -v shasum >/dev/null 2>&1; then
+    shasum -a 256 "$1" | awk '{print $1}'
+    return
+  fi
+  if command -v sha256sum >/dev/null 2>&1; then
+    sha256sum "$1" | awk '{print $1}'
+    return
+  fi
+  err "shasum or sha256sum missing"
+  exit 1
+}
 
 if [[ "${1:-}" == "--check" ]]; then
   command -v aws >/dev/null 2>&1 || { err "aws CLI missing"; exit 1; }
   command -v jq >/dev/null 2>&1 || { err "jq missing"; exit 1; }
   command -v curl >/dev/null 2>&1 || { err "curl missing"; exit 1; }
   command -v python3 >/dev/null 2>&1 || { err "python3 missing (for venv + boto3 presign)"; exit 1; }
+  command -v shasum >/dev/null 2>&1 || command -v sha256sum >/dev/null 2>&1 || { err "shasum or sha256sum missing"; exit 1; }
   [[ -n "${QA_DUMP_S3_BUCKET:-}" ]] || { err "set QA_DUMP_S3_BUCKET"; exit 1; }
   log "OK (tools + QA_DUMP_S3_BUCKET)"
   exit 0
@@ -164,11 +177,15 @@ tar xzf "$LOCAL_TAR" -C "$OUT_DIR"
 
 RECORDS_LINES="$(wc -l < "$OUT_DIR/metadata/qa_records.jsonl" | tr -d ' ')"
 BLOB_FILES="$(find "$OUT_DIR/qa_blobs" -type f 2>/dev/null | wc -l | tr -d ' ')"
+TARBALL_SHA256="$(sha256_file "$LOCAL_TAR")"
+QA_RECORDS_SHA256="$(sha256_file "$OUT_DIR/metadata/qa_records.jsonl")"
 jq -n \
   --arg stamp "$STAMP" \
   --arg s3_key "$S3_KEY" \
   --arg bucket "$BUCKET" \
   --arg tarball "$TARBALL_NAME" \
+  --arg tarball_sha256 "$TARBALL_SHA256" \
+  --arg qa_records_sha256 "$QA_RECORDS_SHA256" \
   --arg region "$REGION" \
   --arg stack "$STACK" \
   --arg instance_id "$INSTANCE_ID" \
@@ -180,6 +197,8 @@ jq -n \
     s3_key: $s3_key,
     bucket: $bucket,
     tarball: $tarball,
+    tarball_sha256: $tarball_sha256,
+    qa_records_sha256: $qa_records_sha256,
     region: $region,
     stack: $stack,
     instance_id: $instance_id,

--- a/scripts/preflight.sh
+++ b/scripts/preflight.sh
@@ -293,6 +293,15 @@ else
     echo "  ok: traj dataset validator accepts/rejects covered fixtures as expected"
 fi
 
+# ---- sub2api: post-deploy smoke script (syntax only; no live HTTP) ----------
+echo ""
+echo "=== sub2api: post-deploy smoke script syntax ==="
+if ! bash -n ./scripts/tk_post_deploy_smoke.sh; then
+    echo "  FAIL: scripts/tk_post_deploy_smoke.sh has bash syntax errors"
+    errors=$((errors + 1))
+else
+    echo "  ok: tk_post_deploy_smoke.sh parses"
+fi
 
 echo ""
 if [ "$errors" -eq 0 ]; then

--- a/scripts/prod-qa-export-and-purge.sh
+++ b/scripts/prod-qa-export-and-purge.sh
@@ -1,7 +1,8 @@
 #!/usr/bin/env bash
-# Export prod qa_records + qa_blobs to local (same as fetch-prod-qa-dump.sh), verify,
-# then purge PostgreSQL qa_records and local blob/export files on the EC2 host, and
-# remove the S3 staging object — so EBS + S3 do not retain QA payload after a good pull.
+# Export prod qa_records + qa_blobs to local (same as fetch-prod-qa-dump.sh), verify
+# manifest counts/checksums, then purge PostgreSQL qa_records and local blob/export files
+# on the EC2 host, and remove the S3 staging object — so EBS + S3 do not retain QA
+# payload after a good pull.
 #
 # Online impact (intentionally limited):
 # - TRUNCATE qa_records briefly locks that table; capture traffic may block for a moment.
@@ -49,6 +50,18 @@ REPO_ROOT="$(cd "$SCRIPT_DIR/.." && pwd)"
 
 err() { echo "[prod-qa-export-and-purge] error: $*" >&2; }
 log() { echo "[prod-qa-export-and-purge] $*"; }
+sha256_file() {
+  if command -v shasum >/dev/null 2>&1; then
+    shasum -a 256 "$1" | awk '{print $1}'
+    return
+  fi
+  if command -v sha256sum >/dev/null 2>&1; then
+    sha256sum "$1" | awk '{print $1}'
+    return
+  fi
+  err "shasum or sha256sum missing"
+  exit 1
+}
 
 DRY_RUN=0
 if [[ "${1:-}" == "--dry-run" ]]; then
@@ -95,8 +108,24 @@ S3_KEY="$(jq -r .s3_key "$MANIFEST")"
 BUCKET="$(jq -r .bucket "$MANIFEST")"
 INSTANCE_ID="$(jq -r .instance_id "$MANIFEST")"
 TARBALL="$(jq -r .tarball "$MANIFEST")"
+TARBALL_SHA256="$(jq -r '.tarball_sha256 // empty' "$MANIFEST")"
+QA_RECORDS_SHA256="$(jq -r '.qa_records_sha256 // empty' "$MANIFEST")"
 
 log "local verify: qa_records_lines=$LINES local_qa_blob_files=$BLOBS"
+if [[ -n "$QA_RECORDS_SHA256" ]]; then
+  ACTUAL_QA_RECORDS_SHA256="$(sha256_file "$OUT_DIR/metadata/qa_records.jsonl")"
+  if [[ "$ACTUAL_QA_RECORDS_SHA256" != "$QA_RECORDS_SHA256" ]]; then
+    err "refusing purge: qa_records.jsonl checksum mismatch"
+    exit 1
+  fi
+fi
+if [[ -n "$TARBALL_SHA256" && -f "$OUT_DIR/$TARBALL" ]]; then
+  ACTUAL_TARBALL_SHA256="$(sha256_file "$OUT_DIR/$TARBALL")"
+  if [[ "$ACTUAL_TARBALL_SHA256" != "$TARBALL_SHA256" ]]; then
+    err "refusing purge: local tarball checksum mismatch"
+    exit 1
+  fi
+fi
 if [[ "$LINES" -lt 1 && "${ALLOW_PURGE_EMPTY_QA_EXPORT:-0}" != "1" ]]; then
   err "refusing purge: qa_records_lines=$LINES (set ALLOW_PURGE_EMPTY_QA_EXPORT=1 to override)"
   exit 1

--- a/scripts/tk_gateway_smoke.sh
+++ b/scripts/tk_gateway_smoke.sh
@@ -1,6 +1,9 @@
 #!/usr/bin/env bash
 # TokenKey smoke tests against TOKENKEY_BASE_URL (never prints API keys).
 #
+# For deploy-stage0's mandatory gate (incl. /v1/messages), use
+# scripts/tk_post_deploy_smoke.sh instead.
+#
 # 1) GET /api/v1/settings/public — no auth (validates cold-start public fields).
 # 2) GET/POST /v1/* — requires a **user API key** (sk-...): TK_TOKEN or TOKENKEY_API_KEY.
 #    Do **not** use ANTHROPIC_AUTH_TOKEN here — it is for Claude CLI / balance auth,

--- a/scripts/tk_post_deploy_smoke.sh
+++ b/scripts/tk_post_deploy_smoke.sh
@@ -1,0 +1,128 @@
+#!/usr/bin/env bash
+# tk_post_deploy_smoke.sh — mandatory post-deploy gateway checks (Stage0).
+#
+# Exercises the same paths Claude Code uses against TokenKey:
+#   public settings, /v1/models, /v1/chat/completions, /v1/messages.
+#
+# Usage:
+#   TOKENKEY_BASE_URL=https://api.example.com \
+#   POST_DEPLOY_SMOKE_API_KEY=sk-... \
+#   bash scripts/tk_post_deploy_smoke.sh
+#
+# Key resolution (first non-empty): POST_DEPLOY_SMOKE_API_KEY,
+# ANTHROPIC_AUTH_TOKEN, TK_TOKEN, TOKENKEY_API_KEY.
+#
+# Never prints the full API key. Requires curl + jq on PATH.
+set -euo pipefail
+
+BASE="${TOKENKEY_BASE_URL:-${TK_GATEWAY_URL:-}}"
+BASE="${BASE%/}"
+
+API_KEY="${POST_DEPLOY_SMOKE_API_KEY:-${ANTHROPIC_AUTH_TOKEN:-${TK_TOKEN:-${TOKENKEY_API_KEY:-}}}}"
+
+if [[ -z "${BASE}" ]]; then
+  echo "tk_post_deploy_smoke: set TOKENKEY_BASE_URL (or TK_GATEWAY_URL)" >&2
+  exit 1
+fi
+if [[ -z "${API_KEY}" ]]; then
+  echo "tk_post_deploy_smoke: set POST_DEPLOY_SMOKE_API_KEY (or ANTHROPIC_AUTH_TOKEN / TK_TOKEN / TOKENKEY_API_KEY)" >&2
+  exit 1
+fi
+
+command -v curl >/dev/null 2>&1 || { echo "tk_post_deploy_smoke: curl not on PATH" >&2; exit 1; }
+command -v jq >/dev/null 2>&1 || { echo "tk_post_deploy_smoke: jq not on PATH" >&2; exit 1; }
+
+tmpdir="$(mktemp -d)"
+trap 'rm -rf "$tmpdir"' EXIT
+
+prefix="$(printf '%s' "${API_KEY}" | head -c 6)"
+suffix="$(printf '%s' "${API_KEY}" | tail -c 4)"
+echo "tk_post_deploy_smoke: base_url=${BASE} key_hint=${prefix}…${suffix}"
+
+# --- 1) Public settings (cold path) ---
+pub_http=$(curl -sS -o "$tmpdir/pub.json" -w "%{http_code}" "${BASE}/api/v1/settings/public")
+echo "tk_post_deploy_smoke: GET .../api/v1/settings/public -> HTTP ${pub_http}"
+if [[ "${pub_http}" != "200" ]]; then
+  echo "tk_post_deploy_smoke: public settings failed" >&2
+  exit 1
+fi
+pub_code="$(jq -r '.code // empty' "$tmpdir/pub.json")"
+if [[ "${pub_code}" != "0" ]]; then
+  echo "tk_post_deploy_smoke: public settings JSON code != 0" >&2
+  jq . "$tmpdir/pub.json" >&2 || true
+  exit 1
+fi
+
+# --- 2) Model list ---
+models_http=$(curl -sS -o "$tmpdir/models.json" -w "%{http_code}" \
+  -H "Authorization: Bearer ${API_KEY}" \
+  -H "Accept: application/json" \
+  "${BASE}/v1/models")
+echo "tk_post_deploy_smoke: GET .../v1/models -> HTTP ${models_http}"
+if [[ "${models_http}" != "200" ]]; then
+  echo "tk_post_deploy_smoke: /v1/models failed" >&2
+  jq . "$tmpdir/models.json" >&2 2>/dev/null || cat "$tmpdir/models.json" >&2
+  exit 1
+fi
+
+model="$(jq -r '(.data // []) as $d | ($d | map(select(.id|test("claude";"i"))) | .[0].id) // $d[0].id // empty' "$tmpdir/models.json")"
+if [[ -z "${model}" ]] || [[ "${model}" == "null" ]]; then
+  echo "tk_post_deploy_smoke: no model id in /v1/models" >&2
+  jq . "$tmpdir/models.json" >&2 || true
+  exit 1
+fi
+echo "tk_post_deploy_smoke: using model=${model}"
+
+# --- 3) OpenAI-compat chat ---
+expect_openai="E2E-OPENAI-OK"
+payload="$(jq -n \
+  --arg m "${model}" \
+  --arg x "${expect_openai}" \
+  '{model:$m,messages:[{role:"user",content:("Reply with exactly: " + $x)}],max_tokens:48,temperature:0,stream:false}')"
+
+chat_http=$(curl -sS -o "$tmpdir/chat.json" -w "%{http_code}" \
+  -H "Authorization: Bearer ${API_KEY}" \
+  -H "Content-Type: application/json" \
+  -H "Accept: application/json" \
+  -d "${payload}" \
+  "${BASE}/v1/chat/completions")
+echo "tk_post_deploy_smoke: POST .../v1/chat/completions -> HTTP ${chat_http}"
+if [[ "${chat_http}" != "200" ]]; then
+  echo "tk_post_deploy_smoke: /v1/chat/completions failed" >&2
+  jq . "$tmpdir/chat.json" >&2 2>/dev/null || cat "$tmpdir/chat.json" >&2
+  exit 1
+fi
+chat_body="$(jq -r '.choices[0].message.content // empty' "$tmpdir/chat.json")"
+if ! printf '%s' "${chat_body}" | grep -Fq "${expect_openai}"; then
+  echo "tk_post_deploy_smoke: chat response missing expected marker '${expect_openai}' (body below)" >&2
+  printf '%s\n' "${chat_body}" >&2
+  exit 1
+fi
+
+# --- 4) Anthropic Messages shape (Claude Code / x-api-key path) ---
+expect_anthropic="E2E-ANTHROPIC-OK"
+apayload="$(jq -n \
+  --arg m "${model}" \
+  --arg x "${expect_anthropic}" \
+  '{model:$m,max_tokens:96,messages:[{role:"user",content:("Reply with exactly: " + $x)}]}')"
+
+msg_http=$(curl -sS -o "$tmpdir/msg.json" -w "%{http_code}" \
+  -H "x-api-key: ${API_KEY}" \
+  -H "anthropic-version: 2023-06-01" \
+  -H "Content-Type: application/json" \
+  -d "${apayload}" \
+  "${BASE}/v1/messages")
+echo "tk_post_deploy_smoke: POST .../v1/messages -> HTTP ${msg_http}"
+if [[ "${msg_http}" != "200" ]]; then
+  echo "tk_post_deploy_smoke: /v1/messages failed" >&2
+  jq . "$tmpdir/msg.json" >&2 2>/dev/null || cat "$tmpdir/msg.json" >&2
+  exit 1
+fi
+msg_text="$(jq -r '[.content[]? | select(.type == "text") | .text] | add // empty' "$tmpdir/msg.json")"
+if ! printf '%s' "${msg_text}" | grep -Fq "${expect_anthropic}"; then
+  echo "tk_post_deploy_smoke: messages response missing expected marker '${expect_anthropic}' (text below)" >&2
+  printf '%s\n' "${msg_text}" >&2
+  exit 1
+fi
+
+echo "tk_post_deploy_smoke: OK"


### PR DESCRIPTION
## Summary
- Document the TokenKey × traj target boundary: real and synth calls share the standard gateway path, TokenKey stays as capture/export substrate, and traj owns transcript quality work.
- Reuse the existing prod QA dump/purge scripts instead of adding a traj-only export path, and add manifest checksum verification before purge.
- Include the deploy-stage0 post-deploy smoke gate changes already present on the local branch.

## Risk
- Low upstream conflict surface: changes are limited to docs, scripts, workflow/deploy support, and no gateway/service/handler production code paths.
- Prod purge remains destructive by design; the update adds checksum verification and documents the current full QA-buffer purge semantics rather than claiming per-session purge.

## Validation
- [x] `git diff --check && git diff --cached --check`
- [x] `bash -n scripts/fetch-prod-qa-dump.sh`
- [x] `bash -n scripts/prod-qa-export-and-purge.sh`
- [x] `python3 scripts/check-trajectory-hooks.py`
- [x] `bash scripts/preflight.sh`

🤖 Generated with [Claude Code](https://claude.com/claude-code)