### PR TITLE
fix(playground): user messages align right (chat convention)

### DIFF
--- a/frontend/src/views/user/PlaygroundView.vue
+++ b/frontend/src/views/user/PlaygroundView.vue
@@ -74,8 +74,9 @@
               v-for="(msg, idx) in displayMessages"
               :key="idx"
               :class="[
-                'flex gap-2.5',
-                msg.role === 'user' ? 'flex-row-reverse justify-end' : 'flex-row justify-start'
+                'flex w-full gap-2.5',
+                /* row-reverse: main-start is right; justify-start packs user turn to the right (chat convention) */
+                msg.role === 'user' ? 'flex-row-reverse justify-start' : 'flex-row justify-start'
               ]"
             >
               <div


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Playground chat used `flex-row-reverse` with `justify-end`. In a reversed row, `justify-end` packs items toward the **left** (the end of the reversed main axis), so the user bubble appeared on the wrong side.

Switched user rows to `justify-start` (start of reversed main axis = **right**) and added `w-full` so each message row spans the chat width.

## Risk

Low — layout-only change in `PlaygroundView.vue`.

## Validation

- `pnpm exec eslint src/views/user/PlaygroundView.vue`
- `./scripts/preflight.sh` (pending)
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-1a0bc8a3-fdba-4e88-a094-a43802d6d852"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-1a0bc8a3-fdba-4e88-a094-a43802d6d852"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

