### PR TITLE
chore: sync dev-rules to 56e3a4a

### DIFF
--- a/.cursor/rules/dev-rules-convention.mdc
+++ b/.cursor/rules/dev-rules-convention.mdc
@@ -28,7 +28,8 @@ alwaysApply: true
 
 ```bash
 cd 项目根目录
-git submodule add git@github.com:youxuanxue/dev-rules.git dev-rules
+DEV_RULES_REMOTE_URL="${DEV_RULES_REMOTE_URL:?set DEV_RULES_REMOTE_URL}"
+git submodule add "$DEV_RULES_REMOTE_URL" dev-rules
 dev-rules/sync.sh --local                   # 复制规则 + 自动 register 该项目
 git add .cursor/rules/ .gitmodules dev-rules
 git commit -m "chore: add dev-rules submodule and sync rules"
@@ -37,12 +38,17 @@ git commit -m "chore: add dev-rules submodule and sync rules"
 **首次在本机使用**（仅一次）：
 
 ```bash
-git clone git@github.com:youxuanxue/dev-rules.git ~/Codes/dev-rules
+DEV_RULES_REMOTE_URL="${DEV_RULES_REMOTE_URL:?set DEV_RULES_REMOTE_URL}"
+git clone "$DEV_RULES_REMOTE_URL" ~/Codes/dev-rules
 ~/Codes/dev-rules/sync.sh                                          # 创建 home symlinks
 bash ~/Codes/dev-rules/templates/install-launchagent.sh            # 注册跨机器同步 agent
 ```
 
-之后在任意项目里 `sync.sh --local` 就会自动把项目 `(name, git remote URL)` 写进 `~/Codes/dev-rules/.registered-projects`（git-tracked，跨机器共享），并把 `(git URL, 本机绝对路径)` 写进 `.local-projects`（per-machine，gitignored）。下一次 `--push` / `--pull` / LaunchAgent 会按本机实际落地的项目自动 fan-out。换机器只需要重新 `--local` 一次，本机映射即重建。
+之后在任意项目里 `sync.sh --local` 就会自动把项目 `(name, git remote URL)` 写进 `~/Codes/dev-rules/.registered-projects`（git-tracked，跨机器共享），并把 `(git URL, 本机绝对路径)` 写进 `.local-projects`（per-machine，gitignored）。下一次 `--push` / `--pull` / LaunchAgent 会按本机实际落地的项目自动 fan-out。
+
+fan-out 使用 `.registered-projects` 与 `.local-projects` 的并集：跨机器登记项目在本机有路径会同步；只存在于 `.local-projects` 的本机项目也会同步。后者适合 zw-brain 这类不希望在项目仓库暴露 dev-rules 远端 URL、但仍希望从 `~/Codes/dev-rules` 获得规则副本的项目。
+
+换机器时，跨机器项目重新 `--local` 一次即可重建本机映射；本机-only 项目需要在该机器写入 `.local-projects` 或手动执行 `sync.sh --project /path/to/project`。
 
 ## 编辑与提交规则
 

--- a/.cursor/rules/product-dev.mdc
+++ b/.cursor/rules/product-dev.mdc
@@ -18,6 +18,7 @@ alwaysApply: true
 - 默认一个 PR 只承载一个用户意图，不按阶段机械拆 PR
 - 默认直接做生产级实现，不先做“为了走流程而存在”的原型 PR
 - 默认用最少的文档承载必要判断，不把 PR、comment、文档写成四份重复说明
+- 行为变更必须有与风险匹配的意图载体：低风险靠任务说明与测试即可；常规风险只有在 PR summary 说不清时才补最小 spec delta；高风险进入 `docs/approved/` 审批基线
 
 只有命中**高风险变更**时，才升级到原型 + 审批路径。
 
@@ -62,6 +63,21 @@ alwaysApply: true
 - PR 评论看起来很长
 
 如果对风险等级拿不准，默认按**常规风险**处理，并先补一个最小澄清问题；只有明确命中高风险条件，或存在安全/数据损失级不确定性时，才升级为高风险。
+
+### 常规风险意图载体
+
+常规风险不默认写文档。只有当行为变化复杂到 PR summary 无法说清，或 reviewer 需要先理解 intent 再看 code 时，才使用最小 spec delta。
+
+建议位置：`docs/spec-delta-<slug>.md`。
+
+内容只保留四块：
+
+1. Background：为什么改
+2. Delta：ADDED / MODIFIED / REMOVED 的行为变化
+3. Scenarios：核心正向、核心负向或关键回归场景
+4. Validation：测试命令、运行结果或 evidence
+
+spec delta 是意图载体，不是审批基线；若命中高风险条件，必须升级到 `docs/approved/`。
 
 ## 高风险路径（例外，而非默认）
 

--- a/.cursor/rules/test-philosophy.mdc
+++ b/.cursor/rules/test-philosophy.mdc
@@ -9,6 +9,7 @@ alwaysApply: true
 
 - 默认路径：先补核心测试，优先证明行为正确
 - 完整 Story 路径：只有命中触发条件时，才进入 Story → 用例 → 对齐门禁的完整闭环
+- 若常规风险变更使用了 `docs/spec-delta-*.md`，其中的核心 scenario 必须至少映射到测试、手动验证步骤或明确的「未验证」说明；spec delta 不是测试替代品
 
 三层保障只在完整 Story 路径中展开：测什么不漏（故事覆盖）→ 怎么测够深（用例覆盖）→ Story 与 Test 不漂移（对齐门禁）。
 
@@ -35,6 +36,16 @@ alwaysApply: true
 - 无公共 API 变化的依赖升级
 - 无公共行为变化的内部重构（但已有测试必须原样通过）
 - 范围清晰的小型行为修复，且可由聚焦测试直接覆盖
+
+### Spec / Scenario → Test 链路
+
+当变更存在 `docs/spec-delta-*.md`、`docs/approved/` 或 `.testing/user-stories/` 时，验证应从意图出发，而不是从实现反推：
+
+1. spec delta 的关键 scenario → 至少有对应测试、手动验证步骤或明确「未验证」说明。
+2. `docs/approved/` 的审批基线 → 高风险实现必须有测试或 evidence 覆盖核心流程与风险点。
+3. 完整 Story 路径 → AC 必须追到 Linked Tests，并由 `verify_quality.py`（如项目启用）检查漂移。
+
+不要为了补链路而生成空泛 Story；低风险和清晰小修复仍按默认最小测试动作执行。
 
 ### 进入完整 Story 路径的变更
 


### PR DESCRIPTION
Bumps dev-rules to `56e3a4a` (youxuanxue/dev-rules#7: align phase 1 agent harness rules). Refreshes tracked `.cursor/rules/*.mdc` copies and submodule pointer where applicable.

Made with [Cursor](https://cursor.com)