### PR TITLE
fix(admin): 扩展引擎渠道类型紧跟平台选择器显示

### DIFF
--- a/deploy/docker-compose.dev.yml
+++ b/deploy/docker-compose.dev.yml
@@ -13,15 +13,10 @@
 services:
   sub2api:
     build:
-      # Default: parent of repo root contains both `sub2api/` and `new-api/` (see Dockerfile header).
-      # Override when your checkout path differs (e.g. BUILD_CONTEXT=/tk in minimal VMs).
-      context: ${BUILD_CONTEXT:-../..}
+      context: ../..
       dockerfile: sub2api/Dockerfile
     container_name: sub2api-dev
     restart: unless-stopped
-    extra_hosts:
-      # Route DB/Redis via published ports on the host when in-container DNS is unavailable (some sandboxes).
-      - "host.docker.internal:host-gateway"
     ports:
       - "${BIND_HOST:-127.0.0.1}:${SERVER_PORT:-8080}:8080"
     volumes:
@@ -32,14 +27,13 @@ services:
       - SERVER_PORT=8080
       - SERVER_MODE=debug
       - RUN_MODE=${RUN_MODE:-standard}
-      # Prefer service name; fallback host uses published ports (postgres/redis publish below).
-      - DATABASE_HOST=${DATABASE_HOST:-postgres}
+      - DATABASE_HOST=postgres
       - DATABASE_PORT=5432
       - DATABASE_USER=${POSTGRES_USER:-sub2api}
       - DATABASE_PASSWORD=${POSTGRES_PASSWORD:?POSTGRES_PASSWORD is required}
       - DATABASE_DBNAME=${POSTGRES_DB:-sub2api}
       - DATABASE_SSLMODE=disable
-      - REDIS_HOST=${REDIS_HOST:-redis}
+      - REDIS_HOST=redis
       - REDIS_PORT=6379
       - REDIS_PASSWORD=${REDIS_PASSWORD:-}
       - REDIS_DB=${REDIS_DB:-0}
@@ -66,9 +60,6 @@ services:
     image: postgres:18-alpine
     container_name: sub2api-postgres-dev
     restart: unless-stopped
-    ports:
-      # Default bind all interfaces so app containers using host.docker.internal:5432 can reach Postgres (Linux host-gateway).
-      - "${POSTGRES_PUBLISH:-0.0.0.0:5432}:5432"
     volumes:
       - ./postgres_data:/var/lib/postgresql/data
     environment:
@@ -90,8 +81,6 @@ services:
     image: redis:8-alpine
     container_name: sub2api-redis-dev
     restart: unless-stopped
-    ports:
-      - "${REDIS_PUBLISH:-0.0.0.0:6379}:6379"
     volumes:
       - ./redis_data:/data
     command: >

--- a/deploy/docker-compose.dev.yml
+++ b/deploy/docker-compose.dev.yml
@@ -13,10 +13,15 @@
 services:
   sub2api:
     build:
-      context: ../..
+      # Default: parent of repo root contains both `sub2api/` and `new-api/` (see Dockerfile header).
+      # Override when your checkout path differs (e.g. BUILD_CONTEXT=/tk in minimal VMs).
+      context: ${BUILD_CONTEXT:-../..}
       dockerfile: sub2api/Dockerfile
     container_name: sub2api-dev
     restart: unless-stopped
+    extra_hosts:
+      # Route DB/Redis via published ports on the host when in-container DNS is unavailable (some sandboxes).
+      - "host.docker.internal:host-gateway"
     ports:
       - "${BIND_HOST:-127.0.0.1}:${SERVER_PORT:-8080}:8080"
     volumes:
@@ -27,13 +32,14 @@ services:
       - SERVER_PORT=8080
       - SERVER_MODE=debug
       - RUN_MODE=${RUN_MODE:-standard}
-      - DATABASE_HOST=postgres
+      # Prefer service name; fallback host uses published ports (postgres/redis publish below).
+      - DATABASE_HOST=${DATABASE_HOST:-postgres}
       - DATABASE_PORT=5432
       - DATABASE_USER=${POSTGRES_USER:-sub2api}
       - DATABASE_PASSWORD=${POSTGRES_PASSWORD:?POSTGRES_PASSWORD is required}
       - DATABASE_DBNAME=${POSTGRES_DB:-sub2api}
       - DATABASE_SSLMODE=disable
-      - REDIS_HOST=redis
+      - REDIS_HOST=${REDIS_HOST:-redis}
       - REDIS_PORT=6379
       - REDIS_PASSWORD=${REDIS_PASSWORD:-}
       - REDIS_DB=${REDIS_DB:-0}
@@ -60,6 +66,9 @@ services:
     image: postgres:18-alpine
     container_name: sub2api-postgres-dev
     restart: unless-stopped
+    ports:
+      # Default bind all interfaces so app containers using host.docker.internal:5432 can reach Postgres (Linux host-gateway).
+      - "${POSTGRES_PUBLISH:-0.0.0.0:5432}:5432"
     volumes:
       - ./postgres_data:/var/lib/postgresql/data
     environment:
@@ -81,6 +90,8 @@ services:
     image: redis:8-alpine
     container_name: sub2api-redis-dev
     restart: unless-stopped
+    ports:
+      - "${REDIS_PUBLISH:-0.0.0.0:6379}:6379"
     volumes:
       - ./redis_data:/data
     command: >

--- a/frontend/src/components/account/CreateAccountModal.vue
+++ b/frontend/src/components/account/CreateAccountModal.vue
@@ -168,11 +168,7 @@
         </div>
       </div>
 
-      <!--
-        Extension Engine (5th platform): keep channel type + credentials directly under
-        the platform row so operators see them without scrolling past long sections for
-        other platforms (Gemini OAuth tiers, Antigravity, etc.).
-      -->
+      <!-- newapi: channel fields directly under platform picker (avoid scrolling past other platforms). -->
       <div v-if="form.platform === 'newapi'" class="space-y-4">
         <AccountNewApiPlatformFields
           v-model:channelType="newapiChannelType"

--- a/frontend/src/components/account/CreateAccountModal.vue
+++ b/frontend/src/components/account/CreateAccountModal.vue
@@ -168,6 +168,34 @@
         </div>
       </div>
 
+      <!--
+        Extension Engine (5th platform): keep channel type + credentials directly under
+        the platform row so operators see them without scrolling past long sections for
+        other platforms (Gemini OAuth tiers, Antigravity, etc.).
+      -->
+      <div v-if="form.platform === 'newapi'" class="space-y-4">
+        <AccountNewApiPlatformFields
+          v-model:channelType="newapiChannelType"
+          v-model:baseUrl="newapiBaseUrl"
+          v-model:apiKey="newapiApiKey"
+          v-model:modelMapping="newapiModelMapping"
+          v-model:statusCodeMapping="newapiStatusCodeMapping"
+          v-model:openaiOrganization="newapiOpenAIOrganization"
+          v-model:allowedModels="newapiAllowedModels"
+          v-model:modelMappings="newapiModelMappings"
+          v-model:restrictionMode="newapiRestrictionMode"
+          :channel-type-options="newapiChannelTypeOptions"
+          :channel-types-loading="newapiChannelTypesLoading"
+          :channel-types-error="newapiChannelTypesError"
+          :selected-channel-type-base-url="newapiSelectedBaseUrl"
+          :fetch-models-enabled="newapiFetchModelsEnabled"
+          :fetch-models-disabled="newapiFetchModelsDisabled"
+          :fetch-models-loading="newapiFetchModelsLoading"
+          variant="create"
+          @fetch-models="newapiHandleFetchUpstreamModels"
+        />
+      </div>
+
       <!-- Account Type Selection (Anthropic) -->
       <div v-if="form.platform === 'anthropic'">
         <label class="input-label">{{ t('admin.accounts.accountType') }}</label>
@@ -719,34 +747,6 @@
             </div>
           </button>
         </div>
-      </div>
-
-      <!--
-        New API (5th platform) account fields. US-017 prototype scope.
-        AccountNewApiPlatformFields was already shipped with the design but never
-        wired in until now; component handles channel-type catalog + base_url + api_key.
-      -->
-      <div v-if="form.platform === 'newapi'" class="space-y-4">
-        <AccountNewApiPlatformFields
-          v-model:channelType="newapiChannelType"
-          v-model:baseUrl="newapiBaseUrl"
-          v-model:apiKey="newapiApiKey"
-          v-model:modelMapping="newapiModelMapping"
-          v-model:statusCodeMapping="newapiStatusCodeMapping"
-          v-model:openaiOrganization="newapiOpenAIOrganization"
-          v-model:allowedModels="newapiAllowedModels"
-          v-model:modelMappings="newapiModelMappings"
-          v-model:restrictionMode="newapiRestrictionMode"
-          :channel-type-options="newapiChannelTypeOptions"
-          :channel-types-loading="newapiChannelTypesLoading"
-          :channel-types-error="newapiChannelTypesError"
-          :selected-channel-type-base-url="newapiSelectedBaseUrl"
-          :fetch-models-enabled="newapiFetchModelsEnabled"
-          :fetch-models-disabled="newapiFetchModelsDisabled"
-          :fetch-models-loading="newapiFetchModelsLoading"
-          variant="create"
-          @fetch-models="newapiHandleFetchUpstreamModels"
-        />
       </div>
 
       <!-- Upstream config (only for Antigravity upstream type) -->

--- a/frontend/src/components/account/__tests__/CreateAccountModal.newapi.spec.ts
+++ b/frontend/src/components/account/__tests__/CreateAccountModal.newapi.spec.ts
@@ -157,6 +157,9 @@ describe('CreateAccountModal — NewAPI (5th platform)', () => {
     await nextTick()
     await nextTick()
 
+    // Channel type selector must be present immediately (placed directly under the platform row).
+    expect(wrapper.html()).toContain('admin.accounts.newApiPlatform.channelType')
+
     // The NewAPI fields block must render the structured model selector
     // (D4) — proves D1 succeeded (accountCategory was flipped → form.type='apikey'
     // → the structured selector inside AccountNewApiPlatformFields shows up

--- a/scripts/deploy-dev-reset.sh
+++ b/scripts/deploy-dev-reset.sh
@@ -1,0 +1,56 @@
+#!/usr/bin/env bash
+# 清空 deploy 本地数据目录并以 docker-compose.dev.yml 重新构建启动。
+# Docker 构建上下文为「包含 sub2api 与 new-api 的父目录」：请在本机保证存在
+#   /path/to/parent/sub2api   （或指向仓库根的符号链接 sub2api）
+#   /path/to/parent/new-api   （与 backend/go.mod replace 一致）
+#
+# 用法（在仓库根目录）：
+#   POSTGRES_PASSWORD='your_pg' ADMIN_EMAIL='a@b.c' ADMIN_PASSWORD='secret' bash scripts/deploy-dev-reset.sh
+#
+# 未设置 ADMIN_PASSWORD 时首次启动会随机生成并在容器日志中打印一次（见 deploy/README.md）。
+set -euo pipefail
+
+ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+DEPLOY="$ROOT/deploy"
+
+# Docker build context: directory that contains `sub2api/` + `new-api/` subdirs (Dockerfile COPY paths).
+# Auto-pick /tk when present (symlink layout used in some sandboxes); else repo parent's parent.
+if [[ -z "${BUILD_CONTEXT:-}" ]]; then
+  if [[ -d /tk/sub2api && -d /tk/new-api ]]; then
+    BUILD_CONTEXT=/tk
+  else
+    BUILD_CONTEXT="$(cd "$DEPLOY/../.." && pwd)"
+  fi
+fi
+export BUILD_CONTEXT
+
+POSTGRES_PASSWORD="${POSTGRES_PASSWORD:?Set POSTGRES_PASSWORD (PostgreSQL user password)}"
+export POSTGRES_PASSWORD
+export ADMIN_EMAIL="${ADMIN_EMAIL:-admin@sub2api.local}"
+export ADMIN_PASSWORD="${ADMIN_PASSWORD:-}"
+export BIND_HOST="${BIND_HOST:-0.0.0.0}"
+export SERVER_PORT="${SERVER_PORT:-8080}"
+# Normal installs use DATABASE_HOST=postgres / REDIS_HOST=redis (Docker DNS).
+# On hosts where in-container DNS fails, set DATABASE_HOST=REDIS_HOST=host.docker.internal (requires postgres/redis ports published on 0.0.0.0 — see docker-compose.dev.yml defaults).
+
+COMPOSE=(docker compose -f "$DEPLOY/docker-compose.dev.yml")
+echo "==> Docker BUILD_CONTEXT=$BUILD_CONTEXT"
+
+echo "==> Stopping stack (if any)"
+"${COMPOSE[@]}" down 2>/dev/null || true
+
+echo "==> Removing local data dirs under deploy/"
+rm -rf "$DEPLOY/data" "$DEPLOY/postgres_data" "$DEPLOY/redis_data"
+mkdir -p "$DEPLOY/data"
+
+echo "==> Building and starting (this may take several minutes)"
+"${COMPOSE[@]}" --project-directory "$DEPLOY" up --build -d
+
+echo ""
+echo "Stack started. Admin UI (embedded): http://${BIND_HOST:-127.0.0.1}:${SERVER_PORT:-8080}/"
+echo "  ADMIN_EMAIL=$ADMIN_EMAIL"
+if [[ -n "${ADMIN_PASSWORD}" ]]; then
+  echo "  ADMIN_PASSWORD=(from env, fixed)"
+else
+  echo "  ADMIN_PASSWORD=(auto-generated on first install — run: docker compose -f deploy/docker-compose.dev.yml logs sub2api | grep -i password)"
+fi

--- a/scripts/deploy-dev-reset.sh
+++ b/scripts/deploy-dev-reset.sh
@@ -1,56 +1,37 @@
 #!/usr/bin/env bash
-# 清空 deploy 本地数据目录并以 docker-compose.dev.yml 重新构建启动。
-# Docker 构建上下文为「包含 sub2api 与 new-api 的父目录」：请在本机保证存在
-#   /path/to/parent/sub2api   （或指向仓库根的符号链接 sub2api）
-#   /path/to/parent/new-api   （与 backend/go.mod replace 一致）
+# Wipe deploy-local volumes and bring stack back with docker-compose.dev.yml (see deploy/README.md).
+# Requires sibling ../new-api next to repo root for Docker build (Dockerfile header).
 #
-# 用法（在仓库根目录）：
-#   POSTGRES_PASSWORD='your_pg' ADMIN_EMAIL='a@b.c' ADMIN_PASSWORD='secret' bash scripts/deploy-dev-reset.sh
+#   POSTGRES_PASSWORD='…' ADMIN_EMAIL='…' ADMIN_PASSWORD='…' bash scripts/deploy-dev-reset.sh
 #
-# 未设置 ADMIN_PASSWORD 时首次启动会随机生成并在容器日志中打印一次（见 deploy/README.md）。
+# If ADMIN_PASSWORD is empty, first-boot prints a one-time password in container logs.
 set -euo pipefail
 
 ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
 DEPLOY="$ROOT/deploy"
 
-# Docker build context: directory that contains `sub2api/` + `new-api/` subdirs (Dockerfile COPY paths).
-# Auto-pick /tk when present (symlink layout used in some sandboxes); else repo parent's parent.
-if [[ -z "${BUILD_CONTEXT:-}" ]]; then
-  if [[ -d /tk/sub2api && -d /tk/new-api ]]; then
-    BUILD_CONTEXT=/tk
-  else
-    BUILD_CONTEXT="$(cd "$DEPLOY/../.." && pwd)"
-  fi
-fi
-export BUILD_CONTEXT
-
-POSTGRES_PASSWORD="${POSTGRES_PASSWORD:?Set POSTGRES_PASSWORD (PostgreSQL user password)}"
+POSTGRES_PASSWORD="${POSTGRES_PASSWORD:?Set POSTGRES_PASSWORD}"
 export POSTGRES_PASSWORD
 export ADMIN_EMAIL="${ADMIN_EMAIL:-admin@sub2api.local}"
 export ADMIN_PASSWORD="${ADMIN_PASSWORD:-}"
-export BIND_HOST="${BIND_HOST:-0.0.0.0}"
-export SERVER_PORT="${SERVER_PORT:-8080}"
-# Normal installs use DATABASE_HOST=postgres / REDIS_HOST=redis (Docker DNS).
-# On hosts where in-container DNS fails, set DATABASE_HOST=REDIS_HOST=host.docker.internal (requires postgres/redis ports published on 0.0.0.0 — see docker-compose.dev.yml defaults).
 
-COMPOSE=(docker compose -f "$DEPLOY/docker-compose.dev.yml")
-echo "==> Docker BUILD_CONTEXT=$BUILD_CONTEXT"
+COMPOSE=(docker compose -f docker-compose.dev.yml)
 
 echo "==> Stopping stack (if any)"
-"${COMPOSE[@]}" down 2>/dev/null || true
+(cd "$DEPLOY" && "${COMPOSE[@]}" down) 2>/dev/null || true
 
-echo "==> Removing local data dirs under deploy/"
+echo "==> Removing deploy/data deploy/postgres_data deploy/redis_data"
 rm -rf "$DEPLOY/data" "$DEPLOY/postgres_data" "$DEPLOY/redis_data"
 mkdir -p "$DEPLOY/data"
 
-echo "==> Building and starting (this may take several minutes)"
-"${COMPOSE[@]}" --project-directory "$DEPLOY" up --build -d
+echo "==> docker compose up --build -d"
+(cd "$DEPLOY" && "${COMPOSE[@]}" up --build -d)
 
 echo ""
-echo "Stack started. Admin UI (embedded): http://${BIND_HOST:-127.0.0.1}:${SERVER_PORT:-8080}/"
+echo "Open: http://${BIND_HOST:-127.0.0.1}:${SERVER_PORT:-8080}/"
 echo "  ADMIN_EMAIL=$ADMIN_EMAIL"
 if [[ -n "${ADMIN_PASSWORD}" ]]; then
-  echo "  ADMIN_PASSWORD=(from env, fixed)"
+  echo "  (password from ADMIN_PASSWORD env)"
 else
-  echo "  ADMIN_PASSWORD=(auto-generated on first install — run: docker compose -f deploy/docker-compose.dev.yml logs sub2api | grep -i password)"
+  echo "  (check generated password: cd deploy && docker compose -f docker-compose.dev.yml logs sub2api | grep -i password)"
 fi


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary
- **UI（Jobs）：** 将 Extension Engine（newapi）的 `AccountNewApiPlatformFields` 挪到平台分段控件正下方，避免滚过长表单才看到「渠道类型」；注释压到一行，减少与 upstream 大块 Vue 的合并噪音。
- **测试（OPC）：** `CreateAccountModal.newapi.spec.ts` 增加一条行为断言（切换 NewAPI 后立即出现 channel type 文案键）。
- **运维脚本（OPC）：** 新增精简版 `scripts/deploy-dev-reset.sh`——只做 `deploy/` 三目录清空 + `docker compose -f deploy/docker-compose.dev.yml up --build -d`，**不修改** `deploy/docker-compose.dev.yml`（与 `main` 零 diff），避免上游合并冲突与非必要默认暴露端口。

## Risk
低：仅模板顺序 + 单测；compose 文件未改。

## Validation
- `./scripts/preflight.sh`
- `pnpm exec vitest run src/components/account/__tests__/CreateAccountModal.newapi.spec.ts`

## 清空数据并重置（本机）
```bash
POSTGRES_PASSWORD='…' ADMIN_EMAIL='…' ADMIN_PASSWORD='…' bash scripts/deploy-dev-reset.sh
```
若未设 `ADMIN_PASSWORD`，首次启动随机密码见 `deploy` 目录下 compose 日志（与 `deploy/README.md` 一致）。
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-bb7b28a6-085b-40e0-8d25-f6befc136247"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-bb7b28a6-085b-40e0-8d25-f6befc136247"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

