### PR TITLE
Harden QA redaction and shorten JWT sessions

### DIFF
--- a/backend/ent/migrate/schema.go
+++ b/backend/ent/migrate/schema.go
@@ -1141,7 +1141,7 @@ var (
 		{Name: "request_blob_uri", Type: field.TypeString, Nullable: true},
 		{Name: "response_blob_uri", Type: field.TypeString, Nullable: true},
 		{Name: "stream_blob_uri", Type: field.TypeString, Nullable: true},
-		{Name: "redaction_version", Type: field.TypeString, Default: "logredact"},
+		{Name: "redaction_version", Type: field.TypeString, Default: "logredact-v2"},
 		{Name: "capture_status", Type: field.TypeString, Default: "captured"},
 		{Name: "tags", Type: field.TypeJSON},
 		{Name: "synth_session_id", Type: field.TypeString, Nullable: true},

--- a/backend/ent/schema/qa_record.go
+++ b/backend/ent/schema/qa_record.go
@@ -52,7 +52,7 @@ func (QARecord) Fields() []ent.Field {
 		field.String("request_blob_uri").Optional().Nillable(),
 		field.String("response_blob_uri").Optional().Nillable(),
 		field.String("stream_blob_uri").Optional().Nillable(),
-		field.String("redaction_version").Default("logredact"),
+		field.String("redaction_version").Default("logredact-v2"),
 		field.String("capture_status").Default("captured"),
 		field.JSON("tags", []string{}).Default([]string{}),
 		// Synthetic-pipeline tagging (issue #59 / docs/projects/auto-traj-from-supply-demand.md §6.1).

--- a/backend/internal/config/config.go
+++ b/backend/internal/config/config.go
@@ -1555,7 +1555,7 @@ func setDefaults() {
 
 	// JWT
 	viper.SetDefault("jwt.secret", "")
-	viper.SetDefault("jwt.expire_hour", 24)
+	viper.SetDefault("jwt.expire_hour", 1)
 	viper.SetDefault("jwt.access_token_expire_minutes", 0) // 0 表示回退到 expire_hour
 	viper.SetDefault("jwt.refresh_token_expire_days", 30)  // 30天Refresh Token有效期
 	viper.SetDefault("jwt.refresh_window_minutes", 2)      // 过期前2分钟开始允许刷新

--- a/backend/internal/config/config_test.go
+++ b/backend/internal/config/config_test.go
@@ -332,8 +332,8 @@ func TestLoadDefaultJWTAccessTokenExpireMinutes(t *testing.T) {
 		t.Fatalf("Load() error: %v", err)
 	}
 
-	if cfg.JWT.ExpireHour != 24 {
-		t.Fatalf("JWT.ExpireHour = %d, want 24", cfg.JWT.ExpireHour)
+	if cfg.JWT.ExpireHour != 1 {
+		t.Fatalf("JWT.ExpireHour = %d, want 1", cfg.JWT.ExpireHour)
 	}
 	if cfg.JWT.AccessTokenExpireMinutes != 0 {
 		t.Fatalf("JWT.AccessTokenExpireMinutes = %d, want 0", cfg.JWT.AccessTokenExpireMinutes)

--- a/backend/internal/handler/payment_webhook_handler.go
+++ b/backend/internal/handler/payment_webhook_handler.go
@@ -12,6 +12,7 @@ import (
 
 	"github.com/Wei-Shaw/sub2api/internal/payment"
 	"github.com/Wei-Shaw/sub2api/internal/service"
+	"github.com/Wei-Shaw/sub2api/internal/util/logredact"
 
 	"github.com/gin-gonic/gin"
 )
@@ -102,6 +103,7 @@ func (h *PaymentWebhookHandler) handleNotify(c *gin.Context, providerKey string)
 		if len(truncatedBody) > webhookLogTruncateLen {
 			truncatedBody = truncatedBody[:webhookLogTruncateLen] + "...(truncated)"
 		}
+		truncatedBody = logredact.RedactText(truncatedBody)
 		slog.Error("[Payment Webhook] verify failed", "provider", providerKey, "error", err, "method", c.Request.Method, "bodyLen", len(rawBody))
 		slog.Debug("[Payment Webhook] verify failed body", "provider", providerKey, "rawBody", truncatedBody)
 		c.String(http.StatusBadRequest, "verify failed")

--- a/backend/internal/observability/qa/service.go
+++ b/backend/internal/observability/qa/service.go
@@ -52,7 +52,7 @@ var (
 )
 
 const (
-	qaRedactionVersion               = "logredact"
+	qaRedactionVersion               = "logredact-v2"
 	captureStatusCaptured            = "captured"
 	qaCaptureStatusCapturedToDLQ     = "captured_dlq"
 	qaCapturePersistModeAsync        = "async"
@@ -555,7 +555,7 @@ func (s *Service) buildBlob(input CaptureInput) ([]byte, string, string, []strin
 		"stream": map[string]any{
 			"chunks": chunks,
 		},
-		"redactions": []string{"logredact"},
+		"redactions": []string{"logredact-v2"},
 	}
 	raw, err := json.Marshal(payload)
 	if err != nil {

--- a/backend/internal/observability/qa/service_export_test.go
+++ b/backend/internal/observability/qa/service_export_test.go
@@ -407,7 +407,7 @@ func TestUS070_PersistCapture_WritesExtendedMetadata(t *testing.T) {
 		RequestBlobURI:   "",
 		ResponseBlobURI:  "",
 		StreamBlobURI:    "",
-		RedactionVersion: "logredact",
+		RedactionVersion: "logredact-v2",
 		CaptureStatus:    "captured",
 		CreatedAt:        createdAt,
 	})
@@ -431,7 +431,7 @@ func TestUS070_PersistCapture_WritesExtendedMetadata(t *testing.T) {
 	require.True(t, record.Success)
 	require.NotNil(t, record.FirstTokenMs)
 	require.Equal(t, firstTokenMs, *record.FirstTokenMs)
-	require.Equal(t, "logredact", record.RedactionVersion)
+	require.Equal(t, "logredact-v2", record.RedactionVersion)
 	require.Equal(t, "captured", record.CaptureStatus)
 	require.NotNil(t, record.BlobURI)
 	require.NotNil(t, record.RequestBlobURI)

--- a/backend/internal/setup/setup.go
+++ b/backend/internal/setup/setup.go
@@ -571,7 +571,7 @@ func AutoSetupFromEnv() error {
 		},
 		JWT: JWTConfig{
 			Secret:     getEnvOrDefault("JWT_SECRET", ""),
-			ExpireHour: getEnvIntOrDefault("JWT_EXPIRE_HOUR", 24),
+			ExpireHour: getEnvIntOrDefault("JWT_EXPIRE_HOUR", 1),
 		},
 		Timezone: tz,
 	}

--- a/backend/internal/util/logredact/redact.go
+++ b/backend/internal/util/logredact/redact.go
@@ -12,25 +12,111 @@ import (
 const maxRedactDepth = 32
 
 var defaultSensitiveKeys = map[string]struct{}{
-	"authorization_code": {},
-	"code":               {},
-	"code_verifier":      {},
-	"access_token":       {},
-	"refresh_token":      {},
-	"id_token":           {},
-	"client_secret":      {},
-	"password":           {},
+	"authorization":         {},
+	"proxy-authorization":   {},
+	"x-api-key":             {},
+	"api-key":               {},
+	"api_key":               {},
+	"apikey":                {},
+	"authorization_code":    {},
+	"code":                  {},
+	"code_verifier":         {},
+	"access_token":          {},
+	"refresh_token":         {},
+	"id_token":              {},
+	"session_token":         {},
+	"bearer_token":          {},
+	"token":                 {},
+	"jwt":                   {},
+	"password":              {},
+	"passwd":                {},
+	"passphrase":            {},
+	"secret":                {},
+	"client_secret":         {},
+	"private_key":           {},
+	"accesskeyid":           {},
+	"secretaccesskey":       {},
+	"aws_access_key_id":     {},
+	"aws_secret_access_key": {},
+	"cookie":                {},
+	"set-cookie":            {},
+	"credential":            {},
+	"credentials":           {},
+	"signature":             {},
 }
 
 var defaultSensitiveKeyList = []string{
 	"access_token",
+	"accesskeyid",
+	"api-key",
+	"api_key",
+	"apikey",
+	"authorization",
 	"authorization_code",
+	"aws_access_key_id",
+	"aws_secret_access_key",
+	"bearer_token",
 	"client_secret",
 	"code",
 	"code_verifier",
+	"cookie",
+	"credential",
+	"credentials",
 	"id_token",
+	"jwt",
+	"passphrase",
+	"passwd",
 	"password",
+	"private_key",
+	"proxy-authorization",
 	"refresh_token",
+	"secret",
+	"secretaccesskey",
+	"session_token",
+	"set-cookie",
+	"signature",
+	"token",
+	"x-api-key",
+}
+
+var defaultSensitiveKeySuffixes = []string{
+	"_api_key",
+	"-api-key",
+	"_secret",
+	"-secret",
+	"_token",
+	"-token",
+	"_password",
+	"-password",
+	"_passwd",
+	"-passwd",
+	"_passphrase",
+	"-passphrase",
+	"_private_key",
+	"-private-key",
+	"_credential",
+	"-credential",
+	"_credentials",
+	"-credentials",
+	"_signature",
+	"-signature",
+}
+
+var defaultNonCredentialKeys = map[string]struct{}{
+	"max_tokens":                  {},
+	"max_output_tokens":           {},
+	"max_input_tokens":            {},
+	"max_completion_tokens":       {},
+	"max_tokens_to_sample":        {},
+	"budget_tokens":               {},
+	"prompt_tokens":               {},
+	"completion_tokens":           {},
+	"input_tokens":                {},
+	"output_tokens":               {},
+	"total_tokens":                {},
+	"token_count":                 {},
+	"cache_creation_input_tokens": {},
+	"cache_read_input_tokens":     {},
 }
 
 type textRedactPatterns struct {
@@ -223,8 +309,19 @@ func redactValueWithDepth(value any, keys map[string]struct{}, depth int) any {
 }
 
 func isSensitiveKey(key string, keys map[string]struct{}) bool {
-	_, ok := keys[normalizeKey(key)]
-	return ok
+	normalized := normalizeKey(key)
+	if _, ok := defaultNonCredentialKeys[normalized]; ok {
+		return false
+	}
+	if _, ok := keys[normalized]; ok {
+		return true
+	}
+	for _, suffix := range defaultSensitiveKeySuffixes {
+		if strings.HasSuffix(normalized, suffix) {
+			return true
+		}
+	}
+	return false
 }
 
 func normalizeKey(key string) string {

--- a/backend/internal/util/logredact/redact_test.go
+++ b/backend/internal/util/logredact/redact_test.go
@@ -67,6 +67,32 @@ func TestRedactText_DefaultPathDoesNotUseExtraCache(t *testing.T) {
 	}
 }
 
+func TestRedactJSON_CredentialKeys(t *testing.T) {
+	in := []byte(`{"authorization":"Bearer sk-live","x-api-key":"tk-key","cookie":"sid=abc","tool":{"name":"web_search","arguments":{"query":"token pricing","api_key":"secret"}},"usage":{"prompt_tokens":12,"completion_tokens":3}}`)
+	out := RedactJSON(in)
+
+	for _, leaked := range []string{"sk-live", "tk-key", "sid=abc", "secret"} {
+		if strings.Contains(out, leaked) {
+			t.Fatalf("expected %q redacted, got %q", leaked, out)
+		}
+	}
+	for _, preserved := range []string{"web_search", "token pricing", `"prompt_tokens":12`, `"completion_tokens":3`} {
+		if !strings.Contains(out, preserved) {
+			t.Fatalf("expected %q preserved, got %q", preserved, out)
+		}
+	}
+}
+
+func TestRedactJSON_SuffixKeys(t *testing.T) {
+	out := RedactJSON([]byte(`{"stripe_signature":"sig-value","customer_password":"pw-value","max_tokens":1024}`))
+	if strings.Contains(out, "sig-value") || strings.Contains(out, "pw-value") {
+		t.Fatalf("expected suffix credential keys redacted, got %q", out)
+	}
+	if !strings.Contains(out, `"max_tokens":1024`) {
+		t.Fatalf("expected max_tokens preserved, got %q", out)
+	}
+}
+
 func clearExtraTextPatternCache() {
 	extraTextPatternCache.Range(func(key, value any) bool {
 		extraTextPatternCache.Delete(key)

--- a/deploy/.env.example
+++ b/deploy/.env.example
@@ -189,7 +189,7 @@ ADMIN_PASSWORD=
 # be generated on each startup, causing all users to be logged out.
 # Generate a secure secret: openssl rand -hex 32
 JWT_SECRET=
-JWT_EXPIRE_HOUR=24
+JWT_EXPIRE_HOUR=1
 # Access Token 有效期（分钟）
 # 优先级说明：
 # - >0: 按分钟生效（优先于 JWT_EXPIRE_HOUR）

--- a/deploy/aws/cloudformation/stage0-single-ec2.yaml
+++ b/deploy/aws/cloudformation/stage0-single-ec2.yaml
@@ -439,7 +439,7 @@ Resources:
           ADMIN_EMAIL=${!ADMIN_EMAIL}
           ADMIN_PASSWORD=
           JWT_SECRET=${!JWT_SECRET}
-          JWT_EXPIRE_HOUR=24
+          JWT_EXPIRE_HOUR=1
           TOTP_ENCRYPTION_KEY=${!TOTP_ENCRYPTION_KEY}
           ENVEOF
           chmod 0600 /var/lib/tokenkey/.env

--- a/deploy/aws/stage0/.env.example
+++ b/deploy/aws/stage0/.env.example
@@ -42,5 +42,5 @@ ADMIN_PASSWORD=
 # JWT / TOTP（必须固定值，否则重启后所有登录态/2FA 失效）
 # 生成命令：openssl rand -hex 32
 JWT_SECRET=
-JWT_EXPIRE_HOUR=24
+JWT_EXPIRE_HOUR=1
 TOTP_ENCRYPTION_KEY=

--- a/deploy/aws/stage0/docker-compose.yml
+++ b/deploy/aws/stage0/docker-compose.yml
@@ -66,7 +66,7 @@ services:
       - ADMIN_EMAIL=${ADMIN_EMAIL:-admin@tokenkey.local}
       - ADMIN_PASSWORD=${ADMIN_PASSWORD:-}
       - JWT_SECRET=${JWT_SECRET:?JWT_SECRET is required (openssl rand -hex 32)}
-      - JWT_EXPIRE_HOUR=${JWT_EXPIRE_HOUR:-24}
+      - JWT_EXPIRE_HOUR=${JWT_EXPIRE_HOUR:-1}
       - TOTP_ENCRYPTION_KEY=${TOTP_ENCRYPTION_KEY:?TOTP_ENCRYPTION_KEY is required (openssl rand -hex 32)}
       - TZ=${TZ:-UTC}
     depends_on:

--- a/deploy/config.example.yaml
+++ b/deploy/config.example.yaml
@@ -799,7 +799,7 @@ jwt:
   secret: "change-this-to-a-secure-random-string"
   # Token expiration time in hours (max 168)
   # 令牌过期时间（小时，最大 168）
-  expire_hour: 24
+  expire_hour: 1
   # Access Token 过期时间（分钟）
   # 优先级说明：
   # - >0: 按分钟生效（优先于 expire_hour）

--- a/deploy/docker-compose.local.yml
+++ b/deploy/docker-compose.local.yml
@@ -92,7 +92,7 @@ services:
       # will be generated on each startup.
       # Generate a secure secret: openssl rand -hex 32
       - JWT_SECRET=${JWT_SECRET:-}
-      - JWT_EXPIRE_HOUR=${JWT_EXPIRE_HOUR:-24}
+      - JWT_EXPIRE_HOUR=${JWT_EXPIRE_HOUR:-1}
 
       # =======================================================================
       # TOTP (2FA) Configuration

--- a/deploy/docker-compose.standalone.yml
+++ b/deploy/docker-compose.standalone.yml
@@ -74,7 +74,7 @@ services:
       # JWT Configuration
       # =======================================================================
       - JWT_SECRET=${JWT_SECRET:-}
-      - JWT_EXPIRE_HOUR=${JWT_EXPIRE_HOUR:-24}
+      - JWT_EXPIRE_HOUR=${JWT_EXPIRE_HOUR:-1}
 
       # =======================================================================
       # Timezone Configuration

--- a/deploy/docker-compose.yml
+++ b/deploy/docker-compose.yml
@@ -88,7 +88,7 @@ services:
       # will be generated on each startup.
       # Generate a secure secret: openssl rand -hex 32
       - JWT_SECRET=${JWT_SECRET:-}
-      - JWT_EXPIRE_HOUR=${JWT_EXPIRE_HOUR:-24}
+      - JWT_EXPIRE_HOUR=${JWT_EXPIRE_HOUR:-1}
 
       # =======================================================================
       # TOTP (2FA) Configuration

--- a/docs/ops/tokenkey-prod-qa-export-partner-manual.md
+++ b/docs/ops/tokenkey-prod-qa-export-partner-manual.md
@@ -1,0 +1,148 @@
+# TokenKey 生产环境 QA 全量导出与清理（运营合伙人简版）
+
+适用对象：需在 **AWS prod（Stage-0）** 做 **QA  trajectory 数据** 全量备份、随后在云上 **释放 PG 与磁盘占用** 的 TokenKey 运营合伙人。  
+技术细节与风险见 `deploy/aws/README.md` 中「Prod QA 全量导出与清理」一节。
+
+---
+
+## 你将得到什么
+
+- **全量 QA**：表 `qa_records` 的 JSON Lines 导出 + 磁盘上 **`qa_blobs`** 整树（含捕获的请求/响应/流式片段等；**正文为已脱敏、`logredact` 处理后的可分析内容**，适用于含 tools 的 JSON 请求体等）。
+- **云上清理（可选但通常需要）**：清空 `qa_records`、清空 **`/var/lib/tokenkey/app/qa_blobs`**（及必要时 `qa_dlq`），并删除用于传递 tar 包的 **S3 暂存对象**，避免 prod EBS 与 staging 桶长期占用。
+
+说明：**未脱敏的原始请求**不会出现在本管道中；若业务上需要，须另议其他渠道，**不在本文范围**。
+
+---
+
+## 前置条件
+
+| 条件 | 说明 |
+|------|------|
+| AWS 权限 | 能对 prod 实例做 **SSM Run Command**（`ssm:SendCommand` / `GetCommandInvocation`）；能对 **staging 桶**做 **GetObject + PutObject**（用于预签名上传/本机下载）。 |
+| 工具 | 本机已装 `aws`、`jq`、`curl`、`python3`；可选 `zstd`（读 blob）。 |
+| Staging 桶 | 环境变量 **`QA_DUMP_S3_BUCKET`** 指向**专用或共用的私有桶**（仅作 tar 中转，用完脚本会删对象）。**桶名属基础设施配置**，由团队提供；若未设置，脚本会报错退出。 |
+| 时间窗口 | TRUNCATE `qa_records` 会短暂锁表；建议在**低峰**操作。清理前确保**已有一份校验通过的本地导出**。 |
+
+---
+
+## 一次性配置（本机 shell）
+
+```bash
+export AWS_REGION=us-east-1
+export QA_DUMP_S3_BUCKET="<由团队提供的 staging 桶名>"
+# 可选：导出落盘目录（默认 ./.dump_trajs），建议带日期便于区分
+export OUT_DIR="./.dump_trajs/prod-export-$(date -u +%Y%m%d)"
+```
+
+---
+
+## 只做「全量导出」（不删云上数据）
+
+脚本：`scripts/fetch-prod-qa-dump.sh`
+
+```bash
+bash scripts/fetch-prod-qa-dump.sh
+```
+
+流程摘要：经 SSM 在 prod 实例打包 → 预签名 **PUT** 到 `QA_DUMP_S3_BUCKET` → 本机 **下载并解压** → 生成 **`$OUT_DIR/.last-prod-qa-export.json`**（行数、校验和、时间戳等）。
+
+自检（不连 AWS 跑逻辑，只检工具与变量）：
+
+```bash
+bash scripts/fetch-prod-qa-dump.sh --check
+```
+
+---
+
+## 「导出 + 清理云上占用」（推荐用于释放 prod 资源）
+
+脚本：`scripts/prod-qa-export-and-purge.sh`
+
+该脚本顺序为：**先完整导出并本地校验** → （可选行数门禁）→ **远端 TRUNCATE + 清空 blob 目录** → **删除 S3 暂存 tar**。破坏性步骤前必须有合法确认串。
+
+### 演练（不删库、不删盘、不删 S3）
+
+用于确认本机与权限无误；仍会执行**完整导出**（与线上读一致）。
+
+```bash
+export PROD_QA_PURGE_CONFIRM=yes-delete-prod-qa-data
+export PROD_QA_PURGE_DRY_RUN=1   # 或使用参数 --dry-run
+bash scripts/prod-qa-export-and-purge.sh --dry-run
+```
+
+结束时日志会出现 **dry-run: skipping remote purge**，且 **不会** TRUNCATE。
+
+### 真实清理（会永久删除 prod 侧 QA 数据）
+
+1. 确认 **`unset PROD_QA_PURGE_DRY_RUN`**（环境中若曾设为 `1`，会导致误跑演练）。
+2. **`PROD_QA_PURGE_CONFIRM`** 必须为字面 **`yes-delete-prod-qa-data`**。
+3. 建议使用 **`PURGE_MAX_EXTRA_ROWS=0`**：在清空前再拉一次 prod 行数，与导出 manifest 行数对齐，避免「导出快照后有新写入却被删掉」的窗口问题。
+
+```bash
+unset PROD_QA_PURGE_DRY_RUN
+export PROD_QA_PURGE_CONFIRM=yes-delete-prod-qa-data
+export QA_DUMP_S3_BUCKET="<staging 桶>"
+export OUT_DIR="./.dump_trajs/prod-export-$(date -u +%Y%m%d)"
+export PURGE_MAX_EXTRA_ROWS=0
+# 若希望保留解压后同目录下的 .tar.gz 副本：
+export KEEP_LOCAL_TAR_AFTER_PURGE=1
+
+bash scripts/prod-qa-export-and-purge.sh
+```
+
+成功时日志中应出现 **`purge_ok`**，并提示已删除 S3 暂存对象。若任一步失败，**以脚本退出码与日志为准**，不要假设 prod 已清空或本地已完整。
+
+---
+
+## 本地导出目录里有什么
+
+以 **`$OUT_DIR`** 为根目录（例如 `.dump_trajs/prod-export-20260428/`）。
+
+| 路径 / 文件 | 含义 |
+|---------------|------|
+| **`.last-prod-qa-export.json`** | **以该文件为准**：对应哪次 tar、时间戳、`qa_records` 行数、本地 blob 文件数、校验和等。同一目录下若留有多个 `tokenkey-qa-dump-*Z.tar.gz`，**与 manifest 里 `tarball` 字段一致的那份**为与当前 `metadata/` / `qa_blobs/` 匹配的一次导出。 |
+| **`metadata/qa_records.jsonl`** | 每张表行一条 JSON；含 `request_id`、`inbound_endpoint`、`tool_calls_present`、各类 **`*_blob_uri`** 等。**不含**完整对话正文（正文在 blob）。 |
+| **`qa_blobs/YYYY/MM/DD/<2 字符>/<request_id>.json.zst`** | **线上自动捕获写入的 blob**：路径按「捕获日期 + request_id」组织；内容为 **zstd 压缩 JSON**。 |
+| **`qa_blobs/exports/<user_id>/<nanos>.zip`** | **用户自助导出**生成的 zip（与上面「按日上链式」的捕获 **不是同一批文件的两种摆法**）。 |
+| **`qa_blobs/traj-exports/...`** | **轨迹专项导出** zip（若存在）。 |
+
+---
+
+## 如何阅读「人类可读的脱敏 QA」（含 tools）
+
+1. **在 `qa_records.jsonl` 中找到目标请求**（如按 `request_id`、时间、`tool_calls_present` 等筛选）。
+2. 根据 **`blob_uri` / `request_blob_uri` / `response_blob_uri` / `stream_blob_uri`** 定位 **`qa_blobs/` 下同名相对路径** 的 **`*.json.zst`**。
+3. **解压为 JSON** 后浏览（需已安装 `zstd`/`zstd-cli`）：
+
+```bash
+zstd -dc qa_blobs/2026/04/28/ab/<request_id>.json.zst | jq .
+```
+
+关注点（均为 **已脱敏** 字段）：
+
+- **`request.body`**：脱敏后的请求体；OpenAI 兼容形态下 **tools** 等多在此。
+- **`response.body`**：脱敏后的响应体。
+- **`stream.chunks[].raw_b64`**：流式分段，需 **base64 解码** 后为可读片段。
+
+ **`metadata/qa_records.jsonl` 单行只能看元数据；要看 tools / 正文，必须解压对应 `.json.zst`。**
+
+---
+
+## 清单（发同事前自检）
+
+- [ ] `QA_DUMP_S3_BUCKET` 已配置且本账号可读写 staging。
+- [ ] AWS 能通过 SSM 连上 prod 实例。
+- [ ] 若执行清理：**已 dry-run 或已书面确认**，且真实跑前 **`unset PROD_QA_PURGE_DRY_RUN`**。
+- [ ] 清理后抽查：`.last-prod-qa-export.json` 与磁盘上的 `qa_records.jsonl` / `qa_blobs` 是否一致；业务上按需再验证 prod。
+
+---
+
+## 脚本与权威文档索引
+
+| 资源 | 路径 |
+|------|------|
+| 仅导出 | `scripts/fetch-prod-qa-dump.sh` |
+| 导出 + 清理 | `scripts/prod-qa-export-and-purge.sh` |
+| AWS 侧说明与迁移注意 | `deploy/aws/README.md`（Prod QA 小节） |
+
+本文仅服务运营合伙人日常操作；**发版 / 镜像部署**与本文无关，请参阅 `deploy/aws/README.md` 中升级与 release 章节。

--- a/scripts/redaction-sentinels.json
+++ b/scripts/redaction-sentinels.json
@@ -1,7 +1,7 @@
 {
-  "version": 1,
+  "version": 2,
   "rationale": "Snapshot of the default sensitive-key set plus the outward redaction version contract. If the sensitive-key set changes, bump redaction_version in the evidence-writing path and schema default in the same commit so existing QA records remain interpretable.",
-  "redaction_version": "logredact",
+  "redaction_version": "logredact-v2",
   "keys_source": "backend/internal/util/logredact/redact.go",
   "version_sources": [
     "backend/internal/observability/qa/service.go",
@@ -9,12 +9,35 @@
   ],
   "sensitive_keys": [
     "access_token",
+    "accesskeyid",
+    "api-key",
+    "api_key",
+    "apikey",
+    "authorization",
     "authorization_code",
+    "aws_access_key_id",
+    "aws_secret_access_key",
+    "bearer_token",
     "client_secret",
     "code",
     "code_verifier",
+    "cookie",
+    "credential",
+    "credentials",
     "id_token",
+    "jwt",
+    "passphrase",
+    "passwd",
     "password",
-    "refresh_token"
+    "private_key",
+    "proxy-authorization",
+    "refresh_token",
+    "secret",
+    "secretaccesskey",
+    "session_token",
+    "set-cookie",
+    "signature",
+    "token",
+    "x-api-key"
   ]
 }


### PR DESCRIPTION
## Summary
- Broaden shared QA/log redaction for credential-shaped fields while preserving tool names, tool queries, and token-usage semantics.
- Bump the QA redaction contract to `logredact-v2` and keep the sentinel registry plus Ent defaults aligned.
- Set new JWT expiry defaults to 1 hour across code, examples, AWS Stage-0, and Docker deploy entry points.
- Track the ops partner manual for prod QA export and cleanup.

## Risk
- Existing deployments with explicit `JWT_EXPIRE_HOUR` keep their configured value; new/default deployments use 1 hour.
- Redaction is stricter for credential-like JSON keys and suffixes, so exported QA evidence may contain more `***` placeholders for sensitive fields.
- `backend/config.yaml` is gitignored and not copied into the production image; AWS Stage-0 uses compose environment variables sourced from `/var/lib/tokenkey/.env`.

## Validation
- `cd backend && go test ./internal/util/logredact ./internal/handler ./internal/config ./internal/setup ./internal/observability/qa`
- `bash scripts/preflight.sh`

🤖 Generated with [Claude Code](https://claude.com/claude-code)