### PR TITLE
fix(admin): 扩展引擎添加账号凭据区在短视口内可滚动

### DIFF
--- a/frontend/src/components/account/CreateAccountModal.vue
+++ b/frontend/src/components/account/CreateAccountModal.vue
@@ -168,28 +168,39 @@
         </div>
       </div>
 
-      <!-- newapi: channel fields directly under platform picker (avoid scrolling past other platforms). -->
-      <div v-if="form.platform === 'newapi'" class="space-y-4">
-        <AccountNewApiPlatformFields
-          v-model:channelType="newapiChannelType"
-          v-model:baseUrl="newapiBaseUrl"
-          v-model:apiKey="newapiApiKey"
-          v-model:modelMapping="newapiModelMapping"
-          v-model:statusCodeMapping="newapiStatusCodeMapping"
-          v-model:openaiOrganization="newapiOpenAIOrganization"
-          v-model:allowedModels="newapiAllowedModels"
-          v-model:modelMappings="newapiModelMappings"
-          v-model:restrictionMode="newapiRestrictionMode"
-          :channel-type-options="newapiChannelTypeOptions"
-          :channel-types-loading="newapiChannelTypesLoading"
-          :channel-types-error="newapiChannelTypesError"
-          :selected-channel-type-base-url="newapiSelectedBaseUrl"
-          :fetch-models-enabled="newapiFetchModelsEnabled"
-          :fetch-models-disabled="newapiFetchModelsDisabled"
-          :fetch-models-loading="newapiFetchModelsLoading"
-          variant="create"
-          @fetch-models="newapiHandleFetchUpstreamModels"
-        />
+      <!--
+        newapi: channel fields directly under platform picker (PR #97).
+        The block is tall (channel + URL + key + models + advanced). Without a local
+        scroll region, the first viewport can end at «配额控制» and look like the
+        credential fields vanished — regression seen on 1.7.x short viewports.
+      -->
+      <div
+        v-if="form.platform === 'newapi'"
+        class="max-h-[min(55vh,28rem)] overflow-y-auto overflow-x-hidden rounded-lg border border-cyan-200/60 bg-cyan-50/30 p-3 pr-2 dark:border-cyan-500/20 dark:bg-cyan-950/20"
+        data-testid="newapi-create-account-fields"
+      >
+        <div class="space-y-4 pr-1">
+          <AccountNewApiPlatformFields
+            v-model:channelType="newapiChannelType"
+            v-model:baseUrl="newapiBaseUrl"
+            v-model:apiKey="newapiApiKey"
+            v-model:modelMapping="newapiModelMapping"
+            v-model:statusCodeMapping="newapiStatusCodeMapping"
+            v-model:openaiOrganization="newapiOpenAIOrganization"
+            v-model:allowedModels="newapiAllowedModels"
+            v-model:modelMappings="newapiModelMappings"
+            v-model:restrictionMode="newapiRestrictionMode"
+            :channel-type-options="newapiChannelTypeOptions"
+            :channel-types-loading="newapiChannelTypesLoading"
+            :channel-types-error="newapiChannelTypesError"
+            :selected-channel-type-base-url="newapiSelectedBaseUrl"
+            :fetch-models-enabled="newapiFetchModelsEnabled"
+            :fetch-models-disabled="newapiFetchModelsDisabled"
+            :fetch-models-loading="newapiFetchModelsLoading"
+            variant="create"
+            @fetch-models="newapiHandleFetchUpstreamModels"
+          />
+        </div>
       </div>
 
       <!-- Account Type Selection (Anthropic) -->

--- a/frontend/src/components/account/CreateAccountModal.vue
+++ b/frontend/src/components/account/CreateAccountModal.vue
@@ -73,7 +73,7 @@
         <div class="mt-2 flex rounded-lg bg-gray-100 p-1 dark:bg-dark-700" data-tour="account-form-platform">
           <button
             type="button"
-            @click="form.platform = 'anthropic'"
+            @click="selectCreateAccountPlatform(GATEWAY_PLATFORMS[0])"
             :class="[
               'flex flex-1 items-center justify-center gap-2 rounded-md px-4 py-2.5 text-sm font-medium transition-all',
               form.platform === 'anthropic'
@@ -86,7 +86,7 @@
           </button>
           <button
             type="button"
-            @click="form.platform = 'openai'"
+            @click="selectCreateAccountPlatform(GATEWAY_PLATFORMS[1])"
             :class="[
               'flex flex-1 items-center justify-center gap-2 rounded-md px-4 py-2.5 text-sm font-medium transition-all',
               form.platform === 'openai'
@@ -111,7 +111,7 @@
           </button>
           <button
             type="button"
-            @click="form.platform = 'gemini'"
+            @click="selectCreateAccountPlatform(GATEWAY_PLATFORMS[2])"
             :class="[
               'flex flex-1 items-center justify-center gap-2 rounded-md px-4 py-2.5 text-sm font-medium transition-all',
               form.platform === 'gemini'
@@ -136,7 +136,7 @@
           </button>
           <button
             type="button"
-            @click="form.platform = 'antigravity'"
+            @click="selectCreateAccountPlatform(GATEWAY_PLATFORMS[3])"
             :class="[
               'flex flex-1 items-center justify-center gap-2 rounded-md px-4 py-2.5 text-sm font-medium transition-all',
               form.platform === 'antigravity'
@@ -154,7 +154,7 @@
           -->
           <button
             type="button"
-            @click="form.platform = 'newapi'"
+            @click="selectCreateAccountPlatform(GATEWAY_PLATFORMS[4])"
             :class="[
               'flex flex-1 items-center justify-center gap-2 rounded-md px-4 py-2.5 text-sm font-medium transition-all',
               form.platform === 'newapi'
@@ -168,18 +168,16 @@
         </div>
       </div>
 
-      <!--
-        newapi: channel fields directly under platform picker (PR #97).
-        The block is tall (channel + URL + key + models + advanced). Without a local
-        scroll region, the first viewport can end at «配额控制» and look like the
-        credential fields vanished — regression seen on 1.7.x short viewports.
-      -->
+      <!-- newapi: channel fields directly under platform picker (PR #97 + hardening). -->
       <div
-        v-if="form.platform === 'newapi'"
-        class="max-h-[min(55vh,28rem)] overflow-y-auto overflow-x-hidden rounded-lg border border-cyan-200/60 bg-cyan-50/30 p-3 pr-2 dark:border-cyan-500/20 dark:bg-cyan-950/20"
+        v-if="isExtensionEngineSelected"
+        class="min-h-[12rem] rounded-lg border border-cyan-200/60 bg-cyan-50/30 p-3 dark:border-cyan-500/20 dark:bg-cyan-950/20"
         data-testid="newapi-create-account-fields"
       >
-        <div class="space-y-4 pr-1">
+        <h3 class="mb-2 text-sm font-semibold text-cyan-800 dark:text-cyan-200">
+          {{ t('admin.accounts.newApiPlatform.credentialsSectionTitle') }}
+        </h3>
+        <div class="space-y-4">
           <AccountNewApiPlatformFields
             v-model:channelType="newapiChannelType"
             v-model:baseUrl="newapiBaseUrl"
@@ -3042,6 +3040,7 @@ import {
 import OAuthAuthorizationFlow from './OAuthAuthorizationFlow.vue'
 import AccountNewApiPlatformFields from './AccountNewApiPlatformFields.vue'
 import { useTkAccountNewApiPlatform } from '@/composables/useTkAccountNewApiPlatform'
+import { GATEWAY_PLATFORMS } from '@/constants/gatewayPlatforms'
 
 // Type for exposed OAuthAuthorizationFlow component
 // Note: defineExpose automatically unwraps refs, so we use the unwrapped types
@@ -3418,6 +3417,14 @@ const form = reactive({
   group_ids: [] as number[],
   expires_at: null as number | null
 })
+
+/** Single write path for platform selection — keeps `form.platform` aligned with `AccountPlatform`. */
+function selectCreateAccountPlatform(platform: AccountPlatform) {
+  form.platform = platform
+}
+
+/** v-if for Extension Engine block (alias for readability + one place to extend if needed). */
+const isExtensionEngineSelected = computed(() => form.platform === 'newapi')
 
 // Helper to check if current type needs OAuth flow
 const isOAuthFlow = computed(() => {

--- a/frontend/src/components/account/__tests__/CreateAccountModal.newapi.spec.ts
+++ b/frontend/src/components/account/__tests__/CreateAccountModal.newapi.spec.ts
@@ -160,11 +160,11 @@ describe('CreateAccountModal — NewAPI (5th platform)', () => {
     // Channel type selector must be present immediately (placed directly under the platform row).
     expect(wrapper.html()).toContain('admin.accounts.newApiPlatform.channelType')
 
-    // PR #97 follow-up: tall newapi block is wrapped in a scroll region so short viewports
-    // do not push credentials below the fold (looks like "no API key fields").
-    const scrollRegion = wrapper.find('[data-testid="newapi-create-account-fields"]')
-    expect(scrollRegion.exists()).toBe(true)
-    expect(scrollRegion.classes().join(' ')).toMatch(/overflow-y-auto/)
+    // Section chrome: visible title + test id so users never "lose" the credential block.
+    const region = wrapper.find('[data-testid="newapi-create-account-fields"]')
+    expect(region.exists()).toBe(true)
+    expect(wrapper.html()).toContain('admin.accounts.newApiPlatform.credentialsSectionTitle')
+    expect(region.classes().join(' ')).toMatch(/min-h-/)
 
     // The NewAPI fields block must render the structured model selector
     // (D4) — proves D1 succeeded (accountCategory was flipped → form.type='apikey'

--- a/frontend/src/components/account/__tests__/CreateAccountModal.newapi.spec.ts
+++ b/frontend/src/components/account/__tests__/CreateAccountModal.newapi.spec.ts
@@ -160,6 +160,12 @@ describe('CreateAccountModal — NewAPI (5th platform)', () => {
     // Channel type selector must be present immediately (placed directly under the platform row).
     expect(wrapper.html()).toContain('admin.accounts.newApiPlatform.channelType')
 
+    // PR #97 follow-up: tall newapi block is wrapped in a scroll region so short viewports
+    // do not push credentials below the fold (looks like "no API key fields").
+    const scrollRegion = wrapper.find('[data-testid="newapi-create-account-fields"]')
+    expect(scrollRegion.exists()).toBe(true)
+    expect(scrollRegion.classes().join(' ')).toMatch(/overflow-y-auto/)
+
     // The NewAPI fields block must render the structured model selector
     // (D4) — proves D1 succeeded (accountCategory was flipped → form.type='apikey'
     // → the structured selector inside AccountNewApiPlatformFields shows up

--- a/frontend/src/i18n/locales/en.ts
+++ b/frontend/src/i18n/locales/en.ts
@@ -3182,6 +3182,8 @@ export default {
         pleaseEnterApiKey: 'Please enter upstream API Key'
       },
       newApiPlatform: {
+        /** Create-account modal: section heading above channel/base URL/api key (must stay visible on all viewports). */
+        credentialsSectionTitle: 'Extension Engine — channel & credentials',
         channelType: 'Channel Type',
         channelTypePlaceholder: 'Select an Extension Engine channel type',
         channelTypeLoadFailed: 'Failed to load channel types, please retry',

--- a/frontend/src/i18n/locales/zh.ts
+++ b/frontend/src/i18n/locales/zh.ts
@@ -3322,6 +3322,8 @@ export default {
         pleaseEnterApiKey: '请输入上游 API Key'
       },
       newApiPlatform: {
+        /** Create-account modal: section heading above channel/base URL/api key (must stay visible on all viewports). */
+        credentialsSectionTitle: '扩展引擎 — 渠道与凭据',
         channelType: '渠道类型',
         channelTypePlaceholder: '请选择扩展引擎渠道类型',
         channelTypeLoadFailed: '加载渠道类型失败，请重试',


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

先前将问题仅归因于「首屏被挡住」在你**已滑到底仍找不到**渠道类型 / Base URL / API Key 等字段时并不成立，已撤回该结论。

本 PR 对 **添加账号 → Extension Engine** 路径做实质加固：

- **统一平台选择入口**：`selectCreateAccountPlatform(GATEWAY_PLATFORMS[i])` 单点写入 `form.platform`，避免分散 `form.platform = ...` 与未来类型/拼写漂移。
- **凭据区强可见**：在 `AccountNewApiPlatformFields` 上方增加独立章节标题（`admin.accounts.newApiPlatform.credentialsSectionTitle`）+ `data-testid="newapi-create-account-fields"` + `min-h`，即使用户认为「滑到底没有」，页面上也会有一整块带标题的扩展引擎凭据区域供对照。
- **去掉内层 `max-h` + 局部 overflow**：仅保留 `BaseDialog` 的 `modal-body` 滚动，避免嵌套滚动条/空白错觉。

## Delta

- `CreateAccountModal.vue`：平台按钮 + newapi 凭据容器调整；`isExtensionEngineSelected` 计算属性。
- `zh.ts` / `en.ts`：新增 `newApiPlatform.credentialsSectionTitle`。
- `CreateAccountModal.newapi.spec.ts`：更新对 `data-testid` 与章节标题的断言。

## Validation

- `pnpm exec vitest run src/components/account/__tests__/CreateAccountModal.newapi.spec.ts`
- `./scripts/preflight.sh`
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-8a1cdf34-97e8-4c79-ba6b-8239a5e909b9"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-8a1cdf34-97e8-4c79-ba6b-8239a5e909b9"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

