### PR TITLE
Enforce fresh embedded frontend assets

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -81,6 +81,11 @@ jobs:
         run: pnpm run build
         working-directory: frontend
 
+      - name: Verify frontend release assets
+        run: |
+          python3 scripts/check-frontend-dist-freshness.py --check backend/internal/web/dist
+          python3 scripts/check-frontend-release-assets.py --dist backend/internal/web/dist
+
       - name: Upload frontend artifact
         uses: actions/upload-artifact@v7
         with:
@@ -111,6 +116,11 @@ jobs:
         with:
           name: frontend-dist
           path: backend/internal/web/dist/
+
+      - name: Verify downloaded frontend artifact
+        run: |
+          python3 scripts/check-frontend-dist-freshness.py --check backend/internal/web/dist
+          python3 scripts/check-frontend-release-assets.py --dist backend/internal/web/dist
 
       - name: Setup Go
         uses: actions/setup-go@v6

--- a/.gitignore
+++ b/.gitignore
@@ -106,6 +106,7 @@ backend/internal/web/dist/
 !backend/internal/web/dist/
 backend/internal/web/dist/*
 !backend/internal/web/dist/.keep
+!backend/internal/web/dist/frontend-source.json
 
 # 后端运行时缓存数据
 backend/data/

--- a/.goreleaser.simple.yaml
+++ b/.goreleaser.simple.yaml
@@ -5,6 +5,8 @@ project_name: sub2api
 
 before:
   hooks:
+    - python3 scripts/check-frontend-dist-freshness.py --check backend/internal/web/dist
+    - python3 scripts/check-frontend-release-assets.py --dist backend/internal/web/dist
     - go mod tidy -C backend
 
 builds:

--- a/.goreleaser.yaml
+++ b/.goreleaser.yaml
@@ -4,6 +4,8 @@ project_name: sub2api
 
 before:
   hooks:
+    - python3 scripts/check-frontend-dist-freshness.py --check backend/internal/web/dist
+    - python3 scripts/check-frontend-release-assets.py --dist backend/internal/web/dist
     - go mod tidy -C backend
 
 builds:

--- a/Dockerfile
+++ b/Dockerfile
@@ -37,8 +37,8 @@ FROM ${NODE_IMAGE} AS frontend-builder
 
 WORKDIR /build/sub2api/frontend
 
-# Install pnpm
-RUN corepack enable && corepack prepare pnpm@latest --activate
+# Install pnpm and Python used by the frontend freshness manifest step
+RUN apk add --no-cache python3 && corepack enable && corepack prepare pnpm@latest --activate
 
 # Install dependencies first (better caching)
 COPY sub2api/frontend/package.json sub2api/frontend/pnpm-lock.yaml ./
@@ -46,6 +46,7 @@ RUN pnpm install --frozen-lockfile
 
 # Copy frontend source and build
 COPY sub2api/frontend/ ./
+COPY sub2api/scripts/check-frontend-dist-freshness.py /build/sub2api/scripts/check-frontend-dist-freshness.py
 RUN pnpm run build
 
 # -----------------------------------------------------------------------------

--- a/Makefile
+++ b/Makefile
@@ -9,7 +9,7 @@ FRONTEND_CRITICAL_VITEST := \
 	src/views/admin/__tests__/SettingsView.spec.ts
 
 # 一键编译前后端
-build: build-backend build-frontend
+build: build-frontend build-backend
 
 # 编译后端（复用 backend/Makefile）
 build-backend:

--- a/backend/internal/web/dist/frontend-source.json
+++ b/backend/internal/web/dist/frontend-source.json
@@ -1,0 +1,7 @@
+{
+  "algorithm": "sha256(path,size,content)",
+  "file_count": 410,
+  "hash": "6894aa2777296379449609003733a2b52281383b673d7767f37c6eda18cde804",
+  "schema": 1,
+  "source": "frontend/"
+}

--- a/backend/internal/web/dist/frontend-source.json
+++ b/backend/internal/web/dist/frontend-source.json
@@ -1,7 +1,7 @@
 {
-  "algorithm": "sha256(path,size,content)",
-  "file_count": 410,
-  "hash": "6894aa2777296379449609003733a2b52281383b673d7767f37c6eda18cde804",
+  "algorithm": "sha256(git-ls-files:path,size,content)",
+  "file_count": 406,
+  "hash": "59a1f022b6e7de05f0495aa2ee468af7bea03b365ec3e1512b5f0a131bf61e40",
   "schema": 1,
   "source": "frontend/"
 }

--- a/backend/internal/web/embed_test.go
+++ b/backend/internal/web/embed_test.go
@@ -573,6 +573,13 @@ func TestNewFrontendServer(t *testing.T) {
 	})
 }
 
+func TestEmbeddedFrontendDistFreshnessManifest(t *testing.T) {
+	manifest, err := frontendFS.ReadFile("dist/frontend-source.json")
+	require.NoError(t, err)
+	assert.Contains(t, string(manifest), `"source": "frontend/"`)
+	assert.Contains(t, string(manifest), `"algorithm": "sha256(path,size,content)"`)
+}
+
 func TestHasEmbeddedFrontend(t *testing.T) {
 	t.Run("returns_true_when_frontend_embedded", func(t *testing.T) {
 		result := HasEmbeddedFrontend()

--- a/backend/internal/web/embed_test.go
+++ b/backend/internal/web/embed_test.go
@@ -577,7 +577,7 @@ func TestEmbeddedFrontendDistFreshnessManifest(t *testing.T) {
 	manifest, err := frontendFS.ReadFile("dist/frontend-source.json")
 	require.NoError(t, err)
 	assert.Contains(t, string(manifest), `"source": "frontend/"`)
-	assert.Contains(t, string(manifest), `"algorithm": "sha256(path,size,content)"`)
+	assert.Contains(t, string(manifest), `"algorithm": "sha256(git-ls-files:path,size,content)"`)
 }
 
 func TestHasEmbeddedFrontend(t *testing.T) {

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -5,7 +5,7 @@
   "type": "module",
   "scripts": {
     "dev": "vite",
-    "build": "vue-tsc -b && vite build",
+    "build": "vue-tsc -b && vite build && python3 ../scripts/check-frontend-dist-freshness.py --write ../backend/internal/web/dist",
     "preview": "vite preview",
     "lint": "eslint . --ext .vue,.js,.jsx,.cjs,.mjs,.ts,.tsx,.cts,.mts --fix",
     "lint:check": "eslint . --ext .vue,.js,.jsx,.cjs,.mjs,.ts,.tsx,.cts,.mts",

--- a/frontend/src/components/account/__tests__/CreateAccountModal.newapi.spec.ts
+++ b/frontend/src/components/account/__tests__/CreateAccountModal.newapi.spec.ts
@@ -157,8 +157,14 @@ describe('CreateAccountModal — NewAPI (5th platform)', () => {
     await nextTick()
     await nextTick()
 
-    // Channel type selector must be present immediately (placed directly under the platform row).
-    expect(wrapper.html()).toContain('admin.accounts.newApiPlatform.channelType')
+    // Channel type selector must be present immediately after the platform row, before other platform blocks.
+    const html = wrapper.html()
+    const platformIdx = html.indexOf('Extension Engine')
+    const channelTypeIdx = html.indexOf('admin.accounts.newApiPlatform.channelType', platformIdx)
+    const accountTypeIdx = html.indexOf('admin.accounts.accountType', platformIdx)
+    expect(platformIdx).toBeGreaterThanOrEqual(0)
+    expect(channelTypeIdx).toBeGreaterThan(platformIdx)
+    expect(accountTypeIdx === -1 || channelTypeIdx < accountTypeIdx).toBe(true)
 
     // The NewAPI fields block must render the structured model selector
     // (D4) — proves D1 succeeded (accountCategory was flipped → form.type='apikey'

--- a/scripts/check-frontend-dist-freshness.py
+++ b/scripts/check-frontend-dist-freshness.py
@@ -6,24 +6,13 @@ from __future__ import annotations
 import argparse
 import hashlib
 import json
+import subprocess
 import sys
 from pathlib import Path
-from typing import Iterable
 
 REPO_ROOT = Path(__file__).resolve().parents[1]
 FRONTEND_ROOT = REPO_ROOT / "frontend"
 MANIFEST_NAME = "frontend-source.json"
-EXCLUDED_DIRS = {
-    ".git",
-    ".vite",
-    "__tests__",
-    "coverage",
-    "dist",
-    "node_modules",
-}
-EXCLUDED_FILES = {
-    ".DS_Store",
-}
 EXCLUDED_SUFFIXES = (
     ".spec.ts",
     ".spec.tsx",
@@ -32,23 +21,38 @@ EXCLUDED_SUFFIXES = (
 )
 
 
-def iter_frontend_inputs() -> Iterable[Path]:
-    for path in sorted(FRONTEND_ROOT.rglob("*")):
-        rel = path.relative_to(FRONTEND_ROOT)
-        if any(part in EXCLUDED_DIRS for part in rel.parts):
+def iter_frontend_input_paths() -> list[Path]:
+    if (REPO_ROOT / ".git").exists():
+        result = subprocess.run(
+            ["git", "ls-files", "frontend"],
+            cwd=REPO_ROOT,
+            check=True,
+            text=True,
+            stdout=subprocess.PIPE,
+        )
+        return filter_input_paths(REPO_ROOT / line for line in result.stdout.splitlines())
+
+    return filter_input_paths(path for path in FRONTEND_ROOT.rglob("*") if path.is_file())
+
+
+def filter_input_paths(paths) -> list[Path]:
+    filtered: list[Path] = []
+    for path in paths:
+        rel = path.relative_to(REPO_ROOT)
+        if any(part in {"node_modules", "dist", "coverage", "__tests__", ".vite"} for part in rel.parts):
             continue
-        if path.name in EXCLUDED_FILES:
+        if rel.name.endswith(EXCLUDED_SUFFIXES):
             continue
-        if path.name.endswith(EXCLUDED_SUFFIXES):
+        if rel.name in {".DS_Store"}:
             continue
-        if path.is_file():
-            yield path
+        filtered.append(path)
+    return sorted(filtered)
 
 
 def compute_digest() -> tuple[str, int]:
     h = hashlib.sha256()
     count = 0
-    for path in iter_frontend_inputs():
+    for path in iter_frontend_input_paths():
         rel = path.relative_to(REPO_ROOT).as_posix()
         data = path.read_bytes()
         h.update(rel.encode("utf-8"))
@@ -66,7 +70,7 @@ def manifest_payload() -> dict[str, object]:
     return {
         "schema": 1,
         "source": "frontend/",
-        "algorithm": "sha256(path,size,content)",
+        "algorithm": "sha256(git-ls-files:path,size,content)",
         "hash": digest,
         "file_count": count,
     }

--- a/scripts/check-frontend-dist-freshness.py
+++ b/scripts/check-frontend-dist-freshness.py
@@ -1,0 +1,130 @@
+#!/usr/bin/env python3
+"""Write or verify the source hash for the embedded frontend dist."""
+
+from __future__ import annotations
+
+import argparse
+import hashlib
+import json
+import sys
+from pathlib import Path
+from typing import Iterable
+
+REPO_ROOT = Path(__file__).resolve().parents[1]
+FRONTEND_ROOT = REPO_ROOT / "frontend"
+MANIFEST_NAME = "frontend-source.json"
+EXCLUDED_DIRS = {
+    ".git",
+    ".vite",
+    "__tests__",
+    "coverage",
+    "dist",
+    "node_modules",
+}
+EXCLUDED_FILES = {
+    ".DS_Store",
+}
+EXCLUDED_SUFFIXES = (
+    ".spec.ts",
+    ".spec.tsx",
+    ".test.ts",
+    ".test.tsx",
+)
+
+
+def iter_frontend_inputs() -> Iterable[Path]:
+    for path in sorted(FRONTEND_ROOT.rglob("*")):
+        rel = path.relative_to(FRONTEND_ROOT)
+        if any(part in EXCLUDED_DIRS for part in rel.parts):
+            continue
+        if path.name in EXCLUDED_FILES:
+            continue
+        if path.name.endswith(EXCLUDED_SUFFIXES):
+            continue
+        if path.is_file():
+            yield path
+
+
+def compute_digest() -> tuple[str, int]:
+    h = hashlib.sha256()
+    count = 0
+    for path in iter_frontend_inputs():
+        rel = path.relative_to(REPO_ROOT).as_posix()
+        data = path.read_bytes()
+        h.update(rel.encode("utf-8"))
+        h.update(b"\0")
+        h.update(str(len(data)).encode("ascii"))
+        h.update(b"\0")
+        h.update(data)
+        h.update(b"\0")
+        count += 1
+    return h.hexdigest(), count
+
+
+def manifest_payload() -> dict[str, object]:
+    digest, count = compute_digest()
+    return {
+        "schema": 1,
+        "source": "frontend/",
+        "algorithm": "sha256(path,size,content)",
+        "hash": digest,
+        "file_count": count,
+    }
+
+
+def write_manifest(dist: Path) -> int:
+    dist.mkdir(parents=True, exist_ok=True)
+    manifest_path = dist / MANIFEST_NAME
+    manifest_path.write_text(json.dumps(manifest_payload(), indent=2, sort_keys=True) + "\n", encoding="utf-8")
+    print(f"wrote {manifest_path}")
+    return 0
+
+
+def check_manifest(dist: Path) -> int:
+    manifest_path = dist / MANIFEST_NAME
+    if not manifest_path.is_file():
+        print(f"FAIL: {manifest_path} is missing; rebuild frontend dist", file=sys.stderr)
+        return 1
+
+    try:
+        recorded = json.loads(manifest_path.read_text(encoding="utf-8"))
+    except (OSError, json.JSONDecodeError) as exc:
+        print(f"FAIL: cannot read {manifest_path}: {exc}", file=sys.stderr)
+        return 1
+
+    current = manifest_payload()
+    if recorded.get("hash") != current["hash"]:
+        print("FAIL: backend/internal/web/dist was not built from the current frontend sources", file=sys.stderr)
+        print(f"      recorded: {recorded.get('hash')}", file=sys.stderr)
+        print(f"      current:  {current['hash']}", file=sys.stderr)
+        print("      run: pnpm --dir frontend run build", file=sys.stderr)
+        return 1
+
+    if recorded.get("file_count") != current["file_count"]:
+        print("FAIL: frontend source file count changed since dist build", file=sys.stderr)
+        print(f"      recorded: {recorded.get('file_count')}", file=sys.stderr)
+        print(f"      current:  {current['file_count']}", file=sys.stderr)
+        print("      run: pnpm --dir frontend run build", file=sys.stderr)
+        return 1
+
+    print("ok: embedded frontend dist source hash matches frontend/")
+    return 0
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser()
+    mode = parser.add_mutually_exclusive_group(required=True)
+    mode.add_argument("--write", action="store_true", help="write the frontend source hash manifest")
+    mode.add_argument("--check", action="store_true", help="verify the frontend source hash manifest")
+    parser.add_argument("dist", nargs="?", default=str(REPO_ROOT / "backend/internal/web/dist"))
+    args = parser.parse_args()
+
+    dist = Path(args.dist)
+    if not dist.is_absolute():
+        dist = (Path.cwd() / dist).resolve()
+
+    return write_manifest(dist) if args.write else check_manifest(dist)
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/scripts/check-frontend-release-assets.py
+++ b/scripts/check-frontend-release-assets.py
@@ -1,0 +1,138 @@
+#!/usr/bin/env python3
+"""Verify release frontend assets carry critical admin-account UI fixes."""
+
+from __future__ import annotations
+
+import argparse
+import re
+import sys
+from pathlib import Path
+from urllib.error import HTTPError, URLError
+from urllib.parse import urljoin
+from urllib.request import Request, urlopen
+
+
+def read_url(url: str) -> str:
+    req = Request(url, headers={"User-Agent": "tokenkey-frontend-asset-check/1.0"})
+    try:
+        with urlopen(req, timeout=15) as resp:
+            return resp.read().decode("utf-8", errors="replace")
+    except HTTPError as exc:
+        raise RuntimeError(f"GET {url} failed: HTTP {exc.code}") from exc
+    except URLError as exc:
+        raise RuntimeError(f"GET {url} failed: {exc.reason}") from exc
+
+
+def read_file(path: Path) -> str:
+    try:
+        return path.read_text(encoding="utf-8", errors="replace")
+    except OSError as exc:
+        raise RuntimeError(f"read {path} failed: {exc}") from exc
+
+
+def account_assets_from_index(index_html: str) -> list[str]:
+    return re.findall(r'src="(/assets/AccountsView-[^"]+\.js)"', index_html)
+
+
+def check_account_asset(asset: str, source: str) -> list[str]:
+    errors: list[str] = []
+    platform_idx = asset.find("Extension Engine")
+    if platform_idx < 0:
+        errors.append(f"{source}: missing Extension Engine platform label")
+        return errors
+
+    create_mount_idx = asset.find("variant:\"create\"", platform_idx)
+    if create_mount_idx < 0:
+        errors.append(f"{source}: missing create-mode Extension Engine field mount near platform picker")
+        return errors
+
+    mount_window = asset[platform_idx:create_mount_idx]
+    required_props = [
+        "channelType:",
+        "baseUrl:",
+        "apiKey:",
+        '"channel-type-options":',
+        '"channel-types-loading":',
+    ]
+    missing = [prop for prop in required_props if prop not in mount_window]
+    if missing:
+        errors.append(f"{source}: create-mode Extension Engine field mount is missing props: {', '.join(missing)}")
+
+    account_type_idx = asset.find("admin.accounts.accountType", platform_idx)
+    if account_type_idx >= 0 and account_type_idx < create_mount_idx:
+        errors.append(f"{source}: account-type block appears before create-mode Extension Engine field mount")
+
+    if create_mount_idx - platform_idx > 5000:
+        errors.append(
+            f"{source}: create-mode Extension Engine field mount is too far from platform picker ({create_mount_idx - platform_idx} bytes)"
+        )
+
+    if "newApiPlatform.channelType" not in asset:
+        errors.append(f"{source}: shared NewAPI field component lacks channel-type label")
+
+    return errors
+
+
+def check_dist(dist: Path) -> list[str]:
+    errors: list[str] = []
+    accounts_assets = sorted((dist / "assets").glob("AccountsView-*.js"))
+    if not accounts_assets:
+        return [f"{dist}: missing assets/AccountsView-*.js"]
+
+    checked = 0
+    for path in accounts_assets:
+        asset = read_file(path)
+        if "Extension Engine" not in asset:
+            continue
+        checked += 1
+        errors.extend(check_account_asset(asset, str(path)))
+
+    if checked == 0:
+        errors.append(f"{dist}: no AccountsView asset contains Extension Engine")
+    return errors
+
+
+def check_url(base_url: str) -> list[str]:
+    base = base_url.rstrip("/") + "/"
+    index = read_url(base)
+    assets = account_assets_from_index(index)
+    if not assets:
+        return [f"{base}: index.html does not reference an AccountsView asset"]
+
+    errors: list[str] = []
+    for asset_path in assets:
+        asset_url = urljoin(base, asset_path.lstrip("/"))
+        asset = read_url(asset_url)
+        if "Extension Engine" not in asset:
+            continue
+        errors.extend(check_account_asset(asset, asset_url))
+        return errors
+
+    errors.append(f"{base}: referenced AccountsView assets do not contain Extension Engine")
+    return errors
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser()
+    group = parser.add_mutually_exclusive_group(required=True)
+    group.add_argument("--dist", type=Path, help="frontend dist directory to inspect")
+    group.add_argument("--url", help="deployed TokenKey base URL to inspect")
+    args = parser.parse_args()
+
+    try:
+        errors = check_dist(args.dist) if args.dist else check_url(args.url)
+    except RuntimeError as exc:
+        print(f"FAIL: {exc}", file=sys.stderr)
+        return 1
+
+    if errors:
+        for err in errors:
+            print(f"FAIL: {err}", file=sys.stderr)
+        return 1
+
+    print("ok: Extension Engine channel-type field is mounted adjacent to the platform picker")
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/scripts/preflight.sh
+++ b/scripts/preflight.sh
@@ -293,6 +293,26 @@ else
     echo "  ok: traj dataset validator accepts/rejects covered fixtures as expected"
 fi
 
+# ---- sub2api: frontend release asset contract -------------------------------
+echo ""
+echo "=== sub2api: frontend release asset contract ==="
+if ! command -v python3 >/dev/null 2>&1; then
+    echo "  FAIL: python3 not on PATH (required to run frontend release checks)"
+    errors=$((errors + 1))
+elif ! python3 -m py_compile ./scripts/check-frontend-release-assets.py ./scripts/check-frontend-dist-freshness.py; then
+    errors=$((errors + 1))
+elif [ -f ./backend/internal/web/dist/index.html ] && ls ./backend/internal/web/dist/assets/AccountsView-*.js >/dev/null 2>&1; then
+    if ! python3 ./scripts/check-frontend-dist-freshness.py --check ./backend/internal/web/dist; then
+        errors=$((errors + 1))
+    elif ! python3 ./scripts/check-frontend-release-assets.py --dist ./backend/internal/web/dist; then
+        errors=$((errors + 1))
+    else
+        echo "  ok: embedded frontend dist is fresh and carries critical account-modal UI contracts"
+    fi
+else
+    echo "  ok: embedded frontend dist not present; release workflow rebuilds and verifies it"
+fi
+
 # ---- sub2api: post-deploy smoke script (syntax only; no live HTTP) ----------
 echo ""
 echo "=== sub2api: post-deploy smoke script syntax ==="

--- a/scripts/preflight.sh
+++ b/scripts/preflight.sh
@@ -301,16 +301,16 @@ if ! command -v python3 >/dev/null 2>&1; then
     errors=$((errors + 1))
 elif ! python3 -m py_compile ./scripts/check-frontend-release-assets.py ./scripts/check-frontend-dist-freshness.py; then
     errors=$((errors + 1))
+elif ! python3 ./scripts/check-frontend-dist-freshness.py --check ./backend/internal/web/dist; then
+    errors=$((errors + 1))
 elif [ -f ./backend/internal/web/dist/index.html ] && ls ./backend/internal/web/dist/assets/AccountsView-*.js >/dev/null 2>&1; then
-    if ! python3 ./scripts/check-frontend-dist-freshness.py --check ./backend/internal/web/dist; then
-        errors=$((errors + 1))
-    elif ! python3 ./scripts/check-frontend-release-assets.py --dist ./backend/internal/web/dist; then
+    if ! python3 ./scripts/check-frontend-release-assets.py --dist ./backend/internal/web/dist; then
         errors=$((errors + 1))
     else
         echo "  ok: embedded frontend dist is fresh and carries critical account-modal UI contracts"
     fi
 else
-    echo "  ok: embedded frontend dist not present; release workflow rebuilds and verifies it"
+    echo "  ok: embedded frontend source manifest is fresh; release workflow rebuilds full dist assets"
 fi
 
 # ---- sub2api: post-deploy smoke script (syntax only; no live HTTP) ----------

--- a/scripts/tk_post_deploy_smoke.sh
+++ b/scripts/tk_post_deploy_smoke.sh
@@ -2,7 +2,7 @@
 # tk_post_deploy_smoke.sh — mandatory post-deploy gateway checks (Stage0).
 #
 # Exercises the same paths Claude Code uses against TokenKey:
-#   public settings, /v1/models, /v1/chat/completions, /v1/messages.
+#   public settings, frontend release assets, /v1/models, /v1/chat/completions, /v1/messages.
 #
 # Usage:
 #   TOKENKEY_BASE_URL=https://api.example.com \
@@ -53,7 +53,18 @@ if [[ "${pub_code}" != "0" ]]; then
   exit 1
 fi
 
-# --- 2) Model list ---
+# --- 2) Frontend release asset shape ---
+if [[ "${POST_DEPLOY_SMOKE_SKIP_FRONTEND:-}" != "1" ]]; then
+  script_dir="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+  if [[ -x "${script_dir}/check-frontend-release-assets.py" || -f "${script_dir}/check-frontend-release-assets.py" ]]; then
+    python3 "${script_dir}/check-frontend-release-assets.py" --url "${BASE}"
+  else
+    echo "tk_post_deploy_smoke: missing check-frontend-release-assets.py" >&2
+    exit 1
+  fi
+fi
+
+# --- 3) Model list ---
 models_http=$(curl -sS -o "$tmpdir/models.json" -w "%{http_code}" \
   -H "Authorization: Bearer ${API_KEY}" \
   -H "Accept: application/json" \
@@ -73,7 +84,7 @@ if [[ -z "${model}" ]] || [[ "${model}" == "null" ]]; then
 fi
 echo "tk_post_deploy_smoke: using model=${model}"
 
-# --- 3) OpenAI-compat chat ---
+# --- 4) OpenAI-compat chat ---
 expect_openai="E2E-OPENAI-OK"
 payload="$(jq -n \
   --arg m "${model}" \
@@ -99,7 +110,7 @@ if ! printf '%s' "${chat_body}" | grep -Fq "${expect_openai}"; then
   exit 1
 fi
 
-# --- 4) Anthropic Messages shape (Claude Code / x-api-key path) ---
+# --- 5) Anthropic Messages shape (Claude Code / x-api-key path) ---
 expect_anthropic="E2E-ANTHROPIC-OK"
 apayload="$(jq -n \
   --arg m "${model}" \


### PR DESCRIPTION
## Summary
- Stamp frontend builds with a source-hash manifest so embedded `web/dist` can be verified against the current `frontend/` inputs.
- Gate local preflight, GoReleaser, release workflow artifacts, and post-deploy smoke on fresh/correct frontend assets.
- Run root `make build` as frontend first, then backend, so embedded builds consume the latest dist.

## Risk
- Low: release/build scripts now require Python 3 for frontend freshness checks; Docker frontend build installs it explicitly.
- Fails closed if `backend/internal/web/dist` was not rebuilt after production frontend source changes.

## Validation
- `pnpm --dir frontend run build`
- `python3 scripts/check-frontend-dist-freshness.py --check backend/internal/web/dist`
- `python3 scripts/check-frontend-release-assets.py --dist backend/internal/web/dist`
- `pnpm --dir frontend exec vitest run src/components/account/__tests__/CreateAccountModal.newapi.spec.ts`
- `go -C backend test -tags=embed ./internal/web`
- `bash scripts/preflight.sh`

🤖 Generated with [Claude Code](https://claude.com/claude-code)