### PR TITLE
chore(release): merge GHCR and Docker Hub Docker builds per arch

### DIFF
--- a/.goreleaser.yaml
+++ b/.goreleaser.yaml
@@ -54,64 +54,35 @@ changelog:
   # 禁用自动 changelog，完全使用 tag 消息
   disable: true
 
-# Docker images
+# Docker images — one buildx build per linux/<arch> (GHCR + optional Docker Hub).
+# Docker Hub lines use an empty template when DOCKERHUB_USERNAME=skip (GoReleaser skips empty names).
 dockers:
-  # DockerHub images (skipped if DOCKERHUB_USERNAME is 'skip')
-  - id: amd64
+  - id: linux-amd64
     goos: linux
     goarch: amd64
-    skip_push: '{{ if eq .Env.DOCKERHUB_USERNAME "skip" }}true{{ else }}false{{ end }}'
-    image_templates:
-      - "{{ .Env.DOCKERHUB_USERNAME }}/sub2api:{{ .Version }}-amd64"
     dockerfile: Dockerfile.goreleaser
     use: buildx
     extra_files:
       - deploy/docker-entrypoint.sh
-    build_flag_templates:
-      - "--platform=linux/amd64"
-      - "--label=org.opencontainers.image.version={{ .Version }}"
-      - "--label=org.opencontainers.image.revision={{ .Commit }}"
-
-  - id: arm64
-    goos: linux
-    goarch: arm64
-    skip_push: '{{ if eq .Env.DOCKERHUB_USERNAME "skip" }}true{{ else }}false{{ end }}'
-    image_templates:
-      - "{{ .Env.DOCKERHUB_USERNAME }}/sub2api:{{ .Version }}-arm64"
-    dockerfile: Dockerfile.goreleaser
-    use: buildx
-    extra_files:
-      - deploy/docker-entrypoint.sh
-    build_flag_templates:
-      - "--platform=linux/arm64"
-      - "--label=org.opencontainers.image.version={{ .Version }}"
-      - "--label=org.opencontainers.image.revision={{ .Commit }}"
-
-  # GHCR images (owner must be lowercase)
-  - id: ghcr-amd64
-    goos: linux
-    goarch: amd64
     image_templates:
       - "ghcr.io/{{ .Env.GITHUB_REPO_OWNER_LOWER }}/sub2api:{{ .Version }}-amd64"
-    dockerfile: Dockerfile.goreleaser
-    use: buildx
-    extra_files:
-      - deploy/docker-entrypoint.sh
+      - '{{ if ne .Env.DOCKERHUB_USERNAME "skip" }}{{ .Env.DOCKERHUB_USERNAME }}/sub2api:{{ .Version }}-amd64{{ end }}'
     build_flag_templates:
       - "--platform=linux/amd64"
       - "--label=org.opencontainers.image.version={{ .Version }}"
       - "--label=org.opencontainers.image.revision={{ .Commit }}"
       - "--label=org.opencontainers.image.source=https://github.com/{{ .Env.GITHUB_REPO_OWNER }}/{{ .Env.GITHUB_REPO_NAME }}"
 
-  - id: ghcr-arm64
+  - id: linux-arm64
     goos: linux
     goarch: arm64
-    image_templates:
-      - "ghcr.io/{{ .Env.GITHUB_REPO_OWNER_LOWER }}/sub2api:{{ .Version }}-arm64"
     dockerfile: Dockerfile.goreleaser
     use: buildx
     extra_files:
       - deploy/docker-entrypoint.sh
+    image_templates:
+      - "ghcr.io/{{ .Env.GITHUB_REPO_OWNER_LOWER }}/sub2api:{{ .Version }}-arm64"
+      - '{{ if ne .Env.DOCKERHUB_USERNAME "skip" }}{{ .Env.DOCKERHUB_USERNAME }}/sub2api:{{ .Version }}-arm64{{ end }}'
     build_flag_templates:
       - "--platform=linux/arm64"
       - "--label=org.opencontainers.image.version={{ .Version }}"


### PR DESCRIPTION
## Summary

Consolidates GoReleaser `dockers` from four entries (Docker Hub amd64/arm64 + GHCR amd64/arm64) to **two**—one buildx build per Linux architecture. Each build tags GHCR and optionally Docker Hub using a conditional template; when `DOCKERHUB_USERNAME=skip`, the Hub template renders empty and GoReleaser skips it.

## Risk

Low: manifest lists and image names unchanged; `simple_release` path untouched (`.goreleaser.simple.yaml` unchanged).

## Validation

- `./scripts/preflight.sh`
- `goreleaser check` with dummy `GITHUB_*` / `DOCKERHUB_*` / `TAG_MESSAGE` env (v2 binary)

Made with [Cursor](https://cursor.com)