### PR TITLE
ci: parallel tests, new-api cache, PR concurrency, incremental lint on PR

### DIFF
--- a/.github/actions/cache-and-checkout-new-api/action.yml
+++ b/.github/actions/cache-and-checkout-new-api/action.yml
@@ -1,0 +1,19 @@
+# Restore sibling ../new-api from GitHub Actions cache (keyed by .new-api-ref SHA),
+# then run checkout-new-api to ensure exact pinned commit. Speeds CI when pin unchanged.
+name: Cache and checkout new-api sibling
+description: Restore cached QuantumNous/new-api clone next to workspace, then sync to .new-api-ref.
+
+runs:
+  using: composite
+  steps:
+    - id: new-api-pin
+      shell: bash
+      run: echo "sha=$(tr -d '[:space:]' < "${GITHUB_WORKSPACE}/.new-api-ref")" >> "$GITHUB_OUTPUT"
+
+    - name: Restore cached new-api sibling
+      uses: actions/cache@v4
+      with:
+        path: ${{ github.workspace }}/../new-api
+        key: new-api-${{ steps.new-api-pin.outputs.sha }}
+
+    - uses: ./.github/actions/checkout-new-api

--- a/.github/actions/checkout-new-api/action.yml
+++ b/.github/actions/checkout-new-api/action.yml
@@ -8,6 +8,9 @@
 #   exact commit in .new-api-ref so release / CI / local-dev stay bit-identical
 #   (scripts/sync-new-api.sh writes the same pin).
 #
+# When CI restores actions/cache into ../new-api, this action reuses that repo:
+# fetch + checkout to NEW_API_REF instead of always cloning from scratch.
+#
 # Usage in a workflow job:
 #   steps:
 #     - uses: actions/checkout@v6
@@ -21,13 +24,26 @@ description: Clone QuantumNous/new-api at the commit pinned in .new-api-ref next
 runs:
   using: composite
   steps:
-    - name: Clone new-api at pinned commit
+    - name: Clone or reuse new-api at pinned commit
       shell: bash
       run: |
         set -euxo pipefail
-        NEW_API_REF="$(tr -d '[:space:]' < .new-api-ref)"
+        NEW_API_REF="$(tr -d '[:space:]' < "${GITHUB_WORKSPACE}/.new-api-ref")"
         [ -n "${NEW_API_REF}" ] || { echo "ERROR: .new-api-ref is empty" >&2; exit 1; }
         target="${GITHUB_WORKSPACE}/../new-api"
+
+        if [ -d "${target}/.git" ]; then
+          git -C "$target" fetch --filter=blob:none origin "${NEW_API_REF}" 2>/dev/null || \
+            git -C "$target" fetch origin "${NEW_API_REF}" 2>/dev/null || true
+          if git -C "$target" rev-parse "${NEW_API_REF}^{commit}" >/dev/null 2>&1; then
+            git -C "$target" checkout -q "${NEW_API_REF}"
+            ls "$target/go.mod"
+            exit 0
+          fi
+          echo "WARN: cached new-api repo missing SHA ${NEW_API_REF}; recloning"
+          rm -rf "$target"
+        fi
+
         git clone --filter=blob:none https://github.com/QuantumNous/new-api.git "$target"
         git -C "$target" fetch --filter=blob:none origin "${NEW_API_REF}" || true
         git -C "$target" checkout "${NEW_API_REF}"

--- a/.github/workflows/backend-ci.yml
+++ b/.github/workflows/backend-ci.yml
@@ -7,6 +7,10 @@ on:
 permissions:
   contents: read
 
+concurrency:
+  group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.sha }}
+  cancel-in-progress: ${{ github.event_name == 'pull_request' }}
+
 jobs:
   preflight:
     # Mechanical gate for process / quality rules from dev-rules submodule.
@@ -18,7 +22,7 @@ jobs:
           submodules: recursive
       # Preflight runs `go test` for traj dataset validation; backend/go.mod
       # replaces new-api with ../../new-api — same sibling checkout as test/lint jobs.
-      - uses: ./.github/actions/checkout-new-api
+      - uses: ./.github/actions/cache-and-checkout-new-api
       - name: Run preflight
         run: |
           if [ -x scripts/preflight.sh ]; then
@@ -27,11 +31,11 @@ jobs:
             ./dev-rules/templates/preflight.sh
           fi
 
-  test:
+  test-unit:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v6
-      - uses: ./.github/actions/checkout-new-api
+      - uses: ./.github/actions/cache-and-checkout-new-api
       - uses: actions/setup-go@v6
         with:
           go-version-file: backend/go.mod
@@ -44,6 +48,21 @@ jobs:
       - name: Unit tests
         working-directory: backend
         run: make test-unit
+
+  test-integration:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v6
+      - uses: ./.github/actions/cache-and-checkout-new-api
+      - uses: actions/setup-go@v6
+        with:
+          go-version-file: backend/go.mod
+          check-latest: false
+          cache: true
+          cache-dependency-path: backend/go.sum
+      - name: Verify Go version
+        run: |
+          go version | grep -q 'go1.26.2'
       - name: Integration tests
         working-directory: backend
         run: make test-integration
@@ -69,10 +88,13 @@ jobs:
         run: make test-frontend
 
   golangci-lint:
+    permissions:
+      contents: read
+      pull-requests: read
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v6
-      - uses: ./.github/actions/checkout-new-api
+      - uses: ./.github/actions/cache-and-checkout-new-api
       - uses: actions/setup-go@v6
         with:
           go-version-file: backend/go.mod
@@ -82,9 +104,11 @@ jobs:
       - name: Verify Go version
         run: |
           go version | grep -q 'go1.26.2'
+      # PR: only-new-issues (GitHub API diff). Push/workflow_dispatch: full ./... lint on backend.
       - name: golangci-lint
         uses: golangci/golangci-lint-action@v9
         with:
           version: v2.9
           args: --concurrency=4 --timeout=30m
           working-directory: backend
+          only-new-issues: ${{ github.event_name == 'pull_request' }}

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -103,7 +103,7 @@ jobs:
           fetch-depth: 0
           ref: ${{ github.event.inputs.tag || github.ref }}
 
-      - uses: ./.github/actions/checkout-new-api
+      - uses: ./.github/actions/cache-and-checkout-new-api
 
       - name: Download VERSION artifact
         uses: actions/download-artifact@v8

--- a/.github/workflows/security-scan.yml
+++ b/.github/workflows/security-scan.yml
@@ -10,13 +10,17 @@ on:
 permissions:
   contents: read
 
+concurrency:
+  group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.sha }}
+  cancel-in-progress: ${{ github.event_name == 'pull_request' }}
+
 jobs:
   backend-security:
     runs-on: ubuntu-latest
     timeout-minutes: 15
     steps:
       - uses: actions/checkout@v6
-      - uses: ./.github/actions/checkout-new-api
+      - uses: ./.github/actions/cache-and-checkout-new-api
       - name: Set up Go
         uses: actions/setup-go@v6
         with:

--- a/.github/workflows/upstream-merge-pr-shape.yml
+++ b/.github/workflows/upstream-merge-pr-shape.yml
@@ -65,7 +65,7 @@ jobs:
 
       # Check 10 runs `go test` in backend/; `backend/go.mod` replaces new-api with
       # ../../new-api — same sibling checkout as CI `test` / `preflight` jobs.
-      - uses: ./.github/actions/checkout-new-api
+      - uses: ./.github/actions/cache-and-checkout-new-api
 
       - name: Set up Go
         uses: actions/setup-go@v6

--- a/.github/workflows/weekly-automation-smoke.yml
+++ b/.github/workflows/weekly-automation-smoke.yml
@@ -25,7 +25,7 @@ jobs:
         with:
           fetch-depth: 0
           submodules: recursive
-      - uses: ./.github/actions/checkout-new-api
+      - uses: ./.github/actions/cache-and-checkout-new-api
       - uses: actions/setup-go@v6
         with:
           go-version-file: backend/go.mod
@@ -47,7 +47,7 @@ jobs:
         with:
           fetch-depth: 0
           submodules: recursive
-      - uses: ./.github/actions/checkout-new-api
+      - uses: ./.github/actions/cache-and-checkout-new-api
       - uses: actions/setup-go@v6
         with:
           go-version-file: backend/go.mod


### PR DESCRIPTION
## Summary

Implements four CI speedups without dropping coverage:

1. **Parallel backend tests** — `test-unit` and `test-integration` are separate jobs (same `make` targets as before).
2. **Cached `new-api` sibling** — New composite `cache-and-checkout-new-api` restores `../new-api` via `actions/cache` keyed by `.new-api-ref`; `checkout-new-api` reuses an existing clone when the pinned SHA is reachable (otherwise reclones).
3. **PR concurrency** — `cancel-in-progress` only for `pull_request` (`group` uses PR number or commit SHA so pushes do not cancel sibling runs).
4. **golangci-lint** — `only-new-issues: true` on pull requests (GitHub API diff); **full** `./...` lint on `push` / `workflow_dispatch`. Job adds `pull-requests: read` for the action.

Also wires the cache composite anywhere we previously called `checkout-new-api` alone (`release`, `security-scan`, `upstream-merge-pr-shape`, `weekly-automation-smoke`) so pin‑unchanged runs share the same benefit.

## Risk

Low. Test commands unchanged; merge to `main` still runs full golangci on push.

## Validation

- `./scripts/preflight.sh`

Made with [Cursor](https://cursor.com)