### PR TITLE
Fix stale frontend asset caching

### DIFF
--- a/backend/internal/web/dist/frontend-source.json
+++ b/backend/internal/web/dist/frontend-source.json
@@ -1,7 +1,7 @@
 {
   "algorithm": "sha256(git-ls-files:path,size,content)",
   "file_count": 406,
-  "hash": "59a1f022b6e7de05f0495aa2ee468af7bea03b365ec3e1512b5f0a131bf61e40",
+  "hash": "3ffbe54b0162ab9afc3cfaf0f32289fd7d81ff29a7c04d2198081223791bfb3d",
   "schema": 1,
   "source": "frontend/"
 }

--- a/backend/internal/web/dist/frontend-source.json
+++ b/backend/internal/web/dist/frontend-source.json
@@ -1,7 +1,7 @@
 {
   "algorithm": "sha256(git-ls-files:path,size,content)",
   "file_count": 406,
-  "hash": "3ffbe54b0162ab9afc3cfaf0f32289fd7d81ff29a7c04d2198081223791bfb3d",
+  "hash": "5e5ba3d63faddabbfd801eaa26953486e6f9562e89591b452fba488537227395",
   "schema": 1,
   "source": "frontend/"
 }

--- a/backend/internal/web/embed_on.go
+++ b/backend/internal/web/embed_on.go
@@ -97,6 +97,13 @@ func (s *FrontendServer) Middleware() gin.HandlerFunc {
 			cleanPath = "index.html"
 		}
 
+		// Static asset URLs are content-hashed. A missing asset means the client is
+		// running a stale entry/chunk reference, not a SPA route.
+		if isStaticAssetPath(cleanPath) && !s.fileExists(cleanPath) {
+			serveMissingStaticAsset(c)
+			return
+		}
+
 		// For index.html or SPA routes, serve with injected settings
 		if cleanPath == "index.html" || !s.fileExists(cleanPath) {
 			s.serveIndexHTML(c)
@@ -277,6 +284,11 @@ func ServeEmbeddedFrontend() gin.HandlerFunc {
 			return
 		}
 
+		if isStaticAssetPath(cleanPath) {
+			serveMissingStaticAsset(c)
+			return
+		}
+
 		serveIndexHTML(c, distFS)
 	}
 }
@@ -294,6 +306,18 @@ func tryServeOverrideFile(c *gin.Context, overrideDir, cleanPath string) bool {
 	c.File(filePath)
 	c.Abort()
 	return true
+}
+
+func serveMissingStaticAsset(c *gin.Context) {
+	c.Header("Cache-Control", "no-store")
+	c.String(http.StatusNotFound, "static asset not found")
+	c.Abort()
+}
+
+func isStaticAssetPath(path string) bool {
+	return path == "favicon.ico" ||
+		path == "logo.png" ||
+		strings.HasPrefix(path, "assets/")
 }
 
 func shouldBypassEmbeddedFrontend(path string) bool {

--- a/backend/internal/web/embed_test.go
+++ b/backend/internal/web/embed_test.go
@@ -541,6 +541,41 @@ func TestFrontendServer_Middleware(t *testing.T) {
 		assert.Equal(t, http.StatusOK, w.Code)
 		assert.Contains(t, w.Header().Get("Content-Type"), "image/png")
 	})
+
+	t.Run("returns_404_for_missing_static_asset", func(t *testing.T) {
+		provider := &mockSettingsProvider{
+			settings: map[string]string{"test": "value"},
+		}
+
+		server, err := NewFrontendServer(provider)
+		require.NoError(t, err)
+
+		router := gin.New()
+		router.Use(server.Middleware())
+
+		w := httptest.NewRecorder()
+		req := httptest.NewRequest(http.MethodGet, "/assets/AccountsView-stale.js", nil)
+		router.ServeHTTP(w, req)
+
+		assert.Equal(t, http.StatusNotFound, w.Code)
+		assert.Equal(t, "no-store", w.Header().Get("Cache-Control"))
+		assert.NotContains(t, w.Body.String(), "<!doctype html>")
+	})
+
+	t.Run("legacy_returns_404_for_missing_static_asset", func(t *testing.T) {
+		middleware := ServeEmbeddedFrontend()
+
+		router := gin.New()
+		router.Use(middleware)
+
+		w := httptest.NewRecorder()
+		req := httptest.NewRequest(http.MethodGet, "/assets/AccountsView-stale.js", nil)
+		router.ServeHTTP(w, req)
+
+		assert.Equal(t, http.StatusNotFound, w.Code)
+		assert.Equal(t, "no-store", w.Header().Get("Cache-Control"))
+		assert.NotContains(t, w.Body.String(), "<!doctype html>")
+	})
 }
 
 func TestNewFrontendServer(t *testing.T) {

--- a/deploy/Caddyfile
+++ b/deploy/Caddyfile
@@ -10,7 +10,7 @@ api.sub2api.com {
 		path /favicon.ico
 	}
 	header @static {
-		Cache-Control "public, max-age=31536000, immutable"
+		?Cache-Control "public, max-age=31536000, immutable"
 		# 移除可能干扰缓存的头
 		-Pragma
 		-Expires

--- a/deploy/aws/stage0/Caddyfile
+++ b/deploy/aws/stage0/Caddyfile
@@ -18,7 +18,7 @@ ${API_DOMAIN} {
 		path /logo.png
 		path /favicon.ico
 	}
-	header @static Cache-Control "public, max-age=31536000, immutable"
+	header @static ?Cache-Control "public, max-age=31536000, immutable"
 
 	tls {
 		protocols tls1.2 tls1.3

--- a/frontend/src/components/account/__tests__/CreateAccountModal.newapi.spec.ts
+++ b/frontend/src/components/account/__tests__/CreateAccountModal.newapi.spec.ts
@@ -129,6 +129,30 @@ function mountModal() {
   })
 }
 
+function mountModalWithRealNewApiChildren() {
+  listChannelTypesMock.mockResolvedValue([
+    { channel_type: 1, name: 'OpenAI', api_type: 0, has_adaptor: true, base_url: 'https://api.openai.com' },
+    { channel_type: 14, name: 'DeepSeek', api_type: 0, has_adaptor: true, base_url: 'https://api.deepseek.com' }
+  ])
+  return mount(CreateAccountModal, {
+    props: {
+      show: true,
+      proxies: [],
+      groups: []
+    },
+    global: {
+      stubs: {
+        BaseDialog: BaseDialogStub,
+        ProxySelector: true,
+        GroupSelector: true,
+        OAuthAuthorizationFlow: true,
+        QuotaLimitCard: true,
+        ConfirmDialog: true
+      }
+    }
+  })
+}
+
 describe('CreateAccountModal — NewAPI (5th platform)', () => {
   beforeEach(() => {
     listChannelTypesMock.mockReset()
@@ -157,14 +181,21 @@ describe('CreateAccountModal — NewAPI (5th platform)', () => {
     await nextTick()
     await nextTick()
 
-    // Channel type selector must be present immediately after the platform row, before other platform blocks.
+    // Channel type / Base URL / API Key must be present immediately after the platform row,
+    // before other platform/account blocks and before quota controls.
     const html = wrapper.html()
     const platformIdx = html.indexOf('Extension Engine')
     const channelTypeIdx = html.indexOf('admin.accounts.newApiPlatform.channelType', platformIdx)
+    const baseUrlIdx = html.indexOf('admin.accounts.newApiPlatform.baseUrl', platformIdx)
+    const apiKeyIdx = html.indexOf('admin.accounts.newApiPlatform.apiKey', platformIdx)
     const accountTypeIdx = html.indexOf('admin.accounts.accountType', platformIdx)
+    const quotaControlIdx = html.indexOf('admin.accounts.quotaControl.title', platformIdx)
     expect(platformIdx).toBeGreaterThanOrEqual(0)
     expect(channelTypeIdx).toBeGreaterThan(platformIdx)
+    expect(baseUrlIdx).toBeGreaterThan(channelTypeIdx)
+    expect(apiKeyIdx).toBeGreaterThan(baseUrlIdx)
     expect(accountTypeIdx === -1 || channelTypeIdx < accountTypeIdx).toBe(true)
+    expect(quotaControlIdx === -1 || apiKeyIdx < quotaControlIdx).toBe(true)
 
     // The NewAPI fields block must render the structured model selector
     // (D4) — proves D1 succeeded (accountCategory was flipped → form.type='apikey'
@@ -172,6 +203,32 @@ describe('CreateAccountModal — NewAPI (5th platform)', () => {
     // because the component is mounted and its default mode is 'whitelist').
     const selectors = wrapper.findAll('[data-testid="model-whitelist-selector"]')
     expect(selectors.length).toBeGreaterThanOrEqual(1)
+  })
+
+  it('renders NewAPI credential fields with the real shared field subtree', async () => {
+    const errorSpy = vi.spyOn(console, 'error').mockImplementation(() => {})
+    const wrapper = mountModalWithRealNewApiChildren()
+    await nextTick()
+
+    await clickPlatform(wrapper, 'Extension Engine')
+    await nextTick()
+    await nextTick()
+
+    const html = wrapper.html()
+    const platformIdx = html.indexOf('Extension Engine')
+    const channelTypeIdx = html.indexOf('admin.accounts.newApiPlatform.channelType', platformIdx)
+    const baseUrlIdx = html.indexOf('admin.accounts.newApiPlatform.baseUrl', platformIdx)
+    const apiKeyIdx = html.indexOf('admin.accounts.newApiPlatform.apiKey', platformIdx)
+    const quotaControlIdx = html.indexOf('admin.accounts.quotaControl.title', platformIdx)
+
+    expect(channelTypeIdx).toBeGreaterThan(platformIdx)
+    expect(baseUrlIdx).toBeGreaterThan(channelTypeIdx)
+    expect(apiKeyIdx).toBeGreaterThan(baseUrlIdx)
+    expect(quotaControlIdx === -1 || apiKeyIdx < quotaControlIdx).toBe(true)
+    expect(wrapper.find('input[type="password"]').exists()).toBe(true)
+    expect(errorSpy).not.toHaveBeenCalled()
+
+    errorSpy.mockRestore()
   })
 
   it('AC-D2: switching OpenAI/API Key → NewAPI does NOT render a duplicate generic apikey block', async () => {

--- a/frontend/src/i18n/locales/en.ts
+++ b/frontend/src/i18n/locales/en.ts
@@ -392,6 +392,7 @@ export default {
     saving: 'Saving...',
     selectedCount: '({count} selected)',
     refresh: 'Refresh',
+    chunkLoadFailed: 'The page assets are still out of date after refresh. Please clear the browser cache and reload this page.',
     autoRefresh: {
       title: 'Auto Refresh',
       enable: 'Enable auto refresh',

--- a/frontend/src/i18n/locales/zh.ts
+++ b/frontend/src/i18n/locales/zh.ts
@@ -391,6 +391,7 @@ export default {
     saving: '保存中...',
     selectedCount: '（已选 {count} 个）',
     refresh: '刷新',
+    chunkLoadFailed: '页面资源刷新后仍然过期，请清理浏览器缓存后重新加载本页面。',
     autoRefresh: {
       title: '自动刷新',
       enable: '启用自动刷新',

--- a/frontend/src/router/index.ts
+++ b/frontend/src/router/index.ts
@@ -10,6 +10,7 @@ import { useAdminSettingsStore } from '@/stores/adminSettings'
 import { useNavigationLoadingState } from '@/composables/useNavigationLoading'
 import { useRoutePrefetch } from '@/composables/useRoutePrefetch'
 import { resolveDocumentTitle } from './title'
+import { i18n } from '@/i18n'
 
 /**
  * Route definitions with lazy loading
@@ -797,6 +798,7 @@ router.onError((error) => {
       console.warn('Chunk load error detected, reloading page to fetch latest version...')
       window.location.reload()
     } else {
+      useAppStore().showError(i18n.global.t('common.chunkLoadFailed'), 0)
       console.error('Chunk load error persists after reload. Please clear browser cache.')
     }
   }

--- a/frontend/src/router/index.ts
+++ b/frontend/src/router/index.ts
@@ -798,7 +798,7 @@ router.onError((error) => {
       console.warn('Chunk load error detected, reloading page to fetch latest version...')
       window.location.reload()
     } else {
-      useAppStore().showError(i18n.global.t('common.chunkLoadFailed'), 0)
+      useAppStore().showToast('error', i18n.global.t('common.chunkLoadFailed'))
       console.error('Chunk load error persists after reload. Please clear browser cache.')
     }
   }

--- a/scripts/check-frontend-release-assets.py
+++ b/scripts/check-frontend-release-assets.py
@@ -74,17 +74,32 @@ def check_account_asset(asset: str, source: str) -> list[str]:
     if missing:
         errors.append(f"{source}: create-mode Extension Engine field mount is missing props: {', '.join(missing)}")
 
+    required_labels = [
+        "newApiPlatform.channelType",
+        "newApiPlatform.baseUrl",
+        "newApiPlatform.apiKey",
+    ]
+    label_positions = {label: asset.find(label) for label in required_labels}
+    missing_labels = [label for label, idx in label_positions.items() if idx < 0]
+    if missing_labels:
+        errors.append(f"{source}: shared NewAPI field component is missing labels: {', '.join(missing_labels)}")
+
+    ordered_labels = [label_positions[label] for label in required_labels]
+    if all(idx >= 0 for idx in ordered_labels) and ordered_labels != sorted(ordered_labels):
+        errors.append(f"{source}: shared NewAPI channel/base-url/api-key labels are out of order")
+
     account_type_idx = asset.find("admin.accounts.accountType", platform_idx)
     if account_type_idx >= 0 and account_type_idx < create_mount_idx:
         errors.append(f"{source}: account-type block appears before create-mode Extension Engine field mount")
+
+    quota_idx = asset.find("quotaControl.title", platform_idx)
+    if quota_idx >= 0 and quota_idx < create_mount_idx:
+        errors.append(f"{source}: quota controls appear before create-mode Extension Engine field mount")
 
     if create_mount_idx - platform_idx > 5000:
         errors.append(
             f"{source}: create-mode Extension Engine field mount is too far from platform picker ({create_mount_idx - platform_idx} bytes)"
         )
-
-    if "newApiPlatform.channelType" not in asset:
-        errors.append(f"{source}: shared NewAPI field component lacks channel-type label")
 
     return errors
 

--- a/scripts/tk_post_deploy_smoke.sh
+++ b/scripts/tk_post_deploy_smoke.sh
@@ -62,6 +62,25 @@ if [[ "${POST_DEPLOY_SMOKE_SKIP_FRONTEND:-}" != "1" ]]; then
     echo "tk_post_deploy_smoke: missing check-frontend-release-assets.py" >&2
     exit 1
   fi
+
+  missing_asset_headers="$tmpdir/missing-asset.headers"
+  missing_asset_body="$tmpdir/missing-asset.body"
+  missing_asset_http=$(curl -sS -o "$missing_asset_body" -D "$missing_asset_headers" -w "%{http_code}" \
+    "${BASE}/assets/TokenKeyMissingAsset-smoke.js")
+  echo "tk_post_deploy_smoke: GET .../assets/TokenKeyMissingAsset-smoke.js -> HTTP ${missing_asset_http}"
+  if [[ "${missing_asset_http}" != "404" ]]; then
+    echo "tk_post_deploy_smoke: missing static asset should return HTTP 404" >&2
+    exit 1
+  fi
+  if ! grep -i '^cache-control:.*no-store' "$missing_asset_headers" >/dev/null; then
+    echo "tk_post_deploy_smoke: missing static asset should return Cache-Control: no-store" >&2
+    cat "$missing_asset_headers" >&2
+    exit 1
+  fi
+  if grep -iq '<!doctype html' "$missing_asset_body"; then
+    echo "tk_post_deploy_smoke: missing static asset returned index.html" >&2
+    exit 1
+  fi
 fi
 
 # --- 3) Model list ---


### PR DESCRIPTION
## Summary
- Return uncached 404s for missing embedded hashed frontend assets instead of SPA fallback HTML.
- Preserve backend `no-store` through Caddy and add post-deploy smoke coverage for the missing-asset path.
- Strengthen Extension Engine release/test guards and show a persistent user-facing chunk-load failure message.

## Risk
- Low: runtime change is limited to missing `/assets/*`, `/logo.png`, and `/favicon.ico` requests; existing assets and SPA routes keep their current behavior.
- Upstream conflict surface is minimal: one small embedded frontend helper, Caddy cache-header modifiers, and focused test/check scripts.

## Validation
- [x] `pnpm typecheck`
- [x] `pnpm build`
- [x] `bash -n scripts/tk_post_deploy_smoke.sh`
- [x] `python3 scripts/check-frontend-release-assets.py --dist backend/internal/web/dist`
- [x] `go -C backend test -tags=embed ./internal/web`
- [x] `bash scripts/preflight.sh`

🤖 Generated with [Claude Code](https://claude.com/claude-code)