### PR TITLE
chore: Cursor skills canonical layout + prod release skill + dev-rules

### DIFF
--- a/.claude/skills
+++ b/.claude/skills
@@ -1,0 +1,1 @@
+../.cursor/skills

--- a/.claude/skills/tokenkey-prod-release-deploy/SKILL.md
+++ b/.claude/skills/tokenkey-prod-release-deploy/SKILL.md
@@ -1,1 +1,0 @@
-../../../.cursor/skills/tokenkey-prod-release-deploy/SKILL.md

--- a/.cursor/skills/tokenkey-prod-release-deploy/SKILL.md
+++ b/.cursor/skills/tokenkey-prod-release-deploy/SKILL.md
@@ -3,15 +3,25 @@ name: tokenkey-prod-release-deploy
 description: >-
   Delivers a new sub2api/TokenKey production release on AWS Stage0 after syncing
   main—bumps backend/cmd/server/VERSION when needed, pushes tag via
-  scripts/release-tag.sh, waits for GHCR images, dispatches deploy-stage0 to
-  prod, and verifies with tk_post_deploy_smoke plus /health. Use when the user
-  asks to ship prod, release to AWS, tag deploy, pull latest main and deploy
-  production, or run post-deploy smoke against production.
+  scripts/release-tag.sh, waits for GHCR images (allow long gh run watch),
+  dispatches deploy-stage0 to prod, waits through Environment approval if any,
+  then verifies with curl probes plus tk_post_deploy_smoke (prefer
+  POST_DEPLOY_SMOKE_API_KEY from environment). Use when the user asks to ship
+  prod, release to AWS, tag deploy, pull latest main and deploy production, or
+  run post-deploy smoke against production.
 ---
 
 # TokenKey：main 同步 → 打 tag → AWS prod 部署 → 真实测试
 
 适用于本仓库（TokenKey fork of sub2api）。权威纪律见根目录 `CLAUDE.md`（发版、ARM、`new-api` 路径）。
+
+## 一次性跑完（原则）
+
+- **顺序做完**：同步 → 决策 VERSION/tag →（按需 bump+push）→ `release-tag.sh` → **watch 到 release 成功** → dispatch deploy → **watch 到 deploy 成功** → **再做本地验收（B + 尽量 C）**。不要在 deploy 绿灯后就结束会话。
+- **读 VERSION 前必须先** `fetch` + `pull --ff-only` **后的** `origin/main` 为准；在未更新的本地分支上读 `VERSION` 会与远端 tag 错位，误判「要不要 bump」。
+- **`gh run watch` 要给够时间**：多架构 `release.yml` 常见 **十余分钟量级**；Agent 应用 `--exit-status` 跟跑到结束，不要用默认几十秒的 command 超时提前杀掉。
+- **`prod` Environment**：run 卡在 `waiting` 时需有人在 GitHub Actions 里批准；批准后继续 watch，勿当作失败退出。
+- **完整烟测密钥**：优先使用环境里已有的 `POST_DEPLOY_SMOKE_API_KEY`（Cursor / shell 已导出），避免停下来向用户索要 key；详见下文 C。
 
 ## 前置条件
 
@@ -23,10 +33,11 @@ description: >-
 ## 决策：要不要升 patch 版本
 
 1. `git fetch origin main --tags && git checkout main && git pull origin main --ff-only`
-2. 读 `backend/cmd/server/VERSION`（记为 `V`，无 `v` 前缀）。
+2. 读 **已与 `origin/main` 对齐的** `backend/cmd/server/VERSION`（记为 `V`，无 `v` 前缀）。
 3. 用 `git ls-remote --tags origin "refs/tags/v${V}"`（或 `git tag -l "v${V}"` 在 fetch 标签之后）判断是否已有 **远端** `v${V}`：
    - **`v${V}` 尚不存在**：若 `main` 已含正确 `VERSION=V` 且已 push，可直接 `bash scripts/release-tag.sh v${V}`，无需 bump。
-   - **`v${V}` 已存在**，且 `origin/main` 比该 tag **更新**（`git merge-base --is-ancestor v${V} origin/main` 为真 **且** `git rev-parse v${V} origin/main` 两个 SHA 不同）：须把 `VERSION` **升到下一 patch**（例 `1.7.9`→`1.7.10`），提交并 push，再对新版本执行 `release-tag.sh`。禁止对已有远端 tag 的同一 `vX.Y.Z` 重复推送。
+   - **`v${V}` 已存在**，且 `origin/main` 比该 tag **更新**（`git merge-base --is-ancestor v${V} origin/main` 为真 **且** `git rev-parse v${V} origin/main` 两个 SHA 不同）：须把 `VERSION` **升到下一 patch**（例 `1.7.9`→`1.7.10`），提交并 push，再对新版本执行 `release-tag.sh`。禁止对已有远端 tag 的同一 `vX.Y.Z` 重复推送。  
+     （典型坑：`VERSION` 文件仍是旧 patch，但远端已有对应 tag 且仅指向更早提交——必须以本条为准 bump，不能复读旧 VERSION。）
    - **`origin/main` 与 `v${V}` 同一 commit**，仅 prod 未部署该镜像：跳过 bump 与打 tag，直接 `gh workflow run deploy-stage0.yml -f environment=prod -f tag=${V}`。
 
 ## 标准流程（发布新镜像 + 部署 prod）
@@ -36,34 +47,43 @@ description: >-
 3. **打 tag**（必须在 `main` 且与 `origin/main` 同 SHA）：  
    `bash scripts/release-tag.sh vX.Y.Z`  
    不要手打 `git tag`；脚本校验 `[skip ci]`、VERSION 一致、分支与同步。
-4. **等待镜像**：`gh run list --workflow=release.yml --limit 1` → `gh run watch <id> --exit-status`，直到 **success**。多架构构建可能需 **十余分钟**。
-5. **部署 prod**：镜像 tag **不带 `v`**：  
-   `gh workflow run deploy-stage0.yml -f environment=prod -f tag=X.Y.Z`  
-   **不要**设 `simple_release_override=true`（prod/test 为 **ARM**；单架构 manifest 会 `exec format error`）。
-6. **等待部署**：`gh run watch` 对本次 `deploy-stage0` run；状态 `waiting` 时需 Environment 审批。
+4. **等待镜像**：`gh run list --workflow=release.yml --limit 1` → 取 **刚触发、与本次 tag 对应** 的 run（可看 `headBranch` / 标题）→ `gh run watch <id> --exit-status`，直到 **success**。多架构构建可能需 **十余分钟**。
+5. **部署 prod**：镜像 tag **不带 `v`**：`gh workflow run deploy-stage0.yml -f environment=prod -f tag=X.Y.Z`。记下输出的 run URL，对该 run `gh run watch <id> --exit-status` 直至 success（停在 **waiting** 时在 GitHub **Environment `prod`** 批准后继续）。**不要**设 `simple_release_override=true`（prod/test 为 **ARM**；单架构 manifest 会 `exec format error`）。
 
 ## 真实测试（必须做）
 
-**A — CI 已做的完整网关烟测**（与 `https://api.tokenkey.dev` 真机交互，需仓库 secret `POST_DEPLOY_SMOKE_API_KEY` 等）：  
-部署 workflow 成功步里会跑 `bash scripts/tk_post_deploy_smoke.sh`。从 run log 中确认出现 **`tk_post_deploy_smoke: OK`** 以及 `GET .../v1/models`、`POST .../v1/chat/completions`、`POST .../v1/messages` 为预期 HTTP。
+部署 workflow **成功**只说明流水线过了；Agent **仍需**下面顺序做完（除非用户明确只要 CI、不做本地）。
 
-**B — 本地快速探活**（无密钥）：  
+### A — CI 日志中的完整网关烟测
+
+与 `https://api.tokenkey.dev` 真机交互，依赖仓库 secret `POST_DEPLOY_SMOKE_API_KEY` 等。在 **本次** `deploy-stage0` run log 里搜索 **`tk_post_deploy_smoke: OK`**，并确认 `GET .../v1/models`、`POST .../v1/chat/completions`、`POST .../v1/messages` 等为预期 HTTP。
+
+### B — 本地快速探活（无密钥）
 
 ```bash
 curl -sS -o /dev/null -w '%{http_code}\n' 'https://api.tokenkey.dev/health'
 curl -sS -o /dev/null -w '%{http_code}\n' 'https://api.tokenkey.dev/api/v1/settings/public'
 ```
 
-期望 **200**；若需更严，对同上 URL 取 body，校验 JSON 的 `code` 为 `0`。
+期望 **200**；若需更严，对 `/api/v1/settings/public` 的 body 校验 JSON `code` 为 `0`。
 
-**C — 本地完整烟测**（有 **prod** 用 API key 时）：  
+### C — 本地完整烟测（prod API key）
+
+**推荐（不间断执行）**：密钥已由环境注入时，不要在命令行粘贴 key：
 
 ```bash
 cd /path/to/sub2api
-TOKENKEY_BASE_URL=https://api.tokenkey.dev POST_DEPLOY_SMOKE_API_KEY='sk-...' bash scripts/tk_post_deploy_smoke.sh
+export TOKENKEY_BASE_URL=https://api.tokenkey.dev
+# POST_DEPLOY_SMOKE_API_KEY 已在 Cursor / shell 中导出即可
+bash scripts/tk_post_deploy_smoke.sh
 ```
 
-不得打印完整 key；脚本只打 key hint。
+脚本内解析顺序（摘自 `scripts/tk_post_deploy_smoke.sh`）：`POST_DEPLOY_SMOKE_API_KEY` → `ANTHROPIC_AUTH_TOKEN` → `TK_TOKEN` → `TOKENKEY_API_KEY`。任一为非空即可。
+
+仅在无法注入环境时再临时：`POST_DEPLOY_SMOKE_API_KEY='sk-…' bash scripts/tk_post_deploy_smoke.sh`。  
+不得打印完整 key；脚本只输出 `key_hint`。
+
+**Agent 注意**：若在沙箱里跑导致读不到用户环境变量，改用可继承本机环境的执行方式（例如非 sandbox / `all`），否则 C 会因缺 key 退出。
 
 ## release 之后 main 是否还有提交
 
@@ -77,6 +97,7 @@ TOKENKEY_BASE_URL=https://api.tokenkey.dev POST_DEPLOY_SMOKE_API_KEY='sk-...' ba
 | `tag already exists on origin` | 升 `VERSION` 再打新 tag，或仅 dispatch deploy 已有 tag |
 | deploy 报单架构 manifest | 重新跑 `release.yml` 且 **`simple_release=false`**；prod 不要 override |
 | smoke 失败 | 看 deploy run log；查 Caddy/容器日志与网关路由（`deploy/aws/README.md`、 `docs/approved/deploy-stage0-workflow.md`） |
+| `gh run watch` 被工具超时打断 | 用同一 run id 再执行 `gh run watch <id> --exit-status` 接到终态 |
 
 ## 扩展阅读（按需打开）
 

--- a/.cursor/skills/tokenkey-stage0-local-deploy/SKILL.md
+++ b/.cursor/skills/tokenkey-stage0-local-deploy/SKILL.md
@@ -1,0 +1,285 @@
+---
+name: tokenkey-stage0-local-deploy
+description: >-
+  Local Docker stack matching deploy/aws Stage 0 (Caddy + app + Postgres + Redis). Skill
+  body pins this clone: REPO_ROOT under $HOME/Codes/token/tk/sub2api, new-api sibling parent,
+  state under REPO_ROOT/.cache/tokenkey-stage0-local. Use for deploy/aws simulation on
+  laptop, port 8088 smoke, AUTO_SETUP admin login, compose down + rm state.
+---
+
+# TokenKey：本地模拟 `deploy/aws` Stage 0（Compose + 验证 + 销毁）
+
+与 `deploy/aws` 相同方式在笔记本起栈、验证后销毁。权威栈定义见 `deploy/aws/stage0/docker-compose.yml` 与 `deploy/aws/README.md`。
+
+## 本项目路径约定（本仓库克隆）
+
+以下值为 **TokenKey fork 当前常用落地布局**（`sub2api` 与 `new-api` 同级）；若你的目录不同，只改这三项即可。
+
+```bash
+export REPO_ROOT="$HOME/Codes/token/tk/sub2api"
+export TOKENKEY_NEWAPI_PARENT="$HOME/Codes/token/tk"   # Dockerfile 构建上下文：内含 sub2api/ 与 new-api/
+export TOKENKEY_STAGE0_LOCAL_ROOT="$HOME/Codes/token/tk/sub2api/.cache/tokenkey-stage0-local"
+```
+
+下文凡出现路径均使用 `"$HOME/Codes/..."`，在脚本与非交互 shell 中也会可靠展开。
+
+- `REPO_ROOT`：本 git 仓库根（含 `backend/`、`deploy/aws/stage0/docker-compose.yml`）。
+- `TOKENKEY_NEWAPI_PARENT`：`Dockerfile` 要求的 **父目录**（与 `CLAUDE.md`「Sibling dependency: New API」一致）。
+- `TOKENKEY_STAGE0_LOCAL_ROOT`：本地 override、`.env`、Caddyfile、PG/Redis 数据落盘处；位于 `REPO_ROOT/.cache/...`，仓库已 `.gitignore` `.cache/`。
+
+默认 **GHCR 镜像坐标** 使用 **`:latest`**，避免与 `VERSION` 文件不同步导致拉取失败；需要与某次发版逐位对照时再显式改为 `ghcr.io/youxuanxue/sub2api:<VERSION>` 或 `sha-…`：
+
+```bash
+export TOKENKEY_IMAGE_DEFAULT="ghcr.io/youxuanxue/sub2api:latest"
+```
+
+`latest` 会随 registry 更新而变，**不一定**等于当前工作区 `backend/cmd/server/VERSION`。发版/对账请用明确 tag。拉取 private 仓库前先 `docker login ghcr.io`。
+
+## 与真机 EC2 的差异（刻意如此）
+
+| 项 | EC2 Stage 0 | 本机模拟 |
+| --- | --- | --- |
+| 数据目录 | `/var/lib/tokenkey/...` | `${TOKENKEY_STAGE0_LOCAL_ROOT}/...`（默认在 `REPO_ROOT/.cache/...`） |
+| Caddy | LE 证书 + `API_DOMAIN` | **纯 HTTP**（映射 `8088→80`），不调 Let's Encrypt |
+| 对外端口 | 80/443 | 宿主机 `8088`（HTTP）、`8443`（预留，本地模板可不启 TLS） |
+| 镜像 | GHCR `sub2api:<tag>` | **拉取 GHCR** 或 **本地 `docker build`**（见下文） |
+
+## 前置条件
+
+- 仓库根目录；已安装 Docker 与 `docker compose`。
+- **private GHCR**：先 `docker login ghcr.io`（PAT 需 `read:packages`）。
+- 走**本地构建**镜像时：Docker 构建上下文必须是 **sub2api 与 new-api 同级目录**，见根目录 `Dockerfile` 头注释与 `CLAUDE.md`（`replace github.com/QuantumNous/new-api => ../../new-api`）。
+
+## 环境变量约定
+
+上一节 **`REPO_ROOT` / `TOKENKEY_NEWAPI_PARENT` / `TOKENKEY_STAGE0_LOCAL_ROOT`** 为项目级默认值；Compose 还要求在运行命令的 shell 里 **export `TOKENKEY_STAGE0_LOCAL_ROOT`**，以便 override YAML 展开卷路径。
+
+## 1) 准备目录
+
+```bash
+export REPO_ROOT="$HOME/Codes/token/tk/sub2api"
+export TOKENKEY_STAGE0_LOCAL_ROOT="$HOME/Codes/token/tk/sub2api/.cache/tokenkey-stage0-local"
+mkdir -p "${TOKENKEY_STAGE0_LOCAL_ROOT}"/{caddy,app,postgres,pgdump,redis}
+```
+
+## 2) 生成秘密并写入 `.env`
+
+用新随机值（**勿复用示例或会话里出现过的十六进制串**）：
+
+```bash
+export REPO_ROOT="$HOME/Codes/token/tk/sub2api"
+export TOKENKEY_STAGE0_LOCAL_ROOT="$HOME/Codes/token/tk/sub2api/.cache/tokenkey-stage0-local"
+ADMIN_PASSWORD="$(openssl rand -hex 16)"
+POSTGRES_PASSWORD="$(openssl rand -hex 12)"
+JWT_SECRET="$(openssl rand -hex 32)"
+TOTP_ENCRYPTION_KEY="$(openssl rand -hex 32)"
+TOKENKEY_IMAGE="${TOKENKEY_IMAGE:-ghcr.io/youxuanxue/sub2api:latest}"   # 可对齐发版时改成 :X.Y.Z；本地 build 改为你的镜像 tag
+
+cat > "${TOKENKEY_STAGE0_LOCAL_ROOT}/.env" <<EOF
+API_DOMAIN=localhost
+ACME_EMAIL=local@tokenkey.local
+TZ=UTC
+SERVER_MODE=release
+RUN_MODE=standard
+TOKENKEY_IMAGE=${TOKENKEY_IMAGE}
+POSTGRES_USER=tokenkey
+POSTGRES_PASSWORD=${POSTGRES_PASSWORD}
+POSTGRES_DB=tokenkey
+DATABASE_MAX_OPEN_CONNS=50
+DATABASE_MAX_IDLE_CONNS=10
+REDIS_PASSWORD=
+REDIS_DB=0
+REDIS_POOL_SIZE=1024
+REDIS_MIN_IDLE_CONNS=10
+ADMIN_EMAIL=admin@tokenkey.local
+ADMIN_PASSWORD=${ADMIN_PASSWORD}
+JWT_SECRET=${JWT_SECRET}
+JWT_EXPIRE_HOUR=1
+TOTP_ENCRYPTION_KEY=${TOTP_ENCRYPTION_KEY}
+EOF
+```
+
+执行后把 **`ADMIN_EMAIL` / `ADMIN_PASSWORD`** 记在安全处（或通过 `grep '^ADMIN_' "${TOKENKEY_STAGE0_LOCAL_ROOT}/.env"` 查看）。
+
+说明：
+
+- Compose 已为 `tokenkey` 容器设置 `AUTO_SETUP=true`，首次启动会按 `ADMIN_EMAIL` / `ADMIN_PASSWORD` 创建管理员。
+- `TOKENKEY_IMAGE`：默认拉 **`:latest`**；要与 `backend/cmd/server/VERSION` 或某次 CI 产物一致时改成该 tag；**未发布、仅测本机代码**时用本地 `docker build` 的 tag，并在 override 里 `pull_policy: never`（见下）。
+
+## 3) `Caddyfile`（本地 HTTP）
+
+写入 `"${TOKENKEY_STAGE0_LOCAL_ROOT}/caddy/Caddyfile"`。站点用 **`:80`**，避免浏览器/curl 带 `Host: localhost:8088` 时与 `http://localhost` 不匹配导致 503：
+
+```caddyfile
+{
+	email local@tokenkey.local
+}
+
+:80 {
+	encode zstd gzip
+
+	@static {
+		path /assets/*
+		path /logo.png
+		path /favicon.ico
+	}
+	header @static ?Cache-Control "public, max-age=31536000, immutable"
+
+	reverse_proxy tokenkey:8080 {
+		health_uri /health
+		health_interval 30s
+		health_timeout 10s
+		header_up X-Real-IP {remote_host}
+		header_up X-Forwarded-For {remote_host}
+		header_up X-Forwarded-Proto {scheme}
+		header_up X-Forwarded-Host {host}
+		transport http {
+			keepalive 120s
+			keepalive_idle_conns 64
+			compression off
+		}
+	}
+
+	request_body {
+		max_size 100MB
+	}
+
+	log {
+		output stdout
+		format json
+		level INFO
+	}
+}
+```
+
+## 4) `docker-compose.override.yml`
+
+写入 `"${TOKENKEY_STAGE0_LOCAL_ROOT}/docker-compose.override.yml"`。  
+**在运行 `docker compose` 的同一 shell 里**先 `export TOKENKEY_STAGE0_LOCAL_ROOT`（与 §1 一致），否则 `${TOKENKEY_STAGE0_LOCAL_ROOT}` 不会展开。
+
+```yaml
+services:
+  caddy:
+    ports:
+      - "8088:80"
+      - "8443:443"
+    volumes:
+      - ${TOKENKEY_STAGE0_LOCAL_ROOT}/caddy/Caddyfile:/etc/caddy/Caddyfile:ro
+      - ${TOKENKEY_STAGE0_LOCAL_ROOT}/caddy/data:/data
+      - ${TOKENKEY_STAGE0_LOCAL_ROOT}/caddy/config:/config
+  tokenkey:
+    volumes:
+      - ${TOKENKEY_STAGE0_LOCAL_ROOT}/app:/app/data
+  postgres:
+    volumes:
+      - ${TOKENKEY_STAGE0_LOCAL_ROOT}/postgres:/var/lib/postgresql/data
+      - ${TOKENKEY_STAGE0_LOCAL_ROOT}/pgdump:/pgdump
+  redis:
+    volumes:
+      - ${TOKENKEY_STAGE0_LOCAL_ROOT}/redis:/data
+```
+
+**使用 GHCR 发布镜像（推荐 smoke）**：保持上面片段即可（`tokenkey` 继承主文件的 `pull_policy: always`）。
+
+**使用本地构建镜像**：在 `tokenkey` 下增加：
+
+```yaml
+  tokenkey:
+    pull_policy: never
+```
+
+并在 `.env` 里把 `TOKENKEY_IMAGE` 设为与 `docker build -t ...` 一致。
+
+## 5) 校验配置、拉依赖、启动
+
+```bash
+export REPO_ROOT="$HOME/Codes/token/tk/sub2api"
+export TOKENKEY_STAGE0_LOCAL_ROOT="$HOME/Codes/token/tk/sub2api/.cache/tokenkey-stage0-local"
+
+docker compose \
+  -f "${REPO_ROOT}/deploy/aws/stage0/docker-compose.yml" \
+  -f "${TOKENKEY_STAGE0_LOCAL_ROOT}/docker-compose.override.yml" \
+  --env-file "${TOKENKEY_STAGE0_LOCAL_ROOT}/.env" \
+  config --quiet
+
+docker compose \
+  -f "${REPO_ROOT}/deploy/aws/stage0/docker-compose.yml" \
+  -f "${TOKENKEY_STAGE0_LOCAL_ROOT}/docker-compose.override.yml" \
+  --env-file "${TOKENKEY_STAGE0_LOCAL_ROOT}/.env" \
+  pull caddy postgres redis
+
+docker compose \
+  -f "${REPO_ROOT}/deploy/aws/stage0/docker-compose.yml" \
+  -f "${TOKENKEY_STAGE0_LOCAL_ROOT}/docker-compose.override.yml" \
+  --env-file "${TOKENKEY_STAGE0_LOCAL_ROOT}/.env" \
+  up -d
+```
+
+可选本地构建（父目录需含 `sub2api` + `new-api`）：
+
+```bash
+export TOKENKEY_NEWAPI_PARENT="$HOME/Codes/token/tk"
+cd "${TOKENKEY_NEWAPI_PARENT}"
+docker build -f sub2api/Dockerfile -t tokenkey-local:dev .
+```
+
+然后在 `.env` 中设置 `TOKENKEY_IMAGE=tokenkey-local:dev` 且 override 里 `pull_policy: never`。
+
+## 6) 验证
+
+**经 Caddy（与会话一致）**：
+
+```bash
+curl -sS -o /dev/null -w '%{http_code}\n' "http://127.0.0.1:8088/health"
+curl -sS -o /dev/null -w '%{http_code}\n' "http://127.0.0.1:8088/api/v1/settings/public"
+```
+
+**绕开 Caddy**（排查 503）：
+
+```bash
+docker exec tokenkey wget -q -T 5 -O - http://localhost:8080/health
+```
+
+**管理员登录**（不要把真实密码贴进聊天记录；口令仅取自本机 `.env`）：
+
+```bash
+export TOKENKEY_STAGE0_LOCAL_ROOT="$HOME/Codes/token/tk/sub2api/.cache/tokenkey-stage0-local"
+set -a
+source "${TOKENKEY_STAGE0_LOCAL_ROOT}/.env"
+set +a
+curl -sS -H 'Content-Type: application/json' \
+  -d "$(printf '{"email":"%s","password":"%s"}' "${ADMIN_EMAIL}" "${ADMIN_PASSWORD}")" \
+  "http://127.0.0.1:8088/api/v1/auth/login"
+```
+
+## 7) 销毁（停栈 + 删数据）
+
+```bash
+export REPO_ROOT="$HOME/Codes/token/tk/sub2api"
+export TOKENKEY_STAGE0_LOCAL_ROOT="$HOME/Codes/token/tk/sub2api/.cache/tokenkey-stage0-local"
+
+docker compose \
+  -f "${REPO_ROOT}/deploy/aws/stage0/docker-compose.yml" \
+  -f "${TOKENKEY_STAGE0_LOCAL_ROOT}/docker-compose.override.yml" \
+  --env-file "${TOKENKEY_STAGE0_LOCAL_ROOT}/.env" \
+  down
+
+# 删除状态（按需；确认路径后再执行）
+rm -rf "${TOKENKEY_STAGE0_LOCAL_ROOT}"
+```
+
+若曾 `docker build` 本地标签且不再使用：`docker rmi tokenkey-local:dev`（替换成实际 tag）。
+
+## 故障速查
+
+| 现象 | 处理 |
+| --- | --- |
+| `exec format error` | 镜像架构与主机不一致；Apple Silicon 拉取 **arm64** 或构建时指定 `--platform linux/arm64`。 |
+| Caddy 503、应用 healthy | 看 `docker logs tokenkey-caddy`；用容器内 `wget` 直连 `tokenkey:8080`；检查 Caddyfile 站点是否为 `:80`。 |
+| GHCR pull 403 | `docker login ghcr.io`；PAT 权限与镜像 owner。 |
+| 构建极慢 | 与会话相同：可改用具已推送到 GHCR 的 tag，跳本地多阶段构建。 |
+
+## 扩展阅读
+
+- `deploy/aws/README.md` — Stage 0 总览与生产升级 SOP  
+- `tokenkey-prod-release-deploy` — 打 tag、GHCR、`deploy-stage0` 真机发布

--- a/.cursor/skills/tokenkey-stage0-local-deploy/SKILL.md
+++ b/.cursor/skills/tokenkey-stage0-local-deploy/SKILL.md
@@ -1,15 +1,25 @@
 ---
 name: tokenkey-stage0-local-deploy
 description: >-
-  Local Docker stack matching deploy/aws Stage 0 (Caddy + app + Postgres + Redis). Skill
-  body pins this clone: REPO_ROOT under $HOME/Codes/token/tk/sub2api, new-api sibling parent,
-  state under REPO_ROOT/.cache/tokenkey-stage0-local. Use for deploy/aws simulation on
-  laptop, port 8088 smoke, AUTO_SETUP admin login, compose down + rm state.
+  Local Docker stack matching deploy/aws Stage 0 (Caddy + app + Postgres + Redis): export
+  $HOME-pinned paths, write .cache override + .env + Caddyfile, docker compose config/pull/up
+  with long timeouts for first pull/up, verify A curl via :8088, B bypass Caddy, optional C
+  tk_post_deploy_smoke when API key exists, then compose down + optional rm cache. Mirrors
+  tokenkey-prod-release-deploy posture (ordered flow, explicit verification, teardown).
 ---
 
 # TokenKey：本地模拟 `deploy/aws` Stage 0（Compose + 验证 + 销毁）
 
-与 `deploy/aws` 相同方式在笔记本起栈、验证后销毁。权威栈定义见 `deploy/aws/stage0/docker-compose.yml` 与 `deploy/aws/README.md`。
+适用于本仓库（TokenKey fork of sub2api）。栈定义见 `deploy/aws/stage0/docker-compose.yml`、`deploy/aws/README.md`；发版与真机 Stage0 路径见 **`tokenkey-prod-release-deploy`**。根目录 **`CLAUDE.md`** 仍为纪律来源（ARM、`new-api` sibling、pnpm 等）。
+
+## 一次性跑完（原则）
+
+- **顺序做完**：`export` 路径变量 → §1 目录 → §2 `.env`（含密钥）→ §3 `Caddyfile` → §4 `docker-compose.override.yml` → **`docker compose … config --quiet`** → **`pull`** → **`up -d`** → **`docker compose ps` 等服务 healthy** → **本节「真实测试」A → B →（有网关 key 时再 C）** → 再结束会话。**不要**在 `up -d` 刚返回就认为成功，也不管 health 就收工。
+- **`docker compose pull` / 首次拉起 tokenkey**：镜像层下载与数据库初始化可能各占 **数分钟量级**；Agent **须给 Shell 命令足够超时**（与 prod 技能的 `gh run watch` 同级思路），**避免**默认短时中断把 pull/up 误判为失败。
+- **健康检查**：执行 **`docker compose ps`**，确认 **`tokenkey` / `postgres` / `redis` / `caddy`**（与 `deploy/aws/stage0/docker-compose.yml` 中 `container_name` 一致）状态与健康就绪；`tokenkey` 依赖 postgres/redis healthy，首轮 **30–90s** 属常见。必要时 **`docker logs tokenkey`** / **`docker logs tokenkey-postgres`**。
+- **`rm -rf "${TOKENKEY_STAGE0_LOCAL_ROOT}"`**：仅在为 **空置栈**收尾且 **确认变量指向 `.cache/tokenkey-stage0-local`**（或自定目录）后再做；破坏性操作不要对错误的父路径执行。
+- **私有 GHCR**：`docker compose pull` tokenkey 镜像前应先在本机 **`docker login ghcr.io`**；Agent 若在沙箱里无法访问 daemon 或未继承登录态，需在可访问 Docker 的环境里执行 compose。
+- **`tk_post_deploy_smoke.sh`（与 prod 同款）**：见下文 **C**；需要 **可用的用户侧网关 API Key**（`POST_DEPLOY_SMOKE_API_KEY` 等）。纯 **AUTO_SETUP** 新栈往往还没有 key——此时 **只做 A+B 或再加管理员登录**即可，不要为了跑 C 而停下向人要 prod key。
 
 ## 本项目路径约定（本仓库克隆）
 
@@ -25,7 +35,9 @@ export TOKENKEY_STAGE0_LOCAL_ROOT="$HOME/Codes/token/tk/sub2api/.cache/tokenkey-
 
 - `REPO_ROOT`：本 git 仓库根（含 `backend/`、`deploy/aws/stage0/docker-compose.yml`）。
 - `TOKENKEY_NEWAPI_PARENT`：`Dockerfile` 要求的 **父目录**（与 `CLAUDE.md`「Sibling dependency: New API」一致）。
-- `TOKENKEY_STAGE0_LOCAL_ROOT`：本地 override、`.env`、Caddyfile、PG/Redis 数据落盘处；位于 `REPO_ROOT/.cache/...`，仓库已 `.gitignore` `.cache/`。
+- `TOKENKEY_STAGE0_LOCAL_ROOT`：本地 override、`.env`、Caddyfile、PG/Redis 数据落盘处；位于 `REPO_ROOT/.cache/...`，仓库根 `.gitignore` 已忽略 `.cache/`。
+
+为方便「单节复制粘贴」，**§2 / §5 / §7 / 部分自检**可能在代码块里重复写出 `export`。若你已在 **`本项目路径约定`** 或 **§1** 导出过 `REPO_ROOT` 与 `TOKENKEY_STAGE0_LOCAL_ROOT`，可跳过这些重复行。**§4 写 override 时仍须在当前 shell `export TOKENKEY_STAGE0_LOCAL_ROOT`**，否则 `${TOKENKEY_STAGE0_LOCAL_ROOT}` 在 YAML 挂载路径中会为空。
 
 默认 **GHCR 镜像坐标** 使用 **`:latest`**，避免与 `VERSION` 文件不同步导致拉取失败；需要与某次发版逐位对照时再显式改为 `ghcr.io/youxuanxue/sub2api:<VERSION>` 或 `sha-…`：
 
@@ -46,13 +58,14 @@ export TOKENKEY_IMAGE_DEFAULT="ghcr.io/youxuanxue/sub2api:latest"
 
 ## 前置条件
 
-- 仓库根目录；已安装 Docker 与 `docker compose`。
-- **private GHCR**：先 `docker login ghcr.io`（PAT 需 `read:packages`）。
-- 走**本地构建**镜像时：Docker 构建上下文必须是 **sub2api 与 new-api 同级目录**，见根目录 `Dockerfile` 头注释与 `CLAUDE.md`（`replace github.com/QuantumNous/new-api => ../../new-api`）。
+- Docker 与本机 **`docker compose`** 可用（Agent 须有权限与 daemon 通信）。
+- **`curl`**：`docker exec tokenkey wget`（镜像内）；宿主机也需 `curl` 做 `:8088` 探活。**可选完整烟测 C** 时需 **`jq` + `python3`**（`scripts/tk_post_deploy_smoke.sh` 依赖）。
+- **private GHCR**：先 `docker login ghcr.io`（PAT 需 `read:packages`），再拉 `ghcr.io/youxuanxue/sub2api:…`。
+- **本地镜像构建**：上下文必须是 **`TOKENKEY_NEWAPI_PARENT`**（`sub2api` + `new-api` 同级），见根目录 `Dockerfile` 头注释与 `CLAUDE.md`（`replace … => ../../new-api`）。
 
 ## 环境变量约定
 
-上一节 **`REPO_ROOT` / `TOKENKEY_NEWAPI_PARENT` / `TOKENKEY_STAGE0_LOCAL_ROOT`** 为项目级默认值；Compose 还要求在运行命令的 shell 里 **export `TOKENKEY_STAGE0_LOCAL_ROOT`**，以便 override YAML 展开卷路径。
+- **`REPO_ROOT` / `TOKENKEY_NEWAPI_PARENT` / `TOKENKEY_STAGE0_LOCAL_ROOT`**：见上节；凡运行 **`docker compose`** 的同一会话里都 **`export TOKENKEY_STAGE0_LOCAL_ROOT`**，否则 override 里 **`${TOKENKEY_STAGE0_LOCAL_ROOT}`** 卷路径为空或错位。
 
 ## 1) 准备目录
 
@@ -67,8 +80,7 @@ mkdir -p "${TOKENKEY_STAGE0_LOCAL_ROOT}"/{caddy,app,postgres,pgdump,redis}
 用新随机值（**勿复用示例或会话里出现过的十六进制串**）：
 
 ```bash
-export REPO_ROOT="$HOME/Codes/token/tk/sub2api"
-export TOKENKEY_STAGE0_LOCAL_ROOT="$HOME/Codes/token/tk/sub2api/.cache/tokenkey-stage0-local"
+# 若未导出：见上文「本项目路径约定」或 §1
 ADMIN_PASSWORD="$(openssl rand -hex 16)"
 POSTGRES_PASSWORD="$(openssl rand -hex 12)"
 JWT_SECRET="$(openssl rand -hex 32)"
@@ -193,8 +205,7 @@ services:
 ## 5) 校验配置、拉依赖、启动
 
 ```bash
-export REPO_ROOT="$HOME/Codes/token/tk/sub2api"
-export TOKENKEY_STAGE0_LOCAL_ROOT="$HOME/Codes/token/tk/sub2api/.cache/tokenkey-stage0-local"
+# 若未导出 REPO_ROOT / TOKENKEY_STAGE0_LOCAL_ROOT：见「本项目路径约定」或 §1
 
 docker compose \
   -f "${REPO_ROOT}/deploy/aws/stage0/docker-compose.yml" \
@@ -206,7 +217,7 @@ docker compose \
   -f "${REPO_ROOT}/deploy/aws/stage0/docker-compose.yml" \
   -f "${TOKENKEY_STAGE0_LOCAL_ROOT}/docker-compose.override.yml" \
   --env-file "${TOKENKEY_STAGE0_LOCAL_ROOT}/.env" \
-  pull caddy postgres redis
+  pull
 
 docker compose \
   -f "${REPO_ROOT}/deploy/aws/stage0/docker-compose.yml" \
@@ -214,6 +225,9 @@ docker compose \
   --env-file "${TOKENKEY_STAGE0_LOCAL_ROOT}/.env" \
   up -d
 ```
+
+**本地镜像、`pull_policy: never`**：`docker compose … pull` 可能因 **tokenkey** 仅存在本机 tag 而失败（仍会去 registry 解析）。可改为只拉基础镜像：  
+**`docker compose … pull caddy postgres redis`**，再 **`up -d`**（`tokenkey` 使用本地 `TOKENKEY_IMAGE`）。
 
 可选本地构建（父目录需含 `sub2api` + `new-api`）：
 
@@ -225,25 +239,46 @@ docker build -f sub2api/Dockerfile -t tokenkey-local:dev .
 
 然后在 `.env` 中设置 `TOKENKEY_IMAGE=tokenkey-local:dev` 且 override 里 `pull_policy: never`。
 
-## 6) 验证
+## 6) 真实测试（会话里尽量做完）
 
-**经 Caddy（与会话一致）**：
+`compose up -d` 成功只代表容器调度成功；Agent **仍需**按下面顺序自检（对齐 prod 技能的 **部署后还须本地验收**，只是探针改为本机 `:8088`）。
+
+### A — 经 Caddy 快速探活（无需网关 API Key）
 
 ```bash
 curl -sS -o /dev/null -w '%{http_code}\n' "http://127.0.0.1:8088/health"
 curl -sS -o /dev/null -w '%{http_code}\n' "http://127.0.0.1:8088/api/v1/settings/public"
 ```
 
-**绕开 Caddy**（排查 503）：
+期望均为 **HTTP 200**。若要对 public 接口更严：`curl -sS "http://127.0.0.1:8088/api/v1/settings/public" | jq -e '.code == 0' >/dev/null`（需本机 **`jq`**）。
+
+### B — 绕开 Caddy（应用本体 / 503 排查）
+
+确认 tokenkey 容器内直连 **8080** 正常：
 
 ```bash
 docker exec tokenkey wget -q -T 5 -O - http://localhost:8080/health
 ```
 
-**管理员登录**（不要把真实密码贴进聊天记录；口令仅取自本机 `.env`）：
+### C — 本地完整网关烟测（可选，与 prod 同款脚本）
+
+与 **`tokenkey-prod-release-deploy`** 中 **C** 使用同一 **`scripts/tk_post_deploy_smoke.sh`**，仅 **`TOKENKEY_BASE_URL`** 指向本机反代：
 
 ```bash
-export TOKENKEY_STAGE0_LOCAL_ROOT="$HOME/Codes/token/tk/sub2api/.cache/tokenkey-stage0-local"
+cd "${REPO_ROOT}" # 须在含 scripts/ 的仓库根；未导出 REPO_ROOT 时见「本项目路径约定」
+export TOKENKEY_BASE_URL=http://127.0.0.1:8088
+# 密钥解析顺序与 prod 相同：POST_DEPLOY_SMOKE_API_KEY → ANTHROPIC_AUTH_TOKEN → TK_TOKEN → TOKENKEY_API_KEY
+bash scripts/tk_post_deploy_smoke.sh
+```
+
+**前提**：须已有 **可用的用户侧网关 API Key**（新 AUTO_SETUP 栈通常没有——先在管理后台创建订阅用户与 key，或使用你专用于本地的测试 key）。**不得**打印完整 key；脚本只输出 `key_hint`。若缺 key：**不要卡住会话**，验收 **A+B**（及下方管理员登录）即可。
+
+### 管理员会话（常与 A/B 一起做，≠ C 的网关 key）
+
+用于验证 **AUTO_SETUP** 账密（**勿把密码粘贴到聊天**；只从本机 `.env` 引用）：
+
+```bash
+# TOKENKEY_STAGE0_LOCAL_ROOT 未导出时：见「本项目路径约定」或 §1
 set -a
 source "${TOKENKEY_STAGE0_LOCAL_ROOT}/.env"
 set +a
@@ -255,8 +290,7 @@ curl -sS -H 'Content-Type: application/json' \
 ## 7) 销毁（停栈 + 删数据）
 
 ```bash
-export REPO_ROOT="$HOME/Codes/token/tk/sub2api"
-export TOKENKEY_STAGE0_LOCAL_ROOT="$HOME/Codes/token/tk/sub2api/.cache/tokenkey-stage0-local"
+# 若未导出：见上文
 
 docker compose \
   -f "${REPO_ROOT}/deploy/aws/stage0/docker-compose.yml" \
@@ -270,16 +304,27 @@ rm -rf "${TOKENKEY_STAGE0_LOCAL_ROOT}"
 
 若曾 `docker build` 本地标签且不再使用：`docker rmi tokenkey-local:dev`（替换成实际 tag）。
 
+## 收尾备忘
+
+- **`${TOKENKEY_STAGE0_LOCAL_ROOT}`**（默认 `REPO_ROOT/.cache/tokenkey-stage0-local`）：勿将 `.env`、`docker-compose.override.yml`、PG/Redis 数据卷产物提交 git；路径在 `.gitignore` 的 `.cache/` 之下。**勿**把该目录当作仓库制品归档进 git。
+- 与 **`tokenkey-prod-release-deploy`** 不同：本地栈**无** `release.yml` 回写 **`VERSION`/sync-version`，流程末尾不必为这个栈再 **`git fetch`/`pull`**（除非仓库本身有其他变更）。
+
 ## 故障速查
 
 | 现象 | 处理 |
 | --- | --- |
-| `exec format error` | 镜像架构与主机不一致；Apple Silicon 拉取 **arm64** 或构建时指定 `--platform linux/arm64`。 |
-| Caddy 503、应用 healthy | 看 `docker logs tokenkey-caddy`；用容器内 `wget` 直连 `tokenkey:8080`；检查 Caddyfile 站点是否为 `:80`。 |
-| GHCR pull 403 | `docker login ghcr.io`；PAT 权限与镜像 owner。 |
-| 构建极慢 | 与会话相同：可改用具已推送到 GHCR 的 tag，跳本地多阶段构建。 |
+| Agent / 工具 **`docker compose pull` 或 `up` 超时** | 拉长超时或与用户说明网络慢；可拆成先 `pull` 再 `up`；未完成不要当失败退出。 |
+| `docker compose ps` 长期 non-healthy | 看 **`docker logs tokenkey`** / **`docker logs tokenkey-postgres`** / **`docker logs tokenkey-redis`**；等资源初始化或修 `.env` 密钥。 |
+| `exec format error` | 镜像架构与主机不一致；Apple Silicon 拉取 **arm64** 或 **`docker build --platform linux/arm64`**。 |
+| Caddy **503**、应用容器已起 | **`docker logs tokenkey-caddy`**；本节 **B** 直连 `localhost:8080`；核对 Caddyfile 站点是否为 **`:80`**。 |
+| GHCR pull **403** | `docker login ghcr.io`；PAT 权限与镜像 owner；Agent 若在沙箱无登录态须在用户 shell 登录。 |
+| **`tk_post_deploy_smoke.sh` 报缺 KEY** | 正常：新栈尚无用户 API key。**只做 A+B** 或先做管理员登录，再在后台发证后重跑 **C**。 |
+| **全量 `pull` 在 tokenkey 上失败（仅本地 tag）** | `.env` 用本地 build 且 override `pull_policy: never`：按上文改为 **`pull caddy postgres redis`** 后 **`up -d`**。 |
 
 ## 扩展阅读
 
-- `deploy/aws/README.md` — Stage 0 总览与生产升级 SOP  
-- `tokenkey-prod-release-deploy` — 打 tag、GHCR、`deploy-stage0` 真机发布
+- [tokenkey-prod-release-deploy](../tokenkey-prod-release-deploy/SKILL.md) — main / tag / `release.yml` / `deploy-stage0` / prod 烟测
+- `deploy/aws/README.md` — Stage 0 总览与 EC2 升级 SOP  
+- `.github/workflows/deploy-stage0.yml` — 真机 `tag` 形参（无 `v` 前缀）  
+- `scripts/tk_post_deploy_smoke.sh` — 与 prod **C** 相同的网关烟测脚本，改 `TOKENKEY_BASE_URL` 即可打本地 `:8088`  
+- `scripts/release-tag.sh` — 仅 prod 打 tag；本地默认不调用

--- a/.cursor/skills/tokenkey-stage0-local-deploy/SKILL.md
+++ b/.cursor/skills/tokenkey-stage0-local-deploy/SKILL.md
@@ -4,8 +4,8 @@ description: >-
   Local Docker stack matching deploy/aws Stage 0 (Caddy + app + Postgres + Redis): export
   $HOME-pinned paths, write .cache override + .env + Caddyfile, docker compose config/pull/up
   with long timeouts for first pull/up, verify A curl via :8088, B bypass Caddy, optional C
-  tk_post_deploy_smoke when API key exists, then compose down + optional rm cache. Mirrors
-  tokenkey-prod-release-deploy posture (ordered flow, explicit verification, teardown).
+  tk_post_deploy_smoke when API key exists; compose down keeps bind-mounted DB/Redis by default.
+  Optional rm only for intentional reset. Mirrors prod skill posture (order, verify, teardown).
 ---
 
 # TokenKey：本地模拟 `deploy/aws` Stage 0（Compose + 验证 + 销毁）
@@ -14,10 +14,11 @@ description: >-
 
 ## 一次性跑完（原则）
 
-- **顺序做完**：`export` 路径变量 → §1 目录 → §2 `.env`（含密钥）→ §3 `Caddyfile` → §4 `docker-compose.override.yml` → **`docker compose … config --quiet`** → **`pull`** → **`up -d`** → **`docker compose ps` 等服务 healthy** → **本节「真实测试」A → B →（有网关 key 时再 C）** → 再结束会话。**不要**在 `up -d` 刚返回就认为成功，也不管 health 就收工。
+- **顺序做完（首次冷启动）**：`export` 路径变量 → §1 目录 → §2 `.env`（含密钥）→ §3 `Caddyfile` → §4 `docker-compose.override.yml` → **`docker compose … config --quiet`** → **`pull`** → **`up -d`** → **`docker compose ps` 等服务 healthy** → **本节「真实测试」A → B →（有网关 key 时再 C）** → 结束或 **§7a `down`**。**日常增量测**：见「日常复用」，往往只需 §5 **`up -d`**，停栈用 §7a，勿默认 `rm -rf`。**不要**在 `up -d` 刚返回就认为成功，须 **`docker compose ps`** 等服务 healthy。
 - **`docker compose pull` / 首次拉起 tokenkey**：镜像层下载与数据库初始化可能各占 **数分钟量级**；Agent **须给 Shell 命令足够超时**（与 prod 技能的 `gh run watch` 同级思路），**避免**默认短时中断把 pull/up 误判为失败。
 - **健康检查**：执行 **`docker compose ps`**，确认 **`tokenkey` / `postgres` / `redis` / `caddy`**（与 `deploy/aws/stage0/docker-compose.yml` 中 `container_name` 一致）状态与健康就绪；`tokenkey` 依赖 postgres/redis healthy，首轮 **30–90s** 属常见。必要时 **`docker logs tokenkey`** / **`docker logs tokenkey-postgres`**。
-- **`rm -rf "${TOKENKEY_STAGE0_LOCAL_ROOT}"`**：仅在为 **空置栈**收尾且 **确认变量指向 `.cache/tokenkey-stage0-local`**（或自定目录）后再做；破坏性操作不要对错误的父路径执行。
+- **数据要「跨多次本地测试」保留**：override 把 PG/Redis/app 绑到宿主机 **`${TOKENKEY_STAGE0_LOCAL_ROOT}/{postgres,redis,app}`**。**`docker compose … down`（不带 `-v`）只删容器，不删这些目录**，账号、订阅、网关 key 等会一直在。**不要**把每次跑本 skill 都当成要执行 §7 的 **`rm -rf`**——那是**有意清盘**才做。日常循环：§5 **`up -d`** ↔ §7a **`down`**，固定同一个 `TOKENKEY_STAGE0_LOCAL_ROOT`。
+- **`rm -rf "${TOKENKEY_STAGE0_LOCAL_ROOT}"`**：仅 **§7b 有意清空**时用，且 **确认路径**（默认 `.cache/tokenkey-stage0-local`）；勿对错误父目录执行。
 - **私有 GHCR**：`docker compose pull` tokenkey 镜像前应先在本机 **`docker login ghcr.io`**；Agent 若在沙箱里无法访问 daemon 或未继承登录态，需在可访问 Docker 的环境里执行 compose。
 - **`tk_post_deploy_smoke.sh`（与 prod 同款）**：见下文 **C**；需要 **可用的用户侧网关 API Key**（`POST_DEPLOY_SMOKE_API_KEY` 等）。纯 **AUTO_SETUP** 新栈往往还没有 key——此时 **只做 A+B 或再加管理员登录**即可，不要为了跑 C 而停下向人要 prod key。
 
@@ -67,6 +68,14 @@ export TOKENKEY_IMAGE_DEFAULT="ghcr.io/youxuanxue/sub2api:latest"
 
 - **`REPO_ROOT` / `TOKENKEY_NEWAPI_PARENT` / `TOKENKEY_STAGE0_LOCAL_ROOT`**：见上节；凡运行 **`docker compose`** 的同一会话里都 **`export TOKENKEY_STAGE0_LOCAL_ROOT`**，否则 override 里 **`${TOKENKEY_STAGE0_LOCAL_ROOT}`** 卷路径为空或错位。
 
+## 日常复用（同一套本地数据）
+
+固定 **`TOKENKEY_STAGE0_LOCAL_ROOT`**（不要每次换一个目录），则：
+
+- **第二次及以后**：可 **跳过 §1–§4**（目录、`.env`、Caddyfile、override 已就绪），直接 **§5** `config` →（镜像有变再 `pull`）→ **`up -d`**。
+- **`.env` 与已有 Postgres 数据必须一致**：`POSTGRES_PASSWORD`（以及库名/用户）在 **首次 init** 时写入数据目录；若你 **重新跑 §2 随机生成新密码** 但 **没有删 `postgres/`**，新 `.env` 与旧库 **不匹配**，Postgres 会认证失败。**想保留数据** → 保留原 `.env`，只改 `TOKENKEY_IMAGE` 等非 PG 字段；**想换一套库** → 走 §7b 删掉 `postgres/`（或整目录）后再 §2。
+- **`AUTO_SETUP`**：库已存在时通常不会重复造管理员；继续用原 **`ADMIN_EMAIL` / `ADMIN_PASSWORD`**（见 §2 当时写入的 `.env`）。
+
 ## 1) 准备目录
 
 ```bash
@@ -76,6 +85,8 @@ mkdir -p "${TOKENKEY_STAGE0_LOCAL_ROOT}"/{caddy,app,postgres,pgdump,redis}
 ```
 
 ## 2) 生成秘密并写入 `.env`
+
+**何时跑本节**：**首次建站**或 **§7b 清空数据后**。**若 Postgres 数据目录已存在且要保留账号/业务数据**：**不要**整张覆盖 `.env` 或至少 **勿改 `POSTGRES_*`**（否则见「日常复用」与故障速查「password authentication failed」）。
 
 用新随机值（**勿复用示例或会话里出现过的十六进制串**）：
 
@@ -287,7 +298,11 @@ curl -sS -H 'Content-Type: application/json' \
   "http://127.0.0.1:8088/api/v1/auth/login"
 ```
 
-## 7) 销毁（停栈 + 删数据）
+## 7) 停栈 / 重置
+
+### 7a) 停栈，**保留** Postgres / Redis / app 数据（默认）
+
+释放端口与容器，**下次 `up -d` 数据仍在**：
 
 ```bash
 # 若未导出：见上文
@@ -297,10 +312,22 @@ docker compose \
   -f "${TOKENKEY_STAGE0_LOCAL_ROOT}/docker-compose.override.yml" \
   --env-file "${TOKENKEY_STAGE0_LOCAL_ROOT}/.env" \
   down
+```
 
-# 删除状态（按需；确认路径后再执行）
+**不要**在本机日常测试末尾自动加 **`rm -rf`**。本栈使用 **bind mount**，**`down` 默认不会删** `${TOKENKEY_STAGE0_LOCAL_ROOT}/postgres` 等目录（与「具名卷 + `down -v`」不同）。
+
+### 7b) **有意清空**（删库 / 回到「全新栈」）
+
+确认 **`TOKENKEY_STAGE0_LOCAL_ROOT`** 指向正确后：
+
+1. 先按 **7a** `down`（避免删目录时容器仍占用文件）。
+2. 再删状态目录，例如：
+
+```bash
 rm -rf "${TOKENKEY_STAGE0_LOCAL_ROOT}"
 ```
+
+之后从 **§1** 起重建；**§2** 会生成新密钥与 **新** `POSTGRES_PASSWORD`，与空数据目录一致。
 
 若曾 `docker build` 本地标签且不再使用：`docker rmi tokenkey-local:dev`（替换成实际 tag）。
 
@@ -315,6 +342,7 @@ rm -rf "${TOKENKEY_STAGE0_LOCAL_ROOT}"
 | --- | --- |
 | Agent / 工具 **`docker compose pull` 或 `up` 超时** | 拉长超时或与用户说明网络慢；可拆成先 `pull` 再 `up`；未完成不要当失败退出。 |
 | `docker compose ps` 长期 non-healthy | 看 **`docker logs tokenkey`** / **`docker logs tokenkey-postgres`** / **`docker logs tokenkey-redis`**；等资源初始化或修 `.env` 密钥。 |
+| **Postgres 起不来 / `password authentication failed`** | 多为 **§2 重写了 `POSTGRES_PASSWORD`** 但 **`postgres/` 数据目录仍是旧库**：恢复与旧库一致的 `.env`，或 **§7b** 删 `postgres/`（或整 `${TOKENKEY_STAGE0_LOCAL_ROOT}`）后重建。 |
 | `exec format error` | 镜像架构与主机不一致；Apple Silicon 拉取 **arm64** 或 **`docker build --platform linux/arm64`**。 |
 | Caddy **503**、应用容器已起 | **`docker logs tokenkey-caddy`**；本节 **B** 直连 `localhost:8080`；核对 Caddyfile 站点是否为 **`:80`**。 |
 | GHCR pull **403** | `docker login ghcr.io`；PAT 权限与镜像 owner；Agent 若在沙箱无登录态须在用户 shell 登录。 |

--- a/.gitignore
+++ b/.gitignore
@@ -135,10 +135,9 @@ backend/.installed
 # 其他
 # ===================
 tests
-# Ignore local Claude Code state; keep tracked project skills for CLI discovery.
+# Ignore local Claude Code state; `.claude/skills` is a tracked symlink → `.cursor/skills`.
 .claude/*
-!.claude/skills/
-!.claude/skills/**
+!.claude/skills
 .codex
 # docs/ — keep fully tracked (no subtree ignore here). Generated or local-only
 # material belongs under paths already ignored (.auto-reports/, output/, etc.).

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -317,9 +317,12 @@ section only records sub2api-specific choices.
   The "submodule first" order is enforced by preflight § 2 (warns on offline,
   fails if SHA missing locally) and by `dev-rules/rules/dev-rules-convention.mdc`.
 
-## Agent skill: prod release + AWS Stage0 deploy
+## Agent skills（Cursor / Claude Code）
 
-Full checklist (**同步 main → VERSION bump / 打 tag → `release.yml` → `deploy-stage0` prod → 真实烟测**) lives in [.cursor/skills/tokenkey-prod-release-deploy/SKILL.md](.cursor/skills/tokenkey-prod-release-deploy/SKILL.md). The same file is symlinked at `.claude/skills/tokenkey-prod-release-deploy/SKILL.md` so **Claude Code** picks it up as a project skill alongside **Cursor** (`.cursor/skills/…`).
+技能正文只在 [.cursor/skills/](.cursor/skills/) 下各目录的 `SKILL.md`。仓库根的 `.claude/skills` **仅为**指向 `.cursor/skills` 的 symlink（不要在 `.claude/skills/` 下创建真实文件或副本）。全局禁令见 **`dev-rules/global/CLAUDE.md`** §4「Agent Skills」。
+
+- **Prod 发布与 AWS Stage0：** [.cursor/skills/tokenkey-prod-release-deploy/SKILL.md](.cursor/skills/tokenkey-prod-release-deploy/SKILL.md) — `main` → VERSION/tag → `release.yml` → `deploy-stage0` prod → 烟测。
+- **本机 Stage0 Docker：** [.cursor/skills/tokenkey-stage0-local-deploy/SKILL.md](.cursor/skills/tokenkey-stage0-local-deploy/SKILL.md) — 与 `deploy/aws/stage0` 对齐的 compose、`AUTO_SETUP`、默认 `REPO_ROOT` / sibling `new-api` / `.cache` 路径见该 skill。
 
 ## Key Reference
 


### PR DESCRIPTION
## Summary

- **`.claude/skills`** is a single symlink to **`.cursor/skills`** so Claude Code and Cursor share one tree; remove the mistakenly tracked `.claude/skills/.../SKILL.md` path.
- **`.gitignore`**: un-ignore only the `.claude/skills` symlink entry.
- **`CLAUDE.md`**: one consolidated **Agent skills** section with links to both skills and a pointer to `dev-rules/global/CLAUDE.md` §4 for the global ban on real `.claude/skills/**` trees.
- **Skills**: refresh `tokenkey-prod-release-deploy` (full run, long `gh run watch`, env-based smoke); add `tokenkey-stage0-local-deploy` under `.cursor/skills/`.
- **`dev-rules` submodule**: bump to include tightened **Agent Skills** bullets in `global/CLAUDE.md` (already pushed to dev-rules `main`).

## Risk

Low — docs, ignore rules, symlinks, and agent-facing skills; submodule pointer update.

## Validation

- `./scripts/preflight.sh` passed on commit (including contract, sentinels, embedded frontend hash).

Made with [Cursor](https://cursor.com)