### PR TITLE
fix(stage0): keep storage safeguards effective across replacements

### DIFF
--- a/backend/internal/config/config.go
+++ b/backend/internal/config/config.go
@@ -1061,8 +1061,7 @@ type OpsCleanupConfig struct {
 	Schedule string `mapstructure:"schedule"`
 
 	// Retention days (0 disables that cleanup target).
-	//
-	// vNext requirement: default 30 days across ops datasets.
+	SystemLogRetentionDays     int `mapstructure:"system_log_retention_days"`
 	ErrorLogRetentionDays      int `mapstructure:"error_log_retention_days"`
 	MinuteMetricsRetentionDays int `mapstructure:"minute_metrics_retention_days"`
 	HourlyMetricsRetentionDays int `mapstructure:"hourly_metrics_retention_days"`
@@ -1544,8 +1543,8 @@ func setDefaults() {
 	viper.SetDefault("ops.use_preaggregated_tables", true)
 	viper.SetDefault("ops.cleanup.enabled", true)
 	viper.SetDefault("ops.cleanup.schedule", "0 2 * * *")
-	// Retention days: vNext defaults to 30 days across ops datasets.
-	viper.SetDefault("ops.cleanup.error_log_retention_days", 30)
+	viper.SetDefault("ops.cleanup.system_log_retention_days", 7)
+	viper.SetDefault("ops.cleanup.error_log_retention_days", 14)
 	viper.SetDefault("ops.cleanup.minute_metrics_retention_days", 30)
 	viper.SetDefault("ops.cleanup.hourly_metrics_retention_days", 30)
 	viper.SetDefault("ops.aggregation.enabled", true)
@@ -2569,6 +2568,9 @@ func (c *Config) Validate() error {
 	}
 	if c.Ops.Cleanup.ErrorLogRetentionDays < 0 {
 		return fmt.Errorf("ops.cleanup.error_log_retention_days must be non-negative")
+	}
+	if c.Ops.Cleanup.SystemLogRetentionDays < 0 {
+		return fmt.Errorf("ops.cleanup.system_log_retention_days must be non-negative")
 	}
 	if c.Ops.Cleanup.MinuteMetricsRetentionDays < 0 {
 		return fmt.Errorf("ops.cleanup.minute_metrics_retention_days must be non-negative")

--- a/backend/internal/config/config_test.go
+++ b/backend/internal/config/config_test.go
@@ -870,6 +870,27 @@ func TestValidateOpsCleanupScheduleRequired(t *testing.T) {
 	}
 }
 
+func TestLoadDefaultOpsCleanupRetentionConfig(t *testing.T) {
+	resetViperWithJWTSecret(t)
+
+	cfg, err := Load()
+	if err != nil {
+		t.Fatalf("Load() error: %v", err)
+	}
+	if cfg.Ops.Cleanup.SystemLogRetentionDays != 7 {
+		t.Fatalf("SystemLogRetentionDays = %d, want 7", cfg.Ops.Cleanup.SystemLogRetentionDays)
+	}
+	if cfg.Ops.Cleanup.ErrorLogRetentionDays != 14 {
+		t.Fatalf("ErrorLogRetentionDays = %d, want 14", cfg.Ops.Cleanup.ErrorLogRetentionDays)
+	}
+	if cfg.Ops.Cleanup.MinuteMetricsRetentionDays != 30 {
+		t.Fatalf("MinuteMetricsRetentionDays = %d, want 30", cfg.Ops.Cleanup.MinuteMetricsRetentionDays)
+	}
+	if cfg.Ops.Cleanup.HourlyMetricsRetentionDays != 30 {
+		t.Fatalf("HourlyMetricsRetentionDays = %d, want 30", cfg.Ops.Cleanup.HourlyMetricsRetentionDays)
+	}
+}
+
 func TestValidateConcurrencyPingInterval(t *testing.T) {
 	resetViperWithJWTSecret(t)
 
@@ -1433,6 +1454,11 @@ func TestValidateConfigErrors(t *testing.T) {
 			name:    "ops cleanup retention",
 			mutate:  func(c *Config) { c.Ops.Cleanup.ErrorLogRetentionDays = -1 },
 			wantErr: "ops.cleanup.error_log_retention_days",
+		},
+		{
+			name:    "ops cleanup system retention",
+			mutate:  func(c *Config) { c.Ops.Cleanup.SystemLogRetentionDays = -1 },
+			wantErr: "ops.cleanup.system_log_retention_days",
 		},
 		{
 			name:    "ops cleanup minute retention",

--- a/backend/internal/service/ops_cleanup_service.go
+++ b/backend/internal/service/ops_cleanup_service.go
@@ -214,8 +214,12 @@ func (s *OpsCleanupService) runCleanupOnce(ctx context.Context) (opsCleanupDelet
 			return out, err
 		}
 		out.alertEvents = n
+	}
 
-		n, err = deleteOldRowsByID(ctx, s.db, "ops_system_logs", "created_at", cutoff, batchSize, false)
+	// System/audit logs are high-volume diagnostics and can use a shorter retention.
+	if days := s.cfg.Ops.Cleanup.SystemLogRetentionDays; days > 0 {
+		cutoff := now.AddDate(0, 0, -days)
+		n, err := deleteOldRowsByID(ctx, s.db, "ops_system_logs", "created_at", cutoff, batchSize, false)
 		if err != nil {
 			return out, err
 		}

--- a/backend/internal/service/ops_cleanup_service_test.go
+++ b/backend/internal/service/ops_cleanup_service_test.go
@@ -39,7 +39,7 @@ func TestOpsCleanupServiceRunCleanupOnceUsesSeparateLogRetentions(t *testing.T) 
 	if err != nil {
 		t.Fatalf("sqlmock.New: %v", err)
 	}
-	defer db.Close()
+	defer func() { _ = db.Close() }()
 
 	cfg := &config.Config{
 		Ops: config.OpsConfig{

--- a/backend/internal/service/ops_cleanup_service_test.go
+++ b/backend/internal/service/ops_cleanup_service_test.go
@@ -1,0 +1,78 @@
+package service
+
+import (
+	"context"
+	"database/sql/driver"
+	"testing"
+	"time"
+
+	"github.com/DATA-DOG/go-sqlmock"
+	"github.com/Wei-Shaw/sub2api/internal/config"
+)
+
+type cutoffDaysArg struct {
+	days int
+}
+
+func (a cutoffDaysArg) Match(v driver.Value) bool {
+	t, ok := v.(time.Time)
+	if !ok {
+		return false
+	}
+	age := time.Since(t)
+	want := time.Duration(a.days) * 24 * time.Hour
+	return age >= want-time.Minute && age <= want+time.Minute
+}
+
+func expectCleanupTable(t *testing.T, mock sqlmock.Sqlmock, table string, cutoffDays int, deleted int64) {
+	t.Helper()
+	mock.ExpectExec(table).
+		WithArgs(cutoffDaysArg{days: cutoffDays}, 5000).
+		WillReturnResult(sqlmock.NewResult(0, deleted))
+	mock.ExpectExec(table).
+		WithArgs(cutoffDaysArg{days: cutoffDays}, 5000).
+		WillReturnResult(sqlmock.NewResult(0, 0))
+}
+
+func TestOpsCleanupServiceRunCleanupOnceUsesSeparateLogRetentions(t *testing.T) {
+	db, mock, err := sqlmock.New(sqlmock.QueryMatcherOption(sqlmock.QueryMatcherRegexp))
+	if err != nil {
+		t.Fatalf("sqlmock.New: %v", err)
+	}
+	defer db.Close()
+
+	cfg := &config.Config{
+		Ops: config.OpsConfig{
+			Cleanup: config.OpsCleanupConfig{
+				SystemLogRetentionDays:     7,
+				ErrorLogRetentionDays:      14,
+				MinuteMetricsRetentionDays: 0,
+				HourlyMetricsRetentionDays: 0,
+			},
+		},
+	}
+	svc := NewOpsCleanupService(&opsRepoMock{}, db, nil, cfg, nil)
+
+	expectCleanupTable(t, mock, "ops_error_logs", 14, 3)
+	expectCleanupTable(t, mock, "ops_retry_attempts", 14, 2)
+	expectCleanupTable(t, mock, "ops_alert_events", 14, 1)
+	expectCleanupTable(t, mock, "ops_system_logs", 7, 5)
+	expectCleanupTable(t, mock, "ops_system_log_cleanup_audits", 7, 4)
+
+	counts, err := svc.runCleanupOnce(context.Background())
+	if err != nil {
+		t.Fatalf("runCleanupOnce() error = %v", err)
+	}
+	if counts.errorLogs != 3 || counts.retryAttempts != 2 || counts.alertEvents != 1 {
+		t.Fatalf("unexpected error-like cleanup counts: %+v", counts)
+	}
+	if counts.systemLogs != 5 || counts.logAudits != 4 {
+		t.Fatalf("unexpected system cleanup counts: %+v", counts)
+	}
+	if counts.systemMetrics != 0 || counts.hourlyPreagg != 0 || counts.dailyPreagg != 0 {
+		t.Fatalf("metrics cleanup should be disabled in this test: %+v", counts)
+	}
+	if err := mock.ExpectationsWereMet(); err != nil {
+		t.Fatalf("unmet sql expectations: %v", err)
+	}
+}

--- a/deploy/aws/cloudformation/stage0-single-ec2.yaml
+++ b/deploy/aws/cloudformation/stage0-single-ec2.yaml
@@ -255,6 +255,16 @@ Resources:
                 Resource: '*'
               - Effect: Allow
                 Action:
+                  - ec2:DescribeVolumes
+                Resource: '*'
+              - Effect: Allow
+                Action:
+                  - ec2:AttachVolume
+                Resource:
+                  - !Sub 'arn:${AWS::Partition}:ec2:${AWS::Region}:${AWS::AccountId}:volume/*'
+                  - !Sub 'arn:${AWS::Partition}:ec2:${AWS::Region}:${AWS::AccountId}:instance/*'
+              - Effect: Allow
+                Action:
                   - ssm:GetParameter
                 Resource: !Sub 'arn:${AWS::Partition}:ssm:${AWS::Region}:${AWS::AccountId}:parameter/${ProjectName}/${Environment}/stage0/*'
       Tags:
@@ -311,6 +321,7 @@ Resources:
     Type: AWS::EC2::Instance
     DependsOn:
       - IGWAttach
+      - DataVolume
       - TokenkeyStage0ComposeGzipB64Parameter
       - TokenkeyStage0CaddyGzipB64Parameter
       - TokenkeyQaStaleCleanupScriptB64Parameter
@@ -376,12 +387,58 @@ Resources:
           chmod +x /usr/local/lib/docker/cli-plugins/docker-compose
           usermod -aG docker ec2-user
 
-          # --- 2a. mount persistent data volume (preflight-debt §9.b) ----------
-          # The CFN DataVolume resource is attached at /dev/sdf; on AL2023 NVMe
-          # this surfaces as /dev/nvme1n1 (or /dev/nvme2n1 if root happens to be
-          # nvme2). Wait up to 90s for the kernel to enumerate it before failing
-          # — VolumeAttachment creates concurrently with the instance and may
-          # take a few seconds to appear after first boot.
+          # --- 2a. attach + mount persistent data volume (preflight-debt §9.b) -
+          # Attach is done here instead of AWS::EC2::VolumeAttachment. During
+          # instance replacement CloudFormation creates the new instance before
+          # deleting the old attachment; a separate VolumeAttachment resource
+          # therefore races with the still-attached EBS volume and fails with
+          # AlreadyExists. UserData can wait until the old instance releases it.
+          DATA_VOLUME_ID='${DataVolume}'
+          DATA_DEVICE='/dev/sdf'
+          IMDS_TOKEN="$(curl -fsS -X PUT "http://169.254.169.254/latest/api/token" -H "X-aws-ec2-metadata-token-ttl-seconds: 21600")"
+          INSTANCE_ID="$(curl -fsS -H "X-aws-ec2-metadata-token: ${!IMDS_TOKEN}" http://169.254.169.254/latest/meta-data/instance-id)"
+          ATTACHED_TO=""
+          ATTACH_STATE=""
+          for attempt in $(seq 1 90); do
+            read -r ATTACHED_TO ATTACH_STATE < <(aws ec2 describe-volumes \
+              --region "${!REGION}" \
+              --volume-ids "${!DATA_VOLUME_ID}" \
+              --query 'Volumes[0].Attachments[0].[InstanceId,State]' \
+              --output text 2>/dev/null || echo "None None")
+            if [ "${!ATTACHED_TO}" = "${!INSTANCE_ID}" ]; then
+              echo "tokenkey data volume ${!DATA_VOLUME_ID} already attached to this instance (${!ATTACH_STATE})"
+              break
+            fi
+            if [ -z "${!ATTACHED_TO}" ] || [ "${!ATTACHED_TO}" = "None" ]; then
+              echo "attaching tokenkey data volume ${!DATA_VOLUME_ID} to ${!INSTANCE_ID}"
+              aws ec2 attach-volume \
+                --region "${!REGION}" \
+                --volume-id "${!DATA_VOLUME_ID}" \
+                --instance-id "${!INSTANCE_ID}" \
+                --device "${!DATA_DEVICE}"
+              break
+            fi
+            echo "waiting for tokenkey data volume ${!DATA_VOLUME_ID}; currently ${!ATTACH_STATE} on ${!ATTACHED_TO}"
+            sleep 10
+          done
+          if [ "${!ATTACHED_TO}" != "${!INSTANCE_ID}" ]; then
+            for attempt in $(seq 1 60); do
+              read -r ATTACHED_TO ATTACH_STATE < <(aws ec2 describe-volumes \
+                --region "${!REGION}" \
+                --volume-ids "${!DATA_VOLUME_ID}" \
+                --query 'Volumes[0].Attachments[0].[InstanceId,State]' \
+                --output text 2>/dev/null || echo "None None")
+              [ "${!ATTACHED_TO}" = "${!INSTANCE_ID}" ] && break
+              sleep 5
+            done
+          fi
+          if [ "${!ATTACHED_TO}" != "${!INSTANCE_ID}" ]; then
+            echo "FATAL: tokenkey data volume ${!DATA_VOLUME_ID} did not attach to ${!INSTANCE_ID}" >&2
+            exit 1
+          fi
+
+          # On AL2023 NVMe, /dev/sdf surfaces as /dev/nvme1n1 (or another
+          # non-root nvme device). Wait for the kernel to enumerate it.
           DATA_DEV=""
           for attempt in 1 2 3 4 5 6 7 8 9; do
             for cand in /dev/nvme1n1 /dev/nvme2n1 /dev/nvme3n1 /dev/xvdf /dev/sdf; do
@@ -476,15 +533,27 @@ Resources:
           # we ever got the order wrong.
           SECRET_FILE=/var/lib/tokenkey/.env.secret
           if [ ! -f "${!SECRET_FILE}" ]; then
-            echo "Generating new persistent secrets at ${!SECRET_FILE} (first boot of data volume)"
-            gen_secret() { openssl rand -hex 32; }
-            gen_pwd()    { openssl rand -hex 24; }
             umask 077
-            cat > "${!SECRET_FILE}" <<SECEOF
+            if [ -f /var/lib/tokenkey/.env ] \
+              && grep -q '^POSTGRES_PASSWORD=' /var/lib/tokenkey/.env \
+              && grep -q '^JWT_SECRET=' /var/lib/tokenkey/.env \
+              && grep -q '^TOTP_ENCRYPTION_KEY=' /var/lib/tokenkey/.env; then
+              echo "Seeding ${!SECRET_FILE} from legacy /var/lib/tokenkey/.env"
+              {
+                grep -m1 '^POSTGRES_PASSWORD=' /var/lib/tokenkey/.env
+                grep -m1 '^JWT_SECRET=' /var/lib/tokenkey/.env
+                grep -m1 '^TOTP_ENCRYPTION_KEY=' /var/lib/tokenkey/.env
+              } > "${!SECRET_FILE}"
+            else
+              echo "Generating new persistent secrets at ${!SECRET_FILE} (first boot of data volume)"
+              gen_secret() { openssl rand -hex 32; }
+              gen_pwd()    { openssl rand -hex 24; }
+              cat > "${!SECRET_FILE}" <<SECEOF
           POSTGRES_PASSWORD=$(gen_pwd)
           JWT_SECRET=$(gen_secret)
           TOTP_ENCRYPTION_KEY=$(gen_secret)
           SECEOF
+            fi
             chmod 0600 "${!SECRET_FILE}"
             chown root:root "${!SECRET_FILE}"
           else
@@ -719,11 +788,11 @@ Resources:
   #                              one is created (operator must reconcile).
   # AvailabilityZone — must equal the instance's AZ; both are pinned to the
   #                    first AZ via !Select [0, !GetAZs ''].
-  # The mount is performed by UserData (see "data volume" section). All
-  # /var/lib/tokenkey/{postgres,redis,caddy,app,pgdump,.env.secret} state lives
-  # here, so that EC2 instance replacement (e.g. ImageTag CFN parameter change
-  # → UserData re-substitution → BlockDeviceMappings churn → root EBS thrown
-  # away) NO LONGER destroys application data.
+  # The attach + mount is performed by UserData (see "data volume" section).
+  # All /var/lib/tokenkey/{postgres,redis,caddy,app,pgdump,.env.secret} state
+  # lives here, so that EC2 instance replacement (e.g. ImageTag CFN parameter
+  # change → UserData re-substitution → BlockDeviceMappings churn → root EBS
+  # thrown away) NO LONGER destroys application data.
   DataVolume:
     Type: AWS::EC2::Volume
     DeletionPolicy: Retain
@@ -739,13 +808,6 @@ Resources:
         - {Key: Environment, Value: !Ref Environment}
         - {Key: Backup, Value: stage0}
         - {Key: Purpose, Value: 'tokenkey-state-postgres-redis-caddy'}
-
-  DataVolumeAttachment:
-    Type: AWS::EC2::VolumeAttachment
-    Properties:
-      Device: /dev/sdf
-      InstanceId: !Ref Instance
-      VolumeId: !Ref DataVolume
 
   EIPAssoc:
     Type: AWS::EC2::EIPAssociation


### PR DESCRIPTION
## Summary
- Move Stage0 data-volume attachment into EC2 UserData so instance replacement can wait for the retained EBS volume instead of racing CloudFormation `VolumeAttachment` replacement.
- Preserve existing PostgreSQL/JWT/TOTP secrets by seeding `.env.secret` from the retained data volume when replacing the instance.
- Split ops log cleanup retention defaults to 7 days for system logs and 14 days for error logs, while keeping metrics retention and `usage_logs` unchanged.

## Risk
- CloudFormation/UserData changes affect Stage0 replacement bootstrap, but production has already been exercised through the same repair path and preflight is green.
- Ops cleanup only narrows internal diagnostic log retention; billing/usage records are not touched.

## Validation
- `go test -tags=unit ./internal/config ./internal/service -run 'TestLoadDefaultOpsCleanupRetentionConfig|TestValidateConfigInvalidCases|TestOpsCleanupServiceRunCleanupOnceUsesSeparateLogRetentions'`
- `./scripts/preflight.sh`
- Review: no blocking issues found in the staged diff.

Made with [Cursor](https://cursor.com)