### PR TITLE
Fix QA export stream default field

### DIFF
--- a/backend/internal/observability/qa/service.go
+++ b/backend/internal/observability/qa/service.go
@@ -435,6 +435,7 @@ func exportQARecordRow(record *ent.QARecord) map[string]any {
 	row["input_tokens"] = record.InputTokens
 	row["output_tokens"] = record.OutputTokens
 	row["cached_tokens"] = record.CachedTokens
+	row["stream"] = record.Stream
 	row["tool_calls_present"] = record.ToolCallsPresent
 	row["multimodal_present"] = record.MultimodalPresent
 	if record.Tags == nil {

--- a/backend/internal/observability/qa/service_export_test.go
+++ b/backend/internal/observability/qa/service_export_test.go
@@ -466,6 +466,7 @@ func TestUS074_ExportUserData_FillsDefaultValuedFields(t *testing.T) {
 	var row map[string]any
 	require.NoError(t, json.Unmarshal(bytes.TrimSpace(raw), &row))
 	require.Equal(t, float64(0), row["cached_tokens"])
+	require.Equal(t, false, row["stream"])
 	require.Equal(t, false, row["tool_calls_present"])
 	require.Equal(t, false, row["multimodal_present"])
 	require.Equal(t, []any{}, row["tags"])


### PR DESCRIPTION
## Summary
- Preserve `stream=false` in exported `qa_records.jsonl` rows so strict evidence consumers receive the stable default-valued field.
- Extend the QA export default-field regression test to cover `stream`.

## Risk
- Low: export-row normalization only; no gateway scheduling, billing, capture persistence, or runtime routing behavior changes.

## Validation
- `go -C backend test -tags=unit ./internal/observability/qa -run TestUS074_ExportUserData_FillsDefaultValuedFields -count=1`
- `./scripts/preflight.sh` (via pre-commit)

Fixes #78

🤖 Generated with [Claude Code](https://claude.com/claude-code)