### PR TITLE
Schedule daily upstream merge agent PRs

### DIFF
--- a/.github/workflows/pr-repair-agent.yml
+++ b/.github/workflows/pr-repair-agent.yml
@@ -1,0 +1,273 @@
+name: PR Repair Agent
+
+# Claude Code CLI repair loop for TokenKey PRs. Normal PRs are repaired against
+# CLAUDE.md and the failed logs; merge/upstream-* PRs additionally load the
+# upstream merge skill SOP because they require a real --no-ff merge commit and
+# stricter merge-hygiene constraints.
+
+on:
+  workflow_run:
+    workflows:
+      - CI
+      - Upstream Merge PR Shape
+      - Security Scan
+    types: [completed]
+  workflow_dispatch:
+    inputs:
+      pr_number:
+        description: Open PR number to repair
+        required: true
+        type: string
+      failed_run_id:
+        description: Optional failed run id whose logs should be included
+        required: false
+        type: string
+
+permissions:
+  contents: write
+  pull-requests: write
+  issues: write
+  actions: read
+
+concurrency:
+  group: pr-repair-${{ github.event.workflow_run.pull_requests[0].number || inputs.pr_number || github.run_id }}
+  cancel-in-progress: false
+
+jobs:
+  repair:
+    if: >-
+      github.event_name == 'workflow_dispatch' ||
+      (github.event.workflow_run.conclusion == 'failure' || github.event.workflow_run.conclusion == 'timed_out' || github.event.workflow_run.conclusion == 'cancelled')
+    runs-on: ubuntu-latest
+    timeout-minutes: 120
+    steps:
+      - name: Check required secrets
+        env:
+          ANTHROPIC_AUTH_TOKEN: ${{ secrets.ANTHROPIC_AUTH_TOKEN }}
+          UPSTREAM_MERGE_GH_TOKEN: ${{ secrets.UPSTREAM_MERGE_GH_TOKEN }}
+        run: |
+          missing=0
+          if [ -z "${ANTHROPIC_AUTH_TOKEN:-}" ]; then
+            echo "::error::Missing required secret ANTHROPIC_AUTH_TOKEN for Claude Code CLI."
+            missing=1
+          fi
+          if [ -z "${UPSTREAM_MERGE_GH_TOKEN:-}" ]; then
+            echo "::error::Missing required secret UPSTREAM_MERGE_GH_TOKEN for branch updates and PR comments."
+            missing=1
+          fi
+          exit "$missing"
+
+      - name: Resolve target PR
+        id: target
+        env:
+          GH_TOKEN: ${{ secrets.UPSTREAM_MERGE_GH_TOKEN }}
+          MANUAL_PR: ${{ inputs.pr_number }}
+          MANUAL_RUN_ID: ${{ inputs.failed_run_id }}
+        run: |
+          set -euo pipefail
+          if [ "${GITHUB_EVENT_NAME}" = "workflow_dispatch" ]; then
+            PR_NUMBER="$MANUAL_PR"
+            FAILED_RUN_ID="${MANUAL_RUN_ID:-}"
+            WORKFLOW_NAME="manual-dispatch"
+            RUN_URL=""
+          else
+            PR_NUMBER="$(jq -r '.workflow_run.pull_requests[0].number // empty' "$GITHUB_EVENT_PATH")"
+            FAILED_RUN_ID="$(jq -r '.workflow_run.id' "$GITHUB_EVENT_PATH")"
+            WORKFLOW_NAME="$(jq -r '.workflow_run.name' "$GITHUB_EVENT_PATH")"
+            RUN_URL="$(jq -r '.workflow_run.html_url' "$GITHUB_EVENT_PATH")"
+          fi
+
+          if [ -z "$PR_NUMBER" ]; then
+            echo "skip=true" >> "$GITHUB_OUTPUT"
+            echo "reason=failed run is not associated with a PR" >> "$GITHUB_OUTPUT"
+            exit 0
+          fi
+
+          PR_JSON="$(gh pr view "$PR_NUMBER" --json number,state,baseRefName,headRefName,headRepositoryOwner,url,title)"
+          STATE="$(jq -r '.state' <<<"$PR_JSON")"
+          BASE="$(jq -r '.baseRefName' <<<"$PR_JSON")"
+          BRANCH="$(jq -r '.headRefName' <<<"$PR_JSON")"
+          OWNER="$(jq -r '.headRepositoryOwner.login' <<<"$PR_JSON")"
+          URL="$(jq -r '.url' <<<"$PR_JSON")"
+          TITLE="$(jq -r '.title' <<<"$PR_JSON")"
+
+          if [ "$STATE" != "OPEN" ] || [ "$BASE" != "main" ]; then
+            echo "skip=true" >> "$GITHUB_OUTPUT"
+            echo "reason=PR #$PR_NUMBER is not an open PR to main" >> "$GITHUB_OUTPUT"
+            exit 0
+          fi
+          if [ "$OWNER" != "${GITHUB_REPOSITORY_OWNER}" ]; then
+            echo "skip=true" >> "$GITHUB_OUTPUT"
+            echo "reason=PR #$PR_NUMBER head repository owner is $OWNER, not ${GITHUB_REPOSITORY_OWNER}" >> "$GITHUB_OUTPUT"
+            exit 0
+          fi
+
+          IS_UPSTREAM=false
+          if [[ "$BRANCH" == merge/upstream-* ]]; then
+            IS_UPSTREAM=true
+          fi
+          echo "is_upstream=$IS_UPSTREAM" >> "$GITHUB_OUTPUT"
+          echo "skip=false" >> "$GITHUB_OUTPUT"
+          echo "pr_number=$PR_NUMBER" >> "$GITHUB_OUTPUT"
+          echo "branch=$BRANCH" >> "$GITHUB_OUTPUT"
+          echo "url=$URL" >> "$GITHUB_OUTPUT"
+          echo "title=$TITLE" >> "$GITHUB_OUTPUT"
+          echo "failed_run_id=$FAILED_RUN_ID" >> "$GITHUB_OUTPUT"
+          echo "workflow_name=$WORKFLOW_NAME" >> "$GITHUB_OUTPUT"
+          echo "run_url=$RUN_URL" >> "$GITHUB_OUTPUT"
+
+      - name: Stop when event does not target a repairable PR
+        if: steps.target.outputs.skip == 'true'
+        run: echo "${{ steps.target.outputs.reason }}"
+
+      - uses: actions/checkout@v6
+        if: steps.target.outputs.skip != 'true'
+        with:
+          fetch-depth: 0
+          submodules: recursive
+          ref: ${{ steps.target.outputs.branch }}
+          persist-credentials: false
+
+      - name: Configure authenticated origin
+        if: steps.target.outputs.skip != 'true'
+        env:
+          UPSTREAM_MERGE_GH_TOKEN: ${{ secrets.UPSTREAM_MERGE_GH_TOKEN }}
+        run: git remote set-url origin "https://x-access-token:${UPSTREAM_MERGE_GH_TOKEN}@github.com/${GITHUB_REPOSITORY}.git"
+
+      - uses: ./.github/actions/cache-and-checkout-new-api
+        if: steps.target.outputs.skip != 'true'
+
+      - name: Set up Go
+        if: steps.target.outputs.skip != 'true'
+        uses: actions/setup-go@v6
+        with:
+          go-version-file: backend/go.mod
+          check-latest: false
+          cache: true
+          cache-dependency-path: backend/go.sum
+
+      - name: Setup pnpm
+        if: steps.target.outputs.skip != 'true'
+        uses: pnpm/action-setup@v4
+        with:
+          version: 9
+
+      - name: Setup Node.js
+        if: steps.target.outputs.skip != 'true'
+        uses: actions/setup-node@v6
+        with:
+          node-version: '20'
+          cache: 'pnpm'
+          cache-dependency-path: frontend/pnpm-lock.yaml
+
+      - name: Install frontend dependencies
+        if: steps.target.outputs.skip != 'true'
+        run: pnpm install --frozen-lockfile
+        working-directory: frontend
+
+      - name: Install Claude Code CLI
+        if: steps.target.outputs.skip != 'true'
+        env:
+          ANTHROPIC_AUTH_TOKEN: ${{ secrets.ANTHROPIC_AUTH_TOKEN }}
+        run: bash scripts/setup-claude-code.sh
+
+      - name: Configure git identity
+        if: steps.target.outputs.skip != 'true'
+        run: |
+          git config user.name "tk-pr-repair-agent[bot]"
+          git config user.email "pr-repair-agent@tokenkey.dev"
+
+      - name: Collect failed run logs
+        if: steps.target.outputs.skip != 'true'
+        env:
+          GH_TOKEN: ${{ secrets.UPSTREAM_MERGE_GH_TOKEN }}
+          FAILED_RUN_ID: ${{ steps.target.outputs.failed_run_id }}
+        run: |
+          mkdir -p /tmp/pr-repair
+          if [ -n "${FAILED_RUN_ID:-}" ]; then
+            gh run view "$FAILED_RUN_ID" --log-failed > /tmp/pr-repair/failed-run.log 2>&1 || \
+              gh run view "$FAILED_RUN_ID" --log > /tmp/pr-repair/failed-run.log 2>&1 || true
+          else
+            echo "No failed run id supplied; inspect current PR checks via gh." > /tmp/pr-repair/failed-run.log
+          fi
+          if [ -s /tmp/pr-repair/failed-run.log ]; then
+            tail -n 1200 /tmp/pr-repair/failed-run.log > /tmp/pr-repair/failed-run-tail.log
+          fi
+
+      - name: Build repair prompt
+        if: steps.target.outputs.skip != 'true'
+        env:
+          PR_NUMBER: ${{ steps.target.outputs.pr_number }}
+          PR_URL: ${{ steps.target.outputs.url }}
+          BRANCH: ${{ steps.target.outputs.branch }}
+          WORKFLOW_NAME: ${{ steps.target.outputs.workflow_name }}
+          RUN_URL: ${{ steps.target.outputs.run_url }}
+          IS_UPSTREAM: ${{ steps.target.outputs.is_upstream }}
+        run: |
+          cat > /tmp/pr-repair-prompt.txt <<EOF
+          You are repairing a TokenKey PR with Claude Code CLI.
+
+          Repository rules:
+          - Follow CLAUDE.md and project instructions exactly.
+          - Fix only what is needed for the failed checks and TokenKey principles.
+          - Do not merge the PR.
+          - Do not bypass hooks or skip validation.
+          - Run focused validation for changed areas plus ./scripts/preflight.sh when feasible.
+          - If you changed files, commit and push back to branch $BRANCH.
+          - If you cannot safely fix the issue, leave the working tree clean and comment on PR #$PR_NUMBER with the blocker and the exact logs/decision needed.
+
+          EOF
+          if [ "$IS_UPSTREAM" = "true" ]; then
+            cat >> /tmp/pr-repair-prompt.txt <<EOF
+          This is a merge/upstream-* PR, so additionally follow this upstream merge skill SOP exactly:
+
+          EOF
+            cat .cursor/skills/tokenkey-upstream-merge/SKILL.md >> /tmp/pr-repair-prompt.txt
+          fi
+          cat >> /tmp/pr-repair-prompt.txt <<EOF
+
+          ## Repair task
+
+          Repair PR #$PR_NUMBER on branch $BRANCH: $PR_URL
+          Failed workflow: $WORKFLOW_NAME
+          Failed run: ${RUN_URL:-not provided}
+          Is upstream merge PR: $IS_UPSTREAM
+
+          Required behavior:
+          - Diagnose the failed check logs below.
+          - Keep the fix scoped to this PR's intent.
+          - For normal TokenKey feature/fix PRs, do not introduce upstream-merge-specific changes.
+          - For merge/upstream-* PRs, preserve upstream features by default and keep TokenKey-only fixes behind companion/facade/component boundaries where possible.
+
+          ## Failed logs tail
+
+          EOF
+          cat /tmp/pr-repair/failed-run-tail.log >> /tmp/pr-repair-prompt.txt
+
+      - name: Run Claude repair agent
+        if: steps.target.outputs.skip != 'true'
+        env:
+          ANTHROPIC_AUTH_TOKEN: ${{ secrets.ANTHROPIC_AUTH_TOKEN }}
+          ANTHROPIC_BASE_URL: https://api.tokenkey.dev
+          GH_TOKEN: ${{ secrets.UPSTREAM_MERGE_GH_TOKEN }}
+          CLAUDE_CODE_DISABLE_ADAPTIVE_THINKING: "1"
+          MAX_THINKING_TOKENS: "31999"
+          CLAUDE_CODE_AUTOCOMPACT_PCT_OVERRIDE: "60"
+          CLAUDE_CODE_ATTRIBUTION_HEADER: "0"
+          ANTHROPIC_MODEL: "opus[1m]"
+        run: |
+          claude -p "$(cat /tmp/pr-repair-prompt.txt)" \
+            --model "opus[1m]" \
+            --max-budget-usd "8.00" \
+            --output /tmp/pr-repair-agent-output.txt
+
+      - name: Upload repair artifacts
+        if: always()
+        uses: actions/upload-artifact@v6
+        with:
+          name: pr-repair-agent-output
+          path: |
+            /tmp/pr-repair-agent-output.txt
+            /tmp/pr-repair-prompt.txt
+            /tmp/pr-repair/failed-run-tail.log
+          if-no-files-found: ignore

--- a/.github/workflows/upstream-drift-monitor.yml
+++ b/.github/workflows/upstream-drift-monitor.yml
@@ -17,6 +17,7 @@ on:
 permissions:
   contents: read
   issues: write
+  pull-requests: read
 
 jobs:
   check:
@@ -63,8 +64,55 @@ jobs:
             } >> "$GITHUB_OUTPUT"
           fi
 
+      - name: Find open upstream merge PR
+        id: upstream_pr
+        env:
+          GH_TOKEN: ${{ github.token }}
+        run: |
+          EXISTING="$(gh pr list \
+            --state open \
+            --base main \
+            --json number,headRefName,url \
+            --jq '[.[] | select(.headRefName | startswith("merge/upstream-"))][0] // empty')"
+          if [ -n "$EXISTING" ]; then
+            echo "exists=true" >> "$GITHUB_OUTPUT"
+            echo "number=$(jq -r '.number' <<<"$EXISTING")" >> "$GITHUB_OUTPUT"
+            echo "url=$(jq -r '.url' <<<"$EXISTING")" >> "$GITHUB_OUTPUT"
+          else
+            echo "exists=false" >> "$GITHUB_OUTPUT"
+          fi
+
+      - name: Close drift issue when an upstream merge PR is already open
+        if: steps.drift.outputs.behind != '0' && steps.upstream_pr.outputs.exists == 'true'
+        uses: actions/github-script@v7
+        with:
+          script: |
+            const prUrl = '${{ steps.upstream_pr.outputs.url }}';
+            const prNumber = '${{ steps.upstream_pr.outputs.number }}';
+            const { data: issues } = await github.rest.issues.listForRepo({
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              labels: 'upstream-drift',
+              state: 'open',
+            });
+            for (const issue of issues) {
+              await github.rest.issues.createComment({
+                owner: context.repo.owner,
+                repo: context.repo.repo,
+                issue_number: issue.number,
+                body: `Open upstream merge PR #${prNumber} is already tracking this drift: ${prUrl}`,
+              });
+              await github.rest.issues.update({
+                owner: context.repo.owner,
+                repo: context.repo.repo,
+                issue_number: issue.number,
+                state: 'closed',
+              });
+              console.log(`Closed drift issue #${issue.number} because PR #${prNumber} exists`);
+            }
+
       - name: Open or update upstream-drift tracking issue
-        if: steps.drift.outputs.behind != '0'
+        if: steps.drift.outputs.behind != '0' && steps.upstream_pr.outputs.exists != 'true'
         uses: actions/github-script@v7
         with:
           script: |

--- a/.github/workflows/upstream-merge-agent-daily.yml
+++ b/.github/workflows/upstream-merge-agent-daily.yml
@@ -1,0 +1,172 @@
+name: Daily Upstream Merge Agent
+
+# Dedicated upstream merge automation.
+# - upstream-drift-monitor.yml only opens/updates a tracking issue.
+# - agent-draft-pr is for small report-driven draft remediations and is not used
+#   here because upstream merge PRs need a real --no-ff merge commit, broader
+#   validation, and possible conflict resolution.
+
+on:
+  schedule:
+    # 04:00 Asia/Shanghai. GitHub cron is UTC.
+    - cron: '0 20 * * *'
+  workflow_dispatch:
+
+permissions:
+  contents: write
+  pull-requests: write
+  issues: write
+  actions: read
+
+concurrency:
+  group: daily-upstream-merge-agent
+  cancel-in-progress: false
+
+jobs:
+  run:
+    runs-on: ubuntu-latest
+    timeout-minutes: 120
+    steps:
+      - uses: actions/checkout@v6
+        with:
+          fetch-depth: 0
+          submodules: recursive
+          persist-credentials: false
+
+      - name: Check required secrets
+        env:
+          ANTHROPIC_AUTH_TOKEN: ${{ secrets.ANTHROPIC_AUTH_TOKEN }}
+          UPSTREAM_MERGE_GH_TOKEN: ${{ secrets.UPSTREAM_MERGE_GH_TOKEN }}
+        run: |
+          missing=0
+          if [ -z "${ANTHROPIC_AUTH_TOKEN:-}" ]; then
+            echo "::error::Missing required secret ANTHROPIC_AUTH_TOKEN for Claude Code CLI."
+            missing=1
+          fi
+          if [ -z "${UPSTREAM_MERGE_GH_TOKEN:-}" ]; then
+            echo "::error::Missing required secret UPSTREAM_MERGE_GH_TOKEN. Use a PAT or GitHub App token so pushed PR branches trigger normal PR checks."
+            missing=1
+          fi
+          exit "$missing"
+
+      - name: Configure authenticated origin
+        env:
+          UPSTREAM_MERGE_GH_TOKEN: ${{ secrets.UPSTREAM_MERGE_GH_TOKEN }}
+        run: git remote set-url origin "https://x-access-token:${UPSTREAM_MERGE_GH_TOKEN}@github.com/${GITHUB_REPOSITORY}.git"
+
+      - uses: ./.github/actions/cache-and-checkout-new-api
+
+      - name: Set up Go
+        uses: actions/setup-go@v6
+        with:
+          go-version-file: backend/go.mod
+          check-latest: false
+          cache: true
+          cache-dependency-path: backend/go.sum
+
+      - name: Setup pnpm
+        uses: pnpm/action-setup@v4
+        with:
+          version: 9
+
+      - name: Setup Node.js
+        uses: actions/setup-node@v6
+        with:
+          node-version: '20'
+          cache: 'pnpm'
+          cache-dependency-path: frontend/pnpm-lock.yaml
+
+      - name: Install frontend dependencies
+        run: pnpm install --frozen-lockfile
+        working-directory: frontend
+
+      - name: Install Claude Code CLI
+        env:
+          ANTHROPIC_AUTH_TOKEN: ${{ secrets.ANTHROPIC_AUTH_TOKEN }}
+        run: bash scripts/setup-claude-code.sh
+
+      - name: Configure git identity
+        run: |
+          git config user.name "tk-upstream-agent[bot]"
+          git config user.email "upstream-agent@tokenkey.dev"
+
+      - name: Find existing upstream merge PR
+        id: upstream_pr
+        env:
+          GH_TOKEN: ${{ secrets.UPSTREAM_MERGE_GH_TOKEN }}
+        run: |
+          EXISTING="$(gh pr list \
+            --state open \
+            --base main \
+            --json number,headRefName,url \
+            --jq '[.[] | select(.headRefName | startswith("merge/upstream-"))][0] // empty')"
+          if [ -n "$EXISTING" ]; then
+            echo "exists=true" >> "$GITHUB_OUTPUT"
+            echo "number=$(jq -r '.number' <<<"$EXISTING")" >> "$GITHUB_OUTPUT"
+            echo "branch=$(jq -r '.headRefName' <<<"$EXISTING")" >> "$GITHUB_OUTPUT"
+            echo "url=$(jq -r '.url' <<<"$EXISTING")" >> "$GITHUB_OUTPUT"
+          else
+            echo "exists=false" >> "$GITHUB_OUTPUT"
+            echo "branch=merge/upstream-$(date -u +%Y-%m-%d)" >> "$GITHUB_OUTPUT"
+          fi
+
+      - name: Build upstream merge prompt
+        env:
+          EXISTING_PR: ${{ steps.upstream_pr.outputs.exists }}
+          PR_NUMBER: ${{ steps.upstream_pr.outputs.number }}
+          PR_URL: ${{ steps.upstream_pr.outputs.url }}
+          BRANCH: ${{ steps.upstream_pr.outputs.branch }}
+        run: |
+          cat > /tmp/upstream-merge-agent-prompt.txt <<EOF
+          You are running the TokenKey upstream merge skill in headless CI. Follow this skill SOP exactly:
+
+          EOF
+          cat .cursor/skills/tokenkey-upstream-merge/SKILL.md >> /tmp/upstream-merge-agent-prompt.txt
+          cat >> /tmp/upstream-merge-agent-prompt.txt <<EOF
+
+          ## Daily automation task
+
+          Run the TokenKey upstream merge workflow unattended for the daily 04:00 Asia/Shanghai automation.
+
+          Required behavior:
+          - Target branch: $BRANCH.
+          - If an open upstream merge PR already exists, update that PR branch instead of creating a new PR. Existing PR: ${PR_URL:-none} (#${PR_NUMBER:-none}).
+          - If no open upstream merge PR exists, create branch $BRANCH from current origin/main and open a PR to main.
+          - Fetch origin and upstream first.
+          - If origin/main already contains upstream/main and there is no open upstream merge PR to update, make no code changes and do not open a PR.
+          - The PR must contain a git merge --no-ff upstream/main merge commit when upstream is behind/ahead as required by the project PR-shape workflow.
+          - Preserve upstream features by default; do not silent-delete upstream-owned files/routes/methods.
+          - Keep TokenKey-only fixes behind companion/facade/component boundaries where possible.
+          - Run appropriate focused checks and ./scripts/preflight.sh when changes are produced.
+          - Write the final PR body to /tmp/upstream-merge-pr-body.md, including the literal upstream/main..HEAD audit cadence and validation run.
+          - Push the branch and create or update the GitHub PR using gh.
+          - If conflicts cannot be resolved safely, push the conflicted/update branch only if it is in a clean, committed state; otherwise leave no partial commit and open/update a PR comment explaining the blocker.
+
+          GitHub auth is available through GH_TOKEN. Do not merge the PR.
+          EOF
+
+      - name: Run Claude upstream merge agent
+        env:
+          ANTHROPIC_AUTH_TOKEN: ${{ secrets.ANTHROPIC_AUTH_TOKEN }}
+          ANTHROPIC_BASE_URL: https://api.tokenkey.dev
+          GH_TOKEN: ${{ secrets.UPSTREAM_MERGE_GH_TOKEN }}
+          CLAUDE_CODE_DISABLE_ADAPTIVE_THINKING: "1"
+          MAX_THINKING_TOKENS: "31999"
+          CLAUDE_CODE_AUTOCOMPACT_PCT_OVERRIDE: "60"
+          CLAUDE_CODE_ATTRIBUTION_HEADER: "0"
+          ANTHROPIC_MODEL: "opus[1m]"
+        run: |
+          claude -p "$(cat /tmp/upstream-merge-agent-prompt.txt)" \
+            --model "opus[1m]" \
+            --max-budget-usd "8.00" \
+            --output /tmp/upstream-merge-agent-output.txt
+
+      - name: Upload agent output
+        if: always()
+        uses: actions/upload-artifact@v6
+        with:
+          name: upstream-merge-agent-output
+          path: |
+            /tmp/upstream-merge-agent-output.txt
+            /tmp/upstream-merge-pr-body.md
+          if-no-files-found: ignore

--- a/.github/workflows/weekly-automation-smoke.yml
+++ b/.github/workflows/weekly-automation-smoke.yml
@@ -9,15 +9,6 @@ permissions:
   contents: read
 
 jobs:
-  upstream-merge-dry-run:
-    runs-on: ubuntu-latest
-    steps:
-      - uses: actions/checkout@v6
-        with:
-          fetch-depth: 0
-      - name: Dry-run upstream merge preparation
-        run: bash scripts/prepare-upstream-merge.sh --dry-run
-
   new-api-bump-smoke:
     runs-on: ubuntu-latest
     steps:

--- a/deploy/aws/README.md
+++ b/deploy/aws/README.md
@@ -420,7 +420,8 @@ sudo systemctl list-timers tokenkey-pgdump.timer
 sudo systemctl list-timers tokenkey-disk-metrics.timer   # → CloudWatch tokenkey/EC2 DataVolumeUsedPercent
 sudo systemctl list-timers tokenkey-qa-stale-cleanup.timer
 ls -lh /var/lib/tokenkey/pgdump/ 2>/dev/null || echo '(no dumps yet — first dump runs ~1h after boot)'
-# hourly pg_dump 默认保留 36 份；卷使用率告警见 CFN DataVolumeDiskAlarm / 主文档 §3.8
+# hourly pg_dump 默认保留 24 小时（约 24 份）；卷使用率告警见 CFN DataVolumeDiskAlarm / 主文档 §3.8
+# 旧版手工/迁移快照 `pre-*.dump` 属存量文件；确认不需回滚后可删除，新模板的 pgdump timer 也会清理。
 # QA：`QaStaleRetentionDays`（默认 1.5 天）每日清理旧 qa_records + qa_blobs/qa_dlq；与 scripts/prod-qa-export-and-purge.sh 范围对齐，0=关闭
 sudo cat /var/lib/tokenkey/.env                           # 含明文密码，慎查
 ```

--- a/deploy/aws/cloudformation/stage0-single-ec2.yaml
+++ b/deploy/aws/cloudformation/stage0-single-ec2.yaml
@@ -628,6 +628,8 @@ Resources:
 
           # Remove bogus sub-kib dumps from failed runs (e.g. disk full).
           find "${!DUMP_DIR}" -maxdepth 1 -type f -name 'tokenkey-*.sql.gz' -size -2k -delete 2>/dev/null || true
+          # Remove legacy pre-*.dump files left by older manual pre-migration snapshots.
+          find "${!DUMP_DIR}" -maxdepth 1 -type f -name 'pre-*.dump' -delete 2>/dev/null || true
 
           set -o pipefail
           if ! docker exec tokenkey-postgres pg_dump -U tokenkey -d tokenkey --format=plain --no-owner \
@@ -644,7 +646,7 @@ Resources:
 
           mv -f "${!PART}" "${!OUT}"
 
-          # Keep only dumps from the past 24 hours.
+          # Keep only tokenkey dumps from the past 24 hours, normally about 24 hourly copies.
           find "${!DUMP_DIR}" -maxdepth 1 -type f -name 'tokenkey-*.sql.gz' -mmin +1440 -delete 2>/dev/null || true
           PGEOF
           chmod +x /usr/local/bin/tokenkey-pgdump.sh
@@ -864,7 +866,7 @@ Resources:
       Period: 300
       EvaluationPeriods: 2
       DatapointsToAlarm: 2
-      # High threshold = few false positives; pair with 36 pg_dump retention + metrics timer.
+      # High threshold = few false positives; pair with 24h pg_dump retention + metrics timer.
       Threshold: 90
       ComparisonOperator: GreaterThanThreshold
       TreatMissingData: notBreaching


### PR DESCRIPTION
## Summary
- Add a dedicated daily upstream merge agent workflow at 04:00 Asia/Shanghai that updates an existing open `merge/upstream-*` PR or creates one when none exists.
- Add a Claude Code CLI PR repair workflow for failed TokenKey PR checks; normal PRs use CLAUDE.md + logs, while `merge/upstream-*` PRs also load the upstream merge skill SOP.
- Keep generic `agent-draft-pr` separate from upstream merge PRs, since upstream merge PRs require `--no-ff` merge commits and broader validation.
- Remove the duplicate upstream dry-run job from weekly automation smoke and make the drift monitor defer to an existing upstream merge PR instead of opening redundant issues.
- Align Stage0 pgdump docs/template with 24h retention and clean legacy `pre-*.dump` snapshots.

## Risk
- Requires repository secrets before the new workflows can run: `ANTHROPIC_AUTH_TOKEN` and `UPSTREAM_MERGE_GH_TOKEN`.
- Workflow changes affect scheduled/repair automation only; no runtime or release path changes.
- Stage0 pgdump cleanup now removes legacy `pre-*.dump` files from `/var/lib/tokenkey/pgdump`; those are old manual/pre-migration snapshots, so keep any one-off rollback file elsewhere if it must be retained.

## Validation
- Parsed changed workflow YAML with Python.
- `git diff --cached --check`
- `./scripts/preflight.sh`

## Required setup before enabling
- Add `UPSTREAM_MERGE_GH_TOKEN` as a repository secret. Prefer a fine-grained PAT or GitHub App token for `youxuanxue/sub2api` with Contents read/write, Pull requests read/write, Issues read/write, and Actions read access.
- Keep existing `ANTHROPIC_AUTH_TOKEN` configured for the TokenKey Claude Code gateway.

🤖 Generated with [Claude Code](https://claude.com/claude-code)