### PR TITLE
fix(auth): remove Turnstile from login path

### DIFF
--- a/backend/internal/handler/auth_handler.go
+++ b/backend/internal/handler/auth_handler.go
@@ -218,11 +218,7 @@ func (h *AuthHandler) Login(c *gin.Context) {
 		return
 	}
 
-	// Turnstile 验证
-	if err := h.authService.VerifyTurnstile(c.Request.Context(), req.TurnstileToken, ip.GetClientIP(c)); err != nil {
-		response.ErrorFrom(c, err)
-		return
-	}
+	slog.Info("login_turnstile_skipped", "policy", "login_without_turnstile")
 
 	token, user, err := h.authService.Login(c.Request.Context(), req.Email, req.Password)
 	if err != nil {

--- a/backend/internal/service/auth_service_register_test.go
+++ b/backend/internal/service/auth_service_register_test.go
@@ -216,6 +216,30 @@ func newAuthService(repo *userRepoStub, settings map[string]string, emailCache E
 	)
 }
 
+func TestAuthService_Login_DoesNotRequireTurnstileToken(t *testing.T) {
+	repo := &userRepoStub{}
+	service := newAuthService(repo, map[string]string{
+		SettingKeyTurnstileEnabled:   "true",
+		SettingKeyTurnstileSecretKey: "secret",
+	}, nil)
+
+	passwordHash, err := service.HashPassword("password123")
+	require.NoError(t, err)
+	repo.user = &User{
+		ID:           10,
+		Email:        "user@example.com",
+		PasswordHash: passwordHash,
+		Role:         RoleUser,
+		Status:       StatusActive,
+		TokenVersion: 1,
+	}
+
+	token, user, err := service.Login(context.Background(), "user@example.com", "password123")
+	require.NoError(t, err)
+	require.NotEmpty(t, token)
+	require.Equal(t, int64(10), user.ID)
+}
+
 func TestAuthService_Register_Disabled(t *testing.T) {
 	repo := &userRepoStub{}
 	service := newAuthService(repo, map[string]string{

--- a/backend/internal/web/dist/frontend-source.json
+++ b/backend/internal/web/dist/frontend-source.json
@@ -1,7 +1,7 @@
 {
   "algorithm": "sha256(git-ls-files:path,size,content)",
   "file_count": 411,
-  "hash": "86b4105409c4421456dab47a2dd85877ef2815affb2916233bb534cecf0f0ec3",
+  "hash": "ae1df670dcd3f89ebdaf0a4203ed1fdea91c6f8daef98d43a1401f73c492f901",
   "schema": 1,
   "source": "frontend/"
 }

--- a/frontend/src/views/auth/LoginView.vue
+++ b/frontend/src/views/auth/LoginView.vue
@@ -104,21 +104,10 @@
           </div>
         </div>
 
-        <!-- Turnstile Widget -->
-        <div v-if="turnstileEnabled && turnstileSiteKey">
-          <TurnstileWidget
-            ref="turnstileRef"
-            :site-key="turnstileSiteKey"
-            @verify="onTurnstileVerify"
-            @expire="onTurnstileExpire"
-            @error="onTurnstileError"
-          />
-        </div>
-
         <!-- Submit Button -->
         <button
           type="submit"
-          :disabled="isLoading || (turnstileEnabled && !turnstileToken)"
+          :disabled="isLoading"
           class="btn btn-primary w-full"
         >
           <svg
@@ -182,7 +171,6 @@ import OidcOAuthSection from '@/components/auth/OidcOAuthSection.vue'
 import WechatOAuthSection from '@/components/auth/WechatOAuthSection.vue'
 import TotpLoginModal from '@/components/auth/TotpLoginModal.vue'
 import Icon from '@/components/icons/Icon.vue'
-import TurnstileWidget from '@/components/TurnstileWidget.vue'
 import { useAuthStore, useAppStore } from '@/stores'
 import { getPublicSettings, isTotp2FARequired, isWeChatWebOAuthEnabled } from '@/api/auth'
 import type { TotpLoginResponse } from '@/types'
@@ -204,18 +192,12 @@ const errorMessage = ref<string>('')
 const showPassword = ref<boolean>(false)
 
 // Public settings
-const turnstileEnabled = ref<boolean>(false)
-const turnstileSiteKey = ref<string>('')
 const linuxdoOAuthEnabled = ref<boolean>(false)
 const wechatOAuthEnabled = ref<boolean>(false)
 const backendModeEnabled = ref<boolean>(false)
 const oidcOAuthEnabled = ref<boolean>(false)
 const oidcOAuthProviderName = ref<string>('OIDC')
 const passwordResetEnabled = ref<boolean>(false)
-
-// Turnstile
-const turnstileRef = ref<InstanceType<typeof TurnstileWidget> | null>(null)
-const turnstileToken = ref<string>('')
 
 // 2FA state
 const show2FAModal = ref<boolean>(false)
@@ -230,13 +212,10 @@ const formData = reactive({
 
 const errors = reactive({
   email: '',
-  password: '',
-  turnstile: ''
+  password: ''
 })
 
-const validationToastMessage = computed(
-  () => errors.email || errors.password || errors.turnstile || ''
-)
+const validationToastMessage = computed(() => errors.email || errors.password || '')
 
 watch(validationToastMessage, (value, previousValue) => {
   if (value && value !== previousValue) {
@@ -257,8 +236,6 @@ onMounted(async () => {
 
   try {
     const settings = await getPublicSettings()
-    turnstileEnabled.value = settings.turnstile_enabled
-    turnstileSiteKey.value = settings.turnstile_site_key || ''
     linuxdoOAuthEnabled.value = settings.linuxdo_oauth_enabled
     wechatOAuthEnabled.value = isWeChatWebOAuthEnabled(settings)
     backendModeEnabled.value = !!settings.backend_mode_enabled
@@ -270,30 +247,12 @@ onMounted(async () => {
   }
 })
 
-// ==================== Turnstile Handlers ====================
-
-function onTurnstileVerify(token: string): void {
-  turnstileToken.value = token
-  errors.turnstile = ''
-}
-
-function onTurnstileExpire(): void {
-  turnstileToken.value = ''
-  errors.turnstile = t('auth.turnstileExpired')
-}
-
-function onTurnstileError(): void {
-  turnstileToken.value = ''
-  errors.turnstile = t('auth.turnstileFailed')
-}
-
 // ==================== Validation ====================
 
 function validateForm(): boolean {
   // Reset errors
   errors.email = ''
   errors.password = ''
-  errors.turnstile = ''
 
   let isValid = true
 
@@ -312,12 +271,6 @@ function validateForm(): boolean {
     isValid = false
   } else if (formData.password.length < 6) {
     errors.password = t('auth.passwordMinLength')
-    isValid = false
-  }
-
-  // Turnstile validation
-  if (turnstileEnabled.value && !turnstileToken.value) {
-    errors.turnstile = t('auth.completeVerification')
     isValid = false
   }
 
@@ -341,8 +294,7 @@ async function handleLogin(): Promise<void> {
     // Call auth store login
     const response = await authStore.login({
       email: formData.email,
-      password: formData.password,
-      turnstile_token: turnstileEnabled.value ? turnstileToken.value : undefined
+      password: formData.password
     })
 
     // Check if 2FA is required
@@ -363,20 +315,8 @@ async function handleLogin(): Promise<void> {
     const redirectTo = (router.currentRoute.value.query.redirect as string) || '/dashboard'
     await router.push(redirectTo)
   } catch (error: unknown) {
-    // Reset Turnstile on error
-    if (turnstileRef.value) {
-      turnstileRef.value.reset()
-      turnstileToken.value = ''
-    }
-
-    // 后端 reason=TURNSTILE_VERIFICATION_FAILED 的真实根因绝大多数是 stale browser
-    // tab：widget 在页面里活了太久，challenge 实例已被 Cloudflare 滚动掉，下一次
-    // 提交的 token 就被 invalid-input-response。直接给出自救建议，比通用文案省事。
     errorMessage.value = buildAuthErrorMessage(error, {
-      fallback: t('auth.loginFailed'),
-      reasonOverrides: {
-        TURNSTILE_VERIFICATION_FAILED: t('auth.turnstileFailedRefresh')
-      }
+      fallback: t('auth.loginFailed')
     })
 
     appStore.showError(errorMessage.value)

--- a/frontend/src/views/auth/__tests__/LoginView.spec.ts
+++ b/frontend/src/views/auth/__tests__/LoginView.spec.ts
@@ -1,0 +1,118 @@
+import { flushPromises, mount } from '@vue/test-utils'
+import { beforeEach, describe, expect, it, vi } from 'vitest'
+import LoginView from '@/views/auth/LoginView.vue'
+
+const {
+  pushMock,
+  loginMock,
+  showSuccessMock,
+  showErrorMock,
+  showWarningMock,
+  getPublicSettingsMock,
+} = vi.hoisted(() => ({
+  pushMock: vi.fn(),
+  loginMock: vi.fn(),
+  showSuccessMock: vi.fn(),
+  showErrorMock: vi.fn(),
+  showWarningMock: vi.fn(),
+  getPublicSettingsMock: vi.fn(),
+}))
+
+vi.mock('vue-router', () => ({
+  useRouter: () => ({
+    push: pushMock,
+    currentRoute: { value: { query: {} } },
+  }),
+}))
+
+vi.mock('vue-i18n', () => ({
+  createI18n: () => ({
+    global: {
+      t: (key: string) => key,
+    },
+  }),
+  useI18n: () => ({
+    t: (key: string) => key,
+  }),
+}))
+
+vi.mock('@/stores', () => ({
+  useAuthStore: () => ({
+    login: (...args: any[]) => loginMock(...args),
+    login2FA: vi.fn(),
+  }),
+  useAppStore: () => ({
+    showSuccess: (...args: any[]) => showSuccessMock(...args),
+    showError: (...args: any[]) => showErrorMock(...args),
+    showWarning: (...args: any[]) => showWarningMock(...args),
+  }),
+}))
+
+vi.mock('@/api/auth', async () => {
+  const actual = await vi.importActual<typeof import('@/api/auth')>('@/api/auth')
+  return {
+    ...actual,
+    getPublicSettings: (...args: any[]) => getPublicSettingsMock(...args),
+    isTotp2FARequired: (response: any) => response?.requires_2fa === true,
+    isWeChatWebOAuthEnabled: () => false,
+  }
+})
+
+describe('LoginView', () => {
+  beforeEach(() => {
+    pushMock.mockReset()
+    loginMock.mockReset()
+    showSuccessMock.mockReset()
+    showErrorMock.mockReset()
+    showWarningMock.mockReset()
+    getPublicSettingsMock.mockReset()
+    sessionStorage.clear()
+    localStorage.clear()
+
+    getPublicSettingsMock.mockResolvedValue({
+      turnstile_enabled: true,
+      turnstile_site_key: 'site-key',
+      linuxdo_oauth_enabled: false,
+      wechat_oauth_enabled: false,
+      backend_mode_enabled: false,
+      oidc_oauth_enabled: false,
+      password_reset_enabled: true,
+    })
+    loginMock.mockResolvedValue({
+      access_token: 'token',
+      token_type: 'Bearer',
+      user: { id: 1, email: 'user@example.com' },
+    })
+  })
+
+  it('does not render or submit Turnstile on login even when public settings enable it', async () => {
+    const wrapper = mount(LoginView, {
+      global: {
+        stubs: {
+          AuthLayout: { template: '<div><slot /><slot name="footer" /></div>' },
+          Icon: true,
+          LinuxDoOAuthSection: true,
+          OidcOAuthSection: true,
+          WechatOAuthSection: true,
+          TotpLoginModal: true,
+          RouterLink: { template: '<a><slot /></a>' },
+          transition: false,
+        },
+      },
+    })
+
+    await flushPromises()
+
+    expect(wrapper.findComponent({ name: 'TurnstileWidget' }).exists()).toBe(false)
+
+    await wrapper.find('#email').setValue('user@example.com')
+    await wrapper.find('#password').setValue('password123')
+    await wrapper.find('form').trigger('submit')
+    await flushPromises()
+
+    expect(loginMock).toHaveBeenCalledWith({
+      email: 'user@example.com',
+      password: 'password123',
+    })
+  })
+})


### PR DESCRIPTION
## Summary
- Remove Cloudflare Turnstile from the normal login path so control-plane login no longer depends on a third-party challenge widget.
- Keep Turnstile protection on registration, verification-code, and password-recovery flows.
- Add focused backend/frontend regressions proving login works without a Turnstile token even when public settings enable Turnstile.

## Risk
- Low-to-normal auth behavior change: login friction decreases while existing Redis login rate limiting remains the low-cost safeguard.
- No schema, migration, dependency, or deployment topology changes.

## Validation
- `go -C backend test -tags=unit ./internal/service ./internal/handler ./internal/server/routes`
- `pnpm --dir frontend exec vitest run src/views/auth/__tests__/LoginView.spec.ts`
- `pnpm --dir frontend lint:check && pnpm --dir frontend typecheck`
- `pnpm --dir frontend run build`
- `./scripts/preflight.sh`

🤖 Generated with [Claude Code](https://claude.com/claude-code)