### PR TITLE
fix(gemini): strip Draft 2020 schema keywords before forwarding to Gemini

### DIFF
--- a/.github/workflows/deploy-stage0.yml
+++ b/.github/workflows/deploy-stage0.yml
@@ -270,6 +270,11 @@ jobs:
         env:
           TOKENKEY_BASE_URL: ${{ steps.instance.outputs.api_url }}
           POST_DEPLOY_SMOKE_API_KEY: ${{ secrets.POST_DEPLOY_SMOKE_API_KEY }}
+          # Optional: api_key bound to a gemini-platform group (e.g. gemini-pa).
+          # When set, smoke step 6 exercises the Anthropic→Gemini tool-schema
+          # cleanup against real Google upstream; silently skipped when unset.
+          POST_DEPLOY_SMOKE_GEMINI_API_KEY: ${{ secrets.POST_DEPLOY_SMOKE_GEMINI_API_KEY }}
+          POST_DEPLOY_SMOKE_GEMINI_MODEL: ${{ vars.POST_DEPLOY_SMOKE_GEMINI_MODEL }}
         run: |
           set -euo pipefail
           if [ -z "${POST_DEPLOY_SMOKE_API_KEY:-}" ]; then

--- a/backend/internal/service/gemini_messages_compat_service.go
+++ b/backend/internal/service/gemini_messages_compat_service.go
@@ -3376,6 +3376,9 @@ func isClaudeWebSearchToolMap(tool map[string]any) bool {
 }
 
 // cleanToolSchema 清理工具的 JSON Schema，移除 Gemini 不支持的字段
+// Gemini 的 Schema 是 OpenAPI 3.0 的受限子集（见 ai.google.dev/api/caching#Schema），
+// 任何 Draft 2020 / OpenAPI 3.1 引入的关键字（propertyNames、const、
+// exclusiveMinimum/Maximum 等）一旦透传都会被上游 400 拒掉。
 func cleanToolSchema(schema any) any {
 	if schema == nil {
 		return nil
@@ -3388,7 +3391,9 @@ func cleanToolSchema(schema any) any {
 			// 跳过不支持的字段
 			if key == "$schema" || key == "$id" || key == "$ref" ||
 				key == "additionalProperties" || key == "patternProperties" || key == "minLength" ||
-				key == "maxLength" || key == "minItems" || key == "maxItems" {
+				key == "maxLength" || key == "minItems" || key == "maxItems" ||
+				key == "propertyNames" || key == "const" ||
+				key == "exclusiveMinimum" || key == "exclusiveMaximum" {
 				continue
 			}
 			// 递归清理嵌套对象

--- a/backend/internal/service/gemini_messages_compat_service.go
+++ b/backend/internal/service/gemini_messages_compat_service.go
@@ -3294,7 +3294,7 @@ func convertClaudeToolsToGeminiTools(tools any) []any {
 			}
 		}
 		// 清理 JSON Schema
-		cleanedParams := cleanToolSchema(params)
+		cleanedParams := tkCleanToolSchema(params)
 
 		funcDecls = append(funcDecls, map[string]any{
 			"name":        name,
@@ -3376,9 +3376,6 @@ func isClaudeWebSearchToolMap(tool map[string]any) bool {
 }
 
 // cleanToolSchema 清理工具的 JSON Schema，移除 Gemini 不支持的字段
-// Gemini 的 Schema 是 OpenAPI 3.0 的受限子集（见 ai.google.dev/api/caching#Schema），
-// 任何 Draft 2020 / OpenAPI 3.1 引入的关键字（propertyNames、const、
-// exclusiveMinimum/Maximum 等）一旦透传都会被上游 400 拒掉。
 func cleanToolSchema(schema any) any {
 	if schema == nil {
 		return nil
@@ -3391,9 +3388,7 @@ func cleanToolSchema(schema any) any {
 			// 跳过不支持的字段
 			if key == "$schema" || key == "$id" || key == "$ref" ||
 				key == "additionalProperties" || key == "patternProperties" || key == "minLength" ||
-				key == "maxLength" || key == "minItems" || key == "maxItems" ||
-				key == "propertyNames" || key == "const" ||
-				key == "exclusiveMinimum" || key == "exclusiveMaximum" {
+				key == "maxLength" || key == "minItems" || key == "maxItems" {
 				continue
 			}
 			// 递归清理嵌套对象

--- a/backend/internal/service/gemini_messages_compat_service_test.go
+++ b/backend/internal/service/gemini_messages_compat_service_test.go
@@ -193,6 +193,54 @@ func TestConvertClaudeToolsToGeminiTools_PreservesWebSearchAlongsideFunctions(t 
 	require.Empty(t, googleSearch)
 }
 
+// TestCleanToolSchema_StripsDraft2020Keywords 钉住一次 prod 事故：Anthropic→Gemini
+// 桥接如果不剥掉 Draft 2020 / OpenAPI 3.1 的 propertyNames / const /
+// exclusiveMinimum / exclusiveMaximum，Google 上游会直接 400
+// "Invalid JSON payload received. Unknown name ...: Cannot find field."。
+// 已支持的 minimum / maximum / required 必须保留。
+func TestCleanToolSchema_StripsDraft2020Keywords(t *testing.T) {
+	in := map[string]any{
+		"type":     "object",
+		"required": []any{"name"},
+		"properties": map[string]any{
+			"name": map[string]any{
+				"type":  "string",
+				"const": "auto",
+			},
+			"limit": map[string]any{
+				"type":             "integer",
+				"minimum":          1,
+				"exclusiveMinimum": 0,
+				"exclusiveMaximum": 100,
+			},
+			"tags": map[string]any{
+				"type":          "object",
+				"propertyNames": map[string]any{"pattern": "^[a-z]+$"},
+			},
+		},
+	}
+
+	out, ok := cleanToolSchema(in).(map[string]any)
+	require.True(t, ok)
+
+	props, ok := out["properties"].(map[string]any)
+	require.True(t, ok)
+
+	name, _ := props["name"].(map[string]any)
+	require.NotContains(t, name, "const", "const must be stripped")
+	require.Equal(t, "STRING", name["type"], "type 仍需大写化为 Gemini Type 枚举")
+
+	limit, _ := props["limit"].(map[string]any)
+	require.NotContains(t, limit, "exclusiveMinimum", "exclusiveMinimum must be stripped")
+	require.NotContains(t, limit, "exclusiveMaximum", "exclusiveMaximum must be stripped")
+	require.Equal(t, 1, limit["minimum"], "supported keywords must survive cleaning")
+
+	tags, _ := props["tags"].(map[string]any)
+	require.NotContains(t, tags, "propertyNames", "propertyNames must be stripped")
+
+	require.Contains(t, out, "required", "required 必须保留")
+}
+
 func TestGeminiHandleNativeNonStreamingResponse_DebugDisabledDoesNotEmitHeaderLogs(t *testing.T) {
 	gin.SetMode(gin.TestMode)
 	logSink, restore := captureStructuredLog(t)

--- a/backend/internal/service/gemini_messages_compat_service_test.go
+++ b/backend/internal/service/gemini_messages_compat_service_test.go
@@ -193,54 +193,6 @@ func TestConvertClaudeToolsToGeminiTools_PreservesWebSearchAlongsideFunctions(t 
 	require.Empty(t, googleSearch)
 }
 
-// TestCleanToolSchema_StripsDraft2020Keywords 钉住一次 prod 事故：Anthropic→Gemini
-// 桥接如果不剥掉 Draft 2020 / OpenAPI 3.1 的 propertyNames / const /
-// exclusiveMinimum / exclusiveMaximum，Google 上游会直接 400
-// "Invalid JSON payload received. Unknown name ...: Cannot find field."。
-// 已支持的 minimum / maximum / required 必须保留。
-func TestCleanToolSchema_StripsDraft2020Keywords(t *testing.T) {
-	in := map[string]any{
-		"type":     "object",
-		"required": []any{"name"},
-		"properties": map[string]any{
-			"name": map[string]any{
-				"type":  "string",
-				"const": "auto",
-			},
-			"limit": map[string]any{
-				"type":             "integer",
-				"minimum":          1,
-				"exclusiveMinimum": 0,
-				"exclusiveMaximum": 100,
-			},
-			"tags": map[string]any{
-				"type":          "object",
-				"propertyNames": map[string]any{"pattern": "^[a-z]+$"},
-			},
-		},
-	}
-
-	out, ok := cleanToolSchema(in).(map[string]any)
-	require.True(t, ok)
-
-	props, ok := out["properties"].(map[string]any)
-	require.True(t, ok)
-
-	name, _ := props["name"].(map[string]any)
-	require.NotContains(t, name, "const", "const must be stripped")
-	require.Equal(t, "STRING", name["type"], "type 仍需大写化为 Gemini Type 枚举")
-
-	limit, _ := props["limit"].(map[string]any)
-	require.NotContains(t, limit, "exclusiveMinimum", "exclusiveMinimum must be stripped")
-	require.NotContains(t, limit, "exclusiveMaximum", "exclusiveMaximum must be stripped")
-	require.Equal(t, 1, limit["minimum"], "supported keywords must survive cleaning")
-
-	tags, _ := props["tags"].(map[string]any)
-	require.NotContains(t, tags, "propertyNames", "propertyNames must be stripped")
-
-	require.Contains(t, out, "required", "required 必须保留")
-}
-
 func TestGeminiHandleNativeNonStreamingResponse_DebugDisabledDoesNotEmitHeaderLogs(t *testing.T) {
 	gin.SetMode(gin.TestMode)
 	logSink, restore := captureStructuredLog(t)

--- a/backend/internal/service/gemini_messages_compat_service_tk_schema.go
+++ b/backend/internal/service/gemini_messages_compat_service_tk_schema.go
@@ -1,0 +1,72 @@
+package service
+
+// TK companion to upstream cleanToolSchema in gemini_messages_compat_service.go.
+//
+// 为什么独立成文件：
+// upstream cleanToolSchema 自己维护了一份 Gemini 不识别的 JSON Schema 字段
+// denylist (90b38381 加过 patternProperties)，函数体处于 upstream 持续演进
+// 路径上。直接在那个 if-key 链中加 TK-only 字段会在每次 upstream 调整 denylist
+// 时撞 textual conflict，并且最坏情形下被 git merge 的 upstream-favor 自动解
+// 决悄悄回退（违反 §5 "minimum upstream conflict surface" 与 §5.x "no silent
+// upstream override"）。所以 TK 这边把额外字段集中在本 companion，upstream
+// 文件只需要 1-token 的 call-site 切换 (cleanToolSchema → tkCleanToolSchema)。
+//
+// 历史背景：
+// 2026-05-06 prod 事故：claude-code 通过 /v1/messages → gemini-pa group 发
+// gemini-3.1-pro-preview，Google 上游 400 拒掉 tool schema：
+//   Invalid JSON payload received. Unknown name "propertyNames" / "const" /
+//   "exclusiveMinimum" at request.tools[0].function_declarations[*].parameters
+//   .properties[*].value: Cannot find field.
+// 这些都是 JSON Schema Draft 2020 / OpenAPI 3.1 引入的关键字，不在 Gemini
+// OpenAPI 3.0 受限子集 (ai.google.dev/api/caching#Schema) 内。
+//
+// 何时拆掉本文件：
+// 如果 upstream 哪天独立把这些字段加进 cleanToolSchema 的 denylist，本文件
+// 的 strip 就成了幂等冗余，可以删掉本文件并把 call-site 还原回
+// cleanToolSchema —— 这是单 PR 即可完成的 mechanical revert。
+
+// tkUnsupportedToolSchemaKeywords 是 upstream cleanToolSchema 漏掉、但
+// Gemini 一定 400 的 JSON Schema 字段集。任何加入此表的字段都必须在 PR
+// 描述里附 prod 错误日志或 Gemini 文档引用，避免无证据的 deny 蔓延。
+var tkUnsupportedToolSchemaKeywords = map[string]struct{}{
+	"propertyNames":    {}, // Draft 6+: properties name schema
+	"const":            {}, // Draft 6+: literal constraint
+	"exclusiveMinimum": {}, // Draft 6+ numeric form
+	"exclusiveMaximum": {}, // Draft 6+ numeric form
+}
+
+// tkCleanToolSchema 是 upstream cleanToolSchema 的 TK extended 包装：先递归
+// 剥掉 TK 维护的额外不兼容关键字，再交给 upstream cleanToolSchema 完成既
+// 有清洗 (大写化 type、删 $schema 等)。call-site 见
+// convertClaudeToolsToGeminiTools 中的 cleanedParams 赋值。
+func tkCleanToolSchema(schema any) any {
+	return cleanToolSchema(tkStripUnsupportedToolSchemaKeywords(schema))
+}
+
+// tkStripUnsupportedToolSchemaKeywords 递归删掉 tkUnsupportedToolSchemaKeywords
+// 列出的字段。结构与 cleanToolSchema 类似但只做 strip，不做大写化 (留给
+// upstream cleanToolSchema 处理，避免 TK 这边重复实现 type 大写化语义)。
+func tkStripUnsupportedToolSchemaKeywords(schema any) any {
+	if schema == nil {
+		return nil
+	}
+	switch v := schema.(type) {
+	case map[string]any:
+		out := make(map[string]any, len(v))
+		for key, value := range v {
+			if _, drop := tkUnsupportedToolSchemaKeywords[key]; drop {
+				continue
+			}
+			out[key] = tkStripUnsupportedToolSchemaKeywords(value)
+		}
+		return out
+	case []any:
+		out := make([]any, len(v))
+		for i, item := range v {
+			out[i] = tkStripUnsupportedToolSchemaKeywords(item)
+		}
+		return out
+	default:
+		return v
+	}
+}

--- a/backend/internal/service/gemini_messages_compat_service_tk_schema_test.go
+++ b/backend/internal/service/gemini_messages_compat_service_tk_schema_test.go
@@ -1,0 +1,88 @@
+package service
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/require"
+)
+
+// TestTKCleanToolSchema_StripsDraft2020Keywords 钉住 2026-05-06 prod 事故：
+// Anthropic→Gemini 桥接如果不剥掉 propertyNames / const / exclusiveMinimum /
+// exclusiveMaximum，Google 上游会直接 400 "Invalid JSON payload received.
+// Unknown name ...: Cannot find field."。同时验证 upstream cleanToolSchema
+// 的既有清洗（type 大写化）以及 minimum / maximum / required 等被 Gemini
+// 接受的字段不被误删。
+func TestTKCleanToolSchema_StripsDraft2020Keywords(t *testing.T) {
+	in := map[string]any{
+		"type":     "object",
+		"required": []any{"name"},
+		"properties": map[string]any{
+			"name": map[string]any{
+				"type":  "string",
+				"const": "auto",
+			},
+			"limit": map[string]any{
+				"type":             "integer",
+				"minimum":          1,
+				"exclusiveMinimum": 0,
+				"exclusiveMaximum": 100,
+			},
+			"tags": map[string]any{
+				"type":          "object",
+				"propertyNames": map[string]any{"pattern": "^[a-z]+$"},
+			},
+		},
+	}
+
+	out, ok := tkCleanToolSchema(in).(map[string]any)
+	require.True(t, ok)
+
+	props, ok := out["properties"].(map[string]any)
+	require.True(t, ok)
+
+	name, _ := props["name"].(map[string]any)
+	require.NotContains(t, name, "const", "const must be stripped")
+	require.Equal(t, "STRING", name["type"], "upstream cleanToolSchema 的 type 大写化必须仍然生效")
+
+	limit, _ := props["limit"].(map[string]any)
+	require.NotContains(t, limit, "exclusiveMinimum", "exclusiveMinimum must be stripped")
+	require.NotContains(t, limit, "exclusiveMaximum", "exclusiveMaximum must be stripped")
+	require.Equal(t, 1, limit["minimum"], "supported keywords must survive cleaning")
+
+	tags, _ := props["tags"].(map[string]any)
+	require.NotContains(t, tags, "propertyNames", "propertyNames must be stripped")
+
+	require.Contains(t, out, "required", "required 必须保留")
+}
+
+// TestTKStripUnsupportedToolSchemaKeywords_RecursesIntoArrays 验证 TK strip
+// 在 []any 容器（例如 anyOf / enum 数组、嵌套 properties 数组化场景）里也能
+// 递归剥离。upstream cleanToolSchema 同样支持这条路径，TK strip 必须对齐。
+func TestTKStripUnsupportedToolSchemaKeywords_RecursesIntoArrays(t *testing.T) {
+	in := map[string]any{
+		"anyOf": []any{
+			map[string]any{
+				"type":  "string",
+				"const": "x",
+			},
+			map[string]any{
+				"type":             "integer",
+				"exclusiveMinimum": 0,
+			},
+		},
+	}
+
+	out, ok := tkStripUnsupportedToolSchemaKeywords(in).(map[string]any)
+	require.True(t, ok)
+
+	anyOf, ok := out["anyOf"].([]any)
+	require.True(t, ok)
+	require.Len(t, anyOf, 2)
+
+	first, _ := anyOf[0].(map[string]any)
+	require.NotContains(t, first, "const")
+	require.Equal(t, "string", first["type"], "TK strip 不做大写化（留给 upstream cleanToolSchema）")
+
+	second, _ := anyOf[1].(map[string]any)
+	require.NotContains(t, second, "exclusiveMinimum")
+}

--- a/scripts/tk_post_deploy_smoke.sh
+++ b/scripts/tk_post_deploy_smoke.sh
@@ -2,15 +2,24 @@
 # tk_post_deploy_smoke.sh — mandatory post-deploy gateway checks (Stage0).
 #
 # Exercises the same paths Claude Code uses against TokenKey:
-#   public settings, frontend release assets, /v1/models, /v1/chat/completions, /v1/messages.
+#   public settings, frontend release assets, /v1/models, /v1/chat/completions,
+#   /v1/messages, and (when configured) /v1/messages-with-tools through the
+#   Gemini bridge to catch tool-schema cleanup regressions.
 #
 # Usage:
 #   TOKENKEY_BASE_URL=https://api.example.com \
 #   POST_DEPLOY_SMOKE_API_KEY=sk-... \
+#   POST_DEPLOY_SMOKE_GEMINI_API_KEY=sk-... \   # optional, binds to gemini group
 #   bash scripts/tk_post_deploy_smoke.sh
 #
 # Key resolution (first non-empty): POST_DEPLOY_SMOKE_API_KEY,
 # ANTHROPIC_AUTH_TOKEN, TK_TOKEN, TOKENKEY_API_KEY.
+#
+# Optional Gemini regression check (skipped silently if unset):
+#   POST_DEPLOY_SMOKE_GEMINI_API_KEY  api_key bound to a gemini-platform group
+#                                     (e.g. gemini-pa); exercises the
+#                                     Anthropic→Gemini tool-schema cleanup.
+#   POST_DEPLOY_SMOKE_GEMINI_MODEL    default: gemini-3.1-pro-preview
 #
 # Never prints the full API key. Requires curl + jq on PATH.
 set -euo pipefail
@@ -188,6 +197,67 @@ if ! printf '%s' "${msg_text}" | grep -Fq "${expect_anthropic}"; then
   echo "tk_post_deploy_smoke: messages response missing expected marker '${expect_anthropic}' (text below)" >&2
   printf '%s\n' "${msg_text}" >&2
   exit 1
+fi
+
+# --- 6) Gemini /v1/messages with tools (Anthropic→Gemini schema cleanup regression) ---
+# Validates tkCleanToolSchema strips Draft 2020 / OpenAPI 3.1 keywords that
+# Gemini's restricted OpenAPI 3.0 schema dialect rejects (propertyNames /
+# const / exclusiveMinimum / exclusiveMaximum). If cleanup regresses, Google
+# upstream returns 400 "Invalid JSON payload received. Unknown name ...:
+# Cannot find field." and this section fails. Skipped silently when no
+# Gemini-bound key is provided.
+GEMINI_KEY="${POST_DEPLOY_SMOKE_GEMINI_API_KEY:-}"
+GEMINI_MODEL="${POST_DEPLOY_SMOKE_GEMINI_MODEL:-gemini-3.1-pro-preview}"
+
+if [[ -n "${GEMINI_KEY}" ]]; then
+  gemini_prefix="$(printf '%s' "${GEMINI_KEY}" | head -c 6)"
+  gemini_suffix="$(printf '%s' "${GEMINI_KEY}" | tail -c 4)"
+  echo "tk_post_deploy_smoke: gemini_key_hint=${gemini_prefix}…${gemini_suffix} gemini_model=${GEMINI_MODEL}"
+
+  gpayload="$(jq -n \
+    --arg m "${GEMINI_MODEL}" \
+    '{
+      model: $m,
+      max_tokens: 96,
+      messages: [{role:"user",content:"Reply with one short sentence."}],
+      tools: [{
+        name: "tk_smoke_schema_probe",
+        description: "Schema sanitize probe. Do not call.",
+        input_schema: {
+          type: "object",
+          required: ["mode"],
+          properties: {
+            mode:  {type:"string",  const: "auto"},
+            limit: {type:"integer", minimum: 1, exclusiveMinimum: 0, exclusiveMaximum: 100},
+            tags:  {type:"object",  propertyNames: {pattern: "^[a-z]+$"}}
+          }
+        }
+      }]
+    }')"
+
+  gemini_http=$(curl -sS -o "$tmpdir/gemini-msg.json" -w "%{http_code}" \
+    -H "x-api-key: ${GEMINI_KEY}" \
+    -H "anthropic-version: 2023-06-01" \
+    -H "Content-Type: application/json" \
+    -d "${gpayload}" \
+    "${BASE}/v1/messages")
+  echo "tk_post_deploy_smoke: POST .../v1/messages (gemini, with tools) -> HTTP ${gemini_http}"
+  if [[ "${gemini_http}" != "200" ]]; then
+    echo "tk_post_deploy_smoke: /v1/messages (gemini, with tools) failed — Gemini schema cleanup may be broken (see prod incident 2026-05-06)" >&2
+    jq . "$tmpdir/gemini-msg.json" >&2 2>/dev/null || cat "$tmpdir/gemini-msg.json" >&2
+    exit 1
+  fi
+  gemini_type="$(jq -r '.type // empty' "$tmpdir/gemini-msg.json")"
+  gemini_role="$(jq -r '.role // empty' "$tmpdir/gemini-msg.json")"
+  gemini_content_count="$(jq -r '(.content // []) | length' "$tmpdir/gemini-msg.json")"
+  if [[ "${gemini_type}" != "message" ]] || [[ "${gemini_role}" != "assistant" ]] || [[ "${gemini_content_count}" -lt 1 ]]; then
+    echo "tk_post_deploy_smoke: /v1/messages (gemini) shape invalid (type=${gemini_type:-missing} role=${gemini_role:-missing} content=${gemini_content_count})" >&2
+    jq . "$tmpdir/gemini-msg.json" >&2 || true
+    exit 1
+  fi
+  echo "tk_post_deploy_smoke: /v1/messages (gemini, with tools) shape type=${gemini_type} role=${gemini_role} content=${gemini_content_count}"
+else
+  echo "tk_post_deploy_smoke: skip /v1/messages (gemini) — POST_DEPLOY_SMOKE_GEMINI_API_KEY not set"
 fi
 
 echo "tk_post_deploy_smoke: OK"


### PR DESCRIPTION
## Summary

修复 Anthropic→Gemini bridge 的 JSON Schema 净化器：剥掉 Claude Code 上送 tools 中携带的 `propertyNames` / `const` / `exclusiveMinimum` / `exclusiveMaximum` (Draft 2020 / OpenAPI 3.1 关键字)，避免 Gemini 上游 (OpenAPI 3.0 受限子集) 直接 400 拒掉，导致 `/v1/messages` 经 `gemini-pa` 平台所有请求挂掉。

**§5 合规**：TK 扩展全部下沉到新建的 `*_tk_schema.go` companion；上游文件 (`gemini_messages_compat_service.go`) 最终 diff 仅 1 个 token (`cleanToolSchema(params)` → `tkCleanToolSchema(params)`)；上游测试文件 0 改动。

```diff
-		cleanedParams := cleanToolSchema(params)
+		cleanedParams := tkCleanToolSchema(params)
```

新增文件：
- `backend/internal/service/gemini_messages_compat_service_tk_schema.go`
  - `tkUnsupportedToolSchemaKeywords` 集中维护扩展 denylist
  - `tkCleanToolSchema` = 先 TK 预剥 → 再交 upstream `cleanToolSchema` 完成既有清洗（type 大写化等不变）
- `backend/internal/service/gemini_messages_compat_service_tk_schema_test.go`
  - 钉住真实 prod 错误字段名 + supported 字段不被误删 + array 容器递归

**Smoke 硬化（§6 升级原则）**：之前 `tk_post_deploy_smoke.sh` 只跑 `/v1/messages` 纯文本，正好把 Gemini 桥接清洗这条肇事路径漏过。新增一段 `/v1/messages-with-tools` 回归段：

- 把肇事字段（`propertyNames` / `const` / `exclusiveMinimum` / `exclusiveMaximum`）**故意塞进** tool input_schema
- 用 `POST_DEPLOY_SMOKE_GEMINI_API_KEY`（绑到 gemini-pa 分组的 api_key）走真实 Google 上游
- 默认模型 `gemini-3.1-pro-preview`，可经 `POST_DEPLOY_SMOKE_GEMINI_MODEL` 覆盖
- 如果 `tkCleanToolSchema` 哪天回退或被 upstream merge 覆盖，Google 立刻 400，部署被拦在烟测阶段
- opt-in：env 未设置时静默跳过，不影响既有部署可用性

## Risk

**P1 prod 阻塞**：今晚 `api_key_id=5` 切到 `gemini-pa` (group_id=8) 后，命中 `Gemini-free-1` 账号一直 400：

```
upstream error: 400 Invalid JSON payload received.
  Unknown name "propertyNames" at request.tools[0].function_declarations[1].parameters.properties[0].value
  Unknown name "const"            at ... function_declarations[13]....
  Unknown name "exclusiveMinimum" at ... function_declarations[14]....
```

**变更面**：
- 上游强活跃文件 (11 个月 81 commits) 仅 1-token 调整 → 极小 conflict surface
- TK companion 是纯新增文件 → 任何 upstream 改动都不会撞它
- 如果 upstream 哪天独立把这些字段加进 `cleanToolSchema` denylist：本 companion 的 strip 变成幂等冗余，可以单 PR mechanical revert (删 companion + 还原 1 token) → 可逆
- Smoke 新增段是 opt-in，未设置 env 时静默跳过 → 不影响其它 stack 的部署

**为什么不直接改 upstream `cleanToolSchema` 的 denylist 表达式**：
- 该函数最近就被 upstream 改过（`90b38381 fix: 移除 Gemini 不支持的 patternProperties 字段 #795`），denylist 表达式是 upstream 持续演进路径
- inline 加字段 → 下次上游再调整 denylist 几乎必撞 textual conflict
- 最坏情形：git merge 的 upstream-favor 自动解决悄悄回退本次 P1 修复（违反 §5.x 的 silent override 红线）

## Validation

- [x] `go test -tags=unit -count=1 ./internal/service/...` → ok（86s 全绿，包含新增 `TestTKCleanToolSchema_StripsDraft2020Keywords` + `TestTKStripUnsupportedToolSchemaKeywords_RecursesIntoArrays`）
- [x] `go vet ./internal/service/...` → 无输出
- [x] `go build ./...` → 无输出
- [x] `bash -n scripts/tk_post_deploy_smoke.sh` → syntax OK
- [x] `bash scripts/preflight.sh` → PASS（含 sub2api 专项 check）
- [ ] CI（backend-ci, security-scan）
- [ ] 部署后 smoke 段 6 在 prod 真实通过（首次部署前需要在管理后台建 gemini-pa 分组的 api_key 并写入 `POST_DEPLOY_SMOKE_GEMINI_API_KEY`）

## 后续

合并后立即打 tag 走 release.yml + deploy-stage0 prod 解 P1。  
（用 `bash scripts/release-tag.sh vX.Y.Z`，commit 消息里**不能**有 `[skip ci]`，§9.2。）

🤖 Generated with [Claude Code](https://claude.com/claude-code)