### PR TITLE
fix(release): drop env context from queue-prod-deploy job-level if

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -305,7 +305,13 @@ jobs:
 
   queue-prod-deploy:
     needs: [release]
-    if: ${{ needs.release.result == 'success' && env.SIMPLE_RELEASE != 'true' }}
+    # NOTE: GitHub Actions 禁止在 job-level if 里引用 env 上下文
+    # (https://docs.github.com/en/actions/learn-github-actions/contexts —
+    # env is unavailable when GitHub evaluates if for jobs).
+    # 引用了会让工作流文件直接解析失败 (HTTP 422 "Unrecognized named-value: 'env'")，
+    # tag-push 与 workflow_dispatch 双双被拒；2026-05-06 v1.7.17 实事故。
+    # 这里展开 workflow-level env 的两个底层来源 vars + inputs，效果一致。
+    if: ${{ needs.release.result == 'success' && vars.SIMPLE_RELEASE != 'true' && github.event.inputs.simple_release != 'true' }}
     runs-on: ubuntu-latest
     steps:
       - name: Queue prod Stage0 deploy


### PR DESCRIPTION
## Summary

修复 PR #120 在 `release.yml` 引入的 GitHub Actions 解析失败：`queue-prod-deploy` job 的 job-level `if:` 引用了 `env.SIMPLE_RELEASE`，但 GitHub Actions 不允许 `env` 出现在 job-level `if` 表达式里。

## Risk

**P0 prod 发版阻塞**。今晚打 tag `v1.7.17` 准备发版 PR #121 修复时，发现 release.yml 解析失败：

```
HTTP 422 failed to parse workflow:
(Line: 308, Col: 9): Unrecognized named-value: 'env'.
Located at position 38 within expression:
needs.release.result == 'success' && env.SIMPLE_RELEASE != 'true'
```

后果：
- `v1.7.17` 的 tag-push event 在 GitHub 处只生成空 run，0 jobs，failure
- `gh workflow run release.yml -f tag=v1.7.17` 直接被 API 422 拒绝
- 所有未来 tag-push / workflow_dispatch 的 release 都被堵死，包括需要紧急上线的 PR #121

`v1.7.17` 因此成为僵尸 tag（指向 commit 78d6027d，但 release.yml 永远跑不起来）。本 PR 合并后，下一发版需要 bump 到 `v1.7.18`，跳过 1.7.17。

## 修复

`if: ${{ ... env.SIMPLE_RELEASE != 'true' }}` → `if: ${{ ... vars.SIMPLE_RELEASE != 'true' && github.event.inputs.simple_release != 'true' }}`

把 workflow-level `env: SIMPLE_RELEASE: ...` 的两个底层来源（`vars.SIMPLE_RELEASE` + `github.event.inputs.simple_release`）直接展开进 if 表达式。两者在 job-level if 都允许（与 `env` 不同），语义对齐：

| 触发方式 | inputs.simple_release | vars.SIMPLE_RELEASE | queue-prod-deploy |
|---|---|---|---|
| tag push（默认） | (empty) | 'false' / unset | 跑 |
| workflow_dispatch simple_release=true | 'true' | * | 跳过 ✓ |
| workflow_dispatch simple_release=false | 'false' | * | 跑 |
| repo vars.SIMPLE_RELEASE='true' 总开关 | * | 'true' | 跳过 ✓ |

参考：https://docs.github.com/en/actions/learn-github-actions/contexts （env context cannot be used in `if` expressions at job level）。

## Validation

- [x] `python3 -c "import yaml; yaml.safe_load(open('.github/workflows/release.yml'))"` → OK
- [x] `bash scripts/preflight.sh` → PASS
- [ ] 合并后下一次 tag-push（计划 v1.7.18）能正常触发 release.yml

## 后续

合并后立即 bump VERSION 1.7.17 → 1.7.18，`scripts/release-tag.sh v1.7.18` 重新发版。

🤖 Generated with [Claude Code](https://claude.com/claude-code)