### PR TITLE
chore(ci): preflight guard for env in job-level if + fix Claude CLI --output

### DIFF
--- a/.github/workflows/pr-repair-agent.yml
+++ b/.github/workflows/pr-repair-agent.yml
@@ -256,10 +256,15 @@ jobs:
           CLAUDE_CODE_ATTRIBUTION_HEADER: "0"
           ANTHROPIC_MODEL: "opus[1m]"
         run: |
+          # claude CLI has no --output flag — pipe stdout instead. tee keeps
+          # CI logs live (helpful for long agent runs); pipefail propagates
+          # claude's exit code through the pipeline so the step actually
+          # fails when the agent fails.
+          set -o pipefail
           claude -p "$(cat /tmp/pr-repair-prompt.txt)" \
             --model "opus[1m]" \
             --max-budget-usd "8.00" \
-            --output /tmp/pr-repair-agent-output.txt
+            2>&1 | tee /tmp/pr-repair-agent-output.txt
 
       - name: Upload repair artifacts
         if: always()

--- a/.github/workflows/upstream-merge-agent-daily.yml
+++ b/.github/workflows/upstream-merge-agent-daily.yml
@@ -156,10 +156,15 @@ jobs:
           CLAUDE_CODE_ATTRIBUTION_HEADER: "0"
           ANTHROPIC_MODEL: "opus[1m]"
         run: |
+          # claude CLI has no --output flag — pipe stdout instead. tee keeps
+          # CI logs live (helpful for long agent runs); pipefail propagates
+          # claude's exit code through the pipeline so the step actually
+          # fails when the agent fails.
+          set -o pipefail
           claude -p "$(cat /tmp/upstream-merge-agent-prompt.txt)" \
             --model "opus[1m]" \
             --max-budget-usd "8.00" \
-            --output /tmp/upstream-merge-agent-output.txt
+            2>&1 | tee /tmp/upstream-merge-agent-output.txt
 
       - name: Upload agent output
         if: always()

--- a/scripts/check-workflow-job-if-env.py
+++ b/scripts/check-workflow-job-if-env.py
@@ -1,0 +1,97 @@
+#!/usr/bin/env python3
+"""Verify .github/workflows/*.yml does not reference env.* in job-level if.
+
+GitHub Actions does NOT allow the env context in job-level if expressions —
+env is unavailable when GitHub evaluates job-level if (it runs before the
+job is set up). Such references cause the ENTIRE workflow to fail to parse
+with HTTP 422 "Unrecognized named-value: 'env'", silently breaking every
+tag-push / workflow_dispatch trigger that uses that workflow.
+
+History: PR #120 introduced this pattern in release.yml's queue-prod-deploy
+job. The defect was invisible until v1.7.17 tag-push (2026-05-06), when it
+blocked the prod release pipeline entirely. PR #122 fixed it; this preflight
+check stops the pattern from recurring.
+
+Step-level if expressions DO support env; only job-level if (jobs.<name>.if)
+is flagged.
+
+Usage: python3 scripts/check-workflow-job-if-env.py [--quiet]
+Exit 0 ok, 1 violation, 2 missing dep / unparseable.
+"""
+
+from __future__ import annotations
+
+import re
+import sys
+import pathlib
+
+try:
+    import yaml  # PyYAML
+except ImportError:
+    print(
+        "  err: PyYAML not installed (required to parse .github/workflows/*.yml).\n"
+        "       fix: python3 -m pip install --user pyyaml",
+        flush=True,
+    )
+    sys.exit(2)
+
+REPO_ROOT = pathlib.Path(__file__).resolve().parent.parent
+WORKFLOW_DIR = REPO_ROOT / ".github" / "workflows"
+ENV_REF = re.compile(r"\benv\.")
+
+
+def find_violations(yml_path: pathlib.Path) -> list[tuple[pathlib.Path, str, str]]:
+    try:
+        doc = yaml.safe_load(yml_path.read_text())
+    except yaml.YAMLError as exc:
+        return [(yml_path, "<parse-error>", f"YAML parse error: {exc}")]
+    if not isinstance(doc, dict):
+        return []
+    jobs = doc.get("jobs")
+    if not isinstance(jobs, dict):
+        return []
+    out: list[tuple[pathlib.Path, str, str]] = []
+    for job_name, job_def in jobs.items():
+        if not isinstance(job_def, dict):
+            continue
+        # NB: jobs.<name>.if is the ONE forbidden surface. Do NOT recurse into
+        # job_def["steps"] — step-level if can use env legitimately.
+        if_expr = job_def.get("if")
+        if isinstance(if_expr, str) and ENV_REF.search(if_expr):
+            out.append((yml_path, str(job_name), if_expr.strip()))
+    return out
+
+
+def main(argv: list[str]) -> int:
+    quiet = "--quiet" in argv
+    if not WORKFLOW_DIR.is_dir():
+        if not quiet:
+            print(f"  skip: no {WORKFLOW_DIR}", flush=True)
+        return 0
+    violations: list[tuple[pathlib.Path, str, str]] = []
+    for path in sorted(list(WORKFLOW_DIR.glob("*.yml")) + list(WORKFLOW_DIR.glob("*.yaml"))):
+        violations.extend(find_violations(path))
+    if violations:
+        for path, job, expr in violations:
+            rel = path.relative_to(REPO_ROOT)
+            print(f"  err: {rel}: jobs.{job}.if references env.* (forbidden at job level)", flush=True)
+            print(f"       expr: {expr}", flush=True)
+        print("", flush=True)
+        print(
+            "  GitHub Actions rejects env in job-level if (HTTP 422 "
+            "\"Unrecognized named-value: 'env'\").",
+            flush=True,
+        )
+        print(
+            "  Use vars.* / github.event.inputs.* / needs.<job>.outputs.* instead. "
+            "See PR #122 for the canonical fix.",
+            flush=True,
+        )
+        return 1
+    if not quiet:
+        print("  ok: no env references in job-level if expressions", flush=True)
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main(sys.argv[1:]))

--- a/scripts/preflight.sh
+++ b/scripts/preflight.sh
@@ -350,6 +350,25 @@ else
     echo "  ok: tk_post_deploy_smoke.sh parses"
 fi
 
+# ---- sub2api: workflow job-level if env-context drift -----------------------
+# GitHub Actions does NOT allow env references in jobs.<name>.if expressions
+# (env evaluates AFTER if). Such references make the entire workflow file
+# fail to parse with HTTP 422 "Unrecognized named-value: 'env'", silently
+# breaking every tag-push / workflow_dispatch trigger that depends on it.
+# 2026-05-06 v1.7.17 prod release was blocked exactly this way (PR #120
+# introduced; PR #122 fixed). This guard prevents recurrence.
+echo ""
+echo "=== sub2api: workflow job-level if env-context ==="
+if ! command -v python3 >/dev/null 2>&1; then
+    echo "  FAIL: python3 not on PATH (required to parse .github/workflows/*.yml)"
+    errors=$((errors + 1))
+elif ! python3 ./scripts/check-workflow-job-if-env.py --quiet; then
+    # check-workflow-job-if-env.py already printed the actionable failure.
+    errors=$((errors + 1))
+else
+    echo "  ok: no env references in job-level if expressions"
+fi
+
 echo ""
 if [ "$errors" -eq 0 ]; then
     echo "=== preflight (with sub2api checks): PASS ==="


### PR DESCRIPTION
## Summary

两条今晚 v1.7.17 release 事故的 CI 硬化：

1. **新增 preflight 静态检查** `scripts/check-workflow-job-if-env.py`：扫 `.github/workflows/*.yml`，发现任何 `jobs.<name>.if` 里引用 `env.*` 就失败。这是 PR #122 修掉的同类 bug 的回归屏障。
2. **修两个 Claude CLI 错误的 `--output` flag**：`upstream-merge-agent-daily.yml` 和 `pr-repair-agent.yml` 都用了不存在的 `--output /tmp/...` 参数（`claude -p` 默认走 stdout），导致每次跑都 `error: unknown option '--output'`。改为 `2>&1 | tee /tmp/...` + `set -o pipefail`。

## Risk

### 1. preflight env-context guard

**事故**：PR #120 在 `release.yml` 的 `queue-prod-deploy` job 里写了 `if: ${{ ... env.SIMPLE_RELEASE != 'true' }}`。GitHub Actions **不允许** `env` 在 job-level `if` 里出现（env evaluates AFTER if，详见 https://docs.github.com/en/actions/learn-github-actions/contexts），整份 workflow 解析失败：

```
HTTP 422 failed to parse workflow:
(Line: 308, Col: 9): Unrecognized named-value: 'env'.
Located at position 38 within expression:
needs.release.result == 'success' && env.SIMPLE_RELEASE != 'true'
```

直接后果：v1.7.17 tag-push 与 workflow_dispatch 双双被 422 拒，所有 release 卡死。PR #122 修复，本 PR 加 guard 防回归。

**实现**：Python + PyYAML，walk `jobs.<name>.if`，正则 `\benv\.`。step-level `if` 不被 flag（GH 允许 env 在 step-level）。空跑当前 main：

```
=== sub2api: workflow job-level if env-context ===
  ok: no env references in job-level if expressions
```

注入测试（暂时改回坏版）：

```
err: .github/workflows/release.yml: jobs.queue-prod-deploy.if references env.* (forbidden at job level)
     expr: ${{ needs.release.result == 'success' && env.SIMPLE_RELEASE != 'true' && ... }}
```

### 2. Claude CLI `--output` 修复

**事故**：https://github.com/youxuanxue/sub2api/actions/runs/25412585042/job/74537351182  
事故时间 2026-05-06，`Daily Upstream Merge Agent` 的 step 14 失败：

```
error: unknown option '--output'
##[error]Process completed with exit code 1.
```

`claude` CLI 并没有 `--output` 参数（`claude -p` 默认走 stdout）。`pr-repair-agent.yml` 同样写法，下次触发也会一样挂。

**修复**：`--output /tmp/...` → `2>&1 | tee /tmp/...`。`tee` 保留 CI 实时日志（长跑 agent 调试友好），`set -o pipefail` 保证 claude 失败时 step 真正失败而不是被 tee 吞掉退出码。

**变更面**：纯 CI hygiene。运行时行为不变（artifact upload 路径不变，agent prompt 不变）。

## Validation

- [x] `python3 scripts/check-workflow-job-if-env.py` → ok（当前 main 无违规）
- [x] 注入测试：临时把 release.yml 改回坏版，check 报错并 exit 1；还原后再 ok
- [x] `python3 -c "import yaml; yaml.safe_load(open('.github/workflows/upstream-merge-agent-daily.yml'))"` → OK
- [x] `python3 -c "import yaml; yaml.safe_load(open('.github/workflows/pr-repair-agent.yml'))"` → OK
- [x] `bash scripts/preflight.sh` → PASS（含新增 sub2api 专项 check）
- [ ] CI（backend-ci, security-scan）
- [ ] 合并后下次 `Daily Upstream Merge Agent` cron run 不再因 `--output` 失败

🤖 Generated with [Claude Code](https://claude.com/claude-code)