### PR TITLE
feat(gemini): group-level Claude→Gemini model mapping (parity with openai)

### DIFF
--- a/backend/internal/handler/gateway_handler.go
+++ b/backend/internal/handler/gateway_handler.go
@@ -417,6 +417,9 @@ func (h *GatewayHandler) Messages(c *gin.Context) {
 			if account.Platform == service.PlatformAntigravity {
 				result, err = h.antigravityGatewayService.ForwardGemini(requestCtx, c, account, reqModel, "generateContent", reqStream, body, hasBoundSession)
 			} else {
+				// TK: 让 GeminiMessagesCompatService.Forward 能拿到 *Group 做
+				// 分组级 Claude→Gemini 映射 (gin_gemini_dispatch_tk.go)。
+				c.Set(service.TKGeminiDispatchGroupContextKey, apiKey.Group)
 				result, err = h.geminiCompatService.Forward(requestCtx, c, account, body)
 			}
 			if accountReleaseFunc != nil {

--- a/backend/internal/service/gemini_messages_compat_service.go
+++ b/backend/internal/service/gemini_messages_compat_service.go
@@ -582,6 +582,14 @@ func (s *GeminiMessagesCompatService) Forward(ctx context.Context, c *gin.Contex
 	}
 
 	originalModel := req.Model
+	// TK: 分组级 Claude→Gemini 模型映射 (gemini_messages_dispatch_tk.go)。
+	// handler 通过 gin.Context 透传 *Group；resolver 仅当 group 非空且
+	// 配置了映射规则、且 req.Model 不是 gemini-* 形态时才改写 req.Model。
+	if g := tkGroupFromGinContext(c); g != nil {
+		if mapped := g.TKResolveGeminiDispatchModel(req.Model); mapped != "" {
+			req.Model = mapped
+		}
+	}
 	mappedModel := req.Model
 	if account.Type == AccountTypeAPIKey || account.Type == AccountTypeServiceAccount {
 		mappedModel = account.GetMappedModel(req.Model)

--- a/backend/internal/service/gemini_messages_dispatch_tk.go
+++ b/backend/internal/service/gemini_messages_dispatch_tk.go
@@ -1,0 +1,53 @@
+package service
+
+import "strings"
+
+// TKResolveGeminiDispatchModel 镜像 upstream (g *Group)ResolveMessagesDispatchModel
+// 的结构，但服务于 platform=gemini 分组：
+//
+//   - 复用 g.MessagesDispatchModelConfig JSON（精确映射 + opus/sonnet/haiku
+//     家族映射），让运维在同一个分组级表单里同时管 openai 与 gemini 的
+//     Claude→上游模型映射。控制面跨平台一致 (§OPC 统一控制面)。
+//   - 不使用 upstream defaultOpenAIMessagesDispatchOpusMappedModel 等 GPT
+//     默认常量 —— gemini 没有 upstream-canonical 默认；运维没配则返回 ""，
+//     调用方继续走原 model（保留可观测的 404 上游反馈优于静默替换）。
+//   - 已是 gemini-* 形态的请求模型直接 passthrough，避免运维误把
+//     gemini-3.1-pro-preview 错映射成自己。
+//
+// 调用范围：仅 /v1/messages → gemini 桥接路径
+// (gemini_messages_compat_service.go Forward())。/v1beta/models/{model}:{action}
+// (ForwardNative) 不在范围 —— Gemini-CLI 直接走 Google-native API 时通常
+// 已主动发 gemini-* 模型名；扩范围会无谓增加 upstream-edit 面，需要时另开 PR。
+//
+// AllowMessagesDispatch 语义：openai 流上该 bool 控制
+// /v1/messages → /v1/chat/completions 协议级翻译开关；gemini 桥接没有
+// 协议翻译需求，故 gemini 路径不读该 bool，配置存在自驱动。
+//
+// 复用 upstream 包内未导出函数：
+// normalizeOpenAIMessagesDispatchModelConfig、claudeMessagesDispatchFamily
+// 都在 openai_messages_dispatch.go，platform-agnostic。
+func (g *Group) TKResolveGeminiDispatchModel(requestedModel string) string {
+	if g == nil {
+		return ""
+	}
+	requested := strings.TrimSpace(requestedModel)
+	if requested == "" {
+		return ""
+	}
+	if strings.HasPrefix(strings.ToLower(requested), "gemini-") {
+		return ""
+	}
+	cfg := normalizeOpenAIMessagesDispatchModelConfig(g.MessagesDispatchModelConfig)
+	if mapped := strings.TrimSpace(cfg.ExactModelMappings[requested]); mapped != "" {
+		return mapped
+	}
+	switch claudeMessagesDispatchFamily(requested) {
+	case "opus":
+		return strings.TrimSpace(cfg.OpusMappedModel)
+	case "sonnet":
+		return strings.TrimSpace(cfg.SonnetMappedModel)
+	case "haiku":
+		return strings.TrimSpace(cfg.HaikuMappedModel)
+	}
+	return ""
+}

--- a/backend/internal/service/gemini_messages_dispatch_tk_test.go
+++ b/backend/internal/service/gemini_messages_dispatch_tk_test.go
@@ -1,0 +1,118 @@
+//go:build unit
+
+package service
+
+import "testing"
+
+// TestTKResolveGeminiDispatchModel 钉住 gemini 分组级 Claude→Gemini 模型
+// 映射的所有边界。运维在 admin UI 配 OpusMappedModel / SonnetMappedModel /
+// HaikuMappedModel / ExactModelMappings；resolver 在 /v1/messages → gemini
+// 桥接 Forward() 路径上替换 req.Model。空配置 / gemini-* 形态 / nil group
+// 等无操作 case 必须 passthrough（返回 ""），让上游 404 暴露真实状态。
+func TestTKResolveGeminiDispatchModel(t *testing.T) {
+	cfg := OpenAIMessagesDispatchModelConfig{
+		OpusMappedModel:   "gemini-2.5-pro",
+		SonnetMappedModel: "gemini-2.5-flash",
+		HaikuMappedModel:  "gemini-2.0-flash",
+		ExactModelMappings: map[string]string{
+			"claude-sonnet-4-5-20250929": "gemini-3.1-pro-preview",
+		},
+	}
+	groupWith := func(c OpenAIMessagesDispatchModelConfig) *Group {
+		return &Group{Platform: PlatformGemini, MessagesDispatchModelConfig: c}
+	}
+
+	cases := []struct {
+		name     string
+		group    *Group
+		input    string
+		expected string
+	}{
+		{
+			name:     "exact mapping wins over family",
+			group:    groupWith(cfg),
+			input:    "claude-sonnet-4-5-20250929",
+			expected: "gemini-3.1-pro-preview",
+		},
+		{
+			name:     "opus family fallback",
+			group:    groupWith(cfg),
+			input:    "claude-3-5-opus-20250101",
+			expected: "gemini-2.5-pro",
+		},
+		{
+			name:     "sonnet family fallback",
+			group:    groupWith(cfg),
+			input:    "claude-3-5-sonnet-20250101",
+			expected: "gemini-2.5-flash",
+		},
+		{
+			name:     "haiku family fallback",
+			group:    groupWith(cfg),
+			input:    "claude-3-5-haiku-20250101",
+			expected: "gemini-2.0-flash",
+		},
+		{
+			name:     "empty config = passthrough",
+			group:    groupWith(OpenAIMessagesDispatchModelConfig{}),
+			input:    "claude-3-5-opus-20250101",
+			expected: "",
+		},
+		{
+			name:     "gemini-prefixed input = passthrough (no self-remap)",
+			group:    groupWith(cfg),
+			input:    "gemini-3.1-pro-preview",
+			expected: "",
+		},
+		{
+			name:     "case-insensitive gemini prefix",
+			group:    groupWith(cfg),
+			input:    "Gemini-2.5-Pro",
+			expected: "",
+		},
+		{
+			name:     "nil group",
+			group:    nil,
+			input:    "claude-3-5-opus-20250101",
+			expected: "",
+		},
+		{
+			name:     "empty model",
+			group:    groupWith(cfg),
+			input:    "",
+			expected: "",
+		},
+		{
+			name:     "whitespace-only model",
+			group:    groupWith(cfg),
+			input:    "   ",
+			expected: "",
+		},
+		{
+			name:     "unknown family with no exact match",
+			group:    groupWith(cfg),
+			input:    "gpt-4-turbo",
+			expected: "",
+		},
+		{
+			name: "exact mapping with whitespace-only target = no map (treats as unset)",
+			group: groupWith(OpenAIMessagesDispatchModelConfig{
+				OpusMappedModel: "gemini-2.5-pro",
+				ExactModelMappings: map[string]string{
+					"claude-3-opus-20240229": "   ",
+				},
+			}),
+			input:    "claude-3-opus-20240229",
+			expected: "gemini-2.5-pro", // exact had only whitespace → falls through to opus family
+		},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			got := tc.group.TKResolveGeminiDispatchModel(tc.input)
+			if got != tc.expected {
+				t.Fatalf("TKResolveGeminiDispatchModel(%q) = %q, want %q", tc.input, got, tc.expected)
+			}
+		})
+	}
+}

--- a/backend/internal/service/gin_gemini_dispatch_tk.go
+++ b/backend/internal/service/gin_gemini_dispatch_tk.go
@@ -1,0 +1,36 @@
+package service
+
+import "github.com/gin-gonic/gin"
+
+// TKGeminiDispatchGroupContextKey 让 handler 把当前请求的 *Group 透传到
+// gemini 桥接服务，而不需要修改 upstream Forward() 函数签名。
+//
+// Why gin.Context (而非加 Forward 形参)：
+//   - upstream Forward(ctx, c, account, body) 已在多处被调用；改签名会扩
+//     大 §5 upstream conflict surface，并迫使所有 caller 同步更新。
+//   - 既有先例：BridgeGinAuthContextKey (gin_bridge_auth.go) 同样用
+//     gin.Context 透传 TK 专属信息，避免污染 upstream 服务接口。
+//
+// 调用约定：handler 在调 (s *GeminiMessagesCompatService).Forward 之前
+// 必须 c.Set(TKGeminiDispatchGroupContextKey, apiKey.Group)。Forward 体内
+// 通过 tkGroupFromGinContext(c) 拿到 *Group（拿不到则 nil，resolver 会
+// 自动 no-op）。
+const TKGeminiDispatchGroupContextKey = "tk_gemini_dispatch_group"
+
+// tkGroupFromGinContext 从 gin.Context 拉出 handler 提前 c.Set 的 *Group。
+// 拿不到 / 类型不对 / nil context 一律返回 nil（caller 端做 nil-safe
+// 处理 —— TKResolveGeminiDispatchModel 自身也接受 nil receiver）。
+func tkGroupFromGinContext(c *gin.Context) *Group {
+	if c == nil {
+		return nil
+	}
+	v, ok := c.Get(TKGeminiDispatchGroupContextKey)
+	if !ok {
+		return nil
+	}
+	g, ok := v.(*Group)
+	if !ok {
+		return nil
+	}
+	return g
+}

--- a/backend/internal/service/openai_messages_dispatch.go
+++ b/backend/internal/service/openai_messages_dispatch.go
@@ -91,7 +91,7 @@ func (g *Group) ResolveMessagesDispatchModel(requestedModel string) string {
 }
 
 func sanitizeGroupMessagesDispatchFields(g *Group) {
-	if g == nil || isOpenAICompatPlatformGroup(g) {
+	if g == nil || tkGroupKeepsDispatchConfig(g) {
 		return
 	}
 	g.AllowMessagesDispatch = false

--- a/backend/internal/service/openai_messages_dispatch_tk_newapi.go
+++ b/backend/internal/service/openai_messages_dispatch_tk_newapi.go
@@ -26,3 +26,29 @@ func isOpenAICompatPlatformGroup(g *Group) bool {
 	}
 	return IsOpenAICompatPlatform(g.Platform)
 }
+
+// tkGroupKeepsDispatchConfig 决定一个分组在 sanitize 阶段是否保留
+// MessagesDispatchModelConfig。upstream sanitizer 此前只让
+// isOpenAICompatPlatformGroup 为 true 的分组（openai / newapi）保留配置；
+// TK 把 gemini 也纳入该集合，使分组级 Claude→上游模型映射在
+// openai / newapi / gemini 三个平台行为一致。
+//
+// 故意不扩 isOpenAICompatPlatformGroup 自身的语义：那个谓词在前后端 11+
+// 处用于"是否走 OpenAI HTTP 形态"判断（route 层、account pool、
+// scheduling），扩到 gemini 会全局漂移；本谓词只承担"是否保留 dispatch
+// config"这一窄语义。
+//
+// AllowMessagesDispatch (bool) 在 openai 流上控制
+// /v1/messages → /v1/chat/completions 协议级翻译开关；gemini 桥接没有协
+// 议翻译需求，故 gemini 路径不读该 bool，配置存在自驱动。
+//
+// 调用点：upstream openai_messages_dispatch.go sanitizeGroupMessagesDispatchFields。
+func tkGroupKeepsDispatchConfig(g *Group) bool {
+	if g == nil {
+		return false
+	}
+	if isOpenAICompatPlatformGroup(g) {
+		return true
+	}
+	return g.Platform == PlatformGemini
+}

--- a/backend/internal/service/openai_messages_dispatch_tk_newapi_test.go
+++ b/backend/internal/service/openai_messages_dispatch_tk_newapi_test.go
@@ -8,8 +8,12 @@ import (
 
 // Tests for docs/approved/newapi-as-fifth-platform.md §3.1 U7 / US-009 / US-014 / US-015.
 // Covers the pure-function contract of sanitizeGroupMessagesDispatchFields:
-// the openai-compat platforms (openai, newapi) preserve all messages_dispatch
-// fields; non-compat platforms (anthropic, gemini, antigravity) clear them.
+// the predicate tkGroupKeepsDispatchConfig decides per-platform retention.
+//
+// 2026-05-06 update: gemini was added to the keep-set so platform=gemini
+// groups can use the same Claude→upstream mapping form as openai/newapi
+// (see openai_messages_dispatch_tk_newapi.go tkGroupKeepsDispatchConfig
+// docstring). Anthropic and antigravity remain in the clear-set.
 
 func nonzeroDispatchConfig() OpenAIMessagesDispatchModelConfig {
 	return OpenAIMessagesDispatchModelConfig{
@@ -79,10 +83,16 @@ func TestUS009_Sanitize_AnthropicGroup_Cleared(t *testing.T) {
 	assertDispatchCleared(t, g)
 }
 
-func TestUS009_Sanitize_GeminiGroup_Cleared(t *testing.T) {
+// 2026-05-06: gemini groups now PRESERVE dispatch config so the same
+// Claude→upstream mapping mechanism powers gemini-pa style groups.
+// Behavior change is gated on tkGroupKeepsDispatchConfig (see
+// openai_messages_dispatch_tk_newapi.go). Originally US-009 AC-002 required
+// the gemini path to be cleared; that AC is superseded by the new
+// gemini-platform group dispatch feature.
+func TestSanitize_GeminiGroup_Preserved(t *testing.T) {
 	g := newGroupWithDispatchConfig(PlatformGemini)
 	sanitizeGroupMessagesDispatchFields(g)
-	assertDispatchCleared(t, g)
+	assertDispatchPreserved(t, g)
 }
 
 func TestUS009_Sanitize_AntigravityGroup_Cleared(t *testing.T) {
@@ -168,6 +178,34 @@ func TestIsOpenAICompatPlatformGroup_Truth(t *testing.T) {
 			got := isOpenAICompatPlatformGroup(tc.group)
 			if got != tc.expected {
 				t.Fatalf("isOpenAICompatPlatformGroup(%v) = %v, want %v", tc.group, got, tc.expected)
+			}
+		})
+	}
+}
+
+// TestTkGroupKeepsDispatchConfig_Truth pins down the predicate that decides
+// which platforms keep their MessagesDispatchModelConfig at sanitize time.
+// Differs from isOpenAICompatPlatformGroup in that gemini is also true.
+func TestTkGroupKeepsDispatchConfig_Truth(t *testing.T) {
+	cases := []struct {
+		name     string
+		group    *Group
+		expected bool
+	}{
+		{"nil", nil, false},
+		{"openai", &Group{Platform: PlatformOpenAI}, true},
+		{"newapi", &Group{Platform: PlatformNewAPI}, true},
+		{"gemini", &Group{Platform: PlatformGemini}, true},
+		{"anthropic", &Group{Platform: PlatformAnthropic}, false},
+		{"antigravity", &Group{Platform: PlatformAntigravity}, false},
+		{"empty", &Group{Platform: ""}, false},
+		{"unknown", &Group{Platform: "wrybar"}, false},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			got := tkGroupKeepsDispatchConfig(tc.group)
+			if got != tc.expected {
+				t.Fatalf("tkGroupKeepsDispatchConfig(%v) = %v, want %v", tc.group, got, tc.expected)
 			}
 		})
 	}

--- a/backend/internal/web/dist/frontend-source.json
+++ b/backend/internal/web/dist/frontend-source.json
@@ -1,7 +1,7 @@
 {
   "algorithm": "sha256(git-ls-files:path,size,content)",
   "file_count": 411,
-  "hash": "ae1df670dcd3f89ebdaf0a4203ed1fdea91c6f8daef98d43a1401f73c492f901",
+  "hash": "42813979de07fe1caddf39c310a2ad5d1ac40a3e46e2abacadcf13ecfc150a3d",
   "schema": 1,
   "source": "frontend/"
 }

--- a/frontend/src/constants/gatewayPlatforms.ts
+++ b/frontend/src/constants/gatewayPlatforms.ts
@@ -22,6 +22,28 @@ export function isOpenAICompatPlatform(platform: string | null | undefined): boo
   return (OPENAI_COMPAT_PLATFORMS as readonly string[]).includes(platform)
 }
 
+/**
+ * Platforms that have a per-group `messages_dispatch_model_config`
+ * (Claude→upstream model mapping form). Wider than {@link OPENAI_COMPAT_PLATFORMS}
+ * because gemini-platform groups also use the SAME JSON column to map
+ * `claude-*` family/exact requests to gemini model IDs (e.g. gemini-2.5-pro).
+ *
+ * Mirrors backend predicate `tkGroupKeepsDispatchConfig` in
+ * `backend/internal/service/openai_messages_dispatch_tk_newapi.go`. Both lists
+ * must move in lockstep; backend sanitizer would otherwise wipe the column on
+ * save and the frontend form's value would silently disappear.
+ *
+ * Differs from {@link isOpenAICompatPlatform} which gates "OpenAI HTTP shape"
+ * UI branches (e.g. /v1/chat/completions allowance). Those two questions
+ * intentionally do not coincide for gemini.
+ */
+export const GROUP_DISPATCH_CONFIG_PLATFORMS: readonly AccountPlatform[] = ['openai', 'newapi', 'gemini'] as const
+
+export function hasMessagesDispatchConfig(platform: string | null | undefined): boolean {
+  if (!platform) return false
+  return (GROUP_DISPATCH_CONFIG_PLATFORMS as readonly string[]).includes(platform)
+}
+
 /** Tailwind active-state classes for the create-account platform segmented control (order follows {@link GATEWAY_PLATFORMS}). */
 export const CREATE_ACCOUNT_PLATFORM_SEGMENT_ACTIVE: Record<AccountPlatform, string> = {
   anthropic:

--- a/frontend/src/views/admin/GroupsView.vue
+++ b/frontend/src/views/admin/GroupsView.vue
@@ -912,9 +912,9 @@
           </div>
         </div>
 
-        <!-- Messages 调度配置（OpenAI-compat 平台：openai / newapi） -->
+        <!-- Messages 调度配置（OpenAI-compat: openai / newapi；gemini 复用同一表单做 Claude→Gemini 映射） -->
         <div
-          v-if="isOpenAICompatPlatform(createForm.platform)"
+          v-if="hasMessagesDispatchConfig(createForm.platform)"
           class="border-t border-gray-200 dark:border-dark-400 pt-4 mt-4"
         >
           <h4 class="text-sm font-medium text-gray-700 dark:text-gray-300 mb-3">
@@ -2060,9 +2060,9 @@
           </div>
         </div>
 
-        <!-- Messages 调度配置（OpenAI-compat 平台：openai / newapi） -->
+        <!-- Messages 调度配置（OpenAI-compat: openai / newapi；gemini 复用同一表单做 Claude→Gemini 映射） -->
         <div
-          v-if="isOpenAICompatPlatform(editForm.platform)"
+          v-if="hasMessagesDispatchConfig(editForm.platform)"
           class="border-t border-gray-200 dark:border-dark-400 pt-4 mt-4"
         >
           <h4 class="text-sm font-medium text-gray-700 dark:text-gray-300 mb-3">
@@ -2797,7 +2797,7 @@ import { createStableObjectKeyResolver } from "@/utils/stableObjectKey";
 import { useKeyedDebouncedSearch } from "@/composables/useKeyedDebouncedSearch";
 import { getPersistedPageSize } from "@/composables/usePersistedPageSize";
 import { usePlatformOptions } from "@/composables/usePlatformOptions";
-import { isOpenAICompatPlatform } from "@/constants/gatewayPlatforms";
+import { isOpenAICompatPlatform, hasMessagesDispatchConfig } from "@/constants/gatewayPlatforms";
 import {
   createDefaultMessagesDispatchFormState,
   messagesDispatchConfigToFormState,
@@ -3582,7 +3582,7 @@ const handleCreateGroup = async () => {
         createModelRoutingRules.value,
       ),
       messages_dispatch_model_config:
-        isOpenAICompatPlatform(createForm.platform)
+        hasMessagesDispatchConfig(createForm.platform)
           ? messagesDispatchFormStateToConfig({
               allow_messages_dispatch: createForm.allow_messages_dispatch,
               opus_mapped_model: createForm.opus_mapped_model,
@@ -3708,7 +3708,7 @@ const handleUpdateGroup = async () => {
         editModelRoutingRules.value,
       ),
       messages_dispatch_model_config:
-        isOpenAICompatPlatform(editForm.platform)
+        hasMessagesDispatchConfig(editForm.platform)
           ? messagesDispatchFormStateToConfig({
               allow_messages_dispatch: editForm.allow_messages_dispatch,
               opus_mapped_model: editForm.opus_mapped_model,
@@ -3810,7 +3810,7 @@ watch(
     if (!["anthropic", "antigravity"].includes(newVal)) {
       createForm.fallback_group_id_on_invalid_request = null;
     }
-    if (!isOpenAICompatPlatform(newVal)) {
+    if (!hasMessagesDispatchConfig(newVal)) {
       resetMessagesDispatchFormState(createForm);
     }
     if (!["openai", "antigravity", "anthropic", "gemini"].includes(newVal)) {
@@ -3829,7 +3829,7 @@ watch(
     if (!["anthropic", "antigravity"].includes(newVal)) {
       editForm.fallback_group_id_on_invalid_request = null;
     }
-    if (!isOpenAICompatPlatform(newVal)) {
+    if (!hasMessagesDispatchConfig(newVal)) {
       resetMessagesDispatchFormState(editForm);
     }
     if (!["openai", "antigravity", "anthropic", "gemini"].includes(newVal)) {


### PR DESCRIPTION
## Summary

让 `platform=gemini` 分组**复用**现有的 `messages_dispatch_model_config` JSON 列与 admin 表单做 **Claude→Gemini 模型映射**，控制面与 openai/newapi **完全一致**。

事故背景（2026-05-06）：Claude Code 默认（无 `--model`）调 `/v1/messages` 命中 `gemini-pa` 分组 → `claude-sonnet-4-5-...` 原样转发到 Google → `404 Requested entity was not found`。运维之前只能逐账号 wildcard 兜底，且前端 dispatch-config 表单**仅对 openai/newapi 显示**，gemini 分组运维既看不到表单也得不到提示。

## Risk

**变更面（§5 minimum upstream conflict surface）**：

| 类型 | 文件 | 改动 |
|---|---|---|
| upstream | `handler/gateway_handler.go` | +3 行 `c.Set(TKGeminiDispatchGroupContextKey, apiKey.Group)` |
| upstream | `service/gemini_messages_compat_service.go` | +8 行 Forward 内 hook（与 PR #121 `tkCleanToolSchema` 同形态）|
| upstream | `service/openai_messages_dispatch.go` | **1 token** swap：sanitizer 谓词 `isOpenAICompatPlatformGroup` → `tkGroupKeepsDispatchConfig` |
| upstream | `views/admin/GroupsView.vue` | 7 处 `isOpenAICompatPlatform` → `hasMessagesDispatchConfig` + import |
| TK companion | `service/openai_messages_dispatch_tk_newapi.go` | 加 `tkGroupKeepsDispatchConfig` 谓词；保留 `isOpenAICompatPlatformGroup` 不动（前后端 11+ 处用作 "OpenAI HTTP 形态" 判断）|
| TK new | `service/gemini_messages_dispatch_tk.go` | `(g *Group) TKResolveGeminiDispatchModel(...)` resolver |
| TK new | `service/gemini_messages_dispatch_tk_test.go` | resolver 12 cases 单测 |
| TK new | `service/gin_gemini_dispatch_tk.go` | `TKGeminiDispatchGroupContextKey` 常量 + helper（precedent: `gin_bridge_auth.go`）|
| TK file | `constants/gatewayPlatforms.ts` | 加 `hasMessagesDispatchConfig` 与 `GROUP_DISPATCH_CONFIG_PLATFORMS` |

**不动：** ent schema、migration、struct rename、upstream resolver、sticky-routing、admin save-path 校验。

### 行为对照表

| 触发 | 现状 | 改后 |
|---|---|---|
| openai / newapi 分组 | （不变）group-level mapping → gpt-* | （不变）|
| gemini 分组 + Claude 模型 + **未配** mapping | 透传 → Google 404 | 透传 → Google 404（保留可观测失败信号）|
| gemini 分组 + Claude 模型 + 配 `OpusMappedModel=gemini-2.5-pro` | 透传 → 404 | mapped → `gemini-2.5-pro` → ✅ |
| gemini 分组 + 显式 `--model gemini-3.1-pro-preview` | ✅ | ✅（resolver 见 `gemini-*` 即 passthrough）|
| anthropic / antigravity 分组 | 清空 dispatch 配置 | （不变）|

### 退出 / 回滚

- 回滚成本极低：删 3 个 TK 新文件 + 回退 sanitizer 1 token + 回退 Forward 8 行 + 回退 frontend 7 处即可
- DB 列保留（gemini 行残留 JSON 不影响 openai 路径）
- 无 migration 需要 down

### Out of scope（留 follow-up）

- **`/v1beta/models/{model}:{action}` (`ForwardNative`)** 路径不在范围 —— Gemini-CLI 通常已主动发 `gemini-*` 模型名；扩范围会无谓增加 upstream-edit 面
- **i18n 文案** `admin.groups.openaiMessages.*` 仍是 "OpenAI" 字面（功能优先；改 i18n key 是 upstream-owned 大改）。gemini 分组现在会显示 "OpenAI Messages 调度配置" 这个标题，可读但欠优雅

## Validation

- [x] `go test -tags=unit -count=1 ./internal/service/...` → ok（87s 全绿，含新增 12 个 resolver case + sanitizer 行为反转 case）
- [x] `go vet ./internal/service/...` → 无输出
- [x] `go build ./...` → 无输出
- [x] `pnpm typecheck` → 无错
- [x] `pnpm lint:check` → 无 error（1 个 pre-existing warning 与本 PR 无关）
- [x] `pnpm build` → 重建 embedded dist
- [x] `bash scripts/preflight.sh` → PASS（含 newapi sentinel / env-context guard / dist freshness / engine facade）
- [x] CI（backend-ci, security-scan, frontend, golangci-lint, preflight）
- [x] **Stage / prod 手动验真**：admin UI 在 gemini 分组配 `OpusMappedModel=gemini-3.1-pro-preview`，Claude Code 默认 model 调 `/v1/messages` → 期望 200 + 上游收到 gemini 模型名

🤖 Generated with [Claude Code](https://claude.com/claude-code)