### PR TITLE
chore(smoke): distinguish schema-regression 400 from runtime-resource 5xx/429

### DIFF
--- a/scripts/tk_post_deploy_smoke.sh
+++ b/scripts/tk_post_deploy_smoke.sh
@@ -206,6 +206,18 @@ fi
 # upstream returns 400 "Invalid JSON payload received. Unknown name ...:
 # Cannot find field." and this section fails. Skipped silently when no
 # Gemini-bound key is provided.
+#
+# Failure semantics (2026-05-06 v1.7.19 false-positive postmortem):
+#   200 → schema cleanup verified end-to-end against real Google upstream.
+#   400 → HARD FAIL. The bug we are guarding (PR #121) has regressed; the
+#         deploy must be rolled back / investigated.
+#   401, 403, 404 → HARD FAIL. The configured smoke key/route is broken.
+#   503 / 502 / 500 / "no available accounts" / 429 → SOFT WARN, exit 0.
+#         These are upstream / scheduling resource issues that could not
+#         possibly indicate a schema cleanup regression (a broken cleanup
+#         would have been rejected with 400 BEFORE reaching the scheduling
+#         pool). Treating them as deploy failures conflates control-plane
+#         health with runtime-resource health.
 GEMINI_KEY="${POST_DEPLOY_SMOKE_GEMINI_API_KEY:-}"
 GEMINI_MODEL="${POST_DEPLOY_SMOKE_GEMINI_MODEL:-gemini-3.1-pro-preview}"
 
@@ -242,20 +254,55 @@ if [[ -n "${GEMINI_KEY}" ]]; then
     -d "${gpayload}" \
     "${BASE}/v1/messages")
   echo "tk_post_deploy_smoke: POST .../v1/messages (gemini, with tools) -> HTTP ${gemini_http}"
-  if [[ "${gemini_http}" != "200" ]]; then
-    echo "tk_post_deploy_smoke: /v1/messages (gemini, with tools) failed — Gemini schema cleanup may be broken (see prod incident 2026-05-06)" >&2
+
+  # Read the gateway-reported error message (if any) to disambiguate
+  # "schema cleanup broken" (400, the bug we guard) from "runtime resource
+  # unavailable" (503 / 5xx / no available accounts / rate-limit).
+  gemini_err_msg="$(jq -r '.error.message // empty' "$tmpdir/gemini-msg.json" 2>/dev/null)"
+
+  # 200 happy path → verify shape, then continue to "OK".
+  if [[ "${gemini_http}" == "200" ]]; then
+    gemini_type="$(jq -r '.type // empty' "$tmpdir/gemini-msg.json")"
+    gemini_role="$(jq -r '.role // empty' "$tmpdir/gemini-msg.json")"
+    gemini_content_count="$(jq -r '(.content // []) | length' "$tmpdir/gemini-msg.json")"
+    if [[ "${gemini_type}" != "message" ]] || [[ "${gemini_role}" != "assistant" ]] || [[ "${gemini_content_count}" -lt 1 ]]; then
+      echo "tk_post_deploy_smoke: /v1/messages (gemini) shape invalid (type=${gemini_type:-missing} role=${gemini_role:-missing} content=${gemini_content_count})" >&2
+      jq . "$tmpdir/gemini-msg.json" >&2 || true
+      exit 1
+    fi
+    echo "tk_post_deploy_smoke: /v1/messages (gemini, with tools) shape type=${gemini_type} role=${gemini_role} content=${gemini_content_count}"
+  # 400 → HARD FAIL. Schema cleanup regressed, that is the whole point of
+  # this section. Operators must investigate before considering the deploy
+  # successful.
+  elif [[ "${gemini_http}" == "400" ]]; then
+    echo "::error::tk_post_deploy_smoke: /v1/messages (gemini, with tools) returned HTTP 400 — Anthropic→Gemini schema cleanup likely regressed (see PR #121 / 2026-05-06 prod incident). DO NOT promote this build." >&2
     jq . "$tmpdir/gemini-msg.json" >&2 2>/dev/null || cat "$tmpdir/gemini-msg.json" >&2
     exit 1
-  fi
-  gemini_type="$(jq -r '.type // empty' "$tmpdir/gemini-msg.json")"
-  gemini_role="$(jq -r '.role // empty' "$tmpdir/gemini-msg.json")"
-  gemini_content_count="$(jq -r '(.content // []) | length' "$tmpdir/gemini-msg.json")"
-  if [[ "${gemini_type}" != "message" ]] || [[ "${gemini_role}" != "assistant" ]] || [[ "${gemini_content_count}" -lt 1 ]]; then
-    echo "tk_post_deploy_smoke: /v1/messages (gemini) shape invalid (type=${gemini_type:-missing} role=${gemini_role:-missing} content=${gemini_content_count})" >&2
-    jq . "$tmpdir/gemini-msg.json" >&2 || true
+  # Other 4xx (auth / route broken) → HARD FAIL: the smoke contract itself
+  # is broken; without auth/route working we cannot say anything about the
+  # gateway behavior.
+  elif [[ "${gemini_http}" == "401" || "${gemini_http}" == "403" || "${gemini_http}" == "404" ]]; then
+    echo "::error::tk_post_deploy_smoke: /v1/messages (gemini, with tools) returned HTTP ${gemini_http} — smoke key/route broken; fix POST_DEPLOY_SMOKE_GEMINI_API_KEY config or gateway routing." >&2
+    jq . "$tmpdir/gemini-msg.json" >&2 2>/dev/null || cat "$tmpdir/gemini-msg.json" >&2
     exit 1
+  # 5xx OR 429 OR gateway "no available accounts" → SOFT WARN. These cannot
+  # signal a schema cleanup regression (the request never reached upstream
+  # Google in a way that Google would have parsed the schema). Surface a CI
+  # warning + the upstream error so operators see the resource issue, but
+  # do NOT mark the deploy failed.
+  else
+    case "${gemini_err_msg}" in
+      *"no available accounts"*|*"rate"*|*"timeout"*|*"context canceled"*|*"upstream error: 5"*)
+        :
+        ;;
+    esac
+    echo "::warning::tk_post_deploy_smoke: /v1/messages (gemini, with tools) returned HTTP ${gemini_http} — runtime resource issue (likely Gemini account cooldown / 429 / upstream 5xx), NOT a schema regression. Schema cleanup contract was not violated." >&2
+    if [[ -n "${gemini_err_msg}" ]]; then
+      echo "  gateway message: ${gemini_err_msg}" >&2
+    fi
+    jq . "$tmpdir/gemini-msg.json" >&2 2>/dev/null || cat "$tmpdir/gemini-msg.json" >&2
+    echo "tk_post_deploy_smoke: gemini section soft-skipped (HTTP ${gemini_http} is not a schema-regression signal)"
   fi
-  echo "tk_post_deploy_smoke: /v1/messages (gemini, with tools) shape type=${gemini_type} role=${gemini_role} content=${gemini_content_count}"
 else
   echo "tk_post_deploy_smoke: skip /v1/messages (gemini) — POST_DEPLOY_SMOKE_GEMINI_API_KEY not set"
 fi


### PR DESCRIPTION
## Summary

post-deploy smoke 段 6（`/v1/messages with tools, gemini`）的失败语义重新设计：把"schema 清洗回归"（PR #121 守护的真实 bug 信号）与"上游资源不足"（gemini-pa 分组临时无可调度账号 / 限速 / 5xx）拆开，让前者继续 hard-fail、后者只 warn-but-continue。

## Risk

**事故复盘**（2026-05-06 v1.7.19 deploy）：

部署 6 步完成、prod 已切到 v1.7.19、Caddy 健康 200，但 smoke 段 6 拿到 503：

```json
{"error":{"message":"No available accounts: no available accounts","type":"api_error"}}
```

整个 deploy run 标 failure。运维需要手动核对 prod 日志才能确认这是 **gemini-pa 分组里 OAuth 账号 cooldown** —— 与 schema 回归毫无关系（schema 错的话 Google 会先 400，根本不会到 select_account 阶段）。

**事后用相同 secret 在本地重跑同样的 smoke**：

```
POST .../v1/messages (gemini, with tools) -> HTTP 200
shape type=message role=assistant content=1
tk_post_deploy_smoke: OK
```

—— v1.7.19 实际正常，原 deploy 只是被资源问题误判。

**新判定矩阵**：

| HTTP | 含义 | smoke 行为 |
|---|---|---|
| 200 | schema 清洗成功 + 真机 round-trip OK | exit 0（绿）|
| **400** | **PR #121 tkCleanToolSchema 回归（schema 真的坏了）** | **exit 1（HARD FAIL）** |
| 401 / 403 / 404 | smoke key/route 配错 | exit 1（外部契约问题）|
| 503 / 502 / 500 / 429 / 上游超时 | 调度池资源不足 / quota 用尽 / 临时 outage | `::warning::` + exit 0 |
| 其它 | 同上（未知非 schema 原因） | `::warning::` + exit 0 |

**为什么 5xx/429 不该挡部署**：schema 回归会在 Google 上游 parse 阶段 400 拒掉，调度池根本不会分配账号；所以一旦请求穿过调度池到了上游，schema 必然已经被接受。5xx/429 只能说明账号资源紧张或 Google 暂时不可用，跟 PR #121 守护的不变量无关。

**额外**：响应体里 jq 出 `.error.message` 给运维直接看到上游原文，不用再翻 prod 日志。

## Validation

- [x] `bash -n scripts/tk_post_deploy_smoke.sh` → ok
- [x] `bash scripts/preflight.sh` → PASS
- [x] 真实 200 路径已经在本地复测（同把 GEMINI key 跑 prod，6 段全 200）
- [ ] 注入测试（注入 503 看 smoke 是否 warn 不 fail）—— 等下次 prod gemini-pa 又 cooldown 时自然会触发，可观察首次效果
- [ ] CI

## 后续

合并后下一次 deploy-stage0 就生效；除非 PR #121 真的回归（`gemini-3.1-pro-preview` 收到 400），否则不会再被 gemini 账号 cooldown 一类的 transient 资源问题挡住部署。

🤖 Generated with [Claude Code](https://claude.com/claude-code)