### PR TITLE
fix(ui): add missing Claude model aliases to model rate-limit badges

### DIFF
--- a/backend/internal/web/dist/frontend-source.json
+++ b/backend/internal/web/dist/frontend-source.json
@@ -1,7 +1,7 @@
 {
   "algorithm": "sha256(git-ls-files:path,size,content)",
   "file_count": 411,
-  "hash": "42813979de07fe1caddf39c310a2ad5d1ac40a3e46e2abacadcf13ecfc150a3d",
+  "hash": "8bc911d606c2c74b00b2f50805fe559669583701eab14032fcc5e31e6f6541ca",
   "schema": 1,
   "source": "frontend/"
 }

--- a/frontend/src/components/account/AccountStatusIndicator.vue
+++ b/frontend/src/components/account/AccountStatusIndicator.vue
@@ -220,11 +220,16 @@ const activeModelStatuses = computed<AccountModelStatusItem[]>(() => {
 const formatScopeName = (scope: string): string => {
   const aliases: Record<string, string> = {
     // Claude 系列
+    'claude-opus-4-7': 'COpus47',
+    'claude-opus-4-7-thinking': 'COpus47T',
     'claude-opus-4-6': 'COpus46',
     'claude-opus-4-6-thinking': 'COpus46T',
     'claude-sonnet-4-6': 'CSon46',
+    'claude-sonnet-4-6-thinking': 'CSon46T',
     'claude-sonnet-4-5': 'CSon45',
     'claude-sonnet-4-5-thinking': 'CSon45T',
+    'claude-haiku-4-5-20251001': 'CHaiku45',
+    'claude-haiku-4-6': 'CHaiku46',
     // Gemini 2.5 系列
     'gemini-2.5-flash': 'G25F',
     'gemini-2.5-flash-lite': 'G25FL',


### PR DESCRIPTION
## Summary

- Add missing Claude model aliases to `formatScopeName` in `AccountStatusIndicator.vue`
- Covers `claude-haiku-4-5-20251001` (CHaiku45), `claude-haiku-4-6` (CHaiku46), `claude-opus-4-7` (COpus47), `claude-opus-4-7-thinking` (COpus47T), `claude-sonnet-4-6-thinking` (CSon46T)

**Background**: During a 503 incident (`no available accounts` for claude-haiku-4-5-20251001), the per-model rate-limit badge in the account management page showed a 24-char raw string instead of a readable tag. The badge logic was already correct; only the alias was missing.

## Risk

None — pure display alias addition, zero runtime logic change.

## Validation

- `pnpm build` passed; dist manifest hash updated
- Preflight PASS
- `CHaiku45` confirmed present in compiled `AccountsView*.js` bundle