### PR TITLE
fix(admin-ui): fluid account table without horizontal scroll

### DIFF
--- a/backend/internal/web/dist/frontend-source.json
+++ b/backend/internal/web/dist/frontend-source.json
@@ -1,7 +1,7 @@
 {
   "algorithm": "sha256(git-ls-files:path,size,content)",
   "file_count": 411,
-  "hash": "8bc911d606c2c74b00b2f50805fe559669583701eab14032fcc5e31e6f6541ca",
+  "hash": "f2f850d213efafee6e9cbd24b7c1debbb3199cbe084050ca2712e6c5cb8cce10",
   "schema": 1,
   "source": "frontend/"
 }

--- a/frontend/src/components/account/AccountGroupsCell.vue
+++ b/frontend/src/components/account/AccountGroupsCell.vue
@@ -1,5 +1,5 @@
 <template>
-  <div v-if="groups && groups.length > 0" class="relative max-w-56">
+    <div v-if="groups && groups.length > 0" class="relative max-w-full">
     <!-- 分组容器：固定最大宽度，最多显示2行 -->
     <div class="flex flex-wrap gap-1 max-h-14 overflow-hidden">
       <GroupBadge

--- a/frontend/src/components/common/DataTable.vue
+++ b/frontend/src/components/common/DataTable.vue
@@ -66,10 +66,14 @@
     class="table-wrapper"
     :class="{
       'actions-expanded': actionsExpanded,
-      'is-scrollable': isScrollable
+      'is-scrollable': isScrollable,
+      'table-wrapper--fluid': fluid
     }"
   >
-    <table class="w-full min-w-max divide-y divide-gray-200 dark:divide-dark-700">
+    <table
+      class="w-full divide-y divide-gray-200 dark:divide-dark-700"
+      :class="fluid ? 'min-w-0 max-w-full' : 'min-w-max'"
+    >
       <thead class="table-header bg-gray-50 dark:bg-dark-800">
         <tr>
           <th
@@ -77,7 +81,8 @@
             :key="column.key"
             scope="col"
             :class="[
-              'sticky-header-cell py-3 text-left text-xs font-medium uppercase tracking-wider text-gray-500 dark:text-dark-400',
+              'sticky-header-cell text-left text-xs font-medium uppercase tracking-wider text-gray-500 dark:text-dark-400',
+              fluid ? 'py-2 whitespace-normal break-words min-w-0 align-top' : 'py-3',
               getAdaptivePaddingClass(),
               { 'cursor-pointer hover:bg-gray-100 dark:hover:bg-dark-700': column.sortable },
               getStickyColumnClass(column, index),
@@ -121,7 +126,15 @@
       <tbody class="table-body divide-y divide-gray-200 bg-white dark:divide-dark-700 dark:bg-dark-900">
         <!-- Loading skeleton -->
         <tr v-if="loading" v-for="i in 5" :key="i">
-          <td v-for="column in columns" :key="column.key" :class="['whitespace-nowrap py-4', getAdaptivePaddingClass()]">
+          <td
+            v-for="column in columns"
+            :key="column.key"
+            :class="[
+              fluid ? 'whitespace-normal break-words min-w-0 align-top' : 'whitespace-nowrap',
+              fluid ? 'py-2' : 'py-4',
+              getAdaptivePaddingClass()
+            ]"
+          >
             <div class="animate-pulse">
               <div class="h-4 w-3/4 rounded bg-gray-200 dark:bg-dark-700"></div>
             </div>
@@ -168,7 +181,8 @@
               v-for="(column, colIndex) in columns"
               :key="column.key"
               :class="[
-                'whitespace-nowrap py-4 text-sm text-gray-900 dark:text-gray-100',
+                'text-sm text-gray-900 dark:text-gray-100',
+                fluid ? 'whitespace-normal break-words min-w-0 align-top py-2' : 'whitespace-nowrap py-4',
                 getAdaptivePaddingClass(),
                 getStickyColumnClass(column, colIndex),
                 column.class
@@ -361,6 +375,10 @@ interface Props {
   estimateRowHeight?: number
   /** Number of rows to render beyond the visible area (default 5) */
   overscan?: number
+  /**
+   * Fit table to viewport width: wrap cell text and avoid horizontal scroll (account admin).
+   */
+  fluid?: boolean
 }
 
 const props = withDefaults(defineProps<Props>(), {
@@ -369,7 +387,8 @@ const props = withDefaults(defineProps<Props>(), {
   stickyActionsColumn: true,
   expandableActions: true,
   defaultSortOrder: 'asc',
-  serverSideSort: false
+  serverSideSort: false,
+  fluid: false
 })
 
 const sortKey = ref<string>('')

--- a/frontend/src/components/layout/TablePageLayout.vue
+++ b/frontend/src/components/layout/TablePageLayout.vue
@@ -1,5 +1,5 @@
 <template>
-  <div class="table-page-layout" :class="{ 'mobile-mode': isMobile }">
+  <div class="table-page-layout" :class="{ 'mobile-mode': isMobile, 'table-page-layout--fluid': fluid }">
     <!-- 固定区域：操作按钮 -->
     <div v-if="$slots.actions" class="layout-section-fixed">
       <slot name="actions" />
@@ -12,7 +12,7 @@
 
     <!-- 滚动区域：表格 -->
     <div class="layout-section-scrollable">
-      <div class="card table-scroll-container">
+      <div class="card table-scroll-container" :class="{ 'table-scroll-container--fluid': fluid }">
         <slot name="table" />
       </div>
     </div>
@@ -26,6 +26,14 @@
 
 <script setup lang="ts">
 import { ref, onMounted, onUnmounted } from 'vue'
+
+withDefaults(
+  defineProps<{
+    /** Table fills viewport width; hide horizontal scrollbar (with DataTable fluid). */
+    fluid?: boolean
+  }>(),
+  { fluid: false }
+)
 
 const isMobile = ref(false)
 
@@ -89,6 +97,20 @@ onUnmounted(() => {
 
 .table-scroll-container :deep(td) {
   @apply px-5 py-4 text-sm text-gray-700 dark:text-gray-300 border-b border-gray-100 dark:border-dark-800;
+}
+
+.table-scroll-container--fluid :deep(.table-wrapper) {
+  @apply overflow-x-hidden overflow-y-auto;
+}
+
+.table-scroll-container--fluid :deep(table) {
+  width: 100%;
+  max-width: 100%;
+  min-width: 0;
+}
+
+.table-page-layout--fluid:not(.mobile-mode) {
+  @apply gap-4;
 }
 
 /* 移动端：恢复正常滚动 */

--- a/frontend/src/views/admin/AccountsView.vue
+++ b/frontend/src/views/admin/AccountsView.vue
@@ -1,6 +1,6 @@
 <template>
   <AppLayout>
-    <TablePageLayout>
+    <TablePageLayout fluid>
       <template #filters>
         <div class="flex flex-wrap-reverse items-start justify-between gap-3">
           <AccountTableFilters
@@ -155,6 +155,7 @@
         <div ref="accountTableRef" class="flex min-h-0 flex-1 flex-col overflow-hidden">
         <DataTable
           ref="dataTableRef"
+          fluid
           :columns="cols"
           :data="accounts"
           :loading="loading"
@@ -164,7 +165,7 @@
           default-sort-key="name"
           default-sort-order="asc"
           :sort-storage-key="ACCOUNT_SORT_STORAGE_KEY"
-          :estimate-row-height="72"
+          :estimate-row-height="76"
           :overscan="5"
         >
           <template #header-select>
@@ -196,16 +197,9 @@
             <span v-else class="text-sm text-gray-400 dark:text-dark-500">-</span>
           </template>
           <template #cell-platform_type="{ row }">
-            <div class="flex flex-wrap items-center gap-1">
+            <div class="flex max-w-full flex-wrap items-center gap-1">
               <PlatformTypeBadge :platform="row.platform" :type="row.type" :plan-type="row.credentials?.plan_type" :privacy-mode="row.extra?.privacy_mode" :subscription-expires-at="row.credentials?.subscription_expires_at" />
               <ChannelTypeBadge :platform="row.platform" :channel-type="row.channel_type" />
-              <span
-                v-if="getOpenAICompactLabel(row)"
-                :class="['inline-block rounded px-1.5 py-0.5 text-[10px] font-medium', getOpenAICompactClass(row)]"
-                :title="getOpenAICompactTitle(row)"
-              >
-                {{ getOpenAICompactLabel(row) }}
-              </span>
               <span
                 v-if="getOpenAICompactLabel(row)"
                 :class="['inline-block rounded px-1.5 py-0.5 text-[10px] font-medium', getOpenAICompactClass(row)]"
@@ -1042,12 +1036,12 @@ function getAntigravityTierClass(row: any): string {
 // All available columns
 const allColumns = computed(() => {
   const c = [
-    { key: 'select', label: '', sortable: false },
+    { key: 'select', label: '', sortable: false, class: 'whitespace-nowrap' },
     { key: 'name', label: t('admin.accounts.columns.name'), sortable: true },
     { key: 'platform_type', label: t('admin.accounts.columns.platformType'), sortable: false },
     { key: 'capacity', label: t('admin.accounts.columns.capacity'), sortable: false },
     { key: 'status', label: t('admin.accounts.columns.status'), sortable: true },
-    { key: 'schedulable', label: t('admin.accounts.columns.schedulable'), sortable: true },
+    { key: 'schedulable', label: t('admin.accounts.columns.schedulable'), sortable: true, class: 'whitespace-nowrap' },
     { key: 'today_stats', label: t('admin.accounts.columns.todayStats'), sortable: false }
   ]
   if (!authStore.isSimpleMode) {
@@ -1061,7 +1055,7 @@ const allColumns = computed(() => {
     { key: 'last_used_at', label: t('admin.accounts.columns.lastUsed'), sortable: true },
     { key: 'expires_at', label: t('admin.accounts.columns.expiresAt'), sortable: true },
     { key: 'notes', label: t('admin.accounts.columns.notes'), sortable: false },
-    { key: 'actions', label: t('admin.accounts.columns.actions'), sortable: false }
+    { key: 'actions', label: t('admin.accounts.columns.actions'), sortable: false, class: 'whitespace-nowrap' },
   )
   return c
 })


### PR DESCRIPTION
## Summary
- Account admin table uses a new **`fluid`** mode on `DataTable` + `TablePageLayout`: cells wrap, table uses full width, horizontal scrollbar is hidden so dense badge rows fit typical viewports.
- Narrow columns (checkbox, schedulable, actions) stay **`whitespace-nowrap`** via column `class`.
- **`AccountGroupsCell`**: `max-w-full` so grouping chips respect fluid column width.
- Embedded **`backend/internal/web/dist`** rebuilt (`pnpm --dir frontend run build`) for preflight/release contract.

## Risk
Low — scoped to account admin + shared optional props; default table behaviour unchanged for other pages.

## Validation
- `./scripts/preflight.sh`
- `pnpm --dir frontend run lint:check && pnpm run typecheck`
- `pnpm exec vitest run src/views/admin/__tests__/AccountsView.bulkEdit.spec.ts`

Made with [Cursor](https://cursor.com)