### PR TITLE
fix(gemini): per-model rate limit for Code Assist 429 + UI aliases for preview models

### DIFF
--- a/backend/internal/service/gemini_messages_compat_service.go
+++ b/backend/internal/service/gemini_messages_compat_service.go
@@ -2826,6 +2826,13 @@ func (s *GeminiMessagesCompatService) handleGeminiUpstreamError(ctx context.Cont
 	projectID := strings.TrimSpace(account.GetCredential("project_id"))
 	isCodeAssist := account.IsGeminiCodeAssist()
 
+	// TK: per-model rate limit for Code Assist 429s carrying ErrorInfo.metadata.model
+	// (e.g. MODEL_CAPACITY_EXHAUSTED on a single model). See
+	// gemini_messages_compat_service_tk_model_rate_limit.go for rationale.
+	if s.tryGeminiCodeAssistApplyModelRateLimit(ctx, account, body) {
+		return
+	}
+
 	resetAt := ParseGeminiRateLimitResetTime(body)
 	if resetAt == nil {
 		// 根据账号类型使用不同的默认重置时间

--- a/backend/internal/service/gemini_messages_compat_service_tk_model_rate_limit.go
+++ b/backend/internal/service/gemini_messages_compat_service_tk_model_rate_limit.go
@@ -1,0 +1,135 @@
+package service
+
+import (
+	"context"
+	"encoding/json"
+	"strings"
+	"time"
+
+	"github.com/Wei-Shaw/sub2api/internal/pkg/logger"
+)
+
+// TK companion to upstream handleGeminiUpstreamError in gemini_messages_compat_service.go.
+//
+// 为什么独立成文件：
+// upstream handleGeminiUpstreamError 对所有 429 一律走账号级限流（SetRateLimited）。
+// 这对 API Key / AI Studio OAuth 是合理的（整个账号一起被限），但对 Code Assist
+// OAuth 不准确：cloudcode-pa.googleapis.com 会针对**单个模型**返回
+// MODEL_CAPACITY_EXHAUSTED（model 名出现在 ErrorInfo.metadata.model），同一账号
+// 的其他模型仍然可用。把这种 per-model 限流写成账号级限流会：
+//  1. 让整个账号在 Code Assist tier cooldown（约 11h）期间被打成「不可调度」，
+//     其他模型完全不能用；
+//  2. 前端 AccountStatusIndicator.vue 走账号级 isRateLimited 分支，只显示「限流中
+//     10h 59m 自动恢复 429」，operator 看不到具体哪个模型限流。
+//
+// 与 antigravity 在 antigravity_gateway_service.go::handleUpstreamError 429 分支
+// 已经做的 SetModelRateLimit 行为对齐——antigravity 走 resolveFinalAntigravityModelKey
+// 把 requestedModel 转成最终 mapping 后的 key，这里直接用上游响应里的
+// metadata.model，因为 platform=gemini 没有默认 mapping（GetMappedModel 在没有
+// 用户 model_mapping 时返回 requestedModel 本身，与上游报错的 model 一致；
+// 用户配置了 mapping 时，请求被映射后发出，上游报错里的 model 也是映射后的值，
+// 仍然与下次调度查询用的 key 一致）。
+//
+// 历史背景：
+// 2026-05-06 prod：claude-code 通过 /v1/messages → gemini-pa group → gemini-3.1-pro-preview
+// 触发 429 RESOURCE_EXHAUSTED + MODEL_CAPACITY_EXHAUSTED；同账号 gemini-2.5-flash
+// 仍然可用，但 UI 只能看到账号级「限流中 10h 59m」，无法判断具体哪个模型限流。
+//
+// 何时拆掉本文件：
+// 如果 upstream 把 per-model rate limit 内化（不太可能：upstream 没有
+// SetModelRateLimit 抽象），可以删掉本文件并将 call-site 还原。
+
+// tryGeminiCodeAssistApplyModelRateLimit attempts to set a per-model rate limit
+// when a Gemini Code Assist 429 carries a model-specific signal.
+//
+// Returns true iff:
+//   - account is platform=gemini Code Assist OAuth (cloudcode-pa upstream), and
+//   - body parses as a Google RPC error containing an ErrorInfo with a
+//     non-empty metadata.model, and
+//   - SetModelRateLimit succeeds.
+//
+// On true, the caller MUST skip its own account-level rate-limit fallback.
+// On false (including parse failure or non-Code-Assist accounts), the caller
+// continues with the existing account-level path.
+func (s *GeminiMessagesCompatService) tryGeminiCodeAssistApplyModelRateLimit(
+	ctx context.Context, account *Account, body []byte,
+) bool {
+	if account == nil || !account.IsGeminiCodeAssist() {
+		return false
+	}
+
+	modelName := extractGeminiCodeAssistRateLimitedModel(body)
+	if modelName == "" {
+		return false
+	}
+
+	// Reset time: prefer the upstream signal (quotaResetDelay / retryDelay),
+	// fall back to the Code Assist tier cooldown — same source the
+	// account-level path uses, so per-model behavior is just narrower scope,
+	// not a different policy.
+	var resetTime time.Time
+	if ts := ParseGeminiRateLimitResetTime(body); ts != nil {
+		resetTime = time.Unix(*ts, 0)
+	} else {
+		cooldown := geminiCooldownForTier(account.GeminiTierID())
+		if s.rateLimitService != nil {
+			cooldown = s.rateLimitService.GeminiCooldown(ctx, account)
+		}
+		resetTime = time.Now().Add(cooldown)
+	}
+
+	if err := s.accountRepo.SetModelRateLimit(ctx, account.ID, modelName, resetTime); err != nil {
+		logger.LegacyPrintf("service.gemini_messages_compat",
+			"[Gemini 429] tk_model_rate_limit_set_failed account=%d model=%s err=%v (falling back to account-level)",
+			account.ID, modelName, err)
+		return false
+	}
+
+	logger.LegacyPrintf("service.gemini_messages_compat",
+		"[Gemini 429] tk_model_rate_limited account=%d (Code Assist) model=%s reset_in=%v",
+		account.ID, modelName, time.Until(resetTime).Truncate(time.Second))
+	return true
+}
+
+// extractGeminiCodeAssistRateLimitedModel returns the rate-limited model name
+// found in a Google RPC error body's ErrorInfo.metadata.model, or "" if no
+// per-model signal is present.
+//
+// We accept any reason (MODEL_CAPACITY_EXHAUSTED, RATE_LIMIT_EXCEEDED with
+// model metadata, etc.) — the discriminator between per-model and account-wide
+// is the **presence** of metadata.model. Account-wide quota errors (daily
+// quota, account suspended, …) do not carry a model name.
+func extractGeminiCodeAssistRateLimitedModel(body []byte) string {
+	var parsed map[string]any
+	if err := json.Unmarshal(body, &parsed); err != nil {
+		return ""
+	}
+	errObj, ok := parsed["error"].(map[string]any)
+	if !ok {
+		return ""
+	}
+	details, ok := errObj["details"].([]any)
+	if !ok {
+		return ""
+	}
+	for _, d := range details {
+		dm, ok := d.(map[string]any)
+		if !ok {
+			continue
+		}
+		atType, _ := dm["@type"].(string)
+		if atType != googleRPCTypeErrorInfo {
+			continue
+		}
+		meta, ok := dm["metadata"].(map[string]any)
+		if !ok {
+			continue
+		}
+		model, _ := meta["model"].(string)
+		model = strings.TrimSpace(model)
+		if model != "" {
+			return model
+		}
+	}
+	return ""
+}

--- a/backend/internal/service/gemini_messages_compat_service_tk_model_rate_limit_test.go
+++ b/backend/internal/service/gemini_messages_compat_service_tk_model_rate_limit_test.go
@@ -1,0 +1,260 @@
+//go:build unit
+
+package service
+
+import (
+	"context"
+	"net/http"
+	"sync"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/require"
+)
+
+// stubGeminiTKAccountRepo embeds AccountRepository so we can override only the
+// limit-setting methods this TK feature exercises; everything else returns the
+// embed's nil-pointer panic if accidentally invoked, which catches regressions
+// where the wrong path is taken.
+type stubGeminiTKAccountRepo struct {
+	AccountRepository
+	mu                  sync.Mutex
+	rateCalls           []rateLimitCall
+	modelRateLimitCalls []modelRateLimitCall
+}
+
+func (s *stubGeminiTKAccountRepo) SetRateLimited(ctx context.Context, id int64, resetAt time.Time) error {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	s.rateCalls = append(s.rateCalls, rateLimitCall{accountID: id, resetAt: resetAt})
+	return nil
+}
+
+func (s *stubGeminiTKAccountRepo) SetModelRateLimit(ctx context.Context, id int64, modelKey string, resetAt time.Time) error {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	s.modelRateLimitCalls = append(s.modelRateLimitCalls, modelRateLimitCall{accountID: id, modelKey: modelKey, resetAt: resetAt})
+	return nil
+}
+
+func newGeminiCodeAssistAccount(id int64) *Account {
+	// project_id present + Type=oauth → IsGeminiCodeAssist() == true
+	return &Account{
+		ID:       id,
+		Platform: PlatformGemini,
+		Type:     AccountTypeOAuth,
+		Credentials: map[string]any{
+			"project_id": "tk-test-project",
+		},
+	}
+}
+
+// TestExtractGeminiCodeAssistRateLimitedModel_ModelCapacityExhausted reproduces
+// the 2026-05-06 prod payload: 429 RESOURCE_EXHAUSTED + MODEL_CAPACITY_EXHAUSTED
+// with model in ErrorInfo.metadata.
+func TestExtractGeminiCodeAssistRateLimitedModel_ModelCapacityExhausted(t *testing.T) {
+	body := []byte(`{
+		"error": {
+			"code": 429,
+			"message": "No capacity available for model gemini-3.1-pro-preview on the server",
+			"status": "RESOURCE_EXHAUSTED",
+			"details": [
+				{
+					"@type": "type.googleapis.com/google.rpc.ErrorInfo",
+					"reason": "MODEL_CAPACITY_EXHAUSTED",
+					"domain": "cloudcode-pa.googleapis.com",
+					"metadata": {"model": "gemini-3.1-pro-preview"}
+				}
+			]
+		}
+	}`)
+
+	require.Equal(t, "gemini-3.1-pro-preview", extractGeminiCodeAssistRateLimitedModel(body))
+}
+
+// TestExtractGeminiCodeAssistRateLimitedModel_NoModelMetadata covers the
+// account-wide quota error (e.g. daily quota exhausted) where no per-model
+// signal is present. We must return "" so the caller falls back to
+// account-level rate limiting.
+func TestExtractGeminiCodeAssistRateLimitedModel_NoModelMetadata(t *testing.T) {
+	body := []byte(`{
+		"error": {
+			"code": 429,
+			"message": "Quota exceeded",
+			"status": "RESOURCE_EXHAUSTED",
+			"details": [
+				{
+					"@type": "type.googleapis.com/google.rpc.QuotaFailure",
+					"violations": [{"subject": "project:tk-test", "description": "daily quota"}]
+				}
+			]
+		}
+	}`)
+
+	require.Equal(t, "", extractGeminiCodeAssistRateLimitedModel(body))
+}
+
+func TestExtractGeminiCodeAssistRateLimitedModel_MalformedBody(t *testing.T) {
+	require.Equal(t, "", extractGeminiCodeAssistRateLimitedModel(nil))
+	require.Equal(t, "", extractGeminiCodeAssistRateLimitedModel([]byte(`not-json`)))
+	require.Equal(t, "", extractGeminiCodeAssistRateLimitedModel([]byte(`{}`)))
+	require.Equal(t, "", extractGeminiCodeAssistRateLimitedModel([]byte(`{"error":{}}`)))
+}
+
+// TestTryGeminiCodeAssistApplyModelRateLimit_RecordsPerModel covers the prod
+// behavior we want: a Code Assist 429 with model metadata writes ONLY a
+// per-model rate limit, never an account-level one. Other models on the same
+// account stay schedulable.
+func TestTryGeminiCodeAssistApplyModelRateLimit_RecordsPerModel(t *testing.T) {
+	repo := &stubGeminiTKAccountRepo{}
+	svc := &GeminiMessagesCompatService{accountRepo: repo}
+	account := newGeminiCodeAssistAccount(42)
+
+	body := []byte(`{
+		"error": {
+			"code": 429,
+			"status": "RESOURCE_EXHAUSTED",
+			"details": [
+				{
+					"@type": "type.googleapis.com/google.rpc.ErrorInfo",
+					"reason": "MODEL_CAPACITY_EXHAUSTED",
+					"metadata": {"model": "gemini-3.1-pro-preview"}
+				}
+			]
+		}
+	}`)
+
+	require.True(t, svc.tryGeminiCodeAssistApplyModelRateLimit(context.Background(), account, body))
+	require.Empty(t, repo.rateCalls, "must not set account-level rate limit when model is identified")
+	require.Len(t, repo.modelRateLimitCalls, 1)
+	require.Equal(t, int64(42), repo.modelRateLimitCalls[0].accountID)
+	require.Equal(t, "gemini-3.1-pro-preview", repo.modelRateLimitCalls[0].modelKey)
+}
+
+// TestTryGeminiCodeAssistApplyModelRateLimit_SkipsForNonCodeAssist ensures we
+// do not change behavior for AI Studio OAuth or API Key accounts — those still
+// take the upstream account-level path.
+func TestTryGeminiCodeAssistApplyModelRateLimit_SkipsForNonCodeAssist(t *testing.T) {
+	repo := &stubGeminiTKAccountRepo{}
+	svc := &GeminiMessagesCompatService{accountRepo: repo}
+
+	// AI Studio OAuth: no project_id, no oauth_type=code_assist
+	aiStudio := &Account{
+		ID:          7,
+		Platform:    PlatformGemini,
+		Type:        AccountTypeOAuth,
+		Credentials: map[string]any{"oauth_type": "ai_studio"},
+	}
+	body := []byte(`{"error":{"status":"RESOURCE_EXHAUSTED","details":[{"@type":"type.googleapis.com/google.rpc.ErrorInfo","reason":"MODEL_CAPACITY_EXHAUSTED","metadata":{"model":"gemini-3.1-pro-preview"}}]}}`)
+
+	require.False(t, svc.tryGeminiCodeAssistApplyModelRateLimit(context.Background(), aiStudio, body))
+	require.Empty(t, repo.modelRateLimitCalls, "AI Studio OAuth must not get per-model rate limit via this path")
+	require.Empty(t, repo.rateCalls, "this helper never writes account-level — caller's fallback handles that")
+
+	// API Key
+	apiKey := &Account{
+		ID:       8,
+		Platform: PlatformGemini,
+		Type:     AccountTypeAPIKey,
+	}
+	require.False(t, svc.tryGeminiCodeAssistApplyModelRateLimit(context.Background(), apiKey, body))
+	require.Empty(t, repo.modelRateLimitCalls)
+}
+
+// TestTryGeminiCodeAssistApplyModelRateLimit_FallsBackWhenNoModel covers the
+// account-wide quota path: no model metadata → return false → caller does
+// account-level fallback. This guarantees we don't silently swallow daily-quota
+// 429s at model granularity.
+func TestTryGeminiCodeAssistApplyModelRateLimit_FallsBackWhenNoModel(t *testing.T) {
+	repo := &stubGeminiTKAccountRepo{}
+	svc := &GeminiMessagesCompatService{accountRepo: repo}
+	account := newGeminiCodeAssistAccount(11)
+
+	body := []byte(`{
+		"error": {
+			"code": 429,
+			"status": "RESOURCE_EXHAUSTED",
+			"message": "Daily quota exceeded for project tk-test"
+		}
+	}`)
+
+	require.False(t, svc.tryGeminiCodeAssistApplyModelRateLimit(context.Background(), account, body))
+	require.Empty(t, repo.modelRateLimitCalls)
+}
+
+// TestTryGeminiCodeAssistApplyModelRateLimit_RespectsParsedRetryDelay verifies
+// that when the upstream provides quotaResetDelay / retryDelay, we honor it
+// rather than always applying the tier cooldown — same precedence the
+// account-level path uses.
+func TestTryGeminiCodeAssistApplyModelRateLimit_RespectsParsedRetryDelay(t *testing.T) {
+	repo := &stubGeminiTKAccountRepo{}
+	svc := &GeminiMessagesCompatService{accountRepo: repo}
+	account := newGeminiCodeAssistAccount(99)
+
+	body := []byte(`{
+		"error": {
+			"status": "RESOURCE_EXHAUSTED",
+			"details": [
+				{
+					"@type": "type.googleapis.com/google.rpc.ErrorInfo",
+					"reason": "MODEL_CAPACITY_EXHAUSTED",
+					"metadata": {"model": "gemini-3.1-pro-preview", "quotaResetDelay": "30s"}
+				}
+			]
+		}
+	}`)
+
+	before := time.Now()
+	require.True(t, svc.tryGeminiCodeAssistApplyModelRateLimit(context.Background(), account, body))
+	require.Len(t, repo.modelRateLimitCalls, 1)
+	resetAt := repo.modelRateLimitCalls[0].resetAt
+	// 30s ± clock drift (allow up to 5s slack).
+	require.WithinDuration(t, before.Add(30*time.Second), resetAt, 5*time.Second,
+		"upstream-provided quotaResetDelay must drive resetAt, not the tier cooldown")
+}
+
+// TestHandleGeminiUpstreamError_CodeAssist429RoutesToPerModel is the end-to-end
+// check on the upstream call site we modified: a Code Assist 429 with model
+// metadata must write per-model and skip the account-level write.
+func TestHandleGeminiUpstreamError_CodeAssist429RoutesToPerModel(t *testing.T) {
+	repo := &stubGeminiTKAccountRepo{}
+	svc := &GeminiMessagesCompatService{accountRepo: repo}
+	account := newGeminiCodeAssistAccount(123)
+
+	body := []byte(`{
+		"error": {
+			"code": 429,
+			"status": "RESOURCE_EXHAUSTED",
+			"details": [
+				{
+					"@type": "type.googleapis.com/google.rpc.ErrorInfo",
+					"reason": "MODEL_CAPACITY_EXHAUSTED",
+					"domain": "cloudcode-pa.googleapis.com",
+					"metadata": {"model": "gemini-3.1-pro-preview"}
+				}
+			]
+		}
+	}`)
+
+	svc.handleGeminiUpstreamError(context.Background(), account, http.StatusTooManyRequests, http.Header{}, body)
+
+	require.Empty(t, repo.rateCalls, "Code Assist 429 with model metadata must NOT set account-level rate limit")
+	require.Len(t, repo.modelRateLimitCalls, 1)
+	require.Equal(t, "gemini-3.1-pro-preview", repo.modelRateLimitCalls[0].modelKey)
+}
+
+// TestHandleGeminiUpstreamError_CodeAssist429AccountWideStillFalls asserts the
+// other half: when the body has no model metadata, we still fall back to the
+// account-level rate limit (existing behavior unchanged).
+func TestHandleGeminiUpstreamError_CodeAssist429AccountWideStillFalls(t *testing.T) {
+	repo := &stubGeminiTKAccountRepo{}
+	svc := &GeminiMessagesCompatService{accountRepo: repo}
+	account := newGeminiCodeAssistAccount(124)
+
+	body := []byte(`{"error":{"code":429,"status":"RESOURCE_EXHAUSTED","message":"Quota exceeded"}}`)
+
+	svc.handleGeminiUpstreamError(context.Background(), account, http.StatusTooManyRequests, http.Header{}, body)
+
+	require.Empty(t, repo.modelRateLimitCalls, "no per-model signal → no per-model write")
+	require.Len(t, repo.rateCalls, 1, "account-level fallback must still fire")
+}

--- a/backend/internal/web/dist/frontend-source.json
+++ b/backend/internal/web/dist/frontend-source.json
@@ -1,7 +1,7 @@
 {
   "algorithm": "sha256(git-ls-files:path,size,content)",
   "file_count": 413,
-  "hash": "cb0621829485bfa7a44cadcc4339b19b4b70f296c707a879571ceb73d5612690",
+  "hash": "75245356d748292a2d36146feadf24261c1f04b373e476065e01f820d361bb56",
   "schema": 1,
   "source": "frontend/"
 }

--- a/frontend/src/components/account/AccountStatusIndicator.vue
+++ b/frontend/src/components/account/AccountStatusIndicator.vue
@@ -236,12 +236,18 @@ const formatScopeName = (scope: string): string => {
     'gemini-2.5-flash-thinking': 'G25FT',
     'gemini-2.5-pro': 'G25P',
     'gemini-2.5-flash-image': 'G25I',
+    'gemini-2.5-flash-image-preview': 'G25IP',
     // Gemini 3 系列
     'gemini-3-flash': 'G3F',
+    'gemini-3-flash-preview': 'G3FP',
+    'gemini-3-pro-preview': 'G3PP',
     'gemini-3.1-pro-high': 'G3PH',
     'gemini-3.1-pro-low': 'G3PL',
+    'gemini-3.1-pro-preview': 'G31PP',
     'gemini-3-pro-image': 'G3PI',
+    'gemini-3-pro-image-preview': 'G3PIP',
     'gemini-3.1-flash-image': 'G31FI',
+    'gemini-3.1-flash-image-preview': 'G31FIP',
     // 其他
     'gpt-oss-120b-medium': 'GPT120',
     'tab_flash_lite_preview': 'TabFL',


### PR DESCRIPTION
## Summary

- Gemini Code Assist (`cloudcode-pa.googleapis.com`) returns `429 RESOURCE_EXHAUSTED + MODEL_CAPACITY_EXHAUSTED` with the offending model in `ErrorInfo.metadata.model` (e.g. `gemini-3.1-pro-preview`) when a **single model's capacity** is exhausted; other models on the same account stay usable.
- Upstream `handleGeminiUpstreamError` wrote account-level `SetRateLimited` for every 429, so a single-model 429 marked the whole account `限流中 10h 59m` (tier cooldown) — operators couldn't tell which model was at fault, and other models were blocked from scheduling.
- TK companion `gemini_messages_compat_service_tk_model_rate_limit.go` parses `metadata.model` and routes to `SetModelRateLimit`, mirroring the antigravity model-level path. One 7-line hook in the upstream file early-returns when the helper handled the case; account-wide errors (no `metadata.model`) keep the original account-level fallback.
- Frontend `AccountStatusIndicator.vue` adds aliases for the preview-suffixed Gemini models that now appear as per-model badge keys: `G31PP`, `G3PP`, `G3FP`, `G31FIP`, `G3PIP`, `G25IP` — same shape as #129.

## Risk

- **Behavior change scope**: only `Account.IsGeminiCodeAssist() == true` (platform=gemini, oauth, project_id present). AI Studio OAuth, API Key, and other platforms are unaffected — guarded by an explicit predicate at the top of the helper.
- **Account-wide quota errors** (daily quota, project suspended, etc.) still mark the account-level rate limit because their bodies do not carry `metadata.model` — verified by `TestHandleGeminiUpstreamError_CodeAssist429AccountWideStillFalls`.
- **Reset time policy is identical** to the existing account-level path (parsed `quotaResetDelay`/`retryDelay` first, Code Assist tier cooldown fallback) — only the **scope** of who gets it changes.
- **Upstream merge surface**: 7-line companion-call injection in the upstream file, no upstream symbols deleted (rule §5.x).

## Validation

- [x] `go test -tags=unit -run 'TestExtractGeminiCodeAssistRateLimitedModel|TestTryGeminiCodeAssistApplyModelRateLimit|TestHandleGeminiUpstreamError_CodeAssist429' ./internal/service/` — 9 new tests pass
- [x] `go test -tags=unit ./internal/service/` — full unit suite passes (~94s)
- [x] `pnpm lint:check` / `pnpm typecheck` / `pnpm test --run AccountStatusIndicator` — clean
- [x] `pnpm build` — frontend dist hash refreshed; bundle contains `G31PP` and `gemini-3.1-pro-preview`
- [x] `bash scripts/preflight.sh` — PASS (also runs in commit-msg / pre-commit hooks)

## Test plan

- [ ] After merge + deploy: trigger a Code Assist 429 with `MODEL_CAPACITY_EXHAUSTED` for `gemini-3.1-pro-preview` on a `gemini-pa` group account; verify the account UI shows the per-model `G31PP` badge instead of the account-level "限流中" banner, and that `gemini-2.5-flash` continues serving from the same account.
- [ ] Trigger an account-wide quota 429 (daily quota); verify account-level `限流中` banner still fires (no behavior regression).

🤖 Generated with [Claude Code](https://claude.com/claude-code)