### PR TITLE
fix(admin-ui): per-column max-width caps to eliminate horizontal scrollbar

### DIFF
--- a/backend/internal/web/dist/frontend-source.json
+++ b/backend/internal/web/dist/frontend-source.json
@@ -1,7 +1,7 @@
 {
   "algorithm": "sha256(git-ls-files:path,size,content)",
   "file_count": 413,
-  "hash": "75245356d748292a2d36146feadf24261c1f04b373e476065e01f820d361bb56",
+  "hash": "2ad0d65ed9319575460c5bd17295cb05830e8650ebd44a8334401fafff2d4742",
   "schema": 1,
   "source": "frontend/"
 }

--- a/frontend/src/views/admin/AccountsView.vue
+++ b/frontend/src/views/admin/AccountsView.vue
@@ -1056,28 +1056,28 @@ function getAntigravityTierClass(row: any): string {
 //     scrollbar — the alternative (more aggressive nowrap) silently clips
 //     the rightmost columns under fluid mode (overflow-x: hidden).
 const nowrap = 'whitespace-nowrap align-middle'
-const wrap = 'min-w-0 align-top'
+const wrap = (maxW: string) => `min-w-0 align-top ${maxW}`
 const allColumns = computed(() => {
   const c = [
     { key: 'select', label: '', sortable: false, class: nowrap },
-    { key: 'name', label: t('admin.accounts.columns.name'), sortable: true, class: 'min-w-0 max-w-[12rem] break-words' },
-    { key: 'platform_type', label: t('admin.accounts.columns.platformType'), sortable: false, class: wrap },
-    { key: 'capacity', label: t('admin.accounts.columns.capacity'), sortable: false, class: wrap },
-    { key: 'status', label: t('admin.accounts.columns.status'), sortable: true, class: wrap },
+    { key: 'name', label: t('admin.accounts.columns.name'), sortable: true, class: 'min-w-0 max-w-[10rem] break-words align-top' },
+    { key: 'platform_type', label: t('admin.accounts.columns.platformType'), sortable: false, class: wrap('max-w-[9rem]') },
+    { key: 'capacity', label: t('admin.accounts.columns.capacity'), sortable: false, class: wrap('max-w-[9rem]') },
+    { key: 'status', label: t('admin.accounts.columns.status'), sortable: true, class: wrap('max-w-[8rem]') },
     { key: 'schedulable', label: t('admin.accounts.columns.schedulable'), sortable: true, class: nowrap },
-    { key: 'today_stats', label: t('admin.accounts.columns.todayStats'), sortable: false, class: wrap }
+    { key: 'today_stats', label: t('admin.accounts.columns.todayStats'), sortable: false, class: wrap('max-w-[9rem]') }
   ]
   if (!authStore.isSimpleMode) {
-    c.push({ key: 'groups', label: t('admin.accounts.columns.groups'), sortable: false, class: wrap })
+    c.push({ key: 'groups', label: t('admin.accounts.columns.groups'), sortable: false, class: wrap('max-w-[8rem]') })
   }
   c.push(
-    { key: 'usage', label: t('admin.accounts.columns.usageWindows'), sortable: false, class: wrap },
-    { key: 'proxy', label: t('admin.accounts.columns.proxy'), sortable: false, class: wrap },
-    { key: 'priority', label: t('admin.accounts.columns.priority'), sortable: true, class: wrap },
-    { key: 'rate_multiplier', label: t('admin.accounts.columns.billingRateMultiplier'), sortable: true, class: wrap },
-    { key: 'last_used_at', label: t('admin.accounts.columns.lastUsed'), sortable: true, class: wrap },
-    { key: 'expires_at', label: t('admin.accounts.columns.expiresAt'), sortable: true, class: wrap },
-    { key: 'notes', label: t('admin.accounts.columns.notes'), sortable: false, class: wrap },
+    { key: 'usage', label: t('admin.accounts.columns.usageWindows'), sortable: false, class: wrap('max-w-[15rem]') },
+    { key: 'proxy', label: t('admin.accounts.columns.proxy'), sortable: false, class: wrap('max-w-[7rem]') },
+    { key: 'priority', label: t('admin.accounts.columns.priority'), sortable: true, class: nowrap },
+    { key: 'rate_multiplier', label: t('admin.accounts.columns.billingRateMultiplier'), sortable: true, class: nowrap },
+    { key: 'last_used_at', label: t('admin.accounts.columns.lastUsed'), sortable: true, class: wrap('max-w-[5rem]') },
+    { key: 'expires_at', label: t('admin.accounts.columns.expiresAt'), sortable: true, class: wrap('max-w-[5rem]') },
+    { key: 'notes', label: t('admin.accounts.columns.notes'), sortable: false, class: wrap('max-w-[8rem]') },
     { key: 'actions', label: t('admin.accounts.columns.actions'), sortable: false, class: nowrap }
   )
   return c

--- a/scripts/frontend-tk-sentinels.json
+++ b/scripts/frontend-tk-sentinels.json
@@ -48,9 +48,11 @@
       "must_contain": [
         "<TablePageLayout fluid>",
         ":sticky-edge-hints=\"false\"",
-        "Wrap-first column policy"
+        "Wrap-first column policy",
+        "const wrap = (maxW: string) =>",
+        "wrap('max-w-[15rem]')"
       ],
-      "rationale": "The TK callsite for fluid+stickyEdgeHints opt-outs (first two literals) and the wrap-first column-class policy (third literal — anchors the comment that documents which columns may carry `whitespace-nowrap` and which must let `table-auto` compress them). Without the wrap policy the fluid table re-overflows under 100% browser zoom even with the auto-fallback CSS in place, since too many nowrap columns prevent the table from compressing in the first place."
+      "rationale": "The TK callsite for fluid+stickyEdgeHints opt-outs (first two literals), the wrap-first column-class policy comment (third literal), and the per-column max-width discipline (fourth + fifth literals). `wrap` as a function (not a plain string constant) means every column carries an explicit cap — an upstream merge that flattens it back to a bare string would silently drop the caps and the table overflows again at 100% browser zoom. The fifth literal anchors the usage column at 15rem (the widest cap), chosen because it is uniquely wide and unlikely to clash with any upstream string. Without the max-width caps, `min-w-0 align-top` alone is insufficient: browser table-auto still sizes columns to their natural max-content width when there is no explicit upper bound."
     }
   ]
 }


### PR DESCRIPTION
## Summary

- Refactors `wrap` constant into `wrap(maxW)` helper so each column carries its own `max-w-[Xrem]` cap
- Caps: usage 15rem, name 10rem, platform_type/capacity/today_stats 9rem, status/groups/notes 8rem, expires_at/last_used_at 5rem, proxy 7rem; priority/rate_multiplier/select/schedulable/actions keep `nowrap`
- Pairs with fluid-mode `overflow-x: auto` fallback from #133

## Risk

Frontend-only, no backend changes. Column widths are visual tuning — worst case a column wraps sooner than expected, easily re-tuned.

## Validation

- `pnpm typecheck` ✓
- `preflight.sh` ✓
- Verified locally via `tokenkey-local:dev` stack at `http://127.0.0.1:8088/admin/accounts` — no horizontal scrollbar at standard viewport