### PR TITLE
feat(openai-compat): previous_response_id continuation (OAuth + sentinel + fixes)

### DIFF
--- a/backend/internal/service/openai_compat_model_test.go
+++ b/backend/internal/service/openai_compat_model_test.go
@@ -655,7 +655,7 @@ func TestForwardAsAnthropic_APIKeyMetadataSessionSurvivesChangingCacheControlAnc
 	require.Equal(t, "message-15", gjson.GetBytes(upstream.bodies[1], "input.16.content.0.text").String())
 }
 
-func TestForwardAsAnthropic_DoesNotAttachPreviousResponseIDForOAuthCompat(t *testing.T) {
+func TestForwardAsAnthropic_AttachesPreviousResponseIDForOAuthCompat(t *testing.T) {
 	t.Parallel()
 	gin.SetMode(gin.TestMode)
 
@@ -686,7 +686,8 @@ func TestForwardAsAnthropic_DoesNotAttachPreviousResponseIDForOAuthCompat(t *tes
 	result, err := svc.ForwardAsAnthropic(context.Background(), c, account, body, "stable-cache-key", "gpt-5.4")
 	require.NoError(t, err)
 	require.NotNil(t, result)
-	require.False(t, gjson.GetBytes(upstream.lastBody, "previous_response_id").Exists())
+	// OAuth continuation is now enabled: previous_response_id should be attached.
+	require.Equal(t, "resp_oauth_prev", gjson.GetBytes(upstream.lastBody, "previous_response_id").String())
 }
 
 func TestForwardAsAnthropic_ReusesOAuthCodexTurnState(t *testing.T) {
@@ -743,7 +744,8 @@ func TestForwardAsAnthropic_ReusesOAuthCodexTurnState(t *testing.T) {
 	require.Empty(t, upstream.requests[1].Header.Get("OpenAI-Beta"))
 	require.Empty(t, upstream.requests[1].Header.Get("originator"))
 	require.False(t, gjson.GetBytes(upstream.bodies[1], "prompt_cache_key").Exists())
-	require.False(t, gjson.GetBytes(upstream.bodies[1], "previous_response_id").Exists())
+	// OAuth continuation is now enabled: previous_response_id from turn 1 is attached on turn 2.
+	require.Equal(t, "resp_oauth_first", gjson.GetBytes(upstream.bodies[1], "previous_response_id").String())
 }
 
 func TestForwardAsAnthropic_OAuthDigestFallbackReusesTurnStateWithoutExplicitKey(t *testing.T) {
@@ -799,7 +801,8 @@ func TestForwardAsAnthropic_OAuthDigestFallbackReusesTurnStateWithoutExplicitKey
 	require.Equal(t, "turn_state_digest_first", upstream.requests[1].Header.Get("x-codex-turn-state"))
 	require.Empty(t, upstream.requests[1].Header.Get("conversation_id"))
 	require.False(t, gjson.GetBytes(upstream.bodies[1], "prompt_cache_key").Exists())
-	require.False(t, gjson.GetBytes(upstream.bodies[1], "previous_response_id").Exists())
+	// OAuth continuation is now enabled: previous_response_id from turn 1 is attached via digest prefix match.
+	require.Equal(t, "resp_oauth_digest_first", gjson.GetBytes(upstream.bodies[1], "previous_response_id").String())
 }
 
 func TestForwardAsAnthropic_OAuthMetadataSessionSurvivesDigestPrefixRewrite(t *testing.T) {
@@ -856,7 +859,8 @@ func TestForwardAsAnthropic_OAuthMetadataSessionSurvivesDigestPrefixRewrite(t *t
 	require.Equal(t, "turn_state_metadata_first", upstream.requests[1].Header.Get("x-codex-turn-state"))
 	require.Empty(t, upstream.requests[1].Header.Get("conversation_id"))
 	require.False(t, gjson.GetBytes(upstream.bodies[1], "prompt_cache_key").Exists())
-	require.False(t, gjson.GetBytes(upstream.bodies[1], "previous_response_id").Exists())
+	// OAuth continuation is now enabled: previous_response_id from turn 1 is attached via stable metadata session key.
+	require.Equal(t, "resp_oauth_metadata_first", gjson.GetBytes(upstream.bodies[1], "previous_response_id").String())
 }
 
 func TestForwardAsAnthropic_OAuthMetadataSessionSurvivesChangingCacheControlAnchor(t *testing.T) {
@@ -913,7 +917,8 @@ func TestForwardAsAnthropic_OAuthMetadataSessionSurvivesChangingCacheControlAnch
 	require.Equal(t, "turn_state_cache_anchor_first", upstream.requests[1].Header.Get("x-codex-turn-state"))
 	require.Empty(t, upstream.requests[1].Header.Get("conversation_id"))
 	require.False(t, gjson.GetBytes(upstream.bodies[1], "prompt_cache_key").Exists())
-	require.False(t, gjson.GetBytes(upstream.bodies[1], "previous_response_id").Exists())
+	// OAuth continuation is now enabled: previous_response_id from turn 1 is attached via stable metadata session key.
+	require.Equal(t, "resp_oauth_cache_anchor_first", gjson.GetBytes(upstream.bodies[1], "previous_response_id").String())
 }
 
 func TestForwardAsAnthropic_OAuthKeepsSystemAsDeveloperInput(t *testing.T) {

--- a/backend/internal/service/openai_gateway_messages.go
+++ b/backend/internal/service/openai_gateway_messages.go
@@ -106,7 +106,13 @@ func (s *OpenAIGatewayService) ForwardAsAnthropic(
 	responsesReq.Model = upstreamModel
 	if previousResponseID != "" {
 		responsesReq.PreviousResponseID = previousResponseID
-		trimAnthropicCompatResponsesInputToLatestTurn(responsesReq)
+		// Only trim for APIKey accounts: OpenAI Platform keeps full history in
+		// session state so only the new turn is needed. For OAuth (ChatGPT Codex),
+		// trimming strips the role=system item and breaks system-prompt delivery
+		// to the transform — keep full replay (same rationale as line 111 above).
+		if openAICompatShouldTrimForContinuation(account) {
+			trimAnthropicCompatResponsesInputToLatestTurn(responsesReq)
+		}
 	}
 	if compatReplayGuardEnabled && account.Type != AccountTypeOAuth {
 		appendOpenAICompatClaudeCodeTodoGuard(responsesReq)
@@ -271,6 +277,11 @@ func (s *OpenAIGatewayService) ForwardAsAnthropic(
 	if account.Type == AccountTypeOAuth && promptCacheKey != "" && strings.TrimSpace(c.GetHeader("conversation_id")) == "" {
 		upstreamReq.Header.Del("conversation_id")
 	}
+	// Note: OAuth accounts with continuation enabled may send BOTH
+	// previous_response_id (body) and x-codex-turn-state (header) simultaneously.
+	// If the upstream rejects the combination, isOpenAICompatPreviousResponseUnsupported
+	// (line ~308) catches the 400 and disableOpenAICompatSessionContinuation reverts
+	// the session to turn-state-only — one failed turn, then automatic recovery.
 	if compatTurnState != "" && upstreamReq.Header.Get("x-codex-turn-state") == "" {
 		upstreamReq.Header.Set("x-codex-turn-state", compatTurnState)
 	}

--- a/backend/internal/service/openai_messages_continuation.go
+++ b/backend/internal/service/openai_messages_continuation.go
@@ -21,7 +21,15 @@ type openAICompatSessionResponseBinding struct {
 }
 
 func openAICompatContinuationEnabled(account *Account, model string) bool {
-	if account == nil || account.Type != AccountTypeAPIKey {
+	if account == nil {
+		return false
+	}
+	// OAuth (claude.ai subscription) and APIKey accounts both route through the
+	// Codex/GPT-5 Responses API endpoint and support previous_response_id
+	// continuation. If the upstream rejects it (400 / "unsupported parameter"),
+	// ForwardAsAnthropic falls back via disableOpenAICompatSessionContinuation
+	// so the degradation is safe.
+	if account.Type != AccountTypeAPIKey && account.Type != AccountTypeOAuth {
 		return false
 	}
 	return shouldAutoInjectPromptCacheKeyForCompat(model)

--- a/backend/internal/service/openai_messages_continuation.go
+++ b/backend/internal/service/openai_messages_continuation.go
@@ -21,15 +21,7 @@ type openAICompatSessionResponseBinding struct {
 }
 
 func openAICompatContinuationEnabled(account *Account, model string) bool {
-	if account == nil {
-		return false
-	}
-	// OAuth (claude.ai subscription) and APIKey accounts both route through the
-	// Codex/GPT-5 Responses API endpoint and support previous_response_id
-	// continuation. If the upstream rejects it (400 / "unsupported parameter"),
-	// ForwardAsAnthropic falls back via disableOpenAICompatSessionContinuation
-	// so the degradation is safe.
-	if account.Type != AccountTypeAPIKey && account.Type != AccountTypeOAuth {
+	if !openAICompatContinuationAllowedAccountType(account) {
 		return false
 	}
 	return shouldAutoInjectPromptCacheKeyForCompat(model)

--- a/backend/internal/service/openai_messages_continuation_test.go
+++ b/backend/internal/service/openai_messages_continuation_test.go
@@ -88,3 +88,21 @@ func TestOpenAICompatContinuationEnabled(t *testing.T) {
 		})
 	}
 }
+
+func TestOpenAICompatContinuationAllowedAccountType(t *testing.T) {
+	assert.True(t, openAICompatContinuationAllowedAccountType(&Account{Type: AccountTypeAPIKey}))
+	assert.True(t, openAICompatContinuationAllowedAccountType(&Account{Type: AccountTypeOAuth}))
+	assert.False(t, openAICompatContinuationAllowedAccountType(nil))
+	assert.False(t, openAICompatContinuationAllowedAccountType(&Account{Type: "anthropic"}))
+	assert.False(t, openAICompatContinuationAllowedAccountType(&Account{Type: "newapi"}))
+}
+
+func TestOpenAICompatShouldTrimForContinuation(t *testing.T) {
+	// Only APIKey accounts get input trimmed: OpenAI Platform retains full history.
+	assert.True(t, openAICompatShouldTrimForContinuation(&Account{Type: AccountTypeAPIKey}))
+	// OAuth must NOT trim: full replay keeps system-prompt in input[0] so the
+	// codex transform can extract it into the instructions field.
+	assert.False(t, openAICompatShouldTrimForContinuation(&Account{Type: AccountTypeOAuth}))
+	assert.False(t, openAICompatShouldTrimForContinuation(nil))
+	assert.False(t, openAICompatShouldTrimForContinuation(&Account{Type: "anthropic"}))
+}

--- a/backend/internal/service/openai_messages_continuation_test.go
+++ b/backend/internal/service/openai_messages_continuation_test.go
@@ -1,0 +1,90 @@
+//go:build unit
+
+package service
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func TestOpenAICompatContinuationEnabled(t *testing.T) {
+	cases := []struct {
+		name    string
+		account *Account
+		model   string
+		want    bool
+	}{
+		// OAuth accounts on Codex/GPT-5 models: must be enabled now.
+		{
+			name:    "oauth gpt-5 enabled",
+			account: &Account{Type: AccountTypeOAuth},
+			model:   "gpt-5",
+			want:    true,
+		},
+		{
+			name:    "oauth gpt-5.4 enabled",
+			account: &Account{Type: AccountTypeOAuth},
+			model:   "gpt-5.4",
+			want:    true,
+		},
+		{
+			name:    "oauth codex enabled",
+			account: &Account{Type: AccountTypeOAuth},
+			model:   "codex-pro-20250601",
+			want:    true,
+		},
+		// OAuth on non-Codex/non-GPT-5 models: disabled.
+		{
+			name:    "oauth gpt-4o disabled",
+			account: &Account{Type: AccountTypeOAuth},
+			model:   "gpt-4o",
+			want:    false,
+		},
+		{
+			name:    "oauth claude model disabled",
+			account: &Account{Type: AccountTypeOAuth},
+			model:   "claude-opus-4-7",
+			want:    false,
+		},
+		// APIKey accounts (regression — must still work).
+		{
+			name:    "apikey gpt-5 enabled",
+			account: &Account{Type: AccountTypeAPIKey},
+			model:   "gpt-5",
+			want:    true,
+		},
+		{
+			name:    "apikey non-codex disabled",
+			account: &Account{Type: AccountTypeAPIKey},
+			model:   "gpt-4o",
+			want:    false,
+		},
+		// Edge cases.
+		{
+			name:    "nil account disabled",
+			account: nil,
+			model:   "gpt-5",
+			want:    false,
+		},
+		{
+			name:    "anthropic account disabled",
+			account: &Account{Type: "anthropic"},
+			model:   "gpt-5",
+			want:    false,
+		},
+		{
+			name:    "newapi account disabled",
+			account: &Account{Type: "newapi"},
+			model:   "gpt-5",
+			want:    false,
+		},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			got := openAICompatContinuationEnabled(tc.account, tc.model)
+			assert.Equal(t, tc.want, got)
+		})
+	}
+}

--- a/backend/internal/service/openai_messages_continuation_tk_oauth.go
+++ b/backend/internal/service/openai_messages_continuation_tk_oauth.go
@@ -1,0 +1,36 @@
+package service
+
+// openAICompatContinuationAllowedAccountType returns true for the account types
+// that support previous_response_id continuation on the /v1/messages HTTP path.
+//
+// Why a TK companion instead of an inline check in openai_messages_continuation.go:
+// that file is upstream-shaped (lyen1688, 0584305e). Putting TK account-type
+// decisions there would be silently lost on any upstream rewrite of
+// openAICompatContinuationEnabled. The sentinel entry in
+// engine-facade-sentinels.json (openai_compat_continuation_companion) guards this
+// function's existence, making the protection visible to the upstream-merge CI gate.
+func openAICompatContinuationAllowedAccountType(account *Account) bool {
+	if account == nil {
+		return false
+	}
+	// AccountTypeAPIKey — direct OpenAI Platform Responses API; previous_response_id
+	// is the primary stateful-session mechanism.
+	// AccountTypeOAuth — ChatGPT Codex endpoint; also supports previous_response_id
+	// (falls back gracefully via disableOpenAICompatSessionContinuation on 400).
+	return account.Type == AccountTypeAPIKey || account.Type == AccountTypeOAuth
+}
+
+// openAICompatShouldTrimForContinuation returns true when the request input
+// should be trimmed to the latest user turn before attaching previous_response_id.
+//
+// Trimming is correct for AccountTypeAPIKey: the Responses API server holds the
+// full history, so only the new input is needed.
+//
+// Trimming is WRONG for AccountTypeOAuth: the ChatGPT Codex path expects full
+// replay so the upstream prompt cache can grow turn-by-turn (see
+// openai_gateway_messages.go:83 comment). Trimming strips the role=system item
+// that AnthropicToResponses placed at input[0]; the OAuth codex transform then
+// cannot extract the system prompt and produces blank instructions.
+func openAICompatShouldTrimForContinuation(account *Account) bool {
+	return account != nil && account.Type == AccountTypeAPIKey
+}

--- a/scripts/engine-facade-sentinels.json
+++ b/scripts/engine-facade-sentinels.json
@@ -60,7 +60,8 @@
       "required_literals": [
         "compatContinuationEnabled := openAICompatContinuationEnabled(account, upstreamModel)",
         "previousResponseID = s.getOpenAICompatSessionResponseID(ctx, c, account, promptCacheKey)",
-        "s.bindOpenAICompatSessionResponseID(ctx, c, account, promptCacheKey, result.ResponseID)"
+        "s.bindOpenAICompatSessionResponseID(ctx, c, account, promptCacheKey, result.ResponseID)",
+        "openAICompatShouldTrimForContinuation(account)"
       ]
     },
     {
@@ -68,8 +69,18 @@
       "source": "backend/internal/service/openai_messages_continuation.go",
       "required_literals": [
         "func openAICompatContinuationEnabled(",
+        "openAICompatContinuationAllowedAccountType(account)",
         "func (s *OpenAIGatewayService) getOpenAICompatSessionResponseID(",
         "func (s *OpenAIGatewayService) bindOpenAICompatSessionResponseID("
+      ]
+    },
+    {
+      "name": "openai_compat_continuation_tk_oauth",
+      "source": "backend/internal/service/openai_messages_continuation_tk_oauth.go",
+      "required_literals": [
+        "func openAICompatContinuationAllowedAccountType(",
+        "func openAICompatShouldTrimForContinuation(",
+        "account.Type == AccountTypeOAuth"
       ]
     }
   ]

--- a/scripts/engine-facade-sentinels.json
+++ b/scripts/engine-facade-sentinels.json
@@ -53,6 +53,24 @@
         "if capability.RequiresTaskAdaptor && !IsVideoSupportedChannelType(in.ChannelType) {",
         "return DispatchPlan{Provider: capability.Provider, Endpoint: in.Endpoint}"
       ]
+    },
+    {
+      "name": "openai_compat_continuation_injection",
+      "source": "backend/internal/service/openai_gateway_messages.go",
+      "required_literals": [
+        "compatContinuationEnabled := openAICompatContinuationEnabled(account, upstreamModel)",
+        "previousResponseID = s.getOpenAICompatSessionResponseID(ctx, c, account, promptCacheKey)",
+        "s.bindOpenAICompatSessionResponseID(ctx, c, account, promptCacheKey, result.ResponseID)"
+      ]
+    },
+    {
+      "name": "openai_compat_continuation_companion",
+      "source": "backend/internal/service/openai_messages_continuation.go",
+      "required_literals": [
+        "func openAICompatContinuationEnabled(",
+        "func (s *OpenAIGatewayService) getOpenAICompatSessionResponseID(",
+        "func (s *OpenAIGatewayService) bindOpenAICompatSessionResponseID("
+      ]
     }
   ]
 }


### PR DESCRIPTION
## Summary

Three commits enabling and properly guarding `previous_response_id` reasoning-state continuity for OAuth accounts on the `/v1/messages` → OpenAI Responses path.

| Commit | Description |
|--------|-------------|
| `bb5dc4db` | Sentinel entries protecting main's continuation injection points from upstream overwrite |
| `5b43bd40` | Enable OAuth in `openAICompatContinuationEnabled` (initial, superseded by fix) |
| `8d597b4f` | **Review fixes**: extract OAuth logic to TK companion; guard input trim for OAuth |

### What `8d597b4f` fixes (two conformance issues found in code review)

**R-001 — Upstream-shaped file body vs §5 companion pattern**

`openai_messages_continuation.go` is upstream-shaped (lyen1688, 0584305e). Putting `AccountTypeOAuth` inside the function body means any upstream rewrite silently drops OAuth support — the sentinel only guards the function *signature*, not the body. Extracted to `openai_messages_continuation_tk_oauth.go`:
- `openAICompatContinuationAllowedAccountType(account)` — account-type gate
- `openAICompatShouldTrimForContinuation(account)` — trim eligibility guard

`openai_messages_continuation.go` now delegates to the companion with a one-line hook.

**R-002 — System-prompt loss on OAuth continuation turns**

`trimAnthropicCompatResponsesInputToLatestTurn` was firing for OAuth when `previousResponseID != ""`. This strips `input[0]` (the `role=system` item), so the OAuth codex transform's `extractPromptLikeInstructionsFromInput` finds nothing and `ensureCodexOAuthInstructionsField` produces blank instructions — CC context silently lost. `openAICompatShouldTrimForContinuation` now returns `false` for OAuth; full replay is preserved (consistent with existing policy at line 111).

## Sentinel coverage (3 entries)

| Entry | Protects |
|-------|----------|
| `openai_compat_continuation_injection` | 4 call sites in `openai_gateway_messages.go` incl. new trim guard |
| `openai_compat_continuation_companion` | 4 function signatures in upstream-shaped `openai_messages_continuation.go` incl. companion delegation |
| `openai_compat_continuation_tk_oauth` (new) | Both helpers + `AccountTypeOAuth` literal in TK companion file |

## Risk

- **OAuth continuation**: if ChatGPT Codex rejects `previous_response_id`, `disableOpenAICompatSessionContinuation` degrades to turn-state-only after one failed turn.
- **Double-continuation** (both `previous_response_id` + `x-codex-turn-state`): documented at the injection site; same graceful fallback.
- No schema, no migration, no API contract change.

## Validation

- [x] `go test -tags=unit -run TestOpenAICompat` — 16 cases (allowed types, trim eligibility, continuation enabled/disabled, regression)
- [x] `python3 scripts/check-engine-facade-hooks.py` PASS
- [x] `scripts/preflight.sh` PASS
- [x] `go build ./...` clean

**Merge mode: Squash and merge** (TK-originated PR per CLAUDE.md §5.y)

🤖 Generated with [Claude Code](https://claude.com/claude-code)