### PR TITLE
chore(skill+ci): enforce mandatory smoke probes, add post-deploy summary, fix drift

### DIFF
--- a/.cursor/skills/tokenkey-prod-release-deploy/SKILL.md
+++ b/.cursor/skills/tokenkey-prod-release-deploy/SKILL.md
@@ -85,25 +85,24 @@ curl -sS -o /dev/null -w '%{http_code}\n' 'https://api.tokenkey.dev/api/v1/setti
 ```bash
 cd /path/to/sub2api
 export TOKENKEY_BASE_URL=https://api.tokenkey.dev    # 或 TK_GATEWAY_URL（脚本两个都识别）
+# 以下三个 key 必须全部导出后再运行；任一缺失均不得视为验收通过
 # POST_DEPLOY_SMOKE_API_KEY 已在 Cursor / shell 中导出即可
-# 可选回归探针（见下文）：
-#   POST_DEPLOY_SMOKE_GEMINI_API_KEY=sk-...           # Gemini tool-schema 清理回归探针
-#   POST_DEPLOY_SMOKE_OPENAI_OAUTH_API_KEY=sk-...     # OpenAI OAuth reasoning_tokens 端到端探针
+# POST_DEPLOY_SMOKE_GEMINI_API_KEY=sk-...     # 绑定 gemini 分组，验证 tool-schema 清理
+# POST_DEPLOY_SMOKE_OPENAI_OAUTH_API_KEY=sk-... # 绑定 OpenAI OAuth/codex 分组，验证 reasoning_tokens 透传
 bash scripts/tk_post_deploy_smoke.sh
 ```
 
 **主 key 解析顺序**（摘自脚本）：`POST_DEPLOY_SMOKE_API_KEY` → `ANTHROPIC_AUTH_TOKEN` → `TK_TOKEN` → `TOKENKEY_API_KEY`，任一非空即可。
 
-**可选探针（提供对应 key 时自动启用，未设则跳过）**：
+**烟测 key 一览（三个均为必填）**：
 
-| 环境变量 | 默认值 | 用途 |
-|---|---|---|
-| `POST_DEPLOY_SMOKE_GEMINI_API_KEY` | — | 绑定 gemini 分组，探针：Anthropic→Gemini tool-schema 清理（`const`/`propertyNames`/`exclusiveMinimum` 等 Draft 2020 关键词）|
-| `POST_DEPLOY_SMOKE_GEMINI_MODEL` | 见脚本注释 | Gemini 探针使用的模型 |
-| `POST_DEPLOY_SMOKE_OPENAI_OAUTH_API_KEY` | — | 绑定 OpenAI OAuth/codex 分组，探针：账号正确性 + `reasoning_tokens` 透传 |
-| `POST_DEPLOY_SMOKE_OPENAI_OAUTH_MODEL` | 见脚本注释 | OpenAI OAuth 探针使用的模型 |
-| `POST_DEPLOY_SMOKE_OPENAI_OAUTH_REQUIRE_REASONING_TOKENS` | `0` | 设 `1` 将 `reasoning_tokens=0` 警告升级为硬失败（需确认该账号确实会返回 reasoning tokens） |
-| `POST_DEPLOY_SMOKE_SKIP_FRONTEND` | `0` | 设 `1` 跳过 frontend release asset 检查（仅本地调试；CI / 正式验收不得跳过）|
+| 环境变量 | 用途 |
+|---|---|
+| `POST_DEPLOY_SMOKE_API_KEY`（或链式备选） | 主路由：public settings / models / chat / messages |
+| `POST_DEPLOY_SMOKE_GEMINI_API_KEY` | 绑定 gemini 分组，验证 Anthropic→Gemini tool-schema 清理（`const`/`propertyNames`/`exclusiveMinimum` 等 Draft 2020 关键词）|
+| `POST_DEPLOY_SMOKE_OPENAI_OAUTH_API_KEY` | 绑定 OpenAI OAuth/codex 分组，验证账号正确性 + `reasoning_tokens` 透传 |
+
+调节项（非必填）：`POST_DEPLOY_SMOKE_GEMINI_MODEL`、`POST_DEPLOY_SMOKE_OPENAI_OAUTH_MODEL`（默认见脚本注释）；`POST_DEPLOY_SMOKE_OPENAI_OAUTH_REQUIRE_REASONING_TOKENS=1` 可将 `reasoning_tokens=0` 升为硬失败；`POST_DEPLOY_SMOKE_SKIP_FRONTEND=1` 仅供本地调试，正式验收不得使用。
 
 仅在无法注入环境时再临时：`POST_DEPLOY_SMOKE_API_KEY='sk-…' bash scripts/tk_post_deploy_smoke.sh`。  
 不得打印完整 key；脚本只输出 `key_hint`。
@@ -117,10 +116,10 @@ bash scripts/tk_post_deploy_smoke.sh
 - **`/v1/models`** — HTTP 200，`object=list`，`data` 非空。
 - **`/v1/chat/completions`** — HTTP 200，`object=chat.completion`，`choices[0].message.content` 含预期 marker，`finish_reason` 合理，`usage` 存在。
 - **`/v1/messages`** — HTTP 200，`type=message`，`role=assistant`，`content[]` 有文本，`stop_reason` 合理，`usage` 存在。
-- **Gemini tool-schema 探针（可选，需 `POST_DEPLOY_SMOKE_GEMINI_API_KEY`）** — HTTP 400 = **硬失败**（schema 清理回归，必须回滚）；HTTP 401/403/404 = **硬失败**（key/路由配置错误）；HTTP 5xx/429/"no available accounts" = **软警告** exit 0（运行时资源问题，非 schema 回归）。
-- **OpenAI OAuth 探针（可选，需 `POST_DEPLOY_SMOKE_OPENAI_OAUTH_API_KEY`）** — HTTP 200 + 正确 shape + 含预期 marker + `prompt_tokens`/`completion_tokens` 非零且 `total` 自洽；`reasoning_tokens=0` 默认软警告，设 `REQUIRE=1` 升为硬失败；HTTP 4xx = **硬失败**；HTTP 5xx/429 = **软警告**。
+- **Gemini tool-schema 探针** — HTTP 400 = **硬失败**（schema 清理回归，必须回滚）；HTTP 401/403/404 = **硬失败**（key/路由配置错误）；HTTP 5xx/429/"no available accounts" = **软警告** exit 0（运行时资源问题，非 schema 回归）。**`POST_DEPLOY_SMOKE_GEMINI_API_KEY` 未设 = 阻塞，不得视为通过。**
+- **OpenAI OAuth 探针** — HTTP 200 + 正确 shape + 含预期 marker + `prompt_tokens`/`completion_tokens` 非零且 `total` 自洽；`reasoning_tokens=0` 默认软警告，设 `REQUIRE=1` 升为硬失败；HTTP 4xx = **硬失败**；HTTP 5xx/429 = **软警告**。**`POST_DEPLOY_SMOKE_OPENAI_OAUTH_API_KEY` 未设 = 阻塞，不得视为通过。**
 
-通过时仍需确认结构字段，不能只看 marker 文本。若本次发布触达 Responses 路径而以上可选探针未覆盖，可追加一次手动 `/v1/responses` 探针：HTTP 200，`object=response`，`status=completed`，`output[]`/`output_text` 含测试短句，`usage` 结构正确，无 `error`。多分组验收时，按 key 分别记录 `key_hint`、group platform、日志 `account_id/platform/model`；不得以一个 key 的通过代替全部分组。
+通过时仍需确认结构字段，不能只看 marker 文本。若本次发布触达 Responses 路径而以上探针未覆盖，可追加一次手动 `/v1/responses` 探针：HTTP 200，`object=response`，`status=completed`，`output[]`/`output_text` 含测试短句，`usage` 结构正确，无 `error`。多分组验收时，按 key 分别记录 `key_hint`、group platform、日志 `account_id/platform/model`；不得以一个 key 的通过代替全部分组。
 
 ## 完成后：本次发版变更摘要
 
@@ -160,8 +159,8 @@ git diff --diff-filter=D --name-only "${PREV_TAG}..${NEW_TAG}" -- backend/ || tr
 
 **影响面与验证重点**（根据实际变更填写，无则省略）：
 
-- **Gemini 路径触达** → 是否提供了 `POST_DEPLOY_SMOKE_GEMINI_API_KEY`；Gemini tool-schema 探针结果（HTTP 200 为通过，400 为硬失败）
-- **OpenAI-compat / Responses 路径** → OpenAI OAuth 探针结果；`reasoning_tokens` 是否透传
+- **Gemini tool-schema 探针结果** — HTTP 200 为通过，400 为硬失败（schema 清理回归）
+- **OpenAI OAuth 探针结果** — shape/marker/token totals；`reasoning_tokens` 是否透传
 - **pricing / model-list** → `/v1/models` 返回数量与可用性标记是否符合预期
 - **frontend 变更** → frontend release asset shape 探针结果
 - **新增 / 修改的 sentinel** → 说明守卫的回归场景；upstream merge 时需重点确认

--- a/.cursor/skills/tokenkey-stage0-local-deploy/SKILL.md
+++ b/.cursor/skills/tokenkey-stage0-local-deploy/SKILL.md
@@ -276,21 +276,19 @@ docker exec tokenkey wget -q -T 5 -O - http://localhost:8080/health
 与 **`tokenkey-prod-release-deploy`** 中 **C** 使用同一 **`scripts/tk_post_deploy_smoke.sh`**，仅 **`TOKENKEY_BASE_URL`** 指向本机反代：
 
 ```bash
-cd "${REPO_ROOT}" # 须在含 scripts/ 的仓库根；未导出 REPO_ROOT 时见「本项目路径约定」
-export TOKENKEY_BASE_URL=http://127.0.0.1:8088
-# 密钥解析顺序与 prod 相同：POST_DEPLOY_SMOKE_API_KEY → ANTHROPIC_AUTH_TOKEN → TK_TOKEN → TOKENKEY_API_KEY
+cd “${REPO_ROOT}” # 须在含 scripts/ 的仓库根；未导出 REPO_ROOT 时见「本项目路径约定」
+export TOKENKEY_BASE_URL=http://127.0.0.1:8088    # 或 TK_GATEWAY_URL（脚本两个都识别）
+# 主 key：POST_DEPLOY_SMOKE_API_KEY → ANTHROPIC_AUTH_TOKEN → TK_TOKEN → TOKENKEY_API_KEY
+# 可选 Gemini 探针：POST_DEPLOY_SMOKE_GEMINI_API_KEY=sk-...
+# 可选 OpenAI OAuth 探针：POST_DEPLOY_SMOKE_OPENAI_OAUTH_API_KEY=sk-...
 bash scripts/tk_post_deploy_smoke.sh
 ```
 
 **前提**：须已有 **可用的用户侧网关 API Key**（新 AUTO_SETUP 栈通常没有——先在管理后台创建订阅用户与 key，或使用你专用于本地的测试 key）。**不得**打印完整 key；脚本只输出 `key_hint`。若缺 key：**不要卡住会话**，验收 **A+B**（及下方管理员登录）即可。
 
-**结构化验收要求**：C 不是“看到文本返回”就结束。至少确认：
+**烟测 key**：与 prod skill § C 要求完全一致——`POST_DEPLOY_SMOKE_API_KEY`、`POST_DEPLOY_SMOKE_GEMINI_API_KEY`、`POST_DEPLOY_SMOKE_OPENAI_OAUTH_API_KEY` 三个均须导出，任一缺失不得视为验收通过。
 
-- `/v1/models`：HTTP 200，`object=list`，`data` 非空。
-- `/v1/chat/completions`：HTTP 200，`object=chat.completion`，`choices[0].message.content` 命中测试短句，`finish_reason` 合理，`usage` 存在（若上游返回）。
-- `/v1/messages`：HTTP 200，`type=message`，`role=assistant`，`content[]` 有文本，`stop_reason` 合理，`usage` 字段结构正确。
-- `/v1/responses`：HTTP 200，`object=response`，`status=completed`（或有明确可解释的非失败终态），`output[]` / `output_text` 含测试短句，`usage` 字段结构正确，且没有 `error`。
-- 若验证多个分组 / 多个 key，按 key 分别记录 `key_hint`、group platform、命中的 `account_id/platform/model` 日志证据；不要把一个 key 的通过误当成全部通过。
+**结构化验收要求**：与 prod skill § C 完全一致，以该节为准。唯一差异是 `TOKENKEY_BASE_URL=http://127.0.0.1:8088`（本地反代端口）。若有多个分组/key，按 key 分别记录 `key_hint`、group platform、`account_id/platform/model`；不要把一个 key 的通过误当成全部通过。
 
 本地 Caddy 开启压缩时，`tk_post_deploy_smoke.sh` 可能只输出启动行后等待连接关闭。若脚本卡住，不要降低验收标准：停止脚本后用同一 key 重跑等价请求，并显式加 `Accept-Encoding: identity`，仍按上面的结构化要求判定。
 
@@ -307,6 +305,39 @@ curl -sS -H 'Content-Type: application/json' \
   -d "$(printf '{"email":"%s","password":"%s"}' "${ADMIN_EMAIL}" "${ADMIN_PASSWORD}")" \
   "http://127.0.0.1:8088/api/v1/auth/login"
 ```
+
+## 完成后：当前代码与上一 tag 的变更摘要
+
+本地栈验证通过后（A+B，或 A+B+C），运行以下命令，向用户呈现"当前工作区相对上一个正式发版的差异"。目的是在本地测试阶段就识别高风险变更，不要等到发版才发现。
+
+```bash
+LAST_TAG=$(git tag --sort=-version:refname | grep '^v[0-9]' | head -1)
+BASE="${LAST_TAG:-origin/main}"
+echo "base: ${BASE}  head: $(git rev-parse --short HEAD)"
+
+# 尚未发版的提交（排除 VERSION bump）
+git log "${BASE}..HEAD" --oneline --no-merges \
+  | grep -v 'chore: bump VERSION' | grep -v '\[skip ci\]'
+
+# 变更文件统计
+git diff --stat "${BASE}..HEAD" -- backend/ frontend/src/ | tail -10
+
+# sentinel 文件有无改动
+git diff --name-only "${BASE}..HEAD" -- scripts/ | grep 'sentinels' || true
+```
+
+基于输出，向用户呈现（无变更则跳过对应行）：
+
+**当前代码领先 `${LAST_TAG}` N 个提交，运行于本地栈 `:8088`**
+
+- **feat / fix 提交**：列出关键条目及影响模块（gateway / scheduler / frontend / sentinel）
+- **高风险路径**（根据 diff 判断）：
+  - Gemini 路径改动 → 本地 C 节有无跑 Gemini 探针；tool-schema 清理是否已验证
+  - OpenAI-compat / Responses 改动 → chat completions shape 与 reasoning_tokens 是否正常
+  - pricing / model-list → `/v1/models` 返回与预期是否一致
+  - frontend 改动 → 浏览器打开 `http://127.0.0.1:8088` 手动验证关键页面
+  - sentinel 新增 → 列出文件名，后续 upstream merge 时 CI 会联检
+- **尚未覆盖的验证**：若本次本地测试未跑 C 节（缺 API key），建议在发版前用 prod smoke 补全
 
 ## 7) 停栈 / 重置
 

--- a/.cursor/skills/tokenkey-upstream-merge/SKILL.md
+++ b/.cursor/skills/tokenkey-upstream-merge/SKILL.md
@@ -122,7 +122,7 @@ PR 前必须完成：
 - Backend stat top files: `<git diff --stat upstream/main..HEAD -- backend/ | head -5>`
 ```
 
-## 7. 完成后：本次 upstream merge 变更摘要
+## 6. 完成后：本次 upstream merge 变更摘要
 
 PR 全部检查通过、准备合并（或刚完成合并）后，运行以下命令，然后向用户输出结构化摘要。
 
@@ -177,7 +177,7 @@ git diff --diff-filter=D --name-only upstream/main..HEAD -- backend/ || echo "(n
 
 **后续建议**：是否需要立即 bump VERSION 发版，或等待下一批 TK 功能合入。
 
-## 6. Red flags
+## 7. Red flags
 
 Stop and fix before PR if any is true:
 

--- a/.cursor/skills/tokenkey-upstream-merge/SKILL.md
+++ b/.cursor/skills/tokenkey-upstream-merge/SKILL.md
@@ -58,7 +58,7 @@ description: >-
 - route canonical 破坏。
 - QA/trajectory capture hook 缺失。
 - redaction contract 漂移。
-- newapi / engine / brand / terminal sentinel 漏洞。
+- newapi / engine / brand / terminal sentinel 漏洞（包括 `engine-facade-sentinels.json` 门禁：dispatch 路径须经 `engine.BuildDispatchPlan`，Gemini 思考块过滤器须保持 `shouldDropGeminiInternalText` / `normalizeGeminiFunctionArgs` 调用链）。
 - release workflow ARM/tag/skip-ci 纪律回退。
 
 ### C. OPC Refactor Commit
@@ -98,7 +98,7 @@ PR 前必须完成：
 - `pnpm --dir frontend lint:check && pnpm --dir frontend typecheck`（如 frontend 触达）。
 - `pnpm --dir frontend run build`（如 frontend dist 或 embedded web 触达）。
 - `python3 scripts/export_agent_contract.py --check`（如 agent contract 相关触达）。
-- `./scripts/preflight.sh`。
+- `./scripts/preflight.sh`（覆盖所有 sub2api sentinel 检查；`upstream-merge-pr-shape.yml` CI 独立跑其中 newapi、engine-facade、frontend-tk 三组）。
 
 不得跳过 hook 或用 `--no-verify`。
 
@@ -122,6 +122,61 @@ PR 前必须完成：
 - Backend stat top files: `<git diff --stat upstream/main..HEAD -- backend/ | head -5>`
 ```
 
+## 7. 完成后：本次 upstream merge 变更摘要
+
+PR 全部检查通过、准备合并（或刚完成合并）后，运行以下命令，然后向用户输出结构化摘要。
+
+```bash
+# 先确保 upstream 已 fetch（未 fetch 时 merge-base 会出错）
+git fetch upstream --quiet
+
+# 1. upstream 本次带入了哪些提交
+MERGE_BASE=$(git merge-base HEAD upstream/main)
+echo "upstream 新带入提交："
+git log "${MERGE_BASE}..upstream/main" --oneline --no-merges | head -30
+
+# 2. upstream 触达的文件统计（backend 最关键）
+echo "upstream backend diff stat："
+git diff --stat "${MERGE_BASE}" upstream/main -- backend/ | tail -10
+
+# 3. TK ahead 数量（PR body 审计数据）
+echo "TK ahead commits: $(git log --oneline upstream/main..HEAD | wc -l | tr -d ' ')"
+
+# 4. 本次 PR 中 TK invariant / OPC 提交
+echo "本次 PR TK 提交（非 merge commit）："
+git log --oneline upstream/main..HEAD --no-merges | head -20
+
+# 5. sentinel 文件有无改动
+git diff --name-only upstream/main..HEAD -- scripts/ | grep 'sentinels' || \
+  echo "(no sentinel changes)"
+
+# 6. 是否删除了 upstream backend 文件（风险点）
+git diff --diff-filter=D --name-only upstream/main..HEAD -- backend/ || echo "(no upstream file deletions)"
+```
+
+基于输出，向用户呈现以下结构：
+
+**upstream merge 范围：`<merge_base_short>` → `upstream/main`（N 个上游提交）**
+
+**上游带入**：按影响维度分类（handler / service / frontend / schema / CI），每类列 1–3 行关键提交。
+
+**TK invariant 修复**（B 类 commit）：列出修复的不可退让项及改动文件。
+
+**TK OPC 收敛**（C 类 commit，如有）：列出从热点文件抽取到 companion 的内容。
+
+**需要在 prod smoke / 本地测试中重点验证**（根据实际变更填写）：
+
+| 触达路径 | 验证方式 |
+|---|---|
+| Gemini 路径 | Gemini tool-schema 探针（必须设 `POST_DEPLOY_SMOKE_GEMINI_API_KEY`）；HTTP 400=硬失败需回查 |
+| OpenAI-compat / Responses | OpenAI OAuth 探针（必须设 `POST_DEPLOY_SMOKE_OPENAI_OAUTH_API_KEY`）；`reasoning_tokens` 是否透传 |
+| pricing / model-list | `/v1/models` 数量与可用性标记 |
+| frontend 组件 | frontend release asset 探针 + 浏览器关键页 |
+| 新增 sentinel | 列出 `*-sentinels.json` 文件名，说明守卫的回归场景 |
+| upstream 删除文件（如有） | 逐一确认 PR description 有 (a)/(b)/(c) 回归说明 |
+
+**后续建议**：是否需要立即 bump VERSION 发版，或等待下一批 TK 功能合入。
+
 ## 6. Red flags
 
 Stop and fix before PR if any is true:
@@ -131,3 +186,5 @@ Stop and fix before PR if any is true:
 - Sensitive payload persists without redaction version contract.
 - New upstream file/route/service was deleted or disabled without explicit regression justification.
 - PR shape check would fail: no upstream merge commit, missing `upstream/main..HEAD`, or first-parent commit contains skip-ci markers.
+- Direct `bridge.Dispatch*` call added outside the approved service boundary files (`gateway_bridge_dispatch.go` / `openai_gateway_bridge_dispatch*.go`) — engine dispatch eligibility must route through `engine.BuildDispatchPlan`; `engine-facade-sentinels.json` will flag this mechanically.
+- New Gemini response path processes `internalThought`/`executableCode` blocks without calling `shouldDropGeminiInternalText` / `normalizeGeminiFunctionArgs` — thinking-block filter or tool-arg normalizer has drifted; `engine-facade-sentinels.json` `gemini_thinking_filter_*` entries will fail.

--- a/.github/workflows/deploy-stage0.yml
+++ b/.github/workflows/deploy-stage0.yml
@@ -270,15 +270,15 @@ jobs:
         env:
           TOKENKEY_BASE_URL: ${{ steps.instance.outputs.api_url }}
           POST_DEPLOY_SMOKE_API_KEY: ${{ secrets.POST_DEPLOY_SMOKE_API_KEY }}
-          # Optional: api_key bound to a gemini-platform group (e.g. gemini-pa).
-          # When set, smoke step 6 exercises the Anthropic→Gemini tool-schema
-          # cleanup against real Google upstream; silently skipped when unset.
+          # Required: api_key bound to a gemini-platform group (e.g. gemini-pa).
+          # Exercises the Anthropic→Gemini tool-schema cleanup against real Google
+          # upstream (const/propertyNames/exclusiveMinimum Draft 2020 keywords).
           POST_DEPLOY_SMOKE_GEMINI_API_KEY: ${{ secrets.POST_DEPLOY_SMOKE_GEMINI_API_KEY }}
           POST_DEPLOY_SMOKE_GEMINI_MODEL: ${{ vars.POST_DEPLOY_SMOKE_GEMINI_MODEL }}
-          # Optional: api_key bound to an OpenAI OAuth/codex-platform group.
-          # When set, smoke step 7 exercises the apicompat reasoning_tokens
-          # passthrough on /v1/chat/completions (Responses → ChatCompletions
-          # usage.completion_tokens_details); silently skipped when unset.
+          # Required: api_key bound to an OpenAI OAuth/codex-platform group.
+          # Exercises the apicompat reasoning_tokens passthrough on
+          # /v1/chat/completions (Responses → ChatCompletions
+          # usage.completion_tokens_details).
           POST_DEPLOY_SMOKE_OPENAI_OAUTH_API_KEY: ${{ secrets.POST_DEPLOY_SMOKE_OPENAI_OAUTH_API_KEY }}
           POST_DEPLOY_SMOKE_OPENAI_OAUTH_MODEL: ${{ vars.POST_DEPLOY_SMOKE_OPENAI_OAUTH_MODEL }}
         run: |
@@ -287,6 +287,18 @@ jobs:
             echo "::error::POST_DEPLOY_SMOKE_API_KEY repository secret is not set."
             echo "Add a TokenKey user API key (sk-...) that is valid for this stack's gateway."
             echo "See deploy/aws/README.md (post-deploy smoke) and docs/approved/deploy-stage0-workflow.md §5."
+            exit 1
+          fi
+          if [ -z "${POST_DEPLOY_SMOKE_GEMINI_API_KEY:-}" ]; then
+            echo "::error::POST_DEPLOY_SMOKE_GEMINI_API_KEY repository secret is not set."
+            echo "Add a TokenKey API key bound to a gemini-platform group (e.g. gemini-pa)."
+            echo "This probe guards the Anthropic→Gemini tool-schema cleanup regression."
+            exit 1
+          fi
+          if [ -z "${POST_DEPLOY_SMOKE_OPENAI_OAUTH_API_KEY:-}" ]; then
+            echo "::error::POST_DEPLOY_SMOKE_OPENAI_OAUTH_API_KEY repository secret is not set."
+            echo "Add a TokenKey API key bound to an OpenAI OAuth/codex-platform group."
+            echo "This probe guards the reasoning_tokens passthrough regression."
             exit 1
           fi
           bash scripts/tk_post_deploy_smoke.sh

--- a/.github/workflows/deploy-stage0.yml
+++ b/.github/workflows/deploy-stage0.yml
@@ -291,14 +291,16 @@ jobs:
           fi
           if [ -z "${POST_DEPLOY_SMOKE_GEMINI_API_KEY:-}" ]; then
             echo "::error::POST_DEPLOY_SMOKE_GEMINI_API_KEY repository secret is not set."
-            echo "Add a TokenKey API key bound to a gemini-platform group (e.g. gemini-pa)."
+            echo "Add a TokenKey API key bound to a gemini-platform group (e.g. gemini-pa) on this stack's gateway."
             echo "This probe guards the Anthropic→Gemini tool-schema cleanup regression."
+            echo "See deploy/aws/README.md (post-deploy smoke) and docs/approved/deploy-stage0-workflow.md §5."
             exit 1
           fi
           if [ -z "${POST_DEPLOY_SMOKE_OPENAI_OAUTH_API_KEY:-}" ]; then
             echo "::error::POST_DEPLOY_SMOKE_OPENAI_OAUTH_API_KEY repository secret is not set."
-            echo "Add a TokenKey API key bound to an OpenAI OAuth/codex-platform group."
+            echo "Add a TokenKey API key bound to an OpenAI OAuth/codex-platform group on this stack's gateway."
             echo "This probe guards the reasoning_tokens passthrough regression."
+            echo "See deploy/aws/README.md (post-deploy smoke) and docs/approved/deploy-stage0-workflow.md §5."
             exit 1
           fi
           bash scripts/tk_post_deploy_smoke.sh


### PR DESCRIPTION
## Summary

- **CI guard**: add `::error::` + `exit 1` for `POST_DEPLOY_SMOKE_GEMINI_API_KEY` and `POST_DEPLOY_SMOKE_OPENAI_OAUTH_API_KEY` in `deploy-stage0.yml` — these two probes were silently skipped when secrets were absent; now the deploy step fails explicitly, matching the existing guard for the main smoke key
- **Skills**: Gemini tool-schema probe and OpenAI OAuth probe are now classified as required in all three skill files; any session without both keys set does not count as passing smoke
- **Skills**: add "完成后：变更摘要" section to prod-release-deploy, stage0-local-deploy, and upstream-merge — executing Agent outputs structured change/impact/verification notes after each run
- **Skills**: fix drift sources — remove hardcoded count (「7 个节」), section ordinals (section 6/7), hardcoded model defaults, enumerated sentinel list in preflight line; collapse stage0's duplicated 1–7 verification list into a single pointer to prod skill
- **Skills**: fix fragile `MERGE_BASE` command in upstream-merge (nested fallback → single `git merge-base HEAD upstream/main` + explicit fetch)

## Risk

`deploy-stage0.yml` change will **immediately fail** the next deploy if `POST_DEPLOY_SMOKE_GEMINI_API_KEY` or `POST_DEPLOY_SMOKE_OPENAI_OAUTH_API_KEY` are not set in GitHub Secrets. Add both secrets before merging.

Skill files: doc-only, no runtime impact.

## Validation

- `bash scripts/preflight.sh` — PASS (all sub2api sentinel checks, workflow-if-env, smoke syntax)