### PR TITLE
fix(gemini): keep Code Assist capacity 429 model-scoped

### DIFF
--- a/.github/workflows/upstream-merge-pr-shape.yml
+++ b/.github/workflows/upstream-merge-pr-shape.yml
@@ -28,6 +28,10 @@ name: Upstream Merge PR Shape
 #      merge — small UI divergences (sidebar geometry, fluid admin-accounts
 #      table mode, sticky-edge-hints opt-out) compile cleanly even if
 #      silently reverted, so a literal-content guard is the only catch.
+#   5c. Every load-bearing TokenKey-only gateway/service hook listed in
+#      `scripts/gateway-tk-sentinels.json` is still intact after the merge;
+#      these are small upstream-hotspot injections that otherwise compile
+#      cleanly when silently reverted.
 #   6. The QA evidence redaction contract stays aligned: if logredact's
 #      default sensitive-key set changes, `scripts/redaction-sentinels.json`
 #      and every outward `redaction_version` literal must move in the same
@@ -225,6 +229,25 @@ jobs:
           if ! python3 ./scripts/check-frontend-tk-sentinels.py; then
             echo "::error::Upstream merge regressed at least one frontend TK sentinel."
             echo "::error::Restore the dropped / reverted TK frontend surface in this merge PR."
+            echo "::error::Do NOT 'fix' by deleting the sentinel entry."
+            exit 1
+          fi
+
+      - name: Check 5c — gateway TK sentinels still intact after merge
+        run: |
+          # Single source of truth: scripts/gateway-tk-sentinels.json. Same
+          # script that scripts/preflight.sh runs locally, so a green local
+          # preflight implies a green check here. Guards small TK gateway/service
+          # hooks in upstream-shaped hotspot files that compile cleanly even if
+          # reverted, with regressions only surfacing in production behavior.
+          if [ ! -x ./scripts/check-gateway-tk-sentinels.py ]; then
+            echo "::error::scripts/check-gateway-tk-sentinels.py missing or not executable."
+            echo "::error::Per CLAUDE.md §5 minimum-invasion guidance, this guard cannot be silently disabled."
+            exit 1
+          fi
+          if ! python3 ./scripts/check-gateway-tk-sentinels.py; then
+            echo "::error::Upstream merge regressed at least one gateway TK sentinel."
+            echo "::error::Restore the dropped / reverted TK gateway hook in this merge PR."
             echo "::error::Do NOT 'fix' by deleting the sentinel entry."
             exit 1
           fi

--- a/backend/internal/service/gemini_error_policy_test.go
+++ b/backend/internal/service/gemini_error_policy_test.go
@@ -313,7 +313,7 @@ func TestGeminiErrorPolicyIntegration(t *testing.T) {
 					handleErrorCalled = false
 					goto verify
 				case ErrorPolicyMatched, ErrorPolicyTempUnscheduled:
-					svc.handleGeminiUpstreamError(ctx, account, statusCode, headers, respBody)
+					svc.handleGeminiUpstreamError(ctx, account, statusCode, headers, respBody, "")
 					handleErrorCalled = true
 					gotFailover = true
 					goto verify
@@ -321,7 +321,7 @@ func TestGeminiErrorPolicyIntegration(t *testing.T) {
 			}
 
 			// ErrorPolicyNone → original logic
-			svc.handleGeminiUpstreamError(ctx, account, statusCode, headers, respBody)
+			svc.handleGeminiUpstreamError(ctx, account, statusCode, headers, respBody, "")
 			handleErrorCalled = true
 			if svc.shouldFailoverGeminiUpstreamError(statusCode) {
 				gotFailover = true
@@ -374,7 +374,7 @@ func TestGeminiErrorPolicy_NilRateLimitService(t *testing.T) {
 
 	// handleGeminiUpstreamError should not panic with nil rateLimitService
 	require.NotPanics(t, func() {
-		svc.handleGeminiUpstreamError(ctx, account, 500, http.Header{}, []byte(`error`))
+		svc.handleGeminiUpstreamError(ctx, account, 500, http.Header{}, []byte(`error`), "")
 	})
 }
 

--- a/backend/internal/service/gemini_error_policy_test.go
+++ b/backend/internal/service/gemini_error_policy_test.go
@@ -313,7 +313,7 @@ func TestGeminiErrorPolicyIntegration(t *testing.T) {
 					handleErrorCalled = false
 					goto verify
 				case ErrorPolicyMatched, ErrorPolicyTempUnscheduled:
-					svc.handleGeminiUpstreamError(ctx, account, statusCode, headers, respBody, "")
+					svc.handleGeminiUpstreamError(ctx, account, statusCode, headers, respBody)
 					handleErrorCalled = true
 					gotFailover = true
 					goto verify
@@ -321,7 +321,7 @@ func TestGeminiErrorPolicyIntegration(t *testing.T) {
 			}
 
 			// ErrorPolicyNone → original logic
-			svc.handleGeminiUpstreamError(ctx, account, statusCode, headers, respBody, "")
+			svc.handleGeminiUpstreamError(ctx, account, statusCode, headers, respBody)
 			handleErrorCalled = true
 			if svc.shouldFailoverGeminiUpstreamError(statusCode) {
 				gotFailover = true
@@ -374,7 +374,7 @@ func TestGeminiErrorPolicy_NilRateLimitService(t *testing.T) {
 
 	// handleGeminiUpstreamError should not panic with nil rateLimitService
 	require.NotPanics(t, func() {
-		svc.handleGeminiUpstreamError(ctx, account, 500, http.Header{}, []byte(`error`), "")
+		svc.handleGeminiUpstreamError(ctx, account, 500, http.Header{}, []byte(`error`))
 	})
 }
 

--- a/backend/internal/service/gemini_messages_compat_service.go
+++ b/backend/internal/service/gemini_messages_compat_service.go
@@ -887,7 +887,7 @@ func (s *GeminiMessagesCompatService) Forward(ctx context.Context, c *gin.Contex
 			}
 			if resp.StatusCode == 429 {
 				// Mark as rate-limited early so concurrent requests avoid this account.
-				s.handleGeminiUpstreamError(ctx, account, resp.StatusCode, resp.Header, respBody)
+				s.handleGeminiUpstreamError(ctx, account, resp.StatusCode, resp.Header, respBody, mappedModel)
 			}
 			if attempt < geminiMaxRetries {
 				upstreamReqID := resp.Header.Get(requestIDHeader)
@@ -944,7 +944,7 @@ func (s *GeminiMessagesCompatService) Forward(ctx context.Context, c *gin.Contex
 				}
 				return nil, s.writeGeminiMappedError(c, account, http.StatusInternalServerError, upstreamReqID, respBody)
 			case ErrorPolicyMatched, ErrorPolicyTempUnscheduled:
-				s.handleGeminiUpstreamError(ctx, account, resp.StatusCode, resp.Header, respBody)
+				s.handleGeminiUpstreamError(ctx, account, resp.StatusCode, resp.Header, respBody, mappedModel)
 				upstreamReqID := resp.Header.Get(requestIDHeader)
 				if upstreamReqID == "" {
 					upstreamReqID = resp.Header.Get("x-goog-request-id")
@@ -974,7 +974,7 @@ func (s *GeminiMessagesCompatService) Forward(ctx context.Context, c *gin.Contex
 		}
 
 		// ErrorPolicyNone → 原有逻辑
-		s.handleGeminiUpstreamError(ctx, account, resp.StatusCode, resp.Header, respBody)
+		s.handleGeminiUpstreamError(ctx, account, resp.StatusCode, resp.Header, respBody, mappedModel)
 		// 精确匹配服务端配置类 400 错误，触发 failover + 临时封禁
 		if resp.StatusCode == http.StatusBadRequest {
 			msg400 := strings.ToLower(strings.TrimSpace(extractUpstreamErrorMessage(respBody)))
@@ -1362,7 +1362,7 @@ func (s *GeminiMessagesCompatService) ForwardNative(ctx context.Context, c *gin.
 				break
 			}
 			if resp.StatusCode == 429 {
-				s.handleGeminiUpstreamError(ctx, account, resp.StatusCode, resp.Header, respBody)
+				s.handleGeminiUpstreamError(ctx, account, resp.StatusCode, resp.Header, respBody, mappedModel)
 			}
 			if attempt < geminiMaxRetries {
 				upstreamReqID := resp.Header.Get(requestIDHeader)
@@ -1461,7 +1461,7 @@ func (s *GeminiMessagesCompatService) ForwardNative(ctx context.Context, c *gin.
 				c.Data(http.StatusInternalServerError, contentType, respBody)
 				return nil, fmt.Errorf("gemini upstream error: %d (skipped by error policy)", resp.StatusCode)
 			case ErrorPolicyMatched, ErrorPolicyTempUnscheduled:
-				s.handleGeminiUpstreamError(ctx, account, resp.StatusCode, resp.Header, respBody)
+				s.handleGeminiUpstreamError(ctx, account, resp.StatusCode, resp.Header, respBody, mappedModel)
 				evBody := unwrapIfNeeded(isOAuth, respBody)
 				upstreamMsg := strings.TrimSpace(extractUpstreamErrorMessage(evBody))
 				upstreamMsg = sanitizeUpstreamErrorMessage(upstreamMsg)
@@ -1488,7 +1488,7 @@ func (s *GeminiMessagesCompatService) ForwardNative(ctx context.Context, c *gin.
 		}
 
 		// ErrorPolicyNone → 原有逻辑
-		s.handleGeminiUpstreamError(ctx, account, resp.StatusCode, resp.Header, respBody)
+		s.handleGeminiUpstreamError(ctx, account, resp.StatusCode, resp.Header, respBody, mappedModel)
 		// 精确匹配服务端配置类 400 错误，触发 failover + 临时封禁
 		if resp.StatusCode == http.StatusBadRequest {
 			msg400 := strings.ToLower(strings.TrimSpace(extractUpstreamErrorMessage(respBody)))
@@ -2822,7 +2822,7 @@ func asInt(v any) (int, bool) {
 	}
 }
 
-func (s *GeminiMessagesCompatService) handleGeminiUpstreamError(ctx context.Context, account *Account, statusCode int, headers http.Header, body []byte) {
+func (s *GeminiMessagesCompatService) handleGeminiUpstreamError(ctx context.Context, account *Account, statusCode int, headers http.Header, body []byte, fallbackModel string) {
 	// 遵守自定义错误码策略：未命中则跳过所有限流处理
 	if !account.ShouldHandleErrorCode(statusCode) {
 		return
@@ -2843,7 +2843,7 @@ func (s *GeminiMessagesCompatService) handleGeminiUpstreamError(ctx context.Cont
 	// TK: per-model rate limit for Code Assist 429s carrying ErrorInfo.metadata.model
 	// (e.g. MODEL_CAPACITY_EXHAUSTED on a single model). See
 	// gemini_messages_compat_service_tk_model_rate_limit.go for rationale.
-	if s.tryGeminiCodeAssistApplyModelRateLimit(ctx, account, body) {
+	if s.tryGeminiCodeAssistApplyModelRateLimit(ctx, account, body, fallbackModel) {
 		return
 	}
 

--- a/backend/internal/service/gemini_messages_compat_service.go
+++ b/backend/internal/service/gemini_messages_compat_service.go
@@ -594,6 +594,7 @@ func (s *GeminiMessagesCompatService) Forward(ctx context.Context, c *gin.Contex
 	if account.Type == AccountTypeAPIKey || account.Type == AccountTypeServiceAccount {
 		mappedModel = account.GetMappedModel(req.Model)
 	}
+	ctx = withGeminiCodeAssistMappedModel(ctx, mappedModel)
 
 	geminiReq, err := convertClaudeMessagesToGeminiGenerateContent(body)
 	if err != nil {
@@ -887,7 +888,7 @@ func (s *GeminiMessagesCompatService) Forward(ctx context.Context, c *gin.Contex
 			}
 			if resp.StatusCode == 429 {
 				// Mark as rate-limited early so concurrent requests avoid this account.
-				s.handleGeminiUpstreamError(ctx, account, resp.StatusCode, resp.Header, respBody, mappedModel)
+				s.handleGeminiUpstreamError(ctx, account, resp.StatusCode, resp.Header, respBody)
 			}
 			if attempt < geminiMaxRetries {
 				upstreamReqID := resp.Header.Get(requestIDHeader)
@@ -944,7 +945,7 @@ func (s *GeminiMessagesCompatService) Forward(ctx context.Context, c *gin.Contex
 				}
 				return nil, s.writeGeminiMappedError(c, account, http.StatusInternalServerError, upstreamReqID, respBody)
 			case ErrorPolicyMatched, ErrorPolicyTempUnscheduled:
-				s.handleGeminiUpstreamError(ctx, account, resp.StatusCode, resp.Header, respBody, mappedModel)
+				s.handleGeminiUpstreamError(ctx, account, resp.StatusCode, resp.Header, respBody)
 				upstreamReqID := resp.Header.Get(requestIDHeader)
 				if upstreamReqID == "" {
 					upstreamReqID = resp.Header.Get("x-goog-request-id")
@@ -974,7 +975,7 @@ func (s *GeminiMessagesCompatService) Forward(ctx context.Context, c *gin.Contex
 		}
 
 		// ErrorPolicyNone → 原有逻辑
-		s.handleGeminiUpstreamError(ctx, account, resp.StatusCode, resp.Header, respBody, mappedModel)
+		s.handleGeminiUpstreamError(ctx, account, resp.StatusCode, resp.Header, respBody)
 		// 精确匹配服务端配置类 400 错误，触发 failover + 临时封禁
 		if resp.StatusCode == http.StatusBadRequest {
 			msg400 := strings.ToLower(strings.TrimSpace(extractUpstreamErrorMessage(respBody)))
@@ -1142,6 +1143,7 @@ func (s *GeminiMessagesCompatService) ForwardNative(ctx context.Context, c *gin.
 	if account.Type == AccountTypeAPIKey || account.Type == AccountTypeServiceAccount {
 		mappedModel = account.GetMappedModel(originalModel)
 	}
+	ctx = withGeminiCodeAssistMappedModel(ctx, mappedModel)
 
 	proxyURL := ""
 	if account.ProxyID != nil && account.Proxy != nil {
@@ -1362,7 +1364,7 @@ func (s *GeminiMessagesCompatService) ForwardNative(ctx context.Context, c *gin.
 				break
 			}
 			if resp.StatusCode == 429 {
-				s.handleGeminiUpstreamError(ctx, account, resp.StatusCode, resp.Header, respBody, mappedModel)
+				s.handleGeminiUpstreamError(ctx, account, resp.StatusCode, resp.Header, respBody)
 			}
 			if attempt < geminiMaxRetries {
 				upstreamReqID := resp.Header.Get(requestIDHeader)
@@ -1461,7 +1463,7 @@ func (s *GeminiMessagesCompatService) ForwardNative(ctx context.Context, c *gin.
 				c.Data(http.StatusInternalServerError, contentType, respBody)
 				return nil, fmt.Errorf("gemini upstream error: %d (skipped by error policy)", resp.StatusCode)
 			case ErrorPolicyMatched, ErrorPolicyTempUnscheduled:
-				s.handleGeminiUpstreamError(ctx, account, resp.StatusCode, resp.Header, respBody, mappedModel)
+				s.handleGeminiUpstreamError(ctx, account, resp.StatusCode, resp.Header, respBody)
 				evBody := unwrapIfNeeded(isOAuth, respBody)
 				upstreamMsg := strings.TrimSpace(extractUpstreamErrorMessage(evBody))
 				upstreamMsg = sanitizeUpstreamErrorMessage(upstreamMsg)
@@ -1488,7 +1490,7 @@ func (s *GeminiMessagesCompatService) ForwardNative(ctx context.Context, c *gin.
 		}
 
 		// ErrorPolicyNone → 原有逻辑
-		s.handleGeminiUpstreamError(ctx, account, resp.StatusCode, resp.Header, respBody, mappedModel)
+		s.handleGeminiUpstreamError(ctx, account, resp.StatusCode, resp.Header, respBody)
 		// 精确匹配服务端配置类 400 错误，触发 failover + 临时封禁
 		if resp.StatusCode == http.StatusBadRequest {
 			msg400 := strings.ToLower(strings.TrimSpace(extractUpstreamErrorMessage(respBody)))
@@ -2822,7 +2824,7 @@ func asInt(v any) (int, bool) {
 	}
 }
 
-func (s *GeminiMessagesCompatService) handleGeminiUpstreamError(ctx context.Context, account *Account, statusCode int, headers http.Header, body []byte, fallbackModel string) {
+func (s *GeminiMessagesCompatService) handleGeminiUpstreamError(ctx context.Context, account *Account, statusCode int, headers http.Header, body []byte) {
 	// 遵守自定义错误码策略：未命中则跳过所有限流处理
 	if !account.ShouldHandleErrorCode(statusCode) {
 		return
@@ -2843,7 +2845,7 @@ func (s *GeminiMessagesCompatService) handleGeminiUpstreamError(ctx context.Cont
 	// TK: per-model rate limit for Code Assist 429s carrying ErrorInfo.metadata.model
 	// (e.g. MODEL_CAPACITY_EXHAUSTED on a single model). See
 	// gemini_messages_compat_service_tk_model_rate_limit.go for rationale.
-	if s.tryGeminiCodeAssistApplyModelRateLimit(ctx, account, body, fallbackModel) {
+	if s.tryGeminiCodeAssistApplyModelRateLimit(ctx, account, body) {
 		return
 	}
 

--- a/backend/internal/service/gemini_messages_compat_service_tk_model_rate_limit.go
+++ b/backend/internal/service/gemini_messages_compat_service_tk_model_rate_limit.go
@@ -39,6 +39,21 @@ import (
 // 如果 upstream 把 per-model rate limit 内化（不太可能：upstream 没有
 // SetModelRateLimit 抽象），可以删掉本文件并将 call-site 还原。
 
+type geminiCodeAssistMappedModelContextKey struct{}
+
+func withGeminiCodeAssistMappedModel(ctx context.Context, model string) context.Context {
+	model = strings.TrimSpace(model)
+	if model == "" {
+		return ctx
+	}
+	return context.WithValue(ctx, geminiCodeAssistMappedModelContextKey{}, model)
+}
+
+func geminiCodeAssistMappedModelFromContext(ctx context.Context) string {
+	model, _ := ctx.Value(geminiCodeAssistMappedModelContextKey{}).(string)
+	return strings.TrimSpace(model)
+}
+
 // tryGeminiCodeAssistApplyModelRateLimit attempts to set a per-model rate limit
 // when a Gemini Code Assist 429 carries a model-specific signal.
 //
@@ -53,7 +68,7 @@ import (
 // On false (including non-Code-Assist accounts or no model key), the caller
 // continues with the existing account-level path.
 func (s *GeminiMessagesCompatService) tryGeminiCodeAssistApplyModelRateLimit(
-	ctx context.Context, account *Account, body []byte, fallbackModel string,
+	ctx context.Context, account *Account, body []byte,
 ) bool {
 	if account == nil || !account.IsGeminiCodeAssist() {
 		return false
@@ -61,7 +76,7 @@ func (s *GeminiMessagesCompatService) tryGeminiCodeAssistApplyModelRateLimit(
 
 	modelName := extractGeminiCodeAssistRateLimitedModel(body)
 	if modelName == "" {
-		fallbackModel = strings.TrimSpace(fallbackModel)
+		fallbackModel := geminiCodeAssistMappedModelFromContext(ctx)
 		modelScoped := isGeminiCodeAssistModelScopedRateLimit(body)
 		if fallbackModel == "" || !modelScoped {
 			logger.LegacyPrintf("service.gemini_messages_compat",

--- a/backend/internal/service/gemini_messages_compat_service_tk_model_rate_limit.go
+++ b/backend/internal/service/gemini_messages_compat_service_tk_model_rate_limit.go
@@ -45,14 +45,15 @@ import (
 // Returns true iff:
 //   - account is platform=gemini Code Assist OAuth (cloudcode-pa upstream), and
 //   - body parses as a Google RPC error containing an ErrorInfo with a
-//     non-empty metadata.model, and
+//     non-empty metadata.model, or the caller provides a non-empty fallback
+//     upstream model, and
 //   - SetModelRateLimit succeeds.
 //
 // On true, the caller MUST skip its own account-level rate-limit fallback.
-// On false (including parse failure or non-Code-Assist accounts), the caller
+// On false (including non-Code-Assist accounts or no model key), the caller
 // continues with the existing account-level path.
 func (s *GeminiMessagesCompatService) tryGeminiCodeAssistApplyModelRateLimit(
-	ctx context.Context, account *Account, body []byte,
+	ctx context.Context, account *Account, body []byte, fallbackModel string,
 ) bool {
 	if account == nil || !account.IsGeminiCodeAssist() {
 		return false
@@ -60,7 +61,15 @@ func (s *GeminiMessagesCompatService) tryGeminiCodeAssistApplyModelRateLimit(
 
 	modelName := extractGeminiCodeAssistRateLimitedModel(body)
 	if modelName == "" {
-		return false
+		fallbackModel = strings.TrimSpace(fallbackModel)
+		modelScoped := isGeminiCodeAssistModelScopedRateLimit(body)
+		if fallbackModel == "" || !modelScoped {
+			logger.LegacyPrintf("service.gemini_messages_compat",
+				"[Gemini 429] tk_model_rate_limit_no_model account=%d fallback_model=%s model_scoped=%v (falling back to account-level)",
+				account.ID, fallbackModel, modelScoped)
+			return false
+		}
+		modelName = fallbackModel
 	}
 
 	// Reset time: prefer the upstream signal (quotaResetDelay / retryDelay),
@@ -100,23 +109,11 @@ func (s *GeminiMessagesCompatService) tryGeminiCodeAssistApplyModelRateLimit(
 // is the **presence** of metadata.model. Account-wide quota errors (daily
 // quota, account suspended, …) do not carry a model name.
 func extractGeminiCodeAssistRateLimitedModel(body []byte) string {
-	var parsed map[string]any
-	if err := json.Unmarshal(body, &parsed); err != nil {
+	details := geminiErrorDetails(body)
+	if len(details) == 0 {
 		return ""
 	}
-	errObj, ok := parsed["error"].(map[string]any)
-	if !ok {
-		return ""
-	}
-	details, ok := errObj["details"].([]any)
-	if !ok {
-		return ""
-	}
-	for _, d := range details {
-		dm, ok := d.(map[string]any)
-		if !ok {
-			continue
-		}
+	for _, dm := range details {
 		atType, _ := dm["@type"].(string)
 		if atType != googleRPCTypeErrorInfo {
 			continue
@@ -132,4 +129,45 @@ func extractGeminiCodeAssistRateLimitedModel(body []byte) string {
 		}
 	}
 	return ""
+}
+
+func isGeminiCodeAssistModelScopedRateLimit(body []byte) bool {
+	details := geminiErrorDetails(body)
+	if len(details) == 0 {
+		return false
+	}
+	for _, dm := range details {
+		atType, _ := dm["@type"].(string)
+		if atType != googleRPCTypeErrorInfo {
+			continue
+		}
+		reason, _ := dm["reason"].(string)
+		if strings.TrimSpace(reason) == googleRPCReasonModelCapacityExhausted {
+			return true
+		}
+	}
+	return false
+}
+
+func geminiErrorDetails(body []byte) []map[string]any {
+	var parsed map[string]any
+	if err := json.Unmarshal(body, &parsed); err != nil {
+		return nil
+	}
+	errObj, ok := parsed["error"].(map[string]any)
+	if !ok {
+		return nil
+	}
+	details, ok := errObj["details"].([]any)
+	if !ok {
+		return nil
+	}
+	out := make([]map[string]any, 0, len(details))
+	for _, d := range details {
+		dm, ok := d.(map[string]any)
+		if ok {
+			out = append(out, dm)
+		}
+	}
+	return out
 }

--- a/backend/internal/service/gemini_messages_compat_service_tk_model_rate_limit_test.go
+++ b/backend/internal/service/gemini_messages_compat_service_tk_model_rate_limit_test.go
@@ -124,7 +124,7 @@ func TestTryGeminiCodeAssistApplyModelRateLimit_RecordsPerModel(t *testing.T) {
 		}
 	}`)
 
-	require.True(t, svc.tryGeminiCodeAssistApplyModelRateLimit(context.Background(), account, body, ""))
+	require.True(t, svc.tryGeminiCodeAssistApplyModelRateLimit(context.Background(), account, body))
 	require.Empty(t, repo.rateCalls, "must not set account-level rate limit when model is identified")
 	require.Len(t, repo.modelRateLimitCalls, 1)
 	require.Equal(t, int64(42), repo.modelRateLimitCalls[0].accountID)
@@ -147,7 +147,7 @@ func TestTryGeminiCodeAssistApplyModelRateLimit_SkipsForNonCodeAssist(t *testing
 	}
 	body := []byte(`{"error":{"status":"RESOURCE_EXHAUSTED","details":[{"@type":"type.googleapis.com/google.rpc.ErrorInfo","reason":"MODEL_CAPACITY_EXHAUSTED","metadata":{"model":"gemini-3.1-pro-preview"}}]}}`)
 
-	require.False(t, svc.tryGeminiCodeAssistApplyModelRateLimit(context.Background(), aiStudio, body, "gemini-3.1-pro-preview"))
+	require.False(t, svc.tryGeminiCodeAssistApplyModelRateLimit(withGeminiCodeAssistMappedModel(context.Background(), "gemini-3.1-pro-preview"), aiStudio, body))
 	require.Empty(t, repo.modelRateLimitCalls, "AI Studio OAuth must not get per-model rate limit via this path")
 	require.Empty(t, repo.rateCalls, "this helper never writes account-level — caller's fallback handles that")
 
@@ -157,7 +157,7 @@ func TestTryGeminiCodeAssistApplyModelRateLimit_SkipsForNonCodeAssist(t *testing
 		Platform: PlatformGemini,
 		Type:     AccountTypeAPIKey,
 	}
-	require.False(t, svc.tryGeminiCodeAssistApplyModelRateLimit(context.Background(), apiKey, body, "gemini-3.1-pro-preview"))
+	require.False(t, svc.tryGeminiCodeAssistApplyModelRateLimit(withGeminiCodeAssistMappedModel(context.Background(), "gemini-3.1-pro-preview"), apiKey, body))
 	require.Empty(t, repo.modelRateLimitCalls)
 }
 
@@ -178,7 +178,7 @@ func TestTryGeminiCodeAssistApplyModelRateLimit_FallsBackWhenNoModel(t *testing.
 		}
 	}`)
 
-	require.False(t, svc.tryGeminiCodeAssistApplyModelRateLimit(context.Background(), account, body, ""))
+	require.False(t, svc.tryGeminiCodeAssistApplyModelRateLimit(context.Background(), account, body))
 	require.Empty(t, repo.modelRateLimitCalls)
 }
 
@@ -199,7 +199,7 @@ func TestTryGeminiCodeAssistApplyModelRateLimit_UsesFallbackModelForModelScoped4
 		}
 	}`)
 
-	require.True(t, svc.tryGeminiCodeAssistApplyModelRateLimit(context.Background(), account, body, "gemini-3.1-pro-preview"))
+	require.True(t, svc.tryGeminiCodeAssistApplyModelRateLimit(withGeminiCodeAssistMappedModel(context.Background(), "gemini-3.1-pro-preview"), account, body))
 	require.Empty(t, repo.rateCalls)
 	require.Len(t, repo.modelRateLimitCalls, 1)
 	require.Equal(t, "gemini-3.1-pro-preview", repo.modelRateLimitCalls[0].modelKey)
@@ -218,7 +218,7 @@ func TestTryGeminiCodeAssistApplyModelRateLimit_DoesNotUseFallbackForAccountWide
 		}
 	}`)
 
-	require.False(t, svc.tryGeminiCodeAssistApplyModelRateLimit(context.Background(), account, body, "gemini-3.1-pro-preview"))
+	require.False(t, svc.tryGeminiCodeAssistApplyModelRateLimit(withGeminiCodeAssistMappedModel(context.Background(), "gemini-3.1-pro-preview"), account, body))
 	require.Empty(t, repo.modelRateLimitCalls)
 }
 
@@ -245,7 +245,7 @@ func TestTryGeminiCodeAssistApplyModelRateLimit_RespectsParsedRetryDelay(t *test
 	}`)
 
 	before := time.Now()
-	require.True(t, svc.tryGeminiCodeAssistApplyModelRateLimit(context.Background(), account, body, ""))
+	require.True(t, svc.tryGeminiCodeAssistApplyModelRateLimit(context.Background(), account, body))
 	require.Len(t, repo.modelRateLimitCalls, 1)
 	resetAt := repo.modelRateLimitCalls[0].resetAt
 	// 30s ± clock drift (allow up to 5s slack).
@@ -276,7 +276,7 @@ func TestHandleGeminiUpstreamError_CodeAssist429RoutesToPerModel(t *testing.T) {
 		}
 	}`)
 
-	svc.handleGeminiUpstreamError(context.Background(), account, http.StatusTooManyRequests, http.Header{}, body, "")
+	svc.handleGeminiUpstreamError(context.Background(), account, http.StatusTooManyRequests, http.Header{}, body)
 
 	require.Empty(t, repo.rateCalls, "Code Assist 429 with model metadata must NOT set account-level rate limit")
 	require.Len(t, repo.modelRateLimitCalls, 1)
@@ -290,7 +290,8 @@ func TestHandleGeminiUpstreamError_CodeAssist429FallbackModelRoutesToPerModel(t 
 
 	body := []byte(`{"error":{"code":429,"status":"RESOURCE_EXHAUSTED","details":[{"@type":"type.googleapis.com/google.rpc.ErrorInfo","reason":"MODEL_CAPACITY_EXHAUSTED"}]}}`)
 
-	svc.handleGeminiUpstreamError(context.Background(), account, http.StatusTooManyRequests, http.Header{}, body, "gemini-3.1-pro-preview")
+	ctx := withGeminiCodeAssistMappedModel(context.Background(), "gemini-3.1-pro-preview")
+	svc.handleGeminiUpstreamError(ctx, account, http.StatusTooManyRequests, http.Header{}, body)
 
 	require.Empty(t, repo.rateCalls, "model-scoped fallback must not set account-level rate limit")
 	require.Len(t, repo.modelRateLimitCalls, 1)
@@ -307,7 +308,7 @@ func TestHandleGeminiUpstreamError_CodeAssist429AccountWideStillFalls(t *testing
 
 	body := []byte(`{"error":{"code":429,"status":"RESOURCE_EXHAUSTED","message":"Quota exceeded"}}`)
 
-	svc.handleGeminiUpstreamError(context.Background(), account, http.StatusTooManyRequests, http.Header{}, body, "")
+	svc.handleGeminiUpstreamError(context.Background(), account, http.StatusTooManyRequests, http.Header{}, body)
 
 	require.Empty(t, repo.modelRateLimitCalls, "no per-model signal → no per-model write")
 	require.Len(t, repo.rateCalls, 1, "account-level fallback must still fire")

--- a/backend/internal/service/gemini_messages_compat_service_tk_model_rate_limit_test.go
+++ b/backend/internal/service/gemini_messages_compat_service_tk_model_rate_limit_test.go
@@ -124,7 +124,7 @@ func TestTryGeminiCodeAssistApplyModelRateLimit_RecordsPerModel(t *testing.T) {
 		}
 	}`)
 
-	require.True(t, svc.tryGeminiCodeAssistApplyModelRateLimit(context.Background(), account, body))
+	require.True(t, svc.tryGeminiCodeAssistApplyModelRateLimit(context.Background(), account, body, ""))
 	require.Empty(t, repo.rateCalls, "must not set account-level rate limit when model is identified")
 	require.Len(t, repo.modelRateLimitCalls, 1)
 	require.Equal(t, int64(42), repo.modelRateLimitCalls[0].accountID)
@@ -147,7 +147,7 @@ func TestTryGeminiCodeAssistApplyModelRateLimit_SkipsForNonCodeAssist(t *testing
 	}
 	body := []byte(`{"error":{"status":"RESOURCE_EXHAUSTED","details":[{"@type":"type.googleapis.com/google.rpc.ErrorInfo","reason":"MODEL_CAPACITY_EXHAUSTED","metadata":{"model":"gemini-3.1-pro-preview"}}]}}`)
 
-	require.False(t, svc.tryGeminiCodeAssistApplyModelRateLimit(context.Background(), aiStudio, body))
+	require.False(t, svc.tryGeminiCodeAssistApplyModelRateLimit(context.Background(), aiStudio, body, "gemini-3.1-pro-preview"))
 	require.Empty(t, repo.modelRateLimitCalls, "AI Studio OAuth must not get per-model rate limit via this path")
 	require.Empty(t, repo.rateCalls, "this helper never writes account-level — caller's fallback handles that")
 
@@ -157,7 +157,7 @@ func TestTryGeminiCodeAssistApplyModelRateLimit_SkipsForNonCodeAssist(t *testing
 		Platform: PlatformGemini,
 		Type:     AccountTypeAPIKey,
 	}
-	require.False(t, svc.tryGeminiCodeAssistApplyModelRateLimit(context.Background(), apiKey, body))
+	require.False(t, svc.tryGeminiCodeAssistApplyModelRateLimit(context.Background(), apiKey, body, "gemini-3.1-pro-preview"))
 	require.Empty(t, repo.modelRateLimitCalls)
 }
 
@@ -178,7 +178,47 @@ func TestTryGeminiCodeAssistApplyModelRateLimit_FallsBackWhenNoModel(t *testing.
 		}
 	}`)
 
-	require.False(t, svc.tryGeminiCodeAssistApplyModelRateLimit(context.Background(), account, body))
+	require.False(t, svc.tryGeminiCodeAssistApplyModelRateLimit(context.Background(), account, body, ""))
+	require.Empty(t, repo.modelRateLimitCalls)
+}
+
+func TestTryGeminiCodeAssistApplyModelRateLimit_UsesFallbackModelForModelScoped429(t *testing.T) {
+	repo := &stubGeminiTKAccountRepo{}
+	svc := &GeminiMessagesCompatService{accountRepo: repo}
+	account := newGeminiCodeAssistAccount(77)
+
+	body := []byte(`{
+		"error": {
+			"status": "RESOURCE_EXHAUSTED",
+			"details": [
+				{
+					"@type": "type.googleapis.com/google.rpc.ErrorInfo",
+					"reason": "MODEL_CAPACITY_EXHAUSTED"
+				}
+			]
+		}
+	}`)
+
+	require.True(t, svc.tryGeminiCodeAssistApplyModelRateLimit(context.Background(), account, body, "gemini-3.1-pro-preview"))
+	require.Empty(t, repo.rateCalls)
+	require.Len(t, repo.modelRateLimitCalls, 1)
+	require.Equal(t, "gemini-3.1-pro-preview", repo.modelRateLimitCalls[0].modelKey)
+}
+
+func TestTryGeminiCodeAssistApplyModelRateLimit_DoesNotUseFallbackForAccountWide429(t *testing.T) {
+	repo := &stubGeminiTKAccountRepo{}
+	svc := &GeminiMessagesCompatService{accountRepo: repo}
+	account := newGeminiCodeAssistAccount(78)
+
+	body := []byte(`{
+		"error": {
+			"code": 429,
+			"status": "RESOURCE_EXHAUSTED",
+			"message": "Daily quota exceeded for project tk-test"
+		}
+	}`)
+
+	require.False(t, svc.tryGeminiCodeAssistApplyModelRateLimit(context.Background(), account, body, "gemini-3.1-pro-preview"))
 	require.Empty(t, repo.modelRateLimitCalls)
 }
 
@@ -205,7 +245,7 @@ func TestTryGeminiCodeAssistApplyModelRateLimit_RespectsParsedRetryDelay(t *test
 	}`)
 
 	before := time.Now()
-	require.True(t, svc.tryGeminiCodeAssistApplyModelRateLimit(context.Background(), account, body))
+	require.True(t, svc.tryGeminiCodeAssistApplyModelRateLimit(context.Background(), account, body, ""))
 	require.Len(t, repo.modelRateLimitCalls, 1)
 	resetAt := repo.modelRateLimitCalls[0].resetAt
 	// 30s ± clock drift (allow up to 5s slack).
@@ -236,9 +276,23 @@ func TestHandleGeminiUpstreamError_CodeAssist429RoutesToPerModel(t *testing.T) {
 		}
 	}`)
 
-	svc.handleGeminiUpstreamError(context.Background(), account, http.StatusTooManyRequests, http.Header{}, body)
+	svc.handleGeminiUpstreamError(context.Background(), account, http.StatusTooManyRequests, http.Header{}, body, "")
 
 	require.Empty(t, repo.rateCalls, "Code Assist 429 with model metadata must NOT set account-level rate limit")
+	require.Len(t, repo.modelRateLimitCalls, 1)
+	require.Equal(t, "gemini-3.1-pro-preview", repo.modelRateLimitCalls[0].modelKey)
+}
+
+func TestHandleGeminiUpstreamError_CodeAssist429FallbackModelRoutesToPerModel(t *testing.T) {
+	repo := &stubGeminiTKAccountRepo{}
+	svc := &GeminiMessagesCompatService{accountRepo: repo}
+	account := newGeminiCodeAssistAccount(125)
+
+	body := []byte(`{"error":{"code":429,"status":"RESOURCE_EXHAUSTED","details":[{"@type":"type.googleapis.com/google.rpc.ErrorInfo","reason":"MODEL_CAPACITY_EXHAUSTED"}]}}`)
+
+	svc.handleGeminiUpstreamError(context.Background(), account, http.StatusTooManyRequests, http.Header{}, body, "gemini-3.1-pro-preview")
+
+	require.Empty(t, repo.rateCalls, "model-scoped fallback must not set account-level rate limit")
 	require.Len(t, repo.modelRateLimitCalls, 1)
 	require.Equal(t, "gemini-3.1-pro-preview", repo.modelRateLimitCalls[0].modelKey)
 }
@@ -253,7 +307,7 @@ func TestHandleGeminiUpstreamError_CodeAssist429AccountWideStillFalls(t *testing
 
 	body := []byte(`{"error":{"code":429,"status":"RESOURCE_EXHAUSTED","message":"Quota exceeded"}}`)
 
-	svc.handleGeminiUpstreamError(context.Background(), account, http.StatusTooManyRequests, http.Header{}, body)
+	svc.handleGeminiUpstreamError(context.Background(), account, http.StatusTooManyRequests, http.Header{}, body, "")
 
 	require.Empty(t, repo.modelRateLimitCalls, "no per-model signal → no per-model write")
 	require.Len(t, repo.rateCalls, 1, "account-level fallback must still fire")

--- a/backend/internal/service/model_rate_limit.go
+++ b/backend/internal/service/model_rate_limit.go
@@ -4,6 +4,8 @@ import (
 	"context"
 	"strings"
 	"time"
+
+	"github.com/Wei-Shaw/sub2api/internal/pkg/ctxkey"
 )
 
 const modelRateLimitsKey = "model_rate_limits"
@@ -35,6 +37,8 @@ func (a *Account) isModelRateLimitedWithContext(ctx context.Context, requestedMo
 	modelKey := a.GetMappedModel(requestedModel)
 	if a.Platform == PlatformAntigravity {
 		modelKey = resolveFinalAntigravityModelKey(ctx, a, requestedModel)
+	} else if a.Platform == PlatformGemini {
+		modelKey = resolveFinalGeminiModelKey(ctx, requestedModel)
 	}
 	modelKey = strings.TrimSpace(modelKey)
 	if modelKey == "" {
@@ -57,6 +61,8 @@ func (a *Account) GetModelRateLimitRemainingTimeWithContext(ctx context.Context,
 	modelKey := a.GetMappedModel(requestedModel)
 	if a.Platform == PlatformAntigravity {
 		modelKey = resolveFinalAntigravityModelKey(ctx, a, requestedModel)
+	} else if a.Platform == PlatformGemini {
+		modelKey = resolveFinalGeminiModelKey(ctx, requestedModel)
 	}
 	modelKey = strings.TrimSpace(modelKey)
 	if modelKey == "" {
@@ -73,6 +79,21 @@ func resolveFinalAntigravityModelKey(ctx context.Context, account *Account, requ
 	// thinking 会影响 Antigravity 最终模型名（例如 claude-sonnet-4-5 -> claude-sonnet-4-5-thinking）
 	if enabled, ok := ThinkingEnabledFromContext(ctx); ok {
 		modelKey = applyThinkingModelSuffix(modelKey, enabled)
+	}
+	return modelKey
+}
+
+func resolveFinalGeminiModelKey(ctx context.Context, requestedModel string) string {
+	modelKey := strings.TrimSpace(requestedModel)
+	if modelKey == "" {
+		return ""
+	}
+	group, ok := ctx.Value(ctxkey.Group).(*Group)
+	if !ok || !IsGroupContextValid(group) || group.Platform != PlatformGemini {
+		return modelKey
+	}
+	if mapped := group.TKResolveGeminiDispatchModel(modelKey); mapped != "" {
+		return mapped
 	}
 	return modelKey
 }

--- a/backend/internal/service/model_rate_limit_test.go
+++ b/backend/internal/service/model_rate_limit_test.go
@@ -177,6 +177,39 @@ func TestIsModelRateLimited(t *testing.T) {
 	}
 }
 
+func TestIsModelRateLimited_GeminiDispatchMappingAffectsModelKey(t *testing.T) {
+	now := time.Now()
+	future := now.Add(10 * time.Minute).Format(time.RFC3339)
+
+	account := &Account{
+		Platform: PlatformGemini,
+		Extra: map[string]any{
+			modelRateLimitsKey: map[string]any{
+				"gemini-3.1-pro-preview": map[string]any{
+					"rate_limit_reset_at": future,
+				},
+			},
+		},
+	}
+	group := &Group{
+		ID:       8,
+		Platform: PlatformGemini,
+		Status:   StatusActive,
+		Hydrated: true,
+		MessagesDispatchModelConfig: OpenAIMessagesDispatchModelConfig{
+			OpusMappedModel: "gemini-3.1-pro-preview",
+		},
+	}
+	ctx := context.WithValue(context.Background(), ctxkey.Group, group)
+
+	if !account.isModelRateLimitedWithContext(ctx, "claude-opus-4-7") {
+		t.Errorf("expected Gemini dispatch mapping to hit upstream model rate limit")
+	}
+	if account.isModelRateLimitedWithContext(context.Background(), "claude-opus-4-7") {
+		t.Errorf("expected no hit without Gemini group context")
+	}
+}
+
 func TestIsModelRateLimited_Antigravity_ThinkingAffectsModelKey(t *testing.T) {
 	now := time.Now()
 	future := now.Add(10 * time.Minute).Format(time.RFC3339)

--- a/scripts/check-gateway-tk-sentinels.py
+++ b/scripts/check-gateway-tk-sentinels.py
@@ -1,0 +1,128 @@
+#!/usr/bin/env python3
+"""
+check-gateway-tk-sentinels.py — verify TokenKey gateway/service hotspot hooks.
+
+Reads `scripts/gateway-tk-sentinels.json` and for each entry verifies:
+
+  1. The file at `path` exists.
+  2. Every literal string in `must_contain` appears at least once in the file.
+
+Exit codes:
+  0  — all sentinels intact.
+  1  — at least one sentinel missing or has lost a required symbol.
+  2  — registry file missing or malformed.
+"""
+from __future__ import annotations
+
+import argparse
+import json
+import sys
+from pathlib import Path
+
+REPO_ROOT = Path(__file__).resolve().parent.parent
+REGISTRY_PATH = REPO_ROOT / "scripts" / "gateway-tk-sentinels.json"
+
+
+def load_registry() -> dict:
+    if not REGISTRY_PATH.is_file():
+        print(
+            f"FATAL: registry file not found: {REGISTRY_PATH.relative_to(REPO_ROOT)}",
+            file=sys.stderr,
+        )
+        sys.exit(2)
+    try:
+        with REGISTRY_PATH.open("r", encoding="utf-8") as f:
+            data = json.load(f)
+    except json.JSONDecodeError as exc:
+        print(f"FATAL: registry file is not valid JSON: {exc}", file=sys.stderr)
+        sys.exit(2)
+    if "sentinels" not in data or not isinstance(data["sentinels"], list):
+        print("FATAL: registry missing 'sentinels' array.", file=sys.stderr)
+        sys.exit(2)
+    return data
+
+
+def check_sentinel(entry: dict) -> tuple[bool, list[str]]:
+    path_str = entry.get("path")
+    if not path_str:
+        return False, ["entry missing 'path'"]
+    file_path = REPO_ROOT / path_str
+    if not file_path.is_file():
+        return False, [f"file missing: {path_str}"]
+    must_contain = entry.get("must_contain") or []
+    if not must_contain:
+        return True, []
+    try:
+        content = file_path.read_text(encoding="utf-8", errors="replace")
+    except OSError as exc:
+        return False, [f"cannot read {path_str}: {exc}"]
+    failures: list[str] = []
+    for needle in must_contain:
+        if needle not in content:
+            failures.append(f"missing literal `{needle}` in {path_str}")
+    return (len(failures) == 0), failures
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("--quiet", action="store_true", help="only print failures")
+    parser.add_argument("--json", action="store_true", help="emit a machine-readable JSON report")
+    args = parser.parse_args()
+
+    registry = load_registry()
+    sentinels = registry["sentinels"]
+
+    results = []
+    fail_count = 0
+    for entry in sentinels:
+        ok, failures = check_sentinel(entry)
+        if not ok:
+            fail_count += 1
+        results.append(
+            {
+                "path": entry.get("path"),
+                "ok": ok,
+                "failures": failures,
+                "rationale": entry.get("rationale", ""),
+            }
+        )
+
+    if args.json:
+        json.dump({"total": len(sentinels), "failed": fail_count, "results": results}, sys.stdout, indent=2)
+        sys.stdout.write("\n")
+    else:
+        if not args.quiet:
+            print(
+                f"gateway TK sentinels: checking {len(sentinels)} entries from "
+                f"{REGISTRY_PATH.relative_to(REPO_ROOT)}"
+            )
+        for r in results:
+            if r["ok"]:
+                if not args.quiet:
+                    print(f"  ok: {r['path']}")
+            else:
+                print(f"  FAIL: {r['path']}")
+                for msg in r["failures"]:
+                    print(f"        - {msg}")
+                if r["rationale"]:
+                    print(f"        why it matters: {r['rationale']}")
+        if fail_count == 0:
+            if not args.quiet:
+                print(f"gateway TK sentinels: PASS ({len(sentinels)}/{len(sentinels)} intact)")
+        else:
+            print(
+                f"gateway TK sentinels: FAIL ({fail_count}/{len(sentinels)} regressed)",
+                file=sys.stderr,
+            )
+            print("  Source of truth: scripts/gateway-tk-sentinels.json", file=sys.stderr)
+            print(
+                "  If a hook was intentionally moved/renamed, update the registry "
+                "in the same commit. Do NOT silently delete entries.",
+                file=sys.stderr,
+            )
+
+    return 0 if fail_count == 0 else 1
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/scripts/gateway-tk-sentinels.json
+++ b/scripts/gateway-tk-sentinels.json
@@ -1,0 +1,31 @@
+{
+  "version": 1,
+  "rationale": "Load-bearing TokenKey gateway/service injections that intentionally live in upstream-shaped hotspot files. These touches are small and compile-clean if dropped, so upstream merges can silently revert them unless preflight and upstream-merge PR shape check their literal hooks.",
+  "sentinels": [
+    {
+      "path": "backend/internal/service/gemini_messages_compat_service.go",
+      "must_contain": ["withGeminiCodeAssistMappedModel(ctx, mappedModel)", "tryGeminiCodeAssistApplyModelRateLimit(ctx, account, body)"],
+      "rationale": "Code Assist 429 fallback-model protection depends on exactly two upstream-file hooks: forwarding stores the resolved upstream Gemini model in context, and handleGeminiUpstreamError delegates to the TK companion before account-level SetRateLimited. Dropping either hook brings back whole-account cooldowns for single-model capacity errors."
+    },
+    {
+      "path": "backend/internal/service/gemini_messages_compat_service_tk_model_rate_limit.go",
+      "must_contain": ["withGeminiCodeAssistMappedModel", "geminiCodeAssistMappedModelFromContext", "isGeminiCodeAssistModelScopedRateLimit", "SetModelRateLimit"],
+      "rationale": "TK companion that keeps Gemini Code Assist MODEL_CAPACITY_EXHAUSTED scoped to the affected upstream model, including the production case where Google omits ErrorInfo.metadata.model."
+    },
+    {
+      "path": "backend/internal/service/model_rate_limit.go",
+      "must_contain": ["resolveFinalGeminiModelKey", "TKResolveGeminiDispatchModel", "PlatformGemini"],
+      "rationale": "Scheduling must read model_rate_limits through the same Gemini group-level Claude→Gemini mapping used by forwarding; otherwise writes use gemini-* keys while subsequent /v1/messages reads probe claude-* keys."
+    },
+    {
+      "path": "backend/internal/service/model_rate_limit_test.go",
+      "must_contain": ["TestIsModelRateLimited_GeminiDispatchMappingAffectsModelKey"],
+      "rationale": "Focused regression proving Gemini dispatch mapping affects model-level rate-limit reads."
+    },
+    {
+      "path": "backend/internal/service/gemini_messages_compat_service_tk_model_rate_limit_test.go",
+      "must_contain": ["TestTryGeminiCodeAssistApplyModelRateLimit_UsesFallbackModelForModelScoped429", "TestHandleGeminiUpstreamError_CodeAssist429FallbackModelRoutesToPerModel"],
+      "rationale": "Focused regressions proving model-scoped Code Assist 429s without metadata.model do not fall back to account-level cooldown."
+    }
+  ]
+}

--- a/scripts/preflight.sh
+++ b/scripts/preflight.sh
@@ -31,6 +31,11 @@
 #        on common Vue components. Driven by `scripts/frontend-tk-sentinels.json`
 #        via `scripts/check-frontend-tk-sentinels.py`. The same script is
 #        invoked by `.github/workflows/upstream-merge-pr-shape.yml`.
+#   gateway TK sentinel registry — guards small TokenKey-only gateway/service
+#        hooks in upstream-shaped hotspot files from being silently reverted by
+#        upstream merges. Driven by `scripts/gateway-tk-sentinels.json` via
+#        `scripts/check-gateway-tk-sentinels.py`. The same script is invoked by
+#        `.github/workflows/upstream-merge-pr-shape.yml`.
 #   redaction version contract   — guards Evidence Spine contract drift:
 #        changing the default sensitive-key set in logredact must bump the
 #        outward QA `redaction_version` contract in the same commit. Driven by
@@ -278,6 +283,23 @@ elif ! python3 ./scripts/check-frontend-tk-sentinels.py --quiet; then
     errors=$((errors + 1))
 else
     echo "  ok: all frontend TK sentinels intact"
+fi
+
+# ---- sub2api: gateway TK sentinel registry ----------------------------------
+# Source of truth: scripts/gateway-tk-sentinels.json. Verifies that small
+# TokenKey-only gateway/service injections in upstream-shaped hotspot files are
+# still present after merges. These hooks compile cleanly if dropped but cause
+# production routing / rate-limit regressions later.
+echo ""
+echo "=== sub2api: gateway TK sentinel registry ==="
+if ! command -v python3 >/dev/null 2>&1; then
+    echo "  FAIL: python3 not on PATH (required to read gateway-tk-sentinels.json)"
+    errors=$((errors + 1))
+elif ! python3 ./scripts/check-gateway-tk-sentinels.py --quiet; then
+    # check-gateway-tk-sentinels.py already printed the actionable failure.
+    errors=$((errors + 1))
+else
+    echo "  ok: all gateway TK sentinels intact"
 fi
 
 # ---- sub2api: redaction version contract ------------------------------------


### PR DESCRIPTION
## Summary
- Keep Gemini Code Assist `MODEL_CAPACITY_EXHAUSTED` 429s model-scoped even when Google omits `ErrorInfo.metadata.model`, using the already-resolved upstream Gemini model as fallback.
- Make Gemini `/v1/messages` scheduling read `model_rate_limits` through the same group-level Claude→Gemini dispatch mapping used by forwarding.
- Preserve the upstream-shaped Gemini error-handler signature by moving fallback-model state into a TK companion context hook.
- Add gateway TK sentinels to local preflight and upstream-merge PR-shape CI so future upstream merges fail if these hooks are silently dropped.

## Risk
- Scoped to Gemini Code Assist OAuth 429 handling plus Gemini model-rate-limit key resolution.
- Account-wide quota errors without model-scoped ErrorInfo still fall back to account-level rate limiting.
- The upstream hot file now keeps only two small TK hooks: `withGeminiCodeAssistMappedModel(ctx, mappedModel)` and `tryGeminiCodeAssistApplyModelRateLimit(ctx, account, body)`.
- `bash scripts/check-upstream-drift.sh` reports TK is behind upstream/main by 21 commits; this incident fix ships out of order because it addresses a current prod regression and now has upstream-merge overwrite sentinels.

## Validation
- [x] `go test -tags=unit -run 'TestTryGeminiCodeAssistApplyModelRateLimit|TestHandleGeminiUpstreamError_CodeAssist429|TestExtractGeminiCodeAssistRateLimitedModel|TestIsModelRateLimited|TestGetModelRateLimitRemainingTime|TestGetRateLimitRemainingTime|TestGeminiErrorPolicy' ./internal/service/`
- [x] `go test -tags=unit ./internal/service/`
- [x] `python3 scripts/check-gateway-tk-sentinels.py`
- [x] `bash scripts/preflight.sh`
- [x] `git diff --check`
- [x] `bash scripts/check-upstream-drift.sh` (expected nonzero: upstream/main ahead by 21 commits)

🤖 Generated with [Claude Code](https://claude.com/claude-code)