### PR TITLE
feat(admin): expose messages compaction threshold settings

### DIFF
--- a/backend/internal/web/dist/frontend-source.json
+++ b/backend/internal/web/dist/frontend-source.json
@@ -1,7 +1,7 @@
 {
   "algorithm": "sha256(git-ls-files:path,size,content)",
   "file_count": 413,
-  "hash": "12e08a3e06cbbdccb2008b329952fc639222b94a13e6fa9a5aa7a4cb8067b150",
+  "hash": "791b4a0a465a7c6f0c91fa6baccc61b32247f7c9a32132c4fcbd4b3d18b371df",
   "schema": 1,
   "source": "frontend/"
 }

--- a/frontend/src/components/account/CreateAccountModal.vue
+++ b/frontend/src/components/account/CreateAccountModal.vue
@@ -2674,6 +2674,44 @@
             <Select v-model="openAICompactMode" :options="openAICompactModeOptions" />
           </div>
         </div>
+        <div class="rounded-lg border border-gray-200 p-4 dark:border-dark-600">
+          <div class="flex items-center justify-between">
+            <div>
+              <label class="input-label mb-0">{{ t('admin.accounts.openai.messagesCompactionEnabled') }}</label>
+              <p class="mt-1 text-xs text-gray-500 dark:text-gray-400">
+                {{ t('admin.accounts.openai.messagesCompactionEnabledDesc') }}
+              </p>
+            </div>
+            <button
+              type="button"
+              @click="openAIMessagesCompactionEnabled = !openAIMessagesCompactionEnabled"
+              :class="[
+                'relative inline-flex h-6 w-11 flex-shrink-0 cursor-pointer rounded-full border-2 border-transparent transition-colors duration-200 ease-in-out focus:outline-none focus:ring-2 focus:ring-primary-500 focus:ring-offset-2',
+                openAIMessagesCompactionEnabled ? 'bg-primary-600' : 'bg-gray-200 dark:bg-dark-600'
+              ]"
+            >
+              <span
+                :class="[
+                  'pointer-events-none inline-block h-5 w-5 transform rounded-full bg-white shadow ring-0 transition duration-200 ease-in-out',
+                  openAIMessagesCompactionEnabled ? 'translate-x-5' : 'translate-x-0'
+                ]"
+              />
+            </button>
+          </div>
+          <div v-if="openAIMessagesCompactionEnabled" class="mt-3">
+            <label class="input-label">{{ t('admin.accounts.openai.messagesCompactionThreshold') }}</label>
+            <input
+              v-model.number="openAIMessagesCompactionInputTokensThreshold"
+              type="number"
+              min="1"
+              step="1"
+              class="input"
+              :placeholder="t('admin.accounts.openai.messagesCompactionThresholdPlaceholder')"
+            />
+            <p class="input-hint">{{ t('admin.accounts.openai.messagesCompactionThresholdHint') }}</p>
+          </div>
+        </div>
+
         <div>
           <label class="input-label">{{ t('admin.accounts.openai.compactModelMapping') }}</label>
           <p class="input-hint">{{ t('admin.accounts.openai.compactModelMappingDesc') }}</p>
@@ -3325,6 +3363,8 @@ const interceptWarmupRequests = ref(false)
 const autoPauseOnExpired = ref(true)
 const openaiPassthroughEnabled = ref(false)
 const openAICompactMode = ref<OpenAICompactMode>('auto')
+const openAIMessagesCompactionEnabled = ref(false)
+const openAIMessagesCompactionInputTokensThreshold = ref<number | null>(null)
 const openaiOAuthResponsesWebSocketV2Mode = ref<OpenAIWSMode>(OPENAI_WS_MODE_OFF)
 const openaiAPIKeyResponsesWebSocketV2Mode = ref<OpenAIWSMode>(OPENAI_WS_MODE_OFF)
 const codexCLIOnlyEnabled = ref(false)
@@ -3420,6 +3460,29 @@ function buildAntigravityExtra(): Record<string, unknown> | undefined {
 
 const buildOpenAICompactModelMapping = () =>
   buildModelMappingObject('mapping', [], openAICompactModelMappings.value)
+
+const normalizeOpenAIMessagesCompactionThreshold = (): number | null => {
+  const value = openAIMessagesCompactionInputTokensThreshold.value
+  if (value === null || value === undefined || value === 0 || Number.isNaN(value)) {
+    return null
+  }
+  const normalized = Math.trunc(Number(value))
+  return normalized >= 1 ? normalized : null
+}
+
+const validateOpenAIMessagesCompactionForm = (): boolean => {
+  if (form.platform !== 'openai') {
+    return true
+  }
+  if (!openAIMessagesCompactionEnabled.value) {
+    return true
+  }
+  if (normalizeOpenAIMessagesCompactionThreshold() === null) {
+    appStore.showError(t('admin.accounts.openai.messagesCompactionThresholdRequired'))
+    return false
+  }
+  return true
+}
 
 const showMixedChannelWarning = ref(false)
 const mixedChannelWarningDetails = ref<{ groupName: string; currentPlatform: string; otherPlatform: string } | null>(
@@ -3737,6 +3800,8 @@ watch(
     }
     if (newPlatform !== 'openai') {
       openaiPassthroughEnabled.value = false
+      openAIMessagesCompactionEnabled.value = false
+      openAIMessagesCompactionInputTokensThreshold.value = null
       openaiOAuthResponsesWebSocketV2Mode.value = OPENAI_WS_MODE_OFF
       openaiAPIKeyResponsesWebSocketV2Mode.value = OPENAI_WS_MODE_OFF
       codexCLIOnlyEnabled.value = false
@@ -4134,6 +4199,8 @@ const resetForm = () => {
   autoPauseOnExpired.value = true
   openaiPassthroughEnabled.value = false
   openAICompactMode.value = 'auto'
+  openAIMessagesCompactionEnabled.value = false
+  openAIMessagesCompactionInputTokensThreshold.value = null
   openaiOAuthResponsesWebSocketV2Mode.value = OPENAI_WS_MODE_OFF
   openaiAPIKeyResponsesWebSocketV2Mode.value = OPENAI_WS_MODE_OFF
   codexCLIOnlyEnabled.value = false
@@ -4217,6 +4284,16 @@ const buildOpenAIExtra = (base?: Record<string, unknown>): Record<string, unknow
     extra.openai_compact_mode = openAICompactMode.value
   } else {
     delete extra.openai_compact_mode
+  }
+  if (openAIMessagesCompactionEnabled.value) {
+    const threshold = normalizeOpenAIMessagesCompactionThreshold()
+    if (threshold !== null) {
+      extra.messages_compaction_enabled = true
+      extra.messages_compaction_input_tokens_threshold = threshold
+    }
+  } else {
+    delete extra.messages_compaction_enabled
+    delete extra.messages_compaction_input_tokens_threshold
   }
 
   return Object.keys(extra).length > 0 ? extra : undefined
@@ -4340,6 +4417,9 @@ const handleSubmit = async () => {
       appStore.showError(t('admin.accounts.pleaseEnterAccountName'))
       return
     }
+    if (!validateOpenAIMessagesCompactionForm()) {
+      return
+    }
     const canContinue = await ensureAntigravityMixedChannelConfirmed(async () => {
       step.value = 2
     })
@@ -4347,6 +4427,10 @@ const handleSubmit = async () => {
       return
     }
     step.value = 2
+    return
+  }
+
+  if (!validateOpenAIMessagesCompactionForm()) {
     return
   }
 

--- a/frontend/src/components/account/EditAccountModal.vue
+++ b/frontend/src/components/account/EditAccountModal.vue
@@ -1580,6 +1580,44 @@
             {{ formatDateTime(new Date(String(account.extra.openai_compact_checked_at))) }}
           </span>
         </div>
+        <div class="rounded-lg border border-gray-200 p-4 dark:border-dark-600">
+          <div class="flex items-center justify-between">
+            <div>
+              <label class="input-label mb-0">{{ t('admin.accounts.openai.messagesCompactionEnabled') }}</label>
+              <p class="mt-1 text-xs text-gray-500 dark:text-gray-400">
+                {{ t('admin.accounts.openai.messagesCompactionEnabledDesc') }}
+              </p>
+            </div>
+            <button
+              type="button"
+              @click="openAIMessagesCompactionEnabled = !openAIMessagesCompactionEnabled"
+              :class="[
+                'relative inline-flex h-6 w-11 flex-shrink-0 cursor-pointer rounded-full border-2 border-transparent transition-colors duration-200 ease-in-out focus:outline-none focus:ring-2 focus:ring-primary-500 focus:ring-offset-2',
+                openAIMessagesCompactionEnabled ? 'bg-primary-600' : 'bg-gray-200 dark:bg-dark-600'
+              ]"
+            >
+              <span
+                :class="[
+                  'pointer-events-none inline-block h-5 w-5 transform rounded-full bg-white shadow ring-0 transition duration-200 ease-in-out',
+                  openAIMessagesCompactionEnabled ? 'translate-x-5' : 'translate-x-0'
+                ]"
+              />
+            </button>
+          </div>
+          <div v-if="openAIMessagesCompactionEnabled" class="mt-3">
+            <label class="input-label">{{ t('admin.accounts.openai.messagesCompactionThreshold') }}</label>
+            <input
+              v-model.number="openAIMessagesCompactionInputTokensThreshold"
+              type="number"
+              min="1"
+              step="1"
+              class="input"
+              :placeholder="t('admin.accounts.openai.messagesCompactionThresholdPlaceholder')"
+            />
+            <p class="input-hint">{{ t('admin.accounts.openai.messagesCompactionThresholdHint') }}</p>
+          </div>
+        </div>
+
         <div>
           <label class="input-label">{{ t('admin.accounts.openai.compactModelMapping') }}</label>
           <p class="input-hint">{{ t('admin.accounts.openai.compactModelMappingDesc') }}</p>
@@ -2337,6 +2375,8 @@ const customBaseUrl = ref('')
 // OpenAI 自动透传开关（OAuth/API Key）
 const openaiPassthroughEnabled = ref(false)
 const openAICompactMode = ref<OpenAICompactMode>('auto')
+const openAIMessagesCompactionEnabled = ref(false)
+const openAIMessagesCompactionInputTokensThreshold = ref<number | null>(null)
 const openaiOAuthResponsesWebSocketV2Mode = ref<OpenAIWSMode>(OPENAI_WS_MODE_OFF)
 const openaiAPIKeyResponsesWebSocketV2Mode = ref<OpenAIWSMode>(OPENAI_WS_MODE_OFF)
 const codexCLIOnlyEnabled = ref(false)
@@ -2395,6 +2435,30 @@ const openAICompactModeOptions = computed(() => [
   { value: 'force_on', label: t('admin.accounts.openai.compactModeForceOn') },
   { value: 'force_off', label: t('admin.accounts.openai.compactModeForceOff') }
 ])
+
+const normalizeOpenAIMessagesCompactionThreshold = (): number | null => {
+  const value = openAIMessagesCompactionInputTokensThreshold.value
+  if (value === null || value === undefined || value === 0 || Number.isNaN(value)) {
+    return null
+  }
+  const normalized = Math.trunc(Number(value))
+  return normalized >= 1 ? normalized : null
+}
+
+const validateOpenAIMessagesCompactionForm = (): boolean => {
+  if (props.account?.platform !== 'openai') {
+    return true
+  }
+  if (!openAIMessagesCompactionEnabled.value) {
+    return true
+  }
+  if (normalizeOpenAIMessagesCompactionThreshold() === null) {
+    appStore.showError(t('admin.accounts.openai.messagesCompactionThresholdRequired'))
+    return false
+  }
+  return true
+}
+
 const isOpenAIModelRestrictionDisabled = computed(() =>
   props.account?.platform === 'openai' && openaiPassthroughEnabled.value
 )
@@ -2544,6 +2608,8 @@ const syncFormFromAccount = (newAccount: Account | null) => {
   // Load OpenAI passthrough toggle (OpenAI OAuth/API Key)
   openaiPassthroughEnabled.value = false
   openAICompactMode.value = 'auto'
+  openAIMessagesCompactionEnabled.value = false
+  openAIMessagesCompactionInputTokensThreshold.value = null
   openAICompactModelMappings.value = []
   openaiOAuthResponsesWebSocketV2Mode.value = OPENAI_WS_MODE_OFF
   openaiAPIKeyResponsesWebSocketV2Mode.value = OPENAI_WS_MODE_OFF
@@ -2553,6 +2619,12 @@ const syncFormFromAccount = (newAccount: Account | null) => {
   if (newAccount.platform === 'openai' && (newAccount.type === 'oauth' || newAccount.type === 'apikey')) {
     openaiPassthroughEnabled.value = extra?.openai_passthrough === true || extra?.openai_oauth_passthrough === true
     openAICompactMode.value = (extra?.openai_compact_mode as OpenAICompactMode) || 'auto'
+    openAIMessagesCompactionEnabled.value = extra?.messages_compaction_enabled === true
+    const compactionThreshold = Number(extra?.messages_compaction_input_tokens_threshold)
+    openAIMessagesCompactionInputTokensThreshold.value =
+      Number.isFinite(compactionThreshold) && compactionThreshold >= 1
+        ? Math.trunc(compactionThreshold)
+        : null
     openaiOAuthResponsesWebSocketV2Mode.value = resolveOpenAIWSModeFromExtra(extra, {
       modeKey: 'openai_oauth_responses_websockets_v2_mode',
       enabledKey: 'openai_oauth_responses_websockets_v2_enabled',
@@ -3272,6 +3344,10 @@ const handleSubmit = async () => {
   if (!props.account) return
   const accountID = props.account.id
 
+  if (!validateOpenAIMessagesCompactionForm()) {
+    return
+  }
+
   if (form.status !== 'active' && form.status !== 'inactive' && form.status !== 'error') {
     appStore.showError(t('admin.accounts.pleaseSelectStatus'))
     return
@@ -3710,6 +3786,16 @@ const handleSubmit = async () => {
         delete newExtra.openai_compact_mode
       } else {
         newExtra.openai_compact_mode = openAICompactMode.value
+      }
+      if (openAIMessagesCompactionEnabled.value) {
+        const threshold = normalizeOpenAIMessagesCompactionThreshold()
+        if (threshold !== null) {
+          newExtra.messages_compaction_enabled = true
+          newExtra.messages_compaction_input_tokens_threshold = threshold
+        }
+      } else {
+        delete newExtra.messages_compaction_enabled
+        delete newExtra.messages_compaction_input_tokens_threshold
       }
 
       if (props.account.type === 'oauth') {

--- a/frontend/src/i18n/locales/en.ts
+++ b/frontend/src/i18n/locales/en.ts
@@ -2187,7 +2187,13 @@ export default {
         claudeModelPlaceholder: 'e.g., claude-sonnet-4-5-20250929',
         targetModel: 'Target Model',
         targetModelPlaceholder: 'e.g., gpt-5.4',
-        removeExactMapping: 'Remove Exact Mapping'
+        removeExactMapping: 'Remove Exact Mapping',
+        compactionEnabled: 'Enable auto compaction',
+        compactionEnabledHint: 'When estimated input tokens exceed the threshold, /v1/messages compaction is applied automatically.',
+        compactionThreshold: 'Input token threshold',
+        compactionThresholdPlaceholder: 'e.g., 900000',
+        compactionThresholdHint: 'Must be >= 1. Choose a value based on model context window.',
+        compactionThresholdRequired: 'Please enter a valid compaction threshold (>= 1)'
       },
       invalidRequestFallback: {
         title: 'Invalid Request Fallback Group',
@@ -3033,6 +3039,13 @@ export default {
         compactMode: 'Compact mode',
         compactModeDesc:
           'Controls how this account participates in /responses/compact routing. Auto follows probe results, Force On always allows, Force Off always excludes.',
+        messagesCompactionEnabled: 'Enable account-level /v1/messages auto compaction',
+        messagesCompactionEnabledDesc:
+          'When enabled, this account uses its own input token compaction threshold; when disabled, group policy applies.',
+        messagesCompactionThreshold: 'Account input token threshold',
+        messagesCompactionThresholdPlaceholder: 'e.g., 900000',
+        messagesCompactionThresholdHint: 'Must be >= 1. Compaction runs automatically when threshold is exceeded.',
+        messagesCompactionThresholdRequired: 'Please enter a valid account compaction threshold (>= 1)',
         compactModeAuto: 'Auto',
         compactModeForceOn: 'Force On',
         compactModeForceOff: 'Force Off',

--- a/frontend/src/i18n/locales/zh.ts
+++ b/frontend/src/i18n/locales/zh.ts
@@ -2270,7 +2270,13 @@ export default {
         claudeModelPlaceholder: '例如: claude-sonnet-4-5-20250929',
         targetModel: '目标模型',
         targetModelPlaceholder: '例如: gpt-5.4',
-        removeExactMapping: '删除精确映射'
+        removeExactMapping: '删除精确映射',
+        compactionEnabled: '启用自动压缩',
+        compactionEnabledHint: '输入 token 估算超过阈值时，自动触发 /v1/messages 压缩。',
+        compactionThreshold: '输入 token 阈值',
+        compactionThresholdPlaceholder: '例如: 900000',
+        compactionThresholdHint: '必须大于等于 1，建议按模型上下文窗口设置。',
+        compactionThresholdRequired: '请填写有效的压缩阈值（>= 1）'
       },
       invalidRequestFallback: {
         title: '无效请求兜底分组',
@@ -3177,6 +3183,13 @@ export default {
         compactMode: 'Compact 模式',
         compactModeDesc:
           '控制本账号在 /responses/compact 调度中的参与方式。Auto 跟随探测结果，Force On 强制允许，Force Off 强制排除。',
+        messagesCompactionEnabled: '启用账号级 /v1/messages 自动压缩',
+        messagesCompactionEnabledDesc:
+          '开启后，当前账号可单独设置输入 token 压缩阈值；关闭则回退到分组策略。',
+        messagesCompactionThreshold: '账号级输入 token 阈值',
+        messagesCompactionThresholdPlaceholder: '例如: 900000',
+        messagesCompactionThresholdHint: '必须大于等于 1，超过阈值后自动执行压缩。',
+        messagesCompactionThresholdRequired: '请填写有效的账号级压缩阈值（>= 1）',
         compactModeAuto: '自动',
         compactModeForceOn: '强制开启',
         compactModeForceOff: '强制关闭',

--- a/frontend/src/types/index.ts
+++ b/frontend/src/types/index.ts
@@ -513,6 +513,8 @@ export interface Group {
   allow_messages_dispatch?: boolean
   default_mapped_model?: string
   messages_dispatch_model_config?: OpenAIMessagesDispatchModelConfig
+  messages_compaction_enabled?: boolean | null
+  messages_compaction_input_tokens_threshold?: number | null
   require_oauth_only: boolean
   require_privacy_set: boolean
   // 上游 prompt cache 粘性路由策略 (auto | passthrough | off)
@@ -625,6 +627,8 @@ export interface CreateGroupRequest {
   fallback_group_id_on_invalid_request?: number | null
   mcp_xml_inject?: boolean
   supported_model_scopes?: string[]
+  messages_compaction_enabled?: boolean | null
+  messages_compaction_input_tokens_threshold?: number | null
   require_oauth_only?: boolean
   require_privacy_set?: boolean
   // 上游 prompt cache 粘性路由策略 (auto | passthrough | off)
@@ -655,6 +659,8 @@ export interface UpdateGroupRequest {
   fallback_group_id_on_invalid_request?: number | null
   mcp_xml_inject?: boolean
   supported_model_scopes?: string[]
+  messages_compaction_enabled?: boolean | null
+  messages_compaction_input_tokens_threshold?: number | null
   require_oauth_only?: boolean
   require_privacy_set?: boolean
   sticky_routing_mode?: 'auto' | 'passthrough' | 'off'

--- a/frontend/src/views/admin/GroupsView.vue
+++ b/frontend/src/views/admin/GroupsView.vue
@@ -1003,6 +1003,59 @@
             {{ t("admin.groups.openaiMessages.allowDispatchHint") }}
           </p>
 
+          <div class="mt-4 rounded-xl border border-gray-200 p-4 dark:border-dark-600">
+            <div class="flex items-center justify-between">
+              <div>
+                <label class="text-sm text-gray-600 dark:text-gray-400">{{
+                  t("admin.groups.openaiMessages.compactionEnabled")
+                }}</label>
+                <p class="text-xs text-gray-500 dark:text-gray-400 mt-1">
+                  {{ t("admin.groups.openaiMessages.compactionEnabledHint") }}
+                </p>
+              </div>
+              <button
+                type="button"
+                @click="
+                  createForm.messages_compaction_enabled =
+                    !createForm.messages_compaction_enabled
+                "
+                class="relative inline-flex h-6 w-12 flex-shrink-0 cursor-pointer rounded-full border-2 border-transparent transition-colors duration-200 ease-in-out focus:outline-none"
+                :class="
+                  createForm.messages_compaction_enabled
+                    ? 'bg-primary-500'
+                    : 'bg-gray-300 dark:bg-dark-600'
+                "
+              >
+                <span
+                  class="pointer-events-none inline-block h-5 w-5 transform rounded-full bg-white shadow ring-0 transition duration-200 ease-in-out"
+                  :class="
+                    createForm.messages_compaction_enabled
+                      ? 'translate-x-6'
+                      : 'translate-x-1'
+                  "
+                />
+              </button>
+            </div>
+            <div v-if="createForm.messages_compaction_enabled" class="mt-3">
+              <label class="input-label">{{
+                t("admin.groups.openaiMessages.compactionThreshold")
+              }}</label>
+              <input
+                v-model.number="createForm.messages_compaction_input_tokens_threshold"
+                type="number"
+                min="1"
+                step="1"
+                class="input"
+                :placeholder="
+                  t('admin.groups.openaiMessages.compactionThresholdPlaceholder')
+                "
+              />
+              <p class="input-hint">
+                {{ t("admin.groups.openaiMessages.compactionThresholdHint") }}
+              </p>
+            </div>
+          </div>
+
           <div v-if="createForm.allow_messages_dispatch" class="mt-3">
             <div
               class="relative overflow-hidden rounded-xl border border-gray-200 bg-white shadow-sm dark:border-dark-600 dark:bg-dark-800"
@@ -2201,6 +2254,59 @@
             {{ t("admin.groups.openaiMessages.allowDispatchHint") }}
           </p>
 
+          <div class="mt-4 rounded-xl border border-gray-200 p-4 dark:border-dark-600">
+            <div class="flex items-center justify-between">
+              <div>
+                <label class="text-sm text-gray-600 dark:text-gray-400">{{
+                  t("admin.groups.openaiMessages.compactionEnabled")
+                }}</label>
+                <p class="text-xs text-gray-500 dark:text-gray-400 mt-1">
+                  {{ t("admin.groups.openaiMessages.compactionEnabledHint") }}
+                </p>
+              </div>
+              <button
+                type="button"
+                @click="
+                  editForm.messages_compaction_enabled =
+                    !editForm.messages_compaction_enabled
+                "
+                class="relative inline-flex h-6 w-12 flex-shrink-0 cursor-pointer rounded-full border-2 border-transparent transition-colors duration-200 ease-in-out focus:outline-none"
+                :class="
+                  editForm.messages_compaction_enabled
+                    ? 'bg-primary-500'
+                    : 'bg-gray-300 dark:bg-dark-600'
+                "
+              >
+                <span
+                  class="pointer-events-none inline-block h-5 w-5 transform rounded-full bg-white shadow ring-0 transition duration-200 ease-in-out"
+                  :class="
+                    editForm.messages_compaction_enabled
+                      ? 'translate-x-6'
+                      : 'translate-x-1'
+                  "
+                />
+              </button>
+            </div>
+            <div v-if="editForm.messages_compaction_enabled" class="mt-3">
+              <label class="input-label">{{
+                t("admin.groups.openaiMessages.compactionThreshold")
+              }}</label>
+              <input
+                v-model.number="editForm.messages_compaction_input_tokens_threshold"
+                type="number"
+                min="1"
+                step="1"
+                class="input"
+                :placeholder="
+                  t('admin.groups.openaiMessages.compactionThresholdPlaceholder')
+                "
+              />
+              <p class="input-hint">
+                {{ t("admin.groups.openaiMessages.compactionThresholdHint") }}
+              </p>
+            </div>
+          </div>
+
           <div v-if="editForm.allow_messages_dispatch" class="mt-3">
             <div
               class="relative overflow-hidden rounded-xl border border-gray-200 bg-white shadow-sm dark:border-dark-600 dark:bg-dark-800"
@@ -3166,6 +3272,8 @@ const createForm = reactive({
   sonnet_mapped_model: createMessagesDispatchDefaults.sonnet_mapped_model,
   haiku_mapped_model: createMessagesDispatchDefaults.haiku_mapped_model,
   exact_model_mappings: [] as MessagesDispatchMappingRow[],
+  messages_compaction_enabled: false,
+  messages_compaction_input_tokens_threshold: null as number | null,
   // 账号过滤控制（OpenAI/Antigravity 平台）
   require_oauth_only: false,
   require_privacy_set: false,
@@ -3455,6 +3563,8 @@ const editForm = reactive({
   sonnet_mapped_model: editMessagesDispatchDefaults.sonnet_mapped_model,
   haiku_mapped_model: editMessagesDispatchDefaults.haiku_mapped_model,
   exact_model_mappings: [] as MessagesDispatchMappingRow[],
+  messages_compaction_enabled: false,
+  messages_compaction_input_tokens_threshold: null as number | null,
   // 账号过滤控制（OpenAI/Antigravity 平台）
   require_oauth_only: false,
   require_privacy_set: false,
@@ -3724,6 +3834,20 @@ const normalizeOptionalLimit = (
   return Number.isFinite(value) && value > 0 ? value : null;
 };
 
+const normalizeCompactionThreshold = (
+  value: number | string | null | undefined,
+): number | null => {
+  if (value === null || value === undefined || value === "") {
+    return null;
+  }
+  const parsed = Number(value);
+  if (!Number.isFinite(parsed)) {
+    return null;
+  }
+  const normalized = Math.trunc(parsed);
+  return normalized >= 1 ? normalized : null;
+};
+
 const normalizeImageRateMultiplier = (
   value: number | string | null | undefined,
 ): number => {
@@ -3742,6 +3866,14 @@ const handleCreateGroup = async () => {
   submitting.value = true;
   try {
     // 构建请求数据，包含模型路由配置
+    const compactionThreshold = normalizeCompactionThreshold(
+      createForm.messages_compaction_input_tokens_threshold,
+    );
+    if (createForm.messages_compaction_enabled && compactionThreshold === null) {
+      appStore.showError(t("admin.groups.openaiMessages.compactionThresholdRequired"));
+      return;
+    }
+
     const requestData = {
       ...createForm,
       daily_limit_usd: normalizeOptionalLimit(
@@ -3766,6 +3898,14 @@ const handleCreateGroup = async () => {
               exact_model_mappings: createForm.exact_model_mappings,
             })
           : undefined,
+      messages_compaction_enabled: hasMessagesDispatchConfig(createForm.platform)
+        ? createForm.messages_compaction_enabled
+        : null,
+      messages_compaction_input_tokens_threshold:
+        hasMessagesDispatchConfig(createForm.platform) &&
+        createForm.messages_compaction_enabled
+          ? compactionThreshold
+          : null,
     };
     // v-model.number 清空输入框时产生 ""，转为 null 让后端设为无限制
     const emptyToNull = (v: any) => (v === "" ? null : v);
@@ -3827,6 +3967,10 @@ const handleEdit = async (group: AdminGroup) => {
   editForm.haiku_mapped_model = messagesDispatchFormState.haiku_mapped_model;
   editForm.exact_model_mappings =
     messagesDispatchFormState.exact_model_mappings;
+  editForm.messages_compaction_enabled =
+    group.messages_compaction_enabled ?? false;
+  editForm.messages_compaction_input_tokens_threshold =
+    group.messages_compaction_input_tokens_threshold ?? null;
   editForm.require_oauth_only = group.require_oauth_only ?? false;
   editForm.require_privacy_set = group.require_privacy_set ?? false;
   editForm.model_routing_enabled = group.model_routing_enabled || false;
@@ -3868,6 +4012,14 @@ const handleUpdateGroup = async () => {
   submitting.value = true;
   try {
     // 转换 fallback_group_id: null -> 0 (后端使用 0 表示清除)
+    const compactionThreshold = normalizeCompactionThreshold(
+      editForm.messages_compaction_input_tokens_threshold,
+    );
+    if (editForm.messages_compaction_enabled && compactionThreshold === null) {
+      appStore.showError(t("admin.groups.openaiMessages.compactionThresholdRequired"));
+      return;
+    }
+
     const payload = {
       ...editForm,
       daily_limit_usd: normalizeOptionalLimit(
@@ -3898,6 +4050,14 @@ const handleUpdateGroup = async () => {
               exact_model_mappings: editForm.exact_model_mappings,
             })
           : undefined,
+      messages_compaction_enabled: hasMessagesDispatchConfig(editForm.platform)
+        ? editForm.messages_compaction_enabled
+        : null,
+      messages_compaction_input_tokens_threshold:
+        hasMessagesDispatchConfig(editForm.platform) &&
+        editForm.messages_compaction_enabled
+          ? compactionThreshold
+          : null,
     };
     // v-model.number 清空输入框时产生 ""，转为 null 让后端设为无限制
     const emptyToNull = (v: any) => (v === "" ? null : v);

--- a/frontend/src/views/admin/groupsMessagesDispatch.ts
+++ b/frontend/src/views/admin/groupsMessagesDispatch.ts
@@ -11,6 +11,8 @@ export interface MessagesDispatchFormState {
   sonnet_mapped_model: string;
   haiku_mapped_model: string;
   exact_model_mappings: MessagesDispatchMappingRow[];
+  messages_compaction_enabled?: boolean;
+  messages_compaction_input_tokens_threshold?: number | null;
 }
 
 export function createDefaultMessagesDispatchFormState(): MessagesDispatchFormState {
@@ -20,6 +22,8 @@ export function createDefaultMessagesDispatchFormState(): MessagesDispatchFormSt
     sonnet_mapped_model: "gpt-5.3-codex",
     haiku_mapped_model: "gpt-5.4-mini",
     exact_model_mappings: [],
+    messages_compaction_enabled: false,
+    messages_compaction_input_tokens_threshold: null,
   };
 }
 
@@ -40,6 +44,9 @@ export function messagesDispatchConfigToFormState(
     haiku_mapped_model:
       config?.haiku_mapped_model?.trim() || defaults.haiku_mapped_model,
     exact_model_mappings: exactMappings,
+    messages_compaction_enabled: defaults.messages_compaction_enabled,
+    messages_compaction_input_tokens_threshold:
+      defaults.messages_compaction_input_tokens_threshold,
   };
 }
 
@@ -69,4 +76,7 @@ export function resetMessagesDispatchFormState(
   target.sonnet_mapped_model = defaults.sonnet_mapped_model;
   target.haiku_mapped_model = defaults.haiku_mapped_model;
   target.exact_model_mappings = [];
+  target.messages_compaction_enabled = defaults.messages_compaction_enabled;
+  target.messages_compaction_input_tokens_threshold =
+    defaults.messages_compaction_input_tokens_threshold;
 }


### PR DESCRIPTION
## Summary
- add group-level OpenAI messages compaction toggle + threshold input in Groups admin create/edit forms
- add account-level OpenAI messages compaction toggle + threshold input in account create/edit modals
- wire payload/type/i18n updates so backend `messages_compaction_enabled` and `messages_compaction_input_tokens_threshold` can be configured from admin UI

## Risk
- low: frontend-only admin form wiring and validation changes; no backend behavior change

## Validation
- [x] pnpm -C frontend lint:check (existing unrelated warning remains in PlaygroundPrototype.spec.ts)
- [x] pnpm -C frontend typecheck
- [x] pnpm --dir frontend run build

🤖 Generated with [Claude Code](https://claude.com/claude-code)