### PR TITLE
fix(workflow): prevent false contract failures in upstream-merge checks

### DIFF
--- a/.github/workflows/upstream-merge-agent-daily.yml
+++ b/.github/workflows/upstream-merge-agent-daily.yml
@@ -224,6 +224,9 @@ jobs:
         run: |
           set -euo pipefail
           git fetch origin main
+          if ! git remote get-url upstream >/dev/null 2>&1; then
+            git remote add upstream "https://github.com/Wei-Shaw/sub2api.git"
+          fi
           git fetch upstream main
 
           contract_ok=false
@@ -257,7 +260,7 @@ jobs:
           } > /tmp/upstream-merge-contract-attempt1.txt
 
       - name: Build retry prompt for unresolved merge
-        if: steps.contract_after_attempt_1.outputs.contract_ok != 'true'
+        if: always() && (steps.contract_after_attempt_1.outcome != 'success' || steps.contract_after_attempt_1.outputs.contract_ok != 'true')
         env:
           TARGET_BRANCH: ${{ steps.upstream_pr.outputs.branch }}
           CONTRACT_REASON: ${{ steps.contract_after_attempt_1.outputs.reason }}
@@ -285,7 +288,7 @@ jobs:
           EOF
 
       - name: Run Claude upstream merge agent (attempt 2)
-        if: steps.contract_after_attempt_1.outputs.contract_ok != 'true'
+        if: always() && (steps.contract_after_attempt_1.outcome != 'success' || steps.contract_after_attempt_1.outputs.contract_ok != 'true')
         id: agent_attempt_2
         env:
           ANTHROPIC_AUTH_TOKEN: ${{ secrets.ANTHROPIC_AUTH_TOKEN }}
@@ -323,6 +326,9 @@ jobs:
         run: |
           set -euo pipefail
           git fetch origin main
+          if ! git remote get-url upstream >/dev/null 2>&1; then
+            git remote add upstream "https://github.com/Wei-Shaw/sub2api.git"
+          fi
           git fetch upstream main
 
           contract_ok=false


### PR DESCRIPTION
## Summary
- add an upstream-remote guard in both contract validation steps so they can fetch `upstream/main` even when the remote was not created earlier in the run
- widen attempt-2 trigger conditions to include `contract_after_attempt_1` step failures, not only the `contract_ok != true` output path
- keep the existing output-contract gate unchanged so runs still fail when neither PR output nor no-drift proof is produced

## Test plan
- [x] `bash scripts/preflight.sh`
- [ ] Run `upstream-merge-agent-daily.yml` via `workflow_dispatch` on `main`
- [ ] Confirm that missing `upstream` remote no longer causes contract-step hard failure before retry path executes

🤖 Generated with [Claude Code](https://claude.com/claude-code)