### PR TITLE
fix(workflow): contract gates preflight + PR body audit, broaden auto-retry

### DIFF
--- a/.github/workflows/upstream-merge-agent-daily.yml
+++ b/.github/workflows/upstream-merge-agent-daily.yml
@@ -163,6 +163,11 @@ jobs:
           set -euo pipefail
           if bash "$STATE_HELPER" restore-state "$RESUME_RUN_ID"; then
             echo "Restored checkpoint from run $RESUME_RUN_ID"
+            # Freeze a copy of the prior run's checkpoint so the auto-retry
+            # progress gate can compare the previous run's preflight error
+            # count against this run's. Without this snapshot, the live state
+            # file gets clobbered as this run progresses.
+            cp /tmp/upstream-merge-state.json /tmp/upstream-merge-prior-state.json
           else
             echo "::warning::No checkpoint artifact found for run $RESUME_RUN_ID; continuing from fresh INIT state"
           fi
@@ -433,6 +438,91 @@ jobs:
           echo "exit_code=$exit_code" >> "$GITHUB_OUTPUT"
           cat /tmp/upstream-merge-agent-output-attempt2.txt >> /tmp/upstream-merge-agent-output.txt
 
+      - name: Verify preflight on target branch (final)
+        id: preflight_final
+        # Skill §4 requires preflight green before the PR is considered done.
+        # We run it here against the agent's pushed branch (not local HEAD) so
+        # contract-eval reflects what review/CI will actually see.
+        if: always() && steps.drift_check.outputs.status == 'need_merge'
+        env:
+          GH_TOKEN: ${{ secrets.UPSTREAM_MERGE_GH_TOKEN }}
+          TARGET_BRANCH: ${{ steps.upstream_pr.outputs.branch }}
+        run: |
+          set -euo pipefail
+          set +e
+          # Fetch the agent-pushed branch. If this fails the agent never got
+          # far enough to push, and the contract gate will surface that
+          # separately as missing-PR; we just record skip here.
+          if ! git fetch origin "$TARGET_BRANCH" 2>/tmp/upstream-merge-preflight-fetch.log; then
+            echo "preflight_ok=skip" >> "$GITHUB_OUTPUT"
+            echo "error_count=-1" >> "$GITHUB_OUTPUT"
+            echo "skip_reason=remote_branch_missing" >> "$GITHUB_OUTPUT"
+            bash "$STATE_HELPER" update-preflight-checkpoint skip -1 remote_branch_missing || true
+            exit 0
+          fi
+
+          # Mirror what review/CI will execute against. -B reset is destructive
+          # to local working state, but we only ever touch state read-only after
+          # this step, so it's safe.
+          git checkout -B preflight-target FETCH_HEAD
+          # Submodule pointer may have moved across the merge; re-init so
+          # dev-rules/templates/preflight.sh exists at the right SHA.
+          git submodule update --init --recursive 2>/dev/null || true
+
+          bash scripts/preflight.sh > /tmp/upstream-merge-preflight.log 2>&1
+          rc=$?
+          set -e
+
+          if [ "$rc" -eq 0 ]; then
+            echo "preflight_ok=true" >> "$GITHUB_OUTPUT"
+            echo "error_count=0" >> "$GITHUB_OUTPUT"
+            bash "$STATE_HELPER" update-preflight-checkpoint true 0 ok || true
+          else
+            # Format from scripts/preflight.sh tail line:
+            #   === preflight (with sub2api checks): FAIL (N check(s) failed) ===
+            count="$(grep -oE '[0-9]+ check\(s\) failed' /tmp/upstream-merge-preflight.log | head -1 | grep -oE '^[0-9]+' || echo 1)"
+            echo "preflight_ok=false" >> "$GITHUB_OUTPUT"
+            echo "error_count=$count" >> "$GITHUB_OUTPUT"
+            bash "$STATE_HELPER" update-preflight-checkpoint false "$count" "preflight failed with $count check(s)" || true
+            # Surface a compact failure block in the workflow log so reviewers
+            # don't have to download the artifact for the common case.
+            echo "::group::preflight tail (last 80 lines)"
+            tail -n 80 /tmp/upstream-merge-preflight.log || true
+            echo "::endgroup::"
+          fi
+
+      - name: Audit PR body for upstream cadence (final)
+        id: pr_body_audit_final
+        # Skill §5 mandates the PR body contains literal `upstream/main..HEAD`.
+        # The shape workflow enforces it at PR-merge time, but we also gate it
+        # in the agent contract so the daily run flips to red on its own
+        # instead of declaring success and letting branch protection catch it.
+        if: always() && steps.drift_check.outputs.status == 'need_merge'
+        env:
+          GH_TOKEN: ${{ secrets.UPSTREAM_MERGE_GH_TOKEN }}
+          TARGET_BRANCH: ${{ steps.upstream_pr.outputs.branch }}
+          KNOWN_PR_NUMBER: ${{ steps.upstream_pr.outputs.number }}
+        run: |
+          set -euo pipefail
+          pr_number="${KNOWN_PR_NUMBER:-}"
+          if [ -z "$pr_number" ]; then
+            pr_number="$(gh pr list --state open --base main --head "$TARGET_BRANCH" --json number --jq '.[0].number // empty' || true)"
+          fi
+
+          if [ -z "$pr_number" ]; then
+            echo "pr_body_audit_ok=skip" >> "$GITHUB_OUTPUT"
+            echo "skip_reason=no_pr" >> "$GITHUB_OUTPUT"
+            exit 0
+          fi
+
+          body="$(gh pr view "$pr_number" --json body --jq '.body' || echo '')"
+          if printf '%s' "$body" | grep -qF 'upstream/main..HEAD'; then
+            echo "pr_body_audit_ok=true" >> "$GITHUB_OUTPUT"
+          else
+            echo "pr_body_audit_ok=false" >> "$GITHUB_OUTPUT"
+            echo "::warning::PR #$pr_number body is missing literal 'upstream/main..HEAD' audit cadence (skill §5)"
+          fi
+
       - name: Validate merge output contract (final)
         id: contract_final
         if: always()
@@ -441,27 +531,34 @@ jobs:
           TARGET_BRANCH: ${{ steps.upstream_pr.outputs.branch }}
           HAD_EXISTING_PR: ${{ steps.upstream_pr.outputs.exists }}
           DRIFT_STATUS: ${{ steps.drift_check.outputs.status }}
+          PREFLIGHT_OK: ${{ steps.preflight_final.outputs.preflight_ok || 'skip' }}
+          PR_BODY_AUDIT_OK: ${{ steps.pr_body_audit_final.outputs.pr_body_audit_ok || 'skip' }}
         run: |
           set -euo pipefail
           if [ "$DRIFT_STATUS" = "no_drift" ]; then
-            jq -n '{contract_ok:"true", reason:"no-drift path: origin/main already contains upstream/main and no upstream merge PR is open", reason_code:"NO_DRIFT", matching_pr_count:0, any_open_upstream_pr_count:0}' > /tmp/upstream-merge-contract-final.json
+            jq -n '{contract_ok:"true", reason:"no-drift path: origin/main already contains upstream/main and no upstream merge PR is open", reason_code:"NO_DRIFT", preflight_ok:"skip", pr_body_audit_ok:"skip", matching_pr_count:0, any_open_upstream_pr_count:0}' > /tmp/upstream-merge-contract-final.json
           else
             set +e
-            bash "$STATE_HELPER" contract-eval-json "$TARGET_BRANCH" "$HAD_EXISTING_PR" > /tmp/upstream-merge-contract-final.json
+            bash "$STATE_HELPER" contract-eval-json "$TARGET_BRANCH" "$HAD_EXISTING_PR" "$PREFLIGHT_OK" "$PR_BODY_AUDIT_OK" > /tmp/upstream-merge-contract-final.json
             eval_rc=$?
             set -e
             if [ "$eval_rc" -ne 0 ] || [ ! -s /tmp/upstream-merge-contract-final.json ]; then
-              jq -n '{contract_ok:"false", reason:"contract eval failed at final gate", reason_code:"CONTRACT_EVAL_ERROR", matching_pr_count:0, any_open_upstream_pr_count:0}' > /tmp/upstream-merge-contract-final.json
+              jq -n '{contract_ok:"false", reason:"contract eval failed at final gate", reason_code:"CONTRACT_EVAL_ERROR", preflight_ok:"skip", pr_body_audit_ok:"skip", matching_pr_count:0, any_open_upstream_pr_count:0}' > /tmp/upstream-merge-contract-final.json
             fi
           fi
 
           echo "contract_ok=$(jq -r '.contract_ok // "false"' /tmp/upstream-merge-contract-final.json)" >> "$GITHUB_OUTPUT"
           echo "reason=$(jq -r '.reason // "contract eval failed at final gate"' /tmp/upstream-merge-contract-final.json)" >> "$GITHUB_OUTPUT"
+          echo "eval_reason_code=$(jq -r '.reason_code // ""' /tmp/upstream-merge-contract-final.json)" >> "$GITHUB_OUTPUT"
+          echo "preflight_ok=$(jq -r '.preflight_ok // "skip"' /tmp/upstream-merge-contract-final.json)" >> "$GITHUB_OUTPUT"
+          echo "pr_body_audit_ok=$(jq -r '.pr_body_audit_ok // "skip"' /tmp/upstream-merge-contract-final.json)" >> "$GITHUB_OUTPUT"
 
           {
             echo "contract_ok=$(jq -r '.contract_ok // "false"' /tmp/upstream-merge-contract-final.json)"
             echo "reason=$(jq -r '.reason // "contract eval failed at final gate"' /tmp/upstream-merge-contract-final.json)"
             echo "reason_code=$(jq -r '.reason_code // ""' /tmp/upstream-merge-contract-final.json)"
+            echo "preflight_ok=$(jq -r '.preflight_ok // "skip"' /tmp/upstream-merge-contract-final.json)"
+            echo "pr_body_audit_ok=$(jq -r '.pr_body_audit_ok // "skip"' /tmp/upstream-merge-contract-final.json)"
             echo "any_open_upstream_pr_count=$(jq -r '.any_open_upstream_pr_count // 0' /tmp/upstream-merge-contract-final.json)"
             echo "matching_pr_count=$(jq -r '.matching_pr_count // 0' /tmp/upstream-merge-contract-final.json)"
             echo "attempt1_exit_code=${{ steps.agent_attempt_1.outputs.exit_code }}"
@@ -480,7 +577,16 @@ jobs:
             jq -n '{contract_ok:"false", reason:"missing final contract artifact", reason_code:"MISSING_CONTRACT_ARTIFACT", matching_pr_count:0, any_open_upstream_pr_count:0}' > /tmp/upstream-merge-contract-final.json
           fi
 
-          reason_code="$(jq -r '.reason_code // ""' /tmp/upstream-merge-contract-final.json)"
+          eval_reason_code="$(jq -r '.reason_code // ""' /tmp/upstream-merge-contract-final.json)"
+          reason_code="$eval_reason_code"
+
+          # Structured codes from contract_eval_pure are authoritative — they
+          # correspond to actionable failures (preflight red, PR body missing
+          # audit cadence). Only fall through to grep heuristics when the
+          # contract eval itself signaled CONTRACT_FAIL or returned empty,
+          # since those are the cases where the agent's stdout contains the
+          # most specific clue (merge conflict markers, budget exhaustion).
+          structured_codes_re='^(PREFLIGHT_FAIL|PR_BODY_INCOMPLETE|NO_DRIFT)$'
 
           if [ "$DRIFT_STATUS" = "infra_error" ]; then
             reason_code="DRIFT_CHECK_INFRA"
@@ -488,6 +594,8 @@ jobs:
             if [ -z "$reason_code" ]; then
               reason_code="SUCCESS"
             fi
+          elif [[ "$eval_reason_code" =~ $structured_codes_re ]]; then
+            reason_code="$eval_reason_code"
           else
             if grep -q "CONFLICT (content)" /tmp/upstream-merge-agent-output.txt 2>/dev/null; then
               reason_code="MERGE_CONFLICT_UNRESOLVED"
@@ -521,6 +629,9 @@ jobs:
           TARGET_BRANCH: ${{ steps.upstream_pr.outputs.branch }}
           ATTEMPT1_EXIT_CODE: ${{ steps.agent_attempt_1.outputs.exit_code || 'not-run' }}
           ATTEMPT2_EXIT_CODE: ${{ steps.agent_attempt_2.outputs.exit_code || 'not-run' }}
+          PREFLIGHT_OK: ${{ steps.preflight_final.outputs.preflight_ok || 'skip' }}
+          PREFLIGHT_ERROR_COUNT: ${{ steps.preflight_final.outputs.error_count || '-1' }}
+          PR_BODY_AUDIT_OK: ${{ steps.pr_body_audit_final.outputs.pr_body_audit_ok || 'skip' }}
         run: |
           set -euo pipefail
           {
@@ -534,6 +645,9 @@ jobs:
             echo "- target_branch: ${TARGET_BRANCH:-n/a}"
             echo "- attempt1_exit_code: ${ATTEMPT1_EXIT_CODE}"
             echo "- attempt2_exit_code: ${ATTEMPT2_EXIT_CODE}"
+            echo "- preflight_ok: ${PREFLIGHT_OK}"
+            echo "- preflight_error_count: ${PREFLIGHT_ERROR_COUNT}"
+            echo "- pr_body_audit_ok: ${PR_BODY_AUDIT_OK}"
           } >> "$GITHUB_STEP_SUMMARY"
 
       - name: Update checkpoint after final contract
@@ -548,12 +662,25 @@ jobs:
           bash "$STATE_HELPER" update-agent-attempt 2 "${ATTEMPT2_EXIT_CODE:-}"
           bash "$STATE_HELPER" update-contract-checkpoint final "$(cat /tmp/upstream-merge-contract-final.json)"
 
-      - name: Auto-dispatch retry for unresolved merge conflicts
+      - name: Auto-dispatch retry for recoverable failures
         id: auto_retry_conflict
-        if: always() && github.ref_name == 'main' && steps.contract_final.outputs.contract_ok != 'true' && steps.reason_code.outputs.reason_code == 'MERGE_CONFLICT_UNRESOLVED'
+        # Trigger set covers every reason_code where another agent run can
+        # plausibly fix things on its own:
+        #  - MERGE_CONFLICT_UNRESOLVED: agent left CONFLICT markers
+        #  - PREFLIGHT_FAIL:            interface/type drift, missing stubs
+        #  - PR_BODY_INCOMPLETE:        missing audit cadence in PR body
+        #  - CONTRACT_FAIL:             generic miss; one more attempt allowed
+        # AUTH_TOKEN_SCOPE / TOOL_GUARD / AGENT_BUDGET_EXCEEDED are intentionally
+        # excluded — they need human-side fixes (token scope, prompt, budget).
+        if: >-
+          always()
+          && github.ref_name == 'main'
+          && steps.contract_final.outputs.contract_ok != 'true'
+          && contains(fromJSON('["MERGE_CONFLICT_UNRESOLVED","PREFLIGHT_FAIL","PR_BODY_INCOMPLETE","CONTRACT_FAIL"]'), steps.reason_code.outputs.reason_code)
         env:
           GH_TOKEN: ${{ secrets.UPSTREAM_MERGE_GH_TOKEN }}
           AUTO_RETRY_COUNT: ${{ github.event.inputs.auto_retry_count || '0' }}
+          REASON_CODE: ${{ steps.reason_code.outputs.reason_code }}
         run: |
           set -euo pipefail
           current="${AUTO_RETRY_COUNT:-0}"
@@ -565,8 +692,30 @@ jobs:
           if [ "$current" -ge "$max_retry" ]; then
             echo "auto_retry_triggered=false" >> "$GITHUB_OUTPUT"
             echo "auto_retry_next_count=$current" >> "$GITHUB_OUTPUT"
+            echo "auto_retry_decline_reason=cap_reached" >> "$GITHUB_OUTPUT"
             echo "Auto-retry cap reached ($current/$max_retry); no further auto-dispatch."
             exit 0
+          fi
+
+          # Progress gate: for PREFLIGHT_FAIL chains, refuse to dispatch a new
+          # run if the previous run had >= as many preflight errors. This keeps
+          # the chain from burning $20/run × 3 in a stable failure state — if
+          # the agent isn't making progress it never will.
+          # The prior run's snapshot exists only when this run was itself a
+          # resume of an earlier auto-dispatched run; on the first failure of
+          # a fresh chain there is no prior snapshot and the gate is skipped.
+          if [ "$REASON_CODE" = "PREFLIGHT_FAIL" ] && [ -f /tmp/upstream-merge-prior-state.json ]; then
+            prior_count="$(jq -r '.preflight.error_count // -1' /tmp/upstream-merge-prior-state.json 2>/dev/null || echo -1)"
+            current_count="$(jq -r '.preflight.error_count // -1' /tmp/upstream-merge-state.json 2>/dev/null || echo -1)"
+            if [ "$prior_count" -gt 0 ] && [ "$current_count" -ge "$prior_count" ]; then
+              echo "::warning::Auto-retry declined: preflight error count not decreasing ($prior_count → $current_count)"
+              echo "auto_retry_triggered=false" >> "$GITHUB_OUTPUT"
+              echo "auto_retry_next_count=$current" >> "$GITHUB_OUTPUT"
+              echo "auto_retry_decline_reason=no_progress" >> "$GITHUB_OUTPUT"
+              echo "auto_retry_prior_count=$prior_count" >> "$GITHUB_OUTPUT"
+              echo "auto_retry_current_count=$current_count" >> "$GITHUB_OUTPUT"
+              exit 0
+            fi
           fi
 
           next=$((current + 1))
@@ -600,6 +749,9 @@ jobs:
               `- target_branch: ${{ steps.upstream_pr.outputs.branch || 'n/a' }}`,
               `- attempt1_exit_code: ${{ steps.agent_attempt_1.outputs.exit_code || 'not-run' }}`,
               `- attempt2_exit_code: ${{ steps.agent_attempt_2.outputs.exit_code || 'not-run' }}`,
+              `- preflight_ok: ${{ steps.preflight_final.outputs.preflight_ok || 'skip' }}`,
+              `- preflight_error_count: ${{ steps.preflight_final.outputs.error_count || '-1' }}`,
+              `- pr_body_audit_ok: ${{ steps.pr_body_audit_final.outputs.pr_body_audit_ok || 'skip' }}`,
               '',
               '## Recovery',
               '',
@@ -607,6 +759,7 @@ jobs:
               '- Re-run this workflow via workflow_dispatch (optionally with resume_run_id).',
               '- auto_retry_triggered: ${{ steps.auto_retry_conflict.outputs.auto_retry_triggered || 'false' }}',
               '- auto_retry_next_count: ${{ steps.auto_retry_conflict.outputs.auto_retry_next_count || 'n/a' }}',
+              '- auto_retry_decline_reason: ${{ steps.auto_retry_conflict.outputs.auto_retry_decline_reason || 'n/a' }}',
             ].join('\n');
 
             const { data: issues } = await github.rest.issues.listForRepo({
@@ -689,6 +842,9 @@ jobs:
             /tmp/upstream-merge-agent-output.txt
             /tmp/upstream-merge-pr-body.md
             /tmp/upstream-merge-state.json
+            /tmp/upstream-merge-preflight.log
+            /tmp/upstream-merge-contract-final.json
+            /tmp/upstream-merge-contract-final.txt
           if-no-files-found: ignore
 
       - name: Upload state checkpoint artifact

--- a/scripts/upstream-merge-state.sh
+++ b/scripts/upstream-merge-state.sh
@@ -103,14 +103,91 @@ update_agent_attempt_checkpoint() {
     '.state="AGENT_RUN" | .state_code=30 | .agent[$key]=$exit_code | .updated_at_utc=$ts'
 }
 
+contract_eval_pure() {
+  # Pure assembler: given facts, produce the contract JSON. Unit-testable
+  # without git/gh — used directly by tests. The I/O wrapper is contract_eval_json.
+  local pr_exists="$1"            # "true"|"false"
+  local had_existing_pr="$2"      # "true"|"false"
+  local any_open_pr_count="$3"    # integer
+  local matching_pr_count="$4"    # integer
+  local upstream_in_main="$5"     # "true"|"false"
+  local preflight_ok="${6:-skip}"      # "true"|"false"|"skip"
+  local pr_body_audit_ok="${7:-skip}"  # "true"|"false"|"skip"
+
+  local contract_ok="false"
+  local reason="contract_unmet"
+  local reason_code="CONTRACT_FAIL"
+
+  # First gate: PR existence (or no-drift fallthrough).
+  local pr_status="missing"
+  if [ "$pr_exists" = "true" ]; then
+    pr_status="present_matching"
+  elif [ "$had_existing_pr" = "true" ] && [ "$any_open_pr_count" -gt 0 ]; then
+    pr_status="present_existing"
+  elif [ "$upstream_in_main" = "true" ] && [ "$any_open_pr_count" -eq 0 ]; then
+    pr_status="no_drift"
+  fi
+
+  case "$pr_status" in
+    no_drift)
+      contract_ok="true"
+      reason="no-drift path: origin/main already contains upstream/main and no upstream merge PR is open"
+      reason_code="NO_DRIFT"
+      ;;
+    present_matching|present_existing)
+      # PR exists; evaluate secondary gates. Order matters — most actionable first.
+      if [ "$preflight_ok" = "false" ]; then
+        contract_ok="false"
+        reason="preflight failed on target branch"
+        reason_code="PREFLIGHT_FAIL"
+      elif [ "$pr_body_audit_ok" = "false" ]; then
+        contract_ok="false"
+        reason="PR body missing required upstream/main..HEAD audit cadence"
+        reason_code="PR_BODY_INCOMPLETE"
+      else
+        contract_ok="true"
+        if [ "$pr_status" = "present_matching" ]; then
+          reason="open PR exists for target branch"
+        else
+          reason="existing upstream PR still open after update path"
+        fi
+        reason_code=""
+      fi
+      ;;
+    missing)
+      contract_ok="false"
+      reason="contract_unmet: no upstream merge PR open and origin/main lags upstream"
+      reason_code="CONTRACT_FAIL"
+      ;;
+  esac
+
+  jq -n \
+    --arg contract_ok "$contract_ok" \
+    --arg reason "$reason" \
+    --arg reason_code "$reason_code" \
+    --arg preflight_ok "$preflight_ok" \
+    --arg pr_body_audit_ok "$pr_body_audit_ok" \
+    --argjson matching_pr_count "$matching_pr_count" \
+    --argjson any_open_upstream_pr_count "$any_open_pr_count" \
+    '{
+      contract_ok:$contract_ok,
+      reason:$reason,
+      reason_code:$reason_code,
+      preflight_ok:$preflight_ok,
+      pr_body_audit_ok:$pr_body_audit_ok,
+      matching_pr_count:$matching_pr_count,
+      any_open_upstream_pr_count:$any_open_upstream_pr_count
+    }'
+}
+
 contract_eval_json() {
   local target_branch="$1"
   local had_existing_pr="$2"
+  local preflight_ok="${3:-skip}"
+  local pr_body_audit_ok="${4:-skip}"
 
   git fetch origin main >/dev/null
-  if ! git remote get-url upstream >/dev/null 2>&1; then
-    git remote add upstream "$UPSTREAM_URL"
-  fi
+  ensure_upstream_remote
   git fetch upstream main >/dev/null
 
   local open_upstream_pr_json
@@ -120,31 +197,35 @@ contract_eval_json() {
   matching_pr_count="$(jq --arg branch "$target_branch" '[.[] | select(.headRefName == $branch)] | length' <<<"$open_upstream_pr_json")"
   any_open_upstream_pr_count="$(jq 'length' <<<"$open_upstream_pr_json")"
 
-  local contract_ok="false"
-  local reason="contract_unmet"
-  local reason_code="CONTRACT_FAIL"
+  local pr_exists="false"
+  [ "$matching_pr_count" -gt 0 ] && pr_exists="true"
 
-  if [ "$matching_pr_count" -gt 0 ]; then
-    contract_ok="true"
-    reason="open PR exists for target branch $target_branch"
-    reason_code=""
-  elif [ "$had_existing_pr" = "true" ] && [ "$any_open_upstream_pr_count" -gt 0 ]; then
-    contract_ok="true"
-    reason="existing upstream PR still open after update path"
-    reason_code=""
-  elif git merge-base --is-ancestor upstream/main origin/main && [ "$any_open_upstream_pr_count" -eq 0 ]; then
-    contract_ok="true"
-    reason="no-drift path: origin/main already contains upstream/main and no upstream merge PR is open"
-    reason_code="NO_DRIFT"
+  local upstream_in_main="false"
+  if git merge-base --is-ancestor upstream/main origin/main 2>/dev/null; then
+    upstream_in_main="true"
   fi
 
-  jq -n \
-    --arg contract_ok "$contract_ok" \
+  contract_eval_pure \
+    "$pr_exists" \
+    "$had_existing_pr" \
+    "$any_open_upstream_pr_count" \
+    "$matching_pr_count" \
+    "$upstream_in_main" \
+    "$preflight_ok" \
+    "$pr_body_audit_ok"
+}
+
+update_preflight_checkpoint() {
+  local result="$1"        # "true"|"false"|"skip"
+  local error_count="$2"   # integer or "-1" when unknown
+  local reason="${3:-}"
+
+  update_state \
+    --arg result "$result" \
     --arg reason "$reason" \
-    --arg reason_code "$reason_code" \
-    --argjson matching_pr_count "$matching_pr_count" \
-    --argjson any_open_upstream_pr_count "$any_open_upstream_pr_count" \
-    '{contract_ok:$contract_ok, reason:$reason, reason_code:$reason_code, matching_pr_count:$matching_pr_count, any_open_upstream_pr_count:$any_open_upstream_pr_count}'
+    --arg ts "$(date -u +%Y-%m-%dT%H:%M:%SZ)" \
+    --argjson error_count "${error_count:-(-1)}" \
+    '.preflight = {ok:$result, error_count:$error_count, reason:$reason} | .updated_at_utc=$ts'
 }
 
 update_contract_checkpoint() {
@@ -217,10 +298,18 @@ case "$cmd" in
     update_agent_attempt_checkpoint "$2" "$3"
     ;;
   contract-eval-json)
-    contract_eval_json "$2" "$3"
+    contract_eval_json "$2" "$3" "${4:-skip}" "${5:-skip}"
+    ;;
+  contract-eval-pure)
+    # Direct pure-assembler entrypoint: facts → JSON, no git/gh I/O. Used by
+    # unit tests in scripts/upstream-merge-state_test.sh.
+    contract_eval_pure "$2" "$3" "$4" "$5" "$6" "${7:-skip}" "${8:-skip}"
     ;;
   update-contract-checkpoint)
     update_contract_checkpoint "$2" "$3"
+    ;;
+  update-preflight-checkpoint)
+    update_preflight_checkpoint "$2" "$3" "${4:-}"
     ;;
   restore-state)
     restore_state_from_artifact "${2:-}"

--- a/scripts/upstream-merge-state_test.sh
+++ b/scripts/upstream-merge-state_test.sh
@@ -1,0 +1,95 @@
+#!/usr/bin/env bash
+#
+# Unit test for the pure contract-eval assembler in scripts/upstream-merge-state.sh.
+# The pure assembler takes facts (PR existence, preflight result, audit result) and
+# produces the contract JSON without touching git/gh, so we can exercise every
+# branch of the gating logic deterministically.
+
+set -euo pipefail
+
+HERE="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+HELPER="$HERE/upstream-merge-state.sh"
+
+if [ ! -f "$HELPER" ]; then
+  echo "FAIL: $HELPER missing" >&2
+  exit 1
+fi
+
+pass=0
+fail=0
+
+# call_pure <pr_exists> <had_existing_pr> <any_open_pr_count> <matching_pr_count> \
+#          <upstream_in_main> [<preflight_ok>] [<pr_body_audit_ok>]
+call_pure() {
+  STATE_FILE=/dev/null bash "$HELPER" contract-eval-pure "$@"
+}
+
+expect_field() {
+  local label="$1" field="$2" expected="$3" json="$4"
+  local actual
+  actual="$(jq -r ".${field}" <<<"$json")"
+  if [ "$actual" = "$expected" ]; then
+    pass=$((pass + 1))
+  else
+    fail=$((fail + 1))
+    echo "FAIL: $label — .${field}" >&2
+    echo "  expected: $expected" >&2
+    echo "  actual:   $actual" >&2
+    echo "  full json: $json" >&2
+  fi
+}
+
+# 1) PR exists (matching) + preflight ok + audit ok → contract_ok=true, no reason_code
+out="$(call_pure true false 1 1 false true true)"
+expect_field "matching PR + green" contract_ok    "true" "$out"
+expect_field "matching PR + green" reason_code    ""     "$out"
+
+# 2) PR exists (matching) + preflight FAIL → PREFLIGHT_FAIL
+out="$(call_pure true false 1 1 false false true)"
+expect_field "preflight fail" contract_ok    "false"          "$out"
+expect_field "preflight fail" reason_code    "PREFLIGHT_FAIL" "$out"
+
+# 3) PR exists (matching) + preflight ok + audit FAIL → PR_BODY_INCOMPLETE
+out="$(call_pure true false 1 1 false true false)"
+expect_field "audit fail" contract_ok    "false"               "$out"
+expect_field "audit fail" reason_code    "PR_BODY_INCOMPLETE"  "$out"
+
+# 4) Preflight failure outranks audit failure when both red.
+out="$(call_pure true false 1 1 false false false)"
+expect_field "both red, preflight wins" reason_code "PREFLIGHT_FAIL" "$out"
+
+# 5) had_existing_pr=true with non-matching open upstream PR → present_existing path
+out="$(call_pure false true 1 0 false true true)"
+expect_field "existing-PR fallback" contract_ok "true" "$out"
+expect_field "existing-PR fallback" reason_code ""     "$out"
+
+# 6) No PR but origin already contains upstream → NO_DRIFT success
+out="$(call_pure false false 0 0 true skip skip)"
+expect_field "no_drift" contract_ok "true"     "$out"
+expect_field "no_drift" reason_code "NO_DRIFT" "$out"
+
+# 7) No PR, origin lags upstream → CONTRACT_FAIL
+out="$(call_pure false false 0 0 false skip skip)"
+expect_field "missing PR" contract_ok "false"         "$out"
+expect_field "missing PR" reason_code "CONTRACT_FAIL" "$out"
+
+# 8) Backward compat: 5-arg call (no preflight/audit args) defaults to "skip"
+#    and must NOT block contract_ok when PR exists. Mirrors today's caller shape.
+out="$(call_pure true false 1 1 false)"
+expect_field "5-arg compat: contract_ok"     contract_ok       "true" "$out"
+expect_field "5-arg compat: preflight_ok"    preflight_ok      "skip" "$out"
+expect_field "5-arg compat: pr_body_audit_ok" pr_body_audit_ok "skip" "$out"
+
+# 9) "skip" behaves as a permissive sentinel: when PR exists and both gates are
+#    skip, contract_ok=true. This is what the after-attempt-1 step relies on.
+out="$(call_pure true false 1 1 false skip skip)"
+expect_field "skip is permissive" contract_ok "true" "$out"
+
+echo ""
+if [ "$fail" -eq 0 ]; then
+  echo "=== upstream-merge-state pure assembler: PASS ($pass assertions) ==="
+  exit 0
+else
+  echo "=== upstream-merge-state pure assembler: FAIL ($fail / $((pass + fail))) ===" >&2
+  exit 1
+fi


### PR DESCRIPTION
## Summary

The daily upstream-merge agent's contract gate only checked "is there an open PR for the target branch". Two failure modes slipped through unchanged:

1. Agent pushes a PR whose preflight is red (this is the run-25557439814 mode: upstream brought in `UserRepository.BatchAddConcurrency` / `AuthSourceDefaultSettings.Google` / `SignupBonusBalanceDisplayUSD` / new `SettingsForm` fields / `"newapi"` outside the platform union, agent didn't propagate them through TK stubs and types). Contract still reports `contract_ok=true`.
2. Agent forgets the literal `upstream/main..HEAD` audit cadence in the PR body. Daily workflow declares success; the separate `upstream-merge-pr-shape.yml` gate then blocks merge — but the daily agent never gets nudged to fix it.

Auto-retry only fired on `MERGE_CONFLICT_UNRESOLVED`, so build/interface drift never re-engaged the agent and the PR sat half-broken until a human took over.

## What changed

**`scripts/upstream-merge-state.sh`**
- Split gating into a pure assembler `contract_eval_pure` (facts → JSON, no git/gh I/O) so every branch is unit-testable.
- New JSON fields `preflight_ok` / `pr_body_audit_ok` (each `"true" | "false" | "skip"`).
- New reason codes: `PREFLIGHT_FAIL`, `PR_BODY_INCOMPLETE`.
- Added `update-preflight-checkpoint <ok|fail|skip> <error_count> [reason]` for the progress gate.
- Backward compat: 2-arg `contract-eval-json` calls still work; missing args default to `skip` (permissive sentinel).

**`scripts/upstream-merge-state_test.sh`** (new)
- 17 assertions covering: matching PR + green path, preflight red, audit red, both red (preflight wins), existing-PR fallback, no-drift, missing-PR, 2 vs 5-arg backward compat, skip-as-permissive sentinel.

**`.github/workflows/upstream-merge-agent-daily.yml`**
- New step `Verify preflight on target branch (final)` checks out the agent-pushed branch via `FETCH_HEAD`, runs `scripts/preflight.sh`, parses the `N check(s) failed` count from the tail line, and tail-prints the failure log into the workflow log.
- New step `Audit PR body for upstream cadence (final)` greps the PR body for literal `upstream/main..HEAD`.
- `Validate merge output contract (final)` now threads `preflight_ok` + `pr_body_audit_ok` into the helper.
- `Classify final reason code` honors structured codes from `contract_eval_pure` (PREFLIGHT_FAIL / PR_BODY_INCOMPLETE / NO_DRIFT) instead of overwriting them with grep heuristics — heuristics still cover MERGE_CONFLICT_UNRESOLVED / AUTH_TOKEN_SCOPE / TOOL_GUARD / AGENT_BUDGET_EXCEEDED.
- `Auto-dispatch retry` (renamed from `... for unresolved merge conflicts`) trigger set widened: `MERGE_CONFLICT_UNRESOLVED | PREFLIGHT_FAIL | PR_BODY_INCOMPLETE | CONTRACT_FAIL`. AUTH_TOKEN_SCOPE / TOOL_GUARD / AGENT_BUDGET_EXCEEDED stay excluded — those need human-side fixes.
- Progress gate inside auto-dispatch: when this run is itself a resume of an earlier auto-dispatched run AND `reason_code=PREFLIGHT_FAIL`, refuse to dispatch again if the preflight error count did not decrease. Avoids burning $20/run × cap-3 = $60 in a stable failure state. Gate is skipped on the first failure of a fresh chain (no prior snapshot).
- `Restore checkpoint from prior run` now also writes `/tmp/upstream-merge-prior-state.json` for the progress gate.
- Job summary, tracking-issue body, and uploaded artifacts now expose `preflight_ok`, `preflight_error_count`, `pr_body_audit_ok`, `auto_retry_decline_reason`, plus `upstream-merge-preflight.log` and the final contract JSON for post-mortem.

**Submodule**
- `dev-rules` pointer bumps `6b40442 → 9278dde` to align with origin/main; `.cursor/rules/` re-synced via `dev-rules/sync.sh --local` (no rule-content drift).

## Risk

- **Preflight runs against a destructive `git checkout -B preflight-target FETCH_HEAD`.** The step runs after both agent attempts and before any further git mutations, so it should only affect transient working state. Worst case the workflow's internal repo is on a different ref when the artifact-upload step runs — artifacts come from `/tmp` which is unaffected.
- **Adds ~3–5 minutes per run** for the preflight execution (only at final, not after attempt 1, to keep budget bounded).
- **Self-consumption risk unchanged** (`ANTHROPIC_BASE_URL: api.tokenkey.dev` still routes through prod TokenKey). That's a separate P1 to address; called out in the audit.
- The progress gate compares against `/tmp/upstream-merge-prior-state.json`, which is only present when `Restore checkpoint from prior run` succeeded. First failure of a fresh chain skips the gate intentionally.

## Validation

- `bash scripts/upstream-merge-state_test.sh` → `PASS (17 assertions)`
- `bash scripts/preflight.sh` → `PASS`
- `python3 scripts/check-workflow-job-if-env.py` → ok (no env-context references in job-level if expressions)
- YAML syntax: `python3 -c "import yaml; yaml.safe_load(...)"` → ok
- Helper: `bash -n scripts/upstream-merge-state.sh` → ok

## Test plan

- [ ] Manually dispatch `Daily Upstream Merge Agent` once main is merged, verify the new preflight + PR body audit steps surface their outputs in the job summary.
- [ ] Trigger a synthetic preflight-red scenario (push a known-broken stub on a `merge/upstream-*` branch, dispatch agent) and confirm `reason_code=PREFLIGHT_FAIL` + auto-retry dispatch fires.
- [ ] Trigger a synthetic missing-cadence scenario (PR body without `upstream/main..HEAD`) and confirm `reason_code=PR_BODY_INCOMPLETE`.
- [ ] Verify progress gate by checking that after 2 dispatches with the same preflight error count, the third refuses to dispatch with `auto_retry_decline_reason=no_progress`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)