### PR TITLE
fix(workflow): preflight checkout guard + prod-logs gitignore + jq default

### DIFF
--- a/.github/workflows/upstream-merge-agent-daily.yml
+++ b/.github/workflows/upstream-merge-agent-daily.yml
@@ -464,9 +464,22 @@ jobs:
           # Mirror what review/CI will execute against. -B reset is destructive
           # to local working state, but we only ever touch state read-only after
           # this step, so it's safe.
-          git checkout -B preflight-target FETCH_HEAD
+          if ! git checkout -B preflight-target FETCH_HEAD 2>/tmp/upstream-merge-preflight-checkout.log; then
+            # If we can't switch to the agent's branch, do NOT silently run
+            # preflight against whatever HEAD happens to be — that would
+            # report main's preflight result as the merge branch's.
+            echo "preflight_ok=skip" >> "$GITHUB_OUTPUT"
+            echo "error_count=-1" >> "$GITHUB_OUTPUT"
+            echo "skip_reason=checkout_failed" >> "$GITHUB_OUTPUT"
+            bash "$STATE_HELPER" update-preflight-checkpoint skip -1 checkout_failed || true
+            echo "::warning::preflight skipped: git checkout of $TARGET_BRANCH failed"
+            cat /tmp/upstream-merge-preflight-checkout.log >&2 || true
+            exit 0
+          fi
           # Submodule pointer may have moved across the merge; re-init so
-          # dev-rules/templates/preflight.sh exists at the right SHA.
+          # dev-rules/templates/preflight.sh exists at the right SHA. If this
+          # fails preflight will likely flag drift below — that surfaces in
+          # the preflight tail block, no need to fail the step here.
           git submodule update --init --recursive 2>/dev/null || true
 
           bash scripts/preflight.sh > /tmp/upstream-merge-preflight.log 2>&1

--- a/.gitignore
+++ b/.gitignore
@@ -119,7 +119,9 @@ backend/data/
 # Cloud Agent 拉取的 prod 运行时数据（包含真实日志行 / 错误聚合，禁止入库）
 # 由 scripts/fetch-prod-logs.sh 与 scripts/fetch-prod-error-clusters.sh 生成
 .prod-logs/
+.prod-logs-*/
 .error-clusters/
+.error-clusters-*/
 
 # 本地/机器生成数据（原 docs/auto-reports/ 已迁至仓库根 .auto-reports/）
 .auto-reports/

--- a/scripts/upstream-merge-state.sh
+++ b/scripts/upstream-merge-state.sh
@@ -224,7 +224,7 @@ update_preflight_checkpoint() {
     --arg result "$result" \
     --arg reason "$reason" \
     --arg ts "$(date -u +%Y-%m-%dT%H:%M:%SZ)" \
-    --argjson error_count "${error_count:-(-1)}" \
+    --argjson error_count "${error_count:--1}" \
     '.preflight = {ok:$result, error_count:$error_count, reason:$reason} | .updated_at_utc=$ts'
 }
 


### PR DESCRIPTION
## Summary

Three follow-ups on top of #153 contract-gating work. All changes scoped to workflow / build infra — **no backend, frontend, or runtime impact on TokenKey users**.

- **workflow** (`.github/workflows/upstream-merge-agent-daily.yml`): Guard against silent false-green when `git checkout -B preflight-target FETCH_HEAD` fails. The prior code let `set +e` swallow the failure and ran preflight against whatever HEAD happened to be (usually main), reporting that as the merge branch's preflight result. The auto-retry progress gate would then be fed a bogus `error_count`. Now: skip with `reason=checkout_failed`, surface stderr to the workflow log, write skip state to the checkpoint.

- **state helper** (`scripts/upstream-merge-state.sh`): `${error_count:-(-1)}` was the wrong bash default-value syntax — it expanded to literal `(-1)` (with parentheses), not a valid jq number. Current callers always pass a value, so this was latent; fixed to `${error_count:--1}` so the empty-fallback path produces `-1` cleanly.

- **gitignore**: `scripts/fetch-prod-logs.sh` produces account/user-suffixed directories like `.prod-logs-account1-24h/` and `.prod-logs-user1/` containing real prod log lines (request paths, account IDs, sometimes user identifiers). The existing rule only covers `.prod-logs/` (no suffix), leaving the suffixed siblings vulnerable to accidental `git add`. Added `.prod-logs-*/` + `.error-clusters-*/` glob patterns.

## Test plan

- [x] `bash scripts/upstream-merge-state_test.sh` → `PASS (17 assertions)` — all branches of `contract_eval_pure` still pass with the unchanged gating logic
- [x] `bash -n scripts/upstream-merge-state.sh` — syntax OK
- [x] `python3 -c "import yaml;yaml.safe_load(open('.github/workflows/upstream-merge-agent-daily.yml'))"` — YAML parses
- [x] `update_preflight_checkpoint` smoke: `update-preflight-checkpoint false 7 "..."` writes `error_count=7`; `update-preflight-checkpoint skip "" "..."` writes `error_count=-1` cleanly (not jq error)
- [x] `git status --ignored` confirms `.prod-logs-account1-24h/`, `.prod-logs-compact-24h/`, `.prod-logs-user1/` are now ignored
- [x] `bash scripts/preflight.sh` → `PASS`

## Audit cadence

`git log --oneline upstream/main..HEAD | wc -l` — N/A (no upstream merge in this PR; pure TK fix)

🤖 Generated with [Claude Code](https://claude.com/claude-code)