### PR TITLE
fix(workflow): repair upstream-agent retry follow-ups

### DIFF
--- a/.github/workflows/upstream-merge-agent-daily.yml
+++ b/.github/workflows/upstream-merge-agent-daily.yml
@@ -17,9 +17,9 @@ on:
         required: false
         type: string
       auto_retry_count:
-        description: "Internal auto-retry counter for merge-conflict resume loop"
+        description: "Internal auto-retry counter for recoverable-failure resume loop"
         required: false
-        default: "3"
+        default: "0"
         type: string
 
 permissions:
@@ -461,10 +461,10 @@ jobs:
             exit 0
           fi
 
-          # Mirror what review/CI will execute against. -B reset is destructive
-          # to local working state, but we only ever touch state read-only after
-          # this step, so it's safe.
-          if ! git checkout -B preflight-target FETCH_HEAD 2>/tmp/upstream-merge-preflight-checkout.log; then
+          # Mirror what review/CI will execute against. Detached HEAD avoids
+          # tripping dev-rules branch naming checks with an internal helper
+          # branch name; `HEAD` is explicitly accepted by preflight.
+          if ! git checkout --detach FETCH_HEAD 2>/tmp/upstream-merge-preflight-checkout.log; then
             # If we can't switch to the agent's branch, do NOT silently run
             # preflight against whatever HEAD happens to be — that would
             # report main's preflight result as the merge branch's.
@@ -598,7 +598,7 @@ jobs:
           # audit cadence). Only fall through to grep heuristics when the
           # contract eval itself signaled CONTRACT_FAIL or returned empty,
           # since those are the cases where the agent's stdout contains the
-          # most specific clue (merge conflict markers, budget exhaustion).
+          # most specific clue (permission scope, merge conflicts, budget).
           structured_codes_re='^(PREFLIGHT_FAIL|PR_BODY_INCOMPLETE|NO_DRIFT)$'
 
           if [ "$DRIFT_STATUS" = "infra_error" ]; then
@@ -610,10 +610,10 @@ jobs:
           elif [[ "$eval_reason_code" =~ $structured_codes_re ]]; then
             reason_code="$eval_reason_code"
           else
-            if grep -q "CONFLICT (content)" /tmp/upstream-merge-agent-output.txt 2>/dev/null; then
-              reason_code="MERGE_CONFLICT_UNRESOLVED"
-            elif grep -q "Resource not accessible by personal access token (createPullRequest)" /tmp/upstream-merge-agent-output.txt 2>/dev/null; then
+            if grep -q "Resource not accessible by personal access token (createPullRequest)" /tmp/upstream-merge-agent-output.txt 2>/dev/null; then
               reason_code="AUTH_TOKEN_SCOPE"
+            elif grep -q "CONFLICT (content)" /tmp/upstream-merge-agent-output.txt 2>/dev/null; then
+              reason_code="MERGE_CONFLICT_UNRESOLVED"
             elif grep -q "File has not been read yet. Read it first before writing to it." /tmp/upstream-merge-agent-output.txt 2>/dev/null; then
               reason_code="TOOL_GUARD"
             elif grep -q "Exceeded USD budget" /tmp/upstream-merge-agent-output.txt 2>/dev/null; then


### PR DESCRIPTION
## Summary

Run 25560876597 validated that the new contract gates execute, but exposed three workflow regressions in the follow-up path:

- `workflow_dispatch.inputs.auto_retry_count.default` was `3`, so a fresh manual dispatch started at the cap and refused to auto-resume.
- final preflight checked out a local branch named `preflight-target`; dev-rules branch naming rejects that helper branch, so preflight failed on the workflow's own branch name instead of code.
- reason-code classification checked stale `CONFLICT (content)` text before `createPullRequest` token-scope errors, so an auth blocker was mislabeled as `MERGE_CONFLICT_UNRESOLVED`.

## Changes

- default `auto_retry_count` → `0` while preserving `max_retry=3`.
- final preflight now uses `git checkout --detach FETCH_HEAD`; preflight sees `HEAD`, which dev-rules explicitly accepts.
- reason-code classifier now checks `Resource not accessible ... createPullRequest` before generic conflict text, so token-scope blockers surface as `AUTH_TOKEN_SCOPE` and do not enter recoverable auto-retry.

## Validation

- `python3 -c "import yaml; yaml.safe_load(open('.github/workflows/upstream-merge-agent-daily.yml'))"`
- `python3 scripts/check-workflow-job-if-env.py`
- `bash scripts/upstream-merge-state_test.sh`
- `bash scripts/preflight.sh`

## Test plan

- [ ] CI passes on this PR.
- [ ] Re-dispatch Daily Upstream Merge Agent after merge; expected blocker (if token scope still missing) is `AUTH_TOKEN_SCOPE`, not `MERGE_CONFLICT_UNRESOLVED`, and auto-retry should not fire for auth failures.

🤖 Generated with [Claude Code](https://claude.com/claude-code)