### PR TITLE
fix(frontend): handle priced upstream model objects

### DIFF
--- a/backend/internal/web/dist/frontend-source.json
+++ b/backend/internal/web/dist/frontend-source.json
@@ -1,7 +1,7 @@
 {
   "algorithm": "sha256(git-ls-files:path,size,content)",
   "file_count": 413,
-  "hash": "791b4a0a465a7c6f0c91fa6baccc61b32247f7c9a32132c4fcbd4b3d18b371df",
+  "hash": "3dbd539f06406fab7016268b7977d00ebf616f55912ab2417c1eeeb2937f527a",
   "schema": 1,
   "source": "frontend/"
 }

--- a/frontend/src/api/__tests__/admin.channels.spec.ts
+++ b/frontend/src/api/__tests__/admin.channels.spec.ts
@@ -1,0 +1,52 @@
+import { describe, expect, it, vi, beforeEach, afterEach } from 'vitest'
+import type { AxiosInstance } from 'axios'
+
+vi.mock('@/i18n', () => ({
+  getLocale: () => 'zh-CN',
+}))
+
+describe('admin channels API', () => {
+  let apiClient: AxiosInstance
+  let channels: typeof import('@/api/admin/channels')
+
+  beforeEach(async () => {
+    vi.resetModules()
+    const clientMod = await import('@/api/client')
+    apiClient = clientMod.apiClient
+    channels = await import('@/api/admin/channels')
+  })
+
+  afterEach(() => {
+    vi.restoreAllMocks()
+  })
+
+  it('normalizes #128 upstream model objects and preserves pricing status', async () => {
+    apiClient.defaults.adapter = vi.fn().mockResolvedValue({
+      status: 200,
+      data: {
+        code: 0,
+        data: {
+          models: [
+            { id: 'claude-opus-4-6', pricing_status: 'priced' },
+            { id: 'claude-sonnet-4-6', pricing_status: 'missing' },
+            { id: 'claude-opus-4-6', pricing_status: 'priced' },
+            '',
+          ],
+        },
+        message: 'ok',
+      },
+      headers: {},
+      config: {},
+      statusText: 'OK',
+    })
+
+    await expect(channels.fetchUpstreamModels({
+      base_url: 'https://example.com',
+      channel_type: 1,
+      api_key: 'sk-test',
+    })).resolves.toEqual([
+      { id: 'claude-opus-4-6', pricing_status: 'priced' },
+      { id: 'claude-sonnet-4-6', pricing_status: 'missing' },
+    ])
+  })
+})

--- a/frontend/src/api/admin/channels.ts
+++ b/frontend/src/api/admin/channels.ts
@@ -191,9 +191,42 @@ export interface FetchUpstreamModelsRequest {
   account_id?: number
 }
 
-export async function fetchUpstreamModels(req: FetchUpstreamModelsRequest): Promise<string[]> {
-  const { data } = await apiClient.post<{ models: string[] }>('/admin/channel-types/fetch-upstream-models', req)
-  return Array.isArray(data?.models) ? data.models : []
+export type FetchedUpstreamModelPricingStatus = 'priced' | 'missing'
+
+export interface FetchedUpstreamModel {
+  id: string
+  pricing_status?: FetchedUpstreamModelPricingStatus
+}
+
+type RawFetchedUpstreamModel = string | Partial<FetchedUpstreamModel> | Record<string, unknown>
+
+function normalizeFetchedUpstreamModel(item: RawFetchedUpstreamModel): FetchedUpstreamModel | null {
+  if (typeof item === 'string') {
+    const id = item.trim()
+    return id ? { id } : null
+  }
+  if (!item || typeof item !== 'object') return null
+  const raw = (item as Record<string, unknown>).id ?? (item as Record<string, unknown>).model_id ?? (item as Record<string, unknown>).model
+  if (typeof raw !== 'string') return null
+  const id = raw.trim()
+  if (!id) return null
+  const pricingStatus = (item as Record<string, unknown>).pricing_status
+  return pricingStatus === 'priced' || pricingStatus === 'missing'
+    ? { id, pricing_status: pricingStatus }
+    : { id }
+}
+
+export async function fetchUpstreamModels(req: FetchUpstreamModelsRequest): Promise<FetchedUpstreamModel[]> {
+  const { data } = await apiClient.post<{ models: RawFetchedUpstreamModel[] }>('/admin/channel-types/fetch-upstream-models', req)
+  if (!Array.isArray(data?.models)) return []
+  const seen = new Set<string>()
+  return data.models
+    .map(normalizeFetchedUpstreamModel)
+    .filter((model): model is FetchedUpstreamModel => {
+      if (!model || seen.has(model.id)) return false
+      seen.add(model.id)
+      return true
+    })
 }
 
 export async function aggregatedGroupModels(params: {

--- a/frontend/src/components/account/AccountNewApiPlatformFields.vue
+++ b/frontend/src/components/account/AccountNewApiPlatformFields.vue
@@ -66,6 +66,7 @@ const openaiOrganization = defineModel<string>('openaiOrganization', { default: 
 const allowedModels = defineModel<string[]>('allowedModels', { default: () => [] })
 const modelMappings = defineModel<{ from: string; to: string }[]>('modelMappings', { default: () => [] })
 const restrictionMode = defineModel<'whitelist' | 'mapping'>('restrictionMode', { default: 'whitelist' })
+const pricingStatusByModel = defineModel<Record<string, 'priced' | 'missing' | undefined>>('pricingStatusByModel', { default: () => ({}) })
 
 const { t } = useI18n()
 
@@ -178,7 +179,7 @@ function removeMapping(index: number): void {
       </div>
 
       <div v-if="restrictionMode === 'whitelist'">
-        <ModelWhitelistSelector v-model="allowedModels" platform="newapi" />
+        <ModelWhitelistSelector v-model="allowedModels" platform="newapi" :pricing-status-by-model="pricingStatusByModel" />
         <p class="mt-1 text-xs text-gray-500 dark:text-gray-400">
           {{ t('admin.accounts.selectedModels', { count: allowedModels.length }) }}
           <span v-if="allowedModels.length === 0">{{ t('admin.accounts.supportsAllModels') }}</span>

--- a/frontend/src/components/account/CreateAccountModal.vue
+++ b/frontend/src/components/account/CreateAccountModal.vue
@@ -42,6 +42,7 @@
     <form
       v-if="step === 1"
       id="create-account-form"
+      novalidate
       @submit.prevent="handleSubmit"
       class="space-y-5"
     >
@@ -178,6 +179,7 @@
           v-model:statusCodeMapping="newapiStatusCodeMapping"
           v-model:openaiOrganization="newapiOpenAIOrganization"
           v-model:allowedModels="newapiAllowedModels"
+          v-model:pricingStatusByModel="newapiUpstreamModelPricingStatus"
           v-model:modelMappings="newapiModelMappings"
           v-model:restrictionMode="newapiRestrictionMode"
           :channel-type-options="newapiChannelTypeOptions"
@@ -3420,6 +3422,7 @@ const {
   statusCodeMapping: newapiStatusCodeMapping,
   openaiOrganization: newapiOpenAIOrganization,
   allowedModels: newapiAllowedModels,
+  upstreamModelPricingStatus: newapiUpstreamModelPricingStatus,
   modelMappings: newapiModelMappings,
   restrictionMode: newapiRestrictionMode,
   channelTypeOptions: newapiChannelTypeOptions,

--- a/frontend/src/components/account/EditAccountModal.vue
+++ b/frontend/src/components/account/EditAccountModal.vue
@@ -43,6 +43,7 @@
           v-model:statusCodeMapping="newapiStatusCodeMapping"
           v-model:openaiOrganization="newapiOpenAIOrganization"
           v-model:allowedModels="newapiAllowedModels"
+          v-model:pricingStatusByModel="newapiUpstreamModelPricingStatus"
           v-model:modelMappings="newapiModelMappings"
           v-model:restrictionMode="newapiRestrictionMode"
           :channel-type-options="newapiChannelTypeOptions"
@@ -2281,6 +2282,7 @@ const {
   statusCodeMapping: newapiStatusCodeMapping,
   openaiOrganization: newapiOpenAIOrganization,
   allowedModels: newapiAllowedModels,
+  upstreamModelPricingStatus: newapiUpstreamModelPricingStatus,
   modelMappings: newapiModelMappings,
   restrictionMode: newapiRestrictionMode,
   channelTypeOptions: newapiChannelTypeOptions,

--- a/frontend/src/components/account/ModelWhitelistSelector.vue
+++ b/frontend/src/components/account/ModelWhitelistSelector.vue
@@ -8,13 +8,19 @@
       >
         <div class="grid grid-cols-2 gap-1.5">
           <span
-            v-for="model in modelValue"
+            v-for="model in selectedModels"
             :key="model"
             class="inline-flex items-center justify-between gap-1 rounded bg-gray-100 px-2 py-1 text-xs text-gray-700 dark:bg-dark-600 dark:text-gray-300"
           >
             <span class="flex items-center gap-1 truncate">
               <ModelIcon :model="model" size="14px" />
               <span class="truncate">{{ model }}</span>
+              <span
+                v-if="pricingStatusByModel[model]"
+                :class="pricingStatusClass(pricingStatusByModel[model])"
+              >
+                {{ pricingStatusLabel(pricingStatusByModel[model]) }}
+              </span>
             </span>
             <button
               type="button"
@@ -26,7 +32,7 @@
           </span>
         </div>
         <div class="mt-2 flex items-center justify-between border-t border-gray-200 pt-2 dark:border-dark-600">
-          <span class="text-xs text-gray-400">{{ t('admin.accounts.modelCount', { count: modelValue.length }) }}</span>
+          <span class="text-xs text-gray-400">{{ t('admin.accounts.modelCount', { count: selectedModels.length }) }}</span>
           <svg class="h-5 w-5 text-gray-400" fill="none" viewBox="0 0 24 24" stroke="currentColor">
             <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M19 9l-7 7-7-7" />
           </svg>
@@ -57,17 +63,23 @@
             <span
               :class="[
                 'flex h-4 w-4 shrink-0 items-center justify-center rounded border',
-                modelValue.includes(model.value)
+                selectedModels.includes(model.value)
                   ? 'border-primary-500 bg-primary-500 text-white'
                   : 'border-gray-300 dark:border-dark-500'
               ]"
             >
-              <svg v-if="modelValue.includes(model.value)" class="h-3 w-3" fill="none" viewBox="0 0 24 24" stroke="currentColor">
+              <svg v-if="selectedModels.includes(model.value)" class="h-3 w-3" fill="none" viewBox="0 0 24 24" stroke="currentColor">
                 <path stroke-linecap="round" stroke-linejoin="round" stroke-width="3" d="M5 13l4 4L19 7" />
               </svg>
             </span>
             <ModelIcon :model="model.value" size="18px" />
             <span class="truncate text-gray-900 dark:text-white">{{ model.value }}</span>
+            <span
+              v-if="pricingStatusByModel[model.value]"
+              :class="pricingStatusClass(pricingStatusByModel[model.value])"
+            >
+              {{ pricingStatusLabel(pricingStatusByModel[model.value]) }}
+            </span>
           </button>
           <div v-if="filteredModels.length === 0" class="px-3 py-4 text-center text-sm text-gray-500">
             {{ t('admin.accounts.noMatchingModels') }}
@@ -129,11 +141,14 @@ import { allModels, getModelsByPlatform } from '@/composables/useModelWhitelist'
 
 const { t } = useI18n()
 
-const props = defineProps<{
-  modelValue: string[]
+const props = withDefaults(defineProps<{
+  modelValue: unknown[]
   platform?: string
   platforms?: string[]
-}>()
+  pricingStatusByModel?: Record<string, 'priced' | 'missing' | undefined>
+}>(), {
+  pricingStatusByModel: () => ({})
+})
 
 const emit = defineEmits<{
   'update:modelValue': [value: string[]]
@@ -145,6 +160,27 @@ const showDropdown = ref(false)
 const searchQuery = ref('')
 const customModel = ref('')
 const isComposing = ref(false)
+
+const modelID = (value: unknown): string => {
+  if (typeof value === 'string') return value.trim()
+  if (value && typeof value === 'object') {
+    const raw = (value as Record<string, unknown>).id
+    return typeof raw === 'string' ? raw.trim() : ''
+  }
+  return ''
+}
+
+const selectedModels = computed(() => {
+  const seen = new Set<string>()
+  return (props.modelValue || [])
+    .map(modelID)
+    .filter((model) => {
+      if (!model || seen.has(model)) return false
+      seen.add(model)
+      return true
+    })
+})
+
 const normalizedPlatforms = computed(() => {
   const rawPlatforms =
     props.platforms && props.platforms.length > 0
@@ -191,25 +227,25 @@ const toggleDropdown = () => {
 }
 
 const removeModel = (model: string) => {
-  emit('update:modelValue', props.modelValue.filter(m => m !== model))
+  emit('update:modelValue', selectedModels.value.filter(m => m !== model))
 }
 
 const toggleModel = (model: string) => {
-  if (props.modelValue.includes(model)) {
+  if (selectedModels.value.includes(model)) {
     removeModel(model)
   } else {
-    emit('update:modelValue', [...props.modelValue, model])
+    emit('update:modelValue', [...selectedModels.value, model])
   }
 }
 
 const addCustom = () => {
   const model = customModel.value.trim()
   if (!model) return
-  if (props.modelValue.includes(model)) {
+  if (selectedModels.value.includes(model)) {
     appStore.showInfo(t('admin.accounts.modelExists'))
     return
   }
-  emit('update:modelValue', [...props.modelValue, model])
+  emit('update:modelValue', [...selectedModels.value, model])
   customModel.value = ''
 }
 
@@ -218,7 +254,7 @@ const handleEnter = () => {
 }
 
 const fillRelated = () => {
-  const newModels = [...props.modelValue]
+  const newModels = [...selectedModels.value]
   for (const platform of normalizedPlatforms.value) {
     for (const model of getModelsByPlatform(platform)) {
       if (!newModels.includes(model)) {
@@ -228,6 +264,21 @@ const fillRelated = () => {
   }
   emit('update:modelValue', newModels)
 }
+
+const pricingStatusByModel = computed(() => props.pricingStatusByModel || {})
+
+const pricingStatusLabel = (status: 'priced' | 'missing' | undefined) => {
+  if (status === 'priced') return t('admin.accounts.newApiPlatform.pricingStatusPriced')
+  if (status === 'missing') return t('admin.accounts.newApiPlatform.pricingStatusMissing')
+  return ''
+}
+
+const pricingStatusClass = (status: 'priced' | 'missing' | undefined) => [
+  'shrink-0 rounded px-1 py-0.5 text-[10px] font-medium leading-none',
+  status === 'priced'
+    ? 'bg-emerald-100 text-emerald-700 dark:bg-emerald-900/30 dark:text-emerald-300'
+    : 'bg-amber-100 text-amber-700 dark:bg-amber-900/30 dark:text-amber-300'
+]
 
 const clearAll = () => {
   emit('update:modelValue', [])

--- a/frontend/src/components/account/__tests__/AccountNewApiPlatformFields.spec.ts
+++ b/frontend/src/components/account/__tests__/AccountNewApiPlatformFields.spec.ts
@@ -32,12 +32,14 @@ import AccountNewApiPlatformFields from '../AccountNewApiPlatformFields.vue'
 const ModelWhitelistSelectorStub = defineComponent({
   name: 'ModelWhitelistSelector',
   props: {
-    modelValue: { type: Array, default: () => [] }
+    modelValue: { type: Array, default: () => [] },
+    pricingStatusByModel: { type: Object, default: () => ({}) }
   },
   emits: ['update:modelValue'],
   template: `
     <div data-testid="newapi-models-selector">
       <span data-testid="newapi-models-value">{{ Array.isArray(modelValue) ? modelValue.join(',') : '' }}</span>
+      <span data-testid="newapi-pricing-status">{{ pricingStatusByModel?.['claude-opus-4-6'] || '' }}</span>
     </div>
   `
 })
@@ -93,6 +95,15 @@ describe('AccountNewApiPlatformFields', () => {
     // 文本区里不再渲染原来的 modelMapping JSON 输入框（D3+D4 单一事实源）
     const labels = wrapper.findAll('label').map((l) => l.text())
     expect(labels.some((l) => l.includes('admin.accounts.newApiPlatform.modelMapping'))).toBe(false)
+  })
+
+  it('passes #128 pricing_status metadata to the model selector', () => {
+    const wrapper = mountFields({
+      allowedModels: ['claude-opus-4-6'],
+      pricingStatusByModel: { 'claude-opus-4-6': 'priced' }
+    })
+
+    expect(wrapper.find('[data-testid="newapi-pricing-status"]').text()).toBe('priced')
   })
 
   it('hides the 获取模型列表 button when fetch_models_enabled is false (D3 — non-fetchable channel type)', () => {

--- a/frontend/src/components/account/__tests__/CreateAccountModal.newapi.spec.ts
+++ b/frontend/src/components/account/__tests__/CreateAccountModal.newapi.spec.ts
@@ -160,6 +160,12 @@ describe('CreateAccountModal — NewAPI (5th platform)', () => {
     createAccountMock.mockReset()
   })
 
+  it('disables native form validation so Vue submit validation always shows a toast', () => {
+    const wrapper = mountModal()
+
+    expect(wrapper.find('form#create-account-form').attributes('novalidate')).toBeDefined()
+  })
+
   // Helper: locate the platform segment buttons by their label text.
   function clickPlatform(wrapper: ReturnType<typeof mountModal>, label: string) {
     const btn = wrapper.findAll('button').find((b) => b.text().trim() === label)

--- a/frontend/src/components/account/__tests__/ModelWhitelistSelector.spec.ts
+++ b/frontend/src/components/account/__tests__/ModelWhitelistSelector.spec.ts
@@ -1,0 +1,48 @@
+import { describe, expect, it, vi } from 'vitest'
+import { mount } from '@vue/test-utils'
+
+vi.mock('vue-i18n', async () => {
+  const actual = await vi.importActual<typeof import('vue-i18n')>('vue-i18n')
+  return {
+    ...actual,
+    useI18n: () => ({
+      t: (key: string) => key
+    })
+  }
+})
+
+vi.mock('@/stores/app', () => ({
+  useAppStore: () => ({
+    showInfo: vi.fn()
+  })
+}))
+
+import ModelWhitelistSelector from '../ModelWhitelistSelector.vue'
+
+describe('ModelWhitelistSelector', () => {
+  it('normalizes #128 model objects and renders pricing status badges', () => {
+    const wrapper = mount(ModelWhitelistSelector, {
+      props: {
+        modelValue: [
+          { id: 'claude-opus-4-6', pricing_status: 'priced' },
+          { id: 'claude-sonnet-4-6', pricing_status: 'missing' },
+        ],
+        platform: 'newapi',
+        pricingStatusByModel: {
+          'claude-opus-4-6': 'priced',
+          'claude-sonnet-4-6': 'missing',
+        },
+      },
+      global: {
+        stubs: {
+          Icon: true,
+        },
+      },
+    })
+
+    expect(wrapper.text()).toContain('claude-opus-4-6')
+    expect(wrapper.text()).toContain('claude-sonnet-4-6')
+    expect(wrapper.text()).toContain('admin.accounts.newApiPlatform.pricingStatusPriced')
+    expect(wrapper.text()).toContain('admin.accounts.newApiPlatform.pricingStatusMissing')
+  })
+})

--- a/frontend/src/components/common/ModelIcon.vue
+++ b/frontend/src/components/common/ModelIcon.vue
@@ -20,7 +20,7 @@
 import { computed } from 'vue'
 
 const props = withDefaults(defineProps<{
-  model: string
+  model: unknown
   size?: string
 }>(), {
   size: '18px'
@@ -157,10 +157,19 @@ const iconData: Record<string, IconData> = {
   }
 }
 
-const fallbackText = computed(() => props.model.charAt(0).toUpperCase())
+const modelText = computed(() => {
+  if (typeof props.model === 'string') return props.model
+  if (props.model && typeof props.model === 'object') {
+    const raw = (props.model as Record<string, unknown>).id
+    if (typeof raw === 'string') return raw
+  }
+  return ''
+})
+
+const fallbackText = computed(() => (modelText.value.charAt(0) || '?').toUpperCase())
 
 const iconKey = computed(() => {
-  const modelLower = props.model.toLowerCase()
+  const modelLower = modelText.value.toLowerCase()
 
   // OpenAI models
   if (modelLower.startsWith('gpt') || modelLower.startsWith('o1') ||

--- a/frontend/src/composables/__tests__/useModelWhitelist.spec.ts
+++ b/frontend/src/composables/__tests__/useModelWhitelist.spec.ts
@@ -57,6 +57,18 @@ describe('useModelWhitelist', () => {
     })
   })
 
+  it('whitelist 模式兼容 #128 的对象模型项，只提取 id', () => {
+    const mapping = buildModelMappingObject('whitelist', [
+      { id: 'claude-opus-4-6', pricing_status: 'priced' },
+      { id: 'claude-sonnet-4-6', pricing_status: 'missing' },
+    ], [])
+
+    expect(mapping).toEqual({
+      'claude-opus-4-6': 'claude-opus-4-6',
+      'claude-sonnet-4-6': 'claude-sonnet-4-6',
+    })
+  })
+
   it('whitelist 模式会保留 GPT-5.4 官方快照的精确映射', () => {
     const mapping = buildModelMappingObject('whitelist', ['gpt-5.4-2026-03-05'], [])
 

--- a/frontend/src/composables/__tests__/useTkAccountNewApiPlatform.spec.ts
+++ b/frontend/src/composables/__tests__/useTkAccountNewApiPlatform.spec.ts
@@ -277,7 +277,11 @@ describe('useTkAccountNewApiPlatform', () => {
 
   describe('handleFetchUpstreamModels', () => {
     it('成功 → 写入 allowedModels + 强制切回 whitelist 模式 + showSuccess', async () => {
-      fetchUpstreamModelsMock.mockResolvedValue(['m1', 'm2', 'm3'])
+      fetchUpstreamModelsMock.mockResolvedValue([
+        { id: 'm1', pricing_status: 'priced' },
+        { id: 'm2', pricing_status: 'priced' },
+        { id: 'm3', pricing_status: 'missing' },
+      ])
       const hook = useTkAccountNewApiPlatform({ isNewapi: () => true })
       hook.channelType.value = 14
       hook.baseUrl.value = 'https://api.deepseek.com'
@@ -285,10 +289,30 @@ describe('useTkAccountNewApiPlatform', () => {
       hook.restrictionMode.value = 'mapping' // 起点是 mapping
       await hook.handleFetchUpstreamModels()
       expect(hook.allowedModels.value).toEqual(['m1', 'm2', 'm3'])
+      expect(hook.upstreamModelPricingStatus.value).toEqual({
+        m1: 'priced',
+        m2: 'priced',
+        m3: 'missing',
+      })
       expect(hook.restrictionMode.value).toBe('whitelist') // 强制切回
       expect(showSuccessMock).toHaveBeenCalledWith(
         expect.stringContaining('admin.accounts.newApiPlatform.fetchUpstreamModelsSuccess')
       )
+    })
+
+    it('兼容 #128 的对象响应，只把 id 写入 allowedModels', async () => {
+      fetchUpstreamModelsMock.mockResolvedValue([
+        { id: 'claude-opus-4-6', pricing_status: 'priced' },
+        { id: 'claude-sonnet-4-6', pricing_status: 'missing' },
+      ])
+      const hook = useTkAccountNewApiPlatform({ isNewapi: () => true })
+      hook.channelType.value = 14
+      hook.baseUrl.value = 'https://api.deepseek.com'
+      hook.apiKey.value = 'sk-test'
+
+      await hook.handleFetchUpstreamModels()
+
+      expect(hook.allowedModels.value).toEqual(['claude-opus-4-6', 'claude-sonnet-4-6'])
     })
 
     it('上游返回空 → showInfo 且不污染 allowedModels', async () => {

--- a/frontend/src/composables/useModelWhitelist.ts
+++ b/frontend/src/composables/useModelWhitelist.ts
@@ -426,6 +426,15 @@ export function getPresetMappingsByPlatform(platform: string) {
 // 构建模型映射对象（用于 API）
 // =====================
 
+function normalizeModelID(value: unknown): string {
+  if (typeof value === 'string') return value.trim()
+  if (value && typeof value === 'object') {
+    const raw = (value as Record<string, unknown>).id
+    return typeof raw === 'string' ? raw.trim() : ''
+  }
+  return ''
+}
+
 // isValidWildcardPattern 校验通配符格式：* 只能放在末尾
 // 导出供表单组件使用实时校验
 export function isValidWildcardPattern(pattern: string): boolean {
@@ -437,13 +446,15 @@ export function isValidWildcardPattern(pattern: string): boolean {
 
 export function buildModelMappingObject(
   mode: 'whitelist' | 'mapping',
-  allowedModels: string[],
+  allowedModels: unknown[],
   modelMappings: { from: string; to: string }[]
 ): Record<string, string> | null {
   const mapping: Record<string, string> = {}
 
   if (mode === 'whitelist') {
-    for (const model of allowedModels) {
+    for (const item of allowedModels) {
+      const model = normalizeModelID(item)
+      if (!model) continue
       // whitelist 模式的本意是"精确模型列表"，如果用户输入了通配符（如 claude-*），
       // 写入 model_mapping 会导致 GetMappedModel() 把真实模型映射成 "claude-*"，从而转发失败。
       // 因此这里跳过包含通配符的条目。

--- a/frontend/src/composables/useTkAccountNewApiPlatform.ts
+++ b/frontend/src/composables/useTkAccountNewApiPlatform.ts
@@ -1,7 +1,7 @@
 import { ref, computed, watch, type Ref, type ComputedRef } from 'vue'
 import { useI18n } from 'vue-i18n'
 import { useAppStore } from '@/stores/app'
-import { fetchUpstreamModels } from '@/api/admin/channels'
+import { fetchUpstreamModels, type FetchedUpstreamModel } from '@/api/admin/channels'
 import { useNewApiChannelTypes } from '@/composables/useNewApiChannelTypes'
 import { isNewApiUpstreamFetchableChannelType } from '@/constants/newApiUpstreamFetchableChannelTypes'
 import { buildModelMappingObject } from '@/composables/useModelWhitelist'
@@ -69,6 +69,7 @@ export function useTkAccountNewApiPlatform(options: UseTkAccountNewApiPlatformOp
   const statusCodeMapping = ref('')
   const openaiOrganization = ref('')
   const allowedModels = ref<string[]>([])
+  const upstreamModelPricingStatus = ref<Record<string, FetchedUpstreamModel['pricing_status']>>({})
   const modelMappings = ref<Array<{ from: string; to: string }>>([])
   const restrictionMode = ref<'whitelist' | 'mapping'>('whitelist')
   const fetchLoading = ref(false)
@@ -135,7 +136,8 @@ export function useTkAccountNewApiPlatform(options: UseTkAccountNewApiPlatformOp
       }
       // 拉到 N 个模型 → 强制切回 whitelist 模式；如果留在 mapping 模式会
       // 把 N 个模型变成 N 行无意义的 X→X 配对，淹没用户原本想填的特殊重命名。
-      allowedModels.value = [...models]
+      allowedModels.value = models.map((model) => model.id)
+      upstreamModelPricingStatus.value = buildPricingStatusMap(models)
       restrictionMode.value = 'whitelist'
       appStore.showSuccess(
         t('admin.accounts.newApiPlatform.fetchUpstreamModelsSuccess', { count: models.length })
@@ -168,6 +170,7 @@ export function useTkAccountNewApiPlatform(options: UseTkAccountNewApiPlatformOp
     statusCodeMapping.value = ''
     openaiOrganization.value = ''
     allowedModels.value = []
+    upstreamModelPricingStatus.value = {}
     modelMappings.value = []
     restrictionMode.value = 'whitelist'
     fetchLoading.value = false
@@ -207,20 +210,24 @@ export function useTkAccountNewApiPlatform(options: UseTkAccountNewApiPlatformOp
       if (entries.length === 0) {
         restrictionMode.value = 'whitelist'
         allowedModels.value = []
+        upstreamModelPricingStatus.value = {}
         modelMappings.value = []
       } else if (entries.every(([from, to]) => from === to)) {
         restrictionMode.value = 'whitelist'
         allowedModels.value = entries.map(([from]) => from)
+        upstreamModelPricingStatus.value = {}
         modelMappings.value = []
       } else {
         restrictionMode.value = 'mapping'
         allowedModels.value = []
+        upstreamModelPricingStatus.value = {}
         modelMappings.value = entries.map(([from, to]) => ({ from, to }))
       }
     } else {
       modelMapping.value = typeof existing === 'string' ? existing : ''
       restrictionMode.value = 'whitelist'
       allowedModels.value = []
+      upstreamModelPricingStatus.value = {}
       modelMappings.value = []
     }
   }
@@ -290,6 +297,7 @@ export function useTkAccountNewApiPlatform(options: UseTkAccountNewApiPlatformOp
     statusCodeMapping,
     openaiOrganization,
     allowedModels,
+    upstreamModelPricingStatus,
     modelMappings,
     restrictionMode,
     // computed props for AccountNewApiPlatformFields
@@ -318,4 +326,12 @@ function isValidJsonObject(raw: string): boolean {
   } catch {
     return false
   }
+}
+
+function buildPricingStatusMap(models: FetchedUpstreamModel[]): Record<string, FetchedUpstreamModel['pricing_status']> {
+  const out: Record<string, FetchedUpstreamModel['pricing_status']> = {}
+  for (const model of models) {
+    if (model.pricing_status) out[model.id] = model.pricing_status
+  }
+  return out
 }

--- a/frontend/src/i18n/locales/en.ts
+++ b/frontend/src/i18n/locales/en.ts
@@ -3288,6 +3288,8 @@ export default {
         fetchUpstreamModelsEmpty: 'Upstream returned no models',
         fetchUpstreamModelsSuccess: 'Fetched {count} models from upstream',
         fetchUpstreamModelsFailed: 'Failed to fetch upstream model list',
+        pricingStatusPriced: 'Priced',
+        pricingStatusMissing: 'Missing price',
         statusCodeMapping: 'Status Code Mapping (JSON, optional)',
         statusCodeMappingHint: 'Remaps upstream HTTP status codes, for example 404 to 500. Leave empty to pass through.',
         openaiOrganization: 'OpenAI Organization (optional)',

--- a/frontend/src/i18n/locales/zh.ts
+++ b/frontend/src/i18n/locales/zh.ts
@@ -3428,6 +3428,8 @@ export default {
         fetchUpstreamModelsEmpty: '上游未返回任何模型',
         fetchUpstreamModelsSuccess: '已获取 {count} 个上游模型',
         fetchUpstreamModelsFailed: '获取上游模型列表失败',
+        pricingStatusPriced: '已定价',
+        pricingStatusMissing: '缺定价',
         statusCodeMapping: '状态码映射（JSON，可选）',
         statusCodeMappingHint: '将上游 HTTP 状态码改写为另一个值，例如 404 改为 500。留空则透传。',
         openaiOrganization: 'OpenAI Organization（可选）',

--- a/scripts/newapi-sentinels.json
+++ b/scripts/newapi-sentinels.json
@@ -71,6 +71,61 @@
       "path": "frontend/src/composables/usePlatformOptions.ts",
       "must_contain": ["newapi:"],
       "rationale": "Shared composable that builds platform option lists for admin pickers/filters. The `newapi:` label entry is what surfaces the fifth platform's display name."
+    },
+    {
+      "path": "frontend/src/api/admin/channels.ts",
+      "must_contain": [
+        "FetchedUpstreamModelPricingStatus",
+        "normalizeFetchedUpstreamModel",
+        "pricing_status",
+        "Promise<FetchedUpstreamModel[]>"
+      ],
+      "rationale": "NewAPI upstream model discovery changed in #128 from string[] to object records that carry pricing_status. The frontend API wrapper must normalize both old and new response shapes and preserve pricing status metadata; otherwise fetched objects flow into account forms and crash string-only UI paths before create/update reaches the backend."
+    },
+    {
+      "path": "frontend/src/composables/useTkAccountNewApiPlatform.ts",
+      "must_contain": [
+        "upstreamModelPricingStatus",
+        "models.map((model) => model.id)",
+        "buildPricingStatusMap"
+      ],
+      "rationale": "The NewAPI account composable is the contract boundary between #128's object response and the account submit payload. It must split fetched models into string IDs for allowedModels/model_mapping and a separate pricing-status map for display-only metadata; if an upstream merge reverts this, create/edit silently breaks with object values in string-only code."
+    },
+    {
+      "path": "frontend/src/components/account/AccountNewApiPlatformFields.vue",
+      "must_contain": [
+        "pricingStatusByModel",
+        ":pricing-status-by-model=\"pricingStatusByModel\""
+      ],
+      "rationale": "The shared NewAPI field component must pass #128 pricing_status metadata into the whitelist selector without changing submit semantics. Dropping this binding compiles cleanly but regresses the pricing-source-of-truth UI contract."
+    },
+    {
+      "path": "frontend/src/components/account/ModelWhitelistSelector.vue",
+      "must_contain": [
+        "modelValue: unknown[]",
+        "const modelID = (value: unknown): string",
+        "selectedModels",
+        "pricingStatusByModel"
+      ],
+      "rationale": "The selector is the UI crash point from the production incident: object-shaped model entries from #128 must be normalized to IDs before includes/render paths, while pricing_status remains badge metadata only. Upstream merges touching this shared component can revert to string[] assumptions without compile failures."
+    },
+    {
+      "path": "frontend/src/components/common/ModelIcon.vue",
+      "must_contain": [
+        "model: unknown",
+        "modelText.value.toLowerCase()",
+        "fallbackText"
+      ],
+      "rationale": "ModelIcon was one of the observed crash sites (`model.toLowerCase is not a function`). It must tolerate object-shaped model values and derive icon matching from a normalized string, because upstream/shared UI changes can reintroduce direct string assumptions while TypeScript still compiles at call sites."
+    },
+    {
+      "path": "frontend/src/composables/useModelWhitelist.ts",
+      "must_contain": [
+        "function normalizeModelID(value: unknown): string",
+        "allowedModels: unknown[]",
+        "const model = normalizeModelID(item)"
+      ],
+      "rationale": "buildModelMappingObject must tolerate stale object entries and emit only string-to-string model_mapping pairs. Without this normalization, the submit path can hit `includes is not a function` or persist invalid object-shaped model mappings after #128 responses."
     }
   ]
 }


### PR DESCRIPTION
## Summary
- Accept #128 upstream model discovery responses shaped as `{ id, pricing_status }` in the NewAPI account form.
- Keep submitted `credentials.model_mapping` based on string model IDs while preserving `pricing_status` as display-only selector metadata.
- Harden selector/icon/model-mapping paths against object-shaped model entries and disable native form validation so Vue submit toasts still run.

## Test plan
- [x] `pnpm --prefix ./frontend exec vitest run src/api/__tests__/admin.channels.spec.ts src/components/account/__tests__/ModelWhitelistSelector.spec.ts src/components/account/__tests__/AccountNewApiPlatformFields.spec.ts src/components/account/__tests__/CreateAccountModal.newapi.spec.ts src/composables/__tests__/useTkAccountNewApiPlatform.spec.ts src/composables/__tests__/useModelWhitelist.spec.ts`
- [x] `pnpm --prefix ./frontend run build`
- [x] `bash scripts/preflight.sh`

🤖 Generated with [Claude Code](https://claude.com/claude-code)