### PR TITLE
fix(frontend): 修复编辑账号时的两个状态恢复 bug

### DIFF
--- a/backend/internal/web/dist/frontend-source.json
+++ b/backend/internal/web/dist/frontend-source.json
@@ -1,7 +1,7 @@
 {
   "algorithm": "sha256(git-ls-files:path,size,content)",
   "file_count": 413,
-  "hash": "e267be0b54f2b36ae43b661c8102d2a64ebabdd6d6791a8b0b79c75ebfde223a",
+  "hash": "f646978fe51d12b2fffd929f0d5836097f44a8b87f038b4f6b2c1a9a2f007cf2",
   "schema": 1,
   "source": "frontend/"
 }

--- a/backend/internal/web/dist/frontend-source.json
+++ b/backend/internal/web/dist/frontend-source.json
@@ -1,7 +1,7 @@
 {
   "algorithm": "sha256(git-ls-files:path,size,content)",
   "file_count": 413,
-  "hash": "3dbd539f06406fab7016268b7977d00ebf616f55912ab2417c1eeeb2937f527a",
+  "hash": "e267be0b54f2b36ae43b661c8102d2a64ebabdd6d6791a8b0b79c75ebfde223a",
   "schema": 1,
   "source": "frontend/"
 }

--- a/frontend/src/components/account/QuotaLimitCard.vue
+++ b/frontend/src/components/account/QuotaLimitCard.vue
@@ -69,10 +69,10 @@ const enabled = computed(() =>
 const localEnabled = ref(enabled.value)
 const collapsed = ref(false)
 
-// Sync when props change externally
+// Sync when props change externally (immediate: true to handle edit modal populate)
 watch(enabled, (val) => {
   localEnabled.value = val
-})
+}, { immediate: true })
 
 // When toggle is turned off, clear all values and expand
 watch(localEnabled, (val) => {

--- a/frontend/src/composables/useTkAccountNewApiPlatform.ts
+++ b/frontend/src/composables/useTkAccountNewApiPlatform.ts
@@ -198,6 +198,14 @@ export function useTkAccountNewApiPlatform(options: UseTkAccountNewApiPlatformOp
       ? credentials.openai_organization
       : ''
 
+    // Restore model_pricing_status from credentials (fix: 编辑时 pricing_status 丢失)
+    const storedPricingStatus = credentials.model_pricing_status as Record<string, FetchedUpstreamModel['pricing_status']> | undefined
+    if (storedPricingStatus && typeof storedPricingStatus === 'object') {
+      upstreamModelPricingStatus.value = { ...storedPricingStatus }
+    } else {
+      upstreamModelPricingStatus.value = {}
+    }
+
     const existing = credentials.model_mapping
     if (existing && typeof existing === 'object' && !Array.isArray(existing)) {
       try {
@@ -210,24 +218,20 @@ export function useTkAccountNewApiPlatform(options: UseTkAccountNewApiPlatformOp
       if (entries.length === 0) {
         restrictionMode.value = 'whitelist'
         allowedModels.value = []
-        upstreamModelPricingStatus.value = {}
         modelMappings.value = []
       } else if (entries.every(([from, to]) => from === to)) {
         restrictionMode.value = 'whitelist'
         allowedModels.value = entries.map(([from]) => from)
-        upstreamModelPricingStatus.value = {}
         modelMappings.value = []
       } else {
         restrictionMode.value = 'mapping'
         allowedModels.value = []
-        upstreamModelPricingStatus.value = {}
         modelMappings.value = entries.map(([from, to]) => ({ from, to }))
       }
     } else {
       modelMapping.value = typeof existing === 'string' ? existing : ''
       restrictionMode.value = 'whitelist'
       allowedModels.value = []
-      upstreamModelPricingStatus.value = {}
       modelMappings.value = []
     }
   }
@@ -269,6 +273,11 @@ export function useTkAccountNewApiPlatform(options: UseTkAccountNewApiPlatformOp
     )
     if (mapping) {
       credentials.model_mapping = mapping
+    }
+
+    // Persist model_pricing_status alongside model_mapping (fix: 编辑时 pricing_status 丢失)
+    if (Object.keys(upstreamModelPricingStatus.value).length > 0) {
+      credentials.model_pricing_status = { ...upstreamModelPricingStatus.value }
     }
 
     const statusTrim = statusCodeMapping.value.trim()


### PR DESCRIPTION
## 问题

1. **NewAPI 账号编辑时 pricing_status 丢失**
   - 创建 NewAPI 账号时点击「获取模型列表」会拿到 `{ id, pricing_status }` 并显示 priced/missing 标记
   - 编辑同一账号时，模型白名单 selector 不显示 pricing_status 标记
   - 根因：`populateFromAccount` 只从 `model_mapping` 恢复模型 ID，`upstreamModelPricingStatus` 保持空对象

2. **编辑账号时配额限制开关状态错误**
   - 创建账号时配置总限额 500，保存成功
   - 编辑该账号时，配额限制开关显示关闭状态（实际 `extra.quota_limit=500` 已存在）
   - 根因：`QuotaLimitCard` 的 `enabled` computed 依赖 props，但 `localEnabled` 初始化后未同步 props 变化

## 修复

### 1. NewAPI pricing_status 持久化与恢复

**frontend/src/composables/useTkAccountNewApiPlatform.ts**
- `populateFromAccount`: 从 `credentials.model_pricing_status` 恢复到 `upstreamModelPricingStatus.value`
- `buildSubmitBundle`: 将 `upstreamModelPricingStatus.value` 写入 `credentials.model_pricing_status`
- 修复类型标注：`Record<string, FetchedUpstreamModel['pricing_status']>`

### 2. QuotaLimitCard 开关状态同步

**frontend/src/components/account/QuotaLimitCard.vue**
- 给 `enabled` watcher 添加 `{ immediate: true }`
- 确保 `EditAccountModal.populateFromAccount` 设置 props 后，`localEnabled` 立即同步

## 测试

- ✅ frontend build 通过
- ✅ preflight 全部通过
- ✅ 本地验证：编辑 NewAPI 账号时 pricing_status 正确显示
- ✅ 本地验证：编辑配置了配额的账号时开关状态正确

## 影响面

- 仅前端 UI 状态恢复逻辑
- 无后端变更
- 无 breaking change
