### PR TITLE
fix(frontend): persist NewAPI quota and pricing metadata

### DIFF
--- a/.github/workflows/backend-ci.yml
+++ b/.github/workflows/backend-ci.yml
@@ -20,6 +20,7 @@ jobs:
     steps:
       - uses: actions/checkout@v6
         with:
+          fetch-depth: 0
           submodules: recursive
       # Preflight runs `go test` for QA evidence dataset validation; backend/go.mod
       # replaces new-api with ../../new-api — same sibling checkout as test/lint jobs.

--- a/backend/internal/web/dist/frontend-source.json
+++ b/backend/internal/web/dist/frontend-source.json
@@ -1,7 +1,7 @@
 {
   "algorithm": "sha256(git-ls-files:path,size,content)",
   "file_count": 420,
-  "hash": "6ec4e50a08e9aecf37b14985378772e90b74a5497ec3df711b6331fa75927492",
+  "hash": "c8f14a3fdc778fb2fb5e3ee3fd59cf6111837e89e17f60c4da302dbf49a91049",
   "schema": 1,
   "source": "frontend/"
 }

--- a/frontend/src/components/account/CreateAccountModal.vue
+++ b/frontend/src/components/account/CreateAccountModal.vue
@@ -4327,6 +4327,33 @@ const buildAnthropicExtra = (base?: Record<string, unknown>): Record<string, unk
   return Object.keys(extra).length > 0 ? extra : undefined
 }
 
+const buildAPIKeyOrBedrockExtra = (base?: Record<string, unknown>): Record<string, unknown> | undefined => {
+  const extra: Record<string, unknown> = { ...(base || {}) }
+  if (editQuotaLimit.value != null && editQuotaLimit.value > 0) {
+    extra.quota_limit = editQuotaLimit.value
+  }
+  if (editQuotaDailyLimit.value != null && editQuotaDailyLimit.value > 0) {
+    extra.quota_daily_limit = editQuotaDailyLimit.value
+  }
+  if (editQuotaWeeklyLimit.value != null && editQuotaWeeklyLimit.value > 0) {
+    extra.quota_weekly_limit = editQuotaWeeklyLimit.value
+  }
+  if (editDailyResetMode.value === 'fixed') {
+    extra.quota_daily_reset_mode = 'fixed'
+    extra.quota_daily_reset_hour = editDailyResetHour.value ?? 0
+  }
+  if (editWeeklyResetMode.value === 'fixed') {
+    extra.quota_weekly_reset_mode = 'fixed'
+    extra.quota_weekly_reset_day = editWeeklyResetDay.value ?? 1
+    extra.quota_weekly_reset_hour = editWeeklyResetHour.value ?? 0
+  }
+  if (editDailyResetMode.value === 'fixed' || editWeeklyResetMode.value === 'fixed') {
+    extra.quota_reset_timezone = editResetTimezone.value || 'UTC'
+  }
+  writeQuotaNotifyToExtra(extra, 'create')
+  return Object.keys(extra).length > 0 ? extra : undefined
+}
+
 // Helper function to create account with mixed channel warning handling
 const doCreateAccount = async (payload: CreateAccountRequest) => {
   const canContinue = await ensureAntigravityMixedChannelConfirmed(async () => {
@@ -4516,6 +4543,7 @@ const handleSubmit = async () => {
       type: 'apikey',
       channel_type: bundle.channelType,
       credentials: bundle.credentials,
+      extra: buildAPIKeyOrBedrockExtra(),
       proxy_id: form.proxy_id,
       concurrency: form.concurrency,
       load_factor: form.load_factor ?? undefined,
@@ -4706,37 +4734,9 @@ const createAccountAndFinish = async (
     return
   }
   // Inject quota limits for apikey/bedrock accounts
-  let finalExtra = extra
-  if (type === 'apikey' || type === 'bedrock') {
-    const quotaExtra: Record<string, unknown> = { ...(extra || {}) }
-    if (editQuotaLimit.value != null && editQuotaLimit.value > 0) {
-      quotaExtra.quota_limit = editQuotaLimit.value
-    }
-    if (editQuotaDailyLimit.value != null && editQuotaDailyLimit.value > 0) {
-      quotaExtra.quota_daily_limit = editQuotaDailyLimit.value
-    }
-    if (editQuotaWeeklyLimit.value != null && editQuotaWeeklyLimit.value > 0) {
-      quotaExtra.quota_weekly_limit = editQuotaWeeklyLimit.value
-    }
-    // Quota reset mode config
-    if (editDailyResetMode.value === 'fixed') {
-      quotaExtra.quota_daily_reset_mode = 'fixed'
-      quotaExtra.quota_daily_reset_hour = editDailyResetHour.value ?? 0
-    }
-    if (editWeeklyResetMode.value === 'fixed') {
-      quotaExtra.quota_weekly_reset_mode = 'fixed'
-      quotaExtra.quota_weekly_reset_day = editWeeklyResetDay.value ?? 1
-      quotaExtra.quota_weekly_reset_hour = editWeeklyResetHour.value ?? 0
-    }
-    if (editDailyResetMode.value === 'fixed' || editWeeklyResetMode.value === 'fixed') {
-      quotaExtra.quota_reset_timezone = editResetTimezone.value || 'UTC'
-    }
-    // Quota notify config
-    writeQuotaNotifyToExtra(quotaExtra, 'create')
-    if (Object.keys(quotaExtra).length > 0) {
-      finalExtra = quotaExtra
-    }
-  }
+  const finalExtra = (type === 'apikey' || type === 'bedrock')
+    ? buildAPIKeyOrBedrockExtra(extra)
+    : extra
   if (platform === 'openai') {
     const compactModelMapping = buildOpenAICompactModelMapping()
     if (compactModelMapping) {

--- a/frontend/src/components/account/EditAccountModal.vue
+++ b/frontend/src/components/account/EditAccountModal.vue
@@ -2296,6 +2296,7 @@ const {
   populateFromAccount: newapiPopulateFromAccount,
   buildSubmitBundle: newapiBuildSubmitBundle,
   handleFetchUpstreamModels: newapiHandleFetchUpstreamModels,
+  refreshStoredPricingStatus: newapiRefreshStoredPricingStatus,
 } = useTkAccountNewApiPlatform({
   isNewapi: () => props.account?.platform === 'newapi',
   storedAccount: () => (props.account ? { id: props.account.id, channel_type: props.account.channel_type } : null),
@@ -2747,6 +2748,9 @@ const syncFormFromAccount = (newAccount: Account | null) => {
         credentials,
       })
       newapiBootstrap()
+      if (!credentials.model_pricing_status) {
+        void newapiRefreshStoredPricingStatus()
+      }
     }
 
     // Load model mappings and detect mode

--- a/frontend/src/composables/useTkAccountNewApiPlatform.ts
+++ b/frontend/src/composables/useTkAccountNewApiPlatform.ts
@@ -110,8 +110,19 @@ export function useTkAccountNewApiPlatform(options: UseTkAccountNewApiPlatformOp
 
   // ---- 副作用：获取上游模型列表 ------------------------------------------
   async function handleFetchUpstreamModels(): Promise<void> {
+    await fetchAndApplyUpstreamModels('replace')
+  }
+
+  async function refreshStoredPricingStatus(): Promise<void> {
+    await fetchAndApplyUpstreamModels('pricing-only', false)
+  }
+
+  async function fetchAndApplyUpstreamModels(
+    mode: 'replace' | 'pricing-only',
+    notify = true
+  ): Promise<void> {
     if (!channelType.value || channelType.value <= 0) {
-      appStore.showError(t('admin.accounts.newApiPlatform.pleaseSelectChannelType'))
+      if (notify) appStore.showError(t('admin.accounts.newApiPlatform.pleaseSelectChannelType'))
       return
     }
     const base = baseUrl.value.trim() || selectedChannelTypeBaseUrl.value
@@ -119,7 +130,7 @@ export function useTkAccountNewApiPlatform(options: UseTkAccountNewApiPlatformOp
     const stored = options.storedAccount?.()
     const canUseStoredKey = !!stored?.id && stored?.channel_type === channelType.value
     if (!base || (!inputKey && !canUseStoredKey)) {
-      appStore.showError(t('admin.accounts.newApiPlatform.fetchUpstreamModelsNeedUrlKey'))
+      if (notify) appStore.showError(t('admin.accounts.newApiPlatform.fetchUpstreamModelsNeedUrlKey'))
       return
     }
     fetchLoading.value = true
@@ -131,21 +142,28 @@ export function useTkAccountNewApiPlatform(options: UseTkAccountNewApiPlatformOp
         ...(inputKey ? {} : { account_id: stored?.id }),
       })
       if (!models.length) {
-        appStore.showInfo(t('admin.accounts.newApiPlatform.fetchUpstreamModelsEmpty'))
+        if (notify) appStore.showInfo(t('admin.accounts.newApiPlatform.fetchUpstreamModelsEmpty'))
         return
       }
-      // 拉到 N 个模型 → 强制切回 whitelist 模式；如果留在 mapping 模式会
-      // 把 N 个模型变成 N 行无意义的 X→X 配对，淹没用户原本想填的特殊重命名。
-      allowedModels.value = models.map((model) => model.id)
-      upstreamModelPricingStatus.value = buildPricingStatusMap(models)
-      restrictionMode.value = 'whitelist'
-      appStore.showSuccess(
-        t('admin.accounts.newApiPlatform.fetchUpstreamModelsSuccess', { count: models.length })
-      )
+      const pricingStatus = buildPricingStatusMap(models)
+      upstreamModelPricingStatus.value = pricingStatus
+      if (mode === 'replace') {
+        // 拉到 N 个模型 → 强制切回 whitelist 模式；如果留在 mapping 模式会
+        // 把 N 个模型变成 N 行无意义的 X→X 配对，淹没用户原本想填的特殊重命名。
+        allowedModels.value = models.map((model) => model.id)
+        restrictionMode.value = 'whitelist'
+      }
+      if (notify) {
+        appStore.showSuccess(
+          t('admin.accounts.newApiPlatform.fetchUpstreamModelsSuccess', { count: models.length })
+        )
+      }
     } catch (e: unknown) {
-      appStore.showError(
-        unknownToErrorMessage(e, t('admin.accounts.newApiPlatform.fetchUpstreamModelsFailed'))
-      )
+      if (notify) {
+        appStore.showError(
+          unknownToErrorMessage(e, t('admin.accounts.newApiPlatform.fetchUpstreamModelsFailed'))
+        )
+      }
     } finally {
       fetchLoading.value = false
     }
@@ -323,6 +341,7 @@ export function useTkAccountNewApiPlatform(options: UseTkAccountNewApiPlatformOp
     populateFromAccount,
     buildSubmitBundle,
     handleFetchUpstreamModels,
+    refreshStoredPricingStatus,
   }
 }
 

--- a/scripts/check-sentinel-registry-update-gate.py
+++ b/scripts/check-sentinel-registry-update-gate.py
@@ -42,6 +42,7 @@ HOTSPOT_PATTERNS: dict[str, list[str]] = {
     "frontend/src/composables/useModelWhitelist.ts": ["scripts/newapi-sentinels.json"],
     "frontend/src/constants/gatewayPlatforms.ts": ["scripts/newapi-sentinels.json"],
     "frontend/src/composables/usePlatformOptions.ts": ["scripts/newapi-sentinels.json"],
+    "backend/internal/integration/newapi/*.go": ["scripts/newapi-sentinels.json"],
     "backend/internal/integration/newapi/**/*.go": ["scripts/newapi-sentinels.json"],
     "backend/internal/**/*_tk_*.go": ["scripts/newapi-sentinels.json", "scripts/gateway-tk-sentinels.json"],
     "backend/internal/relay/bridge/*.go": ["scripts/newapi-sentinels.json"],

--- a/scripts/check-sentinel-registry-update-gate.py
+++ b/scripts/check-sentinel-registry-update-gate.py
@@ -1,0 +1,201 @@
+#!/usr/bin/env python3
+"""
+check-sentinel-registry-update-gate.py — require sentinel registry updates when
+load-bearing TK/NewAPI surfaces change.
+
+This is the hard gate behind the recurring review note: "补充必要的 upstream
+merge 覆写防护门禁". Existing sentinel checkers prove that current literals are
+still present; this checker proves that PRs changing known hotspot files also
+update the relevant registry in the same branch.
+
+Exit codes:
+  0 — no hotspot/sentinel-covered source changed, or matching registry changed.
+  1 — source changed without a matching sentinel registry update.
+  2 — git/registry state is malformed or comparison base cannot be resolved.
+"""
+from __future__ import annotations
+
+import argparse
+import fnmatch
+import json
+import os
+import subprocess
+import sys
+from pathlib import Path
+from typing import Iterable
+
+REPO_ROOT = Path(__file__).resolve().parent.parent
+REGISTRY_GLOB = "scripts/*-sentinels.json"
+DEFAULT_BASE = "origin/main"
+
+# Hotspots that repeatedly need explicit upstream-overwrite guards. Exact files
+# already listed in a sentinel registry are also guarded automatically; these
+# patterns catch newly introduced or still-unregistered TK/NewAPI surfaces.
+HOTSPOT_PATTERNS: dict[str, list[str]] = {
+    "frontend/src/components/account/CreateAccountModal.vue": ["scripts/newapi-sentinels.json", "scripts/frontend-tk-sentinels.json"],
+    "frontend/src/components/account/EditAccountModal.vue": ["scripts/newapi-sentinels.json", "scripts/frontend-tk-sentinels.json"],
+    "frontend/src/components/account/AccountNewApiPlatformFields.vue": ["scripts/newapi-sentinels.json"],
+    "frontend/src/components/account/ModelWhitelistSelector.vue": ["scripts/newapi-sentinels.json"],
+    "frontend/src/components/account/QuotaLimitCard.vue": ["scripts/frontend-tk-sentinels.json"],
+    "frontend/src/components/common/ModelIcon.vue": ["scripts/newapi-sentinels.json"],
+    "frontend/src/composables/useTkAccountNewApiPlatform.ts": ["scripts/newapi-sentinels.json"],
+    "frontend/src/composables/useModelWhitelist.ts": ["scripts/newapi-sentinels.json"],
+    "frontend/src/constants/gatewayPlatforms.ts": ["scripts/newapi-sentinels.json"],
+    "frontend/src/composables/usePlatformOptions.ts": ["scripts/newapi-sentinels.json"],
+    "backend/internal/integration/newapi/**/*.go": ["scripts/newapi-sentinels.json"],
+    "backend/internal/**/*_tk_*.go": ["scripts/newapi-sentinels.json", "scripts/gateway-tk-sentinels.json"],
+    "backend/internal/relay/bridge/*.go": ["scripts/newapi-sentinels.json"],
+}
+
+
+def run_git(args: list[str], check: bool = True) -> subprocess.CompletedProcess[str]:
+    return subprocess.run(
+        ["git", *args],
+        cwd=REPO_ROOT,
+        text=True,
+        stdout=subprocess.PIPE,
+        stderr=subprocess.PIPE,
+        check=check,
+    )
+
+
+def resolve_base(explicit_base: str | None) -> str | None:
+    base = explicit_base or os.environ.get("SENTINEL_GATE_BASE_REF")
+    if not base:
+        github_base = os.environ.get("GITHUB_BASE_REF")
+        base = f"origin/{github_base}" if github_base else DEFAULT_BASE
+
+    current_branch = run_git(["branch", "--show-current"], check=False).stdout.strip()
+    if not explicit_base and not os.environ.get("SENTINEL_GATE_BASE_REF") and not os.environ.get("GITHUB_BASE_REF"):
+        if current_branch in {"main", "master"}:
+            return None
+
+    if run_git(["rev-parse", "--verify", f"{base}^{{commit}}"], check=False).returncode == 0:
+        return base
+
+    # CI checkout may only have refs/remotes/origin/main after fetch-depth:0;
+    # local checkouts may have main but not origin/main if remote setup is unusual.
+    fallback = "main" if base == DEFAULT_BASE else None
+    if fallback and run_git(["rev-parse", "--verify", f"{fallback}^{{commit}}"], check=False).returncode == 0:
+        return fallback
+
+    print(
+        f"FATAL: cannot resolve comparison base `{base}`. Fetch origin/main or set SENTINEL_GATE_BASE_REF.",
+        file=sys.stderr,
+    )
+    return "__UNRESOLVED__"
+
+
+def changed_files(base: str, head: str) -> set[str]:
+    proc = run_git(["diff", "--name-only", "--diff-filter=ACMRTUXB", f"{base}...{head}"])
+    return {line.strip() for line in proc.stdout.splitlines() if line.strip()}
+
+
+def registry_paths() -> list[Path]:
+    return sorted(REPO_ROOT.glob(REGISTRY_GLOB))
+
+
+def load_standard_sentinels(path: Path) -> list[dict]:
+    try:
+        data = json.loads(path.read_text(encoding="utf-8"))
+    except json.JSONDecodeError as exc:
+        raise SystemExit(f"FATAL: invalid JSON in {path.relative_to(REPO_ROOT)}: {exc}")
+    sentinels = data.get("sentinels")
+    if not isinstance(sentinels, list):
+        return []
+    return [entry for entry in sentinels if isinstance(entry, dict)]
+
+
+def covered_paths_by_registry() -> dict[str, set[str]]:
+    out: dict[str, set[str]] = {}
+    for registry in registry_paths():
+        rel_registry = registry.relative_to(REPO_ROOT).as_posix()
+        sentinels = load_standard_sentinels(registry)
+        if not sentinels:
+            continue
+        out.setdefault(rel_registry, set())
+        for entry in sentinels:
+            if isinstance(entry.get("path"), str):
+                out[rel_registry].add(entry["path"])
+    return out
+
+
+def matching_hotspot_registries(path: str) -> set[str]:
+    registries: set[str] = set()
+    for pattern, suggested in HOTSPOT_PATTERNS.items():
+        if fnmatch.fnmatch(path, pattern):
+            registries.update(suggested)
+    return registries
+
+
+def compact(items: Iterable[str]) -> str:
+    values = sorted(set(items))
+    return ", ".join(values) if values else "(none)"
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("--base", help="git ref to compare against (default: GITHUB_BASE_REF or origin/main)")
+    parser.add_argument("--head", default="HEAD", help="git ref to compare as the change head (default: HEAD)")
+    parser.add_argument("--quiet", action="store_true", help="only print failures")
+    args = parser.parse_args()
+
+    base = resolve_base(args.base)
+    if base is None:
+        if not args.quiet:
+            print("sentinel registry update gate: skip on main/master without explicit base")
+        return 0
+    if base == "__UNRESOLVED__":
+        return 2
+
+    if run_git(["rev-parse", "--verify", f"{args.head}^{{commit}}"], check=False).returncode != 0:
+        print(f"FATAL: cannot resolve head `{args.head}`", file=sys.stderr)
+        return 2
+
+    changed = changed_files(base, args.head)
+    if not changed:
+        if not args.quiet:
+            print(f"sentinel registry update gate: no changes vs {base}...{args.head}")
+        return 0
+
+    coverage = covered_paths_by_registry()
+    changed_registries = {p for p in changed if fnmatch.fnmatch(p, REGISTRY_GLOB)}
+    violations: list[tuple[str, set[str], set[str]]] = []
+
+    for path in sorted(changed):
+        if fnmatch.fnmatch(path, REGISTRY_GLOB):
+            continue
+        related = {registry for registry, paths in coverage.items() if path in paths}
+        related.update(matching_hotspot_registries(path))
+        if not related:
+            continue
+        if changed_registries.isdisjoint(related):
+            violations.append((path, related, changed_registries))
+
+    if not violations:
+        if not args.quiet:
+            print(
+                "sentinel registry update gate: ok "
+                f"(changed registries: {compact(changed_registries)})"
+            )
+        return 0
+
+    print("sentinel registry update gate: FAIL", file=sys.stderr)
+    print(
+        "  Load-bearing TK/NewAPI surfaces changed without updating the matching sentinel registry.",
+        file=sys.stderr,
+    )
+    for path, related, seen in violations:
+        print(f"  - {path}", file=sys.stderr)
+        print(f"      update one of: {compact(related)}", file=sys.stderr)
+        print(f"      changed registries in this diff: {compact(seen)}", file=sys.stderr)
+    print(
+        "  Fix: add/adjust the relevant sentinel literal+rationale in the same PR. "
+        "If the change is genuinely not load-bearing, record that decision by updating the registry rationale rather than relying on review memory.",
+        file=sys.stderr,
+    )
+    return 1
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/scripts/newapi-sentinels.json
+++ b/scripts/newapi-sentinels.json
@@ -87,9 +87,32 @@
       "must_contain": [
         "upstreamModelPricingStatus",
         "models.map((model) => model.id)",
-        "buildPricingStatusMap"
+        "buildPricingStatusMap",
+        "credentials.model_pricing_status",
+        "refreshStoredPricingStatus",
+        "fetchAndApplyUpstreamModels('pricing-only', false)",
+        "mode === 'replace'"
       ],
-      "rationale": "The NewAPI account composable is the contract boundary between #128's object response and the account submit payload. It must split fetched models into string IDs for allowedModels/model_mapping and a separate pricing-status map for display-only metadata; if an upstream merge reverts this, create/edit silently breaks with object values in string-only code."
+      "rationale": "The NewAPI account composable is the contract boundary between #128's object response and the account submit payload. It must split fetched models into string IDs for allowedModels/model_mapping and a separate pricing-status map for display-only metadata; if an upstream merge reverts this, create/edit silently breaks with object values in string-only code. PR #160 also fixed two silent data-loss paths: model_pricing_status must be persisted in credentials, and old accounts that lack it must be able to refresh pricing-only metadata without replacing their saved whitelist/model_mapping."
+    },
+    {
+      "path": "frontend/src/components/account/CreateAccountModal.vue",
+      "must_contain": [
+        "buildAPIKeyOrBedrockExtra",
+        "quota_limit",
+        "extra: buildAPIKeyOrBedrockExtra()",
+        "platform: 'newapi'"
+      ],
+      "rationale": "The NewAPI create branch is a direct doCreateAccount path rather than the generic createAccountAndFinish helper. PR #160 fixed a production data-loss bug where newapi account creation dropped apikey quota extra, leaving tokensea-1/2 with extra={}. These literals keep the direct newapi payload wired to the same quota-extra builder as other apikey/bedrock creates."
+    },
+    {
+      "path": "frontend/src/components/account/EditAccountModal.vue",
+      "must_contain": [
+        "refreshStoredPricingStatus: newapiRefreshStoredPricingStatus",
+        "!credentials.model_pricing_status",
+        "void newapiRefreshStoredPricingStatus()"
+      ],
+      "rationale": "Existing NewAPI accounts created before model_pricing_status persistence have no pricing metadata in credentials. EditAccountModal must silently refresh pricing-only metadata from stored credentials so badges render without overwriting the saved whitelist/model_mapping. This is easy to lose in upstream modal rewrites because the form still compiles and saves without it."
     },
     {
       "path": "frontend/src/components/account/AccountNewApiPlatformFields.vue",

--- a/scripts/preflight.sh
+++ b/scripts/preflight.sh
@@ -338,6 +338,23 @@ else
     echo "  ok: all gateway TK sentinels intact"
 fi
 
+# ---- sub2api: sentinel registry update gate ---------------------------------
+# Existing sentinel checks prove current guarded literals still exist. This gate
+# proves PRs that modify guarded/hotspot files also update the matching registry,
+# turning the recurring review ask "补充必要的 upstream merge 覆写防护门禁" into
+# a hard preflight failure instead of human memory.
+echo ""
+echo "=== sub2api: sentinel registry update gate ==="
+if ! command -v python3 >/dev/null 2>&1; then
+    echo "  FAIL: python3 not on PATH (required for sentinel registry update gate)"
+    errors=$((errors + 1))
+elif ! python3 ./scripts/check-sentinel-registry-update-gate.py --quiet; then
+    # check-sentinel-registry-update-gate.py already printed the actionable failure.
+    errors=$((errors + 1))
+else
+    echo "  ok: guarded hotspot changes update their sentinel registries"
+fi
+
 # ---- sub2api: redaction version contract ------------------------------------
 # Source of truth: scripts/redaction-sentinels.json. Verifies that the default
 # sensitive-key set in logredact and the outward QA redaction_version literals


### PR DESCRIPTION
## Summary
- Fix NewAPI account creation so quota limit extra is persisted instead of being dropped by the direct newapi create path.
- Keep model pricing metadata in `credentials.model_pricing_status` and backfill pricing badges for old NewAPI accounts by silently fetching pricing-only metadata on edit.
- Add NewAPI sentinel guards for the three upstream-merge overwrite risks: create-extra wiring, pricing-only refresh, and pricing metadata persistence.
- Harden this review pattern into CI: guarded TK/NewAPI hotspot changes now fail preflight unless the matching sentinel registry changes in the same PR.

## Review notes
- Production data for `tokensea-1/2` showed `extra={}` and no `credentials.model_pricing_status`, proving the previous fix only handled edit display after data existed.
- The direct NewAPI create branch bypassed the generic apikey/bedrock quota-extra helper; this PR routes it through the same builder.
- Pricing-only refresh intentionally does not replace `allowedModels` or `restrictionMode`, so old accounts can display badges without losing their saved whitelist/model_mapping.

## Upstream overwrite guards
- `scripts/newapi-sentinels.json` now pins:
  - `CreateAccountModal.vue`: `buildAPIKeyOrBedrockExtra`, `extra: buildAPIKeyOrBedrockExtra()`, and the `platform: 'newapi'` direct-create payload.
  - `useTkAccountNewApiPlatform.ts`: `credentials.model_pricing_status`, `refreshStoredPricingStatus`, `fetchAndApplyUpstreamModels('pricing-only', false)`, and `mode === 'replace'`.
  - `EditAccountModal.vue`: old-account missing-field backfill via `newapiRefreshStoredPricingStatus()`.
- New hard gate: `scripts/check-sentinel-registry-update-gate.py` is invoked by `scripts/preflight.sh`. If a PR changes a sentinel-covered file or known TK/NewAPI hotspot without changing the matching `*-sentinels.json`, preflight fails.
- CI preflight checkout now uses `fetch-depth: 0` so the hard gate can compare PR head against `origin/main`.

## Test plan
- `pnpm run build`
- `python3 scripts/check-newapi-sentinels.py`
- `python3 scripts/check-sentinel-registry-update-gate.py`
- Negative check: `python3 scripts/check-sentinel-registry-update-gate.py --head 95e8066d` fails when the first fix commit is evaluated without the sentinel commit.
- `bash scripts/preflight.sh`
- After deploy: create a NewAPI account with total quota=500 and verify `extra.quota_limit=500`; edit an old NewAPI account lacking `model_pricing_status` and verify badges appear without replacing whitelist.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
