### PR TITLE
fix(frontend): preserve sessions during network drops

### DIFF
--- a/backend/internal/web/dist/frontend-source.json
+++ b/backend/internal/web/dist/frontend-source.json
@@ -1,7 +1,7 @@
 {
   "algorithm": "sha256(git-ls-files:path,size,content)",
   "file_count": 421,
-  "hash": "f88ade5131dc951c5327fa68b4f528c040ac473ffeadc36911312ed4160cd6d2",
+  "hash": "d15073932ecb32e97399ea0b34ffee9325816e511a1d3c79bbbfd80628dfc996",
   "schema": 1,
   "source": "frontend/"
 }

--- a/backend/internal/web/dist/frontend-source.json
+++ b/backend/internal/web/dist/frontend-source.json
@@ -1,7 +1,7 @@
 {
   "algorithm": "sha256(git-ls-files:path,size,content)",
-  "file_count": 420,
-  "hash": "98c773595af1b22b98be1db4b140a1f5287d656af54037531ef437abd247a72d",
+  "file_count": 421,
+  "hash": "f88ade5131dc951c5327fa68b4f528c040ac473ffeadc36911312ed4160cd6d2",
   "schema": 1,
   "source": "frontend/"
 }

--- a/frontend/src/App.vue
+++ b/frontend/src/App.vue
@@ -7,6 +7,7 @@ import { resolveDocumentTitle } from '@/router/title'
 import AnnouncementPopup from '@/components/common/AnnouncementPopup.vue'
 import { useAppStore, useAuthStore, useSubscriptionStore, useAnnouncementStore } from '@/stores'
 import { getSetupStatus } from '@/api/setup'
+import { isNetworkError } from '@/api/client.tk'
 
 const router = useRouter()
 const route = useRoute()
@@ -59,7 +60,9 @@ watch(
     if (isAuthenticated) {
       // User logged in: preload subscriptions and start polling
       subscriptionStore.fetchActiveSubscriptions().catch((error) => {
-        console.error('Failed to preload subscriptions:', error)
+        if (!isNetworkError(error)) {
+          console.error('Failed to preload subscriptions:', error)
+        }
       })
       subscriptionStore.startPolling()
 

--- a/frontend/src/api/__tests__/client.spec.ts
+++ b/frontend/src/api/__tests__/client.spec.ts
@@ -182,6 +182,38 @@ describe('API Client', () => {
         writable: true,
       })
     })
+
+    it('refresh_token 请求遇到网络错误时保留 localStorage', async () => {
+      localStorage.setItem('auth_token', 'expired-token')
+      localStorage.setItem('refresh_token', 'refresh-token')
+      vi.spyOn(axios, 'post').mockRejectedValue({
+        code: 'ERR_NETWORK',
+        message: 'Network Error',
+        config: { url: '/auth/refresh' },
+      })
+
+      const adapter = vi.fn().mockRejectedValue({
+        response: {
+          status: 401,
+          data: { code: 'TOKEN_EXPIRED', message: 'Token expired' },
+        },
+        config: {
+          url: '/test',
+          headers: { Authorization: 'Bearer expired-token' },
+        },
+        code: 'ERR_BAD_REQUEST',
+      })
+      apiClient.defaults.adapter = adapter
+
+      await expect(apiClient.get('/test')).rejects.toEqual(
+        expect.objectContaining({
+          status: 0,
+          code: 'NETWORK_ERROR',
+        })
+      )
+      expect(localStorage.getItem('auth_token')).toBe('expired-token')
+      expect(localStorage.getItem('refresh_token')).toBe('refresh-token')
+    })
   })
 
   // --- 网络错误 ---

--- a/frontend/src/api/client.tk.ts
+++ b/frontend/src/api/client.tk.ts
@@ -1,0 +1,52 @@
+import type { AxiosError } from 'axios'
+
+const NETWORK_ERROR_MESSAGE = 'Network error. Please check your connection.'
+const NETWORK_ERROR_CODES = new Set([
+  'ERR_NETWORK',
+  'ERR_INTERNET_DISCONNECTED',
+  'ERR_NETWORK_CHANGED',
+  'ERR_CONNECTION_RESET',
+  'ECONNABORTED'
+])
+
+export interface ApiNetworkError {
+  status: 0
+  code: 'NETWORK_ERROR'
+  message: string
+  offline: boolean
+  url?: string
+}
+
+export function isBrowserOffline(): boolean {
+  return typeof navigator !== 'undefined' && 'onLine' in navigator && !navigator.onLine
+}
+
+export function isNetworkError(error: unknown): error is ApiNetworkError {
+  if (!error || typeof error !== 'object') return false
+  const candidate = error as { status?: unknown; code?: unknown; response?: unknown }
+  if (candidate.status === 0) return true
+  if (candidate.response) return false
+  return typeof candidate.code === 'string' && NETWORK_ERROR_CODES.has(candidate.code)
+}
+
+export function requestUrlFromError(error: unknown): string | undefined {
+  if (!error || typeof error !== 'object') return undefined
+  const directUrl = (error as { url?: unknown }).url
+  if (typeof directUrl === 'string') return directUrl
+  const config = (error as { config?: { url?: unknown } }).config
+  return typeof config?.url === 'string' ? config.url : undefined
+}
+
+export function createNetworkError(url?: string): ApiNetworkError {
+  return {
+    status: 0,
+    code: 'NETWORK_ERROR',
+    message: NETWORK_ERROR_MESSAGE,
+    offline: isBrowserOffline(),
+    ...(url ? { url } : {})
+  }
+}
+
+export function networkErrorFromAxios(error: AxiosError): ApiNetworkError {
+  return createNetworkError(error.config?.url)
+}

--- a/frontend/src/api/client.ts
+++ b/frontend/src/api/client.ts
@@ -6,6 +6,7 @@
 import axios, { AxiosInstance, AxiosError, InternalAxiosRequestConfig, AxiosResponse } from 'axios'
 import type { ApiResponse } from '@/types'
 import { getLocale } from '@/i18n'
+import { createNetworkError, isNetworkError, networkErrorFromAxios, requestUrlFromError } from './client.tk'
 
 // ==================== Axios Instance Configuration ====================
 
@@ -25,20 +26,20 @@ export const apiClient: AxiosInstance = axios.create({
 // Track if a token refresh is in progress to prevent multiple simultaneous refresh requests
 let isRefreshing = false
 // Queue of requests waiting for token refresh
-let refreshSubscribers: Array<(token: string) => void> = []
+let refreshSubscribers: Array<(token: string, error?: unknown) => void> = []
 
 /**
  * Subscribe to token refresh completion
  */
-function subscribeTokenRefresh(callback: (token: string) => void): void {
+function subscribeTokenRefresh(callback: (token: string, error?: unknown) => void): void {
   refreshSubscribers.push(callback)
 }
 
 /**
  * Notify all subscribers that token has been refreshed
  */
-function onTokenRefreshed(token: string): void {
-  refreshSubscribers.forEach((callback) => callback(token))
+function onTokenRefreshed(token: string, error?: unknown): void {
+  refreshSubscribers.forEach((callback) => callback(token, error))
   refreshSubscribers = []
 }
 
@@ -160,8 +161,10 @@ apiClient.interceptors.response.use(
           if (isRefreshing) {
             // Wait for the ongoing refresh to complete
             return new Promise((resolve, reject) => {
-              subscribeTokenRefresh((newToken: string) => {
-                if (newToken) {
+              subscribeTokenRefresh((newToken: string, refreshError?: unknown) => {
+                if (refreshError) {
+                  reject(refreshError)
+                } else if (newToken) {
                   // Mark as retried to prevent infinite loop if retry also returns 401
                   originalRequest._retry = true
                   if (originalRequest.headers) {
@@ -220,9 +223,16 @@ apiClient.interceptors.response.use(
             // Refresh response was not successful, fall through to clear auth
             throw new Error('Token refresh failed')
           } catch (refreshError) {
+            isRefreshing = false
+
+            if (isNetworkError(refreshError)) {
+              const networkError = createNetworkError(requestUrlFromError(refreshError))
+              onTokenRefreshed('', networkError)
+              return Promise.reject(networkError)
+            }
+
             // Refresh failed - notify subscribers with empty token
             onTokenRefreshed('')
-            isRefreshing = false
 
             // Clear tokens and redirect to login
             localStorage.removeItem('auth_token')
@@ -279,10 +289,7 @@ apiClient.interceptors.response.use(
     }
 
     // Network error
-    return Promise.reject({
-      status: 0,
-      message: 'Network error. Please check your connection.'
-    })
+    return Promise.reject(networkErrorFromAxios(error))
   }
 )
 

--- a/frontend/src/api/index.ts
+++ b/frontend/src/api/index.ts
@@ -5,6 +5,8 @@
 
 // Re-export the HTTP client
 export { apiClient } from './client'
+export { isBrowserOffline, isNetworkError } from './client.tk'
+export type { ApiNetworkError } from './client.tk'
 
 // Auth API
 export { authAPI, isTotp2FARequired, type LoginResponse } from './auth'

--- a/frontend/src/components/common/SubscriptionProgressMini.vue
+++ b/frontend/src/components/common/SubscriptionProgressMini.vue
@@ -182,6 +182,7 @@ import { ref, computed, onMounted, onBeforeUnmount } from 'vue'
 import { useI18n } from 'vue-i18n'
 import Icon from '@/components/icons/Icon.vue'
 import { useSubscriptionStore } from '@/stores'
+import { isNetworkError } from '@/api/client.tk'
 import type { UserSubscription } from '@/types'
 
 const { t } = useI18n()
@@ -297,7 +298,9 @@ onMounted(() => {
   // Trigger initial fetch if not already loaded
   // The actual data loading is handled by App.vue globally
   subscriptionStore.fetchActiveSubscriptions().catch((error) => {
-    console.error('Failed to load subscriptions in SubscriptionProgressMini:', error)
+    if (!isNetworkError(error)) {
+      console.error('Failed to load subscriptions in SubscriptionProgressMini:', error)
+    }
   })
 })
 

--- a/frontend/src/stores/__tests__/auth.spec.ts
+++ b/frontend/src/stores/__tests__/auth.spec.ts
@@ -212,6 +212,45 @@ describe('useAuthStore', () => {
       expect(store.isAuthenticated).toBe(true)
     })
 
+    it('离线恢复会保留本地会话且不立即请求用户接口', () => {
+      localStorage.setItem('auth_token', 'saved-token')
+      localStorage.setItem('auth_user', JSON.stringify(fakeUser))
+      const onLine = vi.spyOn(navigator, 'onLine', 'get').mockReturnValue(false)
+
+      try {
+        const store = useAuthStore()
+        store.checkAuth()
+
+        expect(store.isAuthenticated).toBe(true)
+        expect(mockGetCurrentUser).not.toHaveBeenCalled()
+      } finally {
+        onLine.mockRestore()
+      }
+    })
+
+    it('离线恢复后上线会刷新用户数据', async () => {
+      localStorage.setItem('auth_token', 'saved-token')
+      localStorage.setItem('auth_user', JSON.stringify(fakeUser))
+      const onLine = vi.spyOn(navigator, 'onLine', 'get')
+      onLine.mockReturnValue(false)
+      const updatedUser = { ...fakeUser, username: 'online-user' }
+      mockGetCurrentUser.mockResolvedValue({ data: updatedUser })
+
+      try {
+        const store = useAuthStore()
+        store.checkAuth()
+        onLine.mockReturnValue(true)
+        mockGetCurrentUser.mockClear()
+        window.dispatchEvent(new Event('online'))
+        await Promise.resolve()
+
+        expect(mockGetCurrentUser).toHaveBeenCalledTimes(1)
+        expect(store.user).toEqual(updatedUser)
+      } finally {
+        onLine.mockRestore()
+      }
+    })
+
     it('恢复持久化 pending auth session', () => {
       localStorage.setItem(
         'pending_auth_session',

--- a/frontend/src/stores/__tests__/auth.spec.ts
+++ b/frontend/src/stores/__tests__/auth.spec.ts
@@ -251,6 +251,31 @@ describe('useAuthStore', () => {
       }
     })
 
+    it('已有 token 刷新定时器时上线不会重复调度刷新', async () => {
+      localStorage.setItem('auth_token', 'saved-token')
+      localStorage.setItem('auth_user', JSON.stringify(fakeUser))
+      localStorage.setItem('refresh_token', 'saved-refresh')
+      localStorage.setItem('token_expires_at', String(Date.now() + 3600_000))
+      const onLine = vi.spyOn(navigator, 'onLine', 'get')
+      onLine.mockReturnValue(false)
+      mockGetCurrentUser.mockResolvedValue({ data: fakeUser })
+      mockRefreshToken.mockResolvedValue(fakeAuthResponse)
+
+      try {
+        const store = useAuthStore()
+        store.checkAuth()
+        onLine.mockReturnValue(true)
+        window.dispatchEvent(new Event('online'))
+        await Promise.resolve()
+        vi.advanceTimersByTime(3600_000 - 120_000)
+        await Promise.resolve()
+
+        expect(mockRefreshToken).toHaveBeenCalledTimes(1)
+      } finally {
+        onLine.mockRestore()
+      }
+    })
+
     it('恢复持久化 pending auth session', () => {
       localStorage.setItem(
         'pending_auth_session',

--- a/frontend/src/stores/__tests__/subscriptions.spec.ts
+++ b/frontend/src/stores/__tests__/subscriptions.spec.ts
@@ -143,6 +143,20 @@ describe('useSubscriptionStore', () => {
 
       await expect(store.fetchActiveSubscriptions()).rejects.toThrow('Network error')
     })
+
+    it('浏览器离线时返回当前缓存且不请求 API', async () => {
+      const onLine = vi.spyOn(navigator, 'onLine', 'get').mockReturnValue(false)
+
+      try {
+        const store = useSubscriptionStore()
+        const result = await store.fetchActiveSubscriptions(true)
+
+        expect(result).toEqual([])
+        expect(mockGetActiveSubscriptions).not.toHaveBeenCalled()
+      } finally {
+        onLine.mockRestore()
+      }
+    })
   })
 
   // --- hasActiveSubscriptions ---

--- a/frontend/src/stores/auth.ts
+++ b/frontend/src/stores/auth.ts
@@ -6,6 +6,7 @@
 import { defineStore } from 'pinia'
 import { ref, computed, readonly } from 'vue'
 import { authAPI, isTotp2FARequired, type LoginResponse } from '@/api'
+import { isBrowserOffline, isNetworkError } from '@/api/client.tk'
 import type { User, LoginRequest, RegisterRequest, AuthResponse } from '@/types'
 
 const AUTH_TOKEN_KEY = 'auth_token'
@@ -15,6 +16,8 @@ const TOKEN_EXPIRES_AT_KEY = 'token_expires_at' // 存储过期时间戳而非�
 const PENDING_AUTH_SESSION_KEY = 'pending_auth_session'
 const AUTO_REFRESH_INTERVAL = 60 * 1000 // 60 seconds for user data refresh
 const TOKEN_REFRESH_BUFFER = 120 * 1000 // 120 seconds before expiry to refresh token
+
+let activeOnlineRefreshHandler: (() => void) | null = null
 
 type PendingAuthTokenField = 'pending_auth_token' | 'pending_oauth_token'
 
@@ -115,9 +118,13 @@ export const useAuthStore = defineStore('auth', () => {
         tokenExpiresAt.value = savedExpiresAt ? parseInt(savedExpiresAt, 10) : null
 
         // Immediately refresh user data from backend (async, don't block)
-        refreshUser().catch((error) => {
-          console.error('Failed to refresh user on init:', error)
-        })
+        if (!isBrowserOffline()) {
+          refreshUser().catch((error) => {
+            if (!isNetworkError(error)) {
+              console.error('Failed to refresh user on init:', error)
+            }
+          })
+        }
 
         // Start auto-refresh interval for user data
         startAutoRefresh()
@@ -141,11 +148,14 @@ export const useAuthStore = defineStore('auth', () => {
   function startAutoRefresh(): void {
     // Clear existing interval if any
     stopAutoRefresh()
+    registerOnlineRefreshHandler()
 
     refreshIntervalId = setInterval(() => {
-      if (token.value) {
+      if (token.value && !isBrowserOffline()) {
         refreshUser().catch((error) => {
-          console.error('Auto-refresh user failed:', error)
+          if (!isNetworkError(error)) {
+            console.error('Auto-refresh user failed:', error)
+          }
         })
       }
     }, AUTO_REFRESH_INTERVAL)
@@ -171,6 +181,7 @@ export const useAuthStore = defineStore('auth', () => {
       clearTimeout(tokenRefreshTimeoutId)
       tokenRefreshTimeoutId = null
     }
+    registerOnlineRefreshHandler()
 
     // Calculate remaining time until refresh (buffer time before expiry)
     const now = Date.now()
@@ -202,7 +213,7 @@ export const useAuthStore = defineStore('auth', () => {
    * Perform the actual token refresh
    */
   async function performTokenRefresh(): Promise<void> {
-    if (!refreshTokenValue.value) {
+    if (!refreshTokenValue.value || isBrowserOffline()) {
       return
     }
 
@@ -216,8 +227,42 @@ export const useAuthStore = defineStore('auth', () => {
       // Schedule next refresh (this also updates tokenExpiresAt and localStorage)
       scheduleTokenRefresh(response.expires_in)
     } catch (error) {
-      console.error('Token refresh failed:', error)
+      if (!isNetworkError(error)) {
+        console.error('Token refresh failed:', error)
+      }
       // Don't clear auth here - the interceptor will handle 401 errors
+    }
+  }
+
+  function registerOnlineRefreshHandler(): void {
+    if (typeof window === 'undefined') return
+    if (activeOnlineRefreshHandler === handleOnline) return
+    if (activeOnlineRefreshHandler) {
+      window.removeEventListener('online', activeOnlineRefreshHandler)
+    }
+
+    window.addEventListener('online', handleOnline)
+    activeOnlineRefreshHandler = handleOnline
+  }
+
+  function unregisterOnlineRefreshHandler(): void {
+    if (typeof window === 'undefined' || activeOnlineRefreshHandler !== handleOnline) return
+
+    window.removeEventListener('online', handleOnline)
+    activeOnlineRefreshHandler = null
+  }
+
+  function handleOnline(): void {
+    if (!token.value) return
+
+    refreshUser().catch((error) => {
+      if (!isNetworkError(error)) {
+        console.error('Auto-refresh user failed:', error)
+      }
+    })
+
+    if (refreshTokenValue.value && tokenExpiresAt.value !== null) {
+      scheduleTokenRefreshAt(tokenExpiresAt.value)
     }
   }
 
@@ -445,6 +490,7 @@ export const useAuthStore = defineStore('auth', () => {
     stopAutoRefresh()
     // Stop token refresh
     stopTokenRefresh()
+    unregisterOnlineRefreshHandler()
 
     token.value = null
     refreshTokenValue.value = null

--- a/frontend/src/stores/auth.ts
+++ b/frontend/src/stores/auth.ts
@@ -261,7 +261,7 @@ export const useAuthStore = defineStore('auth', () => {
       }
     })
 
-    if (refreshTokenValue.value && tokenExpiresAt.value !== null) {
+    if (refreshTokenValue.value && tokenExpiresAt.value !== null && tokenRefreshTimeoutId === null) {
       scheduleTokenRefreshAt(tokenExpiresAt.value)
     }
   }

--- a/frontend/src/stores/subscriptions.ts
+++ b/frontend/src/stores/subscriptions.ts
@@ -6,6 +6,7 @@
 import { defineStore } from 'pinia'
 import { ref, computed } from 'vue'
 import subscriptionsAPI from '@/api/subscriptions'
+import { isBrowserOffline, isNetworkError } from '@/api/client.tk'
 import type { UserSubscription } from '@/types'
 
 // Cache TTL: 60 seconds
@@ -37,6 +38,10 @@ export const useSubscriptionStore = defineStore('subscriptions', () => {
   async function fetchActiveSubscriptions(force = false): Promise<UserSubscription[]> {
     const now = Date.now()
 
+    if (isBrowserOffline()) {
+      return activeSubscriptions.value
+    }
+
     // Return cached data if valid
     if (
       !force &&
@@ -67,7 +72,9 @@ export const useSubscriptionStore = defineStore('subscriptions', () => {
         return data
       })
       .catch((error) => {
-        console.error('Failed to fetch active subscriptions:', error)
+        if (!isNetworkError(error)) {
+          console.error('Failed to fetch active subscriptions:', error)
+        }
         throw error
       })
       .finally(() => {
@@ -89,8 +96,12 @@ export const useSubscriptionStore = defineStore('subscriptions', () => {
     if (pollerInterval) return
 
     pollerInterval = setInterval(() => {
+      if (isBrowserOffline()) return
+
       fetchActiveSubscriptions(true).catch((error) => {
-        console.error('Subscription polling failed:', error)
+        if (!isNetworkError(error)) {
+          console.error('Subscription polling failed:', error)
+        }
       })
     }, 5 * 60 * 1000)
   }

--- a/scripts/frontend-tk-sentinels.json
+++ b/scripts/frontend-tk-sentinels.json
@@ -82,6 +82,42 @@
       "rationale": "Edit-account modal must load and update account-level compaction policy from extra. Compile still passes if only one half (read/write) is dropped; these literals pin the load/edit/persist chain for upstream-merge safety."
     },
     {
+      "path": "frontend/src/api/client.tk.ts",
+      "must_contain": [
+        "NETWORK_ERROR",
+        "ERR_INTERNET_DISCONNECTED",
+        "networkErrorFromAxios"
+      ],
+      "rationale": "TK preserves the authenticated session across browser offline/network-change failures and turns Axios no-response failures into an explicit NETWORK_ERROR contract. This companion keeps the upstream-shaped client.ts to thin injection points; if an upstream merge removes this file or the contract literals, offline users can be logged out or background refresh can resume console/request storms."
+    },
+    {
+      "path": "frontend/src/api/client.ts",
+      "must_contain": [
+        "./client.tk",
+        "networkErrorFromAxios(error)",
+        "onTokenRefreshed('', networkError)"
+      ],
+      "rationale": "The upstream-shaped Axios client must keep only the TK injection points for network-error normalization and refresh-token network failure propagation. Without these literals, the companion module can remain present while the runtime silently falls back to clearing auth on transient network failures."
+    },
+    {
+      "path": "frontend/src/stores/auth.ts",
+      "must_contain": [
+        "isBrowserOffline()",
+        "window.addEventListener('online', handleOnline)",
+        "activeOnlineRefreshHandler"
+      ],
+      "rationale": "Auth background refresh must short-circuit while offline, refresh once when the browser comes back online, and keep a single active online listener across store re-initialization. These anchors guard the user-session preservation fix against upstream store rewrites that still compile but reintroduce refresh storms or listener leaks."
+    },
+    {
+      "path": "frontend/src/stores/subscriptions.ts",
+      "must_contain": [
+        "isBrowserOffline()",
+        "isNetworkError(error)",
+        "return activeSubscriptions.value"
+      ],
+      "rationale": "Subscription polling must return cached data while offline and suppress expected network-error logging. Otherwise a browser network transition causes repeated /subscriptions/active failures and noisy console output without changing UI state."
+    },
+    {
       "path": "frontend/src/api/admin/ops.ts",
       "must_contain": [
         "feishu: {",


### PR DESCRIPTION
## Summary
- Normalize browser network failures into an explicit `NETWORK_ERROR` contract so transient offline/network-change states do not clear auth.
- Pause/suppress auth and subscription background refresh noise while offline, then refresh once when the browser comes back online.
- Keep the upstream-shaped Axios client to thin injection points via `client.tk.ts`, and add frontend TK sentinels so upstream merges cannot silently remove the recovery behavior.

## Test plan
- [x] `pnpm --dir frontend test:run src/api/__tests__/client.spec.ts src/stores/__tests__/auth.spec.ts src/stores/__tests__/subscriptions.spec.ts`
- [x] `pnpm --dir frontend typecheck`
- [x] `pnpm --dir frontend lint:check` (passes with existing playground unused-var warning)
- [x] `pnpm --dir frontend run build`
- [x] `bash scripts/preflight.sh`

## Review notes
- Intent: fix browser console logs from `ERR_INTERNET_DISCONNECTED`, `ERR_NETWORK_CHANGED`, and refresh failures without treating transient network loss as logout.
- Upstream conflict surface: `frontend/src/api/client.ts` only imports/calls `client.tk.ts`; TK-specific network contract lives in a companion file.
- Upstream merge guard: `scripts/frontend-tk-sentinels.json` now pins the companion, client injection points, auth online handler, and subscription offline cache behavior.

🤖 Generated with [Claude Code](https://claude.com/claude-code)