### PR TITLE
fix(gateway): avoid empty thinking replay errors

### DIFF
--- a/backend/internal/handler/page_handler_test.go
+++ b/backend/internal/handler/page_handler_test.go
@@ -58,7 +58,10 @@ func TestResolvePageImagePath(t *testing.T) {
 	if !ok {
 		t.Fatal("expected direct image path to be accepted")
 	}
-	want := filepath.Join(base, "logo.png")
+	want, err := filepath.EvalSymlinks(filepath.Join(base, "logo.png"))
+	if err != nil {
+		t.Fatalf("eval expected direct image path: %v", err)
+	}
 	if got != want {
 		t.Fatalf("path = %q, want %q", got, want)
 	}
@@ -67,7 +70,10 @@ func TestResolvePageImagePath(t *testing.T) {
 	if !ok {
 		t.Fatal("expected nested image path to be accepted")
 	}
-	want = filepath.Join(base, "images", "logo.png")
+	want, err = filepath.EvalSymlinks(filepath.Join(base, "images", "logo.png"))
+	if err != nil {
+		t.Fatalf("eval expected nested image path: %v", err)
+	}
 	if got != want {
 		t.Fatalf("path = %q, want %q", got, want)
 	}

--- a/backend/internal/pkg/apicompat/anthropic_responses_test.go
+++ b/backend/internal/pkg/apicompat/anthropic_responses_test.go
@@ -819,33 +819,104 @@ func TestStreamingReasoning(t *testing.T) {
 		Response: &ResponsesResponse{ID: "resp_3", Model: "gpt-5.2"},
 	}, state)
 
-	// reasoning item added
 	events := ResponsesEventToAnthropicEvents(&ResponsesStreamEvent{
 		Type:        "response.output_item.added",
 		OutputIndex: 0,
 		Item:        &ResponsesOutput{Type: "reasoning"},
 	}, state)
-	require.Len(t, events, 1)
-	assert.Equal(t, "content_block_start", events[0].Type)
-	assert.Equal(t, "thinking", events[0].ContentBlock.Type)
+	require.Len(t, events, 0)
 
-	// reasoning text delta
 	events = ResponsesEventToAnthropicEvents(&ResponsesStreamEvent{
 		Type:        "response.reasoning_summary_text.delta",
 		OutputIndex: 0,
 		Delta:       "Let me think...",
 	}, state)
+	require.Len(t, events, 2)
+	assert.Equal(t, "content_block_start", events[0].Type)
+	assert.Equal(t, "thinking", events[0].ContentBlock.Type)
+	assert.Equal(t, "", events[0].ContentBlock.Thinking)
+	assert.Equal(t, "content_block_delta", events[1].Type)
+	assert.Equal(t, "thinking_delta", events[1].Delta.Type)
+	assert.Equal(t, "Let me think...", events[1].Delta.Thinking)
+
+	events = ResponsesEventToAnthropicEvents(&ResponsesStreamEvent{
+		Type:        "response.reasoning_summary_text.delta",
+		OutputIndex: 0,
+		Delta:       " more.",
+	}, state)
 	require.Len(t, events, 1)
 	assert.Equal(t, "content_block_delta", events[0].Type)
 	assert.Equal(t, "thinking_delta", events[0].Delta.Type)
-	assert.Equal(t, "Let me think...", events[0].Delta.Thinking)
+	assert.Equal(t, " more.", events[0].Delta.Thinking)
 
-	// reasoning done
 	events = ResponsesEventToAnthropicEvents(&ResponsesStreamEvent{
 		Type: "response.reasoning_summary_text.done",
 	}, state)
 	require.Len(t, events, 1)
 	assert.Equal(t, "content_block_stop", events[0].Type)
+}
+
+func TestStreamingReasoning_NoSummaryText(t *testing.T) {
+	state := NewResponsesEventToAnthropicState()
+
+	ResponsesEventToAnthropicEvents(&ResponsesStreamEvent{
+		Type:     "response.created",
+		Response: &ResponsesResponse{ID: "resp_empty_reasoning", Model: "gpt-5.2"},
+	}, state)
+
+	events := ResponsesEventToAnthropicEvents(&ResponsesStreamEvent{
+		Type:        "response.output_item.added",
+		OutputIndex: 0,
+		Item:        &ResponsesOutput{Type: "reasoning"},
+	}, state)
+	require.Len(t, events, 0)
+
+	events = ResponsesEventToAnthropicEvents(&ResponsesStreamEvent{
+		Type: "response.reasoning_summary_text.done",
+	}, state)
+	require.Len(t, events, 0)
+
+	events = ResponsesEventToAnthropicEvents(&ResponsesStreamEvent{
+		Type:        "response.output_item.done",
+		OutputIndex: 0,
+		Item:        &ResponsesOutput{Type: "reasoning"},
+	}, state)
+	require.Len(t, events, 0)
+
+	events = ResponsesEventToAnthropicEvents(&ResponsesStreamEvent{
+		Type:        "response.output_text.delta",
+		OutputIndex: 1,
+		Delta:       "hello",
+	}, state)
+	require.Len(t, events, 2)
+	assert.Equal(t, "content_block_start", events[0].Type)
+	assert.Equal(t, "text", events[0].ContentBlock.Type)
+	assert.Equal(t, 0, *events[0].Index)
+	assert.Equal(t, "content_block_delta", events[1].Type)
+}
+
+func TestStreamingReasoning_EmptyDeltasOnly(t *testing.T) {
+	state := NewResponsesEventToAnthropicState()
+
+	ResponsesEventToAnthropicEvents(&ResponsesStreamEvent{
+		Type:     "response.created",
+		Response: &ResponsesResponse{ID: "resp_empty_deltas", Model: "gpt-5.2"},
+	}, state)
+
+	ResponsesEventToAnthropicEvents(&ResponsesStreamEvent{
+		Type:        "response.output_item.added",
+		OutputIndex: 0,
+		Item:        &ResponsesOutput{Type: "reasoning"},
+	}, state)
+
+	events := ResponsesEventToAnthropicEvents(&ResponsesStreamEvent{
+		Type:        "response.reasoning_summary_text.delta",
+		OutputIndex: 0,
+		Delta:       "",
+	}, state)
+	require.Len(t, events, 0)
+	assert.False(t, state.ContentBlockOpen)
+	assert.False(t, state.EmittedAnyContentBlock)
 }
 
 func TestStreamingIncomplete(t *testing.T) {

--- a/backend/internal/pkg/apicompat/responses_to_anthropic.go
+++ b/backend/internal/pkg/apicompat/responses_to_anthropic.go
@@ -392,24 +392,8 @@ func resToAnthHandleOutputItemAdded(evt *ResponsesStreamEvent, state *ResponsesE
 		return events
 
 	case "reasoning":
-		var events []AnthropicStreamEvent
-		events = append(events, closeCurrentBlock(state)...)
-
-		idx := state.ContentBlockIndex
-		state.OutputIndexToBlockIdx[evt.OutputIndex] = idx
-		state.ContentBlockOpen = true
-		state.CurrentBlockType = "thinking"
-		state.EmittedAnyContentBlock = true
-
-		events = append(events, AnthropicStreamEvent{
-			Type:  "content_block_start",
-			Index: &idx,
-			ContentBlock: &AnthropicContentBlock{
-				Type:     "thinking",
-				Thinking: "",
-			},
-		})
-		return events
+		// Open the thinking block only after a non-empty summary delta arrives.
+		return nil
 
 	case "message":
 		return nil
@@ -521,19 +505,38 @@ func resToAnthHandleReasoningDelta(evt *ResponsesStreamEvent, state *ResponsesEv
 		return nil
 	}
 
+	var events []AnthropicStreamEvent
+
+	// Avoid emitting empty thinking blocks when upstream has no summary text.
 	blockIdx, ok := state.OutputIndexToBlockIdx[evt.OutputIndex]
 	if !ok {
-		return nil
+		events = append(events, closeCurrentBlock(state)...)
+
+		blockIdx = state.ContentBlockIndex
+		state.OutputIndexToBlockIdx[evt.OutputIndex] = blockIdx
+		state.ContentBlockOpen = true
+		state.CurrentBlockType = "thinking"
+		state.EmittedAnyContentBlock = true
+
+		events = append(events, AnthropicStreamEvent{
+			Type:  "content_block_start",
+			Index: &blockIdx,
+			ContentBlock: &AnthropicContentBlock{
+				Type:     "thinking",
+				Thinking: "",
+			},
+		})
 	}
 
-	return []AnthropicStreamEvent{{
+	events = append(events, AnthropicStreamEvent{
 		Type:  "content_block_delta",
 		Index: &blockIdx,
 		Delta: &AnthropicDelta{
 			Type:     "thinking_delta",
 			Thinking: evt.Delta,
 		},
-	}}
+	})
+	return events
 }
 
 func resToAnthHandleBlockDone(state *ResponsesEventToAnthropicState) []AnthropicStreamEvent {

--- a/backend/internal/service/gateway_service.go
+++ b/backend/internal/service/gateway_service.go
@@ -6736,6 +6736,14 @@ func (s *GatewayService) isThinkingBlockSignatureError(respBody []byte) bool {
 		return true
 	}
 
+	// 检测空 thinking 字段错误（OpenAI-compat 历史回放到 Anthropic 原生路由时会触发）。
+	// 例如: "messages.11.content.0.thinking: each thinking block must contain thinking"
+	if strings.Contains(msg, "must contain thinking") ||
+		strings.Contains(msg, "thinking block must contain") {
+		logger.LegacyPrintf("service.gateway", "[SignatureCheck] Detected empty thinking field error")
+		return true
+	}
+
 	return false
 }
 

--- a/backend/internal/service/gateway_service_thinking_signature_test.go
+++ b/backend/internal/service/gateway_service_thinking_signature_test.go
@@ -1,0 +1,77 @@
+//go:build unit
+
+package service
+
+import (
+	"testing"
+)
+
+func TestIsThinkingBlockSignatureError_MustContainThinking(t *testing.T) {
+	svc := &GatewayService{}
+
+	cases := []struct {
+		name string
+		body string
+		want bool
+	}{
+		{
+			name: "anthropic empty thinking field — exact prod incident message",
+			body: `{"type":"error","error":{"type":"invalid_request_error","message":"messages.11.content.0.thinking: each thinking block must contain thinking"},"request_id":"req_011Cat8muQgKEVtqTzncEjfS"}`,
+			want: true,
+		},
+		{
+			name: "alternate phrasing thinking block must contain",
+			body: `{"type":"error","error":{"type":"invalid_request_error","message":"messages.0.content.0: thinking block must contain thinking"}}`,
+			want: true,
+		},
+		{
+			name: "case insensitive",
+			body: `{"type":"error","error":{"type":"invalid_request_error","message":"Each Thinking Block Must Contain Thinking"}}`,
+			want: true,
+		},
+		{
+			name: "existing signature pattern still matches",
+			body: `{"type":"error","error":{"type":"invalid_request_error","message":"Invalid signature in thinking block"}}`,
+			want: true,
+		},
+		{
+			name: "existing expected pattern still matches",
+			body: `{"type":"error","error":{"type":"invalid_request_error","message":"Expected thinking or redacted_thinking but found text"}}`,
+			want: true,
+		},
+		{
+			name: "existing cannot be modified pattern still matches",
+			body: `{"type":"error","error":{"type":"invalid_request_error","message":"thinking blocks in the latest assistant message cannot be modified"}}`,
+			want: true,
+		},
+		{
+			name: "existing empty content pattern still matches",
+			body: `{"type":"error","error":{"type":"invalid_request_error","message":"all messages must have non-empty content"}}`,
+			want: true,
+		},
+		{
+			name: "unrelated 400 must not trigger rectifier",
+			body: `{"type":"error","error":{"type":"invalid_request_error","message":"max_tokens exceeded model context window"}}`,
+			want: false,
+		},
+		{
+			name: "empty body returns false",
+			body: ``,
+			want: false,
+		},
+		{
+			name: "non-json body without thinking keyword returns false",
+			body: `internal server error`,
+			want: false,
+		},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			got := svc.isThinkingBlockSignatureError([]byte(tc.body))
+			if got != tc.want {
+				t.Fatalf("isThinkingBlockSignatureError(%q) = %v, want %v", tc.body, got, tc.want)
+			}
+		})
+	}
+}

--- a/scripts/pricing-availability-sentinels.json
+++ b/scripts/pricing-availability-sentinels.json
@@ -25,7 +25,7 @@
     {
       "path": "backend/internal/service/gateway_service.go",
       "must_contain": ["tkPricingAvailability", "RecordOutcome"],
-      "rationale": "gateway_service.go carries the success-path availability tap inside recordUsageCore (the 100%-hit path for all platform forwards). This is the primary signal source: every successful request records a 'ok' sample. The TK field declaration (tkPricingAvailability) and the RecordOutcome call are both in this large upstream-shaped file (~9600 lines). An upstream merge that restructures recordUsageCore could silently remove the RecordOutcome hook, collapsing the success-rate metric and causing all models to appear 'stale' after 24h."
+      "rationale": "gateway_service.go carries the success-path availability tap inside recordUsageCore (the 100%-hit path for all platform forwards). This is the primary signal source: every successful request records a 'ok' sample. The TK field declaration (tkPricingAvailability) and the RecordOutcome call are both in this large upstream-shaped file (~9600 lines). An upstream merge that restructures recordUsageCore could silently remove the RecordOutcome hook, collapsing the success-rate metric and causing all models to appear 'stale' after 24h. This PR also touches the same file's thinking-error rectifier, but does not move recordUsageCore, tkPricingAvailability, or RecordOutcome; keeping this sentinel entry in the diff records that the availability tap was explicitly re-checked."
     },
     {
       "path": "backend/internal/handler/gateway_handler_tk_forward_error.go",


### PR DESCRIPTION
## Summary
- Defer OpenAI Responses streaming `thinking` content blocks until a non-empty reasoning summary delta arrives, so encrypted-only reasoning cannot persist empty thinking blocks into Claude Code sessions.
- Recognize Anthropic `each thinking block must contain thinking` 400s as rectifiable, so existing persisted bad sessions trigger the existing thinking-block retry sanitizer.
- Make the page image path test compare resolved filesystem paths on macOS (`/private/var` vs `/var`).

## Incident evidence
- Prod log: user_id=1, api_key_id=5, group_id=1, account=35 `claude-am-g-4`, `POST /v1/messages`, Anthropic 400: `messages.11.content.0.thinking: each thinking block must contain thinking`.
- Root cause: OpenAI-compat streaming path emitted `content_block_start` for `thinking` before any summary delta; Anthropic native replay later rejected the persisted empty thinking field.

## Upstream audit
- `git log --oneline upstream/main..HEAD | wc -l`: 380
- `git diff --stat upstream/main..HEAD -- backend/` top files:
  - `backend/.golangci.yml | 12 +-
  - `backend/Makefile | 15 +-
  - `backend/cmd/server/VERSION | 2 +-
  - `backend/cmd/server/main.go | 24 +-
  - `backend/cmd/server/wire.go | 23 +`

## Test plan
- [x] `go test -tags=unit -run 'TestStreamingReasoning|TestIsThinkingBlockSignatureError' ./internal/pkg/apicompat/... ./internal/service/...`
- [x] `go test -tags=unit ./...`
- [x] `golangci-lint run ./...`
- [x] `bash scripts/preflight.sh`

🤖 Generated with [Claude Code](https://claude.com/claude-code)