### PR TITLE
fix(aws): allow OIDC role to read own stack

### DIFF
--- a/deploy/aws/cloudformation/cicd-oidc.yaml
+++ b/deploy/aws/cloudformation/cicd-oidc.yaml
@@ -186,6 +186,7 @@ Resources:
                 Action:
                   - cloudformation:DescribeStacks
                 Resource:
+                  - !Sub "arn:aws:cloudformation:${AWS::Region}:${AWS::AccountId}:stack/tokenkey-cicd-oidc/*"
                   - !Sub "arn:aws:cloudformation:${AWS::Region}:${AWS::AccountId}:stack/tokenkey-prod-stage0/*"
                   - !Sub "arn:aws:cloudformation:${AWS::Region}:${AWS::AccountId}:stack/tokenkey-test-stage0/*"
                   - !Sub "arn:aws:cloudformation:${EdgeUk1Region}:${AWS::AccountId}:stack/tokenkey-edge-uk1-stage0/*"


### PR DESCRIPTION
## Summary
- Allow the regional OIDC workflow role to describe the `tokenkey-cicd-oidc` stack.
- This lets `deploy-edge-stage0.yml` resolve `EdgeUk1CloudFormationExecutionRoleArn` before provisioning uk1.

## Test plan
- [x] `aws cloudformation validate-template --template-body file://deploy/aws/cloudformation/cicd-oidc.yaml --region eu-west-2`
- [x] `bash scripts/preflight.sh`

🤖 Generated with [Claude Code](https://claude.com/claude-code)