### PR TITLE
fix(aws): allow edge cfn role to resolve AMI parameter

### DIFF
--- a/deploy/aws/cloudformation/cicd-oidc.yaml
+++ b/deploy/aws/cloudformation/cicd-oidc.yaml
@@ -277,6 +277,7 @@ Resources:
                   - ssm:PutParameter
                   - ssm:DeleteParameter
                   - ssm:GetParameter
+                  - ssm:GetParameters
                   - cloudwatch:PutMetricAlarm
                   - cloudwatch:DeleteAlarms
                 Resource: "*"


### PR DESCRIPTION
## Summary
- Add `ssm:GetParameters` to the Edge CloudFormation execution role.
- This allows CloudFormation to resolve the AL2023 public AMI SSM parameter during uk1 stack creation.

## Test plan
- [x] `aws cloudformation validate-template --template-body file://deploy/aws/cloudformation/cicd-oidc.yaml --region eu-west-2`
- [x] `bash scripts/preflight.sh`

🤖 Generated with [Claude Code](https://claude.com/claude-code)