### PR TITLE
fix(aws): allow edge cfn role tagging

### DIFF
--- a/deploy/aws/cloudformation/cicd-oidc.yaml
+++ b/deploy/aws/cloudformation/cicd-oidc.yaml
@@ -264,6 +264,8 @@ Resources:
                   - iam:CreateRole
                   - iam:DeleteRole
                   - iam:GetRole
+                  - iam:TagRole
+                  - iam:UntagRole
                   - iam:PassRole
                   - iam:AttachRolePolicy
                   - iam:DetachRolePolicy


### PR DESCRIPTION
## Summary
- Add `iam:TagRole` / `iam:UntagRole` to the Edge CloudFormation execution role.
- This lets uk1 provisioning create tagged instance roles without unauthorized tagging rollback.

## Test plan
- [x] `aws cloudformation validate-template --template-body file://deploy/aws/cloudformation/cicd-oidc.yaml --region eu-west-2`
- [x] `bash scripts/preflight.sh`

🤖 Generated with [Claude Code](https://claude.com/claude-code)