### PR TITLE
fix(ops): run edge smoke health check inside container

### DIFF
--- a/scripts/tk_edge_post_deploy_smoke.sh
+++ b/scripts/tk_edge_post_deploy_smoke.sh
@@ -65,7 +65,7 @@ if [[ "${EDGE_SELF_SMOKE_MODE}" == "api" ]]; then
   fi
   ssm_commands+=(
     "EDGE_KEY=\$(aws ssm get-parameter --name '${EDGE_SSM_PREFIX}/smoke/api-key' --with-decryption --query Parameter.Value --output text)"
-    "TOKENKEY_BASE_URL=http://localhost:8080 POST_DEPLOY_SMOKE_SKIP_FRONTEND=1 POST_DEPLOY_SMOKE_API_KEY=\"\$EDGE_KEY\" bash /var/lib/tokenkey/scripts/tk_post_deploy_smoke.sh"
+    "sudo docker compose -f /var/lib/tokenkey/docker-compose.yml --env-file /var/lib/tokenkey/.env exec -T -e TOKENKEY_BASE_URL=http://localhost:8080 -e POST_DEPLOY_SMOKE_SKIP_FRONTEND=1 -e POST_DEPLOY_SMOKE_API_KEY=\"\$EDGE_KEY\" tokenkey bash /app/scripts/tk_post_deploy_smoke.sh"
   )
 else
   echo "tk_edge_post_deploy_smoke: edge API self-smoke skipped (set EDGE_SELF_SMOKE_MODE=api after Edge upstream/key setup)"

--- a/scripts/tk_edge_post_deploy_smoke.sh
+++ b/scripts/tk_edge_post_deploy_smoke.sh
@@ -54,8 +54,8 @@ fi
 
 ssm_commands=(
   "set -euo pipefail"
-  "curl -sS -o /dev/null -w 'localhost health HTTP %{http_code}\\n' http://localhost:8080/health"
   "sudo docker compose -f /var/lib/tokenkey/docker-compose.yml --env-file /var/lib/tokenkey/.env ps"
+  "sudo docker compose -f /var/lib/tokenkey/docker-compose.yml --env-file /var/lib/tokenkey/.env exec -T tokenkey wget -qO- http://localhost:8080/health"
 )
 
 if [[ "${EDGE_SELF_SMOKE_MODE}" == "api" ]]; then


### PR DESCRIPTION
## Summary
- Run the Edge self-smoke TokenKey health check inside the `tokenkey` container.
- Avoid assuming port 8080 is published on the EC2 host; Edge compose only exposes it to the Docker network behind Caddy.

## Test plan
- [x] `bash -n scripts/tk_edge_post_deploy_smoke.sh`
- [x] `bash scripts/preflight.sh`

🤖 Generated with [Claude Code](https://claude.com/claude-code)