### PR TITLE
Compact frontend typography scale

### DIFF
--- a/backend/internal/web/dist/frontend-source.json
+++ b/backend/internal/web/dist/frontend-source.json
@@ -1,7 +1,7 @@
 {
   "algorithm": "sha256(git-ls-files:path,size,content)",
   "file_count": 421,
-  "hash": "d15073932ecb32e97399ea0b34ffee9325816e511a1d3c79bbbfd80628dfc996",
+  "hash": "f952b0fcb2e4e58baddff249441851b9e06ae86609ee63d700816246166b2011",
   "schema": 1,
   "source": "frontend/"
 }

--- a/backend/internal/web/dist/frontend-source.json
+++ b/backend/internal/web/dist/frontend-source.json
@@ -1,7 +1,7 @@
 {
   "algorithm": "sha256(git-ls-files:path,size,content)",
   "file_count": 421,
-  "hash": "f952b0fcb2e4e58baddff249441851b9e06ae86609ee63d700816246166b2011",
+  "hash": "88b72b1b3967eef5994ef3e8dd6d1807a4f24bd0155d576b0ea527633758a4fa",
   "schema": 1,
   "source": "frontend/"
 }

--- a/frontend/src/style.css
+++ b/frontend/src/style.css
@@ -12,7 +12,7 @@
   }
 
   body {
-    @apply bg-gray-50 text-gray-900 dark:bg-dark-950 dark:text-gray-100;
+    @apply bg-gray-50 text-base text-gray-900 dark:bg-dark-950 dark:text-gray-100;
     @apply min-h-screen;
   }
 

--- a/frontend/tailwind.config.js
+++ b/frontend/tailwind.config.js
@@ -4,6 +4,18 @@ export default {
   darkMode: 'class',
   theme: {
     extend: {
+      fontSize: {
+        xs: ['0.6875rem', { lineHeight: '0.9375rem' }],
+        sm: ['0.8125rem', { lineHeight: '1.125rem' }],
+        base: ['0.9375rem', { lineHeight: '1.375rem' }],
+        lg: ['1.0625rem', { lineHeight: '1.625rem' }],
+        xl: ['1.1875rem', { lineHeight: '1.625rem' }],
+        '2xl': ['1.375rem', { lineHeight: '1.875rem' }],
+        '3xl': ['1.75rem', { lineHeight: '2.125rem' }],
+        '4xl': ['2.125rem', { lineHeight: '2.375rem' }],
+        '5xl': ['2.75rem', { lineHeight: '1' }],
+        '6xl': ['3.5rem', { lineHeight: '1' }]
+      },
       colors: {
         // 主色调 - Teal/Cyan 青色系
         primary: {

--- a/scripts/check-sentinel-registry-update-gate.py
+++ b/scripts/check-sentinel-registry-update-gate.py
@@ -42,6 +42,8 @@ HOTSPOT_PATTERNS: dict[str, list[str]] = {
     "frontend/src/composables/useModelWhitelist.ts": ["scripts/newapi-sentinels.json"],
     "frontend/src/constants/gatewayPlatforms.ts": ["scripts/newapi-sentinels.json"],
     "frontend/src/composables/usePlatformOptions.ts": ["scripts/newapi-sentinels.json"],
+    "frontend/tailwind.config.js": ["scripts/frontend-tk-sentinels.json"],
+    "frontend/src/style.css": ["scripts/frontend-tk-sentinels.json"],
     "backend/internal/integration/newapi/*.go": ["scripts/newapi-sentinels.json"],
     "backend/internal/integration/newapi/**/*.go": ["scripts/newapi-sentinels.json"],
     "backend/internal/**/*_tk_*.go": ["scripts/newapi-sentinels.json", "scripts/gateway-tk-sentinels.json"],
@@ -90,6 +92,14 @@ def resolve_base(explicit_base: str | None) -> str | None:
 def changed_files(base: str, head: str) -> set[str]:
     proc = run_git(["diff", "--name-only", "--diff-filter=ACMRTUXB", f"{base}...{head}"])
     return {line.strip() for line in proc.stdout.splitlines() if line.strip()}
+
+
+def working_tree_changed_files() -> set[str]:
+    changed: set[str] = set()
+    for args in (["diff", "--name-only", "--diff-filter=ACMRTUXB"], ["diff", "--cached", "--name-only", "--diff-filter=ACMRTUXB"]):
+        proc = run_git(args)
+        changed.update(line.strip() for line in proc.stdout.splitlines() if line.strip())
+    return changed
 
 
 def registry_paths() -> list[Path]:
@@ -154,6 +164,7 @@ def main() -> int:
         return 2
 
     changed = changed_files(base, args.head)
+    changed.update(working_tree_changed_files())
     if not changed:
         if not args.quiet:
             print(f"sentinel registry update gate: no changes vs {base}...{args.head}")

--- a/scripts/frontend-tk-sentinels.json
+++ b/scripts/frontend-tk-sentinels.json
@@ -118,6 +118,22 @@
       "rationale": "Subscription polling must return cached data while offline and suppress expected network-error logging. Otherwise a browser network transition causes repeated /subscriptions/active failures and noisy console output without changing UI state."
     },
     {
+      "path": "frontend/tailwind.config.js",
+      "must_contain": [
+        "fontSize: {",
+        "base: ['0.9375rem', { lineHeight: '1.375rem' }]",
+        "'2xl': ['1.375rem', { lineHeight: '1.875rem' }]"
+      ],
+      "rationale": "Global typography scale is a TK-only density choice: TokenKey intentionally maps Tailwind text-base to 15px and keeps heading steps slightly smaller than upstream defaults. This file is a tiny upstream merge hotspot because losing the fontSize extension compiles cleanly but silently restores larger UI text across admin and user pages."
+    },
+    {
+      "path": "frontend/src/style.css",
+      "must_contain": [
+        "@apply bg-gray-50 text-base text-gray-900 dark:bg-dark-950 dark:text-gray-100;"
+      ],
+      "rationale": "The compact Tailwind scale must apply to default body copy, not only explicit text-* utilities. Without body text-base, unclassed prose and third-party/default text remain at browser 16px while classed UI shrinks, producing inconsistent density after upstream merges that still compile."
+    },
+    {
       "path": "frontend/src/api/admin/ops.ts",
       "must_contain": [
         "feishu: {",


### PR DESCRIPTION
## Summary
- Compact the global Tailwind typography scale so TokenKey screens render slightly denser without touching page-level classes.
- Apply the compact `text-base` scale to default body copy as well as explicit text utility classes.
- Add frontend TK sentinel guards so upstream merges cannot silently remove the compact typography scale or body base-size wiring.
- Refresh the embedded frontend source hash after rebuilding frontend assets.

## Test plan
- [x] `pnpm -C frontend lint:check && pnpm -C frontend typecheck` (existing warning in `PlaygroundPrototype.spec.ts` only)
- [x] `pnpm -C frontend build`
- [x] `bash scripts/preflight.sh`
- [x] `python3 scripts/check-frontend-tk-sentinels.py --quiet`
- [x] `python3 scripts/check-sentinel-registry-update-gate.py --base main`
- [x] Browser visual pass with Chrome headless against production preview for `/home`, `/login`, `/pricing`, and `/key-usage`; screenshots showed no obvious clipping, overflow, or broken layout.
- [x] Full local Stage0 browser pass via `http://127.0.0.1:8088`: built `tokenkey-local:pr175-typography`, started Docker Stage0, verified `/health` and `/api/v1/settings/public` through Caddy with proxy bypass, logged in as admin using `.cache/tokenkey-stage0-local/.env` credentials without printing secrets, and captured `/admin/dashboard`, `/admin/accounts`, `/admin/groups`, `/admin/settings`. DOM checks reported body/main font size `15px` and no page-level horizontal overflow; `/admin/groups` retains an expected inner table scrollbar.

🤖 Generated with [Claude Code](https://claude.com/claude-code)