### PR TITLE
fix(ci): skip heavy checks for VERSION-only pushes

### DIFF
--- a/.github/workflows/backend-ci.yml
+++ b/.github/workflows/backend-ci.yml
@@ -3,6 +3,8 @@ name: CI
 on:
   push:
     branches: [main]
+    paths-ignore:
+      - 'backend/cmd/server/VERSION'
   pull_request:
 
 permissions:

--- a/.github/workflows/security-scan.yml
+++ b/.github/workflows/security-scan.yml
@@ -3,6 +3,8 @@ name: Security Scan
 on:
   push:
     branches: [main]
+    paths-ignore:
+      - 'backend/cmd/server/VERSION'
   pull_request:
   workflow_dispatch:
   schedule:


### PR DESCRIPTION
## Summary
- Skip `backend-ci.yml` and `security-scan.yml` on main pushes that only change `backend/cmd/server/VERSION`.
- Keep PR checks, scheduled/manual security scans, and tag-triggered `release.yml` unchanged.
- Avoid duplicate heavy CI alongside Release during version bump rollouts without using CI skip markers.

## Test plan
- [x] `bash ../scripts/preflight.sh`

🤖 Generated with [Claude Code](https://claude.com/claude-code)