### PR TITLE
fix(auth): keep login free of Turnstile

### DIFF
--- a/backend/internal/web/dist/frontend-source.json
+++ b/backend/internal/web/dist/frontend-source.json
@@ -1,7 +1,7 @@
 {
   "algorithm": "sha256(git-ls-files:path,size,content)",
   "file_count": 421,
-  "hash": "88b72b1b3967eef5994ef3e8dd6d1807a4f24bd0155d576b0ea527633758a4fa",
+  "hash": "235f261c797bf8de661e7e94fe34676ebd837ca6f603a87c09b7711ca8c7b0ad",
   "schema": 1,
   "source": "frontend/"
 }

--- a/frontend/src/views/auth/LoginView.vue
+++ b/frontend/src/views/auth/LoginView.vue
@@ -78,21 +78,10 @@
           </div>
         </div>
 
-        <!-- Turnstile Widget -->
-        <div v-if="turnstileEnabled && turnstileSiteKey">
-          <TurnstileWidget
-            ref="turnstileRef"
-            :site-key="turnstileSiteKey"
-            @verify="onTurnstileVerify"
-            @expire="onTurnstileExpire"
-            @error="onTurnstileError"
-          />
-        </div>
-
         <!-- Submit Button -->
         <button
           type="submit"
-          :disabled="authActionDisabled || (turnstileEnabled && !turnstileToken)"
+          :disabled="authActionDisabled"
           class="btn btn-primary w-full"
         >
           <svg
@@ -204,7 +193,6 @@ import EmailOAuthButtons from '@/components/auth/EmailOAuthButtons.vue'
 import LoginAgreementPrompt from '@/components/auth/LoginAgreementPrompt.vue'
 import TotpLoginModal from '@/components/auth/TotpLoginModal.vue'
 import Icon from '@/components/icons/Icon.vue'
-import TurnstileWidget from '@/components/TurnstileWidget.vue'
 import { useAuthStore, useAppStore } from '@/stores'
 import { getPublicSettings, isTotp2FARequired, isWeChatWebOAuthEnabled } from '@/api/auth'
 import type { LoginAgreementDocument, TotpLoginResponse } from '@/types'
@@ -228,8 +216,6 @@ const showPassword = ref<boolean>(false)
 const publicSettingsLoaded = ref<boolean>(false)
 
 // Public settings
-const turnstileEnabled = ref<boolean>(false)
-const turnstileSiteKey = ref<string>('')
 const linuxdoOAuthEnabled = ref<boolean>(false)
 const wechatOAuthEnabled = ref<boolean>(false)
 const backendModeEnabled = ref<boolean>(false)
@@ -246,10 +232,6 @@ const loginAgreementDocuments = ref<LoginAgreementDocument[]>([])
 const agreementAccepted = ref<boolean>(false)
 const showAgreementModal = ref<boolean>(false)
 
-// Turnstile
-const turnstileRef = ref<InstanceType<typeof TurnstileWidget> | null>(null)
-const turnstileToken = ref<string>('')
-
 // 2FA state
 const show2FAModal = ref<boolean>(false)
 const totpTempToken = ref<string>('')
@@ -263,13 +245,10 @@ const formData = reactive({
 
 const errors = reactive({
   email: '',
-  password: '',
-  turnstile: ''
+  password: ''
 })
 
-const validationToastMessage = computed(
-  () => errors.email || errors.password || errors.turnstile || ''
-)
+const validationToastMessage = computed(() => errors.email || errors.password || '')
 
 const agreementGateActive = computed(
   () => loginAgreementEnabled.value && !agreementAccepted.value
@@ -308,8 +287,6 @@ onMounted(async () => {
 
   try {
     const settings = await getPublicSettings()
-    turnstileEnabled.value = settings.turnstile_enabled
-    turnstileSiteKey.value = settings.turnstile_site_key || ''
     linuxdoOAuthEnabled.value = settings.linuxdo_oauth_enabled
     wechatOAuthEnabled.value = isWeChatWebOAuthEnabled(settings)
     backendModeEnabled.value = settings.backend_mode_enabled === true
@@ -390,30 +367,12 @@ function rejectLoginAgreement(): void {
   appStore.showWarning('未同意最新条款前，无法输入账号密码或使用快捷登录。')
 }
 
-// ==================== Turnstile Handlers ====================
-
-function onTurnstileVerify(token: string): void {
-  turnstileToken.value = token
-  errors.turnstile = ''
-}
-
-function onTurnstileExpire(): void {
-  turnstileToken.value = ''
-  errors.turnstile = t('auth.turnstileExpired')
-}
-
-function onTurnstileError(): void {
-  turnstileToken.value = ''
-  errors.turnstile = t('auth.turnstileFailed')
-}
-
 // ==================== Validation ====================
 
 function validateForm(): boolean {
   // Reset errors
   errors.email = ''
   errors.password = ''
-  errors.turnstile = ''
 
   let isValid = true
 
@@ -443,12 +402,6 @@ function validateForm(): boolean {
     isValid = false
   }
 
-  // Turnstile validation
-  if (turnstileEnabled.value && !turnstileToken.value) {
-    errors.turnstile = t('auth.completeVerification')
-    isValid = false
-  }
-
   return isValid
 }
 
@@ -469,8 +422,7 @@ async function handleLogin(): Promise<void> {
     // Call auth store login
     const response = await authStore.login({
       email: formData.email,
-      password: formData.password,
-      turnstile_token: turnstileEnabled.value ? turnstileToken.value : undefined
+      password: formData.password
     })
 
     // Check if 2FA is required
@@ -491,12 +443,6 @@ async function handleLogin(): Promise<void> {
     const redirectTo = (router.currentRoute.value.query.redirect as string) || '/dashboard'
     await router.push(redirectTo)
   } catch (error: unknown) {
-    // Reset Turnstile on error
-    if (turnstileRef.value) {
-      turnstileRef.value.reset()
-      turnstileToken.value = ''
-    }
-
     errorMessage.value = extractI18nErrorMessage(error, t, 'auth.errors', t('auth.loginFailed'))
 
     // Also show error toast

--- a/scripts/check-frontend-tk-sentinels.py
+++ b/scripts/check-frontend-tk-sentinels.py
@@ -9,6 +9,7 @@ each entry verifies:
 
   1. The file at `path` exists.
   2. Every literal string in `must_contain` appears at least once in the file.
+  3. Every literal string in optional `must_not_contain` is absent from the file.
 
 Exit codes:
   0  — all sentinels intact.
@@ -75,7 +76,8 @@ def check_sentinel(entry: dict) -> tuple[bool, list[str]]:
     if not file_path.is_file():
         return False, [f"file missing: {path_str}"]
     must_contain = entry.get("must_contain") or []
-    if not must_contain:
+    must_not_contain = entry.get("must_not_contain") or []
+    if not must_contain and not must_not_contain:
         return True, []
     try:
         content = file_path.read_text(encoding="utf-8", errors="replace")
@@ -85,6 +87,9 @@ def check_sentinel(entry: dict) -> tuple[bool, list[str]]:
     for needle in must_contain:
         if needle not in content:
             failures.append(f"missing literal `{needle}` in {path_str}")
+    for needle in must_not_contain:
+        if needle in content:
+            failures.append(f"forbidden literal `{needle}` found in {path_str}")
     return (len(failures) == 0), failures
 
 

--- a/scripts/check-sentinel-registry-update-gate.py
+++ b/scripts/check-sentinel-registry-update-gate.py
@@ -42,6 +42,7 @@ HOTSPOT_PATTERNS: dict[str, list[str]] = {
     "frontend/src/composables/useModelWhitelist.ts": ["scripts/newapi-sentinels.json"],
     "frontend/src/constants/gatewayPlatforms.ts": ["scripts/newapi-sentinels.json"],
     "frontend/src/composables/usePlatformOptions.ts": ["scripts/newapi-sentinels.json"],
+    "frontend/src/views/auth/LoginView.vue": ["scripts/frontend-tk-sentinels.json"],
     "frontend/tailwind.config.js": ["scripts/frontend-tk-sentinels.json"],
     "frontend/src/style.css": ["scripts/frontend-tk-sentinels.json"],
     "backend/internal/integration/newapi/*.go": ["scripts/newapi-sentinels.json"],

--- a/scripts/frontend-tk-sentinels.json
+++ b/scripts/frontend-tk-sentinels.json
@@ -1,6 +1,6 @@
 {
   "version": 1,
-  "rationale": "Load-bearing TokenKey-only frontend surfaces that anchor admin-UI behavior diverging from upstream defaults — sidebar geometry (TK uses a narrower w-44 rail vs upstream w-64), the fluid table mode used on /admin/accounts (no horizontal scroll, cells wrap), and the per-page sticky-edge-hints opt-out. These are the kinds of small TK changes that get silently reverted by upstream merges precisely because they're small and local; the registry upgrades the rule from `agent must remember` to `merge will fail`. Source-of-truth read by both `scripts/preflight.sh` (frontend TK sentinel registry section, always) and `.github/workflows/upstream-merge-pr-shape.yml` (frontend TK sentinels check, on `merge/upstream-*` PRs). Adding a new TK-only frontend surface that must survive upstream merges MUST add a sentinel here in the same commit. Sibling registries: `newapi-sentinels.json` (fifth-platform integration), `brand-sentinels.json` (outward TK brand surfaces).",
+  "rationale": "Load-bearing TokenKey-only frontend surfaces that anchor admin-UI behavior diverging from upstream defaults — sidebar geometry (TK uses a narrower w-44 rail vs upstream w-64), the fluid table mode used on /admin/accounts (no horizontal scroll, cells wrap), per-page sticky-edge-hints opt-out, and the control-plane login policy that does not depend on Turnstile. These are the kinds of small TK changes that get silently reverted by upstream merges precisely because they're small and local; the registry upgrades the rule from `agent must remember` to `merge will fail`. Source-of-truth read by both `scripts/preflight.sh` (frontend TK sentinel registry section, always) and `.github/workflows/upstream-merge-pr-shape.yml` (frontend TK sentinels check, on `merge/upstream-*` PRs). Adding a new TK-only frontend surface that must survive upstream merges MUST add a sentinel here in the same commit. Sibling registries: `newapi-sentinels.json` (fifth-platform integration), `brand-sentinels.json` (outward TK brand surfaces).",
   "sentinels": [
     {
       "path": "frontend/src/constants/layout.ts",
@@ -132,6 +132,21 @@
         "@apply bg-gray-50 text-base text-gray-900 dark:bg-dark-950 dark:text-gray-100;"
       ],
       "rationale": "The compact Tailwind scale must apply to default body copy, not only explicit text-* utilities. Without body text-base, unclassed prose and third-party/default text remain at browser 16px while classed UI shrinks, producing inconsistent density after upstream merges that still compile."
+    },
+    {
+      "path": "frontend/src/views/auth/LoginView.vue",
+      "must_contain": [
+        "authStore.login({",
+        "email: formData.email",
+        "password: formData.password"
+      ],
+      "must_not_contain": [
+        "TurnstileWidget",
+        "turnstile_token",
+        "turnstileEnabled",
+        "turnstileToken"
+      ],
+      "rationale": "Normal control-plane login is intentionally not gated on Cloudflare Turnstile; PR #119 kept Turnstile on registration, verification-code, and password-recovery flows while relying on login rate limiting for this path. Upstream-shaped LoginView.vue repeatedly brings back the widget/token wiring during merges and compiles cleanly, so this negative sentinel fails preflight/merge-shape if login once again renders, waits for, or submits a Turnstile token."
     },
     {
       "path": "frontend/src/api/admin/ops.ts",


### PR DESCRIPTION
## Summary
- Restore the normal login page so it no longer renders, waits for, or submits a Cloudflare Turnstile token.
- Keep the embedded frontend source hash in sync after rebuilding the frontend.
- Add a frontend TK negative sentinel and hotspot mapping so upstream merges fail loudly if login Turnstile wiring returns.

## Review
- risk_level: normal
- review_mode: concise
- decision: merge-ready
- validation_gaps: none
- findings: none

## Test plan
- [x] `pnpm --dir frontend exec vitest run src/views/auth/__tests__/LoginView.spec.ts`
- [x] `python3 scripts/check-frontend-tk-sentinels.py`
- [x] `python3 scripts/check-sentinel-registry-update-gate.py --base HEAD --head HEAD`
- [x] `git diff --check`
- [x] `bash scripts/preflight.sh`

🤖 Generated with [Claude Code](https://claude.com/claude-code)