### PR TITLE
Support OAuth messages compaction

### DIFF
--- a/.testing/user-stories/stories/US-034-messages-compaction-policy.md
+++ b/.testing/user-stories/stories/US-034-messages-compaction-policy.md
@@ -39,7 +39,7 @@
 - `backend/internal/service/openai_messages_compaction_tk_test.go`::`TestShouldApplyOpenAICompatMessagesCompaction`
 - `backend/internal/service/openai_compat_model_test.go`::`TestForwardAsAnthropic_ReplaysWithoutContinuationWhenPreviousResponseMissing`
 - `backend/internal/service/openai_compat_model_test.go`::`TestForwardAsAnthropic_OAuthDisablesContinuationAfterPreviousResponseNotFound`
-- `backend/internal/service/openai_messages_replay_guard_test.go`::`TestApplyAnthropicCompatFullReplayGuard_KeepsToolBoundaryIntact`
+- `backend/internal/service/openai_messages_replay_guard_test.go`::`TestApplyOpenAICompatReplayCompaction_TailOnlyProfileKeepsToolBoundaryIntact`
 - `backend/internal/service/admin_service_group_test.go`::`TestAdminService_CreateGroup_NormalizesMessagesDispatchModelConfig`
 - `backend/internal/service/api_key_service_cache_test.go`::`TestAPIKeyService_SnapshotRoundTrip_PreservesMessagesDispatchModelConfig`
 - `backend/internal/server/api_contract_test.go`::`TestAPIContracts`

--- a/backend/internal/service/openai_compat_model_test.go
+++ b/backend/internal/service/openai_compat_model_test.go
@@ -389,7 +389,7 @@ func TestForwardAsAnthropic_TrimsFullReplayOnlyForCodexCompatModels(t *testing.T
 	require.Equal(t, "message-00", gjson.GetBytes(nonCompatBody, "input.0.content.0.text").String())
 }
 
-func TestForwardAsAnthropic_OAuthCompatKeepsFullReplayForCacheGrowth(t *testing.T) {
+func TestForwardAsAnthropic_OAuthCompatKeepsFullReplayByDefaultForCacheGrowth(t *testing.T) {
 	t.Parallel()
 	gin.SetMode(gin.TestMode)
 
@@ -429,6 +429,60 @@ func TestForwardAsAnthropic_OAuthCompatKeepsFullReplayForCacheGrowth(t *testing.
 	require.Contains(t, gjson.GetBytes(upstream.lastBody, "input.0.content.0.text").String(), "<sub2api-claude-code-todo-guard>")
 	require.Equal(t, "message-00", gjson.GetBytes(upstream.lastBody, "input.1.content.0.text").String())
 	require.Equal(t, "message-14", gjson.GetBytes(upstream.lastBody, "input.15.content.0.text").String())
+	require.False(t, gjson.GetBytes(upstream.lastBody, "prompt_cache_key").Exists())
+}
+
+func TestForwardAsAnthropic_OAuthCompatCompactionKeepsAnchorsAndTailWhenConfigured(t *testing.T) {
+	t.Parallel()
+	gin.SetMode(gin.TestMode)
+
+	messageCount := openAICompatOAuthReplayAnchorMessages + openAICompatAnthropicReplayMaxTailMessages + 4
+	messages := make([]string, 0, messageCount)
+	for i := 0; i < messageCount; i++ {
+		messages = append(messages, `{"role":"user","content":"message-`+fmt.Sprintf("%02d", i)+`"}`)
+	}
+	body := []byte(`{"model":"claude-sonnet-4-5","max_tokens":16,"system":"project instructions","messages":[` + strings.Join(messages, ",") + `],"stream":false}`)
+
+	rec := httptest.NewRecorder()
+	c, _ := gin.CreateTestContext(rec)
+	c.Request = httptest.NewRequest(http.MethodPost, "/v1/messages", bytes.NewReader(body))
+	c.Request.Header.Set("Content-Type", "application/json")
+
+	upstream := &httpUpstreamRecorder{resp: openAICompatSSECompletedResponse("resp_oauth_compaction", "gpt-5.4")}
+	svc := &OpenAIGatewayService{
+		httpUpstream: upstream,
+		cfg:          &config.Config{Security: config.SecurityConfig{URLAllowlist: config.URLAllowlistConfig{Enabled: false}}},
+	}
+	account := &Account{
+		ID:          1,
+		Name:        "openai-oauth",
+		Platform:    PlatformOpenAI,
+		Type:        AccountTypeOAuth,
+		Concurrency: 1,
+		Credentials: map[string]any{
+			"access_token":       "oauth-token",
+			"chatgpt_account_id": "chatgpt-acc",
+		},
+		Extra: map[string]any{
+			"messages_compaction_enabled":                true,
+			"messages_compaction_input_tokens_threshold": 1,
+		},
+	}
+
+	result, err := svc.ForwardAsAnthropic(context.Background(), c, account, body, "", "gpt-5.4")
+	require.NoError(t, err)
+	require.NotNil(t, result)
+	require.Equal(t, int64(openAICompatOAuthReplayAnchorMessages+openAICompatAnthropicReplayMaxTailMessages+2), gjson.GetBytes(upstream.lastBody, "input.#").Int())
+	require.Equal(t, "developer", gjson.GetBytes(upstream.lastBody, "input.0.role").String())
+	require.Equal(t, "project instructions", gjson.GetBytes(upstream.lastBody, "input.0.content.0.text").String())
+	require.Equal(t, "developer", gjson.GetBytes(upstream.lastBody, "input.1.role").String())
+	require.Contains(t, gjson.GetBytes(upstream.lastBody, "input.1.content.0.text").String(), "<sub2api-claude-code-todo-guard>")
+	require.Equal(t, "message-00", gjson.GetBytes(upstream.lastBody, "input.2.content.0.text").String())
+	require.Equal(t, "message-01", gjson.GetBytes(upstream.lastBody, "input.3.content.0.text").String())
+	require.Equal(t, "message-06", gjson.GetBytes(upstream.lastBody, "input.4.content.0.text").String())
+	require.Equal(t, "message-17", gjson.GetBytes(upstream.lastBody, "input.15.content.0.text").String())
+	require.NotContains(t, string(upstream.lastBody), "message-02")
+	require.NotContains(t, string(upstream.lastBody), "message-05")
 	require.False(t, gjson.GetBytes(upstream.lastBody, "prompt_cache_key").Exists())
 }
 

--- a/backend/internal/service/openai_gateway_messages.go
+++ b/backend/internal/service/openai_gateway_messages.go
@@ -82,12 +82,9 @@ func (s *OpenAIGatewayService) ForwardAsAnthropic(
 	compatContinuationDisabled := compatContinuationEnabled &&
 		s.isOpenAICompatSessionContinuationDisabled(ctx, c, account, promptCacheKey)
 	compatTurnState := ""
-	// OAuth/Plus relies on session_id + x-codex-turn-state; trimming to a
-	// sliding 12-message window makes the cached prefix stall at system/tools.
-	// Keep full replay there so upstream prompt caching can grow turn by turn.
-	if compatReplayGuardEnabled && account.Type != AccountTypeOAuth && previousResponseID == "" && !compatContinuationDisabled {
+	if compatReplayGuardEnabled && shouldEvaluateOpenAICompatMessagesCompactionForAccount(account, previousResponseID, compatContinuationDisabled) {
 		if shouldApplyOpenAICompatMessagesCompaction(compatCompactionPolicy, &anthropicReq) {
-			compatReplayTrimmed = applyOpenAICompatMessagesCompaction(&anthropicReq)
+			compatReplayTrimmed = applyOpenAICompatMessagesCompaction(account, &anthropicReq)
 			compatReplayTrimmedByPolicy = compatReplayTrimmed
 		}
 	}

--- a/backend/internal/service/openai_messages_compaction_tk.go
+++ b/backend/internal/service/openai_messages_compaction_tk.go
@@ -46,12 +46,22 @@ func shouldApplyOpenAICompatMessagesCompaction(policy openAICompatMessagesCompac
 	if !policy.enabled || policy.inputTokenLimit < openAICompatMinCompactionInputTokensThreshold || req == nil {
 		return false
 	}
-	return estimateAnthropicRequestInputTokens(req) > policy.inputTokenLimit
+	return estimateAnthropicRequestInputTokens(req) >= policy.inputTokenLimit
 }
 
-func applyOpenAICompatMessagesCompaction(req *apicompat.AnthropicRequest) bool {
+func shouldEvaluateOpenAICompatMessagesCompactionForAccount(account *Account, previousResponseID string, compatContinuationDisabled bool) bool {
+	if account != nil && account.Type == AccountTypeOAuth {
+		return true
+	}
+	return previousResponseID == "" && !compatContinuationDisabled
+}
+
+func applyOpenAICompatMessagesCompaction(account *Account, req *apicompat.AnthropicRequest) bool {
 	if req == nil {
 		return false
+	}
+	if account != nil && account.Type == AccountTypeOAuth {
+		return applyOpenAICompatOAuthMessagesCompaction(req)
 	}
 	return applyAnthropicCompatFullReplayGuard(req)
 }

--- a/backend/internal/service/openai_messages_compaction_tk_test.go
+++ b/backend/internal/service/openai_messages_compaction_tk_test.go
@@ -69,5 +69,45 @@ func TestShouldApplyOpenAICompatMessagesCompaction(t *testing.T) {
 		},
 	}
 	require.True(t, shouldApplyOpenAICompatMessagesCompaction(policy, req))
+	require.True(t, shouldApplyOpenAICompatMessagesCompaction(openAICompatMessagesCompactionPolicy{enabled: true, inputTokenLimit: estimateAnthropicRequestInputTokens(req)}, req))
 	require.False(t, shouldApplyOpenAICompatMessagesCompaction(openAICompatMessagesCompactionPolicy{}, req))
+}
+
+func TestShouldEvaluateOpenAICompatMessagesCompactionForAccount(t *testing.T) {
+	require.True(t, shouldEvaluateOpenAICompatMessagesCompactionForAccount(&Account{Type: AccountTypeAPIKey}, "", false))
+	require.False(t, shouldEvaluateOpenAICompatMessagesCompactionForAccount(&Account{Type: AccountTypeAPIKey}, "resp_1", false))
+	require.False(t, shouldEvaluateOpenAICompatMessagesCompactionForAccount(&Account{Type: AccountTypeAPIKey}, "", true))
+	require.True(t, shouldEvaluateOpenAICompatMessagesCompactionForAccount(&Account{Type: AccountTypeOAuth}, "resp_1", true))
+}
+
+func TestApplyOpenAICompatMessagesCompaction_UsesOAuthSafeGuardForOAuth(t *testing.T) {
+	messageCount := openAICompatOAuthReplayAnchorMessages + openAICompatAnthropicReplayMaxTailMessages + 4
+	req := &apicompat.AnthropicRequest{Messages: make([]apicompat.AnthropicMessage, 0, messageCount)}
+	for i := 0; i < messageCount; i++ {
+		req.Messages = append(req.Messages, apicompat.AnthropicMessage{
+			Role:    "user",
+			Content: []byte(`"message"`),
+		})
+	}
+
+	trimmed := applyOpenAICompatMessagesCompaction(&Account{Type: AccountTypeOAuth}, req)
+
+	require.True(t, trimmed)
+	require.Len(t, req.Messages, openAICompatOAuthReplayAnchorMessages+openAICompatAnthropicReplayMaxTailMessages)
+}
+
+func TestApplyOpenAICompatMessagesCompaction_UsesTailGuardForAPIKey(t *testing.T) {
+	messageCount := openAICompatAnthropicReplayMaxTailMessages + 4
+	req := &apicompat.AnthropicRequest{Messages: make([]apicompat.AnthropicMessage, 0, messageCount)}
+	for i := 0; i < messageCount; i++ {
+		req.Messages = append(req.Messages, apicompat.AnthropicMessage{
+			Role:    "user",
+			Content: []byte(`"message"`),
+		})
+	}
+
+	trimmed := applyOpenAICompatMessagesCompaction(&Account{Type: AccountTypeAPIKey}, req)
+
+	require.True(t, trimmed)
+	require.Len(t, req.Messages, openAICompatAnthropicReplayMaxTailMessages)
 }

--- a/backend/internal/service/openai_messages_compaction_tk_test.go
+++ b/backend/internal/service/openai_messages_compaction_tk_test.go
@@ -80,7 +80,7 @@ func TestShouldEvaluateOpenAICompatMessagesCompactionForAccount(t *testing.T) {
 	require.True(t, shouldEvaluateOpenAICompatMessagesCompactionForAccount(&Account{Type: AccountTypeOAuth}, "resp_1", true))
 }
 
-func TestApplyOpenAICompatMessagesCompaction_UsesOAuthSafeGuardForOAuth(t *testing.T) {
+func TestApplyOpenAICompatMessagesCompaction_UsesAnchorAndTailProfileForOAuth(t *testing.T) {
 	messageCount := openAICompatOAuthReplayAnchorMessages + openAICompatAnthropicReplayMaxTailMessages + 4
 	req := &apicompat.AnthropicRequest{Messages: make([]apicompat.AnthropicMessage, 0, messageCount)}
 	for i := 0; i < messageCount; i++ {
@@ -96,7 +96,7 @@ func TestApplyOpenAICompatMessagesCompaction_UsesOAuthSafeGuardForOAuth(t *testi
 	require.Len(t, req.Messages, openAICompatOAuthReplayAnchorMessages+openAICompatAnthropicReplayMaxTailMessages)
 }
 
-func TestApplyOpenAICompatMessagesCompaction_UsesTailGuardForAPIKey(t *testing.T) {
+func TestApplyOpenAICompatMessagesCompaction_UsesTailOnlyProfileForAPIKey(t *testing.T) {
 	messageCount := openAICompatAnthropicReplayMaxTailMessages + 4
 	req := &apicompat.AnthropicRequest{Messages: make([]apicompat.AnthropicMessage, 0, messageCount)}
 	for i := 0; i < messageCount; i++ {

--- a/backend/internal/service/openai_messages_replay_guard.go
+++ b/backend/internal/service/openai_messages_replay_guard.go
@@ -6,7 +6,10 @@ import (
 	"github.com/Wei-Shaw/sub2api/internal/pkg/apicompat"
 )
 
-const openAICompatAnthropicReplayMaxTailMessages = 12
+const (
+	openAICompatAnthropicReplayMaxTailMessages = 12
+	openAICompatOAuthReplayAnchorMessages      = 2
+)
 
 func applyAnthropicCompatFullReplayGuard(req *apicompat.AnthropicRequest) bool {
 	if req == nil || len(req.Messages) <= openAICompatAnthropicReplayMaxTailMessages {
@@ -20,6 +23,34 @@ func applyAnthropicCompatFullReplayGuard(req *apicompat.AnthropicRequest) bool {
 	}
 
 	req.Messages = append([]apicompat.AnthropicMessage(nil), req.Messages[start:]...)
+	return true
+}
+
+func applyOpenAICompatOAuthMessagesCompaction(req *apicompat.AnthropicRequest) bool {
+	if req == nil || len(req.Messages) <= openAICompatOAuthReplayAnchorMessages+openAICompatAnthropicReplayMaxTailMessages {
+		return false
+	}
+
+	prefixEnd := openAICompatOAuthReplayAnchorMessages
+	if prefixEnd > len(req.Messages) {
+		prefixEnd = len(req.Messages)
+	}
+	prefixEnd = expandAnthropicCompatPrefixBoundary(req.Messages, prefixEnd)
+
+	tailStart := len(req.Messages) - openAICompatAnthropicReplayMaxTailMessages
+	tailStart = expandAnthropicCompatTrimBoundary(req.Messages, tailStart)
+	if tailStart <= prefixEnd {
+		return false
+	}
+
+	trimmed := make([]apicompat.AnthropicMessage, 0, prefixEnd+len(req.Messages)-tailStart)
+	trimmed = append(trimmed, req.Messages[:prefixEnd]...)
+	trimmed = append(trimmed, req.Messages[tailStart:]...)
+	if len(trimmed) >= len(req.Messages) {
+		return false
+	}
+
+	req.Messages = trimmed
 	return true
 }
 
@@ -63,6 +94,55 @@ func expandAnthropicCompatTrimBoundary(messages []apicompat.AnthropicMessage, st
 			return start
 		}
 		start = next
+	}
+}
+
+func expandAnthropicCompatPrefixBoundary(messages []apicompat.AnthropicMessage, end int) int {
+	if end <= 0 {
+		return end
+	}
+	if end >= len(messages) {
+		return len(messages)
+	}
+
+	toolUseIndex := make(map[string]int)
+	toolResultIndex := make(map[string]int)
+	for i, msg := range messages {
+		uses, results := anthropicCompatMessageToolIDs(msg)
+		for _, id := range uses {
+			if _, exists := toolUseIndex[id]; !exists {
+				toolUseIndex[id] = i
+			}
+		}
+		for _, id := range results {
+			if _, exists := toolResultIndex[id]; !exists {
+				toolResultIndex[id] = i
+			}
+		}
+	}
+
+	for {
+		next := end
+		for i := 0; i < end; i++ {
+			uses, results := anthropicCompatMessageToolIDs(messages[i])
+			for _, id := range uses {
+				if resultIdx, ok := toolResultIndex[id]; ok && resultIdx+1 > next {
+					next = resultIdx + 1
+				}
+			}
+			for _, id := range results {
+				if useIdx, ok := toolUseIndex[id]; ok && useIdx+1 > next {
+					next = useIdx + 1
+				}
+			}
+		}
+		if next == end {
+			return end
+		}
+		if next >= len(messages) {
+			return len(messages)
+		}
+		end = next
 	}
 }
 

--- a/backend/internal/service/openai_messages_replay_guard.go
+++ b/backend/internal/service/openai_messages_replay_guard.go
@@ -11,33 +11,31 @@ const (
 	openAICompatOAuthReplayAnchorMessages      = 2
 )
 
+type openAICompatReplayCompactionProfile struct {
+	prefixMessages int
+	tailMessages   int
+}
+
 func applyAnthropicCompatFullReplayGuard(req *apicompat.AnthropicRequest) bool {
-	if req == nil || len(req.Messages) <= openAICompatAnthropicReplayMaxTailMessages {
-		return false
-	}
-
-	start := len(req.Messages) - openAICompatAnthropicReplayMaxTailMessages
-	start = expandAnthropicCompatTrimBoundary(req.Messages, start)
-	if start <= 0 {
-		return false
-	}
-
-	req.Messages = append([]apicompat.AnthropicMessage(nil), req.Messages[start:]...)
-	return true
+	return applyOpenAICompatReplayCompaction(req, openAICompatReplayCompactionProfile{tailMessages: openAICompatAnthropicReplayMaxTailMessages})
 }
 
 func applyOpenAICompatOAuthMessagesCompaction(req *apicompat.AnthropicRequest) bool {
-	if req == nil || len(req.Messages) <= openAICompatOAuthReplayAnchorMessages+openAICompatAnthropicReplayMaxTailMessages {
+	return applyOpenAICompatReplayCompaction(req, openAICompatReplayCompactionProfile{prefixMessages: openAICompatOAuthReplayAnchorMessages, tailMessages: openAICompatAnthropicReplayMaxTailMessages})
+}
+
+func applyOpenAICompatReplayCompaction(req *apicompat.AnthropicRequest, profile openAICompatReplayCompactionProfile) bool {
+	if req == nil || profile.tailMessages <= 0 || len(req.Messages) <= profile.prefixMessages+profile.tailMessages {
 		return false
 	}
 
-	prefixEnd := openAICompatOAuthReplayAnchorMessages
+	prefixEnd := profile.prefixMessages
 	if prefixEnd > len(req.Messages) {
 		prefixEnd = len(req.Messages)
 	}
 	prefixEnd = expandAnthropicCompatPrefixBoundary(req.Messages, prefixEnd)
 
-	tailStart := len(req.Messages) - openAICompatAnthropicReplayMaxTailMessages
+	tailStart := len(req.Messages) - profile.tailMessages
 	tailStart = expandAnthropicCompatTrimBoundary(req.Messages, tailStart)
 	if tailStart <= prefixEnd {
 		return false

--- a/backend/internal/service/openai_messages_replay_guard_test.go
+++ b/backend/internal/service/openai_messages_replay_guard_test.go
@@ -9,7 +9,7 @@ import (
 	"github.com/stretchr/testify/require"
 )
 
-func TestApplyAnthropicCompatFullReplayGuard_TrimsOldMessages(t *testing.T) {
+func TestApplyOpenAICompatReplayCompaction_TailOnlyProfileTrimsOldMessages(t *testing.T) {
 	t.Parallel()
 
 	req := &apicompat.AnthropicRequest{Messages: make([]apicompat.AnthropicMessage, 0, openAICompatAnthropicReplayMaxTailMessages+3)}
@@ -20,7 +20,7 @@ func TestApplyAnthropicCompatFullReplayGuard_TrimsOldMessages(t *testing.T) {
 		})
 	}
 
-	trimmed := applyAnthropicCompatFullReplayGuard(req)
+	trimmed := applyOpenAICompatReplayCompaction(req, openAICompatReplayCompactionProfile{tailMessages: openAICompatAnthropicReplayMaxTailMessages})
 
 	require.True(t, trimmed)
 	require.Len(t, req.Messages, openAICompatAnthropicReplayMaxTailMessages)
@@ -28,7 +28,7 @@ func TestApplyAnthropicCompatFullReplayGuard_TrimsOldMessages(t *testing.T) {
 	require.JSONEq(t, `"message-14"`, string(req.Messages[len(req.Messages)-1].Content))
 }
 
-func TestApplyAnthropicCompatFullReplayGuard_KeepsToolBoundaryIntact(t *testing.T) {
+func TestApplyOpenAICompatReplayCompaction_TailOnlyProfileKeepsToolBoundaryIntact(t *testing.T) {
 	t.Parallel()
 
 	req := &apicompat.AnthropicRequest{Messages: make([]apicompat.AnthropicMessage, 0, openAICompatAnthropicReplayMaxTailMessages+3)}
@@ -48,7 +48,7 @@ func TestApplyAnthropicCompatFullReplayGuard_KeepsToolBoundaryIntact(t *testing.
 		})
 	}
 
-	trimmed := applyAnthropicCompatFullReplayGuard(req)
+	trimmed := applyOpenAICompatReplayCompaction(req, openAICompatReplayCompactionProfile{tailMessages: openAICompatAnthropicReplayMaxTailMessages})
 
 	require.True(t, trimmed)
 	require.Len(t, req.Messages, openAICompatAnthropicReplayMaxTailMessages+2)
@@ -57,7 +57,7 @@ func TestApplyAnthropicCompatFullReplayGuard_KeepsToolBoundaryIntact(t *testing.
 	require.Contains(t, string(req.Messages[2].Content), `"tool_result"`)
 }
 
-func TestApplyOpenAICompatOAuthMessagesCompaction_KeepsPrefixAndTail(t *testing.T) {
+func TestApplyOpenAICompatReplayCompaction_AnchorAndTailProfileKeepsPrefixAndTail(t *testing.T) {
 	t.Parallel()
 
 	messageCount := openAICompatOAuthReplayAnchorMessages + openAICompatAnthropicReplayMaxTailMessages + 4
@@ -69,7 +69,7 @@ func TestApplyOpenAICompatOAuthMessagesCompaction_KeepsPrefixAndTail(t *testing.
 		})
 	}
 
-	trimmed := applyOpenAICompatOAuthMessagesCompaction(req)
+	trimmed := applyOpenAICompatReplayCompaction(req, openAICompatReplayCompactionProfile{prefixMessages: openAICompatOAuthReplayAnchorMessages, tailMessages: openAICompatAnthropicReplayMaxTailMessages})
 
 	require.True(t, trimmed)
 	require.Len(t, req.Messages, openAICompatOAuthReplayAnchorMessages+openAICompatAnthropicReplayMaxTailMessages)
@@ -79,7 +79,7 @@ func TestApplyOpenAICompatOAuthMessagesCompaction_KeepsPrefixAndTail(t *testing.
 	require.JSONEq(t, `"message-17"`, string(req.Messages[len(req.Messages)-1].Content))
 }
 
-func TestApplyOpenAICompatOAuthMessagesCompaction_KeepsPrefixToolBoundaryIntact(t *testing.T) {
+func TestApplyOpenAICompatReplayCompaction_AnchorAndTailProfileKeepsPrefixToolBoundaryIntact(t *testing.T) {
 	t.Parallel()
 
 	messageCount := openAICompatOAuthReplayAnchorMessages + openAICompatAnthropicReplayMaxTailMessages + 4
@@ -100,7 +100,7 @@ func TestApplyOpenAICompatOAuthMessagesCompaction_KeepsPrefixToolBoundaryIntact(
 		})
 	}
 
-	trimmed := applyOpenAICompatOAuthMessagesCompaction(req)
+	trimmed := applyOpenAICompatReplayCompaction(req, openAICompatReplayCompactionProfile{prefixMessages: openAICompatOAuthReplayAnchorMessages, tailMessages: openAICompatAnthropicReplayMaxTailMessages})
 
 	require.True(t, trimmed)
 	require.Len(t, req.Messages, openAICompatOAuthReplayAnchorMessages+openAICompatAnthropicReplayMaxTailMessages+1)

--- a/backend/internal/service/openai_messages_replay_guard_test.go
+++ b/backend/internal/service/openai_messages_replay_guard_test.go
@@ -56,3 +56,57 @@ func TestApplyAnthropicCompatFullReplayGuard_KeepsToolBoundaryIntact(t *testing.
 	require.Contains(t, string(req.Messages[0].Content), `"toolu_keep"`)
 	require.Contains(t, string(req.Messages[2].Content), `"tool_result"`)
 }
+
+func TestApplyOpenAICompatOAuthMessagesCompaction_KeepsPrefixAndTail(t *testing.T) {
+	t.Parallel()
+
+	messageCount := openAICompatOAuthReplayAnchorMessages + openAICompatAnthropicReplayMaxTailMessages + 4
+	req := &apicompat.AnthropicRequest{Messages: make([]apicompat.AnthropicMessage, 0, messageCount)}
+	for i := 0; i < messageCount; i++ {
+		req.Messages = append(req.Messages, apicompat.AnthropicMessage{
+			Role:    "user",
+			Content: json.RawMessage(fmt.Sprintf(`"message-%02d"`, i)),
+		})
+	}
+
+	trimmed := applyOpenAICompatOAuthMessagesCompaction(req)
+
+	require.True(t, trimmed)
+	require.Len(t, req.Messages, openAICompatOAuthReplayAnchorMessages+openAICompatAnthropicReplayMaxTailMessages)
+	require.JSONEq(t, `"message-00"`, string(req.Messages[0].Content))
+	require.JSONEq(t, `"message-01"`, string(req.Messages[1].Content))
+	require.JSONEq(t, `"message-06"`, string(req.Messages[2].Content))
+	require.JSONEq(t, `"message-17"`, string(req.Messages[len(req.Messages)-1].Content))
+}
+
+func TestApplyOpenAICompatOAuthMessagesCompaction_KeepsPrefixToolBoundaryIntact(t *testing.T) {
+	t.Parallel()
+
+	messageCount := openAICompatOAuthReplayAnchorMessages + openAICompatAnthropicReplayMaxTailMessages + 4
+	req := &apicompat.AnthropicRequest{Messages: make([]apicompat.AnthropicMessage, 0, messageCount)}
+	for i := 0; i < messageCount; i++ {
+		role := "user"
+		content := json.RawMessage(fmt.Sprintf(`"message-%02d"`, i))
+		if i == 1 {
+			role = "assistant"
+			content = json.RawMessage(`[{"type":"tool_use","id":"toolu_prefix","name":"Read","input":{"file_path":"main.go"}}]`)
+		}
+		if i == 2 {
+			content = json.RawMessage(`[{"type":"tool_result","tool_use_id":"toolu_prefix","content":"ok"}]`)
+		}
+		req.Messages = append(req.Messages, apicompat.AnthropicMessage{
+			Role:    role,
+			Content: content,
+		})
+	}
+
+	trimmed := applyOpenAICompatOAuthMessagesCompaction(req)
+
+	require.True(t, trimmed)
+	require.Len(t, req.Messages, openAICompatOAuthReplayAnchorMessages+openAICompatAnthropicReplayMaxTailMessages+1)
+	require.JSONEq(t, `"message-00"`, string(req.Messages[0].Content))
+	require.Contains(t, string(req.Messages[1].Content), `"toolu_prefix"`)
+	require.Contains(t, string(req.Messages[2].Content), `"tool_result"`)
+	require.JSONEq(t, `"message-06"`, string(req.Messages[3].Content))
+	require.JSONEq(t, `"message-17"`, string(req.Messages[len(req.Messages)-1].Content))
+}

--- a/docs/approved/messages-compaction-policy.md
+++ b/docs/approved/messages-compaction-policy.md
@@ -19,6 +19,7 @@ related_stories: [US-034]
 - 优先级：`account.extra > group`；
 - 仅当策略显式启用且 `input_tokens` 达阈值时触发；
 - 无账号/分组配置时保持现状（不压缩）；
+- OpenAI OAuth/Plus/Codex 账号显式启用后使用 OAuth-safe anchor+tail 裁剪；
 - 在 `previous_response_id` 回退路径新增结构化观测，区分 `not_found` 与 `unsupported`。
 
 ## 1. 背景与问题
@@ -29,7 +30,7 @@ related_stories: [US-034]
 
 1. 在不引入全局配置项的前提下，提供最小可控压缩开关；
 2. 保持 upstream 主文件最小侵入：策略逻辑下沉到 TK companion；
-3. 压缩逻辑复用现有 guard/trim，不新增第二套裁剪算法；
+3. APIKey 继续复用现有 guard/trim；OAuth 使用保留 system、首轮 anchor、尾部窗口和 tool 边界的安全裁剪；
 4. 回退路径产出结构化指标，便于区分兼容问题类型；
 5. 行为默认不变：未配置即不生效。
 
@@ -45,9 +46,10 @@ related_stories: [US-034]
 ### 3.2 非目标
 
 - 不新增全局 config 字段；
-- 不改变 OAuth 路径语义；
+- 不改变 OAuth 默认未配置行为；
 - 不引入会话级持久化 continuation 映射；
-- 不改变公共 API 路由或状态码契约。
+- 不改变公共 API 路由或状态码契约；
+- 不改变 `/responses/compact` 端点能力探测/调度路径，本策略仅作用于 `/v1/messages` 自动阈值裁剪。
 
 ## 4. 数据模型 / Schema（高风险项）
 
@@ -84,7 +86,9 @@ related_stories: [US-034]
 
 - 仅在 compat replay guard 场景命中时评估；
 - `input_tokens >= threshold` 才执行压缩；
-- 压缩执行复用已有 replay guard 裁剪路径。
+- APIKey 压缩复用已有 replay guard 裁剪路径；
+- OAuth 压缩保留 `system`、前 2 条业务 messages、尾部 12 条 messages，并扩展 tool_use/tool_result 边界；
+- OAuth 默认未配置时仍保持 full replay；显式配置后即使存在 `previous_response_id` 也允许进入阈值判定。
 
 ## 6. 回退路径可观测性
 
@@ -117,7 +121,7 @@ related_stories: [US-034]
 ## 8. 风险与控制
 
 1. 压缩过度造成上下文丢失
-   - 控制：复用既有 guard/trim，保证 tool 边界不破坏。
+   - 控制：APIKey 复用既有 guard/trim；OAuth 保留 system、首轮 anchor、尾部窗口和 tool 边界。
 2. continuation 回退行为回归
    - 控制：仅增强观测字段，不改状态机语义。
 3. 配置透传断链

--- a/docs/approved/messages-compaction-policy.md
+++ b/docs/approved/messages-compaction-policy.md
@@ -19,7 +19,7 @@ related_stories: [US-034]
 - 优先级：`account.extra > group`；
 - 仅当策略显式启用且 `input_tokens` 达阈值时触发；
 - 无账号/分组配置时保持现状（不压缩）；
-- OpenAI OAuth/Plus/Codex 账号显式启用后使用 OAuth-safe anchor+tail 裁剪；
+- OpenAI OAuth/Plus/Codex 账号显式启用后使用同一裁剪引擎的 anchor+tail profile；
 - 在 `previous_response_id` 回退路径新增结构化观测，区分 `not_found` 与 `unsupported`。
 
 ## 1. 背景与问题
@@ -30,7 +30,7 @@ related_stories: [US-034]
 
 1. 在不引入全局配置项的前提下，提供最小可控压缩开关；
 2. 保持 upstream 主文件最小侵入：策略逻辑下沉到 TK companion；
-3. APIKey 继续复用现有 guard/trim；OAuth 使用保留 system、首轮 anchor、尾部窗口和 tool 边界的安全裁剪；
+3. 裁剪逻辑只有一个参数化 replay compaction engine；APIKey 使用 tail-only profile，OAuth 使用保留 system、首轮 anchor、尾部窗口和 tool 边界的 anchor+tail profile；
 4. 回退路径产出结构化指标，便于区分兼容问题类型；
 5. 行为默认不变：未配置即不生效。
 
@@ -86,8 +86,8 @@ related_stories: [US-034]
 
 - 仅在 compat replay guard 场景命中时评估；
 - `input_tokens >= threshold` 才执行压缩；
-- APIKey 压缩复用已有 replay guard 裁剪路径；
-- OAuth 压缩保留 `system`、前 2 条业务 messages、尾部 12 条 messages，并扩展 tool_use/tool_result 边界；
+- APIKey 压缩使用同一裁剪引擎的 tail-only profile；
+- OAuth 压缩使用同一裁剪引擎的 anchor+tail profile：保留 `system`、前 2 条业务 messages、尾部 12 条 messages，并扩展 tool_use/tool_result 边界；
 - OAuth 默认未配置时仍保持 full replay；显式配置后即使存在 `previous_response_id` 也允许进入阈值判定。
 
 ## 6. 回退路径可观测性
@@ -121,7 +121,7 @@ related_stories: [US-034]
 ## 8. 风险与控制
 
 1. 压缩过度造成上下文丢失
-   - 控制：APIKey 复用既有 guard/trim；OAuth 保留 system、首轮 anchor、尾部窗口和 tool 边界。
+   - 控制：单一裁剪引擎统一处理 tool 边界；APIKey/OAuth 只选择不同 profile，OAuth profile 额外保留 system、首轮 anchor 和尾部窗口。
 2. continuation 回退行为回归
    - 控制：仅增强观测字段，不改状态机语义。
 3. 配置透传断链

--- a/scripts/engine-facade-sentinels.json
+++ b/scripts/engine-facade-sentinels.json
@@ -110,11 +110,13 @@
       ]
     },
     {
-      "name": "openai_compat_oauth_messages_compaction_guard",
+      "name": "openai_compat_replay_compaction_engine",
       "source": "backend/internal/service/openai_messages_replay_guard.go",
       "required_literals": [
-        "func applyOpenAICompatOAuthMessagesCompaction(req *apicompat.AnthropicRequest) bool",
-        "openAICompatOAuthReplayAnchorMessages",
+        "type openAICompatReplayCompactionProfile struct",
+        "func applyOpenAICompatReplayCompaction(req *apicompat.AnthropicRequest, profile openAICompatReplayCompactionProfile) bool",
+        "prefixMessages: openAICompatOAuthReplayAnchorMessages",
+        "tailMessages: openAICompatAnthropicReplayMaxTailMessages",
         "func expandAnthropicCompatPrefixBoundary(messages []apicompat.AnthropicMessage, end int) int",
         "expandAnthropicCompatTrimBoundary(req.Messages, tailStart)"
       ]

--- a/scripts/engine-facade-sentinels.json
+++ b/scripts/engine-facade-sentinels.json
@@ -89,8 +89,9 @@
       "source": "backend/internal/service/openai_gateway_messages.go",
       "required_literals": [
         "compatCompactionPolicy := resolveOpenAICompatMessagesCompactionPolicy(account, apiKeyGroup(getAPIKeyFromContext(c)))",
+        "shouldEvaluateOpenAICompatMessagesCompactionForAccount(account, previousResponseID, compatContinuationDisabled)",
         "if shouldApplyOpenAICompatMessagesCompaction(compatCompactionPolicy, &anthropicReq) {",
-        "compatReplayTrimmed = applyOpenAICompatMessagesCompaction(&anthropicReq)",
+        "compatReplayTrimmed = applyOpenAICompatMessagesCompaction(account, &anthropicReq)",
         "zap.Bool(\"compat_messages_compaction_applied\", true)",
         "zap.Int(\"compat_messages_compaction_input_tokens_threshold\", compatCompactionPolicy.inputTokenLimit)"
       ]
@@ -101,9 +102,21 @@
       "required_literals": [
         "func resolveOpenAICompatMessagesCompactionPolicy(account *Account, group *Group) openAICompatMessagesCompactionPolicy",
         "func shouldApplyOpenAICompatMessagesCompaction(policy openAICompatMessagesCompactionPolicy, req *apicompat.AnthropicRequest) bool",
-        "func applyOpenAICompatMessagesCompaction(req *apicompat.AnthropicRequest) bool",
+        "func shouldEvaluateOpenAICompatMessagesCompactionForAccount(account *Account, previousResponseID string, compatContinuationDisabled bool) bool",
+        "func applyOpenAICompatMessagesCompaction(account *Account, req *apicompat.AnthropicRequest) bool",
+        "return applyOpenAICompatOAuthMessagesCompaction(req)",
         "return applyAnthropicCompatFullReplayGuard(req)",
         "messages_compaction_input_tokens_threshold"
+      ]
+    },
+    {
+      "name": "openai_compat_oauth_messages_compaction_guard",
+      "source": "backend/internal/service/openai_messages_replay_guard.go",
+      "required_literals": [
+        "func applyOpenAICompatOAuthMessagesCompaction(req *apicompat.AnthropicRequest) bool",
+        "openAICompatOAuthReplayAnchorMessages",
+        "func expandAnthropicCompatPrefixBoundary(messages []apicompat.AnthropicMessage, end int) int",
+        "expandAnthropicCompatTrimBoundary(req.Messages, tailStart)"
       ]
     },
     {

--- a/scripts/gateway-tk-sentinels.json
+++ b/scripts/gateway-tk-sentinels.json
@@ -46,6 +46,16 @@
       "path": "backend/internal/service/ops_settings_models.go",
       "must_contain": ["OpsFeishuAlertConfig", "WebhookURLConfigured", "SigningSecretConfigured"],
       "rationale": "Ops email notification config JSON must preserve the Feishu write-only webhook/secret state without a DB migration. If this model shape is overwritten, frontend saves can drop Feishu config or leak secret fields."
+    },
+    {
+      "path": "backend/internal/service/openai_messages_compaction_tk.go",
+      "must_contain": ["shouldEvaluateOpenAICompatMessagesCompactionForAccount", "applyOpenAICompatMessagesCompaction(account *Account", "applyOpenAICompatOAuthMessagesCompaction"],
+      "rationale": "OpenAI OAuth /v1/messages compaction is a TK policy companion: OAuth must opt into threshold-based compaction without falling back to the APIKey-only tail trim. Dropping these hooks silently makes GPT专线 OAuth accounts ignore configured compaction thresholds."
+    },
+    {
+      "path": "backend/internal/service/openai_messages_compaction_tk_test.go",
+      "must_contain": ["TestShouldEvaluateOpenAICompatMessagesCompactionForAccount", "TestApplyOpenAICompatMessagesCompaction_UsesOAuthSafeGuardForOAuth", "TestApplyOpenAICompatMessagesCompaction_UsesTailGuardForAPIKey"],
+      "rationale": "Focused regressions proving OAuth configured compaction uses the OAuth-safe guard while APIKey compaction keeps the existing continuation gate and tail guard."
     }
   ]
 }

--- a/scripts/gateway-tk-sentinels.json
+++ b/scripts/gateway-tk-sentinels.json
@@ -50,12 +50,12 @@
     {
       "path": "backend/internal/service/openai_messages_compaction_tk.go",
       "must_contain": ["shouldEvaluateOpenAICompatMessagesCompactionForAccount", "applyOpenAICompatMessagesCompaction(account *Account", "applyOpenAICompatOAuthMessagesCompaction"],
-      "rationale": "OpenAI OAuth /v1/messages compaction is a TK policy companion: OAuth must opt into threshold-based compaction without falling back to the APIKey-only tail trim. Dropping these hooks silently makes GPT专线 OAuth accounts ignore configured compaction thresholds."
+      "rationale": "OpenAI OAuth /v1/messages compaction is a TK policy companion: OAuth must opt into threshold-based compaction through the shared replay compaction engine's anchor+tail profile. Dropping these hooks silently makes GPT专线 OAuth accounts ignore configured compaction thresholds."
     },
     {
       "path": "backend/internal/service/openai_messages_compaction_tk_test.go",
-      "must_contain": ["TestShouldEvaluateOpenAICompatMessagesCompactionForAccount", "TestApplyOpenAICompatMessagesCompaction_UsesOAuthSafeGuardForOAuth", "TestApplyOpenAICompatMessagesCompaction_UsesTailGuardForAPIKey"],
-      "rationale": "Focused regressions proving OAuth configured compaction uses the OAuth-safe guard while APIKey compaction keeps the existing continuation gate and tail guard."
+      "must_contain": ["TestShouldEvaluateOpenAICompatMessagesCompactionForAccount", "TestApplyOpenAICompatMessagesCompaction_UsesAnchorAndTailProfileForOAuth", "TestApplyOpenAICompatMessagesCompaction_UsesTailOnlyProfileForAPIKey"],
+      "rationale": "Focused regressions proving OAuth configured compaction uses the shared engine's anchor+tail profile while APIKey compaction keeps the existing continuation gate and tail-only profile."
     }
   ]
 }


### PR DESCRIPTION
## Summary
- Enable configured OpenAI OAuth `/v1/messages` traffic to use an OAuth-safe compaction path.
- Preserve OAuth/Codex invariants by keeping system/developer context, first-turn anchors, tail messages, and tool boundaries.
- Update sentinel registries and approved behavior docs for the new guard path.

## Test plan
- [x] `go test -tags=unit ./internal/service -run 'TestResolveOpenAICompatMessagesCompactionPolicy|TestShouldApplyOpenAICompatMessagesCompaction|TestShouldEvaluateOpenAICompatMessagesCompactionForAccount|TestApplyOpenAICompatMessagesCompaction'`
- [x] `go test ./internal/service`
- [x] `bash scripts/preflight.sh`

🤖 Generated with [Claude Code](https://claude.com/claude-code)