### PR TITLE
fix(ci): repair manual workflow smoke paths

### DIFF
--- a/.github/workflows/backend-ci.yml
+++ b/.github/workflows/backend-ci.yml
@@ -156,8 +156,11 @@ jobs:
           go version | grep -q 'go1.26.3'
       - name: Run gosec lint
         if: github.event_name == 'schedule' || github.event_name == 'workflow_dispatch'
-        working-directory: backend
-        run: make lint-security
+        uses: golangci/golangci-lint-action@v9
+        with:
+          version: v2.9
+          args: --enable-only gosec --concurrency=4 --timeout=30m
+          working-directory: backend
       - name: Run govulncheck
         working-directory: backend
         run: |

--- a/.github/workflows/pr-repair-agent.yml
+++ b/.github/workflows/pr-repair-agent.yml
@@ -81,8 +81,18 @@ jobs:
             echo "reason=failed run is not associated with a PR" >> "$GITHUB_OUTPUT"
             exit 0
           fi
+          if ! printf '%s' "$PR_NUMBER" | grep -Eq '^[1-9][0-9]*$'; then
+            echo "skip=true" >> "$GITHUB_OUTPUT"
+            echo "reason=manual pr_number must be a positive integer, got: $PR_NUMBER" >> "$GITHUB_OUTPUT"
+            exit 0
+          fi
 
-          PR_JSON="$(gh pr view "$PR_NUMBER" --json number,state,baseRefName,headRefName,headRepositoryOwner,url,title)"
+          if ! PR_JSON="$(gh pr view "$PR_NUMBER" --json number,state,baseRefName,headRefName,headRepositoryOwner,url,title 2>/tmp/pr-view-error.log)"; then
+            echo "skip=true" >> "$GITHUB_OUTPUT"
+            echo "reason=PR #$PR_NUMBER could not be read" >> "$GITHUB_OUTPUT"
+            cat /tmp/pr-view-error.log >&2 || true
+            exit 0
+          fi
           STATE="$(jq -r '.state' <<<"$PR_JSON")"
           BASE="$(jq -r '.baseRefName' <<<"$PR_JSON")"
           BRANCH="$(jq -r '.headRefName' <<<"$PR_JSON")"


### PR DESCRIPTION
## Summary
- Install golangci-lint through the maintained action before manual/scheduled gosec runs.
- Make PR Repair Agent manual dispatch skip invalid PR numbers cleanly instead of failing before checkout.

## Test plan
- [x] Parsed all `.github/workflows/*.yml` with Python YAML loader
- [x] `bash scripts/preflight.sh` in isolated worktree
- [x] Reproduced failures from manual workflow smoke runs: CI backend-security and PR Repair Agent invalid PR path

🤖 Generated with [Claude Code](https://claude.com/claude-code)