### PR TITLE
Protect Anthropic model 404s

### DIFF
--- a/backend/internal/service/ratelimit_404_model_not_found_test.go
+++ b/backend/internal/service/ratelimit_404_model_not_found_test.go
@@ -1,0 +1,88 @@
+//go:build unit
+
+package service
+
+import (
+	"context"
+	"net/http"
+	"testing"
+	"time"
+
+	"github.com/Wei-Shaw/sub2api/internal/config"
+	"github.com/stretchr/testify/require"
+)
+
+type anthropic404AccountRepoStub struct {
+	mockAccountRepoForGemini
+	modelRateLimitCalls int
+	lastAccountID       int64
+	lastScope           string
+	lastResetAt         time.Time
+	setErrorCalls       int
+	rateLimitCalls      int
+}
+
+func (r *anthropic404AccountRepoStub) SetModelRateLimit(_ context.Context, id int64, scope string, resetAt time.Time) error {
+	r.modelRateLimitCalls++
+	r.lastAccountID = id
+	r.lastScope = scope
+	r.lastResetAt = resetAt
+	return nil
+}
+
+func (r *anthropic404AccountRepoStub) SetError(_ context.Context, _ int64, _ string) error {
+	r.setErrorCalls++
+	return nil
+}
+
+func (r *anthropic404AccountRepoStub) SetRateLimited(_ context.Context, _ int64, _ time.Time) error {
+	r.rateLimitCalls++
+	return nil
+}
+
+func TestHandleUpstreamError_Anthropic404ModelNotFoundSetsModelRateLimit(t *testing.T) {
+	repo := &anthropic404AccountRepoStub{}
+	svc := NewRateLimitService(repo, nil, &config.Config{}, nil, nil)
+	account := &Account{ID: 42, Platform: PlatformAnthropic, Type: AccountTypeOAuth}
+	body := []byte(`{"type":"error","error":{"type":"not_found_error","message":"model: claude-haiku-4-7"}}`)
+
+	before := time.Now()
+	shouldDisable := svc.HandleUpstreamError(context.Background(), account, http.StatusNotFound, http.Header{}, body)
+	after := time.Now()
+
+	require.True(t, shouldDisable)
+	require.Equal(t, 1, repo.modelRateLimitCalls)
+	require.Equal(t, int64(42), repo.lastAccountID)
+	require.Equal(t, "claude-haiku-4-7", repo.lastScope)
+	require.True(t, !repo.lastResetAt.Before(before.Add(anthropic404ModelCooldown)) && !repo.lastResetAt.After(after.Add(anthropic404ModelCooldown)))
+	require.Zero(t, repo.setErrorCalls)
+	require.Zero(t, repo.rateLimitCalls)
+}
+
+func TestHandleUpstreamError_Anthropic404WithoutModelDoesNotDisableAccount(t *testing.T) {
+	repo := &anthropic404AccountRepoStub{}
+	svc := NewRateLimitService(repo, nil, &config.Config{}, nil, nil)
+	account := &Account{ID: 43, Platform: PlatformAnthropic, Type: AccountTypeOAuth}
+	body := []byte(`{"type":"error","error":{"type":"not_found_error","message":"resource not found"}}`)
+
+	shouldDisable := svc.HandleUpstreamError(context.Background(), account, http.StatusNotFound, http.Header{}, body)
+
+	require.False(t, shouldDisable)
+	require.Zero(t, repo.modelRateLimitCalls)
+	require.Zero(t, repo.setErrorCalls)
+	require.Zero(t, repo.rateLimitCalls)
+}
+
+func TestHandleUpstreamError_NonAnthropic404DoesNotUseAnthropicModelProtection(t *testing.T) {
+	repo := &anthropic404AccountRepoStub{}
+	svc := NewRateLimitService(repo, nil, &config.Config{}, nil, nil)
+	account := &Account{ID: 44, Platform: PlatformOpenAI, Type: AccountTypeOAuth}
+	body := []byte(`{"error":{"type":"not_found_error","message":"model: gpt-9"}}`)
+
+	shouldDisable := svc.HandleUpstreamError(context.Background(), account, http.StatusNotFound, http.Header{}, body)
+
+	require.False(t, shouldDisable)
+	require.Zero(t, repo.modelRateLimitCalls)
+	require.Zero(t, repo.setErrorCalls)
+	require.Zero(t, repo.rateLimitCalls)
+}

--- a/backend/internal/service/ratelimit_service.go
+++ b/backend/internal/service/ratelimit_service.go
@@ -7,6 +7,7 @@ import (
 	"fmt"
 	"log/slog"
 	"net/http"
+	"regexp"
 	"strconv"
 	"strings"
 	"sync"
@@ -58,7 +59,10 @@ const geminiPrecheckCacheTTL = time.Minute
 const (
 	defaultRateLimit429CooldownSeconds = 5
 	maxRateLimit429CooldownSeconds     = 7200
+	anthropic404ModelCooldown          = 24 * time.Hour
 )
+
+var anthropicNotFoundModelPattern = regexp.MustCompile(`(?i)model:\s*([A-Za-z0-9._:/-]+)`)
 
 const (
 	openAI403CooldownMinutesDefault = 10
@@ -270,6 +274,8 @@ func (s *RateLimitService) HandleUpstreamError(ctx context.Context, account *Acc
 			truncateForLog(responseBody, 1024),
 		)
 		shouldDisable = s.handle403(ctx, account, upstreamMsg, responseBody)
+	case 404:
+		shouldDisable = s.handle404(ctx, account, upstreamMsg, responseBody)
 	case 429:
 		s.handle429(ctx, account, headers, responseBody)
 		shouldDisable = false
@@ -817,6 +823,60 @@ func (s *RateLimitService) handleCustomErrorCode(ctx context.Context, account *A
 		return
 	}
 	slog.Warn("account_disabled_custom_error", "account_id", account.ID, "status_code", statusCode, "error", errorMsg)
+}
+
+func (s *RateLimitService) handle404(ctx context.Context, account *Account, upstreamMsg string, responseBody []byte) (shouldDisable bool) {
+	if account.Platform != PlatformAnthropic {
+		return false
+	}
+	if !isAnthropicModelNotFound404(responseBody, upstreamMsg) {
+		return false
+	}
+	modelName := extractAnthropicNotFoundModel(responseBody, upstreamMsg)
+	if modelName == "" {
+		slog.Warn("anthropic_404_model_not_found_without_model", "account_id", account.ID, "upstream_msg", upstreamMsg)
+		return false
+	}
+	resetAt := time.Now().Add(anthropic404ModelCooldown)
+	if err := s.accountRepo.SetModelRateLimit(ctx, account.ID, modelName, resetAt); err != nil {
+		slog.Warn("anthropic_404_model_rate_limit_failed", "account_id", account.ID, "model", modelName, "error", err)
+		return false
+	}
+	slog.Warn("anthropic_404_model_rate_limited", "account_id", account.ID, "model", modelName, "reset_at", resetAt)
+	return true
+}
+
+func isAnthropicModelNotFound404(responseBody []byte, upstreamMsg string) bool {
+	errorType := strings.ToLower(strings.TrimSpace(gjson.GetBytes(responseBody, "error.type").String()))
+	if errorType == "not_found_error" {
+		return true
+	}
+	bodyLower := strings.ToLower(string(responseBody))
+	msgLower := strings.ToLower(strings.TrimSpace(upstreamMsg))
+	return strings.Contains(bodyLower, "not_found_error") ||
+		(strings.Contains(msgLower, "model:") && strings.Contains(msgLower, "not found")) ||
+		(strings.Contains(bodyLower, "model:") && strings.Contains(bodyLower, "not found"))
+}
+
+func extractAnthropicNotFoundModel(responseBody []byte, upstreamMsg string) string {
+	if model := strings.TrimSpace(gjson.GetBytes(responseBody, "model").String()); model != "" {
+		return model
+	}
+	if model := strings.TrimSpace(gjson.GetBytes(responseBody, "error.model").String()); model != "" {
+		return model
+	}
+	if model := findAnthropicNotFoundModel(upstreamMsg); model != "" {
+		return model
+	}
+	return findAnthropicNotFoundModel(string(responseBody))
+}
+
+func findAnthropicNotFoundModel(text string) string {
+	match := anthropicNotFoundModelPattern.FindStringSubmatch(text)
+	if len(match) < 2 {
+		return ""
+	}
+	return strings.Trim(match[1], " .,'\"`)")
 }
 
 // handle429 处理429限流错误

--- a/backend/internal/web/dist/frontend-source.json
+++ b/backend/internal/web/dist/frontend-source.json
@@ -1,7 +1,7 @@
 {
   "algorithm": "sha256(git-ls-files:path,size,content)",
   "file_count": 421,
-  "hash": "235f261c797bf8de661e7e94fe34676ebd837ca6f603a87c09b7711ca8c7b0ad",
+  "hash": "4d294e7eeb85e85592006ba3fa4b9fe93ba273d5bc5e6169e4259d2b1dc18aad",
   "schema": 1,
   "source": "frontend/"
 }

--- a/frontend/src/i18n/locales/en.ts
+++ b/frontend/src/i18n/locales/en.ts
@@ -5514,7 +5514,10 @@ export default {
         cchSigningHint: 'Sign the billing header in forwarded requests with CCH hash. When disabled, the placeholder is preserved.',
         stickyRouting: 'Prompt Cache Sticky Routing',
         stickyRoutingHint:
-          'Enabled by default. Derives stable prompt_cache_key / metadata.user_id / X-Session-Id and injects them upstream to maximize prompt cache hits. When disabled, every group falls back to passthrough — only forwarding sticky fields the client already sent. See docs/approved/sticky-routing.md.'
+          'Enabled by default. Derives stable prompt_cache_key / metadata.user_id / X-Session-Id and injects them upstream to maximize prompt cache hits. When disabled, every group falls back to passthrough — only forwarding sticky fields the client already sent. See docs/approved/sticky-routing.md.',
+        anthropicCacheTTL1hInjection: 'Anthropic Cache TTL 1h Injection',
+        anthropicCacheTTL1hInjectionHint:
+          'Inject 1h cache_control TTL on supported Anthropic forwarding paths to improve long-context prompt cache hits. Disable to keep the default cache TTL behavior.'
       },
       webSearchEmulation: {
         title: 'Web Search Emulation',

--- a/frontend/src/i18n/locales/zh.ts
+++ b/frontend/src/i18n/locales/zh.ts
@@ -5670,7 +5670,10 @@ export default {
         cchSigningHint: '对转发请求的 billing header 进行 CCH 哈希签名。关闭时保留原始占位符。',
         stickyRouting: 'Prompt Cache 粘性路由',
         stickyRoutingHint:
-          '默认开启：网关派生稳定的 prompt_cache_key / metadata.user_id / X-Session-Id 注入到上游，以提高 prompt cache 命中率。关闭后所有分组退化为透传客户端已发送的字段，不再派生。详见 docs/approved/sticky-routing.md。'
+          '默认开启：网关派生稳定的 prompt_cache_key / metadata.user_id / X-Session-Id 注入到上游，以提高 prompt cache 命中率。关闭后所有分组退化为透传客户端已发送的字段，不再派生。详见 docs/approved/sticky-routing.md。',
+        anthropicCacheTTL1hInjection: 'Anthropic Cache TTL 1h 注入',
+        anthropicCacheTTL1hInjectionHint:
+          '开启后在支持的 Anthropic 转发路径中注入 1h cache_control TTL，用于提升长上下文 prompt cache 命中率。关闭后保持默认缓存 TTL 行为。'
       },
       webSearchEmulation: {
         title: 'Web Search 模拟',

--- a/frontend/src/views/admin/SettingsView.vue
+++ b/frontend/src/views/admin/SettingsView.vue
@@ -3140,6 +3140,21 @@
                 <Toggle v-model="form.enable_metadata_passthrough" />
               </div>
 
+              <!-- Sticky Routing -->
+              <div class="flex items-center justify-between">
+                <div>
+                  <label
+                    class="text-sm font-medium text-gray-700 dark:text-gray-300"
+                  >
+                    {{ t("admin.settings.gatewayForwarding.stickyRouting") }}
+                  </label>
+                  <p class="mt-0.5 text-xs text-gray-500 dark:text-gray-400">
+                    {{ t("admin.settings.gatewayForwarding.stickyRoutingHint") }}
+                  </p>
+                </div>
+                <Toggle v-model="form.sticky_routing_enabled" />
+              </div>
+
               <!-- CCH Signing -->
               <div class="flex items-center justify-between">
                 <div>

--- a/scripts/frontend-tk-sentinels.json
+++ b/scripts/frontend-tk-sentinels.json
@@ -166,6 +166,32 @@
         "data-testid=\"ops-feishu-webhook-input\""
       ],
       "rationale": "The Ops notification card is the single edit surface for Feishu P0 alerts. The anchors pin the enabled toggle, P0-only/no-resolved/no-@all operator warning, write-only webhook placeholder, and focused test hook so upstream UI merges cannot silently remove the low-noise Feishu config."
+    },
+    {
+      "path": "frontend/src/views/admin/SettingsView.vue",
+      "must_contain": [
+        "admin.settings.gatewayForwarding.stickyRouting",
+        "form.sticky_routing_enabled",
+        "admin.settings.gatewayForwarding.anthropicCacheTTL1hInjection",
+        "form.enable_anthropic_cache_ttl_1h_injection"
+      ],
+      "rationale": "The request-forwarding settings card is a large upstream-shaped admin page. Global prompt-cache sticky routing and Anthropic Cache TTL 1h injection both compile cleanly if their toggles are dropped from the template while the backend settings still exist, leaving operators unable to configure the account-safety/cache controls from the UI."
+    },
+    {
+      "path": "frontend/src/i18n/locales/zh.ts",
+      "must_contain": [
+        "stickyRouting: 'Prompt Cache 粘性路由'",
+        "anthropicCacheTTL1hInjection: 'Anthropic Cache TTL 1h 注入'"
+      ],
+      "rationale": "Chinese admin settings labels must keep the global sticky and Anthropic Cache TTL 1h controls discoverable. Missing locale keys render raw i18n paths in the operator UI and made this control appear broken in the edge-uk1 mitigation workflow."
+    },
+    {
+      "path": "frontend/src/i18n/locales/en.ts",
+      "must_contain": [
+        "stickyRouting: 'Prompt Cache Sticky Routing'",
+        "anthropicCacheTTL1hInjection: 'Anthropic Cache TTL 1h Injection'"
+      ],
+      "rationale": "English admin settings labels must stay in sync with the global sticky and Anthropic Cache TTL 1h controls so upstream locale merges cannot silently regress one language while the template still compiles."
     }
   ]
 }

--- a/scripts/gateway-tk-sentinels.json
+++ b/scripts/gateway-tk-sentinels.json
@@ -56,6 +56,16 @@
       "path": "backend/internal/service/openai_messages_compaction_tk_test.go",
       "must_contain": ["TestShouldEvaluateOpenAICompatMessagesCompactionForAccount", "TestApplyOpenAICompatMessagesCompaction_UsesAnchorAndTailProfileForOAuth", "TestApplyOpenAICompatMessagesCompaction_UsesTailOnlyProfileForAPIKey"],
       "rationale": "Focused regressions proving OAuth configured compaction uses the shared engine's anchor+tail profile while APIKey compaction keeps the existing continuation gate and tail-only profile."
+    },
+    {
+      "path": "backend/internal/service/ratelimit_service.go",
+      "must_contain": ["case 404:", "s.handle404(ctx, account, upstreamMsg, responseBody)", "anthropic404ModelCooldown", "isAnthropicModelNotFound404", "SetModelRateLimit(ctx, account.ID, modelName, resetAt)"],
+      "rationale": "Anthropic model-not-found 404s must stay model-scoped instead of falling through as an unprotected upstream error or disabling the whole OAuth account. Upstream merges in this large service file can compile cleanly while dropping the 404 branch or the model-rate-limit write, which would reintroduce repeated bad-model retries against Anthropic."
+    },
+    {
+      "path": "backend/internal/service/ratelimit_404_model_not_found_test.go",
+      "must_contain": ["TestHandleUpstreamError_Anthropic404ModelNotFoundSetsModelRateLimit", "TestHandleUpstreamError_Anthropic404WithoutModelDoesNotDisableAccount", "TestHandleUpstreamError_NonAnthropic404DoesNotUseAnthropicModelProtection"],
+      "rationale": "Focused regressions proving only Anthropic model-not-found 404s write model_rate_limits, while generic 404s and non-Anthropic 404s do not disable accounts. Dropping these tests lets the upstream-error policy silently drift during future merges."
     }
   ]
 }


### PR DESCRIPTION
## Summary
- Add Anthropic 404 model-not-found handling that sets a model-scoped cooldown instead of disabling the whole account.
- Add focused unit coverage for Anthropic model 404 behavior and non-Anthropic/no-model cases.
- Expose the global sticky routing toggle in admin request-forwarding settings and fill missing Cache TTL i18n labels.
- Add upstream-merge overwrite guards in the gateway/frontend TK sentinel registries for the new protection and admin controls.

## Test plan
- [x] python3 scripts/check-gateway-tk-sentinels.py
- [x] python3 scripts/check-frontend-tk-sentinels.py
- [x] python3 scripts/check-sentinel-registry-update-gate.py
- [x] go -C backend test -tags=unit ./internal/service -run 'TestHandleUpstreamError_Anthropic404|TestHandle429_Fallback'
- [x] go -C backend test -tags=unit ./...
- [x] pnpm -C frontend lint:check
- [x] pnpm -C frontend typecheck
- [x] pnpm --dir frontend run build
- [x] bash scripts/preflight.sh

🤖 Generated with [Claude Code](https://claude.com/claude-code)