### PR TITLE
fix ops log dump env and sticky source observability

### DIFF
--- a/.github/workflows/prod-ops.yml
+++ b/.github/workflows/prod-ops.yml
@@ -313,9 +313,8 @@ jobs:
           INSTANCE_ID: ${{ steps.instance.outputs.id }}
         run: |
           set -euo pipefail
-          GREP_B64=$(printf '%s' "$INPUT_GREP" | base64 -w0 2>/dev/null \
-            || printf '%s' "$INPUT_GREP" | base64 | tr -d '\n')
-          export GREP_B64
+          export GREP_B64="$(printf '%s' "$INPUT_GREP" | base64 -w0 2>/dev/null \
+            || printf '%s' "$INPUT_GREP" | base64 | tr -d '\n')"
 
           python3 - <<'PY' > ssm-params.json
           import json

--- a/.github/workflows/prod-ops.yml
+++ b/.github/workflows/prod-ops.yml
@@ -315,6 +315,7 @@ jobs:
           set -euo pipefail
           GREP_B64=$(printf '%s' "$INPUT_GREP" | base64 -w0 2>/dev/null \
             || printf '%s' "$INPUT_GREP" | base64 | tr -d '\n')
+          export GREP_B64
 
           python3 - <<'PY' > ssm-params.json
           import json

--- a/backend/internal/handler/gateway_handler_tk_selection.go
+++ b/backend/internal/handler/gateway_handler_tk_selection.go
@@ -2,7 +2,9 @@ package handler
 
 import (
 	"context"
+	"strings"
 
+	"github.com/Wei-Shaw/sub2api/internal/pkg/ctxkey"
 	"github.com/Wei-Shaw/sub2api/internal/pkg/ip"
 	"github.com/Wei-Shaw/sub2api/internal/service"
 
@@ -43,5 +45,11 @@ func TkPrepareParsedRequestSessionInputs(c *gin.Context, apiKey *service.APIKey,
 		ClientIP:  ip.GetClientIP(c),
 		UserAgent: c.GetHeader("User-Agent"),
 		APIKeyID:  apiKey.ID,
+	}
+	if requestID, _ := c.Request.Context().Value(ctxkey.RequestID).(string); strings.TrimSpace(requestID) != "" {
+		parsedReq.RequestID = strings.TrimSpace(requestID)
+	}
+	if clientRequestID, _ := c.Request.Context().Value(ctxkey.ClientRequestID).(string); strings.TrimSpace(clientRequestID) != "" {
+		parsedReq.ClientRequestID = strings.TrimSpace(clientRequestID)
 	}
 }

--- a/backend/internal/service/gateway_request.go
+++ b/backend/internal/service/gateway_request.go
@@ -76,6 +76,8 @@ type ParsedRequest struct {
 	OutputEffort      string          // output_config.effort（Claude API 的推理强度控制）
 	MaxTokens         int             // max_tokens 值（用于探测请求拦截）
 	SessionContext    *SessionContext // 可选：请求上下文区分因子（nil 时行为不变）
+	RequestID         string
+	ClientRequestID   string
 
 	// GroupID 请求所属分组 ID（来自 API Key）
 	GroupID *int64

--- a/backend/internal/service/gateway_service.go
+++ b/backend/internal/service/gateway_service.go
@@ -663,6 +663,15 @@ func (s *GatewayService) GenerateSessionHash(parsed *ParsedRequest) string {
 		return ""
 	}
 
+	recordStickyHashSource := func(source string, sessionHash string) {
+		logger.WriteSinkEvent("info", "http.access.sticky", "sticky.hash_source", map[string]any{
+			"request_id":         parsed.RequestID,
+			"client_request_id":  parsed.ClientRequestID,
+			"source":             source,
+			"session_hash_short": shortSessionHash(sessionHash),
+		})
+	}
+
 	// Anthropic ingress keeps real client metadata.user_id above gateway-forwarded sticky headers.
 	if parsed.MetadataUserID != "" {
 		uid := ParseMetadataUserID(parsed.MetadataUserID)
@@ -673,6 +682,7 @@ func (s *GatewayService) GenerateSessionHash(parsed *ParsedRequest) string {
 				"device_id", uid.DeviceID,
 				"is_new_format", uid.IsNewFormat,
 			)
+			recordStickyHashSource("metadata_user_id", uid.SessionID)
 			return uid.SessionID
 		}
 		slog.Info("sticky.hash_metadata_parse_failed",
@@ -687,6 +697,7 @@ func (s *GatewayService) GenerateSessionHash(parsed *ParsedRequest) string {
 			"source", parsed.ExplicitStickyKey.Source,
 			"hash", hash,
 		)
+		recordStickyHashSource(parsed.ExplicitStickyKey.Source, hash)
 		return hash
 	}
 
@@ -696,6 +707,7 @@ func (s *GatewayService) GenerateSessionHash(parsed *ParsedRequest) string {
 			"source", StickyKeySourceClientPromptCacheKey,
 			"hash", hash,
 		)
+		recordStickyHashSource(StickyKeySourceClientPromptCacheKey, hash)
 		return hash
 	}
 
@@ -707,6 +719,7 @@ func (s *GatewayService) GenerateSessionHash(parsed *ParsedRequest) string {
 			"source", "cacheable_content",
 			"hash", hash,
 		)
+		recordStickyHashSource("cacheable_content", hash)
 		return hash
 	}
 
@@ -753,6 +766,7 @@ func (s *GatewayService) GenerateSessionHash(parsed *ParsedRequest) string {
 			"hash", hash,
 			"content_len", combined.Len(),
 		)
+		recordStickyHashSource("message_content_fallback", hash)
 		return hash
 	}
 

--- a/backend/internal/service/ops_system_log_sink_test.go
+++ b/backend/internal/service/ops_system_log_sink_test.go
@@ -60,6 +60,20 @@ func TestOpsSystemLogSink_ShouldIndex(t *testing.T) {
 			want: true,
 		},
 		{
+			name:  "sticky access component",
+			event: &logger.LogEvent{Level: "info", Component: "http.access.sticky"},
+			want:  true,
+		},
+		{
+			name: "sticky access component from fields",
+			event: &logger.LogEvent{
+				Level:     "info",
+				Component: "service.gateway",
+				Fields:    map[string]any{"component": "http.access.sticky"},
+			},
+			want: true,
+		},
+		{
 			name:  "plain info",
 			event: &logger.LogEvent{Level: "info", Component: "app"},
 			want:  false,

--- a/scripts/gateway-tk-sentinels.json
+++ b/scripts/gateway-tk-sentinels.json
@@ -107,9 +107,11 @@
     {
       "path": "backend/internal/service/gateway_service.go",
       "must_contain": [
-        "tkEnsureClaudeCodeSessionHeader(req.Header, body, c)"
+        "tkEnsureClaudeCodeSessionHeader(req.Header, body, c)",
+        "logger.WriteSinkEvent(\"info\", \"http.access.sticky\", \"sticky.hash_source\"",
+        "\"session_hash_short\": shortSessionHash(sessionHash)"
       ],
-      "rationale": "Main gateway upstream builders must invoke unified TK Claude session-header sync after API-key passthrough, OAuth forward, and count_tokens forward paths diverge upstream merge conflicts."
+      "rationale": "Main gateway upstream builders must invoke unified TK Claude session-header sync after API-key passthrough, OAuth forward, and count_tokens forward paths diverge upstream merge conflicts. Sticky-source sink event emission is also load-bearing for prod request_id/client_request_id evidence correlation."
     },
     {
       "path": "backend/internal/handler/gateway_helper.go",
@@ -123,9 +125,11 @@
       "path": "backend/internal/handler/gateway_handler_tk_selection.go",
       "must_contain": [
         "TkPrepareParsedRequestSessionInputs",
-        "ExplicitStickyKey = service.StickyKeyFromClientHeaders(c.Request.Header)"
+        "ExplicitStickyKey = service.StickyKeyFromClientHeaders(c.Request.Header)",
+        "parsedReq.RequestID = strings.TrimSpace(requestID)",
+        "parsedReq.ClientRequestID = strings.TrimSpace(clientRequestID)"
       ],
-      "rationale": "/v1/messages and compat ingress must populate ExplicitStickyKey from whitelist headers including X-Claude-Code-Session-Id forwarded from an upstream sibling before GenerateSessionHash; dropping this TK helper route breaks sticky without compile errors."
+      "rationale": "/v1/messages and compat ingress must populate ExplicitStickyKey from whitelist headers including X-Claude-Code-Session-Id forwarded from an upstream sibling before GenerateSessionHash; it must also copy request_id/client_request_id into ParsedRequest so sticky-source sink events can be correlated in ops_system_logs."
     },
     {
       "path": "backend/internal/service/openai_gateway_bridge_dispatch_tk_anthropic.go",

--- a/scripts/newapi-sentinels.json
+++ b/scripts/newapi-sentinels.json
@@ -24,18 +24,18 @@
     },
     {
       "path": "backend/internal/service/gateway_request.go",
-      "must_contain": ["ExplicitStickyKey", "PromptCacheKey", "prompt_cache_key"],
-      "rationale": "ParsedRequest must preserve explicit sticky identity and top-level prompt_cache_key so the Anthropic edge ingress can consume prod-forwarded sticky signals without reparsing or falling back to message content."
+      "must_contain": ["ExplicitStickyKey", "PromptCacheKey", "prompt_cache_key", "RequestID", "ClientRequestID"],
+      "rationale": "ParsedRequest must preserve explicit sticky identity and top-level prompt_cache_key so the Anthropic edge ingress can consume prod-forwarded sticky signals without reparsing or falling back to message content; request correlation IDs are also load-bearing inputs for sticky-source evidence indexing."
     },
     {
       "path": "backend/internal/service/gateway_service.go",
-      "must_contain": ["parsed.ExplicitStickyKey.Value", "StickyKeySourceClientPromptCacheKey", "message_content_fallback"],
-      "rationale": "Anthropic GenerateSessionHash must prefer metadata.user_id, then explicit headers, then prompt_cache_key before the message-content fallback. Losing this priority recreates the max_sessions exhaustion incident on edge OAuth accounts."
+      "must_contain": ["parsed.ExplicitStickyKey.Value", "StickyKeySourceClientPromptCacheKey", "message_content_fallback", "logger.WriteSinkEvent(\"info\", \"http.access.sticky\", \"sticky.hash_source\"", "\"client_request_id\":  parsed.ClientRequestID"],
+      "rationale": "Anthropic GenerateSessionHash must prefer metadata.user_id, then explicit headers, then prompt_cache_key before the message-content fallback. Losing this priority recreates the max_sessions exhaustion incident on edge OAuth accounts. The sticky-source sink event emission is also load-bearing for request-id based production debugging."
     },
     {
       "path": "backend/internal/handler/gateway_handler_tk_selection.go",
-      "must_contain": ["TkPrepareParsedRequestSessionInputs", "StickyKeyFromClientHeaders", "SessionContext"],
-      "rationale": "Anthropic handlers share this TK companion to populate group, explicit sticky headers, and context before account selection. Without the shared hook, /v1/messages or count_tokens can skip the prod-forwarded sticky identity."
+      "must_contain": ["TkPrepareParsedRequestSessionInputs", "StickyKeyFromClientHeaders", "SessionContext", "parsedReq.RequestID = strings.TrimSpace(requestID)", "parsedReq.ClientRequestID = strings.TrimSpace(clientRequestID)"],
+      "rationale": "Anthropic handlers share this TK companion to populate group, explicit sticky headers, and context before account selection. Without the shared hook, /v1/messages or count_tokens can skip the prod-forwarded sticky identity. Request correlation IDs are part of the same load-bearing contract for sticky-source observability evidence."
     },
     {
       "path": "backend/internal/service/openai_messages_dispatch_tk_newapi.go",


### PR DESCRIPTION
## Summary
- fix `.github/workflows/prod-ops.yml` `log_dump` env propagation by exporting `GREP_B64` in-place before Python heredoc reads `os.environ[\"GREP_B64\"]`
- add sticky source sink event indexing path in `GenerateSessionHash` with `http.access.sticky` component and correlation fields (`request_id`, `client_request_id`, `source`, `session_hash_short`)
- wire `RequestID` / `ClientRequestID` into `ParsedRequest` via `TkPrepareParsedRequestSessionInputs` and update sentinel registries for gateway/newapi guarded surfaces

## Review findings fixed in this PR
- preflight sentinel gate initially failed because load-bearing hotspot files changed without registry updates; fixed by updating:
  - `scripts/gateway-tk-sentinels.json`
  - `scripts/newapi-sentinels.json`
- JSON syntax in sentinel registries was validated and corrected; `scripts/preflight.sh` now passes fully

## Test plan
- [x] `cd backend && go test ./internal/service -run 'TestOpsSystemLogSink_ShouldIndex|TestGenerateSessionHash_'`
- [x] `bash scripts/preflight.sh`
- [ ] after deploy: run `SINCE=10m GREP_PATTERN='sticky.hash_source' bash scripts/fetch-prod-logs.sh` and verify `ops_system_logs` contains `message=sticky.hash_source` with `extra.source`

## Risk
- low/normal: sticky path adds one sink event per sticky hash computation; scope limited to indexed `http.access.*` component and short hash only.

🤖 Generated with [Claude Code](https://claude.com/claude-code)