### PR TITLE
fix(gateway): decompress zstd upstream relay responses

### DIFF
--- a/backend/internal/repository/http_upstream.go
+++ b/backend/internal/repository/http_upstream.go
@@ -16,6 +16,7 @@ import (
 	"time"
 
 	"github.com/andybalholm/brotli"
+	"github.com/klauspost/compress/zstd"
 
 	"github.com/Wei-Shaw/sub2api/internal/config"
 	"github.com/Wei-Shaw/sub2api/internal/pkg/proxyurl"
@@ -887,6 +888,12 @@ func decompressResponseBody(resp *http.Response) {
 			return // 解压失败，保持原样
 		}
 		reader = gr
+	case "zstd":
+		zr, err := zstd.NewReader(resp.Body)
+		if err != nil {
+			return // 解压失败，保持原样
+		}
+		reader = zr
 	case "br":
 		reader = brotli.NewReader(resp.Body)
 	case "deflate":

--- a/backend/internal/repository/http_upstream_test.go
+++ b/backend/internal/repository/http_upstream_test.go
@@ -8,8 +8,8 @@ import (
 	"testing"
 	"time"
 
-	"github.com/klauspost/compress/zstd"
 	"github.com/Wei-Shaw/sub2api/internal/config"
+	"github.com/klauspost/compress/zstd"
 	"github.com/stretchr/testify/require"
 	"github.com/stretchr/testify/suite"
 )

--- a/backend/internal/repository/http_upstream_test.go
+++ b/backend/internal/repository/http_upstream_test.go
@@ -1,12 +1,14 @@
 package repository
 
 import (
+	"bytes"
 	"io"
 	"net/http"
 	"sync/atomic"
 	"testing"
 	"time"
 
+	"github.com/klauspost/compress/zstd"
 	"github.com/Wei-Shaw/sub2api/internal/config"
 	"github.com/stretchr/testify/require"
 	"github.com/stretchr/testify/suite"
@@ -274,6 +276,30 @@ func (s *HTTPUpstreamSuite) TestIdleTTLDoesNotEvictActive() {
 	_, _ = svc.getOrCreateClient("", 2, 1)
 
 	require.True(s.T(), hasEntry(svc, entry1), "有活跃请求时不应回收")
+}
+
+func TestDecompressResponseBody_DecodesZstd(t *testing.T) {
+	t.Parallel()
+	payload := []byte(`{"model":"test-stream"}`)
+	enc, err := zstd.NewWriter(nil)
+	require.NoError(t, err)
+	compressed := enc.EncodeAll(payload, nil)
+	require.NoError(t, enc.Close())
+
+	resp := &http.Response{
+		Header: make(http.Header),
+		Body:   io.NopCloser(bytes.NewReader(compressed)),
+	}
+	resp.Header.Set("Content-Encoding", "zstd")
+
+	decompressResponseBody(resp)
+
+	require.Empty(t, resp.Header.Get("Content-Encoding"))
+
+	got, err := io.ReadAll(resp.Body)
+	require.NoError(t, err)
+	require.Equal(t, payload, got)
+	require.NoError(t, resp.Body.Close())
 }
 
 // TestHTTPUpstreamSuite 运行测试套件


### PR DESCRIPTION
## Summary

`httpUpstream.Do` decompresses upstream bodies when Go does not decode them automatically. The handler omitted **zstd**, which Caddy may return (`encode zstd gzip`) when the gateway forwards browser `Accept-Encoding` to relay hops (prod → Edge). Compressed bytes plus a leaked/stale encoding chain led to **`ZstdDecompressionError`** on client `fetch()` for `/v1/messages`.

## Changes

- Add **zstd** handling in `decompressResponseBody` (same compressor family as request-body decoding elsewhere).
- Unit test **`TestDecompressResponseBody_DecodesZstd`**.

## Risk

Low: narrow change to upstream response handling; failure mode matches gzip (on decode error leave body/header unchanged).

## Validation

- `bash ./scripts/preflight.sh`
- `go test -tags=unit -count=1 ./internal/repository -run TestDecompressResponseBody_DecodesZstd`

Web impact: none

Made with [Cursor](https://cursor.com)