### PR TITLE
ci(upstream-merge): preflight parity gates on PR shape workflow

### DIFF
--- a/.cursor/skills/tokenkey-upstream-merge/SKILL.md
+++ b/.cursor/skills/tokenkey-upstream-merge/SKILL.md
@@ -104,7 +104,7 @@ PR 前必须完成：
 - `pnpm --dir frontend lint:check && pnpm --dir frontend typecheck`（如 frontend 触达）。
 - `pnpm --dir frontend run build`（如 frontend dist 或 embedded web 触达）。
 - `python3 scripts/export_agent_contract.py --check`（如 agent contract 相关触达）。
-- `./scripts/preflight.sh`（覆盖所有 sub2api sentinel 检查；`upstream-merge-pr-shape.yml` CI 独立跑其中 newapi、engine-facade、frontend-tk 三组）。
+- `./scripts/preflight.sh`（覆盖所有 sub2api sentinel 检查；`upstream-merge-pr-shape.yml` 对 merge/upstream-* PR 在 CI 中复跑与 preflight **对齐**的门禁，含 newapi、brand、frontend-tk、gateway-tk、redaction、trajectory、terminal、engine、QA 数据集、**pricing-availability** 与 **sentinel 注册表更新门闸（覆写防护）**；完整清单见该 workflow 文件头注释。）
 
 不得跳过 hook 或用 `--no-verify`。
 

--- a/.github/workflows/upstream-merge-pr-shape.yml
+++ b/.github/workflows/upstream-merge-pr-shape.yml
@@ -1,7 +1,7 @@
 name: Upstream Merge PR Shape
 
 # Mechanical enforcement of CLAUDE.md §5.y for any PR whose head branch
-# matches `merge/upstream-*`. Validates ten things:
+# matches `merge/upstream-*`. Validates twelve things:
 #
 #   1. The PR contains at least one merge commit whose second parent is
 #      reachable from upstream/main. This is what `git merge --no-ff
@@ -50,6 +50,12 @@ name: Upstream Merge PR Shape
 #  10. The exported QA evidence dataset contract stays aligned: the standalone
 #      validator plus its focused regression tests must keep H1/H2/H3/D1 and
 #      structural acceptance gates executable after the merge.
+#  11. The pricing-availability tap contract stays intact: TK call sites registered
+#      in `scripts/pricing-availability-sentinels.json` must survive the merge so
+#      passive availability does not silently go dark (preflight parity).
+#  12. The sentinel-registry update gate stays satisfied on the PR diff: changing
+#      sentinel-covered hotspots without updating the paired `scripts/*-sentinels.json`
+#      fails (mechanical 「覆写防护」vs human review memory — preflight parity).
 #
 # A green check here is a hard prerequisite for merging. Branch protection
 # on `main` should require this workflow status for `merge/upstream-*` PRs.
@@ -74,8 +80,10 @@ jobs:
           ref: ${{ github.event.pull_request.head.sha }}
           submodules: recursive
 
-      # Check 10 runs `go test` in backend/; `backend/go.mod` replaces new-api with
-      # ../../new-api — same sibling checkout as CI `test` / `preflight` jobs.
+      # Checks 4–9 and 11 run Python sentinel scripts; check 10 runs `go test`
+      # in backend/; check 12 runs the registry update gate on the PR merge
+      # range. `backend/go.mod` replaces new-api with ../../new-api — same
+      # sibling checkout as CI `test` / `preflight` jobs.
       - uses: ./.github/actions/cache-and-checkout-new-api
 
       - name: Set up Go
@@ -342,7 +350,37 @@ jobs:
           # longer mechanically enforced.
           (cd backend && go test -tags=unit ./internal/observability/qa -run 'TestUS077_QAEvidenceDatasetCheck_' -count=1)
 
+      - name: Check 11 — pricing-availability sentinels still intact after merge
+        run: |
+          # Preflight parity: scripts/pricing-availability-sentinels.json. Without these
+          # literal tap hooks, merges can compile cleanly while availability ingestion stops.
+          if [ ! -f ./scripts/check-pricing-availability-sentinels.py ]; then
+            echo "::error::scripts/check-pricing-availability-sentinels.py missing."
+            exit 1
+          fi
+          if ! python3 ./scripts/check-pricing-availability-sentinels.py; then
+            echo "::error::Upstream merge regressed at least one pricing-availability sentinel."
+            echo "::error::Restore the tap / RecordOutcome literals in this merge PR; do NOT delete sentinel entries."
+            exit 1
+          fi
+
+      - name: Check 12 — sentinel registry update gate (PR diff ↔ registries coupled)
+        run: |
+          # Preflight parity: scripts/check-sentinel-registry-update-gate.py — forces any
+          # change to sentinel-covered or hotspot-listed sources to accompany a registry edit.
+          if [ ! -f ./scripts/check-sentinel-registry-update-gate.py ]; then
+            echo "::error::scripts/check-sentinel-registry-update-gate.py missing."
+            exit 1
+          fi
+          BASE_SHA='${{ github.event.pull_request.base.sha }}'
+          HEAD_SHA='${{ github.event.pull_request.head.sha }}'
+          if ! python3 ./scripts/check-sentinel-registry-update-gate.py --base "$BASE_SHA" --head "$HEAD_SHA"; then
+            echo "::error::Sentinel registry update gate failed."
+            echo "::error::Changing load-bearing hotspots requires updating scripts/*-sentinels.json in the same PR."
+            exit 1
+          fi
+
       - name: Summary
         run: |
-          echo "All ten §5.y / §5.x checks passed for merge/upstream-* PR."
+          echo "All twelve §5.y / §5.x checks passed for merge/upstream-* PR."
           echo "Reviewer reminder: pick GitHub 'Create a merge commit' (not Squash)."


### PR DESCRIPTION
## Summary

`scripts/preflight.sh` already runs **pricing-availability** sentinels and **`check-sentinel-registry-update-gate.py`** (覆写防护: hotspot changes must update `scripts/*-sentinels.json`). The dedicated `merge/upstream-*` workflow did not re-run those checks, so a merge PR could theoretically pass `upstream-merge-pr-shape.yml` while violating the same rules preflight enforces locally after merge.

This PR adds **Check 11** and **Check 12** to `.github/workflows/upstream-merge-pr-shape.yml` and updates the upstream-merge skill text to describe preflight parity.

## Risk

Low. Only affects CI for branches named `merge/upstream-*`. Check 12 uses explicit `base.sha` / `head.sha` from the PR payload (same merge range as the PR).

## Validation

- `bash ./scripts/preflight.sh`

Web impact: none

Made with [Cursor](https://cursor.com)