### PR TITLE
docs(ops): rewrite cc-uk1-oauth handbook (APIKey mode) + audit code-agent brief

### DIFF
--- a/docs/ops/cc-uk1-oauth-edge-uk1-config-2026-05-12.md
+++ b/docs/ops/cc-uk1-oauth-edge-uk1-config-2026-05-12.md
@@ -1,77 +1,62 @@
-# cc-uk1-oauth / edge-uk1 推荐配置与注意事项
+# TokenKey 运营手册：prod cc-uk1-oauth → edge-uk1 配置
 
-> 查询日期：2026-05-12
+> 适用：在 prod admin UI 上配置 `cc-uk1-oauth` 分组、对接 edge-uk1 节点。
 >
-> 范围：prod (`api.tokenkey.dev`) `cc-uk1-oauth` 分组及其下挂账号、edge-uk1 (`api-uk1.tokenkey.dev`) 分组与节点配置
->
-> 前置：本文档假定读者已读过同期的链路审计报告 → [`cc-uk1-oauth-edge-uk1-sticky-audit-2026-05-12.md`](./cc-uk1-oauth-edge-uk1-sticky-audit-2026-05-12.md)
->
-> 适用代码版本：base commit `4be7dd9c` + PR #190（sticky TTL 一致性 + Vertex 多跳 sticky 修复）
+> 想了解链路代码细节 → 见 [`cc-uk1-oauth-edge-uk1-sticky-audit-2026-05-12.md`](./cc-uk1-oauth-edge-uk1-sticky-audit-2026-05-12.md)。
 
-## 1. prod `cc-uk1-oauth` 分组
+## 这条链路是什么
 
-| 字段 | 推荐值 | 理由 |
-|---|---|---|
-| `platform` | `anthropic` | 走 Anthropic 单平台调度池 |
-| `sticky_routing_mode` | `auto`（默认） | gateway 自动派生+注入 sticky key |
-| `claude_code_only` | `true`，配 `fallback_group_id_on_invalid_request` 兜底 | 这条链路是给 Claude Code CLI 服务的 |
-| `model_routing_enabled` | `false` | 关掉 routing 即可避开 [审计文档 §4 A](./cc-uk1-oauth-edge-uk1-sticky-audit-2026-05-12.md#4-已识别的错误隐患按严重度) 的 latent bug，全走 Layer 1.5 路径；PR #190 已修复 A，但保持关闭仍是最稳路径 |
-| `require_oauth_only` | `true` | 阻止把 APIKey 账号混入 OAuth 池 |
-| `rpm_limit` | 实测峰值 × 0.8 | 给 Anthropic 上游 429 留余量 |
+```
+claude code CLI
+   ↓
+prod (api.tokenkey.dev) · 命中 cc-uk1-oauth 分组
+   ↓
+edge-uk1 (api-uk1.tokenkey.dev) · 命中真 Anthropic OAuth 账号
+   ↓
+api.anthropic.com
+```
 
-## 2. prod cc-uk1-oauth 下挂的账号（即指向 edge-uk1 的 upstream 账号）
+关键：**prod 这一跳是「TokenKey 网关转发到另一个 TokenKey 网关」**，不是直接对接 Anthropic。所以 prod 上挂的账号必须按下面的"API Key 模式"配。
 
-| 字段 | 推荐值 | 理由 |
-|---|---|---|
-| `Type` | 与 token 形态匹配，**二选一并锁定** | edge 的 `api_key_auth.go` 同时接受 `Authorization: Bearer` 与 `x-api-key`；推荐用 `apikey` + edge 的 `tk_xxx`，避免与真 Anthropic OAuth 语义混淆 |
-| `custom_base_url_enabled` | `true`（OAuth 类型时） | 触发 `buildUpstreamRequest` 的 custom_base_url 分支 |
-| `custom_base_url` / `base_url` | `https://api-uk1.tokenkey.dev` | **必须** 在 prod 的 `security.url_allowlist.upstream_hosts`（若开启）内，见 §6 |
-| `session_id_masking_enabled` | **`false`** | 见 §5 的多跳 masking 约束（**这是最容易踩的坑**） |
-| `enable_fingerprint`（`gateway.fingerprint_unification`） | prod 全局可关 | 真伪装在 edge → Anthropic 做，prod → edge 已经在私网链路 |
-| `Concurrency` | 1～4，跟 edge 这一跳能消化的 QPS 匹配 |  |
-| `Priority` | 多账号时同优先级 + LRU 自动均衡 | 默认即可 |
+## ① prod 上的 cc-uk1-oauth 分组
 
-## 3. edge-uk1 分组与账号
+admin UI → 分组 → 编辑 `cc-uk1-oauth`：
 
-| 项 | 推荐值 | 理由 |
-|---|---|---|
-| edge 上的分组 | `platform=anthropic`，`sticky_routing_mode=auto`，`require_oauth_only=true`，`model_routing_enabled=false` | 与 prod 对称 |
-| edge 账号（`cc-en-ld-ec2-16-1-a` 等） | `Type=oauth`（真 Anthropic OAuth），`session_id_masking_enabled=true`，`enable_fingerprint=true` | masking 留在这一跳，见 §5 |
-| `security.url_allowlist.enabled` | `true`，`upstream_hosts=["api.anthropic.com"]` | edge 只允许出站到 Anthropic |
-| Caddy `MAIN_GATEWAY_ALLOWED_CIDR` | 严格写 prod EIP（当前 `34.194.234.88/32`） | 阻断公网直访 `/v1/*` |
-| Redis 持久化 | `appendonly yes`、`appendfsync everysec`（已是） | sticky 表丢了重新绑、不致命 |
-| `gateway.metadata_passthrough` | `false`（默认） | 让 edge 在最后一跳把 metadata.user_id 改写成 Anthropic 期望的指纹形态 |
+| 字段 | 值 |
+|---|---|
+| Platform | `anthropic` |
+| Sticky Routing Mode | `auto`（默认） |
+| Claude Code Only | ✅ 勾上 |
+| Fallback Group On Invalid Request | 指向一个兜底分组 |
+| Model Routing Enabled | ❌ 不勾 |
+| Require OAuth Only | ❌ **不勾** |
+| RPM Limit | 上游能扛的峰值 × 0.8 |
 
-## 4. sticky TTL 注意事项
+⚠️ **Require OAuth Only 要关闭**。下面要挂的账号是 API Key 类型，开启它会把账号从调度池里踢出去。
 
-- 当前 anthropic 路径的 sticky TTL 硬编码 `stickySessionTTL = time.Hour`（`backend/internal/service/gateway_service.go:47`）。
-- PR #190 之后，**5 处 sticky-hit 路径** 都会在命中时刷新 TTL，所以「不停拿同 session 持续请求」的场景不会过期。
-- 但「请求间隔 > 1h」时仍会过期；如果你常见单 session 跨 1h 完全空闲再回头，需要把这个常量调大、或抽成配置项（不在本次范围）。
-- `gateway.openai_ws.sticky_session_ttl_seconds`（默认 3600）只影响 OpenAI-compat 池，**不影响 anthropic OAuth 路径**。
+## ② prod 上指向 edge-uk1 的账号
 
-## 5. ⚠️ 核心注意事项：多跳路径上的 `session_id_masking_enabled`
+新增账号 → 选择 **"Anthropic Claude Console - API Key"** 模式：
 
-**规则：开 masking 的只能是「最后一跳到真 Anthropic」的账号；中间任何一跳（prod → edge）开 masking 都会破坏下游 sticky。**
+| 字段 | 值 |
+|---|---|
+| 账号类型 | **Anthropic Claude Console - API Key** |
+| Base URL | `https://api-uk1.tokenkey.dev` |
+| API Key | 在 edge-uk1 admin UI 上签发的 `tk_xxx` |
+| Concurrency | 1～4（跟 edge 能消化的 QPS 匹配） |
+| Priority | 多账号建议同优先级，让 LRU 自然均衡 |
 
-原理：
+⚠️ **不要用 "Anthropic OAuth + Custom Base URL" 模式**。两种模式都能跑通，但 API Key 模式：
 
-- `RewriteUserIDWithMasking`（`backend/internal/service/identity_service.go:269`）在该账号开 masking 时，每 15 min 轮换一次假 session_id。
-- prod 上的账号如果开 masking → prod 出站给 edge 的 body 里 `metadata.user_id.session_id` 每 15 min 变一次。
-- edge 的 sessionHash 派生 priority 1 是 `metadata.user_id.session_id`，跟着每 15 min 变 → edge 的 sticky 绑定每 15 min 失效一次 → upstream prompt cache 击穿。
+- 客户端 header 直接透传，sticky 命中率更高
+- 不会做 `metadata.user_id` 改写、不会触发 15 min 会话伪装
+- 转发更短更快
 
-正确分工：
+⚠️ 如果账号字段里有 **Session ID Masking**，**不要勾**——API Key 模式下不生效，但勾上等于给未来误改回 OAuth 模式埋雷。
 
-| 跳 | `session_id_masking_enabled` | 目的 |
-|---|---|---|
-| client → prod | 不适用（client 自己出 session_id） | — |
-| prod → edge-uk1 | **`false`** | 让 edge 看到的 session_id 稳定，edge 的 sticky 才能跨多次请求复用同一 OAuth 账号 |
-| edge-uk1 → api.anthropic.com | **`true`** | 防止 Anthropic 根据稳定 session_id 关联多账号活动 |
+## ③ prod 服务器配置
 
-排查思路：如果 edge 上看到「同一 client session 在 15 min 边界后切到了不同账号」，第一件事就是检查 prod 的 `cc-uk1-oauth` 账号是不是误开了 masking。
-
-## 6. ⚠️ prod 出站 URL 白名单核对
-
-如果 prod 的 `backend/config.yaml`（或 SSM 注入的 config）启用了 URL 白名单：
+prod 的 `config.yaml`（或 SSM 注入的 config）：
 
 ```yaml
 security:
@@ -82,38 +67,43 @@ security:
       - api-uk1.tokenkey.dev    # ← 必须有
 ```
 
-**漏掉 `api-uk1.tokenkey.dev` 时的症状**：`buildUpstreamRequest` 内部的 `validateUpstreamBaseURL`（`gateway_service.go:9419` 一带）直接返回错误，所有 cc-uk1-oauth 的请求 502。
+漏掉 `api-uk1.tokenkey.dev` 的症状：**cc-uk1-oauth 所有请求 502**。
 
-排查命令（在 prod EC2 上）：
+## ④ edge-uk1 上的真 Anthropic OAuth 账号
 
-```bash
-# 查 SSM 注入的 config（如果用 SSM 参数）
-aws ssm get-parameter --name /tokenkey/prod/config.yaml --with-decryption \
-  --query 'Parameter.Value' --output text | yq '.security.url_allowlist'
+edge 上挂的账号（如 `cc-en-ld-ec2-16-1-a`）是真要把流量送到 Anthropic 的，规则跟 prod 相反：
 
-# 或直接看容器内
-docker exec tokenkey cat /app/config.yaml | yq '.security.url_allowlist'
-```
+| 字段 | 值 |
+|---|---|
+| 账号类型 | **Anthropic OAuth**（真 OAuth，不是 API Key） |
+| Session ID Masking | ✅ 勾上 |
+| Fingerprint | ✅ 勾上 |
 
-`security.url_allowlist.enabled=false` 时该校验不生效（不推荐生产环境关掉，但作为快速排查手段可以临时关）。
+edge 上的分组配置对称：`platform=anthropic`、`sticky_routing_mode=auto`、`claude_code_only=true`、`model_routing_enabled=false`。
 
-## 7. 配置完成后的验证步骤
+## ⑤ 验证
 
-按 [审计文档 §6](./cc-uk1-oauth-edge-uk1-sticky-audit-2026-05-12.md#6-链路-invariant-验证运维用) 跑一次真实 claude code CLI 请求，确认四条 invariant 全过：
+用一台装了 claude code CLI 的机器，配置 base URL 指向 `https://api.tokenkey.dev` + 你的 `tk_xxx` key，跑一个简单对话：
 
-1. prod ops `sticky.hash_source.source` = `metadata_user_id`
-2. edge ops `sticky.hash_source.source` = `metadata_user_id`
-3. prod ↔ edge 端的 `request_id`/`client_request_id` 能在 `ops_system_logs` 串联
-4. prod 出站 `X-Claude-Code-Session-Id` 与 edge 入站同名 header 一致
+1. 返回 200，输出正常 ✅
+2. prod admin UI 的"调度详情"里能看到流量打到你配置的 cc-uk1-oauth 账号 ✅
+3. edge-uk1 admin UI 上能看到对应账号有调度记录 ✅
+4. 连续跑几条同一对话 → prod 和 edge 两侧**都**应该一直命中同一账号（sticky 生效）✅
 
-任何一条失败：
+第 4 条不成立 → 检查 [§常见坑](#常见坑) 第 2 行。
 
-- 1 / 2 不是 `metadata_user_id` → 检查客户端是否带了 `metadata.user_id`、prod 是否误清掉了 body 中该字段
-- 3 拉不到 → 检查 8396d36b 后 ops 日志接入是否生效（`gh workflow run prod-ops.yml` 是否正常）
-- 4 不一致 → 回到 §5 masking 排查；或检查 [审计文档 §4 D](./cc-uk1-oauth-edge-uk1-sticky-audit-2026-05-12.md#4-已识别的错误隐患按严重度)（RewriteUserID 改写带来的预期差）
+## 常见坑
 
-## 8. 不在本文档范围
+| 现象 | 一般原因 |
+|---|---|
+| cc-uk1-oauth 全部 502 | prod `url_allowlist.upstream_hosts` 漏了 `api-uk1.tokenkey.dev` |
+| 同一对话 edge 端被频繁切换账号 | prod 账号被切回 OAuth 模式 + 勾了 Session ID Masking |
+| 客户端 401/403 | prod 账号填的 API Key 跟 edge 上签发的 `tk_xxx` 对不上，或 edge 上的 key 被删/禁用 |
+| 单对话空闲 > 1 小时后切到新账号 | sticky TTL 默认 1 小时，中间没请求就会过期；**持续在聊不会过期** |
+| edge 看到的客户端 IP 全是 prod 的 EIP | 设计如此（edge Caddy 用 prod 远端 IP 改写 XFF），不影响调度 |
 
-- 链路结构与代码层面的 sticky preservation 机制 → 审计文档
-- new-api / OpenAI-compat 池的配置 → 见 `docs/approved/sticky-routing.md`
-- 跨区域多 edge（us1 / sg1 / fra1）配置 → 这些 edge 当前 `deployable=false`，未来开通时再扩展本文档
+## 不在本手册范围
+
+- 代码层调用链 / 函数 / sentinel 细节 → [审计文档](./cc-uk1-oauth-edge-uk1-sticky-audit-2026-05-12.md)
+- new-api / OpenAI / Gemini 等其他平台的分组配置
+- edge-us1 / sg1 / fra1（当前未部署）

--- a/docs/ops/cc-uk1-oauth-edge-uk1-sticky-audit-2026-05-12.md
+++ b/docs/ops/cc-uk1-oauth-edge-uk1-sticky-audit-2026-05-12.md
@@ -1,116 +1,85 @@
-# claude code CLI → prod cc-uk1-oauth → edge-uk1 sticky 链路审计
+# Sticky audit: claude code CLI → prod cc-uk1-oauth → edge-uk1
 
-> 查询日期：2026-05-12
+> 用途：让后续 code agent 在改 sticky / 多跳路由 / outbound builder 相关代码前，快速掌握这条链路的现状、关键代码点、已知约束与雷区。
 >
-> 范围：prod (`api.tokenkey.dev`) 上的 `cc-uk1-oauth` 分组，以及 edge-uk1 (`api-uk1.tokenkey.dev`) 的代码路径
+> 基线：base commit `4be7dd9c` + PR #190。
 >
-> 触发：排查 claude code CLI 经 prod cc-uk1-oauth 转发到 edge-uk1 账号 `cc-en-ld-ec2-16-1-a` 的 session sticky 现状与隐患
->
-> 同期：base commit `4be7dd9c`；关键依赖 `42f79b3f`（Preserve edge sticky session identity）、`8396d36b`（sticky source observability）
->
-> 配套文档：账号 / 分组 / 部署侧的推荐配置和注意事项见 [`cc-uk1-oauth-edge-uk1-config-2026-05-12.md`](./cc-uk1-oauth-edge-uk1-config-2026-05-12.md)
+> 运营手册（admin UI / 字段配置）：[`cc-uk1-oauth-edge-uk1-config-2026-05-12.md`](./cc-uk1-oauth-edge-uk1-config-2026-05-12.md)
 
-## 1. 调用链结构
+## 1. 链路
 
 ```
-claude code CLI
-   │  UA: claude-cli/x.y.z
-   │  Hdr: X-Claude-Code-Session-Id: <client-session>
-   │  Body.metadata.user_id: user_<uid>_account__session_<client-session>
-   ▼
-prod  api.tokenkey.dev (CloudFront-less, Caddy → tokenkey:8080)
-   │  分组 cc-uk1-oauth · platform=anthropic
-   │  GenerateSessionHash(parsed) → priority 1 = inner session_id
-   │  GatewayService.SelectAccountWithLoadAwareness → Anthropic OAuth account
-   │  account.custom_base_url = https://api-uk1.tokenkey.dev
-   │  buildUpstreamRequest →
-   │     - OAuth mimic（非 claude-cli UA）：丢客户端 header，但 tkEnsureClaudeCodeSessionHeader
-   │       从 body.metadata.user_id 重新塞 X-Claude-Code-Session-Id
-   │     - 真 claude-cli UA：白名单透传 X-Claude-Code-Session-Id
-   │     - RewriteUserID（enableMPT=false）将 metadata.user_id.session 改写为
-   │       hash(prod_account_id::原session)
-   │  Redis 本机 key: sticky_session:{prod_group_id}:{sessionHash}
-   ▼
-edge-uk1  api-uk1.tokenkey.dev (Caddy 仅放行 prod EIP，转 tokenkey:8080)
-   │  本机分组（platform=anthropic）
-   │  GenerateSessionHash → priority 1 = 改写后的 session_id
-   │  GatewayService.SelectAccountWithLoadAwareness → edge OAuth account
-   │     例如 cc-en-ld-ec2-16-1-a
-   │  buildUpstreamRequest → 真 Claude API
-   │  Redis 本机 key: sticky_session:{edge_group_id}:{sessionHash}
-   ▼
-api.anthropic.com
+claude code CLI ─→ prod (api.tokenkey.dev)
+                     │  cc-uk1-oauth · platform=anthropic
+                     │  prod 账号 = APIKey + base_url=https://api-uk1.tokenkey.dev + tk_xxx
+                     │  buildUpstreamRequest line 6027-6035 APIKey 分支
+                     │  → x-api-key: edge_tk_xxx
+                     │  → body 原样转发，header 白名单透传
+                     ▼
+                 edge-uk1 (api-uk1.tokenkey.dev)
+                     │  Caddyfile.edge 仅放行 prod EIP
+                     │  edge 账号 = 真 Anthropic OAuth（cc-en-ld-ec2-16-1-a 等）
+                     │  buildUpstreamRequest line 6093+ OAuth 分支
+                     │  → mimicry / fingerprint / RewriteUserID / masking
+                     ▼
+                 api.anthropic.com
 ```
 
-两点结构要点：
+两端各自的本机 Redis 维护独立 sticky 表 `sticky_session:{groupID}:{sessionHash}`；用 body 中 `metadata.user_id.session_id` 在两跳间对齐。
 
-- **两端各持本机 Redis**（`deploy/aws/stage0/docker-compose.yml`），sticky 表不互通。靠 `metadata.user_id.session_id` 在 body 内的稳定值在两跳间“对齐”到同一逻辑 session。
-- **prod → edge 是私网信任链**：`Caddyfile.edge` 的 `@allowed_relay` 用 `remote_ip ${MAIN_GATEWAY_ALLOWED_CIDR}` 锁死 prod EIP；公网直访 `/v1/*` 一律 403。
+## 2. 关键代码点
 
-## 2. sessionHash 派生优先级（两端同代码）
+| 主题 | 文件:行 / 符号 |
+|---|---|
+| sessionHash 派生（priority 1 = metadata.user_id 内 session_id） | `backend/internal/service/gateway_service.go:660 GenerateSessionHash` |
+| sticky 派生顺序枚举 | `backend/internal/service/sticky_session_injector.go StickyKeyFromClientHeaders` + `StickyKeySource*` |
+| 多跳 sticky preservation | `gateway_service_tk_sticky.go tkEnsureClaudeCodeSessionHeader`，4 个出站 callsite：5333 / 6193 / 6264 / 9392 |
+| 出站 builder 分流 | `gateway_service.go:4462 shouldMimicClaudeCode := account.IsOAuth() && !isClaudeCode`；`6033 buildUpstreamRequest` |
+| OAuth 专用步骤 | `gateway_service.go:6072 if account.IsOAuth() && s.identityService != nil` → fingerprint / RewriteUserID / masking / CCH |
+| masking 实现 | `backend/internal/service/identity_service.go:269 RewriteUserIDWithMasking` |
+| sticky-hit TTL 刷新（PR #190 之后） | `gateway_service.go RefreshSessionTTL` 6 callsite：1711 / 1910 / 3074 / 3192 / 3337 / 3457 |
+| 出口 sentinel 注册 | `scripts/gateway-tk-sentinels.json`（保护 tkEnsure 4 callsite 字符串） |
+| edge Caddy 放行规则 | `deploy/aws/stage0/Caddyfile.edge @allowed_relay remote_ip ${MAIN_GATEWAY_ALLOWED_CIDR}` |
+| 部署拓扑 | `deploy/aws/stage0/edge-targets.json` |
 
-`backend/internal/service/gateway_service.go:660 GenerateSessionHash`：
+## 3. 配置面硬约束
 
-| 优先级 | 来源 | 输出 |
-|---|---|---|
-| 1 | `parsed.MetadataUserID` 解析出 inner `session_id` | 原值，不哈希 |
-| 2 | `parsed.ExplicitStickyKey`（`X-Claude-Code-Session-Id` / `X-Session-Id` 等） | xxhash 16hex |
-| 3 | `parsed.PromptCacheKey` | xxhash 16hex |
-| 4 | cacheable_content（Anthropic ephemeral 块） | xxhash 16hex |
-| 5 | `ClientIP + UA + APIKeyID + system + 全部消息` | xxhash 16hex |
+| 约束 | 失败症状 |
+|---|---|
+| prod cc-uk1-oauth 账号 type = APIKey | OAuth + custom_base_url 模式会进入 OAuth 专用步骤（mimicry / RewriteUserID / masking），行为差异显著（见 §4 C/D） |
+| prod `security.url_allowlist.upstream_hosts` 含 `api-uk1.tokenkey.dev` | `validateUpstreamBaseURL`（`gateway_service.go:9419` 一带）拒绝 → 502 |
+| 分组 `sticky_routing_mode = auto` | `off` 关沉 sticky；`passthrough` 不派生 |
+| 分组 `model_routing_enabled = false` | 开启会走 routing+sticky 路径——PR #190 已修但代码更复杂 |
+| edge 账号 type = 真 Anthropic OAuth | edge 是最后一跳，需要 mimicry+fingerprint+masking |
 
-只要 `metadata.user_id` 不被中途清掉，两端的 sessionHash 都来自 priority 1。
+## 4. 已知隐患清单
 
-`StickyKeyFromClientHeaders` 的 header walk 顺序：`session_id` → `conversation_id` → `X-Claude-Code-Session-Id` → `X-Session-Id`。
+| ID | 状态 | 描述 | 触发条件 |
+|---|---|---|---|
+| A | ✅ PR #190 修复 | sticky-hit TTL 不刷新（routing 路径 + 2 个 legacy path） | 任何 sticky hit return |
+| B | ✅ PR #190 修复 | Vertex 出口漏 `tkEnsureClaudeCodeSessionHeader` | `account.Type=ServiceAccount` |
+| C | ⚠️ 配置约束 | OAuth 路径上 masking 每 15min 轮换 session_id，击穿 edge sticky | prod 账号 type=OAuth + masking=true |
+| D | 📘 设计行为 | OAuth 路径 `RewriteUserID` 让两端 sessionHash 不同 | prod 账号 type=OAuth + custom_base_url |
+| E | 📘 已知非阻塞 | edge Caddy XFF 覆盖，看不到真实客户端 IP | 永久（设计如此） |
+| F | ⚠️ 配置核对 | `url_allowlist` 漏 edge 域名 → 502 | `enabled=true` 且 hosts 缺漏 |
 
-## 3. 多跳 sticky 保护点（commit 42f79b3f 之后）
+## 5. 改代码时的常见雷区
 
-`backend/internal/service/gateway_service_tk_sticky.go`：`tkEnsureClaudeCodeSessionHeader` 在四个出站构造函数被调用（含本 PR #190 新增的 Vertex 一处）：
+- **改 sticky 派生顺序** — 动 `GenerateSessionHash` 的优先级会同时影响 prod 和 edge 两侧，验证要两端都看；改完同步检查 `StickyKeyFromClientHeaders` 的 header walk 顺序是否一致。
+- **新增 `buildUpstreamRequest*` 变种** — 必须调 `tkEnsureClaudeCodeSessionHeader`，并在 `scripts/gateway-tk-sentinels.json` 加 sentinel，否则下次 upstream merge 会静默删掉。
+- **改 TTL refresh 逻辑** — 6 个 callsite 都得动，不要只动一个；现有模式是「sticky hit return 之前刷」。
+- **碰 RewriteUserID / masking / fingerprint** — 这些只在 OAuth 路径生效（`if account.IsOAuth()`）；APIKey 账号根本不进，改的时候要确认你在动哪条路径。
+- **加新的 sticky 派生源**（比如自定义 header）— 同时改 `StickyKeyFromClientHeaders` 顺序和 `GenerateSessionHash` 顺序，并在 sentinel 注册。
+- **改 `validateUpstreamBaseURL` 行为** — 注意 prod→edge 这条链路依赖 `security.url_allowlist.upstream_hosts` 通过校验，不要让默认值变严。
 
-| Callsite | 函数 | 用途 |
-|---|---|---|
-| `gateway_service.go:5333` | `buildUpstreamRequestAnthropicAPIKeyPassthrough` | Anthropic API Key 透传 |
-| `gateway_service.go:6193` | `buildUpstreamRequest`（OAuth + APIKey 直转） | 主路径，cc-uk1-oauth 命中这里 |
-| `gateway_service.go:6264` | `buildUpstreamRequestAnthropicVertex` | Vertex Anthropic（PR #190 新增） |
-| `gateway_service.go:9392` | count_tokens 路径 | tokens 计费回退 |
+## 6. 调用链分支速查
 
-策略：先从出站 body 的 `metadata.user_id` 同步 `X-Claude-Code-Session-Id`；body 没有时回退 ingress `ParsedRequest` 快照（`ClaudeCodeParsedRequestGinKey` Gin context）。即使 OAuth mimic 路径丢掉了客户端原始 header，下一跳照样能从 body 中拿到稳定 session。
+`shouldMimicClaudeCode := account.IsOAuth() && !isClaudeCode`（line 4462）决定 prod 这一跳走哪条：
 
-## 4. 已识别的错误隐患（按严重度）
+| account.IsOAuth() | client UA | mimic | OAuth 专用步骤 | 客户端 header | metadata.user_id |
+|---|---|---|---|---|---|
+| false (APIKey) | any | false | 全部跳过 | 白名单全透传 | 原样转发 |
+| true | claude-cli | false | 部分跳过（fingerprint 跑、RewriteUserID/mimicry 跳） | 白名单全透传 | 改写（masking 时 15min 轮换） |
+| true | 非 claude-cli | true | 全跑 | mimic 时整组丢弃，tkEnsure 兜底 | 改写（masking 时 15min 轮换） |
 
-| ID | 隐患 | 文件 / 行 | 影响 cc-uk1-oauth？ | 状态 |
-|---|---|---|---|---|
-| **A** | `SelectAccountWithLoadAwareness` 在「有 model routing 配置」命中 sticky 时直接 return，未刷 TTL。无 routing 路径（line 1910）有刷。`selectAccountForModelWithPlatform`（3192）与 `selectAccountWithMixedScheduling`（3457）两条 legacy 路径同样不刷。1 h 后 sticky 静默过期、跨账号丢 prompt cache。 | `gateway_service.go:1711 / 3074 / 3192 / 3337 / 3457` | **不直接影响**（cc-uk1-oauth 默认无 routing） | ✅ PR #190 修复，5 处统一刷 TTL |
-| **B** | `buildUpstreamRequestAnthropicVertex` 漏接多跳 sticky preservation，没有调用 `tkEnsureClaudeCodeSessionHeader`。Vertex Anthropic 多跳时 `X-Claude-Code-Session-Id` 不传。 | `gateway_service.go:6264`（修复后） | 不影响（cc-uk1-oauth 不走 Vertex） | ✅ PR #190 修复，加 sentinel + 回归测试 |
-| **C** | `session_id_masking_enabled` 与多跳互动：prod 的 OAuth 账号若开 masking，则每 15 min 轮换“伪 session”，edge 看到的 sessionHash 也跟着换 → edge 这一跳 sticky 失效、prompt cache 击穿。 | 账号 `Extra.session_id_masking_enabled` | 取决于配置 | ⚠️ 配置约束，见 [config 文档](./cc-uk1-oauth-edge-uk1-config-2026-05-12.md) §5 |
-| **D** | `gateway.metadata_passthrough = false`（默认）：prod 会把 client 的 `metadata.user_id` 改写为 `hash(prod_account_id::原session)`。两端 sessionHash 不是同一个值（prod 用原值、edge 用改写值）。本身不是 bug，日志排查时要注意。 | `setting_service.go:1719` | 仅影响日志关联 | 📘 已知非阻塞 |
-| **E** | edge Caddy `header_up X-Forwarded-For {remote_host}`：edge 看到的 ClientIP 永远是 prod EIP。sticky 优先级 1 已绕过 XFF，因此对 sticky 本身无影响，但 ops 日志容易让人误判客户端。 | `deploy/aws/stage0/Caddyfile.edge:45` | 仅影响日志 | 📘 已知非阻塞 |
-| **F** | prod `security.url_allowlist.upstream_hosts` 若启用了，必须包含 `api-uk1.tokenkey.dev`，否则 `validateUpstreamBaseURL` 直接拒绝。 | prod `config.yaml` | 取决于配置 | ⚠️ 配置核对项，见 [config 文档](./cc-uk1-oauth-edge-uk1-config-2026-05-12.md) §6 |
-
-## 5. 配套代码修复（PR #190）
-
-- **A：sticky hit TTL 一致性** — `gateway_service.go` 5 处 sticky 命中 return 之前补 `RefreshSessionTTL`，全部对齐 line 1910 / 1701 已有模式。
-- **B：Vertex 多跳 sticky preservation** — `buildUpstreamRequestAnthropicVertex` (line 6264) 补一行 `tkEnsureClaudeCodeSessionHeader`；同步更新 `scripts/gateway-tk-sentinels.json` 防止 upstream merge 静默回退；加 `TestGatewayService_VertexAnthropicPreservesClaudeCodeSessionID` 回归测试。
-
-修复后 invariant：
-
-- 所有命中 sticky 的路径都会刷 TTL；
-- 所有 Anthropic 出站构造函数（含 Vertex）都会走多跳 sticky 透传。
-
-## 6. 链路 invariant 验证（运维用）
-
-跑一次真实 claude code CLI 请求后，验证：
-
-1. prod ops 日志：`sticky.hash_source` 的 `source` 字段应为 `metadata_user_id`。
-2. edge-uk1 ops 日志：同一 `request_id` 串联，`sticky.hash_source` 也应为 `metadata_user_id`。
-3. 用 `gh workflow run prod-ops.yml -f log_grep="<base64 of session_id>"` 在 prod 端 grep，对应 `client_request_id` 应能在 edge 端 ops_system_logs 里找到匹配项（8396d36b 之后已具备）。
-4. prod 出站请求的 `X-Claude-Code-Session-Id` 与 edge 入站的同名 header 值应一致（来源于 `metadata.user_id.session_id` 解析，跨 hop 稳定）。
-
-不满足任一条，回到 §4 排查对应 ID。
-
-## 7. 不在本文档范围
-
-- new-api 第五平台（`platform=newapi`）的 sticky：见 `docs/approved/sticky-routing.md` §3、`openai_sticky_compat.go`。
-- OpenAI / Codex / GLM 类 OpenAI-compat 池的 sticky：同上。
-- 跨区域多 edge 的 sticky 一致性：edge-us1 / sg1 / fra1 尚未部署（`deploy/aws/stage0/edge-targets.json` 中 `deployable=false`）。
-- 账号 / 分组 / Caddy / `url_allowlist` 等可配置面的推荐值：见 [config 文档](./cc-uk1-oauth-edge-uk1-config-2026-05-12.md)。
+cc-uk1-oauth 的推荐配置（APIKey + base_url）固定第一行。


### PR DESCRIPTION
## Background

PR #190 (squash-merged as ee68a715) carried the initial sticky audit doc + a split into audit/config files. But **three follow-up doc commits were pushed to the feature branch _after_ the squash** and so never reached main:

| 时间 | commit | 内容 |
|---|---|---|
| 16:32 | (squash merge of PR #190) | |
| 16:46 | df6775b1 | 把 prod 账号推荐改成 APIKey + base_url 模式 |
| 16:58 | 9f172a97 | 把 config 文档重写成运营合伙人手册 |
| 16:59 | 49f13359 | 把 audit 文档重写成 code-agent brief |

This PR consolidates those three commits into a single docs-only change.

## What changes

### `docs/ops/cc-uk1-oauth-edge-uk1-config-2026-05-12.md` → 运营合伙人手册

- 删掉 "Type 二选一并锁定" + custom_base_url 那段歧义建议。
- **推荐用 Anthropic Claude Console - API Key 模式** + `base_url=https://api-uk1.tokenkey.dev` + edge 的 \`tk_xxx\`。
- 代码事实：\`gateway_service.go:4462\` \`shouldMimicClaudeCode := account.IsOAuth() && !isClaudeCode\` —— APIKey 账号 \`IsOAuth()=false\` 永远跳过整条 OAuth 专用链（fingerprint / RewriteUserID / masking / mimicry / CCH 签名）。header 白名单全透传、body 原样转发，比 OAuth+custom_base_url 模式严格更稳。
- 风格改成 ①→⑤ 操作步骤 + admin UI 字段表 + 症状→原因排错表。
- 删掉代码路径引用、grep ops_system_logs 之类的开发命令。

### \`docs/ops/cc-uk1-oauth-edge-uk1-sticky-audit-2026-05-12.md\` → code-agent brief

- 改成给后续 code agent 用的紧凑上下文：链路 ASCII 图 + grep-friendly 关键代码点表(文件:行) + 配置硬约束表 + 已知隐患清单表 + 改代码雷区清单 + \`mimicClaudeCode/OAuth 步骤/header/metadata\` 的 truth table。
- 删掉长段原理说明、生产 invariant 验证步骤（那是运营/排查场景，不属于改代码场景）。

## Test plan

- [x] \`bash scripts/preflight.sh\` 全绿
- [x] 文档内部 link（运营手册 ↔ audit）双向 cross-link 验证
- [ ] reviewer 抽样确认运营手册可读性（合伙人受众）和 audit 文档对 code agent 友好性

## Risk

零代码改动；纯文档。Web impact: none。

🤖 Generated with [Claude Code](https://claude.com/claude-code)