### PR TITLE
fix deploy edge reset + dynamic rollout skill

### DIFF
--- a/.cursor/skills/tokenkey-stage0-edge-expansion/SKILL.md
+++ b/.cursor/skills/tokenkey-stage0-edge-expansion/SKILL.md
@@ -1,0 +1,320 @@
+---
+name: tokenkey-stage0-edge-expansion
+description: >-
+  End-to-end runbook for adding a new AWS Stage0 Edge gateway beyond existing
+  uk1/fra1: prepare metadata and IAM/OIDC scope, provision edge stack, set DNS,
+  run smoke/upgrade/rollback via deploy-edge-stage0.yml, and report structured
+  acceptance results with known failure patterns.
+---
+
+# TokenKey：新增任意 Edge 网关全流程（uk1/fra1 之外）
+
+适用于本仓库（TokenKey fork of sub2api）。目标是把一个新 edge（例如 us1/sg1 或未来任意 `<edge_id>`）从“计划中”推进到“可 provision + 可 smoke + 可回滚”。
+
+权威纪律以仓库根 `CLAUDE.md` 为准（ARM、多架构发布、release/deploy 顺序、禁止绕过 preflight）。
+
+## 调用参数
+
+```text
+/tokenkey-stage0-edge-expansion edge_id=<id> region=<aws-region> operation=<prepare|provision|smoke|upgrade|rollback|full> [tag=X.Y.Z] [previous_tag=X.Y.Z] [confirm_stack=tokenkey-edge-<id>-stage0]
+```
+
+| 参数 | 语义 |
+|---|---|
+| `edge_id` | 新 edge 标识，如 `us1`、`sg1`。 |
+| `region` | 目标 AWS 区域，如 `us-west-2`。 |
+| `operation=prepare` | 只做“接入准备与权限开通”（代码/配置/IAM），不部署实例。 |
+| `operation=provision` | 首次创建或更新 edge stack（`deploy-edge-stage0.yml operation=provision`）。 |
+| `operation=smoke` | 只做 smoke 验收（基础设施 + SSM self-smoke）。 |
+| `operation=upgrade` | 对已存在 edge 升级到指定 tag。 |
+| `operation=rollback` | 回滚到 `previous_tag`。 |
+| `operation=full` | 从 prepare 到 provision、DNS、smoke 的完整初始化闭环。 |
+| `tag` | `provision/upgrade/rollback` 必填（无 `v` 前缀）。 |
+| `confirm_stack` | 默认 `tokenkey-edge-<edge_id>-stage0`。 |
+
+默认行为：
+- 用户说“新增/初始化某 edge” → `operation=full`
+- 用户说“先打通权限/配置” → `operation=prepare`
+- 用户说“DNS 好了继续验收” → `operation=smoke`
+
+## 一次性跑完（原则）
+
+- 按顺序推进：`prepare` → `provision` → DNS → `smoke`。
+- `gh run watch` 必须 `--exit-status` 跟到终态，不中途截断。
+- 失败先定位根因再重跑，不做“盲目多次重试”。
+- 任何新增 edge 都必须复用现有共享 primitive（`deploy-edge-stage0.yml` + `scripts/stage0_*`），避免分叉语义。
+
+## 0) 前置检查
+
+1. 同步仓库：
+   ```bash
+   git fetch origin main --tags
+   git checkout main
+   git pull origin main --ff-only
+   ```
+2. 读取 edge 目标定义：`deploy/aws/stage0/edge-targets.json`
+3. 确认 `gh` 与 `aws` 可用，且有权限操作：
+   - GitHub environments/variables/secrets
+   - CloudFormation `tokenkey-cicd-oidc`
+   - IAM role `tokenkey-gha-us-east-1-error-clustering`
+
+## 1) Prepare：把新 edge 接入控制面
+
+### 1.1 更新 edge 目标注册（代码）
+
+编辑 `deploy/aws/stage0/edge-targets.json` 新增或更新 `<edge_id>`：
+- `deployable`（首次建议先 `false`，准备就绪再置 `true`）
+- `region`
+- `domain`（例如 `api-<edge_id>.tokenkey.dev`）
+- `stack`（`tokenkey-edge-<edge_id>-stage0`）
+- `ssm_prefix`（`/tokenkey/edge/<edge_id>`）
+
+### 1.2 更新 deploy-edge workflow 入口（代码）
+
+编辑 `.github/workflows/deploy-edge-stage0.yml`：
+1. `workflow_dispatch.inputs.edge_id.options` 加入新 `<edge_id>`。
+2. `Provision or update Edge stack` 步骤中的 `case "$EDGE_ID"` 新增映射：
+   - `CFN_ROLE_OUTPUT_KEY=Edge<PascalCaseEdgeId>CloudFormationExecutionRoleArn`
+
+### 1.3 更新 OIDC / IAM 模板（代码）
+
+编辑 `deploy/aws/cloudformation/cicd-oidc.yaml`：
+1. `AllowedSubjects` 默认列表加入：`repo:youxuanxue/sub2api:environment:edge-<edge_id>`。
+2. 新增参数：
+   - `<EdgeXRegion>`
+   - `<EdgeXTargetInstanceId>`（可空，首次可留空）
+3. 新增条件 `HasEdgeXInstance`。
+4. 在 `ClusteringRole` 的 `SsmSendCommandStage0` 策略新增该 edge 的 `ssm:SendCommand` 语句。
+5. 新增 CloudFormation execution role（命名遵循现有：`tokenkey-cfn-<region>-edge-<edge_id>-stage0`）。
+6. 新增输出：`Edge<PascalCaseEdgeId>CloudFormationExecutionRoleArn`。
+
+关键坑位（必须做对）：
+- edge 的 `AWS-RunShellScript` 文档 ARN 必须用该 edge 区域：
+  - `arn:aws:ssm:${EdgeXRegion}::document/AWS-RunShellScript`
+- 不能写成 `${AWS::Region}`（这会在 us-east-1 OIDC 栈场景导致跨区 `ssm:SendCommand` 被拒）。
+
+### 1.4 部署 OIDC 控制栈
+
+```bash
+aws cloudformation deploy \
+  --region us-east-1 \
+  --stack-name tokenkey-cicd-oidc \
+  --template-file deploy/aws/cloudformation/cicd-oidc.yaml \
+  --capabilities CAPABILITY_NAMED_IAM \
+  --parameter-overrides ...
+```
+
+说明：
+- 首次可把 `<EdgeXTargetInstanceId>` 置空（只先打通权限框架）。
+- edge 实例创建后再回填该参数并再次 deploy，启用精确 `ssm:SendCommand` 资源授权。
+
+### 1.5 GitHub Environment 准备
+
+新建环境：`edge-<edge_id>`，并配置变量（参考 `edge-uk1`/`edge-fra1`）：
+- `AWS_OIDC_ROLE_ARN`
+- `AWS_OIDC_STACK_NAME`
+- `EDGE_ACME_EMAIL`
+- `EDGE_MAIN_GATEWAY_ALLOWED_CIDR`
+- `EDGE_MAIN_GATEWAY_BASE_URL`
+- `EDGE_GHCR_PAT_SSM_NAME=/tokenkey/edge/<edge_id>/ghcr/pat`
+
+注意：`EDGE_GHCR_PAT_SSM_NAME` 必须是该 edge 自己路径，不可复用别的 edge 路径。
+
+### 1.6 区域 SSM 参数准备
+
+在目标 region 写入（至少）：
+- `/<project>/edge/<edge_id>/ghcr/pat`（SecureString）
+- 以及模板/脚本依赖的 stage0 参数（compose/caddy/template 等）
+
+## 2) Provision：首次初始化
+
+触发 workflow：
+
+```bash
+gh workflow run deploy-edge-stage0.yml \
+  -f edge_id=<edge_id> \
+  -f operation=provision \
+  -f tag=<X.Y.Z> \
+  -f confirm_stack=tokenkey-edge-<edge_id>-stage0
+```
+
+然后 watch：
+
+```bash
+gh run watch <run-id> --exit-status
+```
+
+失败优先检查：
+- OIDC assume role 是否允许 `environment:edge-<edge_id>`
+- `CFN_ROLE_OUTPUT_KEY` 映射是否缺失
+- `EDGE_GHCR_PAT_SSM_NAME` 是否存在于目标 region
+- cloud-init 是否执行完成（`/var/lib/cloud/instance/scripts/part-001`）
+
+## 3) 初始 admin 账密获取（首次初始化后立即执行）
+
+### 3.1 默认账号来源
+
+- 默认邮箱：`admin@<api-domain>`（若 CFN 未显式传 `AdminEmail`）。
+- `AUTO_SETUP` 首次创建 admin 时，若 `ADMIN_PASSWORD` 为空，会生成一次性随机密码并写入日志。
+
+### 3.2 线上日志获取（优先）
+
+```bash
+REGION=<edge-region>
+STACK=tokenkey-edge-<edge_id>-stage0
+INSTANCE_ID=$(aws cloudformation describe-stacks \
+  --region "$REGION" \
+  --stack-name "$STACK" \
+  --query 'Stacks[0].Outputs[?OutputKey==`InstanceId`].OutputValue' \
+  --output text)
+
+CMD_ID=$(aws ssm send-command \
+  --region "$REGION" \
+  --instance-ids "$INSTANCE_ID" \
+  --document-name AWS-RunShellScript \
+  --parameters 'commands=[
+    "set -euo pipefail",
+    "echo === ADMIN_EMAIL ===",
+    "sudo grep -n \"^ADMIN_EMAIL=\" /var/lib/tokenkey/.env || true",
+    "echo === DOCKER LOGS ===",
+    "sudo docker logs tokenkey 2>&1 | grep -nE \"Generated admin password|Admin user created|Auto setup\" || true",
+    "echo === JOURNAL ===",
+    "sudo journalctl -u tokenkey.service --no-pager | grep -nE \"Generated admin password|Admin user created|Auto setup\" || true",
+    "echo === BOOTSTRAP LOG ===",
+    "sudo grep -nE \"Generated admin password|Admin user created|Auto setup|ADMIN_EMAIL\" /var/log/tokenkey-edge-bootstrap.log || true"
+  ]' \
+  --query 'Command.CommandId' --output text)
+
+aws ssm get-command-invocation \
+  --region "$REGION" \
+  --command-id "$CMD_ID" \
+  --instance-id "$INSTANCE_ID" \
+  --query 'StandardOutputContent' --output text
+```
+
+### 3.3 若查不到初始密码（常见）
+
+直接重置：
+
+```bash
+bash scripts/reset-edge-admin-password.sh edge-<edge_id>
+```
+
+脚本会打印 `ADMIN_EMAIL` 与 `NEW_PASSWORD`。登录后立即改为长期密码。
+
+## 4) DNS
+
+从 stack 输出拿到公网 IP（或 EIP），配置：
+- `api-<edge_id>.tokenkey.dev` → 对应 A 记录
+
+DNS 生效后继续 smoke。
+
+## 5) Smoke 验收
+
+触发：
+
+```bash
+gh workflow run deploy-edge-stage0.yml \
+  -f edge_id=<edge_id> \
+  -f operation=smoke \
+  -f confirm_stack=tokenkey-edge-<edge_id>-stage0
+```
+
+验收标准：
+1. `GET https://api-<edge_id>.tokenkey.dev/health` 为 200。
+2. public runner `GET /v1/models` 为 403（allowlist 生效）。
+3. SSM self-smoke 成功（容器与本地 health 正常）。
+4. 若配置 `MAIN_GATEWAY_EDGE_SMOKE_API_KEY`，则 main-gateway-via-edge 业务 smoke 也通过。
+
+若失败：
+- `ssm:SendCommand` AccessDenied：
+  - 检查 OIDC 栈参数 `<EdgeXTargetInstanceId>` 是否已回填实例 ID。
+  - 检查策略中文档 ARN 是否为 `arn:aws:ssm:<edge-region>::document/AWS-RunShellScript`。
+
+## 6) Upgrade / Rollback（日常）
+
+### upgrade
+
+```bash
+gh workflow run deploy-edge-stage0.yml \
+  -f edge_id=<edge_id> \
+  -f operation=upgrade \
+  -f tag=<X.Y.Z> \
+  -f confirm_stack=tokenkey-edge-<edge_id>-stage0
+```
+
+### rollback
+
+```bash
+gh workflow run deploy-edge-stage0.yml \
+  -f edge_id=<edge_id> \
+  -f operation=rollback \
+  -f tag=<PREVIOUS_X.Y.Z> \
+  -f confirm_stack=tokenkey-edge-<edge_id>-stage0
+```
+
+回滚后必须重新 smoke。
+
+## 7) `operation=full` 执行清单
+
+按以下顺序执行：
+1. 完成 Prepare（1.1~1.6）
+2. 执行 Provision
+3. 配置并确认 DNS 生效
+4. 执行 Smoke
+5. 输出结构化结果：
+   - edge_id / region / stack / domain
+   - provision run id + status
+   - smoke run id + status
+   - external health / 403 path / SSM self-smoke
+   - 是否覆盖 main-gateway-via-edge（若缺密钥明确标注“未覆盖”）
+
+## 8) 提交前自检
+
+若本次改了仓库文件（workflow/template/json）：
+
+```bash
+bash scripts/preflight.sh
+```
+
+通过后再提交。
+
+## 故障速查
+
+| 现象 | 根因 | 处理 |
+|---|---|---|
+| `AssumeRoleWithWebIdentity` 拒绝 | AllowedSubjects 缺 `environment:edge-<edge_id>` | 更新 `cicd-oidc.yaml` 并 deploy |
+| provision 报找不到 CFN role output | workflow 未加 `CFN_ROLE_OUTPUT_KEY` 映射 | 更新 `.github/workflows/deploy-edge-stage0.yml` |
+| cloud-init 拉镜像失败 | `EDGE_GHCR_PAT_SSM_NAME` 错路径或参数缺失 | 在目标 region 写入 `.../edge/<edge_id>/ghcr/pat` |
+| smoke 外部 health 000 | DNS 未生效或服务未起来 | 先查 DNS，再查实例 `tokenkey.service` / compose |
+| smoke 报 `ssm:SendCommand` 拒绝 | 实例 ARN/文档 ARN 策略不匹配 | 回填 `<EdgeXTargetInstanceId>`，并确保文档 ARN 用 `<EdgeXRegion>` |
+
+## 扩展阅读
+
+- `.github/workflows/deploy-edge-stage0.yml`
+- `deploy/aws/cloudformation/cicd-oidc.yaml`
+- `deploy/aws/stage0/edge-targets.json`
+- `deploy/aws/cloudformation/stage0-edge-ec2.yaml`
+- `scripts/tk_edge_post_deploy_smoke.sh`
+- `deploy/aws/README.md`
+
+## 工具脚本：重置 Edge admin 密码（随机）
+
+已提供脚本：`scripts/reset-edge-admin-password.sh`
+
+用法：
+
+```bash
+bash scripts/reset-edge-admin-password.sh edge-fra1
+# 或
+bash scripts/reset-edge-admin-password.sh fra1
+```
+
+行为：
+- 自动从 `deploy/aws/stage0/edge-targets.json` 解析 `region/stack`
+- 自动从 stack 输出解析 `InstanceId`
+- 通过 SSM 在实例上读取 `ADMIN_EMAIL`
+- 随机生成新密码并重置 admin（bcrypt/pgcrypto）
+- 最终打印：`ADMIN_EMAIL` 与 `NEW_PASSWORD`
+
+注意：脚本会在终端明文打印新密码，执行后请立即登录并改成你的长期密码。

--- a/.cursor/skills/tokenkey-stage0-edge-expansion/SKILL.md
+++ b/.cursor/skills/tokenkey-stage0-edge-expansion/SKILL.md
@@ -156,7 +156,7 @@ gh run watch <run-id> --exit-status
 
 - 默认邮箱：`admin@<api-domain>`（若 CFN 未显式传 `AdminEmail`）。
 - `AUTO_SETUP` 首次创建 admin 时，若 `ADMIN_PASSWORD` 为空，会生成一次性随机密码并写入日志。
-- 初始和重置 admin 账密必须保存到 `/Users/xuejiao/Codes/keys/tokenkey-<edge_id>-admin-password.txt`，格式与 `tokenkey-uk1-admin-password.txt` 一致：`email=...`、`password=...`。
+- 初始和重置 admin 账密必须保存到 `$HOME/Codes/keys/tokenkey-<edge_id>-admin-password.txt`，格式与 `tokenkey-uk1-admin-password.txt` 一致：`email=...`、`password=...`。
 - 禁止在终端、PR、issue、日志摘要或聊天中打印密码；只报告保存路径和状态。
 
 ### 3.2 线上日志保存（优先）
@@ -165,7 +165,7 @@ gh run watch <run-id> --exit-status
 EDGE_ID=<edge_id>
 REGION=<edge-region>
 STACK=tokenkey-edge-<edge_id>-stage0
-KEYS_DIR=/Users/xuejiao/Codes/keys
+KEYS_DIR=$HOME/Codes/keys
 CREDENTIAL_FILE="$KEYS_DIR/tokenkey-$EDGE_ID-admin-password.txt"
 INSTANCE_ID=$(aws cloudformation describe-stacks \
   --region "$REGION" \
@@ -336,7 +336,7 @@ bash scripts/reset-edge-admin-password.sh fra1
 - 自动从 stack 输出解析 `InstanceId`
 - 通过 SSM 在实例上读取 `ADMIN_EMAIL`
 - 随机生成新密码并重置 admin（bcrypt/pgcrypto）
-- 保存 `email=...` / `password=...` 到 `/Users/xuejiao/Codes/keys/tokenkey-<edge_id>-admin-password.txt`
+- 保存 `email=...` / `password=...` 到 `$HOME/Codes/keys/tokenkey-<edge_id>-admin-password.txt`
 - 最终只打印状态与 `CREDENTIAL_FILE`，不打印密码
 
 注意：该脚本禁止明文打印新密码；执行后从本地 keys 文件读取并登录，再立即改成你的长期密码。

--- a/.cursor/skills/tokenkey-stage0-edge-expansion/SKILL.md
+++ b/.cursor/skills/tokenkey-stage0-edge-expansion/SKILL.md
@@ -150,18 +150,23 @@ gh run watch <run-id> --exit-status
 - `EDGE_GHCR_PAT_SSM_NAME` 是否存在于目标 region
 - cloud-init 是否执行完成（`/var/lib/cloud/instance/scripts/part-001`）
 
-## 3) 初始 admin 账密获取（首次初始化后立即执行）
+## 3) 初始 admin 账密保存（首次初始化后立即执行）
 
-### 3.1 默认账号来源
+### 3.1 默认账号与保存位置
 
 - 默认邮箱：`admin@<api-domain>`（若 CFN 未显式传 `AdminEmail`）。
 - `AUTO_SETUP` 首次创建 admin 时，若 `ADMIN_PASSWORD` 为空，会生成一次性随机密码并写入日志。
+- 初始和重置 admin 账密必须保存到 `/Users/xuejiao/Codes/keys/tokenkey-<edge_id>-admin-password.txt`，格式与 `tokenkey-uk1-admin-password.txt` 一致：`email=...`、`password=...`。
+- 禁止在终端、PR、issue、日志摘要或聊天中打印密码；只报告保存路径和状态。
 
-### 3.2 线上日志获取（优先）
+### 3.2 线上日志保存（优先）
 
 ```bash
+EDGE_ID=<edge_id>
 REGION=<edge-region>
 STACK=tokenkey-edge-<edge_id>-stage0
+KEYS_DIR=/Users/xuejiao/Codes/keys
+CREDENTIAL_FILE="$KEYS_DIR/tokenkey-$EDGE_ID-admin-password.txt"
 INSTANCE_ID=$(aws cloudformation describe-stacks \
   --region "$REGION" \
   --stack-name "$STACK" \
@@ -174,22 +179,38 @@ CMD_ID=$(aws ssm send-command \
   --document-name AWS-RunShellScript \
   --parameters 'commands=[
     "set -euo pipefail",
-    "echo === ADMIN_EMAIL ===",
-    "sudo grep -n \"^ADMIN_EMAIL=\" /var/lib/tokenkey/.env || true",
-    "echo === DOCKER LOGS ===",
-    "sudo docker logs tokenkey 2>&1 | grep -nE \"Generated admin password|Admin user created|Auto setup\" || true",
-    "echo === JOURNAL ===",
-    "sudo journalctl -u tokenkey.service --no-pager | grep -nE \"Generated admin password|Admin user created|Auto setup\" || true",
-    "echo === BOOTSTRAP LOG ===",
-    "sudo grep -nE \"Generated admin password|Admin user created|Auto setup|ADMIN_EMAIL\" /var/log/tokenkey-edge-bootstrap.log || true"
+    "sudo grep \"^ADMIN_EMAIL=\" /var/lib/tokenkey/.env || true",
+    "sudo docker logs tokenkey 2>&1 | grep -E \"Generated admin password\" || true",
+    "sudo journalctl -u tokenkey.service --no-pager | grep -E \"Generated admin password\" || true",
+    "sudo grep -E \"Generated admin password|ADMIN_EMAIL\" /var/log/tokenkey-edge-bootstrap.log || true"
   ]' \
   --query 'Command.CommandId' --output text)
 
-aws ssm get-command-invocation \
+aws ssm wait command-executed \
+  --region "$REGION" \
+  --command-id "$CMD_ID" \
+  --instance-id "$INSTANCE_ID" || true
+
+RAW_OUTPUT=$(aws ssm get-command-invocation \
   --region "$REGION" \
   --command-id "$CMD_ID" \
   --instance-id "$INSTANCE_ID" \
-  --query 'StandardOutputContent' --output text
+  --query 'StandardOutputContent' --output text)
+
+ADMIN_EMAIL=$(printf '%s\n' "$RAW_OUTPUT" | grep -Eo 'ADMIN_EMAIL=[^[:space:]]+' | tail -n 1 | cut -d= -f2-)
+ADMIN_PASSWORD=$(printf '%s\n' "$RAW_OUTPUT" | sed -nE 's/.*Generated admin password \(one-time\): ([^[:space:]]+).*/\1/p' | tail -n 1)
+if [ -z "$ADMIN_EMAIL" ] || [ -z "$ADMIN_PASSWORD" ]; then
+  echo "[warn] initial admin credential not found in logs; run reset script instead" >&2
+else
+  umask 077
+  {
+    printf 'email=%s\n' "$ADMIN_EMAIL"
+    printf 'password=%s\n' "$ADMIN_PASSWORD"
+  } >"$CREDENTIAL_FILE"
+  chmod 600 "$CREDENTIAL_FILE"
+  echo "[ok] admin credentials saved to $CREDENTIAL_FILE"
+fi
+unset RAW_OUTPUT ADMIN_PASSWORD
 ```
 
 ### 3.3 若查不到初始密码（常见）
@@ -200,7 +221,7 @@ aws ssm get-command-invocation \
 bash scripts/reset-edge-admin-password.sh edge-<edge_id>
 ```
 
-脚本会打印 `ADMIN_EMAIL` 与 `NEW_PASSWORD`。登录后立即改为长期密码。
+脚本只打印状态和 `CREDENTIAL_FILE`，不会打印密码。登录后立即改为长期密码。
 
 ## 4) DNS
 
@@ -315,6 +336,7 @@ bash scripts/reset-edge-admin-password.sh fra1
 - 自动从 stack 输出解析 `InstanceId`
 - 通过 SSM 在实例上读取 `ADMIN_EMAIL`
 - 随机生成新密码并重置 admin（bcrypt/pgcrypto）
-- 最终打印：`ADMIN_EMAIL` 与 `NEW_PASSWORD`
+- 保存 `email=...` / `password=...` 到 `/Users/xuejiao/Codes/keys/tokenkey-<edge_id>-admin-password.txt`
+- 最终只打印状态与 `CREDENTIAL_FILE`，不打印密码
 
-注意：脚本会在终端明文打印新密码，执行后请立即登录并改成你的长期密码。
+注意：该脚本禁止明文打印新密码；执行后从本地 keys 文件读取并登录，再立即改成你的长期密码。

--- a/.cursor/skills/tokenkey-stage0-release-rollout/SKILL.md
+++ b/.cursor/skills/tokenkey-stage0-release-rollout/SKILL.md
@@ -4,8 +4,9 @@ description: >-
   Drives TokenKey AWS Stage0 release and rollout across prod and Edge targets:
   sync main, decide VERSION/tag, run scripts/release-tag.sh, watch release.yml,
   deploy prod via deploy-stage0.yml, deploy/smoke deployable Edge targets
-  (edge-uk1 / edge-fra1) via deploy-edge-stage0.yml, report structured smoke
-  results, or run a pre-release check of code facts and production impact risk.
+  (dynamic edge matrix from deploy/aws/stage0/edge-targets.json) via
+  deploy-edge-stage0.yml, report structured smoke results, or run a pre-release
+  check of code facts and production impact risk.
   Use when the user asks to release, deploy, smoke, rollback, check release
   risk, or roll out to prod, Edge regions, or all Stage0 targets.
 ---
@@ -19,22 +20,21 @@ description: >-
 本 skill 默认按用户语义解析；用户未写完整参数时，先按下面语义补全，仍有歧义再问。
 
 ```text
-/tokenkey-stage0-release-rollout target=<prod|edge-uk1|edge-fra1|all> [tag=X.Y.Z] [operation=<check|release|deploy|smoke|rollback>] [previous_tag=X.Y.Z]
+/tokenkey-stage0-release-rollout target=<prod|edge-<edge_id>|all> [tag=X.Y.Z] [operation=<check|release|deploy|smoke|rollback>] [previous_tag=X.Y.Z]
 ```
 
 | 参数 | 语义 |
 |---|---|
 | `operation=check` | 只做预发布风险检查：对比上一个 release tag 到待发布 HEAD 的代码事实，判断上线 prod/Edge 的潜在影响；不 bump、不 tag、不 dispatch deploy。 |
 | `target=prod` | release（必要时 bump/tag/build）→ `deploy-stage0.yml -f tag=…`（绑定 **`prod`** Environment）→ prod smoke。 |
-| `target=edge-uk1` | 默认 tag 已存在：`deploy-edge-stage0.yml edge_id=uk1 operation=upgrade` → Edge smoke；`operation=smoke` 只 smoke；`operation=rollback` 用 `previous_tag`。 |
-| `target=edge-fra1` | 同上，`edge_id=fra1` / `confirm_stack=tokenkey-edge-fra1-stage0`（法国巴黎 `eu-west-3`）。 |
-| `target=all` | release 一次 → deployable Edge 按矩阵顺序 canary（当前 uk1 → fra1）upgrade/smoke → prod deploy/smoke → main-gateway-via-edge smoke → 其余 Edge 类推。 |
+| `target=edge-<edge_id>` | 默认 tag 已存在：`deploy-edge-stage0.yml edge_id=<edge_id> operation=upgrade` → Edge smoke；`operation=smoke` 只 smoke；`operation=rollback` 用 `previous_tag`。`confirm_stack` 按矩阵取 `tokenkey-edge-<edge_id>-stage0`。 |
+| `target=all` | release 一次 → 从 `deploy/aws/stage0/edge-targets.json` 读取 `deployable=true` 的 Edge 矩阵并按顺序 canary upgrade/smoke → prod deploy/smoke → main-gateway-via-edge smoke → 其余 Edge 类推。 |
 
 如果用户只说“发版 / deploy 最新 / ship production”，默认 `target=prod operation=release`。如果用户说“全部 / 所有网关 / prod + edge / all”，默认 `target=all operation=release`。如果用户说“检查 / 预判 / 评估上线影响 / release check”，默认 `operation=check target=all`。
 
 ## check 模式：预发布生产影响评估
 
-`operation=check` 是只读门禁，用来回答“如果这些变更现在上线 prod / Edge（uk1、fra1）会不会影响线上服务”。它**不修改文件、不 bump VERSION、不创建 tag、不 dispatch workflow**。
+`operation=check` 是只读门禁，用来回答“如果这些变更现在上线 prod / Edge（当前 deployable 矩阵）会不会影响线上服务”。它**不修改文件、不 bump VERSION、不创建 tag、不 dispatch workflow**。
 
 默认范围：从最新已发布 tag 到当前待发布 HEAD。用户给 `previous_tag` 时用该 tag；用户给 `tag` 时用该 tag 作为目标，否则用 `HEAD`。
 
@@ -69,15 +69,15 @@ description: >-
 `all` 不是并行全量推送。默认采用顺序化 canary rollout：
 
 1. **release build 一次**：只构建一个 multi-arch GHCR tag，所有目标复用同一 image，避免两套产物。
-2. **Edge canary：deployable Edge 逐个 upgrade + infra smoke**（矩阵顺序，当前 uk1 → fra1）：先在低成本、非用户入口的资源节点验证镜像能在 Graviton/Stage0/共享 compose 上启动，并验证 `/health`、Caddy allowlist、Edge self-smoke。
+2. **Edge canary：deployable Edge 逐个 upgrade + infra smoke**（矩阵顺序由 `deploy/aws/stage0/edge-targets.json` 决定）：先在低成本、非用户入口的资源节点验证镜像能在 Graviton/Stage0/共享 compose 上启动，并验证 `/health`、Caddy allowlist、Edge self-smoke。
 3. **prod 主网关 upgrade + 完整 prod smoke**：主网关是唯一用户入口、计量计费面和体验中心；Edge canary 过后再升级 prod。
-4. **main gateway via Edge smoke**：prod 升级后再跑主网关经 uk1 的业务 smoke，确认 `api.tokenkey.dev` 调度到 Edge 的真实链路。
-5. **剩余 deployable Edge 顺序 rollout**：未来 `us1/sg1` 等变为 `deployable=true` 后，按 `deploy/aws/stage0/edge-targets.json` 顺序逐个 upgrade + smoke，失败即停。
+4. **main gateway via Edge smoke**：prod 升级后再跑主网关经一个已通过 canary 的 Edge（默认矩阵第一个）业务 smoke，确认 `api.tokenkey.dev` 调度到 Edge 的真实链路。
+5. **其余 deployable Edge 顺序 rollout**：按 `deploy/aws/stage0/edge-targets.json` 顺序逐个 upgrade + smoke，失败即停。
 
 例外：
 
 - `target=prod`：只发版/部署 prod，不自动部署 Edge。
-- `target=edge-uk1` / `edge-fra1`：只升级/烟测对应 Edge，不发新 release，除非用户显式要求先 release。
+- `target=edge-<edge_id>`：只升级/烟测对应 Edge，不发新 release，除非用户显式要求先 release。
 - 用户强指定“prod 先”时照做，但在摘要中标出与默认 canary 顺序的差异。
 
 ## 一次性跑完（原则）
@@ -85,7 +85,7 @@ description: >-
 - **顺序做完**：同步 → 决策 VERSION/tag →（按需 bump+push）→ `release-tag.sh` → **watch 到 release 成功** → 根据 `target` dispatch 对应 deploy workflow → **watch 到 deploy/smoke 成功** → **再做本地/日志验收**。不要在 workflow 绿灯后就结束会话。
 - **读 VERSION 前必须先** `fetch` + `pull --ff-only` **后的** `origin/main` 为准；在未更新的本地分支上读 `VERSION` 会与远端 tag 错位。
 - **`gh run watch` 要给够时间**：多架构 `release.yml` 常见十余分钟量级；Agent 应用 `--exit-status` 跟跑到结束，不要用默认短超时提前杀掉。
-- **Environment approval 不是失败**：`prod` / `edge-uk1` / `edge-fra1` run 卡在 `waiting` 时，需要人在 GitHub Actions 批准；批准后继续 watch。
+- **Environment approval 不是失败**：`prod` / `edge-<edge_id>` run 卡在 `waiting` 时，需要人在 GitHub Actions 批准；批准后继续 watch。
 - **完整烟测密钥**：优先使用环境里已有的 smoke key，避免停下来向用户索要 key；详见 prod smoke 与 Edge smoke 章节。
 - **禁止 `simple_release_override=true`**：prod / Edge 当前都跑 AWS Graviton arm64；单架构 manifest 会导致 `exec format error`。
 
@@ -93,7 +93,7 @@ description: >-
 
 - 工作目录：仓库根目录（含 `backend/`、`scripts/release-tag.sh`）。
 - 网络、`git`、`gh` 已认证且对远端可写；`gh` 能 dispatch `release.yml`、`deploy-stage0.yml`、`deploy-edge-stage0.yml`。
-- GitHub Environment：**`prod`**、各 Edge 的 `edge-<edge_id>`（如 `edge-uk1`、`edge-fra1`；若有 Required reviewers，需人工批准）。**`edge-fra1` 的 Variables/Secrets 可与 `edge-uk1` 逐项相同**，详见 `deploy/aws/README.md` Edge 小节（`EDGE_GHCR_PAT_SSM_NAME` 勿抄 uk1 路径）。
+- GitHub Environment：**`prod`**、各 Edge 的 `edge-<edge_id>`（若有 Required reviewers，需人工批准）。新 edge 可参考已上线 edge 的变量/密钥结构，但 `EDGE_GHCR_PAT_SSM_NAME` 必须使用该 edge 自己的 SSM 路径。
 - **禁止**：VERSION bump / 发版 commit 的正文里出现字面量 `[skip ci]` 或 `[ci skip]`（任意位置都不行）。
 
 ## 决策：要不要升 patch 版本
@@ -138,33 +138,36 @@ gh workflow run deploy-stage0.yml \
   -f tag="$TARGET_TAG"
 ```
 
-**target=all 注意**：如果 release 已自动 queue prod，而 Edge canary 尚未完成，不取消 prod run；若它卡在 `prod` Environment approval，先不要批准，等当前 batch 的 Edge canary（uk1 → fra1 …）成功后再批准。若 prod 已开始，继续完成，不强行中断，并在摘要标记“prod 已先行”。
+**target=all 注意**：如果 release 已自动 queue prod，而 Edge canary 尚未完成，不取消 prod run；若它卡在 `prod` Environment approval，先不要批准，等当前 batch 的 Edge canary（按 deployable 矩阵顺序）成功后再批准。若 prod 已开始，继续完成，不强行中断，并在摘要标记“prod 已先行”。
 
-### edge-uk1 / edge-fra1：Edge 资源节点
+### edge-<edge_id>：Edge 资源节点
 
-以 `deploy/aws/stage0/edge-targets.json` 为准：`uk1`、`fra1`（法国巴黎 `eu-west-3`）当前 `deployable=true`。`us1/sg1` 仍为 planned。
+以 `deploy/aws/stage0/edge-targets.json` 为准。`deployable=true` 的 edge 才进入 rollout；`deployable=false` 仅作为 planned。
 
 ```bash
-# Edge upgrade（uk1 示例；fra1 将 edge_id / confirm_stack 换成 fra1 / tokenkey-edge-fra1-stage0）
+# 单个 Edge upgrade（示例：edge_id=<edge_id>）
 TARGET_TAG=X.Y.Z
+EDGE_ID=<edge_id>
+CONFIRM_STACK="tokenkey-edge-${EDGE_ID}-stage0"
+
 gh workflow run deploy-edge-stage0.yml \
-  -f edge_id=uk1 \
+  -f edge_id="$EDGE_ID" \
   -f operation=upgrade \
   -f tag="$TARGET_TAG" \
-  -f confirm_stack=tokenkey-edge-uk1-stage0
+  -f confirm_stack="$CONFIRM_STACK"
 
-# Edge smoke only
+# 单个 Edge smoke only
 gh workflow run deploy-edge-stage0.yml \
-  -f edge_id=uk1 \
+  -f edge_id="$EDGE_ID" \
   -f operation=smoke \
-  -f confirm_stack=tokenkey-edge-uk1-stage0
+  -f confirm_stack="$CONFIRM_STACK"
 
-# Edge rollback
+# 单个 Edge rollback
 gh workflow run deploy-edge-stage0.yml \
-  -f edge_id=uk1 \
+  -f edge_id="$EDGE_ID" \
   -f operation=rollback \
   -f tag="$PREVIOUS_TAG" \
-  -f confirm_stack=tokenkey-edge-uk1-stage0
+  -f confirm_stack="$CONFIRM_STACK"
 ```
 
 `provision` 只用于首次创建或 CloudFormation 参数/模板更新，不是日常 release rollout 默认操作。
@@ -172,12 +175,14 @@ gh workflow run deploy-edge-stage0.yml \
 ## target=all 的执行顺序
 
 1. 完成“标准流程：release 新镜像”，得到 `TARGET_TAG`。
-2. 对每个 deployable Edge（矩阵顺序，当前 uk1 然后 fra1）：dispatch `deploy-edge-stage0.yml operation=upgrade tag=$TARGET_TAG`，watch 到 success。
-3. 检查每场 Edge smoke 结果：external health、public runner relay path block、SSM self-smoke；若失败，停，不推进 prod，除非用户明确 override。
-4. 推进 prod deploy：优先使用 release 自动 queue 的 prod run；没有则手动 dispatch。watch 到 success。
-5. 做 prod 完整 smoke（见下文）。
-6. 对用于主网关链路的 Edge（例如 uk1）再 dispatch `operation=smoke`，做 prod 升级后的 main-gateway-via-edge 验证；若缺 `MAIN_GATEWAY_EDGE_SMOKE_API_KEY`，只可标记“infra smoke 通过，主网关经 Edge 业务 smoke 未覆盖”。其它 Edge 按需 smoke。
-7. 未来新增 deployable Edge 时，仍按矩阵顺序逐个 upgrade + smoke；失败即停。
+2. 读取 deployable 矩阵（按 `deploy/aws/stage0/edge-targets.json` 顺序）：
+   `python3 - <<'PY'\nimport json\nfrom pathlib import Path\np=Path('deploy/aws/stage0/edge-targets.json')\nd=json.loads(p.read_text())\nfor k,v in (d.get('targets') or {}).items():\n    if v.get('deployable'): print(k)\nPY`
+3. 对每个 deployable Edge：dispatch `deploy-edge-stage0.yml operation=upgrade tag=$TARGET_TAG`，watch 到 success。
+4. 检查每场 Edge smoke 结果：external health、public runner relay path block、SSM self-smoke；若失败，停，不推进 prod，除非用户明确 override。
+5. 推进 prod deploy：优先使用 release 自动 queue 的 prod run；没有则手动 dispatch。watch 到 success。
+6. 做 prod 完整 smoke（见下文）。
+7. 对用于主网关链路的 Edge（默认取 deployable 矩阵第一个）再 dispatch `operation=smoke`，做 prod 升级后的 main-gateway-via-edge 验证；若缺 `MAIN_GATEWAY_EDGE_SMOKE_API_KEY`，只可标记“infra smoke 通过，主网关经 Edge 业务 smoke 未覆盖”。
+8. 其余 deployable Edge 按需 smoke；失败即停。
 
 ## prod 真实测试
 
@@ -246,15 +251,15 @@ gh workflow run deploy-stage0.yml \
   -f tag="$PREVIOUS_TAG"
 ```
 
-- Edge rollback：`deploy-edge-stage0.yml operation=rollback`（按目标换 `edge_id` / `confirm_stack`）。
+- Edge rollback：`deploy-edge-stage0.yml operation=rollback`（按目标替换 `edge_id`，`confirm_stack=tokenkey-edge-<edge_id>-stage0`）。
 
 ```bash
+EDGE_ID=<edge_id>
 gh workflow run deploy-edge-stage0.yml \
-  -f edge_id=uk1 \
+  -f edge_id="$EDGE_ID" \
   -f operation=rollback \
   -f tag="$PREVIOUS_TAG" \
-  -f confirm_stack=tokenkey-edge-uk1-stage0
-# fra1：edge_id=fra1，confirm_stack=tokenkey-edge-fra1-stage0
+  -f confirm_stack="tokenkey-edge-${EDGE_ID}-stage0"
 ```
 
 prod smoke 失败：停，优先 rollback prod；不要继续 Edge rollout。Edge canary 失败：停，不批准/推进 prod，除非用户明确 override。
@@ -282,15 +287,14 @@ git diff --diff-filter=D --name-only "${PREV_TAG}..${NEW_TAG}" -- backend/ || tr
 
 | target | workflow | run id | tag | status | smoke |
 |---|---|---:|---|---|---|
-| edge-uk1-canary | deploy-edge-stage0 | ... | X.Y.Z | success/fail/skipped | infra / main-via-edge |
-| edge-fra1-canary | deploy-edge-stage0 | ... | X.Y.Z | success/fail/skipped | infra（按需） |
+| edge-<edge_id>-canary（每个 deployable edge 一行） | deploy-edge-stage0 | ... | X.Y.Z | success/fail/skipped | infra / main-via-edge(按需) |
 | prod | deploy-stage0 | ... | X.Y.Z | success/fail/skipped | full/partial |
 
 并补充：
 
 - **有效提交**：feat/fix/chore 分类。
 - **影响面与验证重点**：Gemini、OpenAI OAuth、pricing/model-list、frontend、sentinel、upstream 删除等按实际变更列出。
-- **未部署或未覆盖目标**：例如 `us1/sg1` 仍为 planned、用户只要求 prod、缺少 main-gateway-via-edge smoke secret、等待人工审批等。
+- **未部署或未覆盖目标**：例如某些 edge 仍 `deployable=false`、用户只要求 prod、缺少 main-gateway-via-edge smoke secret、等待人工审批等。
 
 ## release 之后 main 是否还有提交
 
@@ -317,4 +321,4 @@ git diff --diff-filter=D --name-only "${PREV_TAG}..${NEW_TAG}" -- backend/ || tr
 - `.github/workflows/deploy-edge-stage0.yml` — Edge upgrade/smoke/rollback。
 - `scripts/tk_post_deploy_smoke.sh` — prod 完整 smoke。
 - `scripts/tk_edge_post_deploy_smoke.sh` — Edge smoke wrapper。
-- `deploy/aws/README.md` — Stage0、Edge（uk1 / fra1）、升级 SOP。
+- `deploy/aws/README.md` — Stage0、Edge、多区域升级 SOP。

--- a/.cursor/skills/tokenkey-stage0-release-rollout/SKILL.md
+++ b/.cursor/skills/tokenkey-stage0-release-rollout/SKILL.md
@@ -69,9 +69,9 @@ description: >-
 `all` 不是并行全量推送。默认采用顺序化 canary rollout：
 
 1. **release build 一次**：只构建一个 multi-arch GHCR tag，所有目标复用同一 image，避免两套产物。
-2. **Edge canary：deployable Edge 逐个 upgrade + infra smoke**（矩阵顺序由 `deploy/aws/stage0/edge-targets.json` 决定）：先在低成本、非用户入口的资源节点验证镜像能在 Graviton/Stage0/共享 compose 上启动，并验证 `/health`、Caddy allowlist、Edge self-smoke。
+2. **Edge canary：只取 deployable 矩阵第一个 Edge upgrade + infra smoke**：先在低成本、非用户入口的资源节点验证镜像能在 Graviton/Stage0/共享 compose 上启动，并验证 `/health`、Caddy allowlist、Edge self-smoke。
 3. **prod 主网关 upgrade + 完整 prod smoke**：主网关是唯一用户入口、计量计费面和体验中心；Edge canary 过后再升级 prod。
-4. **main gateway via Edge smoke**：prod 升级后再跑主网关经一个已通过 canary 的 Edge（默认矩阵第一个）业务 smoke，确认 `api.tokenkey.dev` 调度到 Edge 的真实链路。
+4. **main gateway via Edge smoke**：prod 升级后再跑主网关经这个已通过 canary 的 Edge 业务 smoke，确认 `api.tokenkey.dev` 调度到 Edge 的真实链路。
 5. **其余 deployable Edge 顺序 rollout**：按 `deploy/aws/stage0/edge-targets.json` 顺序逐个 upgrade + smoke，失败即停。
 
 例外：
@@ -138,7 +138,7 @@ gh workflow run deploy-stage0.yml \
   -f tag="$TARGET_TAG"
 ```
 
-**target=all 注意**：如果 release 已自动 queue prod，而 Edge canary 尚未完成，不取消 prod run；若它卡在 `prod` Environment approval，先不要批准，等当前 batch 的 Edge canary（按 deployable 矩阵顺序）成功后再批准。若 prod 已开始，继续完成，不强行中断，并在摘要标记“prod 已先行”。
+**target=all 注意**：如果 release 已自动 queue prod，而 Edge canary 尚未完成，不取消 prod run；若它卡在 `prod` Environment approval，先不要批准，等第一个 deployable Edge canary 成功后再批准。若 prod 已开始，继续完成，不强行中断，并在摘要标记“prod 已先行”。
 
 ### edge-<edge_id>：Edge 资源节点
 
@@ -177,12 +177,12 @@ gh workflow run deploy-edge-stage0.yml \
 1. 完成“标准流程：release 新镜像”，得到 `TARGET_TAG`。
 2. 读取 deployable 矩阵（按 `deploy/aws/stage0/edge-targets.json` 顺序）：
    `python3 - <<'PY'\nimport json\nfrom pathlib import Path\np=Path('deploy/aws/stage0/edge-targets.json')\nd=json.loads(p.read_text())\nfor k,v in (d.get('targets') or {}).items():\n    if v.get('deployable'): print(k)\nPY`
-3. 对每个 deployable Edge：dispatch `deploy-edge-stage0.yml operation=upgrade tag=$TARGET_TAG`，watch 到 success。
-4. 检查每场 Edge smoke 结果：external health、public runner relay path block、SSM self-smoke；若失败，停，不推进 prod，除非用户明确 override。
+3. 取矩阵第一个 deployable Edge 作为 canary：dispatch `deploy-edge-stage0.yml operation=upgrade tag=$TARGET_TAG`，watch 到 success。
+4. 检查 canary Edge smoke 结果：external health、public runner relay path block、SSM self-smoke；若失败，停，不推进 prod，除非用户明确 override。
 5. 推进 prod deploy：优先使用 release 自动 queue 的 prod run；没有则手动 dispatch。watch 到 success。
 6. 做 prod 完整 smoke（见下文）。
-7. 对用于主网关链路的 Edge（默认取 deployable 矩阵第一个）再 dispatch `operation=smoke`，做 prod 升级后的 main-gateway-via-edge 验证；若缺 `MAIN_GATEWAY_EDGE_SMOKE_API_KEY`，只可标记“infra smoke 通过，主网关经 Edge 业务 smoke 未覆盖”。
-8. 其余 deployable Edge 按需 smoke；失败即停。
+7. 对 canary Edge 再 dispatch `operation=smoke`，做 prod 升级后的 main-gateway-via-edge 验证；若缺 `MAIN_GATEWAY_EDGE_SMOKE_API_KEY`，只可标记“infra smoke 通过，主网关经 Edge 业务 smoke 未覆盖”。
+8. 其余 deployable Edge 顺序 upgrade + smoke；失败即停。
 
 ## prod 真实测试
 

--- a/deploy/aws/cloudformation/cicd-oidc.yaml
+++ b/deploy/aws/cloudformation/cicd-oidc.yaml
@@ -167,7 +167,7 @@ Resources:
                     - ssm:SendCommand
                   Resource:
                     - !Sub "arn:aws:ec2:${EdgeUk1Region}:${AWS::AccountId}:instance/${EdgeUk1TargetInstanceId}"
-                    - !Sub "arn:aws:ssm:${AWS::Region}::document/AWS-RunShellScript"
+                    - !Sub "arn:aws:ssm:${EdgeUk1Region}::document/AWS-RunShellScript"
                 - !Ref AWS::NoValue
               - !If
                 - HasEdgeFra1Instance
@@ -177,7 +177,7 @@ Resources:
                     - ssm:SendCommand
                   Resource:
                     - !Sub "arn:aws:ec2:${EdgeFra1Region}:${AWS::AccountId}:instance/${EdgeFra1TargetInstanceId}"
-                    - !Sub "arn:aws:ssm:${AWS::Region}::document/AWS-RunShellScript"
+                    - !Sub "arn:aws:ssm:${EdgeFra1Region}::document/AWS-RunShellScript"
                 - !Ref AWS::NoValue
               - Sid: ReadCommandResult
                 Effect: Allow

--- a/scripts/reset-edge-admin-password.sh
+++ b/scripts/reset-edge-admin-password.sh
@@ -1,0 +1,166 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+usage() {
+  cat <<'EOF'
+Usage:
+  bash scripts/reset-edge-admin-password.sh edge-<id>
+  bash scripts/reset-edge-admin-password.sh <id>
+
+Examples:
+  bash scripts/reset-edge-admin-password.sh edge-fra1
+  bash scripts/reset-edge-admin-password.sh fra1
+
+Behavior:
+  - Resolves region/stack from deploy/aws/stage0/edge-targets.json
+  - Reads InstanceId from CloudFormation stack outputs
+  - Reads ADMIN_EMAIL from /var/lib/tokenkey/.env on the instance
+  - Resets admin password to a random 32-hex string via PostgreSQL (pgcrypto bcrypt)
+  - Prints ADMIN_EMAIL and NEW_PASSWORD
+EOF
+}
+
+if [[ "${1:-}" == "-h" || "${1:-}" == "--help" || $# -ne 1 ]]; then
+  usage
+  exit $([[ $# -eq 1 ]] && echo 0 || echo 1)
+fi
+
+INPUT_TARGET="$1"
+EDGE_ID="${INPUT_TARGET#edge-}"
+
+REPO_ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+MATRIX_PATH="$REPO_ROOT/deploy/aws/stage0/edge-targets.json"
+
+if [[ ! -f "$MATRIX_PATH" ]]; then
+  echo "[error] edge target matrix not found: $MATRIX_PATH" >&2
+  exit 1
+fi
+
+read -r REGION STACK <<<"$(python3 - "$MATRIX_PATH" "$EDGE_ID" <<'PY'
+import json
+import sys
+
+path, edge_id = sys.argv[1], sys.argv[2]
+with open(path, 'r', encoding='utf-8') as f:
+    data = json.load(f)
+
+target = (data.get('targets') or {}).get(edge_id)
+if not target:
+    print(f"[error] unknown edge_id {edge_id}", file=sys.stderr)
+    sys.exit(1)
+
+region = target.get('region')
+stack = target.get('stack')
+if not region or not stack:
+    print(f"[error] edge {edge_id} missing region/stack in matrix", file=sys.stderr)
+    sys.exit(1)
+
+print(region, stack)
+PY
+)"
+
+INSTANCE_ID="$(aws cloudformation describe-stacks \
+  --region "$REGION" \
+  --stack-name "$STACK" \
+  --query 'Stacks[0].Outputs[?OutputKey==`InstanceId`].OutputValue' \
+  --output text)"
+
+if [[ -z "$INSTANCE_ID" || "$INSTANCE_ID" == "None" ]]; then
+  echo "[error] could not resolve InstanceId from stack $STACK in $REGION" >&2
+  exit 1
+fi
+
+NEW_PASSWORD="$(openssl rand -hex 16)"
+
+echo "[info] edge_id=$EDGE_ID region=$REGION stack=$STACK instance_id=$INSTANCE_ID"
+echo "[info] resetting admin password via SSM..."
+
+COMMANDS_JSON="$(python3 - "$NEW_PASSWORD" <<'PY'
+import json
+import sys
+
+new_password = sys.argv[1]
+commands = [
+    "set -euo pipefail",
+    "ADMIN_EMAIL=$(sudo grep '^ADMIN_EMAIL=' /var/lib/tokenkey/.env | cut -d= -f2)",
+    "if [ -z \"${ADMIN_EMAIL:-}\" ]; then echo '[error] ADMIN_EMAIL not found in /var/lib/tokenkey/.env' >&2; exit 1; fi",
+    "sudo docker exec tokenkey-postgres psql -U tokenkey -d tokenkey -c 'CREATE EXTENSION IF NOT EXISTS pgcrypto;' >/dev/null",
+    f"sudo docker exec tokenkey-postgres psql -U tokenkey -d tokenkey -c \"UPDATE users SET password_hash = crypt('{new_password}', gen_salt('bf', 10)), updated_at = NOW() WHERE email = '${{ADMIN_EMAIL}}' AND role = 'admin';\"",
+    "UPDATED_COUNT=$(sudo docker exec tokenkey-postgres psql -U tokenkey -d tokenkey -tA -c \"SELECT COUNT(1) FROM users WHERE email = '${ADMIN_EMAIL}' AND role = 'admin';\" | tr -d '[:space:]')",
+    "if [ \"${UPDATED_COUNT}\" != \"1\" ]; then echo \"[error] expected exactly 1 admin row for ${ADMIN_EMAIL}, got ${UPDATED_COUNT}\" >&2; exit 1; fi",
+    "echo ADMIN_EMAIL=$ADMIN_EMAIL",
+    "echo RESET_OK=1",
+]
+print(json.dumps(commands))
+PY
+)"
+
+COMMAND_ID="$(aws ssm send-command \
+  --region "$REGION" \
+  --instance-ids "$INSTANCE_ID" \
+  --document-name AWS-RunShellScript \
+  --comment "reset edge admin password ($EDGE_ID)" \
+  --parameters "commands=$COMMANDS_JSON" \
+  --query 'Command.CommandId' \
+  --output text)"
+
+echo "[info] ssm_command_id=$COMMAND_ID"
+
+if ! aws ssm wait command-executed \
+  --region "$REGION" \
+  --command-id "$COMMAND_ID" \
+  --instance-id "$INSTANCE_ID"; then
+  echo "[warn] waiter reported non-success; fetching invocation details..." >&2
+fi
+
+STATUS="$(aws ssm get-command-invocation \
+  --region "$REGION" \
+  --command-id "$COMMAND_ID" \
+  --instance-id "$INSTANCE_ID" \
+  --query 'Status' \
+  --output text)"
+
+STDOUT_CONTENT="$(aws ssm get-command-invocation \
+  --region "$REGION" \
+  --command-id "$COMMAND_ID" \
+  --instance-id "$INSTANCE_ID" \
+  --query 'StandardOutputContent' \
+  --output text)"
+
+STDERR_CONTENT="$(aws ssm get-command-invocation \
+  --region "$REGION" \
+  --command-id "$COMMAND_ID" \
+  --instance-id "$INSTANCE_ID" \
+  --query 'StandardErrorContent' \
+  --output text)"
+
+if [[ "$STATUS" != "Success" ]]; then
+  echo "[error] SSM command failed: status=$STATUS" >&2
+  if [[ -n "$STDOUT_CONTENT" ]]; then
+    echo "[error] stdout:" >&2
+    printf '%s\n' "$STDOUT_CONTENT" >&2
+  fi
+  if [[ -n "$STDERR_CONTENT" ]]; then
+    echo "[error] stderr:" >&2
+    printf '%s\n' "$STDERR_CONTENT" >&2
+  fi
+  exit 1
+fi
+
+ADMIN_EMAIL_LINE="$(printf '%s\n' "$STDOUT_CONTENT" | grep '^ADMIN_EMAIL=' | tail -n 1 || true)"
+ADMIN_EMAIL="${ADMIN_EMAIL_LINE#ADMIN_EMAIL=}"
+
+if [[ -z "$ADMIN_EMAIL" || "$ADMIN_EMAIL" == "$ADMIN_EMAIL_LINE" ]]; then
+  echo "[error] could not parse ADMIN_EMAIL from SSM output" >&2
+  printf '%s\n' "$STDOUT_CONTENT" >&2
+  exit 1
+fi
+
+echo ""
+echo "[ok] edge admin password reset complete"
+echo "EDGE_ID=$EDGE_ID"
+echo "REGION=$REGION"
+echo "STACK=$STACK"
+echo "INSTANCE_ID=$INSTANCE_ID"
+echo "ADMIN_EMAIL=$ADMIN_EMAIL"
+echo "NEW_PASSWORD=$NEW_PASSWORD"

--- a/scripts/reset-edge-admin-password.sh
+++ b/scripts/reset-edge-admin-password.sh
@@ -16,7 +16,7 @@ Behavior:
   - Reads InstanceId from CloudFormation stack outputs
   - Reads ADMIN_EMAIL from /var/lib/tokenkey/.env on the instance
   - Resets admin password to a random 32-hex string via PostgreSQL (pgcrypto bcrypt)
-  - Saves email/password to /Users/xuejiao/Codes/keys/tokenkey-<id>-admin-password.txt
+  - Saves email/password to $HOME/Codes/keys/tokenkey-<id>-admin-password.txt
   - Prints only status and the credential file path, never the password
 EOF
 }
@@ -28,6 +28,11 @@ fi
 
 INPUT_TARGET="$1"
 EDGE_ID="${INPUT_TARGET#edge-}"
+
+if [[ ! "$EDGE_ID" =~ ^[a-z]{2,4}[0-9]+$ ]]; then
+  echo "[error] edge id must match ^[a-z]{2,4}[0-9]+$: $EDGE_ID" >&2
+  exit 1
+fi
 
 REPO_ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
 MATRIX_PATH="$REPO_ROOT/deploy/aws/stage0/edge-targets.json"
@@ -72,7 +77,7 @@ if [[ -z "$INSTANCE_ID" || "$INSTANCE_ID" == "None" ]]; then
 fi
 
 NEW_PASSWORD="$(openssl rand -hex 16)"
-KEYS_DIR="/Users/xuejiao/Codes/keys"
+KEYS_DIR="$HOME/Codes/keys"
 CREDENTIAL_FILE="$KEYS_DIR/tokenkey-$EDGE_ID-admin-password.txt"
 
 if [[ ! -d "$KEYS_DIR" ]]; then
@@ -93,8 +98,8 @@ commands = [
     "ADMIN_EMAIL=$(sudo grep '^ADMIN_EMAIL=' /var/lib/tokenkey/.env | cut -d= -f2)",
     "if [ -z \"${ADMIN_EMAIL:-}\" ]; then echo '[error] ADMIN_EMAIL not found in /var/lib/tokenkey/.env' >&2; exit 1; fi",
     "sudo docker exec tokenkey-postgres psql -U tokenkey -d tokenkey -c 'CREATE EXTENSION IF NOT EXISTS pgcrypto;' >/dev/null",
-    f"sudo docker exec tokenkey-postgres psql -U tokenkey -d tokenkey -c \"UPDATE users SET password_hash = crypt('{new_password}', gen_salt('bf', 10)), updated_at = NOW() WHERE email = '${{ADMIN_EMAIL}}' AND role = 'admin';\"",
-    "UPDATED_COUNT=$(sudo docker exec tokenkey-postgres psql -U tokenkey -d tokenkey -tA -c \"SELECT COUNT(1) FROM users WHERE email = '${ADMIN_EMAIL}' AND role = 'admin';\" | tr -d '[:space:]')",
+    f"sudo docker exec tokenkey-postgres psql -U tokenkey -d tokenkey -v ON_ERROR_STOP=1 -v new_password={new_password} -v admin_email=\"${{ADMIN_EMAIL}}\" -c \"UPDATE users SET password_hash = crypt(:'new_password', gen_salt('bf', 10)), updated_at = NOW() WHERE email = :'admin_email' AND role = 'admin';\"",
+    "UPDATED_COUNT=$(sudo docker exec tokenkey-postgres psql -U tokenkey -d tokenkey -v ON_ERROR_STOP=1 -v admin_email=\"${ADMIN_EMAIL}\" -tA -c \"SELECT COUNT(1) FROM users WHERE email = :'admin_email' AND role = 'admin';\" | tr -d '[:space:]')",
     "if [ \"${UPDATED_COUNT}\" != \"1\" ]; then echo \"[error] expected exactly 1 admin row for ${ADMIN_EMAIL}, got ${UPDATED_COUNT}\" >&2; exit 1; fi",
     "echo ADMIN_EMAIL=$ADMIN_EMAIL",
     "echo RESET_OK=1",

--- a/scripts/reset-edge-admin-password.sh
+++ b/scripts/reset-edge-admin-password.sh
@@ -16,7 +16,8 @@ Behavior:
   - Reads InstanceId from CloudFormation stack outputs
   - Reads ADMIN_EMAIL from /var/lib/tokenkey/.env on the instance
   - Resets admin password to a random 32-hex string via PostgreSQL (pgcrypto bcrypt)
-  - Prints ADMIN_EMAIL and NEW_PASSWORD
+  - Saves email/password to /Users/xuejiao/Codes/keys/tokenkey-<id>-admin-password.txt
+  - Prints only status and the credential file path, never the password
 EOF
 }
 
@@ -71,6 +72,13 @@ if [[ -z "$INSTANCE_ID" || "$INSTANCE_ID" == "None" ]]; then
 fi
 
 NEW_PASSWORD="$(openssl rand -hex 16)"
+KEYS_DIR="/Users/xuejiao/Codes/keys"
+CREDENTIAL_FILE="$KEYS_DIR/tokenkey-$EDGE_ID-admin-password.txt"
+
+if [[ ! -d "$KEYS_DIR" ]]; then
+  echo "[error] keys directory not found: $KEYS_DIR" >&2
+  exit 1
+fi
 
 echo "[info] edge_id=$EDGE_ID region=$REGION stack=$STACK instance_id=$INSTANCE_ID"
 echo "[info] resetting admin password via SSM..."
@@ -156,11 +164,18 @@ if [[ -z "$ADMIN_EMAIL" || "$ADMIN_EMAIL" == "$ADMIN_EMAIL_LINE" ]]; then
   exit 1
 fi
 
+umask 077
+{
+  printf 'email=%s\n' "$ADMIN_EMAIL"
+  printf 'password=%s\n' "$NEW_PASSWORD"
+} >"$CREDENTIAL_FILE"
+chmod 600 "$CREDENTIAL_FILE"
+
 echo ""
 echo "[ok] edge admin password reset complete"
 echo "EDGE_ID=$EDGE_ID"
 echo "REGION=$REGION"
 echo "STACK=$STACK"
 echo "INSTANCE_ID=$INSTANCE_ID"
-echo "ADMIN_EMAIL=$ADMIN_EMAIL"
-echo "NEW_PASSWORD=$NEW_PASSWORD"
+echo "CREDENTIAL_FILE=$CREDENTIAL_FILE"
+echo "[ok] admin credentials saved; password was not printed"


### PR DESCRIPTION
## Summary
- add `scripts/reset-edge-admin-password.sh` to reset edge admin passwords by `edge-<id>` via CFN+SSM discovery, saving credentials to `$HOME/Codes/keys/tokenkey-<edge_id>-admin-password.txt` without printing passwords
- update `tokenkey-stage0-edge-expansion` skill with initial admin credential save flow and reset fallback, using `$HOME`-relative local paths
- update `tokenkey-stage0-release-rollout` skill to use the dynamic deployable edge matrix and clarify canary → prod → remaining Edge rollout order
- fix `deploy/aws/cloudformation/cicd-oidc.yaml` SSM document ARN scoping for edge regions (`${EdgeUk1Region}` / `${EdgeFra1Region}`)

## Test plan
- [x] `bash scripts/preflight.sh`
- [x] `bash -n scripts/reset-edge-admin-password.sh`
- [x] generated SSM command JSON shape check: parses and uses psql variables
- [x] verify no hardcoded `/Users/xuejiao/` paths remain
- [x] verify no fixed `uk1/fra1` targeting remains in rollout skill
- [x] GitHub CI for PR #194 all green

🤖 Generated with [Claude Code](https://claude.com/claude-code)