### PR TITLE
feat(ops): add post-rollout light diagnostics for all

### DIFF
--- a/.cursor/skills/tokenkey-stage0-release-rollout/SKILL.md
+++ b/.cursor/skills/tokenkey-stage0-release-rollout/SKILL.md
@@ -184,6 +184,10 @@ gh workflow run deploy-edge-stage0.yml \
 6. 做 prod 完整 smoke（见下文）；若仅因 `POST_DEPLOY_SMOKE_CHAT_MODEL` 不在当前 key 的 `/v1/models` 可见列表而失败，先把对应 Environment 变量改到可见模型（如 `gpt-5.5`）再重跑，不要误判为发布回归。
 7. 对 canary Edge 再 dispatch `operation=smoke`，做 prod 升级后的 main-gateway-via-edge 验证；若缺 `MAIN_GATEWAY_EDGE_SMOKE_API_KEY`，只可标记“infra smoke 通过，主网关经 Edge 业务 smoke 未覆盖”。
 8. 其余 deployable Edge 顺序 upgrade + smoke；默认优先 `claude-sonnet-4-6`，若该 edge/key 不可见则切到该 key 的可见模型并重跑一次；失败即停。
+9. **自动轻量 Diagnostics（all 默认搭配）**：all rollout 完成后自动 dispatch `.github/workflows/post-release-light-diagnostics.yml`（默认 `target_selector=all`），该 workflow 会按固定节奏触发两次 `ops-daily-diagnostics.yml operation=diagnostics`：
+   - 第一次：+5min，`diagnostics_log_since=20m`（覆盖发版前后）。
+   - 第二次：+1h，`diagnostics_log_since=2h`（覆盖发版前后）。
+   - 两次都用 `diagnostics_include_error_clustering=false`，仅做 runtime/health 轻量巡检。
 
 ## prod 真实测试
 
@@ -265,6 +269,22 @@ gh workflow run deploy-edge-stage0.yml \
 
 prod smoke 失败：停，优先 rollback prod；不要继续 Edge rollout。Edge canary 失败：停，不批准/推进 prod，除非用户明确 override。
 
+### 触发 all 后置轻量 Diagnostics（自动）
+
+all rollout 验收完成后执行：
+
+```bash
+gh workflow run post-release-light-diagnostics.yml \
+  -f target_selector=all
+```
+
+该 workflow 默认：
+
+- +5min dispatch 一次轻量 diagnostics（`diagnostics_log_since=20m`）
+- +1h dispatch 一次轻量 diagnostics（`diagnostics_log_since=2h`）
+
+如需自定义延时/窗口，可覆写：`first_delay_minutes`、`first_window`、`second_delay_minutes`、`second_window`。
+
 ## 完成后：rollout 摘要
 
 烟测全部完成后，运行以下命令，整理本次 release 变更：
@@ -322,6 +342,7 @@ git diff --diff-filter=D --name-only "${PREV_TAG}..${NEW_TAG}" -- backend/ || tr
 - `.github/workflows/release.yml` — multi-arch image build 与 prod auto-dispatch。
 - `.github/workflows/deploy-stage0.yml` — prod deploy。
 - `.github/workflows/deploy-edge-stage0.yml` — Edge upgrade/smoke/rollback。
+- `.github/workflows/post-release-light-diagnostics.yml` — all rollout 后 +5min/+1h 自动 dispatch 轻量 diagnostics。
 - `scripts/tk_post_deploy_smoke.sh` — prod 完整 smoke。
 - `scripts/tk_edge_post_deploy_smoke.sh` — Edge smoke wrapper。
 - `deploy/aws/README.md` — Stage0、Edge、多区域升级 SOP。

--- a/.github/workflows/ops-daily-diagnostics.yml
+++ b/.github/workflows/ops-daily-diagnostics.yml
@@ -27,6 +27,18 @@ on:
         description: Error clustering lookback window in hours
         required: false
         default: "24"
+      diagnostics_log_since:
+        description: Diagnostics runtime log lookback (docker logs --since), e.g. 20m, 2h, 1d
+        required: false
+        default: "30m"
+      diagnostics_include_error_clustering:
+        description: Include error clustering in diagnostics (false = lightweight runtime/health only)
+        required: false
+        default: "true"
+        type: choice
+        options:
+          - "true"
+          - "false"
       since:
         description: Log dump lookback window passed to docker logs --since (e.g. 30m, 2h, 1d)
         required: false
@@ -104,6 +116,8 @@ jobs:
     env:
       OIDC_ROLE_ARN: ${{ vars.AWS_OIDC_ROLE_ARN }}
       SINCE_HOURS: ${{ inputs.since_hours || '24' }}
+      DIAGNOSTICS_LOG_SINCE: ${{ inputs.diagnostics_log_since || '30m' }}
+      INCLUDE_ERROR_CLUSTERING: ${{ inputs.diagnostics_include_error_clustering || 'true' }}
       TARGET_ID: ${{ matrix.target_id }}
       TARGET_KIND: ${{ matrix.target_kind }}
       EDGE_ID: ${{ matrix.edge_id }}
@@ -224,8 +238,15 @@ jobs:
           fi
 
           if [ -n "$INSTANCE_ID" ] && [ "$INSTANCE_ID" != "None" ]; then
+            if ! printf '%s' "$DIAGNOSTICS_LOG_SINCE" | grep -Eq '^[0-9]+[smhd]$'; then
+              add_finding "diagnostics_log_since_input" "manual_ops" "error" "Invalid diagnostics_log_since input" "diagnostics_log_since must match ^[0-9]+[smhd]$ (e.g. 20m, 2h, 1d), got: $DIAGNOSTICS_LOG_SINCE" "diagnostics-log-since-input|$DIAGNOSTICS_LOG_SINCE"
+            fi
+
             python3 - <<'PY' > "$OUT/runtime-params.json"
           import json
+          import os
+          import shlex
+          log_since = os.environ["DIAGNOSTICS_LOG_SINCE"]
           commands = [
               "set -euo pipefail",
               "echo ===DOCKER_PS===",
@@ -236,7 +257,7 @@ jobs:
               "sudo docker inspect tokenkey-redis --format 'redis_status={{.State.Status}}' 2>/dev/null || true",
               "sudo docker compose -f /var/lib/tokenkey/docker-compose.yml --env-file /var/lib/tokenkey/.env exec -T tokenkey wget -qO- http://localhost:8080/health",
               "echo ===RECENT_ERRORS===",
-              "sudo docker logs tokenkey --since 30m --tail 300 2>&1 | grep -Ei 'panic|fatal|error|traceback|failed|timeout|refused|denied| 5[0-9][0-9] | 429 ' | tail -80 || true",
+              "sudo docker logs tokenkey --since " + shlex.quote(log_since) + " --tail 300 2>&1 | grep -Ei 'panic|fatal|error|traceback|failed|timeout|refused|denied| 5[0-9][0-9] | 429 ' | tail -80 || true",
           ]
           print(json.dumps({"commands": commands}))
           PY
@@ -263,7 +284,9 @@ jobs:
               add_finding "ssm_send_command" "manual_ops" "error" "Could not send SSM command for $TARGET_ID" "SSM SendCommand failed for $INSTANCE_ID in $TARGET_REGION." "ssm-send|$TARGET_ID"
             fi
 
-            if ! printf '%s' "$SINCE_HOURS" | grep -Eq '^[0-9]+$'; then
+            if [ "$INCLUDE_ERROR_CLUSTERING" != "true" ]; then
+              add_finding "error_clustering" "skip" "info" "Error clustering skipped for $TARGET_ID" "diagnostics_include_error_clustering=false; runtime/health-only lightweight diagnostics." "error-clustering|$TARGET_ID|lightweight-skip"
+            elif ! printf '%s' "$SINCE_HOURS" | grep -Eq '^[0-9]+$'; then
               add_finding "error_clustering_input" "manual_ops" "error" "Invalid since_hours input" "since_hours must be a positive integer, got: $SINCE_HOURS" "error-clustering-input|$SINCE_HOURS"
             else
               if ! CMD_ID="$(aws ssm send-command --region "$TARGET_REGION" --instance-ids "$INSTANCE_ID" --document-name AWS-RunShellScript --comment "check error_clustering binary target=$TARGET_ID" --parameters '{"commands":["test -x /usr/local/bin/error_clustering"]}' --query 'Command.CommandId' --output text 2>>"$STDERR")"; then

--- a/.github/workflows/post-release-light-diagnostics.yml
+++ b/.github/workflows/post-release-light-diagnostics.yml
@@ -1,0 +1,99 @@
+name: Post-release Light Diagnostics
+
+on:
+  workflow_dispatch:
+    inputs:
+      target_selector:
+        description: "Diagnostics target selector (default all for rollout-all)."
+        required: false
+        default: all
+      first_delay_minutes:
+        description: "Delay before first diagnostics dispatch (minutes)."
+        required: false
+        default: "5"
+      first_window:
+        description: "First diagnostics runtime log window (docker logs --since)."
+        required: false
+        default: "20m"
+      second_delay_minutes:
+        description: "Delay before second diagnostics dispatch after first run (minutes)."
+        required: false
+        default: "55"
+      second_window:
+        description: "Second diagnostics runtime log window (docker logs --since)."
+        required: false
+        default: "2h"
+
+permissions:
+  contents: read
+  actions: write
+
+jobs:
+  dispatch:
+    runs-on: ubuntu-latest
+    env:
+      TARGET_SELECTOR: ${{ inputs.target_selector || 'all' }}
+      FIRST_DELAY_MINUTES: ${{ inputs.first_delay_minutes || '5' }}
+      FIRST_WINDOW: ${{ inputs.first_window || '20m' }}
+      SECOND_DELAY_MINUTES: ${{ inputs.second_delay_minutes || '55' }}
+      SECOND_WINDOW: ${{ inputs.second_window || '2h' }}
+      GH_TOKEN: ${{ github.token }}
+    steps:
+      - name: Validate inputs
+        run: |
+          set -euo pipefail
+          if ! printf '%s' "$FIRST_DELAY_MINUTES" | grep -Eq '^[0-9]+$'; then
+            echo "::error::first_delay_minutes must be a non-negative integer, got: $FIRST_DELAY_MINUTES"
+            exit 1
+          fi
+          if ! printf '%s' "$SECOND_DELAY_MINUTES" | grep -Eq '^[0-9]+$'; then
+            echo "::error::second_delay_minutes must be a non-negative integer, got: $SECOND_DELAY_MINUTES"
+            exit 1
+          fi
+          if ! printf '%s' "$FIRST_WINDOW" | grep -Eq '^[0-9]+[smhd]$'; then
+            echo "::error::first_window must match ^[0-9]+[smhd]$, got: $FIRST_WINDOW"
+            exit 1
+          fi
+          if ! printf '%s' "$SECOND_WINDOW" | grep -Eq '^[0-9]+[smhd]$'; then
+            echo "::error::second_window must match ^[0-9]+[smhd]$, got: $SECOND_WINDOW"
+            exit 1
+          fi
+
+      - name: Wait before first diagnostics
+        run: |
+          set -euo pipefail
+          sleep "$(( FIRST_DELAY_MINUTES * 60 ))"
+
+      - name: Dispatch first lightweight diagnostics
+        run: |
+          set -euo pipefail
+          gh workflow run ops-daily-diagnostics.yml \
+            -f operation=diagnostics \
+            -f target_selector="$TARGET_SELECTOR" \
+            -f diagnostics_log_since="$FIRST_WINDOW" \
+            -f diagnostics_include_error_clustering=false
+          {
+            echo "## First light diagnostics"
+            echo "- target_selector: \\`$TARGET_SELECTOR\\`"
+            echo "- diagnostics_log_since: \\`$FIRST_WINDOW\\`"
+          } >> "$GITHUB_STEP_SUMMARY"
+
+      - name: Wait before second diagnostics
+        run: |
+          set -euo pipefail
+          sleep "$(( SECOND_DELAY_MINUTES * 60 ))"
+
+      - name: Dispatch second lightweight diagnostics
+        run: |
+          set -euo pipefail
+          gh workflow run ops-daily-diagnostics.yml \
+            -f operation=diagnostics \
+            -f target_selector="$TARGET_SELECTOR" \
+            -f diagnostics_log_since="$SECOND_WINDOW" \
+            -f diagnostics_include_error_clustering=false
+          {
+            echo "## Second light diagnostics"
+            echo "- target_selector: \\`$TARGET_SELECTOR\\`"
+            echo "- diagnostics_log_since: \\`$SECOND_WINDOW\\`"
+            echo "- note: this run dispatches diagnostics only; inspect ops-daily-diagnostics workflow runs for results."
+          } >> "$GITHUB_STEP_SUMMARY"


### PR DESCRIPTION
## Summary
- add `post-release-light-diagnostics.yml` to auto-dispatch two lightweight diagnostics runs after rollout-all
- extend `ops-daily-diagnostics.yml` with `diagnostics_log_since` and `diagnostics_include_error_clustering` inputs for windowed/lightweight diagnostics
- update `tokenkey-stage0-release-rollout` skill to include the automatic post-rollout diagnostics behavior and trigger command

## Test plan
- [x] `bash scripts/preflight.sh`
- [x] YAML parse check for modified/new workflows

🤖 Generated with [Claude Code](https://claude.com/claude-code)