### PR TITLE
ci(cla): correct Claude allowlist entry to lowercase login

### DIFF
--- a/.github/workflows/cla.yml
+++ b/.github/workflows/cla.yml
@@ -63,16 +63,22 @@ jobs:
           # phase the CLA bot must accept it as already-signed to avoid
           # blocking every cloud-agent PR.
           #
-          # `Claude` is the git author NAME used by Claude Code on the Web /
-          # the Claude Agent SDK when it commits on behalf of the maintainer
-          # (commit.author = "Claude <noreply@anthropic.com>"). The
-          # noreply@anthropic.com address is not linked to a GitHub account,
-          # so extractUserFromCommit falls back to commit.author.name, exactly
-          # like the `yyy` case above. Same rationale as `cursoragent`: this
-          # is a non-human contributor whose work is squashed under the
-          # maintainer's authorship at merge time; the CLA bot must accept it
-          # as already-signed to avoid blocking every Claude-authored PR.
-          allowlist: "dependabot[bot],renovate[bot],bot*,yyy,cursoragent,Claude"
+          # `claude` is the GitHub LOGIN that Anthropic's Claude Code on the
+          # Web / Claude Agent SDK resolves to when it commits as
+          # "Claude <noreply@anthropic.com>". Contrary to the `yyy` case
+          # above, GitHub *does* successfully resolve the
+          # `noreply@anthropic.com` author email to a real account
+          # (github.com/claude, user id 81847), so extractUserFromCommit
+          # returns commit.author.user.login = "claude" — NOT the git author
+          # display name "Claude". Same case-sensitivity pitfall as
+          # `cursoragent`: the allowlist must match the LOWERCASE login, not
+          # the capitalized display name; a previous attempt to allowlist
+          # "Claude" had no effect because the matcher never reached the
+          # name fallback. Like `cursoragent`, this is a non-human
+          # contributor whose commits are squashed under the maintainer's
+          # authorship at merge time; the CLA bot must accept it as
+          # already-signed to avoid blocking every Claude-authored PR.
+          allowlist: "dependabot[bot],renovate[bot],bot*,yyy,cursoragent,claude"
           lock-pullrequest-aftermerge: false
           custom-notsigned-prcomment: |
             Thank you for your contribution! Before we can merge this PR, we need $you to sign our [Contributor License Agreement (CLA)](https://github.com/Wei-Shaw/sub2api/blob/main/CLA.md).
@@ -97,5 +103,5 @@ jobs:
           path-to-signatures: "cla.json"
           path-to-document: "https://github.com/Wei-Shaw/sub2api/blob/main/CLA.md"
           branch: "cla-signatures"
-          allowlist: "dependabot[bot],renovate[bot],bot*,yyy,cursoragent,Claude"
+          allowlist: "dependabot[bot],renovate[bot],bot*,yyy,cursoragent,claude"
           lock-pullrequest-aftermerge: true


### PR DESCRIPTION
## Summary
Hot-fix follow-up to #203. The `Claude` entry I added there had no effect — GitHub resolves `noreply@anthropic.com` to the real account `github.com/claude` (id 81847), so the action's `extractUserFromCommit` returns `login = "claude"` (lowercase), not the git author display name `"Claude"`. Allowlist matching is case-sensitive.

This PR:
- Updates both `cla-check` and `cla-lock` jobs to use `claude` (lowercase).
- Rewrites the rationale comment to document the pitfall accurately so the next reader doesn't repeat my mistake.

## Verification
PR #202 commit `7f757b0` via `mcp__github__get_commit`:
```json
"author": { "login": "claude", "id": 81847,
            "profile_url": "https://github.com/claude" }
```
The case-sensitive caveat is already called out in the existing `cursoragent` comment in this file; the `Claude` entry violated that same rule.

## Risk
- Tiny diff: 1 string change repeated in 2 places + comment rewrite.
- Same self-referential merge problem as #203: this PR's own cla-check will still be red (its base-snapshot workflow doesn't yet contain `claude` lowercase). One-time admin bypass required to merge; afterward, both this PR and the follow-up amend of #202 pass mechanically.

## After merge
Trigger a synchronize event on PR #202 (push any commit, or close+reopen) → cla-check on #202 should turn green using the corrected base-branch allowlist.

---
_Generated by [Claude Code](https://claude.ai/code/session_012awXNunpTiPRjMSV7fbvNZ)_