### PR TITLE
docs(accounts): compare edge OAuth stability settings

### DIFF
--- a/deploy/aws/README.md
+++ b/deploy/aws/README.md
@@ -108,6 +108,8 @@ scripts/stage0_external_health.sh
 
 这保证主网关和 Edge 后续都部署同一个 GHCR image 产物、同一份 `deploy/aws/stage0/docker-compose.yml` 基线、同一套 SSM 原地升级/rollback primitive；差异只来自 Edge target 参数、EC2 profile 和 `Caddyfile.edge` 的 API path allowlist。
 
+**Anthropic OAuth 稳定基线**：新增 Edge 账号时，先按 [`docs/accounts/anthropic-oauth-edge-stability-baseline.md`](../../docs/accounts/anthropic-oauth-edge-stability-baseline.md) 收敛账号行为配置，再用只读检查命令比对线上状态：`python3 scripts/check-edge-anthropic-oauth-stability.py --edge-id <edge_id> --account-name <account_name>`。机器可读基线在 `deploy/aws/stage0/anthropic-oauth-stability-baseline.json`；脚本默认不修改线上，`--emit-sql` 只生成审阅用 SQL。
+
 **GitHub**：每种 Edge 绑定 Environment `edge-<edge_id>`（例如 `edge-uk1`、`edge-fra1`），请在仓库 Settings → Environments 里按需配置 Required reviewer。**`edge-fra1` 的 Variables / Secrets 可与 `edge-uk1` 逐项相同复制**（`EDGE_ACME_EMAIL`、`EDGE_MAIN_GATEWAY_ALLOWED_CIDR`、`EDGE_MAIN_GATEWAY_BASE_URL`、`POST_DEPLOY_SMOKE_CHAT_MODEL`、`MAIN_GATEWAY_EDGE_SMOKE_API_KEY` 等）；**例外**：不要在 fra1 复制一条指向 uk1 路径的 **`EDGE_GHCR_PAT_SSM_NAME`**——该项若在 uk1 里设为 `/tokenkey/edge/uk1/ghcr/pat`，fra1 Environment 应**不设**该变量（workflow 会按矩阵自动用 `/tokenkey/edge/fra1/ghcr/pat`）。仓库级 **`AWS_OIDC_ROLE_ARN`**、**`AWS_OIDC_STACK_REGION`/`AWS_REGION`** 仍与各 Edge 共用，无需按 Environment 重复。
 
 **IAM**：更新 `deploy/aws/cloudformation/cicd-oidc.yaml` 并重部署 **`tokenkey-cicd-oidc`**（部署区域须与仓库变量 **`AWS_OIDC_STACK_REGION`** 一致；未设置时 workflow 使用 `vars.AWS_REGION`，再没有则用 `us-east-1`，与 `docs/approved/deploy-stage0-workflow.md` 默认一致）。模板会为 uk1 / fra1 各输出一个 Edge CloudFormation execution role；Edge workload 仍在各自 `region`（矩阵字段）。

--- a/deploy/aws/stage0/anthropic-oauth-stability-baseline.json
+++ b/deploy/aws/stage0/anthropic-oauth-stability-baseline.json
@@ -1,0 +1,119 @@
+{
+  "schema_version": 1,
+  "description": "Stable Anthropic OAuth account baseline for TokenKey Edge Stage0.",
+  "baseline": {
+    "account": {
+      "platform": "anthropic",
+      "type": "oauth",
+      "proxy_id": null,
+      "concurrency": 3,
+      "load_factor": null,
+      "priority": 1,
+      "rate_multiplier": 1.0,
+      "auto_pause_on_expired": true,
+      "channel_type": 0
+    },
+    "credentials": {
+      "intercept_warmup_requests": true,
+      "temp_unschedulable_enabled": true,
+      "temp_unschedulable_rules": [
+        {
+          "error_code": 429,
+          "keywords": [
+            "rate limit",
+            "too many requests"
+          ],
+          "duration_minutes": 30,
+          "description": "触发限流 - 暂停 30 分钟"
+        }
+      ]
+    },
+    "extra": {
+      "enable_tls_fingerprint": true,
+      "base_rpm": 8,
+      "rpm_strategy": "tiered",
+      "rpm_sticky_buffer": 3,
+      "user_msg_queue_mode": "serialize",
+      "max_sessions": 8,
+      "session_idle_timeout_minutes": 8,
+      "session_id_masking_enabled": true,
+      "cache_ttl_override_enabled": true,
+      "cache_ttl_override_target": "1h",
+      "window_cost_limit": 150,
+      "window_cost_sticky_reserve": 10
+    },
+    "tls_profile": {
+      "name": "claude_cli_nodejs24_fixed",
+      "description": "Fixed Claude CLI / Node.js 24.x ClientHello profile for Anthropic OAuth stability.",
+      "enable_grease": false,
+      "cipher_suites": [
+        4865,
+        4866,
+        4867,
+        49195,
+        49199,
+        49196,
+        49200,
+        52393,
+        52392,
+        49161,
+        49171,
+        49162,
+        49172,
+        156,
+        157,
+        47,
+        53
+      ],
+      "curves": [
+        29,
+        23,
+        24
+      ],
+      "point_formats": [
+        0
+      ],
+      "signature_algorithms": [
+        1027,
+        2052,
+        1025,
+        1283,
+        2053,
+        1281,
+        2054,
+        1537,
+        513
+      ],
+      "alpn_protocols": [
+        "http/1.1"
+      ],
+      "supported_versions": [
+        772,
+        771
+      ],
+      "key_share_groups": [
+        29
+      ],
+      "psk_modes": [
+        1
+      ],
+      "extensions": [
+        0,
+        65037,
+        23,
+        65281,
+        10,
+        11,
+        35,
+        16,
+        5,
+        13,
+        18,
+        51,
+        45,
+        43
+      ]
+    }
+  },
+  "stable_accounts": []
+}

--- a/deploy/aws/stage0/anthropic-oauth-stability-baseline.json
+++ b/deploy/aws/stage0/anthropic-oauth-stability-baseline.json
@@ -40,8 +40,12 @@
       "cache_ttl_override_enabled": true,
       "cache_ttl_override_target": "1h",
       "window_cost_limit": 150,
-      "window_cost_sticky_reserve": 10
+      "window_cost_sticky_reserve": 10,
+      "custom_base_url_enabled": false
     },
+    "extra_absent": [
+      "custom_base_url"
+    ],
     "tls_profile": {
       "name": "claude_cli_nodejs24_fixed",
       "description": "Fixed Claude CLI / Node.js 24.x ClientHello profile for Anthropic OAuth stability.",

--- a/docs/accounts/anthropic-oauth-edge-account-stability-2026-05-14.md
+++ b/docs/accounts/anthropic-oauth-edge-account-stability-2026-05-14.md
@@ -1,0 +1,227 @@
+# Anthropic OAuth Edge 账号稳定性配置对比（线上事实，2026-05-14）
+
+> 范围：只对比线上 `edge-fra1` 的 `cc-fr-fra-ec2-5-1-a` 与线上 `edge-uk1` 的 `cc-en-ld-ec2-16-1-a`。  
+> 原则：只使用本次从线上 AWS SSM + PostgreSQL + 容器日志读取到的事实；不引用历史文档、后台截图或本地猜测。  
+> 脱敏：OAuth token、refresh token、token_type、内部 token version、邮箱、account/org UUID 在本文中脱敏或局部描述，避免把线上身份与凭据写入仓库。
+
+## 证据来源
+
+| Edge | 读取方式 | 线上实例 | 线上域名 | 镜像 | 关键证据 |
+|---|---|---|---|---|---|
+| fra1 | AWS SSM + `tokenkey-postgres` 只读 SQL + `docker logs` | `i-05350d8cc7c838355` | `api-fra1.tokenkey.dev` | `ghcr.io/youxuanxue/sub2api:1.7.31` | SSM command `7552ff9a-4115-4a65-8794-42dcc6a90ec5`, `4bb4aee9-d801-44ee-8f03-8e4da3a116c0`, `67bd3596-17b0-4ed3-80fc-dd2e05c28217` |
+| uk1 | AWS SSM + `tokenkey-postgres` 只读 SQL + `docker logs` | `i-0f6ece892c918ea9a` | `api-uk1.tokenkey.dev` | `ghcr.io/youxuanxue/sub2api:1.7.27` | SSM command `9e1d3f80-c9b0-408a-ba86-16ec99945fe9`, `84da0215-e2b6-42dc-8b2d-a492dd3f651c`, `a7b98dd7-9a7b-4c51-8c57-932aad590693` |
+
+## 总结结论
+
+两个账号当前都不是“TLS 参数没调好”的问题，而是已经进入同一种上游失败状态：
+
+| Edge | 账号 | 当前状态 | 线上错误 | 稳定性含义 |
+|---|---|---|---|---|
+| fra1 | `cc-fr-fra-ec2-5-1-a` | `error` | `Organization disabled (400): This organization has been disabled.` | 组织已被上游禁用；TLS/profile/RPM/session 参数不能恢复这个组织。 |
+| uk1 | `cc-en-ld-ec2-16-1-a` | `error` | `Organization disabled (400): This organization has been disabled.` | 同上；该账号不应继续作为稳定性优化验证对象。 |
+
+稳定性配置层面：
+
+- 两边都已经是固定区域出口、无代理、Anthropic OAuth、默认分组、`concurrency=3`、`base_rpm=8`、串行用户消息队列、session masking、cache TTL override 到 `1h`。
+- fra1 已显式绑定 TLS profile `claude_cli_nodejs24_fixed`，但绑定发生在账号最后一次成功流量之后，因此尚无线上请求证明“绑定后 profile 被实际用于上游请求”。
+- uk1 开启了 `enable_tls_fingerprint=true`，但没有显式 `tls_fingerprint_profile_id`，线上 `tls_fingerprint_profiles` 表为空；按当前产品语义这会退回内置默认 profile，但可审计性弱于 fra1。
+- uk1 镜像 `1.7.27` 落后 fra1 的 `1.7.31`，跨 edge 行为对比会混入版本差异。
+
+## 1. Edge 与部署层对比
+
+| 项目 | fra1 | uk1 | 稳定性解读 | 建议 |
+|---|---|---|---|---|
+| Region | `eu-west-3` | `eu-west-2` | 固定区域出口有利于 OAuth 流量稳定；不要同一账号跨区域漂移。 | 保持每个 OAuth 账号固定绑定一个 edge 出口。 |
+| Domain | `api-fra1.tokenkey.dev` | `api-uk1.tokenkey.dev` | 两边都是独立 edge 入口。 | 正常。 |
+| Instance | `i-05350d8cc7c838355` | `i-0f6ece892c918ea9a` | 单 EC2 edge。 | 正常。 |
+| Image | `sub2api:1.7.31` | `sub2api:1.7.27` | 版本不同会影响 TLS profile、调度、错误处理、缓存行为的可比性。 | 优先把 uk1 升级到与 fra1 相同的已验证版本，再做策略对比。 |
+| Proxy | `NULL` | `NULL` | 不经二级代理，出口身份更稳定。 | 对 OAuth 稳定性是正确方向，继续保持。 |
+
+## 2. 账号主表配置对比
+
+| 字段 | fra1：`cc-fr-fra-ec2-5-1-a` | uk1：`cc-en-ld-ec2-16-1-a` | 作用 | 稳定性评价与建议 |
+|---|---:|---:|---|---|
+| `id` | `1` | `2` | DB 主键。 | 仅用于排障定位。 |
+| `platform` | `anthropic` | `anthropic` | 决定走 Anthropic 网关链路。 | 正确。 |
+| `type` | `oauth` | `oauth` | 使用 OAuth access/refresh token。 | 正确。 |
+| `status` | `error` | `error` | 账号调度状态。 | P0：两个账号都已不可作为健康流量源。 |
+| `error_message` | `Organization disabled (400)` | `Organization disabled (400)` | 上游明确返回组织禁用。 | P0：换健康组织/账号；不要通过 TLS/RPM 参数试图恢复。 |
+| `schedulable` | `true` | `true` | 管理侧是否允许参与调度。 | 虽为 true，但 `status=error` 会阻断实际健康调度；不要只看 schedulable。 |
+| `priority` | `1` | `1` | 调度优先级，数值越小越优先。 | 单账号/主力账号可接受；多账号池建议按健康度分层。 |
+| `concurrency` | `3` | `3` | 最大并发。 | 稳定优先下合理，不建议升高。 |
+| `load_factor` | `NULL` | `NULL` | 空值时通常按 concurrency 作为负载因子。 | 正常。 |
+| `rate_multiplier` | `1.0000` | `1.0000` | 账号计费倍率。 | 正常。 |
+| `proxy_id` | `NULL` | `NULL` | 是否绑定代理。 | 正确：edge 自身即出口，不要叠加不稳定代理。 |
+| `channel_type` | `0` | `0` | New API channel 类型。 | Anthropic 原生 OAuth 应为 0。 |
+| `auto_pause_on_expired` | `true` | `true` | 账号过期后自动暂停。 | 正常。 |
+| `last_used_at` | `2026-05-13 10:03:35 UTC` | `2026-05-12 10:27:09 UTC` | 最后使用时间。 | 两者均已停止有效业务流量；uk1 更早停止。 |
+| `session_window_status` | `allowed` | `allowed` | 5h 窗口状态。 | 不是当前阻断点；阻断点是 organization disabled。 |
+| `session_window_start/end` | `2026-05-13 07:50 → 12:50 UTC` | `2026-05-12 07:10 → 12:10 UTC` | Anthropic OAuth 窗口跟踪。 | 历史窗口，账号 error 后不代表当前健康。 |
+
+## 3. OAuth credentials 对比（脱敏）
+
+| 字段 | fra1 | uk1 | 作用 | 稳定性评价与建议 |
+|---|---|---|---|---|
+| `access_token` | `<redacted>` | `<redacted>` | 上游访问 token。 | 不写入文档；如账号 disabled，刷新 token 也不一定能恢复组织。 |
+| `refresh_token` | `<redacted>` | `<redacted>` | 刷新 access token。 | 同上。 |
+| `token_type` | `<redacted>` | `<redacted>` | 通常是 Bearer。 | 正常但脱敏。 |
+| `scope` | `user:file_upload user:inference user:mcp_servers user:profile user:sessions:claude_code` | 同 fra1 | OAuth 权限范围。 | 两边 scope 都完整，权限范围不是当前问题。 |
+| `account_uuid` | 存在，已脱敏 | 存在，已脱敏 | Anthropic 账号身份。 | 两边都存在。 |
+| `org_uuid` | 存在，已脱敏 | 存在，已脱敏 | Anthropic 组织身份。 | 两边错误都指向组织 disabled。 |
+| `email_address` | 存在，已脱敏 | 存在，已脱敏 | 登录邮箱。 | 不写入仓库。 |
+| `expires_at` | JSON number：`1778670058` | JSON string：`"1778592851"` | access token 过期时间。 | 类型不一致但代码通常兼容；建议新账号导入时统一为 number，减少边界差异。 |
+| `expires_in` | JSON number：`28800` | JSON string：`"28800"` | token TTL。 | 同上，建议统一为 number。 |
+| `_token_version` | 无 | 有，已脱敏 | token 缓存/刷新版本。 | uk1 有额外 token 版本字段；不是当前 disabled 根因。 |
+| `intercept_warmup_requests` | `true` | `true` | 拦截 warmup，减少无效上游调用。 | 正确，建议保留。 |
+| `temp_unschedulable_enabled` | `true` | 未见 | 临时不可调度规则开关。 | fra1 更完整；uk1/新账号建议补齐。 |
+| `temp_unschedulable_rules` | 429 + `rate limit`/`too many requests` → 暂停 30 分钟 | 未见 | 命中可恢复限流时暂停账号。 | 建议新健康账号都启用，避免 429 后继续打流。 |
+
+## 4. extra 稳定性配置对比
+
+| 字段 | fra1 | uk1 | 作用 | 稳定性评价与建议 |
+|---|---:|---:|---|---|
+| `enable_tls_fingerprint` | `true` | `true` | 开启出站 TLS ClientHello 模拟。 | 正确。 |
+| `tls_fingerprint_profile_id` | `1` | 未见 | 绑定显式 TLS 模板。 | fra1 可审计性更好；uk1 建议创建并绑定同名固定 profile。 |
+| `base_rpm` | `8` | `8` | 账号基础 RPM 绿区上限。 | 稳定优先下合理。 |
+| `rpm_strategy` | `tiered` | `tiered` | RPM 三段：绿区、sticky-only、红区。 | 正确；比硬切更平滑。 |
+| `rpm_sticky_buffer` | `3` | `3` | 超过 base_rpm 后 sticky 请求缓冲。 | 偏紧；若目标是会话连续性，健康账号可试 `5`。若严格控流，保留 `3`。 |
+| `user_msg_queue_mode` | `serialize` | `serialize` | 同一用户消息串行。 | 强烈建议保留，OAuth 稳定性优先。 |
+| `max_sessions` | `8` | `10` | 最大会话数。 | uk1 更激进；建议健康新账号以 `8` 作为基线，再按成功率上调。 |
+| `session_idle_timeout_minutes` | `8` | `5` | 会话空闲释放时间。 | uk1 更容易 session churn；建议统一到 `8`，减少会话频繁变化。 |
+| `session_id_masking_enabled` | `true` | `true` | 稳定 `metadata.user_id` 的 session 部分。 | 正确，建议保留。 |
+| `cache_ttl_override_enabled` | `true` | `true` | 强制 cache creation TTL 分类。 | 正确。 |
+| `cache_ttl_override_target` | `1h` | `1h` | 将 cache creation 归入 1h。 | 对 Claude Code 长上下文稳定性有利；成本更高但当前目标是稳定。 |
+| `window_cost_limit` | `200` | `200` | 5h 窗口成本阈值。 | 对单账号偏宽；健康账号建议先用 `100–150` 更早降速。 |
+| `window_cost_sticky_reserve` | `5` | `5` | 窗口超过阈值后的 sticky reserve。 | 偏小；若降低 limit，reserve 建议到 `10`。 |
+| `session_window_utilization` | `0.07` | `0.24` | 最近 5h 用量观测。 | uk1 使用强度高于 fra1。 |
+| `passive_usage_7d_utilization` | `0.02` | `0.13` | 7d 用量观测。 | uk1 使用强度高于 fra1。 |
+| `passive_usage_sampled_at` | `2026-05-13T10:03:33Z` | `2026-05-12T10:25:22Z` | 用量采样时间。 | 均为账号进入 error 前后的历史样本。 |
+| `model_rate_limits` | `claude-3-5-sonnet-20240620`，reset `2026-05-14T03:06:25Z` | `gpt-5.5` 与 `claude-3-7-sonnet-20250219`，reset `2026-05-13` | 模型级限流记忆。 | 均为历史/过期风险字段；uk1 的 `gpt-5.5` 出现在 Anthropic 账号上尤其可疑，建议健康账号初始化时不要继承 stale model limits。 |
+
+## 5. TLS profile 对比
+
+| 项目 | fra1 | uk1 | 稳定性解读 | 建议 |
+|---|---|---|---|---|
+| `enable_tls_fingerprint` | `true` | `true` | 两边都启用 TLS 指纹模拟。 | 正确。 |
+| 显式 `tls_fingerprint_profile_id` | `1` | 无 | fra1 已绑定固定模板；uk1 只启用但无显式模板。 | uk1 应补齐显式模板绑定。 |
+| `tls_fingerprint_profiles` 表 | 1 条：`claude_cli_nodejs24_fixed` | 0 条 | fra1 可审计、可复用；uk1 不可在后台看到具体模板。 | 标准化为显式 profile。 |
+| profile 特征 | Node.js 24.x 风格，`enable_grease=false`，ALPN `http/1.1`，TLS 1.3/1.2，X25519 | 无显式 profile | 固定 ClientHello 有助于减少账号流量形态漂移。 | 健康账号统一使用固定显式模板，不使用随机 profile。 |
+| 线上转发日志 | 最后成功流量仍显示 `Built-in Default (Node.js 24.x)`，发生在绑定显式 profile 之前 | 未捕获到目标账号最近转发日志 | fra1 显式绑定后账号已 error，尚无 post-bind 流量证据。 | 需要健康账号产生请求后再验证日志。 |
+
+fra1 当前 profile 线上事实：
+
+```text
+id = 1
+name = claude_cli_nodejs24_fixed
+enable_grease = false
+alpn_protocols = ["http/1.1"]
+supported_versions = [772, 771]
+key_share_groups = [29]
+extensions = [0,65037,23,65281,10,11,35,16,5,13,18,51,45,43]
+created_at = 2026-05-14 01:57:37 UTC
+```
+
+## 6. 分组与代理对比
+
+| 项目 | fra1 | uk1 | 作用 | 建议 |
+|---|---|---|---|---|
+| Group | `default` / `anthropic` / `active` | `default` / `anthropic` / `active` | 账号所在调度池。 | 正常。 |
+| Group rate_multiplier | `1.0000` | `1.0000` | 分组计费倍率。 | 正常。 |
+| Proxy | `NULL` | `NULL` | 是否经额外代理。 | 对 edge 模式正确；不要引入代理漂移。 |
+
+## 7. usage_logs 线上流量事实
+
+| 指标 | fra1 | uk1 | 解读 |
+|---|---:|---:|---|
+| usage_count | `107` | `1138` | uk1 历史请求量明显更大。 |
+| first_usage | `2026-05-13 07:50:52 UTC` | `2026-05-11 00:24:38 UTC` | uk1 运行更早更久。 |
+| last_usage | `2026-05-13 10:03:35 UTC` | `2026-05-12 10:27:09 UTC` | 两者之后均无成功 usage log。 |
+| total_cost | `33.935008` | `159.929572` | uk1 消耗更高。 |
+| cache_ttl_overridden_count | `99 / 107` | `944 / 1138` | 两边多数请求都应用了 cache TTL override。 |
+
+### 模型分布
+
+| Edge | 模型 | 请求数 | 最后出现 | 平均 duration_ms | 平均 first_token_ms |
+|---|---|---:|---|---:|---:|
+| fra1 | `claude-opus-4-7` | `87` | `2026-05-13 10:03:35 UTC` | `13959.0` | `4380.1` |
+| fra1 | `claude-haiku-4-5-20251001` | `14` | `2026-05-13 09:58:16 UTC` | `10725.6` | `1528.7` |
+| fra1 | `claude-sonnet-4-6` | `6` | `2026-05-13 08:17:23 UTC` | `1121.3` | `959.7` |
+| uk1 | `claude-opus-4-7` | `653` | `2026-05-12 10:07:55 UTC` | `11077.6` | `3078.2` |
+| uk1 | `claude-sonnet-4-6` | `238` | `2026-05-12 10:27:09 UTC` | `11528.8` | `3287.5` |
+| uk1 | `claude-haiku-4-5-20251001` | `121` | `2026-05-12 09:55:28 UTC` | `3740.5` | `1556.4` |
+| uk1 | `claude-opus-4-6` | `114` | `2026-05-12 10:24:07 UTC` | `83829.4` | `1542.4` |
+| uk1 | `claude-haiku-4-5` | `12` | `2026-05-12 02:14:03 UTC` | `2505.8` | `992.8` |
+
+线上事实显示：uk1 的历史负载更高、模型更混杂、存在长时非流式 `claude-opus-4-6` 请求；fra1 负载较低但也在较短时间内进入同类 organization disabled 错误。因此当前不能把“哪个配置更稳”归因到单个参数，优先结论是：两个组织均已不可用。
+
+## 8. 逐项优化建议
+
+### P0：不要继续优化这两个 disabled organization 账号
+
+| 事实 | 判断 | 建议 |
+|---|---|---|
+| 两个账号 `status=error`，错误均为 `Organization disabled (400)` | 上游组织禁用是硬失败，不是 TLS、RPM、session 参数能修复的问题。 | 新建健康 Anthropic OAuth 账号；旧账号保留为事故样本，不再作为流量源。 |
+| fra1 最近日志明确出现 `account_disabled_auth_error` | 继续重试只会产生失败请求。 | 不要简单把 `status` 改回 `active` 继续跑。 |
+
+### P1：标准化健康新账号模板
+
+建议健康新账号采用以下稳定性基线：
+
+| 配置 | 建议值 | 理由 |
+|---|---:|---|
+| 固定 edge | 每个账号固定一个 edge，如 fra1 或 uk1 | 避免同一 OAuth 账号跨地区出口漂移。 |
+| `proxy_id` | `NULL` | edge 本身就是出口，减少代理变量。 |
+| `concurrency` | `3` | 当前两边一致，稳定优先。 |
+| `enable_tls_fingerprint` | `true` | 开启 TLS ClientHello 模拟。 |
+| `tls_fingerprint_profile_id` | 显式绑定固定 Node.js/Claude CLI profile | 可审计、可复用，避免“仅启用但看不到模板”。 |
+| `user_msg_queue_mode` | `serialize` | 降低同一用户并发乱序和突刺。 |
+| `session_id_masking_enabled` | `true` | 降低 `metadata.user_id` session 部分频繁变化。 |
+| `cache_ttl_override_enabled` | `true` | 统一 cache token TTL 行为。 |
+| `cache_ttl_override_target` | `1h` | 对 Claude Code 长上下文更稳定。 |
+| `base_rpm` | `8` | 两边已有基线，保守。 |
+| `rpm_strategy` | `tiered` | 比硬切断更平滑。 |
+| `rpm_sticky_buffer` | `3` 起步；若重视会话连续性可试 `5` | `3` 更保守，`5` 更有利于 sticky 会话不断流。 |
+| `max_sessions` | `8` 起步 | uk1 的 `10` 更激进；建议先按 fra1 的 `8` 起步。 |
+| `session_idle_timeout_minutes` | `8` | 比 uk1 的 `5` 更少 session churn。 |
+| `window_cost_limit` | `100–150` 起步 | 当前两边 `200` 对单账号偏宽，较晚降速。 |
+| `window_cost_sticky_reserve` | `10` | 当前 `5` 偏小；配合 lower limit 更平滑。 |
+| `intercept_warmup_requests` | `true` | 减少 warmup 对上游账号的噪音。 |
+| `temp_unschedulable_enabled/rules` | 开启 429 暂停规则 | fra1 有，uk1 缺；建议新账号统一配置。 |
+
+### P1：先消除 edge 版本差异
+
+| 事实 | 风险 | 建议 |
+|---|---|---|
+| fra1 镜像 `1.7.31`，uk1 镜像 `1.7.27` | 行为差异可能来自版本，而非账号配置。 | 在继续做 A/B 之前，把 uk1 升级到同一版本。 |
+
+### P1：为 uk1 补齐显式 TLS profile
+
+| 事实 | 风险 | 建议 |
+|---|---|---|
+| uk1 `enable_tls_fingerprint=true` 但 `tls_fingerprint_profiles` 表为空，且账号无 `tls_fingerprint_profile_id` | 只能依赖内置默认；后台不可审计，不利于跨 edge 对齐。 | 在 uk1 创建与 fra1 同名同值 profile，并绑定新健康账号。旧 disabled 账号不建议继续修。 |
+
+### P2：清理不要继承的历史状态
+
+| 字段 | 事实 | 建议 |
+|---|---|---|
+| `model_rate_limits` | fra1/uk1 都有历史限流条目，uk1 甚至有 `gpt-5.5` 这种与 Anthropic 账号不匹配的键 | 新账号初始化时不要复制旧账号的 `model_rate_limits`。 |
+| `session_window_utilization` / `passive_usage_*` | 都是账号停止前的历史观测值 | 新账号应从空观测开始，让系统重新采样。 |
+| `expires_at` / `expires_in` 类型 | fra1 是 number，uk1 是 string | 新导入统一用 number，减少解析分支。 |
+
+## 9. 推荐执行顺序
+
+1. 不再将这两个 `Organization disabled` 账号作为稳定性优化对象。
+2. 先把 uk1 升级到与 fra1 相同的线上版本，减少变量。
+3. 为每个 edge 新建健康 Anthropic OAuth 账号。
+4. 套用同一套稳定性基线：固定 edge、无代理、显式 TLS profile、serialize 队列、session masking、1h cache TTL、保守 RPM/session/window 限制。
+5. 小流量 smoke：先 Haiku/Sonnet，再 Opus；观察 400/401/403/429/529 分类。
+6. 只有在账号 `status=active` 且产生新请求后，才验证 TLS profile 是否在转发日志中实际生效。
+
+## 10. 本次不建议立即修改的项
+
+| 项 | 原因 |
+|---|---|
+| 直接把两个账号 `status` 从 `error` 改回 `active` | 上游已经返回 organization disabled；强行恢复只会继续失败。 |
+| 继续提高 concurrency / max_sessions | 当前目标是稳定，不是吞吐；两个账号已经 disabled，不能证明高并发安全。 |
+| 给 edge 账号叠加代理 | 会引入出口身份漂移，与 edge 固定出口目标冲突。 |
+| 用旧账号配置完整复制到新账号 | 会复制 stale `model_rate_limits`、usage utilization、历史窗口状态。 |

--- a/docs/accounts/anthropic-oauth-edge-stability-baseline.md
+++ b/docs/accounts/anthropic-oauth-edge-stability-baseline.md
@@ -84,6 +84,8 @@ python3 scripts/check-edge-anthropic-oauth-stability.py \
 | `cache_ttl_override_target` | `1h` | 对 Claude Code 长上下文更稳定。 |
 | `window_cost_limit` | `150` | 比旧线上样本的 `200` 更早进入保护。 |
 | `window_cost_sticky_reserve` | `10` | 超过窗口阈值后保留 sticky 连续性。 |
+| `custom_base_url_enabled` | `false` | 禁止 Anthropic OAuth 账号绕过本 Edge 出口改走自定义 relay。 |
+| `custom_base_url` | 不存在 / 空 | 关闭自定义 relay 后不保留出站 URL 残留。 |
 
 ### TLS profile
 
@@ -170,7 +172,8 @@ python3 scripts/check-edge-anthropic-oauth-stability.py \
 
 - 只接受 `edge-targets.json` 中存在且 `deployable=true` 的 edge。
 - 线上查询只读取 `platform='anthropic' AND type='oauth' AND deleted_at IS NULL` 的账号。
+- 会把 `custom_base_url_enabled=true` 或残留 `custom_base_url` 判为 drift，避免账号改走非 Edge 出站路径。
 - 不回显 OAuth token、邮箱、account UUID 或 org UUID。
-- `--emit-sql` 只写本地 SQL 文件，不执行。
+- `--emit-sql` 只写本地 SQL 文件，不执行；生成内容会关闭自定义 base URL 并移除残留 URL。
 - `--update-stable-list` 只更新 repo 内 JSON，必须显式确认。
 - 首版没有线上 `--apply`，避免把生产数据库写入和清单维护混在一个低门槛命令里。

--- a/docs/accounts/anthropic-oauth-edge-stability-baseline.md
+++ b/docs/accounts/anthropic-oauth-edge-stability-baseline.md
@@ -1,0 +1,176 @@
+# Edge Anthropic OAuth 稳定配置基线
+
+本清单把 `docs/accounts/anthropic-oauth-edge-account-stability-2026-05-14.md` 中的线上事实固化成可复用基线，用于新增或巡检 Edge Stage0 Anthropic OAuth 账号。
+
+目标不是复制旧账号状态，而是复制稳定行为：固定 edge 出口、无二级代理、固定 TLS ClientHello、串行用户消息、稳定 session/cache 行为、保守 RPM 与窗口成本保护。
+
+机器可读源：`deploy/aws/stage0/anthropic-oauth-stability-baseline.json`。
+
+## 快速命令
+
+只读检查线上账号与稳定基线的差异：
+
+```bash
+python3 scripts/check-edge-anthropic-oauth-stability.py \
+  --edge-id fra1 \
+  --account-name cc-fr-fra-ec2-5-1-a
+```
+
+输出 JSON：
+
+```bash
+python3 scripts/check-edge-anthropic-oauth-stability.py \
+  --edge-id fra1 \
+  --account-name cc-fr-fra-ec2-5-1-a \
+  --json
+```
+
+只生成修正 SQL，不执行线上更新：
+
+```bash
+python3 scripts/check-edge-anthropic-oauth-stability.py \
+  --edge-id uk1 \
+  --account-name cc-en-ld-ec2-16-1-a \
+  --emit-sql /tmp/uk1-oauth-stability.sql
+```
+
+登记一个账号到稳定名单，仅修改本仓库 JSON，不访问线上：
+
+```bash
+python3 scripts/check-edge-anthropic-oauth-stability.py \
+  --edge-id fra1 \
+  --account-name cc-fr-fra-ec2-5-1-a \
+  --update-stable-list \
+  --confirm yes-update-anthropic-stable-list
+```
+
+## 稳定基线字段
+
+### Account 顶层字段
+
+| 字段 | 基线 | 作用 |
+|---|---:|---|
+| `platform` | `anthropic` | 固定 Anthropic 原生网关链路。 |
+| `type` | `oauth` | 固定 OAuth 账号类型。 |
+| `proxy_id` | `null` | Edge 本身作为出口，不叠加二级代理。 |
+| `concurrency` | `3` | 保守并发上限。 |
+| `load_factor` | `null` | 空值时按并发作为负载因子。 |
+| `priority` | `1` | 单 edge 主账号优先级。 |
+| `rate_multiplier` | `1.0` | 默认账号倍率。 |
+| `auto_pause_on_expired` | `true` | 到期自动暂停。 |
+| `channel_type` | `0` | Anthropic 原生账号不走 New API channel。 |
+
+### Credentials 配置字段
+
+| 字段 | 基线 | 作用 |
+|---|---:|---|
+| `intercept_warmup_requests` | `true` | 减少 warmup 对上游账号的噪音。 |
+| `temp_unschedulable_enabled` | `true` | 启用可恢复错误的临时暂停。 |
+| `temp_unschedulable_rules` | 429 + `rate limit`/`too many requests` 暂停 30 分钟 | 避免限流后继续打流。 |
+
+### Extra 配置字段
+
+| 字段 | 基线 | 作用 |
+|---|---:|---|
+| `enable_tls_fingerprint` | `true` | 启用出站 TLS ClientHello 模拟。 |
+| `base_rpm` | `8` | 基础 RPM 绿区。 |
+| `rpm_strategy` | `tiered` | 绿区、sticky-only、红区三段保护。 |
+| `rpm_sticky_buffer` | `3` | 超过 base_rpm 后的 sticky 缓冲。会话连续性优先时可人工评估升到 `5`。 |
+| `user_msg_queue_mode` | `serialize` | 同一用户消息串行，减少突刺和乱序。 |
+| `max_sessions` | `8` | 保守会话数上限。 |
+| `session_idle_timeout_minutes` | `8` | 降低过快 session churn。 |
+| `session_id_masking_enabled` | `true` | 稳定 `metadata.user_id` 的 session 部分。 |
+| `cache_ttl_override_enabled` | `true` | 统一 cache creation TTL。 |
+| `cache_ttl_override_target` | `1h` | 对 Claude Code 长上下文更稳定。 |
+| `window_cost_limit` | `150` | 比旧线上样本的 `200` 更早进入保护。 |
+| `window_cost_sticky_reserve` | `10` | 超过窗口阈值后保留 sticky 连续性。 |
+
+### TLS profile
+
+基线要求显式 profile，而不是只开启 `enable_tls_fingerprint` 后依赖内置默认。脚本会单独 diff `tls_fingerprint_profiles` 内容。
+
+| 字段 | 基线 |
+|---|---|
+| `name` | `claude_cli_nodejs24_fixed` |
+| `enable_grease` | `false` |
+| `alpn_protocols` | `["http/1.1"]` |
+| `supported_versions` | `[772, 771]` |
+| `key_share_groups` | `[29]` |
+
+完整 cipher suites、curves、signature algorithms 和 extensions 以 `deploy/aws/stage0/anthropic-oauth-stability-baseline.json` 为准。
+
+## 明确排除字段
+
+以下字段是运行态、观测值、身份值或敏感值，不应复制到稳定基线，也不参与 diff：
+
+- `status`
+- `error_message`
+- `last_used_at`
+- `created_at`
+- `updated_at`
+- `schedulable`
+- `rate_limited_at`
+- `rate_limit_reset_at`
+- `overload_until`
+- `temp_unschedulable_until`
+- `temp_unschedulable_reason`
+- `session_window_start`
+- `session_window_end`
+- `session_window_status`
+- `model_rate_limits`
+- `session_window_utilization`
+- `passive_usage_7d_utilization`
+- `passive_usage_7d_reset`
+- `passive_usage_sampled_at`
+- `access_token`
+- `refresh_token`
+- `token_type`
+- `account_uuid`
+- `org_uuid`
+- `email_address`
+
+## 新 Edge 接入流程
+
+1. 在 `deploy/aws/stage0/edge-targets.json` 中确认 edge 已 `deployable=true`。
+2. 在目标 edge 创建健康 Anthropic OAuth 账号。
+3. 不绑定二级代理，让账号固定使用该 edge 出口。
+4. 确认或创建 `claude_cli_nodejs24_fixed` TLS profile。
+5. 运行只读 diff：
+
+   ```bash
+   python3 scripts/check-edge-anthropic-oauth-stability.py \
+     --edge-id <edge-id> \
+     --account-name <account-name>
+   ```
+
+6. 如有 drift，先生成 SQL 审阅：
+
+   ```bash
+   python3 scripts/check-edge-anthropic-oauth-stability.py \
+     --edge-id <edge-id> \
+     --account-name <account-name> \
+     --emit-sql /tmp/<edge-id>-oauth-stability.sql
+   ```
+
+7. 人工审阅 SQL，确认不含 token、邮箱、UUID 后再决定是否手动执行。
+8. 小流量 smoke：先 Haiku/Sonnet，再 Opus，观察 400/401/403/429/529 分类。
+9. 账号保持 `active` 且请求成功后，登记到稳定名单：
+
+   ```bash
+   python3 scripts/check-edge-anthropic-oauth-stability.py \
+     --edge-id <edge-id> \
+     --account-name <account-name> \
+     --update-stable-list \
+     --confirm yes-update-anthropic-stable-list
+   ```
+
+## 脚本安全边界
+
+`scripts/check-edge-anthropic-oauth-stability.py` 的默认行为是只读：
+
+- 只接受 `edge-targets.json` 中存在且 `deployable=true` 的 edge。
+- 线上查询只读取 `platform='anthropic' AND type='oauth' AND deleted_at IS NULL` 的账号。
+- 不回显 OAuth token、邮箱、account UUID 或 org UUID。
+- `--emit-sql` 只写本地 SQL 文件，不执行。
+- `--update-stable-list` 只更新 repo 内 JSON，必须显式确认。
+- 首版没有线上 `--apply`，避免把生产数据库写入和清单维护混在一个低门槛命令里。

--- a/scripts/check-edge-anthropic-oauth-stability.py
+++ b/scripts/check-edge-anthropic-oauth-stability.py
@@ -1,0 +1,501 @@
+#!/usr/bin/env python3
+from __future__ import annotations
+
+import argparse
+import datetime as dt
+import json
+import pathlib
+import subprocess
+import sys
+from typing import Any
+
+REPO_ROOT = pathlib.Path(__file__).resolve().parents[1]
+DEFAULT_MATRIX = REPO_ROOT / "deploy/aws/stage0/edge-targets.json"
+DEFAULT_BASELINE = REPO_ROOT / "deploy/aws/stage0/anthropic-oauth-stability-baseline.json"
+CONFIRM_UPDATE = "yes-update-anthropic-stable-list"
+
+
+def fail(message: str) -> None:
+    print(f"::error::{message}", file=sys.stderr)
+    raise SystemExit(2)
+
+
+def log(message: str, *, quiet: bool = False) -> None:
+    if not quiet:
+        print(message)
+
+
+def load_json(path: pathlib.Path) -> dict[str, Any]:
+    if not path.is_file():
+        fail(f"file not found: {path}")
+    try:
+        return json.loads(path.read_text(encoding="utf-8"))
+    except json.JSONDecodeError as exc:
+        fail(f"invalid JSON in {path}: {exc}")
+
+
+def write_json(path: pathlib.Path, data: dict[str, Any]) -> None:
+    path.write_text(json.dumps(data, ensure_ascii=False, indent=2, sort_keys=False) + "\n", encoding="utf-8")
+
+
+def run_cmd(args: list[str], *, input_text: str | None = None) -> str:
+    try:
+        proc = subprocess.run(
+            args,
+            input=input_text,
+            text=True,
+            check=False,
+            stdout=subprocess.PIPE,
+            stderr=subprocess.PIPE,
+        )
+    except FileNotFoundError:
+        fail(f"command not found: {args[0]}")
+    if proc.returncode != 0:
+        stderr = proc.stderr.strip()
+        stdout = proc.stdout.strip()
+        detail = stderr or stdout or f"exit {proc.returncode}"
+        fail(f"command failed: {' '.join(args)}\n{detail}")
+    return proc.stdout
+
+
+def resolve_edge(matrix: dict[str, Any], edge_id: str, *, allow_planned: bool = False) -> dict[str, Any]:
+    targets = matrix.get("targets") or {}
+    target = targets.get(edge_id)
+    if target is None:
+        fail(f"unknown edge_id {edge_id}; known edges: {', '.join(sorted(targets))}")
+    if not target.get("deployable") and not allow_planned:
+        fail(f"edge_id {edge_id} is planned but not deployable")
+    for key in ("region", "stack", "domain", "ssm_prefix"):
+        if not target.get(key):
+            fail(f"edge_id {edge_id} missing required field {key}")
+    return {
+        "edge_id": edge_id,
+        "region": target["region"],
+        "stack": target["stack"],
+        "domain": target["domain"],
+        "ssm_prefix": target["ssm_prefix"],
+    }
+
+
+def resolve_instance_id(edge: dict[str, Any], instance_id: str) -> str:
+    if instance_id:
+        return instance_id
+    out = run_cmd([
+        "aws",
+        "cloudformation",
+        "describe-stacks",
+        "--region",
+        edge["region"],
+        "--stack-name",
+        edge["stack"],
+        "--query",
+        "Stacks[0].Outputs[?OutputKey==`InstanceId`].OutputValue",
+        "--output",
+        "text",
+    ]).strip()
+    if not out or out == "None":
+        fail(f"could not resolve InstanceId from stack {edge['stack']}")
+    return out
+
+
+def sql_literal(value: str) -> str:
+    return "'" + value.replace("'", "''") + "'"
+
+
+def build_live_query(account_name: str) -> str:
+    return f"""
+WITH target AS (
+  SELECT * FROM accounts
+  WHERE name = {sql_literal(account_name)}
+    AND platform = 'anthropic'
+    AND type = 'oauth'
+    AND deleted_at IS NULL
+  ORDER BY id
+  LIMIT 1
+), account_stable AS (
+  SELECT CASE WHEN COUNT(*) = 0 THEN NULL ELSE jsonb_build_object(
+    'id', max(id),
+    'name', max(name),
+    'platform', max(platform),
+    'type', max(type),
+    'proxy_id', max(proxy_id),
+    'concurrency', max(concurrency),
+    'load_factor', max(load_factor),
+    'priority', max(priority),
+    'rate_multiplier', max(rate_multiplier),
+    'auto_pause_on_expired', bool_or(auto_pause_on_expired),
+    'channel_type', max(channel_type),
+    'status', max(status),
+    'error_message', max(error_message),
+    'last_used_at', max(last_used_at)
+  ) END AS value
+  FROM target
+), credentials_stable AS (
+  SELECT COALESCE(jsonb_object_agg(key, value ORDER BY key), '{{}}'::jsonb) AS value
+  FROM target, jsonb_each(credentials)
+  WHERE key IN (
+    'intercept_warmup_requests',
+    'temp_unschedulable_enabled',
+    'temp_unschedulable_rules'
+  )
+), extra_stable AS (
+  SELECT COALESCE(jsonb_object_agg(key, value ORDER BY key), '{{}}'::jsonb) AS value
+  FROM target, jsonb_each(extra)
+  WHERE key IN (
+    'enable_tls_fingerprint',
+    'tls_fingerprint_profile_id',
+    'base_rpm',
+    'rpm_strategy',
+    'rpm_sticky_buffer',
+    'user_msg_queue_mode',
+    'max_sessions',
+    'session_idle_timeout_minutes',
+    'session_id_masking_enabled',
+    'cache_ttl_override_enabled',
+    'cache_ttl_override_target',
+    'window_cost_limit',
+    'window_cost_sticky_reserve',
+    'custom_base_url_enabled',
+    'custom_base_url'
+  )
+), group_stable AS (
+  SELECT COALESCE(jsonb_agg(g.name ORDER BY g.name), '[]'::jsonb) AS names,
+         COALESCE(jsonb_agg(g.id ORDER BY g.id), '[]'::jsonb) AS ids
+  FROM target t
+  LEFT JOIN account_groups ag ON ag.account_id = t.id
+  LEFT JOIN groups g ON g.id = ag.group_id
+  WHERE g.id IS NOT NULL
+), tls_profile AS (
+  SELECT CASE WHEN p.id IS NULL THEN NULL ELSE jsonb_build_object(
+    'name', p.name,
+    'description', p.description,
+    'enable_grease', p.enable_grease,
+    'cipher_suites', COALESCE(p.cipher_suites, '[]'::jsonb),
+    'curves', COALESCE(p.curves, '[]'::jsonb),
+    'point_formats', COALESCE(p.point_formats, '[]'::jsonb),
+    'signature_algorithms', COALESCE(p.signature_algorithms, '[]'::jsonb),
+    'alpn_protocols', COALESCE(p.alpn_protocols, '[]'::jsonb),
+    'supported_versions', COALESCE(p.supported_versions, '[]'::jsonb),
+    'key_share_groups', COALESCE(p.key_share_groups, '[]'::jsonb),
+    'psk_modes', COALESCE(p.psk_modes, '[]'::jsonb),
+    'extensions', COALESCE(p.extensions, '[]'::jsonb)
+  ) END AS value
+  FROM target t
+  LEFT JOIN tls_fingerprint_profiles p ON p.id = NULLIF(t.extra->>'tls_fingerprint_profile_id', '')::bigint
+)
+SELECT jsonb_pretty(jsonb_build_object(
+  'found', EXISTS(SELECT 1 FROM target),
+  'account', (SELECT value FROM account_stable),
+  'credentials', (SELECT value FROM credentials_stable),
+  'extra', (SELECT value FROM extra_stable),
+  'groups', jsonb_build_object('ids', (SELECT ids FROM group_stable), 'names', (SELECT names FROM group_stable)),
+  'tls_profile', (SELECT value FROM tls_profile)
+));
+""".strip()
+
+
+def read_live_account(edge: dict[str, Any], instance_id: str, account_name: str) -> dict[str, Any]:
+    remote = "sudo docker exec -i tokenkey-postgres psql -U tokenkey -d tokenkey -t -A -v ON_ERROR_STOP=1"
+    command = f"set -euo pipefail\n{remote} <<'SQL'\n{build_live_query(account_name)}\nSQL"
+    params = json.dumps({"commands": [command]}, ensure_ascii=False)
+    cmd_id = run_cmd([
+        "aws",
+        "ssm",
+        "send-command",
+        "--region",
+        edge["region"],
+        "--instance-ids",
+        instance_id,
+        "--document-name",
+        "AWS-RunShellScript",
+        "--comment",
+        f"check Anthropic OAuth stability edge={edge['edge_id']} account={account_name}",
+        "--parameters",
+        params,
+        "--query",
+        "Command.CommandId",
+        "--output",
+        "text",
+    ]).strip()
+    run_cmd([
+        "aws",
+        "ssm",
+        "wait",
+        "command-executed",
+        "--region",
+        edge["region"],
+        "--command-id",
+        cmd_id,
+        "--instance-id",
+        instance_id,
+    ])
+    stdout = run_cmd([
+        "aws",
+        "ssm",
+        "get-command-invocation",
+        "--region",
+        edge["region"],
+        "--command-id",
+        cmd_id,
+        "--instance-id",
+        instance_id,
+        "--query",
+        "StandardOutputContent",
+        "--output",
+        "text",
+    ]).strip()
+    try:
+        data = json.loads(stdout)
+    except json.JSONDecodeError as exc:
+        fail(f"failed to parse live account JSON from SSM command {cmd_id}: {exc}\n{stdout[:1000]}")
+    data["ssm_command_id"] = cmd_id
+    return data
+
+
+def normalize_scalar(value: Any) -> Any:
+    if isinstance(value, float) and value.is_integer():
+        return int(value)
+    return value
+
+
+def normalize_value(value: Any) -> Any:
+    if isinstance(value, dict):
+        return {key: normalize_value(value[key]) for key in sorted(value)}
+    if isinstance(value, list):
+        return [normalize_value(item) for item in value]
+    return normalize_scalar(value)
+
+
+def diff_dict(section: str, expected: dict[str, Any], actual: dict[str, Any] | None) -> list[dict[str, Any]]:
+    actual = actual or {}
+    diffs: list[dict[str, Any]] = []
+    for key, expected_value in expected.items():
+        actual_value = actual.get(key)
+        if normalize_value(actual_value) != normalize_value(expected_value):
+            diffs.append({
+                "path": f"/{section}/{key}",
+                "expected": expected_value,
+                "actual": actual_value,
+            })
+    return diffs
+
+
+def compare_live_to_baseline(live: dict[str, Any], baseline: dict[str, Any]) -> list[dict[str, Any]]:
+    if not live.get("found"):
+        return [{"path": "/account", "expected": "existing anthropic oauth account", "actual": None}]
+    base = baseline.get("baseline") or {}
+    diffs: list[dict[str, Any]] = []
+    diffs.extend(diff_dict("account", base.get("account") or {}, live.get("account") or {}))
+    diffs.extend(diff_dict("credentials", base.get("credentials") or {}, live.get("credentials") or {}))
+    diffs.extend(diff_dict("extra", base.get("extra") or {}, live.get("extra") or {}))
+    diffs.extend(diff_dict("tls_profile", base.get("tls_profile") or {}, live.get("tls_profile") or {}))
+    return diffs
+
+
+def pg_json(value: Any) -> str:
+    return sql_literal(json.dumps(value, ensure_ascii=False, separators=(",", ":"))) + "::jsonb"
+
+
+def pg_array_json(value: Any) -> str:
+    return pg_json(value)
+
+
+def generate_sql(edge: dict[str, Any], account_name: str, baseline: dict[str, Any]) -> str:
+    base = baseline.get("baseline") or {}
+    account = base.get("account") or {}
+    credentials = base.get("credentials") or {}
+    extra = dict(base.get("extra") or {})
+    profile = base.get("tls_profile") or {}
+    generated_at = dt.datetime.now(dt.UTC).replace(microsecond=0).isoformat()
+
+    profile_name = profile.get("name")
+    if not profile_name:
+        fail("baseline.tls_profile.name is required to generate SQL")
+
+    profile_columns = [
+        "name",
+        "description",
+        "enable_grease",
+        "cipher_suites",
+        "curves",
+        "point_formats",
+        "signature_algorithms",
+        "alpn_protocols",
+        "supported_versions",
+        "key_share_groups",
+        "psk_modes",
+        "extensions",
+    ]
+    insert_values = []
+    for column in profile_columns:
+        value = profile.get(column)
+        if column in ("name", "description"):
+            insert_values.append("NULL" if value is None else sql_literal(str(value)))
+        elif column == "enable_grease":
+            insert_values.append("true" if bool(value) else "false")
+        else:
+            insert_values.append(pg_array_json(value or []))
+
+    conflict_sets = [f"{column} = EXCLUDED.{column}" for column in profile_columns if column != "name"]
+    conflict_sets.append("updated_at = NOW()")
+
+    account_sets = []
+    for key in ("proxy_id", "concurrency", "load_factor", "priority", "rate_multiplier", "auto_pause_on_expired", "channel_type"):
+        if key not in account:
+            continue
+        value = account[key]
+        if value is None:
+            if key in ("proxy_id", "load_factor"):
+                account_sets.append(f"{key} = NULL")
+        elif isinstance(value, bool):
+            account_sets.append(f"{key} = {'true' if value else 'false'}")
+        elif isinstance(value, str):
+            account_sets.append(f"{key} = {sql_literal(value)}")
+        else:
+            account_sets.append(f"{key} = {value}")
+
+    extra["tls_fingerprint_profile_id"] = "__PROFILE_ID__"
+    extra_items = []
+    for key, value in extra.items():
+        if value == "__PROFILE_ID__":
+            extra_items.append(f"{sql_literal(key)}, (SELECT id FROM profile)")
+        else:
+            extra_items.append(f"{sql_literal(key)}, {pg_json(value)}")
+    extra_object = "jsonb_build_object(" + ", ".join(extra_items) + ")"
+
+    statements = [
+        "-- Generated by scripts/check-edge-anthropic-oauth-stability.py",
+        f"-- edge_id: {edge['edge_id']}",
+        f"-- account_name: {account_name}",
+        f"-- generated_at: {generated_at}",
+        "-- Review before running. This SQL does not contain OAuth access/refresh tokens.",
+        "BEGIN;",
+        "WITH profile AS (",
+        "  INSERT INTO tls_fingerprint_profiles (" + ", ".join(profile_columns) + ", created_at, updated_at)",
+        "  VALUES (" + ", ".join(insert_values) + ", NOW(), NOW())",
+        "  ON CONFLICT (name) DO UPDATE SET " + ", ".join(conflict_sets),
+        "  RETURNING id",
+        "), target AS (",
+        "  SELECT id FROM accounts",
+        f"  WHERE name = {sql_literal(account_name)} AND platform = 'anthropic' AND type = 'oauth' AND deleted_at IS NULL",
+        "  ORDER BY id LIMIT 1",
+        "), updated AS (",
+        "  UPDATE accounts a",
+        "  SET",
+    ]
+    set_lines = [f"      {item}" for item in account_sets]
+    set_lines.append(f"      credentials = COALESCE(a.credentials, '{{}}'::jsonb) || {pg_json(credentials)}")
+    set_lines.append(f"      extra = COALESCE(a.extra, '{{}}'::jsonb) || {extra_object}")
+    set_lines.append("      updated_at = NOW()")
+    statements.append(",\n".join(set_lines))
+    statements.extend([
+        "  FROM target",
+        "  WHERE a.id = target.id",
+        "  RETURNING a.id, a.name",
+        ")",
+        "SELECT * FROM updated;",
+        "COMMIT;",
+        "",
+    ])
+    return "\n".join(statements)
+
+
+def update_stable_list(path: pathlib.Path, data: dict[str, Any], edge_id: str, account_name: str) -> None:
+    entries = data.setdefault("stable_accounts", [])
+    now = dt.datetime.now(dt.UTC).replace(microsecond=0).isoformat()
+    found = False
+    for entry in entries:
+        if entry.get("edge_id") == edge_id and entry.get("account_name") == account_name:
+            entry["updated_at"] = now
+            entry.setdefault("source", "manual-confirmed")
+            found = True
+            break
+    if not found:
+        entries.append({
+            "edge_id": edge_id,
+            "account_name": account_name,
+            "added_at": now,
+            "source": "manual-confirmed",
+            "notes": "Added by check-edge-anthropic-oauth-stability.py after operator confirmation."
+        })
+    entries.sort(key=lambda item: (item.get("edge_id", ""), item.get("account_name", "")))
+    write_json(path, data)
+
+
+def format_diff(diffs: list[dict[str, Any]]) -> str:
+    lines = []
+    for item in diffs:
+        lines.append(f"- {item['path']}: expected={json.dumps(item['expected'], ensure_ascii=False)} actual={json.dumps(item['actual'], ensure_ascii=False)}")
+    return "\n".join(lines)
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser(description="Check Edge Anthropic OAuth account stability baseline drift.")
+    parser.add_argument("--edge-id", required=True)
+    parser.add_argument("--account-name", required=True)
+    parser.add_argument("--matrix", default=str(DEFAULT_MATRIX))
+    parser.add_argument("--baseline", default=str(DEFAULT_BASELINE))
+    parser.add_argument("--instance-id", default="")
+    parser.add_argument("--allow-planned", action="store_true")
+    parser.add_argument("--json", action="store_true")
+    parser.add_argument("--quiet", action="store_true")
+    parser.add_argument("--emit-sql", default="")
+    parser.add_argument("--update-stable-list", action="store_true")
+    parser.add_argument("--confirm", default="")
+    args = parser.parse_args()
+
+    if args.json and args.quiet:
+        fail("--json and --quiet are mutually exclusive")
+
+    matrix_path = pathlib.Path(args.matrix)
+    baseline_path = pathlib.Path(args.baseline)
+    matrix = load_json(matrix_path)
+    baseline = load_json(baseline_path)
+    edge = resolve_edge(matrix, args.edge_id, allow_planned=args.allow_planned)
+
+    if args.update_stable_list:
+        if args.confirm != CONFIRM_UPDATE:
+            fail(f"--update-stable-list requires --confirm {CONFIRM_UPDATE}")
+        update_stable_list(baseline_path, baseline, args.edge_id, args.account_name)
+        log(f"updated stable_accounts in {baseline_path}: edge={args.edge_id} account={args.account_name}", quiet=args.quiet)
+        return 0
+
+    instance_id = resolve_instance_id(edge, args.instance_id)
+    live = read_live_account(edge, instance_id, args.account_name)
+    diffs = compare_live_to_baseline(live, baseline)
+
+    if args.emit_sql:
+        sql_path = pathlib.Path(args.emit_sql)
+        sql_path.write_text(generate_sql(edge, args.account_name, baseline), encoding="utf-8")
+
+    result = {
+        "edge": {**edge, "instance_id": instance_id},
+        "account_name": args.account_name,
+        "ssm_command_id": live.get("ssm_command_id"),
+        "status": "ok" if not diffs else "drift",
+        "diff_count": len(diffs),
+        "diffs": diffs,
+        "sql_path": args.emit_sql or None,
+    }
+
+    if args.json:
+        print(json.dumps(result, ensure_ascii=False, indent=2, sort_keys=True))
+    elif not args.quiet:
+        print(f"edge_id={args.edge_id}")
+        print(f"account_name={args.account_name}")
+        print(f"region={edge['region']}")
+        print(f"instance_id={instance_id}")
+        print(f"ssm_command_id={live.get('ssm_command_id')}")
+        print(f"status={result['status']}")
+        print(f"diff_count={len(diffs)}")
+        if diffs:
+            print("\nDiff:")
+            print(format_diff(diffs))
+        if args.emit_sql:
+            print(f"\nsql_path={args.emit_sql}")
+
+    return 1 if diffs else 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/scripts/check-edge-anthropic-oauth-stability.py
+++ b/scripts/check-edge-anthropic-oauth-stability.py
@@ -271,11 +271,26 @@ def diff_dict(section: str, expected: dict[str, Any], actual: dict[str, Any] | N
     diffs: list[dict[str, Any]] = []
     for key, expected_value in expected.items():
         actual_value = actual.get(key)
+        if actual_value is None and expected_value is False:
+            actual_value = False
         if normalize_value(actual_value) != normalize_value(expected_value):
             diffs.append({
                 "path": f"/{section}/{key}",
                 "expected": expected_value,
-                "actual": actual_value,
+                "actual": actual.get(key),
+            })
+    return diffs
+
+
+def diff_absent(section: str, absent_keys: list[str], actual: dict[str, Any] | None) -> list[dict[str, Any]]:
+    actual = actual or {}
+    diffs: list[dict[str, Any]] = []
+    for key in absent_keys:
+        if key in actual and actual[key] not in (None, ""):
+            diffs.append({
+                "path": f"/{section}/{key}",
+                "expected": "absent",
+                "actual": actual[key],
             })
     return diffs
 
@@ -288,6 +303,7 @@ def compare_live_to_baseline(live: dict[str, Any], baseline: dict[str, Any]) -> 
     diffs.extend(diff_dict("account", base.get("account") or {}, live.get("account") or {}))
     diffs.extend(diff_dict("credentials", base.get("credentials") or {}, live.get("credentials") or {}))
     diffs.extend(diff_dict("extra", base.get("extra") or {}, live.get("extra") or {}))
+    diffs.extend(diff_absent("extra", base.get("extra_absent") or [], live.get("extra") or {}))
     diffs.extend(diff_dict("tls_profile", base.get("tls_profile") or {}, live.get("tls_profile") or {}))
     return diffs
 
@@ -305,6 +321,7 @@ def generate_sql(edge: dict[str, Any], account_name: str, baseline: dict[str, An
     account = base.get("account") or {}
     credentials = base.get("credentials") or {}
     extra = dict(base.get("extra") or {})
+    extra_absent = base.get("extra_absent") or []
     profile = base.get("tls_profile") or {}
     generated_at = dt.datetime.now(dt.UTC).replace(microsecond=0).isoformat()
 
@@ -385,7 +402,10 @@ def generate_sql(edge: dict[str, Any], account_name: str, baseline: dict[str, An
     ]
     set_lines = [f"      {item}" for item in account_sets]
     set_lines.append(f"      credentials = COALESCE(a.credentials, '{{}}'::jsonb) || {pg_json(credentials)}")
-    set_lines.append(f"      extra = COALESCE(a.extra, '{{}}'::jsonb) || {extra_object}")
+    extra_base = "COALESCE(a.extra, '{}')::jsonb"
+    for key in extra_absent:
+        extra_base += f" - {sql_literal(str(key))}"
+    set_lines.append(f"      extra = {extra_base} || {extra_object}")
     set_lines.append("      updated_at = NOW()")
     statements.append(",\n".join(set_lines))
     statements.extend([


### PR DESCRIPTION
## Summary
- Add a live-facts comparison of fra1 and uk1 Anthropic OAuth edge account stability settings.
- Codify a reusable Edge Anthropic OAuth stability baseline as machine-readable JSON and a human-readable runbook.
- Add a default read-only drift checker that can compare live edge account config, generate review-only SQL, and update the repo stable-account list with explicit confirmation.

## Test plan
- [x] `python3 -m py_compile scripts/check-edge-anthropic-oauth-stability.py`
- [x] `python3 -m json.tool deploy/aws/stage0/anthropic-oauth-stability-baseline.json`
- [x] `python3 scripts/check-edge-anthropic-oauth-stability.py --help`
- [x] `python3 scripts/check-edge-anthropic-oauth-stability.py --edge-id fra1 --account-name cc-fr-fra-ec2-5-1-a --json` — returns expected drift only for window cost baseline values
- [x] `python3 scripts/check-edge-anthropic-oauth-stability.py --edge-id uk1 --instance-id i-0f6ece892c918ea9a --account-name cc-en-ld-ec2-16-1-a --emit-sql /tmp/uk1-oauth-stability.sql` — generated SQL contains no token/email/UUID values
- [x] stable-list update tested against a temporary baseline file
- [x] `bash scripts/preflight.sh`

🤖 Generated with [Claude Code](https://claude.com/claude-code)