### PR TITLE
fix(ops): emit compact JSON to findings.jsonl in ops-daily-diagnostics

### DIFF
--- a/.github/workflows/ops-daily-diagnostics.yml
+++ b/.github/workflows/ops-daily-diagnostics.yml
@@ -152,7 +152,7 @@ jobs:
           set -euo pipefail
           if [ -z "${OIDC_ROLE_ARN:-}" ]; then
             echo "skip=true" >> "$GITHUB_OUTPUT"
-            jq -n \
+            jq -cn \
               --arg target_id "$TARGET_ID" \
               --arg kind "missing_oidc_role" \
               --arg status "skip" \
@@ -185,7 +185,7 @@ jobs:
 
           add_finding() {
             local kind="$1" status="$2" severity="$3" title="$4" summary="$5" signature="${6:-$1}"
-            jq -n \
+            jq -cn \
               --arg target_id "$TARGET_ID" \
               --arg kind "$kind" \
               --arg status "$status" \


### PR DESCRIPTION
## Summary
First scheduled run of `Ops Daily Diagnostics` — [run 25843958375](https://github.com/youxuanxue/sub2api/actions/runs/25843958375) — failed all four matrix targets (`prod`, `edge-uk1`, `edge-us1`, `edge-fra1`) at step 7 (`Finalize target report`) with `Process completed with exit code 1`. The downstream `decision-and-issue` job then failed because no `prod-ops-claude-diagnosis-<run_id>` artifact was uploaded.

## Root cause
The `Finalize target report` step parses `prod-ops-targets/<target>/findings.jsonl` line-by-line with `json.loads(line)`. Two writers append to that file:

- `Precheck OIDC role` (line 155-163) — writes a `missing_oidc_role` finding when `AWS_OIDC_ROLE_ARN` is empty.
- `add_finding()` inside `Run target diagnostics` (line 188-197) — called dozens of times.

Both used `jq -n …`, which **pretty-prints** JSON across multiple lines by default. The first appended finding produced a bare `{` on its own line, which `json.loads(line)` rejects with `json.decoder.JSONDecodeError: Expecting property name enclosed in double quotes: line 1 column 2 (char 1)`. Python exits non-zero → `set -euo pipefail` bash exits non-zero → step 7 fails for every matrix target. No `target-report.json` is produced, so `aggregate-report` glob finds nothing, emits a `missing_target_reports` finding, and the claude-issue-diagnosis / decision-and-issue path is disrupted.

## Fix
Add `-c` (compact output) to both `jq -n` invocations, so each finding is written on a single line and the JSONL contract holds.

```diff
-            jq -n \
+            jq -cn \
```

Other `jq -n` invocations in the file (line 135 → `target.json` single-object write; line 560 → `issue-diagnosis.json` single-object write) and in sibling workflows (`upstream-merge-agent-daily.yml`, `release.yml`) write to plain `.json` files parsed with full-file `json.loads()`, so pretty-printed JSON is fine there — no change needed.

## Verification
Replayed both writers locally (`jq -cn … >> findings.jsonl`, two findings appended) and re-ran the exact Python snippet from the `Finalize target report` step:

```
=== findings.jsonl content (one JSON per line) ===
{"target_id":"prod","kind":"external_health","status":"ok",...}
{"target_id":"prod","kind":"edge_public_api_block","status":"issue_candidate",...}
=== running Finalize python ===
OK: parsed 2 findings, overall status=issue_candidate
exit=0
```

YAML still parses cleanly (`python3 -c "import yaml; yaml.safe_load(open(...))"`).

## Test plan
- [ ] After merge, re-dispatch `Ops Daily Diagnostics` manually (`operation=diagnostics`, `target_selector=all`) and confirm all four `diagnose-targets` jobs complete step 7 and upload `target-report.json`.
- [ ] Confirm `aggregate-report` no longer emits the `missing_target_reports` synthetic finding.
- [ ] Confirm `decision-and-issue` either opens issues (if real `issue_candidate` findings exist) or exits with `No issue-worthy findings.`

## Risk
- Two-character flag change (`-n` → `-cn`) in one workflow file. No behavior change other than JSON formatting on a file that downstream code already expects to be JSONL.
- Per CLAUDE.md §5.y, this is a TK CI fix PR → reviewer should pick **Squash and merge**.


---
_Generated by [Claude Code](https://claude.ai/code/session_01GYa6EfWBCiyZvoujSpqHqw)_