### PR TITLE
fix(ops): apply cooldown to Anthropic 429 without reset

### DIFF
--- a/backend/internal/service/rate_limit_429_cooldown_test.go
+++ b/backend/internal/service/rate_limit_429_cooldown_test.go
@@ -111,3 +111,27 @@ func TestHandle429_FallbackUsesDefaultSecondsWhenSettingServiceMissing(t *testin
 	require.Equal(t, int64(44), accountRepo.lastRateLimitID)
 	require.True(t, !accountRepo.lastRateLimitReset.Before(before.Add(5*time.Second)) && !accountRepo.lastRateLimitReset.After(after.Add(5*time.Second)))
 }
+
+func TestHandle429_AnthropicNoResetUsesFallbackCooldown(t *testing.T) {
+	accountRepo := &rateLimit429AccountRepoStub{}
+	svc := NewRateLimitService(accountRepo, nil, &config.Config{}, nil, nil)
+
+	account := &Account{ID: 45, Platform: PlatformAnthropic, Type: AccountTypeOAuth}
+	before := time.Now()
+	svc.handle429(context.Background(), account, http.Header{}, []byte(`{"error":{"message":"rate limit exceeded"}}`))
+	after := time.Now()
+
+	require.Equal(t, 1, accountRepo.rateLimitCalls)
+	require.Equal(t, int64(45), accountRepo.lastRateLimitID)
+	require.True(t, !accountRepo.lastRateLimitReset.Before(before.Add(5*time.Second)) && !accountRepo.lastRateLimitReset.After(after.Add(5*time.Second)))
+}
+
+func TestHandle429_AnthropicExtraUsageNoResetSkipsFallbackCooldown(t *testing.T) {
+	accountRepo := &rateLimit429AccountRepoStub{}
+	svc := NewRateLimitService(accountRepo, nil, &config.Config{}, nil, nil)
+
+	account := &Account{ID: 46, Platform: PlatformAnthropic, Type: AccountTypeOAuth}
+	svc.handle429(context.Background(), account, http.Header{}, []byte(`{"error":{"message":"Third-party apps now draw from your extra usage, not your plan limits."}}`))
+
+	require.Zero(t, accountRepo.rateLimitCalls)
+}

--- a/backend/internal/service/ratelimit_service.go
+++ b/backend/internal/service/ratelimit_service.go
@@ -950,17 +950,14 @@ func (s *RateLimitService) handle429(ctx context.Context, account *Account, head
 			}
 		}
 
-		// Anthropic 平台：没有限流重置时间的 429 可能是非真实限流（如 Extra usage required），
-		// 不标记账号限流状态，直接透传错误给客户端
-		if account.Platform == PlatformAnthropic {
+		if account.Platform == PlatformAnthropic && isAnthropicExtraUsage429(responseBody) {
 			slog.Warn("rate_limit_429_no_reset_time_skipped",
 				"account_id", account.ID,
 				"platform", account.Platform,
-				"reason", "no rate limit reset time in headers, likely not a real rate limit")
+				"reason", "anthropic extra usage error without rate limit reset time")
 			return
 		}
 
-		// 其他平台：没有重置时间，使用可配置的秒级默认回避，避免误伤长时间不可调度。
 		s.apply429FallbackRateLimit(ctx, account, "no_reset_time")
 		return
 	}
@@ -989,6 +986,18 @@ func (s *RateLimitService) handle429(ctx context.Context, account *Account, head
 	}
 
 	slog.Info("account_rate_limited", "account_id", account.ID, "reset_at", resetAt)
+}
+
+func isAnthropicExtraUsage429(responseBody []byte) bool {
+	message := strings.ToLower(strings.TrimSpace(gjson.GetBytes(responseBody, "error.message").String()))
+	if message == "" {
+		message = strings.ToLower(strings.TrimSpace(gjson.GetBytes(responseBody, "message").String()))
+	}
+	if message == "" {
+		message = strings.ToLower(string(responseBody))
+	}
+
+	return strings.Contains(message, "extra usage") || strings.Contains(message, "third-party apps now draw")
 }
 
 func (s *RateLimitService) apply429FallbackRateLimit(ctx context.Context, account *Account, reason string) {

--- a/docs/spec-delta-222-no-web-impact.md
+++ b/docs/spec-delta-222-no-web-impact.md
@@ -1,0 +1,23 @@
+# spec-delta: PR #222 no-web-impact
+
+## Scope
+- PR: #222 (`fix/429-no-reset-cooldown`)
+- Backend changes:
+  - `backend/internal/service/ratelimit_service.go`
+  - `backend/internal/service/rate_limit_429_cooldown_test.go`
+- Sentinel registry changes:
+  - `scripts/gateway-tk-sentinels.json`
+
+## Intent
+- Apply the existing configurable short 429 cooldown when Anthropic returns a 429 without reset metadata.
+- Preserve passthrough for known Anthropic third-party / extra-usage rejections so those non-quota errors do not locally rate-limit the account.
+
+## Web / API contract impact
+- No frontend page, route, UI state, or i18n surface changed.
+- No request/response schema changes for public web/admin APIs.
+- No settings schema or OpenAPI/contract shape change required; this reuses the existing `rate_limit_429_cooldown` backend setting.
+
+## Why no web change is needed
+- The change only affects backend account scheduling after an upstream Anthropic 429 response that lacks reset metadata.
+- Operators already control the fallback cooldown through the existing backend setting.
+- Client-visible API payloads and admin UI configuration surfaces are unchanged.

--- a/scripts/gateway-tk-sentinels.json
+++ b/scripts/gateway-tk-sentinels.json
@@ -59,8 +59,8 @@
     },
     {
       "path": "backend/internal/service/ratelimit_service.go",
-      "must_contain": ["case 404:", "s.handle404(ctx, account, upstreamMsg, responseBody)", "anthropic404ModelCooldown", "isAnthropicModelNotFound404", "SetModelRateLimit(ctx, account.ID, modelName, resetAt)"],
-      "rationale": "Anthropic model-not-found 404s must stay model-scoped instead of falling through as an unprotected upstream error or disabling the whole OAuth account. Upstream merges in this large service file can compile cleanly while dropping the 404 branch or the model-rate-limit write, which would reintroduce repeated bad-model retries against Anthropic. This merge also updates adjacent upstream error-shaping paths in the same hotspot file; keeping this sentinel rationale refreshed records that the 404 protection anchors were explicitly re-validated while resolving conflicts."
+      "must_contain": ["case 404:", "s.handle404(ctx, account, upstreamMsg, responseBody)", "anthropic404ModelCooldown", "isAnthropicModelNotFound404", "SetModelRateLimit(ctx, account.ID, modelName, resetAt)", "isAnthropicExtraUsage429", "s.apply429FallbackRateLimit(ctx, account, \"no_reset_time\")"],
+      "rationale": "Anthropic model-not-found 404s must stay model-scoped instead of falling through as an unprotected upstream error or disabling the whole OAuth account. Anthropic 429s without reset metadata must use the configurable short cooldown unless the body is the known third-party/extra-usage rejection, otherwise production can repeatedly hit the same account with no local backoff. Upstream merges in this large service file can compile cleanly while dropping either protection, so the sentinel anchors both policies in the hotspot file."
     },
     {
       "path": "backend/internal/service/ratelimit_404_model_not_found_test.go",


### PR DESCRIPTION
## Summary
- Fixes #211 by applying the configurable short 429 cooldown to Anthropic 429 responses that do not include reset metadata.
- Preserves passthrough for known Anthropic third-party / extra-usage rejections so those non-quota errors do not locally rate-limit the account.
- Updates gateway TK sentinel coverage and adds `docs/spec-delta-222-no-web-impact.md` to record that Web/API/settings contracts are unchanged.
- Bumps `dev-rules` to include the staged Web-alignment evidence preflight fix from youxuanxue/dev-rules#45, avoiding the no-web-impact commit deadlock.

## Test plan
- [x] `go test -tags=unit ./internal/service -run 'TestHandle429_(Fallback|Anthropic)'`
- [x] `go test -tags=unit ./...`
- [x] `bash scripts/check-upstream-drift.sh`
- [x] `bash scripts/preflight.sh`

🤖 Generated with [Claude Code](https://claude.com/claude-code)