### PR TITLE
Fix Claude TLS profile capture timing

### DIFF
--- a/.claude/hooks/export-tls-fingerprint-profile.sh
+++ b/.claude/hooks/export-tls-fingerprint-profile.sh
@@ -210,6 +210,20 @@ async function main() {
     try { hookInput = JSON.parse(hookInputRaw) } catch {}
   }
 
+  const sessionShort = safeSessionId(hookInput)
+  const sessionMarkerPath = hookInput.session_id
+    ? path.join(outDir, `${sessionShort}.captured-session.json`)
+    : null
+
+  fs.mkdirSync(outDir, { recursive: true })
+  if (sessionMarkerPath && fs.existsSync(sessionMarkerPath)) {
+    emit({
+      systemMessage: `TokenKey TLS profile capture skipped: ${sessionShort} already captured`,
+      suppressOutput: true
+    })
+    return
+  }
+
   const payload = await requestJson(captureUrl)
   const tls = payload.tls || {}
   if (!tls.ja3) throw new Error('collector response missing tls.ja3')
@@ -219,13 +233,12 @@ async function main() {
   const stamp = capturedAt.replace(/[-:]/g, '').replace(/\.\d{3}Z$/, 'Z')
   const ja3Hash = String(tls.ja3_hash || 'noja3hash')
   const shortJa3 = ja3Hash.replace(/[^a-fA-F0-9]/g, '').slice(0, 12) || 'noja3hash'
-  const sessionShort = safeSessionId(hookInput)
   const name = `claude_code_cli_${stamp.slice(0, 8)}_${shortJa3}`.slice(0, 100)
 
   const profile = {
     name,
     description: [
-      `Captured by Claude Code SessionEnd hook at ${capturedAt}.`,
+      `Captured by Claude Code hook at ${capturedAt}.`,
       `runtime=node ${process.version} ${process.platform}/${process.arch}.`,
       `ja3_hash=${tls.ja3_hash || ''}.`,
       `ja4=${tls.ja4 || ''}.`,
@@ -247,7 +260,6 @@ async function main() {
     extensions: ja3.extensions
   }
 
-  fs.mkdirSync(outDir, { recursive: true })
   const base = `${stamp}_${sessionShort}_${shortJa3}`
   const profilePath = path.join(outDir, `${base}.tokenkey-profile.json`)
   const yamlPath = path.join(outDir, `${base}.tokenkey-profile.yaml`)
@@ -281,6 +293,16 @@ async function main() {
     },
     tokenkey_profile: profile
   }, null, 2) + '\n')
+
+  if (sessionMarkerPath) {
+    fs.writeFileSync(sessionMarkerPath, JSON.stringify({
+      schema_version: 1,
+      session_id: hookInput.session_id,
+      captured_at: capturedAt,
+      profile_path: path.relative(outDir, profilePath),
+      capture_path: path.relative(outDir, capturePath)
+    }, null, 2) + '\n')
+  }
 
   emit({
     systemMessage: `TokenKey TLS profile captured: ${path.relative(repoRoot, profilePath)}`,

--- a/.claude/settings.json
+++ b/.claude/settings.json
@@ -11,12 +11,24 @@
         ]
       }
     ],
+    "Stop": [
+      {
+        "hooks": [
+          {
+            "type": "command",
+            "command": "bash \"${CLAUDE_PROJECT_DIR}/.claude/hooks/export-tls-fingerprint-profile.sh\"",
+            "timeout": 20,
+            "statusMessage": "Capturing TokenKey TLS fingerprint profile"
+          }
+        ]
+      }
+    ],
     "SessionEnd": [
       {
         "hooks": [
           {
             "type": "command",
-            "command": "bash \"$CLAUDE_PROJECT_DIR/.claude/hooks/export-tls-fingerprint-profile.sh\"",
+            "command": "bash \"${CLAUDE_PROJECT_DIR}/.claude/hooks/export-tls-fingerprint-profile.sh\"",
             "timeout": 20,
             "statusMessage": "Capturing TokenKey TLS fingerprint profile"
           }

--- a/backend/internal/service/gateway_forward_as_chat_completions.go
+++ b/backend/internal/service/gateway_forward_as_chat_completions.go
@@ -126,7 +126,7 @@ func (s *GatewayService) ForwardAsChatCompletions(
 	}
 
 	// 11. Send request
-	resp, err := s.httpUpstream.DoWithTLS(upstreamReq, proxyURL, account.ID, account.Concurrency, s.tlsFPProfileService.ResolveTLSProfile(account))
+	resp, err := s.httpUpstream.DoWithTLS(upstreamReq, proxyURL, account.ID, account.Concurrency, resolveOpsTLSFingerprintProfile(c, s.tlsFPProfileService, account))
 	if err != nil {
 		if resp != nil && resp.Body != nil {
 			_ = resp.Body.Close()

--- a/backend/internal/service/gateway_forward_as_responses.go
+++ b/backend/internal/service/gateway_forward_as_responses.go
@@ -123,7 +123,7 @@ func (s *GatewayService) ForwardAsResponses(
 	}
 
 	// 11. Send request
-	resp, err := s.httpUpstream.DoWithTLS(upstreamReq, proxyURL, account.ID, account.Concurrency, s.tlsFPProfileService.ResolveTLSProfile(account))
+	resp, err := s.httpUpstream.DoWithTLS(upstreamReq, proxyURL, account.ID, account.Concurrency, resolveOpsTLSFingerprintProfile(c, s.tlsFPProfileService, account))
 	if err != nil {
 		if resp != nil && resp.Body != nil {
 			_ = resp.Body.Close()

--- a/backend/internal/service/gateway_service.go
+++ b/backend/internal/service/gateway_service.go
@@ -4562,7 +4562,7 @@ func (s *GatewayService) Forward(ctx context.Context, c *gin.Context, account *A
 	}
 
 	// 解析 TLS 指纹 profile（同一请求生命周期内不变，避免重试循环中重复解析）
-	tlsProfile := s.tlsFPProfileService.ResolveTLSProfile(account)
+	tlsProfile := resolveOpsTLSFingerprintProfile(c, s.tlsFPProfileService, account)
 
 	// 调试日志：记录即将转发的账号信息
 	logger.LegacyPrintf("service.gateway", "[Forward] Using account: ID=%d Name=%s Platform=%s Type=%s TLSFingerprint=%v Proxy=%s",
@@ -5096,7 +5096,7 @@ func (s *GatewayService) forwardAnthropicAPIKeyPassthroughWithInput(
 			return nil, err
 		}
 
-		resp, err = s.httpUpstream.DoWithTLS(upstreamReq, proxyURL, account.ID, account.Concurrency, s.tlsFPProfileService.ResolveTLSProfile(account))
+		resp, err = s.httpUpstream.DoWithTLS(upstreamReq, proxyURL, account.ID, account.Concurrency, resolveOpsTLSFingerprintProfile(c, s.tlsFPProfileService, account))
 		if err != nil {
 			if resp != nil && resp.Body != nil {
 				_ = resp.Body.Close()
@@ -8984,7 +8984,7 @@ func (s *GatewayService) ForwardCountTokens(ctx context.Context, c *gin.Context,
 	}
 
 	// 发送请求
-	resp, err := s.httpUpstream.DoWithTLS(upstreamReq, proxyURL, account.ID, account.Concurrency, s.tlsFPProfileService.ResolveTLSProfile(account))
+	resp, err := s.httpUpstream.DoWithTLS(upstreamReq, proxyURL, account.ID, account.Concurrency, resolveOpsTLSFingerprintProfile(c, s.tlsFPProfileService, account))
 	if err != nil {
 		setOpsUpstreamError(c, 0, sanitizeUpstreamErrorMessage(err.Error()), "")
 		s.countTokensError(c, http.StatusBadGateway, "upstream_error", "Request failed")
@@ -9011,7 +9011,7 @@ func (s *GatewayService) ForwardCountTokens(ctx context.Context, c *gin.Context,
 		filteredBody := FilterThinkingBlocksForRetry(body)
 		retryReq, buildErr := s.buildCountTokensRequest(ctx, c, account, filteredBody, token, tokenType, reqModel, shouldMimicClaudeCode)
 		if buildErr == nil {
-			retryResp, retryErr := s.httpUpstream.DoWithTLS(retryReq, proxyURL, account.ID, account.Concurrency, s.tlsFPProfileService.ResolveTLSProfile(account))
+			retryResp, retryErr := s.httpUpstream.DoWithTLS(retryReq, proxyURL, account.ID, account.Concurrency, resolveOpsTLSFingerprintProfile(c, s.tlsFPProfileService, account))
 			if retryErr == nil {
 				resp = retryResp
 				respBody, err = ReadUpstreamResponseBody(resp.Body, s.cfg, c, countTokensTooLarge)
@@ -9097,7 +9097,7 @@ func (s *GatewayService) forwardCountTokensAnthropicAPIKeyPassthrough(ctx contex
 		proxyURL = account.Proxy.URL()
 	}
 
-	resp, err := s.httpUpstream.DoWithTLS(upstreamReq, proxyURL, account.ID, account.Concurrency, s.tlsFPProfileService.ResolveTLSProfile(account))
+	resp, err := s.httpUpstream.DoWithTLS(upstreamReq, proxyURL, account.ID, account.Concurrency, resolveOpsTLSFingerprintProfile(c, s.tlsFPProfileService, account))
 	if err != nil {
 		setOpsUpstreamError(c, 0, sanitizeUpstreamErrorMessage(err.Error()), "")
 		appendOpsUpstreamError(c, OpsUpstreamErrorEvent{

--- a/backend/internal/service/ops_upstream_context.go
+++ b/backend/internal/service/ops_upstream_context.go
@@ -5,6 +5,7 @@ import (
 	"strings"
 	"time"
 
+	"github.com/Wei-Shaw/sub2api/internal/pkg/tlsfingerprint"
 	"github.com/gin-gonic/gin"
 )
 
@@ -20,6 +21,9 @@ const (
 	// retry the specific upstream attempt (not just the client request).
 	// This value is sanitized+trimmed before being persisted.
 	OpsUpstreamRequestBodyKey = "ops_upstream_request_body"
+
+	OpsTLSFingerprintProfileIDKey   = "ops_tls_fingerprint_profile_id"
+	OpsTLSFingerprintProfileNameKey = "ops_tls_fingerprint_profile_name"
 
 	// Optional stage latencies (milliseconds) for troubleshooting and alerting.
 	OpsAuthLatencyMsKey      = "ops_auth_latency_ms"
@@ -51,6 +55,27 @@ func SetOpsLatencyMs(c *gin.Context, key string, value int64) {
 		return
 	}
 	c.Set(key, value)
+}
+
+func setOpsTLSFingerprintProfile(c *gin.Context, account *Account, profile *tlsfingerprint.Profile) {
+	if c == nil || account == nil || profile == nil {
+		return
+	}
+	if id := account.GetTLSFingerprintProfileID(); id > 0 {
+		c.Set(OpsTLSFingerprintProfileIDKey, id)
+	}
+	if name := strings.TrimSpace(profile.Name); name != "" {
+		c.Set(OpsTLSFingerprintProfileNameKey, name)
+	}
+}
+
+func resolveOpsTLSFingerprintProfile(c *gin.Context, svc *TLSFingerprintProfileService, account *Account) *tlsfingerprint.Profile {
+	if svc == nil {
+		return nil
+	}
+	profile := svc.ResolveTLSProfile(account)
+	setOpsTLSFingerprintProfile(c, account, profile)
+	return profile
 }
 
 // SetOpsUpstreamError is the exported wrapper for setOpsUpstreamError, used by
@@ -85,9 +110,11 @@ type OpsUpstreamErrorEvent struct {
 	Passthrough bool `json:"passthrough,omitempty"`
 
 	// Context
-	Platform    string `json:"platform,omitempty"`
-	AccountID   int64  `json:"account_id,omitempty"`
-	AccountName string `json:"account_name,omitempty"`
+	Platform                  string `json:"platform,omitempty"`
+	AccountID                 int64  `json:"account_id,omitempty"`
+	AccountName               string `json:"account_name,omitempty"`
+	TLSFingerprintProfileID   int64  `json:"tls_fingerprint_profile_id,omitempty"`
+	TLSFingerprintProfileName string `json:"tls_fingerprint_profile_name,omitempty"`
 
 	// Outcome
 	UpstreamStatusCode int    `json:"upstream_status_code,omitempty"`
@@ -119,6 +146,26 @@ func appendOpsUpstreamError(c *gin.Context, ev OpsUpstreamErrorEvent) {
 		ev.AtUnixMs = time.Now().UnixMilli()
 	}
 	ev.Platform = strings.TrimSpace(ev.Platform)
+	ev.TLSFingerprintProfileName = strings.TrimSpace(ev.TLSFingerprintProfileName)
+	if ev.TLSFingerprintProfileID <= 0 {
+		if v, ok := c.Get(OpsTLSFingerprintProfileIDKey); ok {
+			switch t := v.(type) {
+			case int64:
+				ev.TLSFingerprintProfileID = t
+			case int:
+				ev.TLSFingerprintProfileID = int64(t)
+			case float64:
+				ev.TLSFingerprintProfileID = int64(t)
+			}
+		}
+	}
+	if ev.TLSFingerprintProfileName == "" {
+		if v, ok := c.Get(OpsTLSFingerprintProfileNameKey); ok {
+			if s, ok := v.(string); ok {
+				ev.TLSFingerprintProfileName = strings.TrimSpace(s)
+			}
+		}
+	}
 	ev.UpstreamRequestID = strings.TrimSpace(ev.UpstreamRequestID)
 	ev.UpstreamRequestBody = strings.TrimSpace(ev.UpstreamRequestBody)
 	ev.UpstreamResponseBody = strings.TrimSpace(ev.UpstreamResponseBody)

--- a/backend/internal/service/ops_upstream_context_test.go
+++ b/backend/internal/service/ops_upstream_context_test.go
@@ -66,3 +66,29 @@ func TestAppendOpsUpstreamError_UsesRequestBodyStringFromContext(t *testing.T) {
 	require.Len(t, events, 1)
 	require.Equal(t, `{"model":"gpt-4"}`, events[0].UpstreamRequestBody)
 }
+
+func TestAppendOpsUpstreamError_UsesTLSFingerprintProfileFromContext(t *testing.T) {
+	gin.SetMode(gin.TestMode)
+	rec := httptest.NewRecorder()
+	c, _ := gin.CreateTestContext(rec)
+
+	c.Set(OpsTLSFingerprintProfileIDKey, int64(42))
+	c.Set(OpsTLSFingerprintProfileNameKey, "claude_cli_nodejs25_observed_candidate")
+	appendOpsUpstreamError(c, OpsUpstreamErrorEvent{
+		Kind:    "request_error",
+		Message: "tls handshake failed",
+	})
+
+	v, ok := c.Get(OpsUpstreamErrorsKey)
+	require.True(t, ok)
+	events, ok := v.([]*OpsUpstreamErrorEvent)
+	require.True(t, ok)
+	require.Len(t, events, 1)
+	require.Equal(t, int64(42), events[0].TLSFingerprintProfileID)
+	require.Equal(t, "claude_cli_nodejs25_observed_candidate", events[0].TLSFingerprintProfileName)
+
+	raw := marshalOpsUpstreamErrors(events)
+	require.NotNil(t, raw)
+	require.Contains(t, *raw, `"tls_fingerprint_profile_id":42`)
+	require.Contains(t, *raw, `"tls_fingerprint_profile_name":"claude_cli_nodejs25_observed_candidate"`)
+}

--- a/docs/spec-delta-224-tls-capture-no-web-impact.md
+++ b/docs/spec-delta-224-tls-capture-no-web-impact.md
@@ -1,0 +1,22 @@
+# Spec delta: PR #224 TLS capture and attribution no-web-impact
+
+## Intent
+
+PR #224 changes two internal surfaces:
+
+- Claude Code local hook timing for `.tls_list/` capture (`Stop` plus `SessionEnd`).
+- Backend upstream error attribution by adding TLS fingerprint profile id/name to the existing `ops_error_logs.upstream_errors` JSON payload.
+
+## Web impact
+
+None.
+
+## Rationale
+
+No frontend page, user-facing setting, route, request schema, response schema, or admin API contract changes are required. The backend change only adds optional fields inside an existing ops/debug JSON column used for failure attribution, and the hook change only affects local Claude Code session artifacts ignored by git.
+
+## Validation
+
+- `go test -tags=unit ./internal/service -run 'TestAppendOpsUpstreamError|TestSafeUpstreamURL'`
+- `go test -tags=unit ./internal/service -run 'TestNonExistent'`
+- `bash scripts/preflight.sh`

--- a/scripts/gateway-tk-sentinels.json
+++ b/scripts/gateway-tk-sentinels.json
@@ -111,13 +111,14 @@
         "tkEnsureClaudeCodeSessionHeader(req.Header, vertexBody, c)",
         "logger.WriteSinkEvent(\"info\", \"http.access.sticky\", \"sticky.hash_source\"",
         "\"session_hash_short\": shortSessionHash(sessionHash)",
+        "resolveOpsTLSFingerprintProfile(c, s.tlsFPProfileService, account)",
         "applyClaudeCodeMimicHeaders(req *http.Request, _ bool)",
         "getHeaderRaw(req.Header, key) != \"\""
       ],
       "must_not_contain": [
         "x-stainless-helper-method"
       ],
-      "rationale": "Main gateway upstream builders must invoke unified TK Claude session-header sync after API-key passthrough, OAuth forward, count_tokens forward, and Vertex Anthropic forward paths diverge upstream merge conflicts. Sticky-source sink event emission is also load-bearing for prod request_id/client_request_id evidence correlation. Claude Code OAuth mimicry must preserve captured real CLI User-Agent/X-Stainless fingerprint values and only fill missing defaults; reverting to unconditional defaults reintroduces version downgrade/header fingerprint drift. The obsolete x-stainless-helper-method header must stay absent because current real Claude Code traffic does not emit it and reintroducing it increases OAuth fingerprint risk."
+      "rationale": "Main gateway upstream builders must invoke unified TK Claude session-header sync after API-key passthrough, OAuth forward, count_tokens forward, and Vertex Anthropic forward paths diverge upstream merge conflicts. Sticky-source sink event emission is also load-bearing for prod request_id/client_request_id evidence correlation. TLS fingerprint profile resolution must pass through the ops helper so upstream_errors JSON records the profile id/name used by failed Anthropic OAuth attempts; otherwise Node24/Node25 candidate canaries cannot be attributed after a profile switch. Claude Code OAuth mimicry must preserve captured real CLI User-Agent/X-Stainless fingerprint values and only fill missing defaults; reverting to unconditional defaults reintroduces version downgrade/header fingerprint drift. The obsolete x-stainless-helper-method header must stay absent because current real Claude Code traffic does not emit it and reintroducing it increases OAuth fingerprint risk."
     },
     {
       "path": "backend/internal/service/header_util.go",


### PR DESCRIPTION
## Summary
- Capture Claude Code TLS samples on `Stop` as well as `SessionEnd`, with per-session dedupe so `.tls_list/` appears during normal use without repeated captures.
- Persist TLS fingerprint profile id/name into `ops_error_logs.upstream_errors` JSON for upstream failure attribution during Node24/Node25 OAuth canaries.
- Refresh gateway sentinel coverage for the new TLS profile attribution hook.

## Operational note
- `edge-us1` now has `claude_cli_nodejs25_observed_candidate` inserted as TLS profile id `4`.
- No account binding was changed; `cc-am-or-ec2-5-1-b` still uses `claude_cli_nodejs24_fixed` profile id `1`.

## Test plan
- [x] `go test -tags=unit ./internal/service -run 'TestAppendOpsUpstreamError|TestSafeUpstreamURL'`
- [x] `go test -tags=unit ./internal/service -run 'TestNonExistent'`
- [x] `bash scripts/preflight.sh`
- [x] Manual hook run generated `.tls_list/*.tokenkey-profile.{json,yaml}` and skipped duplicate capture for the same session id.
- [x] Verified `edge-us1` candidate profile exists and account binding remains unchanged.

🤖 Generated with [Claude Code](https://claude.com/claude-code)