### PR TITLE
chore: cache upstream issue triage

### DIFF
--- a/scripts/upstream-issue-fixes.json
+++ b/scripts/upstream-issue-fixes.json
@@ -3,6 +3,109 @@
   "rationale": "TokenKey-local registry of upstream Wei-Shaw/sub2api issues that this fork has already addressed. Use this when triaging upstream open issues so already-fixed upstream reports are not repeatedly selected for TokenKey work.",
   "issues": [
     {
+      "upstream": "Wei-Shaw/sub2api#580",
+      "tokenkey_pr": "youxuanxue/sub2api#223",
+      "status": "fixed_in_tokenkey",
+      "fixed_by": [
+        "backend/internal/service/gateway_service.go",
+        "backend/internal/service/claude_mimicry_headers_test.go",
+        "scripts/gateway-tk-sentinels.json"
+      ],
+      "summary": "Preserved captured real Claude CLI User-Agent and X-Stainless fingerprint values when applying mimicry defaults, avoiding version downgrade churn."
+    },
+    {
+      "upstream": "Wei-Shaw/sub2api#1925",
+      "status": "fixed_in_tokenkey",
+      "fixed_by": [
+        "backend/internal/service/account_test_service.go",
+        "backend/internal/service/account_test_service_openai_test.go"
+      ],
+      "summary": "OpenAI /responses account testing requires a terminal response.completed/response.done event; early EOF before completion fails the account test."
+    },
+    {
+      "upstream": "Wei-Shaw/sub2api#2055",
+      "status": "fixed_in_tokenkey",
+      "fixed_by": [
+        "backend/internal/service/ratelimit_service.go",
+        "backend/internal/service/ratelimit_service_clear_test.go"
+      ],
+      "summary": "Manual/successful recovery clears account rate-limit state, model rate limits, temporary unschedulable state, and OpenAI 403 counters."
+    },
+    {
+      "upstream": "Wei-Shaw/sub2api#2168",
+      "status": "fixed_in_tokenkey",
+      "fixed_by": [
+        "backend/internal/service/openai_gateway_service.go",
+        "backend/internal/service/openai_gateway_record_usage_test.go"
+      ],
+      "summary": "Streaming usage billing continues on detached/drained upstream paths when clients disconnect early, preventing zero-cost early-disconnect abuse."
+    },
+    {
+      "upstream": "Wei-Shaw/sub2api#2211",
+      "status": "fixed_in_tokenkey",
+      "fixed_by": [
+        "backend/internal/repository/account_repo.go",
+        "backend/internal/service/openai_account_scheduler.go"
+      ],
+      "summary": "OpenAI scheduling now queries account_groups for the requested group, so grouped balance traffic should not select ungrouped accounts."
+    },
+    {
+      "upstream": "Wei-Shaw/sub2api#2293",
+      "status": "fixed_in_tokenkey",
+      "fixed_by": [
+        "backend/internal/service/billing_service.go",
+        "backend/internal/service/billing_service_test.go"
+      ],
+      "summary": "GPT-5.4/5.5 long-context billing includes cache_read tokens in the threshold and applies the long-context multiplier to cache_read cost."
+    },
+    {
+      "upstream": "Wei-Shaw/sub2api#2310",
+      "status": "fixed_in_tokenkey",
+      "fixed_by": [
+        "backend/internal/service/openai_images_responses.go",
+        "backend/internal/service/gateway_service.go"
+      ],
+      "summary": "OpenAI OAuth image generation uses a detached upstream context, so long non-stream image jobs are not tied to client disconnect/cancel."
+    },
+    {
+      "upstream": "Wei-Shaw/sub2api#2337",
+      "status": "fixed_in_tokenkey",
+      "fixed_by": [
+        "backend/internal/service/openai_codex_transform.go",
+        "backend/internal/service/openai_tool_continuation.go",
+        "backend/internal/service/openai_compat_model_test.go"
+      ],
+      "summary": "Anthropic-to-OpenAI multi-turn tool call conversion preserves tool-call/call-id continuity for tool_result history."
+    },
+    {
+      "upstream": "Wei-Shaw/sub2api#2383",
+      "status": "fixed_in_tokenkey",
+      "fixed_by": [
+        "backend/internal/service/openai_gateway_service.go",
+        "backend/internal/service/openai_gateway_record_usage_test.go"
+      ],
+      "summary": "OpenAI usage recording tracks billing-model candidates and source selection so mapped and unmapped model billing paths are covered."
+    },
+    {
+      "upstream": "Wei-Shaw/sub2api#2411",
+      "status": "fixed_in_tokenkey",
+      "fixed_by": [
+        "backend/internal/service/sticky_session_injector.go",
+        "backend/internal/service/sticky_session_strategy.go",
+        "backend/internal/service/openai_account_scheduler.go"
+      ],
+      "summary": "Sticky-session scheduling has dedicated hash, strategy, TTL refresh, and invalidation logic for OpenAI-compatible account selection."
+    },
+    {
+      "upstream": "Wei-Shaw/sub2api#2487",
+      "status": "fixed_in_tokenkey",
+      "fixed_by": [
+        "backend/internal/service/openai_codex_transform.go",
+        "backend/internal/service/openai_gateway_chat_completions.go"
+      ],
+      "summary": "Codex OAuth forwarding strips temperature and other ChatGPT-internal unsupported parameters before dispatch."
+    },
+    {
       "upstream": "Wei-Shaw/sub2api#2489",
       "tokenkey_pr": "youxuanxue/sub2api#223",
       "status": "fixed_in_tokenkey",
@@ -15,15 +118,14 @@
       "summary": "Stopped emitting or forwarding x-stainless-helper-method on Claude Code OAuth mimicry paths."
     },
     {
-      "upstream": "Wei-Shaw/sub2api#580",
-      "tokenkey_pr": "youxuanxue/sub2api#223",
+      "upstream": "Wei-Shaw/sub2api#2490",
       "status": "fixed_in_tokenkey",
       "fixed_by": [
-        "backend/internal/service/gateway_service.go",
-        "backend/internal/service/claude_mimicry_headers_test.go",
-        "scripts/gateway-tk-sentinels.json"
+        "backend/internal/handler/openai_gateway_handler.go",
+        "backend/internal/service/openai_gateway_service.go",
+        "backend/internal/service/openai_gateway_chat_completions.go"
       ],
-      "summary": "Preserved captured real Claude CLI User-Agent and X-Stainless fingerprint values when applying mimicry defaults, avoiding version downgrade churn."
+      "summary": "OpenAI /compact route handling and request-body normalization are implemented, with compact_not_supported when no compatible account is available."
     }
   ]
 }

--- a/scripts/upstream-issue-triage-generate.py
+++ b/scripts/upstream-issue-triage-generate.py
@@ -1,0 +1,172 @@
+#!/usr/bin/env python3
+from __future__ import annotations
+
+import json
+import re
+import sys
+from pathlib import Path
+
+HIGH_PATTERNS = [
+    ("claude_mimicry", ["claude code", "x-stainless", "user-agent", "authorized for use with claude code", "第三方", "风控"]),
+    ("rate_limit_cooldown", ["429", "cooldown", "冷却", "限流", "503", "pst", "midnight"]),
+    ("billing_usage", ["计费", "多收", "usage", "usage_logs", "input_tokens=0", "重复记录"]),
+    ("image_oauth", ["images", "图片", "生图", "gpt-image", "context canceled", "502", "oauth"]),
+    ("account_pool_health", ["测试账号", "调度池", "stream disconnected", "提前 eof", "response.completed"]),
+    ("security", ["泄露", "secret", "token", "越权", "漏洞", "安全"]),
+]
+
+MEDIUM_PATTERNS = [
+    ("ops_observability", ["运维", "监控", "归因", "日志", "sla", "request_id"]),
+    ("compatibility", ["兼容", "compact", "透传", "header"]),
+    ("admin_ui", ["页面", "展示", "统计", "按钮", "前端"]),
+]
+
+LOW_PATTERNS = [
+    ("enhancement", ["是否可以", "希望", "建议", "feature", "优化"]),
+    ("docs", ["文档", "readme", "教程"]),
+]
+
+MANUAL_TRIAGE = {
+    580: ("fixed", "fixed_in_tokenkey", "Claude Code mimicry UA downgrade fixed by TokenKey PR #223."),
+    641: ("needs_prod_validation", "partially_mitigated", "Gemini google_one 429 now uses tier cooldown on Code Assist paths; verify google_one accounts are classified as Code Assist in production."),
+    1824: ("needs_prod_validation", "partially_mitigated", "OpenAI 403 now starts with temporary unschedulable state, but repeated CF/Arkose challenges can still cool down or error accounts."),
+    1925: ("fixed", "fixed_in_tokenkey", "OpenAI /responses account test requires response.completed/response.done; early EOF fails tests."),
+    2055: ("fixed", "fixed_in_tokenkey", "Rate-limit reset clears account/model rate-limit, temp-unschedulable, and OpenAI 403 counters."),
+    2107: ("high", "unresolved_in_tokenkey", "Channel token interval pricing still returns before applying flat defaults; out-of-range intervals fall back to catalog/base pricing and can charge 0."),
+    2159: ("high", "unresolved_in_tokenkey", "Disabled proxies are still loaded by ID without status filtering, so linked accounts may keep using disabled proxy routes."),
+    2168: ("fixed", "fixed_in_tokenkey", "Streaming billing uses detached/drain paths and tests cover client-disconnect billing."),
+    2211: ("fixed", "fixed_in_tokenkey", "Account scheduling now queries the account_groups join table for the requested group; balance-group requests should not schedule ungrouped accounts."),
+    2232: ("needs_prod_validation", "needs_tokenkey_review", "OpenAI OAuth images/edits gpt-image-2 remains a user-facing image path; validate against current image/edit bridge behavior."),
+    2245: ("needs_prod_validation", "known_protocol_limitation", "Responses stream terminal-event detection exists, but downstream may already have received HTTP 200 before an incomplete SSE is detected."),
+    2258: ("high", "unresolved_in_tokenkey", "OpenAI 429 burst still uses the larger Codex reset header when 5h/7d usage windows are below 100%, causing long 503 windows."),
+    2291: ("medium", "unresolved_observability", "Cache hit rate has inconsistent UI formulas between dashboard/trend views; observability issue, not direct production outage."),
+    2293: ("fixed", "fixed_in_tokenkey", "Long-context billing includes cache_read tokens in the threshold and applies long-context multiplier to cache_read cost."),
+    2310: ("fixed", "fixed_in_tokenkey", "OpenAI OAuth image generation uses a detached upstream context instead of binding long jobs to the client connection."),
+    2332: ("needs_prod_validation", "partially_mitigated", "Anthropic message_delta usage parsing avoids zero-value overwrites; production usage rows should still be sampled for duplicate billing."),
+    2337: ("fixed", "fixed_in_tokenkey", "Anthropic-to-OpenAI multi-turn tool call mapping is covered by tool-continuation code and tests."),
+    2363: ("needs_prod_validation", "partially_mitigated", "Cache-read price overrides exist in resolver and billing paths; verify production channel-pricing source selection."),
+    2383: ("fixed", "fixed_in_tokenkey", "OpenAI usage recording has billing model candidates/source tracking and tests for mapped/unmapped models."),
+    2410: ("medium", "needs_tokenkey_review", "Ops attribution gaps reduce incident actionability; TokenKey has added ops context but needs separate production log audit."),
+    2411: ("fixed", "fixed_in_tokenkey", "Sticky-session scheduling has dedicated hash, mode, and invalidation logic."),
+    2413: ("needs_prod_validation", "partially_mitigated", "OpenAI image 403 still triggers temporary unschedulable cooldown; decide whether CF/Arkose image challenges should be ignored or scoped."),
+    2453: ("medium", "intentional_policy", "Default OpenAI fast policy still filters priority/fast globally by design; important product-policy tradeoff, not an accidental outage bug."),
+    2465: ("not_applicable", "outside_tokenkey_runtime", "Issue is about upstream compat-proxy/proxy.py; this TokenKey worktree has no compat-proxy implementation to patch."),
+    2478: ("high", "unresolved_in_tokenkey", "Expired non-soft-deleted subscriptions still satisfy ExistsByUserIDAndGroupID and can return validity_days_mismatch on reassignment."),
+    2486: ("needs_prod_validation", "needs_tokenkey_review", "Gemini pro-agent billing appears to flow through RecordUsageWithLongContext, but no gemini-pro-agent-specific test was found."),
+    2487: ("fixed", "fixed_in_tokenkey", "Codex OAuth transform strips temperature and other unsupported fields before forwarding to ChatGPT internal endpoints."),
+    2489: ("fixed", "fixed_in_tokenkey", "Claude Code mimicry helper-method header risk fixed by TokenKey PR #223."),
+    2490: ("fixed", "fixed_in_tokenkey", "OpenAI /compact route and request-body normalization are implemented, including compact_not_supported errors when no account is available."),
+}
+
+FIXED_IDS = {num for num, (impact, _, _) in MANUAL_TRIAGE.items() if impact == "fixed"}
+
+
+def norm(s: str) -> str:
+    return re.sub(r"\s+", " ", s or "").strip()
+
+
+def matches(text: str, groups: list[tuple[str, list[str]]]) -> list[str]:
+    out = []
+    lower = text.lower()
+    for name, pats in groups:
+        if any(p.lower() in lower for p in pats):
+            out.append(name)
+    return out
+
+
+def classify(issue: dict) -> dict:
+    num = int(issue["number"])
+    title = norm(issue.get("title", ""))
+    body = norm(issue.get("body", ""))
+    text = f"{title} {body}"
+    manual = MANUAL_TRIAGE.get(num)
+    if manual:
+        impact, status, note = manual
+        cats = matches(text, HIGH_PATTERNS + MEDIUM_PATTERNS + LOW_PATTERNS)
+        return {
+            "upstream": f"Wei-Shaw/sub2api#{num}",
+            "url": issue.get("html_url"),
+            "title": title,
+            "impact": impact,
+            "categories": cats or ["manual"],
+            "tokenkey_status": status,
+            "rationale": note,
+            "updated_at": issue.get("updated_at"),
+        }
+
+    high = matches(text, HIGH_PATTERNS)
+    medium = matches(text, MEDIUM_PATTERNS)
+    low = matches(text, LOW_PATTERNS)
+    if high:
+        impact = "needs_review"
+        status = "candidate_unverified"
+        rationale = "Keyword match for production-sensitive area; not yet manually verified against TokenKey code."
+        cats = high
+    elif medium:
+        impact = "medium"
+        status = "not_prioritized"
+        rationale = "Potential compatibility/ops/admin impact, but not selected as severe TokenKey production risk in this pass."
+        cats = medium
+    elif low:
+        impact = "low"
+        status = "not_prioritized"
+        rationale = "Appears to be enhancement/docs/UI request rather than severe online service risk."
+        cats = low
+    else:
+        impact = "unknown_low_signal"
+        status = "not_prioritized"
+        rationale = "No high-signal production-risk keywords in this pass."
+        cats = []
+    return {
+        "upstream": f"Wei-Shaw/sub2api#{num}",
+        "url": issue.get("html_url"),
+        "title": title,
+        "impact": impact,
+        "categories": cats,
+        "tokenkey_status": status,
+        "rationale": rationale,
+        "updated_at": issue.get("updated_at"),
+    }
+
+
+def main() -> int:
+    if len(sys.argv) != 3:
+        print("usage: upstream_issue_triage_generate.py <input.jsonl> <output.json>", file=sys.stderr)
+        return 2
+    src = Path(sys.argv[1])
+    dst = Path(sys.argv[2])
+    entries = []
+    for line in src.read_text(encoding="utf-8").splitlines():
+        if not line.strip():
+            continue
+        entries.append(classify(json.loads(line)))
+
+    priority = {
+        "high": 0,
+        "needs_review": 1,
+        "needs_prod_validation": 2,
+        "medium": 3,
+        "fixed": 4,
+        "not_applicable": 5,
+        "low": 6,
+        "unknown_low_signal": 7,
+    }
+    entries.sort(key=lambda e: (priority.get(e["impact"], 9), e["upstream"]))
+    data = {
+        "version": 1,
+        "source": "Wei-Shaw/sub2api open issues",
+        "generated_from": "GitHub REST API issues?state=open; pull requests excluded",
+        "rationale": "TokenKey-local triage cache for upstream open issues. Use this file before re-triaging upstream issues; update entries when TokenKey fixes, dismisses, or reclassifies an issue.",
+        "counts": {},
+        "issues": entries,
+    }
+    counts = {}
+    for e in entries:
+        counts[e["impact"]] = counts.get(e["impact"], 0) + 1
+    data["counts"] = counts
+    dst.write_text(json.dumps(data, ensure_ascii=False, indent=2) + "\n", encoding="utf-8")
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/scripts/upstream-issue-triage.json
+++ b/scripts/upstream-issue-triage.json
@@ -1,0 +1,11117 @@
+{
+  "version": 1,
+  "source": "Wei-Shaw/sub2api open issues",
+  "generated_from": "GitHub REST API issues?state=open; pull requests excluded",
+  "rationale": "TokenKey-local triage cache for upstream open issues. Use this file before re-triaging upstream issues; update entries when TokenKey fixes, dismisses, or reclassifies an issue.",
+  "counts": {
+    "high": 4,
+    "needs_review": 343,
+    "needs_prod_validation": 8,
+    "medium": 114,
+    "fixed": 13,
+    "not_applicable": 1,
+    "low": 94,
+    "unknown_low_signal": 393
+  },
+  "issues": [
+    {
+      "upstream": "Wei-Shaw/sub2api#2107",
+      "url": "https://github.com/Wei-Shaw/sub2api/issues/2107",
+      "title": "Bug: 渠道定价配置了区间定价后，默认价格(flat)不生效，导致费用为 0",
+      "impact": "high",
+      "categories": [
+        "billing_usage",
+        "security",
+        "ops_observability"
+      ],
+      "tokenkey_status": "unresolved_in_tokenkey",
+      "rationale": "Channel token interval pricing still returns before applying flat defaults; out-of-range intervals fall back to catalog/base pricing and can charge 0.",
+      "updated_at": "2026-04-29T15:47:22Z"
+    },
+    {
+      "upstream": "Wei-Shaw/sub2api#2159",
+      "url": "https://github.com/Wei-Shaw/sub2api/issues/2159",
+      "title": "Bug: 禁用的代理仍被用于请求转发 & 代理认证信息静默丢失",
+      "impact": "high",
+      "categories": [
+        "ops_observability",
+        "enhancement"
+      ],
+      "tokenkey_status": "unresolved_in_tokenkey",
+      "rationale": "Disabled proxies are still loaded by ID without status filtering, so linked accounts may keep using disabled proxy routes.",
+      "updated_at": "2026-05-02T06:59:45Z"
+    },
+    {
+      "upstream": "Wei-Shaw/sub2api#2258",
+      "url": "https://github.com/Wei-Shaw/sub2api/issues/2258",
+      "title": "紧急: OpenAI 账号 429 冷却时间误判（瞬时突发限流被当成用量限流），导致长时间 503",
+      "impact": "high",
+      "categories": [
+        "rate_limit_cooldown",
+        "billing_usage",
+        "account_pool_health",
+        "security",
+        "admin_ui",
+        "enhancement"
+      ],
+      "tokenkey_status": "unresolved_in_tokenkey",
+      "rationale": "OpenAI 429 burst still uses the larger Codex reset header when 5h/7d usage windows are below 100%, causing long 503 windows.",
+      "updated_at": "2026-05-07T16:54:09Z"
+    },
+    {
+      "upstream": "Wei-Shaw/sub2api#2478",
+      "url": "https://github.com/Wei-Shaw/sub2api/issues/2478",
+      "title": "【bug反馈】 已过期但未软删的订阅会永久阻塞同一 (user, group) 的再分配，返回 409 `validity_days_mismatch`",
+      "impact": "high",
+      "categories": [
+        "billing_usage",
+        "enhancement"
+      ],
+      "tokenkey_status": "unresolved_in_tokenkey",
+      "rationale": "Expired non-soft-deleted subscriptions still satisfy ExistsByUserIDAndGroupID and can return validity_days_mismatch on reassignment.",
+      "updated_at": "2026-05-15T01:33:33Z"
+    },
+    {
+      "upstream": "Wei-Shaw/sub2api#1033",
+      "url": "https://github.com/Wei-Shaw/sub2api/issues/1033",
+      "title": "refresh_token无法调用gpt-5.4",
+      "impact": "needs_review",
+      "categories": [
+        "security"
+      ],
+      "tokenkey_status": "candidate_unverified",
+      "rationale": "Keyword match for production-sensitive area; not yet manually verified against TokenKey code.",
+      "updated_at": "2026-03-15T16:59:54Z"
+    },
+    {
+      "upstream": "Wei-Shaw/sub2api#1044",
+      "url": "https://github.com/Wei-Shaw/sub2api/issues/1044",
+      "title": "sonnet 1M error，opus 1M available",
+      "impact": "needs_review",
+      "categories": [
+        "claude_mimicry"
+      ],
+      "tokenkey_status": "candidate_unverified",
+      "rationale": "Keyword match for production-sensitive area; not yet manually verified against TokenKey code.",
+      "updated_at": "2026-03-17T03:02:39Z"
+    },
+    {
+      "upstream": "Wei-Shaw/sub2api#1055",
+      "url": "https://github.com/Wei-Shaw/sub2api/issues/1055",
+      "title": "codex cli无法读取缓存导致费用飙升",
+      "impact": "needs_review",
+      "categories": [
+        "rate_limit_cooldown",
+        "billing_usage",
+        "security"
+      ],
+      "tokenkey_status": "candidate_unverified",
+      "rationale": "Keyword match for production-sensitive area; not yet manually verified against TokenKey code.",
+      "updated_at": "2026-03-27T02:46:56Z"
+    },
+    {
+      "upstream": "Wei-Shaw/sub2api#1066",
+      "url": "https://github.com/Wei-Shaw/sub2api/issues/1066",
+      "title": "Responses API: system messages in input array not converted to instructions field",
+      "impact": "needs_review",
+      "categories": [
+        "rate_limit_cooldown",
+        "image_oauth"
+      ],
+      "tokenkey_status": "candidate_unverified",
+      "rationale": "Keyword match for production-sensitive area; not yet manually verified against TokenKey code.",
+      "updated_at": "2026-03-16T11:41:31Z"
+    },
+    {
+      "upstream": "Wei-Shaw/sub2api#1087",
+      "url": "https://github.com/Wei-Shaw/sub2api/issues/1087",
+      "title": "功能建议：为 /api/v1/usage/dashboard/models 增加 api_key_id 参数支持",
+      "impact": "needs_review",
+      "categories": [
+        "billing_usage"
+      ],
+      "tokenkey_status": "candidate_unverified",
+      "rationale": "Keyword match for production-sensitive area; not yet manually verified against TokenKey code.",
+      "updated_at": "2026-03-17T07:41:45Z"
+    },
+    {
+      "upstream": "Wei-Shaw/sub2api#109",
+      "url": "https://github.com/Wei-Shaw/sub2api/issues/109",
+      "title": "GenerateSessionHash 未将 model 加入计算，或导致账户优先级不生效",
+      "impact": "needs_review",
+      "categories": [
+        "claude_mimicry",
+        "image_oauth"
+      ],
+      "tokenkey_status": "candidate_unverified",
+      "rationale": "Keyword match for production-sensitive area; not yet manually verified against TokenKey code.",
+      "updated_at": "2026-01-02T14:39:46Z"
+    },
+    {
+      "upstream": "Wei-Shaw/sub2api#1093",
+      "url": "https://github.com/Wei-Shaw/sub2api/issues/1093",
+      "title": "Antigravity API key account test uses invalid upstream paths against cloudcode-pa.googleapis.com",
+      "impact": "needs_review",
+      "categories": [
+        "rate_limit_cooldown",
+        "image_oauth"
+      ],
+      "tokenkey_status": "candidate_unverified",
+      "rationale": "Keyword match for production-sensitive area; not yet manually verified against TokenKey code.",
+      "updated_at": "2026-03-17T10:04:39Z"
+    },
+    {
+      "upstream": "Wei-Shaw/sub2api#1103",
+      "url": "https://github.com/Wei-Shaw/sub2api/issues/1103",
+      "title": "当请求传入User-Agent 请求头为 OpenAI/xxxx 时必现响应返回403",
+      "impact": "needs_review",
+      "categories": [
+        "claude_mimicry"
+      ],
+      "tokenkey_status": "candidate_unverified",
+      "rationale": "Keyword match for production-sensitive area; not yet manually verified against TokenKey code.",
+      "updated_at": "2026-04-12T15:17:35Z"
+    },
+    {
+      "upstream": "Wei-Shaw/sub2api#1170",
+      "url": "https://github.com/Wei-Shaw/sub2api/issues/1170",
+      "title": "批量导入 /admin/accounts/data 时 group_ids 未正确生效，手动编辑账号后才会生效",
+      "impact": "needs_review",
+      "categories": [
+        "image_oauth",
+        "security"
+      ],
+      "tokenkey_status": "candidate_unverified",
+      "rationale": "Keyword match for production-sensitive area; not yet manually verified against TokenKey code.",
+      "updated_at": "2026-03-19T18:15:43Z"
+    },
+    {
+      "upstream": "Wei-Shaw/sub2api#1175",
+      "url": "https://github.com/Wei-Shaw/sub2api/issues/1175",
+      "title": "[Bug] 单账号场景下 thinking block signature 每次多轮对话必触发 400，疑似转发过程中修改了 thinking block",
+      "impact": "needs_review",
+      "categories": [
+        "claude_mimicry",
+        "image_oauth",
+        "security"
+      ],
+      "tokenkey_status": "candidate_unverified",
+      "rationale": "Keyword match for production-sensitive area; not yet manually verified against TokenKey code.",
+      "updated_at": "2026-03-20T05:22:20Z"
+    },
+    {
+      "upstream": "Wei-Shaw/sub2api#1179",
+      "url": "https://github.com/Wei-Shaw/sub2api/issues/1179",
+      "title": "claude code 导入pro账户失败",
+      "impact": "needs_review",
+      "categories": [
+        "claude_mimicry"
+      ],
+      "tokenkey_status": "candidate_unverified",
+      "rationale": "Keyword match for production-sensitive area; not yet manually verified against TokenKey code.",
+      "updated_at": "2026-03-20T07:52:23Z"
+    },
+    {
+      "upstream": "Wei-Shaw/sub2api#1195",
+      "url": "https://github.com/Wei-Shaw/sub2api/issues/1195",
+      "title": "我发现一个问题，任务调度失败后状态、调度居然没自动关闭和暂停这是怎么回事",
+      "impact": "needs_review",
+      "categories": [
+        "security"
+      ],
+      "tokenkey_status": "candidate_unverified",
+      "rationale": "Keyword match for production-sensitive area; not yet manually verified against TokenKey code.",
+      "updated_at": "2026-03-21T08:53:45Z"
+    },
+    {
+      "upstream": "Wei-Shaw/sub2api#1210",
+      "url": "https://github.com/Wei-Shaw/sub2api/issues/1210",
+      "title": "bug：max_output_tokens",
+      "impact": "needs_review",
+      "categories": [
+        "security"
+      ],
+      "tokenkey_status": "candidate_unverified",
+      "rationale": "Keyword match for production-sensitive area; not yet manually verified against TokenKey code.",
+      "updated_at": "2026-03-22T04:54:30Z"
+    },
+    {
+      "upstream": "Wei-Shaw/sub2api#1219",
+      "url": "https://github.com/Wei-Shaw/sub2api/issues/1219",
+      "title": "关于Sora创作增加veo模型创作和gpt生图",
+      "impact": "needs_review",
+      "categories": [
+        "image_oauth"
+      ],
+      "tokenkey_status": "candidate_unverified",
+      "rationale": "Keyword match for production-sensitive area; not yet manually verified against TokenKey code.",
+      "updated_at": "2026-03-22T20:23:52Z"
+    },
+    {
+      "upstream": "Wei-Shaw/sub2api#1238",
+      "url": "https://github.com/Wei-Shaw/sub2api/issues/1238",
+      "title": "遥测",
+      "impact": "needs_review",
+      "categories": [
+        "claude_mimicry"
+      ],
+      "tokenkey_status": "candidate_unverified",
+      "rationale": "Keyword match for production-sensitive area; not yet manually verified against TokenKey code.",
+      "updated_at": "2026-05-04T14:04:29Z"
+    },
+    {
+      "upstream": "Wei-Shaw/sub2api#1245",
+      "url": "https://github.com/Wei-Shaw/sub2api/issues/1245",
+      "title": "账号管理里面筛选正常 会把限流中的也列出来",
+      "impact": "needs_review",
+      "categories": [
+        "rate_limit_cooldown"
+      ],
+      "tokenkey_status": "candidate_unverified",
+      "rationale": "Keyword match for production-sensitive area; not yet manually verified against TokenKey code.",
+      "updated_at": "2026-03-24T05:45:19Z"
+    },
+    {
+      "upstream": "Wei-Shaw/sub2api#1247",
+      "url": "https://github.com/Wei-Shaw/sub2api/issues/1247",
+      "title": "[Bug] Streaming chat completions fails with array-format content (Cursor compatibility)",
+      "impact": "needs_review",
+      "categories": [
+        "rate_limit_cooldown",
+        "image_oauth"
+      ],
+      "tokenkey_status": "candidate_unverified",
+      "rationale": "Keyword match for production-sensitive area; not yet manually verified against TokenKey code.",
+      "updated_at": "2026-04-10T03:14:08Z"
+    },
+    {
+      "upstream": "Wei-Shaw/sub2api#1256",
+      "url": "https://github.com/Wei-Shaw/sub2api/issues/1256",
+      "title": "支持自定义模型计费",
+      "impact": "needs_review",
+      "categories": [
+        "billing_usage"
+      ],
+      "tokenkey_status": "candidate_unverified",
+      "rationale": "Keyword match for production-sensitive area; not yet manually verified against TokenKey code.",
+      "updated_at": "2026-04-25T01:57:31Z"
+    },
+    {
+      "upstream": "Wei-Shaw/sub2api#1264",
+      "url": "https://github.com/Wei-Shaw/sub2api/issues/1264",
+      "title": "# [Bug] `/v1/responses` endpoint forwards unsupported `user` parameter to upstream, causing 400 error",
+      "impact": "needs_review",
+      "categories": [
+        "rate_limit_cooldown",
+        "image_oauth",
+        "security"
+      ],
+      "tokenkey_status": "candidate_unverified",
+      "rationale": "Keyword match for production-sensitive area; not yet manually verified against TokenKey code.",
+      "updated_at": "2026-03-24T13:52:59Z"
+    },
+    {
+      "upstream": "Wei-Shaw/sub2api#1292",
+      "url": "https://github.com/Wei-Shaw/sub2api/issues/1292",
+      "title": "[Bug] OpenAI API Key 上游无法对接 Azure OpenAI Responses API（路径/鉴权/api-version 不兼容）",
+      "impact": "needs_review",
+      "categories": [
+        "security"
+      ],
+      "tokenkey_status": "candidate_unverified",
+      "rationale": "Keyword match for production-sensitive area; not yet manually verified against TokenKey code.",
+      "updated_at": "2026-05-07T12:00:51Z"
+    },
+    {
+      "upstream": "Wei-Shaw/sub2api#1294",
+      "url": "https://github.com/Wei-Shaw/sub2api/issues/1294",
+      "title": "codex 切换问题",
+      "impact": "needs_review",
+      "categories": [
+        "rate_limit_cooldown"
+      ],
+      "tokenkey_status": "candidate_unverified",
+      "rationale": "Keyword match for production-sensitive area; not yet manually verified against TokenKey code.",
+      "updated_at": "2026-03-31T08:28:58Z"
+    },
+    {
+      "upstream": "Wei-Shaw/sub2api#1296",
+      "url": "https://github.com/Wei-Shaw/sub2api/issues/1296",
+      "title": "Codex",
+      "impact": "needs_review",
+      "categories": [
+        "claude_mimicry"
+      ],
+      "tokenkey_status": "candidate_unverified",
+      "rationale": "Keyword match for production-sensitive area; not yet manually verified against TokenKey code.",
+      "updated_at": "2026-03-25T06:59:04Z"
+    },
+    {
+      "upstream": "Wei-Shaw/sub2api#1298",
+      "url": "https://github.com/Wei-Shaw/sub2api/issues/1298",
+      "title": "Error running remote compact task: unexpected status 502 Bad Gateway: Upstream request failed, url: http://127.0.0.1:8000/responses/compact, request id: 24256265-62a 3-4bc3-86dc-53bbec0eca72",
+      "impact": "needs_review",
+      "categories": [
+        "rate_limit_cooldown",
+        "image_oauth",
+        "security"
+      ],
+      "tokenkey_status": "candidate_unverified",
+      "rationale": "Keyword match for production-sensitive area; not yet manually verified against TokenKey code.",
+      "updated_at": "2026-04-06T03:41:47Z"
+    },
+    {
+      "upstream": "Wei-Shaw/sub2api#1307",
+      "url": "https://github.com/Wei-Shaw/sub2api/issues/1307",
+      "title": "openai账号开启自动透传用在claude code里",
+      "impact": "needs_review",
+      "categories": [
+        "claude_mimicry"
+      ],
+      "tokenkey_status": "candidate_unverified",
+      "rationale": "Keyword match for production-sensitive area; not yet manually verified against TokenKey code.",
+      "updated_at": "2026-03-26T01:29:14Z"
+    },
+    {
+      "upstream": "Wei-Shaw/sub2api#1311",
+      "url": "https://github.com/Wei-Shaw/sub2api/issues/1311",
+      "title": "[Bug] /v1/chat/completions non-stream returns JSON body with Content-Type: text/event-stream",
+      "impact": "needs_review",
+      "categories": [
+        "claude_mimicry",
+        "rate_limit_cooldown",
+        "billing_usage",
+        "security"
+      ],
+      "tokenkey_status": "candidate_unverified",
+      "rationale": "Keyword match for production-sensitive area; not yet manually verified against TokenKey code.",
+      "updated_at": "2026-05-07T12:38:41Z"
+    },
+    {
+      "upstream": "Wei-Shaw/sub2api#1312",
+      "url": "https://github.com/Wei-Shaw/sub2api/issues/1312",
+      "title": "codex 中出线这样■ unexpected status 503 Service Unavailable: Service temporarily unavailable, url: http://xx.xx.xx.xx:8080/v1/responses, request id: aa39a7d1-6807-46a4-911d-4c53e32a10a4",
+      "impact": "needs_review",
+      "categories": [
+        "rate_limit_cooldown"
+      ],
+      "tokenkey_status": "candidate_unverified",
+      "rationale": "Keyword match for production-sensitive area; not yet manually verified against TokenKey code.",
+      "updated_at": "2026-04-19T10:53:21Z"
+    },
+    {
+      "upstream": "Wei-Shaw/sub2api#1318",
+      "url": "https://github.com/Wei-Shaw/sub2api/issues/1318",
+      "title": "[bug] openai_passthrough 命中临时不可调度规则后未触发 failover",
+      "impact": "needs_review",
+      "categories": [
+        "rate_limit_cooldown",
+        "image_oauth"
+      ],
+      "tokenkey_status": "candidate_unverified",
+      "rationale": "Keyword match for production-sensitive area; not yet manually verified against TokenKey code.",
+      "updated_at": "2026-03-26T06:47:06Z"
+    },
+    {
+      "upstream": "Wei-Shaw/sub2api#1322",
+      "url": "https://github.com/Wei-Shaw/sub2api/issues/1322",
+      "title": "Responses terminal event detection is inconsistent: gateway_service.go does not treat response.incomplete / response.cancelled as terminal",
+      "impact": "needs_review",
+      "categories": [
+        "rate_limit_cooldown",
+        "billing_usage",
+        "account_pool_health"
+      ],
+      "tokenkey_status": "candidate_unverified",
+      "rationale": "Keyword match for production-sensitive area; not yet manually verified against TokenKey code.",
+      "updated_at": "2026-03-26T08:41:35Z"
+    },
+    {
+      "upstream": "Wei-Shaw/sub2api#1326",
+      "url": "https://github.com/Wei-Shaw/sub2api/issues/1326",
+      "title": "使用容器部署并使用nginx反代，sub2api日志显示请求ip为docker 网桥网关ip",
+      "impact": "needs_review",
+      "categories": [
+        "rate_limit_cooldown",
+        "billing_usage"
+      ],
+      "tokenkey_status": "candidate_unverified",
+      "rationale": "Keyword match for production-sensitive area; not yet manually verified against TokenKey code.",
+      "updated_at": "2026-04-30T06:21:49Z"
+    },
+    {
+      "upstream": "Wei-Shaw/sub2api#1331",
+      "url": "https://github.com/Wei-Shaw/sub2api/issues/1331",
+      "title": "feat: 网关层协议自动转换，使分组与平台解耦",
+      "impact": "needs_review",
+      "categories": [
+        "claude_mimicry",
+        "billing_usage"
+      ],
+      "tokenkey_status": "candidate_unverified",
+      "rationale": "Keyword match for production-sensitive area; not yet manually verified against TokenKey code.",
+      "updated_at": "2026-03-28T16:22:06Z"
+    },
+    {
+      "upstream": "Wei-Shaw/sub2api#1339",
+      "url": "https://github.com/Wei-Shaw/sub2api/issues/1339",
+      "title": "open ai 502 Upstream authentication failed, please contact administrator,免费帐号池从昨晚开始不能用了，不知道啥原因",
+      "impact": "needs_review",
+      "categories": [
+        "rate_limit_cooldown",
+        "image_oauth"
+      ],
+      "tokenkey_status": "candidate_unverified",
+      "rationale": "Keyword match for production-sensitive area; not yet manually verified against TokenKey code.",
+      "updated_at": "2026-03-27T06:44:52Z"
+    },
+    {
+      "upstream": "Wei-Shaw/sub2api#1341",
+      "url": "https://github.com/Wei-Shaw/sub2api/issues/1341",
+      "title": "v0.1.104 备份失败 pg_dump failed: start pg_dump: exec: \\\"pg_dump\\\": executable file not found in $PATH",
+      "impact": "needs_review",
+      "categories": [
+        "rate_limit_cooldown"
+      ],
+      "tokenkey_status": "candidate_unverified",
+      "rationale": "Keyword match for production-sensitive area; not yet manually verified against TokenKey code.",
+      "updated_at": "2026-04-15T22:40:20Z"
+    },
+    {
+      "upstream": "Wei-Shaw/sub2api#1348",
+      "url": "https://github.com/Wei-Shaw/sub2api/issues/1348",
+      "title": "账号状态过载中",
+      "impact": "needs_review",
+      "categories": [
+        "rate_limit_cooldown"
+      ],
+      "tokenkey_status": "candidate_unverified",
+      "rationale": "Keyword match for production-sensitive area; not yet manually verified against TokenKey code.",
+      "updated_at": "2026-03-31T09:20:21Z"
+    },
+    {
+      "upstream": "Wei-Shaw/sub2api#1353",
+      "url": "https://github.com/Wei-Shaw/sub2api/issues/1353",
+      "title": "TLS Fingerprint Collector 捕获指纹提示 401 Invalid API key",
+      "impact": "needs_review",
+      "categories": [
+        "claude_mimicry"
+      ],
+      "tokenkey_status": "candidate_unverified",
+      "rationale": "Keyword match for production-sensitive area; not yet manually verified against TokenKey code.",
+      "updated_at": "2026-03-28T07:55:57Z"
+    },
+    {
+      "upstream": "Wei-Shaw/sub2api#1360",
+      "url": "https://github.com/Wei-Shaw/sub2api/issues/1360",
+      "title": "【建议】账号增加使用量控制，避免某个用户突然使用过高，造成封号",
+      "impact": "needs_review",
+      "categories": [
+        "rate_limit_cooldown"
+      ],
+      "tokenkey_status": "candidate_unverified",
+      "rationale": "Keyword match for production-sensitive area; not yet manually verified against TokenKey code.",
+      "updated_at": "2026-03-28T15:57:33Z"
+    },
+    {
+      "upstream": "Wei-Shaw/sub2api#1369",
+      "url": "https://github.com/Wei-Shaw/sub2api/issues/1369",
+      "title": "openai的免费账号里面的gpt额度是否可以给claude code使用",
+      "impact": "needs_review",
+      "categories": [
+        "claude_mimicry"
+      ],
+      "tokenkey_status": "candidate_unverified",
+      "rationale": "Keyword match for production-sensitive area; not yet manually verified against TokenKey code.",
+      "updated_at": "2026-04-17T10:45:54Z"
+    },
+    {
+      "upstream": "Wei-Shaw/sub2api#1381",
+      "url": "https://github.com/Wei-Shaw/sub2api/issues/1381",
+      "title": "refresh_token 竞争消耗导致 invalid_grant 错误",
+      "impact": "needs_review",
+      "categories": [
+        "security"
+      ],
+      "tokenkey_status": "candidate_unverified",
+      "rationale": "Keyword match for production-sensitive area; not yet manually verified against TokenKey code.",
+      "updated_at": "2026-03-30T06:40:54Z"
+    },
+    {
+      "upstream": "Wei-Shaw/sub2api#1384",
+      "url": "https://github.com/Wei-Shaw/sub2api/issues/1384",
+      "title": "opencode使用gpt模型无法切换推理强度",
+      "impact": "needs_review",
+      "categories": [
+        "rate_limit_cooldown"
+      ],
+      "tokenkey_status": "candidate_unverified",
+      "rationale": "Keyword match for production-sensitive area; not yet manually verified against TokenKey code.",
+      "updated_at": "2026-05-05T05:50:08Z"
+    },
+    {
+      "upstream": "Wei-Shaw/sub2api#1386",
+      "url": "https://github.com/Wei-Shaw/sub2api/issues/1386",
+      "title": "自定义 Claude Code 的 URL 和 KEY 计费为0",
+      "impact": "needs_review",
+      "categories": [
+        "claude_mimicry",
+        "billing_usage"
+      ],
+      "tokenkey_status": "candidate_unverified",
+      "rationale": "Keyword match for production-sensitive area; not yet manually verified against TokenKey code.",
+      "updated_at": "2026-03-30T12:14:03Z"
+    },
+    {
+      "upstream": "Wei-Shaw/sub2api#1387",
+      "url": "https://github.com/Wei-Shaw/sub2api/issues/1387",
+      "title": "用户管理：建议增加 token 用量",
+      "impact": "needs_review",
+      "categories": [
+        "security"
+      ],
+      "tokenkey_status": "candidate_unverified",
+      "rationale": "Keyword match for production-sensitive area; not yet manually verified against TokenKey code.",
+      "updated_at": "2026-03-30T12:25:22Z"
+    },
+    {
+      "upstream": "Wei-Shaw/sub2api#1388",
+      "url": "https://github.com/Wei-Shaw/sub2api/issues/1388",
+      "title": "可以优化下账号系统",
+      "impact": "needs_review",
+      "categories": [
+        "security"
+      ],
+      "tokenkey_status": "candidate_unverified",
+      "rationale": "Keyword match for production-sensitive area; not yet manually verified against TokenKey code.",
+      "updated_at": "2026-03-30T13:03:16Z"
+    },
+    {
+      "upstream": "Wei-Shaw/sub2api#1395",
+      "url": "https://github.com/Wei-Shaw/sub2api/issues/1395",
+      "title": "账号配额可以支持按请求次数吗？",
+      "impact": "needs_review",
+      "categories": [
+        "security"
+      ],
+      "tokenkey_status": "candidate_unverified",
+      "rationale": "Keyword match for production-sensitive area; not yet manually verified against TokenKey code.",
+      "updated_at": "2026-03-30T15:58:41Z"
+    },
+    {
+      "upstream": "Wei-Shaw/sub2api#1409",
+      "url": "https://github.com/Wei-Shaw/sub2api/issues/1409",
+      "title": "Gemini 429问题",
+      "impact": "needs_review",
+      "categories": [
+        "rate_limit_cooldown",
+        "image_oauth"
+      ],
+      "tokenkey_status": "candidate_unverified",
+      "rationale": "Keyword match for production-sensitive area; not yet manually verified against TokenKey code.",
+      "updated_at": "2026-05-03T13:01:23Z"
+    },
+    {
+      "upstream": "Wei-Shaw/sub2api#1413",
+      "url": "https://github.com/Wei-Shaw/sub2api/issues/1413",
+      "title": "claude-code最新的逆向文档",
+      "impact": "needs_review",
+      "categories": [
+        "billing_usage"
+      ],
+      "tokenkey_status": "candidate_unverified",
+      "rationale": "Keyword match for production-sensitive area; not yet manually verified against TokenKey code.",
+      "updated_at": "2026-04-25T11:11:56Z"
+    },
+    {
+      "upstream": "Wei-Shaw/sub2api#1430",
+      "url": "https://github.com/Wei-Shaw/sub2api/issues/1430",
+      "title": "【扣费0元BUG】CC中使用GPT，当模型设置为GPT时，会出现计费0元的问题",
+      "impact": "needs_review",
+      "categories": [
+        "billing_usage"
+      ],
+      "tokenkey_status": "candidate_unverified",
+      "rationale": "Keyword match for production-sensitive area; not yet manually verified against TokenKey code.",
+      "updated_at": "2026-04-01T17:27:01Z"
+    },
+    {
+      "upstream": "Wei-Shaw/sub2api#1438",
+      "url": "https://github.com/Wei-Shaw/sub2api/issues/1438",
+      "title": "Feature Request: How to use \"自定义转发 URL\" for Anthropic setup-token accounts in v0.1.106?",
+      "impact": "needs_review",
+      "categories": [
+        "claude_mimicry",
+        "rate_limit_cooldown",
+        "image_oauth",
+        "security"
+      ],
+      "tokenkey_status": "candidate_unverified",
+      "rationale": "Keyword match for production-sensitive area; not yet manually verified against TokenKey code.",
+      "updated_at": "2026-04-02T17:42:58Z"
+    },
+    {
+      "upstream": "Wei-Shaw/sub2api#1440",
+      "url": "https://github.com/Wei-Shaw/sub2api/issues/1440",
+      "title": "Is this project still maintained? The community is waiting for response!",
+      "impact": "needs_review",
+      "categories": [
+        "claude_mimicry"
+      ],
+      "tokenkey_status": "candidate_unverified",
+      "rationale": "Keyword match for production-sensitive area; not yet manually verified against TokenKey code.",
+      "updated_at": "2026-04-02T19:24:26Z"
+    },
+    {
+      "upstream": "Wei-Shaw/sub2api#1443",
+      "url": "https://github.com/Wei-Shaw/sub2api/issues/1443",
+      "title": "【bug】 新版本 的 cluade code 客户端限制异常",
+      "impact": "needs_review",
+      "categories": [
+        "claude_mimicry"
+      ],
+      "tokenkey_status": "candidate_unverified",
+      "rationale": "Keyword match for production-sensitive area; not yet manually verified against TokenKey code.",
+      "updated_at": "2026-04-29T02:37:58Z"
+    },
+    {
+      "upstream": "Wei-Shaw/sub2api#1445",
+      "url": "https://github.com/Wei-Shaw/sub2api/issues/1445",
+      "title": "【bug】用户消耗量过大",
+      "impact": "needs_review",
+      "categories": [
+        "security"
+      ],
+      "tokenkey_status": "candidate_unverified",
+      "rationale": "Keyword match for production-sensitive area; not yet manually verified against TokenKey code.",
+      "updated_at": "2026-04-05T04:36:57Z"
+    },
+    {
+      "upstream": "Wei-Shaw/sub2api#1450",
+      "url": "https://github.com/Wei-Shaw/sub2api/issues/1450",
+      "title": "【优化建议】限流判断逻辑优化",
+      "impact": "needs_review",
+      "categories": [
+        "rate_limit_cooldown"
+      ],
+      "tokenkey_status": "candidate_unverified",
+      "rationale": "Keyword match for production-sensitive area; not yet manually verified against TokenKey code.",
+      "updated_at": "2026-04-03T16:34:46Z"
+    },
+    {
+      "upstream": "Wei-Shaw/sub2api#1451",
+      "url": "https://github.com/Wei-Shaw/sub2api/issues/1451",
+      "title": "【功能建议】用户身份隐藏功能 - 借鉴 cc-gateway 的实现",
+      "impact": "needs_review",
+      "categories": [
+        "claude_mimicry",
+        "billing_usage",
+        "security"
+      ],
+      "tokenkey_status": "candidate_unverified",
+      "rationale": "Keyword match for production-sensitive area; not yet manually verified against TokenKey code.",
+      "updated_at": "2026-04-05T14:09:07Z"
+    },
+    {
+      "upstream": "Wei-Shaw/sub2api#1456",
+      "url": "https://github.com/Wei-Shaw/sub2api/issues/1456",
+      "title": "我不觉得应该在默认配置中加入 1M 上下文",
+      "impact": "needs_review",
+      "categories": [
+        "security"
+      ],
+      "tokenkey_status": "candidate_unverified",
+      "rationale": "Keyword match for production-sensitive area; not yet manually verified against TokenKey code.",
+      "updated_at": "2026-04-04T10:43:00Z"
+    },
+    {
+      "upstream": "Wei-Shaw/sub2api#1468",
+      "url": "https://github.com/Wei-Shaw/sub2api/issues/1468",
+      "title": "关于日卡额度刷新问题",
+      "impact": "needs_review",
+      "categories": [
+        "billing_usage"
+      ],
+      "tokenkey_status": "candidate_unverified",
+      "rationale": "Keyword match for production-sensitive area; not yet manually verified against TokenKey code.",
+      "updated_at": "2026-04-14T02:47:41Z"
+    },
+    {
+      "upstream": "Wei-Shaw/sub2api#1471",
+      "url": "https://github.com/Wei-Shaw/sub2api/issues/1471",
+      "title": "OpenAI /v1/responses streaming can emit malformed SSE after stream_read_error",
+      "impact": "needs_review",
+      "categories": [
+        "rate_limit_cooldown",
+        "account_pool_health"
+      ],
+      "tokenkey_status": "candidate_unverified",
+      "rationale": "Keyword match for production-sensitive area; not yet manually verified against TokenKey code.",
+      "updated_at": "2026-04-06T00:12:29Z"
+    },
+    {
+      "upstream": "Wei-Shaw/sub2api#1475",
+      "url": "https://github.com/Wei-Shaw/sub2api/issues/1475",
+      "title": "无可用模型时，不应该返回 Service temporarily unavailable",
+      "impact": "needs_review",
+      "categories": [
+        "rate_limit_cooldown"
+      ],
+      "tokenkey_status": "candidate_unverified",
+      "rationale": "Keyword match for production-sensitive area; not yet manually verified against TokenKey code.",
+      "updated_at": "2026-04-26T10:00:20Z"
+    },
+    {
+      "upstream": "Wei-Shaw/sub2api#1493",
+      "url": "https://github.com/Wei-Shaw/sub2api/issues/1493",
+      "title": "`/v1/responses` 流式正常，但非流式可能返回 `output=[]`",
+      "impact": "needs_review",
+      "categories": [
+        "rate_limit_cooldown",
+        "billing_usage",
+        "image_oauth",
+        "account_pool_health",
+        "security"
+      ],
+      "tokenkey_status": "candidate_unverified",
+      "rationale": "Keyword match for production-sensitive area; not yet manually verified against TokenKey code.",
+      "updated_at": "2026-04-07T15:16:26Z"
+    },
+    {
+      "upstream": "Wei-Shaw/sub2api#1494",
+      "url": "https://github.com/Wei-Shaw/sub2api/issues/1494",
+      "title": "从v0.1.106升级到v0.1.108之后，GPT模型的非流式返回异常。",
+      "impact": "needs_review",
+      "categories": [
+        "security"
+      ],
+      "tokenkey_status": "candidate_unverified",
+      "rationale": "Keyword match for production-sensitive area; not yet manually verified against TokenKey code.",
+      "updated_at": "2026-04-07T11:09:46Z"
+    },
+    {
+      "upstream": "Wei-Shaw/sub2api#1499",
+      "url": "https://github.com/Wei-Shaw/sub2api/issues/1499",
+      "title": "批量刷新openai令牌 失败的账号不会标记出来",
+      "impact": "needs_review",
+      "categories": [
+        "image_oauth",
+        "security"
+      ],
+      "tokenkey_status": "candidate_unverified",
+      "rationale": "Keyword match for production-sensitive area; not yet manually verified against TokenKey code.",
+      "updated_at": "2026-04-07T12:50:25Z"
+    },
+    {
+      "upstream": "Wei-Shaw/sub2api#1508",
+      "url": "https://github.com/Wei-Shaw/sub2api/issues/1508",
+      "title": "我这边排查到一个后台“使用记录”展示口径不一致的问题，想反馈一下",
+      "impact": "needs_review",
+      "categories": [
+        "billing_usage"
+      ],
+      "tokenkey_status": "candidate_unverified",
+      "rationale": "Keyword match for production-sensitive area; not yet manually verified against TokenKey code.",
+      "updated_at": "2026-04-08T05:04:59Z"
+    },
+    {
+      "upstream": "Wei-Shaw/sub2api#1510",
+      "url": "https://github.com/Wei-Shaw/sub2api/issues/1510",
+      "title": "502 {\"error\":{\"message\":\"Upstream access forbidden, please contact administrator\",\"type\":\"upstream_error\"},\"type\":\"error\"}",
+      "impact": "needs_review",
+      "categories": [
+        "rate_limit_cooldown",
+        "image_oauth"
+      ],
+      "tokenkey_status": "candidate_unverified",
+      "rationale": "Keyword match for production-sensitive area; not yet manually verified against TokenKey code.",
+      "updated_at": "2026-04-13T03:20:26Z"
+    },
+    {
+      "upstream": "Wei-Shaw/sub2api#1517",
+      "url": "https://github.com/Wei-Shaw/sub2api/issues/1517",
+      "title": "OpenAI APIKey upstream 无法兼容“自定义 URI provider”形态",
+      "impact": "needs_review",
+      "categories": [
+        "rate_limit_cooldown"
+      ],
+      "tokenkey_status": "candidate_unverified",
+      "rationale": "Keyword match for production-sensitive area; not yet manually verified against TokenKey code.",
+      "updated_at": "2026-04-08T14:42:46Z"
+    },
+    {
+      "upstream": "Wei-Shaw/sub2api#1520",
+      "url": "https://github.com/Wei-Shaw/sub2api/issues/1520",
+      "title": "分享: sub2api 在接入大语言模型接口时如何绕过风控的一些经验",
+      "impact": "needs_review",
+      "categories": [
+        "claude_mimicry",
+        "security"
+      ],
+      "tokenkey_status": "candidate_unverified",
+      "rationale": "Keyword match for production-sensitive area; not yet manually verified against TokenKey code.",
+      "updated_at": "2026-04-25T11:22:15Z"
+    },
+    {
+      "upstream": "Wei-Shaw/sub2api#1525",
+      "url": "https://github.com/Wei-Shaw/sub2api/issues/1525",
+      "title": "opencode被claude识别为第三方客户端",
+      "impact": "needs_review",
+      "categories": [
+        "claude_mimicry",
+        "billing_usage"
+      ],
+      "tokenkey_status": "candidate_unverified",
+      "rationale": "Keyword match for production-sensitive area; not yet manually verified against TokenKey code.",
+      "updated_at": "2026-05-04T20:14:46Z"
+    },
+    {
+      "upstream": "Wei-Shaw/sub2api#1528",
+      "url": "https://github.com/Wei-Shaw/sub2api/issues/1528",
+      "title": "[v0.1.110] Anthropic /v1/messages: content_block_start for text type missing initial \"text\":\"\" field breaks Anthropic/Claude Agent SDK",
+      "impact": "needs_review",
+      "categories": [
+        "claude_mimicry",
+        "billing_usage",
+        "security"
+      ],
+      "tokenkey_status": "candidate_unverified",
+      "rationale": "Keyword match for production-sensitive area; not yet manually verified against TokenKey code.",
+      "updated_at": "2026-04-09T04:03:25Z"
+    },
+    {
+      "upstream": "Wei-Shaw/sub2api#1532",
+      "url": "https://github.com/Wei-Shaw/sub2api/issues/1532",
+      "title": "升级到110的版本后 openai 一直502,但是在面板里面测试是正常的",
+      "impact": "needs_review",
+      "categories": [
+        "rate_limit_cooldown",
+        "image_oauth"
+      ],
+      "tokenkey_status": "candidate_unverified",
+      "rationale": "Keyword match for production-sensitive area; not yet manually verified against TokenKey code.",
+      "updated_at": "2026-04-15T02:34:44Z"
+    },
+    {
+      "upstream": "Wei-Shaw/sub2api#1540",
+      "url": "https://github.com/Wei-Shaw/sub2api/issues/1540",
+      "title": "拉取并合并最新上游代码",
+      "impact": "needs_review",
+      "categories": [
+        "rate_limit_cooldown"
+      ],
+      "tokenkey_status": "candidate_unverified",
+      "rationale": "Keyword match for production-sensitive area; not yet manually verified against TokenKey code.",
+      "updated_at": "2026-04-09T15:11:45Z"
+    },
+    {
+      "upstream": "Wei-Shaw/sub2api#1541",
+      "url": "https://github.com/Wei-Shaw/sub2api/issues/1541",
+      "title": "不想自己搞号池，有批发货源的吗？想整个图片/视频/LLM模型的聚合平台",
+      "impact": "needs_review",
+      "categories": [
+        "image_oauth"
+      ],
+      "tokenkey_status": "candidate_unverified",
+      "rationale": "Keyword match for production-sensitive area; not yet manually verified against TokenKey code.",
+      "updated_at": "2026-04-26T12:46:03Z"
+    },
+    {
+      "upstream": "Wei-Shaw/sub2api#1544",
+      "url": "https://github.com/Wei-Shaw/sub2api/issues/1544",
+      "title": "[BUG] 系统中出现未配置的模型,并且计费为 0.",
+      "impact": "needs_review",
+      "categories": [
+        "billing_usage"
+      ],
+      "tokenkey_status": "candidate_unverified",
+      "rationale": "Keyword match for production-sensitive area; not yet manually verified against TokenKey code.",
+      "updated_at": "2026-04-10T09:09:16Z"
+    },
+    {
+      "upstream": "Wei-Shaw/sub2api#1552",
+      "url": "https://github.com/Wei-Shaw/sub2api/issues/1552",
+      "title": "upstream stream ended without terminal event",
+      "impact": "needs_review",
+      "categories": [
+        "claude_mimicry",
+        "rate_limit_cooldown"
+      ],
+      "tokenkey_status": "candidate_unverified",
+      "rationale": "Keyword match for production-sensitive area; not yet manually verified against TokenKey code.",
+      "updated_at": "2026-04-10T21:28:23Z"
+    },
+    {
+      "upstream": "Wei-Shaw/sub2api#1553",
+      "url": "https://github.com/Wei-Shaw/sub2api/issues/1553",
+      "title": "sub2api router is severly compromised",
+      "impact": "needs_review",
+      "categories": [
+        "rate_limit_cooldown",
+        "security"
+      ],
+      "tokenkey_status": "candidate_unverified",
+      "rationale": "Keyword match for production-sensitive area; not yet manually verified against TokenKey code.",
+      "updated_at": "2026-04-10T20:46:17Z"
+    },
+    {
+      "upstream": "Wei-Shaw/sub2api#1554",
+      "url": "https://github.com/Wei-Shaw/sub2api/issues/1554",
+      "title": "无法使用",
+      "impact": "needs_review",
+      "categories": [
+        "image_oauth"
+      ],
+      "tokenkey_status": "candidate_unverified",
+      "rationale": "Keyword match for production-sensitive area; not yet manually verified against TokenKey code.",
+      "updated_at": "2026-04-11T06:31:02Z"
+    },
+    {
+      "upstream": "Wei-Shaw/sub2api#1558",
+      "url": "https://github.com/Wei-Shaw/sub2api/issues/1558",
+      "title": "OpenAI legacy transform 链路删除 previous_response_id，导致 Codex 长会话 prompt cache 频繁失效、费用暴增",
+      "impact": "needs_review",
+      "categories": [
+        "claude_mimicry",
+        "security"
+      ],
+      "tokenkey_status": "candidate_unverified",
+      "rationale": "Keyword match for production-sensitive area; not yet manually verified against TokenKey code.",
+      "updated_at": "2026-04-10T20:24:48Z"
+    },
+    {
+      "upstream": "Wei-Shaw/sub2api#1562",
+      "url": "https://github.com/Wei-Shaw/sub2api/issues/1562",
+      "title": "系统不支持gpt-5.4-pro，手动填gpt-5.4-pro，按gpt-5.4-pro计费",
+      "impact": "needs_review",
+      "categories": [
+        "billing_usage"
+      ],
+      "tokenkey_status": "candidate_unverified",
+      "rationale": "Keyword match for production-sensitive area; not yet manually verified against TokenKey code.",
+      "updated_at": "2026-04-26T14:01:24Z"
+    },
+    {
+      "upstream": "Wei-Shaw/sub2api#1574",
+      "url": "https://github.com/Wei-Shaw/sub2api/issues/1574",
+      "title": "更新到Sub2API 0.1.110后，仍然会触发第三方系统的问题，更新前的一个版本不会遇到这个问题，小请求（<2500 tokens）成功，大请求会被 Anthropic 拒绝",
+      "impact": "needs_review",
+      "categories": [
+        "claude_mimicry",
+        "billing_usage",
+        "security"
+      ],
+      "tokenkey_status": "candidate_unverified",
+      "rationale": "Keyword match for production-sensitive area; not yet manually verified against TokenKey code.",
+      "updated_at": "2026-04-11T11:50:08Z"
+    },
+    {
+      "upstream": "Wei-Shaw/sub2api#1585",
+      "url": "https://github.com/Wei-Shaw/sub2api/issues/1585",
+      "title": "codexModelMap 硬编码将 gpt-5.3-codex-spark 归一化为 gpt-5.3-codex，导致 Spark 独立配额桶无法使用",
+      "impact": "needs_review",
+      "categories": [
+        "rate_limit_cooldown",
+        "billing_usage",
+        "image_oauth"
+      ],
+      "tokenkey_status": "candidate_unverified",
+      "rationale": "Keyword match for production-sensitive area; not yet manually verified against TokenKey code.",
+      "updated_at": "2026-04-15T08:52:21Z"
+    },
+    {
+      "upstream": "Wei-Shaw/sub2api#1599",
+      "url": "https://github.com/Wei-Shaw/sub2api/issues/1599",
+      "title": "账号类型判断错误及限流恢复统计",
+      "impact": "needs_review",
+      "categories": [
+        "rate_limit_cooldown"
+      ],
+      "tokenkey_status": "candidate_unverified",
+      "rationale": "Keyword match for production-sensitive area; not yet manually verified against TokenKey code.",
+      "updated_at": "2026-04-12T15:06:39Z"
+    },
+    {
+      "upstream": "Wei-Shaw/sub2api#1609",
+      "url": "https://github.com/Wei-Shaw/sub2api/issues/1609",
+      "title": "Error running remote compact task: unexpected status 502 Bad Gateway: Upstream request failed, url: http://***/v1/responses/compact",
+      "impact": "needs_review",
+      "categories": [
+        "rate_limit_cooldown",
+        "image_oauth"
+      ],
+      "tokenkey_status": "candidate_unverified",
+      "rationale": "Keyword match for production-sensitive area; not yet manually verified against TokenKey code.",
+      "updated_at": "2026-05-12T01:49:59Z"
+    },
+    {
+      "upstream": "Wei-Shaw/sub2api#1625",
+      "url": "https://github.com/Wei-Shaw/sub2api/issues/1625",
+      "title": "codex 号池每天晚上8点开始集中爆发502错误",
+      "impact": "needs_review",
+      "categories": [
+        "image_oauth",
+        "security"
+      ],
+      "tokenkey_status": "candidate_unverified",
+      "rationale": "Keyword match for production-sensitive area; not yet manually verified against TokenKey code.",
+      "updated_at": "2026-04-13T12:00:23Z"
+    },
+    {
+      "upstream": "Wei-Shaw/sub2api#1627",
+      "url": "https://github.com/Wei-Shaw/sub2api/issues/1627",
+      "title": "计费咨询，都是 gpt-5.4 fast 为啥 有时候是 5刀 输入 25输入，有时候是 10刀 33输出",
+      "impact": "needs_review",
+      "categories": [
+        "billing_usage"
+      ],
+      "tokenkey_status": "candidate_unverified",
+      "rationale": "Keyword match for production-sensitive area; not yet manually verified against TokenKey code.",
+      "updated_at": "2026-04-14T08:17:54Z"
+    },
+    {
+      "upstream": "Wei-Shaw/sub2api#1630",
+      "url": "https://github.com/Wei-Shaw/sub2api/issues/1630",
+      "title": "settings表中turnstile_secret_key、turnstile_site_key、turnstile_enabled不会更新值",
+      "impact": "needs_review",
+      "categories": [
+        "security"
+      ],
+      "tokenkey_status": "candidate_unverified",
+      "rationale": "Keyword match for production-sensitive area; not yet manually verified against TokenKey code.",
+      "updated_at": "2026-04-13T14:45:41Z"
+    },
+    {
+      "upstream": "Wei-Shaw/sub2api#1633",
+      "url": "https://github.com/Wei-Shaw/sub2api/issues/1633",
+      "title": "[BUG] Codex credit not usable due to automatic OAuth account pause",
+      "impact": "needs_review",
+      "categories": [
+        "rate_limit_cooldown",
+        "image_oauth"
+      ],
+      "tokenkey_status": "candidate_unverified",
+      "rationale": "Keyword match for production-sensitive area; not yet manually verified against TokenKey code.",
+      "updated_at": "2026-04-13T22:52:08Z"
+    },
+    {
+      "upstream": "Wei-Shaw/sub2api#1651",
+      "url": "https://github.com/Wei-Shaw/sub2api/issues/1651",
+      "title": "[Bug] v0.1.112 下 `/v1/chat/completions` 会把请求模型静默改写为 `gpt-5.4`（如 `gpt-5.4-mini -> gpt-5.4`）",
+      "impact": "needs_review",
+      "categories": [
+        "billing_usage"
+      ],
+      "tokenkey_status": "candidate_unverified",
+      "rationale": "Keyword match for production-sensitive area; not yet manually verified against TokenKey code.",
+      "updated_at": "2026-04-24T14:22:37Z"
+    },
+    {
+      "upstream": "Wei-Shaw/sub2api#1657",
+      "url": "https://github.com/Wei-Shaw/sub2api/issues/1657",
+      "title": "feat: 前端支持自定义css/html替换",
+      "impact": "needs_review",
+      "categories": [
+        "security"
+      ],
+      "tokenkey_status": "candidate_unverified",
+      "rationale": "Keyword match for production-sensitive area; not yet manually verified against TokenKey code.",
+      "updated_at": "2026-04-16T08:04:20Z"
+    },
+    {
+      "upstream": "Wei-Shaw/sub2api#1661",
+      "url": "https://github.com/Wei-Shaw/sub2api/issues/1661",
+      "title": "接入new-api 测试账号时无内容返回",
+      "impact": "needs_review",
+      "categories": [
+        "rate_limit_cooldown",
+        "account_pool_health"
+      ],
+      "tokenkey_status": "candidate_unverified",
+      "rationale": "Keyword match for production-sensitive area; not yet manually verified against TokenKey code.",
+      "updated_at": "2026-04-15T02:35:52Z"
+    },
+    {
+      "upstream": "Wei-Shaw/sub2api#1662",
+      "url": "https://github.com/Wei-Shaw/sub2api/issues/1662",
+      "title": "[Bug] scheduler cache strips OpenAI WS flags and causes websocket_account_select_failed",
+      "impact": "needs_review",
+      "categories": [
+        "image_oauth"
+      ],
+      "tokenkey_status": "candidate_unverified",
+      "rationale": "Keyword match for production-sensitive area; not yet manually verified against TokenKey code.",
+      "updated_at": "2026-04-16T03:02:02Z"
+    },
+    {
+      "upstream": "Wei-Shaw/sub2api#1665",
+      "url": "https://github.com/Wei-Shaw/sub2api/issues/1665",
+      "title": "openai auth 账号 重置状态无法修改用量窗口",
+      "impact": "needs_review",
+      "categories": [
+        "rate_limit_cooldown"
+      ],
+      "tokenkey_status": "candidate_unverified",
+      "rationale": "Keyword match for production-sensitive area; not yet manually verified against TokenKey code.",
+      "updated_at": "2026-04-15T08:08:59Z"
+    },
+    {
+      "upstream": "Wei-Shaw/sub2api#1674",
+      "url": "https://github.com/Wei-Shaw/sub2api/issues/1674",
+      "title": "429账号能不能自动暂停调度",
+      "impact": "needs_review",
+      "categories": [
+        "rate_limit_cooldown"
+      ],
+      "tokenkey_status": "candidate_unverified",
+      "rationale": "Keyword match for production-sensitive area; not yet manually verified against TokenKey code.",
+      "updated_at": "2026-04-15T10:54:38Z"
+    },
+    {
+      "upstream": "Wei-Shaw/sub2api#1679",
+      "url": "https://github.com/Wei-Shaw/sub2api/issues/1679",
+      "title": "希望 Sub2API 支持 OpenAI 兼容媒体接口：",
+      "impact": "needs_review",
+      "categories": [
+        "image_oauth"
+      ],
+      "tokenkey_status": "candidate_unverified",
+      "rationale": "Keyword match for production-sensitive area; not yet manually verified against TokenKey code.",
+      "updated_at": "2026-04-15T13:34:41Z"
+    },
+    {
+      "upstream": "Wei-Shaw/sub2api#1680",
+      "url": "https://github.com/Wei-Shaw/sub2api/issues/1680",
+      "title": "Nvidia接口无法测试模型",
+      "impact": "needs_review",
+      "categories": [
+        "rate_limit_cooldown",
+        "image_oauth",
+        "account_pool_health"
+      ],
+      "tokenkey_status": "candidate_unverified",
+      "rationale": "Keyword match for production-sensitive area; not yet manually verified against TokenKey code.",
+      "updated_at": "2026-04-16T03:53:13Z"
+    },
+    {
+      "upstream": "Wei-Shaw/sub2api#1694",
+      "url": "https://github.com/Wei-Shaw/sub2api/issues/1694",
+      "title": "bug：渠道配置模型计费，很严重",
+      "impact": "needs_review",
+      "categories": [
+        "billing_usage"
+      ],
+      "tokenkey_status": "candidate_unverified",
+      "rationale": "Keyword match for production-sensitive area; not yet manually verified against TokenKey code.",
+      "updated_at": "2026-04-17T06:47:57Z"
+    },
+    {
+      "upstream": "Wei-Shaw/sub2api#1706",
+      "url": "https://github.com/Wei-Shaw/sub2api/issues/1706",
+      "title": "bug：v0.1.113版本更新后缓存读命中很低",
+      "impact": "needs_review",
+      "categories": [
+        "claude_mimicry"
+      ],
+      "tokenkey_status": "candidate_unverified",
+      "rationale": "Keyword match for production-sensitive area; not yet manually verified against TokenKey code.",
+      "updated_at": "2026-04-16T14:11:46Z"
+    },
+    {
+      "upstream": "Wei-Shaw/sub2api#1715",
+      "url": "https://github.com/Wei-Shaw/sub2api/issues/1715",
+      "title": "请问应该如何配置claude code的oauth比较安全呢，我使用了一段时间配置了两次，两次都掉订阅被ban了，账号倒是没被ban，想知道如何应该合理的配置，我觉得我能理解的选项都选了，还是被ban了，还只是20刀的账户",
+      "impact": "needs_review",
+      "categories": [
+        "claude_mimicry",
+        "image_oauth",
+        "security"
+      ],
+      "tokenkey_status": "candidate_unverified",
+      "rationale": "Keyword match for production-sensitive area; not yet manually verified against TokenKey code.",
+      "updated_at": "2026-04-22T09:09:07Z"
+    },
+    {
+      "upstream": "Wei-Shaw/sub2api#1723",
+      "url": "https://github.com/Wei-Shaw/sub2api/issues/1723",
+      "title": "[Performance] UpdateLastUsed 写放大导致 Redis 大量不必要流量（单部署实测 1.85 TB / 6.5 天）",
+      "impact": "needs_review",
+      "categories": [
+        "billing_usage"
+      ],
+      "tokenkey_status": "candidate_unverified",
+      "rationale": "Keyword match for production-sensitive area; not yet manually verified against TokenKey code.",
+      "updated_at": "2026-04-20T06:29:41Z"
+    },
+    {
+      "upstream": "Wei-Shaw/sub2api#175",
+      "url": "https://github.com/Wei-Shaw/sub2api/issues/175",
+      "title": "Codex 账户Token缓存计算",
+      "impact": "needs_review",
+      "categories": [
+        "security"
+      ],
+      "tokenkey_status": "candidate_unverified",
+      "rationale": "Keyword match for production-sensitive area; not yet manually verified against TokenKey code.",
+      "updated_at": "2026-04-25T01:34:53Z"
+    },
+    {
+      "upstream": "Wei-Shaw/sub2api#1755",
+      "url": "https://github.com/Wei-Shaw/sub2api/issues/1755",
+      "title": "Feature Request: 为 Anthropic 请求增加可配置的 Header / Body 重写规则",
+      "impact": "needs_review",
+      "categories": [
+        "billing_usage",
+        "image_oauth",
+        "security"
+      ],
+      "tokenkey_status": "candidate_unverified",
+      "rationale": "Keyword match for production-sensitive area; not yet manually verified against TokenKey code.",
+      "updated_at": "2026-04-19T15:22:42Z"
+    },
+    {
+      "upstream": "Wei-Shaw/sub2api#1769",
+      "url": "https://github.com/Wei-Shaw/sub2api/issues/1769",
+      "title": "[Bug] Codex Responses WebSocket (ctx_pool) is unstable: frequent disconnects, 1013 busy, continuation unavailable",
+      "impact": "needs_review",
+      "categories": [
+        "rate_limit_cooldown",
+        "billing_usage",
+        "account_pool_health"
+      ],
+      "tokenkey_status": "candidate_unverified",
+      "rationale": "Keyword match for production-sensitive area; not yet manually verified against TokenKey code.",
+      "updated_at": "2026-04-24T04:08:53Z"
+    },
+    {
+      "upstream": "Wei-Shaw/sub2api#1777",
+      "url": "https://github.com/Wei-Shaw/sub2api/issues/1777",
+      "title": "feat: 为 /v1/models 增加 context_length、pricing、max_output_tokens 等可选字段",
+      "impact": "needs_review",
+      "categories": [
+        "security"
+      ],
+      "tokenkey_status": "candidate_unverified",
+      "rationale": "Keyword match for production-sensitive area; not yet manually verified against TokenKey code.",
+      "updated_at": "2026-04-21T03:59:57Z"
+    },
+    {
+      "upstream": "Wei-Shaw/sub2api#1786",
+      "url": "https://github.com/Wei-Shaw/sub2api/issues/1786",
+      "title": "增加claude code订阅过滤绕过的功能",
+      "impact": "needs_review",
+      "categories": [
+        "claude_mimicry",
+        "billing_usage"
+      ],
+      "tokenkey_status": "candidate_unverified",
+      "rationale": "Keyword match for production-sensitive area; not yet manually verified against TokenKey code.",
+      "updated_at": "2026-04-23T02:43:18Z"
+    },
+    {
+      "upstream": "Wei-Shaw/sub2api#1790",
+      "url": "https://github.com/Wei-Shaw/sub2api/issues/1790",
+      "title": "建议适配图片模型",
+      "impact": "needs_review",
+      "categories": [
+        "image_oauth"
+      ],
+      "tokenkey_status": "candidate_unverified",
+      "rationale": "Keyword match for production-sensitive area; not yet manually verified against TokenKey code.",
+      "updated_at": "2026-04-22T08:21:30Z"
+    },
+    {
+      "upstream": "Wei-Shaw/sub2api#1798",
+      "url": "https://github.com/Wei-Shaw/sub2api/issues/1798",
+      "title": "发现问题，关于claude的计费问题",
+      "impact": "needs_review",
+      "categories": [
+        "billing_usage",
+        "security"
+      ],
+      "tokenkey_status": "candidate_unverified",
+      "rationale": "Keyword match for production-sensitive area; not yet manually verified against TokenKey code.",
+      "updated_at": "2026-04-22T08:26:49Z"
+    },
+    {
+      "upstream": "Wei-Shaw/sub2api#1803",
+      "url": "https://github.com/Wei-Shaw/sub2api/issues/1803",
+      "title": "sub2api 对话卡住并且无法调度",
+      "impact": "needs_review",
+      "categories": [
+        "rate_limit_cooldown",
+        "billing_usage",
+        "account_pool_health"
+      ],
+      "tokenkey_status": "candidate_unverified",
+      "rationale": "Keyword match for production-sensitive area; not yet manually verified against TokenKey code.",
+      "updated_at": "2026-04-28T04:12:48Z"
+    },
+    {
+      "upstream": "Wei-Shaw/sub2api#1805",
+      "url": "https://github.com/Wei-Shaw/sub2api/issues/1805",
+      "title": "不能直接通过codex 调用image2 模型",
+      "impact": "needs_review",
+      "categories": [
+        "image_oauth"
+      ],
+      "tokenkey_status": "candidate_unverified",
+      "rationale": "Keyword match for production-sensitive area; not yet manually verified against TokenKey code.",
+      "updated_at": "2026-05-06T02:11:51Z"
+    },
+    {
+      "upstream": "Wei-Shaw/sub2api#1807",
+      "url": "https://github.com/Wei-Shaw/sub2api/issues/1807",
+      "title": "Codex 0.122.0 + sub2api 0.1.115 版本会报错 Stream disconnected before completion: websocket closed by server before response.completed",
+      "impact": "needs_review",
+      "categories": [
+        "account_pool_health"
+      ],
+      "tokenkey_status": "candidate_unverified",
+      "rationale": "Keyword match for production-sensitive area; not yet manually verified against TokenKey code.",
+      "updated_at": "2026-05-06T06:17:03Z"
+    },
+    {
+      "upstream": "Wei-Shaw/sub2api#1812",
+      "url": "https://github.com/Wei-Shaw/sub2api/issues/1812",
+      "title": "[Bug] Cursor 调用 sub2api 的api速度很慢并且计费异常",
+      "impact": "needs_review",
+      "categories": [
+        "billing_usage"
+      ],
+      "tokenkey_status": "candidate_unverified",
+      "rationale": "Keyword match for production-sensitive area; not yet manually verified against TokenKey code.",
+      "updated_at": "2026-05-05T16:01:53Z"
+    },
+    {
+      "upstream": "Wei-Shaw/sub2api#1830",
+      "url": "https://github.com/Wei-Shaw/sub2api/issues/1830",
+      "title": "model not found: gpt-5.4",
+      "impact": "needs_review",
+      "categories": [
+        "rate_limit_cooldown",
+        "billing_usage",
+        "security"
+      ],
+      "tokenkey_status": "candidate_unverified",
+      "rationale": "Keyword match for production-sensitive area; not yet manually verified against TokenKey code.",
+      "updated_at": "2026-04-23T06:14:50Z"
+    },
+    {
+      "upstream": "Wei-Shaw/sub2api#1833",
+      "url": "https://github.com/Wei-Shaw/sub2api/issues/1833",
+      "title": "不扣费",
+      "impact": "needs_review",
+      "categories": [
+        "billing_usage"
+      ],
+      "tokenkey_status": "candidate_unverified",
+      "rationale": "Keyword match for production-sensitive area; not yet manually verified against TokenKey code.",
+      "updated_at": "2026-04-24T08:46:58Z"
+    },
+    {
+      "upstream": "Wei-Shaw/sub2api#1834",
+      "url": "https://github.com/Wei-Shaw/sub2api/issues/1834",
+      "title": "图生图接口有问题",
+      "impact": "needs_review",
+      "categories": [
+        "image_oauth"
+      ],
+      "tokenkey_status": "candidate_unverified",
+      "rationale": "Keyword match for production-sensitive area; not yet manually verified against TokenKey code.",
+      "updated_at": "2026-04-23T07:55:00Z"
+    },
+    {
+      "upstream": "Wei-Shaw/sub2api#1838",
+      "url": "https://github.com/Wei-Shaw/sub2api/issues/1838",
+      "title": "希望可以支持集群部署",
+      "impact": "needs_review",
+      "categories": [
+        "image_oauth"
+      ],
+      "tokenkey_status": "candidate_unverified",
+      "rationale": "Keyword match for production-sensitive area; not yet manually verified against TokenKey code.",
+      "updated_at": "2026-05-11T00:20:32Z"
+    },
+    {
+      "upstream": "Wei-Shaw/sub2api#1840",
+      "url": "https://github.com/Wei-Shaw/sub2api/issues/1840",
+      "title": "希望可以增加下述这些功能",
+      "impact": "needs_review",
+      "categories": [
+        "claude_mimicry"
+      ],
+      "tokenkey_status": "candidate_unverified",
+      "rationale": "Keyword match for production-sensitive area; not yet manually verified against TokenKey code.",
+      "updated_at": "2026-04-23T08:15:11Z"
+    },
+    {
+      "upstream": "Wei-Shaw/sub2api#1848",
+      "url": "https://github.com/Wei-Shaw/sub2api/issues/1848",
+      "title": "No tool output found for tool search call fcAb412xDxQGKyvfaZDRdKyHIQ",
+      "impact": "needs_review",
+      "categories": [
+        "image_oauth"
+      ],
+      "tokenkey_status": "candidate_unverified",
+      "rationale": "Keyword match for production-sensitive area; not yet manually verified against TokenKey code.",
+      "updated_at": "2026-04-24T10:31:04Z"
+    },
+    {
+      "upstream": "Wei-Shaw/sub2api#1849",
+      "url": "https://github.com/Wei-Shaw/sub2api/issues/1849",
+      "title": "请问下为什么在v0.1.116 free账号不支持生图了？",
+      "impact": "needs_review",
+      "categories": [
+        "image_oauth"
+      ],
+      "tokenkey_status": "candidate_unverified",
+      "rationale": "Keyword match for production-sensitive area; not yet manually verified against TokenKey code.",
+      "updated_at": "2026-04-23T16:23:29Z"
+    },
+    {
+      "upstream": "Wei-Shaw/sub2api#1854",
+      "url": "https://github.com/Wei-Shaw/sub2api/issues/1854",
+      "title": "CCS 导入按钮 的默认模型无法更改",
+      "impact": "needs_review",
+      "categories": [
+        "rate_limit_cooldown"
+      ],
+      "tokenkey_status": "candidate_unverified",
+      "rationale": "Keyword match for production-sensitive area; not yet manually verified against TokenKey code.",
+      "updated_at": "2026-04-23T16:24:11Z"
+    },
+    {
+      "upstream": "Wei-Shaw/sub2api#1856",
+      "url": "https://github.com/Wei-Shaw/sub2api/issues/1856",
+      "title": "升级 v0.1.116后，business team账号也不支持gpt-image-2模型了",
+      "impact": "needs_review",
+      "categories": [
+        "image_oauth"
+      ],
+      "tokenkey_status": "candidate_unverified",
+      "rationale": "Keyword match for production-sensitive area; not yet manually verified against TokenKey code.",
+      "updated_at": "2026-04-23T18:44:14Z"
+    },
+    {
+      "upstream": "Wei-Shaw/sub2api#1857",
+      "url": "https://github.com/Wei-Shaw/sub2api/issues/1857",
+      "title": "GPT-5.5模型定价和Fast模式价格适配",
+      "impact": "needs_review",
+      "categories": [
+        "billing_usage"
+      ],
+      "tokenkey_status": "candidate_unverified",
+      "rationale": "Keyword match for production-sensitive area; not yet manually verified against TokenKey code.",
+      "updated_at": "2026-04-24T03:34:12Z"
+    },
+    {
+      "upstream": "Wei-Shaw/sub2api#1858",
+      "url": "https://github.com/Wei-Shaw/sub2api/issues/1858",
+      "title": "升级v0.1.116总是出现502 非常频繁",
+      "impact": "needs_review",
+      "categories": [
+        "rate_limit_cooldown",
+        "image_oauth"
+      ],
+      "tokenkey_status": "candidate_unverified",
+      "rationale": "Keyword match for production-sensitive area; not yet manually verified against TokenKey code.",
+      "updated_at": "2026-04-24T07:07:58Z"
+    },
+    {
+      "upstream": "Wei-Shaw/sub2api#1870",
+      "url": "https://github.com/Wei-Shaw/sub2api/issues/1870",
+      "title": "/v1/models 接口应根据分组类型返回兼容的响应格式",
+      "impact": "needs_review",
+      "categories": [
+        "claude_mimicry"
+      ],
+      "tokenkey_status": "candidate_unverified",
+      "rationale": "Keyword match for production-sensitive area; not yet manually verified against TokenKey code.",
+      "updated_at": "2026-04-24T03:18:27Z"
+    },
+    {
+      "upstream": "Wei-Shaw/sub2api#1872",
+      "url": "https://github.com/Wei-Shaw/sub2api/issues/1872",
+      "title": "更新以后，请求都是502 啊",
+      "impact": "needs_review",
+      "categories": [
+        "image_oauth"
+      ],
+      "tokenkey_status": "candidate_unverified",
+      "rationale": "Keyword match for production-sensitive area; not yet manually verified against TokenKey code.",
+      "updated_at": "2026-04-24T10:19:48Z"
+    },
+    {
+      "upstream": "Wei-Shaw/sub2api#1878",
+      "url": "https://github.com/Wei-Shaw/sub2api/issues/1878",
+      "title": "bug：0.1.117更新后在codex可以生成图片，但是使用记录没有调用图片模型记录",
+      "impact": "needs_review",
+      "categories": [
+        "image_oauth"
+      ],
+      "tokenkey_status": "candidate_unverified",
+      "rationale": "Keyword match for production-sensitive area; not yet manually verified against TokenKey code.",
+      "updated_at": "2026-04-24T05:52:08Z"
+    },
+    {
+      "upstream": "Wei-Shaw/sub2api#1879",
+      "url": "https://github.com/Wei-Shaw/sub2api/issues/1879",
+      "title": "0.1.117 账号限额了，但状态没变",
+      "impact": "needs_review",
+      "categories": [
+        "rate_limit_cooldown"
+      ],
+      "tokenkey_status": "candidate_unverified",
+      "rationale": "Keyword match for production-sensitive area; not yet manually verified against TokenKey code.",
+      "updated_at": "2026-04-24T05:32:01Z"
+    },
+    {
+      "upstream": "Wei-Shaw/sub2api#1880",
+      "url": "https://github.com/Wei-Shaw/sub2api/issues/1880",
+      "title": "能兼容下free账号的生图功能吗？两者可以共存",
+      "impact": "needs_review",
+      "categories": [
+        "image_oauth"
+      ],
+      "tokenkey_status": "candidate_unverified",
+      "rationale": "Keyword match for production-sensitive area; not yet manually verified against TokenKey code.",
+      "updated_at": "2026-04-24T05:39:07Z"
+    },
+    {
+      "upstream": "Wei-Shaw/sub2api#1881",
+      "url": "https://github.com/Wei-Shaw/sub2api/issues/1881",
+      "title": "账号管理测试账号是通过的，但是实际调用会报错",
+      "impact": "needs_review",
+      "categories": [
+        "account_pool_health"
+      ],
+      "tokenkey_status": "candidate_unverified",
+      "rationale": "Keyword match for production-sensitive area; not yet manually verified against TokenKey code.",
+      "updated_at": "2026-04-24T05:43:13Z"
+    },
+    {
+      "upstream": "Wei-Shaw/sub2api#1885",
+      "url": "https://github.com/Wei-Shaw/sub2api/issues/1885",
+      "title": "v0.1.117 版本使用 GPT 5.5 出现 No tool output found for tool search call fcjAsf03FedtKVWvFij7eSFSo7 导致 502 错误",
+      "impact": "needs_review",
+      "categories": [
+        "rate_limit_cooldown",
+        "image_oauth"
+      ],
+      "tokenkey_status": "candidate_unverified",
+      "rationale": "Keyword match for production-sensitive area; not yet manually verified against TokenKey code.",
+      "updated_at": "2026-04-24T12:15:23Z"
+    },
+    {
+      "upstream": "Wei-Shaw/sub2api#1886",
+      "url": "https://github.com/Wei-Shaw/sub2api/issues/1886",
+      "title": "Codex和Chatgpt Images 2 限额问题",
+      "impact": "needs_review",
+      "categories": [
+        "image_oauth"
+      ],
+      "tokenkey_status": "candidate_unverified",
+      "rationale": "Keyword match for production-sensitive area; not yet manually verified against TokenKey code.",
+      "updated_at": "2026-04-25T09:16:30Z"
+    },
+    {
+      "upstream": "Wei-Shaw/sub2api#1887",
+      "url": "https://github.com/Wei-Shaw/sub2api/issues/1887",
+      "title": "OpenAI Codex (v0.124.0) 使用gpt-5.5 后报错Error running remote compact task: unexpected status 502 Bad Gateway: error code: 502",
+      "impact": "needs_review",
+      "categories": [
+        "image_oauth"
+      ],
+      "tokenkey_status": "candidate_unverified",
+      "rationale": "Keyword match for production-sensitive area; not yet manually verified against TokenKey code.",
+      "updated_at": "2026-05-02T15:27:24Z"
+    },
+    {
+      "upstream": "Wei-Shaw/sub2api#1891",
+      "url": "https://github.com/Wei-Shaw/sub2api/issues/1891",
+      "title": "Fix OpenAI OAuth gpt-5.5 support and unknown model error handling",
+      "impact": "needs_review",
+      "categories": [
+        "rate_limit_cooldown",
+        "image_oauth"
+      ],
+      "tokenkey_status": "candidate_unverified",
+      "rationale": "Keyword match for production-sensitive area; not yet manually verified against TokenKey code.",
+      "updated_at": "2026-05-03T06:12:03Z"
+    },
+    {
+      "upstream": "Wei-Shaw/sub2api#1893",
+      "url": "https://github.com/Wei-Shaw/sub2api/issues/1893",
+      "title": "[BUG]: Gemini 生图模型无法使用",
+      "impact": "needs_review",
+      "categories": [
+        "rate_limit_cooldown",
+        "image_oauth",
+        "account_pool_health"
+      ],
+      "tokenkey_status": "candidate_unverified",
+      "rationale": "Keyword match for production-sensitive area; not yet manually verified against TokenKey code.",
+      "updated_at": "2026-04-27T01:55:38Z"
+    },
+    {
+      "upstream": "Wei-Shaw/sub2api#1894",
+      "url": "https://github.com/Wei-Shaw/sub2api/issues/1894",
+      "title": "Claude oauth出现第三方工具，各位佬怎么解决的",
+      "impact": "needs_review",
+      "categories": [
+        "claude_mimicry",
+        "billing_usage",
+        "image_oauth"
+      ],
+      "tokenkey_status": "candidate_unverified",
+      "rationale": "Keyword match for production-sensitive area; not yet manually verified against TokenKey code.",
+      "updated_at": "2026-04-26T11:38:15Z"
+    },
+    {
+      "upstream": "Wei-Shaw/sub2api#1899",
+      "url": "https://github.com/Wei-Shaw/sub2api/issues/1899",
+      "title": "OpenAI OAuth Codex /responses image_generation continuation fails with Unknown parameter input[n].call_id",
+      "impact": "needs_review",
+      "categories": [
+        "rate_limit_cooldown",
+        "image_oauth"
+      ],
+      "tokenkey_status": "candidate_unverified",
+      "rationale": "Keyword match for production-sensitive area; not yet manually verified against TokenKey code.",
+      "updated_at": "2026-04-24T13:45:23Z"
+    },
+    {
+      "upstream": "Wei-Shaw/sub2api#1902",
+      "url": "https://github.com/Wei-Shaw/sub2api/issues/1902",
+      "title": "gpt生图调度问题",
+      "impact": "needs_review",
+      "categories": [
+        "image_oauth"
+      ],
+      "tokenkey_status": "candidate_unverified",
+      "rationale": "Keyword match for production-sensitive area; not yet manually verified against TokenKey code.",
+      "updated_at": "2026-04-25T12:37:25Z"
+    },
+    {
+      "upstream": "Wei-Shaw/sub2api#1903",
+      "url": "https://github.com/Wei-Shaw/sub2api/issues/1903",
+      "title": "gemini 一旦返回429 就会卡在临时停止调度上，除非手动解除",
+      "impact": "needs_review",
+      "categories": [
+        "rate_limit_cooldown"
+      ],
+      "tokenkey_status": "candidate_unverified",
+      "rationale": "Keyword match for production-sensitive area; not yet manually verified against TokenKey code.",
+      "updated_at": "2026-04-24T10:11:59Z"
+    },
+    {
+      "upstream": "Wei-Shaw/sub2api#1908",
+      "url": "https://github.com/Wei-Shaw/sub2api/issues/1908",
+      "title": "更新117版本请求报错",
+      "impact": "needs_review",
+      "categories": [
+        "rate_limit_cooldown",
+        "image_oauth"
+      ],
+      "tokenkey_status": "candidate_unverified",
+      "rationale": "Keyword match for production-sensitive area; not yet manually verified against TokenKey code.",
+      "updated_at": "2026-04-24T10:47:07Z"
+    },
+    {
+      "upstream": "Wei-Shaw/sub2api#1915",
+      "url": "https://github.com/Wei-Shaw/sub2api/issues/1915",
+      "title": "图片生成/修改成功后，会话进入异常状态，后续任意消息都会返回 502，后台日志提示 No tool output found for tool search call",
+      "impact": "needs_review",
+      "categories": [
+        "rate_limit_cooldown",
+        "image_oauth"
+      ],
+      "tokenkey_status": "candidate_unverified",
+      "rationale": "Keyword match for production-sensitive area; not yet manually verified against TokenKey code.",
+      "updated_at": "2026-04-25T12:30:26Z"
+    },
+    {
+      "upstream": "Wei-Shaw/sub2api#1928",
+      "url": "https://github.com/Wei-Shaw/sub2api/issues/1928",
+      "title": "gpt5.5在Claude code一直工具调用失败",
+      "impact": "needs_review",
+      "categories": [
+        "claude_mimicry"
+      ],
+      "tokenkey_status": "candidate_unverified",
+      "rationale": "Keyword match for production-sensitive area; not yet manually verified against TokenKey code.",
+      "updated_at": "2026-04-25T00:54:57Z"
+    },
+    {
+      "upstream": "Wei-Shaw/sub2api#1934",
+      "url": "https://github.com/Wei-Shaw/sub2api/issues/1934",
+      "title": "切组后旧 sticky session 没失效，导致一直调用已经被切出去的账号",
+      "impact": "needs_review",
+      "categories": [
+        "rate_limit_cooldown"
+      ],
+      "tokenkey_status": "candidate_unverified",
+      "rationale": "Keyword match for production-sensitive area; not yet manually verified against TokenKey code.",
+      "updated_at": "2026-04-25T03:35:59Z"
+    },
+    {
+      "upstream": "Wei-Shaw/sub2api#1941",
+      "url": "https://github.com/Wei-Shaw/sub2api/issues/1941",
+      "title": "【BUG】如果用户填写的模型错误，就不会有计费发生，但是还是能正常使用。",
+      "impact": "needs_review",
+      "categories": [
+        "billing_usage"
+      ],
+      "tokenkey_status": "candidate_unverified",
+      "rationale": "Keyword match for production-sensitive area; not yet manually verified against TokenKey code.",
+      "updated_at": "2026-04-25T05:54:39Z"
+    },
+    {
+      "upstream": "Wei-Shaw/sub2api#1946",
+      "url": "https://github.com/Wei-Shaw/sub2api/issues/1946",
+      "title": "【bug】anthropic监控渠道取值逻辑问题，text并不永远是content.0.text",
+      "impact": "needs_review",
+      "categories": [
+        "billing_usage",
+        "security"
+      ],
+      "tokenkey_status": "candidate_unverified",
+      "rationale": "Keyword match for production-sensitive area; not yet manually verified against TokenKey code.",
+      "updated_at": "2026-05-07T08:30:05Z"
+    },
+    {
+      "upstream": "Wei-Shaw/sub2api#1949",
+      "url": "https://github.com/Wei-Shaw/sub2api/issues/1949",
+      "title": "bug: 账号管理页测试弹窗缺少 OpenAI Compact 探测模式入口",
+      "impact": "needs_review",
+      "categories": [
+        "image_oauth",
+        "account_pool_health",
+        "security"
+      ],
+      "tokenkey_status": "candidate_unverified",
+      "rationale": "Keyword match for production-sensitive area; not yet manually verified against TokenKey code.",
+      "updated_at": "2026-04-30T07:31:25Z"
+    },
+    {
+      "upstream": "Wei-Shaw/sub2api#1950",
+      "url": "https://github.com/Wei-Shaw/sub2api/issues/1950",
+      "title": "我想知道Openclaw里面，如何配置gpt-image-2模型",
+      "impact": "needs_review",
+      "categories": [
+        "image_oauth",
+        "security"
+      ],
+      "tokenkey_status": "candidate_unverified",
+      "rationale": "Keyword match for production-sensitive area; not yet manually verified against TokenKey code.",
+      "updated_at": "2026-04-29T11:21:16Z"
+    },
+    {
+      "upstream": "Wei-Shaw/sub2api#1952",
+      "url": "https://github.com/Wei-Shaw/sub2api/issues/1952",
+      "title": "为啥一直提示503错误",
+      "impact": "needs_review",
+      "categories": [
+        "rate_limit_cooldown"
+      ],
+      "tokenkey_status": "candidate_unverified",
+      "rationale": "Keyword match for production-sensitive area; not yet manually verified against TokenKey code.",
+      "updated_at": "2026-04-25T18:45:26Z"
+    },
+    {
+      "upstream": "Wei-Shaw/sub2api#1955",
+      "url": "https://github.com/Wei-Shaw/sub2api/issues/1955",
+      "title": "无法生图",
+      "impact": "needs_review",
+      "categories": [
+        "image_oauth"
+      ],
+      "tokenkey_status": "candidate_unverified",
+      "rationale": "Keyword match for production-sensitive area; not yet manually verified against TokenKey code.",
+      "updated_at": "2026-05-13T07:47:51Z"
+    },
+    {
+      "upstream": "Wei-Shaw/sub2api#1956",
+      "url": "https://github.com/Wei-Shaw/sub2api/issues/1956",
+      "title": "[BUG] 关闭邮箱验证时，Linux.do 第三方注册依然需要邮箱验证",
+      "impact": "needs_review",
+      "categories": [
+        "claude_mimicry"
+      ],
+      "tokenkey_status": "candidate_unverified",
+      "rationale": "Keyword match for production-sensitive area; not yet manually verified against TokenKey code.",
+      "updated_at": "2026-05-11T13:51:39Z"
+    },
+    {
+      "upstream": "Wei-Shaw/sub2api#1966",
+      "url": "https://github.com/Wei-Shaw/sub2api/issues/1966",
+      "title": "Gemini/GPT无法生图",
+      "impact": "needs_review",
+      "categories": [
+        "image_oauth"
+      ],
+      "tokenkey_status": "candidate_unverified",
+      "rationale": "Keyword match for production-sensitive area; not yet manually verified against TokenKey code.",
+      "updated_at": "2026-04-25T15:06:32Z"
+    },
+    {
+      "upstream": "Wei-Shaw/sub2api#1967",
+      "url": "https://github.com/Wei-Shaw/sub2api/issues/1967",
+      "title": "Claude Code 缓存异常",
+      "impact": "needs_review",
+      "categories": [
+        "claude_mimicry"
+      ],
+      "tokenkey_status": "candidate_unverified",
+      "rationale": "Keyword match for production-sensitive area; not yet manually verified against TokenKey code.",
+      "updated_at": "2026-04-26T03:18:06Z"
+    },
+    {
+      "upstream": "Wei-Shaw/sub2api#1968",
+      "url": "https://github.com/Wei-Shaw/sub2api/issues/1968",
+      "title": "Claude Code返回错误“Extra inputs are not permitted”",
+      "impact": "needs_review",
+      "categories": [
+        "claude_mimicry"
+      ],
+      "tokenkey_status": "candidate_unverified",
+      "rationale": "Keyword match for production-sensitive area; not yet manually verified against TokenKey code.",
+      "updated_at": "2026-04-27T04:30:06Z"
+    },
+    {
+      "upstream": "Wei-Shaw/sub2api#1969",
+      "url": "https://github.com/Wei-Shaw/sub2api/issues/1969",
+      "title": "bug: codex开启Auto Review模式会导致503，因为使用了新的codex-auto-review内部模型",
+      "impact": "needs_review",
+      "categories": [
+        "rate_limit_cooldown"
+      ],
+      "tokenkey_status": "candidate_unverified",
+      "rationale": "Keyword match for production-sensitive area; not yet manually verified against TokenKey code.",
+      "updated_at": "2026-05-09T05:46:21Z"
+    },
+    {
+      "upstream": "Wei-Shaw/sub2api#1980",
+      "url": "https://github.com/Wei-Shaw/sub2api/issues/1980",
+      "title": "5.5 fast计费是不是有问题，现在怎么是1倍",
+      "impact": "needs_review",
+      "categories": [
+        "billing_usage"
+      ],
+      "tokenkey_status": "candidate_unverified",
+      "rationale": "Keyword match for production-sensitive area; not yet manually verified against TokenKey code.",
+      "updated_at": "2026-04-26T12:52:17Z"
+    },
+    {
+      "upstream": "Wei-Shaw/sub2api#1981",
+      "url": "https://github.com/Wei-Shaw/sub2api/issues/1981",
+      "title": "限流账号无主动探活，可用账号被长期闲置",
+      "impact": "needs_review",
+      "categories": [
+        "rate_limit_cooldown"
+      ],
+      "tokenkey_status": "candidate_unverified",
+      "rationale": "Keyword match for production-sensitive area; not yet manually verified against TokenKey code.",
+      "updated_at": "2026-04-26T02:45:43Z"
+    },
+    {
+      "upstream": "Wei-Shaw/sub2api#1982",
+      "url": "https://github.com/Wei-Shaw/sub2api/issues/1982",
+      "title": "claude code缓存异常",
+      "impact": "needs_review",
+      "categories": [
+        "claude_mimicry",
+        "billing_usage"
+      ],
+      "tokenkey_status": "candidate_unverified",
+      "rationale": "Keyword match for production-sensitive area; not yet manually verified against TokenKey code.",
+      "updated_at": "2026-04-28T03:55:01Z"
+    },
+    {
+      "upstream": "Wei-Shaw/sub2api#1985",
+      "url": "https://github.com/Wei-Shaw/sub2api/issues/1985",
+      "title": "Improve account plan filtering and OpenAI OAuth model mapping",
+      "impact": "needs_review",
+      "categories": [
+        "image_oauth"
+      ],
+      "tokenkey_status": "candidate_unverified",
+      "rationale": "Keyword match for production-sensitive area; not yet manually verified against TokenKey code.",
+      "updated_at": "2026-04-26T05:16:29Z"
+    },
+    {
+      "upstream": "Wei-Shaw/sub2api#1987",
+      "url": "https://github.com/Wei-Shaw/sub2api/issues/1987",
+      "title": "The 'gpt-image-2' model is not supported when using Codex with a ChatGPT account.",
+      "impact": "needs_review",
+      "categories": [
+        "image_oauth",
+        "account_pool_health"
+      ],
+      "tokenkey_status": "candidate_unverified",
+      "rationale": "Keyword match for production-sensitive area; not yet manually verified against TokenKey code.",
+      "updated_at": "2026-04-28T07:27:40Z"
+    },
+    {
+      "upstream": "Wei-Shaw/sub2api#1989",
+      "url": "https://github.com/Wei-Shaw/sub2api/issues/1989",
+      "title": "【bug】[0.1.119] Stream ended before response.completed 接入了 newapi 的转发报错 GPT",
+      "impact": "needs_review",
+      "categories": [
+        "account_pool_health"
+      ],
+      "tokenkey_status": "candidate_unverified",
+      "rationale": "Keyword match for production-sensitive area; not yet manually verified against TokenKey code.",
+      "updated_at": "2026-05-04T00:37:57Z"
+    },
+    {
+      "upstream": "Wei-Shaw/sub2api#1994",
+      "url": "https://github.com/Wei-Shaw/sub2api/issues/1994",
+      "title": "图片生成计费错误",
+      "impact": "needs_review",
+      "categories": [
+        "billing_usage",
+        "image_oauth"
+      ],
+      "tokenkey_status": "candidate_unverified",
+      "rationale": "Keyword match for production-sensitive area; not yet manually verified against TokenKey code.",
+      "updated_at": "2026-04-26T14:03:22Z"
+    },
+    {
+      "upstream": "Wei-Shaw/sub2api#1999",
+      "url": "https://github.com/Wei-Shaw/sub2api/issues/1999",
+      "title": "/v1/responses 中 image_generation tool 的 gpt-image-2 用量会被记成 gpt-5.5 token 计费",
+      "impact": "needs_review",
+      "categories": [
+        "billing_usage",
+        "image_oauth",
+        "security"
+      ],
+      "tokenkey_status": "candidate_unverified",
+      "rationale": "Keyword match for production-sensitive area; not yet manually verified against TokenKey code.",
+      "updated_at": "2026-04-29T15:12:33Z"
+    },
+    {
+      "upstream": "Wei-Shaw/sub2api#200",
+      "url": "https://github.com/Wei-Shaw/sub2api/issues/200",
+      "title": "功能请求：支持单点登录 (SSO/OIDC)",
+      "impact": "needs_review",
+      "categories": [
+        "security"
+      ],
+      "tokenkey_status": "candidate_unverified",
+      "rationale": "Keyword match for production-sensitive area; not yet manually verified against TokenKey code.",
+      "updated_at": "2026-04-07T02:02:32Z"
+    },
+    {
+      "upstream": "Wei-Shaw/sub2api#2001",
+      "url": "https://github.com/Wei-Shaw/sub2api/issues/2001",
+      "title": "feat: 增加分组级别的模型筛选",
+      "impact": "needs_review",
+      "categories": [
+        "image_oauth"
+      ],
+      "tokenkey_status": "candidate_unverified",
+      "rationale": "Keyword match for production-sensitive area; not yet manually verified against TokenKey code.",
+      "updated_at": "2026-04-26T13:53:38Z"
+    },
+    {
+      "upstream": "Wei-Shaw/sub2api#2003",
+      "url": "https://github.com/Wei-Shaw/sub2api/issues/2003",
+      "title": "有没有办法知道哪个用户在网络滥用？",
+      "impact": "needs_review",
+      "categories": [
+        "security"
+      ],
+      "tokenkey_status": "candidate_unverified",
+      "rationale": "Keyword match for production-sensitive area; not yet manually verified against TokenKey code.",
+      "updated_at": "2026-05-08T08:52:14Z"
+    },
+    {
+      "upstream": "Wei-Shaw/sub2api#2008",
+      "url": "https://github.com/Wei-Shaw/sub2api/issues/2008",
+      "title": "gpt image-2计费存在问题",
+      "impact": "needs_review",
+      "categories": [
+        "billing_usage"
+      ],
+      "tokenkey_status": "candidate_unverified",
+      "rationale": "Keyword match for production-sensitive area; not yet manually verified against TokenKey code.",
+      "updated_at": "2026-04-26T18:40:24Z"
+    },
+    {
+      "upstream": "Wei-Shaw/sub2api#2009",
+      "url": "https://github.com/Wei-Shaw/sub2api/issues/2009",
+      "title": "能否不给用户显示成本只显示最终计费的结果",
+      "impact": "needs_review",
+      "categories": [
+        "billing_usage"
+      ],
+      "tokenkey_status": "candidate_unverified",
+      "rationale": "Keyword match for production-sensitive area; not yet manually verified against TokenKey code.",
+      "updated_at": "2026-04-27T00:29:12Z"
+    },
+    {
+      "upstream": "Wei-Shaw/sub2api#2010",
+      "url": "https://github.com/Wei-Shaw/sub2api/issues/2010",
+      "title": "5.5模型报错",
+      "impact": "needs_review",
+      "categories": [
+        "rate_limit_cooldown"
+      ],
+      "tokenkey_status": "candidate_unverified",
+      "rationale": "Keyword match for production-sensitive area; not yet manually verified against TokenKey code.",
+      "updated_at": "2026-04-27T09:44:44Z"
+    },
+    {
+      "upstream": "Wei-Shaw/sub2api#2013",
+      "url": "https://github.com/Wei-Shaw/sub2api/issues/2013",
+      "title": "claude top level cache control not working",
+      "impact": "needs_review",
+      "categories": [
+        "image_oauth",
+        "security"
+      ],
+      "tokenkey_status": "candidate_unverified",
+      "rationale": "Keyword match for production-sensitive area; not yet manually verified against TokenKey code.",
+      "updated_at": "2026-04-27T01:47:00Z"
+    },
+    {
+      "upstream": "Wei-Shaw/sub2api#2014",
+      "url": "https://github.com/Wei-Shaw/sub2api/issues/2014",
+      "title": "WebSocket 似乎不太稳定",
+      "impact": "needs_review",
+      "categories": [
+        "account_pool_health"
+      ],
+      "tokenkey_status": "candidate_unverified",
+      "rationale": "Keyword match for production-sensitive area; not yet manually verified against TokenKey code.",
+      "updated_at": "2026-04-27T03:02:38Z"
+    },
+    {
+      "upstream": "Wei-Shaw/sub2api#2016",
+      "url": "https://github.com/Wei-Shaw/sub2api/issues/2016",
+      "title": "Error running remote compact task: unexpected status 502 Bad Gateway: Upstream request failed,",
+      "impact": "needs_review",
+      "categories": [
+        "rate_limit_cooldown",
+        "image_oauth"
+      ],
+      "tokenkey_status": "candidate_unverified",
+      "rationale": "Keyword match for production-sensitive area; not yet manually verified against TokenKey code.",
+      "updated_at": "2026-04-27T12:02:15Z"
+    },
+    {
+      "upstream": "Wei-Shaw/sub2api#2017",
+      "url": "https://github.com/Wei-Shaw/sub2api/issues/2017",
+      "title": "希望可以新增deepseek模型计费",
+      "impact": "needs_review",
+      "categories": [
+        "billing_usage"
+      ],
+      "tokenkey_status": "candidate_unverified",
+      "rationale": "Keyword match for production-sensitive area; not yet manually verified against TokenKey code.",
+      "updated_at": "2026-04-27T04:11:45Z"
+    },
+    {
+      "upstream": "Wei-Shaw/sub2api#2022",
+      "url": "https://github.com/Wei-Shaw/sub2api/issues/2022",
+      "title": "bug: v0.1.115 起 OIDC 首次登录错误进入“绑定已有账户 / 创建新账户”选择页",
+      "impact": "needs_review",
+      "categories": [
+        "image_oauth"
+      ],
+      "tokenkey_status": "candidate_unverified",
+      "rationale": "Keyword match for production-sensitive area; not yet manually verified against TokenKey code.",
+      "updated_at": "2026-05-12T11:40:48Z"
+    },
+    {
+      "upstream": "Wei-Shaw/sub2api#2023",
+      "url": "https://github.com/Wei-Shaw/sub2api/issues/2023",
+      "title": "希望加入gpt5.5和5.4的思考模式以及fast模式的分别计费",
+      "impact": "needs_review",
+      "categories": [
+        "billing_usage"
+      ],
+      "tokenkey_status": "candidate_unverified",
+      "rationale": "Keyword match for production-sensitive area; not yet manually verified against TokenKey code.",
+      "updated_at": "2026-04-27T06:19:40Z"
+    },
+    {
+      "upstream": "Wei-Shaw/sub2api#2031",
+      "url": "https://github.com/Wei-Shaw/sub2api/issues/2031",
+      "title": "GPT2接入生图超时问题",
+      "impact": "needs_review",
+      "categories": [
+        "image_oauth"
+      ],
+      "tokenkey_status": "candidate_unverified",
+      "rationale": "Keyword match for production-sensitive area; not yet manually verified against TokenKey code.",
+      "updated_at": "2026-05-10T10:32:30Z"
+    },
+    {
+      "upstream": "Wei-Shaw/sub2api#2033",
+      "url": "https://github.com/Wei-Shaw/sub2api/issues/2033",
+      "title": "接入kimi模型报错",
+      "impact": "needs_review",
+      "categories": [
+        "billing_usage"
+      ],
+      "tokenkey_status": "candidate_unverified",
+      "rationale": "Keyword match for production-sensitive area; not yet manually verified against TokenKey code.",
+      "updated_at": "2026-04-27T11:26:02Z"
+    },
+    {
+      "upstream": "Wei-Shaw/sub2api#204",
+      "url": "https://github.com/Wei-Shaw/sub2api/issues/204",
+      "title": "功能请求：Antigravity调度优化",
+      "impact": "needs_review",
+      "categories": [
+        "rate_limit_cooldown"
+      ],
+      "tokenkey_status": "candidate_unverified",
+      "rationale": "Keyword match for production-sensitive area; not yet manually verified against TokenKey code.",
+      "updated_at": "2026-01-07T14:57:38Z"
+    },
+    {
+      "upstream": "Wei-Shaw/sub2api#2040",
+      "url": "https://github.com/Wei-Shaw/sub2api/issues/2040",
+      "title": "渠道+账号测试全部通过，但是实际使用Codex CLI报错503没有可用的账号",
+      "impact": "needs_review",
+      "categories": [
+        "rate_limit_cooldown"
+      ],
+      "tokenkey_status": "candidate_unverified",
+      "rationale": "Keyword match for production-sensitive area; not yet manually verified against TokenKey code.",
+      "updated_at": "2026-04-30T02:29:24Z"
+    },
+    {
+      "upstream": "Wei-Shaw/sub2api#2052",
+      "url": "https://github.com/Wei-Shaw/sub2api/issues/2052",
+      "title": "这种什么情况？",
+      "impact": "needs_review",
+      "categories": [
+        "rate_limit_cooldown",
+        "image_oauth"
+      ],
+      "tokenkey_status": "candidate_unverified",
+      "rationale": "Keyword match for production-sensitive area; not yet manually verified against TokenKey code.",
+      "updated_at": "2026-04-28T14:37:42Z"
+    },
+    {
+      "upstream": "Wei-Shaw/sub2api#2054",
+      "url": "https://github.com/Wei-Shaw/sub2api/issues/2054",
+      "title": "Responses API with background parameter returns upstream 400 but sub2api wraps it as 502 Upstream request failed",
+      "impact": "needs_review",
+      "categories": [
+        "rate_limit_cooldown",
+        "image_oauth"
+      ],
+      "tokenkey_status": "candidate_unverified",
+      "rationale": "Keyword match for production-sensitive area; not yet manually verified against TokenKey code.",
+      "updated_at": "2026-04-28T07:14:51Z"
+    },
+    {
+      "upstream": "Wei-Shaw/sub2api#2064",
+      "url": "https://github.com/Wei-Shaw/sub2api/issues/2064",
+      "title": "gpt-5.5 在 /v1/chat/completions 下约 272K 输入时返回空的 200 成功响应",
+      "impact": "needs_review",
+      "categories": [
+        "billing_usage",
+        "security"
+      ],
+      "tokenkey_status": "candidate_unverified",
+      "rationale": "Keyword match for production-sensitive area; not yet manually verified against TokenKey code.",
+      "updated_at": "2026-05-08T07:43:44Z"
+    },
+    {
+      "upstream": "Wei-Shaw/sub2api#2072",
+      "url": "https://github.com/Wei-Shaw/sub2api/issues/2072",
+      "title": "友好合作咨询",
+      "impact": "needs_review",
+      "categories": [
+        "claude_mimicry"
+      ],
+      "tokenkey_status": "candidate_unverified",
+      "rationale": "Keyword match for production-sensitive area; not yet manually verified against TokenKey code.",
+      "updated_at": "2026-04-28T15:30:14Z"
+    },
+    {
+      "upstream": "Wei-Shaw/sub2api#2076",
+      "url": "https://github.com/Wei-Shaw/sub2api/issues/2076",
+      "title": "Antigravity 版本不支持",
+      "impact": "needs_review",
+      "categories": [
+        "image_oauth"
+      ],
+      "tokenkey_status": "candidate_unverified",
+      "rationale": "Keyword match for production-sensitive area; not yet manually verified against TokenKey code.",
+      "updated_at": "2026-05-07T13:03:11Z"
+    },
+    {
+      "upstream": "Wei-Shaw/sub2api#2083",
+      "url": "https://github.com/Wei-Shaw/sub2api/issues/2083",
+      "title": "需要增加一个批量编辑API秘钥速率限制的功能",
+      "impact": "needs_review",
+      "categories": [
+        "security"
+      ],
+      "tokenkey_status": "candidate_unverified",
+      "rationale": "Keyword match for production-sensitive area; not yet manually verified against TokenKey code.",
+      "updated_at": "2026-04-29T02:56:57Z"
+    },
+    {
+      "upstream": "Wei-Shaw/sub2api#2085",
+      "url": "https://github.com/Wei-Shaw/sub2api/issues/2085",
+      "title": "希望可以 优化/调整 调用Images-2时的主控模型",
+      "impact": "needs_review",
+      "categories": [
+        "image_oauth"
+      ],
+      "tokenkey_status": "candidate_unverified",
+      "rationale": "Keyword match for production-sensitive area; not yet manually verified against TokenKey code.",
+      "updated_at": "2026-05-05T03:22:26Z"
+    },
+    {
+      "upstream": "Wei-Shaw/sub2api#2091",
+      "url": "https://github.com/Wei-Shaw/sub2api/issues/2091",
+      "title": "请求一下大神，claude code max 用sub2api 在国外服务器跑，容易封号吗？",
+      "impact": "needs_review",
+      "categories": [
+        "claude_mimicry"
+      ],
+      "tokenkey_status": "candidate_unverified",
+      "rationale": "Keyword match for production-sensitive area; not yet manually verified against TokenKey code.",
+      "updated_at": "2026-04-29T07:17:20Z"
+    },
+    {
+      "upstream": "Wei-Shaw/sub2api#2092",
+      "url": "https://github.com/Wei-Shaw/sub2api/issues/2092",
+      "title": "请求一下大神，claude code max 用sub2api 在国外服务器跑，容易封号吗？",
+      "impact": "needs_review",
+      "categories": [
+        "claude_mimicry"
+      ],
+      "tokenkey_status": "candidate_unverified",
+      "rationale": "Keyword match for production-sensitive area; not yet manually verified against TokenKey code.",
+      "updated_at": "2026-05-14T01:30:02Z"
+    },
+    {
+      "upstream": "Wei-Shaw/sub2api#2094",
+      "url": "https://github.com/Wei-Shaw/sub2api/issues/2094",
+      "title": "claude code加上\"CLAUDE_CODE_ATTRIBUTION_HEADER\": \"false\"可以提高缓存命中率，不知道可以在sub2api中覆盖请求实现吗",
+      "impact": "needs_review",
+      "categories": [
+        "claude_mimicry"
+      ],
+      "tokenkey_status": "candidate_unverified",
+      "rationale": "Keyword match for production-sensitive area; not yet manually verified against TokenKey code.",
+      "updated_at": "2026-05-03T07:42:17Z"
+    },
+    {
+      "upstream": "Wei-Shaw/sub2api#21",
+      "url": "https://github.com/Wei-Shaw/sub2api/issues/21",
+      "title": "建议：API密钥页面，新增“最近使用”字段，显示上一次使用时间",
+      "impact": "needs_review",
+      "categories": [
+        "image_oauth"
+      ],
+      "tokenkey_status": "candidate_unverified",
+      "rationale": "Keyword match for production-sensitive area; not yet manually verified against TokenKey code.",
+      "updated_at": "2025-12-24T05:11:35Z"
+    },
+    {
+      "upstream": "Wei-Shaw/sub2api#2109",
+      "url": "https://github.com/Wei-Shaw/sub2api/issues/2109",
+      "title": "count_tokens upstream error 400 (account=1 platform=anthropic type=oauth)",
+      "impact": "needs_review",
+      "categories": [
+        "claude_mimicry",
+        "rate_limit_cooldown",
+        "image_oauth",
+        "security"
+      ],
+      "tokenkey_status": "candidate_unverified",
+      "rationale": "Keyword match for production-sensitive area; not yet manually verified against TokenKey code.",
+      "updated_at": "2026-04-29T16:20:36Z"
+    },
+    {
+      "upstream": "Wei-Shaw/sub2api#2111",
+      "url": "https://github.com/Wei-Shaw/sub2api/issues/2111",
+      "title": "/v1/images/generations路由Tool choice 'image_generation' not found in 'tools' parameter.",
+      "impact": "needs_review",
+      "categories": [
+        "rate_limit_cooldown",
+        "image_oauth"
+      ],
+      "tokenkey_status": "candidate_unverified",
+      "rationale": "Keyword match for production-sensitive area; not yet manually verified against TokenKey code.",
+      "updated_at": "2026-05-03T17:28:05Z"
+    },
+    {
+      "upstream": "Wei-Shaw/sub2api#2133",
+      "url": "https://github.com/Wei-Shaw/sub2api/issues/2133",
+      "title": "Follow-up to #1957: HTTP /v1/responses still rejects previous_response_id on 0.1.120",
+      "impact": "needs_review",
+      "categories": [
+        "image_oauth"
+      ],
+      "tokenkey_status": "candidate_unverified",
+      "rationale": "Keyword match for production-sensitive area; not yet manually verified against TokenKey code.",
+      "updated_at": "2026-04-30T06:32:19Z"
+    },
+    {
+      "upstream": "Wei-Shaw/sub2api#2135",
+      "url": "https://github.com/Wei-Shaw/sub2api/issues/2135",
+      "title": "image-2转发有问题",
+      "impact": "needs_review",
+      "categories": [
+        "rate_limit_cooldown",
+        "image_oauth"
+      ],
+      "tokenkey_status": "candidate_unverified",
+      "rationale": "Keyword match for production-sensitive area; not yet manually verified against TokenKey code.",
+      "updated_at": "2026-04-30T07:05:25Z"
+    },
+    {
+      "upstream": "Wei-Shaw/sub2api#2141",
+      "url": "https://github.com/Wei-Shaw/sub2api/issues/2141",
+      "title": "感谢大神，按照你的方法配置了，但是claude code li 请求以后报错400了",
+      "impact": "needs_review",
+      "categories": [
+        "claude_mimicry"
+      ],
+      "tokenkey_status": "candidate_unverified",
+      "rationale": "Keyword match for production-sensitive area; not yet manually verified against TokenKey code.",
+      "updated_at": "2026-05-02T13:21:30Z"
+    },
+    {
+      "upstream": "Wei-Shaw/sub2api#2145",
+      "url": "https://github.com/Wei-Shaw/sub2api/issues/2145",
+      "title": "关于Cyber Abuse的问题",
+      "impact": "needs_review",
+      "categories": [
+        "claude_mimicry"
+      ],
+      "tokenkey_status": "candidate_unverified",
+      "rationale": "Keyword match for production-sensitive area; not yet manually verified against TokenKey code.",
+      "updated_at": "2026-05-10T11:05:35Z"
+    },
+    {
+      "upstream": "Wei-Shaw/sub2api#2146",
+      "url": "https://github.com/Wei-Shaw/sub2api/issues/2146",
+      "title": "[Feature] 希望增加资源包相关功能（独立额度包）",
+      "impact": "needs_review",
+      "categories": [
+        "security"
+      ],
+      "tokenkey_status": "candidate_unverified",
+      "rationale": "Keyword match for production-sensitive area; not yet manually verified against TokenKey code.",
+      "updated_at": "2026-05-01T01:57:53Z"
+    },
+    {
+      "upstream": "Wei-Shaw/sub2api#2147",
+      "url": "https://github.com/Wei-Shaw/sub2api/issues/2147",
+      "title": "OpenAI OAuth 路径未正确处理 Responses `input_text` 形式的 system message",
+      "impact": "needs_review",
+      "categories": [
+        "image_oauth"
+      ],
+      "tokenkey_status": "candidate_unverified",
+      "rationale": "Keyword match for production-sensitive area; not yet manually verified against TokenKey code.",
+      "updated_at": "2026-05-01T02:34:49Z"
+    },
+    {
+      "upstream": "Wei-Shaw/sub2api#2152",
+      "url": "https://github.com/Wei-Shaw/sub2api/issues/2152",
+      "title": "gpt-5.5压缩失败",
+      "impact": "needs_review",
+      "categories": [
+        "rate_limit_cooldown",
+        "image_oauth"
+      ],
+      "tokenkey_status": "candidate_unverified",
+      "rationale": "Keyword match for production-sensitive area; not yet manually verified against TokenKey code.",
+      "updated_at": "2026-05-03T01:20:31Z"
+    },
+    {
+      "upstream": "Wei-Shaw/sub2api#2171",
+      "url": "https://github.com/Wei-Shaw/sub2api/issues/2171",
+      "title": "请求报错",
+      "impact": "needs_review",
+      "categories": [
+        "account_pool_health"
+      ],
+      "tokenkey_status": "candidate_unverified",
+      "rationale": "Keyword match for production-sensitive area; not yet manually verified against TokenKey code.",
+      "updated_at": "2026-05-04T05:01:10Z"
+    },
+    {
+      "upstream": "Wei-Shaw/sub2api#2175",
+      "url": "https://github.com/Wei-Shaw/sub2api/issues/2175",
+      "title": "【Bug】gpt-image-2 bug（需要支持Veo3、SeeDance2）",
+      "impact": "needs_review",
+      "categories": [
+        "image_oauth"
+      ],
+      "tokenkey_status": "candidate_unverified",
+      "rationale": "Keyword match for production-sensitive area; not yet manually verified against TokenKey code.",
+      "updated_at": "2026-05-05T06:19:25Z"
+    },
+    {
+      "upstream": "Wei-Shaw/sub2api#2179",
+      "url": "https://github.com/Wei-Shaw/sub2api/issues/2179",
+      "title": "linux 在说sub2api有计费漏洞。",
+      "impact": "needs_review",
+      "categories": [
+        "billing_usage",
+        "security"
+      ],
+      "tokenkey_status": "candidate_unverified",
+      "rationale": "Keyword match for production-sensitive area; not yet manually verified against TokenKey code.",
+      "updated_at": "2026-05-04T04:45:49Z"
+    },
+    {
+      "upstream": "Wei-Shaw/sub2api#2181",
+      "url": "https://github.com/Wei-Shaw/sub2api/issues/2181",
+      "title": "账号“测试连接”未应用 Beta 策略，导致测试结果与真实网关请求行为不一致",
+      "impact": "needs_review",
+      "categories": [
+        "image_oauth",
+        "security"
+      ],
+      "tokenkey_status": "candidate_unverified",
+      "rationale": "Keyword match for production-sensitive area; not yet manually verified against TokenKey code.",
+      "updated_at": "2026-05-04T05:07:57Z"
+    },
+    {
+      "upstream": "Wei-Shaw/sub2api#2185",
+      "url": "https://github.com/Wei-Shaw/sub2api/issues/2185",
+      "title": "怎么抹去 Claude Code 的指纹信息呢",
+      "impact": "needs_review",
+      "categories": [
+        "claude_mimicry"
+      ],
+      "tokenkey_status": "candidate_unverified",
+      "rationale": "Keyword match for production-sensitive area; not yet manually verified against TokenKey code.",
+      "updated_at": "2026-05-04T09:03:12Z"
+    },
+    {
+      "upstream": "Wei-Shaw/sub2api#2186",
+      "url": "https://github.com/Wei-Shaw/sub2api/issues/2186",
+      "title": "Token counting returns not_found_error on unsupported platform",
+      "impact": "needs_review",
+      "categories": [
+        "image_oauth",
+        "security"
+      ],
+      "tokenkey_status": "candidate_unverified",
+      "rationale": "Keyword match for production-sensitive area; not yet manually verified against TokenKey code.",
+      "updated_at": "2026-05-04T14:18:22Z"
+    },
+    {
+      "upstream": "Wei-Shaw/sub2api#2188",
+      "url": "https://github.com/Wei-Shaw/sub2api/issues/2188",
+      "title": "渠道状态 的检测方式 希望适配 仅Claude Code",
+      "impact": "needs_review",
+      "categories": [
+        "claude_mimicry"
+      ],
+      "tokenkey_status": "candidate_unverified",
+      "rationale": "Keyword match for production-sensitive area; not yet manually verified against TokenKey code.",
+      "updated_at": "2026-05-15T04:48:46Z"
+    },
+    {
+      "upstream": "Wei-Shaw/sub2api#2189",
+      "url": "https://github.com/Wei-Shaw/sub2api/issues/2189",
+      "title": "gpt-image-2模型调用为啥会一直400错误",
+      "impact": "needs_review",
+      "categories": [
+        "image_oauth"
+      ],
+      "tokenkey_status": "candidate_unverified",
+      "rationale": "Keyword match for production-sensitive area; not yet manually verified against TokenKey code.",
+      "updated_at": "2026-05-12T05:58:35Z"
+    },
+    {
+      "upstream": "Wei-Shaw/sub2api#219",
+      "url": "https://github.com/Wei-Shaw/sub2api/issues/219",
+      "title": "cc用的时候莫名其妙任务会断掉，经常性",
+      "impact": "needs_review",
+      "categories": [
+        "image_oauth"
+      ],
+      "tokenkey_status": "candidate_unverified",
+      "rationale": "Keyword match for production-sensitive area; not yet manually verified against TokenKey code.",
+      "updated_at": "2026-01-12T07:00:10Z"
+    },
+    {
+      "upstream": "Wei-Shaw/sub2api#2196",
+      "url": "https://github.com/Wei-Shaw/sub2api/issues/2196",
+      "title": "发现问题",
+      "impact": "needs_review",
+      "categories": [
+        "rate_limit_cooldown",
+        "image_oauth"
+      ],
+      "tokenkey_status": "candidate_unverified",
+      "rationale": "Keyword match for production-sensitive area; not yet manually verified against TokenKey code.",
+      "updated_at": "2026-05-05T09:46:24Z"
+    },
+    {
+      "upstream": "Wei-Shaw/sub2api#2198",
+      "url": "https://github.com/Wei-Shaw/sub2api/issues/2198",
+      "title": "有没有朋友 国内模型 在 CC 里 全部 502",
+      "impact": "needs_review",
+      "categories": [
+        "image_oauth"
+      ],
+      "tokenkey_status": "candidate_unverified",
+      "rationale": "Keyword match for production-sensitive area; not yet manually verified against TokenKey code.",
+      "updated_at": "2026-05-07T07:37:04Z"
+    },
+    {
+      "upstream": "Wei-Shaw/sub2api#2199",
+      "url": "https://github.com/Wei-Shaw/sub2api/issues/2199",
+      "title": "pro账户登陆无法识别",
+      "impact": "needs_review",
+      "categories": [
+        "image_oauth"
+      ],
+      "tokenkey_status": "candidate_unverified",
+      "rationale": "Keyword match for production-sensitive area; not yet manually verified against TokenKey code.",
+      "updated_at": "2026-05-05T08:17:15Z"
+    },
+    {
+      "upstream": "Wei-Shaw/sub2api#2208",
+      "url": "https://github.com/Wei-Shaw/sub2api/issues/2208",
+      "title": "OpenAI Codex CLI 在 v0.1.122 /v1/responses 下 reasoning/output token 暴涨",
+      "impact": "needs_review",
+      "categories": [
+        "billing_usage",
+        "image_oauth",
+        "security"
+      ],
+      "tokenkey_status": "candidate_unverified",
+      "rationale": "Keyword match for production-sensitive area; not yet manually verified against TokenKey code.",
+      "updated_at": "2026-05-06T02:28:44Z"
+    },
+    {
+      "upstream": "Wei-Shaw/sub2api#2217",
+      "url": "https://github.com/Wei-Shaw/sub2api/issues/2217",
+      "title": "[Bug] GPT在CC使用时 subagent 强制 worktree 隔离无法禁用，所有 subagent 调用失败",
+      "impact": "needs_review",
+      "categories": [
+        "claude_mimicry",
+        "rate_limit_cooldown",
+        "image_oauth"
+      ],
+      "tokenkey_status": "candidate_unverified",
+      "rationale": "Keyword match for production-sensitive area; not yet manually verified against TokenKey code.",
+      "updated_at": "2026-05-10T11:51:11Z"
+    },
+    {
+      "upstream": "Wei-Shaw/sub2api#2223",
+      "url": "https://github.com/Wei-Shaw/sub2api/issues/2223",
+      "title": "Selected model is at capacity. Please try a different model.",
+      "impact": "needs_review",
+      "categories": [
+        "account_pool_health"
+      ],
+      "tokenkey_status": "candidate_unverified",
+      "rationale": "Keyword match for production-sensitive area; not yet manually verified against TokenKey code.",
+      "updated_at": "2026-05-15T02:58:04Z"
+    },
+    {
+      "upstream": "Wei-Shaw/sub2api#2231",
+      "url": "https://github.com/Wei-Shaw/sub2api/issues/2231",
+      "title": "自动刷新令牌log在哪里看呢？ token_refresh_service.go程序 并不打印cycle_completed",
+      "impact": "needs_review",
+      "categories": [
+        "image_oauth",
+        "security"
+      ],
+      "tokenkey_status": "candidate_unverified",
+      "rationale": "Keyword match for production-sensitive area; not yet manually verified against TokenKey code.",
+      "updated_at": "2026-05-06T14:37:14Z"
+    },
+    {
+      "upstream": "Wei-Shaw/sub2api#2235",
+      "url": "https://github.com/Wei-Shaw/sub2api/issues/2235",
+      "title": "能不能支持适配国内的 tokenPlan ？",
+      "impact": "needs_review",
+      "categories": [
+        "security"
+      ],
+      "tokenkey_status": "candidate_unverified",
+      "rationale": "Keyword match for production-sensitive area; not yet manually verified against TokenKey code.",
+      "updated_at": "2026-05-07T07:51:59Z"
+    },
+    {
+      "upstream": "Wei-Shaw/sub2api#2237",
+      "url": "https://github.com/Wei-Shaw/sub2api/issues/2237",
+      "title": "Bug: /v1/chat/completions returns 401 for Gemini platform groups (OAuth accounts)",
+      "impact": "needs_review",
+      "categories": [
+        "rate_limit_cooldown",
+        "image_oauth",
+        "security"
+      ],
+      "tokenkey_status": "candidate_unverified",
+      "rationale": "Keyword match for production-sensitive area; not yet manually verified against TokenKey code.",
+      "updated_at": "2026-05-10T16:14:10Z"
+    },
+    {
+      "upstream": "Wei-Shaw/sub2api#2242",
+      "url": "https://github.com/Wei-Shaw/sub2api/issues/2242",
+      "title": "这个渠道监控模型GPT Image 2有问题",
+      "impact": "needs_review",
+      "categories": [
+        "rate_limit_cooldown"
+      ],
+      "tokenkey_status": "candidate_unverified",
+      "rationale": "Keyword match for production-sensitive area; not yet manually verified against TokenKey code.",
+      "updated_at": "2026-05-07T05:08:46Z"
+    },
+    {
+      "upstream": "Wei-Shaw/sub2api#2248",
+      "url": "https://github.com/Wei-Shaw/sub2api/issues/2248",
+      "title": "124版本的Codex 图片生成桥接 默认设置会导致codex无法生图",
+      "impact": "needs_review",
+      "categories": [
+        "image_oauth"
+      ],
+      "tokenkey_status": "candidate_unverified",
+      "rationale": "Keyword match for production-sensitive area; not yet manually verified against TokenKey code.",
+      "updated_at": "2026-05-07T07:50:53Z"
+    },
+    {
+      "upstream": "Wei-Shaw/sub2api#225",
+      "url": "https://github.com/Wei-Shaw/sub2api/issues/225",
+      "title": "nvalid_request_error messages.13.content.0.thinking.cache_control: Extra inputs are not permitted",
+      "impact": "needs_review",
+      "categories": [
+        "claude_mimicry"
+      ],
+      "tokenkey_status": "candidate_unverified",
+      "rationale": "Keyword match for production-sensitive area; not yet manually verified against TokenKey code.",
+      "updated_at": "2026-01-10T02:34:10Z"
+    },
+    {
+      "upstream": "Wei-Shaw/sub2api#2250",
+      "url": "https://github.com/Wei-Shaw/sub2api/issues/2250",
+      "title": "一个渠道报错导致gpt5.4模型一直502错误",
+      "impact": "needs_review",
+      "categories": [
+        "rate_limit_cooldown",
+        "image_oauth"
+      ],
+      "tokenkey_status": "candidate_unverified",
+      "rationale": "Keyword match for production-sensitive area; not yet manually verified against TokenKey code.",
+      "updated_at": "2026-05-07T08:39:36Z"
+    },
+    {
+      "upstream": "Wei-Shaw/sub2api#2251",
+      "url": "https://github.com/Wei-Shaw/sub2api/issues/2251",
+      "title": "image-2 的edit接口，如传入mask参数则返回失败 502",
+      "impact": "needs_review",
+      "categories": [
+        "rate_limit_cooldown",
+        "image_oauth"
+      ],
+      "tokenkey_status": "candidate_unverified",
+      "rationale": "Keyword match for production-sensitive area; not yet manually verified against TokenKey code.",
+      "updated_at": "2026-05-07T09:19:41Z"
+    },
+    {
+      "upstream": "Wei-Shaw/sub2api#2253",
+      "url": "https://github.com/Wei-Shaw/sub2api/issues/2253",
+      "title": "账号批量导入的问题",
+      "impact": "needs_review",
+      "categories": [
+        "security"
+      ],
+      "tokenkey_status": "candidate_unverified",
+      "rationale": "Keyword match for production-sensitive area; not yet manually verified against TokenKey code.",
+      "updated_at": "2026-05-07T09:47:13Z"
+    },
+    {
+      "upstream": "Wei-Shaw/sub2api#2259",
+      "url": "https://github.com/Wei-Shaw/sub2api/issues/2259",
+      "title": "bug：新版本v0.1.125 在claude code中请求报错",
+      "impact": "needs_review",
+      "categories": [
+        "claude_mimicry"
+      ],
+      "tokenkey_status": "candidate_unverified",
+      "rationale": "Keyword match for production-sensitive area; not yet manually verified against TokenKey code.",
+      "updated_at": "2026-05-11T03:35:50Z"
+    },
+    {
+      "upstream": "Wei-Shaw/sub2api#2268",
+      "url": "https://github.com/Wei-Shaw/sub2api/issues/2268",
+      "title": "feat(risk-control): expose moderation category thresholds in admin UI",
+      "impact": "needs_review",
+      "categories": [
+        "claude_mimicry",
+        "image_oauth"
+      ],
+      "tokenkey_status": "candidate_unverified",
+      "rationale": "Keyword match for production-sensitive area; not yet manually verified against TokenKey code.",
+      "updated_at": "2026-05-07T15:53:32Z"
+    },
+    {
+      "upstream": "Wei-Shaw/sub2api#2274",
+      "url": "https://github.com/Wei-Shaw/sub2api/issues/2274",
+      "title": "[feat] 查看模型列表：API 密钥 > 建议增加显示模型清单",
+      "impact": "needs_review",
+      "categories": [
+        "claude_mimicry"
+      ],
+      "tokenkey_status": "candidate_unverified",
+      "rationale": "Keyword match for production-sensitive area; not yet manually verified against TokenKey code.",
+      "updated_at": "2026-05-08T01:39:03Z"
+    },
+    {
+      "upstream": "Wei-Shaw/sub2api#2277",
+      "url": "https://github.com/Wei-Shaw/sub2api/issues/2277",
+      "title": "透明底生图失败",
+      "impact": "needs_review",
+      "categories": [
+        "rate_limit_cooldown",
+        "image_oauth"
+      ],
+      "tokenkey_status": "candidate_unverified",
+      "rationale": "Keyword match for production-sensitive area; not yet manually verified against TokenKey code.",
+      "updated_at": "2026-05-08T04:02:49Z"
+    },
+    {
+      "upstream": "Wei-Shaw/sub2api#2278",
+      "url": "https://github.com/Wei-Shaw/sub2api/issues/2278",
+      "title": "请求上游和接收请求的能不能分开部署",
+      "impact": "needs_review",
+      "categories": [
+        "rate_limit_cooldown"
+      ],
+      "tokenkey_status": "candidate_unverified",
+      "rationale": "Keyword match for production-sensitive area; not yet manually verified against TokenKey code.",
+      "updated_at": "2026-05-08T04:50:04Z"
+    },
+    {
+      "upstream": "Wei-Shaw/sub2api#2280",
+      "url": "https://github.com/Wei-Shaw/sub2api/issues/2280",
+      "title": "vscode codex插件会莫名调用生成图片",
+      "impact": "needs_review",
+      "categories": [
+        "image_oauth",
+        "account_pool_health"
+      ],
+      "tokenkey_status": "candidate_unverified",
+      "rationale": "Keyword match for production-sensitive area; not yet manually verified against TokenKey code.",
+      "updated_at": "2026-05-08T05:21:54Z"
+    },
+    {
+      "upstream": "Wei-Shaw/sub2api#2284",
+      "url": "https://github.com/Wei-Shaw/sub2api/issues/2284",
+      "title": "[Feature] Support API Key provisioning via environment variables / docker-compose",
+      "impact": "needs_review",
+      "categories": [
+        "security"
+      ],
+      "tokenkey_status": "candidate_unverified",
+      "rationale": "Keyword match for production-sensitive area; not yet manually verified against TokenKey code.",
+      "updated_at": "2026-05-08T07:09:01Z"
+    },
+    {
+      "upstream": "Wei-Shaw/sub2api#2285",
+      "url": "https://github.com/Wei-Shaw/sub2api/issues/2285",
+      "title": "通过openai转出来的claude无法在cherry-studio用",
+      "impact": "needs_review",
+      "categories": [
+        "claude_mimicry"
+      ],
+      "tokenkey_status": "candidate_unverified",
+      "rationale": "Keyword match for production-sensitive area; not yet manually verified against TokenKey code.",
+      "updated_at": "2026-05-08T07:36:56Z"
+    },
+    {
+      "upstream": "Wei-Shaw/sub2api#2295",
+      "url": "https://github.com/Wei-Shaw/sub2api/issues/2295",
+      "title": "是否可以支持gpt-image-2 同时输出多个图片",
+      "impact": "needs_review",
+      "categories": [
+        "image_oauth"
+      ],
+      "tokenkey_status": "candidate_unverified",
+      "rationale": "Keyword match for production-sensitive area; not yet manually verified against TokenKey code.",
+      "updated_at": "2026-05-11T06:58:35Z"
+    },
+    {
+      "upstream": "Wei-Shaw/sub2api#2298",
+      "url": "https://github.com/Wei-Shaw/sub2api/issues/2298",
+      "title": "Bug: Upstream empty SSE data: frames cause OpenAI SDK JSONDecodeError when using Responses API (/v1/responses)",
+      "impact": "needs_review",
+      "categories": [
+        "rate_limit_cooldown"
+      ],
+      "tokenkey_status": "candidate_unverified",
+      "rationale": "Keyword match for production-sensitive area; not yet manually verified against TokenKey code.",
+      "updated_at": "2026-05-08T15:42:59Z"
+    },
+    {
+      "upstream": "Wei-Shaw/sub2api#2315",
+      "url": "https://github.com/Wei-Shaw/sub2api/issues/2315",
+      "title": "This version of Antigravity is no longer supported. Please upgrade to receive the latest features.",
+      "impact": "needs_review",
+      "categories": [
+        "billing_usage",
+        "image_oauth",
+        "security"
+      ],
+      "tokenkey_status": "candidate_unverified",
+      "rationale": "Keyword match for production-sensitive area; not yet manually verified against TokenKey code.",
+      "updated_at": "2026-05-09T17:56:35Z"
+    },
+    {
+      "upstream": "Wei-Shaw/sub2api#2321",
+      "url": "https://github.com/Wei-Shaw/sub2api/issues/2321",
+      "title": "版本：v0.1.112 ， gpt5.4分组，增加2个账号，客户端报502",
+      "impact": "needs_review",
+      "categories": [
+        "rate_limit_cooldown",
+        "image_oauth"
+      ],
+      "tokenkey_status": "candidate_unverified",
+      "rationale": "Keyword match for production-sensitive area; not yet manually verified against TokenKey code.",
+      "updated_at": "2026-05-11T06:30:37Z"
+    },
+    {
+      "upstream": "Wei-Shaw/sub2api#2329",
+      "url": "https://github.com/Wei-Shaw/sub2api/issues/2329",
+      "title": "使用存储日益增长，希望能加上清除无用存储功能",
+      "impact": "needs_review",
+      "categories": [
+        "security"
+      ],
+      "tokenkey_status": "candidate_unverified",
+      "rationale": "Keyword match for production-sensitive area; not yet manually verified against TokenKey code.",
+      "updated_at": "2026-05-10T03:11:57Z"
+    },
+    {
+      "upstream": "Wei-Shaw/sub2api#2330",
+      "url": "https://github.com/Wei-Shaw/sub2api/issues/2330",
+      "title": "这个支持deepseek或火山大模型的api吗？怎么配置的，我需要一份部署好之后网页中使用方法的教程",
+      "impact": "needs_review",
+      "categories": [
+        "rate_limit_cooldown",
+        "image_oauth"
+      ],
+      "tokenkey_status": "candidate_unverified",
+      "rationale": "Keyword match for production-sensitive area; not yet manually verified against TokenKey code.",
+      "updated_at": "2026-05-10T03:04:45Z"
+    },
+    {
+      "upstream": "Wei-Shaw/sub2api#2342",
+      "url": "https://github.com/Wei-Shaw/sub2api/issues/2342",
+      "title": "功能建议：支持“审核通过内容”的哈希缓存，减少重复调用 omni-moderation-latest",
+      "impact": "needs_review",
+      "categories": [
+        "security"
+      ],
+      "tokenkey_status": "candidate_unverified",
+      "rationale": "Keyword match for production-sensitive area; not yet manually verified against TokenKey code.",
+      "updated_at": "2026-05-10T12:46:08Z"
+    },
+    {
+      "upstream": "Wei-Shaw/sub2api#2350",
+      "url": "https://github.com/Wei-Shaw/sub2api/issues/2350",
+      "title": "希望支持分布式集群部署，单机抗压困难",
+      "impact": "needs_review",
+      "categories": [
+        "image_oauth",
+        "security"
+      ],
+      "tokenkey_status": "candidate_unverified",
+      "rationale": "Keyword match for production-sensitive area; not yet manually verified against TokenKey code.",
+      "updated_at": "2026-05-14T22:18:34Z"
+    },
+    {
+      "upstream": "Wei-Shaw/sub2api#2354",
+      "url": "https://github.com/Wei-Shaw/sub2api/issues/2354",
+      "title": "[Bug]claude code 使用 cc-switch，连接sub2api,使用GPT5.5，上下文连不上",
+      "impact": "needs_review",
+      "categories": [
+        "claude_mimicry"
+      ],
+      "tokenkey_status": "candidate_unverified",
+      "rationale": "Keyword match for production-sensitive area; not yet manually verified against TokenKey code.",
+      "updated_at": "2026-05-11T06:48:27Z"
+    },
+    {
+      "upstream": "Wei-Shaw/sub2api#2358",
+      "url": "https://github.com/Wei-Shaw/sub2api/issues/2358",
+      "title": "调用生图模型请求格式不对",
+      "impact": "needs_review",
+      "categories": [
+        "image_oauth"
+      ],
+      "tokenkey_status": "candidate_unverified",
+      "rationale": "Keyword match for production-sensitive area; not yet manually verified against TokenKey code.",
+      "updated_at": "2026-05-11T04:08:43Z"
+    },
+    {
+      "upstream": "Wei-Shaw/sub2api#2366",
+      "url": "https://github.com/Wei-Shaw/sub2api/issues/2366",
+      "title": "There's an issue with the selected model",
+      "impact": "needs_review",
+      "categories": [
+        "claude_mimicry"
+      ],
+      "tokenkey_status": "candidate_unverified",
+      "rationale": "Keyword match for production-sensitive area; not yet manually verified against TokenKey code.",
+      "updated_at": "2026-05-11T09:23:21Z"
+    },
+    {
+      "upstream": "Wei-Shaw/sub2api#2377",
+      "url": "https://github.com/Wei-Shaw/sub2api/issues/2377",
+      "title": "bug：最新版本v0.1.126使用OpenAI转发在claude code里完全无法使用（非常严重）",
+      "impact": "needs_review",
+      "categories": [
+        "claude_mimicry"
+      ],
+      "tokenkey_status": "candidate_unverified",
+      "rationale": "Keyword match for production-sensitive area; not yet manually verified against TokenKey code.",
+      "updated_at": "2026-05-12T04:08:43Z"
+    },
+    {
+      "upstream": "Wei-Shaw/sub2api#2380",
+      "url": "https://github.com/Wei-Shaw/sub2api/issues/2380",
+      "title": "Fix Claude Code thinking signature fallback for API key cross-channel routes",
+      "impact": "needs_review",
+      "categories": [
+        "claude_mimicry",
+        "rate_limit_cooldown",
+        "image_oauth"
+      ],
+      "tokenkey_status": "candidate_unverified",
+      "rationale": "Keyword match for production-sensitive area; not yet manually verified against TokenKey code.",
+      "updated_at": "2026-05-11T17:13:46Z"
+    },
+    {
+      "upstream": "Wei-Shaw/sub2api#240",
+      "url": "https://github.com/Wei-Shaw/sub2api/issues/240",
+      "title": "是否可以添加一个自动发测试命令让 5 小时开始计时、从而不浪费额度的功能。",
+      "impact": "needs_review",
+      "categories": [
+        "claude_mimicry"
+      ],
+      "tokenkey_status": "candidate_unverified",
+      "rationale": "Keyword match for production-sensitive area; not yet manually verified against TokenKey code.",
+      "updated_at": "2026-01-19T12:52:54Z"
+    },
+    {
+      "upstream": "Wei-Shaw/sub2api#2400",
+      "url": "https://github.com/Wei-Shaw/sub2api/issues/2400",
+      "title": "codex-auto-review 计费异常",
+      "impact": "needs_review",
+      "categories": [
+        "billing_usage"
+      ],
+      "tokenkey_status": "candidate_unverified",
+      "rationale": "Keyword match for production-sensitive area; not yet manually verified against TokenKey code.",
+      "updated_at": "2026-05-12T07:23:46Z"
+    },
+    {
+      "upstream": "Wei-Shaw/sub2api#2404",
+      "url": "https://github.com/Wei-Shaw/sub2api/issues/2404",
+      "title": "gemini 401报错,Google One Pro Oauth授权，All available accounts exhausted",
+      "impact": "needs_review",
+      "categories": [
+        "image_oauth"
+      ],
+      "tokenkey_status": "candidate_unverified",
+      "rationale": "Keyword match for production-sensitive area; not yet manually verified against TokenKey code.",
+      "updated_at": "2026-05-12T11:54:20Z"
+    },
+    {
+      "upstream": "Wei-Shaw/sub2api#2407",
+      "url": "https://github.com/Wei-Shaw/sub2api/issues/2407",
+      "title": "Codex使用Image2的apikey报错：unexpected status 502 Bad Gateway: Upstream service temporarily unavailable, url:",
+      "impact": "needs_review",
+      "categories": [
+        "rate_limit_cooldown",
+        "image_oauth"
+      ],
+      "tokenkey_status": "candidate_unverified",
+      "rationale": "Keyword match for production-sensitive area; not yet manually verified against TokenKey code.",
+      "updated_at": "2026-05-12T08:54:23Z"
+    },
+    {
+      "upstream": "Wei-Shaw/sub2api#241",
+      "url": "https://github.com/Wei-Shaw/sub2api/issues/241",
+      "title": "claude oauth授权的账号偶尔出现 Permission denied的错误，并莫名其妙禁用账号（显示已封禁），但账号实际并未被封禁",
+      "impact": "needs_review",
+      "categories": [
+        "image_oauth"
+      ],
+      "tokenkey_status": "candidate_unverified",
+      "rationale": "Keyword match for production-sensitive area; not yet manually verified against TokenKey code.",
+      "updated_at": "2026-04-29T02:41:01Z"
+    },
+    {
+      "upstream": "Wei-Shaw/sub2api#2422",
+      "url": "https://github.com/Wei-Shaw/sub2api/issues/2422",
+      "title": "希望在用户菜单栏增加图片生成功能 使用gpt-image-2",
+      "impact": "needs_review",
+      "categories": [
+        "image_oauth"
+      ],
+      "tokenkey_status": "candidate_unverified",
+      "rationale": "Keyword match for production-sensitive area; not yet manually verified against TokenKey code.",
+      "updated_at": "2026-05-14T13:36:31Z"
+    },
+    {
+      "upstream": "Wei-Shaw/sub2api#2427",
+      "url": "https://github.com/Wei-Shaw/sub2api/issues/2427",
+      "title": "反代模式下 Codex 长会话被 5 小时额度 / 429 / 503 提前中断（直连正常）",
+      "impact": "needs_review",
+      "categories": [
+        "rate_limit_cooldown"
+      ],
+      "tokenkey_status": "candidate_unverified",
+      "rationale": "Keyword match for production-sensitive area; not yet manually verified against TokenKey code.",
+      "updated_at": "2026-05-13T14:26:34Z"
+    },
+    {
+      "upstream": "Wei-Shaw/sub2api#2428",
+      "url": "https://github.com/Wei-Shaw/sub2api/issues/2428",
+      "title": "安装失败 bash: line 37: declare: -A: invalid option",
+      "impact": "needs_review",
+      "categories": [
+        "billing_usage"
+      ],
+      "tokenkey_status": "candidate_unverified",
+      "rationale": "Keyword match for production-sensitive area; not yet manually verified against TokenKey code.",
+      "updated_at": "2026-05-13T06:59:23Z"
+    },
+    {
+      "upstream": "Wei-Shaw/sub2api#2431",
+      "url": "https://github.com/Wei-Shaw/sub2api/issues/2431",
+      "title": "[Feature] OpenAI APIKey 账号应支持在管理后台设置 Responses API 支持状态",
+      "impact": "needs_review",
+      "categories": [
+        "claude_mimicry",
+        "billing_usage",
+        "security"
+      ],
+      "tokenkey_status": "candidate_unverified",
+      "rationale": "Keyword match for production-sensitive area; not yet manually verified against TokenKey code.",
+      "updated_at": "2026-05-13T09:31:54Z"
+    },
+    {
+      "upstream": "Wei-Shaw/sub2api#2435",
+      "url": "https://github.com/Wei-Shaw/sub2api/issues/2435",
+      "title": "支付系统前缀设置无效",
+      "impact": "needs_review",
+      "categories": [
+        "claude_mimicry"
+      ],
+      "tokenkey_status": "candidate_unverified",
+      "rationale": "Keyword match for production-sensitive area; not yet manually verified against TokenKey code.",
+      "updated_at": "2026-05-13T12:58:44Z"
+    },
+    {
+      "upstream": "Wei-Shaw/sub2api#2437",
+      "url": "https://github.com/Wei-Shaw/sub2api/issues/2437",
+      "title": "同一个会话中持续修改图片，会迅速把带宽吃满",
+      "impact": "needs_review",
+      "categories": [
+        "image_oauth"
+      ],
+      "tokenkey_status": "candidate_unverified",
+      "rationale": "Keyword match for production-sensitive area; not yet manually verified against TokenKey code.",
+      "updated_at": "2026-05-13T13:01:43Z"
+    },
+    {
+      "upstream": "Wei-Shaw/sub2api#2441",
+      "url": "https://github.com/Wei-Shaw/sub2api/issues/2441",
+      "title": "Codex相关问题-429 Too Many Requests",
+      "impact": "needs_review",
+      "categories": [
+        "rate_limit_cooldown"
+      ],
+      "tokenkey_status": "candidate_unverified",
+      "rationale": "Keyword match for production-sensitive area; not yet manually verified against TokenKey code.",
+      "updated_at": "2026-05-14T02:48:29Z"
+    },
+    {
+      "upstream": "Wei-Shaw/sub2api#2442",
+      "url": "https://github.com/Wei-Shaw/sub2api/issues/2442",
+      "title": "Docker build fails at pnpm install with ERR_PNPM_IGNORED_BUILDS in frontend-builder",
+      "impact": "needs_review",
+      "categories": [
+        "rate_limit_cooldown"
+      ],
+      "tokenkey_status": "candidate_unverified",
+      "rationale": "Keyword match for production-sensitive area; not yet manually verified against TokenKey code.",
+      "updated_at": "2026-05-13T15:28:48Z"
+    },
+    {
+      "upstream": "Wei-Shaw/sub2api#2445",
+      "url": "https://github.com/Wei-Shaw/sub2api/issues/2445",
+      "title": "exceeded retry limit, last status: 429 Too Many Requests, request id",
+      "impact": "needs_review",
+      "categories": [
+        "rate_limit_cooldown"
+      ],
+      "tokenkey_status": "candidate_unverified",
+      "rationale": "Keyword match for production-sensitive area; not yet manually verified against TokenKey code.",
+      "updated_at": "2026-05-14T02:30:02Z"
+    },
+    {
+      "upstream": "Wei-Shaw/sub2api#245",
+      "url": "https://github.com/Wei-Shaw/sub2api/issues/245",
+      "title": "[Bug] Simple 模式下账号因无分组绑定导致503",
+      "impact": "needs_review",
+      "categories": [
+        "rate_limit_cooldown"
+      ],
+      "tokenkey_status": "candidate_unverified",
+      "rationale": "Keyword match for production-sensitive area; not yet manually verified against TokenKey code.",
+      "updated_at": "2026-01-17T17:30:59Z"
+    },
+    {
+      "upstream": "Wei-Shaw/sub2api#2462",
+      "url": "https://github.com/Wei-Shaw/sub2api/issues/2462",
+      "title": "Support proxy testing for pure IPv6 egress proxies",
+      "impact": "needs_review",
+      "categories": [
+        "rate_limit_cooldown",
+        "image_oauth"
+      ],
+      "tokenkey_status": "candidate_unverified",
+      "rationale": "Keyword match for production-sensitive area; not yet manually verified against TokenKey code.",
+      "updated_at": "2026-05-14T10:23:07Z"
+    },
+    {
+      "upstream": "Wei-Shaw/sub2api#2472",
+      "url": "https://github.com/Wei-Shaw/sub2api/issues/2472",
+      "title": "[期望增加功能] 后台增加自定义 HTML / 脚本注入字段（用于接入客服 / 统计 / 标签管理器等）",
+      "impact": "needs_review",
+      "categories": [
+        "claude_mimicry",
+        "security"
+      ],
+      "tokenkey_status": "candidate_unverified",
+      "rationale": "Keyword match for production-sensitive area; not yet manually verified against TokenKey code.",
+      "updated_at": "2026-05-14T15:47:13Z"
+    },
+    {
+      "upstream": "Wei-Shaw/sub2api#2474",
+      "url": "https://github.com/Wei-Shaw/sub2api/issues/2474",
+      "title": "功能建议：用户侧新增 Token / 费用排行榜，展示本人排名与 Top 消耗概览",
+      "impact": "needs_review",
+      "categories": [
+        "billing_usage",
+        "security"
+      ],
+      "tokenkey_status": "candidate_unverified",
+      "rationale": "Keyword match for production-sensitive area; not yet manually verified against TokenKey code.",
+      "updated_at": "2026-05-14T16:19:53Z"
+    },
+    {
+      "upstream": "Wei-Shaw/sub2api#2480",
+      "url": "https://github.com/Wei-Shaw/sub2api/issues/2480",
+      "title": "「功能建议」期望集成在线聊天在线生图功能",
+      "impact": "needs_review",
+      "categories": [
+        "image_oauth"
+      ],
+      "tokenkey_status": "candidate_unverified",
+      "rationale": "Keyword match for production-sensitive area; not yet manually verified against TokenKey code.",
+      "updated_at": "2026-05-15T02:27:22Z"
+    },
+    {
+      "upstream": "Wei-Shaw/sub2api#263",
+      "url": "https://github.com/Wei-Shaw/sub2api/issues/263",
+      "title": "使用 sub2api + cc-router中转gemini3 在claude code中使用经常 429",
+      "impact": "needs_review",
+      "categories": [
+        "claude_mimicry",
+        "rate_limit_cooldown"
+      ],
+      "tokenkey_status": "candidate_unverified",
+      "rationale": "Keyword match for production-sensitive area; not yet manually verified against TokenKey code.",
+      "updated_at": "2026-01-13T07:40:52Z"
+    },
+    {
+      "upstream": "Wei-Shaw/sub2api#268",
+      "url": "https://github.com/Wei-Shaw/sub2api/issues/268",
+      "title": "我用的是antigratiy反代，现在莫名其妙出现429，尝试了几次之后六个号的额度瞬间满了",
+      "impact": "needs_review",
+      "categories": [
+        "rate_limit_cooldown"
+      ],
+      "tokenkey_status": "candidate_unverified",
+      "rationale": "Keyword match for production-sensitive area; not yet manually verified against TokenKey code.",
+      "updated_at": "2026-01-15T06:42:55Z"
+    },
+    {
+      "upstream": "Wei-Shaw/sub2api#283",
+      "url": "https://github.com/Wei-Shaw/sub2api/issues/283",
+      "title": "接newapi报错",
+      "impact": "needs_review",
+      "categories": [
+        "claude_mimicry"
+      ],
+      "tokenkey_status": "candidate_unverified",
+      "rationale": "Keyword match for production-sensitive area; not yet manually verified against TokenKey code.",
+      "updated_at": "2026-01-14T14:07:46Z"
+    },
+    {
+      "upstream": "Wei-Shaw/sub2api#290",
+      "url": "https://github.com/Wei-Shaw/sub2api/issues/290",
+      "title": "反重力429后的赛博起搏器",
+      "impact": "needs_review",
+      "categories": [
+        "rate_limit_cooldown"
+      ],
+      "tokenkey_status": "candidate_unverified",
+      "rationale": "Keyword match for production-sensitive area; not yet manually verified against TokenKey code.",
+      "updated_at": "2026-01-15T12:48:39Z"
+    },
+    {
+      "upstream": "Wei-Shaw/sub2api#293",
+      "url": "https://github.com/Wei-Shaw/sub2api/issues/293",
+      "title": "【需求】基于 claude 限流封号问题的需求建议",
+      "impact": "needs_review",
+      "categories": [
+        "rate_limit_cooldown"
+      ],
+      "tokenkey_status": "candidate_unverified",
+      "rationale": "Keyword match for production-sensitive area; not yet manually verified against TokenKey code.",
+      "updated_at": "2026-02-07T05:41:45Z"
+    },
+    {
+      "upstream": "Wei-Shaw/sub2api#298",
+      "url": "https://github.com/Wei-Shaw/sub2api/issues/298",
+      "title": "反重力授权增加refresh_token方式",
+      "impact": "needs_review",
+      "categories": [
+        "security"
+      ],
+      "tokenkey_status": "candidate_unverified",
+      "rationale": "Keyword match for production-sensitive area; not yet manually verified against TokenKey code.",
+      "updated_at": "2026-01-15T10:51:34Z"
+    },
+    {
+      "upstream": "Wei-Shaw/sub2api#299",
+      "url": "https://github.com/Wei-Shaw/sub2api/issues/299",
+      "title": "API返回429",
+      "impact": "needs_review",
+      "categories": [
+        "rate_limit_cooldown"
+      ],
+      "tokenkey_status": "candidate_unverified",
+      "rationale": "Keyword match for production-sensitive area; not yet manually verified against TokenKey code.",
+      "updated_at": "2026-01-19T10:03:26Z"
+    },
+    {
+      "upstream": "Wei-Shaw/sub2api#308",
+      "url": "https://github.com/Wei-Shaw/sub2api/issues/308",
+      "title": "部分账号显示有额度，但请求的时候429",
+      "impact": "needs_review",
+      "categories": [
+        "rate_limit_cooldown"
+      ],
+      "tokenkey_status": "candidate_unverified",
+      "rationale": "Keyword match for production-sensitive area; not yet manually verified against TokenKey code.",
+      "updated_at": "2026-01-16T15:17:20Z"
+    },
+    {
+      "upstream": "Wei-Shaw/sub2api#331",
+      "url": "https://github.com/Wei-Shaw/sub2api/issues/331",
+      "title": "更新后都请求都变成503了，但账号管理里显示正常，测试也正常",
+      "impact": "needs_review",
+      "categories": [
+        "rate_limit_cooldown"
+      ],
+      "tokenkey_status": "candidate_unverified",
+      "rationale": "Keyword match for production-sensitive area; not yet manually verified against TokenKey code.",
+      "updated_at": "2026-01-20T04:49:41Z"
+    },
+    {
+      "upstream": "Wei-Shaw/sub2api#334",
+      "url": "https://github.com/Wei-Shaw/sub2api/issues/334",
+      "title": "missing_project_id",
+      "impact": "needs_review",
+      "categories": [
+        "security"
+      ],
+      "tokenkey_status": "candidate_unverified",
+      "rationale": "Keyword match for production-sensitive area; not yet manually verified against TokenKey code.",
+      "updated_at": "2026-01-22T11:31:25Z"
+    },
+    {
+      "upstream": "Wei-Shaw/sub2api#338",
+      "url": "https://github.com/Wei-Shaw/sub2api/issues/338",
+      "title": "点击使用记录有些时候不显示计费",
+      "impact": "needs_review",
+      "categories": [
+        "billing_usage"
+      ],
+      "tokenkey_status": "candidate_unverified",
+      "rationale": "Keyword match for production-sensitive area; not yet manually verified against TokenKey code.",
+      "updated_at": "2026-01-20T03:04:17Z"
+    },
+    {
+      "upstream": "Wei-Shaw/sub2api#342",
+      "url": "https://github.com/Wei-Shaw/sub2api/issues/342",
+      "title": "0.1.57版本 Claude Oauth出现不应该的403问题",
+      "impact": "needs_review",
+      "categories": [
+        "image_oauth",
+        "security"
+      ],
+      "tokenkey_status": "candidate_unverified",
+      "rationale": "Keyword match for production-sensitive area; not yet manually verified against TokenKey code.",
+      "updated_at": "2026-01-21T02:22:40Z"
+    },
+    {
+      "upstream": "Wei-Shaw/sub2api#347",
+      "url": "https://github.com/Wei-Shaw/sub2api/issues/347",
+      "title": "opencode 的使用示例有问题，无法读取图片和 cost",
+      "impact": "needs_review",
+      "categories": [
+        "image_oauth"
+      ],
+      "tokenkey_status": "candidate_unverified",
+      "rationale": "Keyword match for production-sensitive area; not yet manually verified against TokenKey code.",
+      "updated_at": "2026-03-17T06:11:22Z"
+    },
+    {
+      "upstream": "Wei-Shaw/sub2api#353",
+      "url": "https://github.com/Wei-Shaw/sub2api/issues/353",
+      "title": "功能提议：新增自动检测OAuth2方式登录账户可用性的定时任务",
+      "impact": "needs_review",
+      "categories": [
+        "image_oauth"
+      ],
+      "tokenkey_status": "candidate_unverified",
+      "rationale": "Keyword match for production-sensitive area; not yet manually verified against TokenKey code.",
+      "updated_at": "2026-01-22T00:50:00Z"
+    },
+    {
+      "upstream": "Wei-Shaw/sub2api#360",
+      "url": "https://github.com/Wei-Shaw/sub2api/issues/360",
+      "title": "有人遇到过这种429错误码？如何解决",
+      "impact": "needs_review",
+      "categories": [
+        "rate_limit_cooldown"
+      ],
+      "tokenkey_status": "candidate_unverified",
+      "rationale": "Keyword match for production-sensitive area; not yet manually verified against TokenKey code.",
+      "updated_at": "2026-01-22T08:43:50Z"
+    },
+    {
+      "upstream": "Wei-Shaw/sub2api#362",
+      "url": "https://github.com/Wei-Shaw/sub2api/issues/362",
+      "title": "配置了Claude的服务商为智谱，限额到达时账号没有限流",
+      "impact": "needs_review",
+      "categories": [
+        "rate_limit_cooldown"
+      ],
+      "tokenkey_status": "candidate_unverified",
+      "rationale": "Keyword match for production-sensitive area; not yet manually verified against TokenKey code.",
+      "updated_at": "2026-01-24T23:07:15Z"
+    },
+    {
+      "upstream": "Wei-Shaw/sub2api#364",
+      "url": "https://github.com/Wei-Shaw/sub2api/issues/364",
+      "title": "Critical(或可用于恶意攻击其他商家): 配置的 OpenAI OAuth 账户以及 Codex 分组被用户设置进入 Claude Code 后，会导致所有可调度账户出现异常403错误",
+      "impact": "needs_review",
+      "categories": [
+        "claude_mimicry",
+        "image_oauth"
+      ],
+      "tokenkey_status": "candidate_unverified",
+      "rationale": "Keyword match for production-sensitive area; not yet manually verified against TokenKey code.",
+      "updated_at": "2026-01-23T09:47:06Z"
+    },
+    {
+      "upstream": "Wei-Shaw/sub2api#367",
+      "url": "https://github.com/Wei-Shaw/sub2api/issues/367",
+      "title": "请问这个429的时间，是本服务限制的吗？",
+      "impact": "needs_review",
+      "categories": [
+        "rate_limit_cooldown"
+      ],
+      "tokenkey_status": "candidate_unverified",
+      "rationale": "Keyword match for production-sensitive area; not yet manually verified against TokenKey code.",
+      "updated_at": "2026-01-22T22:25:52Z"
+    },
+    {
+      "upstream": "Wei-Shaw/sub2api#374",
+      "url": "https://github.com/Wei-Shaw/sub2api/issues/374",
+      "title": "新添加的账号错误",
+      "impact": "needs_review",
+      "categories": [
+        "security"
+      ],
+      "tokenkey_status": "candidate_unverified",
+      "rationale": "Keyword match for production-sensitive area; not yet manually verified against TokenKey code.",
+      "updated_at": "2026-01-24T17:42:09Z"
+    },
+    {
+      "upstream": "Wei-Shaw/sub2api#375",
+      "url": "https://github.com/Wei-Shaw/sub2api/issues/375",
+      "title": "【anti反代】 反代出来的cc貌似token一多就报错？",
+      "impact": "needs_review",
+      "categories": [
+        "security"
+      ],
+      "tokenkey_status": "candidate_unverified",
+      "rationale": "Keyword match for production-sensitive area; not yet manually verified against TokenKey code.",
+      "updated_at": "2026-01-23T10:04:47Z"
+    },
+    {
+      "upstream": "Wei-Shaw/sub2api#376",
+      "url": "https://github.com/Wei-Shaw/sub2api/issues/376",
+      "title": "是否考虑增加错误码的降级处理?",
+      "impact": "needs_review",
+      "categories": [
+        "rate_limit_cooldown"
+      ],
+      "tokenkey_status": "candidate_unverified",
+      "rationale": "Keyword match for production-sensitive area; not yet manually verified against TokenKey code.",
+      "updated_at": "2026-01-24T00:38:20Z"
+    },
+    {
+      "upstream": "Wei-Shaw/sub2api#378",
+      "url": "https://github.com/Wei-Shaw/sub2api/issues/378",
+      "title": "反重力报错",
+      "impact": "needs_review",
+      "categories": [
+        "rate_limit_cooldown"
+      ],
+      "tokenkey_status": "candidate_unverified",
+      "rationale": "Keyword match for production-sensitive area; not yet manually verified against TokenKey code.",
+      "updated_at": "2026-02-09T08:59:18Z"
+    },
+    {
+      "upstream": "Wei-Shaw/sub2api#379",
+      "url": "https://github.com/Wei-Shaw/sub2api/issues/379",
+      "title": "Antigravity账号触发claude限流后，gemini也无法使用",
+      "impact": "needs_review",
+      "categories": [
+        "rate_limit_cooldown"
+      ],
+      "tokenkey_status": "candidate_unverified",
+      "rationale": "Keyword match for production-sensitive area; not yet manually verified against TokenKey code.",
+      "updated_at": "2026-01-24T06:00:07Z"
+    },
+    {
+      "upstream": "Wei-Shaw/sub2api#390",
+      "url": "https://github.com/Wei-Shaw/sub2api/issues/390",
+      "title": "配置了openAi调用api接口也是/v1/messages 接口访问 吗 为什么cli里是正常的我用/v1/messages方式访问提示`502 Bad Gateway` response:\\n{\\\"error\\\":{\\\"message\\\":\\\"Upstream service temporarily unavailable\\\",\\\"type\\\":\\\"upstream_error\\\"}",
+      "impact": "needs_review",
+      "categories": [
+        "rate_limit_cooldown",
+        "image_oauth"
+      ],
+      "tokenkey_status": "candidate_unverified",
+      "rationale": "Keyword match for production-sensitive area; not yet manually verified against TokenKey code.",
+      "updated_at": "2026-02-09T03:09:42Z"
+    },
+    {
+      "upstream": "Wei-Shaw/sub2api#392",
+      "url": "https://github.com/Wei-Shaw/sub2api/issues/392",
+      "title": "Claude Code 账号登录 即使开启 TLS 指纹模拟仍报错 \"authorized for use with Claude Code\"",
+      "impact": "needs_review",
+      "categories": [
+        "claude_mimicry",
+        "image_oauth",
+        "security"
+      ],
+      "tokenkey_status": "candidate_unverified",
+      "rationale": "Keyword match for production-sensitive area; not yet manually verified against TokenKey code.",
+      "updated_at": "2026-03-06T10:05:03Z"
+    },
+    {
+      "upstream": "Wei-Shaw/sub2api#396",
+      "url": "https://github.com/Wei-Shaw/sub2api/issues/396",
+      "title": "错误: 反重力Token 刷新失败",
+      "impact": "needs_review",
+      "categories": [
+        "security"
+      ],
+      "tokenkey_status": "candidate_unverified",
+      "rationale": "Keyword match for production-sensitive area; not yet manually verified against TokenKey code.",
+      "updated_at": "2026-01-26T04:06:21Z"
+    },
+    {
+      "upstream": "Wei-Shaw/sub2api#408",
+      "url": "https://github.com/Wei-Shaw/sub2api/issues/408",
+      "title": "调度问题",
+      "impact": "needs_review",
+      "categories": [
+        "rate_limit_cooldown"
+      ],
+      "tokenkey_status": "candidate_unverified",
+      "rationale": "Keyword match for production-sensitive area; not yet manually verified against TokenKey code.",
+      "updated_at": "2026-01-28T03:57:48Z"
+    },
+    {
+      "upstream": "Wei-Shaw/sub2api#410",
+      "url": "https://github.com/Wei-Shaw/sub2api/issues/410",
+      "title": "Gemini CLI的账号，没有设置限流，但是会默认触发24小时的限流，怎么关闭这个？",
+      "impact": "needs_review",
+      "categories": [
+        "rate_limit_cooldown"
+      ],
+      "tokenkey_status": "candidate_unverified",
+      "rationale": "Keyword match for production-sensitive area; not yet manually verified against TokenKey code.",
+      "updated_at": "2026-02-26T05:52:37Z"
+    },
+    {
+      "upstream": "Wei-Shaw/sub2api#417",
+      "url": "https://github.com/Wei-Shaw/sub2api/issues/417",
+      "title": "[bug]openai测活响应401",
+      "impact": "needs_review",
+      "categories": [
+        "image_oauth"
+      ],
+      "tokenkey_status": "candidate_unverified",
+      "rationale": "Keyword match for production-sensitive area; not yet manually verified against TokenKey code.",
+      "updated_at": "2026-02-04T14:21:04Z"
+    },
+    {
+      "upstream": "Wei-Shaw/sub2api#429",
+      "url": "https://github.com/Wei-Shaw/sub2api/issues/429",
+      "title": "Antigravity OAuth 登录回调地址硬编码导致无法在非 localhost 环境下使用",
+      "impact": "needs_review",
+      "categories": [
+        "image_oauth"
+      ],
+      "tokenkey_status": "candidate_unverified",
+      "rationale": "Keyword match for production-sensitive area; not yet manually verified against TokenKey code.",
+      "updated_at": "2026-02-08T06:47:53Z"
+    },
+    {
+      "upstream": "Wei-Shaw/sub2api#439",
+      "url": "https://github.com/Wei-Shaw/sub2api/issues/439",
+      "title": "opencode使用遇到问题",
+      "impact": "needs_review",
+      "categories": [
+        "image_oauth"
+      ],
+      "tokenkey_status": "candidate_unverified",
+      "rationale": "Keyword match for production-sensitive area; not yet manually verified against TokenKey code.",
+      "updated_at": "2026-01-31T09:51:24Z"
+    },
+    {
+      "upstream": "Wei-Shaw/sub2api#465",
+      "url": "https://github.com/Wei-Shaw/sub2api/issues/465",
+      "title": "openclaw 空返回",
+      "impact": "needs_review",
+      "categories": [
+        "claude_mimicry",
+        "security"
+      ],
+      "tokenkey_status": "candidate_unverified",
+      "rationale": "Keyword match for production-sensitive area; not yet manually verified against TokenKey code.",
+      "updated_at": "2026-03-25T17:08:32Z"
+    },
+    {
+      "upstream": "Wei-Shaw/sub2api#500",
+      "url": "https://github.com/Wei-Shaw/sub2api/issues/500",
+      "title": "建议：希望能够支持 Antigravity OAuth token导入",
+      "impact": "needs_review",
+      "categories": [
+        "image_oauth",
+        "security"
+      ],
+      "tokenkey_status": "candidate_unverified",
+      "rationale": "Keyword match for production-sensitive area; not yet manually verified against TokenKey code.",
+      "updated_at": "2026-02-06T10:13:47Z"
+    },
+    {
+      "upstream": "Wei-Shaw/sub2api#501",
+      "url": "https://github.com/Wei-Shaw/sub2api/issues/501",
+      "title": "roo code插件使用会报错，与claude工具名称冲突",
+      "impact": "needs_review",
+      "categories": [
+        "claude_mimicry",
+        "security"
+      ],
+      "tokenkey_status": "candidate_unverified",
+      "rationale": "Keyword match for production-sensitive area; not yet manually verified against TokenKey code.",
+      "updated_at": "2026-02-06T10:39:55Z"
+    },
+    {
+      "upstream": "Wei-Shaw/sub2api#520",
+      "url": "https://github.com/Wei-Shaw/sub2api/issues/520",
+      "title": "上游使用zenmux订阅作为源的时候，出现大量报错",
+      "impact": "needs_review",
+      "categories": [
+        "claude_mimicry",
+        "security"
+      ],
+      "tokenkey_status": "candidate_unverified",
+      "rationale": "Keyword match for production-sensitive area; not yet manually verified against TokenKey code.",
+      "updated_at": "2026-02-09T16:25:41Z"
+    },
+    {
+      "upstream": "Wei-Shaw/sub2api#524",
+      "url": "https://github.com/Wei-Shaw/sub2api/issues/524",
+      "title": "官claude每天都要手动重置刷新，否则就会出现帐号错误",
+      "impact": "needs_review",
+      "categories": [
+        "security"
+      ],
+      "tokenkey_status": "candidate_unverified",
+      "rationale": "Keyword match for production-sensitive area; not yet manually verified against TokenKey code.",
+      "updated_at": "2026-02-11T08:00:55Z"
+    },
+    {
+      "upstream": "Wei-Shaw/sub2api#535",
+      "url": "https://github.com/Wei-Shaw/sub2api/issues/535",
+      "title": "openclaw配置codex失败返回502",
+      "impact": "needs_review",
+      "categories": [
+        "image_oauth"
+      ],
+      "tokenkey_status": "candidate_unverified",
+      "rationale": "Keyword match for production-sensitive area; not yet manually verified against TokenKey code.",
+      "updated_at": "2026-02-24T16:54:00Z"
+    },
+    {
+      "upstream": "Wei-Shaw/sub2api#562",
+      "url": "https://github.com/Wei-Shaw/sub2api/issues/562",
+      "title": "1.0.81版本升级后opus频繁报错",
+      "impact": "needs_review",
+      "categories": [
+        "rate_limit_cooldown"
+      ],
+      "tokenkey_status": "candidate_unverified",
+      "rationale": "Keyword match for production-sensitive area; not yet manually verified against TokenKey code.",
+      "updated_at": "2026-02-12T05:11:17Z"
+    },
+    {
+      "upstream": "Wei-Shaw/sub2api#566",
+      "url": "https://github.com/Wei-Shaw/sub2api/issues/566",
+      "title": "费用倍率只对计费页面有用，而订阅的限额和设置的费率倍率并无用还是根据实际费用限额",
+      "impact": "needs_review",
+      "categories": [
+        "billing_usage"
+      ],
+      "tokenkey_status": "candidate_unverified",
+      "rationale": "Keyword match for production-sensitive area; not yet manually verified against TokenKey code.",
+      "updated_at": "2026-03-30T16:04:16Z"
+    },
+    {
+      "upstream": "Wei-Shaw/sub2api#583",
+      "url": "https://github.com/Wei-Shaw/sub2api/issues/583",
+      "title": "【破坏性变更】将 ⁠PGDATA 直接设为卷根目录会导致升级初始化（initdb）失败",
+      "impact": "needs_review",
+      "categories": [
+        "rate_limit_cooldown"
+      ],
+      "tokenkey_status": "candidate_unverified",
+      "rationale": "Keyword match for production-sensitive area; not yet manually verified against TokenKey code.",
+      "updated_at": "2026-02-16T10:09:59Z"
+    },
+    {
+      "upstream": "Wei-Shaw/sub2api#584",
+      "url": "https://github.com/Wei-Shaw/sub2api/issues/584",
+      "title": "OpenAI有时候会报401,但是测试连接是可以请求成功的",
+      "impact": "needs_review",
+      "categories": [
+        "security"
+      ],
+      "tokenkey_status": "candidate_unverified",
+      "rationale": "Keyword match for production-sensitive area; not yet manually verified against TokenKey code.",
+      "updated_at": "2026-02-15T16:41:12Z"
+    },
+    {
+      "upstream": "Wei-Shaw/sub2api#585",
+      "url": "https://github.com/Wei-Shaw/sub2api/issues/585",
+      "title": "JWT_EXPIRE_HOUR 被默认的 jwt.access_token_expire_minutes=360 覆盖，导致提前登出",
+      "impact": "needs_review",
+      "categories": [
+        "security"
+      ],
+      "tokenkey_status": "candidate_unverified",
+      "rationale": "Keyword match for production-sensitive area; not yet manually verified against TokenKey code.",
+      "updated_at": "2026-02-22T09:16:54Z"
+    },
+    {
+      "upstream": "Wei-Shaw/sub2api#588",
+      "url": "https://github.com/Wei-Shaw/sub2api/issues/588",
+      "title": "最新的0.1.83版本无法自动刷新codex的用量",
+      "impact": "needs_review",
+      "categories": [
+        "image_oauth"
+      ],
+      "tokenkey_status": "candidate_unverified",
+      "rationale": "Keyword match for production-sensitive area; not yet manually verified against TokenKey code.",
+      "updated_at": "2026-02-22T13:36:27Z"
+    },
+    {
+      "upstream": "Wei-Shaw/sub2api#593",
+      "url": "https://github.com/Wei-Shaw/sub2api/issues/593",
+      "title": "API Error: 503 {\"error\":{\"message\":\"No available accounts: no available accounts\",\"type\":\"api_error\"},\"type\":\"error\"}",
+      "impact": "needs_review",
+      "categories": [
+        "rate_limit_cooldown"
+      ],
+      "tokenkey_status": "candidate_unverified",
+      "rationale": "Keyword match for production-sensitive area; not yet manually verified against TokenKey code.",
+      "updated_at": "2026-04-27T04:12:26Z"
+    },
+    {
+      "upstream": "Wei-Shaw/sub2api#599",
+      "url": "https://github.com/Wei-Shaw/sub2api/issues/599",
+      "title": "[BUG] FilterThinkingBlocksForRetry 未移除 thinking_strategy 字段导致重试仍然 400",
+      "impact": "needs_review",
+      "categories": [
+        "claude_mimicry",
+        "rate_limit_cooldown"
+      ],
+      "tokenkey_status": "candidate_unverified",
+      "rationale": "Keyword match for production-sensitive area; not yet manually verified against TokenKey code.",
+      "updated_at": "2026-02-25T06:32:27Z"
+    },
+    {
+      "upstream": "Wei-Shaw/sub2api#614",
+      "url": "https://github.com/Wei-Shaw/sub2api/issues/614",
+      "title": "新手引导 -> modal ->开始配置 button 文字有重影",
+      "impact": "needs_review",
+      "categories": [
+        "rate_limit_cooldown"
+      ],
+      "tokenkey_status": "candidate_unverified",
+      "rationale": "Keyword match for production-sensitive area; not yet manually verified against TokenKey code.",
+      "updated_at": "2026-02-24T10:01:44Z"
+    },
+    {
+      "upstream": "Wei-Shaw/sub2api#616",
+      "url": "https://github.com/Wei-Shaw/sub2api/issues/616",
+      "title": "企业身份统一管理（LDAP/AD）",
+      "impact": "needs_review",
+      "categories": [
+        "security"
+      ],
+      "tokenkey_status": "candidate_unverified",
+      "rationale": "Keyword match for production-sensitive area; not yet manually verified against TokenKey code.",
+      "updated_at": "2026-03-05T12:02:38Z"
+    },
+    {
+      "upstream": "Wei-Shaw/sub2api#640",
+      "url": "https://github.com/Wei-Shaw/sub2api/issues/640",
+      "title": "[Feature/Bug] Gemini CLI 反代：剩余配额进度条仅统计请求次数，未纳入 token 用量，导致显示严重失真",
+      "impact": "needs_review",
+      "categories": [
+        "claude_mimicry",
+        "rate_limit_cooldown",
+        "billing_usage",
+        "image_oauth",
+        "security"
+      ],
+      "tokenkey_status": "candidate_unverified",
+      "rationale": "Keyword match for production-sensitive area; not yet manually verified against TokenKey code.",
+      "updated_at": "2026-02-25T14:36:21Z"
+    },
+    {
+      "upstream": "Wei-Shaw/sub2api#643",
+      "url": "https://github.com/Wei-Shaw/sub2api/issues/643",
+      "title": "web_search_20260209 动态过滤的 code execution 始终返回 too_many_requests",
+      "impact": "needs_review",
+      "categories": [
+        "rate_limit_cooldown",
+        "image_oauth",
+        "security"
+      ],
+      "tokenkey_status": "candidate_unverified",
+      "rationale": "Keyword match for production-sensitive area; not yet manually verified against TokenKey code.",
+      "updated_at": "2026-02-25T19:28:04Z"
+    },
+    {
+      "upstream": "Wei-Shaw/sub2api#645",
+      "url": "https://github.com/Wei-Shaw/sub2api/issues/645",
+      "title": "Gemini: MODEL_CAPACITY_EXHAUSTED 429 is cooled down until PST midnight for google_one accounts",
+      "impact": "needs_review",
+      "categories": [
+        "rate_limit_cooldown",
+        "image_oauth"
+      ],
+      "tokenkey_status": "candidate_unverified",
+      "rationale": "Keyword match for production-sensitive area; not yet manually verified against TokenKey code.",
+      "updated_at": "2026-03-12T20:12:05Z"
+    },
+    {
+      "upstream": "Wei-Shaw/sub2api#656",
+      "url": "https://github.com/Wei-Shaw/sub2api/issues/656",
+      "title": "Anthropic 兼容上游在 count_tokens 路径非标准返回时，Claude Code 会失败",
+      "impact": "needs_review",
+      "categories": [
+        "claude_mimicry",
+        "security"
+      ],
+      "tokenkey_status": "candidate_unverified",
+      "rationale": "Keyword match for production-sensitive area; not yet manually verified against TokenKey code.",
+      "updated_at": "2026-02-26T13:14:12Z"
+    },
+    {
+      "upstream": "Wei-Shaw/sub2api#671",
+      "url": "https://github.com/Wei-Shaw/sub2api/issues/671",
+      "title": "Bug: GenerateSessionHash fallback 导致活跃会话数虚增",
+      "impact": "needs_review",
+      "categories": [
+        "rate_limit_cooldown"
+      ],
+      "tokenkey_status": "candidate_unverified",
+      "rationale": "Keyword match for production-sensitive area; not yet manually verified against TokenKey code.",
+      "updated_at": "2026-02-27T17:41:30Z"
+    },
+    {
+      "upstream": "Wei-Shaw/sub2api#687",
+      "url": "https://github.com/Wei-Shaw/sub2api/issues/687",
+      "title": "目前还需要手动增加ANTIGRAVITY_OAUTH_CLIENT_SECRET环境变量吗？",
+      "impact": "needs_review",
+      "categories": [
+        "image_oauth",
+        "security"
+      ],
+      "tokenkey_status": "candidate_unverified",
+      "rationale": "Keyword match for production-sensitive area; not yet manually verified against TokenKey code.",
+      "updated_at": "2026-03-01T03:05:43Z"
+    },
+    {
+      "upstream": "Wei-Shaw/sub2api#704",
+      "url": "https://github.com/Wei-Shaw/sub2api/issues/704",
+      "title": "Feature: Account-level weekly cost limit (weekly_cost_limit) for Anthropic accounts",
+      "impact": "needs_review",
+      "categories": [
+        "rate_limit_cooldown",
+        "billing_usage"
+      ],
+      "tokenkey_status": "candidate_unverified",
+      "rationale": "Keyword match for production-sensitive area; not yet manually verified against TokenKey code.",
+      "updated_at": "2026-03-01T17:06:33Z"
+    },
+    {
+      "upstream": "Wei-Shaw/sub2api#718",
+      "url": "https://github.com/Wei-Shaw/sub2api/issues/718",
+      "title": "503 是啥原因啊 codex没问题 服务器没问题 但是就是返回503",
+      "impact": "needs_review",
+      "categories": [
+        "rate_limit_cooldown"
+      ],
+      "tokenkey_status": "candidate_unverified",
+      "rationale": "Keyword match for production-sensitive area; not yet manually verified against TokenKey code.",
+      "updated_at": "2026-04-28T03:22:36Z"
+    },
+    {
+      "upstream": "Wei-Shaw/sub2api#72",
+      "url": "https://github.com/Wei-Shaw/sub2api/issues/72",
+      "title": "Can this sub2api let us call the api directly??",
+      "impact": "needs_review",
+      "categories": [
+        "claude_mimicry"
+      ],
+      "tokenkey_status": "candidate_unverified",
+      "rationale": "Keyword match for production-sensitive area; not yet manually verified against TokenKey code.",
+      "updated_at": "2026-01-08T17:39:13Z"
+    },
+    {
+      "upstream": "Wei-Shaw/sub2api#728",
+      "url": "https://github.com/Wei-Shaw/sub2api/issues/728",
+      "title": "API 只能对应一个分组的账号，能够支持多选多个分组的账号",
+      "impact": "needs_review",
+      "categories": [
+        "security"
+      ],
+      "tokenkey_status": "candidate_unverified",
+      "rationale": "Keyword match for production-sensitive area; not yet manually verified against TokenKey code.",
+      "updated_at": "2026-05-14T15:26:00Z"
+    },
+    {
+      "upstream": "Wei-Shaw/sub2api#736",
+      "url": "https://github.com/Wei-Shaw/sub2api/issues/736",
+      "title": "openclaw 报错",
+      "impact": "needs_review",
+      "categories": [
+        "security"
+      ],
+      "tokenkey_status": "candidate_unverified",
+      "rationale": "Keyword match for production-sensitive area; not yet manually verified against TokenKey code.",
+      "updated_at": "2026-04-11T15:05:54Z"
+    },
+    {
+      "upstream": "Wei-Shaw/sub2api#751",
+      "url": "https://github.com/Wei-Shaw/sub2api/issues/751",
+      "title": "OpenAI的OAuth和Key放到一个组，为什么不会用key的账号啊",
+      "impact": "needs_review",
+      "categories": [
+        "image_oauth"
+      ],
+      "tokenkey_status": "candidate_unverified",
+      "rationale": "Keyword match for production-sensitive area; not yet manually verified against TokenKey code.",
+      "updated_at": "2026-03-04T03:20:55Z"
+    },
+    {
+      "upstream": "Wei-Shaw/sub2api#753",
+      "url": "https://github.com/Wei-Shaw/sub2api/issues/753",
+      "title": "功能请求：支持账号级别自定义 User-Agent",
+      "impact": "needs_review",
+      "categories": [
+        "claude_mimicry",
+        "image_oauth"
+      ],
+      "tokenkey_status": "candidate_unverified",
+      "rationale": "Keyword match for production-sensitive area; not yet manually verified against TokenKey code.",
+      "updated_at": "2026-03-04T04:51:37Z"
+    },
+    {
+      "upstream": "Wei-Shaw/sub2api#791",
+      "url": "https://github.com/Wei-Shaw/sub2api/issues/791",
+      "title": "[Bug] AntigravityGatewayService 流式响应偶尔返回空流，缺失 message_start 事件",
+      "impact": "needs_review",
+      "categories": [
+        "claude_mimicry",
+        "security"
+      ],
+      "tokenkey_status": "candidate_unverified",
+      "rationale": "Keyword match for production-sensitive area; not yet manually verified against TokenKey code.",
+      "updated_at": "2026-03-05T13:10:46Z"
+    },
+    {
+      "upstream": "Wei-Shaw/sub2api#795",
+      "url": "https://github.com/Wei-Shaw/sub2api/issues/795",
+      "title": "[Bug] Gemini Messages Compat: patternProperties in tool schema causes 400",
+      "impact": "needs_review",
+      "categories": [
+        "image_oauth"
+      ],
+      "tokenkey_status": "candidate_unverified",
+      "rationale": "Keyword match for production-sensitive area; not yet manually verified against TokenKey code.",
+      "updated_at": "2026-03-09T05:09:59Z"
+    },
+    {
+      "upstream": "Wei-Shaw/sub2api#797",
+      "url": "https://github.com/Wei-Shaw/sub2api/issues/797",
+      "title": "Gemini为什么显示429，十几个小时不能用",
+      "impact": "needs_review",
+      "categories": [
+        "rate_limit_cooldown"
+      ],
+      "tokenkey_status": "candidate_unverified",
+      "rationale": "Keyword match for production-sensitive area; not yet manually verified against TokenKey code.",
+      "updated_at": "2026-03-16T20:21:25Z"
+    },
+    {
+      "upstream": "Wei-Shaw/sub2api#816",
+      "url": "https://github.com/Wei-Shaw/sub2api/issues/816",
+      "title": "【bug】API Error: 400 claude max 官方 oauth 调用出异常，api 模式的都没问题",
+      "impact": "needs_review",
+      "categories": [
+        "image_oauth"
+      ],
+      "tokenkey_status": "candidate_unverified",
+      "rationale": "Keyword match for production-sensitive area; not yet manually verified against TokenKey code.",
+      "updated_at": "2026-03-08T13:30:54Z"
+    },
+    {
+      "upstream": "Wei-Shaw/sub2api#819",
+      "url": "https://github.com/Wei-Shaw/sub2api/issues/819",
+      "title": "Responses API: metadata 字段透传导致上游 502",
+      "impact": "needs_review",
+      "categories": [
+        "claude_mimicry",
+        "rate_limit_cooldown",
+        "image_oauth"
+      ],
+      "tokenkey_status": "candidate_unverified",
+      "rationale": "Keyword match for production-sensitive area; not yet manually verified against TokenKey code.",
+      "updated_at": "2026-03-06T11:56:31Z"
+    },
+    {
+      "upstream": "Wei-Shaw/sub2api#822",
+      "url": "https://github.com/Wei-Shaw/sub2api/issues/822",
+      "title": "新手提问：账号管理-添加账号的设置问题",
+      "impact": "needs_review",
+      "categories": [
+        "rate_limit_cooldown"
+      ],
+      "tokenkey_status": "candidate_unverified",
+      "rationale": "Keyword match for production-sensitive area; not yet manually verified against TokenKey code.",
+      "updated_at": "2026-03-12T08:39:13Z"
+    },
+    {
+      "upstream": "Wei-Shaw/sub2api#828",
+      "url": "https://github.com/Wei-Shaw/sub2api/issues/828",
+      "title": "回归故障：GMN 子代理 coder 路由 gpt-5.3-codex / gpt-5.4 返回 403（main 可用）",
+      "impact": "needs_review",
+      "categories": [
+        "claude_mimicry"
+      ],
+      "tokenkey_status": "candidate_unverified",
+      "rationale": "Keyword match for production-sensitive area; not yet manually verified against TokenKey code.",
+      "updated_at": "2026-04-16T11:45:22Z"
+    },
+    {
+      "upstream": "Wei-Shaw/sub2api#834",
+      "url": "https://github.com/Wei-Shaw/sub2api/issues/834",
+      "title": "Feature request: support gateway-level LLM response/prompt cache",
+      "impact": "needs_review",
+      "categories": [
+        "rate_limit_cooldown",
+        "billing_usage",
+        "security"
+      ],
+      "tokenkey_status": "candidate_unverified",
+      "rationale": "Keyword match for production-sensitive area; not yet manually verified against TokenKey code.",
+      "updated_at": "2026-03-07T05:20:51Z"
+    },
+    {
+      "upstream": "Wei-Shaw/sub2api#837",
+      "url": "https://github.com/Wei-Shaw/sub2api/issues/837",
+      "title": "Docs / roadmap clarification: cache capability boundaries and future plan",
+      "impact": "needs_review",
+      "categories": [
+        "rate_limit_cooldown",
+        "security"
+      ],
+      "tokenkey_status": "candidate_unverified",
+      "rationale": "Keyword match for production-sensitive area; not yet manually verified against TokenKey code.",
+      "updated_at": "2026-03-07T10:01:51Z"
+    },
+    {
+      "upstream": "Wei-Shaw/sub2api#849",
+      "url": "https://github.com/Wei-Shaw/sub2api/issues/849",
+      "title": "Error running remote compact task",
+      "impact": "needs_review",
+      "categories": [
+        "rate_limit_cooldown",
+        "image_oauth"
+      ],
+      "tokenkey_status": "candidate_unverified",
+      "rationale": "Keyword match for production-sensitive area; not yet manually verified against TokenKey code.",
+      "updated_at": "2026-04-24T05:45:11Z"
+    },
+    {
+      "upstream": "Wei-Shaw/sub2api#851",
+      "url": "https://github.com/Wei-Shaw/sub2api/issues/851",
+      "title": "[Bug] 重试过滤 thinking block 时未同步移除 context_management 的 clear_thinking 策略，导致 400 错误",
+      "impact": "needs_review",
+      "categories": [
+        "claude_mimicry",
+        "rate_limit_cooldown",
+        "security"
+      ],
+      "tokenkey_status": "candidate_unverified",
+      "rationale": "Keyword match for production-sensitive area; not yet manually verified against TokenKey code.",
+      "updated_at": "2026-03-08T13:16:41Z"
+    },
+    {
+      "upstream": "Wei-Shaw/sub2api#857",
+      "url": "https://github.com/Wei-Shaw/sub2api/issues/857",
+      "title": "BUG: 错误透传不生效",
+      "impact": "needs_review",
+      "categories": [
+        "rate_limit_cooldown",
+        "security"
+      ],
+      "tokenkey_status": "candidate_unverified",
+      "rationale": "Keyword match for production-sensitive area; not yet manually verified against TokenKey code.",
+      "updated_at": "2026-03-08T06:37:17Z"
+    },
+    {
+      "upstream": "Wei-Shaw/sub2api#859",
+      "url": "https://github.com/Wei-Shaw/sub2api/issues/859",
+      "title": "多协议账号",
+      "impact": "needs_review",
+      "categories": [
+        "claude_mimicry",
+        "rate_limit_cooldown"
+      ],
+      "tokenkey_status": "candidate_unverified",
+      "rationale": "Keyword match for production-sensitive area; not yet manually verified against TokenKey code.",
+      "updated_at": "2026-03-08T11:28:39Z"
+    },
+    {
+      "upstream": "Wei-Shaw/sub2api#865",
+      "url": "https://github.com/Wei-Shaw/sub2api/issues/865",
+      "title": "关于账号调度原理及并发性设置问题",
+      "impact": "needs_review",
+      "categories": [
+        "security"
+      ],
+      "tokenkey_status": "candidate_unverified",
+      "rationale": "Keyword match for production-sensitive area; not yet manually verified against TokenKey code.",
+      "updated_at": "2026-03-08T17:16:30Z"
+    },
+    {
+      "upstream": "Wei-Shaw/sub2api#882",
+      "url": "https://github.com/Wei-Shaw/sub2api/issues/882",
+      "title": "使用gpt-5.4之后频繁出现429错误",
+      "impact": "needs_review",
+      "categories": [
+        "rate_limit_cooldown"
+      ],
+      "tokenkey_status": "candidate_unverified",
+      "rationale": "Keyword match for production-sensitive area; not yet manually verified against TokenKey code.",
+      "updated_at": "2026-05-12T14:34:57Z"
+    },
+    {
+      "upstream": "Wei-Shaw/sub2api#888",
+      "url": "https://github.com/Wei-Shaw/sub2api/issues/888",
+      "title": "gpt5.4时不时来个全量，这个是bug吗，token消耗直接爆炸",
+      "impact": "needs_review",
+      "categories": [
+        "security"
+      ],
+      "tokenkey_status": "candidate_unverified",
+      "rationale": "Keyword match for production-sensitive area; not yet manually verified against TokenKey code.",
+      "updated_at": "2026-03-10T06:01:49Z"
+    },
+    {
+      "upstream": "Wei-Shaw/sub2api#89",
+      "url": "https://github.com/Wei-Shaw/sub2api/issues/89",
+      "title": "希望支持转发成open ai或者其他格式的接口",
+      "impact": "needs_review",
+      "categories": [
+        "claude_mimicry"
+      ],
+      "tokenkey_status": "candidate_unverified",
+      "rationale": "Keyword match for production-sensitive area; not yet manually verified against TokenKey code.",
+      "updated_at": "2026-01-15T01:36:25Z"
+    },
+    {
+      "upstream": "Wei-Shaw/sub2api#891",
+      "url": "https://github.com/Wei-Shaw/sub2api/issues/891",
+      "title": "无法统计消耗的token数",
+      "impact": "needs_review",
+      "categories": [
+        "security"
+      ],
+      "tokenkey_status": "candidate_unverified",
+      "rationale": "Keyword match for production-sensitive area; not yet manually verified against TokenKey code.",
+      "updated_at": "2026-03-26T07:00:36Z"
+    },
+    {
+      "upstream": "Wei-Shaw/sub2api#915",
+      "url": "https://github.com/Wei-Shaw/sub2api/issues/915",
+      "title": "gemini没法用",
+      "impact": "needs_review",
+      "categories": [
+        "rate_limit_cooldown"
+      ],
+      "tokenkey_status": "candidate_unverified",
+      "rationale": "Keyword match for production-sensitive area; not yet manually verified against TokenKey code.",
+      "updated_at": "2026-05-02T10:52:24Z"
+    },
+    {
+      "upstream": "Wei-Shaw/sub2api#920",
+      "url": "https://github.com/Wei-Shaw/sub2api/issues/920",
+      "title": "自动生成的ccswitch的api无响应",
+      "impact": "needs_review",
+      "categories": [
+        "account_pool_health"
+      ],
+      "tokenkey_status": "candidate_unverified",
+      "rationale": "Keyword match for production-sensitive area; not yet manually verified against TokenKey code.",
+      "updated_at": "2026-04-08T04:52:05Z"
+    },
+    {
+      "upstream": "Wei-Shaw/sub2api#923",
+      "url": "https://github.com/Wei-Shaw/sub2api/issues/923",
+      "title": "如果遇到用户发来的数据全为空 希望可以加一层处理快速返回空结果",
+      "impact": "needs_review",
+      "categories": [
+        "security"
+      ],
+      "tokenkey_status": "candidate_unverified",
+      "rationale": "Keyword match for production-sensitive area; not yet manually verified against TokenKey code.",
+      "updated_at": "2026-03-11T03:21:36Z"
+    },
+    {
+      "upstream": "Wei-Shaw/sub2api#929",
+      "url": "https://github.com/Wei-Shaw/sub2api/issues/929",
+      "title": "claude code 的oauth账号，活跃账号永远是0",
+      "impact": "needs_review",
+      "categories": [
+        "claude_mimicry",
+        "image_oauth"
+      ],
+      "tokenkey_status": "candidate_unverified",
+      "rationale": "Keyword match for production-sensitive area; not yet manually verified against TokenKey code.",
+      "updated_at": "2026-03-11T07:29:00Z"
+    },
+    {
+      "upstream": "Wei-Shaw/sub2api#943",
+      "url": "https://github.com/Wei-Shaw/sub2api/issues/943",
+      "title": "使用 OPENCLAW 时，发起请求后前端会先显示 503 错误，但过一会刷新网页，又能看到这次请求对应的返回内容已经出来了。",
+      "impact": "needs_review",
+      "categories": [
+        "rate_limit_cooldown"
+      ],
+      "tokenkey_status": "candidate_unverified",
+      "rationale": "Keyword match for production-sensitive area; not yet manually verified against TokenKey code.",
+      "updated_at": "2026-03-12T04:35:50Z"
+    },
+    {
+      "upstream": "Wei-Shaw/sub2api#963",
+      "url": "https://github.com/Wei-Shaw/sub2api/issues/963",
+      "title": "OpenAI OAuth 的 /v1/responses 转发对 Content-Type 过于严格：application/json; charset=utf-8 会触发 Unsupported content type",
+      "impact": "needs_review",
+      "categories": [
+        "image_oauth"
+      ],
+      "tokenkey_status": "candidate_unverified",
+      "rationale": "Keyword match for production-sensitive area; not yet manually verified against TokenKey code.",
+      "updated_at": "2026-03-14T15:43:31Z"
+    },
+    {
+      "upstream": "Wei-Shaw/sub2api#965",
+      "url": "https://github.com/Wei-Shaw/sub2api/issues/965",
+      "title": "bug: apikey 5h速率限制bug",
+      "impact": "needs_review",
+      "categories": [
+        "rate_limit_cooldown",
+        "billing_usage"
+      ],
+      "tokenkey_status": "candidate_unverified",
+      "rationale": "Keyword match for production-sensitive area; not yet manually verified against TokenKey code.",
+      "updated_at": "2026-03-13T02:03:19Z"
+    },
+    {
+      "upstream": "Wei-Shaw/sub2api#981",
+      "url": "https://github.com/Wei-Shaw/sub2api/issues/981",
+      "title": "antigravity URL 404",
+      "impact": "needs_review",
+      "categories": [
+        "claude_mimicry"
+      ],
+      "tokenkey_status": "candidate_unverified",
+      "rationale": "Keyword match for production-sensitive area; not yet manually verified against TokenKey code.",
+      "updated_at": "2026-03-13T14:56:29Z"
+    },
+    {
+      "upstream": "Wei-Shaw/sub2api#985",
+      "url": "https://github.com/Wei-Shaw/sub2api/issues/985",
+      "title": "Feature Request: Trace log or OTEL support",
+      "impact": "needs_review",
+      "categories": [
+        "billing_usage"
+      ],
+      "tokenkey_status": "candidate_unverified",
+      "rationale": "Keyword match for production-sensitive area; not yet manually verified against TokenKey code.",
+      "updated_at": "2026-03-14T01:46:01Z"
+    },
+    {
+      "upstream": "Wei-Shaw/sub2api#991",
+      "url": "https://github.com/Wei-Shaw/sub2api/issues/991",
+      "title": "sub2api 的 streaming failover 逻辑有致命缺陷：",
+      "impact": "needs_review",
+      "categories": [
+        "claude_mimicry",
+        "rate_limit_cooldown"
+      ],
+      "tokenkey_status": "candidate_unverified",
+      "rationale": "Keyword match for production-sensitive area; not yet manually verified against TokenKey code.",
+      "updated_at": "2026-03-14T05:05:00Z"
+    },
+    {
+      "upstream": "Wei-Shaw/sub2api#996",
+      "url": "https://github.com/Wei-Shaw/sub2api/issues/996",
+      "title": "Claude Code 使用 GPT 模型后切换回到 Claude，无法继续对话",
+      "impact": "needs_review",
+      "categories": [
+        "claude_mimicry"
+      ],
+      "tokenkey_status": "candidate_unverified",
+      "rationale": "Keyword match for production-sensitive area; not yet manually verified against TokenKey code.",
+      "updated_at": "2026-03-14T08:28:27Z"
+    },
+    {
+      "upstream": "Wei-Shaw/sub2api#998",
+      "url": "https://github.com/Wei-Shaw/sub2api/issues/998",
+      "title": "无法使用gemini的图片模型，测试报错",
+      "impact": "needs_review",
+      "categories": [
+        "image_oauth",
+        "account_pool_health"
+      ],
+      "tokenkey_status": "candidate_unverified",
+      "rationale": "Keyword match for production-sensitive area; not yet manually verified against TokenKey code.",
+      "updated_at": "2026-03-18T06:53:36Z"
+    },
+    {
+      "upstream": "Wei-Shaw/sub2api#1824",
+      "url": "https://github.com/Wei-Shaw/sub2api/issues/1824",
+      "title": "只有OAuth账号调用生图API会将账号标记错误",
+      "impact": "needs_prod_validation",
+      "categories": [
+        "rate_limit_cooldown",
+        "image_oauth",
+        "ops_observability",
+        "compatibility",
+        "admin_ui"
+      ],
+      "tokenkey_status": "partially_mitigated",
+      "rationale": "OpenAI 403 now starts with temporary unschedulable state, but repeated CF/Arkose challenges can still cool down or error accounts.",
+      "updated_at": "2026-04-23T06:46:12Z"
+    },
+    {
+      "upstream": "Wei-Shaw/sub2api#2232",
+      "url": "https://github.com/Wei-Shaw/sub2api/issues/2232",
+      "title": "Bug：/v1/images/edits 使用 gpt-image-2 通过 OAuth 账号转发失败",
+      "impact": "needs_prod_validation",
+      "categories": [
+        "rate_limit_cooldown",
+        "image_oauth",
+        "account_pool_health",
+        "ops_observability",
+        "compatibility"
+      ],
+      "tokenkey_status": "needs_tokenkey_review",
+      "rationale": "OpenAI OAuth images/edits gpt-image-2 remains a user-facing image path; validate against current image/edit bridge behavior.",
+      "updated_at": "2026-05-11T07:02:08Z"
+    },
+    {
+      "upstream": "Wei-Shaw/sub2api#2245",
+      "url": "https://github.com/Wei-Shaw/sub2api/issues/2245",
+      "title": "OpenAI Responses SSE 流未完成时被转发为 HTTP 200 导致 stream closed before response.completed 问题",
+      "impact": "needs_prod_validation",
+      "categories": [
+        "rate_limit_cooldown",
+        "billing_usage",
+        "account_pool_health",
+        "ops_observability",
+        "compatibility",
+        "enhancement",
+        "docs"
+      ],
+      "tokenkey_status": "known_protocol_limitation",
+      "rationale": "Responses stream terminal-event detection exists, but downstream may already have received HTTP 200 before an incomplete SSE is detected.",
+      "updated_at": "2026-05-07T06:36:20Z"
+    },
+    {
+      "upstream": "Wei-Shaw/sub2api#2332",
+      "url": "https://github.com/Wei-Shaw/sub2api/issues/2332",
+      "title": "Bug: Anthropic streaming message_delta usage 被重复记录导致 input_tokens=0 的冗余计费",
+      "impact": "needs_prod_validation",
+      "categories": [
+        "claude_mimicry",
+        "billing_usage",
+        "security"
+      ],
+      "tokenkey_status": "partially_mitigated",
+      "rationale": "Anthropic message_delta usage parsing avoids zero-value overwrites; production usage rows should still be sampled for duplicate billing.",
+      "updated_at": "2026-05-10T03:47:55Z"
+    },
+    {
+      "upstream": "Wei-Shaw/sub2api#2363",
+      "url": "https://github.com/Wei-Shaw/sub2api/issues/2363",
+      "title": "BUG: 渠道定价中的缓存读取定价未生效，经过计算还是默认值计费的",
+      "impact": "needs_prod_validation",
+      "categories": [
+        "billing_usage"
+      ],
+      "tokenkey_status": "partially_mitigated",
+      "rationale": "Cache-read price overrides exist in resolver and billing paths; verify production channel-pricing source selection.",
+      "updated_at": "2026-05-11T09:19:55Z"
+    },
+    {
+      "upstream": "Wei-Shaw/sub2api#2413",
+      "url": "https://github.com/Wei-Shaw/sub2api/issues/2413",
+      "title": "Cherry Studio 调 gpt-image-2，OpenAI 403 会导致账号被临时标记为不可调度",
+      "impact": "needs_prod_validation",
+      "categories": [
+        "rate_limit_cooldown",
+        "image_oauth",
+        "ops_observability",
+        "enhancement"
+      ],
+      "tokenkey_status": "partially_mitigated",
+      "rationale": "OpenAI image 403 still triggers temporary unschedulable cooldown; decide whether CF/Arkose image challenges should be ignored or scoped.",
+      "updated_at": "2026-05-14T00:33:30Z"
+    },
+    {
+      "upstream": "Wei-Shaw/sub2api#2486",
+      "url": "https://github.com/Wei-Shaw/sub2api/issues/2486",
+      "title": "gemini-pro-agent 不进入计费",
+      "impact": "needs_prod_validation",
+      "categories": [
+        "billing_usage"
+      ],
+      "tokenkey_status": "needs_tokenkey_review",
+      "rationale": "Gemini pro-agent billing appears to flow through RecordUsageWithLongContext, but no gemini-pro-agent-specific test was found.",
+      "updated_at": "2026-05-15T03:55:24Z"
+    },
+    {
+      "upstream": "Wei-Shaw/sub2api#641",
+      "url": "https://github.com/Wei-Shaw/sub2api/issues/641",
+      "title": "[Bug] Gemini CLI 反代：google_one 账号触发 429 时被封至 PST 午夜而非使用 tier 的 Cooldown 配置",
+      "impact": "needs_prod_validation",
+      "categories": [
+        "claude_mimicry",
+        "rate_limit_cooldown",
+        "image_oauth",
+        "security",
+        "ops_observability",
+        "enhancement"
+      ],
+      "tokenkey_status": "partially_mitigated",
+      "rationale": "Gemini google_one 429 now uses tier cooldown on Code Assist paths; verify google_one accounts are classified as Code Assist in production.",
+      "updated_at": "2026-02-25T14:36:43Z"
+    },
+    {
+      "upstream": "Wei-Shaw/sub2api#1009",
+      "url": "https://github.com/Wei-Shaw/sub2api/issues/1009",
+      "title": "0.1.99 版本 缺少pg_dump 导致手动创建备份失败",
+      "impact": "medium",
+      "categories": [
+        "ops_observability",
+        "compatibility"
+      ],
+      "tokenkey_status": "not_prioritized",
+      "rationale": "Potential compatibility/ops/admin impact, but not selected as severe TokenKey production risk in this pass.",
+      "updated_at": "2026-04-16T02:21:08Z"
+    },
+    {
+      "upstream": "Wei-Shaw/sub2api#1048",
+      "url": "https://github.com/Wei-Shaw/sub2api/issues/1048",
+      "title": "功能建议：建议新增gemini的openai兼容协议。openclaw中gemini的原生v1beta协议无法使用",
+      "impact": "medium",
+      "categories": [
+        "compatibility"
+      ],
+      "tokenkey_status": "not_prioritized",
+      "rationale": "Potential compatibility/ops/admin impact, but not selected as severe TokenKey production risk in this pass.",
+      "updated_at": "2026-03-19T03:45:22Z"
+    },
+    {
+      "upstream": "Wei-Shaw/sub2api#1059",
+      "url": "https://github.com/Wei-Shaw/sub2api/issues/1059",
+      "title": "建议兼容老的openai格式（completions），这对于一些老的api非常友好",
+      "impact": "medium",
+      "categories": [
+        "compatibility"
+      ],
+      "tokenkey_status": "not_prioritized",
+      "rationale": "Potential compatibility/ops/admin impact, but not selected as severe TokenKey production risk in this pass.",
+      "updated_at": "2026-03-24T02:47:01Z"
+    },
+    {
+      "upstream": "Wei-Shaw/sub2api#1086",
+      "url": "https://github.com/Wei-Shaw/sub2api/issues/1086",
+      "title": "使用ChatGPT接口，Claude 经常出现空回问题",
+      "impact": "medium",
+      "categories": [
+        "ops_observability"
+      ],
+      "tokenkey_status": "not_prioritized",
+      "rationale": "Potential compatibility/ops/admin impact, but not selected as severe TokenKey production risk in this pass.",
+      "updated_at": "2026-03-17T06:45:43Z"
+    },
+    {
+      "upstream": "Wei-Shaw/sub2api#1094",
+      "url": "https://github.com/Wei-Shaw/sub2api/issues/1094",
+      "title": "建议 我的订阅 页面 与 个人资料 合并",
+      "impact": "medium",
+      "categories": [
+        "admin_ui"
+      ],
+      "tokenkey_status": "not_prioritized",
+      "rationale": "Potential compatibility/ops/admin impact, but not selected as severe TokenKey production risk in this pass.",
+      "updated_at": "2026-03-17T10:28:25Z"
+    },
+    {
+      "upstream": "Wei-Shaw/sub2api#1100",
+      "url": "https://github.com/Wei-Shaw/sub2api/issues/1100",
+      "title": "账号管理导入和筛选功能的建议",
+      "impact": "medium",
+      "categories": [
+        "admin_ui"
+      ],
+      "tokenkey_status": "not_prioritized",
+      "rationale": "Potential compatibility/ops/admin impact, but not selected as severe TokenKey production risk in this pass.",
+      "updated_at": "2026-03-17T13:46:43Z"
+    },
+    {
+      "upstream": "Wei-Shaw/sub2api#1173",
+      "url": "https://github.com/Wei-Shaw/sub2api/issues/1173",
+      "title": "claude最高最低版本输入后点击保存配置按钮没反应",
+      "impact": "medium",
+      "categories": [
+        "admin_ui"
+      ],
+      "tokenkey_status": "not_prioritized",
+      "rationale": "Potential compatibility/ops/admin impact, but not selected as severe TokenKey production risk in this pass.",
+      "updated_at": "2026-03-20T03:10:35Z"
+    },
+    {
+      "upstream": "Wei-Shaw/sub2api#1180",
+      "url": "https://github.com/Wei-Shaw/sub2api/issues/1180",
+      "title": "v0.1.104 版本升级后，无法开启开放注册",
+      "impact": "medium",
+      "categories": [
+        "admin_ui"
+      ],
+      "tokenkey_status": "not_prioritized",
+      "rationale": "Potential compatibility/ops/admin impact, but not selected as severe TokenKey production risk in this pass.",
+      "updated_at": "2026-03-25T03:54:36Z"
+    },
+    {
+      "upstream": "Wei-Shaw/sub2api#1181",
+      "url": "https://github.com/Wei-Shaw/sub2api/issues/1181",
+      "title": "希望添加账号时支持拉取模型列表，并可定时自动刷新",
+      "impact": "medium",
+      "categories": [
+        "admin_ui"
+      ],
+      "tokenkey_status": "not_prioritized",
+      "rationale": "Potential compatibility/ops/admin impact, but not selected as severe TokenKey production risk in this pass.",
+      "updated_at": "2026-04-23T11:58:28Z"
+    },
+    {
+      "upstream": "Wei-Shaw/sub2api#1207",
+      "url": "https://github.com/Wei-Shaw/sub2api/issues/1207",
+      "title": "关于站点设置-添加客服的问题",
+      "impact": "medium",
+      "categories": [
+        "admin_ui"
+      ],
+      "tokenkey_status": "not_prioritized",
+      "rationale": "Potential compatibility/ops/admin impact, but not selected as severe TokenKey production risk in this pass.",
+      "updated_at": "2026-03-22T01:55:58Z"
+    },
+    {
+      "upstream": "Wei-Shaw/sub2api#1251",
+      "url": "https://github.com/Wei-Shaw/sub2api/issues/1251",
+      "title": "阿里百炼使用openai兼容接口失败",
+      "impact": "medium",
+      "categories": [
+        "compatibility"
+      ],
+      "tokenkey_status": "not_prioritized",
+      "rationale": "Potential compatibility/ops/admin impact, but not selected as severe TokenKey production risk in this pass.",
+      "updated_at": "2026-05-13T05:59:04Z"
+    },
+    {
+      "upstream": "Wei-Shaw/sub2api#1319",
+      "url": "https://github.com/Wei-Shaw/sub2api/issues/1319",
+      "title": "Pincc订单页面前往控制台失败，登录也失败",
+      "impact": "medium",
+      "categories": [
+        "admin_ui"
+      ],
+      "tokenkey_status": "not_prioritized",
+      "rationale": "Potential compatibility/ops/admin impact, but not selected as severe TokenKey production risk in this pass.",
+      "updated_at": "2026-03-26T07:27:57Z"
+    },
+    {
+      "upstream": "Wei-Shaw/sub2api#1359",
+      "url": "https://github.com/Wei-Shaw/sub2api/issues/1359",
+      "title": "求求了求求了",
+      "impact": "medium",
+      "categories": [
+        "compatibility"
+      ],
+      "tokenkey_status": "not_prioritized",
+      "rationale": "Potential compatibility/ops/admin impact, but not selected as severe TokenKey production risk in this pass.",
+      "updated_at": "2026-03-29T06:04:11Z"
+    },
+    {
+      "upstream": "Wei-Shaw/sub2api#1363",
+      "url": "https://github.com/Wei-Shaw/sub2api/issues/1363",
+      "title": "【体验优化】分页组件在翻页时宽度变化，导致位置轻微跳动，希望优化一下~",
+      "impact": "medium",
+      "categories": [
+        "admin_ui"
+      ],
+      "tokenkey_status": "not_prioritized",
+      "rationale": "Potential compatibility/ops/admin impact, but not selected as severe TokenKey production risk in this pass.",
+      "updated_at": "2026-03-29T04:19:16Z"
+    },
+    {
+      "upstream": "Wei-Shaw/sub2api#1426",
+      "url": "https://github.com/Wei-Shaw/sub2api/issues/1426",
+      "title": "数据库过大",
+      "impact": "medium",
+      "categories": [
+        "ops_observability"
+      ],
+      "tokenkey_status": "not_prioritized",
+      "rationale": "Potential compatibility/ops/admin impact, but not selected as severe TokenKey production risk in this pass.",
+      "updated_at": "2026-04-01T10:08:19Z"
+    },
+    {
+      "upstream": "Wei-Shaw/sub2api#1432",
+      "url": "https://github.com/Wei-Shaw/sub2api/issues/1432",
+      "title": "删除日志失败",
+      "impact": "medium",
+      "categories": [
+        "ops_observability"
+      ],
+      "tokenkey_status": "not_prioritized",
+      "rationale": "Potential compatibility/ops/admin impact, but not selected as severe TokenKey production risk in this pass.",
+      "updated_at": "2026-04-17T03:09:26Z"
+    },
+    {
+      "upstream": "Wei-Shaw/sub2api#1444",
+      "url": "https://github.com/Wei-Shaw/sub2api/issues/1444",
+      "title": "为什么我将 GPT-5.3-codex 映射到 GPT-5.4-mini，为什么我调用后使用记录里展示的还是使用GPT-5.3-codex",
+      "impact": "medium",
+      "categories": [
+        "admin_ui"
+      ],
+      "tokenkey_status": "not_prioritized",
+      "rationale": "Potential compatibility/ops/admin impact, but not selected as severe TokenKey production risk in this pass.",
+      "updated_at": "2026-04-03T06:16:35Z"
+    },
+    {
+      "upstream": "Wei-Shaw/sub2api#1458",
+      "url": "https://github.com/Wei-Shaw/sub2api/issues/1458",
+      "title": "页面优化",
+      "impact": "medium",
+      "categories": [
+        "admin_ui"
+      ],
+      "tokenkey_status": "not_prioritized",
+      "rationale": "Potential compatibility/ops/admin impact, but not selected as severe TokenKey production risk in this pass.",
+      "updated_at": "2026-04-04T16:24:50Z"
+    },
+    {
+      "upstream": "Wei-Shaw/sub2api#1477",
+      "url": "https://github.com/Wei-Shaw/sub2api/issues/1477",
+      "title": "OpenAI 使用compact压缩问题",
+      "impact": "medium",
+      "categories": [
+        "compatibility"
+      ],
+      "tokenkey_status": "not_prioritized",
+      "rationale": "Potential compatibility/ops/admin impact, but not selected as severe TokenKey production risk in this pass.",
+      "updated_at": "2026-04-21T10:08:35Z"
+    },
+    {
+      "upstream": "Wei-Shaw/sub2api#1496",
+      "url": "https://github.com/Wei-Shaw/sub2api/issues/1496",
+      "title": "🐛 Bug：使用 postgres:18-alpine 时 PostgreSQL 容器初始化失败（unhealthy）",
+      "impact": "medium",
+      "categories": [
+        "ops_observability",
+        "compatibility"
+      ],
+      "tokenkey_status": "not_prioritized",
+      "rationale": "Potential compatibility/ops/admin impact, but not selected as severe TokenKey production risk in this pass.",
+      "updated_at": "2026-04-07T11:28:03Z"
+    },
+    {
+      "upstream": "Wei-Shaw/sub2api#1497",
+      "url": "https://github.com/Wei-Shaw/sub2api/issues/1497",
+      "title": "codex给claude cli用，经常会触发压缩",
+      "impact": "medium",
+      "categories": [
+        "compatibility"
+      ],
+      "tokenkey_status": "not_prioritized",
+      "rationale": "Potential compatibility/ops/admin impact, but not selected as severe TokenKey production risk in this pass.",
+      "updated_at": "2026-04-26T03:00:19Z"
+    },
+    {
+      "upstream": "Wei-Shaw/sub2api#1514",
+      "url": "https://github.com/Wei-Shaw/sub2api/issues/1514",
+      "title": "/setup这个页面为什么一直错误,安装一直进行不下去",
+      "impact": "medium",
+      "categories": [
+        "admin_ui"
+      ],
+      "tokenkey_status": "not_prioritized",
+      "rationale": "Potential compatibility/ops/admin impact, but not selected as severe TokenKey production risk in this pass.",
+      "updated_at": "2026-04-08T08:29:39Z"
+    },
+    {
+      "upstream": "Wei-Shaw/sub2api#1516",
+      "url": "https://github.com/Wei-Shaw/sub2api/issues/1516",
+      "title": "【BUG】cloudflare网关报错",
+      "impact": "medium",
+      "categories": [
+        "ops_observability",
+        "compatibility"
+      ],
+      "tokenkey_status": "not_prioritized",
+      "rationale": "Potential compatibility/ops/admin impact, but not selected as severe TokenKey production risk in this pass.",
+      "updated_at": "2026-04-08T10:50:30Z"
+    },
+    {
+      "upstream": "Wei-Shaw/sub2api#1534",
+      "url": "https://github.com/Wei-Shaw/sub2api/issues/1534",
+      "title": "容量和今日使用不一致",
+      "impact": "medium",
+      "categories": [
+        "admin_ui"
+      ],
+      "tokenkey_status": "not_prioritized",
+      "rationale": "Potential compatibility/ops/admin impact, but not selected as severe TokenKey production risk in this pass.",
+      "updated_at": "2026-04-09T08:50:55Z"
+    },
+    {
+      "upstream": "Wei-Shaw/sub2api#1556",
+      "url": "https://github.com/Wei-Shaw/sub2api/issues/1556",
+      "title": "7天用量统计",
+      "impact": "medium",
+      "categories": [
+        "admin_ui"
+      ],
+      "tokenkey_status": "not_prioritized",
+      "rationale": "Potential compatibility/ops/admin impact, but not selected as severe TokenKey production risk in this pass.",
+      "updated_at": "2026-04-10T08:12:13Z"
+    },
+    {
+      "upstream": "Wei-Shaw/sub2api#1594",
+      "url": "https://github.com/Wei-Shaw/sub2api/issues/1594",
+      "title": "【需求】 支持统计识别上游模型真实来源",
+      "impact": "medium",
+      "categories": [
+        "admin_ui"
+      ],
+      "tokenkey_status": "not_prioritized",
+      "rationale": "Potential compatibility/ops/admin impact, but not selected as severe TokenKey production risk in this pass.",
+      "updated_at": "2026-04-12T10:55:11Z"
+    },
+    {
+      "upstream": "Wei-Shaw/sub2api#1602",
+      "url": "https://github.com/Wei-Shaw/sub2api/issues/1602",
+      "title": "新版本易支付，显示支付成功，一直没有进行回调，请问是什么原因。",
+      "impact": "medium",
+      "categories": [
+        "ops_observability"
+      ],
+      "tokenkey_status": "not_prioritized",
+      "rationale": "Potential compatibility/ops/admin impact, but not selected as severe TokenKey production risk in this pass.",
+      "updated_at": "2026-04-18T08:47:20Z"
+    },
+    {
+      "upstream": "Wei-Shaw/sub2api#1605",
+      "url": "https://github.com/Wei-Shaw/sub2api/issues/1605",
+      "title": "【BUG or 需求？】在上游是claude 池模式时，频繁报错 API Error: 400",
+      "impact": "medium",
+      "categories": [
+        "ops_observability"
+      ],
+      "tokenkey_status": "not_prioritized",
+      "rationale": "Potential compatibility/ops/admin impact, but not selected as severe TokenKey production risk in this pass.",
+      "updated_at": "2026-04-13T02:20:21Z"
+    },
+    {
+      "upstream": "Wei-Shaw/sub2api#161",
+      "url": "https://github.com/Wei-Shaw/sub2api/issues/161",
+      "title": "订阅管理用量没有统计",
+      "impact": "medium",
+      "categories": [
+        "admin_ui"
+      ],
+      "tokenkey_status": "not_prioritized",
+      "rationale": "Potential compatibility/ops/admin impact, but not selected as severe TokenKey production risk in this pass.",
+      "updated_at": "2026-01-05T06:26:56Z"
+    },
+    {
+      "upstream": "Wei-Shaw/sub2api#1616",
+      "url": "https://github.com/Wei-Shaw/sub2api/issues/1616",
+      "title": "feat 能否加一个数据统计列表：以账号为维度统计时间范围内的额度消耗",
+      "impact": "medium",
+      "categories": [
+        "admin_ui"
+      ],
+      "tokenkey_status": "not_prioritized",
+      "rationale": "Potential compatibility/ops/admin impact, but not selected as severe TokenKey production risk in this pass.",
+      "updated_at": "2026-04-15T04:07:41Z"
+    },
+    {
+      "upstream": "Wei-Shaw/sub2api#1636",
+      "url": "https://github.com/Wei-Shaw/sub2api/issues/1636",
+      "title": "版本更新按钮无法点击 修复指南",
+      "impact": "medium",
+      "categories": [
+        "compatibility",
+        "admin_ui"
+      ],
+      "tokenkey_status": "not_prioritized",
+      "rationale": "Potential compatibility/ops/admin impact, but not selected as severe TokenKey production risk in this pass.",
+      "updated_at": "2026-04-26T07:38:49Z"
+    },
+    {
+      "upstream": "Wei-Shaw/sub2api#1650",
+      "url": "https://github.com/Wei-Shaw/sub2api/issues/1650",
+      "title": "请问如何查看模型定价，哪怕是默认的模型定价，我在渠道里面看也是全空的，似乎没有一个页面展示模型是如何定价的",
+      "impact": "medium",
+      "categories": [
+        "admin_ui"
+      ],
+      "tokenkey_status": "not_prioritized",
+      "rationale": "Potential compatibility/ops/admin impact, but not selected as severe TokenKey production risk in this pass.",
+      "updated_at": "2026-04-15T01:46:49Z"
+    },
+    {
+      "upstream": "Wei-Shaw/sub2api#1653",
+      "url": "https://github.com/Wei-Shaw/sub2api/issues/1653",
+      "title": "账号管理下的<自动刷新>没有刷新<用量窗口>",
+      "impact": "medium",
+      "categories": [
+        "admin_ui"
+      ],
+      "tokenkey_status": "not_prioritized",
+      "rationale": "Potential compatibility/ops/admin impact, but not selected as severe TokenKey production risk in this pass.",
+      "updated_at": "2026-04-17T08:38:29Z"
+    },
+    {
+      "upstream": "Wei-Shaw/sub2api#1658",
+      "url": "https://github.com/Wei-Shaw/sub2api/issues/1658",
+      "title": "[BUG] v0.1.112 支付服务商实例配置解密失败, v0.1.113 又出现了, 又得重新配置才行",
+      "impact": "medium",
+      "categories": [
+        "compatibility"
+      ],
+      "tokenkey_status": "not_prioritized",
+      "rationale": "Potential compatibility/ops/admin impact, but not selected as severe TokenKey production risk in this pass.",
+      "updated_at": "2026-04-15T17:06:19Z"
+    },
+    {
+      "upstream": "Wei-Shaw/sub2api#1678",
+      "url": "https://github.com/Wei-Shaw/sub2api/issues/1678",
+      "title": "Stripe成功支付也会显示支付超时",
+      "impact": "medium",
+      "categories": [
+        "admin_ui"
+      ],
+      "tokenkey_status": "not_prioritized",
+      "rationale": "Potential compatibility/ops/admin impact, but not selected as severe TokenKey production risk in this pass.",
+      "updated_at": "2026-05-02T13:22:08Z"
+    },
+    {
+      "upstream": "Wei-Shaw/sub2api#1682",
+      "url": "https://github.com/Wei-Shaw/sub2api/issues/1682",
+      "title": "feat: 支持以USD为结算币种",
+      "impact": "medium",
+      "categories": [
+        "compatibility",
+        "admin_ui"
+      ],
+      "tokenkey_status": "not_prioritized",
+      "rationale": "Potential compatibility/ops/admin impact, but not selected as severe TokenKey production risk in this pass.",
+      "updated_at": "2026-05-08T15:49:40Z"
+    },
+    {
+      "upstream": "Wei-Shaw/sub2api#1696",
+      "url": "https://github.com/Wei-Shaw/sub2api/issues/1696",
+      "title": "sub2api不支持/v1/chat/completions",
+      "impact": "medium",
+      "categories": [
+        "compatibility"
+      ],
+      "tokenkey_status": "not_prioritized",
+      "rationale": "Potential compatibility/ops/admin impact, but not selected as severe TokenKey production risk in this pass.",
+      "updated_at": "2026-05-06T03:53:12Z"
+    },
+    {
+      "upstream": "Wei-Shaw/sub2api#1701",
+      "url": "https://github.com/Wei-Shaw/sub2api/issues/1701",
+      "title": "Windows 下完成 Setup Wizard 后仍会重新进入安装向导（config.yaml / .installed 写入目录与启动读取目录不一致）",
+      "impact": "medium",
+      "categories": [
+        "ops_observability",
+        "compatibility"
+      ],
+      "tokenkey_status": "not_prioritized",
+      "rationale": "Potential compatibility/ops/admin impact, but not selected as severe TokenKey production risk in this pass.",
+      "updated_at": "2026-04-16T10:01:13Z"
+    },
+    {
+      "upstream": "Wei-Shaw/sub2api#1811",
+      "url": "https://github.com/Wei-Shaw/sub2api/issues/1811",
+      "title": "feat：清理使用历史记录支持选时间区间",
+      "impact": "medium",
+      "categories": [
+        "ops_observability"
+      ],
+      "tokenkey_status": "not_prioritized",
+      "rationale": "Potential compatibility/ops/admin impact, but not selected as severe TokenKey production risk in this pass.",
+      "updated_at": "2026-04-22T14:47:50Z"
+    },
+    {
+      "upstream": "Wei-Shaw/sub2api#1818",
+      "url": "https://github.com/Wei-Shaw/sub2api/issues/1818",
+      "title": "v0.1.115版本codex平台刷新令牌无反应，号是plus套餐，显示的是free",
+      "impact": "medium",
+      "categories": [
+        "admin_ui"
+      ],
+      "tokenkey_status": "not_prioritized",
+      "rationale": "Potential compatibility/ops/admin impact, but not selected as severe TokenKey production risk in this pass.",
+      "updated_at": "2026-04-23T01:34:16Z"
+    },
+    {
+      "upstream": "Wei-Shaw/sub2api#1822",
+      "url": "https://github.com/Wei-Shaw/sub2api/issues/1822",
+      "title": "Failed to exchange OpenAI auth code-添加帐号时的问题解决",
+      "impact": "medium",
+      "categories": [
+        "admin_ui"
+      ],
+      "tokenkey_status": "not_prioritized",
+      "rationale": "Potential compatibility/ops/admin impact, but not selected as severe TokenKey production risk in this pass.",
+      "updated_at": "2026-04-23T02:50:02Z"
+    },
+    {
+      "upstream": "Wei-Shaw/sub2api#1865",
+      "url": "https://github.com/Wei-Shaw/sub2api/issues/1865",
+      "title": "GPT5.5在触发上下文压缩的时候报错404了，这个是OpenAI上游的问题还是sub2的问题呢？",
+      "impact": "medium",
+      "categories": [
+        "compatibility"
+      ],
+      "tokenkey_status": "not_prioritized",
+      "rationale": "Potential compatibility/ops/admin impact, but not selected as severe TokenKey production risk in this pass.",
+      "updated_at": "2026-04-25T04:49:32Z"
+    },
+    {
+      "upstream": "Wei-Shaw/sub2api#1871",
+      "url": "https://github.com/Wei-Shaw/sub2api/issues/1871",
+      "title": "如何使用qwen百炼的openai接口",
+      "impact": "medium",
+      "categories": [
+        "compatibility"
+      ],
+      "tokenkey_status": "not_prioritized",
+      "rationale": "Potential compatibility/ops/admin impact, but not selected as severe TokenKey production risk in this pass.",
+      "updated_at": "2026-04-24T03:30:23Z"
+    },
+    {
+      "upstream": "Wei-Shaw/sub2api#1882",
+      "url": "https://github.com/Wei-Shaw/sub2api/issues/1882",
+      "title": "feat: 渠道监控，使用用户真实调用记录",
+      "impact": "medium",
+      "categories": [
+        "ops_observability"
+      ],
+      "tokenkey_status": "not_prioritized",
+      "rationale": "Potential compatibility/ops/admin impact, but not selected as severe TokenKey production risk in this pass.",
+      "updated_at": "2026-04-24T05:49:09Z"
+    },
+    {
+      "upstream": "Wei-Shaw/sub2api#1890",
+      "url": "https://github.com/Wei-Shaw/sub2api/issues/1890",
+      "title": "BUG:运维监控中请求时长和TTFT明细展开后的数据都是请求时长",
+      "impact": "medium",
+      "categories": [
+        "ops_observability"
+      ],
+      "tokenkey_status": "not_prioritized",
+      "rationale": "Potential compatibility/ops/admin impact, but not selected as severe TokenKey production risk in this pass.",
+      "updated_at": "2026-04-24T07:28:43Z"
+    },
+    {
+      "upstream": "Wei-Shaw/sub2api#19",
+      "url": "https://github.com/Wei-Shaw/sub2api/issues/19",
+      "title": "建议未来使用记录展示更多的信息",
+      "impact": "medium",
+      "categories": [
+        "admin_ui"
+      ],
+      "tokenkey_status": "not_prioritized",
+      "rationale": "Potential compatibility/ops/admin impact, but not selected as severe TokenKey production risk in this pass.",
+      "updated_at": "2025-12-23T14:15:57Z"
+    },
+    {
+      "upstream": "Wei-Shaw/sub2api#1900",
+      "url": "https://github.com/Wei-Shaw/sub2api/issues/1900",
+      "title": "5.5 /compact报错",
+      "impact": "medium",
+      "categories": [
+        "compatibility"
+      ],
+      "tokenkey_status": "not_prioritized",
+      "rationale": "Potential compatibility/ops/admin impact, but not selected as severe TokenKey production risk in this pass.",
+      "updated_at": "2026-04-24T14:22:02Z"
+    },
+    {
+      "upstream": "Wei-Shaw/sub2api#192",
+      "url": "https://github.com/Wei-Shaw/sub2api/issues/192",
+      "title": "saas产品方向：希望添加用量展示的换算问题",
+      "impact": "medium",
+      "categories": [
+        "admin_ui"
+      ],
+      "tokenkey_status": "not_prioritized",
+      "rationale": "Potential compatibility/ops/admin impact, but not selected as severe TokenKey production risk in this pass.",
+      "updated_at": "2026-01-07T05:39:55Z"
+    },
+    {
+      "upstream": "Wei-Shaw/sub2api#1927",
+      "url": "https://github.com/Wei-Shaw/sub2api/issues/1927",
+      "title": "GPT-5.5 compact失败，请优化",
+      "impact": "medium",
+      "categories": [
+        "compatibility"
+      ],
+      "tokenkey_status": "not_prioritized",
+      "rationale": "Potential compatibility/ops/admin impact, but not selected as severe TokenKey production risk in this pass.",
+      "updated_at": "2026-04-25T10:59:40Z"
+    },
+    {
+      "upstream": "Wei-Shaw/sub2api#1931",
+      "url": "https://github.com/Wei-Shaw/sub2api/issues/1931",
+      "title": "充值/订阅页面金额前缀显示不一致，建议统一支持可配置货币符号",
+      "impact": "medium",
+      "categories": [
+        "admin_ui"
+      ],
+      "tokenkey_status": "not_prioritized",
+      "rationale": "Potential compatibility/ops/admin impact, but not selected as severe TokenKey production risk in this pass.",
+      "updated_at": "2026-04-25T02:12:48Z"
+    },
+    {
+      "upstream": "Wei-Shaw/sub2api#1954",
+      "url": "https://github.com/Wei-Shaw/sub2api/issues/1954",
+      "title": "Compact？",
+      "impact": "medium",
+      "categories": [
+        "compatibility"
+      ],
+      "tokenkey_status": "not_prioritized",
+      "rationale": "Potential compatibility/ops/admin impact, but not selected as severe TokenKey production risk in this pass.",
+      "updated_at": "2026-04-29T01:36:51Z"
+    },
+    {
+      "upstream": "Wei-Shaw/sub2api#1961",
+      "url": "https://github.com/Wei-Shaw/sub2api/issues/1961",
+      "title": "Tool reference 'TodoWrite' not found in available tools",
+      "impact": "medium",
+      "categories": [
+        "ops_observability"
+      ],
+      "tokenkey_status": "not_prioritized",
+      "rationale": "Potential compatibility/ops/admin impact, but not selected as severe TokenKey production risk in this pass.",
+      "updated_at": "2026-04-25T13:07:48Z"
+    },
+    {
+      "upstream": "Wei-Shaw/sub2api#1963",
+      "url": "https://github.com/Wei-Shaw/sub2api/issues/1963",
+      "title": "claude 工具调用出现问题",
+      "impact": "medium",
+      "categories": [
+        "ops_observability"
+      ],
+      "tokenkey_status": "not_prioritized",
+      "rationale": "Potential compatibility/ops/admin impact, but not selected as severe TokenKey production risk in this pass.",
+      "updated_at": "2026-04-26T01:18:25Z"
+    },
+    {
+      "upstream": "Wei-Shaw/sub2api#2035",
+      "url": "https://github.com/Wei-Shaw/sub2api/issues/2035",
+      "title": "redact-thinking-2026-02-12 可不可以不设置为默认选项，可以开关的。",
+      "impact": "medium",
+      "categories": [
+        "compatibility"
+      ],
+      "tokenkey_status": "not_prioritized",
+      "rationale": "Potential compatibility/ops/admin impact, but not selected as severe TokenKey production risk in this pass.",
+      "updated_at": "2026-04-27T11:46:43Z"
+    },
+    {
+      "upstream": "Wei-Shaw/sub2api#2036",
+      "url": "https://github.com/Wei-Shaw/sub2api/issues/2036",
+      "title": "在codex中使用DeepSeek报错",
+      "impact": "medium",
+      "categories": [
+        "ops_observability",
+        "compatibility"
+      ],
+      "tokenkey_status": "not_prioritized",
+      "rationale": "Potential compatibility/ops/admin impact, but not selected as severe TokenKey production risk in this pass.",
+      "updated_at": "2026-05-15T06:40:13Z"
+    },
+    {
+      "upstream": "Wei-Shaw/sub2api#2045",
+      "url": "https://github.com/Wei-Shaw/sub2api/issues/2045",
+      "title": "希望对充值页面的 帮助文本 加入Markdown 支持",
+      "impact": "medium",
+      "categories": [
+        "admin_ui"
+      ],
+      "tokenkey_status": "not_prioritized",
+      "rationale": "Potential compatibility/ops/admin impact, but not selected as severe TokenKey production risk in this pass.",
+      "updated_at": "2026-04-28T11:54:52Z"
+    },
+    {
+      "upstream": "Wei-Shaw/sub2api#2048",
+      "url": "https://github.com/Wei-Shaw/sub2api/issues/2048",
+      "title": "目前是不支持qwen3.6-plus的计价吗？",
+      "impact": "medium",
+      "categories": [
+        "admin_ui"
+      ],
+      "tokenkey_status": "not_prioritized",
+      "rationale": "Potential compatibility/ops/admin impact, but not selected as severe TokenKey production risk in this pass.",
+      "updated_at": "2026-04-28T02:53:16Z"
+    },
+    {
+      "upstream": "Wei-Shaw/sub2api#2049",
+      "url": "https://github.com/Wei-Shaw/sub2api/issues/2049",
+      "title": "ChatGPT 或 Claude 账号被封?别再用万人骑的劣质 IP 交学费了",
+      "impact": "medium",
+      "categories": [
+        "ops_observability"
+      ],
+      "tokenkey_status": "not_prioritized",
+      "rationale": "Potential compatibility/ops/admin impact, but not selected as severe TokenKey production risk in this pass.",
+      "updated_at": "2026-04-28T03:07:10Z"
+    },
+    {
+      "upstream": "Wei-Shaw/sub2api#2053",
+      "url": "https://github.com/Wei-Shaw/sub2api/issues/2053",
+      "title": "希望可以加一个额度查询刷新的功能",
+      "impact": "medium",
+      "categories": [
+        "admin_ui"
+      ],
+      "tokenkey_status": "not_prioritized",
+      "rationale": "Potential compatibility/ops/admin impact, but not selected as severe TokenKey production risk in this pass.",
+      "updated_at": "2026-04-28T15:01:08Z"
+    },
+    {
+      "upstream": "Wei-Shaw/sub2api#2061",
+      "url": "https://github.com/Wei-Shaw/sub2api/issues/2061",
+      "title": "docker image bug：docker-entrypoint.sh: exec format error",
+      "impact": "medium",
+      "categories": [
+        "ops_observability"
+      ],
+      "tokenkey_status": "not_prioritized",
+      "rationale": "Potential compatibility/ops/admin impact, but not selected as severe TokenKey production risk in this pass.",
+      "updated_at": "2026-04-28T09:58:51Z"
+    },
+    {
+      "upstream": "Wei-Shaw/sub2api#2075",
+      "url": "https://github.com/Wei-Shaw/sub2api/issues/2075",
+      "title": "支持上游账号自定义 Header",
+      "impact": "medium",
+      "categories": [
+        "compatibility"
+      ],
+      "tokenkey_status": "not_prioritized",
+      "rationale": "Potential compatibility/ops/admin impact, but not selected as severe TokenKey production risk in this pass.",
+      "updated_at": "2026-04-29T01:23:40Z"
+    },
+    {
+      "upstream": "Wei-Shaw/sub2api#2108",
+      "url": "https://github.com/Wei-Shaw/sub2api/issues/2108",
+      "title": "数据备份 oom",
+      "impact": "medium",
+      "categories": [
+        "ops_observability"
+      ],
+      "tokenkey_status": "not_prioritized",
+      "rationale": "Potential compatibility/ops/admin impact, but not selected as severe TokenKey production risk in this pass.",
+      "updated_at": "2026-04-29T15:48:23Z"
+    },
+    {
+      "upstream": "Wei-Shaw/sub2api#2121",
+      "url": "https://github.com/Wei-Shaw/sub2api/issues/2121",
+      "title": "[Feature] /v1/messages 流式请求等待上游响应头期间增加 SSE keepalive",
+      "impact": "medium",
+      "categories": [
+        "compatibility"
+      ],
+      "tokenkey_status": "not_prioritized",
+      "rationale": "Potential compatibility/ops/admin impact, but not selected as severe TokenKey production risk in this pass.",
+      "updated_at": "2026-04-30T03:30:19Z"
+    },
+    {
+      "upstream": "Wei-Shaw/sub2api#2127",
+      "url": "https://github.com/Wei-Shaw/sub2api/issues/2127",
+      "title": "BUG：透传的模型id缺失，plus账号只有三个可用模型id",
+      "impact": "medium",
+      "categories": [
+        "compatibility"
+      ],
+      "tokenkey_status": "not_prioritized",
+      "rationale": "Potential compatibility/ops/admin impact, but not selected as severe TokenKey production risk in this pass.",
+      "updated_at": "2026-04-30T05:07:48Z"
+    },
+    {
+      "upstream": "Wei-Shaw/sub2api#2149",
+      "url": "https://github.com/Wei-Shaw/sub2api/issues/2149",
+      "title": "Anthropic 格式 BASE URL 在添加监控的时候，限制路径会导致一些厂商无法请求",
+      "impact": "medium",
+      "categories": [
+        "ops_observability"
+      ],
+      "tokenkey_status": "not_prioritized",
+      "rationale": "Potential compatibility/ops/admin impact, but not selected as severe TokenKey production risk in this pass.",
+      "updated_at": "2026-05-01T07:44:32Z"
+    },
+    {
+      "upstream": "Wei-Shaw/sub2api#2161",
+      "url": "https://github.com/Wei-Shaw/sub2api/issues/2161",
+      "title": "【需求】针对apikey级别统计看板",
+      "impact": "medium",
+      "categories": [
+        "admin_ui"
+      ],
+      "tokenkey_status": "not_prioritized",
+      "rationale": "Potential compatibility/ops/admin impact, but not selected as severe TokenKey production risk in this pass.",
+      "updated_at": "2026-05-02T09:39:52Z"
+    },
+    {
+      "upstream": "Wei-Shaw/sub2api#2162",
+      "url": "https://github.com/Wei-Shaw/sub2api/issues/2162",
+      "title": "部分失败请求，没有合理展示",
+      "impact": "medium",
+      "categories": [
+        "ops_observability",
+        "admin_ui"
+      ],
+      "tokenkey_status": "not_prioritized",
+      "rationale": "Potential compatibility/ops/admin impact, but not selected as severe TokenKey production risk in this pass.",
+      "updated_at": "2026-05-02T11:58:50Z"
+    },
+    {
+      "upstream": "Wei-Shaw/sub2api#2187",
+      "url": "https://github.com/Wei-Shaw/sub2api/issues/2187",
+      "title": "出错的时候怎么打印请求体",
+      "impact": "medium",
+      "categories": [
+        "ops_observability"
+      ],
+      "tokenkey_status": "not_prioritized",
+      "rationale": "Potential compatibility/ops/admin impact, but not selected as severe TokenKey production risk in this pass.",
+      "updated_at": "2026-05-04T14:40:31Z"
+    },
+    {
+      "upstream": "Wei-Shaw/sub2api#2193",
+      "url": "https://github.com/Wei-Shaw/sub2api/issues/2193",
+      "title": "功能建议：在分组管理中支持维护分组下的账号成员",
+      "impact": "medium",
+      "categories": [
+        "admin_ui"
+      ],
+      "tokenkey_status": "not_prioritized",
+      "rationale": "Potential compatibility/ops/admin impact, but not selected as severe TokenKey production risk in this pass.",
+      "updated_at": "2026-05-05T04:56:12Z"
+    },
+    {
+      "upstream": "Wei-Shaw/sub2api#2200",
+      "url": "https://github.com/Wei-Shaw/sub2api/issues/2200",
+      "title": "postgres_data文件夹越来越大 几十个G了怎么办",
+      "impact": "medium",
+      "categories": [
+        "ops_observability"
+      ],
+      "tokenkey_status": "not_prioritized",
+      "rationale": "Potential compatibility/ops/admin impact, but not selected as severe TokenKey production risk in this pass.",
+      "updated_at": "2026-05-05T08:47:37Z"
+    },
+    {
+      "upstream": "Wei-Shaw/sub2api#2214",
+      "url": "https://github.com/Wei-Shaw/sub2api/issues/2214",
+      "title": "支持网页对话",
+      "impact": "medium",
+      "categories": [
+        "admin_ui"
+      ],
+      "tokenkey_status": "not_prioritized",
+      "rationale": "Potential compatibility/ops/admin impact, but not selected as severe TokenKey production risk in this pass.",
+      "updated_at": "2026-05-06T03:46:21Z"
+    },
+    {
+      "upstream": "Wei-Shaw/sub2api#2229",
+      "url": "https://github.com/Wei-Shaw/sub2api/issues/2229",
+      "title": "注册页面增加确认密码输入框",
+      "impact": "medium",
+      "categories": [
+        "admin_ui"
+      ],
+      "tokenkey_status": "not_prioritized",
+      "rationale": "Potential compatibility/ops/admin impact, but not selected as severe TokenKey production risk in this pass.",
+      "updated_at": "2026-05-06T12:37:19Z"
+    },
+    {
+      "upstream": "Wei-Shaw/sub2api#2246",
+      "url": "https://github.com/Wei-Shaw/sub2api/issues/2246",
+      "title": "openai/Anthropic协议转换兼容openai v1/chat/completions格式的需求",
+      "impact": "medium",
+      "categories": [
+        "compatibility"
+      ],
+      "tokenkey_status": "not_prioritized",
+      "rationale": "Potential compatibility/ops/admin impact, but not selected as severe TokenKey production risk in this pass.",
+      "updated_at": "2026-05-08T11:19:32Z"
+    },
+    {
+      "upstream": "Wei-Shaw/sub2api#2275",
+      "url": "https://github.com/Wei-Shaw/sub2api/issues/2275",
+      "title": "现在金额展示的默认$符号，可以改成支持在后台配置吗：",
+      "impact": "medium",
+      "categories": [
+        "admin_ui"
+      ],
+      "tokenkey_status": "not_prioritized",
+      "rationale": "Potential compatibility/ops/admin impact, but not selected as severe TokenKey production risk in this pass.",
+      "updated_at": "2026-05-08T04:32:30Z"
+    },
+    {
+      "upstream": "Wei-Shaw/sub2api#2281",
+      "url": "https://github.com/Wei-Shaw/sub2api/issues/2281",
+      "title": "v0.1.125版本切换微信支付，不显示已配置的微信支付渠道，控制台报错",
+      "impact": "medium",
+      "categories": [
+        "admin_ui"
+      ],
+      "tokenkey_status": "not_prioritized",
+      "rationale": "Potential compatibility/ops/admin impact, but not selected as severe TokenKey production risk in this pass.",
+      "updated_at": "2026-05-09T16:03:39Z"
+    },
+    {
+      "upstream": "Wei-Shaw/sub2api#2291",
+      "url": "https://github.com/Wei-Shaw/sub2api/issues/2291",
+      "title": "Cache Hit Rate 的计算方式有误",
+      "impact": "medium",
+      "categories": [
+        "image_oauth",
+        "security",
+        "admin_ui"
+      ],
+      "tokenkey_status": "unresolved_observability",
+      "rationale": "Cache hit rate has inconsistent UI formulas between dashboard/trend views; observability issue, not direct production outage.",
+      "updated_at": "2026-05-08T10:22:53Z"
+    },
+    {
+      "upstream": "Wei-Shaw/sub2api#2308",
+      "url": "https://github.com/Wei-Shaw/sub2api/issues/2308",
+      "title": "Bug: Docker 镜像未嵌入前端，导致根路径返回 404",
+      "impact": "medium",
+      "categories": [
+        "admin_ui"
+      ],
+      "tokenkey_status": "not_prioritized",
+      "rationale": "Potential compatibility/ops/admin impact, but not selected as severe TokenKey production risk in this pass.",
+      "updated_at": "2026-05-09T01:18:46Z"
+    },
+    {
+      "upstream": "Wei-Shaw/sub2api#2317",
+      "url": "https://github.com/Wei-Shaw/sub2api/issues/2317",
+      "title": "监控页面tps 建议拆分为输入tps和输出tps",
+      "impact": "medium",
+      "categories": [
+        "ops_observability",
+        "admin_ui"
+      ],
+      "tokenkey_status": "not_prioritized",
+      "rationale": "Potential compatibility/ops/admin impact, but not selected as severe TokenKey production risk in this pass.",
+      "updated_at": "2026-05-09T06:20:28Z"
+    },
+    {
+      "upstream": "Wei-Shaw/sub2api#2320",
+      "url": "https://github.com/Wei-Shaw/sub2api/issues/2320",
+      "title": "Claude上游报错",
+      "impact": "medium",
+      "categories": [
+        "ops_observability"
+      ],
+      "tokenkey_status": "not_prioritized",
+      "rationale": "Potential compatibility/ops/admin impact, but not selected as severe TokenKey production risk in this pass.",
+      "updated_at": "2026-05-09T09:52:54Z"
+    },
+    {
+      "upstream": "Wei-Shaw/sub2api#2357",
+      "url": "https://github.com/Wei-Shaw/sub2api/issues/2357",
+      "title": "有大佬解释一下关于 渠道订阅 功能的情况吗",
+      "impact": "medium",
+      "categories": [
+        "ops_observability"
+      ],
+      "tokenkey_status": "not_prioritized",
+      "rationale": "Potential compatibility/ops/admin impact, but not selected as severe TokenKey production risk in this pass.",
+      "updated_at": "2026-05-11T03:54:24Z"
+    },
+    {
+      "upstream": "Wei-Shaw/sub2api#2364",
+      "url": "https://github.com/Wei-Shaw/sub2api/issues/2364",
+      "title": "部分api请求未被统计",
+      "impact": "medium",
+      "categories": [
+        "admin_ui"
+      ],
+      "tokenkey_status": "not_prioritized",
+      "rationale": "Potential compatibility/ops/admin impact, but not selected as severe TokenKey production risk in this pass.",
+      "updated_at": "2026-05-11T09:20:04Z"
+    },
+    {
+      "upstream": "Wei-Shaw/sub2api#2365",
+      "url": "https://github.com/Wei-Shaw/sub2api/issues/2365",
+      "title": "账号管理 名称重复问题",
+      "impact": "medium",
+      "categories": [
+        "admin_ui"
+      ],
+      "tokenkey_status": "not_prioritized",
+      "rationale": "Potential compatibility/ops/admin impact, but not selected as severe TokenKey production risk in this pass.",
+      "updated_at": "2026-05-11T09:20:09Z"
+    },
+    {
+      "upstream": "Wei-Shaw/sub2api#2398",
+      "url": "https://github.com/Wei-Shaw/sub2api/issues/2398",
+      "title": "0.1.126 这次更新导致后台系统设置在dark模式下顶部菜单栏还是白色背景",
+      "impact": "medium",
+      "categories": [
+        "admin_ui"
+      ],
+      "tokenkey_status": "not_prioritized",
+      "rationale": "Potential compatibility/ops/admin impact, but not selected as severe TokenKey production risk in this pass.",
+      "updated_at": "2026-05-12T13:58:31Z"
+    },
+    {
+      "upstream": "Wei-Shaw/sub2api#2406",
+      "url": "https://github.com/Wei-Shaw/sub2api/issues/2406",
+      "title": "建议：用户限制ip访问导致的ACCESS_DENIED不应被算作会导致sla减少的错误",
+      "impact": "medium",
+      "categories": [
+        "ops_observability"
+      ],
+      "tokenkey_status": "not_prioritized",
+      "rationale": "Potential compatibility/ops/admin impact, but not selected as severe TokenKey production risk in this pass.",
+      "updated_at": "2026-05-12T08:41:38Z"
+    },
+    {
+      "upstream": "Wei-Shaw/sub2api#2409",
+      "url": "https://github.com/Wei-Shaw/sub2api/issues/2409",
+      "title": "openai status code 400 message Instructions are required 问题讨论",
+      "impact": "medium",
+      "categories": [
+        "ops_observability"
+      ],
+      "tokenkey_status": "not_prioritized",
+      "rationale": "Potential compatibility/ops/admin impact, but not selected as severe TokenKey production risk in this pass.",
+      "updated_at": "2026-05-12T09:37:31Z"
+    },
+    {
+      "upstream": "Wei-Shaw/sub2api#2410",
+      "url": "https://github.com/Wei-Shaw/sub2api/issues/2410",
+      "title": "[Ops] 运维监控缺少统一请求归因信息，异常日志/SLA明细/系统日志无法稳定定位用户、API Key、邮箱和真实 IP",
+      "impact": "medium",
+      "categories": [
+        "rate_limit_cooldown",
+        "image_oauth",
+        "security",
+        "ops_observability",
+        "compatibility",
+        "admin_ui",
+        "enhancement"
+      ],
+      "tokenkey_status": "needs_tokenkey_review",
+      "rationale": "Ops attribution gaps reduce incident actionability; TokenKey has added ops context but needs separate production log audit.",
+      "updated_at": "2026-05-12T09:59:15Z"
+    },
+    {
+      "upstream": "Wei-Shaw/sub2api#2423",
+      "url": "https://github.com/Wei-Shaw/sub2api/issues/2423",
+      "title": "Windows 独立 exe 部署下，Web 页面在线更新后新版本未生效",
+      "impact": "medium",
+      "categories": [
+        "compatibility",
+        "admin_ui"
+      ],
+      "tokenkey_status": "not_prioritized",
+      "rationale": "Potential compatibility/ops/admin impact, but not selected as severe TokenKey production risk in this pass.",
+      "updated_at": "2026-05-13T02:47:27Z"
+    },
+    {
+      "upstream": "Wei-Shaw/sub2api#2440",
+      "url": "https://github.com/Wei-Shaw/sub2api/issues/2440",
+      "title": "支付宝手机端增加开关控制ismobile",
+      "impact": "medium",
+      "categories": [
+        "admin_ui"
+      ],
+      "tokenkey_status": "not_prioritized",
+      "rationale": "Potential compatibility/ops/admin impact, but not selected as severe TokenKey production risk in this pass.",
+      "updated_at": "2026-05-13T14:57:06Z"
+    },
+    {
+      "upstream": "Wei-Shaw/sub2api#2453",
+      "url": "https://github.com/Wei-Shaw/sub2api/issues/2453",
+      "title": "OpenAI Fast/Flex Policy 默认过滤 service_tier 导致多数部署失去 fast mode",
+      "impact": "medium",
+      "categories": [
+        "compatibility",
+        "enhancement"
+      ],
+      "tokenkey_status": "intentional_policy",
+      "rationale": "Default OpenAI fast policy still filters priority/fast globally by design; important product-policy tradeoff, not an accidental outage bug.",
+      "updated_at": "2026-05-14T06:44:54Z"
+    },
+    {
+      "upstream": "Wei-Shaw/sub2api#2459",
+      "url": "https://github.com/Wei-Shaw/sub2api/issues/2459",
+      "title": "监控渠道使用内网地址不通",
+      "impact": "medium",
+      "categories": [
+        "ops_observability"
+      ],
+      "tokenkey_status": "not_prioritized",
+      "rationale": "Potential compatibility/ops/admin impact, but not selected as severe TokenKey production risk in this pass.",
+      "updated_at": "2026-05-14T09:31:02Z"
+    },
+    {
+      "upstream": "Wei-Shaw/sub2api#2464",
+      "url": "https://github.com/Wei-Shaw/sub2api/issues/2464",
+      "title": "仪表盘-用户消费榜-其他统计项来源",
+      "impact": "medium",
+      "categories": [
+        "admin_ui"
+      ],
+      "tokenkey_status": "not_prioritized",
+      "rationale": "Potential compatibility/ops/admin impact, but not selected as severe TokenKey production risk in this pass.",
+      "updated_at": "2026-05-14T16:39:47Z"
+    },
+    {
+      "upstream": "Wei-Shaw/sub2api#2488",
+      "url": "https://github.com/Wei-Shaw/sub2api/issues/2488",
+      "title": "[性能建议] ops_error_logs 表索引过多，大部分从未被查询过，建议按需创建",
+      "impact": "medium",
+      "categories": [
+        "ops_observability"
+      ],
+      "tokenkey_status": "not_prioritized",
+      "rationale": "Potential compatibility/ops/admin impact, but not selected as severe TokenKey production risk in this pass.",
+      "updated_at": "2026-05-15T04:30:20Z"
+    },
+    {
+      "upstream": "Wei-Shaw/sub2api#2491",
+      "url": "https://github.com/Wei-Shaw/sub2api/issues/2491",
+      "title": "api密钥页面展示用量的时候是否可以详细一些，带统计，可以看到每天的输入输出缓存命中情况",
+      "impact": "medium",
+      "categories": [
+        "admin_ui"
+      ],
+      "tokenkey_status": "not_prioritized",
+      "rationale": "Potential compatibility/ops/admin impact, but not selected as severe TokenKey production risk in this pass.",
+      "updated_at": "2026-05-15T07:02:41Z"
+    },
+    {
+      "upstream": "Wei-Shaw/sub2api#255",
+      "url": "https://github.com/Wei-Shaw/sub2api/issues/255",
+      "title": "账号管理手机端适配",
+      "impact": "medium",
+      "categories": [
+        "admin_ui"
+      ],
+      "tokenkey_status": "not_prioritized",
+      "rationale": "Potential compatibility/ops/admin impact, but not selected as severe TokenKey production risk in this pass.",
+      "updated_at": "2026-01-15T02:25:35Z"
+    },
+    {
+      "upstream": "Wei-Shaw/sub2api#275",
+      "url": "https://github.com/Wei-Shaw/sub2api/issues/275",
+      "title": "「UI建议」过期时间增加一个月/一年选项",
+      "impact": "medium",
+      "categories": [
+        "admin_ui"
+      ],
+      "tokenkey_status": "not_prioritized",
+      "rationale": "Potential compatibility/ops/admin impact, but not selected as severe TokenKey production risk in this pass.",
+      "updated_at": "2026-01-14T03:03:34Z"
+    },
+    {
+      "upstream": "Wei-Shaw/sub2api#312",
+      "url": "https://github.com/Wei-Shaw/sub2api/issues/312",
+      "title": "新手引导ui界面 按钮 分辨率不正常",
+      "impact": "medium",
+      "categories": [
+        "admin_ui"
+      ],
+      "tokenkey_status": "not_prioritized",
+      "rationale": "Potential compatibility/ops/admin impact, but not selected as severe TokenKey production risk in this pass.",
+      "updated_at": "2026-01-16T10:23:59Z"
+    },
+    {
+      "upstream": "Wei-Shaw/sub2api#321",
+      "url": "https://github.com/Wei-Shaw/sub2api/issues/321",
+      "title": "Antigravity 调用Opus-4.5时使用write工具生成超大内容比如5000字的时候，stream会出现错误",
+      "impact": "medium",
+      "categories": [
+        "ops_observability"
+      ],
+      "tokenkey_status": "not_prioritized",
+      "rationale": "Potential compatibility/ops/admin impact, but not selected as severe TokenKey production risk in this pass.",
+      "updated_at": "2026-02-19T02:28:50Z"
+    },
+    {
+      "upstream": "Wei-Shaw/sub2api#352",
+      "url": "https://github.com/Wei-Shaw/sub2api/issues/352",
+      "title": "账号管理页面设计问题：表格默认排序时异常、无自动刷新功能、右侧更多操作唤醒后点击页面其他位置后不消失",
+      "impact": "medium",
+      "categories": [
+        "admin_ui"
+      ],
+      "tokenkey_status": "not_prioritized",
+      "rationale": "Potential compatibility/ops/admin impact, but not selected as severe TokenKey production risk in this pass.",
+      "updated_at": "2026-01-21T14:23:35Z"
+    },
+    {
+      "upstream": "Wei-Shaw/sub2api#438",
+      "url": "https://github.com/Wei-Shaw/sub2api/issues/438",
+      "title": "SMTP 邮件系统无法使用",
+      "impact": "medium",
+      "categories": [
+        "ops_observability"
+      ],
+      "tokenkey_status": "not_prioritized",
+      "rationale": "Potential compatibility/ops/admin impact, but not selected as severe TokenKey production risk in this pass.",
+      "updated_at": "2026-02-08T13:55:41Z"
+    },
+    {
+      "upstream": "Wei-Shaw/sub2api#498",
+      "url": "https://github.com/Wei-Shaw/sub2api/issues/498",
+      "title": "gpt5.3xhigh模式会报错",
+      "impact": "medium",
+      "categories": [
+        "compatibility"
+      ],
+      "tokenkey_status": "not_prioritized",
+      "rationale": "Potential compatibility/ops/admin impact, but not selected as severe TokenKey production risk in this pass.",
+      "updated_at": "2026-02-24T17:16:11Z"
+    },
+    {
+      "upstream": "Wei-Shaw/sub2api#528",
+      "url": "https://github.com/Wei-Shaw/sub2api/issues/528",
+      "title": "antigravity opus 4.6 反代出来在cc中无法正常展示思考",
+      "impact": "medium",
+      "categories": [
+        "admin_ui"
+      ],
+      "tokenkey_status": "not_prioritized",
+      "rationale": "Potential compatibility/ops/admin impact, but not selected as severe TokenKey production risk in this pass.",
+      "updated_at": "2026-02-09T13:41:01Z"
+    },
+    {
+      "upstream": "Wei-Shaw/sub2api#594",
+      "url": "https://github.com/Wei-Shaw/sub2api/issues/594",
+      "title": "Support OpenAI Chat Completions API as a complement to the existing Responses API",
+      "impact": "medium",
+      "categories": [
+        "ops_observability"
+      ],
+      "tokenkey_status": "not_prioritized",
+      "rationale": "Potential compatibility/ops/admin impact, but not selected as severe TokenKey production risk in this pass.",
+      "updated_at": "2026-03-20T03:15:25Z"
+    },
+    {
+      "upstream": "Wei-Shaw/sub2api#619",
+      "url": "https://github.com/Wei-Shaw/sub2api/issues/619",
+      "title": "【bug】运维监控里面的设置不能点击保存",
+      "impact": "medium",
+      "categories": [
+        "ops_observability",
+        "admin_ui"
+      ],
+      "tokenkey_status": "not_prioritized",
+      "rationale": "Potential compatibility/ops/admin impact, but not selected as severe TokenKey production risk in this pass.",
+      "updated_at": "2026-02-27T10:26:34Z"
+    },
+    {
+      "upstream": "Wei-Shaw/sub2api#661",
+      "url": "https://github.com/Wei-Shaw/sub2api/issues/661",
+      "title": "是否考虑增加 responses/compact支持",
+      "impact": "medium",
+      "categories": [
+        "compatibility"
+      ],
+      "tokenkey_status": "not_prioritized",
+      "rationale": "Potential compatibility/ops/admin impact, but not selected as severe TokenKey production risk in this pass.",
+      "updated_at": "2026-04-01T15:58:27Z"
+    },
+    {
+      "upstream": "Wei-Shaw/sub2api#67",
+      "url": "https://github.com/Wei-Shaw/sub2api/issues/67",
+      "title": "佬可以加一个是否显示github按钮的env配置吗",
+      "impact": "medium",
+      "categories": [
+        "admin_ui"
+      ],
+      "tokenkey_status": "not_prioritized",
+      "rationale": "Potential compatibility/ops/admin impact, but not selected as severe TokenKey production risk in this pass.",
+      "updated_at": "2026-01-19T03:53:28Z"
+    },
+    {
+      "upstream": "Wei-Shaw/sub2api#71",
+      "url": "https://github.com/Wei-Shaw/sub2api/issues/71",
+      "title": "[建议] 增加 /v1/models 接口回调返回自定义模型列表",
+      "impact": "medium",
+      "categories": [
+        "compatibility"
+      ],
+      "tokenkey_status": "not_prioritized",
+      "rationale": "Potential compatibility/ops/admin impact, but not selected as severe TokenKey production risk in this pass.",
+      "updated_at": "2026-05-08T12:10:02Z"
+    },
+    {
+      "upstream": "Wei-Shaw/sub2api#77",
+      "url": "https://github.com/Wei-Shaw/sub2api/issues/77",
+      "title": "[Bug]: 账号管理中的分组在“分组管理”被暂停后依然存在且无法移除",
+      "impact": "medium",
+      "categories": [
+        "admin_ui"
+      ],
+      "tokenkey_status": "not_prioritized",
+      "rationale": "Potential compatibility/ops/admin impact, but not selected as severe TokenKey production risk in this pass.",
+      "updated_at": "2025-12-29T13:56:25Z"
+    },
+    {
+      "upstream": "Wei-Shaw/sub2api#805",
+      "url": "https://github.com/Wei-Shaw/sub2api/issues/805",
+      "title": "Codex Compact Error",
+      "impact": "medium",
+      "categories": [
+        "ops_observability",
+        "compatibility"
+      ],
+      "tokenkey_status": "not_prioritized",
+      "rationale": "Potential compatibility/ops/admin impact, but not selected as severe TokenKey production risk in this pass.",
+      "updated_at": "2026-03-06T05:03:59Z"
+    },
+    {
+      "upstream": "Wei-Shaw/sub2api#838",
+      "url": "https://github.com/Wei-Shaw/sub2api/issues/838",
+      "title": "gpt-5.3-codex high 版本调用失败，这个能兼容一下吗？",
+      "impact": "medium",
+      "categories": [
+        "compatibility"
+      ],
+      "tokenkey_status": "not_prioritized",
+      "rationale": "Potential compatibility/ops/admin impact, but not selected as severe TokenKey production risk in this pass.",
+      "updated_at": "2026-03-07T10:13:55Z"
+    },
+    {
+      "upstream": "Wei-Shaw/sub2api#878",
+      "url": "https://github.com/Wei-Shaw/sub2api/issues/878",
+      "title": "bug: 个人设置页面图标奇奇怪怪的",
+      "impact": "medium",
+      "categories": [
+        "admin_ui"
+      ],
+      "tokenkey_status": "not_prioritized",
+      "rationale": "Potential compatibility/ops/admin impact, but not selected as severe TokenKey production risk in this pass.",
+      "updated_at": "2026-03-09T01:50:53Z"
+    },
+    {
+      "upstream": "Wei-Shaw/sub2api#913",
+      "url": "https://github.com/Wei-Shaw/sub2api/issues/913",
+      "title": "自动透传（仅替换认证）打开之后无法关闭.",
+      "impact": "medium",
+      "categories": [
+        "compatibility",
+        "admin_ui"
+      ],
+      "tokenkey_status": "not_prioritized",
+      "rationale": "Potential compatibility/ops/admin impact, but not selected as severe TokenKey production risk in this pass.",
+      "updated_at": "2026-03-10T08:43:50Z"
+    },
+    {
+      "upstream": "Wei-Shaw/sub2api#953",
+      "url": "https://github.com/Wei-Shaw/sub2api/issues/953",
+      "title": "使用 /v1/chat/completions 端点请求模型啥，使用日志里无论请求什么模型都显示为 gpt-5.4 模型。",
+      "impact": "medium",
+      "categories": [
+        "ops_observability"
+      ],
+      "tokenkey_status": "not_prioritized",
+      "rationale": "Potential compatibility/ops/admin impact, but not selected as severe TokenKey production risk in this pass.",
+      "updated_at": "2026-03-14T04:07:52Z"
+    },
+    {
+      "upstream": "Wei-Shaw/sub2api#982",
+      "url": "https://github.com/Wei-Shaw/sub2api/issues/982",
+      "title": "批量修改账号模型白名单时，plain GPT-5 系列被错误写成带后缀的 model_mapping",
+      "impact": "medium",
+      "categories": [
+        "admin_ui"
+      ],
+      "tokenkey_status": "not_prioritized",
+      "rationale": "Potential compatibility/ops/admin impact, but not selected as severe TokenKey production risk in this pass.",
+      "updated_at": "2026-03-13T15:46:09Z"
+    },
+    {
+      "upstream": "Wei-Shaw/sub2api#983",
+      "url": "https://github.com/Wei-Shaw/sub2api/issues/983",
+      "title": "希望增加可配置的模型自动归一化路由开关，而不是在 OpenAI 网关中写死",
+      "impact": "medium",
+      "categories": [
+        "ops_observability"
+      ],
+      "tokenkey_status": "not_prioritized",
+      "rationale": "Potential compatibility/ops/admin impact, but not selected as severe TokenKey production risk in this pass.",
+      "updated_at": "2026-03-13T15:47:43Z"
+    },
+    {
+      "upstream": "Wei-Shaw/sub2api#1925",
+      "url": "https://github.com/Wei-Shaw/sub2api/issues/1925",
+      "title": "OpenAI 账号测试对 /responses 流式校验过宽，提前 EOF 也会判定成功，导致异常账号被误加入调度池",
+      "impact": "fixed",
+      "categories": [
+        "image_oauth",
+        "account_pool_health",
+        "compatibility",
+        "enhancement"
+      ],
+      "tokenkey_status": "fixed_in_tokenkey",
+      "rationale": "OpenAI /responses account test requires response.completed/response.done; early EOF fails tests.",
+      "updated_at": "2026-04-25T07:54:59Z"
+    },
+    {
+      "upstream": "Wei-Shaw/sub2api#2055",
+      "url": "https://github.com/Wei-Shaw/sub2api/issues/2055",
+      "title": "点击重置速率限制用量后额度刷新，但是使用后还是429错误",
+      "impact": "fixed",
+      "categories": [
+        "rate_limit_cooldown"
+      ],
+      "tokenkey_status": "fixed_in_tokenkey",
+      "rationale": "Rate-limit reset clears account/model rate-limit, temp-unschedulable, and OpenAI 403 counters.",
+      "updated_at": "2026-04-28T09:17:25Z"
+    },
+    {
+      "upstream": "Wei-Shaw/sub2api#2168",
+      "url": "https://github.com/Wei-Shaw/sub2api/issues/2168",
+      "title": "[Bug] 计费漏洞，提前断流的请求不会被计为使用",
+      "impact": "fixed",
+      "categories": [
+        "billing_usage",
+        "security",
+        "admin_ui"
+      ],
+      "tokenkey_status": "fixed_in_tokenkey",
+      "rationale": "Streaming billing uses detached/drain paths and tests cover client-disconnect billing.",
+      "updated_at": "2026-05-05T01:18:57Z"
+    },
+    {
+      "upstream": "Wei-Shaw/sub2api#2211",
+      "url": "https://github.com/Wei-Shaw/sub2api/issues/2211",
+      "title": "bug：账号调度存在问题，严重",
+      "impact": "fixed",
+      "categories": [
+        "billing_usage"
+      ],
+      "tokenkey_status": "fixed_in_tokenkey",
+      "rationale": "Account scheduling now queries the account_groups join table for the requested group; balance-group requests should not schedule ungrouped accounts.",
+      "updated_at": "2026-05-05T18:45:31Z"
+    },
+    {
+      "upstream": "Wei-Shaw/sub2api#2293",
+      "url": "https://github.com/Wei-Shaw/sub2api/issues/2293",
+      "title": "GPT-5.4/GPT-5.5 长上下文计费未对 cache_read_tokens 应用倍率",
+      "impact": "fixed",
+      "categories": [
+        "billing_usage",
+        "security",
+        "admin_ui",
+        "enhancement"
+      ],
+      "tokenkey_status": "fixed_in_tokenkey",
+      "rationale": "Long-context billing includes cache_read tokens in the threshold and applies long-context multiplier to cache_read cost.",
+      "updated_at": "2026-05-08T11:51:00Z"
+    },
+    {
+      "upstream": "Wei-Shaw/sub2api#2310",
+      "url": "https://github.com/Wei-Shaw/sub2api/issues/2310",
+      "title": "[Bug] OAuth 图片生成（非流式）因绑定客户端 context 导致超时 context canceled",
+      "impact": "fixed",
+      "categories": [
+        "rate_limit_cooldown",
+        "image_oauth",
+        "ops_observability",
+        "compatibility",
+        "enhancement"
+      ],
+      "tokenkey_status": "fixed_in_tokenkey",
+      "rationale": "OpenAI OAuth image generation uses a detached upstream context instead of binding long jobs to the client connection.",
+      "updated_at": "2026-05-09T02:54:27Z"
+    },
+    {
+      "upstream": "Wei-Shaw/sub2api#2337",
+      "url": "https://github.com/Wei-Shaw/sub2api/issues/2337",
+      "title": "Bug: Anthropic→OpenAI 格式转换时 multi-turn tool_call ID 映射错误导致 400",
+      "impact": "fixed",
+      "categories": [
+        "claude_mimicry",
+        "rate_limit_cooldown",
+        "ops_observability",
+        "compatibility"
+      ],
+      "tokenkey_status": "fixed_in_tokenkey",
+      "rationale": "Anthropic-to-OpenAI multi-turn tool call mapping is covered by tool-continuation code and tests.",
+      "updated_at": "2026-05-10T06:34:54Z"
+    },
+    {
+      "upstream": "Wei-Shaw/sub2api#2383",
+      "url": "https://github.com/Wei-Shaw/sub2api/issues/2383",
+      "title": "模型映射计费有问题",
+      "impact": "fixed",
+      "categories": [
+        "billing_usage",
+        "admin_ui"
+      ],
+      "tokenkey_status": "fixed_in_tokenkey",
+      "rationale": "OpenAI usage recording has billing model candidates/source tracking and tests for mapped/unmapped models.",
+      "updated_at": "2026-05-12T00:36:01Z"
+    },
+    {
+      "upstream": "Wei-Shaw/sub2api#2411",
+      "url": "https://github.com/Wei-Shaw/sub2api/issues/2411",
+      "title": "粘性会话调度不符合预期",
+      "impact": "fixed",
+      "categories": [
+        "compatibility",
+        "enhancement"
+      ],
+      "tokenkey_status": "fixed_in_tokenkey",
+      "rationale": "Sticky-session scheduling has dedicated hash, mode, and invalidation logic.",
+      "updated_at": "2026-05-12T10:22:18Z"
+    },
+    {
+      "upstream": "Wei-Shaw/sub2api#2487",
+      "url": "https://github.com/Wei-Shaw/sub2api/issues/2487",
+      "title": "BUG: Unsupported parameter: temperature",
+      "impact": "fixed",
+      "categories": [
+        "manual"
+      ],
+      "tokenkey_status": "fixed_in_tokenkey",
+      "rationale": "Codex OAuth transform strips temperature and other unsupported fields before forwarding to ChatGPT internal endpoints.",
+      "updated_at": "2026-05-15T04:11:56Z"
+    },
+    {
+      "upstream": "Wei-Shaw/sub2api#2489",
+      "url": "https://github.com/Wei-Shaw/sub2api/issues/2489",
+      "title": "x-stainless-helper-method 在claude code里是不存在的 header，真实 Claude Code: x-stainless-helper: <工具名> (或无此 header) 是否有风险？",
+      "impact": "fixed",
+      "categories": [
+        "claude_mimicry",
+        "compatibility"
+      ],
+      "tokenkey_status": "fixed_in_tokenkey",
+      "rationale": "Claude Code mimicry helper-method header risk fixed by TokenKey PR #223.",
+      "updated_at": "2026-05-15T05:04:53Z"
+    },
+    {
+      "upstream": "Wei-Shaw/sub2api#2490",
+      "url": "https://github.com/Wei-Shaw/sub2api/issues/2490",
+      "title": "openai /compact 兼容问题",
+      "impact": "fixed",
+      "categories": [
+        "compatibility"
+      ],
+      "tokenkey_status": "fixed_in_tokenkey",
+      "rationale": "OpenAI /compact route and request-body normalization are implemented, including compact_not_supported errors when no account is available.",
+      "updated_at": "2026-05-15T05:19:33Z"
+    },
+    {
+      "upstream": "Wei-Shaw/sub2api#580",
+      "url": "https://github.com/Wei-Shaw/sub2api/issues/580",
+      "title": "Bug: OAuth 模拟模式下 User-Agent 版本与真实 Claude Code 客户端不一致",
+      "impact": "fixed",
+      "categories": [
+        "claude_mimicry",
+        "rate_limit_cooldown",
+        "image_oauth",
+        "compatibility",
+        "enhancement"
+      ],
+      "tokenkey_status": "fixed_in_tokenkey",
+      "rationale": "Claude Code mimicry UA downgrade fixed by TokenKey PR #223.",
+      "updated_at": "2026-02-18T10:49:35Z"
+    },
+    {
+      "upstream": "Wei-Shaw/sub2api#2465",
+      "url": "https://github.com/Wei-Shaw/sub2api/issues/2465",
+      "title": "[Bug] compat-proxy follows upstream redirects, breaking all OAuth login flows (blank page)",
+      "impact": "not_applicable",
+      "categories": [
+        "rate_limit_cooldown",
+        "image_oauth",
+        "security",
+        "compatibility"
+      ],
+      "tokenkey_status": "outside_tokenkey_runtime",
+      "rationale": "Issue is about upstream compat-proxy/proxy.py; this TokenKey worktree has no compat-proxy implementation to patch.",
+      "updated_at": "2026-05-14T13:21:13Z"
+    },
+    {
+      "upstream": "Wei-Shaw/sub2api#1008",
+      "url": "https://github.com/Wei-Shaw/sub2api/issues/1008",
+      "title": "代理使用情况没有标注",
+      "impact": "low",
+      "categories": [
+        "enhancement"
+      ],
+      "tokenkey_status": "not_prioritized",
+      "rationale": "Appears to be enhancement/docs/UI request rather than severe online service risk.",
+      "updated_at": "2026-03-14T14:52:41Z"
+    },
+    {
+      "upstream": "Wei-Shaw/sub2api#1046",
+      "url": "https://github.com/Wei-Shaw/sub2api/issues/1046",
+      "title": "功能建议：Claude用量窗口显示周限，显示订阅类型，根据订阅类型筛选",
+      "impact": "low",
+      "categories": [
+        "enhancement"
+      ],
+      "tokenkey_status": "not_prioritized",
+      "rationale": "Appears to be enhancement/docs/UI request rather than severe online service risk.",
+      "updated_at": "2026-03-16T02:19:03Z"
+    },
+    {
+      "upstream": "Wei-Shaw/sub2api#1052",
+      "url": "https://github.com/Wei-Shaw/sub2api/issues/1052",
+      "title": "分组功能建议",
+      "impact": "low",
+      "categories": [
+        "enhancement"
+      ],
+      "tokenkey_status": "not_prioritized",
+      "rationale": "Appears to be enhancement/docs/UI request rather than severe online service risk.",
+      "updated_at": "2026-03-16T07:49:08Z"
+    },
+    {
+      "upstream": "Wei-Shaw/sub2api#1102",
+      "url": "https://github.com/Wei-Shaw/sub2api/issues/1102",
+      "title": "希望增加代理挂掉后故障转移的功能",
+      "impact": "low",
+      "categories": [
+        "enhancement"
+      ],
+      "tokenkey_status": "not_prioritized",
+      "rationale": "Appears to be enhancement/docs/UI request rather than severe online service risk.",
+      "updated_at": "2026-03-17T17:14:37Z"
+    },
+    {
+      "upstream": "Wei-Shaw/sub2api#1119",
+      "url": "https://github.com/Wei-Shaw/sub2api/issues/1119",
+      "title": "【功能建议】能否考虑增加图形识别？",
+      "impact": "low",
+      "categories": [
+        "enhancement"
+      ],
+      "tokenkey_status": "not_prioritized",
+      "rationale": "Appears to be enhancement/docs/UI request rather than severe online service risk.",
+      "updated_at": "2026-03-18T07:48:42Z"
+    },
+    {
+      "upstream": "Wei-Shaw/sub2api#1124",
+      "url": "https://github.com/Wei-Shaw/sub2api/issues/1124",
+      "title": "需求：导入账号的时候支持选择分组",
+      "impact": "low",
+      "categories": [
+        "enhancement"
+      ],
+      "tokenkey_status": "not_prioritized",
+      "rationale": "Appears to be enhancement/docs/UI request rather than severe online service risk.",
+      "updated_at": "2026-03-18T09:31:35Z"
+    },
+    {
+      "upstream": "Wei-Shaw/sub2api#1143",
+      "url": "https://github.com/Wei-Shaw/sub2api/issues/1143",
+      "title": "关于ClaudeCode遥测请求抓包",
+      "impact": "low",
+      "categories": [
+        "enhancement"
+      ],
+      "tokenkey_status": "not_prioritized",
+      "rationale": "Appears to be enhancement/docs/UI request rather than severe online service risk.",
+      "updated_at": "2026-03-26T14:37:12Z"
+    },
+    {
+      "upstream": "Wei-Shaw/sub2api#115",
+      "url": "https://github.com/Wei-Shaw/sub2api/issues/115",
+      "title": "没有弄懂Antigravity的逆向工程达到爽用claude模型的原理",
+      "impact": "low",
+      "categories": [
+        "docs"
+      ],
+      "tokenkey_status": "not_prioritized",
+      "rationale": "Appears to be enhancement/docs/UI request rather than severe online service risk.",
+      "updated_at": "2026-01-02T03:14:45Z"
+    },
+    {
+      "upstream": "Wei-Shaw/sub2api#1184",
+      "url": "https://github.com/Wei-Shaw/sub2api/issues/1184",
+      "title": "Stripe Apple Pay does not show in embedded iframe",
+      "impact": "low",
+      "categories": [
+        "enhancement",
+        "docs"
+      ],
+      "tokenkey_status": "not_prioritized",
+      "rationale": "Appears to be enhancement/docs/UI request rather than severe online service risk.",
+      "updated_at": "2026-03-21T09:42:29Z"
+    },
+    {
+      "upstream": "Wei-Shaw/sub2api#1186",
+      "url": "https://github.com/Wei-Shaw/sub2api/issues/1186",
+      "title": "建议新增功能，自动转移不可用代理的账号到可用代理上",
+      "impact": "low",
+      "categories": [
+        "enhancement"
+      ],
+      "tokenkey_status": "not_prioritized",
+      "rationale": "Appears to be enhancement/docs/UI request rather than severe online service risk.",
+      "updated_at": "2026-03-22T03:51:32Z"
+    },
+    {
+      "upstream": "Wei-Shaw/sub2api#1198",
+      "url": "https://github.com/Wei-Shaw/sub2api/issues/1198",
+      "title": "增加邀请拉新链接等",
+      "impact": "low",
+      "categories": [
+        "enhancement"
+      ],
+      "tokenkey_status": "not_prioritized",
+      "rationale": "Appears to be enhancement/docs/UI request rather than severe online service risk.",
+      "updated_at": "2026-04-15T07:38:09Z"
+    },
+    {
+      "upstream": "Wei-Shaw/sub2api#1211",
+      "url": "https://github.com/Wei-Shaw/sub2api/issues/1211",
+      "title": "强烈建议新增模型价格设置。🤝🤝🤝🤝🤝🤝🤝🤝",
+      "impact": "low",
+      "categories": [
+        "enhancement"
+      ],
+      "tokenkey_status": "not_prioritized",
+      "rationale": "Appears to be enhancement/docs/UI request rather than severe online service risk.",
+      "updated_at": "2026-05-08T09:24:07Z"
+    },
+    {
+      "upstream": "Wei-Shaw/sub2api#1228",
+      "url": "https://github.com/Wei-Shaw/sub2api/issues/1228",
+      "title": "功能建议",
+      "impact": "low",
+      "categories": [
+        "enhancement"
+      ],
+      "tokenkey_status": "not_prioritized",
+      "rationale": "Appears to be enhancement/docs/UI request rather than severe online service risk.",
+      "updated_at": "2026-03-23T07:01:49Z"
+    },
+    {
+      "upstream": "Wei-Shaw/sub2api#123",
+      "url": "https://github.com/Wei-Shaw/sub2api/issues/123",
+      "title": "调度逻辑BUG",
+      "impact": "low",
+      "categories": [
+        "enhancement"
+      ],
+      "tokenkey_status": "not_prioritized",
+      "rationale": "Appears to be enhancement/docs/UI request rather than severe online service risk.",
+      "updated_at": "2026-01-01T15:35:22Z"
+    },
+    {
+      "upstream": "Wei-Shaw/sub2api#1232",
+      "url": "https://github.com/Wei-Shaw/sub2api/issues/1232",
+      "title": "希望支持completions接口以及国内厂商codingplan的接口",
+      "impact": "low",
+      "categories": [
+        "enhancement"
+      ],
+      "tokenkey_status": "not_prioritized",
+      "rationale": "Appears to be enhancement/docs/UI request rather than severe online service risk.",
+      "updated_at": "2026-03-24T07:50:32Z"
+    },
+    {
+      "upstream": "Wei-Shaw/sub2api#1243",
+      "url": "https://github.com/Wei-Shaw/sub2api/issues/1243",
+      "title": "很多账号报fail，一些封号的貌似也没检测出来，能优化吗？",
+      "impact": "low",
+      "categories": [
+        "enhancement"
+      ],
+      "tokenkey_status": "not_prioritized",
+      "rationale": "Appears to be enhancement/docs/UI request rather than severe online service risk.",
+      "updated_at": "2026-03-25T08:07:12Z"
+    },
+    {
+      "upstream": "Wei-Shaw/sub2api#1244",
+      "url": "https://github.com/Wei-Shaw/sub2api/issues/1244",
+      "title": "希望可以新增类似newapi的模型广场的功能",
+      "impact": "low",
+      "categories": [
+        "enhancement"
+      ],
+      "tokenkey_status": "not_prioritized",
+      "rationale": "Appears to be enhancement/docs/UI request rather than severe online service risk.",
+      "updated_at": "2026-05-05T17:38:03Z"
+    },
+    {
+      "upstream": "Wei-Shaw/sub2api#1246",
+      "url": "https://github.com/Wei-Shaw/sub2api/issues/1246",
+      "title": "希望增加测试连接的默认值及支持向上游拉取模型列表",
+      "impact": "low",
+      "categories": [
+        "enhancement"
+      ],
+      "tokenkey_status": "not_prioritized",
+      "rationale": "Appears to be enhancement/docs/UI request rather than severe online service risk.",
+      "updated_at": "2026-03-30T13:04:30Z"
+    },
+    {
+      "upstream": "Wei-Shaw/sub2api#1293",
+      "url": "https://github.com/Wei-Shaw/sub2api/issues/1293",
+      "title": "codex",
+      "impact": "low",
+      "categories": [
+        "enhancement"
+      ],
+      "tokenkey_status": "not_prioritized",
+      "rationale": "Appears to be enhancement/docs/UI request rather than severe online service risk.",
+      "updated_at": "2026-05-09T08:57:27Z"
+    },
+    {
+      "upstream": "Wei-Shaw/sub2api#1355",
+      "url": "https://github.com/Wei-Shaw/sub2api/issues/1355",
+      "title": "sora2 已死，是否考虑移除掉功能",
+      "impact": "low",
+      "categories": [
+        "enhancement"
+      ],
+      "tokenkey_status": "not_prioritized",
+      "rationale": "Appears to be enhancement/docs/UI request rather than severe online service risk.",
+      "updated_at": "2026-03-29T10:59:09Z"
+    },
+    {
+      "upstream": "Wei-Shaw/sub2api#1356",
+      "url": "https://github.com/Wei-Shaw/sub2api/issues/1356",
+      "title": "如果你是新手，接触这个应用，使用docker部署，你将会非常不幸",
+      "impact": "low",
+      "categories": [
+        "enhancement"
+      ],
+      "tokenkey_status": "not_prioritized",
+      "rationale": "Appears to be enhancement/docs/UI request rather than severe online service risk.",
+      "updated_at": "2026-04-15T13:51:50Z"
+    },
+    {
+      "upstream": "Wei-Shaw/sub2api#1362",
+      "url": "https://github.com/Wei-Shaw/sub2api/issues/1362",
+      "title": "现在封号潮来袭，建议加上国产模型",
+      "impact": "low",
+      "categories": [
+        "enhancement"
+      ],
+      "tokenkey_status": "not_prioritized",
+      "rationale": "Appears to be enhancement/docs/UI request rather than severe online service risk.",
+      "updated_at": "2026-03-31T10:04:32Z"
+    },
+    {
+      "upstream": "Wei-Shaw/sub2api#1372",
+      "url": "https://github.com/Wei-Shaw/sub2api/issues/1372",
+      "title": "建议增加国产主流模型的支持",
+      "impact": "low",
+      "categories": [
+        "enhancement"
+      ],
+      "tokenkey_status": "not_prioritized",
+      "rationale": "Appears to be enhancement/docs/UI request rather than severe online service risk.",
+      "updated_at": "2026-03-30T01:47:51Z"
+    },
+    {
+      "upstream": "Wei-Shaw/sub2api#1379",
+      "url": "https://github.com/Wei-Shaw/sub2api/issues/1379",
+      "title": "建议增加功能： 账号复制",
+      "impact": "low",
+      "categories": [
+        "enhancement"
+      ],
+      "tokenkey_status": "not_prioritized",
+      "rationale": "Appears to be enhancement/docs/UI request rather than severe online service risk.",
+      "updated_at": "2026-03-30T03:49:43Z"
+    },
+    {
+      "upstream": "Wei-Shaw/sub2api#1389",
+      "url": "https://github.com/Wei-Shaw/sub2api/issues/1389",
+      "title": "希望增加Vertex AI渠道",
+      "impact": "low",
+      "categories": [
+        "enhancement"
+      ],
+      "tokenkey_status": "not_prioritized",
+      "rationale": "Appears to be enhancement/docs/UI request rather than severe online service risk.",
+      "updated_at": "2026-05-02T00:23:20Z"
+    },
+    {
+      "upstream": "Wei-Shaw/sub2api#1402",
+      "url": "https://github.com/Wei-Shaw/sub2api/issues/1402",
+      "title": "建议增加下国产模型的适配",
+      "impact": "low",
+      "categories": [
+        "enhancement"
+      ],
+      "tokenkey_status": "not_prioritized",
+      "rationale": "Appears to be enhancement/docs/UI request rather than severe online service risk.",
+      "updated_at": "2026-04-15T06:41:14Z"
+    },
+    {
+      "upstream": "Wei-Shaw/sub2api#1425",
+      "url": "https://github.com/Wei-Shaw/sub2api/issues/1425",
+      "title": "建议增加月限额，以及手动刷新用量窗口",
+      "impact": "low",
+      "categories": [
+        "enhancement"
+      ],
+      "tokenkey_status": "not_prioritized",
+      "rationale": "Appears to be enhancement/docs/UI request rather than severe online service risk.",
+      "updated_at": "2026-04-01T08:21:23Z"
+    },
+    {
+      "upstream": "Wei-Shaw/sub2api#1427",
+      "url": "https://github.com/Wei-Shaw/sub2api/issues/1427",
+      "title": "【建议】测试接口 希望可以自己传值，部分上游禁止hi测活",
+      "impact": "low",
+      "categories": [
+        "enhancement"
+      ],
+      "tokenkey_status": "not_prioritized",
+      "rationale": "Appears to be enhancement/docs/UI request rather than severe online service risk.",
+      "updated_at": "2026-04-01T10:13:40Z"
+    },
+    {
+      "upstream": "Wei-Shaw/sub2api#1453",
+      "url": "https://github.com/Wei-Shaw/sub2api/issues/1453",
+      "title": "反重力拉闸了呀",
+      "impact": "low",
+      "categories": [
+        "enhancement"
+      ],
+      "tokenkey_status": "not_prioritized",
+      "rationale": "Appears to be enhancement/docs/UI request rather than severe online service risk.",
+      "updated_at": "2026-04-08T03:06:56Z"
+    },
+    {
+      "upstream": "Wei-Shaw/sub2api#1465",
+      "url": "https://github.com/Wei-Shaw/sub2api/issues/1465",
+      "title": "GC内存问题",
+      "impact": "low",
+      "categories": [
+        "enhancement"
+      ],
+      "tokenkey_status": "not_prioritized",
+      "rationale": "Appears to be enhancement/docs/UI request rather than severe online service risk.",
+      "updated_at": "2026-04-07T11:50:01Z"
+    },
+    {
+      "upstream": "Wei-Shaw/sub2api#147",
+      "url": "https://github.com/Wei-Shaw/sub2api/issues/147",
+      "title": "希望可以增加用户可以自主选择供应商的功能",
+      "impact": "low",
+      "categories": [
+        "enhancement"
+      ],
+      "tokenkey_status": "not_prioritized",
+      "rationale": "Appears to be enhancement/docs/UI request rather than severe online service risk.",
+      "updated_at": "2026-01-04T13:33:43Z"
+    },
+    {
+      "upstream": "Wei-Shaw/sub2api#1476",
+      "url": "https://github.com/Wei-Shaw/sub2api/issues/1476",
+      "title": "返回错误码对应的描述信息，希望增加i18n本地化支持",
+      "impact": "low",
+      "categories": [
+        "enhancement"
+      ],
+      "tokenkey_status": "not_prioritized",
+      "rationale": "Appears to be enhancement/docs/UI request rather than severe online service risk.",
+      "updated_at": "2026-04-05T21:26:18Z"
+    },
+    {
+      "upstream": "Wei-Shaw/sub2api#1478",
+      "url": "https://github.com/Wei-Shaw/sub2api/issues/1478",
+      "title": "[Feature]能不能通过分组直接关联全部账号，设置全局代理。",
+      "impact": "low",
+      "categories": [
+        "enhancement"
+      ],
+      "tokenkey_status": "not_prioritized",
+      "rationale": "Appears to be enhancement/docs/UI request rather than severe online service risk.",
+      "updated_at": "2026-04-07T00:51:34Z"
+    },
+    {
+      "upstream": "Wei-Shaw/sub2api#1527",
+      "url": "https://github.com/Wei-Shaw/sub2api/issues/1527",
+      "title": "关于国内coding plan按每小时、周、月请求次数限制的配置",
+      "impact": "low",
+      "categories": [
+        "enhancement",
+        "docs"
+      ],
+      "tokenkey_status": "not_prioritized",
+      "rationale": "Appears to be enhancement/docs/UI request rather than severe online service risk.",
+      "updated_at": "2026-04-09T13:49:35Z"
+    },
+    {
+      "upstream": "Wei-Shaw/sub2api#1604",
+      "url": "https://github.com/Wei-Shaw/sub2api/issues/1604",
+      "title": "【新需求】希望支持CPA的凭证文件导入",
+      "impact": "low",
+      "categories": [
+        "enhancement"
+      ],
+      "tokenkey_status": "not_prioritized",
+      "rationale": "Appears to be enhancement/docs/UI request rather than severe online service risk.",
+      "updated_at": "2026-05-13T09:57:47Z"
+    },
+    {
+      "upstream": "Wei-Shaw/sub2api#1640",
+      "url": "https://github.com/Wei-Shaw/sub2api/issues/1640",
+      "title": "[feat] 求求本地部署后的操作文档，哪怕是最小MVP[流泪]",
+      "impact": "low",
+      "categories": [
+        "docs"
+      ],
+      "tokenkey_status": "not_prioritized",
+      "rationale": "Appears to be enhancement/docs/UI request rather than severe online service risk.",
+      "updated_at": "2026-04-14T06:58:49Z"
+    },
+    {
+      "upstream": "Wei-Shaw/sub2api#1670",
+      "url": "https://github.com/Wei-Shaw/sub2api/issues/1670",
+      "title": "分组管理希望 模型路由配置 支持 Codex 账号",
+      "impact": "low",
+      "categories": [
+        "enhancement"
+      ],
+      "tokenkey_status": "not_prioritized",
+      "rationale": "Appears to be enhancement/docs/UI request rather than severe online service risk.",
+      "updated_at": "2026-04-15T09:49:52Z"
+    },
+    {
+      "upstream": "Wei-Shaw/sub2api#1676",
+      "url": "https://github.com/Wei-Shaw/sub2api/issues/1676",
+      "title": "支付宝扫码支付应使用 alipay.trade.precreate 而非 page.pay 转二维码",
+      "impact": "low",
+      "categories": [
+        "enhancement"
+      ],
+      "tokenkey_status": "not_prioritized",
+      "rationale": "Appears to be enhancement/docs/UI request rather than severe online service risk.",
+      "updated_at": "2026-05-12T15:56:04Z"
+    },
+    {
+      "upstream": "Wei-Shaw/sub2api#1684",
+      "url": "https://github.com/Wei-Shaw/sub2api/issues/1684",
+      "title": "[feat] 用户管理增加查询筛选条件",
+      "impact": "low",
+      "categories": [
+        "enhancement"
+      ],
+      "tokenkey_status": "not_prioritized",
+      "rationale": "Appears to be enhancement/docs/UI request rather than severe online service risk.",
+      "updated_at": "2026-04-15T17:11:59Z"
+    },
+    {
+      "upstream": "Wei-Shaw/sub2api#1750",
+      "url": "https://github.com/Wei-Shaw/sub2api/issues/1750",
+      "title": "功能建议：新增限制用户每日余额使用上限功能",
+      "impact": "low",
+      "categories": [
+        "enhancement"
+      ],
+      "tokenkey_status": "not_prioritized",
+      "rationale": "Appears to be enhancement/docs/UI request rather than severe online service risk.",
+      "updated_at": "2026-04-19T10:47:18Z"
+    },
+    {
+      "upstream": "Wei-Shaw/sub2api#1784",
+      "url": "https://github.com/Wei-Shaw/sub2api/issues/1784",
+      "title": "希望增加跟newapi新增的过滤词功能",
+      "impact": "low",
+      "categories": [
+        "enhancement"
+      ],
+      "tokenkey_status": "not_prioritized",
+      "rationale": "Appears to be enhancement/docs/UI request rather than severe online service risk.",
+      "updated_at": "2026-04-21T16:14:09Z"
+    },
+    {
+      "upstream": "Wei-Shaw/sub2api#1819",
+      "url": "https://github.com/Wei-Shaw/sub2api/issues/1819",
+      "title": "请求时长和TTFT如何优化？有什么好的方法吗？",
+      "impact": "low",
+      "categories": [
+        "enhancement"
+      ],
+      "tokenkey_status": "not_prioritized",
+      "rationale": "Appears to be enhancement/docs/UI request rather than severe online service risk.",
+      "updated_at": "2026-05-13T11:45:57Z"
+    },
+    {
+      "upstream": "Wei-Shaw/sub2api#1842",
+      "url": "https://github.com/Wei-Shaw/sub2api/issues/1842",
+      "title": "/v1/files",
+      "impact": "low",
+      "categories": [
+        "enhancement"
+      ],
+      "tokenkey_status": "not_prioritized",
+      "rationale": "Appears to be enhancement/docs/UI request rather than severe online service risk.",
+      "updated_at": "2026-04-23T09:19:27Z"
+    },
+    {
+      "upstream": "Wei-Shaw/sub2api#188",
+      "url": "https://github.com/Wei-Shaw/sub2api/issues/188",
+      "title": "关于账号管理添加Antigravity账号额度刷新时间的问题",
+      "impact": "low",
+      "categories": [
+        "enhancement"
+      ],
+      "tokenkey_status": "not_prioritized",
+      "rationale": "Appears to be enhancement/docs/UI request rather than severe online service risk.",
+      "updated_at": "2026-01-07T04:02:55Z"
+    },
+    {
+      "upstream": "Wei-Shaw/sub2api#1906",
+      "url": "https://github.com/Wei-Shaw/sub2api/issues/1906",
+      "title": "能够加个按用户或者key 排序的功能",
+      "impact": "low",
+      "categories": [
+        "enhancement"
+      ],
+      "tokenkey_status": "not_prioritized",
+      "rationale": "Appears to be enhancement/docs/UI request rather than severe online service risk.",
+      "updated_at": "2026-04-24T10:39:45Z"
+    },
+    {
+      "upstream": "Wei-Shaw/sub2api#1932",
+      "url": "https://github.com/Wei-Shaw/sub2api/issues/1932",
+      "title": "希望账号管理列表添加批量测试链接功能",
+      "impact": "low",
+      "categories": [
+        "enhancement"
+      ],
+      "tokenkey_status": "not_prioritized",
+      "rationale": "Appears to be enhancement/docs/UI request rather than severe online service risk.",
+      "updated_at": "2026-05-02T04:14:43Z"
+    },
+    {
+      "upstream": "Wei-Shaw/sub2api#1936",
+      "url": "https://github.com/Wei-Shaw/sub2api/issues/1936",
+      "title": "希望订阅包支持并发数控制",
+      "impact": "low",
+      "categories": [
+        "enhancement"
+      ],
+      "tokenkey_status": "not_prioritized",
+      "rationale": "Appears to be enhancement/docs/UI request rather than severe online service risk.",
+      "updated_at": "2026-04-25T03:52:49Z"
+    },
+    {
+      "upstream": "Wei-Shaw/sub2api#1942",
+      "url": "https://github.com/Wei-Shaw/sub2api/issues/1942",
+      "title": "希望支持单key调用多个格式的上游",
+      "impact": "low",
+      "categories": [
+        "enhancement"
+      ],
+      "tokenkey_status": "not_prioritized",
+      "rationale": "Appears to be enhancement/docs/UI request rather than severe online service risk.",
+      "updated_at": "2026-04-25T09:07:11Z"
+    },
+    {
+      "upstream": "Wei-Shaw/sub2api#1974",
+      "url": "https://github.com/Wei-Shaw/sub2api/issues/1974",
+      "title": "建议给出API测试curl的脚本，测试了好几个API都失败了，但是GPT又是成功的",
+      "impact": "low",
+      "categories": [
+        "enhancement"
+      ],
+      "tokenkey_status": "not_prioritized",
+      "rationale": "Appears to be enhancement/docs/UI request rather than severe online service risk.",
+      "updated_at": "2026-04-25T19:13:59Z"
+    },
+    {
+      "upstream": "Wei-Shaw/sub2api#2000",
+      "url": "https://github.com/Wei-Shaw/sub2api/issues/2000",
+      "title": "网页更新最新版本在国内经常超时报错",
+      "impact": "low",
+      "categories": [
+        "enhancement"
+      ],
+      "tokenkey_status": "not_prioritized",
+      "rationale": "Appears to be enhancement/docs/UI request rather than severe online service risk.",
+      "updated_at": "2026-04-26T13:42:38Z"
+    },
+    {
+      "upstream": "Wei-Shaw/sub2api#2002",
+      "url": "https://github.com/Wei-Shaw/sub2api/issues/2002",
+      "title": "支付设置建议",
+      "impact": "low",
+      "categories": [
+        "enhancement"
+      ],
+      "tokenkey_status": "not_prioritized",
+      "rationale": "Appears to be enhancement/docs/UI request rather than severe online service risk.",
+      "updated_at": "2026-04-26T15:09:37Z"
+    },
+    {
+      "upstream": "Wei-Shaw/sub2api#2015",
+      "url": "https://github.com/Wei-Shaw/sub2api/issues/2015",
+      "title": "希望添加功能，充值支持开通专属分组",
+      "impact": "low",
+      "categories": [
+        "enhancement"
+      ],
+      "tokenkey_status": "not_prioritized",
+      "rationale": "Appears to be enhancement/docs/UI request rather than severe online service risk.",
+      "updated_at": "2026-04-27T03:24:54Z"
+    },
+    {
+      "upstream": "Wei-Shaw/sub2api#2038",
+      "url": "https://github.com/Wei-Shaw/sub2api/issues/2038",
+      "title": "希望GPT账号能加一个五小时额度达到设定的百分比后自动暂停账号使用的功能",
+      "impact": "low",
+      "categories": [
+        "enhancement"
+      ],
+      "tokenkey_status": "not_prioritized",
+      "rationale": "Appears to be enhancement/docs/UI request rather than severe online service risk.",
+      "updated_at": "2026-04-27T11:59:22Z"
+    },
+    {
+      "upstream": "Wei-Shaw/sub2api#2059",
+      "url": "https://github.com/Wei-Shaw/sub2api/issues/2059",
+      "title": "希望添加KIMI2.6支持",
+      "impact": "low",
+      "categories": [
+        "enhancement"
+      ],
+      "tokenkey_status": "not_prioritized",
+      "rationale": "Appears to be enhancement/docs/UI request rather than severe online service risk.",
+      "updated_at": "2026-04-28T08:58:47Z"
+    },
+    {
+      "upstream": "Wei-Shaw/sub2api#2060",
+      "url": "https://github.com/Wei-Shaw/sub2api/issues/2060",
+      "title": "希望可以增加套餐中对并发的管理",
+      "impact": "low",
+      "categories": [
+        "enhancement"
+      ],
+      "tokenkey_status": "not_prioritized",
+      "rationale": "Appears to be enhancement/docs/UI request rather than severe online service risk.",
+      "updated_at": "2026-04-28T08:59:29Z"
+    },
+    {
+      "upstream": "Wei-Shaw/sub2api#2088",
+      "url": "https://github.com/Wei-Shaw/sub2api/issues/2088",
+      "title": "重置额度建议",
+      "impact": "low",
+      "categories": [
+        "enhancement"
+      ],
+      "tokenkey_status": "not_prioritized",
+      "rationale": "Appears to be enhancement/docs/UI request rather than severe online service risk.",
+      "updated_at": "2026-05-03T16:03:25Z"
+    },
+    {
+      "upstream": "Wei-Shaw/sub2api#2103",
+      "url": "https://github.com/Wei-Shaw/sub2api/issues/2103",
+      "title": "希望 适配 深色/浅色模式 自动跟随 系统",
+      "impact": "low",
+      "categories": [
+        "enhancement"
+      ],
+      "tokenkey_status": "not_prioritized",
+      "rationale": "Appears to be enhancement/docs/UI request rather than severe online service risk.",
+      "updated_at": "2026-04-29T10:51:40Z"
+    },
+    {
+      "upstream": "Wei-Shaw/sub2api#2151",
+      "url": "https://github.com/Wei-Shaw/sub2api/issues/2151",
+      "title": "希望作者可以加一个模型列表,可以一键复制模型id的,模型映射的模型可以联想提示,而不是输入",
+      "impact": "low",
+      "categories": [
+        "enhancement"
+      ],
+      "tokenkey_status": "not_prioritized",
+      "rationale": "Appears to be enhancement/docs/UI request rather than severe online service risk.",
+      "updated_at": "2026-05-02T17:28:46Z"
+    },
+    {
+      "upstream": "Wei-Shaw/sub2api#2160",
+      "url": "https://github.com/Wei-Shaw/sub2api/issues/2160",
+      "title": "4.27配置，5.1被封。只坚持了四天。",
+      "impact": "low",
+      "categories": [
+        "docs"
+      ],
+      "tokenkey_status": "not_prioritized",
+      "rationale": "Appears to be enhancement/docs/UI request rather than severe online service risk.",
+      "updated_at": "2026-05-07T14:10:46Z"
+    },
+    {
+      "upstream": "Wei-Shaw/sub2api#2164",
+      "url": "https://github.com/Wei-Shaw/sub2api/issues/2164",
+      "title": "This version of Antigravity is no longer supported. Please upgrade to receive the latest features.",
+      "impact": "low",
+      "categories": [
+        "enhancement"
+      ],
+      "tokenkey_status": "not_prioritized",
+      "rationale": "Appears to be enhancement/docs/UI request rather than severe online service risk.",
+      "updated_at": "2026-05-07T02:50:31Z"
+    },
+    {
+      "upstream": "Wei-Shaw/sub2api#2172",
+      "url": "https://github.com/Wei-Shaw/sub2api/issues/2172",
+      "title": "希望添加一个key支持多分组的功能，希望支付网关可以按照不同的支付方式选择不同的手续费",
+      "impact": "low",
+      "categories": [
+        "enhancement"
+      ],
+      "tokenkey_status": "not_prioritized",
+      "rationale": "Appears to be enhancement/docs/UI request rather than severe online service risk.",
+      "updated_at": "2026-05-10T15:21:10Z"
+    },
+    {
+      "upstream": "Wei-Shaw/sub2api#2173",
+      "url": "https://github.com/Wei-Shaw/sub2api/issues/2173",
+      "title": "希望添加关键词功能",
+      "impact": "low",
+      "categories": [
+        "enhancement"
+      ],
+      "tokenkey_status": "not_prioritized",
+      "rationale": "Appears to be enhancement/docs/UI request rather than severe online service risk.",
+      "updated_at": "2026-05-03T16:12:43Z"
+    },
+    {
+      "upstream": "Wei-Shaw/sub2api#2192",
+      "url": "https://github.com/Wei-Shaw/sub2api/issues/2192",
+      "title": "用户管理中充值记录不显示订阅，希望加套餐订阅次数限制",
+      "impact": "low",
+      "categories": [
+        "enhancement"
+      ],
+      "tokenkey_status": "not_prioritized",
+      "rationale": "Appears to be enhancement/docs/UI request rather than severe online service risk.",
+      "updated_at": "2026-05-05T04:32:16Z"
+    },
+    {
+      "upstream": "Wei-Shaw/sub2api#2194",
+      "url": "https://github.com/Wei-Shaw/sub2api/issues/2194",
+      "title": "功能建议：支持Veo3、SeeDance2",
+      "impact": "low",
+      "categories": [
+        "enhancement"
+      ],
+      "tokenkey_status": "not_prioritized",
+      "rationale": "Appears to be enhancement/docs/UI request rather than severe online service risk.",
+      "updated_at": "2026-05-05T06:45:25Z"
+    },
+    {
+      "upstream": "Wei-Shaw/sub2api#2207",
+      "url": "https://github.com/Wei-Shaw/sub2api/issues/2207",
+      "title": "希望可以接入LINUX DO Credit",
+      "impact": "low",
+      "categories": [
+        "enhancement"
+      ],
+      "tokenkey_status": "not_prioritized",
+      "rationale": "Appears to be enhancement/docs/UI request rather than severe online service risk.",
+      "updated_at": "2026-05-05T13:43:08Z"
+    },
+    {
+      "upstream": "Wei-Shaw/sub2api#2209",
+      "url": "https://github.com/Wei-Shaw/sub2api/issues/2209",
+      "title": "反重力返回的模型太多了",
+      "impact": "low",
+      "categories": [
+        "enhancement"
+      ],
+      "tokenkey_status": "not_prioritized",
+      "rationale": "Appears to be enhancement/docs/UI request rather than severe online service risk.",
+      "updated_at": "2026-05-12T12:34:36Z"
+    },
+    {
+      "upstream": "Wei-Shaw/sub2api#2212",
+      "url": "https://github.com/Wei-Shaw/sub2api/issues/2212",
+      "title": "SeeDance2 建议支持。",
+      "impact": "low",
+      "categories": [
+        "enhancement"
+      ],
+      "tokenkey_status": "not_prioritized",
+      "rationale": "Appears to be enhancement/docs/UI request rather than severe online service risk.",
+      "updated_at": "2026-05-06T00:45:21Z"
+    },
+    {
+      "upstream": "Wei-Shaw/sub2api#2230",
+      "url": "https://github.com/Wei-Shaw/sub2api/issues/2230",
+      "title": "希望增加一个批量测活的功能",
+      "impact": "low",
+      "categories": [
+        "enhancement"
+      ],
+      "tokenkey_status": "not_prioritized",
+      "rationale": "Appears to be enhancement/docs/UI request rather than severe online service risk.",
+      "updated_at": "2026-05-13T09:05:13Z"
+    },
+    {
+      "upstream": "Wei-Shaw/sub2api#2262",
+      "url": "https://github.com/Wei-Shaw/sub2api/issues/2262",
+      "title": "建議: 新增可以更改\"角色\"的參數",
+      "impact": "low",
+      "categories": [
+        "enhancement"
+      ],
+      "tokenkey_status": "not_prioritized",
+      "rationale": "Appears to be enhancement/docs/UI request rather than severe online service risk.",
+      "updated_at": "2026-05-07T13:12:23Z"
+    },
+    {
+      "upstream": "Wei-Shaw/sub2api#2328",
+      "url": "https://github.com/Wei-Shaw/sub2api/issues/2328",
+      "title": "模型广场功能",
+      "impact": "low",
+      "categories": [
+        "enhancement"
+      ],
+      "tokenkey_status": "not_prioritized",
+      "rationale": "Appears to be enhancement/docs/UI request rather than severe online service risk.",
+      "updated_at": "2026-05-10T00:40:52Z"
+    },
+    {
+      "upstream": "Wei-Shaw/sub2api#2382",
+      "url": "https://github.com/Wei-Shaw/sub2api/issues/2382",
+      "title": "重新授权-支持更多方式",
+      "impact": "low",
+      "categories": [
+        "enhancement"
+      ],
+      "tokenkey_status": "not_prioritized",
+      "rationale": "Appears to be enhancement/docs/UI request rather than severe online service risk.",
+      "updated_at": "2026-05-12T00:14:35Z"
+    },
+    {
+      "upstream": "Wei-Shaw/sub2api#2414",
+      "url": "https://github.com/Wei-Shaw/sub2api/issues/2414",
+      "title": "账号额度使用完邮件通知",
+      "impact": "low",
+      "categories": [
+        "enhancement"
+      ],
+      "tokenkey_status": "not_prioritized",
+      "rationale": "Appears to be enhancement/docs/UI request rather than severe online service risk.",
+      "updated_at": "2026-05-12T12:18:52Z"
+    },
+    {
+      "upstream": "Wei-Shaw/sub2api#2419",
+      "url": "https://github.com/Wei-Shaw/sub2api/issues/2419",
+      "title": "多服务器集群 共用数据库时定时测试重复执行",
+      "impact": "low",
+      "categories": [
+        "enhancement"
+      ],
+      "tokenkey_status": "not_prioritized",
+      "rationale": "Appears to be enhancement/docs/UI request rather than severe online service risk.",
+      "updated_at": "2026-05-12T16:46:58Z"
+    },
+    {
+      "upstream": "Wei-Shaw/sub2api#2425",
+      "url": "https://github.com/Wei-Shaw/sub2api/issues/2425",
+      "title": "希望CCS导入中把官网和api地址分开",
+      "impact": "low",
+      "categories": [
+        "enhancement"
+      ],
+      "tokenkey_status": "not_prioritized",
+      "rationale": "Appears to be enhancement/docs/UI request rather than severe online service risk.",
+      "updated_at": "2026-05-13T04:13:15Z"
+    },
+    {
+      "upstream": "Wei-Shaw/sub2api#2466",
+      "url": "https://github.com/Wei-Shaw/sub2api/issues/2466",
+      "title": "【功能】建议添加如下新增功能",
+      "impact": "low",
+      "categories": [
+        "enhancement"
+      ],
+      "tokenkey_status": "not_prioritized",
+      "rationale": "Appears to be enhancement/docs/UI request rather than severe online service risk.",
+      "updated_at": "2026-05-15T04:23:08Z"
+    },
+    {
+      "upstream": "Wei-Shaw/sub2api#2468",
+      "url": "https://github.com/Wei-Shaw/sub2api/issues/2468",
+      "title": "希望充值配置增强：支持阶梯赠送 / 自定义充值产品",
+      "impact": "low",
+      "categories": [
+        "enhancement"
+      ],
+      "tokenkey_status": "not_prioritized",
+      "rationale": "Appears to be enhancement/docs/UI request rather than severe online service risk.",
+      "updated_at": "2026-05-14T14:07:07Z"
+    },
+    {
+      "upstream": "Wei-Shaw/sub2api#286",
+      "url": "https://github.com/Wei-Shaw/sub2api/issues/286",
+      "title": "建议添加代理忽略证书错误选项",
+      "impact": "low",
+      "categories": [
+        "enhancement"
+      ],
+      "tokenkey_status": "not_prioritized",
+      "rationale": "Appears to be enhancement/docs/UI request rather than severe online service risk.",
+      "updated_at": "2026-01-15T01:34:02Z"
+    },
+    {
+      "upstream": "Wei-Shaw/sub2api#302",
+      "url": "https://github.com/Wei-Shaw/sub2api/issues/302",
+      "title": "希望支持转发成 open ai 端点",
+      "impact": "low",
+      "categories": [
+        "enhancement"
+      ],
+      "tokenkey_status": "not_prioritized",
+      "rationale": "Appears to be enhancement/docs/UI request rather than severe online service risk.",
+      "updated_at": "2026-03-10T07:45:34Z"
+    },
+    {
+      "upstream": "Wei-Shaw/sub2api#319",
+      "url": "https://github.com/Wei-Shaw/sub2api/issues/319",
+      "title": "「功能建议」填入API地址和key后自动获取模型",
+      "impact": "low",
+      "categories": [
+        "enhancement"
+      ],
+      "tokenkey_status": "not_prioritized",
+      "rationale": "Appears to be enhancement/docs/UI request rather than severe online service risk.",
+      "updated_at": "2026-04-25T16:48:52Z"
+    },
+    {
+      "upstream": "Wei-Shaw/sub2api#363",
+      "url": "https://github.com/Wei-Shaw/sub2api/issues/363",
+      "title": "[BUG]Permission denied",
+      "impact": "low",
+      "categories": [
+        "enhancement"
+      ],
+      "tokenkey_status": "not_prioritized",
+      "rationale": "Appears to be enhancement/docs/UI request rather than severe online service risk.",
+      "updated_at": "2026-01-23T09:27:19Z"
+    },
+    {
+      "upstream": "Wei-Shaw/sub2api#372",
+      "url": "https://github.com/Wei-Shaw/sub2api/issues/372",
+      "title": "feature: 支持优先使用快刷新的账号",
+      "impact": "low",
+      "categories": [
+        "enhancement"
+      ],
+      "tokenkey_status": "not_prioritized",
+      "rationale": "Appears to be enhancement/docs/UI request rather than severe online service risk.",
+      "updated_at": "2026-01-23T10:11:46Z"
+    },
+    {
+      "upstream": "Wei-Shaw/sub2api#397",
+      "url": "https://github.com/Wei-Shaw/sub2api/issues/397",
+      "title": "后期是否有支持多实例部署 然后每个能指定哪些渠道走哪些实例，这样每个渠道就可以多个出口的ip了的计划啊",
+      "impact": "low",
+      "categories": [
+        "enhancement"
+      ],
+      "tokenkey_status": "not_prioritized",
+      "rationale": "Appears to be enhancement/docs/UI request rather than severe online service risk.",
+      "updated_at": "2026-01-26T06:19:39Z"
+    },
+    {
+      "upstream": "Wei-Shaw/sub2api#470",
+      "url": "https://github.com/Wei-Shaw/sub2api/issues/470",
+      "title": "代理一键分配账号",
+      "impact": "low",
+      "categories": [
+        "enhancement"
+      ],
+      "tokenkey_status": "not_prioritized",
+      "rationale": "Appears to be enhancement/docs/UI request rather than severe online service risk.",
+      "updated_at": "2026-02-03T10:36:48Z"
+    },
+    {
+      "upstream": "Wei-Shaw/sub2api#483",
+      "url": "https://github.com/Wei-Shaw/sub2api/issues/483",
+      "title": "希望一个key可以绑定多个模型使用（可以绑定多个分组）",
+      "impact": "low",
+      "categories": [
+        "enhancement"
+      ],
+      "tokenkey_status": "not_prioritized",
+      "rationale": "Appears to be enhancement/docs/UI request rather than severe online service risk.",
+      "updated_at": "2026-03-20T07:22:23Z"
+    },
+    {
+      "upstream": "Wei-Shaw/sub2api#678",
+      "url": "https://github.com/Wei-Shaw/sub2api/issues/678",
+      "title": "建议添加兑换码购买链接",
+      "impact": "low",
+      "categories": [
+        "enhancement"
+      ],
+      "tokenkey_status": "not_prioritized",
+      "rationale": "Appears to be enhancement/docs/UI request rather than severe online service risk.",
+      "updated_at": "2026-02-28T06:05:11Z"
+    },
+    {
+      "upstream": "Wei-Shaw/sub2api#703",
+      "url": "https://github.com/Wei-Shaw/sub2api/issues/703",
+      "title": "Feature: Auto-assign default subscription group on user registration",
+      "impact": "low",
+      "categories": [
+        "enhancement"
+      ],
+      "tokenkey_status": "not_prioritized",
+      "rationale": "Appears to be enhancement/docs/UI request rather than severe online service risk.",
+      "updated_at": "2026-03-04T17:49:02Z"
+    },
+    {
+      "upstream": "Wei-Shaw/sub2api#783",
+      "url": "https://github.com/Wei-Shaw/sub2api/issues/783",
+      "title": "没有使用文档吗",
+      "impact": "low",
+      "categories": [
+        "docs"
+      ],
+      "tokenkey_status": "not_prioritized",
+      "rationale": "Appears to be enhancement/docs/UI request rather than severe online service risk.",
+      "updated_at": "2026-03-05T09:33:15Z"
+    },
+    {
+      "upstream": "Wei-Shaw/sub2api#79",
+      "url": "https://github.com/Wei-Shaw/sub2api/issues/79",
+      "title": "【功能建议】支持 Key 关联多分组，并支持后台直接为用户生成 Key",
+      "impact": "low",
+      "categories": [
+        "enhancement"
+      ],
+      "tokenkey_status": "not_prioritized",
+      "rationale": "Appears to be enhancement/docs/UI request rather than severe online service risk.",
+      "updated_at": "2025-12-30T03:10:43Z"
+    },
+    {
+      "upstream": "Wei-Shaw/sub2api#817",
+      "url": "https://github.com/Wei-Shaw/sub2api/issues/817",
+      "title": "是否可以支持全局代理？",
+      "impact": "low",
+      "categories": [
+        "enhancement"
+      ],
+      "tokenkey_status": "not_prioritized",
+      "rationale": "Appears to be enhancement/docs/UI request rather than severe online service risk.",
+      "updated_at": "2026-03-28T13:28:38Z"
+    },
+    {
+      "upstream": "Wei-Shaw/sub2api#832",
+      "url": "https://github.com/Wei-Shaw/sub2api/issues/832",
+      "title": "提问：如何在cli开启fastmode模式",
+      "impact": "low",
+      "categories": [
+        "enhancement",
+        "docs"
+      ],
+      "tokenkey_status": "not_prioritized",
+      "rationale": "Appears to be enhancement/docs/UI request rather than severe online service risk.",
+      "updated_at": "2026-05-15T03:26:01Z"
+    },
+    {
+      "upstream": "Wei-Shaw/sub2api#843",
+      "url": "https://github.com/Wei-Shaw/sub2api/issues/843",
+      "title": "希望能让 codex 账号加入 Anthropic 组",
+      "impact": "low",
+      "categories": [
+        "enhancement"
+      ],
+      "tokenkey_status": "not_prioritized",
+      "rationale": "Appears to be enhancement/docs/UI request rather than severe online service risk.",
+      "updated_at": "2026-05-04T16:00:16Z"
+    },
+    {
+      "upstream": "Wei-Shaw/sub2api#884",
+      "url": "https://github.com/Wei-Shaw/sub2api/issues/884",
+      "title": "希望增加对grok api的支持",
+      "impact": "low",
+      "categories": [
+        "enhancement"
+      ],
+      "tokenkey_status": "not_prioritized",
+      "rationale": "Appears to be enhancement/docs/UI request rather than severe online service risk.",
+      "updated_at": "2026-03-25T16:40:47Z"
+    },
+    {
+      "upstream": "Wei-Shaw/sub2api#979",
+      "url": "https://github.com/Wei-Shaw/sub2api/issues/979",
+      "title": "Feature Request: 基于剩余容量的动态负载均衡调度（加权轮询）",
+      "impact": "low",
+      "categories": [
+        "enhancement"
+      ],
+      "tokenkey_status": "not_prioritized",
+      "rationale": "Appears to be enhancement/docs/UI request rather than severe online service risk.",
+      "updated_at": "2026-03-13T11:59:46Z"
+    },
+    {
+      "upstream": "Wei-Shaw/sub2api#989",
+      "url": "https://github.com/Wei-Shaw/sub2api/issues/989",
+      "title": "给出个建议，既然可以增加其他厂商的账号，就应该在分配订阅中的订阅分组增加多选功能，这样用户就可以体验不止一家的模型了",
+      "impact": "low",
+      "categories": [
+        "enhancement"
+      ],
+      "tokenkey_status": "not_prioritized",
+      "rationale": "Appears to be enhancement/docs/UI request rather than severe online service risk.",
+      "updated_at": "2026-03-14T08:28:50Z"
+    },
+    {
+      "upstream": "Wei-Shaw/sub2api#1001",
+      "url": "https://github.com/Wei-Shaw/sub2api/issues/1001",
+      "title": "gpt 默认都变成 xhigh 导致报错",
+      "impact": "unknown_low_signal",
+      "categories": [],
+      "tokenkey_status": "not_prioritized",
+      "rationale": "No high-signal production-risk keywords in this pass.",
+      "updated_at": "2026-03-14T12:00:15Z"
+    },
+    {
+      "upstream": "Wei-Shaw/sub2api#1002",
+      "url": "https://github.com/Wei-Shaw/sub2api/issues/1002",
+      "title": "docker 版本的，配置 db 和 redis 保存以后会长时间没有反应，重启容器以后，有会重新进行配置",
+      "impact": "unknown_low_signal",
+      "categories": [],
+      "tokenkey_status": "not_prioritized",
+      "rationale": "No high-signal production-risk keywords in this pass.",
+      "updated_at": "2026-03-15T08:56:35Z"
+    },
+    {
+      "upstream": "Wei-Shaw/sub2api#1003",
+      "url": "https://github.com/Wei-Shaw/sub2api/issues/1003",
+      "title": "codex auth登录",
+      "impact": "unknown_low_signal",
+      "categories": [],
+      "tokenkey_status": "not_prioritized",
+      "rationale": "No high-signal production-risk keywords in this pass.",
+      "updated_at": "2026-04-29T19:34:01Z"
+    },
+    {
+      "upstream": "Wei-Shaw/sub2api#1004",
+      "url": "https://github.com/Wei-Shaw/sub2api/issues/1004",
+      "title": "该上 kiro 的了",
+      "impact": "unknown_low_signal",
+      "categories": [],
+      "tokenkey_status": "not_prioritized",
+      "rationale": "No high-signal production-risk keywords in this pass.",
+      "updated_at": "2026-04-30T06:12:43Z"
+    },
+    {
+      "upstream": "Wei-Shaw/sub2api#1013",
+      "url": "https://github.com/Wei-Shaw/sub2api/issues/1013",
+      "title": "能否支持gemini Business账号",
+      "impact": "unknown_low_signal",
+      "categories": [],
+      "tokenkey_status": "not_prioritized",
+      "rationale": "No high-signal production-risk keywords in this pass.",
+      "updated_at": "2026-03-14T16:53:52Z"
+    },
+    {
+      "upstream": "Wei-Shaw/sub2api#1029",
+      "url": "https://github.com/Wei-Shaw/sub2api/issues/1029",
+      "title": "0.199备份失败 修复方法",
+      "impact": "unknown_low_signal",
+      "categories": [],
+      "tokenkey_status": "not_prioritized",
+      "rationale": "No high-signal production-risk keywords in this pass.",
+      "updated_at": "2026-03-16T07:33:33Z"
+    },
+    {
+      "upstream": "Wei-Shaw/sub2api#1034",
+      "url": "https://github.com/Wei-Shaw/sub2api/issues/1034",
+      "title": "SMTP 连接测试失败: SMTP connection test failed: smtp authentication failed: unencrypted connection",
+      "impact": "unknown_low_signal",
+      "categories": [],
+      "tokenkey_status": "not_prioritized",
+      "rationale": "No high-signal production-risk keywords in this pass.",
+      "updated_at": "2026-03-15T12:14:25Z"
+    },
+    {
+      "upstream": "Wei-Shaw/sub2api#1038",
+      "url": "https://github.com/Wei-Shaw/sub2api/issues/1038",
+      "title": "更新版本到v0.1.100之后报错",
+      "impact": "unknown_low_signal",
+      "categories": [],
+      "tokenkey_status": "not_prioritized",
+      "rationale": "No high-signal production-risk keywords in this pass.",
+      "updated_at": "2026-03-23T05:24:13Z"
+    },
+    {
+      "upstream": "Wei-Shaw/sub2api#1045",
+      "url": "https://github.com/Wei-Shaw/sub2api/issues/1045",
+      "title": "gemini无法使用system instruction参数",
+      "impact": "unknown_low_signal",
+      "categories": [],
+      "tokenkey_status": "not_prioritized",
+      "rationale": "No high-signal production-risk keywords in this pass.",
+      "updated_at": "2026-03-16T01:46:12Z"
+    },
+    {
+      "upstream": "Wei-Shaw/sub2api#1051",
+      "url": "https://github.com/Wei-Shaw/sub2api/issues/1051",
+      "title": "Gemini cli 不能使用Auto 只能手动指定模型使用",
+      "impact": "unknown_low_signal",
+      "categories": [],
+      "tokenkey_status": "not_prioritized",
+      "rationale": "No high-signal production-risk keywords in this pass.",
+      "updated_at": "2026-03-16T22:54:50Z"
+    },
+    {
+      "upstream": "Wei-Shaw/sub2api#1054",
+      "url": "https://github.com/Wei-Shaw/sub2api/issues/1054",
+      "title": "在哪里新建订阅分组？",
+      "impact": "unknown_low_signal",
+      "categories": [],
+      "tokenkey_status": "not_prioritized",
+      "rationale": "No high-signal production-risk keywords in this pass.",
+      "updated_at": "2026-03-16T09:52:17Z"
+    },
+    {
+      "upstream": "Wei-Shaw/sub2api#1057",
+      "url": "https://github.com/Wei-Shaw/sub2api/issues/1057",
+      "title": "我安装好后登陆的时候一直显示密码错误怎么办？",
+      "impact": "unknown_low_signal",
+      "categories": [],
+      "tokenkey_status": "not_prioritized",
+      "rationale": "No high-signal production-risk keywords in this pass.",
+      "updated_at": "2026-05-07T17:27:17Z"
+    },
+    {
+      "upstream": "Wei-Shaw/sub2api#1061",
+      "url": "https://github.com/Wei-Shaw/sub2api/issues/1061",
+      "title": "open data/model_pricing.sha256: permission denied",
+      "impact": "unknown_low_signal",
+      "categories": [],
+      "tokenkey_status": "not_prioritized",
+      "rationale": "No high-signal production-risk keywords in this pass.",
+      "updated_at": "2026-03-18T02:39:29Z"
+    },
+    {
+      "upstream": "Wei-Shaw/sub2api#1064",
+      "url": "https://github.com/Wei-Shaw/sub2api/issues/1064",
+      "title": "5h窗口费用控制",
+      "impact": "unknown_low_signal",
+      "categories": [],
+      "tokenkey_status": "not_prioritized",
+      "rationale": "No high-signal production-risk keywords in this pass.",
+      "updated_at": "2026-03-16T15:44:48Z"
+    },
+    {
+      "upstream": "Wei-Shaw/sub2api#1065",
+      "url": "https://github.com/Wei-Shaw/sub2api/issues/1065",
+      "title": "额度刷新时间与官方对应不上",
+      "impact": "unknown_low_signal",
+      "categories": [],
+      "tokenkey_status": "not_prioritized",
+      "rationale": "No high-signal production-risk keywords in this pass.",
+      "updated_at": "2026-03-17T00:21:13Z"
+    },
+    {
+      "upstream": "Wei-Shaw/sub2api#1071",
+      "url": "https://github.com/Wei-Shaw/sub2api/issues/1071",
+      "title": "增加对于gemini-3.1-flash-lite-preview模型价格",
+      "impact": "unknown_low_signal",
+      "categories": [],
+      "tokenkey_status": "not_prioritized",
+      "rationale": "No high-signal production-risk keywords in this pass.",
+      "updated_at": "2026-03-16T13:45:38Z"
+    },
+    {
+      "upstream": "Wei-Shaw/sub2api#1079",
+      "url": "https://github.com/Wei-Shaw/sub2api/issues/1079",
+      "title": "能否支持Github copilot订阅转API？",
+      "impact": "unknown_low_signal",
+      "categories": [],
+      "tokenkey_status": "not_prioritized",
+      "rationale": "No high-signal production-risk keywords in this pass.",
+      "updated_at": "2026-04-22T09:31:36Z"
+    },
+    {
+      "upstream": "Wei-Shaw/sub2api#1080",
+      "url": "https://github.com/Wei-Shaw/sub2api/issues/1080",
+      "title": "VS Code的ClaudeCode插件显示返回结果会报错：Cannot read properties of undefined (reading 'trim')",
+      "impact": "unknown_low_signal",
+      "categories": [],
+      "tokenkey_status": "not_prioritized",
+      "rationale": "No high-signal production-risk keywords in this pass.",
+      "updated_at": "2026-03-17T02:36:07Z"
+    },
+    {
+      "upstream": "Wei-Shaw/sub2api#1082",
+      "url": "https://github.com/Wei-Shaw/sub2api/issues/1082",
+      "title": "安装向导中提示管理员密码至少6位，但实际代码要求至少8位，如果少于8位，最后点击安装完成报错：Request failed with status code 400",
+      "impact": "unknown_low_signal",
+      "categories": [],
+      "tokenkey_status": "not_prioritized",
+      "rationale": "No high-signal production-risk keywords in this pass.",
+      "updated_at": "2026-03-17T02:43:30Z"
+    },
+    {
+      "upstream": "Wei-Shaw/sub2api#1088",
+      "url": "https://github.com/Wei-Shaw/sub2api/issues/1088",
+      "title": "和CRS相比，SUB2的Claude请求响应慢，首字慢",
+      "impact": "unknown_low_signal",
+      "categories": [],
+      "tokenkey_status": "not_prioritized",
+      "rationale": "No high-signal production-risk keywords in this pass.",
+      "updated_at": "2026-03-17T06:56:07Z"
+    },
+    {
+      "upstream": "Wei-Shaw/sub2api#1089",
+      "url": "https://github.com/Wei-Shaw/sub2api/issues/1089",
+      "title": "账号调度问题",
+      "impact": "unknown_low_signal",
+      "categories": [],
+      "tokenkey_status": "not_prioritized",
+      "rationale": "No high-signal production-risk keywords in this pass.",
+      "updated_at": "2026-04-22T13:42:12Z"
+    },
+    {
+      "upstream": "Wei-Shaw/sub2api#1091",
+      "url": "https://github.com/Wei-Shaw/sub2api/issues/1091",
+      "title": "发现在sub2api调codex 经常性的\"request_error:request_body_truncated\"",
+      "impact": "unknown_low_signal",
+      "categories": [],
+      "tokenkey_status": "not_prioritized",
+      "rationale": "No high-signal production-risk keywords in this pass.",
+      "updated_at": "2026-04-29T01:50:52Z"
+    },
+    {
+      "upstream": "Wei-Shaw/sub2api#1092",
+      "url": "https://github.com/Wei-Shaw/sub2api/issues/1092",
+      "title": "能否限制使用模型",
+      "impact": "unknown_low_signal",
+      "categories": [],
+      "tokenkey_status": "not_prioritized",
+      "rationale": "No high-signal production-risk keywords in this pass.",
+      "updated_at": "2026-03-17T09:17:36Z"
+    },
+    {
+      "upstream": "Wei-Shaw/sub2api#1098",
+      "url": "https://github.com/Wei-Shaw/sub2api/issues/1098",
+      "title": "功能请求：在订阅分组目前只能限制1天，能否和官方进行同步(同步为5小时)？",
+      "impact": "unknown_low_signal",
+      "categories": [],
+      "tokenkey_status": "not_prioritized",
+      "rationale": "No high-signal production-risk keywords in this pass.",
+      "updated_at": "2026-03-17T12:58:20Z"
+    },
+    {
+      "upstream": "Wei-Shaw/sub2api#1099",
+      "url": "https://github.com/Wei-Shaw/sub2api/issues/1099",
+      "title": "OPENCLAW 无法命中缓存",
+      "impact": "unknown_low_signal",
+      "categories": [],
+      "tokenkey_status": "not_prioritized",
+      "rationale": "No high-signal production-risk keywords in this pass.",
+      "updated_at": "2026-04-04T03:16:22Z"
+    },
+    {
+      "upstream": "Wei-Shaw/sub2api#1112",
+      "url": "https://github.com/Wei-Shaw/sub2api/issues/1112",
+      "title": "bug: IP管理的测试连接不支持纯ipv6的孤岛服务器",
+      "impact": "unknown_low_signal",
+      "categories": [],
+      "tokenkey_status": "not_prioritized",
+      "rationale": "No high-signal production-risk keywords in this pass.",
+      "updated_at": "2026-03-18T04:13:00Z"
+    },
+    {
+      "upstream": "Wei-Shaw/sub2api#1121",
+      "url": "https://github.com/Wei-Shaw/sub2api/issues/1121",
+      "title": "询问 sub2api 怎么在一个api key 中添加多个不同上游的分类？",
+      "impact": "unknown_low_signal",
+      "categories": [],
+      "tokenkey_status": "not_prioritized",
+      "rationale": "No high-signal production-risk keywords in this pass.",
+      "updated_at": "2026-03-20T11:45:05Z"
+    },
+    {
+      "upstream": "Wei-Shaw/sub2api#1122",
+      "url": "https://github.com/Wei-Shaw/sub2api/issues/1122",
+      "title": "咨询：postgres和redis自动安装",
+      "impact": "unknown_low_signal",
+      "categories": [],
+      "tokenkey_status": "not_prioritized",
+      "rationale": "No high-signal production-risk keywords in this pass.",
+      "updated_at": "2026-03-18T08:58:32Z"
+    },
+    {
+      "upstream": "Wei-Shaw/sub2api#1125",
+      "url": "https://github.com/Wei-Shaw/sub2api/issues/1125",
+      "title": "没填分组无法重新更新分组",
+      "impact": "unknown_low_signal",
+      "categories": [],
+      "tokenkey_status": "not_prioritized",
+      "rationale": "No high-signal production-risk keywords in this pass.",
+      "updated_at": "2026-03-18T09:38:47Z"
+    },
+    {
+      "upstream": "Wei-Shaw/sub2api#1127",
+      "url": "https://github.com/Wei-Shaw/sub2api/issues/1127",
+      "title": "GPT5.4模型指向了gpt-5.1-codex",
+      "impact": "unknown_low_signal",
+      "categories": [],
+      "tokenkey_status": "not_prioritized",
+      "rationale": "No high-signal production-risk keywords in this pass.",
+      "updated_at": "2026-04-27T07:33:36Z"
+    },
+    {
+      "upstream": "Wei-Shaw/sub2api#1133",
+      "url": "https://github.com/Wei-Shaw/sub2api/issues/1133",
+      "title": "装好后太难配置用了",
+      "impact": "unknown_low_signal",
+      "categories": [],
+      "tokenkey_status": "not_prioritized",
+      "rationale": "No high-signal production-risk keywords in this pass.",
+      "updated_at": "2026-03-20T17:13:41Z"
+    },
+    {
+      "upstream": "Wei-Shaw/sub2api#1139",
+      "url": "https://github.com/Wei-Shaw/sub2api/issues/1139",
+      "title": "mac2019 32G使用后台特别卡",
+      "impact": "unknown_low_signal",
+      "categories": [],
+      "tokenkey_status": "not_prioritized",
+      "rationale": "No high-signal production-risk keywords in this pass.",
+      "updated_at": "2026-03-19T01:51:24Z"
+    },
+    {
+      "upstream": "Wei-Shaw/sub2api#1140",
+      "url": "https://github.com/Wei-Shaw/sub2api/issues/1140",
+      "title": "【bug 反馈】demo 演示站新手引导卡在第 4、第 8 步，无法进行至最后一步",
+      "impact": "unknown_low_signal",
+      "categories": [],
+      "tokenkey_status": "not_prioritized",
+      "rationale": "No high-signal production-risk keywords in this pass.",
+      "updated_at": "2026-03-19T02:41:10Z"
+    },
+    {
+      "upstream": "Wei-Shaw/sub2api#1141",
+      "url": "https://github.com/Wei-Shaw/sub2api/issues/1141",
+      "title": "升级最新版v0.1.103，新账号一直被封，是要降级到0.96吗？",
+      "impact": "unknown_low_signal",
+      "categories": [],
+      "tokenkey_status": "not_prioritized",
+      "rationale": "No high-signal production-risk keywords in this pass.",
+      "updated_at": "2026-03-24T07:57:39Z"
+    },
+    {
+      "upstream": "Wei-Shaw/sub2api#1165",
+      "url": "https://github.com/Wei-Shaw/sub2api/issues/1165",
+      "title": "清理全部，自己的使用量没有清理的 bug",
+      "impact": "unknown_low_signal",
+      "categories": [],
+      "tokenkey_status": "not_prioritized",
+      "rationale": "No high-signal production-risk keywords in this pass.",
+      "updated_at": "2026-03-19T14:58:54Z"
+    },
+    {
+      "upstream": "Wei-Shaw/sub2api#1166",
+      "url": "https://github.com/Wei-Shaw/sub2api/issues/1166",
+      "title": "账号管理应该加一个未绑定分组的账号筛选，方便绑定。。",
+      "impact": "unknown_low_signal",
+      "categories": [],
+      "tokenkey_status": "not_prioritized",
+      "rationale": "No high-signal production-risk keywords in this pass.",
+      "updated_at": "2026-03-19T15:25:10Z"
+    },
+    {
+      "upstream": "Wei-Shaw/sub2api#1174",
+      "url": "https://github.com/Wei-Shaw/sub2api/issues/1174",
+      "title": "可以直接集成sub2apipay吗？",
+      "impact": "unknown_low_signal",
+      "categories": [],
+      "tokenkey_status": "not_prioritized",
+      "rationale": "No high-signal production-risk keywords in this pass.",
+      "updated_at": "2026-03-20T03:46:33Z"
+    },
+    {
+      "upstream": "Wei-Shaw/sub2api#1177",
+      "url": "https://github.com/Wei-Shaw/sub2api/issues/1177",
+      "title": "能不能增加一键检测401并标记",
+      "impact": "unknown_low_signal",
+      "categories": [],
+      "tokenkey_status": "not_prioritized",
+      "rationale": "No high-signal production-risk keywords in this pass.",
+      "updated_at": "2026-03-20T06:09:31Z"
+    },
+    {
+      "upstream": "Wei-Shaw/sub2api#1178",
+      "url": "https://github.com/Wei-Shaw/sub2api/issues/1178",
+      "title": "Access forbidden (403): account may be suspended or lack permissions",
+      "impact": "unknown_low_signal",
+      "categories": [],
+      "tokenkey_status": "not_prioritized",
+      "rationale": "No high-signal production-risk keywords in this pass.",
+      "updated_at": "2026-04-21T04:51:49Z"
+    },
+    {
+      "upstream": "Wei-Shaw/sub2api#1183",
+      "url": "https://github.com/Wei-Shaw/sub2api/issues/1183",
+      "title": "简单模式（Simple Mode）下能否开放组管理",
+      "impact": "unknown_low_signal",
+      "categories": [],
+      "tokenkey_status": "not_prioritized",
+      "rationale": "No high-signal production-risk keywords in this pass.",
+      "updated_at": "2026-03-20T10:32:56Z"
+    },
+    {
+      "upstream": "Wei-Shaw/sub2api#1185",
+      "url": "https://github.com/Wei-Shaw/sub2api/issues/1185",
+      "title": "清理不了",
+      "impact": "unknown_low_signal",
+      "categories": [],
+      "tokenkey_status": "not_prioritized",
+      "rationale": "No high-signal production-risk keywords in this pass.",
+      "updated_at": "2026-03-20T13:46:15Z"
+    },
+    {
+      "upstream": "Wei-Shaw/sub2api#1187",
+      "url": "https://github.com/Wei-Shaw/sub2api/issues/1187",
+      "title": "账号应该支持更细的检索，比如同是openai的账号，free和team和plus单独检索不了",
+      "impact": "unknown_low_signal",
+      "categories": [],
+      "tokenkey_status": "not_prioritized",
+      "rationale": "No high-signal production-risk keywords in this pass.",
+      "updated_at": "2026-03-20T14:40:26Z"
+    },
+    {
+      "upstream": "Wei-Shaw/sub2api#1191",
+      "url": "https://github.com/Wei-Shaw/sub2api/issues/1191",
+      "title": "能不能直接使用一个apikey就使用不同的ai客户端，不通过cc switch",
+      "impact": "unknown_low_signal",
+      "categories": [],
+      "tokenkey_status": "not_prioritized",
+      "rationale": "No high-signal production-risk keywords in this pass.",
+      "updated_at": "2026-03-20T17:12:32Z"
+    },
+    {
+      "upstream": "Wei-Shaw/sub2api#1199",
+      "url": "https://github.com/Wei-Shaw/sub2api/issues/1199",
+      "title": "升级到3月21号版本，邮箱验证跑不通，前几天的版本是正常的",
+      "impact": "unknown_low_signal",
+      "categories": [],
+      "tokenkey_status": "not_prioritized",
+      "rationale": "No high-signal production-risk keywords in this pass.",
+      "updated_at": "2026-03-21T15:59:11Z"
+    },
+    {
+      "upstream": "Wei-Shaw/sub2api#1205",
+      "url": "https://github.com/Wei-Shaw/sub2api/issues/1205",
+      "title": "English locale shows Chinese text \"倍率\" on Keys page",
+      "impact": "unknown_low_signal",
+      "categories": [],
+      "tokenkey_status": "not_prioritized",
+      "rationale": "No high-signal production-risk keywords in this pass.",
+      "updated_at": "2026-03-21T20:50:52Z"
+    },
+    {
+      "upstream": "Wei-Shaw/sub2api#1206",
+      "url": "https://github.com/Wei-Shaw/sub2api/issues/1206",
+      "title": "【增加功能】推广赚佣",
+      "impact": "unknown_low_signal",
+      "categories": [],
+      "tokenkey_status": "not_prioritized",
+      "rationale": "No high-signal production-risk keywords in this pass.",
+      "updated_at": "2026-03-22T00:41:55Z"
+    },
+    {
+      "upstream": "Wei-Shaw/sub2api#1208",
+      "url": "https://github.com/Wei-Shaw/sub2api/issues/1208",
+      "title": "用户怎么查看模型的价格？",
+      "impact": "unknown_low_signal",
+      "categories": [],
+      "tokenkey_status": "not_prioritized",
+      "rationale": "No high-signal production-risk keywords in this pass.",
+      "updated_at": "2026-03-22T03:06:43Z"
+    },
+    {
+      "upstream": "Wei-Shaw/sub2api#1209",
+      "url": "https://github.com/Wei-Shaw/sub2api/issues/1209",
+      "title": "清理无效",
+      "impact": "unknown_low_signal",
+      "categories": [],
+      "tokenkey_status": "not_prioritized",
+      "rationale": "No high-signal production-risk keywords in this pass.",
+      "updated_at": "2026-03-22T04:32:06Z"
+    },
+    {
+      "upstream": "Wei-Shaw/sub2api#1213",
+      "url": "https://github.com/Wei-Shaw/sub2api/issues/1213",
+      "title": "多个用户触发了并发问题 Concurrency limit exceeded for account, please retry later",
+      "impact": "unknown_low_signal",
+      "categories": [],
+      "tokenkey_status": "not_prioritized",
+      "rationale": "No high-signal production-risk keywords in this pass.",
+      "updated_at": "2026-03-22T12:57:46Z"
+    },
+    {
+      "upstream": "Wei-Shaw/sub2api#1221",
+      "url": "https://github.com/Wei-Shaw/sub2api/issues/1221",
+      "title": "gemini账号，openwebui报错。",
+      "impact": "unknown_low_signal",
+      "categories": [],
+      "tokenkey_status": "not_prioritized",
+      "rationale": "No high-signal production-risk keywords in this pass.",
+      "updated_at": "2026-03-23T08:15:40Z"
+    },
+    {
+      "upstream": "Wei-Shaw/sub2api#1233",
+      "url": "https://github.com/Wei-Shaw/sub2api/issues/1233",
+      "title": "antigravity 封号",
+      "impact": "unknown_low_signal",
+      "categories": [],
+      "tokenkey_status": "not_prioritized",
+      "rationale": "No high-signal production-risk keywords in this pass.",
+      "updated_at": "2026-05-11T07:04:21Z"
+    },
+    {
+      "upstream": "Wei-Shaw/sub2api#1239",
+      "url": "https://github.com/Wei-Shaw/sub2api/issues/1239",
+      "title": "添加gpt 5.4 mini的支持",
+      "impact": "unknown_low_signal",
+      "categories": [],
+      "tokenkey_status": "not_prioritized",
+      "rationale": "No high-signal production-risk keywords in this pass.",
+      "updated_at": "2026-03-24T01:15:24Z"
+    },
+    {
+      "upstream": "Wei-Shaw/sub2api#1241",
+      "url": "https://github.com/Wei-Shaw/sub2api/issues/1241",
+      "title": "数据恢复",
+      "impact": "unknown_low_signal",
+      "categories": [],
+      "tokenkey_status": "not_prioritized",
+      "rationale": "No high-signal production-risk keywords in this pass.",
+      "updated_at": "2026-03-23T18:32:47Z"
+    },
+    {
+      "upstream": "Wei-Shaw/sub2api#1289",
+      "url": "https://github.com/Wei-Shaw/sub2api/issues/1289",
+      "title": "管理员如何能看到每个用户的最近使用时间，和模型",
+      "impact": "unknown_low_signal",
+      "categories": [],
+      "tokenkey_status": "not_prioritized",
+      "rationale": "No high-signal production-risk keywords in this pass.",
+      "updated_at": "2026-03-25T00:47:49Z"
+    },
+    {
+      "upstream": "Wei-Shaw/sub2api#1290",
+      "url": "https://github.com/Wei-Shaw/sub2api/issues/1290",
+      "title": "可以部署在阿里云上，然后去访问claude api吗？",
+      "impact": "unknown_low_signal",
+      "categories": [],
+      "tokenkey_status": "not_prioritized",
+      "rationale": "No high-signal production-risk keywords in this pass.",
+      "updated_at": "2026-03-25T12:05:13Z"
+    },
+    {
+      "upstream": "Wei-Shaw/sub2api#1291",
+      "url": "https://github.com/Wei-Shaw/sub2api/issues/1291",
+      "title": "有些上游的厂商禁止如hi 这样的测活。能否让test接口支持自定义测活内容",
+      "impact": "unknown_low_signal",
+      "categories": [],
+      "tokenkey_status": "not_prioritized",
+      "rationale": "No high-signal production-risk keywords in this pass.",
+      "updated_at": "2026-03-25T03:19:21Z"
+    },
+    {
+      "upstream": "Wei-Shaw/sub2api#1297",
+      "url": "https://github.com/Wei-Shaw/sub2api/issues/1297",
+      "title": "账号连接测试api取值不一致",
+      "impact": "unknown_low_signal",
+      "categories": [],
+      "tokenkey_status": "not_prioritized",
+      "rationale": "No high-signal production-risk keywords in this pass.",
+      "updated_at": "2026-03-25T07:08:10Z"
+    },
+    {
+      "upstream": "Wei-Shaw/sub2api#1304",
+      "url": "https://github.com/Wei-Shaw/sub2api/issues/1304",
+      "title": "提示api错误",
+      "impact": "unknown_low_signal",
+      "categories": [],
+      "tokenkey_status": "not_prioritized",
+      "rationale": "No high-signal production-risk keywords in this pass.",
+      "updated_at": "2026-03-26T02:30:15Z"
+    },
+    {
+      "upstream": "Wei-Shaw/sub2api#1306",
+      "url": "https://github.com/Wei-Shaw/sub2api/issues/1306",
+      "title": "Claude",
+      "impact": "unknown_low_signal",
+      "categories": [],
+      "tokenkey_status": "not_prioritized",
+      "rationale": "No high-signal production-risk keywords in this pass.",
+      "updated_at": "2026-04-03T06:57:34Z"
+    },
+    {
+      "upstream": "Wei-Shaw/sub2api#1315",
+      "url": "https://github.com/Wei-Shaw/sub2api/issues/1315",
+      "title": "谷歌反重力逻辑增强",
+      "impact": "unknown_low_signal",
+      "categories": [],
+      "tokenkey_status": "not_prioritized",
+      "rationale": "No high-signal production-risk keywords in this pass.",
+      "updated_at": "2026-03-28T08:57:33Z"
+    },
+    {
+      "upstream": "Wei-Shaw/sub2api#1317",
+      "url": "https://github.com/Wei-Shaw/sub2api/issues/1317",
+      "title": "登录问题和openclaw调用问题",
+      "impact": "unknown_low_signal",
+      "categories": [],
+      "tokenkey_status": "not_prioritized",
+      "rationale": "No high-signal production-risk keywords in this pass.",
+      "updated_at": "2026-04-26T17:21:57Z"
+    },
+    {
+      "upstream": "Wei-Shaw/sub2api#1329",
+      "url": "https://github.com/Wei-Shaw/sub2api/issues/1329",
+      "title": "增加空回自动重试功能，不然agent 自动暂停了",
+      "impact": "unknown_low_signal",
+      "categories": [],
+      "tokenkey_status": "not_prioritized",
+      "rationale": "No high-signal production-risk keywords in this pass.",
+      "updated_at": "2026-03-26T14:34:31Z"
+    },
+    {
+      "upstream": "Wei-Shaw/sub2api#1333",
+      "url": "https://github.com/Wei-Shaw/sub2api/issues/1333",
+      "title": "[bug] 密钥删了还显示已存在",
+      "impact": "unknown_low_signal",
+      "categories": [],
+      "tokenkey_status": "not_prioritized",
+      "rationale": "No high-signal production-risk keywords in this pass.",
+      "updated_at": "2026-03-27T01:27:10Z"
+    },
+    {
+      "upstream": "Wei-Shaw/sub2api#1342",
+      "url": "https://github.com/Wei-Shaw/sub2api/issues/1342",
+      "title": "使用openai的时候调用工具报错",
+      "impact": "unknown_low_signal",
+      "categories": [],
+      "tokenkey_status": "not_prioritized",
+      "rationale": "No high-signal production-risk keywords in this pass.",
+      "updated_at": "2026-04-18T10:45:17Z"
+    },
+    {
+      "upstream": "Wei-Shaw/sub2api#1347",
+      "url": "https://github.com/Wei-Shaw/sub2api/issues/1347",
+      "title": "【bug】仍有401状态无法标记为错误",
+      "impact": "unknown_low_signal",
+      "categories": [],
+      "tokenkey_status": "not_prioritized",
+      "rationale": "No high-signal production-risk keywords in this pass.",
+      "updated_at": "2026-03-27T10:43:05Z"
+    },
+    {
+      "upstream": "Wei-Shaw/sub2api#135",
+      "url": "https://github.com/Wei-Shaw/sub2api/issues/135",
+      "title": "gemini账号测试连接提示403错误，crs中能正常使用",
+      "impact": "unknown_low_signal",
+      "categories": [],
+      "tokenkey_status": "not_prioritized",
+      "rationale": "No high-signal production-risk keywords in this pass.",
+      "updated_at": "2026-01-04T10:13:56Z"
+    },
+    {
+      "upstream": "Wei-Shaw/sub2api#1351",
+      "url": "https://github.com/Wei-Shaw/sub2api/issues/1351",
+      "title": "[Bug]删除key后无法新建自定义相同的api key",
+      "impact": "unknown_low_signal",
+      "categories": [],
+      "tokenkey_status": "not_prioritized",
+      "rationale": "No high-signal production-risk keywords in this pass.",
+      "updated_at": "2026-03-27T16:25:22Z"
+    },
+    {
+      "upstream": "Wei-Shaw/sub2api#136",
+      "url": "https://github.com/Wei-Shaw/sub2api/issues/136",
+      "title": "无法在cc外调用",
+      "impact": "unknown_low_signal",
+      "categories": [],
+      "tokenkey_status": "not_prioritized",
+      "rationale": "No high-signal production-risk keywords in this pass.",
+      "updated_at": "2026-01-04T14:30:37Z"
+    },
+    {
+      "upstream": "Wei-Shaw/sub2api#1361",
+      "url": "https://github.com/Wei-Shaw/sub2api/issues/1361",
+      "title": "关于新版本claudecode的新遥测请求",
+      "impact": "unknown_low_signal",
+      "categories": [],
+      "tokenkey_status": "not_prioritized",
+      "rationale": "No high-signal production-risk keywords in this pass.",
+      "updated_at": "2026-03-30T07:14:52Z"
+    },
+    {
+      "upstream": "Wei-Shaw/sub2api#1364",
+      "url": "https://github.com/Wei-Shaw/sub2api/issues/1364",
+      "title": "不知道“账号管理”中选项的用途",
+      "impact": "unknown_low_signal",
+      "categories": [],
+      "tokenkey_status": "not_prioritized",
+      "rationale": "No high-signal production-risk keywords in this pass.",
+      "updated_at": "2026-03-29T05:14:16Z"
+    },
+    {
+      "upstream": "Wei-Shaw/sub2api#1368",
+      "url": "https://github.com/Wei-Shaw/sub2api/issues/1368",
+      "title": "https://shop.pincc.ai/ shop页开源了吗大佬",
+      "impact": "unknown_low_signal",
+      "categories": [],
+      "tokenkey_status": "not_prioritized",
+      "rationale": "No high-signal production-risk keywords in this pass.",
+      "updated_at": "2026-03-29T11:28:22Z"
+    },
+    {
+      "upstream": "Wei-Shaw/sub2api#1374",
+      "url": "https://github.com/Wei-Shaw/sub2api/issues/1374",
+      "title": "Claude用两小时就被封，怎么办",
+      "impact": "unknown_low_signal",
+      "categories": [],
+      "tokenkey_status": "not_prioritized",
+      "rationale": "No high-signal production-risk keywords in this pass.",
+      "updated_at": "2026-04-09T10:26:09Z"
+    },
+    {
+      "upstream": "Wei-Shaw/sub2api#1380",
+      "url": "https://github.com/Wei-Shaw/sub2api/issues/1380",
+      "title": "现在codex露头就秒",
+      "impact": "unknown_low_signal",
+      "categories": [],
+      "tokenkey_status": "not_prioritized",
+      "rationale": "No high-signal production-risk keywords in this pass.",
+      "updated_at": "2026-03-30T13:12:09Z"
+    },
+    {
+      "upstream": "Wei-Shaw/sub2api#1398",
+      "url": "https://github.com/Wei-Shaw/sub2api/issues/1398",
+      "title": "exe直接运行配置好后登录报404",
+      "impact": "unknown_low_signal",
+      "categories": [],
+      "tokenkey_status": "not_prioritized",
+      "rationale": "No high-signal production-risk keywords in this pass.",
+      "updated_at": "2026-03-30T17:21:51Z"
+    },
+    {
+      "upstream": "Wei-Shaw/sub2api#1410",
+      "url": "https://github.com/Wei-Shaw/sub2api/issues/1410",
+      "title": "请求支持 nvidia nim api",
+      "impact": "unknown_low_signal",
+      "categories": [],
+      "tokenkey_status": "not_prioritized",
+      "rationale": "No high-signal production-risk keywords in this pass.",
+      "updated_at": "2026-03-31T08:44:37Z"
+    },
+    {
+      "upstream": "Wei-Shaw/sub2api#1431",
+      "url": "https://github.com/Wei-Shaw/sub2api/issues/1431",
+      "title": "误删除账号是否支持记录找回",
+      "impact": "unknown_low_signal",
+      "categories": [],
+      "tokenkey_status": "not_prioritized",
+      "rationale": "No high-signal production-risk keywords in this pass.",
+      "updated_at": "2026-04-02T02:00:37Z"
+    },
+    {
+      "upstream": "Wei-Shaw/sub2api#1433",
+      "url": "https://github.com/Wei-Shaw/sub2api/issues/1433",
+      "title": "Antigravity为什么在这个项目里面一用就封啊？有没有大佬救一下？",
+      "impact": "unknown_low_signal",
+      "categories": [],
+      "tokenkey_status": "not_prioritized",
+      "rationale": "No high-signal production-risk keywords in this pass.",
+      "updated_at": "2026-04-14T02:07:25Z"
+    },
+    {
+      "upstream": "Wei-Shaw/sub2api#1446",
+      "url": "https://github.com/Wei-Shaw/sub2api/issues/1446",
+      "title": "可以考虑加一个 Github Coplit 的反代功能么",
+      "impact": "unknown_low_signal",
+      "categories": [],
+      "tokenkey_status": "not_prioritized",
+      "rationale": "No high-signal production-risk keywords in this pass.",
+      "updated_at": "2026-04-04T03:00:47Z"
+    },
+    {
+      "upstream": "Wei-Shaw/sub2api#1466",
+      "url": "https://github.com/Wei-Shaw/sub2api/issues/1466",
+      "title": "Unknown model: gpt-5.1",
+      "impact": "unknown_low_signal",
+      "categories": [],
+      "tokenkey_status": "not_prioritized",
+      "rationale": "No high-signal production-risk keywords in this pass.",
+      "updated_at": "2026-04-06T13:36:28Z"
+    },
+    {
+      "upstream": "Wei-Shaw/sub2api#1470",
+      "url": "https://github.com/Wei-Shaw/sub2api/issues/1470",
+      "title": "Mailersend SMTP connection problem",
+      "impact": "unknown_low_signal",
+      "categories": [],
+      "tokenkey_status": "not_prioritized",
+      "rationale": "No high-signal production-risk keywords in this pass.",
+      "updated_at": "2026-04-06T08:37:08Z"
+    },
+    {
+      "upstream": "Wei-Shaw/sub2api#1472",
+      "url": "https://github.com/Wei-Shaw/sub2api/issues/1472",
+      "title": "一个key无法对应多个订阅或者余额",
+      "impact": "unknown_low_signal",
+      "categories": [],
+      "tokenkey_status": "not_prioritized",
+      "rationale": "No high-signal production-risk keywords in this pass.",
+      "updated_at": "2026-04-05T19:04:59Z"
+    },
+    {
+      "upstream": "Wei-Shaw/sub2api#1473",
+      "url": "https://github.com/Wei-Shaw/sub2api/issues/1473",
+      "title": "internal error在线更新失败",
+      "impact": "unknown_low_signal",
+      "categories": [],
+      "tokenkey_status": "not_prioritized",
+      "rationale": "No high-signal production-risk keywords in this pass.",
+      "updated_at": "2026-04-05T19:12:36Z"
+    },
+    {
+      "upstream": "Wei-Shaw/sub2api#1474",
+      "url": "https://github.com/Wei-Shaw/sub2api/issues/1474",
+      "title": "一个key无法对应多个订阅或者余额",
+      "impact": "unknown_low_signal",
+      "categories": [],
+      "tokenkey_status": "not_prioritized",
+      "rationale": "No high-signal production-risk keywords in this pass.",
+      "updated_at": "2026-04-05T19:12:49Z"
+    },
+    {
+      "upstream": "Wei-Shaw/sub2api#1482",
+      "url": "https://github.com/Wei-Shaw/sub2api/issues/1482",
+      "title": "作者看下！！下个版本能不能改一下openai相关的一些功能",
+      "impact": "unknown_low_signal",
+      "categories": [],
+      "tokenkey_status": "not_prioritized",
+      "rationale": "No high-signal production-risk keywords in this pass.",
+      "updated_at": "2026-04-06T16:56:12Z"
+    },
+    {
+      "upstream": "Wei-Shaw/sub2api#1486",
+      "url": "https://github.com/Wei-Shaw/sub2api/issues/1486",
+      "title": "用户管理增加第二个管理员角色",
+      "impact": "unknown_low_signal",
+      "categories": [],
+      "tokenkey_status": "not_prioritized",
+      "rationale": "No high-signal production-risk keywords in this pass.",
+      "updated_at": "2026-04-07T08:39:39Z"
+    },
+    {
+      "upstream": "Wei-Shaw/sub2api#1492",
+      "url": "https://github.com/Wei-Shaw/sub2api/issues/1492",
+      "title": "hello大佬，我提个账号状态相关的",
+      "impact": "unknown_low_signal",
+      "categories": [],
+      "tokenkey_status": "not_prioritized",
+      "rationale": "No high-signal production-risk keywords in this pass.",
+      "updated_at": "2026-04-07T08:40:23Z"
+    },
+    {
+      "upstream": "Wei-Shaw/sub2api#1495",
+      "url": "https://github.com/Wei-Shaw/sub2api/issues/1495",
+      "title": "用户能通过api key反查到渠道路由模型的实际模型，很离谱",
+      "impact": "unknown_low_signal",
+      "categories": [],
+      "tokenkey_status": "not_prioritized",
+      "rationale": "No high-signal production-risk keywords in this pass.",
+      "updated_at": "2026-04-13T02:47:50Z"
+    },
+    {
+      "upstream": "Wei-Shaw/sub2api#1500",
+      "url": "https://github.com/Wei-Shaw/sub2api/issues/1500",
+      "title": "升级v0.1.108版本后，会出现兑换码兑换失败",
+      "impact": "unknown_low_signal",
+      "categories": [],
+      "tokenkey_status": "not_prioritized",
+      "rationale": "No high-signal production-risk keywords in this pass.",
+      "updated_at": "2026-04-07T14:21:46Z"
+    },
+    {
+      "upstream": "Wei-Shaw/sub2api#1503",
+      "url": "https://github.com/Wei-Shaw/sub2api/issues/1503",
+      "title": "4月8日早上开始的",
+      "impact": "unknown_low_signal",
+      "categories": [],
+      "tokenkey_status": "not_prioritized",
+      "rationale": "No high-signal production-risk keywords in this pass.",
+      "updated_at": "2026-04-08T00:41:08Z"
+    },
+    {
+      "upstream": "Wei-Shaw/sub2api#1506",
+      "url": "https://github.com/Wei-Shaw/sub2api/issues/1506",
+      "title": "codex 重复回答问题",
+      "impact": "unknown_low_signal",
+      "categories": [],
+      "tokenkey_status": "not_prioritized",
+      "rationale": "No high-signal production-risk keywords in this pass.",
+      "updated_at": "2026-04-15T22:30:55Z"
+    },
+    {
+      "upstream": "Wei-Shaw/sub2api#1507",
+      "url": "https://github.com/Wei-Shaw/sub2api/issues/1507",
+      "title": "有没有计划支持openai chat completions接口的模型供应商？",
+      "impact": "unknown_low_signal",
+      "categories": [],
+      "tokenkey_status": "not_prioritized",
+      "rationale": "No high-signal production-risk keywords in this pass.",
+      "updated_at": "2026-04-11T03:30:51Z"
+    },
+    {
+      "upstream": "Wei-Shaw/sub2api#1509",
+      "url": "https://github.com/Wei-Shaw/sub2api/issues/1509",
+      "title": "Request failed with status code 404",
+      "impact": "unknown_low_signal",
+      "categories": [],
+      "tokenkey_status": "not_prioritized",
+      "rationale": "No high-signal production-risk keywords in this pass.",
+      "updated_at": "2026-04-22T11:56:35Z"
+    },
+    {
+      "upstream": "Wei-Shaw/sub2api#1512",
+      "url": "https://github.com/Wei-Shaw/sub2api/issues/1512",
+      "title": "The Codex Business version does not allow viewing the 5-hour and weekly quotas in the account management section.",
+      "impact": "unknown_low_signal",
+      "categories": [],
+      "tokenkey_status": "not_prioritized",
+      "rationale": "No high-signal production-risk keywords in this pass.",
+      "updated_at": "2026-04-09T09:25:16Z"
+    },
+    {
+      "upstream": "Wei-Shaw/sub2api#1515",
+      "url": "https://github.com/Wei-Shaw/sub2api/issues/1515",
+      "title": "Gemini 403",
+      "impact": "unknown_low_signal",
+      "categories": [],
+      "tokenkey_status": "not_prioritized",
+      "rationale": "No high-signal production-risk keywords in this pass.",
+      "updated_at": "2026-05-12T19:07:05Z"
+    },
+    {
+      "upstream": "Wei-Shaw/sub2api#1518",
+      "url": "https://github.com/Wei-Shaw/sub2api/issues/1518",
+      "title": "feat 奸商",
+      "impact": "unknown_low_signal",
+      "categories": [],
+      "tokenkey_status": "not_prioritized",
+      "rationale": "No high-signal production-risk keywords in this pass.",
+      "updated_at": "2026-04-08T14:28:21Z"
+    },
+    {
+      "upstream": "Wei-Shaw/sub2api#1521",
+      "url": "https://github.com/Wei-Shaw/sub2api/issues/1521",
+      "title": "supabase 数据库的用户名校验不过",
+      "impact": "unknown_low_signal",
+      "categories": [],
+      "tokenkey_status": "not_prioritized",
+      "rationale": "No high-signal production-risk keywords in this pass.",
+      "updated_at": "2026-04-14T03:28:01Z"
+    },
+    {
+      "upstream": "Wei-Shaw/sub2api#1526",
+      "url": "https://github.com/Wei-Shaw/sub2api/issues/1526",
+      "title": "能否添加导入时选中分组",
+      "impact": "unknown_low_signal",
+      "categories": [],
+      "tokenkey_status": "not_prioritized",
+      "rationale": "No high-signal production-risk keywords in this pass.",
+      "updated_at": "2026-04-09T07:27:41Z"
+    },
+    {
+      "upstream": "Wei-Shaw/sub2api#1550",
+      "url": "https://github.com/Wei-Shaw/sub2api/issues/1550",
+      "title": "能否一键清理401 或者指定代码账号",
+      "impact": "unknown_low_signal",
+      "categories": [],
+      "tokenkey_status": "not_prioritized",
+      "rationale": "No high-signal production-risk keywords in this pass.",
+      "updated_at": "2026-04-10T20:48:57Z"
+    },
+    {
+      "upstream": "Wei-Shaw/sub2api#1561",
+      "url": "https://github.com/Wei-Shaw/sub2api/issues/1561",
+      "title": "小米mimo的OpenAI接口协议无法使用",
+      "impact": "unknown_low_signal",
+      "categories": [],
+      "tokenkey_status": "not_prioritized",
+      "rationale": "No high-signal production-risk keywords in this pass.",
+      "updated_at": "2026-04-16T10:53:29Z"
+    },
+    {
+      "upstream": "Wei-Shaw/sub2api#1564",
+      "url": "https://github.com/Wei-Shaw/sub2api/issues/1564",
+      "title": "Failed to exchange OpenAI auth code",
+      "impact": "unknown_low_signal",
+      "categories": [],
+      "tokenkey_status": "not_prioritized",
+      "rationale": "No high-signal production-risk keywords in this pass.",
+      "updated_at": "2026-04-19T15:12:41Z"
+    },
+    {
+      "upstream": "Wei-Shaw/sub2api#1566",
+      "url": "https://github.com/Wei-Shaw/sub2api/issues/1566",
+      "title": "Authentication failed (401) 问题",
+      "impact": "unknown_low_signal",
+      "categories": [],
+      "tokenkey_status": "not_prioritized",
+      "rationale": "No high-signal production-risk keywords in this pass.",
+      "updated_at": "2026-04-11T00:31:18Z"
+    },
+    {
+      "upstream": "Wei-Shaw/sub2api#1577",
+      "url": "https://github.com/Wei-Shaw/sub2api/issues/1577",
+      "title": "转发vllm的自定义模型的时候，第二次问题固定报错",
+      "impact": "unknown_low_signal",
+      "categories": [],
+      "tokenkey_status": "not_prioritized",
+      "rationale": "No high-signal production-risk keywords in this pass.",
+      "updated_at": "2026-04-11T14:50:06Z"
+    },
+    {
+      "upstream": "Wei-Shaw/sub2api#1582",
+      "url": "https://github.com/Wei-Shaw/sub2api/issues/1582",
+      "title": "codex 转 claude 模型映射有问题了......",
+      "impact": "unknown_low_signal",
+      "categories": [],
+      "tokenkey_status": "not_prioritized",
+      "rationale": "No high-signal production-risk keywords in this pass.",
+      "updated_at": "2026-04-14T01:33:08Z"
+    },
+    {
+      "upstream": "Wei-Shaw/sub2api#1583",
+      "url": "https://github.com/Wei-Shaw/sub2api/issues/1583",
+      "title": "工单系统",
+      "impact": "unknown_low_signal",
+      "categories": [],
+      "tokenkey_status": "not_prioritized",
+      "rationale": "No high-signal production-risk keywords in this pass.",
+      "updated_at": "2026-04-14T07:57:41Z"
+    },
+    {
+      "upstream": "Wei-Shaw/sub2api#1595",
+      "url": "https://github.com/Wei-Shaw/sub2api/issues/1595",
+      "title": "【请求增加新的需求】限制每个注册用户的每日使用额度",
+      "impact": "unknown_low_signal",
+      "categories": [],
+      "tokenkey_status": "not_prioritized",
+      "rationale": "No high-signal production-risk keywords in this pass.",
+      "updated_at": "2026-04-12T13:05:42Z"
+    },
+    {
+      "upstream": "Wei-Shaw/sub2api#1596",
+      "url": "https://github.com/Wei-Shaw/sub2api/issues/1596",
+      "title": "添加订阅套餐后，订阅管理看不到",
+      "impact": "unknown_low_signal",
+      "categories": [],
+      "tokenkey_status": "not_prioritized",
+      "rationale": "No high-signal production-risk keywords in this pass.",
+      "updated_at": "2026-04-12T12:32:18Z"
+    },
+    {
+      "upstream": "Wei-Shaw/sub2api#1597",
+      "url": "https://github.com/Wei-Shaw/sub2api/issues/1597",
+      "title": "支付 添加倍率",
+      "impact": "unknown_low_signal",
+      "categories": [],
+      "tokenkey_status": "not_prioritized",
+      "rationale": "No high-signal production-risk keywords in this pass.",
+      "updated_at": "2026-04-12T13:41:48Z"
+    },
+    {
+      "upstream": "Wei-Shaw/sub2api#1598",
+      "url": "https://github.com/Wei-Shaw/sub2api/issues/1598",
+      "title": "Codex升级了最新版本，连接不上，报错401",
+      "impact": "unknown_low_signal",
+      "categories": [],
+      "tokenkey_status": "not_prioritized",
+      "rationale": "No high-signal production-risk keywords in this pass.",
+      "updated_at": "2026-04-13T11:36:34Z"
+    },
+    {
+      "upstream": "Wei-Shaw/sub2api#1600",
+      "url": "https://github.com/Wei-Shaw/sub2api/issues/1600",
+      "title": "【BUG】stripe 支付报错",
+      "impact": "unknown_low_signal",
+      "categories": [],
+      "tokenkey_status": "not_prioritized",
+      "rationale": "No high-signal production-risk keywords in this pass.",
+      "updated_at": "2026-04-15T06:37:00Z"
+    },
+    {
+      "upstream": "Wei-Shaw/sub2api#1601",
+      "url": "https://github.com/Wei-Shaw/sub2api/issues/1601",
+      "title": "账号管理重复问题处理",
+      "impact": "unknown_low_signal",
+      "categories": [],
+      "tokenkey_status": "not_prioritized",
+      "rationale": "No high-signal production-risk keywords in this pass.",
+      "updated_at": "2026-04-13T09:04:42Z"
+    },
+    {
+      "upstream": "Wei-Shaw/sub2api#1620",
+      "url": "https://github.com/Wei-Shaw/sub2api/issues/1620",
+      "title": "0.1.111版本创建订阅套餐是否有bug，创建后订阅套餐界面不显示对应套餐",
+      "impact": "unknown_low_signal",
+      "categories": [],
+      "tokenkey_status": "not_prioritized",
+      "rationale": "No high-signal production-risk keywords in this pass.",
+      "updated_at": "2026-04-13T09:23:57Z"
+    },
+    {
+      "upstream": "Wei-Shaw/sub2api#1631",
+      "url": "https://github.com/Wei-Shaw/sub2api/issues/1631",
+      "title": "点击版本号无法更新",
+      "impact": "unknown_low_signal",
+      "categories": [],
+      "tokenkey_status": "not_prioritized",
+      "rationale": "No high-signal production-risk keywords in this pass.",
+      "updated_at": "2026-04-15T05:58:34Z"
+    },
+    {
+      "upstream": "Wei-Shaw/sub2api#1632",
+      "url": "https://github.com/Wei-Shaw/sub2api/issues/1632",
+      "title": "[feat] 用户管理增加功能",
+      "impact": "unknown_low_signal",
+      "categories": [],
+      "tokenkey_status": "not_prioritized",
+      "rationale": "No high-signal production-risk keywords in this pass.",
+      "updated_at": "2026-04-13T15:50:53Z"
+    },
+    {
+      "upstream": "Wei-Shaw/sub2api#1641",
+      "url": "https://github.com/Wei-Shaw/sub2api/issues/1641",
+      "title": "不能看到会员的秘钥 部分被***号替代了。维护不方便。",
+      "impact": "unknown_low_signal",
+      "categories": [],
+      "tokenkey_status": "not_prioritized",
+      "rationale": "No high-signal production-risk keywords in this pass.",
+      "updated_at": "2026-04-14T06:59:19Z"
+    },
+    {
+      "upstream": "Wei-Shaw/sub2api#1643",
+      "url": "https://github.com/Wei-Shaw/sub2api/issues/1643",
+      "title": "高并发",
+      "impact": "unknown_low_signal",
+      "categories": [],
+      "tokenkey_status": "not_prioritized",
+      "rationale": "No high-signal production-risk keywords in this pass.",
+      "updated_at": "2026-04-14T07:37:48Z"
+    },
+    {
+      "upstream": "Wei-Shaw/sub2api#1645",
+      "url": "https://github.com/Wei-Shaw/sub2api/issues/1645",
+      "title": "期望增加支付宝当面付渠道",
+      "impact": "unknown_low_signal",
+      "categories": [],
+      "tokenkey_status": "not_prioritized",
+      "rationale": "No high-signal production-risk keywords in this pass.",
+      "updated_at": "2026-04-15T09:14:30Z"
+    },
+    {
+      "upstream": "Wei-Shaw/sub2api#1648",
+      "url": "https://github.com/Wei-Shaw/sub2api/issues/1648",
+      "title": "接入别人家的new-api 测试无返回，但是是成功状态",
+      "impact": "unknown_low_signal",
+      "categories": [],
+      "tokenkey_status": "not_prioritized",
+      "rationale": "No high-signal production-risk keywords in this pass.",
+      "updated_at": "2026-04-25T02:15:06Z"
+    },
+    {
+      "upstream": "Wei-Shaw/sub2api#1649",
+      "url": "https://github.com/Wei-Shaw/sub2api/issues/1649",
+      "title": "售卖额度能否增加自定义商品额度，比如多少钱买多少额度，不要固定死一块钱一刀",
+      "impact": "unknown_low_signal",
+      "categories": [],
+      "tokenkey_status": "not_prioritized",
+      "rationale": "No high-signal production-risk keywords in this pass.",
+      "updated_at": "2026-04-14T13:02:31Z"
+    },
+    {
+      "upstream": "Wei-Shaw/sub2api#1664",
+      "url": "https://github.com/Wei-Shaw/sub2api/issues/1664",
+      "title": "当前支付宝官方支付渠道，支付宝APP扫码会跳转为网页收银台",
+      "impact": "unknown_low_signal",
+      "categories": [],
+      "tokenkey_status": "not_prioritized",
+      "rationale": "No high-signal production-risk keywords in this pass.",
+      "updated_at": "2026-05-12T15:56:14Z"
+    },
+    {
+      "upstream": "Wei-Shaw/sub2api#1671",
+      "url": "https://github.com/Wei-Shaw/sub2api/issues/1671",
+      "title": "sub2api啥时候可以支持支持自定义的三方provider呀 主要是openai的competition格式的接口的上游",
+      "impact": "unknown_low_signal",
+      "categories": [],
+      "tokenkey_status": "not_prioritized",
+      "rationale": "No high-signal production-risk keywords in this pass.",
+      "updated_at": "2026-04-15T08:50:43Z"
+    },
+    {
+      "upstream": "Wei-Shaw/sub2api#1673",
+      "url": "https://github.com/Wei-Shaw/sub2api/issues/1673",
+      "title": "web search 不能添加多个同样的服务商吗？",
+      "impact": "unknown_low_signal",
+      "categories": [],
+      "tokenkey_status": "not_prioritized",
+      "rationale": "No high-signal production-risk keywords in this pass.",
+      "updated_at": "2026-04-21T01:36:35Z"
+    },
+    {
+      "upstream": "Wei-Shaw/sub2api#1675",
+      "url": "https://github.com/Wei-Shaw/sub2api/issues/1675",
+      "title": "触发5h或者7d",
+      "impact": "unknown_low_signal",
+      "categories": [],
+      "tokenkey_status": "not_prioritized",
+      "rationale": "No high-signal production-risk keywords in this pass.",
+      "updated_at": "2026-04-15T11:30:35Z"
+    },
+    {
+      "upstream": "Wei-Shaw/sub2api#168",
+      "url": "https://github.com/Wei-Shaw/sub2api/issues/168",
+      "title": "v0.1.35可否增加一个更改模型名称的功能，以便于以cursor这个IDE中使用",
+      "impact": "unknown_low_signal",
+      "categories": [],
+      "tokenkey_status": "not_prioritized",
+      "rationale": "No high-signal production-risk keywords in this pass.",
+      "updated_at": "2026-01-05T13:35:12Z"
+    },
+    {
+      "upstream": "Wei-Shaw/sub2api#1685",
+      "url": "https://github.com/Wei-Shaw/sub2api/issues/1685",
+      "title": "feat: 增加上游请求超时配置化",
+      "impact": "unknown_low_signal",
+      "categories": [],
+      "tokenkey_status": "not_prioritized",
+      "rationale": "No high-signal production-risk keywords in this pass.",
+      "updated_at": "2026-04-15T17:21:04Z"
+    },
+    {
+      "upstream": "Wei-Shaw/sub2api#1686",
+      "url": "https://github.com/Wei-Shaw/sub2api/issues/1686",
+      "title": "feat：创建用户可配置5小时、7天限额、或者可自定义时间窗口限额",
+      "impact": "unknown_low_signal",
+      "categories": [],
+      "tokenkey_status": "not_prioritized",
+      "rationale": "No high-signal production-risk keywords in this pass.",
+      "updated_at": "2026-04-15T17:39:19Z"
+    },
+    {
+      "upstream": "Wei-Shaw/sub2api#1705",
+      "url": "https://github.com/Wei-Shaw/sub2api/issues/1705",
+      "title": "bug：账号管理列表调度开关切换无效、需要在编辑里切才有效",
+      "impact": "unknown_low_signal",
+      "categories": [],
+      "tokenkey_status": "not_prioritized",
+      "rationale": "No high-signal production-risk keywords in this pass.",
+      "updated_at": "2026-04-16T13:42:08Z"
+    },
+    {
+      "upstream": "Wei-Shaw/sub2api#1708",
+      "url": "https://github.com/Wei-Shaw/sub2api/issues/1708",
+      "title": "gpt账号等级无法正确显示，我的是plus但是显示free",
+      "impact": "unknown_low_signal",
+      "categories": [],
+      "tokenkey_status": "not_prioritized",
+      "rationale": "No high-signal production-risk keywords in this pass.",
+      "updated_at": "2026-04-17T09:52:36Z"
+    },
+    {
+      "upstream": "Wei-Shaw/sub2api#1709",
+      "url": "https://github.com/Wei-Shaw/sub2api/issues/1709",
+      "title": "[Bug] Gemini 账号 API Key 失效后未标记 error / 未自动停用",
+      "impact": "unknown_low_signal",
+      "categories": [],
+      "tokenkey_status": "not_prioritized",
+      "rationale": "No high-signal production-risk keywords in this pass.",
+      "updated_at": "2026-04-16T20:50:42Z"
+    },
+    {
+      "upstream": "Wei-Shaw/sub2api#1710",
+      "url": "https://github.com/Wei-Shaw/sub2api/issues/1710",
+      "title": "bug: 支付服务商实例关闭之后会变成空行，无法再打开",
+      "impact": "unknown_low_signal",
+      "categories": [],
+      "tokenkey_status": "not_prioritized",
+      "rationale": "No high-signal production-risk keywords in this pass.",
+      "updated_at": "2026-04-18T18:59:33Z"
+    },
+    {
+      "upstream": "Wei-Shaw/sub2api#1713",
+      "url": "https://github.com/Wei-Shaw/sub2api/issues/1713",
+      "title": "最新的claude opus 4.7怎么使用呢",
+      "impact": "unknown_low_signal",
+      "categories": [],
+      "tokenkey_status": "not_prioritized",
+      "rationale": "No high-signal production-risk keywords in this pass.",
+      "updated_at": "2026-04-17T05:58:39Z"
+    },
+    {
+      "upstream": "Wei-Shaw/sub2api#1714",
+      "url": "https://github.com/Wei-Shaw/sub2api/issues/1714",
+      "title": "AWS bedrock claude-opus-4-7 报错The provided model identifier is invalid.",
+      "impact": "unknown_low_signal",
+      "categories": [],
+      "tokenkey_status": "not_prioritized",
+      "rationale": "No high-signal production-risk keywords in this pass.",
+      "updated_at": "2026-04-17T05:58:37Z"
+    },
+    {
+      "upstream": "Wei-Shaw/sub2api#1720",
+      "url": "https://github.com/Wei-Shaw/sub2api/issues/1720",
+      "title": "不知道是哪里问题",
+      "impact": "unknown_low_signal",
+      "categories": [],
+      "tokenkey_status": "not_prioritized",
+      "rationale": "No high-signal production-risk keywords in this pass.",
+      "updated_at": "2026-04-21T09:52:37Z"
+    },
+    {
+      "upstream": "Wei-Shaw/sub2api#1727",
+      "url": "https://github.com/Wei-Shaw/sub2api/issues/1727",
+      "title": "左上角更新点了没有反应了，如何进行更新",
+      "impact": "unknown_low_signal",
+      "categories": [],
+      "tokenkey_status": "not_prioritized",
+      "rationale": "No high-signal production-risk keywords in this pass.",
+      "updated_at": "2026-04-17T11:09:13Z"
+    },
+    {
+      "upstream": "Wei-Shaw/sub2api#1729",
+      "url": "https://github.com/Wei-Shaw/sub2api/issues/1729",
+      "title": "增加用户查看分组可用模型",
+      "impact": "unknown_low_signal",
+      "categories": [],
+      "tokenkey_status": "not_prioritized",
+      "rationale": "No high-signal production-risk keywords in this pass.",
+      "updated_at": "2026-04-17T12:05:52Z"
+    },
+    {
+      "upstream": "Wei-Shaw/sub2api#1730",
+      "url": "https://github.com/Wei-Shaw/sub2api/issues/1730",
+      "title": "批量编辑账号没有临时不可调度选项",
+      "impact": "unknown_low_signal",
+      "categories": [],
+      "tokenkey_status": "not_prioritized",
+      "rationale": "No high-signal production-risk keywords in this pass.",
+      "updated_at": "2026-04-17T14:48:08Z"
+    },
+    {
+      "upstream": "Wei-Shaw/sub2api#1736",
+      "url": "https://github.com/Wei-Shaw/sub2api/issues/1736",
+      "title": "乱套了，全乱套了",
+      "impact": "unknown_low_signal",
+      "categories": [],
+      "tokenkey_status": "not_prioritized",
+      "rationale": "No high-signal production-risk keywords in this pass.",
+      "updated_at": "2026-04-18T09:05:05Z"
+    },
+    {
+      "upstream": "Wei-Shaw/sub2api#1737",
+      "url": "https://github.com/Wei-Shaw/sub2api/issues/1737",
+      "title": "不知道是不是bug",
+      "impact": "unknown_low_signal",
+      "categories": [],
+      "tokenkey_status": "not_prioritized",
+      "rationale": "No high-signal production-risk keywords in this pass.",
+      "updated_at": "2026-04-18T10:22:05Z"
+    },
+    {
+      "upstream": "Wei-Shaw/sub2api#1738",
+      "url": "https://github.com/Wei-Shaw/sub2api/issues/1738",
+      "title": "最新版 v0.1.114 貌似有并发判定 bug",
+      "impact": "unknown_low_signal",
+      "categories": [],
+      "tokenkey_status": "not_prioritized",
+      "rationale": "No high-signal production-risk keywords in this pass.",
+      "updated_at": "2026-05-13T06:31:27Z"
+    },
+    {
+      "upstream": "Wei-Shaw/sub2api#1741",
+      "url": "https://github.com/Wei-Shaw/sub2api/issues/1741",
+      "title": "sub2api如何才能进行参数覆盖",
+      "impact": "unknown_low_signal",
+      "categories": [],
+      "tokenkey_status": "not_prioritized",
+      "rationale": "No high-signal production-risk keywords in this pass.",
+      "updated_at": "2026-04-18T16:31:35Z"
+    },
+    {
+      "upstream": "Wei-Shaw/sub2api#1744",
+      "url": "https://github.com/Wei-Shaw/sub2api/issues/1744",
+      "title": "Codex刷新令牌没效果",
+      "impact": "unknown_low_signal",
+      "categories": [],
+      "tokenkey_status": "not_prioritized",
+      "rationale": "No high-signal production-risk keywords in this pass.",
+      "updated_at": "2026-05-05T09:14:45Z"
+    },
+    {
+      "upstream": "Wei-Shaw/sub2api#1761",
+      "url": "https://github.com/Wei-Shaw/sub2api/issues/1761",
+      "title": "扩展支付通道",
+      "impact": "unknown_low_signal",
+      "categories": [],
+      "tokenkey_status": "not_prioritized",
+      "rationale": "No high-signal production-risk keywords in this pass.",
+      "updated_at": "2026-04-27T18:50:04Z"
+    },
+    {
+      "upstream": "Wei-Shaw/sub2api#1768",
+      "url": "https://github.com/Wei-Shaw/sub2api/issues/1768",
+      "title": "feat：支持不同类型的余额账户做隔离",
+      "impact": "unknown_low_signal",
+      "categories": [],
+      "tokenkey_status": "not_prioritized",
+      "rationale": "No high-signal production-risk keywords in this pass.",
+      "updated_at": "2026-04-20T17:37:21Z"
+    },
+    {
+      "upstream": "Wei-Shaw/sub2api#177",
+      "url": "https://github.com/Wei-Shaw/sub2api/issues/177",
+      "title": "用户创建过的key，如果上层改变了用户分组，key还是可以用公共池",
+      "impact": "unknown_low_signal",
+      "categories": [],
+      "tokenkey_status": "not_prioritized",
+      "rationale": "No high-signal production-risk keywords in this pass.",
+      "updated_at": "2026-01-06T06:38:23Z"
+    },
+    {
+      "upstream": "Wei-Shaw/sub2api#1773",
+      "url": "https://github.com/Wei-Shaw/sub2api/issues/1773",
+      "title": "Trae 国际版如何接入 Sub2API ？有谁试过吗？",
+      "impact": "unknown_low_signal",
+      "categories": [],
+      "tokenkey_status": "not_prioritized",
+      "rationale": "No high-signal production-risk keywords in this pass.",
+      "updated_at": "2026-04-29T09:27:20Z"
+    },
+    {
+      "upstream": "Wei-Shaw/sub2api#1774",
+      "url": "https://github.com/Wei-Shaw/sub2api/issues/1774",
+      "title": "想问下， 增加了代理之后， 可以将sub2api部署在aliyun么？",
+      "impact": "unknown_low_signal",
+      "categories": [],
+      "tokenkey_status": "not_prioritized",
+      "rationale": "No high-signal production-risk keywords in this pass.",
+      "updated_at": "2026-04-22T05:55:19Z"
+    },
+    {
+      "upstream": "Wei-Shaw/sub2api#1775",
+      "url": "https://github.com/Wei-Shaw/sub2api/issues/1775",
+      "title": "GLM coding plan怎么接入？",
+      "impact": "unknown_low_signal",
+      "categories": [],
+      "tokenkey_status": "not_prioritized",
+      "rationale": "No high-signal production-risk keywords in this pass.",
+      "updated_at": "2026-05-13T11:03:22Z"
+    },
+    {
+      "upstream": "Wei-Shaw/sub2api#1778",
+      "url": "https://github.com/Wei-Shaw/sub2api/issues/1778",
+      "title": "feat: support windsurf API",
+      "impact": "unknown_low_signal",
+      "categories": [],
+      "tokenkey_status": "not_prioritized",
+      "rationale": "No high-signal production-risk keywords in this pass.",
+      "updated_at": "2026-04-21T04:24:34Z"
+    },
+    {
+      "upstream": "Wei-Shaw/sub2api#1782",
+      "url": "https://github.com/Wei-Shaw/sub2api/issues/1782",
+      "title": "给 TOTP 二维码/验证器的 issuer 支持自定义站点名，避免写死成 Sub2API",
+      "impact": "unknown_low_signal",
+      "categories": [],
+      "tokenkey_status": "not_prioritized",
+      "rationale": "No high-signal production-risk keywords in this pass.",
+      "updated_at": "2026-04-21T11:17:52Z"
+    },
+    {
+      "upstream": "Wei-Shaw/sub2api#1783",
+      "url": "https://github.com/Wei-Shaw/sub2api/issues/1783",
+      "title": "更多 - 定时测试反人类",
+      "impact": "unknown_low_signal",
+      "categories": [],
+      "tokenkey_status": "not_prioritized",
+      "rationale": "No high-signal production-risk keywords in this pass.",
+      "updated_at": "2026-04-21T13:42:54Z"
+    },
+    {
+      "upstream": "Wei-Shaw/sub2api#1791",
+      "url": "https://github.com/Wei-Shaw/sub2api/issues/1791",
+      "title": "Bug: Tooltip position is incorrect after scrolling",
+      "impact": "unknown_low_signal",
+      "categories": [],
+      "tokenkey_status": "not_prioritized",
+      "rationale": "No high-signal production-risk keywords in this pass.",
+      "updated_at": "2026-04-22T03:30:36Z"
+    },
+    {
+      "upstream": "Wei-Shaw/sub2api#1794",
+      "url": "https://github.com/Wei-Shaw/sub2api/issues/1794",
+      "title": "gpt-5.5来了，适配下呗",
+      "impact": "unknown_low_signal",
+      "categories": [],
+      "tokenkey_status": "not_prioritized",
+      "rationale": "No high-signal production-risk keywords in this pass.",
+      "updated_at": "2026-04-22T09:17:58Z"
+    },
+    {
+      "upstream": "Wei-Shaw/sub2api#1797",
+      "url": "https://github.com/Wei-Shaw/sub2api/issues/1797",
+      "title": "扩展功能",
+      "impact": "unknown_low_signal",
+      "categories": [],
+      "tokenkey_status": "not_prioritized",
+      "rationale": "No high-signal production-risk keywords in this pass.",
+      "updated_at": "2026-04-22T14:29:29Z"
+    },
+    {
+      "upstream": "Wei-Shaw/sub2api#1808",
+      "url": "https://github.com/Wei-Shaw/sub2api/issues/1808",
+      "title": "docker compose部署之后配置阿里云邮件推送没有办法连接到",
+      "impact": "unknown_low_signal",
+      "categories": [],
+      "tokenkey_status": "not_prioritized",
+      "rationale": "No high-signal production-risk keywords in this pass.",
+      "updated_at": "2026-04-22T13:47:05Z"
+    },
+    {
+      "upstream": "Wei-Shaw/sub2api#181",
+      "url": "https://github.com/Wei-Shaw/sub2api/issues/181",
+      "title": "v0.1.39登录后就session过期",
+      "impact": "unknown_low_signal",
+      "categories": [],
+      "tokenkey_status": "not_prioritized",
+      "rationale": "No high-signal production-risk keywords in this pass.",
+      "updated_at": "2026-04-12T05:28:56Z"
+    },
+    {
+      "upstream": "Wei-Shaw/sub2api#1816",
+      "url": "https://github.com/Wei-Shaw/sub2api/issues/1816",
+      "title": "sub2的iimage2你们怎么配置的？",
+      "impact": "unknown_low_signal",
+      "categories": [],
+      "tokenkey_status": "not_prioritized",
+      "rationale": "No high-signal production-risk keywords in this pass.",
+      "updated_at": "2026-05-13T19:13:22Z"
+    },
+    {
+      "upstream": "Wei-Shaw/sub2api#1820",
+      "url": "https://github.com/Wei-Shaw/sub2api/issues/1820",
+      "title": "Claude Cli 新版本接入国产模型，高频报错InvalidEncryptedContent",
+      "impact": "unknown_low_signal",
+      "categories": [],
+      "tokenkey_status": "not_prioritized",
+      "rationale": "No high-signal production-risk keywords in this pass.",
+      "updated_at": "2026-04-23T10:26:43Z"
+    },
+    {
+      "upstream": "Wei-Shaw/sub2api#1832",
+      "url": "https://github.com/Wei-Shaw/sub2api/issues/1832",
+      "title": "Antigravity 测试没有返回响应",
+      "impact": "unknown_low_signal",
+      "categories": [],
+      "tokenkey_status": "not_prioritized",
+      "rationale": "No high-signal production-risk keywords in this pass.",
+      "updated_at": "2026-04-23T06:02:30Z"
+    },
+    {
+      "upstream": "Wei-Shaw/sub2api#1835",
+      "url": "https://github.com/Wei-Shaw/sub2api/issues/1835",
+      "title": "IP管理池中能否实际自动分配每个账号的代理IP？",
+      "impact": "unknown_low_signal",
+      "categories": [],
+      "tokenkey_status": "not_prioritized",
+      "rationale": "No high-signal production-risk keywords in this pass.",
+      "updated_at": "2026-04-23T06:56:57Z"
+    },
+    {
+      "upstream": "Wei-Shaw/sub2api#1837",
+      "url": "https://github.com/Wei-Shaw/sub2api/issues/1837",
+      "title": "如何在每次调用之前，自动或强制制定系统提示词。",
+      "impact": "unknown_low_signal",
+      "categories": [],
+      "tokenkey_status": "not_prioritized",
+      "rationale": "No high-signal production-risk keywords in this pass.",
+      "updated_at": "2026-04-28T11:21:32Z"
+    },
+    {
+      "upstream": "Wei-Shaw/sub2api#1839",
+      "url": "https://github.com/Wei-Shaw/sub2api/issues/1839",
+      "title": "v0.1.114版本给key重置限额不管用",
+      "impact": "unknown_low_signal",
+      "categories": [],
+      "tokenkey_status": "not_prioritized",
+      "rationale": "No high-signal production-risk keywords in this pass.",
+      "updated_at": "2026-04-23T08:14:41Z"
+    },
+    {
+      "upstream": "Wei-Shaw/sub2api#1841",
+      "url": "https://github.com/Wei-Shaw/sub2api/issues/1841",
+      "title": "OpenAI Key 仅允许 Codex 官方客户端",
+      "impact": "unknown_low_signal",
+      "categories": [],
+      "tokenkey_status": "not_prioritized",
+      "rationale": "No high-signal production-risk keywords in this pass.",
+      "updated_at": "2026-04-23T08:50:18Z"
+    },
+    {
+      "upstream": "Wei-Shaw/sub2api#1843",
+      "url": "https://github.com/Wei-Shaw/sub2api/issues/1843",
+      "title": "v0.1.115使用Codex会频繁出现Codex ran out of room in the model's context window. Start a new thread or clear earlier history before retrying.",
+      "impact": "unknown_low_signal",
+      "categories": [],
+      "tokenkey_status": "not_prioritized",
+      "rationale": "No high-signal production-risk keywords in this pass.",
+      "updated_at": "2026-04-23T15:23:04Z"
+    },
+    {
+      "upstream": "Wei-Shaw/sub2api#1845",
+      "url": "https://github.com/Wei-Shaw/sub2api/issues/1845",
+      "title": "为什么请求的image模型都映射到5.4上了 实际没配置任何映射",
+      "impact": "unknown_low_signal",
+      "categories": [],
+      "tokenkey_status": "not_prioritized",
+      "rationale": "No high-signal production-risk keywords in this pass.",
+      "updated_at": "2026-04-23T14:10:57Z"
+    },
+    {
+      "upstream": "Wei-Shaw/sub2api#1851",
+      "url": "https://github.com/Wei-Shaw/sub2api/issues/1851",
+      "title": "【0.1.116】【bug】转发 OpenAI 服务不可用 - 接入的是 newapi 的接口",
+      "impact": "unknown_low_signal",
+      "categories": [],
+      "tokenkey_status": "not_prioritized",
+      "rationale": "No high-signal production-risk keywords in this pass.",
+      "updated_at": "2026-04-25T02:13:17Z"
+    },
+    {
+      "upstream": "Wei-Shaw/sub2api#1852",
+      "url": "https://github.com/Wei-Shaw/sub2api/issues/1852",
+      "title": "GPT5.5崩了？？？",
+      "impact": "unknown_low_signal",
+      "categories": [],
+      "tokenkey_status": "not_prioritized",
+      "rationale": "No high-signal production-risk keywords in this pass.",
+      "updated_at": "2026-04-24T23:11:38Z"
+    },
+    {
+      "upstream": "Wei-Shaw/sub2api#1855",
+      "url": "https://github.com/Wei-Shaw/sub2api/issues/1855",
+      "title": "有增加github copilot 订阅的计划吗",
+      "impact": "unknown_low_signal",
+      "categories": [],
+      "tokenkey_status": "not_prioritized",
+      "rationale": "No high-signal production-risk keywords in this pass.",
+      "updated_at": "2026-04-24T02:56:55Z"
+    },
+    {
+      "upstream": "Wei-Shaw/sub2api#186",
+      "url": "https://github.com/Wei-Shaw/sub2api/issues/186",
+      "title": "订阅和余额能否区分开不同类型的余额",
+      "impact": "unknown_low_signal",
+      "categories": [],
+      "tokenkey_status": "not_prioritized",
+      "rationale": "No high-signal production-risk keywords in this pass.",
+      "updated_at": "2026-01-06T16:20:21Z"
+    },
+    {
+      "upstream": "Wei-Shaw/sub2api#1860",
+      "url": "https://github.com/Wei-Shaw/sub2api/issues/1860",
+      "title": "能否在账号配置添加 其他Endpoint端点支持？例如/v1/chat/completions",
+      "impact": "unknown_low_signal",
+      "categories": [],
+      "tokenkey_status": "not_prioritized",
+      "rationale": "No high-signal production-risk keywords in this pass.",
+      "updated_at": "2026-04-24T01:16:25Z"
+    },
+    {
+      "upstream": "Wei-Shaw/sub2api#1862",
+      "url": "https://github.com/Wei-Shaw/sub2api/issues/1862",
+      "title": "可以考虑支持国产的 GLM，kimi, minimax， 以及更好的海外的 API 支持吗？",
+      "impact": "unknown_low_signal",
+      "categories": [],
+      "tokenkey_status": "not_prioritized",
+      "rationale": "No high-signal production-risk keywords in this pass.",
+      "updated_at": "2026-04-24T02:02:08Z"
+    },
+    {
+      "upstream": "Wei-Shaw/sub2api#1864",
+      "url": "https://github.com/Wei-Shaw/sub2api/issues/1864",
+      "title": "测试失败: 解析响应 JSON 失败: Exception generated by QuickJS",
+      "impact": "unknown_low_signal",
+      "categories": [],
+      "tokenkey_status": "not_prioritized",
+      "rationale": "No high-signal production-risk keywords in this pass.",
+      "updated_at": "2026-04-24T01:59:57Z"
+    },
+    {
+      "upstream": "Wei-Shaw/sub2api#1867",
+      "url": "https://github.com/Wei-Shaw/sub2api/issues/1867",
+      "title": "将openai模型精简一些，对齐codex",
+      "impact": "unknown_low_signal",
+      "categories": [],
+      "tokenkey_status": "not_prioritized",
+      "rationale": "No high-signal production-risk keywords in this pass.",
+      "updated_at": "2026-04-25T01:20:08Z"
+    },
+    {
+      "upstream": "Wei-Shaw/sub2api#1868",
+      "url": "https://github.com/Wei-Shaw/sub2api/issues/1868",
+      "title": "更新之后 自定义菜单栏的 url链接无预览了",
+      "impact": "unknown_low_signal",
+      "categories": [],
+      "tokenkey_status": "not_prioritized",
+      "rationale": "No high-signal production-risk keywords in this pass.",
+      "updated_at": "2026-04-24T02:36:06Z"
+    },
+    {
+      "upstream": "Wei-Shaw/sub2api#1869",
+      "url": "https://github.com/Wei-Shaw/sub2api/issues/1869",
+      "title": "使用了GPT-5.5 出现这个Invalid value: 'tool'. Supported values are: 'assistant问题很频繁",
+      "impact": "unknown_low_signal",
+      "categories": [],
+      "tokenkey_status": "not_prioritized",
+      "rationale": "No high-signal production-risk keywords in this pass.",
+      "updated_at": "2026-04-24T02:38:52Z"
+    },
+    {
+      "upstream": "Wei-Shaw/sub2api#187",
+      "url": "https://github.com/Wei-Shaw/sub2api/issues/187",
+      "title": "输出中断",
+      "impact": "unknown_low_signal",
+      "categories": [],
+      "tokenkey_status": "not_prioritized",
+      "rationale": "No high-signal production-risk keywords in this pass.",
+      "updated_at": "2026-03-31T03:05:18Z"
+    },
+    {
+      "upstream": "Wei-Shaw/sub2api#1873",
+      "url": "https://github.com/Wei-Shaw/sub2api/issues/1873",
+      "title": "cursor 无法调用工具写代码",
+      "impact": "unknown_low_signal",
+      "categories": [],
+      "tokenkey_status": "not_prioritized",
+      "rationale": "No high-signal production-risk keywords in this pass.",
+      "updated_at": "2026-05-07T13:43:47Z"
+    },
+    {
+      "upstream": "Wei-Shaw/sub2api#1874",
+      "url": "https://github.com/Wei-Shaw/sub2api/issues/1874",
+      "title": "Unknown parameter: 'input[19].call_id'.",
+      "impact": "unknown_low_signal",
+      "categories": [],
+      "tokenkey_status": "not_prioritized",
+      "rationale": "No high-signal production-risk keywords in this pass.",
+      "updated_at": "2026-04-24T13:45:59Z"
+    },
+    {
+      "upstream": "Wei-Shaw/sub2api#1875",
+      "url": "https://github.com/Wei-Shaw/sub2api/issues/1875",
+      "title": "这样算用上5.5了吗",
+      "impact": "unknown_low_signal",
+      "categories": [],
+      "tokenkey_status": "not_prioritized",
+      "rationale": "No high-signal production-risk keywords in this pass.",
+      "updated_at": "2026-04-24T05:53:25Z"
+    },
+    {
+      "upstream": "Wei-Shaw/sub2api#1877",
+      "url": "https://github.com/Wei-Shaw/sub2api/issues/1877",
+      "title": "疑问：更新了在codex中为什么没有gpt-5.5的？",
+      "impact": "unknown_low_signal",
+      "categories": [],
+      "tokenkey_status": "not_prioritized",
+      "rationale": "No high-signal production-risk keywords in this pass.",
+      "updated_at": "2026-04-25T14:22:10Z"
+    },
+    {
+      "upstream": "Wei-Shaw/sub2api#1884",
+      "url": "https://github.com/Wei-Shaw/sub2api/issues/1884",
+      "title": "啥时候支持 GPT5.5 和快速模式啊",
+      "impact": "unknown_low_signal",
+      "categories": [],
+      "tokenkey_status": "not_prioritized",
+      "rationale": "No high-signal production-risk keywords in this pass.",
+      "updated_at": "2026-04-24T06:06:51Z"
+    },
+    {
+      "upstream": "Wei-Shaw/sub2api#1898",
+      "url": "https://github.com/Wei-Shaw/sub2api/issues/1898",
+      "title": "哪里有便宜的plus和team可以蹬啊",
+      "impact": "unknown_low_signal",
+      "categories": [],
+      "tokenkey_status": "not_prioritized",
+      "rationale": "No high-signal production-risk keywords in this pass.",
+      "updated_at": "2026-04-24T09:02:02Z"
+    },
+    {
+      "upstream": "Wei-Shaw/sub2api#1901",
+      "url": "https://github.com/Wei-Shaw/sub2api/issues/1901",
+      "title": "[BUG] codex提示⚠ Model metadata for `gpt-5.5` not found. Defaulting to fallback metadata; this can degrade performance and cause issues.",
+      "impact": "unknown_low_signal",
+      "categories": [],
+      "tokenkey_status": "not_prioritized",
+      "rationale": "No high-signal production-risk keywords in this pass.",
+      "updated_at": "2026-04-24T13:16:14Z"
+    },
+    {
+      "upstream": "Wei-Shaw/sub2api#191",
+      "url": "https://github.com/Wei-Shaw/sub2api/issues/191",
+      "title": "能否指导下如何在cursor如使sub2api转发的模型",
+      "impact": "unknown_low_signal",
+      "categories": [],
+      "tokenkey_status": "not_prioritized",
+      "rationale": "No high-signal production-risk keywords in this pass.",
+      "updated_at": "2026-03-20T03:06:06Z"
+    },
+    {
+      "upstream": "Wei-Shaw/sub2api#1916",
+      "url": "https://github.com/Wei-Shaw/sub2api/issues/1916",
+      "title": "渠道状态会出现超出卡片问题",
+      "impact": "unknown_low_signal",
+      "categories": [],
+      "tokenkey_status": "not_prioritized",
+      "rationale": "No high-signal production-risk keywords in this pass.",
+      "updated_at": "2026-04-24T17:00:35Z"
+    },
+    {
+      "upstream": "Wei-Shaw/sub2api#1929",
+      "url": "https://github.com/Wei-Shaw/sub2api/issues/1929",
+      "title": "gpt5.5 一直调用失败",
+      "impact": "unknown_low_signal",
+      "categories": [],
+      "tokenkey_status": "not_prioritized",
+      "rationale": "No high-signal production-risk keywords in this pass.",
+      "updated_at": "2026-04-25T06:33:16Z"
+    },
+    {
+      "upstream": "Wei-Shaw/sub2api#193",
+      "url": "https://github.com/Wei-Shaw/sub2api/issues/193",
+      "title": "bad response status code 413 还是有这个bug",
+      "impact": "unknown_low_signal",
+      "categories": [],
+      "tokenkey_status": "not_prioritized",
+      "rationale": "No high-signal production-risk keywords in this pass.",
+      "updated_at": "2026-03-27T11:12:58Z"
+    },
+    {
+      "upstream": "Wei-Shaw/sub2api#1945",
+      "url": "https://github.com/Wei-Shaw/sub2api/issues/1945",
+      "title": "gpt-5.5 模型不支持 cli",
+      "impact": "unknown_low_signal",
+      "categories": [],
+      "tokenkey_status": "not_prioritized",
+      "rationale": "No high-signal production-risk keywords in this pass.",
+      "updated_at": "2026-04-25T10:56:57Z"
+    },
+    {
+      "upstream": "Wei-Shaw/sub2api#1951",
+      "url": "https://github.com/Wei-Shaw/sub2api/issues/1951",
+      "title": "Claude 反代后WebSearch无法使用",
+      "impact": "unknown_low_signal",
+      "categories": [],
+      "tokenkey_status": "not_prioritized",
+      "rationale": "No high-signal production-risk keywords in this pass.",
+      "updated_at": "2026-04-25T09:47:36Z"
+    },
+    {
+      "upstream": "Wei-Shaw/sub2api#1972",
+      "url": "https://github.com/Wei-Shaw/sub2api/issues/1972",
+      "title": "GPT一直空回答",
+      "impact": "unknown_low_signal",
+      "categories": [],
+      "tokenkey_status": "not_prioritized",
+      "rationale": "No high-signal production-risk keywords in this pass.",
+      "updated_at": "2026-04-25T17:49:15Z"
+    },
+    {
+      "upstream": "Wei-Shaw/sub2api#1983",
+      "url": "https://github.com/Wei-Shaw/sub2api/issues/1983",
+      "title": "邀请返利额度转余额：新用户使用邀请人的邀请码注册后。 新用户利用 （兑换码）进行充值后，邀请人没有可转入额度",
+      "impact": "unknown_low_signal",
+      "categories": [],
+      "tokenkey_status": "not_prioritized",
+      "rationale": "No high-signal production-risk keywords in this pass.",
+      "updated_at": "2026-05-04T03:16:10Z"
+    },
+    {
+      "upstream": "Wei-Shaw/sub2api#1984",
+      "url": "https://github.com/Wei-Shaw/sub2api/issues/1984",
+      "title": "{\"detail\":\"The 'gpt-5.5' model is not supported when using Codex with a ChatGPT account.\"}",
+      "impact": "unknown_low_signal",
+      "categories": [],
+      "tokenkey_status": "not_prioritized",
+      "rationale": "No high-signal production-risk keywords in this pass.",
+      "updated_at": "2026-04-26T13:59:24Z"
+    },
+    {
+      "upstream": "Wei-Shaw/sub2api#1988",
+      "url": "https://github.com/Wei-Shaw/sub2api/issues/1988",
+      "title": "gpt-5.5 fast服务档位的默认2x倍率错误，应该为2.5x倍率",
+      "impact": "unknown_low_signal",
+      "categories": [],
+      "tokenkey_status": "not_prioritized",
+      "rationale": "No high-signal production-risk keywords in this pass.",
+      "updated_at": "2026-04-26T05:51:50Z"
+    },
+    {
+      "upstream": "Wei-Shaw/sub2api#1991",
+      "url": "https://github.com/Wei-Shaw/sub2api/issues/1991",
+      "title": "支付方式能添加区块链的支付方式么比如bsc，sol，eth",
+      "impact": "unknown_low_signal",
+      "categories": [],
+      "tokenkey_status": "not_prioritized",
+      "rationale": "No high-signal production-risk keywords in this pass.",
+      "updated_at": "2026-04-27T11:07:01Z"
+    },
+    {
+      "upstream": "Wei-Shaw/sub2api#1993",
+      "url": "https://github.com/Wei-Shaw/sub2api/issues/1993",
+      "title": "能添加 webhook 功能来全量替换邮件的消息提醒功能么, 这样接入可能更方便一些",
+      "impact": "unknown_low_signal",
+      "categories": [],
+      "tokenkey_status": "not_prioritized",
+      "rationale": "No high-signal production-risk keywords in this pass.",
+      "updated_at": "2026-04-26T11:23:33Z"
+    },
+    {
+      "upstream": "Wei-Shaw/sub2api#2011",
+      "url": "https://github.com/Wei-Shaw/sub2api/issues/2011",
+      "title": "为什么用户还能负余额？",
+      "impact": "unknown_low_signal",
+      "categories": [],
+      "tokenkey_status": "not_prioritized",
+      "rationale": "No high-signal production-risk keywords in this pass.",
+      "updated_at": "2026-04-27T02:11:40Z"
+    },
+    {
+      "upstream": "Wei-Shaw/sub2api#202",
+      "url": "https://github.com/Wei-Shaw/sub2api/issues/202",
+      "title": "【特性请求】是否有支持kiro接入的计划？",
+      "impact": "unknown_low_signal",
+      "categories": [],
+      "tokenkey_status": "not_prioritized",
+      "rationale": "No high-signal production-risk keywords in this pass.",
+      "updated_at": "2026-02-27T06:50:25Z"
+    },
+    {
+      "upstream": "Wei-Shaw/sub2api#2024",
+      "url": "https://github.com/Wei-Shaw/sub2api/issues/2024",
+      "title": "Google one 授权后，测试链接提示403",
+      "impact": "unknown_low_signal",
+      "categories": [],
+      "tokenkey_status": "not_prioritized",
+      "rationale": "No high-signal production-risk keywords in this pass.",
+      "updated_at": "2026-05-11T09:51:27Z"
+    },
+    {
+      "upstream": "Wei-Shaw/sub2api#2025",
+      "url": "https://github.com/Wei-Shaw/sub2api/issues/2025",
+      "title": "一个分组调用错误bug",
+      "impact": "unknown_low_signal",
+      "categories": [],
+      "tokenkey_status": "not_prioritized",
+      "rationale": "No high-signal production-risk keywords in this pass.",
+      "updated_at": "2026-04-27T07:04:29Z"
+    },
+    {
+      "upstream": "Wei-Shaw/sub2api#2032",
+      "url": "https://github.com/Wei-Shaw/sub2api/issues/2032",
+      "title": "Bug: subscription plan cards show Antigravity model scopes for OpenAI groups",
+      "impact": "unknown_low_signal",
+      "categories": [],
+      "tokenkey_status": "not_prioritized",
+      "rationale": "No high-signal production-risk keywords in this pass.",
+      "updated_at": "2026-04-27T11:00:19Z"
+    },
+    {
+      "upstream": "Wei-Shaw/sub2api#2039",
+      "url": "https://github.com/Wei-Shaw/sub2api/issues/2039",
+      "title": "能否让Claudecode调用codex的模型,对协议进行转换",
+      "impact": "unknown_low_signal",
+      "categories": [],
+      "tokenkey_status": "not_prioritized",
+      "rationale": "No high-signal production-risk keywords in this pass.",
+      "updated_at": "2026-04-28T09:45:31Z"
+    },
+    {
+      "upstream": "Wei-Shaw/sub2api#2046",
+      "url": "https://github.com/Wei-Shaw/sub2api/issues/2046",
+      "title": "订阅问题",
+      "impact": "unknown_low_signal",
+      "categories": [],
+      "tokenkey_status": "not_prioritized",
+      "rationale": "No high-signal production-risk keywords in this pass.",
+      "updated_at": "2026-04-28T01:53:08Z"
+    },
+    {
+      "upstream": "Wei-Shaw/sub2api#2071",
+      "url": "https://github.com/Wei-Shaw/sub2api/issues/2071",
+      "title": "号池能否支持一下国模和中转站,比如minimax,接入newapi,sub2api,毕竟gpt封号严重没得用了",
+      "impact": "unknown_low_signal",
+      "categories": [],
+      "tokenkey_status": "not_prioritized",
+      "rationale": "No high-signal production-risk keywords in this pass.",
+      "updated_at": "2026-04-29T03:52:45Z"
+    },
+    {
+      "upstream": "Wei-Shaw/sub2api#2084",
+      "url": "https://github.com/Wei-Shaw/sub2api/issues/2084",
+      "title": "什么时候支持openai 平台 添加 aws bedrock 上的openai gpt-5.5 模型",
+      "impact": "unknown_low_signal",
+      "categories": [],
+      "tokenkey_status": "not_prioritized",
+      "rationale": "No high-signal production-risk keywords in this pass.",
+      "updated_at": "2026-04-29T03:01:32Z"
+    },
+    {
+      "upstream": "Wei-Shaw/sub2api#2086",
+      "url": "https://github.com/Wei-Shaw/sub2api/issues/2086",
+      "title": "/v1/chat/completions 模型名字不会自动映射思考强度",
+      "impact": "unknown_low_signal",
+      "categories": [],
+      "tokenkey_status": "not_prioritized",
+      "rationale": "No high-signal production-risk keywords in this pass.",
+      "updated_at": "2026-05-02T11:56:00Z"
+    },
+    {
+      "upstream": "Wei-Shaw/sub2api#209",
+      "url": "https://github.com/Wei-Shaw/sub2api/issues/209",
+      "title": "频繁出现账号显示错误 但是刷新重置状态就好了",
+      "impact": "unknown_low_signal",
+      "categories": [],
+      "tokenkey_status": "not_prioritized",
+      "rationale": "No high-signal production-risk keywords in this pass.",
+      "updated_at": "2026-01-10T08:15:41Z"
+    },
+    {
+      "upstream": "Wei-Shaw/sub2api#2093",
+      "url": "https://github.com/Wei-Shaw/sub2api/issues/2093",
+      "title": "gpt-5.5 为什么在codex或者codex app上显示5.4模型",
+      "impact": "unknown_low_signal",
+      "categories": [],
+      "tokenkey_status": "not_prioritized",
+      "rationale": "No high-signal production-risk keywords in this pass.",
+      "updated_at": "2026-04-30T12:29:50Z"
+    },
+    {
+      "upstream": "Wei-Shaw/sub2api#2097",
+      "url": "https://github.com/Wei-Shaw/sub2api/issues/2097",
+      "title": "微信支付中，能否增加平台证书的验签方式",
+      "impact": "unknown_low_signal",
+      "categories": [],
+      "tokenkey_status": "not_prioritized",
+      "rationale": "No high-signal production-risk keywords in this pass.",
+      "updated_at": "2026-04-29T08:32:27Z"
+    },
+    {
+      "upstream": "Wei-Shaw/sub2api#2099",
+      "url": "https://github.com/Wei-Shaw/sub2api/issues/2099",
+      "title": "平台太少，可以支持deepseek、质谱、通义千问、豆包、华为盘古大模型等主流国产模型吗？",
+      "impact": "unknown_low_signal",
+      "categories": [],
+      "tokenkey_status": "not_prioritized",
+      "rationale": "No high-signal production-risk keywords in this pass.",
+      "updated_at": "2026-05-01T05:40:04Z"
+    },
+    {
+      "upstream": "Wei-Shaw/sub2api#2106",
+      "url": "https://github.com/Wei-Shaw/sub2api/issues/2106",
+      "title": "生成兑换码 有效天数 能否不限制365天？",
+      "impact": "unknown_low_signal",
+      "categories": [],
+      "tokenkey_status": "not_prioritized",
+      "rationale": "No high-signal production-risk keywords in this pass.",
+      "updated_at": "2026-04-29T15:45:17Z"
+    },
+    {
+      "upstream": "Wei-Shaw/sub2api#2110",
+      "url": "https://github.com/Wei-Shaw/sub2api/issues/2110",
+      "title": "能否支持chatgpt文字转语音功能",
+      "impact": "unknown_low_signal",
+      "categories": [],
+      "tokenkey_status": "not_prioritized",
+      "rationale": "No high-signal production-risk keywords in this pass.",
+      "updated_at": "2026-05-04T14:04:08Z"
+    },
+    {
+      "upstream": "Wei-Shaw/sub2api#2113",
+      "url": "https://github.com/Wei-Shaw/sub2api/issues/2113",
+      "title": "奇葩问题，排查了一天都没有找到哪里设置有问题。错误码400：Instructions are required",
+      "impact": "unknown_low_signal",
+      "categories": [],
+      "tokenkey_status": "not_prioritized",
+      "rationale": "No high-signal production-risk keywords in this pass.",
+      "updated_at": "2026-05-11T13:29:39Z"
+    },
+    {
+      "upstream": "Wei-Shaw/sub2api#2139",
+      "url": "https://github.com/Wei-Shaw/sub2api/issues/2139",
+      "title": "ctx_pool模式有问题",
+      "impact": "unknown_low_signal",
+      "categories": [],
+      "tokenkey_status": "not_prioritized",
+      "rationale": "No high-signal production-risk keywords in this pass.",
+      "updated_at": "2026-05-06T06:56:32Z"
+    },
+    {
+      "upstream": "Wei-Shaw/sub2api#2140",
+      "url": "https://github.com/Wei-Shaw/sub2api/issues/2140",
+      "title": "压缩问题什么时候可以彻底解决呢？经常压缩失败",
+      "impact": "unknown_low_signal",
+      "categories": [],
+      "tokenkey_status": "not_prioritized",
+      "rationale": "No high-signal production-risk keywords in this pass.",
+      "updated_at": "2026-05-01T01:55:58Z"
+    },
+    {
+      "upstream": "Wei-Shaw/sub2api#2142",
+      "url": "https://github.com/Wei-Shaw/sub2api/issues/2142",
+      "title": "seedance2.0研究项目，欢迎一起交流 #93",
+      "impact": "unknown_low_signal",
+      "categories": [],
+      "tokenkey_status": "not_prioritized",
+      "rationale": "No high-signal production-risk keywords in this pass.",
+      "updated_at": "2026-04-30T12:58:14Z"
+    },
+    {
+      "upstream": "Wei-Shaw/sub2api#2150",
+      "url": "https://github.com/Wei-Shaw/sub2api/issues/2150",
+      "title": "使用本地搭建的llama.cpp对接报错",
+      "impact": "unknown_low_signal",
+      "categories": [],
+      "tokenkey_status": "not_prioritized",
+      "rationale": "No high-signal production-risk keywords in this pass.",
+      "updated_at": "2026-05-01T07:50:12Z"
+    },
+    {
+      "upstream": "Wei-Shaw/sub2api#2154",
+      "url": "https://github.com/Wei-Shaw/sub2api/issues/2154",
+      "title": "后台已打开邀请返利开关，注册界面不显示邀请码输入框",
+      "impact": "unknown_low_signal",
+      "categories": [],
+      "tokenkey_status": "not_prioritized",
+      "rationale": "No high-signal production-risk keywords in this pass.",
+      "updated_at": "2026-05-01T16:15:46Z"
+    },
+    {
+      "upstream": "Wei-Shaw/sub2api#2166",
+      "url": "https://github.com/Wei-Shaw/sub2api/issues/2166",
+      "title": "新开了flow2api研究项目，包含了sora2和seedance2.0，欢迎一起交流",
+      "impact": "unknown_low_signal",
+      "categories": [],
+      "tokenkey_status": "not_prioritized",
+      "rationale": "No high-signal production-risk keywords in this pass.",
+      "updated_at": "2026-05-03T17:19:20Z"
+    },
+    {
+      "upstream": "Wei-Shaw/sub2api#2167",
+      "url": "https://github.com/Wei-Shaw/sub2api/issues/2167",
+      "title": "sub2api疑似有漏掉使用记录的情况",
+      "impact": "unknown_low_signal",
+      "categories": [],
+      "tokenkey_status": "not_prioritized",
+      "rationale": "No high-signal production-risk keywords in this pass.",
+      "updated_at": "2026-05-02T17:27:08Z"
+    },
+    {
+      "upstream": "Wei-Shaw/sub2api#2174",
+      "url": "https://github.com/Wei-Shaw/sub2api/issues/2174",
+      "title": "是不是没有路由策略呀？",
+      "impact": "unknown_low_signal",
+      "categories": [],
+      "tokenkey_status": "not_prioritized",
+      "rationale": "No high-signal production-risk keywords in this pass.",
+      "updated_at": "2026-05-03T16:42:59Z"
+    },
+    {
+      "upstream": "Wei-Shaw/sub2api#2178",
+      "url": "https://github.com/Wei-Shaw/sub2api/issues/2178",
+      "title": "刷新令牌功能反馈",
+      "impact": "unknown_low_signal",
+      "categories": [],
+      "tokenkey_status": "not_prioritized",
+      "rationale": "No high-signal production-risk keywords in this pass.",
+      "updated_at": "2026-05-04T03:37:34Z"
+    },
+    {
+      "upstream": "Wei-Shaw/sub2api#2182",
+      "url": "https://github.com/Wei-Shaw/sub2api/issues/2182",
+      "title": "更新了v0.1.122。所有账号都消失不见了。",
+      "impact": "unknown_low_signal",
+      "categories": [],
+      "tokenkey_status": "not_prioritized",
+      "rationale": "No high-signal production-risk keywords in this pass.",
+      "updated_at": "2026-05-04T09:08:42Z"
+    },
+    {
+      "upstream": "Wei-Shaw/sub2api#2220",
+      "url": "https://github.com/Wei-Shaw/sub2api/issues/2220",
+      "title": "转发 OpenAI 响应接口时需处理 `service_tier` 参数？否则导致 400 错误？",
+      "impact": "unknown_low_signal",
+      "categories": [],
+      "tokenkey_status": "not_prioritized",
+      "rationale": "No high-signal production-risk keywords in this pass.",
+      "updated_at": "2026-05-06T07:25:47Z"
+    },
+    {
+      "upstream": "Wei-Shaw/sub2api#2221",
+      "url": "https://github.com/Wei-Shaw/sub2api/issues/2221",
+      "title": "gpt的订阅等级不更新",
+      "impact": "unknown_low_signal",
+      "categories": [],
+      "tokenkey_status": "not_prioritized",
+      "rationale": "No high-signal production-risk keywords in this pass.",
+      "updated_at": "2026-05-11T06:02:21Z"
+    },
+    {
+      "upstream": "Wei-Shaw/sub2api#223",
+      "url": "https://github.com/Wei-Shaw/sub2api/issues/223",
+      "title": "使用gemini 3 Pro的时候经常莫名其妙terminated",
+      "impact": "unknown_low_signal",
+      "categories": [],
+      "tokenkey_status": "not_prioritized",
+      "rationale": "No high-signal production-risk keywords in this pass.",
+      "updated_at": "2026-01-09T14:42:15Z"
+    },
+    {
+      "upstream": "Wei-Shaw/sub2api#2236",
+      "url": "https://github.com/Wei-Shaw/sub2api/issues/2236",
+      "title": "部署完登录报404",
+      "impact": "unknown_low_signal",
+      "categories": [],
+      "tokenkey_status": "not_prioritized",
+      "rationale": "No high-signal production-risk keywords in this pass.",
+      "updated_at": "2026-05-11T09:02:12Z"
+    },
+    {
+      "upstream": "Wei-Shaw/sub2api#2240",
+      "url": "https://github.com/Wei-Shaw/sub2api/issues/2240",
+      "title": "Selected model is at capacity. Please try a different model.",
+      "impact": "unknown_low_signal",
+      "categories": [],
+      "tokenkey_status": "not_prioritized",
+      "rationale": "No high-signal production-risk keywords in this pass.",
+      "updated_at": "2026-05-07T04:03:11Z"
+    },
+    {
+      "upstream": "Wei-Shaw/sub2api#2249",
+      "url": "https://github.com/Wei-Shaw/sub2api/issues/2249",
+      "title": "请教大神们 codex目前会封号吗？",
+      "impact": "unknown_low_signal",
+      "categories": [],
+      "tokenkey_status": "not_prioritized",
+      "rationale": "No high-signal production-risk keywords in this pass.",
+      "updated_at": "2026-05-11T07:13:30Z"
+    },
+    {
+      "upstream": "Wei-Shaw/sub2api#2254",
+      "url": "https://github.com/Wei-Shaw/sub2api/issues/2254",
+      "title": "image2.0测试一直失败啊",
+      "impact": "unknown_low_signal",
+      "categories": [],
+      "tokenkey_status": "not_prioritized",
+      "rationale": "No high-signal production-risk keywords in this pass.",
+      "updated_at": "2026-05-07T12:11:05Z"
+    },
+    {
+      "upstream": "Wei-Shaw/sub2api#2256",
+      "url": "https://github.com/Wei-Shaw/sub2api/issues/2256",
+      "title": "如何设置一个key 或者不同的模型设置到一个分组呢",
+      "impact": "unknown_low_signal",
+      "categories": [],
+      "tokenkey_status": "not_prioritized",
+      "rationale": "No high-signal production-risk keywords in this pass.",
+      "updated_at": "2026-05-07T10:39:19Z"
+    },
+    {
+      "upstream": "Wei-Shaw/sub2api#2260",
+      "url": "https://github.com/Wei-Shaw/sub2api/issues/2260",
+      "title": "cc的缓存存在问题",
+      "impact": "unknown_low_signal",
+      "categories": [],
+      "tokenkey_status": "not_prioritized",
+      "rationale": "No high-signal production-risk keywords in this pass.",
+      "updated_at": "2026-05-09T08:37:39Z"
+    },
+    {
+      "upstream": "Wei-Shaw/sub2api#2261",
+      "url": "https://github.com/Wei-Shaw/sub2api/issues/2261",
+      "title": "bug: v0.1.125 已知介面上的問題",
+      "impact": "unknown_low_signal",
+      "categories": [],
+      "tokenkey_status": "not_prioritized",
+      "rationale": "No high-signal production-risk keywords in this pass.",
+      "updated_at": "2026-05-07T13:10:30Z"
+    },
+    {
+      "upstream": "Wei-Shaw/sub2api#2279",
+      "url": "https://github.com/Wei-Shaw/sub2api/issues/2279",
+      "title": "v0.1.125版本openai格式账户上游对接deepseek 报错500",
+      "impact": "unknown_low_signal",
+      "categories": [],
+      "tokenkey_status": "not_prioritized",
+      "rationale": "No high-signal production-risk keywords in this pass.",
+      "updated_at": "2026-05-08T05:18:26Z"
+    },
+    {
+      "upstream": "Wei-Shaw/sub2api#2283",
+      "url": "https://github.com/Wei-Shaw/sub2api/issues/2283",
+      "title": "一直报这个错",
+      "impact": "unknown_low_signal",
+      "categories": [],
+      "tokenkey_status": "not_prioritized",
+      "rationale": "No high-signal production-risk keywords in this pass.",
+      "updated_at": "2026-05-09T05:24:01Z"
+    },
+    {
+      "upstream": "Wei-Shaw/sub2api#2287",
+      "url": "https://github.com/Wei-Shaw/sub2api/issues/2287",
+      "title": "为什么open ai授权之后一直是访问拒绝",
+      "impact": "unknown_low_signal",
+      "categories": [],
+      "tokenkey_status": "not_prioritized",
+      "rationale": "No high-signal production-risk keywords in this pass.",
+      "updated_at": "2026-05-08T09:05:52Z"
+    },
+    {
+      "upstream": "Wei-Shaw/sub2api#2292",
+      "url": "https://github.com/Wei-Shaw/sub2api/issues/2292",
+      "title": "BUG 设置了支付宝方式，首个二维码加载出来是假的，扫不了",
+      "impact": "unknown_low_signal",
+      "categories": [],
+      "tokenkey_status": "not_prioritized",
+      "rationale": "No high-signal production-risk keywords in this pass.",
+      "updated_at": "2026-05-13T00:43:26Z"
+    },
+    {
+      "upstream": "Wei-Shaw/sub2api#2307",
+      "url": "https://github.com/Wei-Shaw/sub2api/issues/2307",
+      "title": "请作者for win x86版本添加最小化缩略到托盘和右键菜单功能",
+      "impact": "unknown_low_signal",
+      "categories": [],
+      "tokenkey_status": "not_prioritized",
+      "rationale": "No high-signal production-risk keywords in this pass.",
+      "updated_at": "2026-05-09T00:35:37Z"
+    },
+    {
+      "upstream": "Wei-Shaw/sub2api#2311",
+      "url": "https://github.com/Wei-Shaw/sub2api/issues/2311",
+      "title": "增加 kiro 的支持",
+      "impact": "unknown_low_signal",
+      "categories": [],
+      "tokenkey_status": "not_prioritized",
+      "rationale": "No high-signal production-risk keywords in this pass.",
+      "updated_at": "2026-05-09T05:14:36Z"
+    },
+    {
+      "upstream": "Wei-Shaw/sub2api#2312",
+      "url": "https://github.com/Wei-Shaw/sub2api/issues/2312",
+      "title": "关于邀请返利：可以考虑做个二级分销就好了。",
+      "impact": "unknown_low_signal",
+      "categories": [],
+      "tokenkey_status": "not_prioritized",
+      "rationale": "No high-signal production-risk keywords in this pass.",
+      "updated_at": "2026-05-09T05:57:57Z"
+    },
+    {
+      "upstream": "Wei-Shaw/sub2api#2313",
+      "url": "https://github.com/Wei-Shaw/sub2api/issues/2313",
+      "title": "增加 订阅额度使用完后自动切换密钥分组功能",
+      "impact": "unknown_low_signal",
+      "categories": [],
+      "tokenkey_status": "not_prioritized",
+      "rationale": "No high-signal production-risk keywords in this pass.",
+      "updated_at": "2026-05-09T05:26:37Z"
+    },
+    {
+      "upstream": "Wei-Shaw/sub2api#2318",
+      "url": "https://github.com/Wei-Shaw/sub2api/issues/2318",
+      "title": "openai账号只能接入gpt模型吗",
+      "impact": "unknown_low_signal",
+      "categories": [],
+      "tokenkey_status": "not_prioritized",
+      "rationale": "No high-signal production-risk keywords in this pass.",
+      "updated_at": "2026-05-11T05:44:27Z"
+    },
+    {
+      "upstream": "Wei-Shaw/sub2api#2322",
+      "url": "https://github.com/Wei-Shaw/sub2api/issues/2322",
+      "title": "哪位朋友能解释一下：渠道管理，是干嘛的？",
+      "impact": "unknown_low_signal",
+      "categories": [],
+      "tokenkey_status": "not_prioritized",
+      "rationale": "No high-signal production-risk keywords in this pass.",
+      "updated_at": "2026-05-10T03:12:40Z"
+    },
+    {
+      "upstream": "Wei-Shaw/sub2api#2334",
+      "url": "https://github.com/Wei-Shaw/sub2api/issues/2334",
+      "title": "兑换码生成后全部复制报错",
+      "impact": "unknown_low_signal",
+      "categories": [],
+      "tokenkey_status": "not_prioritized",
+      "rationale": "No high-signal production-risk keywords in this pass.",
+      "updated_at": "2026-05-10T04:26:06Z"
+    },
+    {
+      "upstream": "Wei-Shaw/sub2api#2336",
+      "url": "https://github.com/Wei-Shaw/sub2api/issues/2336",
+      "title": "个人意见-什么时候可以设置 模型的输入、输出、缓存价格？",
+      "impact": "unknown_low_signal",
+      "categories": [],
+      "tokenkey_status": "not_prioritized",
+      "rationale": "No high-signal production-risk keywords in this pass.",
+      "updated_at": "2026-05-11T02:52:53Z"
+    },
+    {
+      "upstream": "Wei-Shaw/sub2api#2345",
+      "url": "https://github.com/Wei-Shaw/sub2api/issues/2345",
+      "title": "能否增加订阅结余机制，比如可以结余1天或2天",
+      "impact": "unknown_low_signal",
+      "categories": [],
+      "tokenkey_status": "not_prioritized",
+      "rationale": "No high-signal production-risk keywords in this pass.",
+      "updated_at": "2026-05-10T15:53:59Z"
+    },
+    {
+      "upstream": "Wei-Shaw/sub2api#2347",
+      "url": "https://github.com/Wei-Shaw/sub2api/issues/2347",
+      "title": "Render部署无法完成install",
+      "impact": "unknown_low_signal",
+      "categories": [],
+      "tokenkey_status": "not_prioritized",
+      "rationale": "No high-signal production-risk keywords in this pass.",
+      "updated_at": "2026-05-10T17:12:54Z"
+    },
+    {
+      "upstream": "Wei-Shaw/sub2api#2348",
+      "url": "https://github.com/Wei-Shaw/sub2api/issues/2348",
+      "title": "新建API key 无法使用，账号管理中的测试是能通过的",
+      "impact": "unknown_low_signal",
+      "categories": [],
+      "tokenkey_status": "not_prioritized",
+      "rationale": "No high-signal production-risk keywords in this pass.",
+      "updated_at": "2026-05-11T10:25:44Z"
+    },
+    {
+      "upstream": "Wei-Shaw/sub2api#235",
+      "url": "https://github.com/Wei-Shaw/sub2api/issues/235",
+      "title": "似乎目前不支持codex的上下文压缩接口，导致上下文满了之后无法继续对话。",
+      "impact": "unknown_low_signal",
+      "categories": [],
+      "tokenkey_status": "not_prioritized",
+      "rationale": "No high-signal production-risk keywords in this pass.",
+      "updated_at": "2026-01-10T15:53:29Z"
+    },
+    {
+      "upstream": "Wei-Shaw/sub2api#2351",
+      "url": "https://github.com/Wei-Shaw/sub2api/issues/2351",
+      "title": "OpenCode 的 go 订阅计划可以代理出来吗？",
+      "impact": "unknown_low_signal",
+      "categories": [],
+      "tokenkey_status": "not_prioritized",
+      "rationale": "No high-signal production-risk keywords in this pass.",
+      "updated_at": "2026-05-12T06:30:02Z"
+    },
+    {
+      "upstream": "Wei-Shaw/sub2api#2359",
+      "url": "https://github.com/Wei-Shaw/sub2api/issues/2359",
+      "title": "codex 每日速率限制不动",
+      "impact": "unknown_low_signal",
+      "categories": [],
+      "tokenkey_status": "not_prioritized",
+      "rationale": "No high-signal production-risk keywords in this pass.",
+      "updated_at": "2026-05-11T04:11:01Z"
+    },
+    {
+      "upstream": "Wei-Shaw/sub2api#2362",
+      "url": "https://github.com/Wei-Shaw/sub2api/issues/2362",
+      "title": "openai_403_temp_unschedulable 这个错误是为什么，下午突然有问题",
+      "impact": "unknown_low_signal",
+      "categories": [],
+      "tokenkey_status": "not_prioritized",
+      "rationale": "No high-signal production-risk keywords in this pass.",
+      "updated_at": "2026-05-11T09:04:47Z"
+    },
+    {
+      "upstream": "Wei-Shaw/sub2api#2367",
+      "url": "https://github.com/Wei-Shaw/sub2api/issues/2367",
+      "title": "请教fast模式怎么开啊",
+      "impact": "unknown_low_signal",
+      "categories": [],
+      "tokenkey_status": "not_prioritized",
+      "rationale": "No high-signal production-risk keywords in this pass.",
+      "updated_at": "2026-05-14T07:10:47Z"
+    },
+    {
+      "upstream": "Wei-Shaw/sub2api#2372",
+      "url": "https://github.com/Wei-Shaw/sub2api/issues/2372",
+      "title": "订阅时间能否精确到小时，比如几天几个小时，现在只能到天，不方便管理",
+      "impact": "unknown_low_signal",
+      "categories": [],
+      "tokenkey_status": "not_prioritized",
+      "rationale": "No high-signal production-risk keywords in this pass.",
+      "updated_at": "2026-05-11T13:29:02Z"
+    },
+    {
+      "upstream": "Wei-Shaw/sub2api#2376",
+      "url": "https://github.com/Wei-Shaw/sub2api/issues/2376",
+      "title": "BUG：No tool call found for function call output with call_id xxx",
+      "impact": "unknown_low_signal",
+      "categories": [],
+      "tokenkey_status": "not_prioritized",
+      "rationale": "No high-signal production-risk keywords in this pass.",
+      "updated_at": "2026-05-12T06:58:01Z"
+    },
+    {
+      "upstream": "Wei-Shaw/sub2api#2379",
+      "url": "https://github.com/Wei-Shaw/sub2api/issues/2379",
+      "title": "平台限制问题",
+      "impact": "unknown_low_signal",
+      "categories": [],
+      "tokenkey_status": "not_prioritized",
+      "rationale": "No high-signal production-risk keywords in this pass.",
+      "updated_at": "2026-05-11T16:56:41Z"
+    },
+    {
+      "upstream": "Wei-Shaw/sub2api#2381",
+      "url": "https://github.com/Wei-Shaw/sub2api/issues/2381",
+      "title": "最新版能更新不？",
+      "impact": "unknown_low_signal",
+      "categories": [],
+      "tokenkey_status": "not_prioritized",
+      "rationale": "No high-signal production-risk keywords in this pass.",
+      "updated_at": "2026-05-11T17:50:34Z"
+    },
+    {
+      "upstream": "Wei-Shaw/sub2api#2385",
+      "url": "https://github.com/Wei-Shaw/sub2api/issues/2385",
+      "title": "现在反重力还封号吗？",
+      "impact": "unknown_low_signal",
+      "categories": [],
+      "tokenkey_status": "not_prioritized",
+      "rationale": "No high-signal production-risk keywords in this pass.",
+      "updated_at": "2026-05-12T12:35:21Z"
+    },
+    {
+      "upstream": "Wei-Shaw/sub2api#2386",
+      "url": "https://github.com/Wei-Shaw/sub2api/issues/2386",
+      "title": "最新版本v0.1.126无法使用",
+      "impact": "unknown_low_signal",
+      "categories": [],
+      "tokenkey_status": "not_prioritized",
+      "rationale": "No high-signal production-risk keywords in this pass.",
+      "updated_at": "2026-05-14T07:51:39Z"
+    },
+    {
+      "upstream": "Wei-Shaw/sub2api#2389",
+      "url": "https://github.com/Wei-Shaw/sub2api/issues/2389",
+      "title": "想问下，我配置支付宝生成支付的二维码，为什么扫不了？ 要放大很大好像才行？",
+      "impact": "unknown_low_signal",
+      "categories": [],
+      "tokenkey_status": "not_prioritized",
+      "rationale": "No high-signal production-risk keywords in this pass.",
+      "updated_at": "2026-05-12T17:55:18Z"
+    },
+    {
+      "upstream": "Wei-Shaw/sub2api#239",
+      "url": "https://github.com/Wei-Shaw/sub2api/issues/239",
+      "title": "后台测试链接正常，但是用户链接就都是0，这是哪里问题呢",
+      "impact": "unknown_low_signal",
+      "categories": [],
+      "tokenkey_status": "not_prioritized",
+      "rationale": "No high-signal production-risk keywords in this pass.",
+      "updated_at": "2026-01-11T15:25:56Z"
+    },
+    {
+      "upstream": "Wei-Shaw/sub2api#2392",
+      "url": "https://github.com/Wei-Shaw/sub2api/issues/2392",
+      "title": "有没有支持 windsurf 的计划",
+      "impact": "unknown_low_signal",
+      "categories": [],
+      "tokenkey_status": "not_prioritized",
+      "rationale": "No high-signal production-risk keywords in this pass.",
+      "updated_at": "2026-05-12T09:17:16Z"
+    },
+    {
+      "upstream": "Wei-Shaw/sub2api#2397",
+      "url": "https://github.com/Wei-Shaw/sub2api/issues/2397",
+      "title": "Windows standalone .exe online update does not take effect after Web UI update",
+      "impact": "unknown_low_signal",
+      "categories": [],
+      "tokenkey_status": "not_prioritized",
+      "rationale": "No high-signal production-risk keywords in this pass.",
+      "updated_at": "2026-05-12T06:51:08Z"
+    },
+    {
+      "upstream": "Wei-Shaw/sub2api#2403",
+      "url": "https://github.com/Wei-Shaw/sub2api/issues/2403",
+      "title": "Selected model is at capacity. Please try a different model.",
+      "impact": "unknown_low_signal",
+      "categories": [],
+      "tokenkey_status": "not_prioritized",
+      "rationale": "No high-signal production-risk keywords in this pass.",
+      "updated_at": "2026-05-12T08:16:02Z"
+    },
+    {
+      "upstream": "Wei-Shaw/sub2api#2405",
+      "url": "https://github.com/Wei-Shaw/sub2api/issues/2405",
+      "title": "GPT5.5支持更大的上下文限制么？",
+      "impact": "unknown_low_signal",
+      "categories": [],
+      "tokenkey_status": "not_prioritized",
+      "rationale": "No high-signal production-risk keywords in this pass.",
+      "updated_at": "2026-05-12T08:21:22Z"
+    },
+    {
+      "upstream": "Wei-Shaw/sub2api#2415",
+      "url": "https://github.com/Wei-Shaw/sub2api/issues/2415",
+      "title": "如何更新管理员邮箱变成自己的？",
+      "impact": "unknown_low_signal",
+      "categories": [],
+      "tokenkey_status": "not_prioritized",
+      "rationale": "No high-signal production-risk keywords in this pass.",
+      "updated_at": "2026-05-12T14:14:39Z"
+    },
+    {
+      "upstream": "Wei-Shaw/sub2api#2418",
+      "url": "https://github.com/Wei-Shaw/sub2api/issues/2418",
+      "title": "现在时间是2026年5月12日，今天部署之后claude授权，两种模式都不过，现在还能用吗？是不是已经被A家封了？",
+      "impact": "unknown_low_signal",
+      "categories": [],
+      "tokenkey_status": "not_prioritized",
+      "rationale": "No high-signal production-risk keywords in this pass.",
+      "updated_at": "2026-05-13T09:13:32Z"
+    },
+    {
+      "upstream": "Wei-Shaw/sub2api#2426",
+      "url": "https://github.com/Wei-Shaw/sub2api/issues/2426",
+      "title": "模型白名单和模型映射不能同时设置",
+      "impact": "unknown_low_signal",
+      "categories": [],
+      "tokenkey_status": "not_prioritized",
+      "rationale": "No high-signal production-risk keywords in this pass.",
+      "updated_at": "2026-05-13T06:11:59Z"
+    },
+    {
+      "upstream": "Wei-Shaw/sub2api#2429",
+      "url": "https://github.com/Wei-Shaw/sub2api/issues/2429",
+      "title": "一个分组就两个账号，但是响应速度特别慢，完成一个任务基本都要半小时，平均响应三十多秒，请问大佬有什么办法可以解决",
+      "impact": "unknown_low_signal",
+      "categories": [],
+      "tokenkey_status": "not_prioritized",
+      "rationale": "No high-signal production-risk keywords in this pass.",
+      "updated_at": "2026-05-14T02:41:49Z"
+    },
+    {
+      "upstream": "Wei-Shaw/sub2api#2430",
+      "url": "https://github.com/Wei-Shaw/sub2api/issues/2430",
+      "title": "开启邀请码后无法注册",
+      "impact": "unknown_low_signal",
+      "categories": [],
+      "tokenkey_status": "not_prioritized",
+      "rationale": "No high-signal production-risk keywords in this pass.",
+      "updated_at": "2026-05-14T06:02:16Z"
+    },
+    {
+      "upstream": "Wei-Shaw/sub2api#2433",
+      "url": "https://github.com/Wei-Shaw/sub2api/issues/2433",
+      "title": "账号用着用着会跳成别人的账号",
+      "impact": "unknown_low_signal",
+      "categories": [],
+      "tokenkey_status": "not_prioritized",
+      "rationale": "No high-signal production-risk keywords in this pass.",
+      "updated_at": "2026-05-13T12:18:24Z"
+    },
+    {
+      "upstream": "Wei-Shaw/sub2api#2438",
+      "url": "https://github.com/Wei-Shaw/sub2api/issues/2438",
+      "title": "claude console接入没有缓存",
+      "impact": "unknown_low_signal",
+      "categories": [],
+      "tokenkey_status": "not_prioritized",
+      "rationale": "No high-signal production-risk keywords in this pass.",
+      "updated_at": "2026-05-13T13:58:44Z"
+    },
+    {
+      "upstream": "Wei-Shaw/sub2api#244",
+      "url": "https://github.com/Wei-Shaw/sub2api/issues/244",
+      "title": "sub2api 不支持droid了吗",
+      "impact": "unknown_low_signal",
+      "categories": [],
+      "tokenkey_status": "not_prioritized",
+      "rationale": "No high-signal production-risk keywords in this pass.",
+      "updated_at": "2026-01-20T04:41:05Z"
+    },
+    {
+      "upstream": "Wei-Shaw/sub2api#2452",
+      "url": "https://github.com/Wei-Shaw/sub2api/issues/2452",
+      "title": "v0.1.126 报错：Failed to read request body",
+      "impact": "unknown_low_signal",
+      "categories": [],
+      "tokenkey_status": "not_prioritized",
+      "rationale": "No high-signal production-risk keywords in this pass.",
+      "updated_at": "2026-05-15T07:02:59Z"
+    },
+    {
+      "upstream": "Wei-Shaw/sub2api#2458",
+      "url": "https://github.com/Wei-Shaw/sub2api/issues/2458",
+      "title": "架构为什么限制一个 API Key 只能绑定一个分组（一个平台）？",
+      "impact": "unknown_low_signal",
+      "categories": [],
+      "tokenkey_status": "not_prioritized",
+      "rationale": "No high-signal production-risk keywords in this pass.",
+      "updated_at": "2026-05-15T03:25:50Z"
+    },
+    {
+      "upstream": "Wei-Shaw/sub2api#2467",
+      "url": "https://github.com/Wei-Shaw/sub2api/issues/2467",
+      "title": "feat: 兑换码增加有效期",
+      "impact": "unknown_low_signal",
+      "categories": [],
+      "tokenkey_status": "not_prioritized",
+      "rationale": "No high-signal production-risk keywords in this pass.",
+      "updated_at": "2026-05-14T13:25:17Z"
+    },
+    {
+      "upstream": "Wei-Shaw/sub2api#2477",
+      "url": "https://github.com/Wei-Shaw/sub2api/issues/2477",
+      "title": "能不能加一个 Grok Build",
+      "impact": "unknown_low_signal",
+      "categories": [],
+      "tokenkey_status": "not_prioritized",
+      "rationale": "No high-signal production-risk keywords in this pass.",
+      "updated_at": "2026-05-15T05:32:46Z"
+    },
+    {
+      "upstream": "Wei-Shaw/sub2api#2482",
+      "url": "https://github.com/Wei-Shaw/sub2api/issues/2482",
+      "title": "126版本批量调整优先级不生效",
+      "impact": "unknown_low_signal",
+      "categories": [],
+      "tokenkey_status": "not_prioritized",
+      "rationale": "No high-signal production-risk keywords in this pass.",
+      "updated_at": "2026-05-15T03:03:51Z"
+    },
+    {
+      "upstream": "Wei-Shaw/sub2api#262",
+      "url": "https://github.com/Wei-Shaw/sub2api/issues/262",
+      "title": "crs可以直接迁移过来吗",
+      "impact": "unknown_low_signal",
+      "categories": [],
+      "tokenkey_status": "not_prioritized",
+      "rationale": "No high-signal production-risk keywords in this pass.",
+      "updated_at": "2026-01-29T03:25:50Z"
+    },
+    {
+      "upstream": "Wei-Shaw/sub2api#272",
+      "url": "https://github.com/Wei-Shaw/sub2api/issues/272",
+      "title": "安装流程 又问题吗？",
+      "impact": "unknown_low_signal",
+      "categories": [],
+      "tokenkey_status": "not_prioritized",
+      "rationale": "No high-signal production-risk keywords in this pass.",
+      "updated_at": "2026-01-13T13:13:00Z"
+    },
+    {
+      "upstream": "Wei-Shaw/sub2api#277",
+      "url": "https://github.com/Wei-Shaw/sub2api/issues/277",
+      "title": "ip管理和账号管理无法区分用的哪个ip",
+      "impact": "unknown_low_signal",
+      "categories": [],
+      "tokenkey_status": "not_prioritized",
+      "rationale": "No high-signal production-risk keywords in this pass.",
+      "updated_at": "2026-01-14T06:45:02Z"
+    },
+    {
+      "upstream": "Wei-Shaw/sub2api#281",
+      "url": "https://github.com/Wei-Shaw/sub2api/issues/281",
+      "title": "反重力平台设置流式或者自定义请求超时时长",
+      "impact": "unknown_low_signal",
+      "categories": [],
+      "tokenkey_status": "not_prioritized",
+      "rationale": "No high-signal production-risk keywords in this pass.",
+      "updated_at": "2026-01-14T09:49:15Z"
+    },
+    {
+      "upstream": "Wei-Shaw/sub2api#291",
+      "url": "https://github.com/Wei-Shaw/sub2api/issues/291",
+      "title": "[bug]: docker-compose.yml语法错误",
+      "impact": "unknown_low_signal",
+      "categories": [],
+      "tokenkey_status": "not_prioritized",
+      "rationale": "No high-signal production-risk keywords in this pass.",
+      "updated_at": "2026-03-04T02:00:26Z"
+    },
+    {
+      "upstream": "Wei-Shaw/sub2api#295",
+      "url": "https://github.com/Wei-Shaw/sub2api/issues/295",
+      "title": "cc经常自动结束，但任务还没做完",
+      "impact": "unknown_low_signal",
+      "categories": [],
+      "tokenkey_status": "not_prioritized",
+      "rationale": "No high-signal production-risk keywords in this pass.",
+      "updated_at": "2026-01-15T15:25:12Z"
+    },
+    {
+      "upstream": "Wei-Shaw/sub2api#305",
+      "url": "https://github.com/Wei-Shaw/sub2api/issues/305",
+      "title": "antigravity 渠道的模型不支持非流方式调用，后续是否会增加非流的方式处理。",
+      "impact": "unknown_low_signal",
+      "categories": [],
+      "tokenkey_status": "not_prioritized",
+      "rationale": "No high-signal production-risk keywords in this pass.",
+      "updated_at": "2026-01-22T13:25:11Z"
+    },
+    {
+      "upstream": "Wei-Shaw/sub2api#307",
+      "url": "https://github.com/Wei-Shaw/sub2api/issues/307",
+      "title": "支持kiro接入的计划？",
+      "impact": "unknown_low_signal",
+      "categories": [],
+      "tokenkey_status": "not_prioritized",
+      "rationale": "No high-signal production-risk keywords in this pass.",
+      "updated_at": "2026-04-30T06:42:53Z"
+    },
+    {
+      "upstream": "Wei-Shaw/sub2api#309",
+      "url": "https://github.com/Wei-Shaw/sub2api/issues/309",
+      "title": "【Bug】选择simple模式无法使用antigravity分组",
+      "impact": "unknown_low_signal",
+      "categories": [],
+      "tokenkey_status": "not_prioritized",
+      "rationale": "No high-signal production-risk keywords in this pass.",
+      "updated_at": "2026-01-17T04:49:41Z"
+    },
+    {
+      "upstream": "Wei-Shaw/sub2api#336",
+      "url": "https://github.com/Wei-Shaw/sub2api/issues/336",
+      "title": "Failed to exchange OpenAI auth code",
+      "impact": "unknown_low_signal",
+      "categories": [],
+      "tokenkey_status": "not_prioritized",
+      "rationale": "No high-signal production-risk keywords in this pass.",
+      "updated_at": "2026-04-07T06:55:49Z"
+    },
+    {
+      "upstream": "Wei-Shaw/sub2api#339",
+      "url": "https://github.com/Wei-Shaw/sub2api/issues/339",
+      "title": "优先级设置不一样还是会调用",
+      "impact": "unknown_low_signal",
+      "categories": [],
+      "tokenkey_status": "not_prioritized",
+      "rationale": "No high-signal production-risk keywords in this pass.",
+      "updated_at": "2026-01-20T03:41:28Z"
+    },
+    {
+      "upstream": "Wei-Shaw/sub2api#340",
+      "url": "https://github.com/Wei-Shaw/sub2api/issues/340",
+      "title": "能否把DB和REDIS的配置项全部放到.env里？",
+      "impact": "unknown_low_signal",
+      "categories": [],
+      "tokenkey_status": "not_prioritized",
+      "rationale": "No high-signal production-risk keywords in this pass.",
+      "updated_at": "2026-02-09T07:00:45Z"
+    },
+    {
+      "upstream": "Wei-Shaw/sub2api#35",
+      "url": "https://github.com/Wei-Shaw/sub2api/issues/35",
+      "title": "删除分组后无法以同名重新创建分组",
+      "impact": "unknown_low_signal",
+      "categories": [],
+      "tokenkey_status": "not_prioritized",
+      "rationale": "No high-signal production-risk keywords in this pass.",
+      "updated_at": "2025-12-29T14:27:26Z"
+    },
+    {
+      "upstream": "Wei-Shaw/sub2api#350",
+      "url": "https://github.com/Wei-Shaw/sub2api/issues/350",
+      "title": "【openai错误】",
+      "impact": "unknown_low_signal",
+      "categories": [],
+      "tokenkey_status": "not_prioritized",
+      "rationale": "No high-signal production-risk keywords in this pass.",
+      "updated_at": "2026-01-29T13:05:38Z"
+    },
+    {
+      "upstream": "Wei-Shaw/sub2api#351",
+      "url": "https://github.com/Wei-Shaw/sub2api/issues/351",
+      "title": "「需求」 codex 測試鏈接支持設置參數",
+      "impact": "unknown_low_signal",
+      "categories": [],
+      "tokenkey_status": "not_prioritized",
+      "rationale": "No high-signal production-risk keywords in this pass.",
+      "updated_at": "2026-01-21T09:00:27Z"
+    },
+    {
+      "upstream": "Wei-Shaw/sub2api#361",
+      "url": "https://github.com/Wei-Shaw/sub2api/issues/361",
+      "title": "Request too Large. Double press esc to go back and try with a smaller file 总是报错",
+      "impact": "unknown_low_signal",
+      "categories": [],
+      "tokenkey_status": "not_prioritized",
+      "rationale": "No high-signal production-risk keywords in this pass.",
+      "updated_at": "2026-01-22T08:55:12Z"
+    },
+    {
+      "upstream": "Wei-Shaw/sub2api#368",
+      "url": "https://github.com/Wei-Shaw/sub2api/issues/368",
+      "title": "[bug] postgresSQL数据库版本为18时，连接的是postgres数据库，而不是sub2api",
+      "impact": "unknown_low_signal",
+      "categories": [],
+      "tokenkey_status": "not_prioritized",
+      "rationale": "No high-signal production-risk keywords in this pass.",
+      "updated_at": "2026-02-09T13:12:21Z"
+    },
+    {
+      "upstream": "Wei-Shaw/sub2api#381",
+      "url": "https://github.com/Wei-Shaw/sub2api/issues/381",
+      "title": "SMTP配置",
+      "impact": "unknown_low_signal",
+      "categories": [],
+      "tokenkey_status": "not_prioritized",
+      "rationale": "No high-signal production-risk keywords in this pass.",
+      "updated_at": "2026-01-24T10:56:26Z"
+    },
+    {
+      "upstream": "Wei-Shaw/sub2api#388",
+      "url": "https://github.com/Wei-Shaw/sub2api/issues/388",
+      "title": "反重力模型映射",
+      "impact": "unknown_low_signal",
+      "categories": [],
+      "tokenkey_status": "not_prioritized",
+      "rationale": "No high-signal production-risk keywords in this pass.",
+      "updated_at": "2026-01-25T04:44:13Z"
+    },
+    {
+      "upstream": "Wei-Shaw/sub2api#389",
+      "url": "https://github.com/Wei-Shaw/sub2api/issues/389",
+      "title": "BUG，现在5h用量都不清空了吗？",
+      "impact": "unknown_low_signal",
+      "categories": [],
+      "tokenkey_status": "not_prioritized",
+      "rationale": "No high-signal production-risk keywords in this pass.",
+      "updated_at": "2026-02-01T18:15:19Z"
+    },
+    {
+      "upstream": "Wei-Shaw/sub2api#395",
+      "url": "https://github.com/Wei-Shaw/sub2api/issues/395",
+      "title": "对话接口不通",
+      "impact": "unknown_low_signal",
+      "categories": [],
+      "tokenkey_status": "not_prioritized",
+      "rationale": "No high-signal production-risk keywords in this pass.",
+      "updated_at": "2026-01-26T03:57:41Z"
+    },
+    {
+      "upstream": "Wei-Shaw/sub2api#398",
+      "url": "https://github.com/Wei-Shaw/sub2api/issues/398",
+      "title": "添加反重力家庭组会员问题",
+      "impact": "unknown_low_signal",
+      "categories": [],
+      "tokenkey_status": "not_prioritized",
+      "rationale": "No high-signal production-risk keywords in this pass.",
+      "updated_at": "2026-02-06T17:24:27Z"
+    },
+    {
+      "upstream": "Wei-Shaw/sub2api#399",
+      "url": "https://github.com/Wei-Shaw/sub2api/issues/399",
+      "title": "反重力gemini function calling问题",
+      "impact": "unknown_low_signal",
+      "categories": [],
+      "tokenkey_status": "not_prioritized",
+      "rationale": "No high-signal production-risk keywords in this pass.",
+      "updated_at": "2026-04-25T05:28:21Z"
+    },
+    {
+      "upstream": "Wei-Shaw/sub2api#400",
+      "url": "https://github.com/Wei-Shaw/sub2api/issues/400",
+      "title": "请求这个端点：/v1/chat/completions，返回404",
+      "impact": "unknown_low_signal",
+      "categories": [],
+      "tokenkey_status": "not_prioritized",
+      "rationale": "No high-signal production-risk keywords in this pass.",
+      "updated_at": "2026-04-17T08:46:52Z"
+    },
+    {
+      "upstream": "Wei-Shaw/sub2api#402",
+      "url": "https://github.com/Wei-Shaw/sub2api/issues/402",
+      "title": "反重力",
+      "impact": "unknown_low_signal",
+      "categories": [],
+      "tokenkey_status": "not_prioritized",
+      "rationale": "No high-signal production-risk keywords in this pass.",
+      "updated_at": "2026-01-27T04:08:38Z"
+    },
+    {
+      "upstream": "Wei-Shaw/sub2api#405",
+      "url": "https://github.com/Wei-Shaw/sub2api/issues/405",
+      "title": "想问一下后期有支持每个用户每天能使用的余额限制吗 现在只有账号级别的",
+      "impact": "unknown_low_signal",
+      "categories": [],
+      "tokenkey_status": "not_prioritized",
+      "rationale": "No high-signal production-risk keywords in this pass.",
+      "updated_at": "2026-01-27T11:14:47Z"
+    },
+    {
+      "upstream": "Wei-Shaw/sub2api#413",
+      "url": "https://github.com/Wei-Shaw/sub2api/issues/413",
+      "title": "目前不支持 clawdbot",
+      "impact": "unknown_low_signal",
+      "categories": [],
+      "tokenkey_status": "not_prioritized",
+      "rationale": "No high-signal production-risk keywords in this pass.",
+      "updated_at": "2026-02-05T02:13:50Z"
+    },
+    {
+      "upstream": "Wei-Shaw/sub2api#415",
+      "url": "https://github.com/Wei-Shaw/sub2api/issues/415",
+      "title": "今天新注册的Claude账号验证通不过",
+      "impact": "unknown_low_signal",
+      "categories": [],
+      "tokenkey_status": "not_prioritized",
+      "rationale": "No high-signal production-risk keywords in this pass.",
+      "updated_at": "2026-05-01T14:27:55Z"
+    },
+    {
+      "upstream": "Wei-Shaw/sub2api#418",
+      "url": "https://github.com/Wei-Shaw/sub2api/issues/418",
+      "title": "调度问题，同一个api请求出现No available account错误，实际有相同优先级的账号空闲",
+      "impact": "unknown_low_signal",
+      "categories": [],
+      "tokenkey_status": "not_prioritized",
+      "rationale": "No high-signal production-risk keywords in this pass.",
+      "updated_at": "2026-04-20T05:46:22Z"
+    },
+    {
+      "upstream": "Wei-Shaw/sub2api#419",
+      "url": "https://github.com/Wei-Shaw/sub2api/issues/419",
+      "title": "crs同步遇到了问题",
+      "impact": "unknown_low_signal",
+      "categories": [],
+      "tokenkey_status": "not_prioritized",
+      "rationale": "No high-signal production-risk keywords in this pass.",
+      "updated_at": "2026-01-29T07:18:52Z"
+    },
+    {
+      "upstream": "Wei-Shaw/sub2api#421",
+      "url": "https://github.com/Wei-Shaw/sub2api/issues/421",
+      "title": "openai的codex反代后能在claudecode里面使用吗",
+      "impact": "unknown_low_signal",
+      "categories": [],
+      "tokenkey_status": "not_prioritized",
+      "rationale": "No high-signal production-risk keywords in this pass.",
+      "updated_at": "2026-04-15T07:38:47Z"
+    },
+    {
+      "upstream": "Wei-Shaw/sub2api#423",
+      "url": "https://github.com/Wei-Shaw/sub2api/issues/423",
+      "title": "cc经常会断掉",
+      "impact": "unknown_low_signal",
+      "categories": [],
+      "tokenkey_status": "not_prioritized",
+      "rationale": "No high-signal production-risk keywords in this pass.",
+      "updated_at": "2026-01-29T11:59:22Z"
+    },
+    {
+      "upstream": "Wei-Shaw/sub2api#431",
+      "url": "https://github.com/Wei-Shaw/sub2api/issues/431",
+      "title": "能不能指定某个用户或者某个分组，他们的会话粘性呢？",
+      "impact": "unknown_low_signal",
+      "categories": [],
+      "tokenkey_status": "not_prioritized",
+      "rationale": "No high-signal production-risk keywords in this pass.",
+      "updated_at": "2026-01-30T06:31:11Z"
+    },
+    {
+      "upstream": "Wei-Shaw/sub2api#433",
+      "url": "https://github.com/Wei-Shaw/sub2api/issues/433",
+      "title": "可否添加模型映射功能",
+      "impact": "unknown_low_signal",
+      "categories": [],
+      "tokenkey_status": "not_prioritized",
+      "rationale": "No high-signal production-risk keywords in this pass.",
+      "updated_at": "2026-01-30T08:57:58Z"
+    },
+    {
+      "upstream": "Wei-Shaw/sub2api#441",
+      "url": "https://github.com/Wei-Shaw/sub2api/issues/441",
+      "title": "请问余额计划支持过期时间么？",
+      "impact": "unknown_low_signal",
+      "categories": [],
+      "tokenkey_status": "not_prioritized",
+      "rationale": "No high-signal production-risk keywords in this pass.",
+      "updated_at": "2026-02-01T15:13:10Z"
+    },
+    {
+      "upstream": "Wei-Shaw/sub2api#442",
+      "url": "https://github.com/Wei-Shaw/sub2api/issues/442",
+      "title": "订阅套餐重置问题讨论",
+      "impact": "unknown_low_signal",
+      "categories": [],
+      "tokenkey_status": "not_prioritized",
+      "rationale": "No high-signal production-risk keywords in this pass.",
+      "updated_at": "2026-02-01T15:24:40Z"
+    },
+    {
+      "upstream": "Wei-Shaw/sub2api#443",
+      "url": "https://github.com/Wei-Shaw/sub2api/issues/443",
+      "title": "账号可用金额预估",
+      "impact": "unknown_low_signal",
+      "categories": [],
+      "tokenkey_status": "not_prioritized",
+      "rationale": "No high-signal production-risk keywords in this pass.",
+      "updated_at": "2026-02-01T18:24:00Z"
+    },
+    {
+      "upstream": "Wei-Shaw/sub2api#451",
+      "url": "https://github.com/Wei-Shaw/sub2api/issues/451",
+      "title": "Web GUI 显示的错误记录缺乏实用信息",
+      "impact": "unknown_low_signal",
+      "categories": [],
+      "tokenkey_status": "not_prioritized",
+      "rationale": "No high-signal production-risk keywords in this pass.",
+      "updated_at": "2026-02-02T10:23:11Z"
+    },
+    {
+      "upstream": "Wei-Shaw/sub2api#477",
+      "url": "https://github.com/Wei-Shaw/sub2api/issues/477",
+      "title": "是否支持配额达到80%后，使用其他账号进行调度？",
+      "impact": "unknown_low_signal",
+      "categories": [],
+      "tokenkey_status": "not_prioritized",
+      "rationale": "No high-signal production-risk keywords in this pass.",
+      "updated_at": "2026-02-07T23:40:00Z"
+    },
+    {
+      "upstream": "Wei-Shaw/sub2api#478",
+      "url": "https://github.com/Wei-Shaw/sub2api/issues/478",
+      "title": "请问 gemini-3-pro-image 模型如何调用",
+      "impact": "unknown_low_signal",
+      "categories": [],
+      "tokenkey_status": "not_prioritized",
+      "rationale": "No high-signal production-risk keywords in this pass.",
+      "updated_at": "2026-02-05T07:55:13Z"
+    },
+    {
+      "upstream": "Wei-Shaw/sub2api#479",
+      "url": "https://github.com/Wei-Shaw/sub2api/issues/479",
+      "title": "Claude官方授权正常,但是测试出现403",
+      "impact": "unknown_low_signal",
+      "categories": [],
+      "tokenkey_status": "not_prioritized",
+      "rationale": "No high-signal production-risk keywords in this pass.",
+      "updated_at": "2026-04-29T02:39:38Z"
+    },
+    {
+      "upstream": "Wei-Shaw/sub2api#484",
+      "url": "https://github.com/Wei-Shaw/sub2api/issues/484",
+      "title": "用量窗口不能刷新",
+      "impact": "unknown_low_signal",
+      "categories": [],
+      "tokenkey_status": "not_prioritized",
+      "rationale": "No high-signal production-risk keywords in this pass.",
+      "updated_at": "2026-02-07T02:20:53Z"
+    },
+    {
+      "upstream": "Wei-Shaw/sub2api#491",
+      "url": "https://github.com/Wei-Shaw/sub2api/issues/491",
+      "title": "openai配置404",
+      "impact": "unknown_low_signal",
+      "categories": [],
+      "tokenkey_status": "not_prioritized",
+      "rationale": "No high-signal production-risk keywords in this pass.",
+      "updated_at": "2026-05-01T09:14:05Z"
+    },
+    {
+      "upstream": "Wei-Shaw/sub2api#51",
+      "url": "https://github.com/Wei-Shaw/sub2api/issues/51",
+      "title": "好 好 好",
+      "impact": "unknown_low_signal",
+      "categories": [],
+      "tokenkey_status": "not_prioritized",
+      "rationale": "No high-signal production-risk keywords in this pass.",
+      "updated_at": "2025-12-27T06:39:34Z"
+    },
+    {
+      "upstream": "Wei-Shaw/sub2api#516",
+      "url": "https://github.com/Wei-Shaw/sub2api/issues/516",
+      "title": "opus 返回404",
+      "impact": "unknown_low_signal",
+      "categories": [],
+      "tokenkey_status": "not_prioritized",
+      "rationale": "No high-signal production-risk keywords in this pass.",
+      "updated_at": "2026-02-11T12:34:36Z"
+    },
+    {
+      "upstream": "Wei-Shaw/sub2api#521",
+      "url": "https://github.com/Wei-Shaw/sub2api/issues/521",
+      "title": "docker部署改密码一直提示错误，登录不进去",
+      "impact": "unknown_low_signal",
+      "categories": [],
+      "tokenkey_status": "not_prioritized",
+      "rationale": "No high-signal production-risk keywords in this pass.",
+      "updated_at": "2026-05-13T03:31:02Z"
+    },
+    {
+      "upstream": "Wei-Shaw/sub2api#534",
+      "url": "https://github.com/Wei-Shaw/sub2api/issues/534",
+      "title": "反代反重力出现新的400错误，bad request.",
+      "impact": "unknown_low_signal",
+      "categories": [],
+      "tokenkey_status": "not_prioritized",
+      "rationale": "No high-signal production-risk keywords in this pass.",
+      "updated_at": "2026-02-26T02:54:51Z"
+    },
+    {
+      "upstream": "Wei-Shaw/sub2api#536",
+      "url": "https://github.com/Wei-Shaw/sub2api/issues/536",
+      "title": "Open apikey账号接入失败",
+      "impact": "unknown_low_signal",
+      "categories": [],
+      "tokenkey_status": "not_prioritized",
+      "rationale": "No high-signal production-risk keywords in this pass.",
+      "updated_at": "2026-03-03T15:09:21Z"
+    },
+    {
+      "upstream": "Wei-Shaw/sub2api#537",
+      "url": "https://github.com/Wei-Shaw/sub2api/issues/537",
+      "title": "「需求」可以对每个账号设置天用量和周用量",
+      "impact": "unknown_low_signal",
+      "categories": [],
+      "tokenkey_status": "not_prioritized",
+      "rationale": "No high-signal production-risk keywords in this pass.",
+      "updated_at": "2026-02-10T00:22:14Z"
+    },
+    {
+      "upstream": "Wei-Shaw/sub2api#538",
+      "url": "https://github.com/Wei-Shaw/sub2api/issues/538",
+      "title": "Debian12系统，源码编译部署时无任何引导配置流程，登录一直提示密码不对",
+      "impact": "unknown_low_signal",
+      "categories": [],
+      "tokenkey_status": "not_prioritized",
+      "rationale": "No high-signal production-risk keywords in this pass.",
+      "updated_at": "2026-02-10T03:17:16Z"
+    },
+    {
+      "upstream": "Wei-Shaw/sub2api#539",
+      "url": "https://github.com/Wei-Shaw/sub2api/issues/539",
+      "title": "现在无论哪个账号opus4.5都不行",
+      "impact": "unknown_low_signal",
+      "categories": [],
+      "tokenkey_status": "not_prioritized",
+      "rationale": "No high-signal production-risk keywords in this pass.",
+      "updated_at": "2026-02-14T04:05:19Z"
+    },
+    {
+      "upstream": "Wei-Shaw/sub2api#540",
+      "url": "https://github.com/Wei-Shaw/sub2api/issues/540",
+      "title": "反重力opus4.6提示没有这个模型",
+      "impact": "unknown_low_signal",
+      "categories": [],
+      "tokenkey_status": "not_prioritized",
+      "rationale": "No high-signal production-risk keywords in this pass.",
+      "updated_at": "2026-02-10T12:23:36Z"
+    },
+    {
+      "upstream": "Wei-Shaw/sub2api#542",
+      "url": "https://github.com/Wei-Shaw/sub2api/issues/542",
+      "title": "如何管理模型价格",
+      "impact": "unknown_low_signal",
+      "categories": [],
+      "tokenkey_status": "not_prioritized",
+      "rationale": "No high-signal production-risk keywords in this pass.",
+      "updated_at": "2026-05-10T11:24:22Z"
+    },
+    {
+      "upstream": "Wei-Shaw/sub2api#546",
+      "url": "https://github.com/Wei-Shaw/sub2api/issues/546",
+      "title": "分组有问题",
+      "impact": "unknown_low_signal",
+      "categories": [],
+      "tokenkey_status": "not_prioritized",
+      "rationale": "No high-signal production-risk keywords in this pass.",
+      "updated_at": "2026-02-10T12:10:52Z"
+    },
+    {
+      "upstream": "Wei-Shaw/sub2api#563",
+      "url": "https://github.com/Wei-Shaw/sub2api/issues/563",
+      "title": "Access forbidden (403):",
+      "impact": "unknown_low_signal",
+      "categories": [],
+      "tokenkey_status": "not_prioritized",
+      "rationale": "No high-signal production-risk keywords in this pass.",
+      "updated_at": "2026-02-25T08:57:29Z"
+    },
+    {
+      "upstream": "Wei-Shaw/sub2api#565",
+      "url": "https://github.com/Wei-Shaw/sub2api/issues/565",
+      "title": "能否像CRS1 一样能够查询缓存的创建和读取的具体数据",
+      "impact": "unknown_low_signal",
+      "categories": [],
+      "tokenkey_status": "not_prioritized",
+      "rationale": "No high-signal production-risk keywords in this pass.",
+      "updated_at": "2026-02-12T04:42:02Z"
+    },
+    {
+      "upstream": "Wei-Shaw/sub2api#568",
+      "url": "https://github.com/Wei-Shaw/sub2api/issues/568",
+      "title": "关于创建缓.存设置开启关闭功能能否添加",
+      "impact": "unknown_low_signal",
+      "categories": [],
+      "tokenkey_status": "not_prioritized",
+      "rationale": "No high-signal production-risk keywords in this pass.",
+      "updated_at": "2026-02-12T19:11:40Z"
+    },
+    {
+      "upstream": "Wei-Shaw/sub2api#575",
+      "url": "https://github.com/Wei-Shaw/sub2api/issues/575",
+      "title": "请问openai通道接入sub2api后如何接入newapi呀",
+      "impact": "unknown_low_signal",
+      "categories": [],
+      "tokenkey_status": "not_prioritized",
+      "rationale": "No high-signal production-risk keywords in this pass.",
+      "updated_at": "2026-03-04T19:32:22Z"
+    },
+    {
+      "upstream": "Wei-Shaw/sub2api#581",
+      "url": "https://github.com/Wei-Shaw/sub2api/issues/581",
+      "title": "佬看到有从CRS同步账号的功能，什么时候添加从CPA同步账号的功能呢",
+      "impact": "unknown_low_signal",
+      "categories": [],
+      "tokenkey_status": "not_prioritized",
+      "rationale": "No high-signal production-risk keywords in this pass.",
+      "updated_at": "2026-02-14T12:31:57Z"
+    },
+    {
+      "upstream": "Wei-Shaw/sub2api#595",
+      "url": "https://github.com/Wei-Shaw/sub2api/issues/595",
+      "title": "通过api添加的账号，上周周限用光了，今天重置额度之后sub2里面还是没办法继续使用，必须删除账号重新添加这个api才可以",
+      "impact": "unknown_low_signal",
+      "categories": [],
+      "tokenkey_status": "not_prioritized",
+      "rationale": "No high-signal production-risk keywords in this pass.",
+      "updated_at": "2026-02-22T09:03:08Z"
+    },
+    {
+      "upstream": "Wei-Shaw/sub2api#626",
+      "url": "https://github.com/Wei-Shaw/sub2api/issues/626",
+      "title": "错误过滤可以忽略API key 额度用完的报错",
+      "impact": "unknown_low_signal",
+      "categories": [],
+      "tokenkey_status": "not_prioritized",
+      "rationale": "No high-signal production-risk keywords in this pass.",
+      "updated_at": "2026-02-24T16:15:52Z"
+    },
+    {
+      "upstream": "Wei-Shaw/sub2api#629",
+      "url": "https://github.com/Wei-Shaw/sub2api/issues/629",
+      "title": "gpt-5.3-codex模型疑似被投毒，输出菠菜内容，有佬有解决办法嘛",
+      "impact": "unknown_low_signal",
+      "categories": [],
+      "tokenkey_status": "not_prioritized",
+      "rationale": "No high-signal production-risk keywords in this pass.",
+      "updated_at": "2026-04-30T09:12:17Z"
+    },
+    {
+      "upstream": "Wei-Shaw/sub2api#637",
+      "url": "https://github.com/Wei-Shaw/sub2api/issues/637",
+      "title": "【需求】告警策略支持增加后置执行操作",
+      "impact": "unknown_low_signal",
+      "categories": [],
+      "tokenkey_status": "not_prioritized",
+      "rationale": "No high-signal production-risk keywords in this pass.",
+      "updated_at": "2026-02-25T10:54:35Z"
+    },
+    {
+      "upstream": "Wei-Shaw/sub2api#642",
+      "url": "https://github.com/Wei-Shaw/sub2api/issues/642",
+      "title": "【需求】代理测试对于ipv6代理无法正常测试",
+      "impact": "unknown_low_signal",
+      "categories": [],
+      "tokenkey_status": "not_prioritized",
+      "rationale": "No high-signal production-risk keywords in this pass.",
+      "updated_at": "2026-03-01T16:25:57Z"
+    },
+    {
+      "upstream": "Wei-Shaw/sub2api#646",
+      "url": "https://github.com/Wei-Shaw/sub2api/issues/646",
+      "title": "这个项目有没有 codex2claude 的方案?",
+      "impact": "unknown_low_signal",
+      "categories": [],
+      "tokenkey_status": "not_prioritized",
+      "rationale": "No high-signal production-risk keywords in this pass.",
+      "updated_at": "2026-05-12T07:22:02Z"
+    },
+    {
+      "upstream": "Wei-Shaw/sub2api#649",
+      "url": "https://github.com/Wei-Shaw/sub2api/issues/649",
+      "title": "【需求】创建密钥支持对密钥设置最大并发数",
+      "impact": "unknown_low_signal",
+      "categories": [],
+      "tokenkey_status": "not_prioritized",
+      "rationale": "No high-signal production-risk keywords in this pass.",
+      "updated_at": "2026-02-26T04:01:31Z"
+    },
+    {
+      "upstream": "Wei-Shaw/sub2api#652",
+      "url": "https://github.com/Wei-Shaw/sub2api/issues/652",
+      "title": "添加了多个上游账号后，如果遇到有某个账号异常，是否会自动切换到其他账号去",
+      "impact": "unknown_low_signal",
+      "categories": [],
+      "tokenkey_status": "not_prioritized",
+      "rationale": "No high-signal production-risk keywords in this pass.",
+      "updated_at": "2026-02-26T08:49:48Z"
+    },
+    {
+      "upstream": "Wei-Shaw/sub2api#655",
+      "url": "https://github.com/Wei-Shaw/sub2api/issues/655",
+      "title": "使用Codex 最新版本0.105.0终端时过程中，任务进行中总是出现 {\"error\":{\"message\":\"Failed to parse request body\",\"type\":\"invalid_request_error\"}}格式错误",
+      "impact": "unknown_low_signal",
+      "categories": [],
+      "tokenkey_status": "not_prioritized",
+      "rationale": "No high-signal production-risk keywords in this pass.",
+      "updated_at": "2026-02-26T10:15:09Z"
+    },
+    {
+      "upstream": "Wei-Shaw/sub2api#660",
+      "url": "https://github.com/Wei-Shaw/sub2api/issues/660",
+      "title": "找回密码配置问题",
+      "impact": "unknown_low_signal",
+      "categories": [],
+      "tokenkey_status": "not_prioritized",
+      "rationale": "No high-signal production-risk keywords in this pass.",
+      "updated_at": "2026-02-27T03:06:42Z"
+    },
+    {
+      "upstream": "Wei-Shaw/sub2api#662",
+      "url": "https://github.com/Wei-Shaw/sub2api/issues/662",
+      "title": "关闭账号还能使用 bug？",
+      "impact": "unknown_low_signal",
+      "categories": [],
+      "tokenkey_status": "not_prioritized",
+      "rationale": "No high-signal production-risk keywords in this pass.",
+      "updated_at": "2026-02-27T11:47:17Z"
+    },
+    {
+      "upstream": "Wei-Shaw/sub2api#667",
+      "url": "https://github.com/Wei-Shaw/sub2api/issues/667",
+      "title": "删除用户不会附带删除用户创建的API",
+      "impact": "unknown_low_signal",
+      "categories": [],
+      "tokenkey_status": "not_prioritized",
+      "rationale": "No high-signal production-risk keywords in this pass.",
+      "updated_at": "2026-02-27T12:28:03Z"
+    },
+    {
+      "upstream": "Wei-Shaw/sub2api#669",
+      "url": "https://github.com/Wei-Shaw/sub2api/issues/669",
+      "title": "BUG Antigravity 用量窗口Claude显示溢出问题",
+      "impact": "unknown_low_signal",
+      "categories": [],
+      "tokenkey_status": "not_prioritized",
+      "rationale": "No high-signal production-risk keywords in this pass.",
+      "updated_at": "2026-02-28T05:25:29Z"
+    },
+    {
+      "upstream": "Wei-Shaw/sub2api#674",
+      "url": "https://github.com/Wei-Shaw/sub2api/issues/674",
+      "title": "[feat] 请求支持admin接口在任意用户下 创建/更新/删除 apikey的能力",
+      "impact": "unknown_low_signal",
+      "categories": [],
+      "tokenkey_status": "not_prioritized",
+      "rationale": "No high-signal production-risk keywords in this pass.",
+      "updated_at": "2026-03-05T01:03:29Z"
+    },
+    {
+      "upstream": "Wei-Shaw/sub2api#677",
+      "url": "https://github.com/Wei-Shaw/sub2api/issues/677",
+      "title": "soar 授权后测试链接403问题",
+      "impact": "unknown_low_signal",
+      "categories": [],
+      "tokenkey_status": "not_prioritized",
+      "rationale": "No high-signal production-risk keywords in this pass.",
+      "updated_at": "2026-02-28T03:26:10Z"
+    },
+    {
+      "upstream": "Wei-Shaw/sub2api#684",
+      "url": "https://github.com/Wei-Shaw/sub2api/issues/684",
+      "title": "TZ environment variable not respected - logs always show +0800 (Asia/Shanghai)",
+      "impact": "unknown_low_signal",
+      "categories": [],
+      "tokenkey_status": "not_prioritized",
+      "rationale": "No high-signal production-risk keywords in this pass.",
+      "updated_at": "2026-02-28T16:27:29Z"
+    },
+    {
+      "upstream": "Wei-Shaw/sub2api#691",
+      "url": "https://github.com/Wei-Shaw/sub2api/issues/691",
+      "title": "redis 配置问题",
+      "impact": "unknown_low_signal",
+      "categories": [],
+      "tokenkey_status": "not_prioritized",
+      "rationale": "No high-signal production-risk keywords in this pass.",
+      "updated_at": "2026-03-04T02:00:00Z"
+    },
+    {
+      "upstream": "Wei-Shaw/sub2api#698",
+      "url": "https://github.com/Wei-Shaw/sub2api/issues/698",
+      "title": "Megumi Fushiguro",
+      "impact": "unknown_low_signal",
+      "categories": [],
+      "tokenkey_status": "not_prioritized",
+      "rationale": "No high-signal production-risk keywords in this pass.",
+      "updated_at": "2026-03-01T15:20:31Z"
+    },
+    {
+      "upstream": "Wei-Shaw/sub2api#700",
+      "url": "https://github.com/Wei-Shaw/sub2api/issues/700",
+      "title": "为了对其其他贡献者，需要完善`openspec`",
+      "impact": "unknown_low_signal",
+      "categories": [],
+      "tokenkey_status": "not_prioritized",
+      "rationale": "No high-signal production-risk keywords in this pass.",
+      "updated_at": "2026-03-01T15:37:37Z"
+    },
+    {
+      "upstream": "Wei-Shaw/sub2api#701",
+      "url": "https://github.com/Wei-Shaw/sub2api/issues/701",
+      "title": "【Bug】选择simple模式无法使用antigravity分组 和 设定antigravity分组",
+      "impact": "unknown_low_signal",
+      "categories": [],
+      "tokenkey_status": "not_prioritized",
+      "rationale": "No high-signal production-risk keywords in this pass.",
+      "updated_at": "2026-03-01T16:35:58Z"
+    },
+    {
+      "upstream": "Wei-Shaw/sub2api#707",
+      "url": "https://github.com/Wei-Shaw/sub2api/issues/707",
+      "title": "codex 授权失败",
+      "impact": "unknown_low_signal",
+      "categories": [],
+      "tokenkey_status": "not_prioritized",
+      "rationale": "No high-signal production-risk keywords in this pass.",
+      "updated_at": "2026-03-02T04:04:44Z"
+    },
+    {
+      "upstream": "Wei-Shaw/sub2api#708",
+      "url": "https://github.com/Wei-Shaw/sub2api/issues/708",
+      "title": "【需求】针对apikey级别进行并发数限制",
+      "impact": "unknown_low_signal",
+      "categories": [],
+      "tokenkey_status": "not_prioritized",
+      "rationale": "No high-signal production-risk keywords in this pass.",
+      "updated_at": "2026-04-12T06:11:37Z"
+    },
+    {
+      "upstream": "Wei-Shaw/sub2api#717",
+      "url": "https://github.com/Wei-Shaw/sub2api/issues/717",
+      "title": "【bug】给订阅分组设置了倍率，关联了用户后，用户实际使用的额度还是按单倍进行限制的",
+      "impact": "unknown_low_signal",
+      "categories": [],
+      "tokenkey_status": "not_prioritized",
+      "rationale": "No high-signal production-risk keywords in this pass.",
+      "updated_at": "2026-03-21T03:00:36Z"
+    },
+    {
+      "upstream": "Wei-Shaw/sub2api#719",
+      "url": "https://github.com/Wei-Shaw/sub2api/issues/719",
+      "title": "目前没有办法知道账号类型",
+      "impact": "unknown_low_signal",
+      "categories": [],
+      "tokenkey_status": "not_prioritized",
+      "rationale": "No high-signal production-risk keywords in this pass.",
+      "updated_at": "2026-03-04T13:06:48Z"
+    },
+    {
+      "upstream": "Wei-Shaw/sub2api#720",
+      "url": "https://github.com/Wei-Shaw/sub2api/issues/720",
+      "title": "为什么本地部署出现404问题？",
+      "impact": "unknown_low_signal",
+      "categories": [],
+      "tokenkey_status": "not_prioritized",
+      "rationale": "No high-signal production-risk keywords in this pass.",
+      "updated_at": "2026-03-11T06:56:55Z"
+    },
+    {
+      "upstream": "Wei-Shaw/sub2api#722",
+      "url": "https://github.com/Wei-Shaw/sub2api/issues/722",
+      "title": "同一个分组的账号池子，一旦在账号比较多的情况下，codex响应返回的速度就会变得很慢，完成一个任务要花非常长的时间，不知道佬有没有遇到这个情况",
+      "impact": "unknown_low_signal",
+      "categories": [],
+      "tokenkey_status": "not_prioritized",
+      "rationale": "No high-signal production-risk keywords in this pass.",
+      "updated_at": "2026-04-21T12:44:16Z"
+    },
+    {
+      "upstream": "Wei-Shaw/sub2api#758",
+      "url": "https://github.com/Wei-Shaw/sub2api/issues/758",
+      "title": "反重力逆向无法使用",
+      "impact": "unknown_low_signal",
+      "categories": [],
+      "tokenkey_status": "not_prioritized",
+      "rationale": "No high-signal production-risk keywords in this pass.",
+      "updated_at": "2026-03-04T08:33:06Z"
+    },
+    {
+      "upstream": "Wei-Shaw/sub2api#76",
+      "url": "https://github.com/Wei-Shaw/sub2api/issues/76",
+      "title": "删除后的分组没有办法使用同样的名称进行创建",
+      "impact": "unknown_low_signal",
+      "categories": [],
+      "tokenkey_status": "not_prioritized",
+      "rationale": "No high-signal production-risk keywords in this pass.",
+      "updated_at": "2025-12-29T14:26:22Z"
+    },
+    {
+      "upstream": "Wei-Shaw/sub2api#768",
+      "url": "https://github.com/Wei-Shaw/sub2api/issues/768",
+      "title": "简单模式下无法更改初始用户并发额度",
+      "impact": "unknown_low_signal",
+      "categories": [],
+      "tokenkey_status": "not_prioritized",
+      "rationale": "No high-signal production-risk keywords in this pass.",
+      "updated_at": "2026-03-04T16:14:11Z"
+    },
+    {
+      "upstream": "Wei-Shaw/sub2api#769",
+      "url": "https://github.com/Wei-Shaw/sub2api/issues/769",
+      "title": "[需求]账号管理中不能筛选出开启调度状态和未开启调度状态的账号",
+      "impact": "unknown_low_signal",
+      "categories": [],
+      "tokenkey_status": "not_prioritized",
+      "rationale": "No high-signal production-risk keywords in this pass.",
+      "updated_at": "2026-03-04T17:23:58Z"
+    },
+    {
+      "upstream": "Wei-Shaw/sub2api#773",
+      "url": "https://github.com/Wei-Shaw/sub2api/issues/773",
+      "title": "unexpected status 413 Payload Too Large",
+      "impact": "unknown_low_signal",
+      "categories": [],
+      "tokenkey_status": "not_prioritized",
+      "rationale": "No high-signal production-risk keywords in this pass.",
+      "updated_at": "2026-04-21T07:47:58Z"
+    },
+    {
+      "upstream": "Wei-Shaw/sub2api#774",
+      "url": "https://github.com/Wei-Shaw/sub2api/issues/774",
+      "title": "阿里云/火山云 coding plan账号分发",
+      "impact": "unknown_low_signal",
+      "categories": [],
+      "tokenkey_status": "not_prioritized",
+      "rationale": "No high-signal production-risk keywords in this pass.",
+      "updated_at": "2026-04-24T11:45:50Z"
+    },
+    {
+      "upstream": "Wei-Shaw/sub2api#776",
+      "url": "https://github.com/Wei-Shaw/sub2api/issues/776",
+      "title": "请问claude max怎么接入到openwebui里，我想再用newapi转接一下好像不行",
+      "impact": "unknown_low_signal",
+      "categories": [],
+      "tokenkey_status": "not_prioritized",
+      "rationale": "No high-signal production-risk keywords in this pass.",
+      "updated_at": "2026-03-22T09:31:34Z"
+    },
+    {
+      "upstream": "Wei-Shaw/sub2api#779",
+      "url": "https://github.com/Wei-Shaw/sub2api/issues/779",
+      "title": "后台登录有效期与service temporarily unavailable问题",
+      "impact": "unknown_low_signal",
+      "categories": [],
+      "tokenkey_status": "not_prioritized",
+      "rationale": "No high-signal production-risk keywords in this pass.",
+      "updated_at": "2026-03-28T10:18:33Z"
+    },
+    {
+      "upstream": "Wei-Shaw/sub2api#786",
+      "url": "https://github.com/Wei-Shaw/sub2api/issues/786",
+      "title": "请求增加新的功能：针对每个注册的用户账号增加速率限制功能，以控制时间窗口内的金额",
+      "impact": "unknown_low_signal",
+      "categories": [],
+      "tokenkey_status": "not_prioritized",
+      "rationale": "No high-signal production-risk keywords in this pass.",
+      "updated_at": "2026-03-05T12:25:13Z"
+    },
+    {
+      "upstream": "Wei-Shaw/sub2api#80",
+      "url": "https://github.com/Wei-Shaw/sub2api/issues/80",
+      "title": "需要填写字段为灰色",
+      "impact": "unknown_low_signal",
+      "categories": [],
+      "tokenkey_status": "not_prioritized",
+      "rationale": "No high-signal production-risk keywords in this pass.",
+      "updated_at": "2025-12-29T14:33:04Z"
+    },
+    {
+      "upstream": "Wei-Shaw/sub2api#804",
+      "url": "https://github.com/Wei-Shaw/sub2api/issues/804",
+      "title": "invalid timezone",
+      "impact": "unknown_low_signal",
+      "categories": [],
+      "tokenkey_status": "not_prioritized",
+      "rationale": "No high-signal production-risk keywords in this pass.",
+      "updated_at": "2026-04-17T02:46:12Z"
+    },
+    {
+      "upstream": "Wei-Shaw/sub2api#81",
+      "url": "https://github.com/Wei-Shaw/sub2api/issues/81",
+      "title": "Gemini-CLI的使用方式错误",
+      "impact": "unknown_low_signal",
+      "categories": [],
+      "tokenkey_status": "not_prioritized",
+      "rationale": "No high-signal production-risk keywords in this pass.",
+      "updated_at": "2026-01-01T15:15:19Z"
+    },
+    {
+      "upstream": "Wei-Shaw/sub2api#845",
+      "url": "https://github.com/Wei-Shaw/sub2api/issues/845",
+      "title": "【bug】2个问题：1个需求、1个bug",
+      "impact": "unknown_low_signal",
+      "categories": [],
+      "tokenkey_status": "not_prioritized",
+      "rationale": "No high-signal production-risk keywords in this pass.",
+      "updated_at": "2026-03-08T04:05:18Z"
+    },
+    {
+      "upstream": "Wei-Shaw/sub2api#862",
+      "url": "https://github.com/Wei-Shaw/sub2api/issues/862",
+      "title": "在线升级不了，网络错误。部署在云服务器上面的，怎么会升级不了，网络错误，是Bug吗？",
+      "impact": "unknown_low_signal",
+      "categories": [],
+      "tokenkey_status": "not_prioritized",
+      "rationale": "No high-signal production-risk keywords in this pass.",
+      "updated_at": "2026-03-08T11:32:19Z"
+    },
+    {
+      "upstream": "Wei-Shaw/sub2api#863",
+      "url": "https://github.com/Wei-Shaw/sub2api/issues/863",
+      "title": "测试连接时，能随带着刷新下用量窗口吗？",
+      "impact": "unknown_low_signal",
+      "categories": [],
+      "tokenkey_status": "not_prioritized",
+      "rationale": "No high-signal production-risk keywords in this pass.",
+      "updated_at": "2026-03-10T02:16:07Z"
+    },
+    {
+      "upstream": "Wei-Shaw/sub2api#873",
+      "url": "https://github.com/Wei-Shaw/sub2api/issues/873",
+      "title": "Codex令牌刷新",
+      "impact": "unknown_low_signal",
+      "categories": [],
+      "tokenkey_status": "not_prioritized",
+      "rationale": "No high-signal production-risk keywords in this pass.",
+      "updated_at": "2026-03-08T18:29:29Z"
+    },
+    {
+      "upstream": "Wei-Shaw/sub2api#879",
+      "url": "https://github.com/Wei-Shaw/sub2api/issues/879",
+      "title": "Codex ran out of room in the model's context window. Start a new thread or clear earlier history before retrying.",
+      "impact": "unknown_low_signal",
+      "categories": [],
+      "tokenkey_status": "not_prioritized",
+      "rationale": "No high-signal production-risk keywords in this pass.",
+      "updated_at": "2026-03-20T02:27:54Z"
+    },
+    {
+      "upstream": "Wei-Shaw/sub2api#880",
+      "url": "https://github.com/Wei-Shaw/sub2api/issues/880",
+      "title": "【BUG】无法筛选 已经设置为停止调度状态的账号",
+      "impact": "unknown_low_signal",
+      "categories": [],
+      "tokenkey_status": "not_prioritized",
+      "rationale": "No high-signal production-risk keywords in this pass.",
+      "updated_at": "2026-03-09T08:21:45Z"
+    },
+    {
+      "upstream": "Wei-Shaw/sub2api#883",
+      "url": "https://github.com/Wei-Shaw/sub2api/issues/883",
+      "title": "大家都是用这个项目做什么的？",
+      "impact": "unknown_low_signal",
+      "categories": [],
+      "tokenkey_status": "not_prioritized",
+      "rationale": "No high-signal production-risk keywords in this pass.",
+      "updated_at": "2026-03-13T10:14:22Z"
+    },
+    {
+      "upstream": "Wei-Shaw/sub2api#895",
+      "url": "https://github.com/Wei-Shaw/sub2api/issues/895",
+      "title": "openai session出现漂移的情况",
+      "impact": "unknown_low_signal",
+      "categories": [],
+      "tokenkey_status": "not_prioritized",
+      "rationale": "No high-signal production-risk keywords in this pass.",
+      "updated_at": "2026-03-09T12:05:49Z"
+    },
+    {
+      "upstream": "Wei-Shaw/sub2api#906",
+      "url": "https://github.com/Wei-Shaw/sub2api/issues/906",
+      "title": "订阅的速率控制窗口的5h能对齐用量窗口的5h么？",
+      "impact": "unknown_low_signal",
+      "categories": [],
+      "tokenkey_status": "not_prioritized",
+      "rationale": "No high-signal production-risk keywords in this pass.",
+      "updated_at": "2026-03-10T03:12:03Z"
+    },
+    {
+      "upstream": "Wei-Shaw/sub2api#911",
+      "url": "https://github.com/Wei-Shaw/sub2api/issues/911",
+      "title": "请求支持embedding",
+      "impact": "unknown_low_signal",
+      "categories": [],
+      "tokenkey_status": "not_prioritized",
+      "rationale": "No high-signal production-risk keywords in this pass.",
+      "updated_at": "2026-04-05T07:15:20Z"
+    },
+    {
+      "upstream": "Wei-Shaw/sub2api#912",
+      "url": "https://github.com/Wei-Shaw/sub2api/issues/912",
+      "title": "请求支持grok",
+      "impact": "unknown_low_signal",
+      "categories": [],
+      "tokenkey_status": "not_prioritized",
+      "rationale": "No high-signal production-risk keywords in this pass.",
+      "updated_at": "2026-03-10T08:35:36Z"
+    },
+    {
+      "upstream": "Wei-Shaw/sub2api#914",
+      "url": "https://github.com/Wei-Shaw/sub2api/issues/914",
+      "title": "提一个通知需求",
+      "impact": "unknown_low_signal",
+      "categories": [],
+      "tokenkey_status": "not_prioritized",
+      "rationale": "No high-signal production-risk keywords in this pass.",
+      "updated_at": "2026-03-10T15:18:46Z"
+    },
+    {
+      "upstream": "Wei-Shaw/sub2api#916",
+      "url": "https://github.com/Wei-Shaw/sub2api/issues/916",
+      "title": "使用team账号的rt 不会自动识别成team 会识别成个人区",
+      "impact": "unknown_low_signal",
+      "categories": [],
+      "tokenkey_status": "not_prioritized",
+      "rationale": "No high-signal production-risk keywords in this pass.",
+      "updated_at": "2026-03-11T13:14:08Z"
+    },
+    {
+      "upstream": "Wei-Shaw/sub2api#924",
+      "url": "https://github.com/Wei-Shaw/sub2api/issues/924",
+      "title": "outh登录多个GPT账号，会不会封号啊？（多账号用同一IP登录）",
+      "impact": "unknown_low_signal",
+      "categories": [],
+      "tokenkey_status": "not_prioritized",
+      "rationale": "No high-signal production-risk keywords in this pass.",
+      "updated_at": "2026-05-07T07:57:17Z"
+    },
+    {
+      "upstream": "Wei-Shaw/sub2api#927",
+      "url": "https://github.com/Wei-Shaw/sub2api/issues/927",
+      "title": "Calculate cost failed: pricing not found for model: glm-5",
+      "impact": "unknown_low_signal",
+      "categories": [],
+      "tokenkey_status": "not_prioritized",
+      "rationale": "No high-signal production-risk keywords in this pass.",
+      "updated_at": "2026-05-13T11:04:06Z"
+    },
+    {
+      "upstream": "Wei-Shaw/sub2api#94",
+      "url": "https://github.com/Wei-Shaw/sub2api/issues/94",
+      "title": "目前管理员只能设置一个，是否能给其他用户设置管理员？",
+      "impact": "unknown_low_signal",
+      "categories": [],
+      "tokenkey_status": "not_prioritized",
+      "rationale": "No high-signal production-risk keywords in this pass.",
+      "updated_at": "2026-02-21T10:57:33Z"
+    },
+    {
+      "upstream": "Wei-Shaw/sub2api#950",
+      "url": "https://github.com/Wei-Shaw/sub2api/issues/950",
+      "title": "Gemini 部分模型缺少定价显示，也没办法自己配置价格",
+      "impact": "unknown_low_signal",
+      "categories": [],
+      "tokenkey_status": "not_prioritized",
+      "rationale": "No high-signal production-risk keywords in this pass.",
+      "updated_at": "2026-03-12T09:44:11Z"
+    },
+    {
+      "upstream": "Wei-Shaw/sub2api#962",
+      "url": "https://github.com/Wei-Shaw/sub2api/issues/962",
+      "title": "GPT 映射的推理强度好像不对。",
+      "impact": "unknown_low_signal",
+      "categories": [],
+      "tokenkey_status": "not_prioritized",
+      "rationale": "No high-signal production-risk keywords in this pass.",
+      "updated_at": "2026-03-12T22:45:20Z"
+    },
+    {
+      "upstream": "Wei-Shaw/sub2api#968",
+      "url": "https://github.com/Wei-Shaw/sub2api/issues/968",
+      "title": "openai自动映射到gpt-5.1",
+      "impact": "unknown_low_signal",
+      "categories": [],
+      "tokenkey_status": "not_prioritized",
+      "rationale": "No high-signal production-risk keywords in this pass.",
+      "updated_at": "2026-04-02T03:38:18Z"
+    },
+    {
+      "upstream": "Wei-Shaw/sub2api#972",
+      "url": "https://github.com/Wei-Shaw/sub2api/issues/972",
+      "title": "优先级的使用顺序有bug",
+      "impact": "unknown_low_signal",
+      "categories": [],
+      "tokenkey_status": "not_prioritized",
+      "rationale": "No high-signal production-risk keywords in this pass.",
+      "updated_at": "2026-04-15T11:48:23Z"
+    },
+    {
+      "upstream": "Wei-Shaw/sub2api#995",
+      "url": "https://github.com/Wei-Shaw/sub2api/issues/995",
+      "title": "能不能支持存在分组既能支持openai又能支持claude、gemini的大分组呢，这样的话订阅可以分配一整天的用量",
+      "impact": "unknown_low_signal",
+      "categories": [],
+      "tokenkey_status": "not_prioritized",
+      "rationale": "No high-signal production-risk keywords in this pass.",
+      "updated_at": "2026-04-30T04:07:49Z"
+    }
+  ]
+}


### PR DESCRIPTION
## Summary
- Add a reusable upstream issue triage cache generated from Wei-Shaw/sub2api open issues.
- Record confirmed high-risk unresolved TokenKey issues and already-fixed upstream reports to avoid repeated manual classification.
- Add a small generator script for refreshing the cache from GitHub issue JSONL data.

## Test plan
- [x] python3 -m json.tool scripts/upstream-issue-triage.json
- [x] python3 -m json.tool scripts/upstream-issue-fixes.json
- [x] python3 scripts/upstream-issue-triage-generate.py "$CLAUDE_JOB_DIR/upstream-open-issues.jsonl" "$CLAUDE_JOB_DIR/triage-check.json"
- [x] bash scripts/preflight.sh

🤖 Generated with [Claude Code](https://claude.com/claude-code)