### PR TITLE
Fix Claude thinking signature retry for API key passthrough

### DIFF
--- a/backend/internal/service/gateway_anthropic_apikey_passthrough_test.go
+++ b/backend/internal/service/gateway_anthropic_apikey_passthrough_test.go
@@ -28,6 +28,17 @@ type anthropicHTTPUpstreamRecorder struct {
 	err      error
 }
 
+type anthropicHTTPUpstreamSequenceRecorder struct {
+	reqs   []*http.Request
+	bodies [][]byte
+	resps  []*http.Response
+	err    error
+}
+
+type anthropicPassthroughSettingRepoStub struct {
+	values map[string]string
+}
+
 func newAnthropicAPIKeyAccountForTest() *Account {
 	return &Account{
 		ID:          201,
@@ -63,6 +74,66 @@ func (u *anthropicHTTPUpstreamRecorder) Do(req *http.Request, proxyURL string, a
 
 func (u *anthropicHTTPUpstreamRecorder) DoWithTLS(req *http.Request, proxyURL string, accountID int64, accountConcurrency int, profile *tlsfingerprint.Profile) (*http.Response, error) {
 	return u.Do(req, proxyURL, accountID, accountConcurrency)
+}
+
+func (u *anthropicHTTPUpstreamSequenceRecorder) Do(req *http.Request, proxyURL string, accountID int64, accountConcurrency int) (*http.Response, error) {
+	u.reqs = append(u.reqs, req)
+	if req != nil && req.Body != nil {
+		b, _ := io.ReadAll(req.Body)
+		u.bodies = append(u.bodies, b)
+		_ = req.Body.Close()
+		req.Body = io.NopCloser(bytes.NewReader(b))
+	}
+	if u.err != nil {
+		return nil, u.err
+	}
+	if len(u.resps) == 0 {
+		return nil, nil
+	}
+	resp := u.resps[0]
+	u.resps = u.resps[1:]
+	return resp, nil
+}
+
+func (u *anthropicHTTPUpstreamSequenceRecorder) DoWithTLS(req *http.Request, proxyURL string, accountID int64, accountConcurrency int, profile *tlsfingerprint.Profile) (*http.Response, error) {
+	return u.Do(req, proxyURL, accountID, accountConcurrency)
+}
+
+func (s *anthropicPassthroughSettingRepoStub) Get(ctx context.Context, key string) (*Setting, error) {
+	panic("unexpected Get call")
+}
+
+func (s *anthropicPassthroughSettingRepoStub) GetValue(ctx context.Context, key string) (string, error) {
+	if v, ok := s.values[key]; ok {
+		return v, nil
+	}
+	return "", ErrSettingNotFound
+}
+
+func (s *anthropicPassthroughSettingRepoStub) Set(ctx context.Context, key, value string) error {
+	panic("unexpected Set call")
+}
+
+func (s *anthropicPassthroughSettingRepoStub) GetMultiple(ctx context.Context, keys []string) (map[string]string, error) {
+	result := make(map[string]string, len(keys))
+	for _, key := range keys {
+		if v, ok := s.values[key]; ok {
+			result[key] = v
+		}
+	}
+	return result, nil
+}
+
+func (s *anthropicPassthroughSettingRepoStub) SetMultiple(ctx context.Context, settings map[string]string) error {
+	panic("unexpected SetMultiple call")
+}
+
+func (s *anthropicPassthroughSettingRepoStub) GetAll(ctx context.Context) (map[string]string, error) {
+	panic("unexpected GetAll call")
+}
+
+func (s *anthropicPassthroughSettingRepoStub) Delete(ctx context.Context, key string) error {
+	panic("unexpected Delete call")
 }
 
 type streamReadCloser struct {
@@ -923,6 +994,51 @@ func TestGatewayService_AnthropicAPIKeyPassthrough_ForwardDirect_NonStreamingSuc
 	require.Equal(t, 5, result.Usage.CacheCreationInputTokens)
 	require.Equal(t, 4, result.Usage.CacheReadInputTokens)
 	require.Equal(t, upstreamJSON, rec.Body.String())
+}
+
+func TestGatewayService_AnthropicAPIKeyPassthrough_ForwardDirect_Signature400RetriesWithFilteredThinking(t *testing.T) {
+	gin.SetMode(gin.TestMode)
+	rec := httptest.NewRecorder()
+	c, _ := gin.CreateTestContext(rec)
+	c.Request = httptest.NewRequest(http.MethodPost, "/v1/messages", nil)
+
+	body := []byte(`{"model":"claude-opus-4-7","thinking":{"type":"adaptive"},"messages":[{"role":"user","content":[{"type":"text","text":"hello"}]},{"role":"assistant","content":[{"type":"thinking","thinking":"cached thought","signature":"sig_from_previous_group"},{"type":"text","text":"answer"}]},{"role":"user","content":[{"type":"text","text":"continue"}]}]}`)
+	upstreamJSON := `{"id":"msg_retry_ok","type":"message","usage":{"input_tokens":3,"output_tokens":2}}`
+	upstream := &anthropicHTTPUpstreamSequenceRecorder{resps: []*http.Response{
+		{
+			StatusCode: http.StatusBadRequest,
+			Header: http.Header{
+				"Content-Type": []string{"application/json"},
+				"x-request-id": []string{"rid-signature-bad"},
+			},
+			Body: io.NopCloser(strings.NewReader(`{"type":"error","error":{"type":"invalid_request_error","message":"messages.1.content.0: Invalid signature in thinking block"},"request_id":"req_bad_sig"}`)),
+		},
+		{
+			StatusCode: http.StatusOK,
+			Header: http.Header{
+				"Content-Type": []string{"application/json"},
+				"x-request-id": []string{"rid-signature-retry-ok"},
+			},
+			Body: io.NopCloser(strings.NewReader(upstreamJSON)),
+		},
+	}}
+	settingSvc := NewSettingService(&anthropicPassthroughSettingRepoStub{values: map[string]string{}}, &config.Config{})
+	svc := &GatewayService{
+		cfg:              &config.Config{},
+		httpUpstream:     upstream,
+		rateLimitService: &RateLimitService{},
+		settingService:   settingSvc,
+	}
+
+	result, err := svc.forwardAnthropicAPIKeyPassthrough(context.Background(), c, newAnthropicAPIKeyAccountForTest(), body, "claude-opus-4-7", "claude-opus-4-7", false, time.Now())
+	require.NoError(t, err)
+	require.NotNil(t, result)
+	require.Equal(t, upstreamJSON, rec.Body.String())
+	require.Len(t, upstream.bodies, 2)
+	require.True(t, gjson.GetBytes(upstream.bodies[0], "thinking").Exists(), "first passthrough attempt should preserve the client body")
+	require.False(t, gjson.GetBytes(upstream.bodies[1], "thinking").Exists(), "signature retry must disable top-level thinking")
+	require.Equal(t, "text", gjson.GetBytes(upstream.bodies[1], "messages.1.content.0.type").String())
+	require.Equal(t, "cached thought", gjson.GetBytes(upstream.bodies[1], "messages.1.content.0.text").String())
 }
 
 func TestGatewayService_AnthropicAPIKeyPassthrough_ForwardDirect_InvalidTokenType(t *testing.T) {

--- a/backend/internal/service/gateway_service.go
+++ b/backend/internal/service/gateway_service.go
@@ -5088,6 +5088,7 @@ func (s *GatewayService) forwardAnthropicAPIKeyPassthroughWithInput(
 
 	var resp *http.Response
 	retryStart := time.Now()
+	signatureRetryAttempted := false
 	for attempt := 1; attempt <= maxRetryAttempts; attempt++ {
 		upstreamCtx, releaseUpstreamCtx := detachStreamUpstreamContext(ctx, input.RequestStream)
 		upstreamReq, err := s.buildUpstreamRequestAnthropicAPIKeyPassthrough(upstreamCtx, c, account, input.Body, token)
@@ -5123,7 +5124,39 @@ func (s *GatewayService) forwardAnthropicAPIKeyPassthroughWithInput(
 			return nil, fmt.Errorf("upstream request failed: %s", safeErr)
 		}
 
-		// 透传分支禁止 400 请求体降级重试（该重试会改写请求体）
+		if resp.StatusCode == 400 {
+			respBody, readErr := io.ReadAll(io.LimitReader(resp.Body, 2<<20))
+			if readErr == nil {
+				_ = resp.Body.Close()
+				if !signatureRetryAttempted && attempt < maxRetryAttempts && time.Since(retryStart) < maxRetryElapsed && s.shouldRectifySignatureError(ctx, account, respBody) {
+					appendOpsUpstreamError(c, OpsUpstreamErrorEvent{
+						Platform:           account.Platform,
+						AccountID:          account.ID,
+						AccountName:        account.Name,
+						UpstreamStatusCode: resp.StatusCode,
+						UpstreamRequestID:  resp.Header.Get("x-request-id"),
+						UpstreamURL:        safeUpstreamURL(upstreamReq.URL.String()),
+						Passthrough:        true,
+						Kind:               "signature_error",
+						Message:            extractUpstreamErrorMessage(respBody),
+						Detail: func() string {
+							if s.cfg != nil && s.cfg.Gateway.LogUpstreamErrorBody {
+								return truncateString(string(respBody), s.cfg.Gateway.LogUpstreamErrorBodyMaxBytes)
+							}
+							return ""
+						}(),
+					})
+					signatureRetryAttempted = true
+					input.Body = FilterThinkingBlocksForRetry(input.Body)
+					setOpsUpstreamRequestBody(c, input.Body)
+					logger.LegacyPrintf("service.gateway", "Anthropic passthrough account %d: thinking blocks have invalid signature, retrying with filtered blocks", account.ID)
+					continue
+				}
+				resp.Body = io.NopCloser(bytes.NewReader(respBody))
+			}
+		}
+
+		// 透传分支禁止普通 400 请求体降级重试（该重试会改写请求体）
 		if resp.StatusCode >= 400 && resp.StatusCode != 400 && s.shouldRetryUpstreamError(account, resp.StatusCode) {
 			if attempt < maxRetryAttempts {
 				elapsed := time.Since(retryStart)

--- a/backend/internal/service/setting_service.go
+++ b/backend/internal/service/setting_service.go
@@ -3690,12 +3690,12 @@ func (s *SettingService) GetRectifierSettings(ctx context.Context) (*RectifierSe
 		return DefaultRectifierSettings(), nil
 	}
 
-	var settings RectifierSettings
-	if err := json.Unmarshal([]byte(value), &settings); err != nil {
+	settings := DefaultRectifierSettings()
+	if err := json.Unmarshal([]byte(value), settings); err != nil {
 		return DefaultRectifierSettings(), nil
 	}
 
-	return &settings, nil
+	return settings, nil
 }
 
 // SetRectifierSettings 设置请求整流器配置

--- a/backend/internal/service/setting_service_rectifier_test.go
+++ b/backend/internal/service/setting_service_rectifier_test.go
@@ -1,0 +1,29 @@
+//go:build unit
+
+package service
+
+import (
+	"context"
+	"testing"
+
+	"github.com/Wei-Shaw/sub2api/internal/config"
+	"github.com/stretchr/testify/require"
+)
+
+func TestSettingService_GetRectifierSettings_DefaultsAPIKeySignatureEnabled(t *testing.T) {
+	settingSvc := NewSettingService(&anthropicPassthroughSettingRepoStub{values: map[string]string{}}, &config.Config{})
+
+	settings, err := settingSvc.GetRectifierSettings(context.Background())
+	require.NoError(t, err)
+	require.True(t, settings.APIKeySignatureEnabled)
+}
+
+func TestSettingService_GetRectifierSettings_LegacyJSONDefaultsAPIKeySignatureEnabled(t *testing.T) {
+	settingSvc := NewSettingService(&anthropicPassthroughSettingRepoStub{values: map[string]string{
+		SettingKeyRectifierSettings: `{"enabled":true,"thinking_signature_enabled":true,"thinking_budget_enabled":true}`,
+	}}, &config.Config{})
+
+	settings, err := settingSvc.GetRectifierSettings(context.Background())
+	require.NoError(t, err)
+	require.True(t, settings.APIKeySignatureEnabled)
+}

--- a/backend/internal/service/settings_view.go
+++ b/backend/internal/service/settings_view.go
@@ -398,6 +398,7 @@ func DefaultRectifierSettings() *RectifierSettings {
 		Enabled:                  true,
 		ThinkingSignatureEnabled: true,
 		ThinkingBudgetEnabled:    true,
+		APIKeySignatureEnabled:   true,
 	}
 }
 

--- a/frontend/src/views/admin/__tests__/SettingsView.spec.ts
+++ b/frontend/src/views/admin/__tests__/SettingsView.spec.ts
@@ -516,7 +516,7 @@ describe("admin SettingsView payment visible method controls", () => {
       enabled: true,
       thinking_signature_enabled: true,
       thinking_budget_enabled: true,
-      apikey_signature_enabled: false,
+      apikey_signature_enabled: true,
       apikey_signature_patterns: [],
     });
     getBetaPolicySettings.mockResolvedValue({
@@ -802,7 +802,7 @@ describe("admin SettingsView wechat connect controls", () => {
       enabled: true,
       thinking_signature_enabled: true,
       thinking_budget_enabled: true,
-      apikey_signature_enabled: false,
+      apikey_signature_enabled: true,
       apikey_signature_patterns: [],
     });
     getBetaPolicySettings.mockResolvedValue({

--- a/scripts/gateway-tk-sentinels.json
+++ b/scripts/gateway-tk-sentinels.json
@@ -113,12 +113,15 @@
         "\"session_hash_short\": shortSessionHash(sessionHash)",
         "resolveOpsTLSFingerprintProfile(c, s.tlsFPProfileService, account)",
         "applyClaudeCodeMimicHeaders(req *http.Request, _ bool)",
-        "getHeaderRaw(req.Header, key) != \"\""
+        "getHeaderRaw(req.Header, key) != \"\"",
+        "signatureRetryAttempted := false",
+        "FilterThinkingBlocksForRetry(input.Body)",
+        "Passthrough:        true,"
       ],
       "must_not_contain": [
         "x-stainless-helper-method"
       ],
-      "rationale": "Main gateway upstream builders must invoke unified TK Claude session-header sync after API-key passthrough, OAuth forward, count_tokens forward, and Vertex Anthropic forward paths diverge upstream merge conflicts. Sticky-source sink event emission is also load-bearing for prod request_id/client_request_id evidence correlation. TLS fingerprint profile resolution must pass through the ops helper so upstream_errors JSON records the profile id/name used by failed Anthropic OAuth attempts; otherwise Node24/Node25 candidate canaries cannot be attributed after a profile switch. Claude Code OAuth mimicry must preserve captured real CLI User-Agent/X-Stainless fingerprint values and only fill missing defaults; reverting to unconditional defaults reintroduces version downgrade/header fingerprint drift. The obsolete x-stainless-helper-method header must stay absent because current real Claude Code traffic does not emit it and reintroducing it increases OAuth fingerprint risk."
+      "rationale": "Main gateway upstream builders must invoke unified TK Claude session-header sync after API-key passthrough, OAuth forward, count_tokens forward, and Vertex Anthropic forward paths diverge upstream merge conflicts. Sticky-source sink event emission is also load-bearing for prod request_id/client_request_id evidence correlation. TLS fingerprint profile resolution must pass through the ops helper so upstream_errors JSON records the profile id/name used by failed Anthropic OAuth attempts; otherwise Node24/Node25 candidate canaries cannot be attributed after a profile switch. Claude Code OAuth mimicry must preserve captured real CLI User-Agent/X-Stainless fingerprint values and only fill missing defaults; reverting to unconditional defaults reintroduces version downgrade/header fingerprint drift. API Key passthrough must keep a single guarded thinking-signature 400 retry that records passthrough ops evidence and downgrades stale cross-upstream thinking blocks before surfacing the error; dropping this makes GPT专线 → cc-edges group switches expose invalid thinking signatures to clients. The obsolete x-stainless-helper-method header must stay absent because current real Claude Code traffic does not emit it and reintroducing it increases OAuth fingerprint risk."
     },
     {
       "path": "backend/internal/service/header_util.go",


### PR DESCRIPTION
## Summary
- Retry Anthropic API key passthrough once when upstream rejects stale thinking-block signatures after group/upstream switches.
- Filter thinking blocks and disable top-level thinking only for the guarded signature retry, while recording passthrough ops evidence.
- Keep rectifier defaults and SettingsView test fixtures aligned so API key signature rectification defaults on.

## Test plan
- [x] `go test -C backend -tags=unit ./internal/service -run 'TestGatewayService_AnthropicAPIKeyPassthrough_ForwardDirect_Signature400RetriesWithFilteredThinking|TestSettingService_GetRectifierSettings'`
- [x] `pnpm exec vitest run src/views/admin/__tests__/SettingsView.spec.ts`
- [x] `bash scripts/preflight.sh`
- [x] `bash scripts/check-upstream-drift.sh`

🤖 Generated with [Claude Code](https://claude.com/claude-code)