### PR TITLE
Restore upstream TLS collector link

### DIFF
--- a/backend/internal/web/dist/frontend-source.json
+++ b/backend/internal/web/dist/frontend-source.json
@@ -1,7 +1,7 @@
 {
   "algorithm": "sha256(git-ls-files:path,size,content)",
   "file_count": 425,
-  "hash": "de0fb2ec6723b5a82cc296852f2f927cd98605bd6bbaf9f1eb589c712385b857",
+  "hash": "81c9e306c0654199c2d74c5aa4daecccb2bfa39f5d75cd242a9bed33904ee0ef",
   "schema": 1,
   "source": "frontend/"
 }

--- a/frontend/src/components/admin/TLSFingerprintProfilesModal.vue
+++ b/frontend/src/components/admin/TLSFingerprintProfilesModal.vue
@@ -145,7 +145,7 @@
             </button>
             <p class="text-xs text-gray-500 dark:text-gray-400">
               {{ t('admin.tlsFingerprintProfiles.form.pasteYamlHint') }}
-              <a href="https://tls.tokenkey.ai" target="_blank" rel="noopener noreferrer" class="text-primary-600 hover:text-primary-700 dark:text-primary-400 dark:hover:text-primary-300 underline">{{ t('admin.tlsFingerprintProfiles.form.openCollector') }}</a>
+              <a href="https://tls.sub2api.org" target="_blank" rel="noopener noreferrer" class="text-primary-600 hover:text-primary-700 dark:text-primary-400 dark:hover:text-primary-300 underline">{{ t('admin.tlsFingerprintProfiles.form.openCollector') }}</a>
             </p>
           </div>
         </div>


### PR DESCRIPTION
## Summary
- Restore the TLS fingerprint profile helper link from `tls.tokenkey.ai` back to upstream `tls.sub2api.org`.
- Refresh the embedded frontend source hash after rebuilding frontend assets.

## Test plan
- [x] `cd frontend && pnpm exec eslint src/components/admin/TLSFingerprintProfilesModal.vue`
- [x] `pnpm run build`
- [x] `bash scripts/preflight.sh`
- [x] `bash scripts/check-upstream-drift.sh`

🤖 Generated with [Claude Code](https://claude.com/claude-code)