### PR TITLE
Capture Claude Code Node 24 TLS profile

### DIFF
--- a/.claude/hooks/export-tls-fingerprint-profile.sh
+++ b/.claude/hooks/export-tls-fingerprint-profile.sh
@@ -15,7 +15,7 @@ emit() {
   printf '%s\n' "$1"
 }
 
-if [ "${CLAUDE_CODE_REMOTE:-}" = "true" ]; then
+if [ "${CLAUDE_CODE_REMOTE:-}" = "true" ] || [ "${TOKENKEY_TLS_PROFILE_CAPTURE_ACTIVE:-}" = "1" ]; then
   emit '{"suppressOutput":true}'
   exit 0
 fi
@@ -63,6 +63,7 @@ env -i \
   ANTHROPIC_BASE_URL="$COLLECTOR_ORIGIN:8090" \
   ANTHROPIC_API_KEY="$TOKEN" \
   ANTHROPIC_AUTH_TOKEN="$TOKEN" \
+  TOKENKEY_TLS_PROFILE_CAPTURE_ACTIVE=1 \
   NODE_TLS_REJECT_UNAUTHORIZED=0 \
   claude --bare -p 'test' --model "$MODEL" --allowedTools '' --max-budget-usd 1 \
   >"$CLAUDE_OUTPUT" 2>&1 || true

--- a/.claude/hooks/export-tls-fingerprint-profile.sh
+++ b/.claude/hooks/export-tls-fingerprint-profile.sh
@@ -1,320 +1,187 @@
 #!/usr/bin/env bash
-# Capture the local Claude Code CLI TLS fingerprint shape at session end and
-# save TokenKey-compatible profile samples under .tls_list/.
+# Capture the local Claude Code CLI TLS fingerprint once per day using a real
+# claude CLI request against the upstream TokenKey collector.
 set -u
 
 REPO_ROOT="${CLAUDE_PROJECT_DIR:-$(cd "$(dirname "$0")/../.." && pwd)}"
+OUT_DIR="$REPO_ROOT/.tls_list"
+COLLECTOR_ORIGIN="${TOKENKEY_TLS_PROFILE_COLLECTOR_ORIGIN:-https://tls.sub2api.org}"
+COLLECTOR_API_ORIGIN="${TOKENKEY_TLS_PROFILE_COLLECTOR_API_ORIGIN:-https://tls.sub2api.org}"
+MODEL="${TOKENKEY_TLS_PROFILE_CAPTURE_MODEL:-claude-haiku-4-5-20251001}"
+TODAY="$(date -u +%Y%m%d)"
+DAILY_MARKER="$OUT_DIR/$TODAY.claude-cli-captured.json"
+
+emit() {
+  printf '%s\n' "$1"
+}
 
 if [ "${CLAUDE_CODE_REMOTE:-}" = "true" ]; then
-  printf '{"suppressOutput":true}\n'
+  emit '{"suppressOutput":true}'
   exit 0
 fi
 
-if ! command -v node >/dev/null 2>&1; then
-  printf '{"systemMessage":"TokenKey TLS profile capture skipped: node is not available","suppressOutput":false}\n'
+if ! command -v claude >/dev/null 2>&1; then
+  emit '{"systemMessage":"TokenKey TLS profile capture skipped: claude CLI is not available","suppressOutput":false}'
+  exit 0
+fi
+if ! command -v jq >/dev/null 2>&1; then
+  emit '{"systemMessage":"TokenKey TLS profile capture skipped: jq is not available","suppressOutput":false}'
+  exit 0
+fi
+if ! command -v curl >/dev/null 2>&1; then
+  emit '{"systemMessage":"TokenKey TLS profile capture skipped: curl is not available","suppressOutput":false}'
   exit 0
 fi
 
-export TOKENKEY_TLS_CAPTURE_REPO_ROOT="$REPO_ROOT"
-TOKENKEY_TLS_CAPTURE_HOOK_INPUT="$(cat || true)"
-export TOKENKEY_TLS_CAPTURE_HOOK_INPUT
+mkdir -p "$OUT_DIR"
+if [ -f "$DAILY_MARKER" ]; then
+  emit '{"suppressOutput":true}'
+  exit 0
+fi
 
-node <<'NODE'
-const fs = require('fs')
-const https = require('https')
-const os = require('os')
-const path = require('path')
+HOOK_INPUT="$(cat || true)"
+SESSION_ID="$(printf '%s' "$HOOK_INPUT" | jq -r '.session_id // empty' 2>/dev/null || true)"
+SESSION_SHORT="$(printf '%s' "${SESSION_ID:-session}" | tr -cd '[:alnum:]_-' | cut -c1-12)"
+[ -n "$SESSION_SHORT" ] || SESSION_SHORT="session"
+STAMP="$(date -u +%Y%m%dT%H%M%SZ)"
+TOKEN="tk-claude-tls-$STAMP-$SESSION_SHORT-$$"
+CAPTURE_WORKDIR="$(mktemp -d "${TMPDIR:-/tmp}/tk-claude-tls.XXXXXX")"
+cleanup() { rm -rf "$CAPTURE_WORKDIR"; }
+trap cleanup EXIT
 
-const repoRoot = process.env.TOKENKEY_TLS_CAPTURE_REPO_ROOT || process.cwd()
-const outDir = path.join(repoRoot, '.tls_list')
-const captureUrl = process.env.TOKENKEY_TLS_PROFILE_CAPTURE_URL || 'https://tls.peet.ws/api/all'
+# Claude Code 2.1.x honors CLAUDE_CODE_API_BASE_URL for API endpoint override.
+# ANTHROPIC_BASE_URL is kept for older/newer variants that may still read it.
+CLAUDE_OUTPUT="$CAPTURE_WORKDIR/claude.out"
+env -i \
+  PATH="$PATH" \
+  HOME="$CAPTURE_WORKDIR/home" \
+  TERM="${TERM:-xterm}" \
+  SHELL="${SHELL:-/bin/sh}" \
+  ANTHROPIC_CONFIG_DIR="$CAPTURE_WORKDIR/anthropic" \
+  CLAUDE_CONFIG_DIR="$CAPTURE_WORKDIR/claude" \
+  CLAUDE_CODE_API_BASE_URL="$COLLECTOR_ORIGIN:8090" \
+  ANTHROPIC_BASE_URL="$COLLECTOR_ORIGIN:8090" \
+  ANTHROPIC_API_KEY="$TOKEN" \
+  ANTHROPIC_AUTH_TOKEN="$TOKEN" \
+  NODE_TLS_REJECT_UNAUTHORIZED=0 \
+  claude --bare -p 'test' --model "$MODEL" --allowedTools '' --max-budget-usd 1 \
+  >"$CLAUDE_OUTPUT" 2>&1 || true
 
-function emit(obj) {
-  process.stdout.write(JSON.stringify(obj) + '\n')
-}
+LATEST_URL="$COLLECTOR_API_ORIGIN/api/latest?token=$TOKEN"
+LATEST_JSON="$CAPTURE_WORKDIR/latest.json"
+if ! curl -fsS --max-time 20 "$LATEST_URL" > "$LATEST_JSON"; then
+  emit '{"systemMessage":"TokenKey TLS profile capture failed: collector latest API request failed","suppressOutput":false}'
+  exit 0
+fi
 
-function requestJson(url) {
-  return new Promise((resolve, reject) => {
-    const req = https.request(url, {
-      method: 'GET',
-      timeout: 10000,
-      headers: {
-        'Accept': 'application/json',
-        'User-Agent': `TokenKey-ClaudeCode-TLSProfileCollector/${process.version}`
-      }
-    }, (res) => {
-      let body = ''
-      res.setEncoding('utf8')
-      res.on('data', chunk => { body += chunk })
-      res.on('end', () => {
-        if (res.statusCode < 200 || res.statusCode >= 300) {
-          reject(new Error(`collector returned HTTP ${res.statusCode}`))
-          return
-        }
-        try {
-          resolve(JSON.parse(body))
-        } catch (err) {
-          reject(new Error(`collector returned non-JSON response: ${err.message}`))
-        }
-      })
-    })
-    req.on('timeout', () => req.destroy(new Error('collector request timed out')))
-    req.on('error', reject)
-    req.end()
-  })
-}
+COUNT="$(jq -r '.count // 0' "$LATEST_JSON")"
+if [ "${COUNT:-0}" = "0" ]; then
+  SUMMARY="$(tr '\n' ' ' < "$CLAUDE_OUTPUT" | cut -c1-240)"
+  emit "$(jq -cn --arg msg "TokenKey TLS profile capture failed: collector recorded no Claude CLI fingerprint. claude_output=$SUMMARY" '{systemMessage:$msg,suppressOutput:false}')"
+  exit 0
+fi
 
-function parseNumList(value, separator = '-') {
-  if (!value) return []
-  return String(value)
-    .split(separator)
-    .map(s => s.trim())
-    .filter(Boolean)
-    .map(s => Number.parseInt(s, 10))
-    .filter(Number.isFinite)
-}
+FIRST_JSON="$CAPTURE_WORKDIR/first.json"
+jq '.fingerprints[0]' "$LATEST_JSON" > "$FIRST_JSON"
+JA3_HASH="$(jq -r '.ja3_hash // "noja3hash"' "$FIRST_JSON")"
+SHORT_JA3="$(printf '%s' "$JA3_HASH" | tr -cd '[:xdigit:]' | cut -c1-12)"
+[ -n "$SHORT_JA3" ] || SHORT_JA3="noja3hash"
+PROFILE_NAME="claude_cli_${STAMP}_${SHORT_JA3}"
+BASE="$STAMP-$SESSION_SHORT-$SHORT_JA3"
+CAPTURE_PATH="$OUT_DIR/$BASE.capture.json"
+PROFILE_PATH="$OUT_DIR/$BASE.tokenkey-profile.json"
+YAML_PATH="$OUT_DIR/$BASE.tokenkey-profile.yaml"
 
-function parseJa3(ja3) {
-  const parts = String(ja3 || '').split(',')
-  return {
-    cipher_suites: parseNumList(parts[1]),
-    extensions: parseNumList(parts[2]),
-    curves: parseNumList(parts[3]),
-    point_formats: parseNumList(parts[4])
-  }
-}
+jq -n \
+  --arg captured_at "$(date -u +%Y-%m-%dT%H:%M:%SZ)" \
+  --arg collector "$COLLECTOR_ORIGIN:8090" \
+  --arg api "$COLLECTOR_API_ORIGIN/api/latest" \
+  --arg event "SessionStart" \
+  --arg session_id "$SESSION_ID" \
+  --slurpfile latest "$LATEST_JSON" \
+  --slurpfile first "$FIRST_JSON" \
+  '{
+    schema_version: 2,
+    captured_at: $captured_at,
+    collector: {url: $collector, latest_api: $api},
+    claude_hook: {event: $event, session_id: ($session_id | if . == "" then null else . end)},
+    latest: $latest[0],
+    observed: $first[0]
+  }' > "$CAPTURE_PATH"
 
-function findExtension(tls, needle) {
-  return (tls.extensions || []).find(ext => String(ext.name || '').includes(needle)) || null
-}
-
-function supportedVersionId(value) {
-  const s = String(value || '').toUpperCase()
-  if (s.includes('1.3')) return 772
-  if (s.includes('1.2')) return 771
-  if (s.includes('1.1')) return 770
-  if (s.includes('1.0')) return 769
-  const n = Number.parseInt(s, 10)
-  return Number.isFinite(n) ? n : null
-}
-
-function parseSupportedVersions(tls) {
-  const ext = findExtension(tls, 'supported_versions')
-  const versions = ext && Array.isArray(ext.versions) ? ext.versions : []
-  return versions.map(supportedVersionId).filter(v => v !== null)
-}
-
-function parseKeyShareGroups(tls) {
-  const ext = findExtension(tls, 'key_share')
-  const shares = ext && Array.isArray(ext.shared_keys) ? ext.shared_keys : []
-  const groups = []
-  for (const share of shares) {
-    for (const key of Object.keys(share || {})) {
-      const match = key.match(/\((\d+)\)/)
-      if (match) groups.push(Number.parseInt(match[1], 10))
-    }
-  }
-  return groups.filter(Number.isFinite)
-}
-
-function parsePskModes(tls) {
-  const ext = findExtension(tls, 'psk_key_exchange_modes')
-  if (!ext) return []
-  const raw = String(ext.PSK_Key_Exchange_Mode || ext.data || '')
-  const match = raw.match(/\((\d+)\)\s*$/)
-  return match ? [Number.parseInt(match[1], 10)] : [1]
-}
-
-function parseAlpnProtocols(tls, payload) {
-  const ext = findExtension(tls, 'application_layer_protocol_negotiation')
-  if (ext && Array.isArray(ext.protocols) && ext.protocols.length > 0) {
-    return ext.protocols.map(String)
-  }
-  if (payload.http_version === 'h2' || payload.http_version === 'HTTP/2') return ['h2']
-  if (payload.http_version) return ['http/1.1']
-  return []
-}
-
-function parseSignatureAlgorithms(tls) {
-  const peetprint = String(tls.peetprint || '')
-  const segments = peetprint.split('|')
-  if (segments.length >= 4) {
-    const parsed = parseNumList(segments[3])
-    if (parsed.length > 0) return parsed
-  }
-  const ext = findExtension(tls, 'signature_algorithms')
-  const values = ext && Array.isArray(ext.signature_algorithms) ? ext.signature_algorithms : []
-  const byName = new Map([
-    ['ecdsa_secp256r1_sha256', 0x0403],
-    ['ecdsa_secp384r1_sha384', 0x0503],
-    ['ecdsa_secp521r1_sha512', 0x0603],
-    ['ed25519', 0x0807],
-    ['ed448', 0x0808],
-    ['rsa_pss_pss_sha256', 0x0809],
-    ['rsa_pss_pss_sha384', 0x080a],
-    ['rsa_pss_pss_sha512', 0x080b],
-    ['rsa_pss_rsae_sha256', 0x0804],
-    ['rsa_pss_rsae_sha384', 0x0805],
-    ['rsa_pss_rsae_sha512', 0x0806],
-    ['rsa_pkcs1_sha256', 0x0401],
-    ['rsa_pkcs1_sha384', 0x0501],
-    ['rsa_pkcs1_sha512', 0x0601],
-    ['ecdsa_sha1', 0x0203],
-    ['rsa_pkcs1_sha1', 0x0201],
-    ['dsa_sha1', 0x0202],
-    ['ecdsa_brainpoolP256r1tls13_sha256', 0x081a],
-    ['ecdsa_brainpoolP384r1tls13_sha384', 0x081b],
-    ['ecdsa_brainpoolP512r1tls13_sha512', 0x081c]
-  ])
-  return values.map(v => {
-    const s = String(v)
-    if (s.startsWith('0x')) return Number.parseInt(s.slice(2), 16)
-    return byName.get(s) || null
-  }).filter(v => v !== null && Number.isFinite(v))
-}
-
-function isGreaseValue(v) {
-  return (v & 0x0f0f) === 0x0a0a && ((v >> 8) & 0xff) === (v & 0xff)
-}
-
-function buildYaml(profile) {
-  const arr = value => `[${(value || []).map(v => typeof v === 'string' ? JSON.stringify(v) : String(v)).join(', ')}]`
-  return [
-    '# TokenKey TLS Fingerprint Profile sample captured by Claude Code SessionEnd hook',
-    `${profile.name}:`,
-    `  name: ${JSON.stringify(profile.name)}`,
-    `  description: ${JSON.stringify(profile.description || '')}`,
-    `  enable_grease: ${profile.enable_grease ? 'true' : 'false'}`,
-    `  cipher_suites: ${arr(profile.cipher_suites)}`,
-    `  curves: ${arr(profile.curves)}`,
-    `  point_formats: ${arr(profile.point_formats)}`,
-    `  signature_algorithms: ${arr(profile.signature_algorithms)}`,
-    `  alpn_protocols: ${arr(profile.alpn_protocols)}`,
-    `  supported_versions: ${arr(profile.supported_versions)}`,
-    `  key_share_groups: ${arr(profile.key_share_groups)}`,
-    `  psk_modes: ${arr(profile.psk_modes)}`,
-    `  extensions: ${arr(profile.extensions)}`,
-    ''
-  ].join('\n')
-}
-
-function safeSessionId(hookInput) {
-  const raw = String((hookInput && hookInput.session_id) || 'session')
-  return raw.replace(/[^a-zA-Z0-9_-]/g, '').slice(0, 12) || 'session'
-}
-
-async function main() {
-  let hookInput = {}
-  const hookInputRaw = process.env.TOKENKEY_TLS_CAPTURE_HOOK_INPUT || ''
-  if (hookInputRaw.trim()) {
-    try { hookInput = JSON.parse(hookInputRaw) } catch {}
-  }
-
-  const sessionShort = safeSessionId(hookInput)
-  const sessionMarkerPath = hookInput.session_id
-    ? path.join(outDir, `${sessionShort}.captured-session.json`)
-    : null
-
-  fs.mkdirSync(outDir, { recursive: true })
-  if (sessionMarkerPath && fs.existsSync(sessionMarkerPath)) {
-    emit({
-      systemMessage: `TokenKey TLS profile capture skipped: ${sessionShort} already captured`,
-      suppressOutput: true
-    })
-    return
-  }
-
-  const payload = await requestJson(captureUrl)
-  const tls = payload.tls || {}
-  if (!tls.ja3) throw new Error('collector response missing tls.ja3')
-
-  const ja3 = parseJa3(tls.ja3)
-  const capturedAt = new Date().toISOString()
-  const stamp = capturedAt.replace(/[-:]/g, '').replace(/\.\d{3}Z$/, 'Z')
-  const ja3Hash = String(tls.ja3_hash || 'noja3hash')
-  const shortJa3 = ja3Hash.replace(/[^a-fA-F0-9]/g, '').slice(0, 12) || 'noja3hash'
-  const name = `claude_code_cli_${stamp.slice(0, 8)}_${shortJa3}`.slice(0, 100)
-
-  const profile = {
-    name,
-    description: [
-      `Captured by Claude Code hook at ${capturedAt}.`,
-      `runtime=node ${process.version} ${process.platform}/${process.arch}.`,
-      `ja3_hash=${tls.ja3_hash || ''}.`,
-      `ja4=${tls.ja4 || ''}.`,
-      `source=${captureUrl}.`
-    ].join(' '),
-    enable_grease: [
-      ...ja3.cipher_suites,
-      ...ja3.extensions,
-      ...ja3.curves
-    ].some(isGreaseValue),
-    cipher_suites: ja3.cipher_suites,
-    curves: ja3.curves,
-    point_formats: ja3.point_formats,
-    signature_algorithms: parseSignatureAlgorithms(tls),
-    alpn_protocols: parseAlpnProtocols(tls, payload),
-    supported_versions: parseSupportedVersions(tls),
-    key_share_groups: parseKeyShareGroups(tls),
-    psk_modes: parsePskModes(tls),
-    extensions: ja3.extensions
-  }
-
-  const base = `${stamp}_${sessionShort}_${shortJa3}`
-  const profilePath = path.join(outDir, `${base}.tokenkey-profile.json`)
-  const yamlPath = path.join(outDir, `${base}.tokenkey-profile.yaml`)
-  const capturePath = path.join(outDir, `${base}.capture.json`)
-
-  fs.writeFileSync(profilePath, JSON.stringify(profile, null, 2) + '\n')
-  fs.writeFileSync(yamlPath, buildYaml(profile))
-  fs.writeFileSync(capturePath, JSON.stringify({
-    schema_version: 1,
-    captured_at: capturedAt,
-    collector: {
-      url: captureUrl,
-      runtime: `node ${process.version}`,
-      platform: process.platform,
-      arch: process.arch,
-      hostname: os.hostname()
-    },
-    claude_hook: {
-      event: hookInput.hook_event_name || hookInput.event || 'SessionEnd',
-      session_id: hookInput.session_id || null
-    },
+jq -n \
+  --arg name "$PROFILE_NAME" \
+  --arg desc "Captured from real Claude Code CLI request to $COLLECTOR_ORIGIN:8090 at $STAMP. ja3_hash=$JA3_HASH." \
+  --slurpfile fp "$FIRST_JSON" \
+  '{
+    name: $name,
+    description: $desc,
+    enable_grease: ($fp[0].enable_grease // false),
+    cipher_suites: ($fp[0].cipher_suites // []),
+    curves: ($fp[0].curves // []),
+    point_formats: ($fp[0].point_formats // []),
+    signature_algorithms: ($fp[0].signature_algorithms // []),
+    alpn_protocols: ($fp[0].alpn_protocols // []),
+    supported_versions: ($fp[0].supported_versions // []),
+    key_share_groups: ($fp[0].key_share_groups // []),
+    psk_modes: ($fp[0].psk_modes // []),
+    extensions: ($fp[0].extensions // []),
     observed: {
-      http_version: payload.http_version || null,
-      user_agent: payload.user_agent || null,
-      ja3: tls.ja3 || null,
-      ja3_hash: tls.ja3_hash || null,
-      ja4: tls.ja4 || null,
-      ja4_r: tls.ja4_r || null,
-      peetprint: tls.peetprint || null,
-      peetprint_hash: tls.peetprint_hash || null
-    },
-    tokenkey_profile: profile
-  }, null, 2) + '\n')
+      model: $fp[0].model,
+      user_agent: $fp[0].user_agent,
+      stainless_os: $fp[0].stainless_os,
+      stainless_arch: $fp[0].stainless_arch,
+      stainless_runtime: $fp[0].stainless_runtime,
+      stainless_runtime_version: $fp[0].stainless_runtime_version,
+      stainless_lang: $fp[0].stainless_lang,
+      stainless_package_version: $fp[0].stainless_package_version,
+      ja3_raw: $fp[0].ja3_raw,
+      ja3_hash: $fp[0].ja3_hash,
+      ja4: $fp[0].ja4
+    }
+  }' > "$PROFILE_PATH"
 
-  if (sessionMarkerPath) {
-    fs.writeFileSync(sessionMarkerPath, JSON.stringify({
-      schema_version: 1,
-      session_id: hookInput.session_id,
-      captured_at: capturedAt,
-      profile_path: path.relative(outDir, profilePath),
-      capture_path: path.relative(outDir, capturePath)
-    }, null, 2) + '\n')
-  }
+python3 - "$PROFILE_PATH" "$YAML_PATH" <<'PY'
+import json
+import sys
+profile_path, yaml_path = sys.argv[1:]
+p = json.load(open(profile_path, encoding='utf-8'))
 
-  emit({
-    systemMessage: `TokenKey TLS profile captured: ${path.relative(repoRoot, profilePath)}`,
-    suppressOutput: true
-  })
-}
+def fmt(v):
+    if isinstance(v, str):
+        return json.dumps(v)
+    return str(v).lower() if isinstance(v, bool) else str(v)
 
-main().catch(err => {
-  emit({
-    systemMessage: `TokenKey TLS profile capture failed: ${err.message}`,
-    suppressOutput: false
-  })
-  process.exit(0)
-})
-NODE
+lines = [
+    '# TokenKey TLS Fingerprint Profile sample captured by real Claude Code CLI',
+    f'{p["name"]}:',
+    f'  name: {json.dumps(p["name"])}',
+    f'  description: {json.dumps(p.get("description", ""))}',
+    f'  enable_grease: {str(bool(p.get("enable_grease"))).lower()}',
+]
+for key in [
+    'cipher_suites', 'curves', 'point_formats', 'signature_algorithms',
+    'alpn_protocols', 'supported_versions', 'key_share_groups', 'psk_modes', 'extensions',
+]:
+    arr = p.get(key) or []
+    lines.append(f'  {key}: [{", ".join(fmt(x) for x in arr)}]')
+lines.append('')
+open(yaml_path, 'w', encoding='utf-8').write('\n'.join(lines))
+PY
+
+jq -n \
+  --arg date "$TODAY" \
+  --arg captured_at "$(date -u +%Y-%m-%dT%H:%M:%SZ)" \
+  --arg session_id "$SESSION_ID" \
+  --arg profile_path "$(basename "$PROFILE_PATH")" \
+  --arg capture_path "$(basename "$CAPTURE_PATH")" \
+  '{
+    schema_version: 1,
+    date: $date,
+    captured_at: $captured_at,
+    session_id: ($session_id | if . == "" then null else . end),
+    profile_path: $profile_path,
+    capture_path: $capture_path
+  }' > "$DAILY_MARKER"
+
+emit "$(jq -cn --arg msg "TokenKey TLS profile captured: ${PROFILE_PATH#$REPO_ROOT/}" '{systemMessage:$msg,suppressOutput:true}')"

--- a/.claude/settings.json
+++ b/.claude/settings.json
@@ -7,30 +7,12 @@
           {
             "type": "command",
             "command": "$CLAUDE_PROJECT_DIR/.claude/hooks/session-start.sh"
-          }
-        ]
-      }
-    ],
-    "Stop": [
-      {
-        "hooks": [
+          },
           {
             "type": "command",
             "command": "bash \"${CLAUDE_PROJECT_DIR}/.claude/hooks/export-tls-fingerprint-profile.sh\"",
-            "timeout": 20,
-            "statusMessage": "Capturing TokenKey TLS fingerprint profile"
-          }
-        ]
-      }
-    ],
-    "SessionEnd": [
-      {
-        "hooks": [
-          {
-            "type": "command",
-            "command": "bash \"${CLAUDE_PROJECT_DIR}/.claude/hooks/export-tls-fingerprint-profile.sh\"",
-            "timeout": 20,
-            "statusMessage": "Capturing TokenKey TLS fingerprint profile"
+            "timeout": 60,
+            "statusMessage": "Capturing daily TokenKey TLS fingerprint profile"
           }
         ]
       }

--- a/.cursor/skills/tokenkey-edge-anthropic-oauth-config/SKILL.md
+++ b/.cursor/skills/tokenkey-edge-anthropic-oauth-config/SKILL.md
@@ -1,9 +1,10 @@
 ---
 name: tokenkey-edge-anthropic-oauth-config
 description: >-
-  Query and update edge Anthropic OAuth account stability config (including
-  account fields and group bindings) with default read-only check, explicit
-  apply confirmation, mixed-channel risk precheck, and post-change verification.
+  Query and update edge Anthropic OAuth account stability config using the
+  Stage0 SQL templates as apply source of truth, with default read-only check,
+  explicit apply confirmation, mixed-channel risk precheck, and post-change
+  verification.
 ---
 
 # TokenKey：Edge Anthropic OAuth 配置查询与更新（含账号与分组）
@@ -157,7 +158,16 @@ confirm_apply=yes-apply-edge-anthropic-oauth
 
 缺失或不匹配则拒绝执行。
 
-### 3.2 账号模式（target_scope=account）
+### 3.2 模板 SQL 是 apply 源头
+
+更新配置时禁止临时手写 SQL 或直接拼一份新的字段清单。必须从仓库模板复制出本次执行 SQL，再只替换本次目标变量和经 `plan-apply` 确认的差异：
+
+- 账号 tier/stability/TLS baseline 更新：复制 `deploy/aws/stage0/anthropic-oauth-stability-tiered-apply-template.sql`
+- 分组聚合 rpm 更新：复制 `deploy/aws/stage0/anthropic-oauth-group-aggregate-apply-template.sql`
+
+推荐落点：`$CLAUDE_JOB_DIR/<edge>-<target>-apply.sql`，不要改原模板来执行单次任务。复制后必须保留模板里的 profile、tier、聚合口径和事务结构；只允许改 `\set account_name`、`\set stability_tier`、`\set group_name` 等执行变量，或把变量替换为本次确认过的字面值。若需求确实要求模板未覆盖的新字段，先更新模板和本 skill，再执行 apply，避免 checker、模板和人工 SQL 分叉。
+
+### 3.3 账号模式（target_scope=account）
 
 安全限制：
 - `apply` 仅允许单 edge + 单账号；
@@ -167,14 +177,13 @@ confirm_apply=yes-apply-edge-anthropic-oauth
 - 先调用 `POST /api/v1/admin/accounts/check-mixed-channel`
 - 若预检返回风险且未明确确认，停止执行。
 
-调用更新接口：
-- `PUT /api/v1/admin/accounts/:id`
+执行策略：
+1. 从 `anthropic-oauth-stability-tiered-apply-template.sql` 复制本次 SQL；
+2. 写入本次 `account_name` 与 `stability_tier`；
+3. 如需改分组绑定，先完成 mixed-channel 预检，再在同一份复制 SQL 中加入经确认的绑定变更；
+4. 通过 SSM/psql 在目标 edge 执行该复制 SQL。
 
-请求体包含：
-- 需要对齐的账号字段（如 `concurrency`、`priority`、`rate_multiplier`、`auto_pause_on_expired` 等）
-- 可选 `group_ids`
-
-### 3.3 分组模式（target_scope=group）
+### 3.4 分组模式（target_scope=group）
 
 安全限制：
 - `apply` 仅允许单 edge + 单分组；
@@ -183,8 +192,9 @@ confirm_apply=yes-apply-edge-anthropic-oauth
 执行策略：
 1. 固定成员快照：先锁定分组内可用账号清单（执行期不允许隐式扩容）；
 2. 逐账号预检：若涉及分组重绑，逐账号做 mixed-channel 预检；
-3. 逐账号更新：对每个成员调用 `PUT /api/v1/admin/accounts/:id`；
-4. 失败即停：任一账号更新失败立即停止，并输出已成功列表与待处理列表。
+3. 对每个需要收敛的成员账号，复制并执行 `anthropic-oauth-stability-tiered-apply-template.sql`；
+4. 成员账号全部收敛后，复制并执行 `anthropic-oauth-group-aggregate-apply-template.sql` 更新分组聚合 rpm；
+5. 失败即停：任一账号或分组聚合更新失败立即停止，并输出已成功列表与待处理列表。
 
 幂等要求：
 - 对已收敛账号重复 apply 不应产生额外副作用；
@@ -296,6 +306,8 @@ summary.error_count=<n>
 
 - `scripts/check-edge-anthropic-oauth-stability.py`
 - `deploy/aws/stage0/anthropic-oauth-stability-baselines-tiered.json`
+- `deploy/aws/stage0/anthropic-oauth-stability-tiered-apply-template.sql`
+- `deploy/aws/stage0/anthropic-oauth-group-aggregate-apply-template.sql`
 - `backend/internal/handler/admin/account_handler.go`
 - `backend/internal/service/admin_service.go`
 - `backend/internal/repository/account_repo.go`

--- a/backend/internal/pkg/tlsfingerprint/dialer.go
+++ b/backend/internal/pkg/tlsfingerprint/dialer.go
@@ -416,6 +416,8 @@ func buildClientHelloSpecFromProfile(profile *Profile) *utls.ClientHelloSpec {
 			extensions = append(extensions, &utls.ALPNExtension{AlpnProtocols: alpnProtocols})
 		case 18: // signed_certificate_timestamp
 			extensions = append(extensions, &utls.SCTExtension{})
+		case 21: // padding
+			extensions = append(extensions, &utls.UtlsPaddingExtension{GetPaddingLen: utls.BoringPaddingStyle})
 		case 23: // extended_master_secret
 			extensions = append(extensions, &utls.ExtendedMasterSecretExtension{})
 		case 35: // session_ticket

--- a/backend/internal/pkg/tlsfingerprint/dialer_test.go
+++ b/backend/internal/pkg/tlsfingerprint/dialer_test.go
@@ -20,6 +20,8 @@ import (
 	"strings"
 	"testing"
 	"time"
+
+	utls "github.com/refraction-networking/utls"
 )
 
 // TestDialerBasicConnection tests that the dialer can establish TLS connections.
@@ -261,6 +263,18 @@ func TestBuildClientHelloSpec(t *testing.T) {
 
 	if len(spec.CipherSuites) != 2 {
 		t.Errorf("expected 2 cipher suites, got %d", len(spec.CipherSuites))
+	}
+
+	paddingProfile := &Profile{
+		Name:       "Padding",
+		Extensions: []uint16{0, 21},
+	}
+	spec = buildClientHelloSpecFromProfile(paddingProfile)
+	if len(spec.Extensions) != 2 {
+		t.Fatalf("expected 2 extensions, got %d", len(spec.Extensions))
+	}
+	if _, ok := spec.Extensions[1].(*utls.UtlsPaddingExtension); !ok {
+		t.Fatalf("extension 21 should build UtlsPaddingExtension, got %T", spec.Extensions[1])
 	}
 }
 

--- a/deploy/aws/stage0/anthropic-oauth-stability-baseline.json
+++ b/deploy/aws/stage0/anthropic-oauth-stability-baseline.json
@@ -74,8 +74,8 @@
       "custom_base_url"
     ],
     "tls_profile": {
-      "name": "claude_cli_nodejs24_fixed",
-      "description": "Fixed Claude CLI / Node.js 24.x ClientHello profile for Anthropic OAuth stability.",
+      "name": "claude_cli_2_1_142_node24_20260515",
+      "description": "Captured from real Claude Code CLI 2.1.142 request to https://tls.sub2api.org:8090 on 2026-05-15. runtime=node v24.3.0 darwin/arm64. ja3_hash=d871d02cecbde59abbf8f4806134addf. ja4=t13d1714h1_5b57614c22b0_43ade6aba3df.",
       "enable_grease": false,
       "cipher_suites": [
         4865,
@@ -130,7 +130,6 @@
       ],
       "extensions": [
         0,
-        65037,
         23,
         65281,
         10,
@@ -142,7 +141,8 @@
         18,
         51,
         45,
-        43
+        43,
+        21
       ]
     }
   },

--- a/deploy/aws/stage0/anthropic-oauth-stability-baselines-tiered.json
+++ b/deploy/aws/stage0/anthropic-oauth-stability-baselines-tiered.json
@@ -101,8 +101,8 @@
       "custom_base_url"
     ],
     "tls_profile": {
-      "name": "claude_cli_nodejs24_fixed",
-      "description": "Fixed Claude CLI / Node.js 24.x ClientHello profile for Anthropic OAuth stability.",
+      "name": "claude_cli_2_1_142_node24_20260515",
+      "description": "Captured from real Claude Code CLI 2.1.142 request to https://tls.sub2api.org:8090 on 2026-05-15. runtime=node v24.3.0 darwin/arm64. ja3_hash=d871d02cecbde59abbf8f4806134addf. ja4=t13d1714h1_5b57614c22b0_43ade6aba3df.",
       "enable_grease": false,
       "cipher_suites": [
         4865,
@@ -157,7 +157,6 @@
       ],
       "extensions": [
         0,
-        65037,
         23,
         65281,
         10,
@@ -169,7 +168,8 @@
         18,
         51,
         45,
-        43
+        43,
+        21
       ]
     }
   },

--- a/deploy/aws/stage0/anthropic-oauth-stability-tiered-apply-template.sql
+++ b/deploy/aws/stage0/anthropic-oauth-stability-tiered-apply-template.sql
@@ -60,8 +60,8 @@ profile AS (
     alpn_protocols, supported_versions, key_share_groups, psk_modes, extensions,
     created_at, updated_at
   ) VALUES (
-    'claude_cli_nodejs24_fixed',
-    'Fixed Claude CLI / Node.js 24.x ClientHello profile for Anthropic OAuth stability.',
+    'claude_cli_2_1_142_node24_20260515',
+    'Captured from real Claude Code CLI 2.1.142 request to https://tls.sub2api.org:8090 on 2026-05-15. runtime=node v24.3.0 darwin/arm64. ja3_hash=d871d02cecbde59abbf8f4806134addf. ja4=t13d1714h1_5b57614c22b0_43ade6aba3df.',
     false,
     '[4865,4866,4867,49195,49199,49196,49200,52393,52392,49161,49171,49162,49172,156,157,47,53]'::jsonb,
     '[29,23,24]'::jsonb,
@@ -71,7 +71,7 @@ profile AS (
     '[772,771]'::jsonb,
     '[29]'::jsonb,
     '[1]'::jsonb,
-    '[0,65037,23,65281,10,11,35,16,5,13,18,51,45,43]'::jsonb,
+    '[0,23,65281,10,11,35,16,5,13,18,51,45,43,21]'::jsonb,
     NOW(), NOW()
   )
   ON CONFLICT (name) DO UPDATE SET

--- a/deploy/aws/stage0/claude_cli_2_1_142_node24_20260515.json
+++ b/deploy/aws/stage0/claude_cli_2_1_142_node24_20260515.json
@@ -1,0 +1,86 @@
+{
+  "name": "claude_cli_2_1_142_node24_20260515",
+  "description": "Captured from real Claude Code CLI 2.1.142 request to https://tls.sub2api.org:8090 on 2026-05-15. runtime=node v24.3.0 darwin/arm64. ja3_hash=d871d02cecbde59abbf8f4806134addf. ja4=t13d1714h1_5b57614c22b0_43ade6aba3df.",
+  "enable_grease": false,
+  "cipher_suites": [
+    4865,
+    4866,
+    4867,
+    49195,
+    49199,
+    49196,
+    49200,
+    52393,
+    52392,
+    49161,
+    49171,
+    49162,
+    49172,
+    156,
+    157,
+    47,
+    53
+  ],
+  "curves": [
+    29,
+    23,
+    24
+  ],
+  "point_formats": [
+    0
+  ],
+  "signature_algorithms": [
+    1027,
+    2052,
+    1025,
+    1283,
+    2053,
+    1281,
+    2054,
+    1537,
+    513
+  ],
+  "alpn_protocols": [
+    "http/1.1"
+  ],
+  "supported_versions": [
+    772,
+    771
+  ],
+  "key_share_groups": [
+    29
+  ],
+  "psk_modes": [
+    1
+  ],
+  "extensions": [
+    0,
+    23,
+    65281,
+    10,
+    11,
+    35,
+    16,
+    5,
+    13,
+    18,
+    51,
+    45,
+    43,
+    21
+  ],
+  "observed": {
+    "model": "claude-haiku-4-5-20251001",
+    "user_agent": "claude-cli/2.1.142 (external, sdk-cli)",
+    "stainless_os": "MacOS",
+    "stainless_arch": "arm64",
+    "stainless_runtime": "node",
+    "stainless_runtime_version": "v24.3.0",
+    "stainless_lang": "js",
+    "stainless_package_version": "0.94.0",
+    "ja3_raw": "771,4865-4866-4867-49195-49199-49196-49200-52393-52392-49161-49171-49162-49172-156-157-47-53,0-23-65281-10-11-35-16-5-13-18-51-45-43-21,29-23-24,0",
+    "ja3_hash": "d871d02cecbde59abbf8f4806134addf",
+    "ja4": "t13d1714h1_5b57614c22b0_43ade6aba3df",
+    "source": "https://tls.sub2api.org:8090"
+  }
+}


### PR DESCRIPTION
## Summary
- Capture the Claude Code TLS profile via a real CLI request path instead of static assumptions.
- Add the observed Claude CLI 2.1.142 Node 24 profile candidate, including padding extension support.
- Keep the branch synced with latest `origin/main` frontend TLS collector link restoration.

## Test plan
- [x] `bash scripts/check-upstream-drift.sh`
- [x] `bash scripts/preflight.sh`
- [x] `(cd backend && go test -tags=unit ./internal/pkg/tlsfingerprint)`

🤖 Generated with [Claude Code](https://claude.com/claude-code)