### PR TITLE
chore(aws): Stage0 pg_dump every 2h, keep 12 backups

### DIFF
--- a/deploy/aws/README.md
+++ b/deploy/aws/README.md
@@ -567,8 +567,8 @@ sudo journalctl -u tokenkey -n 200 --no-pager
 sudo systemctl list-timers tokenkey-pgdump.timer
 sudo systemctl list-timers tokenkey-disk-metrics.timer   # → CloudWatch tokenkey/EC2 DataVolumeUsedPercent
 sudo systemctl list-timers tokenkey-qa-stale-cleanup.timer
-ls -lh /var/lib/tokenkey/pgdump/ 2>/dev/null || echo '(no dumps yet — first dump runs ~1h after boot)'
-# hourly pg_dump 默认保留 24 小时（约 24 份）；卷使用率告警见 CFN DataVolumeDiskAlarm / 主文档 §3.8
+ls -lh /var/lib/tokenkey/pgdump/ 2>/dev/null || echo '(no dumps yet — first dump runs on next scheduled timer tick)'
+# pg_dump 每 2 小时一次，滚动保留约 24 小时内最多 12 份 tokenkey-*.sql.gz；卷使用率告警见 CFN DataVolumeDiskAlarm / 主文档 §3.8
 # 旧版手工/迁移快照 `pre-*.dump` 属存量文件；确认不需回滚后可删除，新模板的 pgdump timer 也会清理。
 # QA：`QaStaleRetentionDays`（默认 1.5 天）每日清理旧 qa_records + qa_blobs/qa_dlq；与 scripts/prod-qa-export-and-purge.sh 范围对齐，0=关闭
 sudo cat /var/lib/tokenkey/.env                           # 含明文密码，慎查

--- a/deploy/aws/cloudformation/stage0-single-ec2.yaml
+++ b/deploy/aws/cloudformation/stage0-single-ec2.yaml
@@ -651,7 +651,7 @@ Resources:
           WantedBy=multi-user.target
           UNITEOF
 
-          # hourly pg_dump (application-consistent backup)
+          # pg_dump every 2h (application-consistent backup); keep rolling 24h + max 12 files.
           cat > /usr/local/bin/tokenkey-pgdump.sh <<'PGEOF'
           #!/bin/bash
           set -euo pipefail
@@ -681,8 +681,13 @@ Resources:
 
           mv -f "${!PART}" "${!OUT}"
 
-          # Keep only tokenkey dumps from the past 24 hours, normally about 24 hourly copies.
+          # Past 24h by mtime, and at most 12 rolling tokenkey-*.sql.gz (2h cadence).
           find "${!DUMP_DIR}" -maxdepth 1 -type f -name 'tokenkey-*.sql.gz' -mmin +1440 -delete 2>/dev/null || true
+          while IFS= read -r _oldf; do
+            [ -z "${!_oldf}" ] && continue
+            rm -f "${!_oldf}"
+          done < <(find "${!DUMP_DIR}" -maxdepth 1 -type f -name 'tokenkey-*.sql.gz' -printf '%T@\t%p\n' 2>/dev/null \
+            | sort -nr | tail -n +13 | cut -f2-)
           PGEOF
           chmod +x /usr/local/bin/tokenkey-pgdump.sh
 
@@ -727,7 +732,7 @@ Resources:
 
           cat > /etc/systemd/system/tokenkey-pgdump.service <<'PSEOF'
           [Unit]
-          Description=tokenkey hourly pg_dump
+          Description=tokenkey pg_dump (every 2 hours)
           After=tokenkey.service
           Requires=tokenkey.service
 
@@ -738,10 +743,10 @@ Resources:
 
           cat > /etc/systemd/system/tokenkey-pgdump.timer <<'PTEOF'
           [Unit]
-          Description=Run tokenkey-pgdump every hour
+          Description=Run tokenkey-pgdump every 2 hours
 
           [Timer]
-          OnCalendar=hourly
+          OnCalendar=*-*-* 00,02,04,06,08,10,12,14,16,18,20,22:00:00
           Persistent=true
           RandomizedDelaySec=2min
 

--- a/docs/deploy/aws-us-openai-gateway-deployment.md
+++ b/docs/deploy/aws-us-openai-gateway-deployment.md
@@ -74,7 +74,7 @@ flowchart TD
 
     APP -- HTTPS --> OAI[auth.openai.com / chatgpt.com]
     EC2 -. 每天/每小时 .-> EBS_SNAP[(EBS Snapshot via DLM)]
-    PG -. 每小时 .-> PGDUMP[(/var/lib/tokenkey/pgdump)]
+    PG -. 每 2 小时 .-> PGDUMP[(/var/lib/tokenkey/pgdump)]
 ```
 
 | 项 | 值 |
@@ -85,7 +85,7 @@ flowchart TD
 | 出口 | 直连 OpenAI（**无 NAT GW**；EC2 自带公网 IP） |
 | TLS | Let's Encrypt（Caddy ACME HTTP-01，自动续签） |
 | 数据栈 | 同机 docker-compose：tokenkey 应用 / PostgreSQL 18 / Redis 8 / Caddy 2 |
-| 备份 | 每日 EBS 整盘快照（DLM）+ 每小时 `pg_dump`（systemd timer） |
+| 备份 | 每日 EBS 整盘快照（DLM）+ 每 2 小时 `pg_dump`（systemd timer，滚动保留 12 份 / ~24h） |
 | 登录 | **AWS SSM Session Manager**（不开 SSH 密钥，免维护跳板机） |
 | 日志 | 容器 stdout → `journald`；CloudWatch Agent 采集 cloud-init 日志与基础内存/磁盘指标 |
 
@@ -303,7 +303,7 @@ sudo bash -lc "
 | 类型 | 工具 | 默认频率 | 保留 | 一致性 | 用途 |
 |---|---|---|---|---|---|
 | **整盘快照** | DLM → EBS Snapshot | 每天 1 次 03:00 UTC | 7 份 | crash-consistent | 实例丢失 / 整机回滚 |
-| **逻辑备份** | systemd timer + `pg_dump` | **每小时 1 次** | **36 份（约 1.5 天）** | application-consistent | 想回到近小时点 / 迁移到 RDS；更长窗口靠 EBS 快照 |
+| **逻辑备份** | systemd timer + `pg_dump` | **每 2 小时 1 次** | **12 份（滚动约 24 小时）** | application-consistent | 想回到较近时间点 / 迁移到 RDS；更长窗口靠 EBS 快照 |
 | **QA 按天清理** | `tokenkey-qa-stale-cleanup.timer` | **每天 ~04:15 UTC（±30 min）** | 由参数 **`QaStaleRetentionDays`**（默认 **1.5** 天，可为小数） | 与 `prod-qa-export-and-purge.sh` 同范围：`qa_records` + `app/qa_blobs` + `app/qa_dlq` | 防运营未按时导出时盘被 QA 占满；**0**=关闭定时器 |
 
 #### 「每日快照 → 每小时快照」的影响
@@ -316,10 +316,10 @@ sudo bash -lc "
 | **额外存储成本** | EBS 快照按**增量块**计费（\$0.05/GiB-month）。30 GiB 卷在轻写场景，每天增量通常仅几百 MB。每日 7 份 ≈ \$0.1–0.3/月；每小时 168 份 ≈ **\$1–4/月**。重写多的卷会拉高，需 Cost Explorer 复核。 |
 | **API 调用** | 每实例每小时 1 次，远低于 EBS 快照速率上限 |
 | **RTO** | 不变（10–30 min 创建新卷 + 改 EIP 关联） |
-| **应用一致性** | 不变。EBS 快照本身始终是 crash-consistent；想「应用一致地回到任一小时」要用 `pg_dump` 那条线（已默认每小时 1 份） |
+| **应用一致性** | 不变。EBS 快照本身始终是 crash-consistent；想「应用一致地回到较近状态」要用 `pg_dump` 那条线（默认每 2 小时 1 份、保留 12 份） |
 | **前台 IO 影响** | 几乎可忽略，EBS 快照后台异步、写时复制 |
 
-**结论：** 默认 `daily` 已经足够（pg_dump 已经每小时一份覆盖应用一致需求）；如果你愿意每月多花 \$1–4 把「整机 RPO」也压到 1 小时，把参数改 `hourly` 即可。
+**结论：** 默认 `daily` 已经足够（`pg_dump` 已每 2 小时一份覆盖近期应用一致需求）；如果你愿意每月多花 \$1–4 把「整机 RPO」也压到 1 小时，把参数改 `hourly` 即可。
 
 #### 恢复演练（每季度 1 次）
 


### PR DESCRIPTION
## Summary
- Change `tokenkey-pgdump.timer` to a 2-hour wall-clock schedule (even hours UTC, with existing jitter).
- Cap rolling `tokenkey-*.sql.gz` at **12** files after the existing **24h** mtime prune, to match ~24h × 2h cadence.
- Update `deploy/aws/README.md` and `docs/deploy/aws-us-openai-gateway-deployment.md` accordingly.

## Risk
- **Operational**: Existing Stage0 EC2 does not re-run UserData on CFN-only updates; operators must patch `/usr/local/bin/tokenkey-pgdump.sh`, the systemd units, and `daemon-reload` + restart the timer (or replace the instance).

## Validation
- `./scripts/preflight.sh` (local, green before commit; pre-commit hook re-ran the same).
- `bash deploy/aws/stage0/build-cfn.sh --check` (embeds unchanged).


Made with [Cursor](https://cursor.com)