### PR TITLE
Fix Claude TLS capture settings isolation

### DIFF
--- a/.claude/hooks/export-tls-fingerprint-profile.sh
+++ b/.claude/hooks/export-tls-fingerprint-profile.sh
@@ -49,9 +49,26 @@ CAPTURE_WORKDIR="$(mktemp -d "${TMPDIR:-/tmp}/tk-claude-tls.XXXXXX")"
 cleanup() { rm -rf "$CAPTURE_WORKDIR"; }
 trap cleanup EXIT
 
-# Claude Code 2.1.x honors CLAUDE_CODE_API_BASE_URL for API endpoint override.
-# ANTHROPIC_BASE_URL is kept for older/newer variants that may still read it.
+# Claude Code can load ANTHROPIC_BASE_URL from global settings even under env -i.
+# Pass an explicit minimal settings file so the child request always hits the collector.
 CLAUDE_OUTPUT="$CAPTURE_WORKDIR/claude.out"
+CLAUDE_SETTINGS="$CAPTURE_WORKDIR/settings.json"
+jq -n \
+  --arg api_base "$COLLECTOR_ORIGIN:8090" \
+  --arg token "$TOKEN" \
+  '{
+    env: {
+      CLAUDE_CODE_API_BASE_URL: $api_base,
+      ANTHROPIC_BASE_URL: $api_base,
+      ANTHROPIC_API_KEY: $token,
+      ANTHROPIC_AUTH_TOKEN: $token,
+      TOKENKEY_TLS_PROFILE_CAPTURE_ACTIVE: "1",
+      NODE_TLS_REJECT_UNAUTHORIZED: "0"
+    },
+    hooks: {SessionStart: []},
+    permissions: {allow: [], deny: []}
+  }' > "$CLAUDE_SETTINGS"
+
 env -i \
   PATH="$PATH" \
   HOME="$CAPTURE_WORKDIR/home" \
@@ -65,7 +82,7 @@ env -i \
   ANTHROPIC_AUTH_TOKEN="$TOKEN" \
   TOKENKEY_TLS_PROFILE_CAPTURE_ACTIVE=1 \
   NODE_TLS_REJECT_UNAUTHORIZED=0 \
-  claude --bare -p 'test' --model "$MODEL" --allowedTools '' --max-budget-usd 1 \
+  claude --bare --setting-sources local --settings "$CLAUDE_SETTINGS" -p 'test' --model "$MODEL" --allowedTools '' --max-budget-usd 1 \
   >"$CLAUDE_OUTPUT" 2>&1 || true
 
 LATEST_URL="$COLLECTOR_API_ORIGIN/api/latest?token=$TOKEN"

--- a/.cursor/skills/tokenkey-edge-anthropic-oauth-config/SKILL.md
+++ b/.cursor/skills/tokenkey-edge-anthropic-oauth-config/SKILL.md
@@ -165,7 +165,7 @@ confirm_apply=yes-apply-edge-anthropic-oauth
 - 账号 tier/stability/TLS baseline 更新：复制 `deploy/aws/stage0/anthropic-oauth-stability-tiered-apply-template.sql`
 - 分组聚合 rpm 更新：复制 `deploy/aws/stage0/anthropic-oauth-group-aggregate-apply-template.sql`
 
-推荐落点：`$CLAUDE_JOB_DIR/<edge>-<target>-apply.sql`，不要改原模板来执行单次任务。复制后必须保留模板里的 profile、tier、聚合口径和事务结构；只允许改 `\set account_name`、`\set stability_tier`、`\set group_name` 等执行变量，或把变量替换为本次确认过的字面值。若需求确实要求模板未覆盖的新字段，先更新模板和本 skill，再执行 apply，避免 checker、模板和人工 SQL 分叉。
+推荐落点：`$CLAUDE_JOB_DIR/<edge>-<target>-apply.sql`，不要改原模板来执行单次任务。复制后必须生成**自包含 SQL**：把模板正文复制进该文件，并在文件顶部写入本次 `\set account_name`、`\set stability_tier`、`\set group_name` 等变量；远端 edge 不保证存在仓库 checkout，所以禁止让 SSM/psql 执行依赖远端文件路径的 `\i deploy/aws/stage0/...`。复制后必须保留模板里的 profile、tier、聚合口径和事务结构；只允许改执行变量或经 `plan-apply` 确认过的字面值。若需求确实要求模板未覆盖的新字段，先更新模板和本 skill，再执行 apply，避免 checker、模板和人工 SQL 分叉。
 
 ### 3.3 账号模式（target_scope=account）
 
@@ -178,10 +178,10 @@ confirm_apply=yes-apply-edge-anthropic-oauth
 - 若预检返回风险且未明确确认，停止执行。
 
 执行策略：
-1. 从 `anthropic-oauth-stability-tiered-apply-template.sql` 复制本次 SQL；
-2. 写入本次 `account_name` 与 `stability_tier`；
-3. 如需改分组绑定，先完成 mixed-channel 预检，再在同一份复制 SQL 中加入经确认的绑定变更；
-4. 通过 SSM/psql 在目标 edge 执行该复制 SQL。
+1. 从 `anthropic-oauth-stability-tiered-apply-template.sql` 复制模板正文，生成自包含本次 SQL；
+2. 在本次 SQL 顶部写入 `account_name` 与 `stability_tier`；
+3. 如需改分组绑定，先完成 mixed-channel 预检，再在同一份自包含 SQL 中加入经确认的绑定变更；
+4. 通过 SSM 把该自包含 SQL 作为 heredoc 传给目标 edge 的 `tokenkey-postgres` 容器执行，不依赖远端目录。
 
 ### 3.4 分组模式（target_scope=group）
 
@@ -192,8 +192,8 @@ confirm_apply=yes-apply-edge-anthropic-oauth
 执行策略：
 1. 固定成员快照：先锁定分组内可用账号清单（执行期不允许隐式扩容）；
 2. 逐账号预检：若涉及分组重绑，逐账号做 mixed-channel 预检；
-3. 对每个需要收敛的成员账号，复制并执行 `anthropic-oauth-stability-tiered-apply-template.sql`；
-4. 成员账号全部收敛后，复制并执行 `anthropic-oauth-group-aggregate-apply-template.sql` 更新分组聚合 rpm；
+3. 对每个需要收敛的成员账号，基于 `anthropic-oauth-stability-tiered-apply-template.sql` 生成自包含 SQL 并执行；
+4. 成员账号全部收敛后，基于 `anthropic-oauth-group-aggregate-apply-template.sql` 生成自包含 SQL 更新分组聚合 rpm；
 5. 失败即停：任一账号或分组聚合更新失败立即停止，并输出已成功列表与待处理列表。
 
 幂等要求：


### PR DESCRIPTION
## Summary
- Pass an explicit minimal Claude settings file to the child TLS capture request.
- Prevent global `ANTHROPIC_BASE_URL` settings from redirecting the capture away from the collector.
- Keep hook recursion protection and collector token isolation intact.

## Test plan
- [x] Hook capture in an isolated temp project generated a TokenKey profile through `https://tls.sub2api.org:8090`.
- [x] Recaptured profile matched `deploy/aws/stage0/claude_cli_2_1_142_node24_20260515.json` with `diff_count=0`.
- [x] `bash scripts/preflight.sh`

🤖 Generated with [Claude Code](https://claude.com/claude-code)