### PR TITLE
Add compact response observability

### DIFF
--- a/backend/internal/service/openai_compat_model_test.go
+++ b/backend/internal/service/openai_compat_model_test.go
@@ -1408,7 +1408,9 @@ func TestForwardAsAnthropic_ClientDisconnectDrainsUpstreamUsage(t *testing.T) {
 		"",
 		`data: {"type":"response.output_text.delta","delta":"ok"}`,
 		"",
-		`data: {"type":"response.completed","response":{"id":"resp_1","object":"response","model":"gpt-5.4","status":"completed","output":[{"type":"message","id":"msg_1","role":"assistant","status":"completed","content":[{"type":"output_text","text":"ok"}]}],"usage":{"input_tokens":9,"output_tokens":4,"total_tokens":13,"input_tokens_details":{"cached_tokens":3}}}}`,
+		`data: {"type":"response.reasoning_summary_text.delta","delta":"想"}`,
+		"",
+		`data: {"type":"response.completed","response":{"id":"resp_1","object":"response","model":"gpt-5.4","status":"completed","output":[{"type":"reasoning","summary":[{"type":"summary_text","text":"想"}]},{"type":"message","id":"msg_1","role":"assistant","status":"completed","content":[{"type":"output_text","text":"ok"}]}],"usage":{"input_tokens":9,"output_tokens":4,"total_tokens":13,"input_tokens_details":{"cached_tokens":3}}}}`,
 		"",
 		"data: [DONE]",
 		"",
@@ -1438,8 +1440,50 @@ func TestForwardAsAnthropic_ClientDisconnectDrainsUpstreamUsage(t *testing.T) {
 	require.Equal(t, 9, result.Usage.InputTokens)
 	require.Equal(t, 4, result.Usage.OutputTokens)
 	require.Equal(t, 3, result.Usage.CacheReadInputTokens)
-	require.Equal(t, 2, result.ContentTextLen)
+	require.Equal(t, 3, result.ContentTextLen)
 	require.False(t, result.CompactCandidate)
+}
+
+func TestForwardAsAnthropic_BufferedObservabilityCapturesCompactCandidateAndTextLen(t *testing.T) {
+	gin.SetMode(gin.TestMode)
+
+	rec := httptest.NewRecorder()
+	c, _ := gin.CreateTestContext(rec)
+	body := []byte(`{"model":"gpt-5.4","max_tokens":4096,"messages":[{"role":"user","content":"hello"},{"role":"assistant","content":"hi"}],"stream":false}`)
+	c.Request = httptest.NewRequest(http.MethodPost, "/v1/messages", bytes.NewReader(body))
+	c.Request.Header.Set("Content-Type", "application/json")
+
+	upstreamBody := strings.Join([]string{
+		`data: {"type":"response.completed","response":{"id":"resp_1","object":"response","model":"gpt-5.4","status":"completed","output":[{"type":"reasoning","summary":[{"type":"summary_text","text":"想"}]},{"type":"message","id":"msg_1","role":"assistant","status":"completed","content":[{"type":"output_text","text":"ok"}]}],"usage":{"input_tokens":9,"output_tokens":4,"total_tokens":13,"input_tokens_details":{"cached_tokens":3}}}}`,
+		"",
+		"data: [DONE]",
+		"",
+	}, "\n")
+	upstream := &httpUpstreamRecorder{resp: &http.Response{
+		StatusCode: http.StatusOK,
+		Header:     http.Header{"Content-Type": []string{"text/event-stream"}, "x-request-id": []string{"rid_buffered_observability"}},
+		Body:       io.NopCloser(strings.NewReader(upstreamBody)),
+	}}
+
+	svc := &OpenAIGatewayService{httpUpstream: upstream}
+	account := &Account{
+		ID:          1,
+		Name:        "openai-oauth",
+		Platform:    PlatformOpenAI,
+		Type:        AccountTypeOAuth,
+		Concurrency: 1,
+		Credentials: map[string]any{
+			"access_token":       "oauth-token",
+			"chatgpt_account_id": "chatgpt-acc",
+		},
+	}
+
+	result, err := svc.ForwardAsAnthropic(context.Background(), c, account, body, "", "gpt-5.1")
+	require.NoError(t, err)
+	require.NotNil(t, result)
+	require.Equal(t, 3, result.ContentTextLen)
+	require.True(t, result.CompactCandidate)
+	require.Contains(t, rec.Body.String(), `"stop_reason":"end_turn"`)
 }
 
 func TestForwardAsAnthropic_TerminalUsageWithoutUpstreamCloseReturns(t *testing.T) {

--- a/backend/internal/service/openai_compat_model_test.go
+++ b/backend/internal/service/openai_compat_model_test.go
@@ -1438,6 +1438,8 @@ func TestForwardAsAnthropic_ClientDisconnectDrainsUpstreamUsage(t *testing.T) {
 	require.Equal(t, 9, result.Usage.InputTokens)
 	require.Equal(t, 4, result.Usage.OutputTokens)
 	require.Equal(t, 3, result.Usage.CacheReadInputTokens)
+	require.Equal(t, 2, result.ContentTextLen)
+	require.False(t, result.CompactCandidate)
 }
 
 func TestForwardAsAnthropic_TerminalUsageWithoutUpstreamCloseReturns(t *testing.T) {

--- a/backend/internal/service/openai_gateway_messages.go
+++ b/backend/internal/service/openai_gateway_messages.go
@@ -12,6 +12,7 @@ import (
 	"strings"
 	"sync/atomic"
 	"time"
+	"unicode/utf8"
 
 	"github.com/Wei-Shaw/sub2api/internal/pkg/apicompat"
 	"github.com/Wei-Shaw/sub2api/internal/pkg/claude"
@@ -156,6 +157,8 @@ func (s *OpenAIGatewayService) ForwardAsAnthropic(
 		logFields = append(logFields, zap.Bool("compat_turn_state_attached", true))
 	}
 	logger.L().Debug("openai messages: model mapping applied", logFields...)
+
+	compactCandidate := openAICompatMessagesCompactCandidate(&anthropicReq)
 
 	// 4. Marshal Responses request body, then apply OAuth codex transform
 	responsesBody, err := json.Marshal(responsesReq)
@@ -410,6 +413,9 @@ func (s *OpenAIGatewayService) ForwardAsAnthropic(
 		// Client wants JSON: buffer the streaming response and assemble a JSON reply.
 		result, handleErr = s.handleAnthropicBufferedStreamingResponse(resp, c, originalModel, billingModel, upstreamModel, startTime)
 	}
+	if result != nil {
+		result.CompactCandidate = compactCandidate
+	}
 
 	// Propagate ServiceTier and ReasoningEffort to result for billing
 	if handleErr == nil && result != nil {
@@ -455,6 +461,8 @@ func (s *OpenAIGatewayService) ForwardAsAnthropic(
 			zap.Int("output_tokens", result.Usage.OutputTokens),
 			zap.Int("cache_read_input_tokens", result.Usage.CacheReadInputTokens),
 			zap.String("stop_reason", result.StopReason),
+			zap.Int("content_text_len", result.ContentTextLen),
+			zap.Bool("compact_candidate", result.CompactCandidate),
 			zap.Int64("duration_ms", result.Duration.Milliseconds()),
 		}
 		// Emit optional fields only when non-empty so happy-path log lines stay compact.
@@ -562,6 +570,7 @@ func (s *OpenAIGatewayService) handleAnthropicBufferedStreamingResponse(
 		Duration:         time.Since(startTime),
 		StopReason:       anthropicResp.StopReason,
 		IncompleteReason: incompleteReason,
+		ContentTextLen:   anthropicResponseContentTextLen(anthropicResp),
 	}, nil
 }
 
@@ -740,6 +749,7 @@ func (s *OpenAIGatewayService) handleAnthropicStreamingResponse(
 	state.Model = originalModel
 	var usage OpenAIUsage
 	responseID := ""
+	contentTextLen := 0
 	var firstTokenMs *int
 	firstChunk := true
 	clientDisconnected := false
@@ -779,6 +789,7 @@ func (s *OpenAIGatewayService) handleAnthropicStreamingResponse(
 			FirstTokenMs:     firstTokenMs,
 			StopReason:       state.StopReason,
 			IncompleteReason: state.IncompleteReason,
+			ContentTextLen:   contentTextLen,
 		}
 	}
 
@@ -800,6 +811,10 @@ func (s *OpenAIGatewayService) handleAnthropicStreamingResponse(
 		}
 
 		// 仅按兼容转换器支持的终止事件提取 usage，避免无意扩大事件语义。
+		if event.Type == "response.output_text.delta" && event.Delta != "" {
+			contentTextLen += utf8.RuneCountInString(event.Delta)
+		}
+
 		isTerminalEvent := isOpenAICompatResponsesTerminalEvent(event.Type)
 		if isTerminalEvent && event.Response != nil {
 			if id := strings.TrimSpace(event.Response.ID); id != "" {

--- a/backend/internal/service/openai_gateway_messages.go
+++ b/backend/internal/service/openai_gateway_messages.go
@@ -811,8 +811,11 @@ func (s *OpenAIGatewayService) handleAnthropicStreamingResponse(
 		}
 
 		// 仅按兼容转换器支持的终止事件提取 usage，避免无意扩大事件语义。
-		if event.Type == "response.output_text.delta" && event.Delta != "" {
-			contentTextLen += utf8.RuneCountInString(event.Delta)
+		switch event.Type {
+		case "response.output_text.delta", "response.reasoning_summary_text.delta":
+			if event.Delta != "" {
+				contentTextLen += utf8.RuneCountInString(event.Delta)
+			}
 		}
 
 		isTerminalEvent := isOpenAICompatResponsesTerminalEvent(event.Type)

--- a/backend/internal/service/openai_gateway_service.go
+++ b/backend/internal/service/openai_gateway_service.go
@@ -247,6 +247,8 @@ type OpenAIForwardResult struct {
 	// content_filter, server_error, …). Empty otherwise. Used only for
 	// observability — does not change response shape.
 	IncompleteReason string
+	ContentTextLen   int
+	CompactCandidate bool
 }
 
 type OpenAIWSRetryMetricsSnapshot struct {

--- a/backend/internal/service/openai_messages_compaction_tk.go
+++ b/backend/internal/service/openai_messages_compaction_tk.go
@@ -3,6 +3,7 @@ package service
 import (
 	"encoding/json"
 	"strings"
+	"unicode/utf8"
 
 	"github.com/Wei-Shaw/sub2api/internal/pkg/apicompat"
 	"github.com/tidwall/gjson"
@@ -137,6 +138,32 @@ func estimateAnthropicRequestInputTokens(req *apicompat.AnthropicRequest) int {
 	}
 	if total < 0 {
 		return 0
+	}
+	return total
+}
+
+func openAICompatMessagesCompactCandidate(req *apicompat.AnthropicRequest) bool {
+	if req == nil || req.Stream {
+		return false
+	}
+	if req.MaxTokens > 0 && req.MaxTokens <= 4096 && len(req.Messages) >= 2 {
+		return true
+	}
+	return len(req.Messages) >= 4 && estimateAnthropicRequestInputTokens(req) >= 10000
+}
+
+func anthropicResponseContentTextLen(resp *apicompat.AnthropicResponse) int {
+	if resp == nil {
+		return 0
+	}
+	total := 0
+	for _, block := range resp.Content {
+		switch block.Type {
+		case "text":
+			total += utf8.RuneCountInString(block.Text)
+		case "thinking":
+			total += utf8.RuneCountInString(block.Thinking)
+		}
 	}
 	return total
 }

--- a/docs/spec-delta-235-no-web-impact.md
+++ b/docs/spec-delta-235-no-web-impact.md
@@ -1,0 +1,26 @@
+# spec-delta: PR #235 no-web-impact
+
+## Scope
+- PR: #235 (`fix/compact-observability`)
+- Backend changes:
+  - `backend/internal/service/openai_gateway_messages.go`
+  - `backend/internal/service/openai_gateway_service.go`
+  - `backend/internal/service/openai_messages_compaction_tk.go`
+  - `backend/internal/service/openai_compat_model_test.go`
+- Sentinel registry changes:
+  - `scripts/gateway-tk-sentinels.json`
+
+## Intent
+- Add production log evidence for OpenAI-compatible Messages compact-candidate requests.
+- Capture output text length consistently across buffered and streaming Anthropic-compatible responses.
+- Keep sentinel coverage for the observability hooks so future refactors do not silently remove compact incident evidence.
+
+## Web / API contract impact
+- No frontend page, route, UI state, or i18n surface changed.
+- No public request/response schema changes.
+- No admin setting, OpenAPI, or agent contract shape change required.
+
+## Why no web change is needed
+- The change only adds backend log fields and tests for gateway observability.
+- Client-visible Anthropic-compatible response payloads are unchanged.
+- Operators consume the new evidence from backend logs, not from Web UI or API contracts.

--- a/scripts/gateway-tk-sentinels.json
+++ b/scripts/gateway-tk-sentinels.json
@@ -49,8 +49,8 @@
     },
     {
       "path": "backend/internal/service/openai_messages_compaction_tk.go",
-      "must_contain": ["shouldEvaluateOpenAICompatMessagesCompactionForAccount", "applyOpenAICompatMessagesCompaction(account *Account", "applyOpenAICompatOAuthMessagesCompaction"],
-      "rationale": "OpenAI OAuth /v1/messages compaction is a TK policy companion: OAuth must opt into threshold-based compaction through the shared replay compaction engine's anchor+tail profile. Dropping these hooks silently makes GPT专线 OAuth accounts ignore configured compaction thresholds."
+      "must_contain": ["shouldEvaluateOpenAICompatMessagesCompactionForAccount", "applyOpenAICompatMessagesCompaction(account *Account", "applyOpenAICompatOAuthMessagesCompaction", "openAICompatMessagesCompactCandidate", "anthropicResponseContentTextLen"],
+      "rationale": "OpenAI OAuth /v1/messages compaction is a TK policy companion: OAuth must opt into threshold-based compaction through the shared replay compaction engine's anchor+tail profile, and gateway completion logs must keep enough compact-attempt evidence to distinguish upstream empty summaries from TokenKey routing or billing failures. Dropping these hooks silently makes GPT专线 OAuth accounts ignore configured compaction thresholds or removes the production evidence needed for long-context compact incidents."
     },
     {
       "path": "backend/internal/service/openai_messages_compaction_tk_test.go",


### PR DESCRIPTION
## Summary
- log compact-candidate requests and output text length for OpenAI-compatible Messages forwarding
- capture text length for buffered and streaming Anthropic-compatible responses
- extend gateway sentinels so future refactors keep compact incident evidence intact

## Test plan
- [x] bash scripts/preflight.sh

🤖 Generated with [Claude Code](https://claude.com/claude-code)