### PR TITLE
chore: refresh upstream issue cache

### DIFF
--- a/scripts/upstream-issue-triage.json
+++ b/scripts/upstream-issue-triage.json
@@ -6,11 +6,11 @@
   "counts": {
     "needs_review": 346,
     "needs_prod_validation": 8,
-    "medium": 114,
+    "medium": 115,
     "fixed": 17,
     "not_applicable": 1,
     "low": 94,
-    "unknown_low_signal": 393
+    "unknown_low_signal": 394
   },
   "issues": [
     {
@@ -5587,6 +5587,18 @@
       "updated_at": "2026-05-15T07:02:41Z"
     },
     {
+      "upstream": "Wei-Shaw/sub2api#2510",
+      "url": "https://github.com/Wei-Shaw/sub2api/issues/2510",
+      "title": "deepseek V4 的 reasoning_content 会支持吗？",
+      "impact": "medium",
+      "categories": [
+        "compatibility"
+      ],
+      "tokenkey_status": "not_prioritized",
+      "rationale": "Potential compatibility/ops/admin impact, but not selected as severe TokenKey production risk in this pass.",
+      "updated_at": "2026-05-16T06:07:54Z"
+    },
+    {
       "upstream": "Wei-Shaw/sub2api#255",
       "url": "https://github.com/Wei-Shaw/sub2api/issues/255",
       "title": "账号管理手机端适配",
@@ -9971,6 +9983,16 @@
       "tokenkey_status": "not_prioritized",
       "rationale": "No high-signal production-risk keywords in this pass.",
       "updated_at": "2026-05-15T03:03:51Z"
+    },
+    {
+      "upstream": "Wei-Shaw/sub2api#2511",
+      "url": "https://github.com/Wei-Shaw/sub2api/issues/2511",
+      "title": "[Bug] Redis Password Configuration Failure via `.env` Update",
+      "impact": "unknown_low_signal",
+      "categories": [],
+      "tokenkey_status": "not_prioritized",
+      "rationale": "No high-signal production-risk keywords in this pass.",
+      "updated_at": "2026-05-16T07:03:21Z"
     },
     {
       "upstream": "Wei-Shaw/sub2api#262",


### PR DESCRIPTION
## Summary
- Refresh `scripts/upstream-issue-triage.json` from the latest Wei-Shaw/sub2api issues.
- Update `scripts/upstream-issue-fixes.json` from current TokenKey main fact checks.
- Keep watchdog workflow/script/fact-check metadata in sync with the refreshed cache.

## Watchdog report
# Upstream Issue Watchdog Report

- Run URL: https://github.com/youxuanxue/sub2api/actions/runs/25955848745
- Repository SHA: `78530d504665f739cddca80b62a7c950a4eecf61`
- Generated at: `2026-05-16T07:12:48Z`
- Upstream issues scanned: `1346`
- Fact checks: `4`
- Fixed facts verified: `4`
- High/critical unresolved: `0`

## Fixed facts verified

- Wei-Shaw/sub2api#2107 via youxuanxue/sub2api#232
- Wei-Shaw/sub2api#2159 via youxuanxue/sub2api#232
- Wei-Shaw/sub2api#2258 via youxuanxue/sub2api#232
- Wei-Shaw/sub2api#2478 via youxuanxue/sub2api#232


## Test plan
- [x] `python3 -m json.tool scripts/upstream-issue-triage.json`
- [x] `python3 -m json.tool scripts/upstream-issue-fixes.json`
- [x] `python3 -m json.tool scripts/upstream-issue-fact-checks.json`
- [x] `python3 -m py_compile scripts/upstream-issue-watchdog.py`
- [x] `python3 -m json.tool .cache/upstream-issue-watchdog/report.json`
- [x] `python3 -m json.tool .cache/upstream-issue-watchdog/agent-input.json`
