### PR TITLE
Adopt human-paced OAuth tiers

### DIFF
--- a/.cursor/skills/tokenkey-edge-anthropic-oauth-config/SKILL.md
+++ b/.cursor/skills/tokenkey-edge-anthropic-oauth-config/SKILL.md
@@ -26,7 +26,7 @@ description: >-
 | `account_name` | `target_scope=account` 时必填；目标账号名（`accounts.name`）；`check` 支持 `all` 自动枚举每个 edge 下全部 anthropic oauth 账号。 |
 | `target_group_id` | `target_scope=group` 时可选；目标分组 ID（与 `target_group_name` 二选一，优先 ID）。 |
 | `target_group_name` | `target_scope=group` 时可选；目标分组名（与 `target_group_id` 二选一）。 |
-| `account.extra.stability_tier` | 分级基线选择键（`l1_novice/l2_junior/l3_mid/l4_senior/l5_ultra`），`check` 会按该字段选择 tier baseline。 |
+| `account.extra.stability_tier` | 分级基线选择键（`l1/l2/l3`），`check` 会按该字段选择 tier baseline。 |
 | `operation=check` | 默认模式，只读检查当前配置与基准差异；`target_scope=group` 时输出分组聚合结果与成员账号明细。 |
 | `operation=plan-apply` | 生成更新计划与请求 payload 预览，不写入。 |
 | `operation=apply` | 执行更新（账号字段 + 可选分组绑定）；`target_scope=group` 时对分组内可用账号逐一执行，必须显式确认。 |
@@ -61,7 +61,7 @@ description: >-
 - `group_agg.total_window_cost_limit` = Σ(每个可用账号 `extra.window_cost_limit`)
 - `group_agg.effective_concurrency` = Σ(每个可用账号 `account.concurrency`)
 - `group_agg.min_priority` / `max_priority` = 分组内优先级范围（数值越小优先级越高）
-- `group_agg.tier_distribution` = 各 tier 账号计数（L1~L5）
+- `group_agg.tier_distribution` = 各 tier 账号计数（L1~L3）
 
 `check` 输出应同时包含：
 1) 分组聚合结果（group_agg）；

--- a/backend/internal/service/account.go
+++ b/backend/internal/service/account.go
@@ -1974,14 +1974,14 @@ func (a *Account) GetWindowCostLimit() float64 {
 }
 
 // GetWindowCostStickyReserve 获取粘性会话预留额度（美元）
-// 默认值为 10
+// 默认值为 10；显式配置 0 表示禁用 sticky 成本缓冲。
 func (a *Account) GetWindowCostStickyReserve() float64 {
 	if a.Extra == nil {
 		return 10.0
 	}
 	if v, ok := a.Extra["window_cost_sticky_reserve"]; ok {
 		val := parseExtraFloat64(v)
-		if val > 0 {
+		if val >= 0 {
 			return val
 		}
 	}

--- a/backend/internal/service/account_window_cost_test.go
+++ b/backend/internal/service/account_window_cost_test.go
@@ -1,0 +1,28 @@
+package service
+
+import "testing"
+
+func TestWindowCostStickyReserveExplicitZero(t *testing.T) {
+	account := &Account{Extra: map[string]any{
+		"window_cost_limit":          100,
+		"window_cost_sticky_reserve": 0,
+	}}
+
+	if got := account.GetWindowCostStickyReserve(); got != 0 {
+		t.Fatalf("GetWindowCostStickyReserve() = %v, want 0", got)
+	}
+	if got := account.CheckWindowCostSchedulability(100); got != WindowCostNotSchedulable {
+		t.Fatalf("CheckWindowCostSchedulability(100) = %v, want WindowCostNotSchedulable", got)
+	}
+}
+
+func TestWindowCostStickyReserveDefault(t *testing.T) {
+	account := &Account{Extra: map[string]any{"window_cost_limit": 100}}
+
+	if got := account.GetWindowCostStickyReserve(); got != 10 {
+		t.Fatalf("GetWindowCostStickyReserve() = %v, want 10", got)
+	}
+	if got := account.CheckWindowCostSchedulability(105); got != WindowCostStickyOnly {
+		t.Fatalf("CheckWindowCostSchedulability(105) = %v, want WindowCostStickyOnly", got)
+	}
+}

--- a/backend/internal/web/dist/frontend-source.json
+++ b/backend/internal/web/dist/frontend-source.json
@@ -1,7 +1,7 @@
 {
   "algorithm": "sha256(git-ls-files:path,size,content)",
   "file_count": 425,
-  "hash": "81c9e306c0654199c2d74c5aa4daecccb2bfa39f5d75cd242a9bed33904ee0ef",
+  "hash": "90f70367a40fcac8c4e99e050c595f6ecd3c060472afdbf41f70395d0e2bcc83",
   "schema": 1,
   "source": "frontend/"
 }

--- a/deploy/aws/stage0/anthropic-oauth-stability-baselines-tiered.json
+++ b/deploy/aws/stage0/anthropic-oauth-stability-baselines-tiered.json
@@ -1,40 +1,14 @@
 {
   "schema_version": 1,
-  "description": "Tiered Anthropic OAuth stability baselines for single-account safe operation.",
+  "description": "Human-paced Anthropic OAuth stability baselines for Claude Code account operation.",
   "policy": {
     "single_account_scope": true,
-    "max_traffic_ratio": 0.7,
     "rate_multiplier_fixed": 1.0,
-    "full_source": {
-      "type": "official-estimate",
-      "reference": "Anthropic API rate limits",
-      "url": "https://platform.claude.com/docs/en/api/rate-limits",
-      "note": "Use Tier 3 (credit purchase threshold $200) as the full reference level; tiered baselines are capped at <=70% of full."
-    },
-    "official_facts": {
-      "tier_3_credit_purchase_usd": 200,
-      "tier_3_monthly_spend_limit_usd": 1000,
-      "tier_3_sonnet_4x_rpm": 2000,
-      "tier_3_sonnet_4x_itpm": 800000,
-      "tier_3_sonnet_4x_otpm": 160000
-    },
-    "tokenkey_full_estimate": {
-      "concurrency": 12,
-      "base_rpm": 20,
-      "max_sessions": 12,
-      "window_cost_limit": 600,
-      "rate_multiplier": 1.0,
-      "derivation": [
-        "base_rpm := floor(official_rpm * 0.01) = floor(2000 * 0.01) = 20",
-        "concurrency := floor(base_rpm * 0.6) = 12",
-        "max_sessions := concurrency = 12",
-        "window_cost_limit := base_rpm * 30 = 600"
-      ]
-    },
+    "usage_model": "Claude Code human-paced work: usage budget and session length are constrained separately; lower tiers are scheduled first but reach their local limits earlier.",
+    "tier_order": ["l1", "l2", "l3"],
     "rounding": {
-      "integer_fields": "floor",
-      "float_fields": "round(2)",
-      "hard_cap": "never exceed full * 0.70"
+      "integer_fields": "explicit",
+      "float_fields": "explicit"
     }
   },
   "shared_baseline": {
@@ -174,30 +148,12 @@
     }
   },
   "tiers": {
-    "l1_novice": {
-      "factor": 0.15,
-      "baseline": {
-        "account": {
-          "concurrency": 2,
-          "priority": 100,
-          "rate_multiplier": 1.0
-        },
-        "extra": {
-          "base_rpm": 3,
-          "rpm_sticky_buffer": 1,
-          "max_sessions": 2,
-          "session_idle_timeout_minutes": 6,
-          "window_cost_limit": 90,
-          "window_cost_sticky_reserve": 1
-        }
-      }
-    },
-    "l2_junior": {
+    "l1": {
       "factor": 0.3,
       "baseline": {
         "account": {
-          "concurrency": 3,
-          "priority": 80,
+          "concurrency": 1,
+          "priority": 10,
           "rate_multiplier": 1.0
         },
         "extra": {
@@ -206,61 +162,43 @@
           "max_sessions": 3,
           "session_idle_timeout_minutes": 8,
           "window_cost_limit": 180,
-          "window_cost_sticky_reserve": 2
+          "window_cost_sticky_reserve": 0
         }
       }
     },
-    "l3_mid": {
-      "factor": 0.5,
+    "l2": {
+      "factor": 0.55,
       "baseline": {
         "account": {
-          "concurrency": 6,
-          "priority": 40,
-          "rate_multiplier": 1.0
-        },
-        "extra": {
-          "base_rpm": 10,
-          "rpm_sticky_buffer": 3,
-          "max_sessions": 6,
-          "session_idle_timeout_minutes": 10,
-          "window_cost_limit": 300,
-          "window_cost_sticky_reserve": 3
-        }
-      }
-    },
-    "l4_senior": {
-      "factor": 0.6,
-      "baseline": {
-        "account": {
-          "concurrency": 7,
+          "concurrency": 2,
           "priority": 20,
           "rate_multiplier": 1.0
         },
         "extra": {
-          "base_rpm": 12,
+          "base_rpm": 8,
           "rpm_sticky_buffer": 4,
-          "max_sessions": 7,
-          "session_idle_timeout_minutes": 11,
-          "window_cost_limit": 360,
-          "window_cost_sticky_reserve": 4
+          "max_sessions": 4,
+          "session_idle_timeout_minutes": 8,
+          "window_cost_limit": 330,
+          "window_cost_sticky_reserve": 0
         }
       }
     },
-    "l5_ultra": {
-      "factor": 0.7,
+    "l3": {
+      "factor": 0.8,
       "baseline": {
         "account": {
-          "concurrency": 8,
-          "priority": 10,
+          "concurrency": 3,
+          "priority": 30,
           "rate_multiplier": 1.0
         },
         "extra": {
-          "base_rpm": 14,
-          "rpm_sticky_buffer": 5,
-          "max_sessions": 8,
-          "session_idle_timeout_minutes": 12,
-          "window_cost_limit": 420,
-          "window_cost_sticky_reserve": 5
+          "base_rpm": 10,
+          "rpm_sticky_buffer": 6,
+          "max_sessions": 5,
+          "session_idle_timeout_minutes": 8,
+          "window_cost_limit": 480,
+          "window_cost_sticky_reserve": 0
         }
       }
     }

--- a/deploy/aws/stage0/anthropic-oauth-stability-tiered-apply-template.sql
+++ b/deploy/aws/stage0/anthropic-oauth-stability-tiered-apply-template.sql
@@ -2,7 +2,7 @@
 -- Source of truth: deploy/aws/stage0/anthropic-oauth-stability-baselines-tiered.json
 -- Usage (psql):
 --   \set account_name 'your-account-name'
---   \set stability_tier 'l1_novice'  -- l1_novice|l2_junior|l3_mid|l4_senior|l5_ultra
+--   \set stability_tier 'l1'  -- l1|l2|l3
 --   \i deploy/aws/stage0/anthropic-oauth-stability-tiered-apply-template.sql
 
 -- Helper for explicit failure (session-scoped, no persistent schema changes).
@@ -23,11 +23,9 @@ WITH input AS (
 tier_cfg AS (
   SELECT *
   FROM (VALUES
-    ('l1_novice'::text, 2::int, 100::int, 3::int, 1::int, 2::int, 6::int, 90::int, 1::int),
-    ('l2_junior'::text, 3::int, 80::int, 6::int, 2::int, 3::int, 8::int, 180::int, 2::int),
-    ('l3_mid'::text, 6::int, 40::int, 10::int, 3::int, 6::int, 10::int, 300::int, 3::int),
-    ('l4_senior'::text, 7::int, 20::int, 12::int, 4::int, 7::int, 11::int, 360::int, 4::int),
-    ('l5_ultra'::text, 8::int, 10::int, 14::int, 5::int, 8::int, 12::int, 420::int, 5::int)
+    ('l1'::text, 1::int, 10::int, 6::int, 2::int, 3::int, 8::int, 180::int, 0::int),
+    ('l2'::text, 2::int, 20::int, 8::int, 4::int, 4::int, 8::int, 330::int, 0::int),
+    ('l3'::text, 3::int, 30::int, 10::int, 6::int, 5::int, 8::int, 480::int, 0::int)
   ) AS v(
     stability_tier,
     concurrency,
@@ -49,7 +47,7 @@ validate AS (
   SELECT
     CASE
       WHEN NOT EXISTS (SELECT 1 FROM selected) THEN
-        pg_temp.pg_raise('invalid stability_tier=%s (expected l1_novice/l2_junior/l3_mid/l4_senior/l5_ultra)', (SELECT stability_tier FROM input))
+        pg_temp.pg_raise('invalid stability_tier=%s (expected l1/l2/l3)', (SELECT stability_tier FROM input))
       ELSE 'ok'
     END AS ok
 ),

--- a/frontend/src/components/account/AccountCapacityCell.vue
+++ b/frontend/src/components/account/AccountCapacityCell.vue
@@ -77,7 +77,7 @@ const windowCostClass = computed(() => {
   if (!showWindowCost.value) return ''
   const current = currentWindowCost.value
   const limit = props.account.window_cost_limit || 0
-  const reserve = props.account.window_cost_sticky_reserve || 10
+  const reserve = props.account.window_cost_sticky_reserve ?? 10
   if (current >= limit + reserve) return 'bg-red-100 text-red-700 dark:bg-red-900/30 dark:text-red-400'
   if (current >= limit) return 'bg-orange-100 text-orange-700 dark:bg-orange-900/30 dark:text-orange-400'
   if (current >= limit * 0.8) return 'bg-yellow-100 text-yellow-700 dark:bg-yellow-900/30 dark:text-yellow-400'
@@ -88,7 +88,7 @@ const windowCostTooltip = computed(() => {
   if (!showWindowCost.value) return ''
   const current = currentWindowCost.value
   const limit = props.account.window_cost_limit || 0
-  const reserve = props.account.window_cost_sticky_reserve || 10
+  const reserve = props.account.window_cost_sticky_reserve ?? 10
   if (current >= limit + reserve) return t('admin.accounts.capacity.windowCost.blocked')
   if (current >= limit) return t('admin.accounts.capacity.windowCost.stickyOnly')
   return t('admin.accounts.capacity.windowCost.normal')

--- a/scripts/check-edge-anthropic-oauth-stability.py
+++ b/scripts/check-edge-anthropic-oauth-stability.py
@@ -373,7 +373,7 @@ def resolve_effective_baseline(
     if not tier_key:
         fail(
             f"account {account_name} on edge {edge_id} missing account.extra.stability_tier; "
-            "expected one of l1_novice/l2_junior/l3_mid/l4_senior/l5_ultra"
+            "expected one of l1/l2/l3"
         )
 
     tiers = baseline.get("tiers") or {}


### PR DESCRIPTION
## Summary
- Replace Stage0 Anthropic OAuth capacity-style L1-L5 baselines with human-paced L1-L3 tiers.
- Align the apply SQL template, checker messaging, and OAuth config skill text with the new tier names.
- Treat explicit `window_cost_sticky_reserve=0` as disabling sticky cost reserve and add focused unit coverage.

## Production update
- Applied edge-us1 account `cc-am-or-ec2-5-1-b` to new `l2` and refreshed default group RPM.
- Verified `check-edge-anthropic-oauth-stability.py --edge-id us1 --account-name cc-am-or-ec2-5-1-b --json` returns `status=ok`, `diff_count=0`.

## Test plan
- [x] `python3 -m json.tool deploy/aws/stage0/anthropic-oauth-stability-baselines-tiered.json >/dev/null`
- [x] `go -C backend test -tags=unit ./internal/service -run 'TestWindowCostStickyReserve|TestCheckRPM'`
- [x] `python3 scripts/check-edge-anthropic-oauth-stability.py --edge-id us1 --account-name cc-am-or-ec2-5-1-b --json`
- [x] `bash scripts/preflight.sh`

🤖 Generated with [Claude Code](https://claude.com/claude-code)