### PR TITLE
fix(admin/account): respect sticky-reserve=0 in capacity badge (review of #246)

### DIFF
--- a/frontend/src/components/account/AccountCapacityCell.vue
+++ b/frontend/src/components/account/AccountCapacityCell.vue
@@ -77,7 +77,7 @@ const windowCostClass = computed(() => {
   if (!showWindowCost.value) return ''
   const current = currentWindowCost.value
   const limit = props.account.window_cost_limit || 0
-  const reserve = props.account.window_cost_sticky_reserve || 10
+  const reserve = props.account.window_cost_sticky_reserve ?? 10
   if (current >= limit + reserve) return 'bg-red-100 text-red-700 dark:bg-red-900/30 dark:text-red-400'
   if (current >= limit) return 'bg-orange-100 text-orange-700 dark:bg-orange-900/30 dark:text-orange-400'
   if (current >= limit * 0.8) return 'bg-yellow-100 text-yellow-700 dark:bg-yellow-900/30 dark:text-yellow-400'
@@ -88,7 +88,7 @@ const windowCostTooltip = computed(() => {
   if (!showWindowCost.value) return ''
   const current = currentWindowCost.value
   const limit = props.account.window_cost_limit || 0
-  const reserve = props.account.window_cost_sticky_reserve || 10
+  const reserve = props.account.window_cost_sticky_reserve ?? 10
   if (current >= limit + reserve) return t('admin.accounts.capacity.windowCost.blocked')
   if (current >= limit) return t('admin.accounts.capacity.windowCost.stickyOnly')
   return t('admin.accounts.capacity.windowCost.normal')


### PR DESCRIPTION
## Review of #246

Reviewed PR #246 "Adopt human-paced OAuth tiers". One follow-up issue
found; the rest of the PR (tier rename, SQL template, checker text,
backend test) reads correctly.

### Issue

PR #246 changes `(*Account).GetWindowCostStickyReserve` so that an
explicit `window_cost_sticky_reserve=0` disables the sticky cost
reserve (previously `0` fell back to the `10` default). The new unit
test `TestWindowCostStickyReserveExplicitZero` confirms the backend
returns `WindowCostNotSchedulable` for `current=limit` when
`reserve=0`.

`frontend/src/components/account/AccountCapacityCell.vue` still used
`props.account.window_cost_sticky_reserve || 10` for the badge color
and tooltip thresholds. The `||` form treats `0` as falsy and falls
back to `10`, so an account configured with `reserve=0` would render
as `stickyOnly` / `normal` (orange/yellow/emerald) while the backend
has already declared it non-schedulable at `current >= limit`.

### Fix

Switch the two thresholds in `AccountCapacityCell.vue` to nullish
coalescing (`?? 10`) so an explicit `0` flows through the display
logic and the badge turns red at `current >= limit`.

No other UI surfaces drift: `EditAccountModal.vue` and
`CreateAccountModal.vue` already use `?? 10` when seeding and
persisting the field.

### Side benefit

This also resolves the failing `preflight` check on #246 —
`check_web_surface_alignment` was complaining about
`backend/internal/service/account.go` changing without matching
Web/config/contract evidence. The frontend fix is the alignment.

### Integration

Targets `feature/human-paced-oauth-tiers` (the PR-#246 branch) so the
diff here is exactly the 2-line fix. Merging this PR rolls the fix
into #246 directly. Alternatively, the maintainer can cherry-pick
commit `8ce2edf` onto the feature branch.

### Test plan

- [x] `pnpm -C frontend lint:check`
- [x] `pnpm -C frontend typecheck`
- [x] `bash scripts/preflight.sh` — web surface alignment now passes
      (remaining failures are local-only: branch-name `claude/*`
      imposed by the harness, and missing local `gh` / dev secrets)
- [x] `cd backend && go test -tags=unit -run TestWindowCostStickyReserve ./internal/service/...` — green


---
_Generated by [Claude Code](https://claude.ai/code/session_01HbEVH3Co2K3c2kknKjLW1f)_