### PR TITLE
fix: close three high-severity upstream billing/usage bugs (#2486, #2363, #2332)

### DIFF
--- a/backend/internal/service/billing_service.go
+++ b/backend/internal/service/billing_service.go
@@ -293,7 +293,12 @@ func (s *BillingService) getFallbackPricing(model string) *ModelPricing {
 	if strings.Contains(modelLower, "claude") {
 		return s.fallbackPrices["claude-sonnet-4"]
 	}
-	if strings.Contains(modelLower, "gemini-3.1-pro") || strings.Contains(modelLower, "gemini-3-1-pro") {
+	// Gemini family fallback (upstream Wei-Shaw/sub2api#2486): any gemini-* model
+	// without an explicit LiteLLM or fallback entry — including new Google variants
+	// like gemini-pro-agent — must bill at the conservative paid-tier rate instead
+	// of returning nil (which causes calculateTokenCost to swallow the error and
+	// silently record ActualCost=0 with no quota deduction).
+	if strings.Contains(modelLower, "gemini") {
 		return s.fallbackPrices["gemini-3.1-pro"]
 	}
 

--- a/backend/internal/service/billing_service_test.go
+++ b/backend/internal/service/billing_service_test.go
@@ -211,7 +211,11 @@ func TestGetFallbackPricing_FamilyMatching(t *testing.T) {
 		{name: "claude opus 4.5 alt separator", model: "claude-opus-4-5-20260101", expectedInput: 5e-6},
 		{name: "claude generic model fallback sonnet", model: "claude-foo-bar", expectedInput: 3e-6},
 		{name: "gemini explicit fallback", model: "gemini-3-1-pro", expectedInput: 2e-6},
-		{name: "gemini unknown no fallback", model: "gemini-2.0-pro", expectNilPricing: true},
+		// upstream Wei-Shaw/sub2api#2486: unknown gemini-* must NOT bill $0; falls back to gemini-3.1-pro pricing.
+		{name: "gemini unknown falls back to 3.1-pro", model: "gemini-2.0-pro", expectedInput: 2e-6},
+		{name: "gemini-pro-agent falls back to 3.1-pro", model: "gemini-pro-agent", expectedInput: 2e-6},
+		{name: "models/gemini-pro-agent falls back to 3.1-pro", model: "models/gemini-pro-agent", expectedInput: 2e-6},
+		{name: "gemini-2.5-flash-unknown falls back to 3.1-pro", model: "gemini-2.5-flash-unknown-variant", expectedInput: 2e-6},
 		{name: "openai gpt5.4", model: "gpt-5.4", expectedInput: 2.5e-6},
 		{name: "openai gpt5.4 mini", model: "gpt-5.4-mini", expectedInput: 7.5e-7},
 		{name: "openai gpt5.3 codex", model: "gpt-5.3-codex", expectedInput: 1.5e-6},

--- a/backend/internal/service/gateway_service.go
+++ b/backend/internal/service/gateway_service.go
@@ -7682,18 +7682,23 @@ func (s *GatewayService) extractSSEUsagePatch(event map[string]any) *sseUsagePat
 			return nil
 		}
 
+		// Upstream Wei-Shaw/sub2api#2332 hardening: gate the hasX flags on
+		// actual parse success. Without this, a partial usage object (e.g.
+		// only output_tokens present, or a fragmented/duplicate message_start)
+		// would clobber legitimate accumulator values with 0 because mergeSSEUsagePatch
+		// writes whenever hasX is true regardless of whether the source key existed.
 		patch := &sseUsagePatch{}
-		patch.hasInputTokens = true
 		if v, ok := parseSSEUsageInt(usageObj["input_tokens"]); ok {
 			patch.inputTokens = v
+			patch.hasInputTokens = true
 		}
-		patch.hasCacheCreationInput = true
 		if v, ok := parseSSEUsageInt(usageObj["cache_creation_input_tokens"]); ok {
 			patch.cacheCreationInputTokens = v
+			patch.hasCacheCreationInput = true
 		}
-		patch.hasCacheReadInput = true
 		if v, ok := parseSSEUsageInt(usageObj["cache_read_input_tokens"]); ok {
 			patch.cacheReadInputTokens = v
+			patch.hasCacheReadInput = true
 		}
 		if cc, ok := usageObj["cache_creation"].(map[string]any); ok {
 			if v, exists := parseSSEUsageInt(cc["ephemeral_5m_input_tokens"]); exists {

--- a/backend/internal/service/gateway_streaming_test.go
+++ b/backend/internal/service/gateway_streaming_test.go
@@ -82,6 +82,27 @@ func TestParseSSEUsage_DeltaOverwritesWithNonZero(t *testing.T) {
 	require.Equal(t, 60, usage.CacheReadInputTokens)
 }
 
+// TestParseSSEUsage_StartPartialUsageDoesNotZeroAccumulator asserts upstream
+// Wei-Shaw/sub2api#2332 hardening: a message_start frame that only carries
+// some usage fields (or a duplicate message_start with a partial usage object)
+// must NOT zero out accumulator dimensions that the parser cannot extract from
+// this specific frame. Earlier code set hasInputTokens/hasCacheCreationInput/
+// hasCacheReadInput=true unconditionally inside message_start, so any later
+// merge would write 0 for the missing dimensions, producing duplicate-billing-
+// shaped usage rows (input_tokens=0 after a real value had landed).
+func TestParseSSEUsage_StartPartialUsageDoesNotZeroAccumulator(t *testing.T) {
+	svc := newMinimalGatewayService()
+	usage := &ClaudeUsage{InputTokens: 123, CacheCreationInputTokens: 45, CacheReadInputTokens: 67}
+
+	// Frame that includes only output_tokens in the start usage object — the
+	// other dimensions are absent (not zero-valued JSON).
+	svc.parseSSEUsage(`{"type":"message_start","message":{"usage":{"output_tokens":10}}}`, usage)
+
+	require.Equal(t, 123, usage.InputTokens, "absent input_tokens must not zero existing value")
+	require.Equal(t, 45, usage.CacheCreationInputTokens, "absent cache_creation_input_tokens must not zero existing value")
+	require.Equal(t, 67, usage.CacheReadInputTokens, "absent cache_read_input_tokens must not zero existing value")
+}
+
 func TestParseSSEUsage_DeltaDoesNotResetCacheCreationBreakdown(t *testing.T) {
 	svc := newMinimalGatewayService()
 	usage := &ClaudeUsage{}

--- a/backend/internal/service/model_pricing_resolver.go
+++ b/backend/internal/service/model_pricing_resolver.go
@@ -168,6 +168,12 @@ func filterValidIntervals(intervals []PricingInterval) []PricingInterval {
 
 // GetIntervalPricing 根据 context token 数获取区间定价。
 // 如果有区间列表，找到匹配区间并构造 ModelPricing；否则直接返回 BasePricing。
+//
+// TK policy (upstream #2363): matched intervals overlay onto BasePricing so the
+// channel's flat defaults (notably CacheReadPrice) are preserved for any
+// dimension the interval itself does not set. See TK companion
+// tkOverlayIntervalOntoBasePricing in
+// model_pricing_resolver_tk_channel_flat_fallback.go.
 func (r *ModelPricingResolver) GetIntervalPricing(resolved *ResolvedPricing, totalContextTokens int) *ModelPricing {
 	if len(resolved.Intervals) == 0 {
 		return resolved.BasePricing
@@ -178,32 +184,7 @@ func (r *ModelPricingResolver) GetIntervalPricing(resolved *ResolvedPricing, tot
 		return resolved.BasePricing
 	}
 
-	return intervalToModelPricing(iv, resolved.SupportsCacheBreakdown)
-}
-
-// intervalToModelPricing 将区间定价转换为 ModelPricing
-func intervalToModelPricing(iv *PricingInterval, supportsCacheBreakdown bool) *ModelPricing {
-	pricing := &ModelPricing{
-		SupportsCacheBreakdown: supportsCacheBreakdown,
-	}
-	if iv.InputPrice != nil {
-		pricing.InputPricePerToken = *iv.InputPrice
-		pricing.InputPricePerTokenPriority = *iv.InputPrice
-	}
-	if iv.OutputPrice != nil {
-		pricing.OutputPricePerToken = *iv.OutputPrice
-		pricing.OutputPricePerTokenPriority = *iv.OutputPrice
-	}
-	if iv.CacheWritePrice != nil {
-		pricing.CacheCreationPricePerToken = *iv.CacheWritePrice
-		pricing.CacheCreation5mPrice = *iv.CacheWritePrice
-		pricing.CacheCreation1hPrice = *iv.CacheWritePrice
-	}
-	if iv.CacheReadPrice != nil {
-		pricing.CacheReadPricePerToken = *iv.CacheReadPrice
-		pricing.CacheReadPricePerTokenPriority = *iv.CacheReadPrice
-	}
-	return pricing
+	return tkOverlayIntervalOntoBasePricing(resolved.BasePricing, iv, resolved.SupportsCacheBreakdown)
 }
 
 // GetRequestTierPrice 根据层级标签获取按次价格

--- a/backend/internal/service/model_pricing_resolver_test.go
+++ b/backend/internal/service/model_pricing_resolver_test.go
@@ -545,6 +545,75 @@ func TestGetIntervalPricing_ChannelIntervalsNoMatch_FlatDefaultsApplied(t *testi
 	require.InDelta(t, 4e-6, outOfRange.CacheCreationPricePerToken, 1e-12)
 }
 
+// TestGetIntervalPricing_IntervalMatched_FlatCacheReadPreserved asserts upstream
+// Wei-Shaw/sub2api#2363: when an in-range interval defines only InputPrice /
+// OutputPrice (a common operator configuration: tiered token prices + one flat
+// cache_read price for cache-hit discount), the channel's flat CacheReadPrice
+// MUST still apply to billing instead of silently dropping to 0. The matched
+// interval overlays onto BasePricing rather than replacing it.
+//
+// Without this, sticky-routing's cache-hit traffic — which is the headline
+// cost-savings feature — would silently bill at $0 cache_read.
+func TestGetIntervalPricing_IntervalMatched_FlatCacheReadPreserved(t *testing.T) {
+	r := newResolverWithChannel(t, []ChannelModelPricing{{
+		Platform:    "anthropic",
+		Models:      []string{"claude-sonnet-4"},
+		BillingMode: BillingModeToken,
+		// Operator configures flat defaults for cache-read/cache-write/image-output,
+		// plus tiered input/output by interval. The interval intentionally lacks
+		// CacheReadPrice / CacheWritePrice / ImageOutputPrice.
+		InputPrice:       testPtrFloat64(11e-6),
+		OutputPrice:      testPtrFloat64(33e-6),
+		CacheReadPrice:   testPtrFloat64(1e-6),
+		CacheWritePrice:  testPtrFloat64(4e-6),
+		ImageOutputPrice: testPtrFloat64(2e-6),
+		Intervals: []PricingInterval{
+			{MinTokens: 50000, MaxTokens: testPtrInt(200000), InputPrice: testPtrFloat64(9e-6), OutputPrice: testPtrFloat64(27e-6)},
+		},
+	}})
+
+	resolved := r.Resolve(context.Background(), PricingInput{
+		Model:   "claude-sonnet-4",
+		GroupID: groupIDPtr(),
+	})
+
+	// In-range match (100000 ∈ [50000, 200000]).
+	pricing := r.GetIntervalPricing(resolved, 100000)
+	require.NotNil(t, pricing)
+	// Interval-overridden dimensions reflect the interval values.
+	require.InDelta(t, 9e-6, pricing.InputPricePerToken, 1e-12)
+	require.InDelta(t, 27e-6, pricing.OutputPricePerToken, 1e-12)
+	// Channel flat defaults are preserved for dimensions the interval does NOT set.
+	require.InDelta(t, 1e-6, pricing.CacheReadPricePerToken, 1e-12, "in-range match must preserve channel flat CacheReadPrice — upstream #2363")
+	require.InDelta(t, 4e-6, pricing.CacheCreationPricePerToken, 1e-12, "in-range match must preserve channel flat CacheWritePrice — upstream #2363")
+	require.InDelta(t, 2e-6, pricing.ImageOutputPricePerToken, 1e-12, "in-range match must preserve channel flat ImageOutputPrice — upstream #2363")
+}
+
+// TestGetIntervalPricing_IntervalMatched_IntervalCacheReadOverridesFlat asserts
+// the precedence direction is correct: when both a flat default and an interval
+// value are set for the same dimension (cache_read), the interval value wins
+// in-range.
+func TestGetIntervalPricing_IntervalMatched_IntervalCacheReadOverridesFlat(t *testing.T) {
+	r := newResolverWithChannel(t, []ChannelModelPricing{{
+		Platform:       "anthropic",
+		Models:         []string{"claude-sonnet-4"},
+		BillingMode:    BillingModeToken,
+		CacheReadPrice: testPtrFloat64(1e-6), // flat default
+		Intervals: []PricingInterval{
+			{MinTokens: 50000, MaxTokens: testPtrInt(200000), InputPrice: testPtrFloat64(9e-6), CacheReadPrice: testPtrFloat64(8e-7)},
+		},
+	}})
+
+	resolved := r.Resolve(context.Background(), PricingInput{
+		Model:   "claude-sonnet-4",
+		GroupID: groupIDPtr(),
+	})
+
+	pricing := r.GetIntervalPricing(resolved, 100000)
+	require.NotNil(t, pricing)
+	require.InDelta(t, 8e-7, pricing.CacheReadPricePerToken, 1e-12, "interval CacheReadPrice must take precedence over channel flat default in-range")
+}
+
 // TestGetIntervalPricing_ChannelIntervalsNoMatch_UnknownModelChargesFlatNotZero
 // asserts upstream #2107: a custom model with no LiteLLM entry, configured with
 // intervals + flat defaults, must NOT bill $0 on out-of-range requests.

--- a/backend/internal/service/model_pricing_resolver_tk_channel_flat_fallback.go
+++ b/backend/internal/service/model_pricing_resolver_tk_channel_flat_fallback.go
@@ -54,3 +54,46 @@ func tkApplyChannelFlatOverridesAsFallback(chPricing *ChannelModelPricing, resol
 		resolved.BasePricing.ImageOutputPricePerToken = *chPricing.ImageOutputPrice
 	}
 }
+
+// tkOverlayIntervalOntoBasePricing returns the effective pricing for a matched
+// interval by overlaying the interval's non-nil fields onto a copy of
+// resolved.BasePricing. This preserves channel flat defaults (input / output /
+// cache_read / cache_write / image_output) for any dimension the interval
+// itself does not override.
+//
+// Upstream Wei-Shaw/sub2api#2363: the original intervalToModelPricing built a
+// brand-new empty ModelPricing{} from interval fields only, so an in-range
+// request silently lost the channel's flat CacheReadPrice (the common operator
+// pattern: tiered input/output by interval + a single flat cache_read price).
+// On TokenKey this is the same failure mode the #2107 fix solved for the
+// out-of-range path — sticky-routing maximizes cache_read_input_tokens
+// specifically to bank that discount, and dropping it makes the headline
+// cost-savings feature silently inert.
+func tkOverlayIntervalOntoBasePricing(base *ModelPricing, iv *PricingInterval, supportsCacheBreakdown bool) *ModelPricing {
+	out := ModelPricing{SupportsCacheBreakdown: supportsCacheBreakdown}
+	if base != nil {
+		out = *base
+		out.SupportsCacheBreakdown = supportsCacheBreakdown
+	}
+	if iv == nil {
+		return &out
+	}
+	if iv.InputPrice != nil {
+		out.InputPricePerToken = *iv.InputPrice
+		out.InputPricePerTokenPriority = *iv.InputPrice
+	}
+	if iv.OutputPrice != nil {
+		out.OutputPricePerToken = *iv.OutputPrice
+		out.OutputPricePerTokenPriority = *iv.OutputPrice
+	}
+	if iv.CacheWritePrice != nil {
+		out.CacheCreationPricePerToken = *iv.CacheWritePrice
+		out.CacheCreation5mPrice = *iv.CacheWritePrice
+		out.CacheCreation1hPrice = *iv.CacheWritePrice
+	}
+	if iv.CacheReadPrice != nil {
+		out.CacheReadPricePerToken = *iv.CacheReadPrice
+		out.CacheReadPricePerTokenPriority = *iv.CacheReadPrice
+	}
+	return &out
+}

--- a/scripts/gateway-tk-sentinels.json
+++ b/scripts/gateway-tk-sentinels.json
@@ -292,18 +292,18 @@
     },
     {
       "path": "backend/internal/service/model_pricing_resolver.go",
-      "must_contain": ["tkApplyChannelFlatOverridesAsFallback(chPricing, resolved)"],
-      "rationale": "TK channel-pricing fallback (upstream #2107): applyTokenOverrides MUST delegate the flat-default application to the TK companion regardless of whether intervals are configured. An upstream merge that restores the original early-return-on-intervals path silently re-introduces $0 billing for custom newapi-channel models on out-of-range token counts."
+      "must_contain": ["tkApplyChannelFlatOverridesAsFallback(chPricing, resolved)", "tkOverlayIntervalOntoBasePricing(resolved.BasePricing, iv, resolved.SupportsCacheBreakdown)"],
+      "rationale": "TK channel-pricing policy: applyTokenOverrides MUST delegate flat-default application to the TK companion regardless of whether intervals are configured (upstream #2107 — out-of-range fallback). GetIntervalPricing MUST delegate matched-interval pricing to the TK overlay helper instead of building a brand-new ModelPricing from interval fields only (upstream #2363 — in-range cache_read/cache_write/image_output preservation). Either revert silently re-introduces $0 or wrong-tier billing on the most cache-hit-heavy traffic that sticky-routing was designed to bank."
     },
     {
       "path": "backend/internal/service/model_pricing_resolver_tk_channel_flat_fallback.go",
-      "must_contain": ["func tkApplyChannelFlatOverridesAsFallback(chPricing *ChannelModelPricing, resolved *ResolvedPricing)", "resolved.BasePricing.InputPricePerToken = *chPricing.InputPrice", "resolved.BasePricing.OutputPricePerToken = *chPricing.OutputPrice", "resolved.BasePricing.CacheReadPricePerToken = *chPricing.CacheReadPrice", "resolved.BasePricing.CacheCreationPricePerToken = *chPricing.CacheWritePrice"],
-      "rationale": "TK companion holding the channel flat-fallback policy referenced from applyTokenOverrides (upstream #2107). Each flat field write is sentinel-pinned so a future change cannot drop one of the five pricing dimensions silently — operators rely on each (input/output/cache-read/cache-write/image-output) being honored as the out-of-range fallback."
+      "must_contain": ["func tkApplyChannelFlatOverridesAsFallback(chPricing *ChannelModelPricing, resolved *ResolvedPricing)", "resolved.BasePricing.InputPricePerToken = *chPricing.InputPrice", "resolved.BasePricing.OutputPricePerToken = *chPricing.OutputPrice", "resolved.BasePricing.CacheReadPricePerToken = *chPricing.CacheReadPrice", "resolved.BasePricing.CacheCreationPricePerToken = *chPricing.CacheWritePrice", "func tkOverlayIntervalOntoBasePricing(base *ModelPricing, iv *PricingInterval, supportsCacheBreakdown bool) *ModelPricing", "Wei-Shaw/sub2api#2363", "out.CacheReadPricePerToken = *iv.CacheReadPrice"],
+      "rationale": "TK companion holding the channel flat-fallback policy referenced from applyTokenOverrides (upstream #2107) AND the interval overlay helper used by GetIntervalPricing (upstream #2363). Each flat field write is sentinel-pinned so a future change cannot drop one of the five pricing dimensions silently — operators rely on each (input/output/cache-read/cache-write/image-output) being honored as the out-of-range fallback. The overlay helper signature, #2363 reference, and the cache_read interval-overlay line are pinned so the symmetric in-range path cannot regress to the original empty-ModelPricing construction."
     },
     {
       "path": "backend/internal/service/model_pricing_resolver_test.go",
-      "must_contain": ["TestGetIntervalPricing_ChannelIntervalsNoMatch_FlatDefaultsApplied", "TestGetIntervalPricing_ChannelIntervalsNoMatch_UnknownModelChargesFlatNotZero"],
-      "rationale": "Focused regressions for upstream #2107: out-of-range token counts must hit channel flat defaults for both LiteLLM-known and LiteLLM-unknown models. Dropping these tests lets the early-return-on-intervals bug return without unit-CI noticing."
+      "must_contain": ["TestGetIntervalPricing_ChannelIntervalsNoMatch_FlatDefaultsApplied", "TestGetIntervalPricing_ChannelIntervalsNoMatch_UnknownModelChargesFlatNotZero", "TestGetIntervalPricing_IntervalMatched_FlatCacheReadPreserved", "TestGetIntervalPricing_IntervalMatched_IntervalCacheReadOverridesFlat"],
+      "rationale": "Focused regressions for upstream #2107 (out-of-range path) and upstream #2363 (in-range path). The four tests jointly assert that channel flat defaults survive every interval lookup outcome (no intervals, no match, match overlapping interval, match disjoint from flat defaults) and that interval values take precedence in-range when both are set. Dropping any of these lets the symmetric pricing-dimension drop bugs return without unit-CI noticing."
     },
     {
       "path": "backend/internal/repository/account_repo.go",

--- a/scripts/upstream-issue-fact-checks.json
+++ b/scripts/upstream-issue-fact-checks.json
@@ -119,6 +119,51 @@
         "backend/internal/service/openai_images_responses.go:Wei-Shaw/sub2api#1311",
         "scripts/check-buffered-content-type-leak.py:def scan_file"
       ]
+    },
+    {
+      "upstream": "Wei-Shaw/sub2api#2486",
+      "severity": "high",
+      "summary": "Unknown gemini-* models (including gemini-pro-agent) fall back to gemini-3.1-pro pricing instead of returning nil (which caused calculateTokenCost to silently record ActualCost=0 with no quota deduction).",
+      "fixed_by": [
+        "backend/internal/service/billing_service.go",
+        "backend/internal/service/billing_service_test.go"
+      ],
+      "fixed_if_all_present": [
+        "backend/internal/service/billing_service.go:Wei-Shaw/sub2api#2486",
+        "backend/internal/service/billing_service.go:if strings.Contains(modelLower, \"gemini\")",
+        "backend/internal/service/billing_service_test.go:gemini-pro-agent falls back to 3.1-pro"
+      ]
+    },
+    {
+      "upstream": "Wei-Shaw/sub2api#2363",
+      "severity": "high",
+      "summary": "GetIntervalPricing overlays the matched interval onto BasePricing (which carries channel flat defaults via the #2107 fix), so channel CacheReadPrice/CacheWritePrice/ImageOutputPrice survive in-range matches instead of being silently dropped to 0. Symmetric in-range counterpart to the #2107 out-of-range fix.",
+      "fixed_by": [
+        "backend/internal/service/model_pricing_resolver.go",
+        "backend/internal/service/model_pricing_resolver_tk_channel_flat_fallback.go",
+        "backend/internal/service/model_pricing_resolver_test.go",
+        "scripts/gateway-tk-sentinels.json"
+      ],
+      "fixed_if_all_present": [
+        "backend/internal/service/model_pricing_resolver.go:tkOverlayIntervalOntoBasePricing(resolved.BasePricing, iv, resolved.SupportsCacheBreakdown)",
+        "backend/internal/service/model_pricing_resolver_tk_channel_flat_fallback.go:func tkOverlayIntervalOntoBasePricing",
+        "backend/internal/service/model_pricing_resolver_tk_channel_flat_fallback.go:Wei-Shaw/sub2api#2363",
+        "backend/internal/service/model_pricing_resolver_test.go:TestGetIntervalPricing_IntervalMatched_FlatCacheReadPreserved",
+        "backend/internal/service/model_pricing_resolver_test.go:TestGetIntervalPricing_IntervalMatched_IntervalCacheReadOverridesFlat"
+      ]
+    },
+    {
+      "upstream": "Wei-Shaw/sub2api#2332",
+      "severity": "high",
+      "summary": "extractSSEUsagePatch message_start branch now gates hasInputTokens/hasCacheCreationInput/hasCacheReadInput on actual parseSSEUsageInt success instead of setting them unconditionally; a partial or duplicate message_start frame no longer zeroes out accumulator dimensions whose source key was absent.",
+      "fixed_by": [
+        "backend/internal/service/gateway_service.go",
+        "backend/internal/service/gateway_streaming_test.go"
+      ],
+      "fixed_if_all_present": [
+        "backend/internal/service/gateway_service.go:Wei-Shaw/sub2api#2332 hardening",
+        "backend/internal/service/gateway_streaming_test.go:TestParseSSEUsage_StartPartialUsageDoesNotZeroAccumulator"
+      ]
     }
   ]
 }

--- a/scripts/upstream-issue-fixes.json
+++ b/scripts/upstream-issue-fixes.json
@@ -203,6 +203,35 @@
         "backend/internal/service/gateway_service_tk_haiku_context_management_test.go"
       ],
       "summary": "normalizeClaudeOAuthRequestBody now skips auto-injecting context_management for Haiku models, mirroring the existing Haiku exemption in the anthropic-beta header path; Anthropic /v1/messages would otherwise return HTTP 400 for claude-haiku-4-5-* when thinking.type is enabled."
+    },
+    {
+      "upstream": "Wei-Shaw/sub2api#2486",
+      "status": "fixed_in_tokenkey",
+      "fixed_by": [
+        "backend/internal/service/billing_service.go",
+        "backend/internal/service/billing_service_test.go"
+      ],
+      "summary": "Unknown gemini-* models (including gemini-pro-agent) fall back to gemini-3.1-pro pricing in getFallbackPricing so calculateTokenCost no longer silently records ActualCost=0 with no quota deduction. Direct revenue leak on TokenKey's Gemini platform path."
+    },
+    {
+      "upstream": "Wei-Shaw/sub2api#2363",
+      "status": "fixed_in_tokenkey",
+      "fixed_by": [
+        "backend/internal/service/model_pricing_resolver.go",
+        "backend/internal/service/model_pricing_resolver_tk_channel_flat_fallback.go",
+        "backend/internal/service/model_pricing_resolver_test.go",
+        "scripts/gateway-tk-sentinels.json"
+      ],
+      "summary": "GetIntervalPricing now overlays the matched interval onto BasePricing (which carries channel flat defaults via the #2107 fix), so channel CacheReadPrice/CacheWritePrice/ImageOutputPrice survive in-range matches instead of being silently dropped to 0. Symmetric in-range counterpart to the #2107 out-of-range fix; sticky-routing's cache-hit discount now actually applies."
+    },
+    {
+      "upstream": "Wei-Shaw/sub2api#2332",
+      "status": "fixed_in_tokenkey",
+      "fixed_by": [
+        "backend/internal/service/gateway_service.go",
+        "backend/internal/service/gateway_streaming_test.go"
+      ],
+      "summary": "extractSSEUsagePatch message_start branch now gates hasInputTokens/hasCacheCreationInput/hasCacheReadInput on actual parseSSEUsageInt success instead of setting them unconditionally; a partial or duplicate message_start frame no longer zeroes out accumulator dimensions whose source key was absent (the input_tokens=0 duplicate-billing shape upstream reported)."
     }
   ]
 }


### PR DESCRIPTION
## Summary

Three production-impacting upstream bugs, all on TokenKey's revenue or usage-accounting hot paths. Selected from the watchdog triage (`scripts/upstream-issue-triage.json`) ranked by impact on `api.tokenkey.dev`.

### 1. `Wei-Shaw/sub2api#2486` — `gemini-pro-agent` silently bills $0 (revenue leak)

`BillingService.getFallbackPricing` matched only `gemini-3.1-pro` literally. Any other `gemini-*` model (including the user-reported `gemini-pro-agent`, plus any new Google variant) returned `nil`. `calculateTokenCost` swallows the resulting `ErrModelPricingUnavailable`, logs it, and records `ActualCost=0` — the request lands in `usage_logs` with no cost, and every downstream `> 0` guard in `finalizePostUsageBilling` short-circuits, so balance, subscription, and rate-limit quota are all skipped. The model is consumed for free.

**Fix:** any `gemini-*` without an explicit entry now falls back to `gemini-3.1-pro` pricing (the conservative paid-tier baseline). Mirrors the existing Claude family-fallback pattern in the same function.

### 2. `Wei-Shaw/sub2api#2363` — channel cache-read pricing dropped on interval match

Symmetric in-range counterpart to the already-shipped `#2107` out-of-range fix. When an in-range interval matched, the legacy `intervalToModelPricing` built a brand-new empty `ModelPricing{}` populated only from interval fields, silently dropping the channel's flat `CacheReadPrice` / `CacheWritePrice` / `ImageOutputPrice` for any dimension the interval itself didn't set. The common operator pattern (tiered input/output by interval + one flat `cache_read` price) silently billed cache_read at $0.

**Fix:** `GetIntervalPricing` now overlays the matched interval onto `BasePricing` (which carries channel flat defaults via `tkApplyChannelFlatOverridesAsFallback`). New helper `tkOverlayIntervalOntoBasePricing` lives in the existing `_tk_channel_flat_fallback.go` companion — same theme as `#2107`, same file. Sticky-routing's cache-hit discount now actually applies in-range.

### 3. `Wei-Shaw/sub2api#2332` — SSE `message_start` patch hardening

`extractSSEUsagePatch`'s `message_start` branch set `hasInputTokens` / `hasCacheCreationInput` / `hasCacheReadInput=true` unconditionally, so a duplicate or partial `message_start` frame (e.g. only `output_tokens` present) would clobber the accumulator with 0 for any field whose source key was absent — the `input_tokens=0` duplicate-billing shape upstream reported.

**Fix:** gate the `hasX` flags on actual `parseSSEUsageInt` success, matching the existing `message_delta` pattern at the same call site.

## Test plan

- [x] `go test -tags=unit ./internal/service/` (passes — 83s)
- [x] `go test -tags=unit -run 'TestGetIntervalPricing|TestGetFallbackPricing|TestParseSSEUsage|TestResolve' ./internal/service/` (passes)
- [x] `go test -tags=unit ./internal/handler/ ./internal/repository/` (passes — no regressions)
- [x] `go build ./...` succeeds
- [x] `python3 scripts/check-gateway-tk-sentinels.py` → PASS (48/48 intact, including the new `tkOverlayIntervalOntoBasePricing` sentinel)
- [x] `python3 scripts/check-newapi-sentinels.py` → PASS (26/26 intact)
- [x] New focused regression tests:
  - `TestGetIntervalPricing_IntervalMatched_FlatCacheReadPreserved` — #2363 in-range cache_read/cache_write/image_output preservation
  - `TestGetIntervalPricing_IntervalMatched_IntervalCacheReadOverridesFlat` — precedence direction (interval wins in-range when both are set)
  - `TestParseSSEUsage_StartPartialUsageDoesNotZeroAccumulator` — #2332 partial message_start no longer zeroes accumulator
  - Extended `TestGetFallbackPricing_FamilyMatching` cases for `gemini-pro-agent`, `models/gemini-pro-agent`, `gemini-2.5-flash-unknown-variant`, `gemini-2.0-pro` — #2486

## PR Checklist (per CLAUDE.md)

- [x] No `[skip ci]` in commit body
- [x] No upstream-owned files deleted
- [x] No `pnpm-lock.yaml` / Ent schema / Wire changes (none touched)
- [x] No `dev-rules/` submodule pointer change
- [x] Sentinels updated in same commit as new TK helper (rule §5.y.1)
- [x] `upstream-issue-fixes.json` + `upstream-issue-fact-checks.json` updated so the watchdog reclassifies these three from open to fixed (and verifies the fix facts remain on future runs)
- [x] Reviewer: use **Squash and merge** (TK-originated PR, per rule §5.y)

## Production risk

All three changes are scoped to billing / usage-accounting fallback paths. Existing behavior for already-priced models (`gpt-5.4`, `claude-sonnet-4`, etc.) is unchanged; the changes only affect the previously-broken paths (unknown gemini, in-range interval + flat default, partial message_start). The SSE hardening is strictly additive — `parseSSEUsage` for the existing well-formed message_start payloads still produces the same patch.

---
_Generated by [Claude Code](https://claude.ai/code/session_01A2shdGSsxaxHoAnmED4U7k)_

<!-- no-web-impact: all changes are backend billing/usage-accounting internals with no frontend surface -->