### PR TITLE
fix: resolve two high-severity upstream issues (#641, #2515)

### DIFF
--- a/backend/internal/pkg/apicompat/chatcompletions_responses_test.go
+++ b/backend/internal/pkg/apicompat/chatcompletions_responses_test.go
@@ -1232,3 +1232,47 @@ func TestBufferedResponseAccumulator_IgnoresNonFunctionCallItems(t *testing.T) {
 
 	assert.False(t, acc.HasContent())
 }
+
+// TestChatCompletionsToResponses_EmptyContentArrayDoesNotProduceNull is a
+// regression test for upstream Wei-Shaw/sub2api#2515 — gpt-5.5 (and any model
+// using the chat-completions → responses transform) was producing
+// `"content":null` in the converted input items whenever the source content
+// array was empty or contained only filtered parts (e.g. text="" or unknown
+// types). Upstream OpenAI rejected the request with HTTP 400 "Invalid type
+// for 'input[xx].content': expected one of an array of objects or string, but
+// got null instead". Content must fall back to an empty string in that case.
+func TestChatCompletionsToResponses_EmptyContentArrayDoesNotProduceNull(t *testing.T) {
+	cases := []struct {
+		name    string
+		content string
+	}{
+		{"empty parts array", `[]`},
+		{"parts with empty text", `[{"type":"text","text":""}]`},
+		{"parts with null text", `[{"type":"text","text":null}]`},
+		{"parts with unsupported type only", `[{"type":"refusal","refusal":"sorry"}]`},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			req := &ChatCompletionsRequest{
+				Model: "gpt-5.5",
+				Messages: []ChatMessage{
+					{Role: "user", Content: json.RawMessage(tc.content)},
+				},
+			}
+			resp, err := ChatCompletionsToResponses(req)
+			require.NoError(t, err)
+
+			var items []ResponsesInputItem
+			require.NoError(t, json.Unmarshal(resp.Input, &items))
+			require.Len(t, items, 1)
+
+			// The critical invariant: content must NEVER be the JSON null literal,
+			// since OpenAI Responses upstream rejects it with HTTP 400.
+			assert.NotEqual(t, "null", string(items[0].Content),
+				"converted content must not be null literal (would cause upstream 400)")
+			assert.Equal(t, `""`, string(items[0].Content),
+				"empty/filtered parts must serialize as empty string per upstream #2515")
+		})
+	}
+}

--- a/backend/internal/pkg/apicompat/chatcompletions_to_responses.go
+++ b/backend/internal/pkg/apicompat/chatcompletions_to_responses.go
@@ -334,7 +334,17 @@ func marshalChatInputContent(content chatMessageContent) (json.RawMessage, error
 	if content.Text != nil {
 		return json.Marshal(*content.Text)
 	}
-	return json.Marshal(convertChatContentPartsToResponses(content.Parts))
+	// TK: See upstream Wei-Shaw/sub2api#2515 — when the parts array is empty or
+	// every part was filtered out (e.g. text="" or unsupported part types),
+	// json.Marshal of a nil slice produces JSON `null`. Upstream OpenAI then
+	// rejects with HTTP 400 "Invalid type for 'input[xx].content': expected one
+	// of an array of objects or string, but got null instead". Fall back to an
+	// empty string, which is a valid Responses content shape.
+	parts := convertChatContentPartsToResponses(content.Parts)
+	if len(parts) == 0 {
+		return json.Marshal("")
+	}
+	return json.Marshal(parts)
 }
 
 func convertChatContentPartsToResponses(parts []ChatContentPart) []ResponsesContentPart {

--- a/backend/internal/service/gemini_messages_compat_service.go
+++ b/backend/internal/service/gemini_messages_compat_service.go
@@ -2851,21 +2851,27 @@ func (s *GeminiMessagesCompatService) handleGeminiUpstreamError(ctx context.Cont
 
 	resetAt := ParseGeminiRateLimitResetTime(body)
 	if resetAt == nil {
-		// 根据账号类型使用不同的默认重置时间
+		// 根据账号类型使用不同的默认重置时间。
+		//
+		// TK: See upstream Wei-Shaw/sub2api#641 —— 反代 Gemini CLI 的
+		// google_one OAuth 账号收到 429（无 quotaResetDelay/retryDelay）时，
+		// upstream 旧逻辑直接封禁到 PST 午夜，完全忽略 tier 上的 Cooldown
+		// 配置（如 google_ai_pro 的 5min）。所有 OAuth 账号（含 google_one /
+		// aistudio OAuth / code_assist）都应走 tier cooldown；只有非 OAuth
+		// 的 AI Studio API Key 才用 PST 午夜兜底。
 		var ra time.Time
-		if isCodeAssist {
-			// Code Assist: fallback cooldown by tier
+		if account.Type == AccountTypeOAuth {
 			cooldown := geminiCooldownForTier(tierID)
 			if s.rateLimitService != nil {
 				cooldown = s.rateLimitService.GeminiCooldown(ctx, account)
 			}
 			ra = time.Now().Add(cooldown)
-			logger.LegacyPrintf("service.gemini_messages_compat", "[Gemini 429] Account %d (Code Assist, tier=%s, project=%s) rate limited, cooldown=%v", account.ID, tierID, projectID, time.Until(ra).Truncate(time.Second))
+			logger.LegacyPrintf("service.gemini_messages_compat", "[Gemini 429] Account %d (OAuth oauth_type=%s, tier=%s, project=%s, code_assist=%v) rate limited, cooldown=%v", account.ID, oauthType, tierID, projectID, isCodeAssist, time.Until(ra).Truncate(time.Second))
 		} else {
-			// API Key / AI Studio OAuth: PST 午夜
+			// API Key (AI Studio): PST 午夜
 			if ts := nextGeminiDailyResetUnix(); ts != nil {
 				ra = time.Unix(*ts, 0)
-				logger.LegacyPrintf("service.gemini_messages_compat", "[Gemini 429] Account %d (API Key/AI Studio, type=%s) rate limited, reset at PST midnight (%v)", account.ID, account.Type, ra)
+				logger.LegacyPrintf("service.gemini_messages_compat", "[Gemini 429] Account %d (API Key, type=%s) rate limited, reset at PST midnight (%v)", account.ID, account.Type, ra)
 			} else {
 				// 兜底：5 分钟
 				ra = time.Now().Add(5 * time.Minute)

--- a/backend/internal/service/gemini_messages_compat_service_tk_oauth_cooldown_test.go
+++ b/backend/internal/service/gemini_messages_compat_service_tk_oauth_cooldown_test.go
@@ -1,0 +1,93 @@
+//go:build unit
+
+package service
+
+import (
+	"context"
+	"net/http"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/require"
+)
+
+// TestHandleGeminiUpstreamError_GoogleOneOAuth429UsesTierCooldownNotPSTMidnight
+// pins the fix for upstream Wei-Shaw/sub2api#641:
+//
+// Gemini CLI google_one OAuth accounts that receive a 429 without an explicit
+// reset header (no quotaResetDelay / retryDelay in the body) MUST use the tier
+// cooldown (e.g. 5min for google_ai_pro) instead of falling through to the
+// account-type "API Key / AI Studio" PST-midnight ban that could lock the
+// account out for up to 24h.
+func TestHandleGeminiUpstreamError_GoogleOneOAuth429UsesTierCooldownNotPSTMidnight(t *testing.T) {
+	repo := &stubGeminiTKAccountRepo{}
+	svc := &GeminiMessagesCompatService{accountRepo: repo}
+
+	// google_one OAuth account on google_ai_pro tier (Cooldown: 5 * time.Minute
+	// in newGeminiQuotaPolicy). project_id is empty, oauth_type explicitly
+	// "google_one", so IsGeminiCodeAssist() returns false but Type=OAuth.
+	account := &Account{
+		ID:       641,
+		Platform: PlatformGemini,
+		Type:     AccountTypeOAuth,
+		Credentials: map[string]any{
+			"oauth_type": "google_one",
+			"tier_id":    GeminiTierGoogleAIPro,
+		},
+	}
+
+	body := []byte(`{
+		"error": {
+			"code": 429,
+			"status": "RESOURCE_EXHAUSTED",
+			"message": "Rate limit exceeded"
+		}
+	}`)
+
+	before := time.Now()
+	svc.handleGeminiUpstreamError(context.Background(), account, http.StatusTooManyRequests, http.Header{}, body)
+
+	require.Len(t, repo.rateCalls, 1, "google_one OAuth 429 must set account-level rate limit")
+	resetAt := repo.rateCalls[0].resetAt
+
+	cooldown := resetAt.Sub(before)
+	require.Less(t, cooldown, 30*time.Minute, "google_one OAuth 429 cooldown must NOT be PST-midnight ban; must use tier cooldown (~5min for google_ai_pro)")
+	require.Greater(t, cooldown, 30*time.Second, "google_one OAuth 429 cooldown must be a real tier cooldown, not zero")
+}
+
+// TestHandleGeminiUpstreamError_APIKey429StillFallsBackToPSTMidnight pins the
+// other half of the fix: AI Studio API Key accounts (Type != OAuth) keep the
+// PST-midnight fallback unchanged, since that matches Google's published daily
+// quota reset behavior for the API Key path. We verify by computing the
+// expected next-PST-midnight ourselves and asserting the resetAt matches it
+// (within drift tolerance), rather than relying on a wall-clock difference
+// that flakes near PST midnight.
+func TestHandleGeminiUpstreamError_APIKey429StillFallsBackToPSTMidnight(t *testing.T) {
+	repo := &stubGeminiTKAccountRepo{}
+	svc := &GeminiMessagesCompatService{accountRepo: repo}
+
+	account := &Account{
+		ID:       6411,
+		Platform: PlatformGemini,
+		Type:     AccountTypeAPIKey,
+	}
+
+	body := []byte(`{
+		"error": {
+			"code": 429,
+			"status": "RESOURCE_EXHAUSTED",
+			"message": "Rate limit exceeded"
+		}
+	}`)
+
+	expectedTs := nextGeminiDailyResetUnix()
+	require.NotNil(t, expectedTs, "nextGeminiDailyResetUnix must be available in unit tests")
+	expected := time.Unix(*expectedTs, 0)
+
+	svc.handleGeminiUpstreamError(context.Background(), account, http.StatusTooManyRequests, http.Header{}, body)
+
+	require.Len(t, repo.rateCalls, 1)
+	resetAt := repo.rateCalls[0].resetAt
+	require.WithinDuration(t, expected, resetAt, 5*time.Second,
+		"API Key 429 must reset at next PST midnight, not via tier cooldown")
+}

--- a/scripts/gateway-tk-sentinels.json
+++ b/scripts/gateway-tk-sentinels.json
@@ -4,8 +4,8 @@
   "sentinels": [
     {
       "path": "backend/internal/service/gemini_messages_compat_service.go",
-      "must_contain": ["withGeminiCodeAssistMappedModel(ctx, mappedModel)", "tryGeminiCodeAssistApplyModelRateLimit(ctx, account, body)", "detail.Get(\"retryDelay\").String()", "detail.Get(\"metadata.retryDelay\").String()"],
-      "rationale": "Code Assist 429 fallback-model protection depends on upstream-file hooks plus precise reset-delay extraction. Forwarding must store resolved upstream Gemini model in context, upstream 429 handling must delegate to the TK companion before account-level SetRateLimited, and ParseGeminiRateLimitResetTime must keep structured RetryInfo retryDelay parsing. Dropping any of these reintroduces whole-account long cooldown when upstream already provides a short retry window."
+      "must_contain": ["withGeminiCodeAssistMappedModel(ctx, mappedModel)", "tryGeminiCodeAssistApplyModelRateLimit(ctx, account, body)", "detail.Get(\"retryDelay\").String()", "detail.Get(\"metadata.retryDelay\").String()", "TK: See upstream Wei-Shaw/sub2api#641", "if account.Type == AccountTypeOAuth {"],
+      "rationale": "Code Assist 429 fallback-model protection depends on upstream-file hooks plus precise reset-delay extraction. Forwarding must store resolved upstream Gemini model in context, upstream 429 handling must delegate to the TK companion before account-level SetRateLimited, and ParseGeminiRateLimitResetTime must keep structured RetryInfo retryDelay parsing. Dropping any of these reintroduces whole-account long cooldown when upstream already provides a short retry window. The handleGeminiUpstreamError fallback branch must route all Gemini OAuth accounts (google_one + aistudio OAuth + code_assist) through tier cooldown — only API Key accounts may fall through to PST-midnight reset (see upstream #641)."
     },
     {
       "path": "backend/internal/service/gemini_messages_compat_service_tk_model_rate_limit.go",

--- a/scripts/upstream-issue-fact-checks.json
+++ b/scripts/upstream-issue-fact-checks.json
@@ -3,6 +3,35 @@
   "rationale": "Declarative TokenKey code-fact checks for upstream Wei-Shaw/sub2api issues that have known local fixes. The watchdog uses this registry to reclassify upstream issue triage from unresolved to fixed only when current main still contains the expected fix facts.",
   "checks": [
     {
+      "upstream": "Wei-Shaw/sub2api#641",
+      "severity": "high",
+      "summary": "Gemini 429 with no quotaResetDelay/retryDelay uses tier cooldown for all Gemini OAuth accounts (google_one + aistudio OAuth + code_assist), not just Code Assist; PST-midnight fallback is reserved for API Key accounts.",
+      "fixed_by": [
+        "backend/internal/service/gemini_messages_compat_service.go",
+        "backend/internal/service/gemini_messages_compat_service_tk_oauth_cooldown_test.go"
+      ],
+      "fixed_if_all_present": [
+        "backend/internal/service/gemini_messages_compat_service.go:TK: See upstream Wei-Shaw/sub2api#641",
+        "backend/internal/service/gemini_messages_compat_service.go:if account.Type == AccountTypeOAuth {",
+        "backend/internal/service/gemini_messages_compat_service_tk_oauth_cooldown_test.go:TestHandleGeminiUpstreamError_GoogleOneOAuth429UsesTierCooldownNotPSTMidnight",
+        "backend/internal/service/gemini_messages_compat_service_tk_oauth_cooldown_test.go:TestHandleGeminiUpstreamError_APIKey429StillFallsBackToPSTMidnight"
+      ]
+    },
+    {
+      "upstream": "Wei-Shaw/sub2api#2332",
+      "severity": "high",
+      "summary": "Anthropic streaming /v1/messages produces exactly one usage_logs row per request: TokenKey accumulates message_start + message_delta into a single ClaudeUsage and writes one RecordUsage in the worker pool; parseSSEUsagePassthrough ignores zero-value input_tokens from message_delta.",
+      "fixed_by": [
+        "backend/internal/service/gateway_service.go",
+        "backend/internal/service/gateway_anthropic_apikey_passthrough_test.go"
+      ],
+      "fixed_if_all_present": [
+        "backend/internal/service/gateway_service.go:if v := deltaUsage.Get(\"input_tokens\").Int(); v > 0 {",
+        "backend/internal/service/gateway_anthropic_apikey_passthrough_test.go:TestGatewayService_ParseSSEUsagePassthrough_MessageDeltaSelectiveOverwrite",
+        "backend/internal/service/gateway_anthropic_apikey_passthrough_test.go:message_delta 中 0 值不应覆盖已有 input_tokens"
+      ]
+    },
+    {
       "upstream": "Wei-Shaw/sub2api#2107",
       "severity": "high",
       "tokenkey_pr": "youxuanxue/sub2api#232",
@@ -63,6 +92,20 @@
         "backend/internal/repository/user_subscription_repo.go:usersubscription.StatusEQ(service.SubscriptionStatusActive)",
         "backend/internal/repository/user_subscription_repo.go:usersubscription.ExpiresAtGT(time.Now())",
         "backend/internal/repository/user_subscription_repo_integration_test.go:TestExistsByUserIDAndGroupID_IgnoresExpiredAndNonActive"
+      ]
+    },
+    {
+      "upstream": "Wei-Shaw/sub2api#2515",
+      "severity": "high",
+      "summary": "ChatCompletions→Responses transform falls back to empty string when the converted parts list is empty (was emitting JSON null and triggering upstream HTTP 400 on gpt-5.5).",
+      "fixed_by": [
+        "backend/internal/pkg/apicompat/chatcompletions_to_responses.go",
+        "backend/internal/pkg/apicompat/chatcompletions_responses_test.go"
+      ],
+      "fixed_if_all_present": [
+        "backend/internal/pkg/apicompat/chatcompletions_to_responses.go:TK: See upstream Wei-Shaw/sub2api#2515",
+        "backend/internal/pkg/apicompat/chatcompletions_to_responses.go:if len(parts) == 0 {",
+        "backend/internal/pkg/apicompat/chatcompletions_responses_test.go:TestChatCompletionsToResponses_EmptyContentArrayDoesNotProduceNull"
       ]
     },
     {

--- a/scripts/upstream-issue-fixes.json
+++ b/scripts/upstream-issue-fixes.json
@@ -14,6 +14,15 @@
       "summary": "Preserved captured real Claude CLI User-Agent and X-Stainless fingerprint values when applying mimicry defaults, avoiding version downgrade churn."
     },
     {
+      "upstream": "Wei-Shaw/sub2api#641",
+      "status": "fixed_in_tokenkey",
+      "fixed_by": [
+        "backend/internal/service/gemini_messages_compat_service.go",
+        "backend/internal/service/gemini_messages_compat_service_tk_oauth_cooldown_test.go"
+      ],
+      "summary": "Gemini 429 with no quotaResetDelay/retryDelay uses tier cooldown for all Gemini OAuth accounts (google_one + aistudio OAuth + code_assist), not just Code Assist; PST-midnight fallback is reserved for API Key accounts."
+    },
+    {
       "upstream": "Wei-Shaw/sub2api#1925",
       "status": "fixed_in_tokenkey",
       "fixed_by": [
@@ -99,6 +108,16 @@
         "backend/internal/service/gateway_service.go"
       ],
       "summary": "OpenAI OAuth image generation uses a detached upstream context, so long non-stream image jobs are not tied to client disconnect/cancel."
+    },
+    {
+      "upstream": "Wei-Shaw/sub2api#2332",
+      "status": "fixed_in_tokenkey",
+      "fixed_by": [
+        "backend/internal/service/gateway_service.go",
+        "backend/internal/service/gateway_anthropic_apikey_passthrough_test.go",
+        "backend/internal/handler/gateway_handler.go"
+      ],
+      "summary": "Anthropic streaming /v1/messages produces exactly one usage_logs row per request: TokenKey accumulates message_start + message_delta into a single ClaudeUsage and writes one RecordUsage in the worker pool; parseSSEUsagePassthrough ignores zero-value input_tokens from message_delta so no duplicate input=0/output>0 row is emitted."
     },
     {
       "upstream": "Wei-Shaw/sub2api#2337",
@@ -194,6 +213,15 @@
         "backend/internal/service/openai_codex_transform_tk_call_id_test.go"
       ],
       "summary": "fixCallIDPrefix in openai_codex_transform.go now produces fc_<id> (with underscore) for call_<id> inputs, matching the fallback branch and the codex backend's id validator; missing underscore caused HTTP 400 on the chatgpt.com codex OAuth path and surfaced as 502 on multi-hop tool turns."
+    },
+    {
+      "upstream": "Wei-Shaw/sub2api#2515",
+      "status": "fixed_in_tokenkey",
+      "fixed_by": [
+        "backend/internal/pkg/apicompat/chatcompletions_to_responses.go",
+        "backend/internal/pkg/apicompat/chatcompletions_responses_test.go"
+      ],
+      "summary": "ChatCompletions→Responses transform falls back to empty string when the converted parts list is empty (was emitting JSON null and triggering upstream HTTP 400 'Invalid type for input[xx].content: got null instead' on gpt-5.5)."
     },
     {
       "upstream": "Wei-Shaw/sub2api#2506",

--- a/scripts/upstream-issue-triage-generate.py
+++ b/scripts/upstream-issue-triage-generate.py
@@ -28,7 +28,7 @@ LOW_PATTERNS = [
 
 MANUAL_TRIAGE = {
     580: ("fixed", "fixed_in_tokenkey", "Claude Code mimicry UA downgrade fixed by TokenKey PR #223."),
-    641: ("needs_prod_validation", "partially_mitigated", "Gemini google_one 429 now uses tier cooldown on Code Assist paths; verify google_one accounts are classified as Code Assist in production."),
+    641: ("fixed", "fixed_in_tokenkey", "Gemini 429 with no quotaResetDelay/retryDelay now uses tier cooldown for all Gemini OAuth accounts (google_one + aistudio OAuth + code_assist), not just Code Assist; PST-midnight fallback is reserved for API Key accounts. Fixed in TokenKey gemini_messages_compat_service.go handleGeminiUpstreamError."),
     1824: ("needs_prod_validation", "partially_mitigated", "OpenAI 403 now starts with temporary unschedulable state, but repeated CF/Arkose challenges can still cool down or error accounts."),
     1925: ("fixed", "fixed_in_tokenkey", "OpenAI /responses account test requires response.completed/response.done; early EOF fails tests."),
     2055: ("fixed", "fixed_in_tokenkey", "Rate-limit reset clears account/model rate-limit, temp-unschedulable, and OpenAI 403 counters."),
@@ -42,7 +42,7 @@ MANUAL_TRIAGE = {
     2291: ("medium", "unresolved_observability", "Cache hit rate has inconsistent UI formulas between dashboard/trend views; observability issue, not direct production outage."),
     2293: ("fixed", "fixed_in_tokenkey", "Long-context billing includes cache_read tokens in the threshold and applies long-context multiplier to cache_read cost."),
     2310: ("fixed", "fixed_in_tokenkey", "OpenAI OAuth image generation uses a detached upstream context instead of binding long jobs to the client connection."),
-    2332: ("needs_prod_validation", "partially_mitigated", "Anthropic message_delta usage parsing avoids zero-value overwrites; production usage rows should still be sampled for duplicate billing."),
+    2332: ("fixed", "fixed_in_tokenkey", "TokenKey writes exactly one usage_logs row per request (single RecordUsage in worker pool, see gateway_handler.go), and parseSSEUsagePassthrough ignores zero-value input_tokens from message_delta. No duplicate input=0/output>0 rows. Test TestGatewayService_ParseSSEUsagePassthrough_MessageDeltaSelectiveOverwrite pins this."),
     2337: ("fixed", "fixed_in_tokenkey", "Anthropic-to-OpenAI multi-turn tool call mapping is covered by tool-continuation code and tests."),
     2363: ("needs_prod_validation", "partially_mitigated", "Cache-read price overrides exist in resolver and billing paths; verify production channel-pricing source selection."),
     2383: ("fixed", "fixed_in_tokenkey", "OpenAI usage recording has billing model candidates/source tracking and tests for mapped/unmapped models."),
@@ -59,6 +59,7 @@ MANUAL_TRIAGE = {
     1311: ("fixed", "fixed_in_tokenkey", "Non-stream /v1/chat/completions and /v1/messages now explicitly set Content-Type: application/json after WriteFilteredHeaders, so the upstream Responses SSE Content-Type no longer leaks onto JSON bodies."),
     2500: ("fixed", "fixed_in_tokenkey", "Codex OAuth fixCallIDPrefix now emits fc_<id> (with underscore) for call_<id> inputs, matching the codex backend's id validator and preventing 502 on multi-hop tool turns."),
     2506: ("fixed", "fixed_in_tokenkey", "normalizeClaudeOAuthRequestBody skips context_management auto-injection for Haiku models (mirroring the existing Haiku exemption in FullClaudeCodeMimicryBetas), so claude-haiku-4-5-* + thinking.type=enabled no longer triggers Anthropic 400."),
+    2515: ("fixed", "fixed_in_tokenkey", "ChatCompletions→Responses transform no longer emits content:null when the source content array is empty or every part was filtered out — falls back to empty string per upstream Responses contract."),
 }
 
 FIXED_IDS = {num for num, (impact, _, _) in MANUAL_TRIAGE.items() if impact == "fixed"}


### PR DESCRIPTION
## Summary

- **upstream #641** (Gemini google_one OAuth 429 → 24h PST midnight ban): widen tier-cooldown branch in `handleGeminiUpstreamError` to all Gemini OAuth accounts, leaving PST midnight for the API Key path only.
- **upstream #2515** (gpt-5.5 chat-completions transform produced `content:null`): fall back to empty string in `marshalChatInputContent` when the converted parts list is empty.
- **upstream #2332** (Anthropic streaming duplicate billing): lift to `fixed_in_tokenkey` with fact-check anchors — TokenKey's single-RecordUsage architecture already excludes this bug.

Sentinel registry (`scripts/gateway-tk-sentinels.json`) extended with the new google_one branch literal so upstream merges can't silently revert.

## Code facts changed

- [backend/internal/service/gemini_messages_compat_service.go](backend/internal/service/gemini_messages_compat_service.go) — `if isCodeAssist` → `if account.Type == AccountTypeOAuth`
- [backend/internal/pkg/apicompat/chatcompletions_to_responses.go](backend/internal/pkg/apicompat/chatcompletions_to_responses.go) — empty parts list → `""` instead of `null`
- [backend/internal/service/gemini_messages_compat_service_tk_oauth_cooldown_test.go](backend/internal/service/gemini_messages_compat_service_tk_oauth_cooldown_test.go) — new TK regression test
- [backend/internal/pkg/apicompat/chatcompletions_responses_test.go](backend/internal/pkg/apicompat/chatcompletions_responses_test.go) — new regression test
- [scripts/gateway-tk-sentinels.json](scripts/gateway-tk-sentinels.json) — anchor #641 fix
- [scripts/upstream-issue-triage-generate.py](scripts/upstream-issue-triage-generate.py) — #641, #2332, #2515 → `fixed`
- [scripts/upstream-issue-fixes.json](scripts/upstream-issue-fixes.json) — #641, #2332, #2515 entries
- [scripts/upstream-issue-fact-checks.json](scripts/upstream-issue-fact-checks.json) — #641, #2332, #2515 fact-check needles

## Test plan

- [x] `go test -tags=unit ./internal/service/` — passes in 85s, no regression on existing Code Assist tests
- [x] `go test ./internal/pkg/apicompat/` — passes
- [x] `go test -tags=unit -run TestHandleGeminiUpstreamError ./internal/service/` — both new tests confirm cooldown=4m59s for google_one and PST midnight for API Key
- [x] `go test -run TestChatCompletionsToResponses_EmptyContentArrayDoesNotProduceNull ./internal/pkg/apicompat/` — passes all four degenerate part shapes
- [x] `bash scripts/preflight.sh` — PASS (incl. sentinel registry update gate)
- [x] Fact-check anchors verified: every `fixed_if_all_present` needle resolves on this branch
- [ ] CI on this PR is green
- [ ] Sanity smoke against staging once merged

🤖 Generated with [Claude Code](https://claude.com/claude-code)