### PR TITLE
feat(ops): add S2 account→group rpm alignment guard

### DIFF
--- a/.cursor/skills/tokenkey-edge-anthropic-oauth-config/SKILL.md
+++ b/.cursor/skills/tokenkey-edge-anthropic-oauth-config/SKILL.md
@@ -158,7 +158,21 @@ confirm_apply=yes-apply-edge-anthropic-oauth
 
 缺失或不匹配则拒绝执行。
 
-### 3.2 模板 SQL 是 apply 源头
+### 3.2 S2 alignment guard（强制 pre-apply 门禁）
+
+任何 `apply` 之前**必须**先跑：
+
+```bash
+python3 scripts/check-account-group-rpm-alignment.py --target <edge_id|prod>
+```
+
+- exit 0 — 通过，继续 apply
+- exit 1 — 检测到 `account.extra.base_rpm > group.rpm_limit` bottleneck，**必须先修复**（升 `group.rpm_limit` 或调账号 tier 降 `base_rpm`），再重跑此 check，再 apply
+- exit 2 — 目标/SSM/schema 故障，按错误信息排查，不要 apply
+
+理由：tier 落档把 `extra.base_rpm` 调高后，如果绑定 group 的 `rpm_limit` 比新 `base_rpm` 小，group 会成为隐性 bottleneck，账号配置实际半失效。H1 (2026-05-17) 在 edge uk1/fra1 上踩中过这个陷阱（`default.rpm_limit=3` 卡住 `base_rpm=6`）。此 guard 强制把这条规则从软约束硬化到可机器验证。
+
+### 3.3 模板 SQL 是 apply 源头
 
 更新配置时禁止临时手写 SQL 或直接拼一份新的字段清单。必须从仓库模板复制出本次执行 SQL，再只替换本次目标变量和经 `plan-apply` 确认的差异：
 
@@ -167,7 +181,7 @@ confirm_apply=yes-apply-edge-anthropic-oauth
 
 推荐落点：`$CLAUDE_JOB_DIR/<edge>-<target>-apply.sql`，不要改原模板来执行单次任务。复制后必须生成**自包含 SQL**：把模板正文复制进该文件，并在文件顶部写入本次 `\set account_name`、`\set stability_tier`、`\set group_name` 等变量；远端 edge 不保证存在仓库 checkout，所以禁止让 SSM/psql 执行依赖远端文件路径的 `\i deploy/aws/stage0/...`。复制后必须保留模板里的 profile、tier、聚合口径和事务结构；只允许改执行变量或经 `plan-apply` 确认过的字面值。若需求确实要求模板未覆盖的新字段，先更新模板和本 skill，再执行 apply，避免 checker、模板和人工 SQL 分叉。
 
-### 3.3 账号模式（target_scope=account）
+### 3.4 账号模式（target_scope=account）
 
 安全限制：
 - `apply` 仅允许单 edge + 单账号；
@@ -183,7 +197,7 @@ confirm_apply=yes-apply-edge-anthropic-oauth
 3. 如需改分组绑定，先完成 mixed-channel 预检，再在同一份自包含 SQL 中加入经确认的绑定变更；
 4. 通过 SSM 把该自包含 SQL 作为 heredoc 传给目标 edge 的 `tokenkey-postgres` 容器执行，不依赖远端目录。
 
-### 3.4 分组模式（target_scope=group）
+### 3.5 分组模式（target_scope=group）
 
 安全限制：
 - `apply` 仅允许单 edge + 单分组；

--- a/scripts/check-account-group-rpm-alignment.py
+++ b/scripts/check-account-group-rpm-alignment.py
@@ -1,0 +1,254 @@
+#!/usr/bin/env python3
+"""
+S2 guard: account → group RPM alignment.
+
+For every active anthropic OAuth account that declares
+`extra.base_rpm`, verify that every group it is bound to has
+`rpm_limit >= base_rpm`. A group with `rpm_limit=0` (or NULL) is
+treated as "unlimited" and always passes.
+
+Why this exists:
+A tier landed on an account (`extra.base_rpm=N`) is useless if its
+group caps RPM below N — the group becomes the bottleneck silently.
+H1 (2026-05-17) tripped exactly this: edge uk1/fra1 `default.rpm_limit=3`
+masked `base_rpm=6` from tier l1.
+
+Targets a single stack at a time:
+  --target prod       → tokenkey-prod-stage0 (us-east-1)
+  --target <edge_id>  → matches deploy/aws/stage0/edge-targets.json
+                       (uk1, us1, fra1, sg1, ...)
+
+Exit codes:
+  0  alignment OK (or no checkable pairs)
+  1  one or more violations
+  2  schema / SSM / target-resolution error
+
+Usage:
+  python3 scripts/check-account-group-rpm-alignment.py --target us1
+  python3 scripts/check-account-group-rpm-alignment.py --target prod --json
+"""
+from __future__ import annotations
+
+import argparse
+import json
+import pathlib
+import subprocess
+import sys
+
+REPO_ROOT = pathlib.Path(__file__).resolve().parents[1]
+EDGE_MATRIX = REPO_ROOT / "deploy/aws/stage0/edge-targets.json"
+
+PROD = {
+    "label": "prod",
+    "stack": "tokenkey-prod-stage0",
+    "region": "us-east-1",
+}
+
+QUERY = """
+SELECT COALESCE(jsonb_agg(jsonb_build_object(
+  'account_id',     a.id,
+  'account_name',   a.name,
+  'group_id',       g.id,
+  'group_name',     g.name,
+  'base_rpm',       NULLIF(a.extra->>'base_rpm','')::int,
+  'group_rpm_limit', g.rpm_limit
+) ORDER BY a.name, g.name), '[]'::jsonb)
+FROM accounts a
+JOIN account_groups ag ON ag.account_id = a.id
+JOIN groups g          ON g.id          = ag.group_id AND g.deleted_at IS NULL
+WHERE a.platform = 'anthropic'
+  AND a.type     = 'oauth'
+  AND a.deleted_at IS NULL
+  AND NULLIF(a.extra->>'base_rpm', '') IS NOT NULL;
+"""
+
+
+def fail(msg: str, code: int = 2) -> None:
+    print(f"::error::{msg}", file=sys.stderr)
+    sys.exit(code)
+
+
+def resolve_target(name: str) -> dict[str, str]:
+    if name == "prod":
+        return dict(PROD)
+    if not EDGE_MATRIX.exists():
+        fail(f"edge matrix not found: {EDGE_MATRIX}")
+    matrix = json.loads(EDGE_MATRIX.read_text())
+    targets = matrix.get("targets") or {}
+    if name not in targets:
+        known = ", ".join(["prod"] + sorted(targets))
+        fail(f"unknown target {name!r}; known: {known}")
+    tgt = targets[name]
+    for key in ("region", "stack"):
+        if key not in tgt:
+            fail(f"edge target {name} missing required field {key}")
+    return {"label": name, "stack": tgt["stack"], "region": tgt["region"]}
+
+
+def resolve_instance_id(region: str, stack: str) -> str:
+    try:
+        out = subprocess.check_output(
+            [
+                "aws",
+                "cloudformation",
+                "describe-stacks",
+                "--region",
+                region,
+                "--stack-name",
+                stack,
+                "--query",
+                "Stacks[0].Outputs[?OutputKey=='InstanceId'].OutputValue",
+                "--output",
+                "text",
+            ],
+            text=True,
+        ).strip()
+    except subprocess.CalledProcessError as e:
+        fail(f"describe-stacks failed for {stack}/{region}: {e}")
+        return ""  # unreachable
+    if not out:
+        fail(f"no InstanceId output on stack {stack}/{region}")
+    return out
+
+
+def run_remote(region: str, inst: str, sql: str, comment: str) -> tuple[str, str]:
+    remote = "sudo docker exec -i tokenkey-postgres psql -U tokenkey -d tokenkey -t -A -v ON_ERROR_STOP=1"
+    command = f"set -euo pipefail\n{remote} <<'SQL'\n{sql}\nSQL"
+    params = json.dumps({"commands": [command]}, ensure_ascii=False)
+    try:
+        cid = subprocess.check_output(
+            [
+                "aws",
+                "ssm",
+                "send-command",
+                "--region",
+                region,
+                "--instance-ids",
+                inst,
+                "--document-name",
+                "AWS-RunShellScript",
+                "--comment",
+                comment,
+                "--parameters",
+                params,
+                "--query",
+                "Command.CommandId",
+                "--output",
+                "text",
+            ],
+            text=True,
+        ).strip()
+    except subprocess.CalledProcessError as e:
+        fail(f"ssm send-command failed: {e}")
+        return "", ""  # unreachable
+    subprocess.run(
+        [
+            "aws",
+            "ssm",
+            "wait",
+            "command-executed",
+            "--region",
+            region,
+            "--command-id",
+            cid,
+            "--instance-id",
+            inst,
+        ],
+        check=False,
+    )
+    inv = json.loads(
+        subprocess.check_output(
+            [
+                "aws",
+                "ssm",
+                "get-command-invocation",
+                "--region",
+                region,
+                "--command-id",
+                cid,
+                "--instance-id",
+                inst,
+                "--output",
+                "json",
+            ],
+            text=True,
+        )
+    )
+    if inv.get("Status") != "Success" or inv.get("ResponseCode") != 0:
+        err = (inv.get("StandardErrorContent") or "").strip()[:600]
+        fail(f"ssm cmd {cid} status={inv.get('Status')} rc={inv.get('ResponseCode')}: {err}")
+    return (inv.get("StandardOutputContent") or "").strip(), cid
+
+
+def main() -> int:
+    ap = argparse.ArgumentParser(
+        description=__doc__.split("\n\n", 1)[0] if __doc__ else "",
+        formatter_class=argparse.RawDescriptionHelpFormatter,
+    )
+    ap.add_argument("--target", required=True, help="edge_id (e.g. us1) or 'prod'")
+    ap.add_argument("--instance-id", help="override SSM instance id (skips CFN describe-stacks)")
+    ap.add_argument("--json", action="store_true", help="emit JSON report only (no human summary)")
+    args = ap.parse_args()
+
+    tgt = resolve_target(args.target)
+    inst = args.instance_id or resolve_instance_id(tgt["region"], tgt["stack"])
+    out, cid = run_remote(
+        tgt["region"], inst, QUERY, f"S2 rpm alignment check {tgt['label']}"
+    )
+    try:
+        rows = json.loads(out) if out else []
+    except json.JSONDecodeError as e:
+        fail(f"failed to parse alignment payload: {e}\n{out[:600]}")
+        return 2
+
+    violations = []
+    for r in rows:
+        base = r.get("base_rpm")
+        gl = r.get("group_rpm_limit")
+        if base is None:
+            continue
+        if gl in (0, None):
+            continue
+        if gl < base:
+            violations.append(r)
+
+    report = {
+        "target": tgt["label"],
+        "region": tgt["region"],
+        "stack": tgt["stack"],
+        "instance_id": inst,
+        "ssm_command_id": cid,
+        "pairs_checked": len(rows),
+        "violation_count": len(violations),
+        "violations": violations,
+    }
+
+    if args.json:
+        print(json.dumps(report, indent=2, ensure_ascii=False))
+    else:
+        print(
+            f"target={tgt['label']} pairs_checked={len(rows)} "
+            f"violations={len(violations)} ssm_cmd={cid}"
+        )
+        if violations:
+            for v in violations:
+                print(
+                    f"  - account={v['account_name']} (base_rpm={v['base_rpm']}) "
+                    f"bound to group={v['group_name']} (rpm_limit={v['group_rpm_limit']}) "
+                    "← bottleneck"
+                )
+            print(
+                "fix: raise group.rpm_limit to >= base_rpm, "
+                "or lower account base_rpm via tier change."
+            )
+        else:
+            print(
+                "OK: every checked anthropic OAuth account.base_rpm "
+                "<= bound group.rpm_limit (or rpm_limit=0/unlimited)"
+            )
+
+    return 1 if violations else 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())


### PR DESCRIPTION
## Summary

Adds `scripts/check-account-group-rpm-alignment.py`, a single-purpose
guard that flags any anthropic OAuth account whose `extra.base_rpm`
exceeds the `rpm_limit` of any group it is bound to. Such a mismatch
silently caps the account's RPM at the group ceiling and wastes the
tier's RPM grant.

H1 (2026-05-17) tripped this exact rule: edge uk1/fra1 `default.rpm_limit=3`
capped `base_rpm=6` from tier l1. The accounts were retired in H3 so the
hazard is currently dormant — this PR encodes the rule before the next
tier/RPM change can re-introduce it.

## What's in this PR

- `scripts/check-account-group-rpm-alignment.py` — one-shot SSM-based
  check against a single stack (prod or edge). Exit 0 / 1 / 2.
- `.cursor/skills/tokenkey-edge-anthropic-oauth-config/SKILL.md` —
  inserts §3.2 declaring the guard as a mandatory pre-apply gate;
  subsequent sections renumbered (3.3 template, 3.4 account mode,
  3.5 group mode).

## Usage

```bash
python3 scripts/check-account-group-rpm-alignment.py --target us1
python3 scripts/check-account-group-rpm-alignment.py --target prod --json
```

| target | mode |
| --- | --- |
| `prod` | `tokenkey-prod-stage0` (us-east-1, hardcoded) |
| `<edge_id>` | matches `deploy/aws/stage0/edge-targets.json` |

## Test plan

- [x] preflight passes
- [x] dry-run on us1 (1 pair, base_rpm=8 vs rpm_limit=8 → exit 0)
- [x] dry-run on uk1 / fra1 (0 pairs after H3 retirement → exit 0)
- [x] dry-run on prod (0 pairs — no anthropic OAuth → exit 0)
- [x] `--json` output validated (machine-readable)
- [x] `--help` renders
- [x] unknown target → exit 2

## Follow-up

`feat(ops)` not `chore` because this introduces a new operational
contract (a gate). Once merged, future tier changes via the
`tokenkey-edge-anthropic-oauth-config` skill must pass this guard
before apply.

🤖 Generated with [Claude Code](https://claude.com/claude-code)