### PR TITLE
chore(ops): record H4 anthropic stub double-bind + skill rename

### DIFF
--- a/.cursor/skills/tokenkey-anthropic-oauth-config/SKILL.md
+++ b/.cursor/skills/tokenkey-anthropic-oauth-config/SKILL.md
@@ -1,15 +1,20 @@
 ---
-name: tokenkey-edge-anthropic-oauth-config
+name: tokenkey-anthropic-oauth-config
 description: >-
-  Query and update edge Anthropic OAuth account stability config using the
-  Stage0 SQL templates as apply source of truth, with default read-only check,
-  explicit apply confirmation, mixed-channel risk precheck, and post-change
-  verification.
+  Query and update Anthropic account/group config across the TokenKey
+  control plane (prod stage0) and the edge stage0 hosts: edge OAuth
+  stability tiers (Stage0 SQL templates), prod cc-*-oauth forward
+  stub bindings, and the cc-edges admin-only routing slot. Default
+  read-only check, explicit apply confirmation, mixed-channel risk
+  precheck, RPM-alignment guard, post-change verification.
 ---
 
-# TokenKey：Edge Anthropic OAuth 配置查询与更新（含账号与分组）
+# TokenKey：Anthropic 账号与分组配置（prod 控制面 + edge OAuth）
 
-适用于本仓库（TokenKey fork of sub2api）。目标是把“查询漂移 → 计划变更 → 显式确认后更新 → 复核”固化为可复用流程。
+适用于本仓库（TokenKey fork of sub2api）。目标是把“查询漂移 → 计划变更 → 显式确认后更新 → 复核”固化为可复用流程，覆盖两条数据路径：
+
+- **edge stage0**：真正的 anthropic OAuth 账号（`platform=anthropic AND type=oauth`），承载 Anthropic 上游流量；tier baseline + TLS profile 在此落档。
+- **prod stage0**：转发 stub（`platform=anthropic AND type=apikey`，credentials 含 `base_url=api-<edge>.tokenkey.dev`），把客户端流量打到对应 edge。
 
 权威纪律以仓库根 `CLAUDE.md` 为准。
 
@@ -41,6 +46,24 @@ description: >-
 - 未声明 `target_scope` 时默认 `target_scope=account`
 - `target_scope=group` 时，`check`/`plan-apply` 可用分组名或分组 ID 定位目标；`apply` 仅允许单 edge + 单分组
 - `edge_id=all` 默认只巡检 deployable edge；如需包含 planned，显式加 `allow_planned=true`
+
+## prod 控制面：anthropic stub 双绑规则
+
+prod 上每一个 anthropic 转发 stub（`platform=anthropic AND type=apikey`，credentials 包含 `base_url=api-<edge>.tokenkey.dev`）必须**同时绑两个分组**：
+
+| 分组 | id | 用途 | 谁可见 |
+| ---- | ---- | ---- | ---- |
+| `default` | 1 | 对外用户流量 | 普通用户 API key |
+| `cc-edges` | 15 | admin 调试旁路 | 仅 admin API key（不暴露给普通用户） |
+
+可见性强制点：**API key → 分组关联**。`cc-edges` 不应被任何普通用户 API key 关联；调试需要时，使用绑定到 `cc-edges` 的 admin API key。两个分组指向同一个 stub（同一个上游 edge），区别仅在调用方身份。
+
+操作流程：
+- **新增 anthropic edge stub**（例如再开一个 edge `xx1`）→ 创建 `cc-xx1-oauth` stub 后，第一时间在 prod 上 `INSERT account_groups` 双行（`default` + `cc-edges`）。两条 binding **不可拆开 apply**：要么一起加，要么一起退。
+- **退役 anthropic edge stub**（例如 H3 处理 uk1/fra1） → 软删 stub 前必须先 `DELETE account_groups` 两行；只删一行会留下幽灵 binding，导致下次审计时声音错乱。
+- **edge 数据库内部** → 真正的 OAuth 账号绑定 `default` 组即可，**不需要** edge 端复刻 `cc-edges`；admin 调试旁路只在 prod 控制面有意义（admin 直接命中 prod，再透传到 edge）。
+
+任何对 prod stub 的 binding 改动都属于 `target_scope=account` 的 `apply` 范畴，必须走本 skill §3 的 `confirm_apply` 流程。
 
 ## 一次性跑完（原则）
 

--- a/docs/ops/2026-05-17-h4-anthropic-double-bind.md
+++ b/docs/ops/2026-05-17-h4-anthropic-double-bind.md
@@ -1,0 +1,139 @@
+# H4 Anthropic Pool Double-Bind — 2026-05-17
+
+Operational record of two coupled changes:
+
+1. **Data**: prod `cc-us1-oauth` (id=42) added back to `cc-edges`
+   (id=15) while keeping its `default` (id=1) binding from H3
+   (2026-05-17 earlier today). Net effect: the stub now sits in both
+   groups, default carries user traffic, cc-edges carries admin debug
+   traffic, both pointing at the same upstream edge.
+2. **Skill**: `tokenkey-edge-anthropic-oauth-config` renamed to
+   `tokenkey-anthropic-oauth-config` and a new section was added
+   declaring the prod stub double-bind rule.
+
+## Why this shape
+
+H3 left `cc-edges` empty by moving the only stub (`cc-us1-oauth`) to
+`default`. That correctly redirected user traffic, but inspecting
+`api_keys` revealed `cc-edges` still hosted 3 admin debug keys
+(`edge-MAIN_GATEWAY_EDGE_SMOKE_API_KEY`, `cc-uk1-test`, `cc-fra1-tes`)
+that would have lost a schedulable account. A 4th key (`zw`, user_id=9,
+non-admin) was identified on `cc-edges` and migrated by hand to
+`GPT专线` (group_id=2) before this change, restoring the admin-only
+invariant.
+
+The fix is to **double-bind** the active stub: same upstream, two
+group entries, two different audiences. The API-key→group association
+in `api_keys.group_id` (single-valued) decides which audience the
+caller is in; `user_allowed_groups` controls which groups a user can
+even pick from when minting a key. Admin (`user_id=1`) keeps both
+`default` and `cc-edges` visibility; normal users only see `default`.
+
+This pattern generalizes to any future anthropic forward stub: ship it
+with both bindings from day one, so the admin debug path is never a
+separate provisioning afterthought.
+
+## Apply
+
+Single SSM transaction on `tokenkey-prod-stage0` (us-east-1):
+
+```sql
+BEGIN;
+INSERT INTO account_groups (account_id, group_id, priority, created_at)
+VALUES (42, 15, 1, NOW())
+ON CONFLICT (account_id, group_id) DO NOTHING;
+
+SELECT 'H4 verify' AS step, ag.account_id, a.name AS account_name,
+       g.id AS group_id, g.name AS group_name, ag.priority
+FROM account_groups ag
+JOIN accounts a ON a.id = ag.account_id AND a.deleted_at IS NULL
+JOIN groups   g ON g.id = ag.group_id  AND g.deleted_at IS NULL
+WHERE ag.account_id = 42
+ORDER BY g.id;
+
+SELECT 'cc-edges bindings count' AS step,
+       count(*) AS n FROM account_groups WHERE group_id = 15;
+COMMIT;
+```
+
+`ON CONFLICT (account_id, group_id) DO NOTHING` keeps the apply
+idempotent. The verify select inside the transaction confirms the
+two bindings; the count select confirms `cc-edges` is no longer empty.
+
+### SSM audit ID
+
+- prod apply: `b2145d60-ce8a-4f8e-8870-f40b39a1d814` (us-east-1)
+- `Status=Success`, `ResponseCode=0`
+- post-apply verify rows: `(42, cc-us1-oauth, 1, default, prio=1)` +
+  `(42, cc-us1-oauth, 15, cc-edges, prio=1)`
+- `cc-edges` bindings count = 1
+
+## Visibility model
+
+| concern | mechanism | enforced at |
+| ---- | ---- | ---- |
+| Which group does a request use? | `api_keys.group_id` (single value) | per API key |
+| Which groups can a user mint keys for? | `user_allowed_groups (user_id, group_id)` | per user |
+| Where does each group's anthropic request go upstream? | `account_groups (account_id, group_id)` | per (account, group) pair |
+
+`cc-edges` is admin-only **operationally**, not via a schema flag:
+admins (`user_id=1`) get a `user_allowed_groups` row pointing at
+`cc-edges`, normal users do not. Any future deviation (e.g. another
+non-admin user appearing on `cc-edges`) should be caught by audit
+queries, not by relying on the DB schema.
+
+## Pre-apply audit (cc-edges state before H4)
+
+```
+api_keys on group_id=15 (cc-edges):
+  id=77  user_id=1  edge-MAIN_GATEWAY_EDGE_SMOKE_API_KEY   (admin debug)
+  id=81  user_id=1  cc-uk1-test                            (admin debug)
+  id=83  user_id=1  cc-fra1-tes                            (admin debug)
+```
+
+(`zw`, id=85, user_id=9 was migrated to `GPT专线` (id=2) before this
+change; reverified to confirm.)
+
+## Skill change
+
+`.cursor/skills/tokenkey-edge-anthropic-oauth-config/` →
+`.cursor/skills/tokenkey-anthropic-oauth-config/`. The skill now
+covers both edge OAuth tier management (the original scope) and the
+prod control-plane stub binding rule.
+
+The new section "prod 控制面：anthropic stub 双绑规则" near the top of
+the skill states:
+
+- Every prod anthropic forward stub must bind both `default` (id=1)
+  and `cc-edges` (id=15) at create time.
+- Bindings are added/removed in pairs — single-binding states are
+  considered drift.
+- Edge databases do **not** mirror `cc-edges`; admin debug is a prod
+  control-plane concept.
+
+## Rollback
+
+Drop the `cc-edges` binding only (H3 end state):
+
+```sql
+BEGIN;
+DELETE FROM account_groups WHERE account_id = 42 AND group_id = 15;
+COMMIT;
+```
+
+The skill rename is reversible with `git mv` in the opposite
+direction, but doing so would invalidate any in-flight slash-command
+references using the new name.
+
+## Follow-ups
+
+- The `cc-uk1-test` and `cc-fra1-tes` admin debug keys still exist
+  even though their target edges were retired in H3. If admins still
+  need them as historical-test artifacts, no action; otherwise they
+  should be deleted in a future cleanup PR.
+- Confirm `user_allowed_groups` actually has rows for `user_id=1` on
+  `cc-edges` (id=15). The pre-apply query returned no rows for that
+  group — if the table is genuinely empty for cc-edges, the admin
+  visibility today depends entirely on whoever provisioned the keys
+  having had elevated rights at provisioning time, not on a persisted
+  ACL. Worth one targeted hardening PR.


### PR DESCRIPTION
## Summary

Two coupled changes recorded on 2026-05-17 (after H3 earlier same day):

1. **Data** — prod `cc-us1-oauth` (id=42) added back to `cc-edges`
   (id=15) while keeping its `default` (id=1) binding from H3.
   The stub now sits in both groups: `default` carries user traffic,
   `cc-edges` carries admin debug traffic, both pointing to the same
   upstream edge us1.
2. **Skill** — `.cursor/skills/tokenkey-edge-anthropic-oauth-config/`
   renamed to `tokenkey-anthropic-oauth-config/`. Scope broadened
   from edge-only to **edge OAuth + prod control-plane stub binding**.
   New section "prod 控制面：anthropic stub 双绑规则" near the top
   declares the rule that every prod anthropic forward stub must bind
   both `default` and `cc-edges` from day one, with admin visibility
   enforced via the `api_keys` → `user_allowed_groups` association layer.

## What's in this PR

- `.cursor/skills/{tokenkey-edge-anthropic-oauth-config → tokenkey-anthropic-oauth-config}/SKILL.md`
  (rename + frontmatter + title + new "prod 控制面" section)
- `docs/ops/2026-05-17-h4-anthropic-double-bind.md` (decision rationale,
  SQL inline, SSM audit id, pre-apply audit, visibility model, follow-ups)

## Pre-apply audit

Confirmed `cc-edges` (id=15) hosted only admin debug keys before H4:
- id=77 user_id=1 `edge-MAIN_GATEWAY_EDGE_SMOKE_API_KEY`
- id=81 user_id=1 `cc-uk1-test`
- id=83 user_id=1 `cc-fra1-tes`

The non-admin `zw` key (id=85, user_id=9) was migrated to `GPT专线`
(group_id=2) manually before H4 and reverified.

## Test plan

- [x] preflight passes
- [x] post-apply verify (in doc) shows 2 bindings for account_id=42
- [x] `cc-edges` bindings count = 1 confirmed
- [x] SQL is idempotent (`ON CONFLICT (account_id, group_id) DO NOTHING`)

## Follow-up noted in doc

- `user_allowed_groups` has no row for `cc-edges` (id=15) today; admin
  visibility depends on provisioner rights at key creation time, not a
  persisted ACL. Worth a targeted hardening PR.
- `cc-uk1-test` / `cc-fra1-tes` debug keys still exist after their
  target edges retired in H3 — possible cleanup PR.

## SSM audit

- prod apply: `b2145d60-ce8a-4f8e-8870-f40b39a1d814` (us-east-1), Status=Success, RC=0

🤖 Generated with [Claude Code](https://claude.com/claude-code)