### PR TITLE
chore: add pre-push hook for web surface alignment

### DIFF
--- a/scripts/pre-push-web-surface.sh
+++ b/scripts/pre-push-web-surface.sh
@@ -1,0 +1,36 @@
+#!/usr/bin/env bash
+#
+# scripts/pre-push-web-surface.sh — lightweight pre-push gate
+#
+# Runs ONLY the web surface alignment check before push, independent of the
+# full preflight. This catches missing `no-web-impact` declarations before
+# CI, avoiding wasted CI cycles.
+#
+# Install:  ln -sf ../../scripts/pre-push-web-surface.sh .git/hooks/pre-push
+# Or:       bash dev-rules/templates/install-hooks.sh  (if updated to install pre-push)
+#
+# Why separate from pre-commit?
+# The pre-commit hook runs the full preflight which may fail for unrelated
+# reasons (branch naming, env vars, etc.), causing developers to --no-verify
+# and bypass ALL checks including this one. A focused pre-push hook survives
+# that bypass because pre-push is a separate hook.
+
+set -euo pipefail
+
+REPO_ROOT="$(git rev-parse --show-toplevel)"
+cd "$REPO_ROOT"
+
+PYTHON_BIN="${PYTHON_BIN:-$(command -v python3 2>/dev/null || command -v python 2>/dev/null || echo python3)}"
+CHECK_SCRIPT="dev-rules/scripts/check_web_surface_alignment.py"
+
+if [ ! -f "$CHECK_SCRIPT" ]; then
+    exit 0
+fi
+
+if ! "$PYTHON_BIN" "$CHECK_SCRIPT" --base "${PREFLIGHT_BASE:-origin/main}" 2>&1; then
+    echo ""
+    echo "pre-push: web surface alignment check failed."
+    echo "If this is a backend-only change, add 'no-web-impact' to a commit message."
+    echo "Bypass with: git push --no-verify (discouraged)"
+    exit 1
+fi


### PR DESCRIPTION
## Summary

- Adds `scripts/pre-push-web-surface.sh` — a lightweight pre-push hook that runs ONLY the web surface alignment check, independent of the full preflight
- When pre-commit is bypassed (`--no-verify`) due to unrelated failures (branch naming, env vars), this hook still catches missing `no-web-impact` declarations before push

**Problem:** PR #252 burned 3 extra CI runs because the pre-commit hook was bypassed for unrelated reasons, and the missing `no-web-impact` declaration wasn't caught until CI.

**Solution:** A separate `pre-push` hook that runs only the focused web surface check. It's resilient to pre-commit bypass because `git push --no-verify` is a separate flag from `git commit --no-verify`.

## Install

```bash
ln -sf ../../scripts/pre-push-web-surface.sh .git/hooks/pre-push
```

## Test plan

- [x] `bash scripts/pre-push-web-surface.sh` runs successfully on this branch (has `no-web-impact` in commit)
- [x] Script correctly exits 0 when `dev-rules/scripts/check_web_surface_alignment.py` is absent
- [x] Script correctly fails when backend changes lack `no-web-impact`

no-web-impact: developer tooling script only, no frontend surface.

🤖 Generated with [Claude Code](https://claude.ai/claude-code)