### PR TITLE
feat(ops): extend S2 alignment guard with sum-cap (Layer B) check

### DIFF
--- a/.cursor/skills/tokenkey-anthropic-oauth-config/SKILL.md
+++ b/.cursor/skills/tokenkey-anthropic-oauth-config/SKILL.md
@@ -224,11 +224,25 @@ confirm_apply=yes-apply-edge-anthropic-oauth
 python3 scripts/check-account-group-rpm-alignment.py --target <edge_id|prod>
 ```
 
-- exit 0 — 通过，继续 apply
-- exit 1 — 检测到 `account.extra.base_rpm > group.rpm_limit` bottleneck，**必须先修复**（升 `group.rpm_limit` 或调账号 tier 降 `base_rpm`），再重跑此 check，再 apply
-- exit 2 — 目标/SSM/schema 故障，按错误信息排查，不要 apply
+对每个 anthropic group（`rpm_limit > 0`）同时校验两层规则：
 
-理由：tier 落档把 `extra.base_rpm` 调高后，如果绑定 group 的 `rpm_limit` 比新 `base_rpm` 小，group 会成为隐性 bottleneck，账号配置实际半失效。H1 (2026-05-17) 在 edge uk1/fra1 上踩中过这个陷阱（`default.rpm_limit=3` 卡住 `base_rpm=6`）。此 guard 强制把这条规则从软约束硬化到可机器验证。
+- **Layer A**（账号不被组卡）：`max(account.base_rpm) ≤ group.rpm_limit`
+  违反 = 组成为单账号的隐性 bottleneck。H1 (2026-05-17) 在 edge uk1/fra1 上踩中（`default.rpm_limit=3` 卡住 `base_rpm=6`）。
+- **Layer B**（组 cap 不超出组内产能总和）：`Σ(account.base_rpm) ≥ group.rpm_limit`
+  违反 = 组的 RPM 上限超过组内 OAuth 账号实际能合并撑起的速率，多出的 cap 是虚的（永远跑不到）。
+
+跳过条件（不计入 violation）：
+
+- `rpm_limit = 0` 或 NULL — 视为 unlimited，整组跳过。
+- `rpm_limit > 0` 但组内**无** anthropic OAuth 账号 / 无任何账号声明 `extra.base_rpm` — 视为 stub-only 组（如 prod `cc-edges`），本 guard 不适用；如需对 stub 容量护栏，见 §"prod stub 主路径镜像规则"。
+
+退出码：
+
+- exit 0 — 所有 in-scope 组通过两层
+- exit 1 — 至少一组违反 Layer A 或 Layer B，**必须先修复**再 apply：
+  - Layer A 修法：升 `group.rpm_limit` ≥ 该组 max base_rpm；或调低 offender 账号 tier
+  - Layer B 修法：降 `group.rpm_limit` ≤ 该组 sum base_rpm；或往组里加 OAuth 账号补容量
+- exit 2 — 目标/SSM/schema 故障，按错误排查
 
 ### 3.3 模板 SQL 是 apply 源头
 

--- a/scripts/check-account-group-rpm-alignment.py
+++ b/scripts/check-account-group-rpm-alignment.py
@@ -1,26 +1,37 @@
 #!/usr/bin/env python3
 """
-S2 guard: account → group RPM alignment.
+S2 guard: account.base_rpm ↔ group.rpm_limit alignment.
 
-For every active anthropic OAuth account that declares
-`extra.base_rpm`, verify that every group it is bound to has
-`rpm_limit >= base_rpm`. A group with `rpm_limit=0` (or NULL) is
-treated as "unlimited" and always passes.
+For every active anthropic group with `rpm_limit > 0`, verify the
+group's RPM cap sits within the band of its bound anthropic OAuth
+accounts' `extra.base_rpm` values:
 
-Why this exists:
-A tier landed on an account (`extra.base_rpm=N`) is useless if its
-group caps RPM below N — the group becomes the bottleneck silently.
-H1 (2026-05-17) tripped exactly this: edge uk1/fra1 `default.rpm_limit=3`
-masked `base_rpm=6` from tier l1.
+  layer A (per-account):  max(account.base_rpm) ≤ group.rpm_limit
+                          — otherwise the group caps a single account
+                            below its tier-declared RPM (silent
+                            bottleneck; this is the original S2 case
+                            from H1 uk1/fra1).
 
-Targets a single stack at a time:
+  layer B (group-aggregate): Σ(account.base_rpm) ≥ group.rpm_limit
+                          — otherwise the group's cap exceeds the
+                            combined RPM the bound OAuth accounts can
+                            actually sustain (the cap is virtual; the
+                            real ceiling is the accounts' sum).
+
+Groups with `rpm_limit = 0` (or NULL) are treated as "unlimited" and
+skipped entirely. Groups with `rpm_limit > 0` but **no** anthropic
+OAuth account bound (e.g. prod `cc-edges` which only holds stubs) are
+out of scope — the H4 stub-only design intentionally has no
+account.base_rpm to compare against. They are reported as `skipped`
+with a clear reason and do not count as violations.
+
+Targets one stack per invocation:
   --target prod       → tokenkey-prod-stage0 (us-east-1)
-  --target <edge_id>  → matches deploy/aws/stage0/edge-targets.json
-                       (uk1, us1, fra1, sg1, ...)
+  --target <edge_id>  → deploy/aws/stage0/edge-targets.json
 
 Exit codes:
-  0  alignment OK (or no checkable pairs)
-  1  one or more violations
+  0  all in-scope groups satisfy both layers
+  1  one or more violations (layer A or B)
   2  schema / SSM / target-resolution error
 
 Usage:
@@ -46,20 +57,26 @@ PROD = {
 
 QUERY = """
 SELECT COALESCE(jsonb_agg(jsonb_build_object(
-  'account_id',     a.id,
-  'account_name',   a.name,
-  'group_id',       g.id,
-  'group_name',     g.name,
-  'base_rpm',       NULLIF(a.extra->>'base_rpm','')::int,
-  'group_rpm_limit', g.rpm_limit
-) ORDER BY a.name, g.name), '[]'::jsonb)
-FROM accounts a
-JOIN account_groups ag ON ag.account_id = a.id
-JOIN groups g          ON g.id          = ag.group_id AND g.deleted_at IS NULL
-WHERE a.platform = 'anthropic'
-  AND a.type     = 'oauth'
-  AND a.deleted_at IS NULL
-  AND NULLIF(a.extra->>'base_rpm', '') IS NOT NULL;
+  'group_id',   g.id,
+  'group_name', g.name,
+  'rpm_limit',  g.rpm_limit,
+  'oauth_accounts', COALESCE((
+    SELECT jsonb_agg(jsonb_build_object(
+      'account_id', a.id,
+      'account_name', a.name,
+      'base_rpm', NULLIF(a.extra->>'base_rpm','')::int
+    ) ORDER BY a.id)
+    FROM account_groups ag
+    JOIN accounts a ON a.id = ag.account_id
+    WHERE ag.group_id = g.id
+      AND a.platform  = 'anthropic'
+      AND a.type      = 'oauth'
+      AND a.deleted_at IS NULL
+  ), '[]'::jsonb)
+) ORDER BY g.id), '[]'::jsonb)
+FROM groups g
+WHERE g.platform = 'anthropic'
+  AND g.deleted_at IS NULL;
 """
 
 
@@ -89,23 +106,15 @@ def resolve_instance_id(region: str, stack: str) -> str:
     try:
         out = subprocess.check_output(
             [
-                "aws",
-                "cloudformation",
-                "describe-stacks",
-                "--region",
-                region,
-                "--stack-name",
-                stack,
-                "--query",
-                "Stacks[0].Outputs[?OutputKey=='InstanceId'].OutputValue",
-                "--output",
-                "text",
+                "aws", "cloudformation", "describe-stacks",
+                "--region", region, "--stack-name", stack,
+                "--query", "Stacks[0].Outputs[?OutputKey=='InstanceId'].OutputValue",
+                "--output", "text",
             ],
             text=True,
         ).strip()
     except subprocess.CalledProcessError as e:
         fail(f"describe-stacks failed for {stack}/{region}: {e}")
-        return ""  # unreachable
     if not out:
         fail(f"no InstanceId output on stack {stack}/{region}")
     return out
@@ -118,58 +127,32 @@ def run_remote(region: str, inst: str, sql: str, comment: str) -> tuple[str, str
     try:
         cid = subprocess.check_output(
             [
-                "aws",
-                "ssm",
-                "send-command",
-                "--region",
-                region,
-                "--instance-ids",
-                inst,
-                "--document-name",
-                "AWS-RunShellScript",
-                "--comment",
-                comment,
-                "--parameters",
-                params,
-                "--query",
-                "Command.CommandId",
-                "--output",
-                "text",
+                "aws", "ssm", "send-command",
+                "--region", region,
+                "--instance-ids", inst,
+                "--document-name", "AWS-RunShellScript",
+                "--comment", comment,
+                "--parameters", params,
+                "--query", "Command.CommandId",
+                "--output", "text",
             ],
             text=True,
         ).strip()
     except subprocess.CalledProcessError as e:
         fail(f"ssm send-command failed: {e}")
-        return "", ""  # unreachable
     subprocess.run(
         [
-            "aws",
-            "ssm",
-            "wait",
-            "command-executed",
-            "--region",
-            region,
-            "--command-id",
-            cid,
-            "--instance-id",
-            inst,
+            "aws", "ssm", "wait", "command-executed",
+            "--region", region, "--command-id", cid, "--instance-id", inst,
         ],
         check=False,
     )
     inv = json.loads(
         subprocess.check_output(
             [
-                "aws",
-                "ssm",
-                "get-command-invocation",
-                "--region",
-                region,
-                "--command-id",
-                cid,
-                "--instance-id",
-                inst,
-                "--output",
-                "json",
+                "aws", "ssm", "get-command-invocation",
+                "--region", region, "--command-id", cid, "--instance-id", inst,
+                "--output", "json",
             ],
             text=True,
         )
@@ -186,8 +169,8 @@ def main() -> int:
         formatter_class=argparse.RawDescriptionHelpFormatter,
     )
     ap.add_argument("--target", required=True, help="edge_id (e.g. us1) or 'prod'")
-    ap.add_argument("--instance-id", help="override SSM instance id (skips CFN describe-stacks)")
-    ap.add_argument("--json", action="store_true", help="emit JSON report only (no human summary)")
+    ap.add_argument("--instance-id", help="override SSM instance id")
+    ap.add_argument("--json", action="store_true", help="emit JSON report only")
     args = ap.parse_args()
 
     tgt = resolve_target(args.target)
@@ -196,21 +179,70 @@ def main() -> int:
         tgt["region"], inst, QUERY, f"S2 rpm alignment check {tgt['label']}"
     )
     try:
-        rows = json.loads(out) if out else []
+        groups = json.loads(out) if out else []
     except json.JSONDecodeError as e:
         fail(f"failed to parse alignment payload: {e}\n{out[:600]}")
         return 2
 
-    violations = []
-    for r in rows:
-        base = r.get("base_rpm")
-        gl = r.get("group_rpm_limit")
-        if base is None:
+    results = []
+    violation_count = 0
+    for g in groups:
+        rpm_limit = g.get("rpm_limit") or 0
+        accounts = g.get("oauth_accounts") or []
+        base_rpms = [a["base_rpm"] for a in accounts if a.get("base_rpm") is not None]
+
+        rec = {
+            "group_id": g["group_id"],
+            "group_name": g["group_name"],
+            "rpm_limit": rpm_limit,
+            "oauth_account_count": len(accounts),
+            "base_rpm_count": len(base_rpms),
+            "max_base_rpm": max(base_rpms) if base_rpms else None,
+            "sum_base_rpm": sum(base_rpms) if base_rpms else 0,
+            "status": "ok",
+            "skip_reason": None,
+            "layer_a_violation": None,
+            "layer_b_violation": None,
+        }
+
+        if rpm_limit == 0:
+            rec["status"] = "skipped"
+            rec["skip_reason"] = "rpm_limit=0 (unlimited)"
+            results.append(rec)
             continue
-        if gl in (0, None):
+        if not base_rpms:
+            rec["status"] = "skipped"
+            rec["skip_reason"] = (
+                f"rpm_limit={rpm_limit} but no anthropic OAuth account "
+                "with extra.base_rpm bound (out of scope: stub-only group)"
+            )
+            results.append(rec)
             continue
-        if gl < base:
-            violations.append(r)
+
+        if rec["max_base_rpm"] > rpm_limit:
+            rec["layer_a_violation"] = {
+                "rule": "max(account.base_rpm) <= group.rpm_limit",
+                "max_base_rpm": rec["max_base_rpm"],
+                "rpm_limit": rpm_limit,
+                "offenders": [
+                    a for a in accounts
+                    if a.get("base_rpm") is not None and a["base_rpm"] > rpm_limit
+                ],
+            }
+            rec["status"] = "fail"
+
+        if rec["sum_base_rpm"] < rpm_limit:
+            rec["layer_b_violation"] = {
+                "rule": "sum(account.base_rpm) >= group.rpm_limit",
+                "sum_base_rpm": rec["sum_base_rpm"],
+                "rpm_limit": rpm_limit,
+            }
+            rec["status"] = "fail"
+
+        if rec["status"] == "fail":
+            violation_count += 1
+
+        results.append(rec)
 
     report = {
         "target": tgt["label"],
@@ -218,36 +250,61 @@ def main() -> int:
         "stack": tgt["stack"],
         "instance_id": inst,
         "ssm_command_id": cid,
-        "pairs_checked": len(rows),
-        "violation_count": len(violations),
-        "violations": violations,
+        "groups_checked": len(results),
+        "violation_count": violation_count,
+        "results": results,
     }
 
     if args.json:
         print(json.dumps(report, indent=2, ensure_ascii=False))
     else:
+        skipped = sum(1 for r in results if r["status"] == "skipped")
+        ok = sum(1 for r in results if r["status"] == "ok")
         print(
-            f"target={tgt['label']} pairs_checked={len(rows)} "
-            f"violations={len(violations)} ssm_cmd={cid}"
+            f"target={tgt['label']} groups_checked={len(results)} "
+            f"ok={ok} skipped={skipped} violations={violation_count} ssm_cmd={cid}"
         )
-        if violations:
-            for v in violations:
-                print(
-                    f"  - account={v['account_name']} (base_rpm={v['base_rpm']}) "
-                    f"bound to group={v['group_name']} (rpm_limit={v['group_rpm_limit']}) "
-                    "← bottleneck"
+        for r in results:
+            head = (
+                f"  [{r['status'].upper()}] group_id={r['group_id']} "
+                f"name={r['group_name']!r} rpm_limit={r['rpm_limit']} "
+                f"oauth_accounts={r['oauth_account_count']}"
+            )
+            print(head)
+            if r["status"] == "skipped":
+                print(f"      skip: {r['skip_reason']}")
+                continue
+            print(
+                f"      max(base_rpm)={r['max_base_rpm']} "
+                f"sum(base_rpm)={r['sum_base_rpm']}"
+            )
+            la = r["layer_a_violation"]
+            if la:
+                offenders = ", ".join(
+                    f"{a['account_name']}(base_rpm={a['base_rpm']})"
+                    for a in la["offenders"]
                 )
-            print(
-                "fix: raise group.rpm_limit to >= base_rpm, "
-                "or lower account base_rpm via tier change."
-            )
-        else:
-            print(
-                "OK: every checked anthropic OAuth account.base_rpm "
-                "<= bound group.rpm_limit (or rpm_limit=0/unlimited)"
-            )
+                print(
+                    f"      layer A FAIL ({la['rule']}): "
+                    f"max={la['max_base_rpm']} > rpm_limit={la['rpm_limit']} "
+                    f"offenders=[{offenders}]"
+                )
+                print(
+                    f"      fix: raise group.rpm_limit to ≥ {la['max_base_rpm']}, "
+                    "or lower offending account tier."
+                )
+            lb = r["layer_b_violation"]
+            if lb:
+                print(
+                    f"      layer B FAIL ({lb['rule']}): "
+                    f"sum={lb['sum_base_rpm']} < rpm_limit={lb['rpm_limit']}"
+                )
+                print(
+                    f"      fix: lower group.rpm_limit to ≤ {lb['sum_base_rpm']}, "
+                    "or add OAuth account capacity to the group."
+                )
 
-    return 1 if violations else 0
+    return 1 if violation_count > 0 else 0
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
## Summary

Extends `scripts/check-account-group-rpm-alignment.py` (the S2 guard
landed in #255) with a second check direction.

Before: single rule **Layer A**
  `max(account.base_rpm) ≤ group.rpm_limit`
  catches "group caps a single account below its tier RPM" — the H1
  uk1/fra1 case where `default.rpm_limit=3` silently masked `base_rpm=6`.

After: also runs **Layer B**
  `Σ(account.base_rpm) ≥ group.rpm_limit`
  catches "group cap exceeds combined account capacity" — i.e. the
  cap is virtual because the bound OAuth accounts can't sustain it.

## Scope semantics

Groups outside scope are explicitly skipped (don't count as violations):

- `rpm_limit = 0` or NULL → unlimited
- `rpm_limit > 0` but **no** anthropic OAuth account bound (e.g. prod
  `cc-edges` which only holds stubs) → out of scope. The H4 stub-only
  design intentionally has no `account.base_rpm` to compare against;
  stub capacity protection lives in §"prod stub 主路径镜像规则"
  (#261).

## Changes

- `scripts/check-account-group-rpm-alignment.py`: SQL rewritten as
  group-centric (one row per group with bound oauth accounts +
  base_rpm as sub-array). Python computes max + sum per group, runs
  both layers, prints per-group status with clear fix hint.
- `.cursor/skills/tokenkey-anthropic-oauth-config/SKILL.md` §3.2:
  rewritten to declare both layers explicitly and the stub-only
  carve-out.

## Test plan

- [x] preflight passes
- [x] dry-run on prod: 2 groups checked, both skipped
  - default (id=1) `rpm_limit=0` → unlimited skip
  - cc-edges (id=15) `rpm_limit=8` + 0 oauth accounts → stub-only skip
  - exit 0
- [x] dry-run on us1: 1 group checked, OK
  - default (id=1) `rpm_limit=8`, max=8 sum=8 → both layers pass
  - exit 0
- [x] dry-run on uk1 / fra1: 0 groups in scope (OAuth retired in H3) → exit 0

## Backwards compatibility

CLI surface unchanged (`--target` / `--json` / `--instance-id` still
accepted). Exit codes preserved (0/1/2). JSON output format restructured
from pair-centric `violations[]` to group-centric `results[]` — any
downstream JSON consumer would need to adapt, but none exists in tree.

🤖 Generated with [Claude Code](https://claude.com/claude-code)