### PR TITLE
chore: disable edge-uk1 and edge-fra1 (no available accounts)

### DIFF
--- a/deploy/aws/stage0/edge-targets.json
+++ b/deploy/aws/stage0/edge-targets.json
@@ -4,7 +4,7 @@
   "max_monthly_budget_usd": 16,
   "targets": {
     "uk1": {
-      "deployable": true,
+      "deployable": false,
       "profile": "edge-minimal",
       "region": "eu-west-2",
       "domain": "api-uk1.tokenkey.dev",
@@ -49,7 +49,7 @@
       "purpose": "sg-egress-planned"
     },
     "fra1": {
-      "deployable": true,
+      "deployable": false,
       "profile": "edge-minimal",
       "region": "eu-west-3",
       "domain": "api-fra1.tokenkey.dev",


### PR DESCRIPTION
## Summary

- Set `deployable=false` for `edge-uk1` and `edge-fra1` in `deploy/aws/stage0/edge-targets.json`
- Both targets currently have no available accounts, causing SSM diagnostics and smoke tests to fail

## Effect

| Surface | Before | After |
|---------|--------|-------|
| ops-daily-diagnostics | uk1/fra1 included → SSM fails → 3 issues opened (#238 #239 #240) | Excluded from matrix |
| deploy-edge-stage0 | uk1/fra1 selectable for smoke/upgrade | Not selectable |
| Release rollout skill | Attempts smoke on uk1/fra1 | Skips them |

Closes #238 (root cause: edge-uk1 SSM unreachable — now excluded from diagnostics).

Re-enable by setting `deployable=true` when accounts are provisioned.

## Test plan

- [x] `python3 deploy/aws/stage0/resolve-edge-target.py --prod-ops-matrix --prod-region us-east-1 --prod-stack tokenkey-prod-stage0` excludes uk1/fra1

no-web-impact: deploy config only.

🤖 Generated with [Claude Code](https://claude.ai/claude-code)