### PR TITLE
chore(ops): add Stage0 pg_dump refresh workflow + SSM helper

### DIFF
--- a/.github/workflows/ops-stage0-pg-dump-refresh.yml
+++ b/.github/workflows/ops-stage0-pg-dump-refresh.yml
@@ -1,0 +1,158 @@
+name: Stage0 pg_dump Refresh
+
+# One-shot ops workflow that pushes the refreshed pg_dump cadence (every 2h,
+# ≤12 rolling files) into running Stage0 instances. The same systemd unit /
+# timer / script content already lives in
+# deploy/aws/cloudformation/stage0-single-ec2.yaml; this workflow brings the
+# LIVE instance in sync without rebuilding EC2 user-data (which would trigger
+# a prod restart). Future stack rebuild remains the source of truth.
+
+on:
+  workflow_dispatch:
+    inputs:
+      target:
+        description: "Target: prod, edge-us1, or all"
+        required: true
+        type: choice
+        options:
+          - prod
+          - edge-us1
+          - all
+
+permissions:
+  contents: read
+  id-token: write
+
+concurrency:
+  group: ops-stage0-pg-dump-refresh-${{ inputs.target }}
+  cancel-in-progress: false
+
+jobs:
+  prod:
+    if: inputs.target == 'prod' || inputs.target == 'all'
+    runs-on: ubuntu-latest
+    environment: prod
+    env:
+      OIDC_ROLE_ARN: ${{ vars.AWS_OIDC_ROLE_ARN }}
+      AWS_REGION: ${{ vars.AWS_REGION || 'us-east-1' }}
+      STACK_NAME: ${{ vars.PROD_STACK_NAME || 'tokenkey-prod-stage0' }}
+    steps:
+      - uses: actions/checkout@v6
+        with:
+          submodules: recursive
+      - name: Validate OIDC role
+        run: |
+          set -euo pipefail
+          if [ -z "${OIDC_ROLE_ARN:-}" ]; then
+            echo "::error::AWS_OIDC_ROLE_ARN repo variable not set"
+            exit 1
+          fi
+      - name: Configure AWS credentials via OIDC
+        uses: aws-actions/configure-aws-credentials@v4
+        with:
+          role-to-assume: ${{ env.OIDC_ROLE_ARN }}
+          aws-region: ${{ env.AWS_REGION }}
+      - name: Resolve prod instance id
+        id: instance
+        env:
+          STACK_NAME: ${{ env.STACK_NAME }}
+        run: |
+          set -euo pipefail
+          ID=$(aws cloudformation describe-stacks --stack-name "$STACK_NAME" \
+            --query 'Stacks[0].Outputs[?OutputKey==`InstanceId`].OutputValue' --output text)
+          if [ -z "$ID" ] || [ "$ID" = "None" ]; then
+            echo "::error::could not resolve InstanceId from stack $STACK_NAME"
+            exit 1
+          fi
+          echo "id=$ID" >> "$GITHUB_OUTPUT"
+      - name: Refresh pg_dump via SSM
+        id: ssm
+        env:
+          INSTANCE_ID: ${{ steps.instance.outputs.id }}
+          STAGE0_SSM_OUTPUT_DIR: .
+        run: bash scripts/stage0_pg_dump_refresh_via_ssm.sh "$INSTANCE_ID" "ops-pg-dump-refresh target=prod"
+      - name: Job summary
+        if: always()
+        env:
+          INSTANCE_ID: ${{ steps.instance.outputs.id }}
+          STACK_NAME: ${{ env.STACK_NAME }}
+          CMD_ID: ${{ steps.ssm.outputs.command_id }}
+        run: |
+          {
+            echo "## ops pg_dump refresh"
+            echo "- environment: \`prod\`"
+            echo "- stack: \`$STACK_NAME\`"
+            echo "- instance: \`$INSTANCE_ID\`"
+            echo "- ssm command id: \`${CMD_ID:-none}\`"
+            echo "- cadence: every 2 hours"
+            echo "- retention: max 12 rolling files + 24h mtime ceiling"
+          } >> "$GITHUB_STEP_SUMMARY"
+
+  edge-us1:
+    if: inputs.target == 'edge-us1' || inputs.target == 'all'
+    runs-on: ubuntu-latest
+    environment: edge-us1
+    env:
+      OIDC_ROLE_ARN: ${{ vars.AWS_OIDC_ROLE_ARN }}
+      INPUT_EDGE_ID: us1
+      INPUT_CONFIRM_STACK: tokenkey-edge-us1-stage0
+    steps:
+      - uses: actions/checkout@v6
+        with:
+          submodules: recursive
+      - name: Validate OIDC role
+        run: |
+          set -euo pipefail
+          if [ -z "${OIDC_ROLE_ARN:-}" ]; then
+            echo "::error::AWS_OIDC_ROLE_ARN repo variable not set"
+            exit 1
+          fi
+      - name: Resolve edge target
+        id: edge
+        run: |
+          python3 deploy/aws/stage0/resolve-edge-target.py \
+            --edge-id "$INPUT_EDGE_ID" \
+            --confirm-stack "$INPUT_CONFIRM_STACK" \
+            --github-output "$GITHUB_OUTPUT"
+      - name: Configure AWS credentials via OIDC
+        uses: aws-actions/configure-aws-credentials@v4
+        with:
+          role-to-assume: ${{ env.OIDC_ROLE_ARN }}
+          aws-region: ${{ steps.edge.outputs.region }}
+      - name: Resolve edge instance id
+        id: instance
+        env:
+          STACK_NAME: ${{ steps.edge.outputs.stack }}
+        run: |
+          set -euo pipefail
+          ID=$(aws cloudformation describe-stacks --stack-name "$STACK_NAME" \
+            --query 'Stacks[0].Outputs[?OutputKey==`InstanceId`].OutputValue' --output text)
+          if [ -z "$ID" ] || [ "$ID" = "None" ]; then
+            echo "::error::could not resolve InstanceId from stack $STACK_NAME"
+            exit 1
+          fi
+          echo "id=$ID" >> "$GITHUB_OUTPUT"
+      - name: Refresh pg_dump via SSM
+        id: ssm
+        env:
+          INSTANCE_ID: ${{ steps.instance.outputs.id }}
+          STAGE0_SSM_OUTPUT_DIR: .
+        run: bash scripts/stage0_pg_dump_refresh_via_ssm.sh "$INSTANCE_ID" "ops-pg-dump-refresh target=edge-us1"
+      - name: Job summary
+        if: always()
+        env:
+          EDGE_ID: ${{ steps.edge.outputs.edge_id }}
+          STACK_NAME: ${{ steps.edge.outputs.stack }}
+          INSTANCE_ID: ${{ steps.instance.outputs.id }}
+          CMD_ID: ${{ steps.ssm.outputs.command_id }}
+        run: |
+          {
+            echo "## ops pg_dump refresh"
+            echo "- environment: \`edge-us1\`"
+            echo "- edge_id: \`$EDGE_ID\`"
+            echo "- stack: \`$STACK_NAME\`"
+            echo "- instance: \`$INSTANCE_ID\`"
+            echo "- ssm command id: \`${CMD_ID:-none}\`"
+            echo "- cadence: every 2 hours"
+            echo "- retention: max 12 rolling files + 24h mtime ceiling"
+          } >> "$GITHUB_STEP_SUMMARY"

--- a/scripts/stage0_pg_dump_refresh_via_ssm.sh
+++ b/scripts/stage0_pg_dump_refresh_via_ssm.sh
@@ -1,0 +1,163 @@
+#!/usr/bin/env bash
+# Push refreshed pg_dump cadence (every 2h, ≤12 rolling files) into a running
+# Stage0 EC2 via SSM Run-Command. Mirrors the user-data segment in
+# deploy/aws/cloudformation/stage0-single-ec2.yaml so the live timer matches
+# the template-of-record without rebuilding the EC2.
+
+set -euo pipefail
+
+INSTANCE_ID="${1:-${INSTANCE_ID:-}}"
+COMMENT="${2:-${SSM_COMMENT:-ops-pg-dump-refresh}}"
+TIMEOUT_SECONDS="${STAGE0_SSM_TIMEOUT_SECONDS:-300}"
+OUTPUT_DIR="${STAGE0_SSM_OUTPUT_DIR:-.}"
+
+if [ -z "${INSTANCE_ID}" ]; then
+  echo "stage0_pg_dump_refresh_via_ssm: instance id is required" >&2
+  exit 1
+fi
+
+mkdir -p "${OUTPUT_DIR}"
+params_file="${OUTPUT_DIR}/ssm-params.json"
+stdout_file="${OUTPUT_DIR}/stdout.txt"
+stderr_file="${OUTPUT_DIR}/stderr.txt"
+
+# Encode each payload to single-line base64 so embedding into the JSON command
+# array is shell-quoting-safe. tr -d strips both GNU and BSD base64 wrapping.
+PG_DUMP_SH_B64="$(cat <<'PGEOF' | base64 | tr -d '\n'
+#!/bin/bash
+set -euo pipefail
+DUMP_DIR=/var/lib/tokenkey/pgdump
+TS=$(date -u +%Y%m%dT%H%M%SZ)
+OUT="${DUMP_DIR}/tokenkey-${TS}.sql.gz"
+PART="${OUT}.part"
+rm -f "${PART}"
+
+# Remove bogus sub-kib dumps from failed runs (e.g. disk full).
+find "${DUMP_DIR}" -maxdepth 1 -type f -name 'tokenkey-*.sql.gz' -size -2k -delete 2>/dev/null || true
+# Remove legacy pre-*.dump files left by older manual pre-migration snapshots.
+find "${DUMP_DIR}" -maxdepth 1 -type f -name 'pre-*.dump' -delete 2>/dev/null || true
+
+set -o pipefail
+if ! docker exec tokenkey-postgres pg_dump -U tokenkey -d tokenkey --format=plain --no-owner \
+    | gzip -9 > "${PART}"; then
+  rm -f "${PART}"
+  exit 1
+fi
+
+SZ=$(wc -c < "${PART}")
+if [ "${SZ}" -lt 2048 ]; then
+  rm -f "${PART}"
+  exit 1
+fi
+
+mv -f "${PART}" "${OUT}"
+
+# Past 24h by mtime, and at most 12 rolling tokenkey-*.sql.gz (2h cadence).
+find "${DUMP_DIR}" -maxdepth 1 -type f -name 'tokenkey-*.sql.gz' -mmin +1440 -delete 2>/dev/null || true
+while IFS= read -r _oldf; do
+  [ -z "${_oldf}" ] && continue
+  rm -f "${_oldf}"
+done < <(find "${DUMP_DIR}" -maxdepth 1 -type f -name 'tokenkey-*.sql.gz' -printf '%T@\t%p\n' 2>/dev/null \
+  | sort -nr | tail -n +13 | cut -f2-)
+PGEOF
+)"
+
+PG_SERVICE_B64="$(cat <<'PSEOF' | base64 | tr -d '\n'
+[Unit]
+Description=tokenkey pg_dump (every 2 hours)
+After=tokenkey.service
+Requires=tokenkey.service
+
+[Service]
+Type=oneshot
+ExecStart=/usr/local/bin/tokenkey-pgdump.sh
+PSEOF
+)"
+
+PG_TIMER_B64="$(cat <<'PTEOF' | base64 | tr -d '\n'
+[Unit]
+Description=Run tokenkey-pgdump every 2 hours
+
+[Timer]
+OnCalendar=*-*-* 00,02,04,06,08,10,12,14,16,18,20,22:00:00
+Persistent=true
+RandomizedDelaySec=2min
+
+[Install]
+WantedBy=timers.target
+PTEOF
+)"
+
+jq -n \
+  --arg sh "${PG_DUMP_SH_B64}" \
+  --arg svc "${PG_SERVICE_B64}" \
+  --arg tmr "${PG_TIMER_B64}" \
+  '{
+    commands: [
+      "set -euo pipefail",
+      "echo === pg_dump refresh: every 2h, max 12 rolling files ===",
+      ("echo " + $sh + " | base64 -d | sudo tee /usr/local/bin/tokenkey-pgdump.sh > /dev/null"),
+      "sudo chmod +x /usr/local/bin/tokenkey-pgdump.sh",
+      ("echo " + $svc + " | base64 -d | sudo tee /etc/systemd/system/tokenkey-pgdump.service > /dev/null"),
+      ("echo " + $tmr + " | base64 -d | sudo tee /etc/systemd/system/tokenkey-pgdump.timer > /dev/null"),
+      "sudo systemctl daemon-reload",
+      "sudo systemctl enable --now tokenkey-pgdump.timer",
+      "sudo systemctl restart tokenkey-pgdump.timer",
+      "echo --- timer status ---",
+      "sudo systemctl status tokenkey-pgdump.timer --no-pager | head -20 || true",
+      "echo --- next firings ---",
+      "sudo systemctl list-timers tokenkey-pgdump.timer --no-pager || true",
+      "echo --- service unit definition ---",
+      "sudo systemctl cat tokenkey-pgdump.service --no-pager || true",
+      "echo --- timer unit definition ---",
+      "sudo systemctl cat tokenkey-pgdump.timer --no-pager || true"
+    ]
+  }' > "${params_file}"
+
+cmd_id="$(aws ssm send-command \
+  --instance-ids "${INSTANCE_ID}" \
+  --document-name AWS-RunShellScript \
+  --comment "${COMMENT}" \
+  --parameters "file://${params_file}" \
+  --query 'Command.CommandId' --output text)"
+
+echo "ssm command-id=${cmd_id}"
+if [ -n "${GITHUB_OUTPUT:-}" ]; then
+  echo "command_id=${cmd_id}" >> "${GITHUB_OUTPUT}"
+fi
+
+deadline=$(( $(date +%s) + TIMEOUT_SECONDS ))
+status="InProgress"
+while true; do
+  status="$(aws ssm get-command-invocation \
+    --command-id "${cmd_id}" --instance-id "${INSTANCE_ID}" \
+    --query 'Status' --output text 2>/dev/null || echo InProgress)"
+  case "${status}" in
+    Success|Failed|TimedOut|Cancelled) break ;;
+  esac
+  if [ "$(date +%s)" -ge "${deadline}" ]; then
+    echo "::error::ssm timeout" >&2
+    status="TimedOut"
+    break
+  fi
+  sleep 5
+done
+
+aws ssm get-command-invocation \
+  --command-id "${cmd_id}" --instance-id "${INSTANCE_ID}" \
+  --query 'StandardOutputContent' --output text > "${stdout_file}"
+aws ssm get-command-invocation \
+  --command-id "${cmd_id}" --instance-id "${INSTANCE_ID}" \
+  --query 'StandardErrorContent' --output text > "${stderr_file}"
+
+echo '--- ssm stdout (last 8KB) ---'
+tail -c 8192 "${stdout_file}"
+echo
+echo '--- ssm stderr (last 8KB) ---'
+tail -c 8192 "${stderr_file}"
+echo
+
+if [ "${status}" != "Success" ]; then
+  echo "::error::ssm command status=${status}" >&2
+  exit 1
+fi


### PR DESCRIPTION
## Summary

- New ops workflow `.github/workflows/ops-stage0-pg-dump-refresh.yml` (manual `workflow_dispatch`) that pushes the refreshed pg_dump cadence into running Stage0 instances via SSM Run-Command.
- New SSM helper `scripts/stage0_pg_dump_refresh_via_ssm.sh`, modeled on `scripts/stage0_deploy_via_ssm.sh`. The systemd unit + timer + dump script content is the **same** as `deploy/aws/cloudformation/stage0-single-ec2.yaml` § pg_dump (every 2h, ≤12 rolling files).

## Why

CloudFormation template change in `stage0-single-ec2.yaml` (already on `main`) reduces pg_dump cadence hourly → 2h and caps rolling files at 12, but the live EC2 user-data is only rewritten on a stack rebuild — a normal `deploy-stage0.yml` SSM-Run-Command rollout does **not** touch the timer. This workflow brings the live timer in sync with the template-of-record **without** triggering a prod restart.

## Inputs

- `target`: `prod` | `edge-us1` | `all`. Each path binds to its respective GitHub Environment (`prod` / `edge-us1`) so the existing `tokenkey-cicd-oidc` trust policy applies unchanged.

## SSM payload

Reads the three artifacts (`tokenkey-pgdump.sh`, `tokenkey-pgdump.service`, `tokenkey-pgdump.timer`) verbatim from the helper script's heredoc blocks, base64-encodes them, and decodes on the target instance before `systemctl daemon-reload` + `restart tokenkey-pgdump.timer`. The job summary prints `systemctl list-timers` + unit definitions for verification.

## Test plan

- [ ] `bash scripts/preflight.sh` — PASS locally
- [ ] After merge: dispatch with `target=prod`, confirm job summary shows the next firing aligned to `*-*-* 00,02,04,06,08,10,12,14,16,18,20,22:00:00` and unit definition contains `OnCalendar=*-*-* 00,02,04,06,08,10,12,14,16,18,20,22:00:00`.
- [ ] Then dispatch with `target=edge-us1`, same verification.
- [ ] After 2h: SSM exec `ls -la /var/lib/tokenkey/pgdump/` on each instance and confirm a new `tokenkey-<ts>.sql.gz` appeared on the 2h boundary.

## Constraints respected

- §5.x: no upstream-owned file deleted.
- §9.1 / §9.2: no `release.yml`/VERSION change; commit body contains no `[skip ci]`.
- §10: dev-rules submodule unchanged.
- `no-web-impact`: backend/ops-only; no frontend or admin surface.

🤖 Generated with [Claude Code](https://claude.com/claude-code)