### PR TITLE
fix(openai-gateway): terminate in-flight SSE event before synthetic error (upstream #1471)

### DIFF
--- a/backend/internal/service/openai_gateway_service.go
+++ b/backend/internal/service/openai_gateway_service.go
@@ -4377,7 +4377,13 @@ func (s *OpenAIGatewayService) handleStreamingResponse(ctx context.Context, resp
 			clientDisconnected = true
 			return
 		}
-		if _, err := bufferedWriter.WriteString("data: " + payload + "\n\n"); err != nil {
+		// TK fix for upstream Wei-Shaw/sub2api#1471: prepend a blank line to
+		// terminate any in-flight upstream SSE event whose trailing blank line
+		// has not yet been written. Without this, the unterminated `data:` line
+		// and this synthetic `data:` line merge into a single SSE event whose
+		// payload contains two concatenated JSON objects, breaking downstream
+		// SDK JSON parsers.
+		if _, err := bufferedWriter.WriteString("\ndata: " + payload + "\n\n"); err != nil {
 			clientDisconnected = true
 			return
 		}

--- a/backend/internal/service/openai_gateway_service_tk_stream_read_error_sse_test.go
+++ b/backend/internal/service/openai_gateway_service_tk_stream_read_error_sse_test.go
@@ -41,13 +41,39 @@ func (r *stepReadCloser) Read(p []byte) (int, error) {
 
 func (r *stepReadCloser) Close() error { return nil }
 
+// assertEachSSEEventHasOneParseableData splits an SSE transcript on the
+// event boundary `\n\n` and asserts every non-empty event carries exactly
+// one `data:` line whose payload is independently parseable JSON. This is
+// the load-bearing invariant for upstream Wei-Shaw/sub2api#1471: a
+// synthetic error event must never merge with an in-flight upstream event
+// (which would produce one SSE event whose data field holds two
+// concatenated JSON objects, breaking downstream JSON.parse).
+func assertEachSSEEventHasOneParseableData(t *testing.T, out string) {
+	t.Helper()
+	for i, ev := range strings.Split(out, "\n\n") {
+		ev = strings.TrimSpace(ev)
+		if ev == "" {
+			continue
+		}
+		var dataLines []string
+		for _, line := range strings.Split(ev, "\n") {
+			if strings.HasPrefix(line, "data:") {
+				dataLines = append(dataLines, strings.TrimSpace(strings.TrimPrefix(line, "data:")))
+			}
+		}
+		require.Lenf(t, dataLines, 1, "event %d must carry exactly one data line, got %v (full event: %q)", i, dataLines, ev)
+		var probe map[string]any
+		require.NoErrorf(t, json.Unmarshal([]byte(dataLines[0]), &probe),
+			"event %d data must be parseable JSON, got %q", i, dataLines[0])
+	}
+}
+
 // TestOpenAIStreamingStreamReadErrorEmitsSeparateSSEEvents covers
-// upstream Wei-Shaw/sub2api#1471: when an upstream read error fires after a
-// `data:` line has been written but before its terminating blank line, the
-// synthetic `stream_read_error` SSE event must start as its own event, not
-// concatenate with the in-flight event's data field. Otherwise a single SSE
-// event's data buffer contains two JSON objects joined by a newline, which
-// the downstream OpenAI/Codex SDK parses as malformed JSON.
+// upstream Wei-Shaw/sub2api#1471 on the synchronous scanner path: when an
+// upstream read error fires after a `data:` line has been written but
+// before its terminating blank line, the synthetic `stream_read_error`
+// SSE event must start as its own event, not concatenate with the
+// in-flight event's data field.
 func TestOpenAIStreamingStreamReadErrorEmitsSeparateSSEEvents(t *testing.T) {
 	gin.SetMode(gin.TestMode)
 	cfg := &config.Config{
@@ -91,22 +117,65 @@ func TestOpenAIStreamingStreamReadErrorEmitsSeparateSSEEvents(t *testing.T) {
 	out := rec.Body.String()
 	require.Contains(t, out, "stream_read_error", "expected synthetic error SSE event to be emitted")
 	require.Contains(t, out, "response.output_item.added", "expected the in-flight upstream event to still be visible")
+	assertEachSSEEventHasOneParseableData(t, out)
+}
 
-	// Split into SSE events and assert each data line is independently valid JSON.
-	for i, ev := range strings.Split(out, "\n\n") {
-		ev = strings.TrimSpace(ev)
-		if ev == "" {
-			continue
-		}
-		var dataLines []string
-		for _, line := range strings.Split(ev, "\n") {
-			if strings.HasPrefix(line, "data:") {
-				dataLines = append(dataLines, strings.TrimSpace(strings.TrimPrefix(line, "data:")))
-			}
-		}
-		require.Lenf(t, dataLines, 1, "event %d must carry exactly one data line, got %v (full event: %q)", i, dataLines, ev)
-		var probe map[string]any
-		require.NoErrorf(t, json.Unmarshal([]byte(dataLines[0]), &probe),
-			"event %d data must be parseable JSON, got %q", i, dataLines[0])
+// TestOpenAIStreamingStreamTimeoutEmitsSeparateSSEEvents covers the
+// asynchronous scanner-goroutine path of upstream Wei-Shaw/sub2api#1471:
+// when the upstream stops sending data mid-event and the interval-timeout
+// ticker fires, the synthetic `stream_timeout` SSE event must still start
+// as its own event. Without the prepended blank line, the in-flight
+// `data:` line and the synthetic `data:` line would merge into one SSE
+// event whose data buffer holds two concatenated JSON objects.
+//
+// StreamDataIntervalTimeout=1s is the minimum supported by the config
+// (seconds-granularity), so this test takes ~2s in practice (first tick
+// at t=1s sees lastRead<1s ago and continues; second tick at t=2s fires
+// the timeout).
+func TestOpenAIStreamingStreamTimeoutEmitsSeparateSSEEvents(t *testing.T) {
+	gin.SetMode(gin.TestMode)
+	cfg := &config.Config{
+		Gateway: config.GatewayConfig{
+			StreamDataIntervalTimeout: 1,
+			StreamKeepaliveInterval:   0,
+			MaxLineSize:               defaultMaxLineSize,
+		},
 	}
+	svc := &OpenAIGatewayService{cfg: cfg}
+
+	rec := httptest.NewRecorder()
+	c, _ := gin.CreateTestContext(rec)
+	c.Request = httptest.NewRequest(http.MethodPost, "/", nil)
+
+	pr, pw := io.Pipe()
+	// pr.Close() unblocks the gateway's scanner goroutine after the
+	// timeout returns from handleStreamingResponse; pw.Close() is a
+	// belt-and-suspenders cleanup for the producer side.
+	defer func() {
+		_ = pr.Close()
+		_ = pw.Close()
+	}()
+
+	go func() {
+		_, _ = pw.Write([]byte(
+			"data: {\"type\":\"response.created\",\"response\":{\"id\":\"resp_1\"}}\n\n" +
+				"data: {\"type\":\"response.in_progress\",\"response\":{\"id\":\"resp_1\"}}\n\n" +
+				"data: {\"type\":\"response.output_item.added\",\"output_index\":0,\"item\":{\"id\":\"msg_1\",\"type\":\"message\",\"role\":\"assistant\",\"content\":[]}}\n",
+		))
+	}()
+
+	resp := &http.Response{
+		StatusCode: http.StatusOK,
+		Body:       pr,
+		Header:     http.Header{"X-Request-Id": []string{"rid-mid-timeout"}},
+	}
+
+	_, err := svc.handleStreamingResponse(c.Request.Context(), resp, c, &Account{ID: 1, Platform: PlatformOpenAI, Name: "acc"}, time.Now(), "model", "model")
+	require.Error(t, err)
+	require.Contains(t, err.Error(), "stream data interval timeout")
+
+	out := rec.Body.String()
+	require.Contains(t, out, "stream_timeout", "expected synthetic timeout SSE event to be emitted")
+	require.Contains(t, out, "response.output_item.added", "expected the in-flight upstream event to still be visible")
+	assertEachSSEEventHasOneParseableData(t, out)
 }

--- a/backend/internal/service/openai_gateway_service_tk_stream_read_error_sse_test.go
+++ b/backend/internal/service/openai_gateway_service_tk_stream_read_error_sse_test.go
@@ -1,0 +1,112 @@
+package service
+
+import (
+	"encoding/json"
+	"io"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/Wei-Shaw/sub2api/internal/config"
+	"github.com/gin-gonic/gin"
+	"github.com/stretchr/testify/require"
+)
+
+// stepReadCloser returns the supplied chunks in order, then returns finalErr
+// on every subsequent Read. It is used to simulate an upstream stream that
+// successfully emits a few SSE bytes and then errors before sending its
+// terminating blank line.
+type stepReadCloser struct {
+	chunks  [][]byte
+	idx     int
+	final   error
+	yielded int
+}
+
+func (r *stepReadCloser) Read(p []byte) (int, error) {
+	if r.idx < len(r.chunks) {
+		chunk := r.chunks[r.idx]
+		n := copy(p, chunk[r.yielded:])
+		r.yielded += n
+		if r.yielded >= len(chunk) {
+			r.idx++
+			r.yielded = 0
+		}
+		return n, nil
+	}
+	return 0, r.final
+}
+
+func (r *stepReadCloser) Close() error { return nil }
+
+// TestOpenAIStreamingStreamReadErrorEmitsSeparateSSEEvents covers
+// upstream Wei-Shaw/sub2api#1471: when an upstream read error fires after a
+// `data:` line has been written but before its terminating blank line, the
+// synthetic `stream_read_error` SSE event must start as its own event, not
+// concatenate with the in-flight event's data field. Otherwise a single SSE
+// event's data buffer contains two JSON objects joined by a newline, which
+// the downstream OpenAI/Codex SDK parses as malformed JSON.
+func TestOpenAIStreamingStreamReadErrorEmitsSeparateSSEEvents(t *testing.T) {
+	gin.SetMode(gin.TestMode)
+	cfg := &config.Config{
+		Gateway: config.GatewayConfig{
+			StreamDataIntervalTimeout: 0,
+			StreamKeepaliveInterval:   0,
+			MaxLineSize:               defaultMaxLineSize,
+		},
+	}
+	svc := &OpenAIGatewayService{cfg: cfg}
+
+	rec := httptest.NewRecorder()
+	c, _ := gin.CreateTestContext(rec)
+	c.Request = httptest.NewRequest(http.MethodPost, "/", nil)
+
+	body := &stepReadCloser{
+		chunks: [][]byte{
+			// Preamble events so the gateway has initialized state. A
+			// non-preamble event below will set clientOutputStarted=true and
+			// route handleScanErr to sendErrorEvent (not pre-output failover).
+			[]byte("data: {\"type\":\"response.created\",\"response\":{\"id\":\"resp_1\"}}\n\n"),
+			[]byte("data: {\"type\":\"response.in_progress\",\"response\":{\"id\":\"resp_1\"}}\n\n"),
+			// Non-preamble event that is intentionally NOT terminated by a
+			// blank line. The next read returns io.ErrUnexpectedEOF before
+			// the upstream could send the `\n\n` terminator.
+			[]byte("data: {\"type\":\"response.output_item.added\",\"output_index\":0,\"item\":{\"id\":\"msg_1\",\"type\":\"message\",\"role\":\"assistant\",\"content\":[]}}\n"),
+		},
+		final: io.ErrUnexpectedEOF,
+	}
+
+	resp := &http.Response{
+		StatusCode: http.StatusOK,
+		Body:       body,
+		Header:     http.Header{"X-Request-Id": []string{"rid-mid-stream"}},
+	}
+
+	_, err := svc.handleStreamingResponse(c.Request.Context(), resp, c, &Account{ID: 1, Platform: PlatformOpenAI, Name: "acc"}, time.Now(), "model", "model")
+	require.Error(t, err)
+	require.Contains(t, err.Error(), "stream read error")
+
+	out := rec.Body.String()
+	require.Contains(t, out, "stream_read_error", "expected synthetic error SSE event to be emitted")
+	require.Contains(t, out, "response.output_item.added", "expected the in-flight upstream event to still be visible")
+
+	// Split into SSE events and assert each data line is independently valid JSON.
+	for i, ev := range strings.Split(out, "\n\n") {
+		ev = strings.TrimSpace(ev)
+		if ev == "" {
+			continue
+		}
+		var dataLines []string
+		for _, line := range strings.Split(ev, "\n") {
+			if strings.HasPrefix(line, "data:") {
+				dataLines = append(dataLines, strings.TrimSpace(strings.TrimPrefix(line, "data:")))
+			}
+		}
+		require.Lenf(t, dataLines, 1, "event %d must carry exactly one data line, got %v (full event: %q)", i, dataLines, ev)
+		var probe map[string]any
+		require.NoErrorf(t, json.Unmarshal([]byte(dataLines[0]), &probe),
+			"event %d data must be parseable JSON, got %q", i, dataLines[0])
+	}
+}

--- a/scripts/gateway-tk-sentinels.json
+++ b/scripts/gateway-tk-sentinels.json
@@ -324,6 +324,23 @@
       "path": "backend/internal/repository/user_subscription_repo_integration_test.go",
       "must_contain": ["TestExistsByUserIDAndGroupID_IgnoresExpiredAndNonActive"],
       "rationale": "Focused regression for upstream #2478 covering the three non-active variants (expired by date, expired by status, suspended). Dropping this test lets the reassignment-block bug sneak back through integration CI."
+    },
+    {
+      "path": "backend/internal/service/openai_gateway_service.go",
+      "must_contain": [
+        "TK fix for upstream Wei-Shaw/sub2api#1471",
+        "bufferedWriter.WriteString(\"\\ndata: \" + payload + \"\\n\\n\")"
+      ],
+      "rationale": "OpenAI /v1/responses handleStreamingResponse.sendErrorEvent MUST prepend a blank line before the synthetic `data:` event so any in-flight upstream SSE event whose terminating blank line was never sent is closed before the synthetic event is written. Without this, the unterminated `data:` line and the synthetic `data:` line merge into one SSE event whose data buffer contains two concatenated JSON objects — downstream OpenAI-compatible SDKs (Codex / OpenCode) fail JSON.parse. An upstream merge that rewrites this closure to the original `\"data: \" + payload + \"\\n\\n\"` literal would silently re-introduce the malformed-SSE failure mode (upstream #1471)."
+    },
+    {
+      "path": "backend/internal/service/openai_gateway_service_tk_stream_read_error_sse_test.go",
+      "must_contain": [
+        "TestOpenAIStreamingStreamReadErrorEmitsSeparateSSEEvents",
+        "stream_read_error",
+        "response.output_item.added"
+      ],
+      "rationale": "Focused regression anchor for upstream #1471 proving each SSE event in the post-error transcript carries exactly one parseable-JSON data line, even when the upstream errored mid-event after a non-preamble (output_item.added) line had already been forwarded. Dropping the test lets the malformed-SSE concatenation regression sneak back through unit CI."
     }
   ]
 }

--- a/scripts/gateway-tk-sentinels.json
+++ b/scripts/gateway-tk-sentinels.json
@@ -328,19 +328,19 @@
     {
       "path": "backend/internal/service/openai_gateway_service.go",
       "must_contain": [
-        "TK fix for upstream Wei-Shaw/sub2api#1471",
-        "bufferedWriter.WriteString(\"\\ndata: \" + payload + \"\\n\\n\")"
+        "TK fix for upstream Wei-Shaw/sub2api#1471"
       ],
-      "rationale": "OpenAI /v1/responses handleStreamingResponse.sendErrorEvent MUST prepend a blank line before the synthetic `data:` event so any in-flight upstream SSE event whose terminating blank line was never sent is closed before the synthetic event is written. Without this, the unterminated `data:` line and the synthetic `data:` line merge into one SSE event whose data buffer contains two concatenated JSON objects — downstream OpenAI-compatible SDKs (Codex / OpenCode) fail JSON.parse. An upstream merge that rewrites this closure to the original `\"data: \" + payload + \"\\n\\n\"` literal would silently re-introduce the malformed-SSE failure mode (upstream #1471)."
+      "rationale": "OpenAI /v1/responses handleStreamingResponse.sendErrorEvent MUST prepend a blank line before the synthetic `data:` event so any in-flight upstream SSE event whose terminating blank line was never sent is closed before the synthetic event is written. Without this, the unterminated `data:` line and the synthetic `data:` line merge into one SSE event whose data buffer contains two concatenated JSON objects — downstream OpenAI-compatible SDKs (Codex / OpenCode) fail JSON.parse. The marker comment is the intent anchor; the literal write expression is intentionally NOT pinned so harmless refactors (extracting prefix to a constant, renaming `payload`, switching to fmt.Fprintf) do not flap the registry. Regression test (sentinel below) is the primary protection — the watchdog fact-check in scripts/upstream-issue-fact-checks.json pins the actual `\\ndata: ` literal for the watchdog's stricter audit."
     },
     {
       "path": "backend/internal/service/openai_gateway_service_tk_stream_read_error_sse_test.go",
       "must_contain": [
         "TestOpenAIStreamingStreamReadErrorEmitsSeparateSSEEvents",
+        "TestOpenAIStreamingStreamTimeoutEmitsSeparateSSEEvents",
         "stream_read_error",
-        "response.output_item.added"
+        "stream_timeout"
       ],
-      "rationale": "Focused regression anchor for upstream #1471 proving each SSE event in the post-error transcript carries exactly one parseable-JSON data line, even when the upstream errored mid-event after a non-preamble (output_item.added) line had already been forwarded. Dropping the test lets the malformed-SSE concatenation regression sneak back through unit CI."
+      "rationale": "Focused regression anchors for upstream #1471 covering both sendErrorEvent triggers that share the closure: synchronous scanner error path (stream_read_error) and asynchronous interval-timeout path (stream_timeout). Each asserts every SSE event in the post-error transcript carries exactly one parseable-JSON data line. Together they prove the prepended-blank-line invariant holds for both the bufio.Scanner sync path and the goroutine async path that read from upstream."
     }
   ]
 }

--- a/scripts/upstream-issue-fact-checks.json
+++ b/scripts/upstream-issue-fact-checks.json
@@ -207,6 +207,20 @@
         "backend/internal/service/gateway_service.go:Wei-Shaw/sub2api#2332 hardening",
         "backend/internal/service/gateway_streaming_test.go:TestParseSSEUsage_StartPartialUsageDoesNotZeroAccumulator"
       ]
+    },
+    {
+      "upstream": "Wei-Shaw/sub2api#1471",
+      "severity": "high",
+      "summary": "OpenAI /v1/responses sendErrorEvent now prepends a blank line before the synthetic data: line, so any in-flight upstream SSE event whose terminating blank line was never sent is closed before the synthetic event is written. Without this, the unterminated `data:` line and the synthetic `data:` line merge into a single SSE event whose payload contains two concatenated JSON objects, which downstream OpenAI-compatible SDKs (Codex, OpenCode, etc.) reject with malformed JSON.",
+      "fixed_by": [
+        "backend/internal/service/openai_gateway_service.go",
+        "backend/internal/service/openai_gateway_service_tk_stream_read_error_sse_test.go"
+      ],
+      "fixed_if_all_present": [
+        "backend/internal/service/openai_gateway_service.go:TK fix for upstream Wei-Shaw/sub2api#1471",
+        "backend/internal/service/openai_gateway_service.go:bufferedWriter.WriteString(\"\\ndata: \" + payload + \"\\n\\n\")",
+        "backend/internal/service/openai_gateway_service_tk_stream_read_error_sse_test.go:TestOpenAIStreamingStreamReadErrorEmitsSeparateSSEEvents"
+      ]
     }
   ]
 }

--- a/scripts/upstream-issue-fixes.json
+++ b/scripts/upstream-issue-fixes.json
@@ -259,6 +259,15 @@
         "backend/internal/service/gateway_streaming_test.go"
       ],
       "summary": "extractSSEUsagePatch message_start branch now gates hasInputTokens/hasCacheCreationInput/hasCacheReadInput on actual parseSSEUsageInt success instead of setting them unconditionally; a partial or duplicate message_start frame no longer zeroes out accumulator dimensions whose source key was absent (the input_tokens=0 duplicate-billing shape upstream reported)."
+    },
+    {
+      "upstream": "Wei-Shaw/sub2api#1471",
+      "status": "fixed_in_tokenkey",
+      "fixed_by": [
+        "backend/internal/service/openai_gateway_service.go",
+        "backend/internal/service/openai_gateway_service_tk_stream_read_error_sse_test.go"
+      ],
+      "summary": "OpenAI /v1/responses sendErrorEvent now prepends a blank line before the synthetic data: line, so any in-flight upstream SSE event whose terminating blank line was never sent is closed before the synthetic event is written. Without this, the unterminated `data:` line and the synthetic `data:` line merge into a single SSE event whose payload contains two concatenated JSON objects, which downstream OpenAI-compatible SDKs (Codex, OpenCode, etc.) reject with malformed JSON."
     }
   ]
 }

--- a/scripts/upstream-issue-triage-generate.py
+++ b/scripts/upstream-issue-triage-generate.py
@@ -60,6 +60,7 @@ MANUAL_TRIAGE = {
     2500: ("fixed", "fixed_in_tokenkey", "Codex OAuth fixCallIDPrefix now emits fc_<id> (with underscore) for call_<id> inputs, matching the codex backend's id validator and preventing 502 on multi-hop tool turns."),
     2506: ("fixed", "fixed_in_tokenkey", "normalizeClaudeOAuthRequestBody skips context_management auto-injection for Haiku models (mirroring the existing Haiku exemption in FullClaudeCodeMimicryBetas), so claude-haiku-4-5-* + thinking.type=enabled no longer triggers Anthropic 400."),
     2515: ("fixed", "fixed_in_tokenkey", "ChatCompletions→Responses transform no longer emits content:null when the source content array is empty or every part was filtered out — falls back to empty string per upstream Responses contract."),
+    1471: ("fixed", "fixed_in_tokenkey", "OpenAI /v1/responses sendErrorEvent prepends a blank line before the synthetic error event so an in-flight upstream SSE event (data: line without terminating blank line) does not merge with the injected error event into a single event carrying two JSON objects; downstream SDK JSON parsing no longer fails."),
 }
 
 FIXED_IDS = {num for num, (impact, _, _) in MANUAL_TRIAGE.items() if impact == "fixed"}


### PR DESCRIPTION
## Summary
- Fixes upstream [Wei-Shaw/sub2api#1471](https://github.com/Wei-Shaw/sub2api/issues/1471): OpenAI `/v1/responses` streaming can emit a malformed SSE payload — the in-flight upstream event's `data:` line concatenates with the synthetic `stream_read_error` event's `data:` line into a single SSE event, breaking downstream OpenAI-compatible SDK JSON parsing.
- Root cause: `handleStreamingResponse.sendErrorEvent` writes `"data: " + payload + "\n\n"` directly after a buffered upstream `data:` line whose `\n\n` terminator was lost when the upstream errored mid-event.
- Fix: prepend `\n` to the synthetic event so any unterminated in-flight event is closed first. SSE parsers tolerate consecutive blank lines, so this is harmless when the prior event was already complete.

## Why this is high-impact (not a cosmetic fix)
- Production symptom: `Could not parse message into JSON` / `Expected ':' after property name in JSON at position …` from Codex / OpenCode / any OpenAI-compatible client whenever an upstream Responses stream errors mid-event.
- Behavior degrades cleanly to an error-only event, instead of corrupting the in-flight event into garbage JSON.

## Test plan
- [x] `go build ./...` clean.
- [x] `go test -tags=unit ./...` passes (entire backend suite, 86s service package).
- [x] `golangci-lint run ./internal/service/...` clean.
- [x] `bash scripts/preflight.sh` PASS (after submodule init).
- [x] New regression test `TestOpenAIStreamingStreamReadErrorEmitsSeparateSSEEvents` passes with the fix.
- [x] Reverse-verified: stashing the one-line fix in `openai_gateway_service.go` and re-running the new test reproduces the bug — "event 2 must carry exactly one data line, got [{response.output_item.added JSON} {stream_read_error JSON}]".

## Drift / merge hygiene
- Sentinel registered in `scripts/gateway-tk-sentinels.json` so an upstream merge cannot silently revert the `sendErrorEvent` closure to the concatenating form.
- `scripts/upstream-issue-{fact-checks,fixes}.json` and `MANUAL_TRIAGE` in `scripts/upstream-issue-triage-generate.py` mark `#1471` as `fixed_in_tokenkey`; the watchdog will reclassify it on the next triage pass.
- `git log --oneline upstream/main..HEAD | wc -l` cadence audit is not applicable here (this PR is TK-only, not an upstream merge).

## File touch summary
- `backend/internal/service/openai_gateway_service.go` — 1 closure: prepend `\n` + 5-line TK comment referencing the upstream issue.
- `backend/internal/service/openai_gateway_service_tk_stream_read_error_sse_test.go` — new file, TK companion test (per CLAUDE.md §5 minimal-invasion guideline).
- `scripts/gateway-tk-sentinels.json` — 2 sentinel entries (fix + test).
- `scripts/upstream-issue-fact-checks.json`, `scripts/upstream-issue-fixes.json`, `scripts/upstream-issue-triage-generate.py` — registry bookkeeping.

## Merge mode
Squash and merge per CLAUDE.md §5.y (TK-originated fix, not an upstream merge).

## Scope notes
- Only the OpenAI `/v1/responses` `handleStreamingResponse` has this bug shape with `data:`-only events. The Anthropic gateway buffers complete events via `pendingEventLines` before writing, so its `sendErrorEvent` is already safe. Antigravity gateways write `data: %s\n\n` per upstream line (always complete event terminator). Anthropic API-key passthrough does not inject synthetic events.
- The other 3 `sendErrorEvent` call sites (`response_too_large`, `stream_timeout`) in the same closure also benefit from the fix.

🤖 Generated with [Claude Code](https://claude.com/claude-code)