### PR TITLE
feat(ops): record internal-error detail on api-key auth 5xx

### DIFF
--- a/backend/internal/handler/ops_error_logger.go
+++ b/backend/internal/handler/ops_error_logger.go
@@ -1303,6 +1303,12 @@ func classifyOpsErrorSource(phase string, message string) string {
 // by middleware (api_key auth fallbacks etc.) and folds it into the captured
 // error_body so RCA can recover the underlying cache/redis/db error string
 // without needing live docker logs.
+//
+// When error_body is a JSON object, the detail is injected as a top-level
+// "_internal_detail" field so downstream service.sanitizeErrorBodyForStorage
+// still applies JSON-aware redaction (redactSensitiveJSON) to any sensitive
+// fields a future caller might leave in the body. When the body is empty or
+// not a JSON object, fall back to a "[internal_detail] <text>" suffix.
 func appendOpsInternalErrorDetail(c *gin.Context, entry *service.OpsInsertErrorLogInput) {
 	if c == nil || entry == nil {
 		return
@@ -1320,6 +1326,20 @@ func appendOpsInternalErrorDetail(c *gin.Context, entry *service.OpsInsertErrorL
 		return
 	}
 	detail = truncateString(detail, 1024)
+
+	if trimmed := strings.TrimSpace(entry.ErrorBody); trimmed != "" {
+		var decoded any
+		if err := json.Unmarshal([]byte(trimmed), &decoded); err == nil {
+			if obj, ok := decoded.(map[string]any); ok {
+				obj["_internal_detail"] = detail
+				if encoded, encErr := json.Marshal(obj); encErr == nil {
+					entry.ErrorBody = string(encoded)
+					return
+				}
+			}
+		}
+	}
+
 	const marker = "[internal_detail] "
 	if entry.ErrorBody == "" {
 		entry.ErrorBody = marker + detail

--- a/backend/internal/handler/ops_error_logger.go
+++ b/backend/internal/handler/ops_error_logger.go
@@ -947,6 +947,8 @@ func OpsErrorLoggerMiddleware(ops *service.OpsService) gin.HandlerFunc {
 			}
 		}
 
+		appendOpsInternalErrorDetail(c, entry)
+
 		if apiKey != nil {
 			entry.APIKeyID = &apiKey.ID
 			if apiKey.User != nil {
@@ -1294,6 +1296,35 @@ func classifyOpsErrorSource(phase string, message string) string {
 			return "upstream_http"
 		}
 		return "gateway"
+	}
+}
+
+// appendOpsInternalErrorDetail consumes a sanitized internal-error detail set
+// by middleware (api_key auth fallbacks etc.) and folds it into the captured
+// error_body so RCA can recover the underlying cache/redis/db error string
+// without needing live docker logs.
+func appendOpsInternalErrorDetail(c *gin.Context, entry *service.OpsInsertErrorLogInput) {
+	if c == nil || entry == nil {
+		return
+	}
+	v, ok := c.Get(service.OpsInternalErrorDetailKey)
+	if !ok {
+		return
+	}
+	s, ok := v.(string)
+	if !ok {
+		return
+	}
+	detail := strings.TrimSpace(s)
+	if detail == "" {
+		return
+	}
+	detail = truncateString(detail, 1024)
+	const marker = "[internal_detail] "
+	if entry.ErrorBody == "" {
+		entry.ErrorBody = marker + detail
+	} else {
+		entry.ErrorBody = entry.ErrorBody + "\n" + marker + detail
 	}
 }
 

--- a/backend/internal/handler/ops_error_logger_test.go
+++ b/backend/internal/handler/ops_error_logger_test.go
@@ -148,13 +148,37 @@ func TestAppendOpsInternalErrorDetail_AppendsAndPrependsCorrectly(t *testing.T) 
 		require.Equal(t, "body", entry.ErrorBody)
 	})
 
-	t.Run("appends to existing body", func(t *testing.T) {
+	t.Run("injects into JSON object body", func(t *testing.T) {
 		c, _ := gin.CreateTestContext(httptest.NewRecorder())
 		c.Set(service.OpsInternalErrorDetailKey, "redis ECONNREFUSED")
 		entry := &service.OpsInsertErrorLogInput{ErrorBody: `{"code":"INTERNAL_ERROR","message":"Failed to validate API key"}`}
 		appendOpsInternalErrorDetail(c, entry)
-		require.Contains(t, entry.ErrorBody, `{"code":"INTERNAL_ERROR","message":"Failed to validate API key"}`)
-		require.Contains(t, entry.ErrorBody, "[internal_detail] redis ECONNREFUSED")
+
+		// Must remain valid JSON so service.sanitizeErrorBodyForStorage can
+		// still apply redactSensitiveJSON downstream.
+		var decoded map[string]any
+		require.NoError(t, json.Unmarshal([]byte(entry.ErrorBody), &decoded))
+		require.Equal(t, "INTERNAL_ERROR", decoded["code"])
+		require.Equal(t, "Failed to validate API key", decoded["message"])
+		require.Equal(t, "redis ECONNREFUSED", decoded["_internal_detail"])
+	})
+
+	t.Run("falls back to marker on non-JSON body", func(t *testing.T) {
+		c, _ := gin.CreateTestContext(httptest.NewRecorder())
+		c.Set(service.OpsInternalErrorDetailKey, "context deadline exceeded")
+		entry := &service.OpsInsertErrorLogInput{ErrorBody: "plain text body, not json"}
+		appendOpsInternalErrorDetail(c, entry)
+		require.Equal(t, "plain text body, not json\n[internal_detail] context deadline exceeded", entry.ErrorBody)
+	})
+
+	t.Run("falls back to marker on JSON array body", func(t *testing.T) {
+		// JSON arrays have no stable "_internal_detail" insertion shape, so
+		// we expect the marker-append fallback to kick in.
+		c, _ := gin.CreateTestContext(httptest.NewRecorder())
+		c.Set(service.OpsInternalErrorDetailKey, "pool exhausted")
+		entry := &service.OpsInsertErrorLogInput{ErrorBody: `["a","b"]`}
+		appendOpsInternalErrorDetail(c, entry)
+		require.Equal(t, `["a","b"]`+"\n[internal_detail] pool exhausted", entry.ErrorBody)
 	})
 
 	t.Run("populates empty body", func(t *testing.T) {

--- a/backend/internal/handler/ops_error_logger_test.go
+++ b/backend/internal/handler/ops_error_logger_test.go
@@ -130,6 +130,54 @@ func TestEnqueueOpsErrorLog_QueueFullFallsBackToDLQ(t *testing.T) {
 	require.Equal(t, "traj_queue_full", entryPayload["TrajectoryID"])
 }
 
+func TestAppendOpsInternalErrorDetail_AppendsAndPrependsCorrectly(t *testing.T) {
+	gin.SetMode(gin.TestMode)
+
+	t.Run("noop when key absent", func(t *testing.T) {
+		c, _ := gin.CreateTestContext(httptest.NewRecorder())
+		entry := &service.OpsInsertErrorLogInput{ErrorBody: `{"code":"INTERNAL_ERROR"}`}
+		appendOpsInternalErrorDetail(c, entry)
+		require.Equal(t, `{"code":"INTERNAL_ERROR"}`, entry.ErrorBody)
+	})
+
+	t.Run("noop when value not string", func(t *testing.T) {
+		c, _ := gin.CreateTestContext(httptest.NewRecorder())
+		c.Set(service.OpsInternalErrorDetailKey, 42)
+		entry := &service.OpsInsertErrorLogInput{ErrorBody: "body"}
+		appendOpsInternalErrorDetail(c, entry)
+		require.Equal(t, "body", entry.ErrorBody)
+	})
+
+	t.Run("appends to existing body", func(t *testing.T) {
+		c, _ := gin.CreateTestContext(httptest.NewRecorder())
+		c.Set(service.OpsInternalErrorDetailKey, "redis ECONNREFUSED")
+		entry := &service.OpsInsertErrorLogInput{ErrorBody: `{"code":"INTERNAL_ERROR","message":"Failed to validate API key"}`}
+		appendOpsInternalErrorDetail(c, entry)
+		require.Contains(t, entry.ErrorBody, `{"code":"INTERNAL_ERROR","message":"Failed to validate API key"}`)
+		require.Contains(t, entry.ErrorBody, "[internal_detail] redis ECONNREFUSED")
+	})
+
+	t.Run("populates empty body", func(t *testing.T) {
+		c, _ := gin.CreateTestContext(httptest.NewRecorder())
+		c.Set(service.OpsInternalErrorDetailKey, "context deadline exceeded")
+		entry := &service.OpsInsertErrorLogInput{}
+		appendOpsInternalErrorDetail(c, entry)
+		require.Equal(t, "[internal_detail] context deadline exceeded", entry.ErrorBody)
+	})
+
+	t.Run("nil context safe", func(t *testing.T) {
+		entry := &service.OpsInsertErrorLogInput{}
+		appendOpsInternalErrorDetail(nil, entry)
+		require.Empty(t, entry.ErrorBody)
+	})
+
+	t.Run("nil entry safe", func(t *testing.T) {
+		c, _ := gin.CreateTestContext(httptest.NewRecorder())
+		c.Set(service.OpsInternalErrorDetailKey, "x")
+		require.NotPanics(t, func() { appendOpsInternalErrorDetail(c, nil) })
+	})
+}
+
 func TestAttachOpsRequestBodyToEntry_EarlyReturnBranches(t *testing.T) {
 	resetOpsErrorLoggerStateForTest(t)
 	gin.SetMode(gin.TestMode)

--- a/backend/internal/server/middleware/api_key_auth.go
+++ b/backend/internal/server/middleware/api_key_auth.go
@@ -85,7 +85,7 @@ func apiKeyAuthWithSubscription(apiKeyService *service.APIKeyService, subscripti
 				AbortWithError(c, 401, "INVALID_API_KEY", "Invalid API key")
 				return
 			}
-			AbortWithError(c, 500, "INTERNAL_ERROR", "Failed to validate API key")
+			AbortWithErrorDetail(c, 500, "INTERNAL_ERROR", "Failed to validate API key", err)
 			return
 		}
 

--- a/backend/internal/server/middleware/api_key_auth_google.go
+++ b/backend/internal/server/middleware/api_key_auth_google.go
@@ -38,6 +38,9 @@ func APIKeyAuthWithSubscriptionGoogle(apiKeyService *service.APIKeyService, subs
 				abortWithGoogleError(c, 401, "Invalid API key")
 				return
 			}
+			if detail := sanitizeMiddlewareInternalErrorDetail(err); detail != "" {
+				c.Set(service.OpsInternalErrorDetailKey, detail)
+			}
 			abortWithGoogleError(c, 500, "Failed to validate API key")
 			return
 		}

--- a/backend/internal/server/middleware/api_key_auth_google.go
+++ b/backend/internal/server/middleware/api_key_auth_google.go
@@ -38,10 +38,7 @@ func APIKeyAuthWithSubscriptionGoogle(apiKeyService *service.APIKeyService, subs
 				abortWithGoogleError(c, 401, "Invalid API key")
 				return
 			}
-			if detail := sanitizeMiddlewareInternalErrorDetail(err); detail != "" {
-				c.Set(service.OpsInternalErrorDetailKey, detail)
-			}
-			abortWithGoogleError(c, 500, "Failed to validate API key")
+			abortWithGoogleErrorDetail(c, 500, "Failed to validate API key", err)
 			return
 		}
 
@@ -170,4 +167,18 @@ func abortWithGoogleError(c *gin.Context, status int, message string) {
 		},
 	})
 	c.Abort()
+}
+
+// abortWithGoogleErrorDetail mirrors AbortWithErrorDetail but writes a
+// Google-style error payload. The internalErr is sanitized and stashed on the
+// gin context via service.OpsInternalErrorDetailKey for ops_error_logger to
+// fold into ops_error_logs.error_body; it is NOT leaked into the client
+// response.
+func abortWithGoogleErrorDetail(c *gin.Context, status int, message string, internalErr error) {
+	if c != nil && internalErr != nil {
+		if detail := sanitizeMiddlewareInternalErrorDetail(internalErr); detail != "" {
+			c.Set(service.OpsInternalErrorDetailKey, detail)
+		}
+	}
+	abortWithGoogleError(c, status, message)
 }

--- a/backend/internal/server/middleware/middleware.go
+++ b/backend/internal/server/middleware/middleware.go
@@ -3,12 +3,16 @@ package middleware
 import (
 	"context"
 	"net/http"
+	"strings"
+	"unicode/utf8"
 
 	"github.com/Wei-Shaw/sub2api/internal/pkg/ctxkey"
 	"github.com/Wei-Shaw/sub2api/internal/pkg/googleapi"
 	"github.com/Wei-Shaw/sub2api/internal/service"
 	"github.com/gin-gonic/gin"
 )
+
+const middlewareInternalErrorDetailMaxLen = 1024
 
 // ContextKey 定义上下文键类型
 type ContextKey string
@@ -73,6 +77,42 @@ func NewErrorResponse(code, message string) ErrorResponse {
 func AbortWithError(c *gin.Context, statusCode int, code, message string) {
 	c.JSON(statusCode, NewErrorResponse(code, message))
 	c.Abort()
+}
+
+// AbortWithErrorDetail behaves like AbortWithError but additionally records a
+// sanitized representation of internalErr on the gin context so that
+// OpsErrorLoggerMiddleware can persist it into ops_error_logs.error_body for
+// post-hoc RCA. The client-facing response is identical to AbortWithError —
+// no detail is leaked to callers.
+func AbortWithErrorDetail(c *gin.Context, statusCode int, code, message string, internalErr error) {
+	if c != nil && internalErr != nil {
+		if detail := sanitizeMiddlewareInternalErrorDetail(internalErr); detail != "" {
+			c.Set(service.OpsInternalErrorDetailKey, detail)
+		}
+	}
+	AbortWithError(c, statusCode, code, message)
+}
+
+// sanitizeMiddlewareInternalErrorDetail trims and length-caps an internal error
+// string so it is safe to persist in ops_error_logs. Internal errors from
+// Postgres/Redis/context cancellation generally do not carry caller secrets,
+// but we still cap length to keep error_body bounded and utf8-safe.
+func sanitizeMiddlewareInternalErrorDetail(err error) string {
+	if err == nil {
+		return ""
+	}
+	s := strings.TrimSpace(err.Error())
+	if s == "" {
+		return ""
+	}
+	if len(s) > middlewareInternalErrorDetailMaxLen {
+		s = s[:middlewareInternalErrorDetailMaxLen]
+		for len(s) > 0 && !utf8.ValidString(s) {
+			s = s[:len(s)-1]
+		}
+		s += "...(truncated)"
+	}
+	return s
 }
 
 // ──────────────────────────────────────────────────────────

--- a/backend/internal/server/middleware/middleware_internal_error_detail_test.go
+++ b/backend/internal/server/middleware/middleware_internal_error_detail_test.go
@@ -1,0 +1,116 @@
+package middleware
+
+import (
+	"context"
+	"errors"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"testing"
+
+	"github.com/Wei-Shaw/sub2api/internal/config"
+	"github.com/Wei-Shaw/sub2api/internal/service"
+
+	"github.com/gin-gonic/gin"
+	"github.com/stretchr/testify/require"
+)
+
+func TestSanitizeMiddlewareInternalErrorDetail_TrimsAndCaps(t *testing.T) {
+	t.Run("nil error", func(t *testing.T) {
+		require.Equal(t, "", sanitizeMiddlewareInternalErrorDetail(nil))
+	})
+	t.Run("empty after trim", func(t *testing.T) {
+		require.Equal(t, "", sanitizeMiddlewareInternalErrorDetail(errors.New("   ")))
+	})
+	t.Run("short message preserved", func(t *testing.T) {
+		require.Equal(t, "redis ECONNREFUSED", sanitizeMiddlewareInternalErrorDetail(errors.New("  redis ECONNREFUSED  ")))
+	})
+	t.Run("long message truncated", func(t *testing.T) {
+		long := strings.Repeat("x", middlewareInternalErrorDetailMaxLen+128)
+		got := sanitizeMiddlewareInternalErrorDetail(errors.New(long))
+		require.True(t, strings.HasSuffix(got, "...(truncated)"))
+		require.True(t, len(got) <= middlewareInternalErrorDetailMaxLen+len("...(truncated)"))
+	})
+}
+
+func TestAbortWithErrorDetail_SetsOpsKey(t *testing.T) {
+	gin.SetMode(gin.TestMode)
+	c, _ := gin.CreateTestContext(httptest.NewRecorder())
+	AbortWithErrorDetail(c, http.StatusInternalServerError, "INTERNAL_ERROR", "Failed to validate API key", errors.New("redis ECONNREFUSED 127.0.0.1:6379"))
+
+	v, ok := c.Get(service.OpsInternalErrorDetailKey)
+	require.True(t, ok)
+	s, ok := v.(string)
+	require.True(t, ok)
+	require.Equal(t, "redis ECONNREFUSED 127.0.0.1:6379", s)
+}
+
+func TestAbortWithErrorDetail_NilErrorDoesNotSetKey(t *testing.T) {
+	gin.SetMode(gin.TestMode)
+	c, _ := gin.CreateTestContext(httptest.NewRecorder())
+	AbortWithErrorDetail(c, http.StatusInternalServerError, "INTERNAL_ERROR", "Failed to validate API key", nil)
+
+	_, ok := c.Get(service.OpsInternalErrorDetailKey)
+	require.False(t, ok)
+}
+
+func TestAPIKeyAuth_500_SetsOpsInternalErrorDetail(t *testing.T) {
+	gin.SetMode(gin.TestMode)
+
+	apiKeyService := newTestAPIKeyService(fakeAPIKeyRepo{
+		getByKey: func(ctx context.Context, key string) (*service.APIKey, error) {
+			return nil, errors.New("postgres conn pool exhausted")
+		},
+	})
+
+	r := gin.New()
+	var captured *gin.Context
+	r.Use(func(c *gin.Context) { captured = c; c.Next() })
+	r.Use(gin.HandlerFunc(NewAPIKeyAuthMiddleware(apiKeyService, nil, &config.Config{})))
+	r.POST("/v1/messages", func(c *gin.Context) { c.JSON(200, gin.H{"ok": true}) })
+
+	req := httptest.NewRequest(http.MethodPost, "/v1/messages", nil)
+	req.Header.Set("Authorization", "Bearer any")
+	rec := httptest.NewRecorder()
+	r.ServeHTTP(rec, req)
+
+	require.Equal(t, http.StatusInternalServerError, rec.Code)
+	require.NotNil(t, captured)
+	v, ok := captured.Get(service.OpsInternalErrorDetailKey)
+	require.True(t, ok, "ops internal-error detail key should be set on 500")
+	s, ok := v.(string)
+	require.True(t, ok)
+	require.Contains(t, s, "postgres conn pool exhausted")
+	// Response body must not leak detail — client still sees the generic message.
+	require.NotContains(t, rec.Body.String(), "postgres conn pool exhausted")
+}
+
+func TestAPIKeyAuthGoogle_500_SetsOpsInternalErrorDetail(t *testing.T) {
+	gin.SetMode(gin.TestMode)
+
+	apiKeyService := newTestAPIKeyService(fakeAPIKeyRepo{
+		getByKey: func(ctx context.Context, key string) (*service.APIKey, error) {
+			return nil, errors.New("context deadline exceeded")
+		},
+	})
+
+	r := gin.New()
+	var captured *gin.Context
+	r.Use(func(c *gin.Context) { captured = c; c.Next() })
+	r.Use(APIKeyAuthWithSubscriptionGoogle(apiKeyService, nil, &config.Config{}))
+	r.GET("/v1beta/test", func(c *gin.Context) { c.JSON(200, gin.H{"ok": true}) })
+
+	req := httptest.NewRequest(http.MethodGet, "/v1beta/test", nil)
+	req.Header.Set("Authorization", "Bearer any")
+	rec := httptest.NewRecorder()
+	r.ServeHTTP(rec, req)
+
+	require.Equal(t, http.StatusInternalServerError, rec.Code)
+	require.NotNil(t, captured)
+	v, ok := captured.Get(service.OpsInternalErrorDetailKey)
+	require.True(t, ok, "ops internal-error detail key should be set on google 500")
+	s, ok := v.(string)
+	require.True(t, ok)
+	require.Contains(t, s, "context deadline exceeded")
+	require.NotContains(t, rec.Body.String(), "context deadline exceeded")
+}

--- a/backend/internal/service/ops_upstream_context.go
+++ b/backend/internal/service/ops_upstream_context.go
@@ -17,6 +17,13 @@ const (
 	OpsUpstreamErrorDetailKey  = "ops_upstream_error_detail"
 	OpsUpstreamErrorsKey       = "ops_upstream_errors"
 
+	// OpsInternalErrorDetailKey carries a sanitized, truncated detail string for
+	// internal-phase errors (cache/redis/db/context failures) that bubble up as
+	// 5xx from middleware. Distinct from upstream-* keys so dashboards don't
+	// confuse internal infra failures with provider errors. Consumed by
+	// handler/ops_error_logger.go which appends it to ops_error_logs.error_body.
+	OpsInternalErrorDetailKey = "ops_internal_error_detail"
+
 	// Best-effort capture of the current upstream request body so ops can
 	// retry the specific upstream attempt (not just the client request).
 	// This value is sanitized+trimmed before being persisted.


### PR DESCRIPTION
> **Continuation of #271** — that PR auto-closed when its `feat/*` head
> branch was renamed to `feature/*` (dev-rules `branch naming` preflight
> gate requires `feature/` not `feat/`). All code from #271 is included
> here, plus the /xj-review fixups (R-001 / R-002).

## Summary

When `apiKeyService.GetByKey()` returns a non-`ErrAPIKeyNotFound` error
(cache / Redis / Postgres / `context.Canceled` / `context.DeadlineExceeded`),
the API-key auth middleware falls through to:

```go
AbortWithError(c, 500, "INTERNAL_ERROR", "Failed to validate API key")
```

The underlying err string was discarded, so `ops_error_logs.error_body`
only held the user-facing JSON. Once the container rolled, RCA was
impossible — observed in prod triage of
`2026-05-16T12:18Z..2026-05-17T12:18Z` where 2 of these 500s landed
with no diagnostic context.

This PR adds a context-only side channel that captures a sanitized,
length-capped representation of the internal error and folds it into
`ops_error_logs.error_body` — **without** changing the response body:

- `service.OpsInternalErrorDetailKey` — new gin context key, kept
  distinct from `OpsUpstream*Key` so dashboards don't conflate infra
  failures with provider errors.
- `middleware.AbortWithErrorDetail(c, status, code, message, err)` —
  drop-in sibling of `AbortWithError`; stashes a UTF8-safe, 1024-char
  capped sanitized form of `err` on the context, then delegates.
- `middleware.abortWithGoogleErrorDetail(c, status, message, err)` —
  Google-style sibling, kept symmetric to `AbortWithErrorDetail` (was
  inlined in #271's first revision; extracted per R-002).
- `handler.appendOpsInternalErrorDetail` — invoked by
  `OpsErrorLoggerMiddleware` before enqueue. When `ErrorBody` is a JSON
  object, injects detail as a top-level `_internal_detail` field so
  downstream `service.sanitizeErrorBodyForStorage` still applies
  `redactSensitiveJSON`. Falls back to `[internal_detail] <text>`
  suffix for empty / non-JSON / JSON-array bodies (per R-001).

Callsites updated:
- `backend/internal/server/middleware/api_key_auth.go:88` (Bearer +
  `x-api-key` auth on `/v1/messages`, `/v1/chat/completions`, etc.)
- `backend/internal/server/middleware/api_key_auth_google.go:41`
  (Gemini-style auth on `/v1beta`)

## Test plan

- [x] `go test -tags=unit ./internal/server/middleware/... ./internal/handler/...`
- [x] `go test ./internal/server/middleware/... ./internal/handler/... ./internal/service/...`
- [x] `golangci-lint run`: 0 issues across touched packages
- [x] `bash scripts/preflight.sh`: PASS (newapi sentinels, web-surface
      alignment, release-skip-ci-safety, branch naming, …)
- [x] New tests cover: sanitize bounds, `AbortWithErrorDetail` key-set,
      nil-err noop, full `apiKeyAuthWithSubscription` +
      `APIKeyAuthWithSubscriptionGoogle` 500 paths (assert ops key set +
      response body does NOT leak detail), JSON-object injection (asserts
      result remains valid JSON with new field), non-JSON / JSON-array
      fallback, empty body, nil-context, nil-entry.

## Rollout / risk

- Pure backend, **no-web-impact**, no DB migration.
- New context key; no new column. Existing `error_body` is a `text`
  column already sanitized through `sanitizeErrorBodyForStorage`. The
  JSON-aware injection path keeps the body valid JSON so downstream
  `redactSensitiveJSON` still runs.
- Response payloads, status codes, and client SDKs see no change.
- Worst-case if anything in the new path panics:
  `appendOpsInternalErrorDetail` is nil-safe and only touches
  `entry.ErrorBody`. `AbortWithErrorDetail` /
  `abortWithGoogleErrorDetail` fall through to their existing siblings
  even when `internalErr == nil` or the context is detached.

🤖 Generated with [Claude Code](https://claude.com/claude-code)