### PR TITLE
fix(ops): keep upstream event Kind a clean enum (no-web-impact)

### DIFF
--- a/backend/internal/service/ops_service.go
+++ b/backend/internal/service/ops_service.go
@@ -355,13 +355,7 @@ func sanitizeOpsUpstreamErrors(entry *OpsInsertErrorLogInput) error {
 			sanitizedBody, truncated, _ := sanitizeAndTrimRequestBody([]byte(out.UpstreamRequestBody), 10*1024)
 			if sanitizedBody != "" {
 				out.UpstreamRequestBody = sanitizedBody
-				if truncated {
-					out.Kind = strings.TrimSpace(out.Kind)
-					if out.Kind == "" {
-						out.Kind = "upstream"
-					}
-					out.Kind = out.Kind + ":request_body_truncated"
-				}
+				out.RequestBodyTruncated = truncated
 			} else {
 				out.UpstreamRequestBody = ""
 			}

--- a/backend/internal/service/ops_upstream_context.go
+++ b/backend/internal/service/ops_upstream_context.go
@@ -143,7 +143,17 @@ type OpsUpstreamErrorEvent struct {
 	// Best-effort upstream response capture (sanitized+trimmed).
 	UpstreamResponseBody string `json:"upstream_response_body,omitempty"`
 
-	// Kind: http_error | request_error | retry_exhausted | failover
+	// Kind is a short categorical label set by gateway services on each
+	// upstream attempt. Common values currently emitted include:
+	// http_error, request_error, retry, retry_exhausted,
+	// retry_exhausted_failover, failover, failover_on_400, signature_error,
+	// signature_retry, signature_retry_thinking,
+	// signature_retry_tools_request_error, signature_retry_request_error,
+	// budget_constraint_error, prompt_too_long, ws_error. Storage and
+	// downstream aggregation treat it as an opaque short string; the
+	// gateway emit sites are the authoritative source. Storage metadata
+	// (e.g. body truncation) must NOT be appended onto this field — it has
+	// its own dedicated columns/booleans.
 	Kind string `json:"kind,omitempty"`
 
 	Message string `json:"message,omitempty"`

--- a/backend/internal/service/ops_upstream_context.go
+++ b/backend/internal/service/ops_upstream_context.go
@@ -135,6 +135,11 @@ type OpsUpstreamErrorEvent struct {
 	// Required for retrying a specific upstream attempt.
 	UpstreamRequestBody string `json:"upstream_request_body,omitempty"`
 
+	// RequestBodyTruncated indicates UpstreamRequestBody was truncated for
+	// storage (the stored value is smaller than the original upstream body).
+	// Kept separate from Kind so the latter stays a clean categorical enum.
+	RequestBodyTruncated bool `json:"request_body_truncated,omitempty"`
+
 	// Best-effort upstream response capture (sanitized+trimmed).
 	UpstreamResponseBody string `json:"upstream_response_body,omitempty"`
 

--- a/backend/internal/service/ops_upstream_context_test.go
+++ b/backend/internal/service/ops_upstream_context_test.go
@@ -1,7 +1,9 @@
 package service
 
 import (
+	"encoding/json"
 	"net/http/httptest"
+	"strings"
 	"testing"
 
 	"github.com/gin-gonic/gin"
@@ -91,4 +93,68 @@ func TestAppendOpsUpstreamError_UsesTLSFingerprintProfileFromContext(t *testing.
 	require.NotNil(t, raw)
 	require.Contains(t, *raw, `"tls_fingerprint_profile_id":42`)
 	require.Contains(t, *raw, `"tls_fingerprint_profile_name":"claude_cli_nodejs25_observed_candidate"`)
+}
+
+// TestSanitizeOpsUpstreamErrors_TruncatedBodyKeepsKindClean verifies that
+// the request_body_truncated marker rides on its own boolean field rather than
+// being suffixed onto Kind (which must stay a clean categorical enum so ops
+// dashboards/alerts can group "request_error" without :request_body_truncated
+// drift based purely on body size).
+func TestSanitizeOpsUpstreamErrors_TruncatedBodyKeepsKindClean(t *testing.T) {
+	// Build an upstream body large enough to exceed the 10 KB cap applied in
+	// sanitizeOpsUpstreamErrors. We embed it inside a valid JSON object so the
+	// sanitizer treats it as a JSON payload (matching the production shape).
+	largeContent := strings.Repeat("x", 20*1024)
+	body, err := json.Marshal(map[string]any{"messages": []map[string]any{{"role": "user", "content": largeContent}}})
+	require.NoError(t, err)
+
+	entry := &OpsInsertErrorLogInput{
+		UpstreamErrors: []*OpsUpstreamErrorEvent{
+			{
+				Kind:                "request_error",
+				Message:             `Post "https://api.anthropic.com/v1/messages": net/http: timeout awaiting response headers`,
+				UpstreamRequestBody: string(body),
+			},
+		},
+	}
+
+	require.NoError(t, sanitizeOpsUpstreamErrors(entry))
+	require.NotNil(t, entry.UpstreamErrorsJSON)
+
+	var got []*OpsUpstreamErrorEvent
+	require.NoError(t, json.Unmarshal([]byte(*entry.UpstreamErrorsJSON), &got))
+	require.Len(t, got, 1)
+
+	require.Equal(t, "request_error", got[0].Kind, "Kind must stay a clean enum value")
+	require.True(t, got[0].RequestBodyTruncated, "RequestBodyTruncated must be true when body exceeds storage cap")
+	require.NotEmpty(t, got[0].UpstreamRequestBody)
+	require.LessOrEqual(t, len(got[0].UpstreamRequestBody), 10*1024)
+	require.NotContains(t, *entry.UpstreamErrorsJSON, ":request_body_truncated",
+		"the truncated marker must not be suffixed onto kind")
+}
+
+// TestSanitizeOpsUpstreamErrors_SmallBodyKeepsTruncatedFalse verifies the
+// boolean is false (and omitted from JSON via omitempty) for bodies that fit.
+func TestSanitizeOpsUpstreamErrors_SmallBodyKeepsTruncatedFalse(t *testing.T) {
+	entry := &OpsInsertErrorLogInput{
+		UpstreamErrors: []*OpsUpstreamErrorEvent{
+			{
+				Kind:                "request_error",
+				Message:             "dial tcp: i/o timeout",
+				UpstreamRequestBody: `{"model":"claude-opus-4-7","stream":true}`,
+			},
+		},
+	}
+
+	require.NoError(t, sanitizeOpsUpstreamErrors(entry))
+	require.NotNil(t, entry.UpstreamErrorsJSON)
+
+	var got []*OpsUpstreamErrorEvent
+	require.NoError(t, json.Unmarshal([]byte(*entry.UpstreamErrorsJSON), &got))
+	require.Len(t, got, 1)
+
+	require.Equal(t, "request_error", got[0].Kind)
+	require.False(t, got[0].RequestBodyTruncated)
+	require.NotContains(t, *entry.UpstreamErrorsJSON, "request_body_truncated",
+		"omitempty must drop the false flag from serialized JSON")
 }

--- a/scripts/preflight.sh
+++ b/scripts/preflight.sh
@@ -275,6 +275,26 @@ else
     echo "  ok: no buffered SSE->JSON Content-Type leak antipattern"
 fi
 
+# ---- sub2api: OpsUpstreamErrorEvent.Kind suffix antipattern ----------------
+# Guards against the regression pattern that surfaced in prod ops_error_logs:
+# storage metadata (e.g. ":request_body_truncated") appended onto the
+# categorical Kind enum, splitting the same root cause into multiple buckets
+# based purely on body size. Kind must stay a clean short label; per-event
+# storage flags belong on dedicated boolean fields of OpsUpstreamErrorEvent.
+# See ops_upstream_context.go Kind comment for the contract.
+echo ""
+echo "=== sub2api: OpsUpstreamErrorEvent.Kind suffix antipattern ==="
+kind_suffix_hits=$(grep -rEn '(out|ev)\.Kind[[:space:]]*=[[:space:]]*(out|ev)\.Kind[[:space:]]*\+' \
+    backend/internal/service/ops*.go 2>/dev/null | grep -v '_test\.go' || true)
+if [ -n "$kind_suffix_hits" ]; then
+    echo "  fail: Kind enum must stay categorical — never append storage metadata."
+    echo "        Use a dedicated boolean field on OpsUpstreamErrorEvent instead."
+    echo "$kind_suffix_hits" | sed 's/^/        /'
+    errors=$((errors + 1))
+else
+    echo "  ok: no Kind enum suffix antipattern"
+fi
+
 # ---- sub2api: newapi sentinel registry --------------------------------------
 # Source of truth: scripts/newapi-sentinels.json. Verifies that every
 # load-bearing surface of the fifth platform (`newapi`) — TK companion files,


### PR DESCRIPTION
## Summary
- `sanitizeOpsUpstreamErrors` no longer suffixes `:request_body_truncated` onto `OpsUpstreamErrorEvent.Kind`. The marker now rides on a dedicated `RequestBodyTruncated bool` field (JSON `omitempty`).
- `Kind` stays a clean categorical enum (`http_error | request_error | retry_exhausted | failover`), so ops dashboards / alert grouping no longer split the same root cause into two buckets purely because the captured upstream body crossed the 10 KB storage cap.

## Why
A real prod incident surfaced this. Anthropic upstream returned no response headers within `ResponseHeaderTimeout` (default 600s = 10 min), and the resulting timeout cascaded:

```
client → tokenkey-prod (cc-us1-oauth #42) → api-us1.tokenkey.dev edge (cc-am-or-ec2-5-1-b #1) → api.anthropic.com
                ↑ http2: timeout                ↑ net/http: timeout
                kind="request_error:request_body_truncated"   kind="request_error"
                (body > 10 KB)                                (body fit)
```

Same incident, two `kind` values — purely a function of how the captured upstream body fared against the 10 KB sanitize cap. Aggregation / alerting on `kind` would miss one half of the cascade.

The truncation itself is *not* a code bug — capping captured bodies at 10 KB is intentional storage hygiene. The bug is welding that storage metadata onto the categorical error-classification field. Repo-wide grep confirmed **no consumer** read the suffix: only `ops_service.go:363` wrote it, and the frontend's `request_body_truncated` is the unrelated top-level `OpsErrorLogDetail.RequestBodyTruncated` bool.

## Changes
- `backend/internal/service/ops_upstream_context.go` — add `RequestBodyTruncated bool` field to `OpsUpstreamErrorEvent` (with `omitempty` so historical / fitting-body rows serialize identically).
- `backend/internal/service/ops_service.go` — `sanitizeOpsUpstreamErrors` sets the boolean instead of mutating `Kind`. Drops the empty-`Kind` → `"upstream"` synthesis because that path no longer needs to materialize anything.
- `backend/internal/service/ops_upstream_context_test.go` — two new tests:
  - `TestSanitizeOpsUpstreamErrors_TruncatedBodyKeepsKindClean`: 20 KB body → `Kind="request_error"`, `RequestBodyTruncated=true`, no `:request_body_truncated` substring in serialized JSON.
  - `TestSanitizeOpsUpstreamErrors_SmallBodyKeepsTruncatedFalse`: fitting body → `RequestBodyTruncated` absent from JSON via `omitempty`.

## Risk
- Low. Backend-only.
- JSON schema of `ops_error_logs.upstream_errors` gains one optional field. Historical rows are unaffected. `omitempty` keeps the unchanged-row footprint identical.
- The categorical-Kind semantics are now strictly tighter (no synthetic `:suffix`), which is the desired direction for any future ops grouping / alerting. Pre-existing dashboards reading `kind` exact-match for the four enum values keep working as before.

## Validation
- `bash scripts/preflight.sh` — PASS (sub2api checks included; explicit `no-web-impact` justification accepted by `check_web_surface_alignment`).
- `go test -tags=unit -run 'TestSanitizeOpsUpstreamErrors_|TestAppendOpsUpstreamError_|TestSafeUpstreamURL' ./internal/service/` — all pass.
- `go build ./...` — clean.
- `bash scripts/check-upstream-drift.sh` — TK in sync with `upstream/main`.

## Web surface
- `no-web-impact`: pure backend struct + sanitize path. Frontend never parsed the `:request_body_truncated` suffix; its `request_body_truncated` field belongs to the unrelated top-level `OpsErrorLogDetail`. Repo-wide grep confirmed no consumer was reading the suffix shape.