### PR TITLE
chore: refresh upstream issue cache

### DIFF
--- a/scripts/upstream-issue-triage.json
+++ b/scripts/upstream-issue-triage.json
@@ -8765,7 +8765,7 @@
       "categories": [],
       "tokenkey_status": "not_prioritized",
       "rationale": "No high-signal production-risk keywords in this pass.",
-      "updated_at": "2026-04-22T05:55:19Z"
+      "updated_at": "2026-05-18T08:06:56Z"
     },
     {
       "upstream": "Wei-Shaw/sub2api#1775",


### PR DESCRIPTION
## Summary
- Refresh `scripts/upstream-issue-triage.json` from the latest Wei-Shaw/sub2api issues.
- Update `scripts/upstream-issue-fixes.json` from current TokenKey main fact checks.
- Keep watchdog workflow/script/fact-check metadata in sync with the refreshed cache.

## Watchdog report
# Upstream Issue Watchdog Report

- Run URL: https://github.com/youxuanxue/sub2api/actions/runs/26021564946
- Repository SHA: `5a3c120de5ee77a6befcc7654031e33152b11b08`
- Generated at: `2026-05-18T08:13:55Z`
- Upstream issues scanned: `1360`
- Fact checks: `14`
- Fixed facts verified: `14`
- High/critical unresolved: `0`

## Fixed facts verified

- Wei-Shaw/sub2api#641 via None
- Wei-Shaw/sub2api#2332 via None
- Wei-Shaw/sub2api#2107 via youxuanxue/sub2api#232
- Wei-Shaw/sub2api#2159 via youxuanxue/sub2api#232
- Wei-Shaw/sub2api#2258 via youxuanxue/sub2api#232
- Wei-Shaw/sub2api#2478 via youxuanxue/sub2api#232
- Wei-Shaw/sub2api#2515 via None
- Wei-Shaw/sub2api#2506 via None
- Wei-Shaw/sub2api#2500 via None
- Wei-Shaw/sub2api#1311 via None
- Wei-Shaw/sub2api#2486 via None
- Wei-Shaw/sub2api#2363 via None
- Wei-Shaw/sub2api#2332 via None
- Wei-Shaw/sub2api#1471 via None


## Test plan
- [x] `python3 -m json.tool scripts/upstream-issue-triage.json`
- [x] `python3 -m json.tool scripts/upstream-issue-fixes.json`
- [x] `python3 -m json.tool scripts/upstream-issue-fact-checks.json`
- [x] `python3 -m py_compile scripts/upstream-issue-watchdog.py`
- [x] `python3 -m json.tool .cache/upstream-issue-watchdog/report.json`
- [x] `python3 -m json.tool .cache/upstream-issue-watchdog/agent-input.json`
