### PR TITLE
fix(workflow): skip timestamp-only upstream cache PRs

### DIFF
--- a/.github/workflows/upstream-issue-watchdog.yml
+++ b/.github/workflows/upstream-issue-watchdog.yml
@@ -126,11 +126,53 @@ jobs:
           python3 -m json.tool scripts/upstream-issue-fixes.json >/dev/null
           python3 -m json.tool .cache/upstream-issue-watchdog/report.json >/dev/null
           python3 -m json.tool .cache/upstream-issue-watchdog/agent-input.json >/dev/null
-          if git diff --quiet -- scripts/upstream-issue-triage.json scripts/upstream-issue-fixes.json; then
-            echo "cache_changed=false" >> "$GITHUB_OUTPUT"
-          else
-            echo "cache_changed=true" >> "$GITHUB_OUTPUT"
-          fi
+          python3 - <<'PY'
+          import json
+          import os
+          import subprocess
+          from pathlib import Path
+
+          def head_text(path):
+              result = subprocess.run(["git", "show", f"HEAD:{path}"], text=True, capture_output=True)
+              return result.stdout if result.returncode == 0 else None
+
+          def scrub_updated_at(value):
+              if isinstance(value, dict):
+                  return {key: scrub_updated_at(item) for key, item in value.items() if key != "updated_at"}
+              if isinstance(value, list):
+                  return [scrub_updated_at(item) for item in value]
+              return value
+
+          def json_changed(path, normalizer=lambda value: value):
+              before = head_text(path)
+              if before is None:
+                  return True
+              after = Path(path).read_text(encoding="utf-8")
+              return normalizer(json.loads(before)) != normalizer(json.loads(after))
+
+          changed_paths = []
+          if json_changed("scripts/upstream-issue-triage.json", scrub_updated_at):
+              changed_paths.append("scripts/upstream-issue-triage.json")
+          if json_changed("scripts/upstream-issue-fixes.json"):
+              changed_paths.append("scripts/upstream-issue-fixes.json")
+
+          raw_changed = subprocess.run([
+              "git",
+              "diff",
+              "--quiet",
+              "--",
+              "scripts/upstream-issue-triage.json",
+              "scripts/upstream-issue-fixes.json",
+          ]).returncode != 0
+          if raw_changed and not changed_paths:
+              print("Only upstream issue updated_at timestamps changed; skipping cache PR.")
+
+          cache_changed = "true" if changed_paths else "false"
+          print(f"substantive_cache_changed={cache_changed}")
+          with open(os.environ["GITHUB_OUTPUT"], "a", encoding="utf-8") as output:
+              output.write(f"cache_changed={cache_changed}\n")
+              output.write(f"cache_changed_paths={','.join(changed_paths)}\n")
+          PY
 
       - name: Open, update, or close tracking issues
         env:
@@ -237,6 +279,12 @@ jobs:
         run: |
           set -euo pipefail
           echo "cache_pr_url=" >> "$GITHUB_OUTPUT"
+          if [ "${{ steps.watchdog.outputs.cache_changed }}" != "true" ]; then
+            if git diff --quiet -- scripts/upstream-issue-triage-generate.py scripts/upstream-issue-fact-checks.json scripts/upstream-issue-watchdog.py .github/workflows/upstream-issue-watchdog.yml; then
+              echo "No substantive upstream issue cache changes to propose."
+              exit 0
+            fi
+          fi
           if git diff --quiet -- scripts/upstream-issue-triage-generate.py scripts/upstream-issue-triage.json scripts/upstream-issue-fixes.json scripts/upstream-issue-fact-checks.json scripts/upstream-issue-watchdog.py .github/workflows/upstream-issue-watchdog.yml; then
             echo "No upstream issue cache changes to propose."
             exit 0


### PR DESCRIPTION
## Summary
- Treat upstream issue cache changes as substantive only when triage data changes after ignoring `issues[].updated_at`.
- Skip creating/updating `chore/upstream-issue-cache` PRs when GitHub issue timestamp churn is the only diff.
- Preserve normal PR creation for workflow/script/fact-check/fixes changes.

## Test plan
- [x] `python3 -m py_compile scripts/upstream-issue-triage-generate.py scripts/upstream-issue-watchdog.py`
- [x] `python3 -m json.tool scripts/upstream-issue-triage.json`
- [x] `python3 -m json.tool scripts/upstream-issue-fixes.json`
- [x] `python3 -m json.tool scripts/upstream-issue-fact-checks.json`
- [x] YAML parse check for `.github/workflows/upstream-issue-watchdog.yml`
- [x] `bash scripts/preflight.sh`

🤖 Generated with [Claude Code](https://claude.com/claude-code)