### PR TITLE
fix(smoke): raise gemini probe max_tokens to fit reasoning models (no-web-impact)

### DIFF
--- a/scripts/tk_post_deploy_smoke.sh
+++ b/scripts/tk_post_deploy_smoke.sh
@@ -260,11 +260,21 @@ if [[ -n "${GEMINI_KEY}" ]]; then
   gemini_suffix="$(printf '%s' "${GEMINI_KEY}" | tail -c 4)"
   echo "tk_post_deploy_smoke: gemini_key_hint=${gemini_prefix}…${gemini_suffix} gemini_model=${GEMINI_MODEL}"
 
+  # max_tokens budget covers BOTH reasoning/thinking tokens AND visible
+  # content for Gemini reasoning models (e.g. gemini-3.1-pro-preview).
+  # The original 96-token budget was sized for non-reasoning Gemini models
+  # and is fully consumed by thinking on reasoning models, producing a
+  # legal upstream `finishReason: MAX_TOKENS` with content=[] — which the
+  # HTTP-200 shape guard below then treats as a hard fail. 2048 gives the
+  # model enough budget to finish thinking AND emit a short sentence, so
+  # the content_count>=1 guard remains meaningful. A schema-cleanup
+  # regression (the bug this section guards) would surface as upstream
+  # 400 long before this token budget matters.
   gpayload="$(jq -n \
     --arg m "${GEMINI_MODEL}" \
     '{
       model: $m,
-      max_tokens: 96,
+      max_tokens: 2048,
       messages: [{role:"user",content:"Reply with one short sentence."}],
       tools: [{
         name: "tk_smoke_schema_probe",


### PR DESCRIPTION
## Summary

- Bump `POST_DEPLOY_SMOKE_GEMINI` probe `max_tokens` `96 → 2048` so reasoning-capable Gemini models (`gemini-3.1-pro-preview` and similar) have budget for thinking tokens **and** a one-sentence reply.
- Pure smoke-script change. No backend / frontend impact. `no-web-impact` declared per project rule.

## Why

Production post-deploy smoke for v1.7.37 surfaced:

```
POST .../v1/messages (gemini, with tools) -> HTTP 200
shape invalid (type=message role=assistant content=0)
stop_reason="max_tokens"
→ exit 1
```

This is **not** a TK regression. Verified `git log v1.7.36..v1.7.37 -- backend/internal/service/gemini_messages_compat_service.go` is empty — the bridge mapping `MAX_TOKENS → stop_reason="max_tokens"` is unchanged.

Root cause is upstream model behavior:

1. `scripts/tk_post_deploy_smoke.sh:267` hard-coded `max_tokens: 96` (PR #121, 2026-05-06 — sized for non-reasoning Gemini).
2. `gemini-3.1-pro-preview` is reasoning-capable; thinking tokens count against `max_tokens`. The 96-token budget is consumed entirely by thinking before any visible content is emitted.
3. Upstream legally returns `finishReason: MAX_TOKENS`; TK bridge maps to `stop_reason="max_tokens"` with `content=[]` (`gemini_messages_compat_service.go:3149-3157`).
4. The HTTP-200 shape guard at `tk_post_deploy_smoke.sh:302-305` treats `content.length < 1` as a hard fail → blocks deploys on a non-regression.

## Why raise max_tokens (not change to soft-warn)

A schema-cleanup regression — the contract this section guards (PR #121) — surfaces as upstream HTTP **400**, caught unchanged by the 400 branch at `tk_post_deploy_smoke.sh:311-314`. By the time a request reaches the HTTP-200 branch, the schema cleanup has already been validated end-to-end.

Raising `max_tokens` keeps the `content_count >= 1` guard meaningful (still catches the "upstream 200 but response truncated to fully empty" anti-shape), where switching to soft-warn would silently swallow that class of issue.

## Test plan

- [x] `bash -n scripts/tk_post_deploy_smoke.sh` — syntax OK
- [x] `bash scripts/preflight.sh` — PASS (includes `post-deploy smoke script syntax` check)
- [ ] Reviewer confirm raising to 2048 is sufficient headroom for the reasoning models we currently smoke (`gemini-3.1-pro-preview` and any future probes); operators can override by editing the script if a future model needs even more.
- [ ] Next prod release smoke run confirms HTTP-200 branch passes with `content >= 1` against `gemini-3.1-pro-preview`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)