### PR TITLE
fix(billing): honor group image price overrides when ImageSize is empty (no-web-impact)

### DIFF
--- a/backend/internal/service/billing_service.go
+++ b/backend/internal/service/billing_service.go
@@ -836,9 +836,22 @@ func (s *BillingService) CalculateImageCost(model string, imageSize string, imag
 
 // getImageUnitPrice 获取图片单价
 func (s *BillingService) getImageUnitPrice(model string, imageSize string, groupConfig *ImagePriceConfig) float64 {
+	// TK: See upstream Wei-Shaw/sub2api#2539 — when imageSize reaches the billing
+	// layer empty (some image-generation paths set ForwardResult.ImageCount > 0
+	// but never thread ImageSize through, e.g. the /v1/images/generations
+	// forwardOpenAIV1JSON path that returns OpenAIForwardResult{ImageCount:...}
+	// without ImageSize). Treat empty as "2K" so the group's configured image
+	// pricing is still applied — this matches normalizeOpenAIImageSizeTier's
+	// behavior for empty/"auto" inputs and prevents group overrides from being
+	// silently dropped in favor of the default LiteLLM price.
+	effectiveSize := imageSize
+	if effectiveSize == "" {
+		effectiveSize = "2K"
+	}
+
 	// 优先使用分组配置的价格
 	if groupConfig != nil {
-		switch imageSize {
+		switch effectiveSize {
 		case "1K":
 			if groupConfig.Price1K != nil {
 				return *groupConfig.Price1K
@@ -854,7 +867,8 @@ func (s *BillingService) getImageUnitPrice(model string, imageSize string, group
 		}
 	}
 
-	// 回退到 LiteLLM 默认价格
+	// 回退到 LiteLLM 默认价格 — 仍传原始 imageSize，避免改变没有 group 覆写时
+	// 现有的"未知/空 size 走 base price"默认行为（与 #2539 修复范围分离）。
 	return s.getDefaultImagePrice(model, imageSize)
 }
 

--- a/backend/internal/service/billing_service_tk_image_size_fallback_test.go
+++ b/backend/internal/service/billing_service_tk_image_size_fallback_test.go
@@ -1,0 +1,141 @@
+//go:build unit
+
+package service
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/require"
+)
+
+// TK: See upstream Wei-Shaw/sub2api#2539 — these tests pin the fallback that
+// keeps group image pricing honored when the upstream pipeline leaves
+// ForwardResult.ImageSize empty (e.g. the /v1/images/generations
+// forwardOpenAIV1JSON path that sets ImageCount but never ImageSize, or any
+// /responses image_generation path where the resolved size tier did not make
+// it onto the result). Without this fallback, billing silently falls back to
+// the hardcoded LiteLLM default price ($0.134) even though the group has
+// explicitly configured image_price_1k / image_price_2k / image_price_4k.
+
+// TestGetImageUnitPrice_EmptySize_UsesGroup2KPrice locks the core #2539 fix:
+// when imageSize is empty and the group configured Price2K, billing applies
+// the group's 2K override (matching normalizeOpenAIImageSizeTier's empty→2K
+// behavior elsewhere in the pipeline).
+func TestGetImageUnitPrice_EmptySize_UsesGroup2KPrice(t *testing.T) {
+	svc := &BillingService{}
+
+	price2K := 0.50
+	groupConfig := &ImagePriceConfig{
+		Price2K: &price2K,
+	}
+
+	cost := svc.CalculateImageCost("gpt-image-2", "", 1, groupConfig, 1.0)
+	require.InDelta(t, 0.50, cost.TotalCost, 0.0001,
+		"empty imageSize must apply group Price2K override, not fall back to default")
+	require.InDelta(t, 0.50, cost.ActualCost, 0.0001)
+}
+
+// TestGetImageUnitPrice_EmptySize_FullGroupConfig_UsesGroup2KPrice covers the
+// realistic case where the group configured every tier: empty size must still
+// pick 2K (not 1K or 4K), matching the normalize-to-2K convention.
+func TestGetImageUnitPrice_EmptySize_FullGroupConfig_UsesGroup2KPrice(t *testing.T) {
+	svc := &BillingService{}
+
+	price1K := 0.30
+	price2K := 0.50
+	price4K := 1.00
+	groupConfig := &ImagePriceConfig{
+		Price1K: &price1K,
+		Price2K: &price2K,
+		Price4K: &price4K,
+	}
+
+	cost := svc.CalculateImageCost("gpt-image-2", "", 1, groupConfig, 1.0)
+	require.InDelta(t, 0.50, cost.TotalCost, 0.0001,
+		"empty imageSize must select the 2K tier from a fully-configured group")
+}
+
+// TestGetImageUnitPrice_EmptySize_GroupHasNo2K_FallsBackToDefault keeps the
+// "no 2K override" case unchanged: empty size still falls through to the
+// default LiteLLM price (basePrice without 1.5x multiplier) so groups that
+// only configured 1K/4K are not surprised by a synthetic 2K bill.
+func TestGetImageUnitPrice_EmptySize_GroupHasNo2K_FallsBackToDefault(t *testing.T) {
+	svc := &BillingService{}
+
+	price1K := 0.30
+	price4K := 1.00
+	groupConfig := &ImagePriceConfig{
+		Price1K: &price1K,
+		Price4K: &price4K,
+	}
+
+	cost := svc.CalculateImageCost("gemini-3-pro-image", "", 1, groupConfig, 1.0)
+	require.InDelta(t, 0.134, cost.TotalCost, 0.0001,
+		"empty imageSize with no Price2K override must fall through to base default ($0.134)")
+}
+
+// TestGetImageUnitPrice_EmptySize_NoGroupConfig_PreservesDefault is the
+// regression guard: when no group config exists at all, empty imageSize still
+// returns the bare base price (not basePrice*1.5). This isolates the #2539 fix
+// to the group-override path and avoids silently raising prices for
+// ungrouped traffic.
+func TestGetImageUnitPrice_EmptySize_NoGroupConfig_PreservesDefault(t *testing.T) {
+	svc := &BillingService{}
+
+	cost := svc.CalculateImageCost("gemini-3-pro-image", "", 1, nil, 1.0)
+	require.InDelta(t, 0.134, cost.TotalCost, 0.0001,
+		"empty imageSize without group config must preserve historical base-price behavior")
+}
+
+// TestGetImageUnitPrice_KnownSizes_StillRespectGroupOverrides is a regression
+// guard so the empty-size fallback does not accidentally override the explicit
+// 1K / 2K / 4K paths.
+func TestGetImageUnitPrice_KnownSizes_StillRespectGroupOverrides(t *testing.T) {
+	svc := &BillingService{}
+
+	price1K := 0.30
+	price2K := 0.50
+	price4K := 1.00
+	groupConfig := &ImagePriceConfig{
+		Price1K: &price1K,
+		Price2K: &price2K,
+		Price4K: &price4K,
+	}
+
+	cost := svc.CalculateImageCost("gpt-image-2", "1K", 1, groupConfig, 1.0)
+	require.InDelta(t, 0.30, cost.TotalCost, 0.0001)
+
+	cost = svc.CalculateImageCost("gpt-image-2", "2K", 1, groupConfig, 1.0)
+	require.InDelta(t, 0.50, cost.TotalCost, 0.0001)
+
+	cost = svc.CalculateImageCost("gpt-image-2", "4K", 1, groupConfig, 1.0)
+	require.InDelta(t, 1.00, cost.TotalCost, 0.0001)
+}
+
+// TestCalculateImageCost_Issue2539_Repro reproduces the exact scenario from
+// upstream Wei-Shaw/sub2api#2539: a group has image_price_1k/2k/4k
+// configured, the request is image-billed (ImageCount > 0), but ImageSize
+// arrives empty because the gateway path did not thread it through. Pre-fix
+// behavior charged $0.134 (the default); post-fix charges $0.50 (group 2K).
+func TestCalculateImageCost_Issue2539_Repro(t *testing.T) {
+	svc := &BillingService{}
+
+	price1K := 0.30
+	price2K := 0.50
+	price4K := 1.00
+	groupConfig := &ImagePriceConfig{
+		Price1K: &price1K,
+		Price2K: &price2K,
+		Price4K: &price4K,
+	}
+
+	// 1 image, empty size — reproduces FourPrism's usage_logs row shape:
+	//   billing_mode = image
+	//   image_count  = 1
+	//   image_size   = ''
+	cost := svc.CalculateImageCost("gpt-image-2", "", 1, groupConfig, 1.0)
+
+	require.InDelta(t, 0.50, cost.ActualCost, 0.0001,
+		"#2539: empty image_size with group image pricing must NOT fall back to default $0.134")
+	require.Equal(t, string(BillingModeImage), cost.BillingMode)
+}

--- a/scripts/gateway-tk-sentinels.json
+++ b/scripts/gateway-tk-sentinels.json
@@ -356,6 +356,24 @@
         "stream_timeout"
       ],
       "rationale": "Focused regression anchors for upstream #1471 covering both sendErrorEvent triggers that share the closure: synchronous scanner error path (stream_read_error) and asynchronous interval-timeout path (stream_timeout). Each asserts every SSE event in the post-error transcript carries exactly one parseable-JSON data line. Together they prove the prepended-blank-line invariant holds for both the bufio.Scanner sync path and the goroutine async path that read from upstream."
+    },
+    {
+      "path": "backend/internal/service/billing_service.go",
+      "must_contain": [
+        "See upstream Wei-Shaw/sub2api#2539",
+        "effectiveSize := imageSize",
+        "if effectiveSize == \"\""
+      ],
+      "rationale": "Image-billing fallback for upstream #2539. getImageUnitPrice MUST normalize empty imageSize to \"2K\" before group-config lookup so configured group image_price_1k/2k/4k overrides are honored when the gateway pipeline leaves ForwardResult.ImageSize empty (the /v1/images/generations forwardOpenAIV1JSON path is the documented offender — it sets ImageCount but never threads ImageSize through). Dropping these literals reintroduces the upstream bug where billing silently falls back to the LiteLLM default ($0.134) and drops group pricing on the floor — a real revenue-accuracy regression, not a display issue."
+    },
+    {
+      "path": "backend/internal/service/billing_service_tk_image_size_fallback_test.go",
+      "must_contain": [
+        "TestGetImageUnitPrice_EmptySize_UsesGroup2KPrice",
+        "TestGetImageUnitPrice_EmptySize_NoGroupConfig_PreservesDefault",
+        "TestCalculateImageCost_Issue2539_Repro"
+      ],
+      "rationale": "Focused regression anchors for upstream #2539 covering the three load-bearing shapes: (a) empty imageSize WITH group Price2K override must apply the group price (the core fix), (b) empty imageSize WITHOUT any group config must preserve the historical base-price default (the no-regression boundary), and (c) the explicit FourPrism repro shape (billing_mode=image, image_count=1, image_size=''). Without all three, future refactors can silently reintroduce the bug because the negative case (no group config) and the positive case (group override applied) test different code paths through the same function."
     }
   ]
 }

--- a/scripts/upstream-issue-fact-checks.json
+++ b/scripts/upstream-issue-fact-checks.json
@@ -221,6 +221,23 @@
         "backend/internal/service/openai_gateway_service.go:bufferedWriter.WriteString(\"\\ndata: \" + payload + \"\\n\\n\")",
         "backend/internal/service/openai_gateway_service_tk_stream_read_error_sse_test.go:TestOpenAIStreamingStreamReadErrorEmitsSeparateSSEEvents"
       ]
+    },
+    {
+      "upstream": "Wei-Shaw/sub2api#2539",
+      "severity": "high",
+      "summary": "Image billing no longer silently drops configured group image_price_1k/2k/4k overrides when the upstream pipeline leaves ForwardResult.ImageSize empty. getImageUnitPrice now normalizes empty imageSize to \"2K\" before group-config lookup (mirroring normalizeOpenAIImageSizeTier's empty→2K convention), so group overrides survive paths that set ImageCount but never thread ImageSize through (e.g. /v1/images/generations forwardOpenAIV1JSON). Falls back to the original default price when the group has no Price2K — keeps the no-group case bit-identical to historical behavior.",
+      "fixed_by": [
+        "backend/internal/service/billing_service.go",
+        "backend/internal/service/billing_service_tk_image_size_fallback_test.go"
+      ],
+      "fixed_if_all_present": [
+        "backend/internal/service/billing_service.go:See upstream Wei-Shaw/sub2api#2539",
+        "backend/internal/service/billing_service.go:effectiveSize := imageSize",
+        "backend/internal/service/billing_service.go:if effectiveSize == \"\" {",
+        "backend/internal/service/billing_service_tk_image_size_fallback_test.go:TestGetImageUnitPrice_EmptySize_UsesGroup2KPrice",
+        "backend/internal/service/billing_service_tk_image_size_fallback_test.go:TestGetImageUnitPrice_EmptySize_NoGroupConfig_PreservesDefault",
+        "backend/internal/service/billing_service_tk_image_size_fallback_test.go:TestCalculateImageCost_Issue2539_Repro"
+      ]
     }
   ]
 }

--- a/scripts/upstream-issue-fixes.json
+++ b/scripts/upstream-issue-fixes.json
@@ -268,6 +268,15 @@
         "backend/internal/service/openai_gateway_service_tk_stream_read_error_sse_test.go"
       ],
       "summary": "OpenAI /v1/responses sendErrorEvent now prepends a blank line before the synthetic data: line, so any in-flight upstream SSE event whose terminating blank line was never sent is closed before the synthetic event is written. Without this, the unterminated `data:` line and the synthetic `data:` line merge into a single SSE event whose payload contains two concatenated JSON objects, which downstream OpenAI-compatible SDKs (Codex, OpenCode, etc.) reject with malformed JSON."
+    },
+    {
+      "upstream": "Wei-Shaw/sub2api#2539",
+      "status": "fixed_in_tokenkey",
+      "fixed_by": [
+        "backend/internal/service/billing_service.go",
+        "backend/internal/service/billing_service_tk_image_size_fallback_test.go"
+      ],
+      "summary": "Image billing no longer silently drops configured group image_price_1k/2k/4k overrides when the upstream pipeline leaves ForwardResult.ImageSize empty. getImageUnitPrice now normalizes empty imageSize to \"2K\" before group-config lookup (mirroring normalizeOpenAIImageSizeTier's empty→2K convention), so group overrides survive paths that set ImageCount but never thread ImageSize through (e.g. /v1/images/generations forwardOpenAIV1JSON). Falls back to the original default price when the group has no Price2K — keeps the no-group case bit-identical to historical behavior."
     }
   ]
 }

--- a/scripts/upstream-issue-triage-generate.py
+++ b/scripts/upstream-issue-triage-generate.py
@@ -61,6 +61,7 @@ MANUAL_TRIAGE = {
     2506: ("fixed", "fixed_in_tokenkey", "normalizeClaudeOAuthRequestBody skips context_management auto-injection for Haiku models (mirroring the existing Haiku exemption in FullClaudeCodeMimicryBetas), so claude-haiku-4-5-* + thinking.type=enabled no longer triggers Anthropic 400."),
     2515: ("fixed", "fixed_in_tokenkey", "ChatCompletions→Responses transform no longer emits content:null when the source content array is empty or every part was filtered out — falls back to empty string per upstream Responses contract."),
     1471: ("fixed", "fixed_in_tokenkey", "OpenAI /v1/responses sendErrorEvent prepends a blank line before the synthetic error event so an in-flight upstream SSE event (data: line without terminating blank line) does not merge with the injected error event into a single event carrying two JSON objects; downstream SDK JSON parsing no longer fails."),
+    2539: ("fixed", "fixed_in_tokenkey", "Image billing no longer drops group image_price_1k/2k/4k overrides when ForwardResult.ImageSize arrives empty; getImageUnitPrice normalizes empty size to \"2K\" before group lookup (matching normalizeOpenAIImageSizeTier), so group pricing is honored on paths that set ImageCount but never thread ImageSize through. No-group case preserves historical default-price behavior."),
 }
 
 FIXED_IDS = {num for num, (impact, _, _) in MANUAL_TRIAGE.items() if impact == "fixed"}

--- a/scripts/upstream-issue-triage.json
+++ b/scripts/upstream-issue-triage.json
@@ -4,10 +4,10 @@
   "generated_from": "GitHub REST API issues?state=open; pull requests excluded",
   "rationale": "TokenKey-local triage cache for upstream open issues. Use this file before re-triaging upstream issues; update entries when TokenKey fixes, dismisses, or reclassifies an issue.",
   "counts": {
-    "needs_review": 347,
+    "needs_review": 346,
     "needs_prod_validation": 4,
     "medium": 115,
-    "fixed": 26,
+    "fixed": 27,
     "not_applicable": 1,
     "low": 94,
     "unknown_low_signal": 401
@@ -3199,19 +3199,6 @@
       "updated_at": "2026-05-18T02:19:59Z"
     },
     {
-      "upstream": "Wei-Shaw/sub2api#2539",
-      "url": "https://github.com/Wei-Shaw/sub2api/issues/2539",
-      "title": "Image billing falls back to default price when usage_logs.image_size is empty, ignoring group image price overrides",
-      "impact": "needs_review",
-      "categories": [
-        "billing_usage",
-        "image_oauth"
-      ],
-      "tokenkey_status": "candidate_unverified",
-      "rationale": "Keyword match for production-sensitive area; not yet manually verified against TokenKey code.",
-      "updated_at": "2026-05-17T16:20:43Z"
-    },
-    {
       "upstream": "Wei-Shaw/sub2api#2540",
       "url": "https://github.com/Wei-Shaw/sub2api/issues/2540",
       "title": "生图问题",
@@ -6137,6 +6124,19 @@
       "tokenkey_status": "fixed_in_tokenkey",
       "rationale": "ChatCompletions→Responses transform falls back to empty string when the converted parts list is empty (was emitting JSON null and triggering upstream HTTP 400 on gpt-5.5).",
       "updated_at": "2026-05-16T12:51:29Z"
+    },
+    {
+      "upstream": "Wei-Shaw/sub2api#2539",
+      "url": "https://github.com/Wei-Shaw/sub2api/issues/2539",
+      "title": "Image billing falls back to default price when usage_logs.image_size is empty, ignoring group image price overrides",
+      "impact": "fixed",
+      "categories": [
+        "billing_usage",
+        "image_oauth"
+      ],
+      "tokenkey_status": "fixed_in_tokenkey",
+      "rationale": "Image billing no longer silently drops configured group image_price_1k/2k/4k overrides when the upstream pipeline leaves ForwardResult.ImageSize empty. getImageUnitPrice now normalizes empty imageSize to \"2K\" before group-config lookup (mirroring normalizeOpenAIImageSizeTier's empty→2K convention), so group overrides survive paths that set ImageCount but never thread ImageSize through (e.g. /v1/images/generations forwardOpenAIV1JSON). Falls back to the original default price when the group has no Price2K — keeps the no-group case bit-identical to historical behavior.",
+      "updated_at": "2026-05-17T16:20:43Z"
     },
     {
       "upstream": "Wei-Shaw/sub2api#580",


### PR DESCRIPTION
## Summary

Fixes upstream [Wei-Shaw/sub2api#2539](https://github.com/Wei-Shaw/sub2api/issues/2539) — image billing silently dropped configured group `image_price_1k/2k/4k` overrides when the gateway pipeline left `ForwardResult.ImageSize` empty, falling back to the hardcoded LiteLLM default (`$0.134`) instead of the group's configured tier. This is a real revenue-accuracy regression, not a display bug: a user with `image_price_2k = 0.30` configured was charged `0.134` per image because the upstream selector skipped the group switch entirely when `imageSize == ""`.

The fix is localized at the billing layer (`getImageUnitPrice`) rather than chasing every upstream path that forgets to thread `ImageSize` through:

- Normalize empty `imageSize` to `"2K"` before the group-config lookup, mirroring `normalizeOpenAIImageSizeTier`'s empty/`"auto"`→2K convention used everywhere else in the OpenAI image pipeline.
- Fall through to the original `getDefaultImagePrice(model, imageSize)` (with the **unchanged** original size) when the group has no `Price2K` override — preserves the no-group / partial-config behavior bit-identically.
- One offender that produces empty `ImageSize` today: the `/v1/images/generations` `forwardOpenAIV1JSON` path returns `OpenAIForwardResult{ImageCount: usage.imageCount, ...}` without setting `ImageSize`. Anchoring at the billing layer covers that path and any future path with the same shape.

Bug repro shape (from FourPrism's issue):

```
billing_mode = image
image_count  = 1
image_size   = ''     ← empty
actual_cost  = 0.134  ← LiteLLM default, group price ignored
```

After fix: `actual_cost = $group.image_price_2k` (or default if no Price2K configured).

## Files

- [backend/internal/service/billing_service.go](backend/internal/service/billing_service.go) — `getImageUnitPrice` normalize-empty-to-2K
- [backend/internal/service/billing_service_tk_image_size_fallback_test.go](backend/internal/service/billing_service_tk_image_size_fallback_test.go) — TK regression tests (6 cases)
- [scripts/upstream-issue-fixes.json](scripts/upstream-issue-fixes.json) — registers #2539 as `fixed_in_tokenkey`
- [scripts/upstream-issue-fact-checks.json](scripts/upstream-issue-fact-checks.json) — fact-check entry so the upstream-issue watchdog reclassifies #2539 from `needs_review` to `fixed` only while the sentinel literals remain
- [scripts/gateway-tk-sentinels.json](scripts/gateway-tk-sentinels.json) — adds 2 sentinels under the gateway-tk registry so preflight's sentinel-registry gate protects the fix from silent upstream-merge reversion (rule §5.x)
- [scripts/upstream-issue-triage-generate.py](scripts/upstream-issue-triage-generate.py) + [scripts/upstream-issue-triage.json](scripts/upstream-issue-triage.json) — manual triage entry + cache update

## Test plan

- [x] `go test -tags=unit ./internal/service/ -count=1` — full service unit tests pass (91s)
- [x] `go test -tags=unit -run 'TestCalculateImageCost|TestGetImageUnitPrice|TestGetDefaultImagePrice|TestCalculateImageCost_Issue2539_Repro' ./internal/service/` — billing image-cost tests pass
- [x] `bash scripts/preflight.sh` — all checks pass (branch naming, dev-rules submodule, sentinel registry update gate, web-surface alignment, etc.)
- [x] `go vet ./internal/service/` — clean
- [x] `golangci-lint run --new-from-rev=HEAD~ ./internal/service/...` — `0 issues.`
- [x] `python3 scripts/upstream-issue-watchdog.py ...` — fact-check verifies all 15 entries including `Wei-Shaw/sub2api#2539`
- [ ] CI green on all required checks

## Notes

- `no-web-impact`: pure backend billing-layer fix + scripts; no frontend / API contract changes.
- Per rule §5: the upstream-owned `billing_service.go` change is a thin localized injection (one `if` + 3 lines of `effectiveSize` normalization + comment block referencing the upstream issue); all test logic lives in the new TK companion test file.
- Per rule §5.x: this is an **override default behavior** fix, not a deletion of upstream symbols.
- Drift check: `bash scripts/check-upstream-drift.sh` — synced.

🤖 Generated with [Claude Code](https://claude.com/claude-code)