### PR TITLE
fix(scheduler): rebuild snapshot when rate-limit cooldown expires (no-web-impact)

### DIFF
--- a/backend/cmd/server/wire.go
+++ b/backend/cmd/server/wire.go
@@ -81,6 +81,9 @@ func provideCleanup(
 	opsScheduledReport *service.OpsScheduledReportService,
 	opsSystemLogSink *service.OpsSystemLogSink,
 	schedulerSnapshot *service.SchedulerSnapshotService,
+	// TK fix for upstream Wei-Shaw/sub2api#2538 — see
+	// internal/service/scheduler_rate_limit_reaper.go.
+	schedulerRateLimitReaper *service.SchedulerRateLimitReaper,
 	tokenRefresh *service.TokenRefreshService,
 	accountExpiry *service.AccountExpiryService,
 	subscriptionExpiry *service.SubscriptionExpiryService,
@@ -166,6 +169,14 @@ func provideCleanup(
 			{"SchedulerSnapshotService", func() error {
 				if schedulerSnapshot != nil {
 					schedulerSnapshot.Stop()
+				}
+				return nil
+			}},
+			// TK fix for upstream Wei-Shaw/sub2api#2538 — see
+			// internal/service/scheduler_rate_limit_reaper.go.
+			{"SchedulerRateLimitReaper", func() error {
+				if schedulerRateLimitReaper != nil {
+					schedulerRateLimitReaper.Stop()
 				}
 				return nil
 			}},

--- a/backend/cmd/server/wire_gen.go
+++ b/backend/cmd/server/wire_gen.go
@@ -274,6 +274,8 @@ func initializeApplication(buildInfo handler.BuildInfo) (*Application, error) {
 	opsAlertEvaluatorService := service.ProvideOpsAlertEvaluatorService(opsService, opsRepository, emailService, redisClient, configConfig)
 	opsCleanupService := service.ProvideOpsCleanupService(opsRepository, db, redisClient, configConfig, channelMonitorService, settingRepository, opsService)
 	opsScheduledReportService := service.ProvideOpsScheduledReportService(opsService, userService, emailService, redisClient, configConfig)
+	rateLimitExpiryRepository := repository.NewRateLimitExpiryRepository(db)
+	schedulerRateLimitReaper := service.ProvideSchedulerRateLimitReaper(rateLimitExpiryRepository, configConfig)
 	tokenRefreshService := service.ProvideTokenRefreshService(accountRepository, oAuthService, openAIOAuthService, geminiOAuthService, antigravityOAuthService, compositeTokenCacheInvalidator, schedulerCache, configConfig, tempUnschedCache, privacyClientFactory, proxyRepository, oAuthRefreshAPI)
 	accountExpiryService := service.ProvideAccountExpiryService(accountRepository)
 	subscriptionExpiryService := service.ProvideSubscriptionExpiryService(userSubscriptionRepository)
@@ -284,7 +286,7 @@ func initializeApplication(buildInfo handler.BuildInfo) (*Application, error) {
 	tkGatewayPricingAvailabilityReady := service.ProvideTKGatewayPricingAvailability(gatewayService, pricingAvailabilityService)
 	modelListFilter := service.NewModelListFilter(pricingCatalogService, pricingAvailabilityService)
 	tkGatewayHandlerModelListReady := handler.ProvideTKGatewayHandlerModelList(gatewayHandler, modelListFilter)
-	v := provideCleanup(client, redisClient, opsMetricsCollector, opsAggregationService, opsAlertEvaluatorService, opsCleanupService, opsScheduledReportService, opsSystemLogSink, schedulerSnapshotService, tokenRefreshService, accountExpiryService, subscriptionExpiryService, usageCleanupService, idempotencyCleanupService, pricingService, emailQueueService, billingCacheService, usageRecordWorkerPool, qaService, subscriptionService, oAuthService, openAIOAuthService, geminiOAuthService, antigravityOAuthService, openAIGatewayService, scheduledTestRunnerService, backupService, paymentOrderExpiryService, channelMonitorRunner, tkAuthServiceColdStartReady, tkGatewayPricingAvailabilityReady, tkGatewayHandlerModelListReady)
+	v := provideCleanup(client, redisClient, opsMetricsCollector, opsAggregationService, opsAlertEvaluatorService, opsCleanupService, opsScheduledReportService, opsSystemLogSink, schedulerSnapshotService, schedulerRateLimitReaper, tokenRefreshService, accountExpiryService, subscriptionExpiryService, usageCleanupService, idempotencyCleanupService, pricingService, emailQueueService, billingCacheService, usageRecordWorkerPool, qaService, subscriptionService, oAuthService, openAIOAuthService, geminiOAuthService, antigravityOAuthService, openAIGatewayService, scheduledTestRunnerService, backupService, paymentOrderExpiryService, channelMonitorRunner, tkAuthServiceColdStartReady, tkGatewayPricingAvailabilityReady, tkGatewayHandlerModelListReady)
 	application := &Application{
 		Server:  httpServer,
 		Cleanup: v,
@@ -320,6 +322,8 @@ func provideCleanup(
 	opsScheduledReport *service.OpsScheduledReportService,
 	opsSystemLogSink *service.OpsSystemLogSink,
 	schedulerSnapshot *service.SchedulerSnapshotService,
+
+	schedulerRateLimitReaper *service.SchedulerRateLimitReaper,
 	tokenRefresh *service.TokenRefreshService,
 	accountExpiry *service.AccountExpiryService,
 	subscriptionExpiry *service.SubscriptionExpiryService,
@@ -396,6 +400,13 @@ func provideCleanup(
 			{"SchedulerSnapshotService", func() error {
 				if schedulerSnapshot != nil {
 					schedulerSnapshot.Stop()
+				}
+				return nil
+			}},
+
+			{"SchedulerRateLimitReaper", func() error {
+				if schedulerRateLimitReaper != nil {
+					schedulerRateLimitReaper.Stop()
 				}
 				return nil
 			}},

--- a/backend/cmd/server/wire_gen_test.go
+++ b/backend/cmd/server/wire_gen_test.go
@@ -46,6 +46,10 @@ func TestProvideCleanup_WithMinimalDependencies_NoPanic(t *testing.T) {
 	billingCacheSvc := service.NewBillingCacheService(nil, nil, nil, nil, nil, nil, cfg)
 	idempotencyCleanupSvc := service.NewIdempotencyCleanupService(nil, cfg)
 	schedulerSnapshotSvc := service.NewSchedulerSnapshotService(nil, nil, nil, nil, cfg)
+	// TK fix for upstream Wei-Shaw/sub2api#2538: nil repo makes Start() a no-op
+	// so this test does not spin a goroutine even though provideCleanup wires
+	// the Stop() call.
+	schedulerRateLimitReaperSvc := service.NewSchedulerRateLimitReaper(nil, cfg)
 	opsSystemLogSinkSvc := service.NewOpsSystemLogSink(nil)
 
 	cleanup := provideCleanup(
@@ -58,6 +62,7 @@ func TestProvideCleanup_WithMinimalDependencies_NoPanic(t *testing.T) {
 		&service.OpsScheduledReportService{},
 		opsSystemLogSinkSvc,
 		schedulerSnapshotSvc,
+		schedulerRateLimitReaperSvc,
 		tokenRefreshSvc,
 		accountExpirySvc,
 		subscriptionExpirySvc,

--- a/backend/internal/config/config.go
+++ b/backend/internal/config/config.go
@@ -994,6 +994,18 @@ type GatewaySchedulingConfig struct {
 	// 全量重建周期配置
 	// 全量重建周期（秒），0 表示禁用
 	FullRebuildIntervalSeconds int `mapstructure:"full_rebuild_interval_seconds"`
+
+	// RateLimitReaperIntervalSeconds 限流过期回收 reaper 周期（秒）。
+	// TK fix for upstream Wei-Shaw/sub2api#2538：账号 429 后调度快照会立即剔除该账号，
+	// 但限流过期时没有事件触发重建，账号最长要等到下一个 full_rebuild_interval_seconds tick
+	// 才回到快照（默认 5 分钟）。Reaper 周期性查询刚过期的账号并入 outbox account_changed
+	// 事件，让现有 outbox worker 自然完成重建。<0 禁用；0 使用默认 5 秒。
+	RateLimitReaperIntervalSeconds int `mapstructure:"rate_limit_reaper_interval_seconds"`
+
+	// RateLimitReaperLookbackSeconds 限流回收 reaper 单次窗口回看长度（秒）。
+	// 用作首个 tick 之前 / wall-clock 跳跃后的安全窗口；正常运行时 reaper 会维护 lastTick
+	// 状态并使用 (lastTick, now] 精确扫描。0 使用默认 30 秒。
+	RateLimitReaperLookbackSeconds int `mapstructure:"rate_limit_reaper_lookback_seconds"`
 }
 
 func (s *ServerConfig) Address() string {
@@ -1793,6 +1805,9 @@ func setDefaults() {
 	viper.SetDefault("gateway.scheduling.outbox_lag_rebuild_failures", 3)
 	viper.SetDefault("gateway.scheduling.outbox_backlog_rebuild_rows", 10000)
 	viper.SetDefault("gateway.scheduling.full_rebuild_interval_seconds", 300)
+	// TK fix for upstream Wei-Shaw/sub2api#2538 — see SchedulingConfig.RateLimitReaper* docs.
+	viper.SetDefault("gateway.scheduling.rate_limit_reaper_interval_seconds", 5)
+	viper.SetDefault("gateway.scheduling.rate_limit_reaper_lookback_seconds", 30)
 	viper.SetDefault("gateway.usage_record.worker_count", 128)
 	viper.SetDefault("gateway.usage_record.queue_size", 16384)
 	viper.SetDefault("gateway.usage_record.task_timeout_seconds", 5)
@@ -2636,6 +2651,13 @@ func (c *Config) Validate() error {
 	}
 	if c.Gateway.Scheduling.FullRebuildIntervalSeconds < 0 {
 		return fmt.Errorf("gateway.scheduling.full_rebuild_interval_seconds must be non-negative")
+	}
+	// TK fix for upstream Wei-Shaw/sub2api#2538: validate reaper knobs. Negative
+	// interval explicitly disables the reaper goroutine; negative lookback is a
+	// misconfiguration because the runOnce path treats lookback as a positive
+	// fallback window when wall-clock jumps forward.
+	if c.Gateway.Scheduling.RateLimitReaperLookbackSeconds < 0 {
+		return fmt.Errorf("gateway.scheduling.rate_limit_reaper_lookback_seconds must be non-negative")
 	}
 	if c.Gateway.Scheduling.OutboxLagWarnSeconds > 0 &&
 		c.Gateway.Scheduling.OutboxLagRebuildSeconds > 0 &&

--- a/backend/internal/config/config.go
+++ b/backend/internal/config/config.go
@@ -999,7 +999,8 @@ type GatewaySchedulingConfig struct {
 	// TK fix for upstream Wei-Shaw/sub2api#2538：账号 429 后调度快照会立即剔除该账号，
 	// 但限流过期时没有事件触发重建，账号最长要等到下一个 full_rebuild_interval_seconds tick
 	// 才回到快照（默认 5 分钟）。Reaper 周期性查询刚过期的账号并入 outbox account_changed
-	// 事件，让现有 outbox worker 自然完成重建。<0 禁用；0 使用默认 5 秒。
+	// 事件，让现有 outbox worker 自然完成重建。<=0 禁用 reaper goroutine（与
+	// FullRebuildIntervalSeconds 同语义）；viper.SetDefault 提供 5 秒默认。
 	RateLimitReaperIntervalSeconds int `mapstructure:"rate_limit_reaper_interval_seconds"`
 
 	// RateLimitReaperLookbackSeconds 限流回收 reaper 单次窗口回看长度（秒）。

--- a/backend/internal/repository/account_repo_tk_rate_limit_reaper.go
+++ b/backend/internal/repository/account_repo_tk_rate_limit_reaper.go
@@ -1,0 +1,85 @@
+package repository
+
+// TK: See upstream Wei-Shaw/sub2api#2538 — RateLimitExpiryRepository
+// implementation backed by a single atomic INSERT ... SELECT statement.
+//
+// Why one SQL: each tick of SchedulerRateLimitReaper must (a) find every
+// account whose `rate_limit_reset_at` falls in the (since, until] window AND
+// (b) enqueue one outbox `account_changed` event per match. Doing both in a
+// single statement avoids race conditions where an account could be selected
+// by the reaper and then have its rate limit re-set by a 429 between the
+// SELECT and the INSERT — the INSERT...SELECT lets PostgreSQL evaluate the
+// predicate atomically against committed state.
+//
+// The outbox table already has a 1-second dedup window for `account_changed`
+// events (see scheduler_outbox_repo.go::enqueueSchedulerOutbox), so reaper
+// ticks shorter than 1s are safe — duplicates get silently dropped by the
+// existing WHERE NOT EXISTS clause.
+
+import (
+	"context"
+	"database/sql"
+	"time"
+
+	"github.com/Wei-Shaw/sub2api/internal/service"
+)
+
+type rateLimitExpiryRepository struct {
+	db *sql.DB
+}
+
+// NewRateLimitExpiryRepository constructs the reaper-facing repository. The
+// implementation talks directly to the shared *sql.DB so it does not depend on
+// AccountRepository — adding a new method to that interface would force every
+// stub/mock in the codebase to grow a no-op implementation (CLAUDE.md rule 6).
+func NewRateLimitExpiryRepository(db *sql.DB) service.RateLimitExpiryRepository {
+	return &rateLimitExpiryRepository{db: db}
+}
+
+// EnqueueOutboxForJustExpiredAccounts inserts one
+// scheduler_outbox(event_type='account_changed') row per account whose
+// `rate_limit_reset_at` falls inside (since, until], excluding soft-deleted
+// rows. The outbox INSERT is bounded by the existing 1-second WHERE NOT
+// EXISTS dedup clause so concurrent reaper invocations or rapid ticks stay
+// idempotent. Returns the number of rows inserted.
+func (r *rateLimitExpiryRepository) EnqueueOutboxForJustExpiredAccounts(ctx context.Context, since, until time.Time) (int, error) {
+	if r == nil || r.db == nil {
+		return 0, nil
+	}
+	if !since.Before(until) {
+		// Defensive: never run an inverted-window query (would return zero
+		// rows but still costs a sequential scan on production-sized tables).
+		return 0, nil
+	}
+
+	// INSERT...SELECT in a single statement so the predicate evaluation and
+	// the outbox writes happen against the same MVCC snapshot. The dedup
+	// clause mirrors scheduler_outbox_repo.go::enqueueSchedulerOutbox so
+	// reaper-written events stay consistent with SetRateLimited-written
+	// events.
+	const query = `
+		INSERT INTO scheduler_outbox (event_type, account_id, group_id, payload)
+		SELECT 'account_changed', a.id, NULL, NULL
+		FROM accounts AS a
+		WHERE a.rate_limit_reset_at > $1
+		  AND a.rate_limit_reset_at <= $2
+		  AND a.deleted_at IS NULL
+		  AND NOT EXISTS (
+			SELECT 1
+			FROM scheduler_outbox AS o
+			WHERE o.event_type = 'account_changed'
+			  AND o.account_id IS NOT DISTINCT FROM a.id
+			  AND o.group_id IS NULL
+			  AND o.created_at >= NOW() - make_interval(secs => 1)
+		  )
+	`
+	res, err := r.db.ExecContext(ctx, query, since, until)
+	if err != nil {
+		return 0, err
+	}
+	affected, err := res.RowsAffected()
+	if err != nil {
+		return 0, err
+	}
+	return int(affected), nil
+}

--- a/backend/internal/repository/account_repo_tk_rate_limit_reaper_integration_test.go
+++ b/backend/internal/repository/account_repo_tk_rate_limit_reaper_integration_test.go
@@ -1,0 +1,200 @@
+//go:build integration
+
+package repository
+
+// TK: See upstream Wei-Shaw/sub2api#2538 — integration tests for the
+// reaper's SQL-side contract. These cover the three failure modes the
+// service-layer fakes cannot prove: (1) the predicate window is inclusive on
+// the right and exclusive on the left, (2) soft-deleted accounts are skipped,
+// and (3) the existing 1s outbox dedup window protects against double-enqueue
+// when consecutive reaper ticks overlap.
+
+import (
+	"context"
+	"testing"
+	"time"
+
+	"github.com/Wei-Shaw/sub2api/internal/service"
+	"github.com/stretchr/testify/require"
+)
+
+// resetSchedulerOutbox truncates the outbox table so each test starts at a
+// known state. The integration suite shares a database, so we cannot rely on
+// the suite-level rollback.
+func resetSchedulerOutbox(t *testing.T) {
+	t.Helper()
+	_, err := integrationDB.ExecContext(context.Background(),
+		"TRUNCATE scheduler_outbox RESTART IDENTITY")
+	require.NoError(t, err)
+}
+
+// insertAccountWithRateLimitReset inserts a minimal account row directly via
+// SQL so the test owns the rate_limit_reset_at value. We avoid the ent
+// Account.Create path because it would force us to populate every required
+// field even when the test only cares about (rate_limit_reset_at, deleted_at).
+func insertAccountWithRateLimitReset(t *testing.T, name string, resetAt *time.Time, deleted bool) int64 {
+	t.Helper()
+	ctx := context.Background()
+
+	// Defensive cleanup: remove any leftover row with the same name so reruns
+	// stay deterministic.
+	_, err := integrationDB.ExecContext(ctx, "DELETE FROM accounts WHERE name = $1", name)
+	require.NoError(t, err)
+
+	var id int64
+	var deletedAt *time.Time
+	if deleted {
+		now := time.Now()
+		deletedAt = &now
+	}
+	err = integrationDB.QueryRowContext(ctx, `
+		INSERT INTO accounts (
+			name, platform, type, status, schedulable, priority, concurrency,
+			credentials, extra, rate_limit_reset_at, deleted_at,
+			created_at, updated_at
+		) VALUES (
+			$1, 'anthropic', 'oauth', 'active', TRUE, 50, 1,
+			'{}'::jsonb, '{}'::jsonb, $2, $3, NOW(), NOW()
+		)
+		RETURNING id
+	`, name, resetAt, deletedAt).Scan(&id)
+	require.NoError(t, err)
+	t.Cleanup(func() {
+		_, _ = integrationDB.ExecContext(context.Background(),
+			"DELETE FROM accounts WHERE id = $1", id)
+	})
+	return id
+}
+
+// TestEnqueueOutboxForJustExpiredAccounts_RepoEnqueuesAccountChangedForExpired
+// is the core #2538 invariant: an account whose cooldown just expired must
+// land in scheduler_outbox as a single `account_changed` event. Without this
+// row, the outbox worker never rebuilds the bucket and the account stays
+// invisible to scheduling.
+func TestEnqueueOutboxForJustExpiredAccounts_RepoEnqueuesAccountChangedForExpired(t *testing.T) {
+	resetSchedulerOutbox(t)
+
+	now := time.Now()
+	expiredAt := now.Add(-5 * time.Second) // expired 5s ago
+	id := insertAccountWithRateLimitReset(t, "rl-reaper-expired", &expiredAt, false)
+
+	repo := NewRateLimitExpiryRepository(integrationDB)
+
+	inserted, err := repo.EnqueueOutboxForJustExpiredAccounts(t.Context(),
+		now.Add(-30*time.Second), now)
+	require.NoError(t, err)
+	require.Equal(t, 1, inserted)
+
+	var rows int
+	require.NoError(t, integrationDB.QueryRowContext(t.Context(),
+		`SELECT COUNT(*) FROM scheduler_outbox
+		 WHERE event_type = $1 AND account_id = $2`,
+		service.SchedulerOutboxEventAccountChanged, id).Scan(&rows))
+	require.Equal(t, 1, rows,
+		"reaper must enqueue exactly one account_changed event per expired account")
+}
+
+// TestEnqueueOutboxForJustExpiredAccounts_RepoSkipsStillCoolingDownAccounts
+// pins the right-bound: accounts whose cooldown has NOT yet elapsed must
+// stay out of the outbox. Without this guard the reaper would prematurely
+// re-add accounts to snapshots while they are still rate-limited.
+func TestEnqueueOutboxForJustExpiredAccounts_RepoSkipsStillCoolingDownAccounts(t *testing.T) {
+	resetSchedulerOutbox(t)
+
+	now := time.Now()
+	futureReset := now.Add(60 * time.Second) // still cooling down
+	insertAccountWithRateLimitReset(t, "rl-reaper-cooling", &futureReset, false)
+
+	repo := NewRateLimitExpiryRepository(integrationDB)
+	inserted, err := repo.EnqueueOutboxForJustExpiredAccounts(t.Context(),
+		now.Add(-30*time.Second), now)
+	require.NoError(t, err)
+	require.Equal(t, 0, inserted, "cooling-down accounts must NOT trigger reaper enqueue")
+}
+
+// TestEnqueueOutboxForJustExpiredAccounts_RepoSkipsLongExpiredOutsideWindow
+// pins the left-bound: accounts that expired far in the past (outside the
+// (since, until] window) must be skipped by this tick. A subsequent reaper
+// tick with a wider window can still pick them up if needed.
+func TestEnqueueOutboxForJustExpiredAccounts_RepoSkipsLongExpiredOutsideWindow(t *testing.T) {
+	resetSchedulerOutbox(t)
+
+	now := time.Now()
+	longAgo := now.Add(-2 * time.Hour)
+	insertAccountWithRateLimitReset(t, "rl-reaper-long-ago", &longAgo, false)
+
+	repo := NewRateLimitExpiryRepository(integrationDB)
+	inserted, err := repo.EnqueueOutboxForJustExpiredAccounts(t.Context(),
+		now.Add(-30*time.Second), now)
+	require.NoError(t, err)
+	require.Equal(t, 0, inserted,
+		"accounts expired outside the (since, until] window must be skipped this tick")
+}
+
+// TestEnqueueOutboxForJustExpiredAccounts_RepoSkipsSoftDeletedAccounts
+// confirms the deleted_at IS NULL guard.
+func TestEnqueueOutboxForJustExpiredAccounts_RepoSkipsSoftDeletedAccounts(t *testing.T) {
+	resetSchedulerOutbox(t)
+
+	now := time.Now()
+	expiredAt := now.Add(-5 * time.Second)
+	insertAccountWithRateLimitReset(t, "rl-reaper-deleted", &expiredAt, true)
+
+	repo := NewRateLimitExpiryRepository(integrationDB)
+	inserted, err := repo.EnqueueOutboxForJustExpiredAccounts(t.Context(),
+		now.Add(-30*time.Second), now)
+	require.NoError(t, err)
+	require.Equal(t, 0, inserted,
+		"soft-deleted accounts must NOT be re-added by the reaper")
+}
+
+// TestEnqueueOutboxForJustExpiredAccounts_RepoDedupsRepeatedTicksWithin1Second
+// pins the dedup contract: when two reaper ticks fire within the 1-second
+// outbox dedup window, the second tick must NOT enqueue a duplicate
+// account_changed row for the same expired account.
+func TestEnqueueOutboxForJustExpiredAccounts_RepoDedupsRepeatedTicksWithin1Second(t *testing.T) {
+	resetSchedulerOutbox(t)
+
+	now := time.Now()
+	expiredAt := now.Add(-2 * time.Second)
+	id := insertAccountWithRateLimitReset(t, "rl-reaper-dedup", &expiredAt, false)
+
+	repo := NewRateLimitExpiryRepository(integrationDB)
+	first, err := repo.EnqueueOutboxForJustExpiredAccounts(t.Context(),
+		now.Add(-30*time.Second), now)
+	require.NoError(t, err)
+	require.Equal(t, 1, first)
+
+	// Immediately re-run: the existing 1s outbox dedup clause must kick in.
+	second, err := repo.EnqueueOutboxForJustExpiredAccounts(t.Context(),
+		now.Add(-30*time.Second), now)
+	require.NoError(t, err)
+	require.Equal(t, 0, second,
+		"reaper ticks within the 1s outbox dedup window must not double-enqueue")
+
+	var rows int
+	require.NoError(t, integrationDB.QueryRowContext(t.Context(),
+		`SELECT COUNT(*) FROM scheduler_outbox
+		 WHERE event_type = $1 AND account_id = $2`,
+		service.SchedulerOutboxEventAccountChanged, id).Scan(&rows))
+	require.Equal(t, 1, rows,
+		"after two back-to-back reaper ticks, exactly one outbox row should exist")
+}
+
+// TestEnqueueOutboxForJustExpiredAccounts_RepoInvertedWindowIsNoOp guards
+// against a misconfigured caller passing since >= until — the SQL must short-
+// circuit before scanning the table.
+func TestEnqueueOutboxForJustExpiredAccounts_RepoInvertedWindowIsNoOp(t *testing.T) {
+	resetSchedulerOutbox(t)
+
+	now := time.Now()
+	expiredAt := now.Add(-5 * time.Second)
+	insertAccountWithRateLimitReset(t, "rl-reaper-inverted", &expiredAt, false)
+
+	repo := NewRateLimitExpiryRepository(integrationDB)
+	// since > until: must be a no-op.
+	inserted, err := repo.EnqueueOutboxForJustExpiredAccounts(t.Context(),
+		now.Add(10*time.Second), now)
+	require.NoError(t, err)
+	require.Equal(t, 0, inserted)
+}

--- a/backend/internal/repository/wire.go
+++ b/backend/internal/repository/wire.go
@@ -118,6 +118,9 @@ var ProviderSet = wire.NewSet(
 	NewGeminiTokenCache,
 	ProvideSchedulerCache,
 	NewSchedulerOutboxRepository,
+	// TK fix for upstream Wei-Shaw/sub2api#2538 — see
+	// account_repo_tk_rate_limit_reaper.go.
+	NewRateLimitExpiryRepository,
 	NewProxyLatencyCache,
 	NewTotpCache,
 	NewRefreshTokenCache,

--- a/backend/internal/service/scheduler_rate_limit_reaper.go
+++ b/backend/internal/service/scheduler_rate_limit_reaper.go
@@ -1,0 +1,173 @@
+package service
+
+// TK: See upstream Wei-Shaw/sub2api#2538 — when an account hits 429, the
+// scheduler outbox immediately rebuilds the bucket and the account is dropped
+// from the snapshot because `ListSchedulableByGroupIDAndPlatform` SQL filters
+// `RateLimitResetAtIsNil OR RateLimitResetAtLTE(now)`. Nothing fires when the
+// cooldown later expires, so the account is invisible to scheduling until the
+// next full-rebuild tick (default 5 minutes) — long enough for ops to perceive
+// "high-priority account never recovers".
+//
+// SchedulerRateLimitReaper closes the gap with a short tick that scans
+// `accounts.rate_limit_reset_at` falling in (since, now] and enqueues a single
+// `account_changed` outbox event per account. The existing outbox worker then
+// runs `loadAccountsFromDB` (which no longer excludes the now-expired account)
+// and writes a fresh snapshot. The outbox INSERT already has a 1-second dedup
+// window, so even sub-second reaper intervals do not flood the table.
+//
+// This module is deliberately a TK companion: it does not modify upstream
+// `scheduler_snapshot_service.go` and degrades to a no-op when
+// RateLimitExpiryRepository is nil, so it can be enabled or disabled via
+// config without touching the upstream snapshot pipeline.
+
+import (
+	"context"
+	"sync"
+	"time"
+
+	"github.com/Wei-Shaw/sub2api/internal/config"
+	"github.com/Wei-Shaw/sub2api/internal/pkg/logger"
+)
+
+// RateLimitExpiryRepository drives the reaper. The repository implementation
+// must run a single atomic SQL that enqueues outbox `account_changed` events
+// for every account whose rate-limit cooldown expired inside (since, until].
+type RateLimitExpiryRepository interface {
+	// EnqueueOutboxForJustExpiredAccounts inserts one
+	// scheduler_outbox(event_type='account_changed') row per matching account
+	// and returns the number of rows inserted. Caller chooses the window;
+	// SchedulerRateLimitReaper passes (now - lookback, now] each tick.
+	EnqueueOutboxForJustExpiredAccounts(ctx context.Context, since, until time.Time) (int, error)
+}
+
+// SchedulerRateLimitReaper is the TK companion goroutine that triggers
+// snapshot rebuilds when an account's rate-limit cooldown elapses. See the
+// file-level comment for the upstream-issue context.
+type SchedulerRateLimitReaper struct {
+	repo     RateLimitExpiryRepository
+	cfg      *config.Config
+	stopCh   chan struct{}
+	stopOnce sync.Once
+	wg       sync.WaitGroup
+	// lastTick is the upper bound of the previous reaper tick. Kept on the
+	// receiver so the next tick uses (lastTick, now] and consecutive ticks
+	// never miss accounts whose reset_at falls inside the gap between ticks.
+	lastTick time.Time
+}
+
+// NewSchedulerRateLimitReaper constructs the reaper. A nil repo or zero-tick
+// interval produces a reaper that no-ops on Start, which keeps wire wiring
+// safe even when tests inject minimal dependencies.
+func NewSchedulerRateLimitReaper(repo RateLimitExpiryRepository, cfg *config.Config) *SchedulerRateLimitReaper {
+	return &SchedulerRateLimitReaper{
+		repo:   repo,
+		cfg:    cfg,
+		stopCh: make(chan struct{}),
+	}
+}
+
+// Start launches the reaper goroutine. Safe to call exactly once; subsequent
+// Start calls are no-ops. The goroutine exits when Stop is called.
+func (r *SchedulerRateLimitReaper) Start() {
+	if r == nil || r.repo == nil {
+		return
+	}
+	interval := r.tickInterval()
+	if interval <= 0 {
+		return
+	}
+	r.lastTick = time.Now()
+
+	r.wg.Add(1)
+	go func() {
+		defer r.wg.Done()
+		ticker := time.NewTicker(interval)
+		defer ticker.Stop()
+		for {
+			select {
+			case <-ticker.C:
+				r.runOnce()
+			case <-r.stopCh:
+				return
+			}
+		}
+	}()
+}
+
+// Stop signals the goroutine to exit and waits for it. Safe to call exactly
+// once; subsequent Stop calls are no-ops.
+func (r *SchedulerRateLimitReaper) Stop() {
+	if r == nil {
+		return
+	}
+	r.stopOnce.Do(func() {
+		close(r.stopCh)
+	})
+	r.wg.Wait()
+}
+
+// runOnce performs a single reaper pass. Exported for tests; production code
+// always reaches it via the ticker.
+func (r *SchedulerRateLimitReaper) runOnce() {
+	if r == nil || r.repo == nil {
+		return
+	}
+	now := time.Now()
+	lookback := r.lookback()
+	since := r.lastTick
+	if since.IsZero() || now.Sub(since) > lookback {
+		// First tick after Start, or wall-clock jumped forward (e.g.
+		// container resume). Fall back to a fixed lookback window so we
+		// still catch every account whose cooldown expired recently
+		// without trying to cover an unbounded history.
+		since = now.Add(-lookback)
+	}
+	ctx, cancel := context.WithTimeout(context.Background(), r.queryTimeout())
+	defer cancel()
+
+	inserted, err := r.repo.EnqueueOutboxForJustExpiredAccounts(ctx, since, now)
+	if err != nil {
+		logger.LegacyPrintf("service.scheduler_rate_limit_reaper",
+			"[Scheduler] rate-limit reaper enqueue failed: since=%s err=%v",
+			since.Format(time.RFC3339), err)
+		// Keep lastTick unchanged so the next tick re-attempts this window.
+		return
+	}
+	r.lastTick = now
+	if inserted > 0 {
+		logger.LegacyPrintf("service.scheduler_rate_limit_reaper",
+			"[Scheduler] rate-limit reaper enqueued %d account_changed events for cooldown-expired accounts (since=%s)",
+			inserted, since.Format(time.RFC3339))
+	}
+}
+
+func (r *SchedulerRateLimitReaper) tickInterval() time.Duration {
+	if r.cfg == nil {
+		return 5 * time.Second
+	}
+	sec := r.cfg.Gateway.Scheduling.RateLimitReaperIntervalSeconds
+	if sec < 0 {
+		return 0
+	}
+	if sec == 0 {
+		return 5 * time.Second
+	}
+	return time.Duration(sec) * time.Second
+}
+
+func (r *SchedulerRateLimitReaper) lookback() time.Duration {
+	if r.cfg == nil {
+		return 30 * time.Second
+	}
+	sec := r.cfg.Gateway.Scheduling.RateLimitReaperLookbackSeconds
+	if sec <= 0 {
+		return 30 * time.Second
+	}
+	return time.Duration(sec) * time.Second
+}
+
+func (r *SchedulerRateLimitReaper) queryTimeout() time.Duration {
+	// Hard-coded; the SQL is a single INSERT...SELECT that should always
+	// finish in well under a second on production-sized account tables.
+	return 5 * time.Second
+}

--- a/backend/internal/service/scheduler_rate_limit_reaper.go
+++ b/backend/internal/service/scheduler_rate_limit_reaper.go
@@ -106,8 +106,9 @@ func (r *SchedulerRateLimitReaper) Stop() {
 	r.wg.Wait()
 }
 
-// runOnce performs a single reaper pass. Exported for tests; production code
-// always reaches it via the ticker.
+// runOnce performs a single reaper pass. Tests call it directly to drive
+// invariants without spinning the wall clock; production code reaches it via
+// the ticker goroutine in Start.
 func (r *SchedulerRateLimitReaper) runOnce() {
 	if r == nil || r.repo == nil {
 		return
@@ -143,14 +144,17 @@ func (r *SchedulerRateLimitReaper) runOnce() {
 
 func (r *SchedulerRateLimitReaper) tickInterval() time.Duration {
 	if r.cfg == nil {
-		return 5 * time.Second
-	}
-	sec := r.cfg.Gateway.Scheduling.RateLimitReaperIntervalSeconds
-	if sec < 0 {
 		return 0
 	}
-	if sec == 0 {
-		return 5 * time.Second
+	// Mirror FullRebuildIntervalSeconds / OutboxLag*Seconds semantics across
+	// the scheduling config block: <=0 explicitly disables the worker, and
+	// viper.SetDefault supplies the non-zero default when the user did not
+	// set the knob at all. Using <0 here would force operators to type `-1`
+	// just to disable the reaper, which diverges from every other interval
+	// knob in SchedulingConfig.
+	sec := r.cfg.Gateway.Scheduling.RateLimitReaperIntervalSeconds
+	if sec <= 0 {
+		return 0
 	}
 	return time.Duration(sec) * time.Second
 }

--- a/backend/internal/service/scheduler_rate_limit_reaper_test.go
+++ b/backend/internal/service/scheduler_rate_limit_reaper_test.go
@@ -10,6 +10,7 @@ package service
 import (
 	"context"
 	"errors"
+	"fmt"
 	"sync"
 	"testing"
 	"time"
@@ -165,20 +166,26 @@ func TestRateLimitReaper_NilRepo_NoOp(t *testing.T) {
 	})
 }
 
-// TestRateLimitReaper_NegativeIntervalDisablesGoroutine verifies the explicit
-// disable knob (interval < 0). With this off, no goroutine is spawned and
-// Stop() must still be safe.
-func TestRateLimitReaper_NegativeIntervalDisablesGoroutine(t *testing.T) {
-	repo := &fakeRateLimitExpiryRepo{}
-	cfg := &config.Config{}
-	cfg.Gateway.Scheduling.RateLimitReaperIntervalSeconds = -1
+// TestRateLimitReaper_NonPositiveIntervalDisablesGoroutine pins the disable
+// knob: both `0` and `<0` interval values must produce zero goroutines and
+// zero repository calls, mirroring FullRebuildIntervalSeconds and the rest of
+// SchedulingConfig. This keeps disable-by-config a single keystroke (`0`)
+// instead of forcing operators to type `-1`.
+func TestRateLimitReaper_NonPositiveIntervalDisablesGoroutine(t *testing.T) {
+	for _, sec := range []int{0, -1} {
+		t.Run(fmt.Sprintf("interval=%d", sec), func(t *testing.T) {
+			repo := &fakeRateLimitExpiryRepo{}
+			cfg := &config.Config{}
+			cfg.Gateway.Scheduling.RateLimitReaperIntervalSeconds = sec
 
-	reaper := NewSchedulerRateLimitReaper(repo, cfg)
-	reaper.Start()
-	reaper.Stop()
+			reaper := NewSchedulerRateLimitReaper(repo, cfg)
+			reaper.Start()
+			reaper.Stop()
 
-	require.Equal(t, 0, repo.callCount(),
-		"a negative interval must disable the reaper entirely (no repository calls, no goroutine)")
+			require.Equal(t, 0, repo.callCount(),
+				"interval=%d must disable the reaper entirely (no goroutine, no repository calls)", sec)
+		})
+	}
 }
 
 // TestRateLimitReaper_StartStop_IsIdempotentAndDoesNotLeak runs the full

--- a/backend/internal/service/scheduler_rate_limit_reaper_test.go
+++ b/backend/internal/service/scheduler_rate_limit_reaper_test.go
@@ -1,0 +1,208 @@
+//go:build unit
+
+package service
+
+// TK: See upstream Wei-Shaw/sub2api#2538 — these tests pin the reaper's
+// invariants for the "high-priority account stuck in cooldown limbo"
+// deadlock. The reaper runs as a goroutine in production, but each test
+// drives runOnce() directly so we never spin on the wall clock.
+
+import (
+	"context"
+	"errors"
+	"sync"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/require"
+
+	"github.com/Wei-Shaw/sub2api/internal/config"
+)
+
+// fakeRateLimitExpiryRepo records every (since, until) window the reaper
+// inspects and returns a scripted (inserted, err) per call. Stays goroutine-
+// safe so a future timer-driven test can race against it without flakes.
+type fakeRateLimitExpiryRepo struct {
+	mu       sync.Mutex
+	calls    []rateLimitExpiryCall
+	inserted []int
+	errors   []error
+	idx      int
+}
+
+type rateLimitExpiryCall struct {
+	since time.Time
+	until time.Time
+}
+
+func (f *fakeRateLimitExpiryRepo) EnqueueOutboxForJustExpiredAccounts(ctx context.Context, since, until time.Time) (int, error) {
+	f.mu.Lock()
+	defer f.mu.Unlock()
+	f.calls = append(f.calls, rateLimitExpiryCall{since: since, until: until})
+	if f.idx < len(f.errors) && f.errors[f.idx] != nil {
+		err := f.errors[f.idx]
+		f.idx++
+		return 0, err
+	}
+	val := 0
+	if f.idx < len(f.inserted) {
+		val = f.inserted[f.idx]
+	}
+	f.idx++
+	return val, nil
+}
+
+func (f *fakeRateLimitExpiryRepo) callCount() int {
+	f.mu.Lock()
+	defer f.mu.Unlock()
+	return len(f.calls)
+}
+
+func (f *fakeRateLimitExpiryRepo) lastCall() rateLimitExpiryCall {
+	f.mu.Lock()
+	defer f.mu.Unlock()
+	if len(f.calls) == 0 {
+		return rateLimitExpiryCall{}
+	}
+	return f.calls[len(f.calls)-1]
+}
+
+// TestRateLimitReaper_FirstTick_UsesLookbackWindow locks the contract that on
+// the very first tick after Start (or after lastTick is zero), the reaper
+// scans (now - lookback, now] rather than skipping the window. Without this,
+// accounts whose cooldown expired between server start and the first reaper
+// tick would stay invisible until the slow full_rebuild_interval_seconds tick.
+func TestRateLimitReaper_FirstTick_UsesLookbackWindow(t *testing.T) {
+	repo := &fakeRateLimitExpiryRepo{inserted: []int{0}}
+	cfg := &config.Config{}
+	cfg.Gateway.Scheduling.RateLimitReaperLookbackSeconds = 30
+
+	reaper := NewSchedulerRateLimitReaper(repo, cfg)
+	require.NotNil(t, reaper)
+
+	before := time.Now()
+	reaper.runOnce()
+	after := time.Now()
+
+	require.Equal(t, 1, repo.callCount(), "reaper should issue exactly one repository call per tick")
+	call := repo.lastCall()
+	gap := call.until.Sub(call.since)
+	require.InDelta(t, 30*time.Second, gap, float64(time.Second),
+		"first tick window must equal the configured lookback")
+	require.True(t, !call.until.Before(before) && !call.until.After(after),
+		"window upper bound must be the reaper's wall-clock now")
+}
+
+// TestRateLimitReaper_SubsequentTicks_UseLastTickAsLowerBound is the core
+// #2538 invariant: between ticks the reaper must scan exactly the gap so no
+// account whose cooldown expired in (lastTick, now] is missed. A weaker
+// implementation that always used (now-lookback, now] would still work but
+// would either (a) miss accounts when lookback < tick interval or (b)
+// repeatedly enqueue the same accounts when lookback > tick interval.
+func TestRateLimitReaper_SubsequentTicks_UseLastTickAsLowerBound(t *testing.T) {
+	repo := &fakeRateLimitExpiryRepo{inserted: []int{0, 0}}
+	cfg := &config.Config{}
+	cfg.Gateway.Scheduling.RateLimitReaperLookbackSeconds = 30
+
+	reaper := NewSchedulerRateLimitReaper(repo, cfg)
+	reaper.runOnce()
+	firstUpper := repo.lastCall().until
+
+	// Simulate the next tick a short time later.
+	time.Sleep(20 * time.Millisecond)
+	reaper.runOnce()
+
+	require.Equal(t, 2, repo.callCount())
+	secondCall := repo.lastCall()
+	require.True(t, secondCall.since.Equal(firstUpper) || secondCall.since.After(firstUpper.Add(-time.Millisecond)),
+		"second tick lower bound must continue from the first tick's upper bound (no gap, no double-scan)")
+}
+
+// TestRateLimitReaper_RepoErrorPreservesLastTick prevents the regression
+// where a transient DB error advances lastTick and silently drops the missed
+// window. The reaper must keep lastTick unchanged so the next tick re-attempts
+// the same window.
+func TestRateLimitReaper_RepoErrorPreservesLastTick(t *testing.T) {
+	repo := &fakeRateLimitExpiryRepo{
+		inserted: []int{0, 0, 0},
+		errors:   []error{nil, errors.New("transient db error"), nil},
+	}
+	cfg := &config.Config{}
+	cfg.Gateway.Scheduling.RateLimitReaperLookbackSeconds = 30
+
+	reaper := NewSchedulerRateLimitReaper(repo, cfg)
+
+	reaper.runOnce()
+	firstUpper := repo.lastCall().until
+
+	time.Sleep(20 * time.Millisecond)
+	reaper.runOnce() // returns error
+	errorCallUpper := repo.lastCall().until
+
+	time.Sleep(20 * time.Millisecond)
+	reaper.runOnce()
+	thirdCall := repo.lastCall()
+
+	require.Equal(t, 3, repo.callCount())
+	// After the error, lastTick must NOT have advanced to errorCallUpper —
+	// instead the third call's lower bound must still be firstUpper (the
+	// last successful tick's upper bound).
+	require.True(t, thirdCall.since.Equal(firstUpper) || thirdCall.since.After(firstUpper.Add(-time.Millisecond)),
+		"after a transient error, the next tick must re-attempt from the last successful tick's upper bound, not from the failed tick's upper bound")
+	require.True(t, thirdCall.since.Before(errorCallUpper),
+		"after error, next tick lower bound must precede the failed tick's upper bound so missed accounts are caught up")
+}
+
+// TestRateLimitReaper_NilRepo_NoOp confirms the reaper degrades to a safe
+// no-op when wire injects a nil repository (e.g. simple_run mode or test
+// fixtures that skip the DB plumbing).
+func TestRateLimitReaper_NilRepo_NoOp(t *testing.T) {
+	reaper := NewSchedulerRateLimitReaper(nil, &config.Config{})
+	require.NotPanics(t, func() {
+		reaper.runOnce()
+		reaper.Start()
+		reaper.Stop()
+	})
+}
+
+// TestRateLimitReaper_NegativeIntervalDisablesGoroutine verifies the explicit
+// disable knob (interval < 0). With this off, no goroutine is spawned and
+// Stop() must still be safe.
+func TestRateLimitReaper_NegativeIntervalDisablesGoroutine(t *testing.T) {
+	repo := &fakeRateLimitExpiryRepo{}
+	cfg := &config.Config{}
+	cfg.Gateway.Scheduling.RateLimitReaperIntervalSeconds = -1
+
+	reaper := NewSchedulerRateLimitReaper(repo, cfg)
+	reaper.Start()
+	reaper.Stop()
+
+	require.Equal(t, 0, repo.callCount(),
+		"a negative interval must disable the reaper entirely (no repository calls, no goroutine)")
+}
+
+// TestRateLimitReaper_StartStop_IsIdempotentAndDoesNotLeak runs the full
+// lifecycle path (Start → tick → Stop) and confirms the goroutine exits
+// cleanly. The test intentionally uses a short interval so the tick fires
+// at least once inside the sleep window without burdening CI.
+func TestRateLimitReaper_StartStop_IsIdempotentAndDoesNotLeak(t *testing.T) {
+	repo := &fakeRateLimitExpiryRepo{inserted: []int{0, 0, 0, 0, 0, 0, 0, 0}}
+	cfg := &config.Config{}
+	// Use a tiny interval so the ticker fires inside the test budget;
+	// production default is 5 s, set in viper defaults.
+	cfg.Gateway.Scheduling.RateLimitReaperIntervalSeconds = 1
+	cfg.Gateway.Scheduling.RateLimitReaperLookbackSeconds = 30
+
+	reaper := NewSchedulerRateLimitReaper(repo, cfg)
+	reaper.Start()
+	defer reaper.Stop()
+
+	require.Eventually(t, func() bool {
+		return repo.callCount() >= 1
+	}, 3*time.Second, 50*time.Millisecond,
+		"reaper goroutine must dispatch at least one tick after Start")
+
+	// A second Stop must not block or panic.
+	reaper.Stop()
+	reaper.Stop()
+}

--- a/backend/internal/service/wire.go
+++ b/backend/internal/service/wire.go
@@ -208,6 +208,20 @@ func ProvideSchedulerSnapshotService(
 	return svc
 }
 
+// ProvideSchedulerRateLimitReaper creates and starts the TK rate-limit reaper.
+// See scheduler_rate_limit_reaper.go for the upstream-issue context
+// (Wei-Shaw/sub2api#2538): without this reaper, accounts whose rate-limit
+// cooldown elapses stay invisible to the scheduler until the next
+// full_rebuild_interval_seconds tick.
+func ProvideSchedulerRateLimitReaper(
+	repo RateLimitExpiryRepository,
+	cfg *config.Config,
+) *SchedulerRateLimitReaper {
+	svc := NewSchedulerRateLimitReaper(repo, cfg)
+	svc.Start()
+	return svc
+}
+
 // ProvideRateLimitService creates RateLimitService with optional dependencies.
 func ProvideRateLimitService(
 	accountRepo AccountRepository,
@@ -489,6 +503,9 @@ var ProviderSet = wire.NewSet(
 	ProvideUserMessageQueueService,
 	NewUsageRecordWorkerPool,
 	ProvideSchedulerSnapshotService,
+	// TK fix for upstream Wei-Shaw/sub2api#2538 — see
+	// scheduler_rate_limit_reaper.go.
+	ProvideSchedulerRateLimitReaper,
 	NewIdentityService,
 	NewCRSSyncService,
 	ProvideUpdateService,

--- a/scripts/gateway-tk-sentinels.json
+++ b/scripts/gateway-tk-sentinels.json
@@ -356,6 +356,52 @@
         "stream_timeout"
       ],
       "rationale": "Focused regression anchors for upstream #1471 covering both sendErrorEvent triggers that share the closure: synchronous scanner error path (stream_read_error) and asynchronous interval-timeout path (stream_timeout). Each asserts every SSE event in the post-error transcript carries exactly one parseable-JSON data line. Together they prove the prepended-blank-line invariant holds for both the bufio.Scanner sync path and the goroutine async path that read from upstream."
+    },
+    {
+      "path": "backend/internal/service/scheduler_rate_limit_reaper.go",
+      "must_contain": [
+        "TK: See upstream Wei-Shaw/sub2api#2538",
+        "type SchedulerRateLimitReaper struct",
+        "type RateLimitExpiryRepository interface",
+        "EnqueueOutboxForJustExpiredAccounts(ctx context.Context, since, until time.Time) (int, error)",
+        "func NewSchedulerRateLimitReaper",
+        "func (r *SchedulerRateLimitReaper) Start()",
+        "func (r *SchedulerRateLimitReaper) Stop()"
+      ],
+      "rationale": "TK companion that closes the upstream #2538 scheduler deadlock: when an account hits 429 it is dropped from the snapshot, but the rate-limit cooldown expiry produces no event so the account stays invisible until the next full_rebuild_interval_seconds tick (default 5 min). Reaper ticks short (5s default) and enqueues a single outbox account_changed per just-expired account; the existing outbox worker rebuilds the bucket. Each anchor literal must remain: the issue reference (so future readers find the rationale), the type names (so wire injection survives renames), and the interface signature (so the SQL contract stays stable across upstream merges)."
+    },
+    {
+      "path": "backend/internal/service/scheduler_rate_limit_reaper_test.go",
+      "must_contain": [
+        "TestRateLimitReaper_FirstTick_UsesLookbackWindow",
+        "TestRateLimitReaper_SubsequentTicks_UseLastTickAsLowerBound",
+        "TestRateLimitReaper_RepoErrorPreservesLastTick",
+        "TestRateLimitReaper_NegativeIntervalDisablesGoroutine"
+      ],
+      "rationale": "Focused regression anchors for upstream #2538 covering the four reaper invariants the SQL alone cannot prove: (a) first-tick window equals configured lookback (no skipped accounts at startup), (b) subsequent ticks use (lastTick, now] so consecutive windows have no gap and no double-scan, (c) a transient repo error must NOT advance lastTick (so the missed window is retried), and (d) a negative interval cleanly disables the goroutine for ops who want to opt out."
+    },
+    {
+      "path": "backend/internal/repository/account_repo_tk_rate_limit_reaper.go",
+      "must_contain": [
+        "TK: See upstream Wei-Shaw/sub2api#2538",
+        "func NewRateLimitExpiryRepository(db *sql.DB) service.RateLimitExpiryRepository",
+        "INSERT INTO scheduler_outbox (event_type, account_id, group_id, payload)",
+        "WHERE a.rate_limit_reset_at > $1",
+        "AND a.rate_limit_reset_at <= $2",
+        "AND a.deleted_at IS NULL",
+        "AND o.created_at >= NOW() - make_interval(secs => 1)"
+      ],
+      "rationale": "Atomic INSERT...SELECT must remain a single statement so reaper window evaluation and outbox writes share a PG MVCC snapshot — without atomicity a 429 firing between SELECT and INSERT can re-set rate_limit_reset_at after we enqueued the resurrection event. The deleted_at IS NULL guard prevents soft-deleted accounts from being resurrected. The 1s dedup window mirrors scheduler_outbox_repo.go::enqueueSchedulerOutbox so reaper events stay consistent with SetRateLimited-written events."
+    },
+    {
+      "path": "backend/internal/repository/account_repo_tk_rate_limit_reaper_integration_test.go",
+      "must_contain": [
+        "TestEnqueueOutboxForJustExpiredAccounts_RepoEnqueuesAccountChangedForExpired",
+        "TestEnqueueOutboxForJustExpiredAccounts_RepoSkipsStillCoolingDownAccounts",
+        "TestEnqueueOutboxForJustExpiredAccounts_RepoSkipsSoftDeletedAccounts",
+        "TestEnqueueOutboxForJustExpiredAccounts_RepoDedupsRepeatedTicksWithin1Second"
+      ],
+      "rationale": "Integration anchors for the SQL contract: predicate is exclusive on lower bound + inclusive on upper bound (so accounts whose reset_at exactly equals a tick boundary still get caught the first time), soft-deleted accounts are skipped, and the 1s dedup window protects against double-enqueue across consecutive reaper ticks. Without these, the reaper could silently spam the outbox or quietly resurrect deleted accounts."
     }
   ]
 }

--- a/scripts/gateway-tk-sentinels.json
+++ b/scripts/gateway-tk-sentinels.json
@@ -376,9 +376,9 @@
         "TestRateLimitReaper_FirstTick_UsesLookbackWindow",
         "TestRateLimitReaper_SubsequentTicks_UseLastTickAsLowerBound",
         "TestRateLimitReaper_RepoErrorPreservesLastTick",
-        "TestRateLimitReaper_NegativeIntervalDisablesGoroutine"
+        "TestRateLimitReaper_NonPositiveIntervalDisablesGoroutine"
       ],
-      "rationale": "Focused regression anchors for upstream #2538 covering the four reaper invariants the SQL alone cannot prove: (a) first-tick window equals configured lookback (no skipped accounts at startup), (b) subsequent ticks use (lastTick, now] so consecutive windows have no gap and no double-scan, (c) a transient repo error must NOT advance lastTick (so the missed window is retried), and (d) a negative interval cleanly disables the goroutine for ops who want to opt out."
+      "rationale": "Focused regression anchors for upstream #2538 covering the four reaper invariants the SQL alone cannot prove: (a) first-tick window equals configured lookback (no skipped accounts at startup), (b) subsequent ticks use (lastTick, now] so consecutive windows have no gap and no double-scan, (c) a transient repo error must NOT advance lastTick (so the missed window is retried), and (d) the non-positive-interval disable knob keeps the disable-by-config keystroke aligned with FullRebuildIntervalSeconds (both <=0 disable)."
     },
     {
       "path": "backend/internal/repository/account_repo_tk_rate_limit_reaper.go",

--- a/scripts/upstream-issue-fact-checks.json
+++ b/scripts/upstream-issue-fact-checks.json
@@ -221,6 +221,32 @@
         "backend/internal/service/openai_gateway_service.go:bufferedWriter.WriteString(\"\\ndata: \" + payload + \"\\n\\n\")",
         "backend/internal/service/openai_gateway_service_tk_stream_read_error_sse_test.go:TestOpenAIStreamingStreamReadErrorEmitsSeparateSSEEvents"
       ]
+    },
+    {
+      "upstream": "Wei-Shaw/sub2api#2538",
+      "severity": "high",
+      "summary": "SchedulerRateLimitReaper closes the deadlock where an account's 429 cooldown expires but no event triggers a snapshot rebuild; reaper ticks every 5s, scans accounts.rate_limit_reset_at in (lastTick, now], and enqueues one scheduler_outbox(account_changed) event per match. The existing outbox worker then rebuilds the bucket. Reaper is independent of upstream SchedulerSnapshotService.",
+      "fixed_by": [
+        "backend/internal/service/scheduler_rate_limit_reaper.go",
+        "backend/internal/service/scheduler_rate_limit_reaper_test.go",
+        "backend/internal/repository/account_repo_tk_rate_limit_reaper.go",
+        "backend/internal/repository/account_repo_tk_rate_limit_reaper_integration_test.go"
+      ],
+      "fixed_if_all_present": [
+        "backend/internal/service/scheduler_rate_limit_reaper.go:TK: See upstream Wei-Shaw/sub2api#2538",
+        "backend/internal/service/scheduler_rate_limit_reaper.go:type SchedulerRateLimitReaper struct",
+        "backend/internal/service/scheduler_rate_limit_reaper.go:type RateLimitExpiryRepository interface",
+        "backend/internal/service/scheduler_rate_limit_reaper.go:EnqueueOutboxForJustExpiredAccounts(ctx context.Context, since, until time.Time) (int, error)",
+        "backend/internal/repository/account_repo_tk_rate_limit_reaper.go:TK: See upstream Wei-Shaw/sub2api#2538",
+        "backend/internal/repository/account_repo_tk_rate_limit_reaper.go:INSERT INTO scheduler_outbox (event_type, account_id, group_id, payload)",
+        "backend/internal/repository/account_repo_tk_rate_limit_reaper.go:WHERE a.rate_limit_reset_at > $1",
+        "backend/internal/repository/account_repo_tk_rate_limit_reaper.go:AND a.rate_limit_reset_at <= $2",
+        "backend/internal/service/scheduler_rate_limit_reaper_test.go:TestRateLimitReaper_FirstTick_UsesLookbackWindow",
+        "backend/internal/service/scheduler_rate_limit_reaper_test.go:TestRateLimitReaper_SubsequentTicks_UseLastTickAsLowerBound",
+        "backend/internal/service/scheduler_rate_limit_reaper_test.go:TestRateLimitReaper_RepoErrorPreservesLastTick",
+        "backend/internal/repository/account_repo_tk_rate_limit_reaper_integration_test.go:TestEnqueueOutboxForJustExpiredAccounts_RepoEnqueuesAccountChangedForExpired",
+        "backend/internal/repository/account_repo_tk_rate_limit_reaper_integration_test.go:TestEnqueueOutboxForJustExpiredAccounts_RepoDedupsRepeatedTicksWithin1Second"
+      ]
     }
   ]
 }

--- a/scripts/upstream-issue-fixes.json
+++ b/scripts/upstream-issue-fixes.json
@@ -268,6 +268,17 @@
         "backend/internal/service/openai_gateway_service_tk_stream_read_error_sse_test.go"
       ],
       "summary": "OpenAI /v1/responses sendErrorEvent now prepends a blank line before the synthetic data: line, so any in-flight upstream SSE event whose terminating blank line was never sent is closed before the synthetic event is written. Without this, the unterminated `data:` line and the synthetic `data:` line merge into a single SSE event whose payload contains two concatenated JSON objects, which downstream OpenAI-compatible SDKs (Codex, OpenCode, etc.) reject with malformed JSON."
+    },
+    {
+      "upstream": "Wei-Shaw/sub2api#2538",
+      "status": "fixed_in_tokenkey",
+      "fixed_by": [
+        "backend/internal/service/scheduler_rate_limit_reaper.go",
+        "backend/internal/service/scheduler_rate_limit_reaper_test.go",
+        "backend/internal/repository/account_repo_tk_rate_limit_reaper.go",
+        "backend/internal/repository/account_repo_tk_rate_limit_reaper_integration_test.go"
+      ],
+      "summary": "SchedulerRateLimitReaper closes the deadlock where an account's 429 cooldown expires but no event triggers a snapshot rebuild; reaper ticks every 5s, scans accounts.rate_limit_reset_at in (lastTick, now], and enqueues one scheduler_outbox(account_changed) event per match. The existing outbox worker then rebuilds the bucket. Reaper is independent of upstream SchedulerSnapshotService."
     }
   ]
 }

--- a/scripts/upstream-issue-triage-generate.py
+++ b/scripts/upstream-issue-triage-generate.py
@@ -61,6 +61,7 @@ MANUAL_TRIAGE = {
     2506: ("fixed", "fixed_in_tokenkey", "normalizeClaudeOAuthRequestBody skips context_management auto-injection for Haiku models (mirroring the existing Haiku exemption in FullClaudeCodeMimicryBetas), so claude-haiku-4-5-* + thinking.type=enabled no longer triggers Anthropic 400."),
     2515: ("fixed", "fixed_in_tokenkey", "ChatCompletions→Responses transform no longer emits content:null when the source content array is empty or every part was filtered out — falls back to empty string per upstream Responses contract."),
     1471: ("fixed", "fixed_in_tokenkey", "OpenAI /v1/responses sendErrorEvent prepends a blank line before the synthetic error event so an in-flight upstream SSE event (data: line without terminating blank line) does not merge with the injected error event into a single event carrying two JSON objects; downstream SDK JSON parsing no longer fails."),
+    2538: ("fixed", "fixed_in_tokenkey", "SchedulerRateLimitReaper closes the deadlock where an account's 429 cooldown expires but no event triggers a scheduler snapshot rebuild; reaper ticks every 5s, atomically enqueues outbox account_changed events for accounts whose rate_limit_reset_at just elapsed, and the existing outbox worker rebuilds the bucket. Reaper is fully independent of upstream SchedulerSnapshotService and degrades to a no-op when disabled via config."),
 }
 
 FIXED_IDS = {num for num, (impact, _, _) in MANUAL_TRIAGE.items() if impact == "fixed"}

--- a/scripts/upstream-issue-triage.json
+++ b/scripts/upstream-issue-triage.json
@@ -6135,7 +6135,7 @@
         "rate_limit_cooldown"
       ],
       "tokenkey_status": "fixed_in_tokenkey",
-      "rationale": "SchedulerRateLimitReaper closes the deadlock where an account's 429 cooldown expires but no event triggers a scheduler snapshot rebuild; reaper ticks every 5s, atomically enqueues outbox account_changed events for accounts whose rate_limit_reset_at just elapsed, and the existing outbox worker rebuilds the bucket. Reaper is fully independent of upstream SchedulerSnapshotService and degrades to a no-op when disabled via config.",
+      "rationale": "SchedulerRateLimitReaper closes the deadlock where an account's 429 cooldown expires but no event triggers a snapshot rebuild; reaper ticks every 5s, scans accounts.rate_limit_reset_at in (lastTick, now], and enqueues one scheduler_outbox(account_changed) event per match. The existing outbox worker then rebuilds the bucket. Reaper is independent of upstream SchedulerSnapshotService.",
       "updated_at": "2026-05-18T02:19:59Z"
     },
     {

--- a/scripts/upstream-issue-triage.json
+++ b/scripts/upstream-issue-triage.json
@@ -4,10 +4,10 @@
   "generated_from": "GitHub REST API issues?state=open; pull requests excluded",
   "rationale": "TokenKey-local triage cache for upstream open issues. Use this file before re-triaging upstream issues; update entries when TokenKey fixes, dismisses, or reclassifies an issue.",
   "counts": {
-    "needs_review": 347,
+    "needs_review": 346,
     "needs_prod_validation": 4,
     "medium": 115,
-    "fixed": 26,
+    "fixed": 27,
     "not_applicable": 1,
     "low": 94,
     "unknown_low_signal": 401
@@ -3187,18 +3187,6 @@
       "updated_at": "2026-05-17T13:12:03Z"
     },
     {
-      "upstream": "Wei-Shaw/sub2api#2538",
-      "url": "https://github.com/Wei-Shaw/sub2api/issues/2538",
-      "title": "[Bug] 429 bug",
-      "impact": "needs_review",
-      "categories": [
-        "rate_limit_cooldown"
-      ],
-      "tokenkey_status": "candidate_unverified",
-      "rationale": "Keyword match for production-sensitive area; not yet manually verified against TokenKey code.",
-      "updated_at": "2026-05-18T02:19:59Z"
-    },
-    {
       "upstream": "Wei-Shaw/sub2api#2539",
       "url": "https://github.com/Wei-Shaw/sub2api/issues/2539",
       "title": "Image billing falls back to default price when usage_logs.image_size is empty, ignoring group image price overrides",
@@ -6137,6 +6125,18 @@
       "tokenkey_status": "fixed_in_tokenkey",
       "rationale": "ChatCompletions→Responses transform falls back to empty string when the converted parts list is empty (was emitting JSON null and triggering upstream HTTP 400 on gpt-5.5).",
       "updated_at": "2026-05-16T12:51:29Z"
+    },
+    {
+      "upstream": "Wei-Shaw/sub2api#2538",
+      "url": "https://github.com/Wei-Shaw/sub2api/issues/2538",
+      "title": "[Bug] 429 bug",
+      "impact": "fixed",
+      "categories": [
+        "rate_limit_cooldown"
+      ],
+      "tokenkey_status": "fixed_in_tokenkey",
+      "rationale": "SchedulerRateLimitReaper closes the deadlock where an account's 429 cooldown expires but no event triggers a scheduler snapshot rebuild; reaper ticks every 5s, atomically enqueues outbox account_changed events for accounts whose rate_limit_reset_at just elapsed, and the existing outbox worker rebuilds the bucket. Reaper is fully independent of upstream SchedulerSnapshotService and degrades to a no-op when disabled via config.",
+      "updated_at": "2026-05-18T02:19:59Z"
     },
     {
       "upstream": "Wei-Shaw/sub2api#580",


### PR DESCRIPTION
## Summary

Fixes upstream [Wei-Shaw/sub2api#2538](https://github.com/Wei-Shaw/sub2api/issues/2538) — when a high-priority account hits 429 it correctly drops from the scheduler snapshot, but when the cooldown later elapses **nothing fires** until the next \`full_rebuild_interval_seconds\` tick (default 5 minutes). During that window the priority-2 account absorbs all traffic and the priority-1 account silently recovers off-stage. FourPrism reports it as "high-priority account never recovers".

**Root cause** (from the issue body):
> 第一账号 429 时它被从调度器缓存快照中移除了，限流过期后没有任何机制把它加回来。第一账号不在缓存快照中 → 不会被选中 → 永远收不到成功响应 → ClearRateLimit 永远不被触发 → 快照永远不重建。

Verified against current TK code:
- \`SetRateLimited\` enqueues a \`scheduler_outbox(account_changed)\` event (good — drops account from snapshot).
- \`loadAccountsFromDB\` → \`ListSchedulableByGroupIDAndPlatform\` SQL filters \`RateLimitResetAtIsNil OR RateLimitResetAtLTE(now)\` (good — excludes cooling-down accounts).
- **Nothing** fires when \`rate_limit_reset_at\` elapses. Only \`runFullRebuildWorker\` (default 300s interval) eventually rebuilds.

## Fix

New TK companion goroutine \`SchedulerRateLimitReaper\`:

- Ticks every 5s (configurable; \`< 0\` disables).
- Atomically enqueues one \`scheduler_outbox(account_changed)\` event per account whose \`rate_limit_reset_at\` falls in (\`lastTick\`, \`now\`].
- The **existing** outbox worker picks the event up and rebuilds the bucket — no changes to upstream \`scheduler_snapshot_service.go\`.
- The **existing** 1s outbox dedup window protects against double-enqueue from rapid ticks.

```
account hits 429 → outbox(account_changed) → bucket rebuilt without account
       ↓ (cooldown elapses, 5s later at most)
reaper tick → outbox(account_changed) → bucket rebuilt WITH account again
```

## Design choices worth flagging

| Choice | Reason |
|---|---|
| Single atomic \`INSERT...SELECT\` (not SELECT-then-INSERT) | A 429 firing between SELECT and INSERT could otherwise race the resurrection event. PG MVCC gives us atomicity inside one statement. |
| New \`RateLimitExpiryRepository\` interface (not extending \`AccountRepository\`) | Saves every existing stub/mock from growing a no-op method (CLAUDE.md rule 6). Mirrors how \`SchedulerOutboxRepository\` is wired today. |
| Reaper independent from \`SchedulerSnapshotService\` | Zero edits to upstream \`scheduler_snapshot_service.go\`. The reaper has its own \`Start\`/\`Stop\`, registered in \`cmd/server/wire.go\`'s cleanup list. |
| Steady-state window is \`(lastTick, now]\` | Consecutive ticks have **no gap and no double-scan**. A weaker design using \`(now-lookback, now]\` each tick would either miss accounts or re-enqueue them. |
| Transient repo error must NOT advance \`lastTick\` | The next tick has to re-attempt the missed window so a single DB hiccup does not lose the resurrection signal. Pinned by \`TestRateLimitReaper_RepoErrorPreservesLastTick\`. |
| Lookback (default 30s) is only first-tick / wall-clock-jump fallback | Steady-state ticks rely on \`lastTick\`; lookback covers (a) the first tick after \`Start\` and (b) container resume where wall clock jumps. |

## Files

- [\`backend/internal/service/scheduler_rate_limit_reaper.go\`](backend/internal/service/scheduler_rate_limit_reaper.go) — TK companion service (interface + reaper struct + lifecycle).
- [\`backend/internal/service/scheduler_rate_limit_reaper_test.go\`](backend/internal/service/scheduler_rate_limit_reaper_test.go) — 6 unit tests covering reaper invariants.
- [\`backend/internal/repository/account_repo_tk_rate_limit_reaper.go\`](backend/internal/repository/account_repo_tk_rate_limit_reaper.go) — \`INSERT...SELECT\` repository.
- [\`backend/internal/repository/account_repo_tk_rate_limit_reaper_integration_test.go\`](backend/internal/repository/account_repo_tk_rate_limit_reaper_integration_test.go) — 6 integration tests for the SQL contract.
- [\`backend/internal/config/config.go\`](backend/internal/config/config.go) — \`RateLimitReaperIntervalSeconds\` (default 5) + \`RateLimitReaperLookbackSeconds\` (default 30) + validation.
- [\`backend/internal/{service,repository}/wire.go\`](backend/internal/) + [\`backend/cmd/server/wire.go\`](backend/cmd/server/wire.go) + regenerated \`wire_gen.go\` — DI hookup.
- [\`scripts/upstream-issue-fixes.json\`](scripts/upstream-issue-fixes.json), [\`scripts/upstream-issue-fact-checks.json\`](scripts/upstream-issue-fact-checks.json), [\`scripts/gateway-tk-sentinels.json\`](scripts/gateway-tk-sentinels.json), [\`scripts/upstream-issue-triage-generate.py\`](scripts/upstream-issue-triage-generate.py), [\`scripts/upstream-issue-triage.json\`](scripts/upstream-issue-triage.json) — watchdog/sentinel registry entries so the fix is protected from silent upstream-merge reversion.

## Test plan

- [x] \`go test -tags=unit ./...\` — full unit suite passes (101s on \`internal/service\`)
- [x] \`go test -tags=integration -run TestEnqueueOutboxForJustExpiredAccounts ./internal/repository/\` — SQL contract verified against live Postgres
- [x] \`go vet ./...\` clean
- [x] \`golangci-lint run --new-from-rev=HEAD ./internal/{service,repository,config}/ ./cmd/server/\` — \`0 issues\`
- [x] \`bash scripts/preflight.sh\` — PASS (sentinel registry gate, dev-rules submodule, branch naming, web-surface alignment, etc.)
- [x] \`python3 scripts/upstream-issue-watchdog.py\` — verifies \`Wei-Shaw/sub2api#2538\` is in the \`fixed_verified\` list (count: 15, missing: 0)
- [ ] CI green on all required checks

## Notes

- \`no-web-impact\`: pure backend goroutine + DB plumbing; no frontend / API contract changes.
- Per CLAUDE.md rule §5 (upstream isolation): all new logic lives in \`*_tk_*.go\` and dedicated TK-named files; the only upstream-shape touches are (a) one new line in \`internal/service/wire.go\` ProviderSet, (b) one new line in \`internal/repository/wire.go\` ProviderSet, (c) constructor parameter + cleanup entry in \`cmd/server/wire.go\` (TK-maintained DI entry point), (d) new config fields + viper default + validate clause. No upstream symbols deleted.
- Per CLAUDE.md rule §6 (interface method completeness): deliberately avoided extending \`AccountRepository\` — used a new small interface so the 7 existing stubs/mocks need zero touches.
- Per CLAUDE.md rule §5.x: pure feature addition (no upstream deletions).

🤖 Generated with [Claude Code](https://claude.com/claude-code)