### PR TITLE
chore: refresh upstream issue cache

### DIFF
--- a/scripts/upstream-issue-fixes.json
+++ b/scripts/upstream-issue-fixes.json
@@ -287,7 +287,7 @@
         "backend/internal/service/billing_service.go",
         "backend/internal/service/billing_service_image_test.go"
       ],
-      "summary": "BillingService.getImageUnitPrice defensively normalizes an empty imageSize to \"2K\" — mirroring the request-side normalizeOpenAIImageSizeTier default — so group image-price overrides (Price1K/Price2K/Price4K) are honored when ForwardResult.ImageSize fails to propagate through the request pipeline, instead of silently falling back to the LiteLLM default price ($0.134)."
+      "summary": "BillingService.getImageUnitPrice now defensively normalizes an empty imageSize to \"2K\" — mirroring the request-side normalizeOpenAIImageSizeTier default — so group image-price overrides (Price1K/Price2K/Price4K) are honored when ForwardResult.ImageSize fails to propagate through the request pipeline, instead of silently falling back to the LiteLLM default price ($0.134). Aligns the empty-size billing tier with the request-side default and unblocks customers with image_price_2k overrides who were being billed at the unconfigured default."
     }
   ]
 }

--- a/scripts/upstream-issue-triage.json
+++ b/scripts/upstream-issue-triage.json
@@ -4,10 +4,10 @@
   "generated_from": "GitHub REST API issues?state=open; pull requests excluded",
   "rationale": "TokenKey-local triage cache for upstream open issues. Use this file before re-triaging upstream issues; update entries when TokenKey fixes, dismisses, or reclassifies an issue.",
   "counts": {
-    "needs_review": 347,
-    "fixed": 28,
+    "needs_review": 348,
     "needs_prod_validation": 4,
     "medium": 115,
+    "fixed": 28,
     "not_applicable": 1,
     "low": 96,
     "unknown_low_signal": 402
@@ -2050,7 +2050,7 @@
       ],
       "tokenkey_status": "candidate_unverified",
       "rationale": "Keyword match for production-sensitive area; not yet manually verified against TokenKey code.",
-      "updated_at": "2026-05-18T10:13:40Z"
+      "updated_at": "2026-05-18T11:19:16Z"
     },
     {
       "upstream": "Wei-Shaw/sub2api#2033",
@@ -3222,6 +3222,20 @@
       "tokenkey_status": "candidate_unverified",
       "rationale": "Keyword match for production-sensitive area; not yet manually verified against TokenKey code.",
       "updated_at": "2026-05-18T09:06:40Z"
+    },
+    {
+      "upstream": "Wei-Shaw/sub2api#2556",
+      "url": "https://github.com/Wei-Shaw/sub2api/issues/2556",
+      "title": "【bug反馈】gpt-5.5 上游静默拒绝（空 SSE + finish_reason=stop）被当成成功响应——计费记 0/0 token、不触发 failover、无错误日志",
+      "impact": "needs_review",
+      "categories": [
+        "rate_limit_cooldown",
+        "billing_usage",
+        "security"
+      ],
+      "tokenkey_status": "candidate_unverified",
+      "rationale": "Keyword match for production-sensitive area; not yet manually verified against TokenKey code.",
+      "updated_at": "2026-05-18T11:15:08Z"
     },
     {
       "upstream": "Wei-Shaw/sub2api#263",
@@ -6156,10 +6170,11 @@
       "title": "Image billing falls back to default price when usage_logs.image_size is empty, ignoring group image price overrides",
       "impact": "fixed",
       "categories": [
-        "manual"
+        "billing_usage",
+        "image_oauth"
       ],
       "tokenkey_status": "fixed_in_tokenkey",
-      "rationale": "BillingService.getImageUnitPrice now defensively normalizes an empty imageSize to \"2K\" (mirroring the request-side normalizeOpenAIImageSizeTier default), so group image-price overrides (image_price_1k/2k/4k) are honored when ForwardResult.ImageSize fails to propagate, instead of silently falling back to the LiteLLM default price ($0.134).",
+      "rationale": "BillingService.getImageUnitPrice now defensively normalizes an empty imageSize to \"2K\" — mirroring the request-side normalizeOpenAIImageSizeTier default — so group image-price overrides (Price1K/Price2K/Price4K) are honored when ForwardResult.ImageSize fails to propagate through the request pipeline, instead of silently falling back to the LiteLLM default price ($0.134). Aligns the empty-size billing tier with the request-side default and unblocks customers with image_price_2k overrides who were being billed at the unconfigured default.",
       "updated_at": "2026-05-17T16:20:43Z"
     },
     {


### PR DESCRIPTION
## Summary
- Refresh `scripts/upstream-issue-triage.json` from the latest Wei-Shaw/sub2api issues.
- Update `scripts/upstream-issue-fixes.json` from current TokenKey main fact checks.
- Keep watchdog workflow/script/fact-check metadata in sync with the refreshed cache.

## Watchdog report
# Upstream Issue Watchdog Report

- Run URL: https://github.com/youxuanxue/sub2api/actions/runs/26031707076
- Repository SHA: `21d9882296b7b4a96b932e5bde838e3d911d8085`
- Generated at: `2026-05-18T11:51:22Z`
- Upstream issues scanned: `1366`
- Fact checks: `16`
- Fixed facts verified: `16`
- High/critical unresolved: `0`

## Fixed facts verified

- Wei-Shaw/sub2api#641 via None
- Wei-Shaw/sub2api#2332 via None
- Wei-Shaw/sub2api#2107 via youxuanxue/sub2api#232
- Wei-Shaw/sub2api#2159 via youxuanxue/sub2api#232
- Wei-Shaw/sub2api#2258 via youxuanxue/sub2api#232
- Wei-Shaw/sub2api#2478 via youxuanxue/sub2api#232
- Wei-Shaw/sub2api#2515 via None
- Wei-Shaw/sub2api#2506 via None
- Wei-Shaw/sub2api#2500 via None
- Wei-Shaw/sub2api#1311 via None
- Wei-Shaw/sub2api#2486 via None
- Wei-Shaw/sub2api#2363 via None
- Wei-Shaw/sub2api#2332 via None
- Wei-Shaw/sub2api#1471 via None
- Wei-Shaw/sub2api#2538 via None
- Wei-Shaw/sub2api#2539 via None


## Test plan
- [x] `python3 -m json.tool scripts/upstream-issue-triage.json`
- [x] `python3 -m json.tool scripts/upstream-issue-fixes.json`
- [x] `python3 -m json.tool scripts/upstream-issue-fact-checks.json`
- [x] `python3 -m py_compile scripts/upstream-issue-watchdog.py`
- [x] `python3 -m json.tool .cache/upstream-issue-watchdog/report.json`
- [x] `python3 -m json.tool .cache/upstream-issue-watchdog/agent-input.json`
