### PR TITLE
fix(billing): honor group image pricing when image_size is empty (upstream #2539) (no-web-impact)

### DIFF
--- a/backend/internal/service/billing_service.go
+++ b/backend/internal/service/billing_service.go
@@ -836,9 +836,19 @@ func (s *BillingService) CalculateImageCost(model string, imageSize string, imag
 
 // getImageUnitPrice 获取图片单价
 func (s *BillingService) getImageUnitPrice(model string, imageSize string, groupConfig *ImagePriceConfig) float64 {
+	// Defensive normalization: when imageSize is empty/whitespace, mirror the
+	// request-side default in normalizeOpenAIImageSizeTier ("" → "2K") so an
+	// upstream pipeline that fails to propagate size into ForwardResult does
+	// not silently skip group image-price overrides nor mis-classify the
+	// default tier as 1K. See upstream Wei-Shaw/sub2api#2539.
+	normalizedSize := imageSize
+	if strings.TrimSpace(normalizedSize) == "" {
+		normalizedSize = "2K"
+	}
+
 	// 优先使用分组配置的价格
 	if groupConfig != nil {
-		switch imageSize {
+		switch normalizedSize {
 		case "1K":
 			if groupConfig.Price1K != nil {
 				return *groupConfig.Price1K
@@ -855,7 +865,7 @@ func (s *BillingService) getImageUnitPrice(model string, imageSize string, group
 	}
 
 	// 回退到 LiteLLM 默认价格
-	return s.getDefaultImagePrice(model, imageSize)
+	return s.getDefaultImagePrice(model, normalizedSize)
 }
 
 // getDefaultImagePrice 获取 LiteLLM 默认图片价格

--- a/backend/internal/service/billing_service_image_test.go
+++ b/backend/internal/service/billing_service_image_test.go
@@ -148,3 +148,58 @@ func TestGetDefaultImagePrice_FallbackHardcoded(t *testing.T) {
 	cost = svc.CalculateImageCost("gemini-3-pro-image", "2K", 1, nil, 1.0)
 	require.InDelta(t, 0.201, cost.TotalCost, 0.0001)
 }
+
+// TestGetImageUnitPrice_EmptyImageSize_UsesGroupTier locks the upstream
+// Wei-Shaw/sub2api#2539 fix: when ForwardResult.ImageSize fails to propagate
+// (image_size == ""), billing must still honor the group's configured image
+// pricing — mirroring the request-side normalizeOpenAIImageSizeTier default
+// (empty → "2K") — instead of silently falling back to the LiteLLM default
+// price of $0.134.
+func TestGetImageUnitPrice_EmptyImageSize_UsesGroupTier(t *testing.T) {
+	svc := &BillingService{}
+
+	price1K := 0.30
+	price2K := 0.50
+	price4K := 1.00
+	groupConfig := &ImagePriceConfig{
+		Price1K: &price1K,
+		Price2K: &price2K,
+		Price4K: &price4K,
+	}
+
+	// Empty imageSize should be treated as the 2K tier and pick group's Price2K
+	// ($0.50), NOT the default $0.134.
+	cost := svc.CalculateImageCost("gpt-image-2", "", 1, groupConfig, 1.0)
+	require.InDelta(t, 0.50, cost.TotalCost, 0.0001)
+	require.InDelta(t, 0.50, cost.ActualCost, 0.0001)
+
+	// Whitespace-only imageSize behaves the same as empty.
+	cost = svc.CalculateImageCost("gpt-image-2", "   ", 2, groupConfig, 1.0)
+	require.InDelta(t, 1.00, cost.TotalCost, 0.0001)
+}
+
+// TestGetImageUnitPrice_EmptyImageSize_NoGroupFallsBackTo2KDefault ensures the
+// empty-imageSize normalization is consistent with the request-side default
+// even when no group pricing is configured: $0.134 * 1.5 = $0.201 (2K tier),
+// not the prior 1K tier of $0.134.
+func TestGetImageUnitPrice_EmptyImageSize_NoGroupFallsBackTo2KDefault(t *testing.T) {
+	svc := &BillingService{}
+
+	cost := svc.CalculateImageCost("gemini-3-pro-image", "", 1, nil, 1.0)
+	require.InDelta(t, 0.201, cost.TotalCost, 0.0001)
+}
+
+// TestGetImageUnitPrice_EmptyImageSize_PartialGroupConfigTier2K covers the
+// realistic case from Wei-Shaw/sub2api#2539: customer configured only the 2K
+// override and the request lost its size on the way to billing.
+func TestGetImageUnitPrice_EmptyImageSize_PartialGroupConfigTier2K(t *testing.T) {
+	svc := &BillingService{}
+
+	price2K := 0.50
+	groupConfig := &ImagePriceConfig{
+		Price2K: &price2K,
+	}
+
+	cost := svc.CalculateImageCost("gpt-image-2", "", 1, groupConfig, 1.0)
+	require.InDelta(t, 0.50, cost.TotalCost, 0.0001)
+}

--- a/scripts/upstream-issue-fact-checks.json
+++ b/scripts/upstream-issue-fact-checks.json
@@ -247,6 +247,24 @@
         "backend/internal/repository/account_repo_tk_rate_limit_reaper_integration_test.go:TestEnqueueOutboxForJustExpiredAccounts_RepoEnqueuesAccountChangedForExpired",
         "backend/internal/repository/account_repo_tk_rate_limit_reaper_integration_test.go:TestEnqueueOutboxForJustExpiredAccounts_RepoDedupsRepeatedTicksWithin1Second"
       ]
+    },
+    {
+      "upstream": "Wei-Shaw/sub2api#2539",
+      "severity": "high",
+      "summary": "BillingService.getImageUnitPrice now defensively normalizes an empty imageSize to \"2K\" — mirroring the request-side normalizeOpenAIImageSizeTier default — so group image-price overrides (Price1K/Price2K/Price4K) are honored when ForwardResult.ImageSize fails to propagate through the request pipeline, instead of silently falling back to the LiteLLM default price ($0.134). Aligns the empty-size billing tier with the request-side default and unblocks customers with image_price_2k overrides who were being billed at the unconfigured default.",
+      "fixed_by": [
+        "backend/internal/service/billing_service.go",
+        "backend/internal/service/billing_service_image_test.go"
+      ],
+      "fixed_if_all_present": [
+        "backend/internal/service/billing_service.go:See upstream Wei-Shaw/sub2api#2539",
+        "backend/internal/service/billing_service.go:normalizedSize := imageSize",
+        "backend/internal/service/billing_service.go:if strings.TrimSpace(normalizedSize) == \"\" {",
+        "backend/internal/service/billing_service.go:normalizedSize = \"2K\"",
+        "backend/internal/service/billing_service_image_test.go:TestGetImageUnitPrice_EmptyImageSize_UsesGroupTier",
+        "backend/internal/service/billing_service_image_test.go:TestGetImageUnitPrice_EmptyImageSize_NoGroupFallsBackTo2KDefault",
+        "backend/internal/service/billing_service_image_test.go:TestGetImageUnitPrice_EmptyImageSize_PartialGroupConfigTier2K"
+      ]
     }
   ]
 }

--- a/scripts/upstream-issue-fixes.json
+++ b/scripts/upstream-issue-fixes.json
@@ -279,6 +279,15 @@
         "backend/internal/repository/account_repo_tk_rate_limit_reaper_integration_test.go"
       ],
       "summary": "SchedulerRateLimitReaper closes the deadlock where an account's 429 cooldown expires but no event triggers a snapshot rebuild; reaper ticks every 5s, scans accounts.rate_limit_reset_at in (lastTick, now], and enqueues one scheduler_outbox(account_changed) event per match. The existing outbox worker then rebuilds the bucket. Reaper is independent of upstream SchedulerSnapshotService."
+    },
+    {
+      "upstream": "Wei-Shaw/sub2api#2539",
+      "status": "fixed_in_tokenkey",
+      "fixed_by": [
+        "backend/internal/service/billing_service.go",
+        "backend/internal/service/billing_service_image_test.go"
+      ],
+      "summary": "BillingService.getImageUnitPrice defensively normalizes an empty imageSize to \"2K\" — mirroring the request-side normalizeOpenAIImageSizeTier default — so group image-price overrides (Price1K/Price2K/Price4K) are honored when ForwardResult.ImageSize fails to propagate through the request pipeline, instead of silently falling back to the LiteLLM default price ($0.134)."
     }
   ]
 }

--- a/scripts/upstream-issue-triage-generate.py
+++ b/scripts/upstream-issue-triage-generate.py
@@ -62,6 +62,7 @@ MANUAL_TRIAGE = {
     2515: ("fixed", "fixed_in_tokenkey", "ChatCompletions→Responses transform no longer emits content:null when the source content array is empty or every part was filtered out — falls back to empty string per upstream Responses contract."),
     1471: ("fixed", "fixed_in_tokenkey", "OpenAI /v1/responses sendErrorEvent prepends a blank line before the synthetic error event so an in-flight upstream SSE event (data: line without terminating blank line) does not merge with the injected error event into a single event carrying two JSON objects; downstream SDK JSON parsing no longer fails."),
     2538: ("fixed", "fixed_in_tokenkey", "SchedulerRateLimitReaper closes the deadlock where an account's 429 cooldown expires but no event triggers a scheduler snapshot rebuild; reaper ticks every 5s, atomically enqueues outbox account_changed events for accounts whose rate_limit_reset_at just elapsed, and the existing outbox worker rebuilds the bucket. Reaper is fully independent of upstream SchedulerSnapshotService and degrades to a no-op when disabled via config."),
+    2539: ("fixed", "fixed_in_tokenkey", "BillingService.getImageUnitPrice now defensively normalizes an empty imageSize to \"2K\" (mirroring the request-side normalizeOpenAIImageSizeTier default), so group image-price overrides (image_price_1k/2k/4k) are honored when ForwardResult.ImageSize fails to propagate, instead of silently falling back to the LiteLLM default price ($0.134)."),
 }
 
 FIXED_IDS = {num for num, (impact, _, _) in MANUAL_TRIAGE.items() if impact == "fixed"}

--- a/scripts/upstream-issue-triage.json
+++ b/scripts/upstream-issue-triage.json
@@ -4,10 +4,10 @@
   "generated_from": "GitHub REST API issues?state=open; pull requests excluded",
   "rationale": "TokenKey-local triage cache for upstream open issues. Use this file before re-triaging upstream issues; update entries when TokenKey fixes, dismisses, or reclassifies an issue.",
   "counts": {
-    "needs_review": 348,
+    "needs_review": 347,
+    "fixed": 28,
     "needs_prod_validation": 4,
     "medium": 115,
-    "fixed": 27,
     "not_applicable": 1,
     "low": 96,
     "unknown_low_signal": 402
@@ -3187,19 +3187,6 @@
       "updated_at": "2026-05-17T13:12:03Z"
     },
     {
-      "upstream": "Wei-Shaw/sub2api#2539",
-      "url": "https://github.com/Wei-Shaw/sub2api/issues/2539",
-      "title": "Image billing falls back to default price when usage_logs.image_size is empty, ignoring group image price overrides",
-      "impact": "needs_review",
-      "categories": [
-        "billing_usage",
-        "image_oauth"
-      ],
-      "tokenkey_status": "candidate_unverified",
-      "rationale": "Keyword match for production-sensitive area; not yet manually verified against TokenKey code.",
-      "updated_at": "2026-05-17T16:20:43Z"
-    },
-    {
       "upstream": "Wei-Shaw/sub2api#2540",
       "url": "https://github.com/Wei-Shaw/sub2api/issues/2540",
       "title": "生图问题",
@@ -6162,6 +6149,18 @@
       "tokenkey_status": "fixed_in_tokenkey",
       "rationale": "SchedulerRateLimitReaper closes the deadlock where an account's 429 cooldown expires but no event triggers a snapshot rebuild; reaper ticks every 5s, scans accounts.rate_limit_reset_at in (lastTick, now], and enqueues one scheduler_outbox(account_changed) event per match. The existing outbox worker then rebuilds the bucket. Reaper is independent of upstream SchedulerSnapshotService.",
       "updated_at": "2026-05-18T02:19:59Z"
+    },
+    {
+      "upstream": "Wei-Shaw/sub2api#2539",
+      "url": "https://github.com/Wei-Shaw/sub2api/issues/2539",
+      "title": "Image billing falls back to default price when usage_logs.image_size is empty, ignoring group image price overrides",
+      "impact": "fixed",
+      "categories": [
+        "manual"
+      ],
+      "tokenkey_status": "fixed_in_tokenkey",
+      "rationale": "BillingService.getImageUnitPrice now defensively normalizes an empty imageSize to \"2K\" (mirroring the request-side normalizeOpenAIImageSizeTier default), so group image-price overrides (image_price_1k/2k/4k) are honored when ForwardResult.ImageSize fails to propagate, instead of silently falling back to the LiteLLM default price ($0.134).",
+      "updated_at": "2026-05-17T16:20:43Z"
     },
     {
       "upstream": "Wei-Shaw/sub2api#580",


### PR DESCRIPTION
## Summary

Fix upstream-issue **Wei-Shaw/sub2api#2539** — image billing fell back to the
default LiteLLM price (`$0.134`) whenever `ForwardResult.ImageSize` failed to
propagate, even when the API-key's group had explicit `image_price_1k/2k/4k`
overrides configured. Customers got the wrong amount deducted.

`BillingService.getImageUnitPrice` now defensively normalizes an empty
`imageSize` to `"2K"`, mirroring the request-side default in
`normalizeOpenAIImageSizeTier("")` → `"2K"`. The fix:

- Honors group `Price2K` (and `Price1K`/`Price4K` when only those tiers are
  configured but `imageSize` is missing) instead of silently bypassing them.
- Aligns the default-tier fallback with the request-side normalization so an
  unconfigured group is billed at the 2K tier (`$0.201`), matching the
  upstream OpenAI default for the `image_generation` tool's `size="auto"`.

This is a minimum-surface, billing-correctness fix — no upstream-shaped files
are restructured, no request-pipeline changes. Future work (normalizing
`ForwardResult.ImageSize` at the source for usage_logs visibility) can layer
on top of this safety net.

## Changed code facts

- `backend/internal/service/billing_service.go` — `getImageUnitPrice` empty
  `imageSize` → `"2K"` normalization at the top of the function, applied to
  both the group-pricing switch and the LiteLLM default fallback.
- `backend/internal/service/billing_service_image_test.go` — adds three
  regression tests:
  - `TestGetImageUnitPrice_EmptyImageSize_UsesGroupTier` (full group config + empty/whitespace size → group's 2K price).
  - `TestGetImageUnitPrice_EmptyImageSize_NoGroupFallsBackTo2KDefault` (no group config + empty size → `$0.201`, the 2K-tier default).
  - `TestGetImageUnitPrice_EmptyImageSize_PartialGroupConfigTier2K` (only `Price2K` configured → group price honored).

## Triage cache updates

- `scripts/upstream-issue-triage-generate.py` — manual triage entry promoting
  `Wei-Shaw/sub2api#2539` to `fixed_in_tokenkey`.
- `scripts/upstream-issue-triage.json` — issue promoted to
  `impact: fixed` / `tokenkey_status: fixed_in_tokenkey`; counts recalculated.
- `scripts/upstream-issue-fixes.json` — registry entry with `status:
  fixed_in_tokenkey` and the changed code paths.
- `scripts/upstream-issue-fact-checks.json` — declarative needles that the
  watchdog will use to keep this issue marked as `fixed_in_tokenkey` on
  future scans of `main`.

## Test plan

- [x] `go test -tags=unit ./internal/service/ -count=1 -run 'Billing|Image|Calculate'`
- [x] `go test -tags=unit ./internal/service/ -count=1 -run 'TestCalculateImageCost|TestGetImageUnitPrice|TestGetDefaultImagePrice' -v` (13 cases, all PASS)
- [x] `go build ./...`
- [x] `python3 -m json.tool` over all three updated cache files
- [x] `python3 -m py_compile scripts/upstream-issue-watchdog.py scripts/upstream-issue-triage-generate.py`
- [x] Manual needle check: every `fixed_if_all_present` entry for #2539 hits current `main`
- [x] `bash scripts/preflight.sh` PASS (including pre-commit hook)

## Reviewer note

- Merge mode per CLAUDE.md §5.y: **Squash and merge** (TK-originated fix PR).
- Backend-only billing change; no web surface impact, no API contract change.
- Commit message does NOT contain literal `[skip ci]`/`[ci skip]` per §9.2.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
