### PR TITLE
feat(anthropic): add L4 OAuth stability tier baseline (no-web-impact)

### DIFF
--- a/deploy/aws/stage0/anthropic-oauth-stability-baselines-tiered.json
+++ b/deploy/aws/stage0/anthropic-oauth-stability-baselines-tiered.json
@@ -5,7 +5,7 @@
     "single_account_scope": true,
     "rate_multiplier_fixed": 1.0,
     "usage_model": "Claude Code human-paced work: usage budget and session length are constrained separately; lower tiers are scheduled first but reach their local limits earlier.",
-    "tier_order": ["l1", "l2", "l3"],
+    "tier_order": ["l1", "l2", "l3", "l4"],
     "rounding": {
       "integer_fields": "explicit",
       "float_fields": "explicit"
@@ -198,6 +198,24 @@
           "max_sessions": 5,
           "session_idle_timeout_minutes": 8,
           "window_cost_limit": 480,
+          "window_cost_sticky_reserve": 0
+        }
+      }
+    },
+    "l4": {
+      "factor": 0.9,
+      "baseline": {
+        "account": {
+          "concurrency": 4,
+          "priority": 40,
+          "rate_multiplier": 1.0
+        },
+        "extra": {
+          "base_rpm": 12,
+          "rpm_sticky_buffer": 8,
+          "max_sessions": 6,
+          "session_idle_timeout_minutes": 8,
+          "window_cost_limit": 540,
           "window_cost_sticky_reserve": 0
         }
       }

--- a/deploy/aws/stage0/anthropic-oauth-stability-tiered-apply-template.sql
+++ b/deploy/aws/stage0/anthropic-oauth-stability-tiered-apply-template.sql
@@ -2,7 +2,7 @@
 -- Source of truth: deploy/aws/stage0/anthropic-oauth-stability-baselines-tiered.json
 -- Usage (psql):
 --   \set account_name 'your-account-name'
---   \set stability_tier 'l1'  -- l1|l2|l3
+--   \set stability_tier 'l1'  -- l1|l2|l3|l4
 --   \i deploy/aws/stage0/anthropic-oauth-stability-tiered-apply-template.sql
 
 -- Helper for explicit failure (session-scoped, no persistent schema changes).
@@ -25,7 +25,8 @@ tier_cfg AS (
   FROM (VALUES
     ('l1'::text, 1::int, 10::int, 6::int, 2::int, 3::int, 8::int, 180::int, 0::int),
     ('l2'::text, 2::int, 20::int, 8::int, 4::int, 4::int, 8::int, 330::int, 0::int),
-    ('l3'::text, 3::int, 30::int, 10::int, 6::int, 5::int, 8::int, 480::int, 0::int)
+    ('l3'::text, 3::int, 30::int, 10::int, 6::int, 5::int, 8::int, 480::int, 0::int),
+    ('l4'::text, 4::int, 40::int, 12::int, 8::int, 6::int, 8::int, 540::int, 0::int)
   ) AS v(
     stability_tier,
     concurrency,
@@ -47,7 +48,7 @@ validate AS (
   SELECT
     CASE
       WHEN NOT EXISTS (SELECT 1 FROM selected) THEN
-        pg_temp.pg_raise('invalid stability_tier=%s (expected l1/l2/l3)', (SELECT stability_tier FROM input))
+        pg_temp.pg_raise('invalid stability_tier=%s (expected l1/l2/l3/l4)', (SELECT stability_tier FROM input))
       ELSE 'ok'
     END AS ok
 ),

--- a/scripts/check-edge-anthropic-oauth-stability.py
+++ b/scripts/check-edge-anthropic-oauth-stability.py
@@ -373,7 +373,7 @@ def resolve_effective_baseline(
     if not tier_key:
         fail(
             f"account {account_name} on edge {edge_id} missing account.extra.stability_tier; "
-            "expected one of l1/l2/l3"
+            "expected one of l1/l2/l3/l4"
         )
 
     tiers = baseline.get("tiers") or {}


### PR DESCRIPTION
## Summary

- 新增 anthropic OAuth `stability_tier=l4` 档位，介于现有 L3 (factor 0.8) 与 plan-cap 之间。
- 三个文件同步更新：baseline JSON、apply SQL 模板、edge stability checker 报错字符串。
- 不动 R1/R3 mirror guard（absorb-zero SUM 与 tier 名无关，新 tier 会自动被 mirror 取到正确目标值）。
- 不动任何 backend Go / 前端代码：`extra.stability_tier` 在 Ent 里走 JSONB 透传，0 处硬编码 tier 字符串。

## Motivation

L3 是 cap=10 RPM。今天对 `edge-us1` 唯一 OAuth 账号做了 L2→L3 升级后做了 3 轮 post-apply 监控：

| 阶段 | cap | 15min 窗 cc-edges 429 |
|---|---|---|
| pre-apply (L2, cap=8) | 8 | 7、3 |
| post-apply (L3, cap=10) #1 | 10 | 3 (46s burst) |
| post-apply #2 | 10 | 0 |
| post-apply #3 | 10 | 2 |

频率 0.22/min → 0.11/min（−50%）但未清零。50min access log 解析：peak_rpm 从 pre 9 升到 post **11**，admin burst 仍偶发超过 cap=10 一个 RPM。同时 Anthropic OAuth 账号的 plan 侧用量在截图中仅 7% session / 15% weekly，plan 容量充足，**factor 上限可推到 0.9 仍留 10% buffer**。

→ 需要一个 cap=12 的档位精确覆盖观察到的 peak 并留 1 RPM buffer。这就是 L4。

## Design

延续 L1→L3 的线性递增结构 (concurrency +1 / priority +10 / base_rpm +2 / rpm_sticky_buffer +2 / max_sessions +1)，但 `factor` 从 +0.25 步长改为 +0.10，以给 \`temp_unschedulable_rules\` 留触发余地（Anthropic 端 429/529 在过去 50min 各观察到 26/15 次 marker，factor 必须 <1.0）。

| 字段 | L3 (0.80) | **L4 (0.90)** | 理由 |
|---|---|---|---|
| concurrency | 3 | **4** | 覆盖 p90=16.4s × 12 RPM ≈ 3.2 平均 inflight + 1 buffer |
| priority | 30 | **40** | 多账号 fleet 时仍处于 fleet 排序下端（数字越大越后调度） |
| base_rpm | 10 | **12** | 观察 peak=11 + 1 RPM buffer，精确消化当前 admin burst |
| rpm_sticky_buffer | 6 | **8** | 维持 ~67% base_rpm 的瞬时 sticky 余量 |
| max_sessions | 5 | **6** | 与 base_rpm 增长保持 0.5 RPM/session 比例 |
| window_cost_limit | 480 | **540** | factor 0.9 × 600 baseline session 满额；plan 7% 用量下远未碰线 |
| factor | 0.80 | **0.90** | 留 10% plan-cap buffer 给 self-throttle 先于 Anthropic 触发 |

## 不在本 PR 范围

- **不**在本 PR 中升级任何线上账号到 L4。promotion 走单独的 \`/tokenkey-edge-anthropic-oauth-config\` skill 流程（target_scope=account / operation=plan-apply → apply with confirm token）。
- **不**新增 SPOF / cc-edges-multi-edge-fanout warning（独立 PR）。
- **不**新增 L5（暂留作未来 admin 流量翻倍或单 plan 极限场景的备用选项）。

## Test plan

- [ ] CI \`backend-ci\` 全绿（Go test/lint 应无变更，仅校验跨仓 build）
- [ ] \`scripts/preflight.sh\` 本地已 PASS（已含 baseline JSON 解析校验）
- [ ] 手工：python3 -c "import json; json.load(open('deploy/aws/stage0/anthropic-oauth-stability-baselines-tiered.json'))" — 已本地验证
- [ ] 不需要触发任何 apply；merge 后下一次 \`/tokenkey-edge-anthropic-oauth-config\` 调用即可识别 \`stability_tier=l4\`

## Rule compliance (CLAUDE.md PR Checklist)

- ✅ no-web-impact: 仅改 deploy 模板 + checker 报错文本，无 backend/前端代码改动
- ✅ 不删 upstream 文件
- ✅ 不动 \`release.yml\` / 不碰 VERSION
- ✅ 不动 dev-rules submodule
- ✅ R1/R3 guard 不需要调整（tier 增加是 absorb-zero SUM 的天然兼容场景）
- ✅ 不破坏 \`tier_order\` 既有调度语义（L1→L2→L3 顺序不变，仅末尾追加 L4）

🤖 Generated with [Claude Code](https://claude.com/claude-code)