### PR TITLE
feat(anthropic): add L4 OAuth stability tier baseline + drift guard (no-web-impact)

### DIFF
--- a/deploy/aws/stage0/anthropic-oauth-stability-baselines-tiered.json
+++ b/deploy/aws/stage0/anthropic-oauth-stability-baselines-tiered.json
@@ -5,7 +5,7 @@
     "single_account_scope": true,
     "rate_multiplier_fixed": 1.0,
     "usage_model": "Claude Code human-paced work: usage budget and session length are constrained separately; lower tiers are scheduled first but reach their local limits earlier.",
-    "tier_order": ["l1", "l2", "l3"],
+    "tier_order": ["l1", "l2", "l3", "l4"],
     "rounding": {
       "integer_fields": "explicit",
       "float_fields": "explicit"
@@ -198,6 +198,24 @@
           "max_sessions": 5,
           "session_idle_timeout_minutes": 8,
           "window_cost_limit": 480,
+          "window_cost_sticky_reserve": 0
+        }
+      }
+    },
+    "l4": {
+      "factor": 0.9,
+      "baseline": {
+        "account": {
+          "concurrency": 4,
+          "priority": 40,
+          "rate_multiplier": 1.0
+        },
+        "extra": {
+          "base_rpm": 12,
+          "rpm_sticky_buffer": 8,
+          "max_sessions": 6,
+          "session_idle_timeout_minutes": 8,
+          "window_cost_limit": 540,
           "window_cost_sticky_reserve": 0
         }
       }

--- a/deploy/aws/stage0/anthropic-oauth-stability-tiered-apply-template.sql
+++ b/deploy/aws/stage0/anthropic-oauth-stability-tiered-apply-template.sql
@@ -2,7 +2,7 @@
 -- Source of truth: deploy/aws/stage0/anthropic-oauth-stability-baselines-tiered.json
 -- Usage (psql):
 --   \set account_name 'your-account-name'
---   \set stability_tier 'l1'  -- l1|l2|l3
+--   \set stability_tier 'l1'  -- l1|l2|l3|l4
 --   \i deploy/aws/stage0/anthropic-oauth-stability-tiered-apply-template.sql
 
 -- Helper for explicit failure (session-scoped, no persistent schema changes).
@@ -25,7 +25,8 @@ tier_cfg AS (
   FROM (VALUES
     ('l1'::text, 1::int, 10::int, 6::int, 2::int, 3::int, 8::int, 180::int, 0::int),
     ('l2'::text, 2::int, 20::int, 8::int, 4::int, 4::int, 8::int, 330::int, 0::int),
-    ('l3'::text, 3::int, 30::int, 10::int, 6::int, 5::int, 8::int, 480::int, 0::int)
+    ('l3'::text, 3::int, 30::int, 10::int, 6::int, 5::int, 8::int, 480::int, 0::int),
+    ('l4'::text, 4::int, 40::int, 12::int, 8::int, 6::int, 8::int, 540::int, 0::int)
   ) AS v(
     stability_tier,
     concurrency,
@@ -47,7 +48,7 @@ validate AS (
   SELECT
     CASE
       WHEN NOT EXISTS (SELECT 1 FROM selected) THEN
-        pg_temp.pg_raise('invalid stability_tier=%s (expected l1/l2/l3)', (SELECT stability_tier FROM input))
+        pg_temp.pg_raise('invalid stability_tier=%s (expected l1/l2/l3/l4)', (SELECT stability_tier FROM input))
       ELSE 'ok'
     END AS ok
 ),

--- a/scripts/check-anthropic-tier-baseline-drift.py
+++ b/scripts/check-anthropic-tier-baseline-drift.py
@@ -1,0 +1,121 @@
+#!/usr/bin/env python3
+# Verify anthropic OAuth tier baseline values match between the JSON source of
+# truth and the SQL apply template's VALUES table. Both files must be edited in
+# lockstep when adding/changing a tier; without a mechanical check, the SQL
+# comment "Source of truth: ...JSON" is just a prose rule.
+#
+# Sources:
+#   deploy/aws/stage0/anthropic-oauth-stability-baselines-tiered.json
+#   deploy/aws/stage0/anthropic-oauth-stability-tiered-apply-template.sql
+
+from __future__ import annotations
+
+import argparse
+import json
+import re
+import sys
+from pathlib import Path
+
+REPO_ROOT = Path(__file__).resolve().parent.parent
+JSON_PATH = REPO_ROOT / "deploy/aws/stage0/anthropic-oauth-stability-baselines-tiered.json"
+SQL_PATH = REPO_ROOT / "deploy/aws/stage0/anthropic-oauth-stability-tiered-apply-template.sql"
+
+JSON_ACCOUNT_FIELDS = ("concurrency", "priority")
+JSON_EXTRA_FIELDS = (
+    "base_rpm",
+    "rpm_sticky_buffer",
+    "max_sessions",
+    "session_idle_timeout_minutes",
+    "window_cost_limit",
+    "window_cost_sticky_reserve",
+)
+ALL_FIELDS = JSON_ACCOUNT_FIELDS + JSON_EXTRA_FIELDS
+
+# Matches a row of the tier_cfg VALUES block, e.g.
+#   ('l3'::text, 3::int, 30::int, 10::int, 6::int, 5::int, 8::int, 480::int, 0::int)
+# Column order is fixed by the SQL `AS v(stability_tier, concurrency, priority,
+# base_rpm, rpm_sticky_buffer, max_sessions, session_idle_timeout_minutes,
+# window_cost_limit, window_cost_sticky_reserve)` declaration.
+_VALUES_ROW_RE = re.compile(
+    r"\(\s*'(?P<name>[a-z0-9_]+)'::text\s*,\s*"
+    r"(?P<concurrency>\d+)::int\s*,\s*"
+    r"(?P<priority>\d+)::int\s*,\s*"
+    r"(?P<base_rpm>\d+)::int\s*,\s*"
+    r"(?P<rpm_sticky_buffer>\d+)::int\s*,\s*"
+    r"(?P<max_sessions>\d+)::int\s*,\s*"
+    r"(?P<session_idle_timeout_minutes>\d+)::int\s*,\s*"
+    r"(?P<window_cost_limit>\d+)::int\s*,\s*"
+    r"(?P<window_cost_sticky_reserve>\d+)::int\s*\)"
+)
+
+
+def parse_json_tiers() -> dict[str, dict[str, int]]:
+    data = json.loads(JSON_PATH.read_text())
+    out: dict[str, dict[str, int]] = {}
+    for name, cfg in (data.get("tiers") or {}).items():
+        baseline = (cfg or {}).get("baseline") or {}
+        account = baseline.get("account") or {}
+        extra = baseline.get("extra") or {}
+        row: dict[str, int] = {}
+        for f in JSON_ACCOUNT_FIELDS:
+            row[f] = account.get(f)
+        for f in JSON_EXTRA_FIELDS:
+            row[f] = extra.get(f)
+        out[name] = row
+    return out
+
+
+def parse_sql_tiers() -> dict[str, dict[str, int]]:
+    text = SQL_PATH.read_text()
+    out: dict[str, dict[str, int]] = {}
+    for m in _VALUES_ROW_RE.finditer(text):
+        name = m.group("name")
+        out[name] = {f: int(m.group(f)) for f in ALL_FIELDS}
+    return out
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("--quiet", action="store_true", help="suppress success output")
+    args = parser.parse_args()
+
+    json_tiers = parse_json_tiers()
+    sql_tiers = parse_sql_tiers()
+
+    json_names = set(json_tiers)
+    sql_names = set(sql_tiers)
+
+    errors: list[str] = []
+    only_json = sorted(json_names - sql_names)
+    only_sql = sorted(sql_names - json_names)
+    if only_json:
+        errors.append(f"tier(s) in JSON missing from SQL VALUES: {only_json}")
+    if only_sql:
+        errors.append(f"tier(s) in SQL VALUES missing from JSON: {only_sql}")
+
+    for name in sorted(json_names & sql_names):
+        for field in ALL_FIELDS:
+            jv = json_tiers[name].get(field)
+            sv = sql_tiers[name].get(field)
+            if jv != sv:
+                errors.append(f"tier {name!r} field {field!r}: JSON={jv!r} SQL={sv!r}")
+
+    if errors:
+        print("FAIL: anthropic tier baseline drift between JSON and SQL apply template:")
+        for e in errors:
+            print(f"  - {e}")
+        print(f"  JSON: {JSON_PATH.relative_to(REPO_ROOT)}")
+        print(f"  SQL : {SQL_PATH.relative_to(REPO_ROOT)}")
+        return 1
+
+    if not args.quiet:
+        names = ", ".join(sorted(json_names))
+        print(
+            f"ok: anthropic tier baseline JSON and SQL VALUES are in sync "
+            f"({len(json_names)} tiers: {names})"
+        )
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/scripts/check-edge-anthropic-oauth-stability.py
+++ b/scripts/check-edge-anthropic-oauth-stability.py
@@ -373,7 +373,7 @@ def resolve_effective_baseline(
     if not tier_key:
         fail(
             f"account {account_name} on edge {edge_id} missing account.extra.stability_tier; "
-            "expected one of l1/l2/l3"
+            "expected one of l1/l2/l3/l4"
         )
 
     tiers = baseline.get("tiers") or {}

--- a/scripts/check-edge-anthropic-oauth-stability.py
+++ b/scripts/check-edge-anthropic-oauth-stability.py
@@ -370,13 +370,13 @@ def resolve_effective_baseline(
     tier_key = str(account.get("stability_tier") or "").strip().lower()
     if not tier_key and default_tier:
         tier_key = default_tier
+    tiers = baseline.get("tiers") or {}
     if not tier_key:
         fail(
             f"account {account_name} on edge {edge_id} missing account.extra.stability_tier; "
-            "expected one of l1/l2/l3/l4"
+            f"expected one of {'/'.join(sorted(tiers))}"
         )
 
-    tiers = baseline.get("tiers") or {}
     tier_cfg = tiers.get(tier_key)
     if not isinstance(tier_cfg, dict):
         fail(

--- a/scripts/preflight.sh
+++ b/scripts/preflight.sh
@@ -572,6 +572,22 @@ else
     echo "  ok: no Edge Stage0 workflow present"
 fi
 
+# Anthropic OAuth tier baseline values must stay in sync between the JSON
+# source of truth and the SQL apply template's VALUES table. The SQL comment
+# claims JSON is canonical, but there is no plpgsql-side JSON loader — the
+# two are aligned by hand. This check fails when any tier is missing on one
+# side or any numeric field disagrees.
+echo ""
+echo "=== sub2api: anthropic tier baseline JSON↔SQL drift ==="
+if ! command -v python3 >/dev/null 2>&1; then
+    echo "  FAIL: python3 not on PATH (required by check-anthropic-tier-baseline-drift.py)"
+    errors=$((errors + 1))
+elif ! python3 ./scripts/check-anthropic-tier-baseline-drift.py --quiet; then
+    errors=$((errors + 1))
+else
+    echo "  ok: anthropic tier baseline JSON and SQL VALUES are in sync"
+fi
+
 # Headless agent stream redactor: scripts/redact-agent-stream.py sits between
 # `claude -p` and `tee` in upstream-merge-agent-daily.yml / pr-repair-agent.yml
 # /agent-draft-pr/action.yml, scrubbing secrets out of the agent's stdout


### PR DESCRIPTION
> 替代 #291（分支命名前缀 `feat/` 不在仓库约定的 `feature/|fix/|chore/|docs/|merge/|prototype/|cursor/` 列表里，被 preflight 拦下）。本 PR 用 `feature/anthropic-oauth-tier-l4` 重开，并把 review 找到的两处问题（F1 + F2）一起带进来。

## Summary

合一个 PR 落三件事：

1. **新增 `stability_tier=l4`** — anthropic OAuth 账号的高容量档位（factor 0.9，base_rpm 12，concurrency 4）。线性递增结构沿用 L1→L3；`factor` 步长从 +0.25 降到 +0.10 以保留 plan-cap buffer。
2. **新增 drift guard** — `scripts/check-anthropic-tier-baseline-drift.py` 解析 JSON 与 SQL apply 模板里的 tier baseline，逐字段比对；钩入 `scripts/preflight.sh` 作为 `=== sub2api: anthropic tier baseline JSON↔SQL drift ===`。任何 tier 缺失或字段不一致都立即 fail。
3. **去除最后一处硬编码 tier 列表** — `scripts/check-edge-anthropic-oauth-stability.py:376` 的 missing-tier fail 路径之前写死 `"expected one of l1/l2/l3"`（之前的 review 已经把它改成 `l1/l2/l3/l4`，但仍是字面字符串）。改成 dynamic `sorted(tiers)`，与同文件中另一条 fail 路径风格统一；未来加 tier 不需要再碰它。

## Motivation

L3 升级后 3 轮 post-apply 监控：

| 阶段 | cap | 15min 窗 cc-edges 429 |
|---|---|---|
| pre-apply (L2, cap=8) | 8 | 7、3 |
| post-apply (L3, cap=10) #1 | 10 | 3 (46s burst) |
| post-apply #2 | 10 | 0 |
| post-apply #3 | 10 | 2 |

频率 0.22/min → 0.11/min（−50%）但未清零；50min access-log 解析 peak_rpm 从 pre 9 升到 post **11**，admin burst 仍偶发超过 cap=10 一个 RPM。同时 Anthropic OAuth 账号 plan 侧用量截图 7% session / 15% weekly，plan 容量充足，**factor 上限可推到 0.9 仍留 10% buffer**。

→ 需要一个 cap=12 的档位精确覆盖观察到的 peak 并留 1 RPM buffer。这就是 L4。

## L4 Design

延续 L1→L3 的线性递增结构 (concurrency +1 / priority +10 / base_rpm +2 / rpm_sticky_buffer +2 / max_sessions +1)，但 `factor` 从 +0.25 步长改为 +0.10。Anthropic 端 429/529 markers 50min 窗口各 26/15 次，factor 必须 <1.0 给 `temp_unschedulable_rules` 留触发余地。

| 字段 | L3 (0.80) | **L4 (0.90)** | 理由 |
|---|---|---|---|
| concurrency | 3 | **4** | 覆盖 p90=16.4s × 12 RPM ≈ 3.2 平均 inflight + 1 buffer |
| priority | 30 | **40** | 多账号 fleet 时仍处于排序下端 |
| base_rpm | 10 | **12** | 观察 peak=11 + 1 RPM buffer |
| rpm_sticky_buffer | 6 | **8** | 维持 ~67% base_rpm 的瞬时 sticky 余量 |
| max_sessions | 5 | **6** | 与 base_rpm 增长保持 0.5 RPM/session 比例 |
| window_cost_limit | 480 | **540** | factor 0.9 × 600 baseline；plan 7% 用量下远未碰线 |
| factor | 0.80 | **0.90** | 留 10% plan-cap buffer 给 self-throttle 先于 Anthropic 触发 |

## Drift Guard Design

`tier_cfg` SQL VALUES 表把 JSON 里的数字重新写了一遍（PostgreSQL 不便从 JSON 加载，apply 链路必须靠这个）。SQL 顶部注释 `-- Source of truth: ...JSON` 之前是 prose rule，没有任何机械化保护。

新增 `scripts/check-anthropic-tier-baseline-drift.py`：

- 解析 JSON `tiers` 字典；每个 tier 收集 8 个 baseline 字段。
- 用 regex 解析 SQL `tier_cfg` 的 `VALUES (...)` 行；按列序号映射到字段名。
- 集合差：JSON-only / SQL-only 任一非空 → fail，列出 tier 名。
- 字段比对：任一不等 → fail，打印 \`tier 'X' field 'Y': JSON=v SQL=w\`。
- 干净时打印 \`ok: ... in sync (N tiers: l1, l2, ...)\`。

挂在 preflight.sh `=== sub2api: anthropic tier baseline JSON↔SQL drift ===` 段。带 `--quiet` flag 避免污染成功输出。

### 手工 fuzz 验证（合 PR 前自跑）

| 注入 | 期望 | 实测 |
|---|---|---|
| L3 base_rpm 在 JSON 改 10→999 | fail，diff 提示 | ✅ `tier 'l3' field 'base_rpm': JSON=999 SQL=10` |
| L4 concurrency 在 SQL 改 4→99 | fail，diff 提示 | ✅ `tier 'l4' field 'concurrency': JSON=4 SQL=99` |
| 删 SQL 中 l4 整行 | fail，缺失提示 | ✅ `tier(s) in JSON missing from SQL VALUES: ['l4']` |
| 还原 | pass，4 tiers in sync | ✅ |

## 不在本 PR 范围

- **不**在本 PR 中升级任何线上账号到 L4。promotion 走单独的 \`/tokenkey-edge-anthropic-oauth-config\` skill 流程。
- **不**新增 SPOF / cc-edges-multi-edge-fanout warning（独立 PR）。
- **不**新增 L5（暂留作未来 admin 流量翻倍或单 plan 极限场景的备用选项）。

## Test plan

- [x] `scripts/preflight.sh` 本地 PASS（含新增 drift 检查）
- [x] drift 检查阴阳性手工 fuzz（见上表）
- [x] python syntax: `python3 -c "import ast; ast.parse(open(...))"`
- [x] JSON 解析: `python3 -c "import json; json.load(open(...))"`
- [ ] CI `backend-ci`、`preflight`、`golangci-lint` 全绿（Go 代码 0 改动；纯 deploy 资产 + scripts）
- [ ] Merge 后下一次 `/tokenkey-edge-anthropic-oauth-config` 调用即可识别 `stability_tier=l4`

## Rule compliance (CLAUDE.md PR Checklist)

- ✅ no-web-impact: 仅改 deploy 模板 + scripts，无 backend Go / 前端代码改动
- ✅ 不删 upstream 文件
- ✅ 不动 release.yml / 不碰 VERSION
- ✅ 不动 dev-rules submodule
- ✅ R1/R3 guard 不需要调整（tier 增加是 absorb-zero SUM 的天然兼容场景）
- ✅ branch naming：`feature/anthropic-oauth-tier-l4` 在 preflight 允许前缀列表内
- ✅ commit message 不含 `[skip ci]`

🤖 Generated with [Claude Code](https://claude.com/claude-code)