### PR TITLE
chore: refresh upstream issue cache

### DIFF
--- a/scripts/upstream-issue-fixes.json
+++ b/scripts/upstream-issue-fixes.json
@@ -297,7 +297,7 @@
         "backend/internal/service/openai_gateway_chat_completions_raw.go",
         "backend/internal/service/openai_gateway_chat_completions_tk_silent_refusal_test.go"
       ],
-      "summary": "OpenAI Chat Completions raw passthrough (streaming and buffered) now detects upstream silent refusal — empty stream/response with finish_reason=stop and zero usage — and emits a categorical ops_error_logs row (Kind=silent_refusal). Detection is conservative (no content / no tool_calls / no reasoning_content / no refusal / no chunk-level error / zero usage / finish_reason=stop) so legitimate short answers are never flagged. Surfaces previously invisible 'ghost stream' failures (the gpt-5.5 above-input-budget shape upstream reported) to ops dashboards without changing the client-visible HTTP body, keeping the behavior change minimum-surface."
+      "summary": "OpenAI Chat Completions raw passthrough detects upstream silent refusal (empty stream/response with finish_reason=stop and zero usage) and emits an ops_error_logs row with Kind=silent_refusal. Conservative predicate: no content / no tool_calls / no reasoning / no refusal / no chunk-level error / zero usage / finish_reason=stop. Stream path keeps the client-visible bytes untouched (headers already flushed); buffered path will keep flexibility to harden later. The categorical ops signal turns the previously invisible 'ghost stream' (gpt-5.5 above input budget) into a dashboard-pivotable event."
     },
     {
       "upstream": "Wei-Shaw/sub2api#1264",
@@ -305,10 +305,9 @@
       "fixed_by": [
         "backend/internal/service/openai_gateway_service.go",
         "backend/internal/service/openai_gateway_chat_completions.go",
-        "backend/internal/service/openai_responses_unsupported_user_test.go",
-        "scripts/gateway-tk-sentinels.json"
+        "backend/internal/service/openai_responses_unsupported_user_test.go"
       ],
-      "summary": "OpenAI /v1/responses passthrough now strips top-level `user` before forwarding upstream. Symmetric coverage: (a) APIKey/native passthrough path adds `user` to the unsupportedFields list in OpenAIGatewayService.Forward (the OAuth path already filters it through openAIChatGPTInternalUnsupportedFields in applyCodexOAuthTransform); (b) the Cursor-shape short-circuit in ForwardAsChatCompletions adds `user` to cursorResponsesUnsupportedFields. Without this, clients like LobeHub posting `user` (for end-user tracking) to /v1/responses get HTTP 400 \"Unsupported parameter: user\" from the OpenAI upstream — the Responses-API equivalent field is `safety_identifier`, which we already strip. Tracked by the same sentinel registry entries plus the focused regression in openai_responses_unsupported_user_test.go."
+      "summary": "OpenAI /v1/responses passthrough strips top-level `user` before forwarding. Symmetric coverage on (a) APIKey native path via OpenAIGatewayService.Forward's unsupportedFields list (the OAuth path already strips it through openAIChatGPTInternalUnsupportedFields in applyCodexOAuthTransform) and (b) the Cursor-shape short-circuit in ForwardAsChatCompletions via cursorResponsesUnsupportedFields. Native OpenAI Responses upstream rejects `user` with HTTP 400 \"Unsupported parameter: user\"; the Responses equivalent is `safety_identifier`, which we already filter."
     },
     {
       "upstream": "Wei-Shaw/sub2api#1170",
@@ -317,7 +316,7 @@
         "backend/internal/handler/admin/account_data.go",
         "backend/internal/handler/admin/account_data_handler_test.go"
       ],
-      "summary": "Batch account import (/admin/accounts/data) propagates `group_ids` from the JSON payload through to CreateAccountInput.GroupIDs so newly imported accounts are bound to the requested groups directly, without requiring a manual edit-and-save. The DataAccount struct now declares the GroupIDs field (the original definition lacked it, so JSON `group_ids` was silently dropped at Unmarshal) and the import handler forwards `item.GroupIDs` instead of hard-coded `nil`. The symmetric export side also surfaces GroupIDs + ChannelType so an export → import round-trip no longer silently drops group bindings or newapi fifth-platform metadata."
+      "summary": "Batch account import (/admin/accounts/data) now propagates `group_ids` through to CreateAccountInput.GroupIDs and the symmetric export carries `group_ids` + `channel_type` so an export → import round trip preserves group bindings and newapi fifth-platform metadata. Original implementation defined no GroupIDs field on DataAccount (so JSON `group_ids` was silently dropped at Unmarshal) and the import handler hard-coded `GroupIDs: nil`, leaving batch-imported accounts ungrouped until manually re-edited."
     }
   ]
 }

--- a/scripts/upstream-issue-triage.json
+++ b/scripts/upstream-issue-triage.json
@@ -6,11 +6,11 @@
   "counts": {
     "needs_review": 345,
     "needs_prod_validation": 4,
-    "medium": 115,
+    "medium": 116,
     "fixed": 31,
     "not_applicable": 1,
     "low": 96,
-    "unknown_low_signal": 402
+    "unknown_low_signal": 404
   },
   "issues": [
     {
@@ -273,7 +273,7 @@
       ],
       "tokenkey_status": "candidate_unverified",
       "rationale": "Keyword match for production-sensitive area; not yet manually verified against TokenKey code.",
-      "updated_at": "2026-04-06T03:41:47Z"
+      "updated_at": "2026-05-18T16:00:49Z"
     },
     {
       "upstream": "Wei-Shaw/sub2api#1307",
@@ -2496,7 +2496,7 @@
       ],
       "tokenkey_status": "candidate_unverified",
       "rationale": "Keyword match for production-sensitive area; not yet manually verified against TokenKey code.",
-      "updated_at": "2026-05-15T02:58:04Z"
+      "updated_at": "2026-05-19T02:26:27Z"
     },
     {
       "upstream": "Wei-Shaw/sub2api#2231",
@@ -3021,18 +3021,6 @@
       "updated_at": "2026-05-14T02:48:29Z"
     },
     {
-      "upstream": "Wei-Shaw/sub2api#2442",
-      "url": "https://github.com/Wei-Shaw/sub2api/issues/2442",
-      "title": "Docker build fails at pnpm install with ERR_PNPM_IGNORED_BUILDS in frontend-builder",
-      "impact": "needs_review",
-      "categories": [
-        "rate_limit_cooldown"
-      ],
-      "tokenkey_status": "candidate_unverified",
-      "rationale": "Keyword match for production-sensitive area; not yet manually verified against TokenKey code.",
-      "updated_at": "2026-05-16T04:42:28Z"
-    },
-    {
       "upstream": "Wei-Shaw/sub2api#2445",
       "url": "https://github.com/Wei-Shaw/sub2api/issues/2445",
       "title": "exceeded retry limit, last status: 429 Too Many Requests, request id",
@@ -3195,6 +3183,18 @@
       "tokenkey_status": "candidate_unverified",
       "rationale": "Keyword match for production-sensitive area; not yet manually verified against TokenKey code.",
       "updated_at": "2026-05-18T09:06:40Z"
+    },
+    {
+      "upstream": "Wei-Shaw/sub2api#2560",
+      "url": "https://github.com/Wei-Shaw/sub2api/issues/2560",
+      "title": "希望完善程序 让gpt-image-2支持远程图片链接处理",
+      "impact": "needs_review",
+      "categories": [
+        "image_oauth"
+      ],
+      "tokenkey_status": "candidate_unverified",
+      "rationale": "Keyword match for production-sensitive area; not yet manually verified against TokenKey code.",
+      "updated_at": "2026-05-18T17:56:10Z"
     },
     {
       "upstream": "Wei-Shaw/sub2api#263",
@@ -5538,6 +5538,18 @@
       "updated_at": "2026-01-15T02:25:35Z"
     },
     {
+      "upstream": "Wei-Shaw/sub2api#2558",
+      "url": "https://github.com/Wei-Shaw/sub2api/issues/2558",
+      "title": "希望在前端 【渠道】-【模型定价】添加【同步支持最新模型】",
+      "impact": "medium",
+      "categories": [
+        "admin_ui"
+      ],
+      "tokenkey_status": "not_prioritized",
+      "rationale": "Potential compatibility/ops/admin impact, but not selected as severe TokenKey production risk in this pass.",
+      "updated_at": "2026-05-18T14:11:26Z"
+    },
+    {
       "upstream": "Wei-Shaw/sub2api#275",
       "url": "https://github.com/Wei-Shaw/sub2api/issues/275",
       "title": "「UI建议」过期时间增加一个月/一年选项",
@@ -5787,10 +5799,11 @@
       "impact": "fixed",
       "categories": [
         "image_oauth",
-        "security"
+        "security",
+        "enhancement"
       ],
       "tokenkey_status": "fixed_in_tokenkey",
-      "rationale": "Batch account import (/admin/accounts/data) propagates `group_ids` from the payload to CreateAccountInput.GroupIDs so imported accounts get the requested groups directly, without requiring a manual edit-and-save. DataAccount now declares GroupIDs (original definition lacked the field, so JSON `group_ids` was silently dropped at Unmarshal) and the import handler forwards `item.GroupIDs` instead of hard-coded `nil`. Export side also surfaces GroupIDs + ChannelType for round-trip integrity.",
+      "rationale": "Batch account import (/admin/accounts/data) now propagates `group_ids` through to CreateAccountInput.GroupIDs and the symmetric export carries `group_ids` + `channel_type` so an export → import round trip preserves group bindings and newapi fifth-platform metadata. Original implementation defined no GroupIDs field on DataAccount (so JSON `group_ids` was silently dropped at Unmarshal) and the import handler hard-coded `GroupIDs: nil`, leaving batch-imported accounts ungrouped until manually re-edited.",
       "updated_at": "2026-03-19T18:15:43Z"
     },
     {
@@ -5804,7 +5817,7 @@
         "security"
       ],
       "tokenkey_status": "fixed_in_tokenkey",
-      "rationale": "OpenAI /v1/responses passthrough strips top-level `user` before forwarding. The APIKey native path adds `user` to OpenAIGatewayService.Forward's unsupportedFields list (the OAuth path already filters it through applyCodexOAuthTransform); the Cursor-shape short-circuit in ForwardAsChatCompletions adds `user` to cursorResponsesUnsupportedFields. Without this, clients like LobeHub posting `user` to /v1/responses got upstream HTTP 400 'Unsupported parameter: user'.",
+      "rationale": "OpenAI /v1/responses passthrough strips top-level `user` before forwarding. Symmetric coverage on (a) APIKey native path via OpenAIGatewayService.Forward's unsupportedFields list (the OAuth path already strips it through openAIChatGPTInternalUnsupportedFields in applyCodexOAuthTransform) and (b) the Cursor-shape short-circuit in ForwardAsChatCompletions via cursorResponsesUnsupportedFields. Native OpenAI Responses upstream rejects `user` with HTTP 400 \"Unsupported parameter: user\"; the Responses equivalent is `safety_identifier`, which we already filter.",
       "updated_at": "2026-03-24T13:52:59Z"
     },
     {
@@ -6092,7 +6105,7 @@
       ],
       "tokenkey_status": "fixed_in_tokenkey",
       "rationale": "OpenAI /compact route and request-body normalization are implemented, including compact_not_supported errors when no account is available.",
-      "updated_at": "2026-05-18T08:48:32Z"
+      "updated_at": "2026-05-18T15:40:20Z"
     },
     {
       "upstream": "Wei-Shaw/sub2api#2500",
@@ -6171,10 +6184,13 @@
       "categories": [
         "rate_limit_cooldown",
         "billing_usage",
-        "security"
+        "security",
+        "ops_observability",
+        "admin_ui",
+        "enhancement"
       ],
       "tokenkey_status": "fixed_in_tokenkey",
-      "rationale": "OpenAI Chat Completions raw passthrough now detects upstream silent refusal (empty stream / response with finish_reason=stop and no usage) and emits an ops_error_logs row with Kind=silent_refusal. Detection is conservative (zero content + zero tool_calls + zero reasoning + zero refusal + zero usage + finish_reason=stop) so legitimate short answers are not flagged. Surfaces previously invisible 'ghost stream' failures to ops/dashboards.",
+      "rationale": "OpenAI Chat Completions raw passthrough detects upstream silent refusal (empty stream/response with finish_reason=stop and zero usage) and emits an ops_error_logs row with Kind=silent_refusal. Conservative predicate: no content / no tool_calls / no reasoning / no refusal / no chunk-level error / zero usage / finish_reason=stop. Stream path keeps the client-visible bytes untouched (headers already flushed); buffered path will keep flexibility to harden later. The categorical ops signal turns the previously invisible 'ghost stream' (gpt-5.5 above input budget) into a dashboard-pivotable event.",
       "updated_at": "2026-05-18T11:15:08Z"
     },
     {
@@ -9628,7 +9644,7 @@
       "categories": [],
       "tokenkey_status": "not_prioritized",
       "rationale": "No high-signal production-risk keywords in this pass.",
-      "updated_at": "2026-05-07T04:03:11Z"
+      "updated_at": "2026-05-19T02:26:49Z"
     },
     {
       "upstream": "Wei-Shaw/sub2api#2249",
@@ -9988,7 +10004,7 @@
       "categories": [],
       "tokenkey_status": "not_prioritized",
       "rationale": "No high-signal production-risk keywords in this pass.",
-      "updated_at": "2026-05-12T08:16:02Z"
+      "updated_at": "2026-05-19T02:26:59Z"
     },
     {
       "upstream": "Wei-Shaw/sub2api#2405",
@@ -10158,7 +10174,7 @@
       "categories": [],
       "tokenkey_status": "not_prioritized",
       "rationale": "No high-signal production-risk keywords in this pass.",
-      "updated_at": "2026-05-16T17:47:38Z"
+      "updated_at": "2026-05-18T12:55:23Z"
     },
     {
       "upstream": "Wei-Shaw/sub2api#2533",
@@ -10219,6 +10235,26 @@
       "tokenkey_status": "not_prioritized",
       "rationale": "No high-signal production-risk keywords in this pass.",
       "updated_at": "2026-05-18T11:07:01Z"
+    },
+    {
+      "upstream": "Wei-Shaw/sub2api#2559",
+      "url": "https://github.com/Wei-Shaw/sub2api/issues/2559",
+      "title": "No available accounts: no available accounts",
+      "impact": "unknown_low_signal",
+      "categories": [],
+      "tokenkey_status": "not_prioritized",
+      "rationale": "No high-signal production-risk keywords in this pass.",
+      "updated_at": "2026-05-18T17:52:30Z"
+    },
+    {
+      "upstream": "Wei-Shaw/sub2api#2561",
+      "url": "https://github.com/Wei-Shaw/sub2api/issues/2561",
+      "title": "初始化完成后setup居然还能打开",
+      "impact": "unknown_low_signal",
+      "categories": [],
+      "tokenkey_status": "not_prioritized",
+      "rationale": "No high-signal production-risk keywords in this pass.",
+      "updated_at": "2026-05-19T01:48:15Z"
     },
     {
       "upstream": "Wei-Shaw/sub2api#262",


### PR DESCRIPTION
## Summary
- Refresh `scripts/upstream-issue-triage.json` from the latest Wei-Shaw/sub2api issues.
- Update `scripts/upstream-issue-fixes.json` from current TokenKey main fact checks.
- Keep watchdog workflow/script/fact-check metadata in sync with the refreshed cache.

## Watchdog report
# Upstream Issue Watchdog Report

- Run URL: https://github.com/youxuanxue/sub2api/actions/runs/26072490725
- Repository SHA: `e877e82acb876ec4b63c8c3f21f4087de5e28f7a`
- Generated at: `2026-05-19T02:29:36Z`
- Upstream issues scanned: `1370`
- Fact checks: `19`
- Fixed facts verified: `19`
- High/critical unresolved: `0`

## Fixed facts verified

- Wei-Shaw/sub2api#641 via None
- Wei-Shaw/sub2api#2332 via None
- Wei-Shaw/sub2api#2107 via youxuanxue/sub2api#232
- Wei-Shaw/sub2api#2159 via youxuanxue/sub2api#232
- Wei-Shaw/sub2api#2258 via youxuanxue/sub2api#232
- Wei-Shaw/sub2api#2478 via youxuanxue/sub2api#232
- Wei-Shaw/sub2api#2515 via None
- Wei-Shaw/sub2api#2506 via None
- Wei-Shaw/sub2api#2500 via None
- Wei-Shaw/sub2api#1311 via None
- Wei-Shaw/sub2api#2486 via None
- Wei-Shaw/sub2api#2363 via None
- Wei-Shaw/sub2api#2332 via None
- Wei-Shaw/sub2api#1471 via None
- Wei-Shaw/sub2api#2538 via None
- Wei-Shaw/sub2api#2539 via None
- Wei-Shaw/sub2api#2556 via None
- Wei-Shaw/sub2api#1264 via None
- Wei-Shaw/sub2api#1170 via None


## Test plan
- [x] `python3 -m json.tool scripts/upstream-issue-triage.json`
- [x] `python3 -m json.tool scripts/upstream-issue-fixes.json`
- [x] `python3 -m json.tool scripts/upstream-issue-fact-checks.json`
- [x] `python3 -m py_compile scripts/upstream-issue-watchdog.py`
- [x] `python3 -m json.tool .cache/upstream-issue-watchdog/report.json`
- [x] `python3 -m json.tool .cache/upstream-issue-watchdog/agent-input.json`
