### PR TITLE
feat(anthropic): add R3 stub-mirror rpm apply template + clarify SKILL rollout (no-web-impact)

### DIFF
--- a/.cursor/skills/tokenkey-anthropic-oauth-config/SKILL.md
+++ b/.cursor/skills/tokenkey-anthropic-oauth-config/SKILL.md
@@ -146,6 +146,10 @@ python3 scripts/check-prod-anthropic-stub-mirror.py --json   # CI-friendly
 
 报告输出按 `--- account-level (R1) ---` 与 `--- group-level (R3) ---` 两段呈现；JSON 模式下 `stub_violation_count` 与 `group_violation_count` 分项汇总。
 
+### R3 mirror 修复路径（guard fail 后 apply）
+
+`check-prod-anthropic-stub-mirror.py` 只检测、不修改。fail 后 op 用 [`anthropic-stub-mirror-rpm-apply-template.sql`](../../../deploy/aws/stage0/anthropic-stub-mirror-rpm-apply-template.sql) 把 prod stub-only group 的 `rpm_limit` 写到 R3 期望值（即 guard JSON 输出的 `group_results[i].expected_rpm_limit`）。模板顶部 DO 块拒绝对 OAuth-bearing group 使用——后者归 strict-redline aggregate 模板（[`anthropic-oauth-group-aggregate-apply-template.sql`](../../../deploy/aws/stage0/anthropic-oauth-group-aggregate-apply-template.sql)）。
+
 ### 规则的本质
 
 prod 是 router、edge 是 worker。两条镜像规则的共同算子是 **absorb-zero SUM**：router 的容量必须**精确等于** worker 总容量。任何 edge tier 变更（如 H1 升降、增删 OAuth 账号）都会被 guard 自动捕获。
@@ -321,15 +325,17 @@ python3 scripts/check-account-group-rpm-alignment.py --target <edge_id|prod> --s
 
 1. **PR 合入** — `--strict-redline` 默认关闭，线上 apply 流仍走旧口径，行为零回归。
 2. **离线巡检** — 逐 edge / prod 用 `--strict-redline --json` 跑一遍，确认 Layer C 全过（baseline 已逐 tier 落档），列出 Layer A/B violation 清单。
-3. **升 group cap** — 对每个 strict-mode 下违反 Layer A/B 的 group，按 [`anthropic-oauth-group-aggregate-apply-template.sql`](../../../deploy/aws/stage0/anthropic-oauth-group-aggregate-apply-template.sql) 生成自包含 SQL，把 `group.rpm_limit` 升到 `Σ redline`。R3 自动把 prod 镜像跟上（不需要单独 apply prod）。
-4. **切默认** — 全部 strict-mode 巡检通过后，另起一个小 PR 把 `--strict-redline` 翻成默认（或删除旧口径），完成切换。
+3. **升 edge group cap** — 对每个 strict-mode 下违反 Layer A/B 的 **OAuth-bearing** group（典型是 edge `default`），按 [`anthropic-oauth-group-aggregate-apply-template.sql`](../../../deploy/aws/stage0/anthropic-oauth-group-aggregate-apply-template.sql) 生成自包含 SQL，把 `group.rpm_limit` 升到 `Σ redline`。
+4. **同步 prod 镜像（R3）** — `check-prod-anthropic-stub-mirror.py` 是 guard 不是 applier；edge 改完后它会在下一次巡检里检出 prod 镜像漂移。op 须用 [`anthropic-stub-mirror-rpm-apply-template.sql`](../../../deploy/aws/stage0/anthropic-stub-mirror-rpm-apply-template.sql) 把 prod stub-only group（如 `cc-edges`）的 `rpm_limit` 写到 R3 期望值（取自 stub-mirror guard 的 `expected_rpm_limit`）。注意：strict-redline aggregate 模板不适合 stub-only group——它会算出 `Σ = 0` 把组改成 unlimited。
+5. **切默认** — 全部 strict-mode 巡检通过后，另起一个小 PR 把 `--strict-redline` 翻成默认（或删除旧口径），完成切换。
 
 ### 3.3 模板 SQL 是 apply 源头
 
 更新配置时禁止临时手写 SQL 或直接拼一份新的字段清单。必须从仓库模板复制出本次执行 SQL，再只替换本次目标变量和经 `plan-apply` 确认的差异：
 
 - 账号 tier/stability/TLS baseline 更新：复制 `deploy/aws/stage0/anthropic-oauth-stability-tiered-apply-template.sql`
-- 分组聚合 rpm 更新：复制 `deploy/aws/stage0/anthropic-oauth-group-aggregate-apply-template.sql`
+- 分组聚合 rpm 更新（OAuth-bearing group）：复制 `deploy/aws/stage0/anthropic-oauth-group-aggregate-apply-template.sql`
+- R3 镜像 rpm 更新（prod stub-only group）：复制 `deploy/aws/stage0/anthropic-stub-mirror-rpm-apply-template.sql`
 
 推荐落点：`$CLAUDE_JOB_DIR/<edge>-<target>-apply.sql`，不要改原模板来执行单次任务。复制后必须生成**自包含 SQL**：把模板正文复制进该文件，并在文件顶部写入本次 `\set account_name`、`\set stability_tier`、`\set group_name` 等变量；远端 edge 不保证存在仓库 checkout，所以禁止让 SSM/psql 执行依赖远端文件路径的 `\i deploy/aws/stage0/...`。复制后必须保留模板里的 profile、tier、聚合口径和事务结构；只允许改执行变量或经 `plan-apply` 确认过的字面值。若需求确实要求模板未覆盖的新字段，先更新模板和本 skill，再执行 apply，避免 checker、模板和人工 SQL 分叉。
 
@@ -472,9 +478,12 @@ summary.error_count=<n>
 ## 扩展阅读
 
 - `scripts/check-edge-anthropic-oauth-stability.py`
+- `scripts/check-account-group-rpm-alignment.py`
+- `scripts/check-prod-anthropic-stub-mirror.py`
 - `deploy/aws/stage0/anthropic-oauth-stability-baselines-tiered.json`
 - `deploy/aws/stage0/anthropic-oauth-stability-tiered-apply-template.sql`
 - `deploy/aws/stage0/anthropic-oauth-group-aggregate-apply-template.sql`
+- `deploy/aws/stage0/anthropic-stub-mirror-rpm-apply-template.sql`
 - `backend/internal/handler/admin/account_handler.go`
 - `backend/internal/service/admin_service.go`
 - `backend/internal/repository/account_repo.go`

--- a/deploy/aws/stage0/anthropic-oauth-group-aggregate-apply-template.sql
+++ b/deploy/aws/stage0/anthropic-oauth-group-aggregate-apply-template.sql
@@ -37,6 +37,17 @@ DECLARE
   tg TEXT := current_setting('app.target_group_name');
   drift TEXT;
 BEGIN
+  -- Group must exist; otherwise the WITH...UPDATE below silently no-ops
+  -- (a typo in :'group_name' would leave the operator thinking the
+  -- aggregate was written when it wasn't).
+  IF NOT EXISTS (
+    SELECT 1 FROM groups WHERE name = tg AND deleted_at IS NULL
+  ) THEN
+    RAISE EXCEPTION 'group % not found (or soft-deleted)', quote_literal(tg);
+  END IF;
+
+  -- Baseline drift: every base_rpm-carrying account must also carry
+  -- rpm_sticky_buffer.
   SELECT string_agg(a.name, ', ') INTO drift
   FROM groups g
   JOIN account_groups ag ON ag.group_id = g.id

--- a/deploy/aws/stage0/anthropic-stub-mirror-rpm-apply-template.sql
+++ b/deploy/aws/stage0/anthropic-stub-mirror-rpm-apply-template.sql
@@ -37,6 +37,17 @@ DECLARE
   tg TEXT := current_setting('app.target_group_name');
   oauth_member TEXT;
 BEGIN
+  -- Group must exist; otherwise the WITH...UPDATE below silently no-ops
+  -- (a typo in :'group_name' would leave the operator thinking the
+  -- mirror was written when it wasn't).
+  IF NOT EXISTS (
+    SELECT 1 FROM groups WHERE name = tg AND deleted_at IS NULL
+  ) THEN
+    RAISE EXCEPTION 'group % not found (or soft-deleted)', quote_literal(tg);
+  END IF;
+
+  -- Refuse stub-mirror writes on groups that own OAuth accounts; those
+  -- are governed by Σ(redline) via the strict-redline aggregate template.
   SELECT a.name INTO oauth_member
   FROM groups g
   JOIN account_groups ag ON ag.group_id = g.id

--- a/deploy/aws/stage0/anthropic-stub-mirror-rpm-apply-template.sql
+++ b/deploy/aws/stage0/anthropic-stub-mirror-rpm-apply-template.sql
@@ -1,0 +1,106 @@
+-- Anthropic stub-only group RPM mirror apply template (R3 mirror path)
+-- Purpose: write group.rpm_limit on a prod-side stub-only group to mirror
+-- the upstream edge's default_group.rpm_limit, per the R3 rule in
+-- SKILL §"prod 控制面：anthropic stub 主路径镜像规则".
+--
+-- Why this template exists: the strict-redline group-aggregate template
+-- (anthropic-oauth-group-aggregate-apply-template.sql) writes
+-- Σ(account.base_rpm + sticky_buffer), which is wrong for stub-only
+-- groups — they have no OAuth members to sum, so the aggregate would
+-- collapse to 0 and unintentionally make the group unlimited.  R3 mirror
+-- requires writing the precomputed mirror value (= upstream edge default
+-- group's rpm_limit, with absorb-zero across stubs) instead.
+--
+-- Pre-flight:
+--   1. Run scripts/check-prod-anthropic-stub-mirror.py --json against this
+--      target and read `group_results[i].expected_rpm_limit` for the
+--      target group; pass that integer as :new_rpm_limit below.
+--   2. The DO block aborts if any OAuth-type account is bound to the
+--      target group; such groups belong to the strict-redline aggregate
+--      path (anthropic-oauth-group-aggregate-apply-template.sql), not
+--      here.
+--
+-- Usage (psql):
+--   \set group_name 'cc-edges'
+--   \set new_rpm_limit 16
+--   \i deploy/aws/stage0/anthropic-stub-mirror-rpm-apply-template.sql
+
+BEGIN;
+
+-- Pre-flight: refuse to run on a group that owns any OAuth account.  Such
+-- groups are governed by Σ(redline) via the strict-redline aggregate
+-- template, not by R3 mirror.  Bridge :'group_name' into the DO block via
+-- a session GUC so it is not expanded inside the dollar-quoted body.
+SELECT set_config('app.target_group_name', :'group_name', true);
+DO $$
+DECLARE
+  tg TEXT := current_setting('app.target_group_name');
+  oauth_member TEXT;
+BEGIN
+  SELECT a.name INTO oauth_member
+  FROM groups g
+  JOIN account_groups ag ON ag.group_id = g.id
+  JOIN accounts a ON a.id = ag.account_id
+  WHERE g.name = tg
+    AND g.deleted_at IS NULL
+    AND a.platform = 'anthropic'
+    AND a.type = 'oauth'
+    AND a.deleted_at IS NULL
+  LIMIT 1;
+  IF oauth_member IS NOT NULL THEN
+    RAISE EXCEPTION USING
+      MESSAGE = 'group "' || tg || '" contains OAuth account "' || oauth_member || '"; R3 mirror template applies only to stub-only groups',
+      HINT = 'Use deploy/aws/stage0/anthropic-oauth-group-aggregate-apply-template.sql for OAuth-bearing groups (strict-redline aggregate path).';
+  END IF;
+END $$;
+
+WITH target_group AS (
+  SELECT g.id, g.name, g.rpm_limit AS rpm_limit_before
+  FROM groups g
+  WHERE g.name = :'group_name'
+    AND g.deleted_at IS NULL
+  ORDER BY g.id
+  LIMIT 1
+),
+updated_group AS (
+  UPDATE groups g
+  SET rpm_limit = :new_rpm_limit,
+      updated_at = NOW()
+  FROM target_group tg
+  WHERE g.id = tg.id
+  RETURNING g.id, g.name, tg.rpm_limit_before, g.rpm_limit AS rpm_limit_after
+),
+stub_members AS (
+  SELECT
+    a.id,
+    a.name,
+    a.platform,
+    a.type,
+    a.concurrency,
+    NULLIF(a.credentials->>'base_url', '') AS base_url
+  FROM target_group g
+  JOIN account_groups ag ON ag.group_id = g.id
+  JOIN accounts a ON a.id = ag.account_id
+  WHERE a.deleted_at IS NULL
+)
+SELECT jsonb_pretty(jsonb_build_object(
+  'group', (SELECT jsonb_build_object('id', id, 'name', name) FROM target_group),
+  'rpm_limit_update', (SELECT jsonb_build_object(
+    'before', rpm_limit_before,
+    'after', rpm_limit_after,
+    'expected_per_r3_mirror', :new_rpm_limit
+  ) FROM updated_group),
+  'stub_members', COALESCE((
+    SELECT jsonb_agg(jsonb_build_object(
+      'id', id,
+      'name', name,
+      'platform', platform,
+      'type', type,
+      'concurrency', concurrency,
+      'base_url', base_url
+    ) ORDER BY name)
+    FROM stub_members
+  ), '[]'::jsonb)
+));
+
+COMMIT;


### PR DESCRIPTION
## Summary

Followup to [#297](https://github.com/youxuanxue/sub2api/pull/297). When the strict-redline rollout (step 3) actually ran on edge-us1 + prod, two gaps surfaced:

1. **SKILL §3.2.1 step 3 was misleading.** It said *"R3 自动把 prod 镜像跟上（不需要单独 apply prod）"*. `check-prod-anthropic-stub-mirror.py` is a **guard, not an applier** — after the operator raises an edge `default.rpm_limit`, R3 only detects the prod drift on the next sweep. The op still has to write the new value into prod manually.
2. **No apply template existed for prod stub-only groups.** Using `anthropic-oauth-group-aggregate-apply-template.sql` against `cc-edges` would compute `Σ(redline) = 0` (no OAuth members in prod) and unintentionally flip the group to `rpm_limit=0` (unlimited). The operator was forced to hand-write SQL, breaking SKILL §3.3 *"模板 SQL 是 apply 源头"*.

## Changes

**New template — [`anthropic-stub-mirror-rpm-apply-template.sql`](deploy/aws/stage0/anthropic-stub-mirror-rpm-apply-template.sql)**

- Takes `:'group_name'` + `:new_rpm_limit` (typically copied from the stub-mirror guard's `group_results[i].expected_rpm_limit`)
- DO block at the top refuses to run on any OAuth-bearing group, routing the operator to the strict-redline aggregate template instead
- Returns before/after `rpm_limit` plus the stub member roster for audit

**SKILL.md edits**

- §3.2.1: step 3 split into *"升 edge group cap"* + new step 4 *"同步 prod 镜像 (R3)"* pointing at the new template; *"切默认"* renumbered to step 5
- §*"prod 控制面 stub 主路径镜像规则"*: new *"R3 mirror 修复路径"* subsection right after the strict pre-apply gate so the guard-fail → apply path is documented in one place
- §3.3: list the new template under apply-source clause
- 扩展阅读: add the new template + the two guard scripts (`check-account-group-rpm-alignment.py`, `check-prod-anthropic-stub-mirror.py`) that were missing from the list

## Files

```
deploy/aws/stage0/anthropic-stub-mirror-rpm-apply-template.sql  +106  (new)
.cursor/skills/tokenkey-anthropic-oauth-config/SKILL.md         +15 / -3
```

## Test plan

- [x] \`bash scripts/preflight.sh\` — PASS (all sub2api checks green)
- [x] \`bash scripts/check-upstream-drift.sh\` — TK still behind upstream by the same 2 keepalive commits (\`1d78dde8\`, \`164e2f61\`) unrelated to this PR's surface; documented below
- [ ] Apply-template smoke (post-merge): use the new template against prod \`cc-edges\` to lift \`rpm_limit\` 10 → 16 after edge-us1 \`default.rpm_limit\` is raised to 16 via the existing aggregate template

## Why ship this before the actual alignment apply

The operator's current task is exactly the case this PR is fixing — edge-us1 needs \`rpm_limit\` 10 → 16, and prod \`cc-edges\` needs to mirror to 16 right after. Without this PR the operator either has to hand-write SQL (violates §3.3) or use the wrong template (would write 0). Shipping this small follow-up first keeps the operational story end-to-end template-driven.

## Upstream drift note

\`scripts/check-upstream-drift.sh\` reports TK is still 2 commits behind upstream/main (\`1d78dde8\`, \`164e2f61\`, both Anthropic passthrough keepalive fix). Neither touches \`deploy/aws/stage0/\` or the anthropic OAuth/stub apply path — surface is fully disjoint. Per CLAUDE.md §5.y this PR ships out of order as a SKILL+template doc/tooling change; the keepalive merge will be tackled separately in a \`merge/upstream-*\` PR.

## Reviewer reminder

- TK-originated PR → **Squash and merge** per CLAUDE.md §5.y.
- After merging, the followup is the operator's apply run (raise edge-us1 \`default.rpm_limit\` 10 → 16, then prod \`cc-edges.rpm_limit\` 10 → 16 with the new template).

🤖 Generated with [Claude Code](https://claude.com/claude-code)