### PR TITLE
fix(openai): propagate shouldDisable in passthrough error handling (upstream #1318) (no-web-impact)

### DIFF
--- a/backend/internal/service/openai_gateway_service.go
+++ b/backend/internal/service/openai_gateway_service.go
@@ -3375,11 +3375,23 @@ func (s *OpenAIGatewayService) handleErrorResponsePassthrough(
 	}
 	setOpsUpstreamError(c, resp.StatusCode, upstreamMsg, upstreamDetail)
 	logOpenAIInstructionsRequiredDebug(ctx, c, account, resp.StatusCode, upstreamMsg, requestBody, body)
+	// TK: See upstream Wei-Shaw/sub2api#1318 — passthrough error handling used to
+	// discard HandleUpstreamError's shouldDisable signal. When the rate-limit
+	// service decided the account must stop scheduling (temp-unsched rule match,
+	// 402 deactivated_workspace, OAuth 401, "organization has been disabled",
+	// etc.) the side effects fired but the current request still returned the
+	// raw upstream error to the client. The result was a half-applied policy:
+	// account got marked, but the in-flight request was not failed over. The
+	// non-passthrough handler at handleErrorResponse already captures this
+	// signal — make passthrough match so the UI-configured temp-unsched rules
+	// actually take effect on the current request.
+	shouldDisable := false
 	if s.rateLimitService != nil {
-		// Passthrough mode preserves the raw upstream error response, but runtime
-		// account state still needs to be updated so sticky routing can stop
-		// reusing a freshly rate-limited account.
-		_ = s.rateLimitService.HandleUpstreamError(ctx, account, resp.StatusCode, resp.Header, body)
+		shouldDisable = s.rateLimitService.HandleUpstreamError(ctx, account, resp.StatusCode, resp.Header, body)
+	}
+	kind := "http_error"
+	if shouldDisable {
+		kind = "failover"
 	}
 	appendOpsUpstreamError(c, OpsUpstreamErrorEvent{
 		Platform:             account.Platform,
@@ -3388,11 +3400,18 @@ func (s *OpenAIGatewayService) handleErrorResponsePassthrough(
 		UpstreamStatusCode:   resp.StatusCode,
 		UpstreamRequestID:    resp.Header.Get("x-request-id"),
 		Passthrough:          true,
-		Kind:                 "http_error",
+		Kind:                 kind,
 		Message:              upstreamMsg,
 		Detail:               upstreamDetail,
 		UpstreamResponseBody: upstreamDetail,
 	})
+	if shouldDisable {
+		return &UpstreamFailoverError{
+			StatusCode:      resp.StatusCode,
+			ResponseBody:    body,
+			ResponseHeaders: resp.Header.Clone(),
+		}
+	}
 
 	writeOpenAIPassthroughResponseHeaders(c.Writer.Header(), resp.Header, s.responseHeaderFilter)
 	contentType := resp.Header.Get("Content-Type")

--- a/backend/internal/service/openai_oauth_passthrough_test.go
+++ b/backend/internal/service/openai_oauth_passthrough_test.go
@@ -883,6 +883,118 @@ func TestOpenAIGatewayService_OpenAIPassthrough_429And529TriggerFailover(t *test
 	}
 }
 
+// passthroughTempUnschedRepo records SetTempUnschedulable calls so the test can
+// assert that a hit on a temp-unsched rule actually propagates to the account
+// repository. SetTempUnschedulable returns nil so the rate-limit service treats
+// the trigger as successful and HandleUpstreamError reports shouldDisable=true.
+type passthroughTempUnschedRepo struct {
+	stubOpenAIAccountRepo
+	tempUnschedCalls []time.Time
+	tempUnschedRason []string
+}
+
+func (r *passthroughTempUnschedRepo) SetTempUnschedulable(_ context.Context, _ int64, until time.Time, reason string) error {
+	r.tempUnschedCalls = append(r.tempUnschedCalls, until)
+	r.tempUnschedRason = append(r.tempUnschedRason, reason)
+	return nil
+}
+
+// TestOpenAIGatewayService_OpenAIPassthrough_TempUnschedRuleTriggersFailover pins
+// the fix for upstream Wei-Shaw/sub2api#1318: when an OAuth account in
+// passthrough mode hits a configured temporary-unschedulable rule, the rate-
+// limit service must (a) mark the account temp-unsched (existing behavior),
+// AND (b) the current request must return UpstreamFailoverError so the handler
+// can fail over to another account instead of returning the upstream error to
+// the client. Before the fix, passthrough discarded HandleUpstreamError's
+// shouldDisable signal and only the side effect fired — the in-flight request
+// was still completed against the now-disabled account.
+func TestOpenAIGatewayService_OpenAIPassthrough_TempUnschedRuleTriggersFailover(t *testing.T) {
+	gin.SetMode(gin.TestMode)
+
+	rec := httptest.NewRecorder()
+	c, _ := gin.CreateTestContext(rec)
+	c.Request = httptest.NewRequest(http.MethodPost, "/v1/responses", bytes.NewReader(nil))
+	c.Request.Header.Set("User-Agent", "codex_cli_rs/0.1.0")
+
+	originalBody := []byte(`{"model":"gpt-5.2","stream":false,"instructions":"local-test-instructions","input":[{"type":"text","text":"hi"}]}`)
+
+	// Upstream returns 402 with body matching the configured temp-unsched
+	// keyword "deactivated". The rate-limit service must trigger the rule and
+	// report shouldDisable=true.
+	resp := &http.Response{
+		StatusCode: http.StatusPaymentRequired,
+		Header: http.Header{
+			"Content-Type": []string{"application/json"},
+			"x-request-id": []string{"rid-temp-unsched"},
+		},
+		Body: io.NopCloser(strings.NewReader(`{"detail":{"code":"deactivated_workspace"}}`)),
+	}
+	upstream := &httpUpstreamRecorder{resp: resp}
+
+	repo := &passthroughTempUnschedRepo{}
+	rateSvc := &RateLimitService{
+		accountRepo: repo,
+		cfg: &config.Config{
+			RateLimit: config.RateLimitConfig{OverloadCooldownMinutes: 10},
+		},
+	}
+
+	svc := &OpenAIGatewayService{
+		cfg:              &config.Config{Gateway: config.GatewayConfig{ForceCodexCLI: false}},
+		httpUpstream:     upstream,
+		rateLimitService: rateSvc,
+	}
+
+	account := &Account{
+		ID:          321,
+		Name:        "acc-temp-unsched",
+		Platform:    PlatformOpenAI,
+		Type:        AccountTypeOAuth,
+		Concurrency: 1,
+		Credentials: map[string]any{
+			"access_token":               "oauth-token",
+			"chatgpt_account_id":         "chatgpt-acc",
+			"temp_unschedulable_enabled": true,
+			"temp_unschedulable_rules": []any{
+				map[string]any{
+					"error_code":       float64(402),
+					"keywords":         []any{"deactivated"},
+					"duration_minutes": float64(1440),
+					"description":      "402 deactivated workspace -> temp unsched",
+				},
+			},
+		},
+		Extra:          map[string]any{"openai_passthrough": true},
+		Status:         StatusActive,
+		Schedulable:    true,
+		RateMultiplier: f64p(1),
+	}
+
+	_, err := svc.Forward(context.Background(), c, account, originalBody)
+	require.Error(t, err)
+
+	var failoverErr *UpstreamFailoverError
+	require.ErrorAs(t, err, &failoverErr,
+		"passthrough + temp-unsched rule match must surface UpstreamFailoverError so the handler retries on another account")
+	require.Equal(t, http.StatusPaymentRequired, failoverErr.StatusCode)
+	require.False(t, c.Writer.Written(),
+		"passthrough must NOT write the upstream error to the client when the account was disabled — failover loop owns the response")
+
+	require.Len(t, repo.tempUnschedCalls, 1,
+		"the temp-unsched rule must still take its side effect on the account repository")
+
+	v, ok := c.Get(OpsUpstreamErrorsKey)
+	require.True(t, ok)
+	arr, ok := v.([]*OpsUpstreamErrorEvent)
+	require.True(t, ok)
+	require.NotEmpty(t, arr)
+	last := arr[len(arr)-1]
+	require.True(t, last.Passthrough)
+	require.Equal(t, "failover", last.Kind,
+		"shouldDisable=true must mark the ops event as failover, not http_error")
+	require.Equal(t, http.StatusPaymentRequired, last.UpstreamStatusCode)
+}
+
 func TestOpenAIGatewayService_OAuthPassthrough_NonCodexUAFallbackToCodexUA(t *testing.T) {
 	gin.SetMode(gin.TestMode)
 

--- a/backend/internal/service/openai_oauth_passthrough_test.go
+++ b/backend/internal/service/openai_oauth_passthrough_test.go
@@ -889,13 +889,13 @@ func TestOpenAIGatewayService_OpenAIPassthrough_429And529TriggerFailover(t *test
 // the trigger as successful and HandleUpstreamError reports shouldDisable=true.
 type passthroughTempUnschedRepo struct {
 	stubOpenAIAccountRepo
-	tempUnschedCalls []time.Time
-	tempUnschedRason []string
+	tempUnschedCalls   []time.Time
+	tempUnschedReasons []string
 }
 
 func (r *passthroughTempUnschedRepo) SetTempUnschedulable(_ context.Context, _ int64, until time.Time, reason string) error {
 	r.tempUnschedCalls = append(r.tempUnschedCalls, until)
-	r.tempUnschedRason = append(r.tempUnschedRason, reason)
+	r.tempUnschedReasons = append(r.tempUnschedReasons, reason)
 	return nil
 }
 
@@ -982,6 +982,18 @@ func TestOpenAIGatewayService_OpenAIPassthrough_TempUnschedRuleTriggersFailover(
 
 	require.Len(t, repo.tempUnschedCalls, 1,
 		"the temp-unsched rule must still take its side effect on the account repository")
+	// Reason must carry the matched rule context (status code + matched keyword)
+	// so ops can later attribute the disable back to the right rule. This pins
+	// that #1318's regression is not just "shouldDisable propagated" but also
+	// "the matched-rule reason was actually persisted" — a previous half-applied
+	// state where the reason was empty would silently make admin troubleshooting
+	// useless.
+	require.Len(t, repo.tempUnschedReasons, 1)
+	persistedReason := repo.tempUnschedReasons[0]
+	require.Contains(t, persistedReason, "deactivated",
+		"persisted temp-unsched reason must contain the matched keyword so admin/ops can attribute the disable")
+	require.Contains(t, persistedReason, "402",
+		"persisted temp-unsched reason must contain the triggering status code")
 
 	v, ok := c.Get(OpsUpstreamErrorsKey)
 	require.True(t, ok)

--- a/scripts/gateway-tk-sentinels.json
+++ b/scripts/gateway-tk-sentinels.json
@@ -663,6 +663,23 @@
         "docs/approved/rpm-override-deferred-removal.md"
       ],
       "rationale": "Admin dashboard RPMMax must surface the real L1 rate-limit gate (group.rpm_limit) instead of Σ account.base_rpm — after the strict-redline rollout (PR #297) these two values diverge by the sticky_buffer gap and the Σ aggregate becomes a visible lie. Three TK touches in this upstream-shaped file: (1) getGroupCapacity takes the group's rpm_limit as an explicit parameter (function-signature drift caught by `groupRPMLimit int`); (2) the override branch (`if groupRPMLimit > 0 {`) flips RPMMax from Σ base_rpm to the real cap, fallback only when unlimited; (3) the rpmCache query guard adds `|| groupRPMLimit > 0` so a group composed entirely of unlimited (base_rpm=0) accounts but capped by group.rpm_limit > 0 still shows live RPMUsed instead of frozen 0. The doc anchor pins the deferred-removal decision for the L1 rpm_override layer (see docs/approved/rpm-override-deferred-removal.md) so a future cleanup understands why this companion file is more than cosmetic."
+    },
+    {
+      "path": "backend/internal/service/openai_gateway_service.go",
+      "must_contain": [
+        "upstream Wei-Shaw/sub2api#1318",
+        "shouldDisable = s.rateLimitService.HandleUpstreamError(ctx, account, resp.StatusCode, resp.Header, body)",
+        "if shouldDisable {\n\t\treturn &UpstreamFailoverError{"
+      ],
+      "rationale": "openai_passthrough error handling (handleErrorResponsePassthrough) MUST propagate HandleUpstreamError's shouldDisable signal: when the rate-limit service decides the account must stop scheduling (temp-unsched rule match, 402 deactivated_workspace, OAuth 401, organization-disabled 400, ...) the current request must return UpstreamFailoverError so the handler retries on another account. Before upstream #1318, the signal was discarded with `_ =` and only the side effect on the account fired — the in-flight request was completed against the now-disabled account, surfacing to the client as the raw upstream error. The literal `shouldDisable = ...` line is pinned so a refactor that reverts to discarding the return value fails preflight rather than reintroducing the half-applied policy at runtime."
+    },
+    {
+      "path": "backend/internal/service/openai_oauth_passthrough_test.go",
+      "must_contain": [
+        "TestOpenAIGatewayService_OpenAIPassthrough_TempUnschedRuleTriggersFailover",
+        "passthrough must NOT write the upstream error to the client when the account was disabled"
+      ],
+      "rationale": "Focused regression anchor for upstream #1318: passthrough + temp-unsched rule match must (a) surface UpstreamFailoverError, (b) leave c.Writer untouched so the failover loop owns the response, and (c) tag the ops event with Kind=failover. Without this test, a future refactor of handleErrorResponsePassthrough could silently revert to discarding shouldDisable (the original upstream bug) and the regression would only show up in production when a temp-unsched rule is actually configured."
     }
   ]
 }

--- a/scripts/gateway-tk-sentinels.json
+++ b/scripts/gateway-tk-sentinels.json
@@ -668,10 +668,9 @@
       "path": "backend/internal/service/openai_gateway_service.go",
       "must_contain": [
         "upstream Wei-Shaw/sub2api#1318",
-        "shouldDisable = s.rateLimitService.HandleUpstreamError(ctx, account, resp.StatusCode, resp.Header, body)",
-        "if shouldDisable {\n\t\treturn &UpstreamFailoverError{"
+        "shouldDisable = s.rateLimitService.HandleUpstreamError(ctx, account, resp.StatusCode, resp.Header, body)"
       ],
-      "rationale": "openai_passthrough error handling (handleErrorResponsePassthrough) MUST propagate HandleUpstreamError's shouldDisable signal: when the rate-limit service decides the account must stop scheduling (temp-unsched rule match, 402 deactivated_workspace, OAuth 401, organization-disabled 400, ...) the current request must return UpstreamFailoverError so the handler retries on another account. Before upstream #1318, the signal was discarded with `_ =` and only the side effect on the account fired — the in-flight request was completed against the now-disabled account, surfacing to the client as the raw upstream error. The literal `shouldDisable = ...` line is pinned so a refactor that reverts to discarding the return value fails preflight rather than reintroducing the half-applied policy at runtime."
+      "rationale": "openai_passthrough error handling (handleErrorResponsePassthrough) MUST propagate HandleUpstreamError's shouldDisable signal: when the rate-limit service decides the account must stop scheduling (temp-unsched rule match, 402 deactivated_workspace, OAuth 401, organization-disabled 400, ...) the current request must return UpstreamFailoverError so the handler retries on another account. Before upstream #1318, the signal was discarded with `_ =` and only the side effect on the account fired — the in-flight request was completed against the now-disabled account, surfacing to the client as the raw upstream error. Pinning the literal `shouldDisable = s.rateLimitService.HandleUpstreamError(...)` assignment (not `_ =`) is enough to catch the regression. The registry intentionally avoids pinning the gofmt-shaped `if shouldDisable {...}` block so future zap-field / logging additions inside the same branch do not break preflight. Behavior is exercised end-to-end by TestOpenAIGatewayService_OpenAIPassthrough_TempUnschedRuleTriggersFailover (which is pinned by its own sentinel below)."
     },
     {
       "path": "backend/internal/service/openai_oauth_passthrough_test.go",

--- a/scripts/upstream-issue-fact-checks.json
+++ b/scripts/upstream-issue-fact-checks.json
@@ -344,6 +344,20 @@
         "backend/internal/service/openai_gateway_messages_tk_terminal_event_test.go:TestIsOpenAICompatResponsesTerminalEvent_FullSet",
         "scripts/terminal-sentinels.json:openai_compat_responses_terminal_helper"
       ]
+    },
+    {
+      "upstream": "Wei-Shaw/sub2api#1318",
+      "severity": "high",
+      "summary": "openai_passthrough now propagates HandleUpstreamError's shouldDisable signal: when a temp-unschedulable rule (or any policy that marks the account unschedulable — 402 deactivated_workspace, OAuth 401, organization disabled, etc.) fires, handleErrorResponsePassthrough returns UpstreamFailoverError and emits ops Kind=failover instead of writing the upstream error straight back to the client. This closes the half-applied state where the account got disabled but the in-flight request was still completed on it.",
+      "fixed_by": [
+        "backend/internal/service/openai_gateway_service.go",
+        "backend/internal/service/openai_oauth_passthrough_test.go"
+      ],
+      "fixed_if_all_present": [
+        "backend/internal/service/openai_gateway_service.go:upstream Wei-Shaw/sub2api#1318",
+        "backend/internal/service/openai_gateway_service.go:shouldDisable = s.rateLimitService.HandleUpstreamError(ctx, account, resp.StatusCode, resp.Header, body)",
+        "backend/internal/service/openai_oauth_passthrough_test.go:TestOpenAIGatewayService_OpenAIPassthrough_TempUnschedRuleTriggersFailover"
+      ]
     }
   ]
 }

--- a/scripts/upstream-issue-fixes.json
+++ b/scripts/upstream-issue-fixes.json
@@ -58,6 +58,15 @@
       "summary": "Non-stream buffered SSE->JSON handlers in both the OpenAI gateway (/v1/chat/completions, /v1/messages) and the Anthropic-backed gateway forward paths (Responses, Chat Completions) now explicitly set Content-Type: application/json after WriteFilteredHeaders. Without this, the upstream SSE Content-Type (text/event-stream) leaks onto JSON bodies because gin's render.writeContentType only writes when no Content-Type is set, breaking OpenAI-SDK consumers that branch on Content-Type."
     },
     {
+      "upstream": "Wei-Shaw/sub2api#1318",
+      "status": "fixed_in_tokenkey",
+      "fixed_by": [
+        "backend/internal/service/openai_gateway_service.go",
+        "backend/internal/service/openai_oauth_passthrough_test.go"
+      ],
+      "summary": "openai_passthrough now propagates HandleUpstreamError's shouldDisable signal: when a temp-unschedulable rule (or any policy that marks the account unschedulable — 402 deactivated_workspace, OAuth 401, organization disabled, etc.) fires, handleErrorResponsePassthrough returns UpstreamFailoverError and emits ops Kind=failover instead of writing the upstream error straight back to the client. This closes the half-applied state where the account got disabled but the in-flight request was still completed on it."
+    },
+    {
       "upstream": "Wei-Shaw/sub2api#1322",
       "status": "fixed_in_tokenkey",
       "fixed_by": [

--- a/scripts/upstream-issue-triage.json
+++ b/scripts/upstream-issue-triage.json
@@ -4,8 +4,8 @@
   "generated_from": "GitHub REST API issues?state=open; pull requests excluded",
   "rationale": "TokenKey-local triage cache for upstream open issues. Use this file before re-triaging upstream issues; update entries when TokenKey fixes, dismisses, or reclassifies an issue.",
   "counts": {
-    "needs_review": 344,
-    "fixed": 32,
+    "needs_review": 343,
+    "fixed": 33,
     "needs_prod_validation": 4,
     "medium": 115,
     "not_applicable": 1,
@@ -298,19 +298,6 @@
       "tokenkey_status": "candidate_unverified",
       "rationale": "Keyword match for production-sensitive area; not yet manually verified against TokenKey code.",
       "updated_at": "2026-04-19T10:53:21Z"
-    },
-    {
-      "upstream": "Wei-Shaw/sub2api#1318",
-      "url": "https://github.com/Wei-Shaw/sub2api/issues/1318",
-      "title": "[bug] openai_passthrough 命中临时不可调度规则后未触发 failover",
-      "impact": "needs_review",
-      "categories": [
-        "rate_limit_cooldown",
-        "image_oauth"
-      ],
-      "tokenkey_status": "candidate_unverified",
-      "rationale": "Keyword match for production-sensitive area; not yet manually verified against TokenKey code.",
-      "updated_at": "2026-03-26T06:47:06Z"
     },
     {
       "upstream": "Wei-Shaw/sub2api#1326",
@@ -5809,6 +5796,19 @@
       "tokenkey_status": "fixed_in_tokenkey",
       "rationale": "Non-stream buffered SSE->JSON handlers in both the OpenAI gateway (/v1/chat/completions, /v1/messages) and the Anthropic-backed gateway forward paths (Responses, Chat Completions) now explicitly set Content-Type: application/json after WriteFilteredHeaders. Without this, the upstream SSE Content-Type (text/event-stream) leaks onto JSON bodies because gin's render.writeContentType only writes when no Content-Type is set, breaking OpenAI-SDK consumers that branch on Content-Type.",
       "updated_at": "2026-05-15T12:00:37Z"
+    },
+    {
+      "upstream": "Wei-Shaw/sub2api#1318",
+      "url": "https://github.com/Wei-Shaw/sub2api/issues/1318",
+      "title": "[bug] openai_passthrough 命中临时不可调度规则后未触发 failover",
+      "impact": "fixed",
+      "categories": [
+        "rate_limit_cooldown",
+        "image_oauth"
+      ],
+      "tokenkey_status": "fixed_in_tokenkey",
+      "rationale": "openai_passthrough now propagates HandleUpstreamError's shouldDisable signal: when a temp-unschedulable rule (or any policy that marks the account unschedulable — 402 deactivated_workspace, OAuth 401, organization disabled, etc.) fires, handleErrorResponsePassthrough returns UpstreamFailoverError and emits ops Kind=failover instead of writing the upstream error straight back to the client. This closes the half-applied state where the account got disabled but the in-flight request was still completed on it.",
+      "updated_at": "2026-03-26T06:47:06Z"
     },
     {
       "upstream": "Wei-Shaw/sub2api#1322",


### PR DESCRIPTION
## Summary
- Closes the half-applied policy in `openai_passthrough` error handling: when the rate-limit service decides an account must stop scheduling (temp-unschedulable rule match, 402 `deactivated_workspace`, OAuth 401, organization-disabled 400, …), the current request now returns `UpstreamFailoverError` so the existing failover loop retries on another account, instead of completing on the now-disabled account and writing the raw upstream error to the client.
- Captures the `shouldDisable` return value from `RateLimitService.HandleUpstreamError` in `handleErrorResponsePassthrough` (was discarded with `_`), mirroring the non-passthrough `handleErrorResponse` path. Ops event is tagged `Kind=failover` so dashboards distinguish "account disabled, request failed over" from passthrough's normal "raw upstream error returned to client".
- Adds focused regression `TestOpenAIGatewayService_OpenAIPassthrough_TempUnschedRuleTriggersFailover` covering OAuth account + passthrough + 402 + temp-unsched rule match → `UpstreamFailoverError` surfaced, `c.Writer` untouched, ops `Kind=failover`, account temp-unsched persisted on the repo.

## Why
Upstream Wei-Shaw/sub2api#1318 reports: after an `openai_passthrough=true` account hits a configured temp-unschedulable rule (e.g. `error_code=402` + keyword `deactivated`), the rule's side effect runs but the in-flight request still completes on the disabled account. Operators had to manually flip schedulable=false to stop the bleeding. Root cause: `handleErrorResponsePassthrough` was invoking `HandleUpstreamError` for the side effect only and ignoring the `shouldDisable` boolean. Other call sites (`handleErrorResponse`, `handleCompatErrorResponse`) already convert `shouldDisable=true` into `UpstreamFailoverError` — passthrough was the lone outlier.

The 429/529 burst path (`handleFailoverErrorResponsePassthrough`) was already correct; this PR only fills the gap for the other status codes (402/403/503/etc.) that flow through the generic error handler.

## Mechanical guards added
- `scripts/gateway-tk-sentinels.json` pins the `shouldDisable = HandleUpstreamError(...)` line in `openai_gateway_service.go` and the test name + "must NOT write" assertion so a future refactor that reverts to `_ =` fails preflight rather than only at runtime.
- `scripts/upstream-issue-fact-checks.json` and `scripts/upstream-issue-fixes.json` add fact-check entries so the upstream-issue watchdog reclassifies #1318 from `candidate_unverified` → `fixed_in_tokenkey`. `scripts/upstream-issue-triage.json` is the watchdog-regenerated cache.

## Scope / Out of scope
- **No web impact.** Backend-only change to OpenAI passthrough error semantics; no frontend, no migration, no config surface, no docs. Existing UI for temp-unsched rules is unchanged — this PR just makes those rules actually take effect on the in-flight request.
- 429/529 burst path unchanged (already correct).
- Non-passthrough OpenAI path unchanged (already correct).
- Chat Completions raw passthrough unchanged — out of scope for #1318.

## Test plan
- [x] `cd backend && go test -tags=unit ./internal/service/...` — full service package green (87s).
- [x] `go test -tags=unit -run 'Passthrough|Failover' ./internal/service/...` — green.
- [x] `go vet ./internal/service/...` — clean.
- [x] `golangci-lint run --new-from-rev=HEAD~ ./internal/service/...` — 0 issues.
- [x] `bash scripts/preflight.sh` — PASS (incl. sentinel registry update gate + sentinel registry intact).
- [x] Watchdog dry-run: `#1318` now reports `fixed_verified` with all three facts hitting.

🤖 Generated with [Claude Code](https://claude.com/claude-code)