### PR TITLE
fix(openai): treat response.cancelled/canceled as terminal in compat Responses stream (upstream #1322) (no-web-impact)

### DIFF
--- a/backend/internal/service/openai_gateway_chat_completions_tk_cancelled_terminal_test.go
+++ b/backend/internal/service/openai_gateway_chat_completions_tk_cancelled_terminal_test.go
@@ -1,0 +1,120 @@
+package service
+
+import (
+	"bytes"
+	"context"
+	"io"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"testing"
+
+	"github.com/gin-gonic/gin"
+	"github.com/stretchr/testify/require"
+)
+
+// TestForwardAsChatCompletions_ResponseCancelledIsTerminal_NoMissingTerminalError
+// is the behaviour-contract regression for upstream Wei-Shaw/sub2api#1322.
+// Before the fix, isOpenAICompatResponsesTerminalEvent only recognised
+// completed/done/incomplete/failed; if the upstream Responses SSE ended with
+// response.cancelled the stream loop fell through to [DONE], returning
+// "stream usage incomplete: missing terminal event" and emitting a spurious
+// openai.forward_failed ops_error_logs row. Helper-level unit coverage lives
+// in openai_gateway_messages_tk_terminal_event_test.go; this test pins the
+// cross-function contract (processDataLine -> finalizeStream) so future
+// refactors of the streaming wiring cannot silently re-break it.
+func TestForwardAsChatCompletions_ResponseCancelledIsTerminal_NoMissingTerminalError(t *testing.T) {
+	gin.SetMode(gin.TestMode)
+
+	rec := httptest.NewRecorder()
+	c, _ := gin.CreateTestContext(rec)
+	body := []byte(`{"model":"gpt-5.4","messages":[{"role":"user","content":"hello"}],"stream":true}`)
+	c.Request = httptest.NewRequest(http.MethodPost, "/v1/chat/completions", bytes.NewReader(body))
+	c.Request.Header.Set("Content-Type", "application/json")
+
+	upstreamBody := strings.Join([]string{
+		`data: {"type":"response.created","response":{"id":"resp_1","model":"gpt-5.4","status":"in_progress","output":[]}}`,
+		"",
+		`data: {"type":"response.output_text.delta","delta":"ok"}`,
+		"",
+		`data: {"type":"response.cancelled","response":{"id":"resp_1","object":"response","model":"gpt-5.4","status":"cancelled","output":[],"usage":{"input_tokens":3,"output_tokens":1,"total_tokens":4}}}`,
+		"",
+		"data: [DONE]",
+		"",
+	}, "\n")
+	upstream := &httpUpstreamRecorder{resp: &http.Response{
+		StatusCode: http.StatusOK,
+		Header:     http.Header{"Content-Type": []string{"text/event-stream"}, "x-request-id": []string{"rid_chat_cancelled"}},
+		Body:       io.NopCloser(strings.NewReader(upstreamBody)),
+	}}
+
+	svc := &OpenAIGatewayService{httpUpstream: upstream}
+	account := &Account{
+		ID:          1,
+		Name:        "openai-oauth",
+		Platform:    PlatformOpenAI,
+		Type:        AccountTypeOAuth,
+		Concurrency: 1,
+		Credentials: map[string]any{
+			"access_token":       "oauth-token",
+			"chatgpt_account_id": "chatgpt-acc",
+		},
+	}
+
+	result, err := svc.ForwardAsChatCompletions(context.Background(), c, account, body, "", "gpt-5.1")
+	require.NoError(t, err, "response.cancelled must close the stream cleanly, not surface missing-terminal")
+	require.NotNil(t, result)
+	// Cancelled events carry usage in the upstream contract; billing must pick it up via the wrapper.
+	require.Equal(t, 3, result.Usage.InputTokens)
+	require.Equal(t, 1, result.Usage.OutputTokens)
+	// Downstream client must see the canonical SSE terminal and no error tail.
+	require.Contains(t, rec.Body.String(), "data: [DONE]")
+	require.NotContains(t, rec.Body.String(), "missing terminal event")
+}
+
+// TestForwardAsChatCompletions_ResponseCanceledIsTerminal_NoMissingTerminalError
+// pins the same contract for the single-`l` "canceled" spelling. The OpenAI
+// Responses contract uses both spellings interchangeably (see
+// openai_ws_forwarder.go and openai_ws_v2/passthrough_relay.go), and any
+// future trimming that drops one but not the other re-opens #1322 silently.
+func TestForwardAsChatCompletions_ResponseCanceledIsTerminal_NoMissingTerminalError(t *testing.T) {
+	gin.SetMode(gin.TestMode)
+
+	rec := httptest.NewRecorder()
+	c, _ := gin.CreateTestContext(rec)
+	body := []byte(`{"model":"gpt-5.4","messages":[{"role":"user","content":"hello"}],"stream":true}`)
+	c.Request = httptest.NewRequest(http.MethodPost, "/v1/chat/completions", bytes.NewReader(body))
+	c.Request.Header.Set("Content-Type", "application/json")
+
+	upstreamBody := strings.Join([]string{
+		`data: {"type":"response.canceled","response":{"id":"resp_2","object":"response","model":"gpt-5.4","status":"canceled","output":[],"usage":{"input_tokens":2,"output_tokens":0,"total_tokens":2}}}`,
+		"",
+		"data: [DONE]",
+		"",
+	}, "\n")
+	upstream := &httpUpstreamRecorder{resp: &http.Response{
+		StatusCode: http.StatusOK,
+		Header:     http.Header{"Content-Type": []string{"text/event-stream"}, "x-request-id": []string{"rid_chat_canceled"}},
+		Body:       io.NopCloser(strings.NewReader(upstreamBody)),
+	}}
+
+	svc := &OpenAIGatewayService{httpUpstream: upstream}
+	account := &Account{
+		ID:          1,
+		Name:        "openai-oauth",
+		Platform:    PlatformOpenAI,
+		Type:        AccountTypeOAuth,
+		Concurrency: 1,
+		Credentials: map[string]any{
+			"access_token":       "oauth-token",
+			"chatgpt_account_id": "chatgpt-acc",
+		},
+	}
+
+	result, err := svc.ForwardAsChatCompletions(context.Background(), c, account, body, "", "gpt-5.1")
+	require.NoError(t, err, "response.canceled must close the stream cleanly, not surface missing-terminal")
+	require.NotNil(t, result)
+	require.Equal(t, 2, result.Usage.InputTokens)
+	require.Contains(t, rec.Body.String(), "data: [DONE]")
+	require.NotContains(t, rec.Body.String(), "missing terminal event")
+}

--- a/backend/internal/service/openai_gateway_messages.go
+++ b/backend/internal/service/openai_gateway_messages.go
@@ -518,9 +518,9 @@ func (s *OpenAIGatewayService) handleAnthropicErrorResponse(
 }
 
 // handleAnthropicBufferedStreamingResponse reads all Responses SSE events from
-// the upstream streaming response, finds the terminal event (response.completed
-// / response.incomplete / response.failed), converts the complete response to
-// Anthropic Messages JSON format, and writes it to the client.
+// the upstream streaming response, finds the terminal event (the six-event
+// set in isOpenAICompatResponsesTerminalEvent), converts the complete response
+// to Anthropic Messages JSON format, and writes it to the client.
 // This is used when the client requested stream=false but the upstream is always
 // streaming.
 func (s *OpenAIGatewayService) handleAnthropicBufferedStreamingResponse(
@@ -583,7 +583,13 @@ func (s *OpenAIGatewayService) handleAnthropicBufferedStreamingResponse(
 
 func isOpenAICompatResponsesTerminalEvent(eventType string) bool {
 	switch strings.TrimSpace(eventType) {
-	case "response.completed", "response.done", "response.incomplete", "response.failed":
+	// TK: align with openAIStreamEventIsTerminal (gateway_service.go),
+	// openai_ws_forwarder.go, and openai_ws_v2/passthrough_relay.go so that
+	// upstream-emitted response.cancelled / response.canceled close the
+	// streaming loop cleanly instead of falling through to "stream usage
+	// incomplete: missing terminal event". See upstream Wei-Shaw/sub2api#1322.
+	case "response.completed", "response.done", "response.incomplete", "response.failed",
+		"response.cancelled", "response.canceled":
 		return true
 	default:
 		return false

--- a/backend/internal/service/openai_gateway_messages_tk_terminal_event_test.go
+++ b/backend/internal/service/openai_gateway_messages_tk_terminal_event_test.go
@@ -1,0 +1,52 @@
+package service
+
+import "testing"
+
+// TestIsOpenAICompatResponsesTerminalEvent_FullSet pins the six terminal event
+// types the Responses-stream consumer must treat as end-of-stream. The
+// predicate drives the OpenAI-compat Anthropic Messages handler and the
+// OpenAI-compat Chat Completions handler (openai_gateway_messages.go and
+// openai_gateway_chat_completions.go); it must stay symmetric with the broader
+// helpers in gateway_service.go (openAIStreamEventIsTerminal),
+// openai_ws_forwarder.go and openai_ws_v2/passthrough_relay.go. Without
+// response.cancelled / response.canceled in this set, an upstream that ends
+// the SSE with a legitimate cancellation event falls through to "stream usage
+// incomplete: missing terminal event", emitting a spurious openai.forward_failed
+// ops_error_logs entry and short-circuiting downstream finalization. See
+// upstream Wei-Shaw/sub2api#1322.
+func TestIsOpenAICompatResponsesTerminalEvent_FullSet(t *testing.T) {
+	terminal := []string{
+		"response.completed",
+		"response.done",
+		"response.incomplete",
+		"response.failed",
+		"response.cancelled",
+		"response.canceled",
+	}
+	for _, ev := range terminal {
+		if !isOpenAICompatResponsesTerminalEvent(ev) {
+			t.Fatalf("expected %q to be a terminal event", ev)
+		}
+		// strings.TrimSpace inside the predicate tolerates surrounding whitespace.
+		if !isOpenAICompatResponsesTerminalEvent("  " + ev + " \t") {
+			t.Fatalf("expected whitespace-padded %q to be a terminal event", ev)
+		}
+	}
+
+	nonTerminal := []string{
+		"",
+		"response.created",
+		"response.output_text.delta",
+		"response.output_item.added",
+		"response.reasoning_summary_text.delta",
+		"response.function_call_arguments.delta",
+		"completed",            // bare suffix is not the upstream contract.
+		"response.completed.x", // prefix is not enough.
+		"RESPONSE.COMPLETED",   // upstream contract is lowercase; case sensitivity is required.
+	}
+	for _, ev := range nonTerminal {
+		if isOpenAICompatResponsesTerminalEvent(ev) {
+			t.Fatalf("expected %q to NOT be a terminal event", ev)
+		}
+	}
+}

--- a/scripts/gateway-tk-sentinels.json
+++ b/scripts/gateway-tk-sentinels.json
@@ -356,9 +356,11 @@
       "must_contain": [
         "Wei-Shaw/sub2api#1311",
         "c.Writer.Header().Set(\"Content-Type\", \"application/json\")",
-        "openAICompatSSEFrameParser"
+        "openAICompatSSEFrameParser",
+        "Wei-Shaw/sub2api#1322",
+        "\"response.cancelled\", \"response.canceled\""
       ],
-      "rationale": "Non-stream /v1/messages uses the same buffered Responses SSE -> JSON conversion root cause as /v1/chat/completions; it must also override Content-Type after WriteFilteredHeaders so JSON bodies are not labeled text/event-stream. The buffered terminal reader must use openAICompatSSEFrameParser to recognise typed completion events when the stream closes without a standalone [DONE] (upstream PR #2530)."
+      "rationale": "Non-stream /v1/messages uses the same buffered Responses SSE -> JSON conversion root cause as /v1/chat/completions; it must also override Content-Type after WriteFilteredHeaders so JSON bodies are not labeled text/event-stream. The buffered terminal reader must use openAICompatSSEFrameParser to recognise typed completion events when the stream closes without a standalone [DONE] (upstream PR #2530). isOpenAICompatResponsesTerminalEvent — used by both the Messages and Chat Completions streaming handlers — must keep response.cancelled / response.canceled in its terminal set so legitimate upstream cancellations close the stream cleanly instead of degenerating to 'stream usage incomplete: missing terminal event' (upstream #1322)."
     },
     {
       "path": "backend/internal/service/openai_gateway_chat_completions_tk_content_type_test.go",

--- a/scripts/terminal-sentinels.json
+++ b/scripts/terminal-sentinels.json
@@ -8,7 +8,17 @@
       "required_literals": [
         "func openAIStreamEventIsTerminal(data string) bool {",
         "if trimmed == \"[DONE]\" {",
-        "case \"response.completed\", \"response.done\", \"response.failed\":"
+        "case \"response.completed\", \"response.done\", \"response.failed\":",
+        "case \"response.incomplete\", \"response.cancelled\", \"response.canceled\":"
+      ]
+    },
+    {
+      "name": "openai_compat_responses_terminal_helper",
+      "source": "backend/internal/service/openai_gateway_messages.go",
+      "required_literals": [
+        "func isOpenAICompatResponsesTerminalEvent(eventType string) bool {",
+        "case \"response.completed\", \"response.done\", \"response.incomplete\", \"response.failed\",",
+        "\"response.cancelled\", \"response.canceled\":"
       ]
     },
     {

--- a/scripts/upstream-issue-fact-checks.json
+++ b/scripts/upstream-issue-fact-checks.json
@@ -328,6 +328,22 @@
         "backend/internal/handler/admin/account_data_handler_test.go:TestImportData_GroupIDsReachCreateAccount",
         "backend/internal/handler/admin/account_data_handler_test.go:TestExportData_IncludesGroupIDsAndChannelType"
       ]
+    },
+    {
+      "upstream": "Wei-Shaw/sub2api#1322",
+      "severity": "high",
+      "summary": "isOpenAICompatResponsesTerminalEvent (driver for the OpenAI-compat Anthropic Messages and Chat Completions streaming handlers) now recognizes the full six-event terminal set, including response.cancelled / response.canceled. Without this, an upstream that ends the Responses SSE with a legitimate cancellation falls through to 'stream usage incomplete: missing terminal event', producing a spurious openai.forward_failed ops_error_logs entry and skipping clean finalization. Symmetric with openAIStreamEventIsTerminal (gateway_service.go), openai_ws_forwarder.go, and openai_ws_v2/passthrough_relay.go.",
+      "fixed_by": [
+        "backend/internal/service/openai_gateway_messages.go",
+        "backend/internal/service/openai_gateway_messages_tk_terminal_event_test.go",
+        "scripts/terminal-sentinels.json"
+      ],
+      "fixed_if_all_present": [
+        "backend/internal/service/openai_gateway_messages.go:See upstream Wei-Shaw/sub2api#1322",
+        "backend/internal/service/openai_gateway_messages.go:\"response.cancelled\", \"response.canceled\"",
+        "backend/internal/service/openai_gateway_messages_tk_terminal_event_test.go:TestIsOpenAICompatResponsesTerminalEvent_FullSet",
+        "scripts/terminal-sentinels.json:openai_compat_responses_terminal_helper"
+      ]
     }
   ]
 }

--- a/scripts/upstream-issue-fixes.json
+++ b/scripts/upstream-issue-fixes.json
@@ -23,6 +23,60 @@
       "summary": "Gemini 429 with no quotaResetDelay/retryDelay uses tier cooldown for all Gemini OAuth accounts (google_one + aistudio OAuth + code_assist), not just Code Assist; PST-midnight fallback is reserved for API Key accounts."
     },
     {
+      "upstream": "Wei-Shaw/sub2api#1170",
+      "status": "fixed_in_tokenkey",
+      "fixed_by": [
+        "backend/internal/handler/admin/account_data.go",
+        "backend/internal/handler/admin/account_data_handler_test.go"
+      ],
+      "summary": "Batch account import (/admin/accounts/data) now propagates `group_ids` through to CreateAccountInput.GroupIDs and the symmetric export carries `group_ids` + `channel_type` so an export → import round trip preserves group bindings and newapi fifth-platform metadata. Original implementation defined no GroupIDs field on DataAccount (so JSON `group_ids` was silently dropped at Unmarshal) and the import handler hard-coded `GroupIDs: nil`, leaving batch-imported accounts ungrouped until manually re-edited."
+    },
+    {
+      "upstream": "Wei-Shaw/sub2api#1264",
+      "status": "fixed_in_tokenkey",
+      "fixed_by": [
+        "backend/internal/service/openai_gateway_service.go",
+        "backend/internal/service/openai_gateway_chat_completions.go",
+        "backend/internal/service/openai_responses_unsupported_user_test.go"
+      ],
+      "summary": "OpenAI /v1/responses passthrough strips top-level `user` before forwarding. Symmetric coverage on (a) APIKey native path via OpenAIGatewayService.Forward's unsupportedFields list (the OAuth path already strips it through openAIChatGPTInternalUnsupportedFields in applyCodexOAuthTransform) and (b) the Cursor-shape short-circuit in ForwardAsChatCompletions via cursorResponsesUnsupportedFields. Native OpenAI Responses upstream rejects `user` with HTTP 400 \"Unsupported parameter: user\"; the Responses equivalent is `safety_identifier`, which we already filter."
+    },
+    {
+      "upstream": "Wei-Shaw/sub2api#1311",
+      "status": "fixed_in_tokenkey",
+      "fixed_by": [
+        "backend/internal/service/openai_gateway_chat_completions.go",
+        "backend/internal/service/openai_gateway_messages.go",
+        "backend/internal/service/openai_gateway_chat_completions_tk_content_type_test.go",
+        "backend/internal/service/gateway_forward_as_responses.go",
+        "backend/internal/service/gateway_forward_as_chat_completions.go",
+        "backend/internal/service/gateway_forward_as_responses_tk_content_type_test.go",
+        "backend/internal/service/gateway_forward_as_chat_completions_tk_content_type_test.go",
+        "backend/internal/service/openai_images_responses.go",
+        "scripts/check-buffered-content-type-leak.py"
+      ],
+      "summary": "Non-stream buffered SSE->JSON handlers in both the OpenAI gateway (/v1/chat/completions, /v1/messages) and the Anthropic-backed gateway forward paths (Responses, Chat Completions) now explicitly set Content-Type: application/json after WriteFilteredHeaders. Without this, the upstream SSE Content-Type (text/event-stream) leaks onto JSON bodies because gin's render.writeContentType only writes when no Content-Type is set, breaking OpenAI-SDK consumers that branch on Content-Type."
+    },
+    {
+      "upstream": "Wei-Shaw/sub2api#1322",
+      "status": "fixed_in_tokenkey",
+      "fixed_by": [
+        "backend/internal/service/openai_gateway_messages.go",
+        "backend/internal/service/openai_gateway_messages_tk_terminal_event_test.go",
+        "scripts/terminal-sentinels.json"
+      ],
+      "summary": "isOpenAICompatResponsesTerminalEvent (driver for the OpenAI-compat Anthropic Messages and Chat Completions streaming handlers) now recognizes the full six-event terminal set, including response.cancelled / response.canceled. Without this, an upstream that ends the Responses SSE with a legitimate cancellation falls through to 'stream usage incomplete: missing terminal event', producing a spurious openai.forward_failed ops_error_logs entry and skipping clean finalization. Symmetric with openAIStreamEventIsTerminal (gateway_service.go), openai_ws_forwarder.go, and openai_ws_v2/passthrough_relay.go."
+    },
+    {
+      "upstream": "Wei-Shaw/sub2api#1471",
+      "status": "fixed_in_tokenkey",
+      "fixed_by": [
+        "backend/internal/service/openai_gateway_service.go",
+        "backend/internal/service/openai_gateway_service_tk_stream_read_error_sse_test.go"
+      ],
+      "summary": "OpenAI /v1/responses sendErrorEvent now prepends a blank line before the synthetic data: line, so any in-flight upstream SSE event whose terminating blank line was never sent is closed before the synthetic event is written. Without this, the unterminated `data:` line and the synthetic `data:` line merge into a single SSE event whose payload contains two concatenated JSON objects, which downstream OpenAI-compatible SDKs (Codex, OpenCode, etc.) reject with malformed JSON."
+    },
+    {
       "upstream": "Wei-Shaw/sub2api#1925",
       "status": "fixed_in_tokenkey",
       "fixed_by": [
@@ -119,6 +173,15 @@
       "summary": "extractSSEUsagePatch message_start branch now gates hasInputTokens/hasCacheCreationInput/hasCacheReadInput on actual parseSSEUsageInt success instead of setting them unconditionally; a partial or duplicate message_start frame no longer zeroes out accumulator dimensions whose source key was absent."
     },
     {
+      "upstream": "Wei-Shaw/sub2api#2332",
+      "status": "fixed_in_tokenkey",
+      "fixed_by": [
+        "backend/internal/service/gateway_service.go",
+        "backend/internal/service/gateway_streaming_test.go"
+      ],
+      "summary": "extractSSEUsagePatch message_start branch now gates hasInputTokens/hasCacheCreationInput/hasCacheReadInput on actual parseSSEUsageInt success instead of setting them unconditionally; a partial or duplicate message_start frame no longer zeroes out accumulator dimensions whose source key was absent (the input_tokens=0 duplicate-billing shape upstream reported)."
+    },
+    {
       "upstream": "Wei-Shaw/sub2api#2337",
       "status": "fixed_in_tokenkey",
       "fixed_by": [
@@ -127,6 +190,17 @@
         "backend/internal/service/openai_compat_model_test.go"
       ],
       "summary": "Anthropic-to-OpenAI multi-turn tool call conversion preserves tool-call/call-id continuity for tool_result history."
+    },
+    {
+      "upstream": "Wei-Shaw/sub2api#2363",
+      "status": "fixed_in_tokenkey",
+      "fixed_by": [
+        "backend/internal/service/model_pricing_resolver.go",
+        "backend/internal/service/model_pricing_resolver_tk_channel_flat_fallback.go",
+        "backend/internal/service/model_pricing_resolver_test.go",
+        "scripts/gateway-tk-sentinels.json"
+      ],
+      "summary": "GetIntervalPricing overlays the matched interval onto BasePricing (which carries channel flat defaults via the #2107 fix), so channel CacheReadPrice/CacheWritePrice/ImageOutputPrice survive in-range matches instead of being silently dropped to 0. Symmetric in-range counterpart to the #2107 out-of-range fix."
     },
     {
       "upstream": "Wei-Shaw/sub2api#2383",
@@ -156,6 +230,15 @@
         "backend/internal/repository/user_subscription_repo_integration_test.go"
       ],
       "summary": "Expired and non-active subscriptions are ignored by reassignment existence checks, preventing stale rows from causing validity_days_mismatch conflicts."
+    },
+    {
+      "upstream": "Wei-Shaw/sub2api#2486",
+      "status": "fixed_in_tokenkey",
+      "fixed_by": [
+        "backend/internal/service/billing_service.go",
+        "backend/internal/service/billing_service_test.go"
+      ],
+      "summary": "Unknown gemini-* models (including gemini-pro-agent) fall back to gemini-3.1-pro pricing instead of returning nil (which caused calculateTokenCost to silently record ActualCost=0 with no quota deduction)."
     },
     {
       "upstream": "Wei-Shaw/sub2api#2487",
@@ -189,22 +272,6 @@
       "summary": "OpenAI /compact route handling and request-body normalization are implemented, with compact_not_supported when no compatible account is available."
     },
     {
-      "upstream": "Wei-Shaw/sub2api#1311",
-      "status": "fixed_in_tokenkey",
-      "fixed_by": [
-        "backend/internal/service/openai_gateway_chat_completions.go",
-        "backend/internal/service/openai_gateway_messages.go",
-        "backend/internal/service/openai_gateway_chat_completions_tk_content_type_test.go",
-        "backend/internal/service/gateway_forward_as_responses.go",
-        "backend/internal/service/gateway_forward_as_chat_completions.go",
-        "backend/internal/service/gateway_forward_as_responses_tk_content_type_test.go",
-        "backend/internal/service/gateway_forward_as_chat_completions_tk_content_type_test.go",
-        "backend/internal/service/openai_images_responses.go",
-        "scripts/check-buffered-content-type-leak.py"
-      ],
-      "summary": "Non-stream buffered SSE->JSON handlers in both the OpenAI gateway (/v1/chat/completions, /v1/messages) and the Anthropic-backed gateway forward paths (Responses, Chat Completions) now explicitly set Content-Type: application/json after WriteFilteredHeaders. Without this, the upstream SSE Content-Type (text/event-stream) leaks onto JSON bodies because gin's render.writeContentType only writes when no Content-Type is set, breaking OpenAI-SDK consumers that branch on Content-Type."
-    },
-    {
       "upstream": "Wei-Shaw/sub2api#2500",
       "status": "fixed_in_tokenkey",
       "fixed_by": [
@@ -212,15 +279,6 @@
         "backend/internal/service/openai_codex_transform_tk_call_id_test.go"
       ],
       "summary": "fixCallIDPrefix in openai_codex_transform.go now produces fc_<id> (with underscore) for call_<id> inputs, matching the fallback branch and the codex backend's id validator; missing underscore caused HTTP 400 on the chatgpt.com codex OAuth path and surfaced as 502 on multi-hop tool turns."
-    },
-    {
-      "upstream": "Wei-Shaw/sub2api#2515",
-      "status": "fixed_in_tokenkey",
-      "fixed_by": [
-        "backend/internal/pkg/apicompat/chatcompletions_to_responses.go",
-        "backend/internal/pkg/apicompat/chatcompletions_responses_test.go"
-      ],
-      "summary": "ChatCompletions→Responses transform falls back to empty string when the converted parts list is empty (was emitting JSON null and triggering upstream HTTP 400 on gpt-5.5)."
     },
     {
       "upstream": "Wei-Shaw/sub2api#2506",
@@ -232,42 +290,13 @@
       "summary": "normalizeClaudeOAuthRequestBody now skips auto-injecting context_management for Haiku models, mirroring the existing Haiku exemption in the anthropic-beta header path; Anthropic /v1/messages would otherwise return HTTP 400 for claude-haiku-4-5-* when thinking.type is enabled."
     },
     {
-      "upstream": "Wei-Shaw/sub2api#2486",
+      "upstream": "Wei-Shaw/sub2api#2515",
       "status": "fixed_in_tokenkey",
       "fixed_by": [
-        "backend/internal/service/billing_service.go",
-        "backend/internal/service/billing_service_test.go"
+        "backend/internal/pkg/apicompat/chatcompletions_to_responses.go",
+        "backend/internal/pkg/apicompat/chatcompletions_responses_test.go"
       ],
-      "summary": "Unknown gemini-* models (including gemini-pro-agent) fall back to gemini-3.1-pro pricing instead of returning nil (which caused calculateTokenCost to silently record ActualCost=0 with no quota deduction)."
-    },
-    {
-      "upstream": "Wei-Shaw/sub2api#2363",
-      "status": "fixed_in_tokenkey",
-      "fixed_by": [
-        "backend/internal/service/model_pricing_resolver.go",
-        "backend/internal/service/model_pricing_resolver_tk_channel_flat_fallback.go",
-        "backend/internal/service/model_pricing_resolver_test.go",
-        "scripts/gateway-tk-sentinels.json"
-      ],
-      "summary": "GetIntervalPricing overlays the matched interval onto BasePricing (which carries channel flat defaults via the #2107 fix), so channel CacheReadPrice/CacheWritePrice/ImageOutputPrice survive in-range matches instead of being silently dropped to 0. Symmetric in-range counterpart to the #2107 out-of-range fix."
-    },
-    {
-      "upstream": "Wei-Shaw/sub2api#2332",
-      "status": "fixed_in_tokenkey",
-      "fixed_by": [
-        "backend/internal/service/gateway_service.go",
-        "backend/internal/service/gateway_streaming_test.go"
-      ],
-      "summary": "extractSSEUsagePatch message_start branch now gates hasInputTokens/hasCacheCreationInput/hasCacheReadInput on actual parseSSEUsageInt success instead of setting them unconditionally; a partial or duplicate message_start frame no longer zeroes out accumulator dimensions whose source key was absent (the input_tokens=0 duplicate-billing shape upstream reported)."
-    },
-    {
-      "upstream": "Wei-Shaw/sub2api#1471",
-      "status": "fixed_in_tokenkey",
-      "fixed_by": [
-        "backend/internal/service/openai_gateway_service.go",
-        "backend/internal/service/openai_gateway_service_tk_stream_read_error_sse_test.go"
-      ],
-      "summary": "OpenAI /v1/responses sendErrorEvent now prepends a blank line before the synthetic data: line, so any in-flight upstream SSE event whose terminating blank line was never sent is closed before the synthetic event is written. Without this, the unterminated `data:` line and the synthetic `data:` line merge into a single SSE event whose payload contains two concatenated JSON objects, which downstream OpenAI-compatible SDKs (Codex, OpenCode, etc.) reject with malformed JSON."
+      "summary": "ChatCompletions→Responses transform falls back to empty string when the converted parts list is empty (was emitting JSON null and triggering upstream HTTP 400 on gpt-5.5)."
     },
     {
       "upstream": "Wei-Shaw/sub2api#2538",
@@ -297,27 +326,7 @@
         "backend/internal/service/openai_gateway_chat_completions_raw.go",
         "backend/internal/service/openai_gateway_chat_completions_tk_silent_refusal_test.go"
       ],
-      "summary": "OpenAI Chat Completions raw passthrough (streaming and buffered) now detects upstream silent refusal — empty stream/response with finish_reason=stop and zero usage — and emits a categorical ops_error_logs row (Kind=silent_refusal). Detection is conservative (no content / no tool_calls / no reasoning_content / no refusal / no chunk-level error / zero usage / finish_reason=stop) so legitimate short answers are never flagged. Surfaces previously invisible 'ghost stream' failures (the gpt-5.5 above-input-budget shape upstream reported) to ops dashboards without changing the client-visible HTTP body, keeping the behavior change minimum-surface."
-    },
-    {
-      "upstream": "Wei-Shaw/sub2api#1264",
-      "status": "fixed_in_tokenkey",
-      "fixed_by": [
-        "backend/internal/service/openai_gateway_service.go",
-        "backend/internal/service/openai_gateway_chat_completions.go",
-        "backend/internal/service/openai_responses_unsupported_user_test.go",
-        "scripts/gateway-tk-sentinels.json"
-      ],
-      "summary": "OpenAI /v1/responses passthrough now strips top-level `user` before forwarding upstream. Symmetric coverage: (a) APIKey/native passthrough path adds `user` to the unsupportedFields list in OpenAIGatewayService.Forward (the OAuth path already filters it through openAIChatGPTInternalUnsupportedFields in applyCodexOAuthTransform); (b) the Cursor-shape short-circuit in ForwardAsChatCompletions adds `user` to cursorResponsesUnsupportedFields. Without this, clients like LobeHub posting `user` (for end-user tracking) to /v1/responses get HTTP 400 \"Unsupported parameter: user\" from the OpenAI upstream — the Responses-API equivalent field is `safety_identifier`, which we already strip. Tracked by the same sentinel registry entries plus the focused regression in openai_responses_unsupported_user_test.go."
-    },
-    {
-      "upstream": "Wei-Shaw/sub2api#1170",
-      "status": "fixed_in_tokenkey",
-      "fixed_by": [
-        "backend/internal/handler/admin/account_data.go",
-        "backend/internal/handler/admin/account_data_handler_test.go"
-      ],
-      "summary": "Batch account import (/admin/accounts/data) propagates `group_ids` from the JSON payload through to CreateAccountInput.GroupIDs so newly imported accounts are bound to the requested groups directly, without requiring a manual edit-and-save. The DataAccount struct now declares the GroupIDs field (the original definition lacked it, so JSON `group_ids` was silently dropped at Unmarshal) and the import handler forwards `item.GroupIDs` instead of hard-coded `nil`. The symmetric export side also surfaces GroupIDs + ChannelType so an export → import round-trip no longer silently drops group bindings or newapi fifth-platform metadata."
+      "summary": "OpenAI Chat Completions raw passthrough detects upstream silent refusal (empty stream/response with finish_reason=stop and zero usage) and emits an ops_error_logs row with Kind=silent_refusal. Conservative predicate: no content / no tool_calls / no reasoning / no refusal / no chunk-level error / zero usage / finish_reason=stop. Stream path keeps the client-visible bytes untouched (headers already flushed); buffered path will keep flexibility to harden later. The categorical ops signal turns the previously invisible 'ghost stream' (gpt-5.5 above input budget) into a dashboard-pivotable event."
     }
   ]
 }

--- a/scripts/upstream-issue-triage.json
+++ b/scripts/upstream-issue-triage.json
@@ -4,10 +4,10 @@
   "generated_from": "GitHub REST API issues?state=open; pull requests excluded",
   "rationale": "TokenKey-local triage cache for upstream open issues. Use this file before re-triaging upstream issues; update entries when TokenKey fixes, dismisses, or reclassifies an issue.",
   "counts": {
-    "needs_review": 345,
+    "needs_review": 344,
+    "fixed": 32,
     "needs_prod_validation": 4,
     "medium": 115,
-    "fixed": 31,
     "not_applicable": 1,
     "low": 96,
     "unknown_low_signal": 402
@@ -311,20 +311,6 @@
       "tokenkey_status": "candidate_unverified",
       "rationale": "Keyword match for production-sensitive area; not yet manually verified against TokenKey code.",
       "updated_at": "2026-03-26T06:47:06Z"
-    },
-    {
-      "upstream": "Wei-Shaw/sub2api#1322",
-      "url": "https://github.com/Wei-Shaw/sub2api/issues/1322",
-      "title": "Responses terminal event detection is inconsistent: gateway_service.go does not treat response.incomplete / response.cancelled as terminal",
-      "impact": "needs_review",
-      "categories": [
-        "rate_limit_cooldown",
-        "billing_usage",
-        "account_pool_health"
-      ],
-      "tokenkey_status": "candidate_unverified",
-      "rationale": "Keyword match for production-sensitive area; not yet manually verified against TokenKey code.",
-      "updated_at": "2026-03-26T08:41:35Z"
     },
     {
       "upstream": "Wei-Shaw/sub2api#1326",
@@ -5790,7 +5776,7 @@
         "security"
       ],
       "tokenkey_status": "fixed_in_tokenkey",
-      "rationale": "Batch account import (/admin/accounts/data) propagates `group_ids` from the payload to CreateAccountInput.GroupIDs so imported accounts get the requested groups directly, without requiring a manual edit-and-save. DataAccount now declares GroupIDs (original definition lacked the field, so JSON `group_ids` was silently dropped at Unmarshal) and the import handler forwards `item.GroupIDs` instead of hard-coded `nil`. Export side also surfaces GroupIDs + ChannelType for round-trip integrity.",
+      "rationale": "Batch account import (/admin/accounts/data) now propagates `group_ids` through to CreateAccountInput.GroupIDs and the symmetric export carries `group_ids` + `channel_type` so an export → import round trip preserves group bindings and newapi fifth-platform metadata. Original implementation defined no GroupIDs field on DataAccount (so JSON `group_ids` was silently dropped at Unmarshal) and the import handler hard-coded `GroupIDs: nil`, leaving batch-imported accounts ungrouped until manually re-edited.",
       "updated_at": "2026-03-19T18:15:43Z"
     },
     {
@@ -5804,7 +5790,7 @@
         "security"
       ],
       "tokenkey_status": "fixed_in_tokenkey",
-      "rationale": "OpenAI /v1/responses passthrough strips top-level `user` before forwarding. The APIKey native path adds `user` to OpenAIGatewayService.Forward's unsupportedFields list (the OAuth path already filters it through applyCodexOAuthTransform); the Cursor-shape short-circuit in ForwardAsChatCompletions adds `user` to cursorResponsesUnsupportedFields. Without this, clients like LobeHub posting `user` to /v1/responses got upstream HTTP 400 'Unsupported parameter: user'.",
+      "rationale": "OpenAI /v1/responses passthrough strips top-level `user` before forwarding. Symmetric coverage on (a) APIKey native path via OpenAIGatewayService.Forward's unsupportedFields list (the OAuth path already strips it through openAIChatGPTInternalUnsupportedFields in applyCodexOAuthTransform) and (b) the Cursor-shape short-circuit in ForwardAsChatCompletions via cursorResponsesUnsupportedFields. Native OpenAI Responses upstream rejects `user` with HTTP 400 \"Unsupported parameter: user\"; the Responses equivalent is `safety_identifier`, which we already filter.",
       "updated_at": "2026-03-24T13:52:59Z"
     },
     {
@@ -5823,6 +5809,20 @@
       "tokenkey_status": "fixed_in_tokenkey",
       "rationale": "Non-stream buffered SSE->JSON handlers in both the OpenAI gateway (/v1/chat/completions, /v1/messages) and the Anthropic-backed gateway forward paths (Responses, Chat Completions) now explicitly set Content-Type: application/json after WriteFilteredHeaders. Without this, the upstream SSE Content-Type (text/event-stream) leaks onto JSON bodies because gin's render.writeContentType only writes when no Content-Type is set, breaking OpenAI-SDK consumers that branch on Content-Type.",
       "updated_at": "2026-05-15T12:00:37Z"
+    },
+    {
+      "upstream": "Wei-Shaw/sub2api#1322",
+      "url": "https://github.com/Wei-Shaw/sub2api/issues/1322",
+      "title": "Responses terminal event detection is inconsistent: gateway_service.go does not treat response.incomplete / response.cancelled as terminal",
+      "impact": "fixed",
+      "categories": [
+        "rate_limit_cooldown",
+        "billing_usage",
+        "account_pool_health"
+      ],
+      "tokenkey_status": "fixed_in_tokenkey",
+      "rationale": "isOpenAICompatResponsesTerminalEvent (driver for the OpenAI-compat Anthropic Messages and Chat Completions streaming handlers) now recognizes the full six-event terminal set, including response.cancelled / response.canceled. Without this, an upstream that ends the Responses SSE with a legitimate cancellation falls through to 'stream usage incomplete: missing terminal event', producing a spurious openai.forward_failed ops_error_logs entry and skipping clean finalization. Symmetric with openAIStreamEventIsTerminal (gateway_service.go), openai_ws_forwarder.go, and openai_ws_v2/passthrough_relay.go.",
+      "updated_at": "2026-03-26T08:41:35Z"
     },
     {
       "upstream": "Wei-Shaw/sub2api#1471",
@@ -6174,7 +6174,7 @@
         "security"
       ],
       "tokenkey_status": "fixed_in_tokenkey",
-      "rationale": "OpenAI Chat Completions raw passthrough now detects upstream silent refusal (empty stream / response with finish_reason=stop and no usage) and emits an ops_error_logs row with Kind=silent_refusal. Detection is conservative (zero content + zero tool_calls + zero reasoning + zero refusal + zero usage + finish_reason=stop) so legitimate short answers are not flagged. Surfaces previously invisible 'ghost stream' failures to ops/dashboards.",
+      "rationale": "OpenAI Chat Completions raw passthrough detects upstream silent refusal (empty stream/response with finish_reason=stop and zero usage) and emits an ops_error_logs row with Kind=silent_refusal. Conservative predicate: no content / no tool_calls / no reasoning / no refusal / no chunk-level error / zero usage / finish_reason=stop. Stream path keeps the client-visible bytes untouched (headers already flushed); buffered path will keep flexibility to harden later. The categorical ops signal turns the previously invisible 'ghost stream' (gpt-5.5 above input budget) into a dashboard-pivotable event.",
       "updated_at": "2026-05-18T11:15:08Z"
     },
     {


### PR DESCRIPTION
## 背景与影响（upstream Wei-Shaw/sub2api#1322）

`isOpenAICompatResponsesTerminalEvent`（`backend/internal/service/openai_gateway_messages.go`）同时驱动两个流式终止判断：

- OpenAI-compat Anthropic Messages handler（`openai_gateway_messages.go`）
- OpenAI-compat Chat Completions handler（`openai_gateway_chat_completions.go`）

但它只识别 4 个事件（`completed`/`done`/`incomplete`/`failed`）。当上游以**合法的** `response.cancelled` / `response.canceled` 关闭 Responses SSE 时，循环走到 `[DONE]`、被识别为 "缺失终止事件"：

- 返回 `stream usage incomplete: missing terminal event` 错误
- 触发 `openai.forward_failed` ops_error_logs（污染告警）
- 跳过 `FinalizeResponsesChatStream` / `FinalizeResponsesAnthropicStream` 的干净收尾

与之相对，`gateway_service.go:openAIStreamEventIsTerminal`、`openai_ws_forwarder.go`、`openai_ws_v2/passthrough_relay.go` 早已覆盖全部 6 个事件。本 PR 抹平这一处不对称。

## 改动概述

1. `backend/internal/service/openai_gateway_messages.go`：`isOpenAICompatResponsesTerminalEvent` 增加 `response.cancelled` / `response.canceled` 终止事件，同步刷新邻近过时注释。
2. `backend/internal/service/openai_gateway_messages_tk_terminal_event_test.go`（新增 TK 回归）：`TestIsOpenAICompatResponsesTerminalEvent_FullSet` 钉死 6 个终止事件、9 个非终止事件，包含前后空白容忍以及大小写敏感性。
3. `scripts/terminal-sentinels.json`：
   - `openai_terminal_helper` 增加 `case "response.incomplete", "response.cancelled", "response.canceled":` literal（之前只覆盖前 3 个）。
   - 新增 `openai_compat_responses_terminal_helper`，pin 住 6 事件 surface。
4. `scripts/gateway-tk-sentinels.json`：`openai_gateway_messages.go` 入口追加 `Wei-Shaw/sub2api#1322` + `"response.cancelled", "response.canceled"` literal，并扩展 rationale，使 upstream merge 不能静默回滚。
5. `scripts/upstream-issue-fact-checks.json`：新增 #1322 fact-check（path:needle）。
6. `scripts/upstream-issue-fixes.json` / `upstream-issue-triage.json`：watchdog 自动重排，#1322 被提升至 `fixed_in_tokenkey`。

## 行为安全性

- 转换器侧（`apicompat.responses_to_chatcompletions.go` / `responses_to_anthropic.go`）保持原样：cancelled/canceled 事件落入 `default: return nil`，不引入新的 chunk。
- 用户 usage 仍由 streaming 包装层从 `event.Response.Usage` 提取（如有），不依赖转换器。
- `state.Finalized` 不会被置为 true → `FinalizeResponsesChatStream` / `FinalizeResponsesAnthropicStream` 仍能 idempotent 地发出干净的 `finish_reason=stop` / `message_stop`。

## 测试与门禁

- `go test -tags=unit ./internal/service/`：全包绿（含新增 `TestIsOpenAICompatResponsesTerminalEvent_FullSet`）。
- `go vet ./internal/service/...`：clean。
- `go build ./...`：clean。
- `python3 scripts/check-terminal-events.py`：terminal-event helpers and focused assertions are aligned。
- `python3 scripts/check-gateway-tk-sentinels.py`：PASS (65/65 intact)。
- `bash scripts/preflight.sh`：全部通过（包括 sentinel registry update gate，已绑定 `openai_gateway_messages.go` ↔ `gateway-tk-sentinels.json` 的同 PR 更新约束）。

## 风险与回滚

- 改动表面极小：1 个 helper 增 2 个 case + 1 个 TK 测试 + 5 处登记表更新。
- upstream 字段是 OpenAI 公开契约，不存在“误触发取消”的风险面。
- 回滚：`git revert` 即可，不需要数据修复。

## 上游覆写防护（依据 CLAUDE.md §5）

`openai_gateway_messages.go` 是 upstream-shaped 大文件。本次改动只增加 5 行 case + 1 行注释指针，未重排 upstream 既有逻辑，符合“minimum-invasion injection”。
两个 sentinel（`gateway-tk-sentinels.json`、`terminal-sentinels.json`）从两侧把 6 事件 surface 与 `Wei-Shaw/sub2api#1322` 标记同时钉死，任何 upstream merge 静默回滚会触发 preflight + sentinel registry update gate。

## Test plan
- [x] `cd backend && go test -tags=unit -run 'TestIsOpenAICompatResponsesTerminalEvent_FullSet' ./internal/service/`
- [x] `cd backend && go test -tags=unit ./internal/service/`
- [x] `cd backend && go build ./...` + `go vet ./internal/service/...`
- [x] `python3 scripts/check-terminal-events.py`
- [x] `python3 scripts/check-gateway-tk-sentinels.py`
- [x] `bash scripts/preflight.sh`
- [ ] CI: backend-ci, preflight, upstream-merge-pr-shape (非 merge PR，不触发)

🤖 Generated with [Claude Code](https://claude.com/claude-code)