### PR TITLE
chore: merge upstream/main (2026-05-18) — Anthropic passthrough keepalive

### DIFF
--- a/backend/internal/service/gateway_anthropic_apikey_passthrough_test.go
+++ b/backend/internal/service/gateway_anthropic_apikey_passthrough_test.go
@@ -1138,6 +1138,99 @@ func TestGatewayService_AnthropicAPIKeyPassthrough_StreamingDataIntervalTimeout(
 	require.False(t, result.clientDisconnect)
 }
 
+func TestGatewayService_AnthropicAPIKeyPassthrough_StreamingSendsKeepaliveDuringIdle(t *testing.T) {
+	gin.SetMode(gin.TestMode)
+	rec := httptest.NewRecorder()
+	c, _ := gin.CreateTestContext(rec)
+	c.Request = httptest.NewRequest(http.MethodPost, "/v1/messages", nil)
+
+	svc := &GatewayService{
+		cfg: &config.Config{
+			Gateway: config.GatewayConfig{
+				StreamKeepaliveInterval: 1,
+				MaxLineSize:             defaultMaxLineSize,
+			},
+		},
+		rateLimitService: &RateLimitService{},
+	}
+
+	pr, pw := io.Pipe()
+	resp := &http.Response{
+		StatusCode: http.StatusOK,
+		Header:     http.Header{"Content-Type": []string{"text/event-stream"}},
+		Body:       pr,
+	}
+
+	done := make(chan struct{})
+	go func() {
+		defer close(done)
+		time.Sleep(1200 * time.Millisecond)
+		_, _ = pw.Write([]byte(strings.Join([]string{
+			`data: {"type":"message_start","message":{"usage":{"input_tokens":3}}}`,
+			"",
+			`data: {"type":"message_delta","usage":{"output_tokens":2}}`,
+			"",
+			"data: [DONE]",
+			"",
+		}, "\n")))
+		_ = pw.Close()
+	}()
+
+	result, err := svc.handleStreamingResponseAnthropicAPIKeyPassthrough(context.Background(), resp, c, &Account{ID: 8}, time.Now(), "claude-3-7-sonnet-20250219")
+	_ = pr.Close()
+	<-done
+
+	require.NoError(t, err)
+	require.NotNil(t, result)
+	require.Contains(t, rec.Body.String(), "event: ping\ndata: {\"type\": \"ping\"}\n\n")
+	require.Contains(t, rec.Body.String(), "data: [DONE]")
+}
+
+func TestGatewayService_AnthropicAPIKeyPassthrough_StreamingKeepaliveDoesNotInterleavePartialEvent(t *testing.T) {
+	gin.SetMode(gin.TestMode)
+	rec := httptest.NewRecorder()
+	c, _ := gin.CreateTestContext(rec)
+	c.Request = httptest.NewRequest(http.MethodPost, "/v1/messages", nil)
+
+	svc := &GatewayService{
+		cfg: &config.Config{
+			Gateway: config.GatewayConfig{
+				StreamKeepaliveInterval: 1,
+				MaxLineSize:             defaultMaxLineSize,
+			},
+		},
+		rateLimitService: &RateLimitService{},
+	}
+
+	pr, pw := io.Pipe()
+	resp := &http.Response{
+		StatusCode: http.StatusOK,
+		Header:     http.Header{"Content-Type": []string{"text/event-stream"}},
+		Body:       pr,
+	}
+
+	done := make(chan struct{})
+	go func() {
+		defer close(done)
+		_, _ = pw.Write([]byte(`data: {"type":"message_start","message":{"usage":{"input_tokens":4}}}` + "\n"))
+		time.Sleep(1200 * time.Millisecond)
+		_, _ = pw.Write([]byte("\n"))
+		_, _ = pw.Write([]byte("data: [DONE]\n\n"))
+		_ = pw.Close()
+	}()
+
+	result, err := svc.handleStreamingResponseAnthropicAPIKeyPassthrough(context.Background(), resp, c, &Account{ID: 9}, time.Now(), "claude-3-7-sonnet-20250219")
+	_ = pr.Close()
+	<-done
+
+	require.NoError(t, err)
+	require.NotNil(t, result)
+	body := rec.Body.String()
+	require.NotContains(t, body, `data: {"type":"message_start","message":{"usage":{"input_tokens":4}}}`+"\n"+"event: ping")
+	require.NotContains(t, body, "event: ping")
+	require.Contains(t, body, "data: [DONE]")
+}
+
 func TestGatewayService_AnthropicAPIKeyPassthrough_StreamingReadError(t *testing.T) {
 	gin.SetMode(gin.TestMode)
 	rec := httptest.NewRecorder()

--- a/backend/internal/service/gateway_service.go
+++ b/backend/internal/service/gateway_service.go
@@ -5357,6 +5357,22 @@ func (s *GatewayService) handleStreamingResponseAnthropicAPIKeyPassthrough(
 		intervalCh = intervalTicker.C
 	}
 
+	keepaliveInterval := time.Duration(0)
+	if s.cfg != nil && s.cfg.Gateway.StreamKeepaliveInterval > 0 {
+		keepaliveInterval = time.Duration(s.cfg.Gateway.StreamKeepaliveInterval) * time.Second
+	}
+	var keepaliveTicker *time.Ticker
+	if keepaliveInterval > 0 {
+		keepaliveTicker = time.NewTicker(keepaliveInterval)
+		defer keepaliveTicker.Stop()
+	}
+	var keepaliveCh <-chan time.Time
+	if keepaliveTicker != nil {
+		keepaliveCh = keepaliveTicker.C
+	}
+	lastDataAt := time.Now()
+	inPartialEvent := false
+
 	for {
 		select {
 		case ev, ok := <-events:
@@ -5422,6 +5438,10 @@ func (s *GatewayService) handleStreamingResponseAnthropicAPIKeyPassthrough(
 				} else if line == "" {
 					// 按 SSE 事件边界刷出，减少每行 flush 带来的 syscall 开销。
 					flusher.Flush()
+					lastDataAt = time.Now()
+					inPartialEvent = false
+				} else {
+					inPartialEvent = true
 				}
 			}
 
@@ -5438,6 +5458,21 @@ func (s *GatewayService) handleStreamingResponseAnthropicAPIKeyPassthrough(
 				s.rateLimitService.HandleStreamTimeout(ctx, account, model)
 			}
 			return &streamingResult{usage: usage, firstTokenMs: firstTokenMs}, fmt.Errorf("stream data interval timeout")
+
+		case <-keepaliveCh:
+			if clientDisconnected || inPartialEvent {
+				continue
+			}
+			if time.Since(lastDataAt) < keepaliveInterval {
+				continue
+			}
+			if _, err := fmt.Fprint(w, "event: ping\ndata: {\"type\": \"ping\"}\n\n"); err != nil {
+				clientDisconnected = true
+				logger.LegacyPrintf("service.gateway", "[Anthropic passthrough] Client disconnected during keepalive ping, continue draining upstream for usage: account=%d", account.ID)
+				continue
+			}
+			flusher.Flush()
+			lastDataAt = time.Now()
 		}
 	}
 }

--- a/scripts/gateway-tk-sentinels.json
+++ b/scripts/gateway-tk-sentinels.json
@@ -4,107 +4,212 @@
   "sentinels": [
     {
       "path": "backend/internal/service/gemini_messages_compat_service.go",
-      "must_contain": ["withGeminiCodeAssistMappedModel(ctx, mappedModel)", "tryGeminiCodeAssistApplyModelRateLimit(ctx, account, body)", "detail.Get(\"retryDelay\").String()", "detail.Get(\"metadata.retryDelay\").String()", "TK: See upstream Wei-Shaw/sub2api#641", "if account.Type == AccountTypeOAuth {"],
+      "must_contain": [
+        "withGeminiCodeAssistMappedModel(ctx, mappedModel)",
+        "tryGeminiCodeAssistApplyModelRateLimit(ctx, account, body)",
+        "detail.Get(\"retryDelay\").String()",
+        "detail.Get(\"metadata.retryDelay\").String()",
+        "TK: See upstream Wei-Shaw/sub2api#641",
+        "if account.Type == AccountTypeOAuth {"
+      ],
       "rationale": "Code Assist 429 fallback-model protection depends on upstream-file hooks plus precise reset-delay extraction. Forwarding must store resolved upstream Gemini model in context, upstream 429 handling must delegate to the TK companion before account-level SetRateLimited, and ParseGeminiRateLimitResetTime must keep structured RetryInfo retryDelay parsing. Dropping any of these reintroduces whole-account long cooldown when upstream already provides a short retry window. The handleGeminiUpstreamError fallback branch must route all Gemini OAuth accounts (google_one + aistudio OAuth + code_assist) through tier cooldown — only API Key accounts may fall through to PST-midnight reset (see upstream #641)."
     },
     {
       "path": "backend/internal/service/gemini_messages_compat_service_tk_model_rate_limit.go",
-      "must_contain": ["withGeminiCodeAssistMappedModel", "geminiCodeAssistMappedModelFromContext", "isGeminiCodeAssistModelScopedRateLimit", "SetModelRateLimit"],
+      "must_contain": [
+        "withGeminiCodeAssistMappedModel",
+        "geminiCodeAssistMappedModelFromContext",
+        "isGeminiCodeAssistModelScopedRateLimit",
+        "SetModelRateLimit"
+      ],
       "rationale": "TK companion that keeps Gemini Code Assist MODEL_CAPACITY_EXHAUSTED scoped to the affected upstream model, including the production case where Google omits ErrorInfo.metadata.model."
     },
     {
       "path": "backend/internal/service/model_rate_limit.go",
-      "must_contain": ["resolveFinalGeminiModelKey", "TKResolveGeminiDispatchModel", "PlatformGemini"],
+      "must_contain": [
+        "resolveFinalGeminiModelKey",
+        "TKResolveGeminiDispatchModel",
+        "PlatformGemini"
+      ],
       "rationale": "Scheduling must read model_rate_limits through the same Gemini group-level Claude→Gemini mapping used by forwarding; otherwise writes use gemini-* keys while subsequent /v1/messages reads probe claude-* keys."
     },
     {
       "path": "backend/internal/service/model_rate_limit_test.go",
-      "must_contain": ["TestIsModelRateLimited_GeminiDispatchMappingAffectsModelKey"],
+      "must_contain": [
+        "TestIsModelRateLimited_GeminiDispatchMappingAffectsModelKey"
+      ],
       "rationale": "Focused regression proving Gemini dispatch mapping affects model-level rate-limit reads."
     },
     {
       "path": "backend/internal/service/gemini_messages_compat_service_tk_model_rate_limit_test.go",
-      "must_contain": ["TestTryGeminiCodeAssistApplyModelRateLimit_UsesFallbackModelForModelScoped429", "TestHandleGeminiUpstreamError_CodeAssist429FallbackModelRoutesToPerModel", "TestHandleGeminiUpstreamError_CodeAssist429RetryDelayRoutesToPerModel"],
+      "must_contain": [
+        "TestTryGeminiCodeAssistApplyModelRateLimit_UsesFallbackModelForModelScoped429",
+        "TestHandleGeminiUpstreamError_CodeAssist429FallbackModelRoutesToPerModel",
+        "TestHandleGeminiUpstreamError_CodeAssist429RetryDelayRoutesToPerModel"
+      ],
       "rationale": "Focused regressions proving model-scoped Code Assist 429s without metadata.model and with RetryInfo retryDelay both stay per-model and do not fall back to account-level cooldown."
     },
     {
       "path": "backend/internal/service/ops_alert_evaluator_service.go",
-      "must_contain": ["maybeSendAlertNotifications", "feishu_sent"],
+      "must_contain": [
+        "maybeSendAlertNotifications",
+        "feishu_sent"
+      ],
       "rationale": "Ops alert evaluator must call the TK companion notification fanout and report Feishu sends in the heartbeat. If an upstream merge restores the old email-only call, P0 Feishu delivery silently stops while alert event creation still works."
     },
     {
       "path": "backend/internal/service/ops_alert_notifications_tk_feishu.go",
-      "must_contain": ["maybeSendAlertFeishu", "strings.EqualFold(strings.TrimSpace(rule.Severity), \"P0\")", "rule.NotifyEmail", "opsFeishuDedupeKey", "s.limiter.SetLimit(cfg.RateLimitPerHour)"],
+      "must_contain": [
+        "maybeSendAlertFeishu",
+        "strings.EqualFold(strings.TrimSpace(rule.Severity), \"P0\")",
+        "rule.NotifyEmail",
+        "opsFeishuDedupeKey",
+        "s.limiter.SetLimit(cfg.RateLimitPerHour)"
+      ],
       "rationale": "TK companion that keeps Feishu alerting P0-only, tied to the existing external-notification opt-in, and protected by per-rule/dimension cooldown plus global hourly rate limiting. Dropping any anchor turns a low-noise OPC pager into either silence or chat noise."
     },
     {
       "path": "backend/internal/service/ops_feishu_notifier_tk.go",
-      "must_contain": ["sanitizeFeishuWebhook", "sanitizeFeishuWebhookError", "signFeishuWebhook", "SigningSecret"],
+      "must_contain": [
+        "sanitizeFeishuWebhook",
+        "sanitizeFeishuWebhookError",
+        "signFeishuWebhook",
+        "SigningSecret"
+      ],
       "rationale": "Feishu webhook delivery must keep secrets out of logs/errors and support the optional bot signing secret. These are safety properties that compile cleanly if accidentally removed."
     },
     {
       "path": "backend/internal/service/ops_settings_models.go",
-      "must_contain": ["OpsFeishuAlertConfig", "WebhookURLConfigured", "SigningSecretConfigured"],
+      "must_contain": [
+        "OpsFeishuAlertConfig",
+        "WebhookURLConfigured",
+        "SigningSecretConfigured"
+      ],
       "rationale": "Ops email notification config JSON must preserve the Feishu write-only webhook/secret state without a DB migration. If this model shape is overwritten, frontend saves can drop Feishu config or leak secret fields."
     },
     {
       "path": "backend/internal/service/openai_messages_compaction_tk.go",
-      "must_contain": ["shouldEvaluateOpenAICompatMessagesCompactionForAccount", "applyOpenAICompatMessagesCompaction(account *Account", "applyOpenAICompatOAuthMessagesCompaction", "openAICompatMessagesCompactCandidate", "anthropicResponseContentTextLen"],
+      "must_contain": [
+        "shouldEvaluateOpenAICompatMessagesCompactionForAccount",
+        "applyOpenAICompatMessagesCompaction(account *Account",
+        "applyOpenAICompatOAuthMessagesCompaction",
+        "openAICompatMessagesCompactCandidate",
+        "anthropicResponseContentTextLen"
+      ],
       "rationale": "OpenAI OAuth /v1/messages compaction is a TK policy companion: OAuth must opt into threshold-based compaction through the shared replay compaction engine's anchor+tail profile, and gateway completion logs must keep enough compact-attempt evidence to distinguish upstream empty summaries from TokenKey routing or billing failures. Dropping these hooks silently makes GPT专线 OAuth accounts ignore configured compaction thresholds or removes the production evidence needed for long-context compact incidents."
     },
     {
       "path": "backend/internal/service/openai_messages_compaction_tk_test.go",
-      "must_contain": ["TestShouldEvaluateOpenAICompatMessagesCompactionForAccount", "TestApplyOpenAICompatMessagesCompaction_UsesAnchorAndTailProfileForOAuth", "TestApplyOpenAICompatMessagesCompaction_UsesTailOnlyProfileForAPIKey"],
+      "must_contain": [
+        "TestShouldEvaluateOpenAICompatMessagesCompactionForAccount",
+        "TestApplyOpenAICompatMessagesCompaction_UsesAnchorAndTailProfileForOAuth",
+        "TestApplyOpenAICompatMessagesCompaction_UsesTailOnlyProfileForAPIKey"
+      ],
       "rationale": "Focused regressions proving OAuth configured compaction uses the shared engine's anchor+tail profile while APIKey compaction keeps the existing continuation gate and tail-only profile."
     },
     {
       "path": "backend/internal/service/ratelimit_service.go",
-      "must_contain": ["case 404:", "s.handle404(ctx, account, upstreamMsg, responseBody)", "anthropic404ModelCooldown", "isAnthropicModelNotFound404", "SetModelRateLimit(ctx, account.ID, modelName, resetAt)", "isAnthropicExtraUsage429", "s.apply429FallbackRateLimit(ctx, account, \"no_reset_time\")", "TkRecordOpenAI429BurstFallthrough(normalized)", "anthropicUpstreamErrorThreshold", "anthropicUpstreamErrorWindowMinutes", "handleAnthropicUpstreamError", "IncrementAnthropicUpstreamErrorCount", "SetTempUnschedulable(ctx, account.ID, until, reason)", "ResetAnthropicUpstreamErrorCounter", "if account.IsPoolMode() && !customErrorCodesEnabled && account.Platform != PlatformAnthropic {", "if !account.ShouldHandleErrorCode(statusCode) && account.Platform != PlatformAnthropic {", "s.ResetAnthropicUpstreamErrorCounter(ctx, accountID)"],
+      "must_contain": [
+        "case 404:",
+        "s.handle404(ctx, account, upstreamMsg, responseBody)",
+        "anthropic404ModelCooldown",
+        "isAnthropicModelNotFound404",
+        "SetModelRateLimit(ctx, account.ID, modelName, resetAt)",
+        "isAnthropicExtraUsage429",
+        "s.apply429FallbackRateLimit(ctx, account, \"no_reset_time\")",
+        "TkRecordOpenAI429BurstFallthrough(normalized)",
+        "anthropicUpstreamErrorThreshold",
+        "anthropicUpstreamErrorWindowMinutes",
+        "handleAnthropicUpstreamError",
+        "IncrementAnthropicUpstreamErrorCount",
+        "SetTempUnschedulable(ctx, account.ID, until, reason)",
+        "ResetAnthropicUpstreamErrorCounter",
+        "if account.IsPoolMode() && !customErrorCodesEnabled && account.Platform != PlatformAnthropic {",
+        "if !account.ShouldHandleErrorCode(statusCode) && account.Platform != PlatformAnthropic {",
+        "s.ResetAnthropicUpstreamErrorCounter(ctx, accountID)"
+      ],
       "rationale": "Anthropic model-not-found 404s must stay model-scoped instead of falling through as an unprotected upstream error or disabling the whole OAuth account. Anthropic 429s without reset metadata must use the configurable short cooldown unless the body is the known third-party/extra-usage rejection, otherwise production can repeatedly hit the same account with no local backoff. Anthropic upstream errors must also feed the TK short-window counter (anchored by the `anthropicUpstreamErrorWindowMinutes` symbol — the value is intentionally short, currently 1 minute, so a transient burst clears quickly rather than carrying stale strikes across an entire 10-minute cooldown) and mark the account temporarily unschedulable after three hits so a single bad Edge/OAuth account cannot produce repeated upstream 400/403/5xx responses before the scheduler removes it; the two `&& account.Platform != PlatformAnthropic` carve-outs are load-bearing because they are the ONLY reason pool-mode + custom-error-codes Anthropic accounts still reach the counter, and the `s.ResetAnthropicUpstreamErrorCounter(ctx, accountID)` call must be invoked from the recovery hotpaths (ClearRateLimit, RecoverAccountState, ClearTempUnschedulable, UpdateSessionWindow allowed status) so a healed account does not carry stale strikes into the next window. OpenAI burst 429s (Codex headers present but neither 5h nor 7d window at 100% used+with-reset) must call the TK companion TkRecordOpenAI429BurstFallthrough and return nil so handle429 falls back to the short cooldown, otherwise transient throttle surges turn into multi-day 503 windows (upstream #2258). Upstream merges in this large service file can compile cleanly while dropping any of these protections, so the sentinel anchors all four policies in the hotspot file."
     },
     {
       "path": "backend/internal/service/anthropic_upstream_error_counter.go",
-      "must_contain": ["type AnthropicUpstreamErrorCounterCache interface", "IncrementAnthropicUpstreamErrorCount", "ResetAnthropicUpstreamErrorCount"],
+      "must_contain": [
+        "type AnthropicUpstreamErrorCounterCache interface",
+        "IncrementAnthropicUpstreamErrorCount",
+        "ResetAnthropicUpstreamErrorCount"
+      ],
       "rationale": "Interface seam for Anthropic upstream-error short-window counting. If an upstream merge drops this interface or its reset path, RateLimitService can no longer atomically count failures or clear the counter after recovery."
     },
     {
       "path": "backend/internal/repository/anthropic_upstream_error_counter_cache.go",
-      "must_contain": ["anthropic_upstream_error_count:account:", "NewAnthropicUpstreamErrorCounterCache", "IncrementAnthropicUpstreamErrorCount", "ResetAnthropicUpstreamErrorCount"],
+      "must_contain": [
+        "anthropic_upstream_error_count:account:",
+        "NewAnthropicUpstreamErrorCounterCache",
+        "IncrementAnthropicUpstreamErrorCount",
+        "ResetAnthropicUpstreamErrorCount"
+      ],
       "rationale": "Redis-backed atomic counter for Anthropic upstream-error bursts. The prefix and constructor wiring must remain stable so all app replicas share the same short-window threshold before setting temp_unschedulable_until."
     },
     {
       "path": "backend/internal/service/wire.go",
-      "must_contain": ["anthropicUpstreamErrorCounterCache AnthropicUpstreamErrorCounterCache,", "svc.SetAnthropicUpstreamErrorCounterCache(anthropicUpstreamErrorCounterCache)"],
+      "must_contain": [
+        "anthropicUpstreamErrorCounterCache AnthropicUpstreamErrorCounterCache,",
+        "svc.SetAnthropicUpstreamErrorCounterCache(anthropicUpstreamErrorCounterCache)"
+      ],
       "rationale": "ProvideRateLimitService MUST keep the Anthropic upstream-error counter parameter and the SetAnthropicUpstreamErrorCounterCache wire call. If an upstream merge drops either line, handleAnthropicUpstreamError silently falls through (nil counter → returns false → no temp_unschedulable) and the burst protection becomes a NOOP that compiles cleanly and passes all current unit tests. The literal parameter declaration is what wire.go regen sees; the Set call is what hands the dependency to the runtime service."
     },
     {
       "path": "backend/internal/repository/wire.go",
-      "must_contain": ["NewAnthropicUpstreamErrorCounterCache"],
+      "must_contain": [
+        "NewAnthropicUpstreamErrorCounterCache"
+      ],
       "rationale": "ProviderSet MUST register the Anthropic upstream-error counter constructor; without it `wire` regen fails to satisfy the service.AnthropicUpstreamErrorCounterCache dependency added in service/wire.go and falls back to the stale wire_gen.go until someone forces a regen. Anchoring the literal here makes the missing provider obvious on first sentinel run instead of waiting for a wire regen drift."
     },
     {
       "path": "backend/internal/service/ratelimit_service_403_test.go",
-      "must_contain": ["TestRateLimitService_HandleUpstreamError_Anthropic403ThresholdTempUnschedulable", "TestRateLimitService_HandleUpstreamError_AnthropicPoolModeStillCounts", "TestRateLimitService_HandleUpstreamError_AnthropicCustomErrorCodesStillCounts", "TestRateLimitService_ClearRateLimit_ResetsAnthropicCounter", "TestRateLimitService_RecoverAccountAfterSuccessfulTest_ResetsAnthropicCounter"],
+      "must_contain": [
+        "TestRateLimitService_HandleUpstreamError_Anthropic403ThresholdTempUnschedulable",
+        "TestRateLimitService_HandleUpstreamError_AnthropicPoolModeStillCounts",
+        "TestRateLimitService_HandleUpstreamError_AnthropicCustomErrorCodesStillCounts",
+        "TestRateLimitService_ClearRateLimit_ResetsAnthropicCounter",
+        "TestRateLimitService_RecoverAccountAfterSuccessfulTest_ResetsAnthropicCounter"
+      ],
       "rationale": "Focused regressions proving the four behaviors that are easy to silently revert in an upstream merge: (1) Anthropic upstream errors only disable after the short-window threshold, (2) the pool-mode carve-out still feeds the counter, (3) the custom-error-codes allowlist carve-out still feeds the counter, (4) ClearRateLimit resets the counter to mirror ResetOpenAI403Counter, and (5) RecoverAccountAfterSuccessfulTest resets the counter so a healed account does not carry stale strikes. Dropping these tests lets the upstream-error policy silently drift during future merges."
     },
     {
       "path": "backend/internal/service/ratelimit_service_401_test.go",
-      "must_contain": ["type anthropicUpstreamErrorCounterCacheStub struct", "IncrementAnthropicUpstreamErrorCount", "ResetAnthropicUpstreamErrorCount"],
+      "must_contain": [
+        "type anthropicUpstreamErrorCounterCacheStub struct",
+        "IncrementAnthropicUpstreamErrorCount",
+        "ResetAnthropicUpstreamErrorCount"
+      ],
       "rationale": "Shared test stub for the Anthropic upstream-error counter interface lives next to the OpenAI 403 counter stub. The 403 regression suite and any future Anthropic upstream-error test depends on this stub satisfying the AnthropicUpstreamErrorCounterCache interface; an upstream merge that mass-rewrites this test file could drop the stub and silently break the entire 403 test bundle with a compile error masked by build tag (the //go:build unit gate hides the failure from non-unit jobs)."
     },
     {
       "path": "backend/internal/service/ratelimit_service_tk_openai_burst.go",
-      "must_contain": ["func TkIsOpenAI429TransientBurst(normalized *NormalizedCodexLimits) bool", "func TkRecordOpenAI429BurstFallthrough(normalized *NormalizedCodexLimits)", "openai_429_burst_below_window_limits", "is7dExhausted := normalized.Used7dPercent != nil && *normalized.Used7dPercent >= 100 && normalized.Reset7dSeconds != nil", "is5hExhausted := normalized.Used5hPercent != nil && *normalized.Used5hPercent >= 100 && normalized.Reset5hSeconds != nil"],
+      "must_contain": [
+        "func TkIsOpenAI429TransientBurst(normalized *NormalizedCodexLimits) bool",
+        "func TkRecordOpenAI429BurstFallthrough(normalized *NormalizedCodexLimits)",
+        "openai_429_burst_below_window_limits",
+        "is7dExhausted := normalized.Used7dPercent != nil && *normalized.Used7dPercent >= 100 && normalized.Reset7dSeconds != nil",
+        "is5hExhausted := normalized.Used5hPercent != nil && *normalized.Used5hPercent >= 100 && normalized.Reset5hSeconds != nil"
+      ],
       "rationale": "TK companion that holds the OpenAI burst-429 policy referenced from calculateOpenAI429ResetTime (upstream #2258). The predicate must require BOTH `used >= 100` AND a non-nil reset value to treat a window as exhausted; without the reset clause, a 100%-but-no-reset signal would skip the short-cooldown fallback and re-introduce multi-day 503 windows. The slog marker `openai_429_burst_below_window_limits` is the observability sentinel operators alert on."
     },
     {
       "path": "backend/internal/service/ratelimit_service_tk_openai_burst_test.go",
-      "must_contain": ["TestTkIsOpenAI429TransientBurst", "TestTkRecordOpenAI429BurstFallthrough_HandlesNil"],
+      "must_contain": [
+        "TestTkIsOpenAI429TransientBurst",
+        "TestTkRecordOpenAI429BurstFallthrough_HandlesNil"
+      ],
       "rationale": "Focused regressions proving the burst predicate handles the four exhausted/with-reset crossings (and nil snapshot) correctly. Dropping these lets the upstream-merge regression sneak back through unit CI."
     },
     {
       "path": "backend/internal/service/ratelimit_404_model_not_found_test.go",
-      "must_contain": ["TestHandleUpstreamError_Anthropic404ModelNotFoundSetsModelRateLimit", "TestHandleUpstreamError_Anthropic404WithoutModelDoesNotDisableAccount", "TestHandleUpstreamError_NonAnthropic404DoesNotUseAnthropicModelProtection"],
+      "must_contain": [
+        "TestHandleUpstreamError_Anthropic404ModelNotFoundSetsModelRateLimit",
+        "TestHandleUpstreamError_Anthropic404WithoutModelDoesNotDisableAccount",
+        "TestHandleUpstreamError_NonAnthropic404DoesNotUseAnthropicModelProtection"
+      ],
       "rationale": "Focused regressions proving only Anthropic model-not-found 404s write model_rate_limits, while generic 404s and non-Anthropic 404s do not disable accounts. Dropping these tests lets the upstream-error policy silently drift during future merges."
     },
     {
@@ -308,37 +413,64 @@
     },
     {
       "path": "backend/internal/service/model_pricing_resolver.go",
-      "must_contain": ["tkApplyChannelFlatOverridesAsFallback(chPricing, resolved)", "tkOverlayIntervalOntoBasePricing(resolved.BasePricing, iv, resolved.SupportsCacheBreakdown)"],
+      "must_contain": [
+        "tkApplyChannelFlatOverridesAsFallback(chPricing, resolved)",
+        "tkOverlayIntervalOntoBasePricing(resolved.BasePricing, iv, resolved.SupportsCacheBreakdown)"
+      ],
       "rationale": "TK channel-pricing policy: applyTokenOverrides MUST delegate flat-default application to the TK companion regardless of whether intervals are configured (upstream #2107 — out-of-range fallback). GetIntervalPricing MUST delegate matched-interval pricing to the TK overlay helper instead of building a brand-new ModelPricing from interval fields only (upstream #2363 — in-range cache_read/cache_write/image_output preservation). Either revert silently re-introduces $0 or wrong-tier billing on the most cache-hit-heavy traffic that sticky-routing was designed to bank."
     },
     {
       "path": "backend/internal/service/model_pricing_resolver_tk_channel_flat_fallback.go",
-      "must_contain": ["func tkApplyChannelFlatOverridesAsFallback(chPricing *ChannelModelPricing, resolved *ResolvedPricing)", "resolved.BasePricing.InputPricePerToken = *chPricing.InputPrice", "resolved.BasePricing.OutputPricePerToken = *chPricing.OutputPrice", "resolved.BasePricing.CacheReadPricePerToken = *chPricing.CacheReadPrice", "resolved.BasePricing.CacheCreationPricePerToken = *chPricing.CacheWritePrice", "func tkOverlayIntervalOntoBasePricing(base *ModelPricing, iv *PricingInterval, supportsCacheBreakdown bool) *ModelPricing", "Wei-Shaw/sub2api#2363", "out.CacheReadPricePerToken = *iv.CacheReadPrice"],
+      "must_contain": [
+        "func tkApplyChannelFlatOverridesAsFallback(chPricing *ChannelModelPricing, resolved *ResolvedPricing)",
+        "resolved.BasePricing.InputPricePerToken = *chPricing.InputPrice",
+        "resolved.BasePricing.OutputPricePerToken = *chPricing.OutputPrice",
+        "resolved.BasePricing.CacheReadPricePerToken = *chPricing.CacheReadPrice",
+        "resolved.BasePricing.CacheCreationPricePerToken = *chPricing.CacheWritePrice",
+        "func tkOverlayIntervalOntoBasePricing(base *ModelPricing, iv *PricingInterval, supportsCacheBreakdown bool) *ModelPricing",
+        "Wei-Shaw/sub2api#2363",
+        "out.CacheReadPricePerToken = *iv.CacheReadPrice"
+      ],
       "rationale": "TK companion holding the channel flat-fallback policy referenced from applyTokenOverrides (upstream #2107) AND the interval overlay helper used by GetIntervalPricing (upstream #2363). Each flat field write is sentinel-pinned so a future change cannot drop one of the five pricing dimensions silently — operators rely on each (input/output/cache-read/cache-write/image-output) being honored as the out-of-range fallback. The overlay helper signature, #2363 reference, and the cache_read interval-overlay line are pinned so the symmetric in-range path cannot regress to the original empty-ModelPricing construction."
     },
     {
       "path": "backend/internal/service/model_pricing_resolver_test.go",
-      "must_contain": ["TestGetIntervalPricing_ChannelIntervalsNoMatch_FlatDefaultsApplied", "TestGetIntervalPricing_ChannelIntervalsNoMatch_UnknownModelChargesFlatNotZero", "TestGetIntervalPricing_IntervalMatched_FlatCacheReadPreserved", "TestGetIntervalPricing_IntervalMatched_IntervalCacheReadOverridesFlat"],
+      "must_contain": [
+        "TestGetIntervalPricing_ChannelIntervalsNoMatch_FlatDefaultsApplied",
+        "TestGetIntervalPricing_ChannelIntervalsNoMatch_UnknownModelChargesFlatNotZero",
+        "TestGetIntervalPricing_IntervalMatched_FlatCacheReadPreserved",
+        "TestGetIntervalPricing_IntervalMatched_IntervalCacheReadOverridesFlat"
+      ],
       "rationale": "Focused regressions for upstream #2107 (out-of-range path) and upstream #2363 (in-range path). The four tests jointly assert that channel flat defaults survive every interval lookup outcome (no intervals, no match, match overlapping interval, match disjoint from flat defaults) and that interval values take precedence in-range when both are set. Dropping any of these lets the symmetric pricing-dimension drop bugs return without unit-CI noticing."
     },
     {
       "path": "backend/internal/repository/account_repo.go",
-      "must_contain": ["dbproxy.StatusEQ(service.StatusActive)", "entAcc.Edges.Proxy.Status == service.StatusActive"],
+      "must_contain": [
+        "dbproxy.StatusEQ(service.StatusActive)",
+        "entAcc.Edges.Proxy.Status == service.StatusActive"
+      ],
       "rationale": "TK proxy-status filter (upstream #2159): account preload paths MUST filter out non-active proxies on both the manual loadProxies query and the WithProxy() edge-preload branch. Disabled proxies leaking back into account.Proxy contradicts operator intent and re-routes traffic through proxies that were explicitly turned off (compliance/IP-rotation regression)."
     },
     {
       "path": "backend/internal/repository/account_repo_integration_test.go",
-      "must_contain": ["TestPreload_SkipsDisabledProxy"],
+      "must_contain": [
+        "TestPreload_SkipsDisabledProxy"
+      ],
       "rationale": "Focused regression for upstream #2159 covering both GetByID and ListWithFilters paths. Dropping this test lets the proxy filter regression sneak back through integration CI."
     },
     {
       "path": "backend/internal/repository/user_subscription_repo.go",
-      "must_contain": ["usersubscription.StatusEQ(service.SubscriptionStatusActive)", "usersubscription.ExpiresAtGT(time.Now())"],
+      "must_contain": [
+        "usersubscription.StatusEQ(service.SubscriptionStatusActive)",
+        "usersubscription.ExpiresAtGT(time.Now())"
+      ],
       "rationale": "TK active-subscription predicate (upstream #2478): ExistsByUserIDAndGroupID and GetActiveByUserIDAndGroupID MUST gate on BOTH status=active AND expires_at>now. Without this, expired-yet-not-soft-deleted rows return exists=true and the reassignment flow blocks legitimate renewals with 409 validity_days_mismatch — a user-paid-but-no-access regression."
     },
     {
       "path": "backend/internal/repository/user_subscription_repo_integration_test.go",
-      "must_contain": ["TestExistsByUserIDAndGroupID_IgnoresExpiredAndNonActive"],
+      "must_contain": [
+        "TestExistsByUserIDAndGroupID_IgnoresExpiredAndNonActive"
+      ],
       "rationale": "Focused regression for upstream #2478 covering the three non-active variants (expired by date, expired by status, suspended). Dropping this test lets the reassignment-block bug sneak back through integration CI."
     },
     {
@@ -430,6 +562,16 @@
         "tkAnthropicSigPreemptCache AnthropicSignaturePreemptCache"
       ],
       "rationale": "Three call sites in upstream-shaped forwarding code that anchor the signature_error preempt feature: (1) the main Anthropic Forward path (~4583) and (3) ForwardCountTokens (~9060) both call applySigPreemptIfArmed on the working body before the first upstream attempt; (2) the Anthropic API-Key passthrough path (~5105) calls applySigPreemptIfArmed on input.Body. armSigPreemptOnError is invoked from all three signature_error detection branches. The struct-field declaration is pinned so upstream merges cannot drop the setter target. If any of these are silently removed, the feature degrades to no-op and the 12-in-4-min burst symptom on a single OAuth account returns."
+    },
+    {
+      "path": "backend/internal/service/gateway_service.go",
+      "must_contain": [
+        "case <-keepaliveCh:",
+        "event: ping\\ndata: {\\\"type\\\": \\\"ping\\\"}\\n\\n",
+        "inPartialEvent",
+        "lastDataAt"
+      ],
+      "rationale": "Upstream Wei-Shaw/sub2api#2552: keepalive ping injection for Anthropic API-key passthrough streams. Uses the existing cfg.Gateway.StreamKeepaliveInterval config field (opt-in when > 0). The select case must remain so long-lived passthrough streams can emit SSE ping events to prevent proxy/load-balancer idle-timeout disconnections. The inPartialEvent guard prevents pings mid-event-boundary; lastDataAt prevents spurious pings when the upstream is already active. This is a pure upstream feature, not a TK-specific injection — documented here so future upstream re-merges cannot silently revert the keepalive path."
     },
     {
       "path": "backend/internal/service/wire.go",


### PR DESCRIPTION
## Summary
- Merge upstream/main into TokenKey with a merge commit (`--no-ff`) while preserving TokenKey OPC invariants.
- Keep upstream features compiled in; TokenKey-specific behavior stays behind companion/facade/component boundaries.
- Upstream change: 2 commits adding keepalive ping support for Anthropic API-key passthrough streams (Wei-Shaw/sub2api#2552).

## Risk
- Small upstream merge: 2 commits touching `backend/internal/service/gateway_service.go` (keepalive ticker + select case) and a new test file.
- `StreamKeepaliveInterval` config field already exists in TK config struct — upstream change is purely additive with no new config surface.
- No TokenKey-specific code added to hotspot files; keepalive logic is entirely upstream-authored.
- No upstream files deleted or disabled.

## Human-reviewed decisions
- Keepalive feature uses existing `cfg.Gateway.StreamKeepaliveInterval` — no new TK config surface needed.
- `inPartialEvent` guard prevents spurious pings mid-SSE-event; `lastDataAt` prevents pings during active upstream data flow.
- Marked `no-web-impact`: opt-in via existing config, no API contract or frontend change.

## Validation
- `go test -tags=unit ./...` — PASS (all packages green)
- `bash scripts/preflight.sh` — PASS (all checks including sub2api sentinels)
- `git diff --diff-filter=D upstream/main..HEAD -- backend/` — no upstream file deletions

## Upstream Audit
- Required audit range: `upstream/main..HEAD`
- TK ahead count: `git log --oneline upstream/main..HEAD | wc -l` = 526
- Backend stat top files:
  ```
  backend/.golangci.yml                              |    12 +-
  backend/Makefile                                   |    15 +-
  backend/cmd/server/VERSION                         |     2 +-
  backend/cmd/server/main.go                         |    24 +-
  backend/cmd/server/wire.go                         |    39 +
  ```

## Upstream commits merged
- `1d78dde8` Merge pull request #2552 from lyen1688/fix/anthropic-passthrough-keepalive
- `164e2f61` fix: add keepalive for Anthropic passthrough streams

## TK commits in this PR
- `c98e2e6e` chore: merge upstream/main (2026-05-18) — keepalive for Anthropic passthrough streams (no-web-impact) ← merge commit
- `4e26cb28` chore(sentinels): register upstream Anthropic passthrough keepalive anchor (no-web-impact) ← B invariant

## Merge method
Reviewer MUST pick **Create a merge commit** (not Squash, not Rebase) per CLAUDE.md §5.y.