### PR TITLE
chore(stage0): rebalance anthropic OAuth tier baselines l1–l5 (no-web-impact)

### DIFF
--- a/.cursor/skills/tokenkey-anthropic-oauth-config/SKILL.md
+++ b/.cursor/skills/tokenkey-anthropic-oauth-config/SKILL.md
@@ -31,7 +31,7 @@ description: >-
 | `account_name` | `target_scope=account` 时必填；目标账号名（`accounts.name`）；`check` 支持 `all` 自动枚举每个 edge 下全部 anthropic oauth 账号。 |
 | `target_group_id` | `target_scope=group` 时可选；目标分组 ID（与 `target_group_name` 二选一，优先 ID）。 |
 | `target_group_name` | `target_scope=group` 时可选；目标分组名（与 `target_group_id` 二选一）。 |
-| `account.extra.stability_tier` | 分级基线选择键（`l1/l2/l3`），`check` 会按该字段选择 tier baseline。 |
+| `account.extra.stability_tier` | 分级基线选择键（`l1/l2/l3/l4/l5`），`check` 会按该字段选择 tier baseline。 |
 | `operation=check` | 默认模式，只读检查当前配置与基准差异；`target_scope=group` 时输出分组聚合结果与成员账号明细。 |
 | `operation=plan-apply` | 生成更新计划与请求 payload 预览，不写入。 |
 | `operation=apply` | 执行更新（账号字段 + 可选分组绑定）；`target_scope=group` 时对分组内可用账号逐一执行，必须显式确认。 |

--- a/deploy/aws/stage0/anthropic-oauth-stability-baselines-tiered.json
+++ b/deploy/aws/stage0/anthropic-oauth-stability-baselines-tiered.json
@@ -157,11 +157,11 @@
           "rate_multiplier": 1.0
         },
         "extra": {
-          "base_rpm": 6,
-          "rpm_sticky_buffer": 2,
+          "base_rpm": 4,
+          "rpm_sticky_buffer": 4,
           "max_sessions": 3,
           "session_idle_timeout_minutes": 8,
-          "window_cost_limit": 180,
+          "window_cost_limit": 120,
           "window_cost_sticky_reserve": 0
         }
       }
@@ -175,11 +175,11 @@
           "rate_multiplier": 1.0
         },
         "extra": {
-          "base_rpm": 8,
-          "rpm_sticky_buffer": 4,
+          "base_rpm": 6,
+          "rpm_sticky_buffer": 6,
           "max_sessions": 4,
           "session_idle_timeout_minutes": 8,
-          "window_cost_limit": 330,
+          "window_cost_limit": 220,
           "window_cost_sticky_reserve": 0
         }
       }
@@ -197,7 +197,7 @@
           "rpm_sticky_buffer": 6,
           "max_sessions": 5,
           "session_idle_timeout_minutes": 8,
-          "window_cost_limit": 480,
+          "window_cost_limit": 400,
           "window_cost_sticky_reserve": 0
         }
       }
@@ -206,16 +206,16 @@
       "factor": 0.9,
       "baseline": {
         "account": {
-          "concurrency": 4,
+          "concurrency": 5,
           "priority": 40,
           "rate_multiplier": 1.0
         },
         "extra": {
-          "base_rpm": 12,
-          "rpm_sticky_buffer": 8,
-          "max_sessions": 6,
+          "base_rpm": 14,
+          "rpm_sticky_buffer": 10,
+          "max_sessions": 8,
           "session_idle_timeout_minutes": 8,
-          "window_cost_limit": 540,
+          "window_cost_limit": 800,
           "window_cost_sticky_reserve": 0
         }
       }
@@ -224,16 +224,16 @@
       "factor": 0.95,
       "baseline": {
         "account": {
-          "concurrency": 5,
+          "concurrency": 8,
           "priority": 50,
           "rate_multiplier": 1.0
         },
         "extra": {
-          "base_rpm": 18,
-          "rpm_sticky_buffer": 12,
-          "max_sessions": 8,
+          "base_rpm": 22,
+          "rpm_sticky_buffer": 14,
+          "max_sessions": 12,
           "session_idle_timeout_minutes": 8,
-          "window_cost_limit": 600,
+          "window_cost_limit": 1500,
           "window_cost_sticky_reserve": 0
         }
       }

--- a/deploy/aws/stage0/anthropic-oauth-stability-tiered-apply-template.sql
+++ b/deploy/aws/stage0/anthropic-oauth-stability-tiered-apply-template.sql
@@ -23,11 +23,11 @@ WITH input AS (
 tier_cfg AS (
   SELECT *
   FROM (VALUES
-    ('l1'::text, 1::int, 10::int, 6::int, 2::int, 3::int, 8::int, 180::int, 0::int),
-    ('l2'::text, 2::int, 20::int, 8::int, 4::int, 4::int, 8::int, 330::int, 0::int),
-    ('l3'::text, 3::int, 30::int, 10::int, 6::int, 5::int, 8::int, 480::int, 0::int),
-    ('l4'::text, 4::int, 40::int, 12::int, 8::int, 6::int, 8::int, 540::int, 0::int),
-    ('l5'::text, 5::int, 50::int, 18::int, 12::int, 8::int, 8::int, 600::int, 0::int)
+    ('l1'::text, 1::int, 10::int, 4::int, 4::int, 3::int, 8::int, 120::int, 0::int),
+    ('l2'::text, 2::int, 20::int, 6::int, 6::int, 4::int, 8::int, 220::int, 0::int),
+    ('l3'::text, 3::int, 30::int, 10::int, 6::int, 5::int, 8::int, 400::int, 0::int),
+    ('l4'::text, 5::int, 40::int, 14::int, 10::int, 8::int, 8::int, 800::int, 0::int),
+    ('l5'::text, 8::int, 50::int, 22::int, 14::int, 12::int, 8::int, 1500::int, 0::int)
   ) AS v(
     stability_tier,
     concurrency,


### PR DESCRIPTION
## Summary

Rebalances `deploy/aws/stage0/anthropic-oauth-stability-baselines-tiered.json` (and its lockstep SQL apply template) so that each Anthropic OAuth tier's **single-account contribution to `group.rpm_limit`** — i.e. `base_rpm + rpm_sticky_buffer` — maps cleanly to the Pro / Max 5x / Max 20x plan economics and to the design invariant documented in [`docs/approved/rpm-override-deferred-removal.md`](../blob/main/docs/approved/rpm-override-deferred-removal.md):

```
Σ base_rpm  <  group.rpm_limit  ≤  Σ (base_rpm + rpm_sticky_buffer)
```

This treats `group.rpm_limit` as the **human-maintained derived value** from `Σ (base + sticky_buffer)` across the pool, not as an independent dial.

## Per-tier values (before → after)

| tier | base_rpm | rpm_sticky_buffer | sum (= single-account contribution to group.rpm_limit) | concurrency | max_sessions | window_cost_limit ($/5h) |
|---|---|---|---|---|---|---|
| **l1** | 6 → **4** | 2 → **4** | 8 → **8** | 1 | 3 | 180 → **120** |
| **l2** | 8 → **6** | 4 → **6** | 12 → **12** | 2 | 4 | 330 → **220** |
| **l3** | 10 (unchanged) | 6 (unchanged) | **16** | 3 | 5 | 480 → **400** |
| **l4** | 12 → **14** | 8 → **10** | 20 → **24** | 4 → **5** | 6 → **8** | 540 → **800** |
| **l5** | 18 → **22** | 12 → **14** | 30 → **36** | 5 → **8** | 8 → **12** | 600 → **1500** |

### Why these numbers

- **l3 (base/buffer/max_sessions/concurrency) intentionally unchanged** so the currently-deployed edge-us1 acct 1 (tier=l3, base+buffer=16=group.rpm_limit) stays aligned. Only `window_cost_limit` shifts 480 → 400 to better reflect Max 5x's published 5h window economics.
- **l4/l5 widened** because the previous range only spanned 30→36 sum (1.2× from l3), which doesn't reflect the Max 5x → Max 20x real-world capacity gap (~4× messages, ~3× tokens). New range 24/36 gives a meaningful upgrade ladder.
- **window_cost_limit** range broadened from 180→600 (1:3.3) to 120→1500 (1:12) to track the published Pro → Max 20x cost ratio (~$30→$1500 per 5h window).
- **l1/l2 base:buffer ratio** moved to ~1:1 so the sticky yellow band is roughly the same size as the green band (matches "Pro burst is ~1× steady-state" observation).

### Operational note

Per the invariant: applying any tier baseline to a pool MUST be accompanied by an explicit `UPDATE groups SET rpm_limit = Σ (base + buffer)`. This PR ships only the **baseline definitions** — no live SQL is applied. The `tokenkey-anthropic-oauth-config` skill is the apply path (read → confirm → apply → verify).

For edge-us1 today (1× l3 OAuth account, group default rpm_limit=16): **no live change needed** — the existing config already matches the new l3 baseline (only `window_cost_limit` would change on next apply).

## Files

- `deploy/aws/stage0/anthropic-oauth-stability-baselines-tiered.json` — source of truth (JSON).
- `deploy/aws/stage0/anthropic-oauth-stability-tiered-apply-template.sql` — SQL VALUES tuple updated in lockstep. Preflight `anthropic tier baseline JSON↔SQL drift` check enforces parity.

## Test plan

- [x] `scripts/preflight.sh` PASS (incl. JSON↔SQL drift check)
- [x] `python3 -c "import json; json.load(...)"` parses
- [x] tier sums computed and verified manually: l1=8, l2=12, l3=16, l4=24, l5=36

## Drift / upstream notes (CLAUDE.md PR Checklist)

- TK is currently **3450 commits behind** upstream/main (as of branch-off SHA). This PR ships out of order because:
  - Pure `deploy/aws/stage0/` JSON+SQL config; zero Go / frontend / upstream-shaped paths touched.
  - Zero merge-conflict risk with upstream (file is TK-only, doesn't exist upstream).
  - Operationally time-sensitive (edge-us1 tier-config troubleshooting context).
- No `git log/diff upstream/main..HEAD` numbers needed — this is not an upstream-merge PR.
- No upstream-override marker needed — preflight `upstream-touch-marker` check passes (the modified paths are not in the upstream-shaped path list); commit message carries `no-web-impact` for the web-impact preflight gate.
- Reviewer: please **Squash and merge** per CLAUDE.md §5.y.