### PR TITLE
feat(stage0): add anthropic stub R1 concurrency mirror apply template (no-web-impact)

### DIFF
--- a/.cursor/skills/tokenkey-anthropic-oauth-config/SKILL.md
+++ b/.cursor/skills/tokenkey-anthropic-oauth-config/SKILL.md
@@ -146,9 +146,14 @@ python3 ops/anthropic/check-prod-stub-mirror.py --json   # CI-friendly
 
 报告输出按 `--- account-level (R1) ---` 与 `--- group-level (R3) ---` 两段呈现；JSON 模式下 `stub_violation_count` 与 `group_violation_count` 分项汇总。
 
-### R3 mirror 修复路径（guard fail 后 apply）
+### R1 / R3 mirror 修复路径（guard fail 后 apply）
 
-`check-prod-anthropic-stub-mirror.py` 只检测、不修改。fail 后 op 用 [`anthropic-stub-mirror-rpm-apply-template.sql`](../../../deploy/aws/stage0/anthropic-stub-mirror-rpm-apply-template.sql) 把 prod stub-only group 的 `rpm_limit` 写到 R3 期望值（即 guard JSON 输出的 `group_results[i].expected_rpm_limit`）。模板顶部 DO 块拒绝对 OAuth-bearing group 使用——后者归 strict-redline aggregate 模板（[`anthropic-oauth-group-aggregate-apply-template.sql`](../../../deploy/aws/stage0/anthropic-oauth-group-aggregate-apply-template.sql)）。
+`check-prod-anthropic-stub-mirror.py` 只检测、不修改。fail 后按违规类型分两条 apply 路径，**两条都要打**（如果两类违规都存在），否则下次 guard 仍会失败：
+
+- **R1（stub concurrency）** — guard `results[i].mirror_violations[field=concurrency]`。op 用 [`anthropic-stub-mirror-concurrency-apply-template.sql`](../../../deploy/aws/stage0/anthropic-stub-mirror-concurrency-apply-template.sql) 逐 stub 把 `account.concurrency` 写到 `expected_concurrency`。模板顶部 DO 块拒绝 OAuth 账号 / 非 self-edge stub（base_url 不匹配 `api-<edge>.tokenkey.dev`）。
+- **R3（stub-only group rpm_limit）** — guard `group_results[i].mirror_violations[field=rpm_limit]`。op 用 [`anthropic-stub-mirror-rpm-apply-template.sql`](../../../deploy/aws/stage0/anthropic-stub-mirror-rpm-apply-template.sql) 把 prod stub-only group 的 `rpm_limit` 写到 R3 期望值（`group_results[i].expected_rpm_limit`）。模板顶部 DO 块拒绝对 OAuth-bearing group 使用——后者归 strict-redline aggregate 模板（[`anthropic-oauth-group-aggregate-apply-template.sql`](../../../deploy/aws/stage0/anthropic-oauth-group-aggregate-apply-template.sql)）。
+
+典型连发顺序：先 R1 stubs 全打完，再 R3 group rpm。任何顺序都不会触发其他模板的拒绝门禁（三类模板的 DO 块互斥保护各自的写入面）。
 
 ### 规则的本质
 
@@ -326,7 +331,10 @@ python3 ops/anthropic/check-account-group-rpm-alignment.py --target <edge_id|pro
 1. **PR 合入** — `--strict-redline` 默认关闭，线上 apply 流仍走旧口径，行为零回归。
 2. **离线巡检** — 逐 edge / prod 用 `--strict-redline --json` 跑一遍，确认 Layer C 全过（baseline 已逐 tier 落档），列出 Layer A/B violation 清单。
 3. **升 edge group cap** — 对每个 strict-mode 下违反 Layer A/B 的 **OAuth-bearing** group（典型是 edge `default`），按 [`anthropic-oauth-group-aggregate-apply-template.sql`](../../../deploy/aws/stage0/anthropic-oauth-group-aggregate-apply-template.sql) 生成自包含 SQL，把 `group.rpm_limit` 升到 `Σ redline`。
-4. **同步 prod 镜像（R3）** — `check-prod-anthropic-stub-mirror.py` 是 guard 不是 applier；edge 改完后它会在下一次巡检里检出 prod 镜像漂移。op 须用 [`anthropic-stub-mirror-rpm-apply-template.sql`](../../../deploy/aws/stage0/anthropic-stub-mirror-rpm-apply-template.sql) 把 prod stub-only group（如 `cc-edges`）的 `rpm_limit` 写到 R3 期望值（取自 stub-mirror guard 的 `expected_rpm_limit`）。注意：strict-redline aggregate 模板不适合 stub-only group——它会算出 `Σ = 0` 把组改成 unlimited。
+4. **同步 prod 镜像（R1 + R3）** — `check-prod-anthropic-stub-mirror.py` 是 guard 不是 applier；edge tier 改完后它会在下一次巡检里检出 prod 镜像漂移。**两类违规都要修**：
+   - **R1（stub concurrency）**：edge OAuth 账号 concurrency 升档后，prod 对应 self-edge stub 的 `account.concurrency` 必须同步抬升。op 用 [`anthropic-stub-mirror-concurrency-apply-template.sql`](../../../deploy/aws/stage0/anthropic-stub-mirror-concurrency-apply-template.sql) 逐 stub apply（取值 `results[i].expected_concurrency`）。
+   - **R3（stub-only group rpm_limit）**：edge `default_group.rpm_limit` 升档后，prod stub-only group（如 `cc-edges`）的 `rpm_limit` 必须 absorb-zero SUM 到同样值。op 用 [`anthropic-stub-mirror-rpm-apply-template.sql`](../../../deploy/aws/stage0/anthropic-stub-mirror-rpm-apply-template.sql) apply（取值 `group_results[i].expected_rpm_limit`）。
+   注意：strict-redline aggregate 模板不适合 stub-only group——它会算出 `Σ = 0` 把组改成 unlimited。
 5. **切默认** — 全部 strict-mode 巡检通过后，另起一个小 PR 把 `--strict-redline` 翻成默认（或删除旧口径），完成切换。
 
 ### 3.3 模板 SQL 是 apply 源头
@@ -335,6 +343,7 @@ python3 ops/anthropic/check-account-group-rpm-alignment.py --target <edge_id|pro
 
 - 账号 tier/stability/TLS baseline 更新：复制 `deploy/aws/stage0/anthropic-oauth-stability-tiered-apply-template.sql`
 - 分组聚合 rpm 更新（OAuth-bearing group）：复制 `deploy/aws/stage0/anthropic-oauth-group-aggregate-apply-template.sql`
+- R1 镜像 concurrency 更新（prod 单 stub）：复制 `deploy/aws/stage0/anthropic-stub-mirror-concurrency-apply-template.sql`
 - R3 镜像 rpm 更新（prod stub-only group）：复制 `deploy/aws/stage0/anthropic-stub-mirror-rpm-apply-template.sql`
 
 推荐落点：`$CLAUDE_JOB_DIR/<edge>-<target>-apply.sql`，不要改原模板来执行单次任务。复制后必须生成**自包含 SQL**：把模板正文复制进该文件，并在文件顶部写入本次 `\set account_name`、`\set stability_tier`、`\set group_name` 等变量；远端 edge 不保证存在仓库 checkout，所以禁止让 SSM/psql 执行依赖远端文件路径的 `\i deploy/aws/stage0/...`。复制后必须保留模板里的 profile、tier、聚合口径和事务结构；只允许改执行变量或经 `plan-apply` 确认过的字面值。若需求确实要求模板未覆盖的新字段，先更新模板和本 skill，再执行 apply，避免 checker、模板和人工 SQL 分叉。
@@ -483,6 +492,7 @@ summary.error_count=<n>
 - `deploy/aws/stage0/anthropic-oauth-stability-baselines-tiered.json`
 - `deploy/aws/stage0/anthropic-oauth-stability-tiered-apply-template.sql`
 - `deploy/aws/stage0/anthropic-oauth-group-aggregate-apply-template.sql`
+- `deploy/aws/stage0/anthropic-stub-mirror-concurrency-apply-template.sql`
 - `deploy/aws/stage0/anthropic-stub-mirror-rpm-apply-template.sql`
 - `backend/internal/handler/admin/account_handler.go`
 - `backend/internal/service/admin_service.go`

--- a/deploy/aws/stage0/anthropic-stub-mirror-concurrency-apply-template.sql
+++ b/deploy/aws/stage0/anthropic-stub-mirror-concurrency-apply-template.sql
@@ -66,7 +66,11 @@ BEGIN
       HINT = 'OAuth accounts are governed by tier baseline (anthropic-oauth-stability-tiered-apply-template.sql).';
   END IF;
 
-  IF acc_base_url IS NULL OR acc_base_url !~ '^https?://api-[a-z0-9]+\.tokenkey\.dev/?$' THEN
+  -- Self-edge regex MUST stay in lockstep with SELF_EDGE_BASE_URL_RE in
+  -- ops/anthropic/check-prod-stub-mirror.py — both apply to the same
+  -- prod stub base_url surface.  Character class includes `-` so edge
+  -- ids like `us-west-1` are accepted by both layers.
+  IF acc_base_url IS NULL OR acc_base_url !~ '^https?://api-[a-z0-9-]+\.tokenkey\.dev/?$' THEN
     RAISE EXCEPTION USING
       MESSAGE = 'account "' || ta || '" base_url=' || COALESCE(acc_base_url, '<null>') || '; not a self-edge stub',
       HINT = 'R1 mirror requires base_url matching api-<edge>.tokenkey.dev. External stubs (e.g. agent.tokensea.ai) have no upstream OAuth pool and must be set independently.';

--- a/deploy/aws/stage0/anthropic-stub-mirror-concurrency-apply-template.sql
+++ b/deploy/aws/stage0/anthropic-stub-mirror-concurrency-apply-template.sql
@@ -1,0 +1,113 @@
+-- Anthropic stub concurrency mirror apply template (R1 mirror path)
+-- Purpose: write account.concurrency on a prod-side anthropic apikey
+-- forward stub to mirror the upstream edge default group's OAuth account
+-- concurrency absorb-zero SUM, per the R1 rule in
+-- SKILL §"prod 控制面：anthropic stub 主路径镜像规则".
+--
+-- Why this template exists: the R3 mirror template
+-- (anthropic-stub-mirror-rpm-apply-template.sql) covers group.rpm_limit
+-- only.  R1 mirror writes to a different surface — accounts.concurrency
+-- on individual stubs — so it needs its own template.  Splitting keeps
+-- each template single-purpose and pre-flight scoped to the surface it
+-- writes.
+--
+-- Pre-flight:
+--   1. Run ops/anthropic/check-prod-stub-mirror.py --json against this
+--      target and read `results[i].expected_concurrency` for the target
+--      stub; pass that integer as :new_concurrency below.
+--   2. The DO block aborts if the account is not an anthropic apikey
+--      stub with a self-edge base_url (matching
+--      `https?://api-<edge>.tokenkey.dev/?`).  OAuth accounts are
+--      governed by the tier baseline template; external stubs (e.g.
+--      agent.tokensea.ai) have no upstream OAuth pool to mirror and
+--      must be set independently by the operator.
+--
+-- Usage (psql):
+--   \set account_name 'cc-us1-oauth'
+--   \set new_concurrency 5
+--   \i deploy/aws/stage0/anthropic-stub-mirror-concurrency-apply-template.sql
+
+BEGIN;
+
+-- Pre-flight: refuse to run on accounts that aren't anthropic apikey
+-- self-edge stubs.  Bridge :'account_name' into the DO block via a
+-- session GUC so it is not expanded inside the dollar-quoted body.
+SELECT set_config('app.target_account_name', :'account_name', true);
+DO $$
+DECLARE
+  ta TEXT := current_setting('app.target_account_name');
+  acc_platform TEXT;
+  acc_type TEXT;
+  acc_base_url TEXT;
+BEGIN
+  -- Account must exist; otherwise the WITH...UPDATE below silently
+  -- no-ops (a typo in :'account_name' would leave the operator thinking
+  -- the mirror was written when it wasn't).
+  IF NOT EXISTS (
+    SELECT 1 FROM accounts WHERE name = ta AND deleted_at IS NULL
+  ) THEN
+    RAISE EXCEPTION 'account % not found (or soft-deleted)', quote_literal(ta);
+  END IF;
+
+  SELECT a.platform, a.type, NULLIF(a.credentials->>'base_url', '')
+    INTO acc_platform, acc_type, acc_base_url
+  FROM accounts a
+  WHERE a.name = ta AND a.deleted_at IS NULL;
+
+  IF acc_platform IS DISTINCT FROM 'anthropic' THEN
+    RAISE EXCEPTION USING
+      MESSAGE = 'account "' || ta || '" platform=' || COALESCE(acc_platform, '<null>') || '; R1 mirror applies only to anthropic stubs',
+      HINT = 'This template targets prod-side anthropic apikey forward stubs only.';
+  END IF;
+
+  IF acc_type IS DISTINCT FROM 'apikey' THEN
+    RAISE EXCEPTION USING
+      MESSAGE = 'account "' || ta || '" type=' || COALESCE(acc_type, '<null>') || '; R1 mirror applies only to apikey stubs',
+      HINT = 'OAuth accounts are governed by tier baseline (anthropic-oauth-stability-tiered-apply-template.sql).';
+  END IF;
+
+  IF acc_base_url IS NULL OR acc_base_url !~ '^https?://api-[a-z0-9]+\.tokenkey\.dev/?$' THEN
+    RAISE EXCEPTION USING
+      MESSAGE = 'account "' || ta || '" base_url=' || COALESCE(acc_base_url, '<null>') || '; not a self-edge stub',
+      HINT = 'R1 mirror requires base_url matching api-<edge>.tokenkey.dev. External stubs (e.g. agent.tokensea.ai) have no upstream OAuth pool and must be set independently.';
+  END IF;
+END $$;
+
+WITH target_account AS (
+  SELECT
+    a.id,
+    a.name,
+    a.platform,
+    a.type,
+    a.concurrency AS concurrency_before,
+    NULLIF(a.credentials->>'base_url', '') AS base_url
+  FROM accounts a
+  WHERE a.name = :'account_name'
+    AND a.deleted_at IS NULL
+  ORDER BY a.id
+  LIMIT 1
+),
+updated_account AS (
+  UPDATE accounts a
+  SET concurrency = :new_concurrency,
+      updated_at = NOW()
+  FROM target_account ta
+  WHERE a.id = ta.id
+  RETURNING a.id, a.name, ta.concurrency_before, a.concurrency AS concurrency_after, ta.base_url
+)
+SELECT jsonb_pretty(jsonb_build_object(
+  'account', (SELECT jsonb_build_object(
+    'id', id,
+    'name', name,
+    'platform', platform,
+    'type', type,
+    'base_url', base_url
+  ) FROM target_account),
+  'concurrency_update', (SELECT jsonb_build_object(
+    'before', concurrency_before,
+    'after', concurrency_after,
+    'expected_per_r1_mirror', :new_concurrency
+  ) FROM updated_account)
+));
+
+COMMIT;


### PR DESCRIPTION
## Summary

Adds `deploy/aws/stage0/anthropic-stub-mirror-concurrency-apply-template.sql` to cover the **R1 mirror surface** (prod stub `account.concurrency` ← edge default group OAuth concurrency absorb-zero SUM, per [skill §"prod stub 主路径镜像规则"](../blob/main/.cursor/skills/tokenkey-anthropic-oauth-config/SKILL.md)).

Until now only the **R3 surface** (stub-only group `rpm_limit`) had an apply template. R1 violations detected by `ops/anthropic/check-prod-stub-mirror.py` had **no template-compliant fix path** — operators were forced to either skip them or hand-write SQL, the latter violating skill §3.3 ("禁止临时手写 SQL").

## Why now

Came up while upgrading edge-us1 acct 1 from l3 → l4 (PR #314 baseline rebalance + in-window apply): the account concurrency change 3 → 5 triggered an R1 mirror violation on prod stub `cc-us1-oauth` (concurrency stuck at 3) that the existing template set couldn't fix. Halted the apply and chose to add the template properly rather than ship ad-hoc SQL.

## Template scope (pre-flight DO block enforces)

- `account` must exist and not be soft-deleted
- `platform = 'anthropic'` — refuses non-anthropic accounts
- `type = 'apikey'` — refuses OAuth accounts (those are governed by `anthropic-oauth-stability-tiered-apply-template.sql`)
- `credentials.base_url` matches `^https?://api-<edge>\.tokenkey\.dev/?$` — refuses external stubs like `agent.tokensea.ai` (no upstream OAuth pool to mirror)

Each refusal `RAISE EXCEPTION` carries a `HINT` pointing at the correct template.

## Skill updates

- §"R1 / R3 mirror 修复路径" (renamed from "R3 mirror 修复路径"): documents both R1 and R3 apply paths side-by-side, recommends "R1 stubs first, R3 group rpm second" sequencing.
- §3.2.1 step 4 (rollout 顺序): splits prod mirror sync into R1 + R3 sub-steps so an operator following the rollout never reaches my gap again.
- §3.3 template list: adds R1 concurrency template.
- 扩展阅读: adds new file path.

## Usage (psql)

```sql
\set account_name 'cc-us1-oauth'
\set new_concurrency 5
\i deploy/aws/stage0/anthropic-stub-mirror-concurrency-apply-template.sql
```

(Per skill §3.3, runtime apply still generates a self-contained SQL — no remote `\i`.)

## Test plan

- [x] `scripts/preflight.sh` PASS
- [x] Template structure mirrors `anthropic-stub-mirror-rpm-apply-template.sql` (BEGIN / pre-flight DO / WITH / UPDATE RETURNING / jsonb_pretty result / COMMIT)
- [x] DO block exception messages include HINT pointing at correct alternative template
- [ ] Post-merge: apply against prod stub `cc-us1-oauth` to write concurrency 3 → 5 (the original blocker that prompted this PR), then re-run `check-prod-stub-mirror.py` to confirm zero R1 violations

## Drift / upstream notes (CLAUDE.md PR Checklist)

- TK is currently behind upstream/main (3450+ commits as of branch-off). This PR ships out of order because:
  - Pure `deploy/aws/stage0/` SQL template + `.cursor/skills/` doc; zero Go / frontend / upstream-shaped paths touched.
  - Zero merge-conflict risk with upstream (TK-only file, doesn't exist upstream).
  - Operationally time-sensitive — blocks completing the edge-us1 → l4 + prod mirror window initiated against the user's confirm token.
- No `git log/diff upstream/main..HEAD` numbers needed — this is not an upstream-merge PR.
- No upstream-override marker needed — paths not in upstream-shaped list; commit carries `no-web-impact` for that gate.
- Reviewer: **Squash and merge** per CLAUDE.md §5.y.