### PR TITLE
fix(stage0): repair smoke frontend-asset check path missed by PR #307 sed (no-web-impact)

### DIFF
--- a/.cursor/skills/tokenkey-stage0-release-rollout/SKILL.md
+++ b/.cursor/skills/tokenkey-stage0-release-rollout/SKILL.md
@@ -235,7 +235,7 @@ bash ops/stage0/post_deploy_smoke.sh
 通过标准：
 
 - public settings：HTTP 200，JSON `code=0`。
-- frontend release asset shape：`check-frontend-release-assets.py` 通过。
+- frontend release asset shape：`scripts/checks/frontend-release-assets.py` 通过。
 - `/v1/models`：HTTP 200，`object=list`，`data` 非空。
 - `/v1/chat/completions`：HTTP 200，shape 正确，usage 存在。
 - `/v1/messages`：HTTP 200，shape 正确，usage 存在。

--- a/ops/stage0/post_deploy_smoke.sh
+++ b/ops/stage0/post_deploy_smoke.sh
@@ -139,11 +139,19 @@ fi
 
 # --- 2) Frontend release asset shape ---
 if [[ "${POST_DEPLOY_SMOKE_SKIP_FRONTEND:-}" != "1" ]]; then
-  script_dir="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
-  if [[ -x "${script_dir}/check-frontend-release-assets.py" || -f "${script_dir}/check-frontend-release-assets.py" ]]; then
-    python3 "${script_dir}/check-frontend-release-assets.py" --url "${BASE}"
+  # PR #307 relocated check-frontend-release-assets.py from ops/stage0/ to
+  # scripts/checks/frontend-release-assets.py. The sed pass that updated
+  # Dockerfile / frontend/package.json / .goreleaser*.yaml missed this
+  # ${script_dir}-relative reference because script-ref-existence.py only
+  # scans literal scripts/|ops/|tools/ prefixes, not shell-variable
+  # indirection. Anchor to repo root explicitly so the path is one
+  # readable string and the next refactor's grep sees it.
+  repo_root="$(cd "$(dirname "${BASH_SOURCE[0]}")/../.." && pwd)"
+  check_script="${repo_root}/scripts/checks/frontend-release-assets.py"
+  if [[ -f "${check_script}" ]]; then
+    python3 "${check_script}" --url "${BASE}"
   else
-    echo "tk_post_deploy_smoke: missing check-frontend-release-assets.py" >&2
+    echo "tk_post_deploy_smoke: missing ${check_script}" >&2
     exit 1
   fi
 


### PR DESCRIPTION
## 背景

`/tokenkey-stage0-release-rollout target=all` 准备发 v1.7.38 之前的 Step 0 baseline smoke 立刻挂在 frontend asset 检查那一步：

```
tk_post_deploy_smoke: missing check-frontend-release-assets.py
```

根因：PR #307 把 `scripts/check-frontend-release-assets.py` 重命名到 `scripts/checks/frontend-release-assets.py`，sed pass 跟进了 Dockerfile / frontend/package.json / .goreleaser*.yaml 三处，但漏了 `ops/stage0/post_deploy_smoke.sh:142-148` 这一处 —— 因为这里用的是 shell-variable indirection（`${script_dir}/check-frontend-release-assets.py`），不带 `scripts/` / `ops/` / `tools/` 前缀。

`scripts/checks/script-ref-existence.py`（PR #308 引入）也没抓到这个 blind spot —— 它的正则只扫 literal `scripts/...` / `ops/...` / `tools/...` 字面引用，不识别 `${VAR}/...` 形态。

## 如果不修

prod / Edge deploy 时 `deploy-stage0.yml:140` 调用本 smoke 脚本，会立刻在 line 146 fail，整个 deploy run 标红。Deploy 本身（image pull + restart）会成功，但 CI 验收门 fail。

## 修复

`ops/stage0/post_deploy_smoke.sh:142-148`：把 `${script_dir}/check-frontend-release-assets.py` 换成 repo-root anchor 的明确路径 `${repo_root}/scripts/checks/frontend-release-assets.py`。一行可读字符串，下次重命名 sed pass 也能扫到。

```diff
   if [[ "${POST_DEPLOY_SMOKE_SKIP_FRONTEND:-}" != "1" ]]; then
-    script_dir="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
-    if [[ -x "${script_dir}/check-frontend-release-assets.py" || -f "${script_dir}/check-frontend-release-assets.py" ]]; then
-      python3 "${script_dir}/check-frontend-release-assets.py" --url "${BASE}"
+    repo_root="$(cd "$(dirname "${BASH_SOURCE[0]}")/../.." && pwd)"
+    check_script="${repo_root}/scripts/checks/frontend-release-assets.py"
+    if [[ -f "${check_script}" ]]; then
+      python3 "${check_script}" --url "${BASE}"
     else
-      echo "tk_post_deploy_smoke: missing check-frontend-release-assets.py" >&2
+      echo "tk_post_deploy_smoke: missing ${check_script}" >&2
       exit 1
     fi
```

同时加 inline 注释记录根因（`${script_dir}` indirection 让 script-ref-existence 漏掉了），下次重命名时直接能看到。

## 验证

本地跑：
```bash
TOKENKEY_BASE_URL=https://api.tokenkey.dev bash ops/stage0/post_deploy_smoke.sh
```
- 修前：line 146 立刻挂，exit 1
- 修后：跑完整条 smoke chain（public settings → frontend asset shape → /v1/models → /v1/chat/completions → /v1/messages → gemini 探针 → openai oauth 探针）。某些 5xx 是 runtime 资源问题（pool dry），脚本里 soft_degrade_or_exit 会软降级为 warning（与 deploy 决策无关）。

## 不在本 PR 范围（建议独立 PR）

`scripts/checks/script-ref-existence.py` 应扩展抓 `${VAR}/<basename>.<ext>` shell-variable 形态，避免同款 indirection blind spot 再发生。本 PR 只修燃眉之急。

upstream-touch-trivial: ops script path repair only; no upstream-shaped code, behavior, or web surface touched.
