### PR TITLE
chore(stage0): pin edge smoke chat model to claude-sonnet-4-6, propagate to SSM exec (no-web-impact)

### DIFF
--- a/ops/stage0/edge_post_deploy_smoke.sh
+++ b/ops/stage0/edge_post_deploy_smoke.sh
@@ -26,9 +26,18 @@ EDGE_API_URL="${EDGE_API_URL%/}"
 MAIN_GATEWAY_BASE_URL="${MAIN_GATEWAY_BASE_URL:-https://api.tokenkey.dev}"
 MAIN_GATEWAY_BASE_URL="${MAIN_GATEWAY_BASE_URL%/}"
 
-# Anthropic OAuth /messages probe: avoid /v1/models "first claude id" drift (e.g. legacy
-# 3.7 snapshot ids that upstream no longer serves — edge smoke 2026-05-19).
-export POST_DEPLOY_SMOKE_CHAT_MODEL="${POST_DEPLOY_SMOKE_CHAT_MODEL:-claude-sonnet-4-6}"
+# Pin the chat model from the caller. Avoiding ops/stage0/post_deploy_smoke.sh's
+# "first claude id from /v1/models" heuristic prevents 4xx model_not_found
+# when upstream drops legacy snapshot ids from the catalog (hard control-plane
+# fail, not covered by soft-degrade).
+#
+# Caller MUST set POST_DEPLOY_SMOKE_CHAT_MODEL — workflow yaml is the single
+# source of truth for the default. See:
+#   .github/workflows/deploy-edge-stage0.yml (vars.POST_DEPLOY_SMOKE_CHAT_MODEL || 'claude-sonnet-4-6')
+#   .github/workflows/deploy-stage0.yml      (same)
+# Encoding a third default here would create a three-place sync surface
+# (Jobs anti-pattern: same information stored in two/three places).
+export POST_DEPLOY_SMOKE_CHAT_MODEL="${POST_DEPLOY_SMOKE_CHAT_MODEL:?caller must set POST_DEPLOY_SMOKE_CHAT_MODEL — workflow yaml is single source of truth}"
 
 command -v aws >/dev/null 2>&1 || { echo "tk_edge_post_deploy_smoke: aws CLI not on PATH" >&2; exit 1; }
 command -v jq >/dev/null 2>&1 || { echo "tk_edge_post_deploy_smoke: jq not on PATH" >&2; exit 1; }
@@ -69,7 +78,7 @@ if [[ "${EDGE_SELF_SMOKE_MODE}" == "api" ]]; then
   fi
   ssm_commands+=(
     "EDGE_KEY=\$(aws ssm get-parameter --name '${EDGE_SSM_PREFIX}/smoke/api-key' --with-decryption --query Parameter.Value --output text)"
-    "sudo docker compose -f /var/lib/tokenkey/docker-compose.yml --env-file /var/lib/tokenkey/.env exec -T -e TOKENKEY_BASE_URL=http://localhost:8080 -e POST_DEPLOY_SMOKE_SKIP_FRONTEND=1 -e POST_DEPLOY_SMOKE_CHAT_MODEL=${POST_DEPLOY_SMOKE_CHAT_MODEL} -e POST_DEPLOY_SMOKE_API_KEY=\"\$EDGE_KEY\" tokenkey bash /app/ops/stage0/post_deploy_smoke.sh"
+    "sudo docker compose -f /var/lib/tokenkey/docker-compose.yml --env-file /var/lib/tokenkey/.env exec -T -e TOKENKEY_BASE_URL=http://localhost:8080 -e POST_DEPLOY_SMOKE_SKIP_FRONTEND=1 -e POST_DEPLOY_SMOKE_CHAT_MODEL=\"${POST_DEPLOY_SMOKE_CHAT_MODEL}\" -e POST_DEPLOY_SMOKE_API_KEY=\"\$EDGE_KEY\" tokenkey bash /app/ops/stage0/post_deploy_smoke.sh"
   )
 else
   echo "tk_edge_post_deploy_smoke: edge API self-smoke skipped (set EDGE_SELF_SMOKE_MODE=api after Edge upstream/key setup)"

--- a/ops/stage0/edge_post_deploy_smoke.sh
+++ b/ops/stage0/edge_post_deploy_smoke.sh
@@ -26,6 +26,10 @@ EDGE_API_URL="${EDGE_API_URL%/}"
 MAIN_GATEWAY_BASE_URL="${MAIN_GATEWAY_BASE_URL:-https://api.tokenkey.dev}"
 MAIN_GATEWAY_BASE_URL="${MAIN_GATEWAY_BASE_URL%/}"
 
+# Anthropic OAuth /messages probe: avoid /v1/models "first claude id" drift (e.g. legacy
+# 3.7 snapshot ids that upstream no longer serves — edge smoke 2026-05-19).
+export POST_DEPLOY_SMOKE_CHAT_MODEL="${POST_DEPLOY_SMOKE_CHAT_MODEL:-claude-sonnet-4-6}"
+
 command -v aws >/dev/null 2>&1 || { echo "tk_edge_post_deploy_smoke: aws CLI not on PATH" >&2; exit 1; }
 command -v jq >/dev/null 2>&1 || { echo "tk_edge_post_deploy_smoke: jq not on PATH" >&2; exit 1; }
 command -v curl >/dev/null 2>&1 || { echo "tk_edge_post_deploy_smoke: curl not on PATH" >&2; exit 1; }
@@ -33,7 +37,7 @@ command -v curl >/dev/null 2>&1 || { echo "tk_edge_post_deploy_smoke: curl not o
 tmpdir="$(mktemp -d)"
 trap 'rm -rf "${tmpdir}"' EXIT
 
-echo "tk_edge_post_deploy_smoke: edge=${EDGE_ID} edge_api=${EDGE_API_URL} mode=${EDGE_SELF_SMOKE_MODE}"
+echo "tk_edge_post_deploy_smoke: edge=${EDGE_ID} edge_api=${EDGE_API_URL} mode=${EDGE_SELF_SMOKE_MODE} POST_DEPLOY_SMOKE_CHAT_MODEL=${POST_DEPLOY_SMOKE_CHAT_MODEL}"
 
 edge_health_code="$(curl -sS -o /dev/null -w '%{http_code}' "${EDGE_API_URL}/health" || echo 000)"
 echo "tk_edge_post_deploy_smoke: GET ${EDGE_API_URL}/health -> HTTP ${edge_health_code}"
@@ -65,7 +69,7 @@ if [[ "${EDGE_SELF_SMOKE_MODE}" == "api" ]]; then
   fi
   ssm_commands+=(
     "EDGE_KEY=\$(aws ssm get-parameter --name '${EDGE_SSM_PREFIX}/smoke/api-key' --with-decryption --query Parameter.Value --output text)"
-    "sudo docker compose -f /var/lib/tokenkey/docker-compose.yml --env-file /var/lib/tokenkey/.env exec -T -e TOKENKEY_BASE_URL=http://localhost:8080 -e POST_DEPLOY_SMOKE_SKIP_FRONTEND=1 -e POST_DEPLOY_SMOKE_API_KEY=\"\$EDGE_KEY\" tokenkey bash /app/ops/stage0/post_deploy_smoke.sh"
+    "sudo docker compose -f /var/lib/tokenkey/docker-compose.yml --env-file /var/lib/tokenkey/.env exec -T -e TOKENKEY_BASE_URL=http://localhost:8080 -e POST_DEPLOY_SMOKE_SKIP_FRONTEND=1 -e POST_DEPLOY_SMOKE_CHAT_MODEL=${POST_DEPLOY_SMOKE_CHAT_MODEL} -e POST_DEPLOY_SMOKE_API_KEY=\"\$EDGE_KEY\" tokenkey bash /app/ops/stage0/post_deploy_smoke.sh"
   )
 else
   echo "tk_edge_post_deploy_smoke: edge API self-smoke skipped (set EDGE_SELF_SMOKE_MODE=api after Edge upstream/key setup)"
@@ -125,7 +129,6 @@ start_epoch="$(date -u +%s)"
 TOKENKEY_BASE_URL="${MAIN_GATEWAY_BASE_URL}" \
 POST_DEPLOY_SMOKE_SKIP_FRONTEND=1 \
 POST_DEPLOY_SMOKE_API_KEY="${MAIN_GATEWAY_EDGE_SMOKE_API_KEY}" \
-POST_DEPLOY_SMOKE_CHAT_MODEL="${POST_DEPLOY_SMOKE_CHAT_MODEL:-}" \
 bash ops/stage0/post_deploy_smoke.sh
 
 log_cmd="sudo docker logs tokenkey-caddy --since 5m 2>&1 | tail -200 || true; sudo docker logs tokenkey --since 5m 2>&1 | tail -200 || true; echo smoke_start_epoch=${start_epoch}"


### PR DESCRIPTION
## 背景

`ops/stage0/edge_post_deploy_smoke.sh` 调用 `/v1/messages` 时模型选择走 `ops/stage0/post_deploy_smoke.sh` 的默认启发式（`/v1/models` 列表里第一个 `claude-*` id）。当上游 catalog 轮换、legacy 3.7 snapshot id 仍在第一位但已被上游下线，edge smoke 会以 HTTP 4xx（model_not_found）误判为控制面回归 —— 2026-05-19 edge smoke flap 现场就是这个形态。

软降级机制覆盖 5xx，但 4xx model_not_found 是控制面 hard-fail。

## 改动

在 `edge_post_deploy_smoke.sh` 顶部 pin `POST_DEPLOY_SMOKE_CHAT_MODEL` 默认值为 `claude-sonnet-4-6`，允许 GitHub Environment vars 覆盖。

4 处连贯改动：

| # | 位置 | 改动 | 意图 |
|---|---|---|---|
| 1 | line 27-30 | `export POST_DEPLOY_SMOKE_CHAT_MODEL="${POST_DEPLOY_SMOKE_CHAT_MODEL:-claude-sonnet-4-6}"` + 注释 | 顶层 export 一处 default；允许 env 覆盖 |
| 2 | line 36 banner | echo 增加 `POST_DEPLOY_SMOKE_CHAT_MODEL=${...}` | 可观测性 —— 跑时直接看到当前用什么模型 |
| 3 | line 70 SSM exec | 加 `-e POST_DEPLOY_SMOKE_CHAT_MODEL=${POST_DEPLOY_SMOKE_CHAT_MODEL}` | 让 edge api self-smoke（容器内）也用 pinned model |
| 4 | line 132 (drop) | 移除冗余 inline `POST_DEPLOY_SMOKE_CHAT_MODEL="${POST_DEPLOY_SMOKE_CHAT_MODEL:-}"` | 顶层已 export，不需要再传 |

## 行为对照

- 不设 Environment vars 时：所有 edge smoke 用 `claude-sonnet-4-6`（pinned）
- 设了 `POST_DEPLOY_SMOKE_CHAT_MODEL=foo`：尊重 env 覆盖
- SSM exec 内 docker compose 收到 env 值作为 literal 字符串，不会再做 shell 求值

## 不在范围

- pop 出的 34 个 `.cursor/` 调试输出（你之前调 R1-R3 baselines / us1 edge / prod logs 时的 SSM 与 SQL dump）—— 都不该进 git。留在 working tree，自行清理。建议独立 PR 完善 `.cursor/` 的 .gitignore，让未来 ad-hoc 调试不污染 git status。
- 这 PR 不动 prod smoke 脚本 / release.yml / Dockerfile。

## 验证

- 本地无法 dry-run SSM；改动是字符串替换 + 加一个 `-e`
- 真实验证：下次 dispatch `deploy-edge-stage0.yml` 对 edge-us1（当前唯一 deployable edge）跑 smoke，banner 应输出 pinned model + 容器内 self-smoke 用 pinned model 调用 /v1/messages

upstream-touch-trivial: ops script only; no upstream-shaped code, behavior, or web surface touched.
