### PR TITLE
docs(skill): tokenkey-stage0-release-rollout switch post-release follow-up from workflow cron to in-session 3-tick (no-web-impact)

### DIFF
--- a/.cursor/skills/tokenkey-stage0-release-rollout/SKILL.md
+++ b/.cursor/skills/tokenkey-stage0-release-rollout/SKILL.md
@@ -331,20 +331,21 @@ git diff --name-only "${PREV_TAG}..${NEW_TAG}" -- 'frontend/src/' 'deploy/aws/st
 
 ### Step C：每次跟进的固定输出形状
 
-每次跟进结束输出一段 5–12 行的简洁汇报，结构固定：
+每次跟进结束输出一段 5–12 行的简洁汇报，结构固定（占位符在执行时按 Step A 提取结果填实）：
 
 ```
-[+Nmin post-release v1.7.38]
-control plane: api 200 ✓ | settings/public 200 ✓ | edge-us1 200 ✓
-errors (last 5m): <error cluster summary, or "none">
+[+Nmin post-release ${NEW_TAG}]
+control plane: api 200 ✓ | settings/public 200 ✓ | <each deployable edge> 200 ✓
+errors (last 5m): <cluster summary by reason/status_code/platform, or "none">
 traffic (last 5m): N total | chat=X messages=Y models=Z
-new-code hooks:
-  - SchedulerRateLimitReaper: <cycle count and intervals, or "no activity">
-  - applySigPreemptIfArmed: <fires, accounts affected, or "no fires">
-  - openai silent_refusal: <fires, or "no fires">
-  - stream keepalive ticker: <events, or "no activity">
+new-code hooks:                   # 按 Step A 提取的本次重点 hook 列项（按 release 不同）
+  - <hook 1 from Step A>: <grep result, or "no fires">
+  - <hook 2 from Step A>: <grep result, or "no activity">
+  - ...
 verdict: green | yellow | red — <one-line reason>
 ```
+
+**不要把上面模板照搬当输出**：`new-code hooks` 这一节的具体 hook 名由 Step A 的 diff 分析动态产出，不是固定 4 条。例如 v1.7.38 那次 Step A 会提取 `SchedulerRateLimitReaper` / `applySigPreemptIfArmed` / `openai silent_refusal` / stream keepalive ticker；下一次 release 改动不同则换成另一组（甚至完全没有，比如纯前端 / 纯 chore release，那一节直接写 `(no new backend hooks this release)`）。
 
 `verdict` 判定原则：
 
@@ -357,7 +358,7 @@ verdict: green | yellow | red — <one-line reason>
 第 3 次（+15min）跟进汇报完后**立即**给综合建议（不再等更长窗口），结构：
 
 ```
-=== Post-release follow-up summary (v1.7.38, 3 ticks over +15min) ===
+=== Post-release follow-up summary (${NEW_TAG}, 3 ticks over +15min) ===
 重点变更：<列出 Step A 的关键 hook / 配置项>
 control plane：3/3 ticks green | <or list any failure tick>
 错误聚类汇总：<去重的 cluster + 频次趋势>
@@ -375,7 +376,7 @@ control plane：3/3 ticks green | <or list any failure tick>
 - 第 1 次跟进在最后一个 smoke 通过后 +5min ± 30s 启动（用 `ScheduleWakeup`、`CronCreate */5 * * * *` 限 3 次、或 Bash background `sleep 300` 循环均可）
 - 第 2 / 3 次按 5 min 间隔自动续上
 - 中间任意一次 verdict = red → 立刻汇报，停止后续 tick，等人工决定 rollback
-- 3 次窗口结束后会话**不再自动延期**；如需 +1h / +6h / +24h 跟踪由人工显式重新触发本 skill（`operation=follow-up tag=X.Y.Z hours=1`），不要自己延期否则会跨越上下文窗口
+- 3 次窗口结束后会话**不再自动延期**；如需 +1h / +6h / +24h 跟踪由人工显式发起：在新会话里重新调用本 skill 的"完成后：会话里 +5/+10/+15min 后置跟进"段（手动指定起点 tick 偏移），不要在当前会话里自己延期否则会跨越上下文窗口
 
 ## 完成后：rollout 摘要
 

--- a/.cursor/skills/tokenkey-stage0-release-rollout/SKILL.md
+++ b/.cursor/skills/tokenkey-stage0-release-rollout/SKILL.md
@@ -190,10 +190,7 @@ gh workflow run deploy-edge-stage0.yml \
 6. 做 prod 完整 smoke（见下文）；若仅因 `POST_DEPLOY_SMOKE_CHAT_MODEL` 不在当前 key 的 `/v1/models` 可见列表而失败，先把对应 Environment 变量改到可见模型（如 `gpt-5.5`）再重跑，不要误判为发布回归。
 7. 对 canary Edge 再 dispatch `operation=smoke`，做 prod 升级后的 main-gateway-via-edge 验证；若缺 `MAIN_GATEWAY_EDGE_SMOKE_API_KEY`，只可标记“infra smoke 通过，主网关经 Edge 业务 smoke 未覆盖”。
 8. 其余 deployable Edge 顺序 upgrade + smoke；默认优先 `claude-sonnet-4-6`，若该 edge/key 不可见则切到该 key 的可见模型并重跑一次；失败即停。
-9. **自动轻量 Diagnostics（all 默认搭配）**：all rollout 完成后自动 dispatch `.github/workflows/post-release-light-diagnostics.yml`（默认 `target_selector=all`），该 workflow 会按固定节奏触发两次 `ops-daily-diagnostics.yml operation=diagnostics`：
-   - 第一次：+5min，`diagnostics_log_since=20m`（覆盖发版前后）。
-   - 第二次：+1h，`diagnostics_log_since=2h`（覆盖发版前后）。
-   - 两次都用 `diagnostics_include_error_clustering=false`，仅做 runtime/health 轻量巡检。
+9. **会话内 3 次后置跟进（all 默认搭配）**：完成最后一个 smoke 后**不要结束会话**，按"完成后：会话里 +5min / +10min / +15min 后置跟进"段执行三次 5 分钟间隔的轻量诊断 + 综合建议（详见下文）。**不要**通过 `gh workflow run post-release-light-diagnostics.yml` 调度 —— 那条路径已弃用，原因是 (a) 把判定推到下个 GH Actions cron tick 后，会话里失去解读上下文 (b) 固定 metric 集无法适配本次发版的重点变更。会话内跟进可以基于 `git diff v${PREV}..v${NEW}` 动态决定本次的观察重点（哪些 runtime hook / 配置项 / 路由 / DB 改动需要重点盯），命中真正的回归窗口。
 
 ## prod 真实测试
 
@@ -275,21 +272,110 @@ gh workflow run deploy-edge-stage0.yml \
 
 prod smoke 失败：停，优先 rollback prod；不要继续 Edge rollout。Edge canary 失败：停，不批准/推进 prod，除非用户明确 override。
 
-### 触发 all 后置轻量 Diagnostics（自动）
+## 完成后：会话里 +5min / +10min / +15min 后置跟进
 
-all rollout 验收完成后执行：
+发版 rollout 完成（prod smoke 通过 + main-via-edge smoke 通过）后**不要立即结束会话**，也**不要**用 `post-release-light-diagnostics.yml` 把跟进推到下个 GH Actions cron tick。在当前会话里做三次 5 分钟间隔的轻量跟进，最后基于 3 次观察给综合建议。
+
+### Step A：确定本次发版的「重点观察变量」
+
+跟进不跑固定 metric 集，而是基于本次 `git diff v${PREV}..v${NEW}` 决定要重点盯什么：
 
 ```bash
-gh workflow run post-release-light-diagnostics.yml \
-  -f target_selector=all
+PREV_TAG=$(git tag --sort=-version:refname | grep '^v[0-9]' | sed -n '2p')
+NEW_TAG=$(git tag --sort=-version:refname | grep '^v[0-9]' | head -1)
+
+# 列出 backend runtime 改动（excl test/migrations）
+git diff --name-only "${PREV_TAG}..${NEW_TAG}" -- \
+  'backend/internal/service/*.go' 'backend/internal/handler/**/*.go' \
+  'backend/internal/repository/*.go' 'backend/cmd/server/*.go' \
+  'backend/internal/config/*.go' 'backend/internal/middleware/*.go' \
+  | grep -v '_test\.go'
+
+# 列出 frontend src 改动 + 配置改动
+git diff --name-only "${PREV_TAG}..${NEW_TAG}" -- 'frontend/src/' 'deploy/aws/stage0/'
 ```
 
-该 workflow 默认：
+对每条 backend 改动，提取**有可观察 trace 的 hook 名**作为本次的"重点观察变量"，例如：
 
-- +5min dispatch 一次轻量 diagnostics（`diagnostics_log_since=20m`）
-- +1h dispatch 一次轻量 diagnostics（`diagnostics_log_since=2h`）
+| 改动类型 | 重点观察的 trace 关键词 |
+|---|---|
+| 新背景 goroutine（如 `*_reaper.go`） | grep `XxxReaper` 启动日志、cycle 频率、Cleanup 退出消息 |
+| 新 gateway 路径 hook（如 `*_tk_signature_preempt.go`） | grep `applyXxxIfArmed` / `armXxxOnError` 触发次数、影响的 account_id 分布 |
+| 新错误处理分支（如 `*_silent_refusal.go`） | grep `silent_refusal` / 新增 `ops_error_logs.reason` 取值 |
+| Stream 行为改动（keepalive ticker、超时等） | 看 SSE 连接持续时间分布、`Gateway.StreamKeepaliveInterval` 是否实际启用 |
+| `wire.go` / `wire_gen.go` DI 变化 | 看启动日志 provider 顺序无 panic、新依赖构造无 nil |
+| `config.go` 新字段 | 在 prod / Edge `.env` 与 `.env.example` 对齐确认；进容器后 `env \| grep -i <field>` 验证 |
+| 数据库 schema / migrations | 新表/列的写入路径在 5 分钟窗口是否 surfacing 异常 |
+| 前端 frontend dist hash 变化 | embedded dist freshness + 关键页面 200 |
 
-如需自定义延时/窗口，可覆写：`first_delay_minutes`、`first_window`、`second_delay_minutes`、`second_window`。
+把"重点观察变量"列在第一次跟进的开头，让 user 看到这一次跟进是按本次发版定制的，而非通用模板。
+
+### Step B：三次轻量跟进的节奏与内容
+
+调度：上线完成时立刻调度 +5min / +10min / +15min 三个时点的醒来，每次跟进做以下三件事：
+
+1. **控制面探活（本地，无密钥）**
+   - `curl -sS -o /dev/null -w '%{http_code}\n' 'https://api.tokenkey.dev/health'` 期望 200
+   - `curl -sS -o /dev/null -w '%{http_code}\n' 'https://api.tokenkey.dev/api/v1/settings/public'` 期望 200
+   - 每个 deployable Edge 也跑一次 `/health` 期望 200
+
+2. **错误 + 流量快照（最近 5 分钟窗口）**
+   - 用 `/tokenkey-online-log-troubleshooting` skill 查 `ops_error_logs` 最近 5 分钟错误聚类（按 `reason`、`status_code`、`platform` 三维聚）
+   - 主网关 docker logs 最近 5 分钟 `level=error` 或 status>=500 的 Top 3 路由
+   - 流量量级估算：最近 5 分钟总请求数、按 `/v1/chat/completions` / `/v1/messages` / `/v1/models` 分布
+   - 不要拉日志全文 — 只要聚类摘要，避免 context 爆
+
+3. **本次「重点观察变量」的 trace**
+   - 对 Step A 提取的每条 hook 关键词，grep 主网关日志 5 分钟窗口的触发计数 + 任何异常 stacktrace
+   - 没看到触发 = 正常（流量未触达该路径）；触发频次明显高于基线（如 reaper 每秒跑一次）= 异常；触发后立即 5xx 跟随 = 异常
+
+### Step C：每次跟进的固定输出形状
+
+每次跟进结束输出一段 5–12 行的简洁汇报，结构固定：
+
+```
+[+Nmin post-release v1.7.38]
+control plane: api 200 ✓ | settings/public 200 ✓ | edge-us1 200 ✓
+errors (last 5m): <error cluster summary, or "none">
+traffic (last 5m): N total | chat=X messages=Y models=Z
+new-code hooks:
+  - SchedulerRateLimitReaper: <cycle count and intervals, or "no activity">
+  - applySigPreemptIfArmed: <fires, accounts affected, or "no fires">
+  - openai silent_refusal: <fires, or "no fires">
+  - stream keepalive ticker: <events, or "no activity">
+verdict: green | yellow | red — <one-line reason>
+```
+
+`verdict` 判定原则：
+
+- **green**：control plane 全 200 + 错误聚类无新 cluster + 重点观察变量按预期触发或合理静默 + 流量量级与基线一致
+- **yellow**：control plane OK 但某条路径错误率上升 / 重点 hook 未按预期触发或频次异常 / 流量明显偏低或偏高 → 列出可疑 cluster + 建议第 4 次（人工触发）+24h 再观察一次
+- **red**：control plane 任一点 fail / 错误聚类含新 type 且 rate 高于基线 2× / 重点 hook 触发后立即 5xx / 流量塌方 → **立即汇报，不再续 +5min**，建议人工立即决定是否 rollback 到 `previous_tag`
+
+### Step D：第 3 次跟进后的综合建议
+
+第 3 次（+15min）跟进汇报完后**立即**给综合建议（不再等更长窗口），结构：
+
+```
+=== Post-release follow-up summary (v1.7.38, 3 ticks over +15min) ===
+重点变更：<列出 Step A 的关键 hook / 配置项>
+control plane：3/3 ticks green | <or list any failure tick>
+错误聚类汇总：<去重的 cluster + 频次趋势>
+流量趋势：<是否与基线一致>
+重点观察变量结论：<逐项 hook 是否按预期>
+综合 verdict: green / yellow / red
+建议：
+  - <green>: 发版稳定，无 follow-up。
+  - <yellow>: 列出 1-3 条需要在 24h / 1week 内再观察或修复的事项；建议是否手动触发 +1h / +6h 跟进。
+  - <red>: 列出可疑回归点，建议立即 `gh workflow run deploy-stage0.yml -f tag=${PREVIOUS_TAG}` rollback；其余 Edge 暂不批准 prod approval。
+```
+
+### 调度纪律
+
+- 第 1 次跟进在最后一个 smoke 通过后 +5min ± 30s 启动（用 `ScheduleWakeup`、`CronCreate */5 * * * *` 限 3 次、或 Bash background `sleep 300` 循环均可）
+- 第 2 / 3 次按 5 min 间隔自动续上
+- 中间任意一次 verdict = red → 立刻汇报，停止后续 tick，等人工决定 rollback
+- 3 次窗口结束后会话**不再自动延期**；如需 +1h / +6h / +24h 跟踪由人工显式重新触发本 skill（`operation=follow-up tag=X.Y.Z hours=1`），不要自己延期否则会跨越上下文窗口
 
 ## 完成后：rollout 摘要
 
@@ -344,7 +430,6 @@ git diff --diff-filter=D --name-only "${PREV_TAG}..${NEW_TAG}" -- backend/ || tr
 | prod smoke 报 `POST_DEPLOY_SMOKE_CHAT_MODEL not listed in GET /v1/models` | 不是代码回归，改 `prod` Environment 的 `POST_DEPLOY_SMOKE_CHAT_MODEL` 为该 key 可见模型（如 `gpt-5.5`）后重跑。 |
 | `gh` 请求持续报 `read ... 127.0.0.1:7890: connection reset by peer` | 先用 `env -u HTTPS_PROXY -u https_proxy -u HTTP_PROXY -u http_proxy gh <cmd>` 做无代理重试；恢复后再继续 watch。 |
 | 无代理后 dispatch 报 `HTTP 403 Must have admin rights to Repository` | `gh` 可能切到另一个账号；先 `env -u GH_TOKEN ... gh auth status`，必要时 `gh auth switch -u <repo-owner>` 后重试 dispatch。 |
-| `post-release-light-diagnostics` 在 `Dispatch first lightweight diagnostics` 失败且日志含 `failed to run git: ... not a git repository` | 视为 workflow 缺陷：先手动 dispatch 一次 `ops-daily-diagnostics.yml operation=diagnostics` 兜底，再记录 run id 并提修复 PR（定位该 workflow 对 `gh workflow run` 的调用上下文）。 |
 
 ## 扩展阅读（按需打开）
 
@@ -352,7 +437,7 @@ git diff --diff-filter=D --name-only "${PREV_TAG}..${NEW_TAG}" -- backend/ || tr
 - `.github/workflows/release.yml` — multi-arch image build 与 prod auto-dispatch。
 - `.github/workflows/deploy-stage0.yml` — prod deploy。
 - `.github/workflows/deploy-edge-stage0.yml` — Edge upgrade/smoke/rollback。
-- `.github/workflows/post-release-light-diagnostics.yml` — all rollout 后 +5min/+1h 自动 dispatch 轻量 diagnostics。
+- `.github/workflows/ops-daily-diagnostics.yml` — 用于会话内 +5/+10/+15min 跟进时拉错误聚类与流量快照（手动 dispatch 或被 `/tokenkey-online-log-troubleshooting` skill 间接调用）。本 skill 已不再调度 `post-release-light-diagnostics.yml`；该 workflow 保留作可选离线 fallback。
 - `ops/stage0/post_deploy_smoke.sh` — prod 完整 smoke。
 - `ops/stage0/edge_post_deploy_smoke.sh` — Edge smoke wrapper。
 - `deploy/aws/README.md` — Stage0、Edge、多区域升级 SOP。


### PR DESCRIPTION
## 背景

刚刚 v1.7.38 上线后，按之前 skill 的描述应该 `gh workflow run post-release-light-diagnostics.yml` 把 +5min / +1h 跟进推给 GH Actions cron，但实际操作时发现这条路径不太对：

1. 把判定推到下个 cron tick 后，**会话里失去解读上下文** —— 等 diagnostics 出 JSON 时，"本次发版改了什么、应该重点盯什么" 已经要从 PR 历史里翻
2. workflow 跑的是固定 metric 集 —— 它能抓 "control plane down / 5xx storm" 这种通用形态，但**抓不到 release-specific 的 hook 是不是按预期跑**（比如 v1.7.38 的 SchedulerRateLimitReaper cycle 频率、applySigPreemptIfArmed 触发情况）

## 改动

`.cursor/skills/tokenkey-stage0-release-rollout/SKILL.md` 把后置跟进改成**会话内 3 次 5 分钟间隔跟进**，并加上"基于本次 diff 动态决定观察重点"的设计。

### 新协议（4 步）

| Step | 内容 |
|---|---|
| **A** | 从 `git diff v${PREV}..v${NEW}` 提取"重点观察变量"：新背景 goroutine / gateway hook / 错误分支 / stream 行为 / DI 变化 / config 新字段 / schema / frontend dist 等。给出每类的 trace 关键词模板。 |
| **B** | 三件事/tick：(1) control plane 探活（api + 每个 deployable edge）(2) 5min 错误聚类 + 流量快照（聚类形态，禁止全文 dump）(3) 重点观察变量的 grep trace |
| **C** | 固定形态 5-12 行 verdict（green/yellow/red），让 reader 一眼看明白 |
| **D** | 第 3 次后立刻综合建议：green = 无 follow-up；yellow = 列 24h 内待办 + 是否手动续 +1h/+6h；red = 立即建议 rollback + 列可疑回归点 |

### 调度纪律

- 第 1 次跟进 = 最后一个 smoke 通过 +5min ± 30s
- red 立刻汇报、停止后续 tick、等人工
- 3 次窗口结束后**不再自动延期**（避免跨 session context 窗口）；longer follow-up 需人工显式重新触发 skill

## 不动的部分

- `.github/workflows/post-release-light-diagnostics.yml` 文件保留作可选离线 fallback；本 skill 已不再调度
- 故障速查表里 `post-release-light-diagnostics` 那一行已删除（skill 不再调用就没必要保留该 troubleshooting 入口）
- 扩展阅读改为指向 `ops-daily-diagnostics.yml`（会话内跟进用到的 primitive）

## 影响

- 下次 `target=all` 发版的最后阶段会按新协议跑 3 次会话内 follow-up
- 与本次 v1.7.38 上线时实际执行的形态对齐：v1.7.38 已经触发了 old workflow（run 26098489097 queued），但实际"看错误 + 看流量 + 看新代码 hook"的解读还是在会话里做的；skill 改了之后下次就不再需要那条 workflow run

upstream-touch-trivial: skill markdown only; no upstream-shaped code, behavior, or web surface touched.
