### PR TITLE
feat(pricing): per-key "your menu" view for authenticated users

### DIFF
--- a/backend/cmd/server/wire_gen.go
+++ b/backend/cmd/server/wire_gen.go
@@ -259,10 +259,12 @@ func initializeApplication(buildInfo handler.BuildInfo) (*Application, error) {
 		return nil, err
 	}
 	pricingCatalogHandler := handler.ProvideTKPricingCatalogHandler(pricingCatalogService, settingService, pricingAvailabilityService)
+	mePricingCatalogService := service.NewMePricingCatalogService(apiKeyService, channelService, pricingCatalogService)
+	mePricingCatalogHandler := handler.NewMePricingCatalogHandler(mePricingCatalogService)
 	qaHandler := handler.NewQAHandler(qaService)
 	idempotencyCoordinator := service.ProvideIdempotencyCoordinator(idempotencyRepository, configConfig)
 	idempotencyCleanupService := service.ProvideIdempotencyCleanupService(idempotencyRepository, configConfig)
-	handlers := handler.ProvideHandlers(authHandler, userHandler, apiKeyHandler, usageHandler, redeemHandler, subscriptionHandler, announcementHandler, channelMonitorUserHandler, adminHandlers, gatewayHandler, openAIGatewayHandler, handlerSettingHandler, totpHandler, handlerPaymentHandler, paymentWebhookHandler, availableChannelHandler, qaService, pricingCatalogHandler, qaHandler, idempotencyCoordinator, idempotencyCleanupService)
+	handlers := handler.ProvideHandlers(authHandler, userHandler, apiKeyHandler, usageHandler, redeemHandler, subscriptionHandler, announcementHandler, channelMonitorUserHandler, adminHandlers, gatewayHandler, openAIGatewayHandler, handlerSettingHandler, totpHandler, handlerPaymentHandler, paymentWebhookHandler, availableChannelHandler, qaService, pricingCatalogHandler, mePricingCatalogHandler, qaHandler, idempotencyCoordinator, idempotencyCleanupService)
 	jwtAuthMiddleware := middleware.NewJWTAuthMiddleware(authService, userService)
 	adminAuthMiddleware := middleware.NewAdminAuthMiddleware(authService, userService, settingService)
 	apiKeyAuthMiddleware := middleware.NewAPIKeyAuthMiddleware(apiKeyService, subscriptionService, configConfig)

--- a/backend/internal/handler/handler.go
+++ b/backend/internal/handler/handler.go
@@ -61,6 +61,8 @@ type Handlers struct {
 	QACapture        *qaobs.Service
 	// TK: public model + pricing catalog (US-028 / docs/approved/user-cold-start.md §2 v1).
 	PricingCatalog *PricingCatalogHandler
+	// TK: per-user "your menu" view backing GET /api/v1/me/pricing-catalog.
+	MePricingCatalog *MePricingCatalogHandler
 	// TK: user-facing QA export (issue #59 / docs/approved/ops-unified-contract.md §2).
 	QA *QAHandler
 }

--- a/backend/internal/handler/me_pricing_catalog_handler_tk.go
+++ b/backend/internal/handler/me_pricing_catalog_handler_tk.go
@@ -1,0 +1,135 @@
+package handler
+
+// TokenKey: GET /api/v1/me/pricing-catalog — per-user pricing menu.
+//
+// JWT-only (lives inside the `authenticated` group registered by
+// RegisterUserRoutes via registerTKUserRoutes). The publicly-gated
+// pricing_catalog_public admin flag does NOT apply here: this surface
+// is identity-scoped and exposes only data the user already has
+// implicit access to via their own keys/groups.
+//
+// docs/approved/user-cold-start.md §2 follow-up (per-key catalog view).
+
+import (
+	"context"
+	"errors"
+	"net/http"
+	"strconv"
+
+	"github.com/Wei-Shaw/sub2api/internal/pkg/response"
+	"github.com/Wei-Shaw/sub2api/internal/server/middleware"
+	"github.com/Wei-Shaw/sub2api/internal/service"
+
+	"github.com/gin-gonic/gin"
+)
+
+// MePricingCatalogSource is the read-side seam the handler depends on.
+// Production wiring uses *service.MePricingCatalogService; tests inject
+// a fake without standing up the full DI graph.
+type MePricingCatalogSource interface {
+	BuildForUser(
+		ctx context.Context,
+		userID int64,
+		opts service.MePricingCatalogOptions,
+	) (*service.MePricingCatalogResponse, error)
+}
+
+// MePricingCatalogHandler exposes the per-user catalog endpoint.
+type MePricingCatalogHandler struct {
+	svc MePricingCatalogSource
+}
+
+// NewMePricingCatalogHandler is the production constructor. A nil svc
+// degrades to 500 rather than panicking — matches the rest of the
+// pricing handlers' defensive shape.
+func NewMePricingCatalogHandler(svc *service.MePricingCatalogService) *MePricingCatalogHandler {
+	var s MePricingCatalogSource
+	if svc != nil {
+		s = svc
+	}
+	return &MePricingCatalogHandler{svc: s}
+}
+
+// Get serves GET /api/v1/me/pricing-catalog.
+//
+// Query params (both optional, mutually exclusive when referring to
+// different groups):
+//   - api_key_id — show menu for the group of this key
+//   - group_id   — show menu for this group ("explore other group" mode)
+//
+// When both are absent, default to the user's first active key's group;
+// when the user has no key, default to their first accessible group.
+func (h *MePricingCatalogHandler) Get(c *gin.Context) {
+	subject, ok := middleware.GetAuthSubjectFromContext(c)
+	if !ok {
+		response.Unauthorized(c, "User not authenticated")
+		return
+	}
+
+	opts, ok := parseMePricingOpts(c)
+	if !ok {
+		return
+	}
+
+	if h == nil || h.svc == nil {
+		response.InternalError(c, "pricing service unavailable")
+		return
+	}
+
+	resp, err := h.svc.BuildForUser(c.Request.Context(), subject.UserID, opts)
+	if err != nil {
+		writeMePricingError(c, err)
+		return
+	}
+	response.Success(c, resp)
+}
+
+// parseMePricingOpts reads and validates the query parameters. On bad
+// input it writes the HTTP error and returns ok=false.
+func parseMePricingOpts(c *gin.Context) (service.MePricingCatalogOptions, bool) {
+	var opts service.MePricingCatalogOptions
+
+	if raw := c.Query("api_key_id"); raw != "" {
+		v, err := strconv.ParseInt(raw, 10, 64)
+		if err != nil || v <= 0 {
+			response.BadRequest(c, "invalid api_key_id")
+			return opts, false
+		}
+		opts.APIKeyID = &v
+	}
+	if raw := c.Query("group_id"); raw != "" {
+		v, err := strconv.ParseInt(raw, 10, 64)
+		if err != nil || v <= 0 {
+			response.BadRequest(c, "invalid group_id")
+			return opts, false
+		}
+		opts.GroupID = &v
+	}
+	return opts, true
+}
+
+// writeMePricingError maps service-level errors to HTTP codes.
+func writeMePricingError(c *gin.Context, err error) {
+	switch {
+	case errors.Is(err, service.ErrMePricingNoAccessibleGroups):
+		// 200 + empty payload so the UI can render the "create a key"
+		// banner without the API client treating it like an error.
+		c.JSON(http.StatusOK, gin.H{
+			"code":    0,
+			"message": "no accessible groups",
+			"data": service.MePricingCatalogResponse{
+				Models:           []service.MePricingModel{},
+				MyKeys:           []service.MePricingKeyRef{},
+				AccessibleGroups: []service.MePricingGroupRef{},
+			},
+		})
+	case errors.Is(err, service.ErrMePricingAPIKeyNotFound):
+		response.NotFound(c, "api key not found")
+	case errors.Is(err, service.ErrMePricingGroupForbidden):
+		response.Forbidden(c, "group not accessible")
+	case errors.Is(err, service.ErrMePricingConflictingTargets):
+		response.BadRequest(c, "api_key_id and group_id refer to different groups")
+	default:
+		response.InternalError(c, err.Error())
+	}
+}

--- a/backend/internal/handler/me_pricing_catalog_handler_tk.go
+++ b/backend/internal/handler/me_pricing_catalog_handler_tk.go
@@ -13,7 +13,6 @@ package handler
 import (
 	"context"
 	"errors"
-	"net/http"
 	"strconv"
 
 	"github.com/Wei-Shaw/sub2api/internal/pkg/response"
@@ -114,14 +113,13 @@ func writeMePricingError(c *gin.Context, err error) {
 	case errors.Is(err, service.ErrMePricingNoAccessibleGroups):
 		// 200 + empty payload so the UI can render the "create a key"
 		// banner without the API client treating it like an error.
-		c.JSON(http.StatusOK, gin.H{
-			"code":    0,
-			"message": "no accessible groups",
-			"data": service.MePricingCatalogResponse{
-				Models:           []service.MePricingModel{},
-				MyKeys:           []service.MePricingKeyRef{},
-				AccessibleGroups: []service.MePricingGroupRef{},
-			},
+		// Reuses response.Success to keep the {code,message,data}
+		// envelope identical to every other success path — the
+		// frontend's emptyHint computed handles the empty arrays.
+		response.Success(c, service.MePricingCatalogResponse{
+			Models:           []service.MePricingModel{},
+			MyKeys:           []service.MePricingKeyRef{},
+			AccessibleGroups: []service.MePricingGroupRef{},
 		})
 	case errors.Is(err, service.ErrMePricingAPIKeyNotFound):
 		response.NotFound(c, "api key not found")

--- a/backend/internal/handler/me_pricing_catalog_handler_tk_test.go
+++ b/backend/internal/handler/me_pricing_catalog_handler_tk_test.go
@@ -142,13 +142,18 @@ func TestMePricingHandler_NoAccessibleGroupsRendersEmptyOK(t *testing.T) {
 	r.ServeHTTP(w, req)
 	require.Equal(t, http.StatusOK, w.Code)
 	var resp struct {
-		Data *service.MePricingCatalogResponse `json:"data"`
+		Code    int                               `json:"code"`
+		Message string                            `json:"message"`
+		Data    *service.MePricingCatalogResponse `json:"data"`
 	}
 	require.NoError(t, json.Unmarshal(w.Body.Bytes(), &resp))
 	require.NotNil(t, resp.Data)
 	assert.Empty(t, resp.Data.Models)
 	assert.Empty(t, resp.Data.AccessibleGroups)
 	assert.Empty(t, resp.Data.MyKeys)
+	// Envelope MUST match response.Success ({code:0, message:"success"}).
+	assert.Equal(t, 0, resp.Code)
+	assert.Equal(t, "success", resp.Message)
 }
 
 func TestMePricingHandler_NilServiceReturns500(t *testing.T) {

--- a/backend/internal/handler/me_pricing_catalog_handler_tk_test.go
+++ b/backend/internal/handler/me_pricing_catalog_handler_tk_test.go
@@ -1,0 +1,169 @@
+//go:build unit
+
+package handler
+
+import (
+	"context"
+	"encoding/json"
+	"errors"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+
+	"github.com/Wei-Shaw/sub2api/internal/server/middleware"
+	"github.com/Wei-Shaw/sub2api/internal/service"
+
+	"github.com/gin-gonic/gin"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+type fakeMePricingSvc struct {
+	resp    *service.MePricingCatalogResponse
+	err     error
+	seenOpt service.MePricingCatalogOptions
+	seenUID int64
+}
+
+func (f *fakeMePricingSvc) BuildForUser(
+	_ context.Context, userID int64, opts service.MePricingCatalogOptions,
+) (*service.MePricingCatalogResponse, error) {
+	f.seenOpt = opts
+	f.seenUID = userID
+	return f.resp, f.err
+}
+
+func newMePricingRouter(t *testing.T, src MePricingCatalogSource, withAuth bool) *gin.Engine {
+	t.Helper()
+	gin.SetMode(gin.TestMode)
+	h := &MePricingCatalogHandler{svc: src}
+	r := gin.New()
+	r.GET("/api/v1/me/pricing-catalog", func(c *gin.Context) {
+		if withAuth {
+			c.Set(string(middleware.ContextKeyUser), middleware.AuthSubject{UserID: 42})
+		}
+		h.Get(c)
+	})
+	return r
+}
+
+func TestMePricingHandler_RequiresAuth(t *testing.T) {
+	r := newMePricingRouter(t, &fakeMePricingSvc{}, false)
+	req := httptest.NewRequest(http.MethodGet, "/api/v1/me/pricing-catalog", nil)
+	w := httptest.NewRecorder()
+	r.ServeHTTP(w, req)
+	assert.Equal(t, http.StatusUnauthorized, w.Code)
+}
+
+func TestMePricingHandler_OK(t *testing.T) {
+	svc := &fakeMePricingSvc{resp: &service.MePricingCatalogResponse{
+		TargetGroup: service.MePricingTargetGroup{ID: 10, Name: "Pro", Platform: "newapi", RateMultiplier: 1.0, ListMultiplier: 1.0},
+		Models:      []service.MePricingModel{{ModelID: "gpt-4o", Capabilities: []string{"vision"}}},
+		MyKeys:      []service.MePricingKeyRef{},
+		AccessibleGroups: []service.MePricingGroupRef{
+			{ID: 10, Name: "Pro", Platform: "newapi", RateMultiplier: 1.0, IsCurrentForKey: true},
+		},
+	}}
+	r := newMePricingRouter(t, svc, true)
+	req := httptest.NewRequest(http.MethodGet, "/api/v1/me/pricing-catalog", nil)
+	w := httptest.NewRecorder()
+	r.ServeHTTP(w, req)
+	require.Equal(t, http.StatusOK, w.Code)
+	var resp struct {
+		Code int                                 `json:"code"`
+		Data *service.MePricingCatalogResponse `json:"data"`
+	}
+	require.NoError(t, json.Unmarshal(w.Body.Bytes(), &resp))
+	require.NotNil(t, resp.Data)
+	assert.Equal(t, int64(10), resp.Data.TargetGroup.ID)
+	require.Len(t, resp.Data.Models, 1)
+	assert.Equal(t, "gpt-4o", resp.Data.Models[0].ModelID)
+	assert.Equal(t, int64(42), svc.seenUID)
+}
+
+func TestMePricingHandler_ParsesAPIKeyAndGroupParams(t *testing.T) {
+	svc := &fakeMePricingSvc{resp: &service.MePricingCatalogResponse{}}
+	r := newMePricingRouter(t, svc, true)
+	req := httptest.NewRequest(http.MethodGet, "/api/v1/me/pricing-catalog?api_key_id=11&group_id=22", nil)
+	w := httptest.NewRecorder()
+	r.ServeHTTP(w, req)
+	require.Equal(t, http.StatusOK, w.Code)
+	require.NotNil(t, svc.seenOpt.APIKeyID)
+	require.NotNil(t, svc.seenOpt.GroupID)
+	assert.Equal(t, int64(11), *svc.seenOpt.APIKeyID)
+	assert.Equal(t, int64(22), *svc.seenOpt.GroupID)
+}
+
+func TestMePricingHandler_RejectsInvalidParams(t *testing.T) {
+	svc := &fakeMePricingSvc{resp: &service.MePricingCatalogResponse{}}
+	r := newMePricingRouter(t, svc, true)
+	cases := []string{
+		"/api/v1/me/pricing-catalog?api_key_id=abc",
+		"/api/v1/me/pricing-catalog?api_key_id=0",
+		"/api/v1/me/pricing-catalog?group_id=-1",
+	}
+	for _, url := range cases {
+		req := httptest.NewRequest(http.MethodGet, url, nil)
+		w := httptest.NewRecorder()
+		r.ServeHTTP(w, req)
+		assert.Equal(t, http.StatusBadRequest, w.Code, url)
+	}
+}
+
+func TestMePricingHandler_MapsServiceErrors(t *testing.T) {
+	cases := []struct {
+		name     string
+		err      error
+		wantCode int
+	}{
+		{"forbidden", service.ErrMePricingGroupForbidden, http.StatusForbidden},
+		{"not_found", service.ErrMePricingAPIKeyNotFound, http.StatusNotFound},
+		{"conflict", service.ErrMePricingConflictingTargets, http.StatusBadRequest},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			svc := &fakeMePricingSvc{err: tc.err}
+			r := newMePricingRouter(t, svc, true)
+			req := httptest.NewRequest(http.MethodGet, "/api/v1/me/pricing-catalog", nil)
+			w := httptest.NewRecorder()
+			r.ServeHTTP(w, req)
+			assert.Equal(t, tc.wantCode, w.Code)
+		})
+	}
+}
+
+func TestMePricingHandler_NoAccessibleGroupsRendersEmptyOK(t *testing.T) {
+	// Empty-keys / no-subscription user: 200 + empty arrays so the UI
+	// can show the "create a key" banner without an error toast.
+	svc := &fakeMePricingSvc{err: service.ErrMePricingNoAccessibleGroups}
+	r := newMePricingRouter(t, svc, true)
+	req := httptest.NewRequest(http.MethodGet, "/api/v1/me/pricing-catalog", nil)
+	w := httptest.NewRecorder()
+	r.ServeHTTP(w, req)
+	require.Equal(t, http.StatusOK, w.Code)
+	var resp struct {
+		Data *service.MePricingCatalogResponse `json:"data"`
+	}
+	require.NoError(t, json.Unmarshal(w.Body.Bytes(), &resp))
+	require.NotNil(t, resp.Data)
+	assert.Empty(t, resp.Data.Models)
+	assert.Empty(t, resp.Data.AccessibleGroups)
+	assert.Empty(t, resp.Data.MyKeys)
+}
+
+func TestMePricingHandler_NilServiceReturns500(t *testing.T) {
+	r := newMePricingRouter(t, nil, true)
+	req := httptest.NewRequest(http.MethodGet, "/api/v1/me/pricing-catalog", nil)
+	w := httptest.NewRecorder()
+	r.ServeHTTP(w, req)
+	assert.Equal(t, http.StatusInternalServerError, w.Code)
+}
+
+func TestMePricingHandler_GenericErrorIs500(t *testing.T) {
+	svc := &fakeMePricingSvc{err: errors.New("boom")}
+	r := newMePricingRouter(t, svc, true)
+	req := httptest.NewRequest(http.MethodGet, "/api/v1/me/pricing-catalog", nil)
+	w := httptest.NewRecorder()
+	r.ServeHTTP(w, req)
+	assert.Equal(t, http.StatusInternalServerError, w.Code)
+}

--- a/backend/internal/handler/wire.go
+++ b/backend/internal/handler/wire.go
@@ -178,6 +178,7 @@ func ProvideHandlers(
 	availableChannelHandler *AvailableChannelHandler,
 	qaService *qaobs.Service,
 	pricingCatalogHandler *PricingCatalogHandler,
+	mePricingCatalogHandler *MePricingCatalogHandler,
 	qaHandler *QAHandler,
 	_ *service.IdempotencyCoordinator,
 	_ *service.IdempotencyCleanupService,
@@ -201,6 +202,7 @@ func ProvideHandlers(
 		AvailableChannel: availableChannelHandler,
 		QACapture:        qaService,
 		PricingCatalog:   pricingCatalogHandler,
+		MePricingCatalog: mePricingCatalogHandler,
 		QA:               qaHandler,
 	}
 }
@@ -225,6 +227,8 @@ var ProviderSet = wire.NewSet(
 	NewAvailableChannelHandler,
 	// TK: pricing-availability observability — see docs/approved/pricing-availability-source-of-truth.md
 	ProvideTKPricingCatalogHandler,
+	// TK: per-user pricing catalog ("Your Menu") — see me_pricing_catalog_handler_tk.go
+	NewMePricingCatalogHandler,
 	ProvideTKGatewayHandlerModelList,
 	NewQAHandler,
 

--- a/backend/internal/server/routes/user_tk_routes.go
+++ b/backend/internal/server/routes/user_tk_routes.go
@@ -17,12 +17,18 @@ import (
 //
 // Endpoints (JWT-only):
 //   - POST /api/v1/user/onboarding-tour-completed — US-031 P1-A.
+//   - GET  /api/v1/me/pricing-catalog            — per-user "your menu"
+//     view; price + capability list scoped to the API key's group, plus
+//     pickers for switching between accessible groups. See
+//     handler/me_pricing_catalog_handler_tk.go.
 //
 // Endpoints requiring BOTH JWT and API-key auth live in
 // registerTKUserDualAuthRoutes below.
 func registerTKUserRoutes(authenticated, user *gin.RouterGroup, h *handler.Handlers) {
 	user.POST("/onboarding-tour-completed", h.User.MarkOnboardingTourSeen)
-	_ = authenticated // reserved for future JWT-only TK additions
+	if h.MePricingCatalog != nil {
+		authenticated.GET("/me/pricing-catalog", h.MePricingCatalog.Get)
+	}
 }
 
 // registerTKUserDualAuthRoutes wires TokenKey user-side endpoints that

--- a/backend/internal/service/me_pricing_catalog_tk.go
+++ b/backend/internal/service/me_pricing_catalog_tk.go
@@ -1,0 +1,528 @@
+package service
+
+// TokenKey: per-user pricing catalog ("Your Menu").
+//
+// Unlike service.PricingCatalogService.BuildPublicCatalog (a platform-wide
+// flat list of LiteLLM list prices), MePricingCatalogService builds a view
+// scoped to ONE group — the group of the user's selected API key, or any
+// other group the user can access ("explore other group" mode). Prices
+// are the prices the user is actually charged: channel-configured rates
+// multiplied by `group.rate_multiplier`, with `user_group_rate` override
+// layered on top.
+//
+// Why a separate service / why not extend ChannelService.ListAvailable:
+//   - This is a TK-only surface; ChannelService is upstream-shaped and we
+//     keep its signature stable per CLAUDE.md §5.
+//   - The cross-platform anti-leak rule and the per-group narrowing pattern
+//     are already proven in `available_channel_handler.go:151-156, 230-249`;
+//     we replicate that discipline here rather than coupling ChannelService
+//     to user-scope concerns.
+//   - LiteLLM metadata (context_window, capabilities) is joined post-hoc
+//     from PricingCatalogService — the channel layer doesn't carry those.
+//
+// Pricing precedence (matches gateway billing path):
+//   effective_rate = user_group_rate[group_id]  if present
+//                  else group.rate_multiplier
+//   A user_group_rate of 0 is the legitimate "free subscription" value
+//   and is NOT short-circuited — we emit zeros.
+//
+// Multi-channel dedupe rule: when the same model_id appears on multiple
+// active channels mapped to the target group, we keep the row with the
+// LOWEST combined input+output price. This matches the implicit promise
+// of "your menu" — the headline price equals the cheapest path the user
+// can actually be billed under.
+
+import (
+	"context"
+	"errors"
+	"sort"
+	"time"
+
+	"github.com/Wei-Shaw/sub2api/internal/pkg/pagination"
+)
+
+// MePricingKeyAccess is the slice of *APIKeyService that BuildForUser
+// needs. Defined as an interface so unit tests can inject fakes without
+// constructing a full APIKeyService.
+type MePricingKeyAccess interface {
+	GetAvailableGroups(ctx context.Context, userID int64) ([]Group, error)
+	GetUserGroupRates(ctx context.Context, userID int64) (map[int64]float64, error)
+	List(ctx context.Context, userID int64, params pagination.PaginationParams, filters APIKeyListFilters) ([]APIKey, *pagination.PaginationResult, error)
+}
+
+// MePricingChannelLister is the slice of *ChannelService that BuildForUser
+// needs.
+type MePricingChannelLister interface {
+	ListAvailable(ctx context.Context) ([]AvailableChannel, error)
+}
+
+// MePricingCatalogProvider is the slice of *PricingCatalogService that
+// BuildForUser needs.
+type MePricingCatalogProvider interface {
+	BuildPublicCatalog(ctx context.Context) *PublicCatalogResponse
+}
+
+// MePricingCatalogService builds the per-user pricing-catalog DTO.
+type MePricingCatalogService struct {
+	keys     MePricingKeyAccess
+	channels MePricingChannelLister
+	catalog  MePricingCatalogProvider
+}
+
+// NewMePricingCatalogService is the production constructor. Any nil
+// dependency degrades to a sensible empty result rather than panicking,
+// because the read path is exercised early by user-facing UI and may race
+// with startup wiring.
+func NewMePricingCatalogService(
+	keys *APIKeyService,
+	channels *ChannelService,
+	catalog *PricingCatalogService,
+) *MePricingCatalogService {
+	var (
+		k MePricingKeyAccess
+		c MePricingChannelLister
+		p MePricingCatalogProvider
+	)
+	if keys != nil {
+		k = keys
+	}
+	if channels != nil {
+		c = channels
+	}
+	if catalog != nil {
+		p = catalog
+	}
+	return &MePricingCatalogService{keys: k, channels: c, catalog: p}
+}
+
+// MePricingCatalogOptions selects which group the menu is built for.
+// APIKeyID and GroupID are mutually-exclusive selectors; when both are
+// nil the service defaults to the user's first active API-key's group,
+// falling back to the first accessible group.
+type MePricingCatalogOptions struct {
+	APIKeyID *int64
+	GroupID  *int64
+}
+
+// MePricingCatalogResponse is the top-level DTO returned to the user UI.
+type MePricingCatalogResponse struct {
+	TargetGroup      MePricingTargetGroup `json:"target_group"`
+	Models           []MePricingModel     `json:"models"`
+	MyKeys           []MePricingKeyRef    `json:"my_keys"`
+	AccessibleGroups []MePricingGroupRef  `json:"accessible_groups"`
+	UpdatedAt        time.Time            `json:"updated_at"`
+}
+
+// MePricingTargetGroup describes the group the menu is currently scoped to.
+//
+// RateMultiplier is the EFFECTIVE multiplier (group default × per-user
+// override). ListMultiplier is the group default — the UI uses the delta
+// to render the "包含个人覆写" hint.
+type MePricingTargetGroup struct {
+	ID               int64   `json:"id"`
+	Name             string  `json:"name"`
+	Platform         string  `json:"platform"`
+	RateMultiplier   float64 `json:"rate_multiplier"`
+	ListMultiplier   float64 `json:"list_multiplier"`
+	HasOverride      bool    `json:"has_override"`
+	IsExclusive      bool    `json:"is_exclusive"`
+	SubscriptionType string  `json:"subscription_type"`
+}
+
+// MePricingModel is one row in the user menu.
+type MePricingModel struct {
+	ModelID         string         `json:"model_id"`
+	Vendor          string         `json:"vendor,omitempty"`
+	BillingMode     string         `json:"billing_mode"`
+	YourPrice       MePricingPrice `json:"your_price"`
+	ContextWindow   int            `json:"context_window,omitempty"`
+	MaxOutputTokens int            `json:"max_output_tokens,omitempty"`
+	Capabilities    []string       `json:"capabilities"`
+}
+
+// MePricingPrice mirrors the "your price" view in USD per 1k tokens (or
+// per-request for non-token modes). Nil pointers signal "no price data";
+// 0.0 is a real value (free subscription).
+type MePricingPrice struct {
+	Currency         string   `json:"currency"`
+	InputPer1K       *float64 `json:"input_per_1k,omitempty"`
+	OutputPer1K      *float64 `json:"output_per_1k,omitempty"`
+	CacheReadPer1K   *float64 `json:"cache_read_per_1k,omitempty"`
+	CacheWritePer1K  *float64 `json:"cache_write_per_1k,omitempty"`
+	ImageOutputPer1K *float64 `json:"image_output_per_1k,omitempty"`
+	PerRequest       *float64 `json:"per_request,omitempty"`
+}
+
+// MePricingKeyRef populates the key-picker dropdown. Only active keys
+// whose group is in the user's accessible set are listed.
+type MePricingKeyRef struct {
+	ID        int64  `json:"id"`
+	Name      string `json:"name"`
+	GroupID   int64  `json:"group_id"`
+	GroupName string `json:"group_name"`
+}
+
+// MePricingGroupRef populates the "explore other group" dropdown. The
+// IsCurrentForKey flag lets the UI mark the row that matches the user's
+// selected key without an extra lookup.
+type MePricingGroupRef struct {
+	ID               int64   `json:"id"`
+	Name             string  `json:"name"`
+	Platform         string  `json:"platform"`
+	RateMultiplier   float64 `json:"rate_multiplier"`
+	IsCurrentForKey  bool    `json:"is_current_for_key"`
+	IsExclusive      bool    `json:"is_exclusive"`
+	SubscriptionType string  `json:"subscription_type"`
+}
+
+// Sentinel errors. Handler maps these to HTTP codes.
+var (
+	// ErrMePricingNoAccessibleGroups means the user has no group they can
+	// bind a key to (no subscription, not on any allowed-user list, all
+	// groups exclusive). Handler renders this as a 200 with empty models[]
+	// and a friendly UI banner, not an error.
+	ErrMePricingNoAccessibleGroups = errors.New("me_pricing: user has no accessible groups")
+	// ErrMePricingAPIKeyNotFound means the api_key_id query param does not
+	// refer to a key owned by this user (or the key has no group binding).
+	ErrMePricingAPIKeyNotFound = errors.New("me_pricing: api key not found or not bound to a group")
+	// ErrMePricingGroupForbidden means the group_id query param is outside
+	// the user's accessible set.
+	ErrMePricingGroupForbidden = errors.New("me_pricing: group not accessible")
+	// ErrMePricingConflictingTargets means api_key_id and group_id were
+	// both provided AND refer to different groups.
+	ErrMePricingConflictingTargets = errors.New("me_pricing: api_key_id and group_id refer to different groups")
+)
+
+// keyListPageSize is the soft upper bound on per-user keys we walk. Users
+// with > this many keys see only the first page in the picker; in
+// practice TokenKey users hold single-digit keys so this is generous.
+const keyListPageSize = 200
+
+// BuildForUser produces the per-user catalog DTO.
+//
+// Algorithm (mirrors plan in /Users/xuejiao/.claude/plans/bubbly-bouncing-sunbeam.md §"数据组装算法"):
+//  1. Load accessibleGroups, userKeys (active only), userRates.
+//  2. Resolve targetGroupID from opts.APIKeyID > opts.GroupID > default.
+//  3. Compute effectiveRate = userRates[gid] when present else group.RateMultiplier.
+//  4. Walk channels, filter to active + mapped to target group, filter
+//     SupportedModels.Platform == targetGroup.Platform (cross-platform leak guard).
+//  5. Dedupe by model_id, keep the cheapest (input + output sum) row.
+//  6. Multiply every price by effectiveRate.
+//  7. Join LiteLLM metadata for capabilities / context_window / max_output.
+//  8. Sort alpha by model_id.
+func (s *MePricingCatalogService) BuildForUser(
+	ctx context.Context,
+	userID int64,
+	opts MePricingCatalogOptions,
+) (*MePricingCatalogResponse, error) {
+	if s == nil || s.keys == nil {
+		return nil, ErrMePricingNoAccessibleGroups
+	}
+
+	accessibleGroups, err := s.keys.GetAvailableGroups(ctx, userID)
+	if err != nil {
+		return nil, err
+	}
+	if len(accessibleGroups) == 0 {
+		return nil, ErrMePricingNoAccessibleGroups
+	}
+	accessByID := make(map[int64]Group, len(accessibleGroups))
+	for i := range accessibleGroups {
+		g := accessibleGroups[i]
+		accessByID[g.ID] = g
+	}
+
+	userRates, err := s.keys.GetUserGroupRates(ctx, userID)
+	if err != nil {
+		return nil, err
+	}
+
+	keysAll, _, err := s.keys.List(ctx, userID,
+		pagination.PaginationParams{Page: 1, PageSize: keyListPageSize},
+		APIKeyListFilters{Status: StatusAPIKeyActive},
+	)
+	if err != nil {
+		return nil, err
+	}
+
+	myKeys := make([]MePricingKeyRef, 0, len(keysAll))
+	for i := range keysAll {
+		k := keysAll[i]
+		if k.GroupID == nil {
+			continue
+		}
+		g, ok := accessByID[*k.GroupID]
+		if !ok {
+			continue
+		}
+		myKeys = append(myKeys, MePricingKeyRef{
+			ID: k.ID, Name: k.Name, GroupID: g.ID, GroupName: g.Name,
+		})
+	}
+
+	targetGroupID, err := resolveTargetGroupID(opts, keysAll, accessByID, myKeys, accessibleGroups)
+	if err != nil {
+		return nil, err
+	}
+	targetGroup := accessByID[targetGroupID]
+
+	listMult := targetGroup.RateMultiplier
+	effective := listMult
+	hasOverride := false
+	if r, ok := userRates[targetGroupID]; ok {
+		effective = r
+		hasOverride = r != listMult
+	}
+
+	models := s.buildModelsForGroup(ctx, targetGroup, effective)
+
+	// Build picker DTO for accessible_groups with effective rate per group.
+	groupRefs := make([]MePricingGroupRef, 0, len(accessibleGroups))
+	for i := range accessibleGroups {
+		g := accessibleGroups[i]
+		rate := g.RateMultiplier
+		if r, ok := userRates[g.ID]; ok {
+			rate = r
+		}
+		groupRefs = append(groupRefs, MePricingGroupRef{
+			ID:               g.ID,
+			Name:             g.Name,
+			Platform:         g.Platform,
+			RateMultiplier:   rate,
+			IsCurrentForKey:  g.ID == targetGroupID,
+			IsExclusive:      g.IsExclusive,
+			SubscriptionType: g.SubscriptionType,
+		})
+	}
+
+	return &MePricingCatalogResponse{
+		TargetGroup: MePricingTargetGroup{
+			ID:               targetGroup.ID,
+			Name:             targetGroup.Name,
+			Platform:         targetGroup.Platform,
+			RateMultiplier:   effective,
+			ListMultiplier:   listMult,
+			HasOverride:      hasOverride,
+			IsExclusive:      targetGroup.IsExclusive,
+			SubscriptionType: targetGroup.SubscriptionType,
+		},
+		Models:           models,
+		MyKeys:           myKeys,
+		AccessibleGroups: groupRefs,
+		UpdatedAt:        time.Now().UTC(),
+	}, nil
+}
+
+// resolveTargetGroupID applies the selector precedence: explicit api_key_id
+// wins; explicit group_id second; otherwise default to the first user key's
+// group, then the first accessible group.
+func resolveTargetGroupID(
+	opts MePricingCatalogOptions,
+	keysAll []APIKey,
+	accessByID map[int64]Group,
+	myKeys []MePricingKeyRef,
+	accessibleGroups []Group,
+) (int64, error) {
+	switch {
+	case opts.APIKeyID != nil:
+		for i := range keysAll {
+			k := keysAll[i]
+			if k.ID != *opts.APIKeyID {
+				continue
+			}
+			if k.GroupID == nil {
+				return 0, ErrMePricingAPIKeyNotFound
+			}
+			if _, ok := accessByID[*k.GroupID]; !ok {
+				return 0, ErrMePricingAPIKeyNotFound
+			}
+			if opts.GroupID != nil && *opts.GroupID != *k.GroupID {
+				return 0, ErrMePricingConflictingTargets
+			}
+			return *k.GroupID, nil
+		}
+		return 0, ErrMePricingAPIKeyNotFound
+	case opts.GroupID != nil:
+		if _, ok := accessByID[*opts.GroupID]; !ok {
+			return 0, ErrMePricingGroupForbidden
+		}
+		return *opts.GroupID, nil
+	case len(myKeys) > 0:
+		return myKeys[0].GroupID, nil
+	default:
+		return accessibleGroups[0].ID, nil
+	}
+}
+
+// buildModelsForGroup performs steps 4-8 of the algorithm. Returns an
+// empty (non-nil) slice when no models exist; UI relies on this for the
+// "no models published" empty state.
+func (s *MePricingCatalogService) buildModelsForGroup(
+	ctx context.Context,
+	targetGroup Group,
+	effectiveRate float64,
+) []MePricingModel {
+	out := []MePricingModel{}
+	if s.channels == nil {
+		return out
+	}
+
+	channels, err := s.channels.ListAvailable(ctx)
+	if err != nil || len(channels) == 0 {
+		return out
+	}
+
+	bestByModel := make(map[string]MePricingModel)
+	for _, ch := range channels {
+		if ch.Status != StatusActive {
+			continue
+		}
+		mapped := false
+		for _, g := range ch.Groups {
+			if g.ID == targetGroup.ID {
+				mapped = true
+				break
+			}
+		}
+		if !mapped {
+			continue
+		}
+		for i := range ch.SupportedModels {
+			m := ch.SupportedModels[i]
+			// Cross-platform leak guard — a channel can sit on groups
+			// from multiple platforms; we restrict to models declared
+			// on the target group's platform.
+			if m.Platform != targetGroup.Platform {
+				continue
+			}
+			candidate := buildModelEntry(m, effectiveRate)
+			if existing, ok := bestByModel[m.Name]; ok {
+				bestByModel[m.Name] = pickCheaperModel(existing, candidate)
+			} else {
+				bestByModel[m.Name] = candidate
+			}
+		}
+	}
+
+	// Join LiteLLM catalog metadata.
+	metaByID := map[string]PublicCatalogModel{}
+	if s.catalog != nil {
+		if resp := s.catalog.BuildPublicCatalog(ctx); resp != nil {
+			for _, m := range resp.Data {
+				metaByID[m.ModelID] = m
+			}
+		}
+	}
+
+	for _, m := range bestByModel {
+		if meta, ok := metaByID[m.ModelID]; ok {
+			m.ContextWindow = meta.ContextWindow
+			m.MaxOutputTokens = meta.MaxOutputTokens
+			if len(meta.Capabilities) > 0 {
+				m.Capabilities = append([]string{}, meta.Capabilities...)
+			}
+			if m.Vendor == "" {
+				m.Vendor = meta.Vendor
+			}
+		}
+		if m.Capabilities == nil {
+			m.Capabilities = []string{}
+		}
+		out = append(out, m)
+	}
+
+	sort.Slice(out, func(i, j int) bool { return out[i].ModelID < out[j].ModelID })
+	return out
+}
+
+// buildModelEntry maps a single SupportedModel + effective rate into a
+// MePricingModel. Pricing fields are scaled to per-1k tokens for token
+// modes; per_request stays as a per-call value.
+func buildModelEntry(m SupportedModel, rate float64) MePricingModel {
+	entry := MePricingModel{
+		ModelID:      m.Name,
+		BillingMode:  string(BillingModeToken),
+		YourPrice:    MePricingPrice{Currency: "USD"},
+		Capabilities: []string{},
+	}
+	p := m.Pricing
+	if p == nil {
+		return entry
+	}
+	if p.BillingMode != "" {
+		entry.BillingMode = string(p.BillingMode)
+	}
+	entry.YourPrice.InputPer1K = scaleTo1K(p.InputPrice, rate)
+	entry.YourPrice.OutputPer1K = scaleTo1K(p.OutputPrice, rate)
+	entry.YourPrice.CacheReadPer1K = scaleTo1K(p.CacheReadPrice, rate)
+	entry.YourPrice.CacheWritePer1K = scaleTo1K(p.CacheWritePrice, rate)
+	entry.YourPrice.ImageOutputPer1K = scaleTo1K(p.ImageOutputPrice, rate)
+	entry.YourPrice.PerRequest = scalePtr(p.PerRequestPrice, rate)
+	return entry
+}
+
+// scaleTo1K converts a per-token price to per-1k-tokens and applies the
+// effective multiplier. nil stays nil so the UI can render "—" instead
+// of "$0".
+func scaleTo1K(v *float64, rate float64) *float64 {
+	if v == nil {
+		return nil
+	}
+	r := *v * 1000.0 * rate
+	return &r
+}
+
+// scalePtr applies the multiplier to a pointer-valued price (per_request
+// flavored — not per-token, so no ×1000).
+func scalePtr(v *float64, rate float64) *float64 {
+	if v == nil {
+		return nil
+	}
+	r := *v * rate
+	return &r
+}
+
+// pickCheaperModel returns the entry whose combined input+output cost is
+// lower. nil price components are treated as "no data" rather than free,
+// so a candidate with concrete prices wins over one with all-nil pricing.
+// For per_request mode, the per-call price contributes (×1000 to put it
+// on the same magnitude axis as per-1k prices for a coarse comparison).
+func pickCheaperModel(a, b MePricingModel) MePricingModel {
+	ac, ah := modelComparableCost(a)
+	bc, bh := modelComparableCost(b)
+	switch {
+	case ah && !bh:
+		return a
+	case bh && !ah:
+		return b
+	case ah && bh:
+		if bc < ac {
+			return b
+		}
+		return a
+	default:
+		return a
+	}
+}
+
+// modelComparableCost returns (cost, has-any-price). cost only matters
+// when has-any-price is true.
+func modelComparableCost(m MePricingModel) (float64, bool) {
+	var (
+		c float64
+		h bool
+	)
+	if v := m.YourPrice.InputPer1K; v != nil {
+		c += *v
+		h = true
+	}
+	if v := m.YourPrice.OutputPer1K; v != nil {
+		c += *v
+		h = true
+	}
+	if v := m.YourPrice.PerRequest; v != nil {
+		c += *v * 1000
+		h = true
+	}
+	return c, h
+}

--- a/backend/internal/service/me_pricing_catalog_tk_test.go
+++ b/backend/internal/service/me_pricing_catalog_tk_test.go
@@ -1,0 +1,512 @@
+//go:build unit
+
+package service
+
+import (
+	"context"
+	"errors"
+	"testing"
+
+	"github.com/Wei-Shaw/sub2api/internal/pkg/pagination"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// ----- fakes -----
+
+type fakeKeyAccess struct {
+	groups   []Group
+	groupErr error
+	rates    map[int64]float64
+	rateErr  error
+	keys     []APIKey
+	listErr  error
+}
+
+func (f *fakeKeyAccess) GetAvailableGroups(ctx context.Context, userID int64) ([]Group, error) {
+	if f.groupErr != nil {
+		return nil, f.groupErr
+	}
+	return f.groups, nil
+}
+
+func (f *fakeKeyAccess) GetUserGroupRates(ctx context.Context, userID int64) (map[int64]float64, error) {
+	if f.rateErr != nil {
+		return nil, f.rateErr
+	}
+	return f.rates, nil
+}
+
+func (f *fakeKeyAccess) List(
+	ctx context.Context, userID int64,
+	_ pagination.PaginationParams, _ APIKeyListFilters,
+) ([]APIKey, *pagination.PaginationResult, error) {
+	if f.listErr != nil {
+		return nil, nil, f.listErr
+	}
+	return f.keys, &pagination.PaginationResult{Total: int64(len(f.keys)), Page: 1, PageSize: 200, Pages: 1}, nil
+}
+
+type fakeChannelLister struct {
+	channels []AvailableChannel
+	err      error
+}
+
+func (f *fakeChannelLister) ListAvailable(ctx context.Context) ([]AvailableChannel, error) {
+	if f.err != nil {
+		return nil, f.err
+	}
+	return f.channels, nil
+}
+
+type fakeCatalogProvider struct {
+	resp *PublicCatalogResponse
+}
+
+func (f *fakeCatalogProvider) BuildPublicCatalog(ctx context.Context) *PublicCatalogResponse {
+	return f.resp
+}
+
+// ----- builders -----
+
+func mkGroupForMe(id int64, name, platform string, rate float64) Group {
+	return Group{
+		ID: id, Name: name, Platform: platform,
+		RateMultiplier: rate, IsExclusive: false,
+		Status: StatusActive, SubscriptionType: "standard",
+	}
+}
+
+func mkKeyForMe(id, userID int64, name string, groupID *int64) APIKey {
+	return APIKey{
+		ID: id, UserID: userID, Name: name,
+		Key: "sk-test-" + name, Status: StatusAPIKeyActive,
+		GroupID: groupID,
+	}
+}
+
+func ptrF(v float64) *float64 { return &v }
+func ptrI(v int64) *int64     { return &v }
+
+func mkChannelWithModel(
+	id int64, name string,
+	groups []AvailableGroupRef,
+	models []SupportedModel,
+) AvailableChannel {
+	return AvailableChannel{
+		ID: id, Name: name, Status: StatusActive,
+		Groups: groups, SupportedModels: models,
+	}
+}
+
+func mkSupportedModel(modelID, platform string, p *ChannelModelPricing) SupportedModel {
+	return SupportedModel{Name: modelID, Platform: platform, Pricing: p}
+}
+
+func mkPricing(input, output, cacheR float64) *ChannelModelPricing {
+	return &ChannelModelPricing{
+		BillingMode: BillingModeToken,
+		InputPrice:  ptrF(input),
+		OutputPrice: ptrF(output),
+		CacheReadPrice: func() *float64 {
+			if cacheR == 0 {
+				return nil
+			}
+			return ptrF(cacheR)
+		}(),
+	}
+}
+
+func newService(k *fakeKeyAccess, c *fakeChannelLister, cat *fakeCatalogProvider) *MePricingCatalogService {
+	return &MePricingCatalogService{keys: k, channels: c, catalog: cat}
+}
+
+// ----- tests -----
+
+func TestMePricingCatalog_DefaultToFirstKeyGroup_AppliesGroupMultiplier(t *testing.T) {
+	gPro := mkGroupForMe(10, "Pro", "newapi", 1.5)
+	gMax := mkGroupForMe(20, "Max", "newapi", 0.8)
+	k1 := mkKeyForMe(1, 7, "default", ptrI(10))
+
+	svc := newService(
+		&fakeKeyAccess{groups: []Group{gPro, gMax}, keys: []APIKey{k1}},
+		&fakeChannelLister{channels: []AvailableChannel{
+			mkChannelWithModel(100, "ch1",
+				[]AvailableGroupRef{{ID: 10, Name: "Pro", Platform: "newapi", RateMultiplier: 1.5}},
+				[]SupportedModel{
+					mkSupportedModel("gpt-4o", "newapi", mkPricing(0.000003, 0.000015, 0)),
+				},
+			),
+		}},
+		&fakeCatalogProvider{resp: nil},
+	)
+
+	resp, err := svc.BuildForUser(context.Background(), 7, MePricingCatalogOptions{})
+	require.NoError(t, err)
+	require.NotNil(t, resp)
+	assert.Equal(t, int64(10), resp.TargetGroup.ID)
+	assert.Equal(t, 1.5, resp.TargetGroup.RateMultiplier)
+	assert.Equal(t, 1.5, resp.TargetGroup.ListMultiplier)
+	assert.False(t, resp.TargetGroup.HasOverride)
+	require.Len(t, resp.Models, 1)
+	// 0.000003 * 1000 * 1.5 = 0.0045
+	assert.InDelta(t, 0.0045, *resp.Models[0].YourPrice.InputPer1K, 1e-9)
+	assert.InDelta(t, 0.0225, *resp.Models[0].YourPrice.OutputPer1K, 1e-9)
+	// my_keys + accessible_groups populated
+	require.Len(t, resp.MyKeys, 1)
+	assert.Equal(t, int64(1), resp.MyKeys[0].ID)
+	require.Len(t, resp.AccessibleGroups, 2)
+	// IsCurrentForKey flag set correctly
+	for _, g := range resp.AccessibleGroups {
+		if g.ID == 10 {
+			assert.True(t, g.IsCurrentForKey)
+		} else {
+			assert.False(t, g.IsCurrentForKey)
+		}
+	}
+}
+
+func TestMePricingCatalog_UserOverrideTakesPrecedence(t *testing.T) {
+	gPro := mkGroupForMe(10, "Pro", "newapi", 1.0)
+	k1 := mkKeyForMe(1, 7, "default", ptrI(10))
+
+	svc := newService(
+		&fakeKeyAccess{
+			groups: []Group{gPro},
+			keys:   []APIKey{k1},
+			rates:  map[int64]float64{10: 0.5},
+		},
+		&fakeChannelLister{channels: []AvailableChannel{
+			mkChannelWithModel(100, "ch1",
+				[]AvailableGroupRef{{ID: 10, Platform: "newapi"}},
+				[]SupportedModel{
+					mkSupportedModel("gpt-4o", "newapi", mkPricing(0.000010, 0.000020, 0)),
+				},
+			),
+		}},
+		&fakeCatalogProvider{},
+	)
+	resp, err := svc.BuildForUser(context.Background(), 7, MePricingCatalogOptions{})
+	require.NoError(t, err)
+	assert.Equal(t, 0.5, resp.TargetGroup.RateMultiplier)
+	assert.Equal(t, 1.0, resp.TargetGroup.ListMultiplier)
+	assert.True(t, resp.TargetGroup.HasOverride)
+	// 0.000010 * 1000 * 0.5 = 0.005
+	assert.InDelta(t, 0.005, *resp.Models[0].YourPrice.InputPer1K, 1e-9)
+	assert.InDelta(t, 0.010, *resp.Models[0].YourPrice.OutputPer1K, 1e-9)
+}
+
+func TestMePricingCatalog_ZeroRateIsLegitFree(t *testing.T) {
+	gPro := mkGroupForMe(10, "Pro", "newapi", 1.0)
+	k1 := mkKeyForMe(1, 7, "default", ptrI(10))
+
+	svc := newService(
+		&fakeKeyAccess{
+			groups: []Group{gPro},
+			keys:   []APIKey{k1},
+			rates:  map[int64]float64{10: 0},
+		},
+		&fakeChannelLister{channels: []AvailableChannel{
+			mkChannelWithModel(100, "ch1",
+				[]AvailableGroupRef{{ID: 10, Platform: "newapi"}},
+				[]SupportedModel{
+					mkSupportedModel("gpt-4o", "newapi", mkPricing(0.000010, 0.000020, 0)),
+				},
+			),
+		}},
+		&fakeCatalogProvider{},
+	)
+	resp, err := svc.BuildForUser(context.Background(), 7, MePricingCatalogOptions{})
+	require.NoError(t, err)
+	assert.Equal(t, 0.0, resp.TargetGroup.RateMultiplier)
+	assert.True(t, resp.TargetGroup.HasOverride)
+	assert.Equal(t, 0.0, *resp.Models[0].YourPrice.InputPer1K)
+	assert.Equal(t, 0.0, *resp.Models[0].YourPrice.OutputPer1K)
+}
+
+func TestMePricingCatalog_ExploreOtherGroup(t *testing.T) {
+	gPro := mkGroupForMe(10, "Pro", "newapi", 1.0)
+	gMax := mkGroupForMe(20, "Max", "newapi", 0.8)
+	k1 := mkKeyForMe(1, 7, "default", ptrI(10))
+
+	svc := newService(
+		&fakeKeyAccess{groups: []Group{gPro, gMax}, keys: []APIKey{k1}},
+		&fakeChannelLister{channels: []AvailableChannel{
+			mkChannelWithModel(100, "ch1",
+				[]AvailableGroupRef{{ID: 20, Platform: "newapi"}},
+				[]SupportedModel{
+					mkSupportedModel("gpt-4o", "newapi", mkPricing(0.000010, 0.000020, 0)),
+				},
+			),
+		}},
+		&fakeCatalogProvider{},
+	)
+	gid := int64(20)
+	resp, err := svc.BuildForUser(context.Background(), 7, MePricingCatalogOptions{GroupID: &gid})
+	require.NoError(t, err)
+	assert.Equal(t, int64(20), resp.TargetGroup.ID)
+	assert.Equal(t, 0.8, resp.TargetGroup.RateMultiplier)
+	// Both groups still in picker; only Max is current
+	require.Len(t, resp.AccessibleGroups, 2)
+	for _, g := range resp.AccessibleGroups {
+		if g.ID == 20 {
+			assert.True(t, g.IsCurrentForKey)
+		} else {
+			assert.False(t, g.IsCurrentForKey)
+		}
+	}
+}
+
+func TestMePricingCatalog_ForbiddenGroup(t *testing.T) {
+	gPro := mkGroupForMe(10, "Pro", "newapi", 1.0)
+	svc := newService(
+		&fakeKeyAccess{groups: []Group{gPro}},
+		&fakeChannelLister{},
+		&fakeCatalogProvider{},
+	)
+	other := int64(99)
+	_, err := svc.BuildForUser(context.Background(), 7, MePricingCatalogOptions{GroupID: &other})
+	require.Error(t, err)
+	assert.ErrorIs(t, err, ErrMePricingGroupForbidden)
+}
+
+func TestMePricingCatalog_APIKeyConflictsWithGroup(t *testing.T) {
+	gPro := mkGroupForMe(10, "Pro", "newapi", 1.0)
+	gMax := mkGroupForMe(20, "Max", "newapi", 0.8)
+	k1 := mkKeyForMe(1, 7, "default", ptrI(10))
+	svc := newService(
+		&fakeKeyAccess{groups: []Group{gPro, gMax}, keys: []APIKey{k1}},
+		&fakeChannelLister{},
+		&fakeCatalogProvider{},
+	)
+	keyID := int64(1)
+	otherGroup := int64(20)
+	_, err := svc.BuildForUser(context.Background(), 7, MePricingCatalogOptions{
+		APIKeyID: &keyID, GroupID: &otherGroup,
+	})
+	require.Error(t, err)
+	assert.ErrorIs(t, err, ErrMePricingConflictingTargets)
+}
+
+func TestMePricingCatalog_APIKeyNotFound(t *testing.T) {
+	gPro := mkGroupForMe(10, "Pro", "newapi", 1.0)
+	svc := newService(
+		&fakeKeyAccess{groups: []Group{gPro}},
+		&fakeChannelLister{},
+		&fakeCatalogProvider{},
+	)
+	keyID := int64(9999)
+	_, err := svc.BuildForUser(context.Background(), 7, MePricingCatalogOptions{APIKeyID: &keyID})
+	require.Error(t, err)
+	assert.ErrorIs(t, err, ErrMePricingAPIKeyNotFound)
+}
+
+func TestMePricingCatalog_KeyWithoutGroupSkippedInPicker(t *testing.T) {
+	gPro := mkGroupForMe(10, "Pro", "newapi", 1.0)
+	k1 := mkKeyForMe(1, 7, "default", ptrI(10))
+	kOrphan := mkKeyForMe(2, 7, "orphan", nil)
+	svc := newService(
+		&fakeKeyAccess{groups: []Group{gPro}, keys: []APIKey{kOrphan, k1}},
+		&fakeChannelLister{},
+		&fakeCatalogProvider{},
+	)
+	resp, err := svc.BuildForUser(context.Background(), 7, MePricingCatalogOptions{})
+	require.NoError(t, err)
+	require.Len(t, resp.MyKeys, 1)
+	assert.Equal(t, int64(1), resp.MyKeys[0].ID)
+}
+
+func TestMePricingCatalog_NoAccessibleGroups(t *testing.T) {
+	svc := newService(&fakeKeyAccess{}, &fakeChannelLister{}, &fakeCatalogProvider{})
+	_, err := svc.BuildForUser(context.Background(), 7, MePricingCatalogOptions{})
+	require.Error(t, err)
+	assert.ErrorIs(t, err, ErrMePricingNoAccessibleGroups)
+}
+
+func TestMePricingCatalog_MultiChannelKeepsCheapest(t *testing.T) {
+	gPro := mkGroupForMe(10, "Pro", "newapi", 1.0)
+	k1 := mkKeyForMe(1, 7, "default", ptrI(10))
+	expensive := mkChannelWithModel(100, "expensive",
+		[]AvailableGroupRef{{ID: 10, Platform: "newapi"}},
+		[]SupportedModel{mkSupportedModel("gpt-4o", "newapi", mkPricing(0.00010, 0.00020, 0))},
+	)
+	cheap := mkChannelWithModel(101, "cheap",
+		[]AvailableGroupRef{{ID: 10, Platform: "newapi"}},
+		[]SupportedModel{mkSupportedModel("gpt-4o", "newapi", mkPricing(0.00001, 0.00002, 0))},
+	)
+	svc := newService(
+		&fakeKeyAccess{groups: []Group{gPro}, keys: []APIKey{k1}},
+		&fakeChannelLister{channels: []AvailableChannel{expensive, cheap}},
+		&fakeCatalogProvider{},
+	)
+	resp, err := svc.BuildForUser(context.Background(), 7, MePricingCatalogOptions{})
+	require.NoError(t, err)
+	require.Len(t, resp.Models, 1)
+	// cheap: 0.00001*1000=0.01 input; expensive: 0.10 input — keep cheap
+	assert.InDelta(t, 0.01, *resp.Models[0].YourPrice.InputPer1K, 1e-9)
+}
+
+func TestMePricingCatalog_MultiChannelOneWithoutPrice(t *testing.T) {
+	// A no-price candidate must NOT win over a priced one (LiteLLM-fallback gone wrong).
+	gPro := mkGroupForMe(10, "Pro", "newapi", 1.0)
+	k1 := mkKeyForMe(1, 7, "default", ptrI(10))
+	noPrice := mkChannelWithModel(100, "noPrice",
+		[]AvailableGroupRef{{ID: 10, Platform: "newapi"}},
+		[]SupportedModel{{Name: "gpt-4o", Platform: "newapi", Pricing: nil}},
+	)
+	priced := mkChannelWithModel(101, "priced",
+		[]AvailableGroupRef{{ID: 10, Platform: "newapi"}},
+		[]SupportedModel{mkSupportedModel("gpt-4o", "newapi", mkPricing(0.00001, 0.00002, 0))},
+	)
+	svc := newService(
+		&fakeKeyAccess{groups: []Group{gPro}, keys: []APIKey{k1}},
+		&fakeChannelLister{channels: []AvailableChannel{noPrice, priced}},
+		&fakeCatalogProvider{},
+	)
+	resp, err := svc.BuildForUser(context.Background(), 7, MePricingCatalogOptions{})
+	require.NoError(t, err)
+	require.Len(t, resp.Models, 1)
+	require.NotNil(t, resp.Models[0].YourPrice.InputPer1K)
+}
+
+func TestMePricingCatalog_CrossPlatformLeakGuard(t *testing.T) {
+	// Channel mapped to a newapi group must NOT bleed an anthropic-platform
+	// model into the newapi menu.
+	gNewapi := mkGroupForMe(10, "Pro", "newapi", 1.0)
+	k1 := mkKeyForMe(1, 7, "default", ptrI(10))
+	mixed := mkChannelWithModel(100, "mixed",
+		[]AvailableGroupRef{{ID: 10, Platform: "newapi"}},
+		[]SupportedModel{
+			mkSupportedModel("gpt-4o", "newapi", mkPricing(0.00001, 0.00002, 0)),
+			mkSupportedModel("claude-opus-4-7", "anthropic", mkPricing(0.00003, 0.00015, 0)),
+		},
+	)
+	svc := newService(
+		&fakeKeyAccess{groups: []Group{gNewapi}, keys: []APIKey{k1}},
+		&fakeChannelLister{channels: []AvailableChannel{mixed}},
+		&fakeCatalogProvider{},
+	)
+	resp, err := svc.BuildForUser(context.Background(), 7, MePricingCatalogOptions{})
+	require.NoError(t, err)
+	require.Len(t, resp.Models, 1)
+	assert.Equal(t, "gpt-4o", resp.Models[0].ModelID)
+}
+
+func TestMePricingCatalog_NonActiveChannelExcluded(t *testing.T) {
+	gPro := mkGroupForMe(10, "Pro", "newapi", 1.0)
+	k1 := mkKeyForMe(1, 7, "default", ptrI(10))
+	disabled := AvailableChannel{
+		ID: 100, Name: "disabled", Status: "disabled",
+		Groups:          []AvailableGroupRef{{ID: 10, Platform: "newapi"}},
+		SupportedModels: []SupportedModel{mkSupportedModel("gpt-4o", "newapi", mkPricing(0.00001, 0.00002, 0))},
+	}
+	svc := newService(
+		&fakeKeyAccess{groups: []Group{gPro}, keys: []APIKey{k1}},
+		&fakeChannelLister{channels: []AvailableChannel{disabled}},
+		&fakeCatalogProvider{},
+	)
+	resp, err := svc.BuildForUser(context.Background(), 7, MePricingCatalogOptions{})
+	require.NoError(t, err)
+	assert.Empty(t, resp.Models)
+}
+
+func TestMePricingCatalog_JoinsCatalogMetadata(t *testing.T) {
+	gPro := mkGroupForMe(10, "Pro", "newapi", 1.0)
+	k1 := mkKeyForMe(1, 7, "default", ptrI(10))
+	ch := mkChannelWithModel(100, "ch",
+		[]AvailableGroupRef{{ID: 10, Platform: "newapi"}},
+		[]SupportedModel{mkSupportedModel("gpt-4o", "newapi", mkPricing(0.00001, 0.00002, 0))},
+	)
+	catalog := &fakeCatalogProvider{resp: &PublicCatalogResponse{
+		Data: []PublicCatalogModel{{
+			ModelID: "gpt-4o", Vendor: "openai",
+			ContextWindow: 128000, MaxOutputTokens: 16384,
+			Capabilities: []string{"vision", "tool_use"},
+		}},
+	}}
+	svc := newService(
+		&fakeKeyAccess{groups: []Group{gPro}, keys: []APIKey{k1}},
+		&fakeChannelLister{channels: []AvailableChannel{ch}},
+		catalog,
+	)
+	resp, err := svc.BuildForUser(context.Background(), 7, MePricingCatalogOptions{})
+	require.NoError(t, err)
+	require.Len(t, resp.Models, 1)
+	assert.Equal(t, 128000, resp.Models[0].ContextWindow)
+	assert.Equal(t, 16384, resp.Models[0].MaxOutputTokens)
+	assert.Equal(t, []string{"vision", "tool_use"}, resp.Models[0].Capabilities)
+	assert.Equal(t, "openai", resp.Models[0].Vendor)
+}
+
+func TestMePricingCatalog_CatalogMissingGracefulDegrade(t *testing.T) {
+	gPro := mkGroupForMe(10, "Pro", "newapi", 1.0)
+	k1 := mkKeyForMe(1, 7, "default", ptrI(10))
+	ch := mkChannelWithModel(100, "ch",
+		[]AvailableGroupRef{{ID: 10, Platform: "newapi"}},
+		[]SupportedModel{mkSupportedModel("gpt-4o", "newapi", mkPricing(0.00001, 0.00002, 0))},
+	)
+	svc := newService(
+		&fakeKeyAccess{groups: []Group{gPro}, keys: []APIKey{k1}},
+		&fakeChannelLister{channels: []AvailableChannel{ch}},
+		&fakeCatalogProvider{resp: nil}, // nil catalog → still ok
+	)
+	resp, err := svc.BuildForUser(context.Background(), 7, MePricingCatalogOptions{})
+	require.NoError(t, err)
+	require.Len(t, resp.Models, 1)
+	assert.Equal(t, 0, resp.Models[0].ContextWindow)
+	assert.Equal(t, []string{}, resp.Models[0].Capabilities)
+	assert.NotNil(t, resp.Models[0].YourPrice.InputPer1K)
+}
+
+func TestMePricingCatalog_ResolveByAPIKeyID(t *testing.T) {
+	gPro := mkGroupForMe(10, "Pro", "newapi", 1.0)
+	gMax := mkGroupForMe(20, "Max", "newapi", 0.8)
+	kA := mkKeyForMe(1, 7, "proKey", ptrI(10))
+	kB := mkKeyForMe(2, 7, "maxKey", ptrI(20))
+	svc := newService(
+		&fakeKeyAccess{groups: []Group{gPro, gMax}, keys: []APIKey{kA, kB}},
+		&fakeChannelLister{},
+		&fakeCatalogProvider{},
+	)
+	keyID := int64(2)
+	resp, err := svc.BuildForUser(context.Background(), 7, MePricingCatalogOptions{APIKeyID: &keyID})
+	require.NoError(t, err)
+	assert.Equal(t, int64(20), resp.TargetGroup.ID)
+}
+
+func TestMePricingCatalog_UpstreamErrorsPropagate(t *testing.T) {
+	wantErr := errors.New("groups boom")
+	svc := newService(
+		&fakeKeyAccess{groupErr: wantErr},
+		&fakeChannelLister{},
+		&fakeCatalogProvider{},
+	)
+	_, err := svc.BuildForUser(context.Background(), 7, MePricingCatalogOptions{})
+	require.ErrorIs(t, err, wantErr)
+}
+
+func TestMePricingCatalog_PerRequestBillingPreservesPrice(t *testing.T) {
+	gPro := mkGroupForMe(10, "Pro", "newapi", 2.0)
+	k1 := mkKeyForMe(1, 7, "default", ptrI(10))
+	pr := &ChannelModelPricing{
+		BillingMode:     BillingModePerRequest,
+		PerRequestPrice: ptrF(0.02),
+	}
+	ch := mkChannelWithModel(100, "ch",
+		[]AvailableGroupRef{{ID: 10, Platform: "newapi"}},
+		[]SupportedModel{mkSupportedModel("flux-fast", "newapi", pr)},
+	)
+	svc := newService(
+		&fakeKeyAccess{groups: []Group{gPro}, keys: []APIKey{k1}},
+		&fakeChannelLister{channels: []AvailableChannel{ch}},
+		&fakeCatalogProvider{},
+	)
+	resp, err := svc.BuildForUser(context.Background(), 7, MePricingCatalogOptions{})
+	require.NoError(t, err)
+	require.Len(t, resp.Models, 1)
+	assert.Equal(t, string(BillingModePerRequest), resp.Models[0].BillingMode)
+	require.NotNil(t, resp.Models[0].YourPrice.PerRequest)
+	assert.InDelta(t, 0.04, *resp.Models[0].YourPrice.PerRequest, 1e-9)
+	assert.Nil(t, resp.Models[0].YourPrice.InputPer1K)
+}

--- a/backend/internal/service/wire.go
+++ b/backend/internal/service/wire.go
@@ -461,6 +461,8 @@ var ProviderSet = wire.NewSet(
 	NewDashboardService,
 	ProvidePricingService,
 	NewPricingCatalogService,
+	// TK: per-user pricing catalog ("Your Menu") — see me_pricing_catalog_tk.go
+	NewMePricingCatalogService,
 	NewBillingService,
 	ProvideBillingCacheService,
 	NewAnnouncementService,

--- a/backend/internal/web/dist/frontend-source.json
+++ b/backend/internal/web/dist/frontend-source.json
@@ -1,7 +1,7 @@
 {
   "algorithm": "sha256(git-ls-files:path,size,content)",
   "file_count": 426,
-  "hash": "49f5734f3cbbae6089e7f1881415b0798937d97c6c505aa74d7ca95f8c9ec970",
+  "hash": "8bac875834c73e7bd7e6b58f7e826a2af754ed8a390e60548eed1100d3b86472",
   "schema": 1,
   "source": "frontend/"
 }

--- a/backend/internal/web/dist/frontend-source.json
+++ b/backend/internal/web/dist/frontend-source.json
@@ -1,7 +1,7 @@
 {
   "algorithm": "sha256(git-ls-files:path,size,content)",
-  "file_count": 425,
-  "hash": "80ba14c5d25fb7fe2f3f328320feec289daf35ff212e36d687e72b389a426800",
+  "file_count": 426,
+  "hash": "49f5734f3cbbae6089e7f1881415b0798937d97c6c505aa74d7ca95f8c9ec970",
   "schema": 1,
   "source": "frontend/"
 }

--- a/frontend/src/api/me-pricing.ts
+++ b/frontend/src/api/me-pricing.ts
@@ -1,0 +1,110 @@
+/**
+ * TokenKey: per-user pricing catalog API client.
+ *
+ * Backed by GET /api/v1/me/pricing-catalog
+ * (handler/me_pricing_catalog_handler_tk.go). Returns the model menu for
+ * the group of the user's selected API key, with prices already multiplied
+ * by the user's effective rate (group.rate_multiplier × per-user override).
+ * The same endpoint serves the "explore other group" comparison view when
+ * `group_id` is supplied.
+ *
+ * Response shape uses the standard `{code,message,data}` envelope, which
+ * the axios response interceptor unwraps — callers receive the `data`
+ * payload directly.
+ */
+
+import { apiClient } from './client'
+
+/** Billing mode mirrors backend service.BillingMode. */
+export type MePricingBillingMode = 'token' | 'per_request' | 'image' | string
+
+/**
+ * "Your price" — already multiplied by effective rate (group default ×
+ * per-user override). Per-1k for token modes; per-call for per_request.
+ * Nil-valued fields mean "no data" (the field is omitted from the JSON
+ * payload entirely thanks to backend `omitempty`).
+ */
+export interface MePricingPrice {
+  currency: string
+  input_per_1k?: number
+  output_per_1k?: number
+  cache_read_per_1k?: number
+  cache_write_per_1k?: number
+  image_output_per_1k?: number
+  per_request?: number
+}
+
+export interface MePricingModel {
+  model_id: string
+  vendor?: string
+  billing_mode: MePricingBillingMode
+  your_price: MePricingPrice
+  context_window?: number
+  max_output_tokens?: number
+  capabilities: string[]
+}
+
+export interface MePricingTargetGroup {
+  id: number
+  name: string
+  platform: string
+  /** Effective multiplier (group default × per-user override). */
+  rate_multiplier: number
+  /** Group default multiplier — only used to show "含个人覆写" hint. */
+  list_multiplier: number
+  has_override: boolean
+  is_exclusive: boolean
+  subscription_type: string
+}
+
+export interface MePricingKeyRef {
+  id: number
+  name: string
+  group_id: number
+  group_name: string
+}
+
+export interface MePricingGroupRef {
+  id: number
+  name: string
+  platform: string
+  rate_multiplier: number
+  is_current_for_key: boolean
+  is_exclusive: boolean
+  subscription_type: string
+}
+
+export interface MePricingCatalogResponse {
+  target_group: MePricingTargetGroup
+  models: MePricingModel[]
+  my_keys: MePricingKeyRef[]
+  accessible_groups: MePricingGroupRef[]
+  updated_at: string
+}
+
+export interface GetMePricingCatalogParams {
+  apiKeyId?: number
+  groupId?: number
+}
+
+/**
+ * Fetch the per-user pricing catalog.
+ *
+ * - With neither param: defaults to the user's first active key's group.
+ * - With `apiKeyId`: shows the menu for that key's group.
+ * - With `groupId`: "explore other group" mode (must be in user's
+ *   accessible set, otherwise 403).
+ * - With BOTH and they refer to different groups: 400 (the API client
+ *   surfaces this as a rejected promise; callers should set one at a time).
+ */
+export async function getMePricingCatalog(
+  params: GetMePricingCatalogParams = {}
+): Promise<MePricingCatalogResponse> {
+  const query: Record<string, string> = {}
+  if (params.apiKeyId != null) query.api_key_id = String(params.apiKeyId)
+  if (params.groupId != null) query.group_id = String(params.groupId)
+  const { data } = await apiClient.get<MePricingCatalogResponse>('/me/pricing-catalog', {
+    params: query,
+  })
+  return data
+}

--- a/frontend/src/i18n/locales/en.ts
+++ b/frontend/src/i18n/locales/en.ts
@@ -48,7 +48,45 @@ export default {
       noMatches: 'No models match your search. Try fuzzy mode or a shorter query.'
     },
     ctaBonus: 'Register — get {amount} trial credit',
-    ctaBonusHint: 'Shown when signup bonus is enabled for this site.'
+    ctaBonusHint: 'Shown when signup bonus is enabled for this site.',
+    perRequest: '/ request',
+    // TK: authenticated "Your Menu" view (GET /api/v1/me/pricing-catalog).
+    my: {
+      tabMy: 'Your Menu',
+      tabPublic: 'Public Catalog',
+      title: 'Your Model Menu',
+      subtitle: 'Models available to the group of your selected API key, at your effective price',
+      description:
+        'Prices are already multiplied by your effective rate (group default × your override), per 1,000 tokens. Switch keys to see another group, or compare other accessible groups to decide whether to upgrade.',
+      pickerKey: 'Current key:',
+      pickerCompare: 'Compare group:',
+      compareDefault: 'Keep current',
+      noKeyHint: 'You have no active API keys yet — create one in the console first.',
+      columns: {
+        input: 'Input (your price)',
+        output: 'Output (your price)'
+      },
+      rateHint: 'Multiplier {multiplier} applied',
+      rateOverride: 'includes personal override',
+      empty: {
+        noAccess: {
+          title: 'No accessible group',
+          hint: 'You have no group you can use yet. Contact the administrator or pick a plan in the subscription page.'
+        },
+        noModels: {
+          title: 'This group has no models yet',
+          hint: 'The administrator may still be configuring channels. Check back later or compare another group.'
+        }
+      },
+      exploreBanner: {
+        message: 'Viewing {group} catalog · multiplier ×{multiplier}',
+        cta: 'Create key in {group}'
+      },
+      billingMode: {
+        per_request: 'per call',
+        image: 'per image'
+      }
+    }
   },
 
   playground: {

--- a/frontend/src/i18n/locales/zh.ts
+++ b/frontend/src/i18n/locales/zh.ts
@@ -47,7 +47,45 @@ export default {
       noMatches: '没有匹配的模型。可切换到模糊搜索或缩短关键词。'
     },
     ctaBonus: '立即注册 · 获赠 {amount} 试用额度',
-    ctaBonusHint: '当本站开启注册赠额时显示此提示。'
+    ctaBonusHint: '当本站开启注册赠额时显示此提示。',
+    perRequest: '/ 次',
+    // TK: 登录态「我的菜单」视图（GET /api/v1/me/pricing-catalog）
+    my: {
+      tabMy: '我的菜单',
+      tabPublic: '公开目录',
+      title: '我的模型菜单',
+      subtitle: '当前 API Key 所属分组可调用的模型与你的实际单价',
+      description:
+        '价格已按你的有效倍率（分组默认 × 个人覆写）计算，单位为每 1,000 tokens。切换 API Key 查看不同 group，或对比其他可用 group 决定是否升级。',
+      pickerKey: '当前 Key：',
+      pickerCompare: '对比其他 group：',
+      compareDefault: '保持当前',
+      noKeyHint: '你还没有可用的 API Key，先去控制台创建一个。',
+      columns: {
+        input: '输入（你的单价）',
+        output: '输出（你的单价）'
+      },
+      rateHint: '已应用 {multiplier} 倍率',
+      rateOverride: '含个人覆写',
+      empty: {
+        noAccess: {
+          title: '暂无可用分组',
+          hint: '没有可访问的 group，请联系管理员或先在订阅页选购。'
+        },
+        noModels: {
+          title: '此分组暂未上架模型',
+          hint: '管理员可能正在配置渠道，请稍后再来或切换到其他 group。'
+        }
+      },
+      exploreBanner: {
+        message: '正在查看 {group} 的目录 · 倍率 ×{multiplier}',
+        cta: '在 {group} 创建 Key'
+      },
+      billingMode: {
+        per_request: '按次',
+        image: '按图'
+      }
+    }
   },
 
   playground: {

--- a/frontend/src/utils/pricingCatalogSearch.ts
+++ b/frontend/src/utils/pricingCatalogSearch.ts
@@ -1,21 +1,25 @@
 /**
- * Client-side filtering for the public pricing catalog (model_id search).
+ * Client-side filtering for any model-keyed row by model_id.
+ *
+ * Generic over `T extends { model_id: string }` so the same matcher serves
+ * both the public LiteLLM catalog (PublicCatalogModel) and the per-user
+ * "your menu" rows. Keeping the constraint to the single field actually
+ * used by the matcher avoids the previous PublicCatalogModel coupling
+ * that forced callers to shape-shift their rows just to reuse this util.
  */
-
-import type { PublicCatalogModel } from '@/api/pricing'
 
 export type PricingCatalogSearchMode = 'fuzzy' | 'exact'
 
 /**
- * Filters catalog rows by model_id.
+ * Filters rows by model_id.
  * - fuzzy: case-insensitive substring match (partial / "模糊")
  * - exact: case-insensitive full string equality after trim ("精准")
  */
-export function filterPricingCatalogByModel(
-  models: PublicCatalogModel[],
+export function filterPricingCatalogByModel<T extends { model_id: string }>(
+  models: T[],
   rawQuery: string,
   mode: PricingCatalogSearchMode
-): PublicCatalogModel[] {
+): T[] {
   const q = rawQuery.trim()
   if (!q) {
     return models

--- a/frontend/src/views/PricingView.vue
+++ b/frontend/src/views/PricingView.vue
@@ -100,8 +100,9 @@
               >
                 <span class="font-medium">{{ t('pricing.my.pickerKey') }}</span>
                 <select
-                  v-model.number="selectedKeyId"
+                  :value="displayKeyId"
                   class="rounded-lg border border-gray-200 bg-white px-3 py-1.5 text-sm dark:border-dark-700 dark:bg-dark-900 dark:text-white"
+                  @change="onPickKey"
                 >
                   <option
                     v-for="k in myCatalog.my_keys"
@@ -122,8 +123,9 @@
             <label class="flex items-center gap-2 text-sm text-gray-700 dark:text-dark-200">
               <span>{{ t('pricing.my.pickerCompare') }}</span>
               <select
-                v-model.number="selectedGroupId"
+                :value="selectedGroupId"
                 class="rounded-lg border border-gray-200 bg-white px-3 py-1.5 text-sm dark:border-dark-700 dark:bg-dark-900 dark:text-white"
+                @change="onPickGroup"
               >
                 <option :value="0">{{ t('pricing.my.compareDefault') }}</option>
                 <option
@@ -326,13 +328,13 @@
                 >
                   <tr
                     v-for="row in filteredRows"
-                    :key="row.modelId"
+                    :key="row.model_id"
                     class="group hover:bg-primary-50/30 dark:hover:bg-dark-800/40"
                   >
                     <td
                       class="sticky left-0 z-10 min-w-[14rem] max-w-[28rem] border-r border-gray-200 bg-white px-3 py-3 align-top font-mono text-sm leading-snug text-gray-900 shadow-[4px_0_12px_-8px_rgba(0,0,0,0.12)] break-words group-hover:bg-primary-50/30 dark:border-dark-700 dark:bg-dark-900 dark:text-white dark:shadow-[4px_0_12px_-8px_rgba(0,0,0,0.45)] dark:group-hover:bg-dark-800/40"
                     >
-                      {{ row.modelId }}
+                      {{ row.model_id }}
                       <span
                         v-if="row.billingMode && row.billingMode !== 'token'"
                         class="ml-1 inline-flex items-center rounded-md bg-amber-50 px-1.5 py-0.5 text-[10px] font-medium text-amber-800 dark:bg-amber-900/30 dark:text-amber-200"
@@ -463,7 +465,7 @@
  * between modes — this is by design; the v1 trade-off accepted in
  * /Users/xuejiao/.claude/plans/bubbly-bouncing-sunbeam.md.
  */
-import { computed, onMounted, ref, watch } from 'vue'
+import { computed, onMounted, ref } from 'vue'
 import { useI18n } from 'vue-i18n'
 import { getPublicPricing, type PublicCatalogResponse } from '@/api/pricing'
 import {
@@ -487,9 +489,16 @@ const appStore = useAppStore()
 
 type ViewMode = 'my' | 'public'
 
-/** Internal row shape — single source of truth for the shared table markup. */
+/**
+ * Internal row shape — single source of truth for the shared table markup.
+ *
+ * Uses snake_case `model_id` (not camelCase modelId) so the row can flow
+ * directly through `filterPricingCatalogByModel<T extends {model_id:string}>`
+ * without an adapter mapping. Other fields stay camelCase because they're
+ * derived/UI-shaped, not echoes of backend DTOs.
+ */
 interface NormalizedRow {
-  modelId: string
+  model_id: string
   vendor: string
   inputPer1K: number | null
   outputPer1K: number | null
@@ -587,7 +596,7 @@ const normalizedRows = computed<NormalizedRow[]>(() => {
   if (viewMode.value === 'public') {
     if (!publicCatalog.value) return []
     return publicCatalog.value.data.map((m) => ({
-      modelId: m.model_id,
+      model_id: m.model_id,
       vendor: m.vendor ?? '',
       inputPer1K: m.pricing.input_per_1k_tokens ?? null,
       outputPer1K: m.pricing.output_per_1k_tokens ?? null,
@@ -603,7 +612,7 @@ const normalizedRows = computed<NormalizedRow[]>(() => {
   // 'my' view
   if (!myCatalog.value) return []
   return myCatalog.value.models.map((m) => ({
-    modelId: m.model_id,
+    model_id: m.model_id,
     vendor: m.vendor ?? '',
     inputPer1K: m.your_price.input_per_1k ?? null,
     outputPer1K: m.your_price.output_per_1k ?? null,
@@ -618,22 +627,7 @@ const normalizedRows = computed<NormalizedRow[]>(() => {
 })
 
 const filteredRows = computed(() =>
-  filterPricingCatalogByModel(
-    normalizedRows.value.map((r) => ({
-      model_id: r.modelId,
-      vendor: r.vendor,
-      pricing: {
-        currency: 'USD',
-        input_per_1k_tokens: r.inputPer1K ?? 0,
-        output_per_1k_tokens: r.outputPer1K ?? 0
-      },
-      capabilities: r.capabilities,
-      context_window: r.contextWindow,
-      max_output_tokens: r.maxOutputTokens
-    })),
-    modelSearchQuery.value,
-    modelSearchMode.value
-  ).map((m) => normalizedRows.value.find((r) => r.modelId === m.model_id)!).filter(Boolean)
+  filterPricingCatalogByModel(normalizedRows.value, modelSearchQuery.value, modelSearchMode.value)
 )
 
 const hasCacheColumns = computed(() =>
@@ -779,15 +773,36 @@ async function loadMyCatalog(): Promise<void> {
     params.apiKeyId = selectedKeyId.value
   }
   myCatalog.value = await getMePricingCatalog(params)
-  // Sync the picker selections to whatever the backend resolved.
-  if (myCatalog.value) {
-    if (selectedKeyId.value === 0 && myCatalog.value.my_keys.length > 0) {
-      const matchingKey = myCatalog.value.my_keys.find(
-        (k) => k.group_id === myCatalog.value!.target_group.id
-      )
-      selectedKeyId.value = matchingKey?.id ?? myCatalog.value.my_keys[0].id
-    }
-  }
+}
+
+/**
+ * `displayKeyId` is the value the key-picker shows. Derived (never written
+ * back into selectedKeyId by the loader) to avoid the watch-loop where a
+ * post-load writeback fires another fetch. User picks are explicit via
+ * onPickKey — no implicit reactive ping-pong.
+ */
+const displayKeyId = computed<number>(() => {
+  if (selectedKeyId.value > 0) return selectedKeyId.value
+  if (!myCatalog.value || myCatalog.value.my_keys.length === 0) return 0
+  const tgID = myCatalog.value.target_group.id
+  const match = myCatalog.value.my_keys.find((k) => k.group_id === tgID)
+  return match?.id ?? myCatalog.value.my_keys[0].id
+})
+
+function onPickKey(e: Event): void {
+  const next = Number((e.target as HTMLSelectElement).value)
+  if (!Number.isFinite(next) || next <= 0) return
+  selectedKeyId.value = next
+  // Switching key clears any explore-group override.
+  selectedGroupId.value = 0
+  void load()
+}
+
+function onPickGroup(e: Event): void {
+  const next = Number((e.target as HTMLSelectElement).value)
+  if (!Number.isFinite(next) || next < 0) return
+  selectedGroupId.value = next
+  void load()
 }
 
 async function load(): Promise<void> {
@@ -810,21 +825,6 @@ async function load(): Promise<void> {
 function reload(): void {
   void load()
 }
-
-// Reload when key or group selection changes.
-watch(selectedKeyId, (next, prev) => {
-  if (viewMode.value !== 'my' || next === prev) return
-  if (next > 0) {
-    // Switching key clears any explore-group override.
-    selectedGroupId.value = 0
-    void load()
-  }
-})
-
-watch(selectedGroupId, (next, prev) => {
-  if (viewMode.value !== 'my' || next === prev) return
-  void load()
-})
 
 onMounted(() => {
   if (canShowMyView.value) {

--- a/frontend/src/views/PricingView.vue
+++ b/frontend/src/views/PricingView.vue
@@ -36,13 +36,13 @@
           <h1
             class="text-3xl font-bold tracking-tight text-gray-900 dark:text-white sm:text-4xl"
           >
-            {{ t('pricing.title') }}
+            {{ heroTitle }}
           </h1>
           <p class="mt-3 text-base text-gray-600 dark:text-dark-300">
-            {{ t('pricing.subtitle') }}
+            {{ heroSubtitle }}
           </p>
           <p class="mx-auto mt-4 max-w-3xl text-sm text-gray-500 dark:text-dark-400">
-            {{ t('pricing.description') }}
+            {{ heroDescription }}
           </p>
           <div
             v-if="bonusCtaVisible"
@@ -56,10 +56,102 @@
             </router-link>
             <p class="text-xs text-gray-600 dark:text-dark-400">{{ t('pricing.ctaBonusHint') }}</p>
           </div>
+
+          <!-- Segmented view switch: 我的菜单 / 公开目录. Only shown when logged in. -->
+          <div v-if="canShowMyView" class="mt-6 flex justify-center">
+            <div
+              role="tablist"
+              class="inline-flex rounded-xl border border-gray-200 bg-white/80 p-1 shadow-sm dark:border-dark-700 dark:bg-dark-900/70"
+            >
+              <button
+                v-for="opt in viewOptions"
+                :key="opt.value"
+                role="tab"
+                :aria-selected="viewMode === opt.value"
+                type="button"
+                class="rounded-lg px-4 py-1.5 text-sm font-medium transition-colors"
+                :class="
+                  viewMode === opt.value
+                    ? 'bg-primary-600 text-white shadow-sm dark:bg-primary-500'
+                    : 'text-gray-600 hover:text-primary-700 dark:text-dark-300 dark:hover:text-primary-200'
+                "
+                @click="setView(opt.value)"
+              >
+                {{ opt.label }}
+              </button>
+            </div>
+          </div>
         </div>
       </div>
 
       <div class="mx-auto flex min-h-0 w-full max-w-[90rem] flex-1 flex-col">
+        <!-- "我的菜单" toolbar: key picker + group switcher + banner -->
+        <div
+          v-if="viewMode === 'my' && !loading && !errorMessage && myCatalog"
+          class="mb-4 flex flex-col gap-3"
+        >
+          <div
+            class="flex flex-col gap-3 rounded-2xl border border-gray-200 bg-white/80 px-4 py-3 shadow-sm dark:border-dark-800 dark:bg-dark-900/70 sm:flex-row sm:items-center sm:justify-between"
+          >
+            <div class="flex flex-col gap-1 sm:flex-row sm:items-center sm:gap-3">
+              <label
+                v-if="myCatalog.my_keys.length > 0"
+                class="flex items-center gap-2 text-sm text-gray-700 dark:text-dark-200"
+              >
+                <span class="font-medium">{{ t('pricing.my.pickerKey') }}</span>
+                <select
+                  v-model.number="selectedKeyId"
+                  class="rounded-lg border border-gray-200 bg-white px-3 py-1.5 text-sm dark:border-dark-700 dark:bg-dark-900 dark:text-white"
+                >
+                  <option
+                    v-for="k in myCatalog.my_keys"
+                    :key="k.id"
+                    :value="k.id"
+                  >
+                    {{ k.name }} · {{ k.group_name }}
+                  </option>
+                </select>
+              </label>
+              <span
+                v-else
+                class="text-sm text-gray-500 dark:text-dark-400"
+              >
+                {{ t('pricing.my.noKeyHint') }}
+              </span>
+            </div>
+            <label class="flex items-center gap-2 text-sm text-gray-700 dark:text-dark-200">
+              <span>{{ t('pricing.my.pickerCompare') }}</span>
+              <select
+                v-model.number="selectedGroupId"
+                class="rounded-lg border border-gray-200 bg-white px-3 py-1.5 text-sm dark:border-dark-700 dark:bg-dark-900 dark:text-white"
+              >
+                <option :value="0">{{ t('pricing.my.compareDefault') }}</option>
+                <option
+                  v-for="g in groupsForComparison"
+                  :key="g.id"
+                  :value="g.id"
+                >
+                  {{ g.name }}{{ formatGroupRateBadge(g) }}
+                </option>
+              </select>
+            </label>
+          </div>
+
+          <!-- Banner: exploring a group the user doesn't have a key in -->
+          <div
+            v-if="exploreBanner"
+            class="flex flex-col gap-2 rounded-2xl border border-primary-200 bg-primary-50/80 px-4 py-3 text-sm text-primary-900 shadow-sm dark:border-primary-900/50 dark:bg-primary-950/40 dark:text-primary-200 sm:flex-row sm:items-center sm:justify-between"
+          >
+            <p>{{ exploreBanner.message }}</p>
+            <router-link
+              :to="exploreBanner.ctaTo"
+              class="inline-flex items-center justify-center rounded-lg bg-primary-600 px-3.5 py-1.5 text-xs font-semibold text-white shadow-sm transition hover:bg-primary-700 dark:bg-primary-500 dark:hover:bg-primary-600"
+            >
+              {{ exploreBanner.ctaLabel }}
+            </router-link>
+          </div>
+        </div>
+
         <div
           v-if="loading"
           class="flex items-center justify-center rounded-2xl bg-white/80 py-24 shadow-sm backdrop-blur dark:bg-dark-900/60"
@@ -85,7 +177,7 @@
           <button
             type="button"
             class="mt-5 inline-flex items-center gap-1.5 rounded-lg border border-red-300 bg-white px-4 py-2 text-sm font-medium text-red-700 transition-colors hover:bg-red-100 dark:border-red-800 dark:bg-red-950/60 dark:text-red-200 dark:hover:bg-red-900/60"
-            @click="loadCatalog"
+            @click="reload"
           >
             <Icon name="refresh" size="sm" />
             {{ t('pricing.retry') }}
@@ -93,15 +185,15 @@
         </div>
 
         <div
-          v-else-if="!catalog || catalog.data.length === 0"
+          v-else-if="normalizedRows.length === 0 && !hasFilterActive"
           class="rounded-2xl border border-dashed border-gray-300 bg-white/60 p-12 text-center dark:border-dark-700 dark:bg-dark-900/40"
         >
           <Icon name="inbox" size="xl" class="mx-auto text-gray-400 dark:text-dark-500" />
           <h2 class="mt-4 text-lg font-semibold text-gray-800 dark:text-dark-100">
-            {{ t('pricing.empty.title') }}
+            {{ emptyTitle }}
           </h2>
           <p class="mt-2 text-sm text-gray-500 dark:text-dark-400">
-            {{ t('pricing.empty.hint') }}
+            {{ emptyHint }}
           </p>
         </div>
 
@@ -145,7 +237,7 @@
                 v-if="modelSearchQuery.trim()"
                 class="text-xs tabular-nums text-gray-500 dark:text-dark-400"
               >
-                {{ t('pricing.search.resultCount', { count: filteredCatalogRows.length }) }}
+                {{ t('pricing.search.resultCount', { count: filteredRows.length }) }}
               </span>
             </div>
           </div>
@@ -155,7 +247,7 @@
             {{ t('pricing.tableHint') }}
           </p>
           <div
-            v-if="filteredCatalogRows.length === 0 && modelSearchQuery.trim()"
+            v-if="filteredRows.length === 0 && modelSearchQuery.trim()"
             class="border-t border-gray-100 px-4 py-12 text-center dark:border-dark-800"
           >
             <Icon name="inbox" size="xl" class="mx-auto text-gray-400 dark:text-dark-500" />
@@ -186,13 +278,13 @@
                       scope="col"
                       class="sticky top-0 z-40 bg-gray-50 px-3 py-3 text-right text-xs font-semibold uppercase tracking-wider text-gray-500 dark:bg-dark-800/60 dark:text-dark-300"
                     >
-                      {{ t('pricing.columns.input') }}
+                      {{ inputColumnTitle }}
                     </th>
                     <th
                       scope="col"
                       class="sticky top-0 z-40 bg-gray-50 px-3 py-3 text-right text-xs font-semibold uppercase tracking-wider text-gray-500 dark:bg-dark-800/60 dark:text-dark-300"
                     >
-                      {{ t('pricing.columns.output') }}
+                      {{ outputColumnTitle }}
                     </th>
                     <th
                       v-if="hasCacheColumns"
@@ -233,55 +325,64 @@
                   class="divide-y divide-gray-100 bg-white dark:divide-dark-800/60 dark:bg-dark-900"
                 >
                   <tr
-                    v-for="model in filteredCatalogRows"
-                    :key="model.model_id"
+                    v-for="row in filteredRows"
+                    :key="row.modelId"
                     class="group hover:bg-primary-50/30 dark:hover:bg-dark-800/40"
                   >
                     <td
                       class="sticky left-0 z-10 min-w-[14rem] max-w-[28rem] border-r border-gray-200 bg-white px-3 py-3 align-top font-mono text-sm leading-snug text-gray-900 shadow-[4px_0_12px_-8px_rgba(0,0,0,0.12)] break-words group-hover:bg-primary-50/30 dark:border-dark-700 dark:bg-dark-900 dark:text-white dark:shadow-[4px_0_12px_-8px_rgba(0,0,0,0.45)] dark:group-hover:bg-dark-800/40"
                     >
-                      {{ model.model_id }}
+                      {{ row.modelId }}
+                      <span
+                        v-if="row.billingMode && row.billingMode !== 'token'"
+                        class="ml-1 inline-flex items-center rounded-md bg-amber-50 px-1.5 py-0.5 text-[10px] font-medium text-amber-800 dark:bg-amber-900/30 dark:text-amber-200"
+                      >
+                        {{ formatBillingMode(row.billingMode) }}
+                      </span>
                     </td>
                     <td
                       class="min-w-[7rem] px-3 py-3 align-top text-sm leading-snug text-gray-600 break-words dark:text-dark-300"
                     >
-                      {{ model.vendor || '—' }}
+                      {{ row.vendor || '—' }}
                     </td>
                     <td class="whitespace-nowrap px-3 py-3 text-right text-sm tabular-nums text-gray-900 dark:text-white">
-                      {{ formatPrice(model.pricing.input_per_1k_tokens) }}
-                      <span class="ml-0.5 text-xs text-gray-400">{{
-                        t('pricing.perThousandTokens')
-                      }}</span>
+                      <template v-if="row.billingMode === 'per_request' && row.perRequest != null">
+                        {{ formatPrice(row.perRequest) }}
+                        <span class="ml-0.5 text-xs text-gray-400">{{ t('pricing.perRequest') }}</span>
+                      </template>
+                      <template v-else-if="row.inputPer1K != null">
+                        {{ formatPrice(row.inputPer1K) }}
+                        <span class="ml-0.5 text-xs text-gray-400">{{
+                          t('pricing.perThousandTokens')
+                        }}</span>
+                      </template>
+                      <template v-else>—</template>
                     </td>
                     <td class="whitespace-nowrap px-3 py-3 text-right text-sm tabular-nums text-gray-900 dark:text-white">
-                      {{ formatPrice(model.pricing.output_per_1k_tokens) }}
-                      <span class="ml-0.5 text-xs text-gray-400">{{
-                        t('pricing.perThousandTokens')
-                      }}</span>
+                      <template v-if="row.billingMode === 'per_request'">—</template>
+                      <template v-else-if="row.outputPer1K != null">
+                        {{ formatPrice(row.outputPer1K) }}
+                        <span class="ml-0.5 text-xs text-gray-400">{{
+                          t('pricing.perThousandTokens')
+                        }}</span>
+                      </template>
+                      <template v-else>—</template>
                     </td>
                     <td
                       v-if="hasCacheColumns"
                       class="whitespace-nowrap px-3 py-3 text-right text-sm tabular-nums text-gray-700 dark:text-dark-200"
                     >
-                      {{
-                        model.pricing.cache_read_per_1k != null
-                          ? formatPrice(model.pricing.cache_read_per_1k)
-                          : '—'
-                      }}
+                      {{ row.cacheReadPer1K != null ? formatPrice(row.cacheReadPer1K) : '—' }}
                     </td>
                     <td
                       v-if="hasCacheColumns"
                       class="whitespace-nowrap px-3 py-3 text-right text-sm tabular-nums text-gray-700 dark:text-dark-200"
                     >
-                      {{
-                        model.pricing.cache_write_per_1k != null
-                          ? formatPrice(model.pricing.cache_write_per_1k)
-                          : '—'
-                      }}
+                      {{ row.cacheWritePer1K != null ? formatPrice(row.cacheWritePer1K) : '—' }}
                     </td>
                     <td class="whitespace-nowrap px-3 py-3 text-right text-sm tabular-nums text-gray-600 dark:text-dark-300">
-                      <template v-if="model.context_window && model.context_window > 0">
-                        {{ formatNumber(model.context_window) }}
+                      <template v-if="row.contextWindow && row.contextWindow > 0">
+                        {{ formatNumber(row.contextWindow) }}
                       </template>
                       <template v-else>—</template>
                     </td>
@@ -289,22 +390,22 @@
                       v-if="hasMaxOutputColumn"
                       class="whitespace-nowrap px-3 py-3 text-right text-sm tabular-nums text-gray-600 dark:text-dark-300"
                     >
-                      <template v-if="model.max_output_tokens && model.max_output_tokens > 0">
-                        {{ formatNumber(model.max_output_tokens) }}
+                      <template v-if="row.maxOutputTokens && row.maxOutputTokens > 0">
+                        {{ formatNumber(row.maxOutputTokens) }}
                       </template>
                       <template v-else>—</template>
                     </td>
                     <td class="px-3 py-3 align-top">
                       <div class="flex flex-wrap gap-1">
                         <span
-                          v-for="cap in model.capabilities"
+                          v-for="cap in row.capabilities"
                           :key="cap"
                           class="inline-flex items-center rounded-full bg-primary-50 px-2 py-0.5 text-xs font-medium text-primary-700 dark:bg-primary-900/30 dark:text-primary-300"
                         >
                           {{ cap }}
                         </span>
                         <span
-                          v-if="!model.capabilities || model.capabilities.length === 0"
+                          v-if="!row.capabilities || row.capabilities.length === 0"
                           class="text-xs text-gray-400"
                           >—</span
                         >
@@ -321,14 +422,17 @@
                 <template v-if="modelSearchQuery.trim()">
                   {{
                     t('pricing.footer.filtered', {
-                      shown: filteredCatalogRows.length,
-                      total: catalogRowTotal
+                      shown: filteredRows.length,
+                      total: rowTotal
                     })
                   }}
                 </template>
                 <template v-else>
-                  {{ t('pricing.footer.total', { count: catalogRowTotal }) }}
+                  {{ t('pricing.footer.total', { count: rowTotal }) }}
                 </template>
+                <span v-if="rateHint" class="ml-2 text-gray-600 dark:text-dark-300">
+                  · {{ rateHint }}
+                </span>
               </p>
               <p class="text-left sm:text-right">
                 {{ t('pricing.updatedAt', { time: formattedUpdatedAt }) }}
@@ -343,18 +447,30 @@
 
 <script setup lang="ts">
 /**
- * Public model + pricing catalog page.
+ * Model + pricing catalog page.
  *
- * Backed by GET /api/v1/public/pricing (no auth required). Renders an empty
- * state when the catalog is unavailable (US-028 AC-005) and a 404 navigation
- * (handled by the API client) when the admin has flipped
- * `pricing_catalog_public = false`.
+ * Two views share the same URL `/pricing`:
+ *  - Public view (unauthenticated default): GET /api/v1/public/pricing returns
+ *    the platform-wide LiteLLM list-price catalog. Behaves per US-028 AC-005
+ *    (empty when source unavailable; 404 when admin disabled public catalog).
+ *  - "我的菜单" view (authenticated default when accessible groups exist):
+ *    GET /api/v1/me/pricing-catalog returns models scoped to the user's
+ *    selected key's group, with prices already multiplied by their effective
+ *    rate (group default × per-user override). The user can switch keys or
+ *    explore other accessible groups for upgrade comparison.
  *
- * docs/approved/user-cold-start.md §2 (v1 MVP).
+ * Both feed a single normalized row shape so the table markup stays identical
+ * between modes — this is by design; the v1 trade-off accepted in
+ * /Users/xuejiao/.claude/plans/bubbly-bouncing-sunbeam.md.
  */
-import { computed, onMounted, ref } from 'vue'
+import { computed, onMounted, ref, watch } from 'vue'
 import { useI18n } from 'vue-i18n'
 import { getPublicPricing, type PublicCatalogResponse } from '@/api/pricing'
+import {
+  getMePricingCatalog,
+  type MePricingCatalogResponse,
+  type MePricingGroupRef
+} from '@/api/me-pricing'
 import Icon from '@/components/icons/Icon.vue'
 import LocaleSwitcher from '@/components/common/LocaleSwitcher.vue'
 import { useAuthStore } from '@/stores/auth'
@@ -368,6 +484,23 @@ import {
 const { t } = useI18n()
 const authStore = useAuthStore()
 const appStore = useAppStore()
+
+type ViewMode = 'my' | 'public'
+
+/** Internal row shape — single source of truth for the shared table markup. */
+interface NormalizedRow {
+  modelId: string
+  vendor: string
+  inputPer1K: number | null
+  outputPer1K: number | null
+  cacheReadPer1K: number | null
+  cacheWritePer1K: number | null
+  contextWindow: number
+  maxOutputTokens: number
+  capabilities: string[]
+  billingMode?: string
+  perRequest?: number | null
+}
 
 const signupBonusFormatted = computed(() =>
   formatCurrency(appStore.cachedPublicSettings?.signup_bonus_balance_usd ?? 0, 'USD')
@@ -399,53 +532,206 @@ const consoleLinkTitle = computed(() =>
   authStore.isAuthenticated ? t('pricing.nav.consoleTitleAuthed') : t('pricing.nav.consoleTitleGuest')
 )
 
-const catalog = ref<PublicCatalogResponse | null>(null)
+// ============================== view-state ==============================
+
+const viewMode = ref<ViewMode>('public')
 const loading = ref(true)
 const errorMessage = ref('')
 const modelSearchQuery = ref('')
 const modelSearchMode = ref<PricingCatalogSearchMode>('fuzzy')
 
-const filteredCatalogRows = computed(() => {
-  if (!catalog.value) return []
-  return filterPricingCatalogByModel(
-    catalog.value.data,
+// Public catalog state (unchanged from v1 — US-028 backing data).
+const publicCatalog = ref<PublicCatalogResponse | null>(null)
+
+// My catalog state.
+const myCatalog = ref<MePricingCatalogResponse | null>(null)
+const selectedKeyId = ref<number>(0)
+const selectedGroupId = ref<number>(0)
+
+const canShowMyView = computed(() => authStore.isAuthenticated)
+
+const viewOptions = computed(() => [
+  { value: 'my' as ViewMode, label: t('pricing.my.tabMy') },
+  { value: 'public' as ViewMode, label: t('pricing.my.tabPublic') }
+])
+
+function setView(next: ViewMode): void {
+  if (next === viewMode.value) return
+  viewMode.value = next
+  modelSearchQuery.value = ''
+  void load()
+}
+
+// ============================== hero copy ==============================
+
+const heroTitle = computed(() =>
+  viewMode.value === 'my' ? t('pricing.my.title') : t('pricing.title')
+)
+const heroSubtitle = computed(() =>
+  viewMode.value === 'my' ? t('pricing.my.subtitle') : t('pricing.subtitle')
+)
+const heroDescription = computed(() =>
+  viewMode.value === 'my' ? t('pricing.my.description') : t('pricing.description')
+)
+
+const inputColumnTitle = computed(() =>
+  viewMode.value === 'my' ? t('pricing.my.columns.input') : t('pricing.columns.input')
+)
+const outputColumnTitle = computed(() =>
+  viewMode.value === 'my' ? t('pricing.my.columns.output') : t('pricing.columns.output')
+)
+
+// ============================== normalize ==============================
+
+const normalizedRows = computed<NormalizedRow[]>(() => {
+  if (viewMode.value === 'public') {
+    if (!publicCatalog.value) return []
+    return publicCatalog.value.data.map((m) => ({
+      modelId: m.model_id,
+      vendor: m.vendor ?? '',
+      inputPer1K: m.pricing.input_per_1k_tokens ?? null,
+      outputPer1K: m.pricing.output_per_1k_tokens ?? null,
+      cacheReadPer1K: m.pricing.cache_read_per_1k ?? null,
+      cacheWritePer1K: m.pricing.cache_write_per_1k ?? null,
+      contextWindow: m.context_window ?? 0,
+      maxOutputTokens: m.max_output_tokens ?? 0,
+      capabilities: m.capabilities ?? [],
+      billingMode: 'token',
+      perRequest: null
+    }))
+  }
+  // 'my' view
+  if (!myCatalog.value) return []
+  return myCatalog.value.models.map((m) => ({
+    modelId: m.model_id,
+    vendor: m.vendor ?? '',
+    inputPer1K: m.your_price.input_per_1k ?? null,
+    outputPer1K: m.your_price.output_per_1k ?? null,
+    cacheReadPer1K: m.your_price.cache_read_per_1k ?? null,
+    cacheWritePer1K: m.your_price.cache_write_per_1k ?? null,
+    contextWindow: m.context_window ?? 0,
+    maxOutputTokens: m.max_output_tokens ?? 0,
+    capabilities: m.capabilities ?? [],
+    billingMode: m.billing_mode,
+    perRequest: m.your_price.per_request ?? null
+  }))
+})
+
+const filteredRows = computed(() =>
+  filterPricingCatalogByModel(
+    normalizedRows.value.map((r) => ({
+      model_id: r.modelId,
+      vendor: r.vendor,
+      pricing: {
+        currency: 'USD',
+        input_per_1k_tokens: r.inputPer1K ?? 0,
+        output_per_1k_tokens: r.outputPer1K ?? 0
+      },
+      capabilities: r.capabilities,
+      context_window: r.contextWindow,
+      max_output_tokens: r.maxOutputTokens
+    })),
     modelSearchQuery.value,
     modelSearchMode.value
+  ).map((m) => normalizedRows.value.find((r) => r.modelId === m.model_id)!).filter(Boolean)
+)
+
+const hasCacheColumns = computed(() =>
+  normalizedRows.value.some(
+    (r) => (r.cacheReadPer1K != null && r.cacheReadPer1K > 0) ||
+           (r.cacheWritePer1K != null && r.cacheWritePer1K > 0)
   )
+)
+
+const hasMaxOutputColumn = computed(() =>
+  normalizedRows.value.some((r) => r.maxOutputTokens > 0)
+)
+
+const rowTotal = computed(() => normalizedRows.value.length)
+const hasFilterActive = computed(() => modelSearchQuery.value.trim().length > 0)
+
+// ============================== empty-state copy ==============================
+
+const emptyTitle = computed(() => {
+  if (viewMode.value === 'my' && myCatalog.value) {
+    return myCatalog.value.my_keys.length === 0 && myCatalog.value.accessible_groups.length === 0
+      ? t('pricing.my.empty.noAccess.title')
+      : t('pricing.my.empty.noModels.title')
+  }
+  return t('pricing.empty.title')
 })
 
-const hasCacheColumns = computed(() => {
-  if (!catalog.value) return false
-  return catalog.value.data.some(
-    (m) =>
-      (m.pricing.cache_read_per_1k != null && m.pricing.cache_read_per_1k > 0) ||
-      (m.pricing.cache_write_per_1k != null && m.pricing.cache_write_per_1k > 0)
-  )
+const emptyHint = computed(() => {
+  if (viewMode.value === 'my' && myCatalog.value) {
+    return myCatalog.value.my_keys.length === 0 && myCatalog.value.accessible_groups.length === 0
+      ? t('pricing.my.empty.noAccess.hint')
+      : t('pricing.my.empty.noModels.hint')
+  }
+  return t('pricing.empty.hint')
 })
 
-/** Show column when catalog has max-output metadata (often unset for slim entries). */
-const hasMaxOutputColumn = computed(() => {
-  if (!catalog.value) return false
-  return catalog.value.data.some((m) => (m.max_output_tokens ?? 0) > 0)
-})
-
-/** Footer total row count (full catalog, not filtered). */
-const catalogRowTotal = computed(() => catalog.value?.data.length ?? 0)
+// ============================== updated-at ==============================
 
 const formattedUpdatedAt = computed(() => {
-  if (!catalog.value?.updated_at) return ''
+  const raw =
+    viewMode.value === 'my'
+      ? myCatalog.value?.updated_at
+      : publicCatalog.value?.updated_at
+  if (!raw) return ''
   try {
-    return new Date(catalog.value.updated_at).toLocaleString()
+    return new Date(raw).toLocaleString()
   } catch {
-    return catalog.value.updated_at
+    return raw
   }
 })
 
-/** Lock main to viewport height when the catalog table is shown so nav + hero stay fixed and only the grid scrolls. */
-const pricingCatalogScrollMode = computed(() => {
-  if (loading.value || errorMessage.value) return false
-  return Boolean(catalog.value && catalog.value.data.length > 0)
+// ============================== rate-hint ==============================
+
+const rateHint = computed(() => {
+  if (viewMode.value !== 'my' || !myCatalog.value) return ''
+  const tg = myCatalog.value.target_group
+  const rate = tg.rate_multiplier
+  if (rate === 1 && !tg.has_override) return ''
+  const fmt = rate === 0 ? '×0' : `×${rate}`
+  const suffix = tg.has_override ? ` (${t('pricing.my.rateOverride')})` : ''
+  return t('pricing.my.rateHint', { multiplier: fmt }) + suffix
 })
+
+// ============================== group switcher ==============================
+
+const groupsForComparison = computed<MePricingGroupRef[]>(() => {
+  if (!myCatalog.value) return []
+  return myCatalog.value.accessible_groups
+})
+
+function formatGroupRateBadge(g: MePricingGroupRef): string {
+  if (g.rate_multiplier === 1) return ''
+  return ` · ×${g.rate_multiplier}`
+}
+
+interface ExploreBanner {
+  message: string
+  ctaLabel: string
+  ctaTo: { path: string; query?: Record<string, string> }
+}
+
+const exploreBanner = computed<ExploreBanner | null>(() => {
+  if (viewMode.value !== 'my' || !myCatalog.value) return null
+  const tg = myCatalog.value.target_group
+  const currentKeysInTarget = myCatalog.value.my_keys.some((k) => k.group_id === tg.id)
+  if (currentKeysInTarget) return null
+  // User is viewing a group they don't hold a key in → upgrade-CTA banner.
+  return {
+    message: t('pricing.my.exploreBanner.message', {
+      group: tg.name,
+      multiplier: tg.rate_multiplier
+    }),
+    ctaLabel: t('pricing.my.exploreBanner.cta', { group: tg.name }),
+    ctaTo: { path: '/dashboard/keys', query: { group_id: String(tg.id) } }
+  }
+})
+
+// ============================== misc formatters ==============================
 
 function formatPrice(value: number): string {
   if (!Number.isFinite(value)) return '—'
@@ -459,27 +745,92 @@ function formatNumber(value: number): string {
   return new Intl.NumberFormat().format(value)
 }
 
-async function loadCatalog(): Promise<void> {
-  loading.value = true
-  errorMessage.value = ''
+function formatBillingMode(mode: string): string {
+  return t(`pricing.my.billingMode.${mode}`, mode)
+}
+
+// ============================== layout ==============================
+
+const pricingCatalogScrollMode = computed(() => {
+  if (loading.value || errorMessage.value) return false
+  return rowTotal.value > 0
+})
+
+// ============================== loaders ==============================
+
+async function loadPublicCatalog(): Promise<void> {
   try {
-    catalog.value = await getPublicPricing()
+    publicCatalog.value = await getPublicPricing()
   } catch (err) {
     const apiErr = err as { status?: number; message?: string }
     if (apiErr.status === 404) {
-      // Admin disabled the public catalog; treat as "empty" rather than error
-      // so the page still renders cleanly when the entry leaks through cache.
-      catalog.value = { object: 'list', data: [], updated_at: '' }
+      publicCatalog.value = { object: 'list', data: [], updated_at: '' }
     } else {
-      errorMessage.value = apiErr.message || 'Network error'
+      throw err
     }
+  }
+}
+
+async function loadMyCatalog(): Promise<void> {
+  const params: { apiKeyId?: number; groupId?: number } = {}
+  if (selectedGroupId.value > 0) {
+    params.groupId = selectedGroupId.value
+  } else if (selectedKeyId.value > 0) {
+    params.apiKeyId = selectedKeyId.value
+  }
+  myCatalog.value = await getMePricingCatalog(params)
+  // Sync the picker selections to whatever the backend resolved.
+  if (myCatalog.value) {
+    if (selectedKeyId.value === 0 && myCatalog.value.my_keys.length > 0) {
+      const matchingKey = myCatalog.value.my_keys.find(
+        (k) => k.group_id === myCatalog.value!.target_group.id
+      )
+      selectedKeyId.value = matchingKey?.id ?? myCatalog.value.my_keys[0].id
+    }
+  }
+}
+
+async function load(): Promise<void> {
+  loading.value = true
+  errorMessage.value = ''
+  try {
+    if (viewMode.value === 'my') {
+      await loadMyCatalog()
+    } else {
+      await loadPublicCatalog()
+    }
+  } catch (err) {
+    const apiErr = err as { message?: string }
+    errorMessage.value = apiErr.message || 'Network error'
   } finally {
     loading.value = false
   }
 }
 
+function reload(): void {
+  void load()
+}
+
+// Reload when key or group selection changes.
+watch(selectedKeyId, (next, prev) => {
+  if (viewMode.value !== 'my' || next === prev) return
+  if (next > 0) {
+    // Switching key clears any explore-group override.
+    selectedGroupId.value = 0
+    void load()
+  }
+})
+
+watch(selectedGroupId, (next, prev) => {
+  if (viewMode.value !== 'my' || next === prev) return
+  void load()
+})
+
 onMounted(() => {
-  loadCatalog()
+  if (canShowMyView.value) {
+    viewMode.value = 'my'
+  }
+  void load()
   void appStore.fetchPublicSettings()
 })
 </script>

--- a/frontend/src/views/__tests__/PricingView.spec.ts
+++ b/frontend/src/views/__tests__/PricingView.spec.ts
@@ -3,20 +3,24 @@ import { flushPromises, mount } from '@vue/test-utils'
 
 import PricingView from '../PricingView.vue'
 import type { PublicCatalogResponse } from '@/api/pricing'
+import type { MePricingCatalogResponse } from '@/api/me-pricing'
 
-const { getPublicPricing } = vi.hoisted(() => ({
+const { getPublicPricing, getMePricingCatalog, authState } = vi.hoisted(() => ({
   getPublicPricing: vi.fn(),
+  getMePricingCatalog: vi.fn(),
+  authState: { isAuthenticated: false, isAdmin: false },
 }))
 
 vi.mock('@/api/pricing', () => ({
   getPublicPricing,
 }))
 
+vi.mock('@/api/me-pricing', () => ({
+  getMePricingCatalog,
+}))
+
 vi.mock('@/stores/auth', () => ({
-  useAuthStore: () => ({
-    isAuthenticated: false,
-    isAdmin: false,
-  }),
+  useAuthStore: () => authState,
 }))
 
 vi.mock('@/stores/app', () => ({
@@ -61,7 +65,27 @@ vi.mock('vue-i18n', async () => {
     'pricing.search.modeExact': '',
     'pricing.tableHint': '',
     'pricing.search.noMatches': '',
-    'common.loading': 'Loading'
+    'common.loading': 'Loading',
+    'pricing.my.tabMy': 'Your Menu',
+    'pricing.my.tabPublic': 'Public Catalog',
+    'pricing.my.title': 'Your Model Menu',
+    'pricing.my.subtitle': '',
+    'pricing.my.description': '',
+    'pricing.my.pickerKey': 'Current key:',
+    'pricing.my.pickerCompare': 'Compare group:',
+    'pricing.my.compareDefault': 'Keep current',
+    'pricing.my.columns.input': 'Input (your price)',
+    'pricing.my.columns.output': 'Output (your price)',
+    'pricing.my.rateHint': 'Multiplier {multiplier} applied',
+    'pricing.my.rateOverride': 'includes personal override',
+    'pricing.my.empty.noModels.title': 'This group has no models yet',
+    'pricing.my.empty.noModels.hint': '',
+    'pricing.my.empty.noAccess.title': 'No accessible group',
+    'pricing.my.empty.noAccess.hint': '',
+    'pricing.my.exploreBanner.message': 'Viewing {group} catalog · ×{multiplier}',
+    'pricing.my.exploreBanner.cta': 'Create key in {group}',
+    'pricing.my.noKeyHint': '',
+    'pricing.perRequest': '/ request'
   }
   return {
     ...actual,
@@ -72,6 +96,8 @@ vi.mock('vue-i18n', async () => {
         base = base.replace(/\{shown\}/g, String(params?.shown ?? ''))
         base = base.replace(/\{total\}/g, String(params?.total ?? ''))
         base = base.replace(/\{time\}/g, String(params?.time ?? ''))
+        base = base.replace(/\{multiplier\}/g, String(params?.multiplier ?? ''))
+        base = base.replace(/\{group\}/g, String(params?.group ?? ''))
         return base
       },
     }),
@@ -81,6 +107,9 @@ vi.mock('vue-i18n', async () => {
 describe('PricingView', () => {
   beforeEach(() => {
     getPublicPricing.mockReset()
+    getMePricingCatalog.mockReset()
+    authState.isAuthenticated = false
+    authState.isAdmin = false
   })
 
   it('shows max output column when catalog includes max_output_tokens', async () => {
@@ -149,5 +178,70 @@ describe('PricingView', () => {
     await flushPromises()
 
     expect(wrapper.html()).toContain('max-w-[90rem]')
+  })
+
+  it('authenticated user defaults to "Your Menu" view with your_price applied', async () => {
+    authState.isAuthenticated = true
+    const me: MePricingCatalogResponse = {
+      target_group: {
+        id: 10,
+        name: 'Pro',
+        platform: 'newapi',
+        rate_multiplier: 1.5,
+        list_multiplier: 1.5,
+        has_override: false,
+        is_exclusive: false,
+        subscription_type: 'standard',
+      },
+      models: [
+        {
+          model_id: 'gpt-4o',
+          vendor: 'openai',
+          billing_mode: 'token',
+          your_price: {
+            currency: 'USD',
+            input_per_1k: 0.0045,
+            output_per_1k: 0.0225,
+          },
+          context_window: 128000,
+          max_output_tokens: 16384,
+          capabilities: ['vision'],
+        },
+      ],
+      my_keys: [{ id: 1, name: 'default', group_id: 10, group_name: 'Pro' }],
+      accessible_groups: [
+        {
+          id: 10,
+          name: 'Pro',
+          platform: 'newapi',
+          rate_multiplier: 1.5,
+          is_current_for_key: true,
+          is_exclusive: false,
+          subscription_type: 'standard',
+        },
+      ],
+      updated_at: '2026-05-20T10:00:00Z',
+    }
+    getMePricingCatalog.mockResolvedValue(me)
+
+    const wrapper = mount(PricingView, {
+      global: {
+        stubs: {
+          RouterLink: { template: '<a><slot /></a>' },
+          LocaleSwitcher: true,
+          Icon: true,
+        },
+      },
+    })
+    await flushPromises()
+
+    expect(getMePricingCatalog).toHaveBeenCalled()
+    expect(getPublicPricing).not.toHaveBeenCalled()
+    // Hero swaps to "Your Model Menu" copy.
+    expect(wrapper.text()).toContain('Your Model Menu')
+    // your_price applied — input 0.0045 → "$0.0045"
+    expect(wrapper.text()).toContain('$0.0045')
+    // Rate hint shown when multiplier != 1.
+    expect(wrapper.text()).toContain('Multiplier ×1.5 applied')
   })
 })

--- a/scripts/sentinels/frontend-tk.json
+++ b/scripts/sentinels/frontend-tk.json
@@ -199,9 +199,28 @@
         "stickyRouting: 'Prompt Cache Sticky Routing'",
         "anthropicCacheTTL1hInjection: 'Anthropic Cache TTL 1h Injection'",
         "providerAirwallex: 'Airwallex'",
-        "airwallex: 'Airwallex'"
+        "airwallex: 'Airwallex'",
+        "tabMy: 'Your Menu'",
+        "exploreBanner: {"
       ],
-      "rationale": "English admin settings labels must stay in sync with the global sticky and Anthropic Cache TTL 1h controls so upstream locale merges cannot silently regress one language while the template still compiles. The Airwallex provider/method labels are likewise load-bearing for admin payment setup and frontend method rendering."
+      "rationale": "English admin settings labels must stay in sync with the global sticky and Anthropic Cache TTL 1h controls so upstream locale merges cannot silently regress one language while the template still compiles. The Airwallex provider/method labels are likewise load-bearing for admin payment setup and frontend method rendering. The pricing 'Your Menu' i18n keys (tabMy, exploreBanner) anchor the per-key pricing catalog feature so an upstream locale merge cannot silently strip them and degrade the segmented control + upgrade-banner UI to raw keys."
+    },
+    {
+      "path": "frontend/src/i18n/locales/zh.ts",
+      "must_contain": [
+        "tabMy: '我的菜单'",
+        "exploreBanner: {"
+      ],
+      "rationale": "Chinese pricing 'Your Menu' i18n keys (tabMy, exploreBanner) must move in lockstep with the English copies above. An upstream merge that drops only one language leaves operators staring at raw `pricing.my.*` paths in either zh or en — a regression that compiles but visibly breaks the page."
+    },
+    {
+      "path": "frontend/src/views/PricingView.vue",
+      "must_contain": [
+        "getMePricingCatalog",
+        "viewMode.value = 'my'",
+        "v-if=\"viewMode === 'my' && !loading"
+      ],
+      "rationale": "PricingView.vue must keep the per-user 'Your Menu' branch wired: (1) calling getMePricingCatalog (otherwise the page only ever shows the public LiteLLM catalog), (2) defaulting authenticated users to viewMode='my' on mount, and (3) the v-if guard that gates the key-picker / group-switcher toolbar to the 'my' view. Dropping any one silently regresses to upstream-style flat-catalog behavior even though the segmented control still renders."
     }
   ]
 }

--- a/scripts/sentinels/gateway-tk.json
+++ b/scripts/sentinels/gateway-tk.json
@@ -681,6 +681,46 @@
         "passthrough must NOT write the upstream error to the client when the account was disabled"
       ],
       "rationale": "Focused regression anchor for upstream #1318: passthrough + temp-unsched rule match must (a) surface UpstreamFailoverError, (b) leave c.Writer untouched so the failover loop owns the response, and (c) tag the ops event with Kind=failover. Without this test, a future refactor of handleErrorResponsePassthrough could silently revert to discarding shouldDisable (the original upstream bug) and the regression would only show up in production when a temp-unsched rule is actually configured."
+    },
+    {
+      "path": "backend/internal/server/routes/user_tk_routes.go",
+      "must_contain": [
+        "authenticated.GET(\"/me/pricing-catalog\", h.MePricingCatalog.Get)"
+      ],
+      "rationale": "Per-user pricing-catalog route MUST stay wired inside the JWT-only authenticated group. Without this line GET /api/v1/me/pricing-catalog 404s, the UI segmented control silently falls back to the public catalog, and users lose the 'your menu' view that drives upgrade-decision conversions. Upstream merges of routes/user.go cannot touch this companion file but a sloppy edit could drop the registration; pinning the literal closes that gap."
+    },
+    {
+      "path": "backend/internal/service/wire.go",
+      "must_contain": [
+        "NewMePricingCatalogService"
+      ],
+      "rationale": "ProviderSet MUST register the per-user pricing-catalog service. Without it `wire` regen fails to satisfy the *MePricingCatalogService dependency in handler/wire.go and falls back to a nil handler (500 on /api/v1/me/pricing-catalog). The TK-only feature lives in service/me_pricing_catalog_tk.go but only this registration makes it reachable at runtime — easy to silently drop in an upstream merge of the ProviderSet."
+    },
+    {
+      "path": "backend/internal/handler/wire.go",
+      "must_contain": [
+        "NewMePricingCatalogHandler",
+        "MePricingCatalog: mePricingCatalogHandler"
+      ],
+      "rationale": "Handler ProviderSet + ProvideHandlers assignment for the per-user pricing-catalog endpoint. Two lines must both survive: the ProviderSet registration so wire can construct the handler, and the field assignment in ProvideHandlers so the runtime Handlers struct actually carries it (a missing assignment lets wire compile but silently leaves Handlers.MePricingCatalog nil → routes/user_tk_routes.go skips registration via its nil guard)."
+    },
+    {
+      "path": "backend/internal/service/me_pricing_catalog_tk.go",
+      "must_contain": [
+        "func (s *MePricingCatalogService) BuildForUser",
+        "ErrMePricingGroupForbidden",
+        "if m.Platform != targetGroup.Platform {"
+      ],
+      "rationale": "Per-user pricing-catalog service. Three load-bearing invariants pinned: (1) BuildForUser is the only entry point; renaming it silently breaks the handler. (2) ErrMePricingGroupForbidden is part of the documented error contract (403 mapping in handler) — losing the sentinel would let a refactor collapse it into a generic error and the handler would surface 500 instead. (3) The cross-platform leak guard (`m.Platform != targetGroup.Platform`) prevents an anthropic-platform model from bleeding into a newapi group's menu when a channel sits on groups across platforms; the same discipline is enforced in available_channel_handler.go and dropping it here would re-introduce the leak."
+    },
+    {
+      "path": "backend/internal/handler/me_pricing_catalog_handler_tk.go",
+      "must_contain": [
+        "middleware.GetAuthSubjectFromContext(c)",
+        "ErrMePricingGroupForbidden",
+        "ErrMePricingNoAccessibleGroups"
+      ],
+      "rationale": "Per-user pricing-catalog handler. Pinning the auth check and the two sentinel-error mappings catches the two most likely regressions: (a) dropping JWT enforcement (anyone could probe other users' menus), and (b) collapsing the error mapping so the UI's 'create a key' empty-state banner and 'group not accessible' forbidden message stop firing. The 200-with-empty-data fallback for ErrMePricingNoAccessibleGroups is intentional UI behavior — not an error suppression bug."
     }
   ]
 }


### PR DESCRIPTION
## Summary

Replaces the platform-wide pricing catalog at `/pricing` with two identity-aware views sharing the same URL:

- **Unauthenticated visitors**: existing public LiteLLM catalog (unchanged).
- **Authenticated users** (default): `GET /api/v1/me/pricing-catalog` returns the model menu scoped to the group of the user's selected API key, with **prices already multiplied by the effective rate** (group default × per-user override). A **key picker** + **accessible-group switcher** enable upgrade-comparison without leaving the page; a banner CTA jumps to key creation pre-selecting the explored group.

### Why
1. Today's `/pricing` answers "what does the platform sell?" but a user holding `sk-...` actually wants to know "what can MY key call, and at what price MY account is charged?"
2. Catalog list prices ≠ user's billed prices once `rate_multiplier` × `user_group_rate` overrides apply. Surface the math, don't ask the user to do it.
3. The same surface becomes the natural upgrade-conversion path: peek into a higher-tier group before committing.

### Design
- No Ent schema changes — feature is a pure read-side join of two existing services:
  - `ChannelService.ListAvailable` → which models the target group can call + raw channel pricing
  - `PricingCatalogService.BuildPublicCatalog` → LiteLLM capabilities, context window, max output
- New service `MePricingCatalogService` (TK-only, `*_tk.go`) owns the join, applies the effective multiplier, dedupes multi-channel collisions to the cheapest priced row, and enforces the cross-platform leak guard (mirrors `available_channel_handler.go`).
- New JWT-only handler at `GET /api/v1/me/pricing-catalog`; not gated by `pricing_catalog_public` (that flag only governs the public unauth endpoint).
- Frontend extends existing TK-only `PricingView.vue` with a segmented control + pickers; shared table markup via a normalized row shape (no premature component extraction).

### Edge cases handled (covered by 18 unit tests + 8 handler tests)
- Per-user `user_group_rate` override layered above group default.
- `rate == 0` legitimate "free subscription" → emits `$0`, not short-circuited.
- API key with no group binding → skipped in picker.
- Cross-platform channel (e.g. `newapi` group with anthropic models) → models filtered to target group's platform.
- Multi-channel same model → cheapest input+output wins; nil prices lose to priced.
- Catalog source unavailable → models still listed with empty capabilities.
- Forbidden group / conflicting api_key_id+group_id → 403 / 400.
- User has no accessible groups → 200 + empty arrays so UI shows "create a key" banner without an error toast.

### Upstream isolation (CLAUDE.md §5)
- All new Go files are `*_tk_*.go` companions.
- Frontend: new `me-pricing.ts` API client; `PricingView.vue` is already TK-only.
- Only upstream-shaped touches are wire glue + 1 route registration; all anchored by new entries in `scripts/sentinels/gateway-tk.json` + `scripts/sentinels/frontend-tk.json` so future upstream merges that drop them fail preflight loudly.
- Commit carries `upstream-touch-guarded` marker per §5.y.1.

## §5.y audit cadence

```
git log --oneline upstream/main..HEAD | wc -l → 290
```

Top changed files vs upstream:
```
backend/internal/service/setting_service.go        |  1456 +-
backend/internal/service/notification_email_service.go | 1347 --
backend/internal/handler/auth_dingtalk_oauth.go    |  1066 --
backend/internal/observability/qa/service.go       |   969 ++
backend/internal/service/openai_gateway_service.go |   909 +-
```

(This PR's own contribution is +2148 / -98 across 17 files — small relative to the TK-ahead delta.)

## Test plan
- [x] `go test -tags=unit ./internal/service/... -run MePricing` (18 cases pass)
- [x] `go test -tags=unit ./internal/handler/... -run MePricingHandler` (8 cases pass)
- [x] `go test -tags=unit ./...` (full service+handler suites green)
- [x] `golangci-lint run ./internal/service/... ./internal/handler/... ./cmd/server/...` (0 issues)
- [x] `pnpm typecheck && pnpm lint:check` clean
- [x] `pnpm test:run PricingView` — 3 tests including new authenticated branch
- [x] `pnpm build` regenerates dist; `frontend-source.json` hash committed
- [x] `bash scripts/preflight.sh` — full suite PASS (branch naming + sentinels + asset contract + drift + ancestry anchor)
- [x] `go generate ./cmd/server` — `wire_gen.go` regenerated and committed
- [ ] Manual smoke after merge:
  - [ ] Unauthenticated `/pricing` shows public catalog (no regression)
  - [ ] Logged-in user sees "Your Menu" by default with `your_price` applied
  - [ ] Switching keys triggers reload + group badge update
  - [ ] Explore-other-group banner + "Create key in <group>" CTA navigates correctly
  - [ ] `user_group_rate(group)=0` (free subscription) renders as `$0`
  - [ ] EN/ZH copy renders correctly via `/?locale=en` / `/?locale=zh`

🤖 Generated with [Claude Code](https://claude.com/claude-code)