### PR TITLE
fix(pricing): vendor-prefix fallback in IsModelPriced for OpenRouter/Azure

### DIFF
--- a/backend/internal/service/pricing_catalog_membership_tk.go
+++ b/backend/internal/service/pricing_catalog_membership_tk.go
@@ -22,9 +22,13 @@ import (
 )
 
 // IsModelPriced reports whether modelID has a pricing entry in the catalog.
-// The platform parameter is reserved for a future per-platform pricing split
-// (see §8 of docs/approved/pricing-availability-source-of-truth.md "遗留事项")
-// and is currently ignored; the catalog is platform-agnostic in v1.
+// The platform parameter is reserved for a future *cross-vendor* pricing
+// split — e.g. claude-3-haiku-20240307 priced differently on Bedrock vs
+// anthropic.com (see §8 of docs/approved/pricing-availability-source-of-truth.md
+// "遗留事项") — and is currently ignored; the catalog is platform-agnostic
+// in v1. Note: <vendor>/<model>-style ids already carry their own
+// per-vendor signal via the "/" prefix, which the fallback below consumes
+// without needing the platform argument.
 //
 // Behavior:
 //   - nil receiver, empty modelID, or empty/cold catalog → false (callers

--- a/backend/internal/service/pricing_catalog_membership_tk.go
+++ b/backend/internal/service/pricing_catalog_membership_tk.go
@@ -31,6 +31,19 @@ import (
 //     interpret false as "not priced", which the upstream-discovery filter
 //     uses to tag pricing_status="missing" and the client model-list filter
 //     uses for fail-open semantics — see ModelListFilter.FilterClientFacing).
+//
+// Vendor-namespaced fallback: OpenRouter (and Azure/Vertex/Bedrock-style
+// proxies) report model ids as "<vendor>/<family-version>" — e.g.
+// "anthropic/claude-3-haiku", "anthropic/claude-opus-4.5". The catalog
+// (LiteLLM-shaped JSON) keys models on the bare name and uses "-" instead of
+// "." in version segments — e.g. "claude-3-haiku-20240307",
+// "claude-opus-4-5-20251001". When the literal lookup fails AND the id
+// contains a single "/", we strip the vendor prefix, normalize "." → "-",
+// and try again: first as an exact match against the catalog, then as a
+// version-suffix prefix match ("<tail>-*"). The prefix match requires tail
+// to contain at least one "-" to prevent a family-level id (e.g.
+// "openai/gpt") from being treated as priced just because some specific
+// variant exists.
 func (s *PricingCatalogService) IsModelPriced(modelID, platform string) bool {
 	if s == nil {
 		return false
@@ -48,5 +61,38 @@ func (s *PricingCatalogService) IsModelPriced(modelID, platform string) bool {
 			return true
 		}
 	}
+	if tail, ok := stripVendorPrefixForCatalogLookup(id); ok {
+		allowPrefix := strings.Contains(tail, "-")
+		prefix := tail + "-"
+		for i := range resp.Data {
+			mid := resp.Data[i].ModelID
+			if mid == tail {
+				return true
+			}
+			if allowPrefix && strings.HasPrefix(mid, prefix) {
+				return true
+			}
+		}
+	}
 	return false
+}
+
+// stripVendorPrefixForCatalogLookup converts an OpenRouter/Azure-style
+// "<vendor>/<model>" id into the bare catalog form, normalizing "." → "-"
+// in the model segment (LiteLLM catalog uses "-" everywhere). Returns
+// (tail, true) only when exactly one "/" is present and both sides are
+// non-empty — multi-segment ids ("a/b/c") are too ambiguous to map safely.
+func stripVendorPrefixForCatalogLookup(id string) (string, bool) {
+	slash := strings.IndexByte(id, '/')
+	if slash <= 0 || slash >= len(id)-1 {
+		return "", false
+	}
+	if strings.IndexByte(id[slash+1:], '/') >= 0 {
+		return "", false
+	}
+	tail := strings.ReplaceAll(id[slash+1:], ".", "-")
+	if tail == "" {
+		return "", false
+	}
+	return tail, true
 }

--- a/backend/internal/service/pricing_catalog_membership_tk_test.go
+++ b/backend/internal/service/pricing_catalog_membership_tk_test.go
@@ -61,3 +61,92 @@ func TestIsModelPriced_WithFixtureData(t *testing.T) {
 		"model absent from catalog must return false")
 }
 
+// TestIsModelPriced_VendorPrefixFallback exercises the OpenRouter / Azure /
+// Bedrock-style "<vendor>/<model>" naming that the LiteLLM catalog does not
+// store directly. Without the fallback, every OpenRouter model id returned
+// from upstream /v1/models would be tagged "missing" in the admin "fetch
+// upstream models" UI.
+func TestIsModelPriced_VendorPrefixFallback(t *testing.T) {
+	svc := NewPricingCatalogService(nil)
+	svc.SetSourceForTesting(func() ([]byte, time.Time, bool) {
+		return []byte(`{
+			"claude-3-haiku-20240307": {
+				"input_cost_per_token": 0.00000025,
+				"output_cost_per_token": 0.00000125,
+				"litellm_provider": "anthropic"
+			},
+			"claude-opus-4-5-20251001": {
+				"input_cost_per_token": 0.000015,
+				"output_cost_per_token": 0.000075,
+				"litellm_provider": "anthropic"
+			},
+			"gpt-4o-mini": {
+				"input_cost_per_token": 0.00000015,
+				"output_cost_per_token": 0.0000006,
+				"litellm_provider": "openai"
+			}
+		}`), time.Now(), true
+	})
+
+	// Vendor prefix + date-suffix prefix match.
+	require.True(t, svc.IsModelPriced("anthropic/claude-3-haiku", "newapi"),
+		"vendor/model should match catalog id sharing the family prefix")
+
+	// Vendor prefix + dot→dash normalization (anthropic-style versioning).
+	require.True(t, svc.IsModelPriced("anthropic/claude-opus-4.5", "newapi"),
+		"dotted version in vendor/model should normalize to dashes before lookup")
+
+	// Vendor prefix + tail already matches catalog id verbatim.
+	require.True(t, svc.IsModelPriced("openai/gpt-4o-mini", "newapi"),
+		"vendor/tail equal to a catalog id must be priced")
+
+	// Tail with no "/" boundary still uses literal match.
+	require.True(t, svc.IsModelPriced("gpt-4o-mini", "newapi"),
+		"bare id literal match should still work after fallback was added")
+
+	// Truly absent model — vendor strip and prefix match both fail.
+	require.False(t, svc.IsModelPriced("ai21/jamba-large-1.7", "newapi"),
+		"model family absent from catalog must return false")
+	require.False(t, svc.IsModelPriced("amazon/nova-pro-v1", "newapi"),
+		"unrelated vendor namespace must not pull false positives from catalog")
+}
+
+// TestIsModelPriced_VendorPrefixDoesNotLeakAcrossFamilies guards the
+// boundary semantics: tail without any "-" must NOT prefix-match a longer
+// catalog id. Otherwise "openai/gpt" would be reported priced because
+// "gpt-4o-mini" exists, which is wrong (the vendor namespace is not a
+// concrete model id).
+func TestIsModelPriced_VendorPrefixDoesNotLeakAcrossFamilies(t *testing.T) {
+	svc := NewPricingCatalogService(nil)
+	svc.SetSourceForTesting(func() ([]byte, time.Time, bool) {
+		return []byte(`{
+			"gpt-4o-mini": {
+				"input_cost_per_token": 0.00000015,
+				"output_cost_per_token": 0.0000006,
+				"litellm_provider": "openai"
+			},
+			"claude-3-haiku-20240307": {
+				"input_cost_per_token": 0.00000025,
+				"output_cost_per_token": 0.00000125,
+				"litellm_provider": "anthropic"
+			}
+		}`), time.Now(), true
+	})
+
+	// Family-only tails (no "-") must not prefix-match any catalog id.
+	require.False(t, svc.IsModelPriced("openai/gpt", "newapi"),
+		"family-only vendor tail must not prefix-match concrete catalog ids")
+	require.False(t, svc.IsModelPriced("anthropic/claude", "newapi"),
+		"family-only vendor tail must not prefix-match concrete catalog ids")
+
+	// Multi-segment vendor paths are ambiguous → no fallback.
+	require.False(t, svc.IsModelPriced("foo/bar/gpt-4o-mini", "newapi"),
+		"multi-slash ids must skip the vendor-prefix fallback")
+
+	// Empty tail after stripping vendor.
+	require.False(t, svc.IsModelPriced("openai/", "newapi"),
+		"empty tail must not match anything")
+	require.False(t, svc.IsModelPriced("/gpt-4o-mini", "newapi"),
+		"empty vendor must not enable the fallback")
+}
+

--- a/scripts/sentinels/newapi.json
+++ b/scripts/sentinels/newapi.json
@@ -170,6 +170,14 @@
         "claude-opus-4-7"
       ],
       "rationale": "buildModelMappingObject must tolerate stale object entries and emit only string-to-string model_mapping pairs. Without this normalization, the submit path can hit `includes is not a function` or persist invalid object-shaped model mappings after #128 responses. This file also owns the admin default model lists; keep Claude defaults on currently available 4.x models and do not re-add retired 3.7 Sonnet entries that trigger Anthropic not_found errors."
+    },
+    {
+      "path": "backend/internal/service/pricing_catalog_membership_tk.go",
+      "must_contain": [
+        "func (s *PricingCatalogService) IsModelPriced",
+        "stripVendorPrefixForCatalogLookup"
+      ],
+      "rationale": "Read-side predicate consumed by integration/newapi/discover_filter_tk.go step [3] to tag admin 'fetch upstream models' results with pricing_status. OpenRouter / Azure / Bedrock report '<vendor>/<family-version>' ids whose tail uses '.' while the LiteLLM catalog stores bare names with '-' and date suffixes (anthropic/claude-opus-4.5 vs claude-opus-4-5-20251001). stripVendorPrefixForCatalogLookup + the '.'→'-' normalization is what keeps the entire OpenRouter / Azure model list from being tagged 'missing' across admin and the client /v1/models filter. Removing either symbol silently flips ~all OpenRouter channels to a wall of orange 'missing' badges (the regression this sentinel guards)."
     }
   ]
 }


### PR DESCRIPTION
## Summary

Admin **「获取模型列表」** for OpenRouter channels (`channel_type=20`) returned 100% `pricing_status="missing"` badges — every model came back orange "缺定价" — because `PricingCatalogService.IsModelPriced` used literal string equality between OpenRouter's `<vendor>/<family-version>` ids (e.g. `anthropic/claude-opus-4.5`) and the LiteLLM catalog's bare names (e.g. `claude-opus-4-5-20251001`). The two naming schemes never matched, so `DiscoveryFilter` step [3] tagged every entry `missing`.

This fixes the predicate to retry with a vendor-prefix-stripped, `.`→`-` normalized id, then exact tail match, then `<tail>-*` prefix match (with a `-` guard against family-level false positives like `openai/gpt` matching `gpt-4o-mini`).

## Client-facing impact (added per xj-review R-001)

`IsModelPriced` is consumed by **two** downstream paths, not just the admin badge:

1. **`DiscoveryFilter.Apply` step [3]** — weak filter, only tags `pricing_status` for admin UI badges. **This is the PR's stated target.**
2. **`ModelListFilter.FilterClientFacing`** (`service/model_list_filter_tk.go:48`) — **strong filter**, used by `GatewayHandler.Models` (`gateway_handler.go:931`) on the client-facing `/v1/models`, `/v1beta/models`, and `/antigravity/models` endpoints. Items that fail `IsModelPriced` are **dropped from the response**.

Before this fix, any `group.platform=newapi` whose accounts whitelisted OpenRouter-style `<vendor>/<model>` ids would have those ids strong-filtered out of `availableModels`, the slice would go empty, and the handler would fall through to `tkOpenAIDefaultModelIDs` — so clients saw the default OpenAI model list, **not** the configured OpenRouter whitelist.

**After this fix**, identifiable OpenRouter / Azure `<vendor>/<model>` ids pass the strong filter and the handler returns the operator-configured whitelist. This is the intended behavior, but it is a visible change in `/v1/models` response content for affected groups and should be called out in release notes when this lands in a tagged release.

Production DI confirms the filter is wired (`service/wire.go:555` `NewModelListFilter` → `handler/wire.go:105` `SetModelListFilter`), so the change takes effect immediately on deploy.

## Scope

- **Backend-only.** `no-web-impact` — embedded frontend dist and Vue UI surfaces are untouched.
- Multi-segment ids (`a/b/c`) skip the fallback (too ambiguous to map safely).
- Empty vendor or empty tail skip the fallback.
- Bare ids already in the catalog are unaffected (existing literal match path is unchanged).

## Why this is load-bearing (sentinel)

`scripts/sentinels/newapi.json` now pins `IsModelPriced` + the new `stripVendorPrefixForCatalogLookup` helper. Removing either silently flips the entire OpenRouter admin model list back to a wall of orange (and silently re-empties the client-facing model list for those groups) — covered by the new sentinel + by `scripts/checks/sentinel-update-gate.py` hotspot rule for `backend/internal/**/*_tk_*.go` (per CLAUDE.md §10).

## What's not fixed (out of scope)

- Bedrock-style ids like `amazon/nova-pro-v1` where LiteLLM uses a different shape entirely (`amazon.nova-pro-v1:0`) still tag missing. Those need either a Bedrock-specific normalizer or per-channel pricing rows; tracked separately if it surfaces in real traffic.
- A future cross-vendor pricing split (same model priced differently on Bedrock vs the vendor's own API) is still on the `platform` parameter's TODO list — the inline comment was clarified in 0f5db4d5 to avoid confusion with the per-vendor work this PR already does.

## Test plan

- [x] `go test -tags=unit ./internal/service/... ./internal/integration/newapi/... -count=1` — green (90s service, 1.5s newapi)
- [x] New `TestIsModelPriced_VendorPrefixFallback` — exact-tail, dot-normalization (`anthropic/claude-opus-4.5` → `claude-opus-4-5-20251001`), prefix-match (`anthropic/claude-3-haiku` → `claude-3-haiku-20240307`), absent-family
- [x] New `TestIsModelPriced_VendorPrefixDoesNotLeakAcrossFamilies` — family-only tails (`openai/gpt`) must NOT match, multi-slash ids must skip the fallback, empty vendor / empty tail
- [x] Existing `TestIsModelPriced_*` still pass (no regression for bare-id path)
- [x] `scripts/preflight.sh` — PASS (sentinel registry update gate now satisfied)
- [ ] Browser verify (deferred to next dev-stack session): in PR #325 dev stack, open "编辑账号" on an OpenRouter `channel_type=20` account, click "获取模型列表" — expect `anthropic/claude-*`, `openai/gpt-*` entries to lose the orange "缺定价" badge; non-mappable families (`ai21/*`, `amazon/*`) still show missing (expected; out of scope).
- [ ] Client-facing `/v1/models` verify (deferred): set a group.platform=newapi key, ensure response now contains the OpenRouter whitelist rather than falling through to openai default models.

## PR Checklist (relevant items)

- [x] `go test -tags=unit ./...` passes (scoped to changed packages)
- [x] No upstream-shaped file touched — only `*_tk.go` companion + sentinel registry
- [x] `no-web-impact` marker in commit message (rule 9.2 wording: no bracketed `skip-ci` discussion)
- [x] Sentinel registry update gate satisfied (rule §5.y.1)
- [x] No deletion of upstream symbols
- [x] PR branch is `fix/openrouter-vendor-prefix-pricing` (independent of PR #325)