### PR TITLE
fix(models): retire Claude 4.0 Sonnet/Opus before 2026-06-15 Anthropic sunset

### DIFF
--- a/backend/internal/service/antigravity_quota_fetcher.go
+++ b/backend/internal/service/antigravity_quota_fetcher.go
@@ -173,7 +173,10 @@ func (f *AntigravityQuotaFetcher) buildUsageInfo(modelsResp *antigravity.FetchAv
 	}
 
 	// 同时设置 FiveHour 用于兼容展示（取主要模型）
-	priorityModels := []string{"claude-sonnet-4-20250514", "claude-sonnet-4", "gemini-2.5-pro"}
+	// 优先用当下 active 的 sonnet 别名；claude-sonnet-4 alias 仍保留作为旧账号兜底；
+	// claude-sonnet-4-20250514 在 Anthropic 主站 2026-06-15 退役，
+	// antigravity 上由 ModelForwardingRules 自动转发，不再放进 priority 列表。
+	priorityModels := []string{"claude-sonnet-4-6", "claude-sonnet-4", "gemini-2.5-pro"}
 	for _, modelName := range priorityModels {
 		if modelInfo, ok := modelsResp.Models[modelName]; ok && modelInfo.QuotaInfo != nil {
 			utilization := (1.0 - modelInfo.QuotaInfo.RemainingFraction) * 100

--- a/backend/internal/service/antigravity_quota_fetcher_test.go
+++ b/backend/internal/service/antigravity_quota_fetcher_test.go
@@ -203,7 +203,7 @@ func TestBuildUsageInfo_ModelWithNilQuotaInfo(t *testing.T) {
 func TestBuildUsageInfo_FiveHourPriorityOrder(t *testing.T) {
 	fetcher := &AntigravityQuotaFetcher{}
 
-	// priorityModels = ["claude-sonnet-4-20250514", "claude-sonnet-4", "gemini-2.5-pro"]
+	// priorityModels = ["claude-sonnet-4-6", "claude-sonnet-4", "gemini-2.5-pro"]
 	// When the first priority model exists, it should be used for FiveHour
 	modelsResp := &antigravity.FetchAvailableModelsResponse{
 		Models: map[string]antigravity.ModelInfo{
@@ -213,7 +213,7 @@ func TestBuildUsageInfo_FiveHourPriorityOrder(t *testing.T) {
 					ResetTime:         "2026-03-08T18:00:00Z",
 				},
 			},
-			"claude-sonnet-4-20250514": {
+			"claude-sonnet-4-6": {
 				QuotaInfo: &antigravity.ModelQuotaInfo{
 					RemainingFraction: 0.80,
 					ResetTime:         "2026-03-08T12:00:00Z",
@@ -225,7 +225,7 @@ func TestBuildUsageInfo_FiveHourPriorityOrder(t *testing.T) {
 	info := fetcher.buildUsageInfo(modelsResp, "", "", nil)
 
 	require.NotNil(t, info.FiveHour, "FiveHour should be set when a priority model exists")
-	// claude-sonnet-4-20250514 is first in priority list, so it should be used
+	// claude-sonnet-4-6 is first in priority list, so it should be used
 	expectedUtilization := (1.0 - 0.80) * 100 // 20
 	require.InDelta(t, expectedUtilization, info.FiveHour.Utilization, 0.01)
 	require.NotNil(t, info.FiveHour.ResetsAt, "ResetsAt should be parsed from ResetTime")
@@ -234,7 +234,7 @@ func TestBuildUsageInfo_FiveHourPriorityOrder(t *testing.T) {
 func TestBuildUsageInfo_FiveHourFallbackToClaude4(t *testing.T) {
 	fetcher := &AntigravityQuotaFetcher{}
 
-	// Only claude-sonnet-4 exists (second in priority list), not claude-sonnet-4-20250514
+	// Only claude-sonnet-4 exists (second in priority list), not claude-sonnet-4-6
 	modelsResp := &antigravity.FetchAvailableModelsResponse{
 		Models: map[string]antigravity.ModelInfo{
 			"claude-sonnet-4": {
@@ -308,7 +308,7 @@ func TestBuildUsageInfo_FiveHourWithEmptyResetTime(t *testing.T) {
 
 	modelsResp := &antigravity.FetchAvailableModelsResponse{
 		Models: map[string]antigravity.ModelInfo{
-			"claude-sonnet-4-20250514": {
+			"claude-sonnet-4-6": {
 				QuotaInfo: &antigravity.ModelQuotaInfo{
 					RemainingFraction: 0.50,
 					ResetTime:         "", // empty reset time

--- a/backend/internal/web/dist/frontend-source.json
+++ b/backend/internal/web/dist/frontend-source.json
@@ -1,7 +1,7 @@
 {
   "algorithm": "sha256(git-ls-files:path,size,content)",
   "file_count": 426,
-  "hash": "375c0b58abb3781a7226563e17d10299d644deed2911335a532f58cde55b2ba5",
+  "hash": "cc8a6be00f70b7eb38042ca3684c35cac5990e915870319240405efd0a0afcac",
   "schema": 1,
   "source": "frontend/"
 }

--- a/frontend/src/composables/__tests__/useModelWhitelist.spec.ts
+++ b/frontend/src/composables/__tests__/useModelWhitelist.spec.ts
@@ -27,13 +27,20 @@ describe('useModelWhitelist', () => {
     expect(models).not.toContain('gpt-5.2-codex')
   })
 
-  it('claude 默认模型列表不再暴露已下线的 3.5/3.7 系列', () => {
+  it('claude 默认模型列表不再暴露已下线或即将退役的旧模型', () => {
     const models = getModelsByPlatform('claude')
 
+    // Retired (per Anthropic model-deprecations page)
     expect(models).not.toContain('claude-3-7-sonnet-20250219')
     expect(models).not.toContain('claude-3-5-sonnet-20241022')
     expect(models).not.toContain('claude-3-5-sonnet-20240620')
     expect(models).not.toContain('claude-3-5-haiku-20241022')
+    expect(models).not.toContain('claude-3-haiku-20240307')
+    expect(models).not.toContain('claude-3-opus-20240229')
+    expect(models).not.toContain('claude-3-sonnet-20240229')
+    // Deprecated, retiring 2026-06-15
+    expect(models).not.toContain('claude-sonnet-4-20250514')
+    expect(models).not.toContain('claude-opus-4-20250514')
   })
 
   it('antigravity 模型列表包含图片模型兼容项', () => {

--- a/frontend/src/composables/useModelWhitelist.ts
+++ b/frontend/src/composables/useModelWhitelist.ts
@@ -41,7 +41,6 @@ const newapiModels = [
 
 // Anthropic Claude
 export const claudeModels = [
-  'claude-sonnet-4-20250514', 'claude-opus-4-20250514',
   'claude-opus-4-1-20250805',
   'claude-sonnet-4-5-20250929', 'claude-haiku-4-5-20251001',
   'claude-opus-4-5-20251101',
@@ -249,7 +248,6 @@ export const allModels = allModelsList.map(m => ({ value: m, label: m }))
 // =====================
 
 const anthropicPresetMappings = [
-  { label: 'Sonnet 4', from: 'claude-sonnet-4-20250514', to: 'claude-sonnet-4-20250514', color: 'bg-blue-100 text-blue-700 hover:bg-blue-200 dark:bg-blue-900/30 dark:text-blue-400' },
   { label: 'Sonnet 4.5', from: 'claude-sonnet-4-5-20250929', to: 'claude-sonnet-4-5-20250929', color: 'bg-indigo-100 text-indigo-700 hover:bg-indigo-200 dark:bg-indigo-900/30 dark:text-indigo-400' },
   { label: 'Sonnet 4.6', from: 'claude-sonnet-4-6', to: 'claude-sonnet-4-6', color: 'bg-indigo-100 text-indigo-700 hover:bg-indigo-200 dark:bg-indigo-900/30 dark:text-indigo-400' },
   { label: 'Opus 4.5', from: 'claude-opus-4-5-20251101', to: 'claude-opus-4-5-20251101', color: 'bg-purple-100 text-purple-700 hover:bg-purple-200 dark:bg-purple-900/30 dark:text-purple-400' },

--- a/scripts/sentinels/newapi.json
+++ b/scripts/sentinels/newapi.json
@@ -169,7 +169,7 @@
         "const model = normalizeModelID(item)",
         "claude-opus-4-7"
       ],
-      "rationale": "buildModelMappingObject must tolerate stale object entries and emit only string-to-string model_mapping pairs. Without this normalization, the submit path can hit `includes is not a function` or persist invalid object-shaped model mappings after #128 responses. This file also owns the admin default model lists; keep Claude defaults on currently available 4.x models and do not re-add retired 3.5 / 3.7 Sonnet (or 3.5 Haiku) entries that trigger Anthropic not_found errors on OAuth subscription channels."
+      "rationale": "buildModelMappingObject must tolerate stale object entries and emit only string-to-string model_mapping pairs. Without this normalization, the submit path can hit `includes is not a function` or persist invalid object-shaped model mappings after #128 responses. This file also owns the admin default model lists; keep Claude defaults on currently-available 4.5/4.6/4.7 models and do not re-add (a) retired 3.x snapshots: claude-3-7-sonnet-20250219, claude-3-5-sonnet-20241022, claude-3-5-sonnet-20240620, claude-3-5-haiku-20241022, claude-3-haiku-20240307, claude-3-opus-20240229, claude-3-sonnet-20240229 — Anthropic API returns not_found_error for these (model-deprecations page verified 2026-05-21); nor (b) deprecated 4.0 snapshots claude-sonnet-4-20250514 and claude-opus-4-20250514 which Anthropic retires on 2026-06-15."
     },
     {
       "path": "backend/internal/service/pricing_catalog_membership_tk.go",


### PR DESCRIPTION
## Summary

Per Anthropic [model-deprecations page](https://docs.anthropic.com/en/docs/about-claude/model-deprecations) (verified 2026-05-21), both `claude-sonnet-4-20250514` and `claude-opus-4-20250514` are **Deprecated** with retirement scheduled **2026-06-15** (25 days away). Recommended replacements: `claude-sonnet-4-6` and `claude-opus-4-7`.

This PR is the 4.0 follow-up to #327 (which retired the 3.5 / 3.7 family) — same minimum-touch pattern, same sentinel-pinned discipline.

### Cross-checked the Retired list while there

Test spec is also extended to assert **all** Retired 3.x snapshots from the deprecations page are absent from the admin dropdown:

| Status (2026-05-21) | Model ID | Retired |
|---|---|---|
| Retired | claude-3-7-sonnet-20250219 | 2026-02-19 |
| Retired | claude-3-5-sonnet-20241022 | 2025-10-28 |
| Retired | claude-3-5-sonnet-20240620 | 2025-10-28 |
| Retired | claude-3-5-haiku-20241022 | 2026-02-19 |
| Retired | claude-3-haiku-20240307 | 2026-04-20 |
| Retired | claude-3-opus-20240229 | 2026-01-05 |
| Retired | claude-3-sonnet-20240229 | 2025-07-21 |
| Deprecated | claude-sonnet-4-20250514 | 2026-06-15 (pending) |
| Deprecated | claude-opus-4-20250514 | 2026-06-15 (pending) |

### Files changed

| File | Change |
|---|---|
| `frontend/src/composables/useModelWhitelist.ts` | Removed `claude-sonnet-4-20250514` and `claude-opus-4-20250514` from `claudeModels`. Removed dead-end `Sonnet 4` self-mapping preset. The antigravity `Sonnet4→4.6` from-side preset is **kept** on purpose: from=legacy, to=active is the right legacy-client compat tool. |
| `frontend/src/composables/__tests__/useModelWhitelist.spec.ts` | Extended the regression spec to assert every Retired 3.x snapshot **plus** the two Deprecated 4.0 snapshots are absent — future upstream merges that re-add these will fail the spec. |
| `backend/internal/service/antigravity_quota_fetcher.go` | `priorityModels` for the quota-progress probe was hard-coded to `claude-sonnet-4-20250514` as the first element. Switched to `claude-sonnet-4-6` first; `claude-sonnet-4` alias kept as second fallback. Antigravity's own `ModelForwardingRules` layer still bridges legacy IDs, so probe data flows either way, but the first hit is now a non-deprecated model. |
| `scripts/sentinels/newapi.json` | Rationale enumerates every Retired snapshot + the two Deprecated 4.0 snapshots and pins the reason (Anthropic not_found_error / 2026-06-15 sunset). |
| `backend/internal/web/dist/frontend-source.json` | Rebuilt for the frontend-release-asset contract. |

### Intentionally NOT changed

- `backend/internal/domain/constants.go` `DefaultBedrockModelMapping` 4.0 entries — Bedrock has independent lifecycle per Anthropic docs ("Partner-operated platforms set their own retirement schedules"). Admins still configuring Bedrock accounts with the 4.0 alias must keep working.
- `backend/internal/service/group.go` and `pricing_catalog_membership_tk.go` comments use a retired model ID as a syntactic example — comment-only, no upstream contact.
- `backend/resources/model-pricing/model_prices_and_context_window.json` keeps pricing rows for retired models so historical billing lookups resolve.
- All `*_test.go` fixtures — no upstream contact, renaming churns review noise.

## Test plan

- [x] `bash scripts/preflight.sh` PASS (sentinel update gate, upstream override marker, frontend release asset contract all green).
- [x] `node_modules/.bin/vitest run frontend/src/composables/__tests__/useModelWhitelist.spec.ts` — 12/12 pass (includes the new Retired + Deprecated regression assertions).
- [x] `go test -tags=unit -count=1 ./internal/service/... -run 'Antigravity|QuotaFetcher'` — pass.
- [x] `go build ./...` — pass.
- [ ] CI green on PR (covers full `make test` matrix).

## Notes

- Same as #327: PR merge to main ≠ prod live. Next `vX.Y.Z` tag → `release.yml` will pull this into the production image and downstream `deploy-stage0.yml` rollout.
- The 25-day Anthropic 2026-06-15 deadline is comfortably ahead of a typical release cadence, so no urgency to cut a hotfix tag for this PR alone.

🤖 Generated with [Claude Code](https://claude.com/claude-code)