### PR TITLE
chore(stage0): unify anthropic config into 5-stage pipeline orchestrator

### DIFF
--- a/.cursor/skills/tokenkey-anthropic-oauth-config/SKILL.md
+++ b/.cursor/skills/tokenkey-anthropic-oauth-config/SKILL.md
@@ -1,551 +1,203 @@
 ---
 name: tokenkey-anthropic-oauth-config
 description: >-
-  Query and update Anthropic account/group config across the TokenKey
-  control plane (prod stage0) and the edge stage0 hosts: edge OAuth
-  stability tiers (Stage0 SQL templates), prod cc-*-oauth forward
-  stub bindings, and the cc-edges admin-only routing slot. Default
-  read-only check, explicit apply confirmation, mixed-channel risk
-  precheck, RPM-alignment guard, post-change verification.
+  TokenKey Anthropic 账号/分组配置 5 阶段流水线：snapshot → check → plan → apply
+  → verify。覆盖 edge OAuth tier baseline、prod 转发 stub R1 concurrency 镜像、
+  prod stub R3-unified declared_rpm 与 group rpm_limit 级联，单一脚本
+  ops/anthropic/manage-anthropic-config.py 编排，4 个 SQL 模板固化所有写入。
+  默认只读检查、显式 confirm 后才写、apply 之后必复核。
 ---
 
-# TokenKey：Anthropic 账号与分组配置（prod 控制面 + edge OAuth）
+# TokenKey：Anthropic 配置 5 阶段流水线
 
-适用于本仓库（TokenKey fork of sub2api）。目标是把“查询漂移 → 计划变更 → 显式确认后更新 → 复核”固化为可复用流程，覆盖两条数据路径：
-
-- **edge stage0**：真正的 anthropic OAuth 账号（`platform=anthropic AND type=oauth`），承载 Anthropic 上游流量；tier baseline + TLS profile 在此落档。
-- **prod stage0**：转发 stub（`platform=anthropic AND type=apikey`，credentials 含 `base_url=api-<edge>.tokenkey.dev`），把客户端流量打到对应 edge。
+适用于本仓库（TokenKey fork of sub2api）。任何 anthropic 配置变更——edge OAuth tier 升降、prod stub external 配额修改——都走同一条流水线。流水线本身固化在 `ops/anthropic/manage-anthropic-config.py`，本文档只描述协议与背景。
 
 权威纪律以仓库根 `CLAUDE.md` 为准。
 
-## 调用参数
+## 1. 5 阶段流水线（**唯一推荐路径**）
 
-```text
-/tokenkey-edge-anthropic-oauth-config edge_id=<id> operation=<check|plan-apply|apply> [account_name=<name>|all] [target_scope=account|group] [target_group_id=<id>] [target_group_name=<name>] [group_ids=1,2] [confirm_apply=yes-apply-edge-anthropic-oauth] [allow_planned=true|false] [update_stable_list=true|false]
+每阶段一个命令，输入/输出明确，失败即停。所有写入通过 4 个固化 SQL 模板，操作员不写 SQL，不手动编排。
+
+```bash
+JOBDIR="$CLAUDE_JOB_DIR"               # or any scratch dir
+MGR=ops/anthropic/manage-anthropic-config.py
+
+# Stage 1 — Snapshot：拉 prod + 所有被 prod 引用的 edge 的全量状态到 JSON
+python3 $MGR snapshot --out $JOBDIR/snap.json
+
+# Stage 2 — Check：编排 3 个 guard，union 报告
+python3 $MGR check --snapshot $JOBDIR/snap.json
+
+# Stage 3 — Plan：声明意图，机器算 cascade
+# 3a) edge OAuth 账号 tier 变更（最常见）
+python3 $MGR plan-edge-account-tier \
+  --edge uk1 --account en-ld-ec2-16-1-b --tier l2 \
+  --snapshot $JOBDIR/snap.json --out $JOBDIR/plan.json
+
+# 3b) external apikey stub 配额变更
+python3 $MGR plan-external-stub \
+  --stub tokensea-0.4 --declared-rpm 150 \
+  --snapshot $JOBDIR/snap.json --out $JOBDIR/plan.json
+
+# Stage 4 — Apply：按 plan 串行执行；失败即停
+python3 $MGR apply \
+  --plan $JOBDIR/plan.json \
+  --confirm yes-apply-anthropic-config-cascade
+
+# Stage 5 — Verify：再 snapshot + 比对每个 expected_after vs live
+python3 $MGR verify --plan $JOBDIR/plan.json
 ```
 
-| 参数 | 语义 |
-|---|---|
-| `edge_id` | 目标 edge，如 `us1` / `uk1` / `fra1`；支持 `all` 自动枚举所有 edge（默认仅 deployable）。 |
-| `target_scope` | 目标范围：`account`（默认）或 `group`。 |
-| `account_name` | `target_scope=account` 时必填；目标账号名（`accounts.name`）；`check` 支持 `all` 自动枚举每个 edge 下全部 anthropic oauth 账号。 |
-| `target_group_id` | `target_scope=group` 时可选；目标分组 ID（与 `target_group_name` 二选一，优先 ID）。 |
-| `target_group_name` | `target_scope=group` 时可选；目标分组名（与 `target_group_id` 二选一）。 |
-| `account.extra.stability_tier` | 分级基线选择键（`l1/l2/l3/l4/l5`），`check` 会按该字段选择 tier baseline。 |
-| `operation=check` | 默认模式，只读检查当前配置与基准差异；`target_scope=group` 时输出分组聚合结果与成员账号明细。 |
-| `operation=plan-apply` | 生成更新计划与请求 payload 预览，不写入。 |
-| `operation=apply` | 执行更新（账号字段 + 可选分组绑定）；`target_scope=group` 时对分组内可用账号逐一执行，必须显式确认。 |
-| `group_ids` | 可选分组 ID 列表（逗号分隔）。在 `target_scope=account` 时表示该账号分组重绑；在 `target_scope=group` 时默认不改绑定，除非显式提供。 |
-| `confirm_apply` | 仅 `apply` 使用，必须精确为 `yes-apply-edge-anthropic-oauth`。 |
-| `allow_planned` | 是否允许在 planned edge 上执行检查，默认 `false`。 |
-| `update_stable_list` | 可选；仅在人工确认稳定后才更新 baseline stable_accounts。 |
+### 各阶段语义
 
-默认行为：
-- 用户只说“查配置/看漂移” → `operation=check`
-- 用户只说“更新/对齐” → 先执行 `check` + `plan-apply`，拿到确认后再 `apply`
-- 未声明 `target_scope` 时默认 `target_scope=account`
-- `target_scope=group` 时，`check`/`plan-apply` 可用分组名或分组 ID 定位目标；`apply` 仅允许单 edge + 单分组
-- `edge_id=all` 默认只巡检 deployable edge；如需包含 planned，显式加 `allow_planned=true`
+| 阶段 | 输入 | 输出 | exit |
+|---|---|---|---|
+| snapshot | EC2 SSM 权限 | `snap.json`：prod 所有 anthropic apikey stubs + 它们引用的 edge 的 OAuth 账号 + groups | 0 / 2 error |
+| check | snap.json | 调 3 个 guard（prod-stub-mirror / edge-oauth-stability / account-group-rpm-alignment），union violation | 0 ok / 1 violation / 2 error |
+| plan-edge-account-tier | snap.json + edge+account+tier | `plan.json`：5 个 action（edge account → edge group → prod stub conc → prod groups r3-unified） | 0 / 2 |
+| plan-external-stub | snap.json + stub+declared_rpm | `plan.json`：1+ action（仅 prod 侧 groups） | 0 / 2 |
+| apply | plan.json + confirm | 渲染每个 action 的 SQL → SSM 执行 → 解析 jsonb 输出 → 校验 `expected_after`；写 `apply-report.json` | 0 / 1 step failed / 2 |
+| verify | plan.json | 再 snapshot + 比对 `actions[*].expected_after` vs live；drift 列表 | 0 / 1 drift / 2 |
 
-## prod 控制面：anthropic stub 双绑规则
+### Cascade 推导规则（plan-* 内部，op 不需要手算）
 
-prod 上每一个 anthropic 转发 stub（`platform=anthropic AND type=apikey`，credentials 包含 `base_url=api-<edge>.tokenkey.dev`）必须**同时绑两个分组**：
+**plan-edge-account-tier** — 一个 edge tier 变化会级联到 5 个写入点：
+
+```
+edge OAuth account.tier  →  edge default group.rpm_limit
+                         →  prod self-edge stub.concurrency
+                         →  prod self-edge stub.extra.declared_rpm
+                         →  prod each group containing this stub.rpm_limit
+```
+
+- step1：写 edge 账号 tier baseline（`anthropic-oauth-stability-tiered-apply-template.sql`）
+- step2：写 edge default group rpm_limit = `absorb_zero_sum(base_rpm + sticky_buffer)` over active OAuth（`anthropic-oauth-group-aggregate-apply-template.sql`）
+- step3：写 prod 对应 self-edge stub concurrency = `absorb_zero_sum(edge OAuth concurrency)`（`anthropic-stub-mirror-concurrency-apply-template.sql`）
+- step4..N：写 prod 含此 stub 的每个 group → 每个成员的 `extra.declared_rpm` + `group.rpm_limit = Σ declared_rpm`（`anthropic-prod-group-r3-unified-apply-template.sql`，单事务）
+
+**plan-external-stub** — external 改动不影响 edge，只改 prod：
+
+- step1..N：写 prod 含此 stub 的每个 group → 替换该 stub `declared_rpm` 后整组 SUM
+
+`absorb_zero_sum`（R1 concurrency 用）：任一项 0 ⇒ 总和 0（unlimited 传播）；否则普通 SUM。
+R3-unified group rpm_limit 是**普通 SUM**（禁 absorb-zero，禁 unlimited）。详见 § 5。
+
+### 失败即停 + Pre-apply re-read
+
+- `apply` 任一 step 失败 → STOP，`apply-report.json` 列出已完成 + 未完成 step
+- 模板 DO-block 在事务内做二次校验（成员集 / Σ / declared_rpm > 0 / 账号 active），plan/apply 之间被并发会话改了 → 拒绝并 RAISE
+- Stage 5 verify 必须跑；drift → operator 决定补 apply 或回滚
+- snapshot 出于"先查后说"原则：禁止凭记忆断言字段值，所有断言都来自一次 SSM read
+
+## 2. prod 控制面：anthropic stub 双绑规则
+
+prod 上每一个 anthropic 转发 stub（`platform=anthropic AND type=apikey`，credentials 含 `base_url=api-<edge>.tokenkey.dev`）必须**同时绑两个分组**：
 
 | 分组 | id | 用途 | 谁可见 |
-| ---- | ---- | ---- | ---- |
+|---|---|---|---|
 | `default` | 1 | 对外用户流量 | 普通用户 API key |
-| `cc-edges` | 15 | admin 调试旁路 | 仅 admin API key（不暴露给普通用户） |
+| `cc-edges` | 15 | admin 调试旁路 | 仅 admin API key |
 
-可见性强制点：**`groups.is_exclusive=true` + `user_allowed_groups` 白名单**。`cc-edges` 必须 `is_exclusive=true`，并且只为 admin user 在 `user_allowed_groups` 写入 `(admin_user_id, 15)` 一行；普通用户在前端选择 group 时 `GetAvailableGroups` 会过滤掉 `cc-edges`，新建/更新 API key 时 `CanBindGroup` 会返回 `GROUP_NOT_ALLOWED`。两个分组指向同一个 stub（同一个上游 edge），区别仅在调用方身份。
+可见性强制点：`groups.is_exclusive=true` + `user_allowed_groups` 白名单。`cc-edges` 必须 `is_exclusive=true`，admin user 在 `user_allowed_groups` 写入 `(admin_user_id, 15)`。
 
-操作流程：
-- **新增 anthropic edge stub**（例如再开一个 edge `xx1`）→ 创建 `cc-xx1-oauth` stub 后，第一时间在 prod 上 `INSERT account_groups` 双行（`default` + `cc-edges`）。两条 binding **不可拆开 apply**：要么一起加，要么一起退。
-- **退役 anthropic edge stub**（例如 H3 处理 uk1/fra1） → 软删 stub 前必须先 `DELETE account_groups` 两行；只删一行会留下幽灵 binding，导致下次审计时声音错乱。
-- **edge 数据库内部** → 真正的 OAuth 账号绑定 `default` 组即可，**不需要** edge 端复刻 `cc-edges`；admin 调试旁路只在 prod 控制面有意义（admin 直接命中 prod，再透传到 edge）。
+operate 流程：
+- **新增 anthropic edge stub** → 同步 `INSERT account_groups` 双行（default + cc-edges）。两行不可拆开 apply。
+- **退役 anthropic edge stub** → 软删 stub 前 `DELETE account_groups` 两行。
+- **edge 内部** 真正的 OAuth 账号绑定 `default` 组即可，不复刻 `cc-edges`（admin 调试旁路只在 prod 控制面有意义）。
 
-任何对 prod stub 的 binding 改动都属于 `target_scope=account` 的 `apply` 范畴，必须走本 skill §3 的 `confirm_apply` 流程。
+这些 binding 改动不在 orchestrator 自动 cascade 范围内（涉及 SKU/UX 决策）；用 admin 前端手动操作，再用 Stage 1 snapshot + Stage 2 check 验证。
 
-## prod 控制面：anthropic stub R1 + R3-unified 镜像规则
+## 3. R3-unified 镜像规则（背景）
 
-prod 上**自持 edge 主路径**类型的 anthropic stub（`credentials.base_url` 匹配 `https://api-<edge_id>.tokenkey.dev`）必须**镜像**其上游 edge 的容量；**外部兜底类型**的 anthropic stub（例如 `agent.tokensea.ai`、`api.deepseek.com/anthropic`）必须**显式声明** RPM 配额。`prod 是 router、edge 是 worker`——router 公布的容量必须等于它实际能调动的 worker 总容量；过紧会替 edge 提前 429/503（伪 throttle），过松会下推真 429 给客户端；**为零会让组成为外部滥用入口**（2026-05-21 R3-unified 修订点）。
+prod 是 router、edge 是 worker。router 公布的容量必须等于它能调动的 worker 总容量；为零会让组成为外部滥用入口。
 
-### `declared_rpm` 字段约定（R3-unified 新增）
+### `accounts.extra.declared_rpm` 字段约定
 
-`accounts.extra.declared_rpm`（int，必填，> 0）是每个 anthropic apikey stub 的 RPM 声明值：
+| stub 类型 | `declared_rpm` 来源 | 校验 |
+|---|---|---|
+| self-edge（`api-<edge>.tokenkey.dev`） | 自动镜像 upstream edge `default_group.rpm_limit` | guard 检 `declared_rpm == upstream.rpm_limit`；漂移 = `r3_self_edge_mirror_drift` |
+| external（其他 base_url） | 运营显式声明 | guard 检 `declared_rpm > 0`；缺失 = `r3_declared_rpm_missing`，零/负 = `r3_declared_rpm_zero_forbidden` |
 
-| stub 类型 | `declared_rpm` 来源 | 谁负责对齐 | 漂移检测 |
+`declared_rpm` 当前是 guard / audit-trail 元数据；runtime 仍由 `group.rpm_limit` 实施限速。未来 Go 层若引入 stub-level 配额会从同一 key 读。
+
+### 容量约定（2026-05-21 修订）
+
+| 字段 | 层 | 0 的含义 | 聚合算子 |
 |---|---|---|---|
-| self-edge（`api-<edge>.tokenkey.dev`） | **自动镜像** 上游 edge `default_group.rpm_limit` | edge tier baseline 改动后操作员对齐 prod | guard 检 `declared_rpm == upstream.default.rpm_limit`，不一致 = `r3_self_edge_mirror_drift` |
-| external（其他 base_url） | **运营显式声明** 的配额 | 创建 stub 时同步落档 | guard 检 `declared_rpm > 0`，缺失 = `r3_declared_rpm_missing`，零/负 = `r3_declared_rpm_zero_forbidden` |
+| `account.concurrency` | 账号 | runtime 无并发限制 | absorb-zero SUM（保留 unlimited 语义） |
+| `account.extra.base_rpm` | OAuth | runtime 未启用 | absorb-zero SUM（OAuth tier baseline 聚合用） |
+| `account.extra.declared_rpm` | apikey stub | **禁止 0**（unlimited 已退场） | 普通 SUM |
+| `group.rpm_limit` | 组 | **prod anthropic 组禁止 0** | 普通 SUM = Σ `declared_rpm` |
 
-**runtime 是否消费 `declared_rpm`**：当前 backend Go 代码不直接读取它；runtime 的 RPM 闸门仍由 `group.rpm_limit` 实施（在 group level 限速）。`declared_rpm` 是 guard / audit-trail 的元数据，固化"每个 stub 承诺的产能或配额"，让 group cap 有数学依据。未来若 backend 引入 stub-level 配额，会从同一 key 读。
-
-### 容量约定（runtime 既有事实，2026-05-21 修订）
-
-| 字段 | 所在层 | 0 的含义 | 聚合算子 |
-|---|---|---|---|
-| `account.concurrency` | 账号 | runtime 无并发限制（[`concurrency_service.go:131`](backend/internal/service/concurrency_service.go:131)） | **absorb-zero SUM**（unlimited 传播） |
-| `account.extra.base_rpm` | OAuth 账号 | runtime 未启用（[`account.go:2020`](backend/internal/service/account.go:2020) / `CheckRPMSchedulability`） | **absorb-zero SUM**（OAuth tier baseline 保留旧语义） |
-| `account.extra.declared_rpm` | apikey stub | **禁止 0**（unlimited 已退场） | **普通 SUM**（不 absorb-zero） |
-| `group.rpm_limit` | 组 | **prod anthropic 组禁止 0**（unlimited 已退场）；其他平台暂未硬化 | **普通 SUM**，等于 Σ `declared_rpm` |
-
-**为什么 declared_rpm 不允许 0**：mixed group（self-edge + external）在旧 R3 absorb-zero 下 → `group.rpm_limit=0` → unlimited group → 外部滥用入口。2026-05-21 R3-unified 把"unknown=unlimited"从合法状态删除，强制每个 stub 显式声明产能（self-edge 自动镜像，external 运营手填），从而 group cap = Σ 是可算的有限上限。
-
-### 镜像规则
-
-**R1 — 账号级 concurrency 镜像**（每个 self-edge stub，保留 absorb-zero）
+### R3-unified 算式
 
 ```
-stub.concurrency  ==  absorb_zero_sum(
-                        oauth_acc.concurrency
-                        for oauth_acc in upstream_edge.default group
-                        where active
-                      )
+prod_group.rpm_limit  ==  Σ  stub.declared_rpm   for stub in g.stubs  (plain SUM)
+stub.declared_rpm     >   0                                            (unlimited forbidden)
+self-edge stub.declared_rpm  ==  upstream_edge.default_group.rpm_limit (mirror)
+external stub.declared_rpm   ==  operator declared quota                (visible)
 ```
 
-含义：一个 stub 代表整个 edge `default` 组的合计 inflight 容量。多 OAuth 账号 edge 的合并值大于单账号；若任一 upstream OAuth 是 unlimited（`concurrency=0`），stub 也必须 `concurrency=0`。R1 保留 absorb-zero：`account.concurrency=0` 在 runtime 仍然是 unlimited 语义（concurrency_service.go），propagating 它到 stub 是正确语义。
-
-**R3-unified — 分组级 RPM 声明**（每个含 stub 的 prod 组，替代旧 absorb-zero R3）
-
-```
-prod_group.rpm_limit  ==  Σ  stub.declared_rpm   for stub in g.stubs    (plain SUM)
-stub.declared_rpm     >   0                                              (forbid unlimited)
-self-edge stub.declared_rpm  ==  upstream_edge.default_group.rpm_limit   (mirror)
-external stub.declared_rpm   ==  operator declared quota                  (visible)
-```
-
-含义：每个 stub 都自报一个有限的 RPM 数字；group cap 是它们的普通 SUM。`unlimited`（任何 0）退出合法状态——`unknown ≠ unlimited`，operator 必须显式声明 external 容量。`absorb-zero SUM` 不再用于 R3（仅保留给 R1 concurrency 与 OAuth tier baseline 聚合）。
-
-**`mixed` group 不再特殊**：组合 self-edge + external 的组直接按公式 `SUM(self-edge declared + external declared)` 算 cap；这与"所有 group 都必须有 rpm 闸门"原则一致，不需要拆组。
-
-**注（strict-redline 之后）**：upstream edge `default_group.rpm_limit` 现按 §3.2.1 切换为 `Σ(account.base_rpm + extra.rpm_sticky_buffer)`（含 sticky_buffer 空间）。self-edge stub 的 `declared_rpm` 随之提高，留出黄区流量空间。
-
-### 刻意**不**镜像的字段（设计放弃）
-
-- `accounts.extra.base_rpm` / `extra.max_sessions` / `extra.window_cost_limit` — stub 不读这些（runtime 由 edge OAuth 自己持有，在 edge 侧落档）。
-- `accounts.priority` — prod 组内调度顺序，与 edge 内部排序无关。
-
-### 共同 baseline（所有 stub 必须满足）
-
-- `channel_type = 0`
-- `rate_multiplier = 1.0`
-- `auto_pause_on_expired = true`
-- `status = 'active'`
-- `accounts.extra.declared_rpm > 0`（R3-unified 新增）
-
-### 强制 pre-apply 门禁
-
-```bash
-python3 ops/anthropic/check-prod-stub-mirror.py
-python3 ops/anthropic/check-prod-stub-mirror.py --json          # CI-friendly
-python3 ops/anthropic/check-prod-stub-mirror.py --legacy-r3     # rollout 过渡窗口 only
-```
-
-退出码：
-- exit 0 — 所有 stub 通过 R1 + R3-unified + baseline
-- exit 1 — 任一违规，**修复后才能 apply**
-- exit 2 — SSM / schema / target 解析失败
-
-报告分两段：`--- account-level (R1 concurrency + R3-unified per-stub declared_rpm) ---` 与 `--- group-level (R3-unified Σ declared_rpm) ---`。JSON 模式下 `stub_violation_count` 与 `group_violation_count` 分项汇总；每条 violation 带 `kind` 字段：
-
-| kind | 含义 | 修法 |
-|---|---|---|
-| `r1_mirror_drift` | stub.concurrency ≠ absorb_zero_sum(upstream OAuth) | 用 concurrency apply 模板对齐 |
-| `upstream_no_active_oauth` | edge default group 没有 active 状态的 anthropic OAuth 账号（可能 status=error / suspended / 软删） | edge OAuth 健康问题，不是镜像数学错误；查 `accounts.status` 与 `error_message`，决定修复 OAuth 还是下线 prod stub。R3-unified 的 `declared_rpm` 镜像仍可继续校验（不依赖 OAuth 状态） |
-| `r3_declared_rpm_missing` | stub 缺 `extra.declared_rpm` | 用 R3-unified apply 模板写入 |
-| `r3_declared_rpm_zero_forbidden` | declared_rpm ≤ 0 | 同上 + 由 operator 拍非零值 |
-| `r3_self_edge_mirror_drift` | self-edge.declared_rpm ≠ upstream.default.rpm_limit | 同上 + 取上游实时值 |
-| `r3_group_rpm_zero_forbidden` | group.rpm_limit ≤ 0（含 stubs） | 用 R3-unified apply 模板把组写到 Σ declared_rpm |
-| `r3_group_sum_mismatch` | group.rpm_limit ≠ Σ declared_rpm | 同上 |
-| `r3_group_sum_blocked_by_stub_violation` | 组内某 stub 还缺 declared_rpm（先修 stub） | 先解决 stub 级违规 |
-
-`--legacy-r3` 开关临时回退到旧 absorb-zero R3，**仅在 R3-unified rollout 过渡窗口使用**，默认开启被 skill 禁止；CI 不接受 `--legacy-r3` 输出作为 PASS。
-
-### R1 / R3-unified 修复路径（guard fail 后 apply）
-
-`check-prod-stub-mirror.py` 只检测、不修改。fail 后按违规类型分两条 apply 路径，**两条都要打**（如果两类违规都存在），否则下次 guard 仍会失败：
-
-- **R1（stub concurrency drift）** — guard `results[i].mirror_violations[kind=r1_mirror_drift]`。op 用 [`anthropic-stub-mirror-concurrency-apply-template.sql`](../../../deploy/aws/stage0/anthropic-stub-mirror-concurrency-apply-template.sql) 逐 stub 把 `account.concurrency` 写到 `expected_concurrency`。模板顶部 DO 块拒绝 OAuth 账号 / 非 self-edge stub。
-- **R3-unified（declared_rpm + group cap）** — guard 输出含 `r3_*` kind violations。op 用 [`anthropic-prod-group-r3-unified-apply-template.sql`](../../../deploy/aws/stage0/anthropic-prod-group-r3-unified-apply-template.sql)：单事务内同时写每个 stub 的 `extra.declared_rpm` 和组的 `rpm_limit`，模板内嵌 SUM 校验、成员集校验、declared_rpm > 0 校验。旧 [`anthropic-stub-mirror-rpm-apply-template.sql`](../../../deploy/aws/stage0/anthropic-stub-mirror-rpm-apply-template.sql) 已弃用（保留作为审计 trail，头部有 deprecation 注释指向新模板）。
-
-典型连发顺序：先 R1 stubs 全打完，再 R3-unified group cap。任何顺序都不会触发其他模板的拒绝门禁（模板的 DO 块互斥保护各自的写入面）。
-
-### Pre-apply re-read 协议（2026-05-21 新增，防并发会话覆盖）
-
-**触发场景**：本 skill 的 apply 没有跨会话锁。同一 prod 数据库可能有多个 Claude/Cursor 会话或 admin 前端在同时操作；2026-05-21 调研发现，本会话 R1 apply 后 1 分钟内被另一会话的 admin 操作覆盖。R3-unified 把"unlimited 不再合法"硬化成 guard violation，但写入并发仍要靠协议防御。
-
-**协议**（强制，每次 apply 前执行）：
-
-1. **plan-apply 时**：所有读取过的"实时输入"（edge OAuth tier、edge default.rpm_limit、prod stub `declared_rpm` / `concurrency`、`group.rpm_limit`、`account_groups` 成员集）都打时间戳，记入 plan 文件（`$CLAUDE_JOB_DIR/<env>-<target>-plan.json` 或 SQL 头部注释）。
-2. **apply 之前最后一刻**：重新拉一次同样的输入，与 plan 文件比对；任一字段漂移即 stop + re-plan，**不能**直接 apply。
-3. **apply 模板内嵌的二次校验**：[`anthropic-prod-group-r3-unified-apply-template.sql`](../../../deploy/aws/stage0/anthropic-prod-group-r3-unified-apply-template.sql) 的 DO 块在事务内再次校验：
-   - `stub_inputs` 的 account_id 集合 ≡ 当前 group 的 anthropic apikey 成员集（防 group 成员增删）
-   - `Σ declared_rpm == :target_group_rpm`（防 plan/apply 数字不一致）
-   - 每个 input 指向有效的 anthropic apikey 账号（防 stub 被删/改）
-   - 每个 declared_rpm > 0（防 unlimited 落档）
-4. **apply 之后**：立即再跑 `check-prod-stub-mirror.py`，若回到 violation 状态 → 报告漂移源（很可能是另一会话），**不**隐式补打。
-
-**"先查后说"原则**（强制）：任何对 prod/edge 字段值的断言（"X 当前是 N"）必须以一次 SSM read 为前提。不允许"我以为/我记得 X = N"出现在 plan 里。本会话曾因此踩坑——误以为 external stub 已配置 RPM，实际 `accounts.extra` 全空。
-
-### 规则的本质
-
-prod 是 router、edge 是 worker。两条镜像规则的核心约束：
-- **R1**：router 公布的并发数 = worker 并发数 SUM（absorb-zero，保留 unlimited 语义）
-- **R3-unified**：router 公布的 RPM = Σ worker + external 的 RPM 声明（普通 SUM，禁止 unlimited）
-
-任何 edge tier 变更（H1 升降、增删 OAuth 账号）会被 guard 自动捕获并指向具体修复模板。
-
-历史事故：
-- **2026-05-18 01:38-01:42 UTC** — `cc-edges.rpm_limit=8` 与 `edge-us1 default.rpm_limit=8` 形成双层 RPM 限速，prod 抢先 429/503。R3（absorb-zero 版）上线后此模式 fail。
-- **2026-05-21** — 调研发现 `default` 组是 mixed（含 external），旧 R3 absorb-zero 让它停留在 `rpm_limit=0` (unlimited)，是唯一无 RPM 闸门的对外入口。R3-unified 把这类状态变为 guard violation 直接禁用；当日 apply 把 `default.rpm_limit` 从 0 升到 364（self-edge 16+48 + external 100×3）。
-
-## 一次性跑完（原则）
-
-- 默认只读，先 `check`。
-- 任何写入前都先给出 `plan-apply` 预览。
-- `apply` 无固定确认口令则拒绝执行。
-- 失败先停并报告，不做隐式重试覆盖。
-- 输出禁止包含 token/secret 明文。
-- **先查后说**：对 prod/edge 任何字段值的断言（"X 当前是 N"）必须以一次 SSM read 为前提；禁止"我以为/我记得 X = N" 进入 plan。本会话曾因此踩坑——误以为 external stub 已配置 RPM，实际 `accounts.extra` 全空。
-- **Pre-apply re-read**：apply 前最后一刻必须重新拉一次"实时输入"与 plan 比对，任一字段漂移立即 stop + re-plan。模板内嵌的 DO 块会做事务内二次校验，但 plan/apply 之间的并发会话窗口需要由 operator 自觉协议保护（见 §"Pre-apply re-read 协议"）。
-- **"unlimited" 不是合法状态**（2026-05-21 修订）：`accounts.extra.declared_rpm > 0` 与 prod anthropic `group.rpm_limit > 0` 强制；`0 = unlimited` 仅保留给 `account.concurrency` 与 OAuth `extra.base_rpm`（runtime 既有事实）。
-
-## 分组口径与聚合规则（target_scope=group）
-
-仅统计“分组下可用账号”（建议口径：`deleted_at IS NULL`、平台=`anthropic`、类型=`oauth`、未被临时/永久禁用，且通过当前调度可用性判定）。
-
-聚合算子统一为 **absorb-zero SUM**（见 §"prod 控制面：anthropic stub 主路径镜像规则" 的"容量约定"）：任一可用账号该字段为 0（runtime 即 unlimited）⇒ 聚合结果为 0；否则 = Σ。朴素 SUM 会把 unlimited 当 0 数值算入加法，得出错误的有限上限。
-
-聚合字段建议口径：
-- `group_agg.available_account_count` = 可用账号数量
-- `group_agg.total_base_rpm` = absorb-zero SUM(每个可用账号 `extra.base_rpm`)
-- `group_agg.total_redline` = absorb-zero SUM(每个可用账号 `extra.base_rpm + extra.rpm_sticky_buffer`)；这是 strict-redline 口径下 group cap apply 的目标值，运行时对齐账号 NotSchedulable 阈值
-- `group_agg.total_max_sessions` = absorb-zero SUM(每个可用账号 `extra.max_sessions`)
-- `group_agg.total_window_cost_limit` = absorb-zero SUM(每个可用账号 `extra.window_cost_limit`)
-- `group_agg.effective_concurrency` = absorb-zero SUM(每个可用账号 `account.concurrency`)
-- `group_agg.min_priority` / `max_priority` = 分组内优先级范围（数值越小优先级越高）
-- `group_agg.tier_distribution` = 各 tier 账号计数（L1~L5）
-
-`check` 输出应同时包含：
-1) 分组聚合结果（group_agg）；
-2) 成员账号明细（每个账号的 tier、diff_count、关键字段）；
-3) 分组是否存在“混合 tier / 混合 channel”风险标记。
-
-## 1) Read-only 检查（operation=check）
-
-复用脚本：`ops/anthropic/check-edge-oauth-stability.py`
-
-### 1.1 账号模式（target_scope=account）
-
-标准命令形态：
-
-```bash
-python3 ops/anthropic/check-edge-oauth-stability.py \
-  --edge-id "$EDGE_ID" \
-  --account-name "$ACCOUNT_NAME" \
-  --json
-```
-
-如果需要 planned edge：追加 `--allow-planned`。
-
-重点读取输出字段：
-- `status`（`ok` / `drift` / `error`）
-- `account_stability_tier`（账号当前标记）
-- `baseline_tier`（实际对比使用的等级）
-- `baseline_factor`
-- `diff_count`
-- `diffs`
-- `ssm_command_id`
-
-若 `diff_count>0`，可选生成 SQL（仅供审阅，不建议直接落库改账号）：
-
-> 注意：`--emit-sql` 只支持单 edge + 单账号；任一参数为 `all` 时会被拒绝。
-
-```bash
-python3 ops/anthropic/check-edge-oauth-stability.py \
-  --edge-id "$EDGE_ID" \
-  --account-name "$ACCOUNT_NAME" \
-  --emit-sql /tmp/${EDGE_ID}-${ACCOUNT_NAME}.sql \
-  --json || true
-```
-
-### 1.2 分组模式（target_scope=group）
-
-先解析目标分组（`target_group_id` 或 `target_group_name`），枚举该分组下全部可用 anthropic oauth 账号，然后对每个账号执行账号模式 `check`，最终汇总为分组结果。
-
-重点读取输出字段：
-- `group_status`（`ok` / `drift` / `error`）
-- `group_agg.available_account_count`
-- `group_agg.total_base_rpm`（分组可用账号 rpm 之和）
-- `group_agg.total_max_sessions`
-- `group_agg.total_window_cost_limit`
-- `group_agg.effective_concurrency`
-- `group_agg.tier_distribution`
-- `member_results[]`（每个账号的 `status` / `diff_count` / `baseline_tier`）
-
-## 2) 变更预览（operation=plan-apply）
-
-`plan-apply` 只做两件事：
-1. 基于 `check` 结果列出待更新字段；
-2. 生成 admin API 请求 payload 预览。
-
-### 2.1 账号模式（target_scope=account）
-
-安全限制：
-- `plan-apply` 不允许 `account_name=all`（避免批量账号预览被误当可执行清单）。
-
-`group_ids` 语义必须与后端一致：
-- **不传 `group_ids`**：不改分组绑定；
-- **传空数组 `[]`**：清空分组绑定；
-- **传非空数组 `[1,2]`**：重绑分组。
-
-### 2.2 分组模式（target_scope=group）
-
-- 基于分组内 `member_results[]` 生成“逐账号变更清单”（账号 ID、字段 diff、tier、预估影响）。
-- 生成“分组聚合前后对比预览”：
-  - `total_base_rpm_before/after`
-  - `total_redline_before/after`（strict-redline 模式下 group cap apply 的目标值）
-  - `total_max_sessions_before/after`
-  - `total_window_cost_limit_before/after`
-  - `effective_concurrency_before/after`
-- 默认不允许 `target_group_id=all` 或 `target_group_name=all` 的 apply 级预览；如需批量分组操作，应拆分为多个单分组执行。
-
-## 3) 执行更新（operation=apply）
-
-### 3.1 强制确认
-
-必须提供：
-
-```text
-confirm_apply=yes-apply-edge-anthropic-oauth
-```
-
-缺失或不匹配则拒绝执行。
-
-### 3.2 S2 alignment guard（强制 pre-apply 门禁）
-
-任何 `apply` 之前**必须**先跑：
-
-```bash
-python3 ops/anthropic/check-account-group-rpm-alignment.py --target <edge_id|prod>
-python3 ops/anthropic/check-account-group-rpm-alignment.py --target <edge_id|prod> --strict-redline
-```
-
-对每个 anthropic group（`rpm_limit > 0`）按所选模式校验账号 redline ↔ `group.rpm_limit`：
-
-| 模式 | redline 定义 | 含义 |
-|---|---|---|
-| 默认（legacy） | `account.extra.base_rpm` | 历史 H1 兼容口径，仅校验绿区上限。**已知漏防护**：group.rpm_limit 可被夹到 Σ base_rpm，sticky_buffer 空间无法生效，黄区流量被组提前 429。 |
-| `--strict-redline`（推荐） | `account.extra.base_rpm + extra.rpm_sticky_buffer` | 对齐 runtime `(*Account).CheckRPMSchedulability` 的 NotSchedulable 阈值（[`account.go:2092`](../../../backend/internal/service/account.go:2092)）。group cap 必须为 in-flight StickyOnly 流量留位。 |
-
-两个模式共享两层规则：
-
-- **Layer A**（账号不被组卡）：`max(redline) ≤ group.rpm_limit`
-  违反 = 组成为单账号的隐性 bottleneck。H1 (2026-05-17) 在 edge uk1/fra1 上踩中（`default.rpm_limit=3` 卡住 `base_rpm=6`）。
-- **Layer B**（组 cap 不超出组内产能总和）：`Σ(redline) ≥ group.rpm_limit`
-  违反 = 组的 RPM 上限超过组内 OAuth 账号实际能合并撑起的速率，多出的 cap 是虚的（永远跑不到）。
-
-`--strict-redline` 额外增加：
-
-- **Layer C**（baseline drift）：每个 `base_rpm > 0` 的账号必须同时具备 `extra.rpm_sticky_buffer > 0`。
-  违反 = baseline 尚未落档。修法：按 [`anthropic-oauth-stability-baselines-tiered.json`](../../../deploy/aws/stage0/anthropic-oauth-stability-baselines-tiered.json) 中该账号 tier 的 `rpm_sticky_buffer` 字段补齐，再重跑 guard。
-
-跳过条件（不计入 violation）：
-
-- `rpm_limit = 0` 或 NULL — 视为 unlimited，整组跳过。
-- `rpm_limit > 0` 但组内**无** anthropic OAuth 账号 / 无任何账号声明 `extra.base_rpm` — 视为 stub-only 组（如 prod `cc-edges`），本 guard 不适用；如需对 stub 容量护栏，见 §"prod stub 主路径镜像规则"。
-- `--strict-redline` 模式下，组内任一账号 `extra.rpm_strategy = 'sticky_exempt'` —— 该策略没有有限的 redline，整组 skip 并提示 op 手动核对（TokenKey 当前不启用此策略，仅作前向防御）。
-
-退出码：
-
-- exit 0 — 所有 in-scope 组通过两层（strict 模式额外含 Layer C）
-- exit 1 — 至少一组违反 Layer A / B / C，**必须先修复**再 apply：
-  - Layer A 修法：升 `group.rpm_limit` ≥ 该组 max(redline)；或调低 offender 账号 tier
-  - Layer B 修法：降 `group.rpm_limit` ≤ 该组 sum(redline)；或往组里加 OAuth 账号补容量
-  - Layer C 修法：按 baseline tier 补齐账号的 `extra.rpm_sticky_buffer`
-- exit 2 — 目标/SSM/schema 故障，按错误排查
-
-#### 3.2.1 rollout 顺序（默认 → strict）
-
-新口径上线需要观察窗口，避免 guard 自锁现有 group cap：
-
-1. **PR 合入** — `--strict-redline` 默认关闭，线上 apply 流仍走旧口径，行为零回归。
-2. **离线巡检** — 逐 edge / prod 用 `--strict-redline --json` 跑一遍，确认 Layer C 全过（baseline 已逐 tier 落档），列出 Layer A/B violation 清单。
-3. **升 edge group cap** — 对每个 strict-mode 下违反 Layer A/B 的 **OAuth-bearing** group（典型是 edge `default`），按 [`anthropic-oauth-group-aggregate-apply-template.sql`](../../../deploy/aws/stage0/anthropic-oauth-group-aggregate-apply-template.sql) 生成自包含 SQL，把 `group.rpm_limit` 升到 `Σ redline`。
-4. **同步 prod 镜像（R1 + R3-unified）** — `check-prod-stub-mirror.py` 是 guard 不是 applier；edge tier 改完后它会在下一次巡检里检出 prod 镜像漂移。**两类违规都要修**：
-   - **R1（stub concurrency drift）**：edge OAuth 账号 concurrency 升档后，prod 对应 self-edge stub 的 `account.concurrency` 必须同步抬升。op 用 [`anthropic-stub-mirror-concurrency-apply-template.sql`](../../../deploy/aws/stage0/anthropic-stub-mirror-concurrency-apply-template.sql) 逐 stub apply（取值 `results[i].expected_concurrency`）。
-   - **R3-unified（declared_rpm + group cap）**：edge `default_group.rpm_limit` 升档后，prod 含该 stub 的所有组（不论 stub-only 还是 mixed）都需要同步更新——stub 的 `extra.declared_rpm` mirror 上游值，group.rpm_limit 重算为 `Σ declared_rpm`。op 用 [`anthropic-prod-group-r3-unified-apply-template.sql`](../../../deploy/aws/stage0/anthropic-prod-group-r3-unified-apply-template.sql) 单事务 apply（取值 `results[i].expected_declared_rpm` + `group_results[i].expected_rpm_limit`）。
-   注意：strict-redline aggregate 模板不适合 prod stub-only / mixed group——它针对 OAuth-bearing edge group，会按 `Σ(base_rpm+sticky_buffer)` 算 prod 没有的字段。R3-unified 模板专门处理 prod 侧。旧 [`anthropic-stub-mirror-rpm-apply-template.sql`](../../../deploy/aws/stage0/anthropic-stub-mirror-rpm-apply-template.sql) 已弃用（保留审计 trail）。
-5. **切默认** — 全部 strict-mode 巡检通过后，另起一个小 PR 把 `--strict-redline` 翻成默认（或删除旧口径），完成切换。
-
-### 3.3 模板 SQL 是 apply 源头
-
-更新配置时禁止临时手写 SQL 或直接拼一份新的字段清单。必须从仓库模板复制出本次执行 SQL，再只替换本次目标变量和经 `plan-apply` 确认的差异：
-
-- 账号 tier/stability/TLS baseline 更新：复制 `deploy/aws/stage0/anthropic-oauth-stability-tiered-apply-template.sql`
-- 分组聚合 rpm 更新（OAuth-bearing edge group）：复制 `deploy/aws/stage0/anthropic-oauth-group-aggregate-apply-template.sql`
-- R1 镜像 concurrency 更新（prod 单 stub）：复制 `deploy/aws/stage0/anthropic-stub-mirror-concurrency-apply-template.sql`
-- R3-unified `declared_rpm` + group cap 更新（prod 任意 anthropic group）：复制 `deploy/aws/stage0/anthropic-prod-group-r3-unified-apply-template.sql`
-- ⚠ 已弃用：`deploy/aws/stage0/anthropic-stub-mirror-rpm-apply-template.sql`（保留审计 trail，新写入禁用，违反 R3-unified 的 absorb-zero 算式）
-
-推荐落点：`$CLAUDE_JOB_DIR/<edge>-<target>-apply.sql`，不要改原模板来执行单次任务。复制后必须生成**自包含 SQL**：把模板正文复制进该文件，并在文件顶部写入本次 `\set account_name`、`\set stability_tier`、`\set group_name` 等变量；远端 edge 不保证存在仓库 checkout，所以禁止让 SSM/psql 执行依赖远端文件路径的 `\i deploy/aws/stage0/...`。复制后必须保留模板里的 profile、tier、聚合口径和事务结构；只允许改执行变量或经 `plan-apply` 确认过的字面值。若需求确实要求模板未覆盖的新字段，先更新模板和本 skill，再执行 apply，避免 checker、模板和人工 SQL 分叉。
-
-### 3.4 账号模式（target_scope=account）
-
-安全限制：
-- `apply` 仅允许单 edge + 单账号；
-- 出现 `edge_id=all` 或 `account_name=all` 一律拒绝执行。
-
-预检 mixed-channel 风险（涉及 `group_ids` 时）：
-- 先调用 `POST /api/v1/admin/accounts/check-mixed-channel`
-- 若预检返回风险且未明确确认，停止执行。
-
-执行策略：
-1. 从 `anthropic-oauth-stability-tiered-apply-template.sql` 复制模板正文，生成自包含本次 SQL；
-2. 在本次 SQL 顶部写入 `account_name` 与 `stability_tier`；
-3. 如需改分组绑定，先完成 mixed-channel 预检，再在同一份自包含 SQL 中加入经确认的绑定变更；
-4. 通过 SSM 把该自包含 SQL 作为 heredoc 传给目标 edge 的 `tokenkey-postgres` 容器执行，不依赖远端目录。
-
-### 3.5 分组模式（target_scope=group）
-
-安全限制：
-- `apply` 仅允许单 edge + 单分组；
-- 出现 `edge_id=all`、`target_group_id=all`、`target_group_name=all` 一律拒绝执行。
-
-执行策略：
-1. 固定成员快照：先锁定分组内可用账号清单（执行期不允许隐式扩容）；
-2. 逐账号预检：若涉及分组重绑，逐账号做 mixed-channel 预检；
-3. 对每个需要收敛的成员账号，基于 `anthropic-oauth-stability-tiered-apply-template.sql` 生成自包含 SQL 并执行；
-4. 成员账号全部收敛后，基于 `anthropic-oauth-group-aggregate-apply-template.sql` 生成自包含 SQL 更新分组聚合 rpm；
-5. 失败即停：任一账号或分组聚合更新失败立即停止，并输出已成功列表与待处理列表。
-
-幂等要求：
-- 对已收敛账号重复 apply 不应产生额外副作用；
-- 结果输出必须包含 `applied_count` / `skipped_count` / `failed_count`。
-
-## 4) 变更后复核
-
-`apply` 完成后必须自动复核：
-
-1. 再跑一次 `operation=check`；
-2. 对比前后 `diff_count` 与 `diffs`；
-3. 输出结构化结果。
-
-账号模式输出：
-- `edge_id`
-- `account_name`
-- 更新字段列表
-- 分组变更（若有）
-- 复核状态（是否收敛到 `diff_count=0`）
-
-分组模式输出：
-- `edge_id`
-- `target_group_id` / `target_group_name`
-- `member_total` / `applied_count` / `failed_count`
-- `group_agg_before` / `group_agg_after`（含 total_base_rpm 等）
-- `remaining_drift_accounts[]`
-- 复核状态（是否全成员收敛）
-
-## 5) 可选：更新 stable_accounts（仅人工确认后）
-
-仅在人工确认“该账号已稳定且应纳入基线名单”时执行：
-
-```bash
-python3 ops/anthropic/check-edge-oauth-stability.py \
-  --edge-id "$EDGE_ID" \
-  --account-name "$ACCOUNT_NAME" \
-  --update-stable-list \
-  --confirm yes-update-anthropic-stable-list
-```
-
-禁止在未确认稳定前更新 stable list。
-
-## 6) 失败处理与回滚
-
-- mixed-channel 预检失败：停止，不写入。
-- 更新 API 非 2xx：停止并报告响应摘要，不继续后续动作。
-- 复核仍有漂移：输出残余差异，进入人工判断（再次 apply 或回滚）。
-- 回滚策略：使用同一更新 API 按变更前快照反向写回（账号字段 + group_ids）。
-
-## 7) 输出模板（建议）
-
-单目标模式（账号）：
-
-```text
-target_scope=account
-edge_id=<id>
-account_name=<name>
-operation=<check|plan-apply|apply>
-status=<ok|drift|applied|failed>
-diff_count_before=<n>
-diff_count_after=<n>
-updated_fields=<...>
-group_ids_change=<unchanged|cleared|rebinding:...>
-notes=<risk/precheck/rollback info>
-```
-
-单目标模式（分组）：
-
-```text
-target_scope=group
-edge_id=<id>
-target_group_id=<id>
-target_group_name=<name>
-operation=<check|plan-apply|apply>
-status=<ok|drift|applied|failed>
-member_total=<n>
-applied_count=<n>
-failed_count=<n>
-group_agg.total_base_rpm=<sum>
-group_agg.total_redline=<sum>
-group_agg.total_max_sessions=<sum>
-group_agg.total_window_cost_limit=<sum>
-notes=<risk/precheck/rollback info>
-```
-
-批量模式（任一参数为 `all`）：
-
-```text
-mode=batch
-selector.edge_id=<id|all>
-selector.account_name=<name|all>
-summary.edge_total=<n>
-summary.account_result_total=<n>
-summary.ok_count=<n>
-summary.drift_count=<n>
-summary.error_count=<n>
-```
-
-## 8) 故障速查
-
-| 现象 | 根因 | 处理 |
-|---|---|---|
-| check 失败且无结果 | edge 目标元数据缺失或 SSM 查询失败 | 先校验 `edge-targets.json`、区域与栈、OIDC/SSM 权限 |
-| apply 被拒绝 | 未提供固定确认口令 | 传入 `confirm_apply=yes-apply-edge-anthropic-oauth` |
-| 分组更新失败 | `group_ids` 含不存在分组或 mixed-channel 风险未通过 | 先调用 mixed-channel 预检并修正分组 |
-| apply 成功但仍有漂移 | 仅更新了部分字段或存在额外策略字段；或并发会话覆盖了写入 | 对照 `diffs` 补齐字段后重试；如同步发现 `updated_at` 在 apply 之后被改 → 触发"Pre-apply re-read 协议"调查另一会话 |
-| 稳定名单更新失败 | 缺确认口令 | 使用 `--confirm yes-update-anthropic-stable-list` |
-| guard 报 `r3_declared_rpm_missing` | apikey stub 未在 `extra` 中落档 declared_rpm | 用 R3-unified apply 模板补齐（self-edge 取上游 default.rpm_limit，external 由 operator 拍配额） |
-| guard 报 `r3_declared_rpm_zero_forbidden` | declared_rpm ≤ 0 | 同上；R3-unified 禁止 unlimited |
-| guard 报 `r3_self_edge_mirror_drift` | edge default.rpm_limit 涨过 / 缩过，prod stub declared_rpm 未跟上 | 取上游实时 rpm_limit，用 R3-unified apply 模板对齐 |
-| guard 报 `r3_group_rpm_zero_forbidden` | 含 stub 的组 `rpm_limit=0`（unlimited） | 用 R3-unified apply 模板把组写到 Σ declared_rpm |
-| guard 报 `r3_group_sum_mismatch` | group.rpm_limit ≠ Σ stub.declared_rpm | 同上 |
-| guard 报 `r3_group_sum_blocked_by_stub_violation` | 组级 SUM 校验被某 stub 级 missing/zero 阻塞 | 先解决 stub 级违规 |
-| apply 模板 DO 块 RAISE "stub_inputs SUM(declared_rpm)=A does not match :target_group_rpm=B" | plan 与 apply 数字不一致 | 重做 plan-apply，写入一致的 SUM 与 group cap |
-| apply 模板 DO 块 RAISE "group id=X has Y member(s) but stub_inputs has Z row(s)" | plan/apply 期间组成员被增删 | 重新拉成员快照 → re-plan → re-apply |
-| guard 报 `--legacy-r3` PASS 但默认模式 FAIL | rollout 过渡窗口未完成 | 不接受 legacy 模式为 PASS；按 R3-unified 修复路径 apply |
-
-## 扩展阅读
-
+历史背景：2026-05-21 之前 R3 用 absorb-zero，mixed group（含 external）→ `rpm_limit=0`（unlimited），是唯一无 RPM 闸门的对外入口。R3-unified 把 unlimited 从合法状态删除，强制每个 stub 显式声明产能。
+
+## 4. 故障速查
+
+| 现象 / violation kind | 处理 |
+|---|---|
+| snapshot 失败 / SSM 拒绝 | 校验 EC2 instance 在跑 / `edge-targets.json` / OIDC 权限 |
+| `apply --confirm` 拒绝 | 必须精确 `yes-apply-anthropic-config-cascade` |
+| `r1_mirror_drift` | edge OAuth concurrency 改了但 prod stub 未跟上 → `plan-edge-account-tier` 重新算 |
+| `r3_declared_rpm_missing` | stub 缺 `extra.declared_rpm` → orchestrator 不应漏写；查 apply-report 看哪 step 失败 |
+| `r3_declared_rpm_zero_forbidden` | declared_rpm ≤ 0 写入 → 检查 plan.json 的 stub_inputs 值是否被外部改成 0 |
+| `r3_self_edge_mirror_drift` | edge default.rpm_limit 改了但 prod stub declared_rpm 未跟上 → `plan-edge-account-tier` |
+| `r3_group_rpm_zero_forbidden` | prod group rpm_limit 被外部回退到 0 → 重跑 plan + apply |
+| `r3_group_sum_mismatch` | group.rpm_limit ≠ Σ declared_rpm → 重跑 plan + apply |
+| `upstream_no_active_oauth` | edge default group 没有 active OAuth（status=error/suspended/软删）→ edge OAuth 健康问题，不是镜像数学错误 |
+| apply 模板 DO-block RAISE "stub_inputs SUM=...mismatch...:target_group_rpm=..." | plan 与 apply 间被并发会话改了；重新 snapshot + plan |
+| apply 模板 DO-block RAISE "group has X members but stub_inputs has Y" | 组成员被增删；重新 snapshot + plan |
+| verify drift | operator 决定再 apply 或回滚（用 admin 前端按 plan.live_inputs 的 *_before 反向写回） |
+
+## 5. 附录 A：底层工具（emergency / debug）
+
+正常流程**只走 5 阶段流水线**。下列工具在流水线 break 或紧急 rollback 时直接用：
+
+**Guards**（只读检查）：
+- `ops/anthropic/check-prod-stub-mirror.py [--json] [--legacy-r3]` — R1 + R3-unified
+- `ops/anthropic/check-edge-oauth-stability.py --edge-id E --account-name A [--json] [--emit-sql FILE]` — edge OAuth tier baseline drift
+- `ops/anthropic/check-account-group-rpm-alignment.py --target T [--strict-redline] [--json]` — Layer A/B/C 校验
+
+**Apply 模板**（每个都自包含、有 DO-block 校验；orchestrator 内部自动渲染，手动写需要自包含 SQL 起手 `\set ...` 然后 base64 通过 SSM 注入）：
+- `deploy/aws/stage0/anthropic-oauth-stability-tiered-apply-template.sql` — edge OAuth tier
+- `deploy/aws/stage0/anthropic-oauth-group-aggregate-apply-template.sql` — edge OAuth group cap（strict-redline）
+- `deploy/aws/stage0/anthropic-stub-mirror-concurrency-apply-template.sql` — prod stub R1 concurrency
+- `deploy/aws/stage0/anthropic-prod-group-r3-unified-apply-template.sql` — prod stub declared_rpm + group cap（单事务）
+- ⚠ deprecated：`deploy/aws/stage0/anthropic-stub-mirror-rpm-apply-template.sql`（顶部 DO-block hard gate，需 `SET app.ack_deprecated='yes-r3-unified-replaces-this'` 才能跑；仅用于 emergency rollback）
+
+**底线**：手动绕开 orchestrator 时 op 必须自己完成 cascade 计算 + DO-block 校验 + apply 后复核——同样不允许跳过 § 1 "先查后说"协议。
+
+## 6. 附录 B：tier baseline 与 stable accounts
+
+- baseline JSON：`deploy/aws/stage0/anthropic-oauth-stability-baselines-tiered.json`（`tier_order: l1..l5`，每个 tier 含 `baseline.account.*` 与 `baseline.extra.*`，orchestrator 在 plan-edge-account-tier 中读它算 cascade）
+- 更新 stable_accounts 列表（仅人工确认后）：
+  ```bash
+  python3 ops/anthropic/check-edge-oauth-stability.py \
+    --edge-id $EDGE --account-name $ACCT \
+    --update-stable-list --confirm yes-update-anthropic-stable-list
+  ```
+  禁止在未确认稳定前更新 stable list。
+
+## 7. 扩展阅读
+
+- `ops/anthropic/manage-anthropic-config.py`（5 阶段 orchestrator，本 skill 唯一推荐入口）
+- `ops/anthropic/check-prod-stub-mirror.py`（R1 + R3-unified guard）
 - `ops/anthropic/check-edge-oauth-stability.py`
 - `ops/anthropic/check-account-group-rpm-alignment.py`
-- `ops/anthropic/check-prod-stub-mirror.py`（R1 + R3-unified guard）
 - `deploy/aws/stage0/anthropic-oauth-stability-baselines-tiered.json`
-- `deploy/aws/stage0/anthropic-oauth-stability-tiered-apply-template.sql`（OAuth 账号 tier）
-- `deploy/aws/stage0/anthropic-oauth-group-aggregate-apply-template.sql`（OAuth-bearing edge group）
-- `deploy/aws/stage0/anthropic-stub-mirror-concurrency-apply-template.sql`（R1 stub concurrency）
-- `deploy/aws/stage0/anthropic-prod-group-r3-unified-apply-template.sql`（R3-unified stub declared_rpm + group cap）
-- ⚠ deprecated：`deploy/aws/stage0/anthropic-stub-mirror-rpm-apply-template.sql`（仅保留审计 trail）
+- `deploy/aws/stage0/anthropic-oauth-stability-tiered-apply-template.sql`
+- `deploy/aws/stage0/anthropic-oauth-group-aggregate-apply-template.sql`
+- `deploy/aws/stage0/anthropic-stub-mirror-concurrency-apply-template.sql`
+- `deploy/aws/stage0/anthropic-prod-group-r3-unified-apply-template.sql`
+- ⚠ deprecated：`deploy/aws/stage0/anthropic-stub-mirror-rpm-apply-template.sql`
 - `backend/internal/handler/admin/account_handler.go`
 - `backend/internal/service/admin_service.go`
 - `backend/internal/repository/account_repo.go`

--- a/ops/anthropic/manage-anthropic-config.py
+++ b/ops/anthropic/manage-anthropic-config.py
@@ -203,11 +203,17 @@ def ssm_run_sql(region: str, instance_id: str, sql: str, comment: str) -> tuple[
     return (inv.get("StandardOutputContent") or "").strip(), cid
 
 
-def ssm_run_sql_b64(region: str, instance_id: str, sql_b64: str, comment: str) -> tuple[str, str]:
+def ssm_run_sql_b64(region: str, instance_id: str, sql_b64: str, comment: str
+                     ) -> tuple[str, str, bool, str]:
     """For apply: send base64-encoded SQL so embedded quotes/heredocs don't escape.
 
     Uses -A -t (unaligned + tuples-only) so jsonb_pretty() output is a parseable
     JSON blob, not psql's "key | { ... +" expanded-mode decoration.
+
+    Returns (stdout, ssm_command_id, success, stderr_preview).  cid is always
+    a valid SSM CommandId string (never decorated with a status suffix), so
+    callers can still feed it to ``aws ssm get-command-invocation`` for
+    after-the-fact debugging even when success=False.
     """
     command = (
         "set -euo pipefail\n"
@@ -252,11 +258,14 @@ def ssm_run_sql_b64(region: str, instance_id: str, sql_b64: str, comment: str) -
             text=True,
         )
     )
-    if inv.get("Status") != "Success" or inv.get("ResponseCode") != 0:
-        err = (inv.get("StandardErrorContent") or "").strip()[:1200]
-        out_preview = (inv.get("StandardOutputContent") or "").strip()[:600]
-        return out_preview, cid + " FAILED"  # let caller detect via exit_status
-    return (inv.get("StandardOutputContent") or "").strip(), cid
+    stdout = (inv.get("StandardOutputContent") or "").strip()
+    stderr = (inv.get("StandardErrorContent") or "").strip()[:1200]
+    success = inv.get("Status") == "Success" and inv.get("ResponseCode") == 0
+    if not success:
+        # Truncate stdout for noisy DO-block RAISE output; full stdout still
+        # available via aws ssm get-command-invocation --command-id <cid>.
+        stdout = stdout[:600]
+    return stdout, cid, success, stderr
 
 
 # --------------------------------------------------------------------------
@@ -628,12 +637,28 @@ def _stub_by_id(snap: dict, account_id: int) -> dict | None:
     return None
 
 
+def _is_oauth_active(acc: dict, override_account: str | None) -> bool:
+    """Active-account filter mirroring the guards' `WHERE a.status = 'active'`.
+
+    The override account (the one whose tier we're about to change) is always
+    treated as active for the purpose of cascade math — even if it's currently
+    status=error, the new tier baseline is what the edge group cap should mirror
+    after apply.  Without this carve-out, an attempt to recover a status=error
+    account by raising/lowering its tier would compute a cap that excludes the
+    very account being repaired.
+    """
+    if override_account and acc.get("name") == override_account:
+        return True
+    return acc.get("status") == "active"
+
+
 def _edge_default_redline_sum(edge: dict, override_account: str | None = None,
                                override_fields: dict | None = None) -> int:
     """Recompute edge default group's rpm_limit = absorb_zero_sum(base+sticky_buffer).
 
     If override_account is given, that account's base/sticky are taken from
-    override_fields instead of the snapshot.
+    override_fields instead of the snapshot.  Inactive accounts are excluded
+    by white-list (status='active'), matching the guards' SQL.
     """
     grp = _find_edge_group(edge, "default")
     if not grp:
@@ -643,7 +668,7 @@ def _edge_default_redline_sum(edge: dict, override_account: str | None = None,
     for acc in edge.get("oauth_accounts", []):
         if acc["id"] not in members:
             continue
-        if acc.get("status") in ("disabled", "suspended"):
+        if not _is_oauth_active(acc, override_account):
             continue
         if override_account and acc.get("name") == override_account and override_fields:
             base = int(override_fields.get("base_rpm") or 0)
@@ -665,7 +690,7 @@ def _edge_default_concurrency_sum(edge: dict, override_account: str | None = Non
     for acc in edge.get("oauth_accounts", []):
         if acc["id"] not in members:
             continue
-        if acc.get("status") in ("disabled", "suspended"):
+        if not _is_oauth_active(acc, override_account):
             continue
         if override_account and acc.get("name") == override_account and override_fields:
             concs.append(int(override_fields.get("concurrency") or 0))
@@ -685,7 +710,57 @@ def cmd_plan_edge_account_tier(args: argparse.Namespace) -> int:
     edge = _find_edge(snap, args.edge_id)
     target_account = _find_edge_account(edge, args.account_name)
 
-    # Edge default group cap recomputed with override
+    # Hard guard: orchestrator currently models the cascade only for the
+    # edge anthropic 'default' group.  If the OAuth account is bound to
+    # additional anthropic groups, those groups' rpm_limit math would
+    # silently drift after apply.  Refuse plan and point operator to
+    # Appendix A emergency mode instead of producing a partially-wrong plan.
+    default_grp = _find_edge_group(edge, "default")
+    if not default_grp:
+        fail(f"edge {args.edge_id!r} has no anthropic 'default' group; cannot plan tier cascade")
+    bindings = list(target_account.get("group_bindings", []))
+    if bindings != [default_grp["id"]]:
+        fail(
+            f"edge OAuth account {args.account_name!r} (edge {args.edge_id}) is bound to groups "
+            f"{bindings}; orchestrator only supports accounts bound to exactly the edge 'default' "
+            f"group (id={default_grp['id']}). Multi-group OAuth bindings require Appendix A "
+            f"emergency mode so the operator can hand-roll the cascade for each affected group."
+        )
+
+    # Short-circuit no-op: target tier == current tier AND no other field drift.
+    current_tier = (target_account.get("stability_tier") or "").lower()
+    fields_match = all(
+        target_account.get(k) == baseline.get(k)
+        for k in ("base_rpm", "rpm_sticky_buffer", "concurrency", "max_sessions")
+    )
+    if current_tier == tier_key and fields_match:
+        print(
+            f"plan: account {args.account_name!r} on edge {args.edge_id} is already at "
+            f"tier {tier_key} with matching baseline fields — emitting empty plan.",
+            file=sys.stderr,
+        )
+        empty_plan = {
+            "version": PLAN_VERSION,
+            "kind": "edge_account_tier_change",
+            "confirm_code": CONFIRM_CODE,
+            "intent": {"edge_id": args.edge_id, "account_name": args.account_name, "new_tier": tier_key},
+            "snapshot_captured_at": snap.get("captured_at"),
+            "plan_built_at": now_utc_iso(),
+            "noop": True,
+            "noop_reason": "current tier and baseline fields already match target",
+            "summary": {"total_steps": 0, "edge_changes": 0, "prod_changes": 0},
+            "live_inputs": {"edge_account_before": target_account},
+            "actions": [],
+        }
+        out_str = json.dumps(empty_plan, indent=2, ensure_ascii=False)
+        if args.out:
+            pathlib.Path(args.out).write_text(out_str)
+            print(f"plan: written {args.out} (noop)", file=sys.stderr)
+        else:
+            print(out_str)
+        return 0
+
+    # Edge default group cap recomputed with override (active-only filter)
     new_edge_default_rpm = _edge_default_redline_sum(
         edge, override_account=args.account_name, override_fields=baseline,
     )
@@ -1098,25 +1173,33 @@ def cmd_apply(args: argparse.Namespace) -> int:
         region, instance_id, target_label = _resolve_action_target(action, edge_matrix)
         sql_b64 = base64.b64encode(sql.encode("utf-8")).decode("ascii")
         print(f"apply: step{step:02d} {kind} → {target_label}  (sql={sql_path})", file=sys.stderr)
-        stdout, cid = ssm_run_sql_b64(region, instance_id, sql_b64,
-                                       f"apply step {step} {kind} on {target_label}")
-        output_json = _extract_output_json(stdout)
-        mismatches = _verify_expected_after(action, output_json)
+        stdout, cid, ssm_ok, stderr = ssm_run_sql_b64(
+            region, instance_id, sql_b64,
+            f"apply step {step} {kind} on {target_label}",
+        )
+        output_json = _extract_output_json(stdout) if ssm_ok else None
+        mismatches = _verify_expected_after(action, output_json) if ssm_ok else []
         result = {
             "step": step,
             "kind": kind,
             "target_label": target_label,
             "sql_path": str(sql_path),
             "ssm_command_id": cid,
+            "ssm_ok": ssm_ok,
             "stdout_preview": stdout[-1200:],
+            "stderr_preview": stderr,
             "output_json": output_json,
             "expected_after": action.get("expected_after"),
             "mismatches": mismatches,
-            "ok": cid.endswith("FAILED") is False and not mismatches,
+            "ok": ssm_ok and not mismatches,
         }
-        if cid.endswith("FAILED"):
-            result["ok"] = False
-            result["error"] = "SSM exit_status indicates failure; see stdout_preview / SSM logs"
+        if not ssm_ok:
+            result["error"] = (
+                "SSM ResponseCode != 0; remote SQL likely failed (DO-block RAISE or "
+                "psql ON_ERROR_STOP). Inspect via: "
+                f"aws ssm get-command-invocation --region {region} "
+                f"--instance-id {instance_id} --command-id {cid}"
+            )
         results.append(result)
         if not result["ok"]:
             print(f"apply: step{step:02d} FAILED — stopping. cid={cid}", file=sys.stderr)
@@ -1207,23 +1290,20 @@ def cmd_verify(args: argparse.Namespace) -> int:
     plan_path = pathlib.Path(args.plan)
     plan = load_json_file(plan_path, "plan")
 
-    print("verify: capturing fresh snapshot...", file=sys.stderr)
-    snap_ns = argparse.Namespace(
-        out=None, allow_planned=False, prod_instance_id=None,
-    )
-    # Capture snapshot to a temp file via a subprocess call to ourselves so the
-    # snapshot subcommand handles all SSM resolution / printing identically.
     snap_path = pathlib.Path(args.snapshot_out) if args.snapshot_out else pathlib.Path(
         f"/tmp/anthropic-verify-snap-{_dt.datetime.now().strftime('%Y%m%d-%H%M%S')}.json"
     )
-    res = subprocess.run(
-        ["python3", str(pathlib.Path(__file__)), "snapshot",
-         "--out", str(snap_path)]
-        + (["--allow-planned"] if args.allow_planned else []),
-        check=False,
+    print(f"verify: capturing fresh snapshot → {snap_path}", file=sys.stderr)
+    # Call cmd_snapshot in-process — same module, same imports, same SSM
+    # auth — no subprocess overhead or argparse marshaling.
+    snap_args = argparse.Namespace(
+        out=str(snap_path),
+        prod_instance_id=None,
+        allow_planned=args.allow_planned,
     )
-    if res.returncode != 0:
-        fail(f"verify: re-snapshot exited {res.returncode}")
+    rc = cmd_snapshot(snap_args)
+    if rc != 0:
+        fail(f"verify: re-snapshot exited {rc}")
     snap = load_json_file(snap_path, "verify snapshot")
 
     drift: list[dict] = []

--- a/ops/anthropic/manage-anthropic-config.py
+++ b/ops/anthropic/manage-anthropic-config.py
@@ -1,0 +1,1326 @@
+#!/usr/bin/env python3
+"""
+TokenKey Anthropic configuration orchestrator (5-stage pipeline).
+
+One entrypoint, five subcommands, one file format (plan JSON) between
+stages.  Replaces the manual sequence of running multiple guard scripts +
+copying multiple SQL templates that was documented as §§ 3.4 / 3.5 / 4 of
+the anthropic-oauth-config skill.
+
+Stages
+------
+  1. snapshot                — pull prod + each referenced edge into one JSON
+  2. check                   — run all three guards against the snapshot
+  3. plan-edge-account-tier  — declare an edge OAuth tier change; emit plan
+     plan-external-stub      — declare an external apikey quota change; emit plan
+  4. apply                   — execute the plan: each action renders an
+                               existing SQL template, runs it via SSM,
+                               compares STDOUT against expected_after
+  5. verify                  — re-snapshot, diff each expected_after vs live
+
+All cascading math (edge account tier → edge group cap → prod stub
+concurrency / declared_rpm → prod group rpm_limit) lives in plan-*.
+Apply is pure execution — no recomputation, no surprises.
+
+The orchestrator owns no SQL: every UPDATE goes through one of the four
+templates in `deploy/aws/stage0/anthropic-*.sql`.  Adding a new mutation
+surface means: (a) add a template, (b) add a `render_<kind>()` here,
+(c) add the kind to plan-* and apply.  The skill documents the protocol;
+this script is the protocol's only legitimate implementation.
+
+Exit codes
+----------
+  0  command succeeded; for check/verify, no violations / no drift
+  1  command ran but reported violations / drift / apply step failure
+  2  setup / SSM / target-resolution / schema error
+
+Usage
+-----
+  manage-anthropic-config.py snapshot --out snap.json
+  manage-anthropic-config.py check --snapshot snap.json
+  manage-anthropic-config.py plan-edge-account-tier \\
+      --edge uk1 --account en-ld-ec2-16-1-b --tier l2 \\
+      --snapshot snap.json --out plan.json
+  manage-anthropic-config.py plan-external-stub \\
+      --stub tokensea-0.4 --declared-rpm 150 \\
+      --snapshot snap.json --out plan.json
+  manage-anthropic-config.py apply --plan plan.json \\
+      --confirm yes-apply-anthropic-config-cascade
+  manage-anthropic-config.py verify --plan plan.json
+"""
+from __future__ import annotations
+
+import argparse
+import base64
+import datetime as _dt
+import json
+import os
+import pathlib
+import re
+import subprocess
+import sys
+from typing import Any
+
+REPO_ROOT = pathlib.Path(__file__).resolve().parents[2]
+EDGE_MATRIX = REPO_ROOT / "deploy/aws/stage0/edge-targets.json"
+TIER_BASELINES = REPO_ROOT / "deploy/aws/stage0/anthropic-oauth-stability-baselines-tiered.json"
+TEMPLATE_DIR = REPO_ROOT / "deploy/aws/stage0"
+OPS_DIR = REPO_ROOT / "ops/anthropic"
+
+PROD = {
+    "label": "prod",
+    "stack": "tokenkey-prod-stage0",
+    "region": "us-east-1",
+}
+
+SELF_EDGE_BASE_URL_RE = re.compile(
+    r"^https?://api-(?P<edge_id>[a-z0-9-]+)\.tokenkey\.dev/?$"
+)
+
+CONFIRM_CODE = "yes-apply-anthropic-config-cascade"
+
+PLAN_VERSION = 1
+SNAPSHOT_VERSION = 1
+
+
+# --------------------------------------------------------------------------
+# Utility
+# --------------------------------------------------------------------------
+
+def fail(msg: str, code: int = 2) -> None:
+    print(f"::error::{msg}", file=sys.stderr)
+    sys.exit(code)
+
+
+def now_utc_iso() -> str:
+    return _dt.datetime.now(_dt.timezone.utc).strftime("%Y-%m-%dT%H:%M:%SZ")
+
+
+def absorb_zero_sum(values: list[int]) -> int:
+    """R1 (concurrency) aggregation: 0 means unlimited, propagates."""
+    if any(v == 0 for v in values):
+        return 0
+    return sum(values)
+
+
+def load_json_file(path: pathlib.Path, what: str) -> Any:
+    if not path.exists():
+        fail(f"{what} not found: {path}")
+    try:
+        return json.loads(path.read_text())
+    except json.JSONDecodeError as e:
+        fail(f"{what} parse error ({path}): {e}")
+    return None  # unreachable
+
+
+# --------------------------------------------------------------------------
+# AWS / SSM plumbing
+# --------------------------------------------------------------------------
+
+def resolve_instance_id(region: str, stack: str) -> str:
+    try:
+        out = subprocess.check_output(
+            [
+                "aws", "cloudformation", "describe-stacks",
+                "--region", region,
+                "--stack-name", stack,
+                "--query", "Stacks[0].Outputs[?OutputKey=='InstanceId'].OutputValue",
+                "--output", "text",
+            ],
+            text=True,
+        ).strip()
+    except subprocess.CalledProcessError as e:
+        fail(f"describe-stacks failed for {stack}/{region}: {e}")
+    if not out or out == "None":
+        # Fallback: try describe-stack-resources for AWS::EC2::Instance
+        try:
+            out = subprocess.check_output(
+                [
+                    "aws", "cloudformation", "describe-stack-resources",
+                    "--region", region,
+                    "--stack-name", stack,
+                    "--query", "StackResources[?ResourceType=='AWS::EC2::Instance'].PhysicalResourceId | [0]",
+                    "--output", "text",
+                ],
+                text=True,
+            ).strip()
+        except subprocess.CalledProcessError as e:
+            fail(f"describe-stack-resources fallback failed for {stack}/{region}: {e}")
+    if not out or out == "None":
+        fail(f"no InstanceId resolvable for stack {stack}/{region}")
+    return out
+
+
+def ssm_run_sql(region: str, instance_id: str, sql: str, comment: str) -> tuple[str, str]:
+    """Pipe SQL to docker exec tokenkey-postgres via SSM. Returns (stdout, command_id)."""
+    remote = "sudo docker exec -i tokenkey-postgres psql -U tokenkey -d tokenkey -t -A -v ON_ERROR_STOP=1"
+    command = f"set -euo pipefail\n{remote} <<'SQL'\n{sql}\nSQL"
+    params = json.dumps({"commands": [command]}, ensure_ascii=False)
+    try:
+        cid = subprocess.check_output(
+            [
+                "aws", "ssm", "send-command",
+                "--region", region,
+                "--instance-ids", instance_id,
+                "--document-name", "AWS-RunShellScript",
+                "--comment", comment,
+                "--parameters", params,
+                "--query", "Command.CommandId",
+                "--output", "text",
+            ],
+            text=True,
+        ).strip()
+    except subprocess.CalledProcessError as e:
+        fail(f"ssm send-command failed ({comment}): {e}")
+    subprocess.run(
+        [
+            "aws", "ssm", "wait", "command-executed",
+            "--region", region,
+            "--command-id", cid,
+            "--instance-id", instance_id,
+        ],
+        check=False,
+    )
+    inv = json.loads(
+        subprocess.check_output(
+            [
+                "aws", "ssm", "get-command-invocation",
+                "--region", region,
+                "--command-id", cid,
+                "--instance-id", instance_id,
+                "--output", "json",
+            ],
+            text=True,
+        )
+    )
+    if inv.get("Status") != "Success" or inv.get("ResponseCode") != 0:
+        err = (inv.get("StandardErrorContent") or "").strip()[:1200]
+        out_preview = (inv.get("StandardOutputContent") or "").strip()[:600]
+        fail(
+            f"ssm cmd {cid} status={inv.get('Status')} rc={inv.get('ResponseCode')} ({comment})\n"
+            f"  stderr: {err}\n  stdout: {out_preview}"
+        )
+    return (inv.get("StandardOutputContent") or "").strip(), cid
+
+
+def ssm_run_sql_b64(region: str, instance_id: str, sql_b64: str, comment: str) -> tuple[str, str]:
+    """For apply: send base64-encoded SQL so embedded quotes/heredocs don't escape.
+
+    Uses -A -t (unaligned + tuples-only) so jsonb_pretty() output is a parseable
+    JSON blob, not psql's "key | { ... +" expanded-mode decoration.
+    """
+    command = (
+        "set -euo pipefail\n"
+        f"echo {sql_b64} | base64 -d | sudo docker exec -i tokenkey-postgres "
+        "psql -U tokenkey -d tokenkey -v ON_ERROR_STOP=1 -X -A -t"
+    )
+    params = json.dumps({"commands": [command]}, ensure_ascii=False)
+    try:
+        cid = subprocess.check_output(
+            [
+                "aws", "ssm", "send-command",
+                "--region", region,
+                "--instance-ids", instance_id,
+                "--document-name", "AWS-RunShellScript",
+                "--comment", comment,
+                "--parameters", params,
+                "--query", "Command.CommandId",
+                "--output", "text",
+            ],
+            text=True,
+        ).strip()
+    except subprocess.CalledProcessError as e:
+        fail(f"ssm send-command failed ({comment}): {e}")
+    subprocess.run(
+        [
+            "aws", "ssm", "wait", "command-executed",
+            "--region", region,
+            "--command-id", cid,
+            "--instance-id", instance_id,
+        ],
+        check=False,
+    )
+    inv = json.loads(
+        subprocess.check_output(
+            [
+                "aws", "ssm", "get-command-invocation",
+                "--region", region,
+                "--command-id", cid,
+                "--instance-id", instance_id,
+                "--output", "json",
+            ],
+            text=True,
+        )
+    )
+    if inv.get("Status") != "Success" or inv.get("ResponseCode") != 0:
+        err = (inv.get("StandardErrorContent") or "").strip()[:1200]
+        out_preview = (inv.get("StandardOutputContent") or "").strip()[:600]
+        return out_preview, cid + " FAILED"  # let caller detect via exit_status
+    return (inv.get("StandardOutputContent") or "").strip(), cid
+
+
+# --------------------------------------------------------------------------
+# Stage 1 — snapshot
+# --------------------------------------------------------------------------
+
+PROD_STUBS_SQL = """
+SELECT COALESCE(jsonb_agg(jsonb_build_object(
+  'id', a.id, 'name', a.name, 'platform', a.platform, 'type', a.type,
+  'concurrency', a.concurrency,
+  'channel_type', a.channel_type,
+  'rate_multiplier', a.rate_multiplier,
+  'auto_pause_on_expired', a.auto_pause_on_expired,
+  'status', a.status,
+  'base_url', a.credentials->>'base_url',
+  'declared_rpm', NULLIF(a.extra->>'declared_rpm', '')::int,
+  'group_bindings', COALESCE((
+    SELECT jsonb_agg(group_id ORDER BY group_id)
+    FROM account_groups WHERE account_id = a.id
+  ), '[]'::jsonb)
+) ORDER BY a.id), '[]'::jsonb)
+FROM accounts a
+WHERE a.platform = 'anthropic'
+  AND a.type = 'apikey'
+  AND a.deleted_at IS NULL;
+"""
+
+PROD_GROUPS_WITH_STUBS_SQL = """
+SELECT COALESCE(jsonb_agg(jsonb_build_object(
+  'id', g.id, 'name', g.name, 'rpm_limit', g.rpm_limit,
+  'is_exclusive', g.is_exclusive,
+  'members', COALESCE((
+    SELECT jsonb_agg(account_id ORDER BY account_id)
+    FROM account_groups WHERE group_id = g.id
+  ), '[]'::jsonb)
+) ORDER BY g.id), '[]'::jsonb)
+FROM groups g
+WHERE g.platform = 'anthropic'
+  AND g.deleted_at IS NULL
+  AND EXISTS (
+    SELECT 1 FROM account_groups ag
+    JOIN accounts a ON a.id = ag.account_id
+    WHERE ag.group_id = g.id
+      AND a.platform = 'anthropic'
+      AND a.type = 'apikey'
+      AND a.deleted_at IS NULL
+  );
+"""
+
+EDGE_ACCOUNTS_SQL = """
+SELECT COALESCE(jsonb_agg(jsonb_build_object(
+  'id', a.id, 'name', a.name, 'platform', a.platform, 'type', a.type,
+  'status', a.status, 'concurrency', a.concurrency, 'priority', a.priority,
+  'channel_type', a.channel_type, 'rate_multiplier', a.rate_multiplier,
+  'auto_pause_on_expired', a.auto_pause_on_expired,
+  'stability_tier', a.extra->>'stability_tier',
+  'rpm_strategy', a.extra->>'rpm_strategy',
+  'base_rpm', NULLIF(a.extra->>'base_rpm', '')::int,
+  'rpm_sticky_buffer', NULLIF(a.extra->>'rpm_sticky_buffer', '')::int,
+  'max_sessions', NULLIF(a.extra->>'max_sessions', '')::int,
+  'session_idle_timeout_minutes', NULLIF(a.extra->>'session_idle_timeout_minutes', '')::int,
+  'window_cost_limit', NULLIF(a.extra->>'window_cost_limit', '')::int,
+  'window_cost_sticky_reserve', NULLIF(a.extra->>'window_cost_sticky_reserve', '')::int,
+  'cache_ttl_override_enabled', NULLIF(a.extra->>'cache_ttl_override_enabled', '')::boolean,
+  'group_bindings', COALESCE((
+    SELECT jsonb_agg(group_id ORDER BY group_id)
+    FROM account_groups WHERE account_id = a.id
+  ), '[]'::jsonb)
+) ORDER BY a.id), '[]'::jsonb)
+FROM accounts a
+WHERE a.platform = 'anthropic'
+  AND a.type = 'oauth'
+  AND a.deleted_at IS NULL;
+"""
+
+EDGE_GROUPS_SQL = """
+SELECT COALESCE(jsonb_agg(jsonb_build_object(
+  'id', g.id, 'name', g.name, 'rpm_limit', g.rpm_limit,
+  'is_exclusive', g.is_exclusive,
+  'members', COALESCE((
+    SELECT jsonb_agg(account_id ORDER BY account_id)
+    FROM account_groups WHERE group_id = g.id
+  ), '[]'::jsonb)
+) ORDER BY g.id), '[]'::jsonb)
+FROM groups g
+WHERE g.platform = 'anthropic'
+  AND g.deleted_at IS NULL;
+"""
+
+
+def parse_self_edge_id(base_url: str | None) -> str | None:
+    if not base_url:
+        return None
+    m = SELF_EDGE_BASE_URL_RE.match(base_url)
+    return m.group("edge_id") if m else None
+
+
+def cmd_snapshot(args: argparse.Namespace) -> int:
+    edge_matrix = load_json_file(EDGE_MATRIX, "edge matrix")
+    edge_targets = edge_matrix.get("targets") or {}
+
+    prod_inst = args.prod_instance_id or resolve_instance_id(PROD["region"], PROD["stack"])
+
+    print(f"snapshot: prod_instance={prod_inst}", file=sys.stderr)
+
+    stubs_raw, _ = ssm_run_sql(PROD["region"], prod_inst, PROD_STUBS_SQL, "snapshot: prod stubs")
+    prod_stubs = json.loads(stubs_raw) if stubs_raw else []
+    groups_raw, _ = ssm_run_sql(PROD["region"], prod_inst, PROD_GROUPS_WITH_STUBS_SQL, "snapshot: prod groups with stubs")
+    prod_groups = json.loads(groups_raw) if groups_raw else []
+
+    # Annotate each stub with kind + edge_id
+    for s in prod_stubs:
+        eid = parse_self_edge_id(s.get("base_url"))
+        s["is_self_edge"] = eid is not None
+        s["edge_id"] = eid
+
+    needed_edges = sorted({s["edge_id"] for s in prod_stubs if s.get("edge_id")})
+    print(f"snapshot: edges referenced by prod stubs = {needed_edges}", file=sys.stderr)
+
+    edges: dict[str, dict] = {}
+    for eid in needed_edges:
+        tgt = edge_targets.get(eid)
+        if not tgt:
+            edges[eid] = {"error": f"edge_id {eid!r} not in edge-targets.json"}
+            continue
+        if not tgt.get("deployable") and not args.allow_planned:
+            edges[eid] = {
+                "deployable": False,
+                "skipped_reason": f"edge {eid} is planned; pass --allow-planned to include",
+                "region": tgt.get("region"), "stack": tgt.get("stack"),
+            }
+            continue
+        try:
+            inst = resolve_instance_id(tgt["region"], tgt["stack"])
+        except SystemExit:
+            edges[eid] = {"error": f"could not resolve instance for edge {eid}"}
+            continue
+        print(f"snapshot: edge {eid} instance={inst}", file=sys.stderr)
+        accts_raw, _ = ssm_run_sql(tgt["region"], inst, EDGE_ACCOUNTS_SQL, f"snapshot: edge {eid} oauth accounts")
+        grps_raw, _ = ssm_run_sql(tgt["region"], inst, EDGE_GROUPS_SQL, f"snapshot: edge {eid} groups")
+        edges[eid] = {
+            "deployable": True,
+            "instance_id": inst,
+            "region": tgt["region"],
+            "stack": tgt["stack"],
+            "domain": tgt.get("domain"),
+            "oauth_accounts": json.loads(accts_raw) if accts_raw else [],
+            "anthropic_groups": json.loads(grps_raw) if grps_raw else [],
+        }
+
+    snapshot = {
+        "version": SNAPSHOT_VERSION,
+        "captured_at": now_utc_iso(),
+        "prod": {
+            "instance_id": prod_inst,
+            "region": PROD["region"],
+            "stack": PROD["stack"],
+            "anthropic_apikey_stubs": prod_stubs,
+            "anthropic_groups_with_stubs": prod_groups,
+        },
+        "edges": edges,
+    }
+
+    out_str = json.dumps(snapshot, indent=2, ensure_ascii=False)
+    if args.out:
+        pathlib.Path(args.out).write_text(out_str)
+        print(f"snapshot: written {args.out} ({len(out_str)} bytes)", file=sys.stderr)
+    else:
+        print(out_str)
+    return 0
+
+
+# --------------------------------------------------------------------------
+# Stage 2 — check
+# --------------------------------------------------------------------------
+
+def _run_guard(argv: list[str], description: str) -> dict[str, Any]:
+    """Run a sub-guard with --json and return parsed dict + exit code."""
+    try:
+        proc = subprocess.run(argv, capture_output=True, text=True, check=False)
+    except FileNotFoundError as e:
+        return {"error": str(e), "exit_code": 127, "raw_stdout": "", "raw_stderr": ""}
+    stdout = proc.stdout.strip()
+    stderr = proc.stderr.strip()
+    out: dict[str, Any] = {"exit_code": proc.returncode, "description": description}
+    if stdout:
+        try:
+            out["report"] = json.loads(stdout)
+        except json.JSONDecodeError:
+            out["raw_stdout"] = stdout[:2000]
+    if stderr:
+        out["raw_stderr"] = stderr[:2000]
+    return out
+
+
+def cmd_check(args: argparse.Namespace) -> int:
+    snapshot = load_json_file(pathlib.Path(args.snapshot), "snapshot") if args.snapshot else None
+
+    # Discover edge IDs from snapshot (if provided) or from a fresh resolve.
+    edge_ids: list[str] = []
+    if snapshot is not None:
+        edge_ids = sorted([
+            eid for eid, e in snapshot.get("edges", {}).items()
+            if e.get("deployable") is not False and "error" not in e
+        ])
+
+    sub_results: list[dict] = []
+
+    # Guard 1: prod stub mirror (R1 + R3-unified)
+    sub_results.append(_run_guard(
+        ["python3", str(OPS_DIR / "check-prod-stub-mirror.py"), "--json"]
+        + (["--allow-planned"] if args.allow_planned else []),
+        "prod-stub-mirror (R1 + R3-unified)",
+    ))
+
+    # Guard 2: edge OAuth stability for each edge × account (best-effort)
+    if edge_ids:
+        for eid in edge_ids:
+            sub_results.append(_run_guard(
+                ["python3", str(OPS_DIR / "check-edge-oauth-stability.py"),
+                 "--edge-id", eid, "--account-name", "all", "--json"]
+                + (["--allow-planned"] if args.allow_planned else []),
+                f"edge-oauth-stability edge={eid}",
+            ))
+    else:
+        sub_results.append({
+            "description": "edge-oauth-stability",
+            "skipped_reason": "no edge_ids resolved (run snapshot first and pass --snapshot)",
+        })
+
+    # Guard 3: account-group alignment, strict-redline, per edge + prod
+    targets = edge_ids + ["prod"]
+    for t in targets:
+        sub_results.append(_run_guard(
+            ["python3", str(OPS_DIR / "check-account-group-rpm-alignment.py"),
+             "--target", t, "--strict-redline", "--json"]
+            + (["--allow-planned"] if args.allow_planned else []),
+            f"account-group-rpm-alignment target={t}",
+        ))
+
+    any_violation = any(
+        sr.get("exit_code", 0) not in (0, None) for sr in sub_results
+    )
+
+    report = {
+        "version": 1,
+        "checked_at": now_utc_iso(),
+        "edges_in_scope": edge_ids,
+        "any_violation": any_violation,
+        "guards": sub_results,
+    }
+    if args.json:
+        print(json.dumps(report, indent=2, ensure_ascii=False))
+    else:
+        print(f"check: any_violation={any_violation} guards_run={len(sub_results)} edges={edge_ids}")
+        for sr in sub_results:
+            ec = sr.get("exit_code")
+            status = "OK" if ec == 0 else (sr.get("skipped_reason", "?") if ec is None else f"FAIL exit={ec}")
+            print(f"  [{status}] {sr.get('description')}")
+            if sr.get("report"):
+                rep = sr["report"]
+                if "stub_violation_count" in rep or "group_violation_count" in rep:
+                    print(f"      stub_violations={rep.get('stub_violation_count')} "
+                          f"group_violations={rep.get('group_violation_count')}")
+                if "violations" in rep and isinstance(rep["violations"], list):
+                    for v in rep["violations"][:5]:
+                        print(f"      - {v}")
+    return 1 if any_violation else 0
+
+
+# --------------------------------------------------------------------------
+# Stage 3 — plan
+# --------------------------------------------------------------------------
+
+def _load_snapshot_or_die(path: str) -> dict:
+    snap = load_json_file(pathlib.Path(path), "snapshot")
+    if snap.get("version") != SNAPSHOT_VERSION:
+        fail(f"snapshot version {snap.get('version')} != expected {SNAPSHOT_VERSION}")
+    return snap
+
+
+def _load_tier_baselines() -> dict[str, dict]:
+    """Return {tier: flattened_fields} keyed by 'l1'..'l5'.
+
+    The JSON ships nested as ``tiers[lN].baseline.{account,extra}.<field>``
+    plus a sibling ``factor``.  We flatten so callers see a single dict
+    per tier: account fields (concurrency, priority, rate_multiplier) and
+    extra fields (base_rpm, rpm_sticky_buffer, max_sessions, ...) both at
+    the top level — convenient for cascade math.  Nested keys ``account``
+    and ``extra`` are preserved verbatim too, in case a caller wants the
+    original shape.
+    """
+    raw = load_json_file(TIER_BASELINES, "tier baselines")
+    out: dict[str, dict] = {}
+    items = raw.get("tiers") if isinstance(raw, dict) and "tiers" in raw else raw
+    src_iter = items.items() if isinstance(items, dict) else (
+        ((t.get("stability_tier") or t.get("tier")), t) for t in items
+    )
+    for key, t in src_iter:
+        if not key:
+            continue
+        baseline = t.get("baseline") if isinstance(t, dict) else None
+        flat: dict[str, Any] = {"tier": str(key).lower(), "factor": t.get("factor") if isinstance(t, dict) else None}
+        if isinstance(baseline, dict):
+            for sub in ("account", "extra"):
+                d = baseline.get(sub)
+                if isinstance(d, dict):
+                    flat[sub] = dict(d)
+                    flat.update(d)  # top-level convenience
+        # Some legacy shapes flatten at tier root; merge those too.
+        for k, v in (t.items() if isinstance(t, dict) else []):
+            if k in ("baseline", "factor"):
+                continue
+            flat.setdefault(k, v)
+        out[str(key).lower()] = flat
+    return out
+
+
+def _find_edge(snap: dict, edge_id: str) -> dict:
+    edges = snap.get("edges", {})
+    if edge_id not in edges:
+        fail(f"edge {edge_id!r} not in snapshot; re-run snapshot")
+    edge = edges[edge_id]
+    if edge.get("error") or edge.get("skipped_reason"):
+        fail(f"edge {edge_id!r} not snapshotted: {edge.get('error') or edge.get('skipped_reason')}")
+    return edge
+
+
+def _find_edge_account(edge: dict, account_name: str) -> dict:
+    for a in edge.get("oauth_accounts", []):
+        if a.get("name") == account_name:
+            return a
+    fail(f"account {account_name!r} not found in edge oauth_accounts")
+    return {}  # unreachable
+
+
+def _find_edge_group(edge: dict, group_name: str) -> dict | None:
+    for g in edge.get("anthropic_groups", []):
+        if g.get("name") == group_name:
+            return g
+    return None
+
+
+def _find_prod_stub_by_edge(snap: dict, edge_id: str) -> dict | None:
+    for s in snap.get("prod", {}).get("anthropic_apikey_stubs", []):
+        if s.get("is_self_edge") and s.get("edge_id") == edge_id:
+            return s
+    return None
+
+
+def _find_prod_stub_by_name(snap: dict, stub_name: str) -> dict | None:
+    for s in snap.get("prod", {}).get("anthropic_apikey_stubs", []):
+        if s.get("name") == stub_name:
+            return s
+    return None
+
+
+def _find_prod_group(snap: dict, group_id: int) -> dict | None:
+    for g in snap.get("prod", {}).get("anthropic_groups_with_stubs", []):
+        if g.get("id") == group_id:
+            return g
+    return None
+
+
+def _stub_by_id(snap: dict, account_id: int) -> dict | None:
+    for s in snap.get("prod", {}).get("anthropic_apikey_stubs", []):
+        if s.get("id") == account_id:
+            return s
+    return None
+
+
+def _edge_default_redline_sum(edge: dict, override_account: str | None = None,
+                               override_fields: dict | None = None) -> int:
+    """Recompute edge default group's rpm_limit = absorb_zero_sum(base+sticky_buffer).
+
+    If override_account is given, that account's base/sticky are taken from
+    override_fields instead of the snapshot.
+    """
+    grp = _find_edge_group(edge, "default")
+    if not grp:
+        return 0
+    members = set(grp.get("members", []))
+    redlines: list[int] = []
+    for acc in edge.get("oauth_accounts", []):
+        if acc["id"] not in members:
+            continue
+        if acc.get("status") in ("disabled", "suspended"):
+            continue
+        if override_account and acc.get("name") == override_account and override_fields:
+            base = int(override_fields.get("base_rpm") or 0)
+            sticky = int(override_fields.get("rpm_sticky_buffer") or 0)
+        else:
+            base = int(acc.get("base_rpm") or 0)
+            sticky = int(acc.get("rpm_sticky_buffer") or 0)
+        redlines.append(base + sticky)
+    return absorb_zero_sum(redlines)
+
+
+def _edge_default_concurrency_sum(edge: dict, override_account: str | None = None,
+                                   override_fields: dict | None = None) -> int:
+    grp = _find_edge_group(edge, "default")
+    if not grp:
+        return 0
+    members = set(grp.get("members", []))
+    concs: list[int] = []
+    for acc in edge.get("oauth_accounts", []):
+        if acc["id"] not in members:
+            continue
+        if acc.get("status") in ("disabled", "suspended"):
+            continue
+        if override_account and acc.get("name") == override_account and override_fields:
+            concs.append(int(override_fields.get("concurrency") or 0))
+        else:
+            concs.append(int(acc.get("concurrency") or 0))
+    return absorb_zero_sum(concs)
+
+
+def cmd_plan_edge_account_tier(args: argparse.Namespace) -> int:
+    snap = _load_snapshot_or_die(args.snapshot)
+    tiers = _load_tier_baselines()
+    tier_key = args.tier.lower()
+    if tier_key not in tiers:
+        fail(f"tier {args.tier!r} not in baselines (available: {sorted(tiers)})")
+    baseline = tiers[tier_key]
+
+    edge = _find_edge(snap, args.edge_id)
+    target_account = _find_edge_account(edge, args.account_name)
+
+    # Edge default group cap recomputed with override
+    new_edge_default_rpm = _edge_default_redline_sum(
+        edge, override_account=args.account_name, override_fields=baseline,
+    )
+    new_stub_concurrency = _edge_default_concurrency_sum(
+        edge, override_account=args.account_name, override_fields=baseline,
+    )
+
+    # Prod stub for this edge
+    prod_stub = _find_prod_stub_by_edge(snap, args.edge_id)
+    if not prod_stub:
+        fail(f"no prod self-edge stub for edge {args.edge_id!r} (looked for base_url=api-{args.edge_id}.tokenkey.dev)")
+
+    new_declared_rpm = new_edge_default_rpm
+
+    # Prod groups that contain this stub — each needs its rpm_limit + per-stub declared_rpm rewritten
+    prod_group_actions: list[dict] = []
+    affected_group_ids = list(prod_stub.get("group_bindings", []))
+    for gid in affected_group_ids:
+        grp = _find_prod_group(snap, gid)
+        if not grp:
+            continue  # group not stub-bearing per snapshot query; skip
+        # stub_inputs for this group: keep other stubs' declared_rpm from snapshot,
+        # replace this stub's declared_rpm with new_declared_rpm
+        stub_inputs: list[dict] = []
+        for member_id in grp.get("members", []):
+            member = _stub_by_id(snap, member_id)
+            if not member:
+                fail(f"prod group {grp['name']!r} member account_id={member_id} not in snapshot stubs (snapshot stale?)")
+            if member_id == prod_stub["id"]:
+                stub_inputs.append({"account_id": member_id, "declared_rpm": new_declared_rpm})
+            else:
+                d = member.get("declared_rpm")
+                if d is None or d <= 0:
+                    fail(
+                        f"prod group {grp['name']!r} contains stub {member['name']!r} (id={member_id}) "
+                        f"with declared_rpm={d}; cascade cannot SUM. Fix that stub first."
+                    )
+                stub_inputs.append({"account_id": member_id, "declared_rpm": d})
+        target_group_rpm = sum(s["declared_rpm"] for s in stub_inputs)
+        prod_group_actions.append({
+            "kind": "prod_group_r3_unified",
+            "target": {"env": "prod", "group_id": grp["id"], "group_name": grp["name"]},
+            "template": "anthropic-prod-group-r3-unified-apply-template.sql",
+            "variables": {"group_id": grp["id"], "target_group_rpm": target_group_rpm},
+            "stub_inputs": stub_inputs,
+            "expected_after": {"group_rpm_limit": target_group_rpm},
+        })
+
+    actions: list[dict] = []
+    actions.append({
+        "kind": "edge_account_tier",
+        "target": {"env": "edge", "edge_id": args.edge_id, "account_name": args.account_name},
+        "template": "anthropic-oauth-stability-tiered-apply-template.sql",
+        "variables": {"account_name": args.account_name, "stability_tier": tier_key},
+        "expected_after": {
+            "stability_tier": tier_key,
+            "base_rpm": baseline.get("base_rpm"),
+            "rpm_sticky_buffer": baseline.get("rpm_sticky_buffer"),
+            "concurrency": baseline.get("concurrency"),
+            "max_sessions": baseline.get("max_sessions"),
+        },
+    })
+    actions.append({
+        "kind": "edge_group_aggregate",
+        "target": {"env": "edge", "edge_id": args.edge_id, "group_name": "default"},
+        "template": "anthropic-oauth-group-aggregate-apply-template.sql",
+        "variables": {"group_name": "default"},
+        "expected_after": {"group_rpm_limit": new_edge_default_rpm},
+    })
+    actions.append({
+        "kind": "prod_stub_concurrency",
+        "target": {"env": "prod", "account_name": prod_stub["name"]},
+        "template": "anthropic-stub-mirror-concurrency-apply-template.sql",
+        "variables": {"account_name": prod_stub["name"], "new_concurrency": new_stub_concurrency},
+        "expected_after": {"concurrency": new_stub_concurrency},
+    })
+    actions.extend(prod_group_actions)
+
+    # Number the steps after assembly
+    for i, a in enumerate(actions, start=1):
+        a["step"] = i
+
+    plan = {
+        "version": PLAN_VERSION,
+        "kind": "edge_account_tier_change",
+        "confirm_code": CONFIRM_CODE,
+        "intent": {"edge_id": args.edge_id, "account_name": args.account_name, "new_tier": tier_key},
+        "snapshot_captured_at": snap.get("captured_at"),
+        "plan_built_at": now_utc_iso(),
+        "summary": {
+            "total_steps": len(actions),
+            "edge_changes": sum(1 for a in actions if a["target"]["env"] == "edge"),
+            "prod_changes": sum(1 for a in actions if a["target"]["env"] == "prod"),
+        },
+        "live_inputs": {
+            "edge_account_before": {k: target_account.get(k) for k in [
+                "id", "name", "concurrency", "stability_tier", "base_rpm",
+                "rpm_sticky_buffer", "max_sessions", "window_cost_limit", "status",
+            ]},
+            "edge_default_group_before": _find_edge_group(edge, "default"),
+            "prod_stub_before": {k: prod_stub.get(k) for k in [
+                "id", "name", "concurrency", "declared_rpm", "base_url", "group_bindings", "status",
+            ]},
+            "prod_groups_before": [
+                {k: g.get(k) for k in ["id", "name", "rpm_limit", "members"]}
+                for g in (
+                    _find_prod_group(snap, gid) for gid in affected_group_ids
+                ) if g is not None
+            ],
+        },
+        "actions": actions,
+    }
+
+    out_str = json.dumps(plan, indent=2, ensure_ascii=False)
+    if args.out:
+        pathlib.Path(args.out).write_text(out_str)
+        print(f"plan: written {args.out} ({plan['summary']['total_steps']} steps)", file=sys.stderr)
+    else:
+        print(out_str)
+    return 0
+
+
+def cmd_plan_external_stub(args: argparse.Namespace) -> int:
+    snap = _load_snapshot_or_die(args.snapshot)
+    stub = _find_prod_stub_by_name(snap, args.stub_name)
+    if not stub:
+        fail(f"prod stub {args.stub_name!r} not found in snapshot")
+    if stub.get("is_self_edge"):
+        fail(
+            f"stub {args.stub_name!r} is self-edge (base_url={stub.get('base_url')}). "
+            f"Use plan-edge-account-tier to change its declared_rpm via mirror."
+        )
+    new_decl = int(args.declared_rpm)
+    if new_decl <= 0:
+        fail(f"--declared-rpm must be > 0 (unlimited forbidden under R3-unified)")
+
+    actions: list[dict] = []
+    affected_group_ids = list(stub.get("group_bindings", []))
+    for gid in affected_group_ids:
+        grp = _find_prod_group(snap, gid)
+        if not grp:
+            continue
+        stub_inputs: list[dict] = []
+        for member_id in grp.get("members", []):
+            member = _stub_by_id(snap, member_id)
+            if not member:
+                fail(f"snapshot stale: prod group {grp['name']!r} member id={member_id} missing")
+            if member_id == stub["id"]:
+                stub_inputs.append({"account_id": member_id, "declared_rpm": new_decl})
+            else:
+                d = member.get("declared_rpm")
+                if d is None or d <= 0:
+                    fail(
+                        f"prod group {grp['name']!r} contains stub {member['name']!r} "
+                        f"with declared_rpm={d}; fix that stub first."
+                    )
+                stub_inputs.append({"account_id": member_id, "declared_rpm": d})
+        target_group_rpm = sum(s["declared_rpm"] for s in stub_inputs)
+        actions.append({
+            "kind": "prod_group_r3_unified",
+            "target": {"env": "prod", "group_id": grp["id"], "group_name": grp["name"]},
+            "template": "anthropic-prod-group-r3-unified-apply-template.sql",
+            "variables": {"group_id": grp["id"], "target_group_rpm": target_group_rpm},
+            "stub_inputs": stub_inputs,
+            "expected_after": {"group_rpm_limit": target_group_rpm},
+        })
+    for i, a in enumerate(actions, start=1):
+        a["step"] = i
+
+    plan = {
+        "version": PLAN_VERSION,
+        "kind": "external_stub_declared_rpm_change",
+        "confirm_code": CONFIRM_CODE,
+        "intent": {"stub_name": args.stub_name, "new_declared_rpm": new_decl},
+        "snapshot_captured_at": snap.get("captured_at"),
+        "plan_built_at": now_utc_iso(),
+        "summary": {
+            "total_steps": len(actions),
+            "edge_changes": 0,
+            "prod_changes": len(actions),
+        },
+        "live_inputs": {
+            "prod_stub_before": {k: stub.get(k) for k in [
+                "id", "name", "concurrency", "declared_rpm", "base_url", "group_bindings",
+            ]},
+            "prod_groups_before": [
+                {k: g.get(k) for k in ["id", "name", "rpm_limit", "members"]}
+                for g in (_find_prod_group(snap, gid) for gid in affected_group_ids) if g is not None
+            ],
+        },
+        "actions": actions,
+    }
+
+    out_str = json.dumps(plan, indent=2, ensure_ascii=False)
+    if args.out:
+        pathlib.Path(args.out).write_text(out_str)
+        print(f"plan: written {args.out} ({plan['summary']['total_steps']} steps)", file=sys.stderr)
+    else:
+        print(out_str)
+    return 0
+
+
+# --------------------------------------------------------------------------
+# Stage 4 — apply
+# --------------------------------------------------------------------------
+
+def _read_template(name: str) -> str:
+    path = TEMPLATE_DIR / name
+    if not path.exists():
+        fail(f"template {name} not found at {path}")
+    return path.read_text()
+
+
+def render_edge_account_tier_sql(account_name: str, stability_tier: str) -> str:
+    body = _read_template("anthropic-oauth-stability-tiered-apply-template.sql")
+    header = (
+        f"-- Auto-generated by manage-anthropic-config.py at {now_utc_iso()}\n"
+        f"\\set account_name '{account_name}'\n"
+        f"\\set stability_tier '{stability_tier}'\n"
+    )
+    return header + body
+
+
+def render_edge_group_aggregate_sql(group_name: str) -> str:
+    body = _read_template("anthropic-oauth-group-aggregate-apply-template.sql")
+    header = (
+        f"-- Auto-generated by manage-anthropic-config.py at {now_utc_iso()}\n"
+        f"\\set group_name '{group_name}'\n"
+    )
+    return header + body
+
+
+def render_prod_stub_concurrency_sql(account_name: str, new_concurrency: int) -> str:
+    body = _read_template("anthropic-stub-mirror-concurrency-apply-template.sql")
+    header = (
+        f"-- Auto-generated by manage-anthropic-config.py at {now_utc_iso()}\n"
+        f"\\set account_name '{account_name}'\n"
+        f"\\set new_concurrency {int(new_concurrency)}\n"
+    )
+    return header + body
+
+
+SENTINEL_LINE = "(-1::bigint, -1::int)     -- SENTINEL: replace with one row per stub"
+
+
+def render_prod_group_r3_unified_sql(group_id: int, target_group_rpm: int,
+                                      stub_inputs: list[dict]) -> str:
+    body = _read_template("anthropic-prod-group-r3-unified-apply-template.sql")
+    # VALUES row separator (",") must precede the line-comment so the comment
+    # doesn't swallow it.  Last row carries no trailing comma.
+    rendered_rows: list[str] = []
+    for idx, s in enumerate(stub_inputs):
+        sep = "," if idx < len(stub_inputs) - 1 else ""
+        rendered_rows.append(
+            f"({int(s['account_id'])}::bigint, {int(s['declared_rpm'])}::int){sep}"
+            f"  -- account_id={s['account_id']}, declared_rpm={s['declared_rpm']}"
+        )
+    values_lines = "\n  ".join(rendered_rows)
+    if SENTINEL_LINE not in body:
+        fail("template anthropic-prod-group-r3-unified missing sentinel placeholder; refusing to render")
+    body = body.replace(SENTINEL_LINE, values_lines)
+    header = (
+        f"-- Auto-generated by manage-anthropic-config.py at {now_utc_iso()}\n"
+        f"\\set group_id {int(group_id)}\n"
+        f"\\set target_group_rpm {int(target_group_rpm)}\n"
+    )
+    return header + body
+
+
+def _render_action_sql(action: dict) -> str:
+    kind = action["kind"]
+    v = action.get("variables", {})
+    if kind == "edge_account_tier":
+        return render_edge_account_tier_sql(v["account_name"], v["stability_tier"])
+    if kind == "edge_group_aggregate":
+        return render_edge_group_aggregate_sql(v["group_name"])
+    if kind == "prod_stub_concurrency":
+        return render_prod_stub_concurrency_sql(v["account_name"], v["new_concurrency"])
+    if kind == "prod_group_r3_unified":
+        return render_prod_group_r3_unified_sql(v["group_id"], v["target_group_rpm"], action["stub_inputs"])
+    fail(f"unknown action.kind {kind!r}")
+    return ""  # unreachable
+
+
+def _resolve_action_target(action: dict, edge_matrix: dict) -> tuple[str, str, str]:
+    """Returns (region, instance_id, label) for the action's target."""
+    tgt = action["target"]
+    env = tgt["env"]
+    if env == "prod":
+        return PROD["region"], resolve_instance_id(PROD["region"], PROD["stack"]), "prod"
+    if env == "edge":
+        eid = tgt["edge_id"]
+        e = edge_matrix.get("targets", {}).get(eid)
+        if not e:
+            fail(f"action target edge {eid!r} not in edge-targets.json")
+        return e["region"], resolve_instance_id(e["region"], e["stack"]), f"edge:{eid}"
+    fail(f"unknown action.target.env {env!r}")
+    return "", "", ""  # unreachable
+
+
+def _extract_output_json(stdout: str) -> dict | None:
+    """psql -P expanded=on returns key-value rows; we wrote jsonb_pretty(...) so
+    look for the first complete '{ ... }' block in stdout.
+    """
+    # Find first '{' ... matching last '}' (cheap nesting count)
+    start = stdout.find("{")
+    if start < 0:
+        return None
+    depth = 0
+    in_str = False
+    esc = False
+    for i, c in enumerate(stdout[start:], start=start):
+        if esc:
+            esc = False
+            continue
+        if c == "\\":
+            esc = True
+            continue
+        if c == '"' and not esc:
+            in_str = not in_str
+            continue
+        if in_str:
+            continue
+        if c == "{":
+            depth += 1
+        elif c == "}":
+            depth -= 1
+            if depth == 0:
+                try:
+                    return json.loads(stdout[start:i + 1])
+                except json.JSONDecodeError:
+                    return None
+    return None
+
+
+def _verify_expected_after(action: dict, output_json: dict | None) -> list[str]:
+    """Compare action.expected_after against output_json. Returns list of mismatch strings.
+
+    Some templates return JSON via jsonb_pretty (edge_group_aggregate,
+    prod_stub_concurrency, prod_group_r3_unified) so we can verify in-band.
+    Others (edge_account_tier) return relation rows only — for those we
+    trust the transaction commit and defer the field-level check to the
+    Stage 5 verify subcommand, which re-snapshots and diffs live state.
+    """
+    exp = action.get("expected_after") or {}
+    out: list[str] = []
+    kind = action["kind"]
+    if kind == "edge_account_tier":
+        # No JSON return; commit success implies the UPDATE landed.
+        # Field-level verification happens in Stage 5 verify.
+        return out
+    if not output_json:
+        return [f"no JSON output to verify expected_after={exp}"]
+    if kind == "edge_group_aggregate":
+        upd = output_json.get("rpm_limit_update") or {}
+        rpm_after = upd.get("after")
+        if rpm_after != exp.get("group_rpm_limit"):
+            out.append(f"edge_group_aggregate rpm_limit after={rpm_after} expected={exp.get('group_rpm_limit')}")
+    elif kind == "prod_stub_concurrency":
+        cu = output_json.get("concurrency_update") or {}
+        if cu.get("after") != exp.get("concurrency"):
+            out.append(f"prod_stub_concurrency after={cu.get('after')} expected={exp.get('concurrency')}")
+    elif kind == "prod_group_r3_unified":
+        grp = output_json.get("group") or {}
+        sc = output_json.get("sum_check") or {}
+        rpm_after = grp.get("rpm_limit")
+        if rpm_after != exp.get("group_rpm_limit"):
+            out.append(f"prod_group_r3_unified rpm_limit={rpm_after} expected={exp.get('group_rpm_limit')}")
+        if sc.get("matches") is not True:
+            out.append(f"prod_group_r3_unified sum_check.matches={sc.get('matches')}")
+    return out
+
+
+def cmd_apply(args: argparse.Namespace) -> int:
+    plan_path = pathlib.Path(args.plan)
+    plan = load_json_file(plan_path, "plan")
+    if plan.get("version") != PLAN_VERSION:
+        fail(f"plan version {plan.get('version')} != expected {PLAN_VERSION}")
+    if args.confirm != CONFIRM_CODE:
+        fail(
+            f"--confirm mismatch.\n  Got:      {args.confirm!r}\n  Required: {CONFIRM_CODE!r}",
+            code=2,
+        )
+
+    edge_matrix = load_json_file(EDGE_MATRIX, "edge matrix")
+
+    job_dir = pathlib.Path(args.job_dir) if args.job_dir else pathlib.Path(
+        f"/tmp/anthropic-apply-{_dt.datetime.now().strftime('%Y%m%d-%H%M%S')}-{os.getpid()}"
+    )
+    job_dir.mkdir(parents=True, exist_ok=True)
+    print(f"apply: job_dir={job_dir}", file=sys.stderr)
+
+    results: list[dict] = []
+    actions = plan.get("actions") or []
+    for action in actions:
+        step = action["step"]
+        kind = action["kind"]
+        tgt = action["target"]
+        env = tgt.get("env")
+        label_id = (
+            tgt.get("account_name") or tgt.get("group_name")
+            or tgt.get("account_id") or tgt.get("group_id") or "?"
+        )
+        edge_part = f"-{tgt['edge_id']}" if env == "edge" else ""
+        label = f"step{step:02d}-{env}{edge_part}-{kind}-{label_id}".replace("/", "-")
+        sql_path = job_dir / f"{label}.sql"
+        sql = _render_action_sql(action)
+        sql_path.write_text(sql)
+
+        region, instance_id, target_label = _resolve_action_target(action, edge_matrix)
+        sql_b64 = base64.b64encode(sql.encode("utf-8")).decode("ascii")
+        print(f"apply: step{step:02d} {kind} → {target_label}  (sql={sql_path})", file=sys.stderr)
+        stdout, cid = ssm_run_sql_b64(region, instance_id, sql_b64,
+                                       f"apply step {step} {kind} on {target_label}")
+        output_json = _extract_output_json(stdout)
+        mismatches = _verify_expected_after(action, output_json)
+        result = {
+            "step": step,
+            "kind": kind,
+            "target_label": target_label,
+            "sql_path": str(sql_path),
+            "ssm_command_id": cid,
+            "stdout_preview": stdout[-1200:],
+            "output_json": output_json,
+            "expected_after": action.get("expected_after"),
+            "mismatches": mismatches,
+            "ok": cid.endswith("FAILED") is False and not mismatches,
+        }
+        if cid.endswith("FAILED"):
+            result["ok"] = False
+            result["error"] = "SSM exit_status indicates failure; see stdout_preview / SSM logs"
+        results.append(result)
+        if not result["ok"]:
+            print(f"apply: step{step:02d} FAILED — stopping. cid={cid}", file=sys.stderr)
+            break
+
+    success = all(r["ok"] for r in results) and len(results) == len(actions)
+    report = {
+        "version": 1,
+        "applied_at": now_utc_iso(),
+        "job_dir": str(job_dir),
+        "plan_path": str(plan_path),
+        "plan_kind": plan.get("kind"),
+        "intent": plan.get("intent"),
+        "total_steps": len(actions),
+        "completed_steps": len(results),
+        "success": success,
+        "results": results,
+    }
+    out_str = json.dumps(report, indent=2, ensure_ascii=False)
+    (job_dir / "apply-report.json").write_text(out_str)
+    if args.json:
+        print(out_str)
+    else:
+        print(f"apply: success={success} completed={len(results)}/{len(actions)} job_dir={job_dir}")
+        for r in results:
+            tag = "OK" if r["ok"] else "FAIL"
+            print(f"  [{tag}] step{r['step']:02d} {r['kind']} → {r['target_label']}  cid={r['ssm_command_id']}")
+            for m in r["mismatches"]:
+                print(f"      mismatch: {m}")
+    return 0 if success else 1
+
+
+# --------------------------------------------------------------------------
+# Stage 5 — verify
+# --------------------------------------------------------------------------
+
+def _live_field_from_snapshot(snap: dict, action: dict) -> dict | None:
+    """Return the live record this action expected to mutate, from a fresh snapshot."""
+    kind = action["kind"]
+    tgt = action["target"]
+    if kind == "edge_account_tier":
+        edge = snap.get("edges", {}).get(tgt["edge_id"], {})
+        for a in edge.get("oauth_accounts", []):
+            if a.get("name") == tgt["account_name"]:
+                return a
+    elif kind == "edge_group_aggregate":
+        edge = snap.get("edges", {}).get(tgt["edge_id"], {})
+        for g in edge.get("anthropic_groups", []):
+            if g.get("name") == tgt["group_name"]:
+                return g
+    elif kind == "prod_stub_concurrency":
+        for s in snap.get("prod", {}).get("anthropic_apikey_stubs", []):
+            if s.get("name") == tgt["account_name"]:
+                return s
+    elif kind == "prod_group_r3_unified":
+        for g in snap.get("prod", {}).get("anthropic_groups_with_stubs", []):
+            if g.get("id") == tgt.get("group_id"):
+                return g
+    return None
+
+
+def _diff_action_live(action: dict, live: dict | None) -> list[str]:
+    if live is None:
+        return [f"target not found in live snapshot"]
+    exp = action.get("expected_after") or {}
+    out: list[str] = []
+    kind = action["kind"]
+    if kind == "edge_account_tier":
+        for k in ("stability_tier", "base_rpm", "rpm_sticky_buffer", "concurrency", "max_sessions"):
+            if k in exp and live.get(k) != exp[k]:
+                out.append(f"{k}: live={live.get(k)} expected={exp[k]}")
+    elif kind == "edge_group_aggregate":
+        if live.get("rpm_limit") != exp.get("group_rpm_limit"):
+            out.append(f"rpm_limit: live={live.get('rpm_limit')} expected={exp.get('group_rpm_limit')}")
+    elif kind == "prod_stub_concurrency":
+        if live.get("concurrency") != exp.get("concurrency"):
+            out.append(f"concurrency: live={live.get('concurrency')} expected={exp.get('concurrency')}")
+    elif kind == "prod_group_r3_unified":
+        if live.get("rpm_limit") != exp.get("group_rpm_limit"):
+            out.append(f"rpm_limit: live={live.get('rpm_limit')} expected={exp.get('group_rpm_limit')}")
+        # Also verify per-stub declared_rpm matches the plan.stub_inputs values
+        # (apply-template DO block already enforced this in-transaction; here we
+        #  re-confirm the post-apply state is preserved.)
+    return out
+
+
+def cmd_verify(args: argparse.Namespace) -> int:
+    plan_path = pathlib.Path(args.plan)
+    plan = load_json_file(plan_path, "plan")
+
+    print("verify: capturing fresh snapshot...", file=sys.stderr)
+    snap_ns = argparse.Namespace(
+        out=None, allow_planned=False, prod_instance_id=None,
+    )
+    # Capture snapshot to a temp file via a subprocess call to ourselves so the
+    # snapshot subcommand handles all SSM resolution / printing identically.
+    snap_path = pathlib.Path(args.snapshot_out) if args.snapshot_out else pathlib.Path(
+        f"/tmp/anthropic-verify-snap-{_dt.datetime.now().strftime('%Y%m%d-%H%M%S')}.json"
+    )
+    res = subprocess.run(
+        ["python3", str(pathlib.Path(__file__)), "snapshot",
+         "--out", str(snap_path)]
+        + (["--allow-planned"] if args.allow_planned else []),
+        check=False,
+    )
+    if res.returncode != 0:
+        fail(f"verify: re-snapshot exited {res.returncode}")
+    snap = load_json_file(snap_path, "verify snapshot")
+
+    drift: list[dict] = []
+    for action in plan.get("actions") or []:
+        live = _live_field_from_snapshot(snap, action)
+        diffs = _diff_action_live(action, live)
+        if diffs:
+            drift.append({
+                "step": action["step"],
+                "kind": action["kind"],
+                "target": action["target"],
+                "diffs": diffs,
+            })
+
+    report = {
+        "version": 1,
+        "verified_at": now_utc_iso(),
+        "plan_path": str(plan_path),
+        "snapshot_path": str(snap_path),
+        "total_actions": len(plan.get("actions") or []),
+        "drift_count": len(drift),
+        "drift": drift,
+    }
+    if args.json:
+        print(json.dumps(report, indent=2, ensure_ascii=False))
+    else:
+        print(f"verify: drift_count={report['drift_count']}/{report['total_actions']}")
+        for d in drift:
+            tgt = d["target"]
+            label = tgt.get("account_name") or tgt.get("group_name") or tgt.get("group_id")
+            print(f"  [DRIFT] step{d['step']:02d} {d['kind']} {tgt['env']}:{label}")
+            for diff in d["diffs"]:
+                print(f"      {diff}")
+    return 1 if drift else 0
+
+
+# --------------------------------------------------------------------------
+# Dispatch
+# --------------------------------------------------------------------------
+
+def main() -> int:
+    ap = argparse.ArgumentParser(
+        description=__doc__.split("\n\n", 1)[0] if __doc__ else "",
+        formatter_class=argparse.RawDescriptionHelpFormatter,
+    )
+    sub = ap.add_subparsers(dest="cmd", required=True)
+
+    sp = sub.add_parser("snapshot", help="pull prod + each referenced edge into one JSON")
+    sp.add_argument("--out", help="write snapshot JSON to this path (otherwise stdout)")
+    sp.add_argument("--prod-instance-id", help="override prod EC2 instance id")
+    sp.add_argument("--allow-planned", action="store_true",
+                    help="include planned edges (per edge-targets.json)")
+    sp.set_defaults(handler=cmd_snapshot)
+
+    sp = sub.add_parser("check", help="run all three guards; compose unified report")
+    sp.add_argument("--snapshot", help="snapshot JSON path; used to discover edge IDs in scope")
+    sp.add_argument("--allow-planned", action="store_true")
+    sp.add_argument("--json", action="store_true")
+    sp.set_defaults(handler=cmd_check)
+
+    sp = sub.add_parser("plan-edge-account-tier",
+                        help="declare an edge OAuth tier change; emit plan JSON")
+    sp.add_argument("--edge-id", "--edge", dest="edge_id", required=True)
+    sp.add_argument("--account-name", "--account", dest="account_name", required=True)
+    sp.add_argument("--tier", required=True, help="l1 / l2 / l3 / l4 / l5")
+    sp.add_argument("--snapshot", required=True)
+    sp.add_argument("--out", help="write plan JSON (otherwise stdout)")
+    sp.set_defaults(handler=cmd_plan_edge_account_tier)
+
+    sp = sub.add_parser("plan-external-stub",
+                        help="declare an external apikey stub quota change; emit plan JSON")
+    sp.add_argument("--stub-name", "--stub", dest="stub_name", required=True)
+    sp.add_argument("--declared-rpm", dest="declared_rpm", required=True, type=int)
+    sp.add_argument("--snapshot", required=True)
+    sp.add_argument("--out")
+    sp.set_defaults(handler=cmd_plan_external_stub)
+
+    sp = sub.add_parser("apply",
+                        help="execute a plan: render each template, SSM run, verify expected_after")
+    sp.add_argument("--plan", required=True)
+    sp.add_argument("--confirm", required=True,
+                    help=f"must be exactly: {CONFIRM_CODE}")
+    sp.add_argument("--job-dir", help="where to write rendered SQL + apply-report.json")
+    sp.add_argument("--json", action="store_true")
+    sp.set_defaults(handler=cmd_apply)
+
+    sp = sub.add_parser("verify",
+                        help="re-snapshot and compare every action's expected_after vs live")
+    sp.add_argument("--plan", required=True)
+    sp.add_argument("--snapshot-out", help="path to write the fresh snapshot used for verify")
+    sp.add_argument("--allow-planned", action="store_true")
+    sp.add_argument("--json", action="store_true")
+    sp.set_defaults(handler=cmd_verify)
+
+    args = ap.parse_args()
+    return args.handler(args)
+
+
+if __name__ == "__main__":
+    sys.exit(main())


### PR DESCRIPTION
## Summary

- New `ops/anthropic/manage-anthropic-config.py`: single entrypoint for all anthropic config mutations as a 5-stage pipeline (`snapshot` → `check` → `plan-*` → `apply` → `verify`). Cascade math (edge OAuth tier → edge group cap → prod stub concurrency → prod stub `declared_rpm` → prod group `rpm_limit`) lives in `plan-*`; `apply` just renders the existing 4 R3-unified-era SQL templates and pipes them through SSM.
- `SKILL.md` rewritten from ~500 lines to ~200 — 5-stage pipeline is the only recommended path; manual guard/template invocation lives in Appendix A "emergency / debug" with an explicit warning that the operator owns the cascade math in that mode.
- Plan JSON is the contract between stages: each `action` references a template by filename + `variables`/`stub_inputs` + `expected_after`. Apply verifies expected_after against the template's `jsonb_pretty()` return body, stops on first mismatch.
- Builds on PR #328's R3-unified building blocks (4 SQL templates with DO-block guards + 3 guard scripts). This PR is the operator-facing layer that stops the 500-line skill from being held together by people reading docs.

## Test plan

- [x] `snapshot` against live prod discovers uk1+us1 from stub `base_url`, returns 6KB JSON
- [x] `check` runs the three guards; surfaces the known pre-existing `upstream_no_active_oauth` on cc-uk1-oauth (uk1 OAuth status=error; not caused by this PR)
- [x] `plan-edge-account-tier --tier l2` on uk1/en-ld-ec2-16-1-b: 5-step plan with correct numbers (edge default 12, prod stub conc 2, prod default 360, cc-edges 60)
- [x] `plan-external-stub --declared-rpm 150` on tokensea-0.4: 1-step plan, target_group_rpm=414
- [x] Ephemeral postgres:16-alpine rehearsal of every rendered template:
  - `prod_group_r3_unified` end-to-end COMMIT with `sum_check.matches=true`
  - `prod_stub_concurrency` COMMIT, `concurrency_update.after=2`
  - VALUES separator regression found+fixed during testing: comma now precedes the line-comment so psql's `--` doesn't swallow it
- [x] `_extract_output_json()` parses `-A -t` jsonb_pretty output (switched from `-P expanded=on` which decorates with `|` and `+`)
- [x] preflight (all generic + sub2api checks): PASS

🤖 Generated with [Claude Code](https://claude.com/claude-code)