### PR TITLE
fix(pricing): account-whitelist fallback in /me/pricing-catalog (no-web-impact)

### DIFF
--- a/backend/cmd/server/wire_gen.go
+++ b/backend/cmd/server/wire_gen.go
@@ -260,7 +260,8 @@ func initializeApplication(buildInfo handler.BuildInfo) (*Application, error) {
 		return nil, err
 	}
 	pricingCatalogHandler := handler.ProvideTKPricingCatalogHandler(pricingCatalogService, settingService, pricingAvailabilityService)
-	mePricingCatalogService := service.NewMePricingCatalogService(apiKeyService, channelService, pricingCatalogService)
+	accountService := service.NewAccountService(accountRepository, groupRepository)
+	mePricingCatalogService := service.NewMePricingCatalogService(apiKeyService, channelService, pricingCatalogService, accountService)
 	mePricingCatalogHandler := handler.NewMePricingCatalogHandler(mePricingCatalogService)
 	qaHandler := handler.NewQAHandler(qaService)
 	idempotencyCoordinator := service.ProvideIdempotencyCoordinator(idempotencyRepository, configConfig)

--- a/backend/internal/service/account_service.go
+++ b/backend/internal/service/account_service.go
@@ -232,6 +232,16 @@ func (s *AccountService) ListByGroup(ctx context.Context, groupID int64) ([]Acco
 	return accounts, nil
 }
 
+// ListSchedulableByGroupID 返回分组下当前可被调度的账号（active + schedulable + 未在临时不可调度窗口）。
+// 与 ListByGroup 的区别：后者返回全部状态，前者贴近调度器视角。
+func (s *AccountService) ListSchedulableByGroupID(ctx context.Context, groupID int64) ([]Account, error) {
+	accounts, err := s.accountRepo.ListSchedulableByGroupID(ctx, groupID)
+	if err != nil {
+		return nil, fmt.Errorf("list schedulable accounts by group: %w", err)
+	}
+	return accounts, nil
+}
+
 // Update 更新账号
 func (s *AccountService) Update(ctx context.Context, id int64, req UpdateAccountRequest) (*Account, error) {
 	account, err := s.accountRepo.GetByID(ctx, id)

--- a/backend/internal/service/me_pricing_catalog_tk.go
+++ b/backend/internal/service/me_pricing_catalog_tk.go
@@ -522,11 +522,16 @@ func (s *MePricingCatalogService) fillWhitelistFallback(
 }
 
 // accountInGroupScope encodes the cross-platform leak guard for the
-// fallback path. Pool-shared groups (openai / newapi) use the upstream
-// compat-pool predicate so a newapi-channel account contributes to an
-// openai-platform group and vice-versa — the same rule the scheduler
-// applies in account_tk_compat_pool.go. All other platforms require
-// strict platform equality, matching the scheduler's anti-leak stance.
+// fallback path. Matches the scheduling-pool partition the scheduler
+// enforces (docs/approved/newapi-as-fifth-platform.md §2.1 "不混池"):
+// openai groups schedule openai accounts only, newapi groups schedule
+// newapi accounts only — there is no cross-platform routing between
+// the two. We delegate openai / newapi to IsOpenAICompatPoolMember so
+// the newapi pool additionally enforces channel_type > 0 (a newapi
+// account with channel_type=0 has no New API adaptor target and would
+// crash bridge dispatch — same defense as the scheduler in
+// openai_account_scheduler.go). Other platforms only need strict
+// platform equality.
 func accountInGroupScope(a *Account, groupPlatform string) bool {
 	if a == nil {
 		return false
@@ -597,19 +602,21 @@ func buildAccountFallbackEntry(modelID string, rate float64, metaByID map[string
 		return entry
 	}
 	entry.Vendor = meta.Vendor
-	entry.YourPrice.InputPer1K = per1KFromCatalog(meta.Pricing.InputPer1KTokens, rate)
-	entry.YourPrice.OutputPer1K = per1KFromCatalog(meta.Pricing.OutputPer1KTokens, rate)
-	entry.YourPrice.CacheReadPer1K = per1KFromCatalog(meta.Pricing.CacheReadPer1K, rate)
-	entry.YourPrice.CacheWritePer1K = per1KFromCatalog(meta.Pricing.CacheWritePer1K, rate)
+	entry.YourPrice.InputPer1K = scaleCatalogPrice(meta.Pricing.InputPer1KTokens, rate)
+	entry.YourPrice.OutputPer1K = scaleCatalogPrice(meta.Pricing.OutputPer1KTokens, rate)
+	entry.YourPrice.CacheReadPer1K = scaleCatalogPrice(meta.Pricing.CacheReadPer1K, rate)
+	entry.YourPrice.CacheWritePer1K = scaleCatalogPrice(meta.Pricing.CacheWritePer1K, rate)
 	return entry
 }
 
-// per1KFromCatalog scales a public-catalog per-1k price by the user's
-// effective rate. Catalog uses 0.0 as the sentinel for "no price
-// published" (PublicCatalogPricing fields are floats, not pointers), so
-// 0.0 surfaces as nil here — preserving MePricingPrice's nil-vs-0
-// contract (nil = "—", 0 = real free-subscription price).
-func per1KFromCatalog(v, rate float64) *float64 {
+// scaleCatalogPrice multiplies a PublicCatalogPricing value (already in
+// per-1k tokens — see pricing_catalog_tk.go PublicCatalogPricing) by the
+// user's effective rate. Unlike scaleTo1K there is NO ×1000 unit
+// conversion: catalog prices are already per-1k. Catalog uses 0.0 as
+// the sentinel for "no price published" (fields are floats, not
+// pointers), so 0.0 surfaces as nil here — preserving MePricingPrice's
+// nil-vs-0 contract (nil = "—", 0 = real free-subscription price).
+func scaleCatalogPrice(v, rate float64) *float64 {
 	if v == 0 {
 		return nil
 	}

--- a/backend/internal/service/me_pricing_catalog_tk.go
+++ b/backend/internal/service/me_pricing_catalog_tk.go
@@ -62,11 +62,25 @@ type MePricingCatalogProvider interface {
 	BuildPublicCatalog(ctx context.Context) *PublicCatalogResponse
 }
 
+// MePricingAccountSource is the slice of *AccountService that BuildForUser
+// needs for the account-whitelist fallback. Defined as an interface so unit
+// tests can inject fakes without constructing a full AccountService.
+//
+// The fallback turns each account's `credentials.model_mapping` whitelist
+// entries (from === to) into menu rows when no channel-configured pricing
+// covers that model under the target group. This bridges the admin "model
+// whitelist" UX (gateway routing limit) into the user-facing "Your Menu"
+// surface — see TK incident 2026-05-21.
+type MePricingAccountSource interface {
+	ListSchedulableByGroupID(ctx context.Context, groupID int64) ([]Account, error)
+}
+
 // MePricingCatalogService builds the per-user pricing-catalog DTO.
 type MePricingCatalogService struct {
 	keys     MePricingKeyAccess
 	channels MePricingChannelLister
 	catalog  MePricingCatalogProvider
+	accounts MePricingAccountSource
 }
 
 // NewMePricingCatalogService is the production constructor. Any nil
@@ -77,11 +91,13 @@ func NewMePricingCatalogService(
 	keys *APIKeyService,
 	channels *ChannelService,
 	catalog *PricingCatalogService,
+	accounts *AccountService,
 ) *MePricingCatalogService {
 	var (
 		k MePricingKeyAccess
 		c MePricingChannelLister
 		p MePricingCatalogProvider
+		a MePricingAccountSource
 	)
 	if keys != nil {
 		k = keys
@@ -92,7 +108,10 @@ func NewMePricingCatalogService(
 	if catalog != nil {
 		p = catalog
 	}
-	return &MePricingCatalogService{keys: k, channels: c, catalog: p}
+	if accounts != nil {
+		a = accounts
+	}
+	return &MePricingCatalogService{keys: k, channels: c, catalog: p, accounts: a}
 }
 
 // MePricingCatalogOptions selects which group the menu is built for.
@@ -357,54 +376,29 @@ func resolveTargetGroupID(
 // buildModelsForGroup performs steps 4-8 of the algorithm. Returns an
 // empty (non-nil) slice when no models exist; UI relies on this for the
 // "no models published" empty state.
+//
+// The build proceeds in three stages:
+//
+//  1. Channel pricing — walk active channels mapped to the target group,
+//     keep platform-matching SupportedModels, dedupe by model_id with the
+//     cheaper-wins rule.
+//  2. Account whitelist fallback — for each schedulable account on the
+//     target group, synthesize a row per whitelisted model_id that the
+//     channel loop did not already cover. Channel pricing always wins on
+//     conflict. Bridges the admin "model whitelist" UX (gateway routing
+//     limit) into Your-Menu when operators have not configured channel
+//     pricing for that group.
+//  3. LiteLLM metadata join — vendor / context_window / capabilities /
+//     max_output_tokens applied to every row, regardless of source.
 func (s *MePricingCatalogService) buildModelsForGroup(
 	ctx context.Context,
 	targetGroup Group,
 	effectiveRate float64,
 ) []MePricingModel {
 	out := []MePricingModel{}
-	if s.channels == nil {
-		return out
-	}
 
-	channels, err := s.channels.ListAvailable(ctx)
-	if err != nil || len(channels) == 0 {
-		return out
-	}
-
-	bestByModel := make(map[string]MePricingModel)
-	for _, ch := range channels {
-		if ch.Status != StatusActive {
-			continue
-		}
-		mapped := false
-		for _, g := range ch.Groups {
-			if g.ID == targetGroup.ID {
-				mapped = true
-				break
-			}
-		}
-		if !mapped {
-			continue
-		}
-		for i := range ch.SupportedModels {
-			m := ch.SupportedModels[i]
-			// Cross-platform leak guard — a channel can sit on groups
-			// from multiple platforms; we restrict to models declared
-			// on the target group's platform.
-			if m.Platform != targetGroup.Platform {
-				continue
-			}
-			candidate := buildModelEntry(m, effectiveRate)
-			if existing, ok := bestByModel[m.Name]; ok {
-				bestByModel[m.Name] = pickCheaperModel(existing, candidate)
-			} else {
-				bestByModel[m.Name] = candidate
-			}
-		}
-	}
-
-	// Join LiteLLM catalog metadata.
+	// Build LiteLLM catalog index up-front: the channel metadata join and
+	// the account-whitelist fallback both consume it, so we read once.
 	metaByID := map[string]PublicCatalogModel{}
 	if s.catalog != nil {
 		if resp := s.catalog.BuildPublicCatalog(ctx); resp != nil {
@@ -414,6 +408,50 @@ func (s *MePricingCatalogService) buildModelsForGroup(
 		}
 	}
 
+	bestByModel := make(map[string]MePricingModel)
+
+	// Stage 1: channel pricing.
+	if s.channels != nil {
+		channels, err := s.channels.ListAvailable(ctx)
+		if err == nil {
+			for _, ch := range channels {
+				if ch.Status != StatusActive {
+					continue
+				}
+				mapped := false
+				for _, g := range ch.Groups {
+					if g.ID == targetGroup.ID {
+						mapped = true
+						break
+					}
+				}
+				if !mapped {
+					continue
+				}
+				for i := range ch.SupportedModels {
+					m := ch.SupportedModels[i]
+					// Cross-platform leak guard — a channel can sit on groups
+					// from multiple platforms; we restrict to models declared
+					// on the target group's platform.
+					if m.Platform != targetGroup.Platform {
+						continue
+					}
+					candidate := buildModelEntry(m, effectiveRate)
+					if existing, ok := bestByModel[m.Name]; ok {
+						bestByModel[m.Name] = pickCheaperModel(existing, candidate)
+					} else {
+						bestByModel[m.Name] = candidate
+					}
+				}
+			}
+		}
+	}
+
+	// Stage 2: account-whitelist fallback (channel-priced rows are
+	// authoritative; this only fills gaps).
+	s.fillWhitelistFallback(ctx, targetGroup, effectiveRate, bestByModel, metaByID)
+
+	// Stage 3: LiteLLM metadata join — applied uniformly to all rows.
 	for _, m := range bestByModel {
 		if meta, ok := metaByID[m.ModelID]; ok {
 			m.ContextWindow = meta.ContextWindow
@@ -433,6 +471,150 @@ func (s *MePricingCatalogService) buildModelsForGroup(
 
 	sort.Slice(out, func(i, j int) bool { return out[i].ModelID < out[j].ModelID })
 	return out
+}
+
+// fillWhitelistFallback inserts account-derived menu rows for any model
+// listed in a schedulable account's whitelist (credentials.model_mapping
+// entries with from === to) that is not already present in bestByModel.
+//
+// Channel-configured rows ALWAYS win on conflict — we never overwrite an
+// existing key. The catalog index is passed in so the price/metadata
+// lookup uses the same source the metadata-join stage does, keeping
+// catalog reads to one round-trip per call.
+//
+// When the catalog has no entry for a whitelisted model_id, vendor-prefix
+// stripping (matches OpenRouter / Azure "<vendor>/<family-version>"
+// style — same predicate as IsModelPriced § PR #326) is retried before
+// giving up. If both lookups miss, the row is still emitted with nil
+// prices: admin-visible whitelist coverage takes priority over hiding
+// unpriced models. MePricingPrice's contract treats nil as "—" in the
+// UI, distinct from a real 0.0 free-subscription price.
+//
+// Errors from the account source are absorbed: the fallback is
+// best-effort and must not block the main pricing-catalog response.
+func (s *MePricingCatalogService) fillWhitelistFallback(
+	ctx context.Context,
+	targetGroup Group,
+	effectiveRate float64,
+	bestByModel map[string]MePricingModel,
+	metaByID map[string]PublicCatalogModel,
+) {
+	if s.accounts == nil {
+		return
+	}
+	accounts, err := s.accounts.ListSchedulableByGroupID(ctx, targetGroup.ID)
+	if err != nil || len(accounts) == 0 {
+		return
+	}
+	for i := range accounts {
+		a := &accounts[i]
+		if !accountInGroupScope(a, targetGroup.Platform) {
+			continue
+		}
+		whitelist := parseWhitelistFromCredentials(a.Credentials)
+		for _, modelID := range whitelist {
+			if _, exists := bestByModel[modelID]; exists {
+				continue
+			}
+			bestByModel[modelID] = buildAccountFallbackEntry(modelID, effectiveRate, metaByID)
+		}
+	}
+}
+
+// accountInGroupScope encodes the cross-platform leak guard for the
+// fallback path. Pool-shared groups (openai / newapi) use the upstream
+// compat-pool predicate so a newapi-channel account contributes to an
+// openai-platform group and vice-versa — the same rule the scheduler
+// applies in account_tk_compat_pool.go. All other platforms require
+// strict platform equality, matching the scheduler's anti-leak stance.
+func accountInGroupScope(a *Account, groupPlatform string) bool {
+	if a == nil {
+		return false
+	}
+	switch groupPlatform {
+	case "openai", "newapi":
+		return a.IsOpenAICompatPoolMember(groupPlatform)
+	default:
+		return a.Platform == groupPlatform
+	}
+}
+
+// parseWhitelistFromCredentials extracts the whitelist-mode entries from
+// an account's credentials.model_mapping JSON. Whitelist mode is the
+// identity map ({from: from}); mapping mode ({from: to}, from != to) is
+// a routing rewrite and contributes nothing to the menu — those models
+// are *aliases*, not user-visible offerings.
+//
+// Returns nil for absent / non-object / empty input. Defensive type
+// assertions guard against malformed JSON without panicking; a single
+// non-string value entry is skipped rather than poisoning the whole map.
+func parseWhitelistFromCredentials(creds map[string]any) []string {
+	if creds == nil {
+		return nil
+	}
+	raw, ok := creds["model_mapping"].(map[string]any)
+	if !ok || len(raw) == 0 {
+		return nil
+	}
+	out := make([]string, 0, len(raw))
+	for from, toAny := range raw {
+		to, ok := toAny.(string)
+		if !ok {
+			continue
+		}
+		if to != from {
+			continue
+		}
+		out = append(out, from)
+	}
+	return out
+}
+
+// buildAccountFallbackEntry constructs a MePricingModel for one
+// whitelisted model_id, sourcing per-1k price and vendor from the
+// catalog index when available. The metadata-join stage in
+// buildModelsForGroup applies context_window / max_output_tokens /
+// capabilities uniformly later, so this function only needs to seed
+// price + vendor.
+//
+// When the catalog lacks the model (e.g. a freshly released family not
+// yet in LiteLLM), the row is returned with nil prices so the user
+// still sees the model is reachable through the gateway.
+func buildAccountFallbackEntry(modelID string, rate float64, metaByID map[string]PublicCatalogModel) MePricingModel {
+	entry := MePricingModel{
+		ModelID:      modelID,
+		BillingMode:  string(BillingModeToken),
+		YourPrice:    MePricingPrice{Currency: "USD"},
+		Capabilities: []string{},
+	}
+	meta, ok := metaByID[modelID]
+	if !ok {
+		if stripped, stripOK := stripVendorPrefixForCatalogLookup(modelID); stripOK {
+			meta, ok = metaByID[stripped]
+		}
+	}
+	if !ok {
+		return entry
+	}
+	entry.Vendor = meta.Vendor
+	entry.YourPrice.InputPer1K = per1KFromCatalog(meta.Pricing.InputPer1KTokens, rate)
+	entry.YourPrice.OutputPer1K = per1KFromCatalog(meta.Pricing.OutputPer1KTokens, rate)
+	entry.YourPrice.CacheReadPer1K = per1KFromCatalog(meta.Pricing.CacheReadPer1K, rate)
+	entry.YourPrice.CacheWritePer1K = per1KFromCatalog(meta.Pricing.CacheWritePer1K, rate)
+	return entry
+}
+
+// per1KFromCatalog scales a public-catalog per-1k price by the user's
+// effective rate. Catalog uses 0.0 as the sentinel for "no price
+// published" (PublicCatalogPricing fields are floats, not pointers), so
+// 0.0 surfaces as nil here — preserving MePricingPrice's nil-vs-0
+// contract (nil = "—", 0 = real free-subscription price).
+func per1KFromCatalog(v, rate float64) *float64 {
+	if v == 0 {
+		return nil
+	}
+	r := v * rate
+	return &r
 }
 
 // buildModelEntry maps a single SupportedModel + effective rate into a

--- a/backend/internal/service/me_pricing_catalog_tk_test.go
+++ b/backend/internal/service/me_pricing_catalog_tk_test.go
@@ -68,6 +68,18 @@ func (f *fakeCatalogProvider) BuildPublicCatalog(ctx context.Context) *PublicCat
 	return f.resp
 }
 
+type fakeAccountSource struct {
+	accounts []Account
+	err      error
+}
+
+func (f *fakeAccountSource) ListSchedulableByGroupID(ctx context.Context, groupID int64) ([]Account, error) {
+	if f.err != nil {
+		return nil, f.err
+	}
+	return f.accounts, nil
+}
+
 // ----- builders -----
 
 func mkGroupForMe(id int64, name, platform string, rate float64) Group {
@@ -120,6 +132,53 @@ func mkPricing(input, output, cacheR float64) *ChannelModelPricing {
 
 func newService(k *fakeKeyAccess, c *fakeChannelLister, cat *fakeCatalogProvider) *MePricingCatalogService {
 	return &MePricingCatalogService{keys: k, channels: c, catalog: cat}
+}
+
+// newServiceWithAccounts mirrors newService but wires the account-whitelist
+// fallback source (introduced by the post-#325/#326 bridge PR). Existing
+// tests that pass nil accounts get the legacy "channel-only" behavior.
+func newServiceWithAccounts(
+	k *fakeKeyAccess,
+	c *fakeChannelLister,
+	cat *fakeCatalogProvider,
+	a *fakeAccountSource,
+) *MePricingCatalogService {
+	return &MePricingCatalogService{keys: k, channels: c, catalog: cat, accounts: a}
+}
+
+// mkAccountWithWhitelist builds an Account whose credentials.model_mapping
+// is the identity map for the supplied model IDs — exactly the JSON shape
+// admin UI's ModelWhitelistSelector emits when in whitelist mode.
+func mkAccountWithWhitelist(id int64, name, platform string, channelType int, whitelist []string) Account {
+	creds := map[string]any{}
+	if len(whitelist) > 0 {
+		mm := make(map[string]any, len(whitelist))
+		for _, m := range whitelist {
+			mm[m] = m
+		}
+		creds["model_mapping"] = mm
+	}
+	return Account{
+		ID: id, Name: name, Platform: platform, ChannelType: channelType,
+		Status: StatusActive, Schedulable: true,
+		Credentials: creds,
+	}
+}
+
+// mkPublicCatalogModel builds a PublicCatalogResponse entry with per-1k
+// prices. CacheReadPer1K is optional — pass 0 to leave it absent.
+func mkPublicCatalogModel(modelID, vendor string, in, out, cacheR float64) PublicCatalogModel {
+	return PublicCatalogModel{
+		ModelID:      modelID,
+		Vendor:       vendor,
+		Capabilities: []string{},
+		Pricing: PublicCatalogPricing{
+			Currency:          "USD",
+			InputPer1KTokens:  in,
+			OutputPer1KTokens: out,
+			CacheReadPer1K:    cacheR,
+		},
+	}
 }
 
 // ----- tests -----
@@ -509,4 +568,214 @@ func TestMePricingCatalog_PerRequestBillingPreservesPrice(t *testing.T) {
 	require.NotNil(t, resp.Models[0].YourPrice.PerRequest)
 	assert.InDelta(t, 0.04, *resp.Models[0].YourPrice.PerRequest, 1e-9)
 	assert.Nil(t, resp.Models[0].YourPrice.InputPer1K)
+}
+
+// ----- account-whitelist fallback (post-#325/#326 bridge) -----
+
+// TestBuildForUser_AccountWhitelistOnly_NoChannels mirrors the production
+// incident that motivated the bridge: operator created an account, ticked
+// the model-whitelist boxes in admin, never configured any channels. The
+// menu should reflect the whitelist with LiteLLM-derived default prices
+// × group rate, not be empty.
+func TestBuildForUser_AccountWhitelistOnly_NoChannels(t *testing.T) {
+	gOpenAI := mkGroupForMe(30, "GPT", "openai", 2.0)
+	k1 := mkKeyForMe(1, 7, "gpt-key", ptrI(30))
+	acct := mkAccountWithWhitelist(11, "openai-oauth", "openai", 0, []string{"gpt-5.2", "gpt-4o"})
+	catalog := &PublicCatalogResponse{
+		Data: []PublicCatalogModel{
+			mkPublicCatalogModel("gpt-5.2", "OpenAI", 0.005, 0.020, 0),
+			mkPublicCatalogModel("gpt-4o", "OpenAI", 0.0025, 0.010, 0),
+		},
+	}
+	svc := newServiceWithAccounts(
+		&fakeKeyAccess{groups: []Group{gOpenAI}, keys: []APIKey{k1}},
+		&fakeChannelLister{},
+		&fakeCatalogProvider{resp: catalog},
+		&fakeAccountSource{accounts: []Account{acct}},
+	)
+	resp, err := svc.BuildForUser(context.Background(), 7, MePricingCatalogOptions{})
+	require.NoError(t, err)
+	require.Len(t, resp.Models, 2, "both whitelisted GPT models should surface")
+	byID := map[string]MePricingModel{}
+	for _, m := range resp.Models {
+		byID[m.ModelID] = m
+	}
+	require.Contains(t, byID, "gpt-5.2")
+	require.NotNil(t, byID["gpt-5.2"].YourPrice.InputPer1K)
+	assert.InDelta(t, 0.010, *byID["gpt-5.2"].YourPrice.InputPer1K, 1e-9, "0.005 catalog × 2.0 effective rate")
+	require.NotNil(t, byID["gpt-5.2"].YourPrice.OutputPer1K)
+	assert.InDelta(t, 0.040, *byID["gpt-5.2"].YourPrice.OutputPer1K, 1e-9, "0.020 catalog × 2.0 effective rate")
+	require.NotNil(t, byID["gpt-4o"].YourPrice.InputPer1K)
+	assert.InDelta(t, 0.005, *byID["gpt-4o"].YourPrice.InputPer1K, 1e-9)
+}
+
+// TestBuildForUser_ChannelAndAccount_ChannelWins guards the "channel
+// price is authoritative on conflict" rule. The catalog input for the
+// shared model is set to a very different number than the channel price
+// so a regression that overwrote channel rows would be obvious.
+func TestBuildForUser_ChannelAndAccount_ChannelWins(t *testing.T) {
+	gOpenAI := mkGroupForMe(30, "GPT", "openai", 1.0)
+	k1 := mkKeyForMe(1, 7, "gpt-key", ptrI(30))
+	channel := mkChannelWithModel(100, "operator-ch",
+		[]AvailableGroupRef{{ID: 30, Platform: "openai"}},
+		[]SupportedModel{mkSupportedModel("gpt-5.2", "openai", mkPricing(0.001, 0.002, 0))},
+	)
+	acct := mkAccountWithWhitelist(11, "openai-oauth", "openai", 0, []string{"gpt-5.2", "gpt-4o"})
+	catalog := &PublicCatalogResponse{
+		Data: []PublicCatalogModel{
+			mkPublicCatalogModel("gpt-5.2", "OpenAI", 0.999, 0.999, 0),
+			mkPublicCatalogModel("gpt-4o", "OpenAI", 0.0025, 0.010, 0),
+		},
+	}
+	svc := newServiceWithAccounts(
+		&fakeKeyAccess{groups: []Group{gOpenAI}, keys: []APIKey{k1}},
+		&fakeChannelLister{channels: []AvailableChannel{channel}},
+		&fakeCatalogProvider{resp: catalog},
+		&fakeAccountSource{accounts: []Account{acct}},
+	)
+	resp, err := svc.BuildForUser(context.Background(), 7, MePricingCatalogOptions{})
+	require.NoError(t, err)
+	require.Len(t, resp.Models, 2)
+	byID := map[string]MePricingModel{}
+	for _, m := range resp.Models {
+		byID[m.ModelID] = m
+	}
+	require.NotNil(t, byID["gpt-5.2"].YourPrice.InputPer1K)
+	assert.InDelta(t, 1.0, *byID["gpt-5.2"].YourPrice.InputPer1K, 1e-9,
+		"0.001 channel × 1000 (per-token → per-1k) × 1.0 rate; catalog 0.999 MUST NOT win")
+	require.NotNil(t, byID["gpt-4o"].YourPrice.InputPer1K)
+	assert.InDelta(t, 0.0025, *byID["gpt-4o"].YourPrice.InputPer1K, 1e-9, "gpt-4o is account-only — catalog 0.0025 × 1.0 rate")
+}
+
+// TestBuildForUser_AccountWhitelist_VendorPrefix exercises reuse of
+// stripVendorPrefixForCatalogLookup (PR #326). An account whitelisting an
+// OpenRouter-style "<vendor>/<model>" must still resolve to the LiteLLM
+// catalog's bare model_id row.
+func TestBuildForUser_AccountWhitelist_VendorPrefix(t *testing.T) {
+	gAnthropic := mkGroupForMe(40, "claude", "anthropic", 1.0)
+	k1 := mkKeyForMe(1, 7, "claude-key", ptrI(40))
+	acct := mkAccountWithWhitelist(11, "anthropic-key", "anthropic", 0,
+		[]string{"anthropic/claude-3-5-sonnet"})
+	catalog := &PublicCatalogResponse{
+		Data: []PublicCatalogModel{
+			mkPublicCatalogModel("claude-3-5-sonnet", "Anthropic", 0.003, 0.015, 0),
+		},
+	}
+	svc := newServiceWithAccounts(
+		&fakeKeyAccess{groups: []Group{gAnthropic}, keys: []APIKey{k1}},
+		&fakeChannelLister{},
+		&fakeCatalogProvider{resp: catalog},
+		&fakeAccountSource{accounts: []Account{acct}},
+	)
+	resp, err := svc.BuildForUser(context.Background(), 7, MePricingCatalogOptions{})
+	require.NoError(t, err)
+	require.Len(t, resp.Models, 1)
+	assert.Equal(t, "anthropic/claude-3-5-sonnet", resp.Models[0].ModelID,
+		"row keeps the operator-facing ID; only the catalog lookup uses the stripped form")
+	require.NotNil(t, resp.Models[0].YourPrice.InputPer1K)
+	assert.InDelta(t, 0.003, *resp.Models[0].YourPrice.InputPer1K, 1e-9)
+}
+
+// TestBuildForUser_AccountWhitelist_CrossPlatformGuard confirms an
+// openai-platform account does not leak into an anthropic-platform group
+// even when both share a group binding edge.
+func TestBuildForUser_AccountWhitelist_CrossPlatformGuard(t *testing.T) {
+	gAnthropic := mkGroupForMe(40, "claude", "anthropic", 1.0)
+	k1 := mkKeyForMe(1, 7, "claude-key", ptrI(40))
+	// openai account that somehow ended up on an anthropic group's
+	// schedulable list (the scheduler would reject it; we double-check
+	// the menu builder enforces the same rule).
+	acct := mkAccountWithWhitelist(11, "stray-openai", "openai", 0, []string{"gpt-5.2"})
+	catalog := &PublicCatalogResponse{
+		Data: []PublicCatalogModel{
+			mkPublicCatalogModel("gpt-5.2", "OpenAI", 0.005, 0.020, 0),
+		},
+	}
+	svc := newServiceWithAccounts(
+		&fakeKeyAccess{groups: []Group{gAnthropic}, keys: []APIKey{k1}},
+		&fakeChannelLister{},
+		&fakeCatalogProvider{resp: catalog},
+		&fakeAccountSource{accounts: []Account{acct}},
+	)
+	resp, err := svc.BuildForUser(context.Background(), 7, MePricingCatalogOptions{})
+	require.NoError(t, err)
+	assert.Empty(t, resp.Models, "openai account must not surface on an anthropic group menu")
+}
+
+// TestBuildForUser_AccountWhitelist_MappingModeIgnored documents the
+// whitelist-only contract: an entry with from != to is a routing
+// rewrite (alias), not a user-visible menu item.
+func TestBuildForUser_AccountWhitelist_MappingModeIgnored(t *testing.T) {
+	gAnthropic := mkGroupForMe(40, "claude", "anthropic", 1.0)
+	k1 := mkKeyForMe(1, 7, "claude-key", ptrI(40))
+	acct := Account{
+		ID: 11, Name: "alias-only", Platform: "anthropic",
+		Status: StatusActive, Schedulable: true,
+		Credentials: map[string]any{
+			"model_mapping": map[string]any{
+				// mapping mode: "claude-3-haiku" requests routed to claude-3-5-sonnet upstream
+				"claude-3-haiku": "claude-3-5-sonnet",
+				// whitelist mode: real menu offering
+				"claude-3-5-sonnet": "claude-3-5-sonnet",
+			},
+		},
+	}
+	catalog := &PublicCatalogResponse{
+		Data: []PublicCatalogModel{
+			mkPublicCatalogModel("claude-3-haiku", "Anthropic", 0.0005, 0.0025, 0),
+			mkPublicCatalogModel("claude-3-5-sonnet", "Anthropic", 0.003, 0.015, 0),
+		},
+	}
+	svc := newServiceWithAccounts(
+		&fakeKeyAccess{groups: []Group{gAnthropic}, keys: []APIKey{k1}},
+		&fakeChannelLister{},
+		&fakeCatalogProvider{resp: catalog},
+		&fakeAccountSource{accounts: []Account{acct}},
+	)
+	resp, err := svc.BuildForUser(context.Background(), 7, MePricingCatalogOptions{})
+	require.NoError(t, err)
+	require.Len(t, resp.Models, 1)
+	assert.Equal(t, "claude-3-5-sonnet", resp.Models[0].ModelID,
+		"only the identity-mapped (whitelist) entry surfaces; the alias rewrite contributes nothing")
+}
+
+// TestBuildForUser_AccountWhitelist_MissingFromLiteLLM_StillEmits
+// documents the forgiving fallback: a model that LiteLLM doesn't price
+// yet (e.g. a freshly released family) still appears in the menu with
+// nil prices, so the user knows the gateway can serve it.
+func TestBuildForUser_AccountWhitelist_MissingFromLiteLLM_StillEmits(t *testing.T) {
+	gOpenAI := mkGroupForMe(30, "GPT", "openai", 1.0)
+	k1 := mkKeyForMe(1, 7, "gpt-key", ptrI(30))
+	acct := mkAccountWithWhitelist(11, "oauth", "openai", 0, []string{"gpt-5.5-not-in-catalog"})
+	svc := newServiceWithAccounts(
+		&fakeKeyAccess{groups: []Group{gOpenAI}, keys: []APIKey{k1}},
+		&fakeChannelLister{},
+		&fakeCatalogProvider{resp: &PublicCatalogResponse{}},
+		&fakeAccountSource{accounts: []Account{acct}},
+	)
+	resp, err := svc.BuildForUser(context.Background(), 7, MePricingCatalogOptions{})
+	require.NoError(t, err)
+	require.Len(t, resp.Models, 1)
+	assert.Equal(t, "gpt-5.5-not-in-catalog", resp.Models[0].ModelID)
+	assert.Nil(t, resp.Models[0].YourPrice.InputPer1K, "unknown to catalog → nil (UI renders —)")
+	assert.Nil(t, resp.Models[0].YourPrice.OutputPer1K)
+}
+
+// TestBuildForUser_AccountSourceError_DoesNotKillResponse documents the
+// best-effort posture of the fallback: a failing account read must not
+// break the catalog endpoint, otherwise a transient DB hiccup in account
+// listing would 500 the /pricing page.
+func TestBuildForUser_AccountSourceError_DoesNotKillResponse(t *testing.T) {
+	gOpenAI := mkGroupForMe(30, "GPT", "openai", 1.0)
+	k1 := mkKeyForMe(1, 7, "gpt-key", ptrI(30))
+	svc := newServiceWithAccounts(
+		&fakeKeyAccess{groups: []Group{gOpenAI}, keys: []APIKey{k1}},
+		&fakeChannelLister{},
+		&fakeCatalogProvider{resp: &PublicCatalogResponse{}},
+		&fakeAccountSource{err: errors.New("db unavailable")},
+	)
+	resp, err := svc.BuildForUser(context.Background(), 7, MePricingCatalogOptions{})
+	require.NoError(t, err)
+	assert.NotNil(t, resp)
+	assert.Empty(t, resp.Models)
 }

--- a/backend/internal/service/me_pricing_catalog_tk_test.go
+++ b/backend/internal/service/me_pricing_catalog_tk_test.go
@@ -779,3 +779,62 @@ func TestBuildForUser_AccountSourceError_DoesNotKillResponse(t *testing.T) {
 	assert.NotNil(t, resp)
 	assert.Empty(t, resp.Models)
 }
+
+// TestBuildForUser_AccountWhitelist_NewapiRequiresChannelType pins the
+// fifth-platform doctrine (docs/approved/newapi-as-fifth-platform.md §2.1):
+// newapi accounts join the pool ONLY when channel_type > 0 — an
+// incompletely configured newapi account (channel_type = 0) has no New
+// API adaptor target and must not contribute menu rows. The scheduler
+// applies the same rule via IsOpenAICompatPoolMember; the fallback path
+// must not diverge.
+func TestBuildForUser_AccountWhitelist_NewapiRequiresChannelType(t *testing.T) {
+	gNewapi := mkGroupForMe(50, "newapi-pro", "newapi", 1.0)
+	k1 := mkKeyForMe(1, 7, "newapi-key", ptrI(50))
+	bad := mkAccountWithWhitelist(11, "incomplete-newapi", "newapi", 0, []string{"gemini-2.5-pro"})
+	good := mkAccountWithWhitelist(12, "configured-newapi", "newapi", 31, []string{"qwen-3-max"})
+	catalog := &PublicCatalogResponse{
+		Data: []PublicCatalogModel{
+			mkPublicCatalogModel("gemini-2.5-pro", "Google", 0.00125, 0.005, 0),
+			mkPublicCatalogModel("qwen-3-max", "Alibaba", 0.0012, 0.0024, 0),
+		},
+	}
+	svc := newServiceWithAccounts(
+		&fakeKeyAccess{groups: []Group{gNewapi}, keys: []APIKey{k1}},
+		&fakeChannelLister{},
+		&fakeCatalogProvider{resp: catalog},
+		&fakeAccountSource{accounts: []Account{bad, good}},
+	)
+	resp, err := svc.BuildForUser(context.Background(), 7, MePricingCatalogOptions{})
+	require.NoError(t, err)
+	require.Len(t, resp.Models, 1, "channel_type=0 newapi account must be filtered out (no adaptor target)")
+	assert.Equal(t, "qwen-3-max", resp.Models[0].ModelID,
+		"only the channel_type>0 newapi account surfaces — matches scheduler IsOpenAICompatPoolMember")
+}
+
+// TestBuildForUser_ChannelsErrorDoesNotKillFallback documents the
+// best-effort posture on the channel-listing side: a transient channel
+// read failure must NOT empty the whole menu when an account-whitelist
+// fallback could still populate it. Behavior change from the pre-bridge
+// code, which used to return an empty []MePricingModel on channel err.
+func TestBuildForUser_ChannelsErrorDoesNotKillFallback(t *testing.T) {
+	gOpenAI := mkGroupForMe(30, "GPT", "openai", 1.0)
+	k1 := mkKeyForMe(1, 7, "gpt-key", ptrI(30))
+	acct := mkAccountWithWhitelist(11, "openai-oauth", "openai", 0, []string{"gpt-4o"})
+	catalog := &PublicCatalogResponse{
+		Data: []PublicCatalogModel{
+			mkPublicCatalogModel("gpt-4o", "OpenAI", 0.0025, 0.010, 0),
+		},
+	}
+	svc := newServiceWithAccounts(
+		&fakeKeyAccess{groups: []Group{gOpenAI}, keys: []APIKey{k1}},
+		&fakeChannelLister{err: errors.New("channel db unavailable")},
+		&fakeCatalogProvider{resp: catalog},
+		&fakeAccountSource{accounts: []Account{acct}},
+	)
+	resp, err := svc.BuildForUser(context.Background(), 7, MePricingCatalogOptions{})
+	require.NoError(t, err)
+	require.Len(t, resp.Models, 1, "channel error must not block account fallback")
+	assert.Equal(t, "gpt-4o", resp.Models[0].ModelID)
+	require.NotNil(t, resp.Models[0].YourPrice.InputPer1K)
+	assert.InDelta(t, 0.0025, *resp.Models[0].YourPrice.InputPer1K, 1e-9)
+}

--- a/scripts/sentinels/newapi.json
+++ b/scripts/sentinels/newapi.json
@@ -178,6 +178,16 @@
         "stripVendorPrefixForCatalogLookup"
       ],
       "rationale": "Read-side predicate consumed by integration/newapi/discover_filter_tk.go step [3] to tag admin 'fetch upstream models' results with pricing_status. OpenRouter / Azure / Bedrock report '<vendor>/<family-version>' ids whose tail uses '.' while the LiteLLM catalog stores bare names with '-' and date suffixes (anthropic/claude-opus-4.5 vs claude-opus-4-5-20251001). stripVendorPrefixForCatalogLookup + the '.'→'-' normalization is what keeps the entire OpenRouter / Azure model list from being tagged 'missing' across admin and the client /v1/models filter. Removing either symbol silently flips ~all OpenRouter channels to a wall of orange 'missing' badges (the regression this sentinel guards)."
+    },
+    {
+      "path": "backend/internal/service/me_pricing_catalog_tk.go",
+      "must_contain": [
+        "MePricingAccountSource",
+        "fillWhitelistFallback",
+        "parseWhitelistFromCredentials",
+        "buildAccountFallbackEntry"
+      ],
+      "rationale": "Post-#325/#326 bridge: /api/v1/me/pricing-catalog (Your Menu) falls back to accounts.credentials.model_mapping whitelist entries when no channel-configured pricing covers the target group's models. Without these symbols, openai/newapi accounts whose operator only configured the admin 'model whitelist' (gateway routing limit) — but never created a Channel row + channel_model_pricing entry — render an empty pricing menu for users holding keys on that group, even though the gateway is happy to serve those models. This is the regression behind the TK 2026-05-21 local-stack incident: 17 GPT-family models in the GPT account's whitelist showed zero rows in /pricing until the bridge landed."
     }
   ]
 }


### PR DESCRIPTION
## Summary

- Fixes the 2026-05-21 local-stack regression where `/api/v1/me/pricing-catalog` ("Your Menu", #325) returned **zero rows** for users whose only path to a model was an account's admin model-whitelist (gateway routing limit) — operator never created a Channel row + `channel_model_pricing` entry for that group. Repro: GPT account with 17 whitelisted GPT-family models → 0 rows in /pricing despite the gateway happily serving them.
- Adds a **stage-2 account-whitelist fallback** to `MePricingCatalogService.buildModelsForGroup`. Build is now: (1) channel pricing (existing, authoritative on conflict) → (2) account-whitelist synthesis from `credentials.model_mapping` identity-mapped (`from === to`) entries with LiteLLM-catalog price + vendor (vendor-prefix lookup retained from #326) → (3) LiteLLM metadata join (context_window / capabilities / max_output_tokens), uniform across sources.
- Contract: channel-priced rows always win on conflict; mapping-mode entries (`from != to`, routing aliases) contribute nothing; cross-platform leak guard reuses `Account.IsOpenAICompatPoolMember` so openai/newapi pool semantics match the scheduler; catalog miss → row still emitted with nil prices (UI renders "—"); account-source errors are absorbed (best-effort, must not break /pricing on DB hiccup).
- Sentinel update: `scripts/sentinels/newapi.json` gains `MePricingAccountSource` / `fillWhitelistFallback` / `parseWhitelistFromCredentials` / `buildAccountFallbackEntry` so a silent upstream-merge removal trips preflight.

## Scope

Backend only — `service.MePricingCatalogService` + `AccountService.ListSchedulableByGroupID` exposure + `wire_gen.go` DI + sentinel registry. **no-web-impact**.

## Test plan

- [x] `go test -tags=unit ./internal/service/...` — full service unit suite passes (92.8s), including 7 new `TestBuildForUser_AccountWhitelist*` cases covering:
  - channel-only path unchanged
  - account-only emission with LiteLLM price × group rate
  - channel + account conflict → channel row wins (catalog set to a "wrong" 0.999 sentinel to make a regression obvious)
  - vendor-prefix lookup (e.g. `anthropic/claude-3-5-sonnet` → `claude-3-5-sonnet` in catalog)
  - cross-platform leak guard (openai account does not surface on anthropic-platform group)
  - mapping-mode entries ignored (alias `claude-3-haiku → claude-3-5-sonnet` produces no menu row)
  - LiteLLM-miss row still emits with nil prices
  - account-source error does not 500 the endpoint
- [x] `go build ./...` clean (cross-repo `../../new-api` resolves).
- [x] `scripts/preflight.sh` PASS — sentinel registry update gate detects the new symbols; upstream-shaped path coverage via sentinel update; main-ancestry anchor intact.
- [x] `pre-push` web-surface alignment: `no-web-impact` justification accepted.

Sibling code path (the channel-priced loop) is preserved verbatim — only the early-return short-circuits were lifted so the fallback runs even when `s.channels` returns no candidates.

🤖 Generated with [Claude Code](https://claude.com/claude-code)