### PR TITLE
fix(gateway): friendly 400 for retired Anthropic model IDs

### DIFF
--- a/backend/internal/service/account.go
+++ b/backend/internal/service/account.go
@@ -864,7 +864,12 @@ const (
 )
 
 // GetPoolModeRetryCount 返回池模式同账号重试次数。
-// 未配置或配置非法时回退为默认值 3；小于 0 按 0 处理；过大则截断到 10。
+// 未配置或配置非法时回退为默认值 1；小于 0 按 0 处理；过大则截断到 10。
+//
+// 注意：非 pool_mode 账号也会拿到 defaultPoolModeRetryCount=1，但实际不被消费——
+// 各平台 gateway 路径中 `RetryableOnSameAccount` 都 gated on
+// `account.IsPoolMode()`（见 gateway_service.go / openai_gateway_*.go），
+// 因此非 pool_mode 账号的 same-account retry 不会触发。
 func (a *Account) GetPoolModeRetryCount() int {
 	if a == nil || !a.IsPoolMode() || a.Credentials == nil {
 		return defaultPoolModeRetryCount

--- a/backend/internal/service/gateway_anthropic_deprecated_model_tk.go
+++ b/backend/internal/service/gateway_anthropic_deprecated_model_tk.go
@@ -1,0 +1,117 @@
+package service
+
+import (
+	"net/http"
+
+	"github.com/gin-gonic/gin"
+)
+
+// TokenKey: friendly 400 gate for retired / soon-to-sunset Anthropic model IDs.
+//
+// Why this exists: PR #329 / #327 removed retired Claude model IDs from the
+// admin dropdowns + default fallback chain, but TokenKey itself did not
+// short-circuit requests that still used those IDs. Without a gate, hardcoded
+// clients hit one of two failure modes:
+//   - account has no model_mapping → request passes through to Anthropic and
+//     fails with the upstream `not_found_error` (Claude 4.0 family until the
+//     2026-06-15 sunset, others already today).
+//   - account has model_mapping → admin's explicit mapping wins; deprecation
+//     check below runs on the *mapped* model so this case is naturally
+//     ignored (operator opt-in).
+//
+// The retired list intentionally includes the Claude 4.0 snapshots that
+// Anthropic accepts until 2026-06-15: surfacing the deprecation 25 days early
+// is the explicit product choice (`/xj-review` R-001 resolution, decision
+// path (c)) — a clear migration signal beats a silent upstream 404 cliff.
+//
+// Scope: native /v1/messages forward path + count_tokens path. Passthrough
+// (IsAnthropicAPIKeyPassthroughEnabled) and Bedrock are intentionally NOT
+// covered — passthrough is a "raw bytes" promise we do not modify, and
+// Bedrock keeps its own model lifecycle independent of Anthropic main
+// (`backend/internal/domain/constants.go` DefaultBedrockModelMapping).
+//
+// The check fires on the *mapped* model (after account.GetMappedModel /
+// claude.NormalizeModelID), so admin-configured rewrites such as
+// `claude-3-5-sonnet-20241022 -> claude-sonnet-4-6` continue to work — the
+// rewritten target is not in the retired list.
+
+const (
+	// tkDeprecatedAnthropicReplacementSonnet — recommended Sonnet replacement.
+	tkDeprecatedAnthropicReplacementSonnet = "claude-sonnet-4-6"
+	// tkDeprecatedAnthropicReplacementOpus — recommended Opus replacement.
+	tkDeprecatedAnthropicReplacementOpus = "claude-opus-4-7"
+	// tkDeprecatedAnthropicErrorType — Anthropic error envelope's inner type.
+	tkDeprecatedAnthropicErrorType = "invalid_request_error"
+)
+
+// tkDeprecatedAnthropicModels maps every retired or soon-to-sunset Anthropic
+// model snapshot ID to its recommended TokenKey replacement. The map is the
+// single source of truth for both the deprecation gate below and the
+// matching unit test. Adding a new entry here is sufficient; no other call
+// site needs to be updated.
+//
+// Sunset references (verified 2026-05-21 against
+// https://docs.anthropic.com/en/docs/about-claude/models/all-models#legacy-models):
+//   - claude-3-haiku-20240307, claude-3-sonnet-20240229, claude-3-opus-20240229:
+//     legacy family, already retired.
+//   - claude-3-5-haiku-20241022, claude-3-5-sonnet-20240620,
+//     claude-3-5-sonnet-20241022, claude-3-7-sonnet-20250219: 3.5 / 3.7 family,
+//     retired by PR #327 (`a9a67000`).
+//   - claude-sonnet-4-20250514, claude-opus-4-20250514: 4.0 family, Anthropic
+//     sunset 2026-06-15, retired by PR #329 (`0c2bdfb2`).
+var tkDeprecatedAnthropicModels = map[string]string{
+	"claude-3-haiku-20240307":    tkDeprecatedAnthropicReplacementSonnet,
+	"claude-3-sonnet-20240229":   tkDeprecatedAnthropicReplacementSonnet,
+	"claude-3-opus-20240229":     tkDeprecatedAnthropicReplacementOpus,
+	"claude-3-5-haiku-20241022":  tkDeprecatedAnthropicReplacementSonnet,
+	"claude-3-5-sonnet-20240620": tkDeprecatedAnthropicReplacementSonnet,
+	"claude-3-5-sonnet-20241022": tkDeprecatedAnthropicReplacementSonnet,
+	"claude-3-7-sonnet-20250219": tkDeprecatedAnthropicReplacementSonnet,
+	"claude-sonnet-4-20250514":   tkDeprecatedAnthropicReplacementSonnet,
+	"claude-opus-4-20250514":     tkDeprecatedAnthropicReplacementOpus,
+}
+
+// tkIsDeprecatedAnthropicModel reports whether the (already mapped) model ID
+// is on the retired list, and returns the recommended replacement. Lookups
+// are exact-match: TokenKey upstream accepts both short and long IDs, and
+// Claude OAuth paths run claude.NormalizeModelID before this hook, so the
+// long-ID exact match catches both call styles.
+func tkIsDeprecatedAnthropicModel(model string) (string, bool) {
+	if model == "" {
+		return "", false
+	}
+	replacement, ok := tkDeprecatedAnthropicModels[model]
+	return replacement, ok
+}
+
+// tkWriteAnthropicDeprecatedModelError emits the Anthropic-shape 400 error
+// for a retired model request and aborts further gin handling. Returning
+// `true` lets callers `return` immediately without writing their own
+// response. Safe to call with c == nil (returns false, no-op).
+func tkWriteAnthropicDeprecatedModelError(c *gin.Context, requestedModel, replacement string) bool {
+	if c == nil {
+		return false
+	}
+	c.AbortWithStatusJSON(http.StatusBadRequest, gin.H{
+		"type": "error",
+		"error": gin.H{
+			"type":    tkDeprecatedAnthropicErrorType,
+			"message": tkBuildDeprecatedAnthropicMessage(requestedModel, replacement),
+		},
+	})
+	return true
+}
+
+// tkBuildDeprecatedAnthropicMessage assembles the friendly migration message.
+// Kept as a separate function so the unit test can assert message content
+// without parsing JSON.
+func tkBuildDeprecatedAnthropicMessage(requestedModel, replacement string) string {
+	if replacement == "" {
+		replacement = tkDeprecatedAnthropicReplacementSonnet
+	}
+	return "Model '" + requestedModel + "' is retired or scheduled for sunset by Anthropic" +
+		" and has been removed from this TokenKey deployment. Please migrate to '" +
+		replacement + "' (or '" + tkDeprecatedAnthropicReplacementOpus +
+		"' for the Opus tier). See https://docs.anthropic.com/en/docs/about-claude/models/all-models" +
+		" for the current model list."
+}

--- a/backend/internal/service/gateway_anthropic_deprecated_model_tk.go
+++ b/backend/internal/service/gateway_anthropic_deprecated_model_tk.go
@@ -85,12 +85,11 @@ func tkIsDeprecatedAnthropicModel(model string) (string, bool) {
 }
 
 // tkWriteAnthropicDeprecatedModelError emits the Anthropic-shape 400 error
-// for a retired model request and aborts further gin handling. Returning
-// `true` lets callers `return` immediately without writing their own
-// response. Safe to call with c == nil (returns false, no-op).
-func tkWriteAnthropicDeprecatedModelError(c *gin.Context, requestedModel, replacement string) bool {
+// for a retired model request and aborts further gin handling. Safe to call
+// with c == nil (no-op).
+func tkWriteAnthropicDeprecatedModelError(c *gin.Context, requestedModel, replacement string) {
 	if c == nil {
-		return false
+		return
 	}
 	c.AbortWithStatusJSON(http.StatusBadRequest, gin.H{
 		"type": "error",
@@ -99,16 +98,14 @@ func tkWriteAnthropicDeprecatedModelError(c *gin.Context, requestedModel, replac
 			"message": tkBuildDeprecatedAnthropicMessage(requestedModel, replacement),
 		},
 	})
-	return true
 }
 
 // tkBuildDeprecatedAnthropicMessage assembles the friendly migration message.
 // Kept as a separate function so the unit test can assert message content
-// without parsing JSON.
+// without parsing JSON. Callers must pass a non-empty replacement — the
+// retired-model table guarantees this (every value is a Sonnet/Opus
+// constant), so there is no defensive fallback here.
 func tkBuildDeprecatedAnthropicMessage(requestedModel, replacement string) string {
-	if replacement == "" {
-		replacement = tkDeprecatedAnthropicReplacementSonnet
-	}
 	return "Model '" + requestedModel + "' is retired or scheduled for sunset by Anthropic" +
 		" and has been removed from this TokenKey deployment. Please migrate to '" +
 		replacement + "' (or '" + tkDeprecatedAnthropicReplacementOpus +

--- a/backend/internal/service/gateway_anthropic_deprecated_model_tk_test.go
+++ b/backend/internal/service/gateway_anthropic_deprecated_model_tk_test.go
@@ -59,19 +59,12 @@ func TestTkBuildDeprecatedAnthropicMessage(t *testing.T) {
 	require.Contains(t, msg, "anthropic.com", "must link to Anthropic docs")
 }
 
-func TestTkBuildDeprecatedAnthropicMessageEmptyReplacementFallsBackToSonnet(t *testing.T) {
-	msg := tkBuildDeprecatedAnthropicMessage("claude-3-opus-20240229", "")
-	require.Contains(t, msg, tkDeprecatedAnthropicReplacementSonnet,
-		"empty replacement should fall back to the sonnet default so the customer message never reads 'migrate to '''")
-}
-
 func TestTkWriteAnthropicDeprecatedModelError(t *testing.T) {
 	gin.SetMode(gin.TestMode)
 	w := httptest.NewRecorder()
 	c, _ := gin.CreateTestContext(w)
 
-	wrote := tkWriteAnthropicDeprecatedModelError(c, "claude-3-5-sonnet-20241022", tkDeprecatedAnthropicReplacementSonnet)
-	require.True(t, wrote)
+	tkWriteAnthropicDeprecatedModelError(c, "claude-3-5-sonnet-20241022", tkDeprecatedAnthropicReplacementSonnet)
 	require.Equal(t, http.StatusBadRequest, w.Code)
 	require.True(t, c.IsAborted(), "must abort further gin handlers")
 
@@ -93,8 +86,9 @@ func TestTkWriteAnthropicDeprecatedModelError(t *testing.T) {
 }
 
 func TestTkWriteAnthropicDeprecatedModelErrorNilContextIsSafe(t *testing.T) {
-	wrote := tkWriteAnthropicDeprecatedModelError(nil, "anything", "anything")
-	require.False(t, wrote, "nil context must be a safe no-op")
+	require.NotPanics(t, func() {
+		tkWriteAnthropicDeprecatedModelError(nil, "anything", "anything")
+	}, "nil context must be a safe no-op")
 }
 
 // Guards against silent table edits during upstream merges. The set of

--- a/backend/internal/service/gateway_anthropic_deprecated_model_tk_test.go
+++ b/backend/internal/service/gateway_anthropic_deprecated_model_tk_test.go
@@ -1,0 +1,123 @@
+package service
+
+import (
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"testing"
+
+	"github.com/gin-gonic/gin"
+	"github.com/stretchr/testify/require"
+)
+
+func TestTkIsDeprecatedAnthropicModel(t *testing.T) {
+	gin.SetMode(gin.TestMode)
+
+	cases := []struct {
+		name           string
+		model          string
+		wantDeprecated bool
+		wantReplaceTo  string
+	}{
+		{"3-haiku retired -> sonnet", "claude-3-haiku-20240307", true, tkDeprecatedAnthropicReplacementSonnet},
+		{"3-sonnet retired -> sonnet", "claude-3-sonnet-20240229", true, tkDeprecatedAnthropicReplacementSonnet},
+		{"3-opus retired -> opus", "claude-3-opus-20240229", true, tkDeprecatedAnthropicReplacementOpus},
+		{"3-5-haiku retired -> sonnet", "claude-3-5-haiku-20241022", true, tkDeprecatedAnthropicReplacementSonnet},
+		{"3-5-sonnet old retired -> sonnet", "claude-3-5-sonnet-20240620", true, tkDeprecatedAnthropicReplacementSonnet},
+		{"3-5-sonnet new retired -> sonnet", "claude-3-5-sonnet-20241022", true, tkDeprecatedAnthropicReplacementSonnet},
+		{"3-7-sonnet retired -> sonnet", "claude-3-7-sonnet-20250219", true, tkDeprecatedAnthropicReplacementSonnet},
+		{"4-0-sonnet sunsetting -> sonnet", "claude-sonnet-4-20250514", true, tkDeprecatedAnthropicReplacementSonnet},
+		{"4-0-opus sunsetting -> opus", "claude-opus-4-20250514", true, tkDeprecatedAnthropicReplacementOpus},
+
+		{"sonnet-4-6 current passes", "claude-sonnet-4-6", false, ""},
+		{"opus-4-7 current passes", "claude-opus-4-7", false, ""},
+		{"sonnet-4-5 current passes", "claude-sonnet-4-5", false, ""},
+		{"empty string passes", "", false, ""},
+		{"non-claude model passes", "gpt-5", false, ""},
+		{"short-id without snapshot passes", "claude-3-5-sonnet", false, ""},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			replacement, deprecated := tkIsDeprecatedAnthropicModel(tc.model)
+			require.Equal(t, tc.wantDeprecated, deprecated, "deprecated flag for %q", tc.model)
+			if tc.wantDeprecated {
+				require.Equal(t, tc.wantReplaceTo, replacement)
+			} else {
+				require.Empty(t, replacement)
+			}
+		})
+	}
+}
+
+func TestTkBuildDeprecatedAnthropicMessage(t *testing.T) {
+	msg := tkBuildDeprecatedAnthropicMessage("claude-3-5-sonnet-20241022", tkDeprecatedAnthropicReplacementSonnet)
+	require.Contains(t, msg, "claude-3-5-sonnet-20241022", "must echo the requested model")
+	require.Contains(t, msg, tkDeprecatedAnthropicReplacementSonnet, "must suggest sonnet replacement")
+	require.Contains(t, msg, tkDeprecatedAnthropicReplacementOpus, "must mention opus replacement")
+	require.Contains(t, msg, "anthropic.com", "must link to Anthropic docs")
+}
+
+func TestTkBuildDeprecatedAnthropicMessageEmptyReplacementFallsBackToSonnet(t *testing.T) {
+	msg := tkBuildDeprecatedAnthropicMessage("claude-3-opus-20240229", "")
+	require.Contains(t, msg, tkDeprecatedAnthropicReplacementSonnet,
+		"empty replacement should fall back to the sonnet default so the customer message never reads 'migrate to '''")
+}
+
+func TestTkWriteAnthropicDeprecatedModelError(t *testing.T) {
+	gin.SetMode(gin.TestMode)
+	w := httptest.NewRecorder()
+	c, _ := gin.CreateTestContext(w)
+
+	wrote := tkWriteAnthropicDeprecatedModelError(c, "claude-3-5-sonnet-20241022", tkDeprecatedAnthropicReplacementSonnet)
+	require.True(t, wrote)
+	require.Equal(t, http.StatusBadRequest, w.Code)
+	require.True(t, c.IsAborted(), "must abort further gin handlers")
+
+	var payload map[string]any
+	require.NoError(t, json.Unmarshal(w.Body.Bytes(), &payload),
+		"response body must be valid JSON in Anthropic shape")
+
+	require.Equal(t, "error", payload["type"], "top-level type must be 'error' for Anthropic clients")
+
+	errObj, ok := payload["error"].(map[string]any)
+	require.True(t, ok, "error field must be an object, got %T", payload["error"])
+	require.Equal(t, tkDeprecatedAnthropicErrorType, errObj["type"])
+
+	message, _ := errObj["message"].(string)
+	require.Contains(t, message, "claude-3-5-sonnet-20241022")
+	require.Contains(t, message, tkDeprecatedAnthropicReplacementSonnet)
+	require.True(t, strings.Contains(message, "retired") || strings.Contains(message, "sunset"),
+		"message should explain why the model is rejected")
+}
+
+func TestTkWriteAnthropicDeprecatedModelErrorNilContextIsSafe(t *testing.T) {
+	wrote := tkWriteAnthropicDeprecatedModelError(nil, "anything", "anything")
+	require.False(t, wrote, "nil context must be a safe no-op")
+}
+
+// Guards against silent table edits during upstream merges. The set of
+// retired IDs is the contract the customer-facing migration message refers
+// to; adding/removing one is a deliberate change that should not slip in
+// alongside an unrelated diff. Update this assertion explicitly when the
+// list changes.
+func TestTkDeprecatedAnthropicModelsTableIsExhaustive(t *testing.T) {
+	expected := map[string]struct{}{
+		"claude-3-haiku-20240307":    {},
+		"claude-3-sonnet-20240229":   {},
+		"claude-3-opus-20240229":     {},
+		"claude-3-5-haiku-20241022":  {},
+		"claude-3-5-sonnet-20240620": {},
+		"claude-3-5-sonnet-20241022": {},
+		"claude-3-7-sonnet-20250219": {},
+		"claude-sonnet-4-20250514":   {},
+		"claude-opus-4-20250514":     {},
+	}
+	require.Len(t, tkDeprecatedAnthropicModels, len(expected),
+		"retired model table size changed; update this assertion intentionally")
+	for id := range expected {
+		_, ok := tkDeprecatedAnthropicModels[id]
+		require.Truef(t, ok, "retired model %q must remain on the gate list", id)
+	}
+}

--- a/backend/internal/service/gateway_service.go
+++ b/backend/internal/service/gateway_service.go
@@ -4582,6 +4582,19 @@ func (s *GatewayService) Forward(ctx context.Context, c *gin.Context, account *A
 		logger.LegacyPrintf("service.gateway", "Model mapping applied: %s -> %s (account: %s, source=%s)", originalModel, mappedModel, account.Name, mappingSource)
 	}
 
+	// TK: friendly 400 for retired / sunset Anthropic model IDs. Runs after
+	// account.GetMappedModel + claude.NormalizeModelID so admin-configured
+	// mappings (e.g. claude-3-5-sonnet-20241022 -> claude-sonnet-4-6) take
+	// precedence — the check fires on the post-mapping model, so an admin
+	// who explicitly rewrote a retired ID into a current one keeps working.
+	// See gateway_anthropic_deprecated_model_tk.go.
+	if account.Platform == PlatformAnthropic {
+		if replacement, deprecated := tkIsDeprecatedAnthropicModel(mappedModel); deprecated {
+			tkWriteAnthropicDeprecatedModelError(c, mappedModel, replacement)
+			return nil, fmt.Errorf("anthropic model %q is retired (suggest %q)", mappedModel, replacement)
+		}
+	}
+
 	if s.shouldInjectAnthropicCacheTTL1h(ctx, account) {
 		body = injectAnthropicCacheControlTTL1h(body)
 	}
@@ -9156,6 +9169,18 @@ func (s *GatewayService) ForwardCountTokens(ctx context.Context, c *gin.Context,
 			body = s.replaceModelInBody(body, mappedModel)
 			reqModel = mappedModel
 			logger.LegacyPrintf("service.gateway", "CountTokens model mapping applied: %s -> %s (account: %s, source=%s)", parsed.Model, mappedModel, account.Name, mappingSource)
+		}
+	}
+
+	// TK: friendly 400 for retired / sunset Anthropic model IDs on the
+	// count_tokens path. Mirrors the Forward path gate so clients get the
+	// same migration signal whether they call /v1/messages or
+	// /v1/messages/count_tokens. Runs after mapping so admin-configured
+	// rewrites take precedence. See gateway_anthropic_deprecated_model_tk.go.
+	if account.Platform == PlatformAnthropic && reqModel != "" {
+		if replacement, deprecated := tkIsDeprecatedAnthropicModel(reqModel); deprecated {
+			tkWriteAnthropicDeprecatedModelError(c, reqModel, replacement)
+			return fmt.Errorf("anthropic model %q is retired (suggest %q)", reqModel, replacement)
 		}
 	}
 

--- a/backend/migrations/migrations.go
+++ b/backend/migrations/migrations.go
@@ -16,6 +16,14 @@ import "embed"
 //   - 格式：NNN_description.sql（如 001_init.sql, 002_add_users.sql）
 //   - 描述部分使用下划线分隔的小写单词
 //
+// 同序号兜底语义：
+//   - applyMigrationsFS 使用 sort.Strings(files) 按 ASCII 字典序加载
+//     （见 backend/internal/repository/migrations_runner.go）
+//   - 同序号的多个迁移按描述部分字典序确定执行顺序
+//     （例：136_add_*.sql < 136_remove_*.sql < 136_usage_*.sql）
+//   - 仅作为多 PR 同期合入时的物理兜底，避免序号冲突阻塞合入；
+//     新增迁移仍应使用唯一序号
+//
 // 迁移文件要求：
 //   - 必须是幂等的（可重复执行而不产生错误）
 //   - 推荐使用 IF NOT EXISTS / IF EXISTS 语法

--- a/scripts/sentinels/gateway-tk.json
+++ b/scripts/sentinels/gateway-tk.json
@@ -786,6 +786,28 @@
       "rationale": "Anchors the two normalize rules and their observability hooks. The rule functions MUST stay pure (no settingService dependency) so they remain trivially unit-testable; the GatewayService method is the only place that consults settingService.IsAnthropicRequestNormalizeEnabled. The two change-kind constants double as ops-event payload identifiers (Message field of OpsUpstreamErrorEvent) and as SQL filter terms in operator runbooks — renaming them silently breaks downstream dashboards. The Kind=\"request_normalized\" literal and the gateway.anthropic_request_normalized log key together let operators compute save-rate = 1 - (rows-with-event / total-normalize-hits); changing either breaks the existing query template."
     },
     {
+      "path": "backend/internal/service/gateway_anthropic_deprecated_model_tk.go",
+      "must_contain": [
+        "func tkIsDeprecatedAnthropicModel",
+        "func tkWriteAnthropicDeprecatedModelError",
+        "func tkBuildDeprecatedAnthropicMessage",
+        "tkDeprecatedAnthropicModels",
+        "claude-3-5-sonnet-20241022",
+        "claude-3-7-sonnet-20250219",
+        "claude-sonnet-4-20250514",
+        "claude-opus-4-20250514"
+      ],
+      "rationale": "Anchors the customer-facing deprecation gate for retired / soon-to-sunset Anthropic model IDs. PR #329 / #327 removed the IDs from admin dropdowns + default chain but did NOT short-circuit requests; this module is what turns a hardcoded-client request into a friendly 400 + migration suggestion instead of an opaque upstream not_found_error. The table literal IDs (3-5-sonnet-20241022, 3-7-sonnet, 4.0 sonnet/opus snapshots) are pinned because dropping any of them silently re-opens the cliff for a specific client population — the snapshot ID is the contract the customer's migration message refers to. The replacement-message builder is anchored separately because the Anthropic 4.0 family is still upstream-accepted until 2026-06-15: the friendly message is the only signal customers get before that date. See /xj-review R-001 (decision path c)."
+    },
+    {
+      "path": "backend/internal/service/gateway_service.go",
+      "must_contain": [
+        "tkWriteAnthropicDeprecatedModelError(c, mappedModel, replacement)",
+        "tkWriteAnthropicDeprecatedModelError(c, reqModel, replacement)"
+      ],
+      "rationale": "Pins the TWO deprecation-gate call sites in gateway_service.go: the Forward path (~4585) checks `mappedModel` AFTER account.GetMappedModel + claude.NormalizeModelID so admin-configured mappings take precedence, and the ForwardCountTokens path (~9175) checks `reqModel` AFTER its own mapping block. Two distinct argument shapes are anchored separately because the literal `tkWriteAnthropicDeprecatedModelError(c, ` alone would be satisfied by either call site, leaving the other silently unguarded — same pattern the normalize anchors already use. Without both, an upstream merge that touches the surrounding mapping/normalize code can silently drop one path and re-open the 2026-06-15 customer cliff on count_tokens (or vice versa)."
+    },
+    {
       "path": "backend/internal/service/setting_service_tk_anthropic_normalize.go",
       "must_contain": [
         "SettingKeyAnthropicRequestNormalizeEnabled",


### PR DESCRIPTION
## Summary

Adds a customer-facing migration gate for retired / soon-to-sunset
Claude snapshot IDs at the `/v1/messages` and `/v1/messages/count_tokens`
gateway entry. Comes out of `/xj-review` on v1.7.39..HEAD (R-001,
decision path **c** — friendly 400 + migration suggestion, not silent
alias).

- Hardcoded clients that still send retired IDs (3.x / 3.5 / 3.7 family
  today, 4.0 family before the 2026-06-15 Anthropic sunset) now receive
  an Anthropic-shape 400 echoing the requested ID, the recommended
  replacement, and a link to Anthropic's current model list — instead
  of an opaque upstream `not_found_error`.
- Gate fires after `account.GetMappedModel` + `claude.NormalizeModelID`,
  so admin-configured rewrites (e.g. `claude-3-5-sonnet-20241022 ->
  claude-sonnet-4-6`) take precedence and keep working.
- Passthrough and Bedrock paths are intentionally **not** gated
  (passthrough is a raw-bytes promise, Bedrock keeps its own model
  lifecycle — `DefaultBedrockModelMapping` still pins 4.0 IDs by design).

### Retired set (single source of truth)

Defined in [`gateway_anthropic_deprecated_model_tk.go`](https://github.com/youxuanxue/sub2api/blob/fix/anthropic-deprecated-model-gate/backend/internal/service/gateway_anthropic_deprecated_model_tk.go):

| Model ID | Replacement | Source |
|---|---|---|
| `claude-3-haiku-20240307` | `claude-sonnet-4-6` | legacy |
| `claude-3-sonnet-20240229` | `claude-sonnet-4-6` | legacy |
| `claude-3-opus-20240229` | `claude-opus-4-7` | legacy |
| `claude-3-5-haiku-20241022` | `claude-sonnet-4-6` | PR #327 |
| `claude-3-5-sonnet-20240620` | `claude-sonnet-4-6` | PR #327 |
| `claude-3-5-sonnet-20241022` | `claude-sonnet-4-6` | PR #327 |
| `claude-3-7-sonnet-20250219` | `claude-sonnet-4-6` | PR #327 |
| `claude-sonnet-4-20250514` | `claude-sonnet-4-6` | PR #329 (sunset 2026-06-15) |
| `claude-opus-4-20250514` | `claude-opus-4-7` | PR #329 (sunset 2026-06-15) |

### Why path (c) and not auto-alias

Path (a) — silent legacy-to-current rewrite inside `GetMappedModel` —
would leave the hardcoded client indefinitely unaware that the snapshot
they depend on is gone, then crash months later when an unrelated config
drift removes the alias. A friendly 400 is the explicit migration signal
customers need now, on the exact endpoint they call. Admin can still
opt into per-account `model_mapping` rewrites if they want to keep a
specific legacy client running unattended.

### xj-review housekeeping bundled in

| Finding | Resolution |
|---|---|
| R-003 | [`backend/migrations/migrations.go`](https://github.com/youxuanxue/sub2api/blob/fix/anthropic-deprecated-model-gate/backend/migrations/migrations.go) documents the "same-prefix sort by description" tie-breaker as the explicit physical fallback for multi-PR migration-number collisions (e.g. the `136_*` trio in this release window). |
| R-005 | [`backend/internal/service/account.go`](https://github.com/youxuanxue/sub2api/blob/fix/anthropic-deprecated-model-gate/backend/internal/service/account.go) `GetPoolModeRetryCount` notes that non-pool_mode callers receive the default `1` but never consume it (all `RetryableOnSameAccount` sites are gated on `account.IsPoolMode()`). Removes the misread that PR #333 cut every platform's retry budget from 3 to 1. |

R-002 (cc-us1-oauth pool_mode alert hook) tracked separately by the
review owner. R-004 verified: `ops_retry.go` and all referencing call
sites were already removed by upstream PR (commit `2eb622f2` imported
via #334); `136_remove_ops_retry_replay.sql` DROP is safe.

## Test plan

- [x] `go build ./...`
- [x] `go vet ./internal/service/...`
- [x] `go test -tags=unit -count=1 ./internal/service/...` (92.5s) — new file's 6 tests + 15 sub-cases all PASS; broader service suite stays green
- [x] `golangci-lint run ./internal/service/...` — 0 issues
- [x] `python3 scripts/sentinels/check-gateway-tk.py` — 84/84 intact (3 new anchors added for the deprecated-model file and the 2 call sites)
- [x] `python3 scripts/sentinels/check-newapi.py` — 27/27 intact
- [x] `python3 scripts/sentinels/check-frontend-tk.py` — 28/28 intact
- [x] `bash scripts/preflight.sh` — PASS
- [ ] Manual smoke after merge: `curl -X POST .../v1/messages -d '{"model":"claude-3-5-sonnet-20241022", …}'` should return Anthropic-shape 400 with migration message; same request with a current ID should pass through.
- [ ] Manual smoke after merge: same on `/v1/messages/count_tokens`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)