### PR TITLE
fix(ratelimit): consolidate Anthropic OAuth error handling (P0-P5)

### DIFF
--- a/backend/cmd/server/wire_gen.go
+++ b/backend/cmd/server/wire_gen.go
@@ -274,7 +274,7 @@ func initializeApplication(buildInfo handler.BuildInfo) (*Application, error) {
 	httpServer := server.ProvideHTTPServer(configConfig, engine)
 	opsMetricsCollector := service.ProvideOpsMetricsCollector(opsRepository, settingRepository, accountRepository, concurrencyService, db, redisClient, configConfig)
 	opsAggregationService := service.ProvideOpsAggregationService(opsRepository, settingRepository, db, redisClient, configConfig)
-	opsAlertEvaluatorService := service.ProvideOpsAlertEvaluatorService(opsService, opsRepository, emailService, redisClient, configConfig)
+	opsAlertEvaluatorService := service.ProvideOpsAlertEvaluatorService(opsService, opsRepository, emailService, redisClient, configConfig, anthropicUpstreamErrorCounterCache)
 	opsCleanupService := service.ProvideOpsCleanupService(opsRepository, db, redisClient, configConfig, channelMonitorService, settingRepository, opsService)
 	opsScheduledReportService := service.ProvideOpsScheduledReportService(opsService, userService, emailService, redisClient, configConfig)
 	rateLimitExpiryRepository := repository.NewRateLimitExpiryRepository(db)

--- a/backend/internal/config/config.go
+++ b/backend/internal/config/config.go
@@ -1268,6 +1268,15 @@ type DefaultConfig struct {
 type RateLimitConfig struct {
 	OverloadCooldownMinutes int `mapstructure:"overload_cooldown_minutes"`  // 529过载冷却时间(分钟)
 	OAuth401CooldownMinutes int `mapstructure:"oauth_401_cooldown_minutes"` // OAuth 401临时不可调度冷却(分钟)
+
+	// AnthropicErrorThreshold 控制 handleAnthropicUpstreamError 的 short-window
+	// 计数阈值（默认 3）。单账号 / 小拼车场景可调到 5–7 减少 Sonnet↔Opus 切换时的
+	// jitter 误触；零值或负值回退到内置默认。
+	AnthropicErrorThreshold int `mapstructure:"anthropic_error_threshold"`
+
+	// AnthropicErrorWindowMinutes 控制阈值短窗口长度（默认 1 分钟）。零值或负值
+	// 回退到内置默认。
+	AnthropicErrorWindowMinutes int `mapstructure:"anthropic_error_window_minutes"`
 }
 
 // APIKeyAuthCacheConfig API Key 认证缓存配置

--- a/backend/internal/config/config.go
+++ b/backend/internal/config/config.go
@@ -1770,6 +1770,8 @@ func setDefaults() {
 	// RateLimit
 	viper.SetDefault("rate_limit.overload_cooldown_minutes", 10)
 	viper.SetDefault("rate_limit.oauth_401_cooldown_minutes", 10)
+	viper.SetDefault("rate_limit.anthropic_error_threshold", 3)
+	viper.SetDefault("rate_limit.anthropic_error_window_minutes", 1)
 
 	// Pricing - 从 model-price-repo 同步模型定价和上下文窗口数据（固定到 commit，避免分支漂移）
 	viper.SetDefault("pricing.remote_url", "https://raw.githubusercontent.com/Wei-Shaw/model-price-repo/main/model_prices_and_context_window.json")

--- a/backend/internal/repository/anthropic_upstream_error_counter_cache.go
+++ b/backend/internal/repository/anthropic_upstream_error_counter_cache.go
@@ -70,3 +70,27 @@ func (c *anthropicUpstreamErrorCounterCache) ResetAnthropicCooldownTier(ctx cont
 	key := fmt.Sprintf("%s%d", anthropicCooldownTierPrefix, accountID)
 	return c.rdb.Del(ctx, key).Err()
 }
+
+func (c *anthropicUpstreamErrorCounterCache) IncrementAnthropicCooldownTierEscalations(ctx context.Context, ttlMinutes int) (int64, error) {
+	ttlSeconds := ttlMinutes * 60
+	if ttlSeconds < 60 {
+		ttlSeconds = 60
+	}
+
+	result, err := anthropicUpstreamErrorCounterIncrScript.Run(ctx, c.rdb, []string{service.AnthropicCooldownTierEscalationsKey}, ttlSeconds).Int64()
+	if err != nil {
+		return 0, fmt.Errorf("increment anthropic cooldown tier escalations: %w", err)
+	}
+	return result, nil
+}
+
+func (c *anthropicUpstreamErrorCounterCache) GetAnthropicCooldownTierEscalations(ctx context.Context) (int64, error) {
+	val, err := c.rdb.Get(ctx, service.AnthropicCooldownTierEscalationsKey).Int64()
+	if err != nil {
+		if err == redis.Nil {
+			return 0, nil
+		}
+		return 0, fmt.Errorf("get anthropic cooldown tier escalations: %w", err)
+	}
+	return val, nil
+}

--- a/backend/internal/service/anthropic_upstream_error_counter.go
+++ b/backend/internal/service/anthropic_upstream_error_counter.go
@@ -2,6 +2,14 @@ package service
 
 import "context"
 
+// AnthropicCooldownTierEscalationsKey is the Redis key used to aggregate
+// "tier >= 1" cooldown events across all Anthropic accounts. Exported so
+// the ops alert evaluator can read it without going through the cache
+// interface (which would require wiring the interface into the evaluator
+// constructor / Wire DI graph). The repository INCR/GET helpers and the
+// evaluator metric MUST agree on this key.
+const AnthropicCooldownTierEscalationsKey = "anthropic_cooldown_tier_escalations:global"
+
 type AnthropicUpstreamErrorCounterCache interface {
 	IncrementAnthropicUpstreamErrorCount(ctx context.Context, accountID int64, windowMinutes int) (int64, error)
 	ResetAnthropicUpstreamErrorCount(ctx context.Context, accountID int64) error
@@ -13,4 +21,14 @@ type AnthropicUpstreamErrorCounterCache interface {
 	// counter so a healed account does not carry escalation state forward.
 	IncrementAnthropicCooldownTier(ctx context.Context, accountID int64, ttlMinutes int) (int64, error)
 	ResetAnthropicCooldownTier(ctx context.Context, accountID int64) error
+
+	// Global escalation counter aggregates "tier >= 1" cooldown events across
+	// all Anthropic accounts in a rolling window (TTL controlled by caller).
+	// It exists so ops_alert_evaluator can drive a metric/alert without
+	// scanning every per-account counter. Increment is best-effort — a Redis
+	// failure only loses telemetry resolution and never blocks request
+	// handling. Read returns 0 when the key has expired (no escalation in
+	// the most recent window) or the cache backend is unhealthy.
+	IncrementAnthropicCooldownTierEscalations(ctx context.Context, ttlMinutes int) (int64, error)
+	GetAnthropicCooldownTierEscalations(ctx context.Context) (int64, error)
 }

--- a/backend/internal/service/ops_alert_evaluator_service.go
+++ b/backend/internal/service/ops_alert_evaluator_service.go
@@ -55,6 +55,23 @@ type OpsAlertEvaluatorService struct {
 	skipLogAt time.Time
 
 	warnNoRedisOnce sync.Once
+
+	// Optional cache injection for anthropic cooldown-tier escalation counter.
+	// When unset the metric path falls back to redisClient.Get on the
+	// canonical key (AnthropicCooldownTierEscalationsKey). Wired via
+	// SetAnthropicUpstreamErrorCounterCache so unit tests can drive the
+	// metric without spinning up Redis.
+	anthropicUpstreamErrorCounterCache AnthropicUpstreamErrorCounterCache
+}
+
+// SetAnthropicUpstreamErrorCounterCache attaches the anthropic upstream-error
+// counter cache for read-side use by the anthropic_cooldown_tier_escalation_
+// count metric. Idempotent and intended for Wire DI / tests.
+func (s *OpsAlertEvaluatorService) SetAnthropicUpstreamErrorCounterCache(cache AnthropicUpstreamErrorCounterCache) {
+	if s == nil {
+		return
+	}
+	s.anthropicUpstreamErrorCounterCache = cache
 }
 
 type opsAlertRuleState struct {
@@ -555,6 +572,36 @@ func (s *OpsAlertEvaluatorService) computeRuleMetric(
 		return float64(countAccountsByCondition(availability.Accounts, func(acc *AccountAvailability) bool {
 			return acc.IsOverloaded
 		})), true
+	case "anthropic_cooldown_tier_escalation_count":
+		// Aggregate count of "tier >= 1" anthropic cooldown events across all
+		// accounts within the rolling window owned by the writer (default 1h
+		// via anthropicCooldownTierEscalationsWindowMinutes). The metric
+		// drives Feishu/email alerts for the PR #337 ladder follow-up:
+		// tier=0 (30s) is transient jitter and intentionally invisible here;
+		// tier>=1 (≥ 2 min cooldown) is the "real problem starting" signal.
+		// Scope filters (platform/groupID) are ignored — the counter is
+		// global by construction.
+		if s == nil {
+			return 0, false
+		}
+		if s.anthropicUpstreamErrorCounterCache != nil {
+			val, err := s.anthropicUpstreamErrorCounterCache.GetAnthropicCooldownTierEscalations(ctx)
+			if err != nil {
+				return 0, false
+			}
+			return float64(val), true
+		}
+		if s.redisClient == nil {
+			return 0, false
+		}
+		val, err := s.redisClient.Get(ctx, AnthropicCooldownTierEscalationsKey).Int64()
+		if err != nil {
+			if err == redis.Nil {
+				return 0, true
+			}
+			return 0, false
+		}
+		return float64(val), true
 	}
 
 	overview, err := s.opsRepo.GetDashboardOverview(ctx, &OpsDashboardFilter{

--- a/backend/internal/service/ops_alert_evaluator_service.go
+++ b/backend/internal/service/ops_alert_evaluator_service.go
@@ -581,24 +581,18 @@ func (s *OpsAlertEvaluatorService) computeRuleMetric(
 		// tier>=1 (≥ 2 min cooldown) is the "real problem starting" signal.
 		// Scope filters (platform/groupID) are ignored — the counter is
 		// global by construction.
-		if s == nil {
+		//
+		// The cache MUST be wired by ProvideOpsAlertEvaluatorService; a nil
+		// cache means the evaluator was constructed without DI (test stub /
+		// shim) and the metric is intentionally unavailable in that mode —
+		// no silent raw-Redis fallback (testing path and production path
+		// must hit the same interface, otherwise the cache interface
+		// would silently disappear from the production graph).
+		if s == nil || s.anthropicUpstreamErrorCounterCache == nil {
 			return 0, false
 		}
-		if s.anthropicUpstreamErrorCounterCache != nil {
-			val, err := s.anthropicUpstreamErrorCounterCache.GetAnthropicCooldownTierEscalations(ctx)
-			if err != nil {
-				return 0, false
-			}
-			return float64(val), true
-		}
-		if s.redisClient == nil {
-			return 0, false
-		}
-		val, err := s.redisClient.Get(ctx, AnthropicCooldownTierEscalationsKey).Int64()
+		val, err := s.anthropicUpstreamErrorCounterCache.GetAnthropicCooldownTierEscalations(ctx)
 		if err != nil {
-			if err == redis.Nil {
-				return 0, true
-			}
 			return 0, false
 		}
 		return float64(val), true

--- a/backend/internal/service/ratelimit_service.go
+++ b/backend/internal/service/ratelimit_service.go
@@ -70,13 +70,62 @@ const (
 	openAI403DisableThreshold       = 3
 	openAI403CounterWindowMinutes   = 180
 
-	anthropicUpstreamErrorThreshold     = 3
-	anthropicUpstreamErrorWindowMinutes = 1
+	// Built-in defaults for handleAnthropicUpstreamError; the live values
+	// are read via getAnthropicErrorThreshold / getAnthropicErrorWindowMinutes
+	// so operators can lift the threshold for single-account or small-pool
+	// deployments without recompiling.
+	anthropicUpstreamErrorThresholdDefault     = 3
+	anthropicUpstreamErrorWindowMinutesDefault = 1
+
 	// Cooldown escalation TTL: how long a prior cooldown trigger keeps the
 	// account at an elevated tier before falling back to the shortest tier
 	// (30s). Anything inside this window counts toward escalation.
 	anthropicCooldownTierTTLMinutes = 30
+
+	// Window owned by the global "tier >= 1" escalation counter that drives
+	// the anthropic_cooldown_tier_escalation_count ops_alert_evaluator
+	// metric. 60 min picks the smallest unit operators care about for the
+	// "is the whole pool burning down right now" question; the counter
+	// expires when the window closes so a healed deploy reads zero.
+	anthropicCooldownTierEscalationsWindowMinutes = 60
+
+	// 403 keyword scan used by handle403 to surface suspected TLS / bot-
+	// detection regressions. When the upstream body contains any of these
+	// tokens we skip the long account_disabled_auth_error cooldown and
+	// keep the account on a short cooldown so an operator can react.
+	tlsFingerprintFailureCooldown = 30 * time.Second
 )
+
+// tlsFingerprintFailureKeywords matches Cloudflare / WAF responses that
+// reveal the request was rejected on TLS shape rather than on the OAuth
+// identity itself (e.g. "ja3" / "ja4" / "bot detection" / "tls fingerprint").
+// Order is insignificant; matching is case-insensitive.
+var tlsFingerprintFailureKeywords = []string{
+	"ja3",
+	"ja4",
+	"bot detection",
+	"bot management",
+	"tls fingerprint",
+	"client fingerprint",
+}
+
+// getAnthropicErrorThreshold returns the configured 3/3-style threshold, or
+// the built-in default when unset / zero / negative.
+func (s *RateLimitService) getAnthropicErrorThreshold() int64 {
+	if s != nil && s.cfg != nil && s.cfg.RateLimit.AnthropicErrorThreshold > 0 {
+		return int64(s.cfg.RateLimit.AnthropicErrorThreshold)
+	}
+	return anthropicUpstreamErrorThresholdDefault
+}
+
+// getAnthropicErrorWindowMinutes returns the configured short-window length
+// for the 3/3 counter, or the built-in default when unset / zero / negative.
+func (s *RateLimitService) getAnthropicErrorWindowMinutes() int {
+	if s != nil && s.cfg != nil && s.cfg.RateLimit.AnthropicErrorWindowMinutes > 0 {
+		return s.cfg.RateLimit.AnthropicErrorWindowMinutes
+	}
+	return anthropicUpstreamErrorWindowMinutesDefault
+}
 
 // anthropicCooldownTierLadder picks an exponentially longer cooldown when
 // the same account repeatedly trips the 3/3 short-window threshold inside
@@ -325,16 +374,25 @@ func (s *RateLimitService) HandleUpstreamError(ctx context.Context, account *Acc
 	case 404:
 		shouldDisable = s.handle404(ctx, account, upstreamMsg, responseBody)
 	case 429:
-		s.handle429(ctx, account, headers, responseBody)
+		// handle429 returns true when SetRateLimited landed on an upstream-
+		// provided reset time. If so, suppress the ladder's parallel
+		// SetTempUnschedulable write (last-write-wins would otherwise
+		// race a less-precise local cooldown over the just-written reset).
+		// The 3/3 + tier counters still advance so persistent failure
+		// still escalates.
+		rateLimitSet := s.handle429(ctx, account, headers, responseBody)
 		if account.Platform == PlatformAnthropic {
-			shouldDisable = s.handleAnthropicUpstreamError(ctx, account, statusCode, upstreamMsg, responseBody)
+			shouldDisable = s.handleAnthropicUpstreamErrorWithOptions(ctx, account, statusCode, upstreamMsg, responseBody, rateLimitSet)
 		} else {
 			shouldDisable = false
 		}
 	case 529:
-		s.handle529(ctx, account)
+		// Same rationale as 429: when handle529 successfully wrote
+		// SetOverloaded with the configured cooldown, suppress the
+		// ladder's redundant SetTempUnschedulable write.
+		overloadSet := s.handle529(ctx, account)
 		if account.Platform == PlatformAnthropic {
-			shouldDisable = s.handleAnthropicUpstreamError(ctx, account, statusCode, upstreamMsg, responseBody)
+			shouldDisable = s.handleAnthropicUpstreamErrorWithOptions(ctx, account, statusCode, upstreamMsg, responseBody, overloadSet)
 		} else {
 			shouldDisable = false
 		}
@@ -772,6 +830,45 @@ func (s *RateLimitService) handle403(ctx context.Context, account *Account, upst
 		return s.handleOpenAI403(ctx, account, upstreamMsg, responseBody)
 	}
 	if account.Platform == PlatformAnthropic {
+		// TLS / bot-detection 失效专项：上游用 403 拒绝是因为 Cloudflare / WAF
+		// 识别到 JA3/JA4 不像真实 Claude Code CLI（指纹库失效或 CLI 版本升级）。
+		// 这种情况下账号本身没问题，是基础设施层面的问题，需要 ops 立即介入
+		// 重新抓 TLS 指纹。用一个短 cooldown 避免持续重试加重风控，并打一个
+		// 高可见性 slog 让告警钩子能拉起来（运维侧用 log-based alert 接入即可）。
+		if matched := matchTempUnschedKeyword(strings.ToLower(string(responseBody)), tlsFingerprintFailureKeywords); matched != "" {
+			until := time.Now().Add(tlsFingerprintFailureCooldown)
+			reasonMessage := fmt.Sprintf("Anthropic 403 with TLS/bot-detection signal (%s): %s",
+				matched, upstreamMsg)
+			state := &TempUnschedState{
+				UntilUnix:       until.Unix(),
+				TriggeredAtUnix: time.Now().Unix(),
+				StatusCode:      http.StatusForbidden,
+				MatchedKeyword:  "tls_fingerprint_failure",
+				RuleIndex:       -1,
+				ErrorMessage:    truncateTempUnschedMessage([]byte(reasonMessage), tempUnschedMessageMaxBytes),
+			}
+			reasonJSON := reasonMessage
+			if raw, marshalErr := json.Marshal(state); marshalErr == nil {
+				reasonJSON = string(raw)
+			}
+			if err := s.accountRepo.SetTempUnschedulable(ctx, account.ID, until, reasonJSON); err != nil {
+				slog.Warn("anthropic_tls_fingerprint_set_temp_unschedulable_failed",
+					"account_id", account.ID, "error", err)
+			}
+			if s.tempUnschedCache != nil {
+				if err := s.tempUnschedCache.SetTempUnsched(ctx, account.ID, state); err != nil {
+					slog.Warn("anthropic_tls_fingerprint_temp_unsched_cache_set_failed",
+						"account_id", account.ID, "error", err)
+				}
+			}
+			slog.Error("anthropic_tls_fingerprint_failure_suspected",
+				"account_id", account.ID,
+				"matched_keyword", matched,
+				"cooldown_seconds", int(tlsFingerprintFailureCooldown.Seconds()),
+				"action", "ops_should_re-capture_claude_cli_tls_profile",
+				"upstream_msg", upstreamMsg)
+			return true
+		}
 		return s.handleAnthropicUpstreamError(ctx, account, http.StatusForbidden, upstreamMsg, responseBody)
 	}
 	msg := buildForbiddenErrorMessage(
@@ -812,23 +909,37 @@ func (s *RateLimitService) handle403(ctx context.Context, account *Account, upst
 // in case 400, OAuth 401 refresh, 429 retry-after cooldown, 529 overload)
 // live outside this function and are unaffected.
 func (s *RateLimitService) handleAnthropicUpstreamError(ctx context.Context, account *Account, statusCode int, upstreamMsg string, responseBody []byte) (shouldDisable bool) {
+	return s.handleAnthropicUpstreamErrorWithOptions(ctx, account, statusCode, upstreamMsg, responseBody, false)
+}
+
+// handleAnthropicUpstreamErrorWithOptions is the implementation seam for
+// callers that already wrote an authoritative cooldown to the account
+// (handle429 with retry-after / handle529 with overload_until). When
+// skipCooldownWrite=true the 3/3 + tier counters still advance and the
+// observability slog still fires — only the SetTempUnschedulable write
+// is suppressed so the just-written rate_limit_reset / overload_until is
+// not raced by a less-precise ladder cooldown (last-write-wins).
+func (s *RateLimitService) handleAnthropicUpstreamErrorWithOptions(ctx context.Context, account *Account, statusCode int, upstreamMsg string, responseBody []byte, skipCooldownWrite bool) (shouldDisable bool) {
 	msg := buildAnthropicUpstreamErrorMessage(statusCode, upstreamMsg, responseBody)
 	if s.anthropicUpstreamErrorCounterCache == nil {
 		slog.Warn("anthropic_upstream_error_counter_missing", "account_id", account.ID, "status_code", statusCode)
 		return false
 	}
 
-	count, err := s.anthropicUpstreamErrorCounterCache.IncrementAnthropicUpstreamErrorCount(ctx, account.ID, anthropicUpstreamErrorWindowMinutes)
+	threshold := s.getAnthropicErrorThreshold()
+	windowMinutes := s.getAnthropicErrorWindowMinutes()
+
+	count, err := s.anthropicUpstreamErrorCounterCache.IncrementAnthropicUpstreamErrorCount(ctx, account.ID, windowMinutes)
 	if err != nil {
 		slog.Warn("anthropic_upstream_error_increment_failed", "account_id", account.ID, "status_code", statusCode, "error", err)
 		return false
 	}
-	if count < anthropicUpstreamErrorThreshold {
+	if count < threshold {
 		slog.Warn("anthropic_upstream_error_count",
 			"account_id", account.ID,
 			"status_code", statusCode,
 			"count", count,
-			"threshold", anthropicUpstreamErrorThreshold,
+			"threshold", threshold,
 			"pool_mode", account.IsPoolMode())
 		return false
 	}
@@ -852,10 +963,49 @@ func (s *RateLimitService) handleAnthropicUpstreamError(ctx context.Context, acc
 	}
 	cooldown := anthropicCooldownTierLadder[tierIndex]
 
+	// Emit a global "tier >= 1" escalation signal so ops_alert_evaluator can
+	// surface "persistent failure rising" without scanning every per-account
+	// counter. tier=0 is intentionally silent — that's transient jitter and
+	// the 30s cooldown absorbs it. Failure here only loses telemetry.
+	if tierIndex >= 1 {
+		if _, escErr := s.anthropicUpstreamErrorCounterCache.IncrementAnthropicCooldownTierEscalations(ctx, anthropicCooldownTierEscalationsWindowMinutes); escErr != nil {
+			slog.Warn("anthropic_cooldown_tier_escalation_increment_failed",
+				"account_id", account.ID,
+				"status_code", statusCode,
+				"tier", tierIndex,
+				"error", escErr)
+		} else {
+			slog.Warn("anthropic_cooldown_tier_escalation",
+				"account_id", account.ID,
+				"status_code", statusCode,
+				"tier", tierIndex,
+				"cooldown_seconds", int(cooldown.Seconds()),
+				"pool_mode", account.IsPoolMode())
+		}
+	}
+
+	if skipCooldownWrite {
+		// The dispatch caller (case 429 retry-after path / case 529 overload
+		// path) already wrote an authoritative cooldown to the account
+		// state. Suppress the ladder's SetTempUnschedulable write so the
+		// just-landed rate_limit_reset / overload_until is not overwritten
+		// by a less-precise local cooldown. Counters above still advanced.
+		slog.Warn("anthropic_upstream_error_cooldown_write_skipped",
+			"account_id", account.ID,
+			"status_code", statusCode,
+			"count", count,
+			"threshold", threshold,
+			"cooldown_seconds", int(cooldown.Seconds()),
+			"tier", tierIndex,
+			"reason", "authoritative_cooldown_already_written",
+			"pool_mode", account.IsPoolMode())
+		return true
+	}
+
 	now := time.Now()
 	until := now.Add(cooldown)
 	reasonMessage := fmt.Sprintf("Anthropic upstream error threshold (%d/%d, cooldown=%s tier=%d): %s",
-		count, anthropicUpstreamErrorThreshold, cooldown, tierIndex, msg)
+		count, threshold, cooldown, tierIndex, msg)
 	state := &TempUnschedState{
 		UntilUnix:       until.Unix(),
 		TriggeredAtUnix: now.Unix(),
@@ -886,7 +1036,7 @@ func (s *RateLimitService) handleAnthropicUpstreamError(ctx context.Context, acc
 		"status_code", statusCode,
 		"until", until,
 		"count", count,
-		"threshold", anthropicUpstreamErrorThreshold,
+		"threshold", threshold,
 		"cooldown_seconds", int(cooldown.Seconds()),
 		"tier", tierIndex,
 		"pool_mode", account.IsPoolMode())
@@ -1058,7 +1208,17 @@ func findAnthropicNotFoundModel(text string) string {
 
 // handle429 处理429限流错误
 // 解析响应头获取重置时间，标记账号为限流状态
-func (s *RateLimitService) handle429(ctx context.Context, account *Account, headers http.Header, responseBody []byte) {
+// handle429 returns true when an exact SetRateLimited write to an
+// upstream-provided reset time succeeded; false otherwise (header missing,
+// SetRateLimited failure, fallback 5-min cooldown, extra-usage skip).
+// The return is consumed by the case 429 dispatch in HandleUpstreamError
+// so handleAnthropicUpstreamError can skip the ladder cooldown write
+// (which is by design less precise than what the upstream told us).
+// The 3/3 short-window counter and the per-account tier counter still
+// advance so persistent failure still escalates — only the
+// SetTempUnschedulable write is suppressed when the more authoritative
+// SetRateLimited has just landed.
+func (s *RateLimitService) handle429(ctx context.Context, account *Account, headers http.Header, responseBody []byte) bool {
 	// 1. OpenAI 平台：优先尝试解析 x-codex-* 响应头（用于 rate_limit_exceeded）
 	if account.Platform == PlatformOpenAI {
 		persistOpenAI429PlanType(ctx, s.accountRepo, account, responseBody)
@@ -1066,10 +1226,10 @@ func (s *RateLimitService) handle429(ctx context.Context, account *Account, head
 		if resetAt := s.calculateOpenAI429ResetTime(headers); resetAt != nil {
 			if err := s.accountRepo.SetRateLimited(ctx, account.ID, *resetAt); err != nil {
 				slog.Warn("rate_limit_set_failed", "account_id", account.ID, "error", err)
-				return
+				return false
 			}
 			slog.Info("openai_account_rate_limited", "account_id", account.ID, "reset_at", *resetAt)
-			return
+			return true
 		}
 	}
 
@@ -1077,7 +1237,7 @@ func (s *RateLimitService) handle429(ctx context.Context, account *Account, head
 	if result := calculateAnthropic429ResetTime(headers); result != nil {
 		if err := s.accountRepo.SetRateLimited(ctx, account.ID, result.resetAt); err != nil {
 			slog.Warn("rate_limit_set_failed", "account_id", account.ID, "error", err)
-			return
+			return false
 		}
 
 		// 更新 session window：优先使用 5h-reset 头精确计算，否则从 resetAt 反推
@@ -1091,7 +1251,7 @@ func (s *RateLimitService) handle429(ctx context.Context, account *Account, head
 		}
 
 		slog.Info("anthropic_account_rate_limited", "account_id", account.ID, "reset_at", result.resetAt, "reset_in", time.Until(result.resetAt).Truncate(time.Second))
-		return
+		return true
 	}
 
 	// 3. 尝试从响应头解析重置时间（Anthropic 聚合头，向后兼容）
@@ -1109,10 +1269,10 @@ func (s *RateLimitService) handle429(ctx context.Context, account *Account, head
 				resetTime := time.Unix(*resetAt, 0)
 				if err := s.accountRepo.SetRateLimited(ctx, account.ID, resetTime); err != nil {
 					slog.Warn("rate_limit_set_failed", "account_id", account.ID, "error", err)
-					return
+					return false
 				}
 				slog.Info("account_rate_limited", "account_id", account.ID, "platform", account.Platform, "reset_at", resetTime, "reset_in", time.Until(resetTime).Truncate(time.Second))
-				return
+				return true
 			}
 		case PlatformGemini, PlatformAntigravity:
 			// 尝试解析 Gemini 格式（用于其他平台）
@@ -1120,10 +1280,10 @@ func (s *RateLimitService) handle429(ctx context.Context, account *Account, head
 				resetTime := time.Unix(*resetAt, 0)
 				if err := s.accountRepo.SetRateLimited(ctx, account.ID, resetTime); err != nil {
 					slog.Warn("rate_limit_set_failed", "account_id", account.ID, "error", err)
-					return
+					return false
 				}
 				slog.Info("account_rate_limited", "account_id", account.ID, "platform", account.Platform, "reset_at", resetTime, "reset_in", time.Until(resetTime).Truncate(time.Second))
-				return
+				return true
 			}
 		}
 
@@ -1132,11 +1292,11 @@ func (s *RateLimitService) handle429(ctx context.Context, account *Account, head
 				"account_id", account.ID,
 				"platform", account.Platform,
 				"reason", "anthropic extra usage error without rate limit reset time")
-			return
+			return false
 		}
 
 		s.apply429FallbackRateLimit(ctx, account, "no_reset_time")
-		return
+		return false
 	}
 
 	// 解析Unix时间戳
@@ -1144,7 +1304,7 @@ func (s *RateLimitService) handle429(ctx context.Context, account *Account, head
 	if err != nil {
 		slog.Warn("rate_limit_reset_parse_failed", "reset_timestamp", resetTimestamp, "error", err)
 		s.apply429FallbackRateLimit(ctx, account, "reset_parse_failed")
-		return
+		return false
 	}
 
 	resetAt := time.Unix(ts, 0)
@@ -1152,7 +1312,7 @@ func (s *RateLimitService) handle429(ctx context.Context, account *Account, head
 	// 标记限流状态
 	if err := s.accountRepo.SetRateLimited(ctx, account.ID, resetAt); err != nil {
 		slog.Warn("rate_limit_set_failed", "account_id", account.ID, "error", err)
-		return
+		return false
 	}
 
 	// 根据重置时间反推5h窗口
@@ -1163,6 +1323,7 @@ func (s *RateLimitService) handle429(ctx context.Context, account *Account, head
 	}
 
 	slog.Info("account_rate_limited", "account_id", account.ID, "reset_at", resetAt)
+	return true
 }
 
 func isAnthropicExtraUsage429(responseBody []byte) bool {
@@ -1491,7 +1652,15 @@ func persistOpenAI429PlanType(ctx context.Context, repo AccountRepository, accou
 
 // handle529 处理529过载错误
 // 根据配置决定是否暂停账号调度及冷却时长
-func (s *RateLimitService) handle529(ctx context.Context, account *Account) {
+// handle529 marks the account overloaded for the configured cooldown and
+// returns true when an exact SetOverloaded write succeeded. The return is
+// consumed by the case 529 dispatch so handleAnthropicUpstreamError can
+// skip writing a parallel SetTempUnschedulable cooldown that would only
+// race the just-written overload_until (last-write-wins) — the per-account
+// counter and tier counter still advance so a repeat 529 storm still
+// escalates the ladder. A false return means the caller should fall back
+// to the ladder write (settings disabled or Redis/DB failure).
+func (s *RateLimitService) handle529(ctx context.Context, account *Account) bool {
 	var settings *OverloadCooldownSettings
 	if s.settingService != nil {
 		var err error
@@ -1512,7 +1681,7 @@ func (s *RateLimitService) handle529(ctx context.Context, account *Account) {
 
 	if !settings.Enabled {
 		slog.Info("account_529_ignored", "account_id", account.ID, "reason", "overload_cooldown_disabled")
-		return
+		return false
 	}
 
 	cooldownMinutes := settings.CooldownMinutes
@@ -1523,10 +1692,11 @@ func (s *RateLimitService) handle529(ctx context.Context, account *Account) {
 	until := time.Now().Add(time.Duration(cooldownMinutes) * time.Minute)
 	if err := s.accountRepo.SetOverloaded(ctx, account.ID, until); err != nil {
 		slog.Warn("overload_set_failed", "account_id", account.ID, "error", err)
-		return
+		return false
 	}
 
 	slog.Info("account_overloaded", "account_id", account.ID, "until", until)
+	return true
 }
 
 // UpdateSessionWindow 从成功响应更新5h窗口状态
@@ -1851,6 +2021,23 @@ func (s *RateLimitService) tryTempUnschedulable(ctx context.Context, account *Ac
 		if wasTempUnschedByStatusCode(reason, statusCode) {
 			slog.Info("401_escalated_to_error", "account_id", account.ID,
 				"reason", "previous temp-unschedulable was also 401")
+			return false
+		}
+	}
+	// 403 二次升级：account_disabled_auth_error / organization disabled
+	// 第二次命中表示上游已经判定账号死亡，6h cooldown 反复探测只会加重风控。
+	// 升级为 SetError（handle403 → handleAuthError），需要人工介入恢复。
+	// Antigravity 跳过：与 401 同理，由 applyErrorPolicy 自行控制。
+	if statusCode == http.StatusForbidden && account.Platform != PlatformAntigravity {
+		reason := account.TempUnschedulableReason
+		if reason == "" {
+			if dbAcc, err := s.accountRepo.GetByID(ctx, account.ID); err == nil && dbAcc != nil {
+				reason = dbAcc.TempUnschedulableReason
+			}
+		}
+		if wasTempUnschedByStatusCode(reason, statusCode) {
+			slog.Warn("403_escalated_to_error", "account_id", account.ID,
+				"reason", "previous temp-unschedulable was also 403; account likely disabled upstream")
 			return false
 		}
 	}

--- a/backend/internal/service/ratelimit_service_401_test.go
+++ b/backend/internal/service/ratelimit_service_401_test.go
@@ -21,6 +21,20 @@ type rateLimitAccountRepoStub struct {
 	lastCredentials        map[string]any
 	lastErrorMsg           string
 	lastTempReason         string
+
+	// PR #338 (P3): track exact-reset-time writes so tests can assert
+	// handle429 / handle529 ran the upstream-precise path before the
+	// ladder write got suppressed via skipCooldownWrite.
+	setRateLimitedCalls    int
+	setOverloadedCalls     int
+	lastRateLimitedResetAt time.Time
+	lastOverloadedUntil    time.Time
+
+	// PR #338 (P4): seed account state for the 403 second-hit escalation
+	// path. When set, GetByID returns an account whose
+	// TempUnschedulableReason holds the prior 403 TempUnschedState so
+	// wasTempUnschedByStatusCode(reason, 403) returns true.
+	tempReasonOnGet string
 }
 
 func (r *rateLimitAccountRepoStub) SetError(ctx context.Context, id int64, errorMsg string) error {
@@ -39,6 +53,25 @@ func (r *rateLimitAccountRepoStub) UpdateCredentials(ctx context.Context, id int
 	r.updateCredentialsCalls++
 	r.lastCredentials = cloneCredentials(credentials)
 	return nil
+}
+
+func (r *rateLimitAccountRepoStub) SetRateLimited(ctx context.Context, id int64, resetAt time.Time) error {
+	r.setRateLimitedCalls++
+	r.lastRateLimitedResetAt = resetAt
+	return nil
+}
+
+func (r *rateLimitAccountRepoStub) SetOverloaded(ctx context.Context, id int64, until time.Time) error {
+	r.setOverloadedCalls++
+	r.lastOverloadedUntil = until
+	return nil
+}
+
+func (r *rateLimitAccountRepoStub) GetByID(ctx context.Context, id int64) (*Account, error) {
+	if r.tempReasonOnGet == "" {
+		return nil, nil
+	}
+	return &Account{ID: id, TempUnschedulableReason: r.tempReasonOnGet}, nil
 }
 
 type tokenCacheInvalidatorRecorder struct {
@@ -84,6 +117,13 @@ type anthropicUpstreamErrorCounterCacheStub struct {
 	tierIncrementIDs []int64
 	tierTTLMinutes   []int
 	tierResetCalls   []int64
+
+	// Global "tier >= 1" escalation counter (PR #338 follow-up to PR #337).
+	// Increments are recorded so tests can assert that tier escalations
+	// emit the ops_alert_evaluator metric signal. Get returns the running
+	// total of the escalations slice length so reads stay consistent with
+	// writes without a real Redis backend.
+	escalationTTLMinutes []int
 }
 
 func (s *anthropicUpstreamErrorCounterCacheStub) IncrementAnthropicUpstreamErrorCount(_ context.Context, accountID int64, windowMinutes int) (int64, error) {
@@ -119,6 +159,15 @@ func (s *anthropicUpstreamErrorCounterCacheStub) IncrementAnthropicCooldownTier(
 func (s *anthropicUpstreamErrorCounterCacheStub) ResetAnthropicCooldownTier(_ context.Context, accountID int64) error {
 	s.tierResetCalls = append(s.tierResetCalls, accountID)
 	return nil
+}
+
+func (s *anthropicUpstreamErrorCounterCacheStub) IncrementAnthropicCooldownTierEscalations(_ context.Context, ttlMinutes int) (int64, error) {
+	s.escalationTTLMinutes = append(s.escalationTTLMinutes, ttlMinutes)
+	return int64(len(s.escalationTTLMinutes)), nil
+}
+
+func (s *anthropicUpstreamErrorCounterCacheStub) GetAnthropicCooldownTierEscalations(_ context.Context) (int64, error) {
+	return int64(len(s.escalationTTLMinutes)), nil
 }
 
 func (r *tokenCacheInvalidatorRecorder) InvalidateToken(ctx context.Context, account *Account) error {

--- a/backend/internal/service/ratelimit_service_403_test.go
+++ b/backend/internal/service/ratelimit_service_403_test.go
@@ -89,7 +89,7 @@ func TestRateLimitService_HandleUpstreamError_Anthropic403ThresholdTempUnschedul
 	require.Equal(t, 0, repo.setErrorCalls)
 	require.Equal(t, 1, repo.tempCalls)
 	require.Equal(t, []int64{401, 401, 401}, counter.incrementIDs)
-	require.Equal(t, []int{anthropicUpstreamErrorWindowMinutes, anthropicUpstreamErrorWindowMinutes, anthropicUpstreamErrorWindowMinutes}, counter.windowMinutes)
+	require.Equal(t, []int{anthropicUpstreamErrorWindowMinutesDefault, anthropicUpstreamErrorWindowMinutesDefault, anthropicUpstreamErrorWindowMinutesDefault}, counter.windowMinutes)
 
 	var state TempUnschedState
 	require.NoError(t, json.Unmarshal([]byte(repo.lastTempReason), &state))

--- a/backend/internal/service/ratelimit_service_anthropic_consolidation_test.go
+++ b/backend/internal/service/ratelimit_service_anthropic_consolidation_test.go
@@ -1,0 +1,439 @@
+//go:build unit
+
+package service
+
+import (
+	"context"
+	"encoding/json"
+	"net/http"
+	"strconv"
+	"testing"
+	"time"
+
+	"github.com/Wei-Shaw/sub2api/internal/config"
+	"github.com/stretchr/testify/require"
+)
+
+// PR #338 (consolidation): tests covering the four behavioral changes layered
+// on top of PR #337's cooldown ladder.
+//
+// P3: 429 with an upstream-provided reset header (anthropic-ratelimit-unified-
+//     reset) must SetRateLimited precisely AND suppress the ladder's
+//     SetTempUnschedulable so last-write-wins doesn't replace the upstream-
+//     authoritative reset time with a less-precise local cooldown. The
+//     counters still advance.
+// P3: 529 with a successful SetOverloaded write must likewise suppress the
+//     ladder cooldown write.
+// P4: A second 403 hit whose prior reason was also a 403 temp-unschedulable
+//     must escalate (tryTempUnschedulable returns false) so handle403's
+//     downstream Anthropic path runs without writing yet another 6h cooldown.
+// P4: A 403 body matching tlsFingerprintFailureKeywords must apply a 30s
+//     cooldown (not 6h) so an operator can re-capture the CLI TLS profile
+//     before the next attempt — the long cooldown would mask a basic-
+//     infrastructure failure as an account-level one.
+// P5: cfg.RateLimit.AnthropicErrorThreshold lifts the 3/3 short-window
+//     threshold without requiring a recompile (motivation: single-account /
+//     small-pool deployments where Sonnet↔Opus burst jitter trips 3/3 too
+//     easily).
+// P2: tier >= 1 cooldown trips emit the global escalation counter so
+//     ops_alert_evaluator can drive a "persistent failure rising" alert
+//     without scanning every per-account key.
+
+// --- P3: 429 retry-after precision suppresses ladder cooldown -----------------
+
+func TestRateLimitService_HandleUpstreamError_Anthropic429PreciseResetSuppressesLadder(t *testing.T) {
+	repo := &rateLimitAccountRepoStub{}
+	counter := &anthropicUpstreamErrorCounterCacheStub{
+		counts:     []int64{1, 2, 3},
+		tierCounts: []int64{1},
+	}
+	service := NewRateLimitService(repo, nil, &config.Config{}, nil, nil)
+	service.SetAnthropicUpstreamErrorCounterCache(counter)
+
+	account := &Account{
+		ID:       701,
+		Platform: PlatformAnthropic,
+		Type:     AccountTypeOAuth,
+	}
+
+	resetAt := time.Now().Add(45 * time.Minute).Unix()
+	headers := http.Header{}
+	headers.Set("anthropic-ratelimit-unified-reset", strconv.FormatInt(resetAt, 10))
+
+	for i := 0; i < 3; i++ {
+		shouldDisable := service.HandleUpstreamError(
+			context.Background(),
+			account,
+			http.StatusTooManyRequests,
+			headers,
+			[]byte(`{"error":{"type":"rate_limit_error","message":"limit reached"}}`),
+		)
+		// First two hits: counter < threshold, ladder returns false.
+		// Third hit: counter == threshold, ladder runs but the SetRateLimited
+		// already landed first, so handleAnthropicUpstreamErrorWithOptions
+		// receives skipCooldownWrite=true and still returns true.
+		if i < 2 {
+			require.False(t, shouldDisable, "hit %d should not have disabled", i+1)
+		} else {
+			require.True(t, shouldDisable, "third hit should have returned true")
+		}
+	}
+
+	require.Equal(t, 3, repo.setRateLimitedCalls, "every 429 with precise reset hits SetRateLimited")
+	require.Equal(t, 0, repo.tempCalls,
+		"ladder must NOT write SetTempUnschedulable when SetRateLimited landed (last-write-wins protection)")
+	require.Equal(t, []int64{701, 701, 701}, counter.incrementIDs,
+		"3/3 short-window counter advanced on every 429")
+}
+
+// 429 without an upstream reset header falls back to handle429's
+// apply429FallbackRateLimit; that path is NOT considered an "authoritative
+// upstream cooldown" so the ladder cooldown write SHOULD still happen
+// (otherwise we lose the only signal that the account is failing).
+func TestRateLimitService_HandleUpstreamError_Anthropic429NoResetHeaderStillLadders(t *testing.T) {
+	repo := &rateLimitAccountRepoStub{}
+	counter := &anthropicUpstreamErrorCounterCacheStub{
+		counts:     []int64{1, 2, 3},
+		tierCounts: []int64{1},
+	}
+	service := NewRateLimitService(repo, nil, &config.Config{}, nil, nil)
+	service.SetAnthropicUpstreamErrorCounterCache(counter)
+
+	account := &Account{
+		ID:       702,
+		Platform: PlatformAnthropic,
+		Type:     AccountTypeOAuth,
+	}
+
+	for i := 0; i < 3; i++ {
+		service.HandleUpstreamError(
+			context.Background(),
+			account,
+			http.StatusTooManyRequests,
+			http.Header{}, // no reset header
+			[]byte(`{"error":{"message":"some other 429 without reset hint"}}`),
+		)
+	}
+
+	require.Equal(t, 1, repo.tempCalls,
+		"third 429 without reset header MUST land the ladder cooldown — that's the only signal of a failing account")
+}
+
+// --- P3: 529 successful overload suppresses ladder cooldown -------------------
+
+func TestRateLimitService_HandleUpstreamError_Anthropic529SetOverloadedSuppressesLadder(t *testing.T) {
+	repo := &rateLimitAccountRepoStub{}
+	counter := &anthropicUpstreamErrorCounterCacheStub{
+		counts:     []int64{1, 2, 3},
+		tierCounts: []int64{1},
+	}
+	service := NewRateLimitService(repo, nil, &config.Config{
+		RateLimit: config.RateLimitConfig{
+			OverloadCooldownMinutes: 10,
+		},
+	}, nil, nil)
+	service.SetAnthropicUpstreamErrorCounterCache(counter)
+
+	account := &Account{
+		ID:       703,
+		Platform: PlatformAnthropic,
+		Type:     AccountTypeOAuth,
+	}
+
+	for i := 0; i < 3; i++ {
+		service.HandleUpstreamError(
+			context.Background(),
+			account,
+			529,
+			http.Header{},
+			[]byte(`{"error":{"type":"overloaded_error","message":"upstream overloaded"}}`),
+		)
+	}
+
+	require.Equal(t, 3, repo.setOverloadedCalls, "every 529 wrote SetOverloaded")
+	require.Equal(t, 0, repo.tempCalls,
+		"ladder must NOT write SetTempUnschedulable when SetOverloaded landed")
+}
+
+// --- P4: 403 second hit escalates ---------------------------------------------
+
+func TestRateLimitService_TryTempUnschedulable_403SecondHitEscalates(t *testing.T) {
+	prior := &TempUnschedState{
+		UntilUnix:       time.Now().Add(6 * time.Hour).Unix(),
+		TriggeredAtUnix: time.Now().Add(-5 * time.Minute).Unix(),
+		StatusCode:      http.StatusForbidden,
+		MatchedKeyword:  "account_disabled_auth_error",
+	}
+	priorJSON, err := json.Marshal(prior)
+	require.NoError(t, err)
+
+	repo := &rateLimitAccountRepoStub{
+		tempReasonOnGet: string(priorJSON),
+	}
+	service := NewRateLimitService(repo, nil, &config.Config{}, nil, nil)
+
+	account := &Account{
+		ID:                      810,
+		Platform:                PlatformAnthropic,
+		Type:                    AccountTypeOAuth,
+		TempUnschedulableReason: string(priorJSON),
+		Credentials: map[string]any{
+			"temp_unschedulable_enabled": true,
+			"temp_unschedulable_rules": []map[string]any{
+				{
+					"error_code":       403,
+					"keywords":         []string{"account_disabled_auth_error"},
+					"duration_minutes": 360,
+				},
+			},
+		},
+	}
+
+	body := []byte(`{"error":{"type":"forbidden","message":"account_disabled_auth_error"}}`)
+	matched := service.HandleTempUnschedulable(context.Background(), account, http.StatusForbidden, body)
+	require.False(t, matched,
+		"second 403 with same status_code on prior temp-unschedulable must NOT re-arm the 6h cooldown")
+}
+
+// --- P4: TLS fingerprint failure path -----------------------------------------
+
+func TestRateLimitService_HandleUpstreamError_Anthropic403TLSFingerprintShortCooldown(t *testing.T) {
+	repo := &rateLimitAccountRepoStub{}
+	counter := &anthropicUpstreamErrorCounterCacheStub{}
+	service := NewRateLimitService(repo, nil, &config.Config{}, nil, nil)
+	service.SetAnthropicUpstreamErrorCounterCache(counter)
+
+	account := &Account{
+		ID:       820,
+		Platform: PlatformAnthropic,
+		Type:     AccountTypeOAuth,
+	}
+
+	body := []byte(`{"error":{"message":"forbidden: JA3 fingerprint does not match expected Claude CLI shape"}}`)
+	shouldDisable := service.HandleUpstreamError(
+		context.Background(),
+		account,
+		http.StatusForbidden,
+		http.Header{},
+		body,
+	)
+
+	require.True(t, shouldDisable)
+	require.Equal(t, 1, repo.tempCalls,
+		"TLS fingerprint failure should write a SetTempUnschedulable cooldown immediately")
+
+	var state TempUnschedState
+	require.NoError(t, json.Unmarshal([]byte(repo.lastTempReason), &state))
+	require.Equal(t, http.StatusForbidden, state.StatusCode)
+	require.Equal(t, "tls_fingerprint_failure", state.MatchedKeyword)
+
+	cooldown := time.Until(time.Unix(state.UntilUnix, 0))
+	require.InDelta(t, tlsFingerprintFailureCooldown, cooldown, float64(2*time.Second),
+		"TLS fingerprint failure must use the short 30s cooldown, NOT the 6h account-disabled cooldown")
+	require.Zero(t, len(counter.incrementIDs),
+		"TLS fingerprint path must NOT feed the 3/3 short-window counter (the account is fine; infra is not)")
+}
+
+// --- P5: cfg.AnthropicErrorThreshold lifts the 3/3 bar -----------------------
+
+func TestRateLimitService_HandleUpstreamError_AnthropicErrorThresholdConfigurable(t *testing.T) {
+	repo := &rateLimitAccountRepoStub{}
+	counter := &anthropicUpstreamErrorCounterCacheStub{
+		counts:     []int64{1, 2, 3, 4, 5},
+		tierCounts: []int64{1},
+	}
+	service := NewRateLimitService(repo, nil, &config.Config{
+		RateLimit: config.RateLimitConfig{
+			AnthropicErrorThreshold:     5,
+			AnthropicErrorWindowMinutes: 2,
+		},
+	}, nil, nil)
+	service.SetAnthropicUpstreamErrorCounterCache(counter)
+
+	account := &Account{
+		ID:       930,
+		Platform: PlatformAnthropic,
+		Type:     AccountTypeOAuth,
+	}
+
+	body := []byte(`{"error":{"message":"upstream pool jitter"}}`)
+	for i := 0; i < 4; i++ {
+		shouldDisable := service.HandleUpstreamError(
+			context.Background(),
+			account,
+			http.StatusBadGateway,
+			http.Header{},
+			body,
+		)
+		require.False(t, shouldDisable,
+			"hit %d below threshold=5 must not have disabled", i+1)
+	}
+	require.Equal(t, 0, repo.tempCalls)
+
+	shouldDisable := service.HandleUpstreamError(
+		context.Background(),
+		account,
+		http.StatusBadGateway,
+		http.Header{},
+		body,
+	)
+	require.True(t, shouldDisable, "fifth hit must trip the configured threshold=5")
+	require.Equal(t, 1, repo.tempCalls)
+
+	require.Equal(t, []int{2, 2, 2, 2, 2}, counter.windowMinutes,
+		"counter must call IncrementAnthropicUpstreamErrorCount with the configured window_minutes=2")
+}
+
+func TestRateLimitService_HandleUpstreamError_AnthropicErrorThresholdDefaultsWhenUnset(t *testing.T) {
+	repo := &rateLimitAccountRepoStub{}
+	counter := &anthropicUpstreamErrorCounterCacheStub{
+		counts:     []int64{1, 2, 3},
+		tierCounts: []int64{1},
+	}
+	service := NewRateLimitService(repo, nil, &config.Config{}, nil, nil) // cfg unset
+	service.SetAnthropicUpstreamErrorCounterCache(counter)
+
+	account := &Account{
+		ID:       931,
+		Platform: PlatformAnthropic,
+		Type:     AccountTypeOAuth,
+	}
+
+	for i := 0; i < 3; i++ {
+		service.HandleUpstreamError(
+			context.Background(),
+			account,
+			http.StatusBadGateway,
+			http.Header{},
+			[]byte(`{"error":{"message":"jitter"}}`),
+		)
+	}
+	require.Equal(t, 1, repo.tempCalls,
+		"unset config must fall back to the built-in default threshold=3")
+}
+
+// --- P2: tier >= 1 emits the global escalation counter signal ---------------
+
+func TestRateLimitService_HandleUpstreamError_AnthropicTier0DoesNotEmitEscalation(t *testing.T) {
+	repo := &rateLimitAccountRepoStub{}
+	counter := &anthropicUpstreamErrorCounterCacheStub{
+		counts:     []int64{3},
+		tierCounts: []int64{1}, // first trip → tier 0 (30s, transient jitter)
+	}
+	service := NewRateLimitService(repo, nil, &config.Config{}, nil, nil)
+	service.SetAnthropicUpstreamErrorCounterCache(counter)
+
+	account := &Account{
+		ID:       1040,
+		Platform: PlatformAnthropic,
+		Type:     AccountTypeOAuth,
+	}
+
+	service.HandleUpstreamError(
+		context.Background(),
+		account,
+		http.StatusBadGateway,
+		http.Header{},
+		[]byte(`{"error":{"message":"transient jitter"}}`),
+	)
+
+	require.Zero(t, len(counter.escalationTTLMinutes),
+		"tier=0 (transient jitter) must NOT increment the global escalation counter")
+}
+
+func TestRateLimitService_HandleUpstreamError_AnthropicTier1EmitsEscalation(t *testing.T) {
+	repo := &rateLimitAccountRepoStub{}
+	counter := &anthropicUpstreamErrorCounterCacheStub{
+		counts:     []int64{3},
+		tierCounts: []int64{2}, // second trip → tier 1 (2 min, real problem starting)
+	}
+	service := NewRateLimitService(repo, nil, &config.Config{}, nil, nil)
+	service.SetAnthropicUpstreamErrorCounterCache(counter)
+
+	account := &Account{
+		ID:       1041,
+		Platform: PlatformAnthropic,
+		Type:     AccountTypeOAuth,
+	}
+
+	service.HandleUpstreamError(
+		context.Background(),
+		account,
+		http.StatusBadGateway,
+		http.Header{},
+		[]byte(`{"error":{"message":"persistent failure"}}`),
+	)
+
+	require.Equal(t, 1, len(counter.escalationTTLMinutes),
+		"tier=1 must increment the global escalation counter exactly once")
+	require.Equal(t, anthropicCooldownTierEscalationsWindowMinutes, counter.escalationTTLMinutes[0],
+		"escalation TTL must match the documented 60-min ops window")
+}
+
+// Sanity: the stub-backed Get returns the running total so an evaluator-style
+// reader sees writes in the same in-process test.
+func TestAnthropicUpstreamErrorCounterCacheStub_EscalationsReadConsistentWithWrites(t *testing.T) {
+	counter := &anthropicUpstreamErrorCounterCacheStub{}
+	ctx := context.Background()
+
+	got, err := counter.GetAnthropicCooldownTierEscalations(ctx)
+	require.NoError(t, err)
+	require.Equal(t, int64(0), got)
+
+	_, err = counter.IncrementAnthropicCooldownTierEscalations(ctx, 60)
+	require.NoError(t, err)
+	_, err = counter.IncrementAnthropicCooldownTierEscalations(ctx, 60)
+	require.NoError(t, err)
+
+	got, err = counter.GetAnthropicCooldownTierEscalations(ctx)
+	require.NoError(t, err)
+	require.Equal(t, int64(2), got)
+}
+
+// End-to-end shape: the evaluator's anthropic_cooldown_tier_escalation_count
+// metric path reads exactly what handleAnthropicUpstreamErrorWithOptions
+// wrote through the stub-backed cache, so a sustained tier>=1 condition
+// drives the rule metric to the same number ops dashboards will display.
+func TestOpsAlertEvaluator_AnthropicCooldownTierEscalationCount_ReflectsLadderWrites(t *testing.T) {
+	repo := &rateLimitAccountRepoStub{}
+	counter := &anthropicUpstreamErrorCounterCacheStub{
+		counts:     []int64{3, 3},
+		tierCounts: []int64{2, 3}, // both trips land at tier>=1
+	}
+	service := NewRateLimitService(repo, nil, &config.Config{}, nil, nil)
+	service.SetAnthropicUpstreamErrorCounterCache(counter)
+
+	account := &Account{
+		ID:       1050,
+		Platform: PlatformAnthropic,
+		Type:     AccountTypeOAuth,
+	}
+
+	for i := 0; i < 2; i++ {
+		service.HandleUpstreamError(
+			context.Background(),
+			account,
+			http.StatusBadGateway,
+			http.Header{},
+			[]byte(`{"error":{"message":"persistent failure"}}`),
+		)
+	}
+
+	evaluator := &OpsAlertEvaluatorService{}
+	evaluator.SetAnthropicUpstreamErrorCounterCache(counter)
+
+	rule := &OpsAlertRule{MetricType: "anthropic_cooldown_tier_escalation_count"}
+	value, ok := evaluator.computeRuleMetric(
+		context.Background(),
+		rule,
+		nil,
+		time.Now().UTC().Add(-time.Hour),
+		time.Now().UTC(),
+		"",
+		nil,
+	)
+	require.True(t, ok, "metric must be reportable when the cache is wired")
+	require.InDelta(t, 2.0, value, 0.0001,
+		"two tier>=1 trips must surface as escalation_count=2 to ops alerts")
+}
+

--- a/backend/internal/service/ratelimit_service_anthropic_consolidation_test.go
+++ b/backend/internal/service/ratelimit_service_anthropic_consolidation_test.go
@@ -234,6 +234,58 @@ func TestRateLimitService_HandleUpstreamError_Anthropic403TLSFingerprintShortCoo
 		"TLS fingerprint path must NOT feed the 3/3 short-window counter (the account is fine; infra is not)")
 }
 
+// Production OAuth accounts ship with the baseline credentials wired —
+// temp_unschedulable_enabled=true + a 403 account_disabled_auth_error rule
+// (anthropic-oauth-stability-baselines-tiered.json shared_baseline.credentials).
+// A 403 body that contains a TLS-fingerprint keyword but NOT
+// account_disabled_auth_error MUST still reach the handle403 TLS branch and
+// land the short 30s cooldown — the JSON 403 rule MUST NOT eat the request
+// just because the rule's error_code matches. Regression coverage for the
+// "production credentials path" vs the simpler bare-account test above.
+func TestRateLimitService_HandleUpstreamError_Anthropic403TLSFingerprintNotEatenBy403Rule(t *testing.T) {
+	repo := &rateLimitAccountRepoStub{}
+	counter := &anthropicUpstreamErrorCounterCacheStub{}
+	service := NewRateLimitService(repo, nil, &config.Config{}, nil, nil)
+	service.SetAnthropicUpstreamErrorCounterCache(counter)
+
+	account := &Account{
+		ID:       821,
+		Platform: PlatformAnthropic,
+		Type:     AccountTypeOAuth,
+		Credentials: map[string]any{
+			"temp_unschedulable_enabled": true,
+			"temp_unschedulable_rules": []map[string]any{
+				{
+					"error_code":       403,
+					"keywords":         []string{"account_disabled_auth_error", "organization disabled"},
+					"duration_minutes": 360,
+				},
+			},
+		},
+	}
+
+	body := []byte(`{"error":{"message":"forbidden: JA4 fingerprint mismatch on this client"}}`)
+	shouldDisable := service.HandleUpstreamError(
+		context.Background(),
+		account,
+		http.StatusForbidden,
+		http.Header{},
+		body,
+	)
+	require.True(t, shouldDisable)
+	require.Equal(t, 1, repo.tempCalls,
+		"TLS fingerprint failure must still write SetTempUnschedulable even with the 403 rule armed")
+
+	var state TempUnschedState
+	require.NoError(t, json.Unmarshal([]byte(repo.lastTempReason), &state))
+	require.Equal(t, "tls_fingerprint_failure", state.MatchedKeyword,
+		"reason must record the TLS path, NOT the 6h account_disabled_auth_error rule")
+
+	cooldown := time.Until(time.Unix(state.UntilUnix, 0))
+	require.InDelta(t, tlsFingerprintFailureCooldown, cooldown, float64(2*time.Second),
+		"production credentials path must still apply 30s cooldown, not 6h")
+}
+
 // --- P5: cfg.AnthropicErrorThreshold lifts the 3/3 bar -----------------------
 
 func TestRateLimitService_HandleUpstreamError_AnthropicErrorThresholdConfigurable(t *testing.T) {

--- a/backend/internal/service/wire.go
+++ b/backend/internal/service/wire.go
@@ -274,14 +274,22 @@ func ProvideOpsAggregationService(
 }
 
 // ProvideOpsAlertEvaluatorService creates and starts OpsAlertEvaluatorService.
+// The anthropic upstream-error counter cache is injected so the
+// anthropic_cooldown_tier_escalation_count metric path reads through the
+// same interface the ratelimit writer side uses (single Redis-backed
+// counter behind one canonical key). Without this injection the metric
+// would silently work via a redundant raw redisClient.Get path and the
+// cache interface would be dead code in production.
 func ProvideOpsAlertEvaluatorService(
 	opsService *OpsService,
 	opsRepo OpsRepository,
 	emailService *EmailService,
 	redisClient *redis.Client,
 	cfg *config.Config,
+	anthropicUpstreamErrorCounterCache AnthropicUpstreamErrorCounterCache,
 ) *OpsAlertEvaluatorService {
 	svc := NewOpsAlertEvaluatorService(opsService, opsRepo, emailService, redisClient, cfg)
+	svc.SetAnthropicUpstreamErrorCounterCache(anthropicUpstreamErrorCounterCache)
 	svc.Start()
 	return svc
 }

--- a/deploy/aws/stage0/anthropic-oauth-stability-baselines-tiered.json
+++ b/deploy/aws/stage0/anthropic-oauth-stability-baselines-tiered.json
@@ -6,6 +6,9 @@
     "rate_multiplier_fixed": 1.0,
     "usage_model": "Claude Code human-paced work: usage budget and session length are constrained separately; lower tiers are scheduled first but reach their local limits earlier.",
     "tier_order": ["l1", "l2", "l3", "l4", "l5"],
+    "escalation_model": "code-owned",
+    "cooldown_ladder_seconds": [30, 120, 600],
+    "cooldown_tier_ttl_minutes": 30,
     "rounding": {
       "integer_fields": "explicit",
       "float_fields": "explicit"
@@ -25,40 +28,13 @@
       "temp_unschedulable_enabled": true,
       "temp_unschedulable_rules": [
         {
-          "error_code": 429,
-          "keywords": [
-            "rate limit",
-            "too many requests"
-          ],
-          "duration_minutes": 30,
-          "description": "触发限流 - 暂停 30 分钟"
-        },
-        {
-          "error_code": 529,
-          "keywords": [
-            "overloaded",
-            "capacity"
-          ],
-          "duration_minutes": 15,
-          "description": "上游过载 - 暂停 15 分钟"
-        },
-        {
-          "error_code": 401,
-          "keywords": [
-            "invalid_token",
-            "expired"
-          ],
-          "duration_minutes": 30,
-          "description": "凭据异常 - 暂停 30 分钟"
-        },
-        {
           "error_code": 403,
           "keywords": [
             "account_disabled_auth_error",
             "organization disabled"
           ],
           "duration_minutes": 360,
-          "description": "账号或组织禁用 - 暂停 6 小时"
+          "description": "账号或组织禁用 - 暂停 6 小时（二次命中由 handle403 升级为 SetError）"
         }
       ]
     },

--- a/deploy/config.example.yaml
+++ b/deploy/config.example.yaml
@@ -975,6 +975,21 @@ rate_limit:
   # Cooldown time (in minutes) when upstream returns 529 (overloaded)
   # 上游返回 529（过载）时的冷却时间（分钟）
   overload_cooldown_minutes: 10
+  # Cooldown time (in minutes) when an OAuth account hits 401 (gives the
+  # background refresher a window to renew the token before the next attempt)
+  # OAuth 账号 401 临时不可调度冷却时间（分钟），给后台刷新服务恢复 token 的窗口
+  oauth_401_cooldown_minutes: 10
+  # Threshold for the Anthropic short-window upstream-error counter (3/3 by
+  # default). Lift to 5–7 for single-account / small-pool deployments where
+  # Sonnet↔Opus burst jitter trips the default too easily. <=0 falls back to
+  # the built-in default (3).
+  # Anthropic 短窗口错误阈值（默认 3 次/窗口触发 cooldown ladder）。单账号或小
+  # 拼车场景可调到 5–7 减少 Sonnet↔Opus 切换 burst 时的误触；<=0 回退到内置默认 3。
+  anthropic_error_threshold: 3
+  # Window length (in minutes) for the Anthropic error counter above. <=0
+  # falls back to the built-in default (1).
+  # Anthropic 错误计数器短窗口长度（分钟），<=0 回退到内置默认 1。
+  anthropic_error_window_minutes: 1
 
 # =============================================================================
 # Pricing Data Source (Optional)

--- a/scripts/preflight.sh
+++ b/scripts/preflight.sh
@@ -401,6 +401,25 @@ else
     echo "  ok: all gateway TK sentinels intact"
 fi
 
+# ---- sub2api: anthropic baseline ↔ ratelimit constants sync -----------------
+# Anthropic OAuth tier baseline JSON documents the cooldown ladder
+# (30s / 2min / 10min) and 30-min tier TTL that the Go runtime owns. If the
+# JSON drifts from the Go constants, ops dashboards mislead operators about
+# what the production ratelimit_service.go actually does. See PR #337 +
+# scripts/sentinels/check-anthropic-baseline-sync.py header for the
+# 2026-05-21 incident that motivated this guard.
+echo ""
+echo "=== sub2api: anthropic baseline sync ==="
+if ! command -v python3 >/dev/null 2>&1; then
+    echo "  FAIL: python3 not on PATH (required for anthropic baseline sync check)"
+    errors=$((errors + 1))
+elif ! python3 ./scripts/sentinels/check-anthropic-baseline-sync.py --quiet; then
+    # check-anthropic-baseline-sync.py already printed the actionable failure.
+    errors=$((errors + 1))
+else
+    echo "  ok: anthropic baseline JSON in sync with ratelimit_service.go constants"
+fi
+
 # ---- sub2api: sentinel registry update gate ---------------------------------
 # Existing sentinel checks prove current guarded literals still exist. This gate
 # proves PRs that modify guarded/hotspot files also update the matching registry,

--- a/scripts/sentinels/check-anthropic-baseline-sync.py
+++ b/scripts/sentinels/check-anthropic-baseline-sync.py
@@ -1,0 +1,220 @@
+#!/usr/bin/env python3
+"""
+check-anthropic-baseline-sync.py — verify that the Anthropic OAuth tier
+baseline JSON's documented cooldown ladder stays in sync with the live
+constants in `backend/internal/service/ratelimit_service.go`.
+
+The cooldown ladder (30s / 2min / 10min) is owned by Go code — JSON
+documents the same values for ops audit so deploy reviewers can read the
+baseline without grepping the codebase. The two MUST stay in lockstep,
+otherwise the JSON becomes misleading documentation.
+
+Reads:
+  - deploy/aws/stage0/anthropic-oauth-stability-baselines-tiered.json
+      policy.cooldown_ladder_seconds  (e.g. [30, 120, 600])
+      policy.cooldown_tier_ttl_minutes (e.g. 30)
+  - backend/internal/service/ratelimit_service.go
+      anthropicCooldownTierLadder    (var [] time.Duration)
+      anthropicCooldownTierTTLMinutes (const int)
+
+Exit codes:
+  0  — JSON and Go constants agree.
+  1  — drift detected (values mismatch).
+  2  — file missing, parse failure, or required symbol not found.
+
+Usage:
+  python3 scripts/sentinels/check-anthropic-baseline-sync.py
+  python3 scripts/sentinels/check-anthropic-baseline-sync.py --quiet  # only print on failure
+  python3 scripts/sentinels/check-anthropic-baseline-sync.py --json   # machine-readable
+
+Why this exists:
+  Before this guard, the JSON's `temp_unschedulable_rules` carried 429/529
+  cooldown durations that conflicted with the Go ladder (PR #337,
+  2026-05-21). Operators reading the JSON saw "30 min cooldown on 429"
+  but production actually applied 30s/2min/10min via the ladder. The
+  rules were removed; the ladder values were promoted into the JSON
+  policy block so the JSON is authoritative for ops dashboards. This
+  script keeps the two ends honest.
+"""
+from __future__ import annotations
+
+import argparse
+import json
+import re
+import sys
+from pathlib import Path
+
+REPO_ROOT = Path(__file__).resolve().parent.parent.parent
+BASELINE_JSON = (
+    REPO_ROOT
+    / "deploy"
+    / "aws"
+    / "stage0"
+    / "anthropic-oauth-stability-baselines-tiered.json"
+)
+RATELIMIT_GO = REPO_ROOT / "backend" / "internal" / "service" / "ratelimit_service.go"
+
+
+def fatal(msg: str, code: int = 2) -> "None":
+    print(f"FATAL: {msg}", file=sys.stderr)
+    sys.exit(code)
+
+
+def load_json_policy() -> dict:
+    if not BASELINE_JSON.is_file():
+        fatal(f"baseline file not found: {BASELINE_JSON.relative_to(REPO_ROOT)}")
+    try:
+        with BASELINE_JSON.open("r", encoding="utf-8") as f:
+            data = json.load(f)
+    except json.JSONDecodeError as exc:
+        fatal(f"baseline JSON parse error: {exc}")
+    policy = data.get("policy")
+    if not isinstance(policy, dict):
+        fatal("baseline JSON missing 'policy' object")
+    return policy
+
+
+_LADDER_RE = re.compile(
+    r"anthropicCooldownTierLadder\s*=\s*\[\]time\.Duration\s*\{([^}]*)\}",
+    re.MULTILINE | re.DOTALL,
+)
+_TTL_RE = re.compile(
+    r"anthropicCooldownTierTTLMinutes\s*=\s*(\d+)",
+    re.MULTILINE,
+)
+_DURATION_TOKEN_RE = re.compile(
+    r"(\d+)\s*\*\s*time\.(Second|Minute|Hour)|(\d+)\s*time\.(Second|Minute|Hour)",
+)
+
+
+def _token_to_seconds(value: int, unit: str) -> int:
+    if unit == "Second":
+        return value
+    if unit == "Minute":
+        return value * 60
+    if unit == "Hour":
+        return value * 3600
+    fatal(f"unsupported time unit in ladder: {unit}")
+    return 0  # unreachable
+
+
+def parse_go_constants() -> tuple[list[int], int]:
+    if not RATELIMIT_GO.is_file():
+        fatal(
+            f"ratelimit_service.go not found: {RATELIMIT_GO.relative_to(REPO_ROOT)}"
+        )
+    try:
+        text = RATELIMIT_GO.read_text(encoding="utf-8")
+    except OSError as exc:
+        fatal(f"cannot read ratelimit_service.go: {exc}")
+
+    ladder_match = _LADDER_RE.search(text)
+    if not ladder_match:
+        fatal("anthropicCooldownTierLadder declaration not found")
+    inner = ladder_match.group(1)
+    seconds: list[int] = []
+    for m in _DURATION_TOKEN_RE.finditer(inner):
+        if m.group(1) is not None:
+            value = int(m.group(1))
+            unit = m.group(2)
+        else:
+            value = int(m.group(3))
+            unit = m.group(4)
+        seconds.append(_token_to_seconds(value, unit))
+    if not seconds:
+        fatal("anthropicCooldownTierLadder body parsed empty")
+
+    ttl_match = _TTL_RE.search(text)
+    if not ttl_match:
+        fatal("anthropicCooldownTierTTLMinutes constant not found")
+    ttl_minutes = int(ttl_match.group(1))
+
+    return seconds, ttl_minutes
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument(
+        "--quiet",
+        action="store_true",
+        help="suppress success output; only print on failure",
+    )
+    parser.add_argument(
+        "--json",
+        action="store_true",
+        help="emit machine-readable JSON report",
+    )
+    args = parser.parse_args()
+
+    policy = load_json_policy()
+    json_ladder = policy.get("cooldown_ladder_seconds")
+    json_ttl = policy.get("cooldown_tier_ttl_minutes")
+    if not isinstance(json_ladder, list) or not all(
+        isinstance(v, int) for v in json_ladder
+    ):
+        fatal("policy.cooldown_ladder_seconds must be a JSON array of ints")
+    if not isinstance(json_ttl, int):
+        fatal("policy.cooldown_tier_ttl_minutes must be an int")
+
+    go_ladder, go_ttl = parse_go_constants()
+
+    ladder_ok = list(json_ladder) == go_ladder
+    ttl_ok = json_ttl == go_ttl
+    ok = ladder_ok and ttl_ok
+
+    if args.json:
+        print(
+            json.dumps(
+                {
+                    "ok": ok,
+                    "ladder": {
+                        "json": json_ladder,
+                        "go": go_ladder,
+                        "ok": ladder_ok,
+                    },
+                    "ttl_minutes": {
+                        "json": json_ttl,
+                        "go": go_ttl,
+                        "ok": ttl_ok,
+                    },
+                },
+                indent=2,
+                sort_keys=True,
+            )
+        )
+        return 0 if ok else 1
+
+    if ok:
+        if not args.quiet:
+            print(
+                "OK: anthropic-oauth-stability-baselines-tiered.json policy "
+                f"in sync with ratelimit_service.go "
+                f"(ladder={go_ladder}s, ttl={go_ttl}min)"
+            )
+        return 0
+
+    print(
+        "FAIL: anthropic-oauth-stability-baselines-tiered.json policy DRIFT vs "
+        "backend/internal/service/ratelimit_service.go",
+        file=sys.stderr,
+    )
+    if not ladder_ok:
+        print(
+            f"  cooldown_ladder_seconds: JSON={json_ladder} vs Go={go_ladder}",
+            file=sys.stderr,
+        )
+    if not ttl_ok:
+        print(
+            f"  cooldown_tier_ttl_minutes: JSON={json_ttl} vs Go={go_ttl}",
+            file=sys.stderr,
+        )
+    print(
+        "Fix: update the JSON policy block to match the Go constants "
+        "(Go owns the runtime; JSON documents for ops).",
+        file=sys.stderr,
+    )
+    return 1
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/scripts/sentinels/gateway-tk.json
+++ b/scripts/sentinels/gateway-tk.json
@@ -54,9 +54,13 @@
       "path": "backend/internal/service/ops_alert_evaluator_service.go",
       "must_contain": [
         "maybeSendAlertNotifications",
-        "feishu_sent"
+        "feishu_sent",
+        "\"anthropic_cooldown_tier_escalation_count\"",
+        "SetAnthropicUpstreamErrorCounterCache",
+        "GetAnthropicCooldownTierEscalations",
+        "AnthropicCooldownTierEscalationsKey"
       ],
-      "rationale": "Ops alert evaluator must call the TK companion notification fanout and report Feishu sends in the heartbeat. If an upstream merge restores the old email-only call, P0 Feishu delivery silently stops while alert event creation still works."
+      "rationale": "Ops alert evaluator must call the TK companion notification fanout and report Feishu sends in the heartbeat. If an upstream merge restores the old email-only call, P0 Feishu delivery silently stops while alert event creation still works. The anthropic_cooldown_tier_escalation_count metric case is the PR #337 follow-up that turns persistent ladder escalation into Feishu/email alerts; dropping the case (or the cache injection seam / shared canonical key) silently disables the alert while the writer side keeps incrementing the counter."
     },
     {
       "path": "backend/internal/service/ops_alert_notifications_tk_feishu.go",
@@ -119,13 +123,24 @@
         "isAnthropicExtraUsage429",
         "s.apply429FallbackRateLimit(ctx, account, \"no_reset_time\")",
         "TkRecordOpenAI429BurstFallthrough(normalized)",
-        "anthropicUpstreamErrorThreshold",
-        "anthropicUpstreamErrorWindowMinutes",
+        "anthropicUpstreamErrorThresholdDefault",
+        "anthropicUpstreamErrorWindowMinutesDefault",
+        "getAnthropicErrorThreshold",
+        "getAnthropicErrorWindowMinutes",
         "anthropicCooldownTierLadder",
         "anthropicCooldownTierTTLMinutes",
+        "anthropicCooldownTierEscalationsWindowMinutes",
+        "tlsFingerprintFailureKeywords",
+        "tlsFingerprintFailureCooldown",
         "handleAnthropicUpstreamError",
+        "handleAnthropicUpstreamErrorWithOptions",
         "IncrementAnthropicUpstreamErrorCount",
         "IncrementAnthropicCooldownTier",
+        "IncrementAnthropicCooldownTierEscalations",
+        "anthropic_cooldown_tier_escalation",
+        "anthropic_upstream_error_cooldown_write_skipped",
+        "anthropic_tls_fingerprint_failure_suspected",
+        "403_escalated_to_error",
         "SetTempUnschedulable(ctx, account.ID, until, reason)",
         "ResetAnthropicUpstreamErrorCounter",
         "ResetAnthropicCooldownTier",
@@ -142,22 +157,28 @@
         "IncrementAnthropicUpstreamErrorCount",
         "ResetAnthropicUpstreamErrorCount",
         "IncrementAnthropicCooldownTier",
-        "ResetAnthropicCooldownTier"
+        "ResetAnthropicCooldownTier",
+        "IncrementAnthropicCooldownTierEscalations",
+        "GetAnthropicCooldownTierEscalations",
+        "AnthropicCooldownTierEscalationsKey"
       ],
-      "rationale": "Interface seam for both (a) Anthropic upstream-error short-window counting and (b) cooldown-tier escalation (30s → 2min → 10min). If an upstream merge drops the tier methods, handleAnthropicUpstreamError silently collapses back to a fixed cooldown — losing the persistent-failure escalation that replaces PR #333's removed pool_mode immunity."
+      "rationale": "Interface seam for (a) per-account Anthropic upstream-error short-window counting, (b) per-account cooldown-tier escalation (30s → 2min → 10min), and (c) global tier>=1 escalation aggregation for ops alerts. If an upstream merge drops the tier methods, handleAnthropicUpstreamError silently collapses back to a fixed cooldown — losing the persistent-failure escalation that replaces PR #333's removed pool_mode immunity. The global escalation pair (Increment/Get) + exported key constant `AnthropicCooldownTierEscalationsKey` are the contract ops_alert_evaluator's `anthropic_cooldown_tier_escalation_count` metric reads from; dropping any one silently disables the alert."
     },
     {
       "path": "backend/internal/repository/anthropic_upstream_error_counter_cache.go",
       "must_contain": [
         "anthropic_upstream_error_count:account:",
         "anthropic_cooldown_tier:account:",
+        "service.AnthropicCooldownTierEscalationsKey",
         "NewAnthropicUpstreamErrorCounterCache",
         "IncrementAnthropicUpstreamErrorCount",
         "ResetAnthropicUpstreamErrorCount",
         "IncrementAnthropicCooldownTier",
-        "ResetAnthropicCooldownTier"
+        "ResetAnthropicCooldownTier",
+        "IncrementAnthropicCooldownTierEscalations",
+        "GetAnthropicCooldownTierEscalations"
       ],
-      "rationale": "Redis-backed atomic counters for both the Anthropic upstream-error short window AND the cooldown-tier escalation window. Both prefixes (`anthropic_upstream_error_count:account:` and `anthropic_cooldown_tier:account:`) must remain stable so all app replicas share the same threshold + tier state."
+      "rationale": "Redis-backed atomic counters for (1) the per-account Anthropic upstream-error short window, (2) the per-account cooldown-tier escalation window, and (3) the global tier>=1 escalation aggregator that drives ops_alert_evaluator's anthropic_cooldown_tier_escalation_count metric. All three prefixes/keys (`anthropic_upstream_error_count:account:`, `anthropic_cooldown_tier:account:`, `AnthropicCooldownTierEscalationsKey` — the latter exported from the service package so the evaluator's Redis fallback and the repository writer share a single literal) must remain stable so all app replicas share the same threshold + tier + escalation state."
     },
     {
       "path": "backend/internal/service/wire.go",


### PR DESCRIPTION
## Summary

Six interrelated improvements layered on top of PR #337's cooldown ladder. Motivated by a community-research session for "single Max \$200 OAuth account best config" — the investigation surfaced that the ladder PR #337 just shipped (2026-05-21) was being masked by stale JSON \`temp_unschedulable_rules\` entries from 2026-04. All six P-blocks are concerns of one consolidated change set.

| P | Concern | Files |
|---|---|---|
| P0 | Dedupe JSON \`temp_unschedulable_rules\` so the ladder can actually run on 429/529 in production (last-write-wins protection); 401 entry was already dead code | \`deploy/aws/stage0/anthropic-oauth-stability-baselines-tiered.json\` |
| P1 | Pin cooldown ladder values in JSON \`policy\` + drift sentinel between JSON and Go constants | JSON + \`scripts/sentinels/check-anthropic-baseline-sync.py\` + \`scripts/preflight.sh\` |
| P2 | PR #337 follow-up: \`anthropic_cooldown_tier_escalation_count\` ops_alert_evaluator metric (global "tier >= 1" Redis counter) | \`anthropic_upstream_error_counter.go\`/_cache.go + \`ops_alert_evaluator_service.go\` |
| P3 | 429 retry-after / 529 SetOverloaded suppress the ladder cooldown write (counters still advance) | \`ratelimit_service.go\` — \`handleAnthropicUpstreamErrorWithOptions\` + \`handle429/handle529\` return bool |
| P4 | 403 second-hit escalates to SetError (mirrors 401 escalation); TLS / bot-detection keyword scan applies short 30s cooldown + ERROR slog | \`ratelimit_service.go\` |
| P5 | \`cfg.RateLimit.AnthropicErrorThreshold\` / \`AnthropicErrorWindowMinutes\` so single-account / small-pool deployments can lift the 3/3 bar without recompiling | \`config.go\` + \`ratelimit_service.go\` |

## Why bundled into one PR

P0 removes JSON rules that today mask the ladder from PR #337 — P2/P3 then make the ladder observable and authoritative. Splitting them would leave a window where the ladder is unmasked but unobserved, or unobserved but already failing silently on retry-after races. The OPC directive favored a single coherent change with one rollback boundary; the alternative was 4-5 PRs across one week.

## Test plan

- [x] \`go test -tags=unit -count=1 ./...\` → PASS (full suite, 115s)
- [x] \`golangci-lint run ./internal/service/... ./internal/repository/... ./internal/config/...\` → 0 issues
- [x] \`bash scripts/preflight.sh\` → PASS (incl. new anthropic baseline sync check, sentinel registry update gate, all existing gateway-tk anchors)
- [x] \`python3 scripts/sentinels/check-gateway-tk.py\` → 84/84 intact
- [x] \`python3 scripts/sentinels/check-anthropic-baseline-sync.py\` → JSON \`cooldown_ladder_seconds=[30,120,600]\` matches Go \`anthropicCooldownTierLadder\`
- [ ] CI on branch
- [ ] Smoke after merge: edge \`anthropic_cooldown_tier_escalation\` slog appears on a forced tier-1 trip; ops dashboard surfaces \`anthropic_cooldown_tier_escalation_count\` non-zero

## New unit tests

\`backend/internal/service/ratelimit_service_anthropic_consolidation_test.go\`:
- \`Anthropic429PreciseResetSuppressesLadder\` — P3 happy path (3 hits → SetRateLimited landed; \`repo.tempCalls == 0\`)
- \`Anthropic429NoResetHeaderStillLadders\` — P3 regression coverage (ladder must still write without authoritative cooldown)
- \`Anthropic529SetOverloadedSuppressesLadder\` — P3 happy path for 529
- \`TryTempUnschedulable_403SecondHitEscalates\` — P4 (second-hit 403 returns false to upstream → SetError instead of 6h re-arm)
- \`Anthropic403TLSFingerprintShortCooldown\` — P4 (body containing "JA3" → 30s cooldown + state.MatchedKeyword == "tls_fingerprint_failure"; counter NOT advanced)
- \`AnthropicErrorThresholdConfigurable\` — P5 (cfg threshold=5 / window=2min honored; counter calls reflect window)
- \`AnthropicErrorThresholdDefaultsWhenUnset\` — P5 fallback to built-in 3
- \`AnthropicTier0DoesNotEmitEscalation\` — P2 silence on transient jitter
- \`AnthropicTier1EmitsEscalation\` — P2 tier=1 increments global counter
- \`OpsAlertEvaluator_AnthropicCooldownTierEscalationCount_ReflectsLadderWrites\` — P2 end-to-end through cache injection seam

## Out of scope

- \`weekly_cost_limit\` / \`min_session_warmup_ms\` baseline JSON fields. These require new service-side support before they become load-bearing, which would significantly expand this PR. Tracked separately.
- GitHub Actions / Feishu alert rule provisioning that consumes the new metric. The metric is reportable; the rule lives in admin UI / ops settings and is operator-owned.

## Reviewer merge-button

Per CLAUDE.md §5.y: **Squash and merge** (TK-originated fix PR). Title under 70 chars; body aggregates the design context.

🤖 Generated with [Claude Code](https://claude.com/claude-code)