### PR TITLE
fix(upstream-merge): resolve lib path in workflow-pinned layout

### DIFF
--- a/scripts/upstream/merge-state.sh
+++ b/scripts/upstream/merge-state.sh
@@ -3,8 +3,17 @@
 set -euo pipefail
 
 SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+# In-repo layout: scripts/upstream/merge-state.sh + scripts/lib/upstream-drift.sh
+# Workflow-pinned layout: $STATE_HELPER_DIR/upstream-merge-state.sh + $STATE_HELPER_DIR/lib/upstream-drift.sh
 # shellcheck source=scripts/lib/upstream-drift.sh
-source "$SCRIPT_DIR/../lib/upstream-drift.sh"
+if [ -f "$SCRIPT_DIR/../lib/upstream-drift.sh" ]; then
+  source "$SCRIPT_DIR/../lib/upstream-drift.sh"
+elif [ -f "$SCRIPT_DIR/lib/upstream-drift.sh" ]; then
+  source "$SCRIPT_DIR/lib/upstream-drift.sh"
+else
+  echo "ERROR: cannot locate upstream-drift.sh next to merge-state.sh" >&2
+  exit 2
+fi
 
 STATE_FILE="${STATE_FILE:-/tmp/upstream-merge-state.json}"
 

--- a/scripts/upstream/merge-state_test.sh
+++ b/scripts/upstream/merge-state_test.sh
@@ -120,6 +120,33 @@ else
   echo "  args: $(cat "$tmpdir/gh-args" 2>/dev/null || true)" >&2
 fi
 
+# 11) Workflow-pinned layout: the daily agent flattens the helper into
+#     /tmp/upstream-merge-scripts/upstream-merge-state.sh and copies scripts/lib
+#     as a SIBLING lib/ (not ../lib/). Regression guard for the twice-recurring
+#     prod failure where the source path resolved to a non-existent ../lib/.
+pinned_dir="$(mktemp -d)"
+trap 'rm -rf "$tmpdir" "$pinned_dir"' EXIT
+cp "$HELPER" "$pinned_dir/upstream-merge-state.sh"
+cp -R "$HERE/../lib" "$pinned_dir/lib"
+chmod +x "$pinned_dir/upstream-merge-state.sh"
+# A no-op-ish subcommand: if the lib source fails, the script dies at the
+# source line (stderr mentions upstream-drift.sh) before reaching business
+# logic. With the source resolved, set-reason-code on a missing STATE_FILE
+# reaches require_state_file and emits "STATE_FILE missing" — the positive
+# proof that the lib loaded and business logic ran.
+set +e
+STATE_FILE="$pinned_dir/nonexistent-state.json" \
+  bash "$pinned_dir/upstream-merge-state.sh" set-reason-code TEST 2>"$pinned_dir/err"
+set -e
+if grep -q "STATE_FILE missing" "$pinned_dir/err" 2>/dev/null \
+   && ! grep -q "upstream-drift.sh" "$pinned_dir/err" 2>/dev/null; then
+  pass=$((pass + 1))
+else
+  fail=$((fail + 1))
+  echo "FAIL: pinned layout did not source lib / reach business logic" >&2
+  echo "  stderr: $(cat "$pinned_dir/err" 2>/dev/null || true)" >&2
+fi
+
 echo ""
 if [ "$fail" -eq 0 ]; then
   echo "=== upstream-merge-state pure assembler: PASS ($pass assertions) ==="


### PR DESCRIPTION
## Summary

`upstream-merge-agent-daily.yml` failed twice in a row (runs `26125624016` on 2026-05-19, `26191715704` on 2026-05-20). Both died at the **Drift check snapshot** step with:

```
/tmp/upstream-merge-scripts/upstream-merge-state.sh: line 7: /tmp/upstream-merge-scripts/../lib/upstream-drift.sh: No such file or directory
```

### Root cause

`scripts/upstream/merge-state.sh` sources its dependency via `$SCRIPT_DIR/../lib/upstream-drift.sh`. That resolves correctly **in-repo** (`scripts/upstream/` → `../lib/` = `scripts/lib/`), but the workflow's *Pin state helper into immutable path* step flattens the helper into `/tmp/upstream-merge-scripts/upstream-merge-state.sh` and copies `scripts/lib/` as a **sibling** `lib/`:

```yaml
cp scripts/upstream/merge-state.sh "$STATE_HELPER_DIR/upstream-merge-state.sh"
cp -R scripts/lib "$STATE_HELPER_DIR/lib"
```

So `../lib/` resolved to the non-existent `/tmp/lib/`. Every `bash "$STATE_HELPER" ...` call exited 1, the drift checkpoint never wrote, and the pipeline classified the run as `CONTRACT_EVAL_ERROR` → *Enforce output contract* failed.

### Fix

Make `merge-state.sh` tolerate both layouts (sibling `../lib/` for in-repo, `./lib/` for the pinned layout), with a clear error if neither is found. No workflow change needed; backward-compatible with the in-repo callers and `merge-state_test.sh`.

## Test plan

- [x] `bash scripts/upstream/merge-state_test.sh` → PASS (18 assertions)
- [x] Simulated workflow pinning (`cp` into `/tmp/upstream-merge-scripts/` + sibling `lib/`) — subcommands now reach business logic instead of failing on the missing source
- [x] `bash scripts/preflight.sh` → PASS
- [ ] Confirm next scheduled `upstream-merge-agent-daily.yml` run is green (or manual dispatch)

🤖 Generated with [Claude Code](https://claude.com/claude-code)