### PR TITLE
chore: refresh upstream issue cache

### DIFF
--- a/.cache/upstream/triage.json
+++ b/.cache/upstream/triage.json
@@ -4,10 +4,10 @@
   "generated_from": "GitHub REST API issues?state=open; pull requests excluded",
   "rationale": "TokenKey-local triage cache for upstream open issues. Use this file before re-triaging upstream issues; update entries when TokenKey fixes, dismisses, or reclassifies an issue.",
   "counts": {
-    "needs_review": 356,
+    "needs_review": 357,
     "fixed": 28,
     "needs_prod_validation": 4,
-    "medium": 115,
+    "medium": 116,
     "not_applicable": 1,
     "low": 101,
     "unknown_low_signal": 415
@@ -2022,7 +2022,7 @@
       ],
       "tokenkey_status": "candidate_unverified",
       "rationale": "Keyword match for production-sensitive area; not yet manually verified against TokenKey code.",
-      "updated_at": "2026-04-27T11:26:02Z"
+      "updated_at": "2026-05-22T06:13:21Z"
     },
     {
       "upstream": "Wei-Shaw/sub2api#204",
@@ -3351,6 +3351,18 @@
       "tokenkey_status": "candidate_unverified",
       "rationale": "Keyword match for production-sensitive area; not yet manually verified against TokenKey code.",
       "updated_at": "2026-05-22T02:43:30Z"
+    },
+    {
+      "upstream": "Wei-Shaw/sub2api#2685",
+      "url": "https://github.com/Wei-Shaw/sub2api/issues/2685",
+      "title": "飞书OAuth 登录接入",
+      "impact": "needs_review",
+      "categories": [
+        "image_oauth"
+      ],
+      "tokenkey_status": "candidate_unverified",
+      "rationale": "Keyword match for production-sensitive area; not yet manually verified against TokenKey code.",
+      "updated_at": "2026-05-22T05:26:05Z"
     },
     {
       "upstream": "Wei-Shaw/sub2api#283",
@@ -5404,7 +5416,7 @@
       ],
       "tokenkey_status": "unresolved_observability",
       "rationale": "Cache hit rate has inconsistent UI formulas between dashboard/trend views; observability issue, not direct production outage.",
-      "updated_at": "2026-05-08T10:22:53Z"
+      "updated_at": "2026-05-22T03:40:47Z"
     },
     {
       "upstream": "Wei-Shaw/sub2api#2308",
@@ -5666,6 +5678,18 @@
       "tokenkey_status": "not_prioritized",
       "rationale": "Potential compatibility/ops/admin impact, but not selected as severe TokenKey production risk in this pass.",
       "updated_at": "2026-05-22T00:21:47Z"
+    },
+    {
+      "upstream": "Wei-Shaw/sub2api#2688",
+      "url": "https://github.com/Wei-Shaw/sub2api/issues/2688",
+      "title": "GPT压缩不开透传就会出现这个504问题",
+      "impact": "medium",
+      "categories": [
+        "compatibility"
+      ],
+      "tokenkey_status": "not_prioritized",
+      "rationale": "Potential compatibility/ops/admin impact, but not selected as severe TokenKey production risk in this pass.",
+      "updated_at": "2026-05-22T06:27:15Z"
     },
     {
       "upstream": "Wei-Shaw/sub2api#275",
@@ -10308,7 +10332,7 @@
       "categories": [],
       "tokenkey_status": "not_prioritized",
       "rationale": "No high-signal production-risk keywords in this pass.",
-      "updated_at": "2026-05-18T02:40:44Z"
+      "updated_at": "2026-05-22T05:11:13Z"
     },
     {
       "upstream": "Wei-Shaw/sub2api#2544",
@@ -10458,7 +10482,7 @@
       "categories": [],
       "tokenkey_status": "not_prioritized",
       "rationale": "No high-signal production-risk keywords in this pass.",
-      "updated_at": "2026-05-22T02:22:56Z"
+      "updated_at": "2026-05-22T05:44:35Z"
     },
     {
       "upstream": "Wei-Shaw/sub2api#2666",
@@ -10498,7 +10522,7 @@
       "categories": [],
       "tokenkey_status": "not_prioritized",
       "rationale": "No high-signal production-risk keywords in this pass.",
-      "updated_at": "2026-05-22T02:15:42Z"
+      "updated_at": "2026-05-22T04:20:37Z"
     },
     {
       "upstream": "Wei-Shaw/sub2api#2679",
@@ -10508,7 +10532,7 @@
       "categories": [],
       "tokenkey_status": "not_prioritized",
       "rationale": "No high-signal production-risk keywords in this pass.",
-      "updated_at": "2026-05-22T02:21:32Z"
+      "updated_at": "2026-05-22T05:53:55Z"
     },
     {
       "upstream": "Wei-Shaw/sub2api#272",


### PR DESCRIPTION
## Summary
- Refresh `.cache/upstream/triage.json` from the latest Wei-Shaw/sub2api issues.
- Update `.cache/upstream/fixes.json` from current TokenKey main fact checks.
- Keep watchdog workflow/script/fact-check metadata in sync with the refreshed cache.

## Watchdog report
# Upstream Issue Watchdog Report

- Run URL: https://github.com/youxuanxue/sub2api/actions/runs/26272456241
- Repository SHA: `b57fab157b05f9e061f0862da045cd25c48c19bc`
- Generated at: `2026-05-22T06:36:01Z`
- Upstream issues scanned: `1428`
- Fact checks: `21`
- Fixed facts verified: `19`
- High/critical unresolved: `0`

## Fixed facts verified

- Wei-Shaw/sub2api#641 via None
- Wei-Shaw/sub2api#2332 via None
- Wei-Shaw/sub2api#2107 via youxuanxue/sub2api#232
- Wei-Shaw/sub2api#2159 via youxuanxue/sub2api#232
- Wei-Shaw/sub2api#2258 via youxuanxue/sub2api#232
- Wei-Shaw/sub2api#2478 via youxuanxue/sub2api#232
- Wei-Shaw/sub2api#2515 via None
- Wei-Shaw/sub2api#2506 via None
- Wei-Shaw/sub2api#2500 via None
- Wei-Shaw/sub2api#2486 via None
- Wei-Shaw/sub2api#2363 via None
- Wei-Shaw/sub2api#2332 via None
- Wei-Shaw/sub2api#1471 via None
- Wei-Shaw/sub2api#2538 via None
- Wei-Shaw/sub2api#2539 via None
- Wei-Shaw/sub2api#2556 via None
- Wei-Shaw/sub2api#1264 via None
- Wei-Shaw/sub2api#1170 via None
- Wei-Shaw/sub2api#1318 via None

## Fact checks missing

- Wei-Shaw/sub2api#1311: scripts/check-buffered-content-type-leak.py:def scan_file
- Wei-Shaw/sub2api#1322: scripts/terminal-sentinels.json:openai_compat_responses_terminal_helper


## Test plan
- [x] `python3 -m json.tool .cache/upstream/triage.json`
- [x] `python3 -m json.tool .cache/upstream/fixes.json`
- [x] `python3 -m json.tool .cache/upstream/fact-checks.json`
- [x] `python3 -m py_compile scripts/upstream/issue-watchdog.py`
- [x] `python3 -m json.tool .cache/upstream-issue-watchdog/report.json`
- [x] `python3 -m json.tool .cache/upstream-issue-watchdog/agent-input.json`
