### PR TITLE
fix(ratelimit): skip OpenAI OAuth pool poisoning on CF/Arkose 403

### DIFF
--- a/.cache/upstream/fact-checks.json
+++ b/.cache/upstream/fact-checks.json
@@ -358,6 +358,22 @@
         "backend/internal/service/openai_gateway_service.go:shouldDisable = s.rateLimitService.HandleUpstreamError(ctx, account, resp.StatusCode, resp.Header, body)",
         "backend/internal/service/openai_oauth_passthrough_test.go:TestOpenAIGatewayService_OpenAIPassthrough_TempUnschedRuleTriggersFailover"
       ]
+    },
+    {
+      "upstream": "Wei-Shaw/sub2api#1824",
+      "severity": "high",
+      "summary": "OpenAI 403 handler skips the per-account counter + temp_unschedulable + SetError writes when the response body matches a Cloudflare / Arkose challenge keyword (cloudflare / just a moment / arkoselabs / funcaptcha / challenge-platform). Failover still proceeds for the in-flight request; the OAuth account stays in the pool for unrelated traffic.",
+      "fixed_by": [
+        "backend/internal/service/ratelimit_service.go",
+        "backend/internal/service/ratelimit_service_tk_openai_cf_challenge_test.go"
+      ],
+      "fixed_if_all_present": [
+        "backend/internal/service/ratelimit_service.go:openAICloudflareChallengeKeywords",
+        "backend/internal/service/ratelimit_service.go:openai_403_cf_challenge_skip_cooldown",
+        "backend/internal/service/ratelimit_service.go:See upstream Wei-Shaw/sub2api#1824 and #2413",
+        "backend/internal/service/ratelimit_service_tk_openai_cf_challenge_test.go:TestRateLimitService_HandleUpstreamError_OpenAI403CloudflareChallengeSkipsCooldown",
+        "backend/internal/service/ratelimit_service_tk_openai_cf_challenge_test.go:TestRateLimitService_HandleUpstreamError_OpenAI403RealAccountErrorStillCoolsDown"
+      ]
     }
   ]
 }

--- a/.cache/upstream/fixes.json
+++ b/.cache/upstream/fixes.json
@@ -336,6 +336,26 @@
         "backend/internal/service/openai_gateway_chat_completions_tk_silent_refusal_test.go"
       ],
       "summary": "OpenAI Chat Completions raw passthrough detects upstream silent refusal (empty stream/response with finish_reason=stop and zero usage) and emits an ops_error_logs row with Kind=silent_refusal. Conservative predicate: no content / no tool_calls / no reasoning / no refusal / no chunk-level error / zero usage / finish_reason=stop. Stream path keeps the client-visible bytes untouched (headers already flushed); buffered path will keep flexibility to harden later. The categorical ops signal turns the previously invisible 'ghost stream' (gpt-5.5 above input budget) into a dashboard-pivotable event."
+    },
+    {
+      "upstream": "Wei-Shaw/sub2api#1824",
+      "status": "fixed_in_tokenkey",
+      "fixed_by": [
+        "backend/internal/service/ratelimit_service.go",
+        "backend/internal/service/ratelimit_service_tk_openai_cf_challenge_test.go",
+        "scripts/sentinels/gateway-tk.json"
+      ],
+      "summary": "OpenAI 403 handler short-circuits on Cloudflare / Arkose challenge bodies (cloudflare, just a moment, arkoselabs, funcaptcha, challenge-platform) by skipping the openAI403Counter increment AND the SetTempUnschedulable / SetError writes. The in-flight request still fails over (shouldDisable=true) but the OAuth account stays in the pool, so per-request CF/Arkose challenges on /v1/images/{generations,edits} no longer poison the entire OAuth pool for unrelated chat/embeddings traffic. Path-agnostic on purpose — body keyword match is the signal, not the URL — because legitimate OpenAI 403s return structured JSON with none of these keywords."
+    },
+    {
+      "upstream": "Wei-Shaw/sub2api#2413",
+      "status": "fixed_in_tokenkey",
+      "fixed_by": [
+        "backend/internal/service/ratelimit_service.go",
+        "backend/internal/service/ratelimit_service_tk_openai_cf_challenge_test.go",
+        "scripts/sentinels/gateway-tk.json"
+      ],
+      "summary": "Same fix as #1824: Cherry Studio gpt-image-2 traffic hits per-request Cloudflare challenges on OpenAI OAuth; the body keyword match in handleOpenAI403 now keeps the account schedulable for non-image traffic instead of writing temp_unschedulable on the first hit."
     }
   ]
 }

--- a/.cache/upstream/triage.json
+++ b/.cache/upstream/triage.json
@@ -5,8 +5,8 @@
   "rationale": "TokenKey-local triage cache for upstream open issues. Use this file before re-triaging upstream issues; update entries when TokenKey fixes, dismisses, or reclassifies an issue.",
   "counts": {
     "needs_review": 357,
-    "fixed": 28,
-    "needs_prod_validation": 4,
+    "fixed": 30,
+    "needs_prod_validation": 2,
     "medium": 116,
     "not_applicable": 1,
     "low": 101,
@@ -4460,7 +4460,7 @@
       "upstream": "Wei-Shaw/sub2api#1824",
       "url": "https://github.com/Wei-Shaw/sub2api/issues/1824",
       "title": "只有OAuth账号调用生图API会将账号标记错误",
-      "impact": "needs_prod_validation",
+      "impact": "fixed",
       "categories": [
         "rate_limit_cooldown",
         "image_oauth",
@@ -4468,8 +4468,8 @@
         "compatibility",
         "admin_ui"
       ],
-      "tokenkey_status": "partially_mitigated",
-      "rationale": "OpenAI 403 now starts with temporary unschedulable state, but repeated CF/Arkose challenges can still cool down or error accounts.",
+      "tokenkey_status": "fixed_in_tokenkey",
+      "rationale": "Body keyword short-circuit in handleOpenAI403 (Cloudflare / Arkose challenge keywords) skips the 403 counter and temp_unschedulable write so per-request CF/Arkose challenges no longer poison the OAuth pool. Failover still occurs. See fact-checks.json.",
       "updated_at": "2026-04-23T06:46:12Z"
     },
     {
@@ -4510,15 +4510,15 @@
       "upstream": "Wei-Shaw/sub2api#2413",
       "url": "https://github.com/Wei-Shaw/sub2api/issues/2413",
       "title": "Cherry Studio 调 gpt-image-2，OpenAI 403 会导致账号被临时标记为不可调度",
-      "impact": "needs_prod_validation",
+      "impact": "fixed",
       "categories": [
         "rate_limit_cooldown",
         "image_oauth",
         "ops_observability",
         "enhancement"
       ],
-      "tokenkey_status": "partially_mitigated",
-      "rationale": "OpenAI image 403 still triggers temporary unschedulable cooldown; decide whether CF/Arkose image challenges should be ignored or scoped.",
+      "tokenkey_status": "fixed_in_tokenkey",
+      "rationale": "Same fix as #1824 — Cherry Studio gpt-image-2 CF challenges no longer cool down the OAuth account. See fact-checks.json.",
       "updated_at": "2026-05-20T14:04:19Z"
     },
     {

--- a/backend/internal/service/ratelimit_service.go
+++ b/backend/internal/service/ratelimit_service.go
@@ -109,6 +109,29 @@ var tlsFingerprintFailureKeywords = []string{
 	"client fingerprint",
 }
 
+// openAICloudflareChallengeKeywords matches Cloudflare / Arkose challenge
+// pages where an OpenAI 403 was returned by infrastructure (CF JS challenge,
+// Arkose FunCaptcha) rather than by OpenAI's auth/permission layer. The
+// most common trigger today is the OAuth /v1/images/{generations,edits}
+// path under heavy automation — Cherry Studio and similar clients see a
+// per-request CF challenge HTML body, but the OAuth identity itself is
+// healthy. Treating these as account-level 403s would write a 10-minute
+// temp_unschedulable on the FIRST hit and SetError on the 3rd within the
+// 180-min counter window, removing the OAuth account from the pool for ALL
+// non-image traffic too. Body match is path-agnostic on purpose: a real
+// OpenAI 403 returns structured JSON ({"error":{"code":"...","message":..."}}),
+// none of these keywords appear in legitimate auth/permission errors.
+//
+// Matching is case-insensitive; order is insignificant.
+// See upstream Wei-Shaw/sub2api#1824 and #2413.
+var openAICloudflareChallengeKeywords = []string{
+	"cloudflare",
+	"just a moment",
+	"arkoselabs",
+	"funcaptcha",
+	"challenge-platform",
+}
+
 // getAnthropicErrorThreshold returns the configured 3/3-style threshold, or
 // the built-in default when unset / zero / negative.
 func (s *RateLimitService) getAnthropicErrorThreshold() int64 {
@@ -1073,6 +1096,23 @@ func buildAnthropicUpstreamErrorMessage(statusCode int, upstreamMsg string, resp
 }
 
 func (s *RateLimitService) handleOpenAI403(ctx context.Context, account *Account, upstreamMsg string, responseBody []byte) (shouldDisable bool) {
+	// TK: Cloudflare / Arkose challenge pages return 403 on OAuth image paths
+	// (and occasionally other paths under heavy automation). The OAuth account
+	// is healthy — the 403 is per-request infrastructure noise. Skip the 403
+	// counter increment AND the temp_unschedulable write so the OAuth pool
+	// is not poisoned for non-image traffic. The in-flight request still
+	// fails over (shouldDisable=true) because this account can't serve it
+	// right now. See upstream Wei-Shaw/sub2api#1824 and #2413.
+	if matched := matchTempUnschedKeyword(strings.ToLower(string(responseBody)), openAICloudflareChallengeKeywords); matched != "" {
+		slog.Warn(
+			"openai_403_cf_challenge_skip_cooldown",
+			"account_id", account.ID,
+			"matched_keyword", matched,
+			"upstream_msg", upstreamMsg,
+		)
+		return true
+	}
+
 	msg := buildForbiddenErrorMessage(
 		"Access forbidden (403):",
 		upstreamMsg,

--- a/backend/internal/service/ratelimit_service_tk_openai_cf_challenge_test.go
+++ b/backend/internal/service/ratelimit_service_tk_openai_cf_challenge_test.go
@@ -1,0 +1,174 @@
+//go:build unit
+
+package service
+
+import (
+	"context"
+	"net/http"
+	"testing"
+
+	"github.com/Wei-Shaw/sub2api/internal/config"
+	"github.com/stretchr/testify/require"
+)
+
+// TK regression for upstream Wei-Shaw/sub2api#1824 and #2413:
+//
+// OpenAI OAuth accounts hitting Cloudflare / Arkose challenges on
+// /v1/images/{generations,edits} (and other automation-heavy paths) MUST
+// NOT have their per-account 403 counter incremented and MUST NOT have a
+// temp_unschedulable cooldown written. The OAuth identity is healthy; the
+// 403 is per-request infrastructure noise. Cooldowns would poison the pool
+// for unrelated traffic (chat completions, embeddings, non-image APIs).
+//
+// shouldDisable still returns true so the in-flight request fails over —
+// this account cannot serve THIS request, but it can serve the next one.
+
+func TestRateLimitService_HandleUpstreamError_OpenAI403CloudflareChallengeSkipsCooldown(t *testing.T) {
+	cases := []struct {
+		name string
+		body []byte
+	}{
+		{
+			name: "cloudflare_html_just_a_moment",
+			body: []byte(`<!DOCTYPE html><html><head><title>Just a moment...</title></head><body><script>window._cf_chl_opt={};</script></body></html>`),
+		},
+		{
+			name: "cloudflare_keyword_in_body",
+			body: []byte(`Sorry, you have been blocked. This website is using a security service to protect itself from online attacks. Powered by Cloudflare.`),
+		},
+		{
+			name: "arkose_funcaptcha_challenge",
+			body: []byte(`<html><head></head><body><script src="https://client-api.arkoselabs.com/v2/funcaptcha/api.js"></script></body></html>`),
+		},
+		{
+			name: "cf_challenge_platform_marker",
+			body: []byte(`<html><body><script src="/cdn-cgi/challenge-platform/h/g/orchestrate/chl_page/v1"></script></body></html>`),
+		},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			repo := &rateLimitAccountRepoStub{}
+			counter := &openAI403CounterCacheStub{counts: []int64{1}}
+			service := NewRateLimitService(repo, nil, &config.Config{}, nil, nil)
+			service.SetOpenAI403CounterCache(counter)
+
+			account := &Account{
+				ID:       901,
+				Platform: PlatformOpenAI,
+				Type:     AccountTypeOAuth,
+			}
+
+			shouldDisable := service.HandleUpstreamError(
+				context.Background(),
+				account,
+				http.StatusForbidden,
+				http.Header{"Cf-Ray": []string{"abc123-IAD"}},
+				tc.body,
+			)
+
+			// In-flight request still fails over so the client retries on a
+			// different OAuth account rather than receiving the CF page.
+			require.True(t, shouldDisable, "shouldDisable must remain true so failover proceeds")
+
+			// Critical invariant: no account-level penalty.
+			require.Equal(t, 0, repo.tempCalls, "CF challenge must not write temp_unschedulable")
+			require.Equal(t, 0, repo.setErrorCalls, "CF challenge must not SetError")
+			require.Empty(t, counter.incrementIDs, "CF challenge must not increment the 403 counter")
+		})
+	}
+}
+
+// Regression guard: real OpenAI 403s (account suspended, lacks permissions,
+// workspace deactivated etc.) still go through the normal counter +
+// temp_unschedulable path. Without this guard, an over-eager keyword list
+// or a future refactor could silently disable cooldowns for legitimate
+// account-health 403s, masking real account problems.
+func TestRateLimitService_HandleUpstreamError_OpenAI403RealAccountErrorStillCoolsDown(t *testing.T) {
+	repo := &rateLimitAccountRepoStub{}
+	counter := &openAI403CounterCacheStub{counts: []int64{1}}
+	service := NewRateLimitService(repo, nil, &config.Config{}, nil, nil)
+	service.SetOpenAI403CounterCache(counter)
+
+	account := &Account{
+		ID:       902,
+		Platform: PlatformOpenAI,
+		Type:     AccountTypeOAuth,
+	}
+
+	shouldDisable := service.HandleUpstreamError(
+		context.Background(),
+		account,
+		http.StatusForbidden,
+		http.Header{},
+		[]byte(`{"error":{"message":"You do not have permission to access this endpoint.","type":"forbidden","code":"account_disabled_auth_error"}}`),
+	)
+
+	require.True(t, shouldDisable)
+	require.Equal(t, 1, repo.tempCalls, "real account 403 must still write temp_unschedulable")
+	require.Equal(t, 0, repo.setErrorCalls)
+	require.Equal(t, []int64{902}, counter.incrementIDs, "real account 403 must still increment the counter")
+	require.Contains(t, repo.lastTempReason, "You do not have permission to access this endpoint")
+	require.Contains(t, repo.lastTempReason, "(1/3)")
+}
+
+// Regression guard: CF challenge keyword that appears INSIDE a structured
+// OpenAI error body must still skip cooldown — this models the rare case
+// where the upstream wraps a CF rejection inside its own error envelope.
+// (Equally important: a regression that flips matching to JSON-aware would
+// stop catching plain-HTML CF pages, which is the dominant in-prod shape.)
+func TestRateLimitService_HandleUpstreamError_OpenAI403CFKeywordInsideStructuredBodyStillSkips(t *testing.T) {
+	repo := &rateLimitAccountRepoStub{}
+	counter := &openAI403CounterCacheStub{counts: []int64{1}}
+	service := NewRateLimitService(repo, nil, &config.Config{}, nil, nil)
+	service.SetOpenAI403CounterCache(counter)
+
+	account := &Account{
+		ID:       903,
+		Platform: PlatformOpenAI,
+		Type:     AccountTypeOAuth,
+	}
+
+	shouldDisable := service.HandleUpstreamError(
+		context.Background(),
+		account,
+		http.StatusForbidden,
+		http.Header{},
+		[]byte(`{"error":{"message":"Request blocked by Cloudflare challenge","type":"forbidden"}}`),
+	)
+
+	require.True(t, shouldDisable)
+	require.Equal(t, 0, repo.tempCalls)
+	require.Equal(t, 0, repo.setErrorCalls)
+	require.Empty(t, counter.incrementIDs)
+}
+
+// Regression guard: non-OAuth (APIKey) accounts also benefit from the CF
+// short-circuit — the keyword match runs before any OAuth-specific branch.
+// CF challenges affect APIKey accounts proxied through CF-fronted endpoints
+// just as much as OAuth accounts.
+func TestRateLimitService_HandleUpstreamError_OpenAI403CFChallengeSkipsForAPIKey(t *testing.T) {
+	repo := &rateLimitAccountRepoStub{}
+	counter := &openAI403CounterCacheStub{counts: []int64{1}}
+	service := NewRateLimitService(repo, nil, &config.Config{}, nil, nil)
+	service.SetOpenAI403CounterCache(counter)
+
+	account := &Account{
+		ID:       904,
+		Platform: PlatformOpenAI,
+		Type:     AccountTypeAPIKey,
+	}
+
+	shouldDisable := service.HandleUpstreamError(
+		context.Background(),
+		account,
+		http.StatusForbidden,
+		http.Header{},
+		[]byte(`<!DOCTYPE html><title>Just a moment...</title>`),
+	)
+
+	require.True(t, shouldDisable)
+	require.Equal(t, 0, repo.tempCalls)
+	require.Equal(t, 0, repo.setErrorCalls)
+	require.Empty(t, counter.incrementIDs)
+}

--- a/scripts/sentinels/gateway-tk.json
+++ b/scripts/sentinels/gateway-tk.json
@@ -132,6 +132,8 @@
         "anthropicCooldownTierEscalationsWindowMinutes",
         "tlsFingerprintFailureKeywords",
         "tlsFingerprintFailureCooldown",
+        "openAICloudflareChallengeKeywords",
+        "openai_403_cf_challenge_skip_cooldown",
         "handleAnthropicUpstreamError",
         "handleAnthropicUpstreamErrorWithOptions",
         "IncrementAnthropicUpstreamErrorCount",
@@ -209,6 +211,16 @@
         "TestRateLimitService_ResetAnthropicCounter_AlsoResetsCooldownTier"
       ],
       "rationale": "Focused regressions proving the behaviors that are easy to silently revert in an upstream merge: (1) non-pool-mode Anthropic upstream errors only disable after the 3/3 short-window threshold, (2) **pool-mode Anthropic accounts STILL feed the counter** and the first cooldown is 30s (2026-05-21 revision of PR #333: the blanket immunity left ops with no mechanical signal that a stub was failing; the replacement is tiered cooldown that keeps single-member-group customer impact ≤30s on transient jitter while still escalating to 10min on persistent failure), (3) **tier escalation 30s → 2min → 10min** via AnthropicCooldownTierEscalates — without this, persistent upstream failure would just bounce every 30s indefinitely, hammering the bad backend at ~50% error rate forever, (4) custom-error-codes allowlist carve-out still feeds the counter (non-pool-mode), (5) ClearRateLimit and RecoverAccountAfterSuccessfulTest both reset the error counter, and (6) ResetAnthropicCounter ALSO resets the cooldown tier so a healed account starts the next failure window at the shortest cooldown. The deleted TestRateLimitService_HandleUpstreamError_AnthropicPoolModeBypassesUpstreamErrorCounter asserted the inverse policy (pool_mode bypasses counter); restoring its name here would fail preflight and prompt the reviewer to read this rationale before re-applying the immunity. Dropping these tests lets the upstream-error policy silently drift during future merges."
+    },
+    {
+      "path": "backend/internal/service/ratelimit_service_tk_openai_cf_challenge_test.go",
+      "must_contain": [
+        "TestRateLimitService_HandleUpstreamError_OpenAI403CloudflareChallengeSkipsCooldown",
+        "TestRateLimitService_HandleUpstreamError_OpenAI403RealAccountErrorStillCoolsDown",
+        "TestRateLimitService_HandleUpstreamError_OpenAI403CFKeywordInsideStructuredBodyStillSkips",
+        "TestRateLimitService_HandleUpstreamError_OpenAI403CFChallengeSkipsForAPIKey"
+      ],
+      "rationale": "Focused regressions for the OpenAI 403 Cloudflare / Arkose challenge short-circuit (upstream Wei-Shaw/sub2api#1824, #2413). Without these tests, an upstream merge or refactor that 'simplifies' handleOpenAI403 by dropping the body keyword scan would silently restore the OAuth-pool-poisoning behavior: a single CF/Arkose challenge on /v1/images/{generations,edits} writes a 10-min temp_unschedulable on the FIRST hit and escalates to SetError on the 3rd within 180 min, removing the account from ALL non-image traffic. The four cases anchor: (1) the four body shapes in the keyword list each match (just-a-moment, cloudflare, arkoselabs, challenge-platform), (2) a real account 403 with structured JSON STILL increments the counter and writes temp_unschedulable, (3) a CF keyword inside a JSON envelope still skips (regression guard for over-clever JSON-aware future refactors), (4) APIKey accounts also benefit — the short-circuit runs before any OAuth-specific branch."
     },
     {
       "path": "backend/internal/service/ratelimit_service_401_test.go",


### PR DESCRIPTION
## Summary

- 给 `handleOpenAI403` 增加 body 关键字短路：Cloudflare / Arkose 挑战页（`cloudflare` / `just a moment` / `arkoselabs` / `funcaptcha` / `challenge-platform`）命中时跳过 403 计数器、`temp_unschedulable` 与 `SetError` 写入，仅本次请求 failover。
- 关闭 upstream [Wei-Shaw/sub2api#1824](https://github.com/Wei-Shaw/sub2api/issues/1824) 与 [Wei-Shaw/sub2api#2413](https://github.com/Wei-Shaw/sub2api/issues/2413)：OpenAI OAuth 账号在 `/v1/images/{generations,edits}` 等高自动化路径上遭遇 CF/Arkose 挑战时，原先 1 次就被 10 分钟冷却、3 次就 SetError，整池被 image-only 噪声拖累。
- 新增 4 个 focused 测试 + sentinel 锁定 + upstream cache (`fact-checks.json` / `fixes.json` / `triage.json`) 同步。

## Why this matters for prod

- OpenAI OAuth 池此前对 image API 的 CF/Arkose 挑战是 per-request 基础设施信号，但被当作 per-account 健康信号处理，导致 chat completions / embeddings 流量被无关原因降级。
- 与 Anthropic 侧已有的 `tlsFingerprintFailureKeywords` 同形状，路径无关（真实 OpenAI 403 走结构化 JSON，关键字不会误命中）。
- 单次请求行为不变（仍 failover），改变的只是不再把 per-request 噪声写到账号级状态上。

## Sentinel / cache anchors

- `scripts/sentinels/gateway-tk.json`: 在 `ratelimit_service.go` 锚点里加 `openAICloudflareChallengeKeywords` + `openai_403_cf_challenge_skip_cooldown`；新增 `ratelimit_service_tk_openai_cf_challenge_test.go` 测试函数锚点。
- `.cache/upstream/fact-checks.json`: 新增 #1824 代码事实检查（满足 `fixed_if_all_present`）。
- `.cache/upstream/fixes.json`: 新增 #1824 / #2413 的修复记录。
- `.cache/upstream/triage.json`: 两条 issue 改为 `fixed_in_tokenkey`，counts 重算。

## Test plan

- [x] `go test -tags=unit ./internal/service/...` 全绿（含 4 个新测试 + 现有 403 测试不退化）
- [x] `go vet ./...` 干净
- [x] `golangci-lint run ./internal/service/...` 0 issues
- [x] `scripts/preflight.sh` 全绿（含 newapi compat-pool drift、gateway-tk sentinel、upstream override marker 等所有 sub2api 检查）
- [ ] 待合并后观察生产 `openai_403_cf_challenge_skip_cooldown` slog 频率与 OAuth pool size 曲线变化（应不再因 image 流量出现整池 cooldown）

## Notes

- 路径无关：第一次想过只豁免 `/v1/images/*`，但要把 endpoint 一路传到 `handle403`，回归面更大且阻挡了未来其他路径的同形态保护，最终选了 body 关键字短路。
- 单次请求仍 `shouldDisable=true`：account 不能服务 *本次* CF 挑战的请求，但保留在池子里给下一次请求用。
- 不动 `OAuth 401` / `402 deactivated_workspace` 等真实账号级 403/40x 路径。

🤖 Generated with [Claude Code](https://claude.com/claude-code)