### PR TITLE
docs(skill/anthropic-oauth): align frontmatter with JSON-derived apply SQL (no-web-impact)

### DIFF
--- a/.cursor/skills/tokenkey-anthropic-oauth-config/SKILL.md
+++ b/.cursor/skills/tokenkey-anthropic-oauth-config/SKILL.md
@@ -4,7 +4,8 @@ description: >-
   TokenKey Anthropic OAuth tier baseline 写入流水线（snapshot → check → plan → apply → verify）。
   覆盖单一写入面：edge anthropic OAuth account 的 tier baseline（concurrency / base_rpm
   / sticky_buffer / max_sessions 等 account 字段）。单一脚本
-  ops/anthropic/manage-anthropic-config.py 编排，1 个 SQL 模板固化写入。
+  ops/anthropic/manage-anthropic-config.py 编排；tier baseline 值只存在于
+  baseline JSON 一处，apply SQL 由 orchestrator 运行时从 JSON 派生（无静态 SQL 模板）。
   group.rpm_limit 不由本流水线写——由 admin UI 直接独立设置。
 ---
 


### PR DESCRIPTION
## What

Follow-up to #348. That PR removed the static SQL apply template and made the orchestrator render apply SQL from the baseline JSON at runtime, and updated the skill **body** — but the `tokenkey-anthropic-oauth-config` skill **frontmatter `description`** still read "1 个 SQL 模板固化写入". This corrects that one stale line so the skill summary matches the code.

## Scope

- One-line frontmatter wording change in `.cursor/skills/tokenkey-anthropic-oauth-config/SKILL.md`.
- **no-web-impact**: docs-only; no code/web surface.
- Merge mode: **Squash and merge** (TK-originated docs fix).

🤖 Generated with [Claude Code](https://claude.com/claude-code)