### PR TITLE
chore(ops/anthropic): bump L5 max_sessions 30→50 + add traffic-profile skill (no-web-impact)

### DIFF
--- a/.cursor/skills/tokenkey-anthropic-oauth-config/SKILL.md
+++ b/.cursor/skills/tokenkey-anthropic-oauth-config/SKILL.md
@@ -61,6 +61,15 @@ python3 $MGR verify --plan $JOBDIR/plan.json
 - Stage 5 verify 必须跑；drift → operator 决定补 apply 或回滚
 - snapshot 出于"先查后说"原则：禁止凭记忆断言字段值，所有断言都来自一次 SSM read
 
+### 改 tier baseline 值（如 L5 max_sessions 30→50）必跟的一步：提交 JSON
+
+tier baseline 的**唯一真值源**是 `deploy/aws/stage0/anthropic-oauth-stability-baselines-tiered.json`；apply 时只读它派生 SQL。若你为了改某个 tier 的基线值而**编辑了这个 JSON**，apply 到 live 后**必须把 JSON 改动经分支 + PR 落到 `origin/main`**（仓库纪律 §5.y，不直推）。否则：
+
+- 本地 JSON=新值、live=新值 → 你本地 `check` 通过；
+- 但 `origin/main` 仍是旧值 → 别人 fresh checkout / CI 跑 `check-edge-oauth-stability` 会把 live 报成 `extra_baseline_drift`（live↔repo 漂移）。
+
+只是把**某账号**改到**现有** tier（不动 JSON 数值）则无此跟进项——那是纯 live 写入，不涉及真值源变更。
+
 ## 2. 不在本流水线范围内（独立操作）
 
 本流水线**只写** edge anthropic OAuth account 的 tier 字段。下列写入面**不由本脚本管**：

--- a/.cursor/skills/tokenkey-online-log-troubleshooting/SKILL.md
+++ b/.cursor/skills/tokenkey-online-log-troubleshooting/SKILL.md
@@ -74,7 +74,16 @@ planned edge 默认不查；除非用户显式允许 `allow_planned=true`。
 
 ### 1.2 Prod / main gateway
 
-prod 目标优先从 deploy 文档和 CloudFormation/SSM 已知入口解析；如果不确定，先问或只查 GitHub/CI，不要猜 AWS 实例。若已有域名或 stack 名，先用只读 AWS CLI/CloudFormation describe 定位 instance id。
+prod 已固定（`api.tokenkey.dev`，AWS Graviton arm64）：**stack=`tokenkey-prod-stage0`，region=`us-east-1`**。直接解析 instance id（只读）：
+
+```bash
+REGION=us-east-1; STACK=tokenkey-prod-stage0
+IID=$(aws cloudformation describe-stacks --region "$REGION" --stack-name "$STACK" \
+  --query "Stacks[0].Outputs[?OutputKey=='InstanceId'].OutputValue" --output text)
+# 回退：若 Outputs 无 InstanceId，用 describe-stack-resources 取 AWS::EC2::Instance 的 PhysicalResourceId
+```
+
+栈若曾在 us-east-1 以外创建过，把 `REGION` 改成当时的 region（见 `deploy/aws/README.md`）。其余仍不确定的入口（新栈/新域名）才回到"先问或只查 CI、不猜实例"。
 
 ### 1.3 快速环境指纹
 
@@ -245,6 +254,8 @@ docker logs tokenkey --since '<start_z>' --until '<end_z>' 2>&1 \
   | grep -E 'GROUP_RPM_EXCEEDED|USER_RPM|rate limit|429|529|overload|temp.*unsched' \
   | tail -n 200 || true
 ```
+
+> **裸数字误报坑（实测）**：`grep -c '429'` / `'529'` 会命中 request_id/UUID、`body_bytes`、`latency_ms`、`content_len` 里的子串，给出几十上百的**假计数**。判**真实** HTTP 429/529 要么解析 JSON 看 `status_code` 字段，要么匹配语义标记 `rate_limit_error` / `overloaded_error` / `too_many_requests`，**不要数裸的 429/529**。`ops_error_logs` 的 `status_code` / `upstream_status_code` 列才是权威，应优先用 §4.2 的 SQL 聚合而非 grep 数字。
 
 **Anthropic thinking signature：**
 

--- a/.cursor/skills/tokenkey-online-traffic-profile/SKILL.md
+++ b/.cursor/skills/tokenkey-online-traffic-profile/SKILL.md
@@ -1,0 +1,222 @@
+---
+name: tokenkey-online-traffic-profile
+description: >-
+  Read-only TokenKey production/edge traffic-profiling workflow. Reconstructs
+  per-minute request-traffic series for the past N hours per account — base RPM
+  (request-start minute), sticky vs non-sticky (load-balance) RPM split, active
+  sessions (idle-window), and peak concurrency — then compares each against its
+  cap (base_rpm / rpm_sticky_buffer / max_sessions / concurrency) and flags
+  which limit is being touched. Use when asked to profile online traffic, see
+  per-minute RPM/session/concurrency, validate the admin account-card gauges
+  (concurrency 1/8, $/window cost, sessions 16/30, RPM 3/28), or explain "no
+  available accounts" / throttling without ad-hoc command guessing.
+---
+
+# TokenKey：线上请求流量画像（逐分钟 RPM / sticky / session / concurrency）
+
+把"过去 N 小时某账号/edge 的流量与限额命中情况"固定成稳定的**只读**重建流程。专治：流量趋势、admin 账号卡片四个 gauge 的核对、`no available accounts` / 节流的归因。
+
+权威纪律以仓库根 `CLAUDE.md` 为准。本 skill **只读**：只跑 `docker logs` / `psql SELECT` / `redis-cli` 读命令 / `aws ... describe|get|send-command(只读脚本)`。任何写配置、改 `max_sessions`/`base_rpm`、重启、部署都必须另行显式确认，并交给写入面 skill（`tokenkey-anthropic-oauth-config` 等）。
+
+环境识别（prod/edge 实例解析、容器名、SSM 执行、UTC+本地双写、小输出优先）与 `tokenkey-online-log-troubleshooting` 完全一致——本 skill 复用它的 §1/§2/§3，不重复；下面只写流量画像特有的部分。
+
+## 调用参数
+
+```text
+/tokenkey-online-traffic-profile target=<prod|edge:<id>|domain> [hours=<N，默认1>] [account=<id|name|all，默认all>] [model=<name>] [path=/v1/messages] [bucket=minute|5min] [allow_planned=false]
+```
+
+| 参数 | 语义 |
+|---|---|
+| `target` | `prod`、`edge:us1`/`edge:uk1`/…，或域名。决定 region/instance。 |
+| `hours` | 回看小时数。注意 docker logs 仅覆盖容器 `Up` 时长——先 `docker ps` 看 `tokenkey` 启动多久，超出部分日志不存在。 |
+| `account` | 账号 id 或 name；`all` 则先列该 platform 的可调度账号再画像。 |
+| `bucket` | 默认按分钟；流量大或回看长时用 `5min`。 |
+
+默认：`hours=1`、`account=all`、`path=/v1/messages`、`mode=只读`。planned edge 不查除非 `allow_planned=true`。
+
+## 0) 为什么必须"逐分钟重建"，不能只看 gauge
+
+admin 账号卡片四个数字是**瞬时 gauge**，主要读 Redis，**没有逐分钟历史**：
+
+| 卡片 gauge | Redis 落地 key | 历史保留 |
+|---|---|---|
+| 🎛 并发 `cur/concurrency` | `concurrency:account:{id}`（zset，活跃 slot） | ❌ 仅当前；`wait:account:{id}` 为等待槽 |
+| 💲 窗口费用 `$x/$limit` | `window_cost:account:{id}`（string，**5h 窗边界缓存**，≠简单尾随求和） | ❌ 仅当前；底层 `usage_logs` 有逐请求成本 |
+| 👥 会话 `cur/max_sessions` | `session_limit:account:{id}`（zset，按 `session_idle_timeout_minutes` 过期，默认 5、可被 extra 覆盖） | ❌ 仅当前 |
+| 🕐 RPM `cur/base_rpm [T]` | `rpm:{id}:{unixMinute}`，**TTL=120s** | ❌ 只留最近 ~2 分钟 |
+
+**结论**：除“当前快照”外，过去 N 小时的逐分钟值只能从 **access log（`http request completed`）+ `sticky.scheduler_entry` + `usage_logs`** 重建。这是本 skill 的核心。
+
+**已踩过的坑**：
+1. `grep -c '429'`/`'529'` 是**误报**——会命中 UUID、`body_bytes`、`latency_ms` 里的子串。判真实上游限流/过载要解析 JSON 或匹配 `rate_limit_error`/`overloaded_error`，不要数裸数字。
+2. 瞬时 gauge ≤ cap **不代表**历史没触顶（峰值已过、配置事后被改）。务必重建；并确认 cap 在事发时段的取值（如 `max_sessions` 被从 16 改到 30）。
+3. account 被判不可用/`no available accounts` 时三个本地 cap（concurrency/max_sessions/base_rpm）都能触发且**不留专门日志**，prod Debug 级 `sticky.layer*` 默认关——只有重建数据能区分。
+4. **不要先认定 base_rpm**（本 skill 第一版排障就误判过）。判别口诀：
+   - `no available` 那一分钟若 **RPM<base_rpm 且 conc<concurrency**（低负载也 503）→ 几乎一定是 **session 面**：算 `全局活跃会话 vs Σ(max_sessions)`。
+   - 现象是「**粘性请求 200、非粘性(新会话/sticky miss)503**」→ 黄区 RPM **或** session 满二选一；用 RPM 序列区分：RPM≥base 选黄区，RPM<base 选 session。
+   - 只有某分钟 RPM 真的 ≥base_rpm 才轮到 base_rpm 黄/红区。
+
+## 1) 先抓 cap 配置 + 当前快照（一次 SSM）
+
+```sql
+-- accounts cap 配置（cap 在事发时段的真实值）
+SELECT id,name,type,status,schedulable,concurrency,
+       extra->>'base_rpm'                    AS base_rpm,
+       extra->>'rpm_strategy'                AS rpm_strategy,      -- tiered | sticky_exempt
+       extra->>'rpm_sticky_buffer'           AS rpm_sticky_buffer, -- 黄区宽度 override
+       extra->>'max_sessions'                AS max_sessions,
+       extra->>'session_idle_timeout_minutes' AS idle_min,         -- 默认 5
+       extra->>'window_cost_limit'           AS window_cost_limit,
+       extra->>'stability_tier'              AS tier
+FROM accounts
+WHERE platform='anthropic' AND ($ACCOUNT='all' OR id=$ID OR name='$NAME')
+ORDER BY id;
+```
+
+RPM 三区（代码 `Account.CheckRPMSchedulability` / `isAccountSchedulableForRPM`）：
+- `buffer = rpm_sticky_buffer`（若设）`else concurrency + max_sessions`，下限 `base_rpm/5`。
+- **绿区** `RPM < base_rpm` → 任何请求可调度。
+- **黄区** `base_rpm ≤ RPM < base_rpm+buffer` → **仅粘性**（非粘性负载均衡路径会跳过该账号，line `isAccountSchedulableForRPM(acc,false)`）。
+- **红区** `RPM ≥ base_rpm+buffer` → 完全不可调度。`rpm_strategy=sticky_exempt` 时无红区。
+
+当前 Redis 快照（确认这 4 个数字"确有落地"，并校准）。Redis **无密码**：不要带 `-a`。
+
+> **stderr 噪声坑（实测）**：本机即使**不带** `-a`，`redis-cli` 仍可能往 **stderr** 刷一堆 `AUTH failed: ERR AUTH <password> called without any password configured`（容器里设了 `REDISCLI_AUTH`）。这是**无害噪声**——**stdout 的取值是正确的**。读结果只看 stdout，别被 stderr 吓到；SSM `get-command-invocation` 时分别看 `StandardOutputContent`（值）与 `StandardErrorContent`（噪声），不要因 stderr 非空就判失败。
+
+```bash
+RC='docker exec tokenkey-redis redis-cli'
+for id in $IDS; do
+  echo "acct $id  conc=$($RC ZCARD concurrency:account:$id)  sess=$($RC ZCARD session_limit:account:$id)  wcost=$($RC GET window_cost:account:$id)"
+done
+# rpm 当前分钟（unixMinute=服务端秒/60；TTL=120s，过去分钟已过期）：
+$RC EVAL "local t=redis.call('TIME'); return redis.call('GET','rpm:'..ARGV[1]..':'..math.floor(tonumber(t[1])/60)) or '0'" 0 $ID
+```
+
+## 2) 拉 access log（host 临时文件，只回摘要）
+
+```bash
+# SSM 命令里：容器名以 docker ps 实测为准（常见 tokenkey / tokenkey-postgres / tokenkey-redis）
+docker logs tokenkey --since ${HOURS}h 2>&1 | grep 'http request completed' | grep '/v1/messages' > /tmp/acc.txt
+docker logs tokenkey --since ${HOURS}h 2>&1 | grep 'sticky.scheduler_entry'                       > /tmp/sse.txt
+wc -l /tmp/acc.txt /tmp/sse.txt
+```
+
+`http request completed` JSON 关键字段：`account_id`、`path`、`status_code`、`latency_ms`、`completed_at`(UTC, `...Z`)。
+`sticky.scheduler_entry` JSON：`session_hash`、`sticky_account_id`(>0=粘性命中,0=无绑定走负载均衡)、`sticky_source`(prefetch/…)、`excluded_count`(cooldown 预排除数)。
+
+## 3) 逐分钟重建（远端 Python，输出聚合表）
+
+把下面整段放进 SSM 命令的 heredoc 远端执行。`ACCTS` 改成目标账号 id；`IDLE_MIN` 用 §1 查到的 `session_idle_timeout_minutes`。
+
+```python
+import json, re, datetime as dt, collections
+ACCTS=[1,4]; IDLE_MIN=8           # ← 按 §1 实测填写
+START_BUCKET='%H:%M'              # 'minute'; 5min 改成自定义
+def parse(fn):
+    out=[]
+    for ln in open(fn):
+        m=re.search(r'\{.*\}$',ln)
+        if not m: continue
+        try: o=json.loads(m.group(0))
+        except: continue
+        out.append((ln[:19],o))
+    return out
+
+# --- access log: RPM(按开始分钟) + 峰值并发 + status ---
+iv={a:[] for a in ACCTS}; rpm={a:collections.Counter() for a in ACCTS}; st={a:collections.Counter() for a in ACCTS}
+for _,o in parse('/tmp/acc.txt'):
+    if o.get('path')!='/v1/messages': continue
+    a=o.get('account_id'); lat=o.get('latency_ms'); ca=o.get('completed_at')
+    if a not in ACCTS or not ca or not isinstance(lat,(int,float)): continue
+    end=dt.datetime.fromisoformat(ca.replace('Z','+00:00')); start=end-dt.timedelta(milliseconds=lat)
+    iv[a].append((start,end)); rpm[a][start.strftime(START_BUCKET)]+=1; st[a][o.get('status_code')]+=1
+def peak_conc(intervals):
+    res=collections.Counter()
+    if not intervals: return res
+    lo=min(s for s,_ in intervals).replace(second=0,microsecond=0); hi=max(e for _,e in intervals)
+    t=lo
+    while t<=hi:
+        c=sum(1 for s,e in intervals if s<=t<e)
+        k=t.strftime(START_BUCKET); res[k]=max(res[k],c); t+=dt.timedelta(seconds=5)
+    return res
+pc={a:peak_conc(iv[a]) for a in ACCTS}
+
+# --- sticky vs non-sticky RPM split（按 sticky_account_id 落到分钟）---
+srpm={a:collections.Counter() for a in ACCTS}; nrpm=collections.Counter()  # 非粘性 sticky_account_id=0，账号未知，单列
+for ts,o in parse('/tmp/sse.txt'):
+    try: t=dt.datetime.strptime(ts,'%Y-%m-%dT%H:%M:%S')
+    except: continue
+    k=t.strftime(START_BUCKET); aid=o.get('sticky_account_id')
+    if aid in ACCTS: srpm[aid][k]+=1
+    elif aid in (0,None): nrpm[k]+=1
+
+# --- 活跃会话（global，trailing IDLE 窗）---
+rows=[]
+for ts,o in parse('/tmp/sse.txt'):
+    sh=o.get('session_hash')
+    try: t=dt.datetime.strptime(ts,'%Y-%m-%dT%H:%M:%S')
+    except: continue
+    if sh: rows.append((t,sh,o.get('sticky_account_id')))
+sess=collections.Counter()
+if rows:
+    lo=min(r[0] for r in rows).replace(second=0); hi=max(r[0] for r in rows).replace(second=0); W=dt.timedelta(minutes=IDLE_MIN); t=lo
+    while t<=hi:
+        seen=set(sh for rt,sh,_ in rows if t-W < rt <= t+dt.timedelta(seconds=59))
+        sess[t.strftime(START_BUCKET)]=len(seen); t+=dt.timedelta(minutes=1)
+
+mins=sorted(set().union(*[set(rpm[a]) for a in ACCTS],*[set(pc[a]) for a in ACCTS],set(sess)))
+hdr='min  | '+' '.join('a%d:rpm/sRpm/conc/st200'%a for a in ACCTS)+' | nonStickyRpm activeSess(global)'
+print(hdr)
+for mn in mins:
+    seg=' '.join('%2d/%2d/%2d/%-3d'%(rpm[a][mn],srpm[a][mn],pc[a][mn],st[a].get(200,0)) for a in ACCTS)
+    print('%s | %s | %3d  %3d'%(mn,seg,nrpm[mn],sess[mn]))
+for a in ACCTS:
+    print('acct%d totals reqs=%d rpm_max=%d conc_max=%d statuses=%s'%(a,len(iv[a]),max(rpm[a].values() or [0]),max(pc[a].values() or [0]),dict(st[a])))
+```
+
+成本逐分钟（DB，独立 SQL；`window_cost` gauge 是 5h 窗缓存，逐分钟用 `usage_logs`）：
+
+```sql
+SELECT to_char(date_trunc('minute',created_at),'HH24:MI') min_utc, account_id,
+       count(*) reqs, round(sum(total_cost),4) cost
+FROM usage_logs
+WHERE account_id = ANY($IDS) AND created_at >= now()-interval '$HOURS hours'
+GROUP BY 1,2 ORDER BY 1,2;
+-- 5h 窗累计校准卡片 $ gauge：
+SELECT account_id, round(sum(total_cost),2) cost_5h FROM usage_logs
+WHERE account_id = ANY($IDS) AND created_at >= now()-interval '5 hours' GROUP BY 1;
+```
+
+## 4) 解读规则（哪个参数触顶）
+
+| 观察 | 判定 |
+|---|---|
+| 某分钟 `rpm ≥ base_rpm` 且非粘性请求失败/`no available` | **base_rpm 黄/红区**：非粘性被 RPM 闸挤出。 |
+| `peak_conc ≈ concurrency` 且新请求 429/排队超时 | **concurrency 触顶**（`Concurrency limit exceeded` 或 `umq`/wait 超时）。 |
+| `global activeSess > Σ(max_sessions)` 且**粘性 200、非粘性 503** | **max_sessions 触顶**：新会话被 `checkAndRegisterSession` 拒（`ErrNoAvailableAccounts`，gateway_service.go ~line 2121），已绑定会话 `ZSCORE` 命中放行。 |
+| RPM<base、conc<max、sess 未饱和，却仍 503 | 查上游：解析 JSON 找 `rate_limit_error`/`overloaded_error`/`cooldown`/`rate_limit_reset_at`，**别数裸 429/529**。 |
+| `nonStickyRpm` 高、`activeSess` 接近 Σmax | 单 CLI 派生大量短会话 → 会话面先到顶（典型：edge 仅 2 账号时）。 |
+
+判 session 饱和的关键不等式：**全局活跃会话 > Σ(max_sessions over 可调度账号)** ⇒ 必有新会话落空。务必用**事发时段**的 `max_sessions`（可能被事后调过）。
+
+## 5) 输出模板
+
+```text
+target=<...>  time_window_utc=<..>..<..>  time_window_local=<..>  bucket=minute
+accounts: <id(name): base_rpm=.. buffer=.. max_sessions=.. concurrency=.. idle=..m>
+caps_snapshot(redis now): <acct: conc/sess/wcost>
+
+peaks(过去Nh):
+- acct<id>: rpm_max=.. (<min>)  conc_max=..  activeSess_max(global)=..  reqs=..  5h_cost=$..
+limit_touched: <base_rpm | concurrency | max_sessions | none/upstream>  置信度 high|med|low
+evidence: <触顶分钟与现象的对应；区分 final status vs upstream events>
+
+per_minute_table: <见 §3 输出；超长则写 $CLAUDE_JOB_DIR 文件，仅回摘要+路径>
+```
+
+证据不足（如 docker logs 未覆盖整段、账号无流量）就说明并缩短 `hours` 或换 target，不要外推。
+
+## 6) 交接
+
+需要改 cap（`base_rpm`/`max_sessions`/`concurrency`/priority）→ 不在本 skill 内写；输出 plan 后交 `tokenkey-anthropic-oauth-config`（tier baseline / account 字段）或 admin UI（`group.rpm_limit` 独立设置）。冗余不足导致落空 503 的同类问题参见运维记忆与 `tokenkey-online-log-troubleshooting`。

--- a/deploy/aws/stage0/anthropic-oauth-stability-baselines-tiered.json
+++ b/deploy/aws/stage0/anthropic-oauth-stability-baselines-tiered.json
@@ -204,7 +204,7 @@
         "extra": {
           "base_rpm": 28,
           "rpm_sticky_buffer": 20,
-          "max_sessions": 30,
+          "max_sessions": 50,
           "session_idle_timeout_minutes": 8,
           "window_cost_limit": 1500,
           "window_cost_sticky_reserve": 0


### PR DESCRIPTION
## What

1. **L5 tier baseline `max_sessions` 30 → 50** in the single-source JSON `deploy/aws/stage0/anthropic-oauth-stability-baselines-tiered.json`.
2. **New read-only skill `tokenkey-online-traffic-profile`** — per-minute reconstruction of base RPM / sticky-vs-non-sticky RPM / active sessions / peak concurrency for the past N hours, vs each cap, to flag which limit is being touched.
3. **Skill hardening** distilled from this session's investigation (see below).

## Why (us1 traffic profiling)

edge-us1 has only **2 L5 OAuth accounts** serving a single heavy Claude Code user. Combined session capacity `2×30=60` was repeatedly exceeded — global active sessions peaked **~62** in the 8-min idle window — so new (non-sticky) sessions found **both** accounts' session ZSET full and got `ErrNoAvailableAccounts` → **503 "no available accounts"**. Per-minute reconstruction showed RPM (≤23 vs base 28) and concurrency (≤4 vs 8) had large headroom; **`max_sessions` was the sole binding cap**.

- Already **applied to live us1 #1/#4** via the `tokenkey-anthropic-oauth-config` pipeline (snapshot→plan→apply→verify, **drift=0**). This PR lands the JSON source of truth so repo↔live don't drift (the `anthropic tier baseline single-source` preflight guard depends on it).
- Scope of live change = us1 only (uk1/sg1/fra1 are `deployable=false`). New combined capacity `2×50=100` vs observed peak ~62.

## Skill hardening
- **traffic-profile**: `redis-cli` stderr `AUTH failed` is harmless noise (stdout values are correct); "don't pre-blame `base_rpm`" heuristic — low-load 503 ⇒ session面; sticky-200 / non-sticky-503 differential maps to yellow-zone RPM **or** session-cap, disambiguated by the RPM series.
- **online-log-troubleshooting**: pin prod resolution (`tokenkey-prod-stage0` / `us-east-1`); warn that bare `grep 429/529` false-matches UUID / byte-count substrings — use `ops_error_logs.status_code` or `rate_limit_error`/`overloaded_error` markers.
- **anthropic-oauth-config**: after editing the baseline JSON, the change MUST land via PR or a fresh-checkout guard reports live↔repo drift.

## Notes
- Pure docs/config; no backend/frontend code → `no-web-impact`.
- `scripts/preflight.sh`: **PASS** (run in an isolated worktree; new-api sibling symlinked for the cross-repo Go check).
- Merge mode per repo §5.y: **Squash and merge** (TK-originated chore PR).

🤖 Generated with [Claude Code](https://claude.com/claude-code)