### PR TITLE
fix(accounts): auto-refresh updates RPM gauge (current_rpm)

### DIFF
--- a/backend/internal/web/dist/frontend-source.json
+++ b/backend/internal/web/dist/frontend-source.json
@@ -1,7 +1,7 @@
 {
   "algorithm": "sha256(git-ls-files:path,size,content)",
   "file_count": 436,
-  "hash": "d49591c9056b44c3f5b912420c20bde7ee225ba7ee7af2f7bfe807e26f99c58c",
+  "hash": "8985ae4d2290fd5c6326e7933c2b2fbe2a7dcc0e3a56817ea48b0729a19a5958",
   "schema": 1,
   "source": "frontend/"
 }

--- a/frontend/src/views/admin/AccountsView.vue
+++ b/frontend/src/views/admin/AccountsView.vue
@@ -845,6 +845,7 @@ const shouldReplaceAutoRefreshRow = (current: Account, next: Account) => {
     current.current_concurrency !== next.current_concurrency ||
     current.current_window_cost !== next.current_window_cost ||
     current.active_sessions !== next.active_sessions ||
+    current.current_rpm !== next.current_rpm ||
     current.schedulable !== next.schedulable ||
     current.status !== next.status ||
     current.rate_limit_reset_at !== next.rate_limit_reset_at ||

--- a/scripts/sentinels/frontend-tk.json
+++ b/scripts/sentinels/frontend-tk.json
@@ -50,9 +50,10 @@
         ":sticky-edge-hints=\"false\"",
         "Wrap-first column policy",
         "const wrap = (maxW: string) =>",
-        "wrap('max-w-[15rem]')"
+        "wrap('max-w-[15rem]')",
+        "current.current_rpm !== next.current_rpm"
       ],
-      "rationale": "The TK callsite for fluid+stickyEdgeHints opt-outs (first two literals), the wrap-first column-class policy comment (third literal), and the per-column max-width discipline (fourth + fifth literals). `wrap` as a function (not a plain string constant) means every column carries an explicit cap — an upstream merge that flattens it back to a bare string would silently drop the caps and the table overflows again at 100% browser zoom. The fifth literal anchors the usage column at 15rem (the widest cap), chosen because it is uniquely wide and unlikely to clash with any upstream string. Without the max-width caps, `min-w-0 align-top` alone is insufficient: browser table-auto still sizes columns to their natural max-content width when there is no explicit upper bound."
+      "rationale": "The TK callsite for fluid+stickyEdgeHints opt-outs (first two literals), the wrap-first column-class policy comment (third literal), and the per-column max-width discipline (fourth + fifth literals). `wrap` as a function (not a plain string constant) means every column carries an explicit cap — an upstream merge that flattens it back to a bare string would silently drop the caps and the table overflows again at 100% browser zoom. The fifth literal anchors the usage column at 15rem (the widest cap), chosen because it is uniquely wide and unlikely to clash with any upstream string. Without the max-width caps, `min-w-0 align-top` alone is insufficient: browser table-auto still sizes columns to their natural max-content width when there is no explicit upper bound. The sixth literal anchors current_rpm inside shouldReplaceAutoRefreshRow's auto-refresh field whitelist: current_rpm is a Redis-backed realtime gauge that never bumps updated_at, so an upstream merge that drops it from the whitelist would silently regress the 6s auto-refresh back to RPM-stale (only manual refresh would update the RPM badge)."
     },
     {
       "path": "frontend/src/views/admin/GroupsView.vue",


### PR DESCRIPTION
## 背景

账号管理页面的「自动刷新（6s）」与手动「刷新」更新范围不一致：手动刷新会全量替换所有行，自动刷新只在 `shouldReplaceAutoRefreshRow` 白名单命中时才替换该行。

## 根因（代码事实）

`shouldReplaceAutoRefreshRow`（`AccountsView.vue`）是一个字段白名单，列出了那些**不会 bump `updated_at`** 的 Redis 实时 gauge（`current_concurrency` / `current_window_cost` / `active_sessions`）。`current_rpm` 同样是 Redis 实时计数、不 bump `updated_at`，却**遗漏未列入**白名单。

后果：RPM 变化时，自动刷新即使从后端拿到了新数据，也因白名单未命中而保留旧行 → RPM 徽标只在手动刷新（无条件全量替换）时更新。这正是用户观察到的「自动刷新范围更窄」。

> 注：与 upstream 的 `/usage` 拉取路径无关 —— 那条路径（5h/7d 用量）由 `usageManualRefreshToken` 控制、有意限定在人工刷新（带 5 分钟缓存），不应塞进 6s 自动刷新去高频打上游用量 API。本 PR 只修 TK 侧列表实时字段。

## 改动

- `AccountsView.vue`：白名单补 `current.current_rpm !== next.current_rpm`（单行）。
- `scripts/sentinels/frontend-tk.json`：把该白名单行加入 AccountsView sentinel 锚点 + rationale，防止未来 upstream merge 静默删掉它再次回退。
- `backend/internal/web/dist/frontend-source.json`：按 release asset contract 重建的源码 hash manifest。

## 验证

- `pnpm typecheck` ✅ / `pnpm lint:check`（0 errors）✅
- `pnpm --dir frontend run build` ✅
- `scripts/preflight.sh` PASS（含 sentinel registry gate / upstream override marker / dist freshness）

🤖 Generated with [Claude Code](https://claude.com/claude-code)