### PR TITLE
feat(accounts): show total sticky RPM buffer on capacity badge

### DIFF
--- a/backend/internal/web/dist/frontend-source.json
+++ b/backend/internal/web/dist/frontend-source.json
@@ -1,7 +1,7 @@
 {
   "algorithm": "sha256(git-ls-files:path,size,content)",
   "file_count": 436,
-  "hash": "8985ae4d2290fd5c6326e7933c2b2fbe2a7dcc0e3a56817ea48b0729a19a5958",
+  "hash": "97842475658c00f5389a01e21bddda32160340f9c8f54c662058bf906cd6396f",
   "schema": 1,
   "source": "frontend/"
 }

--- a/frontend/src/components/account/AccountCapacityCell.vue
+++ b/frontend/src/components/account/AccountCapacityCell.vue
@@ -22,7 +22,7 @@
     </CapacityBadge>
 
     <!-- RPM 限制 -->
-    <CapacityBadge v-if="showRpmLimit" :color-class="rpmClass" :tooltip="rpmTooltip" :current="currentRPM" :max="account.base_rpm!" :suffix="rpmStrategyTag">
+    <CapacityBadge v-if="showRpmLimit" :color-class="rpmClass" :tooltip="rpmTooltip" :current="currentRPM" :max="account.base_rpm!" :suffix="rpmSuffix">
       <svg class="h-2.5 w-2.5" fill="none" viewBox="0 0 24 24" stroke-width="1.5" stroke="currentColor">
         <path stroke-linecap="round" stroke-linejoin="round" d="M12 6v6h4.5m4.5 0a9 9 0 1 1-18 0 9 9 0 0 1 18 0Z" />
       </svg>
@@ -130,12 +130,19 @@ const showRpmLimit = computed(() =>
 
 const currentRPM = computed(() => props.account.current_rpm ?? 0)
 const rpmStrategy = computed(() => props.account.rpm_strategy || 'tiered')
-const rpmStrategyTag = computed(() => rpmStrategy.value === 'sticky_exempt' ? '[S]' : '[T]')
 
 const rpmBuffer = computed(() => {
   const base = props.account.base_rpm || 0
   return props.account.rpm_sticky_buffer ?? (base > 0 ? Math.max(1, Math.floor(base / 5)) : 0)
 })
+
+// sticky_exempt has no finite sticky buffer (unlimited sticky headroom), so it
+// keeps the bare [S] tag; tiered surfaces the actual buffer count as (+N sticky).
+const rpmSuffix = computed(() =>
+  rpmStrategy.value === 'sticky_exempt'
+    ? '[S]'
+    : t('admin.accounts.capacity.rpm.stickyBufferSuffix', { buffer: rpmBuffer.value })
+)
 
 const rpmClass = computed(() => {
   if (!showRpmLimit.value) return ''

--- a/frontend/src/i18n/locales/en.ts
+++ b/frontend/src/i18n/locales/en.ts
@@ -3183,7 +3183,8 @@ export default {
           tieredBlocked: 'RPM limit (Tiered) - Blocked | Buffer: {buffer}',
           stickyExemptNormal: 'RPM limit (Sticky Exempt) - Normal',
           stickyExemptWarning: 'RPM limit (Sticky Exempt) - Approaching limit',
-          stickyExemptOver: 'RPM limit (Sticky Exempt) - Over limit, sticky only'
+          stickyExemptOver: 'RPM limit (Sticky Exempt) - Over limit, sticky only',
+          stickyBufferSuffix: '(+{buffer} sticky)'
         },
         quota: {
           exceeded: 'Quota exceeded, account paused',

--- a/frontend/src/i18n/locales/zh.ts
+++ b/frontend/src/i18n/locales/zh.ts
@@ -3219,7 +3219,8 @@ export default {
           tieredBlocked: 'RPM 限制 (三区模型) - 已阻塞 | 缓冲区: {buffer}',
           stickyExemptNormal: 'RPM 限制 (粘性豁免) - 正常',
           stickyExemptWarning: 'RPM 限制 (粘性豁免) - 接近阈值',
-          stickyExemptOver: 'RPM 限制 (粘性豁免) - 超限，仅粘性会话'
+          stickyExemptOver: 'RPM 限制 (粘性豁免) - 超限，仅粘性会话',
+          stickyBufferSuffix: '(+{buffer} 粘性)'
         },
         quota: {
           exceeded: '配额已用完，账号暂停调度',

--- a/scripts/sentinels/frontend-tk.json
+++ b/scripts/sentinels/frontend-tk.json
@@ -268,6 +268,28 @@
         "v-if=\"viewMode === 'my' && !loading"
       ],
       "rationale": "PricingView.vue must keep the per-user 'Your Menu' branch wired: (1) calling getMePricingCatalog (otherwise the page only ever shows the public LiteLLM catalog), (2) defaulting authenticated users to viewMode='my' on mount, and (3) the v-if guard that gates the key-picker / group-switcher toolbar to the 'my' view. Dropping any one silently regresses to upstream-style flat-catalog behavior even though the segmented control still renders."
+    },
+    {
+      "path": "frontend/src/components/account/AccountCapacityCell.vue",
+      "must_contain": [
+        ":suffix=\"rpmSuffix\"",
+        "admin.accounts.capacity.rpm.stickyBufferSuffix"
+      ],
+      "rationale": "TK diverges the RPM capacity badge suffix from upstream's bare strategy tag: tiered accounts surface the actual sticky-buffer headroom as (+N sticky) instead of upstream's [T], so operators can read the total sticky capacity (base_rpm + rpm_sticky_buffer) directly off the account card. This is a cosmetic-but-load-bearing operator affordance on an upstream-owned file — upstream owns AccountCapacityCell.vue and an upstream merge that restores :suffix=\"rpmStrategyTag\" would compile cleanly while silently reverting the badge to [T] and dropping the buffer readout. The two literals pin the template wiring (rpmSuffix binding) and the i18n key reference; the locale strings themselves are anchored in the en.ts / zh.ts sentinels below."
+    },
+    {
+      "path": "frontend/src/i18n/locales/en.ts",
+      "must_contain": [
+        "stickyBufferSuffix: '(+{buffer} sticky)'"
+      ],
+      "rationale": "English RPM capacity badge sticky-buffer suffix. Renders as (+N sticky) on tiered accounts. Locked in lockstep with the zh.ts counterpart so an upstream locale merge cannot drop one language and leave the badge showing a raw i18n path."
+    },
+    {
+      "path": "frontend/src/i18n/locales/zh.ts",
+      "must_contain": [
+        "stickyBufferSuffix: '(+{buffer} 粘性)'"
+      ],
+      "rationale": "Chinese RPM capacity badge sticky-buffer suffix. Moves in lockstep with the en.ts counterpart above so neither language silently regresses to a raw key during an i18n upstream merge."
     }
   ]
 }


### PR DESCRIPTION
## 背景

账号卡片的 RPM 徽标原本显示 `current / base_rpm [T]`，`[T]` 只表示「tiered 三区策略」，但**看不到实际的 sticky buffer 容量**。运维要知道「含 sticky 的总 RPM 容量」（`base_rpm + rpm_sticky_buffer`）只能去读颜色阈值或 hover tooltip，不直观。

## 改动

把 tiered 账号的 `[T]` 标签替换为 `(+N sticky)`，N = `rpm_sticky_buffer`（默认 `base_rpm/5`）：

- tiered：`5 / 28 (+5 sticky)` —— 28 base + 5 sticky 余量一目了然。
- sticky_exempt：保留 `[S]` —— 它没有有限 buffer（sticky 无限余量，`CheckRPMSchedulability` 里没有红区）。

> current_sticky（当前分钟里 sticky 实际占用了多少 RPM）**不在本 PR 范围**：RPM 计数器 `rpm:{id}:{min}` 是单一合并计数，不区分 sticky/非 sticky，要拆分需后端新增独立计数器（跨四层），另议。本 PR 只显示**已知的、确定的 total sticky 容量**（配置量）。

## 文件

- `AccountCapacityCell.vue`：`rpmStrategyTag` → `rpmSuffix`，tiered 走 i18n 的 `(+N sticky)`。
- `en.ts` / `zh.ts`：新增 `admin.accounts.capacity.rpm.stickyBufferSuffix`。
- `scripts/sentinels/frontend-tk.json`:该文件 upstream 拥有，新增 3 条 sentinel 锚点（rpmSuffix 绑定 + i18n key 引用 + 两个 locale 串），防 upstream merge 静默把 `:suffix` 改回 `rpmStrategyTag` 回退到 `[T]`。
- `frontend-source.json`：按 release asset contract 重建的源码 hash manifest。

## 验证

- `pnpm typecheck` ✅ / `pnpm lint:check`（0 errors）✅
- `pnpm --dir frontend run build` ✅
- `scripts/preflight.sh` PASS（含 frontend TK sentinel registry / upstream override marker / dist freshness）

🤖 Generated with [Claude Code](https://claude.com/claude-code)