### PR TITLE
chore(ops/anthropic): bump L5 max_sessions 50→60 (no-web-impact)

### DIFF
--- a/deploy/aws/stage0/anthropic-oauth-stability-baselines-tiered.json
+++ b/deploy/aws/stage0/anthropic-oauth-stability-baselines-tiered.json
@@ -204,7 +204,7 @@
         "extra": {
           "base_rpm": 28,
           "rpm_sticky_buffer": 20,
-          "max_sessions": 50,
+          "max_sessions": 60,
           "session_idle_timeout_minutes": 8,
           "window_cost_limit": 1500,
           "window_cost_sticky_reserve": 0


### PR DESCRIPTION
## 变更

L5 tier `max_sessions` 50 → 60，改在唯一真值源 `deploy/aws/stage0/anthropic-oauth-stability-baselines-tiered.json`（apply SQL 运行时从它派生）。

## 已 apply + verify（live）

经 `ops/anthropic/manage-anthropic-config.py` 5 阶段流水线在唯一 deployable edge **us1** 落地：

| 账号 | tier | max_sessions | 其余 baseline |
|---|---|---|---|
| id 1 `cc-am-or-ec2-5-1-b` | l5 | 50 → 60 | base_rpm 28 / buffer 20 / conc 8（不变）|
| id 4 `am-us-ec2-5-1-b` | l5 | 50 → 60 | base_rpm 28 / buffer 20 / conc 8（不变）|

- snapshot → check（全绿）→ plan → apply（2/2 step OK）→ **verify drift_count=0**
- us1 池级会话上限 100 → **120**

## 动机

逐分钟流量画像显示：us1 RPM/并发全程绿区，**会话是三个本地 cap 里余量最小的一项**（live 快照 acct1 一度 49/50，重建 activeSess 峰值 ~97–110）。提高会话上限接住更多单 CLI 派生的并发短会话；`base_rpm` / `sticky_buffer` / `concurrency` 故意不动。注意此变更不增加上游配额。

## 为什么需要这个 PR

JSON 是 tier baseline 唯一真值源、apply SQL 运行时派生。live 已是 60，必须让 `origin/main` 同步，否则 fresh checkout / CI 的 `check-edge-oauth-stability` 会把 live 报成 `extra_baseline_drift`（rule §5.y 不直推 main）。

🤖 Generated with [Claude Code](https://claude.com/claude-code)