### PR TITLE
feat(ops/anthropic): add plan-tier-bump batch + document tier-value-bump recipe (no-web-impact)

### DIFF
--- a/.cursor/skills/tokenkey-anthropic-oauth-config/SKILL.md
+++ b/.cursor/skills/tokenkey-anthropic-oauth-config/SKILL.md
@@ -32,8 +32,12 @@ python3 $MGR snapshot --out $JOBDIR/snap.json
 python3 $MGR check --snapshot $JOBDIR/snap.json
 
 # Stage 3 — Plan：声明 tier 变更意图，机器算 expected_after
+#   3a) 移单个账号到某 tier（不改 JSON 数值）：
 python3 $MGR plan-edge-account-tier \
   --edge uk1 --account en-ld-ec2-16-1-b --tier l2 \
+  --snapshot $JOBDIR/snap.json --out $JOBDIR/plan.json
+#   3b) 改某 tier 的基线值本身 → 一个多 action plan 覆盖该 tier 全部账号（见 §1 recipe）：
+python3 $MGR plan-tier-bump --tier l5 \
   --snapshot $JOBDIR/snap.json --out $JOBDIR/plan.json
 
 # Stage 4 — Apply：渲染 SQL → SSM → 写入；失败即停
@@ -51,9 +55,33 @@ python3 $MGR verify --plan $JOBDIR/plan.json
 |---|---|---|---|
 | snapshot | EC2 SSM 权限 | `snap.json`：每个 deployable edge 的 anthropic OAuth account 字段 | 0 / 2 error |
 | check | snap.json | 每个 edge 跑 `check-edge-oauth-stability.py`，union violation | 0 ok / 1 violation / 2 error |
-| plan-edge-account-tier | snap.json + edge+account+tier | `plan.json`：1 个 action（写 OAuth account 的 tier baseline） | 0 / 2 |
-| apply | plan.json + confirm | 渲染 SQL → SSM 执行 → 写 `apply-report.json` | 0 / 1 step failed / 2 |
-| verify | plan.json | 再 snapshot + 比对 `actions[*].expected_after` vs live；drift 列表 | 0 / 1 drift / 2 |
+| plan-edge-account-tier | snap.json + edge+account+tier | `plan.json`：1 个 action（把单个 account 移到某 tier） | 0 / 2 |
+| plan-tier-bump | snap.json + tier | `plan.json`：N 个 action（该 tier 全部账号，跨 deployable edge；已匹配的跳过） | 0 / 2 |
+| apply | plan.json + confirm | 逐 action 渲染 SQL → SSM 执行（支持多 action）→ 写 `apply-report.json`；任一 step 失败即停 | 0 / 1 step failed / 2 |
+| verify | plan.json | 再 snapshot + 比对**每个** `actions[*].expected_after` vs live；drift 列表 | 0 / 1 drift / 2 |
+
+### snapshot JSON 结构速查
+
+解析 `snap.json` 别猜形状（`edges` 是**按 edge_id 索引的 dict**，不是 list；账号在 **`oauth_accounts`**，不是 `accounts`）：
+
+```jsonc
+{
+  "version": <int>, "captured_at": "...Z",
+  "edges": {
+    "us1": {                       // key = edge_id
+      "deployable": true, "instance_id": "i-...", "region": "...",
+      "oauth_accounts": [          // ← 账号在这里
+        { "id": 1, "name": "...", "stability_tier": "l5",
+          "base_rpm": 28, "rpm_sticky_buffer": 20, "concurrency": 8,
+          "max_sessions": 60, "window_cost_limit": 1500, "status": "active", ... }
+      ]
+    },
+    "uk1": { "deployable": false, "skipped_reason": "planned; pass --allow-planned" }
+  }
+}
+```
+
+planned / 未快照的 edge 带 `skipped_reason`（或 `error`）且无 `oauth_accounts`——遍历时跳过它们（`plan-tier-bump` 已自动跳过）。
 
 ### 失败即停 + Pre-apply re-read
 
@@ -61,14 +89,38 @@ python3 $MGR verify --plan $JOBDIR/plan.json
 - Stage 5 verify 必须跑；drift → operator 决定补 apply 或回滚
 - snapshot 出于"先查后说"原则：禁止凭记忆断言字段值，所有断言都来自一次 SSM read
 
-### 改 tier baseline 值（如 L5 max_sessions 30→50）必跟的一步：提交 JSON
+### 两种 plan：移单个账号 vs 改整个 tier 的值
 
-tier baseline 的**唯一真值源**是 `deploy/aws/stage0/anthropic-oauth-stability-baselines-tiered.json`；apply 时只读它派生 SQL。若你为了改某个 tier 的基线值而**编辑了这个 JSON**，apply 到 live 后**必须把 JSON 改动经分支 + PR 落到 `origin/main`**（仓库纪律 §5.y，不直推）。否则：
+- **`plan-edge-account-tier`** —— 把**一个账号**从当前 tier **移到另一个 tier**（不改 JSON 数值）。纯 live 写入，无 JSON/PR 跟进。
+- **`plan-tier-bump`** —— 改**某个 tier 的基线数值本身**（如 L5 `max_sessions` 50→60）。这是 tier 级变更，影响**该 tier 上的每一个账号、跨所有 deployable edge**。
+
+> ⚠️ **改 tier 值时不要用 `plan-edge-account-tier` 逐个手敲账号**——很容易漏掉某个 edge 上的同 tier 账号，导致它静默停在旧值，下次 `check` 报 `extra_baseline_drift`。用 `plan-tier-bump`：它从 snapshot 枚举该 tier 的**全部** live 账号，产出**一个多 action plan**；`apply` / `verify` 本来就迭代 actions 数组，所以**一次 apply + 一次 verify** 覆盖整批。
+
+### 改 tier baseline 值（如 L5 max_sessions 50→60）的完整 recipe
+
+```bash
+# 0) 先编辑唯一真值源（apply 时只读它派生 SQL）
+#    deploy/aws/stage0/anthropic-oauth-stability-baselines-tiered.json
+#    把 tiers.l5.baseline.extra.max_sessions 改成新值
+python3 $MGR snapshot --out $JOBDIR/snap.json
+python3 $MGR check     --snapshot $JOBDIR/snap.json          # 改前基线全绿
+# 1) 枚举该 tier 全部账号 → 一个多 action plan（fields 已匹配的账号自动跳过）
+python3 $MGR plan-tier-bump --tier l5 \
+  --snapshot $JOBDIR/snap.json --out $JOBDIR/plan.json
+# 2) 一次 apply + 一次 verify 覆盖整批
+python3 $MGR apply  --plan $JOBDIR/plan.json --confirm yes-apply-anthropic-config-cascade
+python3 $MGR verify --plan $JOBDIR/plan.json                  # drift_count 必须=0
+# 3) JSON 改动经 分支 + PR 落 origin/main（见下）
+```
+
+`plan-tier-bump` 输出 `noop=true`（0 action）说明该 tier 当前账号字段已全等新值（多半是你已 apply 过又重跑）；要强制重写 credentials 端字段加 `--force-template-rewrite`。
+
+**必跟的一步：提交 JSON。** 若你为改 tier 基线值而**编辑了这个 JSON**，apply 到 live 后**必须把 JSON 改动经分支 + PR 落到 `origin/main`**（仓库纪律 §5.y，不直推）。否则：
 
 - 本地 JSON=新值、live=新值 → 你本地 `check` 通过；
 - 但 `origin/main` 仍是旧值 → 别人 fresh checkout / CI 跑 `check-edge-oauth-stability` 会把 live 报成 `extra_baseline_drift`（live↔repo 漂移）。
 
-只是把**某账号**改到**现有** tier（不动 JSON 数值）则无此跟进项——那是纯 live 写入，不涉及真值源变更。
+**不需要联动改 Go 代码。** preflight 的 `anthropic baseline sync` 检查（`scripts/sentinels/check-anthropic-baseline-sync.py`）只比对 **`policy.cooldown_tier_ttl_minutes`** 一个字段 ↔ `ratelimit_service.go` 常量；per-tier 的 `baseline.account.*` / `baseline.extra.*`（`max_sessions` / `base_rpm` / `rpm_sticky_buffer` / `concurrency` / `window_cost_limit` …）**都不镜像到 Go**，所以改这些 tier 值永远不触发该 check，无需改代码。
 
 ## 2. 不在本流水线范围内（独立操作）
 
@@ -109,7 +161,7 @@ operate 流程：
 |---|---|
 | snapshot 失败 / SSM 拒绝 | 校验 EC2 instance 在跑 / `edge-targets.json` / OIDC 权限 |
 | `apply --confirm` 拒绝 | 必须精确 `yes-apply-anthropic-config-cascade` |
-| tier baseline drift（check-edge-oauth-stability `extra_baseline_drift` / `account_field_drift`） | 用本流水线 plan-edge-account-tier 重写到对应 tier |
+| tier baseline drift（check-edge-oauth-stability `extra_baseline_drift` / `account_field_drift`） | 单账号用 plan-edge-account-tier 重写到对应 tier；整个 tier 值漂移（多账号）用 `plan-tier-bump --tier lN` 一次性重写 |
 | check guard 报 `status: drift` 且 `diffs[].path` 含 `/credentials/temp_unschedulable_rules`，但数值字段全等 | 加 `--force-template-rewrite` 让 plan 不再走 noop 短路，强制重写 credentials 端字段（snapshot/verify 不读 rules，所以默认 noop；这条 flag 是 escape hatch）。Apply 完跑一次 `check` 当真值 |
 | OAuth account `status=error/suspended` | OAuth 凭据问题（token 过期 / 403 / 上游禁用），见 OAuth 故障文档；不在本流水线范围 |
 | verify drift | operator 决定再 apply 或回滚（用 admin 前端按 plan.live_inputs 的 `edge_account_before` 反向写回） |

--- a/ops/anthropic/manage-anthropic-config.py
+++ b/ops/anthropic/manage-anthropic-config.py
@@ -462,19 +462,44 @@ def _find_edge_account(edge: dict, account_name: str) -> dict:
     return {}  # unreachable
 
 
-# Fields the apply template actually rewrites and verify re-reads. Equality on
-# all four means re-applying the same tier would be a no-op for the snapshot/
-# verify surface (credentials-side fields like temp_unschedulable_rules are not
-# tracked here — that is what --force-template-rewrite exists for).
-_TIER_MATCH_FIELDS = ("base_rpm", "rpm_sticky_buffer", "concurrency", "max_sessions")
+# Tier-baseline value fields that the apply SQL writes AND that this pipeline
+# owns end-to-end. The skip-as-noop gate (_tier_fields_match) and Stage-5 verify
+# must both cover this WHOLE set — otherwise a bump touching only one of them
+# (e.g. window_cost_limit-only) is silently skipped by plan-tier-bump and then
+# falsely verified clean, defeating the "no account left at the old value"
+# guarantee. snapshot already carries all of these.
+#
+# `priority` is deliberately EXCLUDED: it is owned by the separate
+# rebalance-anthropic-priority pipeline. Pulling it in here would make
+# plan-tier-bump fight the rebalancer (spurious actions on every rebalanced
+# account) and make verify flag false drift whenever priority was rebalanced.
+# (apply still writes the baseline priority — an existing cross-pipeline
+# interaction, out of scope here.) rate_multiplier is fixed at 1.0 by policy and
+# is likewise not a field anyone bumps, so it is left out to avoid float-equality
+# fragility. credentials-side fields (e.g. temp_unschedulable_rules) are not
+# tracked by snapshot/verify either — that is what --force-template-rewrite covers.
+_TIER_BASELINE_FIELDS = (
+    "base_rpm", "rpm_sticky_buffer", "concurrency", "max_sessions",
+    "window_cost_limit", "session_idle_timeout_minutes", "window_cost_sticky_reserve",
+)
 _ACCOUNT_BEFORE_FIELDS = (
     "id", "name", "concurrency", "stability_tier", "base_rpm",
-    "rpm_sticky_buffer", "max_sessions", "window_cost_limit", "status",
+    "rpm_sticky_buffer", "max_sessions", "session_idle_timeout_minutes",
+    "window_cost_limit", "window_cost_sticky_reserve", "status",
 )
 
 
 def _tier_fields_match(account: dict, baseline: dict) -> bool:
-    return all(account.get(k) == baseline.get(k) for k in _TIER_MATCH_FIELDS)
+    return all(account.get(k) == baseline.get(k) for k in _TIER_BASELINE_FIELDS)
+
+
+def _tier_expected_after(baseline: dict, tier_key: str) -> dict:
+    """The post-apply field values Stage-5 verify compares against live. Carries
+    stability_tier + every field this pipeline owns (_TIER_BASELINE_FIELDS), so
+    verify can confirm each one actually landed."""
+    exp = {"stability_tier": tier_key}
+    exp.update({k: baseline.get(k) for k in _TIER_BASELINE_FIELDS})
+    return exp
 
 
 def _build_tier_action(edge_id: str, account_name: str, baseline: dict,
@@ -488,13 +513,7 @@ def _build_tier_action(edge_id: str, account_name: str, baseline: dict,
         "target": {"env": "edge", "edge_id": edge_id, "account_name": account_name},
         "sql_source": "rendered-from-anthropic-oauth-stability-baselines-tiered.json",
         "variables": {"account_name": account_name, "stability_tier": tier_key},
-        "expected_after": {
-            "stability_tier": tier_key,
-            "base_rpm": baseline.get("base_rpm"),
-            "rpm_sticky_buffer": baseline.get("rpm_sticky_buffer"),
-            "concurrency": baseline.get("concurrency"),
-            "max_sessions": baseline.get("max_sessions"),
-        },
+        "expected_after": _tier_expected_after(baseline, tier_key),
     }
 
 
@@ -790,9 +809,13 @@ def cmd_verify(args: argparse.Namespace) -> int:
         if live is None:
             diffs.append("target not found in live snapshot")
         else:
-            for k in ("stability_tier", "base_rpm", "rpm_sticky_buffer", "concurrency", "max_sessions"):
-                if k in exp and live.get(k) != exp[k]:
-                    diffs.append(f"{k}: live={live.get(k)} expected={exp[k]}")
+            # Compare every field the plan declared in expected_after (it carries
+            # exactly the fields this pipeline owns — see _TIER_BASELINE_FIELDS),
+            # so verify stays faithful to what apply wrote without a second
+            # hand-maintained field list that could drift narrower.
+            for k, want in exp.items():
+                if live.get(k) != want:
+                    diffs.append(f"{k}: live={live.get(k)} expected={want}")
         if diffs:
             drift.append({
                 "step": action["step"],

--- a/ops/anthropic/manage-anthropic-config.py
+++ b/ops/anthropic/manage-anthropic-config.py
@@ -462,6 +462,46 @@ def _find_edge_account(edge: dict, account_name: str) -> dict:
     return {}  # unreachable
 
 
+# Fields the apply template actually rewrites and verify re-reads. Equality on
+# all four means re-applying the same tier would be a no-op for the snapshot/
+# verify surface (credentials-side fields like temp_unschedulable_rules are not
+# tracked here — that is what --force-template-rewrite exists for).
+_TIER_MATCH_FIELDS = ("base_rpm", "rpm_sticky_buffer", "concurrency", "max_sessions")
+_ACCOUNT_BEFORE_FIELDS = (
+    "id", "name", "concurrency", "stability_tier", "base_rpm",
+    "rpm_sticky_buffer", "max_sessions", "window_cost_limit", "status",
+)
+
+
+def _tier_fields_match(account: dict, baseline: dict) -> bool:
+    return all(account.get(k) == baseline.get(k) for k in _TIER_MATCH_FIELDS)
+
+
+def _build_tier_action(edge_id: str, account_name: str, baseline: dict,
+                       tier_key: str, step: int) -> dict:
+    """One apply action re-rendering ``account_name`` at ``tier_key``. The SQL is
+    derived from the JSON baseline at apply time; ``expected_after`` is what Stage
+    5 verify compares against live."""
+    return {
+        "step": step,
+        "kind": "edge_account_tier",
+        "target": {"env": "edge", "edge_id": edge_id, "account_name": account_name},
+        "sql_source": "rendered-from-anthropic-oauth-stability-baselines-tiered.json",
+        "variables": {"account_name": account_name, "stability_tier": tier_key},
+        "expected_after": {
+            "stability_tier": tier_key,
+            "base_rpm": baseline.get("base_rpm"),
+            "rpm_sticky_buffer": baseline.get("rpm_sticky_buffer"),
+            "concurrency": baseline.get("concurrency"),
+            "max_sessions": baseline.get("max_sessions"),
+        },
+    }
+
+
+def _account_before(account: dict) -> dict:
+    return {k: account.get(k) for k in _ACCOUNT_BEFORE_FIELDS}
+
+
 def cmd_plan_edge_account_tier(args: argparse.Namespace) -> int:
     snap = _load_snapshot_or_die(args.snapshot)
     tiers = _load_tier_baselines()
@@ -474,10 +514,7 @@ def cmd_plan_edge_account_tier(args: argparse.Namespace) -> int:
     target_account = _find_edge_account(edge, args.account_name)
 
     current_tier = (target_account.get("stability_tier") or "").lower()
-    fields_match = all(
-        target_account.get(k) == baseline.get(k)
-        for k in ("base_rpm", "rpm_sticky_buffer", "concurrency", "max_sessions")
-    )
+    fields_match = _tier_fields_match(target_account, baseline)
     force_rewrite = bool(getattr(args, "force_template_rewrite", False))
     if current_tier == tier_key and fields_match and not force_rewrite:
         print(
@@ -508,21 +545,7 @@ def cmd_plan_edge_account_tier(args: argparse.Namespace) -> int:
             print(out_str)
         return 0
 
-    action = {
-        "step": 1,
-        "kind": "edge_account_tier",
-        "target": {"env": "edge", "edge_id": args.edge_id,
-                   "account_name": args.account_name},
-        "sql_source": "rendered-from-anthropic-oauth-stability-baselines-tiered.json",
-        "variables": {"account_name": args.account_name, "stability_tier": tier_key},
-        "expected_after": {
-            "stability_tier": tier_key,
-            "base_rpm": baseline.get("base_rpm"),
-            "rpm_sticky_buffer": baseline.get("rpm_sticky_buffer"),
-            "concurrency": baseline.get("concurrency"),
-            "max_sessions": baseline.get("max_sessions"),
-        },
-    }
+    action = _build_tier_action(args.edge_id, args.account_name, baseline, tier_key, 1)
 
     plan = {
         "version": PLAN_VERSION,
@@ -535,10 +558,7 @@ def cmd_plan_edge_account_tier(args: argparse.Namespace) -> int:
         "plan_built_at": now_utc_iso(),
         "summary": {"total_steps": 1, "edge_changes": 1},
         "live_inputs": {
-            "edge_account_before": {k: target_account.get(k) for k in [
-                "id", "name", "concurrency", "stability_tier", "base_rpm",
-                "rpm_sticky_buffer", "max_sessions", "window_cost_limit", "status",
-            ]},
+            "edge_account_before": _account_before(target_account),
         },
         "actions": [action],
     }
@@ -549,6 +569,68 @@ def cmd_plan_edge_account_tier(args: argparse.Namespace) -> int:
         print(f"plan: written {args.out} (1 step)", file=sys.stderr)
     else:
         print(out_str)
+    return 0
+
+
+def cmd_plan_tier_bump(args: argparse.Namespace) -> int:
+    """Re-apply a (just-edited) tier baseline value to *every* account currently
+    on that tier across all snapshotted deployable edges, in one multi-action
+    plan. This is the correct shape for a tier-VALUE bump (e.g. L5 max_sessions
+    50→60): edit the baseline JSON first, then this enumerates the tier's whole
+    live population so no account is silently left at the old value. apply/verify
+    already iterate the actions list, so one apply + one verify covers the batch.
+    Contrast plan-edge-account-tier, which MOVES a single account to a tier."""
+    snap = _load_snapshot_or_die(args.snapshot)
+    tiers = _load_tier_baselines()
+    tier_key = args.tier.lower()
+    if tier_key not in tiers:
+        fail(f"tier {args.tier!r} not in baselines (available: {sorted(tiers)})")
+    baseline = tiers[tier_key]
+    force = bool(getattr(args, "force_template_rewrite", False))
+
+    actions: list[dict] = []
+    befores: list[dict] = []
+    skipped: list[dict] = []
+    for edge_id, edge in sorted(snap.get("edges", {}).items()):
+        if edge.get("error") or edge.get("skipped_reason"):
+            continue
+        for a in edge.get("oauth_accounts", []):
+            if (a.get("stability_tier") or "").lower() != tier_key:
+                continue
+            if _tier_fields_match(a, baseline) and not force:
+                skipped.append({"edge_id": edge_id, "account_name": a.get("name"),
+                                "reason": "live fields already match baseline"})
+                continue
+            step = len(actions) + 1
+            actions.append(_build_tier_action(edge_id, a.get("name"), baseline, tier_key, step))
+            befores.append({"edge_id": edge_id, **_account_before(a)})
+
+    plan = {
+        "version": PLAN_VERSION,
+        "kind": "edge_account_tier_change",
+        "confirm_code": CONFIRM_CODE,
+        "intent": {"tier_bump": tier_key, "scope": "all-snapshotted-deployable-edges",
+                   "force_template_rewrite": force},
+        "snapshot_captured_at": snap.get("captured_at"),
+        "plan_built_at": now_utc_iso(),
+        "noop": len(actions) == 0,
+        "summary": {"total_steps": len(actions), "edge_changes": len(actions),
+                    "skipped": len(skipped)},
+        "live_inputs": {"edge_accounts_before": befores, "skipped": skipped},
+        "actions": actions,
+    }
+
+    out_str = json.dumps(plan, indent=2, ensure_ascii=False)
+    if args.out:
+        pathlib.Path(args.out).write_text(out_str)
+        print(f"plan: written {args.out} ({len(actions)} step(s), {len(skipped)} skipped)",
+              file=sys.stderr)
+    else:
+        print(out_str)
+    if not actions:
+        print(f"plan: no account on tier {tier_key} needs rewriting "
+              f"(skipped={len(skipped)}; pass --force-template-rewrite to rewrite anyway)",
+              file=sys.stderr)
     return 0
 
 
@@ -781,6 +863,23 @@ def main() -> int:
         ),
     )
     sp.set_defaults(handler=cmd_plan_edge_account_tier)
+
+    sp = sub.add_parser(
+        "plan-tier-bump",
+        help="re-apply a tier's baseline to every account on that tier (one multi-action plan)")
+    sp.add_argument("--tier", required=True, help="l1 / l2 / l3 / l4 / l5")
+    sp.add_argument("--snapshot", required=True)
+    sp.add_argument("--out", help="write plan JSON (otherwise stdout)")
+    sp.add_argument(
+        "--force-template-rewrite",
+        action="store_true",
+        help=(
+            "include accounts whose live fields already match the baseline "
+            "(otherwise they are skipped as no-ops). Use when only credentials-side "
+            "fields changed."
+        ),
+    )
+    sp.set_defaults(handler=cmd_plan_tier_bump)
 
     sp = sub.add_parser("apply",
                         help="execute a plan: render the tier-baseline SQL from JSON, run via SSM")

--- a/ops/anthropic/test_manage_anthropic_config_plan.py
+++ b/ops/anthropic/test_manage_anthropic_config_plan.py
@@ -29,16 +29,14 @@ class PlanEdgeAccountTierTest(unittest.TestCase):
     ACCOUNT = "acct-under-test"
 
     def setUp(self) -> None:
-        # Build a snapshot account whose four match-fields equal the live l5
-        # baseline, so the orchestrator's fields_match check is True. Reading
-        # the values from the real baselines file (single source of truth)
-        # keeps the test green if the baseline numbers are retuned later — it
-        # asserts behavior (noop vs action), not specific magic numbers.
+        # Build a snapshot account whose pipeline-owned fields all equal the live
+        # baseline, so the orchestrator's fields_match check is True. Reading the
+        # values from the real baselines file (single source of truth) keeps the
+        # test green if the baseline numbers are retuned later — it asserts
+        # behavior (noop vs action), not specific magic numbers. The field set is
+        # _TIER_BASELINE_FIELDS (R-001: wider than the original 4).
         baseline = mgr._load_tier_baselines()[self.TIER]
-        self.match_fields = {
-            k: baseline[k]
-            for k in ("base_rpm", "rpm_sticky_buffer", "concurrency", "max_sessions")
-        }
+        self.match_fields = {k: baseline[k] for k in mgr._TIER_BASELINE_FIELDS}
         self._tmp = tempfile.TemporaryDirectory()
         self.tmp = pathlib.Path(self._tmp.name)
 
@@ -122,10 +120,7 @@ class PlanTierBumpTest(unittest.TestCase):
 
     def setUp(self) -> None:
         baseline = mgr._load_tier_baselines()[self.TIER]
-        self.match_fields = {
-            k: baseline[k]
-            for k in ("base_rpm", "rpm_sticky_buffer", "concurrency", "max_sessions")
-        }
+        self.match_fields = {k: baseline[k] for k in mgr._TIER_BASELINE_FIELDS}
         self._tmp = tempfile.TemporaryDirectory()
         self.tmp = pathlib.Path(self._tmp.name)
 
@@ -192,6 +187,20 @@ class PlanTierBumpTest(unittest.TestCase):
         plan = self._run(snap, force=True)
         self.assertEqual(len(plan["actions"]), 1)
         self.assertFalse(plan["noop"])
+
+    def test_window_cost_only_change_is_not_skipped(self) -> None:
+        # R-001 regression: an account matching the 4 capacity fields but with a
+        # stale window_cost_limit must NOT be skipped, and expected_after must
+        # carry window_cost_limit so verify can confirm it landed.
+        stale_cost = self.match_fields["window_cost_limit"] - 1
+        snap = self._write_snapshot({
+            "us1": {"deployable": True, "instance_id": "i-1", "region": "us-west-2",
+                    "oauth_accounts": [self._acct("a1", overrides={"window_cost_limit": stale_cost})]},
+        })
+        plan = self._run(snap)
+        self.assertEqual(len(plan["actions"]), 1, "window_cost_limit-only drift must emit an action")
+        self.assertFalse(plan["noop"])
+        self.assertIn("window_cost_limit", plan["actions"][0]["expected_after"])
 
 
 class SingleSourceRenderTest(unittest.TestCase):

--- a/ops/anthropic/test_manage_anthropic_config_plan.py
+++ b/ops/anthropic/test_manage_anthropic_config_plan.py
@@ -114,6 +114,86 @@ class PlanEdgeAccountTierTest(unittest.TestCase):
         self.assertEqual(len(plan["actions"]), 1)
 
 
+class PlanTierBumpTest(unittest.TestCase):
+    """plan-tier-bump enumerates every account on a tier across deployable edges
+    into one multi-action plan — the correct shape for a tier-VALUE bump."""
+
+    TIER = "l5"
+
+    def setUp(self) -> None:
+        baseline = mgr._load_tier_baselines()[self.TIER]
+        self.match_fields = {
+            k: baseline[k]
+            for k in ("base_rpm", "rpm_sticky_buffer", "concurrency", "max_sessions")
+        }
+        self._tmp = tempfile.TemporaryDirectory()
+        self.tmp = pathlib.Path(self._tmp.name)
+
+    def tearDown(self) -> None:
+        self._tmp.cleanup()
+
+    def _acct(self, name, *, tier=None, overrides=None):
+        a = {"id": 0, "name": name, "type": "oauth", "status": "active",
+             "platform": "anthropic", "stability_tier": tier or self.TIER,
+             **self.match_fields}
+        if overrides:
+            a.update(overrides)
+        return a
+
+    def _write_snapshot(self, edges: dict) -> pathlib.Path:
+        snap = {"version": mgr.SNAPSHOT_VERSION, "captured_at": "2026-05-22T00:00:00Z",
+                "edges": edges}
+        path = self.tmp / "snap.json"
+        path.write_text(json.dumps(snap))
+        return path
+
+    def _run(self, snap_path, *, force=False) -> dict:
+        out = self.tmp / "plan.json"
+        ns = argparse.Namespace(tier=self.TIER, snapshot=str(snap_path),
+                                out=str(out), force_template_rewrite=force)
+        self.assertEqual(mgr.cmd_plan_tier_bump(ns), 0)
+        return json.loads(out.read_text())
+
+    def test_enumerates_all_matching_tier_accounts_when_value_bumped(self) -> None:
+        # Stale fields (bumped base_rpm) → both l5 accounts get an action; a
+        # planned edge and an off-tier account are excluded.
+        stale = {"base_rpm": self.match_fields["base_rpm"] + 1}
+        snap = self._write_snapshot({
+            "us1": {"deployable": True, "instance_id": "i-1", "region": "us-west-2",
+                    "oauth_accounts": [self._acct("a1", overrides=stale),
+                                       self._acct("a4", overrides=stale),
+                                       self._acct("other", tier="l3")]},
+            "uk1": {"deployable": False, "skipped_reason": "planned"},
+        })
+        plan = self._run(snap)
+        names = sorted(a["target"]["account_name"] for a in plan["actions"])
+        self.assertEqual(names, ["a1", "a4"])
+        self.assertEqual([a["step"] for a in plan["actions"]], [1, 2])
+        for a in plan["actions"]:
+            self.assertEqual(a["expected_after"]["max_sessions"],
+                             self.match_fields["max_sessions"])
+        self.assertFalse(plan["noop"])
+
+    def test_already_matching_accounts_are_skipped_not_actioned(self) -> None:
+        snap = self._write_snapshot({
+            "us1": {"deployable": True, "instance_id": "i-1", "region": "us-west-2",
+                    "oauth_accounts": [self._acct("a1")]},
+        })
+        plan = self._run(snap)
+        self.assertEqual(plan["actions"], [])
+        self.assertTrue(plan["noop"])
+        self.assertEqual(plan["summary"]["skipped"], 1)
+
+    def test_force_includes_matching_accounts(self) -> None:
+        snap = self._write_snapshot({
+            "us1": {"deployable": True, "instance_id": "i-1", "region": "us-west-2",
+                    "oauth_accounts": [self._acct("a1")]},
+        })
+        plan = self._run(snap, force=True)
+        self.assertEqual(len(plan["actions"]), 1)
+        self.assertFalse(plan["noop"])
+
+
 class SingleSourceRenderTest(unittest.TestCase):
     """Tier baseline values live only in the JSON file; the apply SQL is rendered
     from it at runtime. These tests lock that wiring so the retired dual-source


### PR DESCRIPTION
## 背景

上帝视角回顾 L5 max_sessions 50→60 那次操作 vs `tokenkey-anthropic-oauth-config` skill，发现一个真缺口 + 三个文档空白。本 PR 一并补齐（新增批量入口 + 单测 + 文档）。

## 缺口与修复

**1. tier-值-bump 没有一等公民命令（最重要）**
`plan-edge-account-tier` 只能把**单个账号移到某 tier**。而改 tier 基线值（如 L5 `max_sessions`）影响**该 tier 上每个账号、跨所有 deployable edge**——手敲逐个 plan 容易漏掉某 edge 的同 tier 账号，导致它静默停旧值（之后 `check` 报 `extra_baseline_drift`）。
→ 新增 **`plan-tier-bump --tier lN`**：从 snapshot 枚举该 tier 全部 live 账号，产出**一个多 action plan**。

**2. apply/verify 原生支持多 action，但没文档化**
实测 `apply`(`for action in actions`) / `verify` 都迭代 actions 数组。所以 tier-bump 现在**一次 apply + 一次 verify** 覆盖整批（原来手动 2×2）。已在阶段表写明。

**3. snap.json schema 没文档化**
`edges` 是按 edge_id 索引的 **dict**，账号在 **`oauth_accounts`**，planned edge 带 `skipped_reason`。回顾时我第一次解析就 AttributeError。补了 schema 速查。

**4. 澄清不需要联动改 Go**
`anthropic baseline sync` preflight 只镜像 `policy.cooldown_tier_ttl_minutes` ↔ `ratelimit_service.go`；per-tier `baseline.*`（max_sessions/base_rpm/…）都不镜像，改 tier 值永不触发该 check。

## 实现

- 抽 `_tier_fields_match` / `_build_tier_action` / `_account_before` 三个 helper，两个 plan 命令共用；`plan-edge-account-tier` 输出形状不变，其 3 个旧测试保持绿。
- 新增 `plan-tier-bump` 子命令 + 注册 + help。
- 新增 3 个单测：枚举全部 / 跳过已匹配 / `--force` 强制。
- **smoke**：对本会话 apply 后的 live snapshot 跑 `plan-tier-bump --tier l5` → 两个 us1 l5 账号已 60 → `noop=true, skipped=2`（正确识别无需重写）。

## 验证

- `python3 -m unittest discover -s ops/anthropic`：13 passed（10 旧 + 3 新）。
- 本地 `scripts/preflight.sh` PASS（pre-commit hook 再跑亦 PASS）。

🤖 Generated with [Claude Code](https://claude.com/claude-code)