### PR TITLE
chore(ops/anthropic): align L4 baseline to L5 except concurrency(6)+window_cost_limit (no-web-impact)

### DIFF
--- a/deploy/aws/stage0/anthropic-oauth-stability-baselines-tiered.json
+++ b/deploy/aws/stage0/anthropic-oauth-stability-baselines-tiered.json
@@ -180,14 +180,14 @@
     "l4": {
       "baseline": {
         "account": {
-          "concurrency": 5,
-          "priority": 40,
+          "concurrency": 6,
+          "priority": 50,
           "rate_multiplier": 1.0
         },
         "extra": {
-          "base_rpm": 18,
-          "rpm_sticky_buffer": 14,
-          "max_sessions": 11,
+          "base_rpm": 28,
+          "rpm_sticky_buffer": 20,
+          "max_sessions": 60,
           "session_idle_timeout_minutes": 8,
           "window_cost_limit": 800,
           "window_cost_sticky_reserve": 0


### PR DESCRIPTION
## 变更

L4 tier 基线对齐 L5，仅两处刻意保留差异：

| 字段 | L4 旧 | L4 新 | L5 | 说明 |
|---|---|---|---|---|
| base_rpm | 18 | **28** | 28 | 对齐 L5 |
| rpm_sticky_buffer | 14 | **20** | 20 | 对齐 L5 |
| max_sessions | 11 | **60** | 60 | 对齐 L5 |
| priority | 40 | **50** | 50 | 对齐 L5 |
| concurrency | 5 | **6** | 8 | 刻意设为 6（不随 L5）|
| window_cost_limit | 800 | **800** | 1500 | 刻意不变 |
| rate_multiplier / idle / sticky_reserve | — | 不变 | 同 | 本就相同 |

结果：L4 与 L5 现在仅 `concurrency`(6 vs 8) 和 `window_cost_limit`(800 vs 1500) 不同，其余全等。

## 为什么是纯定义变更（无 live apply）

新拉的全量 deployable-edge snapshot 显示**当前没有任何账号在 tier l4**（唯一 deployable 的 us1 是两个 l5 账号；uk1/sg1/fra1 都是 planned）。所以没有 live 账号可写，`plan-tier-bump --tier l4` 会是 noop。改的是 tier 的**定义**（唯一真值源 JSON）；未来落到 l4 的账号按此派生。

## 验证

- 本地 `scripts/preflight.sh` PASS（含 baseline-sync / tier single-source / ops 单测；pre-commit hook 再跑亦 PASS）。
- JSON 解析正常，L4↔L5 差异如上表。

🤖 Generated with [Claude Code](https://claude.com/claude-code)