### PR TITLE
chore(ops/anthropic): bump L5 max_sessions 60→80 (no-web-impact)

### DIFF
--- a/deploy/aws/stage0/anthropic-oauth-stability-baselines-tiered.json
+++ b/deploy/aws/stage0/anthropic-oauth-stability-baselines-tiered.json
@@ -204,7 +204,7 @@
         "extra": {
           "base_rpm": 28,
           "rpm_sticky_buffer": 20,
-          "max_sessions": 60,
+          "max_sessions": 80,
           "session_idle_timeout_minutes": 8,
           "window_cost_limit": 1500,
           "window_cost_sticky_reserve": 0


### PR DESCRIPTION
## Summary

- 把 L5 tier baseline `max_sessions` 60 → 80（唯一真值源 `deploy/aws/stage0/anthropic-oauth-stability-baselines-tiered.json`）
- 已在 edge us1 跑完 `plan-tier-bump --tier l5` → `apply` → `verify`（live 已写入），本 PR 把 JSON 改动落回 `origin/main`，避免后续 `check-edge-oauth-stability` 报 live↔repo drift
- 其余 L5 字段（concurrency=8 / window_cost_limit=1500 / base_rpm=28 / sticky_buffer=20 / idle=8）未动；L4 `max_sessions` 仍为 60（如需联动请单独提 PR）

## Pipeline evidence

```
plan-tier-bump --tier l5: 1 action (am-us-ec2-5-1-b on us1), 0 skipped
apply ssm cid f7635483-c75a-48d0-ba8f-ad47c1f98b7d → success=True 1/1
verify drift_count=0/1
post-apply check any_violation=false
  am-us-ec2-5-1-b: tier=l5 baseline=l5 diff_count=0 status=ok
  cc-am-or-ec2-5-1-b: tier=l4 baseline=l4 diff_count=0 status=ok
```

## Motivation

缓解 us1 session-cap 顶格触发 503 的趋势（参考 us1 「no available accounts」session-cap 经验）。当前 deployable L5 账号只在 us1（am-us-ec2-5-1-b），uk1/sg1/fra1 都是 planned，所以本次 bump 实际影响面 = 1 个账号。

## Test plan

- [x] `bash scripts/preflight.sh` PASS（含 `anthropic tier baseline single-source` + `ops/anthropic orchestrators unittest`）
- [x] live apply + verify drift=0 + 复跑 check any_violation=false
- [ ] CI green
- [ ] reviewer 自行审视 us1 admin UI 「sessions 16/80」gauge（之前 16/60）