### PR TITLE
chore(ops/anthropic): L5 concurrency 10, max_sessions 100

### DIFF
--- a/.cursor/skills/tokenkey-anthropic-oauth-config/SKILL.md
+++ b/.cursor/skills/tokenkey-anthropic-oauth-config/SKILL.md
@@ -76,8 +76,8 @@ python3 $MGR verify --plan $JOBDIR/plan.json
       "deployable": true, "instance_id": "i-...", "region": "...",
       "oauth_accounts": [          // ← 账号在这里
         { "id": 1, "name": "...", "stability_tier": "l5",
-          "base_rpm": 28, "rpm_sticky_buffer": 20, "concurrency": 8,
-          "max_sessions": 60, "window_cost_limit": 1500, "status": "active", ... }
+          "base_rpm": 28, "rpm_sticky_buffer": 20, "concurrency": 10,
+          "max_sessions": 100, "window_cost_limit": 1500, "status": "active", ... }
       ]
     },
     "uk1": { "deployable": false, "skipped_reason": "planned; pass --allow-planned" }

--- a/deploy/aws/stage0/anthropic-oauth-stability-baselines-tiered.json
+++ b/deploy/aws/stage0/anthropic-oauth-stability-baselines-tiered.json
@@ -197,14 +197,14 @@
     "l5": {
       "baseline": {
         "account": {
-          "concurrency": 8,
+          "concurrency": 10,
           "priority": 50,
           "rate_multiplier": 1.0
         },
         "extra": {
           "base_rpm": 28,
           "rpm_sticky_buffer": 20,
-          "max_sessions": 80,
+          "max_sessions": 100,
           "session_idle_timeout_minutes": 8,
           "window_cost_limit": 1500,
           "window_cost_sticky_reserve": 0


### PR DESCRIPTION
## Summary
- Raise **`tiers.l5`** in `deploy/aws/stage0/anthropic-oauth-stability-baselines-tiered.json`: **concurrency 10**, **max_sessions 100** (single source of truth; Edge L5 OAuth was already rolled to match).
- Align **`tokenkey-anthropic-oauth-config`** SKILL snapshot example numeric fields with this L5 shape.

## Risk
- Low — JSON + SKILL only; ops behavior unchanged for code paths.

## Validation
- `./scripts/preflight.sh`
- Operator spot-check: prod + edge-us1 `users.id=1.concurrency` already aligned with Σ anthropic concurrency before PR (no backend change here).

Made with [Cursor](https://cursor.com)