### PR TITLE
chore: refresh upstream issue cache

### DIFF
--- a/.cache/upstream/triage.json
+++ b/.cache/upstream/triage.json
@@ -7,10 +7,10 @@
     "needs_review": 356,
     "fixed": 30,
     "needs_prod_validation": 3,
-    "medium": 115,
+    "medium": 116,
     "not_applicable": 1,
     "low": 100,
-    "unknown_low_signal": 419
+    "unknown_low_signal": 422
   },
   "issues": [
     {
@@ -3350,7 +3350,7 @@
       ],
       "tokenkey_status": "candidate_unverified",
       "rationale": "Keyword match for production-sensitive area; not yet manually verified against TokenKey code.",
-      "updated_at": "2026-05-22T12:10:09Z"
+      "updated_at": "2026-05-23T01:05:56Z"
     },
     {
       "upstream": "Wei-Shaw/sub2api#283",
@@ -5648,6 +5648,18 @@
       "tokenkey_status": "not_prioritized",
       "rationale": "Potential compatibility/ops/admin impact, but not selected as severe TokenKey production risk in this pass.",
       "updated_at": "2026-05-22T08:58:13Z"
+    },
+    {
+      "upstream": "Wei-Shaw/sub2api#2700",
+      "url": "https://github.com/Wei-Shaw/sub2api/issues/2700",
+      "title": "feat：在OpenAI平台分组里添加service_tier透传规则",
+      "impact": "medium",
+      "categories": [
+        "compatibility"
+      ],
+      "tokenkey_status": "not_prioritized",
+      "rationale": "Potential compatibility/ops/admin impact, but not selected as severe TokenKey production risk in this pass.",
+      "updated_at": "2026-05-22T17:09:37Z"
     },
     {
       "upstream": "Wei-Shaw/sub2api#275",
@@ -10547,6 +10559,36 @@
       "tokenkey_status": "not_prioritized",
       "rationale": "No high-signal production-risk keywords in this pass.",
       "updated_at": "2026-05-22T14:37:56Z"
+    },
+    {
+      "upstream": "Wei-Shaw/sub2api#2699",
+      "url": "https://github.com/Wei-Shaw/sub2api/issues/2699",
+      "title": "feat：添加/编辑账号增加对返回指定错误码或错误信息进行调度重试",
+      "impact": "unknown_low_signal",
+      "categories": [],
+      "tokenkey_status": "not_prioritized",
+      "rationale": "No high-signal production-risk keywords in this pass.",
+      "updated_at": "2026-05-22T16:59:57Z"
+    },
+    {
+      "upstream": "Wei-Shaw/sub2api#2701",
+      "url": "https://github.com/Wei-Shaw/sub2api/issues/2701",
+      "title": "Model problem",
+      "impact": "unknown_low_signal",
+      "categories": [],
+      "tokenkey_status": "not_prioritized",
+      "rationale": "No high-signal production-risk keywords in this pass.",
+      "updated_at": "2026-05-22T19:24:25Z"
+    },
+    {
+      "upstream": "Wei-Shaw/sub2api#2702",
+      "url": "https://github.com/Wei-Shaw/sub2api/issues/2702",
+      "title": "/admin/settings打开白屏了",
+      "impact": "unknown_low_signal",
+      "categories": [],
+      "tokenkey_status": "not_prioritized",
+      "rationale": "No high-signal production-risk keywords in this pass.",
+      "updated_at": "2026-05-23T01:57:19Z"
     },
     {
       "upstream": "Wei-Shaw/sub2api#272",


### PR DESCRIPTION
## Summary
- Refresh `.cache/upstream/triage.json` from the latest Wei-Shaw/sub2api issues.
- Update `.cache/upstream/fixes.json` from current TokenKey main fact checks.
- Keep watchdog workflow/script/fact-check metadata in sync with the refreshed cache.

## Watchdog report
# Upstream Issue Watchdog Report

- Run URL: https://github.com/youxuanxue/sub2api/actions/runs/26320924711
- Repository SHA: `72d010bf5a382bf3dc86a9899c968cab7d9cb500`
- Generated at: `2026-05-23T02:21:21Z`
- Upstream issues scanned: `1440`
- Fact checks: `23`
- Fixed facts verified: `21`
- High/critical unresolved: `0`

## Fixed facts verified

- Wei-Shaw/sub2api#641 via None
- Wei-Shaw/sub2api#2332 via None
- Wei-Shaw/sub2api#2107 via youxuanxue/sub2api#232
- Wei-Shaw/sub2api#2159 via youxuanxue/sub2api#232
- Wei-Shaw/sub2api#2258 via youxuanxue/sub2api#232
- Wei-Shaw/sub2api#2478 via youxuanxue/sub2api#232
- Wei-Shaw/sub2api#2515 via None
- Wei-Shaw/sub2api#2506 via None
- Wei-Shaw/sub2api#2500 via None
- Wei-Shaw/sub2api#2486 via None
- Wei-Shaw/sub2api#2363 via None
- Wei-Shaw/sub2api#2332 via None
- Wei-Shaw/sub2api#1471 via None
- Wei-Shaw/sub2api#2538 via None
- Wei-Shaw/sub2api#2539 via None
- Wei-Shaw/sub2api#2556 via None
- Wei-Shaw/sub2api#2298 via None
- Wei-Shaw/sub2api#1264 via None
- Wei-Shaw/sub2api#1170 via None
- Wei-Shaw/sub2api#1318 via None
- Wei-Shaw/sub2api#1824 via None

## Fact checks missing

- Wei-Shaw/sub2api#1311: scripts/check-buffered-content-type-leak.py:def scan_file
- Wei-Shaw/sub2api#1322: scripts/terminal-sentinels.json:openai_compat_responses_terminal_helper


## Test plan
- [x] `python3 -m json.tool .cache/upstream/triage.json`
- [x] `python3 -m json.tool .cache/upstream/fixes.json`
- [x] `python3 -m json.tool .cache/upstream/fact-checks.json`
- [x] `python3 -m py_compile scripts/upstream/issue-watchdog.py`
- [x] `python3 -m json.tool .cache/upstream-issue-watchdog/report.json`
- [x] `python3 -m json.tool .cache/upstream-issue-watchdog/agent-input.json`
