### PR TITLE
chore(anthropic-tier): bump L4 max_sessions 60→100, L5 max_sessions 100→120

### DIFF
--- a/deploy/aws/stage0/anthropic-oauth-stability-baselines-tiered.json
+++ b/deploy/aws/stage0/anthropic-oauth-stability-baselines-tiered.json
@@ -187,7 +187,7 @@
         "extra": {
           "base_rpm": 28,
           "rpm_sticky_buffer": 20,
-          "max_sessions": 60,
+          "max_sessions": 100,
           "session_idle_timeout_minutes": 8,
           "window_cost_limit": 800,
           "window_cost_sticky_reserve": 0
@@ -204,7 +204,7 @@
         "extra": {
           "base_rpm": 28,
           "rpm_sticky_buffer": 20,
-          "max_sessions": 100,
+          "max_sessions": 120,
           "session_idle_timeout_minutes": 8,
           "window_cost_limit": 1500,
           "window_cost_sticky_reserve": 0


### PR DESCRIPTION
## Summary

- L4 `max_sessions`: 60 → 100
- L5 `max_sessions`: 100 → 120

已通过 `manage-anthropic-config.py plan-tier-bump + apply + verify` 写入 live（us1，drift_count=0）。本 PR 将 JSON 唯一真值源对齐 live 状态，防止 CI `check-edge-oauth-stability` 报 `extra_baseline_drift`。

## Test plan

- [x] `preflight` 全绿（pre-commit hook 已验证）
- [x] `manage-anthropic-config.py verify` drift_count=0/1
- [ ] CI `backend-ci` 通过

🤖 Generated with [Claude Code](https://claude.com/claude-code)