### PR TITLE
chore: refresh upstream issue cache

### DIFF
--- a/.cache/upstream/triage.json
+++ b/.cache/upstream/triage.json
@@ -4,13 +4,13 @@
   "generated_from": "GitHub REST API issues?state=open; pull requests excluded",
   "rationale": "TokenKey-local triage cache for upstream open issues. Use this file before re-triaging upstream issues; update entries when TokenKey fixes, dismisses, or reclassifies an issue.",
   "counts": {
-    "needs_review": 356,
-    "fixed": 30,
+    "needs_review": 358,
+    "fixed": 29,
     "needs_prod_validation": 3,
-    "medium": 116,
+    "medium": 117,
     "not_applicable": 1,
     "low": 100,
-    "unknown_low_signal": 422
+    "unknown_low_signal": 424
   },
   "issues": [
     {
@@ -298,6 +298,19 @@
       "tokenkey_status": "candidate_unverified",
       "rationale": "Keyword match for production-sensitive area; not yet manually verified against TokenKey code.",
       "updated_at": "2026-04-19T10:53:21Z"
+    },
+    {
+      "upstream": "Wei-Shaw/sub2api#1318",
+      "url": "https://github.com/Wei-Shaw/sub2api/issues/1318",
+      "title": "[bug] openai_passthrough 命中临时不可调度规则后未触发 failover",
+      "impact": "needs_review",
+      "categories": [
+        "rate_limit_cooldown",
+        "image_oauth"
+      ],
+      "tokenkey_status": "candidate_unverified",
+      "rationale": "Keyword match for production-sensitive area; not yet manually verified against TokenKey code.",
+      "updated_at": "2026-03-26T06:47:06Z"
     },
     {
       "upstream": "Wei-Shaw/sub2api#1322",
@@ -1703,7 +1716,7 @@
       ],
       "tokenkey_status": "candidate_unverified",
       "rationale": "Keyword match for production-sensitive area; not yet manually verified against TokenKey code.",
-      "updated_at": "2026-05-13T07:47:51Z"
+      "updated_at": "2026-05-23T05:25:58Z"
     },
     {
       "upstream": "Wei-Shaw/sub2api#1956",
@@ -3326,7 +3339,7 @@
       ],
       "tokenkey_status": "candidate_unverified",
       "rationale": "Keyword match for production-sensitive area; not yet manually verified against TokenKey code.",
-      "updated_at": "2026-05-22T10:44:03Z"
+      "updated_at": "2026-05-23T06:03:00Z"
     },
     {
       "upstream": "Wei-Shaw/sub2api#2692",
@@ -3338,7 +3351,7 @@
       ],
       "tokenkey_status": "candidate_unverified",
       "rationale": "Keyword match for production-sensitive area; not yet manually verified against TokenKey code.",
-      "updated_at": "2026-05-22T09:05:55Z"
+      "updated_at": "2026-05-23T05:40:05Z"
     },
     {
       "upstream": "Wei-Shaw/sub2api#2694",
@@ -3351,6 +3364,18 @@
       "tokenkey_status": "candidate_unverified",
       "rationale": "Keyword match for production-sensitive area; not yet manually verified against TokenKey code.",
       "updated_at": "2026-05-23T01:05:56Z"
+    },
+    {
+      "upstream": "Wei-Shaw/sub2api#2704",
+      "url": "https://github.com/Wei-Shaw/sub2api/issues/2704",
+      "title": "image2调用生成图片的配置",
+      "impact": "needs_review",
+      "categories": [
+        "image_oauth"
+      ],
+      "tokenkey_status": "candidate_unverified",
+      "rationale": "Keyword match for production-sensitive area; not yet manually verified against TokenKey code.",
+      "updated_at": "2026-05-23T03:01:33Z"
     },
     {
       "upstream": "Wei-Shaw/sub2api#283",
@@ -5662,6 +5687,18 @@
       "updated_at": "2026-05-22T17:09:37Z"
     },
     {
+      "upstream": "Wei-Shaw/sub2api#2708",
+      "url": "https://github.com/Wei-Shaw/sub2api/issues/2708",
+      "title": "lib/pq watchCancel goroutine 泄漏导致协程数持续增长",
+      "impact": "medium",
+      "categories": [
+        "compatibility"
+      ],
+      "tokenkey_status": "not_prioritized",
+      "rationale": "Potential compatibility/ops/admin impact, but not selected as severe TokenKey production risk in this pass.",
+      "updated_at": "2026-05-23T06:03:27Z"
+    },
+    {
       "upstream": "Wei-Shaw/sub2api#275",
       "url": "https://github.com/Wei-Shaw/sub2api/issues/275",
       "title": "「UI建议」过期时间增加一个月/一年选项",
@@ -5948,19 +5985,6 @@
       "tokenkey_status": "fixed_in_tokenkey",
       "rationale": "Non-stream /v1/chat/completions and /v1/messages now explicitly set Content-Type: application/json after WriteFilteredHeaders, so the upstream Responses SSE Content-Type no longer leaks onto JSON bodies.",
       "updated_at": "2026-05-15T12:00:37Z"
-    },
-    {
-      "upstream": "Wei-Shaw/sub2api#1318",
-      "url": "https://github.com/Wei-Shaw/sub2api/issues/1318",
-      "title": "[bug] openai_passthrough 命中临时不可调度规则后未触发 failover",
-      "impact": "fixed",
-      "categories": [
-        "rate_limit_cooldown",
-        "image_oauth"
-      ],
-      "tokenkey_status": "fixed_in_tokenkey",
-      "rationale": "openai_passthrough now propagates HandleUpstreamError's shouldDisable signal: when a temp-unschedulable rule (or any policy that marks the account unschedulable — 402 deactivated_workspace, OAuth 401, organization disabled, etc.) fires, handleErrorResponsePassthrough returns UpstreamFailoverError and emits ops Kind=failover instead of writing the upstream error straight back to the client. This closes the half-applied state where the account got disabled but the in-flight request was still completed on it.",
-      "updated_at": "2026-03-26T06:47:06Z"
     },
     {
       "upstream": "Wei-Shaw/sub2api#1471",
@@ -9098,7 +9122,7 @@
       "categories": [],
       "tokenkey_status": "not_prioritized",
       "rationale": "No high-signal production-risk keywords in this pass.",
-      "updated_at": "2026-05-13T19:13:22Z"
+      "updated_at": "2026-05-23T03:20:19Z"
     },
     {
       "upstream": "Wei-Shaw/sub2api#1820",
@@ -10538,7 +10562,7 @@
       "categories": [],
       "tokenkey_status": "not_prioritized",
       "rationale": "No high-signal production-risk keywords in this pass.",
-      "updated_at": "2026-05-22T13:40:26Z"
+      "updated_at": "2026-05-23T04:50:57Z"
     },
     {
       "upstream": "Wei-Shaw/sub2api#2695",
@@ -10589,6 +10613,26 @@
       "tokenkey_status": "not_prioritized",
       "rationale": "No high-signal production-risk keywords in this pass.",
       "updated_at": "2026-05-23T01:57:19Z"
+    },
+    {
+      "upstream": "Wei-Shaw/sub2api#2706",
+      "url": "https://github.com/Wei-Shaw/sub2api/issues/2706",
+      "title": "同一个厂家某一个模型不可用 整个 模型都会不可用",
+      "impact": "unknown_low_signal",
+      "categories": [],
+      "tokenkey_status": "not_prioritized",
+      "rationale": "No high-signal production-risk keywords in this pass.",
+      "updated_at": "2026-05-23T04:48:45Z"
+    },
+    {
+      "upstream": "Wei-Shaw/sub2api#2707",
+      "url": "https://github.com/Wei-Shaw/sub2api/issues/2707",
+      "title": "gemini 可以反代吗",
+      "impact": "unknown_low_signal",
+      "categories": [],
+      "tokenkey_status": "not_prioritized",
+      "rationale": "No high-signal production-risk keywords in this pass.",
+      "updated_at": "2026-05-23T05:52:27Z"
     },
     {
       "upstream": "Wei-Shaw/sub2api#272",
@@ -11378,7 +11422,7 @@
       "categories": [],
       "tokenkey_status": "not_prioritized",
       "rationale": "No high-signal production-risk keywords in this pass.",
-      "updated_at": "2026-03-02T04:04:44Z"
+      "updated_at": "2026-05-23T05:24:29Z"
     },
     {
       "upstream": "Wei-Shaw/sub2api#708",


### PR DESCRIPTION
## Summary
- Refresh `.cache/upstream/triage.json` from the latest Wei-Shaw/sub2api issues.
- Update `.cache/upstream/fixes.json` from current TokenKey main fact checks.
- Keep watchdog workflow/script/fact-check metadata in sync with the refreshed cache.

## Watchdog report
# Upstream Issue Watchdog Report

- Run URL: https://github.com/youxuanxue/sub2api/actions/runs/26325673511
- Repository SHA: `93fccefdf48a7916913ebd6d1b94970c74d26afa`
- Generated at: `2026-05-23T06:23:29Z`
- Upstream issues scanned: `1444`
- Fact checks: `23`
- Fixed facts verified: `20`
- High/critical unresolved: `0`

## Fixed facts verified

- Wei-Shaw/sub2api#641 via None
- Wei-Shaw/sub2api#2332 via None
- Wei-Shaw/sub2api#2107 via youxuanxue/sub2api#232
- Wei-Shaw/sub2api#2159 via youxuanxue/sub2api#232
- Wei-Shaw/sub2api#2258 via youxuanxue/sub2api#232
- Wei-Shaw/sub2api#2478 via youxuanxue/sub2api#232
- Wei-Shaw/sub2api#2515 via None
- Wei-Shaw/sub2api#2506 via None
- Wei-Shaw/sub2api#2500 via None
- Wei-Shaw/sub2api#2486 via None
- Wei-Shaw/sub2api#2363 via None
- Wei-Shaw/sub2api#2332 via None
- Wei-Shaw/sub2api#1471 via None
- Wei-Shaw/sub2api#2538 via None
- Wei-Shaw/sub2api#2539 via None
- Wei-Shaw/sub2api#2556 via None
- Wei-Shaw/sub2api#2298 via None
- Wei-Shaw/sub2api#1264 via None
- Wei-Shaw/sub2api#1170 via None
- Wei-Shaw/sub2api#1824 via None

## Fact checks missing

- Wei-Shaw/sub2api#1311: scripts/check-buffered-content-type-leak.py:def scan_file
- Wei-Shaw/sub2api#1322: scripts/terminal-sentinels.json:openai_compat_responses_terminal_helper
- Wei-Shaw/sub2api#1318: backend/internal/service/openai_gateway_service.go:shouldDisable = s.rateLimitService.HandleUpstreamError(ctx, account, resp.StatusCode, resp.Header, body)


## Test plan
- [x] `python3 -m json.tool .cache/upstream/triage.json`
- [x] `python3 -m json.tool .cache/upstream/fixes.json`
- [x] `python3 -m json.tool .cache/upstream/fact-checks.json`
- [x] `python3 -m py_compile scripts/upstream/issue-watchdog.py`
- [x] `python3 -m json.tool .cache/upstream-issue-watchdog/report.json`
- [x] `python3 -m json.tool .cache/upstream-issue-watchdog/agent-input.json`
