### PR TITLE
chore: refresh upstream issue cache

### DIFF
--- a/.cache/upstream/triage.json
+++ b/.cache/upstream/triage.json
@@ -4,13 +4,13 @@
   "generated_from": "GitHub REST API issues?state=open; pull requests excluded",
   "rationale": "TokenKey-local triage cache for upstream open issues. Use this file before re-triaging upstream issues; update entries when TokenKey fixes, dismisses, or reclassifies an issue.",
   "counts": {
-    "needs_review": 358,
+    "needs_review": 359,
     "fixed": 29,
     "needs_prod_validation": 3,
     "medium": 117,
     "not_applicable": 1,
-    "low": 100,
-    "unknown_low_signal": 424
+    "low": 99,
+    "unknown_low_signal": 422
   },
   "issues": [
     {
@@ -3265,7 +3265,7 @@
       ],
       "tokenkey_status": "candidate_unverified",
       "rationale": "Keyword match for production-sensitive area; not yet manually verified against TokenKey code.",
-      "updated_at": "2026-05-20T15:48:57Z"
+      "updated_at": "2026-05-23T06:38:21Z"
     },
     {
       "upstream": "Wei-Shaw/sub2api#2651",
@@ -3354,28 +3354,42 @@
       "updated_at": "2026-05-23T05:40:05Z"
     },
     {
-      "upstream": "Wei-Shaw/sub2api#2694",
-      "url": "https://github.com/Wei-Shaw/sub2api/issues/2694",
-      "title": "openai access_token expired and refresh_token is missing access_token过期问题",
+      "upstream": "Wei-Shaw/sub2api#2717",
+      "url": "https://github.com/Wei-Shaw/sub2api/issues/2717",
+      "title": "OpenAI 的订阅总是会掉",
+      "impact": "needs_review",
+      "categories": [
+        "image_oauth",
+        "security"
+      ],
+      "tokenkey_status": "candidate_unverified",
+      "rationale": "Keyword match for production-sensitive area; not yet manually verified against TokenKey code.",
+      "updated_at": "2026-05-23T13:37:41Z"
+    },
+    {
+      "upstream": "Wei-Shaw/sub2api#2721",
+      "url": "https://github.com/Wei-Shaw/sub2api/issues/2721",
+      "title": "接上游Image2 测试连接成功 但响应信息是文字不是图片 但是使用开源的gpt_image_playground接入这个上游生图是正常的",
+      "impact": "needs_review",
+      "categories": [
+        "rate_limit_cooldown",
+        "image_oauth"
+      ],
+      "tokenkey_status": "candidate_unverified",
+      "rationale": "Keyword match for production-sensitive area; not yet manually verified against TokenKey code.",
+      "updated_at": "2026-05-23T09:24:14Z"
+    },
+    {
+      "upstream": "Wei-Shaw/sub2api#2723",
+      "url": "https://github.com/Wei-Shaw/sub2api/issues/2723",
+      "title": "只有at的正常账号会被视为错误",
       "impact": "needs_review",
       "categories": [
         "security"
       ],
       "tokenkey_status": "candidate_unverified",
       "rationale": "Keyword match for production-sensitive area; not yet manually verified against TokenKey code.",
-      "updated_at": "2026-05-23T01:05:56Z"
-    },
-    {
-      "upstream": "Wei-Shaw/sub2api#2704",
-      "url": "https://github.com/Wei-Shaw/sub2api/issues/2704",
-      "title": "image2调用生成图片的配置",
-      "impact": "needs_review",
-      "categories": [
-        "image_oauth"
-      ],
-      "tokenkey_status": "candidate_unverified",
-      "rationale": "Keyword match for production-sensitive area; not yet manually verified against TokenKey code.",
-      "updated_at": "2026-05-23T03:01:33Z"
+      "updated_at": "2026-05-23T14:06:18Z"
     },
     {
       "upstream": "Wei-Shaw/sub2api#283",
@@ -4830,7 +4844,7 @@
       ],
       "tokenkey_status": "not_prioritized",
       "rationale": "Potential compatibility/ops/admin impact, but not selected as severe TokenKey production risk in this pass.",
-      "updated_at": "2026-04-18T08:47:20Z"
+      "updated_at": "2026-05-23T06:52:45Z"
     },
     {
       "upstream": "Wei-Shaw/sub2api#1605",
@@ -5684,7 +5698,7 @@
       ],
       "tokenkey_status": "not_prioritized",
       "rationale": "Potential compatibility/ops/admin impact, but not selected as severe TokenKey production risk in this pass.",
-      "updated_at": "2026-05-22T17:09:37Z"
+      "updated_at": "2026-05-23T07:35:56Z"
     },
     {
       "upstream": "Wei-Shaw/sub2api#2708",
@@ -7324,18 +7338,6 @@
       "updated_at": "2026-05-20T09:37:57Z"
     },
     {
-      "upstream": "Wei-Shaw/sub2api#2654",
-      "url": "https://github.com/Wei-Shaw/sub2api/issues/2654",
-      "title": "希望增加Windsurf、kiro反代的支持",
-      "impact": "low",
-      "categories": [
-        "enhancement"
-      ],
-      "tokenkey_status": "not_prioritized",
-      "rationale": "Appears to be enhancement/docs/UI request rather than severe online service risk.",
-      "updated_at": "2026-05-20T23:46:02Z"
-    },
-    {
       "upstream": "Wei-Shaw/sub2api#2664",
       "url": "https://github.com/Wei-Shaw/sub2api/issues/2664",
       "title": "希望能够支持国产模型如DS的chat completions协议接入",
@@ -7345,7 +7347,7 @@
       ],
       "tokenkey_status": "not_prioritized",
       "rationale": "Appears to be enhancement/docs/UI request rather than severe online service risk.",
-      "updated_at": "2026-05-22T06:38:16Z"
+      "updated_at": "2026-05-23T13:33:37Z"
     },
     {
       "upstream": "Wei-Shaw/sub2api#286",
@@ -10525,16 +10527,6 @@
       "updated_at": "2026-05-21T15:11:09Z"
     },
     {
-      "upstream": "Wei-Shaw/sub2api#2677",
-      "url": "https://github.com/Wei-Shaw/sub2api/issues/2677",
-      "title": "Codex账号池全军覆没，需要手机号验证",
-      "impact": "unknown_low_signal",
-      "categories": [],
-      "tokenkey_status": "not_prioritized",
-      "rationale": "No high-signal production-risk keywords in this pass.",
-      "updated_at": "2026-05-22T04:20:37Z"
-    },
-    {
       "upstream": "Wei-Shaw/sub2api#2679",
       "url": "https://github.com/Wei-Shaw/sub2api/issues/2679",
       "title": "订阅分组没法设置成公开，只能专属",
@@ -10543,26 +10535,6 @@
       "tokenkey_status": "not_prioritized",
       "rationale": "No high-signal production-risk keywords in this pass.",
       "updated_at": "2026-05-22T05:53:55Z"
-    },
-    {
-      "upstream": "Wei-Shaw/sub2api#2690",
-      "url": "https://github.com/Wei-Shaw/sub2api/issues/2690",
-      "title": "0.1.125版本没法在线升级了",
-      "impact": "unknown_low_signal",
-      "categories": [],
-      "tokenkey_status": "not_prioritized",
-      "rationale": "No high-signal production-risk keywords in this pass.",
-      "updated_at": "2026-05-22T08:39:45Z"
-    },
-    {
-      "upstream": "Wei-Shaw/sub2api#2693",
-      "url": "https://github.com/Wei-Shaw/sub2api/issues/2693",
-      "title": "管理员怎么联系？sub2api 想要注册一下",
-      "impact": "unknown_low_signal",
-      "categories": [],
-      "tokenkey_status": "not_prioritized",
-      "rationale": "No high-signal production-risk keywords in this pass.",
-      "updated_at": "2026-05-23T04:50:57Z"
     },
     {
       "upstream": "Wei-Shaw/sub2api#2695",
@@ -10605,16 +10577,6 @@
       "updated_at": "2026-05-22T19:24:25Z"
     },
     {
-      "upstream": "Wei-Shaw/sub2api#2702",
-      "url": "https://github.com/Wei-Shaw/sub2api/issues/2702",
-      "title": "/admin/settings打开白屏了",
-      "impact": "unknown_low_signal",
-      "categories": [],
-      "tokenkey_status": "not_prioritized",
-      "rationale": "No high-signal production-risk keywords in this pass.",
-      "updated_at": "2026-05-23T01:57:19Z"
-    },
-    {
       "upstream": "Wei-Shaw/sub2api#2706",
       "url": "https://github.com/Wei-Shaw/sub2api/issues/2706",
       "title": "同一个厂家某一个模型不可用 整个 模型都会不可用",
@@ -10633,6 +10595,26 @@
       "tokenkey_status": "not_prioritized",
       "rationale": "No high-signal production-risk keywords in this pass.",
       "updated_at": "2026-05-23T05:52:27Z"
+    },
+    {
+      "upstream": "Wei-Shaw/sub2api#2710",
+      "url": "https://github.com/Wei-Shaw/sub2api/issues/2710",
+      "title": "压缩模型计价识别不到，另外还老是断流",
+      "impact": "unknown_low_signal",
+      "categories": [],
+      "tokenkey_status": "not_prioritized",
+      "rationale": "No high-signal production-risk keywords in this pass.",
+      "updated_at": "2026-05-23T07:02:00Z"
+    },
+    {
+      "upstream": "Wei-Shaw/sub2api#2719",
+      "url": "https://github.com/Wei-Shaw/sub2api/issues/2719",
+      "title": "管理员分级权限",
+      "impact": "unknown_low_signal",
+      "categories": [],
+      "tokenkey_status": "not_prioritized",
+      "rationale": "No high-signal production-risk keywords in this pass.",
+      "updated_at": "2026-05-23T08:55:20Z"
     },
     {
       "upstream": "Wei-Shaw/sub2api#272",


### PR DESCRIPTION
## Summary
- Refresh `.cache/upstream/triage.json` from the latest Wei-Shaw/sub2api issues.
- Update `.cache/upstream/fixes.json` from current TokenKey main fact checks.
- Keep watchdog workflow/script/fact-check metadata in sync with the refreshed cache.

## Watchdog report
# Upstream Issue Watchdog Report

- Run URL: https://github.com/youxuanxue/sub2api/actions/runs/26335779639
- Repository SHA: `63e9cd8c4dbe8ca42a33352e739d02a025619fb7`
- Generated at: `2026-05-23T14:52:24Z`
- Upstream issues scanned: `1450`
- Fact checks: `23`
- Fixed facts verified: `20`
- High/critical unresolved: `0`

## Fixed facts verified

- Wei-Shaw/sub2api#641 via None
- Wei-Shaw/sub2api#2332 via None
- Wei-Shaw/sub2api#2107 via youxuanxue/sub2api#232
- Wei-Shaw/sub2api#2159 via youxuanxue/sub2api#232
- Wei-Shaw/sub2api#2258 via youxuanxue/sub2api#232
- Wei-Shaw/sub2api#2478 via youxuanxue/sub2api#232
- Wei-Shaw/sub2api#2515 via None
- Wei-Shaw/sub2api#2506 via None
- Wei-Shaw/sub2api#2500 via None
- Wei-Shaw/sub2api#2486 via None
- Wei-Shaw/sub2api#2363 via None
- Wei-Shaw/sub2api#2332 via None
- Wei-Shaw/sub2api#1471 via None
- Wei-Shaw/sub2api#2538 via None
- Wei-Shaw/sub2api#2539 via None
- Wei-Shaw/sub2api#2556 via None
- Wei-Shaw/sub2api#2298 via None
- Wei-Shaw/sub2api#1264 via None
- Wei-Shaw/sub2api#1170 via None
- Wei-Shaw/sub2api#1824 via None

## Fact checks missing

- Wei-Shaw/sub2api#1311: scripts/check-buffered-content-type-leak.py:def scan_file
- Wei-Shaw/sub2api#1322: scripts/terminal-sentinels.json:openai_compat_responses_terminal_helper
- Wei-Shaw/sub2api#1318: backend/internal/service/openai_gateway_service.go:shouldDisable = s.rateLimitService.HandleUpstreamError(ctx, account, resp.StatusCode, resp.Header, body)


## Test plan
- [x] `python3 -m json.tool .cache/upstream/triage.json`
- [x] `python3 -m json.tool .cache/upstream/fixes.json`
- [x] `python3 -m json.tool .cache/upstream/fact-checks.json`
- [x] `python3 -m py_compile scripts/upstream/issue-watchdog.py`
- [x] `python3 -m json.tool .cache/upstream-issue-watchdog/report.json`
- [x] `python3 -m json.tool .cache/upstream-issue-watchdog/agent-input.json`
