### PR TITLE
chore(anthropic): bump L1-L5 window_cost_limit 200 → 600

### DIFF
--- a/deploy/aws/stage0/anthropic-oauth-stability-baselines-tiered.json
+++ b/deploy/aws/stage0/anthropic-oauth-stability-baselines-tiered.json
@@ -136,7 +136,7 @@
           "rpm_sticky_buffer": 5,
           "max_sessions": 30,
           "session_idle_timeout_minutes": 8,
-          "window_cost_limit": 200,
+          "window_cost_limit": 600,
           "window_cost_sticky_reserve": 0,
           "cache_ttl_override_enabled": false
         }
@@ -154,7 +154,7 @@
           "rpm_sticky_buffer": 10,
           "max_sessions": 60,
           "session_idle_timeout_minutes": 8,
-          "window_cost_limit": 200,
+          "window_cost_limit": 600,
           "window_cost_sticky_reserve": 0,
           "cache_ttl_override_enabled": false
         }
@@ -172,7 +172,7 @@
           "rpm_sticky_buffer": 15,
           "max_sessions": 90,
           "session_idle_timeout_minutes": 8,
-          "window_cost_limit": 200,
+          "window_cost_limit": 600,
           "window_cost_sticky_reserve": 0
         }
       }
@@ -189,7 +189,7 @@
           "rpm_sticky_buffer": 20,
           "max_sessions": 120,
           "session_idle_timeout_minutes": 8,
-          "window_cost_limit": 200,
+          "window_cost_limit": 600,
           "window_cost_sticky_reserve": 0
         }
       }
@@ -206,7 +206,7 @@
           "rpm_sticky_buffer": 20,
           "max_sessions": 150,
           "session_idle_timeout_minutes": 8,
-          "window_cost_limit": 200,
+          "window_cost_limit": 600,
           "window_cost_sticky_reserve": 0
         }
       }


### PR DESCRIPTION
## Summary

- 把 `deploy/aws/stage0/anthropic-oauth-stability-baselines-tiered.json` 中所有 5 个 tier (L1..L5) 的 `extra.window_cost_limit` 从 `200` 改为 `600`（每窗口 burst budget × 3）
- Live 3 个账号已通过 `manage-anthropic-config.py plan-tier-bump → apply → verify` 写入：
  - `edge=uk1 tier=l3 acct=en-ld-ec2-16-1-b`
  - `edge=us1 tier=l4 acct=cc-am-or-ec2-5-1-b`
  - `edge=us1 tier=l5 acct=am-us-ec2-5-1-b`
- L1 / L2 当前无 live 账号（plan noop=true），JSON 修改作为下次该 tier 上线时的基线
- 最终 `check-edge-oauth-stability` 全绿，verify drift_count=0/1 × 3
- 纯数据/配置改动（`deploy/aws/stage0/*.json`），无 backend Go / frontend 代码影响

## Test plan

- [x] `python3 ops/anthropic/manage-anthropic-config.py snapshot` → ok
- [x] `python3 ops/anthropic/manage-anthropic-config.py check` 改前全绿
- [x] 5 个 tier 的 `plan-tier-bump`（L1/L2 noop，L3/L4/L5 各 1 action）
- [x] `apply --confirm yes-apply-anthropic-config-cascade` × 3，全部 success=True
- [x] `verify` × 3，drift_count=0/1 each
- [x] post-apply `snapshot + check` → 全绿，live `window_cost_limit=600` × 3
- [x] `scripts/preflight.sh` PASS（含 sub2api-specific checks）

🤖 Generated with [Claude Code](https://claude.com/claude-code)