### PR TITLE
fix(ratelimit): close upstream #2413 — OpenAI HTML 403 must not poison OAuth pool

### DIFF
--- a/backend/internal/service/ratelimit_service.go
+++ b/backend/internal/service/ratelimit_service.go
@@ -1139,6 +1139,20 @@ func (s *RateLimitService) handleOpenAI403(ctx context.Context, account *Account
 		return true
 	}
 
+	// TK: shape-based fallback for HTML 403 bodies that don't match a known
+	// challenge keyword — most notably OpenAI's own UA / bot-detect
+	// access-denied page (issue #2413 sample). Real OpenAI account-level
+	// 403s return JSON; any HTML body on a 403 is per-request infrastructure
+	// noise and must not poison the OAuth pool with a cooldown.
+	if openAIIsHTMLBody(responseBody) {
+		slog.Warn(
+			"openai_403_html_body_skip_cooldown",
+			"account_id", account.ID,
+			"upstream_msg", upstreamMsg,
+		)
+		return true
+	}
+
 	msg := buildForbiddenErrorMessage(
 		"Access forbidden (403):",
 		upstreamMsg,

--- a/backend/internal/service/ratelimit_service_tk_openai_html_403.go
+++ b/backend/internal/service/ratelimit_service_tk_openai_html_403.go
@@ -1,0 +1,54 @@
+package service
+
+import "bytes"
+
+// openAIHTMLBodyMarkers are the document-shape tags that identify an OpenAI
+// 403 response body as HTML rather than the structured JSON error envelope
+// (`{"error":{"code":"...","message":"..."}}`) that legitimate account-level
+// 403s carry. Any 403 whose body looks like an HTML document — Cloudflare
+// challenge, Arkose FunCaptcha, OpenAI's own UA / bot-detect access-denied
+// page (issue Wei-Shaw/sub2api#2413), proxy interstitials, etc. — is
+// per-request infrastructure noise; the OAuth identity is healthy and must
+// not be poisoned with a cooldown.
+//
+// Match is case-insensitive and runs only against the first openAIHTMLProbe
+// bytes of the body to keep the check O(1) for large bodies.
+var openAIHTMLBodyMarkers = [][]byte{
+	[]byte("<!doctype html"),
+	[]byte("<html"),
+	[]byte("<head"),
+	[]byte("<body"),
+	[]byte("<meta"),
+	[]byte("<style"),
+}
+
+const openAIHTMLProbe = 2048
+
+// openAIIsHTMLBody returns true when body looks like an HTML document. It is
+// the shape-based companion to openAICloudflareChallengeKeywords: keywords
+// match known challenge platforms by name, while openAIIsHTMLBody catches
+// every other HTML 403 shape — most importantly OpenAI's own access-denied
+// page, whose body contains none of the CF/Arkose keywords (see issue #2413
+// sample: `.logo{color:#8e8ea0}`, `scale-appear`, OpenAI-branded layout).
+//
+// The invariant we rely on is documented at ratelimit_service.go:128 — a
+// real OpenAI account-level 403 returns structured JSON. Any HTML 403 is
+// upstream infrastructure rejecting *this request*, not OpenAI rejecting
+// *this account*.
+func openAIIsHTMLBody(body []byte) bool {
+	trimmed := bytes.TrimLeft(body, " \t\r\n\xef\xbb\xbf")
+	if len(trimmed) == 0 || trimmed[0] != '<' {
+		return false
+	}
+	head := trimmed
+	if len(head) > openAIHTMLProbe {
+		head = head[:openAIHTMLProbe]
+	}
+	lower := bytes.ToLower(head)
+	for _, marker := range openAIHTMLBodyMarkers {
+		if bytes.Contains(lower, marker) {
+			return true
+		}
+	}
+	return false
+}

--- a/backend/internal/service/ratelimit_service_tk_openai_html_403_test.go
+++ b/backend/internal/service/ratelimit_service_tk_openai_html_403_test.go
@@ -1,0 +1,215 @@
+//go:build unit
+
+package service
+
+import (
+	"context"
+	"net/http"
+	"strings"
+	"testing"
+
+	"github.com/Wei-Shaw/sub2api/internal/config"
+	"github.com/stretchr/testify/require"
+)
+
+// TK regression for upstream Wei-Shaw/sub2api#2413 (partially_mitigated):
+//
+// The CF/Arkose keyword list in ratelimit_service.go catches Cloudflare's
+// "Just a moment..." page and Arkose FunCaptcha, but the production sample
+// pasted in the upstream issue is OpenAI's *own* access-denied HTML page —
+// it contains none of `cloudflare` / `arkoselabs` / `funcaptcha` /
+// `challenge-platform` / `just a moment`. Before this fix, that HTML body
+// silently incremented the per-account 403 counter and wrote a 10-minute
+// temp_unschedulable cooldown on a healthy OAuth account on the FIRST hit,
+// then permanently SetError on the 3rd hit within 180 minutes. Result:
+// healthy accounts evicted from the pool, all non-image traffic on those
+// accounts denied too.
+//
+// Shape-based invariant (documented at ratelimit_service.go:128): a real
+// OpenAI account-level 403 returns structured JSON. Any HTML body on a 403
+// is upstream infrastructure rejecting this *request*, not OpenAI rejecting
+// this *account* — must skip the counter and the cooldown.
+
+// openAIAccessDeniedHTMLSample reproduces the exact HTML head shape pasted
+// by the upstream reporter at issue #2413 (Cherry Studio / gpt-image-2
+// triggering OpenAI 403). The distinguishing marker is OpenAI's brand
+// `.logo{color:#8e8ea0}` and the `scale-appear` animation class — none of
+// which match the CF/Arkose keyword list.
+const openAIAccessDeniedHTMLSample = `<html>
+ <head>
+ <meta name="viewport" content="width=device-width, initial-scale=1" />
+ <style global>body{font-family:Arial,Helvetica,sans-serif}.container{align-items:center;display:flex;flex-direction:column;gap:2rem;height:100%;justify-content:center;width:100%}@keyframes enlarge-appear{0%{opacity:0;transform:scale(75%) rotate(-90deg)}to{opacity:1;transform:scale(100%) rotate(0deg)}}.logo{color:#8e8ea0}.scale-appear{animation:enlarge-appear .4s ease-out}@media (min-width:768px){.scale-appear{height:128px;width:128px}}</style>
+ </head>
+ <body>
+ <div class="container">
+ <div class="logo scale-appear">Access denied</div>
+ </div>
+ </body>
+</html>`
+
+func TestRateLimitService_HandleUpstreamError_OpenAI403OpenAIAccessDeniedHTMLSkipsCooldown(t *testing.T) {
+	repo := &rateLimitAccountRepoStub{}
+	counter := &openAI403CounterCacheStub{counts: []int64{1}}
+	service := NewRateLimitService(repo, nil, &config.Config{}, nil, nil)
+	service.SetOpenAI403CounterCache(counter)
+
+	account := &Account{
+		ID:       2413,
+		Platform: PlatformOpenAI,
+		Type:     AccountTypeOAuth,
+	}
+
+	shouldDisable := service.HandleUpstreamError(
+		context.Background(),
+		account,
+		http.StatusForbidden,
+		http.Header{},
+		[]byte(openAIAccessDeniedHTMLSample),
+	)
+
+	require.True(t, shouldDisable, "shouldDisable must remain true so failover proceeds")
+	require.Equal(t, 0, repo.tempCalls, "OpenAI access-denied HTML must not write temp_unschedulable")
+	require.Equal(t, 0, repo.setErrorCalls, "OpenAI access-denied HTML must not SetError")
+	require.Empty(t, counter.incrementIDs, "OpenAI access-denied HTML must not increment the 403 counter")
+}
+
+// Variants of the shape predicate: different HTML opening tags, whitespace,
+// BOM prefix, mixed case — all must be treated as HTML.
+func TestRateLimitService_HandleUpstreamError_OpenAI403HTMLShapeVariantsSkipCooldown(t *testing.T) {
+	cases := []struct {
+		name string
+		body []byte
+	}{
+		{name: "doctype_prefix", body: []byte(`<!DOCTYPE html><html><body>nope</body></html>`)},
+		{name: "doctype_mixed_case", body: []byte(`<!DocType HTML><HTML><BODY>nope</BODY></HTML>`)},
+		{name: "head_only", body: []byte(`<head><title>403</title></head>`)},
+		{name: "body_only", body: []byte(`<body>Access denied</body>`)},
+		{name: "meta_only", body: []byte(`<meta charset="utf-8"><p>Forbidden</p>`)},
+		{name: "style_only", body: []byte(`<style>body{color:red}</style>403`)},
+		{name: "leading_whitespace", body: []byte("   \n\t<html><body>nope</body></html>")},
+		{name: "leading_bom", body: []byte("\xef\xbb\xbf<html><body>nope</body></html>")},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			repo := &rateLimitAccountRepoStub{}
+			counter := &openAI403CounterCacheStub{counts: []int64{1}}
+			service := NewRateLimitService(repo, nil, &config.Config{}, nil, nil)
+			service.SetOpenAI403CounterCache(counter)
+
+			account := &Account{
+				ID:       2413,
+				Platform: PlatformOpenAI,
+				Type:     AccountTypeOAuth,
+			}
+
+			shouldDisable := service.HandleUpstreamError(
+				context.Background(),
+				account,
+				http.StatusForbidden,
+				http.Header{},
+				tc.body,
+			)
+
+			require.True(t, shouldDisable)
+			require.Equal(t, 0, repo.tempCalls)
+			require.Equal(t, 0, repo.setErrorCalls)
+			require.Empty(t, counter.incrementIDs)
+		})
+	}
+}
+
+// Regression guard against the opposite mistake: a structured JSON 403
+// describing a real account problem (suspended, lacks permissions, workspace
+// deactivated, etc.) must still go through the normal counter +
+// temp_unschedulable path. If shape detection bled into legitimate JSON
+// errors, real account-health problems would be silently masked.
+func TestRateLimitService_HandleUpstreamError_OpenAI403JSONBodyStillCoolsDown(t *testing.T) {
+	cases := []struct {
+		name string
+		body []byte
+	}{
+		{
+			name: "structured_error_envelope",
+			body: []byte(`{"error":{"message":"You do not have permission to access this endpoint.","type":"forbidden","code":"account_disabled_auth_error"}}`),
+		},
+		{
+			name: "plain_text_forbidden",
+			body: []byte(`Forbidden`),
+		},
+		{
+			name: "empty_body",
+			body: []byte(``),
+		},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			repo := &rateLimitAccountRepoStub{}
+			counter := &openAI403CounterCacheStub{counts: []int64{1}}
+			service := NewRateLimitService(repo, nil, &config.Config{}, nil, nil)
+			service.SetOpenAI403CounterCache(counter)
+
+			account := &Account{
+				ID:       902,
+				Platform: PlatformOpenAI,
+				Type:     AccountTypeOAuth,
+			}
+
+			shouldDisable := service.HandleUpstreamError(
+				context.Background(),
+				account,
+				http.StatusForbidden,
+				http.Header{},
+				tc.body,
+			)
+
+			require.True(t, shouldDisable)
+			require.Equal(t, 1, repo.tempCalls, "real JSON / opaque 403 must still write temp_unschedulable")
+			require.Equal(t, []int64{902}, counter.incrementIDs)
+		})
+	}
+}
+
+// Unit-level coverage of the shape predicate itself, kept separate from the
+// integration-style HandleUpstreamError tests so a regression localises
+// quickly to the predicate vs. the wiring.
+func TestOpenAIIsHTMLBody(t *testing.T) {
+	htmlCases := []struct {
+		name string
+		body string
+	}{
+		{"doctype", `<!DOCTYPE html><html></html>`},
+		{"html_tag", `<html><body></body></html>`},
+		{"head_only", `<head></head>`},
+		{"body_only", `<body></body>`},
+		{"meta_only", `<meta charset="utf-8">`},
+		{"style_only", `<style>body{}</style>`},
+		{"mixed_case", `<HTML></HTML>`},
+		{"leading_ws", "   \n\t<html></html>"},
+		{"bom_prefix", "\xef\xbb\xbf<html></html>"},
+		{"issue_2413_sample", openAIAccessDeniedHTMLSample},
+		{"large_body_marker_in_probe", "<html>" + strings.Repeat("x", openAIHTMLProbe)},
+	}
+	for _, tc := range htmlCases {
+		t.Run("html/"+tc.name, func(t *testing.T) {
+			require.True(t, openAIIsHTMLBody([]byte(tc.body)), "expected HTML detection for %q", tc.name)
+		})
+	}
+
+	nonHTMLCases := []struct {
+		name string
+		body string
+	}{
+		{"empty", ``},
+		{"whitespace_only", `   `},
+		{"json_envelope", `{"error":{"message":"forbidden"}}`},
+		{"plain_text", `Forbidden`},
+		{"xml_no_html", `<?xml version="1.0"?><root><a/></root>`},
+		{"json_string_with_lt", `"<html>"`},
+		{"marker_after_probe_window", "<x>" + strings.Repeat(" ", openAIHTMLProbe+16) + "<html>"},
+	}
+	for _, tc := range nonHTMLCases {
+		t.Run("non_html/"+tc.name, func(t *testing.T) {
+			require.False(t, openAIIsHTMLBody([]byte(tc.body)), "expected non-HTML for %q", tc.name)
+		})
+	}
+}

--- a/scripts/sentinels/gateway-tk.json
+++ b/scripts/sentinels/gateway-tk.json
@@ -151,6 +151,8 @@
         "tlsFingerprintFailureCooldown",
         "openAICloudflareChallengeKeywords",
         "openai_403_cf_challenge_skip_cooldown",
+        "openAIIsHTMLBody",
+        "openai_403_html_body_skip_cooldown",
         "handleAnthropicUpstreamError",
         "handleAnthropicUpstreamErrorWithOptions",
         "IncrementAnthropicUpstreamErrorCount",
@@ -238,6 +240,17 @@
         "TestRateLimitService_HandleUpstreamError_OpenAI403CFChallengeSkipsForAPIKey"
       ],
       "rationale": "Focused regressions for the OpenAI 403 Cloudflare / Arkose challenge short-circuit (upstream Wei-Shaw/sub2api#1824, #2413). Without these tests, an upstream merge or refactor that 'simplifies' handleOpenAI403 by dropping the body keyword scan would silently restore the OAuth-pool-poisoning behavior: a single CF/Arkose challenge on /v1/images/{generations,edits} writes a 10-min temp_unschedulable on the FIRST hit and escalates to SetError on the 3rd within 180 min, removing the account from ALL non-image traffic. The four cases anchor: (1) the four body shapes in the keyword list each match (just-a-moment, cloudflare, arkoselabs, challenge-platform), (2) a real account 403 with structured JSON STILL increments the counter and writes temp_unschedulable, (3) a CF keyword inside a JSON envelope still skips (regression guard for over-clever JSON-aware future refactors), (4) APIKey accounts also benefit — the short-circuit runs before any OAuth-specific branch."
+    },
+    {
+      "path": "backend/internal/service/ratelimit_service_tk_openai_html_403_test.go",
+      "must_contain": [
+        "TestRateLimitService_HandleUpstreamError_OpenAI403OpenAIAccessDeniedHTMLSkipsCooldown",
+        "TestRateLimitService_HandleUpstreamError_OpenAI403HTMLShapeVariantsSkipCooldown",
+        "TestRateLimitService_HandleUpstreamError_OpenAI403JSONBodyStillCoolsDown",
+        "TestOpenAIIsHTMLBody",
+        "openAIAccessDeniedHTMLSample"
+      ],
+      "rationale": "Shape-based fallback for OpenAI 403 (upstream Wei-Shaw/sub2api#2413 partial-mitigation closeout). The CF/Arkose keyword list only catches *named* challenge platforms; the upstream issue's actual production sample is OpenAI's own UA / bot-detect access-denied HTML page (`.logo{color:#8e8ea0}`, `scale-appear`), which contains none of the keywords and previously slipped through into the 10-min temp_unschedulable + 3/180 SetError path on healthy OAuth accounts. The shape predicate `openAIIsHTMLBody` (anchored in ratelimit_service.go sentinel) catches any HTML 403 body. These regressions anchor: (1) the issue #2413 HTML sample is treated as request-level noise (no counter increment, no cooldown, account stays in the pool), (2) HTML shape variants (DOCTYPE / mixed case / leading whitespace / BOM / individual tags) all detected, (3) non-HTML 403s (structured JSON, plain text, empty body) STILL cool down — regression guard against the predicate bleeding into legitimate account-health 403s, (4) the predicate-level unit test covers boundary conditions (probe window cutoff, XML without HTML tags) so a future refactor cannot silently widen detection. Without these, an upstream merge that 'tightens' the predicate or drops the call site would silently restore OAuth-pool poisoning on every gpt-image-2 UA-detect 403."
     },
     {
       "path": "backend/internal/service/ratelimit_service_401_test.go",

--- a/scripts/test_release_decide_version.py
+++ b/scripts/test_release_decide_version.py
@@ -7,6 +7,7 @@ stdlib-only.
 """
 from __future__ import annotations
 
+import os
 import pathlib
 import shutil
 import subprocess
@@ -16,8 +17,15 @@ import unittest
 _SCRIPT = pathlib.Path(__file__).resolve().parent / "release-decide-version.sh"
 
 
+def _clean_env() -> dict[str, str]:
+    return {k: v for k, v in os.environ.items() if not k.startswith("GIT_")}
+
+
 def _git(cwd: pathlib.Path, *args: str, check: bool = True) -> str:
-    proc = subprocess.run(["git", *args], cwd=cwd, capture_output=True, text=True, check=check)
+    proc = subprocess.run(
+        ["git", *args], cwd=cwd, env=_clean_env(),
+        capture_output=True, text=True, check=check,
+    )
     return proc.stdout
 
 
@@ -28,7 +36,10 @@ class ReleaseDecideVersionTest(unittest.TestCase):
         self.origin = tmp / "origin.git"
         self.repo = tmp / "repo"
         # Bare origin
-        subprocess.run(["git", "init", "--bare", "-q", "-b", "main", str(self.origin)], check=True)
+        subprocess.run(
+            ["git", "init", "--bare", "-q", "-b", "main", str(self.origin)],
+            env=_clean_env(), check=True,
+        )
         # Working repo
         self.repo.mkdir()
         _git(self.repo, "init", "-q", "-b", "main")
@@ -51,7 +62,8 @@ class ReleaseDecideVersionTest(unittest.TestCase):
     def _run(self) -> dict:
         proc = subprocess.run(
             ["bash", "scripts/release-decide-version.sh"],
-            cwd=self.repo, capture_output=True, text=True, check=False,
+            cwd=self.repo, env=_clean_env(),
+            capture_output=True, text=True, check=False,
         )
         if proc.returncode != 0:
             raise AssertionError(
@@ -102,7 +114,8 @@ class ReleaseDecideVersionTest(unittest.TestCase):
         _git(self.repo, "push", "-q", "origin", "main")
         proc = subprocess.run(
             ["bash", "scripts/release-decide-version.sh", "--emit-suggested-bump"],
-            cwd=self.repo, capture_output=True, text=True, check=True,
+            cwd=self.repo, env=_clean_env(),
+            capture_output=True, text=True, check=True,
         )
         self.assertIn("suggested_next_version=1.0.1", proc.stdout)
 

--- a/scripts/test_release_impact_files.py
+++ b/scripts/test_release_impact_files.py
@@ -8,6 +8,7 @@ stdlib-only.
 from __future__ import annotations
 
 import json
+import os
 import pathlib
 import shutil
 import subprocess
@@ -17,8 +18,15 @@ import unittest
 _SCRIPT = pathlib.Path(__file__).resolve().parent / "release-impact-files.sh"
 
 
+def _clean_env() -> dict[str, str]:
+    return {k: v for k, v in os.environ.items() if not k.startswith("GIT_")}
+
+
 def _run_git(cwd: pathlib.Path, *args: str) -> str:
-    proc = subprocess.run(["git", *args], cwd=cwd, capture_output=True, text=True, check=True)
+    proc = subprocess.run(
+        ["git", *args], cwd=cwd, env=_clean_env(),
+        capture_output=True, text=True, check=True,
+    )
     return proc.stdout
 
 
@@ -56,7 +64,8 @@ class ReleaseImpactFilesTest(unittest.TestCase):
     def _classify(self, base: str, head: str) -> dict:
         proc = subprocess.run(
             ["bash", "scripts/release-impact-files.sh", base, head],
-            cwd=self.repo, capture_output=True, text=True, check=True,
+            cwd=self.repo, env=_clean_env(),
+            capture_output=True, text=True, check=True,
         )
         return json.loads(proc.stdout)
 

--- a/scripts/test_release_rollout_summary.py
+++ b/scripts/test_release_rollout_summary.py
@@ -4,6 +4,7 @@ the expected markdown sections against a fake repo. stdlib-only.
 """
 from __future__ import annotations
 
+import os
 import pathlib
 import shutil
 import subprocess
@@ -13,8 +14,15 @@ import unittest
 _SCRIPT = pathlib.Path(__file__).resolve().parent / "release-rollout-summary.sh"
 
 
+def _clean_env() -> dict[str, str]:
+    return {k: v for k, v in os.environ.items() if not k.startswith("GIT_")}
+
+
 def _git(cwd: pathlib.Path, *args: str, check: bool = True) -> str:
-    proc = subprocess.run(["git", *args], cwd=cwd, capture_output=True, text=True, check=check)
+    proc = subprocess.run(
+        ["git", *args], cwd=cwd, env=_clean_env(),
+        capture_output=True, text=True, check=check,
+    )
     return proc.stdout
 
 
@@ -51,7 +59,8 @@ class ReleaseRolloutSummaryTest(unittest.TestCase):
     def _run(self, *args: str) -> str:
         proc = subprocess.run(
             ["bash", "scripts/release-rollout-summary.sh", *args],
-            cwd=self.repo, capture_output=True, text=True, check=True,
+            cwd=self.repo, env=_clean_env(),
+            capture_output=True, text=True, check=True,
         )
         return proc.stdout
 
@@ -88,7 +97,8 @@ class ReleaseRolloutSummaryTest(unittest.TestCase):
     def test_invalid_mode_rejected(self) -> None:
         proc = subprocess.run(
             ["bash", "scripts/release-rollout-summary.sh", "--mode", "bogus"],
-            cwd=self.repo, capture_output=True, text=True, check=False,
+            cwd=self.repo, env=_clean_env(),
+            capture_output=True, text=True, check=False,
         )
         self.assertNotEqual(proc.returncode, 0)
         self.assertIn("--mode must be", proc.stderr)


### PR DESCRIPTION
## Why

Upstream Wei-Shaw/sub2api#2413 was triaged as `partially_mitigated`: the existing CF/Arkose keyword guard in `handleOpenAI403` catches *named* challenge platforms (cloudflare, just-a-moment, arkoselabs, funcaptcha, challenge-platform) but the **production HTML sample pasted in that issue is OpenAI's own UA / bot-detect access-denied page** (`.logo{color:#8e8ea0}`, `scale-appear`) — none of those keywords appear. Before this PR, that body silently:

1. incremented the per-account 403 counter
2. wrote a 10-min `temp_unschedulable` on the **first** hit
3. permanently `SetError` on the 3rd hit within a 180-min window

Net effect: a single misbehaving client (Cherry Studio, gpt_image_playground, lobehub local-browser mode, etc.) repeatedly drained healthy OAuth accounts out of the pool **for all non-image traffic too**. Cooldown TTLs were inherited unchanged from upstream and tested against CF-shaped bodies only, so the regression silently survived PR #347.

## What

- `backend/internal/service/ratelimit_service_tk_openai_html_403.go`: new TK-only file. `openAIIsHTMLBody(body)` is a shape-based predicate — body starts with `<` (after BOM/whitespace trim) **and** contains one of `{<!doctype html, <html, <head, <body, <meta, <style}` in the first 2 KB. Case-insensitive, stdlib-only (`bytes`).
- `backend/internal/service/ratelimit_service.go`: 13-line hook in `handleOpenAI403` immediately after the existing CF keyword check. Hits log `openai_403_html_body_skip_cooldown` and return `shouldDisable=true` (in-flight request still fails over).
- `backend/internal/service/ratelimit_service_tk_openai_html_403_test.go`: reproduces the verbatim issue #2413 HTML sample, eight shape variants (DOCTYPE / mixed case / leading whitespace / BOM / individual tags), three JSON-or-opaque regression-guard cases (structured error envelope / plain text / empty), and predicate-level unit tests for boundary conditions (probe-window cutoff, XML without HTML tags, JSON-string-with-`<`).
- `scripts/sentinels/gateway-tk.json`: anchors `openAIIsHTMLBody` + `openai_403_html_body_skip_cooldown` next to the existing `openAICloudflareChallengeKeywords` line and registers the four new test names. Same pattern as the CF challenge sentinel — future upstream merges cannot silently drop the guard.
- `scripts/test_release_*.py` (×3): tempdir-based git tests inherit GIT_* env vars from `git commit`, so `subprocess.run(["git", "add", "-A"], cwd=tempdir)` was operating on the outer worktree's index and exit-128'ing under pre-commit context (FAILED errors=15 only when invoked from a commit; OK when run directly). Added `_clean_env()` helper that strips GIT_*; verified by `GIT_DIR=$PWD/.git GIT_INDEX_FILE=$PWD/.git/index python3 -m unittest discover -s scripts ...` → OK 15/15.

## Invariant

Already documented at `backend/internal/service/ratelimit_service.go:128`:

> a real OpenAI 403 returns structured JSON (`{"error":{"code":"...","message":"..."}}`), none of these keywords appear in legitimate auth/permission errors.

This PR makes that invariant load-bearing instead of advisory. JSON-body 403 still goes through the counter + temp_unschedulable path unchanged (pinned by `TestRateLimitService_HandleUpstreamError_OpenAI403JSONBodyStillCoolsDown`).

## Risk

- **Predicate over-fires (HTML detected when body is real account-level 403):** outcome is a non-cooldown — the request fails over to another account instead of an account eviction. Strictly safer than the current pool-poisoning misbehavior. Regression test pins the JSON path.
- **Predicate under-fires (HTML body slips past detection):** falls back to existing keyword + counter path. No new behavior; matches today.
- **No web impact** — backend-only change in a service-layer helper. Confirmed via `check_web_surface_alignment` preflight check (no `frontend/` paths touched).

## Test plan

- [x] `go test -tags=unit -run 'OpenAI403|OpenAIIsHTMLBody' ./internal/service/` → PASS (all variants + JSON regression guard)
- [x] `go test -tags=unit ./internal/service/` → PASS
- [x] `go build ./...` → ok
- [x] `go vet ./...` → ok
- [x] `golangci-lint run ./...` → 0 issues
- [x] `python3 -m unittest discover -s scripts -p 'test_*.py' -t scripts` → OK 15/15
- [x] `GIT_DIR=$PWD/.git GIT_INDEX_FILE=$PWD/.git/index python3 -m unittest discover -s scripts ...` → OK 15/15 (pre-commit-hook env simulation)
- [x] `bash scripts/preflight.sh` → PASS (branch naming, dev-rules submodule reachable, sentinel registry intact, all sub2api-specific checks)

## Markers (per CLAUDE.md §5.y.1 / §9.2)

- `no-web-impact` — backend service-layer only
- `upstream-touch-guarded` — anchors added to `scripts/sentinels/gateway-tk.json`

## Audit cadence

```
$ git log --oneline upstream/main..HEAD | wc -l
       1   (this PR commit + ahead from prior merges)
$ git diff --stat upstream/main..HEAD -- backend/ | tail -5
 backend/internal/service/ratelimit_service.go                       |   14 +
 backend/internal/service/ratelimit_service_tk_openai_html_403.go    |   54 +
 backend/internal/service/ratelimit_service_tk_openai_html_403_test.go | 215 +
```

Refs upstream Wei-Shaw/sub2api#2413 (closes the partial-mitigation gap).

Reviewer: **Squash and merge** per CLAUDE.md §5.y (TK-originated fix, not an upstream merge).

🤖 Generated with [Claude Code](https://claude.com/claude-code)