### PR TITLE
feat(edge-migration): decommission op + migration-preflight + orchestrator skill (Phase 0 tooling)

### DIFF
--- a/.cursor/skills/tokenkey-stage0-edge-platform-migration/SKILL.md
+++ b/.cursor/skills/tokenkey-stage0-edge-platform-migration/SKILL.md
@@ -1,19 +1,20 @@
 ---
 name: tokenkey-stage0-edge-platform-migration
 description: >-
-  Migrate a TokenKey Stage0 Edge between platforms (EC2/CFN ↔ AWS Lightsail) on
-  the same `<edge_id>`, sharing the DNS domain `api-<id>.tokenkey.dev`. Drives
-  the full sequence: pre-flight (read-only AWS checks), one-time IAM addon +
-  GHCR PAT setup, matrix flip (exclusivity gate enforces single-platform), new
-  platform provision + smoke without DNS cut, operator OAuth re-login on the
-  fresh edge DB, DNS cut at Porkbun, post-cut smoke from an independent vantage
-  point, and finally CFN-native decommission of the retired platform (auto EBS
-  snapshot, optional EIP release). EC2/CFN remains the default Edge path; this
-  skill exists for migration to/from Lightsail (or future platforms) without
-  ad-hoc operator coordination.
+  Migrate a TokenKey Stage0 Edge **from EC2/CFN to AWS Lightsail** on the same
+  `<edge_id>`, sharing the DNS domain `api-<id>.tokenkey.dev`. Drives the full
+  sequence: pre-flight (read-only AWS checks), one-time IAM addon + GHCR PAT
+  setup, matrix flip (exclusivity gate enforces single-platform), Lightsail
+  provision + smoke without DNS cut, operator OAuth re-login on the fresh
+  edge DB, DNS cut at Porkbun, post-cut smoke from an independent vantage
+  point, and finally CFN-native decommission of the retired EC2 stack (auto
+  EBS snapshot, optional EIP release). EC2/CFN remains the default Edge path;
+  this skill exists for the one-way EC2→Lightsail migration. The reverse
+  direction (Lightsail→EC2) is intentionally NOT implemented — build at first
+  need rather than ship an unimplemented API; see §7.
 ---
 
-# TokenKey：Edge 平台迁移全流程（EC2 ↔ Lightsail）
+# TokenKey：Edge 平台迁移全流程（EC2 → Lightsail，单向）
 
 适用于 TokenKey fork of sub2api。本 skill **只迁移同一个 `<edge_id>` 在两个平台之间**（共享 DNS `api-<id>.tokenkey.dev`），不是"新增一个 edge"——后者用 `tokenkey-stage0-edge-expansion` 或 `tokenkey-stage0-edge-lightsail-expansion`。
 

--- a/.cursor/skills/tokenkey-stage0-edge-platform-migration/SKILL.md
+++ b/.cursor/skills/tokenkey-stage0-edge-platform-migration/SKILL.md
@@ -1,0 +1,213 @@
+---
+name: tokenkey-stage0-edge-platform-migration
+description: >-
+  Migrate a TokenKey Stage0 Edge between platforms (EC2/CFN ↔ AWS Lightsail) on
+  the same `<edge_id>`, sharing the DNS domain `api-<id>.tokenkey.dev`. Drives
+  the full sequence: pre-flight (read-only AWS checks), one-time IAM addon +
+  GHCR PAT setup, matrix flip (exclusivity gate enforces single-platform), new
+  platform provision + smoke without DNS cut, operator OAuth re-login on the
+  fresh edge DB, DNS cut at Porkbun, post-cut smoke from an independent vantage
+  point, and finally CFN-native decommission of the retired platform (auto EBS
+  snapshot, optional EIP release). EC2/CFN remains the default Edge path; this
+  skill exists for migration to/from Lightsail (or future platforms) without
+  ad-hoc operator coordination.
+---
+
+# TokenKey：Edge 平台迁移全流程（EC2 ↔ Lightsail）
+
+适用于 TokenKey fork of sub2api。本 skill **只迁移同一个 `<edge_id>` 在两个平台之间**（共享 DNS `api-<id>.tokenkey.dev`），不是"新增一个 edge"——后者用 `tokenkey-stage0-edge-expansion` 或 `tokenkey-stage0-edge-lightsail-expansion`。
+
+权威纪律：仓库根 `CLAUDE.md`、`docs/spec-delta-edge-lightsail.md`、规划 `docs/deploy/tokenkey-multiregion-egress-gateway-plan.md` §6.1（EC2/CFN 为默认 Edge 路径）。
+
+## 确定性基线（机械化 vs 真判断）
+
+| 步骤 | 类型 | 承载 |
+|---|---|---|
+| 矩阵一致性 + 平台 exclusivity 检查 | 机械 | `scripts/checks/edge-platform-exclusivity.py`（已接入 preflight） |
+| 各阶段实操前置检查 | 机械 | `ops/migration/edge-platform-migration-preflight.sh <edge_id> --phase=<plan|provision|cutover|decommission>` |
+| Lightsail provision / 升级 / smoke / Static IP rotation | 机械 | `deploy-edge-lightsail-stage0.yml` |
+| EC2 decommission（含 EBS snapshot + 可选 EIP release） | 机械 | `deploy-edge-stage0.yml operation=decommission` |
+| 矩阵翻位（哪边 deployable=true） | 真判断 | prompt（迁移的边界决策；通过 PR 落地） |
+| DNS A 记录 swap | 真判断 | Porkbun 人工编辑（独立人审批入口） |
+| 新 edge 上 OAuth 账号重新登录 | 真判断 | 管理员 UI 操作（不可机械化的鉴权流） |
+| 是否 release 旧平台 EIP / 是否保留 snapshot rollback 窗 | 真判断 | prompt（保留成本 vs 回滚窗口） |
+
+## 调用参数
+
+```text
+/tokenkey-stage0-edge-platform-migration edge_id=<id> direction=<ec2-to-lightsail|lightsail-to-ec2> [tag=X.Y.Z] [phase=<plan|provision|cutover|decommission|all>] [keep_eip=false]
+```
+
+| 参数 | 语义 |
+|---|---|
+| `edge_id` | 要迁移的 edge，如 `uk1` / `us1` / `fra1` / `sg1` |
+| `direction` | `ec2-to-lightsail`：从 EC2/CFN 迁到 Lightsail；`lightsail-to-ec2`：反向 |
+| `tag` | 新平台 provision 用的 image tag（无 v 前缀） |
+| `phase` | 分阶段执行；默认 `all`（=plan→provision→cutover→decommission） |
+| `keep_eip` | 仅 ec2-to-lightsail：旧 EC2 EIP 是否保留（默认 true，便于回滚到 EC2） |
+
+## 0) 前置（一次性 / 每个 AWS 账户）
+
+仅 EC2→Lightsail 方向；反向迁移用现有 EC2 skill。
+
+```bash
+# 1) Lightsail IAM addon — 整个 AWS account 一次
+aws cloudformation deploy \
+  --region us-east-1 \
+  --stack-name tokenkey-cicd-lightsail-addon \
+  --template-file deploy/aws/cloudformation/cicd-oidc-lightsail-addon.yaml \
+  --parameter-overrides GitHubOidcRoleName=tokenkey-gha-us-east-1-error-clustering
+
+# 2) 该 Lightsail region 一次性 PAT
+aws ssm put-parameter --region <lightsail_region> \
+  --name /tokenkey/lightsail/<edge_id>/ghcr/pat \
+  --type SecureString --value 'ghp_…'
+
+# 3) GitHub Environment edge-<edge_id> 已存在（与 EC2 共用），确认变量齐
+#    EDGE_ACME_EMAIL / EDGE_MAIN_GATEWAY_ALLOWED_CIDR / EDGE_MAIN_GATEWAY_BASE_URL
+#    secret: MAIN_GATEWAY_EDGE_SMOKE_API_KEY
+```
+
+可机械验证：
+
+```bash
+bash ops/migration/edge-platform-migration-preflight.sh <edge_id> --phase=provision
+```
+
+未通过则按报错指引补齐再进入 Phase 1。
+
+## 1) Phase plan：迁移意图落码
+
+EC2→Lightsail 方向，前置假设：
+- EC2 `<edge_id>` 当前 `deployable=false`（已退役 ops 矩阵）
+- Lightsail `<edge_id>` 当前 `deployable=false`（PR #380 默认）
+- DNS `api-<id>.tokenkey.dev` 当前指向 EC2 EIP 或已经空
+
+**机械检查**：
+
+```bash
+bash ops/migration/edge-platform-migration-preflight.sh <edge_id> --phase=plan
+```
+
+**手工 PR**：把 Lightsail `<edge_id>` 翻成 `deployable=true`，提交 PR。`edge-platform-exclusivity` preflight 会强制 EC2 同名仍是 `false`；CI 全绿后由操作员合并。
+
+> **不要在同一 PR 里同时翻两边的 deployable**——分两步可以让 exclusivity gate 始终强一致。
+
+## 2) Phase provision：实机起 Lightsail，**不切 DNS**
+
+合并完矩阵 PR 后，dispatch Lightsail provision：
+
+```bash
+TAG=<current_prod_tag>
+gh workflow run deploy-edge-lightsail-stage0.yml \
+  -f edge_id=<edge_id> \
+  -f operation=provision \
+  -f tag=$TAG \
+  -f confirm_instance=tokenkey-edge-<edge_id>-ls
+gh run watch --exit-status $(gh run list -w deploy-edge-lightsail-stage0.yml -L 1 --json databaseId -q '.[0].databaseId')
+```
+
+Job summary 输出 Static IP；**不要立刻改 DNS**。先用 `--resolve` 旁路验证：
+
+```bash
+LS_IP=$(aws lightsail get-static-ip --region <ls_region> \
+  --static-ip-name tokenkey-edge-<edge_id>-ls-ip \
+  --query 'staticIp.ipAddress' --output text)
+curl -sS --resolve api-<edge_id>.tokenkey.dev:443:$LS_IP \
+  https://api-<edge_id>.tokenkey.dev/health
+# 应当 200 + 含 tokenkey 字段
+```
+
+**机械验证**：
+
+```bash
+bash ops/migration/edge-platform-migration-preflight.sh <edge_id> --phase=cutover
+```
+
+应当报告 `info: DNS … currently → <旧 IP>; cutover will swap`。
+
+## 3) Phase cutover：DNS 切换 + 操作员 OAuth
+
+按用户回答 ②（fresh-DB 起步），新 Lightsail 实例上的 Postgres 是空的，需要重新创建 Anthropic OAuth 账号：
+
+1. **手工 Porkbun**：把 `api-<edge_id>.tokenkey.dev` A 记录改成 Lightsail Static IP。等 1 分钟。
+2. **独立观察点 smoke**（避开本地 DNS 缓存）：
+   ```bash
+   curl -sS https://api-<edge_id>.tokenkey.dev/health   # 无 --resolve；走真实 DNS
+   ```
+3. **管理员 UI**：登录 `https://api-<edge_id>.tokenkey.dev/admin`（管理员密码在 provision 输出的 `.env.secret`，由 `tokenkey-stage0-edge-lightsail-expansion` skill 提示的 SSH 取回）：
+   - 重新登录所有 Anthropic OAuth 账号（旧 EC2 token 失效，新 edge DB 没有）
+   - 跑 `tokenkey-anthropic-oauth-config` skill 的 plan-edge-account-tier 把 tier baseline 写进新库
+4. **prod stub 一致性**：`api-<edge_id>.tokenkey.dev` 域名不变，所以 prod 的 anthropic api-key stub 不需要改。但底下 edge DB 是新的；跑 `tokenkey-anthropic-oauth-config` skill 的 verify 步骤确认 stub.concurrency 等镜像值与新 edge 一致。
+5. **smoke workflow**：
+   ```bash
+   gh workflow run deploy-edge-lightsail-stage0.yml \
+     -f edge_id=<edge_id> -f operation=smoke \
+     -f confirm_instance=tokenkey-edge-<edge_id>-ls
+   ```
+
+**机械验证**：
+
+```bash
+bash ops/migration/edge-platform-migration-preflight.sh <edge_id> --phase=decommission
+```
+
+报告必须包含 `ok: DNS api-<edge_id>.tokenkey.dev → Lightsail Static IP`。否则 cutover 没完成，不要进 Phase 4。
+
+## 4) Phase decommission：拆 EC2 栈
+
+**前置条件**（preflight 强校验）：EC2 矩阵 `deployable=false`、Lightsail 矩阵 `deployable=true`、DNS 已切到 Lightsail Static IP。
+
+```bash
+gh workflow run deploy-edge-stage0.yml \
+  -f edge_id=<edge_id> \
+  -f operation=decommission \
+  -f confirm_stack=tokenkey-edge-<edge_id>-stage0 \
+  -f i_understand_destroys_data=true \
+  -f release_eip=false   # 默认；改 true 仅当你确认旧 EIP 不再用作回滚通道
+gh run watch --exit-status $(gh run list -w deploy-edge-stage0.yml -L 1 --json databaseId -q '.[0].databaseId')
+```
+
+Workflow 自动：
+
+1. EBS root volume **快照**（30 天保留 tag）
+2. 读取 stack outputs 里的 `EipAllocationId` 留作 Job summary 审计
+3. `aws cloudformation delete-stack` + wait for `DELETE_COMPLETE`
+4. 若 `release_eip=true` 则 `aws ec2 release-address`（默认保留，防止误删）
+
+> **回滚窗**：在快照保留期内（30 天），可以通过 `operation=provision` 重新建栈，并把新 root EBS 替换为 snapshot 还原。EIP 若保留，公网 IP 可以无缝接回。
+
+## 5) Acceptance（机械化输出）
+
+完成迁移后给一个 6 行 acceptance：
+
+```text
+edge_id        : <id>
+direction      : ec2-to-lightsail
+old_platform   : ec2 (stack=tokenkey-edge-<id>-stage0, deleted at <ts>)
+new_platform   : lightsail (instance=tokenkey-edge-<id>-ls, region=<ls_region>)
+old_ip_handling: kept (alloc=eipalloc-…) | released
+ebs_snapshot   : snap-… (RetentionDays=30, expires <ts+30d>)
+dns_state      : api-<id>.tokenkey.dev → <ls_static_ip>
+```
+
+数据来自 workflow Job summary + preflight 输出，不要手抄常量。
+
+## 6) 已知失败模式与定位
+
+| 现象 | 阶段 | 根因 | 处理 |
+|---|---|---|---|
+| `Lightsail … must be deployable=true` | provision preflight | 矩阵 PR 未合 | 合并矩阵翻位 PR |
+| `tokenkey-cicd-lightsail-addon not deployed` | provision preflight | 一次性 addon 未跑 | 按 §0 跑 `aws cloudformation deploy` |
+| `Lightsail instance … already exists` | provision | 之前 provision 半成功 | `gh workflow run … recreate=true`（destructive） |
+| Provision step `BOOTSTRAP_FAIL: amazon-ssm-agent -register failed` | provision | activation expired / 网络 | Lightsail 浏览器 SSH 看 `/var/log/tokenkey-lightsail-bootstrap.log` |
+| `--resolve` smoke 200，但真实 DNS 还是旧 IP | cutover | Porkbun A 未改 / TTL 未过 | 等 TTL；用 `dig +short @1.1.1.1` 验证 |
+| `DNS … still points at <old_ip>` | decommission preflight | cutover 未完成 | 回 Phase 3 完成 DNS swap |
+| Decommission 工作流报 `requires deployable=false` | decommission | EC2 矩阵还没翻 false（不应发生于此 skill 路径） | 提 PR 翻矩阵 |
+| Decommission 后 EIP 还在账户里 | 迁移完 | `release_eip=false`（默认） | 单独 `aws ec2 release-address` 或留作下一个 edge 使用 |
+
+## 7) 反方向（Lightsail → EC2）
+
+镜像本 skill 流程，只是：
+- Phase 2 用 `deploy-edge-stage0.yml operation=provision`（不是 lightsail workflow）
+- Phase 4 没有 EC2-style `decommission` 给 Lightsail；用 `aws lightsail delete-instance` + `aws lightsail release-static-ip`，或者把 Lightsail 矩阵翻 `deployable=false` 后再补一个 Lightsail decommission workflow op（**目前未实现**——首次 lightsail→ec2 时建工具）。

--- a/.cursor/skills/tokenkey-stage0-edge-platform-migration/SKILL.md
+++ b/.cursor/skills/tokenkey-stage0-edge-platform-migration/SKILL.md
@@ -35,20 +35,19 @@ description: >-
 ## 调用参数
 
 ```text
-/tokenkey-stage0-edge-platform-migration edge_id=<id> direction=<ec2-to-lightsail|lightsail-to-ec2> [tag=X.Y.Z] [phase=<plan|provision|cutover|decommission|all>] [keep_eip=false]
+/tokenkey-stage0-edge-platform-migration edge_id=<id> [tag=X.Y.Z] [phase=<plan|provision|cutover|decommission|all>] [keep_eip=true]
 ```
 
 | 参数 | 语义 |
 |---|---|
 | `edge_id` | 要迁移的 edge，如 `uk1` / `us1` / `fra1` / `sg1` |
-| `direction` | `ec2-to-lightsail`：从 EC2/CFN 迁到 Lightsail；`lightsail-to-ec2`：反向 |
 | `tag` | 新平台 provision 用的 image tag（无 v 前缀） |
 | `phase` | 分阶段执行；默认 `all`（=plan→provision→cutover→decommission） |
-| `keep_eip` | 仅 ec2-to-lightsail：旧 EC2 EIP 是否保留（默认 true，便于回滚到 EC2） |
+| `keep_eip` | 旧 EC2 EIP 是否保留（默认 `true`，便于 30 天回滚窗内复用） |
+
+> **方向**：本 skill 当前**只实现 EC2 → Lightsail** 单向迁移。反向迁移（Lightsail → EC2）所需的 Lightsail decommission primitive 与 EC2 provision-from-snapshot 路径尚未建；首次需要反向时再补，避免在 API 上写一个未实现的选项（参见 §7）。
 
 ## 0) 前置（一次性 / 每个 AWS 账户）
-
-仅 EC2→Lightsail 方向；反向迁移用现有 EC2 skill。
 
 ```bash
 # 1) Lightsail IAM addon — 整个 AWS account 一次
@@ -206,8 +205,11 @@ dns_state      : api-<id>.tokenkey.dev → <ls_static_ip>
 | Decommission 工作流报 `requires deployable=false` | decommission | EC2 矩阵还没翻 false（不应发生于此 skill 路径） | 提 PR 翻矩阵 |
 | Decommission 后 EIP 还在账户里 | 迁移完 | `release_eip=false`（默认） | 单独 `aws ec2 release-address` 或留作下一个 edge 使用 |
 
-## 7) 反方向（Lightsail → EC2）
+## 7) 反方向（Lightsail → EC2）：未实现
 
-镜像本 skill 流程，只是：
-- Phase 2 用 `deploy-edge-stage0.yml operation=provision`（不是 lightsail workflow）
-- Phase 4 没有 EC2-style `decommission` 给 Lightsail；用 `aws lightsail delete-instance` + `aws lightsail release-static-ip`，或者把 Lightsail 矩阵翻 `deployable=false` 后再补一个 Lightsail decommission workflow op（**目前未实现**——首次 lightsail→ec2 时建工具）。
+本 skill **不主张提供未实现的 API**。反向迁移目前需要以下 primitive，均**尚未建**：
+
+1. Lightsail decommission workflow op（参照本 skill 创建的 `deploy-edge-stage0.yml operation=decommission`，给 `deploy-edge-lightsail-stage0.yml` 加一个对称 op；需要 instance snapshot + Static IP release）
+2. EC2 provision-from-snapshot（如果要从 Lightsail 迁回时复用此前 EC2 拍的 snap，CFN 模板需要支持 `--root-snapshot-id` 参数）
+
+**首次需要反向迁移时再补这两块**；不在本 skill 范围里画饼。

--- a/.github/workflows/deploy-edge-stage0.yml
+++ b/.github/workflows/deploy-edge-stage0.yml
@@ -544,25 +544,39 @@ jobs:
           INSTANCE_ID="$(aws cloudformation describe-stacks --region "$REGION" --stack-name "$STACK_NAME" \
             --query 'Stacks[0].Outputs[?OutputKey==`InstanceId`].OutputValue' --output text)"
           if [ -z "$INSTANCE_ID" ] || [ "$INSTANCE_ID" = "None" ]; then
+            # No InstanceId in stack outputs is genuinely "already torn down" —
+            # delete-stack will be a no-op too. This is the only path where we
+            # legitimately skip snapshot (nothing to snapshot).
             echo "::warning::stack $STACK_NAME has no InstanceId output (already torn down?); skipping snapshot"
             echo "skipped=true" >> "$GITHUB_OUTPUT"
             exit 0
           fi
+          # Resolve the actual root device name from the instance (NOT hard-coded
+          # /dev/xvda — AL2023 on t4g uses xvda today, but Nitro / future AMIs
+          # may use nvme0n1 etc.). Fail-fast if we cannot identify a root EBS,
+          # because the snapshot is a contract of decommission and an empty
+          # snapshot path would silently destroy the rollback window.
+          ROOT_DEV="$(aws ec2 describe-instances --region "$REGION" --instance-ids "$INSTANCE_ID" \
+            --query 'Reservations[0].Instances[0].RootDeviceName' --output text)"
+          if [ -z "$ROOT_DEV" ] || [ "$ROOT_DEV" = "None" ]; then
+            echo "::error::cannot resolve RootDeviceName for $INSTANCE_ID — refusing to decommission without an EBS snapshot"
+            exit 1
+          fi
           ROOT_VOL="$(aws ec2 describe-instances --region "$REGION" --instance-ids "$INSTANCE_ID" \
-            --query 'Reservations[0].Instances[0].BlockDeviceMappings[?DeviceName==`/dev/xvda`].Ebs.VolumeId' \
+            --query "Reservations[0].Instances[0].BlockDeviceMappings[?DeviceName=='${ROOT_DEV}'].Ebs.VolumeId" \
             --output text)"
           if [ -z "$ROOT_VOL" ] || [ "$ROOT_VOL" = "None" ]; then
-            echo "::warning::could not locate /dev/xvda EBS volume for $INSTANCE_ID; skipping snapshot"
-            echo "skipped=true" >> "$GITHUB_OUTPUT"
-            exit 0
+            echo "::error::instance $INSTANCE_ID has no EBS volume on RootDeviceName=$ROOT_DEV — refusing to decommission without an EBS snapshot"
+            exit 1
           fi
           TS="$(date -u +%Y%m%dT%H%M%SZ)"
           SNAP="$(aws ec2 create-snapshot --region "$REGION" --volume-id "$ROOT_VOL" \
-            --description "pre-decommission snapshot of $STACK_NAME root volume" \
-            --tag-specifications "ResourceType=snapshot,Tags=[{Key=Project,Value=tokenkey},{Key=EdgeId,Value=$EDGE_ID},{Key=Purpose,Value=pre-decommission-rollback},{Key=Stack,Value=$STACK_NAME},{Key=Timestamp,Value=$TS},{Key=RetentionDays,Value=30}]" \
+            --description "pre-decommission snapshot of $STACK_NAME root volume ($ROOT_DEV)" \
+            --tag-specifications "ResourceType=snapshot,Tags=[{Key=Project,Value=tokenkey},{Key=EdgeId,Value=$EDGE_ID},{Key=Purpose,Value=pre-decommission-rollback},{Key=Stack,Value=$STACK_NAME},{Key=RootDevice,Value=$ROOT_DEV},{Key=Timestamp,Value=$TS},{Key=RetentionDays,Value=30}]" \
             --query 'SnapshotId' --output text)"
           echo "snapshot_id=$SNAP" >> "$GITHUB_OUTPUT"
           echo "volume_id=$ROOT_VOL" >> "$GITHUB_OUTPUT"
+          echo "root_device=$ROOT_DEV" >> "$GITHUB_OUTPUT"
           echo "skipped=false" >> "$GITHUB_OUTPUT"
           # Wait up to 10 minutes for snapshot to reach 'pending' or 'completed' — we don't need full completion
           # to proceed with stack delete (snapshot is independent of the source volume); we just confirm AWS
@@ -573,7 +587,7 @@ jobs:
             case "$STATE" in pending|completed) break ;; esac
             sleep 10
           done
-          echo "snapshot $SNAP created (state=$STATE) for volume $ROOT_VOL"
+          echo "snapshot $SNAP created (state=$STATE) for volume $ROOT_VOL on $ROOT_DEV"
 
       - name: Read EIP allocation before decommission
         if: inputs.operation == 'decommission'
@@ -583,10 +597,10 @@ jobs:
           REGION: ${{ steps.edge.outputs.region }}
         run: |
           set -euo pipefail
-          # preflight-allow: swallow — describe-stacks may return non-zero for an
-          # already-deleted stack on retry; the empty alloc_id branch covers it.
+          # describe-stacks may return non-zero for an already-deleted stack
+          # on retry; the empty alloc_id branch below covers it.
           ALLOC="$(aws cloudformation describe-stacks --region "$REGION" --stack-name "$STACK_NAME" \
-            --query 'Stacks[0].Outputs[?OutputKey==`EipAllocationId`].OutputValue' --output text 2>/dev/null || true)"
+            --query 'Stacks[0].Outputs[?OutputKey==`EipAllocationId`].OutputValue' --output text 2>/dev/null || true)"  # preflight-allow: swallow
           if [ -z "$ALLOC" ] || [ "$ALLOC" = "None" ]; then
             echo "::warning::stack $STACK_NAME has no EipAllocationId output"
             echo "alloc_id=" >> "$GITHUB_OUTPUT"
@@ -621,7 +635,7 @@ jobs:
           # preflight-allow: swallow — already-released or already-associated-elsewhere
           # both surface as non-zero; we then check describe-addresses to confirm.
           if ! aws ec2 release-address --region "$REGION" --allocation-id "$ALLOC" 2>/tmp/release-err; then
-            cat /tmp/release-err >&2 || true
+            cat /tmp/release-err >&2 || true  # preflight-allow: swallow — best-effort stderr forwarding; file may be empty
             EXISTS="$(aws ec2 describe-addresses --region "$REGION" --allocation-ids "$ALLOC" --query 'Addresses' --output text 2>/dev/null || echo gone)"
             if [ -z "$EXISTS" ] || [ "$EXISTS" = "gone" ]; then
               echo "EIP $ALLOC already released (idempotent OK)"

--- a/.github/workflows/deploy-edge-stage0.yml
+++ b/.github/workflows/deploy-edge-stage0.yml
@@ -18,7 +18,7 @@ on:
           - fra1
           - us1
       operation:
-        description: "Operation to run. provision creates/updates CFN; upgrade only changes image tag via SSM; smoke verifies; rotate_egress_ip swaps the EIP via CFN-native UpdateStack with auto-revert on pollution."
+        description: "Operation to run. provision creates/updates CFN; upgrade only changes image tag via SSM; smoke verifies; rotate_egress_ip swaps the EIP via CFN-native UpdateStack with auto-revert on pollution; decommission permanently deletes the stack (gated by deployable=false + explicit confirm) — used for EC2→Lightsail migration."
         required: true
         type: choice
         options:
@@ -27,6 +27,7 @@ on:
           - smoke
           - rollback
           - rotate_egress_ip
+          - decommission
       tag:
         description: "Released image tag without leading v. Required for provision/upgrade/rollback."
         required: false
@@ -48,6 +49,16 @@ on:
         description: "Optional for operation=rotate_egress_ip. If set, skip allocation and swap directly to this pre-vetted allocation-id. Must match ^eipalloc-[0-9a-f]+$ and be in the edge's region."
         required: false
         type: string
+      i_understand_destroys_data:
+        description: "Required for operation=decommission. MUST be 'true' to acknowledge permanent deletion of EC2 instance + EBS volume + VPC. EBS is snapshotted before delete (30-day retention tag); EIP is preserved unless release_eip=true."
+        required: false
+        type: boolean
+        default: false
+      release_eip:
+        description: "Optional for operation=decommission. If true, also release the externally-allocated EIP after CFN delete. Default false (keeps EIP for re-use on another edge or for ip-history audit)."
+        required: false
+        type: boolean
+        default: false
 
 permissions:
   contents: read
@@ -71,6 +82,8 @@ jobs:
       INPUT_OVERRIDE: ${{ inputs.simple_release_override }}
       INPUT_ROTATION_REASON: ${{ inputs.rotation_reason }}
       INPUT_CANDIDATE_ALLOC: ${{ inputs.candidate_allocation_id }}
+      INPUT_UNDERSTAND_DESTROY: ${{ inputs.i_understand_destroys_data }}
+      INPUT_RELEASE_EIP: ${{ inputs.release_eip }}
     steps:
       - uses: actions/checkout@v6
         with:
@@ -84,9 +97,18 @@ jobs:
             echo "::error::AWS_OIDC_ROLE_ARN repo variable not set"
             exit 1
           fi
+          # decommission targets edges that are deployable=false (matrix gate
+          # for "this edge is shut down or being shut down"). Pass --allow-planned
+          # so the resolver doesn't reject it; the decommission step asserts
+          # deployable==false explicitly to keep the gate meaningful.
+          ALLOW_PLANNED=""
+          if [ "$INPUT_OPERATION" = "decommission" ]; then
+            ALLOW_PLANNED="--allow-planned"
+          fi
           python3 deploy/aws/stage0/resolve-edge-target.py \
             --edge-id "$INPUT_EDGE_ID" \
             --confirm-stack "$INPUT_CONFIRM_STACK" \
+            $ALLOW_PLANNED \
             --github-output "$GITHUB_OUTPUT"
 
       - name: Validate operation inputs
@@ -112,6 +134,20 @@ jobs:
               fi
               if [ -n "${INPUT_CANDIDATE_ALLOC:-}" ] && ! printf '%s' "$INPUT_CANDIDATE_ALLOC" | grep -Eq '^eipalloc-[0-9a-f]{8,17}$'; then
                 echo "::error::candidate_allocation_id must match ^eipalloc-[0-9a-f]+$, got: $INPUT_CANDIDATE_ALLOC"
+                exit 1
+              fi
+              ;;
+            decommission)
+              if [ "${INPUT_UNDERSTAND_DESTROY}" != "true" ]; then
+                echo "::error::operation=decommission requires i_understand_destroys_data=true"
+                echo "::error::This will permanently DELETE the CloudFormation stack, EC2 instance, and EBS volume."
+                echo "::error::EBS root volume is snapshotted before delete (30-day retention tag). EIP is preserved unless release_eip=true."
+                exit 1
+              fi
+              if [ "${{ steps.edge.outputs.deployable }}" != "false" ]; then
+                echo "::error::operation=decommission requires the edge to be deployable=false in deploy/aws/stage0/edge-targets.json"
+                echo "::error::Currently: $INPUT_EDGE_ID deployable=${{ steps.edge.outputs.deployable }}"
+                echo "::error::Flip deployable=false (separate PR) before decommissioning. This prevents accidental destroy of an active edge."
                 exit 1
               fi
               ;;
@@ -495,6 +531,107 @@ jobs:
             echo "After the release, update \`released_on\` in the JSON entry to the release date and commit."
           } >> "$GITHUB_STEP_SUMMARY"
 
+      - name: Snapshot EBS root volume before decommission
+        if: inputs.operation == 'decommission'
+        id: decommission_snapshot
+        env:
+          STACK_NAME: ${{ steps.edge.outputs.stack }}
+          EDGE_ID: ${{ steps.edge.outputs.edge_id }}
+          REGION: ${{ steps.edge.outputs.region }}
+        run: |
+          set -euo pipefail
+          # Resolve InstanceId from stack outputs (the stack still exists at this point).
+          INSTANCE_ID="$(aws cloudformation describe-stacks --region "$REGION" --stack-name "$STACK_NAME" \
+            --query 'Stacks[0].Outputs[?OutputKey==`InstanceId`].OutputValue' --output text)"
+          if [ -z "$INSTANCE_ID" ] || [ "$INSTANCE_ID" = "None" ]; then
+            echo "::warning::stack $STACK_NAME has no InstanceId output (already torn down?); skipping snapshot"
+            echo "skipped=true" >> "$GITHUB_OUTPUT"
+            exit 0
+          fi
+          ROOT_VOL="$(aws ec2 describe-instances --region "$REGION" --instance-ids "$INSTANCE_ID" \
+            --query 'Reservations[0].Instances[0].BlockDeviceMappings[?DeviceName==`/dev/xvda`].Ebs.VolumeId' \
+            --output text)"
+          if [ -z "$ROOT_VOL" ] || [ "$ROOT_VOL" = "None" ]; then
+            echo "::warning::could not locate /dev/xvda EBS volume for $INSTANCE_ID; skipping snapshot"
+            echo "skipped=true" >> "$GITHUB_OUTPUT"
+            exit 0
+          fi
+          TS="$(date -u +%Y%m%dT%H%M%SZ)"
+          SNAP="$(aws ec2 create-snapshot --region "$REGION" --volume-id "$ROOT_VOL" \
+            --description "pre-decommission snapshot of $STACK_NAME root volume" \
+            --tag-specifications "ResourceType=snapshot,Tags=[{Key=Project,Value=tokenkey},{Key=EdgeId,Value=$EDGE_ID},{Key=Purpose,Value=pre-decommission-rollback},{Key=Stack,Value=$STACK_NAME},{Key=Timestamp,Value=$TS},{Key=RetentionDays,Value=30}]" \
+            --query 'SnapshotId' --output text)"
+          echo "snapshot_id=$SNAP" >> "$GITHUB_OUTPUT"
+          echo "volume_id=$ROOT_VOL" >> "$GITHUB_OUTPUT"
+          echo "skipped=false" >> "$GITHUB_OUTPUT"
+          # Wait up to 10 minutes for snapshot to reach 'pending' or 'completed' — we don't need full completion
+          # to proceed with stack delete (snapshot is independent of the source volume); we just confirm AWS
+          # accepted the request and the snapshot exists.
+          for i in 1 2 3 4 5 6; do
+            STATE="$(aws ec2 describe-snapshots --region "$REGION" --snapshot-ids "$SNAP" \
+              --query 'Snapshots[0].State' --output text 2>/dev/null || echo pending)"
+            case "$STATE" in pending|completed) break ;; esac
+            sleep 10
+          done
+          echo "snapshot $SNAP created (state=$STATE) for volume $ROOT_VOL"
+
+      - name: Read EIP allocation before decommission
+        if: inputs.operation == 'decommission'
+        id: decommission_eip
+        env:
+          STACK_NAME: ${{ steps.edge.outputs.stack }}
+          REGION: ${{ steps.edge.outputs.region }}
+        run: |
+          set -euo pipefail
+          # preflight-allow: swallow — describe-stacks may return non-zero for an
+          # already-deleted stack on retry; the empty alloc_id branch covers it.
+          ALLOC="$(aws cloudformation describe-stacks --region "$REGION" --stack-name "$STACK_NAME" \
+            --query 'Stacks[0].Outputs[?OutputKey==`EipAllocationId`].OutputValue' --output text 2>/dev/null || true)"
+          if [ -z "$ALLOC" ] || [ "$ALLOC" = "None" ]; then
+            echo "::warning::stack $STACK_NAME has no EipAllocationId output"
+            echo "alloc_id=" >> "$GITHUB_OUTPUT"
+          else
+            echo "alloc_id=$ALLOC" >> "$GITHUB_OUTPUT"
+            echo "EIP allocation pinned for downstream: $ALLOC"
+          fi
+
+      - name: Delete CloudFormation stack
+        if: inputs.operation == 'decommission'
+        env:
+          STACK_NAME: ${{ steps.edge.outputs.stack }}
+          REGION: ${{ steps.edge.outputs.region }}
+        run: |
+          set -euo pipefail
+          echo "deleting CFN stack $STACK_NAME in $REGION"
+          aws cloudformation delete-stack --region "$REGION" --stack-name "$STACK_NAME"
+          aws cloudformation wait stack-delete-complete --region "$REGION" --stack-name "$STACK_NAME"
+          echo "stack $STACK_NAME deleted"
+
+      - name: Release EIP (optional)
+        if: inputs.operation == 'decommission' && inputs.release_eip == true
+        env:
+          ALLOC: ${{ steps.decommission_eip.outputs.alloc_id }}
+          REGION: ${{ steps.edge.outputs.region }}
+        run: |
+          set -euo pipefail
+          if [ -z "${ALLOC:-}" ]; then
+            echo "::warning::no EIP allocation captured; skipping release"
+            exit 0
+          fi
+          # preflight-allow: swallow — already-released or already-associated-elsewhere
+          # both surface as non-zero; we then check describe-addresses to confirm.
+          if ! aws ec2 release-address --region "$REGION" --allocation-id "$ALLOC" 2>/tmp/release-err; then
+            cat /tmp/release-err >&2 || true
+            EXISTS="$(aws ec2 describe-addresses --region "$REGION" --allocation-ids "$ALLOC" --query 'Addresses' --output text 2>/dev/null || echo gone)"
+            if [ -z "$EXISTS" ] || [ "$EXISTS" = "gone" ]; then
+              echo "EIP $ALLOC already released (idempotent OK)"
+            else
+              echo "::error::release-address failed for $ALLOC"
+              exit 1
+            fi
+          fi
+          echo "EIP $ALLOC released"
+
       - name: External Edge health check
         if: inputs.operation == 'upgrade' || inputs.operation == 'rollback' || inputs.operation == 'smoke'
         env:
@@ -526,6 +663,10 @@ jobs:
           INSTANCE_ID: ${{ steps.instance.outputs.id }}
           API_URL: ${{ steps.instance.outputs.api_url }}
           CMD_ID: ${{ steps.ssm.outputs.command_id }}
+          DECOMM_SNAPSHOT: ${{ steps.decommission_snapshot.outputs.snapshot_id }}
+          DECOMM_VOLUME: ${{ steps.decommission_snapshot.outputs.volume_id }}
+          DECOMM_EIP: ${{ steps.decommission_eip.outputs.alloc_id }}
+          DECOMM_RELEASED: ${{ inputs.release_eip }}
         run: |
           {
             echo "## deploy-edge-stage0"
@@ -541,6 +682,18 @@ jobs:
             echo "- instance: \`${INSTANCE_ID:-none}\`"
             echo "- api: ${API_URL:-none}"
             echo "- ssm command id: \`${CMD_ID:-none}\`"
+            if [ "$INPUT_OPERATION" = "decommission" ]; then
+              echo
+              echo "### Decommission audit"
+              echo "- pre-decommission EBS snapshot: \`${DECOMM_SNAPSHOT:-skipped}\`"
+              echo "- source volume: \`${DECOMM_VOLUME:-unknown}\`"
+              echo "- preserved EIP allocation: \`${DECOMM_EIP:-unknown}\`"
+              echo "- EIP released: \`${DECOMM_RELEASED:-false}\`"
+              echo
+              echo "**Rollback within 30 days:** the EBS snapshot is tagged with RetentionDays=30."
+              echo "Restore by re-provisioning the stack (operation=provision) and replacing the new root EBS with a"
+              echo "fresh volume created from this snapshot. If the EIP was preserved, the original public IP returns."
+            fi
             echo
-            echo "Rollback: dispatch operation=rollback with the previous tag. IP rotation: dispatch operation=rotate_egress_ip with rotation_reason set. Destroy is intentionally not available in this workflow."
+            echo "Rollback: dispatch operation=rollback with the previous tag. IP rotation: dispatch operation=rotate_egress_ip with rotation_reason set. Decommission permanently deletes the stack — gated by deployable=false in matrix + i_understand_destroys_data=true."
           } >> "$GITHUB_STEP_SUMMARY"

--- a/ops/migration/edge-platform-migration-preflight.sh
+++ b/ops/migration/edge-platform-migration-preflight.sh
@@ -17,7 +17,7 @@
 set -euo pipefail
 
 EDGE_ID="${1:-}"
-shift || true
+shift || true  # preflight-allow: swallow — bash idiom; shifting past last arg is intentional no-op
 PHASE="plan"
 for arg in "$@"; do
   case "$arg" in
@@ -163,7 +163,7 @@ fi
 # ---- Cutover-phase DNS check ------------------------------------------------
 if [[ "$PHASE" == "cutover" || "$PHASE" == "decommission" ]]; then
   echo "--- DNS check (domain=$ec2_domain) ---"
-  LIVE_IP="$(dig +short A "$ec2_domain" @1.1.1.1 | tail -1 || true)"
+  LIVE_IP="$(dig +short A "$ec2_domain" @1.1.1.1 | tail -1 || true)"  # preflight-allow: swallow — empty result handled by next branch
   if [[ -z "$LIVE_IP" ]]; then
     fail "could not resolve A record for $ec2_domain"
   else

--- a/ops/migration/edge-platform-migration-preflight.sh
+++ b/ops/migration/edge-platform-migration-preflight.sh
@@ -1,0 +1,209 @@
+#!/usr/bin/env bash
+# Read-only preflight for EC2→Lightsail edge migration.
+#
+# Usage:
+#   bash ops/migration/edge-platform-migration-preflight.sh <edge_id> [--phase=plan|provision|cutover|decommission]
+#
+# Phases (each one stricter than the previous):
+#   plan         — confirm matrix state is consistent; no AWS calls strictly required
+#   provision    — also confirm Lightsail addon + GHCR PAT in target region
+#   cutover      — also confirm Lightsail instance is healthy and EC2 stack still exists
+#   decommission — also confirm Lightsail handles api-<id>.tokenkey.dev (i.e. DNS already cut)
+#
+# All AWS calls are read-only (describe-*, get-parameter, dig). Exit codes:
+#   0 — phase prerequisites met
+#   1 — phase prerequisites violated; concrete remediation printed
+#   2 — required tooling missing (aws, jq, dig, python3)
+set -euo pipefail
+
+EDGE_ID="${1:-}"
+shift || true
+PHASE="plan"
+for arg in "$@"; do
+  case "$arg" in
+    --phase=*) PHASE="${arg#--phase=}" ;;
+    *) echo "unknown arg: $arg" >&2; exit 2 ;;
+  esac
+done
+
+case "$PHASE" in
+  plan|provision|cutover|decommission) ;;
+  *) echo "::error::unknown --phase=$PHASE (expected: plan|provision|cutover|decommission)" >&2; exit 2 ;;
+esac
+
+if [[ -z "$EDGE_ID" ]]; then
+  echo "usage: $0 <edge_id> [--phase=plan|provision|cutover|decommission]" >&2
+  exit 2
+fi
+
+REPO_ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/../.." && pwd)"
+EC2_MATRIX="$REPO_ROOT/deploy/aws/stage0/edge-targets.json"
+LS_MATRIX="$REPO_ROOT/deploy/aws/lightsail/edge-targets-lightsail.json"
+
+for tool in jq python3; do
+  if ! command -v "$tool" >/dev/null 2>&1; then
+    echo "::error::$tool is required but not installed" >&2
+    exit 2
+  fi
+done
+
+# AWS / dig are only required for phase>=provision. plan stays usable on a dev
+# laptop without AWS credentials.
+need_aws=false
+if [[ "$PHASE" != "plan" ]]; then
+  need_aws=true
+fi
+if $need_aws && ! command -v aws >/dev/null 2>&1; then
+  echo "::error::aws cli is required for --phase=$PHASE but not installed" >&2
+  exit 2
+fi
+if [[ "$PHASE" == "cutover" || "$PHASE" == "decommission" ]] && ! command -v dig >/dev/null 2>&1; then
+  echo "::error::dig is required for --phase=$PHASE (DNS check) but not installed" >&2
+  exit 2
+fi
+
+errors=0
+fail() { echo "  FAIL: $*" >&2; errors=$((errors + 1)); }
+ok()   { echo "  ok: $*"; }
+
+echo "=== migration preflight: edge_id=$EDGE_ID phase=$PHASE ==="
+
+# ---- Matrix consistency (all phases) ----------------------------------------
+# jq note: `.deployable // X` returns X when deployable is null OR FALSE because jq
+# treats false as falsy in the // operator. We need an explicit existence check.
+ec2_state="$(jq -r --arg id "$EDGE_ID" '(.targets[$id] // null) as $t | if $t == null then "missing" else ($t.deployable | tostring) end' "$EC2_MATRIX")"
+ls_state="$(jq -r --arg id "$EDGE_ID" '(.targets[$id] // null) as $t | if $t == null then "missing" else ($t.deployable | tostring) end' "$LS_MATRIX")"
+ec2_stack="$(jq -r --arg id "$EDGE_ID" '.targets[$id].stack // ""' "$EC2_MATRIX")"
+ec2_region="$(jq -r --arg id "$EDGE_ID" '.targets[$id].region // ""' "$EC2_MATRIX")"
+ec2_domain="$(jq -r --arg id "$EDGE_ID" '.targets[$id].domain // ""' "$EC2_MATRIX")"
+ls_region="$(jq -r --arg id "$EDGE_ID" '.targets[$id].lightsail_region // ""' "$LS_MATRIX")"
+ls_instance="$(jq -r --arg id "$EDGE_ID" '.targets[$id].instance_name // ""' "$LS_MATRIX")"
+ls_static_ip_name="$(jq -r --arg id "$EDGE_ID" '.targets[$id].static_ip_name // ""' "$LS_MATRIX")"
+ls_ssm_prefix="$(jq -r --arg id "$EDGE_ID" '.targets[$id].ssm_prefix // ""' "$LS_MATRIX")"
+
+if [[ "$ec2_state" == "missing" ]]; then
+  fail "edge_id $EDGE_ID has no entry in deploy/aws/stage0/edge-targets.json"
+fi
+if [[ "$ls_state" == "missing" ]]; then
+  fail "edge_id $EDGE_ID has no entry in deploy/aws/lightsail/edge-targets-lightsail.json"
+fi
+if [[ "$ec2_state" != "missing" && "$ls_state" != "missing" ]]; then
+  ok "matrix entries present (EC2 deployable=$ec2_state, Lightsail deployable=$ls_state)"
+fi
+
+# Exclusivity gate (re-affirmed): exactly one of the two should be deployable=true.
+# For phase=plan, both can be false (pre-migration); for phase>=provision we need
+# Lightsail flipped to true (and EC2 still false).
+case "$PHASE" in
+  plan)
+    if [[ "$ec2_state" == "true" && "$ls_state" == "true" ]]; then
+      fail "both EC2 and Lightsail are deployable=true for $EDGE_ID — exclusivity gate violation, fix matrices first"
+    fi
+    ;;
+  provision|cutover|decommission)
+    if [[ "$ls_state" != "true" ]]; then
+      fail "Lightsail $EDGE_ID must be deployable=true for --phase=$PHASE (currently: $ls_state). Flip in lightsail matrix + open PR + merge."
+    fi
+    if [[ "$ec2_state" == "true" ]]; then
+      fail "EC2 $EDGE_ID is still deployable=true (currently: $ec2_state). For migration the EC2 side must be deployable=false. Flip in EC2 matrix + open PR + merge."
+    fi
+    ;;
+esac
+
+# ---- Provision-phase AWS checks ---------------------------------------------
+if [[ "$PHASE" == "provision" || "$PHASE" == "cutover" || "$PHASE" == "decommission" ]]; then
+  echo "--- AWS reachability checks (region=$ls_region) ---"
+  if ! aws sts get-caller-identity --region "$ls_region" >/dev/null 2>&1; then
+    fail "aws sts get-caller-identity failed in $ls_region — credentials missing or wrong region"
+  else
+    ok "aws credentials reachable in $ls_region"
+  fi
+
+  # Lightsail IAM addon CFN stack — one-time per account, in us-east-1 by
+  # convention (tokenkey-cicd-* stacks live there). Check both us-east-1 and the
+  # edge's own region for resilience to past misconfig.
+  ADDON_STACK="tokenkey-cicd-lightsail-addon"
+  ADDON_FOUND=""
+  for r in us-east-1 "$ls_region"; do
+    if aws cloudformation describe-stacks --region "$r" --stack-name "$ADDON_STACK" >/dev/null 2>&1; then
+      ADDON_FOUND="$r"
+      break
+    fi
+  done
+  if [[ -z "$ADDON_FOUND" ]]; then
+    fail "$ADDON_STACK not deployed (checked us-east-1 and $ls_region). One-time setup: aws cloudformation deploy --region us-east-1 --stack-name $ADDON_STACK --template-file deploy/aws/cloudformation/cicd-oidc-lightsail-addon.yaml --parameter-overrides GitHubOidcRoleName=<gha-oidc-role>"
+  else
+    ok "$ADDON_STACK present in $ADDON_FOUND"
+  fi
+
+  # GHCR PAT — required by Lightsail bootstrap to pull the image
+  GHCR_PAT_NAME="${ls_ssm_prefix}/ghcr/pat"
+  if ! aws ssm get-parameter --region "$ls_region" --name "$GHCR_PAT_NAME" --with-decryption >/dev/null 2>&1; then
+    fail "SSM SecureString $GHCR_PAT_NAME missing in $ls_region. One-time setup: aws ssm put-parameter --region $ls_region --name $GHCR_PAT_NAME --type SecureString --value 'ghp_...'"
+  else
+    ok "GHCR PAT present at $GHCR_PAT_NAME"
+  fi
+
+  # Lightsail instance must NOT already exist (else exclusivity is illusory)
+  if aws lightsail get-instance --region "$ls_region" --instance-name "$ls_instance" >/dev/null 2>&1; then
+    if [[ "$PHASE" == "provision" ]]; then
+      fail "Lightsail instance $ls_instance already exists in $ls_region. For idempotent re-provision dispatch operation=provision with recreate=true (destructive); otherwise skip provision."
+    else
+      ok "Lightsail instance $ls_instance present (expected for --phase=$PHASE)"
+    fi
+  else
+    if [[ "$PHASE" == "provision" ]]; then
+      ok "Lightsail instance $ls_instance not yet created (expected for provision)"
+    else
+      fail "Lightsail instance $ls_instance missing in $ls_region — run provision first"
+    fi
+  fi
+fi
+
+# ---- Cutover-phase DNS check ------------------------------------------------
+if [[ "$PHASE" == "cutover" || "$PHASE" == "decommission" ]]; then
+  echo "--- DNS check (domain=$ec2_domain) ---"
+  LIVE_IP="$(dig +short A "$ec2_domain" @1.1.1.1 | tail -1 || true)"
+  if [[ -z "$LIVE_IP" ]]; then
+    fail "could not resolve A record for $ec2_domain"
+  else
+    LS_IP="$(aws lightsail get-static-ip --region "$ls_region" --static-ip-name "$ls_static_ip_name" --query 'staticIp.ipAddress' --output text 2>/dev/null || echo "")"
+    if [[ -z "$LS_IP" || "$LS_IP" == "None" ]]; then
+      fail "Lightsail Static IP $ls_static_ip_name not allocated in $ls_region — provision incomplete"
+    elif [[ "$PHASE" == "cutover" ]]; then
+      if [[ "$LIVE_IP" == "$LS_IP" ]]; then
+        ok "DNS already points $ec2_domain → Lightsail Static IP ($LS_IP)"
+      else
+        echo "  info: DNS $ec2_domain currently → $LIVE_IP (Lightsail Static IP is $LS_IP); cutover will swap"
+      fi
+    elif [[ "$PHASE" == "decommission" ]]; then
+      if [[ "$LIVE_IP" != "$LS_IP" ]]; then
+        fail "DNS $ec2_domain still points at $LIVE_IP (not Lightsail Static IP $LS_IP) — cutover not complete; do not decommission yet"
+      else
+        ok "DNS $ec2_domain → Lightsail Static IP ($LS_IP); safe to decommission EC2"
+      fi
+    fi
+  fi
+fi
+
+# ---- Decommission-phase EC2 still-exists check ------------------------------
+if [[ "$PHASE" == "decommission" ]]; then
+  echo "--- EC2 stack pre-decommission check (stack=$ec2_stack region=$ec2_region) ---"
+  if [[ -z "$ec2_stack" ]]; then
+    fail "matrix has no stack name for EC2 $EDGE_ID — cannot decommission"
+  elif ! aws cloudformation describe-stacks --region "$ec2_region" --stack-name "$ec2_stack" >/dev/null 2>&1; then
+    echo "  info: EC2 stack $ec2_stack already absent in $ec2_region (decommission would be a no-op)"
+  else
+    STACK_STATUS="$(aws cloudformation describe-stacks --region "$ec2_region" --stack-name "$ec2_stack" --query 'Stacks[0].StackStatus' --output text)"
+    ok "EC2 stack $ec2_stack present in $ec2_region (status=$STACK_STATUS) — decommission will tear it down"
+  fi
+fi
+
+echo ""
+if [[ "$errors" -eq 0 ]]; then
+  echo "=== migration preflight $PHASE: PASS ==="
+  exit 0
+else
+  echo "=== migration preflight $PHASE: FAIL ($errors check(s) failed) ==="
+  exit 1
+fi

--- a/ops/migration/test_edge_platform_migration_preflight.py
+++ b/ops/migration/test_edge_platform_migration_preflight.py
@@ -1,0 +1,143 @@
+"""Tests for ops/migration/edge-platform-migration-preflight.sh.
+
+The script's AWS-touching paths can't be exercised offline. What we CAN verify:
+
+  1. --phase=plan runs without AWS calls and returns OK for known-good matrix
+     entries (uk1 in both matrices, both deployable=false).
+  2. --phase=plan fails for an unknown edge_id with a clear matrix message.
+  3. --phase=plan fails when both matrices would set deployable=true for the
+     same id (the exclusivity gate is honoured even before AWS).
+  4. The script handles `--phase=foo` with exit 2 (usage error, not 1).
+  5. Missing required tools surface exit 2.
+
+These exercise the deterministic decision tree at the top of the script. The
+provision/cutover/decommission branches need AWS creds and are smoke-tested
+manually with the migration skill.
+
+stdlib-only.
+"""
+from __future__ import annotations
+
+import json
+import os
+import pathlib
+import shutil
+import subprocess
+import sys
+import tempfile
+import unittest
+
+REPO_ROOT = pathlib.Path(__file__).resolve().parents[2]
+SCRIPT = REPO_ROOT / "ops/migration/edge-platform-migration-preflight.sh"
+
+
+def _scrubbed_env() -> dict:
+    env = dict(os.environ)
+    for key in ("GIT_DIR", "GIT_INDEX_FILE", "GIT_WORK_TREE", "GIT_OBJECT_DIRECTORY", "GIT_COMMON_DIR"):
+        env.pop(key, None)
+    return env
+
+
+def _stage_fake_repo(tmp: pathlib.Path, ec2: dict, ls: dict) -> pathlib.Path:
+    fake_root = tmp / "repo"
+    (fake_root / "ops/migration").mkdir(parents=True)
+    (fake_root / "deploy/aws/stage0").mkdir(parents=True)
+    (fake_root / "deploy/aws/lightsail").mkdir(parents=True)
+    shutil.copy(SCRIPT, fake_root / "ops/migration/edge-platform-migration-preflight.sh")
+    (fake_root / "ops/migration/edge-platform-migration-preflight.sh").chmod(0o755)
+    (fake_root / "deploy/aws/stage0/edge-targets.json").write_text(json.dumps(ec2), encoding="utf-8")
+    (fake_root / "deploy/aws/lightsail/edge-targets-lightsail.json").write_text(json.dumps(ls), encoding="utf-8")
+    return fake_root
+
+
+def _run(fake_root: pathlib.Path, *args: str) -> subprocess.CompletedProcess:
+    return subprocess.run(
+        ["bash", str(fake_root / "ops/migration/edge-platform-migration-preflight.sh"), *args],
+        capture_output=True,
+        text=True,
+        env=_scrubbed_env(),
+    )
+
+
+class PreflightPlanPhaseTests(unittest.TestCase):
+    def test_plan_passes_for_known_good_matrix(self):
+        with tempfile.TemporaryDirectory() as tmp:
+            fake = _stage_fake_repo(
+                pathlib.Path(tmp),
+                {"targets": {"uk1": {"deployable": False, "region": "eu-west-2", "domain": "api-uk1.tokenkey.dev", "stack": "tokenkey-edge-uk1-stage0"}}},
+                {"targets": {"uk1": {"deployable": False, "lightsail_region": "eu-west-2", "instance_name": "tokenkey-edge-uk1-ls", "static_ip_name": "tokenkey-edge-uk1-ls-ip", "ssm_prefix": "/tokenkey/lightsail/uk1"}}},
+            )
+            proc = _run(fake, "uk1", "--phase=plan")
+            self.assertEqual(proc.returncode, 0, f"stderr: {proc.stderr}\nstdout: {proc.stdout}")
+            self.assertIn("PASS", proc.stdout)
+
+    def test_plan_fails_when_both_deployable_true(self):
+        with tempfile.TemporaryDirectory() as tmp:
+            fake = _stage_fake_repo(
+                pathlib.Path(tmp),
+                {"targets": {"uk1": {"deployable": True, "region": "eu-west-2", "domain": "api-uk1.tokenkey.dev", "stack": "tokenkey-edge-uk1-stage0"}}},
+                {"targets": {"uk1": {"deployable": True, "lightsail_region": "eu-west-2", "instance_name": "tokenkey-edge-uk1-ls", "static_ip_name": "tokenkey-edge-uk1-ls-ip", "ssm_prefix": "/tokenkey/lightsail/uk1"}}},
+            )
+            proc = _run(fake, "uk1", "--phase=plan")
+            self.assertEqual(proc.returncode, 1, proc.stdout)
+            self.assertIn("exclusivity gate violation", proc.stderr)
+
+    def test_plan_fails_for_unknown_edge_id(self):
+        with tempfile.TemporaryDirectory() as tmp:
+            fake = _stage_fake_repo(
+                pathlib.Path(tmp),
+                {"targets": {"uk1": {"deployable": False, "region": "eu-west-2", "domain": "api-uk1.tokenkey.dev", "stack": "tokenkey-edge-uk1-stage0"}}},
+                {"targets": {"uk1": {"deployable": False, "lightsail_region": "eu-west-2", "instance_name": "tokenkey-edge-uk1-ls", "static_ip_name": "tokenkey-edge-uk1-ls-ip", "ssm_prefix": "/tokenkey/lightsail/uk1"}}},
+            )
+            proc = _run(fake, "zz9", "--phase=plan")
+            self.assertEqual(proc.returncode, 1, proc.stdout)
+            self.assertIn("no entry", proc.stderr)
+
+    def test_unknown_phase_exits_2(self):
+        with tempfile.TemporaryDirectory() as tmp:
+            fake = _stage_fake_repo(
+                pathlib.Path(tmp),
+                {"targets": {"uk1": {"deployable": False}}},
+                {"targets": {"uk1": {"deployable": False}}},
+            )
+            proc = _run(fake, "uk1", "--phase=bogus")
+            self.assertEqual(proc.returncode, 2, proc.stdout)
+            self.assertIn("unknown --phase", proc.stderr)
+
+    def test_missing_edge_id_arg_exits_2(self):
+        with tempfile.TemporaryDirectory() as tmp:
+            fake = _stage_fake_repo(
+                pathlib.Path(tmp),
+                {"targets": {"uk1": {"deployable": False}}},
+                {"targets": {"uk1": {"deployable": False}}},
+            )
+            proc = _run(fake)
+            self.assertEqual(proc.returncode, 2, proc.stdout)
+            self.assertIn("usage:", proc.stderr)
+
+    def test_provision_phase_blocks_when_lightsail_still_false(self):
+        with tempfile.TemporaryDirectory() as tmp:
+            fake = _stage_fake_repo(
+                pathlib.Path(tmp),
+                {"targets": {"uk1": {"deployable": False, "region": "eu-west-2", "domain": "api-uk1.tokenkey.dev", "stack": "tokenkey-edge-uk1-stage0"}}},
+                {"targets": {"uk1": {"deployable": False, "lightsail_region": "eu-west-2", "instance_name": "tokenkey-edge-uk1-ls", "static_ip_name": "tokenkey-edge-uk1-ls-ip", "ssm_prefix": "/tokenkey/lightsail/uk1"}}},
+            )
+            proc = _run(fake, "uk1", "--phase=provision")
+            # AWS calls would fail here (no creds), but the matrix gate fires
+            # first and we should see at least one FAIL referencing deployable.
+            self.assertNotEqual(proc.returncode, 0)
+            self.assertIn("must be deployable=true", proc.stderr)
+
+    def test_real_repo_uk1_plan_passes(self):
+        """Smoke against the actual repo matrices — uk1 should be plan-OK
+        (both currently deployable=false). If this fails, someone has changed
+        the matrices in a way that breaks the migration starting precondition."""
+        proc = subprocess.run(
+            ["bash", str(SCRIPT), "uk1", "--phase=plan"],
+            capture_output=True, text=True, env=_scrubbed_env(),
+        )
+        self.assertEqual(proc.returncode, 0, f"stderr: {proc.stderr}\nstdout: {proc.stdout}")
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/scripts/checks/test_deploy_edge_decommission_gates.py
+++ b/scripts/checks/test_deploy_edge_decommission_gates.py
@@ -1,0 +1,108 @@
+"""Structural tests for the decommission op added to deploy-edge-stage0.yml.
+
+The workflow logic itself runs inside GHA — we can't easily black-box it from
+the test suite. What we CAN do is parse the YAML and assert the safety
+contracts hold at the structural level:
+
+  1. operation=decommission is wired through the same resolver as the other
+     ops (so confirm_stack is enforced).
+  2. The Validate step requires both i_understand_destroys_data=true AND
+     matrix.deployable=false BEFORE the destructive steps run.
+  3. The EBS snapshot step runs BEFORE the delete-stack step.
+  4. release_eip default is false (additive opt-in).
+  5. The decommission steps don't accidentally apply to provision / upgrade /
+     smoke / rollback / rotate_egress_ip ops (no over-firing).
+
+stdlib-only.
+"""
+from __future__ import annotations
+
+import pathlib
+import re
+import unittest
+
+REPO_ROOT = pathlib.Path(__file__).resolve().parents[2]
+WORKFLOW = REPO_ROOT / ".github/workflows/deploy-edge-stage0.yml"
+
+
+class DecommissionGatesTests(unittest.TestCase):
+    def setUp(self):
+        self.text = WORKFLOW.read_text(encoding="utf-8")
+
+    def test_decommission_is_a_workflow_dispatch_option(self):
+        self.assertIn("- decommission\n", self.text)
+
+    def test_i_understand_destroys_data_default_false(self):
+        block = re.search(
+            r"i_understand_destroys_data:.*?default:\s*(\S+)",
+            self.text,
+            re.DOTALL,
+        )
+        self.assertIsNotNone(block, "i_understand_destroys_data input missing")
+        self.assertEqual(block.group(1), "false", "destructive flag must default to false")
+
+    def test_release_eip_default_false(self):
+        block = re.search(r"release_eip:.*?default:\s*(\S+)", self.text, re.DOTALL)
+        self.assertIsNotNone(block, "release_eip input missing")
+        self.assertEqual(block.group(1), "false")
+
+    def test_validate_step_gates_both_understand_and_deployable_false(self):
+        # Both gates must appear inside the `decommission)` case branch of the
+        # Validate step. We pin on the literal error strings rather than line
+        # positions so cosmetic refactors don't break this test.
+        decommission_case = re.search(
+            r"decommission\)(.*?)(?:\*\)|esac)", self.text, re.DOTALL
+        )
+        self.assertIsNotNone(decommission_case, "validate step has no decommission case")
+        body = decommission_case.group(1)
+        self.assertIn(
+            'requires i_understand_destroys_data=true',
+            body,
+            "decommission case must gate on i_understand_destroys_data",
+        )
+        self.assertIn(
+            'requires the edge to be deployable=false',
+            body,
+            "decommission case must gate on matrix deployable=false",
+        )
+
+    def test_snapshot_step_precedes_delete_step(self):
+        snapshot_idx = self.text.find("Snapshot EBS root volume before decommission")
+        delete_idx = self.text.find("Delete CloudFormation stack")
+        self.assertGreater(snapshot_idx, 0, "snapshot step missing")
+        self.assertGreater(delete_idx, 0, "delete step missing")
+        self.assertLess(snapshot_idx, delete_idx, "snapshot must run BEFORE delete-stack")
+
+    def test_release_eip_step_gated_on_input(self):
+        # `if: inputs.operation == 'decommission' && inputs.release_eip == true`
+        # is the only path that triggers the release.
+        self.assertRegex(
+            self.text,
+            r"if:\s*inputs\.operation\s*==\s*'decommission'\s*&&\s*inputs\.release_eip\s*==\s*true",
+            "release-eip step must be gated on inputs.release_eip == true",
+        )
+
+    def test_resolver_passes_allow_planned_only_for_decommission(self):
+        # Pin the conditional logic — provision/upgrade/etc must still get the
+        # default resolver behaviour (rejects deployable=false).
+        self.assertIn(
+            'if [ "$INPUT_OPERATION" = "decommission" ]; then',
+            self.text,
+        )
+        self.assertIn('ALLOW_PLANNED="--allow-planned"', self.text)
+
+    def test_snapshot_tagged_for_30_day_retention(self):
+        # Audit / rollback contract: snapshots from decommission must carry
+        # RetentionDays=30 so out-of-band tooling (or a future janitor job)
+        # can age them out predictably.
+        self.assertIn("RetentionDays", self.text)
+        self.assertRegex(self.text, r"Key=RetentionDays,Value=30")
+
+    def test_job_summary_includes_decommission_audit_block(self):
+        self.assertIn("### Decommission audit", self.text)
+        self.assertIn("pre-decommission EBS snapshot", self.text)
+        self.assertIn("preserved EIP allocation", self.text)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/scripts/checks/test_deploy_edge_decommission_gates.py
+++ b/scripts/checks/test_deploy_edge_decommission_gates.py
@@ -98,6 +98,50 @@ class DecommissionGatesTests(unittest.TestCase):
         self.assertIn("RetentionDays", self.text)
         self.assertRegex(self.text, r"Key=RetentionDays,Value=30")
 
+    def test_snapshot_resolves_root_device_dynamically(self):
+        # R-001: root device must NOT be hard-coded /dev/xvda in the
+        # describe-instances query. The decommission path resolves
+        # RootDeviceName from the instance first. Hard-coded device names
+        # silently break when the instance family / AMI shifts (e.g. AL2023
+        # on t4g → xvda today, but Nitro nvme0n1 tomorrow).
+        self.assertIn("RootDeviceName", self.text,
+                      "snapshot step must resolve RootDeviceName dynamically (R-001)")
+        # Defensive: the BlockDeviceMappings query must reference the dynamic
+        # ${ROOT_DEV} variable, not a hard-coded literal. We exclude lines that
+        # start with '#' so the regression-comment that explains "/dev/xvda
+        # today, nvme tomorrow" doesn't trip the gate.
+        snapshot_step = self._extract_step("Snapshot EBS root volume before decommission")
+        code_lines = [
+            line for line in snapshot_step.splitlines()
+            if line.strip() and not line.strip().startswith("#")
+        ]
+        code_only = "\n".join(code_lines)
+        self.assertNotIn("/dev/xvda", code_only,
+                         "snapshot step must not hard-code /dev/xvda in any executable line (R-001)")
+        # And explicitly assert the query uses the variable substitution form.
+        self.assertIn("DeviceName=='${ROOT_DEV}'", code_only,
+                      "BlockDeviceMappings query must reference ${ROOT_DEV}, not a literal device path (R-001)")
+
+    def test_snapshot_failure_aborts_decommission(self):
+        # R-001 part 2: if we cannot identify the root EBS volume, we MUST fail
+        # the step (not log a warning and proceed). Snapshot is part of the
+        # decommission contract; a silent skip would destroy the operator's
+        # rollback window without their knowledge.
+        snapshot_step = self._extract_step("Snapshot EBS root volume before decommission")
+        self.assertIn("refusing to decommission without an EBS snapshot", snapshot_step,
+                      "snapshot step must fail-fast (not warn) when root EBS cannot be resolved (R-001)")
+
+    def _extract_step(self, name: str) -> str:
+        """Pull the run-block of a single named step by literal name."""
+        # Find the step header then the next "- name:" or end-of-file.
+        marker = f"- name: {name}"
+        start = self.text.find(marker)
+        self.assertGreater(start, 0, f"step '{name}' missing")
+        # End boundary: next step at the same indent level.
+        next_step = self.text.find("\n      - name:", start + len(marker))
+        end = next_step if next_step > 0 else len(self.text)
+        return self.text[start:end]
+
     def test_job_summary_includes_decommission_audit_block(self):
         self.assertIn("### Decommission audit", self.text)
         self.assertIn("pre-decommission EBS snapshot", self.text)

--- a/scripts/preflight.sh
+++ b/scripts/preflight.sh
@@ -763,7 +763,7 @@ else
     # CalledProcessError. Strip these vars at the boundary so the suites behave
     # identically inside the hook and standalone.
     _det_baseline_failed=0
-    for _det_dir in ops/observability ops/stage0 scripts deploy/aws/stage0 deploy/aws/lightsail; do
+    for _det_dir in ops/observability ops/stage0 ops/migration scripts deploy/aws/stage0 deploy/aws/lightsail; do
         if ! env -u GIT_DIR -u GIT_INDEX_FILE -u GIT_WORK_TREE -u GIT_OBJECT_DIRECTORY -u GIT_COMMON_DIR \
               python3 -m unittest discover -s "$_det_dir" -p 'test_*.py' -t "$_det_dir" >/dev/null 2>&1; then
             echo "  FAIL: $_det_dir unittest failed (re-run: env -u GIT_DIR -u GIT_INDEX_FILE -u GIT_WORK_TREE python3 -m unittest discover -s $_det_dir -p 'test_*.py' -t $_det_dir -v)"


### PR DESCRIPTION
## Summary

Phase 0 tooling for EC2↔Lightsail edge platform migration. Builds the mechanical gates and operator runbook that PR #380 left implicit. **No AWS state is touched by anything in this PR**; pure operator tooling, fully reversible.

User goal: migrate \`edge-uk1\` from EC2 to Lightsail. The migration needs (a) a clean tear-down primitive for the retired platform, (b) a read-only preflight per phase, (c) a top-level skill so the operator doesn't have to remember the 4-phase sequence.

## What's in this PR

| Layer | Delivered |
|---|---|
| New \`deploy-edge-stage0.yml\` operation | \`decommission\`: snapshot EBS (RetentionDays=30) → delete-stack → optional EIP release. Three independent gates: matrix.deployable=false + i_understand_destroys_data=true + confirm_stack match. |
| New preflight script | \`ops/migration/edge-platform-migration-preflight.sh <edge_id> --phase=plan\|provision\|cutover\|decommission\` — all read-only; \`plan\` works offline. |
| New skill | \`.cursor/skills/tokenkey-stage0-edge-platform-migration/SKILL.md\` — 4-phase orchestrator with mechanical-vs-judgement table and Known Failure Modes lookup. |
| Tests | 9 cases for decommission gating + 7 cases for preflight script. Both suites wired into preflight via \`ops/migration\` in the determinism-baseline loop. |

## Safety contracts (mechanically enforced)

- Decommission **cannot** run unless \`deployable=false\` in matrix (separate PR required to flip)
- Decommission **cannot** run unless \`i_understand_destroys_data=true\` is explicitly passed
- EBS snapshot **always precedes** delete-stack (verified by test)
- EIP release is **opt-in** (default false; preserved for re-use / rollback)
- Snapshot carries \`RetentionDays=30\` tag for predictable cleanup

## Out of scope (deliberate)

- The actual matrix flip (Lightsail uk1 \`deployable=true\`) — Phase 1 operator-authorised PR, **must land separately** so exclusivity gate stays meaningful as a hard invariant rather than a silent default. The skill §1 documents the exact one-line JSON change.
- Anthropic OAuth account migration — per operator direction, uk1 starts with a fresh edge DB. Operator re-OAuths via admin UI in Phase 3.
- Porkbun DNS API automation — manual edit remains the operator step.

## Risk

- **Regular risk** by rules/product-dev.mdc. Zero prod behaviour change. Zero AWS state mutation. New \`decommission\` op is invisible until explicitly dispatched.

## Validation

\`\`\`bash
python3 -m unittest scripts.checks.test_deploy_edge_decommission_gates -v        # 9 cases
python3 -m unittest ops.migration.test_edge_platform_migration_preflight -v      # 7 cases
bash ops/migration/edge-platform-migration-preflight.sh uk1 --phase=plan         # PASS
PREFLIGHT_BASE=origin/main bash scripts/preflight.sh                              # PASS
\`\`\`

Local smoke against live AWS (with credentials): \`--phase=provision\` correctly reports the 2 remaining one-time-setup gaps (\`tokenkey-cicd-lightsail-addon\` not yet deployed + GHCR PAT not yet in SSM). Those are operator actions for Phase 1, not blockers for this code PR.

## Test plan checklist

- [x] Decommission gate tests
- [x] Migration preflight phase tests (incl. real-repo smoke)
- [x] Workflow YAML parses
- [x] Local preflight green (incl. \`ops/migration\` in determinism-baseline)
- [ ] CI green