### PR TITLE
chore(edge-lightsail): flip uk1 deployable=true for Phase 1 migration

### DIFF
--- a/deploy/aws/lightsail/edge-targets-lightsail.json
+++ b/deploy/aws/lightsail/edge-targets-lightsail.json
@@ -10,7 +10,7 @@
   ],
   "targets": {
     "uk1": {
-      "deployable": false,
+      "deployable": true,
       "profile": "edge-lightsail-minimal",
       "lightsail_region": "eu-west-2",
       "ec2_equivalent_region": "eu-west-2",
@@ -22,7 +22,7 @@
       "blueprint_id": "amazon_linux_2023",
       "monthly_budget_usd": 12,
       "ssm_prefix": "/tokenkey/lightsail/uk1",
-      "purpose": "uk-egress-lightsail-poc-planned (EC2 owns uk1 today; flip deployable=true only after taking EC2 uk1 deployable=false to avoid DNS collision)"
+      "purpose": "uk-egress-lightsail (Phase 1 of EC2→Lightsail migration; EC2 uk1 deployable=false on deploy/aws/stage0/edge-targets.json; exclusivity gate enforces single-platform)"
     },
     "us1": {
       "deployable": false,

--- a/deploy/aws/lightsail/test_resolve_edge_lightsail_target.py
+++ b/deploy/aws/lightsail/test_resolve_edge_lightsail_target.py
@@ -27,54 +27,64 @@ def run_resolver(edge_id, confirm_instance="", allow_planned=False):
 
 
 class ResolveEdgeLightsailTargetTests(unittest.TestCase):
-    """All four Lightsail targets are deployable=false by default — EC2 owns
-    uk1/us1 today (DNS conflict guard); fra1/sg1 are planned PoC targets.
-    `--allow-planned` is the explicit operator opt-in."""
+    """Test resolver against the live lightsail matrix. We pick a deployable=true
+    edge and a deployable=false edge DYNAMICALLY from the matrix so the tests
+    don't break each time an edge gets flipped during a migration."""
 
-    def test_uk1_planned_resolves_with_allow_planned(self):
-        data = json.loads(MATRIX.read_text(encoding="utf-8"))
-        expected = data["targets"]["uk1"]["instance_name"]
-        resolved = run_resolver("uk1", confirm_instance=expected, allow_planned=True)
-        self.assertEqual(resolved["edge_id"], "uk1")
+    @classmethod
+    def setUpClass(cls):
+        cls.data = json.loads(MATRIX.read_text(encoding="utf-8"))
+        targets = cls.data.get("targets", {})
+        deployable = sorted(
+            edge_id for edge_id, t in targets.items() if t.get("deployable") is True
+        )
+        planned = sorted(
+            edge_id for edge_id, t in targets.items() if t.get("deployable") is False
+        )
+        cls.deployable_id = deployable[0] if deployable else None
+        cls.planned_id = planned[0] if planned else None
+
+    def test_deployable_resolves_without_allow_planned(self):
+        if not self.deployable_id:
+            self.skipTest("no deployable=true Lightsail edges in matrix")
+        edge_id = self.deployable_id
+        expected = self.data["targets"][edge_id]["instance_name"]
+        resolved = run_resolver(edge_id, confirm_instance=expected)
+        self.assertEqual(resolved["edge_id"], edge_id)
         self.assertEqual(resolved["instance_name"], expected)
-        self.assertEqual(resolved["lightsail_region"], "eu-west-2")
-        self.assertEqual(resolved["deployable"], "false")
+        self.assertEqual(resolved["deployable"], "true")
 
-    def test_uk1_planned_fails_without_allow_planned(self):
+    def test_planned_fails_without_allow_planned(self):
+        if not self.planned_id:
+            self.skipTest("no deployable=false Lightsail edges in matrix")
         proc = subprocess.run(
-            [sys.executable, str(RESOLVER), "--edge-id", "uk1"],
+            [sys.executable, str(RESOLVER), "--edge-id", self.planned_id],
             capture_output=True,
             text=True,
         )
         self.assertNotEqual(proc.returncode, 0)
         self.assertIn("not deployable", proc.stderr)
+
+    def test_planned_resolves_with_allow_planned(self):
+        if not self.planned_id:
+            self.skipTest("no deployable=false Lightsail edges in matrix")
+        resolved = run_resolver(self.planned_id, allow_planned=True)
+        self.assertEqual(resolved["edge_id"], self.planned_id)
+        self.assertEqual(resolved["deployable"], "false")
 
     def test_confirm_instance_mismatch_fails(self):
-        # --allow-planned to reach the confirm_instance check (deployable
-        # check happens first; that's intentional fail-fast ordering).
-        proc = subprocess.run(
-            [sys.executable, str(RESOLVER), "--edge-id", "uk1",
-             "--confirm-instance", "wrong-name", "--allow-planned"],
-            capture_output=True,
-            text=True,
-        )
+        # Pick any edge (deployable or planned); deployable preferred so we
+        # don't need --allow-planned.
+        edge_id = self.deployable_id or self.planned_id
+        if not edge_id:
+            self.skipTest("matrix empty")
+        args = [sys.executable, str(RESOLVER), "--edge-id", edge_id,
+                "--confirm-instance", "wrong-name"]
+        if edge_id == self.planned_id:
+            args.append("--allow-planned")
+        proc = subprocess.run(args, capture_output=True, text=True)
         self.assertNotEqual(proc.returncode, 0)
         self.assertIn("confirm_instance mismatch", proc.stderr)
-
-    def test_planned_fra1_fails_without_allow_planned(self):
-        proc = subprocess.run(
-            [sys.executable, str(RESOLVER), "--edge-id", "fra1"],
-            capture_output=True,
-            text=True,
-        )
-        self.assertNotEqual(proc.returncode, 0)
-        self.assertIn("not deployable", proc.stderr)
-
-    def test_planned_fra1_with_allow_planned(self):
-        resolved = run_resolver("fra1", allow_planned=True)
-        self.assertEqual(resolved["edge_id"], "fra1")
-        self.assertEqual(resolved["lightsail_region"], "eu-central-1")
-        self.assertEqual(resolved["deployable"], "false")
 
     def test_unknown_edge_id_fails(self):
         proc = subprocess.run(


### PR DESCRIPTION
## Summary

**Phase 1 of EC2→Lightsail migration of edge-uk1.**

Single semantic change: `deploy/aws/lightsail/edge-targets-lightsail.json` uk1.deployable: **false → true**. EC2 uk1 stays `deployable=false` (already in main).

The exclusivity gate (`scripts/checks/edge-platform-exclusivity.py`, runs in preflight) holds: exactly one platform claims uk1, never both.

## What's in this PR

- 1-byte semantic flip on `lightsail/edge-targets-lightsail.json` uk1.deployable
- purpose string updated to record migration context
- Test refactor: `deploy/aws/lightsail/test_resolve_edge_lightsail_target.py` now picks deployable=true / deployable=false edges DYNAMICALLY from the matrix in `setUpClass`, instead of pinning literal "uk1"/"fra1". Future matrix flips (other migrations, Phase 4 decommission) won't require test rewrites.

## What this PR does NOT do

- Provision the Lightsail instance (Phase 2; workflow dispatch by me after this merges)
- Touch DNS api-uk1.tokenkey.dev (Phase 3; operator at Porkbun)
- Decommission EC2 uk1 (Phase 4; workflow dispatch with explicit gates)

## Operator side: one-time AWS setup (independent of this PR)

**To do BEFORE Phase 2** (Lightsail provision will fail without these):

\`\`\`bash
# 1) Lightsail IAM addon — one-time per AWS account
aws cloudformation deploy \\
  --region us-east-1 \\
  --stack-name tokenkey-cicd-lightsail-addon \\
  --template-file deploy/aws/cloudformation/cicd-oidc-lightsail-addon.yaml \\
  --parameter-overrides GitHubOidcRoleName=tokenkey-gha-us-east-1-error-clustering

# 2) GHCR PAT in the Lightsail region (eu-west-2 for uk1) — one-time per region
aws ssm put-parameter --region eu-west-2 \\
  --name /tokenkey/lightsail/uk1/ghcr/pat \\
  --type SecureString --value 'ghp_…'   # your GHCR PAT with read:packages scope
\`\`\`

Verify both:
\`\`\`bash
bash ops/migration/edge-platform-migration-preflight.sh uk1 --phase=provision
# expected: PASS (or surfaces exactly which of the two is missing)
\`\`\`

## Risk

- **Regular risk**. Zero AWS state mutated by this PR. Zero behaviour change until someone dispatches `deploy-edge-lightsail-stage0.yml provision uk1`.
- DNS api-uk1.tokenkey.dev is not affected by this PR.
- Both the EC2 stack (still existing in eu-west-2, deployable=false in matrix) and the planned Lightsail stack remain inactive from operator's perspective until Phase 2.

## Validation

\`\`\`bash
PREFLIGHT_BASE=origin/main bash scripts/preflight.sh           # PASS (incl. exclusivity gate)
python3 -m unittest discover -s deploy/aws/lightsail -p 'test_*.py' -t deploy/aws/lightsail   # 8 tests pass
\`\`\`

## Test plan checklist

- [x] Exclusivity gate green (EC2 uk1=false, Lightsail uk1=true → no collision)
- [x] Lightsail resolver tests refactored to dynamic matrix lookup
- [x] Local preflight green
- [ ] CI green