### PR TITLE
fix(edge-lightsail): default to anonymous GHCR pull; PAT becomes opt-in

### DIFF
--- a/.cursor/skills/tokenkey-stage0-edge-lightsail-expansion/SKILL.md
+++ b/.cursor/skills/tokenkey-stage0-edge-lightsail-expansion/SKILL.md
@@ -98,12 +98,17 @@ aws cloudformation deploy \
   --parameter-overrides GitHubOidcRoleName=tokenkey-gha-us-east-1-error-clustering
 ```
 
-### 1.4 落 GHCR PAT 到 SSM（每个 region 一次）
+### 1.4 GHCR auth（仅在镜像私有时需要）
+
+TokenKey 的 `ghcr.io/<owner>/sub2api` 当前是 **public**，Lightsail bootstrap 走 anonymous pull，**默认不需要 PAT**。workflow input `ghcr_pat_required` 默认 `false`。
+
+仅当镜像未来转私有时，落 PAT 并在 dispatch 时翻位：
 
 ```bash
 aws ssm put-parameter --region "<lightsail_region>" \
   --name "/tokenkey/lightsail/<edge_id>/ghcr/pat" \
   --type SecureString --value 'ghp_…'
+# 然后 provision 时加 -f ghcr_pat_required=true
 ```
 
 ### 1.5 GitHub Environment

--- a/.cursor/skills/tokenkey-stage0-edge-lightsail-expansion/SKILL.md
+++ b/.cursor/skills/tokenkey-stage0-edge-lightsail-expansion/SKILL.md
@@ -4,10 +4,11 @@ description: >-
   End-to-end runbook for adding a TokenKey Stage0 Edge gateway on AWS Lightsail
   (parallel to the EC2/CFN path): register the edge in
   deploy/aws/lightsail/edge-targets-lightsail.json, ensure the one-time
-  Lightsail IAM addon + GHCR PAT are in place, provision via
-  deploy-edge-lightsail-stage0.yml, point DNS, smoke, and upgrade/rollback.
-  EC2/CFN remains the default Edge path; this skill covers the Lightsail
-  parallel path only.
+  Lightsail IAM addon is in place (GHCR PAT only needed when the image is
+  private — TokenKey GHCR is public so default provision uses anonymous pull),
+  provision via deploy-edge-lightsail-stage0.yml, point DNS, smoke, and
+  upgrade/rollback. EC2/CFN remains the default Edge path; this skill covers
+  the Lightsail parallel path only.
 ---
 
 # TokenKey：新增 Lightsail Edge 网关全流程

--- a/.cursor/skills/tokenkey-stage0-edge-platform-migration/SKILL.md
+++ b/.cursor/skills/tokenkey-stage0-edge-platform-migration/SKILL.md
@@ -56,17 +56,16 @@ aws cloudformation deploy \
   --region us-east-1 \
   --stack-name tokenkey-cicd-lightsail-addon \
   --template-file deploy/aws/cloudformation/cicd-oidc-lightsail-addon.yaml \
-  --parameter-overrides GitHubOidcRoleName=tokenkey-gha-us-east-1-error-clustering
+  --parameter-overrides GitHubOidcRoleName=tokenkey-gha-us-east-1-error-clustering \
+  --capabilities CAPABILITY_IAM
 
-# 2) 该 Lightsail region 一次性 PAT
-aws ssm put-parameter --region <lightsail_region> \
-  --name /tokenkey/lightsail/<edge_id>/ghcr/pat \
-  --type SecureString --value 'ghp_…'
-
-# 3) GitHub Environment edge-<edge_id> 已存在（与 EC2 共用），确认变量齐
+# 2) GitHub Environment edge-<edge_id> 已存在（与 EC2 共用），确认变量齐
 #    EDGE_ACME_EMAIL / EDGE_MAIN_GATEWAY_ALLOWED_CIDR / EDGE_MAIN_GATEWAY_BASE_URL
 #    secret: MAIN_GATEWAY_EDGE_SMOKE_API_KEY
 ```
+
+> **GHCR auth**：TokenKey 的 `ghcr.io/<owner>/sub2api` 当前是 public，anonymous pull 可用，**不需要 PAT**。workflow 默认 `ghcr_pat_required=false`。
+> 仅当镜像未来转 private 时：(a) 跑 `aws ssm put-parameter --region <ls_region> --name /tokenkey/lightsail/<edge_id>/ghcr/pat --type SecureString --value 'ghp_…'`；(b) dispatch provision 时加 `-f ghcr_pat_required=true`（或在 Environment 设 `EDGE_GHCR_PAT_SSM_NAME`）。
 
 可机械验证：
 

--- a/.cursor/skills/tokenkey-stage0-edge-platform-migration/SKILL.md
+++ b/.cursor/skills/tokenkey-stage0-edge-platform-migration/SKILL.md
@@ -3,15 +3,16 @@ name: tokenkey-stage0-edge-platform-migration
 description: >-
   Migrate a TokenKey Stage0 Edge **from EC2/CFN to AWS Lightsail** on the same
   `<edge_id>`, sharing the DNS domain `api-<id>.tokenkey.dev`. Drives the full
-  sequence: pre-flight (read-only AWS checks), one-time IAM addon + GHCR PAT
-  setup, matrix flip (exclusivity gate enforces single-platform), Lightsail
-  provision + smoke without DNS cut, operator OAuth re-login on the fresh
-  edge DB, DNS cut at Porkbun, post-cut smoke from an independent vantage
-  point, and finally CFN-native decommission of the retired EC2 stack (auto
-  EBS snapshot, optional EIP release). EC2/CFN remains the default Edge path;
-  this skill exists for the one-way EC2→Lightsail migration. The reverse
-  direction (Lightsail→EC2) is intentionally NOT implemented — build at first
-  need rather than ship an unimplemented API; see §7.
+  sequence: pre-flight (read-only AWS checks), one-time IAM addon setup (GHCR
+  PAT only when the image is private — TokenKey GHCR is public by default),
+  matrix flip (exclusivity gate enforces single-platform), Lightsail provision
+  + smoke without DNS cut, operator OAuth re-login on the fresh edge DB, DNS
+  cut at Porkbun, post-cut smoke from an independent vantage point, and finally
+  CFN-native decommission of the retired EC2 stack (auto EBS snapshot, optional
+  EIP release). EC2/CFN remains the default Edge path; this skill exists for
+  the one-way EC2→Lightsail migration. The reverse direction (Lightsail→EC2)
+  is intentionally NOT implemented — build at first need rather than ship an
+  unimplemented API; see §7.
 ---
 
 # TokenKey：Edge 平台迁移全流程（EC2 → Lightsail，单向）

--- a/.github/workflows/deploy-edge-lightsail-stage0.yml
+++ b/.github/workflows/deploy-edge-lightsail-stage0.yml
@@ -36,6 +36,11 @@ on:
         required: false
         type: boolean
         default: false
+      ghcr_pat_required:
+        description: "provision only: when true, fetch a PAT from /tokenkey/lightsail/<id>/ghcr/pat and docker login ghcr.io. Default false — TokenKey GHCR is public; anonymous pull works. Flip to true if the GHCR image ever becomes private."
+        required: false
+        type: boolean
+        default: false
       simple_release_override:
         description: "Allow single-arch manifest. Default false."
         required: false
@@ -130,10 +135,19 @@ jobs:
             echo "::error::EDGE_MAIN_GATEWAY_ALLOWED_CIDR not set; this MUST mirror the current prod main-gateway egress IP/CIDR (no hard-coded default — see deploy/aws/lightsail/README.md)"
             exit 1
           fi
-          if [ -n "${GHCR_PAT_SSM_NAME_OVERRIDE:-}" ]; then
-            GHCR_PAT_SSM="${GHCR_PAT_SSM_NAME_OVERRIDE}"
+          # GHCR auth: anonymous pull is the default (image is public). Set
+          # ghcr_pat_required=true OR Environment var EDGE_GHCR_PAT_SSM_NAME to
+          # opt back into docker-login-based auth (private-image scenario).
+          GHCR_PAT_SSM=""
+          if [ "${{ inputs.ghcr_pat_required }}" = "true" ] || [ -n "${GHCR_PAT_SSM_NAME_OVERRIDE:-}" ]; then
+            if [ -n "${GHCR_PAT_SSM_NAME_OVERRIDE:-}" ]; then
+              GHCR_PAT_SSM="${GHCR_PAT_SSM_NAME_OVERRIDE}"
+            else
+              GHCR_PAT_SSM="${{ steps.edge.outputs.ssm_prefix }}/ghcr/pat"
+            fi
+            echo "GHCR auth path: docker login via SSM SecureString $GHCR_PAT_SSM"
           else
-            GHCR_PAT_SSM="${{ steps.edge.outputs.ssm_prefix }}/ghcr/pat"
+            echo "GHCR auth path: anonymous (public image; no PAT needed)"
           fi
           if [ "${RECREATE:-false}" = "true" ]; then
             echo "::warning::RECREATE=true — existing instance and Static IP will be DESTROYED"

--- a/deploy/aws/lightsail/generated-launch-script.sh
+++ b/deploy/aws/lightsail/generated-launch-script.sh
@@ -9,11 +9,15 @@ echo "LIGHTSAIL_BOOTSTRAP_START $(date -u +%FT%TZ)"
 : "${ACME_EMAIL:?ACME_EMAIL required}"
 : "${MAIN_GATEWAY_ALLOWED_CIDR:?MAIN_GATEWAY_ALLOWED_CIDR required}"
 : "${TOKENKEY_IMAGE:?TOKENKEY_IMAGE required}"
-: "${GHCR_PULL_USER:?GHCR_PULL_USER required}"
-: "${GHCR_PAT_SSM_NAME:?GHCR_PAT_SSM_NAME required}"
 : "${LIGHTSAIL_REGION:?LIGHTSAIL_REGION required}"
 : "${SSM_ACTIVATION_ID:?SSM_ACTIVATION_ID required}"
 : "${SSM_ACTIVATION_CODE:?SSM_ACTIVATION_CODE required}"
+# GHCR auth is OPTIONAL: when GHCR_PAT_SSM_NAME is empty the bootstrap relies
+# on anonymous pull (works for public ghcr.io/* images, which TokenKey
+# currently is). Set GHCR_PAT_SSM_NAME to an SSM SecureString name when the
+# image becomes private.
+: "${GHCR_PAT_SSM_NAME:=}"
+: "${GHCR_PULL_USER:=}"
 
 export ADMIN_EMAIL="${ADMIN_EMAIL:-admin@${API_DOMAIN}}"
 export TZ_VALUE="${TZ_VALUE:-UTC}"
@@ -114,11 +118,20 @@ TOTP_ENCRYPTION_KEY=${TOTP_ENCRYPTION_KEY}
 ENVEOF
 chmod 0600 /var/lib/tokenkey/.env
 
-GHCR_PAT="$(aws --region "${LIGHTSAIL_REGION}" ssm get-parameter \
-  --name "${GHCR_PAT_SSM_NAME}" --with-decryption \
-  --query Parameter.Value --output text)"
-echo "${GHCR_PAT}" | docker login ghcr.io -u "${GHCR_PULL_USER}" --password-stdin
-unset GHCR_PAT
+if [ -n "${GHCR_PAT_SSM_NAME:-}" ]; then
+  # Private-image path: pull the PAT from SSM SecureString and docker login.
+  GHCR_PAT="$(aws --region "${LIGHTSAIL_REGION}" ssm get-parameter \
+    --name "${GHCR_PAT_SSM_NAME}" --with-decryption \
+    --query Parameter.Value --output text)"
+  echo "${GHCR_PAT}" | docker login ghcr.io -u "${GHCR_PULL_USER}" --password-stdin
+  unset GHCR_PAT
+else
+  # Public-image path (default for TokenKey GHCR): no docker login. Anonymous
+  # pull works because ghcr.io/* manifests are accessible via anonymous bearer.
+  # If the image ever turns private, set GHCR_PAT_SSM_NAME on the workflow side
+  # and the docker login branch above engages with no other changes.
+  echo "GHCR_PAT_SSM_NAME unset; relying on anonymous pull for public image ${TOKENKEY_IMAGE}"
+fi
 
 cat > /etc/systemd/system/tokenkey.service <<'UNITEOF'
 [Unit]

--- a/deploy/aws/lightsail/render-bootstrap.sh
+++ b/deploy/aws/lightsail/render-bootstrap.sh
@@ -39,11 +39,15 @@ echo "LIGHTSAIL_BOOTSTRAP_START $(date -u +%FT%TZ)"
 : "${ACME_EMAIL:?ACME_EMAIL required}"
 : "${MAIN_GATEWAY_ALLOWED_CIDR:?MAIN_GATEWAY_ALLOWED_CIDR required}"
 : "${TOKENKEY_IMAGE:?TOKENKEY_IMAGE required}"
-: "${GHCR_PULL_USER:?GHCR_PULL_USER required}"
-: "${GHCR_PAT_SSM_NAME:?GHCR_PAT_SSM_NAME required}"
 : "${LIGHTSAIL_REGION:?LIGHTSAIL_REGION required}"
 : "${SSM_ACTIVATION_ID:?SSM_ACTIVATION_ID required}"
 : "${SSM_ACTIVATION_CODE:?SSM_ACTIVATION_CODE required}"
+# GHCR auth is OPTIONAL: when GHCR_PAT_SSM_NAME is empty the bootstrap relies
+# on anonymous pull (works for public ghcr.io/* images, which TokenKey
+# currently is). Set GHCR_PAT_SSM_NAME to an SSM SecureString name when the
+# image becomes private.
+: "${GHCR_PAT_SSM_NAME:=}"
+: "${GHCR_PULL_USER:=}"
 
 export ADMIN_EMAIL="${ADMIN_EMAIL:-admin@${API_DOMAIN}}"
 export TZ_VALUE="${TZ_VALUE:-UTC}"
@@ -150,11 +154,20 @@ TOTP_ENCRYPTION_KEY=${TOTP_ENCRYPTION_KEY}
 ENVEOF
 chmod 0600 /var/lib/tokenkey/.env
 
-GHCR_PAT="$(aws --region "${LIGHTSAIL_REGION}" ssm get-parameter \
-  --name "${GHCR_PAT_SSM_NAME}" --with-decryption \
-  --query Parameter.Value --output text)"
-echo "${GHCR_PAT}" | docker login ghcr.io -u "${GHCR_PULL_USER}" --password-stdin
-unset GHCR_PAT
+if [ -n "${GHCR_PAT_SSM_NAME:-}" ]; then
+  # Private-image path: pull the PAT from SSM SecureString and docker login.
+  GHCR_PAT="$(aws --region "${LIGHTSAIL_REGION}" ssm get-parameter \
+    --name "${GHCR_PAT_SSM_NAME}" --with-decryption \
+    --query Parameter.Value --output text)"
+  echo "${GHCR_PAT}" | docker login ghcr.io -u "${GHCR_PULL_USER}" --password-stdin
+  unset GHCR_PAT
+else
+  # Public-image path (default for TokenKey GHCR): no docker login. Anonymous
+  # pull works because ghcr.io/* manifests are accessible via anonymous bearer.
+  # If the image ever turns private, set GHCR_PAT_SSM_NAME on the workflow side
+  # and the docker login branch above engages with no other changes.
+  echo "GHCR_PAT_SSM_NAME unset; relying on anonymous pull for public image ${TOKENKEY_IMAGE}"
+fi
 
 cat > /etc/systemd/system/tokenkey.service <<'UNITEOF'
 [Unit]

--- a/deploy/aws/lightsail/test_render_bootstrap.py
+++ b/deploy/aws/lightsail/test_render_bootstrap.py
@@ -45,6 +45,37 @@ class RenderBootstrapTests(unittest.TestCase):
             "register must not be guarded by || true (R-003).",
         )
 
+    def test_generated_artifact_skips_docker_login_when_pat_empty(self):
+        # Default: GHCR is public → bootstrap must take the anonymous path.
+        content = GENERATED.read_text(encoding="utf-8")
+        self.assertIn(
+            'if [ -n "${GHCR_PAT_SSM_NAME:-}" ]; then',
+            content,
+            "bootstrap must gate docker login on GHCR_PAT_SSM_NAME being non-empty",
+        )
+        self.assertIn(
+            "relying on anonymous pull for public image",
+            content,
+            "bootstrap must log the anonymous-pull branch when PAT is unset",
+        )
+        # The PRIVATE branch must still exist for the case GHCR turns private.
+        self.assertIn(
+            'docker login ghcr.io -u "${GHCR_PULL_USER}" --password-stdin',
+            content,
+            "bootstrap must retain the private-image docker login path",
+        )
+
+    def test_generated_artifact_does_not_require_ghcr_pat_ssm_name(self):
+        # The strict `: "${GHCR_PAT_SSM_NAME:?...}"` guard would break the
+        # anonymous-default invariant by aborting bootstrap when no PAT is
+        # configured. Assert it's gone.
+        content = GENERATED.read_text(encoding="utf-8")
+        self.assertNotIn(
+            '"${GHCR_PAT_SSM_NAME:?',
+            content,
+            "GHCR_PAT_SSM_NAME must not be a required env var (default = anonymous pull)",
+        )
+
 
 if __name__ == "__main__":
     unittest.main()

--- a/ops/migration/edge-platform-migration-preflight.sh
+++ b/ops/migration/edge-platform-migration-preflight.sh
@@ -136,12 +136,16 @@ if [[ "$PHASE" == "provision" || "$PHASE" == "cutover" || "$PHASE" == "decommiss
     ok "$ADDON_STACK present in $ADDON_FOUND"
   fi
 
-  # GHCR PAT — required by Lightsail bootstrap to pull the image
+  # GHCR PAT is OPTIONAL: TokenKey's GHCR image is public, so anonymous pull
+  # works. Only check the PAT path when the workflow is configured to require
+  # auth (env var EDGE_GHCR_PAT_SSM_NAME set, or `ghcr_pat_required=true` at
+  # dispatch time). The preflight doesn't know the dispatch input, so we treat
+  # the PAT as a soft "info" check rather than a hard FAIL.
   GHCR_PAT_NAME="${ls_ssm_prefix}/ghcr/pat"
-  if ! aws ssm get-parameter --region "$ls_region" --name "$GHCR_PAT_NAME" --with-decryption >/dev/null 2>&1; then
-    fail "SSM SecureString $GHCR_PAT_NAME missing in $ls_region. One-time setup: aws ssm put-parameter --region $ls_region --name $GHCR_PAT_NAME --type SecureString --value 'ghp_...'"
+  if aws ssm get-parameter --region "$ls_region" --name "$GHCR_PAT_NAME" --with-decryption >/dev/null 2>&1; then
+    ok "GHCR PAT present at $GHCR_PAT_NAME (workflow may use it if ghcr_pat_required=true)"
   else
-    ok "GHCR PAT present at $GHCR_PAT_NAME"
+    echo "  info: no GHCR PAT at $GHCR_PAT_NAME — provision will use anonymous pull (TokenKey GHCR is public). If the image turns private, set EDGE_GHCR_PAT_SSM_NAME or dispatch with ghcr_pat_required=true after writing the PAT to SSM."
   fi
 
   # Lightsail instance must NOT already exist (else exclusivity is illusory)


### PR DESCRIPTION
## Summary

TokenKey's GHCR image \`ghcr.io/<owner>/sub2api\` is **public** (anonymous bearer works; manifest fetch returns 200). The Lightsail bootstrap was forcing a docker-login flow that required a PAT in SSM, which the migration-preflight then gated as a hard prerequisite. Phase 1 setup required PAT generation + SSM write — for a public image that needs no authentication.

Discovered during Phase 1 of edge-uk1 EC2→Lightsail migration (existing gh CLI token lacks \`read:packages\` scope; anonymous pull would have worked all along).

## What's in this PR

| File | Change |
|---|---|
| \`deploy/aws/lightsail/render-bootstrap.sh\` | docker login is gated on \`[ -n "${GHCR_PAT_SSM_NAME}" ]\`. Empty → log "relying on anonymous pull" + proceed. Strict \`:?\` requirements removed for GHCR_PAT_SSM_NAME / GHCR_PULL_USER. Private-image path preserved bit-for-bit. |
| \`.github/workflows/deploy-edge-lightsail-stage0.yml\` | new boolean input \`ghcr_pat_required\` (default **false**). When true or when Environment var \`EDGE_GHCR_PAT_SSM_NAME\` is set, the PAT path engages. |
| \`ops/migration/edge-platform-migration-preflight.sh\` | GHCR PAT presence demoted from hard FAIL to soft \`info:\` line. Matches the new default. |
| \`deploy/aws/lightsail/generated-launch-script.sh\` | regenerated; preflight drift gate confirms. |
| \`.cursor/skills/tokenkey-stage0-edge-lightsail-expansion/SKILL.md\` | §1.4 rewritten: anonymous-by-default + opt-in private-image path. |
| \`.cursor/skills/tokenkey-stage0-edge-platform-migration/SKILL.md\` | §0 setup commands: drop the mandatory PAT step; explain opt-in private-image path. |
| \`deploy/aws/lightsail/test_render_bootstrap.py\` | 2 new tests pin the anonymous-default contract: docker login is gated; \`:?\` strict require removed. |

## Risk

- **Regular risk**. Public-image path is what AWS Lightsail bootstrap actually needs today. Private-image path is preserved (zero behaviour change when \`ghcr_pat_required=true\`).
- Zero AWS state mutated.

## Validation

\`\`\`bash
python3 -m unittest discover -s deploy/aws/lightsail -p 'test_*.py' -t deploy/aws/lightsail   # 10 pass
bash deploy/aws/lightsail/render-bootstrap.sh --check                                          # OK (no drift)
bash ops/migration/edge-platform-migration-preflight.sh uk1 --phase=provision                 # PASS
PREFLIGHT_BASE=origin/main bash scripts/preflight.sh                                           # PASS
\`\`\`

## Operational consequence

- Phase 1 setup of any new Lightsail edge is now **ONE command** (IAM addon CFN deploy). The PAT step is deferred indefinitely.
- edge-uk1 Phase 2 provision can dispatch directly with no further AWS setup.

## Test plan

- [x] Bootstrap drift gate green
- [x] All lightsail unit tests pass (10)
- [x] migration-preflight \`--phase=provision uk1\` PASS against live AWS
- [x] Local preflight green
- [ ] CI green