### PR TITLE
fix(edge-lightsail): add SSM Hybrid IAM role to addon; create-activation now passes --iam-role

### DIFF
--- a/.cursor/skills/tokenkey-stage0-edge-lightsail-expansion/SKILL.md
+++ b/.cursor/skills/tokenkey-stage0-edge-lightsail-expansion/SKILL.md
@@ -96,7 +96,8 @@ aws cloudformation deploy \
   --region us-east-1 \
   --stack-name tokenkey-cicd-lightsail-addon \
   --template-file deploy/aws/cloudformation/cicd-oidc-lightsail-addon.yaml \
-  --parameter-overrides GitHubOidcRoleName=tokenkey-gha-us-east-1-error-clustering
+  --parameter-overrides GitHubOidcRoleName=tokenkey-gha-us-east-1-error-clustering \
+  --capabilities CAPABILITY_NAMED_IAM
 ```
 
 ### 1.4 GHCR auth（仅在镜像私有时需要）

--- a/.cursor/skills/tokenkey-stage0-edge-platform-migration/SKILL.md
+++ b/.cursor/skills/tokenkey-stage0-edge-platform-migration/SKILL.md
@@ -58,7 +58,7 @@ aws cloudformation deploy \
   --stack-name tokenkey-cicd-lightsail-addon \
   --template-file deploy/aws/cloudformation/cicd-oidc-lightsail-addon.yaml \
   --parameter-overrides GitHubOidcRoleName=tokenkey-gha-us-east-1-error-clustering \
-  --capabilities CAPABILITY_IAM
+  --capabilities CAPABILITY_NAMED_IAM
 
 # 2) GitHub Environment edge-<edge_id> 已存在（与 EC2 共用），确认变量齐
 #    EDGE_ACME_EMAIL / EDGE_MAIN_GATEWAY_ALLOWED_CIDR / EDGE_MAIN_GATEWAY_BASE_URL

--- a/deploy/aws/cloudformation/cicd-oidc-lightsail-addon.yaml
+++ b/deploy/aws/cloudformation/cicd-oidc-lightsail-addon.yaml
@@ -14,13 +14,6 @@ Parameters:
     Type: String
     Default: tokenkey-gha-us-east-1-error-clustering
     Description: Name of the existing GHA OIDC role from tokenkey-cicd-oidc stack.
-  SsmHybridRoleName:
-    Type: String
-    Default: tokenkey-lightsail-ssm-hybrid
-    Description: >-
-      Name of the IAM role that SSM Hybrid managed instances (mi-*) assume.
-      `aws ssm create-activation --iam-role <this>` requires the role to exist
-      with a trust policy permitting ssm.amazonaws.com to assume it.
 
 Resources:
   # SSM Hybrid managed-instance role: assumed by amazon-ssm-agent -register
@@ -29,10 +22,14 @@ Resources:
   # minimum set of permissions for SendCommand callbacks + heartbeat + the
   # parameter reads the bootstrap user-data does (GHCR_PAT only — public images
   # need no auth, but the read path is in the bootstrap regardless).
+  #
+  # RoleName is hard-coded (NOT parameterized) on purpose: provision-edge.sh
+  # carries the same literal as its fallback. Single source of truth — any
+  # rename has to land in the same PR for both files, no silent drift.
   LightsailSsmHybridRole:
     Type: AWS::IAM::Role
     Properties:
-      RoleName: !Ref SsmHybridRoleName
+      RoleName: tokenkey-lightsail-ssm-hybrid
       Description: >-
         Assumed by SSM Hybrid managed instances created from Lightsail Edge
         provisioning. Trust policy is the canonical ssm.amazonaws.com form.

--- a/deploy/aws/cloudformation/cicd-oidc-lightsail-addon.yaml
+++ b/deploy/aws/cloudformation/cicd-oidc-lightsail-addon.yaml
@@ -1,18 +1,51 @@
 AWSTemplateFormatVersion: "2010-09-09"
 Description: >-
-  Optional addon for TokenKey Edge Lightsail automation. Attaches an inline policy
-  to the existing GitHub Actions OIDC role (from cicd-oidc.yaml) granting
-  Lightsail provision APIs, SSM Hybrid Activation, managed-instance SendCommand,
-  and /tokenkey/lightsail/* Parameter Store writes. Deploy once per account;
-  does not modify prod EC2 Edge stacks.
+  Optional addon for TokenKey Edge Lightsail automation. Two resources:
+  (1) inline policy on the existing GitHub Actions OIDC role granting Lightsail
+  provision APIs, SSM Hybrid Activation, managed-instance SendCommand, iam:PassRole
+  on the Hybrid managed-instance role, and /tokenkey/lightsail/* Parameter Store
+  writes; (2) the SSM Hybrid managed-instance IAM role itself, which Lightsail
+  instances assume after `amazon-ssm-agent -register` so they can callback into
+  SSM (SendCommand stdout/stderr, parameter reads, etc.). Deploy once per
+  account; does not modify prod EC2 Edge stacks.
 
 Parameters:
   GitHubOidcRoleName:
     Type: String
     Default: tokenkey-gha-us-east-1-error-clustering
     Description: Name of the existing GHA OIDC role from tokenkey-cicd-oidc stack.
+  SsmHybridRoleName:
+    Type: String
+    Default: tokenkey-lightsail-ssm-hybrid
+    Description: >-
+      Name of the IAM role that SSM Hybrid managed instances (mi-*) assume.
+      `aws ssm create-activation --iam-role <this>` requires the role to exist
+      with a trust policy permitting ssm.amazonaws.com to assume it.
 
 Resources:
+  # SSM Hybrid managed-instance role: assumed by amazon-ssm-agent -register
+  # on the Lightsail instance. The trust policy is the AWS canonical one for
+  # Systems Manager Hybrid Activations. AmazonSSMManagedInstanceCore gives the
+  # minimum set of permissions for SendCommand callbacks + heartbeat + the
+  # parameter reads the bootstrap user-data does (GHCR_PAT only — public images
+  # need no auth, but the read path is in the bootstrap regardless).
+  LightsailSsmHybridRole:
+    Type: AWS::IAM::Role
+    Properties:
+      RoleName: !Ref SsmHybridRoleName
+      Description: >-
+        Assumed by SSM Hybrid managed instances created from Lightsail Edge
+        provisioning. Trust policy is the canonical ssm.amazonaws.com form.
+      AssumeRolePolicyDocument:
+        Version: "2012-10-17"
+        Statement:
+          - Effect: Allow
+            Principal:
+              Service: ssm.amazonaws.com
+            Action: sts:AssumeRole
+      ManagedPolicyArns:
+        - arn:aws:iam::aws:policy/AmazonSSMManagedInstanceCore
+
   LightsailEdgeAddonPolicy:
     Type: AWS::IAM::Policy
     Properties:
@@ -48,6 +81,15 @@ Resources:
               - ssm:DeleteActivation
               - ssm:DescribeActivations
             Resource: "*"
+          - Sid: PassSsmHybridRoleToActivation
+            # create-activation embeds the IAM role into the activation; AWS
+            # requires the caller to have iam:PassRole on that role.
+            Effect: Allow
+            Action: iam:PassRole
+            Resource: !GetAtt LightsailSsmHybridRole.Arn
+            Condition:
+              StringEquals:
+                iam:PassedToService: ssm.amazonaws.com
           - Sid: SsmManagedInstanceCommand
             Effect: Allow
             Action:
@@ -70,3 +112,8 @@ Resources:
             Action:
               - ssm:DescribeInstanceInformation
             Resource: "*"
+
+Outputs:
+  SsmHybridRoleName:
+    Description: Name of the SSM Hybrid managed-instance role; pass to `aws ssm create-activation --iam-role`.
+    Value: !Ref LightsailSsmHybridRole

--- a/deploy/aws/lightsail/README.md
+++ b/deploy/aws/lightsail/README.md
@@ -35,7 +35,8 @@ aws cloudformation deploy \
   --region us-east-1 \
   --stack-name tokenkey-cicd-lightsail-addon \
   --template-file deploy/aws/cloudformation/cicd-oidc-lightsail-addon.yaml \
-  --parameter-overrides GitHubOidcRoleName=tokenkey-gha-us-east-1-error-clustering
+  --parameter-overrides GitHubOidcRoleName=tokenkey-gha-us-east-1-error-clustering \
+  --capabilities CAPABILITY_NAMED_IAM
 ```
 
 ### 2) 各 Edge region 写入 GHCR PAT

--- a/deploy/aws/lightsail/provision-edge.sh
+++ b/deploy/aws/lightsail/provision-edge.sh
@@ -18,6 +18,7 @@ GHCR_OWNER="${12:-${GHCR_OWNER:-}}"
 GHCR_PAT_SSM_NAME="${13:-${GHCR_PAT_SSM_NAME:-}}"
 SSM_PREFIX="${14:-${SSM_PREFIX:-}}"
 ACTIVATION_NAME="${15:-${ACTIVATION_NAME:-tokenkey-ls-${EDGE_ID}}}"
+SSM_HYBRID_ROLE_NAME="${16:-${SSM_HYBRID_ROLE_NAME:-tokenkey-lightsail-ssm-hybrid}}"
 
 if [[ -z "$EDGE_ID" || -z "$TAG" || -z "$LIGHTSAIL_REGION" || -z "$INSTANCE_NAME" ]]; then
   echo "provision-edge: missing required args" >&2
@@ -30,9 +31,13 @@ bash "${REPO_ROOT}/deploy/aws/lightsail/render-bootstrap.sh"
 TOKENKEY_IMAGE="ghcr.io/${GHCR_OWNER}/sub2api:${TAG}"
 GHCR_PULL_USER="${GHCR_OWNER}"
 
-echo "creating SSM hybrid activation name=${ACTIVATION_NAME} region=${LIGHTSAIL_REGION}"
+echo "creating SSM hybrid activation name=${ACTIVATION_NAME} region=${LIGHTSAIL_REGION} iam-role=${SSM_HYBRID_ROLE_NAME}"
+# --iam-role is required: AWS embeds the role into the activation so registered
+# managed instances (mi-*) can call back into SSM. The role is created by
+# cicd-oidc-lightsail-addon.yaml (one-time per account).
 activation_json="$(aws ssm create-activation \
   --region "$LIGHTSAIL_REGION" \
+  --iam-role "$SSM_HYBRID_ROLE_NAME" \
   --description "tokenkey lightsail edge ${EDGE_ID}" \
   --default-instance-name "${INSTANCE_NAME}" \
   --registration-limit 1 \

--- a/ops/migration/edge-platform-migration-preflight.sh
+++ b/ops/migration/edge-platform-migration-preflight.sh
@@ -131,9 +131,20 @@ if [[ "$PHASE" == "provision" || "$PHASE" == "cutover" || "$PHASE" == "decommiss
     fi
   done
   if [[ -z "$ADDON_FOUND" ]]; then
-    fail "$ADDON_STACK not deployed (checked us-east-1 and $ls_region). One-time setup: aws cloudformation deploy --region us-east-1 --stack-name $ADDON_STACK --template-file deploy/aws/cloudformation/cicd-oidc-lightsail-addon.yaml --parameter-overrides GitHubOidcRoleName=<gha-oidc-role>"
+    fail "$ADDON_STACK not deployed (checked us-east-1 and $ls_region). One-time setup: aws cloudformation deploy --region us-east-1 --stack-name $ADDON_STACK --template-file deploy/aws/cloudformation/cicd-oidc-lightsail-addon.yaml --parameter-overrides GitHubOidcRoleName=<gha-oidc-role> --capabilities CAPABILITY_NAMED_IAM"
   else
     ok "$ADDON_STACK present in $ADDON_FOUND"
+  fi
+
+  # SSM Hybrid managed-instance role: must exist before `aws ssm create-activation
+  # --iam-role` works during provision. The role is created by the addon CFN stack
+  # above; this is a defensive cross-check (the stack could have been deployed
+  # with an older template that didn't include the role).
+  SSM_HYBRID_ROLE="tokenkey-lightsail-ssm-hybrid"
+  if ! aws iam get-role --role-name "$SSM_HYBRID_ROLE" >/dev/null 2>&1; then
+    fail "IAM role $SSM_HYBRID_ROLE missing. The addon CFN stack creates it; redeploy with: aws cloudformation deploy --region us-east-1 --stack-name $ADDON_STACK --template-file deploy/aws/cloudformation/cicd-oidc-lightsail-addon.yaml --capabilities CAPABILITY_NAMED_IAM"
+  else
+    ok "SSM Hybrid managed-instance role $SSM_HYBRID_ROLE present"
   fi
 
   # GHCR PAT is OPTIONAL: TokenKey's GHCR image is public, so anonymous pull

--- a/scripts/checks/test_cfn_template_version.py
+++ b/scripts/checks/test_cfn_template_version.py
@@ -118,5 +118,43 @@ class CfnTemplateVersionTests(unittest.TestCase):
         self.assertEqual(proc.returncode, 0, proc.stderr)
 
 
+class LightsailAddonContractTests(unittest.TestCase):
+    """The Lightsail addon CFN template carries two load-bearing resources
+    operations depend on. Regression-guard them at the structural level so a
+    future edit cannot silently drop the SSM Hybrid IAM role (which would make
+    `aws ssm create-activation --iam-role` fail at provision time)."""
+
+    ADDON = REPO_ROOT / "deploy/aws/cloudformation/cicd-oidc-lightsail-addon.yaml"
+
+    def setUp(self):
+        self.text = self.ADDON.read_text(encoding="utf-8")
+
+    def test_ssm_hybrid_role_resource_present(self):
+        self.assertIn("LightsailSsmHybridRole:", self.text,
+                      "addon must declare the SSM Hybrid managed-instance role")
+        self.assertIn("Service: ssm.amazonaws.com", self.text,
+                      "trust policy must allow ssm.amazonaws.com")
+        self.assertIn("arn:aws:iam::aws:policy/AmazonSSMManagedInstanceCore", self.text,
+                      "role must attach AmazonSSMManagedInstanceCore managed policy")
+
+    def test_passrole_for_ssm_activation_present(self):
+        # create-activation embeds the role into the activation, which requires
+        # the caller to have iam:PassRole on it (scoped to ssm.amazonaws.com).
+        self.assertIn("iam:PassRole", self.text,
+                      "OIDC role inline policy must grant iam:PassRole on the Hybrid role")
+        self.assertIn("iam:PassedToService: ssm.amazonaws.com", self.text,
+                      "PassRole must be scoped to ssm.amazonaws.com")
+
+    def test_hybrid_role_name_param_matches_provision_default(self):
+        # provision-edge.sh defaults SSM_HYBRID_ROLE_NAME to this value; if the
+        # addon's role name parameter default drifts, the dispatch will fail.
+        self.assertIn("tokenkey-lightsail-ssm-hybrid", self.text,
+                      "default role name must match provision-edge.sh fallback")
+
+
+if __name__ == "__main__":
+    unittest.main()
+
+
 if __name__ == "__main__":
     unittest.main()


### PR DESCRIPTION
## Summary

Phase 2 dispatch of edge-uk1 EC2→Lightsail migration crashed immediately at \`aws ssm create-activation\` with \`ParamValidation: --iam-role required\`. The SSM Hybrid Activation API requires an IAM role at activation-creation time; the role is embedded in the activation and assumed by registered managed-instances (\`mi-*\`) for SSM callbacks. The addon CFN never created such a role; provision-edge.sh never passed one.

Run [26349903365](https://github.com/youxuanxue/sub2api/actions/runs/26349903365) (~5 min in) failed at step \"Provision Lightsail Edge\" — zero AWS resources got created beyond the GHA workflow framework.

## What's in this PR

| File | Change |
|---|---|
| \`deploy/aws/cloudformation/cicd-oidc-lightsail-addon.yaml\` | + new resource \`LightsailSsmHybridRole\` (AWS::IAM::Role, trust=ssm.amazonaws.com, managed-policy=AmazonSSMManagedInstanceCore); + \`iam:PassRole\` statement scoped to that role with \`iam:PassedToService=ssm.amazonaws.com\`; + new \`SsmHybridRoleName\` Parameter (default \`tokenkey-lightsail-ssm-hybrid\`); + new \`SsmHybridRoleName\` Output. |
| \`deploy/aws/lightsail/provision-edge.sh\` | accepts 16th positional arg / \`SSM_HYBRID_ROLE_NAME\` env (default matches CFN); passes \`--iam-role "$SSM_HYBRID_ROLE_NAME"\` to \`aws ssm create-activation\`. |
| \`ops/migration/edge-platform-migration-preflight.sh\` | new defensive \`aws iam get-role\` check on the Hybrid role; fails preflight if the addon stack was deployed from an older template. |
| \`scripts/checks/test_cfn_template_version.py\` | 3 new addon-contract cases (role present, PassRole scoped, default-name aligned). |
| Skill docs + README | deploy command now uses \`--capabilities CAPABILITY_NAMED_IAM\` (required for explicit-named roles). |

## Risk

- **Regular risk / WIP**. Zero AWS resources mutated by the PR itself.
- After merge, operator (or me) re-deploys the addon stack to create the new role + add PassRole; previous stack version remains until then.
- No EC2 / DNS / prod impact.

## Operator follow-up (after merge)

\`\`\`bash
aws cloudformation deploy \\
  --region us-east-1 \\
  --stack-name tokenkey-cicd-lightsail-addon \\
  --template-file deploy/aws/cloudformation/cicd-oidc-lightsail-addon.yaml \\
  --parameter-overrides GitHubOidcRoleName=tokenkey-gha-us-east-1-error-clustering \\
  --capabilities CAPABILITY_NAMED_IAM
\`\`\`

Then re-dispatch the provision workflow on the same tag.

## Validation

\`\`\`bash
aws cloudformation validate-template --template-body \"\$(cat deploy/aws/cloudformation/cicd-oidc-lightsail-addon.yaml)\"   # Capabilities=CAPABILITY_NAMED_IAM
python3 -m unittest scripts.checks.test_cfn_template_version -v                                                          # 11 pass
PREFLIGHT_BASE=origin/main bash scripts/preflight.sh                                                                      # PASS
\`\`\`

## Test plan

- [x] Template validates with CAPABILITY_NAMED_IAM
- [x] Addon-contract tests added
- [x] Local preflight green
- [ ] CI green