### PR TITLE
fix(cfn): attach Lightsail addon policy to ALL regional OIDC roles

### DIFF
--- a/.cursor/skills/tokenkey-stage0-edge-lightsail-expansion/SKILL.md
+++ b/.cursor/skills/tokenkey-stage0-edge-lightsail-expansion/SKILL.md
@@ -96,8 +96,9 @@ aws cloudformation deploy \
   --region us-east-1 \
   --stack-name tokenkey-cicd-lightsail-addon \
   --template-file deploy/aws/cloudformation/cicd-oidc-lightsail-addon.yaml \
-  --parameter-overrides GitHubOidcRoleName=tokenkey-gha-us-east-1-error-clustering \
   --capabilities CAPABILITY_NAMED_IAM
+# default GitHubOidcRoleNames covers both regional OIDC roles
+# (us-east-1 + eu-west-2). Override only when adding new region-scoped roles.
 ```
 
 ### 1.4 GHCR auth（仅在镜像私有时需要）

--- a/.cursor/skills/tokenkey-stage0-edge-platform-migration/SKILL.md
+++ b/.cursor/skills/tokenkey-stage0-edge-platform-migration/SKILL.md
@@ -57,8 +57,9 @@ aws cloudformation deploy \
   --region us-east-1 \
   --stack-name tokenkey-cicd-lightsail-addon \
   --template-file deploy/aws/cloudformation/cicd-oidc-lightsail-addon.yaml \
-  --parameter-overrides GitHubOidcRoleName=tokenkey-gha-us-east-1-error-clustering \
   --capabilities CAPABILITY_NAMED_IAM
+# default GitHubOidcRoleNames covers both regional OIDC roles
+# (us-east-1 + eu-west-2). Override only when adding new region-scoped roles.
 
 # 2) GitHub Environment edge-<edge_id> 已存在（与 EC2 共用），确认变量齐
 #    EDGE_ACME_EMAIL / EDGE_MAIN_GATEWAY_ALLOWED_CIDR / EDGE_MAIN_GATEWAY_BASE_URL

--- a/deploy/aws/cloudformation/cicd-oidc-lightsail-addon.yaml
+++ b/deploy/aws/cloudformation/cicd-oidc-lightsail-addon.yaml
@@ -10,10 +10,15 @@ Description: >-
   account; does not modify prod EC2 Edge stacks.
 
 Parameters:
-  GitHubOidcRoleName:
-    Type: String
-    Default: tokenkey-gha-us-east-1-error-clustering
-    Description: Name of the existing GHA OIDC role from tokenkey-cicd-oidc stack.
+  GitHubOidcRoleNames:
+    Type: CommaDelimitedList
+    Default: "tokenkey-gha-us-east-1-error-clustering,tokenkey-gha-eu-west-2-error-clustering"
+    Description: >-
+      Comma-delimited list of existing GHA OIDC role names from
+      tokenkey-cicd-oidc stack. The Lightsail addon policy is attached to
+      ALL listed roles (AWS::IAM::Policy.Roles accepts a list). Default
+      covers both region-scoped OIDC roles currently in use; extend the
+      list when adding new region-scoped OIDC roles in the future.
 
 Resources:
   # SSM Hybrid managed-instance role: assumed by amazon-ssm-agent -register
@@ -47,8 +52,7 @@ Resources:
     Type: AWS::IAM::Policy
     Properties:
       PolicyName: tokenkey-lightsail-edge-addon
-      Roles:
-        - !Ref GitHubOidcRoleName
+      Roles: !Ref GitHubOidcRoleNames
       PolicyDocument:
         Version: "2012-10-17"
         Statement:

--- a/deploy/aws/lightsail/README.md
+++ b/deploy/aws/lightsail/README.md
@@ -35,8 +35,9 @@ aws cloudformation deploy \
   --region us-east-1 \
   --stack-name tokenkey-cicd-lightsail-addon \
   --template-file deploy/aws/cloudformation/cicd-oidc-lightsail-addon.yaml \
-  --parameter-overrides GitHubOidcRoleName=tokenkey-gha-us-east-1-error-clustering \
   --capabilities CAPABILITY_NAMED_IAM
+# default GitHubOidcRoleNames covers both regional OIDC roles
+# (us-east-1 + eu-west-2); override only when adding new region-scoped roles.
 ```
 
 ### 2) 各 Edge region 写入 GHCR PAT


### PR DESCRIPTION
## Summary

Phase 2 re-dispatch ([run 26350336970](https://github.com/youxuanxue/sub2api/actions/runs/26350336970)) failed again at \`aws ssm create-activation\` with \`AccessDeniedException ... iam:PassRole\` on \`tokenkey-gha-eu-west-2-error-clustering\`.

Diagnosis: this account has **two regional GHA OIDC roles** — \`tokenkey-gha-us-east-1-error-clustering\` and \`tokenkey-gha-eu-west-2-error-clustering\`. The Lightsail edge workflow runs under the eu-west-2 variant (because edge-uk1 Environment maps AWS_OIDC_ROLE_ARN there). The addon CFN's \`GitHubOidcRoleName\` Parameter defaulted to the us-east-1 variant; redeploying with the default attached the addon policy to the wrong role.

## What's in this PR

| File | Change |
|---|---|
| \`deploy/aws/cloudformation/cicd-oidc-lightsail-addon.yaml\` | Convert \`GitHubOidcRoleName\` → \`GitHubOidcRoleNames\` (CommaDelimitedList). \`AWS::IAM::Policy.Roles\` natively accepts a list. Default now covers both roles in use. |
| \`deploy/aws/lightsail/README.md\` + 2 skills | drop the \`--parameter-overrides GitHubOidcRoleName=...\` flag from the deploy command. Default covers today's two roles. |

## Why this design

- **Minimum API surface**: \`AWS::IAM::Policy.Roles\` is already a list. CFN supports list-typed Parameters natively. The change is one Type tweak + dropping the wrapping list literal.
- **Operator clarity**: default list documents the current OIDC roles in this account; future additions just extend the list.
- **Multi-region future-proof**: when sg1 / fra1 Lightsail edges come online with their own region-scoped OIDC roles, the same addon stack covers them.

## Risk

- **Low**. Pure IAM-policy attachment expansion. Zero behavioural change for the us-east-1 OIDC role (still has the policy); the eu-west-2 role gains the policy that was missing. No new actions, no new resources.
- After merge: re-deploy addon (one-time per parameter change) + re-dispatch provision.

## Validation

\`\`\`bash
aws cloudformation validate-template --template-body \"\$(cat deploy/aws/cloudformation/cicd-oidc-lightsail-addon.yaml)\"   # Capabilities=CAPABILITY_NAMED_IAM
PREFLIGHT_BASE=origin/main bash scripts/preflight.sh                                                                      # PASS
python3 -m unittest scripts.checks.test_cfn_template_version                                                              # 11 pass
\`\`\`

## Test plan

- [x] Template validates
- [x] Existing addon-contract tests still pass (pin literal role name, not Parameter)
- [x] Local preflight green
- [ ] CI green