### PR TITLE
fix(edge-lightsail): grant ssm:AddTagsToResource + OIDC perm coverage gate

### DIFF
--- a/deploy/aws/cloudformation/cicd-oidc-lightsail-addon.yaml
+++ b/deploy/aws/cloudformation/cicd-oidc-lightsail-addon.yaml
@@ -81,6 +81,15 @@ Resources:
               - ssm:CreateActivation
               - ssm:DeleteActivation
               - ssm:DescribeActivations
+              # AddTagsToResource / RemoveTagsFromResource / ListTagsForResource
+              # are required because `aws ssm create-activation --tags ...` does
+              # an inline AddTagsToResource call on the activation (and AWS's
+              # reverse-mapping reports the IAM role as the resource). Without
+              # these, create-activation fails with AccessDeniedException on
+              # ssm:AddTagsToResource even though the rest is permitted.
+              - ssm:AddTagsToResource
+              - ssm:RemoveTagsFromResource
+              - ssm:ListTagsForResource
             Resource: "*"
           - Sid: PassSsmHybridRoleToActivation
             # create-activation embeds the IAM role into the activation; AWS

--- a/scripts/checks/lightsail-oidc-perm-coverage.py
+++ b/scripts/checks/lightsail-oidc-perm-coverage.py
@@ -1,0 +1,167 @@
+#!/usr/bin/env python3
+"""Deterministic coverage check: every AWS action the Lightsail Edge workflow
+issues must be granted by either the addon policy (this repo's CFN) or the
+base OIDC role's inline policies (assumed correct because every other
+workflow depends on it).
+
+Why this script exists
+======================
+
+Phase 2 (Lightsail Edge uk1 provision) hit three separate AWS implicit
+permission contracts in 24 hours:
+
+  - PR #397: `aws ssm create-activation --iam-role` ⇒ needs iam:PassRole
+  - PR #398: addon policy attached to wrong regional OIDC role
+  - PR #399: `aws ssm create-activation --tags` ⇒ needs ssm:AddTagsToResource
+
+Each was discovered via a failed workflow dispatch. Per CLAUDE.md §"升级原则":
+when a soft rule slips through review more than once, harden it. This script
+hardens "did we forget a perm?" — it text-checks the addon CFN (and falls
+back to the base OIDC CFN for inherited perms) for every action the
+Lightsail provision / upgrade / smoke / decommission paths actually issue.
+
+Why static (not iam:SimulatePrincipalPolicy)
+============================================
+
+`aws iam simulate-principal-policy` would be more semantically accurate (it
+respects NotAction, conditions, deny statements, etc.), but it requires the
+caller to have `iam:SimulatePrincipalPolicy` on the target role — which our
+local IAM user doesn't have. Granting that perm is itself a one-shot manual
+step that defeats the OPC "no manual setup" intent.
+
+Static text match is good enough because:
+- IAM policy action names are unique strings (no overlap risk)
+- All our addon statements are `Effect: Allow` (no NotAction / Deny / Condition
+  hazards that need policy-semantic evaluation)
+- The same gate is what `scripts/checks/test_cfn_template_version.py
+  LightsailAddonContractTests` already does for individual actions; this script
+  generalizes that one-action-at-a-time pattern into a single sweep.
+
+Exit codes
+==========
+
+  0  — every expected action is granted by addon OR base policy
+  1  — at least one expected action is missing from both
+  2  — input / file IO error
+
+stdlib-only.
+"""
+from __future__ import annotations
+
+import argparse
+import pathlib
+import sys
+
+REPO_ROOT = pathlib.Path(__file__).resolve().parents[2]
+ADDON_CFN = REPO_ROOT / "deploy/aws/cloudformation/cicd-oidc-lightsail-addon.yaml"
+BASE_CFN = REPO_ROOT / "deploy/aws/cloudformation/cicd-oidc.yaml"
+
+# Hard-coded list of every AWS action the Lightsail Edge workflow issues.
+# Maintenance contract: when provision-edge.sh / render-bootstrap.sh /
+# deploy_via_ssm.sh / edge_post_deploy_smoke.sh / the workflow itself adds
+# a new `aws <service> <command>` invocation that hits AWS via OIDC, append
+# the corresponding action here in the same PR. The notes are operator-
+# facing remediation hints when the gate fires.
+EXPECTED_ACTIONS: list[tuple[str, str]] = [
+    # --- SSM Hybrid Activation (provision step) -------------------------
+    ("ssm:CreateActivation", "aws ssm create-activation — base"),
+    ("ssm:AddTagsToResource", "aws ssm create-activation --tags inline call (PR #399)"),
+    ("ssm:DeleteActivation", "cleanup path"),
+    ("ssm:DescribeActivations", "audit / sanity read"),
+    ("iam:PassRole", "aws ssm create-activation --iam-role tokenkey-lightsail-ssm-hybrid (PR #397)"),
+    # --- Lightsail instance lifecycle ---------------------------------
+    ("lightsail:GetInstance", "probe before create + post-create poll"),
+    ("lightsail:CreateInstances", "the act of creating the instance"),
+    ("lightsail:DeleteInstance", "recreate=true path"),
+    ("lightsail:StopInstance", "recreate=true graceful stop"),
+    # --- Lightsail Static IP lifecycle ---------------------------------
+    ("lightsail:GetStaticIp", "probe before allocate + read for downstream"),
+    ("lightsail:AllocateStaticIp", "first-provision path"),
+    ("lightsail:AttachStaticIp", "bind IP to instance"),
+    ("lightsail:DetachStaticIp", "recreate=true path"),
+    ("lightsail:ReleaseStaticIp", "recreate=true path + ip rotation"),
+    # --- SSM managed-instance ops after registration -------------------
+    ("ssm:DescribeInstanceInformation", "poll for mi-* registration"),
+    ("ssm:SendCommand", "upgrade / smoke / log fetch via Hybrid managed instance"),
+    ("ssm:GetCommandInvocation", "read SendCommand stdout/stderr"),
+    # --- SSM Parameter Store (state read/write) ------------------------
+    ("ssm:PutParameter", "provision writes managed_instance_id / public_ip etc."),
+    ("ssm:GetParameter", "upgrade / IP rotation read public_ip and instance id"),
+]
+
+
+def _load(path: pathlib.Path) -> str:
+    return path.read_text(encoding="utf-8")
+
+
+def _missing_actions(
+    expected: list[tuple[str, str]],
+    addon_text: str,
+    base_text: str,
+) -> list[tuple[str, str, str]]:
+    """Return [(action, where_checked, notes)] for every expected action not
+    present in either policy text.
+
+    Substring match suffices because IAM action names are unique. We do NOT
+    try to interpret `Effect: Deny` or condition gates here — within this
+    codebase neither policy file uses Deny, and conditions only narrow
+    (never widen) what an Allow grants."""
+    missing: list[tuple[str, str, str]] = []
+    for action, notes in expected:
+        if action in addon_text:
+            continue
+        if action in base_text:
+            continue
+        missing.append((action, "addon+base", notes))
+    return missing
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser(description=__doc__.split("\n\n")[0])
+    parser.add_argument(
+        "--quiet",
+        action="store_true",
+        help="On success, print only one OK line",
+    )
+    args = parser.parse_args()
+
+    try:
+        addon_text = _load(ADDON_CFN)
+    except OSError as exc:
+        print(f"FAIL: cannot read {ADDON_CFN.relative_to(REPO_ROOT)}: {exc}", file=sys.stderr)
+        return 2
+    try:
+        base_text = _load(BASE_CFN)
+    except OSError as exc:
+        print(f"FAIL: cannot read {BASE_CFN.relative_to(REPO_ROOT)}: {exc}", file=sys.stderr)
+        return 2
+
+    missing = _missing_actions(EXPECTED_ACTIONS, addon_text, base_text)
+    if not missing:
+        if not args.quiet:
+            print(
+                f"ok: {len(EXPECTED_ACTIONS)} expected action(s) granted by addon and/or base OIDC policy"
+            )
+        else:
+            print(f"ok: lightsail OIDC perm coverage ({len(EXPECTED_ACTIONS)} actions)")
+        return 0
+
+    print(
+        "FAIL: actions used by the Lightsail edge workflow are not granted by "
+        "either addon or base OIDC role policy. The next workflow dispatch will "
+        "AccessDenied on these:",
+        file=sys.stderr,
+    )
+    for action, where, notes in missing:
+        suffix = f" — {notes}" if notes else ""
+        print(f"  - {action!r} (checked: {where}){suffix}", file=sys.stderr)
+    print(
+        f"  Fix by adding the action(s) to {ADDON_CFN.relative_to(REPO_ROOT)} "
+        "(under the SsmHybridActivation or appropriate statement) and redeploying.",
+        file=sys.stderr,
+    )
+    return 1
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/scripts/checks/test_cfn_template_version.py
+++ b/scripts/checks/test_cfn_template_version.py
@@ -151,6 +151,20 @@ class LightsailAddonContractTests(unittest.TestCase):
         self.assertIn("tokenkey-lightsail-ssm-hybrid", self.text,
                       "default role name must match provision-edge.sh fallback")
 
+    def test_ssm_add_tags_to_resource_permitted(self):
+        # `aws ssm create-activation --tags ...` (provision-edge.sh passes tags
+        # at activation creation) makes an inline AddTagsToResource call. Without
+        # this action in the addon policy, create-activation fails with
+        # AccessDeniedException — surfaced in Phase 2 3rd attempt (run 26350611129).
+        # Pin the trio (Add / Remove / List) so the regression cannot return
+        # silently if someone trims the action list in the future.
+        self.assertIn("ssm:AddTagsToResource", self.text,
+                      "addon must grant ssm:AddTagsToResource (required by create-activation --tags)")
+        self.assertIn("ssm:RemoveTagsFromResource", self.text,
+                      "symmetric Remove for cleanup")
+        self.assertIn("ssm:ListTagsForResource", self.text,
+                      "audit reads")
+
 
 if __name__ == "__main__":
     unittest.main()

--- a/scripts/checks/test_lightsail_oidc_perm_coverage.py
+++ b/scripts/checks/test_lightsail_oidc_perm_coverage.py
@@ -1,0 +1,115 @@
+"""Tests for scripts/checks/lightsail-oidc-perm-coverage.py.
+
+stdlib-only.
+"""
+from __future__ import annotations
+
+import importlib.util
+import pathlib
+import subprocess
+import sys
+import tempfile
+import textwrap
+import unittest
+
+REPO_ROOT = pathlib.Path(__file__).resolve().parents[2]
+SCRIPT = REPO_ROOT / "scripts/checks/lightsail-oidc-perm-coverage.py"
+
+
+def _load_module():
+    """Load the script as a module (its file name uses dashes, so importlib)."""
+    spec = importlib.util.spec_from_file_location("lightsail_perm_coverage", SCRIPT)
+    mod = importlib.util.module_from_spec(spec)
+    assert spec.loader is not None
+    spec.loader.exec_module(mod)
+    return mod
+
+
+class LightsailOidcPermCoverageTests(unittest.TestCase):
+    """The coverage gate is text-level. Tests pin: action list non-empty,
+    detection of missing actions, real repo passes."""
+
+    def setUp(self):
+        self.mod = _load_module()
+
+    def test_expected_actions_nonempty(self):
+        """Forgetting to populate EXPECTED_ACTIONS would make every coverage
+        check trivially pass — guard against that emptying."""
+        self.assertGreaterEqual(len(self.mod.EXPECTED_ACTIONS), 10,
+                                "EXPECTED_ACTIONS must enumerate the real action set")
+
+    def test_expected_action_format(self):
+        """Each entry must be (action_string, notes) and the action must look
+        like an IAM action — `service:Action`."""
+        for entry in self.mod.EXPECTED_ACTIONS:
+            self.assertIsInstance(entry, tuple)
+            self.assertEqual(len(entry), 2)
+            action, notes = entry
+            self.assertRegex(action, r"^[a-z][a-z0-9-]+:[A-Z][A-Za-z]+$",
+                             f"action {action!r} doesn't look like an IAM action")
+            self.assertIsInstance(notes, str)
+
+    def test_missing_action_detected(self):
+        # Synthetic empty policies → every expected action reported as missing.
+        missing = self.mod._missing_actions(
+            self.mod.EXPECTED_ACTIONS,
+            addon_text="(no policies)",
+            base_text="(no policies)",
+        )
+        self.assertEqual(len(missing), len(self.mod.EXPECTED_ACTIONS))
+
+    def test_addon_covers_passes(self):
+        # Synthetic "addon" contains every action; base empty. All ok.
+        synth = "\n".join(a for a, _ in self.mod.EXPECTED_ACTIONS)
+        missing = self.mod._missing_actions(
+            self.mod.EXPECTED_ACTIONS,
+            addon_text=synth,
+            base_text="(empty)",
+        )
+        self.assertEqual(missing, [])
+
+    def test_base_covers_passes(self):
+        # Inverse: base contains everything, addon is empty.
+        synth = "\n".join(a for a, _ in self.mod.EXPECTED_ACTIONS)
+        missing = self.mod._missing_actions(
+            self.mod.EXPECTED_ACTIONS,
+            addon_text="(empty)",
+            base_text=synth,
+        )
+        self.assertEqual(missing, [])
+
+    def test_partial_coverage_reports_only_missing(self):
+        # Half in addon, half in base, one truly missing.
+        expected = list(self.mod.EXPECTED_ACTIONS)
+        if len(expected) < 3:
+            self.skipTest("need at least 3 actions")
+        addon_text = "\n".join(a for a, _ in expected[:1])
+        base_text = "\n".join(a for a, _ in expected[1:-1])
+        missing = self.mod._missing_actions(expected, addon_text, base_text)
+        self.assertEqual(len(missing), 1)
+        self.assertEqual(missing[0][0], expected[-1][0])
+
+    def test_real_repo_passes(self):
+        """Smoke: every expected action must be granted by the actual
+        committed policies. If this fails, the addon or base CFN dropped an
+        action our workflow depends on (or the workflow gained an action that
+        wasn't added to EXPECTED_ACTIONS)."""
+        proc = subprocess.run(
+            [sys.executable, str(SCRIPT)],
+            capture_output=True, text=True, check=False,
+        )
+        self.assertEqual(proc.returncode, 0, f"stdout:{proc.stdout}\nstderr:{proc.stderr}")
+
+    def test_real_repo_passes_via_subprocess(self):
+        """Verify the script's CLI surface (not just internals) returns 0 on
+        the real repo."""
+        proc = subprocess.run(
+            [sys.executable, str(SCRIPT), "--quiet"],
+            capture_output=True, text=True, check=False,
+        )
+        self.assertEqual(proc.returncode, 0, proc.stderr)
+        self.assertIn("ok:", proc.stdout)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/scripts/preflight.sh
+++ b/scripts/preflight.sh
@@ -792,6 +792,22 @@ elif ! python3 ./scripts/checks/cfn-template-version.py; then
     errors=$((errors + 1))
 fi
 
+# ---- sub2api: Lightsail OIDC perm coverage -----------------------------------
+# Discover-by-failure on AWS implicit permission contracts is the OPC
+# anti-pattern that PRs #397/#398/#399 each fixed in isolation. This gate
+# text-checks the addon + base OIDC policies against the action list the
+# Lightsail edge workflow actually issues. Any drift (workflow gains a new
+# `aws <service> <command>` call without a matching policy update) fails
+# preflight before a workflow dispatch can hit AccessDenied at runtime.
+echo ""
+echo "=== sub2api: Lightsail OIDC perm coverage ==="
+if ! command -v python3 >/dev/null 2>&1; then
+    echo "  FAIL: python3 not on PATH (required for OIDC perm coverage check)"
+    errors=$((errors + 1))
+elif ! python3 ./scripts/checks/lightsail-oidc-perm-coverage.py --quiet; then
+    errors=$((errors + 1))
+fi
+
 # ---- sub2api: edge platform exclusivity -------------------------------------
 # EC2 Edge and Lightsail Edge intentionally share the same <edge_id> namespace,
 # the same GitHub Environment edge-<id>, and the same DNS domain


### PR DESCRIPTION
## Summary (broadened scope after god-view retrospective)

Originally this PR fixed a single perm (\`ssm:AddTagsToResource\`) found in the Phase 2 3rd-attempt failure ([run 26350611129](https://github.com/youxuanxue/sub2api/actions/runs/26350611129)). The user called out that **three consecutive perm-by-perm PRs in 24 hours is the OPC anti-pattern itself** (per CLAUDE.md §"升级原则": when a soft rule slips through twice, harden it — I waited until the third).

This PR is now reshaped to fix the meta-pattern, not just one more perm:

1. (Original) Grant \`ssm:AddTagsToResource\` / \`ssm:RemoveTagsFromResource\` / \`ssm:ListTagsForResource\` to the addon policy — required by \`aws ssm create-activation --tags\`.
2. (Added in reshape) **Lightsail OIDC perm coverage gate** — \`scripts/checks/lightsail-oidc-perm-coverage.py\` text-checks the addon + base OIDC policies against the full 19-action set the Lightsail edge workflow issues. Wired into \`scripts/preflight.sh\`. Catches the *next* missing perm before workflow dispatch.

## Why text-match (not iam:SimulatePrincipalPolicy)

Live simulation requires \`iam:SimulatePrincipalPolicy\` on the target role; the local IAM user (\`Tech-Partner\`) doesn't have that perm and granting it is itself manual setup that defeats the OPC posture. IAM action names are unique strings, both CFN policies use only \`Effect: Allow\` (no \`NotAction\` / \`Deny\` / widening conditions), so text match is semantically equivalent to simulation for the bug class.

## Files

| File | Change |
|---|---|
| \`deploy/aws/cloudformation/cicd-oidc-lightsail-addon.yaml\` | + \`ssm:AddTagsToResource\` / \`RemoveTagsFromResource\` / \`ListTagsForResource\` (commit b7d985a1) |
| \`scripts/checks/lightsail-oidc-perm-coverage.py\` | New deterministic gate: 19 hard-coded actions, checks addon + base, exits 1 with operator hints on missing |
| \`scripts/checks/test_lightsail_oidc_perm_coverage.py\` | 8 cases (format / detection / synth coverage / real-repo smoke) |
| \`scripts/checks/test_cfn_template_version.py\` | Existing addon-contract tests gain \`test_ssm_add_tags_to_resource_permitted\` (3 string assertions on the Add/Remove/List trio) |
| \`scripts/preflight.sh\` | New section \"Lightsail OIDC perm coverage\" runs the gate on every PR |

## Concession recorded in commit message

I should have added the coverage gate after PR #397 (the first perm gap), not waited until PR #399 (the third). The fix for PR #4 was always going to be \"add another perm\"; the fix for **why we keep finding perm #N** was always going to be \"add the coverage gate\". I treated each instance as its own bug instead of as instances of the same OPC violation.

## Risk

- **Low**. Pure additive: one new perm trio on the existing OIDC role + one new preflight check.
- After merge: redeploy addon (one-time per template change), confirm \`preflight.sh\` reports \"19 actions covered\", re-dispatch provision.

## Validation

\`\`\`bash
python3 -m unittest scripts.checks.test_cfn_template_version            # 12 pass
python3 -m unittest scripts.checks.test_lightsail_oidc_perm_coverage    # 8 pass
python3 scripts/checks/lightsail-oidc-perm-coverage.py                  # ok: 19 actions covered
PREFLIGHT_BASE=origin/main bash scripts/preflight.sh                    # PASS
aws cloudformation validate-template --template-body \"\$(cat deploy/aws/cloudformation/cicd-oidc-lightsail-addon.yaml)\"   # CAPABILITY_NAMED_IAM
\`\`\`

## Test plan

- [x] Both perm trio + coverage gate ship together
- [x] All new tests pass
- [x] Local preflight green; new section reports 19 actions
- [ ] CI green
- [ ] Re-dispatch Phase 2 after merge → should succeed past create-activation