### PR TITLE
fix(edge-lightsail): SSM discovery + uk1 Porkbun IPv4 pin

### DIFF
--- a/.cursor/skills/tokenkey-stage0-edge-platform-migration/SKILL.md
+++ b/.cursor/skills/tokenkey-stage0-edge-platform-migration/SKILL.md
@@ -77,22 +77,22 @@ bash ops/migration/edge-platform-migration-preflight.sh <edge_id> --phase=provis
 
 未通过则按报错指引补齐再进入 Phase 1。
 
-## 1) Phase plan：迁移意图落码
+## 1) Phase plan：迁移意图落码（矩阵独占）
 
-EC2→Lightsail 方向，前置假设：
-- EC2 `<edge_id>` 当前 `deployable=false`（已退役 ops 矩阵）
-- Lightsail `<edge_id>` 当前 `deployable=false`（PR #380 默认）
-- DNS `api-<id>.tokenkey.dev` 当前指向 EC2 EIP 或已经空
+EC2→Lightsail 方向，写入矩阵并通过 `scripts/checks/edge-platform-exclusivity.py` gate 后应保持：
 
-**机械检查**：
+| 矩阵文件 | `<edge_id>` 目标状态 |
+|---------|---------------------|
+| `deploy/aws/stage0/edge-targets.json` | **`deployable=false`**（将该 edge 移出 EC2 Stage0 prod/ops 自动矩阵；旧 CFN 栈可仍存在直至 Phase 4 拆除） |
+| `deploy/aws/lightsail/edge-targets-lightsail.json` | **`deployable=true`**（该 DNS 命名的运维入口切到 Lightsail workflow / SSM Hybrid） |
+
+**当前仓库 uk1 已完成上述翻转**（Lightsail 为 `api-uk1.tokenkey.dev` 权威）。若你还要迁 **us1 / fra1 / sg1**，才需要在 PR 里对自己的 `<edge_id>` 做同款翻位（仍建议 **分两笔 commit / 两个小 PR**：先只在 EC2 侧 `deployable=false` 合并通过，再在 Lightsail 侧 `deployable=true`，以便任何时刻 CI exclusivity gate 都为绿）。
+
+机械检查：
 
 ```bash
 bash ops/migration/edge-platform-migration-preflight.sh <edge_id> --phase=plan
 ```
-
-**手工 PR**：把 Lightsail `<edge_id>` 翻成 `deployable=true`，提交 PR。`edge-platform-exclusivity` preflight 会强制 EC2 同名仍是 `false`；CI 全绿后由操作员合并。
-
-> **不要在同一 PR 里同时翻两边的 deployable**——分两步可以让 exclusivity gate 始终强一致。
 
 ## 2) Phase provision：实机起 Lightsail，**不切 DNS**
 
@@ -131,7 +131,9 @@ bash ops/migration/edge-platform-migration-preflight.sh <edge_id> --phase=cutove
 
 按用户回答 ②（fresh-DB 起步），新 Lightsail 实例上的 Postgres 是空的，需要重新创建 Anthropic OAuth 账号：
 
-1. **手工 Porkbun**：把 `api-<edge_id>.tokenkey.dev` A 记录改成 Lightsail Static IP。等 1 分钟。
+1. **手工 Porkbun**：`api-<edge_id>.tokenkey.dev` A 记录必须指向 **Lightsail Static IP**（与 `aws lightsail get-static-ip --static-ip-name tokenkey-edge-<edge_id>-ls-ip` 一致）。
+   **`edge_id=uk1`：** 运维固定 **`16.61.87.51`** — 记在 `deploy/aws/lightsail/edge-targets-lightsail.json` → `targets.uk1.porkbun_a_ipv4`；Lightsail attach 与该地址不一致时，先修 AWS，**不得以「人工保留旧 Porkbun」绕过**（否则会仍在打 EC2 EIP）。
+   等 TTL 收敛（常见约一分钟）。
 2. **独立观察点 smoke**（避开本地 DNS 缓存）：
    ```bash
    curl -sS https://api-<edge_id>.tokenkey.dev/health   # 无 --resolve；走真实 DNS

--- a/deploy/aws/lightsail/README.md
+++ b/deploy/aws/lightsail/README.md
@@ -112,6 +112,21 @@ PREFLIGHT_BASE=origin/main bash scripts/preflight.sh
 实机 provision/smoke 需账户内 Lightsail 权限与 PAT；首跑由
 `tokenkey-stage0-edge-lightsail-expansion` skill 走 `operation=full` 驱动。
 
+### Provision：`SSM managed instance not registered within timeout`
+
+- **常见假阴性（已修复）**：`DescribeInstanceInformation` 不允许把「标签过滤器」与其它过滤器混在一起；也不得依赖 `ComputerName` 默认等于 Lightsail `instance_name`（AL2023 常为 DHCP hostname）。provision 脚本现以 **`ActivationIds` = 本次 Hybrid activation** 作为主查询，并在 bootstrap 里 `hostnamectl set-hostname` 对齐实例名。
+- **仍超时**：Lightsail 浏览器 SSH 查看 `/var/log/tokenkey-lightsail-bootstrap.log`；失败行以 `BOOTSTRAP_FAIL:` 开头。Workflow 末尾会打印 `describe-activations` 帮助判断 activation / 配额是否用尽。
+
+## uk1：`api-uk1.tokenkey.dev` 权威平台（Lightsail）
+
+矩阵基线：**EC2 `uk1.deployable=false`**（`deploy/aws/stage0/edge-targets.json`），**Lightsail `uk1.deployable=true`**（本目录 `edge-targets-lightsail.json`）。
+同名域名只能由一个平台对外服务；两边的 `deployable` 同时为 `true` 会被 **`scripts/checks/edge-platform-exclusivity.py`** 拦下。
+
+**Porkbun（prod，`api-uk1.tokenkey.dev`）：** A 记录保持 **`16.61.87.51`** — 记录在 `edge-targets-lightsail.json` → `targets.uk1.porkbun_a_ipv4`，作为人工 DNS **唯一真值**。若它与 `aws lightsail get-static-ip` 读到的 Attach 不一致，先修 AWS 对齐再改 Porkbun，不得在未协调前提下漂移该 IP。
+
+端到端实操（provision、旁路校验、DNS 核对、Anthropic OAuth 重建、Smoke、可选拆 EC2 栈）：**`.cursor/skills/tokenkey-stage0-edge-platform-migration/SKILL.md`**（等价副本在 `.claude/skills/…`）。
+Lightsail **首次**拉起实例用 `deploy-edge-lightsail-stage0.yml` **`operation=provision`**；镜像 tag 轮转用 **`upgrade` / `rollback`**。
+
 ## IP 污染轮换
 
 ```bash

--- a/deploy/aws/lightsail/edge-targets-lightsail.json
+++ b/deploy/aws/lightsail/edge-targets-lightsail.json
@@ -16,6 +16,7 @@
       "ec2_equivalent_region": "eu-west-2",
       "availability_zone": "eu-west-2a",
       "domain": "api-uk1.tokenkey.dev",
+      "porkbun_a_ipv4": "16.61.87.51",
       "instance_name": "tokenkey-edge-uk1-ls",
       "static_ip_name": "tokenkey-edge-uk1-ls-ip",
       "bundle_id": "micro_3_0",

--- a/deploy/aws/lightsail/generated-launch-script.sh
+++ b/deploy/aws/lightsail/generated-launch-script.sh
@@ -5,6 +5,7 @@ exec > >(tee -a /var/log/tokenkey-lightsail-bootstrap.log) 2>&1
 echo "LIGHTSAIL_BOOTSTRAP_START $(date -u +%FT%TZ)"
 
 : "${EDGE_ID:?EDGE_ID required}"
+: "${INSTANCE_NAME:?INSTANCE_NAME required}"
 : "${API_DOMAIN:?API_DOMAIN required}"
 : "${ACME_EMAIL:?ACME_EMAIL required}"
 : "${MAIN_GATEWAY_ALLOWED_CIDR:?MAIN_GATEWAY_ALLOWED_CIDR required}"
@@ -18,6 +19,14 @@ echo "LIGHTSAIL_BOOTSTRAP_START $(date -u +%FT%TZ)"
 # image becomes private.
 : "${GHCR_PAT_SSM_NAME:=}"
 : "${GHCR_PULL_USER:=}"
+
+# Align kernel hostname with Lightsail instance name so SSM ComputerName-based
+# discovery matches provision-edge.sh fallbacks (AL2023 default is often a dhcp name).
+if command -v hostnamectl >/dev/null 2>&1; then
+  hostnamectl set-hostname "${INSTANCE_NAME}" || true
+else
+  hostname "${INSTANCE_NAME}" 2>/dev/null || true
+fi
 
 export ADMIN_EMAIL="${ADMIN_EMAIL:-admin@${API_DOMAIN}}"
 export TZ_VALUE="${TZ_VALUE:-UTC}"

--- a/deploy/aws/lightsail/provision-edge.sh
+++ b/deploy/aws/lightsail/provision-edge.sh
@@ -53,6 +53,7 @@ launch_env_file="$(mktemp)"
 trap 'rm -f "$launch_env_file"' EXIT
 cat >"$launch_env_file" <<EOF
 export EDGE_ID='${EDGE_ID}'
+export INSTANCE_NAME='${INSTANCE_NAME}'
 export API_DOMAIN='${API_DOMAIN}'
 export ACME_EMAIL='${ACME_EMAIL}'
 export MAIN_GATEWAY_ALLOWED_CIDR='${MAIN_GATEWAY_ALLOWED_CIDR}'
@@ -132,13 +133,25 @@ aws lightsail attach-static-ip \
 public_ip="$(aws lightsail get-static-ip --region "$LIGHTSAIL_REGION" --static-ip-name "$STATIC_IP_NAME" \
   --query 'staticIp.ipAddress' --output text)"
 
-echo "waiting for SSM managed instance registration (up to 10m)"
+echo "waiting for SSM managed instance registration (activation_id=${activation_id}, up to 15m)"
+echo "::notice::describe-instance-information must use EITHER tag filters OR non-tag filters — never combine (AWS API)."
 managed_id=""
-deadline=$(( $(date +%s) + 600 ))
+deadline=$(( $(date +%s) + 900 ))
 while [[ $(date +%s) -lt $deadline ]]; do
+  # Primary: ActivationIds uniquely identifies the Hybrid registration minted above
+  # (registration_limit=1). This avoids unreliable ComputerName fallback — AL2023 nodes
+  # often report dhcp hostnames unrelated to Lightsail instance_name.
   managed_id="$(aws ssm describe-instance-information \
     --region "$LIGHTSAIL_REGION" \
-    --filters "Key=tag:EdgeId,Values=${EDGE_ID}" "Key=ResourceType,Values=ManagedInstance" \
+    --filters "Key=ActivationIds,Values=${activation_id}" \
+    --query 'InstanceInformationList[0].InstanceId' --output text 2>/dev/null || true)"
+  if [[ -n "$managed_id" && "$managed_id" != "None" && "$managed_id" != "null" ]]; then
+    break
+  fi
+  # Secondary: activation tags propagate to MI but cannot combine with ResourceType.
+  managed_id="$(aws ssm describe-instance-information \
+    --region "$LIGHTSAIL_REGION" \
+    --filters "Key=tag:EdgeId,Values=${EDGE_ID}" \
     --query 'InstanceInformationList[0].InstanceId' --output text 2>/dev/null || true)"
   if [[ -n "$managed_id" && "$managed_id" != "None" && "$managed_id" != "null" ]]; then
     break
@@ -155,6 +168,9 @@ done
 
 if [[ -z "$managed_id" || "$managed_id" == "None" || "$managed_id" == "null" ]]; then
   echo "::error::SSM managed instance not registered within timeout; check /var/log/tokenkey-lightsail-bootstrap.log via Lightsail browser SSH"
+  echo "::notice::describe-activations (registration count / expiration):"
+  aws ssm describe-activations --region "$LIGHTSAIL_REGION" --no-paginate \
+    --filters "FilterKey=ActivationIds,FilterValues=${activation_id}" || true
   exit 1
 fi
 

--- a/deploy/aws/lightsail/render-bootstrap.sh
+++ b/deploy/aws/lightsail/render-bootstrap.sh
@@ -40,6 +40,7 @@ exec > >(tee -a /var/log/tokenkey-lightsail-bootstrap.log) 2>&1
 echo "LIGHTSAIL_BOOTSTRAP_START $(date -u +%FT%TZ)"
 
 : "${EDGE_ID:?EDGE_ID required}"
+: "${INSTANCE_NAME:?INSTANCE_NAME required}"
 : "${API_DOMAIN:?API_DOMAIN required}"
 : "${ACME_EMAIL:?ACME_EMAIL required}"
 : "${MAIN_GATEWAY_ALLOWED_CIDR:?MAIN_GATEWAY_ALLOWED_CIDR required}"
@@ -53,6 +54,14 @@ echo "LIGHTSAIL_BOOTSTRAP_START $(date -u +%FT%TZ)"
 # image becomes private.
 : "${GHCR_PAT_SSM_NAME:=}"
 : "${GHCR_PULL_USER:=}"
+
+# Align kernel hostname with Lightsail instance name so SSM ComputerName-based
+# discovery matches provision-edge.sh fallbacks (AL2023 default is often a dhcp name).
+if command -v hostnamectl >/dev/null 2>&1; then
+  hostnamectl set-hostname "${INSTANCE_NAME}" || true
+else
+  hostname "${INSTANCE_NAME}" 2>/dev/null || true
+fi
 
 export ADMIN_EMAIL="${ADMIN_EMAIL:-admin@${API_DOMAIN}}"
 export TZ_VALUE="${TZ_VALUE:-UTC}"

--- a/deploy/aws/lightsail/test_provision_edge_ssm_discovery.py
+++ b/deploy/aws/lightsail/test_provision_edge_ssm_discovery.py
@@ -1,0 +1,32 @@
+"""Regression: SSM Hybrid discovery filters (provision-edge.sh wait loop)."""
+
+import unittest
+from pathlib import Path
+
+REPO_ROOT = Path(__file__).resolve().parents[3]
+PROVISION_EDGE = REPO_ROOT / "deploy/aws/lightsail/provision-edge.sh"
+
+
+class ProvisionEdgeSSMDiscoveryTests(unittest.TestCase):
+    def test_uses_activation_id_filter_primary(self):
+        txt = PROVISION_EDGE.read_text(encoding="utf-8")
+        self.assertIn(
+            'Key=ActivationIds,Values=${activation_id}',
+            txt,
+            "Hybrid MI must be resolved via the minted ActivationId "
+            "(reliable registration_limit=1 linkage).",
+        )
+
+    def test_does_not_combine_tag_filter_with_resource_type(self):
+        # DescribeInstanceInformation: tag filters cannot be mixed with non-tag filters.
+        # Prior bug: Key=tag:EdgeId,... Key=ResourceType,Values=ManagedInstance → empty/error.
+        txt = PROVISION_EDGE.read_text(encoding="utf-8")
+        self.assertNotRegex(
+            txt,
+            r"tag:\s*EdgeId.*ResourceType,Values=\s*ManagedInstance",
+            "Illegal tag + ResourceType filter combo breaks describe-instance-information.",
+        )
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/deploy/aws/stage0/edge-targets.json
+++ b/deploy/aws/stage0/edge-targets.json
@@ -16,7 +16,7 @@
       "snapshot_schedule": "none",
       "monthly_budget_usd": 16,
       "ssm_prefix": "/tokenkey/edge/uk1",
-      "purpose": "uk-egress-sample"
+      "purpose": "superseded-by-lightsail-uk1-ec2-matrix-stub; cf stack may linger until destroy via deploy-edge-stage0 decommission"
     },
     "us1": {
       "deployable": true,

--- a/docs/spec-delta-edge-lightsail.md
+++ b/docs/spec-delta-edge-lightsail.md
@@ -49,7 +49,8 @@
 ### 正向
 
 1. **provision**：workflow 创建 SSM Hybrid Activation → Lightsail 实例 launch script
-   注册 SSM → 写入 managed instance id → 分配 Static IP → DNS 后 smoke 通过
+   注册 SSM → **`DescribeInstanceInformation` 以本次 `ActivationId`（`ActivationIds` 过滤器）
+   主路径解析 `mi-*`（不可用「标签过滤器 + ResourceType」混用）；bootstrap `hostnamectl` 对齐 Lightsail `instance_name` 作为兜底** → 写入 managed instance id → 分配 Static IP → DNS 后 smoke 通过
 2. **upgrade**：从 SSM 读 `mi-*` → `deploy_via_ssm.sh` 换 tag → external health +
    `edge_post_deploy_smoke.sh` 通过
 3. **daily diagnostics**：`ops-daily-diagnostics.yml` 自动把 deployable Lightsail

--- a/ops/migration/edge-platform-migration-preflight.sh
+++ b/ops/migration/edge-platform-migration-preflight.sh
@@ -80,6 +80,7 @@ ls_region="$(jq -r --arg id "$EDGE_ID" '.targets[$id].lightsail_region // ""' "$
 ls_instance="$(jq -r --arg id "$EDGE_ID" '.targets[$id].instance_name // ""' "$LS_MATRIX")"
 ls_static_ip_name="$(jq -r --arg id "$EDGE_ID" '.targets[$id].static_ip_name // ""' "$LS_MATRIX")"
 ls_ssm_prefix="$(jq -r --arg id "$EDGE_ID" '.targets[$id].ssm_prefix // ""' "$LS_MATRIX")"
+porkbun_pin="$(jq -r --arg id "$EDGE_ID" '.targets[$id].porkbun_a_ipv4 // empty' "$LS_MATRIX")"
 
 if [[ "$ec2_state" == "missing" ]]; then
   fail "edge_id $EDGE_ID has no entry in deploy/aws/stage0/edge-targets.json"
@@ -185,11 +186,18 @@ if [[ "$PHASE" == "cutover" || "$PHASE" == "decommission" ]]; then
     LS_IP="$(aws lightsail get-static-ip --region "$ls_region" --static-ip-name "$ls_static_ip_name" --query 'staticIp.ipAddress' --output text 2>/dev/null || echo "")"
     if [[ -z "$LS_IP" || "$LS_IP" == "None" ]]; then
       fail "Lightsail Static IP $ls_static_ip_name not allocated in $ls_region — provision incomplete"
-    elif [[ "$PHASE" == "cutover" ]]; then
+    fi
+    if [[ -n "$porkbun_pin" && "$LS_IP" != "$porkbun_pin" ]]; then
+      fail "Lightsail Static IP=$LS_IP but matrix porkbun_a_ipv4=$porkbun_pin — DNS Porkbun must match the pinned v4 once cutover completes; reconcile Lightsail attachment or update the matrix in a PR."
+    fi
+    if [[ -n "$porkbun_pin" && "$LS_IP" == "$porkbun_pin" ]]; then
+      ok "Lightsail Static IP matches matrix porkbun_a_ipv4 ($porkbun_pin)"
+    fi
+    if [[ "$PHASE" == "cutover" ]]; then
       if [[ "$LIVE_IP" == "$LS_IP" ]]; then
         ok "DNS already points $ec2_domain → Lightsail Static IP ($LS_IP)"
       else
-        echo "  info: DNS $ec2_domain currently → $LIVE_IP (Lightsail Static IP is $LS_IP); cutover will swap"
+        echo "  info: DNS $ec2_domain currently → $LIVE_IP (Lightsail Static IP is $LS_IP); cutover will swap${porkbun_pin:+ — target Porkbun A = $porkbun_pin per matrix}}"
       fi
     elif [[ "$PHASE" == "decommission" ]]; then
       if [[ "$LIVE_IP" != "$LS_IP" ]]; then


### PR DESCRIPTION
## Summary

- **Provision reliability:** `DescribeInstanceInformation` no longer mixes incompatible filters; the wait loop primarily queries by the minted Hybrid **`ActivationIds`**, with tag-only and hostname fallbacks. Bootstrap sets **`hostnamectl set-hostname`** from **`INSTANCE_NAME`** in user-data (regenerated `generated-launch-script.sh`). Wait window 15m with `describe-activations` diagnostics on failure.
- **uk1 DNS contract:** `targets.uk1.porkbun_a_ipv4` = **`16.61.87.51`** (Porkbun A for `api-uk1.tokenkey.dev`). README + migration skill document the rule. **Cutover/decommission** migration preflight fails if Lightsail Static IP does not match the pin (avoids “DNS still on EC2 while claiming Lightsail”).
- **Regression test:** `deploy/aws/lightsail/test_provision_edge_ssm_discovery.py`. EC2 matrix `uk1.purpose` clarified as superseded-by-Lightsail stub.

## Risk

- Operators running migration preflight **cutover/decommission** with **`porkbun_a_ipv4` set** must have **Lightsail Static IP == 16.61.87.51** in AWS; otherwise the script fails loudly until AWS is reconciled.

## Validation

- `python3 -m unittest discover -s deploy/aws/lightsail -p 'test_*.py' -v`
- `python3 -m unittest ops.migration.test_edge_platform_migration_preflight -v`
- `bash ops/migration/edge-platform-migration-preflight.sh uk1 --phase=plan`
- `./scripts/preflight.sh` (pre-commit hook on commit)

## Test plan

- [ ] Re-run **`deploy-edge-lightsail-stage0`** `operation=provision` (or recreate) against this branch revision and confirm SSM **`mi-*`** resolves without timeout.
- [ ] **`aws lightsail get-static-ip`** for `tokenkey-edge-uk1-ls-ip` shows **16.61.87.51** before relying on Porkbun pin / decommission path.

Made with [Cursor](https://cursor.com)