### PR TITLE
docs(lightsail): pitfall playbook for SSM region and smoke workflow

### DIFF
--- a/.cursor/skills/tokenkey-stage0-edge-lightsail-expansion/SKILL.md
+++ b/.cursor/skills/tokenkey-stage0-edge-lightsail-expansion/SKILL.md
@@ -23,6 +23,7 @@ description: >-
 | 步骤 | 类型 | 承载 |
 |---|---|---|
 | 解析 edge → 区域/AZ/bundle/SSM 前缀 | 机械 | `deploy/aws/lightsail/resolve-edge-lightsail-target.py` |
+| Stage0 routing / 统一 SSM（与 EC2 路径同源 primitive） | 机械 | `ops/stage0/edge_routing_matrix.py` + `ops/stage0/edge_ssm_execution.py`（admin：`edge_admin_resolve_target.py`）；可部署矩阵：`python3 deploy/aws/stage0/resolve-edge-target.py --list-deployable` |
 | 渲染 user-data（launch script） | 机械 | `deploy/aws/lightsail/render-bootstrap.sh`（drift gate 已接入 preflight） |
 | Provision dispatch + watch | 机械 | `gh workflow run deploy-edge-lightsail-stage0.yml` + `gh run watch --exit-status` |
 | 升级/回滚/烟测 dispatch | 机械 | 同上（operation 参数化） |
@@ -196,9 +197,11 @@ gh workflow run deploy-edge-lightsail-stage0.yml \
 |---|---|---|
 | "EDGE_MAIN_GATEWAY_ALLOWED_CIDR not set" | Environment 漏配 | 加到 `edge-<edge_id>`；不要给默认值 |
 | `provision` 步骤 fail，managed instance 未注册 | SSM Hybrid activation expired / 网络不通 | Lightsail 浏览器 SSH 看 `/var/log/tokenkey-lightsail-bootstrap.log`；`BOOTSTRAP_FAIL: ` 行即根因 |
+| GHA `smoke` / SSM 步骤失败，本机同 tag 却正常 | **`aws` / workflow 用了错的 `--region`**（误用 `ec2_equivalent_region`）或 job **工作目录**与脚本相对路径不一致 | 用 `python3 ops/stage0/edge_ssm_execution.py --repo-root . --edge-id <id> --format env` 核对输出的 **`REGION`**；workflow 里凡 SSM 调用必须与之一致；检查 `defaults.run.working-directory` / `cd` |
 | `external_health` 报 5xx | Caddy 还在签证书 / docker compose 起不来 | `ssh` 进实例 `docker compose -f /var/lib/tokenkey/docker-compose.yml ps` |
 | Static IP 已分配但 attach 失败 | 旧 instance 还在持有该 Static IP | `aws lightsail detach-static-ip` 再重 attach；或 `recreate=true` 重来 |
 | GHCR pull 401 | PAT 过期 / 写错 SSM 路径 | 用 1.4 重新 put-parameter |
+| Squash 合并后 `git branch -d feature/...` 拒绝删除 | Squash 不产生「分支 tip 是 main 祖先」关系 | `git checkout main && git pull --ff-only` 后 `git branch -D feature/...`；`git remote prune origin` |
 
 ## 7) Acceptance（机械化输出）
 

--- a/deploy/aws/lightsail/README.md
+++ b/deploy/aws/lightsail/README.md
@@ -129,6 +129,15 @@ gh workflow run deploy-edge-lightsail-stage0.yml \
 | diagnostics | `ops-daily-diagnostics.yml` 矩阵 | `ops-daily-diagnostics.yml` 矩阵自动接入（按 `platform` 分支；error_clustering installer 暂仍 EC2 only） |
 | 成本 | ~$10–16/月（t4g.micro） | ~$12/月（micro bundle，因区域而异） |
 
+## 复盘：Lightsail 侧常见出错点（避免沿用 EC2 心智）
+
+以下来自线上/CI 与研发流程中的反复踩坑，**与「实例在 Lightsail、控制面在 SSM Hybrid」这一组合强相关**：
+
+1. **SSM / AWS CLI 的 `--region`**：凡针对该 edge 的 `aws ssm`（读 `/tokenkey/lightsail/<edge_id>/…`、后续 SendCommand 的前置解析），必须落在矩阵里的 **`lightsail_region`**。字段 **`ec2_equivalent_region` 只用于对账/文档**，不能拿来当 SSM region（否则会出现「实例与参数在同一区，但 CLI 跑到另一区」——包括 **GHA smoke** 里曾出现的 **region / 工作目录** 不一致类失败）。
+2. **GitHub Actions 里跑 smoke / compose**：确保 job 的 **`working-directory`**（或显式 `cd`）与脚本里相对路径一致（仓库根 vs `deploy/aws/stage0`）。错目录会表现为找不到 `docker-compose.yml`、或子脚本解析到错误 `REPO_ROOT`。
+3. **合并 PR 后的本地清理**：若使用 **squash merge**，`feature` 分支 tip **不是** `main` 的祖先，`git branch -d feature/...` 可能提示「未合并到 HEAD」。应先 `git checkout main && git pull --ff-only`，再对已确认进 `main` 的分支使用 **`git branch -D …`**（并 `git remote prune origin` 清 stale 跟踪分支）。
+4. **preflight 的 `silent-error-swallow` 警告**：`capture-edge-admin-credentials.sh`、`run-probe.sh` 等处对多路日志源 / 可选 `aws` 探测使用 `|| true`、`2>/dev/null` 属于**刻意**「多源尝试、缺一不必失败」。若新增类似写法且确属合法吞错，在对应行加 **`# preflight-allow: swallow`** 并写清理由，避免审查时误判。
+
 ## 本地校验
 
 ```bash

--- a/docs/spec-delta-edge-lightsail.md
+++ b/docs/spec-delta-edge-lightsail.md
@@ -69,6 +69,9 @@
    不会静默销毁；要销毁重建必须显式 `recreate=true`
 5. `EDGE_MAIN_GATEWAY_ALLOWED_CIDR` Environment 未配置 → provision step 立即报错
    （workflow 没有兜底默认；硬编码 prod IP 与 IP rotation 实践冲突，已彻底移除）
+6. 运维/CI 用错 **SSM 区域**（误用 `ec2_equivalent_region` 调 `aws ssm`，或与
+   `edge_ssm_execution.py` 解析出的 `REGION` 不一致）→ Parameter / managed instance
+   查空或 SendCommand 错目标；**Lightsail 路径下一律以矩阵 `lightsail_region` 为准**
 
 ### 回归
 


### PR DESCRIPTION
## Summary
- Extend `deploy/aws/lightsail/README.md` with a short **pitfall recap**: SSM/API region vs `lightsail_region`, GHA smoke `working-directory`, squash-merge branch cleanup, and intentional `silent-error-swallow` patterns + `preflight-allow`.
- Extend `tokenkey-stage0-edge-lightsail-expansion` skill §6 failure table with GHA/workdir vs region and squash `git branch` cleanup rows.
- Add a matching **negative** scenario to `docs/spec-delta-edge-lightsail.md` for wrong SSM region misuse.

## Risk
Documentation and spec-delta wording only — no runtime behavior change.

## Test plan
- [x] Local preflight passed at commit time (hooks).
- [ ] CI green on PR.

Made with [Cursor](https://cursor.com)