### PR TITLE
chore(canonical-tls): rename profile 2_1_142_20260515 → 2_1_150_20260525

### DIFF
--- a/.cursor/skills/tokenkey-anthropic-oauth-config/SKILL.md
+++ b/.cursor/skills/tokenkey-anthropic-oauth-config/SKILL.md
@@ -8,7 +8,7 @@ description: >-
   sticky_buffer / max_sessions 等 account 字段 + enable_tls_fingerprint 与同名
   TLS profile UPSERT/bind）—— 来源
   anthropic-oauth-stability-baselines-tiered.json；canonical profile 名为
-  claude_cli_2_1_142_node24_20260515；同一事务把 users.id=1 的
+  claude_cli_2_1_150_node24_20260525；同一事务把 users.id=1 的
   concurrency 更新为该 edge 库内 schedulable=true 的 anthropic 账号 concurrency 之和。
   (B) prod anthropic api-key 镜像 stub（base_url=api-*.tokenkey.dev 形状）的
   credentials.pool_mode + pool_mode_retry_count —— 来源 anthropic-stub-pool-baselines.json。
@@ -79,7 +79,7 @@ description: >-
 
 **反模式**：`enable_tls_fingerprint=true` 但 **`tls_fingerprint_profiles` 无对应模板行／账号无可靠 `tls_fingerprint_profile_id` 绑定** → 运行时会退回**内置默认** ClientHello，后台无法在模板表中点名在用参数；**不要用** **`tls_fingerprint_profile_id=-1`** 随机指纹跑生产 OAuth（库里每多一条模板，随机抽到其中一条的不确定性就上升）。
 
-**标准要求**：每一条 **Anthropic、`type=oauth` 的边缘账号**，必须绑定 **`tls_fingerprint_profiles.name = claude_cli_2_1_142_node24_20260515`**；字段体以 **`deploy/aws/stage0/anthropic-oauth-stability-baselines-tiered.json`** 的 `shared_baseline.tls_profile` 为单一真值源（对照：`deploy/aws/stage0/claude_cli_2_1_142_node24_20260515.json`）。
+**标准要求**：每一条 **Anthropic、`type=oauth` 的边缘账号**，必须绑定 **`tls_fingerprint_profiles.name = claude_cli_2_1_150_node24_20260525`**；字段体以 **`deploy/aws/stage0/anthropic-oauth-stability-baselines-tiered.json`** 的 `shared_baseline.tls_profile` 为单一真值源（对照：`deploy/aws/stage0/claude_cli_2_1_150_node24_20260525.json`）。
 
 **与本流水线的关系**：写入面 **(A)**（`generate_sql`）会 **`ON CONFLICT (name)` upsert** canonical profile，并把 `accounts.extra.tls_fingerprint_profile_id` 写成对应行 **`id`**；`check` / `verify` 比对 live `tls_profile.*` vs baseline **`tls_profile`** 块。**弃用手建并排模板**：**已废止名** **`claude_cli_nodejs24_fixed`** 不得再绑定新账号；库中无主账号绑定其 id 时，须在 Admin 「TLS 指纹模板」删除该行。**删前**须确认无主账号 **`extra.tls_fingerprint_profile_id`** 仍指向该 id，否则运行时查找不到行→退回内置默认（silent 漂移）。
 
@@ -321,7 +321,7 @@ operate 流程：
 | snapshot 失败 / SSM 拒绝（edge 或 prod） | 校验 EC2 instance 在跑 / `edge-targets.json` 或 `PROD_TARGET` 常量 / OIDC 权限。**仅排障 edge** 跑 `snapshot --skip-prod` 临时绕开 prod 失败 |
 | `apply --confirm` 拒绝 | 必须精确 `yes-apply-anthropic-config-cascade` |
 | tier baseline drift（check-edge-oauth-stability `extra_baseline_drift` / `account_field_drift`） | 单账号用 plan-edge-account-tier 重写到对应 tier；整个 tier 值漂移（多账号）用 `plan-tier-bump --tier lN` 一次性重写 |
-| `tls_profile` drift（`/tls_profile/...` 或 UK 模式：启用 TLS 却无 profile） | tier apply 会通过 `generate_sql` upsert `claude_cli_2_1_142_node24_20260515` 并绑定 `tls_fingerprint_profile_id`——走与上条相同的 **plan-tier-bump** / **plan-edge-account-tier** → apply → verify；参见上文 **Anthropic OAuth：TLS fingerprint 模板** |
+| `tls_profile` drift（`/tls_profile/...` 或 UK 模式：启用 TLS 却无 profile） | tier apply 会通过 `generate_sql` upsert `claude_cli_2_1_150_node24_20260525` 并绑定 `tls_fingerprint_profile_id`——走与上条相同的 **plan-tier-bump** / **plan-edge-account-tier** → apply → verify；参见上文 **Anthropic OAuth：TLS fingerprint 模板** |
 | check guard 报 `status: drift` 且 `diffs[].path` 含 `/credentials/temp_unschedulable_rules`，但数值字段全等 | 加 `--force-template-rewrite` 让 plan 不再走 noop 短路，强制重写 credentials 端字段（snapshot/verify 不读 rules，所以默认 noop；这条 flag 是 escape hatch）。Apply 完跑一次 `check` 当真值 |
 | OAuth account `status=error/suspended` | OAuth 凭据问题（token 过期 / 403 / 上游禁用），见 OAuth 故障文档；不在本流水线范围 |
 | `plan-stub-pool` 输出 `skipped_unmatched` 含一个本应匹配的 stub | 检查它的 `cred_base_url` 实际值——多半是早期建账号时写错了（如多余 `/` 或大小写差异）。改 stub 的 `base_url` 通过 admin UI（**不**改 pattern；pattern 是策略，base_url 是个体配置）|
@@ -343,7 +343,7 @@ operate 流程：
 
 ## 6. 附录 B：baseline JSON 速查与 stable accounts
 
-- 写入面 (A) tier baseline：`deploy/aws/stage0/anthropic-oauth-stability-baselines-tiered.json`（`tier_order: l1..l5`，每个 tier 含 `baseline.account.*` 与 `baseline.extra.*`，`shared_baseline.tls_profile.name` **必须为** `claude_cli_2_1_142_node24_20260515`；orchestrator 在 plan-edge-account-tier / plan-tier-bump 中读它算 expected_after，`generate_sql` 负责 profile upsert + `tls_fingerprint_profile_id` 绑定）
+- 写入面 (A) tier baseline：`deploy/aws/stage0/anthropic-oauth-stability-baselines-tiered.json`（`tier_order: l1..l5`，每个 tier 含 `baseline.account.*` 与 `baseline.extra.*`，`shared_baseline.tls_profile.name` **必须为** `claude_cli_2_1_150_node24_20260525`；orchestrator 在 plan-edge-account-tier / plan-tier-bump 中读它算 expected_after，`generate_sql` 负责 profile upsert + `tls_fingerprint_profile_id` 绑定）
 - 写入面 (B) stub pool baseline：`deploy/aws/stage0/anthropic-stub-pool-baselines.json`（`policy.base_url_pattern` regex + `pool_mode_enabled` + `pool_mode_retry_count`；orchestrator 在 plan-stub-pool 中读它算 expected_after）
 - 更新 stable_accounts 列表（仅人工确认后）：
   ```bash
@@ -363,7 +363,7 @@ operate 流程：
 - `backend/internal/service/ratelimit_service.go` `handleAnthropicUpstreamError`（pool_mode 账号在 anthropic 平台上跳过 3/3 短窗阈值的代码路径）
 - `ops/anthropic/check-edge-oauth-stability.py`（`generate_sql`：`tls_profile` upsert + `extra.tls_fingerprint_profile_id` 绑定）
 - `docs/accounts/anthropic-oauth-edge-guidelines.md`（OAuth edge TLS + tier 现行约定短文）
-- `deploy/aws/stage0/claude_cli_2_1_142_node24_20260515.json`（canonical TLS profile JSON，与 tier baseline `shared_baseline.tls_profile` 对齐）
+- `deploy/aws/stage0/claude_cli_2_1_150_node24_20260525.json`（canonical TLS profile JSON，与 tier baseline `shared_baseline.tls_profile` 对齐）
 - `deploy/aws/stage0/anthropic-oauth-stability-baselines-tiered.json`（tier baseline 唯一真值源；apply SQL 运行时从它派生，无静态 SQL 模板）
 - `deploy/aws/stage0/anthropic-stub-pool-baselines.json`（stub pool 策略唯一真值源；apply SQL 运行时从它派生，无静态 SQL 模板）
 - `backend/internal/handler/admin/account_handler.go`

--- a/backend/internal/service/gateway_service_tk_canonical_oauth_guard.go
+++ b/backend/internal/service/gateway_service_tk_canonical_oauth_guard.go
@@ -7,7 +7,7 @@ import (
 )
 
 // TokenKey canonical-OAuth ingress gates. When an Anthropic OAuth account binds
-// the canonical Claude Code TLS profile (claude_cli_2_1_142_node24_20260515),
+// the canonical Claude Code TLS profile (claude_cli_2_1_150_node24_20260525),
 // only the real claude-cli / claude-sdk identity is allowed to route through it,
 // and only models that the current Claude Code CLI release actually emits are
 // accepted upstream. Both gates collapse the cohort signal that triggered the

--- a/backend/internal/service/identity_service_tk_canonical_http.go
+++ b/backend/internal/service/identity_service_tk_canonical_http.go
@@ -7,11 +7,11 @@ import "strings"
 // block — not ingress clients (prod relay may forward mixed CLI/SDK UAs).
 //
 // TLS profiles only affect ClientHello; this companion pins the HTTP layer to
-// deploy/aws/stage0/claude_cli_2_1_142_node24_20260515.json observed.* values.
+// deploy/aws/stage0/claude_cli_2_1_150_node24_20260525.json observed.* values.
 
-const canonicalTLSFingerprintProfileName = "claude_cli_2_1_142_node24_20260515"
+const canonicalTLSFingerprintProfileName = "claude_cli_2_1_150_node24_20260525"
 
-// canonicalHTTPObserved matches deploy/aws/stage0/claude_cli_2_1_142_node24_20260515.json observed.
+// canonicalHTTPObserved matches deploy/aws/stage0/claude_cli_2_1_150_node24_20260525.json observed.
 var canonicalHTTPObserved = Fingerprint{
 	UserAgent:               "claude-cli/2.1.150 (external, sdk-cli)",
 	StainlessLang:           "js",

--- a/backend/internal/service/identity_service_tk_canonical_http_test.go
+++ b/backend/internal/service/identity_service_tk_canonical_http_test.go
@@ -38,8 +38,8 @@ func (r *fingerprintCacheRecorder) SetMaskedSessionID(context.Context, int64, st
 }
 
 func TestIsCanonicalTLSProfileName(t *testing.T) {
-	require.True(t, IsCanonicalTLSProfileName("claude_cli_2_1_142_node24_20260515"))
-	require.True(t, IsCanonicalTLSProfileName("  claude_cli_2_1_142_node24_20260515  "))
+	require.True(t, IsCanonicalTLSProfileName("claude_cli_2_1_150_node24_20260525"))
+	require.True(t, IsCanonicalTLSProfileName("  claude_cli_2_1_150_node24_20260525  "))
 	require.False(t, IsCanonicalTLSProfileName("claude_cli_nodejs24_fixed"))
 	require.False(t, IsCanonicalTLSProfileName(""))
 }

--- a/deploy/aws/stage0/anthropic-oauth-stability-baselines-tiered.json
+++ b/deploy/aws/stage0/anthropic-oauth-stability-baselines-tiered.json
@@ -51,8 +51,8 @@
       "custom_base_url"
     ],
     "tls_profile": {
-      "name": "claude_cli_2_1_142_node24_20260515",
-      "description": "TLS ClientHello from 2026-05-15 capture (ja3_hash=d871d02cecbde59abbf8f4806134addf). HTTP observed.user_agent aligned to 2026-05-24 CLI (2.1.150). runtime=node v24.3.0 darwin/arm64.",
+      "name": "claude_cli_2_1_150_node24_20260525",
+      "description": "TLS ClientHello from 2026-05-15 capture of cc 2.1.142 (ja3_hash=d871d02cecbde59abbf8f4806134addf, byte-identical through 2.1.150). HTTP observed.user_agent aligned to 2026-05-25 CLI (claude-cli/2.1.150). runtime=node v24.3.0 darwin/arm64.",
       "enable_grease": false,
       "cipher_suites": [
         4865,

--- a/deploy/aws/stage0/claude_cli_2_1_150_node24_20260525.json
+++ b/deploy/aws/stage0/claude_cli_2_1_150_node24_20260525.json
@@ -1,6 +1,6 @@
 {
-  "name": "claude_cli_2_1_142_node24_20260515",
-  "description": "TLS ClientHello captured from Claude Code CLI on 2026-05-15 (ja3_hash=d871d02cecbde59abbf8f4806134addf, unchanged through 2026-05-24). HTTP observed.user_agent refreshed 2026-05-24 to claude-cli/2.1.150. runtime=node v24.3.0 darwin/arm64.",
+  "name": "claude_cli_2_1_150_node24_20260525",
+  "description": "TLS ClientHello captured from Claude Code CLI 2.1.142 on 2026-05-15 (ja3_hash=d871d02cecbde59abbf8f4806134addf); HTTP observed.user_agent aligned to claude-cli/2.1.150 release on 2026-05-25. ClientHello byte-for-byte unchanged across the 2.1.142 → 2.1.150 client bump (verified 2026-05-15 ~ 2026-05-25). runtime=node v24.3.0 darwin/arm64.",
   "enable_grease": false,
   "cipher_suites": [
     4865,

--- a/docs/accounts/anthropic-oauth-edge-guidelines.md
+++ b/docs/accounts/anthropic-oauth-edge-guidelines.md
@@ -13,13 +13,13 @@
 
 | 维度 | TokenKey 要求 |
 |---|---|
-| **`tls_fingerprint_profiles.name`** | **`claude_cli_2_1_142_node24_20260515`** |
+| **`tls_fingerprint_profiles.name`** | **`claude_cli_2_1_150_node24_20260525`** |
 | Profile 字段体（cipher、extensions、curves…） | 与 tier baseline JSON **`shared_baseline.tls_profile`** 一致 |
 | 账号 **`accounts.extra`** | `enable_tls_fingerprint=true`，且 **`tls_fingerprint_profile_id`** 指向上述模板对应的 DB 主键 |
 
 `(A)` 的 **`generate_sql`** 会 **`INSERT … ON CONFLICT (name)`** upsert canonical 模板，并把 `accounts.extra.tls_fingerprint_profile_id` 写成刚插入行的 `id`。
 
-可作字段对照的镜像 JSON：`deploy/aws/stage0/claude_cli_2_1_142_node24_20260515.json`。
+可作字段对照的镜像 JSON：`deploy/aws/stage0/claude_cli_2_1_150_node24_20260525.json`。
 
 **HTTP 层（User-Agent / `x-stainless-*`）**：TLS 模板不决定出站 HTTP 指纹。账号绑定上述 canonical 模板时，网关会把 Redis `fingerprint:{accountID}` 的 HTTP 字段钉死在同一 JSON 的 `observed.*`（与 TLS 参数独立）；prod→edge 透传的多版本 ingress UA 不会改写上游 UA。`ops_error_logs.user_agent` 仍是入口侧客户端 UA，不是 `api.anthropic.com` 所见值。
 

--- a/ops/observability/clear-canonical-fingerprint-cache.sh
+++ b/ops/observability/clear-canonical-fingerprint-cache.sh
@@ -37,6 +37,16 @@ CANONICAL_NAME="${CANONICAL_NAME:-claude_cli_2_1_150_node24_20260525}"
 DB_USER="${POSTGRES_USER:-tokenkey}"
 DB_NAME="${POSTGRES_DB:-tokenkey}"
 
+# Reject any CANONICAL_NAME that is not snake_case + digits. Profile names in
+# this repository follow that shape by convention; tightening this here
+# protects the SQL below from any env-override injection attempt, even though
+# the env source is operator-controlled.
+if ! [[ "$CANONICAL_NAME" =~ ^[A-Za-z0-9_]+$ ]]; then
+  printf '{"status":"error","reason":"CANONICAL_NAME must match [A-Za-z0-9_]+ (got: %s)"}\n' \
+    "$CANONICAL_NAME"
+  exit 1
+fi
+
 # Step 1 — resolve canonical profile id from DB.
 PROFILE_ID=$(docker exec tokenkey-postgres psql -U "$DB_USER" -d "$DB_NAME" -X -A -t -c \
   "SELECT id FROM tls_fingerprint_profiles WHERE name = '$CANONICAL_NAME' LIMIT 1;" \
@@ -94,9 +104,6 @@ join_csv() {
 
 cleared_json=$(join_csv "${cleared_arr[@]:-}")
 skipped_json=$(join_csv "${skipped_arr[@]:-}")
-# Guard the "empty array printed as [,] because of unset expansion" edge case.
-[ "$cleared_json" = "[]" ] || [ "$cleared_json" = "[,]" ] && [ "${#cleared_arr[@]}" -eq 0 ] && cleared_json="[]"
-[ "$skipped_json" = "[]" ] || [ "$skipped_json" = "[,]" ] && [ "${#skipped_arr[@]}" -eq 0 ] && skipped_json="[]"
 
 printf '{"status":"ok","canonical_name":"%s","profile_id":%s,"cleared":%s,"skipped_already_empty":%s}\n' \
   "$CANONICAL_NAME" "$PROFILE_ID" "$cleared_json" "$skipped_json"

--- a/ops/observability/clear-canonical-fingerprint-cache.sh
+++ b/ops/observability/clear-canonical-fingerprint-cache.sh
@@ -1,0 +1,102 @@
+#!/usr/bin/env bash
+# clear-canonical-fingerprint-cache.sh — wipe Redis fingerprint:{accountID}
+# entries for every Anthropic OAuth account bound to the canonical TLS profile,
+# so the next request re-seeds the HTTP fingerprint from
+# applyCanonicalHTTPObserved (deploy/aws/stage0/claude_cli_2_1_150_node24_20260525.json)
+# instead of carrying the old client_id / observed block written under the
+# pre-rename profile name.
+#
+# Determinism contract (matches dev-rules-convention.mdc §"skill / command 确定性基线"):
+#   - Same DB state + Redis state → same one-line JSON report
+#   - All SQL reads are bound to a NUMERIC-validated profile id (no template injection)
+#   - Redis DELs are scoped strictly to accounts whose extra.tls_fingerprint_profile_id
+#     matches the canonical profile row; non-canonical accounts are untouched
+#
+# Invocation (read DB live, write Redis live — operator must explicitly target):
+#   bash ops/observability/run-probe.sh --target prod \
+#     --script ops/observability/clear-canonical-fingerprint-cache.sh
+#   bash ops/observability/run-probe.sh --target edge:uk1 \
+#     --script ops/observability/clear-canonical-fingerprint-cache.sh
+#
+# Env overrides:
+#   CANONICAL_NAME (default: current canonical name)
+#   POSTGRES_USER  (default: tokenkey)
+#   POSTGRES_DB    (default: tokenkey)
+#
+# Output (single line on stdout, JSON):
+#   {"status":"ok","canonical_name":"...","profile_id":N,
+#    "cleared":[id1,id2,...],"skipped_already_empty":[id3,...]}
+#
+# Exit codes:
+#   0 success or "no work to do" (profile not in DB yet — apply manage-anthropic-config first)
+#   1 schema / sanity failure (e.g. non-numeric profile id from DB)
+
+set -euo pipefail
+
+CANONICAL_NAME="${CANONICAL_NAME:-claude_cli_2_1_150_node24_20260525}"
+DB_USER="${POSTGRES_USER:-tokenkey}"
+DB_NAME="${POSTGRES_DB:-tokenkey}"
+
+# Step 1 — resolve canonical profile id from DB.
+PROFILE_ID=$(docker exec tokenkey-postgres psql -U "$DB_USER" -d "$DB_NAME" -X -A -t -c \
+  "SELECT id FROM tls_fingerprint_profiles WHERE name = '$CANONICAL_NAME' LIMIT 1;" \
+  | tr -d '[:space:]' || true)
+
+if [ -z "$PROFILE_ID" ]; then
+  printf '{"status":"skipped","canonical_name":"%s","reason":"canonical profile not in DB; run manage-anthropic-config.py apply first"}\n' \
+    "$CANONICAL_NAME"
+  exit 0
+fi
+
+# Reject non-numeric profile id — protects the next SQL from any unexpected DB
+# output shape.
+if ! [[ "$PROFILE_ID" =~ ^[0-9]+$ ]]; then
+  printf '{"status":"error","canonical_name":"%s","reason":"unexpected profile_id shape from DB: %s"}\n' \
+    "$CANONICAL_NAME" "$PROFILE_ID"
+  exit 1
+fi
+
+# Step 2 — enumerate Anthropic OAuth accounts bound to that profile id.
+ACCOUNT_IDS=$(docker exec tokenkey-postgres psql -U "$DB_USER" -d "$DB_NAME" -X -A -t -c \
+  "SELECT id FROM accounts
+   WHERE platform='anthropic'
+     AND type='oauth'
+     AND deleted_at IS NULL
+     AND COALESCE(extra->>'enable_tls_fingerprint','false')='true'
+     AND COALESCE(extra->>'tls_fingerprint_profile_id','0')::bigint = $PROFILE_ID
+   ORDER BY id;")
+
+# Step 3 — DEL fingerprint:{id} per account; record which keys actually existed.
+cleared_arr=()
+skipped_arr=()
+for id in $ACCOUNT_IDS; do
+  [ -z "$id" ] && continue
+  if ! [[ "$id" =~ ^[0-9]+$ ]]; then
+    continue
+  fi
+  res=$(docker exec tokenkey-redis redis-cli DEL "fingerprint:$id" 2>&1 | tr -d '[:space:]')
+  case "$res" in
+    1) cleared_arr+=("$id") ;;
+    0) skipped_arr+=("$id") ;;
+    *) skipped_arr+=("$id") ;;  # unknown redis result: treat as non-fatal
+  esac
+done
+
+# Step 4 — emit single-line JSON report.
+join_csv() {
+  local IFS=,
+  if [ "$#" -eq 0 ]; then
+    echo "[]"
+  else
+    echo "[$*]"
+  fi
+}
+
+cleared_json=$(join_csv "${cleared_arr[@]:-}")
+skipped_json=$(join_csv "${skipped_arr[@]:-}")
+# Guard the "empty array printed as [,] because of unset expansion" edge case.
+[ "$cleared_json" = "[]" ] || [ "$cleared_json" = "[,]" ] && [ "${#cleared_arr[@]}" -eq 0 ] && cleared_json="[]"
+[ "$skipped_json" = "[]" ] || [ "$skipped_json" = "[,]" ] && [ "${#skipped_arr[@]}" -eq 0 ] && skipped_json="[]"
+
+printf '{"status":"ok","canonical_name":"%s","profile_id":%s,"cleared":%s,"skipped_already_empty":%s}\n' \
+  "$CANONICAL_NAME" "$PROFILE_ID" "$cleared_json" "$skipped_json"

--- a/scripts/preflight.sh
+++ b/scripts/preflight.sh
@@ -619,6 +619,27 @@ else
     echo "  ok: run-probe.sh --env loop anchored"
 fi
 
+# ---- sub2api: ops/observability shell script syntax (batch) -----------------
+# ops/observability/*.sh are operator-facing probes invoked via SSM remote
+# execution; a syntax break here lands as a SSM "Status=Failed" with stderr
+# from the remote bash, which is much harder to diagnose than a local
+# `bash -n` failure. PR #408 added clear-canonical-fingerprint-cache.sh as
+# another such probe; locking the whole directory under `bash -n` is the
+# generalization of the run-probe.sh regression guard above (OPC: harden
+# the pattern, not the instance).
+echo ""
+echo "=== sub2api: ops/observability shell script syntax ==="
+ops_obs_scripts_checked=0
+for s in ops/observability/*.sh; do
+    [ -f "$s" ] || continue
+    if ! bash -n "$s" 2>/dev/null; then
+        echo "  FAIL: $s has bash syntax errors"
+        errors=$((errors + 1))
+    fi
+    ops_obs_scripts_checked=$((ops_obs_scripts_checked + 1))
+done
+echo "  ok: $ops_obs_scripts_checked script(s) parse"
+
 # ---- sub2api: workflow job-level if env-context drift -----------------------
 # GitHub Actions does NOT allow env references in jobs.<name>.if expressions
 # (env evaluates AFTER if). Such references make the entire workflow file

--- a/scripts/sentinels/gateway-tk.json
+++ b/scripts/sentinels/gateway-tk.json
@@ -983,7 +983,7 @@
       "must_contain": [
         "func (s *GatewayService) tlsFingerprintProfileNameForAccount(account *Account) string"
       ],
-      "rationale": "Resolves bound TLS profile name for OAuth HTTP fingerprint pinning (B1). Dropping this helper reverts GetOrCreateFingerprint to ingress-driven UA drift on prod→edge relay paths even when accounts bind claude_cli_2_1_142_node24_20260515."
+      "rationale": "Resolves bound TLS profile name for OAuth HTTP fingerprint pinning (B1). Dropping this helper reverts GetOrCreateFingerprint to ingress-driven UA drift on prod→edge relay paths even when accounts bind claude_cli_2_1_150_node24_20260525."
     },
     {
       "path": "backend/internal/service/identity_service_tk_canonical_http.go",
@@ -993,7 +993,7 @@
         "applyCanonicalHTTPObserved(fp *Fingerprint) bool",
         "claude-cli/2.1.150 (external, sdk-cli)"
       ],
-      "rationale": "Pins HTTP User-Agent and x-stainless-* to deploy/aws/stage0/claude_cli_2_1_142_node24_20260515.json observed block when the canonical TLS template is bound. Without this companion, Redis fingerprint:{accountID} learns ingress UA (e.g. claude-cli/2.1.150 from relay) and upstream HTTP/TLS fingerprints diverge."
+      "rationale": "Pins HTTP User-Agent and x-stainless-* to deploy/aws/stage0/claude_cli_2_1_150_node24_20260525.json observed block when the canonical TLS template is bound. Without this companion, Redis fingerprint:{accountID} learns ingress UA (e.g. claude-cli/2.1.150 from relay) and upstream HTTP/TLS fingerprints diverge."
     },
     {
       "path": "backend/internal/service/identity_service_tk_canonical_http_test.go",


### PR DESCRIPTION
## Summary

Realign the canonical TLS profile **name** with its actual `observed.user_agent`
(`claude-cli/2.1.150`, refreshed 2026-05-25) instead of carrying the original
2.1.142 capture-version forever. Closes R-007 from PR #407 /xj-review.

The TLS ClientHello is **byte-identical** across the 2.1.142 → 2.1.150 client
bump (ja3_hash=`d871d02cecbde59abbf8f4806134addf`, verified 2026-05-15 ~ 2026-05-25);
only the HTTP-observed UA changed. This PR is a **label realignment**, not a
fingerprint change.

## Scope (17 references / 8 files / 1 file rename)

| Surface | Change |
|---|---|
| `deploy/aws/stage0/claude_cli_2_1_142_node24_20260515.json` | renamed → `claude_cli_2_1_150_node24_20260525.json` + internal `name` + `description` refresh |
| `deploy/aws/stage0/anthropic-oauth-stability-baselines-tiered.json` | `tls_profile.name` + description refresh (single source of truth for the apply path) |
| `backend/internal/service/identity_service_tk_canonical_http.go` | `canonicalTLSFingerprintProfileName` const + doc references |
| `backend/internal/service/identity_service_tk_canonical_http_test.go` | test literals |
| `backend/internal/service/gateway_service_tk_canonical_oauth_guard.go` | module-doc reference |
| `docs/accounts/anthropic-oauth-edge-guidelines.md` | operator-facing table + mirror-JSON pointer |
| `scripts/sentinels/gateway-tk.json` | sentinel rationale prose (no `must_contain` literal changes — those pin code anchors, not the profile name) |
| `.cursor/skills/tokenkey-anthropic-oauth-config/SKILL.md` | skill-doc references |
| **NEW** `ops/observability/clear-canonical-fingerprint-cache.sh` | post-apply Redis cleanup primitive |

## Risk

- **Regular risk**. The byte-level TLS ClientHello is unchanged, so Anthropic's
  upstream view of the connection is identical pre/post-rename.
- **Behavior**: post-deploy, until the operator runs the SQL apply step below,
  the DB still carries the **old** profile name + id. The Go const `canonicalTLSFingerprintProfileName`
  expects the **new** name, so `IsCanonicalTLSProfileName(...)` returns `false`
  for every account during the gap window — canonical HTTP-UA pinning is OFF
  during that window, and the gateway falls back to ingress-driven UA merge.
  **Mitigation**: complete the SQL apply step immediately after deploy completes
  on each target (single transaction per target, see below). Operator-facing
  guidelines in `docs/accounts/anthropic-oauth-edge-guidelines.md` already
  document this expectation.

## Post-deploy operator workflow

After this PR merges and the next Stage0 release rolls to prod + every deployable
edge, run the following **per target** (prod + each deployable edge):

### Step 1 — `manage-anthropic-config.py apply`

Reads the new `tls_profile.name` from `anthropic-oauth-stability-baselines-tiered.json`,
generates a single transaction that:
- `INSERT … ON CONFLICT (name) DO UPDATE` into `tls_fingerprint_profiles` — new row id materializes
- `UPDATE accounts.extra.tls_fingerprint_profile_id` for every Anthropic OAuth account → new id

This is the existing `(A)` write surface of `tokenkey-anthropic-oauth-config`; no
new code path needed.

### Step 2 — Redis `fingerprint:{id}` cleanup (NEW script)

```bash
# Per target — prod and each deployable edge
bash ops/observability/run-probe.sh --target prod \
  --script ops/observability/clear-canonical-fingerprint-cache.sh
bash ops/observability/run-probe.sh --target edge:uk1 \
  --script ops/observability/clear-canonical-fingerprint-cache.sh
# (repeat for each edge in deploy/aws/stage0/edge-targets.json with deployable=true)
```

Behavior:
- Resolves the canonical profile id from DB by **new** name
- DELs only `fingerprint:{id}` keys for accounts bound to that profile
  (non-canonical accounts are untouched)
- Emits one-line JSON: `{"status":"ok","canonical_name":"...","profile_id":N,"cleared":[...],"skipped_already_empty":[...]}`
- Idempotent (re-running after empty is a no-op)
- If the canonical profile is not yet in DB (Step 1 not run), exits with
  `"status":"skipped"` and a clear reason — safe ordering enforced.

### Step 3 — Drop the orphaned old profile row

After Step 1, the **old** `tls_fingerprint_profiles` row (`claude_cli_2_1_142_node24_20260515`)
becomes an orphan with no account references. Per the `tokenkey-anthropic-oauth-config`
"反模式" section, drop it from the admin UI «TLS 指纹模板» tab to keep the
library tidy.

### Step 4 — Verify

- `manage-anthropic-config.py snapshot` should show `tls_profile.name == claude_cli_2_1_150_node24_20260525`
- A canonical-bound `/v1/messages` request should re-populate Redis `fingerprint:{id}`
  with `UserAgent = claude-cli/2.1.150 (external, sdk-cli)` (via `applyCanonicalHTTPObserved`)

## Validation (local)

```bash
bash scripts/preflight.sh
cd backend && go test -tags=unit ./internal/service/ \
  -run 'Canonical|GetOrCreateFingerprint|IsCanonicalTLSProfileName' -count=1
bash -n ops/observability/clear-canonical-fingerprint-cache.sh
```

- [x] Preflight PASS — gateway-tk sentinel anchors unchanged (they pin code
      identifiers, not the profile name)
- [x] Canonical unit tests pass with new const literal
- [x] New script syntax-checked + read-DB-only safety (numeric-validated profile
      id; Redis DELs scoped strictly to canonical-bound anthropic OAuth accounts)

## Test plan

- [ ] Merge + Stage0 release
- [ ] Deploy prod → run Step 1 + Step 2 → confirm Step 4 verify on prod
- [ ] Deploy each deployable edge → run Step 1 + Step 2 → confirm Step 4 verify per edge
- [ ] Drop orphaned old profile row from admin UI per target

🤖 Generated with [Claude Code](https://claude.com/claude-code)