### PR TITLE
chore(release): speed up CI with linux-only builds and fix new-api cache

### DIFF
--- a/.github/actions/cache-and-checkout-new-api/action.yml
+++ b/.github/actions/cache-and-checkout-new-api/action.yml
@@ -1,7 +1,7 @@
-# Restore sibling ../new-api from GitHub Actions cache (keyed by .new-api-ref SHA),
-# then run checkout-new-api to ensure exact pinned commit. Speeds CI when pin unchanged.
+# Restore new-api from GitHub Actions cache (keyed by .new-api-ref SHA), then sync
+# to the pinned commit. Cache path stays inside the workspace — GHA rejects `..`.
 name: Cache and checkout new-api sibling
-description: Restore cached QuantumNous/new-api clone next to workspace, then sync to .new-api-ref.
+description: Restore cached QuantumNous/new-api under .cache/new-api, then sync to .new-api-ref.
 
 runs:
   using: composite
@@ -13,7 +13,7 @@ runs:
     - name: Restore cached new-api sibling
       uses: actions/cache@v5
       with:
-        path: ${{ github.workspace }}/../new-api
+        path: .cache/new-api
         key: new-api-${{ steps.new-api-pin.outputs.sha }}
 
     - uses: ./.github/actions/checkout-new-api

--- a/.github/actions/checkout-new-api/action.yml
+++ b/.github/actions/checkout-new-api/action.yml
@@ -2,14 +2,8 @@
 # in .new-api-ref so `backend/go.mod`'s `replace ../../new-api` resolves on CI
 # runners.
 #
-# Why this exists (CLAUDE.md §4 "Cross-Repo Dependency: New API"):
-#   GITHUB_WORKSPACE = /home/runner/work/sub2api/sub2api on CI, so
-#   ../../new-api resolves to /home/runner/work/sub2api/new-api. We pin to the
-#   exact commit in .new-api-ref so release / CI / local-dev stay bit-identical
-#   (scripts/upstream/sync-new-api.sh writes the same pin).
-#
-# When CI restores actions/cache into ../new-api, this action reuses that repo:
-# fetch + checkout to NEW_API_REF instead of always cloning from scratch.
+# The repo lives under $GITHUB_WORKSPACE/.cache/new-api (Actions-cacheable) with
+# a symlink at $GITHUB_WORKSPACE/../new-api for the go.mod replace path.
 #
 # Usage in a workflow job:
 #   steps:
@@ -26,25 +20,4 @@ runs:
   steps:
     - name: Clone or reuse new-api at pinned commit
       shell: bash
-      run: |
-        set -euxo pipefail
-        NEW_API_REF="$(tr -d '[:space:]' < "${GITHUB_WORKSPACE}/.new-api-ref")"
-        [ -n "${NEW_API_REF}" ] || { echo "ERROR: .new-api-ref is empty" >&2; exit 1; }
-        target="${GITHUB_WORKSPACE}/../new-api"
-
-        if [ -d "${target}/.git" ]; then
-          git -C "$target" fetch --filter=blob:none origin "${NEW_API_REF}" 2>/dev/null || \
-            git -C "$target" fetch origin "${NEW_API_REF}" 2>/dev/null || true
-          if git -C "$target" rev-parse "${NEW_API_REF}^{commit}" >/dev/null 2>&1; then
-            git -C "$target" checkout -q "${NEW_API_REF}"
-            ls "$target/go.mod"
-            exit 0
-          fi
-          echo "WARN: cached new-api repo missing SHA ${NEW_API_REF}; recloning"
-          rm -rf "$target"
-        fi
-
-        git clone --filter=blob:none https://github.com/QuantumNous/new-api.git "$target"
-        git -C "$target" fetch --filter=blob:none origin "${NEW_API_REF}" || true
-        git -C "$target" checkout "${NEW_API_REF}"
-        ls "$target/go.mod"
+      run: bash "${GITHUB_WORKSPACE}/scripts/ci/ensure-new-api-sibling.sh"

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -19,11 +19,17 @@ on:
         required: false
         type: boolean
         default: false
+      full_release:
+        description: 'Build darwin/windows/linux archives in addition to multi-arch Docker (slower). Default false; tag pushes use linux-only .goreleaser.yaml.'
+        required: false
+        type: boolean
+        default: false
 
 # 环境变量：合并 workflow_dispatch 输入和 repository variable
-# tag push 触发时读取 vars.SIMPLE_RELEASE，workflow_dispatch 时使用输入参数
+# tag push 触发时读取 vars.SIMPLE_RELEASE / vars.FULL_RELEASE，workflow_dispatch 时使用输入参数
 env:
   SIMPLE_RELEASE: ${{ github.event.inputs.simple_release == 'true' || vars.SIMPLE_RELEASE == 'true' }}
+  FULL_RELEASE: ${{ github.event.inputs.full_release == 'true' || vars.FULL_RELEASE == 'true' }}
 
 permissions:
   contents: write
@@ -101,7 +107,7 @@ jobs:
       - name: Checkout
         uses: actions/checkout@v6
         with:
-          fetch-depth: 0
+          fetch-depth: 1
           ref: ${{ github.event.inputs.tag || github.ref }}
 
       - uses: ./.github/actions/cache-and-checkout-new-api
@@ -117,11 +123,6 @@ jobs:
         with:
           name: frontend-dist
           path: backend/internal/web/dist/
-
-      - name: Verify downloaded frontend artifact
-        run: |
-          python3 scripts/checks/frontend-dist-freshness.py --check backend/internal/web/dist
-          python3 scripts/checks/frontend-release-assets.py --dist backend/internal/web/dist
 
       - name: Setup Go
         uses: actions/setup-go@v6
@@ -157,11 +158,6 @@ jobs:
           username: ${{ github.repository_owner }}
           password: ${{ secrets.GITHUB_TOKEN }}
 
-      - name: Fetch tags with annotations
-        run: |
-          # 确保获取完整的 annotated tag 信息
-          git fetch --tags --force
-
       - name: Get tag message
         id: tag_message
         run: |
@@ -171,6 +167,8 @@ jobs:
             TAG_NAME=${GITHUB_REF#refs/tags/}
           fi
           echo "Processing tag: $TAG_NAME"
+
+          git fetch origin "refs/tags/${TAG_NAME}:refs/tags/${TAG_NAME}" --force
 
           # 获取完整的 tag message（跳过第一行标题）
           TAG_MESSAGE=$(git tag -l --format='%(contents:body)' "$TAG_NAME")
@@ -203,6 +201,21 @@ jobs:
           } >> "$GITHUB_STEP_SUMMARY"
           echo "::warning::simple_release=true — amd64-only build, will overwrite shared tags and break ARM consumers"
 
+      - name: Resolve GoReleaser config
+        id: goreleaser_config
+        run: |
+          if [ "${{ env.SIMPLE_RELEASE }}" = "true" ] && [ "${{ env.FULL_RELEASE }}" = "true" ]; then
+            echo "simple_release and full_release are mutually exclusive" >&2
+            exit 1
+          fi
+          if [ "${{ env.SIMPLE_RELEASE }}" = "true" ]; then
+            echo "args=release --clean --skip=validate --config=.goreleaser.simple.yaml" >> "$GITHUB_OUTPUT"
+          elif [ "${{ env.FULL_RELEASE }}" = "true" ]; then
+            echo "args=release --clean --skip=validate --config=.goreleaser.full.yaml" >> "$GITHUB_OUTPUT"
+          else
+            echo "args=release --clean --skip=validate" >> "$GITHUB_OUTPUT"
+          fi
+
       # GoReleaser already retries per-blob on docker push, but exhausted its
       # internal backoff during the 2026-05-18 v1.7.37 release when GHCR was
       # flapping. Outer two-attempt retry so a single registry blip does not
@@ -217,7 +230,7 @@ jobs:
         uses: goreleaser/goreleaser-action@v7
         with:
           version: '~> v2'
-          args: release --clean --skip=validate ${{ env.SIMPLE_RELEASE == 'true' && '--config=.goreleaser.simple.yaml' || '' }}
+          args: ${{ steps.goreleaser_config.outputs.args }}
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           TAG_MESSAGE: ${{ steps.tag_message.outputs.message }}
@@ -237,7 +250,7 @@ jobs:
         uses: goreleaser/goreleaser-action@v7
         with:
           version: '~> v2'
-          args: release --clean --skip=validate ${{ env.SIMPLE_RELEASE == 'true' && '--config=.goreleaser.simple.yaml' || '' }}
+          args: ${{ steps.goreleaser_config.outputs.args }}
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           TAG_MESSAGE: ${{ steps.tag_message.outputs.message }}

--- a/.goreleaser.full.yaml
+++ b/.goreleaser.full.yaml
@@ -1,3 +1,5 @@
+# Full multi-platform release (darwin/windows/linux). Opt-in via workflow_dispatch
+# full_release=true — default tag releases use linux-only .goreleaser.yaml.
 version: 2
 
 project_name: sub2api
@@ -13,9 +15,14 @@ builds:
       - CGO_ENABLED=0
     goos:
       - linux
+      - windows
+      - darwin
     goarch:
       - amd64
       - arm64
+    ignore:
+      - goos: windows
+        goarch: arm64
     ldflags:
       - -s -w
       - -X main.Commit={{.Commit}}
@@ -27,6 +34,9 @@ archives:
     format: tar.gz
     name_template: >-
       {{ .ProjectName }}_{{ .Version }}_{{ .Os }}_{{ .Arch }}
+    format_overrides:
+      - goos: windows
+        format: zip
     files:
       - LICENSE*
       - README*
@@ -37,11 +47,8 @@ checksum:
   algorithm: sha256
 
 changelog:
-  # 禁用自动 changelog，完全使用 tag 消息
   disable: true
 
-# Docker images — one buildx build per linux/<arch> (GHCR + optional Docker Hub).
-# Docker Hub lines use an empty template when DOCKERHUB_USERNAME=skip (GoReleaser skips empty names).
 dockers:
   - id: linux-amd64
     goos: linux
@@ -75,9 +82,7 @@ dockers:
       - "--label=org.opencontainers.image.revision={{ .Commit }}"
       - "--label=org.opencontainers.image.source=https://github.com/{{ .Env.GITHUB_REPO_OWNER }}/{{ .Env.GITHUB_REPO_NAME }}"
 
-# Docker manifests for multi-arch support
 docker_manifests:
-  # DockerHub manifests (skipped if DOCKERHUB_USERNAME is 'skip')
   - name_template: "{{ .Env.DOCKERHUB_USERNAME }}/sub2api:{{ .Version }}"
     skip_push: '{{ if eq .Env.DOCKERHUB_USERNAME "skip" }}true{{ else }}false{{ end }}'
     image_templates:
@@ -102,7 +107,6 @@ docker_manifests:
       - "{{ .Env.DOCKERHUB_USERNAME }}/sub2api:{{ .Version }}-amd64"
       - "{{ .Env.DOCKERHUB_USERNAME }}/sub2api:{{ .Version }}-arm64"
 
-  # GHCR manifests (owner must be lowercase)
   - name_template: "ghcr.io/{{ .Env.GITHUB_REPO_OWNER_LOWER }}/sub2api:{{ .Version }}"
     image_templates:
       - "ghcr.io/{{ .Env.GITHUB_REPO_OWNER_LOWER }}/sub2api:{{ .Version }}-amd64"
@@ -129,10 +133,10 @@ release:
     name: "{{ .Env.GITHUB_REPO_NAME }}"
   draft: false
   prerelease: auto
-  name_template: "Sub2API {{.Version}}"
-  # 完全使用 tag 消息作为 release 内容（通过环境变量传入）
+  name_template: "Sub2API {{.Version}} (Full)"
   header: |
     > AI API Gateway Platform - 将 AI 订阅配额分发和管理
+    > Full Release: includes darwin/windows/linux archives in addition to multi-arch Docker.
 
     {{ .Env.TAG_MESSAGE }}
 
@@ -159,7 +163,7 @@ release:
     ```
 
     **Manual download:**
-    Download the Linux archive for your architecture from the assets below.
+    Download the appropriate archive for your platform from the assets below.
 
     ## 📚 Documentation
 

--- a/.goreleaser.simple.yaml
+++ b/.goreleaser.simple.yaml
@@ -3,12 +3,6 @@ version: 2
 
 project_name: sub2api
 
-before:
-  hooks:
-    - python3 scripts/checks/frontend-dist-freshness.py --check backend/internal/web/dist
-    - python3 scripts/checks/frontend-release-assets.py --dist backend/internal/web/dist
-    - go mod tidy -C backend
-
 builds:
   - id: sub2api
     dir: backend

--- a/scripts/checks/ensure-new-api-sibling_test.sh
+++ b/scripts/checks/ensure-new-api-sibling_test.sh
@@ -1,0 +1,65 @@
+#!/usr/bin/env bash
+# Unit-style tests for scripts/ci/ensure-new-api-sibling.sh (symlink + cache layout).
+set -euo pipefail
+
+ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/../.." && pwd)"
+SCRIPT="${ROOT}/scripts/ci/ensure-new-api-sibling.sh"
+TMP="$(mktemp -d)"
+trap 'rm -rf "${TMP}"' EXIT
+
+setup_workspace() {
+  local ws="${TMP}/sub2api/sub2api"
+  mkdir -p "${ws}/backend"
+  printf '%s\n' "deadbeefdeadbeefdeadbeefdeadbeefdeadbeef" > "${ws}/.new-api-ref"
+  printf '%s\n' "${ws}"
+}
+
+test_symlink_points_at_cache_dir() {
+  local ws
+  ws="$(setup_workspace)"
+  mkdir -p "${ws}/.cache/new-api"
+  git -C "${ws}/.cache/new-api" init -q
+  git -C "${ws}/.cache/new-api" commit --allow-empty -q -m "seed"
+
+  ENSURE_NEW_API_LAYOUT_ONLY=1 bash "${SCRIPT}" "${ws}"
+
+  [ -L "${ws}/../new-api" ] || { echo "expected sibling symlink"; return 1; }
+  [ "$(readlink "${ws}/../new-api")" = "${ws}/.cache/new-api" ] || {
+    echo "symlink target mismatch: $(readlink "${ws}/../new-api")"
+    return 1
+  }
+}
+
+test_migrates_legacy_real_sibling_dir() {
+  local ws
+  ws="$(setup_workspace)"
+  mkdir -p "${ws}/../new-api"
+  git -C "${ws}/../new-api" init -q
+  git -C "${ws}/../new-api" commit --allow-empty -q -m "legacy"
+
+  ENSURE_NEW_API_LAYOUT_ONLY=1 bash "${SCRIPT}" "${ws}"
+
+  [ -d "${ws}/.cache/new-api/.git" ] || { echo "expected migrated cache git dir"; return 1; }
+  [ -L "${ws}/../new-api" ] || { echo "expected sibling symlink after migration"; return 1; }
+}
+
+test_rejects_empty_pin() {
+  local ws="${TMP}/empty/sub2api"
+  mkdir -p "${ws}"
+  : > "${ws}/.new-api-ref"
+  if ENSURE_NEW_API_LAYOUT_ONLY=1 bash "${SCRIPT}" "${ws}" >/dev/null 2>&1; then
+    echo "expected failure for empty .new-api-ref"
+    return 1
+  fi
+}
+
+fail=0
+for name in test_symlink_points_at_cache_dir test_migrates_legacy_real_sibling_dir test_rejects_empty_pin; do
+  if "${name}"; then
+    echo "PASS ${name}"
+  else
+    echo "FAIL ${name}"
+    fail=1
+  fi
+done
+exit "${fail}"

--- a/scripts/checks/script-ref-existence.py
+++ b/scripts/checks/script-ref-existence.py
@@ -62,7 +62,7 @@ SCAN_EXTS = {
 }
 SCAN_BASENAMES = {
     "Dockerfile", "Dockerfile.goreleaser", "Makefile",
-    ".gitignore", ".goreleaser.yaml", ".goreleaser.simple.yaml",
+    ".gitignore", ".goreleaser.yaml", ".goreleaser.simple.yaml", ".goreleaser.full.yaml",
     "CLAUDE.md",
 }
 

--- a/scripts/ci/ensure-new-api-sibling.sh
+++ b/scripts/ci/ensure-new-api-sibling.sh
@@ -1,0 +1,46 @@
+#!/usr/bin/env bash
+# Ensure QuantumNous/new-api exists at the go.mod replace path (../../new-api from
+# backend/) using a workspace-local cache dir that GitHub Actions can save/restore.
+set -euo pipefail
+
+workspace="${1:-${GITHUB_WORKSPACE:?set GITHUB_WORKSPACE or pass workspace path}}"
+new_api_ref="$(tr -d '[:space:]' < "${workspace}/.new-api-ref")"
+if [ -z "${new_api_ref}" ]; then
+  echo "ERROR: .new-api-ref is empty" >&2
+  exit 1
+fi
+
+cache_dir="${workspace}/.cache/new-api"
+sibling_link="${workspace}/../new-api"
+
+mkdir -p "${workspace}/.cache"
+
+# Migrate legacy ../new-api real directories into the cache path once.
+if [ ! -d "${cache_dir}/.git" ] && [ -d "${sibling_link}/.git" ] && [ ! -L "${sibling_link}" ]; then
+  mv "${sibling_link}" "${cache_dir}"
+fi
+
+ln -sfn "${cache_dir}" "${sibling_link}"
+
+if [ "${ENSURE_NEW_API_LAYOUT_ONLY:-}" = "1" ]; then
+  ls "${cache_dir}/go.mod" 2>/dev/null || touch "${cache_dir}/go.mod"
+  exit 0
+fi
+
+if [ -d "${cache_dir}/.git" ]; then
+  git -C "${cache_dir}" fetch --filter=blob:none origin "${new_api_ref}" 2>/dev/null || \
+    git -C "${cache_dir}" fetch origin "${new_api_ref}" 2>/dev/null || true
+  if git -C "${cache_dir}" rev-parse "${new_api_ref}^{commit}" >/dev/null 2>&1; then
+    git -C "${cache_dir}" checkout -q "${new_api_ref}"
+    ls "${cache_dir}/go.mod"
+    exit 0
+  fi
+  echo "WARN: cached new-api repo missing SHA ${new_api_ref}; recloning" >&2
+  rm -rf "${cache_dir}"
+  ln -sfn "${cache_dir}" "${sibling_link}"
+fi
+
+git clone --filter=blob:none https://github.com/QuantumNous/new-api.git "${cache_dir}"
+git -C "${cache_dir}" fetch --filter=blob:none origin "${new_api_ref}" || true
+git -C "${cache_dir}" checkout "${new_api_ref}"
+ls "${cache_dir}/go.mod"

--- a/scripts/preflight.sh
+++ b/scripts/preflight.sh
@@ -463,6 +463,9 @@ else
         # script-ref-existence_test.sh already printed which case(s) failed.
         errors=$((errors + 1))
     fi
+    if ! bash ./scripts/checks/ensure-new-api-sibling_test.sh; then
+        errors=$((errors + 1))
+    fi
 fi
 
 # ---- sub2api: upstream override marker --------------------------------------


### PR DESCRIPTION
## Summary

- Default tag releases now cross-compile **linux/amd64 + linux/arm64 only** (`.goreleaser.yaml`); darwin/windows assets are opt-in via `workflow_dispatch` + `full_release=true` (`.goreleaser.full.yaml`).
- Fix new-api GHA cache: clone into `.cache/new-api` (workspace-local, saveable) and symlink to `../new-api` for `go.mod` replace — replaces the broken `../new-api` cache path that GHA refused to save.
- Slim release pre-steps: drop duplicate frontend verify in the release job and GoReleaser `before` hooks; shallow checkout + targeted tag fetch.

## Risk

- **Low–regular**: GitHub Release assets on default tag pushes shrink to two Linux tarballs (was five platform archives). Multi-arch Docker (`:latest`, `:X.Y.Z`) unchanged. Operators needing macOS/Windows binaries must dispatch with `full_release=true`.
- `simple_release` and `full_release` are mutually exclusive (workflow fails fast if both set).

## Validation

- `bash scripts/checks/ensure-new-api-sibling_test.sh` — 3/3 PASS
- `python3 scripts/checks/script-ref-existence.py` — ok
- `./scripts/preflight.sh` — PASS (pre-commit on commit)


Made with [Cursor](https://cursor.com)