### PR TITLE
chore(deploy): sync uk1-ls Porkbun IP with live Lightsail static IP

### DIFF
--- a/deploy/aws/lightsail/README.md
+++ b/deploy/aws/lightsail/README.md
@@ -160,7 +160,7 @@ PREFLIGHT_BASE=origin/main bash scripts/preflight.sh
 矩阵基线：**EC2 `uk1.deployable=false`**（`deploy/aws/stage0/edge-targets.json`），**Lightsail `uk1.deployable=true`**（本目录 `edge-targets-lightsail.json`）。
 同名域名只能由一个平台对外服务；两边的 `deployable` 同时为 `true` 会被 **`scripts/checks/edge-platform-exclusivity.py`** 拦下。
 
-**Porkbun（prod，`api-uk1.tokenkey.dev`）：** A 记录必须等于 Lightsail Static IP（`aws lightsail get-static-ip --static-ip-name tokenkey-edge-uk1-ls-ip` 的 `ipAddress`）。当前矩阵记在 `edge-targets-lightsail.json` → **`targets.uk1.porkbun_a_ipv4`**（**`18.135.59.111`**），作为人工 DNS **唯一真值**。
+**Porkbun（prod，`api-uk1.tokenkey.dev`）：** A 记录必须等于 Lightsail Static IP（`aws lightsail get-static-ip --static-ip-name tokenkey-edge-uk1-ls-ip` 的 `ipAddress`）。当前矩阵记在 `edge-targets-lightsail.json` → **`targets.uk1.porkbun_a_ipv4`**（**`13.134.80.182`**），作为人工 DNS **唯一真值**。
 
 **不能与 EC2 EIP 混用：** 旧 EC2 Edge 的 Elastic IP（例如历史 **`16.61.87.51` / `eipalloc-03b2653ddd57b9c93`**）**无法挂到 Lightsail 实例**。若 Porkbun 仍指向已游离的 EC2 EIP，公网会超时。迁到 Lightsail 后必须把 A 记录改到 **Lightsail Static IP**；不再需要的老 EIP 可通过 `release-address` 回收。
 

--- a/deploy/aws/lightsail/edge-targets-lightsail.json
+++ b/deploy/aws/lightsail/edge-targets-lightsail.json
@@ -16,7 +16,7 @@
       "ec2_equivalent_region": "eu-west-2",
       "availability_zone": "eu-west-2a",
       "domain": "api-uk1.tokenkey.dev",
-      "porkbun_a_ipv4": "18.135.59.111",
+      "porkbun_a_ipv4": "13.134.80.182",
       "instance_name": "tokenkey-edge-uk1-ls",
       "static_ip_name": "tokenkey-edge-uk1-ls-ip",
       "bundle_id": "micro_3_0",


### PR DESCRIPTION
## Summary

- Update `deploy/aws/lightsail/edge-targets-lightsail.json` `targets.uk1.porkbun_a_ipv4` to match live Lightsail static IP.
- Align `deploy/aws/lightsail/README.md` DNS reference with the matrix.

## Risk

Low — documentation/metadata only; no runtime code change.

## Validation

- `aws lightsail get-static-ip --static-ip-name tokenkey-edge-uk1-ls-ip --region eu-west-2` → `13.134.80.182`

Web impact: none

Made with [Cursor](https://cursor.com)