### PR TITLE
feat(ops): gateway debug fetch and narrow-window UA/TLS probes

### DIFF
--- a/.cursor/skills/tokenkey-online-log-troubleshooting/SKILL.md
+++ b/.cursor/skills/tokenkey-online-log-troubleshooting/SKILL.md
@@ -2,9 +2,9 @@
 name: tokenkey-online-log-troubleshooting
 description: >-
   Read-only TokenKey production/edge troubleshooting workflow for querying live
-  logs, ops_error_logs, Docker containers, SSM targets, CI/deploy runs, and
-  turning evidence into a stable root-cause summary without ad-hoc command
-  guessing.
+  logs, ops_error_logs, Docker containers, SSM targets, gateway UA/TLS
+  fingerprints, SUB2API_DEBUG_GATEWAY_BODY pulls, CI/deploy runs, and turning
+  evidence into a stable root-cause summary without ad-hoc command guessing.
 ---
 
 # TokenKey：线上日志查询与问题定位
@@ -23,6 +23,8 @@ description: >-
 | SSM base64 投递 + send-command + poll | 机械 | `ops/observability/run-probe.sh --target prod\|edge:<id> --script <probe.sh>` |
 | `ops_error_logs` 标准聚合（schema + by_status + upstream_events + 429-by-minute） | 机械 | `ops/observability/ops-error-triage.sh`（通过 run-probe.sh 投递） |
 | Docker access log 解析（status/model/minute/latency 直方图 + marker 计数） | 机械 | `ops/observability/parse-access-log.py --stdin\|--file\|--docker` |
+| Gateway UA/TLS / usage_logs / ops / docker 指纹交叉对比（窄时间窗） | 机械 | `ops/observability/probe-gateway-ua-tls-compare.sh`（通过 run-probe.sh 投递；`WINDOW_MINUTES` 收窄 DB 窗） |
+| `SUB2API_DEBUG_GATEWAY_BODY` 日志拉回本机（SSM gzip → S3 presigned PUT → 本地 gunzip） | 机械 | `ops/observability/fetch-gateway-debug-log.sh --target prod\|edge:<id>`（**本地** orchestrator，不走 run-probe） |
 | anthropic capacity / cap 与 schedulable 证据 | 机械 | `ops/observability/probe-caps.sh`（已有，通过 run-probe.sh 投递）/ `ops/anthropic/manage-anthropic-config.py snapshot` |
 | 时间窗规范（UTC ↔ Asia/Shanghai 双写） | 判断 | prompt（含报告口径，无机械抓手） |
 | 解读规则：final_status vs upstream events、镜像账号链式失败 | 判断 | prompt（架构判断，§0 列出 8 个 trap 已固化） |
@@ -39,7 +41,7 @@ description: >-
 | `target` | `prod`、`edge:us1` / `edge:uk1` / `edge:fra1`，或用户给出的域名。 |
 | `issue` | 用户描述的症状、错误 JSON、request_id、时间点或“昨晚/刚才”等自然语言。 |
 | `time_window` | 优先使用明确 ISO 区间；缺省时根据 issue 推断，并输出 UTC 与本地时间。 |
-| `scope` | 默认 `all`；可收窄到 `gateway`、`ops`、`deploy`、`ci`、`db`。 |
+| `scope` | 默认 `all`；可收窄到 `gateway`、`gateway_fingerprint`、`gateway_debug`、`ops`、`deploy`、`ci`、`db`。 |
 | `request_id` | 上游 request id 或 TokenKey request id；用于精确查日志。 |
 | `user_id` / `api_key_id` | 用户侧定位字段；没有就不要猜。 |
 | `model` / `path` | 过滤 `/v1/messages`、模型、OpenAI/Gemini/NewAPI 路径等。 |
@@ -168,6 +170,8 @@ WITH bounds AS (
 
 不要混用本地时区字符串和 DB UTC 字段。
 
+**窄窗口 outage（如 30 分钟 VM hang）**：除 Docker `--since` 外，对 DB 侧聚合优先用 `probe-gateway-ua-tls-compare.sh` 的 `WINDOW_MINUTES`（见 §5.1），不要用大 `LIMIT` 代替时间过滤。
+
 ## 4) `ops_error_logs` 标准 triage（机械化）
 
 聚合 SQL 由 `ops/observability/ops-error-triage.sh` 渲染（schema 探测 + summary + by_status + upstream_events + 429-by-minute），所有输出都是 `row_to_json(t)`，字段名嵌在值旁，下游用 `jq`/`json.loads` 按字段取，**禁止按列号读**。通过 §2 的 `run-probe.sh` 投递：
@@ -231,6 +235,73 @@ python3 ops/observability/parse-access-log.py --docker tokenkey --since 1h
 | `latency_ms` | `{n, p50, p90, p95, p99, max}` 或 `null` |
 
 确定性保证：同一份 stdin + 同一组 flag → 字节一致的 JSON（排序稳定、整数 ms、无 locale 浮点）。
+
+## 5.1) Gateway UA/TLS 指纹对比（机械化）
+
+`ops/observability/probe-gateway-ua-tls-compare.sh` 在同一 target 上交叉采样 **usage_logs**（含 TLS profile join）、**ops_system_logs**（gateway/http.access 组件）、**docker access log**（`http request completed` + UA/TLS 关键词行）。输出单个紧凑 JSON（SSM stdout ~24KiB 上限）；远端另写 `/tmp/tk-gateway-ua-tls-full.json` 供 SSH 拉全量（本 skill 默认不 dump）。
+
+通过 §2 `run-probe.sh` 投递：
+
+```bash
+# 默认：usage_logs LIMIT=500 + docker logs 48h + ops 48h
+bash ops/observability/run-probe.sh \
+  --target edge:uk1 \
+  --script ops/observability/probe-gateway-ua-tls-compare.sh \
+  --timeout-seconds 180
+
+# 窄时间窗（推荐：用户给了具体 outage 区间，如「07:20–07:36 UTC」≈ 20min）
+bash ops/observability/run-probe.sh \
+  --target edge:uk1 \
+  --script ops/observability/probe-gateway-ua-tls-compare.sh \
+  --env WINDOW_MINUTES=30 \
+  --timeout-seconds 180
+```
+
+env 契约（脚本 header 是 ground truth）：
+
+| env | 默认 | 含义 |
+|---|---|---|
+| `LIMIT` | 500 | `usage_logs` 行数上限（`ORDER BY ul.id DESC`；与 `WINDOW_MINUTES` 叠加时先时间过滤再 limit） |
+| `SINCE` | 48h | `docker logs tokenkey --since` 窗口 |
+| `WINDOW_MINUTES` | （空） | 正整数时：`usage_logs` 与 `ops_system_logs` 仅查 `now() - interval 'N minutes'` |
+| `CONTAINER` | tokenkey | Docker 容器名 |
+
+输出 schema 要点：
+
+| key | 含义 |
+|---|---|
+| `meta.window_minutes` | 生效的 DB 窄窗（未设则为 `null`） |
+| `usage_logs.summary` | UA/TLS/client_ip 计数与 gateway 样本 |
+| `ops_system_logs` | ops 侧 UA/TLS 相关字段聚合 |
+| `docker_access` | access log completed 行 summary + docker 错误 |
+| `docker_ua_tls_lines` | 含 UA/TLS 关键词的 docker 行样本（尾部截断） |
+
+**何时用**：edge 间 UA/TLS 行为差异、OAuth TLS fingerprint 是否生效、outage 窗口内 gateway 是否仍有 completed 行、与 §5 access log 解析互补（本 probe 偏 cross-table 指纹，parse-access-log 偏 status/latency 直方图）。
+
+## 5.2) Debug gateway body 日志拉回本机（机械化，本地 orchestrator）
+
+当容器已开启 `SUB2API_DEBUG_GATEWAY_BODY`（写入 `gateway_debug.log`，见 `gateway_service.go`）且需要**完整 request/response body** 做 deep triage 时使用。**不在 SSM stdout 里传输**——走 gzip + presigned S3 PUT + 本机 `aws s3 cp` + gunzip。
+
+```bash
+bash ops/observability/fetch-gateway-debug-log.sh --target edge:uk1
+bash ops/observability/fetch-gateway-debug-log.sh --target prod --out "$CLAUDE_JOB_DIR/gateway-debug"
+```
+
+CLI 契约：
+
+| 参数 / env | 默认 | 含义 |
+|---|---|---|
+| `--target` | （必填） | `prod` 或 `edge:<id>`（Lightsail/EC2 均经 `ops/stage0/edge_ssm_execution.py` 解析 instance） |
+| `--out` / `OUT_DIR` | `./.cache/gateway-debug` | 本机输出目录 |
+| `--log-path` / `LOG_PATH` | `/app/data/gateway_debug.log` | 容器内 debug 文件路径 |
+| `SSM_OUTPUT_S3_BUCKET` | layer-zip-repro-… | 临时对象桶（上传后脚本会 `aws s3 rm` 清理 key） |
+| `AWS_SSM_WAIT_MAX` | 900 | SSM 等待秒数 |
+
+成功时 stdout 最后一行是本地 `.log` 绝对路径；在本地用 `grep`/`jq`/`less` 分析，**报告里仍遵守 §0 脱敏**（不粘贴 Authorization、完整 API key、OAuth token）。
+
+**前置条件**：目标实例上 debug  env 已开启且文件存在；否则 SSM 会在 `docker exec tokenkey test -f …` 失败。未开启时先用 §5 / §5.1 聚合，或经 deploy/ops 流程临时开启（超出本 skill 只读边界，需显式确认）。
+
+**与 run-probe 的分工**：`run-probe.sh` 只回传远端 stdout 字节；本脚本需要本机 boto3 presign + S3 下载，因此是**开发者机器上运行的 orchestrator**，不要塞进 run-probe。
 
 ## 6) 配置与限额核对
 
@@ -328,6 +399,9 @@ needs input:
 | 误把 recovered upstream error 当故障 | 只看 `upstream_errors` | 必须同时看 final `status_code`。 |
 | 单窗口却 429 | CLI 内部多请求/多模型短峰 | 解析 access log by-minute，而不是按窗口数量判断。 |
 | CI 查错 run | branch/run 未定位 | `gh pr checks` → `gh run view`，按 PR head SHA / branch 过滤。 |
+| `probe-gateway-ua-tls-compare` DB 窗太宽 | 未设 `WINDOW_MINUTES`，outage 证据被 LIMIT 稀释 | 根据 issue 换算分钟数， `--env WINDOW_MINUTES=N`。 |
+| `fetch-gateway-debug-log` SSM Failed | debug 文件不存在或 env 未开 | 远端 `docker exec tokenkey test -f /app/data/gateway_debug.log`；无文件则勿拉 body。 |
+| S3 presign / curl PUT 失败 | 实例无外网或桶策略 | 读 SSM stderr；检查 `SSM_OUTPUT_S3_BUCKET` 与 IAM；勿改线上只为 bypass。 |
 
 ## 10) 交接给修复流程
 

--- a/ops/observability/fetch-gateway-debug-log.sh
+++ b/ops/observability/fetch-gateway-debug-log.sh
@@ -1,0 +1,183 @@
+#!/usr/bin/env bash
+# fetch-gateway-debug-log.sh — pull SUB2API_DEBUG_GATEWAY_BODY log from prod/edge to local.
+#
+# Remote path default: /app/data/gateway_debug.log (inside tokenkey container).
+# Flow: SSM gzip on instance → presigned S3 PUT (curl) → local download + gunzip.
+#
+# Usage:
+#   bash ops/observability/fetch-gateway-debug-log.sh --target edge:us1
+#   bash ops/observability/fetch-gateway-debug-log.sh --target edge:uk1 --out ./.cache/gateway-debug
+#
+# Env:
+#   SSM_OUTPUT_S3_BUCKET   default: layer-zip-repro-682751977094-us-east-1
+#   LOG_PATH               default: /app/data/gateway_debug.log
+#   OUT_DIR                default: ./.cache/gateway-debug
+#   AWS_SSM_WAIT_MAX       default: 900
+#   PRESIGN_TTL_SEC        default: 7200
+set -euo pipefail
+
+REPO_ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/../.." && pwd)"
+TARGET=""
+OUT_DIR="${OUT_DIR:-./.cache/gateway-debug}"
+LOG_PATH="${LOG_PATH:-/app/data/gateway_debug.log}"
+BUCKET="${SSM_OUTPUT_S3_BUCKET:-layer-zip-repro-682751977094-us-east-1}"
+S3_REGION="${SSM_OUTPUT_S3_REGION:-us-east-1}"
+PREFIX="tokenkey/gateway-debug"
+WAIT_MAX="${AWS_SSM_WAIT_MAX:-900}"
+PRESIGN_TTL="${PRESIGN_TTL_SEC:-7200}"
+
+usage() {
+  sed -n '2,14p' "$0" | sed 's/^# \{0,1\}//'
+}
+
+while [ "$#" -gt 0 ]; do
+  case "$1" in
+    -h|--help) usage; exit 0 ;;
+    --target) TARGET="${2:-}"; shift 2 ;;
+    --out) OUT_DIR="${2:-}"; shift 2 ;;
+    --log-path) LOG_PATH="${2:-}"; shift 2 ;;
+    *) echo "[fetch-gateway-debug-log] ERROR: unknown arg: $1" >&2; usage >&2; exit 1 ;;
+  esac
+done
+
+if [ -z "$TARGET" ]; then
+  echo "[fetch-gateway-debug-log] ERROR: --target is required (prod | edge:<id>)" >&2
+  exit 1
+fi
+
+log() { echo "[fetch-gateway-debug-log] $*"; }
+err() { echo "[fetch-gateway-debug-log] error: $*" >&2; }
+
+command -v python3 >/dev/null 2>&1 || { err "python3 required"; exit 1; }
+command -v aws >/dev/null 2>&1 || { err "aws CLI required"; exit 1; }
+command -v jq >/dev/null 2>&1 || { err "jq required"; exit 1; }
+
+REGION=""
+INSTANCE_ID=""
+EDGE_LABEL="$TARGET"
+if [ "$TARGET" = "prod" ]; then
+  REGION="us-east-1"
+  STACK="tokenkey-prod-stage0"
+  INSTANCE_ID=$(aws cloudformation describe-stacks \
+    --region "$REGION" --stack-name "$STACK" \
+    --query "Stacks[0].Outputs[?OutputKey=='InstanceId'].OutputValue" \
+    --output text)
+elif [[ "$TARGET" == edge:* ]]; then
+  EDGE_ID="${TARGET#edge:}"
+  RES_LINES=$(python3 "$REPO_ROOT/ops/stage0/edge_ssm_execution.py" \
+    --repo-root "$REPO_ROOT" --edge-id "$EDGE_ID" --format env)
+  eval "$RES_LINES"
+  EDGE_LABEL="edge-${EDGE_ID}"
+else
+  err "--target must be prod or edge:<id>"
+  exit 1
+fi
+
+if [ -z "${INSTANCE_ID:-}" ] || [ "$INSTANCE_ID" = "None" ]; then
+  err "could not resolve instance id for $TARGET"
+  exit 1
+fi
+
+mkdir -p "$OUT_DIR"
+STAMP="$(date -u +%Y%m%dT%H%M%SZ)"
+S3_KEY="${PREFIX}/${EDGE_LABEL}/${STAMP}.log.gz"
+LOCAL_GZ="${OUT_DIR}/${EDGE_LABEL}-gateway_debug.log.gz"
+LOCAL_LOG="${OUT_DIR}/${EDGE_LABEL}-gateway_debug.log"
+REMOTE_GZ="/tmp/${EDGE_LABEL}-gateway_debug-${STAMP}.log.gz"
+
+SCRATCH="$(mktemp -d)"
+trap 'rm -rf "$SCRATCH"' EXIT
+VENV="$SCRATCH/presign-venv"
+python3 -m venv "$VENV"
+"$VENV/bin/pip" install -q boto3
+
+export AWS_REGION="$S3_REGION"
+export SSM_OUTPUT_S3_BUCKET="$BUCKET"
+export S3_KEY_FOR_PRESIGN="$S3_KEY"
+export PRESIGN_TTL_SEC="$PRESIGN_TTL"
+
+PUT_URL="$("$VENV/bin/python" -c "
+import os, boto3
+b = os.environ['SSM_OUTPUT_S3_BUCKET']
+k = os.environ['S3_KEY_FOR_PRESIGN']
+r = os.environ['AWS_REGION']
+e = int(os.environ['PRESIGN_TTL_SEC'])
+print(boto3.client('s3', region_name=r).generate_presigned_url(
+    'put_object', Params={'Bucket': b, 'Key': k}, ExpiresIn=e), end='')
+")"
+PRESIGN_B64="$(printf '%s' "$PUT_URL" | base64 | tr -d '\n')"
+
+PARAMS="$SCRATCH/ssm-params.json"
+jq -n \
+  --arg log_path "$LOG_PATH" \
+  --arg remote_gz "$REMOTE_GZ" \
+  --arg b64 "$PRESIGN_B64" \
+  '{
+    commands: [
+      "set -euo pipefail",
+      ("docker exec tokenkey test -f " + ($log_path | @sh)),
+      ("docker exec tokenkey gzip -c " + ($log_path | @sh) + " > " + ($remote_gz | @sh)),
+      ("echo " + $b64 + " | base64 -d > /tmp/gw-debug-put.url"),
+      ("curl -fS --max-time 3600 -X PUT --upload-file " + ($remote_gz | @sh) + " \"$(cat /tmp/gw-debug-put.url)\""),
+      "rm -f /tmp/gw-debug-put.url",
+      ("wc -c < " + ($remote_gz | @sh) + " | tr -d \" \\n\"")
+    ]
+  }' > "$PARAMS"
+
+log "target=$TARGET region=$REGION instance=$INSTANCE_ID"
+log "remote=$LOG_PATH → s3://$BUCKET/$S3_KEY → $LOCAL_LOG"
+
+CMD_ID=$(aws ssm send-command \
+  --region "$REGION" \
+  --instance-ids "$INSTANCE_ID" \
+  --document-name AWS-RunShellScript \
+  --comment "fetch gateway_debug.log ($EDGE_LABEL)" \
+  --timeout-seconds "$WAIT_MAX" \
+  --parameters "file://$PARAMS" \
+  --query 'Command.CommandId' --output text)
+
+log "command_id=$CMD_ID (waiting up to ${WAIT_MAX}s)…"
+DEADLINE=$(( $(date +%s) + WAIT_MAX ))
+while true; do
+  STATUS=$(aws ssm get-command-invocation \
+    --region "$REGION" --command-id "$CMD_ID" --instance-id "$INSTANCE_ID" \
+    --query 'Status' --output text 2>/dev/null || echo InProgress)
+  case "$STATUS" in
+    Success|Failed|TimedOut|Cancelled) break ;;
+  esac
+  if [ "$(date +%s)" -ge "$DEADLINE" ]; then
+    STATUS=TimedOut
+    break
+  fi
+  sleep 8
+done
+
+if [ "$STATUS" != "Success" ]; then
+  err "remote status=$STATUS"
+  aws ssm get-command-invocation \
+    --region "$REGION" --command-id "$CMD_ID" --instance-id "$INSTANCE_ID" \
+    --query '{stderr:StandardErrorContent,stdout:StandardOutputContent}' --output text >&2 || true
+  exit 1
+fi
+
+REMOTE_BYTES=$(aws ssm get-command-invocation \
+  --region "$REGION" --command-id "$CMD_ID" --instance-id "$INSTANCE_ID" \
+  --query 'StandardOutputContent' --output text | tr -d '[:space:]')
+log "remote gzip bytes=$REMOTE_BYTES"
+
+log "downloading s3://$BUCKET/$S3_KEY"
+aws s3 cp --region "$S3_REGION" "s3://${BUCKET}/${S3_KEY}" "$LOCAL_GZ"
+gunzip -f "$LOCAL_GZ"
+BYTES=$(wc -c < "$LOCAL_LOG" | tr -d ' ')
+log "saved $LOCAL_LOG (${BYTES} bytes)"
+
+aws s3 rm --region "$S3_REGION" "s3://${BUCKET}/${S3_KEY}" >/dev/null 2>&1 || true
+aws ssm send-command \
+  --region "$REGION" \
+  --instance-ids "$INSTANCE_ID" \
+  --document-name AWS-RunShellScript \
+  --comment "cleanup gateway debug tmp ($EDGE_LABEL)" \
+  --parameters "{\"commands\":[\"rm -f '$REMOTE_GZ'\"]}" \
+  --query 'Command.CommandId' --output text >/dev/null 2>&1 || true
+
+printf '%s\n' "$LOCAL_LOG"

--- a/ops/observability/probe-gateway-ua-tls-compare.sh
+++ b/ops/observability/probe-gateway-ua-tls-compare.sh
@@ -5,14 +5,16 @@
 # Env:
 #   LIMIT          rows per source (default 500)
 #   SINCE          docker logs window (default 48h)
+#   WINDOW_MINUTES if set, usage_logs/ops filter to last N minutes (overrides LIMIT ordering scope)
 #   CONTAINER      gateway container (default tokenkey)
 set -u
 
 LIMIT="${LIMIT:-500}"
 SINCE="${SINCE:-48h}"
+WINDOW_MINUTES="${WINDOW_MINUTES:-}"
 CONTAINER="${CONTAINER:-tokenkey}"
 
-python3 - "$LIMIT" "$SINCE" "$CONTAINER" <<'PY'
+python3 - "$LIMIT" "$SINCE" "$CONTAINER" "$WINDOW_MINUTES" <<'PY'
 import json
 import re
 import subprocess
@@ -22,6 +24,13 @@ from collections import Counter
 limit = int(sys.argv[1])
 since = sys.argv[2]
 container = sys.argv[3]
+window_minutes = sys.argv[4].strip() if len(sys.argv) > 4 else ""
+time_where_ul = ""
+time_where_ops = ""
+if window_minutes.isdigit() and int(window_minutes) > 0:
+    interval = f"{int(window_minutes)} minutes"
+    time_where_ul = f"WHERE ul.created_at > now() - interval '{interval}'"
+    time_where_ops = f"AND created_at > now() - interval '{interval}'"
 
 marker_completed = "http request completed"
 json_re = re.compile(r"\{.*\}\s*$")
@@ -98,11 +107,13 @@ SELECT row_to_json(t) FROM (
   JOIN accounts a ON a.id = ul.account_id
   LEFT JOIN tls_fingerprint_profiles tfp
     ON tfp.id = NULLIF(a.extra->>'tls_fingerprint_profile_id', '')::bigint
+  {time_where_ul}
   ORDER BY ul.id DESC
   LIMIT {limit}
 ) t;
 """
 
+ops_window = time_where_ops or "AND created_at > now() - interval '48 hours'"
 ops_sql = f"""
 SELECT row_to_json(t) FROM (
   SELECT
@@ -116,7 +127,8 @@ SELECT row_to_json(t) FROM (
     model,
     extra
   FROM ops_system_logs
-  WHERE created_at > now() - interval '48 hours'
+  WHERE 1=1
+    {ops_window}
     AND (
       component ILIKE '%gateway%'
       OR component ILIKE '%http.access%'
@@ -294,7 +306,12 @@ def gateway_usage_samples(rows: list[dict], n: int = 40) -> list[dict]:
 
 # SSM StandardOutputContent is ~24KiB; keep stdout compact (summary only).
 out = {
-    "meta": {"limit": limit, "since": since, "container": container},
+    "meta": {
+        "limit": limit,
+        "since": since,
+        "container": container,
+        "window_minutes": int(window_minutes) if window_minutes.isdigit() else None,
+    },
     "usage_logs": {
         "summary": summarize_usage(usage_rows),
         "gateway_samples": gateway_usage_samples(usage_rows, n=12),


### PR DESCRIPTION
## Summary
- Add `ops/observability/fetch-gateway-debug-log.sh` to pull `SUB2API_DEBUG_GATEWAY_BODY` logs from prod/edge via SSM gzip → S3 presigned PUT → local gunzip.
- Extend `probe-gateway-ua-tls-compare.sh` with `WINDOW_MINUTES` for narrow DB time windows during outage triage.
- Update `tokenkey-online-log-troubleshooting` skill with §5.1/§5.2 runbooks and deterministic baseline entries.

## Risk
Low — read-only ops scripts + skill documentation. No backend/API/WebUI behavior change.

## Validation
- `bash -n ops/observability/fetch-gateway-debug-log.sh`
- `bash -n ops/observability/probe-gateway-ua-tls-compare.sh`
- `PREFLIGHT_BASE=origin/main bash scripts/preflight.sh` — PASS (pre-commit)


Made with [Cursor](https://cursor.com)