### PR TITLE
fix(ci): skip PR Repair Agent on non-PR CI failures

### DIFF
--- a/.github/workflows/pr-repair-agent.yml
+++ b/.github/workflows/pr-repair-agent.yml
@@ -39,9 +39,14 @@ concurrency:
 
 jobs:
   repair:
+    # Scheduled/push CI failures have no pull_requests[] entry; repairing them is
+    # impossible and just burns runner time (and fails on the same infra blips).
     if: >-
       github.event_name == 'workflow_dispatch' ||
-      (github.event.workflow_run.conclusion == 'failure' || github.event.workflow_run.conclusion == 'timed_out' || github.event.workflow_run.conclusion == 'cancelled')
+      (
+        (github.event.workflow_run.conclusion == 'failure' || github.event.workflow_run.conclusion == 'timed_out' || github.event.workflow_run.conclusion == 'cancelled') &&
+        github.event.workflow_run.pull_requests[0] != null
+      )
     runs-on: ubuntu-latest
     timeout-minutes: 120
     steps:


### PR DESCRIPTION
## Summary
- PR Repair Agent 仅在 `workflow_run` 关联到 open PR 时才启动；schedule / push 到 main 的 CI 失败不再误触发 repair job。
- 避免在无 PR 可修时白白占用 runner，并在 GitHub Actions infra 抖动（如 `setup-go` 下载失败）时产生二次失败噪音。

## Risk
- 低风险，仅收紧 workflow 触发条件；手动 `workflow_dispatch` 路径不变。

## Validation
- 根因核查：失败 run [26447790280](https://github.com/youxuanxue/sub2api/actions/runs/26447790280)（schedule weekly smoke，`setup-go@v6` codeload 瞬时失败）→ [26447796664](https://github.com/youxuanxue/sub2api/actions/runs/26447796664)（PR Repair Agent 被误触发，同样下载失败）。
- weekly smoke 手动重跑 [26450191695](https://github.com/youxuanxue/sub2api/actions/runs/26450191695) 已通过。
- 本 PR 仅改 `.github/workflows/pr-repair-agent.yml`，preflight 本地通过。


Made with [Cursor](https://cursor.com)