### PR TITLE
fix(stage0): soft-skip /v1/chat/completions when key is claude_code_only-bound

### DIFF
--- a/ops/stage0/smoke_lib.sh
+++ b/ops/stage0/smoke_lib.sh
@@ -79,12 +79,31 @@ if [[ -z "${_TK_SMOKE_LIB_LOADED:-}" ]]; then
             return 1
             ;;
           *"restricted to Claude Code clients"*|*"/v1/messages only"*)
+            # claude_code_only group policy: the configured Anthropic key is
+            # bound to a group that allows /v1/messages with a Claude Code UA
+            # only. Two cases:
+            #   main-via-edge suite — this branch should be unreachable
+            #     (smoke_suite_runs gates out non-messages sections), so a
+            #     claude_code_only hit here means the smoke runner itself is
+            #     misconfigured. Hard fail to surface the config bug.
+            #   full / quick suite — /v1/chat/completions against a
+            #     claude_code_only-restricted key is policy-correct rejection,
+            #     not a control-plane regression. The /v1/messages section
+            #     (Claude Code UA) still runs and is the canonical signal for
+            #     this key's group. Soft-skip with a warning.
             if [[ "${GATEWAY_SMOKE_SUITE}" == "main-via-edge" ]]; then
               echo "::error::tk_post_deploy_smoke: ${label} returned HTTP ${http} — main-via-edge must use /v1/messages with a Claude Code User-Agent, not /v1/chat/completions." >&2
+              echo "tk_post_deploy_smoke: ${label} failed" >&2
+              jq . "${resp_file}" >&2 2>/dev/null || cat "${resp_file}" >&2
+              exit 1
             fi
-            echo "tk_post_deploy_smoke: ${label} failed" >&2
+            echo "::warning::tk_post_deploy_smoke: ${label} returned HTTP ${http} — configured key is bound to a Claude Code-only group (claude_code_only policy); /v1/messages section will cover this key. Soft-skipped." >&2
+            if [[ -n "${err_msg}" ]]; then
+              echo "  gateway message: ${err_msg}" >&2
+            fi
             jq . "${resp_file}" >&2 2>/dev/null || cat "${resp_file}" >&2
-            exit 1
+            echo "tk_post_deploy_smoke: ${label} section soft-skipped (claude_code_only policy; /v1/messages probe is the canonical signal)"
+            return 1
             ;;
           *)
             echo "tk_post_deploy_smoke: ${label} failed" >&2

--- a/scripts/test_smoke_suite.py
+++ b/scripts/test_smoke_suite.py
@@ -3,6 +3,7 @@
 from __future__ import annotations
 
 import json
+import os
 import pathlib
 import subprocess
 import tempfile
@@ -86,12 +87,14 @@ class SoftDegradeOrExitTest(unittest.TestCase):
             f'  echo MARKER=softskip\n'
             f'fi\n'
         )
+        env = os.environ.copy()
+        env["GATEWAY_SMOKE_SUITE"] = suite
         try:
             proc = subprocess.run(
                 ["bash", "-c", script],
                 capture_output=True,
                 text=True,
-                env={"GATEWAY_SMOKE_SUITE": suite, "PATH": "/usr/bin:/bin:/usr/local/bin"},
+                env=env,
                 check=False,
             )
         finally:

--- a/scripts/test_smoke_suite.py
+++ b/scripts/test_smoke_suite.py
@@ -2,6 +2,10 @@
 """Tests for gateway smoke suite gating and model pick logic."""
 from __future__ import annotations
 
+import json
+import pathlib
+import subprocess
+import tempfile
 import unittest
 
 from scripts.stage0.smoke_suite import (
@@ -11,6 +15,9 @@ from scripts.stage0.smoke_suite import (
     pick_model,
     suite_runs,
 )
+
+REPO_ROOT = pathlib.Path(__file__).resolve().parents[1]
+SMOKE_LIB = REPO_ROOT / "ops" / "stage0" / "smoke_lib.sh"
 
 
 class SmokeSuiteTest(unittest.TestCase):
@@ -56,6 +63,76 @@ class SmokeSuiteTest(unittest.TestCase):
         self.assertEqual(edge_phase_gateway_suite("main-via-edge"), "main-via-edge")
         self.assertEqual(edge_phase_gateway_suite("full"), "main-via-edge")
         self.assertIsNone(edge_phase_gateway_suite("infra"))
+
+
+class SoftDegradeOrExitTest(unittest.TestCase):
+    """Pins the soft/hard-fail contract of ops/stage0/smoke_lib.sh::soft_degrade_or_exit.
+
+    The function is bash; we exercise it via `bash -c "source ...; soft_degrade_or_exit ..."`.
+    Stdout marker (`MARKER=continue` / `MARKER=softskip`) tells us which branch
+    the caller pattern took; exit code separates soft-skip (0) from hard-fail (1).
+    """
+
+    @staticmethod
+    def _run(suite: str, http: str, body: dict) -> tuple[int, str]:
+        with tempfile.NamedTemporaryFile("w", suffix=".json", delete=False) as f:
+            json.dump(body, f)
+            resp_path = f.name
+        script = (
+            f'source "{SMOKE_LIB}"\n'
+            f'if soft_degrade_or_exit "/v1/x" "{http}" "{resp_path}"; then\n'
+            f'  echo MARKER=continue\n'
+            f'else\n'
+            f'  echo MARKER=softskip\n'
+            f'fi\n'
+        )
+        try:
+            proc = subprocess.run(
+                ["bash", "-c", script],
+                capture_output=True,
+                text=True,
+                env={"GATEWAY_SMOKE_SUITE": suite, "PATH": "/usr/bin:/bin:/usr/local/bin"},
+                check=False,
+            )
+        finally:
+            pathlib.Path(resp_path).unlink(missing_ok=True)
+        return proc.returncode, proc.stdout + proc.stderr
+
+    def test_full_403_claude_code_only_soft_skips(self) -> None:
+        rc, out = self._run(
+            "full", "403",
+            {"error": {"message": "This group is restricted to Claude Code clients (/v1/messages only)"}},
+        )
+        self.assertEqual(rc, 0, out)
+        self.assertIn("MARKER=softskip", out)
+        self.assertIn("soft-skipped", out)
+
+    def test_main_via_edge_403_claude_code_only_hard_fails(self) -> None:
+        rc, out = self._run(
+            "main-via-edge", "403",
+            {"error": {"message": "This group is restricted to Claude Code clients (/v1/messages only)"}},
+        )
+        self.assertEqual(rc, 1, out)
+        self.assertNotIn("MARKER=continue", out)
+
+    def test_full_503_no_available_accounts_soft_skips(self) -> None:
+        rc, out = self._run(
+            "full", "503", {"error": {"message": "no available accounts"}},
+        )
+        self.assertEqual(rc, 0, out)
+        self.assertIn("MARKER=softskip", out)
+
+    def test_full_200_continues(self) -> None:
+        rc, out = self._run("full", "200", {"ok": True})
+        self.assertEqual(rc, 0, out)
+        self.assertIn("MARKER=continue", out)
+
+    def test_full_403_unrelated_hard_fails(self) -> None:
+        rc, out = self._run(
+            "full", "403", {"error": {"message": "invalid api key"}},
+        )
+        self.assertEqual(rc, 1, out)
+        self.assertNotIn("MARKER=continue", out)
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
## Summary

- post_deploy_smoke 的 full-suite chat 段命中绑定到 claude_code_only group 的 Anthropic key 时,gateway 正确返回 HTTP 403 "restricted to Claude Code clients (/v1/messages only)";原 soft_degrade_or_exit 将其当作 control-plane 退化硬失败,误判 prod 退化。
- 改为:full / quick suite 软跳过 chat 段并 warn;/v1/messages 段(Claude Code UA + x-api-key)继续运行,仍是该 key group 的规范探针。
- main-via-edge suite 保留 hard-fail(那个 suite 已 gate 掉 chat,出现在此即 smoke runner 配错)。

## Background

v1.7.44 (2026-05-27) deploy-stage0 run `26485303585` 整体 conclusion=failure,但 prod 实际健康:
- `GET /api/v1/settings/public -> 200 version=1.7.44`
- `GET /v1/models -> 200 count=7`
- `POST /v1/chat/completions -> 403` (`group restricted to Claude Code clients (/v1/messages only)`) — 唯一红灯
- 后续段未运行

按 prod 当前的 claude_code_only 策略,Anthropic key 命中 /v1/chat/completions 就该被拒。探针硬失败是探针不对齐策略,不是 prod 退化。

## Test plan

- [x] 本地 dry-run 5 case 全过:
  - C1 full+403 claude_code_only → soft-skip (return 1, script exits 0)
  - C2 main-via-edge+403 claude_code_only → hard fail (exit 1)
  - C3 full+503 → soft-skip (existing path,回归检查)
  - C4 full+200 → continue (回归检查)
  - C5 full+403 其他错 → hard fail (回归检查)
- [x] `scripts/preflight.sh` 全绿 (包含 stage0 smoke script syntax + smoke suite contract tests 20 个)
- [ ] PR 合并后再次跑 deploy-stage0,确认整 workflow 不再因策略-探针错位红。
- [ ] 单独跟进:把 canary key `TK_SMOKE_EDGE_CANARY_KEY` 在 prod DB 激活/重置(uk1 canary main-via-edge HTTP 401 的根因,与本 PR 无关)。

## Rollout context

本 PR 来自 v1.7.44 发版回顾的两个非阻断告警之一。另一个 (canary key 失效) 是 ops/secret 配置问题,不在代码层修。