### PR TITLE
feat(anthropic): align OAuth mimicry with cc 2.1.152 capture

### DIFF
--- a/backend/internal/handler/admin/setting_handler.go
+++ b/backend/internal/handler/admin/setting_handler.go
@@ -1462,7 +1462,7 @@ func (h *SettingHandler) UpdateSettings(c *gin.Context) {
 		normalized := strings.TrimSpace(*req.ClaudeCodeUserAgentVersion)
 		req.ClaudeCodeUserAgentVersion = &normalized
 		if normalized != "" && !semverPattern.MatchString(normalized) {
-			response.Error(c, http.StatusBadRequest, "claude_code_user_agent_version must be empty or a valid semver (e.g. 2.1.150)")
+			response.Error(c, http.StatusBadRequest, "claude_code_user_agent_version must be empty or a valid semver (e.g. 2.1.152)")
 			return
 		}
 	}

--- a/backend/internal/pkg/claude/constants.go
+++ b/backend/internal/pkg/claude/constants.go
@@ -125,7 +125,7 @@ var DefaultHeaders = map[string]string{
 	// that Claude Code-scoped OAuth credentials are rejected as "non-CLI" usage.
 	"User-Agent":                                "claude-cli/2.1.152 (external, cli)",
 	"X-Stainless-Lang":                          "js",
-	"X-Stainless-Package-Version":               "0.70.0",
+	"X-Stainless-Package-Version":               "0.94.0",
 	"X-Stainless-OS":                            "Linux",
 	"X-Stainless-Arch":                          "arm64",
 	"X-Stainless-Runtime":                       "node",

--- a/backend/internal/pkg/claude/constants.go
+++ b/backend/internal/pkg/claude/constants.go
@@ -1,13 +1,14 @@
 // Package claude provides constants and helpers for Claude API integration.
 package claude
 
+import "strings"
+
 // Claude Code 客户端相关常量
 
 // Beta header 常量
 //
-// 这里的常量对齐真实 Claude Code CLI 的最新流量（截至 2026-04）。
-// 选型参考：与 Parrot (src/transform/cc_mimicry.py) 的 BETAS 保持一致，
-// 原因：Anthropic 上游会基于 anthropic-beta 的完整集合判定请求来源；
+// 这里的常量对齐真实 Claude Code CLI 的最新流量（截至 2026-05，cc 2.1.152 抓包）。
+// Anthropic 上游会基于 anthropic-beta 的完整集合判定请求来源；
 // 缺少任何"官方 Claude Code 请求才会带"的 beta，都会被降级到第三方额度，
 // 对应报错：`Third-party apps now draw from your extra usage, not your plan limits.`
 const (
@@ -19,20 +20,26 @@ const (
 	BetaContext1M                = "context-1m-2025-08-07"
 	BetaFastMode                 = "fast-mode-2026-02-01"
 
-	// 新增（对齐官方 CLI 2.1.9x 以来的流量）
 	BetaPromptCachingScope = "prompt-caching-scope-2026-01-05"
 	BetaEffort             = "effort-2025-11-24"
 	BetaRedactThinking     = "redact-thinking-2026-02-12"
 	BetaContextManagement  = "context-management-2025-06-27"
 	BetaExtendedCacheTTL   = "extended-cache-ttl-2025-04-11"
+
+	// cc 2.1.152 抓包新增；fine-grained-tool-streaming 已从真实 CLI 流量中消失。
+	BetaAdvisorTool     = "advisor-tool-2026-03-01"
+	BetaAdvancedToolUse = "advanced-tool-use-2025-11-20"
+	BetaCacheDiagnosis  = "cache-diagnosis-2026-04-07"
 )
 
 // DroppedBetas 是转发时需要从 anthropic-beta header 中移除的 beta token 列表。
 // 这些 token 是客户端特有的，不应透传给上游 API。
 var DroppedBetas = []string{}
 
-// DefaultBetaHeader Claude Code 客户端默认的 anthropic-beta header
-const DefaultBetaHeader = BetaClaudeCode + "," + BetaOAuth + "," + BetaInterleavedThinking + "," + BetaFineGrainedToolStreaming
+// DefaultBetaHeader Claude Code 客户端默认的 anthropic-beta header（Sonnet/Opus OAuth 回退）。
+const DefaultBetaHeader = BetaClaudeCode + "," + BetaOAuth + "," + BetaInterleavedThinking + "," +
+	BetaContextManagement + "," + BetaPromptCachingScope + "," + BetaAdvisorTool + "," +
+	BetaAdvancedToolUse + "," + BetaEffort + "," + BetaExtendedCacheTTL + "," + BetaCacheDiagnosis
 
 // MessageBetaHeaderNoTools /v1/messages 在无工具时的 beta header
 //
@@ -48,8 +55,10 @@ const MessageBetaHeaderWithTools = BetaClaudeCode + "," + BetaOAuth + "," + Beta
 // CountTokensBetaHeader count_tokens 请求使用的 anthropic-beta header
 const CountTokensBetaHeader = BetaClaudeCode + "," + BetaOAuth + "," + BetaInterleavedThinking + "," + BetaTokenCounting
 
-// HaikuBetaHeader Haiku 模型使用的 anthropic-beta header（不需要 claude-code beta）
-const HaikuBetaHeader = BetaOAuth + "," + BetaInterleavedThinking
+// HaikuBetaHeader Haiku 模型 OAuth 回退 anthropic-beta（对齐 cc 2.1.152 抓包顺序）。
+const HaikuBetaHeader = BetaOAuth + "," + BetaInterleavedThinking + "," + BetaContextManagement + "," +
+	BetaPromptCachingScope + "," + BetaClaudeCode + "," + BetaAdvisorTool + "," +
+	BetaExtendedCacheTTL + "," + BetaCacheDiagnosis
 
 // APIKeyBetaHeader API-key 账号建议使用的 anthropic-beta header（不包含 oauth）
 const APIKeyBetaHeader = BetaClaudeCode + "," + BetaInterleavedThinking + "," + BetaFineGrainedToolStreaming
@@ -65,15 +74,20 @@ const DefaultCacheControlTTL = "5m"
 // CLICurrentVersion 是 sub2api 当前对外伪装的 Claude Code CLI 版本号（三段 semver）。
 // 用于 billing attribution block 中的 cc_version=X.Y.Z.{fp} 前缀以及 fingerprint 计算。
 // 必须与 DefaultHeaders["User-Agent"] 中的版本号严格一致；不一致会被 Anthropic 判第三方。
-const CLICurrentVersion = "2.1.92"
+const CLICurrentVersion = "2.1.152"
 
-// FullClaudeCodeMimicryBetas 返回最"像"真实 Claude Code CLI 的完整 beta 列表，
+// JoinBetaHeader joins beta tokens into the wire anthropic-beta header value.
+func JoinBetaHeader(betas []string) string {
+	return strings.Join(betas, ",")
+}
+
+// FullClaudeCodeMimicryBetas 返回最"像"真实 Claude Code CLI 的完整 beta 列表（Sonnet/Opus），
 // 用于 OAuth 账号伪装成 Claude Code 时使用。
-// 顺序与真实 CLI 抓包一致。
+// 顺序与 cc 2.1.152 /v1/messages 抓包一致。
 //
 // 使用建议：
 //   - OAuth 账号 + 非 haiku：追加这整份列表，再按需保留 client 带来的 beta。
-//   - OAuth 账号 + haiku：Anthropic 对 haiku 不做 third-party 判定，使用 HaikuBetaHeader 即可。
+//   - OAuth 账号 + haiku：使用 FullClaudeCodeHaikuMimicryBetas（无 effort / advanced-tool-use）。
 //   - API-key 账号：不要使用本函数，参见 APIKeyBetaHeader。
 //   - 不默认加入 redact-thinking，避免上游抹除 thinking 内容；客户端显式传入时由合并逻辑保留。
 func FullClaudeCodeMimicryBetas() []string {
@@ -81,10 +95,27 @@ func FullClaudeCodeMimicryBetas() []string {
 		BetaClaudeCode,
 		BetaOAuth,
 		BetaInterleavedThinking,
-		BetaPromptCachingScope,
-		BetaEffort,
 		BetaContextManagement,
+		BetaPromptCachingScope,
+		BetaAdvisorTool,
+		BetaAdvancedToolUse,
+		BetaEffort,
 		BetaExtendedCacheTTL,
+		BetaCacheDiagnosis,
+	}
+}
+
+// FullClaudeCodeHaikuMimicryBetas 返回 Haiku 模型 OAuth mimicry 的 beta 列表（cc 2.1.152 抓包）。
+func FullClaudeCodeHaikuMimicryBetas() []string {
+	return []string{
+		BetaOAuth,
+		BetaInterleavedThinking,
+		BetaContextManagement,
+		BetaPromptCachingScope,
+		BetaClaudeCode,
+		BetaAdvisorTool,
+		BetaExtendedCacheTTL,
+		BetaCacheDiagnosis,
 	}
 }
 
@@ -92,8 +123,7 @@ func FullClaudeCodeMimicryBetas() []string {
 var DefaultHeaders = map[string]string{
 	// Keep these in sync with recent Claude CLI traffic to reduce the chance
 	// that Claude Code-scoped OAuth credentials are rejected as "non-CLI" usage.
-	// 版本参考：对齐 Parrot (src/transform/cc_mimicry.py:49) 的 CLI_USER_AGENT。
-	"User-Agent":                                "claude-cli/2.1.92 (external, cli)",
+	"User-Agent":                                "claude-cli/2.1.152 (external, cli)",
 	"X-Stainless-Lang":                          "js",
 	"X-Stainless-Package-Version":               "0.70.0",
 	"X-Stainless-OS":                            "Linux",

--- a/backend/internal/pkg/claude/constants_test.go
+++ b/backend/internal/pkg/claude/constants_test.go
@@ -1,0 +1,60 @@
+//go:build unit
+
+package claude
+
+import (
+	"strings"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+)
+
+func TestFullClaudeCodeMimicryBetas_MatchesCC0152SonnetCapture(t *testing.T) {
+	want := []string{
+		"claude-code-20250219",
+		"oauth-2025-04-20",
+		"interleaved-thinking-2025-05-14",
+		"context-management-2025-06-27",
+		"prompt-caching-scope-2026-01-05",
+		"advisor-tool-2026-03-01",
+		"advanced-tool-use-2025-11-20",
+		"effort-2025-11-24",
+		"extended-cache-ttl-2025-04-11",
+		"cache-diagnosis-2026-04-07",
+	}
+	require.Equal(t, want, FullClaudeCodeMimicryBetas())
+	require.Equal(t, want, splitBetaHeader(DefaultBetaHeader))
+	require.NotContains(t, FullClaudeCodeMimicryBetas(), BetaFineGrainedToolStreaming)
+}
+
+func TestFullClaudeCodeHaikuMimicryBetas_MatchesCC0152HaikuCapture(t *testing.T) {
+	want := []string{
+		"oauth-2025-04-20",
+		"interleaved-thinking-2025-05-14",
+		"context-management-2025-06-27",
+		"prompt-caching-scope-2026-01-05",
+		"claude-code-20250219",
+		"advisor-tool-2026-03-01",
+		"extended-cache-ttl-2025-04-11",
+		"cache-diagnosis-2026-04-07",
+	}
+	require.Equal(t, want, FullClaudeCodeHaikuMimicryBetas())
+	require.Equal(t, want, splitBetaHeader(HaikuBetaHeader))
+	require.NotContains(t, FullClaudeCodeHaikuMimicryBetas(), BetaEffort)
+	require.NotContains(t, FullClaudeCodeHaikuMimicryBetas(), BetaAdvancedToolUse)
+}
+
+func TestJoinBetaHeader(t *testing.T) {
+	require.Equal(t, DefaultBetaHeader, JoinBetaHeader(FullClaudeCodeMimicryBetas()))
+	require.Equal(t, HaikuBetaHeader, JoinBetaHeader(FullClaudeCodeHaikuMimicryBetas()))
+}
+
+func splitBetaHeader(header string) []string {
+	parts := make([]string, 0)
+	for _, p := range strings.Split(header, ",") {
+		if trimmed := strings.TrimSpace(p); trimmed != "" {
+			parts = append(parts, trimmed)
+		}
+	}
+	return parts
+}

--- a/backend/internal/service/gateway_beta_test.go
+++ b/backend/internal/service/gateway_beta_test.go
@@ -128,9 +128,20 @@ func TestFullClaudeCodeMimicryBetas_DoesNotDefaultRedactThinking(t *testing.T) {
 	required := claude.FullClaudeCodeMimicryBetas()
 
 	require.NotContains(t, required, claude.BetaRedactThinking)
+	require.NotContains(t, required, claude.BetaFineGrainedToolStreaming)
 	require.Contains(t, required, claude.BetaClaudeCode)
 	require.Contains(t, required, claude.BetaOAuth)
 	require.Contains(t, required, claude.BetaInterleavedThinking)
+	require.Contains(t, required, claude.BetaAdvisorTool)
+	require.Contains(t, required, claude.BetaAdvancedToolUse)
+	require.Contains(t, required, claude.BetaCacheDiagnosis)
+}
+
+func TestGatewayService_getBetaHeader_HaikuDefaultMatchesCapture(t *testing.T) {
+	s := &GatewayService{}
+	got := s.getBetaHeader("claude-haiku-4-5-20251001", "")
+	require.Equal(t, claude.HaikuBetaHeader, got)
+	require.Equal(t, claude.JoinBetaHeader(claude.FullClaudeCodeHaikuMimicryBetas()), got)
 }
 
 func TestMergeAnthropicBetaDropping_PreservesIncomingRedactThinking(t *testing.T) {

--- a/backend/internal/service/gateway_service.go
+++ b/backend/internal/service/gateway_service.go
@@ -6368,7 +6368,8 @@ func (s *GatewayService) buildUpstreamRequest(ctx context.Context, c *gin.Contex
 			// Non-haiku models MUST include claude-code beta for Anthropic to recognize
 			// this as a legitimate Claude Code request; without it, the request is
 			// rejected as third-party ("out of extra usage").
-			// Haiku models are exempt from third-party detection and don't need it.
+			// Haiku also sends the cc 2.1.152 capture mimicry set (includes claude-code
+			// beta); token set/order differs from Sonnet (no effort / advanced-tool-use).
 			requiredBetas := claude.FullClaudeCodeHaikuMimicryBetas()
 			if !strings.Contains(strings.ToLower(modelID), "haiku") {
 				requiredBetas = claude.FullClaudeCodeMimicryBetas()
@@ -6513,8 +6514,7 @@ func (s *GatewayService) getBetaHeader(modelID string, clientBetaHeader string) 
 		return claude.BetaOAuth + "," + clientBetaHeader
 	}
 
-	// 客户端没传，根据模型生成
-	// haiku 模型不需要 claude-code beta
+	// 客户端没传，根据模型生成（Haiku 使用 capture 顺序的 8-token 集合，含 claude-code beta）
 	if strings.Contains(strings.ToLower(modelID), "haiku") {
 		return claude.HaikuBetaHeader
 	}

--- a/backend/internal/service/gateway_service.go
+++ b/backend/internal/service/gateway_service.go
@@ -4490,7 +4490,7 @@ func (s *GatewayService) Forward(ctx context.Context, c *gin.Context, account *A
 	// TK canonical-OAuth ingress gates (see gateway_service_tk_canonical_oauth_guard.go):
 	//   1. reject third-party SDK UAs that would silently drain a personal cc subscription
 	//   2. remap retired opus model ids to the current default so the upstream model mix
-	//      stays consistent with what real claude-cli/2.1.150 produces
+	//      stays consistent with what real claude-cli/2.1.152 produces
 	// Scoped to anthropic OAuth + canonical TLS profile only.
 	if c != nil && s.isCanonicalAnthropicOAuth(account) {
 		if err := checkCanonicalIngressUA(c.Request.Header); err != nil {
@@ -6369,7 +6369,7 @@ func (s *GatewayService) buildUpstreamRequest(ctx context.Context, c *gin.Contex
 			// this as a legitimate Claude Code request; without it, the request is
 			// rejected as third-party ("out of extra usage").
 			// Haiku models are exempt from third-party detection and don't need it.
-			requiredBetas := []string{claude.BetaOAuth, claude.BetaInterleavedThinking}
+			requiredBetas := claude.FullClaudeCodeHaikuMimicryBetas()
 			if !strings.Contains(strings.ToLower(modelID), "haiku") {
 				requiredBetas = claude.FullClaudeCodeMimicryBetas()
 			}

--- a/backend/internal/service/identity_service.go
+++ b/backend/internal/service/identity_service.go
@@ -26,7 +26,7 @@ var (
 
 // 默认指纹值（当客户端未提供时使用）
 var defaultFingerprint = Fingerprint{
-	UserAgent:               "claude-cli/2.1.92 (external, cli)",
+	UserAgent:               "claude-cli/2.1.152 (external, cli)",
 	StainlessLang:           "js",
 	StainlessPackageVersion: "0.70.0",
 	StainlessOS:             "Linux",

--- a/backend/internal/service/identity_service.go
+++ b/backend/internal/service/identity_service.go
@@ -28,7 +28,7 @@ var (
 var defaultFingerprint = Fingerprint{
 	UserAgent:               "claude-cli/2.1.152 (external, cli)",
 	StainlessLang:           "js",
-	StainlessPackageVersion: "0.70.0",
+	StainlessPackageVersion: "0.94.0",
 	StainlessOS:             "Linux",
 	StainlessArch:           "arm64",
 	StainlessRuntime:        "node",

--- a/backend/internal/service/identity_service_tk_canonical_http.go
+++ b/backend/internal/service/identity_service_tk_canonical_http.go
@@ -56,7 +56,7 @@ const (
 	// neither env nor runtime resolver provides a value. Keep in sync with
 	// the most recent cc CLI release this build was validated against; the
 	// admin UI / runtime resolver is the normal update path going forward.
-	DefaultClaudeCodeUserAgentVersion = "2.1.150"
+	DefaultClaudeCodeUserAgentVersion = "2.1.152"
 
 	// canonicalUAPrefix / canonicalUASuffix wrap the version-only field.
 	// Matches the wire shape Anthropic observes from a real Claude Code CLI

--- a/deploy/aws/stage0/anthropic-oauth-stability-baselines-tiered.json
+++ b/deploy/aws/stage0/anthropic-oauth-stability-baselines-tiered.json
@@ -52,7 +52,7 @@
     ],
     "tls_profile": {
       "name": "tk_canonical_cc_oauth",
-      "description": "TokenKey canonical Claude Code OAuth TLS profile. Stable id decoupled from cc CLI patch version (TLS ClientHello byte-identical 2.1.142 → 2.1.150). HTTP UA driven at runtime by SettingService.GetClaudeCodeUserAgentVersion. runtime=node v24.3.0 darwin/arm64. ja3_hash=d871d02cecbde59abbf8f4806134addf (2026-05-15 capture).",
+      "description": "TokenKey canonical Claude Code OAuth TLS profile. Stable id decoupled from cc CLI patch version (TLS ClientHello byte-identical 2.1.142 → 2.1.152). HTTP UA driven at runtime by SettingService.GetClaudeCodeUserAgentVersion. runtime=node v24.3.0 darwin/arm64. ja3_hash=d871d02cecbde59abbf8f4806134addf (2026-05-15 capture).",
       "enable_grease": false,
       "cipher_suites": [
         4865,

--- a/deploy/aws/stage0/tk_canonical_cc_oauth.json
+++ b/deploy/aws/stage0/tk_canonical_cc_oauth.json
@@ -1,6 +1,6 @@
 {
   "name": "tk_canonical_cc_oauth",
-  "description": "TokenKey canonical Claude Code OAuth TLS profile. Stable id intentionally decoupled from cc CLI patch version: TLS ClientHello is byte-identical across 2.1.142 (2026-05-15 capture, ja3_hash=d871d02cecbde59abbf8f4806134addf) through 2.1.150 (2026-05-25), so a new patch release never triggers a rename. HTTP observed.user_agent below is a compile-time snapshot; the live wire UA is driven at runtime by SettingService.GetClaudeCodeUserAgentVersion (admin setting → env CLAUDE_CODE_USER_AGENT_VERSION → compile default). runtime=node v24.3.0 darwin/arm64.",
+  "description": "TokenKey canonical Claude Code OAuth TLS profile. Stable id intentionally decoupled from cc CLI patch version: TLS ClientHello is byte-identical across 2.1.142 (2026-05-15 capture, ja3_hash=d871d02cecbde59abbf8f4806134addf) through 2.1.152 (2026-05-27 cc0 capture), so a new patch release never triggers a rename. HTTP observed.user_agent below is a compile-time snapshot; the live wire UA is driven at runtime by SettingService.GetClaudeCodeUserAgentVersion (admin setting → env CLAUDE_CODE_USER_AGENT_VERSION → compile default). runtime=node v24.3.0 darwin/arm64.",
   "enable_grease": false,
   "cipher_suites": [
     4865,
@@ -71,7 +71,7 @@
   ],
   "observed": {
     "model": "claude-haiku-4-5-20251001",
-    "user_agent": "claude-cli/2.1.150 (external, sdk-cli)",
+    "user_agent": "claude-cli/2.1.152 (external, sdk-cli)",
     "stainless_os": "MacOS",
     "stainless_arch": "arm64",
     "stainless_runtime": "node",

--- a/docs/accounts/anthropic-oauth-edge-guidelines.md
+++ b/docs/accounts/anthropic-oauth-edge-guidelines.md
@@ -23,7 +23,7 @@
 
 **HTTP 层（User-Agent / `x-stainless-*`）**：TLS 模板不决定出站 HTTP 指纹。账号绑定 canonical 模板时，网关会把 Redis `fingerprint:{accountID}` 的 HTTP 字段钉死在 canonical observed 块（与 TLS 参数独立）；prod→edge 透传的多版本 ingress UA 不会改写上游 UA。`ops_error_logs.user_agent` 仍是入口侧客户端 UA，不是 `api.anthropic.com` 所见值。
 
-**Profile 命名稳定性**：profile 名 `tk_canonical_cc_oauth` 不含 cc CLI patch version——TLS ClientHello 跨 cc 2.1.142 → 2.1.150 等 patch release 字节不变（同 ja3_hash），换 patch version 不需要 DB profile rename / migration。
+**Profile 命名稳定性**：profile 名 `tk_canonical_cc_oauth` 不含 cc CLI patch version——TLS ClientHello 跨 cc 2.1.142 → 2.1.152 等 patch release 字节不变（同 ja3_hash），换 patch version 不需要 DB profile rename / migration。
 
 **UA 运行期可配（三层解析）**：
 
@@ -33,7 +33,7 @@
 | 环境变量 | `CLAUDE_CODE_USER_AGENT_VERSION` | 进程启动期生效（重启进程，不重新部署） |
 | 编译期默认 | `DefaultClaudeCodeUserAgentVersion` 常量 | 兜底（仅当上述两层均缺失或非法） |
 
-只填**版本号**（如 `2.1.150`），prefix/suffix（`claude-cli/.../ (external, sdk-cli)`）由代码固定。Semver `^\d+\.\d+\.\d+$` 校验，非法值在 admin PATCH 阶段就被拒；下沉到 setting 后任何非法值再走 normalize fallback 到 default。
+只填**版本号**（如 `2.1.152`），prefix/suffix（`claude-cli/.../ (external, sdk-cli)`）由代码固定。Semver `^\d+\.\d+\.\d+$` 校验，非法值在 admin PATCH 阶段就被拒；下沉到 setting 后任何非法值再走 normalize fallback 到 default。
 
 **UA 变更后无需 SQL apply / Redis 清缓存**：`applyCanonicalHTTPObserved` 每次 OAuth forward 都会比对 Redis 缓存 UA 与当前 canonical UA，不一致即 in-place update。即 admin 改 setting → next request → Redis 自动 self-heal，无运维步骤。
 
@@ -64,7 +64,7 @@ canonical 路径上请求**已退役的 opus 模型**（`claude-opus-4-0` ~ `cla
 
 权威列表：`backend/internal/service/gateway_service_tk_canonical_oauth_guard.go` 的 `canonicalDeprecatedOpusPrefixes` + `canonicalDefaultOpus`。
 
-**理由**：真实 `claude-cli/2.1.150` 默认只发 `claude-opus-4-7` / `claude-sonnet-4-6` / `claude-haiku-4-5-*`；同账号上同时出现 4-6 + 4-7 是「混合发行版客户端共享同一个 OAuth」的强 cohort signal——风控会聚合识别。Sonnet 4-5/4-6 与 Haiku 4-5 在真实 cc 客户端中均处于活跃状态，**仅 opus 退役系列**会被改写。
+**理由**：真实 `claude-cli/2.1.152` 默认只发 `claude-opus-4-7` / `claude-sonnet-4-6` / `claude-haiku-4-5-*`；同账号上同时出现 4-6 + 4-7 是「混合发行版客户端共享同一个 OAuth」的强 cohort signal——风控会聚合识别。Sonnet 4-5/4-6 与 Haiku 4-5 在真实 cc 客户端中均处于活跃状态，**仅 opus 退役系列**会被改写。
 
 ---
 

--- a/docs/spec-delta-cc-canonical-ua-beta-2.1.152.md
+++ b/docs/spec-delta-cc-canonical-ua-beta-2.1.152.md
@@ -1,0 +1,120 @@
+# spec-delta: PR #423 — cc 2.1.152 OAuth mimicry alignment
+
+## Background
+
+PR [#423](https://github.com/youxuanxue/sub2api/pull/423) aligns TokenKey canonical / OAuth Claude Code mimicry with **cc 2.1.152 mitm capture** (cc0 → gost → socks) and us1 Phase 0 cross-checks:
+
+- **TLS ClientHello** unchanged across cc 2.1.142 → 2.1.152 (same ja3); no DB TLS profile migration.
+- **HTTP fingerprint** drift was the actionable gap: compile-time UA default, `anthropic-beta` token set, and Haiku mimicry path lagged real cc traffic.
+
+Community / upstream context (why this PR exists, not what it fully solves):
+
+| Source | Takeaway |
+|--------|----------|
+| [Wei-Shaw/sub2api#580](https://github.com/Wei-Shaw/sub2api/issues/580) | Hard-coded mimic UA causes **version up/down churn** on shared OAuth accounts when real cc and third-party clients mix. |
+| [Wei-Shaw/sub2api#766](https://github.com/Wei-Shaw/sub2api/issues/766) | UA rewrite → mimic path + **un-rewritten `metadata.user_id`** → identity mismatch → ban risk. |
+| [Wei-Shaw/sub2api#1755](https://github.com/Wei-Shaw/sub2api/issues/1755) | Upstream wants configurable header rewrite; TK uses **code-canonical constants + admin UA setting** instead. |
+| Anthropic 2026-04 third-party policy | OAuth subscription plan limits apply to **first-party cc**; third-party harnesses draw **extra usage** even with perfect beta alignment. |
+| LINUX DO (deployment / ban threads) | **TLS/HTTP fingerprint mismatch**, IP profile, pooling concurrency, and token refresh batching dominate anecdotal ban stories — beta/UA alone is insufficient. |
+
+Related TK docs: `docs/accounts/anthropic-oauth-edge-guidelines.md`. Prior mimicry work: `docs/spec-delta-2489-580-no-web-impact.md`.
+
+## Delta
+
+### ADDED
+
+- `BetaAdvisorTool`, `BetaAdvancedToolUse`, `BetaCacheDiagnosis` in `backend/internal/pkg/claude/constants.go`.
+- `FullClaudeCodeHaikuMimicryBetas()` — 8-token Haiku OAuth set (cc 2.1.152 capture order).
+- `JoinBetaHeader()` helper; `backend/internal/pkg/claude/constants_test.go` capture-order regression tests.
+- Sentinel anchors in `scripts/sentinels/gateway-tk.json` for the beta registry.
+
+### MODIFIED
+
+- `DefaultClaudeCodeUserAgentVersion`: **2.1.150 → 2.1.152** (`identity_service_tk_canonical_http.go`).
+- `CLICurrentVersion` / `DefaultHeaders` / default fingerprint UA: **2.1.92 → 2.1.152** (non-canonical mimic + billing block).
+- `FullClaudeCodeMimicryBetas()` Sonnet/Opus set: **10 tokens**, order matches cc 2.1.152; adds advisor / advanced-tool-use / cache-diagnosis.
+- `DefaultBetaHeader`, `HaikuBetaHeader`: rebuilt from the new mimicry functions (no `fine-grained-tool-streaming` on OAuth paths).
+- OAuth mimic path (`gateway_service.go`): Haiku uses `FullClaudeCodeHaikuMimicryBetas()` instead of `{oauth, interleaved}` only.
+- Smoke default UA: `ops/stage0/smoke_lib.sh` → `claude-cli/2.1.152 (external, sdk-cli)`.
+- TLS profile snapshot text: `deploy/aws/stage0/tk_canonical_cc_oauth.json`, tier baseline description strings.
+
+### REMOVED (OAuth mimic paths only)
+
+- `fine-grained-tool-streaming-2025-05-14` from **OAuth** default / Sonnet mimicry sets (still present on `APIKeyBetaHeader`).
+
+### NOT changed (explicit non-goals)
+
+- TLS cipher/extension bodies in `tk_canonical_cc_oauth` DB profile.
+- `RewriteUserID` / JSON `metadata.user_id` rewrite logic ([#766](https://github.com/Wei-Shaw/sub2api/issues/766)).
+- Monotonic global UA cache across all mimic clients ([#580](https://github.com/Wei-Shaw/sub2api/issues/580) full fix).
+- `backend/migrations/129_seed_claude_code_template.sql` **「Claude Code 伪装」** channel monitor template (still UA 2.1.114, partial beta) — separate bump if used in prod.
+
+## Scenarios
+
+### Core positive
+
+1. **Canonical OAuth + unset admin UA setting + post-release deploy**  
+   Given edge on new binary and empty `claude_code_user_agent_version`, when smoke hits canonical account, then upstream UA is `claude-cli/2.1.152 (external, sdk-cli)` and Sonnet `anthropic-beta` matches 10-token capture set.
+
+2. **Admin UA bump without redeploy**  
+   Given live edge still on compile default 2.1.150, when admin PATCH `claude_code_user_agent_version=2.1.152`, then next OAuth forward self-heals Redis canonical UA (no SQL / TLS apply).
+
+3. **Haiku OAuth mimicry**  
+   Given non-cc client on OAuth account + Haiku model, when gateway merges mimic betas, then header contains 8-token Haiku set **without** `effort` / `advanced-tool-use`, and body still **does not** auto-inject `context_management` (regression: upstream #2506).
+
+### Core negative
+
+1. **Third-party client policy boundary**  
+   Given OpenCode / ChatWise / OpenAI SDK client (not cc), when betas are aligned, upstream may still return **extra usage / third-party** — not a regression from this PR; do not chase with more beta tokens alone.
+
+2. **Ingress UA cohort on same account**  
+   Given same OAuth account sees ingress `2.1.150` and `2.1.152` in `usage_logs`, when only compile default changes, then **ingress mix persists** until clients upgrade; canonical **upstream** UA is unified but ingress telemetry still flags mixed clients.
+
+3. **Stale DB monitor template**  
+   Given operator uses migration-129 「Claude Code 伪装」 template on channel monitor, when gateway uses PR #423 constants, then monitor requests may still send **2.1.114 + 5-token beta** — drift independent of gateway.
+
+### Post-merge ops checklist
+
+Run after PR #423 merges and on each deployable edge (prod + edge matrix):
+
+| # | Check | How | Pass criteria |
+|---|--------|-----|---------------|
+| 1 | Admin UA | PATCH `/api/v1/admin/settings` → `claude_code_user_agent_version=2.1.152` on edges still unset | Next canonical forward uses 2.1.152 upstream UA |
+| 2 | Smoke UA | `ops/stage0/smoke_lib.sh` default or `TK_SMOKE_CLAUDE_USER_AGENT` | Requests use `(external, sdk-cli)` shape |
+| 3 | Upstream beta (Sonnet) | Probe one `/v1/messages` on canonical OAuth account | 10 tokens incl. `advisor-tool`, `advanced-tool-use`, `cache-diagnosis`; **no** `fine-grained-tool-streaming` |
+| 4 | Upstream beta (Haiku) | Same on `claude-haiku-4-5-*` | 8-token set; no `effort` / `advanced-tool-use` |
+| 5 | Error budget | `ops_error_logs` / alerts for `extra usage`, `third-party apps now draw` | Rate not **worse** than pre-deploy baseline; if up, inspect client mix / IP / concurrency (not beta list) |
+| 6 | Ingress cohort | SQL on `usage_logs.user_agent` for canonical accounts (120m window) | Trend toward single cc patch version on ingress; upstream already unified |
+| 7 | Template drift | If `channel_monitor_request_templates` 「Claude Code 伪装」 is used | Bump template or disable; do not rely on migration-129 seed alone |
+| 8 | Middle proxy | Confirm no layer between cc and TokenKey rewrites UA without rewriting `metadata.user_id` | Avoid #766 pattern |
+| 9 | Client env | Users on OAuth direct cc | No stray `ANTHROPIC_API_KEY` / conflicting `ANTHROPIC_AUTH_TOKEN` in shell or `.claude/settings.json` env |
+
+**us1 immediate action (pre-release):** admin `claude_code_user_agent_version=2.1.152` — no redeploy required.
+
+**Known remaining gaps (track separately, not #423 blockers):**
+
+- Global monotonic UA cache for non-canonical mimic ([#580](https://github.com/Wei-Shaw/sub2api/issues/580)).
+- `#766`-class user_id rewrite when ingress UA is stripped by middle boxes.
+- Migration-129 monitor template version bump.
+- cc patch release cadence (~days): expect next bump via admin setting first, then compile default on following release.
+
+## Validation
+
+### Automated (CI / preflight)
+
+```bash
+go test -tags=unit ./internal/pkg/claude/... -run 'TestFullClaudeCode'
+go test -tags=unit ./internal/service/... -run 'TestFullClaudeCode|TestGatewayService_getBetaHeader|TestNormalizeClaudeOAuthRequestBody_Haiku'
+python3 scripts/sentinels/check-gateway-tk.py   # or full ./scripts/preflight.sh
+```
+
+### Manual (post-deploy, per edge)
+
+1. Admin PATCH UA setting (checklist row 1).
+2. One Sonnet + one Haiku canonical OAuth request; inspect debug / upstream snapshot if enabled (rows 3–4).
+3. Compare `extra usage` error rate 24h before vs after (row 5).
+
+### Evidence pointers
+
+- cc0 mitm capture session (2026-05-27): Sonnet/Opus 10-token beta list; Haiku 8-token list; TLS ClientHello unchanged vs 2.1.142 profile.
+- us1 Phase 0: unset admin setting → compile default 2.1.150; ingress mix 2.1.150 / 2.1.152 on same account.

--- a/docs/spec-delta-cc-canonical-ua-beta-2.1.152.md
+++ b/docs/spec-delta-cc-canonical-ua-beta-2.1.152.md
@@ -35,6 +35,7 @@ Related TK docs: `docs/accounts/anthropic-oauth-edge-guidelines.md`. Prior mimic
 - `FullClaudeCodeMimicryBetas()` Sonnet/Opus set: **10 tokens**, order matches cc 2.1.152; adds advisor / advanced-tool-use / cache-diagnosis.
 - `DefaultBetaHeader`, `HaikuBetaHeader`: rebuilt from the new mimicry functions (no `fine-grained-tool-streaming` on OAuth paths).
 - OAuth mimic path (`gateway_service.go`): Haiku uses `FullClaudeCodeHaikuMimicryBetas()` instead of `{oauth, interleaved}` only.
+- Mimic `DefaultHeaders` / default fingerprint `X-Stainless-Package-Version`: **0.70.0 → 0.94.0** (matches cc 2.1.152 capture; canonical path already 0.94.0).
 - Smoke default UA: `ops/stage0/smoke_lib.sh` → `claude-cli/2.1.152 (external, sdk-cli)`.
 - TLS profile snapshot text: `deploy/aws/stage0/tk_canonical_cc_oauth.json`, tier baseline description strings.
 
@@ -116,5 +117,6 @@ python3 scripts/sentinels/check-gateway-tk.py   # or full ./scripts/preflight.sh
 
 ### Evidence pointers
 
-- cc0 mitm capture session (2026-05-27): Sonnet/Opus 10-token beta list; Haiku 8-token list; TLS ClientHello unchanged vs 2.1.142 profile.
+- **cc 2.1.152 cc0 mitm** (2026-05-27, gost → api.anthropic.com `/v1/messages`): Haiku `anthropic-beta` 8-token capture order; `X-Stainless-Package-Version: 0.94.0` (not 0.70.0); Sonnet/Opus 10-token beta list.
+- **cc 2.1.152 TLS collector** (2026-05-27, `tls.sub2api.org:8090`): `ja3_hash=d871d02cecbde59abbf8f4806134addf`, `ja3_raw=771,4865-4866-4867-49195-49199-49196-49200-52393-52392-49161-49171-49162-49172-156-157-47-53,0-23-65281-10-11-35-16-5-13-18-51-45-43-21,29-23-24,0` — **identical** to cc 2.1.142 / 2.1.150 captures in `.tls_list/`; no DB TLS profile migration.
 - us1 Phase 0: unset admin setting → compile default 2.1.150; ingress mix 2.1.150 / 2.1.152 on same account.

--- a/ops/stage0/smoke_lib.sh
+++ b/ops/stage0/smoke_lib.sh
@@ -49,7 +49,7 @@ if [[ -z "${_TK_SMOKE_LIB_LOADED:-}" ]]; then
   }
 
   smoke_default_claude_user_agent() {
-    printf '%s' "${TK_SMOKE_CLAUDE_USER_AGENT:-claude-cli/2.1.150 (external, sdk-cli)}"
+    printf '%s' "${TK_SMOKE_CLAUDE_USER_AGENT:-claude-cli/2.1.152 (external, sdk-cli)}"
   }
 
   # soft_degrade_or_exit — see post_deploy_smoke.sh header for contract.

--- a/scripts/sentinels/gateway-tk.json
+++ b/scripts/sentinels/gateway-tk.json
@@ -1059,6 +1059,18 @@
       "rationale": "Focused regression anchors for canonical-OAuth ingress gates: (1) real claude-cli/claude-code UAs and unknown UAs pass (deny-list-only), (2) every named third-party SDK in the registry is rejected with the original UA preserved on the error, (3) the documented retired opus ids (4-6/4-5/4-4/4-3/4-2/4-1/4-0 with dated suffixes) remap to canonical default, (4) current opus 4-7 plus sonnet/haiku ids pass through unchanged, (5) the prefix-isolation case proves `claude-opus-4-65` (hypothetical future) is NOT collapsed into 4-6 because the prefix check requires either exact match or a trailing `-`."
     },
     {
+      "path": "backend/internal/pkg/claude/constants.go",
+      "must_contain": [
+        "BetaAdvisorTool",
+        "BetaAdvancedToolUse",
+        "BetaCacheDiagnosis",
+        "func FullClaudeCodeMimicryBetas()",
+        "func FullClaudeCodeHaikuMimicryBetas()",
+        "func JoinBetaHeader("
+      ],
+      "rationale": "OAuth Claude Code mimicry beta registry: Sonnet/Opus and Haiku sets must stay aligned with real cc CLI traffic (cc 2.1.152 capture). Dropping advisor/advanced-tool-use/cache-diagnosis or reverting Haiku to the legacy two-token header re-opens third-party cohort signals on OAuth subscriptions."
+    },
+    {
       "path": "backend/internal/handler/gateway_handler.go",
       "must_contain": [
         "var canonicalUARejectErr *service.CanonicalIngressUARejectedError",


### PR DESCRIPTION
## Summary

- Bump canonical compile-time Claude Code UA default from **2.1.150 → 2.1.152** (`DefaultClaudeCodeUserAgentVersion`, smoke default, TLS profile snapshot text).
- Refresh OAuth `anthropic-beta` mimicry to match **cc0/claude0-here mitm capture** on cc 2.1.152:
  - Sonnet/Opus (10 tokens): add `advisor-tool`, `advanced-tool-use`, `cache-diagnosis`; remove stale `fine-grained-tool-streaming`.
  - Haiku (8 tokens): new `FullClaudeCodeHaikuMimicryBetas()` wired into mimicry path + `getBetaHeader` fallback.
- **TLS ClientHello unchanged** (2.1.142→2.1.152 patch releases share ja3); no DB profile migration required.

**Ops / community cross-ref:** `docs/spec-delta-cc-canonical-ua-beta-2.1.152.md` (upstream #580/#766, LINUX DO pitfalls, post-merge edge checklist).

## Risk

- Regular risk: changes upstream HTTP fingerprint only for OAuth/canonical and non-cc mimicry paths.
- Deployed edges with unset `claude_code_user_agent_version` will pick up compile default on next release; live us1 still benefits from admin setting `2.1.152` for immediate alignment without redeploy.
- Does **not** fix third-party client extra-usage policy, #766 user_id leak, or migration-129 monitor template drift — tracked in spec delta.

## Validation

- `go test -tags=unit ./internal/pkg/claude/... ./internal/service/... -run 'TestFullClaudeCode|TestGatewayService_getBetaHeader'`
- `./scripts/preflight.sh` (incl. gateway-tk sentinel + smoke suite)
- Evidence: cc0 capture via gost→socks (Sonnet/Haiku beta sets identical except effort/advanced-tool-use on Haiku)
- Post-merge: see spec delta § Post-merge ops checklist (admin UA, beta probe, error budget, template drift)

## Post-merge ops (us1)

Admin PATCH `claude_code_user_agent_version=2.1.152` on edges still on compile default 2.1.150 — next request self-heals Redis canonical UA; no SQL/TLS apply needed.