### PR TITLE
feat(monitor): seed Claude Code 2.1.152 channel monitor template

### DIFF
--- a/backend/migrations/tk_011_seed_claude_code_template_2_1_152.sql
+++ b/backend/migrations/tk_011_seed_claude_code_template_2_1_152.sql
@@ -1,0 +1,33 @@
+-- Migration: tk_011_seed_claude_code_template_2_1_152
+-- Follow-up to PR #423 / migration-129: seed a cc 2.1.152-aligned channel monitor template.
+-- Does NOT update the legacy 「Claude Code 伪装」 row (still 2.1.114) so operator edits are preserved.
+-- Operators on the old template should switch to this seed or bump headers manually.
+
+INSERT INTO channel_monitor_request_templates (
+    name, provider, description, extra_headers, body_override_mode, body_override
+)
+VALUES (
+    'Claude Code 伪装 2.1.152',
+    'anthropic',
+    '完整模拟 Claude Code 2.1.152 客户端：UA + anthropic-beta + system + metadata.user_id 对齐 cc 2.1.152 抓包（无 oauth beta，适用于 API-key 渠道监控）。',
+    '{
+        "User-Agent": "claude-cli/2.1.152 (external, sdk-cli)",
+        "X-App": "cli",
+        "anthropic-version": "2023-06-01",
+        "anthropic-beta": "claude-code-20250219,interleaved-thinking-2025-05-14,context-management-2025-06-27,prompt-caching-scope-2026-01-05,advisor-tool-2026-03-01,advanced-tool-use-2025-11-20,effort-2025-11-24,extended-cache-ttl-2025-04-11,cache-diagnosis-2026-04-07",
+        "anthropic-dangerous-direct-browser-access": "true"
+    }'::jsonb,
+    'merge',
+    '{
+        "system": [
+            {
+                "type": "text",
+                "text": "You are Claude Code, Anthropic''s official CLI for Claude."
+            }
+        ],
+        "metadata": {
+            "user_id": "user_0000000000000000000000000000000000000000000000000000000000000000_account_00000000-0000-0000-0000-000000000000_session_00000000-0000-0000-0000-000000000000"
+        }
+    }'::jsonb
+)
+ON CONFLICT (provider, name) DO NOTHING;

--- a/docs/spec-delta-cc-canonical-ua-beta-2.1.152.md
+++ b/docs/spec-delta-cc-canonical-ua-beta-2.1.152.md
@@ -48,7 +48,7 @@ Related TK docs: `docs/accounts/anthropic-oauth-edge-guidelines.md`. Prior mimic
 - TLS cipher/extension bodies in `tk_canonical_cc_oauth` DB profile.
 - `RewriteUserID` / JSON `metadata.user_id` rewrite logic ([#766](https://github.com/Wei-Shaw/sub2api/issues/766)).
 - Monotonic global UA cache across all mimic clients ([#580](https://github.com/Wei-Shaw/sub2api/issues/580) full fix).
-- `backend/migrations/129_seed_claude_code_template.sql` **「Claude Code 伪装」** channel monitor template (still UA 2.1.114, partial beta) — separate bump if used in prod.
+- `backend/migrations/129_seed_claude_code_template.sql` legacy **「Claude Code 伪装」** row (UA 2.1.114) — left untouched; follow-up **tk_011** seeds **「Claude Code 伪装 2.1.152」**.
 
 ## Scenarios
 
@@ -86,7 +86,7 @@ Run after PR #423 merges and on each deployable edge (prod + edge matrix):
 | 4 | Upstream beta (Haiku) | Same on `claude-haiku-4-5-*` | 8-token set; no `effort` / `advanced-tool-use` |
 | 5 | Error budget | `ops_error_logs` / alerts for `extra usage`, `third-party apps now draw` | Rate not **worse** than pre-deploy baseline; if up, inspect client mix / IP / concurrency (not beta list) |
 | 6 | Ingress cohort | SQL on `usage_logs.user_agent` for canonical accounts (120m window) | Trend toward single cc patch version on ingress; upstream already unified |
-| 7 | Template drift | If `channel_monitor_request_templates` 「Claude Code 伪装」 is used | Bump template or disable; do not rely on migration-129 seed alone |
+| 7 | Template drift | If still on migration-129 「Claude Code 伪装」 | Switch monitor to **「Claude Code 伪装 2.1.152」** (tk_011) or edit headers manually |
 | 8 | Middle proxy | Confirm no layer between cc and TokenKey rewrites UA without rewriting `metadata.user_id` | Avoid #766 pattern |
 | 9 | Client env | Users on OAuth direct cc | No stray `ANTHROPIC_API_KEY` / conflicting `ANTHROPIC_AUTH_TOKEN` in shell or `.claude/settings.json` env |
 
@@ -96,7 +96,7 @@ Run after PR #423 merges and on each deployable edge (prod + edge matrix):
 
 - Global monotonic UA cache for non-canonical mimic ([#580](https://github.com/Wei-Shaw/sub2api/issues/580)).
 - `#766`-class user_id rewrite when ingress UA is stripped by middle boxes.
-- Migration-129 monitor template version bump.
+- tk_011 monitor template seed (operators still on migration-129 「Claude Code 伪装」 must switch manually).
 - cc patch release cadence (~days): expect next bump via admin setting first, then compile default on following release.
 
 ## Validation


### PR DESCRIPTION
## Summary

- Follow-up to merged #423: add **migration-143** seeding **「Claude Code 伪装 2.1.152」** (UA `2.1.152`, 9-token anthropic-beta aligned with cc 2.1.152 capture minus `oauth`).
- Leaves migration-129 **「Claude Code 伪装」** (2.1.114) untouched so existing operator edits are preserved.
- Updates `docs/spec-delta-cc-canonical-ua-beta-2.1.152.md` ops checklist for template drift.

**Explicitly out of scope (track separately):**

- [Wei-Shaw/sub2api#580](https://github.com/Wei-Shaw/sub2api/issues/580) — global monotonic UA cache for non-canonical mimic
- [Wei-Shaw/sub2api#766](https://github.com/Wei-Shaw/sub2api/issues/766) — `metadata.user_id` rewrite when middle proxy strips UA

## Risk

- Low: DB seed only (`ON CONFLICT DO NOTHING`); no gateway/runtime behavior change.
- Operators still on the legacy template must switch monitor config manually after deploy.

## Validation

- `./scripts/preflight.sh` — PASS
- `go test -tags=unit ./internal/repository/... -run Migration` — PASS

## Test plan

- [ ] Deploy / run migrations on a dev stack; confirm new template appears in channel monitor template list
- [ ] Select **「Claude Code 伪装 2.1.152」** on an anthropic channel monitor; verify probe sends UA `2.1.152` and expanded beta set
- [ ] Confirm legacy **「Claude Code 伪装」** row unchanged on upgraded DBs


Made with [Cursor](https://cursor.com)