### PR TITLE
chore(ops): cc fingerprint capture skill and deterministic diff tooling

### DIFF
--- a/.cursor/skills/tokenkey-cc-fingerprint-alignment/SKILL.md
+++ b/.cursor/skills/tokenkey-cc-fingerprint-alignment/SKILL.md
@@ -1,0 +1,170 @@
+---
+name: tokenkey-cc-fingerprint-alignment
+description: >-
+  End-to-end workflow to capture real Claude Code (cc0-here / claude0-here) TLS
+  and HTTP fingerprints, diff against TokenKey repo constants
+  (tk_canonical_cc_oauth, constants.go, identity_service*), fix drift, and open
+  a spec-delta PR. Use when cc patch releases, ingress UA cohort mixes, OAuth
+  mimicry/beta/stainless drift is suspected, or after PR #423-style alignment
+  needs repeating for a new cc version.
+---
+
+# TokenKey：cc 指纹对齐（抓包 → diff → 修代码 → PR）
+
+适用于本仓库（TokenKey fork of sub2api）。把 **真实 cc 流量** 当作 ground truth，**TokenKey 常量 + DB TLS profile** 当作待对齐对象。TLS 与 HTTP **分轨采集、分轨决策**——禁止从 UA 版本号推断 ja3 或 `X-Stainless-Package-Version`。
+
+关联：`cc0-claude0-launcher` skill（cc0-here 环境）、`tokenkey-anthropic-oauth-config` skill（ja3 变更时的 TLS profile apply）、`docs/spec-delta-cc-canonical-ua-beta-2.1.152.md`（PR #423 实例）。
+
+## 确定性基线（机械化 vs 真判断）
+
+| 步骤 | 类型 | 承载 |
+|---|---|---|
+| 读取 TokenKey baseline（ja3、UA 版本、stainless、mimicry beta 列表） | 机械 | `python3 ops/anthropic/capture_cc_fingerprint.py show-baseline` |
+| TLS collector 采集 ClientHello | 机械 | `bash ops/anthropic/capture-cc-fingerprint.sh capture` |
+| HTTP mitm 采集 `/v1/messages` headers | 机械 | `bash ops/anthropic/capture-cc-fingerprint.sh capture --http` |
+| bundle 组装 + diff + `--check` 门禁 | 机械 | `capture_cc_fingerprint.py bundle-from-artifacts` / `diff` / `check` |
+| Phase 0 ingress cohort / admin UA | 机械 | `ops/observability/probe-us1-cc-ua-setting.sh` 等（可选） |
+| ja3 变更 → TLS profile SQL apply | 机械 | `ops/anthropic/manage-anthropic-config.py plan/apply/verify` |
+| 代码修复位点（constants / identity / gateway） | 判断 + 清单 | 本 skill §4 |
+| 是否发版 / admin PATCH 先后 | 判断 | `tokenkey-stage0-release-rollout` skill |
+| PR 风险分级 / spec-delta 是否足够 | 判断 | `product-dev.mdc` |
+
+## 调用参数
+
+```text
+/tokenkey-cc-fingerprint-alignment cc_version=<optional> [http=true] [phase0=true] [open_pr=false]
+```
+
+| 参数 | 语义 |
+|---|---|
+| `cc_version` | 目标 cc patch；缺省从 `claude --version` 读取 |
+| `http=true` | 同时跑 mitm HTTP（需 gost + cc0 OAuth） |
+| `phase0=true` | 抓包前先跑 ingress/admin 只读侦察 |
+| `open_pr=false` | 默认只 capture + diff + 修复建议；显式 true 才开分支提交 |
+
+## 0) 触发条件
+
+- cc 新 patch（约每 2–4 天）
+- 同 OAuth 账号 `usage_logs.user_agent` 混多个 patch
+- `extra usage` / third-party 怀疑指纹而非并发
+- 上次对齐后 cc 升级
+
+## 1) Phase 0（只读，可选）
+
+区分 **ingress**（客户端进来）与 **upstream**（TokenKey 发出）：
+
+1. 各 edge `claude_code_user_agent_version` admin setting
+2. canonical 账号 ingress UA cohort（120m 窗）
+3. 编译默认：`DefaultClaudeCodeUserAgentVersion`、`CLICurrentVersion`
+
+**不在 Phase 0 改代码。**
+
+## 2) Ground truth 采集
+
+### 2.1 环境
+
+```bash
+source ~/.config/cc0/env   # CC0_GOST_HTTP_PORT, CC0_USER_OVERLAY, …
+~/.local/bin/claude --version   # TLS 采集默认用这个
+cc0-here --version              # HTTP mitm 路径用这个（需 gost + OAuth）
+```
+
+TLS 打 collector **不需要** gost；HTTP mitm 打 `api.anthropic.com` **必须** cc0-here（或 `CC0_HTTP_CLAUDE_BIN`）。
+
+Desktop 形状不同则 **`claude0-here`** 另抓一条 HTTP（本脚本默认 CLI）。
+
+### 2.2 一键采集 + diff
+
+```bash
+cd "$REPO_ROOT"
+
+# TLS only（最低门槛；ja3 + collector 侧 stainless/UA）
+bash ops/anthropic/capture-cc-fingerprint.sh capture
+
+# TLS + HTTP（mitm：anthropic-beta 顺序 + X-Stainless-*）
+bash ops/anthropic/capture-cc-fingerprint.sh capture --http
+```
+
+产出（默认 `$REPO_ROOT/.tls_list/`，gitignore）：
+
+- `*cc-capture.tls-observed.json` — collector `fingerprints[0]`
+- `*cc-capture.bundle.json` — diff 输入
+- 终端打印 `capture_cc_fingerprint.py diff` 报告
+
+### 2.3 仅 diff 已有 bundle
+
+```bash
+python3 ops/anthropic/capture_cc_fingerprint.py diff --bundle .tls_list/YYYYMMDD…-cc-capture.bundle.json
+python3 ops/anthropic/capture_cc_fingerprint.py check --bundle .tls_list/….bundle.json
+# exit 1 = 有关键 mismatch，需修代码或 TLS profile
+```
+
+### 2.4 手工组装 bundle（已有 hook 产物）
+
+```bash
+python3 ops/anthropic/capture_cc_fingerprint.py bundle-from-artifacts \
+  --tls-json .tls_list/20260527T….capture.json \
+  --http-log /tmp/http.log \
+  --cc-version 2.1.152 \
+  --out .tls_list/manual.bundle.json
+```
+
+## 3) 解读 diff 报告
+
+| 字段 | mismatch 含义 | 动作 |
+|---|---|---|
+| `tls.ja3_*` | ClientHello 变了 | 更新 `deploy/aws/stage0/tk_canonical_cc_oauth.json` → `manage-anthropic-config.py apply` |
+| `canonical.user_agent_version` | compile default 落后 | `identity_service_tk_canonical_http.go` + admin setting |
+| `mimic.cli_version` / mimic UA | mimic 路径落后 | `constants.go` `CLICurrentVersion` + `DefaultHeaders` + `identity_service.go` |
+| `*.stainless_package_version` | **不能从 UA 推断** | 以 mitm/collector 实测为准（#423：0.94.0） |
+| `betas.sonnet_mimicry` / `haiku_mimicry` | token 集合或**顺序**错 | `FullClaudeCode*MimicryBetas()` + `constants_test.go` |
+
+**ja3 相同 → 不改 DB cipher/extension 体**；只更新 profile description 里的 cc 版本说明即可。
+
+## 4) 代码修复清单（HTTP-only 型，PR #423 型）
+
+1. `backend/internal/pkg/claude/constants.go` — beta、`DefaultHeaders`、`CLICurrentVersion`
+2. `backend/internal/service/identity_service_tk_canonical_http.go` — `DefaultClaudeCodeUserAgentVersion`、`canonicalHTTPObservedStatic`
+3. `backend/internal/service/identity_service.go` — mimic `defaultFingerprint`
+4. `backend/internal/service/gateway_service.go` — Haiku/Sonnet mimic beta；**注释必须与抓包一致**
+5. `backend/internal/pkg/claude/constants_test.go` — 抓包顺序回归
+6. `scripts/sentinels/gateway-tk.json` — beta registry 锚点
+7. `ops/stage0/smoke_lib.sh` — smoke UA 默认
+8. `docs/spec-delta-cc-<patch>.md` — Evidence 段写 ja3/stainless/beta 实测值
+
+## 5) 验证与 PR
+
+```bash
+go test -tags=unit ./internal/pkg/claude/... -run TestFullClaudeCode
+go test -tags=unit ./internal/service/... -run 'TestGatewayService_getBetaHeader|TestNormalizeClaudeOAuthRequestBody_Haiku'
+python3 -m unittest discover -s ops/anthropic -p 'test_capture_cc_fingerprint.py' -t ops/anthropic
+./scripts/preflight.sh
+```
+
+分支：`feature/cc-canonical-ua-beta-<patch>`
+
+PR body：`Summary` / `Risk`（常规 HTTP 指纹；ja3 未变则无 migration）/ `Validation`（含 bundle path 或 Evidence 数值）
+
+合并后：
+
+1. Admin PATCH `claude_code_user_agent_version=<patch>`（canonical，无需 redeploy）
+2. Release + deploy（mimic compile default）
+3. Sonnet + Haiku smoke；24h `extra usage` 错误预算
+
+## 6) 禁止事项
+
+- 未抓包就改 beta 列表或 stainless 版本
+- 假设「Haiku 不需要 claude-code beta」（必须以 mitm 为准）
+- 从 2.1.142 ja3 推断 2.1.152 ja3（必须 2.1.Z 实测）
+- ja3 变了却只改 HTTP 常量
+- 注释与 `FullClaudeCodeHaikuMimicryBetas()` 矛盾
+
+## 7) 流程图
+
+```text
+Phase0(可选) → capture [--http] → bundle.json
+    → capture_cc_fingerprint.py check
+    → [ja3变?] manage-anthropic-config apply
+    → [HTTP drift?] constants + identity + gateway + tests
+    → spec-delta → preflight → PR → merge → admin UA → deploy → smoke
+```

--- a/.cursor/skills/tokenkey-cc-fingerprint-alignment/SKILL.md
+++ b/.cursor/skills/tokenkey-cc-fingerprint-alignment/SKILL.md
@@ -23,7 +23,7 @@ description: >-
 | TLS collector 采集 ClientHello | 机械 | `bash ops/anthropic/capture-cc-fingerprint.sh capture` |
 | HTTP mitm 采集 `/v1/messages` headers | 机械 | `bash ops/anthropic/capture-cc-fingerprint.sh capture --http` |
 | bundle 组装 + diff + `--check` 门禁 | 机械 | `capture_cc_fingerprint.py bundle-from-artifacts` / `diff` / `check` |
-| Phase 0 ingress cohort / admin UA | 机械 | `ops/observability/probe-us1-cc-ua-setting.sh` 等（可选） |
+| Phase 0 ingress cohort / admin UA | 机械 | `ops/observability/run-probe.sh` + admin settings / `usage_logs`（见 `tokenkey-online-log-troubleshooting` skill） |
 | ja3 变更 → TLS profile SQL apply | 机械 | `ops/anthropic/manage-anthropic-config.py plan/apply/verify` |
 | 代码修复位点（constants / identity / gateway） | 判断 + 清单 | 本 skill §4 |
 | 是否发版 / admin PATCH 先后 | 判断 | `tokenkey-stage0-release-rollout` skill |

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -341,6 +341,7 @@ section only records sub2api-specific choices.
 
 - **Stage0 发布与 rollout：** [.cursor/skills/tokenkey-stage0-release-rollout/SKILL.md](.cursor/skills/tokenkey-stage0-release-rollout/SKILL.md) — `main` → VERSION/tag → `release.yml` → `deploy-stage0` prod 与 `deploy-edge-stage0` Edge rollout → 烟测。
 - **本机 Stage0 Docker：** [.cursor/skills/tokenkey-stage0-local-deploy/SKILL.md](.cursor/skills/tokenkey-stage0-local-deploy/SKILL.md) — 与 `deploy/aws/stage0` 对齐的 compose、`AUTO_SETUP`、默认 `REPO_ROOT` / sibling `new-api` / `.cache` 路径见该 skill。
+- **cc 指纹对齐（抓包 → diff → PR）：** [.cursor/skills/tokenkey-cc-fingerprint-alignment/SKILL.md](.cursor/skills/tokenkey-cc-fingerprint-alignment/SKILL.md) — `capture-cc-fingerprint.sh` + `capture_cc_fingerprint.py`；cc0-here 实机 TLS/HTTP 对照 TokenKey 常量。
 
 ## Key Reference
 

--- a/docs/spec-delta-cc-canonical-ua-beta-2.1.152.md
+++ b/docs/spec-delta-cc-canonical-ua-beta-2.1.152.md
@@ -104,6 +104,9 @@ Run after PR #423 merges and on each deployable edge (prod + edge matrix):
 ### Automated (CI / preflight)
 
 ```bash
+bash ops/anthropic/capture-cc-fingerprint.sh capture          # TLS collector → bundle → diff
+bash ops/anthropic/capture-cc-fingerprint.sh capture --http   # + cc0-here mitm beta/stainless
+python3 ops/anthropic/capture_cc_fingerprint.py check --bundle .tls_list/*-cc-capture.bundle.json
 go test -tags=unit ./internal/pkg/claude/... -run 'TestFullClaudeCode'
 go test -tags=unit ./internal/service/... -run 'TestFullClaudeCode|TestGatewayService_getBetaHeader|TestNormalizeClaudeOAuthRequestBody_Haiku'
 python3 scripts/sentinels/check-gateway-tk.py   # or full ./scripts/preflight.sh

--- a/ops/anthropic/capture-cc-fingerprint.sh
+++ b/ops/anthropic/capture-cc-fingerprint.sh
@@ -111,14 +111,14 @@ run_tls_capture() {
     NODE_TLS_REJECT_UNAUTHORIZED=0 \
     "$claude_bin" --bare --setting-sources local --settings "$settings" \
     -p 'test' --model "$MODEL" --allowedTools '' --max-budget-usd 0.15 \
-    >"$work/claude-tls.out" 2>"$work/claude-tls.err" || true
+    >"$work/claude-tls.out" 2>"$work/claude-tls.err" || true  # preflight-allow: swallow
 
   curl -fsS --max-time 30 "$COLLECTOR_API_ORIGIN/api/latest?token=$token" >"$work/latest.json"
   local count
   count="$(jq -r '.count // 0' "$work/latest.json")"
   if [[ "${count:-0}" == "0" ]]; then
     echo "error: TLS collector recorded no fingerprint (token=$token)" >&2
-    sed -n '1,5p' "$work/claude-tls.err" >&2 || true
+    sed -n '1,5p' "$work/claude-tls.err" >&2 || true  # preflight-allow: swallow
     exit 1
   fi
   jq '.fingerprints[0]' "$work/latest.json" >"$work/tls-observed.json"
@@ -138,7 +138,7 @@ run_http_capture() {
     exit 1
   fi
 
-  pkill -f "mitmdump.*${MITM_PORT}" 2>/dev/null || true
+  pkill -f "mitmdump.*${MITM_PORT}" 2>/dev/null || true  # preflight-allow: swallow
   sleep 1
   : >"$http_log"
   CC_CAPTURE_HTTP_LOG="$http_log" \
@@ -161,14 +161,14 @@ run_http_capture() {
       NO_PROXY="127.0.0.1,localhost" no_proxy="127.0.0.1,localhost" \
       NODE_EXTRA_CA_CERTS="$ca" \
       "$claude_bin" -p 'Reply OK' --model "$model" --max-budget-usd 0.15 --output-format text \
-      </dev/null >"$work/claude-${model##*-}.out" 2>"$work/claude-${model##*-}.err" || true
+      </dev/null >"$work/claude-${model##*-}.out" 2>"$work/claude-${model##*-}.err" || true  # preflight-allow: swallow
   }
 
   run_one_http "$MODEL"
   run_one_http "$SONNET_MODEL"
   sleep 2
-  kill "$mitm_pid" 2>/dev/null || true
-  wait "$mitm_pid" 2>/dev/null || true
+  kill "$mitm_pid" 2>/dev/null || true  # preflight-allow: swallow
+  wait "$mitm_pid" 2>/dev/null || true  # preflight-allow: swallow
 
   if ! grep -q '"anthropic_beta"' "$http_log" 2>/dev/null; then
     echo "error: HTTP mitm log empty — check gost on port $GOST_PORT and cc0-here OAuth" >&2
@@ -228,8 +228,8 @@ cmd_capture() {
   python3 "$PY" bundle-from-artifacts "${bundle_args[@]}"
 
   echo "bundle=$bundle_path"
-  python3 "$PY" diff --bundle "$bundle_path" --check || true
   python3 "$PY" diff --bundle "$bundle_path"
+  python3 "$PY" check --bundle "$bundle_path"
   trap - EXIT
   cleanup_work
 }

--- a/ops/anthropic/capture-cc-fingerprint.sh
+++ b/ops/anthropic/capture-cc-fingerprint.sh
@@ -1,0 +1,259 @@
+#!/usr/bin/env bash
+# Capture real Claude Code (cc0-here) TLS + optional HTTP fingerprints and diff
+# against TokenKey repo constants. Deterministic diff via capture_cc_fingerprint.py.
+set -euo pipefail
+
+REPO_ROOT="$(cd "$(dirname "$0")/../.." && pwd)"
+SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
+PY="$SCRIPT_DIR/capture_cc_fingerprint.py"
+MITM_ADDON="$SCRIPT_DIR/mitm_cc_http_headers.py"
+
+COLLECTOR_ORIGIN="${TOKENKEY_TLS_PROFILE_COLLECTOR_ORIGIN:-https://tls.sub2api.org}"
+COLLECTOR_API_ORIGIN="${TOKENKEY_TLS_PROFILE_COLLECTOR_API_ORIGIN:-https://tls.sub2api.org}"
+MODEL="${TOKENKEY_CC_CAPTURE_MODEL:-claude-haiku-4-5-20251001}"
+SONNET_MODEL="${TOKENKEY_CC_CAPTURE_SONNET_MODEL:-claude-sonnet-4-20250514}"
+OUT_DIR="${TOKENKEY_CC_CAPTURE_OUT_DIR:-$REPO_ROOT/.tls_list}"
+HTTP_CAPTURE="${TOKENKEY_CC_CAPTURE_HTTP:-0}"
+MITM_PORT="${TOKENKEY_CC_CAPTURE_MITM_PORT:-11803}"
+GOST_PORT="${CC0_GOST_HTTP_PORT:-11800}"
+
+usage() {
+  cat <<'EOF'
+Usage:
+  capture-cc-fingerprint.sh capture [--http] [--out-dir DIR]
+  capture-cc-fingerprint.sh diff --bundle PATH [--check]
+  capture-cc-fingerprint.sh check --bundle PATH
+  capture-cc-fingerprint.sh show-baseline
+
+Environment (capture):
+  CC0_USER_OVERLAY          cc0 overlay (default: ~/.cache/cc0/claude-user-overlay)
+  CC0_GOST_HTTP_PORT        gost HTTP listen port (default: 11800)
+  TOKENKEY_CC_CAPTURE_HTTP  1 = also run mitm HTTP capture (or pass --http)
+  CLAUDE_BIN                TLS 采集用 claude（默认 ~/.local/bin/claude）；HTTP 用 cc0-here
+  CC0_HTTP_CLAUDE_BIN       覆盖 HTTP mitm 路径的 launcher（默认 cc0-here）
+  TOKENKEY_CC_CAPTURE_MODEL / TOKENKEY_CC_CAPTURE_SONNET_MODEL
+
+Requires: python3, jq, curl, claude CLI. HTTP capture also needs mitmdump + cc0 gost chain.
+EOF
+}
+
+require_cmd() {
+  command -v "$1" >/dev/null 2>&1 || {
+    echo "error: required command not found: $1" >&2
+    exit 1
+  }
+}
+
+resolve_claude_bin() {
+  if [[ -n "${CLAUDE_BIN:-}" ]]; then
+    echo "$CLAUDE_BIN"
+    return
+  fi
+  if [[ -x "${HOME}/.local/bin/claude" ]]; then
+    echo "${HOME}/.local/bin/claude"
+    return
+  fi
+  if command -v claude >/dev/null 2>&1; then
+    echo "claude"
+    return
+  fi
+  echo "error: set CLAUDE_BIN or install ~/.local/bin/claude" >&2
+  exit 1
+}
+
+resolve_http_claude_bin() {
+  if [[ -n "${CC0_HTTP_CLAUDE_BIN:-}" ]]; then
+    echo "$CC0_HTTP_CLAUDE_BIN"
+    return
+  fi
+  if command -v cc0-here >/dev/null 2>&1; then
+    echo "cc0-here"
+    return
+  fi
+  resolve_claude_bin
+}
+
+run_tls_capture() {
+  local work="$1"
+  local token="$2"
+  local claude_bin="$3"
+  local overlay="${CC0_USER_OVERLAY:-$HOME/.cache/cc0/claude-user-overlay}"
+  local settings="$work/settings.json"
+
+  jq -n \
+    --arg api_base "$COLLECTOR_ORIGIN:8090" \
+    --arg token "$token" \
+    '{
+      env: {
+        CLAUDE_CODE_API_BASE_URL: $api_base,
+        ANTHROPIC_BASE_URL: $api_base,
+        ANTHROPIC_API_KEY: $token,
+        ANTHROPIC_AUTH_TOKEN: $token,
+        TOKENKEY_TLS_PROFILE_CAPTURE_ACTIVE: "1",
+        NODE_TLS_REJECT_UNAUTHORIZED: "0"
+      },
+      hooks: {SessionStart: []},
+      permissions: {allow: [], deny: []}
+    }' >"$settings"
+
+  env -i \
+    PATH="$PATH" \
+    HOME="$work/home" \
+    TERM="${TERM:-xterm}" \
+    SHELL="${SHELL:-/bin/sh}" \
+    CLAUDE_CONFIG_DIR="$overlay" \
+    ANTHROPIC_CONFIG_DIR="$work/anthropic" \
+    CLAUDE_CODE_API_BASE_URL="$COLLECTOR_ORIGIN:8090" \
+    ANTHROPIC_BASE_URL="$COLLECTOR_ORIGIN:8090" \
+    ANTHROPIC_API_KEY="$token" \
+    ANTHROPIC_AUTH_TOKEN="$token" \
+    TOKENKEY_TLS_PROFILE_CAPTURE_ACTIVE=1 \
+    NODE_TLS_REJECT_UNAUTHORIZED=0 \
+    "$claude_bin" --bare --setting-sources local --settings "$settings" \
+    -p 'test' --model "$MODEL" --allowedTools '' --max-budget-usd 0.15 \
+    >"$work/claude-tls.out" 2>"$work/claude-tls.err" || true
+
+  curl -fsS --max-time 30 "$COLLECTOR_API_ORIGIN/api/latest?token=$token" >"$work/latest.json"
+  local count
+  count="$(jq -r '.count // 0' "$work/latest.json")"
+  if [[ "${count:-0}" == "0" ]]; then
+    echo "error: TLS collector recorded no fingerprint (token=$token)" >&2
+    sed -n '1,5p' "$work/claude-tls.err" >&2 || true
+    exit 1
+  fi
+  jq '.fingerprints[0]' "$work/latest.json" >"$work/tls-observed.json"
+}
+
+run_http_capture() {
+  local work="$1"
+  local http_log="$work/http.log"
+  local ca="${HOME}/.mitmproxy/mitmproxy-ca-cert.pem"
+  local mitm_pid=""
+  local claude_bin
+  claude_bin="$(resolve_http_claude_bin)"
+
+  require_cmd mitmdump
+  if [[ ! -f "$ca" ]]; then
+    echo "error: mitm CA missing at $ca — run mitmdump once to generate" >&2
+    exit 1
+  fi
+
+  pkill -f "mitmdump.*${MITM_PORT}" 2>/dev/null || true
+  sleep 1
+  : >"$http_log"
+  CC_CAPTURE_HTTP_LOG="$http_log" \
+    mitmdump --mode "upstream:http://127.0.0.1:${GOST_PORT}" \
+    -s "$MITM_ADDON" --listen-port "$MITM_PORT" \
+    >"$work/mitm.out" 2>"$work/mitm.err" &
+  mitm_pid=$!
+  sleep 2
+
+  local proxy="http://127.0.0.1:${MITM_PORT}"
+  local overlay="${CC0_USER_OVERLAY:-$HOME/.cache/cc0/claude-user-overlay}"
+
+  run_one_http() {
+    local model="$1"
+    env -i \
+      PATH="$PATH" HOME="$HOME" TERM="${TERM:-xterm}" SHELL="${SHELL:-/bin/sh}" \
+      CLAUDE_CONFIG_DIR="$overlay" \
+      HTTP_PROXY="$proxy" HTTPS_PROXY="$proxy" \
+      http_proxy="$proxy" https_proxy="$proxy" \
+      NO_PROXY="127.0.0.1,localhost" no_proxy="127.0.0.1,localhost" \
+      NODE_EXTRA_CA_CERTS="$ca" \
+      "$claude_bin" -p 'Reply OK' --model "$model" --max-budget-usd 0.15 --output-format text \
+      </dev/null >"$work/claude-${model##*-}.out" 2>"$work/claude-${model##*-}.err" || true
+  }
+
+  run_one_http "$MODEL"
+  run_one_http "$SONNET_MODEL"
+  sleep 2
+  kill "$mitm_pid" 2>/dev/null || true
+  wait "$mitm_pid" 2>/dev/null || true
+
+  if ! grep -q '"anthropic_beta"' "$http_log" 2>/dev/null; then
+    echo "error: HTTP mitm log empty — check gost on port $GOST_PORT and cc0-here OAuth" >&2
+    exit 1
+  fi
+  echo "$http_log"
+}
+
+cmd_capture() {
+  local with_http="$HTTP_CAPTURE"
+  while [[ $# -gt 0 ]]; do
+    case "$1" in
+      --http) with_http=1; shift ;;
+      --out-dir) OUT_DIR="$2"; shift 2 ;;
+      *) echo "unknown arg: $1" >&2; usage; exit 1 ;;
+    esac
+  done
+
+  require_cmd python3
+  require_cmd jq
+  require_cmd curl
+  local claude_bin
+  claude_bin="$(resolve_claude_bin)"
+
+  mkdir -p "$OUT_DIR"
+  local stamp cc_version token work tls_capture http_log bundle_path
+  stamp="$(date -u +%Y%m%dT%H%M%SZ)"
+  cc_version="$("$claude_bin" --version 2>/dev/null | awk '{print $1}' || true)"
+  token="tk-cc-capture-${stamp}-$$"
+  work="$(mktemp -d "${TMPDIR:-/tmp}/tk-cc-capture.XXXXXX")"
+  cleanup_work() { rm -rf "$work"; }
+  trap cleanup_work EXIT
+
+  echo "cc_version=${cc_version:-unknown} claude_bin=$claude_bin"
+  run_tls_capture "$work" "$token" "$claude_bin"
+
+  http_log=""
+  if [[ "$with_http" == "1" ]]; then
+    http_log="$(run_http_capture "$work")"
+  fi
+
+  tls_capture="$OUT_DIR/${stamp}-cc-capture.tls-observed.json"
+  cp "$work/tls-observed.json" "$tls_capture"
+
+  bundle_path="$OUT_DIR/${stamp}-cc-capture.bundle.json"
+  bundle_args=(
+    --tls-json "$tls_capture"
+    --out "$bundle_path"
+    --collector "$COLLECTOR_ORIGIN:8090"
+  )
+  if [[ -n "$http_log" ]]; then
+    bundle_args+=(--http-log "$http_log")
+  fi
+  if [[ -n "${cc_version:-}" ]]; then
+    bundle_args+=(--cc-version "$cc_version")
+  fi
+  python3 "$PY" bundle-from-artifacts "${bundle_args[@]}"
+
+  echo "bundle=$bundle_path"
+  python3 "$PY" diff --bundle "$bundle_path" --check || true
+  python3 "$PY" diff --bundle "$bundle_path"
+  trap - EXIT
+  cleanup_work
+}
+
+main() {
+  local cmd="${1:-}"
+  shift || true
+  case "$cmd" in
+    capture) cmd_capture "$@" ;;
+    diff)
+      require_cmd python3
+      exec python3 "$PY" diff "$@"
+      ;;
+    check)
+      require_cmd python3
+      exec python3 "$PY" check "$@"
+      ;;
+    show-baseline)
+      require_cmd python3
+      exec python3 "$PY" show-baseline "$@"
+      ;;
+    -h|--help|"") usage ;;
+    *) echo "unknown command: $cmd" >&2; usage; exit 1 ;;
+  esac
+}
+
+main "$@"

--- a/ops/anthropic/capture_cc_fingerprint.py
+++ b/ops/anthropic/capture_cc_fingerprint.py
@@ -1,0 +1,467 @@
+#!/usr/bin/env python3
+"""Deterministic Claude Code fingerprint capture diff for TokenKey alignment.
+
+Reads a capture bundle (TLS collector + optional HTTP mitm log) and compares it
+against live repo constants (constants.go, identity_service*, tk_canonical JSON).
+
+Subcommands:
+  diff    Compare --bundle to TokenKey baseline; human report on stdout.
+  check   Same as diff but exits 1 when actionable mismatches exist.
+  bundle-from-artifacts  Build bundle JSON from TLS capture + HTTP log files.
+
+stdlib-only except when invoked as __main__ with no network.
+"""
+from __future__ import annotations
+
+import argparse
+import json
+import re
+import sys
+from dataclasses import dataclass
+from datetime import datetime, timezone
+from pathlib import Path
+from typing import Any
+
+SCHEMA_VERSION = 1
+REPO_ROOT = Path(__file__).resolve().parents[2]
+_BETA_CONST_MAP: dict[str, str] | None = None
+CONSTANTS_GO = REPO_ROOT / "backend/internal/pkg/claude/constants.go"
+IDENTITY_CANONICAL_GO = REPO_ROOT / "backend/internal/service/identity_service_tk_canonical_http.go"
+IDENTITY_GO = REPO_ROOT / "backend/internal/service/identity_service.go"
+TLS_PROFILE_JSON = REPO_ROOT / "deploy/aws/stage0/tk_canonical_cc_oauth.json"
+
+# Fields that block merge / require code fix when mismatched.
+CRITICAL_HTTP_FIELDS = frozenset(
+    {
+        "canonical.user_agent_version",
+        "mimic.cli_version",
+        "mimic.stainless_package_version",
+        "canonical.stainless_package_version",
+        "betas.sonnet_mimicry",
+        "betas.haiku_mimicry",
+    }
+)
+
+
+@dataclass(frozen=True)
+class DiffRow:
+    field: str
+    tokenkey: str
+    captured: str
+    status: str  # match | mismatch | missing_capture | missing_tokenkey
+    critical: bool
+    note: str = ""
+
+
+def _read_text(path: Path) -> str:
+    return path.read_text(encoding="utf-8")
+
+
+def _extract_const(go_src: str, name: str) -> str:
+    m = re.search(rf"\b{re.escape(name)}\s*=\s*\"([^\"]*)\"", go_src)
+    if not m:
+        raise ValueError(f"const {name} not found")
+    return m.group(1)
+
+
+def _extract_map_string(go_src: str, key: str) -> str:
+    m = re.search(
+        rf"\"{re.escape(key)}\"\s*:\s*\"([^\"]*)\"",
+        go_src,
+    )
+    if not m:
+        raise ValueError(f"DefaultHeaders key {key!r} not found")
+    return m.group(1)
+
+
+def _extract_go_string_var(go_src: str, field: str) -> str:
+    m = re.search(rf"{re.escape(field)}:\s*\"([^\"]*)\"", go_src)
+    if not m:
+        raise ValueError(f"field {field} not found")
+    return m.group(1)
+
+
+def _extract_beta_slice(go_src: str, func_name: str) -> list[str]:
+    marker = f"func {func_name}() []string {{"
+    start = go_src.find(marker)
+    if start < 0:
+        raise ValueError(f"function {func_name} not found")
+    start += len(marker)
+    end = go_src.find("}", start)
+    body = go_src[start:end]
+    return re.findall(r"Beta[A-Za-z0-9]+", body)
+
+
+def _beta_token_map(constants_src: str) -> dict[str, str]:
+    global _BETA_CONST_MAP
+    if _BETA_CONST_MAP is not None:
+        return _BETA_CONST_MAP
+    mapping: dict[str, str] = {}
+    for m in re.finditer(r"(Beta[A-Za-z0-9]+)\s*=\s*\"([^\"]+)\"", constants_src):
+        mapping[m.group(1)] = m.group(2)
+    _BETA_CONST_MAP = mapping
+    return mapping
+
+
+def _resolve_betas(constants_src: str, func_name: str) -> list[str]:
+    names = _extract_beta_slice(constants_src, func_name)
+    mapping = _beta_token_map(constants_src)
+    return [mapping[n] for n in names]
+
+
+def _ua_version(ua: str) -> str:
+    m = re.search(r"claude-cli/(\d+\.\d+\.\d+)", ua or "")
+    return m.group(1) if m else ""
+
+
+def load_tokenkey_baseline(repo_root: Path | None = None) -> dict[str, Any]:
+    root = repo_root or REPO_ROOT
+    constants_src = _read_text(root / CONSTANTS_GO.relative_to(REPO_ROOT))
+    canonical_src = _read_text(root / IDENTITY_CANONICAL_GO.relative_to(REPO_ROOT))
+    identity_src = _read_text(root / IDENTITY_GO.relative_to(REPO_ROOT))
+    tls_profile = json.loads(_read_text(root / TLS_PROFILE_JSON.relative_to(REPO_ROOT)))
+
+    mimic_ua = _extract_map_string(constants_src, "User-Agent")
+    observed = tls_profile.get("observed") or {}
+
+    return {
+        "tls": {
+            "profile_name": tls_profile.get("name", ""),
+            "ja3_hash": observed.get("ja3_hash", ""),
+            "ja3_raw": observed.get("ja3_raw", ""),
+        },
+        "canonical_http": {
+            "default_version": _extract_const(canonical_src, "DefaultClaudeCodeUserAgentVersion"),
+            "user_agent_shape": "claude-cli/<version> (external, sdk-cli)",
+            "stainless_package_version": _extract_go_string_var(
+                canonical_src, "StainlessPackageVersion"
+            ),
+            "stainless_os": _extract_go_string_var(canonical_src, "StainlessOS"),
+            "stainless_arch": _extract_go_string_var(canonical_src, "StainlessArch"),
+            "stainless_runtime_version": _extract_go_string_var(
+                canonical_src, "StainlessRuntimeVersion"
+            ),
+        },
+        "mimic_http": {
+            "cli_version": _extract_const(constants_src, "CLICurrentVersion"),
+            "user_agent": mimic_ua,
+            "stainless_package_version": _extract_map_string(
+                constants_src, "X-Stainless-Package-Version"
+            ),
+            "stainless_os": _extract_map_string(constants_src, "X-Stainless-OS"),
+        },
+        "mimic_default_fingerprint": {
+            "user_agent": _extract_go_string_var(identity_src, "UserAgent"),
+            "stainless_package_version": _extract_go_string_var(
+                identity_src, "StainlessPackageVersion"
+            ),
+        },
+        "betas": {
+            "sonnet_mimicry": _resolve_betas(constants_src, "FullClaudeCodeMimicryBetas"),
+            "haiku_mimicry": _resolve_betas(constants_src, "FullClaudeCodeHaikuMimicryBetas"),
+        },
+    }
+
+
+def _parse_http_log_line(line: str) -> dict[str, Any] | None:
+    line = line.strip()
+    if not line:
+        return None
+    if line.startswith("CC_CAPTURE "):
+        line = line[len("CC_CAPTURE ") :]
+    try:
+        return json.loads(line)
+    except json.JSONDecodeError:
+        return None
+
+
+def _pick_http_by_model(records: list[dict[str, Any]]) -> dict[str, dict[str, Any]]:
+    out: dict[str, dict[str, Any]] = {}
+    for rec in records:
+        model = (rec.get("model") or "").lower()
+        if "haiku" in model and "haiku" not in out:
+            out["haiku"] = rec
+        elif "haiku" not in model and "sonnet" not in out and model:
+            out["sonnet"] = rec
+    return out
+
+
+def load_http_log(path: Path) -> dict[str, dict[str, Any]]:
+    records: list[dict[str, Any]] = []
+    for line in path.read_text(encoding="utf-8").splitlines():
+        rec = _parse_http_log_line(line)
+        if rec:
+            records.append(rec)
+    return _pick_http_by_model(records)
+
+
+def bundle_from_artifacts(
+    *,
+    cc_version: str,
+    tls_observed: dict[str, Any],
+    http_by_variant: dict[str, dict[str, Any]] | None = None,
+    collector_url: str = "",
+) -> dict[str, Any]:
+    return {
+        "schema_version": SCHEMA_VERSION,
+        "captured_at": datetime.now(timezone.utc).strftime("%Y-%m-%dT%H:%M:%SZ"),
+        "cc_version": cc_version,
+        "collector": collector_url,
+        "tls": {
+            "ja3_hash": tls_observed.get("ja3_hash", ""),
+            "ja3_raw": tls_observed.get("ja3_raw", ""),
+            "user_agent": tls_observed.get("user_agent", ""),
+            "stainless_package_version": tls_observed.get(
+                "stainless_package_version", ""
+            ),
+        },
+        "http": http_by_variant or {},
+    }
+
+
+def load_capture_bundle(path: Path) -> dict[str, Any]:
+    data = json.loads(path.read_text(encoding="utf-8"))
+    if data.get("schema_version") != SCHEMA_VERSION:
+        raise ValueError(f"unsupported bundle schema_version: {data.get('schema_version')}")
+    return data
+
+
+def _beta_list(header: str) -> list[str]:
+    return [p.strip() for p in (header or "").split(",") if p.strip()]
+
+
+def diff_baseline_vs_capture(
+    baseline: dict[str, Any], capture: dict[str, Any]
+) -> list[DiffRow]:
+    rows: list[DiffRow] = []
+
+    cap_tls = capture.get("tls") or {}
+    base_tls = baseline.get("tls") or {}
+    for key in ("ja3_hash", "ja3_raw"):
+        tk = str(base_tls.get(key) or "")
+        cap = str(cap_tls.get(key) or "")
+        if not cap:
+            rows.append(
+                DiffRow(
+                    f"tls.{key}",
+                    tk,
+                    cap,
+                    "missing_capture",
+                    critical=False,
+                    note="Run TLS collector capture",
+                )
+            )
+        elif tk == cap:
+            rows.append(DiffRow(f"tls.{key}", tk, cap, "match", critical=False))
+        else:
+            rows.append(
+                DiffRow(
+                    f"tls.{key}",
+                    tk,
+                    cap,
+                    "mismatch",
+                    critical=True,
+                    note="Update tk_canonical_cc_oauth + manage-anthropic-config apply",
+                )
+            )
+
+    cap_cc = capture.get("cc_version") or _ua_version(cap_tls.get("user_agent", ""))
+    canon_ver = baseline["canonical_http"]["default_version"]
+    mimic_ver = baseline["mimic_http"]["cli_version"]
+    rows.append(
+        DiffRow(
+            "canonical.user_agent_version",
+            canon_ver,
+            cap_cc,
+            "match" if canon_ver == cap_cc else "mismatch",
+            critical=True,
+        )
+    )
+    rows.append(
+        DiffRow(
+            "mimic.cli_version",
+            mimic_ver,
+            cap_cc,
+            "match" if mimic_ver == cap_cc else "mismatch",
+            critical=True,
+        )
+    )
+
+    cap_stainless = str(
+        cap_tls.get("stainless_package_version")
+        or (capture.get("http") or {}).get("haiku", {}).get("x_stainless", {}).get(
+            "X-Stainless-Package-Version", ""
+        )
+        or ""
+    )
+    canon_stainless = baseline["canonical_http"]["stainless_package_version"]
+    mimic_stainless = baseline["mimic_http"]["stainless_package_version"]
+    rows.append(
+        DiffRow(
+            "canonical.stainless_package_version",
+            canon_stainless,
+            cap_stainless,
+            "match" if canon_stainless == cap_stainless else "mismatch",
+            critical=True,
+        )
+    )
+    rows.append(
+        DiffRow(
+            "mimic.stainless_package_version",
+            mimic_stainless,
+            cap_stainless,
+            "match" if mimic_stainless == cap_stainless else "mismatch",
+            critical=True,
+        )
+    )
+
+    http = capture.get("http") or {}
+    for variant, beta_key in (("haiku", "haiku_mimicry"), ("sonnet", "sonnet_mimicry")):
+        rec = http.get(variant)
+        if not rec:
+            rows.append(
+                DiffRow(
+                    f"betas.{beta_key}",
+                    ",".join(baseline["betas"][beta_key]),
+                    "",
+                    "missing_capture",
+                    critical=True,
+                    note=f"Run HTTP mitm capture with --http for {variant}",
+                )
+            )
+            continue
+        tk_betas = baseline["betas"][beta_key]
+        cap_betas = _beta_list(rec.get("anthropic_beta", ""))
+        status = "match" if tk_betas == cap_betas else "mismatch"
+        rows.append(
+            DiffRow(
+                f"betas.{beta_key}",
+                ",".join(tk_betas),
+                ",".join(cap_betas),
+                status,
+                critical=True,
+            )
+        )
+
+    return rows
+
+
+def format_diff_report(rows: list[DiffRow], *, capture_path: str = "") -> str:
+    lines = ["TokenKey cc fingerprint diff"]
+    if capture_path:
+        lines.append(f"capture: {capture_path}")
+    mismatches = [r for r in rows if r.status == "mismatch" and r.critical]
+    missing = [r for r in rows if r.status == "missing_capture" and r.critical]
+    matches = [r for r in rows if r.status == "match"]
+
+    lines.append(f"match={len(matches)} mismatch={len(mismatches)} missing_capture={len(missing)}")
+    lines.append("")
+    for r in rows:
+        flag = {"match": "OK", "mismatch": "FAIL", "missing_capture": "SKIP"}.get(
+            r.status, r.status
+        )
+        crit = " [critical]" if r.critical and r.status != "match" else ""
+        lines.append(f"{flag}{crit} {r.field}")
+        if r.status != "match":
+            lines.append(f"  tokenkey: {r.tokenkey[:200]}")
+            lines.append(f"  captured: {r.captured[:200]}")
+            if r.note:
+                lines.append(f"  note: {r.note}")
+    if mismatches:
+        lines.append("")
+        lines.append("action: update backend/internal/pkg/claude/constants.go,")
+        lines.append("  identity_service*.go, gateway_service.go mimic path; add constants_test;")
+        lines.append("  run preflight; open docs/spec-delta-cc-<patch>.md PR.")
+    tls_mismatch = any(r.field.startswith("tls.") and r.status == "mismatch" for r in rows)
+    if tls_mismatch:
+        lines.append("")
+        lines.append("action_tls: ja3 changed — update deploy/aws/stage0/tk_canonical_cc_oauth.json")
+        lines.append("  then ops/anthropic/manage-anthropic-config.py plan/apply on edges.")
+    return "\n".join(lines)
+
+
+def has_actionable_mismatch(rows: list[DiffRow]) -> bool:
+    return any(r.status == "mismatch" and r.critical for r in rows)
+
+
+def cmd_diff(args: argparse.Namespace) -> int:
+    baseline = load_tokenkey_baseline(Path(args.repo_root) if args.repo_root else None)
+    bundle = load_capture_bundle(Path(args.bundle))
+    rows = diff_baseline_vs_capture(baseline, bundle)
+    print(format_diff_report(rows, capture_path=str(args.bundle)))
+    if args.check and has_actionable_mismatch(rows):
+        return 1
+    return 0
+
+
+def cmd_bundle_from_artifacts(args: argparse.Namespace) -> int:
+    tls_path = Path(args.tls_json)
+    tls_data = json.loads(tls_path.read_text(encoding="utf-8"))
+    observed = tls_data.get("observed") or tls_data
+    if "fingerprints" in tls_data:
+        observed = (tls_data.get("fingerprints") or [None])[0] or observed
+    http_by_variant: dict[str, dict[str, Any]] = {}
+    if args.http_log:
+        http_by_variant = load_http_log(Path(args.http_log))
+    bundle = bundle_from_artifacts(
+        cc_version=args.cc_version or _ua_version(observed.get("user_agent", "")),
+        tls_observed=observed,
+        http_by_variant=http_by_variant,
+        collector_url=args.collector or "",
+    )
+    out = Path(args.out)
+    out.parent.mkdir(parents=True, exist_ok=True)
+    out.write_text(json.dumps(bundle, indent=2, sort_keys=True) + "\n", encoding="utf-8")
+    print(out)
+    return 0
+
+
+def cmd_show_baseline(_args: argparse.Namespace) -> int:
+    baseline = load_tokenkey_baseline()
+    print(json.dumps(baseline, indent=2, sort_keys=True))
+    return 0
+
+
+def build_parser() -> argparse.ArgumentParser:
+    p = argparse.ArgumentParser(description=__doc__)
+    sub = p.add_subparsers(dest="cmd", required=True)
+
+    diff = sub.add_parser("diff", help="Compare capture bundle to TokenKey baseline")
+    diff.add_argument("--bundle", required=True, help="Capture bundle JSON path")
+    diff.add_argument("--repo-root", default="", help="Repo root override")
+    diff.add_argument(
+        "--check",
+        action="store_true",
+        help="Exit 1 when critical mismatches exist",
+    )
+    diff.set_defaults(func=cmd_diff)
+
+    check = sub.add_parser("check", help="diff --check shorthand")
+    check.add_argument("--bundle", required=True)
+    check.add_argument("--repo-root", default="")
+    check.set_defaults(func=lambda a: cmd_diff(argparse.Namespace(**{**vars(a), "check": True})))
+
+    bfa = sub.add_parser(
+        "bundle-from-artifacts",
+        help="Build bundle JSON from TLS capture file + optional HTTP log",
+    )
+    bfa.add_argument("--tls-json", required=True)
+    bfa.add_argument("--http-log", default="")
+    bfa.add_argument("--cc-version", default="")
+    bfa.add_argument("--collector", default="")
+    bfa.add_argument("--out", required=True)
+    bfa.set_defaults(func=cmd_bundle_from_artifacts)
+
+    show = sub.add_parser("show-baseline", help="Print TokenKey baseline JSON")
+    show.set_defaults(func=cmd_show_baseline)
+    return p
+
+
+def main(argv: list[str] | None = None) -> int:
+    parser = build_parser()
+    args = parser.parse_args(argv)
+    return args.func(args)
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/ops/anthropic/capture_cc_fingerprint.py
+++ b/ops/anthropic/capture_cc_fingerprint.py
@@ -175,14 +175,21 @@ def _parse_http_log_line(line: str) -> dict[str, Any] | None:
         return None
 
 
+def _http_variant(model: str) -> str | None:
+    model_l = (model or "").lower()
+    if "haiku" in model_l:
+        return "haiku"
+    if model_l:
+        return "sonnet"
+    return None
+
+
 def _pick_http_by_model(records: list[dict[str, Any]]) -> dict[str, dict[str, Any]]:
     out: dict[str, dict[str, Any]] = {}
     for rec in records:
-        model = (rec.get("model") or "").lower()
-        if "haiku" in model and "haiku" not in out:
-            out["haiku"] = rec
-        elif "haiku" not in model and "sonnet" not in out and model:
-            out["sonnet"] = rec
+        variant = _http_variant(str(rec.get("model") or ""))
+        if variant and variant not in out:
+            out[variant] = rec
     return out
 
 
@@ -274,7 +281,7 @@ def diff_baseline_vs_capture(
             canon_ver,
             cap_cc,
             "match" if canon_ver == cap_cc else "mismatch",
-            critical=True,
+            critical="canonical.user_agent_version" in CRITICAL_HTTP_FIELDS,
         )
     )
     rows.append(
@@ -283,7 +290,7 @@ def diff_baseline_vs_capture(
             mimic_ver,
             cap_cc,
             "match" if mimic_ver == cap_cc else "mismatch",
-            critical=True,
+            critical="mimic.cli_version" in CRITICAL_HTTP_FIELDS,
         )
     )
 
@@ -302,7 +309,7 @@ def diff_baseline_vs_capture(
             canon_stainless,
             cap_stainless,
             "match" if canon_stainless == cap_stainless else "mismatch",
-            critical=True,
+            critical="canonical.stainless_package_version" in CRITICAL_HTTP_FIELDS,
         )
     )
     rows.append(
@@ -311,7 +318,7 @@ def diff_baseline_vs_capture(
             mimic_stainless,
             cap_stainless,
             "match" if mimic_stainless == cap_stainless else "mismatch",
-            critical=True,
+            critical="mimic.stainless_package_version" in CRITICAL_HTTP_FIELDS,
         )
     )
 
@@ -325,7 +332,7 @@ def diff_baseline_vs_capture(
                     ",".join(baseline["betas"][beta_key]),
                     "",
                     "missing_capture",
-                    critical=True,
+                    critical=f"betas.{beta_key}" in CRITICAL_HTTP_FIELDS,
                     note=f"Run HTTP mitm capture with --http for {variant}",
                 )
             )
@@ -339,7 +346,7 @@ def diff_baseline_vs_capture(
                 ",".join(tk_betas),
                 ",".join(cap_betas),
                 status,
-                critical=True,
+                critical=f"betas.{beta_key}" in CRITICAL_HTTP_FIELDS,
             )
         )
 

--- a/ops/anthropic/mitm_cc_http_headers.py
+++ b/ops/anthropic/mitm_cc_http_headers.py
@@ -1,0 +1,56 @@
+"""mitmproxy addon: log Claude Code HTTP headers on api.anthropic.com /v1/messages.
+
+Used by ops/anthropic/capture-cc-fingerprint.sh. Writes one JSON object per line
+to the path in env CC_CAPTURE_HTTP_LOG (append mode).
+"""
+from __future__ import annotations
+
+import json
+import os
+
+from mitmproxy import http
+
+
+def _log_path() -> str | None:
+    path = os.environ.get("CC_CAPTURE_HTTP_LOG", "").strip()
+    return path or None
+
+
+def request(flow: http.HTTPFlow) -> None:
+    if "anthropic.com" not in (flow.request.host or ""):
+        return
+    path = flow.request.path.split("?", 1)[0]
+    if path != "/v1/messages" and not path.startswith("/v1/messages"):
+        return
+
+    hdrs = flow.request.headers
+    stainless = {
+        k: hdrs[k]
+        for k in hdrs
+        if k.lower().startswith("x-stainless")
+    }
+    body = flow.request.get_text(strict=False) or ""
+    model = ""
+    try:
+        import json as _json
+
+        parsed = _json.loads(body) if body.strip().startswith("{") else {}
+        model = str(parsed.get("model") or "")
+    except Exception:
+        model = ""
+
+    record = {
+        "path": path,
+        "model": model,
+        "user_agent": hdrs.get("user-agent", ""),
+        "anthropic_beta": hdrs.get("anthropic-beta", ""),
+        "x_stainless": stainless,
+        "x_app": hdrs.get("x-app", ""),
+    }
+    line = json.dumps(record, ensure_ascii=False, sort_keys=True)
+
+    log_path = _log_path()
+    if log_path:
+        with open(log_path, "a", encoding="utf-8") as fh:
+            fh.write(line + "\n")
+    print("CC_CAPTURE " + line, flush=True)

--- a/ops/anthropic/test_capture_cc_fingerprint.py
+++ b/ops/anthropic/test_capture_cc_fingerprint.py
@@ -1,0 +1,118 @@
+#!/usr/bin/env python3
+"""Unit tests for ops/anthropic/capture_cc_fingerprint.py (stdlib unittest)."""
+from __future__ import annotations
+
+import importlib.util
+import json
+import pathlib
+import tempfile
+import unittest
+
+_MOD_PATH = pathlib.Path(__file__).resolve().parent / "capture_cc_fingerprint.py"
+_spec = importlib.util.spec_from_file_location("capture_cc_fingerprint", _MOD_PATH)
+mod = importlib.util.module_from_spec(_spec)
+assert _spec and _spec.loader
+import sys
+
+sys.modules[_spec.name] = mod
+_spec.loader.exec_module(mod)
+
+
+class CaptureCCFingerprintTest(unittest.TestCase):
+    def test_load_tokenkey_baseline_has_expected_keys(self) -> None:
+        baseline = mod.load_tokenkey_baseline(mod.REPO_ROOT)
+        self.assertEqual(baseline["tls"]["ja3_hash"], "d871d02cecbde59abbf8f4806134addf")
+        self.assertEqual(baseline["canonical_http"]["default_version"], "2.1.152")
+        self.assertEqual(baseline["mimic_http"]["stainless_package_version"], "0.94.0")
+        self.assertIn("claude-code-20250219", baseline["betas"]["sonnet_mimicry"])
+        self.assertIn("claude-code-20250219", baseline["betas"]["haiku_mimicry"])
+        self.assertNotIn("effort-2025-11-24", baseline["betas"]["haiku_mimicry"])
+
+    def test_diff_all_match_when_capture_matches_baseline(self) -> None:
+        baseline = mod.load_tokenkey_baseline(mod.REPO_ROOT)
+        capture = {
+            "schema_version": 1,
+            "cc_version": baseline["canonical_http"]["default_version"],
+            "tls": {
+                "ja3_hash": baseline["tls"]["ja3_hash"],
+                "ja3_raw": baseline["tls"]["ja3_raw"],
+                "stainless_package_version": baseline["canonical_http"]["stainless_package_version"],
+            },
+            "http": {
+                "haiku": {
+                    "anthropic_beta": ",".join(baseline["betas"]["haiku_mimicry"]),
+                },
+                "sonnet": {
+                    "anthropic_beta": ",".join(baseline["betas"]["sonnet_mimicry"]),
+                },
+            },
+        }
+        rows = mod.diff_baseline_vs_capture(baseline, capture)
+        self.assertFalse(mod.has_actionable_mismatch(rows))
+        self.assertTrue(all(r.status == "match" for r in rows if not r.field.startswith("mimic.cli")))
+
+    def test_diff_flags_stainless_mismatch(self) -> None:
+        baseline = mod.load_tokenkey_baseline(mod.REPO_ROOT)
+        capture = {
+            "schema_version": 1,
+            "cc_version": baseline["canonical_http"]["default_version"],
+            "tls": {
+                "ja3_hash": baseline["tls"]["ja3_hash"],
+                "ja3_raw": baseline["tls"]["ja3_raw"],
+                "stainless_package_version": "0.70.0",
+            },
+            "http": {},
+        }
+        rows = mod.diff_baseline_vs_capture(baseline, capture)
+        self.assertTrue(mod.has_actionable_mismatch(rows))
+        stainless_rows = [r for r in rows if "stainless" in r.field]
+        self.assertTrue(any(r.status == "mismatch" for r in stainless_rows))
+
+    def test_diff_flags_ja3_mismatch_with_tls_action_note(self) -> None:
+        baseline = mod.load_tokenkey_baseline(mod.REPO_ROOT)
+        capture = {
+            "schema_version": 1,
+            "cc_version": baseline["canonical_http"]["default_version"],
+            "tls": {"ja3_hash": "deadbeef", "ja3_raw": "771"},
+            "http": {},
+        }
+        rows = mod.diff_baseline_vs_capture(baseline, capture)
+        report = mod.format_diff_report(rows)
+        self.assertIn("action_tls", report)
+        ja3_row = next(r for r in rows if r.field == "tls.ja3_hash")
+        self.assertEqual(ja3_row.status, "mismatch")
+
+    def test_bundle_roundtrip_write_and_load(self) -> None:
+        baseline = mod.load_tokenkey_baseline(mod.REPO_ROOT)
+        bundle = mod.bundle_from_artifacts(
+            cc_version="2.1.152",
+            tls_observed={
+                "ja3_hash": baseline["tls"]["ja3_hash"],
+                "ja3_raw": baseline["tls"]["ja3_raw"],
+                "stainless_package_version": "0.94.0",
+            },
+            http_by_variant={
+                "haiku": {"anthropic_beta": ",".join(baseline["betas"]["haiku_mimicry"])},
+            },
+        )
+        with tempfile.TemporaryDirectory() as tmp:
+            path = pathlib.Path(tmp) / "bundle.json"
+            path.write_text(json.dumps(bundle), encoding="utf-8")
+            loaded = mod.load_capture_bundle(path)
+            self.assertEqual(loaded["cc_version"], "2.1.152")
+
+    def test_load_http_log_parses_cc_capture_prefix(self) -> None:
+        line = (
+            'CC_CAPTURE {"model":"claude-haiku-4-5-20251001",'
+            '"anthropic_beta":"oauth-2025-04-20,claude-code-20250219"}'
+        )
+        with tempfile.TemporaryDirectory() as tmp:
+            log = pathlib.Path(tmp) / "http.log"
+            log.write_text(line + "\n", encoding="utf-8")
+            picked = mod.load_http_log(log)
+            self.assertIn("haiku", picked)
+            self.assertIn("oauth-2025-04-20", picked["haiku"]["anthropic_beta"])
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Summary
- Add `.cursor/skills/tokenkey-cc-fingerprint-alignment/SKILL.md` — runbook for cc0/cc0-here capture → TokenKey diff → fix → PR (codifies PR #423 workflow).
- Add `ops/anthropic/capture-cc-fingerprint.sh` — TLS collector capture + optional cc0-here mitm HTTP capture.
- Add `ops/anthropic/capture_cc_fingerprint.py` — deterministic baseline load + bundle diff/check (preflight unittest covered).
- Add `ops/anthropic/mitm_cc_http_headers.py` — mitmproxy addon for `/v1/messages` header logging.

## Risk
Low — ops/skill/docs only; no runtime gateway behavior change.

## Validation
- `python3 -m unittest discover -s ops/anthropic -p 'test_capture_cc_fingerprint.py' -t ops/anthropic`
- `bash ops/anthropic/capture-cc-fingerprint.sh capture` (TLS-only, ja3/stainless/UA all OK on cc 2.1.152)
- `./scripts/preflight.sh`

Made with [Cursor](https://cursor.com)