### PR TITLE
feat(ops): add cc beta-consistency multi-request HTTP capture tool

### DIFF
--- a/.cursor/skills/tokenkey-cc-fingerprint-alignment/SKILL.md
+++ b/.cursor/skills/tokenkey-cc-fingerprint-alignment/SKILL.md
@@ -60,6 +60,7 @@ TOKENKEY_CC_DAILY_DRY_RUN=1 bash ops/anthropic/cc_fingerprint_open_tls_drift_pr.
 | 读取 TokenKey baseline | 机械 | `python3 ops/anthropic/capture_cc_fingerprint.py show-baseline` |
 | TLS collector 采集 ClientHello | 机械 | `bash ops/anthropic/capture-cc-fingerprint.sh capture` |
 | HTTP mitm 采集 `/v1/messages` headers | 机械 | `bash ops/anthropic/capture-cc-fingerprint.sh capture --http` |
+| 多请求 beta 一致性校验（haiku/sonnet/opus 各 N 次） | 机械 | `bash ops/anthropic/capture-http-comprehensive.sh` |
 | bundle 组装 + diff + `--check` 门禁 | 机械 | `capture_cc_fingerprint.py` / `check-tls` |
 | 每日 TLS 漂移开 PR | 机械 | `ops/anthropic/cc_fingerprint_open_tls_drift_pr.sh` |
 | Phase 0 ingress cohort / admin UA | 机械 | `ops/observability/run-probe.sh` + admin settings |
@@ -144,6 +145,17 @@ plain claude + CC0_USER_OVERLAY OAuth
 - 使用 `NODE_EXTRA_CA_CERTS` + `NODE_TLS_REJECT_UNAUTHORIZED=0`（**不走 cc0-here**，因 cc0 白名单不转发 CA）。
 - 采集前 `check env` 会校验 gost 在 `CC0_GOST_HTTP_PORT` 监听。
 - 覆盖 launcher：`CC0_HTTP_CLAUDE_BIN=/path/to/custom`（默认 `http_capture_invoke.sh`）。
+
+### 2.5 多请求 beta 一致性校验（可选，深查 beta 抖动）
+
+`capture --http` 是**单次**抓包做 diff/check。当怀疑 cc 对同一 model **跨请求**发出不一致的 `anthropic-beta`（灰度 / 分裂），用 comprehensive 跨 haiku/sonnet/opus 各跑 N 次并统计每族 beta 是否全一致：
+
+```bash
+bash ops/anthropic/capture-http-comprehensive.sh
+# 调整每族请求数：TOKENKEY_CC_CAPTURE_HAIKU_N / _SONNET_N / _OPUS_N（默认 3/3/2）
+```
+
+输出每个 model 族的 `N requests, M unique beta header(s)` + `OK/WARN`；末尾自动用最新 `tls-observed` bundle 跑一次 repo `diff` / `check`。复用 §2.4 同一条 mitm 链（gost + cc0 OAuth）。
 
 ## 3) 解读 diff 报告
 

--- a/ops/anthropic/capture-http-comprehensive.sh
+++ b/ops/anthropic/capture-http-comprehensive.sh
@@ -1,0 +1,145 @@
+#!/usr/bin/env bash
+# Multi-request HTTP mitm capture for beta consistency check (Haiku / Sonnet / Opus).
+set -euo pipefail
+
+REPO_ROOT="$(cd "$(dirname "$0")/../.." && pwd)"
+SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
+HTTP_INVOKE="$SCRIPT_DIR/http_capture_invoke.sh"
+PY="$SCRIPT_DIR/capture_cc_fingerprint.py"
+MITM_ADDON="$SCRIPT_DIR/mitm_cc_http_headers.py"
+OUT_DIR="${TOKENKEY_CC_CAPTURE_OUT_DIR:-$REPO_ROOT/.tls_list}"
+MITM_PORT="${TOKENKEY_CC_CAPTURE_MITM_PORT:-11803}"
+GOST_PORT="${CC0_GOST_HTTP_PORT:-11800}"
+
+# Repeat counts per family (total requests = sum).
+HAIKU_N="${TOKENKEY_CC_CAPTURE_HAIKU_N:-3}"
+SONNET_N="${TOKENKEY_CC_CAPTURE_SONNET_N:-3}"
+OPUS_N="${TOKENKEY_CC_CAPTURE_OPUS_N:-2}"
+
+HAIKU_MODEL="${TOKENKEY_CC_CAPTURE_MODEL:-claude-haiku-4-5-20251001}"
+SONNET_MODEL="${TOKENKEY_CC_CAPTURE_SONNET_MODEL:-claude-sonnet-4-20250514}"
+OPUS_MODEL="${TOKENKEY_CC_CAPTURE_OPUS_MODEL:-claude-opus-4-5-20251101}"
+
+[[ -f "${HOME}/.config/cc0/env" ]] && # shellcheck disable=SC1091
+  source "${HOME}/.config/cc0/env"
+
+require_cmd() { command -v "$1" >/dev/null || { echo "error: missing $1" >&2; exit 1; }; }
+require_cmd mitmdump
+require_cmd python3
+require_cmd jq
+[[ -x "$HTTP_INVOKE" ]] || { echo "error: missing $HTTP_INVOKE (need #427 http_capture_invoke.sh)" >&2; exit 1; }
+
+_cc0_port_open() {
+  python3 - "$1" "$2" <<'PY'
+import socket, sys
+s = socket.socket(); s.settimeout(2)
+try: s.connect((sys.argv[1], int(sys.argv[2])))
+except OSError: raise SystemExit(1)
+finally: s.close()
+PY
+}
+
+host="${CC0_GOST_HTTP_HOST:-127.0.0.1}"
+port="${CC0_GOST_HTTP_PORT:-11800}"
+if ! _cc0_port_open "$host" "$port"; then
+  echo "error: gost not listening on http://${host}:${port}" >&2
+  exit 1
+fi
+
+stamp="$(date -u +%Y%m%dT%H%M%SZ)"
+mkdir -p "$OUT_DIR"
+work="$(mktemp -d "${TMPDIR:-/tmp}/tk-http-multi.XXXXXX")"
+http_log="$OUT_DIR/${stamp}-http-multi.log"
+: >"$http_log"
+
+pkill -f "mitmdump.*${MITM_PORT}" 2>/dev/null || true  # preflight-allow: swallow
+sleep 1
+CC_CAPTURE_HTTP_LOG="$http_log" \
+  mitmdump --mode "upstream:http://127.0.0.1:${GOST_PORT}" \
+  -s "$MITM_ADDON" --listen-port "$MITM_PORT" \
+  >"$work/mitm.out" 2>"$work/mitm.err" &
+mitm_pid=$!
+sleep 2
+
+run_n() {
+  local n="$1" model="$2" label="$3"
+  local i
+  for ((i = 1; i <= n; i++)); do
+    echo "request ${label} ${i}/${n} model=${model}"
+    "$HTTP_INVOKE" --mitm-port "$MITM_PORT" --model "$model" --work-dir "$work" || true  # preflight-allow: swallow
+    sleep 1
+  done
+}
+
+run_n "$HAIKU_N" "$HAIKU_MODEL" haiku
+run_n "$SONNET_N" "$SONNET_MODEL" sonnet
+run_n "$OPUS_N" "$OPUS_MODEL" opus
+
+sleep 2
+kill "$mitm_pid" 2>/dev/null || true  # preflight-allow: swallow
+wait "$mitm_pid" 2>/dev/null || true  # preflight-allow: swallow
+
+lines="$(wc -l <"$http_log" | tr -d ' ')"
+if [[ "${lines:-0}" == "0" ]]; then
+  echo "error: no HTTP records captured" >&2
+  exit 1
+fi
+
+echo "http_log=$http_log (${lines} records)"
+python3 - "$http_log" <<'PY'
+import json, sys
+from collections import defaultdict
+path = sys.argv[1]
+by_variant: dict[str, list[str]] = defaultdict(list)
+for line in open(path, encoding="utf-8"):
+    line = line.strip()
+    if not line:
+        continue
+    if line.startswith("CC_CAPTURE "):
+        line = line[len("CC_CAPTURE ") :]
+    rec = json.loads(line)
+    model = (rec.get("model") or "").lower()
+    beta = rec.get("anthropic_beta") or ""
+    if "haiku" in model:
+        v = "haiku"
+    elif "opus" in model:
+        v = "opus"
+    elif "sonnet" in model:
+        v = "sonnet"
+    else:
+        v = model or "unknown"
+    by_variant[v].append(beta)
+print("=== HTTP capture consistency ===")
+for v, betas in sorted(by_variant.items()):
+    uniq = list(dict.fromkeys(betas))
+    print(f"{v}: {len(betas)} requests, {len(uniq)} unique beta header(s)")
+    for i, b in enumerate(betas, 1):
+        print(f"  [{i}] {b}")
+    if len(uniq) == 1:
+        print(f"  OK all {v} requests identical")
+    else:
+        print(f"  WARN {v} beta headers differ across requests")
+PY
+
+# Pick last TLS bundle or run quick TLS - use latest tls-observed if exists
+tls_json="$(ls -t "$OUT_DIR"/*-cc-capture.tls-observed.json 2>/dev/null | head -1 || true)"
+if [[ -z "$tls_json" ]]; then
+  echo "note: no tls-observed.json; run capture-cc-fingerprint.sh capture for TLS bundle" >&2
+  exit 0
+fi
+
+cc_ver="$(jq -r '.cc_version // empty' "$(ls -t "$OUT_DIR"/*-cc-capture.bundle.json 2>/dev/null | head -1)" 2>/dev/null || true)"
+[[ -z "$cc_ver" ]] && cc_ver="$("$HOME/.local/bin/claude" --version 2>/dev/null | awk '{print $1}' || true)"
+
+bundle="$OUT_DIR/${stamp}-cc-capture.bundle.json"
+python3 "$PY" bundle-from-artifacts \
+  --tls-json "$tls_json" \
+  --http-log "$http_log" \
+  --cc-version "${cc_ver:-unknown}" \
+  --out "$bundle" \
+  --collector "https://tls.sub2api.org:8090"
+
+echo "bundle=$bundle"
+python3 "$PY" diff --bundle "$bundle"
+python3 "$PY" check --bundle "$bundle"
+rm -rf "$work"

--- a/ops/anthropic/capture-http-comprehensive.sh
+++ b/ops/anthropic/capture-http-comprehensive.sh
@@ -122,14 +122,14 @@ for v, betas in sorted(by_variant.items()):
 PY
 
 # Pick last TLS bundle or run quick TLS - use latest tls-observed if exists
-tls_json="$(ls -t "$OUT_DIR"/*-cc-capture.tls-observed.json 2>/dev/null | head -1 || true)"
+tls_json="$(ls -t "$OUT_DIR"/*-cc-capture.tls-observed.json 2>/dev/null | head -1 || true)"  # preflight-allow: swallow
 if [[ -z "$tls_json" ]]; then
   echo "note: no tls-observed.json; run capture-cc-fingerprint.sh capture for TLS bundle" >&2
   exit 0
 fi
 
-cc_ver="$(jq -r '.cc_version // empty' "$(ls -t "$OUT_DIR"/*-cc-capture.bundle.json 2>/dev/null | head -1)" 2>/dev/null || true)"
-[[ -z "$cc_ver" ]] && cc_ver="$("$HOME/.local/bin/claude" --version 2>/dev/null | awk '{print $1}' || true)"
+cc_ver="$(jq -r '.cc_version // empty' "$(ls -t "$OUT_DIR"/*-cc-capture.bundle.json 2>/dev/null | head -1)" 2>/dev/null || true)"  # preflight-allow: swallow
+[[ -z "$cc_ver" ]] && cc_ver="$("$HOME/.local/bin/claude" --version 2>/dev/null | awk '{print $1}' || true)"  # preflight-allow: swallow
 
 bundle="$OUT_DIR/${stamp}-cc-capture.bundle.json"
 python3 "$PY" bundle-from-artifacts \


### PR DESCRIPTION
## Summary
- 将之前未跟踪的本地 helper `ops/anthropic/capture-http-comprehensive.sh` 入库
- 多请求 HTTP mitm 抓包,跨 Haiku/Sonnet/Opus 校验 cc 对每个模型族发出的 `anthropic-beta` header 是否跨请求一致
- 复用 #427 落地的 `http_capture_invoke.sh` / `capture_cc_fingerprint.py` 基建;与 cc-fingerprint-alignment skill 配套

## Test plan
- [x] `scripts/preflight.sh` PASS(纯 ops 脚本,no-web-impact)
- [ ] 在具备 cc0 mitm 环境的机器上跑一次 `bash ops/anthropic/capture-http-comprehensive.sh` 验证抓包+一致性输出

🤖 Generated with [Claude Code](https://claude.com/claude-code)