### PR TITLE
fix(ops): request attribution + optional Responses short-stream buffer

### DIFF
--- a/.cache/upstream/fact-checks.json
+++ b/.cache/upstream/fact-checks.json
@@ -149,7 +149,7 @@
         "backend/internal/service/gateway_forward_as_responses_tk_content_type_test.go",
         "backend/internal/service/gateway_forward_as_chat_completions_tk_content_type_test.go",
         "backend/internal/service/openai_images_responses.go",
-        "scripts/check-buffered-content-type-leak.py"
+        "scripts/checks/buffered-content-type-leak.py"
       ],
       "fixed_if_all_present": [
         "backend/internal/service/openai_gateway_chat_completions.go:Wei-Shaw/sub2api#1311",
@@ -160,7 +160,7 @@
         "backend/internal/service/gateway_forward_as_responses_tk_content_type_test.go:TestHandleResponsesBufferedStreamingResponse_NonStream_ReturnsApplicationJSONContentType",
         "backend/internal/service/gateway_forward_as_chat_completions_tk_content_type_test.go:TestHandleCCBufferedFromAnthropic_NonStream_ReturnsApplicationJSONContentType",
         "backend/internal/service/openai_images_responses.go:Wei-Shaw/sub2api#1311",
-        "scripts/check-buffered-content-type-leak.py:def scan_file"
+        "scripts/checks/buffered-content-type-leak.py:def scan_file"
       ]
     },
     {
@@ -357,13 +357,13 @@
       "fixed_by": [
         "backend/internal/service/openai_gateway_messages.go",
         "backend/internal/service/openai_gateway_messages_tk_terminal_event_test.go",
-        "scripts/terminal-sentinels.json"
+        "scripts/sentinels/terminal.json"
       ],
       "fixed_if_all_present": [
         "backend/internal/service/openai_gateway_messages.go:See upstream Wei-Shaw/sub2api#1322",
         "backend/internal/service/openai_gateway_messages.go:\"response.cancelled\", \"response.canceled\"",
         "backend/internal/service/openai_gateway_messages_tk_terminal_event_test.go:TestIsOpenAICompatResponsesTerminalEvent_FullSet",
-        "scripts/terminal-sentinels.json:openai_compat_responses_terminal_helper"
+        "scripts/sentinels/terminal.json:openai_compat_responses_terminal_helper"
       ]
     },
     {
@@ -376,7 +376,7 @@
       ],
       "fixed_if_all_present": [
         "backend/internal/service/openai_gateway_service.go:upstream Wei-Shaw/sub2api#1318",
-        "backend/internal/service/openai_gateway_service.go:shouldDisable = s.rateLimitService.HandleUpstreamError(ctx, account, resp.StatusCode, resp.Header, body)",
+        "backend/internal/service/openai_gateway_service.go:shouldDisable := s.handleOpenAIAccountUpstreamError(ctx, account, resp.StatusCode, resp.Header, body)",
         "backend/internal/service/openai_oauth_passthrough_test.go:TestOpenAIGatewayService_OpenAIPassthrough_TempUnschedRuleTriggersFailover"
       ]
     },

--- a/backend/internal/config/config.go
+++ b/backend/internal/config/config.go
@@ -810,6 +810,15 @@ type GatewayConfig struct {
 	// MaxLineSize: 上游 SSE 单行最大字节数（0使用默认值）
 	MaxLineSize int `mapstructure:"max_line_size"`
 
+	// ResponsesShortStreamBufferBytes: OpenAI Responses 透传流式的短流缓冲阈值（字节）。
+	// 见 upstream Wei-Shaw/sub2api#2245 的「可选防御性优化」：上游返回 HTTP 200 +
+	// text/event-stream，却在 response.completed 等终止事件前就 EOF 时，严格客户端会
+	// 报 "stream closed before response.completed"。本配置启用后，透传层会把首批正文
+	// 内容暂存到该字节窗口内再下发；若上游在窗口内提前 EOF 且未见终止事件，则触发
+	// failover（干净重试）而非把残缺的 200 短流下发给客户端。0 表示禁用（默认，保持
+	// 现有 prod 行为：preamble 事件仍会缓冲，正文内容仍逐行立即下发）。
+	ResponsesShortStreamBufferBytes int `mapstructure:"responses_short_stream_buffer_bytes"`
+
 	// 是否记录上游错误响应体摘要（避免输出请求内容）
 	LogUpstreamErrorBody bool `mapstructure:"log_upstream_error_body"`
 	// 上游错误响应体记录最大字节数（超过会截断）
@@ -1887,6 +1896,7 @@ func setDefaults() {
 	viper.SetDefault("gateway.max_account_switches_gemini", 3)
 	viper.SetDefault("gateway.force_codex_cli", false)
 	viper.SetDefault("gateway.codex_image_generation_bridge_enabled", false)
+	viper.SetDefault("gateway.responses_short_stream_buffer_bytes", 0)
 	viper.SetDefault("gateway.openai_passthrough_allow_timeout_headers", false)
 	// OpenAI Responses WebSocket（默认开启；可通过 force_http 紧急回滚）
 	viper.SetDefault("gateway.openai_ws.enabled", true)

--- a/backend/internal/repository/ops_repo.go
+++ b/backend/internal/repository/ops_repo.go
@@ -221,7 +221,9 @@ SELECT
   COALESCE(e.error_message, ''),
   e.user_id,
   COALESCE(u.email, ''),
+  COALESCE(u.username, ''),
   e.api_key_id,
+  COALESCE(k.name, ''),
   e.account_id,
   COALESCE(a.name, ''),
   e.group_id,
@@ -239,6 +241,7 @@ LEFT JOIN accounts a ON e.account_id = a.id
 LEFT JOIN groups g ON e.group_id = g.id
 LEFT JOIN users u ON e.user_id = u.id
 LEFT JOIN users u2 ON e.resolved_by_user_id = u2.id
+LEFT JOIN api_keys k ON e.api_key_id = k.id
 ` + where + `
 ORDER BY e.created_at DESC
 LIMIT $` + itoa(len(args)+1) + ` OFFSET $` + itoa(len(args)+2)
@@ -261,6 +264,8 @@ LIMIT $` + itoa(len(args)+1) + ` OFFSET $` + itoa(len(args)+2)
 		var groupID sql.NullInt64
 		var groupName string
 		var userEmail string
+		var username string
+		var apiKeyName string
 		var resolvedAt sql.NullTime
 		var resolvedBy sql.NullInt64
 		var resolvedByName string
@@ -285,7 +290,9 @@ LIMIT $` + itoa(len(args)+1) + ` OFFSET $` + itoa(len(args)+2)
 			&item.Message,
 			&userID,
 			&userEmail,
+			&username,
 			&apiKeyID,
+			&apiKeyName,
 			&accountID,
 			&accountName,
 			&groupID,
@@ -320,10 +327,12 @@ LIMIT $` + itoa(len(args)+1) + ` OFFSET $` + itoa(len(args)+2)
 			item.UserID = &v
 		}
 		item.UserEmail = userEmail
+		item.Username = username
 		if apiKeyID.Valid {
 			v := apiKeyID.Int64
 			item.APIKeyID = &v
 		}
+		item.APIKeyName = apiKeyName
 		if accountID.Valid {
 			v := accountID.Int64
 			item.AccountID = &v
@@ -386,7 +395,9 @@ SELECT
   e.is_business_limited,
   e.user_id,
   COALESCE(u.email, ''),
+  COALESCE(u.username, ''),
   e.api_key_id,
+  COALESCE(k.name, ''),
   e.account_id,
   COALESCE(a.name, ''),
   e.group_id,
@@ -409,6 +420,7 @@ FROM ops_error_logs e
 LEFT JOIN users u ON e.user_id = u.id
 LEFT JOIN accounts a ON e.account_id = a.id
 LEFT JOIN groups g ON e.group_id = g.id
+LEFT JOIN api_keys k ON e.api_key_id = k.id
 WHERE e.id = $1
 LIMIT 1`
 
@@ -454,7 +466,9 @@ LIMIT 1`
 		&out.IsBusinessLimited,
 		&userID,
 		&out.UserEmail,
+		&out.Username,
 		&apiKeyID,
+		&out.APIKeyName,
 		&accountID,
 		&out.AccountName,
 		&groupID,

--- a/backend/internal/repository/ops_repo_request_details.go
+++ b/backend/internal/repository/ops_repo_request_details.go
@@ -102,10 +102,20 @@ WITH combined AS (
     ul.api_key_id AS api_key_id,
     ul.account_id AS account_id,
     ul.group_id AS group_id,
+    -- TK: See upstream Wei-Shaw/sub2api#2410 — surface human-readable request
+    -- attribution (who is calling) next to the raw IDs so ops can locate the
+    -- user/key/account without a manual DB lookup.
+    COALESCE(u.email, '') AS user_email,
+    COALESCE(u.username, '') AS username,
+    COALESCE(k.name, '') AS api_key_name,
+    COALESCE(g.name, '') AS group_name,
+    COALESCE(a.name, '') AS account_name,
     ul.stream AS stream
   FROM usage_logs ul
   LEFT JOIN groups g ON g.id = ul.group_id
   LEFT JOIN accounts a ON a.id = ul.account_id
+  LEFT JOIN users u ON u.id = ul.user_id
+  LEFT JOIN api_keys k ON k.id = ul.api_key_id
   WHERE ul.created_at >= $1 AND ul.created_at < $2
 
   UNION ALL
@@ -126,10 +136,17 @@ WITH combined AS (
     o.api_key_id AS api_key_id,
     o.account_id AS account_id,
     o.group_id AS group_id,
+    COALESCE(u.email, '') AS user_email,
+    COALESCE(u.username, '') AS username,
+    COALESCE(k.name, '') AS api_key_name,
+    COALESCE(g.name, '') AS group_name,
+    COALESCE(a.name, '') AS account_name,
     o.stream AS stream
   FROM ops_error_logs o
   LEFT JOIN groups g ON g.id = o.group_id
   LEFT JOIN accounts a ON a.id = o.account_id
+  LEFT JOIN users u ON u.id = o.user_id
+  LEFT JOIN api_keys k ON k.id = o.api_key_id
   WHERE o.created_at >= $1 AND o.created_at < $2
     AND COALESCE(o.status_code, 0) >= 400
 )
@@ -175,6 +192,11 @@ SELECT
   api_key_id,
   account_id,
   group_id,
+  user_email,
+  username,
+  api_key_name,
+  group_name,
+  account_name,
   stream
 FROM combined
 %s
@@ -226,6 +248,12 @@ LIMIT $%d OFFSET $%d
 			accountID sql.NullInt64
 			groupID   sql.NullInt64
 
+			userEmail   sql.NullString
+			username    sql.NullString
+			apiKeyName  sql.NullString
+			groupName   sql.NullString
+			accountName sql.NullString
+
 			stream bool
 		)
 
@@ -245,6 +273,11 @@ LIMIT $%d OFFSET $%d
 			&apiKeyID,
 			&accountID,
 			&groupID,
+			&userEmail,
+			&username,
+			&apiKeyName,
+			&groupName,
+			&accountName,
 			&stream,
 		); err != nil {
 			return nil, 0, err
@@ -268,6 +301,12 @@ LIMIT $%d OFFSET $%d
 			APIKeyID:  toInt64Ptr(apiKeyID),
 			AccountID: toInt64Ptr(accountID),
 			GroupID:   toInt64Ptr(groupID),
+
+			UserEmail:   strings.TrimSpace(userEmail.String),
+			Username:    strings.TrimSpace(username.String),
+			APIKeyName:  strings.TrimSpace(apiKeyName.String),
+			GroupName:   strings.TrimSpace(groupName.String),
+			AccountName: strings.TrimSpace(accountName.String),
 
 			Stream: stream,
 		}

--- a/backend/internal/service/openai_gateway_service.go
+++ b/backend/internal/service/openai_gateway_service.go
@@ -3737,6 +3737,41 @@ func (s *OpenAIGatewayService) handleStreamingResponsePassthrough(
 		return true
 	}
 
+	// TK: See upstream Wei-Shaw/sub2api#2245 — optional short-stream buffer. When
+	// gateway.responses_short_stream_buffer_bytes > 0, hold the first body content
+	// in a byte-bounded window before the first flush. If the upstream EOFs inside
+	// that window without a terminal event, the request fails over cleanly instead
+	// of shipping a half-finished HTTP 200 SSE that strict Responses clients reject
+	// with "stream closed before response.completed". Default 0 keeps the prior
+	// behavior: preamble events still buffer, body content still flushes per-line.
+	shortStreamThreshold := 0
+	if s.cfg != nil {
+		shortStreamThreshold = s.cfg.Gateway.ResponsesShortStreamBufferBytes
+	}
+	shortStreamBuffering := shortStreamThreshold > 0
+	shortStreamReleased := false
+	heldContentLines := make([]string, 0, 8)
+	heldContentBytes := 0
+	releaseHeldContent := func() {
+		shortStreamReleased = true
+		if !writePendingLines() {
+			heldContentLines = heldContentLines[:0]
+			return
+		}
+		for _, held := range heldContentLines {
+			if _, err := fmt.Fprintln(w, held); err != nil {
+				clientDisconnected = true
+				logger.LegacyPrintf("service.openai_gateway", "[OpenAI passthrough] Client disconnected during streaming, continue draining upstream for usage: account=%d", account.ID)
+				break
+			}
+			clientOutputStarted = true
+		}
+		heldContentLines = heldContentLines[:0]
+		if clientOutputStarted && !clientDisconnected {
+			flusher.Flush()
+		}
+	}
+
 	scanner := bufio.NewScanner(resp.Body)
 	maxLineSize := defaultMaxLineSize
 	if s.cfg != nil && s.cfg.Gateway.MaxLineSize > 0 {
@@ -3805,6 +3840,17 @@ func (s *OpenAIGatewayService) handleStreamingResponsePassthrough(
 		if !clientDisconnected {
 			if !clientOutputStarted && !lineStartsClientOutput {
 				pendingLines = append(pendingLines, line)
+				continue
+			}
+			if shortStreamBuffering && !shortStreamReleased {
+				// Hold body content until the window fills or a terminal event
+				// arrives. A stream that dies inside the window leaves nothing
+				// flushed, so the caller can fail over (see scanner-end block).
+				heldContentLines = append(heldContentLines, line)
+				heldContentBytes += len(line)
+				if sawTerminalEvent || sawDone || forceFlushFailedEvent || heldContentBytes >= shortStreamThreshold {
+					releaseHeldContent()
+				}
 				continue
 			}
 			if !clientOutputStarted && len(pendingLines) > 0 {

--- a/backend/internal/service/openai_gateway_service_tk_short_stream_buffer_test.go
+++ b/backend/internal/service/openai_gateway_service_tk_short_stream_buffer_test.go
@@ -1,0 +1,114 @@
+package service
+
+import (
+	"io"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/Wei-Shaw/sub2api/internal/config"
+	"github.com/gin-gonic/gin"
+	"github.com/stretchr/testify/require"
+)
+
+// These tests pin the upstream Wei-Shaw/sub2api#2245 short-stream buffer on the
+// OpenAI Responses passthrough path: when gateway.responses_short_stream_buffer_bytes
+// is set, body content is held in a byte window before the first flush so an
+// upstream that EOFs before a terminal event fails over cleanly instead of
+// shipping a half-finished HTTP 200 SSE.
+
+func newShortStreamPassthroughService(bufBytes int) *OpenAIGatewayService {
+	return &OpenAIGatewayService{cfg: &config.Config{
+		Gateway: config.GatewayConfig{
+			MaxLineSize:                     defaultMaxLineSize,
+			ResponsesShortStreamBufferBytes: bufBytes,
+		},
+	}}
+}
+
+// Content shorter than the window, then EOF with no terminal event: nothing is
+// flushed to the client and the request fails over.
+func TestOpenAIStreamingPassthrough_ShortStreamBuffer_FailoverOnEarlyEOF(t *testing.T) {
+	gin.SetMode(gin.TestMode)
+	svc := newShortStreamPassthroughService(4096)
+
+	rec := httptest.NewRecorder()
+	c, _ := gin.CreateTestContext(rec)
+	c.Request = httptest.NewRequest(http.MethodPost, "/", nil)
+
+	resp := &http.Response{
+		StatusCode: http.StatusOK,
+		Body: io.NopCloser(strings.NewReader(strings.Join([]string{
+			"event: response.created",
+			`data: {"type":"response.created","response":{"id":"resp_1"}}`,
+			"",
+			`data: {"type":"response.output_item.added","item":{"type":"message"},"output_index":0}`,
+			"",
+		}, "\n"))),
+		Header: http.Header{"X-Request-Id": []string{"rid-short-eof"}},
+	}
+
+	_, err := svc.handleStreamingResponsePassthrough(c.Request.Context(), resp, c, &Account{ID: 1, Platform: PlatformOpenAI, Name: "acc"}, time.Now(), "", "")
+	require.Error(t, err)
+	var failoverErr *UpstreamFailoverError
+	require.ErrorAs(t, err, &failoverErr)
+	require.False(t, c.Writer.Written(), "no content should be flushed to the client")
+	require.Empty(t, rec.Body.String(), "client must not receive a half-finished SSE 200")
+}
+
+// Content shorter than the window followed by a terminal event: the held
+// content is flushed and the request succeeds.
+func TestOpenAIStreamingPassthrough_ShortStreamBuffer_FlushesOnTerminal(t *testing.T) {
+	gin.SetMode(gin.TestMode)
+	svc := newShortStreamPassthroughService(4096)
+
+	rec := httptest.NewRecorder()
+	c, _ := gin.CreateTestContext(rec)
+	c.Request = httptest.NewRequest(http.MethodPost, "/", nil)
+
+	resp := &http.Response{
+		StatusCode: http.StatusOK,
+		Body: io.NopCloser(strings.NewReader(strings.Join([]string{
+			`data: {"type":"response.output_item.added","item":{"type":"message"},"output_index":0}`,
+			"",
+			`data: {"type":"response.completed","response":{"usage":{"input_tokens":2,"output_tokens":3}}}`,
+			"",
+		}, "\n"))),
+		Header: http.Header{},
+	}
+
+	result, err := svc.handleStreamingResponsePassthrough(c.Request.Context(), resp, c, &Account{ID: 1}, time.Now(), "", "")
+	require.NoError(t, err)
+	require.NotNil(t, result)
+	body := rec.Body.String()
+	require.Contains(t, body, "response.output_item.added")
+	require.Contains(t, body, "response.completed")
+}
+
+// Content exceeding the window is released and streamed normally; a later EOF
+// without a terminal event surfaces the incomplete error (cannot fail over once
+// bytes were committed) but the content was delivered.
+func TestOpenAIStreamingPassthrough_ShortStreamBuffer_ReleasesPastWindow(t *testing.T) {
+	gin.SetMode(gin.TestMode)
+	svc := newShortStreamPassthroughService(16)
+
+	rec := httptest.NewRecorder()
+	c, _ := gin.CreateTestContext(rec)
+	c.Request = httptest.NewRequest(http.MethodPost, "/", nil)
+
+	resp := &http.Response{
+		StatusCode: http.StatusOK,
+		Body: io.NopCloser(strings.NewReader(strings.Join([]string{
+			`data: {"type":"response.output_item.added","item":{"type":"message"},"output_index":0}`,
+			"",
+		}, "\n"))),
+		Header: http.Header{},
+	}
+
+	_, err := svc.handleStreamingResponsePassthrough(c.Request.Context(), resp, c, &Account{ID: 1}, time.Now(), "", "")
+	require.Error(t, err)
+	require.Contains(t, err.Error(), "missing terminal event")
+	require.Contains(t, rec.Body.String(), "response.output_item.added", "content past the window must be delivered")
+}

--- a/backend/internal/service/ops_models.go
+++ b/backend/internal/service/ops_models.go
@@ -47,9 +47,13 @@ type OpsErrorLog struct {
 	RequestID       string `json:"request_id"`
 	Message         string `json:"message"`
 
-	UserID      *int64 `json:"user_id"`
-	UserEmail   string `json:"user_email"`
+	UserID    *int64 `json:"user_id"`
+	UserEmail string `json:"user_email"`
+	// TK: See upstream Wei-Shaw/sub2api#2410 — carry username + API key name so ops
+	// can identify the caller (and which key) without a separate DB lookup.
+	Username    string `json:"username"`
 	APIKeyID    *int64 `json:"api_key_id"`
+	APIKeyName  string `json:"api_key_name"`
 	AccountID   *int64 `json:"account_id"`
 	AccountName string `json:"account_name"`
 	GroupID     *int64 `json:"group_id"`

--- a/backend/internal/service/ops_request_details.go
+++ b/backend/internal/service/ops_request_details.go
@@ -37,6 +37,15 @@ type OpsRequestDetail struct {
 	AccountID *int64 `json:"account_id,omitempty"`
 	GroupID   *int64 `json:"group_id,omitempty"`
 
+	// TK: See upstream Wei-Shaw/sub2api#2410 — human-readable attribution so the
+	// admin request-detail drill-down can identify who is calling without a
+	// separate DB lookup.
+	UserEmail   string `json:"user_email,omitempty"`
+	Username    string `json:"username,omitempty"`
+	APIKeyName  string `json:"api_key_name,omitempty"`
+	AccountName string `json:"account_name,omitempty"`
+	GroupName   string `json:"group_name,omitempty"`
+
 	Stream bool `json:"stream"`
 }
 

--- a/backend/internal/web/dist/frontend-source.json
+++ b/backend/internal/web/dist/frontend-source.json
@@ -1,7 +1,7 @@
 {
   "algorithm": "sha256(git-ls-files:path,size,content)",
   "file_count": 439,
-  "hash": "47bb25be23340ff7ce7d1a3084a08b5734739914c64dd9ddc6a91bb7954481ba",
+  "hash": "78af36a36d4df28a848e5fad46f7c7dcc787f107858b864821bc1d989245b32d",
   "schema": 1,
   "source": "frontend/"
 }

--- a/frontend/src/api/admin/ops.ts
+++ b/frontend/src/api/admin/ops.ts
@@ -129,6 +129,13 @@ export interface OpsRequestDetail {
   account_id?: number | null
   group_id?: number | null
 
+  // Human-readable request attribution (upstream #2410).
+  user_email?: string
+  username?: string
+  api_key_name?: string
+  account_name?: string
+  group_name?: string
+
   stream?: boolean
 }
 
@@ -909,7 +916,9 @@ export interface OpsErrorLog {
 
   user_id?: number | null
   user_email: string
+  username?: string
   api_key_id?: number | null
+  api_key_name?: string
   account_id?: number | null
   account_name: string
   group_id?: number | null

--- a/frontend/src/i18n/locales/en.ts
+++ b/frontend/src/i18n/locales/en.ts
@@ -4974,6 +4974,8 @@ export default {
         group: 'Group',
         user: 'User',
         account: 'Account',
+        apiKey: 'API Key',
+        clientIp: 'Client IP',
         latency: 'Request Duration',
         businessLimited: 'Business Limited',
         requestPath: 'Request Path',
@@ -5034,8 +5036,15 @@ export default {
           model: 'Model',
           duration: 'Duration',
           status: 'Status',
+          requester: 'Requester',
           requestId: 'Request ID',
           actions: 'Actions'
+        },
+        requester: {
+          anonymous: 'Anonymous',
+          key: 'Key',
+          group: 'Group',
+          account: 'Upstream'
         }
       },
       alertEvents: {

--- a/frontend/src/i18n/locales/zh.ts
+++ b/frontend/src/i18n/locales/zh.ts
@@ -5135,6 +5135,8 @@ export default {
         group: '分组',
         user: '用户',
         account: '账号',
+        apiKey: 'API Key',
+        clientIp: '客户端 IP',
         latency: '请求时长',
         businessLimited: '业务限制',
         requestPath: '请求路径',
@@ -5195,8 +5197,15 @@ export default {
           model: '模型',
           duration: '耗时',
           status: '状态码',
+          requester: '请求方',
           requestId: '请求ID',
           actions: '操作'
+        },
+        requester: {
+          anonymous: '匿名',
+          key: 'Key',
+          group: '分组',
+          account: '上游账号'
         }
       },
       alertEvents: {

--- a/frontend/src/views/admin/ops/components/OpsErrorDetailModal.vue
+++ b/frontend/src/views/admin/ops/components/OpsErrorDetailModal.vue
@@ -37,8 +37,24 @@
               {{ detail.account_name || (detail.account_id != null ? String(detail.account_id) : '—') }}
             </template>
             <template v-else>
-              {{ detail.user_email || (detail.user_id != null ? String(detail.user_id) : '—') }}
+              {{ detail.user_email || detail.username || (detail.user_id != null ? String(detail.user_id) : '—') }}
+              <span v-if="detail.user_email && detail.username" class="ml-1 text-xs text-gray-400">({{ detail.username }})</span>
             </template>
+          </div>
+        </div>
+
+        <!-- upstream #2410: surface API Key + client IP so ops can identify the caller. -->
+        <div class="rounded-xl bg-gray-50 p-4 dark:bg-dark-900">
+          <div class="text-xs font-bold uppercase tracking-wider text-gray-400">{{ t('admin.ops.errorDetail.apiKey') }}</div>
+          <div class="mt-1 text-sm font-medium text-gray-900 dark:text-white">
+            {{ detail.api_key_name || (detail.api_key_id != null ? `#${detail.api_key_id}` : '—') }}
+          </div>
+        </div>
+
+        <div class="rounded-xl bg-gray-50 p-4 dark:bg-dark-900">
+          <div class="text-xs font-bold uppercase tracking-wider text-gray-400">{{ t('admin.ops.errorDetail.clientIp') }}</div>
+          <div class="mt-1 break-all font-mono text-sm font-medium text-gray-900 dark:text-white">
+            {{ detail.client_ip || '—' }}
           </div>
         </div>
 

--- a/frontend/src/views/admin/ops/components/OpsRequestDetailsModal.vue
+++ b/frontend/src/views/admin/ops/components/OpsRequestDetailsModal.vue
@@ -147,6 +147,29 @@ const kindBadgeClass = (kind: string) => {
   if (kind === 'error') return 'bg-red-100 text-red-700 dark:bg-red-900/30 dark:text-red-300'
   return 'bg-green-100 text-green-700 dark:bg-green-900/30 dark:text-green-300'
 }
+
+// Primary requester identity: prefer email, then username, then a #id fallback.
+// upstream #2410 — let ops see who is calling without a DB lookup.
+function requesterPrimary(row: OpsRequestDetail): string {
+  const email = (row.user_email || '').trim()
+  if (email) return email
+  const name = (row.username || '').trim()
+  if (name) return name
+  if (typeof row.user_id === 'number' && row.user_id > 0) return `#${row.user_id}`
+  return t('admin.ops.requestDetails.requester.anonymous')
+}
+
+// Secondary attribution line: key name, group name, upstream account name.
+function requesterMeta(row: OpsRequestDetail): string {
+  const parts: string[] = []
+  const key = (row.api_key_name || '').trim()
+  if (key) parts.push(`${t('admin.ops.requestDetails.requester.key')}: ${key}`)
+  const group = (row.group_name || '').trim()
+  if (group) parts.push(`${t('admin.ops.requestDetails.requester.group')}: ${group}`)
+  const account = (row.account_name || '').trim()
+  if (account) parts.push(`${t('admin.ops.requestDetails.requester.account')}: ${account}`)
+  return parts.join(' · ')
+}
 </script>
 
 <template>
@@ -212,6 +235,9 @@ const kindBadgeClass = (kind: string) => {
                     {{ t('admin.ops.requestDetails.table.status') }}
                   </th>
                   <th class="px-4 py-3 text-left text-[11px] font-bold uppercase tracking-wider text-gray-500 dark:text-gray-400">
+                    {{ t('admin.ops.requestDetails.table.requester') }}
+                  </th>
+                  <th class="px-4 py-3 text-left text-[11px] font-bold uppercase tracking-wider text-gray-500 dark:text-gray-400">
                     {{ t('admin.ops.requestDetails.table.requestId') }}
                   </th>
                   <th class="px-4 py-3 text-right text-[11px] font-bold uppercase tracking-wider text-gray-500 dark:text-gray-400">
@@ -240,6 +266,20 @@ const kindBadgeClass = (kind: string) => {
                   </td>
                   <td class="whitespace-nowrap px-4 py-3 text-xs text-gray-600 dark:text-gray-300">
                     {{ row.status_code ?? '-' }}
+                  </td>
+                  <td class="max-w-[240px] px-4 py-3">
+                    <div class="flex flex-col gap-0.5">
+                      <span class="truncate text-xs font-medium text-gray-700 dark:text-gray-200" :title="requesterPrimary(row)">
+                        {{ requesterPrimary(row) }}
+                      </span>
+                      <span
+                        v-if="requesterMeta(row)"
+                        class="truncate text-[10px] text-gray-400 dark:text-gray-500"
+                        :title="requesterMeta(row)"
+                      >
+                        {{ requesterMeta(row) }}
+                      </span>
+                    </div>
                   </td>
                   <td class="px-4 py-3">
                     <div v-if="row.request_id" class="flex items-center gap-2">

--- a/scripts/sentinels/frontend-tk.json
+++ b/scripts/sentinels/frontend-tk.json
@@ -308,6 +308,14 @@
         "must_not_contain"
       ],
       "rationale": "The ProxiesView ad-banner sentinel above uses both `must_contain` (positive anchor on the TK override comment) and `must_not_contain` (negative anchor blocking re-introduction of the upstream banner render/import). If a future check-frontend-tk.py refactor drops the must_not_contain handler, the negative side of the ad-banner guard becomes a silent no-op. Anchoring the literal token here forces any such refactor to either keep handling must_not_contain or remove this sentinel deliberately."
+    },
+    {
+      "path": "frontend/src/views/admin/ops/components/OpsRequestDetailsModal.vue",
+      "must_contain": [
+        "requesterPrimary",
+        "requesterMeta"
+      ],
+      "rationale": "TK ops request-attribution column (upstream Wei-Shaw/sub2api#2410). The admin request-details drill-down shows a Requester column built from requesterPrimary (user email/username) + requesterMeta (api key / group / upstream account names) so operators can identify who is calling without a DB lookup. These names ride on the user_email/username/api_key_name/group_name/account_name fields the request-details query joins; an upstream merge that rewrites this modal would silently drop the attribution UI. The sentinel forces the merge to keep (or deliberately remove) the requester helpers."
     }
   ]
 }

--- a/scripts/sentinels/gateway-tk.json
+++ b/scripts/sentinels/gateway-tk.json
@@ -1078,6 +1078,14 @@
         "http.StatusForbidden, \"permission_error\""
       ],
       "rationale": "Handler MUST translate the canonical-OAuth UA-reject service error into an immediate HTTP 403 + `permission_error` body without falling into failover. Without this branch the rejection propagates as a generic upstream error and the failover loop retries the same forbidden ingress against other accounts, defeating the gate."
+    },
+    {
+      "path": "backend/internal/service/openai_gateway_service.go",
+      "must_contain": [
+        "ResponsesShortStreamBufferBytes",
+        "shortStreamBuffering"
+      ],
+      "rationale": "TK short-stream buffer on the OpenAI Responses passthrough (upstream Wei-Shaw/sub2api#2245). When gateway.responses_short_stream_buffer_bytes>0, handleStreamingResponsePassthrough holds the first body content in a byte window before the first flush, so an upstream that EOFs before a terminal event fails over cleanly instead of shipping a half-finished HTTP 200 SSE that strict Responses clients reject with 'stream closed before response.completed'. An upstream merge that rewrites the passthrough streaming loop could silently drop this guard; the sentinel forces the merge to keep (or deliberately remove) the buffer wiring."
     }
   ]
 }


### PR DESCRIPTION
## Summary

Found via `.cache/upstream` triage; addresses the two highest-impact open upstream reports that actually affect TokenKey production, plus a watchdog cache drift.

- **upstream Wei-Shaw/sub2api#2410 — ops request attribution.** `ops_error_logs` already stored user/api_key/account/group IDs, but the monitoring UI only exposed raw IDs (request-details panel) or partial names (error list/detail lacked `username` + `api_key_name`) — ops could see errors but not *who* was calling. The request-details query now `LEFT JOIN`s `users` + `api_keys` and returns `user_email`/`username`/`api_key_name`/`group_name`/`account_name`; the error list/detail queries add `username` + `api_key_name`. The admin request-details modal gains a **Requester** column and the error-detail modal gains **API Key** + **Client IP** cards (zh/en i18n + TS types updated).
- **upstream Wei-Shaw/sub2api#2245 — Responses short-stream buffer.** The native OpenAI Responses passthrough already buffers preamble events and fails over when an upstream EOFs before a terminal event with no body flushed. This adds the issue's *optional defensive optimization*: a config-gated `gateway.responses_short_stream_buffer_bytes` (**default 0 = disabled, prod behavior unchanged**) that holds the first body content in a byte window, so an upstream that dies inside the window fails over cleanly instead of shipping a half-finished HTTP 200 SSE that strict clients reject with `stream closed before response.completed`.
- **watchdog cache.** `.cache/upstream/fact-checks.json` pointed at script paths moved by PR #307 (`scripts/checks/`, `scripts/sentinels/`) and a since-refactored `#1318` call site, causing false "regressed" flags. Repointed so all 23 fact-checks pass — the underlying code fixes were intact (no behavior change).

Sentinels: added `gateway-tk` + `frontend-tk` registry entries guarding the new short-stream buffer wiring and the request-attribution column against upstream overwrite.

## Test plan

- [x] `go build ./internal/...`, `go vet`, `golangci-lint run` (0 issues)
- [x] `go test -tags=unit ./...` (full suite green, incl. 3 new short-stream buffer tests)
- [x] `pnpm typecheck` + `pnpm lint:check` (only a pre-existing unrelated warning)
- [x] `scripts/preflight.sh` PASS (sentinels + dist freshness + registry gate)
- [ ] SQL changes need integration coverage (testcontainers) — local Docker unavailable; query column/scan counts verified manually
- [ ] Verify in a running admin UI: request-details Requester column + error-detail API Key/Client IP cards render

🤖 Generated with [Claude Code](https://claude.com/claude-code)