### PR TITLE
fix(smoke): construct Claude Code client shape for /v1/messages

### DIFF
--- a/ops/stage0/post_deploy_smoke.sh
+++ b/ops/stage0/post_deploy_smoke.sh
@@ -196,14 +196,29 @@ if ! smoke_suite_runs messages; then
 else
 expect_anthropic="E2E-ANTHROPIC-OK"
 claude_ua="$(smoke_default_claude_user_agent)"
+# Claude Code client shape: required by ClaudeCodeValidator (Step 4) so that
+# groups with claude_code_only=true (e.g. cc-edges in prod) accept the smoke
+# request. See backend/internal/service/claude_code_validator.go.
+#  - system: Dice similarity >= 0.5 vs canonical Claude Code prompts
+#  - anthropic-beta + X-App: non-empty (canonical claude-code-20250219)
+#  - metadata.user_id: JSON form parsable by ParseMetadataUserID
+claude_cc_system="You are Claude Code, Anthropic's official CLI for Claude."
+claude_cc_meta_user_id='{"device_id":"0000000000000000000000000000000000000000000000000000000000000001","account_uuid":"","session_id":"00000000-0000-0000-0000-000000000001"}'
 apayload="$(jq -n \
   --arg m "${model}" \
   --arg x "${expect_anthropic}" \
-  '{model:$m,max_tokens:96,messages:[{role:"user",content:("Reply with exactly: " + $x)}]}')"
+  --arg sys "${claude_cc_system}" \
+  --arg uid "${claude_cc_meta_user_id}" \
+  '{model:$m,max_tokens:96,
+    system:[{type:"text",text:$sys}],
+    messages:[{role:"user",content:("Reply with exactly: " + $x)}],
+    metadata:{user_id:$uid}}')"
 
 msg_http=$(curl -sS -o "$tmpdir/msg.json" -w "%{http_code}" \
   -H "x-api-key: ${API_KEY}" \
   -H "anthropic-version: 2023-06-01" \
+  -H "anthropic-beta: claude-code-20250219" \
+  -H "X-App: cli" \
   -H "Content-Type: application/json" \
   -H "User-Agent: ${claude_ua}" \
   -d "${apayload}" \


### PR DESCRIPTION
## Summary

Fix the structural mismatch between `ops/stage0/post_deploy_smoke.sh` and `ClaudeCodeValidator` (Step 4) that caused both **prod CI full smoke** and **canary main-via-edge smoke** to hit HTTP 503 on `/v1/messages` against the `cc-edges` group (`claude_code_only=true`).

## Root cause

The smoke key `TK_SMOKE_PROD_ANTHROPIC_KEY` (`sk-f9f…121c`) is bound to `cc-edges` (group_id=15). That group has `claude_code_only=true`, so the gateway routes the request through `service.ClaudeCodeValidator.Validate` (`backend/internal/service/claude_code_validator.go`):

- Step 1 (UA `^claude-cli/\d+\.\d+\.\d+`) — ✅ passes (`claude-cli/2.1.152`)
- Step 2 (`/v1/models` non-messages path) — ✅ passes (this is why `/v1/models` returned 200)
- Step 3 (`max_tokens=1 + haiku` bypass) — ❌ smoke uses `max_tokens=96`
- **Step 4 (messages path strict checks) — ❌ failed all of 4.1/4.2/4.3**:
  - no `system` field at all (4.1 Dice similarity)
  - no `X-App` header (4.2)
  - no `anthropic-beta` header (4.2)
  - no `metadata.user_id` (4.3)

Result: `IsClaudeCodeClient(ctx) = false` → `gateway.select_account_no_available` with `error="this group only allows Claude Code clients"` → HTTP 503. The runner soft-skipped this as a runtime-resource issue, masking the structural mismatch.

Server log evidence (uk1 main-via-edge smoke 2026-05-28T00:03:32Z):

```
gateway.select_account_no_available
  group_name: cc-edges, group_id: 15, platform: anthropic
  fallback_used: false
  error: "this group only allows Claude Code clients"
```

## Fix

Add the four pieces Step 4 needs to `/v1/messages` request:
- `system: [{type:"text", text:"You are Claude Code, Anthropic's official CLI for Claude."}]` — exact canonical template from `claude_code_validator.go`, Dice = 1.0
- `-H "anthropic-beta: claude-code-20250219"` — canonical token from `backend/internal/pkg/claude/constants.go`
- `-H "X-App: cli"` — non-empty
- `metadata.user_id` — JSON form `{"device_id":"<64hex>","account_uuid":"","session_id":"<uuid>"}` parsable by `ParseMetadataUserID`

These additions are harmless for non-`claude_code_only` groups (they are valid Anthropic Messages fields), so they apply unconditionally to both `full` and `main-via-edge` suites.

## Validation

Dispatched `deploy-edge-lightsail-stage0.yml` with `--ref fix/smoke-main-via-edge-cc-shape` against uk1 (run `26546952683`):

```
tk_post_deploy_smoke: POST .../v1/messages -> HTTP 200
tk_post_deploy_smoke: /v1/messages shape type=message role=assistant content=1
                     stop_reason=end_turn
                     usage_keys=cache_creation,...,inference_geo,...,service_tier
tk_edge_post_deploy_smoke: confirmed recent Edge API traffic in uk1 logs
tk_edge_post_deploy_smoke: OK phase=main-via-edge
```

`usage_keys` containing `cache_creation` / `inference_geo` / `service_tier` confirms the request flowed all the way through real Anthropic upstream, not a stub.

- `bash scripts/preflight.sh` — PASS
- `go test -tags=unit -run "TestParseMetadataUserID|TestClaudeCodeValidator" ./internal/service/...` — PASS (validator side unchanged)

## Why this matters

This bug has been silent on every prod release smoke because the runner soft-skipped 503 as "runtime resource issue, NOT a control-plane regression". After this fix:
1. `full` suite (prod CI smoke) actually exercises the `/v1/messages` business path end-to-end instead of skipping it.
2. `main-via-edge` smoke now provides a true business-link monitor (prod → cc-edges → cc-uk1/cc-us1 OAuth → Anthropic upstream → Edge log echo).

No backend code or business logic touched.

no-web-impact

🤖 Generated with [Claude Code](https://claude.com/claude-code)