### PR TITLE
fix(gateway): failover when edge stub returns TokenKey balance 403

### DIFF
--- a/backend/internal/handler/failover_loop.go
+++ b/backend/internal/handler/failover_loop.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"encoding/json"
 	"net/http"
+	"strings"
 	"time"
 
 	"github.com/Wei-Shaw/sub2api/internal/pkg/logger"
@@ -212,18 +213,20 @@ func sleepWithContext(ctx context.Context, d time.Duration) bool {
 }
 
 // looksLikeStructuredErrorJSON 判断上游 ResponseBody 是否为某种 platform 的结构化
-// 错误 JSON（anthropic / openai / gemini 任一）。
+// 错误 JSON（anthropic / openai / gemini / TokenKey middleware 任一）。
 //
 // 兼容的错误 shape:
 //
 //   - anthropic: {"type":"error","error":{"type":"...","message":"..."}}
 //   - openai:    {"error":{"message":"...","type":"...","code":"..."}}
 //   - gemini:    {"error":{"code":403,"message":"...","status":"..."}}
+//   - tokenkey:  {"code":"INSUFFICIENT_BALANCE","message":"Insufficient account balance"}
+//     （prod stub → edge/api 节点 auth middleware 返回；账号级 billing/usage 错误，应 failover）
 //
-// 命中策略：有效 JSON 且顶层有 `error` 字段（object）即视为结构化错误，
-// 走原 failover 切账号路径；anthropic 顶层 `"type":"error"` 不再强制要求。
+// 命中策略：有效 JSON 且顶层有 `error` 字段（object），或同时有非空 `code`+`message`
+// 字符串字段，即视为结构化错误，走原 failover 切账号路径。
 //
-// 任何其他形态（空 body、HTML、Cloudflare 错误页、纯文本、合法 JSON 但无 error 字段）
+// 任何其他形态（空 body、HTML、Cloudflare 错误页、纯文本、合法 JSON 但无上述字段）
 // 都视为"非结构化错误"，在 403 场景下触发 fail-fast。
 func looksLikeStructuredErrorJSON(body []byte) bool {
 	if len(body) == 0 {
@@ -232,5 +235,10 @@ func looksLikeStructuredErrorJSON(body []byte) bool {
 	if !json.Valid(body) {
 		return false
 	}
-	return gjson.GetBytes(body, "error").IsObject()
+	if gjson.GetBytes(body, "error").IsObject() {
+		return true
+	}
+	code := strings.TrimSpace(gjson.GetBytes(body, "code").String())
+	msg := strings.TrimSpace(gjson.GetBytes(body, "message").String())
+	return code != "" && msg != ""
 }

--- a/backend/internal/handler/failover_loop_test.go
+++ b/backend/internal/handler/failover_loop_test.go
@@ -894,6 +894,22 @@ func TestHandleFailoverError_Forbidden403FailFast(t *testing.T) {
 		require.Equal(t, 1, fs.SwitchCount)
 	})
 
+	t.Run("403_tokenkeyInsufficientBalanceJSON_走原failover路径切账号", func(t *testing.T) {
+		fs := NewFailoverState(5, false)
+		mock := &mockTempUnscheduler{}
+		body := []byte(`{"code":"INSUFFICIENT_BALANCE","message":"Insufficient account balance"}`)
+		err := newTestFailoverErrWithBody(403, true, body)
+
+		action := fs.HandleFailoverError(context.Background(), mock, 46, "anthropic", 1, err)
+		require.Equal(t, FailoverContinue, action, "第一次应同账号 retry，不应 fail-fast")
+		require.Equal(t, 0, fs.SwitchCount)
+
+		action = fs.HandleFailoverError(context.Background(), mock, 46, "anthropic", 1, err)
+		require.Equal(t, FailoverContinue, action, "retry 用尽后应 failover 到其他 stub 账号")
+		require.Equal(t, 1, fs.SwitchCount)
+		require.Contains(t, fs.FailedAccountIDs, int64(46))
+	})
+
 	t.Run("非403_不触发fail-fast", func(t *testing.T) {
 		fs := NewFailoverState(5, false)
 		mock := &mockTempUnscheduler{}
@@ -943,5 +959,7 @@ func TestHandleFailoverError_Forbidden403FailFast(t *testing.T) {
 			"gemini shape")
 		require.True(t, looksLikeStructuredErrorJSON([]byte(`{"error":{}}`)),
 			"任何有 error object 的 JSON 都视为结构化错误")
+		require.True(t, looksLikeStructuredErrorJSON([]byte(`{"code":"INSUFFICIENT_BALANCE","message":"Insufficient account balance"}`)),
+			"TokenKey middleware shape")
 	})
 }

--- a/scripts/sentinels/gateway-tk.json
+++ b/scripts/sentinels/gateway-tk.json
@@ -858,13 +858,25 @@
       "path": "backend/internal/handler/failover_loop.go",
       "must_contain": [
         "sameAccountRetryLimit int,",
-        "s.SameAccountRetryCount[accountID] < sameAccountRetryLimit"
+        "s.SameAccountRetryCount[accountID] < sameAccountRetryLimit",
+        "looksLikeStructuredErrorJSON(failoverErr.ResponseBody)",
+        "gjson.GetBytes(body, \"code\").String()",
+        "gjson.GetBytes(body, \"message\").String()",
+        "INSUFFICIENT_BALANCE"
       ],
       "must_not_contain": [
         "maxSameAccountRetries = 3",
         "fallbackSameAccountRetries"
       ],
-      "rationale": "Same-account retry upper bound MUST come from the caller-supplied parameter (in production: account.GetPoolModeRetryCount() per upstream-pool-aware UI config), not from a hardcoded constant or a silent fallback. The signature anchor `sameAccountRetryLimit int,` ensures a future refactor cannot quietly drop the parameter. The L110 comparison literal pins the actual gate so a refactor changing it to `< 3` or `< maxSameAccountRetries` (re-introducing a hardcoded ceiling) trips the registry. The two must_not_contain anchors block two known-bad re-introductions: (a) the old `maxSameAccountRetries = 3` constant that originally hid the bug, and (b) the `fallbackSameAccountRetries` shim from an interim revision that would have silently re-mapped a UI-configured `pool_mode_retry_count=0` (operator explicitly disabling retry) back to 1, contradicting the i18n hint. Background: 2026-05-21 cc-us1-oauth incident exposed that the OpenAI handlers already read GetPoolModeRetryCount() while the shared failover_loop hardcoded 3 — anthropic stub UI settings were silently ignored. Unifying the read path means a single per-account `pool_mode_retry_count` JSONB field controls retry pressure on the upstream pool for every platform, including the explicit 'zero retry' choice."
+      "rationale": "Same-account retry upper bound MUST come from the caller-supplied parameter (in production: account.GetPoolModeRetryCount() per upstream-pool-aware UI config), not from a hardcoded constant or a silent fallback. The signature anchor `sameAccountRetryLimit int,` ensures a future refactor cannot quietly drop the parameter. The L110 comparison literal pins the actual gate so a refactor changing it to `< 3` or `< maxSameAccountRetries` (re-introducing a hardcoded ceiling) trips the registry. The two must_not_contain anchors block two known-bad re-introductions: (a) the old `maxSameAccountRetries = 3` constant that originally hid the bug, and (b) the `fallbackSameAccountRetries` shim from an interim revision that would have silently re-mapped a UI-configured `pool_mode_retry_count=0` (operator explicitly disabling retry) back to 1, contradicting the i18n hint. Background: 2026-05-21 cc-us1-oauth incident exposed that the OpenAI handlers already read GetPoolModeRetryCount() while the shared failover_loop hardcoded 3 — anthropic stub UI settings were silently ignored. Unifying the read path means a single per-account `pool_mode_retry_count` JSONB field controls retry pressure on the upstream pool for every platform, including the explicit 'zero retry' choice. **403 fail-fast structured-body gate (2026-05-28 cc-us2 incident)**: looksLikeStructuredErrorJSON MUST treat TokenKey auth middleware `{code,message}` JSON (e.g. INSUFFICIENT_BALANCE from prod stub → edge) as account-level structured errors so pool_mode stubs failover to sibling edges; treating that shape as WAF noise triggers immediate FailoverExhausted and leaves traffic stuck on a dead cc-us2 even when cc-us1/cc-uk1 are healthy."
+    },
+    {
+      "path": "backend/internal/handler/failover_loop_test.go",
+      "must_contain": [
+        "403_tokenkeyInsufficientBalanceJSON_走原failover路径切账号",
+        "TokenKey middleware shape"
+      ],
+      "rationale": "Regression anchor for the 2026-05-28 cc-us2 incident: edge operator balance=0 returns `{code:INSUFFICIENT_BALANCE,message:...}` which must NOT hit the 403 fail-fast path; without this test an upstream merge can silently restore WAF-only structured JSON detection and block prod stub failover to healthy sibling edges."
     },
     {
       "path": "backend/internal/handler/gateway_handler.go",


### PR DESCRIPTION
## Summary

- When prod `cc-us2` (and other pool_mode stubs) hit an edge that returns `403` with TokenKey auth middleware JSON `{"code":"INSUFFICIENT_BALANCE","message":"..."}`, the shared 403 fail-fast path treated it as WAF/request-level noise and returned `FailoverExhausted` immediately instead of switching to sibling stubs (`cc-us1`, `cc-uk1`).
- Extend `looksLikeStructuredErrorJSON` to recognize the `{code, message}` middleware shape as account-level structured errors, restoring normal pool_mode same-account retry + account failover.
- Add regression tests and update `gateway-tk.json` sentinel anchors.

## Risk

Regular risk — handler failover logic only; no public API contract change. Users previously saw `502 Upstream returned 403...` even when other edge stubs were healthy.

## Validation

```bash
go test -tags=unit ./internal/handler/ -run 'TestHandleFailoverError_Forbidden403FailFast' -count=1
./scripts/preflight.sh
```

Prod triage context (2026-05-28): edge us2 `users.id=1 balance=0`; all 31 recent 502s were `account_id=46` (cc-us2) with `upstream_error_message=Insufficient account balance`. uk1/us1 edges had normal operator balance.


Made with [Cursor](https://cursor.com)