### PR TITLE
feat(gateway): allow Claude Desktop 3p through claude_code_only groups

### DIFF
--- a/backend/internal/handler/gateway_helper.go
+++ b/backend/internal/handler/gateway_helper.go
@@ -54,6 +54,7 @@ func SetClaudeCodeClientContext(c *gin.Context, body []byte, parsedReq *service.
 
 	// 更新 request context
 	ctx := service.SetClaudeCodeClient(c.Request.Context(), isClaudeCode)
+	ctx = service.SetClaudeDesktopGatewayClient(ctx, service.IsClaudeDesktopGatewayUserAgent(ua))
 
 	// 仅在确认为 Claude Code 客户端时提取版本号写入 context
 	if isClaudeCode {

--- a/backend/internal/pkg/ctxkey/ctxkey.go
+++ b/backend/internal/pkg/ctxkey/ctxkey.go
@@ -38,6 +38,9 @@ const (
 	// IsClaudeCodeClient 标识当前请求是否来自 Claude Code 客户端
 	IsClaudeCodeClient Key = "ctx_is_claude_code_client"
 
+	// IsClaudeDesktopGatewayClient 标识当前请求是否来自 Claude Desktop 自定义推理网关（3p）
+	IsClaudeDesktopGatewayClient Key = "ctx_is_claude_desktop_gateway_client"
+
 	// ThinkingEnabled 标识当前请求是否开启 thinking（用于 Antigravity 最终模型名推导与模型维度限流）
 	ThinkingEnabled Key = "ctx_thinking_enabled"
 	// Group 认证后的分组信息，由 API Key 认证中间件设置

--- a/backend/internal/service/claude_desktop_gateway_client.go
+++ b/backend/internal/service/claude_desktop_gateway_client.go
@@ -1,0 +1,39 @@
+package service
+
+import (
+	"context"
+	"regexp"
+	"strings"
+
+	"github.com/Wei-Shaw/sub2api/internal/pkg/ctxkey"
+)
+
+// claudeDesktopGatewayUAPattern matches Claude Desktop (Electron) traffic via a custom
+// inference gateway (3p). Captured 2026-05-28: UA contains "Claude/<semver>" and "Electron/".
+var claudeDesktopGatewayUAPattern = regexp.MustCompile(`(?i)Claude/\d+\.\d+(?:\.\d+)?.*Electron/`)
+
+// IsClaudeDesktopGatewayUserAgent reports whether ua looks like Claude Desktop 3p gateway traffic.
+func IsClaudeDesktopGatewayUserAgent(ua string) bool {
+	ua = strings.TrimSpace(ua)
+	if ua == "" {
+		return false
+	}
+	// Claude Code CLI uses claude-cli/* — never treat as Desktop.
+	if claudeCodeUAPattern.MatchString(ua) {
+		return false
+	}
+	return claudeDesktopGatewayUAPattern.MatchString(ua)
+}
+
+// IsClaudeDesktopGatewayClient reads the Desktop 3p gateway client flag from context.
+func IsClaudeDesktopGatewayClient(ctx context.Context) bool {
+	if v, ok := ctx.Value(ctxkey.IsClaudeDesktopGatewayClient).(bool); ok {
+		return v
+	}
+	return false
+}
+
+// SetClaudeDesktopGatewayClient stores the Desktop 3p gateway client flag in context.
+func SetClaudeDesktopGatewayClient(ctx context.Context, isDesktop bool) context.Context {
+	return context.WithValue(ctx, ctxkey.IsClaudeDesktopGatewayClient, isDesktop)
+}

--- a/backend/internal/service/claude_desktop_gateway_client_test.go
+++ b/backend/internal/service/claude_desktop_gateway_client_test.go
@@ -1,0 +1,97 @@
+//go:build unit
+
+package service
+
+import (
+	"context"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+)
+
+const capturedDesktop3pUA = "Mozilla/5.0 (Macintosh; Intel Mac OS X 10_15_7) AppleWebKit/537.36 (KHTML, like Gecko) Claude/1.8555.2 Chrome/146.0.7680.216 Electron/41.6.1 Safari/537.36"
+
+func TestIsClaudeDesktopGatewayUserAgent(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name string
+		ua   string
+		want bool
+	}{
+		{"captured desktop 3p", capturedDesktop3pUA, true},
+		{"claude code cli excluded", "claude-cli/1.2.3", false},
+		{"curl", "curl/8.0", false},
+		{"empty", "", false},
+		{"browser without electron", "Mozilla/5.0 Claude/1.0.0 Safari/537.36", false},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			require.Equal(t, tt.want, IsClaudeDesktopGatewayUserAgent(tt.ua))
+		})
+	}
+}
+
+func TestIsClaudeDesktopGatewayClient_Context(t *testing.T) {
+	t.Parallel()
+
+	ctx := context.Background()
+	require.False(t, IsClaudeDesktopGatewayClient(ctx))
+
+	ctx = SetClaudeDesktopGatewayClient(ctx, true)
+	require.True(t, IsClaudeDesktopGatewayClient(ctx))
+
+	ctx = SetClaudeDesktopGatewayClient(ctx, false)
+	require.False(t, IsClaudeDesktopGatewayClient(ctx))
+}
+
+func TestResolveGatewayGroup_AllowsDesktopGatewayOnClaudeCodeOnly(t *testing.T) {
+	t.Parallel()
+
+	groupID := int64(70)
+	groupRepo := &mockGroupRepoForGateway{
+		groups: map[int64]*Group{
+			groupID: {
+				ID:             groupID,
+				Platform:       PlatformAnthropic,
+				Status:         StatusActive,
+				Hydrated:       true,
+				ClaudeCodeOnly: true,
+			},
+		},
+	}
+
+	svc := &GatewayService{groupRepo: groupRepo}
+	ctx := SetClaudeDesktopGatewayClient(context.Background(), true)
+
+	gotGroup, gotID, err := svc.resolveGatewayGroup(ctx, &groupID)
+	require.NoError(t, err)
+	require.NotNil(t, gotGroup)
+	require.Equal(t, groupID, gotGroup.ID)
+	require.NotNil(t, gotID)
+	require.Equal(t, groupID, *gotID)
+}
+
+func TestResolveGatewayGroup_StillRejectsUnknownClientOnClaudeCodeOnly(t *testing.T) {
+	t.Parallel()
+
+	groupID := int64(71)
+	groupRepo := &mockGroupRepoForGateway{
+		groups: map[int64]*Group{
+			groupID: {
+				ID:             groupID,
+				Platform:       PlatformAnthropic,
+				Status:         StatusActive,
+				Hydrated:       true,
+				ClaudeCodeOnly: true,
+			},
+		},
+	}
+
+	svc := &GatewayService{groupRepo: groupRepo}
+	gotGroup, gotID, err := svc.resolveGatewayGroup(context.Background(), &groupID)
+	require.ErrorIs(t, err, ErrClaudeCodeOnly)
+	require.Nil(t, gotGroup)
+	require.Nil(t, gotID)
+}

--- a/backend/internal/service/gateway_service.go
+++ b/backend/internal/service/gateway_service.go
@@ -2259,7 +2259,7 @@ func (s *GatewayService) resolveGatewayGroup(ctx context.Context, groupID *int64
 			return nil, nil, err
 		}
 
-		if !group.ClaudeCodeOnly || IsClaudeCodeClient(ctx) {
+		if !group.ClaudeCodeOnly || IsClaudeCodeClient(ctx) || IsClaudeDesktopGatewayClient(ctx) {
 			return group, &currentID, nil
 		}
 
@@ -2271,7 +2271,7 @@ func (s *GatewayService) resolveGatewayGroup(ctx context.Context, groupID *int64
 }
 
 // checkClaudeCodeRestriction 检查分组的 Claude Code 客户端限制
-// 如果分组启用了 claude_code_only 且请求不是来自 Claude Code 客户端：
+// 如果分组启用了 claude_code_only 且请求不是来自 Claude Code 或 Claude Desktop 3p 网关客户端：
 //   - 有降级分组：返回降级分组的 ID
 //   - 无降级分组：返回 ErrClaudeCodeOnly 错误
 func (s *GatewayService) checkClaudeCodeRestriction(ctx context.Context, groupID *int64) (*Group, *int64, error) {

--- a/scripts/sentinels/gateway-tk.json
+++ b/scripts/sentinels/gateway-tk.json
@@ -388,9 +388,26 @@
       "path": "backend/internal/handler/gateway_helper.go",
       "must_contain": [
         "c.Set(service.ClaudeCodeParsedRequestGinKey, parsedReq)",
-        "c.Get(service.ClaudeCodeParsedRequestGinKey)"
+        "c.Get(service.ClaudeCodeParsedRequestGinKey)",
+        "SetClaudeDesktopGatewayClient(ctx, service.IsClaudeDesktopGatewayUserAgent(ua))"
       ],
-      "rationale": "Claude Code parsed request snapshot must remain on the canonical Gin key so service-layer tkEnsure can recover session UUID when outbound serialization loses metadata.user_id."
+      "rationale": "Claude Code parsed request snapshot must remain on the canonical Gin key so service-layer tkEnsure can recover session UUID when outbound serialization loses metadata.user_id. Desktop 3p custom-gateway traffic (Electron UA) must set IsClaudeDesktopGatewayClient on the same hot path so claude_code_only groups accept health checks without masquerading as claude-cli."
+    },
+    {
+      "path": "backend/internal/service/gateway_service.go",
+      "must_contain": [
+        "IsClaudeCodeClient(ctx) || IsClaudeDesktopGatewayClient(ctx)"
+      ],
+      "rationale": "claude_code_only group resolution must allow Claude Code CLI and Claude Desktop 3p inference-gateway clients; dropping the Desktop branch blocks Electron health probes that lack CC system prompts and metadata.user_id."
+    },
+    {
+      "path": "backend/internal/service/claude_desktop_gateway_client.go",
+      "must_contain": [
+        "IsClaudeDesktopGatewayUserAgent",
+        "claudeDesktopGatewayUAPattern",
+        "IsClaudeDesktopGatewayClient"
+      ],
+      "rationale": "Dedicated Desktop 3p gateway client detector (Electron + Claude/<version> UA). Keeps claude_code_only bypass separate from Claude Code CLI validation so Desktop never needs to spoof claude-cli fingerprints."
     },
     {
       "path": "backend/internal/handler/gateway_handler_tk_selection.go",


### PR DESCRIPTION
## Summary

- Add `IsClaudeDesktopGatewayClient` detection for Claude Desktop custom inference gateway (3p) traffic: Electron UA with `Claude/<version>`, excluding `claude-cli/*`.
- Extend `claude_code_only` group resolution to allow `IsClaudeCodeClient(ctx) || IsClaudeDesktopGatewayClient(ctx)` so Desktop 3p health checks and chat are not blocked without masquerading as CC.
- Set Desktop client flag on the existing Anthropic gateway hot path in `SetClaudeCodeClientContext`.

## Risk

常规风险 — backend-only gateway client classification; no API/schema change. Desktop UA heuristic may need tuning if Anthropic changes Electron UA shape.

## Validation

```bash
cd backend && go test -tags=unit ./internal/service/ -run 'ClaudeDesktop|ResolveGatewayGroup_AllowsDesktop|ResolveGatewayGroup_StillRejectsUnknown' -count=1
cd backend && go test -tags=unit ./internal/handler/ -run 'SetClaudeCodeClientContext' -count=1
./scripts/preflight.sh
```


Made with [Cursor](https://cursor.com)