### PR TITLE
fix(ci): gofmt SettingService and harden watchdog JSONL parsing

### DIFF
--- a/.github/workflows/upstream-issue-watchdog.yml
+++ b/.github/workflows/upstream-issue-watchdog.yml
@@ -8,6 +8,8 @@ on:
       - '.cache/upstream/*.json'
       - 'scripts/upstream/issue-*.py'
       - '.github/workflows/upstream-issue-watchdog.yml'
+    paths-ignore:
+      - 'backend/cmd/server/VERSION'
   schedule:
     # 05:20 Asia/Shanghai. GitHub cron is UTC. Runs after the daily upstream merge agent.
     - cron: '20 21 * * *'

--- a/backend/internal/service/setting_service.go
+++ b/backend/internal/service/setting_service.go
@@ -176,17 +176,17 @@ type WebSearchManagerBuilder func(cfg *WebSearchEmulationConfig, proxyURLs map[i
 
 // SettingService 系统设置服务
 type SettingService struct {
-	settingRepo               SettingRepository
-	defaultSubGroupReader     DefaultSubscriptionGroupReader
-	proxyRepo                 ProxyRepository // for resolving websearch provider proxy URLs
-	cfg                       *config.Config
-	onUpdate                  func() // Callback when settings are updated (for cache invalidation)
-	version                   string // Application version
-	webSearchManagerBuilder   WebSearchManagerBuilder
-	antigravityUAVersionCache atomic.Value // *cachedAntigravityUserAgentVersion
-	antigravityUAVersionSF    singleflight.Group
-	openAICodexUACache        atomic.Value // *cachedOpenAICodexUserAgent
-	openAICodexUASF           singleflight.Group
+	settingRepo                    SettingRepository
+	defaultSubGroupReader          DefaultSubscriptionGroupReader
+	proxyRepo                      ProxyRepository // for resolving websearch provider proxy URLs
+	cfg                            *config.Config
+	onUpdate                       func() // Callback when settings are updated (for cache invalidation)
+	version                        string // Application version
+	webSearchManagerBuilder        WebSearchManagerBuilder
+	antigravityUAVersionCache      atomic.Value // *cachedAntigravityUserAgentVersion
+	antigravityUAVersionSF         singleflight.Group
+	openAICodexUACache             atomic.Value // *cachedOpenAICodexUserAgent
+	openAICodexUASF                singleflight.Group
 	claudeCodeUAVersionCache       atomic.Value // *cachedClaudeCodeUserAgentVersion
 	claudeCodeUAVersionSF          singleflight.Group
 	claudeCodeMimicryManifestCache atomic.Value // *cachedClaudeCodeHTTPMimicryManifest

--- a/scripts/test_issue_watchdog_jsonl.py
+++ b/scripts/test_issue_watchdog_jsonl.py
@@ -1,0 +1,60 @@
+#!/usr/bin/env python3
+"""Regression tests for scripts/upstream/issue-watchdog.py load_jsonl.
+
+Same producer/consumer contract as issue-triage-generate: JSONL records are
+newline-delimited only; str.splitlines() must not be used because Unicode line
+separators inside issue title/body would split valid JSON mid-string.
+"""
+from __future__ import annotations
+
+import importlib.util
+import json
+import pathlib
+import sys
+import tempfile
+import unittest
+
+_MOD_PATH = pathlib.Path(__file__).resolve().parent / "upstream" / "issue-watchdog.py"
+_spec = importlib.util.spec_from_file_location("issue_watchdog", _MOD_PATH)
+assert _spec and _spec.loader
+mod = importlib.util.module_from_spec(_spec)
+sys.modules[_spec.name] = mod
+_spec.loader.exec_module(mod)
+
+
+class IssueWatchdogJsonlTest(unittest.TestCase):
+    def test_u2028_inside_string_value_does_not_split_record(self) -> None:
+        issue = {
+            "number": 99,
+            "title": "upstream bug\u2028second visual line",
+            "body": "repro",
+            "state": "open",
+        }
+        line = json.dumps(issue, ensure_ascii=False)
+        self.assertGreater(len((line + "\n").splitlines()), 1)
+        self.assertEqual(len([s for s in (line + "\n").split("\n") if s.strip()]), 1)
+
+        with tempfile.TemporaryDirectory() as tmp:
+            path = pathlib.Path(tmp) / "issues.jsonl"
+            path.write_text(line + "\n", encoding="utf-8")
+            rows = mod.load_jsonl(path)
+
+        self.assertEqual(len(rows), 1)
+        self.assertEqual(rows[0]["number"], 99)
+
+    def test_multiple_records_and_blank_lines(self) -> None:
+        lines = [
+            json.dumps({"number": 1, "title": "a"}, ensure_ascii=False),
+            "",
+            json.dumps({"number": 2, "title": "b"}, ensure_ascii=False),
+        ]
+        with tempfile.TemporaryDirectory() as tmp:
+            path = pathlib.Path(tmp) / "issues.jsonl"
+            path.write_text("\n".join(lines) + "\n", encoding="utf-8")
+            rows = mod.load_jsonl(path)
+
+        self.assertEqual([row["number"] for row in rows], [1, 2])
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/scripts/upstream/issue-watchdog.py
+++ b/scripts/upstream/issue-watchdog.py
@@ -42,7 +42,12 @@ def load_jsonl(path: Path) -> list[dict[str, Any]]:
     rows: list[dict[str, Any]] = []
     if not path.exists():
         return rows
-    for line in path.read_text(encoding="utf-8").splitlines():
+    # Split only on "\n" (the producer separator), NOT str.splitlines(): the
+    # latter also breaks on Unicode line boundaries (U+2028/U+2029/U+0085).
+    # json.dumps(ensure_ascii=False) keeps those raw inside string values, so an
+    # upstream issue title/body containing U+2028 would split one valid JSON
+    # record across "lines" and raise JSONDecodeError: Unterminated string.
+    for line in path.read_text(encoding="utf-8").split("\n"):
         if line.strip():
             rows.append(json.loads(line))
     return rows


### PR DESCRIPTION
## Summary

- Run `gofmt` on `SettingService` struct in `setting_service.go` — this was the sole failing job (`golangci-lint` / gofmt) on recent main CI runs.
- Fix `issue-watchdog.py` `load_jsonl` to split on `\n` only (not `splitlines()`), matching the existing fix in `issue-triage-generate.py`. Upstream issue titles/bodies can contain U+2028, which caused `JSONDecodeError: Unterminated string` in Upstream Issue Watchdog.
- Skip VERSION-only pushes for Upstream Issue Watchdog (`paths-ignore: backend/cmd/server/VERSION`), aligned with CI.
- Add regression tests in `scripts/test_issue_watchdog_jsonl.py`.

## Risk

Low — formatting-only Go change plus defensive JSONL parsing; no runtime gateway behavior change.

## Validation

- `python3 scripts/test_issue_watchdog_jsonl.py` — OK
- `python3 scripts/test_issue_triage_generate.py` — OK
- `gofmt -l backend/internal/service/setting_service.go` — clean
- `./scripts/preflight.sh` — PASS (both commits)


Made with [Cursor](https://cursor.com)