### PR TITLE
fix(gateway): set Desktop 3p client flag on non-CLI fast path

### DIFF
--- a/backend/internal/handler/gateway_helper.go
+++ b/backend/internal/handler/gateway_helper.go
@@ -29,9 +29,11 @@ func SetClaudeCodeClientContext(c *gin.Context, body []byte, parsedReq *service.
 	}
 
 	ua := c.GetHeader("User-Agent")
+	isDesktopGateway := service.IsClaudeDesktopGatewayUserAgent(ua)
 	// Fast path：非 Claude CLI UA 直接判定 false，避免热路径二次 JSON 反序列化。
 	if !claudeCodeValidator.ValidateUserAgent(ua) {
 		ctx := service.SetClaudeCodeClient(c.Request.Context(), false)
+		ctx = service.SetClaudeDesktopGatewayClient(ctx, isDesktopGateway)
 		c.Request = c.Request.WithContext(ctx)
 		return
 	}
@@ -54,7 +56,7 @@ func SetClaudeCodeClientContext(c *gin.Context, body []byte, parsedReq *service.
 
 	// 更新 request context
 	ctx := service.SetClaudeCodeClient(c.Request.Context(), isClaudeCode)
-	ctx = service.SetClaudeDesktopGatewayClient(ctx, service.IsClaudeDesktopGatewayUserAgent(ua))
+	ctx = service.SetClaudeDesktopGatewayClient(ctx, isDesktopGateway)
 
 	// 仅在确认为 Claude Code 客户端时提取版本号写入 context
 	if isClaudeCode {

--- a/backend/internal/handler/gateway_helper_desktop_test.go
+++ b/backend/internal/handler/gateway_helper_desktop_test.go
@@ -1,0 +1,23 @@
+//go:build unit
+
+package handler
+
+import (
+	"net/http"
+	"testing"
+
+	"github.com/Wei-Shaw/sub2api/internal/service"
+	"github.com/stretchr/testify/require"
+)
+
+func TestSetClaudeCodeClientContext_DesktopGatewayUA(t *testing.T) {
+	t.Parallel()
+
+	c, _ := newHelperTestContext(http.MethodPost, "/v1/messages")
+	c.Request.Header.Set("User-Agent", "Mozilla/5.0 (Macintosh; Intel Mac OS X 10_15_7) AppleWebKit/537.36 (KHTML, like Gecko) Claude/1.8555.2 Chrome/146.0.7680.216 Electron/41.6.1 Safari/537.36")
+
+	SetClaudeCodeClientContext(c, []byte(`{"model":"claude-haiku-4-5-20251001","max_tokens":4,"messages":[{"role":"user","content":"ok"}]}`), nil)
+
+	require.False(t, service.IsClaudeCodeClient(c.Request.Context()))
+	require.True(t, service.IsClaudeDesktopGatewayClient(c.Request.Context()), "Desktop 3p Electron UA must set IsClaudeDesktopGatewayClient on fast path")
+}

--- a/backend/internal/handler/gateway_helper_hotpath_test.go
+++ b/backend/internal/handler/gateway_helper_hotpath_test.go
@@ -147,6 +147,7 @@ func TestSetClaudeCodeClientContext_FastPathAndStrictPath(t *testing.T) {
 
 		SetClaudeCodeClientContext(c, validClaudeCodeBodyJSON(), nil)
 		require.False(t, service.IsClaudeCodeClient(c.Request.Context()))
+		require.False(t, service.IsClaudeDesktopGatewayClient(c.Request.Context()))
 	})
 
 	t.Run("cli_non_messages_path_sets_true", func(t *testing.T) {

--- a/scripts/sentinels/gateway-tk.json
+++ b/scripts/sentinels/gateway-tk.json
@@ -389,9 +389,10 @@
       "must_contain": [
         "c.Set(service.ClaudeCodeParsedRequestGinKey, parsedReq)",
         "c.Get(service.ClaudeCodeParsedRequestGinKey)",
-        "SetClaudeDesktopGatewayClient(ctx, service.IsClaudeDesktopGatewayUserAgent(ua))"
+        "isDesktopGateway := service.IsClaudeDesktopGatewayUserAgent(ua)",
+        "SetClaudeDesktopGatewayClient(ctx, isDesktopGateway)"
       ],
-      "rationale": "Claude Code parsed request snapshot must remain on the canonical Gin key so service-layer tkEnsure can recover session UUID when outbound serialization loses metadata.user_id. Desktop 3p custom-gateway traffic (Electron UA) must set IsClaudeDesktopGatewayClient on the same hot path so claude_code_only groups accept health checks without masquerading as claude-cli."
+      "rationale": "Claude Code parsed request snapshot must remain on the canonical Gin key so service-layer tkEnsure can recover session UUID when outbound serialization loses metadata.user_id. Desktop 3p custom-gateway traffic (Electron UA) must set IsClaudeDesktopGatewayClient on the non-CLI fast path as well as the Claude CLI path so claude_code_only groups accept health checks without masquerading as claude-cli."
     },
     {
       "path": "backend/internal/service/gateway_service.go",


### PR DESCRIPTION
## Summary

- Fix wiring bug in PR #445: `SetClaudeDesktopGatewayClient` was only reached on the Claude CLI code path, but Desktop 3p uses Electron UA and hit the non-CLI fast path early return without setting the flag.
- Set `IsClaudeDesktopGatewayClient` on the fast path so `claude_code_only` groups accept Claude Desktop 3p `/v1/messages` health checks.
- Add regression test `TestSetClaudeCodeClientContext_DesktopGatewayUA` and update `gateway-tk.json` sentinel anchors.

## Risk

常规风险 — backend-only gateway context wiring; no API/schema change. Desktop UA heuristic unchanged from #445.

## Validation

```bash
cd backend && go test -tags=unit ./internal/handler/ -run 'DesktopGatewayUA|SetClaudeCodeClientContext' -count=1
cd backend && go test -tags=unit ./internal/service/ -run 'ClaudeDesktop|ResolveGatewayGroup_AllowsDesktop' -count=1
./scripts/preflight.sh
```

After deploy: `claude3p` preflight against `api.tokenkey.dev` with Desktop Electron UA should return HTTP 200 on `/v1/messages`.

Made with [Cursor](https://cursor.com)