### PR TITLE
fix(ci): repair invalid upstream watchdog path filters

### DIFF
--- a/.github/workflows/upstream-issue-watchdog.yml
+++ b/.github/workflows/upstream-issue-watchdog.yml
@@ -4,12 +4,21 @@ on:
   push:
     branches: [main]
     paths:
-      - 'backend/**'
+      # GitHub allows only one of paths / paths-ignore per event; exclude
+      # backend/cmd/server/VERSION by matching code paths, not backend/**.
+      - 'backend/internal/**'
+      - 'backend/ent/**'
+      - 'backend/migrations/**'
+      - 'backend/resources/**'
+      - 'backend/cmd/**/*.go'
+      - 'backend/go.mod'
+      - 'backend/go.sum'
+      - 'backend/.golangci.yml'
+      - 'backend/Makefile'
+      - 'backend/Dockerfile'
       - '.cache/upstream/*.json'
       - 'scripts/upstream/issue-*.py'
       - '.github/workflows/upstream-issue-watchdog.yml'
-    paths-ignore:
-      - 'backend/cmd/server/VERSION'
   schedule:
     # 05:20 Asia/Shanghai. GitHub cron is UTC. Runs after the daily upstream merge agent.
     - cron: '20 21 * * *'


### PR DESCRIPTION
## Summary

- Remove invalid `paths` + `paths-ignore` combo from `upstream-issue-watchdog.yml` (GitHub hard error: only one allowed per event).
- Replace blanket `backend/**` with explicit backend code paths so `backend/cmd/server/VERSION`-only pushes still skip the watchdog (same intent as CI `paths-ignore`).

## Why main kept failing after #446

#446 fixed the JSONL parse bug but also added `paths-ignore` alongside existing `paths`. GitHub marks the workflow invalid and fails in 0s with no jobs — looks like a mysterious recurring red X on main, but it is a workflow syntax issue, not the watchdog runtime.

## Risk

Low — trigger filter only; watchdog logic unchanged.

## Validation

- `python3 dev-rules/scripts/check_workflow_yaml.py` — clean
- `./scripts/preflight.sh` — PASS


Made with [Cursor](https://cursor.com)