### PR TITLE
fix(claude): align OAuth mimicry UA to cc 2.1.156

### DIFF
--- a/backend/internal/pkg/claude/constants.go
+++ b/backend/internal/pkg/claude/constants.go
@@ -7,7 +7,7 @@ import "strings"
 
 // Beta header 常量
 //
-// 这里的常量对齐真实 Claude Code CLI 的最新流量（截至 2026-05，cc 2.1.154 抓包）。
+// 这里的常量对齐真实 Claude Code CLI 的最新流量（截至 2026-05，cc 2.1.156 抓包）。
 // Anthropic 上游会基于 anthropic-beta 的完整集合判定请求来源；
 // 缺少任何"官方 Claude Code 请求才会带"的 beta，都会被降级到第三方额度，
 // 对应报错：`Third-party apps now draw from your extra usage, not your plan limits.`
@@ -31,7 +31,7 @@ const (
 	BetaAdvancedToolUse = "advanced-tool-use-2025-11-20"
 	BetaCacheDiagnosis  = "cache-diagnosis-2026-04-07"
 
-	// cc 2.1.154 抓包新增。
+	// cc 2.1.154+ 抓包新增。
 	BetaThinkingTokenCount = "thinking-token-count-2026-05-13"
 	BetaStructuredOutputs  = "structured-outputs-2025-12-15"
 )
@@ -59,7 +59,7 @@ const MessageBetaHeaderWithTools = BetaClaudeCode + "," + BetaOAuth + "," + Beta
 // CountTokensBetaHeader count_tokens 请求使用的 anthropic-beta header
 const CountTokensBetaHeader = BetaClaudeCode + "," + BetaOAuth + "," + BetaInterleavedThinking + "," + BetaTokenCounting
 
-// HaikuBetaHeader Haiku 模型 OAuth 回退 anthropic-beta（对齐 cc 2.1.154 抓包顺序）。
+// HaikuBetaHeader Haiku 模型 OAuth 回退 anthropic-beta（对齐 cc 2.1.156 抓包顺序）。
 const HaikuBetaHeader = BetaOAuth + "," + BetaInterleavedThinking + "," + BetaThinkingTokenCount + "," +
 	BetaContextManagement + "," + BetaPromptCachingScope + "," + BetaAdvisorTool + "," +
 	BetaStructuredOutputs + "," + BetaCacheDiagnosis
@@ -78,7 +78,7 @@ const DefaultCacheControlTTL = "5m"
 // CLICurrentVersion 是 sub2api 当前对外伪装的 Claude Code CLI 版本号（三段 semver）。
 // 用于 billing attribution block 中的 cc_version=X.Y.Z.{fp} 前缀以及 fingerprint 计算。
 // 必须与 DefaultHeaders["User-Agent"] 中的版本号严格一致；不一致会被 Anthropic 判第三方。
-const CLICurrentVersion = "2.1.154"
+const CLICurrentVersion = "2.1.156"
 
 // JoinBetaHeader joins beta tokens into the wire anthropic-beta header value.
 func JoinBetaHeader(betas []string) string {
@@ -87,7 +87,7 @@ func JoinBetaHeader(betas []string) string {
 
 // FullClaudeCodeMimicryBetas 返回最"像"真实 Claude Code CLI 的完整 beta 列表（Sonnet/Opus），
 // 用于 OAuth 账号伪装成 Claude Code 时使用。
-// 顺序与 cc 2.1.154 /v1/messages 抓包一致。
+// 顺序与 cc 2.1.156 /v1/messages 抓包一致。
 //
 // 使用建议：
 //   - OAuth 账号 + 非 haiku：追加这整份列表，再按需保留 client 带来的 beta。
@@ -109,7 +109,7 @@ func FullClaudeCodeMimicryBetas() []string {
 	}
 }
 
-// FullClaudeCodeHaikuMimicryBetas 返回 Haiku 模型 OAuth mimicry 的 beta 列表（cc 2.1.154 抓包）。
+// FullClaudeCodeHaikuMimicryBetas 返回 Haiku 模型 OAuth mimicry 的 beta 列表（cc 2.1.156 抓包）。
 func FullClaudeCodeHaikuMimicryBetas() []string {
 	return []string{
 		BetaOAuth,
@@ -127,7 +127,7 @@ func FullClaudeCodeHaikuMimicryBetas() []string {
 var DefaultHeaders = map[string]string{
 	// Keep these in sync with recent Claude CLI traffic to reduce the chance
 	// that Claude Code-scoped OAuth credentials are rejected as "non-CLI" usage.
-	"User-Agent":                                "claude-cli/2.1.154 (external, cli)",
+	"User-Agent":                                "claude-cli/2.1.156 (external, cli)",
 	"X-Stainless-Lang":                          "js",
 	"X-Stainless-Package-Version":               "0.94.0",
 	"X-Stainless-OS":                            "Linux",

--- a/backend/internal/pkg/claude/constants_test.go
+++ b/backend/internal/pkg/claude/constants_test.go
@@ -9,7 +9,7 @@ import (
 	"github.com/stretchr/testify/require"
 )
 
-func TestFullClaudeCodeMimicryBetas_MatchesCC0154SonnetCapture(t *testing.T) {
+func TestFullClaudeCodeMimicryBetas_MatchesCC0156SonnetCapture(t *testing.T) {
 	want := []string{
 		"claude-code-20250219",
 		"oauth-2025-04-20",
@@ -28,7 +28,7 @@ func TestFullClaudeCodeMimicryBetas_MatchesCC0154SonnetCapture(t *testing.T) {
 	require.NotContains(t, FullClaudeCodeMimicryBetas(), BetaFineGrainedToolStreaming)
 }
 
-func TestFullClaudeCodeHaikuMimicryBetas_MatchesCC0154HaikuCapture(t *testing.T) {
+func TestFullClaudeCodeHaikuMimicryBetas_MatchesCC0156HaikuCapture(t *testing.T) {
 	want := []string{
 		"oauth-2025-04-20",
 		"interleaved-thinking-2025-05-14",

--- a/backend/internal/service/claude_code_mimicry_manifest_test.go
+++ b/backend/internal/service/claude_code_mimicry_manifest_test.go
@@ -7,10 +7,10 @@ import (
 )
 
 func TestParseClaudeCodeHTTPMimicryManifest_Valid(t *testing.T) {
-	raw := `{"schema_version":1,"cc_version":"2.1.154","sonnet_opus":["oauth-2025-04-20","claude-code-20250219"],"haiku":["oauth-2025-04-20"]}`
+	raw := `{"schema_version":1,"cc_version":"2.1.156","sonnet_opus":["oauth-2025-04-20","claude-code-20250219"],"haiku":["oauth-2025-04-20"]}`
 	m := ParseClaudeCodeHTTPMimicryManifest(raw)
 	require.NotNil(t, m)
-	require.Equal(t, "2.1.154", m.CCVersion)
+	require.Equal(t, "2.1.156", m.CCVersion)
 	require.Equal(t, []string{"oauth-2025-04-20", "claude-code-20250219"}, m.SonnetOpus)
 	require.Equal(t, []string{"oauth-2025-04-20"}, m.Haiku)
 }
@@ -21,7 +21,7 @@ func TestParseClaudeCodeHTTPMimicryManifest_RejectsInvalid(t *testing.T) {
 		"not-json",
 		`{"schema_version":0}`,
 		`{"schema_version":1,"cc_version":"bad","sonnet_opus":["x"],"haiku":["oauth-2025-04-20"]}`,
-		`{"schema_version":1,"cc_version":"2.1.154","sonnet_opus":[],"haiku":["oauth-2025-04-20"]}`,
+		`{"schema_version":1,"cc_version":"2.1.156","sonnet_opus":[],"haiku":["oauth-2025-04-20"]}`,
 	}
 	for _, raw := range cases {
 		require.Nil(t, ParseClaudeCodeHTTPMimicryManifest(raw), "raw=%q", raw)

--- a/backend/internal/service/identity_service.go
+++ b/backend/internal/service/identity_service.go
@@ -26,7 +26,7 @@ var (
 
 // 默认指纹值（当客户端未提供时使用）
 var defaultFingerprint = Fingerprint{
-	UserAgent:               "claude-cli/2.1.154 (external, cli)",
+	UserAgent:               "claude-cli/2.1.156 (external, cli)",
 	StainlessLang:           "js",
 	StainlessPackageVersion: "0.94.0",
 	StainlessOS:             "Linux",

--- a/backend/internal/service/identity_service_tk_canonical_http.go
+++ b/backend/internal/service/identity_service_tk_canonical_http.go
@@ -56,7 +56,7 @@ const (
 	// neither env nor runtime resolver provides a value. Keep in sync with
 	// the most recent cc CLI release this build was validated against; the
 	// admin UI / runtime resolver is the normal update path going forward.
-	DefaultClaudeCodeUserAgentVersion = "2.1.154"
+	DefaultClaudeCodeUserAgentVersion = "2.1.156"
 
 	// canonicalUAPrefix / canonicalUASuffix wrap the version-only field.
 	// Matches the wire shape Anthropic observes from a real Claude Code CLI

--- a/deploy/aws/stage0/anthropic-http-mimicry-baselines.json
+++ b/deploy/aws/stage0/anthropic-http-mimicry-baselines.json
@@ -1,6 +1,6 @@
 {
   "schema_version": 1,
-  "cc_version": "2.1.154",
+  "cc_version": "2.1.156",
   "description": "Canonical OAuth HTTP mimicry betas for Claude Code CLI. Live wire values are driven at runtime by settings.claude_code_http_mimicry_manifest (sync-runtime / plan-http-mimicry-sync). Compile-time defaults in backend/internal/pkg/claude/constants.go catch up on the release train.",
   "sonnet_opus": [
     "claude-code-20250219",

--- a/deploy/aws/stage0/tk_canonical_cc_oauth.json
+++ b/deploy/aws/stage0/tk_canonical_cc_oauth.json
@@ -1,6 +1,6 @@
 {
   "name": "tk_canonical_cc_oauth",
-  "description": "TokenKey canonical Claude Code OAuth TLS profile. Stable id intentionally decoupled from cc CLI patch version: TLS ClientHello is byte-identical across 2.1.142 (2026-05-15 capture, ja3_hash=d871d02cecbde59abbf8f4806134addf) through 2.1.154 (2026-05-29 cc0 capture), so a new patch release never triggers a rename. HTTP observed.user_agent below is a compile-time snapshot; the live wire UA is driven at runtime by SettingService.GetClaudeCodeUserAgentVersion (admin setting → env CLAUDE_CODE_USER_AGENT_VERSION → compile default). runtime=node v24.3.0 darwin/arm64.",
+  "description": "TokenKey canonical Claude Code OAuth TLS profile. Stable id intentionally decoupled from cc CLI patch version: TLS ClientHello is byte-identical across 2.1.142 (2026-05-15 capture, ja3_hash=d871d02cecbde59abbf8f4806134addf) through 2.1.156 (2026-05-29 cc0 capture), so a new patch release never triggers a rename. HTTP observed.user_agent below is a compile-time snapshot; the live wire UA is driven at runtime by SettingService.GetClaudeCodeUserAgentVersion (admin setting → env CLAUDE_CODE_USER_AGENT_VERSION → compile default). runtime=node v24.3.0 darwin/arm64.",
   "enable_grease": false,
   "cipher_suites": [
     4865,
@@ -71,7 +71,7 @@
   ],
   "observed": {
     "model": "claude-haiku-4-5-20251001",
-    "user_agent": "claude-cli/2.1.154 (external, sdk-cli)",
+    "user_agent": "claude-cli/2.1.156 (external, sdk-cli)",
     "stainless_os": "MacOS",
     "stainless_arch": "arm64",
     "stainless_runtime": "node",

--- a/docs/spec-delta-cc-2.1.156.md
+++ b/docs/spec-delta-cc-2.1.156.md
@@ -1,0 +1,49 @@
+# spec-delta: cc 2.1.156 UA alignment
+
+## Background
+
+cc 2.1.156 mitm + TLS capture (2026-05-29, cc0 → gost → socks) shows **UA-only** drift from 2.1.154. TLS ClientHello unchanged (same ja3_hash). Beta sets for Sonnet/Opus and dominant Haiku mimicry (structured-outputs path) unchanged.
+
+`capture-http-comprehensive.sh` (3×3×2): Sonnet and Opus stable (1 unique beta each). Haiku **bimodal** (structured-outputs vs claude-code+extended-cache-ttl) — same gray split as 2.1.154; PR keeps dominant structured-outputs set in `FullClaudeCodeHaikuMimicryBetas()` and documents the WARN in evidence only.
+
+## Delta
+
+### MODIFIED
+
+- `DefaultClaudeCodeUserAgentVersion` / `CLICurrentVersion` / mimic + canonical observed UA: **2.1.154 → 2.1.156**.
+- `anthropic-http-mimicry-baselines.json` `cc_version` field.
+- Smoke default UA, sentinel rationale, capture baseline test.
+
+### NOT changed
+
+- TLS ja3 / `tk_canonical_cc_oauth` cipher profile bodies.
+- `FullClaudeCodeMimicryBetas()` / `FullClaudeCodeHaikuMimicryBetas()` token lists.
+
+## Scenarios
+
+### Core positive
+
+1. Given cc 2.1.156 bundle, when `capture_cc_fingerprint.py check --bundle`, then all critical HTTP+TLS fields match.
+2. Given OAuth forward on canonical path, when UA is built, then wire version is 2.1.156.
+
+### Core negative
+
+1. Given stale 2.1.154 constants, when check runs against 2.1.156 capture, then UA mismatches fail the gate.
+
+### Regression
+
+- `TestFullClaudeCodeMimicryBetas_MatchesCC0156*` pass.
+- TLS `check-tls` on capture bundle: OK.
+
+## Validation
+
+```bash
+go test -tags=unit ./internal/pkg/claude/... -run TestFullClaudeCode
+python3 -m unittest discover -s ops/anthropic -p 'test_capture_cc_fingerprint.py' -t ops/anthropic
+bash ops/anthropic/capture-cc-fingerprint.sh capture --http
+TOKENKEY_CC_CAPTURE_HAIKU_N=5 TOKENKEY_CC_CAPTURE_SONNET_N=5 TOKENKEY_CC_CAPTURE_OPUS_N=5 \
+  bash ops/anthropic/capture-http-comprehensive.sh
+./scripts/preflight.sh
+```
+
+Evidence: `.tls_list/20260529T030652Z-cc-capture.bundle.json`, `.tls_list/20260529T030719Z-http-multi.log` (comprehensive; haiku WARN bimodal).

--- a/ops/anthropic/test_capture_cc_fingerprint.py
+++ b/ops/anthropic/test_capture_cc_fingerprint.py
@@ -22,7 +22,7 @@ class CaptureCCFingerprintTest(unittest.TestCase):
     def test_load_tokenkey_baseline_has_expected_keys(self) -> None:
         baseline = mod.load_tokenkey_baseline(mod.REPO_ROOT)
         self.assertEqual(baseline["tls"]["ja3_hash"], "d871d02cecbde59abbf8f4806134addf")
-        self.assertEqual(baseline["canonical_http"]["default_version"], "2.1.154")
+        self.assertEqual(baseline["canonical_http"]["default_version"], "2.1.156")
         self.assertEqual(baseline["mimic_http"]["stainless_package_version"], "0.94.0")
         self.assertIn("claude-code-20250219", baseline["betas"]["sonnet_mimicry"])
         self.assertNotIn("effort-2025-11-24", baseline["betas"]["sonnet_mimicry"])

--- a/ops/stage0/smoke_lib.sh
+++ b/ops/stage0/smoke_lib.sh
@@ -49,7 +49,7 @@ if [[ -z "${_TK_SMOKE_LIB_LOADED:-}" ]]; then
   }
 
   smoke_default_claude_user_agent() {
-    printf '%s' "${TK_SMOKE_CLAUDE_USER_AGENT:-claude-cli/2.1.154 (external, sdk-cli)}"
+    printf '%s' "${TK_SMOKE_CLAUDE_USER_AGENT:-claude-cli/2.1.156 (external, sdk-cli)}"
   }
 
   # soft_degrade_or_exit — see post_deploy_smoke.sh header for contract.

--- a/scripts/sentinels/gateway-tk.json
+++ b/scripts/sentinels/gateway-tk.json
@@ -1138,7 +1138,7 @@
         "func FullClaudeCodeHaikuMimicryBetas()",
         "func JoinBetaHeader("
       ],
-      "rationale": "OAuth Claude Code mimicry beta registry: Sonnet/Opus and Haiku sets must stay aligned with real cc CLI traffic (cc 2.1.154 capture). Dropping thinking-token-count / structured-outputs or reverting Haiku to the legacy claude-code + extended-cache-ttl set re-opens third-party cohort signals on OAuth subscriptions."
+      "rationale": "OAuth Claude Code mimicry beta registry: Sonnet/Opus and Haiku sets must stay aligned with real cc CLI traffic (cc 2.1.156 capture). Dropping thinking-token-count / structured-outputs or reverting Haiku to the legacy claude-code + extended-cache-ttl set re-opens third-party cohort signals on OAuth subscriptions."
     },
     {
       "path": "backend/internal/handler/gateway_handler.go",


### PR DESCRIPTION
## Summary

- cc 2.1.156 mitm + TLS capture (2026-05-29): **UA-only** drift from 2.1.154; TLS ja3 unchanged; Sonnet/Haiku dominant beta sets unchanged.
- Bump compile defaults + runtime baselines (`anthropic-http-mimicry-baselines.json`, `DefaultClaudeCodeUserAgentVersion`, mimic UA).
- Haiku comprehensive capture shows **bimodal** beta headers (structured-outputs vs claude-code+extended-cache-ttl); documented in `docs/spec-delta-cc-2.1.156.md`, beta token lists **not** changed.

## Risk

常规风险 — OAuth wire UA version only; no TLS profile or beta registry change.

## Validation

```bash
go test -tags=unit ./internal/pkg/claude/... -run TestFullClaudeCode
python3 -m unittest discover -s ops/anthropic -p 'test_capture_cc_fingerprint.py' -t ops/anthropic
python3 ops/anthropic/capture_cc_fingerprint.py check --bundle .tls_list/20260529T030652Z-cc-capture.bundle.json
./scripts/preflight.sh
```

Evidence: `.tls_list/20260529T030652Z-cc-capture.bundle.json`, `.tls_list/20260529T030719Z-http-multi.log`

**Post-merge:** run `bash ops/anthropic/cc_fingerprint_apply_http_runtime.sh` to sync live `claude_code_http_mimicry_manifest` / UA setting without a release.


Made with [Cursor](https://cursor.com)