### PR TITLE
feat(edge-lightsail): us2 adopt oh2 after IP pollution + register edge-us5 on or2

### DIFF
--- a/.github/workflows/deploy-edge-lightsail-stage0.yml
+++ b/.github/workflows/deploy-edge-lightsail-stage0.yml
@@ -17,6 +17,7 @@ on:
           - us2
           - us3
           - us4
+          - us5
       operation:
         description: "provision creates Lightsail instance; upgrade/rollback use SSM; smoke verifies."
         required: true

--- a/deploy/aws/cloudformation/cicd-oidc.yaml
+++ b/deploy/aws/cloudformation/cicd-oidc.yaml
@@ -16,7 +16,7 @@ Parameters:
     Description: GitHub <owner>/<repo> allowed to assume the role.
   AllowedSubjects:
     Type: CommaDelimitedList
-    Default: "repo:youxuanxue/sub2api:ref:refs/heads/main,repo:youxuanxue/sub2api:environment:prod,repo:youxuanxue/sub2api:environment:edge-uk1,repo:youxuanxue/sub2api:environment:edge-fra1,repo:youxuanxue/sub2api:environment:edge-us1,repo:youxuanxue/sub2api:environment:edge-us2,repo:youxuanxue/sub2api:environment:edge-us3,repo:youxuanxue/sub2api:environment:edge-us4"
+    Default: "repo:youxuanxue/sub2api:ref:refs/heads/main,repo:youxuanxue/sub2api:environment:prod,repo:youxuanxue/sub2api:environment:edge-uk1,repo:youxuanxue/sub2api:environment:edge-fra1,repo:youxuanxue/sub2api:environment:edge-us1,repo:youxuanxue/sub2api:environment:edge-us2,repo:youxuanxue/sub2api:environment:edge-us3,repo:youxuanxue/sub2api:environment:edge-us4,repo:youxuanxue/sub2api:environment:edge-us5"
     Description: >-
       Full OIDC sub claims (StringLike patterns) allowed to assume the role.
       Default allows main (for ops-daily-diagnostics.yml),

--- a/deploy/aws/lightsail/edge-targets-lightsail.json
+++ b/deploy/aws/lightsail/edge-targets-lightsail.json
@@ -78,18 +78,18 @@
       "deployable": true,
       "profile": "edge-lightsail-minimal",
       "swap_gib": 2,
-      "lightsail_region": "us-east-1",
-      "ec2_equivalent_region": "us-east-1",
-      "availability_zone": "us-east-1a",
+      "lightsail_region": "us-east-2",
+      "ec2_equivalent_region": "us-east-2",
+      "availability_zone": "us-east-2a",
       "domain": "api-us2.tokenkey.dev",
-      "porkbun_a_ipv4": "100.48.129.133",
-      "instance_name": "tokenkey-edge-us-va1-ls",
-      "static_ip_name": "StaticIp-2",
+      "porkbun_a_ipv4": "3.150.58.200",
+      "instance_name": "tokenkey-edge-us-oh2-ls",
+      "static_ip_name": "StaticIp-oh-2",
       "bundle_id": "micro_3_0",
       "blueprint_id": "amazon_linux_2023",
       "monthly_budget_usd": 12,
       "ssm_prefix": "/tokenkey/lightsail/us2",
-      "purpose": "us-east-1-virginia-egress (pre-provisioned StaticIp-2 / tokenkey-edge-us-va1-ls)"
+      "purpose": "us-east-2-ohio-egress (adopted StaticIp-oh-2 after us-east-1 100.48.129.133 pollution)"
     },
     "us3": {
       "deployable": true,
@@ -124,6 +124,23 @@
       "monthly_budget_usd": 12,
       "ssm_prefix": "/tokenkey/lightsail/us4",
       "purpose": "us-west-2-oregon-egress (pre-provisioned Static-or-1 / tokenkey-edge-us-or1-ls)"
+    },
+    "us5": {
+      "deployable": true,
+      "profile": "edge-lightsail-minimal",
+      "swap_gib": 2,
+      "lightsail_region": "us-west-2",
+      "ec2_equivalent_region": "us-west-2",
+      "availability_zone": "us-west-2a",
+      "domain": "api-us5.tokenkey.dev",
+      "porkbun_a_ipv4": "44.224.133.40",
+      "instance_name": "tokenkey-edge-us-or2-ls",
+      "static_ip_name": "StaticIp-or-2",
+      "bundle_id": "micro_3_0",
+      "blueprint_id": "amazon_linux_2023",
+      "monthly_budget_usd": 12,
+      "ssm_prefix": "/tokenkey/lightsail/us5",
+      "purpose": "us-west-2-oregon-egress-2 (pre-provisioned StaticIp-or-2 / tokenkey-edge-us-or2-ls)"
     }
   }
 }

--- a/deploy/aws/stage0/edge-polluted-ips.json
+++ b/deploy/aws/stage0/edge-polluted-ips.json
@@ -11,6 +11,11 @@
       "ip": "35.177.124.150",
       "region": "eu-west-2",
       "notes": "upstream API risk-block (2026-05-22)"
+    },
+    {
+      "ip": "100.48.129.133",
+      "region": "us-east-1",
+      "notes": "Lightsail edge-us2 StaticIp-2 upstream API risk-block (2026-05-29)"
     }
   ]
 }

--- a/docs/deploy/tokenkey-edge-ip-history.md
+++ b/docs/deploy/tokenkey-edge-ip-history.md
@@ -15,4 +15,5 @@ Active edge EIP rotation runbook: [`.cursor/skills/tokenkey-stage0-edge-ip-rotat
 | --- | --- | --- |
 | `3.9.160.161` | eu-west-2 | upstream API risk-block (2026-05-20) |
 | `35.177.124.150` | eu-west-2 | upstream API risk-block (2026-05-22) |
+| `100.48.129.133` | us-east-1 | Lightsail edge-us2 StaticIp-2 upstream API risk-block (2026-05-29) |
 <!-- END edge-ip-status:polluted -->


### PR DESCRIPTION
## Summary
- **edge-us2**: polluted `100.48.129.133` (us-east-1 StaticIp-2) → adopt pre-provisioned **oh2** in **us-east-2** (`3.150.58.200` / `StaticIp-oh-2` / `tokenkey-edge-us-oh2-ls`). Provision completed on branch.
- **edge-us5**: new Lightsail edge on **or2** in **us-west-2** (`44.224.133.40` / `StaticIp-or-2` / `tokenkey-edge-us-or2-ls`). OIDC trust + GitHub `edge-us5` environment added.
- Polluted IP `100.48.129.133` registered in `edge-polluted-ips.json`.

## Risk
常规风险 — Lightsail matrix + OIDC trust only; no EC2 CFN execution role for us5.

## Validation
- GHA provision: us2 run https://github.com/youxuanxue/sub2api/actions/runs/26622328091 (green)
- GHA provision: us5 run https://github.com/youxuanxue/sub2api/actions/runs/26622329422 (green)
- `curl --resolve api-us2.tokenkey.dev:443:3.150.58.200 https://api-us2.tokenkey.dev/health` → `{"status":"ok"}`
- Admin creds: `~/Codes/keys/tokenkey-us2-admin-password.txt`, `tokenkey-us5-admin-password.txt`

## Operator follow-ups (post-merge)
1. Porkbun: `api-us2.tokenkey.dev` A → **3.150.58.200** (was polluted `100.48.129.133`)
2. Porkbun: **api-us5.tokenkey.dev** A → **44.224.133.40** (new)
3. After DNS: `bash ops/stage0/verify-edge-lightsail-network.sh us2 --renew-cert` and same for us5
4. Decommission retired us-east-1 `tokenkey-edge-us-va1-ls` + release `StaticIp-2` after DNS cut
5. Smoke: `gh workflow run deploy-edge-lightsail-stage0.yml -f edge_id=us2 -f operation=smoke -f confirm_instance=tokenkey-edge-us-oh2-ls` (and us5)

Made with [Cursor](https://cursor.com)