### PR TITLE
fix(openai): strip stale reasoning encrypted_content on Responses failover

### DIFF
--- a/backend/internal/handler/openai_gateway_handler.go
+++ b/backend/internal/handler/openai_gateway_handler.go
@@ -325,8 +325,17 @@ func (h *OpenAIGatewayHandler) Responses(c *gin.Context) {
 		forwardStart := time.Now()
 		// 应用渠道模型映射到请求体
 		forwardBody := body
+		// TK: after an account switch, the carried reasoning encrypted_content is
+		// bound to a previous account and would draw a 400 invalid_encrypted_content
+		// from the freshly-selected one. Strip it proactively so the new account's
+		// first hop succeeds instead of eating that 400 + per-account retry. Only on
+		// failover (len(failedAccountIDs) > 0) — the sticky-preferred first account
+		// keeps its valid encrypted_content. Fast path is a no-op when absent.
+		if len(failedAccountIDs) > 0 {
+			forwardBody = service.TkStripEncryptedReasoningForFailover(forwardBody)
+		}
 		if channelMapping.Mapped {
-			forwardBody = h.gatewayService.ReplaceModelInBody(body, channelMapping.MappedModel)
+			forwardBody = h.gatewayService.ReplaceModelInBody(forwardBody, channelMapping.MappedModel)
 		}
 		writerSizeBeforeForward := c.Writer.Size()
 		result, err := func() (*service.OpenAIForwardResult, error) {

--- a/backend/internal/service/openai_gateway_tk_failover_encrypted_reasoning.go
+++ b/backend/internal/service/openai_gateway_tk_failover_encrypted_reasoning.go
@@ -1,0 +1,64 @@
+package service
+
+import (
+	"bytes"
+	"encoding/json"
+)
+
+// encryptedContentMarker is the substring that must be present for a Responses
+// request body to carry OpenAI reasoning `encrypted_content`. Used as a cheap
+// pre-filter so the common case (no encrypted reasoning, or a Chat Completions
+// body that has no `input` array at all) pays zero parse cost.
+var encryptedContentMarker = []byte(`"encrypted_content"`)
+
+// TkStripEncryptedReasoningForFailover removes OpenAI Responses
+// `encrypted_content` from reasoning `input` items in a JSON request body,
+// returning the rewritten body (or the original bytes if there is nothing to
+// strip).
+//
+// Why this exists: OpenAI reasoning `encrypted_content` is bound to the account
+// that produced it. When the Responses failover loop switches to a freshly
+// selected account (sticky drift, 429, account unavailable, ...), the carried
+// `encrypted_content` from the previous account cannot be verified by the new
+// one, so the upstream returns 400 `invalid_encrypted_content`. The per-account
+// HTTP path already recovers from this (see trimOpenAIEncryptedReasoningItems
+// callers in openai_gateway_service.go), but only after eating that 400 and
+// retrying — one wasted upstream round-trip plus an ops-noise log per account
+// switch. Stripping proactively at the handler's failover boundary skips the
+// doomed first hop entirely.
+//
+// This MUST only be applied when an account switch has actually happened. On the
+// first (sticky-preferred) account the carried `encrypted_content` is normally
+// valid, and stripping it there would needlessly discard reasoning context /
+// prompt-cache affinity. Callers gate on len(failedAccountIDs) > 0.
+//
+// Fast path: if the body does not contain the `encrypted_content` marker it is
+// returned untouched with no JSON parse. The re-marshal here is safe — this is
+// an OpenAI Responses body, not an Anthropic Messages body, so it carries no
+// `thinking` block signature that re-serialization could invalidate (the
+// thinking-signature byte-passthrough invariant lives on the native Anthropic
+// path, not here). It mirrors exactly the json.Marshal(reqBody) the per-account
+// invalid_encrypted_content retry already performs.
+func TkStripEncryptedReasoningForFailover(body []byte) []byte {
+	if len(body) == 0 || !bytes.Contains(body, encryptedContentMarker) {
+		return body
+	}
+
+	var reqBody map[string]any
+	if err := json.Unmarshal(body, &reqBody); err != nil {
+		// Malformed/non-object body: leave it to the upstream to reject so we
+		// don't mask a real client error. The per-account retry path remains a
+		// backstop if it really was the encrypted content.
+		return body
+	}
+
+	if !trimOpenAIEncryptedReasoningItems(reqBody) {
+		return body
+	}
+
+	out, err := json.Marshal(reqBody)
+	if err != nil {
+		return body
+	}
+	return out
+}

--- a/backend/internal/service/openai_gateway_tk_failover_encrypted_reasoning_test.go
+++ b/backend/internal/service/openai_gateway_tk_failover_encrypted_reasoning_test.go
@@ -1,0 +1,92 @@
+//go:build unit
+
+package service
+
+import (
+	"bytes"
+	"encoding/json"
+	"testing"
+)
+
+func TestTkStripEncryptedReasoningForFailover_FastPathNoMarker(t *testing.T) {
+	// A Responses body with reasoning but no encrypted_content must be returned
+	// byte-for-byte without any parse/re-marshal.
+	body := []byte(`{"model":"o3","input":[{"type":"reasoning","summary":[]},{"type":"message","role":"user","content":"hi"}]}`)
+	got := TkStripEncryptedReasoningForFailover(body)
+	if !bytes.Equal(got, body) {
+		t.Fatalf("expected body unchanged on fast path, got %s", got)
+	}
+}
+
+func TestTkStripEncryptedReasoningForFailover_StripsEncryptedContent(t *testing.T) {
+	// reasoning item carries other fields besides encrypted_content -> the item
+	// is kept but encrypted_content is dropped.
+	body := []byte(`{"model":"o3","input":[{"type":"reasoning","id":"rs_1","encrypted_content":"abc","summary":["s"]},{"type":"message","role":"user","content":"hi"}]}`)
+	got := TkStripEncryptedReasoningForFailover(body)
+	if bytes.Contains(got, []byte("encrypted_content")) {
+		t.Fatalf("encrypted_content should be stripped, got %s", got)
+	}
+
+	var parsed map[string]any
+	if err := json.Unmarshal(got, &parsed); err != nil {
+		t.Fatalf("result not valid JSON: %v", err)
+	}
+	input, ok := parsed["input"].([]any)
+	if !ok || len(input) != 2 {
+		t.Fatalf("expected 2 input items preserved, got %#v", parsed["input"])
+	}
+	reasoning, ok := input[0].(map[string]any)
+	if !ok {
+		t.Fatalf("first item not an object: %#v", input[0])
+	}
+	if _, has := reasoning["encrypted_content"]; has {
+		t.Fatalf("encrypted_content not removed from reasoning item: %#v", reasoning)
+	}
+	if reasoning["id"] != "rs_1" {
+		t.Fatalf("non-encrypted fields must be preserved, got %#v", reasoning)
+	}
+}
+
+func TestTkStripEncryptedReasoningForFailover_DropsBareReasoningItem(t *testing.T) {
+	// reasoning item whose only payload was encrypted_content collapses to empty
+	// and is removed entirely.
+	body := []byte(`{"model":"o3","input":[{"type":"reasoning","encrypted_content":"abc"},{"type":"message","role":"user","content":"hi"}]}`)
+	got := TkStripEncryptedReasoningForFailover(body)
+
+	var parsed map[string]any
+	if err := json.Unmarshal(got, &parsed); err != nil {
+		t.Fatalf("result not valid JSON: %v", err)
+	}
+	input, ok := parsed["input"].([]any)
+	if !ok || len(input) != 1 {
+		t.Fatalf("expected bare reasoning item dropped (1 item left), got %#v", parsed["input"])
+	}
+	msg, ok := input[0].(map[string]any)
+	if !ok || msg["type"] != "message" {
+		t.Fatalf("surviving item should be the message, got %#v", input[0])
+	}
+}
+
+func TestTkStripEncryptedReasoningForFailover_ChatCompletionsBodyUntouched(t *testing.T) {
+	// A Chat Completions body has no top-level `input` array, so even if the
+	// literal substring appears (e.g. inside message text) nothing is stripped.
+	body := []byte(`{"model":"gpt-4o","messages":[{"role":"user","content":"what is encrypted_content?"}]}`)
+	got := TkStripEncryptedReasoningForFailover(body)
+	if !bytes.Equal(got, body) {
+		t.Fatalf("chat completions body must be untouched, got %s", got)
+	}
+}
+
+func TestTkStripEncryptedReasoningForFailover_MalformedBodyReturnedAsIs(t *testing.T) {
+	body := []byte(`{"input":[{"type":"reasoning","encrypted_content":`) // truncated, contains marker
+	got := TkStripEncryptedReasoningForFailover(body)
+	if !bytes.Equal(got, body) {
+		t.Fatalf("malformed body must be returned unchanged, got %s", got)
+	}
+}
+
+func TestTkStripEncryptedReasoningForFailover_EmptyBody(t *testing.T) {
+	if got := TkStripEncryptedReasoningForFailover(nil); got != nil {
+		t.Fatalf("nil body must round-trip as nil, got %s", got)
+	}
+}

--- a/scripts/sentinels/gateway-tk.json
+++ b/scripts/sentinels/gateway-tk.json
@@ -1013,9 +1013,10 @@
     {
       "path": "backend/internal/handler/openai_gateway_handler.go",
       "must_contain": [
-        "service.TkEnrichClaudeIncidentMessage("
+        "service.TkEnrichClaudeIncidentMessage(",
+        "service.TkStripEncryptedReasoningForFailover("
       ],
-      "rationale": "Locks the incident-aware client-message hook in handleAnthropicFailoverExhausted — the native /v1/messages (Claude Code / claude-cli) exhausted path. Without this call a Claude API incident surfaces to the caller as a generic upstream error with no pointer to status.claude.com; an upstream merge that rewrites the exhausted handler would silently drop the redirect."
+      "rationale": "Locks two TK hooks in the OpenAI gateway handler. (1) TkEnrichClaudeIncidentMessage in handleAnthropicFailoverExhausted — the native /v1/messages (Claude Code / claude-cli) exhausted path; without it a Claude API incident surfaces to the caller as a generic upstream error with no pointer to status.claude.com. (2) TkStripEncryptedReasoningForFailover at the Responses failover boundary — strips a previous account's reasoning encrypted_content before re-dispatching to a freshly-selected account, so the new account's first hop does not draw a 400 invalid_encrypted_content. An upstream merge that rewrites the failover loop would silently drop either hook."
     },
     {
       "path": "backend/internal/service/gateway_service_tk_canonical_http.go",
@@ -1235,6 +1236,14 @@
         "SettingKeyOpenAIMaxRateLimitCooldownSeconds"
       ],
       "rationale": "TK#1981: opt-in (default OFF) clamp of long OpenAI 429 reset windows. Guards the capability against silent upstream-merge deletion."
+    },
+    {
+      "path": "backend/internal/service/openai_gateway_tk_failover_encrypted_reasoning.go",
+      "must_contain": [
+        "func TkStripEncryptedReasoningForFailover",
+        "trimOpenAIEncryptedReasoningItems("
+      ],
+      "rationale": "Failover-boundary stripper for OpenAI Responses reasoning encrypted_content. encrypted_content is bound to the account that produced it; when the Responses failover loop switches accounts the carried value draws a 400 invalid_encrypted_content from the new account. This helper (called from openai_gateway_handler.go, gated on an actual account switch) reuses trimOpenAIEncryptedReasoningItems to drop it proactively, skipping the doomed first hop. Behaviour-neutral on the happy path (fast-path no-op when the marker is absent) and the per-account invalid_encrypted_content retry remains a backstop, so this is a latency/ops-noise optimization — but the sentinel guards the file against silent upstream-merge deletion that would reintroduce the per-switch 400 storm."
     }
   ]
 }


### PR DESCRIPTION
## What

When the OpenAI **Responses** failover loop switches accounts, the request still carries the previous account's reasoning `encrypted_content`. That value is bound to the account that produced it, so the freshly-selected account returns `400 invalid_encrypted_content`. The per-account HTTP path already recovers (`trimOpenAIEncryptedReasoningItems` retry in `openai_gateway_service.go:2945`), but only **after eating that 400 + a retry** — one wasted upstream round-trip and an ops-noise log per account switch.

This strips `encrypted_content` **proactively at the handler failover boundary**, so the new account's first hop succeeds.

## Why this is safe / scoped

- **Not a correctness fix, a latency/noise optimization.** The per-account retry remains a backstop. This just skips the doomed first hop.
- **Gated on an actual account switch** (`len(failedAccountIDs) > 0`). The sticky-preferred first account keeps its valid `encrypted_content` (preserves reasoning context / prompt-cache affinity).
- **Fast-path no-op** when the `encrypted_content` marker is absent (no JSON parse) — and a Chat Completions body (no top-level `input`) is untouched.
- **Re-marshal is OpenAI Responses body only.** The native Anthropic `thinking`-block signature byte-passthrough invariant (`/v1/messages` → `buildUpstreamRequest` → `bytes.NewReader`) is **not** on this path and is unaffected. Mirrors exactly the `json.Marshal(reqBody)` the existing per-account retry already does.

## Changes

- new TK helper `service.TkStripEncryptedReasoningForFailover` (`openai_gateway_tk_failover_encrypted_reasoning.go`), reuses `trimOpenAIEncryptedReasoningItems`
- inject at `openai_gateway_handler.go` Responses failover boundary
- 6 unit tests
- `gateway-tk.json` sentinels guard both the injection point and the helper (125 intact)

## Verification

- `go build ./...` ✅
- `go test -tags=unit ./...` ✅
- `golangci-lint run` ✅ (0 issues)
- `scripts/preflight.sh` ✅ (all sub2api sentinel checks pass)

## Upstream cadence (out-of-order note)

TK is currently **472 commits ahead of upstream/main** (`git log --oneline upstream/main..HEAD | wc -l`). check-drift reports TK **behind upstream/main by 36** at time of writing. This PR ships **out of order** deliberately: the change is self-contained, touches only the TK failover boundary + a TK-only `*_tk_*.go` helper, and does **not** depend on the pending upstream commits. The upstream merge is handled by the daily upstream-merge agent and is independent of this fix.

Merge mode: **Squash and merge** (TK-originated fix, per CLAUDE.md §5.y).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
