### PR TITLE
ci: P0 workflow hardening — release concurrency, watchdog dedup, agent/security gates

### DIFF
--- a/.github/workflows/backend-ci.yml
+++ b/.github/workflows/backend-ci.yml
@@ -161,10 +161,23 @@ jobs:
           version: v2.9
           args: --enable-only gosec --concurrency=4 --timeout=30m
           working-directory: backend
+      - name: Note gosec scope (push/PR runs)
+        # Honesty signal: on push/PR this job runs ONLY govulncheck — gosec static
+        # analysis is gated to schedule/dispatch above. Without this note a green
+        # `backend-security` check on a PR reads as "gosec passed" when it never
+        # ran. Zero-cost; surfaces the gap in the log + step summary.
+        if: github.event_name == 'push' || github.event_name == 'pull_request'
+        run: |
+          echo "::notice title=gosec scope::gosec static analysis runs weekly (Mon 03:00 UTC) and on manual dispatch — NOT on push/PR. This run executed govulncheck only."
+          echo "ℹ️ \`backend-security\` on push/PR runs **govulncheck only**. gosec static analysis runs weekly (Mon 03:00 UTC) + manual dispatch (\`suite: security\`)." >> "$GITHUB_STEP_SUMMARY"
       - name: Run govulncheck
         working-directory: backend
         run: |
-          go install golang.org/x/vuln/cmd/govulncheck@latest
+          # Pin govulncheck (was @latest). An unpinned @latest is non-reproducible
+          # and a supply-chain surface — a bad upstream release would silently
+          # break or poison this gate. Contrast golangci-lint (pinned v2.9) and
+          # new-api (pinned by SHA). Bump deliberately.
+          go install golang.org/x/vuln/cmd/govulncheck@v1.3.0
           govulncheck ./...
 
   frontend-security:
@@ -188,7 +201,26 @@ jobs:
       - name: Run pnpm audit
         working-directory: frontend
         run: |
+          # `pnpm audit` exits non-zero when advisories are found — that is
+          # EXPECTED here; the exception checker (next step) decides pass/fail.
+          # But a registry/network failure ALSO exits non-zero with empty/garbage
+          # output, which the checker would then pass VACUOUSLY (empty audit =
+          # "no vulns"). So: run, ignore the advisory exit, then assert the output
+          # is real audit JSON (parses + has a recognized top-level key) before
+          # trusting it. Fail loudly if the audit did not actually run.
           pnpm audit --prod --audit-level=high --json > audit.json || true
+          python3 - <<'PY'
+          import json, sys
+          try:
+              with open("audit.json") as fh:
+                  data = json.load(fh)
+          except Exception as exc:
+              sys.stderr.write(f"::error title=pnpm audit::audit.json is not valid JSON ({exc}); pnpm audit failed to run (registry/network?). Failing instead of passing vacuously.\n")
+              sys.exit(1)
+          if not (isinstance(data, dict) and any(k in data for k in ("advisories", "vulnerabilities", "metadata"))):
+              sys.stderr.write("::error title=pnpm audit::audit.json parsed but lacks advisories/vulnerabilities/metadata; not a real audit result. Failing instead of passing vacuously.\n")
+              sys.exit(1)
+          PY
       - name: Check audit exceptions
         run: |
           python tools/check_pnpm_audit_exceptions.py \

--- a/.github/workflows/cla.yml
+++ b/.github/workflows/cla.yml
@@ -6,8 +6,12 @@ on:
   pull_request_target:
     types: [opened, reopened, closed, synchronize]
 
+# Least-privilege: CLA sign/lock only needs to write the signature store
+# (contents), comment/label PRs (pull-requests), and set the CLA status check
+# (statuses). `actions: write` was over-granted and unused — dropped. This block
+# runs in pull_request_target context (base-repo secrets + write token even on
+# fork PRs), so the scope is deliberately minimal.
 permissions:
-  actions: write
   contents: write
   pull-requests: write
   statuses: write
@@ -30,7 +34,11 @@ jobs:
           (github.event.comment.body == 'recheck' ||
            github.event.comment.body == 'I have read the CLA Document and I hereby sign the CLA') ||
           github.event_name == 'pull_request_target'
-        uses: contributor-assistant/github-action@v2.6.1
+        # Pinned to the v2.6.1 commit SHA (was the mutable @v2.6.1 tag). This
+        # action receives a write-scoped GITHUB_TOKEN in pull_request_target
+        # context; a re-pointed tag (account compromise / dependency confusion)
+        # would hand that token to attacker-controlled code. Bump deliberately.
+        uses: contributor-assistant/github-action@ca4a40a7d1004f18d9960b404b97e5f30a505a08 # v2.6.1
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         with:
@@ -112,7 +120,8 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: "Lock merged PR"
-        uses: contributor-assistant/github-action@v2.6.1
+        # Pinned to the v2.6.1 commit SHA (see cla-check rationale above).
+        uses: contributor-assistant/github-action@ca4a40a7d1004f18d9960b404b97e5f30a505a08 # v2.6.1
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         with:

--- a/.github/workflows/pr-repair-agent.yml
+++ b/.github/workflows/pr-repair-agent.yml
@@ -47,10 +47,16 @@ jobs:
     # entire repair job. The `event == 'pull_request'` check still excludes
     # scheduled/push CI failures (no PR to repair) without depending on the flaky
     # array; the resolve step below recovers the PR number from the head SHA.
+    # NOTE: 'cancelled' is deliberately EXCLUDED. backend-ci's PR-only
+    # cancel-in-progress concurrency cancels older runs on every new push, so a
+    # normal rapid push sequence produces 'cancelled' CI runs that are NOT
+    # repairable failures — the superseding push re-runs CI on its own. Firing a
+    # 120-min Opus repair toolchain on a superseded run is pure waste. Only
+    # 'failure' / 'timed_out' indicate a CI run that genuinely needs repair.
     if: >-
       github.event_name == 'workflow_dispatch' ||
       (
-        (github.event.workflow_run.conclusion == 'failure' || github.event.workflow_run.conclusion == 'timed_out' || github.event.workflow_run.conclusion == 'cancelled') &&
+        (github.event.workflow_run.conclusion == 'failure' || github.event.workflow_run.conclusion == 'timed_out') &&
         github.event.workflow_run.event == 'pull_request'
       )
     runs-on: ubuntu-latest

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -31,6 +31,19 @@ env:
   SIMPLE_RELEASE: ${{ github.event.inputs.simple_release == 'true' || vars.SIMPLE_RELEASE == 'true' }}
   FULL_RELEASE: ${{ github.event.inputs.full_release == 'true' || vars.FULL_RELEASE == 'true' }}
 
+# Serialize the ENTIRE release pipeline. Two concurrent releases — e.g. a tag
+# push plus the §9.2 recovery dispatch `gh workflow run release.yml -f tag=...`,
+# or two tags landing close together — would otherwise race non-atomically on
+# the shared :latest / :X / :X.Y / :X.Y.Z image tags (last-writer-wins, no
+# signal on which build the manifest ends up pointing at) AND on the
+# `[skip ci]` VERSION writeback that sync-version-file pushes directly to main.
+# A single global group + cancel-in-progress:false queues releases instead of
+# racing; releases are infrequent and are meant to be serial. See CLAUDE.md
+# §9.1 (arch manifest) / §9.2 (VERSION writeback).
+concurrency:
+  group: release
+  cancel-in-progress: false
+
 permissions:
   contents: write
   packages: write

--- a/.github/workflows/upstream-issue-watchdog.yml
+++ b/.github/workflows/upstream-issue-watchdog.yml
@@ -16,7 +16,9 @@ on:
       - 'backend/.golangci.yml'
       - 'backend/Makefile'
       - 'backend/Dockerfile'
-      - '.cache/upstream/*.json'
+      # NOTE: do NOT add '.cache/upstream/*.json' here. The watchdog itself
+      # force-pushes a cache-refresh PR touching those files; merging it would
+      # re-trigger the watchdog (self-retrigger loop, deduped only internally).
       - 'scripts/upstream/issue-*.py'
       - '.github/workflows/upstream-issue-watchdog.yml'
   schedule:
@@ -36,10 +38,12 @@ on:
         description: "Optional Wei-Shaw/sub2api issue number to force-review/fix"
         required: false
         type: string
-  workflow_run:
-    workflows:
-      - Daily Upstream Merge Agent
-    types: [completed]
+  # NOTE: deliberately NO `workflow_run` trigger off "Daily Upstream Merge
+  # Agent". The cron above (21:20 UTC) is the single source of truth for the
+  # daily scan and runs ~80 min after the merge agent regardless of whether it
+  # ran. Chaining workflow_run on top of the cron made the scan double-fire
+  # every day (same paginated upstream fetch + duplicate force-push to the
+  # fixed cache branch). One trigger source only.
 
 permissions:
   contents: write
@@ -53,7 +57,6 @@ concurrency:
 
 jobs:
   scan:
-    if: github.event_name != 'workflow_run' || github.event.workflow_run.conclusion == 'success'
     runs-on: ubuntu-latest
     timeout-minutes: 60
     outputs:


### PR DESCRIPTION
## What

Batch 1 of 4 from the workflow god-eye review. **Pure hardening; no behavior change on the normal path.** Each fix is an independent, trivially `git revert`-able hunk. Touches `.github/workflows/` only — no backend/frontend, no upstream-shaped paths, no `VERSION` bump.

## Fixes (in severity order)

| Sev | Workflow | Change |
|---|---|---|
| **CRITICAL** | `release.yml` | Add a global `concurrency: { group: release, cancel-in-progress: false }`. The release pipeline had **zero** concurrency control — a tag push plus the §9.2 recovery dispatch (or two close tags) could race non-atomically on the shared `:latest`/`:X.Y.Z` image tags **and** on the `skip-ci` `VERSION` writeback to `main`. Now fully serialized. |
| HIGH | `upstream-issue-watchdog.yml` | Drop the `workflow_run` trigger and remove `.cache/upstream/*.json` from `push:main` paths. The cron (21:20 UTC) is now the **single** trigger source. Previously the scan double-fired daily and could self-retrigger off its own cache-refresh PR. |
| MEDIUM | `pr-repair-agent.yml` | Stop firing on `cancelled` CI. `backend-ci`'s PR-only cancel-in-progress produces `cancelled` runs on every rapid re-push; each was spinning up a 120-min Opus repair on a merely-superseded run. |
| HIGH | `backend-ci.yml` | (a) Pin `govulncheck` `@latest` → `@v1.3.0` (reproducible, no supply-chain `@latest`). (b) Make `pnpm audit` **fail loudly** when it produces no real audit JSON, instead of letting the exception checker pass vacuously on empty/garbage output. (c) Add a zero-cost notice that `gosec` runs weekly-only, so a green `backend-security` check on a PR isn't misread as "gosec passed". |
| HIGH | `cla.yml` | Pin `contributor-assistant/github-action` `@v2.6.1` → commit SHA `ca4a40a…` (it gets a write-scoped token in `pull_request_target` context). Drop the unused `actions: write` permission. |

## Decisions taken (operator-confirmed)

- **gosec**: keep weekly-only + make the PR signal honest (chosen over adding per-PR gosec cost, which would fight the cost-lens work in batch 2/3).
- **watchdog**: keep `cron`, drop `workflow_run` (chosen over the reverse — cron is the robust single source even if the merge agent didn't run).

## Verification

- `scripts/preflight.sh` → **PASS** (full sub2api suite, incl. `release.yml simple_release default = false` Graviton guard, `13 workflow(s) clean`, Stage0 primitive-sharing).
- `pnpm audit` guard unit-tested against 6 cases (empty / `{}` / garbage / pnpm-error / clean / vuln) — fails closed on the 4 non-results, passes the 2 real ones.
- All 5 workflows parse; the embedded `pnpm audit` heredoc verified via `bash -n` after YAML dedent.

## Merge

Per CLAUDE.md §5.y this is a TK-originated PR → **Squash and merge**.

---
Next: batch 2 (`deploy-*` → reusable `workflow_call`), batch 3 (`run-headless-agent` composite), batch 4 (governance consolidation).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
