### PR TITLE
chore(stage0): extract shared deploy tag-format gate + sentinel

### DIFF
--- a/.github/workflows/deploy-edge-lightsail-stage0.yml
+++ b/.github/workflows/deploy-edge-lightsail-stage0.yml
@@ -105,10 +105,10 @@ jobs:
                 echo "::error::tag is required for operation=$INPUT_OPERATION"
                 exit 1
               fi
-              if ! printf '%s' "$INPUT_TAG" | grep -Eq '^[0-9]+\.[0-9]+\.[0-9]+(-rc\.[0-9]+|-beta\.[0-9]+)?$'; then
-                echo "::error::tag must match X.Y.Z, got: $INPUT_TAG"
-                exit 1
-              fi
+              # Tag-format gate: shared with prod + EC2-edge deploy workflows.
+              # (Was an inline regex whose error message had drifted shorter than
+              # the other two — now the canonical message from the shared script.)
+              bash ops/stage0/validate-deploy-tag.sh "$INPUT_TAG"
               ;;
             smoke) ;;
             *) echo "::error::unsupported operation=$INPUT_OPERATION"; exit 1 ;;

--- a/.github/workflows/deploy-edge-stage0.yml
+++ b/.github/workflows/deploy-edge-stage0.yml
@@ -125,10 +125,8 @@ jobs:
                 echo "::error::tag is required for operation=$INPUT_OPERATION"
                 exit 1
               fi
-              if ! printf '%s' "$INPUT_TAG" | grep -Eq '^[0-9]+\.[0-9]+\.[0-9]+(-rc\.[0-9]+|-beta\.[0-9]+)?$'; then
-                echo "::error::tag must match X.Y.Z (optionally -rc.N / -beta.N), got: $INPUT_TAG"
-                exit 1
-              fi
+              # Tag-format gate: shared with prod + Lightsail deploy workflows.
+              bash ops/stage0/validate-deploy-tag.sh "$INPUT_TAG"
               ;;
             smoke)
               ;;

--- a/.github/workflows/deploy-stage0.yml
+++ b/.github/workflows/deploy-stage0.yml
@@ -48,10 +48,10 @@ jobs:
         id: stack
         run: |
           set -euo pipefail
-          if ! printf '%s' "$INPUT_TAG" | grep -Eq '^[0-9]+\.[0-9]+\.[0-9]+(-rc\.[0-9]+|-beta\.[0-9]+)?$'; then
-            echo "::error::tag must match X.Y.Z (optionally -rc.N / -beta.N), got: $INPUT_TAG"
-            exit 1
-          fi
+          # Tag-format gate: single source of truth shared with the two Edge
+          # deploy workflows (prevents the regex/message drift that had already
+          # crept into deploy-edge-lightsail-stage0.yml).
+          bash ops/stage0/validate-deploy-tag.sh "$INPUT_TAG"
           if [ -z "${OIDC_ROLE_ARN:-}" ]; then
             echo "::error::AWS_OIDC_ROLE_ARN repo variable not set; configure per docs/approved/deploy-stage0-workflow.md §5"
             exit 1

--- a/ops/stage0/validate-deploy-tag.sh
+++ b/ops/stage0/validate-deploy-tag.sh
@@ -1,0 +1,37 @@
+#!/usr/bin/env bash
+# Single source of truth for the Stage0 deploy TAG-format gate.
+#
+# Shared by all three deploy workflows so the tag-format rule never grows
+# divergent copies:
+#   - .github/workflows/deploy-stage0.yml            (prod)
+#   - .github/workflows/deploy-edge-stage0.yml       (EC2 edge)
+#   - .github/workflows/deploy-edge-lightsail-stage0.yml (Lightsail edge)
+#
+# History: the regex was inlined in all three; the Lightsail copy had already
+# dropped the "(optionally -rc.N / -beta.N)" note from its error message — the
+# exact "patch one, the others drift" failure this script prevents. Re-inlining
+# the regex is blocked by the `Stage0 deploy tag-validation sharing` preflight
+# sentinel (scripts/preflight.sh).
+#
+# Scope: FORMAT only. The "tag is required for operation=X" empty-check stays in
+# the edge workflows (its wording is operation-contextual, which this script has
+# no business knowing). Prod always requires a tag, so it calls this directly.
+#
+# Usage: validate-deploy-tag.sh <tag>   (falls back to $INPUT_TAG)
+# Exit 0 on a well-formed tag; exit 1 (with a ::error:: annotation) otherwise.
+set -euo pipefail
+
+TAG="${1:-${INPUT_TAG:-}}"
+
+if [ -z "$TAG" ]; then
+  echo "::error::validate-deploy-tag: no tag provided (pass as \$1 or set INPUT_TAG)" >&2
+  exit 1
+fi
+
+# Canonical Stage0 release-tag shape: X.Y.Z, optionally -rc.N or -beta.N.
+if ! printf '%s' "$TAG" | grep -Eq '^[0-9]+\.[0-9]+\.[0-9]+(-rc\.[0-9]+|-beta\.[0-9]+)?$'; then
+  echo "::error::tag must match X.Y.Z (optionally -rc.N / -beta.N), got: $TAG" >&2
+  exit 1
+fi
+
+echo "ok: tag $TAG matches X.Y.Z (optionally -rc.N / -beta.N)"

--- a/scripts/preflight.sh
+++ b/scripts/preflight.sh
@@ -751,6 +751,43 @@ else
     echo "  ok: no Edge Stage0 workflow present"
 fi
 
+echo ""
+echo "=== sub2api: Stage0 deploy tag-validation sharing ==="
+# The X.Y.Z(-rc.N/-beta.N) release-tag gate is a single shared script so the
+# three deploy workflows never grow divergent copies (the Lightsail copy had
+# already drifted to a shorter error message). This sentinel fails closed if any
+# deploy workflow stops calling it or re-inlines the regex.
+_tag_script="ops/stage0/validate-deploy-tag.sh"
+_tag_files=".github/workflows/deploy-stage0.yml .github/workflows/deploy-edge-stage0.yml .github/workflows/deploy-edge-lightsail-stage0.yml"
+_tag_ok=1
+if [ ! -x "$_tag_script" ]; then
+    echo "  FAIL: $_tag_script missing or not executable (shared tag-format gate)"
+    errors=$((errors + 1)); _tag_ok=0
+fi
+for _f in $_tag_files; do
+    [ -f "$_f" ] || continue
+    if ! grep -q "$_tag_script" "$_f"; then
+        echo "  FAIL: $_f must call $_tag_script (do not re-inline the tag regex)"
+        errors=$((errors + 1)); _tag_ok=0
+    fi
+    if grep -Fq '[0-9]+\.[0-9]+\.[0-9]+' "$_f"; then
+        echo "  FAIL: $_f re-inlines the X.Y.Z tag regex; call $_tag_script instead"
+        errors=$((errors + 1)); _tag_ok=0
+    fi
+done
+if [ -x "$_tag_script" ]; then
+    if ! bash "$_tag_script" 1.2.3 >/dev/null 2>&1 || ! bash "$_tag_script" 1.2.3-rc.4 >/dev/null 2>&1; then
+        echo "  FAIL: $_tag_script rejected a well-formed tag (1.2.3 / 1.2.3-rc.4)"
+        errors=$((errors + 1)); _tag_ok=0
+    fi
+    if bash "$_tag_script" 1.2 >/dev/null 2>&1 || bash "$_tag_script" "" >/dev/null 2>&1; then
+        echo "  FAIL: $_tag_script accepted a malformed/empty tag"
+        errors=$((errors + 1)); _tag_ok=0
+    fi
+fi
+[ "$_tag_ok" = 1 ] && echo "  ok: prod + Edge deploy workflows share the tag-format gate ($_tag_script)"
+unset _tag_script _tag_files _tag_ok _f
+
 # Anthropic OAuth tier baseline values now live in exactly one place: the JSON
 # source of truth. The apply SQL is generated from it at runtime (orchestrator
 # reuses the guard's generate_sql), so there is no second hand-aligned copy to


### PR DESCRIPTION
## What

Batch 2 of the workflow god-eye review — **right-sized down from the original plan after exploration.**

The god-eye review flagged "deploy-* arch-gate / SSM logic duplicated across 3 workflows" as HIGH and suggested a `deploy-stage0-core.yml` reusable workflow. Exploration showed that estimate was **too aggressive**:

- The §9.1 arch-gate (`verify_ghcr_manifest.sh`) and the SSM deploy (`deploy_via_ssm.sh`) are **already** single shared scripts.
- A `Stage0 deployment primitive sharing` preflight sentinel uses static grep to require those script calls in the deploy files — a reusable workflow would move the calls out and **break that sentinel**.
- The three files are genuinely different (prod 1-op / EC2-edge 6-op incl. ~240-line EIP rotation + ~90-line decommission / Lightsail 4-op, SSM-resolved). Forcing them into one `workflow_call` = conditional bloat = over-abstraction.

So per operator decision the scope is **narrow**: consolidate only the one thing that was truly duplicated and had **already drifted** — the release-tag format gate.

## Changes

- **`ops/stage0/validate-deploy-tag.sh`** (new): single source of truth for the `X.Y.Z(-rc.N/-beta.N)` tag-format check. Format-only — the per-operation `tag is required` empty-check stays in the edge workflows where its wording is operation-contextual.
- **3 deploy workflows**: replace the inline regex with a one-line call to the script. `deploy-edge-lightsail-stage0.yml`'s error message had drifted shorter (`X.Y.Z` without the `-rc.N / -beta.N` note) — now retired for the canonical message.
- **`scripts/preflight.sh`**: new `Stage0 deploy tag-validation sharing` sentinel — fails closed if any deploy workflow stops calling the script or re-inlines the regex, plus a positive/negative self-test of the gate (so the consolidation can't silently un-converge).

## Explicitly NOT done

- ❌ Reusable `workflow_call` — over-abstraction + breaks the primitive-sharing sentinel.
- ⏸️ Deduping the two edge files' byte-identical smoke/guard blocks (involves the `id` vs `managed_instance_id` divergence) — deferred; can be its own PR.

## Verification

- `validate-deploy-tag.sh`: `1.2.3` / `1.2.3-rc.4` / `1.7.52-beta.1` → exit 0; `1.2` / `x.y.z` / `v1.2.3` / empty → exit 1.
- `PREFLIGHT_BASE=origin/main scripts/preflight.sh` → **PASS**; both `Stage0 deployment primitive sharing` and the new `Stage0 deploy tag-validation sharing` sentinels green; new sentinel's re-inline / missing-script detection negative-tested.
- Behavior-equivalent: same regex in all 3; only visible change is the Lightsail error message becoming the canonical (longer) one.

## Merge

TK-originated chore → **Squash and merge** (§5.y).

🤖 Generated with [Claude Code](https://claude.com/claude-code)