### PR TITLE
chore: align cc fingerprint baseline with 2.1.158

### DIFF
--- a/backend/internal/pkg/claude/constants.go
+++ b/backend/internal/pkg/claude/constants.go
@@ -7,7 +7,7 @@ import "strings"
 
 // Beta header 常量
 //
-// 这里的常量对齐真实 Claude Code CLI 的最新流量（截至 2026-05，cc 2.1.157 抓包）。
+// 这里的常量对齐真实 Claude Code CLI 的最新流量（截至 2026-05，cc 2.1.158 抓包）。
 // Anthropic 上游会基于 anthropic-beta 的完整集合判定请求来源；
 // 缺少任何"官方 Claude Code 请求才会带"的 beta，都会被降级到第三方额度，
 // 对应报错：`Third-party apps now draw from your extra usage, not your plan limits.`
@@ -59,7 +59,7 @@ const MessageBetaHeaderWithTools = BetaClaudeCode + "," + BetaOAuth + "," + Beta
 // CountTokensBetaHeader count_tokens 请求使用的 anthropic-beta header
 const CountTokensBetaHeader = BetaClaudeCode + "," + BetaOAuth + "," + BetaInterleavedThinking + "," + BetaTokenCounting
 
-// HaikuBetaHeader Haiku 模型 OAuth 回退 anthropic-beta（对齐 cc 2.1.157 抓包顺序）。
+// HaikuBetaHeader Haiku 模型 OAuth 回退 anthropic-beta（对齐 cc 2.1.158 structured-outputs 抓包顺序）。
 const HaikuBetaHeader = BetaOAuth + "," + BetaInterleavedThinking + "," + BetaThinkingTokenCount + "," +
 	BetaContextManagement + "," + BetaPromptCachingScope + "," + BetaAdvisorTool + "," +
 	BetaStructuredOutputs + "," + BetaCacheDiagnosis
@@ -78,7 +78,7 @@ const DefaultCacheControlTTL = "5m"
 // CLICurrentVersion 是 sub2api 当前对外伪装的 Claude Code CLI 版本号（三段 semver）。
 // 用于 billing attribution block 中的 cc_version=X.Y.Z.{fp} 前缀以及 fingerprint 计算。
 // 必须与 DefaultHeaders["User-Agent"] 中的版本号严格一致；不一致会被 Anthropic 判第三方。
-const CLICurrentVersion = "2.1.157"
+const CLICurrentVersion = "2.1.158"
 
 // JoinBetaHeader joins beta tokens into the wire anthropic-beta header value.
 func JoinBetaHeader(betas []string) string {
@@ -87,7 +87,7 @@ func JoinBetaHeader(betas []string) string {
 
 // FullClaudeCodeMimicryBetas 返回最"像"真实 Claude Code CLI 的完整 beta 列表（Sonnet/Opus），
 // 用于 OAuth 账号伪装成 Claude Code 时使用。
-// 顺序与 cc 2.1.157 /v1/messages 抓包一致。
+// 顺序与 cc 2.1.158 /v1/messages 抓包一致。
 //
 // 使用建议：
 //   - OAuth 账号 + 非 haiku：追加这整份列表，再按需保留 client 带来的 beta。
@@ -109,7 +109,7 @@ func FullClaudeCodeMimicryBetas() []string {
 	}
 }
 
-// FullClaudeCodeHaikuMimicryBetas 返回 Haiku 模型 OAuth mimicry 的 beta 列表（cc 2.1.157 抓包）。
+// FullClaudeCodeHaikuMimicryBetas 返回 Haiku 模型 OAuth mimicry 的 beta 列表（cc 2.1.158 structured-outputs 抓包）。
 func FullClaudeCodeHaikuMimicryBetas() []string {
 	return []string{
 		BetaOAuth,
@@ -127,7 +127,7 @@ func FullClaudeCodeHaikuMimicryBetas() []string {
 var DefaultHeaders = map[string]string{
 	// Keep these in sync with recent Claude CLI traffic to reduce the chance
 	// that Claude Code-scoped OAuth credentials are rejected as "non-CLI" usage.
-	"User-Agent":                                "claude-cli/2.1.157 (external, cli)",
+	"User-Agent":                                "claude-cli/2.1.158 (external, cli)",
 	"X-Stainless-Lang":                          "js",
 	"X-Stainless-Package-Version":               "0.94.0",
 	"X-Stainless-OS":                            "Linux",

--- a/backend/internal/pkg/claude/constants_test.go
+++ b/backend/internal/pkg/claude/constants_test.go
@@ -9,7 +9,7 @@ import (
 	"github.com/stretchr/testify/require"
 )
 
-func TestFullClaudeCodeMimicryBetas_MatchesCC0157SonnetCapture(t *testing.T) {
+func TestFullClaudeCodeMimicryBetas_MatchesCC0158SonnetCapture(t *testing.T) {
 	want := []string{
 		"claude-code-20250219",
 		"oauth-2025-04-20",
@@ -28,7 +28,7 @@ func TestFullClaudeCodeMimicryBetas_MatchesCC0157SonnetCapture(t *testing.T) {
 	require.NotContains(t, FullClaudeCodeMimicryBetas(), BetaFineGrainedToolStreaming)
 }
 
-func TestFullClaudeCodeHaikuMimicryBetas_MatchesCC0157HaikuCapture(t *testing.T) {
+func TestFullClaudeCodeHaikuMimicryBetas_MatchesCC0158HaikuCapture(t *testing.T) {
 	want := []string{
 		"oauth-2025-04-20",
 		"interleaved-thinking-2025-05-14",

--- a/backend/internal/service/gateway_context_management_test.go
+++ b/backend/internal/service/gateway_context_management_test.go
@@ -431,7 +431,7 @@ func TestBuildUpstreamRequest_OAuthMimicHaiku_StripsContextManagementEndToEnd(t 
 	//   - body：Anthropic 对 claude-haiku-4-5 的 body.context_management 返回 400
 	//     ("context_management: Extra inputs are not permitted")，所以 body 必须 strip。
 	//     computeFinalAnthropicBeta 的 haiku 分支刻意不含 context-management，正好驱动 strip。
-	//   - header：真实 Claude Code 2.1.157 抓包（8/8 match，.tls_list/20260530…cc-capture.bundle.json；
+	//   - header：真实 Claude Code 2.1.158 抓包（haiku comprehensive 双峰都含 context-management；
 	//     FullClaudeCodeHaikuMimicryBetas 含 BetaContextManagement）确认 haiku 请求**确实**带
 	//     context-management beta header —— 剥掉它会破指纹、被 Anthropic 判 third-party。
 	body := []byte(`{"model":"claude-haiku-4-5","context_management":{"edits":[{"type":"clear_thinking_20251015"}]},"messages":[]}`)
@@ -448,7 +448,7 @@ func TestBuildUpstreamRequest_OAuthMimicHaiku_StripsContextManagementEndToEnd(t 
 	require.False(t, gjson.GetBytes(outBody, "context_management").Exists(),
 		"OAuth mimic + haiku 端到端：outgoing body 不应含 context_management（Anthropic 对 haiku 返回 400）")
 	require.True(t, anthropicBetaTokensContains(outBeta, claude.BetaContextManagement),
-		"指纹对齐：outgoing anthropic-beta header 必须带 context-management beta（真实 cc 2.1.157 haiku 就带）")
+		"指纹对齐：outgoing anthropic-beta header 必须带 context-management beta（真实 cc 2.1.158 haiku 就带）")
 }
 
 func TestBuildUpstreamRequest_OAuthMimicNonHaiku_PreservesContextManagementEndToEnd(t *testing.T) {

--- a/backend/internal/service/identity_service.go
+++ b/backend/internal/service/identity_service.go
@@ -26,7 +26,7 @@ var (
 
 // 默认指纹值（当客户端未提供时使用）
 var defaultFingerprint = Fingerprint{
-	UserAgent:               "claude-cli/2.1.157 (external, cli)",
+	UserAgent:               "claude-cli/2.1.158 (external, cli)",
 	StainlessLang:           "js",
 	StainlessPackageVersion: "0.94.0",
 	StainlessOS:             "Linux",

--- a/backend/internal/service/identity_service_tk_canonical_http.go
+++ b/backend/internal/service/identity_service_tk_canonical_http.go
@@ -56,7 +56,7 @@ const (
 	// neither env nor runtime resolver provides a value. Keep in sync with
 	// the most recent cc CLI release this build was validated against; the
 	// admin UI / runtime resolver is the normal update path going forward.
-	DefaultClaudeCodeUserAgentVersion = "2.1.157"
+	DefaultClaudeCodeUserAgentVersion = "2.1.158"
 
 	// canonicalUAPrefix / canonicalUASuffix wrap the version-only field.
 	// Matches the wire shape Anthropic observes from a real Claude Code CLI

--- a/deploy/aws/stage0/anthropic-http-mimicry-baselines.json
+++ b/deploy/aws/stage0/anthropic-http-mimicry-baselines.json
@@ -1,6 +1,6 @@
 {
   "schema_version": 1,
-  "cc_version": "2.1.157",
+  "cc_version": "2.1.158",
   "description": "Canonical OAuth HTTP mimicry betas for Claude Code CLI. Live wire values are driven at runtime by settings.claude_code_http_mimicry_manifest (sync-runtime / plan-http-mimicry-sync). Compile-time defaults in backend/internal/pkg/claude/constants.go catch up on the release train.",
   "sonnet_opus": [
     "claude-code-20250219",

--- a/deploy/aws/stage0/tk_canonical_cc_oauth.json
+++ b/deploy/aws/stage0/tk_canonical_cc_oauth.json
@@ -1,6 +1,6 @@
 {
   "name": "tk_canonical_cc_oauth",
-  "description": "TokenKey canonical Claude Code OAuth TLS profile. Stable id intentionally decoupled from cc CLI patch version: TLS ClientHello is byte-identical across 2.1.142 (2026-05-15 capture, ja3_hash=d871d02cecbde59abbf8f4806134addf) through 2.1.157 (2026-05-30 cc0 capture), so a new patch release never triggers a rename. HTTP observed.user_agent below is a compile-time snapshot; the live wire UA is driven at runtime by SettingService.GetClaudeCodeUserAgentVersion (admin setting → env CLAUDE_CODE_USER_AGENT_VERSION → compile default). runtime=node v24.3.0 darwin/arm64.",
+  "description": "TokenKey canonical Claude Code OAuth TLS profile. Stable id intentionally decoupled from cc CLI patch version: TLS ClientHello is byte-identical across 2.1.142 (2026-05-15 capture, ja3_hash=d871d02cecbde59abbf8f4806134addf) through 2.1.158 (2026-05-30 cc0 capture), so a new patch release never triggers a rename. HTTP observed.user_agent below is a compile-time snapshot; the live wire UA is driven at runtime by SettingService.GetClaudeCodeUserAgentVersion (admin setting → env CLAUDE_CODE_USER_AGENT_VERSION → compile default). runtime=node v24.3.0 darwin/arm64.",
   "enable_grease": false,
   "cipher_suites": [
     4865,
@@ -71,7 +71,7 @@
   ],
   "observed": {
     "model": "claude-haiku-4-5-20251001",
-    "user_agent": "claude-cli/2.1.157 (external, sdk-cli)",
+    "user_agent": "claude-cli/2.1.158 (external, sdk-cli)",
     "stainless_os": "MacOS",
     "stainless_arch": "arm64",
     "stainless_runtime": "node",

--- a/docs/spec-delta-cc-2.1.158.md
+++ b/docs/spec-delta-cc-2.1.158.md
@@ -1,0 +1,58 @@
+# spec-delta: cc 2.1.158 UA alignment
+
+## Background
+
+cc 2.1.158 mitm + TLS capture (2026-05-30, cc0 -> gost -> socks) shows **UA-only** drift from 2.1.157. TLS ClientHello is unchanged (`ja3_hash=d871d02cecbde59abbf8f4806134addf`). Stainless package version remains `0.94.0`.
+
+`capture-http-comprehensive.sh` (3x3x2) showed Sonnet and Opus stable at one beta header each. Haiku remains bimodal: the structured-outputs path is still the captured baseline, while a minority path adds `claude-code-20250219` and `extended-cache-ttl-2025-04-11` and drops `structured-outputs-2025-12-15`. Because haiku is split, this PR does not change beta constants.
+
+## Delta
+
+### MODIFIED
+
+- `DefaultClaudeCodeUserAgentVersion` / `CLICurrentVersion` / mimic + canonical observed UA: **2.1.157 -> 2.1.158**.
+- `anthropic-http-mimicry-baselines.json` `cc_version` field.
+- Smoke default UA, sentinel rationale, capture baseline test, and comments that name the latest cc capture.
+- `capture-cc-fingerprint.sh check env` no-arg invocation now works on macOS Bash 3.2 with `set -u`.
+
+### NOT changed
+
+- TLS ja3 / `tk_canonical_cc_oauth` cipher profile bodies.
+- `FullClaudeCodeMimicryBetas()` / `FullClaudeCodeHaikuMimicryBetas()` token lists.
+- Stainless package/runtime fields.
+
+## Scenarios
+
+### Core positive
+
+1. Given cc 2.1.158 bundle, when `capture_cc_fingerprint.py check --bundle` runs against repo baseline, then all critical HTTP+TLS fields match.
+2. Given OAuth forward on canonical path, when UA is built, then wire version is 2.1.158.
+
+### Core negative
+
+1. Given stale 2.1.157 constants, when check runs against 2.1.158 capture, then UA mismatches fail the gate.
+
+### Regression
+
+- `TestFullClaudeCodeMimicryBetas_MatchesCC0158*` pass.
+- TLS `check-tls` on capture bundle: OK.
+
+## Validation
+
+```bash
+bash ops/anthropic/capture-cc-fingerprint.sh capture --http
+bash ops/anthropic/capture-http-comprehensive.sh
+python3 ops/anthropic/capture_cc_fingerprint.py check --bundle /Users/xuejiao/Codes/token/tk/sub2api/.tls_list/20260530T062407Z-cc-capture.bundle.json
+bash ops/anthropic/capture-cc-fingerprint.sh check-tls --bundle /Users/xuejiao/Codes/token/tk/sub2api/.tls_list/20260530T062407Z-cc-capture.bundle.json
+go test -tags=unit ./internal/pkg/claude/... -run TestFullClaudeCode
+python3 -m unittest discover -s ops/anthropic -p 'test_capture_cc_fingerprint.py' -t ops/anthropic
+./scripts/preflight.sh
+```
+
+Post-merge runtime sync (no release required for HTTP UA):
+
+```bash
+bash ops/anthropic/cc_fingerprint_apply_http_runtime.sh
+```
+
+Evidence: `.tls_list/20260530T062407Z-cc-capture.bundle.json`, `.tls_list/20260530T062431Z-http-multi.log` (comprehensive; haiku WARN bimodal).

--- a/ops/anthropic/capture-cc-fingerprint.sh
+++ b/ops/anthropic/capture-cc-fingerprint.sh
@@ -272,7 +272,10 @@ cmd_check_env() {
       *) echo "unknown check env arg: $1" >&2; usage; exit 1 ;;
     esac
   done
-  exec python3 "$PY" check-env "${args[@]}"
+  if ((${#args[@]})); then
+    exec python3 "$PY" check-env "${args[@]}"
+  fi
+  exec python3 "$PY" check-env
 }
 
 main() {

--- a/ops/anthropic/cc_fingerprint_daily_hook.sh
+++ b/ops/anthropic/cc_fingerprint_daily_hook.sh
@@ -47,8 +47,14 @@ env_flags=()
 [[ "$relax" == "1" ]] && env_flags+=(--relax-desktop)
 [[ "$skip_egress" == "1" ]] && env_flags+=(--skip-egress)
 
-log "check env (${env_flags[*]})"
-if ! bash "$CAPTURE_SH" check env "${env_flags[@]}" >>"$LOG_FILE" 2>&1; then
+if ((${#env_flags[@]})); then
+  log "check env (${env_flags[*]})"
+  check_env_cmd=(bash "$CAPTURE_SH" check env "${env_flags[@]}")
+else
+  log "check env (no flags)"
+  check_env_cmd=(bash "$CAPTURE_SH" check env)
+fi
+if ! "${check_env_cmd[@]}" >>"$LOG_FILE" 2>&1; then
   log "FAIL: check-env — start cc0-here / claude0-here stack before daily capture"
   printf '%s\n' "$today" >"$STATE_FILE"
   exit 0

--- a/ops/anthropic/test_capture_cc_fingerprint.py
+++ b/ops/anthropic/test_capture_cc_fingerprint.py
@@ -22,7 +22,7 @@ class CaptureCCFingerprintTest(unittest.TestCase):
     def test_load_tokenkey_baseline_has_expected_keys(self) -> None:
         baseline = mod.load_tokenkey_baseline(mod.REPO_ROOT)
         self.assertEqual(baseline["tls"]["ja3_hash"], "d871d02cecbde59abbf8f4806134addf")
-        self.assertEqual(baseline["canonical_http"]["default_version"], "2.1.157")
+        self.assertEqual(baseline["canonical_http"]["default_version"], "2.1.158")
         self.assertEqual(baseline["mimic_http"]["stainless_package_version"], "0.94.0")
         self.assertIn("claude-code-20250219", baseline["betas"]["sonnet_mimicry"])
         self.assertNotIn("effort-2025-11-24", baseline["betas"]["sonnet_mimicry"])

--- a/ops/stage0/smoke_lib.sh
+++ b/ops/stage0/smoke_lib.sh
@@ -49,7 +49,7 @@ if [[ -z "${_TK_SMOKE_LIB_LOADED:-}" ]]; then
   }
 
   smoke_default_claude_user_agent() {
-    printf '%s' "${TK_SMOKE_CLAUDE_USER_AGENT:-claude-cli/2.1.157 (external, sdk-cli)}"
+    printf '%s' "${TK_SMOKE_CLAUDE_USER_AGENT:-claude-cli/2.1.158 (external, sdk-cli)}"
   }
 
   # soft_degrade_or_exit — see post_deploy_smoke.sh header for contract.

--- a/scripts/sentinels/gateway-tk.json
+++ b/scripts/sentinels/gateway-tk.json
@@ -1139,7 +1139,7 @@
         "func FullClaudeCodeHaikuMimicryBetas()",
         "func JoinBetaHeader("
       ],
-      "rationale": "OAuth Claude Code mimicry beta registry: Sonnet/Opus and Haiku sets must stay aligned with real cc CLI traffic (cc 2.1.157 capture). Dropping thinking-token-count / structured-outputs or reverting Haiku to the legacy claude-code + extended-cache-ttl set re-opens third-party cohort signals on OAuth subscriptions."
+      "rationale": "OAuth Claude Code mimicry beta registry: Sonnet/Opus and Haiku sets must stay aligned with real cc CLI traffic (cc 2.1.158 capture). Dropping thinking-token-count / structured-outputs or reverting Haiku to the legacy claude-code + extended-cache-ttl set re-opens third-party cohort signals on OAuth subscriptions."
     },
     {
       "path": "backend/internal/handler/gateway_handler.go",


### PR DESCRIPTION
Summary
- Align Claude Code HTTP fingerprint defaults and runtime baseline metadata from 2.1.157 to captured 2.1.158.
- Keep TLS ja3/stainless/beta token lists unchanged; document haiku beta bimodality in spec-delta.
- Fix capture check-env no-arg handling on macOS Bash 3.2 with set -u.

Risk
- Low operational risk: UA/version-only drift fix; no TLS cipher material or beta list changes.
- Post-merge runtime sync remains required for live HTTP UA setting: bash ops/anthropic/cc_fingerprint_apply_http_runtime.sh

Validation
- bash ops/anthropic/capture-cc-fingerprint.sh capture --http
- bash ops/anthropic/capture-http-comprehensive.sh (haiku WARN bimodal, sonnet/opus stable)
- python3 ops/anthropic/capture_cc_fingerprint.py check --bundle /Users/xuejiao/Codes/token/tk/sub2api/.tls_list/20260530T062407Z-cc-capture.bundle.json
- bash ops/anthropic/capture-cc-fingerprint.sh check-tls --bundle /Users/xuejiao/Codes/token/tk/sub2api/.tls_list/20260530T062407Z-cc-capture.bundle.json
- go test -tags=unit ./internal/pkg/claude/... -run TestFullClaudeCode
- python3 -m unittest discover -s ops/anthropic -p test_capture_cc_fingerprint.py -t ops/anthropic
- go test -tags=unit ./internal/service/... -run TestBuildUpstreamRequest_OAuthMimicHaiku|TestClaudeCodeMimicryManifest|TestCanonicalUserAgent|TestIdentity
- ./scripts/preflight.sh