### PR TITLE
chore(ci): extract run-headless-agent composite for the 4 agent workflows

### DIFF
--- a/.github/actions/run-headless-agent/action.yml
+++ b/.github/actions/run-headless-agent/action.yml
@@ -1,0 +1,132 @@
+name: Run headless Claude agent
+description: >-
+  Single source of truth for the headless `claude -p` scaffold shared by the
+  TokenKey agent workflows (pr-repair-agent, upstream-issue-watchdog,
+  upstream-merge-agent-daily, ops-daily-diagnostics). Installs the Claude Code
+  CLI, stages the secret redactor from origin/main (fail-closed), and runs the
+  agent with the canonical thinking-env, streaming the transcript through the
+  redactor to an output file. Callers keep their own prompt construction, git /
+  PR / issue logic, and artifact upload. Previously each workflow hand-copied
+  this block and the values had already drifted (ops-daily-diagnostics ran
+  MAX_THINKING_TOKENS=16000 and omitted set -o pipefail + autocompact).
+
+inputs:
+  prompt-file:
+    description: Path to the file holding the agent prompt (read via cat).
+    required: true
+  model:
+    description: ANTHROPIC_MODEL / --model (e.g. "opus[1m]", "claude-sonnet-4-6"). No default — callers state it explicitly (CLAUDE.md §4).
+    required: true
+  max-budget-usd:
+    description: --max-budget-usd cap. No default — callers state it explicitly (CLAUDE.md §4 headless discipline).
+    required: true
+  allowed-tools:
+    description: --allowedTools whitelist, space-separated (e.g. "Read Grep Glob" or "Bash Read Write Edit Grep Glob").
+    required: true
+  auth-token:
+    description: TokenKey gateway token consumed as ANTHROPIC_AUTH_TOKEN. Pass from secrets.
+    required: true
+  output-file:
+    description: Where to tee the redacted JSONL transcript. The caller uploads it as an artifact.
+    required: true
+  base-url:
+    description: Claude Code gateway base URL.
+    required: false
+    default: "https://api.tokenkey.dev"
+  gh-token:
+    description: Optional GH_TOKEN exported into the agent env (for agents that git-push / call gh). Empty = not set.
+    required: false
+    default: ""
+  fail-on-error:
+    description: >-
+      "true" (default) fails the step when the agent exits non-zero. "false"
+      exposes the agent exit code as the `exit_code` output and the step
+      succeeds, so the caller can branch on it (used by upstream-merge-agent's
+      retry logic).
+    required: false
+    default: "true"
+
+outputs:
+  exit_code:
+    description: The agent's exit code (PIPESTATUS[0]), set regardless of fail-on-error.
+    value: ${{ steps.agent.outputs.exit_code }}
+
+runs:
+  using: composite
+  steps:
+    - name: Stage agent stream redactor from origin/main (fail-closed)
+      shell: bash
+      run: |
+        # The redactor scrubs secrets from the agent stream before `tee` writes
+        # the artifact. Actions live-log masking does NOT apply to bytes that hit
+        # disk via tee, so this is the ONLY control between the transcript and a
+        # leaked gateway/github token in a public artifact. Stage it from the
+        # TRUSTED origin/main (NOT the caller's worktree, which on a PR branch
+        # could be attacker-influenced) into RUNNER_TEMP (never the worktree, so
+        # it can't leak into the agent's `git add -A`). FAIL-CLOSED: if
+        # origin/main lacks it, refuse to run rather than upload unredacted.
+        set -euo pipefail
+        git fetch origin main --depth=1 >/dev/null 2>&1 || true
+        if git show origin/main:scripts/agent/redact-stream.py > "${RUNNER_TEMP}/redact-agent-stream.py" 2>/dev/null; then
+          echo "ok: staged scripts/agent/redact-stream.py from origin/main"
+        else
+          echo "::error::scripts/agent/redact-stream.py not found on origin/main — refusing to run the agent unredacted (fail-closed)."
+          exit 1
+        fi
+
+    - name: Install Claude Code CLI
+      shell: bash
+      env:
+        ANTHROPIC_AUTH_TOKEN: ${{ inputs.auth-token }}
+      run: bash scripts/agent/setup-claude-code.sh
+
+    - name: Run Claude agent
+      id: agent
+      shell: bash
+      env:
+        ANTHROPIC_AUTH_TOKEN: ${{ inputs.auth-token }}
+        ANTHROPIC_BASE_URL: ${{ inputs.base-url }}
+        GH_TOKEN: ${{ inputs.gh-token }}
+        ANTHROPIC_MODEL: ${{ inputs.model }}
+        # Canonical thinking-env — the single source of truth this action exists
+        # to enforce. Keep here, not in callers.
+        CLAUDE_CODE_DISABLE_ADAPTIVE_THINKING: "1"
+        MAX_THINKING_TOKENS: "31999"
+        CLAUDE_CODE_AUTOCOMPACT_PCT_OVERRIDE: "60"
+        CLAUDE_CODE_ATTRIBUTION_HEADER: "0"
+        # Inputs mapped to env (not interpolated into the run script) to avoid
+        # shell-injection from input values.
+        PROMPT_FILE: ${{ inputs.prompt-file }}
+        MAX_BUDGET_USD: ${{ inputs.max-budget-usd }}
+        ALLOWED_TOOLS: ${{ inputs.allowed-tools }}
+        OUTPUT_FILE: ${{ inputs.output-file }}
+        FAIL_ON_ERROR: ${{ inputs.fail-on-error }}
+      run: |
+        # claude CLI has no --output flag — pipe stdout. `set -o pipefail`
+        # propagates claude's exit code through the redactor pipeline.
+        # --allowedTools is REQUIRED in headless mode (without it `claude -p`
+        # defaults to interactive permission mode and rejects every tool call).
+        # --output-format stream-json --verbose lands the full transcript (tool
+        # calls / results / cost / errors) as JSONL. The redactor still scrubs
+        # token patterns inside JSON strings line-by-line.
+        # --exclude-dynamic-system-prompt-sections stabilizes the system-prompt
+        # prefix for ephemeral prompt-cache hits across runs.
+        set -o pipefail
+        set +e
+        claude -p "$(cat "${PROMPT_FILE}")" \
+          --model "${ANTHROPIC_MODEL}" \
+          --max-budget-usd "${MAX_BUDGET_USD}" \
+          --allowedTools "${ALLOWED_TOOLS}" \
+          --output-format stream-json --verbose \
+          --exclude-dynamic-system-prompt-sections \
+          2>&1 \
+          | python3 "${RUNNER_TEMP}/redact-agent-stream.py" \
+          | tee "${OUTPUT_FILE}"
+        code=${PIPESTATUS[0]}
+        set -e
+        echo "exit_code=${code}" >> "$GITHUB_OUTPUT"
+        echo "agent exited with code ${code}"
+        if [ "${FAIL_ON_ERROR}" = "true" ] && [ "${code}" -ne 0 ]; then
+          echo "::error::headless agent exited ${code}"
+          exit "${code}"
+        fi

--- a/.github/actions/run-headless-agent/action.yml
+++ b/.github/actions/run-headless-agent/action.yml
@@ -11,33 +11,33 @@ description: >-
   MAX_THINKING_TOKENS=16000 and omitted set -o pipefail + autocompact).
 
 inputs:
-  prompt-file:
+  prompt_file:
     description: Path to the file holding the agent prompt (read via cat).
     required: true
   model:
     description: ANTHROPIC_MODEL / --model (e.g. "opus[1m]", "claude-sonnet-4-6"). No default — callers state it explicitly (CLAUDE.md §4).
     required: true
-  max-budget-usd:
+  max_budget_usd:
     description: --max-budget-usd cap. No default — callers state it explicitly (CLAUDE.md §4 headless discipline).
     required: true
-  allowed-tools:
+  allowed_tools:
     description: --allowedTools whitelist, space-separated (e.g. "Read Grep Glob" or "Bash Read Write Edit Grep Glob").
     required: true
-  auth-token:
+  auth_token:
     description: TokenKey gateway token consumed as ANTHROPIC_AUTH_TOKEN. Pass from secrets.
     required: true
-  output-file:
+  output_file:
     description: Where to tee the redacted JSONL transcript. The caller uploads it as an artifact.
     required: true
-  base-url:
+  base_url:
     description: Claude Code gateway base URL.
     required: false
     default: "https://api.tokenkey.dev"
-  gh-token:
+  gh_token:
     description: Optional GH_TOKEN exported into the agent env (for agents that git-push / call gh). Empty = not set.
     required: false
     default: ""
-  fail-on-error:
+  fail_on_error:
     description: >-
       "true" (default) fails the step when the agent exits non-zero. "false"
       exposes the agent exit code as the `exit_code` output and the step
@@ -48,7 +48,7 @@ inputs:
 
 outputs:
   exit_code:
-    description: The agent's exit code (PIPESTATUS[0]), set regardless of fail-on-error.
+    description: The agent's exit code (PIPESTATUS[0]), set regardless of fail_on_error.
     value: ${{ steps.agent.outputs.exit_code }}
 
 runs:
@@ -66,7 +66,7 @@ runs:
         # it can't leak into the agent's `git add -A`). FAIL-CLOSED: if
         # origin/main lacks it, refuse to run rather than upload unredacted.
         set -euo pipefail
-        git fetch origin main --depth=1 >/dev/null 2>&1 || true
+        git fetch origin main --depth=1 >/dev/null 2>&1 || true  # preflight-allow: swallow — best-effort fetch; the fail-closed `git show` below is the real gate
         if git show origin/main:scripts/agent/redact-stream.py > "${RUNNER_TEMP}/redact-agent-stream.py" 2>/dev/null; then
           echo "ok: staged scripts/agent/redact-stream.py from origin/main"
         else
@@ -77,16 +77,16 @@ runs:
     - name: Install Claude Code CLI
       shell: bash
       env:
-        ANTHROPIC_AUTH_TOKEN: ${{ inputs.auth-token }}
+        ANTHROPIC_AUTH_TOKEN: ${{ inputs.auth_token }}
       run: bash scripts/agent/setup-claude-code.sh
 
     - name: Run Claude agent
       id: agent
       shell: bash
       env:
-        ANTHROPIC_AUTH_TOKEN: ${{ inputs.auth-token }}
-        ANTHROPIC_BASE_URL: ${{ inputs.base-url }}
-        GH_TOKEN: ${{ inputs.gh-token }}
+        ANTHROPIC_AUTH_TOKEN: ${{ inputs.auth_token }}
+        ANTHROPIC_BASE_URL: ${{ inputs.base_url }}
+        GH_TOKEN: ${{ inputs.gh_token }}
         ANTHROPIC_MODEL: ${{ inputs.model }}
         # Canonical thinking-env — the single source of truth this action exists
         # to enforce. Keep here, not in callers.
@@ -96,11 +96,11 @@ runs:
         CLAUDE_CODE_ATTRIBUTION_HEADER: "0"
         # Inputs mapped to env (not interpolated into the run script) to avoid
         # shell-injection from input values.
-        PROMPT_FILE: ${{ inputs.prompt-file }}
-        MAX_BUDGET_USD: ${{ inputs.max-budget-usd }}
-        ALLOWED_TOOLS: ${{ inputs.allowed-tools }}
-        OUTPUT_FILE: ${{ inputs.output-file }}
-        FAIL_ON_ERROR: ${{ inputs.fail-on-error }}
+        PROMPT_FILE: ${{ inputs.prompt_file }}
+        MAX_BUDGET_USD: ${{ inputs.max_budget_usd }}
+        ALLOWED_TOOLS: ${{ inputs.allowed_tools }}
+        OUTPUT_FILE: ${{ inputs.output_file }}
+        FAIL_ON_ERROR: ${{ inputs.fail_on_error }}
       run: |
         # claude CLI has no --output flag — pipe stdout. `set -o pipefail`
         # propagates claude's exit code through the redactor pipeline.
@@ -112,7 +112,7 @@ runs:
         # --exclude-dynamic-system-prompt-sections stabilizes the system-prompt
         # prefix for ephemeral prompt-cache hits across runs.
         set -o pipefail
-        set +e
+        set +e  # preflight-allow: swallow — deliberate exit-code capture; PIPESTATUS read below, then set -e restored
         claude -p "$(cat "${PROMPT_FILE}")" \
           --model "${ANTHROPIC_MODEL}" \
           --max-budget-usd "${MAX_BUDGET_USD}" \

--- a/.github/workflows/ops-daily-diagnostics.yml
+++ b/.github/workflows/ops-daily-diagnostics.yml
@@ -659,12 +659,6 @@ jobs:
             : > claude-issue-diagnosis.jsonl
           fi
 
-      - name: Install Claude Code CLI
-        if: steps.claude_token.outputs.present == 'true'
-        env:
-          ANTHROPIC_AUTH_TOKEN: ${{ secrets.ANTHROPIC_AUTH_TOKEN }}
-        run: bash scripts/agent/setup-claude-code.sh
-
       - name: Build read-only diagnosis prompt
         if: steps.claude_token.outputs.present == 'true'
         run: |
@@ -687,25 +681,20 @@ jobs:
       - name: Run Claude read-only diagnosis
         if: steps.claude_token.outputs.present == 'true'
         id: claude_run
+        # continue-on-error stays: a failed diagnosis falls back to deterministic
+        # issue bodies. Via the shared action this now also gains set -o pipefail
+        # (previously omitted here, so a claude failure was masked by tee's exit
+        # code) and the canonical thinking-env (was MAX_THINKING_TOKENS=16000;
+        # the $1 budget still caps cost) + the origin/main fail-closed redactor.
         continue-on-error: true
-        env:
-          ANTHROPIC_AUTH_TOKEN: ${{ secrets.ANTHROPIC_AUTH_TOKEN }}
-          ANTHROPIC_BASE_URL: https://api.tokenkey.dev
-          CLAUDE_CODE_DISABLE_ADAPTIVE_THINKING: "1"
-          MAX_THINKING_TOKENS: "16000"
-          CLAUDE_CODE_ATTRIBUTION_HEADER: "0"
-          ANTHROPIC_MODEL: opus[1m]
-        run: |
-          set -o pipefail
-          claude -p "$(cat /tmp/claude-issue-prompt.txt)" \
-            --model "opus[1m]" \
-            --max-budget-usd "1.00" \
-            --output-format stream-json --verbose \
-            --exclude-dynamic-system-prompt-sections \
-            --allowedTools "Read Grep Glob" \
-            2>&1 \
-            | python3 scripts/agent/redact-stream.py \
-            | tee claude-issue-diagnosis.jsonl
+        uses: ./.github/actions/run-headless-agent
+        with:
+          prompt-file: /tmp/claude-issue-prompt.txt
+          model: "opus[1m]"
+          max-budget-usd: "1.00"
+          allowed-tools: "Read Grep Glob"
+          auth-token: ${{ secrets.ANTHROPIC_AUTH_TOKEN }}
+          output-file: claude-issue-diagnosis.jsonl
 
       - name: Extract Claude diagnosis
         if: steps.claude_token.outputs.present == 'true'

--- a/.github/workflows/ops-daily-diagnostics.yml
+++ b/.github/workflows/ops-daily-diagnostics.yml
@@ -689,12 +689,12 @@ jobs:
         continue-on-error: true
         uses: ./.github/actions/run-headless-agent
         with:
-          prompt-file: /tmp/claude-issue-prompt.txt
+          prompt_file: /tmp/claude-issue-prompt.txt
           model: "opus[1m]"
-          max-budget-usd: "1.00"
-          allowed-tools: "Read Grep Glob"
-          auth-token: ${{ secrets.ANTHROPIC_AUTH_TOKEN }}
-          output-file: claude-issue-diagnosis.jsonl
+          max_budget_usd: "1.00"
+          allowed_tools: "Read Grep Glob"
+          auth_token: ${{ secrets.ANTHROPIC_AUTH_TOKEN }}
+          output_file: claude-issue-diagnosis.jsonl
 
       - name: Extract Claude diagnosis
         if: steps.claude_token.outputs.present == 'true'

--- a/.github/workflows/pr-repair-agent.yml
+++ b/.github/workflows/pr-repair-agent.yml
@@ -217,42 +217,11 @@ jobs:
         run: pnpm install --frozen-lockfile
         working-directory: frontend
 
-      - name: Install Claude Code CLI
-        if: steps.target.outputs.skip != 'true'
-        env:
-          ANTHROPIC_AUTH_TOKEN: ${{ secrets.ANTHROPIC_AUTH_TOKEN }}
-        run: bash scripts/agent/setup-claude-code.sh
-
       - name: Configure git identity
         if: steps.target.outputs.skip != 'true'
         run: |
           git config user.name "tk-pr-repair-agent[bot]"
           git config user.email "pr-repair-agent@tokenkey.dev"
-
-      - name: Stage agent stream redactor from origin/main
-        if: steps.target.outputs.skip != 'true'
-        run: |
-          # PR branches can predate the redactor commit on main. Pull the
-          # current redactor to /tmp/ (NOT into the PR branch worktree, so
-          # it cannot leak into the agent's `git add -A`) and use it from
-          # there. If origin/main also lacks the file, fall back to a
-          # passthrough so the step doesn't hard-fail an otherwise valid
-          # repair run — but in that fallback the artifact is unfiltered
-          # and the warning is loud.
-          set -euo pipefail
-          git fetch origin main --depth=1 >/dev/null 2>&1 || true
-          if git show origin/main:scripts/agent/redact-stream.py > /tmp/redact-agent-stream.py 2>/dev/null; then
-            chmod +x /tmp/redact-agent-stream.py
-            echo "ok: staged scripts/agent/redact-stream.py from origin/main"
-          else
-            echo "::warning::scripts/agent/redact-stream.py missing on origin/main — agent artifact will be unfiltered"
-            cat > /tmp/redact-agent-stream.py <<'PYEOF'
-          import sys
-          for line in sys.stdin:
-              sys.stdout.write(line)
-              sys.stdout.flush()
-          PYEOF
-          fi
 
       - name: Collect failed run logs
         if: steps.target.outputs.skip != 'true'
@@ -323,49 +292,18 @@ jobs:
 
       - name: Run Claude repair agent
         if: steps.target.outputs.skip != 'true'
-        env:
-          ANTHROPIC_AUTH_TOKEN: ${{ secrets.ANTHROPIC_AUTH_TOKEN }}
-          ANTHROPIC_BASE_URL: https://api.tokenkey.dev
-          GH_TOKEN: ${{ secrets.UPSTREAM_MERGE_GH_TOKEN }}
-          CLAUDE_CODE_DISABLE_ADAPTIVE_THINKING: "1"
-          MAX_THINKING_TOKENS: "31999"
-          CLAUDE_CODE_AUTOCOMPACT_PCT_OVERRIDE: "60"
-          CLAUDE_CODE_ATTRIBUTION_HEADER: "0"
-          ANTHROPIC_MODEL: "opus[1m]"
-        run: |
-          # claude CLI has no --output flag — pipe stdout instead. tee keeps
-          # CI logs live (helpful for long agent runs); pipefail propagates
-          # claude's exit code through the pipeline so the step actually
-          # fails when the agent fails.
-          # --allowedTools is required in headless: without it Claude prompt-mode run
-          # defaults to interactive `default` permission mode and rejects
-          # every tool call with "This command requires approval" (same
-          # failure mode the upstream merge agent hit on 2026-05-06).
-          # Whitelist the work toolkit explicitly per global CLAUDE.md §5.
-          # /tmp/redact-agent-stream.py was staged from origin/main above;
-          # it scrubs secrets out of the stream so the artifact uploaded
-          # to GitHub Actions cannot leak ANTHROPIC_AUTH_TOKEN / GH_TOKEN
-          # even if the agent echoes them. Live-log masking does NOT
-          # apply to bytes that hit disk via tee.
-          # --output-format stream-json + --verbose makes the agent
-          # transcript (tool calls, results, final cost / errors /
-          # permission denials) land in the artifact as JSONL — without
-          # it Claude prompt-mode run only writes the final reply text and a
-          # mid-SOP failure leaves the artifact empty.
-          # --exclude-dynamic-system-prompt-sections keeps the system
-          # prompt prefix stable across runs so the 1h ephemeral prompt
-          # cache can be hit by chained workflow_run repairs and manual
-          # re-dispatches. See upstream-merge-agent-daily.yml for full
-          # rationale.
-          set -o pipefail
-          claude -p "$(cat /tmp/pr-repair-prompt.txt)" --allowedTools "Bash Read Write Edit Grep Glob" \
-            --model "opus[1m]" \
-            --max-budget-usd "8.00" \
-            --output-format stream-json --verbose \
-            --exclude-dynamic-system-prompt-sections \
-            2>&1 \
-            | python3 /tmp/redact-agent-stream.py \
-            | tee /tmp/pr-repair-agent-output.txt
+        # Shared headless-agent scaffold (CLI install + origin/main redactor
+        # staging fail-closed + canonical thinking-env + claude→redact→tee).
+        # fail-on-error defaults true → preserves the prior hard-fail behavior.
+        uses: ./.github/actions/run-headless-agent
+        with:
+          prompt-file: /tmp/pr-repair-prompt.txt
+          model: "opus[1m]"
+          max-budget-usd: "8.00"
+          allowed-tools: "Bash Read Write Edit Grep Glob"
+          auth-token: ${{ secrets.ANTHROPIC_AUTH_TOKEN }}
+          gh-token: ${{ secrets.UPSTREAM_MERGE_GH_TOKEN }}
+          output-file: /tmp/pr-repair-agent-output.txt
 
       - name: Upload repair artifacts
         if: always()

--- a/.github/workflows/pr-repair-agent.yml
+++ b/.github/workflows/pr-repair-agent.yml
@@ -294,16 +294,16 @@ jobs:
         if: steps.target.outputs.skip != 'true'
         # Shared headless-agent scaffold (CLI install + origin/main redactor
         # staging fail-closed + canonical thinking-env + claude→redact→tee).
-        # fail-on-error defaults true → preserves the prior hard-fail behavior.
+        # fail_on_error defaults true → preserves the prior hard-fail behavior.
         uses: ./.github/actions/run-headless-agent
         with:
-          prompt-file: /tmp/pr-repair-prompt.txt
+          prompt_file: /tmp/pr-repair-prompt.txt
           model: "opus[1m]"
-          max-budget-usd: "8.00"
-          allowed-tools: "Bash Read Write Edit Grep Glob"
-          auth-token: ${{ secrets.ANTHROPIC_AUTH_TOKEN }}
-          gh-token: ${{ secrets.UPSTREAM_MERGE_GH_TOKEN }}
-          output-file: /tmp/pr-repair-agent-output.txt
+          max_budget_usd: "8.00"
+          allowed_tools: "Bash Read Write Edit Grep Glob"
+          auth_token: ${{ secrets.ANTHROPIC_AUTH_TOKEN }}
+          gh_token: ${{ secrets.UPSTREAM_MERGE_GH_TOKEN }}
+          output_file: /tmp/pr-repair-agent-output.txt
 
       - name: Upload repair artifacts
         if: always()

--- a/.github/workflows/upstream-issue-watchdog.yml
+++ b/.github/workflows/upstream-issue-watchdog.yml
@@ -417,11 +417,6 @@ jobs:
         run: pnpm install --frozen-lockfile
         working-directory: frontend
 
-      - name: Install Claude Code CLI
-        env:
-          ANTHROPIC_AUTH_TOKEN: ${{ secrets.ANTHROPIC_AUTH_TOKEN }}
-        run: bash scripts/agent/setup-claude-code.sh
-
       - name: Configure git identity
         run: |
           git config user.name "tk-upstream-issue-fix-agent[bot]"
@@ -480,25 +475,18 @@ jobs:
           printf '\n```\n' >> /tmp/upstream-issue-fix-prompt.txt
 
       - name: Run Claude upstream issue fix agent
-        env:
-          ANTHROPIC_AUTH_TOKEN: ${{ secrets.ANTHROPIC_AUTH_TOKEN }}
-          ANTHROPIC_BASE_URL: https://api.tokenkey.dev
-          GH_TOKEN: ${{ secrets.UPSTREAM_MERGE_GH_TOKEN }}
-          CLAUDE_CODE_DISABLE_ADAPTIVE_THINKING: "1"
-          MAX_THINKING_TOKENS: "31999"
-          CLAUDE_CODE_AUTOCOMPACT_PCT_OVERRIDE: "60"
-          CLAUDE_CODE_ATTRIBUTION_HEADER: "0"
-          ANTHROPIC_MODEL: "claude-sonnet-4-6"
-        run: |
-          set -o pipefail
-          claude -p "$(cat /tmp/upstream-issue-fix-prompt.txt)" --allowedTools "Bash Read Write Edit Grep Glob" \
-            --model "claude-sonnet-4-6" \
-            --max-budget-usd "20.00" \
-            --output-format stream-json --verbose \
-            --exclude-dynamic-system-prompt-sections \
-            2>&1 \
-            | python3 scripts/agent/redact-stream.py \
-            | tee /tmp/upstream-issue-fix-agent-output.txt
+        # Shared headless-agent scaffold (CLI install + origin/main redactor
+        # staging fail-closed + canonical thinking-env + claude→redact→tee).
+        # fail-on-error defaults true → preserves the prior hard-fail behavior.
+        uses: ./.github/actions/run-headless-agent
+        with:
+          prompt-file: /tmp/upstream-issue-fix-prompt.txt
+          model: "claude-sonnet-4-6"
+          max-budget-usd: "20.00"
+          allowed-tools: "Bash Read Write Edit Grep Glob"
+          auth-token: ${{ secrets.ANTHROPIC_AUTH_TOKEN }}
+          gh-token: ${{ secrets.UPSTREAM_MERGE_GH_TOKEN }}
+          output-file: /tmp/upstream-issue-fix-agent-output.txt
 
       - uses: actions/upload-artifact@v4
         if: always()

--- a/.github/workflows/upstream-issue-watchdog.yml
+++ b/.github/workflows/upstream-issue-watchdog.yml
@@ -477,16 +477,16 @@ jobs:
       - name: Run Claude upstream issue fix agent
         # Shared headless-agent scaffold (CLI install + origin/main redactor
         # staging fail-closed + canonical thinking-env + claude→redact→tee).
-        # fail-on-error defaults true → preserves the prior hard-fail behavior.
+        # fail_on_error defaults true → preserves the prior hard-fail behavior.
         uses: ./.github/actions/run-headless-agent
         with:
-          prompt-file: /tmp/upstream-issue-fix-prompt.txt
+          prompt_file: /tmp/upstream-issue-fix-prompt.txt
           model: "claude-sonnet-4-6"
-          max-budget-usd: "20.00"
-          allowed-tools: "Bash Read Write Edit Grep Glob"
-          auth-token: ${{ secrets.ANTHROPIC_AUTH_TOKEN }}
-          gh-token: ${{ secrets.UPSTREAM_MERGE_GH_TOKEN }}
-          output-file: /tmp/upstream-issue-fix-agent-output.txt
+          max_budget_usd: "20.00"
+          allowed_tools: "Bash Read Write Edit Grep Glob"
+          auth_token: ${{ secrets.ANTHROPIC_AUTH_TOKEN }}
+          gh_token: ${{ secrets.UPSTREAM_MERGE_GH_TOKEN }}
+          output_file: /tmp/upstream-issue-fix-agent-output.txt
 
       - uses: actions/upload-artifact@v4
         if: always()

--- a/.github/workflows/upstream-merge-agent-daily.yml
+++ b/.github/workflows/upstream-merge-agent-daily.yml
@@ -90,11 +90,6 @@ jobs:
         run: pnpm install --frozen-lockfile
         working-directory: frontend
 
-      - name: Install Claude Code CLI
-        env:
-          ANTHROPIC_AUTH_TOKEN: ${{ secrets.ANTHROPIC_AUTH_TOKEN }}
-        run: bash scripts/agent/setup-claude-code.sh
-
       - name: Configure git identity
         run: |
           git config user.name "tk-upstream-agent[bot]"
@@ -264,72 +259,28 @@ jobs:
       - name: Run Claude upstream merge agent (attempt 1)
         if: steps.drift_check.outputs.status == 'need_merge'
         id: agent_attempt_1
-        env:
-          ANTHROPIC_AUTH_TOKEN: ${{ secrets.ANTHROPIC_AUTH_TOKEN }}
-          ANTHROPIC_BASE_URL: https://api.tokenkey.dev
-          GH_TOKEN: ${{ secrets.UPSTREAM_MERGE_GH_TOKEN }}
-          CLAUDE_CODE_DISABLE_ADAPTIVE_THINKING: "1"
-          MAX_THINKING_TOKENS: "31999"
-          CLAUDE_CODE_AUTOCOMPACT_PCT_OVERRIDE: "60"
-          CLAUDE_CODE_ATTRIBUTION_HEADER: "0"
-          ANTHROPIC_MODEL: "claude-sonnet-4-6"
-        run: |
-          # claude CLI has no --output flag — pipe stdout instead. tee keeps
-          # CI logs live (helpful for long agent runs); pipefail propagates
-          # claude's exit code through the pipeline so the step actually
-          # fails when the agent fails.
-          # --allowedTools is required in headless: without it Claude prompt-mode run
-          # defaults to interactive `default` permission mode and rejects
-          # every tool call with "This command requires approval", so the
-          # agent runs the SOP read-only and never produces a PR
-          # (run 25415454229 / job 74548660906, 2026-05-06). Whitelist the
-          # work toolkit explicitly per global CLAUDE.md §5 ("严格遵守
-          # --allowedTools 限制"); WebFetch/WebSearch/Skill stay denied.
-          # scripts/agent/redact-stream.py scrubs secrets from the stream
-          # before tee writes the artifact: Actions log masking does NOT
-          # apply to bytes that hit disk via tee, so without this filter
-          # the public artifact can leak ANTHROPIC_AUTH_TOKEN / GH_TOKEN
-          # if the agent ever echoes them (e.g. an accidental `printenv`).
-          # Model+budget retuning (run 25417602884, 2026-05-06): the agent
-          # under opus[1m] burned its $8 cap in 16 min and hit
-          # `Exceeded USD budget` mid-SOP without producing a PR. The
-          # cache-creation fee for a single fresh Claude prompt-mode run is ~$0.75
-          # at opus[1m] (40k-token system prompt × ~$18.75/M write rate),
-          # so $8 left only ~$7 for actual work. Sonnet 4.6 is roughly
-          # 5× cheaper, and $20 gives the SOP enough headroom to fetch
-          # upstream, run preflight, resolve conflicts, push, and open a
-          # PR even on a busy upstream day.
-          # --output-format stream-json + --verbose makes the agent
-          # transcript (every tool_use, tool_result, thinking block, and
-          # the final result with total_cost_usd / errors / permission
-          # denials) land in the artifact as JSONL. Without it, `claude
-          # -p` only writes the final reply text — on `Exceeded USD
-          # budget` failures the artifact contains a single line and
-          # debugging is impossible. The redactor still scrubs token
-          # patterns inside JSON strings line-by-line.
-          # --exclude-dynamic-system-prompt-sections hoists per-machine
-          # bits (cwd, env info, memory paths, git status) out of the
-          # system prompt into the first user message, keeping the
-          # system prompt prefix stable across runs. Within the 1h
-          # ephemeral cache TTL this lets re-dispatches and chained
-          # workflow_run agents hit the prompt cache instead of paying
-          # the ~$0.15 / 40k-token cache-creation fee. Daily cron runs
-          # are 24h apart so cache is already cold for them, but the
-          # flag is harmless on miss.
-          set -o pipefail
-          set +e
-          claude -p "$(cat /tmp/upstream-merge-agent-prompt.txt)" --allowedTools "Bash Read Write Edit Grep Glob" \
-            --model "claude-sonnet-4-6" \
-            --max-budget-usd "20.00" \
-            --output-format stream-json --verbose \
-            --exclude-dynamic-system-prompt-sections \
-            2>&1 \
-            | python3 scripts/agent/redact-stream.py \
-            | tee /tmp/upstream-merge-agent-output-attempt1.txt
-          exit_code=${PIPESTATUS[0]}
-          set -e
-          echo "exit_code=$exit_code" >> "$GITHUB_OUTPUT"
-          cp /tmp/upstream-merge-agent-output-attempt1.txt /tmp/upstream-merge-agent-output.txt
+        # Shared headless-agent scaffold (CLI install + origin/main redactor
+        # staging fail-closed + canonical thinking-env + claude→redact→tee).
+        # fail-on-error:false preserves the prior `set +e` + PIPESTATUS flow so
+        # the contract/retry logic below branches on the captured exit_code
+        # (steps.agent_attempt_1.outputs.exit_code) instead of hard-failing.
+        # Model/budget rationale (sonnet-4-6 @ $20, was opus[1m] @ $8 which
+        # burned its cap in 16 min — run 25417602884, 2026-05-06): see git
+        # history of this file.
+        uses: ./.github/actions/run-headless-agent
+        with:
+          prompt-file: /tmp/upstream-merge-agent-prompt.txt
+          model: "claude-sonnet-4-6"
+          max-budget-usd: "20.00"
+          allowed-tools: "Bash Read Write Edit Grep Glob"
+          auth-token: ${{ secrets.ANTHROPIC_AUTH_TOKEN }}
+          gh-token: ${{ secrets.UPSTREAM_MERGE_GH_TOKEN }}
+          output-file: /tmp/upstream-merge-agent-output-attempt1.txt
+          fail-on-error: "false"
+
+      - name: Snapshot attempt 1 output as canonical
+        if: steps.drift_check.outputs.status == 'need_merge'
+        run: cp /tmp/upstream-merge-agent-output-attempt1.txt /tmp/upstream-merge-agent-output.txt
 
       - name: Update checkpoint after attempt 1
         if: always() && steps.drift_check.outputs.status == 'need_merge'
@@ -412,30 +363,22 @@ jobs:
       - name: Run Claude upstream merge agent (attempt 2)
         if: always() && steps.drift_check.outputs.status == 'need_merge' && (steps.contract_after_attempt_1.outcome != 'success' || steps.contract_after_attempt_1.outputs.contract_ok != 'true')
         id: agent_attempt_2
-        env:
-          ANTHROPIC_AUTH_TOKEN: ${{ secrets.ANTHROPIC_AUTH_TOKEN }}
-          ANTHROPIC_BASE_URL: https://api.tokenkey.dev
-          GH_TOKEN: ${{ secrets.UPSTREAM_MERGE_GH_TOKEN }}
-          CLAUDE_CODE_DISABLE_ADAPTIVE_THINKING: "1"
-          MAX_THINKING_TOKENS: "31999"
-          CLAUDE_CODE_AUTOCOMPACT_PCT_OVERRIDE: "60"
-          CLAUDE_CODE_ATTRIBUTION_HEADER: "0"
-          ANTHROPIC_MODEL: "claude-sonnet-4-6"
-        run: |
-          set -o pipefail
-          set +e
-          claude -p "$(cat /tmp/upstream-merge-agent-retry-prompt.txt)" --allowedTools "Bash Read Write Edit Grep Glob" \
-            --model "claude-sonnet-4-6" \
-            --max-budget-usd "20.00" \
-            --output-format stream-json --verbose \
-            --exclude-dynamic-system-prompt-sections \
-            2>&1 \
-            | python3 scripts/agent/redact-stream.py \
-            | tee /tmp/upstream-merge-agent-output-attempt2.txt
-          exit_code=${PIPESTATUS[0]}
-          set -e
-          echo "exit_code=$exit_code" >> "$GITHUB_OUTPUT"
-          cat /tmp/upstream-merge-agent-output-attempt2.txt >> /tmp/upstream-merge-agent-output.txt
+        # Shared headless-agent scaffold; fail-on-error:false so the final
+        # contract/exit logic branches on steps.agent_attempt_2.outputs.exit_code.
+        uses: ./.github/actions/run-headless-agent
+        with:
+          prompt-file: /tmp/upstream-merge-agent-retry-prompt.txt
+          model: "claude-sonnet-4-6"
+          max-budget-usd: "20.00"
+          allowed-tools: "Bash Read Write Edit Grep Glob"
+          auth-token: ${{ secrets.ANTHROPIC_AUTH_TOKEN }}
+          gh-token: ${{ secrets.UPSTREAM_MERGE_GH_TOKEN }}
+          output-file: /tmp/upstream-merge-agent-output-attempt2.txt
+          fail-on-error: "false"
+
+      - name: Append attempt 2 output to canonical
+        if: always() && steps.drift_check.outputs.status == 'need_merge' && (steps.contract_after_attempt_1.outcome != 'success' || steps.contract_after_attempt_1.outputs.contract_ok != 'true')
+        run: cat /tmp/upstream-merge-agent-output-attempt2.txt >> /tmp/upstream-merge-agent-output.txt
 
       - name: Verify preflight on target branch (final)
         id: preflight_final

--- a/.github/workflows/upstream-merge-agent-daily.yml
+++ b/.github/workflows/upstream-merge-agent-daily.yml
@@ -261,22 +261,22 @@ jobs:
         id: agent_attempt_1
         # Shared headless-agent scaffold (CLI install + origin/main redactor
         # staging fail-closed + canonical thinking-env + claude→redact→tee).
-        # fail-on-error:false preserves the prior `set +e` + PIPESTATUS flow so
-        # the contract/retry logic below branches on the captured exit_code
+        # fail_on_error:false preserves the prior exit-code-capture (PIPESTATUS)
+        # flow so the contract/retry logic below branches on the captured exit_code
         # (steps.agent_attempt_1.outputs.exit_code) instead of hard-failing.
         # Model/budget rationale (sonnet-4-6 @ $20, was opus[1m] @ $8 which
         # burned its cap in 16 min — run 25417602884, 2026-05-06): see git
         # history of this file.
         uses: ./.github/actions/run-headless-agent
         with:
-          prompt-file: /tmp/upstream-merge-agent-prompt.txt
+          prompt_file: /tmp/upstream-merge-agent-prompt.txt
           model: "claude-sonnet-4-6"
-          max-budget-usd: "20.00"
-          allowed-tools: "Bash Read Write Edit Grep Glob"
-          auth-token: ${{ secrets.ANTHROPIC_AUTH_TOKEN }}
-          gh-token: ${{ secrets.UPSTREAM_MERGE_GH_TOKEN }}
-          output-file: /tmp/upstream-merge-agent-output-attempt1.txt
-          fail-on-error: "false"
+          max_budget_usd: "20.00"
+          allowed_tools: "Bash Read Write Edit Grep Glob"
+          auth_token: ${{ secrets.ANTHROPIC_AUTH_TOKEN }}
+          gh_token: ${{ secrets.UPSTREAM_MERGE_GH_TOKEN }}
+          output_file: /tmp/upstream-merge-agent-output-attempt1.txt
+          fail_on_error: "false"
 
       - name: Snapshot attempt 1 output as canonical
         if: steps.drift_check.outputs.status == 'need_merge'
@@ -363,18 +363,18 @@ jobs:
       - name: Run Claude upstream merge agent (attempt 2)
         if: always() && steps.drift_check.outputs.status == 'need_merge' && (steps.contract_after_attempt_1.outcome != 'success' || steps.contract_after_attempt_1.outputs.contract_ok != 'true')
         id: agent_attempt_2
-        # Shared headless-agent scaffold; fail-on-error:false so the final
+        # Shared headless-agent scaffold; fail_on_error:false so the final
         # contract/exit logic branches on steps.agent_attempt_2.outputs.exit_code.
         uses: ./.github/actions/run-headless-agent
         with:
-          prompt-file: /tmp/upstream-merge-agent-retry-prompt.txt
+          prompt_file: /tmp/upstream-merge-agent-retry-prompt.txt
           model: "claude-sonnet-4-6"
-          max-budget-usd: "20.00"
-          allowed-tools: "Bash Read Write Edit Grep Glob"
-          auth-token: ${{ secrets.ANTHROPIC_AUTH_TOKEN }}
-          gh-token: ${{ secrets.UPSTREAM_MERGE_GH_TOKEN }}
-          output-file: /tmp/upstream-merge-agent-output-attempt2.txt
-          fail-on-error: "false"
+          max_budget_usd: "20.00"
+          allowed_tools: "Bash Read Write Edit Grep Glob"
+          auth_token: ${{ secrets.ANTHROPIC_AUTH_TOKEN }}
+          gh_token: ${{ secrets.UPSTREAM_MERGE_GH_TOKEN }}
+          output_file: /tmp/upstream-merge-agent-output-attempt2.txt
+          fail_on_error: "false"
 
       - name: Append attempt 2 output to canonical
         if: always() && steps.drift_check.outputs.status == 'need_merge' && (steps.contract_after_attempt_1.outcome != 'success' || steps.contract_after_attempt_1.outputs.contract_ok != 'true')

--- a/scripts/preflight.sh
+++ b/scripts/preflight.sh
@@ -971,6 +971,49 @@ else
 fi
 
 echo ""
+echo "=== sub2api: headless-agent composite sharing ==="
+# The headless `claude -p` scaffold (CLI install + origin/main redactor staging +
+# canonical thinking-env + claude->redact->tee) lives in ONE composite action so
+# the four agent workflows can't re-grow divergent copies (they had already
+# drifted: ops-daily-diagnostics ran MAX_THINKING_TOKENS=16000 + omitted
+# set -o pipefail). Fail closed if any agent workflow re-inlines `claude -p` or
+# stops using the action, or if the composite loses its single-source
+# thinking-env / pipefail / fail-closed redactor.
+_hac_action=".github/actions/run-headless-agent/action.yml"
+_hac_files=".github/workflows/pr-repair-agent.yml .github/workflows/upstream-issue-watchdog.yml .github/workflows/upstream-merge-agent-daily.yml .github/workflows/ops-daily-diagnostics.yml"
+_hac_ok=1
+if [ ! -f "$_hac_action" ]; then
+    echo "  FAIL: $_hac_action missing (the shared headless-agent scaffold)"
+    errors=$((errors + 1)); _hac_ok=0
+else
+    grep -q 'MAX_THINKING_TOKENS: "31999"' "$_hac_action" || {
+        echo "  FAIL: $_hac_action lost the canonical MAX_THINKING_TOKENS=31999 single source"
+        errors=$((errors + 1)); _hac_ok=0; }
+    grep -q 'set -o pipefail' "$_hac_action" || {
+        echo "  FAIL: $_hac_action lost set -o pipefail (claude exit code would be masked by tee)"
+        errors=$((errors + 1)); _hac_ok=0; }
+    grep -q 'refusing to run the agent unredacted' "$_hac_action" || {
+        echo "  FAIL: $_hac_action redactor lost its fail-closed refusal"
+        errors=$((errors + 1)); _hac_ok=0; }
+    if grep -q 'for line in sys.stdin' "$_hac_action"; then
+        echo "  FAIL: $_hac_action redactor reintroduced a passthrough fallback (must stay fail-closed)"
+        errors=$((errors + 1)); _hac_ok=0
+    fi
+fi
+for _f in $_hac_files; do
+    [ -f "$_f" ] || continue
+    grep -q 'run-headless-agent' "$_f" || {
+        echo "  FAIL: $_f must run the agent via ./.github/actions/run-headless-agent"
+        errors=$((errors + 1)); _hac_ok=0; }
+    if grep -q 'claude -p' "$_f"; then
+        echo "  FAIL: $_f re-inlines 'claude -p'; use the run-headless-agent action instead"
+        errors=$((errors + 1)); _hac_ok=0
+    fi
+done
+[ "$_hac_ok" = 1 ] && echo "  ok: agent workflows share the run-headless-agent composite (single-source scaffold)"
+unset _hac_action _hac_files _hac_ok _f
+
+echo ""
 if [ "$errors" -eq 0 ]; then
     echo "=== preflight (with sub2api checks): PASS ==="
     exit 0


### PR DESCRIPTION
## What

Batch 3 of the workflow god-eye review. Unlike batch 2, the duplication here was **real and already drifted**, so this consolidates it into one composite action.

The headless `claude -p` scaffold (CLI install + secret-redactor staging + canonical thinking-env + `claude → redact → tee` pipeline) was hand-copied into all four agent workflows. The values had drifted:

| | MAX_THINKING_TOKENS | set -o pipefail | autocompact | redactor source |
|---|---|---|---|---|
| ops-daily-diagnostics | **16000** | **missing** (claude failure masked by tee) | **missing** | cwd, no fallback |
| pr-repair-agent | 31999 | ✓ | ✓ | origin/main + passthrough |
| upstream-issue-watchdog | 31999 | ✓ | ✓ | cwd, no fallback |
| upstream-merge-agent (×2) | 31999 | ✓ | ✓ | cwd, no fallback |

## Changes

- **`.github/actions/run-headless-agent/action.yml`** (new): single source for the scaffold. Owns CLI install, the canonical thinking-env, and the `claude → redact → tee` pipeline. The redactor is staged from the **trusted origin/main** and is now **fail-closed** — if it is unavailable the step refuses to run rather than upload an unredacted transcript (operator decision; upgrades the 3 cwd-callers and supersedes pr-repair's passthrough-with-warning). Inputs cover only what varies (`prompt-file`, `model`, `max-budget-usd`, `allowed-tools`, `auth-token`, `output-file`, `gh-token`, `fail-on-error`); exposes the agent `exit_code` output.
- **4 workflows** now call the action, behavior preserved per caller:
  - pr-repair / watchdog → hard-fail (`fail-on-error` default true);
  - upstream-merge → two-attempt `set +e`/PIPESTATUS branching (`fail-on-error: false`, downstream reads `steps.agent_attempt_N.outputs.exit_code`, the `cp`/`cat` canonical-output steps retained);
  - ops-daily → keeps `continue-on-error` and **gains the pipefail fix** + thinking-env alignment ($1 budget still caps cost).
- **`scripts/preflight.sh`**: new `headless-agent composite sharing` sentinel — fails closed if any of the 4 re-inlines `claude -p` or drops the action, or if the composite loses its single-source thinking-env / pipefail / fail-closed redactor.

## Explicitly NOT done

- `.github/actions/agent-draft-pr` (an unused near-duplicate pipeline) — left alone; can consume the composite later or be deleted if confirmed dead.
- `scripts/agent/redact-stream.py` not moved (its 14-case self-test + redaction-version contract pin its path).

## Verification

- `PREFLIGHT_BASE=origin/main scripts/preflight.sh` → **PASS**; new sentinel + existing `agent stream redactor self-test` + `redaction version contract` all green.
- All 4 workflows + the composite parse; `check_workflow_yaml` clean (13 workflows). No residual inline `claude -p` / `redact-stream` / `setup-claude-code` / thinking-env in the 4 callers. Sentinel re-inline / missing-action / passthrough-reintroduction detection negative-tested.
- merge-agent `exit_code` wiring confirmed: all 6 downstream `steps.agent_attempt_N.outputs.exit_code` consumers resolve to the composite output.

> ⚠️ These 4 workflows run on cron / dispatch / workflow_run, **not on PR CI** — so this PR's CI does not exercise them live. Validated by inspection + YAML lint + the unchanged redactor self-test; the pipeline is kept byte-equivalent to the battle-tested `agent-draft-pr` template.

## Merge

TK-originated chore → **Squash and merge** (§5.y).

🤖 Generated with [Claude Code](https://claude.com/claude-code)