### PR TITLE
fix: keep cc runtime sync wrapper aligned with snapshot CLI

### DIFF
--- a/ops/anthropic/cc_fingerprint_apply_http_runtime.sh
+++ b/ops/anthropic/cc_fingerprint_apply_http_runtime.sh
@@ -11,7 +11,7 @@ mkdir -p "$JOBDIR"
 cd "$REPO_ROOT"
 
 echo "cc_fingerprint_apply_http_runtime: snapshot → sync-runtime (all deployable + prod)" >&2
-python3 "$MGR" snapshot --out "$JOBDIR/snap.json" --json
+python3 "$MGR" snapshot --out "$JOBDIR/snap.json"
 
 python3 "$MGR" sync-runtime \
   --target all-deployable-and-prod \


### PR DESCRIPTION
Summary
- Remove unsupported --json from the snapshot step in cc_fingerprint_apply_http_runtime.sh.
- sync-runtime still emits JSON reports; the wrapper now matches manage-anthropic-config snapshot CLI.

Risk
- Low: wrapper-only fix for a post-merge operator command. No runtime config values or service code changed.

Validation
- bash -n ops/anthropic/cc_fingerprint_apply_http_runtime.sh
- ./scripts/preflight.sh
- Manual post-merge runtime sync for #466 completed with equivalent commands: snapshot --out, then sync-runtime --json.