### PR TITLE
chore(ci): unify skip-ci matcher, fix Check 10 fail-open, add merge-gate parity guard

### DIFF
--- a/.github/workflows/main-ancestry-guard.yml
+++ b/.github/workflows/main-ancestry-guard.yml
@@ -188,31 +188,15 @@ jobs:
           # The bracketed form `[skip ci]` / `[ci skip]` is what GitHub
           # matches literally, and the only form this check rejects.
 
-          fail=0
-          check_source () {
-            local label="$1"
-            local text="$2"
-            if printf '%s' "$text" | grep -Fq -e '[skip ci]' -e '[ci skip]'; then
-              echo "::error::$label contains a bracketed skip-ci / ci-skip marker."
-              echo "::error::This would land in the squash-merge commit body and"
-              echo "::error::silently disable release.yml on any future tag of that commit."
-              echo "::error::Replace the bracketed form with an unbracketed form when"
-              echo "::error::discussing the marker — e.g. 'skip-ci' (hyphen)."
-              fail=1
-            else
-              echo "OK: $label clean"
-            fi
-          }
-
-          check_source "PR title" "$PR_TITLE"
-          check_source "PR body"  "$PR_BODY"
-          # Use --first-parent so imported upstream history (second-parent
-          # of a `merge/upstream-*` merge commit) does NOT count — upstream's
-          # own `chore: sync VERSION to X.Y.Z [skip ci]` commits are by
-          # contract preserved and would otherwise wrongly trip this gate
-          # on every upstream merge. This matches the documented intent in
-          # upstream-merge-pr-shape.yml Check 3 ("Imported upstream history
-          # is allowed to keep upstream's own release-sync messages").
-          check_source "PR commit messages" "$(git log --first-parent --format='%B' "$BASE".."$HEAD")"
-
-          exit $fail
+          # Single matcher shared with upstream-merge-pr-shape.yml Check 3 and
+          # scripts/preflight.sh — scripts/checks/skip-ci-marker.py — so the two
+          # guards can no longer drift on grep engine (-F vs -E) or scan scope.
+          # This guard passes the strictest source set: title + body + commits.
+          # --commits-range uses --first-parent inside the script so imported
+          # upstream history (second parent of a merge/upstream-* merge commit)
+          # does NOT count — upstream's own `chore: sync VERSION ... [skip ci]`
+          # commits are preserved by contract.
+          python3 ./scripts/checks/skip-ci-marker.py \
+            --title "$PR_TITLE" \
+            --body "$PR_BODY" \
+            --commits-range "$BASE..$HEAD"

--- a/.github/workflows/upstream-merge-pr-shape.yml
+++ b/.github/workflows/upstream-merge-pr-shape.yml
@@ -175,17 +175,13 @@ jobs:
           # chain: local gate-fix commits plus the upstream merge commit. Imported
           # upstream history may legitimately contain upstream release-sync
           # messages, and rewriting those commits would violate §5.y.
-          OFFENDERS=$(git log --first-parent --format='%H %s' "$BASE".."$HEAD" | \
-            grep -E '\[skip ci\]|\[ci skip\]' || true)
-
-          if [ -n "$OFFENDERS" ]; then
-            echo "::error::Found first-parent commits with literal '[skip ci]' / '[ci skip]':"
-            echo "$OFFENDERS" | while read line; do echo "::error::  $line"; done
-            echo "::error::Per §9.2, a commit that may later be tagged must not carry [skip ci]."
-            echo "::error::Rewrite the offending commit messages (use e.g. 'skip-ci' or remove entirely)."
-            exit 1
-          fi
-          echo "OK: no PR first-parent commits carry literal [skip ci] / [ci skip]."
+          # Single matcher shared with main-ancestry-guard.yml Check 3 and
+          # scripts/preflight.sh — scripts/checks/skip-ci-marker.py — so the two
+          # guards can no longer drift on grep engine or scan scope. This PR's
+          # title/body are already covered by main-ancestry-guard (base==main),
+          # so here we scan only the first-parent commit chain. --first-parent
+          # (inside the script) preserves imported upstream release-sync messages.
+          python3 ./scripts/checks/skip-ci-marker.py --commits-range "$BASE..$HEAD"
 
       - name: Check 4 — newapi sentinels still intact after merge
         run: |
@@ -196,8 +192,8 @@ jobs:
           # load-bearing fifth-platform surface — fix the merge to restore
           # the file/symbol, do NOT delete the sentinel entry to make the
           # check pass.
-          if [ ! -x ./scripts/sentinels/check-newapi.py ]; then
-            echo "::error::scripts/sentinels/check-newapi.py missing or not executable."
+          if [ ! -f ./scripts/sentinels/check-newapi.py ]; then
+            echo "::error::scripts/sentinels/check-newapi.py missing."
             echo "::error::Per CLAUDE.md §5.x, this guard cannot be silently disabled."
             exit 1
           fi
@@ -215,8 +211,8 @@ jobs:
           # identities like `sub2api` / `newapi` are still valid in internal
           # route / image / repo identities; this check only protects outward
           # TokenKey brand surfaces from drifting apart again.
-          if [ ! -x ./scripts/sentinels/check-brand.py ]; then
-            echo "::error::scripts/sentinels/check-brand.py missing or not executable."
+          if [ ! -f ./scripts/sentinels/check-brand.py ]; then
+            echo "::error::scripts/sentinels/check-brand.py missing."
             echo "::error::Per the TokenKey OPC baseline, this guard cannot be silently disabled."
             exit 1
           fi
@@ -235,8 +231,8 @@ jobs:
           # divergences (sidebar geometry, fluid table mode, sticky-edge-hints
           # opt-out) that would otherwise compile cleanly even if reverted —
           # the regression only surfaces visually.
-          if [ ! -x ./scripts/sentinels/check-frontend-tk.py ]; then
-            echo "::error::scripts/sentinels/check-frontend-tk.py missing or not executable."
+          if [ ! -f ./scripts/sentinels/check-frontend-tk.py ]; then
+            echo "::error::scripts/sentinels/check-frontend-tk.py missing."
             echo "::error::Per CLAUDE.md §5 minimum-invasion guidance, this guard cannot be silently disabled."
             exit 1
           fi
@@ -254,8 +250,8 @@ jobs:
           # preflight implies a green check here. Guards small TK gateway/service
           # hooks in upstream-shaped hotspot files that compile cleanly even if
           # reverted, with regressions only surfacing in production behavior.
-          if [ ! -x ./scripts/sentinels/check-gateway-tk.py ]; then
-            echo "::error::scripts/sentinels/check-gateway-tk.py missing or not executable."
+          if [ ! -f ./scripts/sentinels/check-gateway-tk.py ]; then
+            echo "::error::scripts/sentinels/check-gateway-tk.py missing."
             echo "::error::Per CLAUDE.md §5 minimum-invasion guidance, this guard cannot be silently disabled."
             exit 1
           fi
@@ -274,8 +270,8 @@ jobs:
           # here. Failure means the merge changed logredact's default sensitive
           # keys or version literals without moving the outward QA contract in
           # lockstep.
-          if [ ! -x ./scripts/sentinels/check-redaction-version.py ]; then
-            echo "::error::scripts/sentinels/check-redaction-version.py missing or not executable."
+          if [ ! -f ./scripts/sentinels/check-redaction-version.py ]; then
+            echo "::error::scripts/sentinels/check-redaction-version.py missing."
             echo "::error::Per the Evidence Spine contract, this guard cannot be silently disabled."
             exit 1
           fi
@@ -293,8 +289,8 @@ jobs:
           # registry" check, so a green local preflight implies a green Check 7
           # here. Failure means the merge dropped gateway trajectory/qa capture
           # wiring or the QA middleware stopped terminating in CaptureFromContext.
-          if [ ! -x ./scripts/sentinels/check-trajectory-hooks.py ]; then
-            echo "::error::scripts/sentinels/check-trajectory-hooks.py missing or not executable."
+          if [ ! -f ./scripts/sentinels/check-trajectory-hooks.py ]; then
+            echo "::error::scripts/sentinels/check-trajectory-hooks.py missing."
             echo "::error::Per the Evidence Spine contract, this guard cannot be silently disabled."
             exit 1
           fi
@@ -313,8 +309,8 @@ jobs:
           # here. Failure means the merge regressed stable terminal helpers,
           # `[DONE]` emission, or the focused terminal assertions that protect
           # Evidence Spine completion semantics.
-          if [ ! -x ./scripts/sentinels/check-terminal-events.py ]; then
-            echo "::error::scripts/sentinels/check-terminal-events.py missing or not executable."
+          if [ ! -f ./scripts/sentinels/check-terminal-events.py ]; then
+            echo "::error::scripts/sentinels/check-terminal-events.py missing."
             echo "::error::Per the Evidence Spine contract, this guard cannot be silently disabled."
             exit 1
           fi
@@ -333,8 +329,8 @@ jobs:
           # here. Failure means bridge/provider selection truth drifted back
           # into hotspot gateway service files instead of staying behind the
           # shared Engine facade.
-          if [ ! -x ./scripts/sentinels/check-engine-facade.py ]; then
-            echo "::error::scripts/sentinels/check-engine-facade.py missing or not executable."
+          if [ ! -f ./scripts/sentinels/check-engine-facade.py ]; then
+            echo "::error::scripts/sentinels/check-engine-facade.py missing."
             echo "::error::Per the Engine Spine contract, this guard cannot be silently disabled."
             exit 1
           fi
@@ -353,6 +349,16 @@ jobs:
           # a green Check 10 here. Failure means the export artifact or standalone
           # validator drifted and the H1/H2/H3/D1 / structural contract is no
           # longer mechanically enforced.
+          # `go test -run <regex>` exits 0 when the regex matches ZERO tests, so a
+          # rename/move of TestUS077_QAEvidenceDatasetCheck_* would make this check
+          # pass vacuously (the one fail-open check among 4-13). Assert ≥1 match
+          # first via -list, then run the focused tests.
+          MATCHED=$(cd backend && go test -tags=unit ./internal/observability/qa -list 'TestUS077_QAEvidenceDatasetCheck_' 2>/dev/null | grep -c '^TestUS077_QAEvidenceDatasetCheck_' || true)
+          if [ "${MATCHED:-0}" -lt 1 ]; then
+            echo "::error::-run 'TestUS077_QAEvidenceDatasetCheck_' matched ZERO tests (renamed / moved / deleted?)."
+            echo "::error::go test -run with no matches exits 0; this assertion stops that fail-open."
+            exit 1
+          fi
           (cd backend && go test -tags=unit ./internal/observability/qa -run 'TestUS077_QAEvidenceDatasetCheck_' -count=1)
 
       - name: Check 11 — pricing-availability sentinels still intact after merge

--- a/.github/workflows/upstream-merge-pr-shape.yml
+++ b/.github/workflows/upstream-merge-pr-shape.yml
@@ -353,7 +353,10 @@ jobs:
           # rename/move of TestUS077_QAEvidenceDatasetCheck_* would make this check
           # pass vacuously (the one fail-open check among 4-13). Assert ≥1 match
           # first via -list, then run the focused tests.
-          MATCHED=$(cd backend && go test -tags=unit ./internal/observability/qa -list 'TestUS077_QAEvidenceDatasetCheck_' 2>/dev/null | grep -c '^TestUS077_QAEvidenceDatasetCheck_' || true)
+          # grep -c exits 1 on a zero count, and GHA bash runs set -e -o pipefail,
+          # so the trailing fallback below lets the count reach MATCHED before the
+          # explicit assertion can report a clean "matched ZERO tests" error.
+          MATCHED=$(cd backend && go test -tags=unit ./internal/observability/qa -list 'TestUS077_QAEvidenceDatasetCheck_' 2>/dev/null | grep -c '^TestUS077_QAEvidenceDatasetCheck_' || true)  # preflight-allow: swallow
           if [ "${MATCHED:-0}" -lt 1 ]; then
             echo "::error::-run 'TestUS077_QAEvidenceDatasetCheck_' matched ZERO tests (renamed / moved / deleted?)."
             echo "::error::go test -run with no matches exits 0; this assertion stops that fail-open."

--- a/scripts/checks/merge-gate-parity.py
+++ b/scripts/checks/merge-gate-parity.py
@@ -1,0 +1,88 @@
+#!/usr/bin/env python3
+"""merge-gate-parity.py — keep upstream-merge-pr-shape.yml and preflight.sh in sync.
+
+The merge/upstream-* PR-shape gate (.github/workflows/upstream-merge-pr-shape.yml
+checks 4-13) runs the SAME sentinel / contract checks that scripts/preflight.sh
+runs locally, deliberately, so a green local preflight implies a green merge gate.
+They are hand-maintained copies that could drift (a 14th sentinel wired into one
+but not the other). Rather than collapse them — which would touch the merge-gate
+machinery itself — this guard makes the drift fail closed:
+
+  1. Every script in scripts/sentinels/merge-gate-parity.json MUST be invoked in
+     BOTH scripts/preflight.sh AND upstream-merge-pr-shape.yml.
+  2. Every scripts/sentinels/check-*.py referenced in the workflow MUST be listed
+     in the manifest (so adding a sentinel to the workflow forces a manifest
+     update; scripts/checks/* are covered by rule 1 since that dir also holds
+     merge-topology helpers like skip-ci-marker.py that are NOT gate sentinels).
+  3. The one merge-gate check that is a go test, not a script
+     (TestUS077_QAEvidenceDatasetCheck_), must appear in both files.
+
+Exit 0 = in sync; 1 = drift; 2 = environment failure.
+
+Usage: python3 scripts/checks/merge-gate-parity.py [--quiet]
+"""
+from __future__ import annotations
+
+import argparse
+import json
+import re
+import sys
+from pathlib import Path
+
+REPO = Path(__file__).resolve().parents[2]
+MANIFEST = REPO / "scripts/sentinels/merge-gate-parity.json"
+PREFLIGHT = REPO / "scripts/preflight.sh"
+WORKFLOW = REPO / ".github/workflows/upstream-merge-pr-shape.yml"
+GO_TEST_TOKEN = "TestUS077_QAEvidenceDatasetCheck_"
+SENTINEL_REF_RE = re.compile(r"scripts/sentinels/check-[A-Za-z0-9_-]+\.py")
+
+
+def main() -> int:
+    ap = argparse.ArgumentParser(description=__doc__)
+    ap.add_argument("--quiet", action="store_true")
+    args = ap.parse_args()
+
+    try:
+        listed = set(json.loads(MANIFEST.read_text(encoding="utf-8"))["scripts"])
+        preflight_text = PREFLIGHT.read_text(encoding="utf-8")
+        workflow_text = WORKFLOW.read_text(encoding="utf-8")
+    except (OSError, json.JSONDecodeError, KeyError) as exc:
+        print(f"FAIL: cannot read inputs: {exc}", file=sys.stderr)
+        return 2
+
+    failures: list[str] = []
+
+    # Rule 1 — each manifest script is invoked in BOTH files.
+    for script in sorted(listed):
+        if script not in preflight_text:
+            failures.append(f"{script}: listed in manifest but NOT invoked in scripts/preflight.sh")
+        if script not in workflow_text:
+            failures.append(f"{script}: listed in manifest but NOT invoked in upstream-merge-pr-shape.yml")
+
+    # Rule 2 — each sentinel referenced in the workflow is in the manifest.
+    for script in sorted(set(SENTINEL_REF_RE.findall(workflow_text))):
+        if script not in listed:
+            failures.append(
+                f"{script}: invoked in upstream-merge-pr-shape.yml but missing from "
+                "scripts/sentinels/merge-gate-parity.json (add it, and run it in preflight.sh too)"
+            )
+
+    # Rule 3 — the QA-evidence go test is the one non-script merge-gate check.
+    if GO_TEST_TOKEN not in preflight_text:
+        failures.append(f"{GO_TEST_TOKEN}: go test not found in scripts/preflight.sh")
+    if GO_TEST_TOKEN not in workflow_text:
+        failures.append(f"{GO_TEST_TOKEN}: go test not found in upstream-merge-pr-shape.yml")
+
+    if failures:
+        print("[check_merge_gate_parity] FAIL: merge-gate / preflight sentinel-set drift:", file=sys.stderr)
+        for f in failures:
+            print(f"  - {f}", file=sys.stderr)
+        return 1
+
+    if not args.quiet:
+        print(f"[check_merge_gate_parity] ok: {len(listed)} merge-gate sentinels in sync (preflight <-> workflow)")
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/scripts/checks/skip-ci-marker.py
+++ b/scripts/checks/skip-ci-marker.py
@@ -1,0 +1,127 @@
+#!/usr/bin/env python3
+"""skip-ci-marker.py — single source of truth for the §9.2 bracketed skip-ci gate.
+
+GitHub's CI-skip detector matches the literal substring `[skip ci]` / `[ci skip]`
+anywhere in the message of the commit being tagged, ignoring context. A bracketed
+marker that lands on main (via PR title, PR body, or a first-parent commit message
+that becomes the squash-merge body) silently disables release.yml on any future
+tag of that commit — see CLAUDE.md §9.2 (v1.3.0 incident, PR #312 re-occurrence).
+
+This script is the ONE matcher shared by:
+  - .github/workflows/main-ancestry-guard.yml       (PR title + body + commits)
+  - .github/workflows/upstream-merge-pr-shape.yml   (first-parent commits)
+  - scripts/preflight.sh                            (local origin/main..HEAD commits)
+so the two workflows can no longer drift on grep engine (-F vs -E) or scan scope.
+
+Only the BRACKETED forms are matched. Discussing the marker in unbracketed prose
+(`skip-ci`, `ci-skip`, `skip ci`, `ci skip`) is allowed (CLAUDE.md §9.2).
+
+Commit scans use --first-parent so imported upstream history (the second parent of
+a merge/upstream-* merge commit) does NOT count — upstream's own
+`chore: sync VERSION ... [skip ci]` commits are preserved by contract.
+
+Exit codes
+----------
+  0 — no bracketed marker in any scanned source
+  1 — a bracketed marker was found
+  2 — git / environment failure (or nothing to scan)
+
+Usage
+-----
+  python3 scripts/checks/skip-ci-marker.py \
+      [--title TEXT] [--body TEXT] [--commits-range BASE..HEAD] [--quiet]
+"""
+from __future__ import annotations
+
+import argparse
+import subprocess
+import sys
+
+MARKERS = ("[skip ci]", "[ci skip]")
+
+
+def first_parent_commit_bodies(commit_range: str) -> str:
+    return subprocess.check_output(
+        ["git", "log", "--first-parent", "--format=%B", commit_range],
+        text=True,
+    )
+
+
+def scan(label: str, text: str, failures: list[str]) -> None:
+    hit = next((m for m in MARKERS if m in text), None)
+    if hit:
+        failures.append(f"{label}: contains bracketed '{hit}'")
+
+
+def main() -> int:
+    ap = argparse.ArgumentParser(
+        description=__doc__, formatter_class=argparse.RawDescriptionHelpFormatter
+    )
+    ap.add_argument("--title", default=None, help="PR title to scan")
+    ap.add_argument("--body", default=None, help="PR body to scan")
+    ap.add_argument(
+        "--commits-range",
+        default=None,
+        help="BASE..HEAD; scans first-parent commit messages in the range",
+    )
+    ap.add_argument(
+        "--quiet", action="store_true", help="suppress success output (preflight wrapper)"
+    )
+    args = ap.parse_args()
+
+    if args.title is None and args.body is None and args.commits_range is None:
+        print(
+            "FAIL: nothing to scan; pass at least one of --title / --body / --commits-range",
+            file=sys.stderr,
+        )
+        return 2
+
+    failures: list[str] = []
+    if args.title is not None:
+        scan("PR title", args.title, failures)
+    if args.body is not None:
+        scan("PR body", args.body, failures)
+    if args.commits_range is not None:
+        try:
+            bodies = first_parent_commit_bodies(args.commits_range)
+        except subprocess.CalledProcessError as exc:
+            print(f"FAIL: git log {args.commits_range} failed: {exc}", file=sys.stderr)
+            return 2
+        scan(f"first-parent commits ({args.commits_range})", bodies, failures)
+
+    if failures:
+        print(
+            "[check_skip_ci_marker] FAIL: bracketed skip-ci / ci-skip marker found:",
+            file=sys.stderr,
+        )
+        for f in failures:
+            print(f"  {f}", file=sys.stderr)
+        print("", file=sys.stderr)
+        print(
+            "Per CLAUDE.md §9.2 a title/body/commit that may land on main and later be",
+            file=sys.stderr,
+        )
+        print(
+            "tagged must NOT carry the bracketed form. When DISCUSSING the marker use an",
+            file=sys.stderr,
+        )
+        print(
+            "unbracketed form: skip-ci (hyphen), ci-skip (hyphen), or skip ci / ci skip.",
+            file=sys.stderr,
+        )
+        return 1
+
+    if not args.quiet:
+        scanned = []
+        if args.title is not None:
+            scanned.append("title")
+        if args.body is not None:
+            scanned.append("body")
+        if args.commits_range is not None:
+            scanned.append(f"commits({args.commits_range})")
+        print(f"[check_skip_ci_marker] clean: {', '.join(scanned)}")
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/scripts/preflight.sh
+++ b/scripts/preflight.sh
@@ -576,6 +576,11 @@ if ! command -v python3 >/dev/null 2>&1; then
 elif ! command -v go >/dev/null 2>&1; then
     echo "  FAIL: go not on PATH (required to run QA evidence dataset regression tests)"
     errors=$((errors + 1))
+elif [ "$(cd backend && go test -tags=unit ./internal/observability/qa -list 'TestUS077_QAEvidenceDatasetCheck_' 2>/dev/null | grep -c '^TestUS077_QAEvidenceDatasetCheck_')" -lt 1 ]; then
+    # `go test -run <regex>` exits 0 on ZERO matches — a rename/move would pass
+    # vacuously. Assert ≥1 match before trusting the -run result below.
+    echo "  FAIL: -run 'TestUS077_QAEvidenceDatasetCheck_' matched ZERO tests (renamed/moved?); go test -run exits 0 on no match"
+    errors=$((errors + 1))
 elif ! (cd backend && go test -tags=unit ./internal/observability/qa -run 'TestUS077_QAEvidenceDatasetCheck_' -count=1); then
     errors=$((errors + 1))
 else
@@ -1012,6 +1017,43 @@ for _f in $_hac_files; do
 done
 [ "$_hac_ok" = 1 ] && echo "  ok: agent workflows share the run-headless-agent composite (single-source scaffold)"
 unset _hac_action _hac_files _hac_ok _f
+
+echo ""
+echo "=== sub2api: skip-ci marker (local commits) ==="
+# Local pre-catch of the §9.2 bracketed [skip ci] / [ci skip] marker in this
+# branch's own commits, using the SAME matcher the two PR-gate workflows call
+# (scripts/checks/skip-ci-marker.py). PR title/body are only visible to the
+# workflows, so locally we scan commit messages only.
+if ! command -v python3 >/dev/null 2>&1; then
+    echo "  FAIL: python3 not on PATH (required by skip-ci-marker.py)"
+    errors=$((errors + 1))
+else
+    _skipci_base="${PREFLIGHT_BASE:-origin/main}"
+    python3 ./scripts/checks/skip-ci-marker.py --commits-range "${_skipci_base}..HEAD" --quiet
+    _skipci_rc=$?
+    if [ "$_skipci_rc" -eq 1 ]; then
+        errors=$((errors + 1))
+    elif [ "$_skipci_rc" -eq 2 ]; then
+        echo "  skip: cannot resolve ${_skipci_base}..HEAD (fetch origin/main); the PR gate enforces this"
+    else
+        echo "  ok: no bracketed [skip ci] / [ci skip] in ${_skipci_base}..HEAD commits"
+    fi
+    unset _skipci_base _skipci_rc
+fi
+
+echo ""
+echo "=== sub2api: merge-gate sentinel parity ==="
+# Keeps upstream-merge-pr-shape.yml checks 4-13 and preflight's sentinel set
+# mechanically coupled (manifest: scripts/sentinels/merge-gate-parity.json) so a
+# new merge-gate sentinel can't be wired into one file but not the other.
+if ! command -v python3 >/dev/null 2>&1; then
+    echo "  FAIL: python3 not on PATH (required by merge-gate-parity.py)"
+    errors=$((errors + 1))
+elif ! python3 ./scripts/checks/merge-gate-parity.py --quiet; then
+    errors=$((errors + 1))
+else
+    echo "  ok: merge-gate sentinels in sync (preflight <-> upstream-merge-pr-shape)"
+fi
 
 echo ""
 if [ "$errors" -eq 0 ]; then

--- a/scripts/sentinels/merge-gate-parity.json
+++ b/scripts/sentinels/merge-gate-parity.json
@@ -1,0 +1,16 @@
+{
+  "rationale": "The merge/upstream-* PR-shape gate (.github/workflows/upstream-merge-pr-shape.yml checks 4-13) runs the SAME sentinel / contract checks that scripts/preflight.sh runs locally, deliberately, so a green local preflight implies a green merge gate. The two are hand-maintained copies that could drift (a 14th sentinel added to one but not the other). This manifest is the single list that keeps them coupled: scripts/checks/merge-gate-parity.py asserts every script here is invoked in BOTH files, and that every scripts/sentinels/check-*.py referenced by the workflow is listed here. Adding a new merge-gate sentinel means wiring it into preflight.sh + upstream-merge-pr-shape.yml + this list, or merge-gate-parity fails closed. This replaces collapsing the workflow into a `preflight --sentinels-only` call, which would have touched the merge-gate machinery itself. Merge-topology checks 1-3 (merge-commit ancestry, PR-body cadence, skip-ci-marker) are NOT in this set — they need PR base/head/body data preflight does not have.",
+  "scripts": [
+    "scripts/sentinels/check-newapi.py",
+    "scripts/sentinels/check-brand.py",
+    "scripts/sentinels/check-frontend-tk.py",
+    "scripts/sentinels/check-gateway-tk.py",
+    "scripts/sentinels/check-redaction-version.py",
+    "scripts/sentinels/check-trajectory-hooks.py",
+    "scripts/sentinels/check-terminal-events.py",
+    "scripts/sentinels/check-engine-facade.py",
+    "scripts/sentinels/check-pricing-availability.py",
+    "scripts/sentinels/check-registry-update-gate.py",
+    "scripts/checks/buffered-content-type-leak.py"
+  ]
+}


### PR DESCRIPTION
## What

Batch 4 of the workflow god-eye review — governance consolidation. Fixes three real bugs in the §5.y / §9.2 merge-gate stack and adds a drift guard, **without** the high-risk `--sentinels-only` collapse (which would have touched the merge-gate machinery itself).

## Changes

**1. skip-ci-marker single source** — the bracketed-marker scan (CLAUDE.md §9.2) was forked: `main-ancestry-guard` used `grep -F` over title+body+commits, `upstream-merge-pr-shape` used `grep -E` over commits only (different engine AND scope). Both now call `scripts/checks/skip-ci-marker.py` (one fixed-string matcher); `preflight.sh` calls it on local commits as a pre-catch. main-ancestry-guard keeps the stricter title+body+commits scope; the merge-PR gate keeps commits-only (title/body already covered by main-ancestry-guard on `base==main` PRs).

**2. Check 10 fail-open fixed** — `go test -run 'TestUS077_QAEvidenceDatasetCheck_'` exits 0 when the regex matches **zero** tests, so a rename/move would pass vacuously (the one fail-open check among 4-13). Both the workflow check and `preflight.sh` now assert `>=1` match via `go test -list` before running the focused tests.

**3. `-x` vs `-f` unified** — `upstream-merge-pr-shape` checks 4-9 guarded the sentinel scripts with `[ ! -x ]` while 11-13 used `[ ! -f ]`; since invocation is always `python3 ./script.py`, a stripped `+x` bit made 4-9 false-fail while 11-13 passed. All now use `[ ! -f ]`, error messages corrected to "missing".

**4. merge-gate parity guard (replaces the collapse)** — `scripts/checks/merge-gate-parity.py` + `scripts/sentinels/merge-gate-parity.json` assert every merge-gate sentinel is invoked in **both** `preflight.sh` and `upstream-merge-pr-shape.yml`, and that any `check-*.py` the workflow references is in the manifest. Adding a new merge-gate sentinel now **fails closed** unless wired into preflight + workflow + manifest. Reaches the anti-drift goal of `--sentinels-only` without changing merge-gate behavior.

## Why not the collapse

`preflight.sh`'s sentinel checks are interleaved with deploy/CFN/lightsail checks (not a contiguous block), and the registry-gate check needs base/head pass-through. A `--sentinels-only` refactor would touch the gate that protects `main` for a DRY-only benefit. The parity guard achieves the drift protection mechanically at far lower risk — per operator decision.

## Verification

- `skip-ci-marker.py` unit-tested: bracketed forms in title/body/commits → exit 1; hyphen `skip-ci` prose → exit 0; nothing-to-scan → exit 2.
- `merge-gate-parity.py` unit-tested positive (11 sentinels in sync) + negative (bogus manifest entry → fail closed).
- Check 10 `-list` assertion: a renamed/non-existent test name → 0 matches → fails; the real suite → 2 matches → passes.
- `PREFLIGHT_BASE=origin/main scripts/preflight.sh` → **PASS** with both new checks ok; `check_workflow_yaml` clean (13 workflows).

## Merge

TK-originated chore → **Squash and merge** (§5.y).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
