### PR TITLE
chore(deploy): bound deploy job timeouts, fail-fast prod smoke secrets, fix edge resolve guard

### DIFF
--- a/.github/workflows/deploy-edge-lightsail-stage0.yml
+++ b/.github/workflows/deploy-edge-lightsail-stage0.yml
@@ -68,6 +68,10 @@ concurrency:
 jobs:
   edge:
     runs-on: ubuntu-latest
+    # Above a normal Lightsail provision + upgrade but far below the 6h GHA
+    # default, so a hung step can't hold the cancel-in-progress:false edge
+    # concurrency lock for hours.
+    timeout-minutes: 45
     environment: edge-${{ inputs.edge_id }}
     env:
       OIDC_ROLE_ARN: ${{ vars.AWS_OIDC_ROLE_ARN }}
@@ -181,7 +185,12 @@ jobs:
 
       - name: Resolve SSM managed instance + API URL
         id: instance
-        if: inputs.operation != 'provision' || success()
+        # No explicit `if:` — GitHub then auto-applies success(), so this resolve
+        # runs for every op only when all prior steps succeeded (for non-provision
+        # ops the provision step is skipped, not failed, so success() holds). The
+        # previous `if: inputs.operation != 'provision' || success()` contained a
+        # status function, which suppressed the auto-success() and made it run even
+        # after a prior step failed for non-provision ops.
         env:
           SSM_PREFIX: ${{ steps.edge.outputs.ssm_prefix }}
           AWS_REGION: ${{ steps.edge.outputs.lightsail_region }}

--- a/.github/workflows/deploy-edge-stage0.yml
+++ b/.github/workflows/deploy-edge-stage0.yml
@@ -76,6 +76,10 @@ concurrency:
 jobs:
   edge:
     runs-on: ubuntu-latest
+    # Above the heaviest op (CFN provision / rotate_egress_ip with SSM + egress
+    # verification, ~10-20 min) but far below the 6h GHA default, so a hung step
+    # can't hold the cancel-in-progress:false edge concurrency lock for hours.
+    timeout-minutes: 60
     environment: edge-${{ inputs.edge_id }}
     env:
       OIDC_ROLE_ARN: ${{ vars.AWS_OIDC_ROLE_ARN }}
@@ -264,7 +268,12 @@ jobs:
 
       - name: Resolve Edge instance + API URL
         id: instance
-        if: inputs.operation != 'provision' || success()
+        # No explicit `if:` — GitHub then auto-applies success(), so this resolve
+        # runs for every op only when all prior steps succeeded (for non-provision
+        # ops the provision step is skipped, not failed, so success() holds). The
+        # previous `if: inputs.operation != 'provision' || success()` contained a
+        # status function, which suppressed the auto-success() and made it run even
+        # after a prior step failed for non-provision ops.
         env:
           STACK_NAME: ${{ steps.edge.outputs.stack }}
         run: |

--- a/.github/workflows/deploy-stage0.yml
+++ b/.github/workflows/deploy-stage0.yml
@@ -30,6 +30,10 @@ concurrency:
 jobs:
   deploy:
     runs-on: ubuntu-latest
+    # Bound well above a normal prod SSM upgrade (~5-10 min) but far below the
+    # 6h GHA default, so a hung describe-stacks / health-poll can't hold the
+    # cancel-in-progress:false prod concurrency lock for hours.
+    timeout-minutes: 30
     # GitHub Environment binding for prod only:
     #   1. Adds environment:prod to the OIDC sub claim (IAM trust in cicd-oidc.yaml).
     #   2. Pauses for Required reviewers when configured on the prod Environment.
@@ -58,6 +62,39 @@ jobs:
           fi
           NAME="${{ vars.PROD_STACK_NAME || 'tokenkey-prod-stage0' }}"
           echo "name=$NAME" >> "$GITHUB_OUTPUT"
+
+      - name: Validate prod smoke secrets (before touching prod)
+        # Fail fast BEFORE the SSM image swap: a missing smoke secret is a config
+        # error, not a deploy failure. Validating here (instead of inside the
+        # post-deploy smoke step that runs AFTER deploy_via_ssm.sh) means a
+        # missing secret never leaves a freshly-swapped image live behind a red
+        # "smoke" run that actually means "secret not configured".
+        env:
+          TK_SMOKE_PROD_ANTHROPIC_KEY: ${{ secrets.TK_SMOKE_PROD_ANTHROPIC_KEY }}
+          TK_SMOKE_PROD_GEMINI_KEY: ${{ secrets.TK_SMOKE_PROD_GEMINI_KEY }}
+          TK_SMOKE_PROD_OPENAI_OAUTH_KEY: ${{ secrets.TK_SMOKE_PROD_OPENAI_OAUTH_KEY }}
+        run: |
+          set -euo pipefail
+          if [ -z "${TK_SMOKE_PROD_ANTHROPIC_KEY:-}" ]; then
+            echo "::error::TK_SMOKE_PROD_ANTHROPIC_KEY is not set in prod Environment."
+            echo "Add a TokenKey user API key (sk-...) that is valid for this stack's gateway."
+            echo "See deploy/aws/README.md (Smoke config) and docs/approved/deploy-stage0-workflow.md §5."
+            exit 1
+          fi
+          if [ -z "${TK_SMOKE_PROD_GEMINI_KEY:-}" ]; then
+            echo "::error::TK_SMOKE_PROD_GEMINI_KEY is not set in prod Environment."
+            echo "Add a TokenKey API key bound to a gemini-platform group (e.g. gemini-pa) on this stack's gateway."
+            echo "This probe guards the Anthropic→Gemini tool-schema cleanup regression."
+            echo "See deploy/aws/README.md (Smoke config) and docs/approved/deploy-stage0-workflow.md §5."
+            exit 1
+          fi
+          if [ -z "${TK_SMOKE_PROD_OPENAI_OAUTH_KEY:-}" ]; then
+            echo "::error::TK_SMOKE_PROD_OPENAI_OAUTH_KEY is not set in prod Environment."
+            echo "Add a TokenKey API key bound to an OpenAI OAuth/codex-platform group on this stack's gateway."
+            echo "This probe guards the reasoning_tokens passthrough regression."
+            echo "See deploy/aws/README.md (Smoke config) and docs/approved/deploy-stage0-workflow.md §5."
+            exit 1
+          fi
 
       - name: Verify GHCR multi-arch manifest
         # Shared with deploy-edge-stage0.yml so prod and Edge never grow
@@ -117,26 +154,9 @@ jobs:
           TK_SMOKE_PROD_OPENAI_OAUTH_MODEL: ${{ vars.TK_SMOKE_PROD_OPENAI_OAUTH_MODEL }}
         run: |
           set -euo pipefail
-          if [ -z "${TK_SMOKE_PROD_ANTHROPIC_KEY:-}" ]; then
-            echo "::error::TK_SMOKE_PROD_ANTHROPIC_KEY is not set in prod Environment."
-            echo "Add a TokenKey user API key (sk-...) that is valid for this stack's gateway."
-            echo "See deploy/aws/README.md (Smoke config) and docs/approved/deploy-stage0-workflow.md §5."
-            exit 1
-          fi
-          if [ -z "${TK_SMOKE_PROD_GEMINI_KEY:-}" ]; then
-            echo "::error::TK_SMOKE_PROD_GEMINI_KEY is not set in prod Environment."
-            echo "Add a TokenKey API key bound to a gemini-platform group (e.g. gemini-pa) on this stack's gateway."
-            echo "This probe guards the Anthropic→Gemini tool-schema cleanup regression."
-            echo "See deploy/aws/README.md (Smoke config) and docs/approved/deploy-stage0-workflow.md §5."
-            exit 1
-          fi
-          if [ -z "${TK_SMOKE_PROD_OPENAI_OAUTH_KEY:-}" ]; then
-            echo "::error::TK_SMOKE_PROD_OPENAI_OAUTH_KEY is not set in prod Environment."
-            echo "Add a TokenKey API key bound to an OpenAI OAuth/codex-platform group on this stack's gateway."
-            echo "This probe guards the reasoning_tokens passthrough regression."
-            echo "See deploy/aws/README.md (Smoke config) and docs/approved/deploy-stage0-workflow.md §5."
-            exit 1
-          fi
+          # Secret presence is validated up front in "Validate prod smoke secrets"
+          # (before the SSM image swap); here we just run the smoke against the
+          # already-deployed image.
           bash ops/stage0/post_deploy_smoke.sh
 
       - name: Job summary

--- a/scripts/preflight.sh
+++ b/scripts/preflight.sh
@@ -793,6 +793,22 @@ fi
 [ "$_tag_ok" = 1 ] && echo "  ok: prod + Edge deploy workflows share the tag-format gate ($_tag_script)"
 unset _tag_script _tag_files _tag_ok _f
 
+echo ""
+echo "=== sub2api: Stage0 deploy job timeouts ==="
+# Every Stage0 deploy job has cancel-in-progress:false concurrency, so a hung
+# step (describe-stacks / health-poll) would hold the prod/edge lock to the 6h
+# GHA default without a job-level timeout-minutes. Assert the cap stays present.
+_dt_ok=1
+for _df in .github/workflows/deploy-stage0.yml .github/workflows/deploy-edge-stage0.yml .github/workflows/deploy-edge-lightsail-stage0.yml; do
+    [ -f "$_df" ] || continue
+    if ! grep -q '^    timeout-minutes:' "$_df"; then
+        echo "  FAIL: $_df job is missing timeout-minutes (a hang would hold the deploy concurrency lock up to the 6h GHA default)"
+        errors=$((errors + 1)); _dt_ok=0
+    fi
+done
+[ "$_dt_ok" = 1 ] && echo "  ok: all Stage0 deploy jobs declare a job-level timeout-minutes"
+unset _dt_ok _df
+
 # Anthropic OAuth tier baseline values now live in exactly one place: the JSON
 # source of truth. The apply SQL is generated from it at runtime (orchestrator
 # reuses the guard's generate_sql), so there is no second hand-aligned copy to


### PR DESCRIPTION
## What

Batch 5 (final) of the workflow god-eye review — three deploy-* reliability residuals that were catalogued but not in batches 1-4.

| # | Fix | File(s) |
|---|---|---|
| 1 | **`timeout-minutes`** on all three Stage0 deploy jobs (prod **30** / edge-ec2 **60** / lightsail **45**). Each job runs `cancel-in-progress:false`, so a hung `describe-stacks` / health-poll could hold the prod/edge lock to the **6h** GHA default and block every queued deploy. Values sit above the heaviest real op (CFN provision / EIP rotation ~10-20 min) and far below 6h. | `deploy-stage0`, `deploy-edge-stage0`, `deploy-edge-lightsail-stage0` |
| 2 | **Fail-fast prod smoke secrets**: the three mandatory `TK_SMOKE_PROD_*` presence checks move to a new step **before** the SSM image swap, instead of inside the post-deploy smoke step that runs after `deploy_via_ssm.sh`. A missing secret is a config error — validating up front means it no longer leaves a freshly-swapped image live behind a red "smoke" run that actually means "secret missing". | `deploy-stage0` |
| 3 | **Edge resolve-instance guard fix**: drop `if: inputs.operation != 'provision' \|\| success()` from the two edge resolve steps. Because that expression contains a status function, GitHub **suppressed** the implicit `success()` prefix, so the step ran even after a prior step failed for non-provision ops. Removing the explicit `if` restores the auto-`success()` (runs only when prior steps succeeded; for non-provision ops the provision step is *skipped*, not *failed*). Downstream SSM/health/smoke steps already get the auto-prefix, so none run with an empty instance. | `deploy-edge-stage0`, `deploy-edge-lightsail-stage0` |

Plus a **`Stage0 deploy job timeouts` preflight sentinel** asserting all three deploy jobs keep a job-level `timeout-minutes` (no soft rule without a check).

## Verification

- `PREFLIGHT_BASE=origin/main scripts/preflight.sh` → **PASS**; new timeout sentinel ok; negative-tested (a job without `timeout-minutes` → fails). `check_workflow_yaml` clean (13 workflows).
- Structural diff confirmed: #2 presence checks moved (not duplicated), smoke run unchanged; #3 only the `if` line removed (real directive gone, kept an explanatory comment); #1 job-level only.

> ⚠️ These workflows are `workflow_dispatch`-only — not exercised by PR CI. Validated by inspection + yaml-lint + the new sentinel.

## Merge

TK-originated chore → **Squash and merge** (§5.y).

🤖 Generated with [Claude Code](https://claude.com/claude-code)