### PR TITLE
fix(gateway): edge 503 "no available accounts" must not cool prod mirror stub

### DIFF
--- a/backend/internal/service/ratelimit_service.go
+++ b/backend/internal/service/ratelimit_service.go
@@ -970,6 +970,23 @@ func (s *RateLimitService) handle403(ctx context.Context, account *Account, upst
 // in case 400, OAuth 401 refresh, 429 retry-after cooldown, 529 overload)
 // live outside this function and are unaffected.
 func (s *RateLimitService) handleAnthropicUpstreamError(ctx context.Context, account *Account, statusCode int, upstreamMsg string, responseBody []byte) (shouldDisable bool) {
+	// TK (prod incident 2026-05-31): a 503 whose body is the downstream gateway's
+	// own "no available accounts" pool-exhaustion signal is a transient capacity
+	// blip on the *forwarded-to* pool (e.g. a thin edge bursting on parallel haiku
+	// background requests), NOT a health problem with THIS forwarding stub account.
+	// Advancing the per-account anthropic_upstream_error counter would let a 3-503
+	// edge burst trip the 3/3 ladder and cool the whole edge stub for 10 minutes
+	// (tier=2), collapsing the prod pool — a self-inflicted 503 amplifier. Fail the
+	// in-flight request over to the next stub (return true) but leave stub health
+	// untouched: no counter advance, no SetTempUnschedulable. See
+	// tkIsDownstreamNoAvailableAccounts.
+	if statusCode == http.StatusServiceUnavailable && tkIsDownstreamNoAvailableAccounts(upstreamMsg, responseBody) {
+		slog.Info("anthropic_downstream_no_available_accounts_skip_penalty",
+			"account_id", account.ID,
+			"status_code", statusCode)
+		return true
+	}
+
 	// TK: when status.claude.com reports a non-operational Claude API, the error is
 	// Anthropic's fault, not the account's. Skip writing temp_unschedulable_until so
 	// account health scores are not penalised during upstream incidents.

--- a/backend/internal/service/ratelimit_service_tk_downstream_no_available.go
+++ b/backend/internal/service/ratelimit_service_tk_downstream_no_available.go
@@ -1,0 +1,37 @@
+package service
+
+import "strings"
+
+// tkIsDownstreamNoAvailableAccounts reports whether an Anthropic upstream error
+// is the downstream gateway's own "no available accounts" pool-exhaustion signal
+// rather than a health problem with the (stub) account that forwarded the
+// request.
+//
+// TK (prod incident 2026-05-31): on the prod main gateway, Anthropic is reached
+// only through per-edge api-key mirror "stub" accounts (cc-us1 / cc-uk1 / …) that
+// forward to the corresponding edge. When a thin edge pool (e.g. uk1 has a single
+// schedulable OAuth account) briefly saturates on a burst of parallel Claude Code
+// haiku background requests, the edge returns a 503 whose body is *our own*
+// gateway error envelope: {"type":"error","error":{"type":"api_error",
+// "message":"No available accounts: no available accounts"}}.
+//
+// That 503 is a transient *downstream* capacity blip — the forwarding stub itself
+// is perfectly healthy. Counting it toward the per-account anthropic_upstream_error
+// threshold (handleAnthropicUpstreamErrorWithOptions) lets a 3-request edge burst
+// trip the 3/3 ladder and cool the whole edge stub for 10 minutes
+// (SetTempUnschedulable, tier=2). With both regional stubs cooled at once the prod
+// pool collapses and every model (opus + haiku) 503s — a self-inflicted 503
+// amplifier. The in-flight request should instead fail over to the next stub
+// (another edge), leaving stub health untouched.
+//
+// The phrase "no available accounts" is TokenKey's own internal scheduler string
+// (service.ErrNoAvailableAccounts, rendered by the gateway handlers as an
+// "api_error"); Anthropic's real API never emits it, so a case-insensitive match
+// on a 503 body is a specific signal of downstream pool exhaustion.
+func tkIsDownstreamNoAvailableAccounts(upstreamMsg string, responseBody []byte) bool {
+	needle := ErrNoAvailableAccounts.Error() // "no available accounts"
+	if strings.Contains(strings.ToLower(upstreamMsg), needle) {
+		return true
+	}
+	return strings.Contains(strings.ToLower(string(responseBody)), needle)
+}

--- a/backend/internal/service/ratelimit_service_tk_downstream_no_available_test.go
+++ b/backend/internal/service/ratelimit_service_tk_downstream_no_available_test.go
@@ -1,0 +1,67 @@
+//go:build unit
+
+package service
+
+import (
+	"context"
+	"net/http"
+	"testing"
+
+	"github.com/Wei-Shaw/sub2api/internal/config"
+	"github.com/stretchr/testify/require"
+)
+
+func TestTkIsDownstreamNoAvailableAccounts(t *testing.T) {
+	// Edge mirror-stub 503 body (our own gateway error envelope).
+	require.True(t, tkIsDownstreamNoAvailableAccounts("", []byte(`{"type":"error","error":{"type":"api_error","message":"No available accounts: no available accounts"}}`)))
+	// Already-parsed upstream message.
+	require.True(t, tkIsDownstreamNoAvailableAccounts("No available accounts: no available accounts", nil))
+	// Case-insensitive.
+	require.True(t, tkIsDownstreamNoAvailableAccounts("NO AVAILABLE ACCOUNTS", nil))
+	// A genuine Anthropic upstream error must not match.
+	require.False(t, tkIsDownstreamNoAvailableAccounts("Internal server error", []byte(`{"type":"error","error":{"type":"api_error","message":"Internal server error"}}`)))
+	require.False(t, tkIsDownstreamNoAvailableAccounts("", []byte(`{}`)))
+}
+
+// prod incident 2026-05-31: a downstream edge stub returning 503 "no available
+// accounts" (a transient edge pool-capacity blip) must fail the request over to
+// the next stub WITHOUT advancing the per-account cooldown counter or cooling the
+// stub — otherwise a 3-503 edge burst trips the 3/3 ladder and blacks out the
+// whole edge stub for 10 minutes, collapsing the prod pool.
+func TestRateLimitService_HandleUpstreamError_DownstreamNoAvailable_DoesNotPenalizeStub(t *testing.T) {
+	repo := &rateLimitAccountRepoStub{}
+	counter := &anthropicUpstreamErrorCounterCacheStub{counts: []int64{1, 2, 3, 4, 5}}
+	service := NewRateLimitService(repo, nil, &config.Config{}, nil, nil)
+	service.SetAnthropicUpstreamErrorCounterCache(counter)
+	account := &Account{ID: 4042, Platform: PlatformAnthropic, Type: AccountTypeAPIKey}
+
+	body := []byte(`{"type":"error","error":{"type":"api_error","message":"No available accounts: no available accounts"}}`)
+	for i := 0; i < 5; i++ {
+		shouldDisable := service.HandleUpstreamError(context.Background(), account, http.StatusServiceUnavailable, http.Header{}, body)
+		require.True(t, shouldDisable, "iteration %d: downstream 503 no-available must fail over to the next stub", i)
+	}
+
+	require.Equal(t, 0, repo.tempCalls, "downstream no-available 503 must never write temp_unschedulable")
+	require.Equal(t, 0, repo.setErrorCalls)
+	require.Empty(t, counter.incrementIDs, "downstream no-available 503 must NOT advance the cooldown counter")
+}
+
+// Regression: a genuine Anthropic upstream 503 (no "no available accounts" body)
+// still flows through the threshold path so persistent real upstream failure
+// continues to escalate and eventually cools the account.
+func TestRateLimitService_HandleUpstreamError_GenuineUpstream503_StillCounts(t *testing.T) {
+	repo := &rateLimitAccountRepoStub{}
+	counter := &anthropicUpstreamErrorCounterCacheStub{counts: []int64{1, 2, 3}, tierCounts: []int64{1}}
+	service := NewRateLimitService(repo, nil, &config.Config{}, nil, nil)
+	service.SetAnthropicUpstreamErrorCounterCache(counter)
+	account := &Account{ID: 4043, Platform: PlatformAnthropic, Type: AccountTypeAPIKey}
+
+	body := []byte(`{"type":"error","error":{"type":"api_error","message":"upstream request failed"}}`)
+	for i := 0; i < 2; i++ {
+		require.False(t, service.HandleUpstreamError(context.Background(), account, http.StatusServiceUnavailable, http.Header{}, body))
+	}
+	require.True(t, service.HandleUpstreamError(context.Background(), account, http.StatusServiceUnavailable, http.Header{}, body),
+		"3rd genuine upstream 503 must trip the threshold")
+	require.Equal(t, 1, repo.tempCalls)
+	require.Equal(t, []int64{4043, 4043, 4043}, counter.incrementIDs)
+}

--- a/scripts/sentinels/gateway-tk.json
+++ b/scripts/sentinels/gateway-tk.json
@@ -1218,9 +1218,11 @@
       "path": "backend/internal/service/ratelimit_service.go",
       "must_contain": [
         "tkIsAnthropicClientInducedBadRequest(responseBody)",
-        "s.tkClampOpenAIRateLimitReset(ctx, account.ID"
+        "s.tkClampOpenAIRateLimitReset(ctx, account.ID",
+        "tkIsDownstreamNoAvailableAccounts(upstreamMsg, responseBody)",
+        "anthropic_downstream_no_available_accounts_skip_penalty"
       ],
-      "rationale": "TK#2608: client-induced Anthropic 400 invalid_request_error must not advance the per-account cooldown counter (else an external caller can pause a shared OAuth subscription account). TK#1981: opt-in clamp of long OpenAI 429 resets so released accounts are re-probed by traffic instead of idling."
+      "rationale": "TK#2608: client-induced Anthropic 400 invalid_request_error must not advance the per-account cooldown counter (else an external caller can pause a shared OAuth subscription account). TK#1981: opt-in clamp of long OpenAI 429 resets so released accounts are re-probed by traffic instead of idling. Prod incident 2026-05-31: a downstream 503 whose body is our own 'no available accounts' pool-exhaustion signal (a thin edge bursting on parallel haiku background requests, surfaced through a prod per-edge mirror stub) must fail over to the next stub WITHOUT advancing the anthropic_upstream_error counter — else a 3-503 edge burst trips the 3/3 ladder and cools the whole edge stub for 10 minutes, collapsing the prod pool (self-inflicted 503 amplifier)."
     },
     {
       "path": "backend/internal/service/ratelimit_service_tk_client_induced_400.go",
@@ -1229,6 +1231,14 @@
         "invalid_request_error"
       ],
       "rationale": "TK#2608: the predicate distinguishing client-induced 400s from account-level punishment. Removing it reopens the external account-disable abuse vector."
+    },
+    {
+      "path": "backend/internal/service/ratelimit_service_tk_downstream_no_available.go",
+      "must_contain": [
+        "func tkIsDownstreamNoAvailableAccounts",
+        "ErrNoAvailableAccounts.Error()"
+      ],
+      "rationale": "Prod incident 2026-05-31: the predicate distinguishing a downstream gateway's own 'no available accounts' pool-exhaustion 503 (transient edge capacity blip on a forwarded-to pool) from a genuine account-health upstream error. Removing it lets a brief edge-side haiku burst trip the 3/3 anthropic_upstream_error ladder and 10-minute-cool the prod mirror stub for that whole edge, reintroducing the self-inflicted 503 amplifier."
     },
     {
       "path": "backend/internal/service/openai_gateway_service_tk_implicit_throttle.go",


### PR DESCRIPTION
## 背景：线上事故（2026-05-31）

prod、edge-us1、edge-uk1 出现「临时不可调度 / no available accounts」503。逐分钟重建后定位为**两层级联**：

**第 1 层（触发，在 edge）** — 边缘 Anthropic 账号池太薄（uk1 仅 **1** 个可调度 OAuth 账号，us1 仅 2 个）。Claude Code 并行发一簇 `claude-haiku-4-5-20251001` 背景请求（同秒 ~3 条），薄池瞬时占满 → 溢出请求拿不到账号 → 本地路由 503 `no available accounts`。edge 账号本身未被置 temp_unschedulable，仅 haiku 命中（高频并行），opus 几乎不受影响。

| edge | haiku 200 | haiku 503 | opus 200 | opus 503 | 503 分布 |
|---|---|---|---|---|---|
| uk1 | 274 | 12 | 161 | 1 | 每簇 3–4 条 |
| us1 | 504 | 9 | 94 | 0 | **每簇正好 3 条** |

**第 2 层（放大，在 prod）** — prod 走 Anthropic 只能经**按 edge 的 api-key 镜像 stub**（cc-us1 / cc-uk1）。每个 edge 503 被计为 `anthropic_upstream_error`，**3/3 阈值即触发、tier=2 冷却 10 分钟**。edge「每分钟正好 3 条」突发恰好卡满阈值 → cc-us1/cc-uk1 同时被冷却 10min → prod anthropic 池整体塌陷 → 对 **opus + haiku 全模型** 报 503。

证据（prod stub 的 `temp_unschedulable_reason`）：
```
Anthropic upstream error threshold (3/3, cooldown=10m0s tier=2):
Anthropic upstream error (503): No available accounts: no available accounts
```

## 改动（修「放大器」）

edge 返回的 503 `no available accounts` 是**下游池容量瞬时抖动**，不是转发 stub 的健康问题。本 PR 在 `handleAnthropicUpstreamError` 顶部加守卫：

- 当 `statusCode==503` 且响应体/上游消息含 `no available accounts`（TokenKey 自有调度串 `service.ErrNoAvailableAccounts`，Anthropic 真实 API 永不产出）→ **failover 到下一个 stub（`shouldDisable=true`）**，但**完全跳过计数与 `SetTempUnschedulable`**。
- 这比现状更好：现状前 2 次返回 false 直接给客户端 502、第 3 次才转移且上 10 分钟冷却；改后每次都立即转移到其他 edge，且永不冷却。
- **真实上游 503**（任何其他 body）仍走原阈值路径，持续故障照常升级 → 不掩盖真问题。

实现完全照搬已有 TK 守卫模式 `tkIsAnthropicClientInducedBadRequest`（#2608）：
- 新增伴生 `ratelimit_service_tk_downstream_no_available.go`（纯判定函数）
- `ratelimit_service.go` 仅一处薄注入（守卫 + 注释）
- sentinel anchors 已为新守卫 + 伴生文件补齐（防 upstream merge 静默删除）

> 注：edge 扩冗余（uk1/us1 加账号）与 cc-us2 余额由运维另行处理（事故根因第 1 层）；本 PR 只消除 prod 侧的放大效应。

## 验证

- `go build ./...` ✅
- `go test -tags=unit ./...` ✅（全量）
- `golangci-lint run ./internal/service/...` ✅ 0 issues
- 新增单测：edge 503 no-available × 5 次 → 全部 failover、`temp_unschedulable` 0 次、counter 0 次；真实上游 503 第 3 次仍触发阈值（回归）
- `scripts/preflight.sh` ✅（含 gateway-tk sentinel 142/142、newapi 29/29）

## 合并方式

TK fix PR → **Squash and merge**（rule §5.y）。

🤖 Generated with [Claude Code](https://claude.com/claude-code)
