### PR TITLE
ci(release): rolling Go build cache to warm arm64 cross-compile

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -142,7 +142,36 @@ jobs:
         with:
           go-version-file: backend/go.mod
           check-latest: false
-          cache-dependency-path: backend/go.sum
+          # Build/module cache is handled by the rolling cache step below, NOT
+          # by setup-go's built-in cache. setup-go keys its cache on go.sum and
+          # is IMMUTABLE: once the go.sum-keyed entry exists it is never
+          # re-saved. Because that entry is first written by an amd64-only run,
+          # the arm64 cross-compile objects stay perpetually cold and GoReleaser
+          # recompiles the full arm64 package set every release (~3m40s
+          # "building binaries", ~79% of the GoReleaser step). Disabling it here
+          # lets the rolling cache below own GOCACHE + GOMODCACHE.
+          cache: false
+
+      # Rolling Go cache for the cross-arch (amd64+arm64) GoReleaser compile.
+      # A run_id-unique SAVE key means the cache is ALWAYS re-saved at post-job;
+      # the restore-keys fall back to the most recent warm snapshot — which
+      # already holds BOTH arches' object files from the previous release — so a
+      # typical release only recompiles changed packages + relinks, instead of
+      # rebuilding arm64 from scratch. Go's cache is content-addressed, so a
+      # stale entry (e.g. after a .new-api-ref bump) is simply unused, never
+      # wrong. First run after this change is a one-time cold build; budget note:
+      # each release writes a fresh ~1-2GB entry under the 10GB repo cache limit,
+      # GHA LRU-evicts the oldest, the freshest (what we need) always survives.
+      - name: Rolling Go build cache (amd64 + arm64 cross-compile)
+        uses: actions/cache@v4
+        with:
+          path: |
+            ~/.cache/go-build
+            ~/go/pkg/mod
+          key: ${{ runner.os }}-go-release-${{ hashFiles('backend/go.sum') }}-${{ github.run_id }}
+          restore-keys: |
+            ${{ runner.os }}-go-release-${{ hashFiles('backend/go.sum') }}-
+            ${{ runner.os }}-go-release-
 
       - name: Verify Go version
         run: |


### PR DESCRIPTION
## 问题

release 流水线长尾在 GoReleaser 的 `building binaries` 阶段(~3m40s,占 GoReleaser step ~79%),跨架构编译 linux/amd64 + linux/arm64。**QEMU 不是瓶颈**——docker build(含 arm64 模拟)仅 ~17s,push GHCR ~23s。

实测计时(v1.7.52):

| 阶段 | 耗时 |
|---|---|
| building binaries(Go 编译 amd64+arm64) | **3m40s** |
| archives | 17s |
| building docker images(含 arm64 QEMU) | 17s |
| publishing(push GHCR) | 23s |

**根因**:`setup-go` 的缓存用 go.sum 不可变 key,日志末尾 `Cache hit ... no cache is saved`——该缓存条目最初在 amd64-only 构建时写入,arm64 跨编对象**永远是冷的**,每次 release 都从头编 arm64 全套包。

## 改动(仅方案 B,不换 runner、不拆 arch matrix)

- release job 关掉 `setup-go` 内置缓存(`cache: false`)
- 新增滚动 `actions/cache`:`~/.cache/go-build` + `~/go/pkg/mod`,save-key 带 `github.run_id`(每次必存),`restore-keys` 回退到最近暖快照(已含上次 release 编出的两架构对象)

之后每次 release 只重编改动的包 + 链接。预期 `building binaries` 3m40s → ~1.5-2min,总流水线 ~7min → ~5min。第一次跑仍冷编译,从第二次起变快。

## 两个架构都不能砍

线上混合架构:prod + EC2 edge = arm64(Graviton t4g);5 个 deployable Lightsail edge = x86/amd64(bundle `micro_3_0`,见 `deploy/aws/lightsail/README.md`);公开 GHCR `:latest` 服务社区 amd64。砍任一架构都会让对应 fleet 崩 `exec format error`。

## 发版纪律(§9)未触碰

- `simple_release` default 仍 `false`,warning banner 原样
- skip-ci 安全检查、VERSION 回写逻辑零改动
- commit/PR 文案按 §9.2 用无括号 `skip-ci` 形态

## 自检

- [x] YAML 合法,`preflight.sh` 全绿
- [x] 改动内容寻址安全:`.new-api-ref` bump 后旧缓存条目只是不被用,不会编错
- [x] override-marker 门禁不覆盖 `.github/workflows/`(commit 带 `no-upstream-touch`)
- [x] 合并方式:TK-originated → **Squash and merge**

🤖 Generated with [Claude Code](https://claude.com/claude-code)