### PR TITLE
fix(edge): scheduling-capacity must use global schedulable Σ, not nonexistent group

### DIFF
--- a/backend/internal/handler/edge_tk_capacity_handler.go
+++ b/backend/internal/handler/edge_tk_capacity_handler.go
@@ -15,13 +15,8 @@ import (
 // endpoint needs. service.AccountRepository satisfies it; a small interface keeps
 // the handler unit-testable without stubbing the whole repository surface.
 type schedulingCapacityReader interface {
-	SumConcurrencyAnthropicByGroup(ctx context.Context, groupName string) (int64, error)
+	SumConcurrencyAnthropic(ctx context.Context) (int64, error)
 }
-
-// anthropicDefaultGroupName is the canonical default group for anthropic accounts
-// (group naming convention is "<platform>-default"). Surface-C counts only this
-// group's schedulable concurrency so prod mirrors the right edge pool number.
-const anthropicDefaultGroupName = "anthropic-default"
 
 // EdgeCapacityHandler serves the TokenKey "scheduling capacity" read endpoint
 // that prod's anthropic-config reconciler (surface C) calls over HTTP to mirror
@@ -68,7 +63,14 @@ func (h *EdgeCapacityHandler) GetSchedulingCapacity(c *gin.Context) {
 		return
 	}
 
-	total, err := h.accounts.SumConcurrencyAnthropicByGroup(c.Request.Context(), anthropicDefaultGroupName)
+	// Global Σ schedulable anthropic concurrency — the canonical "edge serving
+	// capacity" number (same rule as the operator-Σ alignment in
+	// anthropic_operator_concurrency.go). The prior by-group sum hardcoded a
+	// group name ("anthropic-default") that does not exist on edges (their
+	// anthropic group is "default"), so the endpoint always returned 0 and prod's
+	// surface-C mirror never converged. SumConcurrencyAnthropic already filters
+	// schedulable=true, so the admin-bypass api-key (schedulable=false) is excluded.
+	total, err := h.accounts.SumConcurrencyAnthropic(c.Request.Context())
 	if err != nil {
 		response.Error(c, http.StatusInternalServerError, "failed to read scheduling capacity")
 		return

--- a/backend/internal/handler/edge_tk_capacity_handler_test.go
+++ b/backend/internal/handler/edge_tk_capacity_handler_test.go
@@ -15,13 +15,13 @@ import (
 )
 
 type capacityReaderStub struct {
-	sum       int64
-	err       error
-	lastGroup string
+	sum    int64
+	err    error
+	called bool
 }
 
-func (s *capacityReaderStub) SumConcurrencyAnthropicByGroup(_ context.Context, groupName string) (int64, error) {
-	s.lastGroup = groupName
+func (s *capacityReaderStub) SumConcurrencyAnthropic(_ context.Context) (int64, error) {
+	s.called = true
 	return s.sum, s.err
 }
 
@@ -52,8 +52,12 @@ func TestEdgeCapacityHandler_ReturnsTotalConcurrency(t *testing.T) {
 	require.Equal(t, "anthropic", env.Data.Platform)
 	require.Equal(t, int64(42), env.Data.TotalConcurrency)
 	require.NotZero(t, env.Data.TS)
-	// Surface-C: capacity counts only the anthropic-default scheduling pool.
-	require.Equal(t, "anthropic-default", stub.lastGroup)
+	// Regression: surface-C must read the GLOBAL Σ schedulable anthropic
+	// concurrency (SumConcurrencyAnthropic), not a by-group sum. The prior
+	// by-group call hardcoded "anthropic-default", a group that does not exist on
+	// edges (their group is "default"), so the endpoint always returned 0 and the
+	// prod mirror never converged.
+	require.True(t, stub.called, "must call SumConcurrencyAnthropic (global schedulable Σ)")
 }
 
 func TestEdgeCapacityHandler_DefaultsToAnthropic(t *testing.T) {

--- a/backend/internal/repository/account_repo.go
+++ b/backend/internal/repository/account_repo.go
@@ -166,28 +166,6 @@ WHERE platform = $1 AND schedulable = true AND deleted_at IS NULL`
 	return sum.Int64, nil
 }
 
-// SumConcurrencyAnthropicByGroup returns Σ concurrency for schedulable anthropic
-// accounts that belong to the named group (e.g. "anthropic-default"). Surface-C:
-// the edge capacity endpoint reports only the default-group pool so prod mirrors
-// the right number.
-func (r *accountRepository) SumConcurrencyAnthropicByGroup(ctx context.Context, groupName string) (int64, error) {
-	const q = `
-SELECT COALESCE(SUM(a.concurrency), 0)::bigint
-FROM accounts a
-JOIN account_groups ag ON ag.account_id = a.id
-JOIN groups g ON g.id = ag.group_id
-WHERE a.platform = $1 AND a.schedulable = true AND a.deleted_at IS NULL
-  AND g.name = $2 AND g.deleted_at IS NULL`
-	var sum sql.NullInt64
-	if err := scanSingleRow(ctx, r.sql, q, []any{domain.PlatformAnthropic, groupName}, &sum); err != nil {
-		return 0, fmt.Errorf("sum anthropic concurrency by group %q: %w", groupName, err)
-	}
-	if !sum.Valid {
-		return 0, nil
-	}
-	return sum.Int64, nil
-}
-
 func (r *accountRepository) GetByID(ctx context.Context, id int64) (*service.Account, error) {
 	m, err := r.client.Account.Query().Where(dbaccount.IDEQ(id)).Only(ctx)
 	if err != nil {

--- a/backend/internal/server/api_contract_test.go
+++ b/backend/internal/server/api_contract_test.go
@@ -1813,10 +1813,6 @@ func (s *stubAccountRepo) SumConcurrencyAnthropic(context.Context) (int64, error
 	return 0, nil
 }
 
-func (s *stubAccountRepo) SumConcurrencyAnthropicByGroup(context.Context, string) (int64, error) {
-	return 0, nil
-}
-
 func (s *stubAccountRepo) ListCRSAccountIDs(ctx context.Context) (map[string]int64, error) {
 	return nil, errors.New("not implemented")
 }

--- a/backend/internal/service/account_service.go
+++ b/backend/internal/service/account_service.go
@@ -71,12 +71,11 @@ type AccountRepository interface {
 	UpdateExtra(ctx context.Context, id int64, updates map[string]any) error
 	BulkUpdate(ctx context.Context, ids []int64, updates AccountBulkUpdate) (int64, error)
 
-	// SumConcurrencyAnthropic returns Σ concurrency for all anthropic rows (oauth + apikey,
-	// excluding non-Anthropic platforms and soft-deleted accounts). Matches edge apply injection.
+	// SumConcurrencyAnthropic returns Σ concurrency for schedulable anthropic
+	// accounts (oauth + apikey; schedulable=true, excluding soft-deleted and
+	// admin-bypass schedulable=false rows). The canonical edge serving-capacity /
+	// operator-Σ number; also surface-C's edge scheduling-capacity endpoint.
 	SumConcurrencyAnthropic(ctx context.Context) (int64, error)
-	// SumConcurrencyAnthropicByGroup returns Σ concurrency for schedulable anthropic
-	// accounts in the named group (surface-C: edge capacity counts only the default group).
-	SumConcurrencyAnthropicByGroup(ctx context.Context, groupName string) (int64, error)
 	// IncrementQuotaUsed 原子递增 API Key 账号的配额用量（总/日/周）
 	IncrementQuotaUsed(ctx context.Context, id int64, amount float64) error
 	// ResetQuotaUsed 重置 API Key 账号所有维度的配额用量为 0

--- a/backend/internal/service/account_service_delete_test.go
+++ b/backend/internal/service/account_service_delete_test.go
@@ -211,10 +211,6 @@ func (s *accountRepoStub) SumConcurrencyAnthropic(ctx context.Context) (int64, e
 	return 0, nil
 }
 
-func (s *accountRepoStub) SumConcurrencyAnthropicByGroup(context.Context, string) (int64, error) {
-	return 0, nil
-}
-
 // TestAccountService_Delete_NotFound 测试删除不存在的账号时返回正确的错误。
 // 预期行为：
 //   - ExistsByID 返回 false（账号不存在）

--- a/backend/internal/service/admin_service_bulk_update_test.go
+++ b/backend/internal/service/admin_service_bulk_update_test.go
@@ -261,13 +261,6 @@ func (s *bulkAccountRepoAnthropicSum) SumConcurrencyAnthropic(context.Context) (
 	return s.anthropicConcurrencySum, nil
 }
 
-func (s *bulkAccountRepoAnthropicSum) SumConcurrencyAnthropicByGroup(context.Context, string) (int64, error) {
-	if s.anthropicConcurrencyErr != nil {
-		return 0, s.anthropicConcurrencyErr
-	}
-	return s.anthropicConcurrencySum, nil
-}
-
 // TestBulkUpdateAccounts_SyncAnthropicOperatorConcurrency 验证 userRepo 齐备时，
 // 批量成功后会把管理员用户（users.id=AnthropicOperatorConcurrencyUserID）的并发写成 Σ anthropic accounts。
 func TestBulkUpdateAccounts_SyncAnthropicOperatorConcurrency(t *testing.T) {

--- a/backend/internal/service/anthropic_config_reconciler_test.go
+++ b/backend/internal/service/anthropic_config_reconciler_test.go
@@ -44,13 +44,6 @@ func (s *reconcilerAccountStub) SumConcurrencyAnthropic(ctx context.Context) (in
 	return s.sum, nil
 }
 
-func (s *reconcilerAccountStub) SumConcurrencyAnthropicByGroup(context.Context, string) (int64, error) {
-	if s.sumErr != nil {
-		return 0, s.sumErr
-	}
-	return s.sum, nil
-}
-
 func (s *reconcilerAccountStub) BulkUpdate(ctx context.Context, ids []int64, updates AccountBulkUpdate) (int64, error) {
 	if s.bulkErr != nil {
 		return 0, s.bulkErr

--- a/backend/internal/service/anthropic_operator_concurrency_test.go
+++ b/backend/internal/service/anthropic_operator_concurrency_test.go
@@ -20,13 +20,6 @@ func (a *accountRepoSumStub) SumConcurrencyAnthropic(context.Context) (int64, er
 	return a.sum, nil
 }
 
-func (a *accountRepoSumStub) SumConcurrencyAnthropicByGroup(context.Context, string) (int64, error) {
-	if a.err != nil {
-		return 0, a.err
-	}
-	return a.sum, nil
-}
-
 type recordingUserRepoStub struct {
 	UserRepository
 

--- a/backend/internal/service/gateway_multiplatform_test.go
+++ b/backend/internal/service/gateway_multiplatform_test.go
@@ -199,10 +199,6 @@ func (m *mockAccountRepoForPlatform) SumConcurrencyAnthropic(context.Context) (i
 	return 0, nil
 }
 
-func (m *mockAccountRepoForPlatform) SumConcurrencyAnthropicByGroup(context.Context, string) (int64, error) {
-	return 0, nil
-}
-
 // Verify interface implementation
 var _ AccountRepository = (*mockAccountRepoForPlatform)(nil)
 

--- a/backend/internal/service/gemini_multiplatform_test.go
+++ b/backend/internal/service/gemini_multiplatform_test.go
@@ -188,10 +188,6 @@ func (m *mockAccountRepoForGemini) SumConcurrencyAnthropic(context.Context) (int
 	return 0, nil
 }
 
-func (m *mockAccountRepoForGemini) SumConcurrencyAnthropicByGroup(context.Context, string) (int64, error) {
-	return 0, nil
-}
-
 // Verify interface implementation
 var _ AccountRepository = (*mockAccountRepoForGemini)(nil)
 

--- a/backend/internal/service/ratelimit_session_window_test.go
+++ b/backend/internal/service/ratelimit_session_window_test.go
@@ -156,9 +156,6 @@ func (m *sessionWindowMockRepo) ResetQuotaUsed(context.Context, int64) error { p
 func (m *sessionWindowMockRepo) SumConcurrencyAnthropic(context.Context) (int64, error) {
 	panic("unexpected")
 }
-func (m *sessionWindowMockRepo) SumConcurrencyAnthropicByGroup(context.Context, string) (int64, error) {
-	panic("unexpected")
-}
 
 // newRateLimitServiceForTest creates a RateLimitService with the given mock repo.
 func newRateLimitServiceForTest(repo AccountRepository) *RateLimitService {

--- a/scripts/sentinels/gateway-tk.json
+++ b/scripts/sentinels/gateway-tk.json
@@ -1364,10 +1364,9 @@
       "path": "backend/internal/handler/edge_tk_capacity_handler.go",
       "must_contain": [
         "func (h *EdgeCapacityHandler) GetSchedulingCapacity(",
-        "SumConcurrencyAnthropicByGroup(",
-        "anthropicDefaultGroupName"
+        "SumConcurrencyAnthropic("
       ],
-      "rationale": "Edge capacity read endpoint (surface C): GET /api/v1/edge/scheduling-capacity exposes Σ schedulable anthropic concurrency so prod's reconciler can mirror a live edge's capacity onto its stub. The pool now partitions by group — capacity counts ONLY the anthropic-default scheduling pool (SumConcurrencyAnthropicByGroup(\"anthropic-default\")), not every anthropic row; a silent revert to the unscoped sum would over-count cross-group accounts. Read-only, off the gateway billing/concurrency chain. Silent deletion would break the prod concurrency-mirror without a compile error (prod would just stop converging)."
+      "rationale": "Edge capacity read endpoint (surface C): GET /api/v1/edge/scheduling-capacity exposes the GLOBAL Σ schedulable anthropic concurrency (SumConcurrencyAnthropic, schedulable=true filter) so prod's reconciler can mirror a live edge's capacity onto its stub. This is the SAME canonical rule as the operator-Σ alignment (anthropic_operator_concurrency.go). It must NOT use a by-group sum: the prior SumConcurrencyAnthropicByGroup(\"anthropic-default\") hardcoded a group name that does not exist on edges (their anthropic group is \"default\"), so the endpoint always returned 0 and prod's mirror never converged since #472 — a silent always-no-op. Read-only, off the gateway billing/concurrency chain; the schedulable=true filter already excludes admin-bypass api-keys. Silent deletion or a revert to the by-group sum would break the prod concurrency-mirror without a compile error (prod would just stop converging)."
     },
     {
       "path": "backend/internal/server/middleware/edge_capacity_auth_tk.go",


### PR DESCRIPTION
## Bug:surface-C(#472)从上线起就是 no-op

`edge_tk_capacity_handler.go` 硬编码 `SumConcurrencyAnthropicByGroup("anthropic-default")`,但每个 edge 的 anthropic 组实际叫 **`default`**——该组名永不匹配,所以 `GET /api/v1/edge/scheduling-capacity` 对每个 edge **永远返回 `total_concurrency=0`**。

prod 的 surface-C reconciler 把 0 当「skip, never write 0」,于是 prod `cc-<edge>` 镜像 stub concurrency **自 #472 以来从未收敛**,是个静默 no-op。

**线上实证**(激活 gate 后):
- `cc-us1` 卡在 18(应 22)、`cc-uk1` 卡在 8(应 10)
- prod 日志每 5min:`edge reported capacity < 1; skipping  total_concurrency=0`(us1/uk1)
- live 验证:`SumConcurrencyAnthropicByGroup('default')`=22、`('anthropic-default')`=0

## 修复(方案 B:全局 schedulable Σ)

端点改用 `SumConcurrencyAnthropic`(已带 `schedulable=true` 过滤)= 22,**去掉组名依赖**,与 operator-Σ 对齐的 canonical 口径一致(到处都是「Σ schedulable」,唯独这里用 by-group 才踩坑)。admin 旁路 api-key(`schedulable=false`)仍被排除。

- handler + 窄接口改用 `SumConcurrencyAnthropic`
- 回归测试断言走全局 Σ 路径(去掉 by-group 断言)
- **sentinel anchor + rationale 已修正**(旧 rationale 把 bug 当成了正确行为)

## 验证
- `go build ./...` ✅、`go test -tags=unit ./internal/handler/... ./internal/service/...` ✅、`golangci-lint` 0 issues
- `scripts/preflight.sh` PASS(gateway-tk sentinel 重新对齐)

## 发版
合并后立即 `target=prod` 发版(用户要求)。gate 已在 prod 开着;新镜像上线后 ≤5min tick 即把 cc-us1→22、cc-uk1→10 自愈。

## 合并方式
TK fix PR → Squash and merge(§5.y)。

🤖 Generated with [Claude Code](https://claude.com/claude-code)
