### PR TITLE
feat(deploy): auto-record Lightsail polluted IPs and backfill uk history

### DIFF
--- a/.cursor/skills/tokenkey-stage0-edge-lightsail-ip-rotation/SKILL.md
+++ b/.cursor/skills/tokenkey-stage0-edge-lightsail-ip-rotation/SKILL.md
@@ -24,6 +24,8 @@ EC2 路径见 `tokenkey-stage0-edge-ip-rotation`。Lightsail 路径**没有 Clou
 | 解析 edge → region / instance / static IP name / domain | 机械 | `ops/lightsail/rotate-static-ip.sh`（jq 读 `edge-targets-lightsail.json`） |
 | 计划输出（dry run） | 机械 | 同上脚本默认行为（无 `--apply`） |
 | 三步 swap（allocate → detach → attach → release） | 机械 | 同上脚本 `--apply` |
+| 候选 IP 撞 exclusion registry 时重试 | 机械 | 同上脚本（默认最多 5 次） |
+| 释放旧 IP 后写入 exclusion registry | 机械 | [`deploy/aws/stage0/record-polluted-ip.py`](../../../deploy/aws/stage0/record-polluted-ip.py)（由 rotate 脚本调用） |
 | 把 ssm_prefix/public_ip 改成新 IP | 机械 | 同上脚本 |
 | Porkbun DNS A 记录更新 | 真判断 | prompt（人工操作 Porkbun） |
 | 外部干净出口验证 | 真判断 | prompt（选择哪个 observation host 取决于运营当时态势） |
@@ -76,21 +78,24 @@ ssm_prefix        : /tokenkey/lightsail/uk1
 ## 2) Swap
 
 ```bash
-bash ops/lightsail/rotate-static-ip.sh <edge_id> --apply
+bash ops/lightsail/rotate-static-ip.sh <edge_id> --apply --reason 'upstream-api-risk-block-YYYY-MM-DD'
 ```
 
 脚本顺序：
 
-1. `aws lightsail allocate-static-ip` 新名字
+1. `aws lightsail allocate-static-ip` 新名字（若候选 IP 已在 [`edge-polluted-ips.json`](../../../deploy/aws/stage0/edge-polluted-ips.json) 则 release 并重试）
 2. `aws lightsail detach-static-ip` 旧名字
 3. `aws lightsail attach-static-ip` 新名字到 instance
 4. `aws lightsail get-static-ip` 读出 NEW ip
 5. `aws ssm put-parameter` 写 `${ssm_prefix}/public_ip = <new_ip>`
 6. `aws lightsail release-static-ip` 旧名字（**该 IP 进入 AWS pool**）
+7. `record-polluted-ip.py append` 把旧 IP 写入 exclusion registry（**记得 commit JSON + 跑 `scripts/edge-ip-status.sh --check`**）
 
 输出最后会打印 NEW ip 和 DNS / smoke 提示。
 
-> **同账户 IP 池注意**：Lightsail 在同账户同 region 复用 IP 池，新分配的 IP 极少撞回相同的旧 IP，但概率不是零。如果 NEW ip 仍被污染，重跑一次 swap 即可（旧 IP 已 release，不会回收到自己手里）。
+> **同账户 IP 池注意**：Lightsail 在同账户同 region 复用 IP 池。rotate 脚本会查
+> [`edge-polluted-ips.json`](../../../deploy/aws/stage0/edge-polluted-ips.json) 并在候选 IP
+> 已登记时自动重试；释放的旧 IP 也会自动 append 进 registry，避免再次撞回。
 
 ## 3) DNS 与 Caddy
 

--- a/deploy/aws/stage0/allocate-clean-egress-eip.py
+++ b/deploy/aws/stage0/allocate-clean-egress-eip.py
@@ -1,6 +1,7 @@
 #!/usr/bin/env python3
 """Allocate a fresh VPC EIP for an edge, refusing any allocation that lands on
 a known-excluded IP listed in deploy/aws/stage0/edge-polluted-ips.json (polluted[]).
+Lightsail Static IP rotations use the same registry via record-polluted-ip.py.
 
 Used by .github/workflows/deploy-edge-stage0.yml operation=rotate_egress_ip
 before the CloudFormation update-stack that binds the new allocation to the

--- a/deploy/aws/stage0/edge-polluted-ips.json
+++ b/deploy/aws/stage0/edge-polluted-ips.json
@@ -1,20 +1,40 @@
 {
   "schema_version": 2,
-  "description": "EC2 edge EIP exclusion registry. allocate-clean-egress-eip.py refuses any fresh allocation that lands on these IPs (per region).",
+  "description": "Edge egress IP exclusion registry (EC2 EIP + Lightsail Static IP). allocate-clean-egress-eip.py and ops/lightsail/rotate-static-ip.sh refuse fresh allocations that land on these IPs (per region).",
   "polluted": [
     {
       "ip": "3.9.160.161",
       "region": "eu-west-2",
+      "platform": "ec2",
+      "edge_id": "uk1",
       "notes": "upstream API risk-block (2026-05-20)"
     },
     {
       "ip": "35.177.124.150",
       "region": "eu-west-2",
+      "platform": "ec2",
+      "edge_id": "uk1",
       "notes": "upstream API risk-block (2026-05-22)"
+    },
+    {
+      "ip": "16.61.87.51",
+      "region": "eu-west-2",
+      "platform": "ec2",
+      "edge_id": "uk1",
+      "notes": "EC2 uk1 orphan EIP released 2026-05-26 after EC2→Lightsail migration (not upstream pollution; exclude from re-allocation)"
+    },
+    {
+      "ip": "18.135.59.111",
+      "region": "eu-west-2",
+      "platform": "lightsail",
+      "edge_id": "uk1",
+      "notes": "Lightsail edge-uk1 tokenkey-edge-uk1-ls-ip superseded 2026-05-26; released after matrix correction to 13.134.80.182"
     },
     {
       "ip": "100.48.129.133",
       "region": "us-east-1",
+      "platform": "lightsail",
+      "edge_id": "us2",
       "notes": "Lightsail edge-us2 StaticIp-2 upstream API risk-block (2026-05-29)"
     }
   ]

--- a/deploy/aws/stage0/record-polluted-ip.py
+++ b/deploy/aws/stage0/record-polluted-ip.py
@@ -1,0 +1,172 @@
+#!/usr/bin/env python3
+"""Append an egress IP to deploy/aws/stage0/edge-polluted-ips.json (atomic replace).
+
+Used by ops/lightsail/rotate-static-ip.sh after releasing a polluted Static IP.
+EC2 rotations may call the same helper once workflow automation lands.
+
+Exit codes:
+  0 — entry recorded (or already present with same ip+region)
+  2 — validation / duplicate conflict / I/O error
+"""
+
+from __future__ import annotations
+
+import argparse
+import json
+import os
+import re
+import sys
+import tempfile
+from pathlib import Path
+from typing import Any
+
+REPO_ROOT = Path(__file__).resolve().parents[3]
+REGISTRY = REPO_ROOT / "deploy" / "aws" / "stage0" / "edge-polluted-ips.json"
+IPV4 = re.compile(r"^(\d{1,3}\.){3}\d{1,3}$")
+
+
+def fail(msg: str, code: int = 2) -> None:
+    print(f"record-polluted-ip: {msg}", file=sys.stderr)
+    sys.exit(code)
+
+
+def validate_ip(ip: str) -> None:
+    if not IPV4.match(ip):
+        fail(f"invalid IPv4 address: {ip!r}")
+    octets = [int(part) for part in ip.split(".")]
+    if any(o < 0 or o > 255 for o in octets):
+        fail(f"invalid IPv4 address: {ip!r}")
+
+
+def load_registry(path: Path = REGISTRY) -> dict[str, Any]:
+    if not path.exists():
+        fail(f"missing registry: {path}")
+    try:
+        return json.loads(path.read_text(encoding="utf-8"))
+    except json.JSONDecodeError as exc:
+        fail(f"malformed JSON in {path}: {exc}")
+
+
+def excluded_ips_for_region(data: dict[str, Any], region: str) -> set[str]:
+    return {
+        entry["ip"]
+        for entry in data.get("polluted", [])
+        if entry.get("region") == region and "ip" in entry
+    }
+
+
+def find_entry(data: dict[str, Any], ip: str, region: str) -> dict[str, Any] | None:
+    for entry in data.get("polluted", []):
+        if entry.get("ip") == ip and entry.get("region") == region:
+            return entry
+    return None
+
+
+def atomic_write_registry(data: dict[str, Any], path: Path = REGISTRY) -> None:
+    payload = json.dumps(data, indent=2, ensure_ascii=False) + "\n"
+    path.parent.mkdir(parents=True, exist_ok=True)
+    fd, tmp_name = tempfile.mkstemp(
+        prefix=f".{path.name}.",
+        suffix=".tmp",
+        dir=str(path.parent),
+    )
+    try:
+        with os.fdopen(fd, "w", encoding="utf-8") as handle:
+            handle.write(payload)
+            handle.flush()
+            os.fsync(handle.fileno())
+        os.replace(tmp_name, path)
+    except OSError as exc:
+        try:
+            os.unlink(tmp_name)
+        except OSError:
+            pass
+        fail(f"failed to write {path}: {exc}")
+
+
+def append_entry(
+    *,
+    ip: str,
+    region: str,
+    notes: str,
+    edge_id: str = "",
+    platform: str = "",
+    registry_path: Path = REGISTRY,
+    dry_run: bool = False,
+) -> bool:
+    validate_ip(ip)
+    if not region.strip():
+        fail("region is required")
+    if not notes.strip():
+        fail("notes is required")
+
+    data = load_registry(registry_path)
+    existing = find_entry(data, ip, region)
+    if existing is not None:
+        print(
+            f"record-polluted-ip: already registered {ip} in {region} "
+            f"(notes={existing.get('notes', '')!r})",
+            file=sys.stderr,
+        )
+        return False
+
+    entry: dict[str, Any] = {
+        "ip": ip,
+        "region": region,
+        "notes": notes.strip(),
+    }
+    if edge_id:
+        entry["edge_id"] = edge_id
+    if platform:
+        entry["platform"] = platform
+
+    data.setdefault("polluted", []).append(entry)
+    if dry_run:
+        print(json.dumps(entry, indent=2))
+        return True
+
+    atomic_write_registry(data, registry_path)
+    print(f"record-polluted-ip: appended {ip} ({region}) to {registry_path}")
+    return True
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("--registry", type=Path, default=REGISTRY, help="Registry JSON path")
+    sub = parser.add_subparsers(dest="command", required=True)
+
+    append = sub.add_parser("append", help="Append an exclusion entry (idempotent on ip+region)")
+    append.add_argument("--ip", required=True)
+    append.add_argument("--region", required=True)
+    append.add_argument("--notes", required=True)
+    append.add_argument("--edge-id", default="")
+    append.add_argument("--platform", choices=("ec2", "lightsail"), default="")
+    append.add_argument("--dry-run", action="store_true")
+
+    check = sub.add_parser("is-excluded", help="Exit 0 when ip+region is already excluded")
+    check.add_argument("--ip", required=True)
+    check.add_argument("--region", required=True)
+
+    args = parser.parse_args()
+
+    if args.command == "is-excluded":
+        validate_ip(args.ip)
+        data = load_registry(args.registry)
+        if args.ip in excluded_ips_for_region(data, args.region):
+            return 0
+        return 1
+
+    append_entry(
+        ip=args.ip,
+        region=args.region,
+        notes=args.notes,
+        edge_id=args.edge_id,
+        platform=args.platform,
+        registry_path=args.registry,
+        dry_run=args.dry_run,
+    )
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/deploy/aws/stage0/test_allocate_clean_egress_eip.py
+++ b/deploy/aws/stage0/test_allocate_clean_egress_eip.py
@@ -28,6 +28,8 @@ class LoadExcludedIPsTests(unittest.TestCase):
         polluted_ips = {e["ip"] for e in data["polluted"]}
         self.assertIn("3.9.160.161", polluted_ips)
         self.assertIn("35.177.124.150", polluted_ips)
+        self.assertIn("16.61.87.51", polluted_ips)
+        self.assertIn("18.135.59.111", polluted_ips)
         self.assertNotIn("retired_excluded", data)
 
     def test_load_excluded_ips_for_region(self):

--- a/deploy/aws/stage0/test_record_polluted_ip.py
+++ b/deploy/aws/stage0/test_record_polluted_ip.py
@@ -1,0 +1,85 @@
+import json
+import tempfile
+import unittest
+from pathlib import Path
+
+REPO_ROOT = Path(__file__).resolve().parents[3]
+RECORD = REPO_ROOT / "deploy" / "aws" / "stage0" / "record-polluted-ip.py"
+
+
+def load_module():
+    import importlib.util
+
+    spec = importlib.util.spec_from_file_location("record_polluted_ip", RECORD)
+    mod = importlib.util.module_from_spec(spec)
+    assert spec.loader is not None
+    spec.loader.exec_module(mod)
+    return mod
+
+
+class RecordPollutedIPTests(unittest.TestCase):
+    @classmethod
+    def setUpClass(cls):
+        cls.mod = load_module()
+
+    def test_append_is_idempotent(self):
+        with tempfile.TemporaryDirectory() as tmp:
+            path = Path(tmp) / "edge-polluted-ips.json"
+            path.write_text(
+                json.dumps({"schema_version": 2, "polluted": []}),
+                encoding="utf-8",
+            )
+            added = self.mod.append_entry(
+                ip="18.135.59.111",
+                region="eu-west-2",
+                notes="Lightsail uk1 superseded",
+                edge_id="uk1",
+                platform="lightsail",
+                registry_path=path,
+            )
+            self.assertTrue(added)
+            again = self.mod.append_entry(
+                ip="18.135.59.111",
+                region="eu-west-2",
+                notes="duplicate attempt",
+                registry_path=path,
+            )
+            self.assertFalse(again)
+            data = json.loads(path.read_text(encoding="utf-8"))
+            self.assertEqual(len(data["polluted"]), 1)
+            self.assertEqual(data["polluted"][0]["edge_id"], "uk1")
+
+    def test_atomic_write_replaces_whole_file(self):
+        with tempfile.TemporaryDirectory() as tmp:
+            path = Path(tmp) / "edge-polluted-ips.json"
+            path.write_text('{"schema_version":2,"polluted":[]}', encoding="utf-8")
+            self.mod.append_entry(
+                ip="1.2.3.4",
+                region="us-east-1",
+                notes="test",
+                registry_path=path,
+            )
+            data = json.loads(path.read_text(encoding="utf-8"))
+            self.assertEqual(data["polluted"][0]["ip"], "1.2.3.4")
+
+    def test_is_excluded_lookup(self):
+        with tempfile.TemporaryDirectory() as tmp:
+            path = Path(tmp) / "edge-polluted-ips.json"
+            path.write_text(
+                json.dumps(
+                    {
+                        "polluted": [
+                            {"ip": "3.9.160.161", "region": "eu-west-2", "notes": "x"}
+                        ]
+                    }
+                ),
+                encoding="utf-8",
+            )
+            data = self.mod.load_registry(path)
+            excluded = self.mod.excluded_ips_for_region(data, "eu-west-2")
+            self.assertIn("3.9.160.161", excluded)
+            self.assertNotIn("3.9.160.161", self.mod.excluded_ips_for_region(data, "us-east-1"))
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/docs/deploy/tokenkey-edge-ip-history.md
+++ b/docs/deploy/tokenkey-edge-ip-history.md
@@ -1,9 +1,9 @@
 # Edge egress IP exclusion registry
 
-Permanent list of **polluted** EC2 egress IPs. Do not bind these addresses to any edge again.
+Permanent list of **excluded** edge egress IPs (EC2 EIP and Lightsail Static IP). Do not bind these addresses to any edge again.
 
 - **Source of truth:** [`deploy/aws/stage0/edge-polluted-ips.json`](../../deploy/aws/stage0/edge-polluted-ips.json)
-- **Enforcement:** [`deploy/aws/stage0/allocate-clean-egress-eip.py`](../../deploy/aws/stage0/allocate-clean-egress-eip.py) (EC2 `rotate_egress_ip` path)
+- **Enforcement:** [`deploy/aws/stage0/allocate-clean-egress-eip.py`](../../deploy/aws/stage0/allocate-clean-egress-eip.py) (EC2 `rotate_egress_ip` path); [`deploy/aws/stage0/record-polluted-ip.py`](../../deploy/aws/stage0/record-polluted-ip.py) + [`ops/lightsail/rotate-static-ip.sh`](../../ops/lightsail/rotate-static-ip.sh) (Lightsail Static IP rotation)
 - **Regenerate table:** `scripts/edge-ip-status.sh --markdown` (paste polluted block below if it drifted)
 
 Active edge EIP rotation runbook: [`.cursor/skills/tokenkey-stage0-edge-ip-rotation/SKILL.md`](../../.cursor/skills/tokenkey-stage0-edge-ip-rotation/SKILL.md).
@@ -15,5 +15,7 @@ Active edge EIP rotation runbook: [`.cursor/skills/tokenkey-stage0-edge-ip-rotat
 | --- | --- | --- |
 | `3.9.160.161` | eu-west-2 | upstream API risk-block (2026-05-20) |
 | `35.177.124.150` | eu-west-2 | upstream API risk-block (2026-05-22) |
+| `16.61.87.51` | eu-west-2 | EC2 uk1 orphan EIP released 2026-05-26 after EC2→Lightsail migration (not upstream pollution; exclude from re-allocation) |
+| `18.135.59.111` | eu-west-2 | Lightsail edge-uk1 tokenkey-edge-uk1-ls-ip superseded 2026-05-26; released after matrix correction to 13.134.80.182 |
 | `100.48.129.133` | us-east-1 | Lightsail edge-us2 StaticIp-2 upstream API risk-block (2026-05-29) |
 <!-- END edge-ip-status:polluted -->

--- a/docs/spec-delta-edge-lightsail.md
+++ b/docs/spec-delta-edge-lightsail.md
@@ -56,8 +56,9 @@
 3. **daily diagnostics**：`ops-daily-diagnostics.yml` 自动把 deployable Lightsail
    edge 接入矩阵，复用 SSM SendCommand 跑 docker ps / 健康 / 日志信号计数；同
    一份 ops-report 同时覆盖 prod + EC2 edge + Lightsail edge
-4. **IP rotation**：`ops/lightsail/rotate-static-ip.sh <edge_id> --apply` 三步换 IP
-   并把 `${ssm_prefix}/public_ip` 同步更新
+4. **IP rotation**：`ops/lightsail/rotate-static-ip.sh <edge_id> --apply` 三步换 IP、
+   拒绝落在 exclusion registry 的候选 IP、自动 append 旧 IP 到
+   `deploy/aws/stage0/edge-polluted-ips.json`，并把 `${ssm_prefix}/public_ip` 同步更新
 
 ### 负向
 

--- a/ops/lightsail/rotate-static-ip.sh
+++ b/ops/lightsail/rotate-static-ip.sh
@@ -9,26 +9,66 @@
 #   1) allocate a new Static IP under <static_ip_name>-rotated-<ts>
 #   2) detach the old Static IP from the Lightsail instance, attach the new one
 #   3) release the old Static IP only after the new attach is confirmed
+#   4) append the released IP to deploy/aws/stage0/edge-polluted-ips.json
 #
 # DNS is intentionally NOT touched here — the operator updates Porkbun once
 # the new IP is verified clean. Same posture as the EC2 EIP rotation skill:
 # rotation primitive owns AWS state; DNS swap is the human gate.
 #
 # Usage:
-#   bash ops/lightsail/rotate-static-ip.sh <edge_id> [--apply]
+#   bash ops/lightsail/rotate-static-ip.sh <edge_id> [--apply] [--reason '...']
 # Without --apply the script only prints the plan (no AWS mutation).
 
 set -euo pipefail
 
-EDGE_ID="${1:-}"
-APPLY="${2:-}"
+EDGE_ID=""
+APPLY=""
+REASON=""
+MAX_ATTEMPTS="${LIGHTSAIL_ALLOCATE_MAX_ATTEMPTS:-5}"
+
+while [[ $# -gt 0 ]]; do
+  case "$1" in
+    --apply)
+      APPLY=--apply
+      shift
+      ;;
+    --reason)
+      REASON="${2:-}"
+      shift 2
+      ;;
+    --max-attempts)
+      MAX_ATTEMPTS="${2:-5}"
+      shift 2
+      ;;
+    -h|--help)
+      echo "usage: $0 <edge_id> [--apply] [--reason 'upstream API risk-block ...'] [--max-attempts N]" >&2
+      exit 0
+      ;;
+    --*)
+      echo "unknown option: $1" >&2
+      exit 1
+      ;;
+    *)
+      if [[ -n "$EDGE_ID" ]]; then
+        echo "unexpected argument: $1" >&2
+        exit 1
+      fi
+      EDGE_ID="$1"
+      shift
+      ;;
+  esac
+done
+
 if [[ -z "$EDGE_ID" ]]; then
-  echo "usage: $0 <edge_id> [--apply]" >&2
+  echo "usage: $0 <edge_id> [--apply] [--reason '...']" >&2
   exit 1
 fi
 
 REPO_ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && cd .. && pwd)"
 MATRIX="${REPO_ROOT}/deploy/aws/lightsail/edge-targets-lightsail.json"
+REGISTRY="${REPO_ROOT}/deploy/aws/stage0/edge-polluted-ips.json"
+RECORD_PY="${REPO_ROOT}/deploy/aws/stage0/record-polluted-ip.py"
+
 if [[ ! -f "$MATRIX" ]]; then
   echo "lightsail matrix not found: $MATRIX" >&2
   exit 1
@@ -49,6 +89,11 @@ if [[ -z "$region" || -z "$instance_name" || -z "$static_ip_name" || -z "$domain
   echo "edge_id ${EDGE_ID} not fully defined in matrix" >&2
   exit 1
 fi
+
+is_excluded_ip() {
+  local ip="$1"
+  python3 "$RECORD_PY" is-excluded --ip "$ip" --region "$region" --registry "$REGISTRY"
+}
 
 # Read the live IP before any mutation so the verification gate is honest.
 old_ip="$(aws lightsail get-static-ip --region "$region" --static-ip-name "$static_ip_name" \
@@ -71,14 +116,16 @@ old_static_ip_name: ${static_ip_name}
 old_ip            : ${old_ip}
 new_static_ip_name: ${new_name}
 ssm_prefix        : ${ssm_prefix}
+max_attempts      : ${MAX_ATTEMPTS}
 
 Steps (each is irreversible without re-allocation):
-  1) allocate Static IP ${new_name}
+  1) allocate Static IP ${new_name} (retry if allocation lands on excluded IP)
   2) detach ${static_ip_name} (=> ${old_ip}) from ${instance_name}
   3) attach ${new_name} to ${instance_name}; read NEW ip
   4) write ${ssm_prefix}/public_ip = NEW ip
   5) release ${static_ip_name}
-  6) human gate: update Porkbun A record ${domain} -> NEW ip
+  6) append ${old_ip} to ${REGISTRY}
+  7) human gate: update Porkbun A record ${domain} -> NEW ip
 
 PLAN
 
@@ -87,32 +134,77 @@ if [[ "$APPLY" != "--apply" ]]; then
   exit 0
 fi
 
-echo "[1/5] allocate ${new_name}"
-aws lightsail allocate-static-ip --region "$region" --static-ip-name "$new_name" >/dev/null
+attempt=1
+new_ip=""
+while [[ "$attempt" -le "$MAX_ATTEMPTS" ]]; do
+  candidate_name="${new_name}"
+  if [[ "$attempt" -gt 1 ]]; then
+    candidate_name="${static_ip_name}-rot-${ts}-${attempt}"
+  fi
 
-echo "[2/5] detach ${static_ip_name}"
+  echo "[1/6] allocate ${candidate_name} (attempt ${attempt}/${MAX_ATTEMPTS})"
+  aws lightsail allocate-static-ip --region "$region" --static-ip-name "$candidate_name" >/dev/null
+
+  candidate_ip="$(aws lightsail get-static-ip --region "$region" --static-ip-name "$candidate_name" \
+    --query 'staticIp.ipAddress' --output text)"
+  if [[ -z "$candidate_ip" || "$candidate_ip" == "None" ]]; then
+    echo "::error::failed to read candidate Static IP after allocate" >&2
+    exit 1
+  fi
+
+  if is_excluded_ip "$candidate_ip"; then
+    echo "  candidate ${candidate_ip} is in exclusion registry; releasing and retrying"
+    aws lightsail release-static-ip --region "$region" --static-ip-name "$candidate_name" >/dev/null
+    attempt=$((attempt + 1))
+    continue
+  fi
+
+  new_name="$candidate_name"
+  new_ip="$candidate_ip"
+  break
+done
+
+if [[ -z "$new_ip" ]]; then
+  echo "::error::exhausted ${MAX_ATTEMPTS} attempts; every allocation landed on an excluded IP" >&2
+  exit 1
+fi
+
+echo "[2/6] detach ${static_ip_name}"
 aws lightsail detach-static-ip --region "$region" --static-ip-name "$static_ip_name" >/dev/null
 
-echo "[3/5] attach ${new_name} to ${instance_name}"
+echo "[3/6] attach ${new_name} to ${instance_name}"
 aws lightsail attach-static-ip --region "$region" --static-ip-name "$new_name" \
   --instance-name "$instance_name" >/dev/null
 
-new_ip="$(aws lightsail get-static-ip --region "$region" --static-ip-name "$new_name" \
+attached_ip="$(aws lightsail get-static-ip --region "$region" --static-ip-name "$new_name" \
   --query 'staticIp.ipAddress' --output text)"
-if [[ -z "$new_ip" || "$new_ip" == "None" ]]; then
+if [[ -z "$attached_ip" || "$attached_ip" == "None" ]]; then
   echo "::error::failed to read NEW Static IP after attach; aborting before release" >&2
   exit 1
 fi
+new_ip="$attached_ip"
 echo "  new_ip = ${new_ip}"
 
 if [[ -n "$ssm_prefix" ]]; then
-  echo "[4/5] write ${ssm_prefix}/public_ip = ${new_ip}"
+  echo "[4/6] write ${ssm_prefix}/public_ip = ${new_ip}"
   aws ssm put-parameter --region "$region" --name "${ssm_prefix}/public_ip" \
     --type String --value "$new_ip" --overwrite >/dev/null
 fi
 
-echo "[5/5] release ${static_ip_name}"
+echo "[5/6] release ${static_ip_name}"
 aws lightsail release-static-ip --region "$region" --static-ip-name "$static_ip_name" >/dev/null
+
+today="$(date -u +%F)"
+rotation_reason="${REASON:-upstream API risk-block (${today})}"
+registry_notes="${rotation_reason}; static_ip_name=${static_ip_name}; released via ops/lightsail/rotate-static-ip.sh"
+
+echo "[6/6] record ${old_ip} in exclusion registry"
+python3 "$RECORD_PY" append \
+  --ip "$old_ip" \
+  --region "$region" \
+  --edge-id "$EDGE_ID" \
+  --platform lightsail \
+  --notes "$registry_notes"
 
 cat <<DONE
 
@@ -121,8 +213,10 @@ edge_id : ${EDGE_ID}
 old_ip  : ${old_ip}
 new_ip  : ${new_ip}
 domain  : ${domain}
+registry: ${REGISTRY} (commit this file + run scripts/edge-ip-status.sh --check)
 
 NEXT (human):
+  - commit deploy/aws/stage0/edge-polluted-ips.json and sync docs/deploy/tokenkey-edge-ip-history.md
   - Porkbun A record ${domain} -> ${new_ip}
   - external probe from a clean-egress host:
       curl -sS --resolve ${domain}:443:${new_ip} https://${domain}/health

--- a/ops/lightsail/rotate-static-ip.sh
+++ b/ops/lightsail/rotate-static-ip.sh
@@ -91,8 +91,17 @@ if [[ -z "$region" || -z "$instance_name" || -z "$static_ip_name" || -z "$domain
 fi
 
 is_excluded_ip() {
-  local ip="$1"
+  local ip="$1" rc
   python3 "$RECORD_PY" is-excluded --ip "$ip" --region "$region" --registry "$REGISTRY"
+  rc=$?
+  case "$rc" in
+    0) return 0 ;;
+    1) return 1 ;;
+    *)
+      echo "::error::exclusion registry check failed for ${ip} (exit ${rc})" >&2
+      exit 1
+      ;;
+  esac
 }
 
 # Read the live IP before any mutation so the verification gate is honest.


### PR DESCRIPTION
## Summary
- Add `record-polluted-ip.py` as the shared atomic writer/checker for `edge-polluted-ips.json`.
- Wire `ops/lightsail/rotate-static-ip.sh` to retry allocations that hit the exclusion registry and auto-append the released old IP after swap.
- Backfill uk1 historical retired egress IPs (`16.61.87.51`, `18.135.59.111`) and sync docs/skill/spec delta.

## Risk
- Low: deploy/ops tooling only; no runtime gateway behavior change.
- Registry grows by two historical uk entries; EC2 and Lightsail allocators both consult the same `polluted[]` list per region.

## Validation
- `python3 deploy/aws/stage0/test_record_polluted_ip.py -v`
- `python3 deploy/aws/stage0/test_allocate_clean_egress_eip.py -v`
- `./scripts/edge-ip-status.sh --check`
- `./scripts/preflight.sh` (pre-commit)


Made with [Cursor](https://cursor.com)