### PR TITLE
fix(ops): OAuth check validates tiers table vs git, not stale per-account extra

### DIFF
--- a/.cursor/skills/tokenkey-anthropic-oauth-config/SKILL.md
+++ b/.cursor/skills/tokenkey-anthropic-oauth-config/SKILL.md
@@ -58,11 +58,23 @@ MGR=ops/anthropic/manage-anthropic-config.py
 # Stage 1 — Snapshot：拉所有 deployable edge 的 anthropic OAuth account + prod anthropic api-key stub 状态到 JSON
 python3 $MGR snapshot --out $JOBDIR/snap.json
 
-# Stage 2 — Check（联查）：每个 edge 跑 OAuth 稳定性 guard，只读出 tier baseline / TLS / 余额漂移
+# Stage 2 — Check（联查）：每个 edge 跑 OAuth 稳定性 guard，只读出 TLS / 余额 /
+#   tier 表（vs git）漂移
 python3 $MGR check --snapshot $JOBDIR/snap.json
-#   退出码：0 全绿 / 1 violation（含 tls_profile drift、operator_balance 低于门槛等）/ 2 error
-#   注意：check 只“报告”漂移。tier 数值漂移 → admin UI ApplyTier；并发/pool_mode/余额漂移
-#         → 后端 reconciler 自愈（§3）；只有 TLS 模板漂移与 HTTP UA 由本 skill 修。
+#   退出码：0 全绿 / 1 violation（含 tls_profile drift、operator_balance 低于门槛、
+#           tier_table_drift 等）/ 2 error
+#   注意：check 只“报告”漂移。修复入口分流：
+#     - tls_profile 漂移 → 本 skill Stage 3（plan-guard-drift-fix / remediate-guard-drift）
+#     - operator_balance / pool_mode / concurrency 漂移 → 后端 reconciler 自愈（§3）
+#     - tier_table_drift（live `tiers` 表 != git baseline）→ tier 行被 admin 后台改过
+#       （PUT /admin/tiers/:id），下次重启/发版会被 ensureSeededFromBaseline 回刷；
+#       要么撤销后台改动、要么把改动落进 git baseline JSON 再发版。
+#   ⚠️ check **不再** diff 账号持久化 extra 的 8 个 tier-managed 键（base_rpm /
+#      max_sessions / rpm_sticky_buffer / session_idle_timeout_minutes /
+#      window_cost_limit / window_cost_sticky_reserve / cache_ttl_override_*）：
+#      PR #472 后这些值在 `tiers` 表、运行时 overlay 到账号、写路径剥离，账号 extra
+#      为 null 是**正确态**。它们的正确性由 tier_table_drift（tier 表 vs git）保证，
+#      不再按账号比对（旧逻辑对每个账号每次都假报，已重构）。
 
 # Stage 3 — TLS 模板修复（仅当 check 报 /tls_profile/* 漂移或“启用 TLS 却无 profile”）
 #   3a) 从 check 报告生成 force-template-rewrite 多 action plan：
@@ -200,7 +212,9 @@ operate 流程：
 | `apply --confirm` 拒绝 | 必须精确 `yes-apply-anthropic-config-cascade` |
 | `tls_profile` drift（`/tls_profile/...` 或 UK 模式：启用 TLS 却无 profile） | 用 **`plan-guard-drift-fix`** 或 **`remediate-guard-drift`**（含 `apply --sync-runtime`）force-template-rewrite，不要手工拼 SQL |
 | check guard 报 `status: drift` 且 `diffs[].path` 含 `/credentials/temp_unschedulable_rules`，但数值字段全等 | guard-drift force-template-rewrite 会重写 credentials 端字段；apply 完跑一次 `check` 当真值 |
-| check 报 `extra_baseline_drift` / `account_field_drift`（tier 数值漂移） | **不**用本 skill 修——走 admin UI `ApplyTier` 重设该账号 tier（§3）；reconciler 只报告不重写 |
+| check guard 对账号 `extra.base_rpm` / `max_sessions` 等报 drift | **不应再发生**：PR #472 后这 8 个 tier-managed 键由 `tiers` 表 overlay、账号侧不持久化，guard 已停止比对它们（旧逻辑假报）。若仍看到，说明 guard 未更新——核对 `check-edge-oauth-stability.py` 的 `TIER_MANAGED_EXTRA_KEYS` 排除逻辑 |
+| check 报 `tier_table_drift`（live `tiers` 表 != git baseline，violation/exit 1） | tier 行被 admin 后台改过（`PUT /admin/tiers/:id`），全副本即时生效但下次重启/发版被 `ensureSeededFromBaseline` 回刷。看 `items[].warning` 定位 node/tier/字段；**撤销后台改动**（admin UI 改回），或若是有意调整就**把新值落进 git baseline JSON**（`deploy/aws/stage0/anthropic-oauth-stability-baselines-tiered.json` + 同步 embed/迁移，过 `check-tier-baseline-embed.py`）再发版固化 |
+| check 报账号 `account_field_drift`（非 tier-managed 字段，如 priority / concurrency） | concurrency 由 reconciler 自愈（§3）；其余账号级字段走 admin UI |
 | check 报 `operator_balance` 低于门槛 / pool_mode / concurrency 漂移 | 由后端 reconciler 自愈（§3）；若持续未自愈，查该节点 reconciler leader 锁 / slog 日志，不要手工 plan |
 | HTTP UA / mimicry 未生效 | `sync-runtime --target …`（或先 `plan-http-mimicry-sync` 核对 manifest）；确认 `anthropic-http-mimicry-baselines.json` 的 `cc_version` 已是目标版本 |
 | OAuth account `status=error/suspended` | OAuth 凭据问题（token 过期 / 403 / 上游禁用），见 OAuth 故障文档；不在本流水线范围 |

--- a/ops/anthropic/check-edge-oauth-stability.py
+++ b/ops/anthropic/check-edge-oauth-stability.py
@@ -15,6 +15,27 @@ DEFAULT_MATRIX = REPO_ROOT / "deploy/aws/stage0/edge-targets.json"
 DEFAULT_BASELINE = REPO_ROOT / "deploy/aws/stage0/anthropic-oauth-stability-baselines-tiered.json"
 CONFIRM_UPDATE = "yes-update-anthropic-stable-list"
 
+# Tier-managed extra keys: since PR #472's tier reference-table model these
+# strategy values live in the `tiers` table and are overlaid onto an account's
+# in-memory Extra at the load boundary (read path), and STRIPPED on the write
+# path (TierManagedExtraStripped) — so they are intentionally absent from a
+# tier-managed account's persisted `extra` JSONB. This guard therefore must NOT
+# diff them against the per-account baseline (doing so reported false "drift"
+# for every account whose extra was correctly stripped). The tier VALUES are
+# validated instead by manage-anthropic-config.py's tier_table_drift section
+# (live `tiers` table vs git baseline). Mirror of Go
+# model.TierManagedExtraKeys (backend/internal/model/tier.go); keep in lockstep.
+TIER_MANAGED_EXTRA_KEYS = frozenset({
+    "base_rpm",
+    "max_sessions",
+    "rpm_sticky_buffer",
+    "session_idle_timeout_minutes",
+    "window_cost_limit",
+    "window_cost_sticky_reserve",
+    "cache_ttl_override_enabled",
+    "cache_ttl_override_target",
+})
+
 _ROUTING_SPEC = importlib.util.spec_from_file_location(
     "tk_edge_routing_oauth_chk",
     REPO_ROOT / "ops/stage0/edge_routing_matrix.py",
@@ -561,7 +582,15 @@ def compare_live_to_baseline(live: dict[str, Any], baseline: dict[str, Any]) -> 
     diffs: list[dict[str, Any]] = []
     diffs.extend(diff_dict("account", base.get("account") or {}, live.get("account") or {}))
     diffs.extend(diff_dict("credentials", base.get("credentials") or {}, live.get("credentials") or {}))
-    diffs.extend(diff_dict("extra", base.get("extra") or {}, live.get("extra") or {}))
+    # Exclude tier-managed keys (base_rpm / max_sessions / ...): post-#472 they
+    # are tier-table + runtime-overlay managed and stripped from the persisted
+    # account.extra, so diffing them here is a guaranteed false positive. Their
+    # values are validated by manage-anthropic-config.py tier_table_drift.
+    account_extra_baseline = {
+        k: v for k, v in (base.get("extra") or {}).items()
+        if k not in TIER_MANAGED_EXTRA_KEYS
+    }
+    diffs.extend(diff_dict("extra", account_extra_baseline, live.get("extra") or {}))
     diffs.extend(diff_absent("extra", base.get("extra_absent") or [], live.get("extra") or {}))
     diffs.extend(diff_dict("tls_profile", base.get("tls_profile") or {}, live.get("tls_profile") or {}))
     return diffs

--- a/ops/anthropic/manage-anthropic-config.py
+++ b/ops/anthropic/manage-anthropic-config.py
@@ -767,8 +767,7 @@ SELECT COALESCE(jsonb_agg(jsonb_build_object(
   'cache_ttl_override_target', t.cache_ttl_override_target,
   'tls_profile_name', t.tls_profile_name
 ) ORDER BY t.name), '[]'::jsonb)
-FROM tiers t
-WHERE t.deleted_at IS NULL;
+FROM tiers t;
 """
 
 

--- a/ops/anthropic/manage-anthropic-config.py
+++ b/ops/anthropic/manage-anthropic-config.py
@@ -191,10 +191,24 @@ _EDGE_ROUTING = importlib.util.module_from_spec(ROUTING_SPEC)
 sys.modules.setdefault(ROUTING_SPEC.name, _EDGE_ROUTING)
 ROUTING_SPEC.loader.exec_module(_EDGE_ROUTING)
 
+# Reuse the embed sentinel's JSON->effective-tier-row mapping as the single
+# source for expected tier-table values. check-tier-baseline-embed.py already
+# guarantees this JSON == Go embed == tk_012 migration seed (preflight gate),
+# so "live tiers table vs effective_tiers_from_json(...)" == "live vs git".
+TIER_EMBED_SPEC = importlib.util.spec_from_file_location(
+    "tk_tier_baseline_embed",
+    REPO_ROOT / "scripts/sentinels/check-tier-baseline-embed.py",
+)
+if TIER_EMBED_SPEC is None or TIER_EMBED_SPEC.loader is None:
+    raise RuntimeError("cannot load scripts/sentinels/check-tier-baseline-embed.py")
+_TIER_EMBED = importlib.util.module_from_spec(TIER_EMBED_SPEC)
+sys.modules.setdefault(TIER_EMBED_SPEC.name, _TIER_EMBED)
+TIER_EMBED_SPEC.loader.exec_module(_TIER_EMBED)
+
 CONFIRM_CODE = "yes-apply-anthropic-config-cascade"
 
 PLAN_VERSION = 4
-SNAPSHOT_VERSION = 6
+SNAPSHOT_VERSION = 7
 
 # After each OAuth tier-baseline apply on an edge Postgres, bump the operator
 # (admin/default) user's row concurrency to match Σ anthropic account concurrency
@@ -731,6 +745,42 @@ WHERE g.platform = 'anthropic'
   AND g.deleted_at IS NULL;
 """
 
+# tiers reference table (PR #472): the single per-node source for tier strategy
+# values (base_rpm / max_sessions / ...). Seeded from the Go embed baseline on
+# startup (ensureSeededFromBaseline, git->DB), admin-editable via PUT
+# /api/v1/admin/tiers/:id. snapshot pulls it so the tier_table_drift check can
+# compare live rows vs the git baseline without re-querying. Column names mirror
+# the tiers table / check-tier-baseline-embed.effective_tiers_from_json.
+TIERS_SQL = """
+SELECT COALESCE(jsonb_agg(jsonb_build_object(
+  'name', t.name,
+  'concurrency', t.concurrency,
+  'priority', t.priority,
+  'rate_multiplier', t.rate_multiplier,
+  'base_rpm', t.base_rpm,
+  'max_sessions', t.max_sessions,
+  'rpm_sticky_buffer', t.rpm_sticky_buffer,
+  'session_idle_timeout_minutes', t.session_idle_timeout_minutes,
+  'window_cost_limit', t.window_cost_limit,
+  'window_cost_sticky_reserve', t.window_cost_sticky_reserve,
+  'cache_ttl_override_enabled', t.cache_ttl_override_enabled,
+  'cache_ttl_override_target', t.cache_ttl_override_target,
+  'tls_profile_name', t.tls_profile_name
+) ORDER BY t.name), '[]'::jsonb)
+FROM tiers t
+WHERE t.deleted_at IS NULL;
+"""
+
+
+def _read_tiers(region: str, instance_id: str, label: str) -> list[dict]:
+    """Pull the live `tiers` reference-table rows for one node (edge or prod)."""
+    raw, _ = ssm_run_sql(region, instance_id, TIERS_SQL, f"snapshot: {label} tiers table")
+    try:
+        return json.loads(raw) if raw else []
+    except json.JSONDecodeError:
+        return []
+
+
 OPERATOR_CONCURRENCY_SQL = f"""
 SELECT jsonb_build_object(
   'operator_user_concurrency',
@@ -840,6 +890,7 @@ def cmd_snapshot(args: argparse.Namespace) -> int:
         )
         op = _read_operator_concurrency(ident.region, ident.instance_id, f"edge {eid}")
         bal = _read_operator_balance(ident.region, ident.instance_id, f"edge {eid}")
+        tiers = _read_tiers(ident.region, ident.instance_id, f"edge {eid}")
         edges[eid] = {
             "deployable": True,
             "instance_id": ident.instance_id,
@@ -849,6 +900,7 @@ def cmd_snapshot(args: argparse.Namespace) -> int:
             "ssm_routing": ident.routing,
             "oauth_accounts": json.loads(accts_raw) if accts_raw else [],
             "anthropic_groups": json.loads(groups_raw) if groups_raw else [],
+            "tiers": tiers,
             "operator_user_concurrency": op["operator_user_concurrency"],
             "schedulable_concurrency_sum": op["schedulable_concurrency_sum"],
             "operator_user_balance": bal["operator_user_balance"],
@@ -869,6 +921,7 @@ def cmd_snapshot(args: argparse.Namespace) -> int:
                 "snapshot: prod anthropic groups",
             )
             prod_op = _read_operator_concurrency(PROD_TARGET["region"], prod_inst, "prod")
+            prod_tiers = _read_tiers(PROD_TARGET["region"], prod_inst, "prod")
             prod_view = {
                 "instance_id": prod_inst,
                 "region": PROD_TARGET["region"],
@@ -876,6 +929,7 @@ def cmd_snapshot(args: argparse.Namespace) -> int:
                 "domain": PROD_TARGET["domain"],
                 "anthropic_stubs": json.loads(stubs_raw) if stubs_raw else [],
                 "anthropic_groups": json.loads(groups_raw) if groups_raw else [],
+                "tiers": prod_tiers,
                 "operator_user_concurrency": prod_op["operator_user_concurrency"],
                 "schedulable_concurrency_sum": prod_op["schedulable_concurrency_sum"],
             }
@@ -1012,6 +1066,113 @@ def _run_balance_checks_live(edge_ids: list[str], policy: dict) -> list[dict]:
     return out
 
 
+# --------------------------------------------------------------------------
+# tier_table_drift: live `tiers` reference table vs git baseline
+# --------------------------------------------------------------------------
+# Post-#472 the per-tier strategy values (base_rpm / max_sessions / ...) live in
+# the per-node `tiers` table, seeded from the Go embed baseline on startup and
+# overlaid onto accounts at read time. The table is admin-editable
+# (PUT /api/v1/admin/tiers/:id), and such edits go live fleet-wide via pub/sub
+# but are silently reverted on the next restart/deploy by ensureSeededFromBaseline.
+# This surface REVEALS such backend edits (live tier row != git) and WARNS that a
+# deploy will revert them. We compare exactly the keys OverlayExtra writes
+# (_GUARD.TIER_MANAGED_EXTRA_KEYS) — the runtime-authoritative tier strategy —
+# against effective_tiers_from_json (the same JSON the embed sentinel pins to the
+# Go embed + tk_012 migration seed, so expected == git).
+
+TIER_TABLE_COMPARE_KEYS = sorted(_GUARD.TIER_MANAGED_EXTRA_KEYS)
+
+
+def _tier_val_eq(expected: Any, actual: Any) -> bool:
+    """Numeric-aware equality (28 == 28.0); exact otherwise (bools/strings)."""
+    if isinstance(expected, bool) or isinstance(actual, bool):
+        return expected == actual
+    try:
+        return float(expected) == float(actual)
+    except (TypeError, ValueError):
+        return expected == actual
+
+
+def _load_expected_tiers() -> dict[str, dict]:
+    """Effective per-tier rows from the git baseline JSON (single source, anchored
+    to Go embed + migration by scripts/sentinels/check-tier-baseline-embed.py)."""
+    doc = load_json_file(TIER_BASELINES, "tier baseline")
+    return _TIER_EMBED.effective_tiers_from_json(doc)
+
+
+def _tier_table_drift_items(node_label: str, live_tiers: list[dict] | None,
+                            expected_by_tier: dict[str, dict]) -> list[dict]:
+    """Diff one node's live tiers rows vs the git baseline. Returns drift/missing/
+    extra items, each carrying a human warning. Empty list == node matches git."""
+    items: list[dict] = []
+    live_by_name = {t.get("name"): t for t in (live_tiers or []) if isinstance(t, dict)}
+    for tier_name, exp in sorted(expected_by_tier.items()):
+        live = live_by_name.get(tier_name)
+        if live is None:
+            items.append({
+                "node": node_label, "tier": tier_name, "status": "missing",
+                "warning": (f"tier {tier_name} on {node_label} is missing from the live "
+                            f"tiers table; the git baseline defines it — a fresh seed "
+                            f"(restart/deploy) will recreate it"),
+            })
+            continue
+        diffs = [
+            {"path": f"/{k}", "expected": exp.get(k), "actual": live.get(k)}
+            for k in TIER_TABLE_COMPARE_KEYS
+            if not _tier_val_eq(exp.get(k), live.get(k))
+        ]
+        if diffs:
+            summary = ", ".join(f"{d['path'].lstrip('/')} {d['expected']}->{d['actual']}" for d in diffs)
+            items.append({
+                "node": node_label, "tier": tier_name, "status": "drift", "diffs": diffs,
+                "warning": (f"tier {tier_name} on {node_label} modified via backend admin "
+                            f"({summary}); diverges from git single-source; will be reverted "
+                            f"on next restart/deploy (ensureSeededFromBaseline)"),
+            })
+    for tier_name in sorted(set(live_by_name) - set(expected_by_tier)):
+        items.append({
+            "node": node_label, "tier": tier_name, "status": "extra",
+            "warning": (f"tier {tier_name} on {node_label} exists in the live tiers table "
+                        f"but not in git baseline; created via backend admin; it will not "
+                        f"survive a fresh seed"),
+        })
+    return items
+
+
+def _tier_table_drift_from_snapshot(snap: dict, expected_by_tier: dict[str, dict]) -> list[dict]:
+    items: list[dict] = []
+    for edge_id, edge in sorted(snap.get("edges", {}).items()):
+        if edge.get("error") or edge.get("skipped_reason") or not edge.get("deployable"):
+            continue
+        items.extend(_tier_table_drift_items(f"edge:{edge_id}", edge.get("tiers"), expected_by_tier))
+    prod = snap.get("prod") or {}
+    if not prod.get("error") and not prod.get("skipped_reason"):
+        items.extend(_tier_table_drift_items("prod", prod.get("tiers"), expected_by_tier))
+    return items
+
+
+def _run_tier_table_checks_live(edge_ids: list[str], expected_by_tier: dict[str, dict]) -> list[dict]:
+    """Live SSM tiers-table read per node (used when check runs without a snapshot)."""
+    items: list[dict] = []
+    for eid in edge_ids:
+        try:
+            ident = _EDGE_SSM.resolve_edge_execution_identity(REPO_ROOT, eid)
+        except SystemExit:
+            items.append({"node": f"edge:{eid}", "tier": "*", "status": "error",
+                          "warning": f"could not resolve SSM instance for edge {eid}"})
+            continue
+        live = _read_tiers(ident.region, ident.instance_id, f"edge {eid}")
+        items.extend(_tier_table_drift_items(f"edge:{eid}", live, expected_by_tier))
+    try:
+        prod_inst = resolve_instance_id(PROD_TARGET["region"], PROD_TARGET["stack"])
+        prod_live = _read_tiers(PROD_TARGET["region"], prod_inst, "prod")
+        items.extend(_tier_table_drift_items("prod", prod_live, expected_by_tier))
+    except SystemExit:
+        items.append({"node": "prod", "tier": "*", "status": "error",
+                      "warning": "could not resolve SSM instance for prod"})
+    return items
+
+
 def cmd_check(args: argparse.Namespace) -> int:
     snapshot = load_json_file(pathlib.Path(args.snapshot), "snapshot") if args.snapshot else None
     edge_ids = _edge_ids_for_check(snapshot, bool(args.allow_planned))
@@ -1034,13 +1195,30 @@ def cmd_check(args: argparse.Namespace) -> int:
         "error_count": sum(1 for x in balance_items if x.get("status") == "error"),
         "items": balance_items,
     }
-    report["any_violation"] = bool(report.get("any_violation")) or balance_violation or balance_error
+    # tier_table_drift: live tiers table vs git baseline (reveal backend edits)
+    expected_tiers = _load_expected_tiers()
+    if snapshot is not None:
+        tier_items = _tier_table_drift_from_snapshot(snapshot, expected_tiers)
+    else:
+        tier_items = _run_tier_table_checks_live(edge_ids, expected_tiers)
+    tier_table_violation = any(x.get("status") in ("drift", "missing", "extra", "error") for x in tier_items)
+    report["tier_table_drift"] = {
+        "policy_source": TIER_BASELINES.name,
+        "compare_keys": TIER_TABLE_COMPARE_KEYS,
+        "violation_count": sum(1 for x in tier_items if x.get("status") in ("drift", "missing", "extra")),
+        "error_count": sum(1 for x in tier_items if x.get("status") == "error"),
+        "items": tier_items,
+    }
+    report["any_violation"] = (
+        bool(report.get("any_violation")) or balance_violation or balance_error or tier_table_violation
+    )
     if args.json:
         print(json.dumps(report, indent=2, ensure_ascii=False))
     else:
         any_violation = report.get("any_violation")
         print(f"check: any_violation={any_violation} guards_run={len(report.get('guards', []))} "
-              f"edges={edge_ids} balance_violations={report['operator_balance']['violation_count']}")
+              f"edges={edge_ids} balance_violations={report['operator_balance']['violation_count']} "
+              f"tier_table_drift={report['tier_table_drift']['violation_count']}")
         for sr in report.get("guards", []):
             ec = sr.get("exit_code")
             status = "OK" if ec == 0 else (sr.get("skipped_reason", "?") if ec is None else f"FAIL exit={ec}")
@@ -1052,6 +1230,8 @@ def cmd_check(args: argparse.Namespace) -> int:
                       f"< threshold={policy['min_balance_threshold']}")
             elif st == "error":
                 print(f"  [BALANCE-ERR] edge={item['edge_id']}: {item.get('reason')}")
+        for item in tier_items:
+            print(f"  [TIER-{item.get('status', '?').upper()}] {item.get('warning')}")
     return 1 if report.get("any_violation") else 0
 
 
@@ -1279,7 +1459,9 @@ def _load_snapshot_or_die(path: str) -> dict:
              f"v4 added per-target operator_user_concurrency + schedulable_concurrency_sum "
              f"for the concurrency-mirror surface; "
              f"v5 added per-target anthropic_groups for group claude-code-only surface; "
-             f"v6 added per-edge operator_user_balance + operator_user_exists for surface E)")
+             f"v6 added per-edge operator_user_balance + operator_user_exists for surface E; "
+             f"v7 added per-node tiers table rows for the tier_table_drift surface "
+             f"(live tiers vs git baseline; post-#472 tier reference-table model))")
     return snap
 
 

--- a/ops/anthropic/test_check_edge_oauth_stability_tier_managed.py
+++ b/ops/anthropic/test_check_edge_oauth_stability_tier_managed.py
@@ -1,0 +1,75 @@
+#!/usr/bin/env python3
+"""Unit tests for check-edge-oauth-stability.py tier-managed extra handling.
+
+Post-PR #472 the 8 TierManagedExtraKeys (base_rpm / max_sessions / ...) are
+overlaid from the `tiers` table at read time and stripped from the persisted
+account.extra on write. The guard must NOT diff them against the per-account
+baseline (doing so was a guaranteed false positive). Non-tier-managed extra,
+account, credentials and tls_profile diffs must still work; a missing/unknown
+stability_tier must still fail.
+"""
+from __future__ import annotations
+
+import importlib.util
+import pathlib
+import unittest
+
+_MOD_PATH = pathlib.Path(__file__).resolve().parent / "check-edge-oauth-stability.py"
+_spec = importlib.util.spec_from_file_location("check_edge_oauth_stability_guard", _MOD_PATH)
+guard = importlib.util.module_from_spec(_spec)
+assert _spec and _spec.loader
+_spec.loader.exec_module(guard)
+
+
+def _baseline(extra: dict, *, extra_absent=None) -> dict:
+    return {"baseline": {
+        "account": {},
+        "credentials": {},
+        "extra": extra,
+        "extra_absent": extra_absent or [],
+        "tls_profile": {},
+    }}
+
+
+def _live(extra: dict) -> dict:
+    return {"found": True, "account": {}, "credentials": {}, "extra": extra, "tls_profile": {}}
+
+
+class TierManagedExtraTest(unittest.TestCase):
+    def test_tier_managed_keys_are_not_diffed(self) -> None:
+        # baseline says base_rpm=56/max_sessions=120; live extra has them stripped
+        # (the correct post-#472 state) AND a stale leftover value.
+        baseline = _baseline({"base_rpm": 56, "max_sessions": 120})
+        diffs = guard.compare_live_to_baseline(_live({}), baseline)
+        self.assertEqual(diffs, [], "tier-managed keys must not produce drift when absent")
+
+        diffs2 = guard.compare_live_to_baseline(_live({"base_rpm": 14}), baseline)
+        self.assertEqual(diffs2, [], "stale persisted tier-managed value must not produce drift")
+
+    def test_non_tier_managed_extra_still_diffs(self) -> None:
+        baseline = _baseline({"base_rpm": 56, "enable_tls_fingerprint": True})
+        diffs = guard.compare_live_to_baseline(_live({"enable_tls_fingerprint": False}), baseline)
+        paths = [d["path"] for d in diffs]
+        self.assertIn("/extra/enable_tls_fingerprint", paths)
+        self.assertNotIn("/extra/base_rpm", paths)
+
+    def test_all_eight_tier_managed_keys_covered(self) -> None:
+        # Mirror of Go model.TierManagedExtraKeys — guard must exclude exactly these.
+        self.assertEqual(guard.TIER_MANAGED_EXTRA_KEYS, frozenset({
+            "base_rpm", "max_sessions", "rpm_sticky_buffer",
+            "session_idle_timeout_minutes", "window_cost_limit",
+            "window_cost_sticky_reserve", "cache_ttl_override_enabled",
+            "cache_ttl_override_target",
+        }))
+        baseline = _baseline({k: 1 for k in guard.TIER_MANAGED_EXTRA_KEYS})
+        self.assertEqual(guard.compare_live_to_baseline(_live({}), baseline), [])
+
+    def test_missing_account_still_flagged(self) -> None:
+        diffs = guard.compare_live_to_baseline({"found": False}, _baseline({"base_rpm": 56}))
+        self.assertEqual(diffs, [{"path": "/account",
+                                  "expected": "existing anthropic oauth account",
+                                  "actual": None}])
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/ops/anthropic/test_manage_anthropic_config_tier_table_drift.py
+++ b/ops/anthropic/test_manage_anthropic_config_tier_table_drift.py
@@ -1,0 +1,103 @@
+#!/usr/bin/env python3
+"""Unit tests for the tier_table_drift surface of manage-anthropic-config.py.
+
+Post-PR #472 the per-tier strategy values live in the `tiers` reference table
+(seeded from git embed baseline, admin-editable, reverted on restart). The check
+reveals & warns when a live tiers row diverges from the git baseline — it must
+NOT diff the per-account `extra` (that is overlay-only since #472).
+"""
+from __future__ import annotations
+
+import importlib.util
+import pathlib
+import unittest
+
+_MOD_PATH = pathlib.Path(__file__).resolve().parent / "manage-anthropic-config.py"
+_spec = importlib.util.spec_from_file_location("manage_anthropic_config_tier_drift", _MOD_PATH)
+mgr = importlib.util.module_from_spec(_spec)
+assert _spec and _spec.loader
+_spec.loader.exec_module(mgr)
+
+
+def _row_for(expected_tier: dict, **overrides) -> dict:
+    """Build a live tiers-table row matching the git-effective tier, with overrides."""
+    row = {"name": expected_tier["name"]}
+    for k in mgr.TIER_TABLE_COMPARE_KEYS:
+        row[k] = expected_tier[k]
+    row.update(overrides)
+    return row
+
+
+class TierTableDriftTest(unittest.TestCase):
+    def setUp(self) -> None:
+        # Real git baseline → effective per-tier rows (single source, anchored to
+        # Go embed + tk_012 by check-tier-baseline-embed.py).
+        self.expected = mgr._load_expected_tiers()
+        self.assertIn("l4", self.expected)
+
+    def test_clean_node_no_drift(self) -> None:
+        live = [_row_for(self.expected[t]) for t in self.expected]
+        items = mgr._tier_table_drift_items("edge:uk1", live, self.expected)
+        self.assertEqual(items, [])
+
+    def test_backend_edit_is_revealed_with_warning(self) -> None:
+        live = [_row_for(self.expected[t]) for t in self.expected]
+        # Simulate an admin backend edit to l4.base_rpm.
+        for r in live:
+            if r["name"] == "l4":
+                r["base_rpm"] = 999
+        items = mgr._tier_table_drift_items("edge:uk1", live, self.expected)
+        self.assertEqual(len(items), 1)
+        it = items[0]
+        self.assertEqual(it["tier"], "l4")
+        self.assertEqual(it["status"], "drift")
+        self.assertEqual(it["diffs"], [{"path": "/base_rpm",
+                                        "expected": self.expected["l4"]["base_rpm"],
+                                        "actual": 999}])
+        self.assertIn("modified via backend admin", it["warning"])
+        self.assertIn("will be reverted", it["warning"])
+
+    def test_missing_tier_row(self) -> None:
+        live = [_row_for(self.expected[t]) for t in self.expected if t != "l2"]
+        items = mgr._tier_table_drift_items("prod", live, self.expected)
+        self.assertEqual([i["tier"] for i in items], ["l2"])
+        self.assertEqual(items[0]["status"], "missing")
+
+    def test_extra_tier_row(self) -> None:
+        live = [_row_for(self.expected[t]) for t in self.expected]
+        live.append({"name": "l9", **{k: 1 for k in mgr.TIER_TABLE_COMPARE_KEYS}})
+        items = mgr._tier_table_drift_items("edge:us1", live, self.expected)
+        self.assertEqual([i["status"] for i in items], ["extra"])
+        self.assertEqual(items[0]["tier"], "l9")
+
+    def test_numeric_equality_tolerates_float(self) -> None:
+        live = [_row_for(self.expected[t]) for t in self.expected]
+        for r in live:
+            if r["name"] == "l4":
+                r["base_rpm"] = float(self.expected["l4"]["base_rpm"])  # 56 -> 56.0
+        items = mgr._tier_table_drift_items("edge:uk1", live, self.expected)
+        self.assertEqual(items, [])
+
+    def test_snapshot_aggregation_skips_planned_and_errored(self) -> None:
+        clean = [_row_for(self.expected[t]) for t in self.expected]
+        drifted = [_row_for(self.expected[t]) for t in self.expected]
+        for r in drifted:
+            if r["name"] == "l5":
+                r["max_sessions"] = 7
+        snap = {
+            "edges": {
+                "uk1": {"deployable": True, "tiers": clean},
+                "us1": {"deployable": True, "tiers": drifted},
+                "us9": {"deployable": False, "skipped_reason": "planned"},
+                "usX": {"error": "no instance"},
+            },
+            "prod": {"tiers": clean},
+        }
+        items = mgr._tier_table_drift_from_snapshot(snap, self.expected)
+        nodes = sorted({i["node"] for i in items})
+        self.assertEqual(nodes, ["edge:us1"])  # only the drifted deployable node
+        self.assertEqual(items[0]["tier"], "l5")
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## 背景：#472 后 check 必假报

PR #472（tier reference-table 模型）把 8 个 tier 策略值（base_rpm / max_sessions /
rpm_sticky_buffer / session_idle_timeout_minutes / window_cost_limit /
window_cost_sticky_reserve / cache_ttl_override_*）从**每账号 `extra`** 迁到 **`tiers` 表**：
读路径 overlay 到账号、**写路径 `TierManagedExtraStripped` 剥离** → 账号持久化 `extra`
**本就不含**这些键（`extra=null` 是正确态）。

但 `check-edge-oauth-stability.py` 仍 diff 持久化 `account.extra.*` vs baseline →
**对每个 tier-managed 账号每次发版假报 8 项漂移**（v1.7.55 发版后 check all 报的 26 项
`/extra/*` 漂移全是误报；线上 overlay 正常）。

## 改动（用户决策 = B + 揭示/警告）

- **guard** (`check-edge-oauth-stability.py`)：新增 `TIER_MANAGED_EXTRA_KEYS`（镜像 Go
  `model.TierManagedExtraKeys`），从 per-account extra diff 中**排除**这 8 键。账号侧仍校验
  `stability_tier` 指向有效 tier + diff 非 tier-managed extra / credentials / tls_profile。
- **orchestrator** (`manage-anthropic-config.py`)：snapshot 捕获每节点 `tiers` 表
  （`SNAPSHOT_VERSION` 6→7）；check 新增 **`tier_table_drift`** 段，比对 **live `tiers` 表 vs
  git baseline**（复用 embed sentinel 的 `effective_tiers_from_json` —— 同一份被 preflight
  钉死 == Go embed == `tk_012` seed 的 JSON）。tier 行被 admin 后台改过（`PUT /admin/tiers/:id`）
  报 **violation（exit 1 / yellow）** + 警告「will be reverted on next restart/deploy」。
- **测试**：`test_check_edge_oauth_stability_tier_managed.py`（8 键排除 / 非 tier-managed 仍 diff /
  缺账号仍 fail）+ `test_manage_anthropic_config_tier_table_drift.py`（clean/drift/missing/extra /
  数值容差 / snapshot 聚合跳过 planned·errored 节点）。
- **文档**：SKILL.md check 段 + 故障速查；memory 更新为 #472 模型。

## 不做
- 不动 Go / backend（tier 模型本身正确，只是工具脚本陈旧）。
- baseline JSON 值不变（仍是 tiers 表的源；embed sentinel 继续守 JSON==embed==迁移）。
  未加 JSON 注释——加 key 只到 deploy 一侧会破坏 embed sentinel 的语义等价；语义记在代码注释 + SKILL + memory。

## 验证
- 81 个 ops/anthropic 单测全过（含两个新测试）
- `scripts/preflight.sh` 全 PASS（embed/tier baseline single-source、ops/anthropic unittest 等）
- 本地 smoke：clean 节点 0 drift；篡改 l4.base_rpm→drift+warning；guard 对 `extra.base_rpm=null` 不再报

## 合并方式
TK fix PR → **Squash and merge**（§5.y）。纯 ops 工具改动，无需发版即生效于下次 check 运行。

🤖 Generated with [Claude Code](https://claude.com/claude-code)