### PR TITLE
fix(frontend): allow esbuild/vue-demi build scripts via pnpm onlyBuiltDependencies

### DIFF
--- a/backend/internal/web/dist/frontend-source.json
+++ b/backend/internal/web/dist/frontend-source.json
@@ -1,7 +1,7 @@
 {
   "algorithm": "sha256(git-ls-files:path,size,content)",
   "file_count": 446,
-  "hash": "d37812905a9031c038e36fd141c1e80c8d5b88a88032dd105c093bd885ea7c20",
+  "hash": "5de27cf1ccdef83dd23d3276af735b93c1c1fe8d955b9145f7f2174ed24094f2",
   "schema": 1,
   "source": "frontend/"
 }

--- a/frontend/.npmrc
+++ b/frontend/.npmrc
@@ -1,4 +1,6 @@
 legacy-peer-deps=true
-# 允许运行所有包的构建脚本
-# esbuild 和 vue-demi 是已知安全的包，需要 postinstall 脚本才能正常工作
+# ignore-scripts=false 只是 pnpm 默认值（允许本项目自身的生命周期脚本）。
+# pnpm 10+ 默认不跑「依赖」的 build script，需要在 package.json 的
+# pnpm.onlyBuiltDependencies 里显式 allow-list（见 esbuild / vue-demi）。
+# 否则 pnpm@latest(11+) 全新安装会 ERR_PNPM_IGNORED_BUILDS，Docker 前端构建失败。
 ignore-scripts=false

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -61,6 +61,10 @@
   "pnpm": {
     "overrides": {
       "js-cookie": "3.0.7"
-    }
+    },
+    "onlyBuiltDependencies": [
+      "esbuild",
+      "vue-demi"
+    ]
   }
 }


### PR DESCRIPTION
## What

Add `pnpm.onlyBuiltDependencies = [esbuild, vue-demi]` to `frontend/package.json` so a fresh `pnpm install` runs those two dependency build scripts.

## Why (root cause)

pnpm 10+ no longer runs **dependency** build scripts by default (security default). The existing `frontend/.npmrc` line `ignore-scripts=false` only governs **this project's own** lifecycle scripts — not the dependency allow-list — so it never fixed this. The misleading comment is corrected in this PR.

The Dockerfile pins `corepack prepare pnpm@latest` (currently 11.x), where ignored dep builds are a **hard error** `ERR_PNPM_IGNORED_BUILDS`, failing the frontend build stage. Locally it's only a warning on pnpm 10.x + cached `node_modules`, which is why it stayed hidden.

Pre-existing infra issue — **reproduced on `main`**, independent of any feature branch. It was surfaced while trying to build a Stage0 image for unrelated feature validation.

## Verification

Isolated fresh install (clean store) with the fix:
- ✅ No `Ignored build scripts` warning (was: `esbuild@0.21.5, vue-demi@0.14.10`)
- ✅ esbuild native binary builds & runs: `@esbuild/darwin-arm64/.../bin/esbuild --version` → `0.21.5`
- ✅ `pnpm-lock.yaml` unchanged → CI/Docker `--frozen-lockfile` still holds
- ✅ `scripts/preflight.sh` PASS

## Notes

- `backend/internal/web/dist/frontend-source.json` manifest hash refreshed for the new `package.json`/`.npmrc` input hash; **no built artifact changes** (install-time config only).
- Upstream-shaped touch is trivial build config (`upstream-touch-trivial`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
