### PR TITLE
fix(gateway): keep thinking blocks for tool-use turns on signature_error retry

### DIFF
--- a/backend/internal/service/gateway_request.go
+++ b/backend/internal/service/gateway_request.go
@@ -522,8 +522,20 @@ func FilterThinkingBlocksForRetry(body []byte) []byte {
 
 	modified := false
 
-	// Disable top-level thinking mode for retry to avoid structural/signature constraints upstream.
-	deleteTopLevelThinking := gjson.Get(jsonStr, "thinking").Exists()
+	// Anthropic tool-use contract: during a tool-use loop you MUST send the thinking
+	// blocks back, unchanged with their signature, for any assistant message that
+	// contains tool_use ("the thinking blocks capture Claude's step-by-step reasoning
+	// that led to tool requests"). Stripping them orphans the tool_use, which breaks
+	// interleaved-thinking clients (Claude Code reports the tool call as malformed) and
+	// can itself trigger upstream 400s. So we only strip thinking from assistant turns
+	// WITHOUT tool_use (earlier pure-reasoning turns, which the API allows omitting),
+	// and we keep top-level thinking enabled whenever any tool-coupled thinking block is
+	// preserved (deleting it while thinking blocks remain is a mid-turn toggle conflict).
+	// The genuinely-unrecoverable case (a bad signature on a tool-coupled thinking block)
+	// is handled by the contract-complete FilterSignatureSensitiveBlocksForRetry, which
+	// downgrades thinking AND its dependent tool blocks together.
+	topLevelThinkingExists := gjson.Get(jsonStr, "thinking").Exists()
+	anyThinkingPreserved := false
 
 	for i := 0; i < len(messages); i++ {
 		msgMap, ok := messages[i].(map[string]any)
@@ -536,6 +548,20 @@ func FilterThinkingBlocksForRetry(body []byte) []byte {
 		if !ok {
 			// String content or other format - keep as is
 			continue
+		}
+
+		// Detect tool_use in this assistant message; if present, its thinking blocks
+		// must be preserved verbatim (signature included) per the contract above.
+		msgHasToolUse := false
+		if role == "assistant" {
+			for _, b := range content {
+				if bm, ok := b.(map[string]any); ok {
+					if t, _ := bm["type"].(string); t == "tool_use" {
+						msgHasToolUse = true
+						break
+					}
+				}
+			}
 		}
 
 		// 延迟分配：只有检测到需要修改的块，才构建新 slice。
@@ -575,24 +601,38 @@ func FilterThinkingBlocksForRetry(body []byte) []byte {
 			}
 
 			// Convert thinking blocks to text (preserve content) and drop redacted_thinking.
+			// EXCEPT when the assistant message also contains tool_use: there the thinking
+			// blocks are contractually required and must pass through verbatim (signature kept).
 			switch blockType {
-			case "thinking":
-				modifiedThisMsg = true
-				ensureNewContent(bi)
-				thinkingText, _ := blockMap["thinking"].(string)
-				if thinkingText != "" {
-					newContent = append(newContent, map[string]any{"type": "text", "text": thinkingText})
+			case "thinking", "redacted_thinking":
+				if msgHasToolUse {
+					anyThinkingPreserved = true
+					if newContent != nil {
+						newContent = append(newContent, block)
+					}
+					continue
 				}
-				continue
-			case "redacted_thinking":
 				modifiedThisMsg = true
 				ensureNewContent(bi)
+				if blockType == "thinking" {
+					thinkingText, _ := blockMap["thinking"].(string)
+					if thinkingText != "" {
+						newContent = append(newContent, map[string]any{"type": "text", "text": thinkingText})
+					}
+				}
 				continue
 			}
 
 			// Handle blocks without type discriminator but with a "thinking" field.
 			if blockType == "" {
 				if rawThinking, hasThinking := blockMap["thinking"]; hasThinking {
+					if msgHasToolUse {
+						anyThinkingPreserved = true
+						if newContent != nil {
+							newContent = append(newContent, block)
+						}
+						continue
+					}
 					modifiedThisMsg = true
 					ensureNewContent(bi)
 					switch v := rawThinking.(type) {
@@ -659,6 +699,11 @@ func FilterThinkingBlocksForRetry(body []byte) []byte {
 			msgMap["content"] = newContent
 		}
 	}
+
+	// Only disable top-level thinking when we did NOT preserve any tool-coupled thinking
+	// block. Deleting it while signed thinking blocks remain in the body is a mid-turn
+	// thinking toggle that the API rejects ("thinking blocks present but thinking off").
+	deleteTopLevelThinking := topLevelThinkingExists && !anyThinkingPreserved
 
 	if !modified && !deleteTopLevelThinking {
 		// Avoid rewriting JSON when no changes are needed.

--- a/backend/internal/service/gateway_request_thinking_tooluse_test.go
+++ b/backend/internal/service/gateway_request_thinking_tooluse_test.go
@@ -1,0 +1,198 @@
+//go:build unit
+
+package service
+
+import (
+	"encoding/json"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+)
+
+// These tests pin the Anthropic tool-use contract: during a tool-use loop the
+// thinking blocks of an assistant message that contains tool_use MUST be passed
+// back unchanged (signature included). Stripping them orphans the tool_use and
+// makes interleaved-thinking clients (Claude Code) report malformed tool calls.
+// See FilterThinkingBlocksForRetry.
+
+// Helpers ------------------------------------------------------------------
+
+func parseReq(t *testing.T, b []byte) map[string]any {
+	t.Helper()
+	var req map[string]any
+	require.NoError(t, json.Unmarshal(b, &req))
+	return req
+}
+
+func assistantContent(t *testing.T, req map[string]any, idx int) []any {
+	t.Helper()
+	msgs, ok := req["messages"].([]any)
+	require.True(t, ok)
+	require.Greater(t, len(msgs), idx)
+	m, ok := msgs[idx].(map[string]any)
+	require.True(t, ok)
+	c, ok := m["content"].([]any)
+	require.True(t, ok)
+	return c
+}
+
+func countBlockType(content []any, typ string) int {
+	n := 0
+	for _, b := range content {
+		if bm, ok := b.(map[string]any); ok {
+			if t, _ := bm["type"].(string); t == typ {
+				n++
+			}
+		}
+	}
+	return n
+}
+
+// Tests --------------------------------------------------------------------
+
+// The live-captured bug: an assistant turn with signed thinking + tool_use must
+// NOT be stripped, and top-level thinking must stay enabled.
+func TestFilterThinkingBlocksForRetry_PreservesThinkingInToolUseTurn(t *testing.T) {
+	input := []byte(`{
+		"model":"claude-opus-4-1",
+		"thinking":{"type":"enabled","budget_tokens":1024},
+		"messages":[
+			{"role":"user","content":[{"type":"text","text":"List files then read one"}]},
+			{"role":"assistant","content":[
+				{"type":"thinking","thinking":"I should call the tool","signature":"EuAGCmMIDh_realsig"},
+				{"type":"tool_use","id":"toolu_1","name":"Bash","input":{"command":"ls"}}
+			]},
+			{"role":"user","content":[{"type":"tool_result","tool_use_id":"toolu_1","content":"a.txt"}]}
+		]
+	}`)
+
+	out := FilterThinkingBlocksForRetry(input)
+	req := parseReq(t, out)
+
+	// top-level thinking must remain enabled (a preserved thinking block requires it).
+	_, hasThinking := req["thinking"]
+	require.True(t, hasThinking, "top-level thinking must be kept when tool-coupled thinking is preserved")
+
+	content := assistantContent(t, req, 1)
+	require.Equal(t, 1, countBlockType(content, "thinking"), "thinking block must be preserved, not converted to text")
+	require.Equal(t, 1, countBlockType(content, "tool_use"), "tool_use must remain")
+
+	// signature must pass through verbatim.
+	thinkingBlock := content[0].(map[string]any)
+	require.Equal(t, "thinking", thinkingBlock["type"])
+	require.Equal(t, "EuAGCmMIDh_realsig", thinkingBlock["signature"])
+}
+
+// redacted_thinking in a tool-use turn must also be preserved.
+func TestFilterThinkingBlocksForRetry_PreservesRedactedThinkingInToolUseTurn(t *testing.T) {
+	input := []byte(`{
+		"model":"claude-opus-4-1",
+		"thinking":{"type":"enabled","budget_tokens":1024},
+		"messages":[
+			{"role":"assistant","content":[
+				{"type":"redacted_thinking","data":"encrypted-blob"},
+				{"type":"tool_use","id":"toolu_2","name":"Read","input":{"path":"a.txt"}}
+			]}
+		]
+	}`)
+
+	out := FilterThinkingBlocksForRetry(input)
+	req := parseReq(t, out)
+
+	_, hasThinking := req["thinking"]
+	require.True(t, hasThinking)
+	content := assistantContent(t, req, 0)
+	require.Equal(t, 1, countBlockType(content, "redacted_thinking"), "redacted_thinking must be preserved in a tool-use turn")
+	require.Equal(t, 1, countBlockType(content, "tool_use"))
+}
+
+// Pure-reasoning assistant turn (NO tool_use) keeps the existing behavior:
+// thinking is downgraded to text and top-level thinking is disabled.
+func TestFilterThinkingBlocksForRetry_StripsThinkingWhenNoToolUse(t *testing.T) {
+	input := []byte(`{
+		"model":"claude-opus-4-1",
+		"thinking":{"type":"enabled","budget_tokens":1024},
+		"messages":[
+			{"role":"assistant","content":[
+				{"type":"thinking","thinking":"pure reasoning","signature":"sig"},
+				{"type":"text","text":"Answer"}
+			]}
+		]
+	}`)
+
+	out := FilterThinkingBlocksForRetry(input)
+	req := parseReq(t, out)
+
+	_, hasThinking := req["thinking"]
+	require.False(t, hasThinking, "no tool_use → thinking is omittable → top-level thinking disabled")
+	content := assistantContent(t, req, 0)
+	require.Equal(t, 0, countBlockType(content, "thinking"), "thinking with no tool_use should be downgraded to text")
+	require.Equal(t, "text", content[0].(map[string]any)["type"])
+	require.Equal(t, "pure reasoning", content[0].(map[string]any)["text"])
+}
+
+// Mixed conversation: an EARLIER pure-reasoning turn is stripped while a LATER
+// tool-use turn is preserved; because a tool-coupled thinking block survives,
+// top-level thinking must stay enabled.
+func TestFilterThinkingBlocksForRetry_MixedConversationPreservesOnlyToolTurns(t *testing.T) {
+	input := []byte(`{
+		"model":"claude-opus-4-1",
+		"thinking":{"type":"enabled","budget_tokens":1024},
+		"messages":[
+			{"role":"user","content":[{"type":"text","text":"q1"}]},
+			{"role":"assistant","content":[
+				{"type":"thinking","thinking":"earlier reasoning","signature":"sig0"},
+				{"type":"text","text":"intermediate answer"}
+			]},
+			{"role":"user","content":[{"type":"text","text":"q2, use a tool"}]},
+			{"role":"assistant","content":[
+				{"type":"thinking","thinking":"tool reasoning","signature":"sigTOOL"},
+				{"type":"tool_use","id":"toolu_3","name":"Grep","input":{"q":"x"}}
+			]}
+		]
+	}`)
+
+	out := FilterThinkingBlocksForRetry(input)
+	req := parseReq(t, out)
+
+	// top-level thinking kept (a tool-coupled thinking block survives).
+	_, hasThinking := req["thinking"]
+	require.True(t, hasThinking)
+
+	// earlier turn (idx 1): thinking stripped to text.
+	earlier := assistantContent(t, req, 1)
+	require.Equal(t, 0, countBlockType(earlier, "thinking"), "earlier non-tool thinking should be stripped")
+
+	// later tool turn (idx 3): thinking + signature preserved.
+	later := assistantContent(t, req, 3)
+	require.Equal(t, 1, countBlockType(later, "thinking"), "tool-coupled thinking must be preserved")
+	require.Equal(t, "sigTOOL", later[0].(map[string]any)["signature"])
+	require.Equal(t, 1, countBlockType(later, "tool_use"))
+}
+
+// Contract consistency: when a tool-coupled thinking block is preserved we keep
+// thinking enabled, so the clear_thinking_20251015 context-management strategy
+// must NOT be removed (it is only invalid when thinking is disabled).
+func TestFilterThinkingBlocksForRetry_KeepsClearThinkingStrategyWhenThinkingPreserved(t *testing.T) {
+	input := []byte(`{
+		"model":"claude-opus-4-1",
+		"thinking":{"type":"enabled","budget_tokens":1024},
+		"context_management":{"edits":[{"type":"clear_thinking_20251015","keep":"all"}]},
+		"messages":[
+			{"role":"assistant","content":[
+				{"type":"thinking","thinking":"t","signature":"sig"},
+				{"type":"tool_use","id":"toolu_4","name":"Bash","input":{}}
+			]}
+		]
+	}`)
+
+	out := FilterThinkingBlocksForRetry(input)
+	req := parseReq(t, out)
+
+	cm, ok := req["context_management"].(map[string]any)
+	require.True(t, ok, "context_management must be kept when thinking stays enabled")
+	edits, ok := cm["edits"].([]any)
+	require.True(t, ok)
+	require.Len(t, edits, 1)
+	require.Equal(t, "clear_thinking_20251015", edits[0].(map[string]any)["type"])
+}

--- a/backend/internal/service/gateway_service.go
+++ b/backend/internal/service/gateway_service.go
@@ -4813,8 +4813,16 @@ func (s *GatewayService) Forward(ctx context.Context, c *gin.Context, account *A
 									}(),
 								})
 								msg2 := extractUpstreamErrorMessage(retryRespBody)
-								if looksLikeToolSignatureError(msg2) && time.Since(retryStart) < maxRetryElapsed {
-									logger.LegacyPrintf("service.gateway", "Account %d: signature retry still failing and looks tool-related, retrying with tool blocks downgraded", account.ID)
+								// FilterThinkingBlocksForRetry now preserves thinking in tool-coupled
+								// assistant turns (contract requirement), so for any request carrying
+								// tool_use a lingering signature error can only be cleared by the
+								// contract-complete downgrade (thinking + dependent tool blocks → text).
+								// Escalate whenever the error looks tool-related OR the request itself
+								// contains tool_use, not just when upstream names a tool in the message.
+								reqHasToolUse := bytes.Contains(body, []byte(`"type":"tool_use"`)) ||
+									bytes.Contains(body, []byte(`"type": "tool_use"`))
+								if (looksLikeToolSignatureError(msg2) || reqHasToolUse) && time.Since(retryStart) < maxRetryElapsed {
+									logger.LegacyPrintf("service.gateway", "Account %d: signature retry still failing with tool_use present, retrying with tool blocks downgraded", account.ID)
 									filteredBody2 := FilterSignatureSensitiveBlocksForRetry(body)
 									retryCtx2, releaseRetryCtx2 := detachStreamUpstreamContext(ctx, reqStream)
 									retryReq2, buildErr2 := s.buildUpstreamRequest(retryCtx2, c, account, filteredBody2, token, tokenType, reqModel, reqStream, shouldMimicClaudeCode)

--- a/backend/internal/service/gateway_service_tk_signature_preempt_test.go
+++ b/backend/internal/service/gateway_service_tk_signature_preempt_test.go
@@ -217,3 +217,31 @@ func TestHasAnthropicSigPreemptCache_Setter(t *testing.T) {
 	s.SetAnthropicSigPreemptCache(&fakeSigPreemptCache{})
 	require.True(t, s.HasAnthropicSigPreemptCache())
 }
+
+// TestApplyPreempt_Armed_PreservesToolUseThinking pins the end-to-end contract:
+// even when the per-account preempt is armed (300s cooldown), a request whose
+// assistant turn contains tool_use must NOT have its thinking blocks stripped —
+// stripping there orphans the tool_use and makes Claude Code report malformed
+// tool calls (live edge-us1: 139 signed thinking + 216 tool_use forwarded as 0).
+// Complements TestApplyPreempt_Armed_StripsThinkingBlocks (the no-tool case that
+// is still safely stripped).
+func TestApplyPreempt_Armed_PreservesToolUseThinking(t *testing.T) {
+	cache := &fakeSigPreemptCache{}
+	cache.armed.Store(true)
+	s := &GatewayService{tkAnthropicSigPreemptCache: cache}
+	c := newTestGin()
+
+	body := []byte(`{"model":"claude-opus-4-1","thinking":{"type":"enabled"},"messages":[{"role":"assistant","content":[{"type":"thinking","thinking":"tool reasoning","signature":"sigTOOL"},{"type":"tool_use","id":"toolu_1","name":"Bash","input":{"command":"ls"}}]}]}`)
+
+	out := s.applySigPreemptIfArmed(context.Background(), c, newTestAccount(), body)
+
+	// Tool-coupled thinking + its signature must pass through verbatim.
+	require.Contains(t, string(out), `"type":"thinking"`, "tool-coupled thinking must NOT be stripped while preempt is armed")
+	require.Contains(t, string(out), "sigTOOL", "signature must pass through verbatim")
+	require.Contains(t, string(out), `"type":"tool_use"`, "tool_use must remain")
+	// Top-level thinking must stay enabled (a preserved thinking block requires it).
+	require.Contains(t, string(out), `"thinking":{"type":"enabled"}`, "top-level thinking must stay enabled")
+	// Body unchanged → no signature_preempt_applied event (armed-but-nothing-to-strip stays silent).
+	require.False(t, hasOpsEventKind(c, "signature_preempt_applied"), "no applied event when nothing is safely strippable")
+	require.True(t, bytes.Equal(out, body), "armed preempt must be a no-op for a tool-coupled thinking request")
+}

--- a/scripts/sentinels/gateway-tk.json
+++ b/scripts/sentinels/gateway-tk.json
@@ -1392,6 +1392,15 @@
         "func (r *AnthropicConfigReconciler) reportTierDrift("
       ],
       "rationale": "Per-node in-process self-healer that drops the ops/anthropic high-frequency safe-item writes into the backend: operator-Σ alignment, prod stub pool_mode, edge balance floor, and the surface-C concurrency mirror — plus REPORT-ONLY tier drift (never silently rewrites a UI-set tier). The surface-C 'never write 0 on a failed edge read' invariant and the report-only tier-drift boundary are load-bearing correctness properties; a silent upstream-merge deletion or weakening must be caught."
+    },
+    {
+      "path": "backend/internal/service/gateway_request.go",
+      "must_contain": [
+        "msgHasToolUse",
+        "anyThinkingPreserved",
+        "topLevelThinkingExists"
+      ],
+      "rationale": "Anthropic tool-use contract guard in FilterThinkingBlocksForRetry: during a tool-use loop the thinking/redacted_thinking blocks of an assistant message that ALSO contains tool_use must be passed back unchanged (signature included). msgHasToolUse gates per-message preservation; deleteTopLevelThinking is computed as topLevelThinkingExists && !anyThinkingPreserved so top-level thinking stays enabled whenever a tool-coupled block survives (deleting it then would be a mid-turn thinking-toggle the API rejects). Only pure-reasoning turns (no tool_use, which the API permits omitting) are downgraded to text. Captured live on edge-us1: 139 signed thinking + 216 tool_use forwarded as 0 thinking via the SigPreempt blanket strip, orphaning the tool_use and making Claude Code report malformed tool calls. A silent upstream-merge that reverts this to an unconditional strip reinstates that regression; the unrecoverable case (bad signature on a tool-coupled block) is handled by FilterSignatureSensitiveBlocksForRetry, which downgrades thinking AND its dependent tool blocks together."
     }
   ]
 }


### PR DESCRIPTION
## Problem
Claude Code (interleaved thinking + tools) through TK returns **malformed / non-executing tool calls**; direct cc0 (OAuth login, no relay) does not.

**Live evidence (edge-us1, debug body capture):** an assistant turn with **139 signed `thinking` blocks + 216 `tool_use`** was forwarded to Anthropic with **thinking stripped to 0** (`SigPreempt armed×1 / applied×6`), orphaning the `tool_use`.

## Root cause
- `FilterThinkingBlocksForRetry` strips **all** thinking blocks unconditionally; `applySigPreemptIfArmed` then blanket-applies it to **every** request to an account for the 300 s signature-error cooldown — including healthy tool+thinking requests that would have succeeded.
- Per [Anthropic's contract](https://platform.claude.com/docs/en/build-with-claude/extended-thinking): *“During tool use, you must pass `thinking` blocks back to the API for the last assistant message … you can't rearrange or modify the sequence.”* Stripping them produces an invalid turn → interleaved-thinking clients (Claude Code) report the tool call as malformed.
- Only the pooled-account gateway path runs this transform; cc0 direct keeps Anthropic's own signed blocks intact.

## Fix (contract-driven — not another strip layer)
1. **`FilterThinkingBlocksForRetry` is tool-aware**: `thinking`/`redacted_thinking` in any assistant message containing `tool_use` are preserved **verbatim (signature kept)**; only pure-reasoning turns (no tool_use — which the API allows omitting) are downgraded to text. Fixes both the preempt blanket-strip and the first retry.
2. **Top-level `thinking` is disabled only when no tool-coupled thinking survives** (avoids a mid-turn thinking-toggle conflict; keeps `clear_thinking_20251015` context-management consistent).
3. **OAuth retry escalation broadened**: when the request carries `tool_use`, a lingering signature error escalates to the contract-complete `FilterSignatureSensitiveBlocksForRetry` (downgrades thinking **and** dependent tool blocks together).

## Regression-proofing & tests
- New **gateway-tk sentinel anchor** (`msgHasToolUse` / `anyThinkingPreserved` / `topLevelThinkingExists`) so an upstream merge can't silently revert the guard.
- New `gateway_request_thinking_tooluse_test.go` (5 cases): preserve thinking+signature in a tool-use turn, preserve `redacted_thinking`, strip pure-reasoning turns, mixed conversation, `clear_thinking` consistency. Full `internal/service` unit suite + `golangci-lint` green; full `scripts/preflight.sh` (incl. all sub2api gates) green locally.

## Research basis
Anthropic extended-thinking tool-use contract; sub2api #599 (FilterThinkingBlocksForRetry origin) and #658 (sticky-switch encrypted-content 400); 9router #885 (proxies must not mutate signatures).

## Notes
- Backend-only; no API/contract/web surface change (`no-web-impact`).
- Upstream-shaped touch is pinned by a sentinel anchor (`upstream-touch-guarded`).
- Supersedes #484 (same fix; this branch lands it as one clean commit that satisfies the upstream-override sentinel gate CI caught on #484).
- **Do not merge without human review** (per repo policy).

🤖 Generated with [Claude Code](https://claude.com/claude-code)