### PR TITLE
chore(fingerprint): single-source cc version + preflight gate

### DIFF
--- a/backend/internal/pkg/claude/constants.go
+++ b/backend/internal/pkg/claude/constants.go
@@ -109,7 +109,7 @@ func FullClaudeCodeMimicryBetas() []string {
 	}
 }
 
-// FullClaudeCodeHaikuMimicryBetas 返回 Haiku 模型 OAuth mimicry 的 beta 列表（cc 2.1.159 structured-outputs 抓包）。
+// FullClaudeCodeHaikuMimicryBetas 返回 Haiku 模型 OAuth mimicry 的 beta 列表（近期 cc structured-outputs 抓包）。
 func FullClaudeCodeHaikuMimicryBetas() []string {
 	return []string{
 		BetaOAuth,

--- a/backend/internal/service/gateway_context_management_test.go
+++ b/backend/internal/service/gateway_context_management_test.go
@@ -431,7 +431,7 @@ func TestBuildUpstreamRequest_OAuthMimicHaiku_StripsContextManagementEndToEnd(t 
 	//   - body：Anthropic 对 claude-haiku-4-5 的 body.context_management 返回 400
 	//     ("context_management: Extra inputs are not permitted")，所以 body 必须 strip。
 	//     computeFinalAnthropicBeta 的 haiku 分支刻意不含 context-management，正好驱动 strip。
-	//   - header：真实 Claude Code 2.1.159 抓包（haiku comprehensive 双峰都含 context-management；
+	//   - header：真实 Claude Code 近期抓包（haiku comprehensive 双峰都含 context-management；
 	//     FullClaudeCodeHaikuMimicryBetas 含 BetaContextManagement）确认 haiku 请求**确实**带
 	//     context-management beta header —— 剥掉它会破指纹、被 Anthropic 判 third-party。
 	body := []byte(`{"model":"claude-haiku-4-5","context_management":{"edits":[{"type":"clear_thinking_20251015"}]},"messages":[]}`)
@@ -448,7 +448,7 @@ func TestBuildUpstreamRequest_OAuthMimicHaiku_StripsContextManagementEndToEnd(t 
 	require.False(t, gjson.GetBytes(outBody, "context_management").Exists(),
 		"OAuth mimic + haiku 端到端：outgoing body 不应含 context_management（Anthropic 对 haiku 返回 400）")
 	require.True(t, anthropicBetaTokensContains(outBeta, claude.BetaContextManagement),
-		"指纹对齐：outgoing anthropic-beta header 必须带 context-management beta（真实 cc 2.1.159 haiku 就带）")
+		"指纹对齐：outgoing anthropic-beta header 必须带 context-management beta（真实 cc haiku 就带）")
 }
 
 func TestBuildUpstreamRequest_OAuthMimicNonHaiku_PreservesContextManagementEndToEnd(t *testing.T) {

--- a/scripts/preflight.sh
+++ b/scripts/preflight.sh
@@ -447,6 +447,27 @@ else
     echo "  ok: embedded tier/stub baselines match deploy/aws/stage0 sources"
 fi
 
+# ---- sub2api: cc version string single-source -------------------------------
+# A cc CLI patch bump (e.g. 2.1.158 -> 2.1.159) used to require hand-editing
+# ~10 files; PR #482 shipped 5 wrong dead-value edits because nothing checked
+# them. Source of truth is anthropic-http-mimicry-baselines.json cc_version;
+# check-cc-version-sync.py proves every Go compile default + dead snapshot
+# agrees, and its --selftest keeps the guard's own parse/write logic honest.
+echo ""
+echo "=== sub2api: cc version string single-source ==="
+if ! command -v python3 >/dev/null 2>&1; then
+    echo "  FAIL: python3 not on PATH (required for cc version sync check)"
+    errors=$((errors + 1))
+elif ! python3 ./scripts/sentinels/check-cc-version-sync.py --selftest >/dev/null; then
+    echo "  FAIL: check-cc-version-sync.py self-test failed"
+    errors=$((errors + 1))
+elif ! python3 ./scripts/sentinels/check-cc-version-sync.py --quiet; then
+    # check-cc-version-sync.py already printed the actionable failure.
+    errors=$((errors + 1))
+else
+    echo "  ok: cc_version in anthropic-http-mimicry-baselines.json synced to all copies"
+fi
+
 # ---- sub2api: sentinel registry update gate ---------------------------------
 # Existing sentinel checks prove current guarded literals still exist. This gate
 # proves PRs that modify guarded/hotspot files also update the matching registry,

--- a/scripts/sentinels/check-cc-version-sync.py
+++ b/scripts/sentinels/check-cc-version-sync.py
@@ -1,0 +1,376 @@
+#!/usr/bin/env python3
+"""
+check-cc-version-sync.py — keep the Claude Code CLI version string in lockstep
+across every place that carries it, with a single source of truth.
+
+Source of truth (the ONE field a cc patch bump should edit):
+  deploy/aws/stage0/anthropic-http-mimicry-baselines.json  ->  cc_version
+
+This is the value `manage-anthropic-config.py sync-runtime` pushes to the live
+fleet, so it is the authoritative cc version. Every other copy must agree with
+it. Before this guard a cc bump (e.g. 2.1.158 -> 2.1.159, PR #482) required
+hand-editing ~10 files and 5 of those edits were wrong — dead snapshots and
+comments drifted because nothing mechanically checked them.
+
+Two classes of derived copy:
+
+1. Go compile-time fallback defaults — PARSED and compared, never auto-written
+   (go:embed cannot reach deploy/ from the backend module, and these are the
+   last-resort defaults a brand-new deploy boots with, so they stay hand-edited
+   on a cc bump; this guard just refuses to let them drift):
+     - backend/internal/pkg/claude/constants.go
+         CLICurrentVersion             = "X.Y.Z"
+         DefaultHeaders["User-Agent"]  = "claude-cli/X.Y.Z (external, cli)"
+     - backend/internal/service/identity_service.go
+         defaultFingerprint.UserAgent  = "claude-cli/X.Y.Z (external, cli)"
+     - backend/internal/service/identity_service_tk_canonical_http.go
+         DefaultClaudeCodeUserAgentVersion = "X.Y.Z"
+
+2. Pure dead snapshots — compared, and AUTO-REGENERATED with --write so a cc
+   bump no longer hand-touches them:
+     - deploy/aws/stage0/tk_canonical_cc_oauth.json   observed.user_agent
+     - ops/stage0/smoke_lib.sh                        smoke_default_claude_user_agent default
+
+Exit codes:
+  0  — every copy agrees with cc_version.
+  1  — drift detected (some copy != cc_version).
+  2  — file missing, parse failure, or required symbol not found.
+
+Usage:
+  python3 scripts/sentinels/check-cc-version-sync.py            # check, verbose
+  python3 scripts/sentinels/check-cc-version-sync.py --quiet    # check, print only on failure
+  python3 scripts/sentinels/check-cc-version-sync.py --json     # machine-readable
+  python3 scripts/sentinels/check-cc-version-sync.py --write    # regenerate dead snapshots from source of truth
+  python3 scripts/sentinels/check-cc-version-sync.py --selftest # run built-in fixture self-test
+
+cc bump workflow (see tokenkey-cc-fingerprint-alignment skill):
+  1. edit cc_version in anthropic-http-mimicry-baselines.json
+  2. run this script with --write  (regenerates the dead snapshots)
+  3. hand-edit the 4 Go compile defaults listed above
+  4. re-run this script (--check)  — must exit 0; preflight enforces it
+"""
+from __future__ import annotations
+
+import argparse
+import json
+import re
+import sys
+import tempfile
+from pathlib import Path
+
+REPO_ROOT = Path(__file__).resolve().parent.parent.parent
+SOURCE_JSON = REPO_ROOT / "deploy" / "aws" / "stage0" / "anthropic-http-mimicry-baselines.json"
+
+CONSTANTS_GO = REPO_ROOT / "backend" / "internal" / "pkg" / "claude" / "constants.go"
+IDENTITY_GO = REPO_ROOT / "backend" / "internal" / "service" / "identity_service.go"
+CANONICAL_HTTP_GO = (
+    REPO_ROOT / "backend" / "internal" / "service" / "identity_service_tk_canonical_http.go"
+)
+CANONICAL_TLS_JSON = REPO_ROOT / "deploy" / "aws" / "stage0" / "tk_canonical_cc_oauth.json"
+SMOKE_LIB_SH = REPO_ROOT / "ops" / "stage0" / "smoke_lib.sh"
+
+SEMVER_RE = re.compile(r"\d+\.\d+\.\d+")
+
+# Each parsed copy: one regex with a single capture group around the bare semver
+# (so the field name stays anchored in the pattern — no column-number reads).
+# label -> (file, compiled regex). The regex MUST capture exactly the X.Y.Z.
+_PARSE_TARGETS = {
+    "constants.go CLICurrentVersion": (
+        CONSTANTS_GO,
+        re.compile(r'const\s+CLICurrentVersion\s*=\s*"(\d+\.\d+\.\d+)"'),
+    ),
+    'constants.go DefaultHeaders["User-Agent"]': (
+        CONSTANTS_GO,
+        re.compile(r'"User-Agent":\s*"claude-cli/(\d+\.\d+\.\d+) \(external, cli\)"'),
+    ),
+    "identity_service.go defaultFingerprint.UserAgent": (
+        IDENTITY_GO,
+        re.compile(r'UserAgent:\s*"claude-cli/(\d+\.\d+\.\d+) \(external, cli\)"'),
+    ),
+    "identity_service_tk_canonical_http.go DefaultClaudeCodeUserAgentVersion": (
+        CANONICAL_HTTP_GO,
+        re.compile(r'DefaultClaudeCodeUserAgentVersion\s*=\s*"(\d+\.\d+\.\d+)"'),
+    ),
+}
+
+# Dead snapshots: (file, parse regex, rewrite-template builder). The builder
+# takes the new version and returns the full replacement line text. The parse
+# regex captures the current semver for comparison.
+_SMOKE_RE = re.compile(
+    r'(printf \'%s\' "\$\{TK_SMOKE_CLAUDE_USER_AGENT:-claude-cli/)(\d+\.\d+\.\d+)( \(external, sdk-cli\)\}")'
+)
+_OBSERVED_UA_RE = re.compile(
+    r'("user_agent":\s*"claude-cli/)(\d+\.\d+\.\d+)( \(external, sdk-cli\)")'
+)
+
+
+class CheckError(Exception):
+    pass
+
+
+def _read(path: Path) -> str:
+    if not path.is_file():
+        raise CheckError(f"file not found: {path.relative_to(REPO_ROOT)}")
+    return path.read_text(encoding="utf-8")
+
+
+def load_source_version(source_json: Path = SOURCE_JSON) -> str:
+    text = _read(source_json)
+    try:
+        data = json.loads(text)
+    except json.JSONDecodeError as exc:
+        raise CheckError(f"{source_json.relative_to(REPO_ROOT)} parse error: {exc}") from exc
+    cc = data.get("cc_version")
+    if not isinstance(cc, str) or not SEMVER_RE.fullmatch(cc.strip()):
+        raise CheckError(
+            f"{source_json.relative_to(REPO_ROOT)} cc_version missing or not X.Y.Z: {cc!r}"
+        )
+    return cc.strip()
+
+
+def parse_copy(label: str, path: Path, regex: re.Pattern[str]) -> str:
+    m = regex.search(_read(path))
+    if not m:
+        raise CheckError(
+            f"{label}: pattern not found in {path.relative_to(REPO_ROOT)} "
+            "(symbol renamed or reformatted? update check-cc-version-sync.py)"
+        )
+    return m.group(1)
+
+
+def _parse_dead(label: str, path: Path, regex: re.Pattern[str], group: int) -> str:
+    m = regex.search(_read(path))
+    if not m:
+        raise CheckError(
+            f"{label}: pattern not found in {path.relative_to(REPO_ROOT)} "
+            "(reformatted? update check-cc-version-sync.py)"
+        )
+    return m.group(group)
+
+
+def gather(
+    expected: str,
+    *,
+    source_json: Path = SOURCE_JSON,
+    parse_targets: dict[str, tuple[Path, re.Pattern[str]]] = _PARSE_TARGETS,
+    smoke_path: Path = SMOKE_LIB_SH,
+    canonical_tls_path: Path = CANONICAL_TLS_JSON,
+) -> list[dict[str, object]]:
+    findings: list[dict[str, object]] = []
+    for label, (path, regex) in parse_targets.items():
+        found = parse_copy(label, path, regex)
+        findings.append(
+            {"label": label, "kind": "go-default", "found": found, "ok": found == expected}
+        )
+    smoke_found = _parse_dead(
+        "smoke_lib.sh smoke_default_claude_user_agent", smoke_path, _SMOKE_RE, 2
+    )
+    findings.append(
+        {"label": "smoke_lib.sh smoke_default_claude_user_agent", "kind": "dead",
+         "found": smoke_found, "ok": smoke_found == expected}
+    )
+    observed_found = _parse_dead(
+        "tk_canonical_cc_oauth.json observed.user_agent", canonical_tls_path, _OBSERVED_UA_RE, 2
+    )
+    findings.append(
+        {"label": "tk_canonical_cc_oauth.json observed.user_agent", "kind": "dead",
+         "found": observed_found, "ok": observed_found == expected}
+    )
+    return findings
+
+
+def _rel(path: Path) -> str:
+    try:
+        return str(path.relative_to(REPO_ROOT))
+    except ValueError:
+        return str(path)
+
+
+def write_dead_snapshots(
+    expected: str,
+    *,
+    smoke_path: Path = SMOKE_LIB_SH,
+    canonical_tls_path: Path = CANONICAL_TLS_JSON,
+) -> list[str]:
+    """Rewrite the dead snapshots to `expected`. Returns list of changed files."""
+    changed: list[str] = []
+
+    smoke_text = _read(smoke_path)
+    new_smoke, n = _SMOKE_RE.subn(lambda m: m.group(1) + expected + m.group(3), smoke_text)
+    if n == 0:
+        raise CheckError(f"smoke_lib.sh: nothing to rewrite (pattern not found)")
+    if new_smoke != smoke_text:
+        smoke_path.write_text(new_smoke, encoding="utf-8")
+        changed.append(_rel(smoke_path))
+
+    tls_text = _read(canonical_tls_path)
+    new_tls, n = _OBSERVED_UA_RE.subn(lambda m: m.group(1) + expected + m.group(3), tls_text)
+    if n == 0:
+        raise CheckError(f"tk_canonical_cc_oauth.json: nothing to rewrite (pattern not found)")
+    if new_tls != tls_text:
+        canonical_tls_path.write_text(new_tls, encoding="utf-8")
+        changed.append(_rel(canonical_tls_path))
+
+    return changed
+
+
+def run_check(args: argparse.Namespace) -> int:
+    expected = load_source_version()
+    findings = gather(expected)
+    drift = [f for f in findings if not f["ok"]]
+
+    if args.json:
+        print(json.dumps(
+            {"expected": expected, "ok": not drift, "findings": findings},
+            indent=2, sort_keys=True,
+        ))
+        return 1 if drift else 0
+
+    if not drift:
+        if not args.quiet:
+            print(
+                f"OK: cc_version={expected} consistent across "
+                f"{len(findings)} copies (source: {SOURCE_JSON.relative_to(REPO_ROOT)})"
+            )
+        return 0
+
+    print(
+        f"FAIL: cc version DRIFT — source of truth "
+        f"{SOURCE_JSON.relative_to(REPO_ROOT)} cc_version={expected}",
+        file=sys.stderr,
+    )
+    has_dead = False
+    for f in drift:
+        print(f"  {f['label']}: found {f['found']} != {expected}", file=sys.stderr)
+        if f["kind"] == "dead":
+            has_dead = True
+    if has_dead:
+        print(
+            "Fix dead snapshots: python3 scripts/sentinels/check-cc-version-sync.py --write",
+            file=sys.stderr,
+        )
+    if any(f["kind"] == "go-default" for f in drift):
+        print(
+            "Fix Go compile defaults by hand (cannot be auto-derived: go:embed "
+            "cannot reach deploy/): edit the listed constants to "
+            f"{expected}.",
+            file=sys.stderr,
+        )
+    return 1
+
+
+def run_write(args: argparse.Namespace) -> int:
+    expected = load_source_version()
+    changed = write_dead_snapshots(expected)
+    if changed:
+        for c in changed:
+            print(f"wrote {c} -> cc_version={expected}")
+    else:
+        print(f"no change: dead snapshots already at cc_version={expected}")
+    # Re-check Go defaults and report (write does not touch them).
+    findings = gather(expected)
+    go_drift = [f for f in findings if f["kind"] == "go-default" and not f["ok"]]
+    if go_drift:
+        print(
+            "NOTE: Go compile defaults still drift (hand-edit required):",
+            file=sys.stderr,
+        )
+        for f in go_drift:
+            print(f"  {f['label']}: {f['found']} != {expected}", file=sys.stderr)
+        return 1
+    return 0
+
+
+# ---------------------------------------------------------------------------
+# Built-in self-test: build a throwaway fixture tree, prove check + write.
+# Runs alongside preflight so the guard's own logic stays honest.
+# ---------------------------------------------------------------------------
+def run_selftest() -> int:
+    failures: list[str] = []
+
+    def expect(cond: bool, msg: str) -> None:
+        if not cond:
+            failures.append(msg)
+
+    with tempfile.TemporaryDirectory() as td:
+        root = Path(td)
+        src = root / "src.json"
+        smoke = root / "smoke_lib.sh"
+        tls = root / "tk.json"
+        go_const = root / "constants.go"
+
+        src.write_text(json.dumps({"schema_version": 1, "cc_version": "9.9.9"}), encoding="utf-8")
+        smoke.write_text(
+            'printf \'%s\' "${TK_SMOKE_CLAUDE_USER_AGENT:-claude-cli/1.0.0 (external, sdk-cli)}"\n',
+            encoding="utf-8",
+        )
+        tls.write_text(
+            json.dumps({"observed": {"user_agent": "claude-cli/1.0.0 (external, sdk-cli)"}}, indent=2),
+            encoding="utf-8",
+        )
+        go_const.write_text('const CLICurrentVersion = "1.0.0"\n', encoding="utf-8")
+
+        expected = load_source_version(src)
+        expect(expected == "9.9.9", f"source version parse: got {expected!r}")
+
+        targets = {
+            "constants.go CLICurrentVersion": (
+                go_const,
+                re.compile(r'const\s+CLICurrentVersion\s*=\s*"(\d+\.\d+\.\d+)"'),
+            ),
+        }
+
+        # before write: drift expected (smoke/tls/go all 1.0.0 != 9.9.9)
+        findings = gather(expected, parse_targets=targets, smoke_path=smoke, canonical_tls_path=tls)
+        expect(all(not f["ok"] for f in findings), "pre-write: all copies should drift")
+
+        # --write regenerates the two dead snapshots
+        changed = write_dead_snapshots(expected, smoke_path=smoke, canonical_tls_path=tls)
+        expect(len(changed) == 2, f"write should change 2 files, got {changed}")
+
+        findings = gather(expected, parse_targets=targets, smoke_path=smoke, canonical_tls_path=tls)
+        dead_ok = [f for f in findings if f["kind"] == "dead"]
+        expect(all(f["ok"] for f in dead_ok), "post-write: dead snapshots should match")
+        go_f = [f for f in findings if f["kind"] == "go-default"]
+        expect(all(not f["ok"] for f in go_f), "post-write: go default still drifts (hand-edit)")
+
+        # fix go default by hand -> all green
+        go_const.write_text('const CLICurrentVersion = "9.9.9"\n', encoding="utf-8")
+        findings = gather(expected, parse_targets=targets, smoke_path=smoke, canonical_tls_path=tls)
+        expect(all(f["ok"] for f in findings), "after hand-edit: all copies should match")
+
+    if failures:
+        print("SELFTEST FAIL:", file=sys.stderr)
+        for f in failures:
+            print(f"  - {f}", file=sys.stderr)
+        return 1
+    print("ok: check-cc-version-sync self-test passed")
+    return 0
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser(description="cc version single-source guard")
+    mode = parser.add_mutually_exclusive_group()
+    mode.add_argument("--write", action="store_true", help="regenerate dead snapshots from cc_version")
+    mode.add_argument("--selftest", action="store_true", help="run built-in fixture self-test")
+    parser.add_argument("--quiet", action="store_true", help="check mode: print only on failure")
+    parser.add_argument("--json", action="store_true", help="check mode: machine-readable report")
+    args = parser.parse_args()
+
+    if args.json and args.quiet:
+        print("FATAL: --json and --quiet are mutually exclusive", file=sys.stderr)
+        return 2
+
+    try:
+        if args.selftest:
+            return run_selftest()
+        if args.write:
+            return run_write(args)
+        return run_check(args)
+    except CheckError as exc:
+        print(f"FATAL: {exc}", file=sys.stderr)
+        return 2
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/scripts/sentinels/gateway-tk.json
+++ b/scripts/sentinels/gateway-tk.json
@@ -1139,7 +1139,7 @@
         "func FullClaudeCodeHaikuMimicryBetas()",
         "func JoinBetaHeader("
       ],
-      "rationale": "OAuth Claude Code mimicry beta registry: Sonnet/Opus and Haiku sets must stay aligned with real cc CLI traffic (cc 2.1.159 capture). Dropping thinking-token-count / structured-outputs or reverting Haiku to the legacy claude-code + extended-cache-ttl set re-opens third-party cohort signals on OAuth subscriptions."
+      "rationale": "OAuth Claude Code mimicry beta registry: Sonnet/Opus and Haiku sets must stay aligned with real cc CLI traffic (latest cc capture; version single-sourced in deploy/aws/stage0/anthropic-http-mimicry-baselines.json). Dropping thinking-token-count / structured-outputs or reverting Haiku to the legacy claude-code + extended-cache-ttl set re-opens third-party cohort signals on OAuth subscriptions."
     },
     {
       "path": "backend/internal/handler/gateway_handler.go",


### PR DESCRIPTION
## What

A cc CLI patch bump used to require hand-editing ~10 files; **PR #482 shipped 5 wrong dead-value edits (R-001..R-005)** because nothing mechanically checked the copies. This makes `deploy/aws/stage0/anthropic-http-mimicry-baselines.json` `cc_version` the **single source of truth** and derives/verifies the rest.

## Changes

- **`scripts/sentinels/check-cc-version-sync.py`** (new) — proves every copy agrees with `cc_version`.
  - Go compile defaults (`CLICurrentVersion` / `DefaultHeaders` UA / `defaultFingerprint.UserAgent` / `DefaultClaudeCodeUserAgentVersion`) are **parsed and compared** — cannot auto-derive because `go:embed` cannot reach `deploy/` from the backend module.
  - Dead snapshots (`smoke_lib.sh` default UA, `tk_canonical_cc_oauth.json` `observed.user_agent`) are **regenerated by `--write`**.
  - `--quiet` / `--json` / `--write` / `--selftest`; exit 0/1/2. Built-in fixture self-test keeps the parse/write logic honest.
- **`scripts/preflight.sh`** — new `cc version string single-source` gate (runs self-test then check).
- **Genericized patch-number comments** that are guaranteed to drift (the R-003 class): `constants.go` capture comments, `gateway_context_management_test.go` comment/message, `gateway-tk.json` sentinel rationale → version-agnostic, pointing at the JSON source of truth.
- **`tokenkey-cc-fingerprint-alignment` skill** §4 rewritten: "hand-edit ~10 files" → "edit 1 JSON → `--write` regenerates dead snapshots → hand-edit 4 Go defaults → check/preflight enforce".

## Why

Answers the operator question: *"#482 改 1 个实值却要改 10 个文件，过于复杂、易错。"* Root cause: the runtime source of truth had already converged to the JSON, but no check kept the dead copies aligned — all on skill prose. Hardens it into a gate (global CLAUDE.md §5 / dev-rules「可机械化的不写成 prose」).

## Validation

- `python3 scripts/sentinels/check-cc-version-sync.py --selftest` — passes
- `python3 scripts/sentinels/check-cc-version-sync.py` — exit 0 (6 copies in sync)
- drift→fail→`--write`→pass round trip verified on real `smoke_lib.sh`
- `go build ./...` + `go test -tags=unit ./internal/pkg/claude/... ./internal/service/...` — pass
- `scripts/preflight.sh` — PASS (new gate shows ok)

Comment + ops + skill only; no behavior change, no web surface. Go compile defaults unchanged (already 2.1.159 from #482).

🤖 Generated with [Claude Code](https://claude.com/claude-code)