### PR TITLE
feat(ops): check live HTTP UA drift in anthropic-oauth-config

### DIFF
--- a/.cursor/skills/tokenkey-anthropic-oauth-config/SKILL.md
+++ b/.cursor/skills/tokenkey-anthropic-oauth-config/SKILL.md
@@ -58,13 +58,18 @@ MGR=ops/anthropic/manage-anthropic-config.py
 # Stage 1 — Snapshot：拉所有 deployable edge 的 anthropic OAuth account + prod anthropic api-key stub 状态到 JSON
 python3 $MGR snapshot --out $JOBDIR/snap.json
 
-# Stage 2 — Check（联查）：每个 edge 跑 OAuth 稳定性 guard，只读出 TLS / 余额 /
-#   tier 表（vs git）漂移
+# Stage 2 — Check（联查）：每个 edge 跑 OAuth 稳定性 guard，读出 TLS / 余额 /
+#   tier 表（vs git）/ HTTP UA + mimicry manifest 漂移
 python3 $MGR check --snapshot $JOBDIR/snap.json
 #   退出码：0 全绿 / 1 violation（含 tls_profile drift、operator_balance 低于门槛、
-#           tier_table_drift 等）/ 2 error
+#           tier_table_drift、http_ua_drift 等）/ 2 error
 #   注意：check 只“报告”漂移。修复入口分流：
 #     - tls_profile 漂移 → 本 skill Stage 3（plan-guard-drift-fix / remediate-guard-drift）
+#     - http_ua_drift（live settings.claude_code_user_agent_version / mimicry manifest
+#       != deploy/aws/stage0/anthropic-http-mimicry-baselines.json）→ 本 skill Stage 4
+#       `sync-runtime`。这是把「最关键的 HTTP 指纹配置」纳入 check 的覆盖面：cc bump 合并后
+#       若忘记 sync-runtime，fleet live UA 会停在旧版本而 check 旧版**不会报**——现已会 violation。
+#       **始终 live 读**（即使传 --snapshot）：UA 是部署级运行时旋钮，snapshot 不抓它。
 #     - operator_balance / pool_mode / concurrency 漂移 → 后端 reconciler 自愈（§3）
 #     - tier_table_drift（live `tiers` 表 != git baseline）→ tier 行被 admin 后台改过
 #       （PUT /admin/tiers/:id），下次重启/发版会被 ensureSeededFromBaseline 回刷；
@@ -112,7 +117,7 @@ prod 无 OAuth 账号时只写 settings；edge 两者都写。HTTP UA 运行时 
 | 阶段 | 输入 | 输出 | exit |
 |---|---|---|---|
 | snapshot | EC2/Lightsail SSM 权限 | `snap.json`：`edges.*.oauth_accounts` + `prod.anthropic_stubs`，**字段名嵌在值旁**（jsonb_agg） | 0 / 2 error |
-| check | snap.json | 每个 edge 跑 `check-edge-oauth-stability.py` + `operator_balance` 段（live 或 snapshot v6）；**只读报告** | 0 ok / 1 violation / 2 error |
+| check | snap.json | 每 edge 跑 `check-edge-oauth-stability.py`（含 `tls_profile` diff）+ `operator_balance` + `tier_table_drift` + `http_ua_drift`（**始终 live 读** settings UA + mimicry manifest vs baseline JSON）；**报告**，drift/error 计入 violation | 0 ok / 1 violation / 2 error |
 | plan-guard-drift-fix | snap.json + check.json（或重跑 guard） | 每个 `status=drift` 账号一个 `edge_account_tier` action（force template rewrite，重写 TLS profile + 绑定 + credentials 模板字段） | 0 / 2 |
 | remediate-guard-drift | confirm + job-dir | 上述全流程（snapshot → check → plan → apply --sync-runtime → verify → check）artifact 落盘 | 0 / 1 |
 | apply | plan.json + confirm | 逐 action 渲染 SQL → SSM；可选 `--sync-runtime` 写 settings + 清 Redis | 0 / 1 step failed / 2 |
@@ -216,7 +221,7 @@ operate 流程：
 | check 报 `tier_table_drift`（live `tiers` 表 != git baseline，violation/exit 1） | tier 行被 admin 后台改过（`PUT /admin/tiers/:id`），全副本即时生效但下次重启/发版被 `ensureSeededFromBaseline` 回刷。看 `items[].warning` 定位 node/tier/字段；**撤销后台改动**（admin UI 改回），或若是有意调整就**把新值落进 git baseline JSON**（`deploy/aws/stage0/anthropic-oauth-stability-baselines-tiered.json` + 同步 embed/迁移，过 `check-tier-baseline-embed.py`）再发版固化 |
 | check 报账号 `account_field_drift`（非 tier-managed 字段，如 priority / concurrency） | concurrency 由 reconciler 自愈（§3）；其余账号级字段走 admin UI |
 | check 报 `operator_balance` 低于门槛 / pool_mode / concurrency 漂移 | 由后端 reconciler 自愈（§3）；若持续未自愈，查该节点 reconciler leader 锁 / slog 日志，不要手工 plan |
-| HTTP UA / mimicry 未生效 | `sync-runtime --target …`（或先 `plan-http-mimicry-sync` 核对 manifest）；确认 `anthropic-http-mimicry-baselines.json` 的 `cc_version` 已是目标版本 |
+| check 报 `http_ua_drift` / HTTP UA 未生效 | `sync-runtime --target …`（或先 `plan-http-mimicry-sync` 核对 manifest）；确认 `anthropic-http-mimicry-baselines.json` 的 `cc_version` 已是目标版本。典型成因：cc 版本 bump PR 合并后忘了跑 sync-runtime，fleet live UA 仍停在旧版本——check 现在会 violation（exit 1），不再假绿 |
 | OAuth account `status=error/suspended` | OAuth 凭据问题（token 过期 / 403 / 上游禁用），见 OAuth 故障文档；不在本流水线范围 |
 | verify drift | operator 决定再 apply 或回滚（用 admin 前端按 plan.live_inputs.* 的 before 反向写回） |
 

--- a/ops/anthropic/manage-anthropic-config.py
+++ b/ops/anthropic/manage-anthropic-config.py
@@ -1172,6 +1172,135 @@ def _run_tier_table_checks_live(edge_ids: list[str], expected_by_tier: dict[str,
     return items
 
 
+# --------------------------------------------------------------------------
+# http_ua_drift: live settings UA / mimicry manifest vs baseline JSON
+# --------------------------------------------------------------------------
+# `sync-runtime` pushes settings.claude_code_user_agent_version +
+# settings.claude_code_http_mimicry_manifest to each node; nothing READ them
+# back, so `check` could stay all-green while the fleet's live UA was a stale
+# cc version (observed 2026-06: fleet on 2.1.158 while baseline was 2.1.159,
+# check green throughout). This surface reads the same two setting keys live
+# and diffs them against the single-source baseline JSON, so a fleet that has
+# not been sync-runtime'd after a cc bump now fails check. Always reads LIVE
+# (even with --snapshot): UA is a deploy-level runtime knob updated out of band
+# from snapshot, and a stale snapshot is exactly how the blind spot hid.
+
+# Mirror render_runtime_sync_shell's settings read (row_to_json beside values,
+# no column-number reads). One row per present key.
+SETTINGS_UA_SQL = f"""
+SELECT COALESCE(jsonb_object_agg(key, value), '{{}}'::jsonb)
+FROM (
+  SELECT key, value FROM settings
+  WHERE key IN ('{RUNTIME_SYNC_SETTING_KEY}', '{RUNTIME_SYNC_MIMICRY_SETTING_KEY}')
+) t;
+""".strip()
+
+
+def _read_http_ua_settings(region: str, instance_id: str, label: str) -> dict:
+    """Pull the two cc-fingerprint setting keys for one node. Missing keys are
+    simply absent from the returned dict (caller treats absent as drift)."""
+    raw, _ = ssm_run_sql(region, instance_id, SETTINGS_UA_SQL, f"check: {label} http ua settings")
+    try:
+        return json.loads(raw) if raw else {}
+    except json.JSONDecodeError:
+        return {}
+
+
+def _http_ua_drift_items(node_label: str, live_settings: dict, expected: dict) -> list[dict]:
+    """Diff one node's live UA setting + mimicry manifest vs the baseline JSON.
+    Returns drift items (status=drift), each with the offending field. Empty == match."""
+    items: list[dict] = []
+    exp_ver = str(expected["cc_version"]).strip()
+
+    live_ua = live_settings.get(RUNTIME_SYNC_SETTING_KEY)
+    if live_ua is None:
+        items.append({
+            "node": node_label, "field": RUNTIME_SYNC_SETTING_KEY, "status": "drift",
+            "expected": exp_ver, "actual": None,
+            "warning": (f"{node_label}: settings.{RUNTIME_SYNC_SETTING_KEY} unset; "
+                        f"run sync-runtime (expected {exp_ver})"),
+        })
+    elif str(live_ua).strip() != exp_ver:
+        items.append({
+            "node": node_label, "field": RUNTIME_SYNC_SETTING_KEY, "status": "drift",
+            "expected": exp_ver, "actual": str(live_ua).strip(),
+            "warning": (f"{node_label}: live UA {str(live_ua).strip()} != baseline {exp_ver}; "
+                        f"run sync-runtime"),
+        })
+
+    # Manifest is stored as a JSON string in settings.value; parse and compare
+    # the version-relevant fields (cc_version + the two beta lists).
+    live_manifest_raw = live_settings.get(RUNTIME_SYNC_MIMICRY_SETTING_KEY)
+    exp_manifest = {
+        "cc_version": exp_ver,
+        "sonnet_opus": list(expected["sonnet_opus"]),
+        "haiku": list(expected["haiku"]),
+    }
+    if live_manifest_raw is None:
+        items.append({
+            "node": node_label, "field": RUNTIME_SYNC_MIMICRY_SETTING_KEY, "status": "drift",
+            "expected": exp_manifest, "actual": None,
+            "warning": (f"{node_label}: settings.{RUNTIME_SYNC_MIMICRY_SETTING_KEY} unset; "
+                        f"run sync-runtime"),
+        })
+    else:
+        try:
+            live_manifest = (json.loads(live_manifest_raw)
+                             if isinstance(live_manifest_raw, str) else live_manifest_raw)
+        except (json.JSONDecodeError, TypeError):
+            live_manifest = None
+        if not isinstance(live_manifest, dict):
+            items.append({
+                "node": node_label, "field": RUNTIME_SYNC_MIMICRY_SETTING_KEY, "status": "drift",
+                "expected": exp_manifest, "actual": str(live_manifest_raw)[:120],
+                "warning": (f"{node_label}: {RUNTIME_SYNC_MIMICRY_SETTING_KEY} not valid JSON object; "
+                            f"run sync-runtime"),
+            })
+        else:
+            mismatched = [
+                k for k in ("cc_version", "sonnet_opus", "haiku")
+                if live_manifest.get(k) != exp_manifest[k]
+            ]
+            if mismatched:
+                items.append({
+                    "node": node_label, "field": RUNTIME_SYNC_MIMICRY_SETTING_KEY, "status": "drift",
+                    "expected": {k: exp_manifest[k] for k in mismatched},
+                    "actual": {k: live_manifest.get(k) for k in mismatched},
+                    "warning": (f"{node_label}: mimicry manifest drift ({', '.join(mismatched)}); "
+                                f"run sync-runtime"),
+                })
+    return items
+
+
+def _run_http_ua_checks_live(edge_ids: list[str], expected: dict) -> list[dict]:
+    """Live SSM settings read per node (edge + prod). Always live: UA is updated
+    out of band from snapshot. SSM failures degrade to status=error (counted like
+    tier/balance errors), never silently treated as in-sync."""
+    items: list[dict] = []
+    for eid in edge_ids:
+        try:
+            ident = _EDGE_SSM.resolve_edge_execution_identity(REPO_ROOT, eid)
+        except SystemExit:
+            items.append({"node": f"edge:{eid}", "field": "*", "status": "error",
+                          "warning": f"could not resolve SSM instance for edge {eid}"})
+            continue
+        try:
+            live = _read_http_ua_settings(ident.region, ident.instance_id, f"edge {eid}")
+        except SystemExit:
+            items.append({"node": f"edge:{eid}", "field": "*", "status": "error",
+                          "warning": f"could not read settings for edge {eid}"})
+            continue
+        items.extend(_http_ua_drift_items(f"edge:{eid}", live, expected))
+    try:
+        prod_inst = resolve_instance_id(PROD_TARGET["region"], PROD_TARGET["stack"])
+        prod_live = _read_http_ua_settings(PROD_TARGET["region"], prod_inst, "prod")
+        items.extend(_http_ua_drift_items("prod", prod_live, expected))
+    except SystemExit:
+        items.append({"node": "prod", "field": "*", "status": "error",
+                      "warning": "could not resolve / read settings for prod"})
+    return items
+
+
 def cmd_check(args: argparse.Namespace) -> int:
     snapshot = load_json_file(pathlib.Path(args.snapshot), "snapshot") if args.snapshot else None
     edge_ids = _edge_ids_for_check(snapshot, bool(args.allow_planned))
@@ -1208,8 +1337,22 @@ def cmd_check(args: argparse.Namespace) -> int:
         "error_count": sum(1 for x in tier_items if x.get("status") == "error"),
         "items": tier_items,
     }
+    # http_ua_drift: live settings UA + mimicry manifest vs baseline JSON.
+    # Always live (UA is updated out of band from snapshot; a stale snapshot is
+    # exactly how the blind spot hid).
+    http_ua_expected = _load_http_mimicry_baseline()
+    http_ua_items = _run_http_ua_checks_live(edge_ids, http_ua_expected)
+    http_ua_violation = any(x.get("status") in ("drift", "error") for x in http_ua_items)
+    report["http_ua_drift"] = {
+        "policy_source": HTTP_MIMICRY_BASELINES.name,
+        "expected_cc_version": str(http_ua_expected["cc_version"]).strip(),
+        "violation_count": sum(1 for x in http_ua_items if x.get("status") == "drift"),
+        "error_count": sum(1 for x in http_ua_items if x.get("status") == "error"),
+        "items": http_ua_items,
+    }
     report["any_violation"] = (
-        bool(report.get("any_violation")) or balance_violation or balance_error or tier_table_violation
+        bool(report.get("any_violation")) or balance_violation or balance_error
+        or tier_table_violation or http_ua_violation
     )
     if args.json:
         print(json.dumps(report, indent=2, ensure_ascii=False))
@@ -1217,7 +1360,8 @@ def cmd_check(args: argparse.Namespace) -> int:
         any_violation = report.get("any_violation")
         print(f"check: any_violation={any_violation} guards_run={len(report.get('guards', []))} "
               f"edges={edge_ids} balance_violations={report['operator_balance']['violation_count']} "
-              f"tier_table_drift={report['tier_table_drift']['violation_count']}")
+              f"tier_table_drift={report['tier_table_drift']['violation_count']} "
+              f"http_ua_drift={report['http_ua_drift']['violation_count']}")
         for sr in report.get("guards", []):
             ec = sr.get("exit_code")
             status = "OK" if ec == 0 else (sr.get("skipped_reason", "?") if ec is None else f"FAIL exit={ec}")
@@ -1231,6 +1375,8 @@ def cmd_check(args: argparse.Namespace) -> int:
                 print(f"  [BALANCE-ERR] edge={item['edge_id']}: {item.get('reason')}")
         for item in tier_items:
             print(f"  [TIER-{item.get('status', '?').upper()}] {item.get('warning')}")
+        for item in http_ua_items:
+            print(f"  [UA-{item.get('status', '?').upper()}] {item.get('warning')}")
     return 1 if report.get("any_violation") else 0
 
 

--- a/ops/anthropic/test_manage_anthropic_config_runtime_sync.py
+++ b/ops/anthropic/test_manage_anthropic_config_runtime_sync.py
@@ -139,5 +139,80 @@ class GuardDriftPlanTest(unittest.TestCase):
             self.assertTrue(plan["intent"]["force_template_rewrite"])
 
 
+class HttpUaDriftTest(unittest.TestCase):
+    """Live HTTP UA / mimicry-manifest drift comparison (the check blind spot
+    that let the fleet run a stale cc UA while `check` stayed green)."""
+
+    EXPECTED = {
+        "cc_version": "2.1.159",
+        "sonnet_opus": ["claude-code-20250219", "oauth-2025-04-20"],
+        "haiku": ["oauth-2025-04-20"],
+    }
+
+    def _manifest(self, **over) -> str:
+        m = {
+            "schema_version": 1,
+            "cc_version": self.EXPECTED["cc_version"],
+            "sonnet_opus": list(self.EXPECTED["sonnet_opus"]),
+            "haiku": list(self.EXPECTED["haiku"]),
+        }
+        m.update(over)
+        return json.dumps(m, separators=(",", ":"))
+
+    def test_in_sync_no_drift(self) -> None:
+        live = {
+            "claude_code_user_agent_version": "2.1.159",
+            "claude_code_http_mimicry_manifest": self._manifest(),
+        }
+        self.assertEqual([], mgr._http_ua_drift_items("edge:us1", live, self.EXPECTED))
+
+    def test_stale_ua_version_is_drift(self) -> None:
+        live = {
+            "claude_code_user_agent_version": "2.1.158",  # stale — the real incident
+            "claude_code_http_mimicry_manifest": self._manifest(),
+        }
+        items = mgr._http_ua_drift_items("edge:us1", live, self.EXPECTED)
+        self.assertEqual(1, len(items))
+        self.assertEqual("drift", items[0]["status"])
+        self.assertEqual("claude_code_user_agent_version", items[0]["field"])
+        self.assertEqual("2.1.158", items[0]["actual"])
+
+    def test_unset_ua_is_drift(self) -> None:
+        items = mgr._http_ua_drift_items("prod", {}, self.EXPECTED)
+        # both UA and manifest unset -> two drift items
+        fields = {i["field"] for i in items}
+        self.assertEqual(
+            {"claude_code_user_agent_version", "claude_code_http_mimicry_manifest"}, fields
+        )
+        self.assertTrue(all(i["status"] == "drift" for i in items))
+
+    def test_manifest_cc_version_drift(self) -> None:
+        live = {
+            "claude_code_user_agent_version": "2.1.159",
+            "claude_code_http_mimicry_manifest": self._manifest(cc_version="2.1.158"),
+        }
+        items = mgr._http_ua_drift_items("edge:us1", live, self.EXPECTED)
+        self.assertEqual(1, len(items))
+        self.assertEqual("claude_code_http_mimicry_manifest", items[0]["field"])
+
+    def test_manifest_beta_set_drift(self) -> None:
+        live = {
+            "claude_code_user_agent_version": "2.1.159",
+            "claude_code_http_mimicry_manifest": self._manifest(haiku=["oauth-2025-04-20", "extra-beta"]),
+        }
+        items = mgr._http_ua_drift_items("edge:us1", live, self.EXPECTED)
+        self.assertEqual(1, len(items))
+        self.assertIn("haiku", items[0]["warning"])
+
+    def test_manifest_invalid_json_is_drift(self) -> None:
+        live = {
+            "claude_code_user_agent_version": "2.1.159",
+            "claude_code_http_mimicry_manifest": "{not-json",
+        }
+        items = mgr._http_ua_drift_items("edge:us1", live, self.EXPECTED)
+        self.assertEqual(1, len(items))
+        self.assertEqual("drift", items[0]["status"])
+
+
 if __name__ == "__main__":
     unittest.main()


### PR DESCRIPTION
## What

`manage-anthropic-config.py check` verified tier values, TLS fingerprint profile, operator balance, and tier-table drift — but **never read live `settings.claude_code_user_agent_version` / `claude_code_http_mimicry_manifest`**. So `check` could return all-green while the fleet's live UA was a stale cc version.

**This actually happened (2026-06):** after #482 merged (baseline → 2.1.159) the fleet's live UA stayed on 2.1.158 until a manual `sync-runtime`, and `check` was green the whole time. The two most fingerprint-critical runtime knobs were the check's blind spot.

## Changes

- **`http_ua_drift` surface in `cmd_check`** — mirrors the existing `operator_balance` / `tier_table_drift` surfaces:
  - `SETTINGS_UA_SQL` reads the two setting keys via `jsonb_object_agg` (field name beside value), the same keys `sync-runtime` writes.
  - `_read_http_ua_settings` / `_http_ua_drift_items` / `_run_http_ua_checks_live` — compare live UA + manifest (`cc_version` + `sonnet_opus` + `haiku`) against the single-source baseline JSON. Drift or SSM error counts into `any_violation` (same as tier/balance).
  - **Always reads live, even with `--snapshot`** — UA is a deploy-level runtime knob updated out of band from snapshot; a stale snapshot is exactly how the blind spot hid.
  - `cmd_check` summary gains `http_ua_drift={n}`; report gains `http_ua_drift`.
- **6 stdlib-only unit tests** (in-sync / stale UA / unset / manifest cc_version / manifest beta-set / invalid JSON), run by the existing preflight ops suite.
- **skill `tokenkey-anthropic-oauth-config`**: check stage documents `http_ua_drift` coverage + the "forgot `sync-runtime` after cc bump" failure mode.

## Scope note

TLS drift was **already** covered (the guard JOINs `tls_fingerprint_profiles` and diffs `tls_profile`) — this PR adds only the UA half, **not** a duplicate TLS gate.

## Why

Answers the operator question: *"配置检查应该把 TLS 指纹模板和 HTTP UA 纳入，这些是最关键的配置。"* TLS was already in; HTTP UA was the genuine gap. A "config check" that omits the live UA is a false-green — worse than a hard error because it stops the operator from looking.

## Validation

- `python3 ops/anthropic/test_manage_anthropic_config_runtime_sync.py` — 14 tests pass (6 new)
- module import + `SETTINGS_UA_SQL` present + helpers wired
- `scripts/preflight.sh` — PASS (ops/anthropic unittest suite runs the new tests)
- live `check` against the fleet (read-only, needs AWS) expected `http_ua_drift=0` now that the fleet was synced to 2.1.159

no-web-impact

🤖 Generated with [Claude Code](https://claude.com/claude-code)