### PR TITLE
feat(newapi): Vertex(ch41) bridge + provider-prefix pricing + veo per-second billing

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -27,10 +27,15 @@ WORKDIR /build/sub2api/frontend
 
 # Install pnpm and Python used by the frontend freshness manifest step.
 # Python is TK-specific: scripts/checks/frontend-dist-freshness.py runs during
-# the frontend build to fail-fast on stale embedded dist. pnpm@latest keeps the
-# image aligned with the maintainer's local toolchain — pnpm-lock.yaml shape is
-# the actual reproducibility anchor (`pnpm install --frozen-lockfile` below).
-RUN apk add --no-cache python3 && corepack enable && corepack prepare pnpm@latest --activate
+# the frontend build to fail-fast on stale embedded dist.
+# pnpm is pinned to major 9 to match CI (.github/workflows/backend-ci.yml uses
+# pnpm/action-setup version: 9) and pnpm-lock.yaml (lockfileVersion 9.0). Do NOT
+# use pnpm@latest: pnpm 10 stopped reading package.json's `pnpm.overrides`
+# (it moved to a top-level `overrides` / pnpm-workspace.yaml), so the still-present
+# `pnpm.overrides` block makes `pnpm install --frozen-lockfile` below hard-fail with
+# ERR_PNPM_LOCKFILE_CONFIG_MISMATCH. The lockfile is the reproducibility anchor; the
+# pnpm major must match the version that produced it.
+RUN apk add --no-cache python3 && corepack enable && corepack prepare pnpm@9 --activate
 
 # Install dependencies first (better caching)
 COPY sub2api/frontend/package.json sub2api/frontend/pnpm-lock.yaml ./

--- a/backend/internal/handler/openai_gateway_tk_video.go
+++ b/backend/internal/handler/openai_gateway_tk_video.go
@@ -212,13 +212,19 @@ func (h *OpenAIGatewayHandler) VideoSubmit(c *gin.Context) {
 
 	userAgent := c.GetHeader("User-Agent")
 	clientIP := ip.GetClientIP(c)
+	// Per-second video billing (veo etc.): we record at submit using the requested
+	// duration (default 8s) rather than at fetch — the submit path already holds the
+	// full billing context (apiKey/user/account/subscription), and 8s is veo's
+	// conservative max so we never under-charge when the field is omitted.
+	videoSeconds := videoRequestedSeconds(body)
 	h.submitUsageRecordTask(c.Request.Context(), func(ctx context.Context) {
 		if err := h.gatewayService.RecordUsage(ctx, &service.OpenAIRecordUsageInput{
 			Result: &service.OpenAIForwardResult{
-				Model:         outcome.OriginModel,
-				UpstreamModel: outcome.UpstreamModel,
-				Stream:        false,
-				Duration:      outcome.Duration,
+				Model:                outcome.OriginModel,
+				UpstreamModel:        outcome.UpstreamModel,
+				Stream:               false,
+				Duration:             outcome.Duration,
+				VideoDurationSeconds: &videoSeconds,
 			},
 			APIKey:           apiKey,
 			User:             apiKey.User,
@@ -329,4 +335,27 @@ func (h *OpenAIGatewayHandler) VideoFetch(c *gin.Context) {
 // upstream's id) when surfaced in logs and dashboards.
 func generateVideoTaskID() string {
 	return "vt_" + strings.ReplaceAll(uuid.NewString(), "-", "")
+}
+
+// videoRequestedSeconds extracts the requested video duration (seconds) from an
+// OpenAI-compat video request body, trying the common field spellings. Falls back to a
+// conservative 8s (veo's max) so per-second billing never under-charges when the client
+// omits the field; clamped to a sane [1,60] range.
+func videoRequestedSeconds(body []byte) int64 {
+	for _, key := range []string{"seconds", "duration_seconds", "duration"} {
+		r := gjson.GetBytes(body, key)
+		if !r.Exists() {
+			continue
+		}
+		// Float() parses both JSON numbers and numeric strings ("6"); round to nearest
+		// so fractional durations bill up rather than truncate down.
+		if f := r.Float(); f > 0 {
+			n := int64(f + 0.5)
+			if n > 60 {
+				n = 60
+			}
+			return n
+		}
+	}
+	return 8
 }

--- a/backend/internal/handler/openai_gateway_tk_video_test.go
+++ b/backend/internal/handler/openai_gateway_tk_video_test.go
@@ -109,3 +109,24 @@ func TestVideoFetch_MissingTaskID_Returns400(t *testing.T) {
 		t.Fatalf("expected 400, got %d", w.Code)
 	}
 }
+
+func TestVideoRequestedSeconds(t *testing.T) {
+	cases := []struct {
+		body string
+		want int64
+	}{
+		{`{"model":"veo-3.1-generate-preview","prompt":"x"}`, 8}, // default
+		{`{"seconds":4}`, 4},          // numeric
+		{`{"seconds":"6"}`, 6},        // string numeric
+		{`{"duration_seconds":5}`, 5}, // alt key
+		{`{"duration":3}`, 3},         // alt key
+		{`{"seconds":120}`, 60},       // clamp upper
+		{`{"seconds":0}`, 8},          // non-positive → default
+		{`{"seconds":4.6}`, 5},        // float rounds
+	}
+	for _, c := range cases {
+		if got := videoRequestedSeconds([]byte(c.body)); got != c.want {
+			t.Errorf("videoRequestedSeconds(%s)=%d want %d", c.body, got, c.want)
+		}
+	}
+}

--- a/backend/internal/relay/bridge/context_input.go
+++ b/backend/internal/relay/bridge/context_input.go
@@ -6,6 +6,7 @@ import (
 
 	newapicommon "github.com/QuantumNous/new-api/common"
 	newapiconstant "github.com/QuantumNous/new-api/constant"
+	newapidto "github.com/QuantumNous/new-api/dto"
 	"github.com/gin-gonic/gin"
 )
 
@@ -32,6 +33,13 @@ type ChannelContextInput struct {
 	// UserGroup / UsingGroup optional, for affinity/logging alignment.
 	UserGroup  string
 	UsingGroup string
+	// VertexKeyType selects how new-api's VertexAI adaptor (channel_type 41) authenticates:
+	// "json" = service-account JSON (APIKey carries the SA JSON), "api_key" = plain key.
+	// Empty leaves new-api's default; only set for channel_type 41 service-account accounts.
+	VertexKeyType string
+	// VertexLocation is the Vertex region (e.g. "us-central1") read by new-api as ApiVersion
+	// for channel_type 41 (see InitChannelMeta: ApiVersion = c.GetString("region")).
+	VertexLocation string
 }
 
 // PopulateContextKeys sets New API constant context keys on the Gin context so GenRelayInfo / InitChannelMeta work.
@@ -62,6 +70,20 @@ func PopulateContextKeys(c *gin.Context, in ChannelContextInput) {
 	}
 	if in.StatusCodeMappingJSON != "" && in.StatusCodeMappingJSON != "{}" {
 		c.Set("status_code_mapping", in.StatusCodeMappingJSON)
+	}
+
+	// VertexAI (channel_type 41) service-account passthrough: new-api's InitChannelMeta
+	// reads VertexKeyType from ContextKeyChannelOtherSetting and the region from the
+	// "region" gin key. The SA JSON itself rides on ContextKeyChannelKey (in.APIKey).
+	if in.VertexKeyType != "" {
+		keyType := newapidto.VertexKeyTypeAPIKey
+		if in.VertexKeyType == string(newapidto.VertexKeyTypeJSON) {
+			keyType = newapidto.VertexKeyTypeJSON
+		}
+		newapicommon.SetContextKey(c, newapiconstant.ContextKeyChannelOtherSetting, newapidto.ChannelOtherSettings{VertexKeyType: keyType})
+	}
+	if in.VertexLocation != "" {
+		c.Set("region", in.VertexLocation)
 	}
 }
 

--- a/backend/internal/relay/bridge/dispatch.go
+++ b/backend/internal/relay/bridge/dispatch.go
@@ -43,6 +43,10 @@ type DispatchOutcome struct {
 	Duration        time.Duration
 	AdaptorRelayFmt types.RelayFormat
 	AdaptorAPIType  int
+	// ImageCount is the number of images requested (image generations only, default 1).
+	// Propagated so the gateway bills per-image (output_cost_per_image) instead of by
+	// tokens; without it imagen via the bridge silently falls back to token billing.
+	ImageCount int
 }
 
 func installBodyStorage(c *gin.Context, body []byte) error {
@@ -244,6 +248,11 @@ func DispatchImageGenerations(_ context.Context, c *gin.Context, in ChannelConte
 		apiType = relayInfo.ApiType
 	}
 
+	imageCount := 1
+	if req.N != nil && *req.N > 0 {
+		imageCount = int(*req.N)
+	}
+
 	return &DispatchOutcome{
 		Usage:           usage,
 		Model:           req.Model,
@@ -252,6 +261,7 @@ func DispatchImageGenerations(_ context.Context, c *gin.Context, in ChannelConte
 		Duration:        dur,
 		AdaptorRelayFmt: types.RelayFormatOpenAIImage,
 		AdaptorAPIType:  apiType,
+		ImageCount:      imageCount,
 	}, nil
 }
 

--- a/backend/internal/service/billing_service.go
+++ b/backend/internal/service/billing_service.go
@@ -924,6 +924,33 @@ func (s *BillingService) getImageUnitPrice(model string, imageSize string, group
 	return s.getDefaultImagePrice(model, normalizedSize)
 }
 
+// CalculateVideoCost prices a video generation as duration(seconds) × per-second rate,
+// where the per-second rate comes from the LiteLLM table (e.g. veo `output_cost_per_second`,
+// resolved via the provider-prefix fallback in GetModelPricing). Callers pass the requested
+// duration (handlers default to a conservative 8s when the request omits it). When no
+// per-second price exists the cost is zero — an unpriced model must never block the request,
+// and the real spend ceiling is the upstream provider budget, not this internal estimate.
+func (s *BillingService) CalculateVideoCost(model string, seconds int64, rateMultiplier float64) *CostBreakdown {
+	if seconds <= 0 {
+		seconds = 1
+	}
+	perSecond := 0.0
+	if s.pricingService != nil {
+		if pricing := s.pricingService.GetModelPricing(model); pricing != nil {
+			perSecond = pricing.OutputCostPerSecond
+		}
+	}
+	totalCost := perSecond * float64(seconds)
+	if rateMultiplier < 0 {
+		rateMultiplier = 0
+	}
+	return &CostBreakdown{
+		TotalCost:   totalCost,
+		ActualCost:  totalCost * rateMultiplier,
+		BillingMode: "video",
+	}
+}
+
 // getDefaultImagePrice 获取 LiteLLM 默认图片价格
 func (s *BillingService) getDefaultImagePrice(model string, imageSize string) float64 {
 	basePrice := 0.0

--- a/backend/internal/service/billing_service_video_test.go
+++ b/backend/internal/service/billing_service_video_test.go
@@ -1,0 +1,50 @@
+//go:build unit
+
+package service
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/require"
+)
+
+func TestCalculateVideoCost_PerSecondFromLiteLLM(t *testing.T) {
+	svc := &BillingService{
+		pricingService: &PricingService{
+			pricingData: map[string]*LiteLLMModelPricing{
+				// provider-prefixed key; bare name resolves via GetModelPricing fallback
+				"gemini/veo-3.1-generate-preview": {OutputCostPerSecond: 0.40, Mode: "video_generation"},
+			},
+		},
+	}
+
+	// 8s × $0.40 = $3.20
+	cost := svc.CalculateVideoCost("veo-3.1-generate-preview", 8, 1.0)
+	require.InDelta(t, 3.20, cost.TotalCost, 1e-9)
+	require.InDelta(t, 3.20, cost.ActualCost, 1e-9)
+	require.Equal(t, "video", cost.BillingMode)
+
+	// rate multiplier applies to ActualCost only
+	cost = svc.CalculateVideoCost("veo-3.1-generate-preview", 4, 2.0)
+	require.InDelta(t, 1.60, cost.TotalCost, 1e-9)
+	require.InDelta(t, 3.20, cost.ActualCost, 1e-9)
+}
+
+func TestCalculateVideoCost_UnpricedModelIsZeroNotBlocking(t *testing.T) {
+	svc := &BillingService{pricingService: &PricingService{pricingData: map[string]*LiteLLMModelPricing{}}}
+	cost := svc.CalculateVideoCost("veo-unknown-model", 8, 1.0)
+	require.Zero(t, cost.TotalCost)
+	require.Zero(t, cost.ActualCost)
+}
+
+func TestCalculateVideoCost_NonPositiveSecondsClampedToOne(t *testing.T) {
+	svc := &BillingService{
+		pricingService: &PricingService{
+			pricingData: map[string]*LiteLLMModelPricing{
+				"gemini/veo-3.1-generate-preview": {OutputCostPerSecond: 0.40},
+			},
+		},
+	}
+	cost := svc.CalculateVideoCost("veo-3.1-generate-preview", 0, 1.0)
+	require.InDelta(t, 0.40, cost.TotalCost, 1e-9) // clamped to 1s
+}

--- a/backend/internal/service/newapi_bridge_usage.go
+++ b/backend/internal/service/newapi_bridge_usage.go
@@ -4,6 +4,7 @@ import (
 	"encoding/json"
 	"strings"
 
+	newapiconstant "github.com/QuantumNous/new-api/constant"
 	"github.com/QuantumNous/new-api/dto"
 	newapitypes "github.com/QuantumNous/new-api/types"
 	newapiintegration "github.com/Wei-Shaw/sub2api/internal/integration/newapi"
@@ -83,6 +84,21 @@ func newAPIBridgeChannelInput(account *Account, userID int64, groupLabel string)
 	// effectively disable the feature, mirroring upstream new-api semantics.
 	organization := strings.TrimSpace(account.GetCredential("openai_organization"))
 	statusCodeMappingJSON := strings.TrimSpace(account.GetCredential("status_code_mapping"))
+
+	// VertexAI (channel_type 41) service-account: forward the SA JSON as the channel key
+	// and signal new-api's adaptor to use JWT auth + the account's region. The Gemini
+	// Developer API (channel_type 24, plain API key) needs none of this. project_id is
+	// derived by new-api from the SA JSON, so it is not passed separately.
+	vertexKeyType := ""
+	vertexLocation := ""
+	if account.ChannelType == newapiconstant.ChannelTypeVertexAi && account.IsVertexServiceAccount() {
+		if saJSON := account.VertexServiceAccountJSON(); saJSON != "" {
+			apiKey = saJSON
+			vertexKeyType = string(dto.VertexKeyTypeJSON)
+			vertexLocation = account.VertexLocation("")
+		}
+	}
+
 	return bridge.ChannelContextInput{
 		ChannelType:           account.ChannelType,
 		ChannelID:             int(account.ID),
@@ -94,5 +110,7 @@ func newAPIBridgeChannelInput(account *Account, userID int64, groupLabel string)
 		UserID:                int(userID),
 		UserGroup:             groupLabel,
 		UsingGroup:            groupLabel,
+		VertexKeyType:         vertexKeyType,
+		VertexLocation:        vertexLocation,
 	}
 }

--- a/backend/internal/service/newapi_bridge_usage_test.go
+++ b/backend/internal/service/newapi_bridge_usage_test.go
@@ -96,3 +96,55 @@ func TestNewAPIBridgeChannelInput_OmitsEmptyForwardingCredentials(t *testing.T) 
 		t.Fatalf("StatusCodeMappingJSON should be empty when not configured, got %q", in.StatusCodeMappingJSON)
 	}
 }
+
+// TestNewAPIBridgeChannelInput_VertexServiceAccount pins #0: a channel_type 41
+// (VertexAI) account with a service-account JSON forwards the SA JSON as the channel
+// key, signals VertexKeyType=json, and carries the account's region — so new-api's
+// Vertex adaptor authenticates via JWT against Cloud Billing (the only way the GCP
+// trial credit is spendable; the Gemini Developer API ch24 prepay path does not accept it).
+func TestNewAPIBridgeChannelInput_VertexServiceAccount(t *testing.T) {
+	saJSON := `{"type":"service_account","project_id":"tk-proj","client_email":"x@tk-proj.iam.gserviceaccount.com","private_key":"-----BEGIN PRIVATE KEY-----\nAAA\n-----END PRIVATE KEY-----\n"}`
+	account := &Account{
+		ID:          9,
+		Platform:    PlatformNewAPI,
+		Type:        AccountTypeServiceAccount,
+		ChannelType: 41,
+		Credentials: map[string]any{
+			"base_url":             "https://us-central1-aiplatform.googleapis.com",
+			"service_account_json": saJSON,
+			"location":             "us-central1",
+		},
+	}
+	in := newAPIBridgeChannelInput(account, 1, "google")
+	if in.ChannelType != 41 {
+		t.Fatalf("ChannelType: want 41, got %d", in.ChannelType)
+	}
+	if in.VertexKeyType != "json" {
+		t.Fatalf("VertexKeyType: want json, got %q", in.VertexKeyType)
+	}
+	if in.VertexLocation != "us-central1" {
+		t.Fatalf("VertexLocation: want us-central1, got %q", in.VertexLocation)
+	}
+	if in.APIKey != saJSON {
+		t.Fatalf("APIKey must carry the service-account JSON, got %q", in.APIKey)
+	}
+}
+
+// TestNewAPIBridgeChannelInput_NonVertexUntouched ensures a non-vertex account (ch24,
+// plain api_key) gets no SA passthrough (VertexKeyType empty, api_key intact).
+func TestNewAPIBridgeChannelInput_NonVertexUntouched(t *testing.T) {
+	account := &Account{
+		ID:          10,
+		Platform:    PlatformNewAPI,
+		Type:        AccountTypeAPIKey,
+		ChannelType: 24,
+		Credentials: map[string]any{"base_url": "https://generativelanguage.googleapis.com", "api_key": "sk-x"},
+	}
+	in := newAPIBridgeChannelInput(account, 1, "google")
+	if in.VertexKeyType != "" {
+		t.Fatalf("VertexKeyType must be empty for non-vertex, got %q", in.VertexKeyType)
+	}
+	if in.APIKey != "sk-x" {
+		t.Fatalf("APIKey: want sk-x, got %q", in.APIKey)
+	}
+}

--- a/backend/internal/service/openai_gateway_bridge_dispatch.go
+++ b/backend/internal/service/openai_gateway_bridge_dispatch.go
@@ -245,5 +245,8 @@ func (s *OpenAIGatewayService) ForwardAsImageGenerationsDispatched(
 		Stream:        false,
 		Duration:      out.Duration,
 		Usage:         openAIUsageFromNewAPIDTO(out.Usage),
+		// Drives per-image billing (output_cost_per_image); without it imagen via the
+		// bridge silently bills by tokens. See bridge.DispatchOutcome.ImageCount.
+		ImageCount: out.ImageCount,
 	}, nil
 }

--- a/backend/internal/service/openai_gateway_service.go
+++ b/backend/internal/service/openai_gateway_service.go
@@ -230,19 +230,22 @@ type OpenAIForwardResult struct {
 	ServiceTier *string
 	// ReasoningEffort is extracted from request body (reasoning.effort) or derived from model suffix.
 	// Stored for usage records display; nil means not provided / not applicable.
-	ReasoningEffort    *string
-	Stream             bool
-	OpenAIWSMode       bool
-	ResponseHeaders    http.Header
-	Duration           time.Duration
-	FirstTokenMs       *int
-	ImageCount         int
-	ImageSize          string
-	ImageInputSize     string
-	ImageOutputSize    string
-	ImageOutputSizes   []string
-	ImageSizeSource    string
-	ImageSizeBreakdown map[string]int
+	ReasoningEffort  *string
+	Stream           bool
+	OpenAIWSMode     bool
+	ResponseHeaders  http.Header
+	Duration         time.Duration
+	FirstTokenMs     *int
+	ImageCount       int
+	ImageSize        string
+	ImageInputSize   string
+	ImageOutputSize  string
+	ImageOutputSizes []string
+	ImageSizeSource  string
+	// VideoDurationSeconds, when set (>0), routes cost to per-second video billing
+	// (veo etc.). Handlers populate it from the submit request's duration (default 8s).
+	VideoDurationSeconds *int64
+	ImageSizeBreakdown   map[string]int
 	// StopReason is the Anthropic-shaped stop reason returned to the client
 	// ("end_turn" / "max_tokens" / "tool_use"). Recorded for the access log
 	// so we can verify that "incomplete" upstream responses surface as
@@ -6109,6 +6112,9 @@ func (s *OpenAIGatewayService) calculateOpenAIRecordUsageCost(
 	serviceTier string,
 ) (*CostBreakdown, error) {
 	billingModel := firstUsageBillingModel(billingModels)
+	if result != nil && result.VideoDurationSeconds != nil && *result.VideoDurationSeconds > 0 {
+		return s.calculateOpenAIVideoCost(billingModel, *result.VideoDurationSeconds, multiplier), nil
+	}
 	if result != nil && result.ImageCount > 0 {
 		return s.calculateOpenAIImageCost(ctx, billingModel, apiKey, result, imageMultiplier), nil
 	}
@@ -6166,6 +6172,18 @@ func (s *OpenAIGatewayService) calculateOpenAIRecordUsageTokenCost(
 		})
 	}
 	return s.billingService.CalculateCostWithServiceTier(billingModel, tokens, multiplier, serviceTier)
+}
+
+// calculateOpenAIVideoCost prices async video generation (veo) per second. Duration comes
+// from the submit request (default 8s); the per-second rate is resolved from the LiteLLM
+// table. Mirrors calculateOpenAIImageCost's zero-cost-on-missing-price posture so an
+// unpriced video model never blocks the request.
+func (s *OpenAIGatewayService) calculateOpenAIVideoCost(
+	billingModel string,
+	seconds int64,
+	multiplier float64,
+) *CostBreakdown {
+	return s.billingService.CalculateVideoCost(billingModel, seconds, multiplier)
 }
 
 func (s *OpenAIGatewayService) calculateOpenAIImageCost(

--- a/backend/internal/service/pricing_service.go
+++ b/backend/internal/service/pricing_service.go
@@ -73,6 +73,7 @@ type LiteLLMModelPricing struct {
 	SupportsPromptCaching               bool    `json:"supports_prompt_caching"`
 	OutputCostPerImage                  float64 `json:"output_cost_per_image"`       // 图片生成模型每张图片价格
 	OutputCostPerImageToken             float64 `json:"output_cost_per_image_token"` // 图片输出 token 价格
+	OutputCostPerSecond                 float64 `json:"output_cost_per_second"`      // 视频生成模型每秒价格（veo 等）
 }
 
 // PricingRemoteClient 远程价格数据获取接口
@@ -97,6 +98,7 @@ type LiteLLMRawEntry struct {
 	SupportsPromptCaching               bool     `json:"supports_prompt_caching"`
 	OutputCostPerImage                  *float64 `json:"output_cost_per_image"`
 	OutputCostPerImageToken             *float64 `json:"output_cost_per_image_token"`
+	OutputCostPerSecond                 *float64 `json:"output_cost_per_second"`
 }
 
 // PricingService 动态价格服务
@@ -372,8 +374,12 @@ func (s *PricingService) parsePricingData(body []byte) (map[string]*LiteLLMModel
 			continue
 		}
 
-		// 只保留有有效价格的条目
-		if entry.InputCostPerToken == nil && entry.OutputCostPerToken == nil {
+		// 只保留有有效价格的条目。除 token 价外，也保留纯图片(每图/每图token)与
+		// 纯视频(每秒)模型 —— 否则 imagen-4.0-* / veo-* 这类无 token 价的条目会被整体丢弃，
+		// 导致下游按裸名匹配时根本找不到（命中错误兜底价）。
+		if entry.InputCostPerToken == nil && entry.OutputCostPerToken == nil &&
+			entry.OutputCostPerImage == nil && entry.OutputCostPerImageToken == nil &&
+			entry.OutputCostPerSecond == nil {
 			continue
 		}
 
@@ -413,6 +419,9 @@ func (s *PricingService) parsePricingData(body []byte) (map[string]*LiteLLMModel
 		}
 		if entry.OutputCostPerImageToken != nil {
 			pricing.OutputCostPerImageToken = *entry.OutputCostPerImageToken
+		}
+		if entry.OutputCostPerSecond != nil {
+			pricing.OutputCostPerSecond = *entry.OutputCostPerSecond
 		}
 
 		result[modelName] = pricing
@@ -575,7 +584,57 @@ func (s *PricingService) GetModelPricing(modelName string) *LiteLLMModelPricing 
 		return s.matchOpenAIModel(lookupCandidates[0])
 	}
 
+	// 6. Provider-prefixed 回退：裸名（如 "imagen-4.0-generate-001" / "veo-3.1-generate-preview"）
+	// 匹配 LiteLLM 表里带 provider 前缀的 key（"gemini/imagen-4.0-generate-001"、
+	// "vertex_ai/imagen-4.0-generate-001"）。多 provider 命中时取最高单价，计费保守不少收。
+	if pricing := s.matchByProviderPrefix(lookupCandidates[0]); pricing != nil {
+		return pricing
+	}
+
 	return nil
+}
+
+// matchByProviderPrefix 用裸模型名匹配 LiteLLM 表里 "<provider>/.../<model>" 形态的 key
+// （按最后一段精确相等，兼容 "gemini/x" 与 "aiml/google/x" 这类多段前缀），命中多个时取最高价。
+// 仅扫描含 "/" 的 key（裸 key 已在精确匹配阶段尝试过），避免回退误配裸名条目。
+func (s *PricingService) matchByProviderPrefix(bareModel string) *LiteLLMModelPricing {
+	bareModel = strings.ToLower(strings.TrimSpace(bareModel))
+	if bareModel == "" {
+		return nil
+	}
+	var best *LiteLLMModelPricing
+	var bestCost float64
+	for key, pricing := range s.pricingData {
+		if pricing == nil || !strings.Contains(key, "/") {
+			continue
+		}
+		if lastSegment(strings.ToLower(key)) != bareModel {
+			continue
+		}
+		if cost := comparablePricingCost(pricing); best == nil || cost > bestCost {
+			best = pricing
+			bestCost = cost
+		}
+	}
+	return best
+}
+
+// comparablePricingCost 取一个可比单价用于在同名多 provider 变体间挑最高价。
+// 优先级：每图 > 每秒(视频) > 每输出 token > 每输入 token。
+func comparablePricingCost(p *LiteLLMModelPricing) float64 {
+	if p == nil {
+		return 0
+	}
+	if p.OutputCostPerImage > 0 {
+		return p.OutputCostPerImage
+	}
+	if p.OutputCostPerSecond > 0 {
+		return p.OutputCostPerSecond
+	}
+	if p.OutputCostPerToken > 0 {
+		return p.OutputCostPerToken
+	}
+	return p.InputCostPerToken
 }
 
 func (s *PricingService) buildModelLookupCandidates(modelLower string) []string {

--- a/backend/internal/service/pricing_service.go
+++ b/backend/internal/service/pricing_service.go
@@ -435,6 +435,10 @@ func (s *PricingService) parsePricingData(body []byte) (map[string]*LiteLLMModel
 		return nil, fmt.Errorf("no valid pricing entries found")
 	}
 
+	// TK: fill-only overlay for media (image/video) models the trimmed runtime source
+	// drops (imagen-*/veo-*). See pricing_service_tk_media_overlay.go.
+	applyTKMediaPricingOverlay(result)
+
 	return result, nil
 }
 
@@ -584,9 +588,10 @@ func (s *PricingService) GetModelPricing(modelName string) *LiteLLMModelPricing 
 		return s.matchOpenAIModel(lookupCandidates[0])
 	}
 
-	// 6. Provider-prefixed 回退：裸名（如 "imagen-4.0-generate-001" / "veo-3.1-generate-preview"）
-	// 匹配 LiteLLM 表里带 provider 前缀的 key（"gemini/imagen-4.0-generate-001"、
-	// "vertex_ai/imagen-4.0-generate-001"）。多 provider 命中时取最高单价，计费保守不少收。
+	// 6. Provider-prefixed 最后兜底：仅当运行时源恰好带前缀 key（"gemini/imagen-4.0-*"、
+	// "vertex_ai/imagen-4.0-*"）时才命中。注意这不是媒体计价的主路径——生产源（Wei-Shaw 镜像）
+	// 把这些前缀 key 全裁掉了，真正让 imagen-*/veo-* 解析出价的是 always-merged 的 TK overlay
+	// （见 pricing_service_tk_media_overlay.go），overlay 注入的裸名已在上面第 1 步 exact-match 命中。
 	if pricing := s.matchByProviderPrefix(lookupCandidates[0]); pricing != nil {
 		return pricing
 	}
@@ -619,8 +624,9 @@ func (s *PricingService) matchByProviderPrefix(bareModel string) *LiteLLMModelPr
 	return best
 }
 
-// comparablePricingCost 取一个可比单价用于在同名多 provider 变体间挑最高价。
-// 优先级：每图 > 每秒(视频) > 每输出 token > 每输入 token。
+// comparablePricingCost 取一个可比单价，仅用于第 6 步兜底里同名多 provider 变体的挑选。
+// 此处取最高价是「无法确定实际承接 provider 时的保守猜测」，不是计价语义的主张——主路径
+// （TK overlay）已固化按实际承接 provider（Vertex ch41）的价。优先级：每图 > 每秒(视频) > 每输出 token > 每输入 token。
 func comparablePricingCost(p *LiteLLMModelPricing) float64 {
 	if p == nil {
 		return 0

--- a/backend/internal/service/pricing_service_test.go
+++ b/backend/internal/service/pricing_service_test.go
@@ -287,3 +287,62 @@ func TestListModelNamesByProvider_EmptyCatalog(t *testing.T) {
 	require.NotNil(t, got)
 	require.Empty(t, got)
 }
+
+func TestGetModelPricing_BareNameMatchesProviderPrefixedHighestPrice(t *testing.T) {
+	svc := &PricingService{
+		pricingData: map[string]*LiteLLMModelPricing{
+			"gemini/imagen-4.0-generate-001":    {OutputCostPerImage: 0.04, Mode: "image_generation"},
+			"vertex_ai/imagen-4.0-generate-001": {OutputCostPerImage: 0.06, Mode: "image_generation"},
+		},
+	}
+	got := svc.GetModelPricing("imagen-4.0-generate-001")
+	require.NotNil(t, got)
+	// 多 provider 命中取最高价（保守计费）
+	require.InDelta(t, 0.06, got.OutputCostPerImage, 1e-12)
+}
+
+func TestGetModelPricing_BareNameMatchesMultiSegmentPrefix(t *testing.T) {
+	svc := &PricingService{
+		pricingData: map[string]*LiteLLMModelPricing{
+			"aiml/google/imagen-4.0-ultra-generate-001": {OutputCostPerImage: 0.05, Mode: "image_generation"},
+		},
+	}
+	got := svc.GetModelPricing("imagen-4.0-ultra-generate-001")
+	require.NotNil(t, got)
+	require.InDelta(t, 0.05, got.OutputCostPerImage, 1e-12)
+}
+
+func TestGetModelPricing_VideoBareNameMatchesPerSecondHighestPrice(t *testing.T) {
+	svc := &PricingService{
+		pricingData: map[string]*LiteLLMModelPricing{
+			"gemini/veo-3.1-generate-preview":    {OutputCostPerSecond: 0.40, Mode: "video_generation"},
+			"vertex_ai/veo-3.1-generate-preview": {OutputCostPerSecond: 0.30, Mode: "video_generation"},
+		},
+	}
+	got := svc.GetModelPricing("veo-3.1-generate-preview")
+	require.NotNil(t, got)
+	require.InDelta(t, 0.40, got.OutputCostPerSecond, 1e-12)
+}
+
+func TestGetModelPricing_ProviderPrefixFallbackNoFalseMatch(t *testing.T) {
+	svc := &PricingService{
+		pricingData: map[string]*LiteLLMModelPricing{
+			"gemini/imagen-4.0-generate-001": {OutputCostPerImage: 0.04},
+		},
+	}
+	require.Nil(t, svc.GetModelPricing("nonexistent-model-xyz"))
+}
+
+func TestParsePricingData_ParsesOutputCostPerSecond(t *testing.T) {
+	svc := &PricingService{}
+	data, err := svc.parsePricingData([]byte(`{
+		"gemini/veo-3.1-generate-preview": {
+			"output_cost_per_second": 0.4,
+			"litellm_provider": "gemini",
+			"mode": "video_generation"
+		}
+	}`))
+	require.NoError(t, err)
+	require.NotNil(t, data["gemini/veo-3.1-generate-preview"])
+	require.InDelta(t, 0.4, data["gemini/veo-3.1-generate-preview"].OutputCostPerSecond, 1e-12)
+}

--- a/backend/internal/service/pricing_service_test.go
+++ b/backend/internal/service/pricing_service_test.go
@@ -346,3 +346,45 @@ func TestParsePricingData_ParsesOutputCostPerSecond(t *testing.T) {
 	require.NotNil(t, data["gemini/veo-3.1-generate-preview"])
 	require.InDelta(t, 0.4, data["gemini/veo-3.1-generate-preview"].OutputCostPerSecond, 1e-12)
 }
+
+// TestParsePricingData_TKMediaOverlayMergesWhenSourceLacksMedia proves the
+// load-bearing production path: the runtime source (Wei-Shaw mirror) carries NO
+// imagen/veo entries at all — not bare, not provider-prefixed — yet imagen-*/veo-*
+// must still resolve to a real price via the always-merged TK overlay. This is what
+// makes the feature work in prod (matchByProviderPrefix has nothing to match there).
+func TestParsePricingData_TKMediaOverlayMergesWhenSourceLacksMedia(t *testing.T) {
+	svc := &PricingService{}
+	// Wei-Shaw-shaped source: only mainstream token models, no media, no "/" keys.
+	body := []byte(`{
+		"gpt-4o": {"input_cost_per_token": 0.0000025, "output_cost_per_token": 0.00001, "litellm_provider": "openai"},
+		"claude-3-7-sonnet-20250219": {"input_cost_per_token": 0.000003, "output_cost_per_token": 0.000015, "litellm_provider": "anthropic"}
+	}`)
+	pricingData, err := svc.parsePricingData(body)
+	require.NoError(t, err)
+	svc.pricingData = pricingData
+
+	img := svc.GetModelPricing("imagen-4.0-generate-001")
+	require.NotNil(t, img, "overlay must supply imagen even when the source lacks it")
+	require.Equal(t, "image_generation", img.Mode)
+	require.Greater(t, img.OutputCostPerImage, 0.0)
+
+	vid := svc.GetModelPricing("veo-3.1-generate-001")
+	require.NotNil(t, vid, "overlay must supply veo even when the source lacks it")
+	require.Equal(t, "video_generation", vid.Mode)
+	require.Greater(t, vid.OutputCostPerSecond, 0.0)
+}
+
+// TestParsePricingData_TKMediaOverlayIsFillOnly proves the overlay never overwrites
+// the loaded source: the day the source carries a bare media key natively, the source
+// value wins and the overlay entry is ignored (self-deprecating).
+func TestParsePricingData_TKMediaOverlayIsFillOnly(t *testing.T) {
+	svc := &PricingService{}
+	body := []byte(`{
+		"imagen-4.0-generate-001": {"output_cost_per_image": 0.99, "mode": "image_generation", "litellm_provider": "vertex_ai"}
+	}`)
+	pricingData, err := svc.parsePricingData(body)
+	require.NoError(t, err)
+	got := pricingData["imagen-4.0-generate-001"]
+	require.NotNil(t, got)
+	require.InDelta(t, 0.99, got.OutputCostPerImage, 1e-12) // source wins, not the overlay's value
+}

--- a/backend/internal/service/pricing_service_tk_media_overlay.go
+++ b/backend/internal/service/pricing_service_tk_media_overlay.go
@@ -1,0 +1,97 @@
+package service
+
+// TK media (image/video) pricing overlay.
+//
+// Why this exists: the production runtime price source (Wei-Shaw/model-price-repo)
+// is a TRIMMED mirror of litellm — it drops provider-prefixed keys
+// ("vertex_ai/imagen-4.0-generate-001") and token-less media entries entirely, so
+// imagen-*/veo-* resolve to nothing and fall back to a wrong default (imagen) or $0
+// (veo). litellm DOES carry these prices, but only under provider-prefixed keys, while
+// the lookup path normalizes toward bare names and never reconstructs a prefix. Rather
+// than open a second litellm sync pipeline (Wei-Shaw is already litellm-rooted — that
+// would be same-source redundancy), TokenKey owns this tiny curated overlay of the
+// handful of media models the mirror drops.
+//
+// Semantics: merged into every parsePricingData result (remote OR disk fallback) so the
+// entries are present regardless of source. fill-only — the loaded source is authoritative
+// and is never overwritten, so the overlay is self-deprecating: the day the source carries
+// a bare media key natively, the source value wins and the entry here is ignored. The
+// DB-backed ModelPricing override (model_pricing_resolver.go) still sits above everything.
+//
+// Price = vertex_ai provider (TK media traffic routes through Vertex ch41); see the JSON
+// _meta block for provenance. Adding a media model = one JSON line; if media models ever
+// proliferate, replace this with a provider-aware sync.
+
+import (
+	_ "embed"
+	"encoding/json"
+	"strings"
+	"sync"
+
+	"github.com/Wei-Shaw/sub2api/internal/pkg/logger"
+)
+
+//go:embed tk_media_pricing_overlay.json
+var tkMediaPricingOverlayRaw []byte
+
+var (
+	tkMediaPricingOverlayOnce sync.Once
+	tkMediaPricingOverlay     map[string]*LiteLLMModelPricing
+)
+
+// loadTKMediaPricingOverlay parses the embedded overlay once. It deliberately does NOT
+// call parsePricingData (that would recurse, since applyTKMediaPricingOverlay is invoked
+// from inside parsePricingData) — it parses the small fixed file directly. Keys starting
+// with "_" (e.g. "_meta") are provenance, not pricing, and are skipped.
+func loadTKMediaPricingOverlay() map[string]*LiteLLMModelPricing {
+	tkMediaPricingOverlayOnce.Do(func() {
+		var raw map[string]json.RawMessage
+		if err := json.Unmarshal(tkMediaPricingOverlayRaw, &raw); err != nil {
+			logger.LegacyPrintf("service.pricing", "[Pricing] TK media overlay parse failed: %v", err)
+			return
+		}
+		out := make(map[string]*LiteLLMModelPricing, len(raw))
+		for name, rawEntry := range raw {
+			if strings.HasPrefix(name, "_") {
+				continue
+			}
+			var e LiteLLMRawEntry
+			if err := json.Unmarshal(rawEntry, &e); err != nil {
+				continue
+			}
+			p := &LiteLLMModelPricing{LiteLLMProvider: e.LiteLLMProvider, Mode: e.Mode}
+			if e.OutputCostPerImage != nil {
+				p.OutputCostPerImage = *e.OutputCostPerImage
+			}
+			if e.OutputCostPerImageToken != nil {
+				p.OutputCostPerImageToken = *e.OutputCostPerImageToken
+			}
+			if e.OutputCostPerSecond != nil {
+				p.OutputCostPerSecond = *e.OutputCostPerSecond
+			}
+			if e.InputCostPerToken != nil {
+				p.InputCostPerToken = *e.InputCostPerToken
+			}
+			if e.OutputCostPerToken != nil {
+				p.OutputCostPerToken = *e.OutputCostPerToken
+			}
+			out[name] = p
+		}
+		tkMediaPricingOverlay = out
+	})
+	return tkMediaPricingOverlay
+}
+
+// applyTKMediaPricingOverlay fills in TK-owned media pricing for models the loaded source
+// does not already carry. fill-only by design (see file header).
+func applyTKMediaPricingOverlay(result map[string]*LiteLLMModelPricing) {
+	if result == nil {
+		return
+	}
+	for name, pricing := range loadTKMediaPricingOverlay() {
+		if _, ok := result[name]; ok {
+			continue
+		}
+		result[name] = pricing
+	}
+}

--- a/backend/internal/service/tk_media_pricing_overlay.json
+++ b/backend/internal/service/tk_media_pricing_overlay.json
@@ -1,0 +1,97 @@
+{
+  "_meta": {
+    "note": "TK-owned media (image/video) pricing overlay. fill-only: merged into PricingService AFTER any source load (Wei-Shaw remote OR disk fallback), and ONLY for keys the source does not already carry. The Wei-Shaw runtime mirror is a TRIMMED litellm mirror that drops provider-prefixed keys and token-less media entries, so imagen-*/veo-* resolve to nothing there. Price = vertex_ai provider (TK media flow routes through Vertex ch41); falls back to gemini only when no vertex variant exists. Self-deprecating: the day the source carries a bare key natively, the source value wins and the entry below is ignored.",
+    "provenance": "BerriAI/litellm model_prices_and_context_window.json, captured 2026-06-01",
+    "regen": "manual curation; no auto-sync (media models are few + slow-moving). If they proliferate, add provider-aware sync."
+  },
+  "imagen-3.0-capability-001": {
+    "litellm_provider": "vertex_ai",
+    "mode": "image_generation",
+    "output_cost_per_image": 0.04,
+    "source": "litellm:vertex_ai/imagen-3.0-capability-001"
+  },
+  "imagen-3.0-fast-generate-001": {
+    "litellm_provider": "vertex_ai",
+    "mode": "image_generation",
+    "output_cost_per_image": 0.02,
+    "source": "litellm:vertex_ai/imagen-3.0-fast-generate-001"
+  },
+  "imagen-3.0-generate-001": {
+    "litellm_provider": "vertex_ai",
+    "mode": "image_generation",
+    "output_cost_per_image": 0.04,
+    "source": "litellm:vertex_ai/imagen-3.0-generate-001"
+  },
+  "imagen-3.0-generate-002": {
+    "litellm_provider": "vertex_ai",
+    "mode": "image_generation",
+    "output_cost_per_image": 0.04,
+    "source": "litellm:vertex_ai/imagen-3.0-generate-002"
+  },
+  "imagen-4.0-fast-generate-001": {
+    "litellm_provider": "vertex_ai",
+    "mode": "image_generation",
+    "output_cost_per_image": 0.02,
+    "source": "litellm:vertex_ai/imagen-4.0-fast-generate-001"
+  },
+  "imagen-4.0-generate-001": {
+    "litellm_provider": "vertex_ai",
+    "mode": "image_generation",
+    "output_cost_per_image": 0.04,
+    "source": "litellm:vertex_ai/imagen-4.0-generate-001"
+  },
+  "imagen-4.0-ultra-generate-001": {
+    "litellm_provider": "vertex_ai",
+    "mode": "image_generation",
+    "output_cost_per_image": 0.06,
+    "source": "litellm:vertex_ai/imagen-4.0-ultra-generate-001"
+  },
+  "veo-2.0-generate-001": {
+    "litellm_provider": "vertex_ai",
+    "mode": "video_generation",
+    "output_cost_per_second": 0.35,
+    "source": "litellm:vertex_ai/veo-2.0-generate-001"
+  },
+  "veo-3.0-fast-generate-001": {
+    "litellm_provider": "vertex_ai",
+    "mode": "video_generation",
+    "output_cost_per_second": 0.15,
+    "source": "litellm:vertex_ai/veo-3.0-fast-generate-001"
+  },
+  "veo-3.0-generate-001": {
+    "litellm_provider": "vertex_ai",
+    "mode": "video_generation",
+    "output_cost_per_second": 0.4,
+    "source": "litellm:vertex_ai/veo-3.0-generate-001"
+  },
+  "veo-3.1-fast-generate-001": {
+    "litellm_provider": "vertex_ai",
+    "mode": "video_generation",
+    "output_cost_per_second": 0.15,
+    "source": "litellm:vertex_ai/veo-3.1-fast-generate-001"
+  },
+  "veo-3.1-fast-generate-preview": {
+    "litellm_provider": "vertex_ai",
+    "mode": "video_generation",
+    "output_cost_per_second": 0.15,
+    "source": "litellm:vertex_ai/veo-3.1-fast-generate-preview"
+  },
+  "veo-3.1-generate-001": {
+    "litellm_provider": "vertex_ai",
+    "mode": "video_generation",
+    "output_cost_per_second": 0.4,
+    "source": "litellm:vertex_ai/veo-3.1-generate-001"
+  },
+  "veo-3.1-generate-preview": {
+    "litellm_provider": "vertex_ai",
+    "mode": "video_generation",
+    "output_cost_per_second": 0.4,
+    "source": "litellm:vertex_ai/veo-3.1-generate-preview"
+  },
+  "veo-3.1-lite-generate-preview": {
+    "litellm_provider": "gemini",
+    "mode": "video_generation",
+    "output_cost_per_second": 0.05,
+    "source": "litellm:gemini/veo-3.1-lite-generate-preview"
+  }
+}

--- a/backend/internal/service/vertex_service_account.go
+++ b/backend/internal/service/vertex_service_account.go
@@ -91,6 +91,33 @@ func (a *Account) VertexLocation(model string) string {
 	return vertexDefaultLocation
 }
 
+// VertexServiceAccountJSON returns the raw service-account JSON string, whether the
+// credential is stored as a JSON string or a nested object. Empty when absent. The
+// newapi bridge forwards this as the channel key so new-api's Vertex adaptor can
+// unmarshal it (project_id is derived from the JSON, not passed separately).
+func (a *Account) VertexServiceAccountJSON() string {
+	if a == nil || a.Credentials == nil {
+		return ""
+	}
+	if raw := strings.TrimSpace(a.GetCredential("service_account_json")); raw != "" {
+		return raw
+	}
+	if raw := strings.TrimSpace(a.GetCredential("service_account")); raw != "" {
+		return raw
+	}
+	if nested, ok := a.Credentials["service_account_json"].(map[string]any); ok {
+		if b, err := json.Marshal(nested); err == nil {
+			return string(b)
+		}
+	}
+	if nested, ok := a.Credentials["service_account"].(map[string]any); ok {
+		if b, err := json.Marshal(nested); err == nil {
+			return string(b)
+		}
+	}
+	return ""
+}
+
 func parseVertexServiceAccountKey(account *Account) (*vertexServiceAccountKey, error) {
 	if account == nil || account.Credentials == nil {
 		return nil, errors.New("service account credentials not configured")

--- a/scripts/checks/media-pricing-overlay.py
+++ b/scripts/checks/media-pricing-overlay.py
@@ -1,0 +1,98 @@
+#!/usr/bin/env python3
+"""Validate the TK-owned media (image/video) pricing overlay.
+
+Source of truth: backend/internal/service/tk_media_pricing_overlay.json — a small
+curated overlay merged (fill-only) into every PricingService load so imagen-*/veo-*
+resolve to a real price even though the production runtime source (Wei-Shaw mirror,
+a trimmed litellm) drops those keys. Without this overlay imagen silently bills the
+$0.134 default and veo bills $0.
+
+This check hardens that against silent regression (CLAUDE.md §5 "upgrade principle":
+a soft rule that bit us once becomes a mechanical gate). It asserts:
+  1. The overlay parses and is non-empty.
+  2. Anchor models are present with a non-zero price in the right field:
+       imagen-4.0-generate-001 -> output_cost_per_image > 0
+       veo-3.1-generate-001    -> output_cost_per_second > 0
+  3. EVERY entry has a recognized mode and a > 0 price in the matching field
+     (no silently-shipped $0 media entry, which would deduct nothing).
+
+Usage: python3 scripts/checks/media-pricing-overlay.py [--quiet]
+Exit 0 ok, 1 violation, 2 missing dep / file / unparseable.
+"""
+
+from __future__ import annotations
+
+import json
+import pathlib
+import sys
+
+REPO_ROOT = pathlib.Path(__file__).resolve().parent.parent.parent
+OVERLAY = REPO_ROOT / "backend" / "internal" / "service" / "tk_media_pricing_overlay.json"
+
+# mode -> the price field that MUST be > 0 for that mode
+MODE_FIELD = {
+    "image_generation": "output_cost_per_image",
+    "video_generation": "output_cost_per_second",
+}
+
+ANCHORS = {
+    "imagen-4.0-generate-001": "output_cost_per_image",
+    "veo-3.1-generate-001": "output_cost_per_second",
+}
+
+
+def main() -> int:
+    quiet = "--quiet" in sys.argv
+
+    if not OVERLAY.is_file():
+        print(f"  FAIL: media overlay not found: {OVERLAY}", flush=True)
+        return 2
+    try:
+        data = json.loads(OVERLAY.read_text(encoding="utf-8"))
+    except (ValueError, OSError) as exc:
+        print(f"  FAIL: media overlay unparseable: {exc}", flush=True)
+        return 2
+
+    # Entries are bare model -> pricing dict; keys starting with "_" (e.g. _meta) are
+    # provenance, not pricing.
+    entries = {k: v for k, v in data.items() if not k.startswith("_")}
+    errors: list[str] = []
+
+    if not entries:
+        errors.append("overlay has zero pricing entries")
+
+    for model, pricing in entries.items():
+        if not isinstance(pricing, dict):
+            errors.append(f"{model}: entry is not an object")
+            continue
+        mode = pricing.get("mode")
+        field = MODE_FIELD.get(mode)
+        if field is None:
+            errors.append(f"{model}: unrecognized mode {mode!r} (want one of {sorted(MODE_FIELD)})")
+            continue
+        price = pricing.get(field)
+        if not isinstance(price, (int, float)) or price <= 0:
+            errors.append(f"{model}: mode={mode} requires {field} > 0, got {price!r}")
+
+    for model, field in ANCHORS.items():
+        pricing = entries.get(model)
+        if not isinstance(pricing, dict):
+            errors.append(f"anchor {model} missing from overlay")
+            continue
+        price = pricing.get(field)
+        if not isinstance(price, (int, float)) or price <= 0:
+            errors.append(f"anchor {model}: {field} must be > 0, got {price!r}")
+
+    if errors:
+        print(f"  FAIL: media pricing overlay invalid ({len(errors)} issue(s)):", flush=True)
+        for e in errors:
+            print(f"    - {e}", flush=True)
+        return 1
+
+    if not quiet:
+        print(f"  ok: {len(entries)} media overlay entries valid (anchors present, no $0)", flush=True)
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/scripts/preflight.sh
+++ b/scripts/preflight.sh
@@ -372,6 +372,25 @@ else
     echo "  ok: all pricing-availability sentinels intact"
 fi
 
+# ---- sub2api: media pricing overlay -----------------------------------------
+# Source of truth: backend/internal/service/tk_media_pricing_overlay.json. The
+# production price source (Wei-Shaw mirror) is a trimmed litellm that drops
+# provider-prefixed + token-less media entries, so imagen-*/veo-* resolve to a
+# wrong default unless this fill-only overlay supplies them. Assert the overlay
+# is non-empty, anchors are present, and no entry ships a $0 price. CLAUDE.md
+# §「升级原则」: a soft rule that bit us once becomes a mechanical gate.
+echo ""
+echo "=== sub2api: media pricing overlay ==="
+if ! command -v python3 >/dev/null 2>&1; then
+    echo "  FAIL: python3 not on PATH (required to validate tk_media_pricing_overlay.json)"
+    errors=$((errors + 1))
+elif ! python3 ./scripts/checks/media-pricing-overlay.py --quiet; then
+    # media-pricing-overlay.py already printed the actionable failure.
+    errors=$((errors + 1))
+else
+    echo "  ok: media pricing overlay valid (anchors present, no \$0)"
+fi
+
 # ---- sub2api: frontend TK sentinel registry ---------------------------------
 # Source of truth: scripts/sentinels/frontend-tk.json. Verifies that load-bearing
 # TokenKey-only frontend surfaces (sidebar geometry, fluid table mode, sticky

--- a/scripts/sentinels/gateway-tk.json
+++ b/scripts/sentinels/gateway-tk.json
@@ -1505,6 +1505,14 @@
         "v24.3.0"
       ],
       "rationale": "defaultFingerprint fallback identity must match the canonical block (canonicalHTTPObservedStatic): UA suffix (external, sdk-cli) and node v24.3.0. Kept as an explicit literal (not a func derivation) so ops/anthropic/capture_cc_fingerprint.py can statically read it; consistency with canonical is locked by identity_canonical_consistency_test.go."
+    },
+    {
+      "path": "backend/internal/handler/openai_gateway_tk_video.go",
+      "must_contain": [
+        "videoRequestedSeconds",
+        "VideoDurationSeconds"
+      ],
+      "rationale": "Per-second video (veo) billing: VideoSubmit records usage with the requested duration (default 8s via videoRequestedSeconds) so the cost path bills duration x per-second rate. Without this anchor veo silently bills $0 (no tokens, no per-second branch)."
     }
   ]
 }

--- a/scripts/sentinels/newapi.json
+++ b/scripts/sentinels/newapi.json
@@ -260,6 +260,23 @@
         "account.IsOpenAI() && !account.SupportsOpenAIEndpointCapability"
       ],
       "rationale": "TK reconciliation of upstream endpoint-capability gating onto the fifth-platform scheduler. accountSupportsOpenAICapabilities applies the OpenAI endpoint-capability filter to native `openai` accounts ONLY (`account.IsOpenAI() && !...`), so `newapi` accounts (platform != openai, !IsOpenAI) are never fail-closed out of chat/embeddings scheduling. If a future merge drops the IsOpenAI() guard and applies SupportsOpenAIEndpointCapability unconditionally, every newapi account would be filtered out of the compat pool — a total fifth-platform outage. Must survive future upstream merges."
+    },
+    {
+      "path": "backend/internal/relay/bridge/context_input.go",
+      "must_contain": [
+        "VertexKeyType",
+        "ContextKeyChannelOtherSetting"
+      ],
+      "rationale": "VertexAI (channel_type 41) service-account passthrough: the newapi bridge sets new-api's ChannelOtherSettings.VertexKeyType (via ContextKeyChannelOtherSetting) and the region gin key so the Vertex adaptor authenticates via JWT. Without it ch41 reverts to api_key mode and fails; this is also the only path by which the GCP trial credit is spendable (Gemini Developer API ch24 prepay does not accept Cloud Billing credits)."
+    },
+    {
+      "path": "backend/internal/service/newapi_bridge_usage.go",
+      "must_contain": [
+        "ChannelTypeVertexAi",
+        "IsVertexServiceAccount",
+        "VertexServiceAccountJSON"
+      ],
+      "rationale": "newAPIBridgeChannelInput forwards the service-account JSON as the channel key and signals VertexKeyType=json + region for channel_type 41. Removing this silently reverts Vertex accounts to broken api_key auth."
     }
   ]
 }

--- a/scripts/sentinels/newapi.json
+++ b/scripts/sentinels/newapi.json
@@ -277,6 +277,20 @@
         "VertexServiceAccountJSON"
       ],
       "rationale": "newAPIBridgeChannelInput forwards the service-account JSON as the channel key and signals VertexKeyType=json + region for channel_type 41. Removing this silently reverts Vertex accounts to broken api_key auth."
+    },
+    {
+      "path": "backend/internal/service/openai_gateway_bridge_dispatch.go",
+      "must_contain": [
+        "ImageCount: out.ImageCount"
+      ],
+      "rationale": "Per-image billing for imagen via the newapi bridge: ForwardAsImageGenerationsDispatched must propagate bridge.DispatchOutcome.ImageCount onto OpenAIForwardResult, otherwise the gateway's `result.ImageCount > 0` branch never fires and imagen bills by tokens instead of output_cost_per_image (silent under-charge). Pairs with the TK media pricing overlay (without a resolvable per-image price the count is moot; without the count the resolved price never applies). An upstream merge restructuring the bridge image dispatch could drop this one line."
+    },
+    {
+      "path": "backend/internal/service/pricing_service.go",
+      "must_contain": [
+        "applyTKMediaPricingOverlay(result)"
+      ],
+      "rationale": "TK media (image/video) pricing overlay injection point inside parsePricingData — the single choke-point both the remote (Wei-Shaw) and disk-fallback load paths funnel through. The production price source is a TRIMMED litellm mirror that drops provider-prefixed keys and token-less media entries, so imagen-*/veo-* resolve to nothing there; this fill-only overlay (companion pricing_service_tk_media_overlay.go, embedded tk_media_pricing_overlay.json) supplies the bare-name entries so per-image / per-second billing applies. If an upstream merge restructures parsePricingData and drops this one-line call, imagen silently reverts to the $0.134 default and veo to $0. The companion file's go:embed also makes the overlay JSON's presence build-enforced."
     }
   ]
 }


### PR DESCRIPTION
## 为什么

让 Google Cloud 试用信用($380 SGD)能经 TokenKey 跑 imagen/veo。gcloud 实测:**Gemini Developer API(ch24, prepay)不收 Cloud Billing 信用**(文本+imagen 均 429 prepay depleted),而 **Vertex AI(ch41, service account, 走 Cloud Billing)imagen/文本均 200**。要花到信用必须切 ch41,但 newapi 桥接此前不透传 service-account;且 imagen/veo 定价匹配不上、imagen 每图价不生效、veo 计费记 $0。本 PR 一并解决。

## 改动(一个 PR,三块)

**#0 newapi 桥接透传 Vertex(ch41)service-account**(new-api 不改)
- `relay/bridge/context_input.go`:`ChannelContextInput` 增 `VertexKeyType`/`VertexLocation`;`PopulateContextKeys` 设 new-api 的 `ChannelOtherSettings.VertexKeyType`(`ContextKeyChannelOtherSetting`)+ `region` gin key。
- `service/newapi_bridge_usage.go`:ch41 且 service-account 时,把 SA JSON 作为 channel key 转发、置 `VertexKeyType=json` + region(project_id 由 new-api 从 JSON 自解析)。
- `service/vertex_service_account.go`:新增 `VertexServiceAccountJSON()`。

**#1 媒体定价:TK 自有 overlay(always-merged),生产承重路径**
- 关键事实:生产运行时价目源 **Wei-Shaw 镜像是 litellm 的裁剪镜像**(195 vs 2748),把**带 provider 前缀的 key 和纯媒体(无 token 价)条目整体剔掉**了 —— 实测三源比对:litellm 有 30 条带前缀 imagen/veo($0.04/图、$0.4/秒),Wei-Shaw 0 条,仓内 fallback 0 条。所以单靠 lookup 端「裸名 last-segment 匹配带前缀 key」在**生产里扫不到任何东西**。
- 解法(方案 B):TK 自己拥有一个**极小、手工维护、`go:embed` 编进二进制**的 overlay `service/tk_media_pricing_overlay.json`(15 条 imagen/veo,**价取 `vertex_ai/` provider** —— TK 媒体走 ch41=Vertex)。在 `parsePricingData`(remote 与 disk-fallback **共用的单一 choke-point**)末尾**一行** `applyTKMediaPricingOverlay(result)` **fill-only** 合入 → 不论运行时源是 Wei-Shaw 还是 fallback,条目都在;**源哪天自带就被源值覆盖、overlay 自我退役**。companion:`service/pricing_service_tk_media_overlay.go`。
- 为什么不开第二条同步管道:Wei-Shaw 上游就是 litellm,再拉一次 = 同源冗余;媒体模型少且变慢,15 条手工补丁(每模型一行)比管道划算。
- 保留并修复的承重项:`parsePricingData` 不再丢纯图/纯视频条目;新增 `output_cost_per_second`。`matchByProviderPrefix` **降级为「源恰含前缀 key 时」的最后兜底**(生产无害);其多 provider「取最高价」改注释为「无法确定承接 provider 时的保守猜测」,非主路径(主路径 overlay 已固化 Vertex 价)。

**#2 imagen 每图 + veo 按秒计费(让解析出的价真正落账)**
- imagen:`relay/bridge/dispatch.go` 的 `DispatchOutcome` 增 `ImageCount`(由 `req.N` 派生),`openai_gateway_bridge_dispatch.go` 透传到 `OpenAIForwardResult.ImageCount` —— 否则 `result.ImageCount>0` 分支不触发,imagen 经 bridge **静默按 token 计费**(此前的隐性少收)。
- veo:`handler/openai_gateway_tk_video.go` + `service/openai_gateway_service.go` + `service/billing_service.go`:submit 按请求时长(缺省 8s 保守)记 `VideoDurationSeconds`,cost = 时长 × 每秒价。此前 veo 记 $0。

Sentinel:为承重面(ch41 透传、veo 计费、overlay 注入点、imagen ImageCount 透传)新增/更新 `newapi.json` / `gateway-tk.json` 条目。新增 preflight 段 `media pricing overlay`(断言 overlay 非空、锚点在、无 $0)。

## 验证
- `go build ./...` ✓、`go test -tags=unit ./...` ✓(全包 `./...` 全绿)、`golangci-lint run ./...` 0 issues、`gofmt` 干净、`scripts/preflight.sh` PASS。
- 新增单测:**overlay 在「源完全无 imagen/veo」时仍解析出每图/每秒价**(证明生产承重路径)、overlay **fill-only**(源带则源胜)、前缀兜底/纯视频解析、veo cost、桥接 vertex 映射。
- 落地后(线上,非本 PR):发版 → 部署 edge-us1 → 账号5 改 ch41 + 传 SA JSON + project_id/location → 端到端 smoke(flash/imagen/veo 经 prod→stub→edge→Vertex,扣 $380)。

🤖 Generated with [Claude Code](https://claude.com/claude-code)


---

## 本地端到端验证(stub 上游,真实 usage_log)

用本分支编译的二进制 + dockerized PG/Redis + stub 上游,经 admin 建组/账号/key 发真请求查 `usage_logs`:

- **运行时 overlay 生效**:进程启动加载 `206`(fallback 路径,191+15)/`210`(remote 路径,195+15)模型 —— overlay 在 remote 与 fallback 两条路径都合入。
- **imagen 每图计费**:`imagen-4.0-generate-001` n=1→$0.06、n=2→$0.12;`imagen-4.0-fast-generate-001` n=1→$0.03(均 2K×1.5 倍率)。`billing_mode=image`,单价 0.04 vs 0.02 = 2:1 精确匹配 overlay(排除旧 $0.134 默认价),`ImageCount` 透传修复实证。
- **veo 每秒计费**:`veo-3.1-generate-001` seconds=5→$2.00、seconds=3→$1.20。`billing_mode=video`,单价 $0.40/s = overlay 值,线性随时长。经 ch45(VolcEngine)任务 submit→stub→`vt_` task_id。
- 顺带复现 veo `seconds` 须为字符串的上游约束(数字会 `cannot unmarshal number into ...seconds of type string`)。

## 附带修复:Dockerfile pnpm pin(commit 2)

主 `Dockerfile` 前端阶段的 `corepack prepare pnpm@latest` 在 pnpm 10 下不再读 `package.json` 的 `pnpm.overrides`,导致 `pnpm install --frozen-lockfile` 报 `ERR_PNPM_LOCKFILE_CONFIG_MISMATCH`、本地 `docker build` 失败。改为 `pnpm@9`(对齐 CI `pnpm/action-setup version: 9` 与 `lockfileVersion 9.0`)。**仅影响本地/dev 构建**:CI 用 action-setup,release 用无前端阶段的 `Dockerfile.goreleaser`,prod 发版镜像不受影响。brand.json 的 LABEL 锚点未动(随附 `sentinel-registry-reviewed` marker commit)。
