### PR TITLE
chore(edge): retire fra1 + sg1 EC2 footprint (Lightsail-only)

### DIFF
--- a/deploy/aws/cloudformation/cicd-oidc.yaml
+++ b/deploy/aws/cloudformation/cicd-oidc.yaml
@@ -20,8 +20,9 @@ Parameters:
     Description: >-
       Full OIDC sub claims (StringLike patterns) allowed to assume the role.
       Default allows main (for ops-daily-diagnostics.yml),
-      environment:prod (for deploy-stage0.yml), and
-      environment:edge-uk1 (Lightsail uk1 deploy) / environment:edge-fra1 / environment:edge-us1 (EC2 Edge Stage0). The Environment
+      environment:prod (for deploy-stage0.yml),
+      environment:edge-uk1 / environment:edge-fra1 (Lightsail deploy) and
+      environment:edge-us1 (EC2 Edge Stage0). The Environment
       binding is what makes reviewer gates load-bearing on the AWS side, not
       just GitHub UI cosmetic. Temporarily add e.g.
       "repo:youxuanxue/sub2api:ref:refs/heads/feature/clustering-oidc-ssm"
@@ -34,21 +35,6 @@ Parameters:
       Optional prod EC2 instance the role is allowed to send SSM commands to.
       Empty suppresses the prod SSM statement, which lets a regional OIDC stack
       bootstrap before the target Stage0 instance exists.
-  EdgeFra1Region:
-    Type: String
-    Default: eu-west-3
-    AllowedPattern: "^[a-z]{2}-[a-z]+-[0-9]+$"
-    Description: AWS region for the fra1 Edge Stage0 stack (Paris).
-  EdgeFra1TargetInstanceId:
-    Type: String
-    Default: ""
-    AllowedPattern: "^(i-[0-9a-f]{8,17})?$"
-    Description: >-
-      Optional fra1 Edge EC2 instance the role may send SSM commands to after
-      tokenkey-edge-fra1-stage0 is provisioned. Empty suppresses the fra1 SSM
-      statement; fill this with the stack output InstanceId before running
-      deploy-edge-stage0 upgrade/smoke/rollback for fra1.
-
   EdgeUs1Region:
     Type: String
     Default: us-west-2
@@ -80,7 +66,6 @@ Parameters:
 Conditions:
   ShouldCreateOIDC: !Equals [!Ref CreateOIDCProvider, "true"]
   HasProdInstance: !Not [!Equals [!Ref TargetInstanceId, ""]]
-  HasEdgeFra1Instance: !Not [!Equals [!Ref EdgeFra1TargetInstanceId, ""]]
   HasEdgeUs1Instance: !Not [!Equals [!Ref EdgeUs1TargetInstanceId, ""]]
 
 Resources:
@@ -143,7 +128,6 @@ Resources:
                 Action:
                   - sts:AssumeRole
                 Resource:
-                  - !GetAtt EdgeFra1CloudFormationExecutionRole.Arn
                   - !GetAtt EdgeUs1CloudFormationExecutionRole.Arn
         - PolicyName: SsmSendCommandStage0
           PolicyDocument:
@@ -158,16 +142,6 @@ Resources:
                   Resource:
                     - !Sub "arn:aws:ec2:${AWS::Region}:${AWS::AccountId}:instance/${TargetInstanceId}"
                     - !Sub "arn:aws:ssm:${AWS::Region}::document/AWS-RunShellScript"
-                - !Ref AWS::NoValue
-              - !If
-                - HasEdgeFra1Instance
-                - Sid: SendRunShellScriptEdgeFra1
-                  Effect: Allow
-                  Action:
-                    - ssm:SendCommand
-                  Resource:
-                    - !Sub "arn:aws:ec2:${EdgeFra1Region}:${AWS::AccountId}:instance/${EdgeFra1TargetInstanceId}"
-                    - !Sub "arn:aws:ssm:${EdgeFra1Region}::document/AWS-RunShellScript"
                 - !Ref AWS::NoValue
               - !If
                 - HasEdgeUs1Instance
@@ -198,7 +172,6 @@ Resources:
                   StringEquals:
                     "aws:RequestedRegion":
                       - !Ref AWS::Region
-                      - !Ref EdgeFra1Region
                       - !Ref EdgeUs1Region
               - Sid: DescribeEgressEipForRotation
                 # Read-side of EIP rotation: discover current allocation-id,
@@ -213,7 +186,6 @@ Resources:
                 Condition:
                   StringEquals:
                     "aws:RequestedRegion":
-                      - !Ref EdgeFra1Region
                       - !Ref EdgeUs1Region
               - Sid: AllocateAndTagEgressEipForRotation
                 # Write-side, allocate: workflow allocates a fresh candidate EIP
@@ -227,7 +199,6 @@ Resources:
                 Condition:
                   StringEquals:
                     "aws:RequestedRegion":
-                      - !Ref EdgeFra1Region
                       - !Ref EdgeUs1Region
               - Sid: TagFreshEgressEipOnAllocate
                 Effect: Allow
@@ -238,7 +209,6 @@ Resources:
                   StringEquals:
                     "ec2:CreateAction": AllocateAddress
                     "aws:RequestedRegion":
-                      - !Ref EdgeFra1Region
                       - !Ref EdgeUs1Region
               - Sid: ReleaseTaggedTokenkeyCandidateEip
                 # Write-side, release: only EIPs we tagged (Project=tokenkey)
@@ -253,7 +223,6 @@ Resources:
                   StringEquals:
                     "aws:ResourceTag/Project": tokenkey
                     "aws:RequestedRegion":
-                      - !Ref EdgeFra1Region
                       - !Ref EdgeUs1Region
               - Sid: DescribeStackForInstanceLookup
                 Effect: Allow
@@ -262,18 +231,7 @@ Resources:
                 Resource:
                   - !Sub "arn:aws:cloudformation:${AWS::Region}:${AWS::AccountId}:stack/tokenkey-cicd-oidc/*"
                   - !Sub "arn:aws:cloudformation:${AWS::Region}:${AWS::AccountId}:stack/tokenkey-prod-stage0/*"
-                  - !Sub "arn:aws:cloudformation:${EdgeFra1Region}:${AWS::AccountId}:stack/tokenkey-edge-fra1-stage0/*"
                   - !Sub "arn:aws:cloudformation:${EdgeUs1Region}:${AWS::AccountId}:stack/tokenkey-edge-us1-stage0/*"
-              - Sid: DeployEdgeFra1Stack
-                Effect: Allow
-                Action:
-                  - cloudformation:CreateChangeSet
-                  - cloudformation:ExecuteChangeSet
-                  - cloudformation:DescribeChangeSet
-                  - cloudformation:DeleteChangeSet
-                  - cloudformation:GetTemplateSummary
-                Resource:
-                  - !Sub "arn:aws:cloudformation:${EdgeFra1Region}:${AWS::AccountId}:stack/tokenkey-edge-fra1-stage0/*"
               - Sid: DeployEdgeUs1Stack
                 Effect: Allow
                 Action:
@@ -289,105 +247,12 @@ Resources:
                 Action:
                   - iam:PassRole
                 Resource:
-                  - !GetAtt EdgeFra1CloudFormationExecutionRole.Arn
                   - !GetAtt EdgeUs1CloudFormationExecutionRole.Arn
       Tags:
         - Key: Project
           Value: tokenkey
         - Key: ManagedBy
           Value: cloudformation
-
-  EdgeFra1CloudFormationExecutionRole:
-    Type: AWS::IAM::Role
-    Properties:
-      RoleName: !Sub "tokenkey-cfn-${EdgeFra1Region}-edge-fra1-stage0"
-      Description: >-
-        CloudFormation execution role for tokenkey-edge-fra1-stage0. GitHub
-        Actions may pass this role, but does not receive direct EC2/IAM
-        provisioning permissions.
-      AssumeRolePolicyDocument:
-        Version: "2012-10-17"
-        Statement:
-          - Effect: Allow
-            Principal:
-              Service: cloudformation.amazonaws.com
-            Action: sts:AssumeRole
-      Policies:
-        - PolicyName: ProvisionEdgeFra1Resources
-          PolicyDocument:
-            Version: "2012-10-17"
-            Statement:
-              - Effect: Allow
-                Action:
-                  - ec2:CreateVpc
-                  - ec2:DeleteVpc
-                  - ec2:ModifyVpcAttribute
-                  - ec2:CreateInternetGateway
-                  - ec2:DeleteInternetGateway
-                  - ec2:AttachInternetGateway
-                  - ec2:DetachInternetGateway
-                  - ec2:CreateSubnet
-                  - ec2:DeleteSubnet
-                  - ec2:ModifySubnetAttribute
-                  - ec2:CreateRouteTable
-                  - ec2:DeleteRouteTable
-                  - ec2:CreateRoute
-                  - ec2:DeleteRoute
-                  - ec2:AssociateRouteTable
-                  - ec2:DisassociateRouteTable
-                  - ec2:CreateSecurityGroup
-                  - ec2:DeleteSecurityGroup
-                  - ec2:AuthorizeSecurityGroupIngress
-                  - ec2:RevokeSecurityGroupIngress
-                  - ec2:AllocateAddress
-                  - ec2:ReleaseAddress
-                  - ec2:AssociateAddress
-                  - ec2:DisassociateAddress
-                  - ec2:RunInstances
-                  - ec2:TerminateInstances
-                  - ec2:StartInstances
-                  - ec2:StopInstances
-                  - ec2:CreateVolume
-                  - ec2:DeleteVolume
-                  - ec2:AttachVolume
-                  - ec2:DetachVolume
-                  - ec2:ModifyInstanceAttribute
-                  - ec2:CreateTags
-                  - ec2:DeleteTags
-                  - ec2:Describe*
-                  - iam:CreateRole
-                  - iam:DeleteRole
-                  - iam:GetRole
-                  - iam:TagRole
-                  - iam:UntagRole
-                  - iam:PassRole
-                  - iam:AttachRolePolicy
-                  - iam:DetachRolePolicy
-                  - iam:PutRolePolicy
-                  - iam:DeleteRolePolicy
-                  - iam:CreateInstanceProfile
-                  - iam:DeleteInstanceProfile
-                  - iam:TagInstanceProfile
-                  - iam:UntagInstanceProfile
-                  - iam:AddRoleToInstanceProfile
-                  - iam:RemoveRoleFromInstanceProfile
-                  - iam:GetInstanceProfile
-                  - iam:ListInstanceProfilesForRole
-                  - ssm:PutParameter
-                  - ssm:DeleteParameter
-                  - ssm:GetParameter
-                  - ssm:GetParameters
-                  - cloudwatch:PutMetricAlarm
-                  - cloudwatch:DeleteAlarms
-                  - cloudwatch:DescribeAlarms
-                Resource: "*"
-      Tags:
-        - Key: Project
-          Value: tokenkey
-        - Key: ManagedBy
-          Value: cloudformation
-        - Key: EdgeId
-          Value: fra1
 
   EdgeUs1CloudFormationExecutionRole:
     Type: AWS::IAM::Role
@@ -487,11 +352,6 @@ Outputs:
     Value: !GetAtt ClusteringRole.Arn
     Export:
       Name: !Sub "${AWS::StackName}-RoleArn"
-  EdgeFra1CloudFormationExecutionRoleArn:
-    Description: CloudFormation execution role for tokenkey-edge-fra1-stage0.
-    Value: !GetAtt EdgeFra1CloudFormationExecutionRole.Arn
-    Export:
-      Name: !Sub "${AWS::StackName}-EdgeFra1CloudFormationExecutionRoleArn"
   EdgeUs1CloudFormationExecutionRoleArn:
     Description: CloudFormation execution role for tokenkey-edge-us1-stage0.
     Value: !GetAtt EdgeUs1CloudFormationExecutionRole.Arn

--- a/deploy/aws/stage0/edge-polluted-ips.json
+++ b/deploy/aws/stage0/edge-polluted-ips.json
@@ -36,6 +36,13 @@
       "platform": "lightsail",
       "edge_id": "us2",
       "notes": "Lightsail edge-us2 StaticIp-2 upstream API risk-block (2026-05-29)"
+    },
+    {
+      "ip": "52.47.52.132",
+      "region": "eu-west-3",
+      "platform": "ec2",
+      "edge_id": "fra1",
+      "notes": "EC2 fra1 EIP released 2026-06-01 on EC2 decommission (fra1 goes Lightsail-only; not upstream pollution; exclude from re-allocation)"
     }
   ]
 }

--- a/deploy/aws/stage0/edge-targets.json
+++ b/deploy/aws/stage0/edge-targets.json
@@ -17,36 +17,6 @@
       "monthly_budget_usd": 16,
       "ssm_prefix": "/tokenkey/edge/us1",
       "purpose": "clean-us-egress-planned"
-    },
-    "sg1": {
-      "deployable": false,
-      "profile": "edge-minimal",
-      "region": "ap-southeast-1",
-      "domain": "api-sg1.tokenkey.dev",
-      "stack": "tokenkey-edge-sg1-stage0",
-      "instance_type": "t4g.micro",
-      "root_volume_gib": 20,
-      "data_volume_gib": 0,
-      "swap_gib": 2,
-      "snapshot_schedule": "none",
-      "monthly_budget_usd": 16,
-      "ssm_prefix": "/tokenkey/edge/sg1",
-      "purpose": "sg-egress-planned"
-    },
-    "fra1": {
-      "deployable": false,
-      "profile": "edge-minimal",
-      "region": "eu-west-3",
-      "domain": "api-fra1.tokenkey.dev",
-      "stack": "tokenkey-edge-fra1-stage0",
-      "instance_type": "t4g.micro",
-      "root_volume_gib": 20,
-      "data_volume_gib": 0,
-      "swap_gib": 2,
-      "snapshot_schedule": "none",
-      "monthly_budget_usd": 16,
-      "ssm_prefix": "/tokenkey/edge/fra1",
-      "purpose": "fr-paris-egress"
     }
   }
 }

--- a/docs/deploy/tokenkey-edge-ip-history.md
+++ b/docs/deploy/tokenkey-edge-ip-history.md
@@ -18,4 +18,5 @@ Active edge EIP rotation runbook: [`.cursor/skills/tokenkey-stage0-edge-ip-rotat
 | `16.61.87.51` | eu-west-2 | EC2 uk1 orphan EIP released 2026-05-26 after EC2→Lightsail migration (not upstream pollution; exclude from re-allocation) |
 | `18.135.59.111` | eu-west-2 | Lightsail edge-uk1 tokenkey-edge-uk1-ls-ip superseded 2026-05-26; released after matrix correction to 13.134.80.182 |
 | `100.48.129.133` | us-east-1 | Lightsail edge-us2 StaticIp-2 upstream API risk-block (2026-05-29) |
+| `52.47.52.132` | eu-west-3 | EC2 fra1 EIP released 2026-06-01 on EC2 decommission (fra1 goes Lightsail-only; not upstream pollution; exclude from re-allocation) |
 <!-- END edge-ip-status:polluted -->


### PR DESCRIPTION
## What

fra1 and sg1 will use **Lightsail exclusively** going forward. Remove their EC2 footprint.

## Live AWS actions already executed (operator-authorized teardown)

- **fra1 EC2 stack `tokenkey-edge-fra1-stage0` (eu-west-3): deleted** — `DELETE_COMPLETE`. Instance `i-05350d8cc7c838355` terminated, EIP `52.47.52.132` released. No EBS snapshot kept (operator opted out of the 30-day snapshot; teardown ran via direct `cloudformation delete-stack` rather than the snapshot-gated workflow).
- **sg1**: had **no EC2 resources** (never provisioned — `deploy-edge-stage0` placeholder only). Nothing to tear down.

## Code changes (this PR)

- `deploy/aws/stage0/edge-targets.json`: drop `fra1` + `sg1` rows. `us1` remains the only EC2 edge.
- `deploy/aws/cloudformation/cicd-oidc.yaml`: strip all fra1 EC2 IAM (params, condition, `EdgeFra1CloudFormationExecutionRole`, SSM/CFN/EIP region-scoped statements, DescribeStacks ARN, PassRole, Output). **Keeps** `environment:edge-fra1` in `AllowedSubjects` per the uk1 precedent — Lightsail fra1 reuses the subject.
- `deploy/aws/stage0/edge-polluted-ips.json` + `docs/deploy/tokenkey-edge-ip-history.md`: record retired fra1 EIP `52.47.52.132` so it is excluded from future clean-egress allocation.

Lightsail `fra1`/`sg1` planning entries (`deployable=false`) are retained for later provisioning.

## Post-merge step (not in this PR)

Live-deploy `tokenkey-cicd-oidc` (us-east-1) so the fra1 IAM removal takes effect on AWS (template-only removal does not auto-apply). Will preserve prod/us1 params + `AllowedSubjects`.

## Checks

- Platform exclusivity gate green (no edge_id deployable=true on both matrices).
- `scripts/preflight.sh` PASS (incl. edge-ip-status doc/JSON drift, CFN template version, Lightsail OIDC perm coverage).
- No upstream-shaped paths touched (`no-upstream-touch`).

Merge mode: **Squash and merge** (TK chore PR).

🤖 Generated with [Claude Code](https://claude.com/claude-code)