### PR TITLE
fix(tier): allow ApplyTier on anthropic setup-token accounts

### DIFF
--- a/backend/internal/service/account_tier_service_tk.go
+++ b/backend/internal/service/account_tier_service_tk.go
@@ -39,9 +39,11 @@ func NewAccountTierService(adminSvc AdminService, tierSvc *TierService, tlsSvc *
 	return &AccountTierService{adminSvc: adminSvc, tierSvc: tierSvc, tlsSvc: tlsSvc}
 }
 
-// ApplyTier binds the given account to `tier`. Only anthropic OAUTH accounts are
-// accepted (apikey mirror stubs and other platforms are rejected — applying a
-// tier to a stub would wipe its base_url/pool_mode).
+// ApplyTier binds the given account to `tier`. Only anthropic OAUTH and
+// setup-token accounts are accepted — these are the two types subject to 5h
+// window + session control (see Account.IsAnthropicOAuthOrSetupToken). apikey
+// mirror stubs and other platforms are rejected — applying a tier to a stub
+// would wipe its base_url/pool_mode.
 func (s *AccountTierService) ApplyTier(ctx context.Context, accountID int64, tier string) (*Account, error) {
 	if s == nil || s.adminSvc == nil || s.tierSvc == nil {
 		return nil, fmt.Errorf("account tier service unavailable")
@@ -57,8 +59,8 @@ func (s *AccountTierService) ApplyTier(ctx context.Context, accountID int64, tie
 	if account.Platform != PlatformAnthropic {
 		return nil, fmt.Errorf("apply-tier is only supported for anthropic accounts (account %d is platform %q)", accountID, account.Platform)
 	}
-	if account.Type != AccountTypeOAuth {
-		return nil, fmt.Errorf("apply-tier is only supported for anthropic OAuth accounts (account %d is type %q); tier does not apply to api-key / mirror-stub accounts", accountID, account.Type)
+	if account.Type != AccountTypeOAuth && account.Type != AccountTypeSetupToken {
+		return nil, fmt.Errorf("apply-tier is only supported for anthropic OAuth / setup-token accounts (account %d is type %q); tier does not apply to api-key / mirror-stub accounts", accountID, account.Type)
 	}
 
 	row, err := s.tierSvc.GetByName(ctx, tier)

--- a/backend/internal/service/account_tier_service_tk_test.go
+++ b/backend/internal/service/account_tier_service_tk_test.go
@@ -105,6 +105,51 @@ func TestApplyTier_RejectsApikeyStub(t *testing.T) {
 	require.Error(t, err)
 }
 
+func TestApplyTier_SetupTokenBindsTier(t *testing.T) {
+	// Regression: setup-token anthropic accounts are subject to the same 5h
+	// window + session control as OAuth (Account.IsAnthropicOAuthOrSetupToken)
+	// and MUST be tier-eligible. PR #472's over-narrow Type==oauth gate rejected
+	// them; this asserts they now bind.
+	admin := &stubAdminServiceForTier{getAccount: &Account{
+		ID:       9,
+		Platform: PlatformAnthropic,
+		Type:     AccountTypeSetupToken,
+	}}
+	svc := NewAccountTierService(admin, tierServiceWithL4(t), nil)
+
+	_, err := svc.ApplyTier(context.Background(), 9, "l4")
+	require.NoError(t, err)
+	require.NotNil(t, admin.updateInput)
+	require.NotNil(t, admin.updateInput.TierID)
+	require.Equal(t, int64(4), *admin.updateInput.TierID, "setup-token must bind tier_id")
+	require.NotNil(t, admin.updateInput.Concurrency)
+	require.Equal(t, 8, *admin.updateInput.Concurrency, "setup-token must value-sync concurrency from tier")
+}
+
+func TestApplyTierExtra_OverlaysSetupToken(t *testing.T) {
+	// Runtime overlay must apply to setup-token accounts too, otherwise a bound
+	// setup-token account would read base_rpm/max_sessions == 0 (unlimited).
+	tierID := int64(4)
+	acct := &Account{Platform: PlatformAnthropic, Type: AccountTypeSetupToken, TierID: &tierID}
+	tierServiceWithL4(t).ApplyTierExtra(acct)
+	require.Equal(t, 28, parseExtraInt(acct.Extra["base_rpm"]), "setup-token overlay must set base_rpm from tier")
+	require.Equal(t, 120, parseExtraInt(acct.Extra["max_sessions"]), "setup-token overlay must set max_sessions from tier")
+}
+
+func TestTierManagedExtraStripped_StripsSetupTokenOverlay(t *testing.T) {
+	// Write path must strip overlaid tier-managed keys for setup-token too, so the
+	// in-memory overlay is never persisted back onto the account.
+	tierID := int64(4)
+	acct := &Account{
+		Platform: PlatformAnthropic, Type: AccountTypeSetupToken, TierID: &tierID,
+		Extra: map[string]any{"base_rpm": 28, "rpm_strategy": "tiered"},
+	}
+	out := tierServiceWithL4(t).TierManagedExtraStripped(acct)
+	_, hasBaseRPM := out["base_rpm"]
+	require.False(t, hasBaseRPM, "tier-managed base_rpm must be stripped for setup-token write path")
+	require.Equal(t, "tiered", out["rpm_strategy"], "non-tier extra preserved")
+}
+
 func TestApplyTier_OAuthBindsTierAndValueSyncsConcurrency(t *testing.T) {
 	admin := &stubAdminServiceForTier{getAccount: &Account{
 		ID:       7,

--- a/backend/internal/service/anthropic_config_reconciler.go
+++ b/backend/internal/service/anthropic_config_reconciler.go
@@ -278,7 +278,7 @@ func (r *AnthropicConfigReconciler) reconcileTierConcurrency(ctx context.Context
 	}
 	for i := range accounts {
 		a := &accounts[i]
-		if a.TierID == nil || *a.TierID <= 0 || a.Type != AccountTypeOAuth {
+		if a.TierID == nil || *a.TierID <= 0 || !a.IsAnthropicOAuthOrSetupToken() {
 			continue
 		}
 		want, ok := r.tiers.ResolveConcurrency(*a.TierID)
@@ -485,12 +485,12 @@ func (r *AnthropicConfigReconciler) reconcileBalanceFloor(ctx context.Context) {
 // reportTierDrift is REPORT ONLY. In the reference-table model per-tier numeric
 // config is resolved at runtime (overlay) and concurrency is value-synced by Step
 // T, so per-field drift no longer exists. The remaining meaningful signal is a
-// MIGRATION GAP: an anthropic OAUTH account carrying the legacy stability_tier
-// label but with no tier_id binding (not tier-resolved at runtime).
+// MIGRATION GAP: an anthropic OAUTH / setup-token account carrying the legacy
+// stability_tier label but with no tier_id binding (not tier-resolved at runtime).
 func (r *AnthropicConfigReconciler) reportTierDrift(accounts []Account) {
 	for i := range accounts {
 		a := &accounts[i]
-		if a.Type != AccountTypeOAuth {
+		if !a.IsAnthropicOAuthOrSetupToken() {
 			continue
 		}
 		if a.TierID != nil && *a.TierID > 0 {

--- a/backend/internal/service/tier_service.go
+++ b/backend/internal/service/tier_service.go
@@ -144,7 +144,7 @@ func (s *TierService) ApplyTierExtra(account *Account) {
 	if s == nil || account == nil || account.TierID == nil || *account.TierID <= 0 {
 		return
 	}
-	if account.Platform != PlatformAnthropic || account.Type != AccountTypeOAuth {
+	if !account.IsAnthropicOAuthOrSetupToken() {
 		return
 	}
 	t := s.lookupByID(*account.TierID)
@@ -159,13 +159,12 @@ func (s *TierService) ApplyTierExtra(account *Account) {
 
 // TierManagedExtraStripped 返回剥离 tier-overlay 键后的 extra 副本（写路径在
 // repo.Update 调用），保证内存 overlay 不持久化到账号。非 tier-managed 账号
-// （无 tier_id / 非 anthropic-oauth）原样返回。
+// （无 tier_id / 非 anthropic-oauth/setup-token）原样返回。
 func (s *TierService) TierManagedExtraStripped(account *Account) map[string]any {
 	if account == nil {
 		return nil
 	}
-	if account.TierID == nil || *account.TierID <= 0 ||
-		account.Platform != PlatformAnthropic || account.Type != AccountTypeOAuth {
+	if account.TierID == nil || *account.TierID <= 0 || !account.IsAnthropicOAuthOrSetupToken() {
 		return account.Extra
 	}
 	if account.Extra == nil {

--- a/backend/migrations/tk_013_backfill_setup_token_tier_id.sql
+++ b/backend/migrations/tk_013_backfill_setup_token_tier_id.sql
@@ -1,0 +1,21 @@
+-- tk_013: backfill tier_id for anthropic setup-token accounts carrying the
+-- legacy extra.stability_tier label.
+--
+-- tk_012's backfill only matched `type = 'oauth'`, mirroring an over-narrow gate
+-- that PR #472 introduced in ApplyTier/overlay/reconciler. Setup-token accounts
+-- are subject to the same 5h window + session control (Account.IsAnthropicOAuth-
+-- OrSetupToken) and are tier-eligible, so any setup-token account that carried a
+-- stability_tier label under the old value-copy model was left with tier_id NULL
+-- and is not tier-resolved at runtime. This idempotent backfill closes that gap.
+--
+-- Idempotent (only fills NULL tier_id). The legacy extra.* values are left in
+-- place (no runtime gap; the runtime resolver overlays tier values, and the
+-- reconciler re-asserts concurrency).
+UPDATE accounts a
+SET tier_id = t.id, updated_at = NOW()
+FROM tiers t
+WHERE a.platform = 'anthropic'
+  AND a.type = 'setup-token'
+  AND a.deleted_at IS NULL
+  AND a.tier_id IS NULL
+  AND lower(trim(a.extra->>'stability_tier')) = t.name;

--- a/scripts/sentinels/gateway-tk.json
+++ b/scripts/sentinels/gateway-tk.json
@@ -1271,7 +1271,7 @@
         "extra[\"enable_tls_fingerprint\"] = true",
         "AccountTierExtraKey"
       ],
-      "rationale": "TK per-account tier-apply service: the UI 'Set Tier' action that replaces the high-frequency ops/anthropic SSM fan-out for a single deployment. ApplyTier derives the desired account config from the embedded tier baseline (concurrency/priority/rate_multiplier + merged extra + shared credentials), upserts the canonical TLS fingerprint profile, pins enable_tls_fingerprint + tls_fingerprint_profile_id + stability_tier on extra, and persists via the existing UpdateAccount path (which runs the operator-Σ sync). Writes ONLY this deployment's DB. Silent upstream-merge deletion would break the admin Set-Tier UI flow."
+      "rationale": "TK per-account tier-apply service: the UI 'Set Tier' action that replaces the high-frequency ops/anthropic SSM fan-out for a single deployment. ApplyTier accepts anthropic OAuth AND setup-token accounts (both are subject to 5h window + session control per Account.IsAnthropicOAuthOrSetupToken); api-key / mirror stubs and other platforms are rejected. It derives the desired account config from the embedded tier baseline (concurrency/priority/rate_multiplier + merged extra + shared credentials), upserts the canonical TLS fingerprint profile, pins enable_tls_fingerprint + tls_fingerprint_profile_id + stability_tier on extra, and persists via the existing UpdateAccount path (which runs the operator-Σ sync). Writes ONLY this deployment's DB. Silent upstream-merge deletion would break the admin Set-Tier UI flow."
     },
     {
       "path": "backend/internal/handler/admin/account_handler_tk_tier.go",


### PR DESCRIPTION
## Problem

The admin **Set Tier** UI fails for anthropic **setup-token** accounts (e.g. `tokenkey-edge-us-or1-ls-b`) with:

> Failed to apply tier: apply-tier is only supported for anthropic OAuth accounts (account 2 is type "setup-token"); tier does not apply to api-key / mirror-stub accounts

## Root cause

PR #472 (`1eefef7f`) tightened the tier subsystem's gate to `Type==oauth`. The commit's stated intent was to **reject api-key / mirror-stub accounts** (applying a tier to a stub corrupts its `base_url`/`pool_mode`). But the exact-match gate also rejected **setup-token** accounts — which are legitimate anthropic inference accounts subject to the *same* 5h window + session control and TLS fingerprint, per the repo's own canonical predicate `Account.IsAnthropicOAuthOrSetupToken()` ("仅这两类账号支持 5h 窗口额度控制和会话数量控制").

So setup-token was collateral damage of an over-broad gate.

## Fix

Replace the over-narrow `Type==oauth` check with `IsAnthropicOAuthOrSetupToken()` across the **entire** tier path, so setup-token gets the same lifecycle as OAuth (api-key / mirror stubs and other platforms remain rejected — #472's intent preserved):

| File | Change |
|---|---|
| `account_tier_service_tk.go` | ApplyTier gate (the visible error) |
| `tier_service.go` | `ApplyTierExtra` runtime overlay **and** `TierManagedExtraStripped` write-path strip — the strip must change too, else overlaid `base_rpm`/`max_sessions` would persist back onto the account, reintroducing the #472 leak |
| `anthropic_config_reconciler.go` | `reconcileTierConcurrency` + `reportTierDrift` |
| `migrations/tk_013_*.sql` | **new** idempotent backfill for setup-token accounts carrying the legacy `stability_tier` label (tk_012 only matched `type=oauth` and is already shipped/immutable) |

Without the overlay/strip/reconciler fixes, even a bound setup-token would read `base_rpm`/`max_sessions == 0` (unlimited).

## Tests

- New regression tests in `account_tier_service_tk_test.go`: setup-token apply / runtime overlay / write-path strip.
- `go build ./...` ✅ · `go test -tags=unit ./...` ✅ · `golangci-lint run ./internal/service/...` 0 issues · `scripts/preflight.sh` PASS.

## Merge mode

TK-originated fix → **Squash and merge** per rule §5.y.

🤖 Generated with [Claude Code](https://claude.com/claude-code)