### PR TITLE
fix(ops): grant decommission EBS-snapshot perms to shared OIDC role

### DIFF
--- a/deploy/aws/cloudformation/cicd-oidc.yaml
+++ b/deploy/aws/cloudformation/cicd-oidc.yaml
@@ -224,6 +224,36 @@ Resources:
                     "aws:ResourceTag/Project": tokenkey
                     "aws:RequestedRegion":
                       - !Ref EdgeUs1Region
+              - Sid: SnapshotEbsRootBeforeDecommission
+                # decommission op (deploy-edge-stage0.yml operation=decommission)
+                # snapshots the edge root EBS volume before delete-stack as a
+                # 30-day rollback artifact. CreateSnapshot covers the source
+                # volume + the new snapshot; DescribeSnapshots is the readiness
+                # poll. Neither supports useful resource-level scoping here, so
+                # gate on edge regions only (add new edge regions as they land).
+                Effect: Allow
+                Action:
+                  - ec2:CreateSnapshot
+                  - ec2:DescribeSnapshots
+                Resource: "*"
+                Condition:
+                  StringEquals:
+                    "aws:RequestedRegion":
+                      - !Ref EdgeUs1Region
+              - Sid: TagSnapshotOnCreate
+                # the snapshot step passes --tag-specifications, so CreateTags
+                # is checked with ec2:CreateAction=CreateSnapshot. Mirror the
+                # AllocateAddress tag gate above so we cannot tag arbitrary
+                # pre-existing resources.
+                Effect: Allow
+                Action:
+                  - ec2:CreateTags
+                Resource: "*"
+                Condition:
+                  StringEquals:
+                    "ec2:CreateAction": CreateSnapshot
+                    "aws:RequestedRegion":
+                      - !Ref EdgeUs1Region
               - Sid: DescribeStackForInstanceLookup
                 Effect: Allow
                 Action:


### PR DESCRIPTION
## Why

`deploy-edge-stage0.yml operation=decommission` **unconditionally** snapshots the edge root EBS volume before `delete-stack` (a 30-day rollback contract — the step refuses to proceed without a snapshot). The shared OIDC `ClusteringRole` had no `ec2:CreateSnapshot`, so **every workflow-based edge decommission fails at that step**.

Discovered during fra1 retirement (#489): the decommission run died with `UnauthorizedOperation … ec2:CreateSnapshot`, and the teardown fell back to a direct `cloudformation delete-stack` instead.

## What

Add to `ClusteringRole` (`cicd-oidc.yaml`), mirroring the existing EIP-rotation perm shape:
- `Sid: SnapshotEbsRootBeforeDecommission` — `ec2:CreateSnapshot` + `ec2:DescribeSnapshots`, region-gated.
- `Sid: TagSnapshotOnCreate` — `ec2:CreateTags` scoped to `ec2:CreateAction=CreateSnapshot` (the snapshot step passes `--tag-specifications`).

Both gated to edge regions (`EdgeUs1Region` today; add new edge regions alongside their stacks). No `ec2:DeleteSnapshot` (workflow keeps the snapshot for its retention window).

## Checks
- `aws cloudformation validate-template` OK (`CAPABILITY_NAMED_IAM`).
- `scripts/preflight.sh` PASS.
- `no-upstream-touch` (deploy/ infra only).

## Post-merge
Live-deploy `tokenkey-cicd-oidc` (us-east-1) so the new perms take effect, preserving prod/us1 params.

Merge mode: **Squash and merge** (TK fix PR).

🤖 Generated with [Claude Code](https://claude.com/claude-code)