### PR TITLE
fix(openai): classify ChatGPT settings anti-bot challenge as CF-blocked, not Fail

### DIFF
--- a/backend/internal/service/openai_privacy_service.go
+++ b/backend/internal/service/openai_privacy_service.go
@@ -69,25 +69,23 @@ func disableOpenAITraining(ctx context.Context, clientFactory PrivacyClientFacto
 		return PrivacyModeFailed
 	}
 
-	if resp.StatusCode == 403 || resp.StatusCode == 503 {
-		body := resp.String()
-		if strings.Contains(body, "cloudflare") || strings.Contains(body, "cf-") || strings.Contains(body, "Just a moment") {
-			slog.Warn("openai_privacy_cf_blocked", "status", resp.StatusCode)
-			return PrivacyModeCFBlocked
-		}
-	}
-
-	if !resp.IsSuccessState() {
+	// TK: classification (incl. broadened anti-bot/CF-challenge detection) lives in
+	// openai_privacy_tk_classify.go to keep this upstream file a thin call site.
+	switch mode := classifyOpenAIPrivacyResponse(resp.StatusCode, resp.GetContentType(), resp.String()); mode {
+	case PrivacyModeCFBlocked:
+		slog.Warn("openai_privacy_cf_blocked", "status", resp.StatusCode, "content_type", resp.GetContentType())
+		return mode
+	case PrivacyModeTrainingOff:
+		slog.Info("openai_privacy_training_disabled")
+		return mode
+	default:
 		// truncate at 2000B (was 200B): OpenAI privacy API failure responses can include
 		// nested HTML/JSON error envelopes, request-id, and rate-limit hints; 200B routinely
 		// cut these off mid-key and forced operators to re-enable debug logging to root-cause
 		// (see prod incident on 2026-04: "Privacy not set" loop on GPT-A1).
-		slog.Warn("openai_privacy_failed", "status", resp.StatusCode, "body", truncate(resp.String(), 2000))
-		return PrivacyModeFailed
+		slog.Warn("openai_privacy_failed", "status", resp.StatusCode, "content_type", resp.GetContentType(), "body", truncate(resp.String(), 2000))
+		return mode
 	}
-
-	slog.Info("openai_privacy_training_disabled")
-	return PrivacyModeTrainingOff
 }
 
 // ChatGPTAccountInfo 从 chatgpt.com/backend-api/accounts/check 获取的账号信息

--- a/backend/internal/service/openai_privacy_tk_classify.go
+++ b/backend/internal/service/openai_privacy_tk_classify.go
@@ -1,0 +1,51 @@
+package service
+
+import "strings"
+
+// classifyOpenAIPrivacyResponse maps a chatgpt.com settings-PATCH response to a privacy_mode.
+//
+// TK fix: the OpenAI/Cloudflare anti-bot interstitial served on
+// chatgpt.com/backend-api/* is an OpenAI-branded challenge page (gray logo SVG +
+// <meta http-equiv="refresh">) that does NOT contain the literal "cloudflare" /
+// "cf-" / "Just a moment" markers the original heuristic looked for. From a
+// datacenter egress IP these challenges are routine, so they were mis-recorded as
+// PrivacyModeFailed (red "Fail" on the account card) instead of PrivacyModeCFBlocked
+// (yellow "CF" — blocked, retryable, not an account fault). A JSON settings API that
+// answers a 403/503 with an HTML body is an anti-bot challenge, never a genuine
+// setting failure, so classify it as CF-blocked.
+func classifyOpenAIPrivacyResponse(statusCode int, contentType, body string) string {
+	if statusCode >= 200 && statusCode < 300 {
+		return PrivacyModeTrainingOff
+	}
+	if (statusCode == 403 || statusCode == 503) && isAntiBotChallenge(contentType, body) {
+		return PrivacyModeCFBlocked
+	}
+	return PrivacyModeFailed
+}
+
+// isAntiBotChallenge reports whether a response looks like a Cloudflare / OpenAI
+// anti-bot interstitial rather than a real JSON API error.
+func isAntiBotChallenge(contentType, body string) bool {
+	if strings.Contains(strings.ToLower(contentType), "text/html") {
+		return true
+	}
+	lc := strings.ToLower(body)
+	trimmed := strings.TrimSpace(lc)
+	if strings.HasPrefix(trimmed, "<!doctype html") || strings.HasPrefix(trimmed, "<html") {
+		return true
+	}
+	for _, marker := range []string{
+		"cloudflare",
+		"cf-ray",
+		"cf-",
+		"just a moment",
+		`http-equiv="refresh"`,
+		"enable-javascript",
+		"__cf_",
+	} {
+		if strings.Contains(lc, marker) {
+			return true
+		}
+	}
+	return false
+}

--- a/backend/internal/service/openai_privacy_tk_classify_test.go
+++ b/backend/internal/service/openai_privacy_tk_classify_test.go
@@ -1,0 +1,104 @@
+//go:build unit
+
+package service
+
+import "testing"
+
+// openaiChallengeBodySnippet is a trimmed copy of the real OpenAI/Cloudflare anti-bot
+// interstitial captured from prod (openai_privacy_failed status=403). It is the OpenAI
+// branded challenge page (gray logo SVG + meta-refresh) and contains NONE of the legacy
+// "cloudflare" / "cf-" / "Just a moment" markers — that gap caused the false "Fail".
+const openaiChallengeBodySnippet = `<html>
+  <head>
+    <meta name="viewport" content="width=device-width, initial-scale=1" />
+    <style global>body{font-family:Arial,Helvetica,sans-serif}.logo{color:#8e8ea0}</style>
+  <meta http-equiv="refresh" content="360"></head>
+  <body>
+    <div class="container">
+      <div class="logo">
+        <svg width="41" height="41" viewBox="0 0 41 41" fill="none">
+          <path d="M37.5324 16.8707C37.9808 15.5241 38.1363 14.0974"/>
+        </svg>
+      </div>
+    </div>
+  </body>
+</html>`
+
+func TestClassifyOpenAIPrivacyResponse(t *testing.T) {
+	t.Parallel()
+
+	cases := []struct {
+		name        string
+		status      int
+		contentType string
+		body        string
+		want        string
+	}{
+		{
+			name:        "2xx json success",
+			status:      200,
+			contentType: "application/json",
+			body:        `{"success":true}`,
+			want:        PrivacyModeTrainingOff,
+		},
+		{
+			name:        "403 openai branded challenge page",
+			status:      403,
+			contentType: "text/html; charset=utf-8",
+			body:        openaiChallengeBodySnippet,
+			want:        PrivacyModeCFBlocked,
+		},
+		{
+			name:        "503 classic cloudflare just a moment",
+			status:      503,
+			contentType: "text/html",
+			body:        `<!DOCTYPE html><html><head><title>Just a moment...</title></head><body>cloudflare</body></html>`,
+			want:        PrivacyModeCFBlocked,
+		},
+		{
+			name:        "403 genuine json error stays failed",
+			status:      403,
+			contentType: "application/json",
+			body:        `{"detail":"missing scope"}`,
+			want:        PrivacyModeFailed,
+		},
+		{
+			name:        "400 json bad request stays failed",
+			status:      400,
+			contentType: "application/json",
+			body:        `{"detail":"invalid feature"}`,
+			want:        PrivacyModeFailed,
+		},
+		{
+			name:        "403 html content-type empty body still cf",
+			status:      403,
+			contentType: "text/html",
+			body:        "",
+			want:        PrivacyModeCFBlocked,
+		},
+		{
+			name:        "403 meta-refresh body without content-type header",
+			status:      403,
+			contentType: "",
+			body:        `<html><head><meta http-equiv="refresh" content="360"></head></html>`,
+			want:        PrivacyModeCFBlocked,
+		},
+		{
+			name:        "500 json failure stays failed",
+			status:      500,
+			contentType: "application/json",
+			body:        `{"error":"internal"}`,
+			want:        PrivacyModeFailed,
+		},
+	}
+
+	for _, tc := range cases {
+		tc := tc
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+			if got := classifyOpenAIPrivacyResponse(tc.status, tc.contentType, tc.body); got != tc.want {
+				t.Fatalf("classifyOpenAIPrivacyResponse(%d, %q, ...) = %q, want %q", tc.status, tc.contentType, got, tc.want)
+			}
+		})
+	}
+}

--- a/scripts/sentinels/gateway-tk.json
+++ b/scripts/sentinels/gateway-tk.json
@@ -1513,6 +1513,13 @@
         "VideoDurationSeconds"
       ],
       "rationale": "Per-second video (veo) billing: VideoSubmit records usage with the requested duration (default 8s via videoRequestedSeconds) so the cost path bills duration x per-second rate. Without this anchor veo silently bills $0 (no tokens, no per-second branch)."
+    },
+    {
+      "path": "backend/internal/service/openai_privacy_service.go",
+      "must_contain": [
+        "classifyOpenAIPrivacyResponse(resp.StatusCode, resp.GetContentType(), resp.String())"
+      ],
+      "rationale": "The OpenAI 'disable training data sharing' PATCH to chatgpt.com/backend-api gets served an OpenAI-branded Cloudflare anti-bot interstitial (gray logo SVG + <meta http-equiv=refresh>, status 403) from a datacenter egress IP. That page contains NONE of the legacy cloudflare/cf-/Just-a-moment markers, so the original inline detection mis-recorded it as training_set_failed (red 'Fail') instead of training_set_cf_blocked (yellow 'CF' — blocked, retryable, not an account fault). disableOpenAITraining now delegates classification to classifyOpenAIPrivacyResponse in openai_privacy_tk_classify.go (broadened HTML / <html> / cf / meta-refresh detection). An upstream merge that restores the old inline 3-marker block here compiles clean but silently reverts the fix and leaves the companion file as dead code — this sentinel catches that revert."
     }
   ]
 }


### PR DESCRIPTION
## 问题

账号卡 `GPT-pro2`(prod id=48) 显示红色 **Fail** + tooltip「关闭训练数据共享失败」，但 ChatGPT 浏览器设置里「Improve the model for everyone」实际**已是 Off**。

## 根因（线上日志佐证）

prod gateway 日志：`openai_privacy_failed status=403`，返回体是 **OpenAI/Cloudflare 反爬质询页**（灰 logo SVG + `<meta http-equiv="refresh" content="360">`）。

`disableOpenAITraining` 从 prod 数据中心 IP 直接 PATCH `chatgpt.com/backend-api/settings`（10 个 OpenAI OAuth 账号全部无代理），被 Cloudflare bot 管控拦在 403 质询页。原内联识别只匹配 `cloudflare` / `cf-` / `Just a moment` 三个串，而 OpenAI 这个品牌质询页**不含**任一 → fall through 成 `training_set_failed`（红 Fail），本应是 `training_set_cf_blocked`（黄 CF：被挡可重试、非账号故障）。

## 改动

- **新增** `openai_privacy_tk_classify.go`（TK 伴生）：`classifyOpenAIPrivacyResponse` + `isAntiBotChallenge`，放宽反爬识别（`text/html` content-type / `<html>` 开头 / `cloudflare`·`cf-ray`·`http-equiv="refresh"`·`__cf_` 等 marker）。
- **改** upstream `openai_privacy_service.go`：`disableOpenAITraining` 尾部改为薄 hook 调用伴生分类函数，保留 2000B 截断日志并补 `content_type` 字段（-14/+12）。
- **新增** `openai_privacy_tk_classify_test.go`（`unit`，8 用例，含 prod 抓到的真实质询页片段）。
- **新增** `gateway-tk.json` sentinel：锚定 upstream 文件里的分类委托调用，防止 upstream merge 静默还原旧内联检测、伴生文件沦为死代码。

## 上线后行为

`shouldSkipOpenAIPrivacyEnsure` 对 `training_set_failed` 仍重试 → 下次 ensure（token 刷新 / 账号更新 / 运维点「Set Privacy」）即重判为 `cf_blocked` 并持久化，徽章由红 Fail 翻黄 CF。**无需 SQL 回填**。前端已能渲染 `cf_blocked` 为黄「CF」，**无前端改动**。

## 不做（明确排除，留待有干净住宅出口时）

服务端无法可靠打通 Cloudflare（无住宅/移动代理）。本 PR 只修误分类，不做：fallback 代理设置、PATCH 后 GET 回读 `training_allowed`（响应结构未知）、挑战求解器。

## 验证

- `go build ./...` ✅
- `go test -tags=unit ./internal/service/ -run 'OpenAIPrivacy|ClassifyOpenAIPrivacy'` ✅
- `golangci-lint run ./internal/service/...` → 0 issues ✅
- `scripts/preflight.sh` → PASS ✅（含 sentinel registry update gate、upstream override marker、no-web-impact）

🤖 Generated with [Claude Code](https://claude.com/claude-code)