### PR TITLE
fix(admin): allow platform=kiro on group create/update

### DIFF
--- a/backend/internal/handler/admin/group_handler.go
+++ b/backend/internal/handler/admin/group_handler.go
@@ -84,7 +84,7 @@ func NewGroupHandler(adminService service.AdminService, dashboardService *servic
 type CreateGroupRequest struct {
 	Name             string             `json:"name" binding:"required"`
 	Description      string             `json:"description"`
-	Platform         string             `json:"platform" binding:"omitempty,oneof=anthropic openai gemini antigravity newapi"`
+	Platform         string             `json:"platform" binding:"omitempty,oneof=anthropic openai gemini antigravity newapi kiro"`
 	RateMultiplier   float64            `json:"rate_multiplier"`
 	IsExclusive      bool               `json:"is_exclusive"`
 	SubscriptionType string             `json:"subscription_type" binding:"omitempty,oneof=standard subscription"`
@@ -129,7 +129,7 @@ type CreateGroupRequest struct {
 type UpdateGroupRequest struct {
 	Name             string             `json:"name"`
 	Description      string             `json:"description"`
-	Platform         string             `json:"platform" binding:"omitempty,oneof=anthropic openai gemini antigravity newapi"`
+	Platform         string             `json:"platform" binding:"omitempty,oneof=anthropic openai gemini antigravity newapi kiro"`
 	RateMultiplier   *float64           `json:"rate_multiplier"`
 	IsExclusive      *bool              `json:"is_exclusive"`
 	Status           string             `json:"status" binding:"omitempty,oneof=active inactive"`

--- a/backend/internal/handler/admin/group_handler_platform_binding_test.go
+++ b/backend/internal/handler/admin/group_handler_platform_binding_test.go
@@ -71,6 +71,65 @@ func TestCreateGroupRequest_RejectsUnknownPlatform(t *testing.T) {
 	require.Equal(t, http.StatusBadRequest, rec.Code)
 }
 
+// TestCreateGroupRequest_AcceptsKiroPlatform is the regression guard for the
+// same bug class as newapi above, re-introduced by the sixth platform (#481):
+// `platform: "kiro"` accounts could be created but `oneof=... newapi` rejected
+// `platform: "kiro"` group creation, so kiro accounts had no schedulable group
+// (anthropic groups only schedule {anthropic, antigravity}). The scheduler and
+// frontend GATEWAY_PLATFORMS already supported kiro; only these two DTO enums
+// lagged.
+func TestCreateGroupRequest_AcceptsKiroPlatform(t *testing.T) {
+	gin.SetMode(gin.TestMode)
+	r := gin.New()
+	r.POST("/groups", func(c *gin.Context) {
+		var req CreateGroupRequest
+		if err := c.ShouldBindJSON(&req); err != nil {
+			c.JSON(http.StatusBadRequest, gin.H{"error": err.Error()})
+			return
+		}
+		c.JSON(http.StatusOK, gin.H{"platform": req.Platform})
+	})
+
+	body, _ := json.Marshal(map[string]any{
+		"name":     "kiro-prod",
+		"platform": "kiro",
+	})
+	rec := httptest.NewRecorder()
+	req := httptest.NewRequest(http.MethodPost, "/groups", bytes.NewReader(body))
+	req.Header.Set("Content-Type", "application/json")
+	r.ServeHTTP(rec, req)
+
+	require.Equalf(t, http.StatusOK, rec.Code, "kiro must be a valid platform value; body=%s", rec.Body.String())
+	var resp map[string]string
+	require.NoError(t, json.Unmarshal(rec.Body.Bytes(), &resp))
+	require.Equal(t, "kiro", resp["platform"])
+}
+
+// TestUpdateGroupRequest_AcceptsKiroPlatform mirrors the create-side kiro guard
+// for the update path; both DTOs had the same gap pre-fix.
+func TestUpdateGroupRequest_AcceptsKiroPlatform(t *testing.T) {
+	gin.SetMode(gin.TestMode)
+	r := gin.New()
+	r.PUT("/groups/:id", func(c *gin.Context) {
+		var req UpdateGroupRequest
+		if err := c.ShouldBindJSON(&req); err != nil {
+			c.JSON(http.StatusBadRequest, gin.H{"error": err.Error()})
+			return
+		}
+		c.JSON(http.StatusOK, gin.H{"platform": req.Platform})
+	})
+
+	body, _ := json.Marshal(map[string]any{
+		"platform": "kiro",
+	})
+	rec := httptest.NewRecorder()
+	req := httptest.NewRequest(http.MethodPut, "/groups/1", bytes.NewReader(body))
+	req.Header.Set("Content-Type", "application/json")
+	r.ServeHTTP(rec, req)
+
+	require.Equalf(t, http.StatusOK, rec.Code, "kiro must be a valid platform value on update; body=%s", rec.Body.String())
+}
+
 // TestUpdateGroupRequest_AcceptsNewAPIPlatform mirrors the create-side guard
 // for the update path; both DTOs had the same bug pre-fix.
 func TestUpdateGroupRequest_AcceptsNewAPIPlatform(t *testing.T) {


### PR DESCRIPTION
## What

Adds `kiro` to the `Platform` `oneof` whitelist on **both** `CreateGroupRequest` and `UpdateGroupRequest`, so operators can create/patch `platform=kiro` groups via the admin API/UI.

## Why (gap from #481)

#481 shipped the sixth platform (kiro) for **account creation + forwarding + scheduling**, but missed the group DTO whitelist. Result: a kiro account could be created, but **had no schedulable group** —

- anthropic groups schedule only `{anthropic, antigravity}` (`listSchedulableAccounts` mixed branch), so a kiro account dropped into an anthropic group is filtered out;
- the non-mixed scheduler path (`ListSchedulableByGroupIDAndPlatform(groupID, "kiro")`) **already** handles `platform=kiro` correctly;
- frontend `GATEWAY_PLATFORMS` + `usePlatformOptions` **already** offered kiro in the group form;
- only the two backend binding tags lagged.

This is the **same bug class** as the earlier newapi gap (`group_handler_platform_binding_test.go` documents it). This PR follows that precedent exactly.

## Discovered via

Configuring real Kiro creds end-to-end on edge-us1 + prod: the group create API returned 500/validation reject for `platform=kiro`, forcing a temporary DB-patch (`UPDATE groups SET platform='kiro'`) to unblock testing. This PR removes the need for that hack.

## Changes

- `group_handler.go`: `oneof=anthropic openai gemini antigravity newapi` → `... newapi kiro` (×2).
- `group_handler_platform_binding_test.go`: add `TestCreateGroupRequest_AcceptsKiroPlatform` + `TestUpdateGroupRequest_AcceptsKiroPlatform` (mirror the newapi guards). The negative `RejectsUnknownPlatform` guard still holds.

## Verify

- `go test -tags=unit ./internal/handler/admin/ -run 'TestCreateGroupRequest|TestUpdateGroupRequest'` → all PASS (incl. 2 new kiro cases).
- `go build ./...` / `go vet` PASS.
- No frontend change (already supports kiro); no migration.

## Merge mode

TK-originated fix → **Squash and merge**.

🤖 Generated with [Claude Code](https://claude.com/claude-code)