### PR TITLE
docs(examples): Gemini media generation example (Imagen image + Veo video)

### DIFF
--- a/docs/examples/media-generation/README.md
+++ b/docs/examples/media-generation/README.md
@@ -1,0 +1,83 @@
+# TokenKey 媒体生成示例（图片 / 视频）
+
+通过 TokenKey 的 OpenAI 兼容网关生成图片（Imagen）和视频（Veo）。Gemini 媒体模型在网关后端经
+Google **Vertex AI** 计费/出图，对调用方完全透明——你只需要一个绑定到 Gemini 媒体分组的 API key。
+
+`generate_media.py` 仅依赖 Python 标准库，无需 `pip install`。
+
+## 快速开始
+
+```bash
+export TOKENKEY_API_KEY=sk-...           # 绑定到 Gemini 媒体分组的 key
+# export TOKENKEY_BASE_URL=https://api.tokenkey.dev   # 默认值
+
+python3 generate_media.py image "a red apple on a wooden table"
+python3 generate_media.py video "a golden retriever puppy running on a beach at sunset"
+```
+
+产物写到当前目录：`out_image_*.png` / `out_video_*.mp4`。
+
+## 模型名
+
+| 用途 | 模型 id | 备注 |
+| --- | --- | --- |
+| 图片 | `imagen-4.0-fast-generate-001` | 也支持 `imagen-4.0-generate-001`、`imagen-4.0-ultra-generate-001` |
+| 视频 | `veo-3.1-generate-001` | **不是** `-preview`；见下方"为什么是这个名字" |
+
+## 接口形态
+
+### 图片（同步，OpenAI 兼容）
+
+```
+POST /v1/images/generations
+{ "model": "imagen-4.0-fast-generate-001", "prompt": "...", "n": 1 }
+
+-> 200 { "data": [ { "b64_json": "<base64 png>", "url": "", "revised_prompt": "..." } ] }
+```
+
+OpenAI 标准形态，**Cherry Studio 等客户端可直接用**（填 base_url + key + 上面的模型 id）。
+
+### 视频（异步，原始 Vertex LRO）
+
+```
+POST /v1/video/generations
+{ "model": "veo-3.1-generate-001", "prompt": "...", "duration_seconds": 8, "aspect_ratio": "16:9" }
+
+-> 200 { "id": "vt_...", "task_id": "vt_...", "status": "queued", ... }
+```
+
+随后轮询：
+
+```
+GET /v1/video/generations/{task_id}
+
+# 进行中（原始 Vertex operation 对象，无 done 字段）：
+-> 200 { "name": "projects/.../operations/..." }
+
+# 完成：
+-> 200 { "name": "...", "done": true,
+         "response": { "videos": [ { "bytesBase64Encoded": "<base64 mp4>", "mimeType": "video/mp4" } ] } }
+
+# 完成后记录被清理（终态只下发一次，再轮询返回 404）：
+-> 404 { "error": { "message": "video task not found or expired" } }
+```
+
+**注意：**
+
+- 视频响应是**原始 Vertex 长任务（LRO）形态，不是 OpenAI 视频形态**。Cherry Studio 之类的 UI
+  通常不支持这种异步轮询，**视频建议直接走 API 调用**（如本脚本）。
+- 终态（`done: true`）只在那次轮询下发一次，随后记录删除。轮询间隔别设太大，否则可能错过终态
+  直接拿到 404。Veo 通常 1–2 分钟出片，脚本默认 10s 轮询。
+
+## 为什么视频名必须是 `veo-3.1-generate-001`
+
+视频提交路径不会应用账号级 `model_mapping`，client 传入的模型名会被原样转发给 Vertex，因此必须是
+Vertex 真实存在的模型名。Vertex 上没有 `veo-3.1-generate-preview`（那是 AI Studio 的命名），用它会
+返回 404 `Publisher Model not found`。图片路径同名透传，`imagen-4.0-*` 在两边一致。
+
+## 背景
+
+Gemini 媒体为何走 Vertex 而非 AI Studio：AI Studio（generativelanguage，API key）在部分区域是
+**预付费（prepay）钱包**计费，与 Cloud billing 额度是两个独立的池子，Cloud 额度喂不进 prepay
+钱包，会一律返回 `prepayment credits are depleted`。Vertex（Service Account JWT）走标准 Cloud
+计费，可正常使用 Cloud 额度。网关侧已配置为 Vertex 直连，调用方无需关心这些。

--- a/docs/examples/media-generation/generate_media.py
+++ b/docs/examples/media-generation/generate_media.py
@@ -1,0 +1,156 @@
+#!/usr/bin/env python3
+"""TokenKey media-generation example: image (Imagen) + video (Veo).
+
+Calls the TokenKey OpenAI-compatible gateway, which routes Gemini-media models
+to Google Vertex AI. Standard-library only (urllib/json/base64) — no pip install.
+
+Endpoints used:
+  POST {base}/v1/images/generations            -> sync, OpenAI-shaped image response
+  POST {base}/v1/video/generations             -> async submit, returns a `vt_` task id
+  GET  {base}/v1/video/generations/{task_id}   -> poll until terminal, returns raw Vertex LRO
+
+Model ids (must be the exact Vertex names — the video submit path does NOT apply
+account-level model remapping, so the client model name is forwarded verbatim):
+  image: imagen-4.0-fast-generate-001   (also: imagen-4.0-generate-001, imagen-4.0-ultra-generate-001)
+  video: veo-3.1-generate-001
+
+Configuration (env):
+  TOKENKEY_BASE_URL   default https://api.tokenkey.dev
+  TOKENKEY_API_KEY    required — a key bound to the Gemini-media group
+
+Usage:
+  export TOKENKEY_API_KEY=sk-...
+  python3 generate_media.py image "a red apple on a wooden table"
+  python3 generate_media.py video "a golden retriever puppy running on a beach at sunset"
+
+Output files are written to the current directory (out_image_*.png / out_video_*.mp4).
+"""
+
+import base64
+import json
+import os
+import sys
+import time
+import urllib.error
+import urllib.request
+
+BASE_URL = os.environ.get("TOKENKEY_BASE_URL", "https://api.tokenkey.dev").rstrip("/")
+API_KEY = os.environ.get("TOKENKEY_API_KEY", "")
+
+IMAGE_MODEL = "imagen-4.0-fast-generate-001"
+VIDEO_MODEL = "veo-3.1-generate-001"
+
+# Veo takes ~1-2 min. Poll a little faster than that so we catch the terminal
+# response before the gateway deletes the finished task record (terminal status
+# is delivered once, then the record is cleaned up and further polls return 404).
+POLL_INTERVAL_SECONDS = 10
+POLL_MAX_ATTEMPTS = 60  # ~10 minutes ceiling
+
+
+def _request(method, path, payload=None):
+    """Return (status_code, parsed_json_or_None, raw_bytes)."""
+    url = f"{BASE_URL}{path}"
+    data = json.dumps(payload).encode() if payload is not None else None
+    req = urllib.request.Request(url, data=data, method=method)
+    req.add_header("Authorization", f"Bearer {API_KEY}")
+    if data is not None:
+        req.add_header("Content-Type", "application/json")
+    try:
+        with urllib.request.urlopen(req, timeout=300) as resp:
+            raw = resp.read()
+            status = resp.status
+    except urllib.error.HTTPError as exc:
+        raw = exc.read()
+        status = exc.code
+    parsed = None
+    if raw:
+        try:
+            parsed = json.loads(raw)
+        except json.JSONDecodeError:
+            parsed = None
+    return status, parsed, raw
+
+
+def _die(msg):
+    print(f"ERROR: {msg}", file=sys.stderr)
+    sys.exit(1)
+
+
+def generate_image(prompt):
+    print(f"[image] model={IMAGE_MODEL} prompt={prompt!r}")
+    status, body, _ = _request(
+        "POST",
+        "/v1/images/generations",
+        {"model": IMAGE_MODEL, "prompt": prompt, "n": 1},
+    )
+    if status != 200 or not body or "data" not in body:
+        _die(f"image generation failed (http {status}): {body}")
+    item = body["data"][0]
+    b64 = item.get("b64_json")
+    if not b64:
+        # Some deployments return a URL instead of inline base64.
+        url = item.get("url")
+        _die(f"no inline image bytes; url={url}")
+    out = f"out_image_{int(time.time())}.png"
+    with open(out, "wb") as fh:
+        fh.write(base64.b64decode(b64))
+    print(f"[image] saved {out} ({os.path.getsize(out)} bytes)")
+
+
+def generate_video(prompt):
+    print(f"[video] model={VIDEO_MODEL} prompt={prompt!r}")
+    status, body, _ = _request(
+        "POST",
+        "/v1/video/generations",
+        {
+            "model": VIDEO_MODEL,
+            "prompt": prompt,
+            "duration_seconds": 8,
+            "aspect_ratio": "16:9",
+        },
+    )
+    if status != 200 or not body:
+        _die(f"video submit failed (http {status}): {body}")
+    task_id = body.get("task_id") or body.get("id")
+    if not task_id:
+        _die(f"video submit returned no task id: {body}")
+    print(f"[video] submitted task_id={task_id} status={body.get('status')}")
+
+    for attempt in range(1, POLL_MAX_ATTEMPTS + 1):
+        time.sleep(POLL_INTERVAL_SECONDS)
+        status, body, _ = _request("GET", f"/v1/video/generations/{task_id}")
+        if status == 404:
+            _die(
+                "task not found / expired — it likely finished and the record was "
+                "cleaned up before this poll. Lower POLL_INTERVAL_SECONDS and retry."
+            )
+        if status != 200 or body is None:
+            print(f"[video] poll {attempt}: http {status}, retrying")
+            continue
+        # Poll body is the raw Vertex long-running-operation object.
+        if body.get("done") is True:
+            if "error" in body:
+                _die(f"video generation failed upstream: {body['error']}")
+            videos = (body.get("response") or {}).get("videos") or []
+            if not videos or "bytesBase64Encoded" not in videos[0]:
+                _die(f"done but no video bytes in response: {body}")
+            out = f"out_video_{int(time.time())}.mp4"
+            with open(out, "wb") as fh:
+                fh.write(base64.b64decode(videos[0]["bytesBase64Encoded"]))
+            print(f"[video] done -> saved {out} ({os.path.getsize(out)} bytes)")
+            return
+        print(f"[video] poll {attempt}: in progress")
+    _die("timed out waiting for video to finish")
+
+
+def main():
+    if not API_KEY:
+        _die("set TOKENKEY_API_KEY")
+    if len(sys.argv) < 3 or sys.argv[1] not in ("image", "video"):
+        _die("usage: generate_media.py {image|video} <prompt>")
+    mode, prompt = sys.argv[1], " ".join(sys.argv[2:])
+    (generate_image if mode == "image" else generate_video)(prompt)
+
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
## What

Adds `docs/examples/media-generation/` — a self-contained, stdlib-only Python
example for calling the OpenAI-compatible gateway's media endpoints (backed by
Vertex AI):

- **Image** (sync, OpenAI-shaped): `POST /v1/images/generations`, model `imagen-4.0-fast-generate-001`
- **Video** (async LRO): `POST /v1/video/generations` → poll `GET /v1/video/generations/{vt_id}`, model `veo-3.1-generate-001`

`README.md` documents endpoint shapes, the exact Vertex model names (and why
`veo-3.1-generate-001` not `-preview`), the async video polling contract
(terminal status delivered once, then the record is cleaned up → 404), and the
Cherry-Studio caveat (image works as a normal OpenAI client; video is a raw
Vertex LRO and generally needs direct API calls).

## Validation

- `python3 -m py_compile` clean.
- **Live-run** against prod (ephemeral key, group 16): image mode produced a
  940 KB PNG; the video submit→poll→`done:true`→mp4 path was verified manually
  end-to-end (Veo mp4 returned).

## Scope

Docs/example only — no backend, frontend, or upstream-shaped code touched.
`scripts/preflight.sh` passes. Merge via **Squash and merge** (TK-originated PR).

🤖 Generated with [Claude Code](https://claude.com/claude-code)