### PR TITLE
docs(operator): add Kiro account onboarding guide for ops partners

### DIFF
--- a/docs/operator/kiro-account-onboarding.md
+++ b/docs/operator/kiro-account-onboarding.md
@@ -1,0 +1,63 @@
+# Kiro 账号配置 · 极简操作指南
+
+> 给运营：拿到一个 Kiro / AWS CodeWhisperer 授权，在 TokenKey 后台配成可用账号。
+> 全程在你自己的 Mac 上操作。
+
+## 5 步搞定
+
+**1. 装 Kiro 并登录**
+- 装：`brew install --cask kiro`（或官网 <https://kiro.dev> 下载）
+- 开：`open -a Kiro`
+- 登录选 **组织 / 公司 SSO**，填起始地址（例 `https://d-906671b2ce.awsapps.com/start`），浏览器点 **批准**。
+
+**2. 提取凭证**（终端粘贴运行，会打印一段 JSON）
+
+```bash
+python3 - <<'PY'
+import json, glob, os
+c = os.path.expanduser("~/.aws/sso/cache")
+t = json.load(open(os.path.join(c, "kiro-auth-token.json")))
+auth = "social" if str(t.get("authMethod","")).lower()=="social" else "idc"
+out = {"access_token": t["accessToken"], "refresh_token": t["refreshToken"],
+       "region": t.get("region","us-east-1"), "auth_method": auth}
+if auth == "idc":
+    reg = next(json.load(open(f)) for f in glob.glob(c+"/*.json")
+               if not f.endswith("kiro-auth-token.json") and "clientSecret" in json.load(open(f)))
+    out["client_id"], out["client_secret"] = reg["clientId"], reg["clientSecret"]
+print(json.dumps(out, ensure_ascii=False, indent=2))
+PY
+```
+
+> 这几段是敏感凭证（等于账号密码）：只在后台输入框粘贴，不发群、不存文件、不截图。
+
+**3. 后台新建账号**
+账号管理 → 新建 → 平台选 **Kiro**，把上面 JSON 填进对应框：
+
+| 后台字段 | 填 |
+| --- | --- |
+| Access Token | `access_token` |
+| Refresh Token | `refresh_token` |
+| Region | `us-east-1` |
+| 认证方式 | IdC（组织 SSO）/ Social（社交登录） |
+| Client ID / Client Secret | `client_id` / `client_secret`（仅 IdC） |
+| Profile ARN | 留空 |
+| ☑ 接受 Kiro 服务条款 | **必须勾** |
+
+保存。
+
+**4. 打开总开关（只需开一次）**
+系统设置 → 「Kiro（第六平台）」→ 打开 **启用 Kiro 转发** → 保存。
+
+**5. 挂分组**
+把账号挂到对应 group，按常规设 RPM / 并发即可（和其它平台一样）。
+
+## 常见问题
+
+| 现象 | 处理 |
+| --- | --- |
+| 调用报 `kiro platform is disabled` | 第 4 步总开关没开 |
+| 创建提示要确认 ToS | 勾「接受 Kiro 服务条款」 |
+| 创建提示缺 client_id/secret | IdC 必须填这两个 |
+| 持续 401 / 刷新失败 | 回第 1 步重登 Kiro，重跑第 2 步，**编辑**账号粘新 token |
+
+> Access Token 过期不用管，系统会用 refresh token 自动续。


### PR DESCRIPTION
## What

新增运营合伙人用的 **Kiro（第六平台）账号配置极简操作指南**：`docs/operator/kiro-account-onboarding.md`。

5 步流程：装 Kiro 并用组织 SSO 登录 → 从本机 `~/.aws/sso/cache/` 提取 OAuth 凭证（附一键脚本）→ 后台新建 `kiro` 账号（逐字段对照表）→ 打开全局「启用 Kiro 转发」总开关（一次性）→ 挂分组。外加常见问题对照表。

## Why

Kiro 已在本机实测打通（PR #481 已合并）。运营需要一份能直接照做的交付文档来批量接入 Kiro 订阅账号。

## 契约对齐（非凭印象）

文档里的字段 / 必填规则 / 两道 ToS 门禁均对齐已发布代码：
- `backend/internal/handler/admin/account_handler_tk_kiro_validate.go` — 创建校验（access/refresh/region 必填、idc 需 client_id/secret、tos_acknowledged）
- `backend/internal/service/setting_service_tk_kiro.go` — 全局启用门禁（默认关，关时返回 `kiro platform is disabled`）
- `frontend/src/composables/useTkAccountKiroPlatform.ts` / `AccountKiroPlatformFields.vue` — 表单字段
- `frontend/src/views/admin/SettingsView.vue` — 「Kiro（第六平台）」总开关

## Scope

Docs-only，新增一个文件，无代码 / 无 upstream 路径改动。`scripts/preflight.sh` 本地全绿。

🤖 Generated with [Claude Code](https://claude.com/claude-code)