### PR TITLE
feat(admin): enrich edge accounts overview with live gauges + show all statuses

### DIFF
--- a/backend/cmd/server/wire_gen.go
+++ b/backend/cmd/server/wire_gen.go
@@ -277,7 +277,7 @@ func initializeApplication(buildInfo handler.BuildInfo) (*Application, error) {
 	mePricingCatalogHandler := handler.NewMePricingCatalogHandler(mePricingCatalogService)
 	qaHandler := handler.NewQAHandler(qaService)
 	edgeCapacityHandler := handler.ProvideEdgeCapacityHandler(accountRepository)
-	handlerEdgeAccountsHandler := handler.ProvideEdgeAccountsHandler(accountRepository)
+	handlerEdgeAccountsHandler := handler.ProvideEdgeAccountsHandler(adminService, concurrencyService, sessionLimitCache, rpmCache, accountUsageService)
 	idempotencyCoordinator := service.ProvideIdempotencyCoordinator(idempotencyRepository, configConfig)
 	idempotencyCleanupService := service.ProvideIdempotencyCleanupService(idempotencyRepository, configConfig)
 	handlers := handler.ProvideHandlers(authHandler, userHandler, apiKeyHandler, usageHandler, redeemHandler, subscriptionHandler, announcementHandler, channelMonitorUserHandler, adminHandlers, gatewayHandler, openAIGatewayHandler, handlerSettingHandler, totpHandler, handlerPaymentHandler, paymentWebhookHandler, availableChannelHandler, qaService, pricingCatalogHandler, mePricingCatalogHandler, qaHandler, edgeCapacityHandler, handlerEdgeAccountsHandler, idempotencyCoordinator, idempotencyCleanupService)

--- a/backend/internal/handler/edge_tk_accounts_handler.go
+++ b/backend/internal/handler/edge_tk_accounts_handler.go
@@ -4,27 +4,36 @@ import (
 	"context"
 	"net/http"
 	"strings"
+	"sync"
 	"time"
 
 	"github.com/Wei-Shaw/sub2api/internal/pkg/response"
+	"github.com/Wei-Shaw/sub2api/internal/pkg/usagestats"
 	"github.com/Wei-Shaw/sub2api/internal/service"
 
 	"github.com/gin-gonic/gin"
+	"golang.org/x/sync/errgroup"
 )
 
-// edgeAccountsReader is the narrow read-only dependency the edge accounts
-// endpoint needs. service.AccountRepository satisfies it via ListByPlatform.
-// Reusing the existing repository method means NO change to the AccountRepository
-// interface — and therefore zero churn on its mocks/stubs (CLAUDE.md rule 6).
-type edgeAccountsReader interface {
-	ListByPlatform(ctx context.Context, platform string) ([]service.Account, error)
+// edgeAccountsMaxPageSize bounds the single-page listing. Edges host a handful
+// of operator-curated accounts, so one large page returns the whole inventory.
+const edgeAccountsMaxPageSize = 1000
+
+// edgeAccountsLister is the narrow read-only dependency the edge accounts
+// endpoint needs. service.AdminService satisfies it via ListAccounts.
+//
+// It MUST be ListAccounts (status filter = ""), NOT the repository's
+// ListByPlatform: ListByPlatform pins status = "active" and therefore hides
+// disabled / errored accounts, making this endpoint show fewer rows than the
+// edge's own /admin/accounts page. The prod overview must mirror that page's
+// full inventory, so it reuses the exact same lister the admin page uses.
+type edgeAccountsLister interface {
+	ListAccounts(ctx context.Context, page, pageSize int, platform, accountType, status, search string, groupID int64, privacyMode, sortBy, sortOrder string) ([]service.Account, int64, error)
 }
 
 // edgeAccountsSupportedPlatforms is the allowlist this read endpoint accepts.
 // Edges are anthropic-centric today; the gate keeps a prod misconfig loud
 // (400) rather than silently returning an empty list for a typo'd platform.
-// Mirrors the capacity endpoint's "reject unsupported, never default silently"
-// posture (see edge_tk_capacity_handler.go).
 var edgeAccountsSupportedPlatforms = map[string]struct{}{
 	service.PlatformAnthropic:   {},
 	service.PlatformOpenAI:      {},
@@ -32,9 +41,33 @@ var edgeAccountsSupportedPlatforms = map[string]struct{}{
 	service.PlatformAntigravity: {},
 }
 
+// The runtime-gauge readers below mirror the dependencies admin AccountHandler
+// uses to enrich its list (see handler/admin/account_handler.go List() — the
+// reference block this endpoint replicates). Each is OPTIONAL (nil-safe): a nil
+// reader simply skips that gauge so the endpoint degrades to the static fields
+// rather than failing. They read THIS edge's local Redis/DB, which is exactly
+// the per-edge live state the prod overview wants to surface.
+type edgeConcurrencyReader interface {
+	GetAccountConcurrencyBatch(ctx context.Context, accountIDs []int64) (map[int64]int, error)
+}
+
+type edgeSessionReader interface {
+	GetActiveSessionCountBatch(ctx context.Context, accountIDs []int64, idleTimeouts map[int64]time.Duration) (map[int64]int, error)
+}
+
+type edgeRPMReader interface {
+	GetRPMBatch(ctx context.Context, accountIDs []int64) (map[int64]int, error)
+}
+
+type edgeUsageReader interface {
+	GetAccountWindowStats(ctx context.Context, accountID int64, startTime time.Time) (*usagestats.AccountStats, error)
+	GetTodayStatsBatch(ctx context.Context, accountIDs []int64) (map[int64]*service.WindowStats, error)
+}
+
 // EdgeAccountsHandler serves the TokenKey read-only "edge accounts" endpoint
 // that prod's cross-edge admin overview calls over HTTP to enumerate each
-// edge's account inventory. It is the list sibling of EdgeCapacityHandler.
+// edge's account inventory + live capacity/today gauges. It is the list sibling
+// of EdgeCapacityHandler.
 //
 // Like the capacity endpoint it is mounted behind the dedicated lightweight
 // api-key check (middleware/edge_capacity_auth_tk.go), NOT the gateway
@@ -46,18 +79,45 @@ var edgeAccountsSupportedPlatforms = map[string]struct{}{
 // than merely redacted. The edge_tk_accounts_handler_test.go asserts the raw
 // bytes carry no credential substrings.
 type EdgeAccountsHandler struct {
-	accounts edgeAccountsReader
+	accounts    edgeAccountsLister
+	concurrency edgeConcurrencyReader
+	sessions    edgeSessionReader
+	rpm         edgeRPMReader
+	usage       edgeUsageReader
 }
 
-// NewEdgeAccountsHandler wires the edge accounts handler.
-func NewEdgeAccountsHandler(accounts edgeAccountsReader) *EdgeAccountsHandler {
-	return &EdgeAccountsHandler{accounts: accounts}
+// NewEdgeAccountsHandler wires the edge accounts handler. The runtime-gauge
+// readers may be nil (the endpoint then returns static fields only).
+func NewEdgeAccountsHandler(
+	accounts edgeAccountsLister,
+	concurrency edgeConcurrencyReader,
+	sessions edgeSessionReader,
+	rpm edgeRPMReader,
+	usage edgeUsageReader,
+) *EdgeAccountsHandler {
+	return &EdgeAccountsHandler{
+		accounts:    accounts,
+		concurrency: concurrency,
+		sessions:    sessions,
+		rpm:         rpm,
+		usage:       usage,
+	}
+}
+
+// edgeTodayStats mirrors service.WindowStats minus standard_cost (the overview
+// shows account cost "A" and user cost "U", matching AccountTodayStatsCell).
+type edgeTodayStats struct {
+	Requests int64   `json:"requests"`
+	Tokens   int64   `json:"tokens"`
+	Cost     float64 `json:"cost"`
+	UserCost float64 `json:"user_cost"`
 }
 
 // edgeAccountDTO is the on-the-wire, sanitized read-model for one edge account.
 // It deliberately omits every credential-bearing field. Timestamps marshal as
-// RFC3339 (nil → omitted). Optional anthropic-tier scalars are omitempty so the
-// payload stays small for non-anthropic accounts.
+// RFC3339 (nil → omitted). The current_* / today_stats fields are live gauges
+// computed from this edge's local Redis/DB; the *_limit / max_* / base_* fields
+// are the configured caps the gauges render against.
 type edgeAccountDTO struct {
 	ID             int64   `json:"id"`
 	Name           string  `json:"name"`
@@ -86,9 +146,22 @@ type edgeAccountDTO struct {
 	RateLimitResetAt *time.Time `json:"rate_limit_reset_at,omitempty"`
 	OverloadUntil    *time.Time `json:"overload_until,omitempty"`
 
-	WindowCostLimit float64 `json:"window_cost_limit,omitempty"`
-	MaxSessions     int     `json:"max_sessions,omitempty"`
-	BaseRPM         int     `json:"base_rpm,omitempty"`
+	// Configured caps (anthropic oauth/setup-token).
+	WindowCostLimit           float64 `json:"window_cost_limit,omitempty"`
+	WindowCostStickyReserve   float64 `json:"window_cost_sticky_reserve,omitempty"`
+	MaxSessions               int     `json:"max_sessions,omitempty"`
+	SessionIdleTimeoutMinutes int     `json:"session_idle_timeout_minutes,omitempty"`
+	BaseRPM                   int     `json:"base_rpm,omitempty"`
+	RPMStrategy               string  `json:"rpm_strategy,omitempty"`
+	RPMStickyBuffer           int     `json:"rpm_sticky_buffer,omitempty"`
+
+	// Live gauges (this edge's local Redis/DB). Pointers so "feature off" (nil)
+	// is distinguishable from a real 0; current_concurrency is always present.
+	CurrentConcurrency int             `json:"current_concurrency"`
+	CurrentWindowCost  *float64        `json:"current_window_cost,omitempty"`
+	ActiveSessions     *int            `json:"active_sessions,omitempty"`
+	CurrentRPM         *int            `json:"current_rpm,omitempty"`
+	TodayStats         *edgeTodayStats `json:"today_stats,omitempty"`
 
 	TierID *int64   `json:"tier_id,omitempty"`
 	Groups []string `json:"groups,omitempty"`
@@ -114,15 +187,22 @@ func (h *EdgeAccountsHandler) ListAccounts(c *gin.Context) {
 		return
 	}
 
-	accounts, err := h.accounts.ListByPlatform(c.Request.Context(), platform)
+	ctx := c.Request.Context()
+	// status="" → all statuses (active/disabled/errored), matching the edge's own
+	// /admin/accounts page. priority asc mirrors the admin default ordering.
+	accounts, _, err := h.accounts.ListAccounts(ctx, 1, edgeAccountsMaxPageSize, platform, "", "", "", 0, "", "priority", "asc")
 	if err != nil {
 		response.Error(c, http.StatusInternalServerError, "failed to list accounts")
 		return
 	}
 
+	runtime := h.collectRuntimeGauges(ctx, accounts)
+
 	dtos := make([]edgeAccountDTO, 0, len(accounts))
 	for i := range accounts {
-		dtos = append(dtos, toEdgeAccountDTO(&accounts[i]))
+		dto := toEdgeAccountDTO(&accounts[i])
+		runtime.apply(&accounts[i], &dto)
+		dtos = append(dtos, dto)
 	}
 
 	response.Success(c, edgeAccountsResponse{
@@ -132,42 +212,180 @@ func (h *EdgeAccountsHandler) ListAccounts(c *gin.Context) {
 	})
 }
 
-// toEdgeAccountDTO maps a service.Account to the sanitized read-model. It reads
-// ONLY non-sensitive fields/getters — Credentials/Extra/Proxy/Notes are never
-// touched. The anthropic window/session/rpm scalars come from Extra-backed
-// getters and are 0 (→ omitted) for platforms that don't use them.
+// edgeRuntimeGauges holds the batch-collected live values keyed by account id.
+type edgeRuntimeGauges struct {
+	concurrency map[int64]int
+	windowCost  map[int64]float64
+	sessions    map[int64]int
+	rpm         map[int64]int
+	today       map[int64]*service.WindowStats
+}
+
+// apply copies the per-account gauges onto the DTO, mirroring the admin
+// AccountWithConcurrency assembly (current_* only set when the feature applies).
+func (g *edgeRuntimeGauges) apply(acc *service.Account, dto *edgeAccountDTO) {
+	if g == nil {
+		return
+	}
+	dto.CurrentConcurrency = g.concurrency[acc.ID]
+	if g.windowCost != nil {
+		if cost, ok := g.windowCost[acc.ID]; ok {
+			dto.CurrentWindowCost = &cost
+		}
+	}
+	if g.sessions != nil {
+		if n, ok := g.sessions[acc.ID]; ok {
+			dto.ActiveSessions = &n
+		}
+	}
+	if g.rpm != nil {
+		if n, ok := g.rpm[acc.ID]; ok {
+			dto.CurrentRPM = &n
+		}
+	}
+	if g.today != nil {
+		if ws, ok := g.today[acc.ID]; ok && ws != nil {
+			dto.TodayStats = &edgeTodayStats{
+				Requests: ws.Requests,
+				Tokens:   ws.Tokens,
+				Cost:     ws.Cost,
+				UserCost: ws.UserCost,
+			}
+		}
+	}
+}
+
+// collectRuntimeGauges batch-reads the live capacity/today gauges for the given
+// accounts from this edge's local Redis/DB. It replicates the gating and batch
+// strategy of admin AccountHandler.List (account_handler.go:278-386): concurrency
+// + today-stats for all accounts; window-cost / sessions / rpm only for anthropic
+// OAuth/setup-token accounts with the corresponding cap configured. Every reader
+// is nil-safe and partial failure is swallowed (the gauge is simply absent).
+func (h *EdgeAccountsHandler) collectRuntimeGauges(ctx context.Context, accounts []service.Account) *edgeRuntimeGauges {
+	g := &edgeRuntimeGauges{concurrency: map[int64]int{}}
+	if len(accounts) == 0 {
+		return g
+	}
+
+	accountIDs := make([]int64, len(accounts))
+	for i := range accounts {
+		accountIDs[i] = accounts[i].ID
+	}
+
+	// Concurrency: cheap Redis ZCARD, all accounts.
+	if h.concurrency != nil {
+		if cc, err := h.concurrency.GetAccountConcurrencyBatch(ctx, accountIDs); err == nil && cc != nil {
+			g.concurrency = cc
+		}
+	}
+
+	// Today stats: batch SQL, all accounts.
+	if h.usage != nil {
+		if ts, err := h.usage.GetTodayStatsBatch(ctx, accountIDs); err == nil && ts != nil {
+			g.today = ts
+		}
+	}
+
+	// Gate window-cost / sessions / rpm by anthropic OAuth/setup-token + cap.
+	windowCostIDs := make([]int64, 0)
+	sessionIDs := make([]int64, 0)
+	rpmIDs := make([]int64, 0)
+	idleTimeouts := make(map[int64]time.Duration)
+	for i := range accounts {
+		acc := &accounts[i]
+		if !acc.IsAnthropicOAuthOrSetupToken() {
+			continue
+		}
+		if acc.GetWindowCostLimit() > 0 {
+			windowCostIDs = append(windowCostIDs, acc.ID)
+		}
+		if acc.GetMaxSessions() > 0 {
+			sessionIDs = append(sessionIDs, acc.ID)
+			idleTimeouts[acc.ID] = time.Duration(acc.GetSessionIdleTimeoutMinutes()) * time.Minute
+		}
+		if acc.GetBaseRPM() > 0 {
+			rpmIDs = append(rpmIDs, acc.ID)
+		}
+	}
+
+	if len(rpmIDs) > 0 && h.rpm != nil {
+		if m, err := h.rpm.GetRPMBatch(ctx, rpmIDs); err == nil {
+			g.rpm = m
+		}
+	}
+	if len(sessionIDs) > 0 && h.sessions != nil {
+		if m, err := h.sessions.GetActiveSessionCountBatch(ctx, sessionIDs, idleTimeouts); err == nil {
+			g.sessions = m
+		}
+	}
+	if len(windowCostIDs) > 0 && h.usage != nil {
+		g.windowCost = make(map[int64]float64)
+		var mu sync.Mutex
+		eg, egctx := errgroup.WithContext(ctx)
+		eg.SetLimit(10)
+		for i := range accounts {
+			acc := &accounts[i]
+			if !acc.IsAnthropicOAuthOrSetupToken() || acc.GetWindowCostLimit() <= 0 {
+				continue
+			}
+			accCopy := acc
+			eg.Go(func() error {
+				startTime := accCopy.GetCurrentWindowStartTime()
+				stats, err := h.usage.GetAccountWindowStats(egctx, accCopy.ID, startTime)
+				if err == nil && stats != nil {
+					mu.Lock()
+					g.windowCost[accCopy.ID] = stats.StandardCost
+					mu.Unlock()
+				}
+				return nil // partial failure tolerated
+			})
+		}
+		_ = eg.Wait()
+	}
+
+	return g
+}
+
+// toEdgeAccountDTO maps a service.Account to the sanitized read-model's static
+// fields. It reads ONLY non-sensitive fields/getters — Credentials/Extra/Proxy/
+// Notes are never touched. The live current_* gauges are attached separately by
+// edgeRuntimeGauges.apply.
 func toEdgeAccountDTO(a *service.Account) edgeAccountDTO {
 	dto := edgeAccountDTO{
-		ID:                      a.ID,
-		Name:                    a.Name,
-		Platform:                a.Platform,
-		Type:                    a.Type,
-		ChannelType:             a.ChannelType,
-		Status:                  a.Status,
-		Schedulable:             a.Schedulable,
-		IsSchedulable:           a.IsSchedulable(),
-		Concurrency:             a.Concurrency,
-		Priority:                a.Priority,
-		RateMultiplier:          a.BillingRateMultiplier(),
-		ErrorMessage:            a.ErrorMessage,
-		LastUsedAt:              a.LastUsedAt,
-		ExpiresAt:               a.ExpiresAt,
-		CreatedAt:               a.CreatedAt,
-		SessionWindowStatus:     a.SessionWindowStatus,
-		SessionWindowEnd:        a.SessionWindowEnd,
-		TempUnschedulableUntil:  a.TempUnschedulableUntil,
-		TempUnschedulableReason: a.TempUnschedulableReason,
-		RateLimitedAt:           a.RateLimitedAt,
-		RateLimitResetAt:        a.RateLimitResetAt,
-		OverloadUntil:           a.OverloadUntil,
-		WindowCostLimit:         a.GetWindowCostLimit(),
-		MaxSessions:             a.GetMaxSessions(),
-		BaseRPM:                 a.GetBaseRPM(),
-		TierID:                  a.TierID,
+		ID:                        a.ID,
+		Name:                      a.Name,
+		Platform:                  a.Platform,
+		Type:                      a.Type,
+		ChannelType:               a.ChannelType,
+		Status:                    a.Status,
+		Schedulable:               a.Schedulable,
+		IsSchedulable:             a.IsSchedulable(),
+		Concurrency:               a.Concurrency,
+		Priority:                  a.Priority,
+		RateMultiplier:            a.BillingRateMultiplier(),
+		ErrorMessage:              a.ErrorMessage,
+		LastUsedAt:                a.LastUsedAt,
+		ExpiresAt:                 a.ExpiresAt,
+		CreatedAt:                 a.CreatedAt,
+		SessionWindowStatus:       a.SessionWindowStatus,
+		SessionWindowEnd:          a.SessionWindowEnd,
+		TempUnschedulableUntil:    a.TempUnschedulableUntil,
+		TempUnschedulableReason:   a.TempUnschedulableReason,
+		RateLimitedAt:             a.RateLimitedAt,
+		RateLimitResetAt:          a.RateLimitResetAt,
+		OverloadUntil:             a.OverloadUntil,
+		WindowCostLimit:           a.GetWindowCostLimit(),
+		WindowCostStickyReserve:   a.GetWindowCostStickyReserve(),
+		MaxSessions:               a.GetMaxSessions(),
+		SessionIdleTimeoutMinutes: a.GetSessionIdleTimeoutMinutes(),
+		BaseRPM:                   a.GetBaseRPM(),
+		RPMStrategy:               a.GetRPMStrategy(),
+		RPMStickyBuffer:           a.GetRPMStickyBuffer(),
+		TierID:                    a.TierID,
 	}
-	for _, g := range a.Groups {
-		if g != nil && strings.TrimSpace(g.Name) != "" {
-			dto.Groups = append(dto.Groups, g.Name)
+	for _, grp := range a.Groups {
+		if grp != nil && strings.TrimSpace(grp.Name) != "" {
+			dto.Groups = append(dto.Groups, grp.Name)
 		}
 	}
 	return dto

--- a/backend/internal/handler/edge_tk_accounts_handler_test.go
+++ b/backend/internal/handler/edge_tk_accounts_handler_test.go
@@ -12,21 +12,24 @@ import (
 	"testing"
 	"time"
 
+	"github.com/Wei-Shaw/sub2api/internal/pkg/usagestats"
 	"github.com/Wei-Shaw/sub2api/internal/service"
 
 	"github.com/gin-gonic/gin"
 	"github.com/stretchr/testify/require"
 )
 
-type edgeAccountsReaderStub struct {
+type edgeAccountsListerStub struct {
 	accounts     []service.Account
 	err          error
 	lastPlatform string
+	lastStatus   string
 }
 
-func (s *edgeAccountsReaderStub) ListByPlatform(_ context.Context, platform string) ([]service.Account, error) {
+func (s *edgeAccountsListerStub) ListAccounts(_ context.Context, _, _ int, platform, _, status, _ string, _ int64, _, _, _ string) ([]service.Account, int64, error) {
 	s.lastPlatform = platform
-	return s.accounts, s.err
+	s.lastStatus = status
+	return s.accounts, int64(len(s.accounts)), s.err
 }
 
 func performEdgeAccountsRequest(t *testing.T, h *EdgeAccountsHandler, query string) *httptest.ResponseRecorder {
@@ -75,11 +78,13 @@ func richAccount() service.Account {
 }
 
 func TestEdgeAccountsHandler_ReturnsSanitizedAccounts(t *testing.T) {
-	stub := &edgeAccountsReaderStub{accounts: []service.Account{richAccount()}}
-	h := NewEdgeAccountsHandler(stub)
+	stub := &edgeAccountsListerStub{accounts: []service.Account{richAccount()}}
+	h := NewEdgeAccountsHandler(stub, nil, nil, nil, nil)
 	w := performEdgeAccountsRequest(t, h, "?platform=anthropic")
 	require.Equal(t, http.StatusOK, w.Code)
 	require.Equal(t, service.PlatformAnthropic, stub.lastPlatform)
+	// MUST list all statuses (status filter empty) to mirror the edge admin page.
+	require.Equal(t, "", stub.lastStatus)
 
 	var env struct {
 		Data edgeAccountsResponse `json:"data"`
@@ -105,8 +110,8 @@ func TestEdgeAccountsHandler_ReturnsSanitizedAccounts(t *testing.T) {
 // TestEdgeAccountsHandler_NeverLeaksCredentials is the load-bearing security
 // assertion: the raw response bytes must not contain ANY credential value or key.
 func TestEdgeAccountsHandler_NeverLeaksCredentials(t *testing.T) {
-	stub := &edgeAccountsReaderStub{accounts: []service.Account{richAccount()}}
-	h := NewEdgeAccountsHandler(stub)
+	stub := &edgeAccountsListerStub{accounts: []service.Account{richAccount()}}
+	h := NewEdgeAccountsHandler(stub, nil, nil, nil, nil)
 	w := performEdgeAccountsRequest(t, h, "?platform=anthropic")
 	require.Equal(t, http.StatusOK, w.Code)
 
@@ -121,30 +126,114 @@ func TestEdgeAccountsHandler_NeverLeaksCredentials(t *testing.T) {
 	}
 }
 
+// ---- runtime-gauge enrichment ----
+
+type fakeConcReader struct{ m map[int64]int }
+
+func (f fakeConcReader) GetAccountConcurrencyBatch(_ context.Context, _ []int64) (map[int64]int, error) {
+	return f.m, nil
+}
+
+type fakeSessReader struct{ m map[int64]int }
+
+func (f fakeSessReader) GetActiveSessionCountBatch(_ context.Context, _ []int64, _ map[int64]time.Duration) (map[int64]int, error) {
+	return f.m, nil
+}
+
+type fakeRPMReader struct{ m map[int64]int }
+
+func (f fakeRPMReader) GetRPMBatch(_ context.Context, _ []int64) (map[int64]int, error) {
+	return f.m, nil
+}
+
+type fakeUsageReader struct {
+	today map[int64]*service.WindowStats
+	wcost float64
+}
+
+func (f fakeUsageReader) GetAccountWindowStats(_ context.Context, _ int64, _ time.Time) (*usagestats.AccountStats, error) {
+	return &usagestats.AccountStats{StandardCost: f.wcost}, nil
+}
+
+func (f fakeUsageReader) GetTodayStatsBatch(_ context.Context, _ []int64) (map[int64]*service.WindowStats, error) {
+	return f.today, nil
+}
+
+func richOAuthAccount() service.Account {
+	return service.Account{
+		ID:       7,
+		Name:     "edge-oauth-1",
+		Platform: service.PlatformAnthropic,
+		Type:     service.AccountTypeOAuth,
+		Status:   service.StatusActive,
+		Extra: map[string]any{
+			"window_cost_limit": 600.0,
+			"max_sessions":      150,
+			"base_rpm":          56,
+		},
+		Concurrency: 12,
+		Priority:    5,
+		Schedulable: true,
+		CreatedAt:   time.Now(),
+	}
+}
+
+func TestEdgeAccountsHandler_EnrichesRuntimeGauges(t *testing.T) {
+	stub := &edgeAccountsListerStub{accounts: []service.Account{richOAuthAccount()}}
+	h := NewEdgeAccountsHandler(
+		stub,
+		fakeConcReader{m: map[int64]int{7: 3}},
+		fakeSessReader{m: map[int64]int{7: 4}},
+		fakeRPMReader{m: map[int64]int{7: 9}},
+		fakeUsageReader{today: map[int64]*service.WindowStats{7: {Requests: 80, Tokens: 65_900_000, Cost: 36.53, UserCost: 36.53}}, wcost: 36.53},
+	)
+	w := performEdgeAccountsRequest(t, h, "?platform=anthropic")
+	require.Equal(t, http.StatusOK, w.Code)
+
+	var env struct {
+		Data edgeAccountsResponse `json:"data"`
+	}
+	require.NoError(t, json.Unmarshal(w.Body.Bytes(), &env))
+	require.Len(t, env.Data.Accounts, 1)
+	got := env.Data.Accounts[0]
+
+	require.Equal(t, 3, got.CurrentConcurrency)
+	require.NotNil(t, got.ActiveSessions)
+	require.Equal(t, 4, *got.ActiveSessions)
+	require.NotNil(t, got.CurrentRPM)
+	require.Equal(t, 9, *got.CurrentRPM)
+	require.NotNil(t, got.CurrentWindowCost)
+	require.Equal(t, 36.53, *got.CurrentWindowCost)
+	require.NotNil(t, got.TodayStats)
+	require.Equal(t, int64(80), got.TodayStats.Requests)
+	require.Equal(t, int64(65_900_000), got.TodayStats.Tokens)
+	require.Equal(t, 36.53, got.TodayStats.Cost)
+	require.Equal(t, 36.53, got.TodayStats.UserCost)
+}
+
 func TestEdgeAccountsHandler_RejectsUnknownPlatform(t *testing.T) {
-	h := NewEdgeAccountsHandler(&edgeAccountsReaderStub{})
+	h := NewEdgeAccountsHandler(&edgeAccountsListerStub{}, nil, nil, nil, nil)
 	w := performEdgeAccountsRequest(t, h, "?platform=bogus")
 	require.Equal(t, http.StatusBadRequest, w.Code)
 }
 
 func TestEdgeAccountsHandler_DefaultsToAnthropic(t *testing.T) {
-	stub := &edgeAccountsReaderStub{}
-	h := NewEdgeAccountsHandler(stub)
+	stub := &edgeAccountsListerStub{}
+	h := NewEdgeAccountsHandler(stub, nil, nil, nil, nil)
 	w := performEdgeAccountsRequest(t, h, "")
 	require.Equal(t, http.StatusOK, w.Code)
 	require.Equal(t, service.PlatformAnthropic, stub.lastPlatform)
 }
 
 func TestEdgeAccountsHandler_ListError(t *testing.T) {
-	h := NewEdgeAccountsHandler(&edgeAccountsReaderStub{err: errors.New("db down")})
+	h := NewEdgeAccountsHandler(&edgeAccountsListerStub{err: errors.New("db down")}, nil, nil, nil, nil)
 	w := performEdgeAccountsRequest(t, h, "?platform=anthropic")
 	require.Equal(t, http.StatusInternalServerError, w.Code)
 }
 
 func TestEdgeAccountsHandler_NilReader(t *testing.T) {
-	h := NewEdgeAccountsHandler(nil)
+	h := NewEdgeAccountsHandler(nil, nil, nil, nil, nil)
 	w := performEdgeAccountsRequest(t, h, "?platform=anthropic")
 	require.Equal(t, http.StatusInternalServerError, w.Code)
-	// sanity: the body should not look like a normal success envelope
 	require.False(t, strings.Contains(w.Body.String(), `"accounts"`))
 }

--- a/backend/internal/handler/wire.go
+++ b/backend/internal/handler/wire.go
@@ -179,11 +179,19 @@ func ProvideEdgeCapacityHandler(accountRepo service.AccountRepository) *EdgeCapa
 	return NewEdgeCapacityHandler(accountRepo)
 }
 
-// ProvideEdgeAccountsHandler adapts the wire-provided service.AccountRepository
-// (which satisfies the handler's narrow edgeAccountsReader interface) to the
-// edge accounts read handler. Mirrors ProvideEdgeCapacityHandler.
-func ProvideEdgeAccountsHandler(accountRepo service.AccountRepository) *EdgeAccountsHandler {
-	return NewEdgeAccountsHandler(accountRepo)
+// ProvideEdgeAccountsHandler adapts the wire-provided account repository plus the
+// live-gauge services (concurrency / session-limit / rpm / usage — the same set
+// admin AccountHandler uses) to the edge accounts read handler. The gauge readers
+// let the edge endpoint surface per-edge capacity/today figures that align with
+// the per-edge admin accounts page. Mirrors ProvideEdgeCapacityHandler in shape.
+func ProvideEdgeAccountsHandler(
+	adminService service.AdminService,
+	concurrencyService *service.ConcurrencyService,
+	sessionLimitCache service.SessionLimitCache,
+	rpmCache service.RPMCache,
+	accountUsageService *service.AccountUsageService,
+) *EdgeAccountsHandler {
+	return NewEdgeAccountsHandler(adminService, concurrencyService, sessionLimitCache, rpmCache, accountUsageService)
 }
 
 // ProvideTKEdgeAccountsAdminHandler adapts the wire-provided concrete

--- a/backend/internal/service/edge_accounts_aggregator_tk.go
+++ b/backend/internal/service/edge_accounts_aggregator_tk.go
@@ -50,48 +50,19 @@ type edgeAccountsStore interface {
 	ListByPlatform(ctx context.Context, platform string) ([]Account, error)
 }
 
-// EdgeAccountSummary is prod's decode target for one account returned by an edge.
-// It mirrors handler.edgeAccountDTO's wire shape (cross-deployment JSON contract).
-// Kept as a prod-local struct rather than a shared type because the two sides are
-// separate deployments whose only coupling is this JSON shape.
-type EdgeAccountSummary struct {
-	ID                      int64      `json:"id"`
-	Name                    string     `json:"name"`
-	Platform                string     `json:"platform"`
-	Type                    string     `json:"type"`
-	ChannelType             int        `json:"channel_type,omitempty"`
-	Status                  string     `json:"status"`
-	Schedulable             bool       `json:"schedulable"`
-	IsSchedulable           bool       `json:"is_schedulable"`
-	Concurrency             int        `json:"concurrency"`
-	Priority                int        `json:"priority"`
-	RateMultiplier          float64    `json:"rate_multiplier"`
-	ErrorMessage            string     `json:"error_message,omitempty"`
-	LastUsedAt              *time.Time `json:"last_used_at,omitempty"`
-	ExpiresAt               *time.Time `json:"expires_at,omitempty"`
-	CreatedAt               time.Time  `json:"created_at"`
-	SessionWindowStatus     string     `json:"session_window_status,omitempty"`
-	SessionWindowEnd        *time.Time `json:"session_window_end,omitempty"`
-	TempUnschedulableUntil  *time.Time `json:"temp_unschedulable_until,omitempty"`
-	TempUnschedulableReason string     `json:"temp_unschedulable_reason,omitempty"`
-	RateLimitedAt           *time.Time `json:"rate_limited_at,omitempty"`
-	RateLimitResetAt        *time.Time `json:"rate_limit_reset_at,omitempty"`
-	OverloadUntil           *time.Time `json:"overload_until,omitempty"`
-	WindowCostLimit         float64    `json:"window_cost_limit,omitempty"`
-	MaxSessions             int        `json:"max_sessions,omitempty"`
-	BaseRPM                 int        `json:"base_rpm,omitempty"`
-	TierID                  *int64     `json:"tier_id,omitempty"`
-	Groups                  []string   `json:"groups,omitempty"`
-}
-
 // EdgeAccountsResult is one edge's slice of the aggregate. OK distinguishes a
 // reachable edge (even with zero accounts) from an unreachable one (Error set).
+//
+// Accounts is carried as opaque json.RawMessage: the per-account shape (the
+// sanitized, credential-free edgeAccountDTO with its live capacity/today gauges)
+// is owned solely by the edge handler and the frontend TS type. Prod just relays
+// it verbatim, so adding an account field never requires touching this file.
 type EdgeAccountsResult struct {
-	EdgeID   string               `json:"edge_id"`
-	BaseURL  string               `json:"base_url"`
-	OK       bool                 `json:"ok"`
-	Error    string               `json:"error,omitempty"`
-	Accounts []EdgeAccountSummary `json:"accounts"`
+	EdgeID   string            `json:"edge_id"`
+	BaseURL  string            `json:"base_url"`
+	OK       bool              `json:"ok"`
+	Error    string            `json:"error,omitempty"`
+	Accounts []json.RawMessage `json:"accounts"`
 }
 
 // EdgeAccountsAggregate is the full cross-edge payload returned to the admin UI.
@@ -235,7 +206,7 @@ func edgeIDFromBaseURL(baseURL string) string {
 // x-api-key auth and an 8s timeout. Any failure → {ok:false, error}, never a
 // panic and never a failed aggregate.
 func (a *EdgeAccountsAggregator) fetchEdgeAccounts(ctx context.Context, t edgeTarget, platform string) EdgeAccountsResult {
-	res := EdgeAccountsResult{EdgeID: t.edgeID, BaseURL: t.baseURL, Accounts: []EdgeAccountSummary{}}
+	res := EdgeAccountsResult{EdgeID: t.edgeID, BaseURL: t.baseURL, Accounts: []json.RawMessage{}}
 	if a.http == nil {
 		res.Error = "no http client"
 		return res
@@ -267,7 +238,7 @@ func (a *EdgeAccountsAggregator) fetchEdgeAccounts(ctx context.Context, t edgeTa
 	}
 	var env struct {
 		Data struct {
-			Accounts []EdgeAccountSummary `json:"accounts"`
+			Accounts []json.RawMessage `json:"accounts"`
 		} `json:"data"`
 	}
 	if err := json.Unmarshal(body, &env); err != nil {

--- a/backend/internal/service/edge_accounts_aggregator_tk_test.go
+++ b/backend/internal/service/edge_accounts_aggregator_tk_test.go
@@ -108,9 +108,10 @@ func TestEdgeAccountsAggregator_FanoutDedupAndErrorIsolation(t *testing.T) {
 	require.Empty(t, out.Edges[0].Accounts)
 
 	// us1: ok with one account; the FIRST stub's api_key is used (dedup kept first).
+	// Accounts are opaque json.RawMessage passthrough — assert on the raw JSON.
 	require.True(t, out.Edges[1].OK)
 	require.Len(t, out.Edges[1].Accounts, 1)
-	require.Equal(t, int64(11), out.Edges[1].Accounts[0].ID)
+	require.Contains(t, string(out.Edges[1].Accounts[0]), `"id":11`)
 
 	require.Equal(t, "key-us1", doer.keysSeen["api-us1.tokenkey.dev"])
 	require.Equal(t, "key-fra1", doer.keysSeen["api-fra1.tokenkey.dev"])

--- a/backend/internal/web/dist/frontend-source.json
+++ b/backend/internal/web/dist/frontend-source.json
@@ -1,7 +1,7 @@
 {
   "algorithm": "sha256(git-ls-files:path,size,content)",
   "file_count": 452,
-  "hash": "6583637a4e54219fda28f17b6e4b9a14f34bc6bdfff85e2aa51f6a0cb528418b",
+  "hash": "ee2cda3f4bb6b16889e1671cd94242f6de52fd386243aa13450017143b95859e",
   "schema": 1,
   "source": "frontend/"
 }

--- a/backend/internal/web/dist/frontend-source.json
+++ b/backend/internal/web/dist/frontend-source.json
@@ -1,7 +1,7 @@
 {
   "algorithm": "sha256(git-ls-files:path,size,content)",
   "file_count": 452,
-  "hash": "57eecaaaa19b9c5ac635c9a760ee4382cddd6d734199aacfc7cc1b18070f48a1",
+  "hash": "6583637a4e54219fda28f17b6e4b9a14f34bc6bdfff85e2aa51f6a0cb528418b",
   "schema": 1,
   "source": "frontend/"
 }

--- a/frontend/src/api/admin/edgeAccounts.ts
+++ b/frontend/src/api/admin/edgeAccounts.ts
@@ -39,11 +39,30 @@ export interface EdgeAccountSummary {
   rate_limited_at?: string
   rate_limit_reset_at?: string
   overload_until?: string
+  // Configured caps (anthropic oauth/setup-token).
   window_cost_limit?: number
+  window_cost_sticky_reserve?: number
   max_sessions?: number
+  session_idle_timeout_minutes?: number
   base_rpm?: number
+  rpm_strategy?: string
+  rpm_sticky_buffer?: number
+  // Live gauges from the edge's local Redis/DB (align with the per-edge admin page).
+  current_concurrency?: number
+  current_window_cost?: number
+  active_sessions?: number
+  current_rpm?: number
+  today_stats?: EdgeTodayStats
   tier_id?: number
   groups?: string[]
+}
+
+/** Today's usage for one account (mirrors backend WindowStats subset). */
+export interface EdgeTodayStats {
+  requests: number
+  tokens: number
+  cost: number
+  user_cost: number
 }
 
 /**

--- a/frontend/src/api/admin/index.ts
+++ b/frontend/src/api/admin/index.ts
@@ -114,6 +114,7 @@ export type { ContentModerationConfig, ContentModerationLog, ModerationMode } fr
 export type { Tier, TierRequest } from './tier'
 export type {
   EdgeAccountSummary,
+  EdgeTodayStats,
   EdgeAccountsResult,
   EdgeAccountsAggregate,
   EdgeAccountsListParams

--- a/frontend/src/i18n/locales/en.ts
+++ b/frontend/src/i18n/locales/en.ts
@@ -3112,7 +3112,6 @@ export default {
         capacity: 'Capacity',
         todayStats: 'Today',
         state: 'State',
-        concurrency: 'Concurrency',
         priority: 'Priority',
         groups: 'Groups',
         lastUsed: 'Last Used'

--- a/frontend/src/i18n/locales/en.ts
+++ b/frontend/src/i18n/locales/en.ts
@@ -3109,6 +3109,8 @@ export default {
       columns: {
         name: 'Name',
         platformType: 'Platform / Type',
+        capacity: 'Capacity',
+        todayStats: 'Today',
         state: 'State',
         concurrency: 'Concurrency',
         priority: 'Priority',

--- a/frontend/src/i18n/locales/zh.ts
+++ b/frontend/src/i18n/locales/zh.ts
@@ -3187,7 +3187,6 @@ export default {
         capacity: '容量',
         todayStats: '今日',
         state: '状态',
-        concurrency: '并发',
         priority: '优先级',
         groups: '分组',
         lastUsed: '最近使用'

--- a/frontend/src/i18n/locales/zh.ts
+++ b/frontend/src/i18n/locales/zh.ts
@@ -3184,6 +3184,8 @@ export default {
       columns: {
         name: '名称',
         platformType: '平台 / 类型',
+        capacity: '容量',
+        todayStats: '今日',
         state: '状态',
         concurrency: '并发',
         priority: '优先级',

--- a/frontend/src/utils/edgeAccounts.tk.ts
+++ b/frontend/src/utils/edgeAccounts.tk.ts
@@ -35,13 +35,6 @@ export function accountStateLabel(a: EdgeAccountSummary): string {
 }
 
 /**
- * Variant for an edge's reachability pill.
- */
-export function edgeStatusVariant(e: EdgeAccountsResult): StatusVariant {
-  return e.ok ? 'success' : 'danger'
-}
-
-/**
  * Count of effectively-schedulable accounts in an edge slice.
  */
 export function schedulableCount(e: EdgeAccountsResult): number {

--- a/frontend/src/utils/edgeAccounts.tk.ts
+++ b/frontend/src/utils/edgeAccounts.tk.ts
@@ -6,6 +6,7 @@
  */
 
 import type { EdgeAccountSummary, EdgeAccountsResult } from '@/api/admin/edgeAccounts'
+import type { Account, WindowStats } from '@/types'
 
 export type StatusVariant = 'success' | 'warning' | 'danger' | 'neutral'
 
@@ -45,4 +46,64 @@ export function edgeStatusVariant(e: EdgeAccountsResult): StatusVariant {
  */
 export function schedulableCount(e: EdgeAccountsResult): number {
   return e.accounts.reduce((n, a) => (a.is_schedulable ? n + 1 : n), 0)
+}
+
+/**
+ * Adapts a credential-free EdgeAccountSummary into the admin `Account` shape so
+ * the read-only Edge Accounts page can reuse AccountCapacityCell verbatim (the
+ * cell only reads capacity/gauge fields). Missing-but-required Account fields are
+ * filled with inert defaults; `expires_at` is dropped (the edge DTO carries it as
+ * an RFC3339 string while Account types it as a unix number, and the cell doesn't
+ * read it). No side effects — pure mapping.
+ */
+export function toAccountLike(s: EdgeAccountSummary): Account {
+  return {
+    id: s.id,
+    name: s.name,
+    platform: s.platform as Account['platform'],
+    type: s.type as Account['type'],
+    channel_type: s.channel_type,
+    proxy_id: null,
+    concurrency: s.concurrency,
+    current_concurrency: s.current_concurrency,
+    priority: s.priority,
+    rate_multiplier: s.rate_multiplier,
+    status: s.status as Account['status'],
+    error_message: s.error_message ?? null,
+    last_used_at: s.last_used_at ?? null,
+    expires_at: null,
+    auto_pause_on_expired: false,
+    created_at: s.created_at,
+    updated_at: s.created_at,
+    schedulable: s.schedulable,
+    rate_limited_at: s.rate_limited_at ?? null,
+    rate_limit_reset_at: s.rate_limit_reset_at ?? null,
+    overload_until: s.overload_until ?? null,
+    temp_unschedulable_until: s.temp_unschedulable_until ?? null,
+    temp_unschedulable_reason: s.temp_unschedulable_reason ?? null,
+    session_window_start: null,
+    session_window_end: s.session_window_end ?? null,
+    session_window_status: (s.session_window_status as Account['session_window_status']) ?? null,
+    window_cost_limit: s.window_cost_limit ?? null,
+    window_cost_sticky_reserve: s.window_cost_sticky_reserve ?? null,
+    max_sessions: s.max_sessions ?? null,
+    session_idle_timeout_minutes: s.session_idle_timeout_minutes ?? null,
+    base_rpm: s.base_rpm ?? null,
+    rpm_strategy: s.rpm_strategy ?? null,
+    rpm_sticky_buffer: s.rpm_sticky_buffer ?? null,
+    current_window_cost: s.current_window_cost ?? null,
+    active_sessions: s.active_sessions ?? null,
+    current_rpm: s.current_rpm ?? null
+  }
+}
+
+/** Extracts the today-stats as the WindowStats shape AccountTodayStatsCell wants. */
+export function toWindowStats(s: EdgeAccountSummary): WindowStats | null {
+  if (!s.today_stats) return null
+  return {
+    requests: s.today_stats.requests,
+    tokens: s.today_stats.tokens,
+    cost: s.today_stats.cost,
+    user_cost: s.today_stats.user_cost
+  }
 }

--- a/frontend/src/views/admin/EdgeAccountsView.vue
+++ b/frontend/src/views/admin/EdgeAccountsView.vue
@@ -90,8 +90,9 @@
                 <tr>
                   <th class="px-4 py-2 text-left font-medium">{{ t('admin.edgeAccounts.columns.name') }}</th>
                   <th class="px-4 py-2 text-left font-medium">{{ t('admin.edgeAccounts.columns.platformType') }}</th>
+                  <th class="px-4 py-2 text-left font-medium">{{ t('admin.edgeAccounts.columns.capacity') }}</th>
+                  <th class="px-4 py-2 text-left font-medium">{{ t('admin.edgeAccounts.columns.todayStats') }}</th>
                   <th class="px-4 py-2 text-left font-medium">{{ t('admin.edgeAccounts.columns.state') }}</th>
-                  <th class="px-4 py-2 text-right font-medium">{{ t('admin.edgeAccounts.columns.concurrency') }}</th>
                   <th class="px-4 py-2 text-right font-medium">{{ t('admin.edgeAccounts.columns.priority') }}</th>
                   <th class="px-4 py-2 text-left font-medium">{{ t('admin.edgeAccounts.columns.groups') }}</th>
                   <th class="px-4 py-2 text-left font-medium">{{ t('admin.edgeAccounts.columns.lastUsed') }}</th>
@@ -99,29 +100,34 @@
               </thead>
               <tbody class="divide-y divide-gray-50 dark:divide-dark-700/50">
                 <tr v-for="acct in edge.accounts" :key="acct.id" class="hover:bg-gray-50 dark:hover:bg-dark-700/40">
-                  <td class="px-4 py-2">
+                  <td class="px-4 py-2 align-top">
                     <div class="font-medium text-gray-900 dark:text-white">{{ acct.name }}</div>
                     <div v-if="acct.error_message" class="mt-0.5 max-w-xs truncate text-xs text-red-500" :title="acct.error_message">
                       {{ acct.error_message }}
                     </div>
                   </td>
-                  <td class="px-4 py-2 text-gray-600 dark:text-gray-300">
+                  <td class="px-4 py-2 align-top text-gray-600 dark:text-gray-300">
                     <span>{{ acct.platform }}</span>
                     <span class="text-gray-400 dark:text-gray-500"> / {{ acct.type }}</span>
                     <span v-if="acct.channel_type" class="text-gray-400 dark:text-gray-500"> · ch{{ acct.channel_type }}</span>
                   </td>
-                  <td class="px-4 py-2">
+                  <td class="px-4 py-2 align-top">
+                    <AccountCapacityCell :account="toAccountLike(acct)" />
+                  </td>
+                  <td class="px-4 py-2 align-top">
+                    <AccountTodayStatsCell :stats="toWindowStats(acct)" />
+                  </td>
+                  <td class="px-4 py-2 align-top">
                     <span :class="['inline-flex rounded-full px-2 py-0.5 text-xs font-medium', stateBadgeClass(acct)]">
                       {{ accountStateLabel(acct) }}
                     </span>
                   </td>
-                  <td class="px-4 py-2 text-right text-gray-700 dark:text-gray-200">{{ acct.concurrency }}</td>
-                  <td class="px-4 py-2 text-right text-gray-700 dark:text-gray-200">{{ acct.priority }}</td>
-                  <td class="px-4 py-2 text-gray-600 dark:text-gray-300">
+                  <td class="px-4 py-2 align-top text-right text-gray-700 dark:text-gray-200">{{ acct.priority }}</td>
+                  <td class="px-4 py-2 align-top text-gray-600 dark:text-gray-300">
                     <span v-if="acct.groups && acct.groups.length">{{ acct.groups.join(', ') }}</span>
                     <span v-else class="text-gray-300 dark:text-gray-600">—</span>
                   </td>
-                  <td class="px-4 py-2 text-xs text-gray-500 dark:text-gray-400">
+                  <td class="px-4 py-2 align-top text-xs text-gray-500 dark:text-gray-400">
                     {{ acct.last_used_at ? formatRelativeTime(acct.last_used_at) : '—' }}
                   </td>
                 </tr>
@@ -147,9 +153,11 @@ import { onMounted } from 'vue'
 import { useI18n } from 'vue-i18n'
 import AppLayout from '@/components/layout/AppLayout.vue'
 import Icon from '@/components/icons/Icon.vue'
+import AccountCapacityCell from '@/components/account/AccountCapacityCell.vue'
+import AccountTodayStatsCell from '@/components/account/AccountTodayStatsCell.vue'
 import { formatDateTime, formatRelativeTime } from '@/utils/format'
 import { useTkEdgeAccounts } from '@/composables/useTkEdgeAccounts'
-import { accountStateLabel, accountStatusVariant, schedulableCount } from '@/utils/edgeAccounts.tk'
+import { accountStateLabel, accountStatusVariant, schedulableCount, toAccountLike, toWindowStats } from '@/utils/edgeAccounts.tk'
 import type { EdgeAccountSummary } from '@/api/admin/edgeAccounts'
 
 const { t } = useI18n()

--- a/scripts/sentinels/frontend-tk.json
+++ b/scripts/sentinels/frontend-tk.json
@@ -402,9 +402,11 @@
       "path": "frontend/src/views/admin/EdgeAccountsView.vue",
       "must_contain": [
         "useTkEdgeAccounts",
-        "admin.edgeAccounts.title"
+        "admin.edgeAccounts.title",
+        "AccountCapacityCell",
+        "toAccountLike"
       ],
-      "rationale": "TK-only read-only admin page grouping accounts by edge. Renders the per-edge ok/failed/timeout state and a credential-free account table. Guards against silent upstream-merge deletion of the view."
+      "rationale": "TK-only read-only admin page grouping accounts by edge. Renders the per-edge ok/failed/timeout state and a credential-free account table that REUSES the real admin AccountCapacityCell (+ AccountTodayStatsCell) via toAccountLike, so the overview's capacity/today gauges stay pixel-aligned with the per-edge /admin/accounts page. Guards against silent upstream-merge deletion of the view or a refactor that drops the cell reuse (which would regress the page back to a sparse static table)."
     },
     {
       "path": "frontend/src/components/layout/AppSidebar.vue",

--- a/scripts/sentinels/gateway-tk.json
+++ b/scripts/sentinels/gateway-tk.json
@@ -1445,9 +1445,10 @@
       "must_contain": [
         "func (h *EdgeAccountsHandler) ListAccounts(",
         "func toEdgeAccountDTO(",
-        "edgeAccountsSupportedPlatforms"
+        "edgeAccountsSupportedPlatforms",
+        "func (h *EdgeAccountsHandler) collectRuntimeGauges("
       ],
-      "rationale": "Edge read-only account inventory endpoint: GET /api/v1/edge/accounts returns each edge's accounts so prod's admin Edge Accounts overview can enumerate the fleet. Credential-free by construction — toEdgeAccountDTO builds an allowlist edgeAccountDTO with NO Credentials/Extra/Proxy/Notes member, so leakage is structurally impossible rather than merely redacted. A silent upstream-merge deletion would break the prod overview without a compile error; a refactor that reintroduces a Credentials field would regress the no-leak guarantee (covered additionally by the raw-bytes assertion in edge_tk_accounts_handler_test.go). Mounted behind the lightweight edge api-key auth, off the gateway billing/concurrency chain."
+      "rationale": "Edge read-only account inventory endpoint: GET /api/v1/edge/accounts returns each edge's accounts (with live capacity/today gauges) so prod's admin Edge Accounts overview can mirror the per-edge /admin/accounts page. Credential-free by construction — toEdgeAccountDTO builds an allowlist edgeAccountDTO with NO Credentials/Extra/Proxy/Notes member, so leakage is structurally impossible rather than merely redacted (raw-bytes assertion in the test). Two load-bearing properties: (1) it lists via adminService.ListAccounts with an EMPTY status filter — NOT the repository ListByPlatform which pins status=active and would silently hide disabled/errored accounts, making the overview show fewer rows than the edge's own admin page (the bug fixed alongside the gauge work); (2) collectRuntimeGauges batch-reads current_concurrency/window_cost/active_sessions/current_rpm + today_stats from this edge's local Redis/DB, mirroring admin AccountHandler.List — dropping it regresses the overview to static-only fields. Mounted behind the lightweight edge api-key auth, off the gateway billing/concurrency chain."
     },
     {
       "path": "backend/internal/service/edge_accounts_aggregator_tk.go",


### PR DESCRIPTION
## What

Aligns the prod **Edge Accounts** overview (`/admin/edge-accounts`) with each edge's own `/admin/accounts` page. Two fixes:

1. **Show all accounts, not just active.** The edge endpoint listed via repository `ListByPlatform`, which pins `status=active` and silently hid disabled/errored accounts — so edges showed fewer (or zero) rows than their real admin page (the reported uk1/us2/us5 gap). It now lists via `adminService.ListAccounts` with an **empty status filter**, exactly like the admin page.

2. **Live capacity + today-stats gauges.** The edge endpoint batch-reads `current_concurrency / current_window_cost / active_sessions / current_rpm` (this edge's local Redis/DB) + `today_stats` (req/tokens/cost/user_cost), mirroring `admin AccountHandler.List`'s enrichment block. The frontend `EdgeAccountsView` reuses the real `AccountCapacityCell` + `AccountTodayStatsCell` (via `toAccountLike`), so the gauges are pixel-aligned with the per-edge page.

> Out of scope (by design): the 5h/7d usage-window % bars — they need a per-account `/usage` fetch + a non-self-fetching cell.

Prod aggregator now relays accounts as opaque `json.RawMessage`, so the per-account shape is owned solely by the edge DTO + frontend TS type.

## ⚠️ Redeploy required

The enrichment + status fix run on the **edge endpoint** → redeploy all deployable edges (uk1 canary → us1–us5), then prod.

## Verification

- `go test -tags=unit ./...` ✅ · `golangci-lint` ✅ · `go build ./...` ✅ · wire regenerated ✅
- frontend `typecheck` + `lint:check` ✅ · `pnpm build` (embedded dist refreshed) ✅
- `scripts/preflight.sh` ✅ (sentinel registry gate satisfied via strengthened edge-accounts anchors)
- New unit coverage: enrichment populates `current_*` + `today_stats` from fake services; status filter asserted empty; credential-leak raw-bytes assertion retained; aggregator RawMessage passthrough.

upstream-touch-guarded — upstream-shaped files get additive minimal injection only; `AccountCapacityCell`/`AccountTodayStatsCell` reused unmodified.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
