### PR TITLE
fix(admin): auto-refresh Edge Accounts page so it tracks live edge data

### DIFF
--- a/backend/internal/web/dist/frontend-source.json
+++ b/backend/internal/web/dist/frontend-source.json
@@ -1,7 +1,7 @@
 {
   "algorithm": "sha256(git-ls-files:path,size,content)",
   "file_count": 452,
-  "hash": "f530bafdae79d5dca6b7c5b1377a72a173ec791132300f2b1f08da5989f8ad48",
+  "hash": "e42ce3cc444c68d7471b1cee81a3f99271d8f21d7f1d9839a8f2e117c0040f2f",
   "schema": 1,
   "source": "frontend/"
 }

--- a/frontend/src/composables/useTkEdgeAccounts.ts
+++ b/frontend/src/composables/useTkEdgeAccounts.ts
@@ -1,14 +1,22 @@
 /**
  * Edge Accounts overview composable (TokenKey-only).
  *
- * Owns all state + the single API call for the read-only cross-edge account
- * view, keeping EdgeAccountsView.vue a thin template. Mirrors the TK convention
- * of useTk*.ts composables (CLAUDE.md §5).
+ * Owns all state + the API call for the read-only cross-edge account view, and
+ * keeps the data live with a periodic auto-refresh (mirroring the per-edge admin
+ * accounts page, which auto-refreshes). Without it the page only fetched once on
+ * mount and could show a stale snapshot — e.g. a 5h-window utilization captured
+ * just after a window roll — diverging from the always-fresh per-edge page.
+ * Mirrors the TK convention of useTk*.ts composables (CLAUDE.md §5).
  */
 
-import { ref, computed } from 'vue'
+import { ref, computed, onMounted, onBeforeUnmount } from 'vue'
+import { useIntervalFn } from '@vueuse/core'
 import { adminAPI } from '@/api/admin'
 import type { EdgeAccountsResult } from '@/api/admin/edgeAccounts'
+
+// Each refresh fans out to every edge, so keep the cadence gentle. 30s is fresh
+// enough to track the per-edge page without hammering the fan-out.
+const AUTO_REFRESH_MS = 30_000
 
 export function useTkEdgeAccounts(initialPlatform = 'anthropic') {
   const platform = ref(initialPlatform)
@@ -24,6 +32,7 @@ export function useTkEdgeAccounts(initialPlatform = 'anthropic') {
   )
 
   async function fetch() {
+    if (loading.value) return
     loading.value = true
     error.value = null
     try {
@@ -37,6 +46,22 @@ export function useTkEdgeAccounts(initialPlatform = 'anthropic') {
       loading.value = false
     }
   }
+
+  // Periodic auto-refresh; skip when the tab is hidden or a fetch is in flight.
+  const { pause, resume } = useIntervalFn(
+    () => {
+      if (typeof document !== 'undefined' && document.hidden) return
+      void fetch()
+    },
+    AUTO_REFRESH_MS,
+    { immediate: false }
+  )
+
+  onMounted(() => {
+    void fetch()
+    resume()
+  })
+  onBeforeUnmount(() => pause())
 
   return {
     platform,

--- a/frontend/src/views/admin/EdgeAccountsView.vue
+++ b/frontend/src/views/admin/EdgeAccountsView.vue
@@ -153,7 +153,6 @@
 </template>
 
 <script setup lang="ts">
-import { onMounted } from 'vue'
 import { useI18n } from 'vue-i18n'
 import AppLayout from '@/components/layout/AppLayout.vue'
 import Icon from '@/components/icons/Icon.vue'
@@ -187,6 +186,5 @@ const STATE_BADGE_CLASSES: Record<string, string> = {
 function stateBadgeClass(a: EdgeAccountSummary): string {
   return STATE_BADGE_CLASSES[accountStatusVariant(a)] ?? STATE_BADGE_CLASSES.neutral
 }
-
-onMounted(fetch)
+// Initial fetch + periodic auto-refresh are owned by useTkEdgeAccounts.
 </script>

--- a/scripts/sentinels/frontend-tk.json
+++ b/scripts/sentinels/frontend-tk.json
@@ -394,9 +394,10 @@
       "path": "frontend/src/composables/useTkEdgeAccounts.ts",
       "must_contain": [
         "export function useTkEdgeAccounts",
-        "adminAPI.edgeAccounts.list"
+        "adminAPI.edgeAccounts.list",
+        "useIntervalFn"
       ],
-      "rationale": "TK-only composable owning the Edge Accounts overview flow (state + the single fan-out API call). Keeps EdgeAccountsView.vue thin (template + wiring) per CLAUDE.md §5. Guards against silent upstream-merge deletion that would orphan the view."
+      "rationale": "TK-only composable owning the Edge Accounts overview flow (state + the single fan-out API call + periodic auto-refresh). Keeps EdgeAccountsView.vue thin (template + wiring) per CLAUDE.md §5. The useIntervalFn anchor pins the auto-refresh: without it the page only fetched on mount and showed stale snapshots (e.g. a 5h-window utilization captured right after a window roll) that diverged from the always-fresh per-edge admin page. Guards against silent upstream-merge deletion that would orphan the view or drop the freshness."
     },
     {
       "path": "frontend/src/views/admin/EdgeAccountsView.vue",


### PR DESCRIPTION
## What

The Edge Accounts overview (`/admin/edge-accounts`) showed stale data that diverged from the per-edge `/admin/accounts` page (e.g. 5h window **99% / 4h58m** vs the real **12% / 2h37m**).

## Root cause (confirmed on live us5 DB)

Not a data-source bug — both pages read the same passive source. The overview's `useTkEdgeAccounts` fetched **only on mount** (no auto-refresh), while the per-edge admin page auto-refreshes. The stale snapshot was captured right after a 5h-window roll, where `session_window_utilization` (old window's ~99%) is briefly paired with the just-reset window end until the next gateway request re-samples. Live us5 right now: `session_window_utilization=0.12`, `session_window_end=02:50Z`, sampled 20s ago → matches the per-edge page. The overview was just never re-fetching.

## Fix

Add a 30s auto-refresh in `useTkEdgeAccounts` (`useIntervalFn`, paused when the tab is hidden or a fetch is in flight), mirroring the per-edge page. Initial fetch + interval now owned by the composable. **Frontend-only — no edge redeploy** (the edge endpoint already returns live data; prod serves the SPA).

Sentinel pins `useIntervalFn` so an upstream merge can't silently drop the freshness.

> Note (separate, optional): `account_usage_service.go::estimateSetupTokenUsage` pairs a passive utilization sample with the current window without checking the sample belongs to it — so right after a window roll **both** pages can momentarily show a stale high %. Fixing that is a shared backend change (affects the per-edge page too + needs an edge redeploy); out of scope here.

## Verification

- frontend `typecheck` + `lint:check` ✅ · `pnpm build` ✅ (dist refreshed) · `scripts/preflight.sh` ✅
- Live us5 DB query confirms the endpoint serves 0.12 (12%); the page will now track it via auto-refresh.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
