### PR TITLE
chore(security): bump Go toolchain 1.26.3 → 1.26.4 (fix GO-2026-5037/5039)

### DIFF
--- a/.github/workflows/backend-ci.yml
+++ b/.github/workflows/backend-ci.yml
@@ -65,7 +65,7 @@ jobs:
           cache-dependency-path: backend/go.sum
       - name: Verify Go version
         run: |
-          go version | grep -q 'go1.26.3'
+          go version | grep -q 'go1.26.4'
       - name: Unit tests
         working-directory: backend
         run: make test-unit
@@ -84,7 +84,7 @@ jobs:
           cache-dependency-path: backend/go.sum
       - name: Verify Go version
         run: |
-          go version | grep -q 'go1.26.3'
+          go version | grep -q 'go1.26.4'
       - name: Integration tests
         working-directory: backend
         run: make test-integration
@@ -127,7 +127,7 @@ jobs:
           cache-dependency-path: backend/go.sum
       - name: Verify Go version
         run: |
-          go version | grep -q 'go1.26.3'
+          go version | grep -q 'go1.26.4'
       # PR: only-new-issues (GitHub API diff). Push/workflow_dispatch: full ./... lint on backend.
       - name: golangci-lint
         uses: golangci/golangci-lint-action@v9
@@ -153,7 +153,7 @@ jobs:
           cache-dependency-path: backend/go.sum
       - name: Verify Go version
         run: |
-          go version | grep -q 'go1.26.3'
+          go version | grep -q 'go1.26.4'
       - name: Run gosec lint
         if: github.event_name == 'schedule' || github.event_name == 'workflow_dispatch'
         uses: golangci/golangci-lint-action@v9
@@ -244,7 +244,7 @@ jobs:
           cache-dependency-path: backend/go.sum
       - name: Verify Go version
         run: |
-          go version | grep -q 'go1.26.3'
+          go version | grep -q 'go1.26.4'
       - name: Run pinned new-api smoke via bump helper
         run: |
           CURRENT_PIN="$(tr -d '[:space:]' < .new-api-ref)"
@@ -267,7 +267,7 @@ jobs:
           cache-dependency-path: backend/go.sum
       - name: Verify Go version
         run: |
-          go version | grep -q 'go1.26.3'
+          go version | grep -q 'go1.26.4'
       - name: Setup pnpm
         uses: pnpm/action-setup@v6
         with:

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -175,7 +175,7 @@ jobs:
 
       - name: Verify Go version
         run: |
-          go version | grep -q 'go1.26.3'
+          go version | grep -q 'go1.26.4'
 
       # Docker setup for GoReleaser
       - name: Set up QEMU

--- a/Dockerfile
+++ b/Dockerfile
@@ -12,7 +12,7 @@
 # =============================================================================
 
 ARG NODE_IMAGE=node:24-alpine
-ARG GOLANG_IMAGE=golang:1.26.3-alpine
+ARG GOLANG_IMAGE=golang:1.26.4-alpine
 ARG ALPINE_IMAGE=alpine:3.21
 ARG POSTGRES_IMAGE=postgres:18-alpine
 ARG GOPROXY=https://goproxy.cn,direct

--- a/backend/Dockerfile
+++ b/backend/Dockerfile
@@ -1,4 +1,4 @@
-FROM golang:1.26.3-alpine
+FROM golang:1.26.4-alpine
 
 WORKDIR /app
 

--- a/backend/go.mod
+++ b/backend/go.mod
@@ -1,6 +1,6 @@
 module github.com/Wei-Shaw/sub2api
 
-go 1.26.3
+go 1.26.4
 
 require (
 	entgo.io/ent v0.14.5

--- a/deploy/Dockerfile
+++ b/deploy/Dockerfile
@@ -7,7 +7,7 @@
 # =============================================================================
 
 ARG NODE_IMAGE=node:24-alpine
-ARG GOLANG_IMAGE=golang:1.26.3-alpine
+ARG GOLANG_IMAGE=golang:1.26.4-alpine
 ARG ALPINE_IMAGE=alpine:3.20
 ARG GOPROXY=https://goproxy.cn,direct
 ARG GOSUMDB=sum.golang.google.cn

--- a/scripts/sentinels/brand.json
+++ b/scripts/sentinels/brand.json
@@ -4,63 +4,91 @@
   "sentinels": [
     {
       "path": "frontend/index.html",
-      "must_contain": ["<title>TokenKey"],
+      "must_contain": [
+        "<title>TokenKey"
+      ],
       "rationale": "Default embedded SPA browser tab title before JS runs; regressing to Sub2API breaks the single-product narrative for every fresh load."
     },
     {
       "path": "frontend/src/router/title.ts",
-      "must_contain": ["'TokenKey'", "trimmed.toLowerCase() === 'sub2api'"],
+      "must_contain": [
+        "'TokenKey'",
+        "trimmed.toLowerCase() === 'sub2api'"
+      ],
       "rationale": "SPA `document.title` fallback when site_name is unset or upstream's default site_name leaks through; drifting back to Sub2API re-splits admin tab branding from the embedded index.html default."
     },
     {
       "path": "frontend/src/composables/usePlatformOptions.ts",
-      "must_contain": ["newapi: 'Extension Engine'"],
+      "must_contain": [
+        "newapi: 'Extension Engine'"
+      ],
       "rationale": "Fifth platform admin display label: degrades `newapi` from an external product name to Extension Engine while keeping the platform key `newapi` for routing/API."
     },
     {
       "path": "docs/PAYMENT.md",
-      "must_contain": ["TokenKey has a built-in payment system"],
+      "must_contain": [
+        "TokenKey has a built-in payment system"
+      ],
       "rationale": "Public payment guide is an external operator-facing surface; the opening sentence should stay aligned with the TokenKey product brand."
     },
     {
       "path": "deploy/README.md",
-      "must_contain": ["# TokenKey Deployment Files", "deploying TokenKey"],
+      "must_contain": [
+        "# TokenKey Deployment Files",
+        "deploying TokenKey"
+      ],
       "rationale": "Deployment overview is an outward operator-facing entry point; its title and opening sentence should stay aligned with the TokenKey product brand."
     },
     {
       "path": "deploy/DOCKER.md",
-      "must_contain": ["# TokenKey Docker Image", "TokenKey is an AI"],
+      "must_contain": [
+        "# TokenKey Docker Image",
+        "TokenKey is an AI"
+      ],
       "rationale": "Docker Hub/operator documentation is an external product surface; its title and opening sentence should stay aligned with the TokenKey brand."
     },
     {
       "path": "deploy/install.sh",
-      "must_contain": ["TokenKey Installation Script", "TokenKey 安装脚本"],
+      "must_contain": [
+        "TokenKey Installation Script",
+        "TokenKey 安装脚本"
+      ],
       "rationale": "The one-click installer is an operator-visible setup surface; its bilingual title must stay aligned with the TokenKey product brand."
     },
     {
       "path": "deploy/sub2api.service",
-      "must_contain": ["Description=TokenKey - AI API Gateway Platform"],
+      "must_contain": [
+        "Description=TokenKey - AI API Gateway Platform"
+      ],
       "rationale": "The systemd unit description is shown to operators in service tooling and should present the outward TokenKey product brand while keeping the compatibility unit filename unchanged."
     },
     {
       "path": "deploy/sub2api-datamanagementd.service",
-      "must_contain": ["Description=TokenKey Data Management Daemon"],
+      "must_contain": [
+        "Description=TokenKey Data Management Daemon"
+      ],
       "rationale": "The datamanagementd unit description is operator-visible and should use the TokenKey outward brand while preserving the compatibility unit filename."
     },
     {
       "path": "Dockerfile",
-      "must_contain": ["LABEL description=\"TokenKey - AI API Gateway Platform\""],
-      "rationale": "The root runtime image label is an external metadata surface and should reflect the TokenKey brand while preserving image names and source URLs."
+      "must_contain": [
+        "LABEL description=\"TokenKey - AI API Gateway Platform\""
+      ],
+      "rationale": "The root runtime image label is an external metadata surface and should reflect the TokenKey brand while preserving image names and source URLs. (The golang:<ver>-alpine builder tag in this file is a build/security pin, bumped independently — e.g. for Go stdlib CVE patches — and is NOT a brand anchor; only the LABEL is brand-load-bearing.)"
     },
     {
       "path": "deploy/Dockerfile",
-      "must_contain": ["LABEL description=\"TokenKey - AI API Gateway Platform\""],
-      "rationale": "The deploy runtime image label is external metadata and should reflect the TokenKey brand while preserving image names and source URLs."
+      "must_contain": [
+        "LABEL description=\"TokenKey - AI API Gateway Platform\""
+      ],
+      "rationale": "The deploy runtime image label is external metadata and should reflect the TokenKey brand while preserving image names and source URLs. (The golang:<ver>-alpine builder tag in this file is a build/security pin, bumped independently — e.g. for Go stdlib CVE patches — and is NOT a brand anchor; only the LABEL is brand-load-bearing.)"
     },
     {
       "path": "Dockerfile.goreleaser",
-      "must_contain": ["LABEL description=\"TokenKey - AI API Gateway Platform\""],
-      "rationale": "The release image label is external metadata and should reflect the TokenKey brand while preserving image names and source URLs."
+      "must_contain": [
+        "LABEL description=\"TokenKey - AI API Gateway Platform\""
+      ],
+      "rationale": "The release image label is external metadata and should reflect the TokenKey brand while preserving image names and source URLs. (The golang:<ver>-alpine builder tag in this file is a build/security pin, bumped independently — e.g. for Go stdlib CVE patches — and is NOT a brand anchor; only the LABEL is brand-load-bearing.)"
     }
   ]
 }

--- a/tools/error_clustering/go.mod
+++ b/tools/error_clustering/go.mod
@@ -1,5 +1,5 @@
 module tokenkey.dev/tools/error_clustering
 
-go 1.26.3
+go 1.26.4
 
 require github.com/lib/pq v1.10.9


### PR DESCRIPTION
## Why

govulncheck went red **repo-wide** (main's latest backend-ci included) after two Go **stdlib** CVEs were published today, blocking every PR:
- **GO-2026-5039** (net/textproto) — reachable via gateway error path, TLS dialer (ReadResponse), SMTP test.
- **GO-2026-5037** (crypto/x509) — reachable via TLS handshake, volcengine relay, gateway error path.

Both fixed in **go1.26.4**; repo pinned to 1.26.3.

## What

Bumps the pinned toolchain everywhere it is asserted: `backend/go.mod` + `tools/error_clustering/go.mod` (go directive), the three build Dockerfiles (`golang:1.26.4-alpine`), and the 7 `backend-ci`/`release` `go version | grep go1.26.4` guards.

Unblocks all open PRs and patches the reachable stdlib CVEs in the shipped binary (the deployed 1.7.61 was built on 1.26.3).

`brand.json`: refreshed the Dockerfile sentinel rationales to note the `golang:` builder tag is a build/security pin, not a brand anchor (the LABEL anchor is untouched).

## Verification
- `scripts/preflight.sh` ✅
- CI `backend-security / govulncheck` should go green (CVEs fixed in 1.26.4) — the signal this PR exists to flip.

no-web-impact.

🤖 Generated with [Claude Code](https://claude.com/claude-code)