### PR TITLE
fix(admin): edge-accounts status via AccountStatusIndicator + passive 5h staleness guard

### DIFF
--- a/backend/internal/service/account_usage_service.go
+++ b/backend/internal/service/account_usage_service.go
@@ -436,13 +436,7 @@ func (s *AccountUsageService) GetPassiveUsage(ctx context.Context, accountID int
 	info.Source = "passive"
 
 	// 设置采样时间
-	if raw, ok := account.Extra["passive_usage_sampled_at"]; ok {
-		if str, ok := raw.(string); ok {
-			if t, err := time.Parse(time.RFC3339, str); err == nil {
-				info.UpdatedAt = &t
-			}
-		}
-	}
+	info.UpdatedAt = parseExtraSampledAt(account.Extra["passive_usage_sampled_at"])
 
 	// 构建 7d 窗口（从被动采样数据）
 	util7d := parseExtraFloat64(account.Extra["passive_usage_7d_utilization"])
@@ -1283,6 +1277,18 @@ func (s *AccountUsageService) estimateSetupTokenUsage(account *Account) *UsageIn
 			}
 		}
 
+		// 陈旧采样护栏：session_window_utilization 是上次上游响应的被动采样值。
+		// 若它的采样时间早于当前窗口开始（窗口已滚动但尚未被新请求重新采样——
+		// 写入侧的 clear-on-roll 仅在过期驱动的 init 触发，header 驱动的窗口变更
+		// 不触发），它属于上一个窗口，会在刚重置的新窗口上显示误导性高利用率
+		// （线上观察到刚滚动的 5h 窗口显示 99%）。此时丢弃该值，回退状态估算。
+		if found && account.SessionWindowStart != nil {
+			if sampled := parseExtraSampledAt(account.Extra["passive_usage_sampled_at"]); sampled != nil && sampled.Before(*account.SessionWindowStart) {
+				found = false
+				utilization = 0 // clear the stale value; the status fallback below re-derives it
+			}
+		}
+
 		// 如果没有存储的 utilization，回退到状态估算
 		if !found {
 			switch account.SessionWindowStatus {
@@ -1308,6 +1314,21 @@ func (s *AccountUsageService) estimateSetupTokenUsage(account *Account) *UsageIn
 
 	// Setup Token无法获取7d数据
 	return info
+}
+
+// parseExtraSampledAt parses the passive_usage_sampled_at Extra value (an
+// RFC3339 string written by the gateway's passive sampler) into a time, or nil
+// when absent/unparseable.
+func parseExtraSampledAt(raw any) *time.Time {
+	str, ok := raw.(string)
+	if !ok {
+		return nil
+	}
+	t, err := time.Parse(time.RFC3339, str)
+	if err != nil {
+		return nil
+	}
+	return &t
 }
 
 func buildGeminiUsageProgress(used, limit int64, resetAt time.Time, tokens int64, cost float64, now time.Time) *UsageProgress {

--- a/backend/internal/service/account_usage_service_tk_stale_test.go
+++ b/backend/internal/service/account_usage_service_tk_stale_test.go
@@ -1,0 +1,68 @@
+package service
+
+import (
+	"testing"
+	"time"
+)
+
+// TestEstimateSetupTokenUsage_StaleSampleGuard verifies that a
+// session_window_utilization sample taken before the current window started is
+// treated as stale (dropped → status-based fallback), while a sample taken
+// within the window is used as-is. Guards the "99% on a just-rolled window" bug.
+func TestEstimateSetupTokenUsage_StaleSampleGuard(t *testing.T) {
+	now := time.Now()
+	wStart := now.Add(-1 * time.Hour)
+	wEnd := now.Add(4 * time.Hour)
+
+	mk := func(sampledAt *time.Time) *Account {
+		extra := map[string]any{"session_window_utilization": 0.99}
+		if sampledAt != nil {
+			extra["passive_usage_sampled_at"] = sampledAt.UTC().Format(time.RFC3339)
+		}
+		return &Account{
+			SessionWindowStart:  &wStart,
+			SessionWindowEnd:    &wEnd,
+			SessionWindowStatus: "allowed",
+			Extra:               extra,
+		}
+	}
+
+	svc := &AccountUsageService{}
+
+	t.Run("stale sample (before window start) is dropped", func(t *testing.T) {
+		sampled := wStart.Add(-1 * time.Hour) // before window start → stale
+		got := svc.estimateSetupTokenUsage(mk(&sampled))
+		if got.FiveHour == nil {
+			t.Fatal("FiveHour nil")
+		}
+		// status=allowed → status-based fallback is 0, NOT the stale 99.
+		if got.FiveHour.Utilization != 0 {
+			t.Fatalf("expected stale util dropped to 0, got %v", got.FiveHour.Utilization)
+		}
+	})
+
+	t.Run("fresh sample (within window) is used", func(t *testing.T) {
+		sampled := wStart.Add(30 * time.Minute) // after window start → fresh
+		got := svc.estimateSetupTokenUsage(mk(&sampled))
+		if got.FiveHour == nil || got.FiveHour.Utilization != 99 {
+			t.Fatalf("expected fresh util 99, got %+v", got.FiveHour)
+		}
+	})
+
+	t.Run("no sampled_at falls back to using util (backward compatible)", func(t *testing.T) {
+		got := svc.estimateSetupTokenUsage(mk(nil))
+		if got.FiveHour == nil || got.FiveHour.Utilization != 99 {
+			t.Fatalf("expected util 99 when sampled_at absent, got %+v", got.FiveHour)
+		}
+	})
+
+	t.Run("no window start leaves util untouched", func(t *testing.T) {
+		sampled := now.Add(-3 * time.Hour)
+		acc := mk(&sampled)
+		acc.SessionWindowStart = nil // can't verify → use util as-is
+		got := svc.estimateSetupTokenUsage(acc)
+		if got.FiveHour == nil || got.FiveHour.Utilization != 99 {
+			t.Fatalf("expected util 99 when window start unknown, got %+v", got.FiveHour)
+		}
+	})
+}

--- a/backend/internal/web/dist/frontend-source.json
+++ b/backend/internal/web/dist/frontend-source.json
@@ -1,7 +1,7 @@
 {
   "algorithm": "sha256(git-ls-files:path,size,content)",
   "file_count": 452,
-  "hash": "e42ce3cc444c68d7471b1cee81a3f99271d8f21d7f1d9839a8f2e117c0040f2f",
+  "hash": "8f80738a5ad0c2ec4a8887f1b5cd7d3ba856ea7b2aefdab90952aca0d74c3196",
   "schema": 1,
   "source": "frontend/"
 }

--- a/backend/internal/web/dist/frontend-source.json
+++ b/backend/internal/web/dist/frontend-source.json
@@ -1,7 +1,7 @@
 {
   "algorithm": "sha256(git-ls-files:path,size,content)",
   "file_count": 452,
-  "hash": "8f80738a5ad0c2ec4a8887f1b5cd7d3ba856ea7b2aefdab90952aca0d74c3196",
+  "hash": "d8b2a9dee49b3b85cd499258c099e2a9d151892145d2700f713d877dd6d08a20",
   "schema": 1,
   "source": "frontend/"
 }

--- a/frontend/src/utils/edgeAccounts.tk.ts
+++ b/frontend/src/utils/edgeAccounts.tk.ts
@@ -8,32 +8,6 @@
 import type { EdgeAccountSummary, EdgeAccountsResult } from '@/api/admin/edgeAccounts'
 import type { Account, WindowStats, AccountUsageInfo } from '@/types'
 
-export type StatusVariant = 'success' | 'warning' | 'danger' | 'neutral'
-
-/**
- * Maps an account's effective state to a colour variant for a status pill.
- * Read-only derivation — does not call any API.
- */
-export function accountStatusVariant(a: EdgeAccountSummary): StatusVariant {
-  if (a.status !== 'active') return 'danger'
-  if (a.error_message) return 'danger'
-  if (a.rate_limit_reset_at || a.overload_until || a.temp_unschedulable_until) return 'warning'
-  if (!a.is_schedulable) return 'warning'
-  return 'success'
-}
-
-/**
- * Short human label for an account's effective schedulability.
- */
-export function accountStateLabel(a: EdgeAccountSummary): string {
-  if (a.status !== 'active') return a.status
-  if (a.overload_until) return 'overloaded'
-  if (a.rate_limit_reset_at) return 'rate-limited'
-  if (a.temp_unschedulable_until) return 'temp-unschedulable'
-  if (!a.schedulable) return 'unschedulable'
-  return 'schedulable'
-}
-
 /**
  * Count of effectively-schedulable accounts in an edge slice.
  */

--- a/frontend/src/views/admin/EdgeAccountsView.vue
+++ b/frontend/src/views/admin/EdgeAccountsView.vue
@@ -105,6 +105,12 @@
                     <div v-if="acct.error_message" class="mt-0.5 max-w-xs truncate text-xs text-red-500" :title="acct.error_message">
                       {{ acct.error_message }}
                     </div>
+                    <!-- temp-unschedulable reason shown inline: the reused AccountStatusIndicator's
+                         temp-unsched badge opens an admin modal we don't have here (read-only), so
+                         surface the reason passively rather than behind an inert click. -->
+                    <div v-if="acct.temp_unschedulable_reason" class="mt-0.5 max-w-xs truncate text-xs text-amber-600 dark:text-amber-400" :title="acct.temp_unschedulable_reason">
+                      {{ acct.temp_unschedulable_reason }}
+                    </div>
                   </td>
                   <td class="px-4 py-2 align-top text-gray-600 dark:text-gray-300">
                     <span>{{ acct.platform }}</span>

--- a/frontend/src/views/admin/EdgeAccountsView.vue
+++ b/frontend/src/views/admin/EdgeAccountsView.vue
@@ -122,9 +122,7 @@
                     />
                   </td>
                   <td class="px-4 py-2 align-top">
-                    <span :class="['inline-flex rounded-full px-2 py-0.5 text-xs font-medium', stateBadgeClass(acct)]">
-                      {{ accountStateLabel(acct) }}
-                    </span>
+                    <AccountStatusIndicator :account="toAccountLike(acct)" />
                   </td>
                   <td class="px-4 py-2 align-top text-right text-gray-700 dark:text-gray-200">{{ acct.priority }}</td>
                   <td class="px-4 py-2 align-top text-gray-600 dark:text-gray-300">
@@ -158,10 +156,10 @@ import AppLayout from '@/components/layout/AppLayout.vue'
 import Icon from '@/components/icons/Icon.vue'
 import AccountCapacityCell from '@/components/account/AccountCapacityCell.vue'
 import AccountUsageCell from '@/components/account/AccountUsageCell.vue'
+import AccountStatusIndicator from '@/components/account/AccountStatusIndicator.vue'
 import { formatDateTime, formatRelativeTime } from '@/utils/format'
 import { useTkEdgeAccounts } from '@/composables/useTkEdgeAccounts'
-import { accountStateLabel, accountStatusVariant, schedulableCount, toAccountLike, toWindowStats, toUsageInfo } from '@/utils/edgeAccounts.tk'
-import type { EdgeAccountSummary } from '@/api/admin/edgeAccounts'
+import { schedulableCount, toAccountLike, toWindowStats, toUsageInfo } from '@/utils/edgeAccounts.tk'
 
 const { t } = useI18n()
 
@@ -175,16 +173,5 @@ const {
   totalAccounts,
   fetch
 } = useTkEdgeAccounts()
-
-const STATE_BADGE_CLASSES: Record<string, string> = {
-  success: 'bg-green-100 text-green-700 dark:bg-green-900/40 dark:text-green-300',
-  warning: 'bg-amber-100 text-amber-700 dark:bg-amber-900/40 dark:text-amber-300',
-  danger: 'bg-red-100 text-red-700 dark:bg-red-900/40 dark:text-red-300',
-  neutral: 'bg-gray-100 text-gray-600 dark:bg-dark-700 dark:text-gray-300'
-}
-
-function stateBadgeClass(a: EdgeAccountSummary): string {
-  return STATE_BADGE_CLASSES[accountStatusVariant(a)] ?? STATE_BADGE_CLASSES.neutral
-}
 // Initial fetch + periodic auto-refresh are owned by useTkEdgeAccounts.
 </script>

--- a/scripts/sentinels/frontend-tk.json
+++ b/scripts/sentinels/frontend-tk.json
@@ -406,10 +406,11 @@
         "admin.edgeAccounts.title",
         "AccountCapacityCell",
         "AccountUsageCell",
+        "AccountStatusIndicator",
         "toAccountLike",
         "toUsageInfo"
       ],
-      "rationale": "TK-only read-only admin page grouping accounts by edge. Renders the per-edge ok/failed/timeout state and a credential-free account table that REUSES the real admin AccountCapacityCell + AccountUsageCell (today + 5h/7d windows) via toAccountLike / toUsageInfo, so the overview's capacity + usage-window gauges stay pixel-aligned with the per-edge /admin/accounts page. Guards against silent upstream-merge deletion of the view or a refactor that drops the cell reuse (which would regress the page back to a sparse static table)."
+      "rationale": "TK-only read-only admin page grouping accounts by edge. Renders the per-edge ok/failed/timeout state and a credential-free account table that REUSES the real admin AccountCapacityCell + AccountUsageCell (today + 5h/7d windows) via toAccountLike / toUsageInfo, so the overview's capacity + usage-window gauges stay pixel-aligned with the per-edge /admin/accounts page. Guards against silent upstream-merge deletion of the view or a refactor that drops the cell reuse (which would regress the page back to a sparse static table). Also reuses AccountStatusIndicator for the 状态 column (instead of a hand-rolled badge) so it matches the per-edge admin page's status semantics; dropping it would regress status display."
     },
     {
       "path": "frontend/src/components/account/AccountUsageCell.vue",

--- a/scripts/sentinels/gateway-tk.json
+++ b/scripts/sentinels/gateway-tk.json
@@ -1558,6 +1558,14 @@
         "classifyOpenAIPrivacyResponse(resp.StatusCode, resp.GetContentType(), resp.String())"
       ],
       "rationale": "The OpenAI 'disable training data sharing' PATCH to chatgpt.com/backend-api gets served an OpenAI-branded Cloudflare anti-bot interstitial (gray logo SVG + <meta http-equiv=refresh>, status 403) from a datacenter egress IP. That page contains NONE of the legacy cloudflare/cf-/Just-a-moment markers, so the original inline detection mis-recorded it as training_set_failed (red 'Fail') instead of training_set_cf_blocked (yellow 'CF' — blocked, retryable, not an account fault). disableOpenAITraining now delegates classification to classifyOpenAIPrivacyResponse in openai_privacy_tk_classify.go (broadened HTML / <html> / cf / meta-refresh detection). An upstream merge that restores the old inline 3-marker block here compiles clean but silently reverts the fix and leaves the companion file as dead code — this sentinel catches that revert."
+    },
+    {
+      "path": "backend/internal/service/account_usage_service.go",
+      "must_contain": [
+        "func parseExtraSampledAt(",
+        "if found && account.SessionWindowStart != nil {"
+      ],
+      "rationale": "Passive 5h-window staleness guard in estimateSetupTokenUsage: session_window_utilization is a passive sample from the last upstream response; if it was sampled BEFORE the current SessionWindowStart (window rolled but not yet re-sampled — the writer's clear-on-roll only fires on expiry-driven init, not header-driven window changes), it belongs to a prior window and would show a misleading high % on a fresh window (observed live: a just-rolled 5h window showing 99%). The guard drops such samples and falls back to status-based estimation. Load-bearing for BOTH the per-edge /admin/accounts page and the cross-edge Edge Accounts overview (both read GetPassiveUsage→estimateSetupTokenUsage); an upstream merge that removes the guard or parseExtraSampledAt silently reintroduces the stale-99% display."
     }
   ]
 }


### PR DESCRIPTION
## What

Two related Edge Accounts fixes (the "1 and 2" follow-ups) in one PR.

### 1. Passive 5h-window staleness guard (backend, shared)

`estimateSetupTokenUsage` showed `session_window_utilization` paired with the current `SessionWindowEnd` **without verifying the sample belonged to that window**. After a header-driven 5h window roll (where the writer's clear-on-roll doesn't fire — it only fires on expiry-driven `needInitWindow`), a prior window's ~99% util was displayed on a just-reset window.

**Confirmed live on us5**: overview showed `99% / 4h58m`, real per-edge page `12% / 2h37m`; the DB sample was fresh at 0.12 — the 99% was a stale sample on a rolled window.

Fix: if `passive_usage_sampled_at` predates `SessionWindowStart`, drop the sample (reset util to 0) → status-based fallback. Applies to **both** the per-edge `/admin/accounts` page and the cross-edge overview (both go through `GetPassiveUsage`). Added `parseExtraSampledAt` (reused in `GetPassiveUsage`) + unit test (stale-drop / fresh-keep / no-sample / no-window-start).

### 2. 状态 column → real `AccountStatusIndicator`

Edge Accounts now reuses the per-edge page's `AccountStatusIndicator` instead of a hand-rolled `accountStateLabel` badge, so status semantics match (429/529 countdown, temp-unsched, etc.). Removed the now-dead `accountStateLabel` / `accountStatusVariant` / `StatusVariant` helpers.

## ⚠️ Redeploy

Fix 1 is in shared backend (`account_usage_service.go`) → **requires edge redeploy** (+ prod). Fix 2 is frontend.

## Verification
- `go test -tags=unit ./internal/service/` ✅ (incl. new staleness test) · `golangci-lint` ✅ · `go build` ✅
- frontend `typecheck` + `lint:check` ✅ · `pnpm build` ✅ (dist refreshed)
- `scripts/preflight.sh` ✅

upstream-touch-guarded — additive guard + cell swap, pinned by new sentinels in `gateway-tk.json` / `frontend-tk.json`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
