### PR TITLE
feat(ops): 账号失效事件 → 飞书即时告警（分级两形态）

### DIFF
--- a/backend/cmd/server/wire.go
+++ b/backend/cmd/server/wire.go
@@ -107,6 +107,10 @@ func provideCleanup(
 	backupSvc *service.BackupService,
 	paymentOrderExpiry *service.PaymentOrderExpiryService,
 	channelMonitorRunner *service.ChannelMonitorRunner,
+	// TokenKey: account-incident Feishu notifier. Passed so its digest ticker is
+	// Stopped at shutdown, and so wire forces evaluation of
+	// ProvideTKAccountIncidentNotifier (which attaches it onto RateLimitService).
+	accountIncidentNotifier *service.TKAccountIncidentNotifier,
 	// TokenKey: forces wire to evaluate ProvideTKAuthServiceColdStart so the
 	// trial-key issuer gets wired onto AuthService at startup. The value is
 	// unused — only the dependency edge matters. See US-029 / US-030.
@@ -291,6 +295,12 @@ func provideCleanup(
 			{"ChannelMonitorRunner", func() error {
 				if channelMonitorRunner != nil {
 					channelMonitorRunner.Stop()
+				}
+				return nil
+			}},
+			{"AccountIncidentNotifier", func() error {
+				if accountIncidentNotifier != nil {
+					accountIncidentNotifier.Stop()
 				}
 				return nil
 			}},

--- a/backend/cmd/server/wire_gen.go
+++ b/backend/cmd/server/wire_gen.go
@@ -301,13 +301,14 @@ func initializeApplication(buildInfo handler.BuildInfo) (*Application, error) {
 	scheduledTestRunnerService := service.ProvideScheduledTestRunnerService(scheduledTestPlanRepository, scheduledTestService, accountTestService, rateLimitService, configConfig)
 	paymentOrderExpiryService := service.ProvidePaymentOrderExpiryService(paymentService)
 	channelMonitorRunner := service.ProvideChannelMonitorRunner(channelMonitorService, settingService)
+	tkAccountIncidentNotifier := service.ProvideTKAccountIncidentNotifier(rateLimitService, opsService, configConfig)
 	tkAuthServiceColdStartReady := service.ProvideTKAuthServiceColdStart(authService, apiKeyService, settingService)
 	tkGatewayPricingAvailabilityReady := service.ProvideTKGatewayPricingAvailability(gatewayService, pricingAvailabilityService)
 	anthropicSignaturePreemptCache := repository.NewAnthropicSignaturePreemptCache(redisClient)
 	tkGatewayAnthropicSigPreemptReady := service.ProvideTKGatewayAnthropicSigPreempt(gatewayService, anthropicSignaturePreemptCache)
 	modelListFilter := service.NewModelListFilter(pricingCatalogService, pricingAvailabilityService)
 	tkGatewayHandlerModelListReady := handler.ProvideTKGatewayHandlerModelList(gatewayHandler, modelListFilter)
-	v := provideCleanup(client, redisClient, opsMetricsCollector, opsAggregationService, opsAlertEvaluatorService, opsCleanupService, opsScheduledReportService, opsSystemLogSink, schedulerSnapshotService, schedulerRateLimitReaper, anthropicConfigReconciler, tokenRefreshService, accountExpiryService, subscriptionExpiryService, usageCleanupService, idempotencyCleanupService, pricingService, emailQueueService, billingCacheService, usageRecordWorkerPool, qaService, subscriptionService, oAuthService, openAIOAuthService, geminiOAuthService, antigravityOAuthService, openAIGatewayService, scheduledTestRunnerService, backupService, paymentOrderExpiryService, channelMonitorRunner, tkAuthServiceColdStartReady, tkGatewayPricingAvailabilityReady, tkGatewayAnthropicSigPreemptReady, tkGatewayHandlerModelListReady)
+	v := provideCleanup(client, redisClient, opsMetricsCollector, opsAggregationService, opsAlertEvaluatorService, opsCleanupService, opsScheduledReportService, opsSystemLogSink, schedulerSnapshotService, schedulerRateLimitReaper, anthropicConfigReconciler, tokenRefreshService, accountExpiryService, subscriptionExpiryService, usageCleanupService, idempotencyCleanupService, pricingService, emailQueueService, billingCacheService, usageRecordWorkerPool, qaService, subscriptionService, oAuthService, openAIOAuthService, geminiOAuthService, antigravityOAuthService, openAIGatewayService, scheduledTestRunnerService, backupService, paymentOrderExpiryService, channelMonitorRunner, tkAccountIncidentNotifier, tkAuthServiceColdStartReady, tkGatewayPricingAvailabilityReady, tkGatewayAnthropicSigPreemptReady, tkGatewayHandlerModelListReady)
 	application := &Application{
 		Server:  httpServer,
 		Cleanup: v,
@@ -367,6 +368,8 @@ func provideCleanup(
 	backupSvc *service.BackupService,
 	paymentOrderExpiry *service.PaymentOrderExpiryService,
 	channelMonitorRunner *service.ChannelMonitorRunner,
+
+	accountIncidentNotifier *service.TKAccountIncidentNotifier,
 
 	_ service.TKAuthServiceColdStartReady,
 
@@ -538,6 +541,12 @@ func provideCleanup(
 			{"ChannelMonitorRunner", func() error {
 				if channelMonitorRunner != nil {
 					channelMonitorRunner.Stop()
+				}
+				return nil
+			}},
+			{"AccountIncidentNotifier", func() error {
+				if accountIncidentNotifier != nil {
+					accountIncidentNotifier.Stop()
 				}
 				return nil
 			}},

--- a/backend/cmd/server/wire_gen_test.go
+++ b/backend/cmd/server/wire_gen_test.go
@@ -84,10 +84,11 @@ func TestProvideCleanup_WithMinimalDependencies_NoPanic(t *testing.T) {
 		nil,                                   // backupSvc
 		nil,                                   // paymentOrderExpiry
 		nil,                                   // channelMonitorRunner
-		service.TKAuthServiceColdStartReady{},             // TK: forces SetTrialKeyIssuer wiring
-		service.TKGatewayPricingAvailabilityReady{},       // TK: forces SetPricingAvailabilityService wiring
-		service.TKGatewayAnthropicSigPreemptReady{},       // TK: forces SetAnthropicSigPreemptCache wiring
-		handler.TKGatewayHandlerModelListReady{},          // TK: forces SetModelListFilter wiring
+		nil,                                   // accountIncidentNotifier
+		service.TKAuthServiceColdStartReady{}, // TK: forces SetTrialKeyIssuer wiring
+		service.TKGatewayPricingAvailabilityReady{}, // TK: forces SetPricingAvailabilityService wiring
+		service.TKGatewayAnthropicSigPreemptReady{}, // TK: forces SetAnthropicSigPreemptCache wiring
+		handler.TKGatewayHandlerModelListReady{},    // TK: forces SetModelListFilter wiring
 	)
 
 	require.NotPanics(t, func() {

--- a/backend/internal/service/account_incident_notifier_tk.go
+++ b/backend/internal/service/account_incident_notifier_tk.go
@@ -1,0 +1,408 @@
+package service
+
+// TK: 账号失效事件 → 飞书即时告警（分级两形态）。
+//
+// 设计见 docs / plan「账号失效事件 → 飞书告警」。核心:
+//   - 永久失效（status=error 终态，需人工重新 OAuth / 查 bug）→ 即时单条 P0 卡片（红头）。
+//   - 临时冷却（429/529/oauth_401 临时/403temp/temp，自愈）→ 不逐条发,写入聚合 buffer,
+//     由后台 ticker 按 feishu.account_incident_digest_seconds（默认 600s）flush 一条摘要（橙头）。
+// 信噪比第一: 自愈类绝不和"账号挂了"挤在同一个即时 P0 流里淹没真故障。
+//
+// 唯一挂钩点是 RateLimitService.notifyAccountSchedulingBlocked（见 ratelimit_service_tk_incident.go）。
+// 单副本 Stage0、无 leader,挂钩点直接发不会跨节点重复。
+
+import (
+	"context"
+	"fmt"
+	"net/http"
+	"net/url"
+	"sort"
+	"strings"
+	"sync"
+	"time"
+
+	"github.com/Wei-Shaw/sub2api/internal/pkg/logger"
+)
+
+// AccountIncidentKind 区分账号失效事件的两种形态。
+type AccountIncidentKind int
+
+const (
+	IncidentKindUnknown           AccountIncidentKind = iota
+	IncidentKindPermanentDisable                      // status=error 终态,需人工
+	IncidentKindTemporaryCooldown                     // 429/529/temp,自愈,聚合摘要
+)
+
+// AccountIncidentNotifier 是注入给 RateLimitService 的最小通知面（仿 AccountRuntimeBlocker）。
+type AccountIncidentNotifier interface {
+	NotifyAccountIncident(account *Account, until time.Time, reason string, kind AccountIncidentKind)
+}
+
+const (
+	// 永久失效同 (site,account,reasonClass) 的去重窗口,防极端刷屏。
+	accountIncidentPermanentDedupeWindow = time.Hour
+	// 永久失效卡片每小时最多条数（滑动窗口防爆量）。
+	accountIncidentPermanentRatePerHour = 30
+	// 聚合摘要 flush 间隔的兜底值（配置缺失时）。
+	accountIncidentDigestSecondsFallback = 600
+	// 摘要里每个 reasonClass 展示的账号名样例上限。
+	accountIncidentDigestMaxSamples = 8
+)
+
+// incidentClass 是 reason 经分类后的派生信息。
+type incidentClass struct {
+	alert       bool
+	kind        AccountIncidentKind
+	reasonClass string // 去重 / 聚合分组键
+	kindZh      string // 中文事件类型
+	advice      string // 运营建议动作
+}
+
+// classifyIncident 把底层 reason 字符串映射成 (形态, 去重类, 中文文案, 建议)。
+// reason 精确匹配优先（覆盖全部已知挂钩点）;未知 reason 时用显式 kind + until 兜底。
+func classifyIncident(reason string, until time.Time, kind AccountIncidentKind) incidentClass {
+	switch strings.TrimSpace(strings.ToLower(reason)) {
+	case "auth_error":
+		return incidentClass{true, IncidentKindPermanentDisable, "auth", "账号永久失效（认证失败）", "立即重新 OAuth 授权该账号"}
+	case "custom_error_code":
+		return incidentClass{true, IncidentKindPermanentDisable, "custom_code", "账号被自定义错误码罚下", "检查命中的自定义错误码规则与上游响应"}
+	case "stream_timeout_error":
+		return incidentClass{true, IncidentKindPermanentDisable, "stream_timeout", "账号永久失效（流超时累计）", "检查上游连通性后重测该账号"}
+	case "oauth_401":
+		return incidentClass{true, IncidentKindTemporaryCooldown, "oauth401", "OAuth 401 临时冷却", "观察是否升级为永久失效;检查 token 刷新链路"}
+	case "429", "429_fallback":
+		return incidentClass{true, IncidentKindTemporaryCooldown, "429", "限流冷却（429）", "容量/节奏问题,关注是否反复触发"}
+	case "529":
+		return incidentClass{true, IncidentKindTemporaryCooldown, "529", "过载冷却（529）", "上游过载,通常自愈"}
+	case "openai_403_temp":
+		return incidentClass{true, IncidentKindTemporaryCooldown, "403", "OpenAI 403 临时冷却", "检查 IP/账号风控状态"}
+	case "temp_unschedulable", "stream_timeout_temp_unschedulable":
+		return incidentClass{true, IncidentKindTemporaryCooldown, "temp", "临时不可调度", "观察是否自愈"}
+	}
+	// 未知 reason: 显式 kind 优先,缺省再看 until。
+	k := kind
+	if k == IncidentKindUnknown {
+		if until.IsZero() {
+			k = IncidentKindPermanentDisable
+		} else {
+			k = IncidentKindTemporaryCooldown
+		}
+	}
+	if k == IncidentKindPermanentDisable {
+		return incidentClass{true, IncidentKindPermanentDisable, "other", "账号永久失效", "人工检查该账号（可能需重新授权）"}
+	}
+	return incidentClass{true, IncidentKindTemporaryCooldown, "other", "账号临时冷却", "观察是否自愈"}
+}
+
+// accountIncidentDigestEntry 是临时冷却聚合 buffer 的单个 reasonClass 条目。
+type accountIncidentDigestEntry struct {
+	reasonClass    string
+	kindZh         string
+	advice         string
+	accountIDs     map[int64]struct{}
+	accountSamples []string
+	count          int
+	firstAt        time.Time
+	lastAt         time.Time
+}
+
+// opsFeishuConfigProvider 是 notifier 读取飞书配置的最小面（*OpsService 天然满足）。
+// 收成接口便于单测注入,而不必搭建整个 OpsService + setting repo。
+type opsFeishuConfigProvider interface {
+	GetEmailNotificationConfig(ctx context.Context) (*OpsEmailNotificationConfig, error)
+}
+
+type TKAccountIncidentNotifier struct {
+	cfgProvider opsFeishuConfigProvider
+	httpClient  opsFeishuHTTPDoer
+	siteID      string
+	now         func() time.Time
+
+	mu          sync.Mutex
+	permSentAt  map[string]time.Time                   // 永久失效去重: key -> 上次发送
+	permLimiter *slidingWindowLimiter                  // 永久失效防爆量
+	digest      map[string]*accountIncidentDigestEntry // reasonClass -> 聚合条目
+
+	stopCh   chan struct{}
+	stopOnce sync.Once
+}
+
+func newTKAccountIncidentNotifier(cfgProvider opsFeishuConfigProvider, siteID string) *TKAccountIncidentNotifier {
+	n := &TKAccountIncidentNotifier{
+		cfgProvider: cfgProvider,
+		httpClient:  &http.Client{Timeout: opsFeishuWebhookTimeout},
+		siteID:      strings.TrimSpace(siteID),
+		now:         time.Now,
+		permSentAt:  map[string]time.Time{},
+		permLimiter: newSlidingWindowLimiter(accountIncidentPermanentRatePerHour, time.Hour),
+		digest:      map[string]*accountIncidentDigestEntry{},
+		stopCh:      make(chan struct{}),
+	}
+	if n.siteID == "" {
+		n.siteID = "unknown"
+	}
+	return n
+}
+
+// Start 启动后台聚合 flush ticker。必须配对 Stop()。
+func (n *TKAccountIncidentNotifier) Start() {
+	if n == nil {
+		return
+	}
+	go n.digestLoop()
+}
+
+// Stop 优雅停 ticker,供 wire cleanup 调用。幂等。
+func (n *TKAccountIncidentNotifier) Stop() {
+	if n == nil {
+		return
+	}
+	n.stopOnce.Do(func() {
+		close(n.stopCh)
+	})
+}
+
+func (n *TKAccountIncidentNotifier) NotifyAccountIncident(account *Account, until time.Time, reason string, kind AccountIncidentKind) {
+	if n == nil || account == nil {
+		return
+	}
+	cls := classifyIncident(reason, until, kind)
+	if !cls.alert {
+		return
+	}
+	if cls.kind == IncidentKindPermanentDisable {
+		n.handlePermanent(account, reason, cls)
+		return
+	}
+	n.recordTemporary(account, cls)
+}
+
+// handlePermanent: 同步只做内存去重判定,命中后异步发即时单条 P0 卡片。
+func (n *TKAccountIncidentNotifier) handlePermanent(account *Account, reason string, cls incidentClass) {
+	now := n.currentTime()
+	key := accountIncidentDedupeKey(n.siteID, account.ID, cls.reasonClass)
+	n.mu.Lock()
+	if last, seen := n.permSentAt[key]; seen && now.Sub(last) < accountIncidentPermanentDedupeWindow {
+		n.mu.Unlock()
+		return
+	}
+	if n.permLimiter != nil && !n.permLimiter.Allow(now) {
+		n.mu.Unlock()
+		return
+	}
+	n.permSentAt[key] = now
+	n.mu.Unlock()
+
+	title := fmt.Sprintf("TokenKey 账号永久失效 [%s]", n.siteID)
+	body := buildAccountIncidentPermanentText(n.siteID, account, reason, cls, now)
+	n.send(title, "red", body, fmt.Sprintf("account_id=%d reason=%s", account.ID, reason))
+}
+
+// recordTemporary: 仅写入聚合 buffer,不立即发。
+func (n *TKAccountIncidentNotifier) recordTemporary(account *Account, cls incidentClass) {
+	now := n.currentTime()
+	n.mu.Lock()
+	defer n.mu.Unlock()
+	entry := n.digest[cls.reasonClass]
+	if entry == nil {
+		entry = &accountIncidentDigestEntry{
+			reasonClass: cls.reasonClass,
+			kindZh:      cls.kindZh,
+			advice:      cls.advice,
+			accountIDs:  map[int64]struct{}{},
+			firstAt:     now,
+		}
+		n.digest[cls.reasonClass] = entry
+	}
+	entry.count++
+	entry.lastAt = now
+	if _, ok := entry.accountIDs[account.ID]; !ok {
+		entry.accountIDs[account.ID] = struct{}{}
+		if len(entry.accountSamples) < accountIncidentDigestMaxSamples {
+			entry.accountSamples = append(entry.accountSamples, accountIncidentLabel(account))
+		}
+	}
+}
+
+func (n *TKAccountIncidentNotifier) digestLoop() {
+	defer func() {
+		if r := recover(); r != nil {
+			logger.LegacyPrintf("service.account_incident", "[AccountIncident] digest loop panic recovered: %v", r)
+		}
+	}()
+	for {
+		timer := time.NewTimer(n.digestInterval())
+		select {
+		case <-n.stopCh:
+			timer.Stop()
+			return
+		case <-timer.C:
+			n.flushDigest()
+		}
+	}
+}
+
+// digestInterval 从配置读 flush 间隔（秒）,下限 30s,缺失则兜底 600s。
+func (n *TKAccountIncidentNotifier) digestInterval() time.Duration {
+	secs := accountIncidentDigestSecondsFallback
+	if n.cfgProvider != nil {
+		if cfg, err := n.cfgProvider.GetEmailNotificationConfig(context.Background()); err == nil && cfg != nil && cfg.Feishu.AccountIncidentDigestSeconds > 0 {
+			secs = cfg.Feishu.AccountIncidentDigestSeconds
+		}
+	}
+	if secs < 30 {
+		secs = 30
+	}
+	return time.Duration(secs) * time.Second
+}
+
+// flushDigest 取出并清空 buffer,有内容则异步发一条摘要;空则跳过。
+func (n *TKAccountIncidentNotifier) flushDigest() {
+	n.mu.Lock()
+	if len(n.digest) == 0 {
+		n.mu.Unlock()
+		return
+	}
+	entries := make([]*accountIncidentDigestEntry, 0, len(n.digest))
+	for _, e := range n.digest {
+		entries = append(entries, e)
+	}
+	n.digest = map[string]*accountIncidentDigestEntry{}
+	n.mu.Unlock()
+
+	sort.Slice(entries, func(i, j int) bool { return entries[i].reasonClass < entries[j].reasonClass })
+	now := n.currentTime()
+	title := fmt.Sprintf("TokenKey 账号临时冷却摘要 [%s]", n.siteID)
+	body := buildAccountIncidentDigestText(n.siteID, entries, now)
+	n.send(title, "orange", body, "digest")
+}
+
+// send 异步发送（绝不阻塞挂钩点 / flush goroutine）。
+func (n *TKAccountIncidentNotifier) send(title, headerTemplate, body, logCtx string) {
+	go n.sendNow(title, headerTemplate, body, logCtx)
+}
+
+// sendNow 同步发送一条飞书卡片。独立 5s ctx,不继承请求 ctx;panic recover。
+func (n *TKAccountIncidentNotifier) sendNow(title, headerTemplate, body, logCtx string) {
+	defer func() {
+		if r := recover(); r != nil {
+			logger.LegacyPrintf("service.account_incident", "[AccountIncident] send panic recovered (%s): %v", logCtx, r)
+		}
+	}()
+	if n == nil || n.cfgProvider == nil {
+		return
+	}
+	cfg, err := n.cfgProvider.GetEmailNotificationConfig(context.Background())
+	if err != nil || cfg == nil || !cfg.Feishu.Enabled || strings.TrimSpace(cfg.Feishu.WebhookURL) == "" {
+		return
+	}
+	ctx, cancel := context.WithTimeout(context.Background(), opsFeishuWebhookTimeout)
+	defer cancel()
+	payload := feishuCardPayload(cfg.Feishu, n.now, headerTemplate, title, body)
+	if err := sendFeishuPayload(ctx, n.httpClient, cfg.Feishu, payload); err != nil {
+		logger.LegacyPrintf("service.account_incident", "[AccountIncident] feishu send failed (%s): %s", logCtx, err.Error())
+	}
+}
+
+func (n *TKAccountIncidentNotifier) currentTime() time.Time {
+	if n != nil && n.now != nil {
+		return n.now()
+	}
+	return time.Now()
+}
+
+func buildAccountIncidentPermanentText(site string, account *Account, reason string, cls incidentClass, now time.Time) string {
+	return fmt.Sprintf("**节点**：%s\n**账号**：%s\n**平台**：%s\n**组**：%s\n**事件**：%s\n**reason**：%s\n**时间**：%s\n\n**建议**：%s",
+		escapeFeishuText(site),
+		escapeFeishuText(accountIncidentLabel(account)),
+		escapeFeishuText(strings.TrimSpace(account.Platform)),
+		escapeFeishuText(accountGroupNames(account)),
+		escapeFeishuText(cls.kindZh),
+		escapeFeishuText(strings.TrimSpace(reason)),
+		escapeFeishuText(now.Format(time.RFC3339)),
+		escapeFeishuText(cls.advice),
+	)
+}
+
+func buildAccountIncidentDigestText(site string, entries []*accountIncidentDigestEntry, now time.Time) string {
+	lines := make([]string, 0, len(entries)+1)
+	lines = append(lines, fmt.Sprintf("**节点**：%s\n**时间**：%s\n\n临时冷却（自愈类）聚合摘要：",
+		escapeFeishuText(site), escapeFeishuText(now.Format(time.RFC3339))))
+	for _, e := range entries {
+		samples := strings.Join(e.accountSamples, ", ")
+		if len(e.accountIDs) > len(e.accountSamples) {
+			samples += fmt.Sprintf(" 等共%d个", len(e.accountIDs))
+		}
+		lines = append(lines, fmt.Sprintf("- **%s**：%d 次 / %d 账号（%s）",
+			escapeFeishuText(e.kindZh), e.count, len(e.accountIDs), escapeFeishuText(samples)))
+	}
+	return strings.Join(lines, "\n")
+}
+
+func accountIncidentLabel(account *Account) string {
+	if account == nil {
+		return "-"
+	}
+	name := strings.TrimSpace(account.Name)
+	if name == "" {
+		return fmt.Sprintf("#%d", account.ID)
+	}
+	return fmt.Sprintf("%s(#%d)", name, account.ID)
+}
+
+func accountGroupNames(account *Account) string {
+	if account == nil || len(account.Groups) == 0 {
+		return "-"
+	}
+	names := make([]string, 0, len(account.Groups))
+	for _, g := range account.Groups {
+		if g == nil {
+			continue
+		}
+		gn := strings.TrimSpace(g.Name)
+		if gn == "" {
+			gn = fmt.Sprintf("#%d", g.ID)
+		}
+		names = append(names, gn)
+	}
+	if len(names) == 0 {
+		return "-"
+	}
+	return strings.Join(names, ",")
+}
+
+func accountIncidentDedupeKey(site string, accountID int64, reasonClass string) string {
+	return fmt.Sprintf("%s|%d|%s", site, accountID, reasonClass)
+}
+
+// siteFromFrontendURL 从 server.frontend_url 域名提取节点名:
+//
+//	api.tokenkey.dev      -> prod
+//	api-us1.tokenkey.dev  -> edge-us1
+//
+// 无法解析时返回 "unknown"。
+func siteFromFrontendURL(frontendURL string) string {
+	raw := strings.TrimSpace(frontendURL)
+	if raw == "" {
+		return "unknown"
+	}
+	parsed, err := url.Parse(raw)
+	if err != nil || parsed.Host == "" {
+		return "unknown"
+	}
+	host := parsed.Hostname()
+	first := host
+	if idx := strings.IndexByte(host, '.'); idx > 0 {
+		first = host[:idx]
+	}
+	switch {
+	case first == "":
+		return "unknown"
+	case first == "api":
+		return "prod"
+	case strings.HasPrefix(first, "api-"):
+		return "edge-" + strings.TrimPrefix(first, "api-")
+	default:
+		return first
+	}
+}

--- a/backend/internal/service/account_incident_notifier_tk.go
+++ b/backend/internal/service/account_incident_notifier_tk.go
@@ -258,6 +258,14 @@ func (n *TKAccountIncidentNotifier) digestInterval() time.Duration {
 
 // flushDigest 取出并清空 buffer,有内容则异步发一条摘要;空则跳过。
 func (n *TKAccountIncidentNotifier) flushDigest() {
+	// 单次 flush 的 panic 必须就地兜住,不能传播到 digestLoop——否则其函数级 recover
+	// 会让整个聚合 goroutine 退出,临时冷却摘要永久静默。持锁区只做 map 取数+清空、
+	// 不会 panic,故 recover 兜的是 unlock 之后的排序/构造/发送,无持锁 panic 死锁路径。
+	defer func() {
+		if r := recover(); r != nil {
+			logger.LegacyPrintf("service.account_incident", "[AccountIncident] flushDigest panic recovered: %v", r)
+		}
+	}()
 	n.mu.Lock()
 	if len(n.digest) == 0 {
 		n.mu.Unlock()

--- a/backend/internal/service/account_incident_notifier_tk_test.go
+++ b/backend/internal/service/account_incident_notifier_tk_test.go
@@ -1,0 +1,259 @@
+//go:build unit
+
+package service
+
+import (
+	"context"
+	"io"
+	"net/http"
+	"strings"
+	"sync"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/require"
+)
+
+// --- fakes ---------------------------------------------------------------
+
+type fakeIncidentConfigProvider struct {
+	cfg *OpsEmailNotificationConfig
+	err error
+}
+
+func (f *fakeIncidentConfigProvider) GetEmailNotificationConfig(_ context.Context) (*OpsEmailNotificationConfig, error) {
+	return f.cfg, f.err
+}
+
+func enabledFeishuConfig() *OpsEmailNotificationConfig {
+	return &OpsEmailNotificationConfig{
+		Feishu: OpsFeishuAlertConfig{
+			Enabled:                      true,
+			WebhookURL:                   "https://open.feishu.cn/open-apis/bot/v2/hook/test",
+			AccountIncidentDigestSeconds: 600,
+		},
+	}
+}
+
+type blockingFeishuDoer struct {
+	mu     sync.Mutex
+	calls  int
+	bodies []string
+	block  chan struct{} // if non-nil, Do blocks on receive
+	done   chan struct{} // if non-nil, Do signals after each call
+	panics bool
+}
+
+func (d *blockingFeishuDoer) Do(req *http.Request) (*http.Response, error) {
+	if req.Body != nil {
+		body, _ := io.ReadAll(req.Body)
+		d.mu.Lock()
+		d.bodies = append(d.bodies, string(body))
+		d.mu.Unlock()
+	}
+	d.mu.Lock()
+	d.calls++
+	d.mu.Unlock()
+	if d.block != nil {
+		<-d.block
+	}
+	if d.panics {
+		panic("boom from doer")
+	}
+	if d.done != nil {
+		d.done <- struct{}{}
+	}
+	return &http.Response{StatusCode: http.StatusOK, Body: io.NopCloser(strings.NewReader(`{"code":0}`)), Header: http.Header{}}, nil
+}
+
+func (d *blockingFeishuDoer) callCount() int {
+	d.mu.Lock()
+	defer d.mu.Unlock()
+	return d.calls
+}
+
+func (d *blockingFeishuDoer) lastBody() string {
+	d.mu.Lock()
+	defer d.mu.Unlock()
+	if len(d.bodies) == 0 {
+		return ""
+	}
+	return d.bodies[len(d.bodies)-1]
+}
+
+func newTestNotifier(provider opsFeishuConfigProvider, doer opsFeishuHTTPDoer, fixedNow time.Time) *TKAccountIncidentNotifier {
+	n := newTKAccountIncidentNotifier(provider, "edge-test")
+	n.httpClient = doer
+	n.now = func() time.Time { return fixedNow }
+	return n
+}
+
+func testAccount(id int64, name, platform string) *Account {
+	return &Account{ID: id, Name: name, Platform: platform, Groups: []*Group{{ID: 7, Name: "group15"}}}
+}
+
+// --- tests ---------------------------------------------------------------
+
+func TestClassifyIncident(t *testing.T) {
+	t.Parallel()
+	cases := []struct {
+		reason    string
+		until     time.Time
+		kind      AccountIncidentKind
+		wantKind  AccountIncidentKind
+		wantClass string
+	}{
+		{"auth_error", time.Time{}, IncidentKindUnknown, IncidentKindPermanentDisable, "auth"},
+		{"custom_error_code", time.Time{}, IncidentKindUnknown, IncidentKindPermanentDisable, "custom_code"},
+		{"stream_timeout_error", time.Time{}, IncidentKindUnknown, IncidentKindPermanentDisable, "stream_timeout"},
+		{"oauth_401", time.Now(), IncidentKindUnknown, IncidentKindTemporaryCooldown, "oauth401"},
+		{"429", time.Now(), IncidentKindUnknown, IncidentKindTemporaryCooldown, "429"},
+		{"429_fallback", time.Now(), IncidentKindUnknown, IncidentKindTemporaryCooldown, "429"},
+		{"529", time.Now(), IncidentKindUnknown, IncidentKindTemporaryCooldown, "529"},
+		{"openai_403_temp", time.Now(), IncidentKindUnknown, IncidentKindTemporaryCooldown, "403"},
+		{"temp_unschedulable", time.Now(), IncidentKindUnknown, IncidentKindTemporaryCooldown, "temp"},
+		{"stream_timeout_temp_unschedulable", time.Now(), IncidentKindUnknown, IncidentKindTemporaryCooldown, "temp"},
+		// unknown reason → fall back to until/kind
+		{"mystery", time.Time{}, IncidentKindUnknown, IncidentKindPermanentDisable, "other"},
+		{"mystery", time.Now(), IncidentKindUnknown, IncidentKindTemporaryCooldown, "other"},
+		{"mystery", time.Time{}, IncidentKindTemporaryCooldown, IncidentKindTemporaryCooldown, "other"},
+	}
+	for _, c := range cases {
+		got := classifyIncident(c.reason, c.until, c.kind)
+		require.True(t, got.alert, "reason=%s should alert", c.reason)
+		require.Equal(t, c.wantKind, got.kind, "reason=%s kind", c.reason)
+		require.Equal(t, c.wantClass, got.reasonClass, "reason=%s class", c.reason)
+		require.NotEmpty(t, got.kindZh)
+		require.NotEmpty(t, got.advice)
+	}
+}
+
+func TestSiteFromFrontendURL(t *testing.T) {
+	t.Parallel()
+	cases := map[string]string{
+		"https://api.tokenkey.dev":          "prod",
+		"https://api-us1.tokenkey.dev":      "edge-us1",
+		"https://api-uk1.tokenkey.dev/":     "edge-uk1",
+		"https://api-us2.tokenkey.dev:8443": "edge-us2",
+		"":                                  "unknown",
+		"not a url":                         "unknown",
+	}
+	for in, want := range cases {
+		require.Equal(t, want, siteFromFrontendURL(in), "input=%q", in)
+	}
+}
+
+func TestNotifyPermanentSendsImmediately(t *testing.T) {
+	doer := &blockingFeishuDoer{done: make(chan struct{}, 1)}
+	n := newTestNotifier(&fakeIncidentConfigProvider{cfg: enabledFeishuConfig()}, doer, time.Unix(1700000000, 0))
+
+	n.NotifyAccountIncident(testAccount(42, "cc-main", "anthropic"), time.Time{}, "auth_error", IncidentKindUnknown)
+
+	select {
+	case <-doer.done:
+	case <-time.After(2 * time.Second):
+		t.Fatal("permanent incident did not send within 2s")
+	}
+	require.Equal(t, 1, doer.callCount())
+	body := doer.lastBody()
+	require.Contains(t, body, "cc-main")
+	require.Contains(t, body, "anthropic")
+	require.Contains(t, body, "group15")
+}
+
+func TestNotifyTemporaryBuffersUntilFlush(t *testing.T) {
+	doer := &blockingFeishuDoer{done: make(chan struct{}, 1)}
+	n := newTestNotifier(&fakeIncidentConfigProvider{cfg: enabledFeishuConfig()}, doer, time.Unix(1700000000, 0))
+
+	// Two different accounts hit 429 — must NOT send immediately.
+	n.NotifyAccountIncident(testAccount(1, "acc1", "openai"), time.Now().Add(time.Minute), "429", IncidentKindUnknown)
+	n.NotifyAccountIncident(testAccount(2, "acc2", "openai"), time.Now().Add(time.Minute), "429", IncidentKindUnknown)
+	require.Equal(t, 0, doer.callCount(), "temporary incidents must not send immediately")
+
+	// buffer has one reasonClass with two accounts
+	n.mu.Lock()
+	require.Len(t, n.digest, 1)
+	require.Equal(t, 2, n.digest["429"].count)
+	require.Len(t, n.digest["429"].accountIDs, 2)
+	n.mu.Unlock()
+
+	n.flushDigest()
+	select {
+	case <-doer.done:
+	case <-time.After(2 * time.Second):
+		t.Fatal("digest flush did not send within 2s")
+	}
+	require.Equal(t, 1, doer.callCount())
+	require.Contains(t, doer.lastBody(), "限流冷却")
+
+	// buffer cleared after flush
+	n.mu.Lock()
+	require.Empty(t, n.digest)
+	n.mu.Unlock()
+}
+
+func TestFlushEmptyBufferDoesNotSend(t *testing.T) {
+	doer := &blockingFeishuDoer{}
+	n := newTestNotifier(&fakeIncidentConfigProvider{cfg: enabledFeishuConfig()}, doer, time.Unix(1700000000, 0))
+	n.flushDigest()
+	time.Sleep(50 * time.Millisecond)
+	require.Equal(t, 0, doer.callCount())
+}
+
+func TestPermanentDedupeWithinWindow(t *testing.T) {
+	doer := &blockingFeishuDoer{done: make(chan struct{}, 2)}
+	now := time.Unix(1700000000, 0)
+	n := newTestNotifier(&fakeIncidentConfigProvider{cfg: enabledFeishuConfig()}, doer, now)
+
+	acc := testAccount(42, "cc-main", "anthropic")
+	n.NotifyAccountIncident(acc, time.Time{}, "auth_error", IncidentKindUnknown)
+	select {
+	case <-doer.done:
+	case <-time.After(2 * time.Second):
+		t.Fatal("first permanent incident did not send")
+	}
+	// second, same (site,account,reasonClass) within 1h window (now unchanged) → suppressed
+	n.NotifyAccountIncident(acc, time.Time{}, "auth_error", IncidentKindUnknown)
+	select {
+	case <-doer.done:
+		t.Fatal("duplicate permanent incident should have been suppressed")
+	case <-time.After(150 * time.Millisecond):
+	}
+	require.Equal(t, 1, doer.callCount())
+}
+
+func TestNotifyDisabledDoesNotSend(t *testing.T) {
+	doer := &blockingFeishuDoer{done: make(chan struct{}, 1)}
+	disabled := &OpsEmailNotificationConfig{Feishu: OpsFeishuAlertConfig{Enabled: false}}
+	n := newTestNotifier(&fakeIncidentConfigProvider{cfg: disabled}, doer, time.Unix(1700000000, 0))
+
+	n.NotifyAccountIncident(testAccount(42, "cc-main", "anthropic"), time.Time{}, "auth_error", IncidentKindUnknown)
+	select {
+	case <-doer.done:
+		t.Fatal("must not send when feishu disabled")
+	case <-time.After(150 * time.Millisecond):
+	}
+	require.Equal(t, 0, doer.callCount())
+}
+
+func TestNotifyDoesNotBlockOnSlowHTTP(t *testing.T) {
+	block := make(chan struct{})
+	doer := &blockingFeishuDoer{block: block}
+	n := newTestNotifier(&fakeIncidentConfigProvider{cfg: enabledFeishuConfig()}, doer, time.Unix(1700000000, 0))
+
+	start := time.Now()
+	n.NotifyAccountIncident(testAccount(42, "cc-main", "anthropic"), time.Time{}, "auth_error", IncidentKindUnknown)
+	elapsed := time.Since(start)
+	require.Less(t, elapsed, 50*time.Millisecond, "hook point must return immediately even if HTTP is stuck")
+
+	close(block) // release the goroutine for clean teardown
+}
+
+func TestSendPanicRecovered(t *testing.T) {
+	doer := &blockingFeishuDoer{panics: true}
+	n := newTestNotifier(&fakeIncidentConfigProvider{cfg: enabledFeishuConfig()}, doer, time.Unix(1700000000, 0))
+	// sendNow runs synchronously here; a panic in the doer must be recovered, not crash the test.
+	require.NotPanics(t, func() {
+		n.sendNow("title", "red", "body", "test")
+	})
+}

--- a/backend/internal/service/ops_feishu_notifier_tk.go
+++ b/backend/internal/service/ops_feishu_notifier_tk.go
@@ -39,14 +39,56 @@ func (n *opsFeishuNotifier) sendAlert(ctx context.Context, cfg OpsFeishuAlertCon
 	if n == nil {
 		n = newOpsFeishuNotifier()
 	}
-	client := n.httpClient
-	if client == nil {
-		client = &http.Client{Timeout: opsFeishuWebhookTimeout}
-	}
-
 	payload, err := n.buildPayload(cfg, rule, event)
 	if err != nil {
 		return err
+	}
+	return sendFeishuPayload(ctx, n.httpClient, cfg, payload)
+}
+
+// feishuCardPayload builds the interactive-card envelope (header template/title
+// + lark_md body) and signs it when a secret is configured. Both the ops alert
+// path (buildPayload) and the account-incident path reuse it so the card shape +
+// signing live in one place.
+func feishuCardPayload(cfg OpsFeishuAlertConfig, now func() time.Time, headerTemplate, headerTitle, markdownBody string) map[string]any {
+	if now == nil {
+		now = time.Now
+	}
+	payload := map[string]any{
+		"msg_type": "interactive",
+		"card": map[string]any{
+			"header": map[string]any{
+				"template": headerTemplate,
+				"title": map[string]any{
+					"tag":     "plain_text",
+					"content": headerTitle,
+				},
+			},
+			"elements": []map[string]any{
+				{
+					"tag": "div",
+					"text": map[string]any{
+						"tag":     "lark_md",
+						"content": markdownBody,
+					},
+				},
+			},
+		},
+	}
+	if secret := strings.TrimSpace(cfg.SigningSecret); secret != "" {
+		timestamp := strconv.FormatInt(now().Unix(), 10)
+		payload["timestamp"] = timestamp
+		payload["sign"] = signFeishuWebhook(timestamp, secret)
+	}
+	return payload
+}
+
+// sendFeishuPayload is the shared low-level sender: marshal → POST → interpret
+// the Feishu response. Reused by the ops alert path and the account-incident
+// path so the HTTP / error-sanitization logic lives in exactly one place.
+func sendFeishuPayload(ctx context.Context, client opsFeishuHTTPDoer, cfg OpsFeishuAlertConfig, payload map[string]any) error {
+	if client == nil {
+		client = &http.Client{Timeout: opsFeishuWebhookTimeout}
 	}
 	body, err := json.Marshal(payload)
 	if err != nil {
@@ -87,33 +129,11 @@ func (n *opsFeishuNotifier) buildPayload(cfg OpsFeishuAlertConfig, rule *OpsAler
 		return nil, errors.New("missing alert context")
 	}
 	text := buildOpsFeishuAlertText(rule, event)
-	payload := map[string]any{
-		"msg_type": "interactive",
-		"card": map[string]any{
-			"header": map[string]any{
-				"template": "red",
-				"title": map[string]any{
-					"tag":     "plain_text",
-					"content": "TokenKey P0 告警",
-				},
-			},
-			"elements": []map[string]any{
-				{
-					"tag": "div",
-					"text": map[string]any{
-						"tag":     "lark_md",
-						"content": text,
-					},
-				},
-			},
-		},
+	now := time.Now
+	if n != nil && n.now != nil {
+		now = n.currentTime
 	}
-	if secret := strings.TrimSpace(cfg.SigningSecret); secret != "" {
-		timestamp := strconv.FormatInt(n.currentTime().Unix(), 10)
-		payload["timestamp"] = timestamp
-		payload["sign"] = signFeishuWebhook(timestamp, secret)
-	}
-	return payload, nil
+	return feishuCardPayload(cfg, now, "red", "TokenKey P0 告警", text), nil
 }
 
 func (n *opsFeishuNotifier) currentTime() time.Time {

--- a/backend/internal/service/ops_settings.go
+++ b/backend/internal/service/ops_settings.go
@@ -15,6 +15,8 @@ const (
 	opsAlertEvaluatorLeaderLockTTLDefault = 30 * time.Second
 	opsFeishuAlertRateLimitPerHourDefault = 3
 	opsFeishuAlertCooldownSecondsDefault  = 3600
+	// 账号失效事件「临时冷却」聚合摘要的默认 flush 间隔（秒）。
+	opsFeishuAccountIncidentDigestSecondsDefault = 600
 )
 
 // =========================
@@ -208,9 +210,10 @@ func validateOpsEmailNotificationConfig(cfg *OpsEmailNotificationConfig) error {
 
 func defaultOpsFeishuAlertConfig() OpsFeishuAlertConfig {
 	return OpsFeishuAlertConfig{
-		Enabled:          false,
-		RateLimitPerHour: opsFeishuAlertRateLimitPerHourDefault,
-		CooldownSeconds:  opsFeishuAlertCooldownSecondsDefault,
+		Enabled:                      false,
+		RateLimitPerHour:             opsFeishuAlertRateLimitPerHourDefault,
+		CooldownSeconds:              opsFeishuAlertCooldownSecondsDefault,
+		AccountIncidentDigestSeconds: opsFeishuAccountIncidentDigestSecondsDefault,
 	}
 }
 
@@ -227,6 +230,7 @@ func updateOpsFeishuAlertConfig(dst *OpsFeishuAlertConfig, req *OpsFeishuAlertCo
 	}
 	dst.RateLimitPerHour = req.RateLimitPerHour
 	dst.CooldownSeconds = req.CooldownSeconds
+	dst.AccountIncidentDigestSeconds = req.AccountIncidentDigestSeconds
 }
 
 func normalizeOpsFeishuAlertConfig(cfg *OpsFeishuAlertConfig) {
@@ -243,6 +247,9 @@ func normalizeOpsFeishuAlertConfig(cfg *OpsFeishuAlertConfig) {
 	if cfg.CooldownSeconds == 0 {
 		cfg.CooldownSeconds = opsFeishuAlertCooldownSecondsDefault
 	}
+	if cfg.AccountIncidentDigestSeconds == 0 {
+		cfg.AccountIncidentDigestSeconds = opsFeishuAccountIncidentDigestSecondsDefault
+	}
 }
 
 func validateOpsFeishuAlertConfig(cfg OpsFeishuAlertConfig) error {
@@ -257,6 +264,9 @@ func validateOpsFeishuAlertConfig(cfg OpsFeishuAlertConfig) error {
 	}
 	if cfg.CooldownSeconds < 60 || cfg.CooldownSeconds > 86400 {
 		return errors.New("feishu.cooldown_seconds must be between 60 and 86400")
+	}
+	if cfg.AccountIncidentDigestSeconds < 30 || cfg.AccountIncidentDigestSeconds > 86400 {
+		return errors.New("feishu.account_incident_digest_seconds must be between 30 and 86400")
 	}
 	return nil
 }

--- a/backend/internal/service/ops_settings_models.go
+++ b/backend/internal/service/ops_settings_models.go
@@ -40,6 +40,9 @@ type OpsFeishuAlertConfig struct {
 	SigningSecretConfigured bool   `json:"signing_secret_configured"`
 	RateLimitPerHour        int    `json:"rate_limit_per_hour"`
 	CooldownSeconds         int    `json:"cooldown_seconds"`
+	// AccountIncidentDigestSeconds 控制账号失效事件中「临时冷却」类（429/529/temp）
+	// 聚合摘要的 flush 间隔（秒）。永久失效类即时单发，不受此值影响。默认 600。
+	AccountIncidentDigestSeconds int `json:"account_incident_digest_seconds"`
 }
 
 // OpsEmailNotificationConfigUpdateRequest allows partial updates, while the

--- a/backend/internal/service/ratelimit_service.go
+++ b/backend/internal/service/ratelimit_service.go
@@ -34,8 +34,11 @@ type RateLimitService struct {
 	settingService              *SettingService
 	tokenCacheInvalidator       TokenCacheInvalidator
 	runtimeBlocker              AccountRuntimeBlocker
-	usageCacheMu                sync.RWMutex
-	usageCache                  map[int64]*geminiUsageCacheEntry
+	// TK: 账号失效事件 → 飞书即时告警。挂钩在 notifyAccountSchedulingBlocked,
+	// 实现在 account_incident_notifier_tk.go / ratelimit_service_tk_incident.go。
+	incidentNotifier AccountIncidentNotifier
+	usageCacheMu     sync.RWMutex
+	usageCache       map[int64]*geminiUsageCacheEntry
 }
 
 type AccountRuntimeBlocker interface {
@@ -223,6 +226,8 @@ func (s *RateLimitService) notifyAccountSchedulingBlocked(account *Account, unti
 		return
 	}
 	s.runtimeBlocker.BlockAccountScheduling(account, until, reason)
+	// TK: 同一汇聚点上报账号失效事件给飞书（kind 由 reason 在 classifyIncident 内精确派生）。
+	s.notifyAccountIncident(account, until, reason, IncidentKindUnknown)
 }
 
 func (s *RateLimitService) notifyAccountSchedulingBlockCleared(accountID int64) {

--- a/backend/internal/service/ratelimit_service_tk_incident.go
+++ b/backend/internal/service/ratelimit_service_tk_incident.go
@@ -1,0 +1,24 @@
+package service
+
+import "time"
+
+// TK: 账号失效事件 → 飞书告警的挂钩 glue。核心实现在 account_incident_notifier_tk.go。
+//
+// notifyAccountSchedulingBlocked（ratelimit_service.go）是所有账号失效/冷却的唯一汇聚点;
+// 在其内部并排调用 notifyAccountIncident 上报。kind 传 Unknown,由 classifyIncident 依据
+// reason 字符串精确派生（auth_error/custom/stream_timeout_error → 永久,其余 → 临时聚合）。
+
+// SetAccountIncidentNotifier 注入账号失效通知器（由 wire sentinel provider 在构造后回填）。
+func (s *RateLimitService) SetAccountIncidentNotifier(n AccountIncidentNotifier) {
+	if s == nil {
+		return
+	}
+	s.incidentNotifier = n
+}
+
+func (s *RateLimitService) notifyAccountIncident(account *Account, until time.Time, reason string, kind AccountIncidentKind) {
+	if s == nil || s.incidentNotifier == nil || account == nil {
+		return
+	}
+	s.incidentNotifier.NotifyAccountIncident(account, until, reason, kind)
+}

--- a/backend/internal/service/wire.go
+++ b/backend/internal/service/wire.go
@@ -633,6 +633,11 @@ var ProviderSet = wire.NewSet(
 	// Same shape as ProvideTKGatewayPricingAvailability; consumed by
 	// provideCleanup in cmd/server/wire.go so wire forces evaluation.
 	ProvideTKGatewayAnthropicSigPreempt,
+	// TokenKey: account-incident → Feishu notifier. Builds the notifier, starts
+	// its digest ticker, and wires it onto RateLimitService post-construction.
+	// Returns the instance so provideCleanup (cmd/server/wire.go) can Stop() the
+	// ticker at shutdown — same lifecycle shape as ChannelMonitorRunner.
+	ProvideTKAccountIncidentNotifier,
 )
 
 // TKAuthServiceColdStartReady is a wire sentinel: holding it proves that
@@ -759,4 +764,37 @@ func ProvideTKGatewayAnthropicSigPreempt(
 		gw.SetAnthropicSigPreemptCache(cache)
 	}
 	return TKGatewayAnthropicSigPreemptReady{}
+}
+
+// ProvideTKAccountIncidentNotifier builds the account-incident Feishu notifier,
+// starts its background digest ticker, and wires it onto RateLimitService
+// post-construction. It returns the concrete instance (not a sentinel) so
+// provideCleanup can Stop() the ticker at shutdown — mirroring the
+// ChannelMonitorRunner lifecycle shape rather than the setter-only sentinel
+// pattern.
+//
+// Node identity (prod / edge-<id>) is derived from server.frontend_url so no new
+// env / deploy-template change is needed. Setter is nil-safe; if rl is nil the
+// notifier is still returned (and Stopped) without being attached.
+func ProvideTKAccountIncidentNotifier(
+	rl *RateLimitService,
+	ops *OpsService,
+	cfg *config.Config,
+) *TKAccountIncidentNotifier {
+	site := "unknown"
+	if cfg != nil {
+		site = siteFromFrontendURL(cfg.Server.FrontendURL)
+	}
+	// Pass a nil interface (not a typed-nil *OpsService) when ops is absent so the
+	// notifier's `cfgProvider != nil` guards short-circuit cleanly.
+	var provider opsFeishuConfigProvider
+	if ops != nil {
+		provider = ops
+	}
+	n := newTKAccountIncidentNotifier(provider, site)
+	n.Start()
+	if rl != nil {
+		rl.SetAccountIncidentNotifier(n)
+	}
+	return n
 }

--- a/ops/observability/probe-alert-config.sh
+++ b/ops/observability/probe-alert-config.sh
@@ -40,7 +40,7 @@ SELECT severity, enabled, count(*)
 FROM ops_alert_rules
 GROUP BY severity, enabled
 ORDER BY severity, enabled;
-" 2>/dev/null || true
+" 2>/dev/null || echo "(ops_alert_rules aggregation skipped)"
 
 echo "=== recent_alert_events_14d (severity,status,count) ==="
 psql -F $'\t' -c "

--- a/ops/observability/probe-alert-config.sh
+++ b/ops/observability/probe-alert-config.sh
@@ -1,0 +1,52 @@
+#!/usr/bin/env bash
+# Read-only probe: dump ops feishu/email alert config + ops_alert_rules summary.
+# Sensitive fields (webhook_url, signing_secret) are reduced to *_present booleans.
+# Container/db names follow the Stage0 convention; falls back to docker ps if absent.
+set -euo pipefail
+
+PG="${PG_CONTAINER:-tokenkey-postgres}"
+DB="${PG_DB:-tokenkey}"
+DBUSER="${PG_USER:-tokenkey}"
+
+psql() { docker exec -i "$PG" psql -U "$DBUSER" -d "$DB" -X -A -t "$@"; }
+
+echo "=== feishu_email_config (sanitized) ==="
+psql -c "
+WITH s AS (
+  SELECT value::jsonb AS v FROM settings WHERE key = 'ops_email_notification_config'
+)
+SELECT COALESCE(json_build_object(
+  'row_present', (SELECT count(*) FROM s) > 0,
+  'feishu_enabled',            (SELECT (v->'feishu'->>'enabled')::boolean FROM s),
+  'feishu_webhook_present',    (SELECT length(coalesce(v->'feishu'->>'webhook_url','')) > 0 FROM s),
+  'feishu_secret_present',     (SELECT length(coalesce(v->'feishu'->>'signing_secret','')) > 0 FROM s),
+  'feishu_rate_limit_per_hour',(SELECT v->'feishu'->>'rate_limit_per_hour' FROM s),
+  'feishu_cooldown_seconds',   (SELECT v->'feishu'->>'cooldown_seconds' FROM s),
+  'alert_email_enabled',       (SELECT (v->'alert'->>'enabled')::boolean FROM s),
+  'report_email_enabled',      (SELECT (v->'report'->>'enabled')::boolean FROM s)
+)::text, '{\"row_present\":false}');
+"
+
+echo "=== alert_rules (id,name,metric,op,threshold,severity,enabled,notify_email) ==="
+psql -F $'\t' -c "
+SELECT id, name, metric_type, operator, threshold, severity, enabled, notify_email
+FROM ops_alert_rules
+ORDER BY id;
+" 2>/dev/null || echo "(ops_alert_rules table missing or schema differs)"
+
+echo "=== alert_rules_count_by_severity ==="
+psql -F $'\t' -c "
+SELECT severity, enabled, count(*)
+FROM ops_alert_rules
+GROUP BY severity, enabled
+ORDER BY severity, enabled;
+" 2>/dev/null || true
+
+echo "=== recent_alert_events_14d (severity,status,count) ==="
+psql -F $'\t' -c "
+SELECT severity, status, count(*)
+FROM ops_alert_events
+WHERE created_at >= now() - interval '14 days'
+GROUP BY severity, status
+ORDER BY severity, status;
+" 2>/dev/null || echo "(ops_alert_events table missing or schema differs)"

--- a/scripts/sentinels/gateway-tk.json
+++ b/scripts/sentinels/gateway-tk.json
@@ -1566,6 +1566,29 @@
         "if found && account.SessionWindowStart != nil {"
       ],
       "rationale": "Passive 5h-window staleness guard in estimateSetupTokenUsage: session_window_utilization is a passive sample from the last upstream response; if it was sampled BEFORE the current SessionWindowStart (window rolled but not yet re-sampled — the writer's clear-on-roll only fires on expiry-driven init, not header-driven window changes), it belongs to a prior window and would show a misleading high % on a fresh window (observed live: a just-rolled 5h window showing 99%). The guard drops such samples and falls back to status-based estimation. Load-bearing for BOTH the per-edge /admin/accounts page and the cross-edge Edge Accounts overview (both read GetPassiveUsage→estimateSetupTokenUsage); an upstream merge that removes the guard or parseExtraSampledAt silently reintroduces the stale-99% display."
+    },
+    {
+      "path": "backend/internal/service/ratelimit_service.go",
+      "must_contain": [
+        "s.notifyAccountIncident(account, until, reason, IncidentKindUnknown)"
+      ],
+      "rationale": "账号失效 → 飞书告警的唯一挂钩点。notifyAccountSchedulingBlocked 是所有 13 个账号失效/冷却场景（auth_error / oauth_401 / 429 / 529 / 403temp / temp / custom / stream_timeout）的汇聚点；这一行把失效事件上报给 AccountIncidentNotifier（永久失效即时 P0 红头卡片、临时冷却聚合低频橙头摘要）。上游合并若重写 notifyAccountSchedulingBlocked 并丢掉此行，会让账号失效告警静默失效——运营再也收不到『某账号该重新 OAuth / 查 bug』，且无编译错误、极难发现。本 sentinel 捕获该 revert。"
+    },
+    {
+      "path": "backend/internal/service/account_incident_notifier_tk.go",
+      "must_contain": [
+        "func (n *TKAccountIncidentNotifier) NotifyAccountIncident(",
+        "func classifyIncident("
+      ],
+      "rationale": "账号失效 → 飞书告警的核心实现（TK-only，无上游对应）。NotifyAccountIncident 按 classifyIncident 的派生形态分流：永久失效（status=error 终态）即时单条 P0；临时冷却（429/529/...自愈）写聚合 buffer 由后台 ticker flush 成低频摘要，保住信噪比不刷屏。classifyIncident 把底层 reason 字符串映射成 (形态, 去重类, 中文文案, 运营建议)。整文件易在大重构/上游合并中被整体误删——删掉等于告警链路断裂。"
+    },
+    {
+      "path": "backend/internal/service/ratelimit_service_tk_incident.go",
+      "must_contain": [
+        "func (s *RateLimitService) SetAccountIncidentNotifier(",
+        "func (s *RateLimitService) notifyAccountIncident("
+      ],
+      "rationale": "把 AccountIncidentNotifier 注入 RateLimitService 的 glue：wire ProvideTKAccountIncidentNotifier 在构造后调 SetAccountIncidentNotifier 回填，挂钩点（ratelimit_service.go）经 notifyAccountIncident 转发。删掉会让挂钩行编译失败或静默 no-op，账号失效告警链路断裂。"
     }
   ]
 }


### PR DESCRIPTION
## 背景

只读核查发现：6 个 deployable edge 的飞书告警**全部 `enabled=false`、webhook 未配**，告警只走邮件；规则仍是 8 条原始系统/流量种子规则，没人改过。运营最关心的「单账号健康/稳定」——某账号 401(OAuth 失效要重授权)/429/400/529——**现有规则引擎做不到**：account 维度指标全是匿名计数、`ops_alert_events` 无 account_id、飞书模板不含账号字段，运营拿到告警也不知道该 re-oauth 哪个账号。

## 做了什么

当某上游账号因错误失效/被罚下时，向飞书群推一条卡片，精确定位「节点(prod/edge-us1) + 账号 + 平台 + 组 + reason + 建议动作」。

**分级两形态（信噪比第一）：**
- **永久失效**（status=error 终态，需人工 re-oauth/查 bug）→ **即时单条 P0 红头卡片**
- **临时冷却**（429/529/oauth_401临时/403temp/temp，自愈）→ 后台**聚合成低频橙头摘要**（默认每 600s 一条，可配 `feishu.account_incident_digest_seconds`），绝不逐条刷屏淹没真故障

## 实现要点

- **唯一挂钩点** `RateLimitService.notifyAccountSchedulingBlocked`（13 个失效场景的汇聚点），kind 由 reason 在 `classifyIncident` 内精确派生，仅加一行上报 → 最小侵入 upstream 大文件
- **节点身份从 `server.frontend_url` 域名提取**（`api-us1.tokenkey.dev`→`edge-us1`），零 deploy 改动、当天生效、无「存量不生效」尾巴
- **异步发送**（独立 5s ctx + panic recover），绝不阻塞请求路径；单副本 Stage0 无 leader，挂钩点直接发不跨节点重复
- 复用飞书配置/签名，抽出 `feishuCardPayload` + `sendFeishuPayload` 供告警/账号事件两路共用（告警路径行为零变化）
- wire sentinel 注入 + cleanup `Stop()` 停聚合 ticker
- 3 条 gateway-tk sentinel 守护挂钩行/核心文件，防上游合并静默误删告警链路
- 附只读 probe `ops/observability/probe-alert-config.sh`（脱敏查各节点告警配置）

## 验证

- `go build ./...` ✅ / 全包 `go test -tags=unit ./...` ✅ / `golangci-lint run` 0 issues ✅ / `go vet` ✅
- `go generate ./cmd/server` wire_gen 已重生成并提交 ✅
- `scripts/preflight.sh`（含全部 sub2api sentinel 检查）**PASS** ✅
- 新单测覆盖：reason 分类 / 永久即时发 vs 临时进 buffer / ticker flush 聚合 / 空窗口不发 / disabled 不发 / **异步不阻塞(<50ms)** / panic recovery / 域名提取 / 卡片内容

## 上线后续（合并后单独执行）

1. 发版 rollout prod + 6 edge
2. 逐节点（各独立 DB）写 `feishu.enabled+webhook+secret` 才真正生效（运营层，单独授权）

## 合并方式

TK feature PR → 请用 GitHub **Squash and merge**（CLAUDE.md §5.y）。

🤖 Generated with [Claude Code](https://claude.com/claude-code)