### PR TITLE
fix(gateway): anthropic upstream-audit remediation (#656 count_tokens + #2859 sticky escape + #2754 haiku comment)

### DIFF
--- a/.cache/upstream/fixes.json
+++ b/.cache/upstream/fixes.json
@@ -518,6 +518,63 @@
         "backend/internal/service/gateway_service_tk_canonical_oauth_guard.go"
       ],
       "summary": "Already mitigated by the full mimicry stack (fingerprint alignment + billing attribution block + system rewrite + canonical UA guard + sticky routing). No single patch — maintained via the cc-fingerprint-alignment skill. NOTE: subscription-ban risk is existential; verify online (no third-party 400s) per 'config convergence != online stability'."
+    },
+    {
+      "upstream": "Wei-Shaw/sub2api#225",
+      "tokenkey_pr": "youxuanxue/sub2api (branch: fix/upstream-issue-remediation)",
+      "status": "fixed_in_tokenkey",
+      "fixed_by": [
+        "backend/internal/service/gateway_service.go"
+      ],
+      "summary": "thinking 块上挂 cache_control（Extra inputs are not permitted 400）：collectCacheControlPaths 判定 type==thinking 的 cache_control 归入 invalidThinking，enforceCacheControlLimit 在计数前无条件删除（覆盖 system + messages）。同根 #2013。"
+    },
+    {
+      "upstream": "Wei-Shaw/sub2api#599",
+      "tokenkey_pr": "youxuanxue/sub2api (branch: fix/upstream-issue-remediation)",
+      "status": "fixed_in_tokenkey",
+      "fixed_by": [
+        "backend/internal/service/gateway_request.go"
+      ],
+      "summary": "FilterThinkingBlocksForRetry 在禁用顶层 thinking 时删除 thinking 字段并把 thinking 块降级为 text；当前 schema 的 thinking_strategy 对应 context_management.edits 的 clear_thinking_20251015，由 removeThinkingDependentContextStrategies 一并清理（见 #851）。有专项单测护栏。"
+    },
+    {
+      "upstream": "Wei-Shaw/sub2api#851",
+      "tokenkey_pr": "youxuanxue/sub2api (branch: fix/upstream-issue-remediation)",
+      "status": "fixed_in_tokenkey",
+      "fixed_by": [
+        "backend/internal/service/gateway_request.go"
+      ],
+      "summary": "removeThinkingDependentContextStrategies 从 context_management.edits 移除 clear_thinking_20251015（edits 清空时删整键），在 FilterThinkingBlocksForRetry fast-path/完整路径及 FilterSignatureSensitiveBlocksForRetry 三处调用；另有 sanitizeAnthropicBodyForBetaTokens 按 anthropic-beta 是否含 context-management-2025-06-27 决定 strip。TestFilterThinkingBlocksForRetry_RemovesClearThinkingStrategy 等护栏。"
+    },
+    {
+      "upstream": "Wei-Shaw/sub2api#656",
+      "tokenkey_pr": "youxuanxue/sub2api (branch: worktree-anthropic-upstream-audit)",
+      "status": "fixed_in_tokenkey",
+      "fixed_by": [
+        "backend/internal/service/gateway_service.go",
+        "backend/internal/service/gateway_beta_test.go"
+      ],
+      "summary": "isCountTokensUnsupported404 放宽：除标准 404 外，对中转站把 NoResourceFoundException/No static resource 包装进 HTTP 400/500 的非标准返回也识别为端点不支持（收窄到同时提及 count_tokens + Spring 强信号，刻意不认裸 'not found'，保留 invalid_request_error/#2109 temperature 不被误吞，含 raw-body 兜底）；并在主路径 ForwardCountTokens 的 >=400 分支熔断/failover 之前接入，返回 404 让 Claude Code fallback 本地估算。新增 4 个单测用例。"
+    },
+    {
+      "upstream": "Wei-Shaw/sub2api#2754",
+      "tokenkey_pr": "youxuanxue/sub2api (branch: worktree-anthropic-upstream-audit)",
+      "status": "fixed_in_tokenkey",
+      "fixed_by": [
+        "backend/internal/service/gateway_service.go",
+        "backend/internal/pkg/claude/constants.go"
+      ],
+      "summary": "设计性差异非缺陷：Haiku OAuth mimic 刻意用独立 beta 集 FullClaudeCodeHaikuMimicryBetas（cc 2.1.160 structured-outputs 抓包，OMITS claude-code beta + advanced-tool-use，加 structured-outputs），运行时可经 claude_code_http_mimicry_manifest 热改。修正 gateway_service.go 误导注释（原称 Haiku 'includes claude-code beta'/'cc 2.1.152' 与实际 token 集矛盾）。无行为变更；如未来抓包确认 Haiku 真带 claude-code beta，改常量或下发 manifest。"
+    },
+    {
+      "upstream": "Wei-Shaw/sub2api#392",
+      "tokenkey_pr": "youxuanxue/sub2api (branch: fix/upstream-issue-remediation)",
+      "status": "fixed_in_tokenkey",
+      "fixed_by": [
+        "backend/internal/service/gateway_service.go",
+        "backend/internal/service/gateway_service_tk_canonical_oauth_guard.go"
+      ],
+      "summary": "'authorized for use with Claude Code' 是 OAuth 凭证 scope 错误，TLS 指纹对齐是必要非充分条件。已有识别 isClaudeCodeCredentialScopeError + ingress canonical OAuth guard（拒第三方 SDK UA / 重映射退役 opus）+ 完整 mimicry 栈（同 #1574/#1525/#1715）压制。线上复发用 cc-fingerprint-alignment skill 抓包核对 beta/UA/system 三层。"
     }
   ]
 }

--- a/.cache/upstream/triage.json
+++ b/.cache/upstream/triage.json
@@ -4,8 +4,8 @@
   "generated_from": "GitHub REST API issues?state=open; pull requests excluded",
   "rationale": "TokenKey-local triage cache for upstream open issues. Use this file before re-triaging upstream issues; update entries when TokenKey fixes, dismisses, or reclassifies an issue.",
   "counts": {
-    "needs_review": 388,
-    "fixed": 35,
+    "needs_review": 382,
+    "fixed": 41,
     "needs_prod_validation": 2,
     "medium": 121,
     "not_applicable": 1,
@@ -2475,13 +2475,13 @@
       "upstream": "Wei-Shaw/sub2api#225",
       "url": "https://github.com/Wei-Shaw/sub2api/issues/225",
       "title": "nvalid_request_error messages.13.content.0.thinking.cache_control: Extra inputs are not permitted",
-      "impact": "needs_review",
+      "impact": "fixed",
       "categories": [
         "claude_mimicry"
       ],
-      "tokenkey_status": "candidate_unverified",
-      "rationale": "Keyword match for production-sensitive area; not yet manually verified against TokenKey code.",
-      "updated_at": "2026-01-10T02:34:10Z"
+      "tokenkey_status": "fixed_in_tokenkey",
+      "rationale": "Verified against TokenKey code in anthropic-upstream-audit pass (2026-06-03); see .cache/upstream/fixes.json for fix locations.",
+      "updated_at": "2026-06-03T00:00:00Z"
     },
     {
       "upstream": "Wei-Shaw/sub2api#2250",
@@ -3381,15 +3381,15 @@
       "upstream": "Wei-Shaw/sub2api#2754",
       "url": "https://github.com/Wei-Shaw/sub2api/issues/2754",
       "title": "Haiku OAuth mimic mode should use full Claude Code beta headers",
-      "impact": "needs_review",
+      "impact": "fixed",
       "categories": [
         "claude_mimicry",
         "billing_usage",
         "image_oauth"
       ],
-      "tokenkey_status": "candidate_unverified",
-      "rationale": "Keyword match for production-sensitive area; not yet manually verified against TokenKey code.",
-      "updated_at": "2026-05-25T06:23:09Z"
+      "tokenkey_status": "fixed_in_tokenkey",
+      "rationale": "Verified against TokenKey code in anthropic-upstream-audit pass (2026-06-03); see .cache/upstream/fixes.json for fix locations.",
+      "updated_at": "2026-06-03T00:00:00Z"
     },
     {
       "upstream": "Wei-Shaw/sub2api#2759",
@@ -4016,15 +4016,15 @@
       "upstream": "Wei-Shaw/sub2api#392",
       "url": "https://github.com/Wei-Shaw/sub2api/issues/392",
       "title": "Claude Code 账号登录 即使开启 TLS 指纹模拟仍报错 \"authorized for use with Claude Code\"",
-      "impact": "needs_review",
+      "impact": "fixed",
       "categories": [
         "claude_mimicry",
         "image_oauth",
         "security"
       ],
-      "tokenkey_status": "candidate_unverified",
-      "rationale": "Keyword match for production-sensitive area; not yet manually verified against TokenKey code.",
-      "updated_at": "2026-03-06T10:05:03Z"
+      "tokenkey_status": "fixed_in_tokenkey",
+      "rationale": "Verified against TokenKey code in anthropic-upstream-audit pass (2026-06-03); see .cache/upstream/fixes.json for fix locations.",
+      "updated_at": "2026-06-03T00:00:00Z"
     },
     {
       "upstream": "Wei-Shaw/sub2api#396",
@@ -4262,14 +4262,14 @@
       "upstream": "Wei-Shaw/sub2api#599",
       "url": "https://github.com/Wei-Shaw/sub2api/issues/599",
       "title": "[BUG] FilterThinkingBlocksForRetry 未移除 thinking_strategy 字段导致重试仍然 400",
-      "impact": "needs_review",
+      "impact": "fixed",
       "categories": [
         "claude_mimicry",
         "rate_limit_cooldown"
       ],
-      "tokenkey_status": "candidate_unverified",
-      "rationale": "Keyword match for production-sensitive area; not yet manually verified against TokenKey code.",
-      "updated_at": "2026-02-25T06:32:27Z"
+      "tokenkey_status": "fixed_in_tokenkey",
+      "rationale": "Verified against TokenKey code in anthropic-upstream-audit pass (2026-06-03); see .cache/upstream/fixes.json for fix locations.",
+      "updated_at": "2026-06-03T00:00:00Z"
     },
     {
       "upstream": "Wei-Shaw/sub2api#614",
@@ -4342,14 +4342,14 @@
       "upstream": "Wei-Shaw/sub2api#656",
       "url": "https://github.com/Wei-Shaw/sub2api/issues/656",
       "title": "Anthropic 兼容上游在 count_tokens 路径非标准返回时，Claude Code 会失败",
-      "impact": "needs_review",
+      "impact": "fixed",
       "categories": [
         "claude_mimicry",
         "security"
       ],
-      "tokenkey_status": "candidate_unverified",
-      "rationale": "Keyword match for production-sensitive area; not yet manually verified against TokenKey code.",
-      "updated_at": "2026-02-26T13:14:12Z"
+      "tokenkey_status": "fixed_in_tokenkey",
+      "rationale": "Verified against TokenKey code in anthropic-upstream-audit pass (2026-06-03); see .cache/upstream/fixes.json for fix locations.",
+      "updated_at": "2026-06-03T00:00:00Z"
     },
     {
       "upstream": "Wei-Shaw/sub2api#671",
@@ -4593,15 +4593,15 @@
       "upstream": "Wei-Shaw/sub2api#851",
       "url": "https://github.com/Wei-Shaw/sub2api/issues/851",
       "title": "[Bug] 重试过滤 thinking block 时未同步移除 context_management 的 clear_thinking 策略，导致 400 错误",
-      "impact": "needs_review",
+      "impact": "fixed",
       "categories": [
         "claude_mimicry",
         "rate_limit_cooldown",
         "security"
       ],
-      "tokenkey_status": "candidate_unverified",
-      "rationale": "Keyword match for production-sensitive area; not yet manually verified against TokenKey code.",
-      "updated_at": "2026-03-08T13:16:41Z"
+      "tokenkey_status": "fixed_in_tokenkey",
+      "rationale": "Verified against TokenKey code in anthropic-upstream-audit pass (2026-06-03); see .cache/upstream/fixes.json for fix locations.",
+      "updated_at": "2026-06-03T00:00:00Z"
     },
     {
       "upstream": "Wei-Shaw/sub2api#857",

--- a/backend/internal/service/domain_constants.go
+++ b/backend/internal/service/domain_constants.go
@@ -462,6 +462,10 @@ const (
 	// 当为 false 时所有分组一律退化为 passthrough（仅透传客户端已送的 sticky 字段，不派生）。
 	// 详见 docs/approved/sticky-routing.md §3.2。
 	SettingKeyStickyRoutingEnabled = "gateway.sticky_routing.enabled"
+	// SettingKeyStickySlotFullEscapeEnabled 控制 sticky 绑定账号并发槽满时是否先试
+	// 全池再排队（upstream #2859，默认 true）。为 false 时退回今日行为：槽满即在
+	// 原 sticky 账号上排队。详见 docs/approved/sticky-routing.md §11.5。
+	SettingKeyStickySlotFullEscapeEnabled = "gateway.sticky_routing.slot_full_escape_enabled"
 	// SettingKeyEnableAnthropicCacheTTL1hInjection 是否对 Anthropic OAuth/SetupToken 请求体注入 1h cache_control ttl（默认 false）
 	SettingKeyEnableAnthropicCacheTTL1hInjection = "enable_anthropic_cache_ttl_1h_injection"
 	// SettingKeyRewriteMessageCacheControl 是否改写 messages[*].content[*].cache_control（默认 false）

--- a/backend/internal/service/gateway_beta_test.go
+++ b/backend/internal/service/gateway_beta_test.go
@@ -240,10 +240,44 @@ func TestIsCountTokensUnsupported404(t *testing.T) {
 			want:       false,
 		},
 		{
-			name:       "non-404 status",
+			// TK(#656) 守卫：400 + invalid_request_error 即使 message 含 "Not found" +
+			// count_tokens 路径，也必须返回 false——这是客户端 body schema 错误（如
+			// #2109 的 temperature 字段错误），不能误吞成 "端点不支持" 而短路 404。
+			name:       "non-404 invalid_request not swallowed",
 			statusCode: 400,
 			body:       `{"error":{"message":"Not found: /v1/messages/count_tokens","type":"invalid_request_error"}}`,
 			want:       false,
+		},
+		{
+			// TK(#656)：国产中转站把 Spring NoResourceFoundException（HTTP 400）当作
+			// count_tokens 不支持返回，应识别为端点不支持。
+			name:       "400 wraps spring NoResourceFoundException",
+			statusCode: 400,
+			body:       `{"error":{"message":"404 NOT_FOUND \"NoResourceFoundException: No static resource v1/messages/count_tokens.\""}}`,
+			want:       true,
+		},
+		{
+			// TK(#656)：包装进 HTTP 500 的同类资源不存在错误也应识别。
+			name:       "500 wraps no static resource",
+			statusCode: 500,
+			body:       `{"message":"No static resource v1/messages/count_tokens."}`,
+			want:       true,
+		},
+		{
+			// TK(#656) 守卫：500 资源不存在但不涉及 count_tokens 端点（如错误 base_url
+			// 的其他路径），不能误吞。
+			name:       "500 no static resource other path not swallowed",
+			statusCode: 500,
+			body:       `{"message":"No static resource v1/foo/bar."}`,
+			want:       false,
+		},
+		{
+			// TK(#656)：非 JSON 的原始 Spring 错误串（extractUpstreamErrorMessage 取不到
+			// 结构化 message）也应通过 raw-body 兜底识别。
+			name:       "non-json raw spring error body",
+			statusCode: 400,
+			body:       `No static resource v1/messages/count_tokens.`,
+			want:       true,
 		},
 	}
 

--- a/backend/internal/service/gateway_count_tokens_breaker_test.go
+++ b/backend/internal/service/gateway_count_tokens_breaker_test.go
@@ -84,6 +84,64 @@ func TestGatewayService_ForwardCountTokens_400DoesNotTripUpstreamErrorBreaker(t 
 	require.Equal(t, 0, repo.tempCalls, "count_tokens 400 must not mark account temp_unschedulable")
 }
 
+// TestGatewayService_ForwardCountTokens_Wrapped404ReturnsNotFound 验证 #656 主路径短路：
+// 中转站不支持 count_tokens 端点、把 Spring NoResourceFoundException 包装进非标准的
+// HTTP 400 返回时，ForwardCountTokens 应在熔断/failover **之前**短路，返回 HTTP 404
+// （not_found_error）让 Claude Code 回退到本地 token 估算，且既不熔断也不罚下账号。
+// 这条覆盖的是 #656 的主路径接线（谓词本身由 TestIsCountTokensUnsupported404 覆盖）。
+func TestGatewayService_ForwardCountTokens_Wrapped404ReturnsNotFound(t *testing.T) {
+	gin.SetMode(gin.TestMode)
+
+	rec := httptest.NewRecorder()
+	c, _ := gin.CreateTestContext(rec)
+	c.Request = httptest.NewRequest(http.MethodPost, "/v1/messages/count_tokens", nil)
+
+	body := []byte(`{"model":"claude-opus-4-7","messages":[{"role":"user","content":"hi"}]}`)
+	parsed := &ParsedRequest{Body: NewRequestBodyRef(body), Model: "claude-opus-4-7"}
+
+	// 中转站把 Spring NoResourceFoundException / 404 NOT_FOUND 包装进 HTTP 400（非标准）。
+	upstreamRespBody := `{"error":{"message":"404 NOT_FOUND \"NoResourceFoundException: No static resource v1/messages/count_tokens.\""}}`
+	upstream := &anthropicHTTPUpstreamRecorder{
+		resp: &http.Response{
+			StatusCode: http.StatusBadRequest,
+			Header:     http.Header{"Content-Type": []string{"application/json"}},
+			Body:       io.NopCloser(strings.NewReader(upstreamRespBody)),
+		},
+	}
+
+	counter := &anthropicUpstreamErrorCounterCacheStub{counts: []int64{1, 2, 3}}
+	repo := &rateLimitAccountRepoStub{}
+	rateLimit := NewRateLimitService(repo, nil, &config.Config{}, nil, nil)
+	rateLimit.SetAnthropicUpstreamErrorCounterCache(counter)
+
+	svc := &GatewayService{
+		cfg:              &config.Config{Gateway: config.GatewayConfig{MaxLineSize: defaultMaxLineSize}},
+		httpUpstream:     upstream,
+		rateLimitService: rateLimit,
+	}
+
+	account := &Account{
+		ID:          502,
+		Name:        "ct-wrapped-404",
+		Platform:    PlatformAnthropic,
+		Type:        AccountTypeAPIKey,
+		Concurrency: 1,
+		Credentials: map[string]any{
+			"api_key":  "k",
+			"base_url": "https://relay.example.com",
+		},
+		Status:      StatusActive,
+		Schedulable: true,
+	}
+
+	err := svc.ForwardCountTokens(context.Background(), c, account, parsed)
+	require.NoError(t, err, "wrapped-404 应短路并返回 nil（已写 404 响应），不作为错误冒泡")
+	require.Equal(t, http.StatusNotFound, rec.Code, "应短路返回 HTTP 404 让客户端本地估算")
+	require.Contains(t, rec.Body.String(), "not_found_error")
+	require.Empty(t, counter.incrementIDs, "端点不支持不应熔断账号（短路在熔断之前）")
+	require.Equal(t, 0, repo.tempCalls, "端点不支持不应 temp_unschedulable 账号")
+}
+
 // TestGatewayService_ForwardCountTokens_CapacityErrorsFailoverNoBreaker
 // 契约更新（count_tokens failover 修复，见 gateway_handler_tk_count_tokens_failover.go）：
 // count_tokens 是请求前预检端点，其 429/529 容量类错误现在

--- a/backend/internal/service/gateway_service.go
+++ b/backend/internal/service/gateway_service.go
@@ -6734,8 +6734,15 @@ func (s *GatewayService) buildUpstreamRequest(ctx context.Context, c *gin.Contex
 			// Non-haiku models MUST include claude-code beta for Anthropic to recognize
 			// this as a legitimate Claude Code request; without it, the request is
 			// rejected as third-party ("out of extra usage").
-			// Haiku also sends the cc 2.1.152 capture mimicry set (includes claude-code
-			// beta); token set/order differs from Sonnet (no effort / advanced-tool-use).
+			//
+			// Haiku uses a DISTINCT beta set (FullClaudeCodeHaikuMimicryBetas), captured
+			// from cc 2.1.160 Haiku traffic where the server runs an A/B with
+			// structured-outputs as the majority state (see HaikuBetaHeader /
+			// docs/spec-delta-cc-2.1.160.md). That set deliberately OMITS claude-code beta
+			// and advanced-tool-use, and adds structured-outputs — it is NOT the Sonnet/Opus
+			// token set. Do not "fix" this to add claude-code beta without a fresh Haiku
+			// capture: the runtime claude_code_http_mimicry_manifest setting can override
+			// the list hot if a future cc Haiku build changes the cohort.
 			requiredBetas := claude.GetFullClaudeCodeHaikuMimicryBetasForContext(ctx)
 			if !strings.Contains(strings.ToLower(modelID), "haiku") {
 				requiredBetas = claude.GetFullClaudeCodeMimicryBetasForContext(ctx)
@@ -7617,17 +7624,45 @@ func extractUpstreamErrorCode(body []byte) string {
 }
 
 func isCountTokensUnsupported404(statusCode int, body []byte) bool {
-	if statusCode != http.StatusNotFound {
-		return false
-	}
 	msg := strings.ToLower(strings.TrimSpace(extractUpstreamErrorMessage(body)))
+	if msg == "" {
+		// 部分中转站返回非 JSON 的 Spring 错误串（extractUpstreamErrorMessage 取不到
+		// 结构化 message），回退到原始 body 扫描。仍受下方 count_tokens 端点特征收窄。
+		msg = strings.ToLower(string(body))
+	}
 	if msg == "" {
 		return false
 	}
-	if strings.Contains(msg, "/v1/messages/count_tokens") {
-		return true
+
+	switch statusCode {
+	case http.StatusNotFound:
+		// 标准 404（原行为）：count_tokens 端点路径出现，或 count_tokens + not found。
+		if strings.Contains(msg, "/v1/messages/count_tokens") {
+			return true
+		}
+		return strings.Contains(msg, "count_tokens") && strings.Contains(msg, "not found")
+	case http.StatusBadRequest, http.StatusInternalServerError:
+		// TK(#656): 部分国产 Anthropic 兼容中转站不支持 count_tokens 端点时，把
+		// "NoResourceFoundException / No static resource v1/messages/count_tokens"
+		// 语义包装进非标准的 HTTP 400/500 返回，而非标准 404。
+		//
+		// 收窄到「同时提及 count_tokens 端点 + Spring 风格的资源不存在强信号」：
+		//   - 必须命中 count_tokens（端点特征），避免误吞错误 base_url 的通用 404；
+		//   - 只认 NoResourceFoundException / no static resource / no resource found
+		//     这类强信号，**刻意不认裸 "not found"**——后者可能是上游对真正的
+		//     invalid_request_error 的描述性文案（见单测 "non-404 invalid_request"：
+		//     400 + invalid_request_error + "Not found: /v1/messages/count_tokens"
+		//     必须返回 false，不能误吞客户端 body schema 错误，如 #2109 的
+		//     temperature 字段错误）。
+		if !strings.Contains(msg, "count_tokens") {
+			return false
+		}
+		return strings.Contains(msg, "noresourcefoundexception") ||
+			strings.Contains(msg, "no static resource") ||
+			strings.Contains(msg, "no resource found")
+	default:
+		return false
 	}
-	return strings.Contains(msg, "count_tokens") && strings.Contains(msg, "not found")
 }
 
 func (s *GatewayService) readUpstreamErrorBody(resp *http.Response) ([]byte, error) {
@@ -9926,6 +9961,20 @@ func (s *GatewayService) ForwardCountTokens(ctx context.Context, c *gin.Context,
 
 	// 处理错误响应
 	if resp.StatusCode >= 400 {
+		// TK(#656): 部分国产 Anthropic 兼容中转站不支持 count_tokens 端点时，把
+		// 404/NoResourceFoundException 语义包装进非标准的 400/500 返回。优先在熔断与
+		// failover 之前短路：返回 404 让 Claude Code fallback 到本地 token 估算（与
+		// passthrough 路径一致），既不罚下账号（500-wrap 不计入熔断），也不浪费
+		// failover 名额（同组其他账号多半同一上游、同样不支持）。
+		if isCountTokensUnsupported404(resp.StatusCode, respBody) {
+			logger.LegacyPrintf("service.gateway",
+				"[count_tokens] Upstream does not support count_tokens (status=%d), returning 404: account=%d name=%s msg=%s",
+				resp.StatusCode, account.ID, account.Name,
+				truncateString(sanitizeUpstreamErrorMessage(extractUpstreamErrorMessage(respBody)), 512))
+			s.countTokensError(c, http.StatusNotFound, "not_found_error", "count_tokens endpoint is not supported by upstream")
+			return nil
+		}
+
 		// 标记账号状态。count_tokens 预检端点的 400/429/529 不计入熔断
 		// （tkCountTokensSkipBreaker，见 gateway_service_tk_count_tokens_failover.go）。
 		if !tkCountTokensSkipBreaker(resp.StatusCode) {

--- a/backend/internal/service/openai_account_scheduler.go
+++ b/backend/internal/service/openai_account_scheduler.go
@@ -306,16 +306,30 @@ func (s *defaultOpenAIAccountScheduler) Select(
 		}
 	}
 
-	selection, err := s.selectBySessionHash(ctx, req)
+	markStickyHit := func(sel *AccountSelectionResult) {
+		decision.Layer = openAIAccountScheduleLayerSessionSticky
+		decision.StickySessionHit = true
+		decision.SelectedAccountID = sel.Account.ID
+		decision.SelectedAccountType = sel.Account.Type
+	}
+
+	stickySel, err := s.selectBySessionHash(ctx, req)
 	if err != nil {
 		return nil, decision, err
 	}
-	if selection != nil && selection.Account != nil {
-		decision.Layer = openAIAccountScheduleLayerSessionSticky
-		decision.StickySessionHit = true
-		decision.SelectedAccountID = selection.Account.ID
-		decision.SelectedAccountType = selection.Account.Type
-		return selection, decision, nil
+	// sticky 真拿到并发槽 → 照旧返回（缓存最优 happy path，连开关都不读）。
+	if stickySel != nil && stickySel.Acquired {
+		markStickyHit(stickySel)
+		return stickySel, decision, nil
+	}
+
+	// sticky 没拿到槽：要么槽满只给了 WaitPlan，要么 sticky 未命中（nil）。
+	// upstream #2859：槽满逃逸开启时，先试全池；池里有空账号就去办，避免把用户
+	// 困在堵塞的 sticky 账号上排队。开关关闭时退回今日行为（在 sticky 上排队）。
+	stickyWaitPlan := stickySel != nil && stickySel.Account != nil
+	if stickyWaitPlan && !s.stickySlotFullEscapeEnabled(ctx) {
+		markStickyHit(stickySel)
+		return stickySel, decision, nil
 	}
 
 	selection, candidateCount, topK, loadSkew, err := s.selectByLoadBalance(ctx, req)
@@ -326,11 +340,33 @@ func (s *defaultOpenAIAccountScheduler) Select(
 	if err != nil {
 		return nil, decision, err
 	}
+	// 池里有空账号 → 逃逸到它（#2859 的修复点）。
+	if selection != nil && selection.Acquired && selection.Account != nil {
+		decision.SelectedAccountID = selection.Account.ID
+		decision.SelectedAccountType = selection.Account.Type
+		return selection, decision, nil
+	}
+	// 全池也满 → 回到 sticky 的 WaitPlan（缓存仍热，不比今天差）。
+	if stickyWaitPlan {
+		markStickyHit(stickySel)
+		return stickySel, decision, nil
+	}
+	// 既无可逃逸的空账号也无 sticky WaitPlan：返回 load-balance 自身结果
+	// （其 WaitPlan 或 nil），保持原行为。
 	if selection != nil && selection.Account != nil {
 		decision.SelectedAccountID = selection.Account.ID
 		decision.SelectedAccountType = selection.Account.Type
 	}
 	return selection, decision, nil
+}
+
+// stickySlotFullEscapeEnabled 报告是否启用 sticky 槽满逃逸（upstream #2859）。
+// fail-open 默认 true：未接 SettingService 的测试/装配按默认开。
+func (s *defaultOpenAIAccountScheduler) stickySlotFullEscapeEnabled(ctx context.Context) bool {
+	if s == nil || s.service == nil || s.service.settingService == nil {
+		return true
+	}
+	return s.service.settingService.IsStickySlotFullEscapeEnabled(ctx)
 }
 
 func (s *defaultOpenAIAccountScheduler) selectBySessionHash(

--- a/backend/internal/service/openai_account_scheduler_test.go
+++ b/backend/internal/service/openai_account_scheduler_test.go
@@ -1144,8 +1144,33 @@ func TestOpenAIGatewayService_SelectAccountWithScheduler_SessionSticky(t *testin
 	}
 }
 
+// slotEscapeSettingRepo 是只为 #2859 escape 开关服务的 settingRepo 桩：仅对
+// SettingKeyStickySlotFullEscapeEnabled 返回配置值，其余 key 返回空（取默认）。
+// 刻意定义在本无 build-tag 文件，使其在 no-tag(golangci) / unit / integration
+// 三种构建下都可见——SessionStickyBusyKeepsSticky（无 tag）与 US2859 用例
+// （//go:build unit，openai_account_scheduler_tk_slot_full_escape_test.go）共用。
+type slotEscapeSettingRepo struct {
+	SettingRepository
+	val string
+}
+
+func (r *slotEscapeSettingRepo) GetValue(_ context.Context, key string) (string, error) {
+	if key == SettingKeyStickySlotFullEscapeEnabled {
+		return r.val, nil
+	}
+	return "", nil
+}
+
+// 注意（upstream #2859）：本测试钉的是 sticky 槽满逃逸**关闭**（opt-out）时的契约
+// ——槽满即在原 sticky 账号排队、即使池里有空账号也不切换（缓存亲和优先）。
+// 这曾是默认行为；自 #2859 起默认改为「槽满先试全池」（见
+// docs/approved/sticky-routing.md §11.5），新默认行为由
+// openai_account_scheduler_tk_slot_full_escape_test.go 的 US2859 用例覆盖。
+// 因此此处显式把 escape 开关设为 false，保留对 opt-out 模式的回归保护。
 func TestOpenAIGatewayService_SelectAccountWithScheduler_SessionStickyBusyKeepsSticky(t *testing.T) {
 	ctx := context.Background()
+	stickySlotFullEscapeCache.Store(&stickySlotFullEscapeCacheEntry{expiresAt: 0})
+	t.Cleanup(func() { stickySlotFullEscapeCache.Store(&stickySlotFullEscapeCacheEntry{expiresAt: 0}) })
 	groupID := int64(10100)
 	accounts := []Account{
 		{
@@ -1200,6 +1225,8 @@ func TestOpenAIGatewayService_SelectAccountWithScheduler_SessionStickyBusyKeepsS
 		cfg:                cfg,
 		rateLimitService:   newOpenAIAdvancedSchedulerRateLimitService("true"),
 		concurrencyService: NewConcurrencyService(concurrencyCache),
+		// #2859: 显式关闭槽满逃逸以钉住 opt-out 模式（keep-sticky）契约。
+		settingService: &SettingService{settingRepo: &slotEscapeSettingRepo{val: "false"}},
 	}
 
 	selection, decision, err := svc.SelectAccountWithScheduler(

--- a/backend/internal/service/openai_account_scheduler_tk_slot_full_escape_test.go
+++ b/backend/internal/service/openai_account_scheduler_tk_slot_full_escape_test.go
@@ -1,0 +1,176 @@
+//go:build unit
+
+package service
+
+import (
+	"context"
+	"testing"
+
+	"github.com/Wei-Shaw/sub2api/internal/config"
+	"github.com/stretchr/testify/require"
+)
+
+// Tests for upstream Wei-Shaw/sub2api#2859 — sticky slot-full escape.
+// See docs/approved/sticky-routing.md §11.5.
+//
+// 行为表（与开关无关的 happy path + 三个分支）：
+//   - sticky 账号有空槽            → 用 sticky（不变）
+//   - sticky 满、池里有空、逃逸 ON → 逃逸到空账号（修复点）
+//   - sticky 满、全池也满、逃逸 ON → 回到 sticky WaitPlan（缓存仍热）
+//   - sticky 满、池里有空、逃逸 OFF → 在 sticky 上排队（今日行为）
+
+// slotEscapeSettingRepo（escape 开关 settingRepo 桩）定义在无 build-tag 的
+// openai_account_scheduler_test.go 中，以便 no-tag / unit / integration 三种
+// 构建下都可见——该 stub 被无 tag 的 SessionStickyBusyKeepsSticky 测试复用。
+
+// newSlotEscapeFixture 构建一个 OpenAIGatewayService，可控制每账号并发槽获取
+// 结果（acquireResults）与可选 settingService（驱动 escape 开关）。
+func newSlotEscapeFixture(
+	t *testing.T,
+	groupID int64,
+	pool []*Account,
+	sessionHash string,
+	stickyAccountID int64,
+	acquireResults map[int64]bool,
+	settingService *SettingService,
+) *OpenAIGatewayService {
+	t.Helper()
+	resetOpenAIAdvancedSchedulerSettingCacheForTest()
+
+	accountsByID := make(map[int64]*Account, len(pool))
+	repoAccounts := make([]Account, 0, len(pool))
+	for _, p := range pool {
+		if p != nil {
+			accountsByID[p.ID] = p
+			repoAccounts = append(repoAccounts, *p)
+		}
+	}
+	snapshotCache := &openAISnapshotCacheStub{snapshotAccounts: pool, accountsByID: accountsByID, filterPlatform: PlatformOpenAI}
+	groupRepo := &stubSchedulerGroupRepo{groupsByID: map[int64]*Group{groupID: {ID: groupID, Platform: PlatformOpenAI}}}
+	snapshotService := &SchedulerSnapshotService{cache: snapshotCache, groupRepo: groupRepo}
+
+	bindings := map[string]int64{}
+	if sessionHash != "" && stickyAccountID > 0 {
+		bindings["openai:"+sessionHash] = stickyAccountID
+	}
+	cfg := &config.Config{}
+	cfg.RunMode = config.RunModeStandard
+	cfg.Gateway.Scheduling.LoadBatchEnabled = false
+
+	return &OpenAIGatewayService{
+		accountRepo:        stubOpenAIAccountRepo{accounts: repoAccounts},
+		cache:              &stubGatewayCache{sessionBindings: bindings},
+		cfg:                cfg,
+		schedulerSnapshot:  snapshotService,
+		concurrencyService: NewConcurrencyService(stubConcurrencyCache{acquireResults: acquireResults}),
+		rateLimitService:   newOpenAIAdvancedSchedulerRateLimitService("true"),
+		settingService:     settingService,
+	}
+}
+
+// A — 修复点：sticky 账号槽满、池里有空账号、逃逸默认开（settingService=nil → fail-open true）
+// → 逃逸到空账号，而不是把用户困在堵塞的 sticky 账号上排队。
+func TestUS2859_SlotFullEscape_EscapesToFreePoolAccount(t *testing.T) {
+	ctx := context.Background()
+	groupID := int64(85001)
+	sticky := openAIAccount(1, 7)
+	free := openAIAccount(2, 5)
+	svc := newSlotEscapeFixture(t, groupID, []*Account{sticky, free}, "sess-escape", 1,
+		map[int64]bool{1: false, 2: true}, nil)
+
+	sel, decision, err := svc.SelectAccountWithScheduler(ctx, &groupID, "", "sess-escape", "", nil, OpenAIUpstreamTransportAny, false)
+	require.NoError(t, err)
+	require.NotNil(t, sel)
+	require.NotNil(t, sel.Account)
+	require.Equal(t, int64(2), sel.Account.ID, "槽满应逃逸到池里的空账号，而非困在 sticky 账号")
+	require.True(t, sel.Acquired, "逃逸的账号应真正拿到槽")
+	require.Equal(t, openAIAccountScheduleLayerLoadBalance, decision.Layer)
+}
+
+// B — happy path 不变：sticky 账号有空槽 → 仍走 sticky（缓存最优）。
+func TestUS2859_SlotFullEscape_StickyHasSlot_StaysSticky(t *testing.T) {
+	ctx := context.Background()
+	groupID := int64(85002)
+	sticky := openAIAccount(1, 7)
+	free := openAIAccount(2, 5)
+	svc := newSlotEscapeFixture(t, groupID, []*Account{sticky, free}, "sess-happy", 1,
+		map[int64]bool{1: true, 2: true}, nil)
+
+	sel, decision, err := svc.SelectAccountWithScheduler(ctx, &groupID, "", "sess-happy", "", nil, OpenAIUpstreamTransportAny, false)
+	require.NoError(t, err)
+	require.NotNil(t, sel)
+	require.NotNil(t, sel.Account)
+	require.Equal(t, int64(1), sel.Account.ID, "sticky 有空槽时必须走 sticky")
+	require.True(t, sel.Acquired)
+	require.Equal(t, openAIAccountScheduleLayerSessionSticky, decision.Layer)
+	require.True(t, decision.StickySessionHit)
+}
+
+// C — 全池也满、逃逸 ON → 回到 sticky 的 WaitPlan（在缓存最热的原账号上等，不比今天差）。
+func TestUS2859_SlotFullEscape_PoolAlsoFull_FallsBackToStickyWait(t *testing.T) {
+	ctx := context.Background()
+	groupID := int64(85003)
+	sticky := openAIAccount(1, 7)
+	other := openAIAccount(2, 5)
+	svc := newSlotEscapeFixture(t, groupID, []*Account{sticky, other}, "sess-allfull", 1,
+		map[int64]bool{1: false, 2: false}, nil)
+
+	sel, decision, err := svc.SelectAccountWithScheduler(ctx, &groupID, "", "sess-allfull", "", nil, OpenAIUpstreamTransportAny, false)
+	require.NoError(t, err)
+	require.NotNil(t, sel)
+	require.NotNil(t, sel.Account)
+	require.Equal(t, int64(1), sel.Account.ID, "全池满时应回到 sticky 账号等待（缓存仍热）")
+	require.False(t, sel.Acquired, "全满时返回的是 WaitPlan，未真正拿到槽")
+	require.NotNil(t, sel.WaitPlan)
+	require.Equal(t, openAIAccountScheduleLayerSessionSticky, decision.Layer)
+}
+
+// E — 开关关闭 → 退回今日行为：sticky 槽满即在原账号排队，即使池里有空账号也不逃逸。
+func TestUS2859_SlotFullEscape_Disabled_QueuesOnSticky(t *testing.T) {
+	ctx := context.Background()
+	// 重置进程内缓存，确保读到本测试 settingRepo 的值。
+	stickySlotFullEscapeCache.Store(&stickySlotFullEscapeCacheEntry{expiresAt: 0})
+	t.Cleanup(func() { stickySlotFullEscapeCache.Store(&stickySlotFullEscapeCacheEntry{expiresAt: 0}) })
+
+	groupID := int64(85004)
+	sticky := openAIAccount(1, 7)
+	free := openAIAccount(2, 5)
+	ss := &SettingService{settingRepo: &slotEscapeSettingRepo{val: "false"}}
+	svc := newSlotEscapeFixture(t, groupID, []*Account{sticky, free}, "sess-off", 1,
+		map[int64]bool{1: false, 2: true}, ss)
+
+	sel, decision, err := svc.SelectAccountWithScheduler(ctx, &groupID, "", "sess-off", "", nil, OpenAIUpstreamTransportAny, false)
+	require.NoError(t, err)
+	require.NotNil(t, sel)
+	require.NotNil(t, sel.Account)
+	require.Equal(t, int64(1), sel.Account.ID, "逃逸关闭时即使池里有空账号也必须留在 sticky 账号排队")
+	require.False(t, sel.Acquired)
+	require.NotNil(t, sel.WaitPlan)
+	require.Equal(t, openAIAccountScheduleLayerSessionSticky, decision.Layer)
+}
+
+// D — reader：默认开（未设置/空/error/"true"），仅显式 "false" 关闭。
+func TestIsStickySlotFullEscapeEnabled_Default(t *testing.T) {
+	cases := []struct {
+		name string
+		val  string
+		want bool
+	}{
+		{"unset/empty defaults true", "", true},
+		{"explicit true", "true", true},
+		{"explicit false", "false", false},
+		{"garbage defaults true (opt-out)", "yes", true},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			stickySlotFullEscapeCache.Store(&stickySlotFullEscapeCacheEntry{expiresAt: 0})
+			ss := &SettingService{settingRepo: &slotEscapeSettingRepo{val: tc.val}}
+			require.Equal(t, tc.want, ss.IsStickySlotFullEscapeEnabled(context.Background()))
+		})
+	}
+
+	// nil SettingService / nil repo → fail-open true。
+	stickySlotFullEscapeCache.Store(&stickySlotFullEscapeCacheEntry{expiresAt: 0})
+	var nilSvc *SettingService
+	require.True(t, nilSvc.IsStickySlotFullEscapeEnabled(context.Background()))
+}

--- a/backend/internal/service/setting_service.go
+++ b/backend/internal/service/setting_service.go
@@ -2270,6 +2270,58 @@ func (s *SettingService) IsStickyRoutingEnabled(ctx context.Context) bool {
 	return true
 }
 
+// stickySlotFullEscapeCache 缓存 sticky 槽满逃逸开关（进程内 atomic.Value，60s TTL）
+type stickySlotFullEscapeCacheEntry struct {
+	enabled   bool
+	expiresAt int64 // unix nano
+}
+
+var stickySlotFullEscapeCache atomic.Value // *stickySlotFullEscapeCacheEntry
+var stickySlotFullEscapeSF singleflight.Group
+
+// IsStickySlotFullEscapeEnabled 返回 sticky 绑定账号并发槽满时是否先试全池再排队
+// （upstream #2859）。默认 true（fail-open）：setting 缺失或 DB 出错时按默认开。
+// 见 docs/approved/sticky-routing.md §11.5。
+func (s *SettingService) IsStickySlotFullEscapeEnabled(ctx context.Context) bool {
+	if s == nil || s.settingRepo == nil {
+		return true
+	}
+	if cached, ok := stickySlotFullEscapeCache.Load().(*stickySlotFullEscapeCacheEntry); ok && cached != nil {
+		if time.Now().UnixNano() < cached.expiresAt {
+			return cached.enabled
+		}
+	}
+	val, _, _ := stickySlotFullEscapeSF.Do("sticky_slot_full_escape_enabled", func() (any, error) {
+		if cached, ok := stickySlotFullEscapeCache.Load().(*stickySlotFullEscapeCacheEntry); ok && cached != nil {
+			if time.Now().UnixNano() < cached.expiresAt {
+				return cached.enabled, nil
+			}
+		}
+		dbCtx, cancel := context.WithTimeout(context.WithoutCancel(ctx), stickyRoutingDBTimeout)
+		defer cancel()
+		raw, err := s.settingRepo.GetValue(dbCtx, SettingKeyStickySlotFullEscapeEnabled)
+		if err != nil {
+			slog.Warn("failed to get sticky slot-full escape setting", "error", err)
+			stickySlotFullEscapeCache.Store(&stickySlotFullEscapeCacheEntry{
+				enabled:   true,
+				expiresAt: time.Now().Add(stickyRoutingErrorTTL).UnixNano(),
+			})
+			return true, nil
+		}
+		// 空字符串 => 从未设置 => 默认 true（opt-out，不是 opt-in）。
+		enabled := strings.TrimSpace(raw) != "false"
+		stickySlotFullEscapeCache.Store(&stickySlotFullEscapeCacheEntry{
+			enabled:   enabled,
+			expiresAt: time.Now().Add(stickyRoutingCacheTTL).UnixNano(),
+		})
+		return enabled, nil
+	})
+	if b, ok := val.(bool); ok {
+		return b
+	}
+	return true
+}
+
 // IsRewriteMessageCacheControlEnabled 检查是否启用 messages cache_control 改写。
 func (s *SettingService) IsRewriteMessageCacheControlEnabled(ctx context.Context) bool {
 	return s.getGatewayForwardingSettingsCached(ctx).rewriteMessageCacheControl

--- a/docs/approved/sticky-routing.md
+++ b/docs/approved/sticky-routing.md
@@ -376,3 +376,24 @@ type CacheStats struct {
   - R5: main/master 分支上禁止 `approved_by: pending`（其他分支允许）
 - **执行链**：`dev-rules/templates/preflight.sh § 7` 调用上述脚本；`scripts/preflight.sh`（项目 wrapper）→ dev-rules 模板 → § 7；`pre-commit` hook 与 CI（`.github/workflows/backend-ci.yml` `preflight` job）同步运行。
 - **演进路径**：本机制 2026-04-19 由 sub2api 项目级实现上提到 dev-rules submodule。
+
+## 11.5 槽满逃逸（upstream #2859，2026-06-03 增补）
+
+sticky 账号并发槽满时，upstream 让用户**原地排队**（`StickySessionMaxWaiting` 深度，默认 3），
+即使池里有空账号也不切换。#2859 改为 **OpenAI/newapi 高级调度器：槽满先试全池、有空账号即
+逃逸、全池满才回退 sticky `WaitPlan`**（缓存仍热，不比原行为差）。开关
+`gateway.sticky_routing.slot_full_escape_enabled`（默认 true / fail-open，可即时回滚）。
+anthropic 主网关路径**不动**（上游已在 `wait_queue_full` 时逃逸）。代码：
+`openai_account_scheduler.go` 的 `Select` 按 `result.Acquired` 分流 + `IsStickySlotFullEscapeEnabled`。
+
+**决策记录（勿重蹈，A/B/C vs upstream）**：
+
+- 队列机制（sticky + `MaxWaiting` + `WaitPlan`）是 **upstream Wei-Shaw/sub2api 的设计**，非 TK 自造。
+  TK 用最小 override（**A 方案**）止血，不删上游分支。
+- **不要删 `MaxWaiting` 队列（B）或把 sticky 重写成 load-balance 软加分（C）**：二者局部更简，但在 fork 里
+  净删 / 重写上游 = 永久 merge 债（CLAUDE.md §5.x / §5.y）。其简化价值应作为 PR 推 upstream，让 TK 零冲突继承。
+- **不要把 `StickySessionMaxWaiting` 设为 0** 来"关掉队列"：(1) `config.go` 校验 `<=0` 直接 fatal，app 起不来；
+  (2) 两条 sticky 路径结构不同——OpenAI `selectBySessionHash` 槽满时**无条件**返回 `WaitPlan`（0 → 用户被拒、
+  非逃逸），anthropic gateway 才有 `waitingCount < MaxWaiting` 门（0 → 逃逸）。同一配置值在两路径行为相反，是埋雷。
+  逃逸决策必须放在"知道池里有没有空账号"的调度代码点，一个全局整数表达不了。
+- 逃逸 / `#656` 谓词的 load-bearing 锚点见 `scripts/sentinels/gateway-tk.json`（防上游 merge 静默回退）。

--- a/scripts/sentinels/gateway-tk.json
+++ b/scripts/sentinels/gateway-tk.json
@@ -1589,6 +1589,35 @@
         "func (s *RateLimitService) notifyAccountIncident("
       ],
       "rationale": "把 AccountIncidentNotifier 注入 RateLimitService 的 glue：wire ProvideTKAccountIncidentNotifier 在构造后调 SetAccountIncidentNotifier 回填，挂钩点（ratelimit_service.go）经 notifyAccountIncident 转发。删掉会让挂钩行编译失败或静默 no-op，账号失效告警链路断裂。"
+    },
+    {
+      "path": "backend/internal/service/openai_account_scheduler.go",
+      "must_contain": [
+        "func (s *defaultOpenAIAccountScheduler) stickySlotFullEscapeEnabled",
+        "if stickySel != nil && stickySel.Acquired {",
+        "if stickyWaitPlan && !s.stickySlotFullEscapeEnabled(ctx) {",
+        "if selection != nil && selection.Acquired && selection.Account != nil {"
+      ],
+      "rationale": "TK #2859 sticky slot-full escape (OpenAI/newapi advanced scheduler). Upstream selectBySessionHash returns a WaitPlan unconditionally when the sticky-bound account's concurrency slot is full, trapping the user on a busy account even when free accounts exist. The caller now dispatches on result.Acquired: sticky slot acquired -> return sticky (happy path, cache-optimal, zero added cost); slot full -> try load-balance FIRST and escape to a free (Acquired) account; only when the whole pool is full fall back to the sticky WaitPlan (cache still warm). Gated by gateway.sticky_routing.slot_full_escape_enabled (default true, fail-open) for instant rollback. These anchors keep an upstream merge from silently reverting the Acquired-based dispatch back to upstream's immediate-WaitPlan trap. anthropic main gateway path is intentionally NOT changed (it already escapes on wait_queue_full). See docs/approved/sticky-routing.md §11.5."
+    },
+    {
+      "path": "backend/internal/service/setting_service.go",
+      "must_contain": [
+        "func (s *SettingService) IsStickySlotFullEscapeEnabled",
+        "SettingKeyStickySlotFullEscapeEnabled",
+        "var stickySlotFullEscapeCache atomic.Value"
+      ],
+      "rationale": "TK #2859 sticky slot-full escape global toggle reader. Default true / fail-open (missing setting or DB error => enabled), mirroring IsStickyRoutingEnabled with its own 60s atomic+singleflight cache. The scheduler escape (openai_account_scheduler.go) reads this; the scheduler helper also has a nil-safe true fallback, but dropping this reader silently removes the admin-toggle / instant-rollback capability that the #2859 design promises. Anchor the reader + SettingKey + the cache var so the default-on, reversible contract survives upstream merges."
+    },
+    {
+      "path": "backend/internal/service/gateway_service.go",
+      "must_contain": [
+        "func isCountTokensUnsupported404(statusCode int, body []byte) bool {",
+        "strings.Contains(msg, \"noresourcefoundexception\")",
+        "strings.Contains(msg, \"no static resource\")",
+        "count_tokens (status=%d), returning 404"
+      ],
+      "rationale": "TK #656 count_tokens non-standard not-found fallback. Some Chinese Anthropic-compatible relays that do not support /v1/messages/count_tokens wrap a Spring NoResourceFoundException / 'No static resource v1/messages/count_tokens' into a non-standard HTTP 400/500 instead of a clean 404. isCountTokensUnsupported404 is widened to recognize these (narrowed to count_tokens-endpoint mention + strong Spring not-found signals so a real invalid_request_error like #2109 temperature is NOT swallowed; includes raw-body fallback), and the main ForwardCountTokens path short-circuits to 404 BEFORE the breaker/failover so Claude Code falls back to local token estimation while the account is neither penalized nor wasted on failover (same posture as the passthrough variant). Anchor the widened strong-signal predicates + the main-path 404 short-circuit log so an upstream merge cannot silently narrow it back to status==404-only and re-break these relays."
     }
   ]
 }


### PR DESCRIPTION
## 背景

`.cache/upstream` triage 的 anthropic 平台 upstream issue 审计——对照真实代码核查后，绝大多数已闭环；本 PR 落地 3 个真实缺口 + 登记卫生。详见 `docs/sticky-health-escape-2859-design.md`。

## 改动

### #656 count_tokens 非标准返回兜底（fix）
- 部分国产 Anthropic 兼容中转站不支持 `/v1/messages/count_tokens` 时，把 `NoResourceFoundException` / `No static resource` 语义包装进 HTTP **400/500**（非标准 404）。
- `isCountTokensUnsupported404` 放宽识别这类包装；**收窄到 count_tokens 端点 + Spring 强信号**，刻意保留 `invalid_request_error`（#2109 temperature）不被误吞；含 raw-body 兜底。
- 主路径 `ForwardCountTokens` 在**熔断/failover 之前**短路返 404，让 Claude Code fallback 本地估算，账号不被罚下、不浪费 failover。
- +4 单测（含守卫用例）。

### #2859 sticky 槽满逃逸（feat，OpenAI/newapi scheduler）
- 账号并发槽满时**先试全池**：有空账号即逃逸；全池也满才回退 sticky `WaitPlan`（缓存仍热，不比今天差）。
- happy-path（sticky 拿到槽）零成本不变；只在槽满时按 `Acquired` 分流。
- 新增**默认开**开关 `gateway.sticky_routing.slot_full_escape_enabled`（fail-open，可即时回滚）。
- **anthropic 主网关路径不动**（上游已有 `wait_queue_full` 逃逸）。
- 既有 `SessionStickyBusyKeepsSticky` 改为显式钉 `escape=off` 的 opt-out 契约（不翻转其意图）。
- +5 单测。A/B/C-vs-upstream 决策记录见设计 doc（B/C 留给 upstream PR，避免 fork merge 债）。

### #2754 Haiku beta 注释修正（chore）
- 修正 `gateway_service.go` 误导注释（原称 Haiku 含 `claude-code` beta / cc 2.1.152，与 `FullClaudeCodeHaikuMimicryBetas` 实际 token 集矛盾）。**无行为变更**。

### 登记卫生
- `fixes.json` / `triage.json` 补登 #225/#599/#851/#392/#656/#2754。
- `scripts/sentinels/gateway-tk.json` 新增 3 条 sentinel 钉住 #2859/#656 的 load-bearing 面，防上游 merge 静默回退。

## 验证
- `go build ./...` ✅
- `go test -tags=unit ./...` 全绿（52 包）✅
- `scripts/preflight.sh` PASS（含 sentinel registry update gate）✅
- 纯后端，`no-web-impact`；`upstream-touch-guarded`。

## 合并方式
TK-originated → **Squash and merge**（§5.y）。**等显式授权后再合**。
