### PR TITLE
chore(ci): retry caddy image pull + skip Caddyfile gate on registry outage

### DIFF
--- a/scripts/checks/caddyfile-syntax.sh
+++ b/scripts/checks/caddyfile-syntax.sh
@@ -29,6 +29,37 @@ if ! docker info >/dev/null 2>&1; then
   exit 0
 fi
 
+CADDY_IMAGE="caddy:2-alpine"
+
+# Ensure the caddy image is on disk BEFORE the per-file `docker run`, with retry.
+# Otherwise every `docker run` re-pulls from Docker Hub, and a transient registry
+# timeout (registry-1.docker.io context-deadline) is misreported as "caddy adapt
+# failed" — i.e. a CI flake, not a Caddyfile error. Returns: 0 image ready,
+# 1 image genuinely unreachable after retries.
+ensure_caddy_image() {
+  if docker image inspect "$CADDY_IMAGE" >/dev/null 2>&1; then
+    return 0
+  fi
+  local attempt
+  for attempt in 1 2 3; do
+    if docker pull "$CADDY_IMAGE" >/dev/null 2>&1; then
+      return 0
+    fi
+    echo "warn: docker pull $CADDY_IMAGE attempt ${attempt}/3 failed; retrying..." >&2
+    sleep "$((attempt * 5))"
+  done
+  return 1
+}
+
+if ! ensure_caddy_image; then
+  # Could not fetch the image after retries → registry/network outage, not a
+  # config error. Do NOT fail the gate on Docker Hub being down (that is the
+  # flake this guard exists to avoid). Skip loudly; a real Caddyfile error during
+  # an outage is still caught by the local pre-commit run (image usually cached).
+  echo "warn: could not pull $CADDY_IMAGE after retries (registry/network issue) — SKIPPING Caddyfile syntax check (infra, not a config error)" >&2
+  exit 0
+fi
+
 # Use deterministic placeholder values for stage0 templates that are rendered via envsubst in Cloud-Init.
 export API_DOMAIN="api.example.com"
 export ACME_EMAIL="ops@example.com"
@@ -52,7 +83,7 @@ adapt_with_caddy() {
   local file="$1"
   docker run --rm \
     -v "$file:/work/Caddyfile:ro" \
-    caddy:2-alpine \
+    "$CADDY_IMAGE" \
     caddy adapt --config /work/Caddyfile --adapter caddyfile >/dev/null
 }
 


### PR DESCRIPTION
## 问题

`scripts/checks/caddyfile-syntax.sh`(preflight 的 Caddyfile syntax gate)对每个文件跑 `docker run caddy:2-alpine caddy adapt`。CI runner 没缓存镜像 → 每次现拉 Docker Hub → 一次瞬态 `registry-1.docker.io ... context deadline exceeded` 就被**误报成 "caddy adapt failed"**、挂掉整个 preflight job。本会话已撞 2 次(#519、#520,都是无关改动)。

## 修复

- `ensure_caddy_image()`:在 per-file 循环**之前**把 `caddy:2-alpine` 拉一次,**3 次重试 + 线性退避**,瞬态超时被兜住而非失败;后续 `docker run` 复用已落盘的镜像(不再重拉)。
- 重试后仍拉不到(Docker Hub 真宕)→ **SKIP**(exit 0)+ 大声 warning,而不是 FAIL——registry 中断是 infra,不是 Caddyfile 错误。真出 config 错也会被本地 pre-commit(通常有缓存镜像)兜住。

**registry 可达时(常态)严格性不变**:镜像在、config 真错仍 FAIL。

## 验证

- happy path(本地有缓存镜像):严格通过 `ok: Caddyfile syntax checks passed (3 files)`,exit 0。
- skip path(`CI=1` + 不可拉镜像):**exit 0**(修复前是 1),打印 SKIP 而非 "FAIL: caddy adapt failed"。
- `scripts/preflight.sh` 全套绿。

合并方式:TK chore → **Squash and merge**。

🤖 Generated with [Claude Code](https://claude.com/claude-code)