### PR TITLE
fix(ci): cc-issue-watchdog first-run cache-PR bootstrap deadlock

### DIFF
--- a/.github/workflows/anthropic-cc-issue-watchdog.yml
+++ b/.github/workflows/anthropic-cc-issue-watchdog.yml
@@ -316,14 +316,23 @@ jobs:
         run: |
           set -euo pipefail
           echo "cache_pr_url=" >> "$GITHUB_OUTPUT"
-          if [ "${{ steps.watchdog.outputs.cache_changed }}" != "true" ]; then
-            if git diff --quiet -- scripts/anthropic/cc-issue-triage-generate.py .cache/anthropic/cc-fact-checks.json .github/workflows/anthropic-cc-issue-watchdog.yml; then
-              echo "No substantive upstream issue cache changes to propose."
-              exit 0
-            fi
+          # Decide whether to propose a cache PR from two independent signals:
+          #  - substantive cache change: steps.watchdog.outputs.cache_changed is the
+          #    updated_at-scrubbed comparison (true only when triage/fixes CONTENT
+          #    really changed, not when GitHub merely re-stamped issue updated_at —
+          #    that scrub is what prevents a daily no-op PR), AND it returns true when
+          #    .cache/anthropic/cc-triage.json is new/untracked (HEAD-missing → true).
+          #  - script/workflow change: a plain tracked-file diff.
+          # Do NOT gate on `git diff` of cc-triage.json itself: on the first run it is
+          # brand-new and gitignored/untracked, and `git diff` (tracked-only) is blind
+          # to it — that previously deadlocked the bootstrap (never staged → never
+          # tracked → never a PR). cache_changed already covers it.
+          meta_changed=false
+          if ! git diff --quiet -- scripts/anthropic/cc-issue-triage-generate.py .github/workflows/anthropic-cc-issue-watchdog.yml; then
+            meta_changed=true
           fi
-          if git diff --quiet -- scripts/anthropic/cc-issue-triage-generate.py .cache/anthropic/cc-triage.json .cache/anthropic/cc-fixes.json .cache/anthropic/cc-fact-checks.json .github/workflows/anthropic-cc-issue-watchdog.yml; then
-            echo "No upstream issue cache changes to propose."
+          if [ "${{ steps.watchdog.outputs.cache_changed }}" != "true" ] && [ "$meta_changed" != "true" ]; then
+            echo "No substantive claude-code issue cache changes to propose."
             exit 0
           fi
 
@@ -334,7 +343,7 @@ jobs:
           # snapshots (2026-05-19 watchdog regression: previously broken when
           # the .gitignore began catching these paths).
           git add -f scripts/anthropic/cc-issue-triage-generate.py .cache/anthropic/cc-triage.json .cache/anthropic/cc-fixes.json .cache/anthropic/cc-fact-checks.json .github/workflows/anthropic-cc-issue-watchdog.yml
-          git commit -m "chore: refresh upstream issue cache"
+          git commit -m "chore: refresh claude-code issue cache"
           git push --force-with-lease origin "$BRANCH"
 
           cat > .cache/anthropic-cc-issue-watchdog/cache-pr-body.md <<'EOF'
@@ -361,9 +370,9 @@ jobs:
           if [ -n "$EXISTING" ]; then
             NUMBER="$(jq -r '.number' <<<"$EXISTING")"
             URL="$(jq -r '.url' <<<"$EXISTING")"
-            gh pr edit "$NUMBER" --title "chore: refresh upstream issue cache" --body-file .cache/anthropic-cc-issue-watchdog/cache-pr-body.md
+            gh pr edit "$NUMBER" --title "chore: refresh claude-code issue cache" --body-file .cache/anthropic-cc-issue-watchdog/cache-pr-body.md
           else
-            URL="$(gh pr create --base main --head "$BRANCH" --title "chore: refresh upstream issue cache" --body-file .cache/anthropic-cc-issue-watchdog/cache-pr-body.md)"
+            URL="$(gh pr create --base main --head "$BRANCH" --title "chore: refresh claude-code issue cache" --body-file .cache/anthropic-cc-issue-watchdog/cache-pr-body.md)"
           fi
           echo "cache_pr_url=$URL" >> "$GITHUB_OUTPUT"
           echo "cache PR: $URL"


### PR DESCRIPTION
## 背景

手动 dispatch #522 的 watchdog 跑了一次(run 26868166587),**scan 一切正常**——拉 2988 个近期 issue(1723 open)、relevance 过滤、`#61348` 标 `fixed_verified`、0 误晋升、`substantive_cache_changed=true`。**但没开出台账 PR**。

## 根因:first-run bootstrap 死锁

cache-PR 步骤的守卫用 `git diff --quiet -- .cache/anthropic/cc-triage.json` 判断是否有变化,而 **`git diff` 只看 tracked 文件**。首次运行 `cc-triage.json` 是全新生成且 gitignored/**untracked**,git-diff 看不见它 → 打印 "No changes" 退出 → 永远不 `git add -f` → 永远不 tracked → **永远开不出 PR**(死锁)。上游 watchdog 没踩到只因它的 triage.json 很久前手工提交过。

## 修复

把 cache-PR 守卫改为:**`cache_changed`(python updated_at-scrubbed 比对,对 HEAD-missing/新文件正确返回 true)OR tracked 脚本/workflow diff**——**不再** 对 untracked 的 `cc-triage.json` 跑 `git diff`。后续既有的 `git add -f` 正常把它提交。保留了"只有 updated_at 漂移就跳过 PR"的防日更噪音逻辑。

顺带:commit/PR 标题 "upstream issue cache" → "claude-code issue cache"。

## 验证

本地最小复现证明:旧守卫对 untracked 文件返回 "no change"(死锁),新逻辑 `cache_changed=true` 时正常 proceed。`scripts/preflight.sh` 全绿。

合并后我会再 dispatch 一次确认台账 PR 真的开出来。

纯 CI,无 backend/前端。marker `no-web-impact`。

🤖 Generated with [Claude Code](https://claude.com/claude-code)