### PR TITLE
chore: refresh claude-code issue cache

### DIFF
--- a/.cache/anthropic/cc-triage.json
+++ b/.cache/anthropic/cc-triage.json
@@ -1,0 +1,21670 @@
+{
+  "version": 1,
+  "source": "anthropics/claude-code open issues",
+  "generated_from": "GitHub REST API issues?state=open; pull requests excluded; gateway-relevance filtered",
+  "rationale": "TokenKey-local triage cache for anthropics/claude-code issues, filtered for gateway/relay relevance. Most claude-code issues are client-side (IDE/terminal/MCP) and are marked not_applicable. Only human-pinned MANUAL_TRIAGE high/critical entries become fix candidates.",
+  "counts": {
+    "needs_review": 402,
+    "medium": 20,
+    "not_applicable": 1165,
+    "unknown_low_signal": 137
+  },
+  "issues": [
+    {
+      "upstream": "anthropics/claude-code#11008",
+      "url": "https://github.com/anthropics/claude-code/issues/11008",
+      "title": "[FEATURE] Expose token usage and cost data in hook inputs",
+      "impact": "needs_review",
+      "categories": [
+        "prompt_caching"
+      ],
+      "tokenkey_status": "candidate_unverified",
+      "rationale": "Gateway/relay-relevant keyword match; not yet manually verified against TokenKey code.",
+      "updated_at": "2026-06-01T17:46:05Z"
+    },
+    {
+      "upstream": "anthropics/claude-code#15542",
+      "url": "https://github.com/anthropics/claude-code/issues/15542",
+      "title": "[FEATURE] Enable Claude Code to access chat history in Claude App",
+      "impact": "needs_review",
+      "categories": [
+        "auth_token"
+      ],
+      "tokenkey_status": "candidate_unverified",
+      "rationale": "Gateway/relay-relevant keyword match; not yet manually verified against TokenKey code.",
+      "updated_at": "2026-05-31T17:58:47Z"
+    },
+    {
+      "upstream": "anthropics/claude-code#20131",
+      "url": "https://github.com/anthropics/claude-code/issues/20131",
+      "title": "Feature Request: Multi-Account Profile Support",
+      "impact": "needs_review",
+      "categories": [
+        "rate_limit",
+        "auth_token"
+      ],
+      "tokenkey_status": "candidate_unverified",
+      "rationale": "Gateway/relay-relevant keyword match; not yet manually verified against TokenKey code.",
+      "updated_at": "2026-06-02T23:50:06Z"
+    },
+    {
+      "upstream": "anthropics/claude-code#20194",
+      "url": "https://github.com/anthropics/claude-code/issues/20194",
+      "title": "[BUG] Native Claude Code not using system certs on MacOS",
+      "impact": "needs_review",
+      "categories": [
+        "model_lifecycle"
+      ],
+      "tokenkey_status": "candidate_unverified",
+      "rationale": "Gateway/relay-relevant keyword match; not yet manually verified against TokenKey code.",
+      "updated_at": "2026-06-02T14:24:20Z"
+    },
+    {
+      "upstream": "anthropics/claude-code#25979",
+      "url": "https://github.com/anthropics/claude-code/issues/25979",
+      "title": "[BUG] Claude Code hangs indefinitely when API streaming connection stalls (no read timeout)",
+      "impact": "needs_review",
+      "categories": [
+        "request_shape_400"
+      ],
+      "tokenkey_status": "candidate_unverified",
+      "rationale": "Gateway/relay-relevant keyword match; not yet manually verified against TokenKey code.",
+      "updated_at": "2026-06-01T17:18:18Z"
+    },
+    {
+      "upstream": "anthropics/claude-code#26281",
+      "url": "https://github.com/anthropics/claude-code/issues/26281",
+      "title": "[BUG] MCP OAuth tokens without expires_in and refresh_token silently expires",
+      "impact": "needs_review",
+      "categories": [
+        "auth_token"
+      ],
+      "tokenkey_status": "candidate_unverified",
+      "rationale": "Gateway/relay-relevant keyword match; not yet manually verified against TokenKey code.",
+      "updated_at": "2026-06-02T22:52:59Z"
+    },
+    {
+      "upstream": "anthropics/claude-code#27263",
+      "url": "https://github.com/anthropics/claude-code/issues/27263",
+      "title": "[FEATURE] Preview: Allow configurable external URL whitelist for OAuth and other third-party required flows",
+      "impact": "needs_review",
+      "categories": [
+        "auth_token"
+      ],
+      "tokenkey_status": "candidate_unverified",
+      "rationale": "Gateway/relay-relevant keyword match; not yet manually verified against TokenKey code.",
+      "updated_at": "2026-06-02T19:37:47Z"
+    },
+    {
+      "upstream": "anthropics/claude-code#27359",
+      "url": "https://github.com/anthropics/claude-code/issues/27359",
+      "title": "Feature Request: Named account profiles for quick switching between multiple claude.ai accounts",
+      "impact": "needs_review",
+      "categories": [
+        "auth_token"
+      ],
+      "tokenkey_status": "candidate_unverified",
+      "rationale": "Gateway/relay-relevant keyword match; not yet manually verified against TokenKey code.",
+      "updated_at": "2026-06-03T00:11:05Z"
+    },
+    {
+      "upstream": "anthropics/claude-code#30039",
+      "url": "https://github.com/anthropics/claude-code/issues/30039",
+      "title": "[FEATURE] Native Context Graph: Temporal knowledge graph for cross-session learning and hallucination prevention",
+      "impact": "needs_review",
+      "categories": [
+        "request_shape_400"
+      ],
+      "tokenkey_status": "candidate_unverified",
+      "rationale": "Gateway/relay-relevant keyword match; not yet manually verified against TokenKey code.",
+      "updated_at": "2026-06-02T22:44:22Z"
+    },
+    {
+      "upstream": "anthropics/claude-code#30745",
+      "url": "https://github.com/anthropics/claude-code/issues/30745",
+      "title": "[Feature Request] Add message timestamps to interactive conversation view",
+      "impact": "needs_review",
+      "categories": [
+        "rate_limit"
+      ],
+      "tokenkey_status": "candidate_unverified",
+      "rationale": "Gateway/relay-relevant keyword match; not yet manually verified against TokenKey code.",
+      "updated_at": "2026-06-02T15:01:21Z"
+    },
+    {
+      "upstream": "anthropics/claude-code#32982",
+      "url": "https://github.com/anthropics/claude-code/issues/32982",
+      "title": "[BUG] Remote Control sessions die after ~20 min idle — server TTL ignores keepalives",
+      "impact": "needs_review",
+      "categories": [
+        "rate_limit",
+        "model_lifecycle"
+      ],
+      "tokenkey_status": "candidate_unverified",
+      "rationale": "Gateway/relay-relevant keyword match; not yet manually verified against TokenKey code.",
+      "updated_at": "2026-06-02T22:10:59Z"
+    },
+    {
+      "upstream": "anthropics/claude-code#33539",
+      "url": "https://github.com/anthropics/claude-code/issues/33539",
+      "title": "OAuth login URL broken by TUI box/table formatting — unclickable, uncopyable, no workaround for Pro/Max subscribers",
+      "impact": "needs_review",
+      "categories": [
+        "auth_token"
+      ],
+      "tokenkey_status": "candidate_unverified",
+      "rationale": "Gateway/relay-relevant keyword match; not yet manually verified against TokenKey code.",
+      "updated_at": "2026-05-31T10:41:32Z"
+    },
+    {
+      "upstream": "anthropics/claude-code#33978",
+      "url": "https://github.com/anthropics/claude-code/issues/33978",
+      "title": "[FEATURE] Built-in Usage Analytics Command (claude usage) — Consolidates 10+ Open Issues",
+      "impact": "needs_review",
+      "categories": [
+        "rate_limit",
+        "prompt_caching"
+      ],
+      "tokenkey_status": "candidate_unverified",
+      "rationale": "Gateway/relay-relevant keyword match; not yet manually verified against TokenKey code.",
+      "updated_at": "2026-06-01T17:48:58Z"
+    },
+    {
+      "upstream": "anthropics/claude-code#34281",
+      "url": "https://github.com/anthropics/claude-code/issues/34281",
+      "title": "[DOCS] Model configuration page missing documentation of automatic fallback notification behavior",
+      "impact": "needs_review",
+      "categories": [
+        "rate_limit"
+      ],
+      "tokenkey_status": "candidate_unverified",
+      "rationale": "Gateway/relay-relevant keyword match; not yet manually verified against TokenKey code.",
+      "updated_at": "2026-06-02T14:21:56Z"
+    },
+    {
+      "upstream": "anthropics/claude-code#3433",
+      "url": "https://github.com/anthropics/claude-code/issues/3433",
+      "title": "Claude Code cannot connect to GitHub's remote MCP server using OAuth authentication",
+      "impact": "needs_review",
+      "categories": [
+        "auth_token"
+      ],
+      "tokenkey_status": "candidate_unverified",
+      "rationale": "Gateway/relay-relevant keyword match; not yet manually verified against TokenKey code.",
+      "updated_at": "2026-06-02T22:53:02Z"
+    },
+    {
+      "upstream": "anthropics/claude-code#36670",
+      "url": "https://github.com/anthropics/claude-code/issues/36670",
+      "title": "[BUG] Team agent teammates don't inherit [1m] context window variant from leader (v2.1.80)",
+      "impact": "needs_review",
+      "categories": [
+        "rate_limit"
+      ],
+      "tokenkey_status": "candidate_unverified",
+      "rationale": "Gateway/relay-relevant keyword match; not yet manually verified against TokenKey code.",
+      "updated_at": "2026-06-02T22:44:00Z"
+    },
+    {
+      "upstream": "anthropics/claude-code#37793",
+      "url": "https://github.com/anthropics/claude-code/issues/37793",
+      "title": "Subagents fail with 'prompt is too long' when user has many MCP servers (tool definitions exceed 200k)",
+      "impact": "needs_review",
+      "categories": [
+        "request_shape_400"
+      ],
+      "tokenkey_status": "candidate_unverified",
+      "rationale": "Gateway/relay-relevant keyword match; not yet manually verified against TokenKey code.",
+      "updated_at": "2026-06-03T02:20:47Z"
+    },
+    {
+      "upstream": "anthropics/claude-code#38335",
+      "url": "https://github.com/anthropics/claude-code/issues/38335",
+      "title": "[BUG] Claude Max plan session limits exhausted abnormally fast since March 23, 2026 (CLI usage)",
+      "impact": "needs_review",
+      "categories": [
+        "rate_limit"
+      ],
+      "tokenkey_status": "candidate_unverified",
+      "rationale": "Gateway/relay-relevant keyword match; not yet manually verified against TokenKey code.",
+      "updated_at": "2026-06-03T04:57:51Z"
+    },
+    {
+      "upstream": "anthropics/claude-code#38896",
+      "url": "https://github.com/anthropics/claude-code/issues/38896",
+      "title": "[Bug] API Error: Rate limit reached despite 0% usage",
+      "impact": "needs_review",
+      "categories": [
+        "rate_limit"
+      ],
+      "tokenkey_status": "candidate_unverified",
+      "rationale": "Gateway/relay-relevant keyword match; not yet manually verified against TokenKey code.",
+      "updated_at": "2026-06-02T22:44:15Z"
+    },
+    {
+      "upstream": "anthropics/claude-code#38984",
+      "url": "https://github.com/anthropics/claude-code/issues/38984",
+      "title": "[BUG] Cowork — \"Additional allowed domains\" allowlist non-functional",
+      "impact": "needs_review",
+      "categories": [
+        "fingerprint_ua"
+      ],
+      "tokenkey_status": "candidate_unverified",
+      "rationale": "Gateway/relay-relevant keyword match; not yet manually verified against TokenKey code.",
+      "updated_at": "2026-06-02T08:13:03Z"
+    },
+    {
+      "upstream": "anthropics/claude-code#40769",
+      "url": "https://github.com/anthropics/claude-code/issues/40769",
+      "title": "[BUG] Cloud scheduled tasks: gRPC/HTTP2 blocked by sandbox TLS proxy to googleapis.com",
+      "impact": "needs_review",
+      "categories": [
+        "fingerprint_ua"
+      ],
+      "tokenkey_status": "candidate_unverified",
+      "rationale": "Gateway/relay-relevant keyword match; not yet manually verified against TokenKey code.",
+      "updated_at": "2026-06-02T22:44:27Z"
+    },
+    {
+      "upstream": "anthropics/claude-code#42850",
+      "url": "https://github.com/anthropics/claude-code/issues/42850",
+      "title": "[BUG] Remote Control returns \"disabled by your organization's policy\" on Team plan despite admin toggle being ON",
+      "impact": "needs_review",
+      "categories": [
+        "auth_token"
+      ],
+      "tokenkey_status": "candidate_unverified",
+      "rationale": "Gateway/relay-relevant keyword match; not yet manually verified against TokenKey code.",
+      "updated_at": "2026-06-01T22:45:44Z"
+    },
+    {
+      "upstream": "anthropics/claude-code#43000",
+      "url": "https://github.com/anthropics/claude-code/issues/43000",
+      "title": "[BUG] MCP OAuth with multiple terminals open causes re-auth",
+      "impact": "needs_review",
+      "categories": [
+        "auth_token",
+        "prompt_caching"
+      ],
+      "tokenkey_status": "candidate_unverified",
+      "rationale": "Gateway/relay-relevant keyword match; not yet manually verified against TokenKey code.",
+      "updated_at": "2026-06-02T22:53:42Z"
+    },
+    {
+      "upstream": "anthropics/claude-code#44101",
+      "url": "https://github.com/anthropics/claude-code/issues/44101",
+      "title": "Auto mode cannot be enabled via UI despite meeting all requirements (Team plan, Sonnet 4.6, admin enabled)",
+      "impact": "needs_review",
+      "categories": [
+        "model_lifecycle"
+      ],
+      "tokenkey_status": "candidate_unverified",
+      "rationale": "Gateway/relay-relevant keyword match; not yet manually verified against TokenKey code.",
+      "updated_at": "2026-06-01T12:02:16Z"
+    },
+    {
+      "upstream": "anthropics/claude-code#44778",
+      "url": "https://github.com/anthropics/claude-code/issues/44778",
+      "title": "[Bug] System events delivered as user-role messages cause model to fabricate user consent and act on it",
+      "impact": "needs_review",
+      "categories": [
+        "auth_token"
+      ],
+      "tokenkey_status": "candidate_unverified",
+      "rationale": "Gateway/relay-relevant keyword match; not yet manually verified against TokenKey code.",
+      "updated_at": "2026-06-01T01:20:04Z"
+    },
+    {
+      "upstream": "anthropics/claude-code#44805",
+      "url": "https://github.com/anthropics/claude-code/issues/44805",
+      "title": "Remote Control: mobile app fails with \"GitHub repository access check failed\" when environment has git_repo_url",
+      "impact": "needs_review",
+      "categories": [
+        "request_shape_400",
+        "auth_token"
+      ],
+      "tokenkey_status": "candidate_unverified",
+      "rationale": "Gateway/relay-relevant keyword match; not yet manually verified against TokenKey code.",
+      "updated_at": "2026-06-01T21:12:50Z"
+    },
+    {
+      "upstream": "anthropics/claude-code#44980",
+      "url": "https://github.com/anthropics/claude-code/issues/44980",
+      "title": "[SECURITY] Claude Teams: Custom MCP connectors expose shared credentials to all team members — no per-user scoping",
+      "impact": "needs_review",
+      "categories": [
+        "auth_token",
+        "fingerprint_ua"
+      ],
+      "tokenkey_status": "candidate_unverified",
+      "rationale": "Gateway/relay-relevant keyword match; not yet manually verified against TokenKey code.",
+      "updated_at": "2026-06-01T12:02:04Z"
+    },
+    {
+      "upstream": "anthropics/claude-code#45729",
+      "url": "https://github.com/anthropics/claude-code/issues/45729",
+      "title": "[BUG] Claude Code for VS Code hangs in 2.1.78+",
+      "impact": "needs_review",
+      "categories": [
+        "auth_token"
+      ],
+      "tokenkey_status": "candidate_unverified",
+      "rationale": "Gateway/relay-relevant keyword match; not yet manually verified against TokenKey code.",
+      "updated_at": "2026-06-01T22:45:19Z"
+    },
+    {
+      "upstream": "anthropics/claude-code#46328",
+      "url": "https://github.com/anthropics/claude-code/issues/46328",
+      "title": "[BUG] MCP OAuth tokens not refreshed for claude.ai proxy connections (mcp-proxy.anthropic.com)",
+      "impact": "needs_review",
+      "categories": [
+        "auth_token"
+      ],
+      "tokenkey_status": "candidate_unverified",
+      "rationale": "Gateway/relay-relevant keyword match; not yet manually verified against TokenKey code.",
+      "updated_at": "2026-06-02T22:44:48Z"
+    },
+    {
+      "upstream": "anthropics/claude-code#46846",
+      "url": "https://github.com/anthropics/claude-code/issues/46846",
+      "title": "Language instruction ignored: Claude responds in Japanese despite explicit Traditional Chinese requirement in CLAUDE.md",
+      "impact": "needs_review",
+      "categories": [
+        "model_lifecycle"
+      ],
+      "tokenkey_status": "candidate_unverified",
+      "rationale": "Gateway/relay-relevant keyword match; not yet manually verified against TokenKey code.",
+      "updated_at": "2026-06-01T22:45:31Z"
+    },
+    {
+      "upstream": "anthropics/claude-code#46917",
+      "url": "https://github.com/anthropics/claude-code/issues/46917",
+      "title": "CC v2.1.100+ inflates cache_creation by ~20K tokens vs v2.1.98 — same payload, server-side",
+      "impact": "needs_review",
+      "categories": [
+        "request_shape_400",
+        "prompt_caching",
+        "fingerprint_ua"
+      ],
+      "tokenkey_status": "candidate_unverified",
+      "rationale": "Gateway/relay-relevant keyword match; not yet manually verified against TokenKey code.",
+      "updated_at": "2026-06-02T16:33:43Z"
+    },
+    {
+      "upstream": "anthropics/claude-code#47488",
+      "url": "https://github.com/anthropics/claude-code/issues/47488",
+      "title": "[BUG] Cowork: Agent tool `model` parameter silently ignored — all sub-agents routed to Haiku",
+      "impact": "needs_review",
+      "categories": [
+        "model_lifecycle",
+        "prompt_caching"
+      ],
+      "tokenkey_status": "candidate_unverified",
+      "rationale": "Gateway/relay-relevant keyword match; not yet manually verified against TokenKey code.",
+      "updated_at": "2026-06-01T22:45:59Z"
+    },
+    {
+      "upstream": "anthropics/claude-code#48011",
+      "url": "https://github.com/anthropics/claude-code/issues/48011",
+      "title": "[FEATURE] Make OAuth/admin base URL configurable like ANTHROPIC_BASE_URL",
+      "impact": "needs_review",
+      "categories": [
+        "auth_token"
+      ],
+      "tokenkey_status": "candidate_unverified",
+      "rationale": "Gateway/relay-relevant keyword match; not yet manually verified against TokenKey code.",
+      "updated_at": "2026-06-02T11:32:24Z"
+    },
+    {
+      "upstream": "anthropics/claude-code#48806",
+      "url": "https://github.com/anthropics/claude-code/issues/48806",
+      "title": "[BUG] Claude in Chrome + Control Chrome Failures in Cowork Mode",
+      "impact": "needs_review",
+      "categories": [
+        "fingerprint_ua"
+      ],
+      "tokenkey_status": "candidate_unverified",
+      "rationale": "Gateway/relay-relevant keyword match; not yet manually verified against TokenKey code.",
+      "updated_at": "2026-06-01T22:46:05Z"
+    },
+    {
+      "upstream": "anthropics/claude-code#48965",
+      "url": "https://github.com/anthropics/claude-code/issues/48965",
+      "title": "Feature: Multi-session coordination primitives (cross-session messaging, session registry, compaction-resistant state, shared task board)",
+      "impact": "needs_review",
+      "categories": [
+        "prompt_caching"
+      ],
+      "tokenkey_status": "candidate_unverified",
+      "rationale": "Gateway/relay-relevant keyword match; not yet manually verified against TokenKey code.",
+      "updated_at": "2026-06-01T20:44:39Z"
+    },
+    {
+      "upstream": "anthropics/claude-code#49038",
+      "url": "https://github.com/anthropics/claude-code/issues/49038",
+      "title": "Prompt cache miss on resume: Agent tool description enumerates sub-agents in non-deterministic order",
+      "impact": "needs_review",
+      "categories": [
+        "beta_header_drift",
+        "request_shape_400",
+        "prompt_caching"
+      ],
+      "tokenkey_status": "candidate_unverified",
+      "rationale": "Gateway/relay-relevant keyword match; not yet manually verified against TokenKey code.",
+      "updated_at": "2026-06-02T22:44:39Z"
+    },
+    {
+      "upstream": "anthropics/claude-code#49268",
+      "url": "https://github.com/anthropics/claude-code/issues/49268",
+      "title": "Thinking summaries missing on Opus 4.7 — harness doesn't set display: \"summarized\"",
+      "impact": "needs_review",
+      "categories": [
+        "model_lifecycle"
+      ],
+      "tokenkey_status": "candidate_unverified",
+      "rationale": "Gateway/relay-relevant keyword match; not yet manually verified against TokenKey code.",
+      "updated_at": "2026-06-02T21:03:51Z"
+    },
+    {
+      "upstream": "anthropics/claude-code#49322",
+      "url": "https://github.com/anthropics/claude-code/issues/49322",
+      "title": "[BUG] Opus 4.7 thinking summaries not rendered in VS Code extension",
+      "impact": "needs_review",
+      "categories": [
+        "model_lifecycle"
+      ],
+      "tokenkey_status": "candidate_unverified",
+      "rationale": "Gateway/relay-relevant keyword match; not yet manually verified against TokenKey code.",
+      "updated_at": "2026-06-02T15:04:49Z"
+    },
+    {
+      "upstream": "anthropics/claude-code#49572",
+      "url": "https://github.com/anthropics/claude-code/issues/49572",
+      "title": "[Bug] Authentication fails with --bare flag despite successful login",
+      "impact": "needs_review",
+      "categories": [
+        "rate_limit"
+      ],
+      "tokenkey_status": "candidate_unverified",
+      "rationale": "Gateway/relay-relevant keyword match; not yet manually verified against TokenKey code.",
+      "updated_at": "2026-06-01T16:24:36Z"
+    },
+    {
+      "upstream": "anthropics/claude-code#49747",
+      "url": "https://github.com/anthropics/claude-code/issues/49747",
+      "title": "[BUG] Opus 4.7 mixes legacy XML tool-use format into JSON tool calls on longer payloads",
+      "impact": "needs_review",
+      "categories": [
+        "model_lifecycle"
+      ],
+      "tokenkey_status": "candidate_unverified",
+      "rationale": "Gateway/relay-relevant keyword match; not yet manually verified against TokenKey code.",
+      "updated_at": "2026-06-02T08:51:37Z"
+    },
+    {
+      "upstream": "anthropics/claude-code#50486",
+      "url": "https://github.com/anthropics/claude-code/issues/50486",
+      "title": "feat(plugins): namespace plugin skills with plugin name prefix like commands",
+      "impact": "needs_review",
+      "categories": [
+        "model_lifecycle"
+      ],
+      "tokenkey_status": "candidate_unverified",
+      "rationale": "Gateway/relay-relevant keyword match; not yet manually verified against TokenKey code.",
+      "updated_at": "2026-06-01T19:15:24Z"
+    },
+    {
+      "upstream": "anthropics/claude-code#50559",
+      "url": "https://github.com/anthropics/claude-code/issues/50559",
+      "title": "[BUG] Subprocess initialization did not complete within 60000ms on Windows — regression from 2.1.114",
+      "impact": "needs_review",
+      "categories": [
+        "auth_token"
+      ],
+      "tokenkey_status": "candidate_unverified",
+      "rationale": "Gateway/relay-relevant keyword match; not yet manually verified against TokenKey code.",
+      "updated_at": "2026-06-02T06:01:53Z"
+    },
+    {
+      "upstream": "anthropics/claude-code#50624",
+      "url": "https://github.com/anthropics/claude-code/issues/50624",
+      "title": "auto-mode permission-deny envelope returned without intercepting Bash dispatch (silent-bypass on git push origin main, CLI 2.1.114, Opus 4.7)",
+      "impact": "needs_review",
+      "categories": [
+        "request_shape_400",
+        "model_lifecycle",
+        "fingerprint_ua"
+      ],
+      "tokenkey_status": "candidate_unverified",
+      "rationale": "Gateway/relay-relevant keyword match; not yet manually verified against TokenKey code.",
+      "updated_at": "2026-06-02T22:44:45Z"
+    },
+    {
+      "upstream": "anthropics/claude-code#50994",
+      "url": "https://github.com/anthropics/claude-code/issues/50994",
+      "title": "[BUG] Billing between claude.ai and claud code is confusing.",
+      "impact": "needs_review",
+      "categories": [
+        "request_shape_400",
+        "new_endpoints"
+      ],
+      "tokenkey_status": "candidate_unverified",
+      "rationale": "Gateway/relay-relevant keyword match; not yet manually verified against TokenKey code.",
+      "updated_at": "2026-06-02T11:32:18Z"
+    },
+    {
+      "upstream": "anthropics/claude-code#51096",
+      "url": "https://github.com/anthropics/claude-code/issues/51096",
+      "title": "[BUG] Unable to specify AWS eu-central-1 as a region when using a Bedrock API key",
+      "impact": "needs_review",
+      "categories": [
+        "auth_token"
+      ],
+      "tokenkey_status": "candidate_unverified",
+      "rationale": "Gateway/relay-relevant keyword match; not yet manually verified against TokenKey code.",
+      "updated_at": "2026-06-01T12:02:18Z"
+    },
+    {
+      "upstream": "anthropics/claude-code#51267",
+      "url": "https://github.com/anthropics/claude-code/issues/51267",
+      "title": "[BUG] Remote Control (mobile): session silently hangs mid-execution; only local Esc recovers it — no remote unstick mechanism",
+      "impact": "needs_review",
+      "categories": [
+        "request_shape_400",
+        "rate_limit"
+      ],
+      "tokenkey_status": "candidate_unverified",
+      "rationale": "Gateway/relay-relevant keyword match; not yet manually verified against TokenKey code.",
+      "updated_at": "2026-05-31T19:43:12Z"
+    },
+    {
+      "upstream": "anthropics/claude-code#51398",
+      "url": "https://github.com/anthropics/claude-code/issues/51398",
+      "title": "Cowork Desktop: ${CLAUDE_PLUGIN_DATA} is not persistent across conversations (MCP plugin tokens lost on every new conversation)",
+      "impact": "needs_review",
+      "categories": [
+        "request_shape_400",
+        "auth_token"
+      ],
+      "tokenkey_status": "candidate_unverified",
+      "rationale": "Gateway/relay-relevant keyword match; not yet manually verified against TokenKey code.",
+      "updated_at": "2026-06-01T08:23:34Z"
+    },
+    {
+      "upstream": "anthropics/claude-code#51798",
+      "url": "https://github.com/anthropics/claude-code/issues/51798",
+      "title": "[BUG] PreToolUse permissionDecision: \"allow\" no longer suppresses prompt for Bash with dangerouslyDisableSandbox: true (2.1.116+ regression)",
+      "impact": "needs_review",
+      "categories": [
+        "request_shape_400"
+      ],
+      "tokenkey_status": "candidate_unverified",
+      "rationale": "Gateway/relay-relevant keyword match; not yet manually verified against TokenKey code.",
+      "updated_at": "2026-06-01T03:40:02Z"
+    },
+    {
+      "upstream": "anthropics/claude-code#51802",
+      "url": "https://github.com/anthropics/claude-code/issues/51802",
+      "title": "[MODEL] Claude loses user-identity + role anchors from memory after summary/resume",
+      "impact": "needs_review",
+      "categories": [
+        "model_lifecycle"
+      ],
+      "tokenkey_status": "candidate_unverified",
+      "rationale": "Gateway/relay-relevant keyword match; not yet manually verified against TokenKey code.",
+      "updated_at": "2026-06-01T22:45:30Z"
+    },
+    {
+      "upstream": "anthropics/claude-code#51940",
+      "url": "https://github.com/anthropics/claude-code/issues/51940",
+      "title": "Assistant response re-rendered after turn ends without user input (Opus 4.7)",
+      "impact": "needs_review",
+      "categories": [
+        "model_lifecycle"
+      ],
+      "tokenkey_status": "candidate_unverified",
+      "rationale": "Gateway/relay-relevant keyword match; not yet manually verified against TokenKey code.",
+      "updated_at": "2026-06-02T22:44:24Z"
+    },
+    {
+      "upstream": "anthropics/claude-code#52121",
+      "url": "https://github.com/anthropics/claude-code/issues/52121",
+      "title": "Grep and Glob tools missing entirely from registry under ENABLE_TOOL_SEARCH=true",
+      "impact": "needs_review",
+      "categories": [
+        "model_lifecycle"
+      ],
+      "tokenkey_status": "candidate_unverified",
+      "rationale": "Gateway/relay-relevant keyword match; not yet manually verified against TokenKey code.",
+      "updated_at": "2026-06-03T00:26:58Z"
+    },
+    {
+      "upstream": "anthropics/claude-code#52135",
+      "url": "https://github.com/anthropics/claude-code/issues/52135",
+      "title": "[BUG] Max (20x) weekly limit depletes disproportionately — 51% mid-week, ~17% within minutes of session reset",
+      "impact": "needs_review",
+      "categories": [
+        "model_lifecycle"
+      ],
+      "tokenkey_status": "candidate_unverified",
+      "rationale": "Gateway/relay-relevant keyword match; not yet manually verified against TokenKey code.",
+      "updated_at": "2026-06-01T22:46:16Z"
+    },
+    {
+      "upstream": "anthropics/claude-code#52482",
+      "url": "https://github.com/anthropics/claude-code/issues/52482",
+      "title": "[BUG] Model drifts full-width CJK punctuation to half-width in Edit's old_string, causing silent \"String to replace not found\"",
+      "impact": "needs_review",
+      "categories": [
+        "model_lifecycle"
+      ],
+      "tokenkey_status": "candidate_unverified",
+      "rationale": "Gateway/relay-relevant keyword match; not yet manually verified against TokenKey code.",
+      "updated_at": "2026-06-01T13:09:20Z"
+    },
+    {
+      "upstream": "anthropics/claude-code#52765",
+      "url": "https://github.com/anthropics/claude-code/issues/52765",
+      "title": "[BUG] Server is busy Claude cowork desktop error",
+      "impact": "needs_review",
+      "categories": [
+        "auth_token"
+      ],
+      "tokenkey_status": "candidate_unverified",
+      "rationale": "Gateway/relay-relevant keyword match; not yet manually verified against TokenKey code.",
+      "updated_at": "2026-06-01T04:38:13Z"
+    },
+    {
+      "upstream": "anthropics/claude-code#52871",
+      "url": "https://github.com/anthropics/claude-code/issues/52871",
+      "title": "[BUG] MCP OAuth appends trailing slash to `resource` parameter, breaking Entra ID auth (AADSTS9010010)",
+      "impact": "needs_review",
+      "categories": [
+        "auth_token"
+      ],
+      "tokenkey_status": "candidate_unverified",
+      "rationale": "Gateway/relay-relevant keyword match; not yet manually verified against TokenKey code.",
+      "updated_at": "2026-06-02T11:56:19Z"
+    },
+    {
+      "upstream": "anthropics/claude-code#52921",
+      "url": "https://github.com/anthropics/claude-code/issues/52921",
+      "title": "[Max 20x] Weekly limits counter resets on a ~24-hour cycle instead of the documented 7-day cycle",
+      "impact": "needs_review",
+      "categories": [
+        "rate_limit"
+      ],
+      "tokenkey_status": "candidate_unverified",
+      "rationale": "Gateway/relay-relevant keyword match; not yet manually verified against TokenKey code.",
+      "updated_at": "2026-05-31T10:41:52Z"
+    },
+    {
+      "upstream": "anthropics/claude-code#53610",
+      "url": "https://github.com/anthropics/claude-code/issues/53610",
+      "title": "[Feature] Multi-agent runtime needs mechanical enforcement: 9 gaps that defeat unattended overnight operation",
+      "impact": "needs_review",
+      "categories": [
+        "prompt_caching"
+      ],
+      "tokenkey_status": "candidate_unverified",
+      "rationale": "Gateway/relay-relevant keyword match; not yet manually verified against TokenKey code.",
+      "updated_at": "2026-06-01T12:03:30Z"
+    },
+    {
+      "upstream": "anthropics/claude-code#53915",
+      "url": "https://github.com/anthropics/claude-code/issues/53915",
+      "title": "[BUG] API Error: Server is temporarily limiting requests (not your usage limit) · Rate limited",
+      "impact": "needs_review",
+      "categories": [
+        "rate_limit"
+      ],
+      "tokenkey_status": "candidate_unverified",
+      "rationale": "Gateway/relay-relevant keyword match; not yet manually verified against TokenKey code.",
+      "updated_at": "2026-06-03T06:32:36Z"
+    },
+    {
+      "upstream": "anthropics/claude-code#53922",
+      "url": "https://github.com/anthropics/claude-code/issues/53922",
+      "title": "[BUG] Parallel Claude Code sessions started right after 5-hour limit resets — first 3–4 work, the rest fail with \"Server is temporarily limiting requests (not your usage limit) · Rate limited\"",
+      "impact": "needs_review",
+      "categories": [
+        "rate_limit",
+        "auth_token",
+        "model_lifecycle"
+      ],
+      "tokenkey_status": "candidate_unverified",
+      "rationale": "Gateway/relay-relevant keyword match; not yet manually verified against TokenKey code.",
+      "updated_at": "2026-06-02T01:51:54Z"
+    },
+    {
+      "upstream": "anthropics/claude-code#54018",
+      "url": "https://github.com/anthropics/claude-code/issues/54018",
+      "title": "[BUG] Async subagent loops are silently dropped when the parent has concurrent activity",
+      "impact": "needs_review",
+      "categories": [
+        "request_shape_400"
+      ],
+      "tokenkey_status": "candidate_unverified",
+      "rationale": "Gateway/relay-relevant keyword match; not yet manually verified against TokenKey code.",
+      "updated_at": "2026-06-01T12:03:32Z"
+    },
+    {
+      "upstream": "anthropics/claude-code#54130",
+      "url": "https://github.com/anthropics/claude-code/issues/54130",
+      "title": "[BUG] Closed Claude Code sessions leave zombie subprocesses that corrupt session files (\"No message found with message.uuid\")",
+      "impact": "needs_review",
+      "categories": [
+        "model_lifecycle"
+      ],
+      "tokenkey_status": "candidate_unverified",
+      "rationale": "Gateway/relay-relevant keyword match; not yet manually verified against TokenKey code.",
+      "updated_at": "2026-05-31T10:41:39Z"
+    },
+    {
+      "upstream": "anthropics/claude-code#54225",
+      "url": "https://github.com/anthropics/claude-code/issues/54225",
+      "title": "[BUG] Sharing picture without text in Claude Code via Windows App causes session to stall permanently",
+      "impact": "needs_review",
+      "categories": [
+        "request_shape_400"
+      ],
+      "tokenkey_status": "candidate_unverified",
+      "rationale": "Gateway/relay-relevant keyword match; not yet manually verified against TokenKey code.",
+      "updated_at": "2026-06-01T12:02:05Z"
+    },
+    {
+      "upstream": "anthropics/claude-code#54393",
+      "url": "https://github.com/anthropics/claude-code/issues/54393",
+      "title": "Post-mortem 2026-04-28: 12 multi-agent coordination bugs surfaced across a single autonomous-overnight cycle",
+      "impact": "needs_review",
+      "categories": [
+        "rate_limit"
+      ],
+      "tokenkey_status": "candidate_unverified",
+      "rationale": "Gateway/relay-relevant keyword match; not yet manually verified against TokenKey code.",
+      "updated_at": "2026-06-02T22:03:47Z"
+    },
+    {
+      "upstream": "anthropics/claude-code#54434",
+      "url": "https://github.com/anthropics/claude-code/issues/54434",
+      "title": "[Bug] SSE stream stalls in long-running sessions without message_stop event",
+      "impact": "needs_review",
+      "categories": [
+        "rate_limit",
+        "auth_token",
+        "model_lifecycle"
+      ],
+      "tokenkey_status": "candidate_unverified",
+      "rationale": "Gateway/relay-relevant keyword match; not yet manually verified against TokenKey code.",
+      "updated_at": "2026-06-01T17:18:17Z"
+    },
+    {
+      "upstream": "anthropics/claude-code#54443",
+      "url": "https://github.com/anthropics/claude-code/issues/54443",
+      "title": "[BUG] OAuth refresh returns 400 after early 401 before local expiresAt; concurrent sessions forced to /login",
+      "impact": "needs_review",
+      "categories": [
+        "request_shape_400",
+        "auth_token"
+      ],
+      "tokenkey_status": "candidate_unverified",
+      "rationale": "Gateway/relay-relevant keyword match; not yet manually verified against TokenKey code.",
+      "updated_at": "2026-06-01T11:05:04Z"
+    },
+    {
+      "upstream": "anthropics/claude-code#54588",
+      "url": "https://github.com/anthropics/claude-code/issues/54588",
+      "title": "[BUG] Claude Max 20x subscription not recognized — account shows Free plan",
+      "impact": "needs_review",
+      "categories": [
+        "auth_token"
+      ],
+      "tokenkey_status": "candidate_unverified",
+      "rationale": "Gateway/relay-relevant keyword match; not yet manually verified against TokenKey code.",
+      "updated_at": "2026-06-01T22:45:50Z"
+    },
+    {
+      "upstream": "anthropics/claude-code#54595",
+      "url": "https://github.com/anthropics/claude-code/issues/54595",
+      "title": "Agent tool's foreground/sync dispatch silently removed and replaced with always-fork mode via undocumented Statsig rollout",
+      "impact": "needs_review",
+      "categories": [
+        "model_lifecycle"
+      ],
+      "tokenkey_status": "candidate_unverified",
+      "rationale": "Gateway/relay-relevant keyword match; not yet manually verified against TokenKey code.",
+      "updated_at": "2026-06-01T22:45:57Z"
+    },
+    {
+      "upstream": "anthropics/claude-code#54677",
+      "url": "https://github.com/anthropics/claude-code/issues/54677",
+      "title": "[Feature Request] Distinguish between API key and OAuth subscription billing in startup banner",
+      "impact": "needs_review",
+      "categories": [
+        "auth_token"
+      ],
+      "tokenkey_status": "candidate_unverified",
+      "rationale": "Gateway/relay-relevant keyword match; not yet manually verified against TokenKey code.",
+      "updated_at": "2026-06-02T22:44:29Z"
+    },
+    {
+      "upstream": "anthropics/claude-code#54817",
+      "url": "https://github.com/anthropics/claude-code/issues/54817",
+      "title": "[Bug] Claude Code 4.7 regression: degraded reasoning and project context loss",
+      "impact": "needs_review",
+      "categories": [
+        "rate_limit"
+      ],
+      "tokenkey_status": "candidate_unverified",
+      "rationale": "Gateway/relay-relevant keyword match; not yet manually verified against TokenKey code.",
+      "updated_at": "2026-06-02T22:44:10Z"
+    },
+    {
+      "upstream": "anthropics/claude-code#55021",
+      "url": "https://github.com/anthropics/claude-code/issues/55021",
+      "title": "Microsoft 365 MCP connector shows 'Needs Auth' in VS Code despite being connected in desktop app",
+      "impact": "needs_review",
+      "categories": [
+        "auth_token"
+      ],
+      "tokenkey_status": "candidate_unverified",
+      "rationale": "Gateway/relay-relevant keyword match; not yet manually verified against TokenKey code.",
+      "updated_at": "2026-06-01T12:02:01Z"
+    },
+    {
+      "upstream": "anthropics/claude-code#55051",
+      "url": "https://github.com/anthropics/claude-code/issues/55051",
+      "title": "You've hit your limit · resets 1:40pm (America/New_York)",
+      "impact": "needs_review",
+      "categories": [
+        "rate_limit"
+      ],
+      "tokenkey_status": "candidate_unverified",
+      "rationale": "Gateway/relay-relevant keyword match; not yet manually verified against TokenKey code.",
+      "updated_at": "2026-06-02T22:44:56Z"
+    },
+    {
+      "upstream": "anthropics/claude-code#55121",
+      "url": "https://github.com/anthropics/claude-code/issues/55121",
+      "title": "[BUG] Token counter appears to omit sub-agent consumption, causing up to 10× undercount",
+      "impact": "needs_review",
+      "categories": [
+        "auth_token"
+      ],
+      "tokenkey_status": "candidate_unverified",
+      "rationale": "Gateway/relay-relevant keyword match; not yet manually verified against TokenKey code.",
+      "updated_at": "2026-06-01T22:45:57Z"
+    },
+    {
+      "upstream": "anthropics/claude-code#55455",
+      "url": "https://github.com/anthropics/claude-code/issues/55455",
+      "title": "[BUG] Token drift in parallel Write tool calls: repeated path prefix produces real-word substitution (\"shane\" → \"seine\")",
+      "impact": "needs_review",
+      "categories": [
+        "model_lifecycle"
+      ],
+      "tokenkey_status": "candidate_unverified",
+      "rationale": "Gateway/relay-relevant keyword match; not yet manually verified against TokenKey code.",
+      "updated_at": "2026-06-01T22:45:16Z"
+    },
+    {
+      "upstream": "anthropics/claude-code#55598",
+      "url": "https://github.com/anthropics/claude-code/issues/55598",
+      "title": "[FEATURE] Environment variables for default and max effort level (shared-host admin use case)",
+      "impact": "needs_review",
+      "categories": [
+        "prompt_caching"
+      ],
+      "tokenkey_status": "candidate_unverified",
+      "rationale": "Gateway/relay-relevant keyword match; not yet manually verified against TokenKey code.",
+      "updated_at": "2026-06-01T22:46:13Z"
+    },
+    {
+      "upstream": "anthropics/claude-code#55910",
+      "url": "https://github.com/anthropics/claude-code/issues/55910",
+      "title": "API content filter blocks Contributor Covenant 2.1 verbatim output",
+      "impact": "needs_review",
+      "categories": [
+        "request_shape_400"
+      ],
+      "tokenkey_status": "candidate_unverified",
+      "rationale": "Gateway/relay-relevant keyword match; not yet manually verified against TokenKey code.",
+      "updated_at": "2026-06-01T12:02:31Z"
+    },
+    {
+      "upstream": "anthropics/claude-code#55954",
+      "url": "https://github.com/anthropics/claude-code/issues/55954",
+      "title": "[BUG] Remote MCP OAuth requests every scope from oauth-authorization-server.scopes_supported, causing invalid_scope on GitLab self-hosted",
+      "impact": "needs_review",
+      "categories": [
+        "auth_token"
+      ],
+      "tokenkey_status": "candidate_unverified",
+      "rationale": "Gateway/relay-relevant keyword match; not yet manually verified against TokenKey code.",
+      "updated_at": "2026-06-02T13:50:05Z"
+    },
+    {
+      "upstream": "anthropics/claude-code#56059",
+      "url": "https://github.com/anthropics/claude-code/issues/56059",
+      "title": "[BUG] ECONNRESET on every API call — macOS 26 Tahoe, Darwin 25.4.0, ARM64",
+      "impact": "needs_review",
+      "categories": [
+        "auth_token",
+        "fingerprint_ua"
+      ],
+      "tokenkey_status": "candidate_unverified",
+      "rationale": "Gateway/relay-relevant keyword match; not yet manually verified against TokenKey code.",
+      "updated_at": "2026-06-02T11:32:29Z"
+    },
+    {
+      "upstream": "anthropics/claude-code#56075",
+      "url": "https://github.com/anthropics/claude-code/issues/56075",
+      "title": "[BUG] Single README.md edit burns entire 5-hour Max 5x window in 9m 39s (Opus 4.7 1M, resumed session, v2.1.126, JetBrains, Windows)",
+      "impact": "needs_review",
+      "categories": [
+        "rate_limit",
+        "model_lifecycle",
+        "prompt_caching"
+      ],
+      "tokenkey_status": "candidate_unverified",
+      "rationale": "Gateway/relay-relevant keyword match; not yet manually verified against TokenKey code.",
+      "updated_at": "2026-05-31T22:11:19Z"
+    },
+    {
+      "upstream": "anthropics/claude-code#56356",
+      "url": "https://github.com/anthropics/claude-code/issues/56356",
+      "title": "Opus 4.7 returns no thinking blocks even with --thinking adaptive --thinking-display summarized",
+      "impact": "needs_review",
+      "categories": [
+        "auth_token",
+        "model_lifecycle"
+      ],
+      "tokenkey_status": "candidate_unverified",
+      "rationale": "Gateway/relay-relevant keyword match; not yet manually verified against TokenKey code.",
+      "updated_at": "2026-06-01T15:17:33Z"
+    },
+    {
+      "upstream": "anthropics/claude-code#56633",
+      "url": "https://github.com/anthropics/claude-code/issues/56633",
+      "title": "[BUG] Misleading \"Rate limit reached\" error when model is at capacity — caused me to waste resources creating new account",
+      "impact": "needs_review",
+      "categories": [
+        "rate_limit"
+      ],
+      "tokenkey_status": "candidate_unverified",
+      "rationale": "Gateway/relay-relevant keyword match; not yet manually verified against TokenKey code.",
+      "updated_at": "2026-06-02T23:22:34Z"
+    },
+    {
+      "upstream": "anthropics/claude-code#56872",
+      "url": "https://github.com/anthropics/claude-code/issues/56872",
+      "title": "MCP server \"ide\" connection fails immediately on startup - IntelliJ IDEA plugin 0.1.14-beta",
+      "impact": "needs_review",
+      "categories": [
+        "request_shape_400"
+      ],
+      "tokenkey_status": "candidate_unverified",
+      "rationale": "Gateway/relay-relevant keyword match; not yet manually verified against TokenKey code.",
+      "updated_at": "2026-06-01T10:50:11Z"
+    },
+    {
+      "upstream": "anthropics/claude-code#56978",
+      "url": "https://github.com/anthropics/claude-code/issues/56978",
+      "title": "Graceful handling when hitting usage limits mid-session",
+      "impact": "needs_review",
+      "categories": [
+        "rate_limit"
+      ],
+      "tokenkey_status": "candidate_unverified",
+      "rationale": "Gateway/relay-relevant keyword match; not yet manually verified against TokenKey code.",
+      "updated_at": "2026-06-01T05:37:07Z"
+    },
+    {
+      "upstream": "anthropics/claude-code#56984",
+      "url": "https://github.com/anthropics/claude-code/issues/56984",
+      "title": "[BUG] CLAUDE_CODE_EXTRA_BODY thinking config breaks WebSearch and WebFetch on Opus 4.7 [1m]",
+      "impact": "needs_review",
+      "categories": [
+        "request_shape_400",
+        "model_lifecycle"
+      ],
+      "tokenkey_status": "candidate_unverified",
+      "rationale": "Gateway/relay-relevant keyword match; not yet manually verified against TokenKey code.",
+      "updated_at": "2026-06-01T12:03:27Z"
+    },
+    {
+      "upstream": "anthropics/claude-code#57242",
+      "url": "https://github.com/anthropics/claude-code/issues/57242",
+      "title": "Windows 11: Claude Code interactive claude command frozen in all terminals; non‑interactive and doctor work",
+      "impact": "needs_review",
+      "categories": [
+        "auth_token"
+      ],
+      "tokenkey_status": "candidate_unverified",
+      "rationale": "Gateway/relay-relevant keyword match; not yet manually verified against TokenKey code.",
+      "updated_at": "2026-06-02T03:15:17Z"
+    },
+    {
+      "upstream": "anthropics/claude-code#57492",
+      "url": "https://github.com/anthropics/claude-code/issues/57492",
+      "title": "[BUG] Repeated API errors, stream idle timeouts, and excessive retry loops causing wasted credits and failed sessions",
+      "impact": "needs_review",
+      "categories": [
+        "model_lifecycle"
+      ],
+      "tokenkey_status": "candidate_unverified",
+      "rationale": "Gateway/relay-relevant keyword match; not yet manually verified against TokenKey code.",
+      "updated_at": "2026-06-02T10:48:35Z"
+    },
+    {
+      "upstream": "anthropics/claude-code#58217",
+      "url": "https://github.com/anthropics/claude-code/issues/58217",
+      "title": "[BUG]Advisor tool injects same-tier opus calls into every opus subagent, doubling spend invisibly",
+      "impact": "needs_review",
+      "categories": [
+        "model_lifecycle"
+      ],
+      "tokenkey_status": "candidate_unverified",
+      "rationale": "Gateway/relay-relevant keyword match; not yet manually verified against TokenKey code.",
+      "updated_at": "2026-06-02T22:44:17Z"
+    },
+    {
+      "upstream": "anthropics/claude-code#58294",
+      "url": "https://github.com/anthropics/claude-code/issues/58294",
+      "title": "MCP tool calls to api.anthropic.com blocked by Cloudflare WAF (SQL injection rule false positive)",
+      "impact": "needs_review",
+      "categories": [
+        "model_lifecycle",
+        "fingerprint_ua"
+      ],
+      "tokenkey_status": "candidate_unverified",
+      "rationale": "Gateway/relay-relevant keyword match; not yet manually verified against TokenKey code.",
+      "updated_at": "2026-06-01T09:29:28Z"
+    },
+    {
+      "upstream": "anthropics/claude-code#58392",
+      "url": "https://github.com/anthropics/claude-code/issues/58392",
+      "title": "Atlassian MCP plugin still on deprecated HTTP+SSE — 30 June 2026 cutoff (~7 weeks); re-filing closed #38853",
+      "impact": "needs_review",
+      "categories": [
+        "model_lifecycle"
+      ],
+      "tokenkey_status": "candidate_unverified",
+      "rationale": "Gateway/relay-relevant keyword match; not yet manually verified against TokenKey code.",
+      "updated_at": "2026-06-01T15:57:49Z"
+    },
+    {
+      "upstream": "anthropics/claude-code#58463",
+      "url": "https://github.com/anthropics/claude-code/issues/58463",
+      "title": "[Regression bug] TranscriptEvent write delay: AskUserQuestion tool_use event not written to session.jsonl until user responds.",
+      "impact": "needs_review",
+      "categories": [
+        "request_shape_400"
+      ],
+      "tokenkey_status": "candidate_unverified",
+      "rationale": "Gateway/relay-relevant keyword match; not yet manually verified against TokenKey code.",
+      "updated_at": "2026-06-01T22:45:51Z"
+    },
+    {
+      "upstream": "anthropics/claude-code#58859",
+      "url": "https://github.com/anthropics/claude-code/issues/58859",
+      "title": "[DOCS] Plugin docs missing `CLAUDE_CODE_PLUGIN_PREFER_HTTPS` for GitHub sources",
+      "impact": "needs_review",
+      "categories": [
+        "fingerprint_ua"
+      ],
+      "tokenkey_status": "candidate_unverified",
+      "rationale": "Gateway/relay-relevant keyword match; not yet manually verified against TokenKey code.",
+      "updated_at": "2026-06-01T01:11:37Z"
+    },
+    {
+      "upstream": "anthropics/claude-code#58879",
+      "url": "https://github.com/anthropics/claude-code/issues/58879",
+      "title": "[DOCS] Agent view omits 5-minute retirement for empty idle background sessions",
+      "impact": "needs_review",
+      "categories": [
+        "model_lifecycle"
+      ],
+      "tokenkey_status": "candidate_unverified",
+      "rationale": "Gateway/relay-relevant keyword match; not yet manually verified against TokenKey code.",
+      "updated_at": "2026-06-01T01:08:39Z"
+    },
+    {
+      "upstream": "anthropics/claude-code#58933",
+      "url": "https://github.com/anthropics/claude-code/issues/58933",
+      "title": "Claude Code provides no in-session determinism mechanism, forcing automation users onto the metered Agent SDK path",
+      "impact": "needs_review",
+      "categories": [
+        "auth_token"
+      ],
+      "tokenkey_status": "candidate_unverified",
+      "rationale": "Gateway/relay-relevant keyword match; not yet manually verified against TokenKey code.",
+      "updated_at": "2026-06-03T04:56:29Z"
+    },
+    {
+      "upstream": "anthropics/claude-code#59108",
+      "url": "https://github.com/anthropics/claude-code/issues/59108",
+      "title": "[BUG] `claude -p` / `claude --print` has control-plane parity risks across hooks, permissions, skills, MCP, auth, and subagents",
+      "impact": "needs_review",
+      "categories": [
+        "beta_header_drift",
+        "fingerprint_ua"
+      ],
+      "tokenkey_status": "candidate_unverified",
+      "rationale": "Gateway/relay-relevant keyword match; not yet manually verified against TokenKey code.",
+      "updated_at": "2026-06-01T03:41:03Z"
+    },
+    {
+      "upstream": "anthropics/claude-code#59281",
+      "url": "https://github.com/anthropics/claude-code/issues/59281",
+      "title": "API Error 529 and 500",
+      "impact": "needs_review",
+      "categories": [
+        "rate_limit"
+      ],
+      "tokenkey_status": "candidate_unverified",
+      "rationale": "Gateway/relay-relevant keyword match; not yet manually verified against TokenKey code.",
+      "updated_at": "2026-06-01T12:02:48Z"
+    },
+    {
+      "upstream": "anthropics/claude-code#59412",
+      "url": "https://github.com/anthropics/claude-code/issues/59412",
+      "title": "[FEATURE] Display token usage (session + weekly) in the agent view row",
+      "impact": "needs_review",
+      "categories": [
+        "model_lifecycle"
+      ],
+      "tokenkey_status": "candidate_unverified",
+      "rationale": "Gateway/relay-relevant keyword match; not yet manually verified against TokenKey code.",
+      "updated_at": "2026-05-31T10:41:18Z"
+    },
+    {
+      "upstream": "anthropics/claude-code#59451",
+      "url": "https://github.com/anthropics/claude-code/issues/59451",
+      "title": "Sessions auto-archiving every 30-90 min when launched from specific cwd bucket (since 2026-05-09)",
+      "impact": "needs_review",
+      "categories": [
+        "model_lifecycle"
+      ],
+      "tokenkey_status": "candidate_unverified",
+      "rationale": "Gateway/relay-relevant keyword match; not yet manually verified against TokenKey code.",
+      "updated_at": "2026-06-03T05:40:07Z"
+    },
+    {
+      "upstream": "anthropics/claude-code#59460",
+      "url": "https://github.com/anthropics/claude-code/issues/59460",
+      "title": "MCP OAuth: Claude Code re-runs DCR on every authenticate, orphaning the previously-issued client_id and its refresh_token",
+      "impact": "needs_review",
+      "categories": [
+        "auth_token",
+        "fingerprint_ua"
+      ],
+      "tokenkey_status": "candidate_unverified",
+      "rationale": "Gateway/relay-relevant keyword match; not yet manually verified against TokenKey code.",
+      "updated_at": "2026-06-02T11:33:17Z"
+    },
+    {
+      "upstream": "anthropics/claude-code#59564",
+      "url": "https://github.com/anthropics/claude-code/issues/59564",
+      "title": "[BUG] Cowork VM worker (vmwp.exe) overwrites host-side filesystem changes with stale VM-cached content on session startup",
+      "impact": "needs_review",
+      "categories": [
+        "model_lifecycle",
+        "fingerprint_ua"
+      ],
+      "tokenkey_status": "candidate_unverified",
+      "rationale": "Gateway/relay-relevant keyword match; not yet manually verified against TokenKey code.",
+      "updated_at": "2026-06-01T12:01:57Z"
+    },
+    {
+      "upstream": "anthropics/claude-code#59572",
+      "url": "https://github.com/anthropics/claude-code/issues/59572",
+      "title": "[BUG] Weekly \"all models\" counter dropping mid-cycle without reset (Max, Opus 4.7)",
+      "impact": "needs_review",
+      "categories": [
+        "prompt_caching"
+      ],
+      "tokenkey_status": "candidate_unverified",
+      "rationale": "Gateway/relay-relevant keyword match; not yet manually verified against TokenKey code.",
+      "updated_at": "2026-06-01T13:12:53Z"
+    },
+    {
+      "upstream": "anthropics/claude-code#59573",
+      "url": "https://github.com/anthropics/claude-code/issues/59573",
+      "title": "claude --print hangs on Sonnet 4-6 at default/high effort with large prompts",
+      "impact": "needs_review",
+      "categories": [
+        "request_shape_400",
+        "auth_token",
+        "model_lifecycle",
+        "prompt_caching"
+      ],
+      "tokenkey_status": "candidate_unverified",
+      "rationale": "Gateway/relay-relevant keyword match; not yet manually verified against TokenKey code.",
+      "updated_at": "2026-06-02T11:31:55Z"
+    },
+    {
+      "upstream": "anthropics/claude-code#59582",
+      "url": "https://github.com/anthropics/claude-code/issues/59582",
+      "title": "[DOCS] Background sessions docs omit effort-level persistence across idle wake",
+      "impact": "needs_review",
+      "categories": [
+        "model_lifecycle"
+      ],
+      "tokenkey_status": "candidate_unverified",
+      "rationale": "Gateway/relay-relevant keyword match; not yet manually verified against TokenKey code.",
+      "updated_at": "2026-06-01T01:33:40Z"
+    },
+    {
+      "upstream": "anthropics/claude-code#59590",
+      "url": "https://github.com/anthropics/claude-code/issues/59590",
+      "title": "[DOCS] `claude --bg --dangerously-skip-permissions` persistence across retire/wake is undocumented",
+      "impact": "needs_review",
+      "categories": [
+        "model_lifecycle"
+      ],
+      "tokenkey_status": "candidate_unverified",
+      "rationale": "Gateway/relay-relevant keyword match; not yet manually verified against TokenKey code.",
+      "updated_at": "2026-06-01T01:04:54Z"
+    },
+    {
+      "upstream": "anthropics/claude-code#59606",
+      "url": "https://github.com/anthropics/claude-code/issues/59606",
+      "title": "claude.ai/code: head branch not deleted after MCP-driven PR merge despite agent instructions",
+      "impact": "needs_review",
+      "categories": [
+        "auth_token",
+        "model_lifecycle"
+      ],
+      "tokenkey_status": "candidate_unverified",
+      "rationale": "Gateway/relay-relevant keyword match; not yet manually verified against TokenKey code.",
+      "updated_at": "2026-05-31T10:41:33Z"
+    },
+    {
+      "upstream": "anthropics/claude-code#59616",
+      "url": "https://github.com/anthropics/claude-code/issues/59616",
+      "title": "[Bug] Content filter rejection on benign test data containing \"Never Gonna Give You Up\" reference",
+      "impact": "needs_review",
+      "categories": [
+        "request_shape_400"
+      ],
+      "tokenkey_status": "candidate_unverified",
+      "rationale": "Gateway/relay-relevant keyword match; not yet manually verified against TokenKey code.",
+      "updated_at": "2026-05-31T10:41:38Z"
+    },
+    {
+      "upstream": "anthropics/claude-code#59619",
+      "url": "https://github.com/anthropics/claude-code/issues/59619",
+      "title": "[BUG] [DEP0190] Startup hook with complex shell command triggers Node.js deprecation warning on every SessionStart",
+      "impact": "needs_review",
+      "categories": [
+        "model_lifecycle"
+      ],
+      "tokenkey_status": "candidate_unverified",
+      "rationale": "Gateway/relay-relevant keyword match; not yet manually verified against TokenKey code.",
+      "updated_at": "2026-05-31T10:41:57Z"
+    },
+    {
+      "upstream": "anthropics/claude-code#59621",
+      "url": "https://github.com/anthropics/claude-code/issues/59621",
+      "title": "[BUG] Review crashed before producing findings",
+      "impact": "needs_review",
+      "categories": [
+        "rate_limit"
+      ],
+      "tokenkey_status": "candidate_unverified",
+      "rationale": "Gateway/relay-relevant keyword match; not yet manually verified against TokenKey code.",
+      "updated_at": "2026-05-31T23:05:00Z"
+    },
+    {
+      "upstream": "anthropics/claude-code#59626",
+      "url": "https://github.com/anthropics/claude-code/issues/59626",
+      "title": "API 400 \"cache_control cannot be set for empty text blocks\" when user message contains only an image",
+      "impact": "needs_review",
+      "categories": [
+        "request_shape_400",
+        "model_lifecycle",
+        "prompt_caching"
+      ],
+      "tokenkey_status": "candidate_unverified",
+      "rationale": "Gateway/relay-relevant keyword match; not yet manually verified against TokenKey code.",
+      "updated_at": "2026-05-31T10:41:47Z"
+    },
+    {
+      "upstream": "anthropics/claude-code#59631",
+      "url": "https://github.com/anthropics/claude-code/issues/59631",
+      "title": "[Bug] Sidebar context menu \"Fork\" creates two forked chats instead of one (Desktop)",
+      "impact": "needs_review",
+      "categories": [
+        "request_shape_400"
+      ],
+      "tokenkey_status": "candidate_unverified",
+      "rationale": "Gateway/relay-relevant keyword match; not yet manually verified against TokenKey code.",
+      "updated_at": "2026-05-31T10:41:45Z"
+    },
+    {
+      "upstream": "anthropics/claude-code#59634",
+      "url": "https://github.com/anthropics/claude-code/issues/59634",
+      "title": "[FEATURE] Rate-limit-aware deferred prompt scheduling for Claude Code",
+      "impact": "needs_review",
+      "categories": [
+        "rate_limit"
+      ],
+      "tokenkey_status": "candidate_unverified",
+      "rationale": "Gateway/relay-relevant keyword match; not yet manually verified against TokenKey code.",
+      "updated_at": "2026-06-02T11:32:00Z"
+    },
+    {
+      "upstream": "anthropics/claude-code#59642",
+      "url": "https://github.com/anthropics/claude-code/issues/59642",
+      "title": "Silent failure (exit 0, empty output) with CLAUDE_CONFIG_DIR isolation on 2.1.123+",
+      "impact": "needs_review",
+      "categories": [
+        "auth_token"
+      ],
+      "tokenkey_status": "candidate_unverified",
+      "rationale": "Gateway/relay-relevant keyword match; not yet manually verified against TokenKey code.",
+      "updated_at": "2026-05-31T10:41:49Z"
+    },
+    {
+      "upstream": "anthropics/claude-code#59650",
+      "url": "https://github.com/anthropics/claude-code/issues/59650",
+      "title": "Deferred MCP tool schemas inflate cache reads and per-turn token counts unnecessarily",
+      "impact": "needs_review",
+      "categories": [
+        "model_lifecycle"
+      ],
+      "tokenkey_status": "candidate_unverified",
+      "rationale": "Gateway/relay-relevant keyword match; not yet manually verified against TokenKey code.",
+      "updated_at": "2026-05-31T10:41:52Z"
+    },
+    {
+      "upstream": "anthropics/claude-code#59687",
+      "url": "https://github.com/anthropics/claude-code/issues/59687",
+      "title": "[BUG] ultrareview crashes before producing findings — credits consumed but no results returned",
+      "impact": "needs_review",
+      "categories": [
+        "rate_limit"
+      ],
+      "tokenkey_status": "candidate_unverified",
+      "rationale": "Gateway/relay-relevant keyword match; not yet manually verified against TokenKey code.",
+      "updated_at": "2026-06-01T22:45:08Z"
+    },
+    {
+      "upstream": "anthropics/claude-code#59689",
+      "url": "https://github.com/anthropics/claude-code/issues/59689",
+      "title": "[BUG] \"Prompt is too long\" error mid-response, session stuck with --resume for 8+ hours",
+      "impact": "needs_review",
+      "categories": [
+        "model_lifecycle"
+      ],
+      "tokenkey_status": "candidate_unverified",
+      "rationale": "Gateway/relay-relevant keyword match; not yet manually verified against TokenKey code.",
+      "updated_at": "2026-06-01T22:45:08Z"
+    },
+    {
+      "upstream": "anthropics/claude-code#59700",
+      "url": "https://github.com/anthropics/claude-code/issues/59700",
+      "title": "[BUG] org:create_api_key scope silently dropped from OAuth grant — Remote Control permanently broken on Max subscription",
+      "impact": "needs_review",
+      "categories": [
+        "rate_limit",
+        "auth_token"
+      ],
+      "tokenkey_status": "candidate_unverified",
+      "rationale": "Gateway/relay-relevant keyword match; not yet manually verified against TokenKey code.",
+      "updated_at": "2026-06-01T12:03:07Z"
+    },
+    {
+      "upstream": "anthropics/claude-code#59711",
+      "url": "https://github.com/anthropics/claude-code/issues/59711",
+      "title": "[BUG] Transcribing that should have been reproduced verbatim",
+      "impact": "needs_review",
+      "categories": [
+        "model_lifecycle"
+      ],
+      "tokenkey_status": "candidate_unverified",
+      "rationale": "Gateway/relay-relevant keyword match; not yet manually verified against TokenKey code.",
+      "updated_at": "2026-06-01T12:02:21Z"
+    },
+    {
+      "upstream": "anthropics/claude-code#59725",
+      "url": "https://github.com/anthropics/claude-code/issues/59725",
+      "title": "Slack MCP (mcp.slack.com) OAuth stores empty accessToken after completing flow; complete_authentication also broken",
+      "impact": "needs_review",
+      "categories": [
+        "auth_token"
+      ],
+      "tokenkey_status": "candidate_unverified",
+      "rationale": "Gateway/relay-relevant keyword match; not yet manually verified against TokenKey code.",
+      "updated_at": "2026-06-01T12:03:13Z"
+    },
+    {
+      "upstream": "anthropics/claude-code#59742",
+      "url": "https://github.com/anthropics/claude-code/issues/59742",
+      "title": "Built-in channel-reply guardrail for channel-routed plugins (e.g. Telegram)",
+      "impact": "needs_review",
+      "categories": [
+        "request_shape_400"
+      ],
+      "tokenkey_status": "candidate_unverified",
+      "rationale": "Gateway/relay-relevant keyword match; not yet manually verified against TokenKey code.",
+      "updated_at": "2026-06-01T12:03:03Z"
+    },
+    {
+      "upstream": "anthropics/claude-code#59746",
+      "url": "https://github.com/anthropics/claude-code/issues/59746",
+      "title": "[Bug] Anthropic API Error: 500 Internal Server Error with Claude 3.5 Opus",
+      "impact": "needs_review",
+      "categories": [
+        "request_shape_400"
+      ],
+      "tokenkey_status": "candidate_unverified",
+      "rationale": "Gateway/relay-relevant keyword match; not yet manually verified against TokenKey code.",
+      "updated_at": "2026-06-01T12:02:34Z"
+    },
+    {
+      "upstream": "anthropics/claude-code#59754",
+      "url": "https://github.com/anthropics/claude-code/issues/59754",
+      "title": "I don't have a bug report to analyze. Please provide the bug report or issue description so I can generate an appropriate GitHub issue title.",
+      "impact": "needs_review",
+      "categories": [
+        "request_shape_400",
+        "auth_token"
+      ],
+      "tokenkey_status": "candidate_unverified",
+      "rationale": "Gateway/relay-relevant keyword match; not yet manually verified against TokenKey code.",
+      "updated_at": "2026-06-01T12:02:38Z"
+    },
+    {
+      "upstream": "anthropics/claude-code#59791",
+      "url": "https://github.com/anthropics/claude-code/issues/59791",
+      "title": "[Bug] Anthropic API Error: Server rate limiting preventing all sessions",
+      "impact": "needs_review",
+      "categories": [
+        "rate_limit"
+      ],
+      "tokenkey_status": "candidate_unverified",
+      "rationale": "Gateway/relay-relevant keyword match; not yet manually verified against TokenKey code.",
+      "updated_at": "2026-06-01T12:03:02Z"
+    },
+    {
+      "upstream": "anthropics/claude-code#59809",
+      "url": "https://github.com/anthropics/claude-code/issues/59809",
+      "title": "QuickBooks connector stuck in 'Requested' status with no management options (no three dots, Remove button, or Cancel option)",
+      "impact": "needs_review",
+      "categories": [
+        "auth_token"
+      ],
+      "tokenkey_status": "candidate_unverified",
+      "rationale": "Gateway/relay-relevant keyword match; not yet manually verified against TokenKey code.",
+      "updated_at": "2026-06-01T12:03:16Z"
+    },
+    {
+      "upstream": "anthropics/claude-code#59831",
+      "url": "https://github.com/anthropics/claude-code/issues/59831",
+      "title": "[BUG] Claude Desktop Cowork freezes at “Authenticating” — LocalAgentModeSessions OAuth exchange never completes",
+      "impact": "needs_review",
+      "categories": [
+        "auth_token"
+      ],
+      "tokenkey_status": "candidate_unverified",
+      "rationale": "Gateway/relay-relevant keyword match; not yet manually verified against TokenKey code.",
+      "updated_at": "2026-06-01T22:45:14Z"
+    },
+    {
+      "upstream": "anthropics/claude-code#59841",
+      "url": "https://github.com/anthropics/claude-code/issues/59841",
+      "title": "[Feature/Policy] Provide an interactive-auth path for ACP/editor integrations so human-paced Claude Code use isn't billed as autonomous Agent SDK usage",
+      "impact": "needs_review",
+      "categories": [
+        "prompt_caching"
+      ],
+      "tokenkey_status": "candidate_unverified",
+      "rationale": "Gateway/relay-relevant keyword match; not yet manually verified against TokenKey code.",
+      "updated_at": "2026-06-02T22:42:33Z"
+    },
+    {
+      "upstream": "anthropics/claude-code#59843",
+      "url": "https://github.com/anthropics/claude-code/issues/59843",
+      "title": "[BUG] Approving a plan via \"Plan Approved\" UI button drops session into `default` mode instead of restoring prior permission mode",
+      "impact": "needs_review",
+      "categories": [
+        "request_shape_400"
+      ],
+      "tokenkey_status": "candidate_unverified",
+      "rationale": "Gateway/relay-relevant keyword match; not yet manually verified against TokenKey code.",
+      "updated_at": "2026-06-01T12:03:37Z"
+    },
+    {
+      "upstream": "anthropics/claude-code#59844",
+      "url": "https://github.com/anthropics/claude-code/issues/59844",
+      "title": "`showThinkingSummaries: true` silently no-ops on Opus 4.7 in non-interactive surfaces (VS Code extension, SDK, `--print`): one-line CLI fix or one-line extension fix",
+      "impact": "needs_review",
+      "categories": [
+        "request_shape_400",
+        "model_lifecycle"
+      ],
+      "tokenkey_status": "candidate_unverified",
+      "rationale": "Gateway/relay-relevant keyword match; not yet manually verified against TokenKey code.",
+      "updated_at": "2026-06-02T17:55:30Z"
+    },
+    {
+      "upstream": "anthropics/claude-code#59849",
+      "url": "https://github.com/anthropics/claude-code/issues/59849",
+      "title": "Voice dictation mic button silently fails — audio captured but no transcript inserted (desktop app, Windows)",
+      "impact": "needs_review",
+      "categories": [
+        "auth_token",
+        "model_lifecycle"
+      ],
+      "tokenkey_status": "candidate_unverified",
+      "rationale": "Gateway/relay-relevant keyword match; not yet manually verified against TokenKey code.",
+      "updated_at": "2026-06-01T12:03:34Z"
+    },
+    {
+      "upstream": "anthropics/claude-code#59854",
+      "url": "https://github.com/anthropics/claude-code/issues/59854",
+      "title": "[BUG] Cowork — GitHub connector unusable: OAuth DCR unsupported, UI shows misleading state, Disconnect button dead",
+      "impact": "needs_review",
+      "categories": [
+        "auth_token"
+      ],
+      "tokenkey_status": "candidate_unverified",
+      "rationale": "Gateway/relay-relevant keyword match; not yet manually verified against TokenKey code.",
+      "updated_at": "2026-06-01T12:03:39Z"
+    },
+    {
+      "upstream": "anthropics/claude-code#59886",
+      "url": "https://github.com/anthropics/claude-code/issues/59886",
+      "title": "Session/thread context lost mid-workflow, auto-memory saved us but reveals gaps in long-running project resilience",
+      "impact": "needs_review",
+      "categories": [
+        "auth_token"
+      ],
+      "tokenkey_status": "candidate_unverified",
+      "rationale": "Gateway/relay-relevant keyword match; not yet manually verified against TokenKey code.",
+      "updated_at": "2026-06-02T11:31:52Z"
+    },
+    {
+      "upstream": "anthropics/claude-code#59927",
+      "url": "https://github.com/anthropics/claude-code/issues/59927",
+      "title": "[BUG] ExitPlanMode \"Yes, clear context and use auto mode\" registers as rejection — infinite plan-mode loop (regression of #33479 / #33870)",
+      "impact": "needs_review",
+      "categories": [
+        "request_shape_400"
+      ],
+      "tokenkey_status": "candidate_unverified",
+      "rationale": "Gateway/relay-relevant keyword match; not yet manually verified against TokenKey code.",
+      "updated_at": "2026-06-01T22:45:26Z"
+    },
+    {
+      "upstream": "anthropics/claude-code#59934",
+      "url": "https://github.com/anthropics/claude-code/issues/59934",
+      "title": "[BUG] MSIX auto-update mid-session: AppContainer Job race breaks launch AND orphans the in-flight conversation (two-bug cascade, both with working fixes)",
+      "impact": "needs_review",
+      "categories": [
+        "request_shape_400"
+      ],
+      "tokenkey_status": "candidate_unverified",
+      "rationale": "Gateway/relay-relevant keyword match; not yet manually verified against TokenKey code.",
+      "updated_at": "2026-06-01T22:45:32Z"
+    },
+    {
+      "upstream": "anthropics/claude-code#59937",
+      "url": "https://github.com/anthropics/claude-code/issues/59937",
+      "title": "[BUG] Forced to Reauth after sleep",
+      "impact": "needs_review",
+      "categories": [
+        "auth_token"
+      ],
+      "tokenkey_status": "candidate_unverified",
+      "rationale": "Gateway/relay-relevant keyword match; not yet manually verified against TokenKey code.",
+      "updated_at": "2026-06-01T22:45:33Z"
+    },
+    {
+      "upstream": "anthropics/claude-code#59951",
+      "url": "https://github.com/anthropics/claude-code/issues/59951",
+      "title": "[FEATURE] - [Telemetry] Opt-in for verbatim plugin/skill labels on token.usage and cost.usage metrics",
+      "impact": "needs_review",
+      "categories": [
+        "prompt_caching"
+      ],
+      "tokenkey_status": "candidate_unverified",
+      "rationale": "Gateway/relay-relevant keyword match; not yet manually verified against TokenKey code.",
+      "updated_at": "2026-06-01T20:54:53Z"
+    },
+    {
+      "upstream": "anthropics/claude-code#59953",
+      "url": "https://github.com/anthropics/claude-code/issues/59953",
+      "title": "GitHub MCP returns 403 \"not authorized to use this Copilot feature\" on Claude Code web; OAuth fallback renders misleading \"Server Turned Down → Google Drive\" page",
+      "impact": "needs_review",
+      "categories": [
+        "auth_token",
+        "fingerprint_ua"
+      ],
+      "tokenkey_status": "candidate_unverified",
+      "rationale": "Gateway/relay-relevant keyword match; not yet manually verified against TokenKey code.",
+      "updated_at": "2026-06-01T22:45:38Z"
+    },
+    {
+      "upstream": "anthropics/claude-code#59973",
+      "url": "https://github.com/anthropics/claude-code/issues/59973",
+      "title": "session usage jumped 30% per prompt in less then 1 minute of entering the prompt",
+      "impact": "needs_review",
+      "categories": [
+        "rate_limit"
+      ],
+      "tokenkey_status": "candidate_unverified",
+      "rationale": "Gateway/relay-relevant keyword match; not yet manually verified against TokenKey code.",
+      "updated_at": "2026-06-01T22:45:46Z"
+    },
+    {
+      "upstream": "anthropics/claude-code#59975",
+      "url": "https://github.com/anthropics/claude-code/issues/59975",
+      "title": "[FEATURE] Expose runtime metadata (token usage, context %, compaction status) to the model inside the conversation",
+      "impact": "needs_review",
+      "categories": [
+        "prompt_caching"
+      ],
+      "tokenkey_status": "candidate_unverified",
+      "rationale": "Gateway/relay-relevant keyword match; not yet manually verified against TokenKey code.",
+      "updated_at": "2026-06-01T22:45:46Z"
+    },
+    {
+      "upstream": "anthropics/claude-code#59985",
+      "url": "https://github.com/anthropics/claude-code/issues/59985",
+      "title": "[Bug] Model generates confident but inaccurate responses on unfamiliar domains without uncertainty signaling",
+      "impact": "needs_review",
+      "categories": [
+        "request_shape_400"
+      ],
+      "tokenkey_status": "candidate_unverified",
+      "rationale": "Gateway/relay-relevant keyword match; not yet manually verified against TokenKey code.",
+      "updated_at": "2026-06-01T22:45:49Z"
+    },
+    {
+      "upstream": "anthropics/claude-code#60001",
+      "url": "https://github.com/anthropics/claude-code/issues/60001",
+      "title": "Background-Agent completion notifications drop silently when ≥3 parallel run_in_background agents dispatched",
+      "impact": "needs_review",
+      "categories": [
+        "model_lifecycle"
+      ],
+      "tokenkey_status": "candidate_unverified",
+      "rationale": "Gateway/relay-relevant keyword match; not yet manually verified against TokenKey code.",
+      "updated_at": "2026-06-01T20:44:53Z"
+    },
+    {
+      "upstream": "anthropics/claude-code#60033",
+      "url": "https://github.com/anthropics/claude-code/issues/60033",
+      "title": "Built-in Write tool: large escape-dense content intermittently yields malformed tool-input JSON; retry resends identical payload and also fails",
+      "impact": "needs_review",
+      "categories": [
+        "request_shape_400",
+        "model_lifecycle"
+      ],
+      "tokenkey_status": "candidate_unverified",
+      "rationale": "Gateway/relay-relevant keyword match; not yet manually verified against TokenKey code.",
+      "updated_at": "2026-06-01T22:46:15Z"
+    },
+    {
+      "upstream": "anthropics/claude-code#60042",
+      "url": "https://github.com/anthropics/claude-code/issues/60042",
+      "title": "[BUG] AskUserQuestion fails with \"Tool permission stream closed before response received\" when dispatched in a parallel batch alongside other tool calls",
+      "impact": "needs_review",
+      "categories": [
+        "new_endpoints"
+      ],
+      "tokenkey_status": "candidate_unverified",
+      "rationale": "Gateway/relay-relevant keyword match; not yet manually verified against TokenKey code.",
+      "updated_at": "2026-06-02T11:32:05Z"
+    },
+    {
+      "upstream": "anthropics/claude-code#60046",
+      "url": "https://github.com/anthropics/claude-code/issues/60046",
+      "title": "[MODEL] Repeated unresearched API changes broke production business system; explicit welfare instructions ignored throughout",
+      "impact": "needs_review",
+      "categories": [
+        "auth_token",
+        "model_lifecycle"
+      ],
+      "tokenkey_status": "candidate_unverified",
+      "rationale": "Gateway/relay-relevant keyword match; not yet manually verified against TokenKey code.",
+      "updated_at": "2026-06-01T22:46:18Z"
+    },
+    {
+      "upstream": "anthropics/claude-code#60051",
+      "url": "https://github.com/anthropics/claude-code/issues/60051",
+      "title": "[BUG] Desktop: misbehaving DXT can spam unblockable file-attach consent dialog with no UI escape",
+      "impact": "needs_review",
+      "categories": [
+        "rate_limit"
+      ],
+      "tokenkey_status": "candidate_unverified",
+      "rationale": "Gateway/relay-relevant keyword match; not yet manually verified against TokenKey code.",
+      "updated_at": "2026-06-02T22:43:59Z"
+    },
+    {
+      "upstream": "anthropics/claude-code#60070",
+      "url": "https://github.com/anthropics/claude-code/issues/60070",
+      "title": "critical scientific work blocked in mid-context, completely destroying the work developed in the context.",
+      "impact": "needs_review",
+      "categories": [
+        "request_shape_400",
+        "rate_limit"
+      ],
+      "tokenkey_status": "candidate_unverified",
+      "rationale": "Gateway/relay-relevant keyword match; not yet manually verified against TokenKey code.",
+      "updated_at": "2026-06-02T11:32:08Z"
+    },
+    {
+      "upstream": "anthropics/claude-code#60076",
+      "url": "https://github.com/anthropics/claude-code/issues/60076",
+      "title": "Once a session transcript trips AUP, --continue/--resume is permanently blocked with no in-product recovery",
+      "impact": "needs_review",
+      "categories": [
+        "model_lifecycle"
+      ],
+      "tokenkey_status": "candidate_unverified",
+      "rationale": "Gateway/relay-relevant keyword match; not yet manually verified against TokenKey code.",
+      "updated_at": "2026-06-02T11:32:23Z"
+    },
+    {
+      "upstream": "anthropics/claude-code#60084",
+      "url": "https://github.com/anthropics/claude-code/issues/60084",
+      "title": "There's an issue with the selected model (claude-opus-4.1). It may not exist or you may not have access to it. Run /model to pick a different model.",
+      "impact": "needs_review",
+      "categories": [
+        "model_lifecycle"
+      ],
+      "tokenkey_status": "candidate_unverified",
+      "rationale": "Gateway/relay-relevant keyword match; not yet manually verified against TokenKey code.",
+      "updated_at": "2026-06-02T11:32:19Z"
+    },
+    {
+      "upstream": "anthropics/claude-code#60096",
+      "url": "https://github.com/anthropics/claude-code/issues/60096",
+      "title": "[Bug] Anthropic API Error: Rate Limited - Credit Consumed Without Review Generated",
+      "impact": "needs_review",
+      "categories": [
+        "rate_limit"
+      ],
+      "tokenkey_status": "candidate_unverified",
+      "rationale": "Gateway/relay-relevant keyword match; not yet manually verified against TokenKey code.",
+      "updated_at": "2026-06-02T11:32:20Z"
+    },
+    {
+      "upstream": "anthropics/claude-code#60122",
+      "url": "https://github.com/anthropics/claude-code/issues/60122",
+      "title": "Claude Desktop: /tmp/claude-settings-<hash>.json not UID-namespaced — second macOS user hits EACCES, Claude Code panel \"crashes\"",
+      "impact": "needs_review",
+      "categories": [
+        "model_lifecycle"
+      ],
+      "tokenkey_status": "candidate_unverified",
+      "rationale": "Gateway/relay-relevant keyword match; not yet manually verified against TokenKey code.",
+      "updated_at": "2026-06-02T11:32:50Z"
+    },
+    {
+      "upstream": "anthropics/claude-code#60126",
+      "url": "https://github.com/anthropics/claude-code/issues/60126",
+      "title": "[BUG] /login does not auto-open browser in PowerShell/cmd on Windows 11 (works in VS Code integrated terminal)",
+      "impact": "needs_review",
+      "categories": [
+        "auth_token"
+      ],
+      "tokenkey_status": "candidate_unverified",
+      "rationale": "Gateway/relay-relevant keyword match; not yet manually verified against TokenKey code.",
+      "updated_at": "2026-06-02T11:32:49Z"
+    },
+    {
+      "upstream": "anthropics/claude-code#60138",
+      "url": "https://github.com/anthropics/claude-code/issues/60138",
+      "title": "Claude silently dropped an explicitly assigned task instead of doing it or flagging it",
+      "impact": "needs_review",
+      "categories": [
+        "rate_limit"
+      ],
+      "tokenkey_status": "candidate_unverified",
+      "rationale": "Gateway/relay-relevant keyword match; not yet manually verified against TokenKey code.",
+      "updated_at": "2026-06-02T11:33:11Z"
+    },
+    {
+      "upstream": "anthropics/claude-code#60162",
+      "url": "https://github.com/anthropics/claude-code/issues/60162",
+      "title": "Stop hook trace `No stderr output` fires every turn for passing hooks (session-scoped)",
+      "impact": "needs_review",
+      "categories": [
+        "model_lifecycle"
+      ],
+      "tokenkey_status": "candidate_unverified",
+      "rationale": "Gateway/relay-relevant keyword match; not yet manually verified against TokenKey code.",
+      "updated_at": "2026-06-02T11:32:59Z"
+    },
+    {
+      "upstream": "anthropics/claude-code#60168",
+      "url": "https://github.com/anthropics/claude-code/issues/60168",
+      "title": "[BUG] Please finally fix the JSON low surrogate issue.",
+      "impact": "needs_review",
+      "categories": [
+        "request_shape_400"
+      ],
+      "tokenkey_status": "candidate_unverified",
+      "rationale": "Gateway/relay-relevant keyword match; not yet manually verified against TokenKey code.",
+      "updated_at": "2026-06-02T11:33:09Z"
+    },
+    {
+      "upstream": "anthropics/claude-code#60197",
+      "url": "https://github.com/anthropics/claude-code/issues/60197",
+      "title": "[BUG] Edit tool silently misses some Edits in a rapid Edit + git mv + commit sequence (selective miss within same commit; refuted hypothesis 2 vs 1+3 still open)",
+      "impact": "needs_review",
+      "categories": [
+        "auth_token"
+      ],
+      "tokenkey_status": "candidate_unverified",
+      "rationale": "Gateway/relay-relevant keyword match; not yet manually verified against TokenKey code.",
+      "updated_at": "2026-06-02T22:44:03Z"
+    },
+    {
+      "upstream": "anthropics/claude-code#60200",
+      "url": "https://github.com/anthropics/claude-code/issues/60200",
+      "title": "Make /effort auto context-adaptive (currently it just resolves to the model's static default)",
+      "impact": "needs_review",
+      "categories": [
+        "request_shape_400",
+        "model_lifecycle"
+      ],
+      "tokenkey_status": "candidate_unverified",
+      "rationale": "Gateway/relay-relevant keyword match; not yet manually verified against TokenKey code.",
+      "updated_at": "2026-06-02T22:44:04Z"
+    },
+    {
+      "upstream": "anthropics/claude-code#60202",
+      "url": "https://github.com/anthropics/claude-code/issues/60202",
+      "title": "[FEATURE] Training data gap: Spring Boot 4 is not covered (released Nov 20, 2025)",
+      "impact": "needs_review",
+      "categories": [
+        "model_lifecycle"
+      ],
+      "tokenkey_status": "candidate_unverified",
+      "rationale": "Gateway/relay-relevant keyword match; not yet manually verified against TokenKey code.",
+      "updated_at": "2026-06-02T22:44:05Z"
+    },
+    {
+      "upstream": "anthropics/claude-code#60252",
+      "url": "https://github.com/anthropics/claude-code/issues/60252",
+      "title": "[BUG] --strict-mcp-config with empty --mcp-config still fetches MCP registry and attempts user-configured servers",
+      "impact": "needs_review",
+      "categories": [
+        "auth_token",
+        "model_lifecycle",
+        "new_endpoints"
+      ],
+      "tokenkey_status": "candidate_unverified",
+      "rationale": "Gateway/relay-relevant keyword match; not yet manually verified against TokenKey code.",
+      "updated_at": "2026-06-02T22:44:11Z"
+    },
+    {
+      "upstream": "anthropics/claude-code#60284",
+      "url": "https://github.com/anthropics/claude-code/issues/60284",
+      "title": "MCP M365 Teams chat_message_search timing out (no response)",
+      "impact": "needs_review",
+      "categories": [
+        "rate_limit"
+      ],
+      "tokenkey_status": "candidate_unverified",
+      "rationale": "Gateway/relay-relevant keyword match; not yet manually verified against TokenKey code.",
+      "updated_at": "2026-06-02T22:44:24Z"
+    },
+    {
+      "upstream": "anthropics/claude-code#60288",
+      "url": "https://github.com/anthropics/claude-code/issues/60288",
+      "title": "[Bug] CLI hangs indefinitely when reading small files",
+      "impact": "needs_review",
+      "categories": [
+        "request_shape_400"
+      ],
+      "tokenkey_status": "candidate_unverified",
+      "rationale": "Gateway/relay-relevant keyword match; not yet manually verified against TokenKey code.",
+      "updated_at": "2026-06-02T22:44:26Z"
+    },
+    {
+      "upstream": "anthropics/claude-code#60307",
+      "url": "https://github.com/anthropics/claude-code/issues/60307",
+      "title": "Regression: claude hangs post-TLS-handshake in agent loop on Debian 12 (2.1.101+ broken, 2.1.100 works)",
+      "impact": "needs_review",
+      "categories": [
+        "auth_token"
+      ],
+      "tokenkey_status": "candidate_unverified",
+      "rationale": "Gateway/relay-relevant keyword match; not yet manually verified against TokenKey code.",
+      "updated_at": "2026-06-02T22:44:42Z"
+    },
+    {
+      "upstream": "anthropics/claude-code#60313",
+      "url": "https://github.com/anthropics/claude-code/issues/60313",
+      "title": "[BUG] Cloud session permanently stuck on \"API Error 400: text content blocks must be non-empty\" — no in-app recovery path",
+      "impact": "needs_review",
+      "categories": [
+        "request_shape_400",
+        "fingerprint_ua"
+      ],
+      "tokenkey_status": "candidate_unverified",
+      "rationale": "Gateway/relay-relevant keyword match; not yet manually verified against TokenKey code.",
+      "updated_at": "2026-06-02T22:44:36Z"
+    },
+    {
+      "upstream": "anthropics/claude-code#60316",
+      "url": "https://github.com/anthropics/claude-code/issues/60316",
+      "title": "Expose `cache_control.ttl` (5m / 1h) as a user-configurable setting",
+      "impact": "needs_review",
+      "categories": [
+        "request_shape_400",
+        "model_lifecycle",
+        "prompt_caching"
+      ],
+      "tokenkey_status": "candidate_unverified",
+      "rationale": "Gateway/relay-relevant keyword match; not yet manually verified against TokenKey code.",
+      "updated_at": "2026-06-02T22:44:38Z"
+    },
+    {
+      "upstream": "anthropics/claude-code#60327",
+      "url": "https://github.com/anthropics/claude-code/issues/60327",
+      "title": "[FEATURE]: way for Claude Code to query an externally-maintained design system (e.g. Claude Design)",
+      "impact": "needs_review",
+      "categories": [
+        "model_lifecycle"
+      ],
+      "tokenkey_status": "candidate_unverified",
+      "rationale": "Gateway/relay-relevant keyword match; not yet manually verified against TokenKey code.",
+      "updated_at": "2026-06-02T22:44:49Z"
+    },
+    {
+      "upstream": "anthropics/claude-code#60364",
+      "url": "https://github.com/anthropics/claude-code/issues/60364",
+      "title": "Slack MCP via browser session tokens (xoxc/xoxd) unreliable on Enterprise Grid — request first-class OAuth-based Slack MCP",
+      "impact": "needs_review",
+      "categories": [
+        "auth_token"
+      ],
+      "tokenkey_status": "candidate_unverified",
+      "rationale": "Gateway/relay-relevant keyword match; not yet manually verified against TokenKey code.",
+      "updated_at": "2026-06-02T22:44:58Z"
+    },
+    {
+      "upstream": "anthropics/claude-code#60438",
+      "url": "https://github.com/anthropics/claude-code/issues/60438",
+      "title": "Persistent HTTP 429 on auto-mode classifier (xml_s1), account-side config",
+      "impact": "needs_review",
+      "categories": [
+        "rate_limit",
+        "model_lifecycle"
+      ],
+      "tokenkey_status": "candidate_unverified",
+      "rationale": "Gateway/relay-relevant keyword match; not yet manually verified against TokenKey code.",
+      "updated_at": "2026-06-01T19:08:07Z"
+    },
+    {
+      "upstream": "anthropics/claude-code#60583",
+      "url": "https://github.com/anthropics/claude-code/issues/60583",
+      "title": "[BUG] Cross-session blindness causes three-stage failure: incomplete refactor → misdiagnosis → unauthorized revert",
+      "impact": "needs_review",
+      "categories": [
+        "auth_token",
+        "model_lifecycle"
+      ],
+      "tokenkey_status": "candidate_unverified",
+      "rationale": "Gateway/relay-relevant keyword match; not yet manually verified against TokenKey code.",
+      "updated_at": "2026-06-03T05:02:50Z"
+    },
+    {
+      "upstream": "anthropics/claude-code#60669",
+      "url": "https://github.com/anthropics/claude-code/issues/60669",
+      "title": "[BUG]",
+      "impact": "needs_review",
+      "categories": [
+        "model_lifecycle"
+      ],
+      "tokenkey_status": "candidate_unverified",
+      "rationale": "Gateway/relay-relevant keyword match; not yet manually verified against TokenKey code.",
+      "updated_at": "2026-06-02T14:58:36Z"
+    },
+    {
+      "upstream": "anthropics/claude-code#61012",
+      "url": "https://github.com/anthropics/claude-code/issues/61012",
+      "title": "Usage limit reached repeatedly without active use — Pro plan",
+      "impact": "needs_review",
+      "categories": [
+        "auth_token"
+      ],
+      "tokenkey_status": "candidate_unverified",
+      "rationale": "Gateway/relay-relevant keyword match; not yet manually verified against TokenKey code.",
+      "updated_at": "2026-06-02T20:21:45Z"
+    },
+    {
+      "upstream": "anthropics/claude-code#61313",
+      "url": "https://github.com/anthropics/claude-code/issues/61313",
+      "title": "[BUG] Publish @anthropic-ai/claude-code-freebsd-x64 (and -arm64) native binary packages",
+      "impact": "needs_review",
+      "categories": [
+        "model_lifecycle"
+      ],
+      "tokenkey_status": "candidate_unverified",
+      "rationale": "Gateway/relay-relevant keyword match; not yet manually verified against TokenKey code.",
+      "updated_at": "2026-06-02T10:41:06Z"
+    },
+    {
+      "upstream": "anthropics/claude-code#61634",
+      "url": "https://github.com/anthropics/claude-code/issues/61634",
+      "title": "[BUG] False-positive Usage Policy refusal mid-stream on a markdown comparison table",
+      "impact": "needs_review",
+      "categories": [
+        "model_lifecycle"
+      ],
+      "tokenkey_status": "candidate_unverified",
+      "rationale": "Gateway/relay-relevant keyword match; not yet manually verified against TokenKey code.",
+      "updated_at": "2026-06-01T06:32:30Z"
+    },
+    {
+      "upstream": "anthropics/claude-code#61646",
+      "url": "https://github.com/anthropics/claude-code/issues/61646",
+      "title": "False-positive cyber-safeguard intervention on legitimate systems-engineering work in Claude Code",
+      "impact": "needs_review",
+      "categories": [
+        "auth_token"
+      ],
+      "tokenkey_status": "candidate_unverified",
+      "rationale": "Gateway/relay-relevant keyword match; not yet manually verified against TokenKey code.",
+      "updated_at": "2026-06-01T06:33:00Z"
+    },
+    {
+      "upstream": "anthropics/claude-code#61889",
+      "url": "https://github.com/anthropics/claude-code/issues/61889",
+      "title": "CVP approved user being blocked on completely benign, non-security queries in fresh sessions on claude.ai (not Claude Code).",
+      "impact": "needs_review",
+      "categories": [
+        "model_lifecycle"
+      ],
+      "tokenkey_status": "candidate_unverified",
+      "rationale": "Gateway/relay-relevant keyword match; not yet manually verified against TokenKey code.",
+      "updated_at": "2026-06-02T23:43:02Z"
+    },
+    {
+      "upstream": "anthropics/claude-code#61890",
+      "url": "https://github.com/anthropics/claude-code/issues/61890",
+      "title": "[BUG] Remote Control: \"is not yet enabled for your account\" persists for Max user across all documented troubleshooting steps",
+      "impact": "needs_review",
+      "categories": [
+        "rate_limit",
+        "auth_token",
+        "fingerprint_ua"
+      ],
+      "tokenkey_status": "candidate_unverified",
+      "rationale": "Gateway/relay-relevant keyword match; not yet manually verified against TokenKey code.",
+      "updated_at": "2026-05-31T21:49:13Z"
+    },
+    {
+      "upstream": "anthropics/claude-code#61895",
+      "url": "https://github.com/anthropics/claude-code/issues/61895",
+      "title": "[BUG] acli (Atlassian's official CLI tool) using OAuth fails in Claude Code but works in macOS Terminal",
+      "impact": "needs_review",
+      "categories": [
+        "auth_token"
+      ],
+      "tokenkey_status": "candidate_unverified",
+      "rationale": "Gateway/relay-relevant keyword match; not yet manually verified against TokenKey code.",
+      "updated_at": "2026-06-02T17:32:48Z"
+    },
+    {
+      "upstream": "anthropics/claude-code#61941",
+      "url": "https://github.com/anthropics/claude-code/issues/61941",
+      "title": "[Bug] Usage Policy cyber-safeguards block parallel headless Task() subagents doing localhost QA",
+      "impact": "needs_review",
+      "categories": [
+        "model_lifecycle"
+      ],
+      "tokenkey_status": "candidate_unverified",
+      "rationale": "Gateway/relay-relevant keyword match; not yet manually verified against TokenKey code.",
+      "updated_at": "2026-06-01T06:32:40Z"
+    },
+    {
+      "upstream": "anthropics/claude-code#62015",
+      "url": "https://github.com/anthropics/claude-code/issues/62015",
+      "title": "[BUG] Claude Code corrupted FlutterFlow project via deprecated proto field in MCP integration — server-level damage, project completely frozen",
+      "impact": "needs_review",
+      "categories": [
+        "model_lifecycle"
+      ],
+      "tokenkey_status": "candidate_unverified",
+      "rationale": "Gateway/relay-relevant keyword match; not yet manually verified against TokenKey code.",
+      "updated_at": "2026-05-31T11:01:53Z"
+    },
+    {
+      "upstream": "anthropics/claude-code#62063",
+      "url": "https://github.com/anthropics/claude-code/issues/62063",
+      "title": "[BUG] Claude Code defaults to 1M context on fresh session with no workaround on Pro plan",
+      "impact": "needs_review",
+      "categories": [
+        "model_lifecycle"
+      ],
+      "tokenkey_status": "candidate_unverified",
+      "rationale": "Gateway/relay-relevant keyword match; not yet manually verified against TokenKey code.",
+      "updated_at": "2026-06-03T00:15:41Z"
+    },
+    {
+      "upstream": "anthropics/claude-code#62265",
+      "url": "https://github.com/anthropics/claude-code/issues/62265",
+      "title": "Usage cap: single ~30k-token prompt (no subagents) burned 38% of 5h Max 20x limit on Opus 4.7",
+      "impact": "needs_review",
+      "categories": [
+        "model_lifecycle"
+      ],
+      "tokenkey_status": "candidate_unverified",
+      "rationale": "Gateway/relay-relevant keyword match; not yet manually verified against TokenKey code.",
+      "updated_at": "2026-06-01T08:37:30Z"
+    },
+    {
+      "upstream": "anthropics/claude-code#62314",
+      "url": "https://github.com/anthropics/claude-code/issues/62314",
+      "title": "Sonnet 4.6 routes every request to long-context tier on Claude Desktop 2.1.149 (429 'Usage credits required')",
+      "impact": "needs_review",
+      "categories": [
+        "rate_limit",
+        "model_lifecycle"
+      ],
+      "tokenkey_status": "candidate_unverified",
+      "rationale": "Gateway/relay-relevant keyword match; not yet manually verified against TokenKey code.",
+      "updated_at": "2026-06-01T14:46:59Z"
+    },
+    {
+      "upstream": "anthropics/claude-code#62353",
+      "url": "https://github.com/anthropics/claude-code/issues/62353",
+      "title": "[BUG] --resume normalizes model ID, breaking custom API endpoints that require the original model name",
+      "impact": "needs_review",
+      "categories": [
+        "auth_token"
+      ],
+      "tokenkey_status": "candidate_unverified",
+      "rationale": "Gateway/relay-relevant keyword match; not yet manually verified against TokenKey code.",
+      "updated_at": "2026-06-01T03:55:31Z"
+    },
+    {
+      "upstream": "anthropics/claude-code#62376",
+      "url": "https://github.com/anthropics/claude-code/issues/62376",
+      "title": "Claude Code agent set Meta Ads budget 100x wrong — caused NT$11,168 (USD ~$350) financial loss",
+      "impact": "needs_review",
+      "categories": [
+        "model_lifecycle"
+      ],
+      "tokenkey_status": "candidate_unverified",
+      "rationale": "Gateway/relay-relevant keyword match; not yet manually verified against TokenKey code.",
+      "updated_at": "2026-06-02T03:15:28Z"
+    },
+    {
+      "upstream": "anthropics/claude-code#62378",
+      "url": "https://github.com/anthropics/claude-code/issues/62378",
+      "title": "[BUG] PTY leak: Claude desktop app accumulates ~490 /dev/ptmx file descriptors",
+      "impact": "needs_review",
+      "categories": [
+        "new_endpoints"
+      ],
+      "tokenkey_status": "candidate_unverified",
+      "rationale": "Gateway/relay-relevant keyword match; not yet manually verified against TokenKey code.",
+      "updated_at": "2026-06-02T17:08:56Z"
+    },
+    {
+      "upstream": "anthropics/claude-code#62556",
+      "url": "https://github.com/anthropics/claude-code/issues/62556",
+      "title": "[BUG] Cowork macOS: all claude.ai-hosted MCP connectors fail — desktop OAuth token requested without `user:mcp_servers` scope",
+      "impact": "needs_review",
+      "categories": [
+        "auth_token"
+      ],
+      "tokenkey_status": "candidate_unverified",
+      "rationale": "Gateway/relay-relevant keyword match; not yet manually verified against TokenKey code.",
+      "updated_at": "2026-06-02T18:48:14Z"
+    },
+    {
+      "upstream": "anthropics/claude-code#62644",
+      "url": "https://github.com/anthropics/claude-code/issues/62644",
+      "title": "[BUG] \"Buy credits\" button permanently disabled - Free tier account incorrectly shows $500 limit, HTTP 429 errors on billing page",
+      "impact": "needs_review",
+      "categories": [
+        "rate_limit"
+      ],
+      "tokenkey_status": "candidate_unverified",
+      "rationale": "Gateway/relay-relevant keyword match; not yet manually verified against TokenKey code.",
+      "updated_at": "2026-06-02T08:42:31Z"
+    },
+    {
+      "upstream": "anthropics/claude-code#62871",
+      "url": "https://github.com/anthropics/claude-code/issues/62871",
+      "title": "Claude Desktop 3P mode — inferenceCustomHeaders not applied to HTTP requests",
+      "impact": "needs_review",
+      "categories": [
+        "auth_token"
+      ],
+      "tokenkey_status": "candidate_unverified",
+      "rationale": "Gateway/relay-relevant keyword match; not yet manually verified against TokenKey code.",
+      "updated_at": "2026-06-01T13:01:21Z"
+    },
+    {
+      "upstream": "anthropics/claude-code#62885",
+      "url": "https://github.com/anthropics/claude-code/issues/62885",
+      "title": "[Bug] Anthropic API Error: Missing corresponding server_tool_use block for advisor_tool_result",
+      "impact": "needs_review",
+      "categories": [
+        "request_shape_400"
+      ],
+      "tokenkey_status": "candidate_unverified",
+      "rationale": "Gateway/relay-relevant keyword match; not yet manually verified against TokenKey code.",
+      "updated_at": "2026-05-31T22:55:48Z"
+    },
+    {
+      "upstream": "anthropics/claude-code#62924",
+      "url": "https://github.com/anthropics/claude-code/issues/62924",
+      "title": "[BUG] Remote Control bridge fails with \"/login\" on macOS desktop app despite valid claude.ai auth",
+      "impact": "needs_review",
+      "categories": [
+        "auth_token"
+      ],
+      "tokenkey_status": "candidate_unverified",
+      "rationale": "Gateway/relay-relevant keyword match; not yet manually verified against TokenKey code.",
+      "updated_at": "2026-06-01T20:06:28Z"
+    },
+    {
+      "upstream": "anthropics/claude-code#62983",
+      "url": "https://github.com/anthropics/claude-code/issues/62983",
+      "title": "Opus 4.7 behavioral regression: loaded instruction-following discipline degraded in recent Claude Code/Cowork updates",
+      "impact": "needs_review",
+      "categories": [
+        "model_lifecycle"
+      ],
+      "tokenkey_status": "candidate_unverified",
+      "rationale": "Gateway/relay-relevant keyword match; not yet manually verified against TokenKey code.",
+      "updated_at": "2026-06-02T17:32:40Z"
+    },
+    {
+      "upstream": "anthropics/claude-code#63015",
+      "url": "https://github.com/anthropics/claude-code/issues/63015",
+      "title": "[Bug] Auto-compact never triggers despite statusline reporting \"100% context used\" (v2.1.153, Max sub, 200K mode)",
+      "impact": "needs_review",
+      "categories": [
+        "auth_token",
+        "model_lifecycle",
+        "prompt_caching"
+      ],
+      "tokenkey_status": "candidate_unverified",
+      "rationale": "Gateway/relay-relevant keyword match; not yet manually verified against TokenKey code.",
+      "updated_at": "2026-06-03T03:11:43Z"
+    },
+    {
+      "upstream": "anthropics/claude-code#63120",
+      "url": "https://github.com/anthropics/claude-code/issues/63120",
+      "title": "[BUG] 2.1.153 silently discards tools/list response from rmcp 0.12.0 HTTP MCP server (works in 2.1.152, wire-identical handshake)",
+      "impact": "needs_review",
+      "categories": [
+        "request_shape_400",
+        "fingerprint_ua"
+      ],
+      "tokenkey_status": "candidate_unverified",
+      "rationale": "Gateway/relay-relevant keyword match; not yet manually verified against TokenKey code.",
+      "updated_at": "2026-05-31T20:19:43Z"
+    },
+    {
+      "upstream": "anthropics/claude-code#63141",
+      "url": "https://github.com/anthropics/claude-code/issues/63141",
+      "title": "Subagents on Pro 1M tier: trivial probes pass, real workloads fail at first tool call (probe-vs-workload divergence)",
+      "impact": "needs_review",
+      "categories": [
+        "auth_token",
+        "model_lifecycle"
+      ],
+      "tokenkey_status": "candidate_unverified",
+      "rationale": "Gateway/relay-relevant keyword match; not yet manually verified against TokenKey code.",
+      "updated_at": "2026-05-31T12:35:09Z"
+    },
+    {
+      "upstream": "anthropics/claude-code#63147",
+      "url": "https://github.com/anthropics/claude-code/issues/63147",
+      "title": "Resuming an extended-thinking session fails permanently with 400 \"thinking blocks cannot be modified\" (transcript stores thinking text as empty but keeps signature)",
+      "impact": "needs_review",
+      "categories": [
+        "request_shape_400"
+      ],
+      "tokenkey_status": "candidate_unverified",
+      "rationale": "Gateway/relay-relevant keyword match; not yet manually verified against TokenKey code.",
+      "updated_at": "2026-06-01T01:45:00Z"
+    },
+    {
+      "upstream": "anthropics/claude-code#63192",
+      "url": "https://github.com/anthropics/claude-code/issues/63192",
+      "title": "Cancelling a parallel tool-call batch corrupts thinking blocks -> 400 \"thinking blocks cannot be modified\" permanently wedges the session",
+      "impact": "needs_review",
+      "categories": [
+        "request_shape_400",
+        "model_lifecycle",
+        "new_endpoints"
+      ],
+      "tokenkey_status": "candidate_unverified",
+      "rationale": "Gateway/relay-relevant keyword match; not yet manually verified against TokenKey code.",
+      "updated_at": "2026-05-31T19:24:52Z"
+    },
+    {
+      "upstream": "anthropics/claude-code#63199",
+      "url": "https://github.com/anthropics/claude-code/issues/63199",
+      "title": "[Bug] Anthropic API Error: Cannot Modify Thinking Blocks in Assistant Messages",
+      "impact": "needs_review",
+      "categories": [
+        "request_shape_400"
+      ],
+      "tokenkey_status": "candidate_unverified",
+      "rationale": "Gateway/relay-relevant keyword match; not yet manually verified against TokenKey code.",
+      "updated_at": "2026-05-31T13:57:19Z"
+    },
+    {
+      "upstream": "anthropics/claude-code#63275",
+      "url": "https://github.com/anthropics/claude-code/issues/63275",
+      "title": "[BUG] \"400 Guardrail was enabled\" error when using Claude Opus 4.8 with AWS Bedrock",
+      "impact": "needs_review",
+      "categories": [
+        "request_shape_400",
+        "model_lifecycle"
+      ],
+      "tokenkey_status": "candidate_unverified",
+      "rationale": "Gateway/relay-relevant keyword match; not yet manually verified against TokenKey code.",
+      "updated_at": "2026-06-02T15:51:18Z"
+    },
+    {
+      "upstream": "anthropics/claude-code#63335",
+      "url": "https://github.com/anthropics/claude-code/issues/63335",
+      "title": "Extended thinking: signed thinking block 'cannot be modified' (400) permanently wedges session",
+      "impact": "needs_review",
+      "categories": [
+        "request_shape_400",
+        "new_endpoints",
+        "fingerprint_ua"
+      ],
+      "tokenkey_status": "candidate_unverified",
+      "rationale": "Gateway/relay-relevant keyword match; not yet manually verified against TokenKey code.",
+      "updated_at": "2026-06-01T12:21:15Z"
+    },
+    {
+      "upstream": "anthropics/claude-code#63358",
+      "url": "https://github.com/anthropics/claude-code/issues/63358",
+      "title": "Opus 4.8 returns empty thinking blocks — no thinking shown in chat (same regression as Opus 4.7 #49268)",
+      "impact": "needs_review",
+      "categories": [
+        "model_lifecycle"
+      ],
+      "tokenkey_status": "candidate_unverified",
+      "rationale": "Gateway/relay-relevant keyword match; not yet manually verified against TokenKey code.",
+      "updated_at": "2026-06-02T23:24:47Z"
+    },
+    {
+      "upstream": "anthropics/claude-code#63375",
+      "url": "https://github.com/anthropics/claude-code/issues/63375",
+      "title": "[BUG] Slash command (/usage) during in-flight advisor() call splits assistant message in JSONL, permanently 400s the session (v2.1.154; repro of stale-closed #50527)",
+      "impact": "needs_review",
+      "categories": [
+        "request_shape_400"
+      ],
+      "tokenkey_status": "candidate_unverified",
+      "rationale": "Gateway/relay-relevant keyword match; not yet manually verified against TokenKey code.",
+      "updated_at": "2026-06-02T08:47:45Z"
+    },
+    {
+      "upstream": "anthropics/claude-code#63396",
+      "url": "https://github.com/anthropics/claude-code/issues/63396",
+      "title": "[BUG] CLI 2.1.154 builds invalid request after context ops (compact/clear/model-switch): system role at messages[0], and modified signed thinking blocks → 400 Error -> Wedged",
+      "impact": "needs_review",
+      "categories": [
+        "request_shape_400"
+      ],
+      "tokenkey_status": "candidate_unverified",
+      "rationale": "Gateway/relay-relevant keyword match; not yet manually verified against TokenKey code.",
+      "updated_at": "2026-05-31T15:16:36Z"
+    },
+    {
+      "upstream": "anthropics/claude-code#63420",
+      "url": "https://github.com/anthropics/claude-code/issues/63420",
+      "title": "[Bug] Anthropic API Error: Cannot modify thinking blocks in assistant message",
+      "impact": "needs_review",
+      "categories": [
+        "request_shape_400"
+      ],
+      "tokenkey_status": "candidate_unverified",
+      "rationale": "Gateway/relay-relevant keyword match; not yet manually verified against TokenKey code.",
+      "updated_at": "2026-05-31T11:33:50Z"
+    },
+    {
+      "upstream": "anthropics/claude-code#63454",
+      "url": "https://github.com/anthropics/claude-code/issues/63454",
+      "title": "[BUG] API Error: 400 Failed to deserialize the JSON body into the target type",
+      "impact": "needs_review",
+      "categories": [
+        "request_shape_400"
+      ],
+      "tokenkey_status": "candidate_unverified",
+      "rationale": "Gateway/relay-relevant keyword match; not yet manually verified against TokenKey code.",
+      "updated_at": "2026-06-03T05:13:49Z"
+    },
+    {
+      "upstream": "anthropics/claude-code#63469",
+      "url": "https://github.com/anthropics/claude-code/issues/63469",
+      "title": "[BUG] API 400 \"messages[1].role must be either 'user' or 'assistant', but got 'system'\" (v2.1.156)",
+      "impact": "needs_review",
+      "categories": [
+        "request_shape_400"
+      ],
+      "tokenkey_status": "candidate_unverified",
+      "rationale": "Gateway/relay-relevant keyword match; not yet manually verified against TokenKey code.",
+      "updated_at": "2026-06-01T09:36:24Z"
+    },
+    {
+      "upstream": "anthropics/claude-code#63499",
+      "url": "https://github.com/anthropics/claude-code/issues/63499",
+      "title": "[BUG] /compact fails with cyber safeguards false positive during legitimate defensive security session",
+      "impact": "needs_review",
+      "categories": [
+        "fingerprint_ua"
+      ],
+      "tokenkey_status": "candidate_unverified",
+      "rationale": "Gateway/relay-relevant keyword match; not yet manually verified against TokenKey code.",
+      "updated_at": "2026-06-01T06:32:38Z"
+    },
+    {
+      "upstream": "anthropics/claude-code#63538",
+      "url": "https://github.com/anthropics/claude-code/issues/63538",
+      "title": "Model fabricates tool output (and even a user instruction) when a parallel batch is partially cancelled / appears empty",
+      "impact": "needs_review",
+      "categories": [
+        "model_lifecycle"
+      ],
+      "tokenkey_status": "candidate_unverified",
+      "rationale": "Gateway/relay-relevant keyword match; not yet manually verified against TokenKey code.",
+      "updated_at": "2026-06-01T01:32:54Z"
+    },
+    {
+      "upstream": "anthropics/claude-code#63634",
+      "url": "https://github.com/anthropics/claude-code/issues/63634",
+      "title": "[Bug] /compact fails with \"Usage credits required for 1M context\" even after /model set to Sonnet 4.6",
+      "impact": "needs_review",
+      "categories": [
+        "model_lifecycle",
+        "prompt_caching"
+      ],
+      "tokenkey_status": "candidate_unverified",
+      "rationale": "Gateway/relay-relevant keyword match; not yet manually verified against TokenKey code.",
+      "updated_at": "2026-06-03T00:01:24Z"
+    },
+    {
+      "upstream": "anthropics/claude-code#63642",
+      "url": "https://github.com/anthropics/claude-code/issues/63642",
+      "title": "[BUG] Claude hangs with no output on Linux Mint despite all-green",
+      "impact": "needs_review",
+      "categories": [
+        "auth_token"
+      ],
+      "tokenkey_status": "candidate_unverified",
+      "rationale": "Gateway/relay-relevant keyword match; not yet manually verified against TokenKey code.",
+      "updated_at": "2026-06-01T09:22:26Z"
+    },
+    {
+      "upstream": "anthropics/claude-code#63654",
+      "url": "https://github.com/anthropics/claude-code/issues/63654",
+      "title": "/model picker does not list newly available models (Opus 4.7, 4.8)",
+      "impact": "needs_review",
+      "categories": [
+        "model_lifecycle"
+      ],
+      "tokenkey_status": "candidate_unverified",
+      "rationale": "Gateway/relay-relevant keyword match; not yet manually verified against TokenKey code.",
+      "updated_at": "2026-06-01T10:43:05Z"
+    },
+    {
+      "upstream": "anthropics/claude-code#63677",
+      "url": "https://github.com/anthropics/claude-code/issues/63677",
+      "title": "[BUG] Using the 2.1.156 version of the Claude Code for VS Code extension",
+      "impact": "needs_review",
+      "categories": [
+        "request_shape_400"
+      ],
+      "tokenkey_status": "candidate_unverified",
+      "rationale": "Gateway/relay-relevant keyword match; not yet manually verified against TokenKey code.",
+      "updated_at": "2026-06-01T18:22:08Z"
+    },
+    {
+      "upstream": "anthropics/claude-code#63685",
+      "url": "https://github.com/anthropics/claude-code/issues/63685",
+      "title": "Your organization has disabled Claude subscription access for Claude Code · Use an Anthropic API key instead, or ask your admin to enable access",
+      "impact": "needs_review",
+      "categories": [
+        "auth_token"
+      ],
+      "tokenkey_status": "candidate_unverified",
+      "rationale": "Gateway/relay-relevant keyword match; not yet manually verified against TokenKey code.",
+      "updated_at": "2026-05-31T17:38:36Z"
+    },
+    {
+      "upstream": "anthropics/claude-code#63693",
+      "url": "https://github.com/anthropics/claude-code/issues/63693",
+      "title": "[FEATURE] Expose model configuration for subagents in dynamic workflows",
+      "impact": "needs_review",
+      "categories": [
+        "rate_limit",
+        "model_lifecycle"
+      ],
+      "tokenkey_status": "candidate_unverified",
+      "rationale": "Gateway/relay-relevant keyword match; not yet manually verified against TokenKey code.",
+      "updated_at": "2026-05-31T22:34:46Z"
+    },
+    {
+      "upstream": "anthropics/claude-code#63751",
+      "url": "https://github.com/anthropics/claude-code/issues/63751",
+      "title": "[BUG] AUP/cyber-safeguard false positives on legitimate own-software hardening; one hit contaminates entire session",
+      "impact": "needs_review",
+      "categories": [
+        "model_lifecycle"
+      ],
+      "tokenkey_status": "candidate_unverified",
+      "rationale": "Gateway/relay-relevant keyword match; not yet manually verified against TokenKey code.",
+      "updated_at": "2026-06-01T15:56:52Z"
+    },
+    {
+      "upstream": "anthropics/claude-code#63754",
+      "url": "https://github.com/anthropics/claude-code/issues/63754",
+      "title": "[BUG] Cowork — account enrolled in two A/B variants (`testfoo` + `0526`) causing skill misfires + connector failure; `ENABLE_TOOL_SEARCH` mismatch",
+      "impact": "needs_review",
+      "categories": [
+        "auth_token",
+        "fingerprint_ua"
+      ],
+      "tokenkey_status": "candidate_unverified",
+      "rationale": "Gateway/relay-relevant keyword match; not yet manually verified against TokenKey code.",
+      "updated_at": "2026-06-02T16:12:23Z"
+    },
+    {
+      "upstream": "anthropics/claude-code#63797",
+      "url": "https://github.com/anthropics/claude-code/issues/63797",
+      "title": "Bash/Read tool results intermittently return empty (then flush late, redundantly) on Linux — NOT length/concurrency-correlated; same symptom as stale-closed #36038",
+      "impact": "needs_review",
+      "categories": [
+        "request_shape_400"
+      ],
+      "tokenkey_status": "candidate_unverified",
+      "rationale": "Gateway/relay-relevant keyword match; not yet manually verified against TokenKey code.",
+      "updated_at": "2026-06-01T03:38:44Z"
+    },
+    {
+      "upstream": "anthropics/claude-code#63806",
+      "url": "https://github.com/anthropics/claude-code/issues/63806",
+      "title": "AskUserQuestion blocks invisibly behind the thinking spinner (no prompt shown) when extended thinking is active",
+      "impact": "needs_review",
+      "categories": [
+        "model_lifecycle"
+      ],
+      "tokenkey_status": "candidate_unverified",
+      "rationale": "Gateway/relay-relevant keyword match; not yet manually verified against TokenKey code.",
+      "updated_at": "2026-06-03T03:58:32Z"
+    },
+    {
+      "upstream": "anthropics/claude-code#63825",
+      "url": "https://github.com/anthropics/claude-code/issues/63825",
+      "title": "[BUG] TypeError \"undefined is not an object (evaluating 'H.replace')\" replaces Bash tool output",
+      "impact": "needs_review",
+      "categories": [
+        "request_shape_400",
+        "new_endpoints"
+      ],
+      "tokenkey_status": "candidate_unverified",
+      "rationale": "Gateway/relay-relevant keyword match; not yet manually verified against TokenKey code.",
+      "updated_at": "2026-05-31T12:44:07Z"
+    },
+    {
+      "upstream": "anthropics/claude-code#63861",
+      "url": "https://github.com/anthropics/claude-code/issues/63861",
+      "title": "[BUG] Opus 4.8 in Claude Code declares work \"verified\" / \"done\" without running the canonical build — false-green regression vs. Opus 4.7",
+      "impact": "needs_review",
+      "categories": [
+        "model_lifecycle",
+        "new_endpoints"
+      ],
+      "tokenkey_status": "candidate_unverified",
+      "rationale": "Gateway/relay-relevant keyword match; not yet manually verified against TokenKey code.",
+      "updated_at": "2026-06-01T01:18:08Z"
+    },
+    {
+      "upstream": "anthropics/claude-code#63869",
+      "url": "https://github.com/anthropics/claude-code/issues/63869",
+      "title": "[BUG] API Error: 400 — thinking or redacted_thinking blocks in the latest assistant message cannot be modified.",
+      "impact": "needs_review",
+      "categories": [
+        "request_shape_400"
+      ],
+      "tokenkey_status": "candidate_unverified",
+      "rationale": "Gateway/relay-relevant keyword match; not yet manually verified against TokenKey code.",
+      "updated_at": "2026-05-31T19:47:15Z"
+    },
+    {
+      "upstream": "anthropics/claude-code#63870",
+      "url": "https://github.com/anthropics/claude-code/issues/63870",
+      "title": "[BUG] Bash tool calls emitted as raw <invoke> text instead of executing",
+      "impact": "needs_review",
+      "categories": [
+        "request_shape_400"
+      ],
+      "tokenkey_status": "candidate_unverified",
+      "rationale": "Gateway/relay-relevant keyword match; not yet manually verified against TokenKey code.",
+      "updated_at": "2026-06-03T01:25:16Z"
+    },
+    {
+      "upstream": "anthropics/claude-code#63875",
+      "url": "https://github.com/anthropics/claude-code/issues/63875",
+      "title": "Recurring error: \"The model's tool call could not be parsed (retry also failed)\" interrupts sessions",
+      "impact": "needs_review",
+      "categories": [
+        "model_lifecycle"
+      ],
+      "tokenkey_status": "candidate_unverified",
+      "rationale": "Gateway/relay-relevant keyword match; not yet manually verified against TokenKey code.",
+      "updated_at": "2026-06-03T02:48:01Z"
+    },
+    {
+      "upstream": "anthropics/claude-code#63880",
+      "url": "https://github.com/anthropics/claude-code/issues/63880",
+      "title": "[Bug] Advisor narrates but then fails to make tool calls",
+      "impact": "needs_review",
+      "categories": [
+        "request_shape_400",
+        "model_lifecycle"
+      ],
+      "tokenkey_status": "candidate_unverified",
+      "rationale": "Gateway/relay-relevant keyword match; not yet manually verified against TokenKey code.",
+      "updated_at": "2026-06-01T17:17:46Z"
+    },
+    {
+      "upstream": "anthropics/claude-code#63885",
+      "url": "https://github.com/anthropics/claude-code/issues/63885",
+      "title": "API Error: 400 — surrogates not allowed when dragging macOS screenshots",
+      "impact": "needs_review",
+      "categories": [
+        "request_shape_400",
+        "model_lifecycle"
+      ],
+      "tokenkey_status": "candidate_unverified",
+      "rationale": "Gateway/relay-relevant keyword match; not yet manually verified against TokenKey code.",
+      "updated_at": "2026-06-02T08:56:48Z"
+    },
+    {
+      "upstream": "anthropics/claude-code#63886",
+      "url": "https://github.com/anthropics/claude-code/issues/63886",
+      "title": "Your organization has disabled Claude subscription access for Claude Code · Use an Anthropic API key instead, or ask your admin to enable access",
+      "impact": "needs_review",
+      "categories": [
+        "auth_token"
+      ],
+      "tokenkey_status": "candidate_unverified",
+      "rationale": "Gateway/relay-relevant keyword match; not yet manually verified against TokenKey code.",
+      "updated_at": "2026-06-01T08:17:53Z"
+    },
+    {
+      "upstream": "anthropics/claude-code#63887",
+      "url": "https://github.com/anthropics/claude-code/issues/63887",
+      "title": "[Bug] Agent spams no-op echo probe commands to flush shell output",
+      "impact": "needs_review",
+      "categories": [
+        "model_lifecycle"
+      ],
+      "tokenkey_status": "candidate_unverified",
+      "rationale": "Gateway/relay-relevant keyword match; not yet manually verified against TokenKey code.",
+      "updated_at": "2026-06-01T02:45:45Z"
+    },
+    {
+      "upstream": "anthropics/claude-code#63896",
+      "url": "https://github.com/anthropics/claude-code/issues/63896",
+      "title": "[BUG] Error: Error during compaction: API Error: Usage credits required for 1M context · turn on usage credits at claude.ai/settings/usage, or use --model to switch to standard context",
+      "impact": "needs_review",
+      "categories": [
+        "model_lifecycle"
+      ],
+      "tokenkey_status": "candidate_unverified",
+      "rationale": "Gateway/relay-relevant keyword match; not yet manually verified against TokenKey code.",
+      "updated_at": "2026-06-03T06:22:27Z"
+    },
+    {
+      "upstream": "anthropics/claude-code#63929",
+      "url": "https://github.com/anthropics/claude-code/issues/63929",
+      "title": "[BUG] Server is temporarily limiting requests",
+      "impact": "needs_review",
+      "categories": [
+        "model_lifecycle"
+      ],
+      "tokenkey_status": "candidate_unverified",
+      "rationale": "Gateway/relay-relevant keyword match; not yet manually verified against TokenKey code.",
+      "updated_at": "2026-06-02T02:02:09Z"
+    },
+    {
+      "upstream": "anthropics/claude-code#63930",
+      "url": "https://github.com/anthropics/claude-code/issues/63930",
+      "title": "Prompt cache fully re-created after turns with many parallel tool calls (cache_read collapses to system+tools floor) — ~74% of cache writes wasted on Opus 4.8 / v2.1.15x",
+      "impact": "needs_review",
+      "categories": [
+        "request_shape_400",
+        "model_lifecycle",
+        "prompt_caching"
+      ],
+      "tokenkey_status": "candidate_unverified",
+      "rationale": "Gateway/relay-relevant keyword match; not yet manually verified against TokenKey code.",
+      "updated_at": "2026-06-01T17:31:12Z"
+    },
+    {
+      "upstream": "anthropics/claude-code#63966",
+      "url": "https://github.com/anthropics/claude-code/issues/63966",
+      "title": "[BUG] Tool-call results empty in live UI then flush late/out-of-order (Bash, Read, MCP, advisor) — macOS, Opus 4.8, parallel batches",
+      "impact": "needs_review",
+      "categories": [
+        "request_shape_400",
+        "auth_token",
+        "model_lifecycle",
+        "new_endpoints"
+      ],
+      "tokenkey_status": "candidate_unverified",
+      "rationale": "Gateway/relay-relevant keyword match; not yet manually verified against TokenKey code.",
+      "updated_at": "2026-05-31T23:33:17Z"
+    },
+    {
+      "upstream": "anthropics/claude-code#64007",
+      "url": "https://github.com/anthropics/claude-code/issues/64007",
+      "title": "cct = TUI: turn-transition render omission — content recorded in .jsonl but absent from scrollback (2 incidents across 2 versions)",
+      "impact": "needs_review",
+      "categories": [
+        "request_shape_400"
+      ],
+      "tokenkey_status": "candidate_unverified",
+      "rationale": "Gateway/relay-relevant keyword match; not yet manually verified against TokenKey code.",
+      "updated_at": "2026-06-01T21:11:50Z"
+    },
+    {
+      "upstream": "anthropics/claude-code#64030",
+      "url": "https://github.com/anthropics/claude-code/issues/64030",
+      "title": "CLI surfaces transient 429 \"rate_limit_error\" to user with no backoff/retry; session sits idle until user types `continue`",
+      "impact": "needs_review",
+      "categories": [
+        "request_shape_400",
+        "rate_limit",
+        "auth_token"
+      ],
+      "tokenkey_status": "candidate_unverified",
+      "rationale": "Gateway/relay-relevant keyword match; not yet manually verified against TokenKey code.",
+      "updated_at": "2026-05-31T23:47:00Z"
+    },
+    {
+      "upstream": "anthropics/claude-code#64034",
+      "url": "https://github.com/anthropics/claude-code/issues/64034",
+      "title": "[Bug] Context usage discrepancy between CLI and web/desktop UI causing incorrect billing",
+      "impact": "needs_review",
+      "categories": [
+        "auth_token"
+      ],
+      "tokenkey_status": "candidate_unverified",
+      "rationale": "Gateway/relay-relevant keyword match; not yet manually verified against TokenKey code.",
+      "updated_at": "2026-06-02T03:19:49Z"
+    },
+    {
+      "upstream": "anthropics/claude-code#64047",
+      "url": "https://github.com/anthropics/claude-code/issues/64047",
+      "title": "[BUG] Automatic parallel-tool-call cancellation is indistinguishable from a user interrupt",
+      "impact": "needs_review",
+      "categories": [
+        "new_endpoints"
+      ],
+      "tokenkey_status": "candidate_unverified",
+      "rationale": "Gateway/relay-relevant keyword match; not yet manually verified against TokenKey code.",
+      "updated_at": "2026-06-01T19:01:41Z"
+    },
+    {
+      "upstream": "anthropics/claude-code#64049",
+      "url": "https://github.com/anthropics/claude-code/issues/64049",
+      "title": "[MODEL] Opus 4.8 (max effort) likely hallucinated a prompt-injection in tool output, then acted on it for many turns",
+      "impact": "needs_review",
+      "categories": [
+        "request_shape_400",
+        "model_lifecycle"
+      ],
+      "tokenkey_status": "candidate_unverified",
+      "rationale": "Gateway/relay-relevant keyword match; not yet manually verified against TokenKey code.",
+      "updated_at": "2026-05-31T16:19:46Z"
+    },
+    {
+      "upstream": "anthropics/claude-code#64065",
+      "url": "https://github.com/anthropics/claude-code/issues/64065",
+      "title": "Opus 4.8 / xhigh / Claude Code: model asserts specific tool-output values BEFORE the tool calls return — model self-diagnoses the bug in-context but keeps doing it",
+      "impact": "needs_review",
+      "categories": [
+        "request_shape_400",
+        "model_lifecycle"
+      ],
+      "tokenkey_status": "candidate_unverified",
+      "rationale": "Gateway/relay-relevant keyword match; not yet manually verified against TokenKey code.",
+      "updated_at": "2026-05-31T19:56:17Z"
+    },
+    {
+      "upstream": "anthropics/claude-code#64080",
+      "url": "https://github.com/anthropics/claude-code/issues/64080",
+      "title": "Harness silently executes duplicated parallel tool_use blocks: subagent fan-out runs N× the intended count (6 → 24)",
+      "impact": "needs_review",
+      "categories": [
+        "request_shape_400",
+        "new_endpoints",
+        "fingerprint_ua"
+      ],
+      "tokenkey_status": "candidate_unverified",
+      "rationale": "Gateway/relay-relevant keyword match; not yet manually verified against TokenKey code.",
+      "updated_at": "2026-06-01T16:43:04Z"
+    },
+    {
+      "upstream": "anthropics/claude-code#64088",
+      "url": "https://github.com/anthropics/claude-code/issues/64088",
+      "title": "[BUG] API Error: Server is temporarily limiting requests (not your usage limit) · Rate limited",
+      "impact": "needs_review",
+      "categories": [
+        "rate_limit"
+      ],
+      "tokenkey_status": "candidate_unverified",
+      "rationale": "Gateway/relay-relevant keyword match; not yet manually verified against TokenKey code.",
+      "updated_at": "2026-05-31T15:45:42Z"
+    },
+    {
+      "upstream": "anthropics/claude-code#64097",
+      "url": "https://github.com/anthropics/claude-code/issues/64097",
+      "title": "[Bug] Claude Opus 4.8 emits malformed tool calls with parsing errors",
+      "impact": "needs_review",
+      "categories": [
+        "model_lifecycle"
+      ],
+      "tokenkey_status": "candidate_unverified",
+      "rationale": "Gateway/relay-relevant keyword match; not yet manually verified against TokenKey code.",
+      "updated_at": "2026-06-01T12:33:17Z"
+    },
+    {
+      "upstream": "anthropics/claude-code#64127",
+      "url": "https://github.com/anthropics/claude-code/issues/64127",
+      "title": "Spurious \"tool call was malformed and could not be parsed\" appended after successful tool calls",
+      "impact": "needs_review",
+      "categories": [
+        "request_shape_400",
+        "model_lifecycle"
+      ],
+      "tokenkey_status": "candidate_unverified",
+      "rationale": "Gateway/relay-relevant keyword match; not yet manually verified against TokenKey code.",
+      "updated_at": "2026-06-02T03:53:49Z"
+    },
+    {
+      "upstream": "anthropics/claude-code#64129",
+      "url": "https://github.com/anthropics/claude-code/issues/64129",
+      "title": "[Bug] Opus 4.8 responses not displayed after tool use — quota consumed with no output",
+      "impact": "needs_review",
+      "categories": [
+        "model_lifecycle"
+      ],
+      "tokenkey_status": "candidate_unverified",
+      "rationale": "Gateway/relay-relevant keyword match; not yet manually verified against TokenKey code.",
+      "updated_at": "2026-06-02T05:17:22Z"
+    },
+    {
+      "upstream": "anthropics/claude-code#64153",
+      "url": "https://github.com/anthropics/claude-code/issues/64153",
+      "title": "[BUG] Opus 4.8 medium effort spends 46k output tokens on hidden thinking for a simple coding turn",
+      "impact": "needs_review",
+      "categories": [
+        "request_shape_400",
+        "model_lifecycle",
+        "prompt_caching"
+      ],
+      "tokenkey_status": "candidate_unverified",
+      "rationale": "Gateway/relay-relevant keyword match; not yet manually verified against TokenKey code.",
+      "updated_at": "2026-06-01T01:43:02Z"
+    },
+    {
+      "upstream": "anthropics/claude-code#64168",
+      "url": "https://github.com/anthropics/claude-code/issues/64168",
+      "title": "[BUG] VS Code extension subprocess init timeout on WSL2/Ubuntu 26.04 — CLI fully healthy (stream-json handshake works from terminal)",
+      "impact": "needs_review",
+      "categories": [
+        "auth_token",
+        "model_lifecycle"
+      ],
+      "tokenkey_status": "candidate_unverified",
+      "rationale": "Gateway/relay-relevant keyword match; not yet manually verified against TokenKey code.",
+      "updated_at": "2026-06-02T16:45:10Z"
+    },
+    {
+      "upstream": "anthropics/claude-code#64177",
+      "url": "https://github.com/anthropics/claude-code/issues/64177",
+      "title": "Workflow counts API-errored subagents as \"completed\"; 429/500/529 storm under multi-agent load",
+      "impact": "needs_review",
+      "categories": [
+        "rate_limit",
+        "model_lifecycle"
+      ],
+      "tokenkey_status": "candidate_unverified",
+      "rationale": "Gateway/relay-relevant keyword match; not yet manually verified against TokenKey code.",
+      "updated_at": "2026-05-31T21:17:05Z"
+    },
+    {
+      "upstream": "anthropics/claude-code#64190",
+      "url": "https://github.com/anthropics/claude-code/issues/64190",
+      "title": "After /compact on Opus 4.8 (1M), whole tool calls emitted as <invoke> text instead of executing (not seen on 4.7)",
+      "impact": "needs_review",
+      "categories": [
+        "request_shape_400",
+        "model_lifecycle"
+      ],
+      "tokenkey_status": "candidate_unverified",
+      "rationale": "Gateway/relay-relevant keyword match; not yet manually verified against TokenKey code.",
+      "updated_at": "2026-05-31T10:46:01Z"
+    },
+    {
+      "upstream": "anthropics/claude-code#64195",
+      "url": "https://github.com/anthropics/claude-code/issues/64195",
+      "title": "[Feature Request] Restore deprecated Claude Opus versions (4.6, 4.7) with deprecation warnings",
+      "impact": "needs_review",
+      "categories": [
+        "model_lifecycle"
+      ],
+      "tokenkey_status": "candidate_unverified",
+      "rationale": "Gateway/relay-relevant keyword match; not yet manually verified against TokenKey code.",
+      "updated_at": "2026-05-31T11:02:21Z"
+    },
+    {
+      "upstream": "anthropics/claude-code#64196",
+      "url": "https://github.com/anthropics/claude-code/issues/64196",
+      "title": "Claude Pro: 1M context limit breaks active workflows without warning",
+      "impact": "needs_review",
+      "categories": [
+        "request_shape_400"
+      ],
+      "tokenkey_status": "candidate_unverified",
+      "rationale": "Gateway/relay-relevant keyword match; not yet manually verified against TokenKey code.",
+      "updated_at": "2026-05-31T13:21:42Z"
+    },
+    {
+      "upstream": "anthropics/claude-code#64209",
+      "url": "https://github.com/anthropics/claude-code/issues/64209",
+      "title": "[Bug] Tool-layer unreliability in long/compacted sessions: duplicated results, delayed delivery, empty/garbled file reads",
+      "impact": "needs_review",
+      "categories": [
+        "model_lifecycle"
+      ],
+      "tokenkey_status": "candidate_unverified",
+      "rationale": "Gateway/relay-relevant keyword match; not yet manually verified against TokenKey code.",
+      "updated_at": "2026-05-31T19:13:08Z"
+    },
+    {
+      "upstream": "anthropics/claude-code#64212",
+      "url": "https://github.com/anthropics/claude-code/issues/64212",
+      "title": "[MODEL] Opus 4.8 (xhigh): claims work verified when it isn't, self-contradicts, and over-parallelizes contradictory tool calls — on a low-complexity codebase",
+      "impact": "needs_review",
+      "categories": [
+        "model_lifecycle",
+        "new_endpoints",
+        "fingerprint_ua"
+      ],
+      "tokenkey_status": "candidate_unverified",
+      "rationale": "Gateway/relay-relevant keyword match; not yet manually verified against TokenKey code.",
+      "updated_at": "2026-05-31T14:42:58Z"
+    },
+    {
+      "upstream": "anthropics/claude-code#64213",
+      "url": "https://github.com/anthropics/claude-code/issues/64213",
+      "title": "[BUG] 400 \"thinking/redacted_thinking blocks cannot be modified\" bricks session after large multi-tool turns",
+      "impact": "needs_review",
+      "categories": [
+        "request_shape_400",
+        "new_endpoints"
+      ],
+      "tokenkey_status": "candidate_unverified",
+      "rationale": "Gateway/relay-relevant keyword match; not yet manually verified against TokenKey code.",
+      "updated_at": "2026-05-31T14:57:48Z"
+    },
+    {
+      "upstream": "anthropics/claude-code#64216",
+      "url": "https://github.com/anthropics/claude-code/issues/64216",
+      "title": "[Bug] Increased tool call failures and retry attempts with Opus model",
+      "impact": "needs_review",
+      "categories": [
+        "model_lifecycle"
+      ],
+      "tokenkey_status": "candidate_unverified",
+      "rationale": "Gateway/relay-relevant keyword match; not yet manually verified against TokenKey code.",
+      "updated_at": "2026-05-31T13:02:32Z"
+    },
+    {
+      "upstream": "anthropics/claude-code#64227",
+      "url": "https://github.com/anthropics/claude-code/issues/64227",
+      "title": "Claude Code repeatedly made unauthorized destructive changes, ignored explicit rules, and permanently destroyed user data across multiple sessions[MODEL]",
+      "impact": "needs_review",
+      "categories": [
+        "auth_token"
+      ],
+      "tokenkey_status": "candidate_unverified",
+      "rationale": "Gateway/relay-relevant keyword match; not yet manually verified against TokenKey code.",
+      "updated_at": "2026-06-01T21:39:58Z"
+    },
+    {
+      "upstream": "anthropics/claude-code#64229",
+      "url": "https://github.com/anthropics/claude-code/issues/64229",
+      "title": "Server-side tool (server_tool_use) emitted but no result returned; response reports stop_reason: end_turn",
+      "impact": "needs_review",
+      "categories": [
+        "request_shape_400",
+        "model_lifecycle"
+      ],
+      "tokenkey_status": "candidate_unverified",
+      "rationale": "Gateway/relay-relevant keyword match; not yet manually verified against TokenKey code.",
+      "updated_at": "2026-05-31T21:18:01Z"
+    },
+    {
+      "upstream": "anthropics/claude-code#64232",
+      "url": "https://github.com/anthropics/claude-code/issues/64232",
+      "title": "[Bug] Single-use OAuth refresh token consumed by test copy invalidates production token",
+      "impact": "needs_review",
+      "categories": [
+        "auth_token"
+      ],
+      "tokenkey_status": "candidate_unverified",
+      "rationale": "Gateway/relay-relevant keyword match; not yet manually verified against TokenKey code.",
+      "updated_at": "2026-05-31T14:15:03Z"
+    },
+    {
+      "upstream": "anthropics/claude-code#64233",
+      "url": "https://github.com/anthropics/claude-code/issues/64233",
+      "title": "[BUG] Windows: stopShellPty on tab switch kills session with exit code 4294967295 — regression in May 27+ build",
+      "impact": "needs_review",
+      "categories": [
+        "auth_token"
+      ],
+      "tokenkey_status": "candidate_unverified",
+      "rationale": "Gateway/relay-relevant keyword match; not yet manually verified against TokenKey code.",
+      "updated_at": "2026-05-31T14:23:03Z"
+    },
+    {
+      "upstream": "anthropics/claude-code#64235",
+      "url": "https://github.com/anthropics/claude-code/issues/64235",
+      "title": "Regression (since 2026-05-29): intermittent \"tool call was malformed and could not be parsed\" — tool_use block absent on a stop_reason=tool_use turn",
+      "impact": "needs_review",
+      "categories": [
+        "request_shape_400",
+        "model_lifecycle"
+      ],
+      "tokenkey_status": "candidate_unverified",
+      "rationale": "Gateway/relay-relevant keyword match; not yet manually verified against TokenKey code.",
+      "updated_at": "2026-06-01T04:21:58Z"
+    },
+    {
+      "upstream": "anthropics/claude-code#64237",
+      "url": "https://github.com/anthropics/claude-code/issues/64237",
+      "title": "Expose a way to disable parallel tool execution (the API's disable_parallel_tool_use) in Claude Code",
+      "impact": "needs_review",
+      "categories": [
+        "request_shape_400",
+        "model_lifecycle",
+        "new_endpoints"
+      ],
+      "tokenkey_status": "candidate_unverified",
+      "rationale": "Gateway/relay-relevant keyword match; not yet manually verified against TokenKey code.",
+      "updated_at": "2026-05-31T14:50:17Z"
+    },
+    {
+      "upstream": "anthropics/claude-code#64241",
+      "url": "https://github.com/anthropics/claude-code/issues/64241",
+      "title": "run_in_background silently kills active processes and reports success (exit code 0)",
+      "impact": "needs_review",
+      "categories": [
+        "auth_token"
+      ],
+      "tokenkey_status": "candidate_unverified",
+      "rationale": "Gateway/relay-relevant keyword match; not yet manually verified against TokenKey code.",
+      "updated_at": "2026-05-31T15:09:53Z"
+    },
+    {
+      "upstream": "anthropics/claude-code#64246",
+      "url": "https://github.com/anthropics/claude-code/issues/64246",
+      "title": "Parallel tool-call batch cascades \"Cancelled\" to independent calls when one fails",
+      "impact": "needs_review",
+      "categories": [
+        "model_lifecycle"
+      ],
+      "tokenkey_status": "candidate_unverified",
+      "rationale": "Gateway/relay-relevant keyword match; not yet manually verified against TokenKey code.",
+      "updated_at": "2026-05-31T20:00:39Z"
+    },
+    {
+      "upstream": "anthropics/claude-code#64251",
+      "url": "https://github.com/anthropics/claude-code/issues/64251",
+      "title": "[BUG] Claude Code query worker dies silently on Windows — `--version` works, but every query produces no output (exit 0); VS Code extension shows \"Query closed before response received\"",
+      "impact": "needs_review",
+      "categories": [
+        "auth_token",
+        "model_lifecycle"
+      ],
+      "tokenkey_status": "candidate_unverified",
+      "rationale": "Gateway/relay-relevant keyword match; not yet manually verified against TokenKey code.",
+      "updated_at": "2026-06-02T03:14:12Z"
+    },
+    {
+      "upstream": "anthropics/claude-code#64256",
+      "url": "https://github.com/anthropics/claude-code/issues/64256",
+      "title": "[BUG] Persistent server-side session billing phantom usage — cannot be killed from client",
+      "impact": "needs_review",
+      "categories": [
+        "auth_token",
+        "new_endpoints"
+      ],
+      "tokenkey_status": "candidate_unverified",
+      "rationale": "Gateway/relay-relevant keyword match; not yet manually verified against TokenKey code.",
+      "updated_at": "2026-05-31T16:00:37Z"
+    },
+    {
+      "upstream": "anthropics/claude-code#64257",
+      "url": "https://github.com/anthropics/claude-code/issues/64257",
+      "title": "opus-4-8 appears to re-fetch identical tool results after normal (non-error) returns — 2-3x vs opus-4-7",
+      "impact": "needs_review",
+      "categories": [
+        "prompt_caching"
+      ],
+      "tokenkey_status": "candidate_unverified",
+      "rationale": "Gateway/relay-relevant keyword match; not yet manually verified against TokenKey code.",
+      "updated_at": "2026-06-01T00:01:49Z"
+    },
+    {
+      "upstream": "anthropics/claude-code#64260",
+      "url": "https://github.com/anthropics/claude-code/issues/64260",
+      "title": "[MODEL] Opus 4.8 fabricated a present-tense user request and persisted on an invented task context",
+      "impact": "needs_review",
+      "categories": [
+        "request_shape_400",
+        "model_lifecycle",
+        "prompt_caching"
+      ],
+      "tokenkey_status": "candidate_unverified",
+      "rationale": "Gateway/relay-relevant keyword match; not yet manually verified against TokenKey code.",
+      "updated_at": "2026-06-02T20:18:07Z"
+    },
+    {
+      "upstream": "anthropics/claude-code#64269",
+      "url": "https://github.com/anthropics/claude-code/issues/64269",
+      "title": "C:/Program Files/Git/schedule fails with \"trouble connecting with your remote claude.ai account\" — persistent, no public status incident",
+      "impact": "needs_review",
+      "categories": [
+        "auth_token",
+        "fingerprint_ua"
+      ],
+      "tokenkey_status": "candidate_unverified",
+      "rationale": "Gateway/relay-relevant keyword match; not yet manually verified against TokenKey code.",
+      "updated_at": "2026-05-31T17:11:18Z"
+    },
+    {
+      "upstream": "anthropics/claude-code#64278",
+      "url": "https://github.com/anthropics/claude-code/issues/64278",
+      "title": "/compact fails with 'thinking or redacted_thinking blocks cannot be modified' error when context is too long",
+      "impact": "needs_review",
+      "categories": [
+        "request_shape_400"
+      ],
+      "tokenkey_status": "candidate_unverified",
+      "rationale": "Gateway/relay-relevant keyword match; not yet manually verified against TokenKey code.",
+      "updated_at": "2026-05-31T17:49:57Z"
+    },
+    {
+      "upstream": "anthropics/claude-code#64284",
+      "url": "https://github.com/anthropics/claude-code/issues/64284",
+      "title": "[Bug] File read errors not surfaced, causing hallucinations in tool use",
+      "impact": "needs_review",
+      "categories": [
+        "rate_limit",
+        "auth_token",
+        "prompt_caching"
+      ],
+      "tokenkey_status": "candidate_unverified",
+      "rationale": "Gateway/relay-relevant keyword match; not yet manually verified against TokenKey code.",
+      "updated_at": "2026-05-31T22:18:26Z"
+    },
+    {
+      "upstream": "anthropics/claude-code#64317",
+      "url": "https://github.com/anthropics/claude-code/issues/64317",
+      "title": "Intermittent tool-result corruption: stale/replayed output + sibling cancellation (v2.1.143)",
+      "impact": "needs_review",
+      "categories": [
+        "request_shape_400"
+      ],
+      "tokenkey_status": "candidate_unverified",
+      "rationale": "Gateway/relay-relevant keyword match; not yet manually verified against TokenKey code.",
+      "updated_at": "2026-05-31T20:55:33Z"
+    },
+    {
+      "upstream": "anthropics/claude-code#64321",
+      "url": "https://github.com/anthropics/claude-code/issues/64321",
+      "title": "[BUG]",
+      "impact": "needs_review",
+      "categories": [
+        "request_shape_400"
+      ],
+      "tokenkey_status": "candidate_unverified",
+      "rationale": "Gateway/relay-relevant keyword match; not yet manually verified against TokenKey code.",
+      "updated_at": "2026-05-31T20:42:55Z"
+    },
+    {
+      "upstream": "anthropics/claude-code#64322",
+      "url": "https://github.com/anthropics/claude-code/issues/64322",
+      "title": "Worktree isolation: Edit-tool path validation + drift-detection in task-notification payload",
+      "impact": "needs_review",
+      "categories": [
+        "model_lifecycle"
+      ],
+      "tokenkey_status": "candidate_unverified",
+      "rationale": "Gateway/relay-relevant keyword match; not yet manually verified against TokenKey code.",
+      "updated_at": "2026-05-31T20:57:27Z"
+    },
+    {
+      "upstream": "anthropics/claude-code#64327",
+      "url": "https://github.com/anthropics/claude-code/issues/64327",
+      "title": "[BUG] API Error: Server is temporarily limiting requests (not your usage limit) · Rate limited",
+      "impact": "needs_review",
+      "categories": [
+        "rate_limit"
+      ],
+      "tokenkey_status": "candidate_unverified",
+      "rationale": "Gateway/relay-relevant keyword match; not yet manually verified against TokenKey code.",
+      "updated_at": "2026-05-31T21:08:41Z"
+    },
+    {
+      "upstream": "anthropics/claude-code#64328",
+      "url": "https://github.com/anthropics/claude-code/issues/64328",
+      "title": "[BUG] Workflow harness retries indefinitely on HTTP 429 rate_limit — 97 agents, 2M tokens burned in 34 seconds ()",
+      "impact": "needs_review",
+      "categories": [
+        "rate_limit"
+      ],
+      "tokenkey_status": "candidate_unverified",
+      "rationale": "Gateway/relay-relevant keyword match; not yet manually verified against TokenKey code.",
+      "updated_at": "2026-05-31T21:27:01Z"
+    },
+    {
+      "upstream": "anthropics/claude-code#64329",
+      "url": "https://github.com/anthropics/claude-code/issues/64329",
+      "title": "Opus 4.8 Model stated multiple unverified claims as fact and fabricates specifics within a single session",
+      "impact": "needs_review",
+      "categories": [
+        "model_lifecycle"
+      ],
+      "tokenkey_status": "candidate_unverified",
+      "rationale": "Gateway/relay-relevant keyword match; not yet manually verified against TokenKey code.",
+      "updated_at": "2026-06-01T03:04:27Z"
+    },
+    {
+      "upstream": "anthropics/claude-code#64330",
+      "url": "https://github.com/anthropics/claude-code/issues/64330",
+      "title": "[BUG] Installer places binary in VS Code Snap directory, leading to silent uninstallation on Ubuntu",
+      "impact": "needs_review",
+      "categories": [
+        "prompt_caching"
+      ],
+      "tokenkey_status": "candidate_unverified",
+      "rationale": "Gateway/relay-relevant keyword match; not yet manually verified against TokenKey code.",
+      "updated_at": "2026-05-31T21:21:49Z"
+    },
+    {
+      "upstream": "anthropics/claude-code#64336",
+      "url": "https://github.com/anthropics/claude-code/issues/64336",
+      "title": "Multiple profile directories (~/.claude-a, ~/.claude-b) require independent re-logins despite sharing the same account",
+      "impact": "needs_review",
+      "categories": [
+        "auth_token"
+      ],
+      "tokenkey_status": "candidate_unverified",
+      "rationale": "Gateway/relay-relevant keyword match; not yet manually verified against TokenKey code.",
+      "updated_at": "2026-06-01T03:07:07Z"
+    },
+    {
+      "upstream": "anthropics/claude-code#64339",
+      "url": "https://github.com/anthropics/claude-code/issues/64339",
+      "title": "[BUG] Thousands of ghost \"root-server\" sessions regenerate on every launch, crashing the app — survive full uninstall/reinstall and all known data clearing",
+      "impact": "needs_review",
+      "categories": [
+        "model_lifecycle"
+      ],
+      "tokenkey_status": "candidate_unverified",
+      "rationale": "Gateway/relay-relevant keyword match; not yet manually verified against TokenKey code.",
+      "updated_at": "2026-05-31T22:18:55Z"
+    },
+    {
+      "upstream": "anthropics/claude-code#64345",
+      "url": "https://github.com/anthropics/claude-code/issues/64345",
+      "title": "[MODEL] Claude ignored instructions/configuration (also: Claude made incorrect assumptions)",
+      "impact": "needs_review",
+      "categories": [
+        "new_endpoints"
+      ],
+      "tokenkey_status": "candidate_unverified",
+      "rationale": "Gateway/relay-relevant keyword match; not yet manually verified against TokenKey code.",
+      "updated_at": "2026-05-31T22:48:37Z"
+    },
+    {
+      "upstream": "anthropics/claude-code#64346",
+      "url": "https://github.com/anthropics/claude-code/issues/64346",
+      "title": "Parallel tool calls: one benign tool error cancels all sibling calls → agent misreads as broken shell and flails",
+      "impact": "needs_review",
+      "categories": [
+        "request_shape_400",
+        "model_lifecycle",
+        "new_endpoints"
+      ],
+      "tokenkey_status": "candidate_unverified",
+      "rationale": "Gateway/relay-relevant keyword match; not yet manually verified against TokenKey code.",
+      "updated_at": "2026-06-01T01:13:16Z"
+    },
+    {
+      "upstream": "anthropics/claude-code#64350",
+      "url": "https://github.com/anthropics/claude-code/issues/64350",
+      "title": "MCP gateway WAF blocks legitimate tool-call bodies (SQL/shell/config text)",
+      "impact": "needs_review",
+      "categories": [
+        "fingerprint_ua"
+      ],
+      "tokenkey_status": "candidate_unverified",
+      "rationale": "Gateway/relay-relevant keyword match; not yet manually verified against TokenKey code.",
+      "updated_at": "2026-06-01T15:36:34Z"
+    },
+    {
+      "upstream": "anthropics/claude-code#64355",
+      "url": "https://github.com/anthropics/claude-code/issues/64355",
+      "title": "[BUG] Opus deleted entire repository without realizing it (corrupt tool call?)",
+      "impact": "needs_review",
+      "categories": [
+        "new_endpoints"
+      ],
+      "tokenkey_status": "candidate_unverified",
+      "rationale": "Gateway/relay-relevant keyword match; not yet manually verified against TokenKey code.",
+      "updated_at": "2026-06-01T12:49:50Z"
+    },
+    {
+      "upstream": "anthropics/claude-code#64357",
+      "url": "https://github.com/anthropics/claude-code/issues/64357",
+      "title": "[Bug] Anthropic API Error: Cannot modify thinking blocks in assistant message",
+      "impact": "needs_review",
+      "categories": [
+        "request_shape_400",
+        "fingerprint_ua"
+      ],
+      "tokenkey_status": "candidate_unverified",
+      "rationale": "Gateway/relay-relevant keyword match; not yet manually verified against TokenKey code.",
+      "updated_at": "2026-06-01T03:07:06Z"
+    },
+    {
+      "upstream": "anthropics/claude-code#64359",
+      "url": "https://github.com/anthropics/claude-code/issues/64359",
+      "title": "Opus 4.8 burns 5h limit in ~30min on operational work; no signal to downgrade to Sonnet",
+      "impact": "needs_review",
+      "categories": [
+        "rate_limit",
+        "model_lifecycle"
+      ],
+      "tokenkey_status": "candidate_unverified",
+      "rationale": "Gateway/relay-relevant keyword match; not yet manually verified against TokenKey code.",
+      "updated_at": "2026-06-01T01:13:04Z"
+    },
+    {
+      "upstream": "anthropics/claude-code#64364",
+      "url": "https://github.com/anthropics/claude-code/issues/64364",
+      "title": "opus-4-8 re-fetches identical tool results after normal (non-error) returns — ~2-3× vs opus-4-7",
+      "impact": "needs_review",
+      "categories": [
+        "model_lifecycle",
+        "prompt_caching"
+      ],
+      "tokenkey_status": "candidate_unverified",
+      "rationale": "Gateway/relay-relevant keyword match; not yet manually verified against TokenKey code.",
+      "updated_at": "2026-06-01T01:32:07Z"
+    },
+    {
+      "upstream": "anthropics/claude-code#64386",
+      "url": "https://github.com/anthropics/claude-code/issues/64386",
+      "title": "[FEATURE] Annotate thinking blocks at JSONL save-time with corruption-trigger context (meta-fix for the #10199 duplicate-issue pile)",
+      "impact": "needs_review",
+      "categories": [
+        "request_shape_400",
+        "new_endpoints"
+      ],
+      "tokenkey_status": "candidate_unverified",
+      "rationale": "Gateway/relay-relevant keyword match; not yet manually verified against TokenKey code.",
+      "updated_at": "2026-06-01T14:38:45Z"
+    },
+    {
+      "upstream": "anthropics/claude-code#64387",
+      "url": "https://github.com/anthropics/claude-code/issues/64387",
+      "title": "[BUG] Linear MCP OAuth /authorize endpoint redirects to deprecated gdrive install URL",
+      "impact": "needs_review",
+      "categories": [
+        "auth_token",
+        "model_lifecycle"
+      ],
+      "tokenkey_status": "candidate_unverified",
+      "rationale": "Gateway/relay-relevant keyword match; not yet manually verified against TokenKey code.",
+      "updated_at": "2026-06-01T03:53:24Z"
+    },
+    {
+      "upstream": "anthropics/claude-code#64388",
+      "url": "https://github.com/anthropics/claude-code/issues/64388",
+      "title": "Foundry: `/context` shows 200k cap even with 1M beta enabled and `effectiveWindow=1M` confirmed",
+      "impact": "needs_review",
+      "categories": [
+        "model_lifecycle"
+      ],
+      "tokenkey_status": "candidate_unverified",
+      "rationale": "Gateway/relay-relevant keyword match; not yet manually verified against TokenKey code.",
+      "updated_at": "2026-06-01T04:04:26Z"
+    },
+    {
+      "upstream": "anthropics/claude-code#64392",
+      "url": "https://github.com/anthropics/claude-code/issues/64392",
+      "title": "[Bug] Tool calls executing incorrectly and deleting files unintentionally",
+      "impact": "needs_review",
+      "categories": [
+        "auth_token"
+      ],
+      "tokenkey_status": "candidate_unverified",
+      "rationale": "Gateway/relay-relevant keyword match; not yet manually verified against TokenKey code.",
+      "updated_at": "2026-06-01T06:08:41Z"
+    },
+    {
+      "upstream": "anthropics/claude-code#64393",
+      "url": "https://github.com/anthropics/claude-code/issues/64393",
+      "title": "[BUG] Desktop SSH: turns completed while client is disconnected never appear in UI",
+      "impact": "needs_review",
+      "categories": [
+        "new_endpoints"
+      ],
+      "tokenkey_status": "candidate_unverified",
+      "rationale": "Gateway/relay-relevant keyword match; not yet manually verified against TokenKey code.",
+      "updated_at": "2026-06-01T04:31:04Z"
+    },
+    {
+      "upstream": "anthropics/claude-code#64397",
+      "url": "https://github.com/anthropics/claude-code/issues/64397",
+      "title": "[Bug] CCR routines: 3 structural observability gaps — RemoteTrigger.run HTTP 400 + unmerged claude/* fire artifacts + MCP-permission-prompt deadlocks",
+      "impact": "needs_review",
+      "categories": [
+        "request_shape_400"
+      ],
+      "tokenkey_status": "candidate_unverified",
+      "rationale": "Gateway/relay-relevant keyword match; not yet manually verified against TokenKey code.",
+      "updated_at": "2026-06-02T16:18:56Z"
+    },
+    {
+      "upstream": "anthropics/claude-code#64402",
+      "url": "https://github.com/anthropics/claude-code/issues/64402",
+      "title": "[Bug] askUserQuestion tool executes twice after user responds",
+      "impact": "needs_review",
+      "categories": [
+        "auth_token"
+      ],
+      "tokenkey_status": "candidate_unverified",
+      "rationale": "Gateway/relay-relevant keyword match; not yet manually verified against TokenKey code.",
+      "updated_at": "2026-06-01T05:30:40Z"
+    },
+    {
+      "upstream": "anthropics/claude-code#64409",
+      "url": "https://github.com/anthropics/claude-code/issues/64409",
+      "title": "[BUG] Hallucinated, empty, and duplicated tool results in a long-running session",
+      "impact": "needs_review",
+      "categories": [
+        "request_shape_400",
+        "model_lifecycle",
+        "new_endpoints"
+      ],
+      "tokenkey_status": "candidate_unverified",
+      "rationale": "Gateway/relay-relevant keyword match; not yet manually verified against TokenKey code.",
+      "updated_at": "2026-06-01T06:43:55Z"
+    },
+    {
+      "upstream": "anthropics/claude-code#64414",
+      "url": "https://github.com/anthropics/claude-code/issues/64414",
+      "title": "[BUG] Cowork omits anthropic-workspace-id header on custom gateway (Code works)",
+      "impact": "needs_review",
+      "categories": [
+        "request_shape_400"
+      ],
+      "tokenkey_status": "candidate_unverified",
+      "rationale": "Gateway/relay-relevant keyword match; not yet manually verified against TokenKey code.",
+      "updated_at": "2026-06-01T07:15:23Z"
+    },
+    {
+      "upstream": "anthropics/claude-code#64418",
+      "url": "https://github.com/anthropics/claude-code/issues/64418",
+      "title": "[Bug] Opus 4.8: Tool calls serialized as plain text instead of tool_use blocks in high-composition sessions",
+      "impact": "needs_review",
+      "categories": [
+        "request_shape_400",
+        "model_lifecycle"
+      ],
+      "tokenkey_status": "candidate_unverified",
+      "rationale": "Gateway/relay-relevant keyword match; not yet manually verified against TokenKey code.",
+      "updated_at": "2026-06-02T04:02:34Z"
+    },
+    {
+      "upstream": "anthropics/claude-code#64422",
+      "url": "https://github.com/anthropics/claude-code/issues/64422",
+      "title": "LSP plugin extension conflict resolves silently — losing plugin appears enabled but server never spawns",
+      "impact": "needs_review",
+      "categories": [
+        "model_lifecycle"
+      ],
+      "tokenkey_status": "candidate_unverified",
+      "rationale": "Gateway/relay-relevant keyword match; not yet manually verified against TokenKey code.",
+      "updated_at": "2026-06-02T14:35:41Z"
+    },
+    {
+      "upstream": "anthropics/claude-code#64424",
+      "url": "https://github.com/anthropics/claude-code/issues/64424",
+      "title": "[DOCS] Per-feature platform availability is not discoverable in docs",
+      "impact": "needs_review",
+      "categories": [
+        "prompt_caching"
+      ],
+      "tokenkey_status": "candidate_unverified",
+      "rationale": "Gateway/relay-relevant keyword match; not yet manually verified against TokenKey code.",
+      "updated_at": "2026-06-01T08:00:53Z"
+    },
+    {
+      "upstream": "anthropics/claude-code#64425",
+      "url": "https://github.com/anthropics/claude-code/issues/64425",
+      "title": "Remote folder connection fails with \"Host denied (verification failed)\" for specific hostname",
+      "impact": "needs_review",
+      "categories": [
+        "auth_token"
+      ],
+      "tokenkey_status": "candidate_unverified",
+      "rationale": "Gateway/relay-relevant keyword match; not yet manually verified against TokenKey code.",
+      "updated_at": "2026-06-01T08:04:34Z"
+    },
+    {
+      "upstream": "anthropics/claude-code#64426",
+      "url": "https://github.com/anthropics/claude-code/issues/64426",
+      "title": "Bash tool silently strips -flag tokens when a command has a command substitution with a nested $",
+      "impact": "needs_review",
+      "categories": [
+        "model_lifecycle"
+      ],
+      "tokenkey_status": "candidate_unverified",
+      "rationale": "Gateway/relay-relevant keyword match; not yet manually verified against TokenKey code.",
+      "updated_at": "2026-06-01T08:05:56Z"
+    },
+    {
+      "upstream": "anthropics/claude-code#64427",
+      "url": "https://github.com/anthropics/claude-code/issues/64427",
+      "title": "[BUG] Pro plan — 1M context error blocks all requests",
+      "impact": "needs_review",
+      "categories": [
+        "model_lifecycle"
+      ],
+      "tokenkey_status": "candidate_unverified",
+      "rationale": "Gateway/relay-relevant keyword match; not yet manually verified against TokenKey code.",
+      "updated_at": "2026-06-01T08:08:58Z"
+    },
+    {
+      "upstream": "anthropics/claude-code#64432",
+      "url": "https://github.com/anthropics/claude-code/issues/64432",
+      "title": "dontAsk: Write allow-list broken for all path forms on Windows native (2.1.145); PreToolUse hook confirmed workaround",
+      "impact": "needs_review",
+      "categories": [
+        "auth_token"
+      ],
+      "tokenkey_status": "candidate_unverified",
+      "rationale": "Gateway/relay-relevant keyword match; not yet manually verified against TokenKey code.",
+      "updated_at": "2026-06-01T12:21:27Z"
+    },
+    {
+      "upstream": "anthropics/claude-code#64436",
+      "url": "https://github.com/anthropics/claude-code/issues/64436",
+      "title": "Background sessions (claude agents) drop work-phase OTEL logs (user_prompt/api_request) on shutdown",
+      "impact": "needs_review",
+      "categories": [
+        "request_shape_400"
+      ],
+      "tokenkey_status": "candidate_unverified",
+      "rationale": "Gateway/relay-relevant keyword match; not yet manually verified against TokenKey code.",
+      "updated_at": "2026-06-01T16:04:13Z"
+    },
+    {
+      "upstream": "anthropics/claude-code#64438",
+      "url": "https://github.com/anthropics/claude-code/issues/64438",
+      "title": "[Bug] Anthropic API Error: Server temporarily limiting requests due to rate limiting",
+      "impact": "needs_review",
+      "categories": [
+        "rate_limit"
+      ],
+      "tokenkey_status": "candidate_unverified",
+      "rationale": "Gateway/relay-relevant keyword match; not yet manually verified against TokenKey code.",
+      "updated_at": "2026-06-01T09:16:09Z"
+    },
+    {
+      "upstream": "anthropics/claude-code#64439",
+      "url": "https://github.com/anthropics/claude-code/issues/64439",
+      "title": "[BUG] /ultrareview consumes a free trial when the run fails with a server-side rate limit",
+      "impact": "needs_review",
+      "categories": [
+        "rate_limit"
+      ],
+      "tokenkey_status": "candidate_unverified",
+      "rationale": "Gateway/relay-relevant keyword match; not yet manually verified against TokenKey code.",
+      "updated_at": "2026-06-01T13:55:28Z"
+    },
+    {
+      "upstream": "anthropics/claude-code#64462",
+      "url": "https://github.com/anthropics/claude-code/issues/64462",
+      "title": "You've hit your limit · resets 6:30pm (Asia/Calcutta)",
+      "impact": "needs_review",
+      "categories": [
+        "rate_limit"
+      ],
+      "tokenkey_status": "candidate_unverified",
+      "rationale": "Gateway/relay-relevant keyword match; not yet manually verified against TokenKey code.",
+      "updated_at": "2026-06-01T11:06:55Z"
+    },
+    {
+      "upstream": "anthropics/claude-code#64465",
+      "url": "https://github.com/anthropics/claude-code/issues/64465",
+      "title": "[Feature Request] Add confirmation prompt before submitting critical feedback",
+      "impact": "needs_review",
+      "categories": [
+        "auth_token"
+      ],
+      "tokenkey_status": "candidate_unverified",
+      "rationale": "Gateway/relay-relevant keyword match; not yet manually verified against TokenKey code.",
+      "updated_at": "2026-06-01T11:36:44Z"
+    },
+    {
+      "upstream": "anthropics/claude-code#64475",
+      "url": "https://github.com/anthropics/claude-code/issues/64475",
+      "title": "MCP stdio transport dropped on unrecognized notifications/progress token, corrupting in-flight tools/call",
+      "impact": "needs_review",
+      "categories": [
+        "request_shape_400"
+      ],
+      "tokenkey_status": "candidate_unverified",
+      "rationale": "Gateway/relay-relevant keyword match; not yet manually verified against TokenKey code.",
+      "updated_at": "2026-06-01T12:31:52Z"
+    },
+    {
+      "upstream": "anthropics/claude-code#64477",
+      "url": "https://github.com/anthropics/claude-code/issues/64477",
+      "title": "TypeError when resuming session: Cannot read properties of undefined (reading 'trim')",
+      "impact": "needs_review",
+      "categories": [
+        "model_lifecycle"
+      ],
+      "tokenkey_status": "candidate_unverified",
+      "rationale": "Gateway/relay-relevant keyword match; not yet manually verified against TokenKey code.",
+      "updated_at": "2026-06-01T15:25:04Z"
+    },
+    {
+      "upstream": "anthropics/claude-code#64478",
+      "url": "https://github.com/anthropics/claude-code/issues/64478",
+      "title": "[BUG] VSCode UI",
+      "impact": "needs_review",
+      "categories": [
+        "model_lifecycle"
+      ],
+      "tokenkey_status": "candidate_unverified",
+      "rationale": "Gateway/relay-relevant keyword match; not yet manually verified against TokenKey code.",
+      "updated_at": "2026-06-01T12:40:57Z"
+    },
+    {
+      "upstream": "anthropics/claude-code#64482",
+      "url": "https://github.com/anthropics/claude-code/issues/64482",
+      "title": "Hosted Microsoft 365 MCP server OAuth fails with AADSTS900971: No reply address provided",
+      "impact": "needs_review",
+      "categories": [
+        "auth_token"
+      ],
+      "tokenkey_status": "candidate_unverified",
+      "rationale": "Gateway/relay-relevant keyword match; not yet manually verified against TokenKey code.",
+      "updated_at": "2026-06-01T12:53:37Z"
+    },
+    {
+      "upstream": "anthropics/claude-code#64493",
+      "url": "https://github.com/anthropics/claude-code/issues/64493",
+      "title": "FleetView bg-session dispatcher defaults to Opus 4.7 instead of latest model; ignores ANTHROPIC_MODEL and settings.json `model`",
+      "impact": "needs_review",
+      "categories": [
+        "model_lifecycle"
+      ],
+      "tokenkey_status": "candidate_unverified",
+      "rationale": "Gateway/relay-relevant keyword match; not yet manually verified against TokenKey code.",
+      "updated_at": "2026-06-01T15:31:44Z"
+    },
+    {
+      "upstream": "anthropics/claude-code#64497",
+      "url": "https://github.com/anthropics/claude-code/issues/64497",
+      "title": "[BUG] Enterprise-managed marketplaces in project enabledPlugins are orphaned on first run; only install after a restart",
+      "impact": "needs_review",
+      "categories": [
+        "auth_token"
+      ],
+      "tokenkey_status": "candidate_unverified",
+      "rationale": "Gateway/relay-relevant keyword match; not yet manually verified against TokenKey code.",
+      "updated_at": "2026-06-02T08:26:09Z"
+    },
+    {
+      "upstream": "anthropics/claude-code#64505",
+      "url": "https://github.com/anthropics/claude-code/issues/64505",
+      "title": "[BUG] Desktop app renderer OOMs at ~2.7 GB V8 heap within 15–50s when Dispatch is active (macOS 26.5, M5 Pro)",
+      "impact": "needs_review",
+      "categories": [
+        "model_lifecycle"
+      ],
+      "tokenkey_status": "candidate_unverified",
+      "rationale": "Gateway/relay-relevant keyword match; not yet manually verified against TokenKey code.",
+      "updated_at": "2026-06-01T18:59:30Z"
+    },
+    {
+      "upstream": "anthropics/claude-code#64510",
+      "url": "https://github.com/anthropics/claude-code/issues/64510",
+      "title": "[BUG] No supported way to disable only the context_management beta — breaks Claude Code on HIPAA-flagged orgs without ZDR (first-party Anthropic API)",
+      "impact": "needs_review",
+      "categories": [
+        "beta_header_drift",
+        "request_shape_400"
+      ],
+      "tokenkey_status": "candidate_unverified",
+      "rationale": "Gateway/relay-relevant keyword match; not yet manually verified against TokenKey code.",
+      "updated_at": "2026-06-01T15:28:43Z"
+    },
+    {
+      "upstream": "anthropics/claude-code#64514",
+      "url": "https://github.com/anthropics/claude-code/issues/64514",
+      "title": "Claude main AI is not following user-defined workflows and exceeds command scope",
+      "impact": "needs_review",
+      "categories": [
+        "auth_token"
+      ],
+      "tokenkey_status": "candidate_unverified",
+      "rationale": "Gateway/relay-relevant keyword match; not yet manually verified against TokenKey code.",
+      "updated_at": "2026-06-01T15:35:05Z"
+    },
+    {
+      "upstream": "anthropics/claude-code#64516",
+      "url": "https://github.com/anthropics/claude-code/issues/64516",
+      "title": "Claude main AI is not following user-defined workflows and exceeds command scope",
+      "impact": "needs_review",
+      "categories": [
+        "auth_token"
+      ],
+      "tokenkey_status": "candidate_unverified",
+      "rationale": "Gateway/relay-relevant keyword match; not yet manually verified against TokenKey code.",
+      "updated_at": "2026-06-01T15:40:42Z"
+    },
+    {
+      "upstream": "anthropics/claude-code#64533",
+      "url": "https://github.com/anthropics/claude-code/issues/64533",
+      "title": "Multi-minute first-byte stalls on claude-opus-4-8[1m], compounded by auto-mode classifier timeouts — sessions near-unusable",
+      "impact": "needs_review",
+      "categories": [
+        "auth_token",
+        "model_lifecycle"
+      ],
+      "tokenkey_status": "candidate_unverified",
+      "rationale": "Gateway/relay-relevant keyword match; not yet manually verified against TokenKey code.",
+      "updated_at": "2026-06-01T18:35:14Z"
+    },
+    {
+      "upstream": "anthropics/claude-code#64539",
+      "url": "https://github.com/anthropics/claude-code/issues/64539",
+      "title": "Harness-injected control text and tool-result content share one untagged channel — independent of phrasing",
+      "impact": "needs_review",
+      "categories": [
+        "request_shape_400"
+      ],
+      "tokenkey_status": "candidate_unverified",
+      "rationale": "Gateway/relay-relevant keyword match; not yet manually verified against TokenKey code.",
+      "updated_at": "2026-06-02T18:24:16Z"
+    },
+    {
+      "upstream": "anthropics/claude-code#64540",
+      "url": "https://github.com/anthropics/claude-code/issues/64540",
+      "title": "Opus 4.7 (1M context) — confident assertion of stale data, fabricated dates, over-scripted simple operations",
+      "impact": "needs_review",
+      "categories": [
+        "model_lifecycle",
+        "prompt_caching"
+      ],
+      "tokenkey_status": "candidate_unverified",
+      "rationale": "Gateway/relay-relevant keyword match; not yet manually verified against TokenKey code.",
+      "updated_at": "2026-06-01T17:52:21Z"
+    },
+    {
+      "upstream": "anthropics/claude-code#64545",
+      "url": "https://github.com/anthropics/claude-code/issues/64545",
+      "title": "[Bug] Anthropic API Error: 400 Could not process image",
+      "impact": "needs_review",
+      "categories": [
+        "request_shape_400"
+      ],
+      "tokenkey_status": "candidate_unverified",
+      "rationale": "Gateway/relay-relevant keyword match; not yet manually verified against TokenKey code.",
+      "updated_at": "2026-06-01T18:11:12Z"
+    },
+    {
+      "upstream": "anthropics/claude-code#64547",
+      "url": "https://github.com/anthropics/claude-code/issues/64547",
+      "title": "claude --resume does not find sessions renamed with /rename by custom title",
+      "impact": "needs_review",
+      "categories": [
+        "auth_token"
+      ],
+      "tokenkey_status": "candidate_unverified",
+      "rationale": "Gateway/relay-relevant keyword match; not yet manually verified against TokenKey code.",
+      "updated_at": "2026-06-02T04:10:54Z"
+    },
+    {
+      "upstream": "anthropics/claude-code#64550",
+      "url": "https://github.com/anthropics/claude-code/issues/64550",
+      "title": "[BUG] Agent Teams (in-process): team-lead \"active agent\" pointer sticks on a teammate after a long/compacted session — lead routes AS the teammate, Agent spawns fail \"Teammates cannot spawn other teammates\"",
+      "impact": "needs_review",
+      "categories": [
+        "model_lifecycle"
+      ],
+      "tokenkey_status": "candidate_unverified",
+      "rationale": "Gateway/relay-relevant keyword match; not yet manually verified against TokenKey code.",
+      "updated_at": "2026-06-01T19:13:18Z"
+    },
+    {
+      "upstream": "anthropics/claude-code#64561",
+      "url": "https://github.com/anthropics/claude-code/issues/64561",
+      "title": "[BUG] Malformed/unparseable tool call: the raw tool-call markup (full parameter payload) is rendered to the user as message text",
+      "impact": "needs_review",
+      "categories": [
+        "model_lifecycle"
+      ],
+      "tokenkey_status": "candidate_unverified",
+      "rationale": "Gateway/relay-relevant keyword match; not yet manually verified against TokenKey code.",
+      "updated_at": "2026-06-01T20:27:11Z"
+    },
+    {
+      "upstream": "anthropics/claude-code#64566",
+      "url": "https://github.com/anthropics/claude-code/issues/64566",
+      "title": "[Feature Request] Add `promptStyle` config option for rate-limit/decision prompts",
+      "impact": "needs_review",
+      "categories": [
+        "rate_limit"
+      ],
+      "tokenkey_status": "candidate_unverified",
+      "rationale": "Gateway/relay-relevant keyword match; not yet manually verified against TokenKey code.",
+      "updated_at": "2026-06-01T21:08:52Z"
+    },
+    {
+      "upstream": "anthropics/claude-code#64567",
+      "url": "https://github.com/anthropics/claude-code/issues/64567",
+      "title": "[BUG] cct = TUI: permission-gate render-duplication",
+      "impact": "needs_review",
+      "categories": [
+        "request_shape_400"
+      ],
+      "tokenkey_status": "candidate_unverified",
+      "rationale": "Gateway/relay-relevant keyword match; not yet manually verified against TokenKey code.",
+      "updated_at": "2026-06-01T21:10:52Z"
+    },
+    {
+      "upstream": "anthropics/claude-code#64574",
+      "url": "https://github.com/anthropics/claude-code/issues/64574",
+      "title": "Claude Code AI ignored direct user instructions, resulting in financial loss of $112.77",
+      "impact": "needs_review",
+      "categories": [
+        "auth_token"
+      ],
+      "tokenkey_status": "candidate_unverified",
+      "rationale": "Gateway/relay-relevant keyword match; not yet manually verified against TokenKey code.",
+      "updated_at": "2026-06-02T05:46:24Z"
+    },
+    {
+      "upstream": "anthropics/claude-code#64578",
+      "url": "https://github.com/anthropics/claude-code/issues/64578",
+      "title": "[BUG] Managed MCP server tools permanently stuck in \"Needs Approval\" — users cannot approve unlisted tools, contradicting docs and UI",
+      "impact": "needs_review",
+      "categories": [
+        "auth_token"
+      ],
+      "tokenkey_status": "candidate_unverified",
+      "rationale": "Gateway/relay-relevant keyword match; not yet manually verified against TokenKey code.",
+      "updated_at": "2026-06-01T21:56:49Z"
+    },
+    {
+      "upstream": "anthropics/claude-code#64579",
+      "url": "https://github.com/anthropics/claude-code/issues/64579",
+      "title": "[Bug] Tool call parsing fails with unrecoverable error",
+      "impact": "needs_review",
+      "categories": [
+        "model_lifecycle"
+      ],
+      "tokenkey_status": "candidate_unverified",
+      "rationale": "Gateway/relay-relevant keyword match; not yet manually verified against TokenKey code.",
+      "updated_at": "2026-06-01T22:08:21Z"
+    },
+    {
+      "upstream": "anthropics/claude-code#64582",
+      "url": "https://github.com/anthropics/claude-code/issues/64582",
+      "title": "[BUG] extensibility.py follows symlinks in project-controlled guidance file, sending local file content to API",
+      "impact": "needs_review",
+      "categories": [
+        "auth_token"
+      ],
+      "tokenkey_status": "candidate_unverified",
+      "rationale": "Gateway/relay-relevant keyword match; not yet manually verified against TokenKey code.",
+      "updated_at": "2026-06-01T22:17:56Z"
+    },
+    {
+      "upstream": "anthropics/claude-code#64585",
+      "url": "https://github.com/anthropics/claude-code/issues/64585",
+      "title": "[BUG] CLAUDE_CODE_ATTRIBUTION_HEADER=0 also blocks auto classifier model",
+      "impact": "needs_review",
+      "categories": [
+        "model_lifecycle"
+      ],
+      "tokenkey_status": "candidate_unverified",
+      "rationale": "Gateway/relay-relevant keyword match; not yet manually verified against TokenKey code.",
+      "updated_at": "2026-06-01T22:59:10Z"
+    },
+    {
+      "upstream": "anthropics/claude-code#64587",
+      "url": "https://github.com/anthropics/claude-code/issues/64587",
+      "title": "[BUG] OAuth authentification fails on WSL2",
+      "impact": "needs_review",
+      "categories": [
+        "auth_token"
+      ],
+      "tokenkey_status": "candidate_unverified",
+      "rationale": "Gateway/relay-relevant keyword match; not yet manually verified against TokenKey code.",
+      "updated_at": "2026-06-02T20:05:25Z"
+    },
+    {
+      "upstream": "anthropics/claude-code#64588",
+      "url": "https://github.com/anthropics/claude-code/issues/64588",
+      "title": "[BUG] Claude Code burns rate limits in minutes, indexes its own generated files, silently burns rate limits on failed image processing",
+      "impact": "needs_review",
+      "categories": [
+        "rate_limit"
+      ],
+      "tokenkey_status": "candidate_unverified",
+      "rationale": "Gateway/relay-relevant keyword match; not yet manually verified against TokenKey code.",
+      "updated_at": "2026-06-01T23:07:54Z"
+    },
+    {
+      "upstream": "anthropics/claude-code#64589",
+      "url": "https://github.com/anthropics/claude-code/issues/64589",
+      "title": "[BUG] Massive dump of context caching issues, duplication of actions, and bloat",
+      "impact": "needs_review",
+      "categories": [
+        "request_shape_400",
+        "model_lifecycle",
+        "prompt_caching"
+      ],
+      "tokenkey_status": "candidate_unverified",
+      "rationale": "Gateway/relay-relevant keyword match; not yet manually verified against TokenKey code.",
+      "updated_at": "2026-06-02T00:07:27Z"
+    },
+    {
+      "upstream": "anthropics/claude-code#64591",
+      "url": "https://github.com/anthropics/claude-code/issues/64591",
+      "title": "Remote Control: registration reconnect ignores 429 retry-after, causing synchronized reconnect storms with multiple hosts on one account",
+      "impact": "needs_review",
+      "categories": [
+        "rate_limit",
+        "auth_token"
+      ],
+      "tokenkey_status": "candidate_unverified",
+      "rationale": "Gateway/relay-relevant keyword match; not yet manually verified against TokenKey code.",
+      "updated_at": "2026-06-01T23:22:25Z"
+    },
+    {
+      "upstream": "anthropics/claude-code#64608",
+      "url": "https://github.com/anthropics/claude-code/issues/64608",
+      "title": "[BUG] False-positive AUP block on legitimate RNA biophysics substrate output",
+      "impact": "needs_review",
+      "categories": [
+        "model_lifecycle"
+      ],
+      "tokenkey_status": "candidate_unverified",
+      "rationale": "Gateway/relay-relevant keyword match; not yet manually verified against TokenKey code.",
+      "updated_at": "2026-06-02T00:52:23Z"
+    },
+    {
+      "upstream": "anthropics/claude-code#64610",
+      "url": "https://github.com/anthropics/claude-code/issues/64610",
+      "title": "[DOCS] Undocumented built-in allowlist bypasses WebFetch `deny` rules",
+      "impact": "needs_review",
+      "categories": [
+        "model_lifecycle"
+      ],
+      "tokenkey_status": "candidate_unverified",
+      "rationale": "Gateway/relay-relevant keyword match; not yet manually verified against TokenKey code.",
+      "updated_at": "2026-06-02T01:39:25Z"
+    },
+    {
+      "upstream": "anthropics/claude-code#64613",
+      "url": "https://github.com/anthropics/claude-code/issues/64613",
+      "title": "[Bug] API requests consuming personal token quota when subscription tokens available",
+      "impact": "needs_review",
+      "categories": [
+        "auth_token"
+      ],
+      "tokenkey_status": "candidate_unverified",
+      "rationale": "Gateway/relay-relevant keyword match; not yet manually verified against TokenKey code.",
+      "updated_at": "2026-06-02T05:31:36Z"
+    },
+    {
+      "upstream": "anthropics/claude-code#64615",
+      "url": "https://github.com/anthropics/claude-code/issues/64615",
+      "title": "[BUG] /rewind (Esc Esc) silently reverts/loses code — destructive \"Restore code and conversation\" is the default with no confirmation",
+      "impact": "needs_review",
+      "categories": [
+        "rate_limit"
+      ],
+      "tokenkey_status": "candidate_unverified",
+      "rationale": "Gateway/relay-relevant keyword match; not yet manually verified against TokenKey code.",
+      "updated_at": "2026-06-02T03:25:17Z"
+    },
+    {
+      "upstream": "anthropics/claude-code#64618",
+      "url": "https://github.com/anthropics/claude-code/issues/64618",
+      "title": "[FEATURE] Off-Peak Usage Incentives for Personal Accounts",
+      "impact": "needs_review",
+      "categories": [
+        "rate_limit"
+      ],
+      "tokenkey_status": "candidate_unverified",
+      "rationale": "Gateway/relay-relevant keyword match; not yet manually verified against TokenKey code.",
+      "updated_at": "2026-06-02T02:34:18Z"
+    },
+    {
+      "upstream": "anthropics/claude-code#64633",
+      "url": "https://github.com/anthropics/claude-code/issues/64633",
+      "title": "[FEATURE] MCP Server Registry Discovery: connect Claude Code to an enterprise MCP server catalog",
+      "impact": "needs_review",
+      "categories": [
+        "auth_token"
+      ],
+      "tokenkey_status": "candidate_unverified",
+      "rationale": "Gateway/relay-relevant keyword match; not yet manually verified against TokenKey code.",
+      "updated_at": "2026-06-02T03:38:24Z"
+    },
+    {
+      "upstream": "anthropics/claude-code#64636",
+      "url": "https://github.com/anthropics/claude-code/issues/64636",
+      "title": "Microsoft 365 MCP server: AADSTS900971 “No reply address provided” on every auth attempt",
+      "impact": "needs_review",
+      "categories": [
+        "auth_token"
+      ],
+      "tokenkey_status": "candidate_unverified",
+      "rationale": "Gateway/relay-relevant keyword match; not yet manually verified against TokenKey code.",
+      "updated_at": "2026-06-02T03:55:43Z"
+    },
+    {
+      "upstream": "anthropics/claude-code#64646",
+      "url": "https://github.com/anthropics/claude-code/issues/64646",
+      "title": "[DOCS] Fast mode docs still instruct users to set removed `CLAUDE_CODE_OPUS_4_6_FAST_MODE_OVERRIDE`",
+      "impact": "needs_review",
+      "categories": [
+        "model_lifecycle"
+      ],
+      "tokenkey_status": "candidate_unverified",
+      "rationale": "Gateway/relay-relevant keyword match; not yet manually verified against TokenKey code.",
+      "updated_at": "2026-06-02T04:28:39Z"
+    },
+    {
+      "upstream": "anthropics/claude-code#64648",
+      "url": "https://github.com/anthropics/claude-code/issues/64648",
+      "title": "[DOCS] Error reference suggests `/model` and `--model` for SDK `model_not_found` errors",
+      "impact": "needs_review",
+      "categories": [
+        "model_lifecycle"
+      ],
+      "tokenkey_status": "candidate_unverified",
+      "rationale": "Gateway/relay-relevant keyword match; not yet manually verified against TokenKey code.",
+      "updated_at": "2026-06-02T04:30:03Z"
+    },
+    {
+      "upstream": "anthropics/claude-code#64651",
+      "url": "https://github.com/anthropics/claude-code/issues/64651",
+      "title": "[BUG] VSCode: background agent output streams into foreground chat, disrupting active conversation",
+      "impact": "needs_review",
+      "categories": [
+        "model_lifecycle"
+      ],
+      "tokenkey_status": "candidate_unverified",
+      "rationale": "Gateway/relay-relevant keyword match; not yet manually verified against TokenKey code.",
+      "updated_at": "2026-06-02T20:23:10Z"
+    },
+    {
+      "upstream": "anthropics/claude-code#64654",
+      "url": "https://github.com/anthropics/claude-code/issues/64654",
+      "title": "[BUG] plugin:github:github MCP fails with HTTP 400 — malformed JSON-RPC payload missing version tag",
+      "impact": "needs_review",
+      "categories": [
+        "request_shape_400"
+      ],
+      "tokenkey_status": "candidate_unverified",
+      "rationale": "Gateway/relay-relevant keyword match; not yet manually verified against TokenKey code.",
+      "updated_at": "2026-06-02T05:16:22Z"
+    },
+    {
+      "upstream": "anthropics/claude-code#64658",
+      "url": "https://github.com/anthropics/claude-code/issues/64658",
+      "title": "[Bug] Desktop app (Code tab) 1.9659.4: Opus 4.8 \"tool call could not be parsed (retry also failed)\" still reproduces",
+      "impact": "needs_review",
+      "categories": [
+        "request_shape_400",
+        "model_lifecycle"
+      ],
+      "tokenkey_status": "candidate_unverified",
+      "rationale": "Gateway/relay-relevant keyword match; not yet manually verified against TokenKey code.",
+      "updated_at": "2026-06-02T05:47:42Z"
+    },
+    {
+      "upstream": "anthropics/claude-code#64660",
+      "url": "https://github.com/anthropics/claude-code/issues/64660",
+      "title": "Feature: Option to restrict the /advisor command to specific models (e.g. disable on Opus)",
+      "impact": "needs_review",
+      "categories": [
+        "model_lifecycle"
+      ],
+      "tokenkey_status": "candidate_unverified",
+      "rationale": "Gateway/relay-relevant keyword match; not yet manually verified against TokenKey code.",
+      "updated_at": "2026-06-02T06:19:20Z"
+    },
+    {
+      "upstream": "anthropics/claude-code#64664",
+      "url": "https://github.com/anthropics/claude-code/issues/64664",
+      "title": "[Bug] Swarm in dynamic workflow causes context overflow and agent termination on rate limiting",
+      "impact": "needs_review",
+      "categories": [
+        "rate_limit"
+      ],
+      "tokenkey_status": "candidate_unverified",
+      "rationale": "Gateway/relay-relevant keyword match; not yet manually verified against TokenKey code.",
+      "updated_at": "2026-06-02T18:07:01Z"
+    },
+    {
+      "upstream": "anthropics/claude-code#64667",
+      "url": "https://github.com/anthropics/claude-code/issues/64667",
+      "title": "[Bug] Rate Limit: Anthropic API Overloaded (Error 529)",
+      "impact": "needs_review",
+      "categories": [
+        "rate_limit",
+        "auth_token"
+      ],
+      "tokenkey_status": "candidate_unverified",
+      "rationale": "Gateway/relay-relevant keyword match; not yet manually verified against TokenKey code.",
+      "updated_at": "2026-06-02T06:54:03Z"
+    },
+    {
+      "upstream": "anthropics/claude-code#64669",
+      "url": "https://github.com/anthropics/claude-code/issues/64669",
+      "title": "[BUG] All official plugin slash commands (/) unavailable — plugin.json missing commands/skills fields",
+      "impact": "needs_review",
+      "categories": [
+        "model_lifecycle"
+      ],
+      "tokenkey_status": "candidate_unverified",
+      "rationale": "Gateway/relay-relevant keyword match; not yet manually verified against TokenKey code.",
+      "updated_at": "2026-06-02T07:00:36Z"
+    },
+    {
+      "upstream": "anthropics/claude-code#64672",
+      "url": "https://github.com/anthropics/claude-code/issues/64672",
+      "title": "[BUG] Google OAuth login repeatedly fails on Windows - \"ignoring repeat delivery of login callback\"",
+      "impact": "needs_review",
+      "categories": [
+        "auth_token",
+        "fingerprint_ua"
+      ],
+      "tokenkey_status": "candidate_unverified",
+      "rationale": "Gateway/relay-relevant keyword match; not yet manually verified against TokenKey code.",
+      "updated_at": "2026-06-02T07:07:11Z"
+    },
+    {
+      "upstream": "anthropics/claude-code#64677",
+      "url": "https://github.com/anthropics/claude-code/issues/64677",
+      "title": "[BUG] Claude Desktop 3P - Foundry config with Interactive Sign-in uses wrong url",
+      "impact": "needs_review",
+      "categories": [
+        "model_lifecycle"
+      ],
+      "tokenkey_status": "candidate_unverified",
+      "rationale": "Gateway/relay-relevant keyword match; not yet manually verified against TokenKey code.",
+      "updated_at": "2026-06-02T07:45:10Z"
+    },
+    {
+      "upstream": "anthropics/claude-code#64683",
+      "url": "https://github.com/anthropics/claude-code/issues/64683",
+      "title": "[Bug] Anthropic API Error: Usage credits required for 1M context persists after login",
+      "impact": "needs_review",
+      "categories": [
+        "model_lifecycle"
+      ],
+      "tokenkey_status": "candidate_unverified",
+      "rationale": "Gateway/relay-relevant keyword match; not yet manually verified against TokenKey code.",
+      "updated_at": "2026-06-02T08:17:40Z"
+    },
+    {
+      "upstream": "anthropics/claude-code#64684",
+      "url": "https://github.com/anthropics/claude-code/issues/64684",
+      "title": "Tool call intermittently emitted as literal \"count\" (antml: prefix dropped, \"could not be parsed\") in long Opus 4.8 1M-context sessions",
+      "impact": "needs_review",
+      "categories": [
+        "model_lifecycle"
+      ],
+      "tokenkey_status": "candidate_unverified",
+      "rationale": "Gateway/relay-relevant keyword match; not yet manually verified against TokenKey code.",
+      "updated_at": "2026-06-02T08:16:09Z"
+    },
+    {
+      "upstream": "anthropics/claude-code#64698",
+      "url": "https://github.com/anthropics/claude-code/issues/64698",
+      "title": "Phantom user turn carried a context-aware prompt-injection / data-exfiltration payload (Windows, CLI 2.1.160, Opus 4.8)",
+      "impact": "needs_review",
+      "categories": [
+        "auth_token",
+        "model_lifecycle"
+      ],
+      "tokenkey_status": "candidate_unverified",
+      "rationale": "Gateway/relay-relevant keyword match; not yet manually verified against TokenKey code.",
+      "updated_at": "2026-06-02T21:50:42Z"
+    },
+    {
+      "upstream": "anthropics/claude-code#64700",
+      "url": "https://github.com/anthropics/claude-code/issues/64700",
+      "title": "Stray \"court\" token emitted immediately before tool-use <invoke> tag corrupts the tool call (Opus 4.8, Claude Code 2.1.158)",
+      "impact": "needs_review",
+      "categories": [
+        "model_lifecycle"
+      ],
+      "tokenkey_status": "candidate_unverified",
+      "rationale": "Gateway/relay-relevant keyword match; not yet manually verified against TokenKey code.",
+      "updated_at": "2026-06-02T09:54:26Z"
+    },
+    {
+      "upstream": "anthropics/claude-code#64701",
+      "url": "https://github.com/anthropics/claude-code/issues/64701",
+      "title": "Cost price-map wrong in CLI 2.1.159: claude-opus-4-8 billed 3× high, claude-sonnet-4-5 1.67× high",
+      "impact": "needs_review",
+      "categories": [
+        "model_lifecycle"
+      ],
+      "tokenkey_status": "candidate_unverified",
+      "rationale": "Gateway/relay-relevant keyword match; not yet manually verified against TokenKey code.",
+      "updated_at": "2026-06-02T09:54:38Z"
+    },
+    {
+      "upstream": "anthropics/claude-code#64705",
+      "url": "https://github.com/anthropics/claude-code/issues/64705",
+      "title": "[BUG]",
+      "impact": "needs_review",
+      "categories": [
+        "auth_token",
+        "prompt_caching"
+      ],
+      "tokenkey_status": "candidate_unverified",
+      "rationale": "Gateway/relay-relevant keyword match; not yet manually verified against TokenKey code.",
+      "updated_at": "2026-06-02T10:15:52Z"
+    },
+    {
+      "upstream": "anthropics/claude-code#64707",
+      "url": "https://github.com/anthropics/claude-code/issues/64707",
+      "title": "Agent self-review: 6 failure modes from adding a parallel agent path to a benchmark framework (with corrected rules)",
+      "impact": "needs_review",
+      "categories": [
+        "request_shape_400"
+      ],
+      "tokenkey_status": "candidate_unverified",
+      "rationale": "Gateway/relay-relevant keyword match; not yet manually verified against TokenKey code.",
+      "updated_at": "2026-06-02T10:03:37Z"
+    },
+    {
+      "upstream": "anthropics/claude-code#64710",
+      "url": "https://github.com/anthropics/claude-code/issues/64710",
+      "title": "[BUG] Desktop app injects an EMPTY `ANTHROPIC_API_KEY=\"\"` into Claude Code sessions, which disables Remote Control (false positive of the 2.1.139 API-key guard)",
+      "impact": "needs_review",
+      "categories": [
+        "auth_token"
+      ],
+      "tokenkey_status": "candidate_unverified",
+      "rationale": "Gateway/relay-relevant keyword match; not yet manually verified against TokenKey code.",
+      "updated_at": "2026-06-02T10:32:27Z"
+    },
+    {
+      "upstream": "anthropics/claude-code#64715",
+      "url": "https://github.com/anthropics/claude-code/issues/64715",
+      "title": "[BUG] MSIX/Store install does not register claude:// protocol handler → OAuth login loops indefinitely",
+      "impact": "needs_review",
+      "categories": [
+        "auth_token"
+      ],
+      "tokenkey_status": "candidate_unverified",
+      "rationale": "Gateway/relay-relevant keyword match; not yet manually verified against TokenKey code.",
+      "updated_at": "2026-06-02T10:57:09Z"
+    },
+    {
+      "upstream": "anthropics/claude-code#64722",
+      "url": "https://github.com/anthropics/claude-code/issues/64722",
+      "title": "[BUG] Claude Code activity in organisation analytics are missing some users",
+      "impact": "needs_review",
+      "categories": [
+        "model_lifecycle"
+      ],
+      "tokenkey_status": "candidate_unverified",
+      "rationale": "Gateway/relay-relevant keyword match; not yet manually verified against TokenKey code.",
+      "updated_at": "2026-06-02T11:42:18Z"
+    },
+    {
+      "upstream": "anthropics/claude-code#64730",
+      "url": "https://github.com/anthropics/claude-code/issues/64730",
+      "title": "[BUG] RTL paragraph alignment regressed in terminal CLI: right-aligned in 2.1.132 → left-aligned since 2.1.138",
+      "impact": "needs_review",
+      "categories": [
+        "auth_token"
+      ],
+      "tokenkey_status": "candidate_unverified",
+      "rationale": "Gateway/relay-relevant keyword match; not yet manually verified against TokenKey code.",
+      "updated_at": "2026-06-02T12:38:51Z"
+    },
+    {
+      "upstream": "anthropics/claude-code#64735",
+      "url": "https://github.com/anthropics/claude-code/issues/64735",
+      "title": "[BUG] Cowork",
+      "impact": "needs_review",
+      "categories": [
+        "model_lifecycle"
+      ],
+      "tokenkey_status": "candidate_unverified",
+      "rationale": "Gateway/relay-relevant keyword match; not yet manually verified against TokenKey code.",
+      "updated_at": "2026-06-02T12:55:22Z"
+    },
+    {
+      "upstream": "anthropics/claude-code#64737",
+      "url": "https://github.com/anthropics/claude-code/issues/64737",
+      "title": "[BUG]",
+      "impact": "needs_review",
+      "categories": [
+        "request_shape_400"
+      ],
+      "tokenkey_status": "candidate_unverified",
+      "rationale": "Gateway/relay-relevant keyword match; not yet manually verified against TokenKey code.",
+      "updated_at": "2026-06-02T13:02:29Z"
+    },
+    {
+      "upstream": "anthropics/claude-code#64742",
+      "url": "https://github.com/anthropics/claude-code/issues/64742",
+      "title": "[BUG]",
+      "impact": "needs_review",
+      "categories": [
+        "request_shape_400",
+        "model_lifecycle"
+      ],
+      "tokenkey_status": "candidate_unverified",
+      "rationale": "Gateway/relay-relevant keyword match; not yet manually verified against TokenKey code.",
+      "updated_at": "2026-06-02T13:18:35Z"
+    },
+    {
+      "upstream": "anthropics/claude-code#64762",
+      "url": "https://github.com/anthropics/claude-code/issues/64762",
+      "title": "[BUG] claude.ai/install.sh got Cloudflare'd (403 due to Managed Challege)",
+      "impact": "needs_review",
+      "categories": [
+        "fingerprint_ua"
+      ],
+      "tokenkey_status": "candidate_unverified",
+      "rationale": "Gateway/relay-relevant keyword match; not yet manually verified against TokenKey code.",
+      "updated_at": "2026-06-02T14:34:36Z"
+    },
+    {
+      "upstream": "anthropics/claude-code#64766",
+      "url": "https://github.com/anthropics/claude-code/issues/64766",
+      "title": "[BUG] Azure AI Foundry model probe missing api-version parameter causes spurious 404 error",
+      "impact": "needs_review",
+      "categories": [
+        "model_lifecycle"
+      ],
+      "tokenkey_status": "candidate_unverified",
+      "rationale": "Gateway/relay-relevant keyword match; not yet manually verified against TokenKey code.",
+      "updated_at": "2026-06-02T14:33:32Z"
+    },
+    {
+      "upstream": "anthropics/claude-code#64774",
+      "url": "https://github.com/anthropics/claude-code/issues/64774",
+      "title": "Opus claude-opus-4-8 emits unparseable tool calls at ~1.5% rate; opus-4-7 and sonnet-4-6 have 0% failure rate",
+      "impact": "needs_review",
+      "categories": [
+        "model_lifecycle"
+      ],
+      "tokenkey_status": "candidate_unverified",
+      "rationale": "Gateway/relay-relevant keyword match; not yet manually verified against TokenKey code.",
+      "updated_at": "2026-06-03T05:09:22Z"
+    },
+    {
+      "upstream": "anthropics/claude-code#64777",
+      "url": "https://github.com/anthropics/claude-code/issues/64777",
+      "title": "[BUG] API Error 400 - The request body is not valid JSON: str is not valid UTF-8: surrogates not allowed - mid-conversation error",
+      "impact": "needs_review",
+      "categories": [
+        "request_shape_400"
+      ],
+      "tokenkey_status": "candidate_unverified",
+      "rationale": "Gateway/relay-relevant keyword match; not yet manually verified against TokenKey code.",
+      "updated_at": "2026-06-02T15:13:20Z"
+    },
+    {
+      "upstream": "anthropics/claude-code#64784",
+      "url": "https://github.com/anthropics/claude-code/issues/64784",
+      "title": "[BUG] Claude in Chrome (VS Code 2.1.160): `mcp_set_servers` publishes only SDK tools to the model and gates even that on `sdkServersChanged` — so a dynamically-added stdio server connects (status/pill shows its tools) but the model never receives them",
+      "impact": "needs_review",
+      "categories": [
+        "model_lifecycle"
+      ],
+      "tokenkey_status": "candidate_unverified",
+      "rationale": "Gateway/relay-relevant keyword match; not yet manually verified against TokenKey code.",
+      "updated_at": "2026-06-02T15:47:30Z"
+    },
+    {
+      "upstream": "anthropics/claude-code#64791",
+      "url": "https://github.com/anthropics/claude-code/issues/64791",
+      "title": "[Bug] Assistant response hallucinating fake user/system turns with stop_reason=None at high context accumulation",
+      "impact": "needs_review",
+      "categories": [
+        "model_lifecycle",
+        "prompt_caching"
+      ],
+      "tokenkey_status": "candidate_unverified",
+      "rationale": "Gateway/relay-relevant keyword match; not yet manually verified against TokenKey code.",
+      "updated_at": "2026-06-02T16:22:07Z"
+    },
+    {
+      "upstream": "anthropics/claude-code#64796",
+      "url": "https://github.com/anthropics/claude-code/issues/64796",
+      "title": "/schedule (RemoteTrigger create) returns 400: events[0] event_type is required vs proto unknown field event_type — schema v1→v2 mismatch",
+      "impact": "needs_review",
+      "categories": [
+        "request_shape_400",
+        "model_lifecycle"
+      ],
+      "tokenkey_status": "candidate_unverified",
+      "rationale": "Gateway/relay-relevant keyword match; not yet manually verified against TokenKey code.",
+      "updated_at": "2026-06-02T16:39:49Z"
+    },
+    {
+      "upstream": "anthropics/claude-code#64797",
+      "url": "https://github.com/anthropics/claude-code/issues/64797",
+      "title": "Remote Control: Android approval signal silently dropped — server never receives it (Linux/tmux, pure remote session)",
+      "impact": "needs_review",
+      "categories": [
+        "request_shape_400"
+      ],
+      "tokenkey_status": "candidate_unverified",
+      "rationale": "Gateway/relay-relevant keyword match; not yet manually verified against TokenKey code.",
+      "updated_at": "2026-06-03T04:39:55Z"
+    },
+    {
+      "upstream": "anthropics/claude-code#64801",
+      "url": "https://github.com/anthropics/claude-code/issues/64801",
+      "title": "google-workspace MCP: read tools fail with \"Field mask cannot retrieve comment-specific fields when include_comments is false\"",
+      "impact": "needs_review",
+      "categories": [
+        "auth_token",
+        "fingerprint_ua"
+      ],
+      "tokenkey_status": "candidate_unverified",
+      "rationale": "Gateway/relay-relevant keyword match; not yet manually verified against TokenKey code.",
+      "updated_at": "2026-06-02T16:41:09Z"
+    },
+    {
+      "upstream": "anthropics/claude-code#64802",
+      "url": "https://github.com/anthropics/claude-code/issues/64802",
+      "title": "Autocompact silently disabled for Bedrock/Vertex users since v2.1.154",
+      "impact": "needs_review",
+      "categories": [
+        "model_lifecycle"
+      ],
+      "tokenkey_status": "candidate_unverified",
+      "rationale": "Gateway/relay-relevant keyword match; not yet manually verified against TokenKey code.",
+      "updated_at": "2026-06-02T16:41:30Z"
+    },
+    {
+      "upstream": "anthropics/claude-code#64814",
+      "url": "https://github.com/anthropics/claude-code/issues/64814",
+      "title": "[Billing Bug] Account charged twice for unauthorized Max Plan upgrade — refund denied despite system error",
+      "impact": "needs_review",
+      "categories": [
+        "auth_token"
+      ],
+      "tokenkey_status": "candidate_unverified",
+      "rationale": "Gateway/relay-relevant keyword match; not yet manually verified against TokenKey code.",
+      "updated_at": "2026-06-02T17:21:36Z"
+    },
+    {
+      "upstream": "anthropics/claude-code#64820",
+      "url": "https://github.com/anthropics/claude-code/issues/64820",
+      "title": "[Bug] Doctor command detects issues but lacks remediation guidance",
+      "impact": "needs_review",
+      "categories": [
+        "auth_token",
+        "prompt_caching"
+      ],
+      "tokenkey_status": "candidate_unverified",
+      "rationale": "Gateway/relay-relevant keyword match; not yet manually verified against TokenKey code.",
+      "updated_at": "2026-06-02T17:43:24Z"
+    },
+    {
+      "upstream": "anthropics/claude-code#64832",
+      "url": "https://github.com/anthropics/claude-code/issues/64832",
+      "title": "Suspected Node.js subprocess leak in v2.1.160 — ~115 node processes exhaust RAM, trigger system-wide OOM",
+      "impact": "needs_review",
+      "categories": [
+        "request_shape_400"
+      ],
+      "tokenkey_status": "candidate_unverified",
+      "rationale": "Gateway/relay-relevant keyword match; not yet manually verified against TokenKey code.",
+      "updated_at": "2026-06-03T00:21:03Z"
+    },
+    {
+      "upstream": "anthropics/claude-code#64838",
+      "url": "https://github.com/anthropics/claude-code/issues/64838",
+      "title": "[BUG] Cowork remote MCP connector — \"Couldn't reach the MCP server\" with auth state desync, reference ID returned for support lookup",
+      "impact": "needs_review",
+      "categories": [
+        "auth_token"
+      ],
+      "tokenkey_status": "candidate_unverified",
+      "rationale": "Gateway/relay-relevant keyword match; not yet manually verified against TokenKey code.",
+      "updated_at": "2026-06-02T20:36:30Z"
+    },
+    {
+      "upstream": "anthropics/claude-code#64846",
+      "url": "https://github.com/anthropics/claude-code/issues/64846",
+      "title": "[BUG] Unable to authenticate my monday.com account with claude.ai using their Oauth flow",
+      "impact": "needs_review",
+      "categories": [
+        "auth_token",
+        "model_lifecycle"
+      ],
+      "tokenkey_status": "candidate_unverified",
+      "rationale": "Gateway/relay-relevant keyword match; not yet manually verified against TokenKey code.",
+      "updated_at": "2026-06-02T19:55:57Z"
+    },
+    {
+      "upstream": "anthropics/claude-code#64848",
+      "url": "https://github.com/anthropics/claude-code/issues/64848",
+      "title": "Model self-identification stale: UI selects Opus 4.8, system prompt still says Opus 4.7",
+      "impact": "needs_review",
+      "categories": [
+        "model_lifecycle"
+      ],
+      "tokenkey_status": "candidate_unverified",
+      "rationale": "Gateway/relay-relevant keyword match; not yet manually verified against TokenKey code.",
+      "updated_at": "2026-06-02T20:21:19Z"
+    },
+    {
+      "upstream": "anthropics/claude-code#64850",
+      "url": "https://github.com/anthropics/claude-code/issues/64850",
+      "title": "Context limit UX failure: No progressive warnings, misleading error messages, cascade failure in compaction",
+      "impact": "needs_review",
+      "categories": [
+        "model_lifecycle"
+      ],
+      "tokenkey_status": "candidate_unverified",
+      "rationale": "Gateway/relay-relevant keyword match; not yet manually verified against TokenKey code.",
+      "updated_at": "2026-06-02T20:31:37Z"
+    },
+    {
+      "upstream": "anthropics/claude-code#64852",
+      "url": "https://github.com/anthropics/claude-code/issues/64852",
+      "title": "[BUG] API Error: Server is temporarily limiting requests (not your usage limit) · Rate limited",
+      "impact": "needs_review",
+      "categories": [
+        "rate_limit"
+      ],
+      "tokenkey_status": "candidate_unverified",
+      "rationale": "Gateway/relay-relevant keyword match; not yet manually verified against TokenKey code.",
+      "updated_at": "2026-06-02T20:41:17Z"
+    },
+    {
+      "upstream": "anthropics/claude-code#64854",
+      "url": "https://github.com/anthropics/claude-code/issues/64854",
+      "title": "[BUG] Claude Dispatch returns \"Could not process image\" error (400 invalid_request_error) on every message, breaking sessions on Windows",
+      "impact": "needs_review",
+      "categories": [
+        "request_shape_400"
+      ],
+      "tokenkey_status": "candidate_unverified",
+      "rationale": "Gateway/relay-relevant keyword match; not yet manually verified against TokenKey code.",
+      "updated_at": "2026-06-02T20:48:55Z"
+    },
+    {
+      "upstream": "anthropics/claude-code#64859",
+      "url": "https://github.com/anthropics/claude-code/issues/64859",
+      "title": "[BUG] claude-opus-4-7[1m] drifts from auto-loaded CLAUDE.md and memory notes across long sessions",
+      "impact": "needs_review",
+      "categories": [
+        "model_lifecycle"
+      ],
+      "tokenkey_status": "candidate_unverified",
+      "rationale": "Gateway/relay-relevant keyword match; not yet manually verified against TokenKey code.",
+      "updated_at": "2026-06-03T06:02:33Z"
+    },
+    {
+      "upstream": "anthropics/claude-code#64880",
+      "url": "https://github.com/anthropics/claude-code/issues/64880",
+      "title": "[BUG] API returns the same `message.id` across multiple sequential responses under load (silent corruption, no error)",
+      "impact": "needs_review",
+      "categories": [
+        "request_shape_400",
+        "rate_limit",
+        "model_lifecycle"
+      ],
+      "tokenkey_status": "candidate_unverified",
+      "rationale": "Gateway/relay-relevant keyword match; not yet manually verified against TokenKey code.",
+      "updated_at": "2026-06-02T23:39:25Z"
+    },
+    {
+      "upstream": "anthropics/claude-code#64882",
+      "url": "https://github.com/anthropics/claude-code/issues/64882",
+      "title": "[BUG] Model re-reads an unchanged file in a loop, ignoring repeated \"Wasted call — file unchanged\" rejections (bare rejection gives a context-corrupted model nothing to recover from)",
+      "impact": "needs_review",
+      "categories": [
+        "request_shape_400",
+        "model_lifecycle"
+      ],
+      "tokenkey_status": "candidate_unverified",
+      "rationale": "Gateway/relay-relevant keyword match; not yet manually verified against TokenKey code.",
+      "updated_at": "2026-06-02T23:02:08Z"
+    },
+    {
+      "upstream": "anthropics/claude-code#64885",
+      "url": "https://github.com/anthropics/claude-code/issues/64885",
+      "title": "[BUG] \"Usage limit reached\" hard-stop fires below the displayed 5-hour ceiling (~95%, not 100%)",
+      "impact": "needs_review",
+      "categories": [
+        "request_shape_400",
+        "rate_limit"
+      ],
+      "tokenkey_status": "candidate_unverified",
+      "rationale": "Gateway/relay-relevant keyword match; not yet manually verified against TokenKey code.",
+      "updated_at": "2026-06-02T23:10:38Z"
+    },
+    {
+      "upstream": "anthropics/claude-code#64886",
+      "url": "https://github.com/anthropics/claude-code/issues/64886",
+      "title": "[DOCS] `claude mcp list/get` docs omit secret-safe terminal output behavior",
+      "impact": "needs_review",
+      "categories": [
+        "auth_token"
+      ],
+      "tokenkey_status": "candidate_unverified",
+      "rationale": "Gateway/relay-relevant keyword match; not yet manually verified against TokenKey code.",
+      "updated_at": "2026-06-03T02:15:24Z"
+    },
+    {
+      "upstream": "anthropics/claude-code#64893",
+      "url": "https://github.com/anthropics/claude-code/issues/64893",
+      "title": "[BUG] --callback-port not respected — OAuth listener not started when using /mcp authentication flow.",
+      "impact": "needs_review",
+      "categories": [
+        "auth_token"
+      ],
+      "tokenkey_status": "candidate_unverified",
+      "rationale": "Gateway/relay-relevant keyword match; not yet manually verified against TokenKey code.",
+      "updated_at": "2026-06-02T23:39:05Z"
+    },
+    {
+      "upstream": "anthropics/claude-code#64894",
+      "url": "https://github.com/anthropics/claude-code/issues/64894",
+      "title": "[BUG] headersHelper output not applied to HTTP MCP requests -- SDK ignores tokens and falls through to OAuth 2.1 browser flow",
+      "impact": "needs_review",
+      "categories": [
+        "auth_token",
+        "fingerprint_ua"
+      ],
+      "tokenkey_status": "candidate_unverified",
+      "rationale": "Gateway/relay-relevant keyword match; not yet manually verified against TokenKey code.",
+      "updated_at": "2026-06-03T00:17:05Z"
+    },
+    {
+      "upstream": "anthropics/claude-code#64900",
+      "url": "https://github.com/anthropics/claude-code/issues/64900",
+      "title": "[BUG] Intermittent mid-stream SSE stall — Opus 4.7/4.8, Sonnet 4.6, pause token emission 40–600s mid-response, latency increasing (VS Code extension)",
+      "impact": "needs_review",
+      "categories": [
+        "auth_token",
+        "model_lifecycle"
+      ],
+      "tokenkey_status": "candidate_unverified",
+      "rationale": "Gateway/relay-relevant keyword match; not yet manually verified against TokenKey code.",
+      "updated_at": "2026-06-03T01:31:13Z"
+    },
+    {
+      "upstream": "anthropics/claude-code#64901",
+      "url": "https://github.com/anthropics/claude-code/issues/64901",
+      "title": "[BUG] Async sub-agent completion can rebuild warm prompt cache, quickly burning usage limits in long-running sessions",
+      "impact": "needs_review",
+      "categories": [
+        "prompt_caching"
+      ],
+      "tokenkey_status": "candidate_unverified",
+      "rationale": "Gateway/relay-relevant keyword match; not yet manually verified against TokenKey code.",
+      "updated_at": "2026-06-03T00:09:05Z"
+    },
+    {
+      "upstream": "anthropics/claude-code#64904",
+      "url": "https://github.com/anthropics/claude-code/issues/64904",
+      "title": "[BUG] Autocompact not triggering at appropriate threshold - reached 186% context - could no longer /compact",
+      "impact": "needs_review",
+      "categories": [
+        "model_lifecycle"
+      ],
+      "tokenkey_status": "candidate_unverified",
+      "rationale": "Gateway/relay-relevant keyword match; not yet manually verified against TokenKey code.",
+      "updated_at": "2026-06-03T00:31:00Z"
+    },
+    {
+      "upstream": "anthropics/claude-code#64905",
+      "url": "https://github.com/anthropics/claude-code/issues/64905",
+      "title": "API Error: Server is temporarily limiting requests (not your usage limit) · Rate limited",
+      "impact": "needs_review",
+      "categories": [
+        "rate_limit"
+      ],
+      "tokenkey_status": "candidate_unverified",
+      "rationale": "Gateway/relay-relevant keyword match; not yet manually verified against TokenKey code.",
+      "updated_at": "2026-06-03T00:41:32Z"
+    },
+    {
+      "upstream": "anthropics/claude-code#64911",
+      "url": "https://github.com/anthropics/claude-code/issues/64911",
+      "title": "/compact blocked by the same tier gate that caused the overflow, leaving sessions unrecoverable",
+      "impact": "needs_review",
+      "categories": [
+        "model_lifecycle",
+        "fingerprint_ua"
+      ],
+      "tokenkey_status": "candidate_unverified",
+      "rationale": "Gateway/relay-relevant keyword match; not yet manually verified against TokenKey code.",
+      "updated_at": "2026-06-03T01:12:52Z"
+    },
+    {
+      "upstream": "anthropics/claude-code#64912",
+      "url": "https://github.com/anthropics/claude-code/issues/64912",
+      "title": "Specific API error silently replaced by generic UI message, hiding actionable remediation",
+      "impact": "needs_review",
+      "categories": [
+        "rate_limit",
+        "model_lifecycle"
+      ],
+      "tokenkey_status": "candidate_unverified",
+      "rationale": "Gateway/relay-relevant keyword match; not yet manually verified against TokenKey code.",
+      "updated_at": "2026-06-03T01:16:47Z"
+    },
+    {
+      "upstream": "anthropics/claude-code#64923",
+      "url": "https://github.com/anthropics/claude-code/issues/64923",
+      "title": "Auto-compaction fired mid-task on a 1M-context (Opus 4.8) session at ~50% reported context utilization",
+      "impact": "needs_review",
+      "categories": [
+        "model_lifecycle"
+      ],
+      "tokenkey_status": "candidate_unverified",
+      "rationale": "Gateway/relay-relevant keyword match; not yet manually verified against TokenKey code.",
+      "updated_at": "2026-06-03T01:58:42Z"
+    },
+    {
+      "upstream": "anthropics/claude-code#64924",
+      "url": "https://github.com/anthropics/claude-code/issues/64924",
+      "title": "[BUG] API Error: Server is temporarily limiting requests (not your usage limit) · Rate limited",
+      "impact": "needs_review",
+      "categories": [
+        "rate_limit"
+      ],
+      "tokenkey_status": "candidate_unverified",
+      "rationale": "Gateway/relay-relevant keyword match; not yet manually verified against TokenKey code.",
+      "updated_at": "2026-06-03T02:04:53Z"
+    },
+    {
+      "upstream": "anthropics/claude-code#64939",
+      "url": "https://github.com/anthropics/claude-code/issues/64939",
+      "title": "Claude Desktop (macOS): opening Settings hangs the entire app after a model is retired (stale model id 404s)",
+      "impact": "needs_review",
+      "categories": [
+        "auth_token",
+        "model_lifecycle"
+      ],
+      "tokenkey_status": "candidate_unverified",
+      "rationale": "Gateway/relay-relevant keyword match; not yet manually verified against TokenKey code.",
+      "updated_at": "2026-06-03T03:40:41Z"
+    },
+    {
+      "upstream": "anthropics/claude-code#64941",
+      "url": "https://github.com/anthropics/claude-code/issues/64941",
+      "title": "Slash-command autocomplete fails to match non-ASCII (CJK/Chinese) command names when filtering (v2.1.161, macOS)",
+      "impact": "needs_review",
+      "categories": [
+        "model_lifecycle"
+      ],
+      "tokenkey_status": "candidate_unverified",
+      "rationale": "Gateway/relay-relevant keyword match; not yet manually verified against TokenKey code.",
+      "updated_at": "2026-06-03T03:56:39Z"
+    },
+    {
+      "upstream": "anthropics/claude-code#64942",
+      "url": "https://github.com/anthropics/claude-code/issues/64942",
+      "title": "[BUG]: Chat panel renders black/blank in v2.1.161 (regression from v2.1.160)",
+      "impact": "needs_review",
+      "categories": [
+        "auth_token"
+      ],
+      "tokenkey_status": "candidate_unverified",
+      "rationale": "Gateway/relay-relevant keyword match; not yet manually verified against TokenKey code.",
+      "updated_at": "2026-06-03T03:54:04Z"
+    },
+    {
+      "upstream": "anthropics/claude-code#64944",
+      "url": "https://github.com/anthropics/claude-code/issues/64944",
+      "title": "[BUG]",
+      "impact": "needs_review",
+      "categories": [
+        "auth_token"
+      ],
+      "tokenkey_status": "candidate_unverified",
+      "rationale": "Gateway/relay-relevant keyword match; not yet manually verified against TokenKey code.",
+      "updated_at": "2026-06-03T04:08:29Z"
+    },
+    {
+      "upstream": "anthropics/claude-code#64947",
+      "url": "https://github.com/anthropics/claude-code/issues/64947",
+      "title": "[BUG] Claude in Chrome — Native Messaging Host IPC Failure on Windows",
+      "impact": "needs_review",
+      "categories": [
+        "rate_limit"
+      ],
+      "tokenkey_status": "candidate_unverified",
+      "rationale": "Gateway/relay-relevant keyword match; not yet manually verified against TokenKey code.",
+      "updated_at": "2026-06-03T04:57:38Z"
+    },
+    {
+      "upstream": "anthropics/claude-code#64950",
+      "url": "https://github.com/anthropics/claude-code/issues/64950",
+      "title": "[BUG] API Error: Server is temporarily limiting requests (not your usage limit) · Rate limited",
+      "impact": "needs_review",
+      "categories": [
+        "rate_limit"
+      ],
+      "tokenkey_status": "candidate_unverified",
+      "rationale": "Gateway/relay-relevant keyword match; not yet manually verified against TokenKey code.",
+      "updated_at": "2026-06-03T04:53:43Z"
+    },
+    {
+      "upstream": "anthropics/claude-code#64955",
+      "url": "https://github.com/anthropics/claude-code/issues/64955",
+      "title": "[Bug] Frequent \"tool call could not be parsed\" errors with parallel/non-ASCII tool calls",
+      "impact": "needs_review",
+      "categories": [
+        "model_lifecycle"
+      ],
+      "tokenkey_status": "candidate_unverified",
+      "rationale": "Gateway/relay-relevant keyword match; not yet manually verified against TokenKey code.",
+      "updated_at": "2026-06-03T05:32:03Z"
+    },
+    {
+      "upstream": "anthropics/claude-code#64960",
+      "url": "https://github.com/anthropics/claude-code/issues/64960",
+      "title": "Claude desktop (macOS) renders a blank window on the first launch after every update",
+      "impact": "needs_review",
+      "categories": [
+        "model_lifecycle"
+      ],
+      "tokenkey_status": "candidate_unverified",
+      "rationale": "Gateway/relay-relevant keyword match; not yet manually verified against TokenKey code.",
+      "updated_at": "2026-06-03T06:06:45Z"
+    },
+    {
+      "upstream": "anthropics/claude-code#64970",
+      "url": "https://github.com/anthropics/claude-code/issues/64970",
+      "title": "[Bug] Usage credits required for 1M context on Max 5x plan — standard model selected, Cowork + Claude Code",
+      "impact": "needs_review",
+      "categories": [
+        "rate_limit"
+      ],
+      "tokenkey_status": "candidate_unverified",
+      "rationale": "Gateway/relay-relevant keyword match; not yet manually verified against TokenKey code.",
+      "updated_at": "2026-06-03T06:53:58Z"
+    },
+    {
+      "upstream": "anthropics/claude-code#8327",
+      "url": "https://github.com/anthropics/claude-code/issues/8327",
+      "title": "[Bug/Documentation] 'Organization has been disabled' error when ANTHROPIC_API_KEY overrides Max/Pro subscription",
+      "impact": "needs_review",
+      "categories": [
+        "request_shape_400"
+      ],
+      "tokenkey_status": "candidate_unverified",
+      "rationale": "Gateway/relay-relevant keyword match; not yet manually verified against TokenKey code.",
+      "updated_at": "2026-06-02T20:35:55Z"
+    },
+    {
+      "upstream": "anthropics/claude-code#8938",
+      "url": "https://github.com/anthropics/claude-code/issues/8938",
+      "title": "[BUG] claude setup-token/CLAUDE_CODE_OAUTH_TOKEN is not enough to authenticate claude",
+      "impact": "needs_review",
+      "categories": [
+        "auth_token"
+      ],
+      "tokenkey_status": "candidate_unverified",
+      "rationale": "Gateway/relay-relevant keyword match; not yet manually verified against TokenKey code.",
+      "updated_at": "2026-06-01T15:09:44Z"
+    },
+    {
+      "upstream": "anthropics/claude-code#22264",
+      "url": "https://github.com/anthropics/claude-code/issues/22264",
+      "title": "Sibling tool call errored: parallel tool calls cascade-fail when one fails",
+      "impact": "medium",
+      "categories": [
+        "token_limits"
+      ],
+      "tokenkey_status": "not_prioritized",
+      "rationale": "Possible gateway compatibility/streaming impact, but not a high-severity relay signal in this pass.",
+      "updated_at": "2026-06-02T23:21:45Z"
+    },
+    {
+      "upstream": "anthropics/claude-code#36678",
+      "url": "https://github.com/anthropics/claude-code/issues/36678",
+      "title": "Expose session_id and context_window usage to the AI model",
+      "impact": "medium",
+      "categories": [
+        "token_limits",
+        "effort_structured"
+      ],
+      "tokenkey_status": "not_prioritized",
+      "rationale": "Possible gateway compatibility/streaming impact, but not a high-severity relay signal in this pass.",
+      "updated_at": "2026-06-02T11:31:43Z"
+    },
+    {
+      "upstream": "anthropics/claude-code#52819",
+      "url": "https://github.com/anthropics/claude-code/issues/52819",
+      "title": "ultrareview crashed before producing findings — free credit consumed",
+      "impact": "medium",
+      "categories": [
+        "token_limits"
+      ],
+      "tokenkey_status": "not_prioritized",
+      "rationale": "Possible gateway compatibility/streaming impact, but not a high-severity relay signal in this pass.",
+      "updated_at": "2026-06-02T22:44:07Z"
+    },
+    {
+      "upstream": "anthropics/claude-code#55814",
+      "url": "https://github.com/anthropics/claude-code/issues/55814",
+      "title": "ultrareview crashed before producing findings — refund request",
+      "impact": "medium",
+      "categories": [
+        "token_limits"
+      ],
+      "tokenkey_status": "not_prioritized",
+      "rationale": "Possible gateway compatibility/streaming impact, but not a high-severity relay signal in this pass.",
+      "updated_at": "2026-06-01T22:46:04Z"
+    },
+    {
+      "upstream": "anthropics/claude-code#60109",
+      "url": "https://github.com/anthropics/claude-code/issues/60109",
+      "title": "/usage Session view shows stale or cross-session data",
+      "impact": "medium",
+      "categories": [
+        "token_limits"
+      ],
+      "tokenkey_status": "not_prioritized",
+      "rationale": "Possible gateway compatibility/streaming impact, but not a high-severity relay signal in this pass.",
+      "updated_at": "2026-06-02T11:33:06Z"
+    },
+    {
+      "upstream": "anthropics/claude-code#63024",
+      "url": "https://github.com/anthropics/claude-code/issues/63024",
+      "title": "Add option to hide email address from welcome banner",
+      "impact": "medium",
+      "categories": [
+        "effort_structured"
+      ],
+      "tokenkey_status": "not_prioritized",
+      "rationale": "Possible gateway compatibility/streaming impact, but not a high-severity relay signal in this pass.",
+      "updated_at": "2026-06-01T03:58:07Z"
+    },
+    {
+      "upstream": "anthropics/claude-code#63456",
+      "url": "https://github.com/anthropics/claude-code/issues/63456",
+      "title": "Opus 4.8 not selectable in CLI `/model` despite being available on account",
+      "impact": "medium",
+      "categories": [
+        "token_limits"
+      ],
+      "tokenkey_status": "not_prioritized",
+      "rationale": "Possible gateway compatibility/streaming impact, but not a high-severity relay signal in this pass.",
+      "updated_at": "2026-06-01T17:51:07Z"
+    },
+    {
+      "upstream": "anthropics/claude-code#64028",
+      "url": "https://github.com/anthropics/claude-code/issues/64028",
+      "title": "claude --bg daemon idle-exit (5s) races client handshake → \"socket missing\"",
+      "impact": "medium",
+      "categories": [
+        "streaming_sse"
+      ],
+      "tokenkey_status": "not_prioritized",
+      "rationale": "Possible gateway compatibility/streaming impact, but not a high-severity relay signal in this pass.",
+      "updated_at": "2026-05-31T21:18:44Z"
+    },
+    {
+      "upstream": "anthropics/claude-code#64280",
+      "url": "https://github.com/anthropics/claude-code/issues/64280",
+      "title": "Wrong Charges of extra credits!!",
+      "impact": "medium",
+      "categories": [
+        "token_limits"
+      ],
+      "tokenkey_status": "not_prioritized",
+      "rationale": "Possible gateway compatibility/streaming impact, but not a high-severity relay signal in this pass.",
+      "updated_at": "2026-05-31T17:52:44Z"
+    },
+    {
+      "upstream": "anthropics/claude-code#64408",
+      "url": "https://github.com/anthropics/claude-code/issues/64408",
+      "title": "[Bug] Multilingual token mixing in extended context with web search and bash execution",
+      "impact": "medium",
+      "categories": [
+        "token_limits"
+      ],
+      "tokenkey_status": "not_prioritized",
+      "rationale": "Possible gateway compatibility/streaming impact, but not a high-severity relay signal in this pass.",
+      "updated_at": "2026-06-01T06:28:16Z"
+    },
+    {
+      "upstream": "anthropics/claude-code#64428",
+      "url": "https://github.com/anthropics/claude-code/issues/64428",
+      "title": "[FEATURE] Auto-save project state before context compaction",
+      "impact": "medium",
+      "categories": [
+        "token_limits",
+        "effort_structured"
+      ],
+      "tokenkey_status": "not_prioritized",
+      "rationale": "Possible gateway compatibility/streaming impact, but not a high-severity relay signal in this pass.",
+      "updated_at": "2026-06-01T08:16:13Z"
+    },
+    {
+      "upstream": "anthropics/claude-code#64445",
+      "url": "https://github.com/anthropics/claude-code/issues/64445",
+      "title": "1M context credits consumed without user selecting 1M mode",
+      "impact": "medium",
+      "categories": [
+        "token_limits"
+      ],
+      "tokenkey_status": "not_prioritized",
+      "rationale": "Possible gateway compatibility/streaming impact, but not a high-severity relay signal in this pass.",
+      "updated_at": "2026-06-01T11:44:23Z"
+    },
+    {
+      "upstream": "anthropics/claude-code#64468",
+      "url": "https://github.com/anthropics/claude-code/issues/64468",
+      "title": "[FEATURE] Allow manually overriding session status + a 'Closed'/'Archived' state in agent view",
+      "impact": "medium",
+      "categories": [
+        "streaming_sse"
+      ],
+      "tokenkey_status": "not_prioritized",
+      "rationale": "Possible gateway compatibility/streaming impact, but not a high-severity relay signal in this pass.",
+      "updated_at": "2026-06-01T11:58:39Z"
+    },
+    {
+      "upstream": "anthropics/claude-code#64546",
+      "url": "https://github.com/anthropics/claude-code/issues/64546",
+      "title": "[BUG] Context window display shows stale \"Messages\" count from previous session on new session start — corrects after first message",
+      "impact": "medium",
+      "categories": [
+        "token_limits"
+      ],
+      "tokenkey_status": "not_prioritized",
+      "rationale": "Possible gateway compatibility/streaming impact, but not a high-severity relay signal in this pass.",
+      "updated_at": "2026-06-01T18:30:50Z"
+    },
+    {
+      "upstream": "anthropics/claude-code#64692",
+      "url": "https://github.com/anthropics/claude-code/issues/64692",
+      "title": "[FEATURE] Option to suppress context-limit dialog in automated/pipeline sessions",
+      "impact": "medium",
+      "categories": [
+        "token_limits"
+      ],
+      "tokenkey_status": "not_prioritized",
+      "rationale": "Possible gateway compatibility/streaming impact, but not a high-severity relay signal in this pass.",
+      "updated_at": "2026-06-02T08:56:19Z"
+    },
+    {
+      "upstream": "anthropics/claude-code#64721",
+      "url": "https://github.com/anthropics/claude-code/issues/64721",
+      "title": "[FEATURE] Session export/backup — prevent data loss on reinstallURE]",
+      "impact": "medium",
+      "categories": [
+        "effort_structured"
+      ],
+      "tokenkey_status": "not_prioritized",
+      "rationale": "Possible gateway compatibility/streaming impact, but not a high-severity relay signal in this pass.",
+      "updated_at": "2026-06-03T03:05:07Z"
+    },
+    {
+      "upstream": "anthropics/claude-code#64740",
+      "url": "https://github.com/anthropics/claude-code/issues/64740",
+      "title": "Workflow (and other heavy tools) should be lazy-loaded — inline docs burn ~14.5k tokens every session",
+      "impact": "medium",
+      "categories": [
+        "token_limits"
+      ],
+      "tokenkey_status": "not_prioritized",
+      "rationale": "Possible gateway compatibility/streaming impact, but not a high-severity relay signal in this pass.",
+      "updated_at": "2026-06-02T13:06:51Z"
+    },
+    {
+      "upstream": "anthropics/claude-code#64772",
+      "url": "https://github.com/anthropics/claude-code/issues/64772",
+      "title": "Feature Request: Show context window consumption percentage",
+      "impact": "medium",
+      "categories": [
+        "token_limits"
+      ],
+      "tokenkey_status": "not_prioritized",
+      "rationale": "Possible gateway compatibility/streaming impact, but not a high-severity relay signal in this pass.",
+      "updated_at": "2026-06-02T15:02:34Z"
+    },
+    {
+      "upstream": "anthropics/claude-code#64827",
+      "url": "https://github.com/anthropics/claude-code/issues/64827",
+      "title": "ccstatusline Total counter is misleading: inflates by re-adding cached tokens every request",
+      "impact": "medium",
+      "categories": [
+        "token_limits"
+      ],
+      "tokenkey_status": "not_prioritized",
+      "rationale": "Possible gateway compatibility/streaming impact, but not a high-severity relay signal in this pass.",
+      "updated_at": "2026-06-02T18:11:31Z"
+    },
+    {
+      "upstream": "anthropics/claude-code#64829",
+      "url": "https://github.com/anthropics/claude-code/issues/64829",
+      "title": "Agent has no signal for \"this tool call is taking too long\" — silently waits on hangs",
+      "impact": "medium",
+      "categories": [
+        "token_limits"
+      ],
+      "tokenkey_status": "not_prioritized",
+      "rationale": "Possible gateway compatibility/streaming impact, but not a high-severity relay signal in this pass.",
+      "updated_at": "2026-06-02T18:38:16Z"
+    },
+    {
+      "upstream": "anthropics/claude-code#11447",
+      "url": "https://github.com/anthropics/claude-code/issues/11447",
+      "title": "[BUG] Claude can't edit files that use tabs for indentation",
+      "impact": "not_applicable",
+      "categories": [
+        "terminal"
+      ],
+      "tokenkey_status": "not_applicable",
+      "rationale": "Client-side claude-code concern (terminal); not a gateway/relay relevance signal.",
+      "updated_at": "2026-06-01T09:43:28Z"
+    },
+    {
+      "upstream": "anthropics/claude-code#12346",
+      "url": "https://github.com/anthropics/claude-code/issues/12346",
+      "title": "[FEATURE] Add GitLab Integration (Repository Connection, MRs, Mobile Access)",
+      "impact": "not_applicable",
+      "categories": [
+        "ide"
+      ],
+      "tokenkey_status": "not_applicable",
+      "rationale": "Client-side claude-code concern (ide); not a gateway/relay relevance signal.",
+      "updated_at": "2026-06-01T11:31:08Z"
+    },
+    {
+      "upstream": "anthropics/claude-code#12531",
+      "url": "https://github.com/anthropics/claude-code/issues/12531",
+      "title": "[Bug] macOS brew upgrade requires bypassing security to launch Claude Code",
+      "impact": "not_applicable",
+      "categories": [
+        "ide",
+        "terminal"
+      ],
+      "tokenkey_status": "not_applicable",
+      "rationale": "Client-side claude-code concern (ide, terminal); not a gateway/relay relevance signal.",
+      "updated_at": "2026-06-02T11:31:59Z"
+    },
+    {
+      "upstream": "anthropics/claude-code#12676",
+      "url": "https://github.com/anthropics/claude-code/issues/12676",
+      "title": "[FEATURE] Video Input Support in Claude Code",
+      "impact": "not_applicable",
+      "categories": [
+        "terminal",
+        "platform"
+      ],
+      "tokenkey_status": "not_applicable",
+      "rationale": "Client-side claude-code concern (terminal, platform); not a gateway/relay relevance signal.",
+      "updated_at": "2026-06-02T09:20:35Z"
+    },
+    {
+      "upstream": "anthropics/claude-code#12808",
+      "url": "https://github.com/anthropics/claude-code/issues/12808",
+      "title": "[BUG] In vscode workspace, Claude Code always starts in first project",
+      "impact": "not_applicable",
+      "categories": [
+        "ide",
+        "terminal",
+        "plugin"
+      ],
+      "tokenkey_status": "not_applicable",
+      "rationale": "Client-side claude-code concern (ide, terminal, plugin); not a gateway/relay relevance signal.",
+      "updated_at": "2026-06-03T04:52:58Z"
+    },
+    {
+      "upstream": "anthropics/claude-code#13354",
+      "url": "https://github.com/anthropics/claude-code/issues/13354",
+      "title": "[FEATURE] Continue when the session limit reached",
+      "impact": "not_applicable",
+      "categories": [
+        "terminal"
+      ],
+      "tokenkey_status": "not_applicable",
+      "rationale": "Client-side claude-code concern (terminal); not a gateway/relay relevance signal.",
+      "updated_at": "2026-06-01T17:01:05Z"
+    },
+    {
+      "upstream": "anthropics/claude-code#14131",
+      "url": "https://github.com/anthropics/claude-code/issues/14131",
+      "title": "[BUG] German umlauts (ä, ö, ü) randomly replaced with ASCII substitutes (ae, oe, ue)",
+      "impact": "not_applicable",
+      "categories": [
+        "terminal"
+      ],
+      "tokenkey_status": "not_applicable",
+      "rationale": "Client-side claude-code concern (terminal); not a gateway/relay relevance signal.",
+      "updated_at": "2026-06-01T05:07:58Z"
+    },
+    {
+      "upstream": "anthropics/claude-code#14200",
+      "url": "https://github.com/anthropics/claude-code/issues/14200",
+      "title": "[FEATURE] Add rules support to Plugins",
+      "impact": "not_applicable",
+      "categories": [
+        "plugin"
+      ],
+      "tokenkey_status": "not_applicable",
+      "rationale": "Client-side claude-code concern (plugin); not a gateway/relay relevance signal.",
+      "updated_at": "2026-06-02T11:18:55Z"
+    },
+    {
+      "upstream": "anthropics/claude-code#1509",
+      "url": "https://github.com/anthropics/claude-code/issues/1509",
+      "title": "[BUG] Claude code spitting out random characters in user input area while running",
+      "impact": "not_applicable",
+      "categories": [
+        "terminal"
+      ],
+      "tokenkey_status": "not_applicable",
+      "rationale": "Client-side claude-code concern (terminal); not a gateway/relay relevance signal.",
+      "updated_at": "2026-06-01T08:07:53Z"
+    },
+    {
+      "upstream": "anthropics/claude-code#15199",
+      "url": "https://github.com/anthropics/claude-code/issues/15199",
+      "title": "[BUG] CLI output formatting artifacts break copy/paste - workarounds waste tokens",
+      "impact": "not_applicable",
+      "categories": [
+        "ide",
+        "terminal",
+        "platform"
+      ],
+      "tokenkey_status": "not_applicable",
+      "rationale": "Client-side claude-code concern (ide, terminal, platform); not a gateway/relay relevance signal.",
+      "updated_at": "2026-05-31T20:55:46Z"
+    },
+    {
+      "upstream": "anthropics/claude-code#15942",
+      "url": "https://github.com/anthropics/claude-code/issues/15942",
+      "title": "Add support for Visual Studio 2026 Integration",
+      "impact": "not_applicable",
+      "categories": [
+        "ide",
+        "terminal",
+        "plugin",
+        "slash_hook",
+        "platform"
+      ],
+      "tokenkey_status": "not_applicable",
+      "rationale": "Client-side claude-code concern (ide, terminal, plugin, slash_hook, platform); not a gateway/relay relevance signal.",
+      "updated_at": "2026-05-31T15:27:12Z"
+    },
+    {
+      "upstream": "anthropics/claude-code#16135",
+      "url": "https://github.com/anthropics/claude-code/issues/16135",
+      "title": "Background process termination crashes Claude Code in Docker containers",
+      "impact": "not_applicable",
+      "categories": [
+        "terminal"
+      ],
+      "tokenkey_status": "not_applicable",
+      "rationale": "Client-side claude-code concern (terminal); not a gateway/relay relevance signal.",
+      "updated_at": "2026-06-01T22:45:05Z"
+    },
+    {
+      "upstream": "anthropics/claude-code#16157",
+      "url": "https://github.com/anthropics/claude-code/issues/16157",
+      "title": "[BUG] Instantly hitting usage limits with Max subscription",
+      "impact": "not_applicable",
+      "categories": [
+        "terminal"
+      ],
+      "tokenkey_status": "not_applicable",
+      "rationale": "Client-side claude-code concern (terminal); not a gateway/relay relevance signal.",
+      "updated_at": "2026-06-03T05:03:51Z"
+    },
+    {
+      "upstream": "anthropics/claude-code#16446",
+      "url": "https://github.com/anthropics/claude-code/issues/16446",
+      "title": "[FEATURE] LaTeX rendering in \"Claude Code for VS Code\" plugin",
+      "impact": "not_applicable",
+      "categories": [
+        "ide",
+        "terminal",
+        "plugin"
+      ],
+      "tokenkey_status": "not_applicable",
+      "rationale": "Client-side claude-code concern (ide, terminal, plugin); not a gateway/relay relevance signal.",
+      "updated_at": "2026-06-01T20:35:24Z"
+    },
+    {
+      "upstream": "anthropics/claude-code#16507",
+      "url": "https://github.com/anthropics/claude-code/issues/16507",
+      "title": "Glob tool does not follow symbolic links",
+      "impact": "not_applicable",
+      "categories": [
+        "install"
+      ],
+      "tokenkey_status": "not_applicable",
+      "rationale": "Client-side claude-code concern (install); not a gateway/relay relevance signal.",
+      "updated_at": "2026-06-02T11:05:13Z"
+    },
+    {
+      "upstream": "anthropics/claude-code#16514",
+      "url": "https://github.com/anthropics/claude-code/issues/16514",
+      "title": "[BUG] Poor contrast in agent status colors on light cyan backgrounds",
+      "impact": "not_applicable",
+      "categories": [
+        "terminal"
+      ],
+      "tokenkey_status": "not_applicable",
+      "rationale": "Client-side claude-code concern (terminal); not a gateway/relay relevance signal.",
+      "updated_at": "2026-06-02T22:44:35Z"
+    },
+    {
+      "upstream": "anthropics/claude-code#18435",
+      "url": "https://github.com/anthropics/claude-code/issues/18435",
+      "title": "[FEATURE] Add the ability to manage multiple Claude accounts within the Claude Desktop app with easy switching between profiles.",
+      "impact": "not_applicable",
+      "categories": [
+        "ide",
+        "mcp",
+        "slash_hook"
+      ],
+      "tokenkey_status": "not_applicable",
+      "rationale": "Client-side claude-code concern (ide, mcp, slash_hook); not a gateway/relay relevance signal.",
+      "updated_at": "2026-06-01T13:05:18Z"
+    },
+    {
+      "upstream": "anthropics/claude-code#19976",
+      "url": "https://github.com/anthropics/claude-code/issues/19976",
+      "title": "[FEATURE] Support terminal notifications when running inside tmux",
+      "impact": "not_applicable",
+      "categories": [
+        "terminal",
+        "slash_hook"
+      ],
+      "tokenkey_status": "not_applicable",
+      "rationale": "Client-side claude-code concern (terminal, slash_hook); not a gateway/relay relevance signal.",
+      "updated_at": "2026-06-01T21:04:21Z"
+    },
+    {
+      "upstream": "anthropics/claude-code#20697",
+      "url": "https://github.com/anthropics/claude-code/issues/20697",
+      "title": "[FEATURE] Sync Skills between Claude Desktop and Claude Code CLI",
+      "impact": "not_applicable",
+      "categories": [
+        "slash_hook"
+      ],
+      "tokenkey_status": "not_applicable",
+      "rationale": "Client-side claude-code concern (slash_hook); not a gateway/relay relevance signal.",
+      "updated_at": "2026-06-03T03:21:56Z"
+    },
+    {
+      "upstream": "anthropics/claude-code#21051",
+      "url": "https://github.com/anthropics/claude-code/issues/21051",
+      "title": "[FEATURE] Display message timestamps in Claude Code CLI interface",
+      "impact": "not_applicable",
+      "categories": [
+        "ide",
+        "terminal",
+        "slash_hook",
+        "platform"
+      ],
+      "tokenkey_status": "not_applicable",
+      "rationale": "Client-side claude-code concern (ide, terminal, slash_hook, platform); not a gateway/relay relevance signal.",
+      "updated_at": "2026-06-02T23:02:33Z"
+    },
+    {
+      "upstream": "anthropics/claude-code#22872",
+      "url": "https://github.com/anthropics/claude-code/issues/22872",
+      "title": "[BUG] Switching between personal and work Claude Code accounts is abysmal",
+      "impact": "not_applicable",
+      "categories": [
+        "terminal"
+      ],
+      "tokenkey_status": "not_applicable",
+      "rationale": "Client-side claude-code concern (terminal); not a gateway/relay relevance signal.",
+      "updated_at": "2026-06-03T00:12:55Z"
+    },
+    {
+      "upstream": "anthropics/claude-code#23620",
+      "url": "https://github.com/anthropics/claude-code/issues/23620",
+      "title": "Agent team lost when lead's context gets compacted during long session",
+      "impact": "not_applicable",
+      "categories": [
+        "terminal",
+        "slash_hook"
+      ],
+      "tokenkey_status": "not_applicable",
+      "rationale": "Client-side claude-code concern (terminal, slash_hook); not a gateway/relay relevance signal.",
+      "updated_at": "2026-06-03T04:23:36Z"
+    },
+    {
+      "upstream": "anthropics/claude-code#24055",
+      "url": "https://github.com/anthropics/claude-code/issues/24055",
+      "title": "[BUG] API Error: Claude's response exceeded the 32000 output token maximum.",
+      "impact": "not_applicable",
+      "categories": [
+        "terminal",
+        "platform"
+      ],
+      "tokenkey_status": "not_applicable",
+      "rationale": "Client-side claude-code concern (terminal, platform); not a gateway/relay relevance signal.",
+      "updated_at": "2026-06-02T23:06:02Z"
+    },
+    {
+      "upstream": "anthropics/claude-code#24285",
+      "url": "https://github.com/anthropics/claude-code/issues/24285",
+      "title": "[BUG] Can't see Claude's thinking anymore",
+      "impact": "not_applicable",
+      "categories": [
+        "terminal",
+        "platform"
+      ],
+      "tokenkey_status": "not_applicable",
+      "rationale": "Client-side claude-code concern (terminal, platform); not a gateway/relay relevance signal.",
+      "updated_at": "2026-06-01T18:56:09Z"
+    },
+    {
+      "upstream": "anthropics/claude-code#2441",
+      "url": "https://github.com/anthropics/claude-code/issues/2441",
+      "title": "[FRE] Add timestamp to each message",
+      "impact": "not_applicable",
+      "categories": [
+        "slash_hook"
+      ],
+      "tokenkey_status": "not_applicable",
+      "rationale": "Client-side claude-code concern (slash_hook); not a gateway/relay relevance signal.",
+      "updated_at": "2026-06-02T22:39:51Z"
+    },
+    {
+      "upstream": "anthropics/claude-code#24726",
+      "url": "https://github.com/anthropics/claude-code/issues/24726",
+      "title": "[FEATURE] VS Code extension: add setting to disable auto-attach of open file / selection",
+      "impact": "not_applicable",
+      "categories": [
+        "ide"
+      ],
+      "tokenkey_status": "not_applicable",
+      "rationale": "Client-side claude-code concern (ide); not a gateway/relay relevance signal.",
+      "updated_at": "2026-06-02T07:35:51Z"
+    },
+    {
+      "upstream": "anthropics/claude-code#25128",
+      "url": "https://github.com/anthropics/claude-code/issues/25128",
+      "title": "[BUG] Drag and drop not working in VS Code extension chat panel (works in terminal CLI)",
+      "impact": "not_applicable",
+      "categories": [
+        "ide",
+        "terminal",
+        "platform"
+      ],
+      "tokenkey_status": "not_applicable",
+      "rationale": "Client-side claude-code concern (ide, terminal, platform); not a gateway/relay relevance signal.",
+      "updated_at": "2026-05-31T17:45:56Z"
+    },
+    {
+      "upstream": "anthropics/claude-code#25791",
+      "url": "https://github.com/anthropics/claude-code/issues/25791",
+      "title": "[FEATURE] Claude Code ↔ Cowork Bridge: Programmatically trigger Cowork tasks from Claude Code CLI",
+      "impact": "not_applicable",
+      "categories": [
+        "terminal",
+        "mcp",
+        "platform"
+      ],
+      "tokenkey_status": "not_applicable",
+      "rationale": "Client-side claude-code concern (terminal, mcp, platform); not a gateway/relay relevance signal.",
+      "updated_at": "2026-06-02T17:27:11Z"
+    },
+    {
+      "upstream": "anthropics/claude-code#26224",
+      "url": "https://github.com/anthropics/claude-code/issues/26224",
+      "title": "[BUG] [URGENT!!!] Claude Code is hanging / freezing / stuck on heaps of prompts for 5-20minutes or more.",
+      "impact": "not_applicable",
+      "categories": [
+        "terminal",
+        "platform"
+      ],
+      "tokenkey_status": "not_applicable",
+      "rationale": "Client-side claude-code concern (terminal, platform); not a gateway/relay relevance signal.",
+      "updated_at": "2026-06-02T09:14:19Z"
+    },
+    {
+      "upstream": "anthropics/claude-code#26784",
+      "url": "https://github.com/anthropics/claude-code/issues/26784",
+      "title": "[FEATURE] Allow drag-and-drop files into chat without holding Shift key",
+      "impact": "not_applicable",
+      "categories": [
+        "ide"
+      ],
+      "tokenkey_status": "not_applicable",
+      "rationale": "Client-side claude-code concern (ide); not a gateway/relay relevance signal.",
+      "updated_at": "2026-06-02T13:16:51Z"
+    },
+    {
+      "upstream": "anthropics/claude-code#27302",
+      "url": "https://github.com/anthropics/claude-code/issues/27302",
+      "title": "[FEATURE] Support multiple Connector accounts (same connector, different accounts) in Claude and Claude Code on the web (claude.ai/code)",
+      "impact": "not_applicable",
+      "categories": [
+        "ide",
+        "mcp"
+      ],
+      "tokenkey_status": "not_applicable",
+      "rationale": "Client-side claude-code concern (ide, mcp); not a gateway/relay relevance signal.",
+      "updated_at": "2026-06-01T09:49:57Z"
+    },
+    {
+      "upstream": "anthropics/claude-code#27561",
+      "url": "https://github.com/anthropics/claude-code/issues/27561",
+      "title": "[Feature Request] Modern text input: click-to-position, text selection, and standard editing in the prompt",
+      "impact": "not_applicable",
+      "categories": [
+        "terminal",
+        "slash_hook",
+        "platform"
+      ],
+      "tokenkey_status": "not_applicable",
+      "rationale": "Client-side claude-code concern (terminal, slash_hook, platform); not a gateway/relay relevance signal.",
+      "updated_at": "2026-06-02T15:54:45Z"
+    },
+    {
+      "upstream": "anthropics/claude-code#28300",
+      "url": "https://github.com/anthropics/claude-code/issues/28300",
+      "title": "[FEATURE] Multi-agent collaboration across machines (Agent-to-Agent protocol)",
+      "impact": "not_applicable",
+      "categories": [
+        "terminal",
+        "mcp"
+      ],
+      "tokenkey_status": "not_applicable",
+      "rationale": "Client-side claude-code concern (terminal, mcp); not a gateway/relay relevance signal.",
+      "updated_at": "2026-06-01T00:32:42Z"
+    },
+    {
+      "upstream": "anthropics/claude-code#28508",
+      "url": "https://github.com/anthropics/claude-code/issues/28508",
+      "title": "[BUG] Remote Control: AskUserQuestion selections made on mobile not received by CLI — causes infinite wait",
+      "impact": "not_applicable",
+      "categories": [
+        "ide",
+        "terminal",
+        "platform"
+      ],
+      "tokenkey_status": "not_applicable",
+      "rationale": "Client-side claude-code concern (ide, terminal, platform); not a gateway/relay relevance signal.",
+      "updated_at": "2026-06-02T10:10:14Z"
+    },
+    {
+      "upstream": "anthropics/claude-code#28817",
+      "url": "https://github.com/anthropics/claude-code/issues/28817",
+      "title": "[Bug] Remote Control unavailable despite Pro plan authentication",
+      "impact": "not_applicable",
+      "categories": [
+        "terminal"
+      ],
+      "tokenkey_status": "not_applicable",
+      "rationale": "Client-side claude-code concern (terminal); not a gateway/relay relevance signal.",
+      "updated_at": "2026-06-01T23:56:48Z"
+    },
+    {
+      "upstream": "anthropics/claude-code#29214",
+      "url": "https://github.com/anthropics/claude-code/issues/29214",
+      "title": "Remote Control: mobile app shows permission prompts despite --dangerously-skip-permissions",
+      "impact": "not_applicable",
+      "categories": [
+        "platform"
+      ],
+      "tokenkey_status": "not_applicable",
+      "rationale": "Client-side claude-code concern (platform); not a gateway/relay relevance signal.",
+      "updated_at": "2026-06-03T04:51:08Z"
+    },
+    {
+      "upstream": "anthropics/claude-code#2933",
+      "url": "https://github.com/anthropics/claude-code/issues/2933",
+      "title": "VS Code Extension Ignores Global dangerously-skip-permissions Setting",
+      "impact": "not_applicable",
+      "categories": [
+        "ide",
+        "terminal",
+        "slash_hook",
+        "install"
+      ],
+      "tokenkey_status": "not_applicable",
+      "rationale": "Client-side claude-code concern (ide, terminal, slash_hook, install); not a gateway/relay relevance signal.",
+      "updated_at": "2026-06-01T12:15:24Z"
+    },
+    {
+      "upstream": "anthropics/claude-code#29423",
+      "url": "https://github.com/anthropics/claude-code/issues/29423",
+      "title": "Task subagents do not load project CLAUDE.md or .claude/rules/ -- project configuration silently ignored",
+      "impact": "not_applicable",
+      "categories": [
+        "plugin",
+        "platform"
+      ],
+      "tokenkey_status": "not_applicable",
+      "rationale": "Client-side claude-code concern (plugin, platform); not a gateway/relay relevance signal.",
+      "updated_at": "2026-06-01T22:46:21Z"
+    },
+    {
+      "upstream": "anthropics/claude-code#29449",
+      "url": "https://github.com/anthropics/claude-code/issues/29449",
+      "title": "[BUG] \"Remote Control environments are not available for your account.\" for Claude Code Pro Plan user",
+      "impact": "not_applicable",
+      "categories": [
+        "ide",
+        "terminal"
+      ],
+      "tokenkey_status": "not_applicable",
+      "rationale": "Client-side claude-code concern (ide, terminal); not a gateway/relay relevance signal.",
+      "updated_at": "2026-06-01T08:30:00Z"
+    },
+    {
+      "upstream": "anthropics/claude-code#29937",
+      "url": "https://github.com/anthropics/claude-code/issues/29937",
+      "title": "[BUG] Terminal rendering corruption in tmux - text overlaps and overwrites previous output",
+      "impact": "not_applicable",
+      "categories": [
+        "terminal"
+      ],
+      "tokenkey_status": "not_applicable",
+      "rationale": "Client-side claude-code concern (terminal); not a gateway/relay relevance signal.",
+      "updated_at": "2026-06-02T02:11:25Z"
+    },
+    {
+      "upstream": "anthropics/claude-code#30014",
+      "url": "https://github.com/anthropics/claude-code/issues/30014",
+      "title": "[Bug] Explore agent infinite loop or hang condition",
+      "impact": "not_applicable",
+      "categories": [
+        "terminal"
+      ],
+      "tokenkey_status": "not_applicable",
+      "rationale": "Client-side claude-code concern (terminal); not a gateway/relay relevance signal.",
+      "updated_at": "2026-06-02T22:44:37Z"
+    },
+    {
+      "upstream": "anthropics/claude-code#30232",
+      "url": "https://github.com/anthropics/claude-code/issues/30232",
+      "title": "Show status line during permission prompts and user questions",
+      "impact": "not_applicable",
+      "categories": [
+        "terminal"
+      ],
+      "tokenkey_status": "not_applicable",
+      "rationale": "Client-side claude-code concern (terminal); not a gateway/relay relevance signal.",
+      "updated_at": "2026-06-02T11:32:39Z"
+    },
+    {
+      "upstream": "anthropics/claude-code#30407",
+      "url": "https://github.com/anthropics/claude-code/issues/30407",
+      "title": "[workflow issue] all issues get auto-closed without review??",
+      "impact": "not_applicable",
+      "categories": [
+        "ide",
+        "terminal"
+      ],
+      "tokenkey_status": "not_applicable",
+      "rationale": "Client-side claude-code concern (ide, terminal); not a gateway/relay relevance signal.",
+      "updated_at": "2026-06-01T05:31:08Z"
+    },
+    {
+      "upstream": "anthropics/claude-code#30519",
+      "url": "https://github.com/anthropics/claude-code/issues/30519",
+      "title": "Permissions matching is fundamentally broken — 30+ open issues, no staff engagement, community building workarounds",
+      "impact": "not_applicable",
+      "categories": [
+        "slash_hook"
+      ],
+      "tokenkey_status": "not_applicable",
+      "rationale": "Client-side claude-code concern (slash_hook); not a gateway/relay relevance signal.",
+      "updated_at": "2026-05-31T22:40:15Z"
+    },
+    {
+      "upstream": "anthropics/claude-code#30533",
+      "url": "https://github.com/anthropics/claude-code/issues/30533",
+      "title": "[FEATURE] Microsoft 365 MCP:Add support for reading email attachments",
+      "impact": "not_applicable",
+      "categories": [
+        "mcp"
+      ],
+      "tokenkey_status": "not_applicable",
+      "rationale": "Client-side claude-code concern (mcp); not a gateway/relay relevance signal.",
+      "updated_at": "2026-06-01T18:40:35Z"
+    },
+    {
+      "upstream": "anthropics/claude-code#30660",
+      "url": "https://github.com/anthropics/claude-code/issues/30660",
+      "title": "Stream extended thinking output in real-time during interactive mode",
+      "impact": "not_applicable",
+      "categories": [
+        "terminal"
+      ],
+      "tokenkey_status": "not_applicable",
+      "rationale": "Client-side claude-code concern (terminal); not a gateway/relay relevance signal.",
+      "updated_at": "2026-05-31T13:42:40Z"
+    },
+    {
+      "upstream": "anthropics/claude-code#31012",
+      "url": "https://github.com/anthropics/claude-code/issues/31012",
+      "title": "[BUG] Claude Max 20x subscription not recognized — account shows Free Plan, Claude Code requires Pro/Max",
+      "impact": "not_applicable",
+      "categories": [
+        "terminal",
+        "platform"
+      ],
+      "tokenkey_status": "not_applicable",
+      "rationale": "Client-side claude-code concern (terminal, platform); not a gateway/relay relevance signal.",
+      "updated_at": "2026-06-02T12:26:57Z"
+    },
+    {
+      "upstream": "anthropics/claude-code#3134",
+      "url": "https://github.com/anthropics/claude-code/issues/3134",
+      "title": "[BUG] Terminal Paste Corruption from Bracketed Paste Mode",
+      "impact": "not_applicable",
+      "categories": [
+        "terminal",
+        "mcp",
+        "install"
+      ],
+      "tokenkey_status": "not_applicable",
+      "rationale": "Client-side claude-code concern (terminal, mcp, install); not a gateway/relay relevance signal.",
+      "updated_at": "2026-06-02T06:22:19Z"
+    },
+    {
+      "upstream": "anthropics/claude-code#31977",
+      "url": "https://github.com/anthropics/claude-code/issues/31977",
+      "title": "[BUG] In-process team agents lack the Agent tool (cannot spawn subagents)",
+      "impact": "not_applicable",
+      "categories": [
+        "plugin"
+      ],
+      "tokenkey_status": "not_applicable",
+      "rationale": "Client-side claude-code concern (plugin); not a gateway/relay relevance signal.",
+      "updated_at": "2026-06-01T22:45:12Z"
+    },
+    {
+      "upstream": "anthropics/claude-code#32005",
+      "url": "https://github.com/anthropics/claude-code/issues/32005",
+      "title": "[FEATURE] Support image/screenshot paste in Claude Code terminal",
+      "impact": "not_applicable",
+      "categories": [
+        "terminal"
+      ],
+      "tokenkey_status": "not_applicable",
+      "rationale": "Client-side claude-code concern (terminal); not a gateway/relay relevance signal.",
+      "updated_at": "2026-06-03T00:39:21Z"
+    },
+    {
+      "upstream": "anthropics/claude-code#32362",
+      "url": "https://github.com/anthropics/claude-code/issues/32362",
+      "title": "[Feature Request] Zed IDE integration support",
+      "impact": "not_applicable",
+      "categories": [
+        "ide",
+        "terminal",
+        "plugin"
+      ],
+      "tokenkey_status": "not_applicable",
+      "rationale": "Client-side claude-code concern (ide, terminal, plugin); not a gateway/relay relevance signal.",
+      "updated_at": "2026-05-31T22:03:07Z"
+    },
+    {
+      "upstream": "anthropics/claude-code#32364",
+      "url": "https://github.com/anthropics/claude-code/issues/32364",
+      "title": "[FEATURE] Support OpenTelemetry (OTel) configuration in Claude Code on the Web (claude.ai/code)",
+      "impact": "not_applicable",
+      "categories": [
+        "ide",
+        "slash_hook",
+        "platform"
+      ],
+      "tokenkey_status": "not_applicable",
+      "rationale": "Client-side claude-code concern (ide, slash_hook, platform); not a gateway/relay relevance signal.",
+      "updated_at": "2026-05-31T23:44:49Z"
+    },
+    {
+      "upstream": "anthropics/claude-code#32508",
+      "url": "https://github.com/anthropics/claude-code/issues/32508",
+      "title": "[MODEL] System prompt \"Output efficiency\" section causes action-before-understanding bias, degrading code quality",
+      "impact": "not_applicable",
+      "categories": [
+        "plugin"
+      ],
+      "tokenkey_status": "not_applicable",
+      "rationale": "Client-side claude-code concern (plugin); not a gateway/relay relevance signal.",
+      "updated_at": "2026-06-01T22:46:17Z"
+    },
+    {
+      "upstream": "anthropics/claude-code#32524",
+      "url": "https://github.com/anthropics/claude-code/issues/32524",
+      "title": "[BUG] MCP tool parameters with type: number are sent as strings to MCP servers",
+      "impact": "not_applicable",
+      "categories": [
+        "mcp",
+        "install"
+      ],
+      "tokenkey_status": "not_applicable",
+      "rationale": "Client-side claude-code concern (mcp, install); not a gateway/relay relevance signal.",
+      "updated_at": "2026-05-31T19:54:10Z"
+    },
+    {
+      "upstream": "anthropics/claude-code#33242",
+      "url": "https://github.com/anthropics/claude-code/issues/33242",
+      "title": "[BUG] [VSCode Extension] Plan content not visible in panel before accepting plan mode prompt",
+      "impact": "not_applicable",
+      "categories": [
+        "ide",
+        "terminal"
+      ],
+      "tokenkey_status": "not_applicable",
+      "rationale": "Client-side claude-code concern (ide, terminal); not a gateway/relay relevance signal.",
+      "updated_at": "2026-06-02T11:32:14Z"
+    },
+    {
+      "upstream": "anthropics/claude-code#33932",
+      "url": "https://github.com/anthropics/claude-code/issues/33932",
+      "title": "[FEATURE] VS Code Extension: Diff review UI similar to GitHub Copilot Edits Review",
+      "impact": "not_applicable",
+      "categories": [
+        "ide",
+        "terminal"
+      ],
+      "tokenkey_status": "not_applicable",
+      "rationale": "Client-side claude-code concern (ide, terminal); not a gateway/relay relevance signal.",
+      "updated_at": "2026-06-03T06:05:04Z"
+    },
+    {
+      "upstream": "anthropics/claude-code#34229",
+      "url": "https://github.com/anthropics/claude-code/issues/34229",
+      "title": "[BUG] Phone verification",
+      "impact": "not_applicable",
+      "categories": [
+        "terminal",
+        "plugin"
+      ],
+      "tokenkey_status": "not_applicable",
+      "rationale": "Client-side claude-code concern (terminal, plugin); not a gateway/relay relevance signal.",
+      "updated_at": "2026-06-01T02:01:42Z"
+    },
+    {
+      "upstream": "anthropics/claude-code#34255",
+      "url": "https://github.com/anthropics/claude-code/issues/34255",
+      "title": "[BUG] Remote Control: automatic reconnection doesn't work -- connection drops silently with no recovery",
+      "impact": "not_applicable",
+      "categories": [
+        "terminal",
+        "slash_hook"
+      ],
+      "tokenkey_status": "not_applicable",
+      "rationale": "Client-side claude-code concern (terminal, slash_hook); not a gateway/relay relevance signal.",
+      "updated_at": "2026-06-01T06:50:53Z"
+    },
+    {
+      "upstream": "anthropics/claude-code#34556",
+      "url": "https://github.com/anthropics/claude-code/issues/34556",
+      "title": "Feature Request: Persistent Memory Across Context Compactions (59 compactions, built our own)",
+      "impact": "not_applicable",
+      "categories": [
+        "slash_hook"
+      ],
+      "tokenkey_status": "not_applicable",
+      "rationale": "Client-side claude-code concern (slash_hook); not a gateway/relay relevance signal.",
+      "updated_at": "2026-06-01T16:27:31Z"
+    },
+    {
+      "upstream": "anthropics/claude-code#35148",
+      "url": "https://github.com/anthropics/claude-code/issues/35148",
+      "title": "[BUG] Logo and \"Thinking\" animation colors are dull/washed-out inside tmux",
+      "impact": "not_applicable",
+      "categories": [
+        "terminal"
+      ],
+      "tokenkey_status": "not_applicable",
+      "rationale": "Client-side claude-code concern (terminal); not a gateway/relay relevance signal.",
+      "updated_at": "2026-06-02T12:34:31Z"
+    },
+    {
+      "upstream": "anthropics/claude-code#35798",
+      "url": "https://github.com/anthropics/claude-code/issues/35798",
+      "title": "[BUG] # memory",
+      "impact": "not_applicable",
+      "categories": [
+        "terminal"
+      ],
+      "tokenkey_status": "not_applicable",
+      "rationale": "Client-side claude-code concern (terminal); not a gateway/relay relevance signal.",
+      "updated_at": "2026-06-01T22:46:01Z"
+    },
+    {
+      "upstream": "anthropics/claude-code#36179",
+      "url": "https://github.com/anthropics/claude-code/issues/36179",
+      "title": "[BUG] Unsupported content type: redacted_thinking，Errors often occur when using the plugin.",
+      "impact": "not_applicable",
+      "categories": [
+        "ide",
+        "terminal",
+        "plugin",
+        "platform"
+      ],
+      "tokenkey_status": "not_applicable",
+      "rationale": "Client-side claude-code concern (ide, terminal, plugin, platform); not a gateway/relay relevance signal.",
+      "updated_at": "2026-06-01T20:37:05Z"
+    },
+    {
+      "upstream": "anthropics/claude-code#36411",
+      "url": "https://github.com/anthropics/claude-code/issues/36411",
+      "title": "[BUG] Telegram MCP plugin: inbound notifications/claude/channel never delivered to session (outbound works)",
+      "impact": "not_applicable",
+      "categories": [
+        "terminal",
+        "mcp",
+        "plugin",
+        "install"
+      ],
+      "tokenkey_status": "not_applicable",
+      "rationale": "Client-side claude-code concern (terminal, mcp, plugin, install); not a gateway/relay relevance signal.",
+      "updated_at": "2026-06-02T00:34:54Z"
+    },
+    {
+      "upstream": "anthropics/claude-code#36648",
+      "url": "https://github.com/anthropics/claude-code/issues/36648",
+      "title": "[Bug] Credit balance too low error with valid API key and sufficient balance",
+      "impact": "not_applicable",
+      "categories": [
+        "ide",
+        "terminal"
+      ],
+      "tokenkey_status": "not_applicable",
+      "rationale": "Client-side claude-code concern (ide, terminal); not a gateway/relay relevance signal.",
+      "updated_at": "2026-06-02T11:32:10Z"
+    },
+    {
+      "upstream": "anthropics/claude-code#36797",
+      "url": "https://github.com/anthropics/claude-code/issues/36797",
+      "title": "[Bug] Authentication redirect loops to onboarding for existing account with active subscription",
+      "impact": "not_applicable",
+      "categories": [
+        "terminal"
+      ],
+      "tokenkey_status": "not_applicable",
+      "rationale": "Client-side claude-code concern (terminal); not a gateway/relay relevance signal.",
+      "updated_at": "2026-06-02T10:57:29Z"
+    },
+    {
+      "upstream": "anthropics/claude-code#36800",
+      "url": "https://github.com/anthropics/claude-code/issues/36800",
+      "title": "[BUG] Claude Code spawns duplicate channel plugin instances mid-session, causing 409 Conflict and tool loss",
+      "impact": "not_applicable",
+      "categories": [
+        "mcp",
+        "plugin"
+      ],
+      "tokenkey_status": "not_applicable",
+      "rationale": "Client-side claude-code concern (mcp, plugin); not a gateway/relay relevance signal.",
+      "updated_at": "2026-05-31T10:41:19Z"
+    },
+    {
+      "upstream": "anthropics/claude-code#36884",
+      "url": "https://github.com/anthropics/claude-code/issues/36884",
+      "title": "VS Code extension ignores Edit/Write permission rules in settings files",
+      "impact": "not_applicable",
+      "categories": [
+        "ide",
+        "slash_hook",
+        "platform"
+      ],
+      "tokenkey_status": "not_applicable",
+      "rationale": "Client-side claude-code concern (ide, slash_hook, platform); not a gateway/relay relevance signal.",
+      "updated_at": "2026-06-02T11:32:43Z"
+    },
+    {
+      "upstream": "anthropics/claude-code#38005",
+      "url": "https://github.com/anthropics/claude-code/issues/38005",
+      "title": "RTL (Right-to-Left) Support for Hebrew & Arabic in Claude Desktop / Cowork",
+      "impact": "not_applicable",
+      "categories": [
+        "ide",
+        "terminal"
+      ],
+      "tokenkey_status": "not_applicable",
+      "rationale": "Client-side claude-code concern (ide, terminal); not a gateway/relay relevance signal.",
+      "updated_at": "2026-06-01T12:03:13Z"
+    },
+    {
+      "upstream": "anthropics/claude-code#38129",
+      "url": "https://github.com/anthropics/claude-code/issues/38129",
+      "title": "[BUG] Cowork web GUI unavailable on Linux -- only macOS and Windows supported",
+      "impact": "not_applicable",
+      "categories": [
+        "terminal",
+        "install",
+        "platform"
+      ],
+      "tokenkey_status": "not_applicable",
+      "rationale": "Client-side claude-code concern (terminal, install, platform); not a gateway/relay relevance signal.",
+      "updated_at": "2026-06-01T08:08:26Z"
+    },
+    {
+      "upstream": "anthropics/claude-code#38928",
+      "url": "https://github.com/anthropics/claude-code/issues/38928",
+      "title": "Explore agent always fails with \"Prompt is too long\" when many MCP tools are connected",
+      "impact": "not_applicable",
+      "categories": [
+        "mcp",
+        "plugin"
+      ],
+      "tokenkey_status": "not_applicable",
+      "rationale": "Client-side claude-code concern (mcp, plugin); not a gateway/relay relevance signal.",
+      "updated_at": "2026-06-02T04:39:01Z"
+    },
+    {
+      "upstream": "anthropics/claude-code#38993",
+      "url": "https://github.com/anthropics/claude-code/issues/38993",
+      "title": "[BUG] Cowork: virtiofs FUSE mount serves truncated/stale files — host-side file changes not reflected in VM",
+      "impact": "not_applicable",
+      "categories": [
+        "terminal",
+        "platform"
+      ],
+      "tokenkey_status": "not_applicable",
+      "rationale": "Client-side claude-code concern (terminal, platform); not a gateway/relay relevance signal.",
+      "updated_at": "2026-06-02T13:12:29Z"
+    },
+    {
+      "upstream": "anthropics/claude-code#39027",
+      "url": "https://github.com/anthropics/claude-code/issues/39027",
+      "title": "Background task notifications trigger autonomous API calls — model responds as if it were the user",
+      "impact": "not_applicable",
+      "categories": [
+        "slash_hook",
+        "install"
+      ],
+      "tokenkey_status": "not_applicable",
+      "rationale": "Client-side claude-code concern (slash_hook, install); not a gateway/relay relevance signal.",
+      "updated_at": "2026-06-01T22:45:24Z"
+    },
+    {
+      "upstream": "anthropics/claude-code#39161",
+      "url": "https://github.com/anthropics/claude-code/issues/39161",
+      "title": "[BUG] Cowork ARM64: VM boots but guest never connects — \"VM connection timeout after 60 seconds",
+      "impact": "not_applicable",
+      "categories": [
+        "terminal",
+        "install",
+        "platform"
+      ],
+      "tokenkey_status": "not_applicable",
+      "rationale": "Client-side claude-code concern (terminal, install, platform); not a gateway/relay relevance signal.",
+      "updated_at": "2026-06-01T10:07:45Z"
+    },
+    {
+      "upstream": "anthropics/claude-code#39472",
+      "url": "https://github.com/anthropics/claude-code/issues/39472",
+      "title": "[FEATURE] Project-scoped LSP configuration",
+      "impact": "not_applicable",
+      "categories": [
+        "mcp",
+        "plugin",
+        "install"
+      ],
+      "tokenkey_status": "not_applicable",
+      "rationale": "Client-side claude-code concern (mcp, plugin, install); not a gateway/relay relevance signal.",
+      "updated_at": "2026-06-02T11:33:03Z"
+    },
+    {
+      "upstream": "anthropics/claude-code#39473",
+      "url": "https://github.com/anthropics/claude-code/issues/39473",
+      "title": "[FEATURE] Add /lsp slash command for LSP server status",
+      "impact": "not_applicable",
+      "categories": [
+        "mcp",
+        "plugin",
+        "slash_hook",
+        "install"
+      ],
+      "tokenkey_status": "not_applicable",
+      "rationale": "Client-side claude-code concern (mcp, plugin, slash_hook, install); not a gateway/relay relevance signal.",
+      "updated_at": "2026-06-02T11:33:01Z"
+    },
+    {
+      "upstream": "anthropics/claude-code#39663",
+      "url": "https://github.com/anthropics/claude-code/issues/39663",
+      "title": "Context is lost when Claude suggests restarting — should auto-save a session summary before restart",
+      "impact": "not_applicable",
+      "categories": [
+        "mcp",
+        "slash_hook"
+      ],
+      "tokenkey_status": "not_applicable",
+      "rationale": "Client-side claude-code concern (mcp, slash_hook); not a gateway/relay relevance signal.",
+      "updated_at": "2026-06-02T22:44:33Z"
+    },
+    {
+      "upstream": "anthropics/claude-code#39841",
+      "url": "https://github.com/anthropics/claude-code/issues/39841",
+      "title": "Opus 1M context on Max plan requires extra usage despite docs saying 'included with subscription'",
+      "impact": "not_applicable",
+      "categories": [
+        "platform"
+      ],
+      "tokenkey_status": "not_applicable",
+      "rationale": "Client-side claude-code concern (platform); not a gateway/relay relevance signal.",
+      "updated_at": "2026-06-02T14:43:16Z"
+    },
+    {
+      "upstream": "anthropics/claude-code#40123",
+      "url": "https://github.com/anthropics/claude-code/issues/40123",
+      "title": "[DOCS] Read tool docs omit compact line-number output and unchanged re-read deduplication",
+      "impact": "not_applicable",
+      "categories": [
+        "plugin",
+        "slash_hook"
+      ],
+      "tokenkey_status": "not_applicable",
+      "rationale": "Client-side claude-code concern (plugin, slash_hook); not a gateway/relay relevance signal.",
+      "updated_at": "2026-06-02T22:44:46Z"
+    },
+    {
+      "upstream": "anthropics/claude-code#40173",
+      "url": "https://github.com/anthropics/claude-code/issues/40173",
+      "title": "Claude-in-Chrome: Server-side domain blocking breaks legitimate business automation",
+      "impact": "not_applicable",
+      "categories": [
+        "ide"
+      ],
+      "tokenkey_status": "not_applicable",
+      "rationale": "Client-side claude-code concern (ide); not a gateway/relay relevance signal.",
+      "updated_at": "2026-06-01T06:25:41Z"
+    },
+    {
+      "upstream": "anthropics/claude-code#40198",
+      "url": "https://github.com/anthropics/claude-code/issues/40198",
+      "title": "[BUG] [BUG] Cowork VM fails to start on Windows ARM64 (Samsung Galaxy Book4 Edge, Snapdragon)",
+      "impact": "not_applicable",
+      "categories": [
+        "terminal",
+        "mcp",
+        "install",
+        "platform"
+      ],
+      "tokenkey_status": "not_applicable",
+      "rationale": "Client-side claude-code concern (terminal, mcp, install, platform); not a gateway/relay relevance signal.",
+      "updated_at": "2026-06-02T15:09:42Z"
+    },
+    {
+      "upstream": "anthropics/claude-code#40897",
+      "url": "https://github.com/anthropics/claude-code/issues/40897",
+      "title": "Allow disabling built-in PR number display on status line",
+      "impact": "not_applicable",
+      "categories": [
+        "terminal",
+        "slash_hook"
+      ],
+      "tokenkey_status": "not_applicable",
+      "rationale": "Client-side claude-code concern (terminal, slash_hook); not a gateway/relay relevance signal.",
+      "updated_at": "2026-06-02T22:44:51Z"
+    },
+    {
+      "upstream": "anthropics/claude-code#41007",
+      "url": "https://github.com/anthropics/claude-code/issues/41007",
+      "title": "Spinner characters have inconsistent widths in Noto Sans Mono",
+      "impact": "not_applicable",
+      "categories": [
+        "terminal",
+        "slash_hook"
+      ],
+      "tokenkey_status": "not_applicable",
+      "rationale": "Client-side claude-code concern (terminal, slash_hook); not a gateway/relay relevance signal.",
+      "updated_at": "2026-06-02T22:44:28Z"
+    },
+    {
+      "upstream": "anthropics/claude-code#41179",
+      "url": "https://github.com/anthropics/claude-code/issues/41179",
+      "title": "[FEATURE] Enable Auto mode support for Amazon Bedrock models",
+      "impact": "not_applicable",
+      "categories": [
+        "terminal",
+        "slash_hook",
+        "install"
+      ],
+      "tokenkey_status": "not_applicable",
+      "rationale": "Client-side claude-code concern (terminal, slash_hook, install); not a gateway/relay relevance signal.",
+      "updated_at": "2026-06-02T13:36:59Z"
+    },
+    {
+      "upstream": "anthropics/claude-code#41581",
+      "url": "https://github.com/anthropics/claude-code/issues/41581",
+      "title": "[BUG] Max subscription downgraded to Free plan without any action from user",
+      "impact": "not_applicable",
+      "categories": [
+        "terminal"
+      ],
+      "tokenkey_status": "not_applicable",
+      "rationale": "Client-side claude-code concern (terminal); not a gateway/relay relevance signal.",
+      "updated_at": "2026-06-01T22:45:50Z"
+    },
+    {
+      "upstream": "anthropics/claude-code#41737",
+      "url": "https://github.com/anthropics/claude-code/issues/41737",
+      "title": "Task output files grow unboundedly, filling entire disk (278 GB in minutes)",
+      "impact": "not_applicable",
+      "categories": [
+        "mcp",
+        "plugin"
+      ],
+      "tokenkey_status": "not_applicable",
+      "rationale": "Client-side claude-code concern (mcp, plugin); not a gateway/relay relevance signal.",
+      "updated_at": "2026-06-02T02:59:18Z"
+    },
+    {
+      "upstream": "anthropics/claude-code#42029",
+      "url": "https://github.com/anthropics/claude-code/issues/42029",
+      "title": "Enter key not sending command",
+      "impact": "not_applicable",
+      "categories": [
+        "terminal"
+      ],
+      "tokenkey_status": "not_applicable",
+      "rationale": "Client-side claude-code concern (terminal); not a gateway/relay relevance signal.",
+      "updated_at": "2026-06-01T07:20:03Z"
+    },
+    {
+      "upstream": "anthropics/claude-code#42264",
+      "url": "https://github.com/anthropics/claude-code/issues/42264",
+      "title": "[Bug] \"Unchanged since last read\" error when reading file previously accessed in reverted conversation state",
+      "impact": "not_applicable",
+      "categories": [
+        "terminal"
+      ],
+      "tokenkey_status": "not_applicable",
+      "rationale": "Client-side claude-code concern (terminal); not a gateway/relay relevance signal.",
+      "updated_at": "2026-06-02T11:15:50Z"
+    },
+    {
+      "upstream": "anthropics/claude-code#42486",
+      "url": "https://github.com/anthropics/claude-code/issues/42486",
+      "title": "--dangerously-load-development-channels should support skipping the confirmation dialog",
+      "impact": "not_applicable",
+      "categories": [
+        "terminal",
+        "mcp",
+        "plugin",
+        "slash_hook",
+        "platform"
+      ],
+      "tokenkey_status": "not_applicable",
+      "rationale": "Client-side claude-code concern (terminal, mcp, plugin, slash_hook, platform); not a gateway/relay relevance signal.",
+      "updated_at": "2026-06-03T01:13:13Z"
+    },
+    {
+      "upstream": "anthropics/claude-code#42776",
+      "url": "https://github.com/anthropics/claude-code/issues/42776",
+      "title": "[BUG] Claude Code Desktop fails to Relaunch on Windows due to orphaned process file lock",
+      "impact": "not_applicable",
+      "categories": [
+        "terminal",
+        "slash_hook",
+        "platform"
+      ],
+      "tokenkey_status": "not_applicable",
+      "rationale": "Client-side claude-code concern (terminal, slash_hook, platform); not a gateway/relay relevance signal.",
+      "updated_at": "2026-06-02T08:07:12Z"
+    },
+    {
+      "upstream": "anthropics/claude-code#42975",
+      "url": "https://github.com/anthropics/claude-code/issues/42975",
+      "title": "Desktop app: bypassPermissions mode still prompts for confirmation",
+      "impact": "not_applicable",
+      "categories": [
+        "slash_hook",
+        "platform"
+      ],
+      "tokenkey_status": "not_applicable",
+      "rationale": "Client-side claude-code concern (slash_hook, platform); not a gateway/relay relevance signal.",
+      "updated_at": "2026-06-02T11:32:12Z"
+    },
+    {
+      "upstream": "anthropics/claude-code#43013",
+      "url": "https://github.com/anthropics/claude-code/issues/43013",
+      "title": "[BUG] 🚨 `--continue` and `-p` are now seriously broken together in 2.1.90",
+      "impact": "not_applicable",
+      "categories": [
+        "terminal"
+      ],
+      "tokenkey_status": "not_applicable",
+      "rationale": "Client-side claude-code concern (terminal); not a gateway/relay relevance signal.",
+      "updated_at": "2026-06-01T19:40:28Z"
+    },
+    {
+      "upstream": "anthropics/claude-code#43113",
+      "url": "https://github.com/anthropics/claude-code/issues/43113",
+      "title": "[FEATURE] Add a flag that tells Claude Code to emit long lines for prose/markdown content and let the terminal emulator handle word wrapping, rather than inserting hard newline characters at word boundaries",
+      "impact": "not_applicable",
+      "categories": [
+        "terminal",
+        "platform"
+      ],
+      "tokenkey_status": "not_applicable",
+      "rationale": "Client-side claude-code concern (terminal, platform); not a gateway/relay relevance signal.",
+      "updated_at": "2026-06-01T19:56:18Z"
+    },
+    {
+      "upstream": "anthropics/claude-code#43127",
+      "url": "https://github.com/anthropics/claude-code/issues/43127",
+      "title": "bug: installer places binary in ~/.local/bin but shell snapshot drops it from PATH, causing spurious startup warning",
+      "impact": "not_applicable",
+      "categories": [
+        "install"
+      ],
+      "tokenkey_status": "not_applicable",
+      "rationale": "Client-side claude-code concern (install); not a gateway/relay relevance signal.",
+      "updated_at": "2026-06-02T15:48:01Z"
+    },
+    {
+      "upstream": "anthropics/claude-code#43477",
+      "url": "https://github.com/anthropics/claude-code/issues/43477",
+      "title": "[BUG] Copying text (Ctrl+C) from Claude Code window in VS Code fails",
+      "impact": "not_applicable",
+      "categories": [
+        "ide",
+        "terminal",
+        "platform"
+      ],
+      "tokenkey_status": "not_applicable",
+      "rationale": "Client-side claude-code concern (ide, terminal, platform); not a gateway/relay relevance signal.",
+      "updated_at": "2026-06-02T11:31:49Z"
+    },
+    {
+      "upstream": "anthropics/claude-code#44129",
+      "url": "https://github.com/anthropics/claude-code/issues/44129",
+      "title": "Scheduled tasks never execute automatically — wakeScheduler feature flag unavailable",
+      "impact": "not_applicable",
+      "categories": [
+        "terminal"
+      ],
+      "tokenkey_status": "not_applicable",
+      "rationale": "Client-side claude-code concern (terminal); not a gateway/relay relevance signal.",
+      "updated_at": "2026-05-31T10:41:29Z"
+    },
+    {
+      "upstream": "anthropics/claude-code#44163",
+      "url": "https://github.com/anthropics/claude-code/issues/44163",
+      "title": "[BUG] Gift Pro subscription auto-canceled + broken credit redemption link (Page not found)",
+      "impact": "not_applicable",
+      "categories": [
+        "terminal"
+      ],
+      "tokenkey_status": "not_applicable",
+      "rationale": "Client-side claude-code concern (terminal); not a gateway/relay relevance signal.",
+      "updated_at": "2026-06-01T22:45:56Z"
+    },
+    {
+      "upstream": "anthropics/claude-code#44380",
+      "url": "https://github.com/anthropics/claude-code/issues/44380",
+      "title": "Channel messages don't wake idle sessions (--channels plugin)",
+      "impact": "not_applicable",
+      "categories": [
+        "terminal",
+        "mcp",
+        "plugin"
+      ],
+      "tokenkey_status": "not_applicable",
+      "rationale": "Client-side claude-code concern (terminal, mcp, plugin); not a gateway/relay relevance signal.",
+      "updated_at": "2026-06-03T04:52:47Z"
+    },
+    {
+      "upstream": "anthropics/claude-code#44567",
+      "url": "https://github.com/anthropics/claude-code/issues/44567",
+      "title": "[BUG] bwrap fails in a worktree when .claude/skills is a symlink in a repository",
+      "impact": "not_applicable",
+      "categories": [
+        "terminal",
+        "slash_hook"
+      ],
+      "tokenkey_status": "not_applicable",
+      "rationale": "Client-side claude-code concern (terminal, slash_hook); not a gateway/relay relevance signal.",
+      "updated_at": "2026-06-01T05:58:16Z"
+    },
+    {
+      "upstream": "anthropics/claude-code#4462",
+      "url": "https://github.com/anthropics/claude-code/issues/4462",
+      "title": "[BUG] Sub-agents claim successful file creation but files don't persist to filesystem",
+      "impact": "not_applicable",
+      "categories": [
+        "plugin"
+      ],
+      "tokenkey_status": "not_applicable",
+      "rationale": "Client-side claude-code concern (plugin); not a gateway/relay relevance signal.",
+      "updated_at": "2026-06-02T19:22:42Z"
+    },
+    {
+      "upstream": "anthropics/claude-code#44648",
+      "url": "https://github.com/anthropics/claude-code/issues/44648",
+      "title": "[FEATURE] Persistent governance context to address context dilution",
+      "impact": "not_applicable",
+      "categories": [
+        "mcp",
+        "slash_hook",
+        "platform"
+      ],
+      "tokenkey_status": "not_applicable",
+      "rationale": "Client-side claude-code concern (mcp, slash_hook, platform); not a gateway/relay relevance signal.",
+      "updated_at": "2026-06-01T22:45:29Z"
+    },
+    {
+      "upstream": "anthropics/claude-code#44752",
+      "url": "https://github.com/anthropics/claude-code/issues/44752",
+      "title": "[BUG] VSCode \"There's an issue with the selected model\" With OpenRouter",
+      "impact": "not_applicable",
+      "categories": [
+        "ide",
+        "terminal",
+        "install"
+      ],
+      "tokenkey_status": "not_applicable",
+      "rationale": "Client-side claude-code concern (ide, terminal, install); not a gateway/relay relevance signal.",
+      "updated_at": "2026-06-02T11:32:26Z"
+    },
+    {
+      "upstream": "anthropics/claude-code#44763",
+      "url": "https://github.com/anthropics/claude-code/issues/44763",
+      "title": "Show timestamps on conversation messages",
+      "impact": "not_applicable",
+      "categories": [
+        "terminal",
+        "slash_hook"
+      ],
+      "tokenkey_status": "not_applicable",
+      "rationale": "Client-side claude-code concern (terminal, slash_hook); not a gateway/relay relevance signal.",
+      "updated_at": "2026-06-02T17:41:14Z"
+    },
+    {
+      "upstream": "anthropics/claude-code#44826",
+      "url": "https://github.com/anthropics/claude-code/issues/44826",
+      "title": "MCP parameter parser silently swallows args on mismatched close tag",
+      "impact": "not_applicable",
+      "categories": [
+        "mcp"
+      ],
+      "tokenkey_status": "not_applicable",
+      "rationale": "Client-side claude-code concern (mcp); not a gateway/relay relevance signal.",
+      "updated_at": "2026-06-01T12:03:11Z"
+    },
+    {
+      "upstream": "anthropics/claude-code#44892",
+      "url": "https://github.com/anthropics/claude-code/issues/44892",
+      "title": "Support spinnerVerbs customization in desktop app",
+      "impact": "not_applicable",
+      "categories": [
+        "terminal",
+        "slash_hook"
+      ],
+      "tokenkey_status": "not_applicable",
+      "rationale": "Client-side claude-code concern (terminal, slash_hook); not a gateway/relay relevance signal.",
+      "updated_at": "2026-05-31T16:51:13Z"
+    },
+    {
+      "upstream": "anthropics/claude-code#44941",
+      "url": "https://github.com/anthropics/claude-code/issues/44941",
+      "title": "[BUG] Auto mode is not showing up in the VS code extension on windows",
+      "impact": "not_applicable",
+      "categories": [
+        "ide",
+        "terminal",
+        "platform"
+      ],
+      "tokenkey_status": "not_applicable",
+      "rationale": "Client-side claude-code concern (ide, terminal, platform); not a gateway/relay relevance signal.",
+      "updated_at": "2026-06-02T01:18:06Z"
+    },
+    {
+      "upstream": "anthropics/claude-code#45390",
+      "url": "https://github.com/anthropics/claude-code/issues/45390",
+      "title": "[Bug] 1M context incorrectly requires extra usage on Max plan",
+      "impact": "not_applicable",
+      "categories": [
+        "terminal"
+      ],
+      "tokenkey_status": "not_applicable",
+      "rationale": "Client-side claude-code concern (terminal); not a gateway/relay relevance signal.",
+      "updated_at": "2026-06-01T01:18:50Z"
+    },
+    {
+      "upstream": "anthropics/claude-code#45596",
+      "url": "https://github.com/anthropics/claude-code/issues/45596",
+      "title": "Bring Back Buddy — A Consolidated Plea from the Community",
+      "impact": "not_applicable",
+      "categories": [
+        "ide",
+        "terminal",
+        "slash_hook",
+        "platform"
+      ],
+      "tokenkey_status": "not_applicable",
+      "rationale": "Client-side claude-code concern (ide, terminal, slash_hook, platform); not a gateway/relay relevance signal.",
+      "updated_at": "2026-06-01T22:27:33Z"
+    },
+    {
+      "upstream": "anthropics/claude-code#45692",
+      "url": "https://github.com/anthropics/claude-code/issues/45692",
+      "title": "[BUG] Jetbrains Plugin cannot connect properly on WSL",
+      "impact": "not_applicable",
+      "categories": [
+        "ide",
+        "terminal",
+        "plugin",
+        "platform"
+      ],
+      "tokenkey_status": "not_applicable",
+      "rationale": "Client-side claude-code concern (ide, terminal, plugin, platform); not a gateway/relay relevance signal.",
+      "updated_at": "2026-06-01T18:08:01Z"
+    },
+    {
+      "upstream": "anthropics/claude-code#45717",
+      "url": "https://github.com/anthropics/claude-code/issues/45717",
+      "title": "[BUG] Bash tool timeout kills Claude Code process (SIGTERM propagation), not just the child command",
+      "impact": "not_applicable",
+      "categories": [
+        "terminal",
+        "mcp"
+      ],
+      "tokenkey_status": "not_applicable",
+      "rationale": "Client-side claude-code concern (terminal, mcp); not a gateway/relay relevance signal.",
+      "updated_at": "2026-06-01T22:45:04Z"
+    },
+    {
+      "upstream": "anthropics/claude-code#45810",
+      "url": "https://github.com/anthropics/claude-code/issues/45810",
+      "title": "Marketplace update button is disabled/not pressable even when version is outdated",
+      "impact": "not_applicable",
+      "categories": [
+        "plugin"
+      ],
+      "tokenkey_status": "not_applicable",
+      "rationale": "Client-side claude-code concern (plugin); not a gateway/relay relevance signal.",
+      "updated_at": "2026-06-02T04:51:51Z"
+    },
+    {
+      "upstream": "anthropics/claude-code#45880",
+      "url": "https://github.com/anthropics/claude-code/issues/45880",
+      "title": "[BUG] Multiple concurrent sessions multiply MCP server processes without memory limits, causing kernel panic",
+      "impact": "not_applicable",
+      "categories": [
+        "mcp",
+        "slash_hook"
+      ],
+      "tokenkey_status": "not_applicable",
+      "rationale": "Client-side claude-code concern (mcp, slash_hook); not a gateway/relay relevance signal.",
+      "updated_at": "2026-05-31T10:41:35Z"
+    },
+    {
+      "upstream": "anthropics/claude-code#45942",
+      "url": "https://github.com/anthropics/claude-code/issues/45942",
+      "title": "[BUG] Remote Control: \"Always allow\" permission from Android app breaks tool calls",
+      "impact": "not_applicable",
+      "categories": [
+        "terminal",
+        "platform"
+      ],
+      "tokenkey_status": "not_applicable",
+      "rationale": "Client-side claude-code concern (terminal, platform); not a gateway/relay relevance signal.",
+      "updated_at": "2026-06-02T10:03:58Z"
+    },
+    {
+      "upstream": "anthropics/claude-code#46041",
+      "url": "https://github.com/anthropics/claude-code/issues/46041",
+      "title": "[Bug] /insights command displays incorrect file path on Windows (missing backslash between username and .claude)",
+      "impact": "not_applicable",
+      "categories": [
+        "terminal",
+        "platform"
+      ],
+      "tokenkey_status": "not_applicable",
+      "rationale": "Client-side claude-code concern (terminal, platform); not a gateway/relay relevance signal.",
+      "updated_at": "2026-06-02T11:32:22Z"
+    },
+    {
+      "upstream": "anthropics/claude-code#46083",
+      "url": "https://github.com/anthropics/claude-code/issues/46083",
+      "title": "[BUG] [workflow] No email warning when \"stale\" label is applied",
+      "impact": "not_applicable",
+      "categories": [
+        "terminal"
+      ],
+      "tokenkey_status": "not_applicable",
+      "rationale": "Client-side claude-code concern (terminal); not a gateway/relay relevance signal.",
+      "updated_at": "2026-06-01T15:36:04Z"
+    },
+    {
+      "upstream": "anthropics/claude-code#46147",
+      "url": "https://github.com/anthropics/claude-code/issues/46147",
+      "title": "[Bug] File Read Encoding Corruption Triggers False Positive Usage Policy Block",
+      "impact": "not_applicable",
+      "categories": [
+        "terminal",
+        "platform"
+      ],
+      "tokenkey_status": "not_applicable",
+      "rationale": "Client-side claude-code concern (terminal, platform); not a gateway/relay relevance signal.",
+      "updated_at": "2026-05-31T10:41:34Z"
+    },
+    {
+      "upstream": "anthropics/claude-code#46425",
+      "url": "https://github.com/anthropics/claude-code/issues/46425",
+      "title": "[FEATURE] VS Code extension: collapse large pasted text like terminal CLI does",
+      "impact": "not_applicable",
+      "categories": [
+        "ide",
+        "terminal"
+      ],
+      "tokenkey_status": "not_applicable",
+      "rationale": "Client-side claude-code concern (ide, terminal); not a gateway/relay relevance signal.",
+      "updated_at": "2026-06-01T22:46:07Z"
+    },
+    {
+      "upstream": "anthropics/claude-code#46616",
+      "url": "https://github.com/anthropics/claude-code/issues/46616",
+      "title": "Max plan: \"auto mode is not available for your plan\" shown under input bar",
+      "impact": "not_applicable",
+      "categories": [
+        "terminal"
+      ],
+      "tokenkey_status": "not_applicable",
+      "rationale": "Client-side claude-code concern (terminal); not a gateway/relay relevance signal.",
+      "updated_at": "2026-06-02T11:32:59Z"
+    },
+    {
+      "upstream": "anthropics/claude-code#47056",
+      "url": "https://github.com/anthropics/claude-code/issues/47056",
+      "title": "[Bug] CLAUDE_CONFIG_DIR env var ignored; still loads ~/.claude/CLAUDE.md",
+      "impact": "not_applicable",
+      "categories": [
+        "ide",
+        "terminal"
+      ],
+      "tokenkey_status": "not_applicable",
+      "rationale": "Client-side claude-code concern (ide, terminal); not a gateway/relay relevance signal.",
+      "updated_at": "2026-06-01T12:02:20Z"
+    },
+    {
+      "upstream": "anthropics/claude-code#47154",
+      "url": "https://github.com/anthropics/claude-code/issues/47154",
+      "title": "[Bug] Monitor tool missing from Claude Code v2.1.104 despite documentation stating it exists",
+      "impact": "not_applicable",
+      "categories": [
+        "terminal"
+      ],
+      "tokenkey_status": "not_applicable",
+      "rationale": "Client-side claude-code concern (terminal); not a gateway/relay relevance signal.",
+      "updated_at": "2026-06-01T19:19:29Z"
+    },
+    {
+      "upstream": "anthropics/claude-code#47336",
+      "url": "https://github.com/anthropics/claude-code/issues/47336",
+      "title": "[Bug] Agent hangs indefinitely without progress",
+      "impact": "not_applicable",
+      "categories": [
+        "ide",
+        "terminal"
+      ],
+      "tokenkey_status": "not_applicable",
+      "rationale": "Client-side claude-code concern (ide, terminal); not a gateway/relay relevance signal.",
+      "updated_at": "2026-06-01T22:45:36Z"
+    },
+    {
+      "upstream": "anthropics/claude-code#47378",
+      "url": "https://github.com/anthropics/claude-code/issues/47378",
+      "title": "MCP stdio transport: client kills stdin 2-5s after receiving successful tool response (chrome-devtools-mcp)",
+      "impact": "not_applicable",
+      "categories": [
+        "mcp"
+      ],
+      "tokenkey_status": "not_applicable",
+      "rationale": "Client-side claude-code concern (mcp); not a gateway/relay relevance signal.",
+      "updated_at": "2026-06-01T22:45:26Z"
+    },
+    {
+      "upstream": "anthropics/claude-code#47400",
+      "url": "https://github.com/anthropics/claude-code/issues/47400",
+      "title": "Claude Code (VSC Extension) - MCP handshake timeout",
+      "impact": "not_applicable",
+      "categories": [
+        "ide",
+        "terminal",
+        "mcp",
+        "slash_hook",
+        "platform"
+      ],
+      "tokenkey_status": "not_applicable",
+      "rationale": "Client-side claude-code concern (ide, terminal, mcp, slash_hook, platform); not a gateway/relay relevance signal.",
+      "updated_at": "2026-06-02T22:44:42Z"
+    },
+    {
+      "upstream": "anthropics/claude-code#47482",
+      "url": "https://github.com/anthropics/claude-code/issues/47482",
+      "title": "[BUG] Output styles with YAML frontmatter not injected into system prompt",
+      "impact": "not_applicable",
+      "categories": [
+        "ide",
+        "plugin"
+      ],
+      "tokenkey_status": "not_applicable",
+      "rationale": "Client-side claude-code concern (ide, plugin); not a gateway/relay relevance signal.",
+      "updated_at": "2026-06-02T19:28:56Z"
+    },
+    {
+      "upstream": "anthropics/claude-code#47733",
+      "url": "https://github.com/anthropics/claude-code/issues/47733",
+      "title": "[BUG] User-level MCP servers don't load in worktree sessions",
+      "impact": "not_applicable",
+      "categories": [
+        "mcp",
+        "slash_hook"
+      ],
+      "tokenkey_status": "not_applicable",
+      "rationale": "Client-side claude-code concern (mcp, slash_hook); not a gateway/relay relevance signal.",
+      "updated_at": "2026-06-02T17:05:26Z"
+    },
+    {
+      "upstream": "anthropics/claude-code#47853",
+      "url": "https://github.com/anthropics/claude-code/issues/47853",
+      "title": "[BUG] PreToolUse updatedInput silently ignored for Edit tool — works for Read and Bash",
+      "impact": "not_applicable",
+      "categories": [
+        "ide",
+        "plugin",
+        "slash_hook",
+        "platform"
+      ],
+      "tokenkey_status": "not_applicable",
+      "rationale": "Client-side claude-code concern (ide, plugin, slash_hook, platform); not a gateway/relay relevance signal.",
+      "updated_at": "2026-06-01T22:46:06Z"
+    },
+    {
+      "upstream": "anthropics/claude-code#47899",
+      "url": "https://github.com/anthropics/claude-code/issues/47899",
+      "title": "Scheduled tasks dispatch but never execute — sessions stuck \"Running\" with zero turns, causing permanent skip-cascade",
+      "impact": "not_applicable",
+      "categories": [
+        "terminal",
+        "platform"
+      ],
+      "tokenkey_status": "not_applicable",
+      "rationale": "Client-side claude-code concern (terminal, platform); not a gateway/relay relevance signal.",
+      "updated_at": "2026-06-02T22:44:21Z"
+    },
+    {
+      "upstream": "anthropics/claude-code#48094",
+      "url": "https://github.com/anthropics/claude-code/issues/48094",
+      "title": "Feature request: metals-lsp plugin for Scala language server",
+      "impact": "not_applicable",
+      "categories": [
+        "plugin"
+      ],
+      "tokenkey_status": "not_applicable",
+      "rationale": "Client-side claude-code concern (plugin); not a gateway/relay relevance signal.",
+      "updated_at": "2026-06-02T11:32:48Z"
+    },
+    {
+      "upstream": "anthropics/claude-code#48231",
+      "url": "https://github.com/anthropics/claude-code/issues/48231",
+      "title": "[BUG] Claude Pro gift subscription downgraded to Free after 5 days",
+      "impact": "not_applicable",
+      "categories": [
+        "terminal",
+        "platform"
+      ],
+      "tokenkey_status": "not_applicable",
+      "rationale": "Client-side claude-code concern (terminal, platform); not a gateway/relay relevance signal.",
+      "updated_at": "2026-06-02T05:55:42Z"
+    },
+    {
+      "upstream": "anthropics/claude-code#48362",
+      "url": "https://github.com/anthropics/claude-code/issues/48362",
+      "title": "[BUG] Claude Desktop (Windows Store / MSIX): Code sessions silently fail to persist due to EXDEV error inside MSIX sandbox, even when everything is on C: — resolved by switching to Win32 installer",
+      "impact": "not_applicable",
+      "categories": [
+        "terminal",
+        "mcp",
+        "install",
+        "platform"
+      ],
+      "tokenkey_status": "not_applicable",
+      "rationale": "Client-side claude-code concern (terminal, mcp, install, platform); not a gateway/relay relevance signal.",
+      "updated_at": "2026-06-02T11:32:31Z"
+    },
+    {
+      "upstream": "anthropics/claude-code#48435",
+      "url": "https://github.com/anthropics/claude-code/issues/48435",
+      "title": "[BUG] Scrolling Claude Response with Keyboard Stopped Working",
+      "impact": "not_applicable",
+      "categories": [
+        "terminal",
+        "platform"
+      ],
+      "tokenkey_status": "not_applicable",
+      "rationale": "Client-side claude-code concern (terminal, platform); not a gateway/relay relevance signal.",
+      "updated_at": "2026-06-02T16:41:57Z"
+    },
+    {
+      "upstream": "anthropics/claude-code#48641",
+      "url": "https://github.com/anthropics/claude-code/issues/48641",
+      "title": "[FEATURE] VS Code extension: click-to-copy affordance on code blocks in Claude responses",
+      "impact": "not_applicable",
+      "categories": [
+        "ide",
+        "terminal"
+      ],
+      "tokenkey_status": "not_applicable",
+      "rationale": "Client-side claude-code concern (ide, terminal); not a gateway/relay relevance signal.",
+      "updated_at": "2026-06-01T12:44:22Z"
+    },
+    {
+      "upstream": "anthropics/claude-code#48680",
+      "url": "https://github.com/anthropics/claude-code/issues/48680",
+      "title": "[BUG] claude.ai marketplace MCP server instructions inject into context on every session regardless of Tool Search",
+      "impact": "not_applicable",
+      "categories": [
+        "terminal",
+        "mcp",
+        "plugin"
+      ],
+      "tokenkey_status": "not_applicable",
+      "rationale": "Client-side claude-code concern (terminal, mcp, plugin); not a gateway/relay relevance signal.",
+      "updated_at": "2026-06-01T15:36:27Z"
+    },
+    {
+      "upstream": "anthropics/claude-code#48765",
+      "url": "https://github.com/anthropics/claude-code/issues/48765",
+      "title": "Add setting to hide/disable the 'Create PR' button in the git status bar",
+      "impact": "not_applicable",
+      "categories": [
+        "slash_hook"
+      ],
+      "tokenkey_status": "not_applicable",
+      "rationale": "Client-side claude-code concern (slash_hook); not a gateway/relay relevance signal.",
+      "updated_at": "2026-06-02T17:17:59Z"
+    },
+    {
+      "upstream": "anthropics/claude-code#48805",
+      "url": "https://github.com/anthropics/claude-code/issues/48805",
+      "title": "[FEATURE] Terminal font family setting in desktop app",
+      "impact": "not_applicable",
+      "categories": [
+        "terminal"
+      ],
+      "tokenkey_status": "not_applicable",
+      "rationale": "Client-side claude-code concern (terminal); not a gateway/relay relevance signal.",
+      "updated_at": "2026-06-02T15:54:37Z"
+    },
+    {
+      "upstream": "anthropics/claude-code#49184",
+      "url": "https://github.com/anthropics/claude-code/issues/49184",
+      "title": "[BUG] Agent spawning steals tmux focus from the user's pane",
+      "impact": "not_applicable",
+      "categories": [
+        "terminal",
+        "slash_hook"
+      ],
+      "tokenkey_status": "not_applicable",
+      "rationale": "Client-side claude-code concern (terminal, slash_hook); not a gateway/relay relevance signal.",
+      "updated_at": "2026-06-02T22:44:58Z"
+    },
+    {
+      "upstream": "anthropics/claude-code#49272",
+      "url": "https://github.com/anthropics/claude-code/issues/49272",
+      "title": "[BUG] Cowork (desktop app): mkdir/os.makedirs does not persist to Windows filesystem — virtiofs FUSE_MKDIR not forwarded to Windows host",
+      "impact": "not_applicable",
+      "categories": [
+        "terminal",
+        "platform"
+      ],
+      "tokenkey_status": "not_applicable",
+      "rationale": "Client-side claude-code concern (terminal, platform); not a gateway/relay relevance signal.",
+      "updated_at": "2026-06-01T22:45:53Z"
+    },
+    {
+      "upstream": "anthropics/claude-code#49282",
+      "url": "https://github.com/anthropics/claude-code/issues/49282",
+      "title": "[BUG] claude binary re-registers as new app in macOS Privacy & Security on every version update (versioned install path, not code signing)",
+      "impact": "not_applicable",
+      "categories": [
+        "terminal",
+        "plugin",
+        "install"
+      ],
+      "tokenkey_status": "not_applicable",
+      "rationale": "Client-side claude-code concern (terminal, plugin, install); not a gateway/relay relevance signal.",
+      "updated_at": "2026-06-02T11:43:19Z"
+    },
+    {
+      "upstream": "anthropics/claude-code#49536",
+      "url": "https://github.com/anthropics/claude-code/issues/49536",
+      "title": "[BUG] Limits got reset early - Huge loss of usage",
+      "impact": "not_applicable",
+      "categories": [
+        "terminal"
+      ],
+      "tokenkey_status": "not_applicable",
+      "rationale": "Client-side claude-code concern (terminal); not a gateway/relay relevance signal.",
+      "updated_at": "2026-06-01T22:45:38Z"
+    },
+    {
+      "upstream": "anthropics/claude-code#49565",
+      "url": "https://github.com/anthropics/claude-code/issues/49565",
+      "title": "--no-session-persistence flag is ignored in 2.1.112 (regression from 2.1.104)",
+      "impact": "not_applicable",
+      "categories": [
+        "install"
+      ],
+      "tokenkey_status": "not_applicable",
+      "rationale": "Client-side claude-code concern (install); not a gateway/relay relevance signal.",
+      "updated_at": "2026-06-02T11:31:54Z"
+    },
+    {
+      "upstream": "anthropics/claude-code#49616",
+      "url": "https://github.com/anthropics/claude-code/issues/49616",
+      "title": "[BUG] Weekly usage limit reset 4+ hours before scheduled reset time",
+      "impact": "not_applicable",
+      "categories": [
+        "terminal"
+      ],
+      "tokenkey_status": "not_applicable",
+      "rationale": "Client-side claude-code concern (terminal); not a gateway/relay relevance signal.",
+      "updated_at": "2026-06-01T22:45:36Z"
+    },
+    {
+      "upstream": "anthropics/claude-code#49933",
+      "url": "https://github.com/anthropics/claude-code/issues/49933",
+      "title": "[Feature Request] Native WSL Remote Integration for Claude Code Desktop on Windows",
+      "impact": "not_applicable",
+      "categories": [
+        "ide",
+        "terminal",
+        "install",
+        "platform"
+      ],
+      "tokenkey_status": "not_applicable",
+      "rationale": "Client-side claude-code concern (ide, terminal, install, platform); not a gateway/relay relevance signal.",
+      "updated_at": "2026-06-02T23:39:43Z"
+    },
+    {
+      "upstream": "anthropics/claude-code#50014",
+      "url": "https://github.com/anthropics/claude-code/issues/50014",
+      "title": "[FEATURE] Secret scrubbing and rotation for session logs (~/.claude/projects/*.jsonl)",
+      "impact": "not_applicable",
+      "categories": [
+        "ide",
+        "plugin",
+        "install"
+      ],
+      "tokenkey_status": "not_applicable",
+      "rationale": "Client-side claude-code concern (ide, plugin, install); not a gateway/relay relevance signal.",
+      "updated_at": "2026-06-02T22:44:53Z"
+    },
+    {
+      "upstream": "anthropics/claude-code#50159",
+      "url": "https://github.com/anthropics/claude-code/issues/50159",
+      "title": "[BUG] Shift+Enter regression - **AGAIN** - on version 2.1.113 - worked on 2.1.112",
+      "impact": "not_applicable",
+      "categories": [
+        "terminal",
+        "platform"
+      ],
+      "tokenkey_status": "not_applicable",
+      "rationale": "Client-side claude-code concern (terminal, platform); not a gateway/relay relevance signal.",
+      "updated_at": "2026-06-02T22:44:02Z"
+    },
+    {
+      "upstream": "anthropics/claude-code#50214",
+      "url": "https://github.com/anthropics/claude-code/issues/50214",
+      "title": "Add Russian language support for voice input in desktop app",
+      "impact": "not_applicable",
+      "categories": [
+        "terminal",
+        "slash_hook",
+        "platform"
+      ],
+      "tokenkey_status": "not_applicable",
+      "rationale": "Client-side claude-code concern (terminal, slash_hook, platform); not a gateway/relay relevance signal.",
+      "updated_at": "2026-06-01T15:01:35Z"
+    },
+    {
+      "upstream": "anthropics/claude-code#50270",
+      "url": "https://github.com/anthropics/claude-code/issues/50270",
+      "title": "v2.1.113+ broken on Termux/Android: native binary requires glibc, no JS fallback",
+      "impact": "not_applicable",
+      "categories": [
+        "install"
+      ],
+      "tokenkey_status": "not_applicable",
+      "rationale": "Client-side claude-code concern (install); not a gateway/relay relevance signal.",
+      "updated_at": "2026-06-03T05:56:18Z"
+    },
+    {
+      "upstream": "anthropics/claude-code#50277",
+      "url": "https://github.com/anthropics/claude-code/issues/50277",
+      "title": "[BUG] SSH binary deployment fails on Synology NAS — incompatible internal-sftp implementation",
+      "impact": "not_applicable",
+      "categories": [
+        "ide",
+        "terminal",
+        "platform"
+      ],
+      "tokenkey_status": "not_applicable",
+      "rationale": "Client-side claude-code concern (ide, terminal, platform); not a gateway/relay relevance signal.",
+      "updated_at": "2026-06-02T22:44:26Z"
+    },
+    {
+      "upstream": "anthropics/claude-code#50303",
+      "url": "https://github.com/anthropics/claude-code/issues/50303",
+      "title": "[BUG] `--allowedTools` has no effect when permission bypass flags are active",
+      "impact": "not_applicable",
+      "categories": [
+        "ide",
+        "terminal",
+        "platform"
+      ],
+      "tokenkey_status": "not_applicable",
+      "rationale": "Client-side claude-code concern (ide, terminal, platform); not a gateway/relay relevance signal.",
+      "updated_at": "2026-06-02T22:44:43Z"
+    },
+    {
+      "upstream": "anthropics/claude-code#50396",
+      "url": "https://github.com/anthropics/claude-code/issues/50396",
+      "title": "[Feature Request] Clear Context and Accept plan is missing from Claude Desktop",
+      "impact": "not_applicable",
+      "categories": [
+        "terminal",
+        "slash_hook"
+      ],
+      "tokenkey_status": "not_applicable",
+      "rationale": "Client-side claude-code concern (terminal, slash_hook); not a gateway/relay relevance signal.",
+      "updated_at": "2026-06-01T12:02:25Z"
+    },
+    {
+      "upstream": "anthropics/claude-code#50423",
+      "url": "https://github.com/anthropics/claude-code/issues/50423",
+      "title": "[BUG] VS Code extension doesn't load Chrome browser tools in chat panel despite docs stating @browser should work (Linux)",
+      "impact": "not_applicable",
+      "categories": [
+        "ide",
+        "terminal",
+        "mcp",
+        "install"
+      ],
+      "tokenkey_status": "not_applicable",
+      "rationale": "Client-side claude-code concern (ide, terminal, mcp, install); not a gateway/relay relevance signal.",
+      "updated_at": "2026-06-01T03:16:57Z"
+    },
+    {
+      "upstream": "anthropics/claude-code#50647",
+      "url": "https://github.com/anthropics/claude-code/issues/50647",
+      "title": "[BUG] WebFetch summarizer model drops critical details from static HTML pages",
+      "impact": "not_applicable",
+      "categories": [
+        "ide",
+        "terminal",
+        "platform"
+      ],
+      "tokenkey_status": "not_applicable",
+      "rationale": "Client-side claude-code concern (ide, terminal, platform); not a gateway/relay relevance signal.",
+      "updated_at": "2026-06-02T11:31:51Z"
+    },
+    {
+      "upstream": "anthropics/claude-code#50674",
+      "url": "https://github.com/anthropics/claude-code/issues/50674",
+      "title": "Cowork fails on ARM64 (Snapdragon X) despite passing readiness check",
+      "impact": "not_applicable",
+      "categories": [
+        "terminal",
+        "platform"
+      ],
+      "tokenkey_status": "not_applicable",
+      "rationale": "Client-side claude-code concern (terminal, platform); not a gateway/relay relevance signal.",
+      "updated_at": "2026-06-02T12:06:44Z"
+    },
+    {
+      "upstream": "anthropics/claude-code#50722",
+      "url": "https://github.com/anthropics/claude-code/issues/50722",
+      "title": "[BUG] Cowork tab missing in Mac desktop app on latest build, personal account",
+      "impact": "not_applicable",
+      "categories": [
+        "terminal",
+        "platform"
+      ],
+      "tokenkey_status": "not_applicable",
+      "rationale": "Client-side claude-code concern (terminal, platform); not a gateway/relay relevance signal.",
+      "updated_at": "2026-06-01T12:03:18Z"
+    },
+    {
+      "upstream": "anthropics/claude-code#50780",
+      "url": "https://github.com/anthropics/claude-code/issues/50780",
+      "title": "[BUG] Desktop app cannot rewind the first message.",
+      "impact": "not_applicable",
+      "categories": [
+        "terminal"
+      ],
+      "tokenkey_status": "not_applicable",
+      "rationale": "Client-side claude-code concern (terminal); not a gateway/relay relevance signal.",
+      "updated_at": "2026-05-31T10:41:46Z"
+    },
+    {
+      "upstream": "anthropics/claude-code#50867",
+      "url": "https://github.com/anthropics/claude-code/issues/50867",
+      "title": "[BUG] remote control",
+      "impact": "not_applicable",
+      "categories": [
+        "terminal"
+      ],
+      "tokenkey_status": "not_applicable",
+      "rationale": "Client-side claude-code concern (terminal); not a gateway/relay relevance signal.",
+      "updated_at": "2026-05-31T10:41:43Z"
+    },
+    {
+      "upstream": "anthropics/claude-code#50873",
+      "url": "https://github.com/anthropics/claude-code/issues/50873",
+      "title": "[Bug] virtiofs mount serves truncated file contents to sandboxed environment while host files are clean",
+      "impact": "not_applicable",
+      "categories": [
+        "ide",
+        "terminal",
+        "mcp",
+        "install",
+        "platform"
+      ],
+      "tokenkey_status": "not_applicable",
+      "rationale": "Client-side claude-code concern (ide, terminal, mcp, install, platform); not a gateway/relay relevance signal.",
+      "updated_at": "2026-06-01T21:36:25Z"
+    },
+    {
+      "upstream": "anthropics/claude-code#50892",
+      "url": "https://github.com/anthropics/claude-code/issues/50892",
+      "title": "[BUG] False positive usage policy violation on computational biology research content",
+      "impact": "not_applicable",
+      "categories": [
+        "ide",
+        "terminal",
+        "platform"
+      ],
+      "tokenkey_status": "not_applicable",
+      "rationale": "Client-side claude-code concern (ide, terminal, platform); not a gateway/relay relevance signal.",
+      "updated_at": "2026-06-02T00:56:21Z"
+    },
+    {
+      "upstream": "anthropics/claude-code#50903",
+      "url": "https://github.com/anthropics/claude-code/issues/50903",
+      "title": "Channels feature regressed between 2.1.104 and 2.1.114 on personal Max: tengu_harbor evaluates false despite cached true",
+      "impact": "not_applicable",
+      "categories": [
+        "terminal",
+        "mcp",
+        "plugin",
+        "slash_hook",
+        "install"
+      ],
+      "tokenkey_status": "not_applicable",
+      "rationale": "Client-side claude-code concern (terminal, mcp, plugin, slash_hook, install); not a gateway/relay relevance signal.",
+      "updated_at": "2026-06-02T22:44:41Z"
+    },
+    {
+      "upstream": "anthropics/claude-code#50975",
+      "url": "https://github.com/anthropics/claude-code/issues/50975",
+      "title": "Write tool silently converts full-width CJK punctuation to half-width ASCII when overwriting files",
+      "impact": "not_applicable",
+      "categories": [
+        "terminal"
+      ],
+      "tokenkey_status": "not_applicable",
+      "rationale": "Client-side claude-code concern (terminal); not a gateway/relay relevance signal.",
+      "updated_at": "2026-06-01T13:09:58Z"
+    },
+    {
+      "upstream": "anthropics/claude-code#51008",
+      "url": "https://github.com/anthropics/claude-code/issues/51008",
+      "title": "Skills appear duplicated/triplicated in the slash command list",
+      "impact": "not_applicable",
+      "categories": [
+        "slash_hook",
+        "install"
+      ],
+      "tokenkey_status": "not_applicable",
+      "rationale": "Client-side claude-code concern (slash_hook, install); not a gateway/relay relevance signal.",
+      "updated_at": "2026-06-01T22:45:06Z"
+    },
+    {
+      "upstream": "anthropics/claude-code#51040",
+      "url": "https://github.com/anthropics/claude-code/issues/51040",
+      "title": "Claude.ai Google Drive/Gmail/Calendar MCP integrations lack write operations (move, rename, delete/trash)",
+      "impact": "not_applicable",
+      "categories": [
+        "mcp"
+      ],
+      "tokenkey_status": "not_applicable",
+      "rationale": "Client-side claude-code concern (mcp); not a gateway/relay relevance signal.",
+      "updated_at": "2026-06-02T11:32:36Z"
+    },
+    {
+      "upstream": "anthropics/claude-code#51143",
+      "url": "https://github.com/anthropics/claude-code/issues/51143",
+      "title": "[BUG] Claude Desktop persistent blank/white screen on Windows — Cowork unusable, multiple reinstalls have no effect",
+      "impact": "not_applicable",
+      "categories": [
+        "terminal",
+        "slash_hook",
+        "install",
+        "platform"
+      ],
+      "tokenkey_status": "not_applicable",
+      "rationale": "Client-side claude-code concern (terminal, slash_hook, install, platform); not a gateway/relay relevance signal.",
+      "updated_at": "2026-05-31T17:34:44Z"
+    },
+    {
+      "upstream": "anthropics/claude-code#51160",
+      "url": "https://github.com/anthropics/claude-code/issues/51160",
+      "title": "[BUG] Claude Desktop cannot connect to Claude in Chrome extension in any mode with \"No tab available\" on Windows",
+      "impact": "not_applicable",
+      "categories": [
+        "ide",
+        "mcp",
+        "install",
+        "platform"
+      ],
+      "tokenkey_status": "not_applicable",
+      "rationale": "Client-side claude-code concern (ide, mcp, install, platform); not a gateway/relay relevance signal.",
+      "updated_at": "2026-05-31T10:41:16Z"
+    },
+    {
+      "upstream": "anthropics/claude-code#51213",
+      "url": "https://github.com/anthropics/claude-code/issues/51213",
+      "title": "[BUG] Titlebar buttons overlap and hide Claude’s top menu on RTL Windows languages (Hebrew/Arabic)",
+      "impact": "not_applicable",
+      "categories": [
+        "terminal",
+        "platform"
+      ],
+      "tokenkey_status": "not_applicable",
+      "rationale": "Client-side claude-code concern (terminal, platform); not a gateway/relay relevance signal.",
+      "updated_at": "2026-06-01T11:55:22Z"
+    },
+    {
+      "upstream": "anthropics/claude-code#51222",
+      "url": "https://github.com/anthropics/claude-code/issues/51222",
+      "title": "[Bug] Weekly usage reset time displayed incorrectly for Pro plan users",
+      "impact": "not_applicable",
+      "categories": [
+        "terminal"
+      ],
+      "tokenkey_status": "not_applicable",
+      "rationale": "Client-side claude-code concern (terminal); not a gateway/relay relevance signal.",
+      "updated_at": "2026-05-31T10:41:31Z"
+    },
+    {
+      "upstream": "anthropics/claude-code#51677",
+      "url": "https://github.com/anthropics/claude-code/issues/51677",
+      "title": "[BUG] Codicon font blocked by webview CSP font-src — diff markers render as tofu on 2.1.116 (extends #26836)",
+      "impact": "not_applicable",
+      "categories": [
+        "ide",
+        "terminal",
+        "install",
+        "platform"
+      ],
+      "tokenkey_status": "not_applicable",
+      "rationale": "Client-side claude-code concern (ide, terminal, install, platform); not a gateway/relay relevance signal.",
+      "updated_at": "2026-06-02T22:44:03Z"
+    },
+    {
+      "upstream": "anthropics/claude-code#51815",
+      "url": "https://github.com/anthropics/claude-code/issues/51815",
+      "title": "[BUG] Claude Code for VS Code 2.1.117: Read/Edit tools fail on Windows when username contains \\uXXXX sequence",
+      "impact": "not_applicable",
+      "categories": [
+        "ide",
+        "terminal",
+        "platform"
+      ],
+      "tokenkey_status": "not_applicable",
+      "rationale": "Client-side claude-code concern (ide, terminal, platform); not a gateway/relay relevance signal.",
+      "updated_at": "2026-06-02T09:03:00Z"
+    },
+    {
+      "upstream": "anthropics/claude-code#51910",
+      "url": "https://github.com/anthropics/claude-code/issues/51910",
+      "title": "[BUG] Native Windows binary fails on every prompt and command",
+      "impact": "not_applicable",
+      "categories": [
+        "install",
+        "platform"
+      ],
+      "tokenkey_status": "not_applicable",
+      "rationale": "Client-side claude-code concern (install, platform); not a gateway/relay relevance signal.",
+      "updated_at": "2026-06-03T06:06:11Z"
+    },
+    {
+      "upstream": "anthropics/claude-code#51976",
+      "url": "https://github.com/anthropics/claude-code/issues/51976",
+      "title": "[BUG] npm install broken on non-AVX Linux x64 CPUs since v2.1.113 — Node.js (cli.js) fallback removed",
+      "impact": "not_applicable",
+      "categories": [
+        "terminal",
+        "install"
+      ],
+      "tokenkey_status": "not_applicable",
+      "rationale": "Client-side claude-code concern (terminal, install); not a gateway/relay relevance signal.",
+      "updated_at": "2026-05-31T10:41:55Z"
+    },
+    {
+      "upstream": "anthropics/claude-code#52075",
+      "url": "https://github.com/anthropics/claude-code/issues/52075",
+      "title": "[BUG] Permissions prompt despite bypass",
+      "impact": "not_applicable",
+      "categories": [
+        "terminal"
+      ],
+      "tokenkey_status": "not_applicable",
+      "rationale": "Client-side claude-code concern (terminal); not a gateway/relay relevance signal.",
+      "updated_at": "2026-06-01T12:03:12Z"
+    },
+    {
+      "upstream": "anthropics/claude-code#52099",
+      "url": "https://github.com/anthropics/claude-code/issues/52099",
+      "title": "[BUG] --teleport only checks the origin remote, fails when the GitHub remote has a different name",
+      "impact": "not_applicable",
+      "categories": [
+        "terminal",
+        "platform"
+      ],
+      "tokenkey_status": "not_applicable",
+      "rationale": "Client-side claude-code concern (terminal, platform); not a gateway/relay relevance signal.",
+      "updated_at": "2026-06-02T11:32:40Z"
+    },
+    {
+      "upstream": "anthropics/claude-code#52103",
+      "url": "https://github.com/anthropics/claude-code/issues/52103",
+      "title": "[BUG] Cygwin: CWD temp file path missing /cygdrive prefix",
+      "impact": "not_applicable",
+      "categories": [
+        "terminal",
+        "platform"
+      ],
+      "tokenkey_status": "not_applicable",
+      "rationale": "Client-side claude-code concern (terminal, platform); not a gateway/relay relevance signal.",
+      "updated_at": "2026-06-02T11:32:46Z"
+    },
+    {
+      "upstream": "anthropics/claude-code#52112",
+      "url": "https://github.com/anthropics/claude-code/issues/52112",
+      "title": "[BUG] Cowork SSL certificate expired error on Windows 11 Enterprise — API calls fail before VM rootfs download completes in v1.3561.0",
+      "impact": "not_applicable",
+      "categories": [
+        "terminal",
+        "install",
+        "platform"
+      ],
+      "tokenkey_status": "not_applicable",
+      "rationale": "Client-side claude-code concern (terminal, install, platform); not a gateway/relay relevance signal.",
+      "updated_at": "2026-06-02T22:44:20Z"
+    },
+    {
+      "upstream": "anthropics/claude-code#52153",
+      "url": "https://github.com/anthropics/claude-code/issues/52153",
+      "title": "[Bug] Excessive token consumption per prompt with Opus 4.7 1M context model",
+      "impact": "not_applicable",
+      "categories": [
+        "mcp",
+        "platform"
+      ],
+      "tokenkey_status": "not_applicable",
+      "rationale": "Client-side claude-code concern (mcp, platform); not a gateway/relay relevance signal.",
+      "updated_at": "2026-05-31T18:30:59Z"
+    },
+    {
+      "upstream": "anthropics/claude-code#52166",
+      "url": "https://github.com/anthropics/claude-code/issues/52166",
+      "title": "CLI pauses execution when terminal/composer loses focus",
+      "impact": "not_applicable",
+      "categories": [
+        "terminal"
+      ],
+      "tokenkey_status": "not_applicable",
+      "rationale": "Client-side claude-code concern (terminal); not a gateway/relay relevance signal.",
+      "updated_at": "2026-06-02T11:32:41Z"
+    },
+    {
+      "upstream": "anthropics/claude-code#52252",
+      "url": "https://github.com/anthropics/claude-code/issues/52252",
+      "title": "[BUG] Cowork sandbox disk at 100% capacity — base image too large for allocated disk",
+      "impact": "not_applicable",
+      "categories": [
+        "terminal",
+        "platform"
+      ],
+      "tokenkey_status": "not_applicable",
+      "rationale": "Client-side claude-code concern (terminal, platform); not a gateway/relay relevance signal.",
+      "updated_at": "2026-06-02T19:33:17Z"
+    },
+    {
+      "upstream": "anthropics/claude-code#52390",
+      "url": "https://github.com/anthropics/claude-code/issues/52390",
+      "title": "[BUG] CLAUDE_AUTOCOMPACT_PCT_OVERRIDE=50 does not trigger autocompact — context reaches 100% requiring manual /compact",
+      "impact": "not_applicable",
+      "categories": [
+        "plugin",
+        "slash_hook"
+      ],
+      "tokenkey_status": "not_applicable",
+      "rationale": "Client-side claude-code concern (plugin, slash_hook); not a gateway/relay relevance signal.",
+      "updated_at": "2026-05-31T13:43:03Z"
+    },
+    {
+      "upstream": "anthropics/claude-code#52472",
+      "url": "https://github.com/anthropics/claude-code/issues/52472",
+      "title": "[Bug] Weekly usage limit reset occurring before scheduled reset time & new week ends in 5 days, not 7 days",
+      "impact": "not_applicable",
+      "categories": [
+        "ide",
+        "terminal",
+        "mcp",
+        "plugin"
+      ],
+      "tokenkey_status": "not_applicable",
+      "rationale": "Client-side claude-code concern (ide, terminal, mcp, plugin); not a gateway/relay relevance signal.",
+      "updated_at": "2026-05-31T10:41:29Z"
+    },
+    {
+      "upstream": "anthropics/claude-code#52509",
+      "url": "https://github.com/anthropics/claude-code/issues/52509",
+      "title": "[BUG] Messages typed during \"Thinking/Deliberating/Manifesting\" state aren't delivered until user hits Escape",
+      "impact": "not_applicable",
+      "categories": [
+        "ide",
+        "terminal",
+        "platform"
+      ],
+      "tokenkey_status": "not_applicable",
+      "rationale": "Client-side claude-code concern (ide, terminal, platform); not a gateway/relay relevance signal.",
+      "updated_at": "2026-06-01T22:46:14Z"
+    },
+    {
+      "upstream": "anthropics/claude-code#52518",
+      "url": "https://github.com/anthropics/claude-code/issues/52518",
+      "title": "[FEATURE] Richer TUI — sidebar with context/token usage, cleaner message layout",
+      "impact": "not_applicable",
+      "categories": [
+        "terminal"
+      ],
+      "tokenkey_status": "not_applicable",
+      "rationale": "Client-side claude-code concern (terminal); not a gateway/relay relevance signal.",
+      "updated_at": "2026-06-02T14:54:15Z"
+    },
+    {
+      "upstream": "anthropics/claude-code#52625",
+      "url": "https://github.com/anthropics/claude-code/issues/52625",
+      "title": "[BUG] Claude code disabled by org administration on personal account",
+      "impact": "not_applicable",
+      "categories": [
+        "terminal"
+      ],
+      "tokenkey_status": "not_applicable",
+      "rationale": "Client-side claude-code concern (terminal); not a gateway/relay relevance signal.",
+      "updated_at": "2026-06-01T22:45:45Z"
+    },
+    {
+      "upstream": "anthropics/claude-code#52691",
+      "url": "https://github.com/anthropics/claude-code/issues/52691",
+      "title": "[Bug] Anthropic API Error: Usage Policy false positive issue blocking operations",
+      "impact": "not_applicable",
+      "categories": [
+        "terminal",
+        "platform"
+      ],
+      "tokenkey_status": "not_applicable",
+      "rationale": "Client-side claude-code concern (terminal, platform); not a gateway/relay relevance signal.",
+      "updated_at": "2026-06-01T06:32:27Z"
+    },
+    {
+      "upstream": "anthropics/claude-code#52724",
+      "url": "https://github.com/anthropics/claude-code/issues/52724",
+      "title": "[Bug] Config save not triggered on Enter key press",
+      "impact": "not_applicable",
+      "categories": [
+        "terminal"
+      ],
+      "tokenkey_status": "not_applicable",
+      "rationale": "Client-side claude-code concern (terminal); not a gateway/relay relevance signal.",
+      "updated_at": "2026-06-01T08:05:07Z"
+    },
+    {
+      "upstream": "anthropics/claude-code#52793",
+      "url": "https://github.com/anthropics/claude-code/issues/52793",
+      "title": "Feature request: Per-project account switching for claude.ai subscription users",
+      "impact": "not_applicable",
+      "categories": [
+        "slash_hook"
+      ],
+      "tokenkey_status": "not_applicable",
+      "rationale": "Client-side claude-code concern (slash_hook); not a gateway/relay relevance signal.",
+      "updated_at": "2026-06-02T11:31:59Z"
+    },
+    {
+      "upstream": "anthropics/claude-code#52924",
+      "url": "https://github.com/anthropics/claude-code/issues/52924",
+      "title": "TUI duplicates rendered text in scrollback on long sessions (Windows + Linux)",
+      "impact": "not_applicable",
+      "categories": [
+        "terminal",
+        "platform"
+      ],
+      "tokenkey_status": "not_applicable",
+      "rationale": "Client-side claude-code concern (terminal, platform); not a gateway/relay relevance signal.",
+      "updated_at": "2026-06-01T14:46:16Z"
+    },
+    {
+      "upstream": "anthropics/claude-code#52926",
+      "url": "https://github.com/anthropics/claude-code/issues/52926",
+      "title": "PowerShell(*) wildcard has silent carve-out for subexpressions -- bypasses allowlist, prompts anyway -- v2.1.119",
+      "impact": "not_applicable",
+      "categories": [
+        "platform"
+      ],
+      "tokenkey_status": "not_applicable",
+      "rationale": "Client-side claude-code concern (platform); not a gateway/relay relevance signal.",
+      "updated_at": "2026-06-02T08:59:25Z"
+    },
+    {
+      "upstream": "anthropics/claude-code#52944",
+      "url": "https://github.com/anthropics/claude-code/issues/52944",
+      "title": "Feature Request: Add timestamp to CLI input prompt",
+      "impact": "not_applicable",
+      "categories": [
+        "slash_hook"
+      ],
+      "tokenkey_status": "not_applicable",
+      "rationale": "Client-side claude-code concern (slash_hook); not a gateway/relay relevance signal.",
+      "updated_at": "2026-06-02T15:01:28Z"
+    },
+    {
+      "upstream": "anthropics/claude-code#53096",
+      "url": "https://github.com/anthropics/claude-code/issues/53096",
+      "title": "[BUG] Team Org Account rejected -> resulting in account banned for suspicious signals.",
+      "impact": "not_applicable",
+      "categories": [
+        "terminal"
+      ],
+      "tokenkey_status": "not_applicable",
+      "rationale": "Client-side claude-code concern (terminal); not a gateway/relay relevance signal.",
+      "updated_at": "2026-06-01T12:03:17Z"
+    },
+    {
+      "upstream": "anthropics/claude-code#53134",
+      "url": "https://github.com/anthropics/claude-code/issues/53134",
+      "title": "[BUG] Windows: MCP servers spawned twice at startup (directMcpHost + LocalMcpServerManager)",
+      "impact": "not_applicable",
+      "categories": [
+        "ide",
+        "mcp",
+        "plugin",
+        "install",
+        "platform"
+      ],
+      "tokenkey_status": "not_applicable",
+      "rationale": "Client-side claude-code concern (ide, mcp, plugin, install, platform); not a gateway/relay relevance signal.",
+      "updated_at": "2026-06-03T04:08:55Z"
+    },
+    {
+      "upstream": "anthropics/claude-code#53246",
+      "url": "https://github.com/anthropics/claude-code/issues/53246",
+      "title": "[BUG] In VSCode extension, is model switching via /model isolated per chat session? Seems like it might not be.",
+      "impact": "not_applicable",
+      "categories": [
+        "ide",
+        "terminal",
+        "platform"
+      ],
+      "tokenkey_status": "not_applicable",
+      "rationale": "Client-side claude-code concern (ide, terminal, platform); not a gateway/relay relevance signal.",
+      "updated_at": "2026-06-01T22:46:10Z"
+    },
+    {
+      "upstream": "anthropics/claude-code#53260",
+      "url": "https://github.com/anthropics/claude-code/issues/53260",
+      "title": "Harness writes synthetic \"No response requested.\" turns when API returns empty content on auto-resume",
+      "impact": "not_applicable",
+      "categories": [
+        "mcp",
+        "plugin",
+        "platform"
+      ],
+      "tokenkey_status": "not_applicable",
+      "rationale": "Client-side claude-code concern (mcp, plugin, platform); not a gateway/relay relevance signal.",
+      "updated_at": "2026-06-02T11:32:13Z"
+    },
+    {
+      "upstream": "anthropics/claude-code#53340",
+      "url": "https://github.com/anthropics/claude-code/issues/53340",
+      "title": "[BUG] Claude Code in Claude Desktop is Missing Project Level Folders",
+      "impact": "not_applicable",
+      "categories": [
+        "terminal",
+        "install",
+        "platform"
+      ],
+      "tokenkey_status": "not_applicable",
+      "rationale": "Client-side claude-code concern (terminal, install, platform); not a gateway/relay relevance signal.",
+      "updated_at": "2026-05-31T10:41:49Z"
+    },
+    {
+      "upstream": "anthropics/claude-code#53346",
+      "url": "https://github.com/anthropics/claude-code/issues/53346",
+      "title": "⎿ API Error: Unable to connect to API...",
+      "impact": "not_applicable",
+      "categories": [
+        "terminal"
+      ],
+      "tokenkey_status": "not_applicable",
+      "rationale": "Client-side claude-code concern (terminal); not a gateway/relay relevance signal.",
+      "updated_at": "2026-06-02T11:45:25Z"
+    },
+    {
+      "upstream": "anthropics/claude-code#53484",
+      "url": "https://github.com/anthropics/claude-code/issues/53484",
+      "title": "Chat search omits Code chats currently open in other windows; no body-text index for Code chats",
+      "impact": "not_applicable",
+      "categories": [
+        "platform"
+      ],
+      "tokenkey_status": "not_applicable",
+      "rationale": "Client-side claude-code concern (platform); not a gateway/relay relevance signal.",
+      "updated_at": "2026-06-02T11:33:15Z"
+    },
+    {
+      "upstream": "anthropics/claude-code#53492",
+      "url": "https://github.com/anthropics/claude-code/issues/53492",
+      "title": "[Bug] Duplicate output in terminal causing content duplication",
+      "impact": "not_applicable",
+      "categories": [
+        "terminal",
+        "mcp",
+        "plugin"
+      ],
+      "tokenkey_status": "not_applicable",
+      "rationale": "Client-side claude-code concern (terminal, mcp, plugin); not a gateway/relay relevance signal.",
+      "updated_at": "2026-05-31T17:16:07Z"
+    },
+    {
+      "upstream": "anthropics/claude-code#53638",
+      "url": "https://github.com/anthropics/claude-code/issues/53638",
+      "title": "Claude Code Desktop silently uses project API keys for billing instead of subscription",
+      "impact": "not_applicable",
+      "categories": [
+        "terminal"
+      ],
+      "tokenkey_status": "not_applicable",
+      "rationale": "Client-side claude-code concern (terminal); not a gateway/relay relevance signal.",
+      "updated_at": "2026-06-02T11:32:17Z"
+    },
+    {
+      "upstream": "anthropics/claude-code#53940",
+      "url": "https://github.com/anthropics/claude-code/issues/53940",
+      "title": "[BUG] Cowork Edit/Write tools silently truncate files via byte-conservation buffer cap (deterministic, fires at all file sizes)",
+      "impact": "not_applicable",
+      "categories": [
+        "terminal",
+        "platform"
+      ],
+      "tokenkey_status": "not_applicable",
+      "rationale": "Client-side claude-code concern (terminal, platform); not a gateway/relay relevance signal.",
+      "updated_at": "2026-06-01T07:20:12Z"
+    },
+    {
+      "upstream": "anthropics/claude-code#54016",
+      "url": "https://github.com/anthropics/claude-code/issues/54016",
+      "title": "macOS TCC permission dialog shows version string \"2.1.119\" instead of \"Claude Code\"",
+      "impact": "not_applicable",
+      "categories": [
+        "install"
+      ],
+      "tokenkey_status": "not_applicable",
+      "rationale": "Client-side claude-code concern (install); not a gateway/relay relevance signal.",
+      "updated_at": "2026-05-31T10:41:35Z"
+    },
+    {
+      "upstream": "anthropics/claude-code#54063",
+      "url": "https://github.com/anthropics/claude-code/issues/54063",
+      "title": "/insights report only analyzes 328/1291 sessions, missing most data",
+      "impact": "not_applicable",
+      "categories": [
+        "terminal",
+        "plugin",
+        "slash_hook"
+      ],
+      "tokenkey_status": "not_applicable",
+      "rationale": "Client-side claude-code concern (terminal, plugin, slash_hook); not a gateway/relay relevance signal.",
+      "updated_at": "2026-06-02T11:31:57Z"
+    },
+    {
+      "upstream": "anthropics/claude-code#54117",
+      "url": "https://github.com/anthropics/claude-code/issues/54117",
+      "title": "[BUG] Claude Code (Opus 4.7) repeatedly fails to comply with global ~/.claude/CLAUDE.md and modular rules in ~/.claude/rules/ despite extensive auto-loaded documentation -- 41 logged violations across 60+ sessions",
+      "impact": "not_applicable",
+      "categories": [
+        "terminal",
+        "slash_hook"
+      ],
+      "tokenkey_status": "not_applicable",
+      "rationale": "Client-side claude-code concern (terminal, slash_hook); not a gateway/relay relevance signal.",
+      "updated_at": "2026-06-01T22:46:01Z"
+    },
+    {
+      "upstream": "anthropics/claude-code#54138",
+      "url": "https://github.com/anthropics/claude-code/issues/54138",
+      "title": "Cowork: artifacts folder hardcoded to Documents path, ignores selected project folder",
+      "impact": "not_applicable",
+      "categories": [
+        "terminal"
+      ],
+      "tokenkey_status": "not_applicable",
+      "rationale": "Client-side claude-code concern (terminal); not a gateway/relay relevance signal.",
+      "updated_at": "2026-06-01T18:55:14Z"
+    },
+    {
+      "upstream": "anthropics/claude-code#54254",
+      "url": "https://github.com/anthropics/claude-code/issues/54254",
+      "title": "[FEATURE] /handover — user-curated session hand-off with fresh context",
+      "impact": "not_applicable",
+      "categories": [
+        "slash_hook"
+      ],
+      "tokenkey_status": "not_applicable",
+      "rationale": "Client-side claude-code concern (slash_hook); not a gateway/relay relevance signal.",
+      "updated_at": "2026-06-01T10:13:55Z"
+    },
+    {
+      "upstream": "anthropics/claude-code#54332",
+      "url": "https://github.com/anthropics/claude-code/issues/54332",
+      "title": "Feature request: claude.ai Slack MCP — expose conversations.open to support group DMs",
+      "impact": "not_applicable",
+      "categories": [
+        "mcp"
+      ],
+      "tokenkey_status": "not_applicable",
+      "rationale": "Client-side claude-code concern (mcp); not a gateway/relay relevance signal.",
+      "updated_at": "2026-05-31T10:41:27Z"
+    },
+    {
+      "upstream": "anthropics/claude-code#54370",
+      "url": "https://github.com/anthropics/claude-code/issues/54370",
+      "title": "Schedule skill / RemoteTrigger API doesn't see MCP connectors connected on Team workspace",
+      "impact": "not_applicable",
+      "categories": [
+        "mcp",
+        "platform"
+      ],
+      "tokenkey_status": "not_applicable",
+      "rationale": "Client-side claude-code concern (mcp, platform); not a gateway/relay relevance signal.",
+      "updated_at": "2026-06-01T08:03:37Z"
+    },
+    {
+      "upstream": "anthropics/claude-code#54392",
+      "url": "https://github.com/anthropics/claude-code/issues/54392",
+      "title": "[Bug] Session CPU usage spikes to 100% repeatedly",
+      "impact": "not_applicable",
+      "categories": [
+        "terminal"
+      ],
+      "tokenkey_status": "not_applicable",
+      "rationale": "Client-side claude-code concern (terminal); not a gateway/relay relevance signal.",
+      "updated_at": "2026-06-01T12:02:22Z"
+    },
+    {
+      "upstream": "anthropics/claude-code#54394",
+      "url": "https://github.com/anthropics/claude-code/issues/54394",
+      "title": "[BUG] v2.1.117 embedded ugrep wrapper amplifies regex backtracking from grep-process-OOM into V8-heap-OOM (8 GB ceiling) — host freezes on WSL2",
+      "impact": "not_applicable",
+      "categories": [
+        "slash_hook"
+      ],
+      "tokenkey_status": "not_applicable",
+      "rationale": "Client-side claude-code concern (slash_hook); not a gateway/relay relevance signal.",
+      "updated_at": "2026-05-31T13:20:31Z"
+    },
+    {
+      "upstream": "anthropics/claude-code#54440",
+      "url": "https://github.com/anthropics/claude-code/issues/54440",
+      "title": "[FEATURE] Localize auto-generated session titles in \"Recents\" sidebar",
+      "impact": "not_applicable",
+      "categories": [
+        "slash_hook",
+        "platform"
+      ],
+      "tokenkey_status": "not_applicable",
+      "rationale": "Client-side claude-code concern (slash_hook, platform); not a gateway/relay relevance signal.",
+      "updated_at": "2026-06-02T05:31:32Z"
+    },
+    {
+      "upstream": "anthropics/claude-code#54461",
+      "url": "https://github.com/anthropics/claude-code/issues/54461",
+      "title": "Desktop app: cannot change primary working directory or open new chat",
+      "impact": "not_applicable",
+      "categories": [
+        "terminal",
+        "platform"
+      ],
+      "tokenkey_status": "not_applicable",
+      "rationale": "Client-side claude-code concern (terminal, platform); not a gateway/relay relevance signal.",
+      "updated_at": "2026-06-01T21:42:28Z"
+    },
+    {
+      "upstream": "anthropics/claude-code#54580",
+      "url": "https://github.com/anthropics/claude-code/issues/54580",
+      "title": "Feature request: Expose context usage to hooks for autonomous session handoff",
+      "impact": "not_applicable",
+      "categories": [
+        "ide",
+        "slash_hook"
+      ],
+      "tokenkey_status": "not_applicable",
+      "rationale": "Client-side claude-code concern (ide, slash_hook); not a gateway/relay relevance signal.",
+      "updated_at": "2026-06-02T22:44:51Z"
+    },
+    {
+      "upstream": "anthropics/claude-code#54587",
+      "url": "https://github.com/anthropics/claude-code/issues/54587",
+      "title": "[BUG] System prompt rule 'Never write multi-paragraph docstrings... one short line max' breaks language-idiomatic API documentation",
+      "impact": "not_applicable",
+      "categories": [
+        "terminal"
+      ],
+      "tokenkey_status": "not_applicable",
+      "rationale": "Client-side claude-code concern (terminal); not a gateway/relay relevance signal.",
+      "updated_at": "2026-06-02T22:09:29Z"
+    },
+    {
+      "upstream": "anthropics/claude-code#54647",
+      "url": "https://github.com/anthropics/claude-code/issues/54647",
+      "title": "[BUG] disableAutoUpdates should not lock the entire third-party inference UI",
+      "impact": "not_applicable",
+      "categories": [
+        "terminal",
+        "install"
+      ],
+      "tokenkey_status": "not_applicable",
+      "rationale": "Client-side claude-code concern (terminal, install); not a gateway/relay relevance signal.",
+      "updated_at": "2026-06-01T11:22:40Z"
+    },
+    {
+      "upstream": "anthropics/claude-code#54670",
+      "url": "https://github.com/anthropics/claude-code/issues/54670",
+      "title": "[FEATURE] VSCode extension: Copy chat response as markdown source",
+      "impact": "not_applicable",
+      "categories": [
+        "ide",
+        "terminal",
+        "slash_hook",
+        "platform"
+      ],
+      "tokenkey_status": "not_applicable",
+      "rationale": "Client-side claude-code concern (ide, terminal, slash_hook, platform); not a gateway/relay relevance signal.",
+      "updated_at": "2026-06-01T12:44:39Z"
+    },
+    {
+      "upstream": "anthropics/claude-code#54813",
+      "url": "https://github.com/anthropics/claude-code/issues/54813",
+      "title": "[Bug] Auto Mode Classifier Incorrectly Denies Git Push Command",
+      "impact": "not_applicable",
+      "categories": [
+        "terminal",
+        "mcp"
+      ],
+      "tokenkey_status": "not_applicable",
+      "rationale": "Client-side claude-code concern (terminal, mcp); not a gateway/relay relevance signal.",
+      "updated_at": "2026-06-01T22:45:37Z"
+    },
+    {
+      "upstream": "anthropics/claude-code#54856",
+      "url": "https://github.com/anthropics/claude-code/issues/54856",
+      "title": "Path-pattern scanner false-positives on macOS usernames containing `.`, and \"always allow\" option fails to persist a rule (Bash and Write only; Edit unaffected)",
+      "impact": "not_applicable",
+      "categories": [
+        "install",
+        "platform"
+      ],
+      "tokenkey_status": "not_applicable",
+      "rationale": "Client-side claude-code concern (install, platform); not a gateway/relay relevance signal.",
+      "updated_at": "2026-06-02T22:44:30Z"
+    },
+    {
+      "upstream": "anthropics/claude-code#54859",
+      "url": "https://github.com/anthropics/claude-code/issues/54859",
+      "title": "[FEATURE] Cowork: allow configuring the storage location for scheduled tasks (currently hardcoded to ~/Documents/Claude/Scheduled/)",
+      "impact": "not_applicable",
+      "categories": [
+        "mcp",
+        "platform"
+      ],
+      "tokenkey_status": "not_applicable",
+      "rationale": "Client-side claude-code concern (mcp, platform); not a gateway/relay relevance signal.",
+      "updated_at": "2026-06-02T06:47:27Z"
+    },
+    {
+      "upstream": "anthropics/claude-code#54879",
+      "url": "https://github.com/anthropics/claude-code/issues/54879",
+      "title": "[Bug] Auto-mode yields to user after Agent tool returns instead of continuing pipeline",
+      "impact": "not_applicable",
+      "categories": [
+        "terminal",
+        "plugin"
+      ],
+      "tokenkey_status": "not_applicable",
+      "rationale": "Client-side claude-code concern (terminal, plugin); not a gateway/relay relevance signal.",
+      "updated_at": "2026-06-01T12:03:33Z"
+    },
+    {
+      "upstream": "anthropics/claude-code#55023",
+      "url": "https://github.com/anthropics/claude-code/issues/55023",
+      "title": "[BUG] Session recap never auto-fires in Claude for Windows desktop GUI",
+      "impact": "not_applicable",
+      "categories": [
+        "terminal",
+        "slash_hook",
+        "install",
+        "platform"
+      ],
+      "tokenkey_status": "not_applicable",
+      "rationale": "Client-side claude-code concern (terminal, slash_hook, install, platform); not a gateway/relay relevance signal.",
+      "updated_at": "2026-06-02T11:33:16Z"
+    },
+    {
+      "upstream": "anthropics/claude-code#55065",
+      "url": "https://github.com/anthropics/claude-code/issues/55065",
+      "title": "CLAUDE_CONFIG_DIR semantics inconsistent: settings.json under .claude/ but skills at root",
+      "impact": "not_applicable",
+      "categories": [
+        "slash_hook"
+      ],
+      "tokenkey_status": "not_applicable",
+      "rationale": "Client-side claude-code concern (slash_hook); not a gateway/relay relevance signal.",
+      "updated_at": "2026-05-31T10:41:44Z"
+    },
+    {
+      "upstream": "anthropics/claude-code#55107",
+      "url": "https://github.com/anthropics/claude-code/issues/55107",
+      "title": "[BUG] Failed to resume session: EINVAL: invalid argument, stat 'C:\\Users\\username",
+      "impact": "not_applicable",
+      "categories": [
+        "terminal",
+        "platform"
+      ],
+      "tokenkey_status": "not_applicable",
+      "rationale": "Client-side claude-code concern (terminal, platform); not a gateway/relay relevance signal.",
+      "updated_at": "2026-06-01T14:22:23Z"
+    },
+    {
+      "upstream": "anthropics/claude-code#55109",
+      "url": "https://github.com/anthropics/claude-code/issues/55109",
+      "title": "CronCreate: `durable: true` accepted but not persisted to disk",
+      "impact": "not_applicable",
+      "categories": [
+        "platform"
+      ],
+      "tokenkey_status": "not_applicable",
+      "rationale": "Client-side claude-code concern (platform); not a gateway/relay relevance signal.",
+      "updated_at": "2026-05-31T10:41:31Z"
+    },
+    {
+      "upstream": "anthropics/claude-code#5512",
+      "url": "https://github.com/anthropics/claude-code/issues/5512",
+      "title": "Feature Request: Add /copy command to copy messages to clipboard",
+      "impact": "not_applicable",
+      "categories": [
+        "slash_hook",
+        "platform"
+      ],
+      "tokenkey_status": "not_applicable",
+      "rationale": "Client-side claude-code concern (slash_hook, platform); not a gateway/relay relevance signal.",
+      "updated_at": "2026-06-01T09:35:28Z"
+    },
+    {
+      "upstream": "anthropics/claude-code#55254",
+      "url": "https://github.com/anthropics/claude-code/issues/55254",
+      "title": "[BUG] Something went wrong Try sending your message again. If it keeps happening, share feedback so we can investigate. The session stopped responding. Send your message again to resume with a fresh process.",
+      "impact": "not_applicable",
+      "categories": [
+        "terminal",
+        "platform"
+      ],
+      "tokenkey_status": "not_applicable",
+      "rationale": "Client-side claude-code concern (terminal, platform); not a gateway/relay relevance signal.",
+      "updated_at": "2026-05-31T15:57:46Z"
+    },
+    {
+      "upstream": "anthropics/claude-code#55457",
+      "url": "https://github.com/anthropics/claude-code/issues/55457",
+      "title": "[DOCS] Misleading messages in the Claude Code tab of Windows 11 Claude app",
+      "impact": "not_applicable",
+      "categories": [
+        "platform"
+      ],
+      "tokenkey_status": "not_applicable",
+      "rationale": "Client-side claude-code concern (platform); not a gateway/relay relevance signal.",
+      "updated_at": "2026-06-02T11:32:07Z"
+    },
+    {
+      "upstream": "anthropics/claude-code#55500",
+      "url": "https://github.com/anthropics/claude-code/issues/55500",
+      "title": "[BUG] Branch selector missing in iOS Code UI",
+      "impact": "not_applicable",
+      "categories": [
+        "terminal"
+      ],
+      "tokenkey_status": "not_applicable",
+      "rationale": "Client-side claude-code concern (terminal); not a gateway/relay relevance signal.",
+      "updated_at": "2026-06-02T13:19:40Z"
+    },
+    {
+      "upstream": "anthropics/claude-code#55580",
+      "url": "https://github.com/anthropics/claude-code/issues/55580",
+      "title": "[FEATURE] User-controlled allowlist override for server-side domain blocks (Claude in Chrome)",
+      "impact": "not_applicable",
+      "categories": [
+        "ide",
+        "platform"
+      ],
+      "tokenkey_status": "not_applicable",
+      "rationale": "Client-side claude-code concern (ide, platform); not a gateway/relay relevance signal.",
+      "updated_at": "2026-06-01T07:31:39Z"
+    },
+    {
+      "upstream": "anthropics/claude-code#55586",
+      "url": "https://github.com/anthropics/claude-code/issues/55586",
+      "title": "[BUG] Agent Teams: Single teammate spawn creates 10-151 duplicate worker instances, each consuming full context and actively editing files",
+      "impact": "not_applicable",
+      "categories": [
+        "terminal",
+        "plugin",
+        "slash_hook",
+        "platform"
+      ],
+      "tokenkey_status": "not_applicable",
+      "rationale": "Client-side claude-code concern (terminal, plugin, slash_hook, platform); not a gateway/relay relevance signal.",
+      "updated_at": "2026-06-02T22:03:56Z"
+    },
+    {
+      "upstream": "anthropics/claude-code#55653",
+      "url": "https://github.com/anthropics/claude-code/issues/55653",
+      "title": "Read-only subagents claim to save files via 'Document saved to <path>' without a Write tool",
+      "impact": "not_applicable",
+      "categories": [
+        "plugin"
+      ],
+      "tokenkey_status": "not_applicable",
+      "rationale": "Client-side claude-code concern (plugin); not a gateway/relay relevance signal.",
+      "updated_at": "2026-06-02T22:44:33Z"
+    },
+    {
+      "upstream": "anthropics/claude-code#55671",
+      "url": "https://github.com/anthropics/claude-code/issues/55671",
+      "title": "Windows: PowerShell permission classifier fails 'command line too long' when additionalDirectories list is large",
+      "impact": "not_applicable",
+      "categories": [
+        "ide",
+        "slash_hook",
+        "install",
+        "platform"
+      ],
+      "tokenkey_status": "not_applicable",
+      "rationale": "Client-side claude-code concern (ide, slash_hook, install, platform); not a gateway/relay relevance signal.",
+      "updated_at": "2026-06-02T22:44:38Z"
+    },
+    {
+      "upstream": "anthropics/claude-code#55712",
+      "url": "https://github.com/anthropics/claude-code/issues/55712",
+      "title": "[BUG] Cowork mode: sub-agent spawning completely broken — \"Prompt is too long\" at 0 tokens for all models",
+      "impact": "not_applicable",
+      "categories": [
+        "terminal"
+      ],
+      "tokenkey_status": "not_applicable",
+      "rationale": "Client-side claude-code concern (terminal); not a gateway/relay relevance signal.",
+      "updated_at": "2026-06-02T22:44:32Z"
+    },
+    {
+      "upstream": "anthropics/claude-code#55725",
+      "url": "https://github.com/anthropics/claude-code/issues/55725",
+      "title": "[DOCS] Add a warning against using \"npm update -g\" to upgrade Claude Code",
+      "impact": "not_applicable",
+      "categories": [
+        "terminal",
+        "install"
+      ],
+      "tokenkey_status": "not_applicable",
+      "rationale": "Client-side claude-code concern (terminal, install); not a gateway/relay relevance signal.",
+      "updated_at": "2026-06-02T11:32:44Z"
+    },
+    {
+      "upstream": "anthropics/claude-code#55772",
+      "url": "https://github.com/anthropics/claude-code/issues/55772",
+      "title": "[FEATURE] VSCode extension: Quote affordance on assistant messages (parity with Claude.ai web and Claude Code on Windows)",
+      "impact": "not_applicable",
+      "categories": [
+        "ide",
+        "terminal",
+        "plugin",
+        "platform"
+      ],
+      "tokenkey_status": "not_applicable",
+      "rationale": "Client-side claude-code concern (ide, terminal, plugin, platform); not a gateway/relay relevance signal.",
+      "updated_at": "2026-06-02T11:33:14Z"
+    },
+    {
+      "upstream": "anthropics/claude-code#55841",
+      "url": "https://github.com/anthropics/claude-code/issues/55841",
+      "title": "[BUG] plugin:telegram@claude-plugins-official reports connected but does not poll Bot API in claude 2.1.126",
+      "impact": "not_applicable",
+      "categories": [
+        "terminal",
+        "mcp",
+        "plugin",
+        "install"
+      ],
+      "tokenkey_status": "not_applicable",
+      "rationale": "Client-side claude-code concern (terminal, mcp, plugin, install); not a gateway/relay relevance signal.",
+      "updated_at": "2026-06-02T00:34:55Z"
+    },
+    {
+      "upstream": "anthropics/claude-code#55854",
+      "url": "https://github.com/anthropics/claude-code/issues/55854",
+      "title": "[FEATURE] Permission prompts: never use a number for \"No\"; treat stray digits as \"Yes\" fallback",
+      "impact": "not_applicable",
+      "categories": [
+        "terminal"
+      ],
+      "tokenkey_status": "not_applicable",
+      "rationale": "Client-side claude-code concern (terminal); not a gateway/relay relevance signal.",
+      "updated_at": "2026-06-01T05:35:59Z"
+    },
+    {
+      "upstream": "anthropics/claude-code#55863",
+      "url": "https://github.com/anthropics/claude-code/issues/55863",
+      "title": "[BUG] Session recap (post_turn_summary) never renders in VSCode extension, only in CLI",
+      "impact": "not_applicable",
+      "categories": [
+        "ide",
+        "terminal",
+        "install",
+        "platform"
+      ],
+      "tokenkey_status": "not_applicable",
+      "rationale": "Client-side claude-code concern (ide, terminal, install, platform); not a gateway/relay relevance signal.",
+      "updated_at": "2026-06-02T11:33:13Z"
+    },
+    {
+      "upstream": "anthropics/claude-code#55893",
+      "url": "https://github.com/anthropics/claude-code/issues/55893",
+      "title": "Background bash tasks (run_in_background polling loops) get stuck post-completion and across sessions; TaskStop can't reach prior-session IDs",
+      "impact": "not_applicable",
+      "categories": [
+        "terminal",
+        "install",
+        "platform"
+      ],
+      "tokenkey_status": "not_applicable",
+      "rationale": "Client-side claude-code concern (terminal, install, platform); not a gateway/relay relevance signal.",
+      "updated_at": "2026-05-31T10:41:46Z"
+    },
+    {
+      "upstream": "anthropics/claude-code#55915",
+      "url": "https://github.com/anthropics/claude-code/issues/55915",
+      "title": "Add option to configure week start day (Monday) for welcome page heatmap",
+      "impact": "not_applicable",
+      "categories": [
+        "slash_hook"
+      ],
+      "tokenkey_status": "not_applicable",
+      "rationale": "Client-side claude-code concern (slash_hook); not a gateway/relay relevance signal.",
+      "updated_at": "2026-06-01T05:35:46Z"
+    },
+    {
+      "upstream": "anthropics/claude-code#55945",
+      "url": "https://github.com/anthropics/claude-code/issues/55945",
+      "title": "[FEATURE] Hook which fires when you run out of tokens; expose time when they will be available again",
+      "impact": "not_applicable",
+      "categories": [
+        "slash_hook"
+      ],
+      "tokenkey_status": "not_applicable",
+      "rationale": "Client-side claude-code concern (slash_hook); not a gateway/relay relevance signal.",
+      "updated_at": "2026-06-01T05:36:22Z"
+    },
+    {
+      "upstream": "anthropics/claude-code#56017",
+      "url": "https://github.com/anthropics/claude-code/issues/56017",
+      "title": "[BUG] ECONNRESET errors in session",
+      "impact": "not_applicable",
+      "categories": [
+        "terminal"
+      ],
+      "tokenkey_status": "not_applicable",
+      "rationale": "Client-side claude-code concern (terminal); not a gateway/relay relevance signal.",
+      "updated_at": "2026-06-03T05:35:37Z"
+    },
+    {
+      "upstream": "anthropics/claude-code#56144",
+      "url": "https://github.com/anthropics/claude-code/issues/56144",
+      "title": "Unexpected message injection — text from WhatsApp appeared in Claude Code session",
+      "impact": "not_applicable",
+      "categories": [
+        "terminal",
+        "platform"
+      ],
+      "tokenkey_status": "not_applicable",
+      "rationale": "Client-side claude-code concern (terminal, platform); not a gateway/relay relevance signal.",
+      "updated_at": "2026-06-02T08:17:40Z"
+    },
+    {
+      "upstream": "anthropics/claude-code#56268",
+      "url": "https://github.com/anthropics/claude-code/issues/56268",
+      "title": "claude -p silent-freeze when spawned from a long-running orchestrator (no stdout, deterministic 100% from direct spawn, probabilistic with bash wrap)",
+      "impact": "not_applicable",
+      "categories": [
+        "mcp",
+        "slash_hook"
+      ],
+      "tokenkey_status": "not_applicable",
+      "rationale": "Client-side claude-code concern (mcp, slash_hook); not a gateway/relay relevance signal.",
+      "updated_at": "2026-06-01T22:45:43Z"
+    },
+    {
+      "upstream": "anthropics/claude-code#56300",
+      "url": "https://github.com/anthropics/claude-code/issues/56300",
+      "title": "[BUG] Claude start session with 100% usage!",
+      "impact": "not_applicable",
+      "categories": [
+        "terminal",
+        "platform"
+      ],
+      "tokenkey_status": "not_applicable",
+      "rationale": "Client-side claude-code concern (terminal, platform); not a gateway/relay relevance signal.",
+      "updated_at": "2026-06-01T12:02:10Z"
+    },
+    {
+      "upstream": "anthropics/claude-code#56335",
+      "url": "https://github.com/anthropics/claude-code/issues/56335",
+      "title": "[BUG] claude process leaks to 74 GB virtual memory, causing full system OOM freeze",
+      "impact": "not_applicable",
+      "categories": [
+        "terminal",
+        "mcp",
+        "plugin",
+        "slash_hook",
+        "install"
+      ],
+      "tokenkey_status": "not_applicable",
+      "rationale": "Client-side claude-code concern (terminal, mcp, plugin, slash_hook, install); not a gateway/relay relevance signal.",
+      "updated_at": "2026-06-01T15:03:46Z"
+    },
+    {
+      "upstream": "anthropics/claude-code#56618",
+      "url": "https://github.com/anthropics/claude-code/issues/56618",
+      "title": "[FEATURE] Add setting to right-align user messages in chat UI",
+      "impact": "not_applicable",
+      "categories": [
+        "ide",
+        "terminal"
+      ],
+      "tokenkey_status": "not_applicable",
+      "rationale": "Client-side claude-code concern (ide, terminal); not a gateway/relay relevance signal.",
+      "updated_at": "2026-06-01T20:59:49Z"
+    },
+    {
+      "upstream": "anthropics/claude-code#56637",
+      "url": "https://github.com/anthropics/claude-code/issues/56637",
+      "title": "[BUG] /usage no longer renders visual horizontal bar graphs in TUI",
+      "impact": "not_applicable",
+      "categories": [
+        "terminal"
+      ],
+      "tokenkey_status": "not_applicable",
+      "rationale": "Client-side claude-code concern (terminal); not a gateway/relay relevance signal.",
+      "updated_at": "2026-06-02T09:54:32Z"
+    },
+    {
+      "upstream": "anthropics/claude-code#56778",
+      "url": "https://github.com/anthropics/claude-code/issues/56778",
+      "title": "[FEATURE] VS Code extension should honor remoteControlAtStartup (or expose claudeCode.remoteControlAtStartup)",
+      "impact": "not_applicable",
+      "categories": [
+        "ide",
+        "terminal",
+        "plugin",
+        "slash_hook"
+      ],
+      "tokenkey_status": "not_applicable",
+      "rationale": "Client-side claude-code concern (ide, terminal, plugin, slash_hook); not a gateway/relay relevance signal.",
+      "updated_at": "2026-06-02T11:31:50Z"
+    },
+    {
+      "upstream": "anthropics/claude-code#56855",
+      "url": "https://github.com/anthropics/claude-code/issues/56855",
+      "title": "Feature request: temporal awareness toggle (timestamps on actions and prompts)",
+      "impact": "not_applicable",
+      "categories": [
+        "slash_hook"
+      ],
+      "tokenkey_status": "not_applicable",
+      "rationale": "Client-side claude-code concern (slash_hook); not a gateway/relay relevance signal.",
+      "updated_at": "2026-06-02T15:02:20Z"
+    },
+    {
+      "upstream": "anthropics/claude-code#56906",
+      "url": "https://github.com/anthropics/claude-code/issues/56906",
+      "title": "[BUG] Claude consistently makes unverified technical assertions that cascade into incorrect development decisions",
+      "impact": "not_applicable",
+      "categories": [
+        "terminal"
+      ],
+      "tokenkey_status": "not_applicable",
+      "rationale": "Client-side claude-code concern (terminal); not a gateway/relay relevance signal.",
+      "updated_at": "2026-06-02T22:44:18Z"
+    },
+    {
+      "upstream": "anthropics/claude-code#56913",
+      "url": "https://github.com/anthropics/claude-code/issues/56913",
+      "title": "Make autonomous Claude Code actually viable: tiered Opus brains + Sonnet workers + persistent state",
+      "impact": "not_applicable",
+      "categories": [
+        "slash_hook"
+      ],
+      "tokenkey_status": "not_applicable",
+      "rationale": "Client-side claude-code concern (slash_hook); not a gateway/relay relevance signal.",
+      "updated_at": "2026-06-02T22:03:36Z"
+    },
+    {
+      "upstream": "anthropics/claude-code#56952",
+      "url": "https://github.com/anthropics/claude-code/issues/56952",
+      "title": "[BUG] Claude Code Desktop SSH to Hostinger KVM4 VPS - process.spawn exits with code 1 on every message",
+      "impact": "not_applicable",
+      "categories": [
+        "terminal",
+        "platform"
+      ],
+      "tokenkey_status": "not_applicable",
+      "rationale": "Client-side claude-code concern (terminal, platform); not a gateway/relay relevance signal.",
+      "updated_at": "2026-06-01T12:03:14Z"
+    },
+    {
+      "upstream": "anthropics/claude-code#56965",
+      "url": "https://github.com/anthropics/claude-code/issues/56965",
+      "title": "Claude in Chrome v1.0.70: `permission_required` regression continues from #53630 — approval popup never renders, all MCP navigations blocked",
+      "impact": "not_applicable",
+      "categories": [
+        "ide",
+        "terminal",
+        "mcp",
+        "platform"
+      ],
+      "tokenkey_status": "not_applicable",
+      "rationale": "Client-side claude-code concern (ide, terminal, mcp, platform); not a gateway/relay relevance signal.",
+      "updated_at": "2026-06-02T21:26:28Z"
+    },
+    {
+      "upstream": "anthropics/claude-code#57132",
+      "url": "https://github.com/anthropics/claude-code/issues/57132",
+      "title": "[Bug] Allow rules under `~/.claude/` show as loaded per /permissions but don't match at runtime",
+      "impact": "not_applicable",
+      "categories": [
+        "slash_hook"
+      ],
+      "tokenkey_status": "not_applicable",
+      "rationale": "Client-side claude-code concern (slash_hook); not a gateway/relay relevance signal.",
+      "updated_at": "2026-06-02T11:32:45Z"
+    },
+    {
+      "upstream": "anthropics/claude-code#57159",
+      "url": "https://github.com/anthropics/claude-code/issues/57159",
+      "title": "[BUG] Windows 11 Pro 24H2: segmentation fault during PowerShell install, and also when launching `claude.exe` after WinGet install",
+      "impact": "not_applicable",
+      "categories": [
+        "terminal",
+        "install",
+        "platform"
+      ],
+      "tokenkey_status": "not_applicable",
+      "rationale": "Client-side claude-code concern (terminal, install, platform); not a gateway/relay relevance signal.",
+      "updated_at": "2026-06-03T06:15:20Z"
+    },
+    {
+      "upstream": "anthropics/claude-code#57178",
+      "url": "https://github.com/anthropics/claude-code/issues/57178",
+      "title": "[BUG] Auto-update creates broken claude.exe symlink on macOS, leaving CLI unusable after restart",
+      "impact": "not_applicable",
+      "categories": [
+        "terminal",
+        "install",
+        "platform"
+      ],
+      "tokenkey_status": "not_applicable",
+      "rationale": "Client-side claude-code concern (terminal, install, platform); not a gateway/relay relevance signal.",
+      "updated_at": "2026-06-02T11:04:11Z"
+    },
+    {
+      "upstream": "anthropics/claude-code#57230",
+      "url": "https://github.com/anthropics/claude-code/issues/57230",
+      "title": "[VSCode Extension] Add native system/toast notifications when Claude needs attention",
+      "impact": "not_applicable",
+      "categories": [
+        "ide",
+        "terminal",
+        "platform"
+      ],
+      "tokenkey_status": "not_applicable",
+      "rationale": "Client-side claude-code concern (ide, terminal, platform); not a gateway/relay relevance signal.",
+      "updated_at": "2026-06-02T12:04:12Z"
+    },
+    {
+      "upstream": "anthropics/claude-code#57276",
+      "url": "https://github.com/anthropics/claude-code/issues/57276",
+      "title": "[BUG] WorkspaceTrustError: Workspace requires trust approval before starting a session.",
+      "impact": "not_applicable",
+      "categories": [
+        "terminal"
+      ],
+      "tokenkey_status": "not_applicable",
+      "rationale": "Client-side claude-code concern (terminal); not a gateway/relay relevance signal.",
+      "updated_at": "2026-06-02T12:14:48Z"
+    },
+    {
+      "upstream": "anthropics/claude-code#57295",
+      "url": "https://github.com/anthropics/claude-code/issues/57295",
+      "title": "[BUG] Claude tries to get the project owner's attention with @Human, but that's me.",
+      "impact": "not_applicable",
+      "categories": [
+        "terminal"
+      ],
+      "tokenkey_status": "not_applicable",
+      "rationale": "Client-side claude-code concern (terminal); not a gateway/relay relevance signal.",
+      "updated_at": "2026-06-01T12:12:26Z"
+    },
+    {
+      "upstream": "anthropics/claude-code#57371",
+      "url": "https://github.com/anthropics/claude-code/issues/57371",
+      "title": "Claude Desktop (Windows): provide a way to disable the bundled Cowork background service (CoworkVMService) for users who don't use Cowork",
+      "impact": "not_applicable",
+      "categories": [
+        "ide",
+        "install",
+        "platform"
+      ],
+      "tokenkey_status": "not_applicable",
+      "rationale": "Client-side claude-code concern (ide, install, platform); not a gateway/relay relevance signal.",
+      "updated_at": "2026-05-31T17:57:36Z"
+    },
+    {
+      "upstream": "anthropics/claude-code#57580",
+      "url": "https://github.com/anthropics/claude-code/issues/57580",
+      "title": "macOS: PTY file descriptors leaked across a long Bash-heavy session, exhausting kern.tty.ptmx_max (forkpty / posix_openpt fail with ENXIO system-wide)",
+      "impact": "not_applicable",
+      "categories": [
+        "ide",
+        "terminal",
+        "install"
+      ],
+      "tokenkey_status": "not_applicable",
+      "rationale": "Client-side claude-code concern (ide, terminal, install); not a gateway/relay relevance signal.",
+      "updated_at": "2026-05-31T13:07:42Z"
+    },
+    {
+      "upstream": "anthropics/claude-code#57601",
+      "url": "https://github.com/anthropics/claude-code/issues/57601",
+      "title": "[BUG] Rewind option visible in picker but selecting any anchor returns 'Can't rewind to this message' (v2.1.119, CLI)",
+      "impact": "not_applicable",
+      "categories": [
+        "terminal",
+        "plugin",
+        "slash_hook"
+      ],
+      "tokenkey_status": "not_applicable",
+      "rationale": "Client-side claude-code concern (terminal, plugin, slash_hook); not a gateway/relay relevance signal.",
+      "updated_at": "2026-06-01T22:45:27Z"
+    },
+    {
+      "upstream": "anthropics/claude-code#57609",
+      "url": "https://github.com/anthropics/claude-code/issues/57609",
+      "title": "[FEATURE] API for reading organization-wide skills",
+      "impact": "not_applicable",
+      "categories": [
+        "ide",
+        "plugin"
+      ],
+      "tokenkey_status": "not_applicable",
+      "rationale": "Client-side claude-code concern (ide, plugin); not a gateway/relay relevance signal.",
+      "updated_at": "2026-06-03T01:41:16Z"
+    },
+    {
+      "upstream": "anthropics/claude-code#57659",
+      "url": "https://github.com/anthropics/claude-code/issues/57659",
+      "title": "Allow tab in /permissions UI: down-arrow does not navigate the rule list (focus appears trapped in search box)",
+      "impact": "not_applicable",
+      "categories": [
+        "terminal",
+        "slash_hook"
+      ],
+      "tokenkey_status": "not_applicable",
+      "rationale": "Client-side claude-code concern (terminal, slash_hook); not a gateway/relay relevance signal.",
+      "updated_at": "2026-05-31T10:41:41Z"
+    },
+    {
+      "upstream": "anthropics/claude-code#57700",
+      "url": "https://github.com/anthropics/claude-code/issues/57700",
+      "title": "[BUG] Rider MCP Server fails to detect installed Claude Code, but does detect Codex, which I've never installed or used",
+      "impact": "not_applicable",
+      "categories": [
+        "ide",
+        "terminal",
+        "mcp",
+        "plugin",
+        "slash_hook",
+        "platform"
+      ],
+      "tokenkey_status": "not_applicable",
+      "rationale": "Client-side claude-code concern (ide, terminal, mcp, plugin, slash_hook, platform); not a gateway/relay relevance signal.",
+      "updated_at": "2026-06-02T05:25:55Z"
+    },
+    {
+      "upstream": "anthropics/claude-code#57743",
+      "url": "https://github.com/anthropics/claude-code/issues/57743",
+      "title": "[FEATURE] Visual conventions for blocking questions and end-of-session summaries",
+      "impact": "not_applicable",
+      "categories": [
+        "terminal"
+      ],
+      "tokenkey_status": "not_applicable",
+      "rationale": "Client-side claude-code concern (terminal); not a gateway/relay relevance signal.",
+      "updated_at": "2026-06-01T22:46:09Z"
+    },
+    {
+      "upstream": "anthropics/claude-code#57844",
+      "url": "https://github.com/anthropics/claude-code/issues/57844",
+      "title": "Preview panel: mobile/desktop viewport toggle button is gone",
+      "impact": "not_applicable",
+      "categories": [
+        "ide"
+      ],
+      "tokenkey_status": "not_applicable",
+      "rationale": "Client-side claude-code concern (ide); not a gateway/relay relevance signal.",
+      "updated_at": "2026-06-02T23:34:09Z"
+    },
+    {
+      "upstream": "anthropics/claude-code#57859",
+      "url": "https://github.com/anthropics/claude-code/issues/57859",
+      "title": "Claude desktop app's PR/CI panel can't find `gh` because PATH is `/usr/bin:/bin:/usr/sbin:/sbin` (LSEnvironment override)",
+      "impact": "not_applicable",
+      "categories": [
+        "install"
+      ],
+      "tokenkey_status": "not_applicable",
+      "rationale": "Client-side claude-code concern (install); not a gateway/relay relevance signal.",
+      "updated_at": "2026-06-01T08:05:03Z"
+    },
+    {
+      "upstream": "anthropics/claude-code#57862",
+      "url": "https://github.com/anthropics/claude-code/issues/57862",
+      "title": "[BUG] \"Clear Context\" No longer removes old context fully",
+      "impact": "not_applicable",
+      "categories": [
+        "ide",
+        "terminal",
+        "plugin"
+      ],
+      "tokenkey_status": "not_applicable",
+      "rationale": "Client-side claude-code concern (ide, terminal, plugin); not a gateway/relay relevance signal.",
+      "updated_at": "2026-06-02T22:44:16Z"
+    },
+    {
+      "upstream": "anthropics/claude-code#57947",
+      "url": "https://github.com/anthropics/claude-code/issues/57947",
+      "title": "Agent emits fabricated input-shape content (Human prefix, system-reminder tags, task-notification blocks) in its own assistant text, invisible on self-audit",
+      "impact": "not_applicable",
+      "categories": [
+        "terminal",
+        "plugin",
+        "slash_hook"
+      ],
+      "tokenkey_status": "not_applicable",
+      "rationale": "Client-side claude-code concern (terminal, plugin, slash_hook); not a gateway/relay relevance signal.",
+      "updated_at": "2026-06-03T03:35:01Z"
+    },
+    {
+      "upstream": "anthropics/claude-code#57964",
+      "url": "https://github.com/anthropics/claude-code/issues/57964",
+      "title": "[BUG] `CLAUDE_CODE_AUTO_COMPACT_WINDOW` is capped at the hardcoded model context window size (preventing larger context for custom APIs)",
+      "impact": "not_applicable",
+      "categories": [
+        "terminal"
+      ],
+      "tokenkey_status": "not_applicable",
+      "rationale": "Client-side claude-code concern (terminal); not a gateway/relay relevance signal.",
+      "updated_at": "2026-06-02T11:33:18Z"
+    },
+    {
+      "upstream": "anthropics/claude-code#57998",
+      "url": "https://github.com/anthropics/claude-code/issues/57998",
+      "title": "[FEATURE] CLAUDE_DATA_DIR env var or config key to relocate %APPDATA%\\Claude\\ on Windows",
+      "impact": "not_applicable",
+      "categories": [
+        "ide",
+        "slash_hook",
+        "install",
+        "platform"
+      ],
+      "tokenkey_status": "not_applicable",
+      "rationale": "Client-side claude-code concern (ide, slash_hook, install, platform); not a gateway/relay relevance signal.",
+      "updated_at": "2026-06-01T17:00:20Z"
+    },
+    {
+      "upstream": "anthropics/claude-code#58101",
+      "url": "https://github.com/anthropics/claude-code/issues/58101",
+      "title": "[BUG] Weekly usage limit not updated after upgrade from Pro to Max 20x — account still behaves as Pro/5x",
+      "impact": "not_applicable",
+      "categories": [
+        "terminal"
+      ],
+      "tokenkey_status": "not_applicable",
+      "rationale": "Client-side claude-code concern (terminal); not a gateway/relay relevance signal.",
+      "updated_at": "2026-06-02T11:32:32Z"
+    },
+    {
+      "upstream": "anthropics/claude-code#58137",
+      "url": "https://github.com/anthropics/claude-code/issues/58137",
+      "title": "[BUG] TaskList wipes from in-memory state on Stop events at plain turn boundaries (no /compact, no /clear) — disk taskdir intact",
+      "impact": "not_applicable",
+      "categories": [
+        "terminal",
+        "slash_hook",
+        "platform"
+      ],
+      "tokenkey_status": "not_applicable",
+      "rationale": "Client-side claude-code concern (terminal, slash_hook, platform); not a gateway/relay relevance signal.",
+      "updated_at": "2026-06-01T22:46:11Z"
+    },
+    {
+      "upstream": "anthropics/claude-code#58144",
+      "url": "https://github.com/anthropics/claude-code/issues/58144",
+      "title": "False 'Update available' notification when installed via apt",
+      "impact": "not_applicable",
+      "categories": [
+        "install"
+      ],
+      "tokenkey_status": "not_applicable",
+      "rationale": "Client-side claude-code concern (install); not a gateway/relay relevance signal.",
+      "updated_at": "2026-06-02T09:11:45Z"
+    },
+    {
+      "upstream": "anthropics/claude-code#58215",
+      "url": "https://github.com/anthropics/claude-code/issues/58215",
+      "title": "[FEATURE] Agent view should not auto-complete sessions — require manual completion or archive",
+      "impact": "not_applicable",
+      "categories": [
+        "terminal",
+        "slash_hook"
+      ],
+      "tokenkey_status": "not_applicable",
+      "rationale": "Client-side claude-code concern (terminal, slash_hook); not a gateway/relay relevance signal.",
+      "updated_at": "2026-06-03T02:07:09Z"
+    },
+    {
+      "upstream": "anthropics/claude-code#58219",
+      "url": "https://github.com/anthropics/claude-code/issues/58219",
+      "title": "[FEATURE][Trace] Support per-request trace context propagation for LLM API calls",
+      "impact": "not_applicable",
+      "categories": [
+        "ide",
+        "mcp",
+        "slash_hook"
+      ],
+      "tokenkey_status": "not_applicable",
+      "rationale": "Client-side claude-code concern (ide, mcp, slash_hook); not a gateway/relay relevance signal.",
+      "updated_at": "2026-06-02T11:32:47Z"
+    },
+    {
+      "upstream": "anthropics/claude-code#58332",
+      "url": "https://github.com/anthropics/claude-code/issues/58332",
+      "title": "[FEATURE] Multi-LSP per file extension: let linting servers coexist with type servers — or tell us it won't happen",
+      "impact": "not_applicable",
+      "categories": [
+        "ide",
+        "plugin"
+      ],
+      "tokenkey_status": "not_applicable",
+      "rationale": "Client-side claude-code concern (ide, plugin); not a gateway/relay relevance signal.",
+      "updated_at": "2026-05-31T14:09:24Z"
+    },
+    {
+      "upstream": "anthropics/claude-code#58333",
+      "url": "https://github.com/anthropics/claude-code/issues/58333",
+      "title": "claude update: false-positive \"~/.local/bin is not in your PATH\" warning when it actually is",
+      "impact": "not_applicable",
+      "categories": [
+        "terminal",
+        "install"
+      ],
+      "tokenkey_status": "not_applicable",
+      "rationale": "Client-side claude-code concern (terminal, install); not a gateway/relay relevance signal.",
+      "updated_at": "2026-06-02T15:48:23Z"
+    },
+    {
+      "upstream": "anthropics/claude-code#58345",
+      "url": "https://github.com/anthropics/claude-code/issues/58345",
+      "title": "[Bug] EnterWorktree/ExitWorktree tools don't restore core.bare config on exit",
+      "impact": "not_applicable",
+      "categories": [
+        "terminal",
+        "mcp",
+        "plugin"
+      ],
+      "tokenkey_status": "not_applicable",
+      "rationale": "Client-side claude-code concern (terminal, mcp, plugin); not a gateway/relay relevance signal.",
+      "updated_at": "2026-06-02T11:32:27Z"
+    },
+    {
+      "upstream": "anthropics/claude-code#58429",
+      "url": "https://github.com/anthropics/claude-code/issues/58429",
+      "title": "[A11y feature request] Built-in option to speak Claude's responses aloud",
+      "impact": "not_applicable",
+      "categories": [
+        "terminal",
+        "slash_hook"
+      ],
+      "tokenkey_status": "not_applicable",
+      "rationale": "Client-side claude-code concern (terminal, slash_hook); not a gateway/relay relevance signal.",
+      "updated_at": "2026-05-31T23:03:50Z"
+    },
+    {
+      "upstream": "anthropics/claude-code#58438",
+      "url": "https://github.com/anthropics/claude-code/issues/58438",
+      "title": "VSCode extension: 'Loading config cache by launching Claude' pre-launch takes 11-51s on ARM64/LinuxKit, blocks session-ready",
+      "impact": "not_applicable",
+      "categories": [
+        "ide",
+        "plugin",
+        "slash_hook",
+        "platform"
+      ],
+      "tokenkey_status": "not_applicable",
+      "rationale": "Client-side claude-code concern (ide, plugin, slash_hook, platform); not a gateway/relay relevance signal.",
+      "updated_at": "2026-05-31T10:41:40Z"
+    },
+    {
+      "upstream": "anthropics/claude-code#58444",
+      "url": "https://github.com/anthropics/claude-code/issues/58444",
+      "title": "HTTP MCP Servers Don't Auto-Reconnect After Transient Startup Failures",
+      "impact": "not_applicable",
+      "categories": [
+        "mcp"
+      ],
+      "tokenkey_status": "not_applicable",
+      "rationale": "Client-side claude-code concern (mcp); not a gateway/relay relevance signal.",
+      "updated_at": "2026-06-01T17:58:49Z"
+    },
+    {
+      "upstream": "anthropics/claude-code#58504",
+      "url": "https://github.com/anthropics/claude-code/issues/58504",
+      "title": "[BUG] VSCode 2.1.139: acceptEdits / Edit automatically mode still prompts for Edit tool approval (regression persists since v2.1.79)",
+      "impact": "not_applicable",
+      "categories": [
+        "ide",
+        "slash_hook",
+        "platform"
+      ],
+      "tokenkey_status": "not_applicable",
+      "rationale": "Client-side claude-code concern (ide, slash_hook, platform); not a gateway/relay relevance signal.",
+      "updated_at": "2026-06-01T12:02:15Z"
+    },
+    {
+      "upstream": "anthropics/claude-code#58522",
+      "url": "https://github.com/anthropics/claude-code/issues/58522",
+      "title": "[BUG] Desktop app passes invalid --session-id (\"local_\" prefix) to bundled binary — all new Code-mode sessions crash with exit code 1 (regression since May 9 app.asar update)",
+      "impact": "not_applicable",
+      "categories": [
+        "terminal"
+      ],
+      "tokenkey_status": "not_applicable",
+      "rationale": "Client-side claude-code concern (terminal); not a gateway/relay relevance signal.",
+      "updated_at": "2026-06-02T22:44:56Z"
+    },
+    {
+      "upstream": "anthropics/claude-code#58614",
+      "url": "https://github.com/anthropics/claude-code/issues/58614",
+      "title": "Path-pattern scanner false-positives on Windows 8.3 short names (e.g. ALICEM~1), bypassing user allow-rules — affects users with non-ASCII chars in their Windows username",
+      "impact": "not_applicable",
+      "categories": [
+        "plugin",
+        "slash_hook",
+        "install",
+        "platform"
+      ],
+      "tokenkey_status": "not_applicable",
+      "rationale": "Client-side claude-code concern (plugin, slash_hook, install, platform); not a gateway/relay relevance signal.",
+      "updated_at": "2026-06-02T13:15:41Z"
+    },
+    {
+      "upstream": "anthropics/claude-code#58636",
+      "url": "https://github.com/anthropics/claude-code/issues/58636",
+      "title": "[BUG] Critical: sandbox.filesystem.denyRead does not prevent credential exposure",
+      "impact": "not_applicable",
+      "categories": [
+        "terminal",
+        "slash_hook"
+      ],
+      "tokenkey_status": "not_applicable",
+      "rationale": "Client-side claude-code concern (terminal, slash_hook); not a gateway/relay relevance signal.",
+      "updated_at": "2026-06-02T22:44:18Z"
+    },
+    {
+      "upstream": "anthropics/claude-code#58660",
+      "url": "https://github.com/anthropics/claude-code/issues/58660",
+      "title": "Scroll wheel/trackpad should scroll agent transcript inside agent detail view",
+      "impact": "not_applicable",
+      "categories": [
+        "terminal",
+        "slash_hook"
+      ],
+      "tokenkey_status": "not_applicable",
+      "rationale": "Client-side claude-code concern (terminal, slash_hook); not a gateway/relay relevance signal.",
+      "updated_at": "2026-06-01T22:45:34Z"
+    },
+    {
+      "upstream": "anthropics/claude-code#58671",
+      "url": "https://github.com/anthropics/claude-code/issues/58671",
+      "title": "Phantom user messages: text appears in transcript as user input that the user did not type",
+      "impact": "not_applicable",
+      "categories": [
+        "terminal",
+        "slash_hook"
+      ],
+      "tokenkey_status": "not_applicable",
+      "rationale": "Client-side claude-code concern (terminal, slash_hook); not a gateway/relay relevance signal.",
+      "updated_at": "2026-06-02T09:36:37Z"
+    },
+    {
+      "upstream": "anthropics/claude-code#58674",
+      "url": "https://github.com/anthropics/claude-code/issues/58674",
+      "title": "[BUG] The skill_activated event emits custom_skill instead of actual skill name",
+      "impact": "not_applicable",
+      "categories": [
+        "terminal",
+        "plugin"
+      ],
+      "tokenkey_status": "not_applicable",
+      "rationale": "Client-side claude-code concern (terminal, plugin); not a gateway/relay relevance signal.",
+      "updated_at": "2026-06-02T11:32:55Z"
+    },
+    {
+      "upstream": "anthropics/claude-code#58717",
+      "url": "https://github.com/anthropics/claude-code/issues/58717",
+      "title": "[Bug] Claude replaces ASCII quotes with Unicode quotes in code generation, breaking syntax",
+      "impact": "not_applicable",
+      "categories": [
+        "terminal"
+      ],
+      "tokenkey_status": "not_applicable",
+      "rationale": "Client-side claude-code concern (terminal); not a gateway/relay relevance signal.",
+      "updated_at": "2026-06-02T11:33:06Z"
+    },
+    {
+      "upstream": "anthropics/claude-code#58732",
+      "url": "https://github.com/anthropics/claude-code/issues/58732",
+      "title": "claude.exe polls entire PATH for \\coder\\ (and other tools) every 30 seconds, including removable/archive drives",
+      "impact": "not_applicable",
+      "categories": [
+        "install",
+        "platform"
+      ],
+      "tokenkey_status": "not_applicable",
+      "rationale": "Client-side claude-code concern (install, platform); not a gateway/relay relevance signal.",
+      "updated_at": "2026-06-01T22:46:08Z"
+    },
+    {
+      "upstream": "anthropics/claude-code#58750",
+      "url": "https://github.com/anthropics/claude-code/issues/58750",
+      "title": "[BUG] Cowork Desktop (macOS): AskUserQuestion card never reaches renderer; yellow-dot badge shows pending but no UI; on app quit, pending request silently resolves as \"Dismissed\"",
+      "impact": "not_applicable",
+      "categories": [
+        "terminal",
+        "plugin"
+      ],
+      "tokenkey_status": "not_applicable",
+      "rationale": "Client-side claude-code concern (terminal, plugin); not a gateway/relay relevance signal.",
+      "updated_at": "2026-06-03T04:00:47Z"
+    },
+    {
+      "upstream": "anthropics/claude-code#58780",
+      "url": "https://github.com/anthropics/claude-code/issues/58780",
+      "title": "[BUG] VSCode extension: copy button on completed code blocks flickers during streaming",
+      "impact": "not_applicable",
+      "categories": [
+        "ide",
+        "terminal",
+        "install"
+      ],
+      "tokenkey_status": "not_applicable",
+      "rationale": "Client-side claude-code concern (ide, terminal, install); not a gateway/relay relevance signal.",
+      "updated_at": "2026-06-01T12:44:18Z"
+    },
+    {
+      "upstream": "anthropics/claude-code#58784",
+      "url": "https://github.com/anthropics/claude-code/issues/58784",
+      "title": "[BUG] Claude Code process exited with code 1",
+      "impact": "not_applicable",
+      "categories": [
+        "terminal"
+      ],
+      "tokenkey_status": "not_applicable",
+      "rationale": "Client-side claude-code concern (terminal); not a gateway/relay relevance signal.",
+      "updated_at": "2026-06-01T22:45:54Z"
+    },
+    {
+      "upstream": "anthropics/claude-code#58793",
+      "url": "https://github.com/anthropics/claude-code/issues/58793",
+      "title": "Claude Desktop window is completely blank",
+      "impact": "not_applicable",
+      "categories": [
+        "terminal",
+        "platform"
+      ],
+      "tokenkey_status": "not_applicable",
+      "rationale": "Client-side claude-code concern (terminal, platform); not a gateway/relay relevance signal.",
+      "updated_at": "2026-06-01T07:39:06Z"
+    },
+    {
+      "upstream": "anthropics/claude-code#58821",
+      "url": "https://github.com/anthropics/claude-code/issues/58821",
+      "title": "[Preview] Windows: viewport toggle missing + URL truncated in Preview pane toolbar",
+      "impact": "not_applicable",
+      "categories": [
+        "terminal",
+        "platform"
+      ],
+      "tokenkey_status": "not_applicable",
+      "rationale": "Client-side claude-code concern (terminal, platform); not a gateway/relay relevance signal.",
+      "updated_at": "2026-06-02T23:34:42Z"
+    },
+    {
+      "upstream": "anthropics/claude-code#58862",
+      "url": "https://github.com/anthropics/claude-code/issues/58862",
+      "title": "[DOCS] `/feedback` docs omit recent-session attachment options for cross-session issues",
+      "impact": "not_applicable",
+      "categories": [
+        "install"
+      ],
+      "tokenkey_status": "not_applicable",
+      "rationale": "Client-side claude-code concern (install); not a gateway/relay relevance signal.",
+      "updated_at": "2026-06-01T01:12:03Z"
+    },
+    {
+      "upstream": "anthropics/claude-code#58864",
+      "url": "https://github.com/anthropics/claude-code/issues/58864",
+      "title": "[DOCS] Auto mode docs omit that `permissions.ask` rules still trigger manual approval prompts",
+      "impact": "not_applicable",
+      "categories": [
+        "slash_hook"
+      ],
+      "tokenkey_status": "not_applicable",
+      "rationale": "Client-side claude-code concern (slash_hook); not a gateway/relay relevance signal.",
+      "updated_at": "2026-06-01T01:11:29Z"
+    },
+    {
+      "upstream": "anthropics/claude-code#58866",
+      "url": "https://github.com/anthropics/claude-code/issues/58866",
+      "title": "[DOCS] Extended thinking docs omit the amber spinner state during long thinking periods",
+      "impact": "not_applicable",
+      "categories": [
+        "terminal"
+      ],
+      "tokenkey_status": "not_applicable",
+      "rationale": "Client-side claude-code concern (terminal); not a gateway/relay relevance signal.",
+      "updated_at": "2026-06-01T01:11:28Z"
+    },
+    {
+      "upstream": "anthropics/claude-code#58867",
+      "url": "https://github.com/anthropics/claude-code/issues/58867",
+      "title": "[DOCS] Plugin manager docs omit fullscreen tab and search navigation controls",
+      "impact": "not_applicable",
+      "categories": [
+        "plugin"
+      ],
+      "tokenkey_status": "not_applicable",
+      "rationale": "Client-side claude-code concern (plugin); not a gateway/relay relevance signal.",
+      "updated_at": "2026-06-01T01:11:17Z"
+    },
+    {
+      "upstream": "anthropics/claude-code#58871",
+      "url": "https://github.com/anthropics/claude-code/issues/58871",
+      "title": "[DOCS] Interactive mode docs omit interrupted-prompt Up-arrow history behavior",
+      "impact": "not_applicable",
+      "categories": [
+        "slash_hook"
+      ],
+      "tokenkey_status": "not_applicable",
+      "rationale": "Client-side claude-code concern (slash_hook); not a gateway/relay relevance signal.",
+      "updated_at": "2026-06-01T01:11:09Z"
+    },
+    {
+      "upstream": "anthropics/claude-code#58872",
+      "url": "https://github.com/anthropics/claude-code/issues/58872",
+      "title": "[DOCS] `/tui` docs omit that running background shells and subagents block renderer switching",
+      "impact": "not_applicable",
+      "categories": [
+        "terminal",
+        "plugin"
+      ],
+      "tokenkey_status": "not_applicable",
+      "rationale": "Client-side claude-code concern (terminal, plugin); not a gateway/relay relevance signal.",
+      "updated_at": "2026-06-01T01:08:40Z"
+    },
+    {
+      "upstream": "anthropics/claude-code#58873",
+      "url": "https://github.com/anthropics/claude-code/issues/58873",
+      "title": "[DOCS] Plugin marketplace docs omit deleted-`ref` behavior when `sha` is pinned",
+      "impact": "not_applicable",
+      "categories": [
+        "plugin",
+        "install"
+      ],
+      "tokenkey_status": "not_applicable",
+      "rationale": "Client-side claude-code concern (plugin, install); not a gateway/relay relevance signal.",
+      "updated_at": "2026-06-01T01:09:07Z"
+    },
+    {
+      "upstream": "anthropics/claude-code#58895",
+      "url": "https://github.com/anthropics/claude-code/issues/58895",
+      "title": "[FEATURE] UserIdle hook event for proactive state persistence after N minutes of inactivity",
+      "impact": "not_applicable",
+      "categories": [
+        "ide",
+        "terminal",
+        "plugin",
+        "slash_hook",
+        "platform"
+      ],
+      "tokenkey_status": "not_applicable",
+      "rationale": "Client-side claude-code concern (ide, terminal, plugin, slash_hook, platform); not a gateway/relay relevance signal.",
+      "updated_at": "2026-06-01T22:45:41Z"
+    },
+    {
+      "upstream": "anthropics/claude-code#58910",
+      "url": "https://github.com/anthropics/claude-code/issues/58910",
+      "title": "[FEATURE] Recognize and Skip Social/Conversational Phrases Without Token Consumption",
+      "impact": "not_applicable",
+      "categories": [
+        "terminal"
+      ],
+      "tokenkey_status": "not_applicable",
+      "rationale": "Client-side claude-code concern (terminal); not a gateway/relay relevance signal.",
+      "updated_at": "2026-06-02T11:32:34Z"
+    },
+    {
+      "upstream": "anthropics/claude-code#58924",
+      "url": "https://github.com/anthropics/claude-code/issues/58924",
+      "title": "Project-scope .mcp.json silently skipped during startup in 2.1.141 (native, Linux)",
+      "impact": "not_applicable",
+      "categories": [
+        "ide",
+        "terminal",
+        "mcp",
+        "install"
+      ],
+      "tokenkey_status": "not_applicable",
+      "rationale": "Client-side claude-code concern (ide, terminal, mcp, install); not a gateway/relay relevance signal.",
+      "updated_at": "2026-06-02T22:44:34Z"
+    },
+    {
+      "upstream": "anthropics/claude-code#58930",
+      "url": "https://github.com/anthropics/claude-code/issues/58930",
+      "title": "[BUG]",
+      "impact": "not_applicable",
+      "categories": [
+        "terminal"
+      ],
+      "tokenkey_status": "not_applicable",
+      "rationale": "Client-side claude-code concern (terminal); not a gateway/relay relevance signal.",
+      "updated_at": "2026-06-02T22:43:58Z"
+    },
+    {
+      "upstream": "anthropics/claude-code#58966",
+      "url": "https://github.com/anthropics/claude-code/issues/58966",
+      "title": "[FEATURE] Inverse of background mode: archive agent from Agent View without destroying data",
+      "impact": "not_applicable",
+      "categories": [
+        "slash_hook"
+      ],
+      "tokenkey_status": "not_applicable",
+      "rationale": "Client-side claude-code concern (slash_hook); not a gateway/relay relevance signal.",
+      "updated_at": "2026-06-01T12:03:25Z"
+    },
+    {
+      "upstream": "anthropics/claude-code#59032",
+      "url": "https://github.com/anthropics/claude-code/issues/59032",
+      "title": "[BUG] Why is the /compact command so slow?",
+      "impact": "not_applicable",
+      "categories": [
+        "terminal"
+      ],
+      "tokenkey_status": "not_applicable",
+      "rationale": "Client-side claude-code concern (terminal); not a gateway/relay relevance signal.",
+      "updated_at": "2026-06-01T22:45:06Z"
+    },
+    {
+      "upstream": "anthropics/claude-code#59057",
+      "url": "https://github.com/anthropics/claude-code/issues/59057",
+      "title": "[BUG] Chat history empty when workspace is on a mapped network drive (Windows)",
+      "impact": "not_applicable",
+      "categories": [
+        "ide",
+        "terminal",
+        "platform"
+      ],
+      "tokenkey_status": "not_applicable",
+      "rationale": "Client-side claude-code concern (ide, terminal, platform); not a gateway/relay relevance signal.",
+      "updated_at": "2026-06-01T12:03:21Z"
+    },
+    {
+      "upstream": "anthropics/claude-code#59069",
+      "url": "https://github.com/anthropics/claude-code/issues/59069",
+      "title": "[FEATURE] User-side configurable plugin namespace alias (e.g. `omcw` for `oh-my-cc-workflow`)",
+      "impact": "not_applicable",
+      "categories": [
+        "plugin",
+        "slash_hook",
+        "install"
+      ],
+      "tokenkey_status": "not_applicable",
+      "rationale": "Client-side claude-code concern (plugin, slash_hook, install); not a gateway/relay relevance signal.",
+      "updated_at": "2026-05-31T10:41:54Z"
+    },
+    {
+      "upstream": "anthropics/claude-code#59136",
+      "url": "https://github.com/anthropics/claude-code/issues/59136",
+      "title": "Agent window model selection limited to Haiku 4.5 in VS Code Insiders",
+      "impact": "not_applicable",
+      "categories": [
+        "ide"
+      ],
+      "tokenkey_status": "not_applicable",
+      "rationale": "Client-side claude-code concern (ide); not a gateway/relay relevance signal.",
+      "updated_at": "2026-06-01T12:27:23Z"
+    },
+    {
+      "upstream": "anthropics/claude-code#59139",
+      "url": "https://github.com/anthropics/claude-code/issues/59139",
+      "title": "[Cowork UI] \"Unhandled case: [object Object]\" banner — MCP tool-result envelope + SDK stream-end-with-error renderer paths",
+      "impact": "not_applicable",
+      "categories": [
+        "ide",
+        "terminal",
+        "mcp",
+        "plugin",
+        "slash_hook",
+        "platform"
+      ],
+      "tokenkey_status": "not_applicable",
+      "rationale": "Client-side claude-code concern (ide, terminal, mcp, plugin, slash_hook, platform); not a gateway/relay relevance signal.",
+      "updated_at": "2026-06-01T12:01:54Z"
+    },
+    {
+      "upstream": "anthropics/claude-code#59191",
+      "url": "https://github.com/anthropics/claude-code/issues/59191",
+      "title": "[BUG] Claude Code 'spinning' 'moseying' 'gitifying' for MANY MINUTES on each prompt",
+      "impact": "not_applicable",
+      "categories": [
+        "terminal"
+      ],
+      "tokenkey_status": "not_applicable",
+      "rationale": "Client-side claude-code concern (terminal); not a gateway/relay relevance signal.",
+      "updated_at": "2026-06-02T11:31:58Z"
+    },
+    {
+      "upstream": "anthropics/claude-code#59245",
+      "url": "https://github.com/anthropics/claude-code/issues/59245",
+      "title": "Feature request: surface AskUserQuestion through the MCP channel API so plugins can proxy it",
+      "impact": "not_applicable",
+      "categories": [
+        "ide",
+        "terminal",
+        "mcp",
+        "plugin",
+        "slash_hook"
+      ],
+      "tokenkey_status": "not_applicable",
+      "rationale": "Client-side claude-code concern (ide, terminal, mcp, plugin, slash_hook); not a gateway/relay relevance signal.",
+      "updated_at": "2026-06-01T12:01:59Z"
+    },
+    {
+      "upstream": "anthropics/claude-code#59258",
+      "url": "https://github.com/anthropics/claude-code/issues/59258",
+      "title": "[DOCS] Plugin docs omit root-level `SKILL.md` discovery without a `skills/` subdirectory",
+      "impact": "not_applicable",
+      "categories": [
+        "plugin",
+        "slash_hook",
+        "install"
+      ],
+      "tokenkey_status": "not_applicable",
+      "rationale": "Client-side claude-code concern (plugin, slash_hook, install); not a gateway/relay relevance signal.",
+      "updated_at": "2026-06-01T01:09:07Z"
+    },
+    {
+      "upstream": "anthropics/claude-code#59259",
+      "url": "https://github.com/anthropics/claude-code/issues/59259",
+      "title": "[DOCS] Plugin details docs omit LSP servers in `/plugin` and `claude plugin details`",
+      "impact": "not_applicable",
+      "categories": [
+        "mcp",
+        "plugin"
+      ],
+      "tokenkey_status": "not_applicable",
+      "rationale": "Client-side claude-code concern (mcp, plugin); not a gateway/relay relevance signal.",
+      "updated_at": "2026-06-01T01:08:17Z"
+    },
+    {
+      "upstream": "anthropics/claude-code#59260",
+      "url": "https://github.com/anthropics/claude-code/issues/59260",
+      "title": "[DOCS] `/web-setup` docs omit warning before replacing an existing GitHub App connection",
+      "impact": "not_applicable",
+      "categories": [
+        "terminal"
+      ],
+      "tokenkey_status": "not_applicable",
+      "rationale": "Client-side claude-code concern (terminal); not a gateway/relay relevance signal.",
+      "updated_at": "2026-06-01T01:08:03Z"
+    },
+    {
+      "upstream": "anthropics/claude-code#59282",
+      "url": "https://github.com/anthropics/claude-code/issues/59282",
+      "title": "[Bug] Desktop Projects \"Recent\" sort uses stale timestamps instead of chat activity",
+      "impact": "not_applicable",
+      "categories": [
+        "terminal"
+      ],
+      "tokenkey_status": "not_applicable",
+      "rationale": "Client-side claude-code concern (terminal); not a gateway/relay relevance signal.",
+      "updated_at": "2026-06-01T12:18:57Z"
+    },
+    {
+      "upstream": "anthropics/claude-code#59309",
+      "url": "https://github.com/anthropics/claude-code/issues/59309",
+      "title": "CLAUDE.md rules not propagated to Agent subagents and weakened after context compaction",
+      "impact": "not_applicable",
+      "categories": [
+        "plugin"
+      ],
+      "tokenkey_status": "not_applicable",
+      "rationale": "Client-side claude-code concern (plugin); not a gateway/relay relevance signal.",
+      "updated_at": "2026-06-01T22:46:20Z"
+    },
+    {
+      "upstream": "anthropics/claude-code#59336",
+      "url": "https://github.com/anthropics/claude-code/issues/59336",
+      "title": "[FEATURE] AskUserQuestion shouldn't steal focus / interrupt active typing",
+      "impact": "not_applicable",
+      "categories": [
+        "terminal"
+      ],
+      "tokenkey_status": "not_applicable",
+      "rationale": "Client-side claude-code concern (terminal); not a gateway/relay relevance signal.",
+      "updated_at": "2026-06-02T22:44:57Z"
+    },
+    {
+      "upstream": "anthropics/claude-code#59366",
+      "url": "https://github.com/anthropics/claude-code/issues/59366",
+      "title": "Feature Request: Skill-scoped permissions",
+      "impact": "not_applicable",
+      "categories": [
+        "slash_hook"
+      ],
+      "tokenkey_status": "not_applicable",
+      "rationale": "Client-side claude-code concern (slash_hook); not a gateway/relay relevance signal.",
+      "updated_at": "2026-06-02T09:47:45Z"
+    },
+    {
+      "upstream": "anthropics/claude-code#59388",
+      "url": "https://github.com/anthropics/claude-code/issues/59388",
+      "title": "[BUG] Claude Desktop 1.7196.0 — EXC_BREAKPOINT crash in Electron Framework on macOS Tahoe 26.3 (M1)",
+      "impact": "not_applicable",
+      "categories": [
+        "terminal"
+      ],
+      "tokenkey_status": "not_applicable",
+      "rationale": "Client-side claude-code concern (terminal); not a gateway/relay relevance signal.",
+      "updated_at": "2026-05-31T10:41:16Z"
+    },
+    {
+      "upstream": "anthropics/claude-code#59397",
+      "url": "https://github.com/anthropics/claude-code/issues/59397",
+      "title": "[FEATURE] Pure-exec slash commands (deterministic, discoverable alias for Bash mode)",
+      "impact": "not_applicable",
+      "categories": [
+        "ide",
+        "terminal",
+        "slash_hook"
+      ],
+      "tokenkey_status": "not_applicable",
+      "rationale": "Client-side claude-code concern (ide, terminal, slash_hook); not a gateway/relay relevance signal.",
+      "updated_at": "2026-05-31T10:41:50Z"
+    },
+    {
+      "upstream": "anthropics/claude-code#59404",
+      "url": "https://github.com/anthropics/claude-code/issues/59404",
+      "title": "[BUG] Write tool code preview renders invisible keywords",
+      "impact": "not_applicable",
+      "categories": [
+        "terminal"
+      ],
+      "tokenkey_status": "not_applicable",
+      "rationale": "Client-side claude-code concern (terminal); not a gateway/relay relevance signal.",
+      "updated_at": "2026-05-31T10:41:14Z"
+    },
+    {
+      "upstream": "anthropics/claude-code#59405",
+      "url": "https://github.com/anthropics/claude-code/issues/59405",
+      "title": "[Bug] Claude Code skips UI modules when building from Claude.com shared prompts with screenshots",
+      "impact": "not_applicable",
+      "categories": [
+        "terminal",
+        "plugin"
+      ],
+      "tokenkey_status": "not_applicable",
+      "rationale": "Client-side claude-code concern (terminal, plugin); not a gateway/relay relevance signal.",
+      "updated_at": "2026-06-01T12:02:26Z"
+    },
+    {
+      "upstream": "anthropics/claude-code#59407",
+      "url": "https://github.com/anthropics/claude-code/issues/59407",
+      "title": "[BUG] Chat tab disappears when switching from Anthropic login to third-party API gateway",
+      "impact": "not_applicable",
+      "categories": [
+        "platform"
+      ],
+      "tokenkey_status": "not_applicable",
+      "rationale": "Client-side claude-code concern (platform); not a gateway/relay relevance signal.",
+      "updated_at": "2026-05-31T10:41:15Z"
+    },
+    {
+      "upstream": "anthropics/claude-code#59423",
+      "url": "https://github.com/anthropics/claude-code/issues/59423",
+      "title": "\"N skill descriptions dropped\" — empty descriptions for duplicate SKILL.md between plugins/marketplaces/ and plugins/cache/",
+      "impact": "not_applicable",
+      "categories": [
+        "plugin",
+        "install"
+      ],
+      "tokenkey_status": "not_applicable",
+      "rationale": "Client-side claude-code concern (plugin, install); not a gateway/relay relevance signal.",
+      "updated_at": "2026-06-01T12:02:11Z"
+    },
+    {
+      "upstream": "anthropics/claude-code#59492",
+      "url": "https://github.com/anthropics/claude-code/issues/59492",
+      "title": "[FEATURE] Native /restart and /handoff: consolidating 9 open requests + 2 working prototypes",
+      "impact": "not_applicable",
+      "categories": [
+        "terminal",
+        "mcp",
+        "plugin",
+        "slash_hook",
+        "install",
+        "platform"
+      ],
+      "tokenkey_status": "not_applicable",
+      "rationale": "Client-side claude-code concern (terminal, mcp, plugin, slash_hook, install, platform); not a gateway/relay relevance signal.",
+      "updated_at": "2026-06-02T22:44:46Z"
+    },
+    {
+      "upstream": "anthropics/claude-code#59522",
+      "url": "https://github.com/anthropics/claude-code/issues/59522",
+      "title": "[BUG] terminal title \"icons\" no longer seem to accurately reflect status",
+      "impact": "not_applicable",
+      "categories": [
+        "terminal"
+      ],
+      "tokenkey_status": "not_applicable",
+      "rationale": "Client-side claude-code concern (terminal); not a gateway/relay relevance signal.",
+      "updated_at": "2026-06-01T22:45:11Z"
+    },
+    {
+      "upstream": "anthropics/claude-code#59550",
+      "url": "https://github.com/anthropics/claude-code/issues/59550",
+      "title": "[BUG] Selecting \"Chat about this\" on AskUserQuestion is reported to Claude as \"User declined to answer questions\" and ends the interview",
+      "impact": "not_applicable",
+      "categories": [
+        "terminal"
+      ],
+      "tokenkey_status": "not_applicable",
+      "rationale": "Client-side claude-code concern (terminal); not a gateway/relay relevance signal.",
+      "updated_at": "2026-05-31T10:41:19Z"
+    },
+    {
+      "upstream": "anthropics/claude-code#59559",
+      "url": "https://github.com/anthropics/claude-code/issues/59559",
+      "title": "[BUG] Claude Code Hangs and Thinks Longer on Godot Specific Projects",
+      "impact": "not_applicable",
+      "categories": [
+        "ide",
+        "terminal",
+        "platform"
+      ],
+      "tokenkey_status": "not_applicable",
+      "rationale": "Client-side claude-code concern (ide, terminal, platform); not a gateway/relay relevance signal.",
+      "updated_at": "2026-06-01T12:01:55Z"
+    },
+    {
+      "upstream": "anthropics/claude-code#59562",
+      "url": "https://github.com/anthropics/claude-code/issues/59562",
+      "title": "[BUG] /rename command is self-defeating",
+      "impact": "not_applicable",
+      "categories": [
+        "terminal"
+      ],
+      "tokenkey_status": "not_applicable",
+      "rationale": "Client-side claude-code concern (terminal); not a gateway/relay relevance signal.",
+      "updated_at": "2026-06-01T12:01:56Z"
+    },
+    {
+      "upstream": "anthropics/claude-code#59565",
+      "url": "https://github.com/anthropics/claude-code/issues/59565",
+      "title": "Expose /remote-control-style session bridging as a local-only transport",
+      "impact": "not_applicable",
+      "categories": [
+        "slash_hook"
+      ],
+      "tokenkey_status": "not_applicable",
+      "rationale": "Client-side claude-code concern (slash_hook); not a gateway/relay relevance signal.",
+      "updated_at": "2026-05-31T10:41:44Z"
+    },
+    {
+      "upstream": "anthropics/claude-code#59567",
+      "url": "https://github.com/anthropics/claude-code/issues/59567",
+      "title": "[BUG] Edit tool writes to a sibling worktree's copy of a file (silent), instead of the cwd worktree, when both checkouts have the same tracked path",
+      "impact": "not_applicable",
+      "categories": [
+        "terminal"
+      ],
+      "tokenkey_status": "not_applicable",
+      "rationale": "Client-side claude-code concern (terminal); not a gateway/relay relevance signal.",
+      "updated_at": "2026-06-01T12:01:58Z"
+    },
+    {
+      "upstream": "anthropics/claude-code#59574",
+      "url": "https://github.com/anthropics/claude-code/issues/59574",
+      "title": "[BUG] Latest claude.code version (2.1.142) is massively degraded in (tokens per context/memory(recovery)/inference/etc.)",
+      "impact": "not_applicable",
+      "categories": [
+        "terminal",
+        "mcp",
+        "platform"
+      ],
+      "tokenkey_status": "not_applicable",
+      "rationale": "Client-side claude-code concern (terminal, mcp, platform); not a gateway/relay relevance signal.",
+      "updated_at": "2026-06-01T12:02:00Z"
+    },
+    {
+      "upstream": "anthropics/claude-code#59577",
+      "url": "https://github.com/anthropics/claude-code/issues/59577",
+      "title": "[BUG] Permission-suggestion UI generates malformed rule (unclosed quote) for git commit heredoc patterns; sometimes crashes the dialog",
+      "impact": "not_applicable",
+      "categories": [
+        "ide",
+        "terminal"
+      ],
+      "tokenkey_status": "not_applicable",
+      "rationale": "Client-side claude-code concern (ide, terminal); not a gateway/relay relevance signal.",
+      "updated_at": "2026-05-31T10:41:27Z"
+    },
+    {
+      "upstream": "anthropics/claude-code#59579",
+      "url": "https://github.com/anthropics/claude-code/issues/59579",
+      "title": "[DOCS] `/plugin` marketplace browse pane projected context cost estimates are undocumented",
+      "impact": "not_applicable",
+      "categories": [
+        "mcp",
+        "plugin"
+      ],
+      "tokenkey_status": "not_applicable",
+      "rationale": "Client-side claude-code concern (mcp, plugin); not a gateway/relay relevance signal.",
+      "updated_at": "2026-06-01T01:05:30Z"
+    },
+    {
+      "upstream": "anthropics/claude-code#59584",
+      "url": "https://github.com/anthropics/claude-code/issues/59584",
+      "title": "[DOCS] `/goal` docs do not explain evaluator waits for background shells or delegated subagents",
+      "impact": "not_applicable",
+      "categories": [
+        "plugin",
+        "slash_hook"
+      ],
+      "tokenkey_status": "not_applicable",
+      "rationale": "Client-side claude-code concern (plugin, slash_hook); not a gateway/relay relevance signal.",
+      "updated_at": "2026-06-01T01:04:55Z"
+    },
+    {
+      "upstream": "anthropics/claude-code#59588",
+      "url": "https://github.com/anthropics/claude-code/issues/59588",
+      "title": "[DOCS] PowerShell tool docs still describe opt-in rollout instead of default-enable behavior for Bedrock, Vertex, and Foundry on Windows",
+      "impact": "not_applicable",
+      "categories": [
+        "slash_hook",
+        "platform"
+      ],
+      "tokenkey_status": "not_applicable",
+      "rationale": "Client-side claude-code concern (slash_hook, platform); not a gateway/relay relevance signal.",
+      "updated_at": "2026-06-01T01:05:11Z"
+    },
+    {
+      "upstream": "anthropics/claude-code#59592",
+      "url": "https://github.com/anthropics/claude-code/issues/59592",
+      "title": "[DOCS] Background-session docs omit macOS Full Disk Access behavior for protected home folders",
+      "impact": "not_applicable",
+      "categories": [
+        "terminal",
+        "mcp",
+        "plugin"
+      ],
+      "tokenkey_status": "not_applicable",
+      "rationale": "Client-side claude-code concern (terminal, mcp, plugin); not a gateway/relay relevance signal.",
+      "updated_at": "2026-06-01T01:32:47Z"
+    },
+    {
+      "upstream": "anthropics/claude-code#59595",
+      "url": "https://github.com/anthropics/claude-code/issues/59595",
+      "title": "[DOCS] `/bg` and `←` detach docs omit `--allow-dangerously-skip-permissions` preservation for backgrounded sessions",
+      "impact": "not_applicable",
+      "categories": [
+        "plugin"
+      ],
+      "tokenkey_status": "not_applicable",
+      "rationale": "Client-side claude-code concern (plugin); not a gateway/relay relevance signal.",
+      "updated_at": "2026-06-01T01:04:23Z"
+    },
+    {
+      "upstream": "anthropics/claude-code#59600",
+      "url": "https://github.com/anthropics/claude-code/issues/59600",
+      "title": "[BUG] VSCode webview crash \"Error rendering content: disposing of store\" — AggregateError from DisposableStore during long agent sessions",
+      "impact": "not_applicable",
+      "categories": [
+        "ide",
+        "terminal"
+      ],
+      "tokenkey_status": "not_applicable",
+      "rationale": "Client-side claude-code concern (ide, terminal); not a gateway/relay relevance signal.",
+      "updated_at": "2026-05-31T10:41:30Z"
+    },
+    {
+      "upstream": "anthropics/claude-code#59605",
+      "url": "https://github.com/anthropics/claude-code/issues/59605",
+      "title": "[BUG] Cowork never installed — MSIX stuck Claude_1.6608.2.0_x64__pzs8sxrjxfjjc, all user-side fixes exhausted (relates to #25162, #49917)",
+      "impact": "not_applicable",
+      "categories": [
+        "terminal",
+        "install",
+        "platform"
+      ],
+      "tokenkey_status": "not_applicable",
+      "rationale": "Client-side claude-code concern (terminal, install, platform); not a gateway/relay relevance signal.",
+      "updated_at": "2026-05-31T10:41:32Z"
+    },
+    {
+      "upstream": "anthropics/claude-code#59608",
+      "url": "https://github.com/anthropics/claude-code/issues/59608",
+      "title": "macOS TCC prompt shows version number (\"2.1.143\") instead of \"Claude Code\" and re-prompts on every update",
+      "impact": "not_applicable",
+      "categories": [
+        "terminal",
+        "install"
+      ],
+      "tokenkey_status": "not_applicable",
+      "rationale": "Client-side claude-code concern (terminal, install); not a gateway/relay relevance signal.",
+      "updated_at": "2026-05-31T10:41:34Z"
+    },
+    {
+      "upstream": "anthropics/claude-code#59611",
+      "url": "https://github.com/anthropics/claude-code/issues/59611",
+      "title": "[IDE Extension] Agents panel exit causes focus trap — UI becomes unselectable",
+      "impact": "not_applicable",
+      "categories": [
+        "ide",
+        "platform"
+      ],
+      "tokenkey_status": "not_applicable",
+      "rationale": "Client-side claude-code concern (ide, platform); not a gateway/relay relevance signal.",
+      "updated_at": "2026-05-31T10:41:36Z"
+    },
+    {
+      "upstream": "anthropics/claude-code#59614",
+      "url": "https://github.com/anthropics/claude-code/issues/59614",
+      "title": "[BUG] [Claude Desktop] Stopping Command Crash Zsh",
+      "impact": "not_applicable",
+      "categories": [
+        "terminal"
+      ],
+      "tokenkey_status": "not_applicable",
+      "rationale": "Client-side claude-code concern (terminal); not a gateway/relay relevance signal.",
+      "updated_at": "2026-05-31T10:41:38Z"
+    },
+    {
+      "upstream": "anthropics/claude-code#59622",
+      "url": "https://github.com/anthropics/claude-code/issues/59622",
+      "title": "[BUG] Bash tool and SessionStart hooks fail with EEXIST on Windows due to non-idempotent mkdir of session-env",
+      "impact": "not_applicable",
+      "categories": [
+        "ide",
+        "terminal",
+        "plugin",
+        "slash_hook",
+        "install",
+        "platform"
+      ],
+      "tokenkey_status": "not_applicable",
+      "rationale": "Client-side claude-code concern (ide, terminal, plugin, slash_hook, install, platform); not a gateway/relay relevance signal.",
+      "updated_at": "2026-05-31T10:41:47Z"
+    },
+    {
+      "upstream": "anthropics/claude-code#59627",
+      "url": "https://github.com/anthropics/claude-code/issues/59627",
+      "title": "[BUG] agent thinking work lost when hitting limit",
+      "impact": "not_applicable",
+      "categories": [
+        "terminal",
+        "plugin"
+      ],
+      "tokenkey_status": "not_applicable",
+      "rationale": "Client-side claude-code concern (terminal, plugin); not a gateway/relay relevance signal.",
+      "updated_at": "2026-05-31T10:41:43Z"
+    },
+    {
+      "upstream": "anthropics/claude-code#59628",
+      "url": "https://github.com/anthropics/claude-code/issues/59628",
+      "title": "Worktree sessions can edit files in the parent main checkout with no guardrail",
+      "impact": "not_applicable",
+      "categories": [
+        "slash_hook",
+        "platform"
+      ],
+      "tokenkey_status": "not_applicable",
+      "rationale": "Client-side claude-code concern (slash_hook, platform); not a gateway/relay relevance signal.",
+      "updated_at": "2026-06-03T02:51:57Z"
+    },
+    {
+      "upstream": "anthropics/claude-code#59633",
+      "url": "https://github.com/anthropics/claude-code/issues/59633",
+      "title": "Transcript view (Ctrl+O) does not respond to scroll keys",
+      "impact": "not_applicable",
+      "categories": [
+        "terminal",
+        "slash_hook",
+        "install"
+      ],
+      "tokenkey_status": "not_applicable",
+      "rationale": "Client-side claude-code concern (terminal, slash_hook, install); not a gateway/relay relevance signal.",
+      "updated_at": "2026-05-31T10:41:48Z"
+    },
+    {
+      "upstream": "anthropics/claude-code#59647",
+      "url": "https://github.com/anthropics/claude-code/issues/59647",
+      "title": "[BUG] PR status badge is shown in every session's composer, not only the session that created the PR",
+      "impact": "not_applicable",
+      "categories": [
+        "terminal"
+      ],
+      "tokenkey_status": "not_applicable",
+      "rationale": "Client-side claude-code concern (terminal); not a gateway/relay relevance signal.",
+      "updated_at": "2026-05-31T10:41:51Z"
+    },
+    {
+      "upstream": "anthropics/claude-code#59654",
+      "url": "https://github.com/anthropics/claude-code/issues/59654",
+      "title": "[BUG] (shell) git bash in claude code desktop app windows",
+      "impact": "not_applicable",
+      "categories": [
+        "terminal",
+        "slash_hook",
+        "platform"
+      ],
+      "tokenkey_status": "not_applicable",
+      "rationale": "Client-side claude-code concern (terminal, slash_hook, platform); not a gateway/relay relevance signal.",
+      "updated_at": "2026-05-31T10:41:55Z"
+    },
+    {
+      "upstream": "anthropics/claude-code#59655",
+      "url": "https://github.com/anthropics/claude-code/issues/59655",
+      "title": "[FEATURE] config git bash in ui",
+      "impact": "not_applicable",
+      "categories": [
+        "terminal",
+        "slash_hook",
+        "platform"
+      ],
+      "tokenkey_status": "not_applicable",
+      "rationale": "Client-side claude-code concern (terminal, slash_hook, platform); not a gateway/relay relevance signal.",
+      "updated_at": "2026-05-31T10:41:54Z"
+    },
+    {
+      "upstream": "anthropics/claude-code#59656",
+      "url": "https://github.com/anthropics/claude-code/issues/59656",
+      "title": "[BUG] Max user, Claude unusable 3x issues - 1. 1M context error 2. repeated auto compaction after 1/2 messages 3. Single word prompt \"too long\"",
+      "impact": "not_applicable",
+      "categories": [
+        "ide",
+        "terminal"
+      ],
+      "tokenkey_status": "not_applicable",
+      "rationale": "Client-side claude-code concern (ide, terminal); not a gateway/relay relevance signal.",
+      "updated_at": "2026-06-01T12:02:27Z"
+    },
+    {
+      "upstream": "anthropics/claude-code#59661",
+      "url": "https://github.com/anthropics/claude-code/issues/59661",
+      "title": "Alt+V image paste broken on Windows (regression — accessibility impact for eye-gaze-only users)",
+      "impact": "not_applicable",
+      "categories": [
+        "terminal",
+        "plugin",
+        "slash_hook",
+        "platform"
+      ],
+      "tokenkey_status": "not_applicable",
+      "rationale": "Client-side claude-code concern (terminal, plugin, slash_hook, platform); not a gateway/relay relevance signal.",
+      "updated_at": "2026-06-01T12:02:29Z"
+    },
+    {
+      "upstream": "anthropics/claude-code#59664",
+      "url": "https://github.com/anthropics/claude-code/issues/59664",
+      "title": "[Bug] macOS incompatible `head -n` command destroyed production database manifests",
+      "impact": "not_applicable",
+      "categories": [
+        "ide",
+        "terminal"
+      ],
+      "tokenkey_status": "not_applicable",
+      "rationale": "Client-side claude-code concern (ide, terminal); not a gateway/relay relevance signal.",
+      "updated_at": "2026-05-31T10:41:56Z"
+    },
+    {
+      "upstream": "anthropics/claude-code#59667",
+      "url": "https://github.com/anthropics/claude-code/issues/59667",
+      "title": "[BUG] Claude incorrectly claims except A, B: is a SyntaxError in Python",
+      "impact": "not_applicable",
+      "categories": [
+        "ide",
+        "terminal",
+        "platform"
+      ],
+      "tokenkey_status": "not_applicable",
+      "rationale": "Client-side claude-code concern (ide, terminal, platform); not a gateway/relay relevance signal.",
+      "updated_at": "2026-05-31T10:41:57Z"
+    },
+    {
+      "upstream": "anthropics/claude-code#59670",
+      "url": "https://github.com/anthropics/claude-code/issues/59670",
+      "title": "[BUG] Conversation fade-gradient overlays the vertical scrollbar in the VSCode extension",
+      "impact": "not_applicable",
+      "categories": [
+        "ide",
+        "terminal"
+      ],
+      "tokenkey_status": "not_applicable",
+      "rationale": "Client-side claude-code concern (ide, terminal); not a gateway/relay relevance signal.",
+      "updated_at": "2026-06-01T12:02:06Z"
+    },
+    {
+      "upstream": "anthropics/claude-code#59672",
+      "url": "https://github.com/anthropics/claude-code/issues/59672",
+      "title": "[BUG] Windows VS Code terminal output becomes garbled (CJK-looking glyphs) after ~60–90 minutes of session",
+      "impact": "not_applicable",
+      "categories": [
+        "ide",
+        "terminal",
+        "platform"
+      ],
+      "tokenkey_status": "not_applicable",
+      "rationale": "Client-side claude-code concern (ide, terminal, platform); not a gateway/relay relevance signal.",
+      "updated_at": "2026-06-01T22:45:31Z"
+    },
+    {
+      "upstream": "anthropics/claude-code#59675",
+      "url": "https://github.com/anthropics/claude-code/issues/59675",
+      "title": "Feature Request: A7A (I OBJECT!) and MEH (Close But No Cigar) — Two AI Accountability Buttons",
+      "impact": "not_applicable",
+      "categories": [
+        "slash_hook"
+      ],
+      "tokenkey_status": "not_applicable",
+      "rationale": "Client-side claude-code concern (slash_hook); not a gateway/relay relevance signal.",
+      "updated_at": "2026-06-01T12:02:08Z"
+    },
+    {
+      "upstream": "anthropics/claude-code#59676",
+      "url": "https://github.com/anthropics/claude-code/issues/59676",
+      "title": "Feature Request: A7A (I OBJECT!) and MEH (Close But No Cigar) — Two AI Accountability Buttons",
+      "impact": "not_applicable",
+      "categories": [
+        "slash_hook"
+      ],
+      "tokenkey_status": "not_applicable",
+      "rationale": "Client-side claude-code concern (slash_hook); not a gateway/relay relevance signal.",
+      "updated_at": "2026-06-01T12:02:09Z"
+    },
+    {
+      "upstream": "anthropics/claude-code#59683",
+      "url": "https://github.com/anthropics/claude-code/issues/59683",
+      "title": "[FEATURE] Files panel (macOS Desktop): render symlinked directories as expandable folders",
+      "impact": "not_applicable",
+      "categories": [
+        "ide",
+        "terminal",
+        "platform"
+      ],
+      "tokenkey_status": "not_applicable",
+      "rationale": "Client-side claude-code concern (ide, terminal, platform); not a gateway/relay relevance signal.",
+      "updated_at": "2026-06-01T22:45:03Z"
+    },
+    {
+      "upstream": "anthropics/claude-code#59685",
+      "url": "https://github.com/anthropics/claude-code/issues/59685",
+      "title": "[BUG] Broken access control",
+      "impact": "not_applicable",
+      "categories": [
+        "ide",
+        "terminal"
+      ],
+      "tokenkey_status": "not_applicable",
+      "rationale": "Client-side claude-code concern (ide, terminal); not a gateway/relay relevance signal.",
+      "updated_at": "2026-06-01T12:03:22Z"
+    },
+    {
+      "upstream": "anthropics/claude-code#59686",
+      "url": "https://github.com/anthropics/claude-code/issues/59686",
+      "title": "[Bug] Duplicate options displayed in command completion menu",
+      "impact": "not_applicable",
+      "categories": [
+        "ide",
+        "terminal"
+      ],
+      "tokenkey_status": "not_applicable",
+      "rationale": "Client-side claude-code concern (ide, terminal); not a gateway/relay relevance signal.",
+      "updated_at": "2026-06-01T22:45:07Z"
+    },
+    {
+      "upstream": "anthropics/claude-code#59693",
+      "url": "https://github.com/anthropics/claude-code/issues/59693",
+      "title": "[Feature Request] Support for alternative LLM providers beyond Anthropic Claude models",
+      "impact": "not_applicable",
+      "categories": [
+        "terminal"
+      ],
+      "tokenkey_status": "not_applicable",
+      "rationale": "Client-side claude-code concern (terminal); not a gateway/relay relevance signal.",
+      "updated_at": "2026-06-01T22:45:09Z"
+    },
+    {
+      "upstream": "anthropics/claude-code#59698",
+      "url": "https://github.com/anthropics/claude-code/issues/59698",
+      "title": "[Bug] Vim motion h/l not supported for effort selection in /model command",
+      "impact": "not_applicable",
+      "categories": [
+        "terminal"
+      ],
+      "tokenkey_status": "not_applicable",
+      "rationale": "Client-side claude-code concern (terminal); not a gateway/relay relevance signal.",
+      "updated_at": "2026-06-01T12:02:14Z"
+    },
+    {
+      "upstream": "anthropics/claude-code#59704",
+      "url": "https://github.com/anthropics/claude-code/issues/59704",
+      "title": "Expose per-session/bg-job state visually in the terminal (extend agent-view color cues to split panes)",
+      "impact": "not_applicable",
+      "categories": [
+        "terminal",
+        "slash_hook"
+      ],
+      "tokenkey_status": "not_applicable",
+      "rationale": "Client-side claude-code concern (terminal, slash_hook); not a gateway/relay relevance signal.",
+      "updated_at": "2026-06-01T12:02:17Z"
+    },
+    {
+      "upstream": "anthropics/claude-code#59706",
+      "url": "https://github.com/anthropics/claude-code/issues/59706",
+      "title": "Community Workaround for #22903 — CDP Connector gives Claude browser eyes/hands today",
+      "impact": "not_applicable",
+      "categories": [
+        "platform"
+      ],
+      "tokenkey_status": "not_applicable",
+      "rationale": "Client-side claude-code concern (platform); not a gateway/relay relevance signal.",
+      "updated_at": "2026-06-01T12:02:19Z"
+    },
+    {
+      "upstream": "anthropics/claude-code#59709",
+      "url": "https://github.com/anthropics/claude-code/issues/59709",
+      "title": "[FEATURE] Expose Claude Max plan usage quota in statusline JSON",
+      "impact": "not_applicable",
+      "categories": [
+        "terminal"
+      ],
+      "tokenkey_status": "not_applicable",
+      "rationale": "Client-side claude-code concern (terminal); not a gateway/relay relevance signal.",
+      "updated_at": "2026-06-01T12:03:19Z"
+    },
+    {
+      "upstream": "anthropics/claude-code#59710",
+      "url": "https://github.com/anthropics/claude-code/issues/59710",
+      "title": "Slack MCP Connector: Add support for mark-as-read (conversations.mark)",
+      "impact": "not_applicable",
+      "categories": [
+        "mcp"
+      ],
+      "tokenkey_status": "not_applicable",
+      "rationale": "Client-side claude-code concern (mcp); not a gateway/relay relevance signal.",
+      "updated_at": "2026-06-01T12:02:21Z"
+    },
+    {
+      "upstream": "anthropics/claude-code#59713",
+      "url": "https://github.com/anthropics/claude-code/issues/59713",
+      "title": "Plugin hooks: CLAUDE_PLUGIN_ROOT not injected into hook subprocess environment",
+      "impact": "not_applicable",
+      "categories": [
+        "plugin",
+        "slash_hook",
+        "platform"
+      ],
+      "tokenkey_status": "not_applicable",
+      "rationale": "Client-side claude-code concern (plugin, slash_hook, platform); not a gateway/relay relevance signal.",
+      "updated_at": "2026-06-02T22:44:29Z"
+    },
+    {
+      "upstream": "anthropics/claude-code#59717",
+      "url": "https://github.com/anthropics/claude-code/issues/59717",
+      "title": "[Bug] Claude Code creates single Agent instead of Team when explicitly requested",
+      "impact": "not_applicable",
+      "categories": [
+        "terminal",
+        "slash_hook"
+      ],
+      "tokenkey_status": "not_applicable",
+      "rationale": "Client-side claude-code concern (terminal, slash_hook); not a gateway/relay relevance signal.",
+      "updated_at": "2026-06-01T12:03:09Z"
+    },
+    {
+      "upstream": "anthropics/claude-code#59723",
+      "url": "https://github.com/anthropics/claude-code/issues/59723",
+      "title": "Chrome MCP returns `permission_required` with no UI to approve domain",
+      "impact": "not_applicable",
+      "categories": [
+        "ide",
+        "mcp"
+      ],
+      "tokenkey_status": "not_applicable",
+      "rationale": "Client-side claude-code concern (ide, mcp); not a gateway/relay relevance signal.",
+      "updated_at": "2026-05-31T19:35:21Z"
+    },
+    {
+      "upstream": "anthropics/claude-code#59726",
+      "url": "https://github.com/anthropics/claude-code/issues/59726",
+      "title": "[BUG] ENAMETOOLONG creating ~/.claude/projects/ when cwd is long (eCryptfs NAME_MAX=143); reproduces via Claude Desktop cowork bootstrap",
+      "impact": "not_applicable",
+      "categories": [
+        "install"
+      ],
+      "tokenkey_status": "not_applicable",
+      "rationale": "Client-side claude-code concern (install); not a gateway/relay relevance signal.",
+      "updated_at": "2026-06-01T12:02:28Z"
+    },
+    {
+      "upstream": "anthropics/claude-code#59735",
+      "url": "https://github.com/anthropics/claude-code/issues/59735",
+      "title": "[Bug] Diff view text unreadable on light terminal backgrounds without theme configuration",
+      "impact": "not_applicable",
+      "categories": [
+        "terminal",
+        "slash_hook"
+      ],
+      "tokenkey_status": "not_applicable",
+      "rationale": "Client-side claude-code concern (terminal, slash_hook); not a gateway/relay relevance signal.",
+      "updated_at": "2026-06-01T12:02:30Z"
+    },
+    {
+      "upstream": "anthropics/claude-code#59736",
+      "url": "https://github.com/anthropics/claude-code/issues/59736",
+      "title": "Desktop 3p Code sessions disappear from UI after restart while JSONL transcripts remain on disk",
+      "impact": "not_applicable",
+      "categories": [
+        "ide",
+        "platform"
+      ],
+      "tokenkey_status": "not_applicable",
+      "rationale": "Client-side claude-code concern (ide, platform); not a gateway/relay relevance signal.",
+      "updated_at": "2026-06-01T23:14:19Z"
+    },
+    {
+      "upstream": "anthropics/claude-code#59737",
+      "url": "https://github.com/anthropics/claude-code/issues/59737",
+      "title": "[Bug] Claude Code ignores $COLORTERM=truecolor in foot terminal, downgrades to 16-color",
+      "impact": "not_applicable",
+      "categories": [
+        "terminal",
+        "install"
+      ],
+      "tokenkey_status": "not_applicable",
+      "rationale": "Client-side claude-code concern (terminal, install); not a gateway/relay relevance signal.",
+      "updated_at": "2026-06-01T12:02:31Z"
+    },
+    {
+      "upstream": "anthropics/claude-code#59740",
+      "url": "https://github.com/anthropics/claude-code/issues/59740",
+      "title": "[FEATURE] Allow users to manually dismiss \"Needs input\" state in Claude Code Desktop",
+      "impact": "not_applicable",
+      "categories": [
+        "terminal"
+      ],
+      "tokenkey_status": "not_applicable",
+      "rationale": "Client-side claude-code concern (terminal); not a gateway/relay relevance signal.",
+      "updated_at": "2026-06-01T12:02:32Z"
+    },
+    {
+      "upstream": "anthropics/claude-code#59741",
+      "url": "https://github.com/anthropics/claude-code/issues/59741",
+      "title": "Drag & Drop: Drop indicator desynchronizes from cursor position when scrolling during drag",
+      "impact": "not_applicable",
+      "categories": [
+        "terminal",
+        "platform"
+      ],
+      "tokenkey_status": "not_applicable",
+      "rationale": "Client-side claude-code concern (terminal, platform); not a gateway/relay relevance signal.",
+      "updated_at": "2026-06-01T22:45:28Z"
+    },
+    {
+      "upstream": "anthropics/claude-code#59747",
+      "url": "https://github.com/anthropics/claude-code/issues/59747",
+      "title": "[Bug] Anthropic API Error: 500 Internal Server Error",
+      "impact": "not_applicable",
+      "categories": [
+        "terminal"
+      ],
+      "tokenkey_status": "not_applicable",
+      "rationale": "Client-side claude-code concern (terminal); not a gateway/relay relevance signal.",
+      "updated_at": "2026-06-01T12:02:35Z"
+    },
+    {
+      "upstream": "anthropics/claude-code#59748",
+      "url": "https://github.com/anthropics/claude-code/issues/59748",
+      "title": "[BUG] API Error: 500 Internal server error.",
+      "impact": "not_applicable",
+      "categories": [
+        "terminal"
+      ],
+      "tokenkey_status": "not_applicable",
+      "rationale": "Client-side claude-code concern (terminal); not a gateway/relay relevance signal.",
+      "updated_at": "2026-06-01T12:02:52Z"
+    },
+    {
+      "upstream": "anthropics/claude-code#59749",
+      "url": "https://github.com/anthropics/claude-code/issues/59749",
+      "title": "[Bug] Claude Code desktop app on macOS not accepting prompt input",
+      "impact": "not_applicable",
+      "categories": [
+        "terminal"
+      ],
+      "tokenkey_status": "not_applicable",
+      "rationale": "Client-side claude-code concern (terminal); not a gateway/relay relevance signal.",
+      "updated_at": "2026-06-01T12:02:36Z"
+    },
+    {
+      "upstream": "anthropics/claude-code#59751",
+      "url": "https://github.com/anthropics/claude-code/issues/59751",
+      "title": "[Bug] Anthropic API Error: 500 Internal Server Error",
+      "impact": "not_applicable",
+      "categories": [
+        "terminal"
+      ],
+      "tokenkey_status": "not_applicable",
+      "rationale": "Client-side claude-code concern (terminal); not a gateway/relay relevance signal.",
+      "updated_at": "2026-06-01T12:02:37Z"
+    },
+    {
+      "upstream": "anthropics/claude-code#59752",
+      "url": "https://github.com/anthropics/claude-code/issues/59752",
+      "title": "[Bug] Anthropic API Error: High 500 error rate on requests",
+      "impact": "not_applicable",
+      "categories": [
+        "terminal"
+      ],
+      "tokenkey_status": "not_applicable",
+      "rationale": "Client-side claude-code concern (terminal); not a gateway/relay relevance signal.",
+      "updated_at": "2026-06-01T12:02:38Z"
+    },
+    {
+      "upstream": "anthropics/claude-code#59753",
+      "url": "https://github.com/anthropics/claude-code/issues/59753",
+      "title": "[Bug] Anthropic API Error: 500 Internal Server Error",
+      "impact": "not_applicable",
+      "categories": [
+        "ide",
+        "terminal"
+      ],
+      "tokenkey_status": "not_applicable",
+      "rationale": "Client-side claude-code concern (ide, terminal); not a gateway/relay relevance signal.",
+      "updated_at": "2026-06-01T12:02:50Z"
+    },
+    {
+      "upstream": "anthropics/claude-code#59755",
+      "url": "https://github.com/anthropics/claude-code/issues/59755",
+      "title": "[Bug] Anthropic API Error: 500 Internal Server Error",
+      "impact": "not_applicable",
+      "categories": [
+        "terminal"
+      ],
+      "tokenkey_status": "not_applicable",
+      "rationale": "Client-side claude-code concern (terminal); not a gateway/relay relevance signal.",
+      "updated_at": "2026-06-01T12:02:39Z"
+    },
+    {
+      "upstream": "anthropics/claude-code#59756",
+      "url": "https://github.com/anthropics/claude-code/issues/59756",
+      "title": "[Bug] Anthropic API Error: 500 Internal Server Error",
+      "impact": "not_applicable",
+      "categories": [
+        "terminal"
+      ],
+      "tokenkey_status": "not_applicable",
+      "rationale": "Client-side claude-code concern (terminal); not a gateway/relay relevance signal.",
+      "updated_at": "2026-06-01T12:02:40Z"
+    },
+    {
+      "upstream": "anthropics/claude-code#59758",
+      "url": "https://github.com/anthropics/claude-code/issues/59758",
+      "title": "[Bug] Anthropic API Error: 500 Internal Server Error",
+      "impact": "not_applicable",
+      "categories": [
+        "terminal"
+      ],
+      "tokenkey_status": "not_applicable",
+      "rationale": "Client-side claude-code concern (terminal); not a gateway/relay relevance signal.",
+      "updated_at": "2026-06-01T12:02:41Z"
+    },
+    {
+      "upstream": "anthropics/claude-code#59759",
+      "url": "https://github.com/anthropics/claude-code/issues/59759",
+      "title": "[Bug] Anthropic API Error: 500 Internal Server Error occurring frequently",
+      "impact": "not_applicable",
+      "categories": [
+        "terminal"
+      ],
+      "tokenkey_status": "not_applicable",
+      "rationale": "Client-side claude-code concern (terminal); not a gateway/relay relevance signal.",
+      "updated_at": "2026-06-01T12:03:01Z"
+    },
+    {
+      "upstream": "anthropics/claude-code#59760",
+      "url": "https://github.com/anthropics/claude-code/issues/59760",
+      "title": "[Bug] Anthropic API Error: 500 Internal Server Error",
+      "impact": "not_applicable",
+      "categories": [
+        "ide",
+        "terminal"
+      ],
+      "tokenkey_status": "not_applicable",
+      "rationale": "Client-side claude-code concern (ide, terminal); not a gateway/relay relevance signal.",
+      "updated_at": "2026-06-01T12:02:42Z"
+    },
+    {
+      "upstream": "anthropics/claude-code#59761",
+      "url": "https://github.com/anthropics/claude-code/issues/59761",
+      "title": "[Bug] Anthropic API Error: 500 Internal Server Error",
+      "impact": "not_applicable",
+      "categories": [
+        "terminal"
+      ],
+      "tokenkey_status": "not_applicable",
+      "rationale": "Client-side claude-code concern (terminal); not a gateway/relay relevance signal.",
+      "updated_at": "2026-06-01T12:02:43Z"
+    },
+    {
+      "upstream": "anthropics/claude-code#59762",
+      "url": "https://github.com/anthropics/claude-code/issues/59762",
+      "title": "[Bug] Anthropic API Error: 500 Internal Server Error",
+      "impact": "not_applicable",
+      "categories": [
+        "terminal"
+      ],
+      "tokenkey_status": "not_applicable",
+      "rationale": "Client-side claude-code concern (terminal); not a gateway/relay relevance signal.",
+      "updated_at": "2026-06-01T12:02:44Z"
+    },
+    {
+      "upstream": "anthropics/claude-code#59763",
+      "url": "https://github.com/anthropics/claude-code/issues/59763",
+      "title": "[Bug] Anthropic API Error: 500 Internal Server Error",
+      "impact": "not_applicable",
+      "categories": [
+        "terminal"
+      ],
+      "tokenkey_status": "not_applicable",
+      "rationale": "Client-side claude-code concern (terminal); not a gateway/relay relevance signal.",
+      "updated_at": "2026-06-01T12:02:45Z"
+    },
+    {
+      "upstream": "anthropics/claude-code#59764",
+      "url": "https://github.com/anthropics/claude-code/issues/59764",
+      "title": "[Bug] Anthropic API Error: Internal Server Error (500)",
+      "impact": "not_applicable",
+      "categories": [
+        "ide",
+        "terminal"
+      ],
+      "tokenkey_status": "not_applicable",
+      "rationale": "Client-side claude-code concern (ide, terminal); not a gateway/relay relevance signal.",
+      "updated_at": "2026-06-01T12:02:46Z"
+    },
+    {
+      "upstream": "anthropics/claude-code#59765",
+      "url": "https://github.com/anthropics/claude-code/issues/59765",
+      "title": "[Bug] Anthropic API Error: 500 Internal Server Error",
+      "impact": "not_applicable",
+      "categories": [
+        "terminal"
+      ],
+      "tokenkey_status": "not_applicable",
+      "rationale": "Client-side claude-code concern (terminal); not a gateway/relay relevance signal.",
+      "updated_at": "2026-06-01T12:02:47Z"
+    },
+    {
+      "upstream": "anthropics/claude-code#59766",
+      "url": "https://github.com/anthropics/claude-code/issues/59766",
+      "title": "[Bug] Anthropic API Error: 500 Internal Server Error",
+      "impact": "not_applicable",
+      "categories": [
+        "ide",
+        "terminal"
+      ],
+      "tokenkey_status": "not_applicable",
+      "rationale": "Client-side claude-code concern (ide, terminal); not a gateway/relay relevance signal.",
+      "updated_at": "2026-06-01T12:02:58Z"
+    },
+    {
+      "upstream": "anthropics/claude-code#59767",
+      "url": "https://github.com/anthropics/claude-code/issues/59767",
+      "title": "[Bug] Anthropic API Error: 500 Internal Server Error",
+      "impact": "not_applicable",
+      "categories": [
+        "terminal",
+        "platform"
+      ],
+      "tokenkey_status": "not_applicable",
+      "rationale": "Client-side claude-code concern (terminal, platform); not a gateway/relay relevance signal.",
+      "updated_at": "2026-06-01T12:02:57Z"
+    },
+    {
+      "upstream": "anthropics/claude-code#59768",
+      "url": "https://github.com/anthropics/claude-code/issues/59768",
+      "title": "[Bug] Anthropic API Error: Internal server error (500)",
+      "impact": "not_applicable",
+      "categories": [
+        "ide",
+        "terminal"
+      ],
+      "tokenkey_status": "not_applicable",
+      "rationale": "Client-side claude-code concern (ide, terminal); not a gateway/relay relevance signal.",
+      "updated_at": "2026-06-01T12:02:56Z"
+    },
+    {
+      "upstream": "anthropics/claude-code#59769",
+      "url": "https://github.com/anthropics/claude-code/issues/59769",
+      "title": "[Bug] Internal Server Error: HTTP 500 Response from Anthropic API",
+      "impact": "not_applicable",
+      "categories": [
+        "terminal",
+        "mcp",
+        "plugin",
+        "install"
+      ],
+      "tokenkey_status": "not_applicable",
+      "rationale": "Client-side claude-code concern (terminal, mcp, plugin, install); not a gateway/relay relevance signal.",
+      "updated_at": "2026-06-01T12:02:49Z"
+    },
+    {
+      "upstream": "anthropics/claude-code#59770",
+      "url": "https://github.com/anthropics/claude-code/issues/59770",
+      "title": "[Bug] Anthropic API Error: 500 Internal Server Error across all sessions",
+      "impact": "not_applicable",
+      "categories": [
+        "terminal"
+      ],
+      "tokenkey_status": "not_applicable",
+      "rationale": "Client-side claude-code concern (terminal); not a gateway/relay relevance signal.",
+      "updated_at": "2026-06-01T12:02:54Z"
+    },
+    {
+      "upstream": "anthropics/claude-code#59771",
+      "url": "https://github.com/anthropics/claude-code/issues/59771",
+      "title": "[Bug] Anthropic API Error: HTTP 500 Internal Server Error",
+      "impact": "not_applicable",
+      "categories": [
+        "terminal"
+      ],
+      "tokenkey_status": "not_applicable",
+      "rationale": "Client-side claude-code concern (terminal); not a gateway/relay relevance signal.",
+      "updated_at": "2026-06-01T12:02:51Z"
+    },
+    {
+      "upstream": "anthropics/claude-code#59772",
+      "url": "https://github.com/anthropics/claude-code/issues/59772",
+      "title": "[Bug] Anthropic API Error: 500 Internal Server Error",
+      "impact": "not_applicable",
+      "categories": [
+        "terminal"
+      ],
+      "tokenkey_status": "not_applicable",
+      "rationale": "Client-side claude-code concern (terminal); not a gateway/relay relevance signal.",
+      "updated_at": "2026-06-01T12:02:52Z"
+    },
+    {
+      "upstream": "anthropics/claude-code#59774",
+      "url": "https://github.com/anthropics/claude-code/issues/59774",
+      "title": "[Bug] Anthropic API Error: 500 Internal Server Error",
+      "impact": "not_applicable",
+      "categories": [
+        "terminal"
+      ],
+      "tokenkey_status": "not_applicable",
+      "rationale": "Client-side claude-code concern (terminal); not a gateway/relay relevance signal.",
+      "updated_at": "2026-06-01T12:02:53Z"
+    },
+    {
+      "upstream": "anthropics/claude-code#59775",
+      "url": "https://github.com/anthropics/claude-code/issues/59775",
+      "title": "[Bug] Anthropic API Error: 500 Internal Server Error",
+      "impact": "not_applicable",
+      "categories": [
+        "terminal"
+      ],
+      "tokenkey_status": "not_applicable",
+      "rationale": "Client-side claude-code concern (terminal); not a gateway/relay relevance signal.",
+      "updated_at": "2026-06-01T12:02:55Z"
+    },
+    {
+      "upstream": "anthropics/claude-code#59776",
+      "url": "https://github.com/anthropics/claude-code/issues/59776",
+      "title": "[Bug] Anthropic API Error: 500 Internal Server Error",
+      "impact": "not_applicable",
+      "categories": [
+        "terminal",
+        "mcp"
+      ],
+      "tokenkey_status": "not_applicable",
+      "rationale": "Client-side claude-code concern (terminal, mcp); not a gateway/relay relevance signal.",
+      "updated_at": "2026-06-01T12:02:58Z"
+    },
+    {
+      "upstream": "anthropics/claude-code#59778",
+      "url": "https://github.com/anthropics/claude-code/issues/59778",
+      "title": "[Bug] Anthropic API Error: 500 Internal Server Error",
+      "impact": "not_applicable",
+      "categories": [
+        "terminal"
+      ],
+      "tokenkey_status": "not_applicable",
+      "rationale": "Client-side claude-code concern (terminal); not a gateway/relay relevance signal.",
+      "updated_at": "2026-06-01T12:02:59Z"
+    },
+    {
+      "upstream": "anthropics/claude-code#59779",
+      "url": "https://github.com/anthropics/claude-code/issues/59779",
+      "title": "[Bug] Anthropic API Error: 500 Internal Server Error",
+      "impact": "not_applicable",
+      "categories": [
+        "terminal"
+      ],
+      "tokenkey_status": "not_applicable",
+      "rationale": "Client-side claude-code concern (terminal); not a gateway/relay relevance signal.",
+      "updated_at": "2026-06-01T12:03:00Z"
+    },
+    {
+      "upstream": "anthropics/claude-code#59781",
+      "url": "https://github.com/anthropics/claude-code/issues/59781",
+      "title": "[Bug] Anthropic API Error: 500 Internal Server Error",
+      "impact": "not_applicable",
+      "categories": [
+        "terminal"
+      ],
+      "tokenkey_status": "not_applicable",
+      "rationale": "Client-side claude-code concern (terminal); not a gateway/relay relevance signal.",
+      "updated_at": "2026-06-01T12:03:23Z"
+    },
+    {
+      "upstream": "anthropics/claude-code#59787",
+      "url": "https://github.com/anthropics/claude-code/issues/59787",
+      "title": "Harness silently truncates Write content at literal `<` character + drops bare `<parameter>` tags (XML-parser overreach on content payloads)",
+      "impact": "not_applicable",
+      "categories": [
+        "terminal",
+        "mcp"
+      ],
+      "tokenkey_status": "not_applicable",
+      "rationale": "Client-side claude-code concern (terminal, mcp); not a gateway/relay relevance signal.",
+      "updated_at": "2026-06-01T12:03:10Z"
+    },
+    {
+      "upstream": "anthropics/claude-code#59794",
+      "url": "https://github.com/anthropics/claude-code/issues/59794",
+      "title": "[BUG] Claude workspace VM fails silently after service crash — app never attempts to restart the Windows service",
+      "impact": "not_applicable",
+      "categories": [
+        "terminal",
+        "platform"
+      ],
+      "tokenkey_status": "not_applicable",
+      "rationale": "Client-side claude-code concern (terminal, platform); not a gateway/relay relevance signal.",
+      "updated_at": "2026-06-01T12:03:04Z"
+    },
+    {
+      "upstream": "anthropics/claude-code#59795",
+      "url": "https://github.com/anthropics/claude-code/issues/59795",
+      "title": "[Bug] bash: .claude/hooks/skill-instructions-hook.sh: No such file or directory",
+      "impact": "not_applicable",
+      "categories": [
+        "terminal",
+        "slash_hook"
+      ],
+      "tokenkey_status": "not_applicable",
+      "rationale": "Client-side claude-code concern (terminal, slash_hook); not a gateway/relay relevance signal.",
+      "updated_at": "2026-06-01T12:03:05Z"
+    },
+    {
+      "upstream": "anthropics/claude-code#59797",
+      "url": "https://github.com/anthropics/claude-code/issues/59797",
+      "title": "Single Click to copy last question and answer.",
+      "impact": "not_applicable",
+      "categories": [
+        "terminal"
+      ],
+      "tokenkey_status": "not_applicable",
+      "rationale": "Client-side claude-code concern (terminal); not a gateway/relay relevance signal.",
+      "updated_at": "2026-06-01T12:03:07Z"
+    },
+    {
+      "upstream": "anthropics/claude-code#59801",
+      "url": "https://github.com/anthropics/claude-code/issues/59801",
+      "title": "[BUG] fakechat MCP server silently drops all but the first file when multiple attachments are passed to reply tool",
+      "impact": "not_applicable",
+      "categories": [
+        "terminal",
+        "mcp",
+        "platform"
+      ],
+      "tokenkey_status": "not_applicable",
+      "rationale": "Client-side claude-code concern (terminal, mcp, platform); not a gateway/relay relevance signal.",
+      "updated_at": "2026-06-01T12:03:06Z"
+    },
+    {
+      "upstream": "anthropics/claude-code#59802",
+      "url": "https://github.com/anthropics/claude-code/issues/59802",
+      "title": "[BUG] Claude Desktop autostart entry crashes Windows 11 Settings > Apps > Startup (SettingsHandlers_Startup.dll 0xc0000005)",
+      "impact": "not_applicable",
+      "categories": [
+        "terminal",
+        "slash_hook",
+        "install",
+        "platform"
+      ],
+      "tokenkey_status": "not_applicable",
+      "rationale": "Client-side claude-code concern (terminal, slash_hook, install, platform); not a gateway/relay relevance signal.",
+      "updated_at": "2026-06-01T12:03:09Z"
+    },
+    {
+      "upstream": "anthropics/claude-code#59815",
+      "url": "https://github.com/anthropics/claude-code/issues/59815",
+      "title": "[BUG] Claude-code app window doesn't scroll to end of respons",
+      "impact": "not_applicable",
+      "categories": [
+        "terminal",
+        "platform"
+      ],
+      "tokenkey_status": "not_applicable",
+      "rationale": "Client-side claude-code concern (terminal, platform); not a gateway/relay relevance signal.",
+      "updated_at": "2026-06-01T12:03:15Z"
+    },
+    {
+      "upstream": "anthropics/claude-code#59826",
+      "url": "https://github.com/anthropics/claude-code/issues/59826",
+      "title": "Granting a permission from the VS Code extension requires hand-editing JSON",
+      "impact": "not_applicable",
+      "categories": [
+        "ide"
+      ],
+      "tokenkey_status": "not_applicable",
+      "rationale": "Client-side claude-code concern (ide); not a gateway/relay relevance signal.",
+      "updated_at": "2026-06-01T22:45:15Z"
+    },
+    {
+      "upstream": "anthropics/claude-code#59832",
+      "url": "https://github.com/anthropics/claude-code/issues/59832",
+      "title": "[Bug] Anthropic API Error: 500 Internal Server Error",
+      "impact": "not_applicable",
+      "categories": [
+        "ide",
+        "terminal"
+      ],
+      "tokenkey_status": "not_applicable",
+      "rationale": "Client-side claude-code concern (ide, terminal); not a gateway/relay relevance signal.",
+      "updated_at": "2026-06-01T12:03:19Z"
+    },
+    {
+      "upstream": "anthropics/claude-code#59834",
+      "url": "https://github.com/anthropics/claude-code/issues/59834",
+      "title": "Feature request: Unified session history sync across VS Code extension, desktop app, and CLI",
+      "impact": "not_applicable",
+      "categories": [
+        "ide",
+        "platform"
+      ],
+      "tokenkey_status": "not_applicable",
+      "rationale": "Client-side claude-code concern (ide, platform); not a gateway/relay relevance signal.",
+      "updated_at": "2026-06-01T12:03:20Z"
+    },
+    {
+      "upstream": "anthropics/claude-code#59835",
+      "url": "https://github.com/anthropics/claude-code/issues/59835",
+      "title": "MCP stdio servers using rmcp >= 0.2 show 'tools fetch failed' — client not sending initialized notification",
+      "impact": "not_applicable",
+      "categories": [
+        "mcp",
+        "install"
+      ],
+      "tokenkey_status": "not_applicable",
+      "rationale": "Client-side claude-code concern (mcp, install); not a gateway/relay relevance signal.",
+      "updated_at": "2026-06-01T12:03:24Z"
+    },
+    {
+      "upstream": "anthropics/claude-code#59837",
+      "url": "https://github.com/anthropics/claude-code/issues/59837",
+      "title": "[BUG] Cowork create_scheduled_task hangs silently 180s on Windows - regression in v1.7196.0",
+      "impact": "not_applicable",
+      "categories": [
+        "terminal",
+        "mcp",
+        "platform"
+      ],
+      "tokenkey_status": "not_applicable",
+      "rationale": "Client-side claude-code concern (terminal, mcp, platform); not a gateway/relay relevance signal.",
+      "updated_at": "2026-06-01T12:03:37Z"
+    },
+    {
+      "upstream": "anthropics/claude-code#59838",
+      "url": "https://github.com/anthropics/claude-code/issues/59838",
+      "title": "Agent Teams: allow per-teammate cwd and additional working directories (subsets of the lead's access) at spawn time",
+      "impact": "not_applicable",
+      "categories": [
+        "mcp",
+        "plugin",
+        "slash_hook"
+      ],
+      "tokenkey_status": "not_applicable",
+      "rationale": "Client-side claude-code concern (mcp, plugin, slash_hook); not a gateway/relay relevance signal.",
+      "updated_at": "2026-06-01T12:03:29Z"
+    },
+    {
+      "upstream": "anthropics/claude-code#59842",
+      "url": "https://github.com/anthropics/claude-code/issues/59842",
+      "title": "Compact display mode for tool calls (collapse Bash/Write to one-line summaries)",
+      "impact": "not_applicable",
+      "categories": [
+        "terminal",
+        "slash_hook"
+      ],
+      "tokenkey_status": "not_applicable",
+      "rationale": "Client-side claude-code concern (terminal, slash_hook); not a gateway/relay relevance signal.",
+      "updated_at": "2026-06-01T12:03:35Z"
+    },
+    {
+      "upstream": "anthropics/claude-code#59846",
+      "url": "https://github.com/anthropics/claude-code/issues/59846",
+      "title": "Naming feedback: \"agent view\" conflates with the existing \"agent\" concept",
+      "impact": "not_applicable",
+      "categories": [
+        "terminal",
+        "plugin"
+      ],
+      "tokenkey_status": "not_applicable",
+      "rationale": "Client-side claude-code concern (terminal, plugin); not a gateway/relay relevance signal.",
+      "updated_at": "2026-06-02T11:31:48Z"
+    },
+    {
+      "upstream": "anthropics/claude-code#59850",
+      "url": "https://github.com/anthropics/claude-code/issues/59850",
+      "title": "[BUG] Cowork archived conversations disappear permanently — no way to retrieve them",
+      "impact": "not_applicable",
+      "categories": [
+        "terminal",
+        "platform"
+      ],
+      "tokenkey_status": "not_applicable",
+      "rationale": "Client-side claude-code concern (terminal, platform); not a gateway/relay relevance signal.",
+      "updated_at": "2026-06-02T11:32:38Z"
+    },
+    {
+      "upstream": "anthropics/claude-code#59852",
+      "url": "https://github.com/anthropics/claude-code/issues/59852",
+      "title": "[Bug] Desktop hijacks mouse XButton1/XButton2 with no opt-out — accidentally switches active chat during normal use",
+      "impact": "not_applicable",
+      "categories": [
+        "terminal",
+        "slash_hook",
+        "platform"
+      ],
+      "tokenkey_status": "not_applicable",
+      "rationale": "Client-side claude-code concern (terminal, slash_hook, platform); not a gateway/relay relevance signal.",
+      "updated_at": "2026-06-01T12:03:36Z"
+    },
+    {
+      "upstream": "anthropics/claude-code#59853",
+      "url": "https://github.com/anthropics/claude-code/issues/59853",
+      "title": "VS Code: model picker collapsed row shows stale model name (Sonnet 4.6) when Default (Opus 4.7) is selected",
+      "impact": "not_applicable",
+      "categories": [
+        "ide"
+      ],
+      "tokenkey_status": "not_applicable",
+      "rationale": "Client-side claude-code concern (ide); not a gateway/relay relevance signal.",
+      "updated_at": "2026-06-01T12:03:40Z"
+    },
+    {
+      "upstream": "anthropics/claude-code#59855",
+      "url": "https://github.com/anthropics/claude-code/issues/59855",
+      "title": "Remote Control Android approvals do not unblock local Claude Code TUI (host stays Waiting)",
+      "impact": "not_applicable",
+      "categories": [
+        "terminal"
+      ],
+      "tokenkey_status": "not_applicable",
+      "rationale": "Client-side claude-code concern (terminal); not a gateway/relay relevance signal.",
+      "updated_at": "2026-06-01T11:39:09Z"
+    },
+    {
+      "upstream": "anthropics/claude-code#59860",
+      "url": "https://github.com/anthropics/claude-code/issues/59860",
+      "title": "[BUG] Long-running session degradation since v2.1.139, compounded by silent fast-mode model swap in v2.1.142 — no changelog, breaks pinned-model workflows, quantified waste",
+      "impact": "not_applicable",
+      "categories": [
+        "terminal"
+      ],
+      "tokenkey_status": "not_applicable",
+      "rationale": "Client-side claude-code concern (terminal); not a gateway/relay relevance signal.",
+      "updated_at": "2026-06-01T22:45:13Z"
+    },
+    {
+      "upstream": "anthropics/claude-code#59865",
+      "url": "https://github.com/anthropics/claude-code/issues/59865",
+      "title": "[BUG] Repeated violations of explicit rules in CLAUDE.md",
+      "impact": "not_applicable",
+      "categories": [
+        "terminal"
+      ],
+      "tokenkey_status": "not_applicable",
+      "rationale": "Client-side claude-code concern (terminal); not a gateway/relay relevance signal.",
+      "updated_at": "2026-06-01T22:45:14Z"
+    },
+    {
+      "upstream": "anthropics/claude-code#59868",
+      "url": "https://github.com/anthropics/claude-code/issues/59868",
+      "title": "Duplicate: VS Code model picker shows stale model name",
+      "impact": "not_applicable",
+      "categories": [
+        "ide",
+        "terminal"
+      ],
+      "tokenkey_status": "not_applicable",
+      "rationale": "Client-side claude-code concern (ide, terminal); not a gateway/relay relevance signal.",
+      "updated_at": "2026-06-01T22:45:16Z"
+    },
+    {
+      "upstream": "anthropics/claude-code#59874",
+      "url": "https://github.com/anthropics/claude-code/issues/59874",
+      "title": "VS Code model picker shows stale model name after selecting default model",
+      "impact": "not_applicable",
+      "categories": [
+        "ide",
+        "terminal"
+      ],
+      "tokenkey_status": "not_applicable",
+      "rationale": "Client-side claude-code concern (ide, terminal); not a gateway/relay relevance signal.",
+      "updated_at": "2026-06-01T22:45:18Z"
+    },
+    {
+      "upstream": "anthropics/claude-code#59877",
+      "url": "https://github.com/anthropics/claude-code/issues/59877",
+      "title": "[Feature Request] Add vim keybindings to agent navigation menu",
+      "impact": "not_applicable",
+      "categories": [
+        "terminal",
+        "slash_hook"
+      ],
+      "tokenkey_status": "not_applicable",
+      "rationale": "Client-side claude-code concern (terminal, slash_hook); not a gateway/relay relevance signal.",
+      "updated_at": "2026-06-01T22:45:19Z"
+    },
+    {
+      "upstream": "anthropics/claude-code#59878",
+      "url": "https://github.com/anthropics/claude-code/issues/59878",
+      "title": "[BUG] VIBE CODED STUPID ANTHROPIC USAGE POLICY FLAGS EVERYTHING FOR NO REASON",
+      "impact": "not_applicable",
+      "categories": [
+        "terminal",
+        "platform"
+      ],
+      "tokenkey_status": "not_applicable",
+      "rationale": "Client-side claude-code concern (terminal, platform); not a gateway/relay relevance signal.",
+      "updated_at": "2026-06-01T22:45:20Z"
+    },
+    {
+      "upstream": "anthropics/claude-code#59879",
+      "url": "https://github.com/anthropics/claude-code/issues/59879",
+      "title": "Testing issue classification boundaries",
+      "impact": "not_applicable",
+      "categories": [
+        "terminal"
+      ],
+      "tokenkey_status": "not_applicable",
+      "rationale": "Client-side claude-code concern (terminal); not a gateway/relay relevance signal.",
+      "updated_at": "2026-06-02T11:31:47Z"
+    },
+    {
+      "upstream": "anthropics/claude-code#59882",
+      "url": "https://github.com/anthropics/claude-code/issues/59882",
+      "title": "[Bug] Hallucination: WebFetch refuses verbatim retrieval of public source; only lossy, prompt-sensitive paraphrase available (no raw-content path)",
+      "impact": "not_applicable",
+      "categories": [
+        "terminal"
+      ],
+      "tokenkey_status": "not_applicable",
+      "rationale": "Client-side claude-code concern (terminal); not a gateway/relay relevance signal.",
+      "updated_at": "2026-06-02T11:32:01Z"
+    },
+    {
+      "upstream": "anthropics/claude-code#59890",
+      "url": "https://github.com/anthropics/claude-code/issues/59890",
+      "title": "Add message-count alert feature (20 messages per chat)",
+      "impact": "not_applicable",
+      "categories": [
+        "slash_hook"
+      ],
+      "tokenkey_status": "not_applicable",
+      "rationale": "Client-side claude-code concern (slash_hook); not a gateway/relay relevance signal.",
+      "updated_at": "2026-06-02T11:31:53Z"
+    },
+    {
+      "upstream": "anthropics/claude-code#59892",
+      "url": "https://github.com/anthropics/claude-code/issues/59892",
+      "title": "Remote Control sessions show in 'Other' instead of correct project folder in Desktop app",
+      "impact": "not_applicable",
+      "categories": [
+        "platform"
+      ],
+      "tokenkey_status": "not_applicable",
+      "rationale": "Client-side claude-code concern (platform); not a gateway/relay relevance signal.",
+      "updated_at": "2026-06-02T11:31:54Z"
+    },
+    {
+      "upstream": "anthropics/claude-code#59895",
+      "url": "https://github.com/anthropics/claude-code/issues/59895",
+      "title": "[FEATURE] Surface context-window usage in the Android app (and web app)",
+      "impact": "not_applicable",
+      "categories": [
+        "platform"
+      ],
+      "tokenkey_status": "not_applicable",
+      "rationale": "Client-side claude-code concern (platform); not a gateway/relay relevance signal.",
+      "updated_at": "2026-06-02T11:31:56Z"
+    },
+    {
+      "upstream": "anthropics/claude-code#59896",
+      "url": "https://github.com/anthropics/claude-code/issues/59896",
+      "title": "[BUG] `voice:pushToTalk` multi-binding silently picks one key; the chosen key changed in v2.1.141",
+      "impact": "not_applicable",
+      "categories": [
+        "ide",
+        "terminal",
+        "slash_hook"
+      ],
+      "tokenkey_status": "not_applicable",
+      "rationale": "Client-side claude-code concern (ide, terminal, slash_hook); not a gateway/relay relevance signal.",
+      "updated_at": "2026-06-02T11:32:02Z"
+    },
+    {
+      "upstream": "anthropics/claude-code#59900",
+      "url": "https://github.com/anthropics/claude-code/issues/59900",
+      "title": "[BUG] Task list accumulates stale tasks across sessions; spinner surfaces in_progress tasks from months ago alongside current work",
+      "impact": "not_applicable",
+      "categories": [
+        "terminal"
+      ],
+      "tokenkey_status": "not_applicable",
+      "rationale": "Client-side claude-code concern (terminal); not a gateway/relay relevance signal.",
+      "updated_at": "2026-06-02T11:32:03Z"
+    },
+    {
+      "upstream": "anthropics/claude-code#59906",
+      "url": "https://github.com/anthropics/claude-code/issues/59906",
+      "title": "[Bug] Claude Code generating unrelated code output to user plan",
+      "impact": "not_applicable",
+      "categories": [
+        "terminal"
+      ],
+      "tokenkey_status": "not_applicable",
+      "rationale": "Client-side claude-code concern (terminal); not a gateway/relay relevance signal.",
+      "updated_at": "2026-06-01T22:45:22Z"
+    },
+    {
+      "upstream": "anthropics/claude-code#59907",
+      "url": "https://github.com/anthropics/claude-code/issues/59907",
+      "title": "CLAUDE_CODE_EXPERIMENTAL_AGENT_TEAMS auto-distributor injects orchestrator/team task descriptions into specialist contexts as fake teammate messages",
+      "impact": "not_applicable",
+      "categories": [
+        "plugin",
+        "slash_hook"
+      ],
+      "tokenkey_status": "not_applicable",
+      "rationale": "Client-side claude-code concern (plugin, slash_hook); not a gateway/relay relevance signal.",
+      "updated_at": "2026-06-01T22:45:55Z"
+    },
+    {
+      "upstream": "anthropics/claude-code#59917",
+      "url": "https://github.com/anthropics/claude-code/issues/59917",
+      "title": "[Feature Request] Auto-load multimodal files (PNG/HTML) from CLAUDE.md directories via @-imports",
+      "impact": "not_applicable",
+      "categories": [
+        "terminal",
+        "mcp",
+        "slash_hook"
+      ],
+      "tokenkey_status": "not_applicable",
+      "rationale": "Client-side claude-code concern (terminal, mcp, slash_hook); not a gateway/relay relevance signal.",
+      "updated_at": "2026-06-01T22:45:23Z"
+    },
+    {
+      "upstream": "anthropics/claude-code#59922",
+      "url": "https://github.com/anthropics/claude-code/issues/59922",
+      "title": "Plan mode session pinned to generated filename — can't redirect approval UI to a different plan file",
+      "impact": "not_applicable",
+      "categories": [
+        "ide",
+        "platform"
+      ],
+      "tokenkey_status": "not_applicable",
+      "rationale": "Client-side claude-code concern (ide, platform); not a gateway/relay relevance signal.",
+      "updated_at": "2026-06-01T22:45:24Z"
+    },
+    {
+      "upstream": "anthropics/claude-code#59923",
+      "url": "https://github.com/anthropics/claude-code/issues/59923",
+      "title": "[Bug] Conversation home directory incorrectly switches to nested test directory after compaction",
+      "impact": "not_applicable",
+      "categories": [
+        "terminal"
+      ],
+      "tokenkey_status": "not_applicable",
+      "rationale": "Client-side claude-code concern (terminal); not a gateway/relay relevance signal.",
+      "updated_at": "2026-06-01T22:45:25Z"
+    },
+    {
+      "upstream": "anthropics/claude-code#59929",
+      "url": "https://github.com/anthropics/claude-code/issues/59929",
+      "title": "[FEATURE]",
+      "impact": "not_applicable",
+      "categories": [
+        "mcp",
+        "plugin",
+        "slash_hook"
+      ],
+      "tokenkey_status": "not_applicable",
+      "rationale": "Client-side claude-code concern (mcp, plugin, slash_hook); not a gateway/relay relevance signal.",
+      "updated_at": "2026-06-01T22:45:27Z"
+    },
+    {
+      "upstream": "anthropics/claude-code#59938",
+      "url": "https://github.com/anthropics/claude-code/issues/59938",
+      "title": "[Bug] Claude Code commits and pushes changes without explicit user approval",
+      "impact": "not_applicable",
+      "categories": [
+        "ide",
+        "terminal"
+      ],
+      "tokenkey_status": "not_applicable",
+      "rationale": "Client-side claude-code concern (ide, terminal); not a gateway/relay relevance signal.",
+      "updated_at": "2026-06-01T22:45:33Z"
+    },
+    {
+      "upstream": "anthropics/claude-code#59939",
+      "url": "https://github.com/anthropics/claude-code/issues/59939",
+      "title": "[Bug] Stop hook error: Failed with non-blocking status code",
+      "impact": "not_applicable",
+      "categories": [
+        "ide",
+        "terminal",
+        "slash_hook"
+      ],
+      "tokenkey_status": "not_applicable",
+      "rationale": "Client-side claude-code concern (ide, terminal, slash_hook); not a gateway/relay relevance signal.",
+      "updated_at": "2026-06-01T22:45:35Z"
+    },
+    {
+      "upstream": "anthropics/claude-code#59950",
+      "url": "https://github.com/anthropics/claude-code/issues/59950",
+      "title": "[BUG] Fin AI agent claims it has no ability to pass messages to a human support",
+      "impact": "not_applicable",
+      "categories": [
+        "terminal"
+      ],
+      "tokenkey_status": "not_applicable",
+      "rationale": "Client-side claude-code concern (terminal); not a gateway/relay relevance signal.",
+      "updated_at": "2026-06-01T22:45:40Z"
+    },
+    {
+      "upstream": "anthropics/claude-code#59957",
+      "url": "https://github.com/anthropics/claude-code/issues/59957",
+      "title": "[BUG] CoWork Deleted All Content from a Cowork Workspace",
+      "impact": "not_applicable",
+      "categories": [
+        "terminal",
+        "plugin",
+        "install",
+        "platform"
+      ],
+      "tokenkey_status": "not_applicable",
+      "rationale": "Client-side claude-code concern (terminal, plugin, install, platform); not a gateway/relay relevance signal.",
+      "updated_at": "2026-06-01T22:45:39Z"
+    },
+    {
+      "upstream": "anthropics/claude-code#59960",
+      "url": "https://github.com/anthropics/claude-code/issues/59960",
+      "title": "[BUG] Remote Control registration ignores persisted /rename title after /resume",
+      "impact": "not_applicable",
+      "categories": [
+        "terminal"
+      ],
+      "tokenkey_status": "not_applicable",
+      "rationale": "Client-side claude-code concern (terminal); not a gateway/relay relevance signal.",
+      "updated_at": "2026-06-01T22:45:40Z"
+    },
+    {
+      "upstream": "anthropics/claude-code#59967",
+      "url": "https://github.com/anthropics/claude-code/issues/59967",
+      "title": "[BUG] Cowork / Claude Desktop (Windows MSIX): VM service fails to start ~48 hours after MSIX re-registration; named pipe never created",
+      "impact": "not_applicable",
+      "categories": [
+        "terminal",
+        "install",
+        "platform"
+      ],
+      "tokenkey_status": "not_applicable",
+      "rationale": "Client-side claude-code concern (terminal, install, platform); not a gateway/relay relevance signal.",
+      "updated_at": "2026-06-01T22:45:42Z"
+    },
+    {
+      "upstream": "anthropics/claude-code#59968",
+      "url": "https://github.com/anthropics/claude-code/issues/59968",
+      "title": "[BUG] Skill tool invoked from sub-agent doesn't inherit parent's Agent tool grant — collapses multi-agent skills into single-context self-affirmation",
+      "impact": "not_applicable",
+      "categories": [
+        "mcp",
+        "plugin"
+      ],
+      "tokenkey_status": "not_applicable",
+      "rationale": "Client-side claude-code concern (mcp, plugin); not a gateway/relay relevance signal.",
+      "updated_at": "2026-06-01T22:45:43Z"
+    },
+    {
+      "upstream": "anthropics/claude-code#59969",
+      "url": "https://github.com/anthropics/claude-code/issues/59969",
+      "title": "[BUG] /goal and /permissions report \"not available in this environment\" in Claude Desktop Code tab (macOS)",
+      "impact": "not_applicable",
+      "categories": [
+        "terminal",
+        "slash_hook"
+      ],
+      "tokenkey_status": "not_applicable",
+      "rationale": "Client-side claude-code concern (terminal, slash_hook); not a gateway/relay relevance signal.",
+      "updated_at": "2026-06-02T22:43:56Z"
+    },
+    {
+      "upstream": "anthropics/claude-code#59988",
+      "url": "https://github.com/anthropics/claude-code/issues/59988",
+      "title": "Chrome crashes on any page-interacting MCP op (navigate / get_page_text) against a SharePoint Online tenant",
+      "impact": "not_applicable",
+      "categories": [
+        "ide",
+        "mcp"
+      ],
+      "tokenkey_status": "not_applicable",
+      "rationale": "Client-side claude-code concern (ide, mcp); not a gateway/relay relevance signal.",
+      "updated_at": "2026-06-01T22:45:58Z"
+    },
+    {
+      "upstream": "anthropics/claude-code#59990",
+      "url": "https://github.com/anthropics/claude-code/issues/59990",
+      "title": "[BUG] Desktop app intercepts Windows screenshot shortcuts and triggers file-association errors on Windows 11.",
+      "impact": "not_applicable",
+      "categories": [
+        "terminal",
+        "slash_hook",
+        "install",
+        "platform"
+      ],
+      "tokenkey_status": "not_applicable",
+      "rationale": "Client-side claude-code concern (terminal, slash_hook, install, platform); not a gateway/relay relevance signal.",
+      "updated_at": "2026-06-02T22:44:01Z"
+    },
+    {
+      "upstream": "anthropics/claude-code#59995",
+      "url": "https://github.com/anthropics/claude-code/issues/59995",
+      "title": "[FEATURE] File drag-and-drop in CLI (Windows Terminal)",
+      "impact": "not_applicable",
+      "categories": [
+        "ide",
+        "terminal",
+        "platform"
+      ],
+      "tokenkey_status": "not_applicable",
+      "rationale": "Client-side claude-code concern (ide, terminal, platform); not a gateway/relay relevance signal.",
+      "updated_at": "2026-06-01T22:45:54Z"
+    },
+    {
+      "upstream": "anthropics/claude-code#60002",
+      "url": "https://github.com/anthropics/claude-code/issues/60002",
+      "title": "VSCode extension: \"Unhandled case: [object Object]\" banner orphans response, leaves chat stuck at \"Thinking…\"",
+      "impact": "not_applicable",
+      "categories": [
+        "ide",
+        "terminal",
+        "mcp",
+        "platform"
+      ],
+      "tokenkey_status": "not_applicable",
+      "rationale": "Client-side claude-code concern (ide, terminal, mcp, platform); not a gateway/relay relevance signal.",
+      "updated_at": "2026-06-02T22:44:17Z"
+    },
+    {
+      "upstream": "anthropics/claude-code#60006",
+      "url": "https://github.com/anthropics/claude-code/issues/60006",
+      "title": "EEXIST: file already exists, mkdir '.claude' on Windows startup",
+      "impact": "not_applicable",
+      "categories": [
+        "install",
+        "platform"
+      ],
+      "tokenkey_status": "not_applicable",
+      "rationale": "Client-side claude-code concern (install, platform); not a gateway/relay relevance signal.",
+      "updated_at": "2026-06-01T22:46:00Z"
+    },
+    {
+      "upstream": "anthropics/claude-code#60008",
+      "url": "https://github.com/anthropics/claude-code/issues/60008",
+      "title": "[BUG] Persistent ENOENT mkdir error in local-agent-mode-sessions on Windows — non-recursive mkdir attempted with sibling .json file path",
+      "impact": "not_applicable",
+      "categories": [
+        "ide",
+        "terminal",
+        "install",
+        "platform"
+      ],
+      "tokenkey_status": "not_applicable",
+      "rationale": "Client-side claude-code concern (ide, terminal, install, platform); not a gateway/relay relevance signal.",
+      "updated_at": "2026-06-01T22:46:02Z"
+    },
+    {
+      "upstream": "anthropics/claude-code#60011",
+      "url": "https://github.com/anthropics/claude-code/issues/60011",
+      "title": "[BUG] Claude Code extension crashes with virtual filesystem repos (vscode-vfs://)",
+      "impact": "not_applicable",
+      "categories": [
+        "ide",
+        "terminal",
+        "platform"
+      ],
+      "tokenkey_status": "not_applicable",
+      "rationale": "Client-side claude-code concern (ide, terminal, platform); not a gateway/relay relevance signal.",
+      "updated_at": "2026-06-01T22:46:03Z"
+    },
+    {
+      "upstream": "anthropics/claude-code#60012",
+      "url": "https://github.com/anthropics/claude-code/issues/60012",
+      "title": "[BUG] On Windows with English as the primary system language, spell check in Claude Code only checks the primary language (English).",
+      "impact": "not_applicable",
+      "categories": [
+        "terminal",
+        "install",
+        "platform"
+      ],
+      "tokenkey_status": "not_applicable",
+      "rationale": "Client-side claude-code concern (terminal, install, platform); not a gateway/relay relevance signal.",
+      "updated_at": "2026-06-01T22:46:04Z"
+    },
+    {
+      "upstream": "anthropics/claude-code#60018",
+      "url": "https://github.com/anthropics/claude-code/issues/60018",
+      "title": "[BUG] /rewind does nothing in Windows desktop app (version 1.7196.0.0)",
+      "impact": "not_applicable",
+      "categories": [
+        "terminal",
+        "platform"
+      ],
+      "tokenkey_status": "not_applicable",
+      "rationale": "Client-side claude-code concern (terminal, platform); not a gateway/relay relevance signal.",
+      "updated_at": "2026-06-01T22:46:06Z"
+    },
+    {
+      "upstream": "anthropics/claude-code#60020",
+      "url": "https://github.com/anthropics/claude-code/issues/60020",
+      "title": "[FEATURE] VS Code extension panel should display current model name passively",
+      "impact": "not_applicable",
+      "categories": [
+        "ide"
+      ],
+      "tokenkey_status": "not_applicable",
+      "rationale": "Client-side claude-code concern (ide); not a gateway/relay relevance signal.",
+      "updated_at": "2026-06-02T11:32:14Z"
+    },
+    {
+      "upstream": "anthropics/claude-code#60023",
+      "url": "https://github.com/anthropics/claude-code/issues/60023",
+      "title": "[Bug] ripgrep default color output corrupts text, --color=never workaroundSorr",
+      "impact": "not_applicable",
+      "categories": [
+        "terminal"
+      ],
+      "tokenkey_status": "not_applicable",
+      "rationale": "Client-side claude-code concern (terminal); not a gateway/relay relevance signal.",
+      "updated_at": "2026-06-01T22:46:08Z"
+    },
+    {
+      "upstream": "anthropics/claude-code#60025",
+      "url": "https://github.com/anthropics/claude-code/issues/60025",
+      "title": "Claude Code 2.1.143 hangs during subprocess initialization with UNC additionalDirectory",
+      "impact": "not_applicable",
+      "categories": [
+        "ide",
+        "plugin",
+        "slash_hook",
+        "platform"
+      ],
+      "tokenkey_status": "not_applicable",
+      "rationale": "Client-side claude-code concern (ide, plugin, slash_hook, platform); not a gateway/relay relevance signal.",
+      "updated_at": "2026-06-01T22:46:10Z"
+    },
+    {
+      "upstream": "anthropics/claude-code#60029",
+      "url": "https://github.com/anthropics/claude-code/issues/60029",
+      "title": "[BUG] SANDBOX ERROR CODE ENOSPC: no space left on device,",
+      "impact": "not_applicable",
+      "categories": [
+        "terminal"
+      ],
+      "tokenkey_status": "not_applicable",
+      "rationale": "Client-side claude-code concern (terminal); not a gateway/relay relevance signal.",
+      "updated_at": "2026-06-01T22:46:12Z"
+    },
+    {
+      "upstream": "anthropics/claude-code#60030",
+      "url": "https://github.com/anthropics/claude-code/issues/60030",
+      "title": "[FEATURE] Accessibility/Usability feature for vs code extention.",
+      "impact": "not_applicable",
+      "categories": [
+        "ide"
+      ],
+      "tokenkey_status": "not_applicable",
+      "rationale": "Client-side claude-code concern (ide); not a gateway/relay relevance signal.",
+      "updated_at": "2026-06-02T11:32:09Z"
+    },
+    {
+      "upstream": "anthropics/claude-code#60032",
+      "url": "https://github.com/anthropics/claude-code/issues/60032",
+      "title": "[Bug] Unreliable vocabulary data generation without official source validation",
+      "impact": "not_applicable",
+      "categories": [
+        "terminal"
+      ],
+      "tokenkey_status": "not_applicable",
+      "rationale": "Client-side claude-code concern (terminal); not a gateway/relay relevance signal.",
+      "updated_at": "2026-06-01T22:46:14Z"
+    },
+    {
+      "upstream": "anthropics/claude-code#60036",
+      "url": "https://github.com/anthropics/claude-code/issues/60036",
+      "title": "[FEATURE] Add a preflight checklist item requiring confirmation that user PII has been scrubbed, in every issue template in this repo",
+      "impact": "not_applicable",
+      "categories": [
+        "terminal",
+        "slash_hook"
+      ],
+      "tokenkey_status": "not_applicable",
+      "rationale": "Client-side claude-code concern (terminal, slash_hook); not a gateway/relay relevance signal.",
+      "updated_at": "2026-06-01T22:46:20Z"
+    },
+    {
+      "upstream": "anthropics/claude-code#60040",
+      "url": "https://github.com/anthropics/claude-code/issues/60040",
+      "title": "[Bug] Claude ignores explicit instructions to avoid shortcuts despite custom hooks and memory configuration",
+      "impact": "not_applicable",
+      "categories": [
+        "ide",
+        "terminal",
+        "slash_hook"
+      ],
+      "tokenkey_status": "not_applicable",
+      "rationale": "Client-side claude-code concern (ide, terminal, slash_hook); not a gateway/relay relevance signal.",
+      "updated_at": "2026-06-01T22:46:16Z"
+    },
+    {
+      "upstream": "anthropics/claude-code#60043",
+      "url": "https://github.com/anthropics/claude-code/issues/60043",
+      "title": "Long working sessions auto-archive mid-conversation; no opt-out",
+      "impact": "not_applicable",
+      "categories": [
+        "mcp",
+        "slash_hook",
+        "install",
+        "platform"
+      ],
+      "tokenkey_status": "not_applicable",
+      "rationale": "Client-side claude-code concern (mcp, slash_hook, install, platform); not a gateway/relay relevance signal.",
+      "updated_at": "2026-06-02T11:32:06Z"
+    },
+    {
+      "upstream": "anthropics/claude-code#60044",
+      "url": "https://github.com/anthropics/claude-code/issues/60044",
+      "title": "[BUG] in VS Code/Cursor extension spinnerVerbs read from claudeCode.* workspace config instead of ~/.claude/settings.json effective view (one-line fix in extension.js)",
+      "impact": "not_applicable",
+      "categories": [
+        "ide",
+        "terminal",
+        "mcp",
+        "slash_hook",
+        "install"
+      ],
+      "tokenkey_status": "not_applicable",
+      "rationale": "Client-side claude-code concern (ide, terminal, mcp, slash_hook, install); not a gateway/relay relevance signal.",
+      "updated_at": "2026-06-02T02:30:36Z"
+    },
+    {
+      "upstream": "anthropics/claude-code#60045",
+      "url": "https://github.com/anthropics/claude-code/issues/60045",
+      "title": "VSCode: Config probe subprocess always times out (60s) on first tab",
+      "impact": "not_applicable",
+      "categories": [
+        "ide",
+        "mcp",
+        "slash_hook"
+      ],
+      "tokenkey_status": "not_applicable",
+      "rationale": "Client-side claude-code concern (ide, mcp, slash_hook); not a gateway/relay relevance signal.",
+      "updated_at": "2026-06-02T22:44:23Z"
+    },
+    {
+      "upstream": "anthropics/claude-code#60047",
+      "url": "https://github.com/anthropics/claude-code/issues/60047",
+      "title": "[Bug] Context Limit Reached on Initial Message",
+      "impact": "not_applicable",
+      "categories": [
+        "terminal"
+      ],
+      "tokenkey_status": "not_applicable",
+      "rationale": "Client-side claude-code concern (terminal); not a gateway/relay relevance signal.",
+      "updated_at": "2026-06-01T22:46:19Z"
+    },
+    {
+      "upstream": "anthropics/claude-code#60049",
+      "url": "https://github.com/anthropics/claude-code/issues/60049",
+      "title": "[FEATURE] VS Code extension's \"Web\" tab should list active `claude remote-control` sessions",
+      "impact": "not_applicable",
+      "categories": [
+        "ide",
+        "terminal"
+      ],
+      "tokenkey_status": "not_applicable",
+      "rationale": "Client-side claude-code concern (ide, terminal); not a gateway/relay relevance signal.",
+      "updated_at": "2026-06-02T22:43:57Z"
+    },
+    {
+      "upstream": "anthropics/claude-code#60050",
+      "url": "https://github.com/anthropics/claude-code/issues/60050",
+      "title": "[BUG] Multi-repo session: href points to wrong repo",
+      "impact": "not_applicable",
+      "categories": [
+        "terminal"
+      ],
+      "tokenkey_status": "not_applicable",
+      "rationale": "Client-side claude-code concern (terminal); not a gateway/relay relevance signal.",
+      "updated_at": "2026-06-02T22:43:57Z"
+    },
+    {
+      "upstream": "anthropics/claude-code#60054",
+      "url": "https://github.com/anthropics/claude-code/issues/60054",
+      "title": "[BUG]",
+      "impact": "not_applicable",
+      "categories": [
+        "terminal"
+      ],
+      "tokenkey_status": "not_applicable",
+      "rationale": "Client-side claude-code concern (terminal); not a gateway/relay relevance signal.",
+      "updated_at": "2026-06-02T22:43:59Z"
+    },
+    {
+      "upstream": "anthropics/claude-code#60057",
+      "url": "https://github.com/anthropics/claude-code/issues/60057",
+      "title": "CLAUDE_PLUGIN_DATA is unnamespaced — plugins persisting it via CLAUDE_ENV_FILE pollute other plugins and skills",
+      "impact": "not_applicable",
+      "categories": [
+        "plugin",
+        "slash_hook",
+        "install"
+      ],
+      "tokenkey_status": "not_applicable",
+      "rationale": "Client-side claude-code concern (plugin, slash_hook, install); not a gateway/relay relevance signal.",
+      "updated_at": "2026-06-02T22:44:00Z"
+    },
+    {
+      "upstream": "anthropics/claude-code#60061",
+      "url": "https://github.com/anthropics/claude-code/issues/60061",
+      "title": "Claude Code 2.1.143 silently hangs MCP tool calls after SSE drop — client logs the drop but does not fail or reconnect",
+      "impact": "not_applicable",
+      "categories": [
+        "mcp"
+      ],
+      "tokenkey_status": "not_applicable",
+      "rationale": "Client-side claude-code concern (mcp); not a gateway/relay relevance signal.",
+      "updated_at": "2026-06-02T11:20:24Z"
+    },
+    {
+      "upstream": "anthropics/claude-code#60062",
+      "url": "https://github.com/anthropics/claude-code/issues/60062",
+      "title": "Security: IDE extension silently captures selected text, including secrets from .env files",
+      "impact": "not_applicable",
+      "categories": [
+        "ide"
+      ],
+      "tokenkey_status": "not_applicable",
+      "rationale": "Client-side claude-code concern (ide); not a gateway/relay relevance signal.",
+      "updated_at": "2026-06-02T22:44:02Z"
+    },
+    {
+      "upstream": "anthropics/claude-code#60069",
+      "url": "https://github.com/anthropics/claude-code/issues/60069",
+      "title": "[BUG] Renderer paints stale frame past new viewport after SIGWINCH — cumulative \\x1b[1B walks exceed new row count (relative-cursor path, alt-screen)",
+      "impact": "not_applicable",
+      "categories": [
+        "terminal"
+      ],
+      "tokenkey_status": "not_applicable",
+      "rationale": "Client-side claude-code concern (terminal); not a gateway/relay relevance signal.",
+      "updated_at": "2026-06-02T22:45:01Z"
+    },
+    {
+      "upstream": "anthropics/claude-code#60074",
+      "url": "https://github.com/anthropics/claude-code/issues/60074",
+      "title": "autoArchiveSessions: false ignored for worktree sessions",
+      "impact": "not_applicable",
+      "categories": [
+        "slash_hook",
+        "platform"
+      ],
+      "tokenkey_status": "not_applicable",
+      "rationale": "Client-side claude-code concern (slash_hook, platform); not a gateway/relay relevance signal.",
+      "updated_at": "2026-06-02T11:32:16Z"
+    },
+    {
+      "upstream": "anthropics/claude-code#60082",
+      "url": "https://github.com/anthropics/claude-code/issues/60082",
+      "title": "Feature request: real-time multi-user collaboration on a single Claude Code session",
+      "impact": "not_applicable",
+      "categories": [
+        "ide"
+      ],
+      "tokenkey_status": "not_applicable",
+      "rationale": "Client-side claude-code concern (ide); not a gateway/relay relevance signal.",
+      "updated_at": "2026-06-02T11:32:11Z"
+    },
+    {
+      "upstream": "anthropics/claude-code#60087",
+      "url": "https://github.com/anthropics/claude-code/issues/60087",
+      "title": "Pass suggestion-acceptance provenance to the model",
+      "impact": "not_applicable",
+      "categories": [
+        "terminal"
+      ],
+      "tokenkey_status": "not_applicable",
+      "rationale": "Client-side claude-code concern (terminal); not a gateway/relay relevance signal.",
+      "updated_at": "2026-06-02T22:44:55Z"
+    },
+    {
+      "upstream": "anthropics/claude-code#60088",
+      "url": "https://github.com/anthropics/claude-code/issues/60088",
+      "title": "[BUG] Cowork Chrome MCP connection failure - persistent \"not connected\" error",
+      "impact": "not_applicable",
+      "categories": [
+        "ide",
+        "terminal",
+        "mcp",
+        "platform"
+      ],
+      "tokenkey_status": "not_applicable",
+      "rationale": "Client-side claude-code concern (ide, terminal, mcp, platform); not a gateway/relay relevance signal.",
+      "updated_at": "2026-06-02T11:32:16Z"
+    },
+    {
+      "upstream": "anthropics/claude-code#60091",
+      "url": "https://github.com/anthropics/claude-code/issues/60091",
+      "title": "Macos MCP connector crashes after ~17h despite system sleep being prevented",
+      "impact": "not_applicable",
+      "categories": [
+        "mcp"
+      ],
+      "tokenkey_status": "not_applicable",
+      "rationale": "Client-side claude-code concern (mcp); not a gateway/relay relevance signal.",
+      "updated_at": "2026-06-02T11:32:47Z"
+    },
+    {
+      "upstream": "anthropics/claude-code#60097",
+      "url": "https://github.com/anthropics/claude-code/issues/60097",
+      "title": "[Desktop] Display current worktree/cwd name in app UI (statusLine equivalent)",
+      "impact": "not_applicable",
+      "categories": [
+        "terminal",
+        "slash_hook"
+      ],
+      "tokenkey_status": "not_applicable",
+      "rationale": "Client-side claude-code concern (terminal, slash_hook); not a gateway/relay relevance signal.",
+      "updated_at": "2026-06-02T11:32:20Z"
+    },
+    {
+      "upstream": "anthropics/claude-code#60098",
+      "url": "https://github.com/anthropics/claude-code/issues/60098",
+      "title": "[BUG] Failed to use fast mode in opus 4.7 when using LLM Gateway",
+      "impact": "not_applicable",
+      "categories": [
+        "terminal",
+        "platform"
+      ],
+      "tokenkey_status": "not_applicable",
+      "rationale": "Client-side claude-code concern (terminal, platform); not a gateway/relay relevance signal.",
+      "updated_at": "2026-06-02T11:32:21Z"
+    },
+    {
+      "upstream": "anthropics/claude-code#60102",
+      "url": "https://github.com/anthropics/claude-code/issues/60102",
+      "title": "[BUG] notification/banner issue named \"Claude Code Download\" above chat from desktop app",
+      "impact": "not_applicable",
+      "categories": [
+        "terminal",
+        "install",
+        "platform"
+      ],
+      "tokenkey_status": "not_applicable",
+      "rationale": "Client-side claude-code concern (terminal, install, platform); not a gateway/relay relevance signal.",
+      "updated_at": "2026-06-02T11:33:05Z"
+    },
+    {
+      "upstream": "anthropics/claude-code#60106",
+      "url": "https://github.com/anthropics/claude-code/issues/60106",
+      "title": "agents-view: clear(new)/clear(reset) orphans previous session, invisible in --resume picker",
+      "impact": "not_applicable",
+      "categories": [
+        "slash_hook"
+      ],
+      "tokenkey_status": "not_applicable",
+      "rationale": "Client-side claude-code concern (slash_hook); not a gateway/relay relevance signal.",
+      "updated_at": "2026-06-02T11:32:37Z"
+    },
+    {
+      "upstream": "anthropics/claude-code#60113",
+      "url": "https://github.com/anthropics/claude-code/issues/60113",
+      "title": "[FEATURE] Agent view: opt-out of worktree isolation and reuse heavy dependency directories",
+      "impact": "not_applicable",
+      "categories": [
+        "plugin",
+        "slash_hook",
+        "install"
+      ],
+      "tokenkey_status": "not_applicable",
+      "rationale": "Client-side claude-code concern (plugin, slash_hook, install); not a gateway/relay relevance signal.",
+      "updated_at": "2026-06-02T11:32:33Z"
+    },
+    {
+      "upstream": "anthropics/claude-code#60116",
+      "url": "https://github.com/anthropics/claude-code/issues/60116",
+      "title": "[BUG] ccd-cli does not terminate prior --resume <uuid> child when same session is resumed",
+      "impact": "not_applicable",
+      "categories": [
+        "terminal",
+        "install"
+      ],
+      "tokenkey_status": "not_applicable",
+      "rationale": "Client-side claude-code concern (terminal, install); not a gateway/relay relevance signal.",
+      "updated_at": "2026-06-02T11:32:36Z"
+    },
+    {
+      "upstream": "anthropics/claude-code#60118",
+      "url": "https://github.com/anthropics/claude-code/issues/60118",
+      "title": "[BUG] - CRITICAL",
+      "impact": "not_applicable",
+      "categories": [
+        "terminal",
+        "platform"
+      ],
+      "tokenkey_status": "not_applicable",
+      "rationale": "Client-side claude-code concern (terminal, platform); not a gateway/relay relevance signal.",
+      "updated_at": "2026-06-03T06:06:48Z"
+    },
+    {
+      "upstream": "anthropics/claude-code#60123",
+      "url": "https://github.com/anthropics/claude-code/issues/60123",
+      "title": "[BUG]",
+      "impact": "not_applicable",
+      "categories": [
+        "ide",
+        "terminal",
+        "platform"
+      ],
+      "tokenkey_status": "not_applicable",
+      "rationale": "Client-side claude-code concern (ide, terminal, platform); not a gateway/relay relevance signal.",
+      "updated_at": "2026-06-02T11:32:41Z"
+    },
+    {
+      "upstream": "anthropics/claude-code#60124",
+      "url": "https://github.com/anthropics/claude-code/issues/60124",
+      "title": "Bash tool summary line undercounts find paths and -o patterns",
+      "impact": "not_applicable",
+      "categories": [
+        "slash_hook"
+      ],
+      "tokenkey_status": "not_applicable",
+      "rationale": "Client-side claude-code concern (slash_hook); not a gateway/relay relevance signal.",
+      "updated_at": "2026-06-02T11:32:42Z"
+    },
+    {
+      "upstream": "anthropics/claude-code#60136",
+      "url": "https://github.com/anthropics/claude-code/issues/60136",
+      "title": "[BUG] Claude Desktop silently disappears after UAC prompt on Windows 11",
+      "impact": "not_applicable",
+      "categories": [
+        "terminal",
+        "install",
+        "platform"
+      ],
+      "tokenkey_status": "not_applicable",
+      "rationale": "Client-side claude-code concern (terminal, install, platform); not a gateway/relay relevance signal.",
+      "updated_at": "2026-06-02T11:32:52Z"
+    },
+    {
+      "upstream": "anthropics/claude-code#60143",
+      "url": "https://github.com/anthropics/claude-code/issues/60143",
+      "title": "[FEATURE] Search the sessions list in `claude agents`",
+      "impact": "not_applicable",
+      "categories": [
+        "terminal"
+      ],
+      "tokenkey_status": "not_applicable",
+      "rationale": "Client-side claude-code concern (terminal); not a gateway/relay relevance signal.",
+      "updated_at": "2026-06-02T11:32:51Z"
+    },
+    {
+      "upstream": "anthropics/claude-code#60145",
+      "url": "https://github.com/anthropics/claude-code/issues/60145",
+      "title": "[MODEL] Potentially malicious iOS device-wipe behaviour not caught by Auto checker",
+      "impact": "not_applicable",
+      "categories": [
+        "plugin"
+      ],
+      "tokenkey_status": "not_applicable",
+      "rationale": "Client-side claude-code concern (plugin); not a gateway/relay relevance signal.",
+      "updated_at": "2026-06-02T11:32:52Z"
+    },
+    {
+      "upstream": "anthropics/claude-code#60146",
+      "url": "https://github.com/anthropics/claude-code/issues/60146",
+      "title": "Edit/Write tool leaves .tmp.<PID>.<hex> files after atomic rename",
+      "impact": "not_applicable",
+      "categories": [
+        "slash_hook",
+        "platform"
+      ],
+      "tokenkey_status": "not_applicable",
+      "rationale": "Client-side claude-code concern (slash_hook, platform); not a gateway/relay relevance signal.",
+      "updated_at": "2026-06-02T11:32:54Z"
+    },
+    {
+      "upstream": "anthropics/claude-code#60157",
+      "url": "https://github.com/anthropics/claude-code/issues/60157",
+      "title": "Markdown links lack hover highlight/underline styling",
+      "impact": "not_applicable",
+      "categories": [
+        "terminal"
+      ],
+      "tokenkey_status": "not_applicable",
+      "rationale": "Client-side claude-code concern (terminal); not a gateway/relay relevance signal.",
+      "updated_at": "2026-06-02T11:32:56Z"
+    },
+    {
+      "upstream": "anthropics/claude-code#60158",
+      "url": "https://github.com/anthropics/claude-code/issues/60158",
+      "title": "Feature: Compact tool + customizable plan exit options",
+      "impact": "not_applicable",
+      "categories": [
+        "slash_hook"
+      ],
+      "tokenkey_status": "not_applicable",
+      "rationale": "Client-side claude-code concern (slash_hook); not a gateway/relay relevance signal.",
+      "updated_at": "2026-06-02T11:32:57Z"
+    },
+    {
+      "upstream": "anthropics/claude-code#60161",
+      "url": "https://github.com/anthropics/claude-code/issues/60161",
+      "title": "[BUG] Regression in Claude Desktop Code tab: chat pane no longer pins the user message corresponding to the response currently in view",
+      "impact": "not_applicable",
+      "categories": [
+        "ide",
+        "terminal"
+      ],
+      "tokenkey_status": "not_applicable",
+      "rationale": "Client-side claude-code concern (ide, terminal); not a gateway/relay relevance signal.",
+      "updated_at": "2026-06-02T11:32:58Z"
+    },
+    {
+      "upstream": "anthropics/claude-code#60163",
+      "url": "https://github.com/anthropics/claude-code/issues/60163",
+      "title": "[Feature Request] Support multiple languages in voice mode",
+      "impact": "not_applicable",
+      "categories": [
+        "terminal"
+      ],
+      "tokenkey_status": "not_applicable",
+      "rationale": "Client-side claude-code concern (terminal); not a gateway/relay relevance signal.",
+      "updated_at": "2026-06-02T11:33:00Z"
+    },
+    {
+      "upstream": "anthropics/claude-code#60165",
+      "url": "https://github.com/anthropics/claude-code/issues/60165",
+      "title": "[BUG] VSCode Extension: Restored conversations not discoverable in sidebar",
+      "impact": "not_applicable",
+      "categories": [
+        "ide",
+        "terminal",
+        "install"
+      ],
+      "tokenkey_status": "not_applicable",
+      "rationale": "Client-side claude-code concern (ide, terminal, install); not a gateway/relay relevance signal.",
+      "updated_at": "2026-06-02T11:33:04Z"
+    },
+    {
+      "upstream": "anthropics/claude-code#60167",
+      "url": "https://github.com/anthropics/claude-code/issues/60167",
+      "title": "[Mobile] Floating button shortcut for slash commands (configurable per user)",
+      "impact": "not_applicable",
+      "categories": [
+        "slash_hook",
+        "install"
+      ],
+      "tokenkey_status": "not_applicable",
+      "rationale": "Client-side claude-code concern (slash_hook, install); not a gateway/relay relevance signal.",
+      "updated_at": "2026-06-02T11:33:02Z"
+    },
+    {
+      "upstream": "anthropics/claude-code#60170",
+      "url": "https://github.com/anthropics/claude-code/issues/60170",
+      "title": "feat(claude-in-chrome): support `url` param on `tabs_create_mcp`",
+      "impact": "not_applicable",
+      "categories": [
+        "ide"
+      ],
+      "tokenkey_status": "not_applicable",
+      "rationale": "Client-side claude-code concern (ide); not a gateway/relay relevance signal.",
+      "updated_at": "2026-06-02T11:33:07Z"
+    },
+    {
+      "upstream": "anthropics/claude-code#60171",
+      "url": "https://github.com/anthropics/claude-code/issues/60171",
+      "title": "feat: Edit tool should auto-verify fresh file content before applying changes",
+      "impact": "not_applicable",
+      "categories": [
+        "slash_hook",
+        "platform"
+      ],
+      "tokenkey_status": "not_applicable",
+      "rationale": "Client-side claude-code concern (slash_hook, platform); not a gateway/relay relevance signal.",
+      "updated_at": "2026-06-02T11:33:08Z"
+    },
+    {
+      "upstream": "anthropics/claude-code#60176",
+      "url": "https://github.com/anthropics/claude-code/issues/60176",
+      "title": "Option to render AskUserQuestion prompts inline instead of as a modal dialog",
+      "impact": "not_applicable",
+      "categories": [
+        "terminal",
+        "slash_hook"
+      ],
+      "tokenkey_status": "not_applicable",
+      "rationale": "Client-side claude-code concern (terminal, slash_hook); not a gateway/relay relevance signal.",
+      "updated_at": "2026-06-02T11:33:11Z"
+    },
+    {
+      "upstream": "anthropics/claude-code#60178",
+      "url": "https://github.com/anthropics/claude-code/issues/60178",
+      "title": "[Bug] Anthropic API Error: False positive validation for biological structure queries",
+      "impact": "not_applicable",
+      "categories": [
+        "terminal",
+        "platform"
+      ],
+      "tokenkey_status": "not_applicable",
+      "rationale": "Client-side claude-code concern (terminal, platform); not a gateway/relay relevance signal.",
+      "updated_at": "2026-06-02T11:33:10Z"
+    },
+    {
+      "upstream": "anthropics/claude-code#60190",
+      "url": "https://github.com/anthropics/claude-code/issues/60190",
+      "title": "[BUG] Confusing UI for fast mode in VS Code extension",
+      "impact": "not_applicable",
+      "categories": [
+        "ide",
+        "terminal"
+      ],
+      "tokenkey_status": "not_applicable",
+      "rationale": "Client-side claude-code concern (ide, terminal); not a gateway/relay relevance signal.",
+      "updated_at": "2026-06-02T22:44:14Z"
+    },
+    {
+      "upstream": "anthropics/claude-code#60201",
+      "url": "https://github.com/anthropics/claude-code/issues/60201",
+      "title": "[FEATURE] Support panel parameter in claude://resume deeplink to open plan pane",
+      "impact": "not_applicable",
+      "categories": [
+        "terminal",
+        "slash_hook"
+      ],
+      "tokenkey_status": "not_applicable",
+      "rationale": "Client-side claude-code concern (terminal, slash_hook); not a gateway/relay relevance signal.",
+      "updated_at": "2026-06-02T22:44:04Z"
+    },
+    {
+      "upstream": "anthropics/claude-code#60205",
+      "url": "https://github.com/anthropics/claude-code/issues/60205",
+      "title": "[FEATURE] Project-scoped skills in Cowork (parity with Claude Code's `.claude/skills/`)",
+      "impact": "not_applicable",
+      "categories": [
+        "install"
+      ],
+      "tokenkey_status": "not_applicable",
+      "rationale": "Client-side claude-code concern (install); not a gateway/relay relevance signal.",
+      "updated_at": "2026-06-02T22:44:06Z"
+    },
+    {
+      "upstream": "anthropics/claude-code#60208",
+      "url": "https://github.com/anthropics/claude-code/issues/60208",
+      "title": "Push notifications broken - mobile devices not receiving notifications",
+      "impact": "not_applicable",
+      "categories": [
+        "platform"
+      ],
+      "tokenkey_status": "not_applicable",
+      "rationale": "Client-side claude-code concern (platform); not a gateway/relay relevance signal.",
+      "updated_at": "2026-06-02T22:44:44Z"
+    },
+    {
+      "upstream": "anthropics/claude-code#60210",
+      "url": "https://github.com/anthropics/claude-code/issues/60210",
+      "title": "Month-long SEO nightmare: Claude Code repeatedly confirmed fixes as deployed when they weren't",
+      "impact": "not_applicable",
+      "categories": [
+        "terminal"
+      ],
+      "tokenkey_status": "not_applicable",
+      "rationale": "Client-side claude-code concern (terminal); not a gateway/relay relevance signal.",
+      "updated_at": "2026-06-02T22:44:15Z"
+    },
+    {
+      "upstream": "anthropics/claude-code#60215",
+      "url": "https://github.com/anthropics/claude-code/issues/60215",
+      "title": "[BUG] Linux: Bun runtime segfault on Linux (claude-code 2.1.143, Bun 1.3.14, Ubuntu 24.04 / kernel 6.18.x)",
+      "impact": "not_applicable",
+      "categories": [
+        "terminal",
+        "mcp"
+      ],
+      "tokenkey_status": "not_applicable",
+      "rationale": "Client-side claude-code concern (terminal, mcp); not a gateway/relay relevance signal.",
+      "updated_at": "2026-06-02T22:44:06Z"
+    },
+    {
+      "upstream": "anthropics/claude-code#60219",
+      "url": "https://github.com/anthropics/claude-code/issues/60219",
+      "title": "Plugin auto-update orphans all cached versions, leaving no active version at session start",
+      "impact": "not_applicable",
+      "categories": [
+        "plugin",
+        "slash_hook"
+      ],
+      "tokenkey_status": "not_applicable",
+      "rationale": "Client-side claude-code concern (plugin, slash_hook); not a gateway/relay relevance signal.",
+      "updated_at": "2026-06-02T22:44:07Z"
+    },
+    {
+      "upstream": "anthropics/claude-code#60220",
+      "url": "https://github.com/anthropics/claude-code/issues/60220",
+      "title": "[BUG] PushNotification reports success but no Windows desktop toast appears (mobile push works; Action Center stays empty)",
+      "impact": "not_applicable",
+      "categories": [
+        "terminal",
+        "platform"
+      ],
+      "tokenkey_status": "not_applicable",
+      "rationale": "Client-side claude-code concern (terminal, platform); not a gateway/relay relevance signal.",
+      "updated_at": "2026-06-02T22:44:08Z"
+    },
+    {
+      "upstream": "anthropics/claude-code#60240",
+      "url": "https://github.com/anthropics/claude-code/issues/60240",
+      "title": "Settings migration silently removes user's explicit model pin without notification or backup",
+      "impact": "not_applicable",
+      "categories": [
+        "slash_hook"
+      ],
+      "tokenkey_status": "not_applicable",
+      "rationale": "Client-side claude-code concern (slash_hook); not a gateway/relay relevance signal.",
+      "updated_at": "2026-06-02T22:44:11Z"
+    },
+    {
+      "upstream": "anthropics/claude-code#60246",
+      "url": "https://github.com/anthropics/claude-code/issues/60246",
+      "title": "[DOCS] governance and security guidance for MCP server adoption in teams",
+      "impact": "not_applicable",
+      "categories": [
+        "mcp",
+        "install"
+      ],
+      "tokenkey_status": "not_applicable",
+      "rationale": "Client-side claude-code concern (mcp, install); not a gateway/relay relevance signal.",
+      "updated_at": "2026-06-01T22:25:27Z"
+    },
+    {
+      "upstream": "anthropics/claude-code#60253",
+      "url": "https://github.com/anthropics/claude-code/issues/60253",
+      "title": "System prompt advertises uninstallable Cowork skills as \"available\"",
+      "impact": "not_applicable",
+      "categories": [
+        "plugin",
+        "slash_hook",
+        "install",
+        "platform"
+      ],
+      "tokenkey_status": "not_applicable",
+      "rationale": "Client-side claude-code concern (plugin, slash_hook, install, platform); not a gateway/relay relevance signal.",
+      "updated_at": "2026-06-02T22:44:19Z"
+    },
+    {
+      "upstream": "anthropics/claude-code#60259",
+      "url": "https://github.com/anthropics/claude-code/issues/60259",
+      "title": "[Bug] Legitimate biological content incorrectly flagged by safety filters",
+      "impact": "not_applicable",
+      "categories": [
+        "terminal",
+        "platform"
+      ],
+      "tokenkey_status": "not_applicable",
+      "rationale": "Client-side claude-code concern (terminal, platform); not a gateway/relay relevance signal.",
+      "updated_at": "2026-06-02T22:44:21Z"
+    },
+    {
+      "upstream": "anthropics/claude-code#60262",
+      "url": "https://github.com/anthropics/claude-code/issues/60262",
+      "title": "[BUG] Cowork \"Virtualization is not available\" — Windows 10 Home, all features enabled, VM never initializes",
+      "impact": "not_applicable",
+      "categories": [
+        "terminal",
+        "install",
+        "platform"
+      ],
+      "tokenkey_status": "not_applicable",
+      "rationale": "Client-side claude-code concern (terminal, install, platform); not a gateway/relay relevance signal.",
+      "updated_at": "2026-06-02T22:44:13Z"
+    },
+    {
+      "upstream": "anthropics/claude-code#60266",
+      "url": "https://github.com/anthropics/claude-code/issues/60266",
+      "title": "Feature request: configurable statusLine position (below the mode/footer line)",
+      "impact": "not_applicable",
+      "categories": [
+        "terminal",
+        "slash_hook",
+        "platform"
+      ],
+      "tokenkey_status": "not_applicable",
+      "rationale": "Client-side claude-code concern (terminal, slash_hook, platform); not a gateway/relay relevance signal.",
+      "updated_at": "2026-06-03T05:32:03Z"
+    },
+    {
+      "upstream": "anthropics/claude-code#60275",
+      "url": "https://github.com/anthropics/claude-code/issues/60275",
+      "title": "[BUG] es como un ingeniero (no todos) muy inteligente pero inutil con sus manos",
+      "impact": "not_applicable",
+      "categories": [
+        "ide",
+        "terminal",
+        "platform"
+      ],
+      "tokenkey_status": "not_applicable",
+      "rationale": "Client-side claude-code concern (ide, terminal, platform); not a gateway/relay relevance signal.",
+      "updated_at": "2026-06-02T22:44:20Z"
+    },
+    {
+      "upstream": "anthropics/claude-code#60278",
+      "url": "https://github.com/anthropics/claude-code/issues/60278",
+      "title": "[BUG] claude.ai MT Newswires MCP connector — fetch returns HTTPStatusError.__init__() crash on all data requests",
+      "impact": "not_applicable",
+      "categories": [
+        "terminal",
+        "mcp",
+        "platform"
+      ],
+      "tokenkey_status": "not_applicable",
+      "rationale": "Client-side claude-code concern (terminal, mcp, platform); not a gateway/relay relevance signal.",
+      "updated_at": "2026-06-02T22:44:39Z"
+    },
+    {
+      "upstream": "anthropics/claude-code#60281",
+      "url": "https://github.com/anthropics/claude-code/issues/60281",
+      "title": "[Bug] Auto-update fails repeatedly across all update methods",
+      "impact": "not_applicable",
+      "categories": [
+        "terminal",
+        "install"
+      ],
+      "tokenkey_status": "not_applicable",
+      "rationale": "Client-side claude-code concern (terminal, install); not a gateway/relay relevance signal.",
+      "updated_at": "2026-06-02T22:44:23Z"
+    },
+    {
+      "upstream": "anthropics/claude-code#60285",
+      "url": "https://github.com/anthropics/claude-code/issues/60285",
+      "title": "[BUG] CONSISTENT AND AGGRESSIVE PUSH BY CLAUDE TO CLEAR CONTEXT \"new task? /clear to save 189.6k tokens\"",
+      "impact": "not_applicable",
+      "categories": [
+        "terminal",
+        "platform"
+      ],
+      "tokenkey_status": "not_applicable",
+      "rationale": "Client-side claude-code concern (terminal, platform); not a gateway/relay relevance signal.",
+      "updated_at": "2026-06-02T22:44:25Z"
+    },
+    {
+      "upstream": "anthropics/claude-code#60287",
+      "url": "https://github.com/anthropics/claude-code/issues/60287",
+      "title": "[BUG] Token waste from missed context — Claude Code session 2026-05-18 / Token waste from missed user context — refund request ($35 CAD)",
+      "impact": "not_applicable",
+      "categories": [
+        "terminal",
+        "platform"
+      ],
+      "tokenkey_status": "not_applicable",
+      "rationale": "Client-side claude-code concern (terminal, platform); not a gateway/relay relevance signal.",
+      "updated_at": "2026-06-02T22:44:25Z"
+    },
+    {
+      "upstream": "anthropics/claude-code#60292",
+      "url": "https://github.com/anthropics/claude-code/issues/60292",
+      "title": "[BUG] User-scope plugins show \"not cached at (not recorded)\" — /plugins TUI cannot refresh or reinstall",
+      "impact": "not_applicable",
+      "categories": [
+        "terminal",
+        "plugin",
+        "slash_hook",
+        "install"
+      ],
+      "tokenkey_status": "not_applicable",
+      "rationale": "Client-side claude-code concern (terminal, plugin, slash_hook, install); not a gateway/relay relevance signal.",
+      "updated_at": "2026-06-02T22:44:27Z"
+    },
+    {
+      "upstream": "anthropics/claude-code#60295",
+      "url": "https://github.com/anthropics/claude-code/issues/60295",
+      "title": "Multiple Claude Code sessions in same repo can silently swap each other's branch",
+      "impact": "not_applicable",
+      "categories": [
+        "terminal"
+      ],
+      "tokenkey_status": "not_applicable",
+      "rationale": "Client-side claude-code concern (terminal); not a gateway/relay relevance signal.",
+      "updated_at": "2026-06-02T01:51:41Z"
+    },
+    {
+      "upstream": "anthropics/claude-code#60296",
+      "url": "https://github.com/anthropics/claude-code/issues/60296",
+      "title": "[BUG] Claude repeatedly sets iOS deployment target too low in Flutter projects",
+      "impact": "not_applicable",
+      "categories": [
+        "terminal",
+        "plugin",
+        "platform"
+      ],
+      "tokenkey_status": "not_applicable",
+      "rationale": "Client-side claude-code concern (terminal, plugin, platform); not a gateway/relay relevance signal.",
+      "updated_at": "2026-06-02T22:44:30Z"
+    },
+    {
+      "upstream": "anthropics/claude-code#60297",
+      "url": "https://github.com/anthropics/claude-code/issues/60297",
+      "title": "[BUG] VS Code extension: renamed sessions show old title until window reload",
+      "impact": "not_applicable",
+      "categories": [
+        "ide",
+        "terminal"
+      ],
+      "tokenkey_status": "not_applicable",
+      "rationale": "Client-side claude-code concern (ide, terminal); not a gateway/relay relevance signal.",
+      "updated_at": "2026-06-02T22:44:31Z"
+    },
+    {
+      "upstream": "anthropics/claude-code#60305",
+      "url": "https://github.com/anthropics/claude-code/issues/60305",
+      "title": "Cloud sessions: non-interactive Azure CLI auth path",
+      "impact": "not_applicable",
+      "categories": [
+        "mcp",
+        "slash_hook",
+        "install"
+      ],
+      "tokenkey_status": "not_applicable",
+      "rationale": "Client-side claude-code concern (mcp, slash_hook, install); not a gateway/relay relevance signal.",
+      "updated_at": "2026-06-02T22:44:34Z"
+    },
+    {
+      "upstream": "anthropics/claude-code#60309",
+      "url": "https://github.com/anthropics/claude-code/issues/60309",
+      "title": "[FEATURE] Port message_compose_v1 (inline email composer) to Cowork",
+      "impact": "not_applicable",
+      "categories": [
+        "terminal"
+      ],
+      "tokenkey_status": "not_applicable",
+      "rationale": "Client-side claude-code concern (terminal); not a gateway/relay relevance signal.",
+      "updated_at": "2026-06-02T22:44:37Z"
+    },
+    {
+      "upstream": "anthropics/claude-code#60310",
+      "url": "https://github.com/anthropics/claude-code/issues/60310",
+      "title": "IDE diagnostics ignore workspace gopls build env (GOOS/GOARCH)",
+      "impact": "not_applicable",
+      "categories": [
+        "ide",
+        "slash_hook"
+      ],
+      "tokenkey_status": "not_applicable",
+      "rationale": "Client-side claude-code concern (ide, slash_hook); not a gateway/relay relevance signal.",
+      "updated_at": "2026-06-02T22:44:35Z"
+    },
+    {
+      "upstream": "anthropics/claude-code#60321",
+      "url": "https://github.com/anthropics/claude-code/issues/60321",
+      "title": "[BUG] Claude Code crashes in Mac Desktop App",
+      "impact": "not_applicable",
+      "categories": [
+        "terminal",
+        "plugin",
+        "install"
+      ],
+      "tokenkey_status": "not_applicable",
+      "rationale": "Client-side claude-code concern (terminal, plugin, install); not a gateway/relay relevance signal.",
+      "updated_at": "2026-06-02T22:44:40Z"
+    },
+    {
+      "upstream": "anthropics/claude-code#60322",
+      "url": "https://github.com/anthropics/claude-code/issues/60322",
+      "title": "Agent View: allow voice:pushToTalk (or dictation) from a selected session row",
+      "impact": "not_applicable",
+      "categories": [
+        "slash_hook"
+      ],
+      "tokenkey_status": "not_applicable",
+      "rationale": "Client-side claude-code concern (slash_hook); not a gateway/relay relevance signal.",
+      "updated_at": "2026-06-02T22:44:41Z"
+    },
+    {
+      "upstream": "anthropics/claude-code#60324",
+      "url": "https://github.com/anthropics/claude-code/issues/60324",
+      "title": "[Feature Request] Add setting to disable automatic PR badge display in UI",
+      "impact": "not_applicable",
+      "categories": [
+        "terminal"
+      ],
+      "tokenkey_status": "not_applicable",
+      "rationale": "Client-side claude-code concern (terminal); not a gateway/relay relevance signal.",
+      "updated_at": "2026-06-02T22:44:50Z"
+    },
+    {
+      "upstream": "anthropics/claude-code#60332",
+      "url": "https://github.com/anthropics/claude-code/issues/60332",
+      "title": "Feature request: allow disabling bypass permission mode entirely",
+      "impact": "not_applicable",
+      "categories": [
+        "ide",
+        "slash_hook"
+      ],
+      "tokenkey_status": "not_applicable",
+      "rationale": "Client-side claude-code concern (ide, slash_hook); not a gateway/relay relevance signal.",
+      "updated_at": "2026-06-02T22:44:45Z"
+    },
+    {
+      "upstream": "anthropics/claude-code#60333",
+      "url": "https://github.com/anthropics/claude-code/issues/60333",
+      "title": "[BUG] version 1.7196.3, Mac, Cowork absent, résultat du grep vide",
+      "impact": "not_applicable",
+      "categories": [
+        "terminal"
+      ],
+      "tokenkey_status": "not_applicable",
+      "rationale": "Client-side claude-code concern (terminal); not a gateway/relay relevance signal.",
+      "updated_at": "2026-06-02T22:44:47Z"
+    },
+    {
+      "upstream": "anthropics/claude-code#60338",
+      "url": "https://github.com/anthropics/claude-code/issues/60338",
+      "title": "[BUG] The Claude Code CLI does not wrap text in the \"What's new\" pane at the top.",
+      "impact": "not_applicable",
+      "categories": [
+        "terminal"
+      ],
+      "tokenkey_status": "not_applicable",
+      "rationale": "Client-side claude-code concern (terminal); not a gateway/relay relevance signal.",
+      "updated_at": "2026-06-02T22:44:49Z"
+    },
+    {
+      "upstream": "anthropics/claude-code#60344",
+      "url": "https://github.com/anthropics/claude-code/issues/60344",
+      "title": "[Bug] macOS TCC permission dialog displays version string instead of \"Claude Code\" due to missing Info.plist in binary",
+      "impact": "not_applicable",
+      "categories": [
+        "terminal"
+      ],
+      "tokenkey_status": "not_applicable",
+      "rationale": "Client-side claude-code concern (terminal); not a gateway/relay relevance signal.",
+      "updated_at": "2026-06-02T22:44:48Z"
+    },
+    {
+      "upstream": "anthropics/claude-code#60347",
+      "url": "https://github.com/anthropics/claude-code/issues/60347",
+      "title": "[Bug] PR review loop fails to identify issues on subsequent iterations",
+      "impact": "not_applicable",
+      "categories": [
+        "terminal"
+      ],
+      "tokenkey_status": "not_applicable",
+      "rationale": "Client-side claude-code concern (terminal); not a gateway/relay relevance signal.",
+      "updated_at": "2026-06-02T22:44:50Z"
+    },
+    {
+      "upstream": "anthropics/claude-code#60348",
+      "url": "https://github.com/anthropics/claude-code/issues/60348",
+      "title": "/ultraplan: session creation fails with `firestore: not found` on bundle import; GitHub preflight appears to fall through to bundle path even with App installed",
+      "impact": "not_applicable",
+      "categories": [
+        "install"
+      ],
+      "tokenkey_status": "not_applicable",
+      "rationale": "Client-side claude-code concern (install); not a gateway/relay relevance signal.",
+      "updated_at": "2026-06-02T22:44:52Z"
+    },
+    {
+      "upstream": "anthropics/claude-code#60351",
+      "url": "https://github.com/anthropics/claude-code/issues/60351",
+      "title": "OpenViking Memory Hooks — persistent long-term memory plugin",
+      "impact": "not_applicable",
+      "categories": [
+        "mcp",
+        "plugin",
+        "install"
+      ],
+      "tokenkey_status": "not_applicable",
+      "rationale": "Client-side claude-code concern (mcp, plugin, install); not a gateway/relay relevance signal.",
+      "updated_at": "2026-06-02T22:44:53Z"
+    },
+    {
+      "upstream": "anthropics/claude-code#60353",
+      "url": "https://github.com/anthropics/claude-code/issues/60353",
+      "title": "Voice tap mode: no way to stop recording without sending",
+      "impact": "not_applicable",
+      "categories": [
+        "slash_hook"
+      ],
+      "tokenkey_status": "not_applicable",
+      "rationale": "Client-side claude-code concern (slash_hook); not a gateway/relay relevance signal.",
+      "updated_at": "2026-06-02T22:44:54Z"
+    },
+    {
+      "upstream": "anthropics/claude-code#60358",
+      "url": "https://github.com/anthropics/claude-code/issues/60358",
+      "title": "Render inline code and code fences in the TUI input composer",
+      "impact": "not_applicable",
+      "categories": [
+        "terminal"
+      ],
+      "tokenkey_status": "not_applicable",
+      "rationale": "Client-side claude-code concern (terminal); not a gateway/relay relevance signal.",
+      "updated_at": "2026-06-02T22:44:55Z"
+    },
+    {
+      "upstream": "anthropics/claude-code#60362",
+      "url": "https://github.com/anthropics/claude-code/issues/60362",
+      "title": "[Bug] Firestore not found error during seed bundle import after web-setup",
+      "impact": "not_applicable",
+      "categories": [
+        "ide",
+        "terminal"
+      ],
+      "tokenkey_status": "not_applicable",
+      "rationale": "Client-side claude-code concern (ide, terminal); not a gateway/relay relevance signal.",
+      "updated_at": "2026-06-02T22:44:57Z"
+    },
+    {
+      "upstream": "anthropics/claude-code#60363",
+      "url": "https://github.com/anthropics/claude-code/issues/60363",
+      "title": "[BUG] Windows: Bun crashes when UserPromptSubmit hook fires frequently in long sessions",
+      "impact": "not_applicable",
+      "categories": [
+        "terminal",
+        "slash_hook",
+        "platform"
+      ],
+      "tokenkey_status": "not_applicable",
+      "rationale": "Client-side claude-code concern (terminal, slash_hook, platform); not a gateway/relay relevance signal.",
+      "updated_at": "2026-06-02T22:45:00Z"
+    },
+    {
+      "upstream": "anthropics/claude-code#60365",
+      "url": "https://github.com/anthropics/claude-code/issues/60365",
+      "title": "[Feature Request] Improve onboarding message tone for better user experience",
+      "impact": "not_applicable",
+      "categories": [
+        "terminal"
+      ],
+      "tokenkey_status": "not_applicable",
+      "rationale": "Client-side claude-code concern (terminal); not a gateway/relay relevance signal.",
+      "updated_at": "2026-06-02T22:44:59Z"
+    },
+    {
+      "upstream": "anthropics/claude-code#60366",
+      "url": "https://github.com/anthropics/claude-code/issues/60366",
+      "title": "[BUG] Saying \"hi\" returns \"API Error: Claude Code is unable to respond to this request, which appears to violate our Usage Policy\"",
+      "impact": "not_applicable",
+      "categories": [
+        "ide",
+        "terminal",
+        "platform"
+      ],
+      "tokenkey_status": "not_applicable",
+      "rationale": "Client-side claude-code concern (ide, terminal, platform); not a gateway/relay relevance signal.",
+      "updated_at": "2026-06-01T06:33:09Z"
+    },
+    {
+      "upstream": "anthropics/claude-code#60369",
+      "url": "https://github.com/anthropics/claude-code/issues/60369",
+      "title": "Allow disabling or restyling the agent-name badge in transcript",
+      "impact": "not_applicable",
+      "categories": [
+        "terminal",
+        "slash_hook"
+      ],
+      "tokenkey_status": "not_applicable",
+      "rationale": "Client-side claude-code concern (terminal, slash_hook); not a gateway/relay relevance signal.",
+      "updated_at": "2026-06-02T22:45:00Z"
+    },
+    {
+      "upstream": "anthropics/claude-code#60415",
+      "url": "https://github.com/anthropics/claude-code/issues/60415",
+      "title": "[DOCS] Agent view docs omit recovery guidance for an unresponsive background service",
+      "impact": "not_applicable",
+      "categories": [
+        "terminal"
+      ],
+      "tokenkey_status": "not_applicable",
+      "rationale": "Client-side claude-code concern (terminal); not a gateway/relay relevance signal.",
+      "updated_at": "2026-06-01T01:30:08Z"
+    },
+    {
+      "upstream": "anthropics/claude-code#60694",
+      "url": "https://github.com/anthropics/claude-code/issues/60694",
+      "title": "[DOCS] Agent view docs omit voice dictation support in the peek-panel reply input",
+      "impact": "not_applicable",
+      "categories": [
+        "slash_hook"
+      ],
+      "tokenkey_status": "not_applicable",
+      "rationale": "Client-side claude-code concern (slash_hook); not a gateway/relay relevance signal.",
+      "updated_at": "2026-06-01T01:29:24Z"
+    },
+    {
+      "upstream": "anthropics/claude-code#60711",
+      "url": "https://github.com/anthropics/claude-code/issues/60711",
+      "title": "Feature request: inline message timestamps",
+      "impact": "not_applicable",
+      "categories": [
+        "slash_hook"
+      ],
+      "tokenkey_status": "not_applicable",
+      "rationale": "Client-side claude-code concern (slash_hook); not a gateway/relay relevance signal.",
+      "updated_at": "2026-06-02T15:01:18Z"
+    },
+    {
+      "upstream": "anthropics/claude-code#60763",
+      "url": "https://github.com/anthropics/claude-code/issues/60763",
+      "title": "[FEATURE] Subagents have no Agent/Task tool — recursive/nested subagent dispatch impossible",
+      "impact": "not_applicable",
+      "categories": [
+        "plugin"
+      ],
+      "tokenkey_status": "not_applicable",
+      "rationale": "Client-side claude-code concern (plugin); not a gateway/relay relevance signal.",
+      "updated_at": "2026-05-31T14:12:12Z"
+    },
+    {
+      "upstream": "anthropics/claude-code#60844",
+      "url": "https://github.com/anthropics/claude-code/issues/60844",
+      "title": "[Feature Request] Add NotebookRead tool for efficient Jupyter notebook cell extraction",
+      "impact": "not_applicable",
+      "categories": [
+        "ide",
+        "terminal"
+      ],
+      "tokenkey_status": "not_applicable",
+      "rationale": "Client-side claude-code concern (ide, terminal); not a gateway/relay relevance signal.",
+      "updated_at": "2026-06-01T16:41:55Z"
+    },
+    {
+      "upstream": "anthropics/claude-code#60875",
+      "url": "https://github.com/anthropics/claude-code/issues/60875",
+      "title": "[BUG] Cowork on Windows ARM64: Linux guest never establishes vsock callback — stuck at add_plan9_shares, 100% reproducible after exhaustive diagnosis",
+      "impact": "not_applicable",
+      "categories": [
+        "terminal",
+        "install",
+        "platform"
+      ],
+      "tokenkey_status": "not_applicable",
+      "rationale": "Client-side claude-code concern (terminal, install, platform); not a gateway/relay relevance signal.",
+      "updated_at": "2026-06-02T06:49:22Z"
+    },
+    {
+      "upstream": "anthropics/claude-code#60975",
+      "url": "https://github.com/anthropics/claude-code/issues/60975",
+      "title": "Agent View / FleetView: allow specifying a starting directory (cwd) when spawning a new agent so it boots with the correct project context",
+      "impact": "not_applicable",
+      "categories": [
+        "terminal",
+        "mcp",
+        "plugin",
+        "slash_hook"
+      ],
+      "tokenkey_status": "not_applicable",
+      "rationale": "Client-side claude-code concern (terminal, mcp, plugin, slash_hook); not a gateway/relay relevance signal.",
+      "updated_at": "2026-06-01T12:42:06Z"
+    },
+    {
+      "upstream": "anthropics/claude-code#61088",
+      "url": "https://github.com/anthropics/claude-code/issues/61088",
+      "title": "[BUG] False positive: Usage Policy violation triggered by legitimate input",
+      "impact": "not_applicable",
+      "categories": [
+        "terminal",
+        "platform"
+      ],
+      "tokenkey_status": "not_applicable",
+      "rationale": "Client-side claude-code concern (terminal, platform); not a gateway/relay relevance signal.",
+      "updated_at": "2026-06-01T06:33:06Z"
+    },
+    {
+      "upstream": "anthropics/claude-code#61142",
+      "url": "https://github.com/anthropics/claude-code/issues/61142",
+      "title": "[MODEL] Korean output corruption — words replaced with \"영역\" token in long responses",
+      "impact": "not_applicable",
+      "categories": [
+        "platform"
+      ],
+      "tokenkey_status": "not_applicable",
+      "rationale": "Client-side claude-code concern (platform); not a gateway/relay relevance signal.",
+      "updated_at": "2026-06-01T01:47:55Z"
+    },
+    {
+      "upstream": "anthropics/claude-code#61147",
+      "url": "https://github.com/anthropics/claude-code/issues/61147",
+      "title": "[BUG]",
+      "impact": "not_applicable",
+      "categories": [
+        "terminal",
+        "install",
+        "platform"
+      ],
+      "tokenkey_status": "not_applicable",
+      "rationale": "Client-side claude-code concern (terminal, install, platform); not a gateway/relay relevance signal.",
+      "updated_at": "2026-06-02T14:26:24Z"
+    },
+    {
+      "upstream": "anthropics/claude-code#61185",
+      "url": "https://github.com/anthropics/claude-code/issues/61185",
+      "title": "[BUG] Cyber safeguards false positive: routine sysadmin audit commands blocked, write-only reporting blocked in new session, context poisoning breaks session recovery",
+      "impact": "not_applicable",
+      "categories": [
+        "terminal"
+      ],
+      "tokenkey_status": "not_applicable",
+      "rationale": "Client-side claude-code concern (terminal); not a gateway/relay relevance signal.",
+      "updated_at": "2026-06-02T00:05:13Z"
+    },
+    {
+      "upstream": "anthropics/claude-code#61315",
+      "url": "https://github.com/anthropics/claude-code/issues/61315",
+      "title": "[BUG] Sub-agent dispatched via Agent tool stalls silently on MCP permission gate — no surface to parent CLI UI",
+      "impact": "not_applicable",
+      "categories": [
+        "terminal",
+        "mcp",
+        "plugin",
+        "slash_hook"
+      ],
+      "tokenkey_status": "not_applicable",
+      "rationale": "Client-side claude-code concern (terminal, mcp, plugin, slash_hook); not a gateway/relay relevance signal.",
+      "updated_at": "2026-06-01T03:40:23Z"
+    },
+    {
+      "upstream": "anthropics/claude-code#61339",
+      "url": "https://github.com/anthropics/claude-code/issues/61339",
+      "title": "[BUG] Double-charged after Max 5x plan silently downgraded to Free mid-cycle",
+      "impact": "not_applicable",
+      "categories": [
+        "terminal",
+        "platform"
+      ],
+      "tokenkey_status": "not_applicable",
+      "rationale": "Client-side claude-code concern (terminal, platform); not a gateway/relay relevance signal.",
+      "updated_at": "2026-06-01T06:31:12Z"
+    },
+    {
+      "upstream": "anthropics/claude-code#61405",
+      "url": "https://github.com/anthropics/claude-code/issues/61405",
+      "title": "[Bug] Subagent delegation lacks timeout, monitoring, and abort controls—caused 12+ hour session hang",
+      "impact": "not_applicable",
+      "categories": [
+        "plugin"
+      ],
+      "tokenkey_status": "not_applicable",
+      "rationale": "Client-side claude-code concern (plugin); not a gateway/relay relevance signal.",
+      "updated_at": "2026-06-02T18:07:20Z"
+    },
+    {
+      "upstream": "anthropics/claude-code#61415",
+      "url": "https://github.com/anthropics/claude-code/issues/61415",
+      "title": "[BUG] Desktop: Bypass Permissions mode can't be enabled on macOS — reverts to Accept Edits, \"Permission mode couldn't be changed\" (2.1.148)",
+      "impact": "not_applicable",
+      "categories": [
+        "terminal"
+      ],
+      "tokenkey_status": "not_applicable",
+      "rationale": "Client-side claude-code concern (terminal); not a gateway/relay relevance signal.",
+      "updated_at": "2026-06-02T09:04:36Z"
+    },
+    {
+      "upstream": "anthropics/claude-code#61484",
+      "url": "https://github.com/anthropics/claude-code/issues/61484",
+      "title": "Feature request: add \"Copy selection\" to right-click menu",
+      "impact": "not_applicable",
+      "categories": [
+        "platform"
+      ],
+      "tokenkey_status": "not_applicable",
+      "rationale": "Client-side claude-code concern (platform); not a gateway/relay relevance signal.",
+      "updated_at": "2026-06-01T00:16:29Z"
+    },
+    {
+      "upstream": "anthropics/claude-code#61491",
+      "url": "https://github.com/anthropics/claude-code/issues/61491",
+      "title": "Claude Code suggests non-existent \"fan out subagents\" command",
+      "impact": "not_applicable",
+      "categories": [
+        "plugin",
+        "slash_hook",
+        "install",
+        "platform"
+      ],
+      "tokenkey_status": "not_applicable",
+      "rationale": "Client-side claude-code concern (plugin, slash_hook, install, platform); not a gateway/relay relevance signal.",
+      "updated_at": "2026-06-02T19:27:04Z"
+    },
+    {
+      "upstream": "anthropics/claude-code#61559",
+      "url": "https://github.com/anthropics/claude-code/issues/61559",
+      "title": "Claude Desktop Cowork is failing to start a workspace on Windows.",
+      "impact": "not_applicable",
+      "categories": [
+        "terminal",
+        "install",
+        "platform"
+      ],
+      "tokenkey_status": "not_applicable",
+      "rationale": "Client-side claude-code concern (terminal, install, platform); not a gateway/relay relevance signal.",
+      "updated_at": "2026-06-01T18:54:17Z"
+    },
+    {
+      "upstream": "anthropics/claude-code#61582",
+      "url": "https://github.com/anthropics/claude-code/issues/61582",
+      "title": "[BUG] \"Relaunch to update\" applies the update immediately, with no changelog, no confirmation, and no option to defer",
+      "impact": "not_applicable",
+      "categories": [
+        "terminal"
+      ],
+      "tokenkey_status": "not_applicable",
+      "rationale": "Client-side claude-code concern (terminal); not a gateway/relay relevance signal.",
+      "updated_at": "2026-06-01T20:15:48Z"
+    },
+    {
+      "upstream": "anthropics/claude-code#61591",
+      "url": "https://github.com/anthropics/claude-code/issues/61591",
+      "title": "[DOCS] /usage docs omit the current limits-usage breakdown categories",
+      "impact": "not_applicable",
+      "categories": [
+        "mcp",
+        "plugin"
+      ],
+      "tokenkey_status": "not_applicable",
+      "rationale": "Client-side claude-code concern (mcp, plugin); not a gateway/relay relevance signal.",
+      "updated_at": "2026-06-01T17:49:07Z"
+    },
+    {
+      "upstream": "anthropics/claude-code#61609",
+      "url": "https://github.com/anthropics/claude-code/issues/61609",
+      "title": "[BUG] Image paste (Ctrl+V) does not work in native WSL2 terminal on Windows 11",
+      "impact": "not_applicable",
+      "categories": [
+        "ide",
+        "terminal",
+        "platform"
+      ],
+      "tokenkey_status": "not_applicable",
+      "rationale": "Client-side claude-code concern (ide, terminal, platform); not a gateway/relay relevance signal.",
+      "updated_at": "2026-06-03T01:20:46Z"
+    },
+    {
+      "upstream": "anthropics/claude-code#61638",
+      "url": "https://github.com/anthropics/claude-code/issues/61638",
+      "title": "False positive on Claude Code Usage Policy classifier — please stop over-flagging legitimate engineering work",
+      "impact": "not_applicable",
+      "categories": [
+        "terminal",
+        "mcp"
+      ],
+      "tokenkey_status": "not_applicable",
+      "rationale": "Client-side claude-code concern (terminal, mcp); not a gateway/relay relevance signal.",
+      "updated_at": "2026-06-01T06:32:32Z"
+    },
+    {
+      "upstream": "anthropics/claude-code#61642",
+      "url": "https://github.com/anthropics/claude-code/issues/61642",
+      "title": "[BUG] False-positive Usage Policy (AUP) violation on benign FPGA/hardware engineering waveform analysis",
+      "impact": "not_applicable",
+      "categories": [
+        "ide",
+        "terminal",
+        "platform"
+      ],
+      "tokenkey_status": "not_applicable",
+      "rationale": "Client-side claude-code concern (ide, terminal, platform); not a gateway/relay relevance signal.",
+      "updated_at": "2026-06-01T06:28:15Z"
+    },
+    {
+      "upstream": "anthropics/claude-code#61681",
+      "url": "https://github.com/anthropics/claude-code/issues/61681",
+      "title": "Sonnet dispatched via Agent tool fails with \"1M context required\" error",
+      "impact": "not_applicable",
+      "categories": [
+        "plugin",
+        "slash_hook",
+        "platform"
+      ],
+      "tokenkey_status": "not_applicable",
+      "rationale": "Client-side claude-code concern (plugin, slash_hook, platform); not a gateway/relay relevance signal.",
+      "updated_at": "2026-05-31T15:04:59Z"
+    },
+    {
+      "upstream": "anthropics/claude-code#61682",
+      "url": "https://github.com/anthropics/claude-code/issues/61682",
+      "title": "[BUG] GitHub connector shows \"Connected\" but exposes no tools in Cowork (Windows 11, app v1.8555.2.0)",
+      "impact": "not_applicable",
+      "categories": [
+        "terminal",
+        "platform"
+      ],
+      "tokenkey_status": "not_applicable",
+      "rationale": "Client-side claude-code concern (terminal, platform); not a gateway/relay relevance signal.",
+      "updated_at": "2026-06-03T01:47:22Z"
+    },
+    {
+      "upstream": "anthropics/claude-code#61692",
+      "url": "https://github.com/anthropics/claude-code/issues/61692",
+      "title": "[BUG] Sonnet 4.6 blocked by false \"usage credits required\" error",
+      "impact": "not_applicable",
+      "categories": [
+        "terminal",
+        "platform"
+      ],
+      "tokenkey_status": "not_applicable",
+      "rationale": "Client-side claude-code concern (terminal, platform); not a gateway/relay relevance signal.",
+      "updated_at": "2026-06-02T15:16:51Z"
+    },
+    {
+      "upstream": "anthropics/claude-code#61703",
+      "url": "https://github.com/anthropics/claude-code/issues/61703",
+      "title": "False Usage Limit and Request blocked",
+      "impact": "not_applicable",
+      "categories": [
+        "terminal",
+        "platform"
+      ],
+      "tokenkey_status": "not_applicable",
+      "rationale": "Client-side claude-code concern (terminal, platform); not a gateway/relay relevance signal.",
+      "updated_at": "2026-06-01T05:29:26Z"
+    },
+    {
+      "upstream": "anthropics/claude-code#61762",
+      "url": "https://github.com/anthropics/claude-code/issues/61762",
+      "title": "[FEATURE] Jetbrains plugin should support setting parent folder as working folder",
+      "impact": "not_applicable",
+      "categories": [
+        "ide",
+        "plugin"
+      ],
+      "tokenkey_status": "not_applicable",
+      "rationale": "Client-side claude-code concern (ide, plugin); not a gateway/relay relevance signal.",
+      "updated_at": "2026-06-01T02:03:20Z"
+    },
+    {
+      "upstream": "anthropics/claude-code#61807",
+      "url": "https://github.com/anthropics/claude-code/issues/61807",
+      "title": "[BUG] \"Install JetBrains plugin\" suggestion appears even when plugin is already installed",
+      "impact": "not_applicable",
+      "categories": [
+        "ide",
+        "terminal",
+        "plugin",
+        "install",
+        "platform"
+      ],
+      "tokenkey_status": "not_applicable",
+      "rationale": "Client-side claude-code concern (ide, terminal, plugin, install, platform); not a gateway/relay relevance signal.",
+      "updated_at": "2026-06-01T22:31:04Z"
+    },
+    {
+      "upstream": "anthropics/claude-code#61927",
+      "url": "https://github.com/anthropics/claude-code/issues/61927",
+      "title": "[BUG] \"Pull request status couldn't be checked\" banner persistently appears on every session in worktree branches without an associated PR",
+      "impact": "not_applicable",
+      "categories": [
+        "slash_hook",
+        "platform"
+      ],
+      "tokenkey_status": "not_applicable",
+      "rationale": "Client-side claude-code concern (slash_hook, platform); not a gateway/relay relevance signal.",
+      "updated_at": "2026-06-03T03:01:40Z"
+    },
+    {
+      "upstream": "anthropics/claude-code#61952",
+      "url": "https://github.com/anthropics/claude-code/issues/61952",
+      "title": "[BUG] ~20 sessions lost, only 11 survived - 2 months of work I paid for - gone",
+      "impact": "not_applicable",
+      "categories": [
+        "terminal"
+      ],
+      "tokenkey_status": "not_applicable",
+      "rationale": "Client-side claude-code concern (terminal); not a gateway/relay relevance signal.",
+      "updated_at": "2026-06-03T05:25:18Z"
+    },
+    {
+      "upstream": "anthropics/claude-code#62052",
+      "url": "https://github.com/anthropics/claude-code/issues/62052",
+      "title": "Misleading \"Usage limit reached\" error when selecting Sonnet — actually a 1M context tier gate",
+      "impact": "not_applicable",
+      "categories": [
+        "terminal",
+        "platform"
+      ],
+      "tokenkey_status": "not_applicable",
+      "rationale": "Client-side claude-code concern (terminal, platform); not a gateway/relay relevance signal.",
+      "updated_at": "2026-06-01T16:35:13Z"
+    },
+    {
+      "upstream": "anthropics/claude-code#62071",
+      "url": "https://github.com/anthropics/claude-code/issues/62071",
+      "title": "[Bug] Usage Policy classifier stuck in blocked state for legitimate kernel security work",
+      "impact": "not_applicable",
+      "categories": [
+        "terminal"
+      ],
+      "tokenkey_status": "not_applicable",
+      "rationale": "Client-side claude-code concern (terminal); not a gateway/relay relevance signal.",
+      "updated_at": "2026-06-01T06:28:17Z"
+    },
+    {
+      "upstream": "anthropics/claude-code#62072",
+      "url": "https://github.com/anthropics/claude-code/issues/62072",
+      "title": "[BUG] Cowork on macOS 1.8555.2 — zero MCP tools bind in any install path (.mcpb + SDK bridge + Custom Connectors + project .mcp.json); spawn pipeline missing --mcp-config since 2026-05-23 auto-update",
+      "impact": "not_applicable",
+      "categories": [
+        "ide",
+        "mcp",
+        "plugin",
+        "install"
+      ],
+      "tokenkey_status": "not_applicable",
+      "rationale": "Client-side claude-code concern (ide, mcp, plugin, install); not a gateway/relay relevance signal.",
+      "updated_at": "2026-06-01T18:58:46Z"
+    },
+    {
+      "upstream": "anthropics/claude-code#62096",
+      "url": "https://github.com/anthropics/claude-code/issues/62096",
+      "title": "[BUG] subscribe_pr_activity delivers human review events but not bot review events (from GitHub Apps like chatgpt-codex-connector[bot] and gemini-code-assist[bot])",
+      "impact": "not_applicable",
+      "categories": [
+        "terminal"
+      ],
+      "tokenkey_status": "not_applicable",
+      "rationale": "Client-side claude-code concern (terminal); not a gateway/relay relevance signal.",
+      "updated_at": "2026-06-01T13:47:44Z"
+    },
+    {
+      "upstream": "anthropics/claude-code#62123",
+      "url": "https://github.com/anthropics/claude-code/issues/62123",
+      "title": "[Bug] Anthropic API Error: Model's tool call could not be parsed (retry also failed)",
+      "impact": "not_applicable",
+      "categories": [
+        "ide",
+        "terminal"
+      ],
+      "tokenkey_status": "not_applicable",
+      "rationale": "Client-side claude-code concern (ide, terminal); not a gateway/relay relevance signal.",
+      "updated_at": "2026-06-03T06:49:45Z"
+    },
+    {
+      "upstream": "anthropics/claude-code#62149",
+      "url": "https://github.com/anthropics/claude-code/issues/62149",
+      "title": "[BUG] VS Code extension ignores `remoteControlAtStartup` — re-filing after #41036 and #53647 were auto-misrouted by dup-bot",
+      "impact": "not_applicable",
+      "categories": [
+        "ide",
+        "terminal",
+        "slash_hook",
+        "platform"
+      ],
+      "tokenkey_status": "not_applicable",
+      "rationale": "Client-side claude-code concern (ide, terminal, slash_hook, platform); not a gateway/relay relevance signal.",
+      "updated_at": "2026-06-02T04:19:00Z"
+    },
+    {
+      "upstream": "anthropics/claude-code#62191",
+      "url": "https://github.com/anthropics/claude-code/issues/62191",
+      "title": "[Bug] VERY sensitive cyber-safeguards",
+      "impact": "not_applicable",
+      "categories": [
+        "terminal"
+      ],
+      "tokenkey_status": "not_applicable",
+      "rationale": "Client-side claude-code concern (terminal); not a gateway/relay relevance signal.",
+      "updated_at": "2026-06-01T06:32:35Z"
+    },
+    {
+      "upstream": "anthropics/claude-code#62194",
+      "url": "https://github.com/anthropics/claude-code/issues/62194",
+      "title": "[BUG] Cowork UI shows zero projects/conversations after macOS major update + logout, while all local data files remain intact on disk",
+      "impact": "not_applicable",
+      "categories": [
+        "terminal"
+      ],
+      "tokenkey_status": "not_applicable",
+      "rationale": "Client-side claude-code concern (terminal); not a gateway/relay relevance signal.",
+      "updated_at": "2026-06-02T18:42:26Z"
+    },
+    {
+      "upstream": "anthropics/claude-code#62199",
+      "url": "https://github.com/anthropics/claude-code/issues/62199",
+      "title": "Claude Code changed default model to 1M context without notifying Pro users",
+      "impact": "not_applicable",
+      "categories": [
+        "ide",
+        "terminal",
+        "slash_hook",
+        "platform"
+      ],
+      "tokenkey_status": "not_applicable",
+      "rationale": "Client-side claude-code concern (ide, terminal, slash_hook, platform); not a gateway/relay relevance signal.",
+      "updated_at": "2026-06-02T19:22:01Z"
+    },
+    {
+      "upstream": "anthropics/claude-code#62259",
+      "url": "https://github.com/anthropics/claude-code/issues/62259",
+      "title": "[FEATURE] Allow user override of sandbox auto-deny on .claude/skills/ (currently hard-coded in 2.1.x)",
+      "impact": "not_applicable",
+      "categories": [
+        "ide",
+        "terminal",
+        "slash_hook",
+        "platform"
+      ],
+      "tokenkey_status": "not_applicable",
+      "rationale": "Client-side claude-code concern (ide, terminal, slash_hook, platform); not a gateway/relay relevance signal.",
+      "updated_at": "2026-06-02T07:17:09Z"
+    },
+    {
+      "upstream": "anthropics/claude-code#62263",
+      "url": "https://github.com/anthropics/claude-code/issues/62263",
+      "title": "[BUG] Cowork - Server busy / ECONNRESET on macOS - started ~14h UTC, May 25 2026",
+      "impact": "not_applicable",
+      "categories": [
+        "terminal"
+      ],
+      "tokenkey_status": "not_applicable",
+      "rationale": "Client-side claude-code concern (terminal); not a gateway/relay relevance signal.",
+      "updated_at": "2026-06-02T19:57:36Z"
+    },
+    {
+      "upstream": "anthropics/claude-code#62272",
+      "url": "https://github.com/anthropics/claude-code/issues/62272",
+      "title": "[BUG] Chat JSONLs deleted from ~/.claude/projects/ despite cleanupPeriodDays set high — appears triggered by updates/restarts",
+      "impact": "not_applicable",
+      "categories": [
+        "ide",
+        "terminal",
+        "slash_hook",
+        "platform"
+      ],
+      "tokenkey_status": "not_applicable",
+      "rationale": "Client-side claude-code concern (ide, terminal, slash_hook, platform); not a gateway/relay relevance signal.",
+      "updated_at": "2026-06-02T20:16:23Z"
+    },
+    {
+      "upstream": "anthropics/claude-code#62333",
+      "url": "https://github.com/anthropics/claude-code/issues/62333",
+      "title": "[BUG] Desktop app appears in dock but never opens on macOS Tahoe 26.2",
+      "impact": "not_applicable",
+      "categories": [
+        "terminal",
+        "platform"
+      ],
+      "tokenkey_status": "not_applicable",
+      "rationale": "Client-side claude-code concern (terminal, platform); not a gateway/relay relevance signal.",
+      "updated_at": "2026-06-02T00:27:29Z"
+    },
+    {
+      "upstream": "anthropics/claude-code#62338",
+      "url": "https://github.com/anthropics/claude-code/issues/62338",
+      "title": "[BUG] Claude Code silently billed $447 to API instead of Max subscription, then gave incorrect auth confirmation",
+      "impact": "not_applicable",
+      "categories": [
+        "terminal"
+      ],
+      "tokenkey_status": "not_applicable",
+      "rationale": "Client-side claude-code concern (terminal); not a gateway/relay relevance signal.",
+      "updated_at": "2026-06-02T07:42:16Z"
+    },
+    {
+      "upstream": "anthropics/claude-code#62466",
+      "url": "https://github.com/anthropics/claude-code/issues/62466",
+      "title": "[BUG] Repeated \"Image couldn't be processed\" API errors consuming usage limit in Claude Code",
+      "impact": "not_applicable",
+      "categories": [
+        "terminal"
+      ],
+      "tokenkey_status": "not_applicable",
+      "rationale": "Client-side claude-code concern (terminal); not a gateway/relay relevance signal.",
+      "updated_at": "2026-06-03T05:53:17Z"
+    },
+    {
+      "upstream": "anthropics/claude-code#62487",
+      "url": "https://github.com/anthropics/claude-code/issues/62487",
+      "title": "[BUG] Switching to mimo-v2.5-pro fails after reading images in mimo-v2.5",
+      "impact": "not_applicable",
+      "categories": [
+        "ide",
+        "terminal",
+        "platform"
+      ],
+      "tokenkey_status": "not_applicable",
+      "rationale": "Client-side claude-code concern (ide, terminal, platform); not a gateway/relay relevance signal.",
+      "updated_at": "2026-06-01T09:34:20Z"
+    },
+    {
+      "upstream": "anthropics/claude-code#62537",
+      "url": "https://github.com/anthropics/claude-code/issues/62537",
+      "title": "[BUG] Windows: PowerShell tool absent from schema when Git Bash is on PATH, despite pwsh.exe being present and detectable",
+      "impact": "not_applicable",
+      "categories": [
+        "terminal",
+        "slash_hook",
+        "install",
+        "platform"
+      ],
+      "tokenkey_status": "not_applicable",
+      "rationale": "Client-side claude-code concern (terminal, slash_hook, install, platform); not a gateway/relay relevance signal.",
+      "updated_at": "2026-05-31T21:33:04Z"
+    },
+    {
+      "upstream": "anthropics/claude-code#62585",
+      "url": "https://github.com/anthropics/claude-code/issues/62585",
+      "title": "Remote Control \"not yet enabled\" on Max plan — v2.1.126 (Arch Linux)",
+      "impact": "not_applicable",
+      "categories": [
+        "terminal",
+        "plugin"
+      ],
+      "tokenkey_status": "not_applicable",
+      "rationale": "Client-side claude-code concern (terminal, plugin); not a gateway/relay relevance signal.",
+      "updated_at": "2026-06-01T09:01:51Z"
+    },
+    {
+      "upstream": "anthropics/claude-code#62619",
+      "url": "https://github.com/anthropics/claude-code/issues/62619",
+      "title": "[BUG] False positive \"Usage Policy violation\" errors on normal coding requests",
+      "impact": "not_applicable",
+      "categories": [
+        "ide",
+        "terminal"
+      ],
+      "tokenkey_status": "not_applicable",
+      "rationale": "Client-side claude-code concern (ide, terminal); not a gateway/relay relevance signal.",
+      "updated_at": "2026-06-01T06:33:16Z"
+    },
+    {
+      "upstream": "anthropics/claude-code#62623",
+      "url": "https://github.com/anthropics/claude-code/issues/62623",
+      "title": "[BUG] Slash command does not work with modified keybindings",
+      "impact": "not_applicable",
+      "categories": [
+        "terminal",
+        "slash_hook"
+      ],
+      "tokenkey_status": "not_applicable",
+      "rationale": "Client-side claude-code concern (terminal, slash_hook); not a gateway/relay relevance signal.",
+      "updated_at": "2026-06-02T08:01:29Z"
+    },
+    {
+      "upstream": "anthropics/claude-code#62631",
+      "url": "https://github.com/anthropics/claude-code/issues/62631",
+      "title": "Inter-session coordination: wake / notify a parent session on child (sub-session) turn-end or idle",
+      "impact": "not_applicable",
+      "categories": [
+        "plugin",
+        "platform"
+      ],
+      "tokenkey_status": "not_applicable",
+      "rationale": "Client-side claude-code concern (plugin, platform); not a gateway/relay relevance signal.",
+      "updated_at": "2026-06-01T16:43:26Z"
+    },
+    {
+      "upstream": "anthropics/claude-code#62659",
+      "url": "https://github.com/anthropics/claude-code/issues/62659",
+      "title": "[BUG] Windows: Bash tool (grand)children survive command completion/kill as unkillable orphans — no per-command Job Object, and `SILENT_BREAKAWAY_OK` defeats the one that exists",
+      "impact": "not_applicable",
+      "categories": [
+        "terminal",
+        "mcp",
+        "plugin",
+        "install",
+        "platform"
+      ],
+      "tokenkey_status": "not_applicable",
+      "rationale": "Client-side claude-code concern (terminal, mcp, plugin, install, platform); not a gateway/relay relevance signal.",
+      "updated_at": "2026-06-01T23:49:55Z"
+    },
+    {
+      "upstream": "anthropics/claude-code#62671",
+      "url": "https://github.com/anthropics/claude-code/issues/62671",
+      "title": "[DOCS] `/usage` documentation omits large session files in limits breakdown",
+      "impact": "not_applicable",
+      "categories": [
+        "mcp",
+        "plugin"
+      ],
+      "tokenkey_status": "not_applicable",
+      "rationale": "Client-side claude-code concern (mcp, plugin); not a gateway/relay relevance signal.",
+      "updated_at": "2026-06-01T17:41:03Z"
+    },
+    {
+      "upstream": "anthropics/claude-code#62681",
+      "url": "https://github.com/anthropics/claude-code/issues/62681",
+      "title": "[FEATURE] Claude cli should not clear terminal output on exit",
+      "impact": "not_applicable",
+      "categories": [
+        "terminal",
+        "platform"
+      ],
+      "tokenkey_status": "not_applicable",
+      "rationale": "Client-side claude-code concern (terminal, platform); not a gateway/relay relevance signal.",
+      "updated_at": "2026-06-02T17:24:17Z"
+    },
+    {
+      "upstream": "anthropics/claude-code#62693",
+      "url": "https://github.com/anthropics/claude-code/issues/62693",
+      "title": "[BUG] Claude cli can not round-trip its own Copy/paste now",
+      "impact": "not_applicable",
+      "categories": [
+        "terminal"
+      ],
+      "tokenkey_status": "not_applicable",
+      "rationale": "Client-side claude-code concern (terminal); not a gateway/relay relevance signal.",
+      "updated_at": "2026-06-02T20:11:08Z"
+    },
+    {
+      "upstream": "anthropics/claude-code#62699",
+      "url": "https://github.com/anthropics/claude-code/issues/62699",
+      "title": "[BUG] Text cannot be copied from Claude Code's output using `Ctrl+Shift+C` or right-click context menu.",
+      "impact": "not_applicable",
+      "categories": [
+        "terminal"
+      ],
+      "tokenkey_status": "not_applicable",
+      "rationale": "Client-side claude-code concern (terminal); not a gateway/relay relevance signal.",
+      "updated_at": "2026-06-02T14:20:38Z"
+    },
+    {
+      "upstream": "anthropics/claude-code#62718",
+      "url": "https://github.com/anthropics/claude-code/issues/62718",
+      "title": "[BUG] Multi-root workspace: agent-emitted file links unclickable outside primary folder",
+      "impact": "not_applicable",
+      "categories": [
+        "ide",
+        "terminal",
+        "mcp",
+        "plugin",
+        "platform"
+      ],
+      "tokenkey_status": "not_applicable",
+      "rationale": "Client-side claude-code concern (ide, terminal, mcp, plugin, platform); not a gateway/relay relevance signal.",
+      "updated_at": "2026-06-03T04:48:56Z"
+    },
+    {
+      "upstream": "anthropics/claude-code#62729",
+      "url": "https://github.com/anthropics/claude-code/issues/62729",
+      "title": "[BUG] Claude Code crashed",
+      "impact": "not_applicable",
+      "categories": [
+        "terminal",
+        "platform"
+      ],
+      "tokenkey_status": "not_applicable",
+      "rationale": "Client-side claude-code concern (terminal, platform); not a gateway/relay relevance signal.",
+      "updated_at": "2026-06-01T16:55:15Z"
+    },
+    {
+      "upstream": "anthropics/claude-code#62736",
+      "url": "https://github.com/anthropics/claude-code/issues/62736",
+      "title": "[BUG] 2.1.152 regression: arrow keys hijacked in prompt input (cursor cannot move down/left/right)",
+      "impact": "not_applicable",
+      "categories": [
+        "terminal",
+        "plugin",
+        "slash_hook",
+        "install"
+      ],
+      "tokenkey_status": "not_applicable",
+      "rationale": "Client-side claude-code concern (terminal, plugin, slash_hook, install); not a gateway/relay relevance signal.",
+      "updated_at": "2026-06-02T22:37:27Z"
+    },
+    {
+      "upstream": "anthropics/claude-code#6275",
+      "url": "https://github.com/anthropics/claude-code/issues/6275",
+      "title": "Prompt Input: Unexpected Text Loss on Up Arrow Key Press",
+      "impact": "not_applicable",
+      "categories": [
+        "terminal",
+        "install"
+      ],
+      "tokenkey_status": "not_applicable",
+      "rationale": "Client-side claude-code concern (terminal, install); not a gateway/relay relevance signal.",
+      "updated_at": "2026-06-01T05:59:26Z"
+    },
+    {
+      "upstream": "anthropics/claude-code#62890",
+      "url": "https://github.com/anthropics/claude-code/issues/62890",
+      "title": "Tmux scrollback broken after May 26 update (v2.1.152)",
+      "impact": "not_applicable",
+      "categories": [
+        "terminal"
+      ],
+      "tokenkey_status": "not_applicable",
+      "rationale": "Client-side claude-code concern (terminal); not a gateway/relay relevance signal.",
+      "updated_at": "2026-06-01T17:06:17Z"
+    },
+    {
+      "upstream": "anthropics/claude-code#62942",
+      "url": "https://github.com/anthropics/claude-code/issues/62942",
+      "title": "claude-in-chrome: Browser extension never connects on Linux (tabs_context_mcp always returns 'not connected')",
+      "impact": "not_applicable",
+      "categories": [
+        "ide",
+        "terminal",
+        "mcp",
+        "install"
+      ],
+      "tokenkey_status": "not_applicable",
+      "rationale": "Client-side claude-code concern (ide, terminal, mcp, install); not a gateway/relay relevance signal.",
+      "updated_at": "2026-06-02T16:12:50Z"
+    },
+    {
+      "upstream": "anthropics/claude-code#62962",
+      "url": "https://github.com/anthropics/claude-code/issues/62962",
+      "title": "claude --continue ignores ANTHROPIC_DEFAULT_OPUS_MODEL, resumes on 200K instead of configured 1M — wastes tokens on failed context load",
+      "impact": "not_applicable",
+      "categories": [
+        "slash_hook"
+      ],
+      "tokenkey_status": "not_applicable",
+      "rationale": "Client-side claude-code concern (slash_hook); not a gateway/relay relevance signal.",
+      "updated_at": "2026-06-02T15:26:03Z"
+    },
+    {
+      "upstream": "anthropics/claude-code#62967",
+      "url": "https://github.com/anthropics/claude-code/issues/62967",
+      "title": "[BUG] Claude in Chrome v1.0.74 — MCP bridge navigation and read tools wedge after May 27 update",
+      "impact": "not_applicable",
+      "categories": [
+        "ide",
+        "terminal",
+        "mcp"
+      ],
+      "tokenkey_status": "not_applicable",
+      "rationale": "Client-side claude-code concern (ide, terminal, mcp); not a gateway/relay relevance signal.",
+      "updated_at": "2026-06-01T03:39:14Z"
+    },
+    {
+      "upstream": "anthropics/claude-code#63002",
+      "url": "https://github.com/anthropics/claude-code/issues/63002",
+      "title": "[Bug] Thread context stale after sleep/resume, returns outdated date and calendar data",
+      "impact": "not_applicable",
+      "categories": [
+        "terminal"
+      ],
+      "tokenkey_status": "not_applicable",
+      "rationale": "Client-side claude-code concern (terminal); not a gateway/relay relevance signal.",
+      "updated_at": "2026-06-02T07:54:19Z"
+    },
+    {
+      "upstream": "anthropics/claude-code#63012",
+      "url": "https://github.com/anthropics/claude-code/issues/63012",
+      "title": "[BUG] API 500 ERROR \"Attempt N/10... Retrying in Xs...\" MAKING CLAUDE CODE UNUSEABLE",
+      "impact": "not_applicable",
+      "categories": [
+        "terminal"
+      ],
+      "tokenkey_status": "not_applicable",
+      "rationale": "Client-side claude-code concern (terminal); not a gateway/relay relevance signal.",
+      "updated_at": "2026-06-01T06:47:02Z"
+    },
+    {
+      "upstream": "anthropics/claude-code#63037",
+      "url": "https://github.com/anthropics/claude-code/issues/63037",
+      "title": "[DOCS] Agent view docs omit macOS Privacy & Security identity for background agents",
+      "impact": "not_applicable",
+      "categories": [
+        "terminal"
+      ],
+      "tokenkey_status": "not_applicable",
+      "rationale": "Client-side claude-code concern (terminal); not a gateway/relay relevance signal.",
+      "updated_at": "2026-06-01T01:27:48Z"
+    },
+    {
+      "upstream": "anthropics/claude-code#63040",
+      "url": "https://github.com/anthropics/claude-code/issues/63040",
+      "title": "[DOCS] Background session docs omit `$CLAUDE_JOB_DIR` temp-file behavior",
+      "impact": "not_applicable",
+      "categories": [
+        "platform"
+      ],
+      "tokenkey_status": "not_applicable",
+      "rationale": "Client-side claude-code concern (platform); not a gateway/relay relevance signal.",
+      "updated_at": "2026-06-01T01:27:58Z"
+    },
+    {
+      "upstream": "anthropics/claude-code#63048",
+      "url": "https://github.com/anthropics/claude-code/issues/63048",
+      "title": "/code-review skill: silent fallback to main...HEAD reviews other people's commits, and JSON-only output is hard to read",
+      "impact": "not_applicable",
+      "categories": [
+        "terminal",
+        "slash_hook"
+      ],
+      "tokenkey_status": "not_applicable",
+      "rationale": "Client-side claude-code concern (terminal, slash_hook); not a gateway/relay relevance signal.",
+      "updated_at": "2026-06-03T03:26:38Z"
+    },
+    {
+      "upstream": "anthropics/claude-code#63060",
+      "url": "https://github.com/anthropics/claude-code/issues/63060",
+      "title": "[BUG] API Error: Usage credits required for 1M context",
+      "impact": "not_applicable",
+      "categories": [
+        "terminal"
+      ],
+      "tokenkey_status": "not_applicable",
+      "rationale": "Client-side claude-code concern (terminal); not a gateway/relay relevance signal.",
+      "updated_at": "2026-06-03T03:30:31Z"
+    },
+    {
+      "upstream": "anthropics/claude-code#63138",
+      "url": "https://github.com/anthropics/claude-code/issues/63138",
+      "title": "[Bug] VSCode terminal output displays corrupted text with garbled symbols",
+      "impact": "not_applicable",
+      "categories": [
+        "ide",
+        "terminal"
+      ],
+      "tokenkey_status": "not_applicable",
+      "rationale": "Client-side claude-code concern (ide, terminal); not a gateway/relay relevance signal.",
+      "updated_at": "2026-05-31T22:50:24Z"
+    },
+    {
+      "upstream": "anthropics/claude-code#63238",
+      "url": "https://github.com/anthropics/claude-code/issues/63238",
+      "title": "[BUG] Persistent \"update available\" notification despite being on latest version",
+      "impact": "not_applicable",
+      "categories": [
+        "terminal",
+        "platform"
+      ],
+      "tokenkey_status": "not_applicable",
+      "rationale": "Client-side claude-code concern (terminal, platform); not a gateway/relay relevance signal.",
+      "updated_at": "2026-06-02T17:02:14Z"
+    },
+    {
+      "upstream": "anthropics/claude-code#63298",
+      "url": "https://github.com/anthropics/claude-code/issues/63298",
+      "title": "[DOCS] Agent view dispatch input docs incorrectly imply `/logout` dispatches as a prompt",
+      "impact": "not_applicable",
+      "categories": [
+        "slash_hook"
+      ],
+      "tokenkey_status": "not_applicable",
+      "rationale": "Client-side claude-code concern (slash_hook); not a gateway/relay relevance signal.",
+      "updated_at": "2026-06-01T01:38:10Z"
+    },
+    {
+      "upstream": "anthropics/claude-code#63304",
+      "url": "https://github.com/anthropics/claude-code/issues/63304",
+      "title": "VSCode Chrome integration silently fails: 3 distinct bugs",
+      "impact": "not_applicable",
+      "categories": [
+        "ide",
+        "mcp",
+        "install"
+      ],
+      "tokenkey_status": "not_applicable",
+      "rationale": "Client-side claude-code concern (ide, mcp, install); not a gateway/relay relevance signal.",
+      "updated_at": "2026-06-01T12:16:26Z"
+    },
+    {
+      "upstream": "anthropics/claude-code#63315",
+      "url": "https://github.com/anthropics/claude-code/issues/63315",
+      "title": "[DOCS] Background session docs omit worktree-isolation behavior for spawned subagents",
+      "impact": "not_applicable",
+      "categories": [
+        "plugin"
+      ],
+      "tokenkey_status": "not_applicable",
+      "rationale": "Client-side claude-code concern (plugin); not a gateway/relay relevance signal.",
+      "updated_at": "2026-06-01T01:27:14Z"
+    },
+    {
+      "upstream": "anthropics/claude-code#63353",
+      "url": "https://github.com/anthropics/claude-code/issues/63353",
+      "title": "[UNACCEPTABLE/UNRESOLVED] Cannot open a folder in the desktop app on Windows — 7 closed issues, zero fixes, paying customers locked out of basic IDE functionality for 2+ months",
+      "impact": "not_applicable",
+      "categories": [
+        "ide",
+        "terminal",
+        "install",
+        "platform"
+      ],
+      "tokenkey_status": "not_applicable",
+      "rationale": "Client-side claude-code concern (ide, terminal, install, platform); not a gateway/relay relevance signal.",
+      "updated_at": "2026-06-03T06:43:33Z"
+    },
+    {
+      "upstream": "anthropics/claude-code#63370",
+      "url": "https://github.com/anthropics/claude-code/issues/63370",
+      "title": "Hook path with spaces in username executes wrong file on Windows — unquoted ~ expansion splits path at space",
+      "impact": "not_applicable",
+      "categories": [
+        "slash_hook",
+        "install",
+        "platform"
+      ],
+      "tokenkey_status": "not_applicable",
+      "rationale": "Client-side claude-code concern (slash_hook, install, platform); not a gateway/relay relevance signal.",
+      "updated_at": "2026-06-02T00:15:58Z"
+    },
+    {
+      "upstream": "anthropics/claude-code#63462",
+      "url": "https://github.com/anthropics/claude-code/issues/63462",
+      "title": "Phantom `⏺ Human:` lines appearing in transcript — assistant acts on instructions the user never typed",
+      "impact": "not_applicable",
+      "categories": [
+        "terminal",
+        "slash_hook"
+      ],
+      "tokenkey_status": "not_applicable",
+      "rationale": "Client-side claude-code concern (terminal, slash_hook); not a gateway/relay relevance signal.",
+      "updated_at": "2026-06-02T18:56:24Z"
+    },
+    {
+      "upstream": "anthropics/claude-code#63479",
+      "url": "https://github.com/anthropics/claude-code/issues/63479",
+      "title": "[BUG] CLAUDE_CODE_DISABLE_1M_CONTEXT ignored in 2.1.156",
+      "impact": "not_applicable",
+      "categories": [
+        "terminal"
+      ],
+      "tokenkey_status": "not_applicable",
+      "rationale": "Client-side claude-code concern (terminal); not a gateway/relay relevance signal.",
+      "updated_at": "2026-05-31T17:06:55Z"
+    },
+    {
+      "upstream": "anthropics/claude-code#63488",
+      "url": "https://github.com/anthropics/claude-code/issues/63488",
+      "title": "[Feature Request] Add timestamp display for conversation interactions",
+      "impact": "not_applicable",
+      "categories": [
+        "terminal",
+        "mcp",
+        "plugin"
+      ],
+      "tokenkey_status": "not_applicable",
+      "rationale": "Client-side claude-code concern (terminal, mcp, plugin); not a gateway/relay relevance signal.",
+      "updated_at": "2026-06-02T15:01:25Z"
+    },
+    {
+      "upstream": "anthropics/claude-code#63531",
+      "url": "https://github.com/anthropics/claude-code/issues/63531",
+      "title": "[BUG] ClaudeCodeManager-VM Checksum Mismatch on macOS Apple Silicon — v1.9659.2",
+      "impact": "not_applicable",
+      "categories": [
+        "terminal",
+        "install"
+      ],
+      "tokenkey_status": "not_applicable",
+      "rationale": "Client-side claude-code concern (terminal, install); not a gateway/relay relevance signal.",
+      "updated_at": "2026-06-03T06:17:20Z"
+    },
+    {
+      "upstream": "anthropics/claude-code#63545",
+      "url": "https://github.com/anthropics/claude-code/issues/63545",
+      "title": "Claude Code inside tmux: scroll hits input not scrollback, no rich mode (\"waiting for output\"), transcript not saved",
+      "impact": "not_applicable",
+      "categories": [
+        "terminal"
+      ],
+      "tokenkey_status": "not_applicable",
+      "rationale": "Client-side claude-code concern (terminal); not a gateway/relay relevance signal.",
+      "updated_at": "2026-06-01T17:06:20Z"
+    },
+    {
+      "upstream": "anthropics/claude-code#63547",
+      "url": "https://github.com/anthropics/claude-code/issues/63547",
+      "title": "[Regression 1.9659.2] computer-use tools disconnect after first use in Code mode (Windows)",
+      "impact": "not_applicable",
+      "categories": [
+        "terminal",
+        "mcp",
+        "platform"
+      ],
+      "tokenkey_status": "not_applicable",
+      "rationale": "Client-side claude-code concern (terminal, mcp, platform); not a gateway/relay relevance signal.",
+      "updated_at": "2026-06-02T17:40:13Z"
+    },
+    {
+      "upstream": "anthropics/claude-code#63559",
+      "url": "https://github.com/anthropics/claude-code/issues/63559",
+      "title": "[Bug] Frequent ECONNRESET errors with failed retry logic in autonomous sessions",
+      "impact": "not_applicable",
+      "categories": [
+        "terminal"
+      ],
+      "tokenkey_status": "not_applicable",
+      "rationale": "Client-side claude-code concern (terminal); not a gateway/relay relevance signal.",
+      "updated_at": "2026-06-03T05:33:12Z"
+    },
+    {
+      "upstream": "anthropics/claude-code#63576",
+      "url": "https://github.com/anthropics/claude-code/issues/63576",
+      "title": "[Bug] Parallel tool calls trigger persistent \"Cancelled\" errors",
+      "impact": "not_applicable",
+      "categories": [
+        "terminal"
+      ],
+      "tokenkey_status": "not_applicable",
+      "rationale": "Client-side claude-code concern (terminal); not a gateway/relay relevance signal.",
+      "updated_at": "2026-06-02T23:21:46Z"
+    },
+    {
+      "upstream": "anthropics/claude-code#63609",
+      "url": "https://github.com/anthropics/claude-code/issues/63609",
+      "title": "Illegal Instruction crash on CPUs without AVX since v2.1.113",
+      "impact": "not_applicable",
+      "categories": [
+        "install"
+      ],
+      "tokenkey_status": "not_applicable",
+      "rationale": "Client-side claude-code concern (install); not a gateway/relay relevance signal.",
+      "updated_at": "2026-06-01T12:02:34Z"
+    },
+    {
+      "upstream": "anthropics/claude-code#63650",
+      "url": "https://github.com/anthropics/claude-code/issues/63650",
+      "title": "[BUG] Claude Desktop blurry on high-DPI ultrawide display due to MSIX packaging blocking DPI override",
+      "impact": "not_applicable",
+      "categories": [
+        "ide",
+        "terminal",
+        "install",
+        "platform"
+      ],
+      "tokenkey_status": "not_applicable",
+      "rationale": "Client-side claude-code concern (ide, terminal, install, platform); not a gateway/relay relevance signal.",
+      "updated_at": "2026-06-02T13:45:15Z"
+    },
+    {
+      "upstream": "anthropics/claude-code#63670",
+      "url": "https://github.com/anthropics/claude-code/issues/63670",
+      "title": "Up/Down arrows jump to history instead of moving cursor through wrapped multi-line prompt input (all platforms; regressed ~2.1.15)",
+      "impact": "not_applicable",
+      "categories": [
+        "terminal",
+        "slash_hook",
+        "install",
+        "platform"
+      ],
+      "tokenkey_status": "not_applicable",
+      "rationale": "Client-side claude-code concern (terminal, slash_hook, install, platform); not a gateway/relay relevance signal.",
+      "updated_at": "2026-06-02T15:08:07Z"
+    },
+    {
+      "upstream": "anthropics/claude-code#63675",
+      "url": "https://github.com/anthropics/claude-code/issues/63675",
+      "title": "[BUG] Session working directory diverges from the directory Claude Code was launched from",
+      "impact": "not_applicable",
+      "categories": [
+        "terminal"
+      ],
+      "tokenkey_status": "not_applicable",
+      "rationale": "Client-side claude-code concern (terminal); not a gateway/relay relevance signal.",
+      "updated_at": "2026-06-02T06:12:12Z"
+    },
+    {
+      "upstream": "anthropics/claude-code#63695",
+      "url": "https://github.com/anthropics/claude-code/issues/63695",
+      "title": "Warning 'Native installation exists but ~/.local/bin is not in your PATH' fires even when ~/.local/bin is in PATH",
+      "impact": "not_applicable",
+      "categories": [
+        "ide",
+        "terminal",
+        "install"
+      ],
+      "tokenkey_status": "not_applicable",
+      "rationale": "Client-side claude-code concern (ide, terminal, install); not a gateway/relay relevance signal.",
+      "updated_at": "2026-06-02T15:47:18Z"
+    },
+    {
+      "upstream": "anthropics/claude-code#63722",
+      "url": "https://github.com/anthropics/claude-code/issues/63722",
+      "title": "[BUG] [Enterprise] CoworkVMService deadlocks MSIX updates on Windows 11 — fleet-wide",
+      "impact": "not_applicable",
+      "categories": [
+        "terminal",
+        "platform"
+      ],
+      "tokenkey_status": "not_applicable",
+      "rationale": "Client-side claude-code concern (terminal, platform); not a gateway/relay relevance signal.",
+      "updated_at": "2026-06-01T12:33:27Z"
+    },
+    {
+      "upstream": "anthropics/claude-code#63725",
+      "url": "https://github.com/anthropics/claude-code/issues/63725",
+      "title": "Workflow tool triggers on keyword 'workflow' in normal conversation",
+      "impact": "not_applicable",
+      "categories": [
+        "plugin"
+      ],
+      "tokenkey_status": "not_applicable",
+      "rationale": "Client-side claude-code concern (plugin); not a gateway/relay relevance signal.",
+      "updated_at": "2026-06-02T17:13:03Z"
+    },
+    {
+      "upstream": "anthropics/claude-code#63743",
+      "url": "https://github.com/anthropics/claude-code/issues/63743",
+      "title": "Regression (2.1.149 → 2.1.156): 1Password `op` CLI session broke in Bash tool calls on macOS",
+      "impact": "not_applicable",
+      "categories": [
+        "terminal"
+      ],
+      "tokenkey_status": "not_applicable",
+      "rationale": "Client-side claude-code concern (terminal); not a gateway/relay relevance signal.",
+      "updated_at": "2026-06-01T13:42:03Z"
+    },
+    {
+      "upstream": "anthropics/claude-code#63752",
+      "url": "https://github.com/anthropics/claude-code/issues/63752",
+      "title": "[Bug] Overly aggressive content filter blocks legitimate infrastructure debugging of timeout issues",
+      "impact": "not_applicable",
+      "categories": [
+        "terminal"
+      ],
+      "tokenkey_status": "not_applicable",
+      "rationale": "Client-side claude-code concern (terminal); not a gateway/relay relevance signal.",
+      "updated_at": "2026-06-01T06:28:22Z"
+    },
+    {
+      "upstream": "anthropics/claude-code#63755",
+      "url": "https://github.com/anthropics/claude-code/issues/63755",
+      "title": "[FEATURE] Add workflow tool to cloud scheduled tasks",
+      "impact": "not_applicable",
+      "categories": [
+        "mcp"
+      ],
+      "tokenkey_status": "not_applicable",
+      "rationale": "Client-side claude-code concern (mcp); not a gateway/relay relevance signal.",
+      "updated_at": "2026-06-01T07:12:51Z"
+    },
+    {
+      "upstream": "anthropics/claude-code#63761",
+      "url": "https://github.com/anthropics/claude-code/issues/63761",
+      "title": "[Bug] Anthropic API Error: Usage credits required for 1M context with 1M context disabled",
+      "impact": "not_applicable",
+      "categories": [
+        "terminal"
+      ],
+      "tokenkey_status": "not_applicable",
+      "rationale": "Client-side claude-code concern (terminal); not a gateway/relay relevance signal.",
+      "updated_at": "2026-06-01T16:55:50Z"
+    },
+    {
+      "upstream": "anthropics/claude-code#63800",
+      "url": "https://github.com/anthropics/claude-code/issues/63800",
+      "title": "[Bug] opus 4.8 hangs indefinitely on tool calls after extended usage, freezes on messages ending with \"let me...\"",
+      "impact": "not_applicable",
+      "categories": [
+        "terminal"
+      ],
+      "tokenkey_status": "not_applicable",
+      "rationale": "Client-side claude-code concern (terminal); not a gateway/relay relevance signal.",
+      "updated_at": "2026-06-01T07:44:30Z"
+    },
+    {
+      "upstream": "anthropics/claude-code#63839",
+      "url": "https://github.com/anthropics/claude-code/issues/63839",
+      "title": "[BUG] Session not found on disk for all sessions except most recent after update to 1.9659.2 (May 28)",
+      "impact": "not_applicable",
+      "categories": [
+        "terminal"
+      ],
+      "tokenkey_status": "not_applicable",
+      "rationale": "Client-side claude-code concern (terminal); not a gateway/relay relevance signal.",
+      "updated_at": "2026-06-01T21:11:40Z"
+    },
+    {
+      "upstream": "anthropics/claude-code#63860",
+      "url": "https://github.com/anthropics/claude-code/issues/63860",
+      "title": "[FEATURE] raw terminal output option",
+      "impact": "not_applicable",
+      "categories": [
+        "terminal"
+      ],
+      "tokenkey_status": "not_applicable",
+      "rationale": "Client-side claude-code concern (terminal); not a gateway/relay relevance signal.",
+      "updated_at": "2026-06-01T04:35:43Z"
+    },
+    {
+      "upstream": "anthropics/claude-code#63881",
+      "url": "https://github.com/anthropics/claude-code/issues/63881",
+      "title": "[Bug] Parallel tool calls hang on Bash execution errors",
+      "impact": "not_applicable",
+      "categories": [
+        "ide",
+        "terminal"
+      ],
+      "tokenkey_status": "not_applicable",
+      "rationale": "Client-side claude-code concern (ide, terminal); not a gateway/relay relevance signal.",
+      "updated_at": "2026-05-31T11:14:54Z"
+    },
+    {
+      "upstream": "anthropics/claude-code#63884",
+      "url": "https://github.com/anthropics/claude-code/issues/63884",
+      "title": "[MODEL] Opus 4.8 starts hallucinating results before parallel tasks finish",
+      "impact": "not_applicable",
+      "categories": [
+        "ide",
+        "terminal"
+      ],
+      "tokenkey_status": "not_applicable",
+      "rationale": "Client-side claude-code concern (ide, terminal); not a gateway/relay relevance signal.",
+      "updated_at": "2026-06-01T00:20:18Z"
+    },
+    {
+      "upstream": "anthropics/claude-code#63903",
+      "url": "https://github.com/anthropics/claude-code/issues/63903",
+      "title": "[BUG] autoMemoryEnabled=false does not suppress the ~11-16k memory preamble (re: closed #44829)",
+      "impact": "not_applicable",
+      "categories": [
+        "slash_hook"
+      ],
+      "tokenkey_status": "not_applicable",
+      "rationale": "Client-side claude-code concern (slash_hook); not a gateway/relay relevance signal.",
+      "updated_at": "2026-06-01T15:23:01Z"
+    },
+    {
+      "upstream": "anthropics/claude-code#63904",
+      "url": "https://github.com/anthropics/claude-code/issues/63904",
+      "title": "[BUG] Session visible in UI but \"Session not found on disk\" — JSONL file exists but has mismatched internal session ID",
+      "impact": "not_applicable",
+      "categories": [
+        "terminal",
+        "platform"
+      ],
+      "tokenkey_status": "not_applicable",
+      "rationale": "Client-side claude-code concern (terminal, platform); not a gateway/relay relevance signal.",
+      "updated_at": "2026-06-01T09:20:37Z"
+    },
+    {
+      "upstream": "anthropics/claude-code#63908",
+      "url": "https://github.com/anthropics/claude-code/issues/63908",
+      "title": "[BUG] Something went wrong Try sending your message again. If it keeps happening, share feedback so we can investigate. API Error: Usage credits required for 1M context · turn on usage credits at claude.ai/settings/usage, or use",
+      "impact": "not_applicable",
+      "categories": [
+        "terminal"
+      ],
+      "tokenkey_status": "not_applicable",
+      "rationale": "Client-side claude-code concern (terminal); not a gateway/relay relevance signal.",
+      "updated_at": "2026-06-02T21:52:06Z"
+    },
+    {
+      "upstream": "anthropics/claude-code#63925",
+      "url": "https://github.com/anthropics/claude-code/issues/63925",
+      "title": "[Feature Request] Add settings to disable auto-attaching active editor file and selection by default",
+      "impact": "not_applicable",
+      "categories": [
+        "ide",
+        "slash_hook"
+      ],
+      "tokenkey_status": "not_applicable",
+      "rationale": "Client-side claude-code concern (ide, slash_hook); not a gateway/relay relevance signal.",
+      "updated_at": "2026-06-02T16:47:46Z"
+    },
+    {
+      "upstream": "anthropics/claude-code#63938",
+      "url": "https://github.com/anthropics/claude-code/issues/63938",
+      "title": "Feature Request: Configurable concurrent subagent limit in workflows",
+      "impact": "not_applicable",
+      "categories": [
+        "plugin",
+        "slash_hook"
+      ],
+      "tokenkey_status": "not_applicable",
+      "rationale": "Client-side claude-code concern (plugin, slash_hook); not a gateway/relay relevance signal.",
+      "updated_at": "2026-06-01T16:43:46Z"
+    },
+    {
+      "upstream": "anthropics/claude-code#63954",
+      "url": "https://github.com/anthropics/claude-code/issues/63954",
+      "title": "[BUG] Abnormal Session Limit Drain Since Opus 4.8 Rollout (May 28, 2026) — VSCode Extension, Pro Plan, Windows",
+      "impact": "not_applicable",
+      "categories": [
+        "ide",
+        "terminal",
+        "platform"
+      ],
+      "tokenkey_status": "not_applicable",
+      "rationale": "Client-side claude-code concern (ide, terminal, platform); not a gateway/relay relevance signal.",
+      "updated_at": "2026-05-31T23:46:59Z"
+    },
+    {
+      "upstream": "anthropics/claude-code#64001",
+      "url": "https://github.com/anthropics/claude-code/issues/64001",
+      "title": "[BUG] Plugin directory does not render in Claude Desktop",
+      "impact": "not_applicable",
+      "categories": [
+        "terminal",
+        "plugin",
+        "install",
+        "platform"
+      ],
+      "tokenkey_status": "not_applicable",
+      "rationale": "Client-side claude-code concern (terminal, plugin, install, platform); not a gateway/relay relevance signal.",
+      "updated_at": "2026-05-31T23:15:08Z"
+    },
+    {
+      "upstream": "anthropics/claude-code#64020",
+      "url": "https://github.com/anthropics/claude-code/issues/64020",
+      "title": "Animated gradient drains battery. Still causes ~40% WindowServer CPU with prefersReducedMotion:true (regression / #25575 not fixed)",
+      "impact": "not_applicable",
+      "categories": [
+        "terminal",
+        "slash_hook"
+      ],
+      "tokenkey_status": "not_applicable",
+      "rationale": "Client-side claude-code concern (terminal, slash_hook); not a gateway/relay relevance signal.",
+      "updated_at": "2026-06-02T08:06:41Z"
+    },
+    {
+      "upstream": "anthropics/claude-code#64048",
+      "url": "https://github.com/anthropics/claude-code/issues/64048",
+      "title": "[MODEL] Claude confabulated a prompt-injection payload in a file before the file-read result returned",
+      "impact": "not_applicable",
+      "categories": [
+        "slash_hook"
+      ],
+      "tokenkey_status": "not_applicable",
+      "rationale": "Client-side claude-code concern (slash_hook); not a gateway/relay relevance signal.",
+      "updated_at": "2026-05-31T16:19:47Z"
+    },
+    {
+      "upstream": "anthropics/claude-code#64086",
+      "url": "https://github.com/anthropics/claude-code/issues/64086",
+      "title": "Feature request: j/k vim navigation in interactive selection menus (e.g. /effort)",
+      "impact": "not_applicable",
+      "categories": [
+        "terminal"
+      ],
+      "tokenkey_status": "not_applicable",
+      "rationale": "Client-side claude-code concern (terminal); not a gateway/relay relevance signal.",
+      "updated_at": "2026-06-01T05:14:53Z"
+    },
+    {
+      "upstream": "anthropics/claude-code#64108",
+      "url": "https://github.com/anthropics/claude-code/issues/64108",
+      "title": "Tool calls intermittently emitted as literal text (stray 'court' + raw <invoke>) instead of executing — mostly Edit/Read (Opus, CLI)",
+      "impact": "not_applicable",
+      "categories": [
+        "terminal"
+      ],
+      "tokenkey_status": "not_applicable",
+      "rationale": "Client-side claude-code concern (terminal); not a gateway/relay relevance signal.",
+      "updated_at": "2026-06-02T20:45:18Z"
+    },
+    {
+      "upstream": "anthropics/claude-code#64136",
+      "url": "https://github.com/anthropics/claude-code/issues/64136",
+      "title": "v2.1.158 (Opus 4.8): main session missing Grep/Glob, Bash storms, duplicate Bash commands, fabricated branches/commits/files, excessive shell text commands",
+      "impact": "not_applicable",
+      "categories": [
+        "plugin"
+      ],
+      "tokenkey_status": "not_applicable",
+      "rationale": "Client-side claude-code concern (plugin); not a gateway/relay relevance signal.",
+      "updated_at": "2026-06-02T23:15:41Z"
+    },
+    {
+      "upstream": "anthropics/claude-code#64144",
+      "url": "https://github.com/anthropics/claude-code/issues/64144",
+      "title": "In-flight /btw side conversation silently lost on Code -> Cowork -> Code switch (data loss)",
+      "impact": "not_applicable",
+      "categories": [
+        "terminal"
+      ],
+      "tokenkey_status": "not_applicable",
+      "rationale": "Client-side claude-code concern (terminal); not a gateway/relay relevance signal.",
+      "updated_at": "2026-05-31T22:17:37Z"
+    },
+    {
+      "upstream": "anthropics/claude-code#64192",
+      "url": "https://github.com/anthropics/claude-code/issues/64192",
+      "title": "TaskCreate 'task tools haven't been used recently' system-reminder fires repeatedly per long session — needs suppression knob (cross-repo from AaaS-Love/.claude#2048)",
+      "impact": "not_applicable",
+      "categories": [
+        "slash_hook"
+      ],
+      "tokenkey_status": "not_applicable",
+      "rationale": "Client-side claude-code concern (slash_hook); not a gateway/relay relevance signal.",
+      "updated_at": "2026-05-31T10:56:27Z"
+    },
+    {
+      "upstream": "anthropics/claude-code#64193",
+      "url": "https://github.com/anthropics/claude-code/issues/64193",
+      "title": "[Feature/UX] Yellow notification dot never clears on read + no way to configure dot behaviour",
+      "impact": "not_applicable",
+      "categories": [
+        "terminal",
+        "slash_hook",
+        "platform"
+      ],
+      "tokenkey_status": "not_applicable",
+      "rationale": "Client-side claude-code concern (terminal, slash_hook, platform); not a gateway/relay relevance signal.",
+      "updated_at": "2026-05-31T11:02:35Z"
+    },
+    {
+      "upstream": "anthropics/claude-code#64194",
+      "url": "https://github.com/anthropics/claude-code/issues/64194",
+      "title": "Token waste bug: Workflow spawned 44 parallel agents to read files instead of using git clone (2M tokens vs ~1000)",
+      "impact": "not_applicable",
+      "categories": [
+        "platform"
+      ],
+      "tokenkey_status": "not_applicable",
+      "rationale": "Client-side claude-code concern (platform); not a gateway/relay relevance signal.",
+      "updated_at": "2026-05-31T21:17:24Z"
+    },
+    {
+      "upstream": "anthropics/claude-code#64197",
+      "url": "https://github.com/anthropics/claude-code/issues/64197",
+      "title": "[BUG] macOS: npm/Homebrew install places native binary at bin/claude.exe, causing recurring \"claude.exe would like to access data from other apps\" TCC prompts",
+      "impact": "not_applicable",
+      "categories": [
+        "terminal",
+        "install",
+        "platform"
+      ],
+      "tokenkey_status": "not_applicable",
+      "rationale": "Client-side claude-code concern (terminal, install, platform); not a gateway/relay relevance signal.",
+      "updated_at": "2026-05-31T11:04:30Z"
+    },
+    {
+      "upstream": "anthropics/claude-code#64199",
+      "url": "https://github.com/anthropics/claude-code/issues/64199",
+      "title": "Unsent draft text lost when switching sessions (VS Code extension)",
+      "impact": "not_applicable",
+      "categories": [
+        "ide"
+      ],
+      "tokenkey_status": "not_applicable",
+      "rationale": "Client-side claude-code concern (ide); not a gateway/relay relevance signal.",
+      "updated_at": "2026-05-31T11:23:52Z"
+    },
+    {
+      "upstream": "anthropics/claude-code#64200",
+      "url": "https://github.com/anthropics/claude-code/issues/64200",
+      "title": "I'm ready to help generate a GitHub issue title for Claude Code, but I don't see a bug report in your message. Please provide the bug report details, and I'll create a concise technical issue title following the guidelines you've outlined.",
+      "impact": "not_applicable",
+      "categories": [
+        "ide",
+        "terminal"
+      ],
+      "tokenkey_status": "not_applicable",
+      "rationale": "Client-side claude-code concern (ide, terminal); not a gateway/relay relevance signal.",
+      "updated_at": "2026-05-31T11:21:18Z"
+    },
+    {
+      "upstream": "anthropics/claude-code#64201",
+      "url": "https://github.com/anthropics/claude-code/issues/64201",
+      "title": "[BUG] Title: Auth URL line-wraps in JetBrains IDE terminal, making clickable link invalid",
+      "impact": "not_applicable",
+      "categories": [
+        "ide",
+        "terminal",
+        "platform"
+      ],
+      "tokenkey_status": "not_applicable",
+      "rationale": "Client-side claude-code concern (ide, terminal, platform); not a gateway/relay relevance signal.",
+      "updated_at": "2026-05-31T11:24:28Z"
+    },
+    {
+      "upstream": "anthropics/claude-code#64202",
+      "url": "https://github.com/anthropics/claude-code/issues/64202",
+      "title": "Regression in 2.1.158: claude -p hangs waiting for stdin EOF on Termux/arm64",
+      "impact": "not_applicable",
+      "categories": [
+        "install"
+      ],
+      "tokenkey_status": "not_applicable",
+      "rationale": "Client-side claude-code concern (install); not a gateway/relay relevance signal.",
+      "updated_at": "2026-06-02T01:28:06Z"
+    },
+    {
+      "upstream": "anthropics/claude-code#64203",
+      "url": "https://github.com/anthropics/claude-code/issues/64203",
+      "title": "[Bug Report: Model performance degradation on project tasks",
+      "impact": "not_applicable",
+      "categories": [
+        "terminal"
+      ],
+      "tokenkey_status": "not_applicable",
+      "rationale": "Client-side claude-code concern (terminal); not a gateway/relay relevance signal.",
+      "updated_at": "2026-05-31T11:49:18Z"
+    },
+    {
+      "upstream": "anthropics/claude-code#64204",
+      "url": "https://github.com/anthropics/claude-code/issues/64204",
+      "title": "[Feature Request] Message queuing for sequential task execution in VSCodeClaude extension",
+      "impact": "not_applicable",
+      "categories": [
+        "ide"
+      ],
+      "tokenkey_status": "not_applicable",
+      "rationale": "Client-side claude-code concern (ide); not a gateway/relay relevance signal.",
+      "updated_at": "2026-05-31T11:56:00Z"
+    },
+    {
+      "upstream": "anthropics/claude-code#64205",
+      "url": "https://github.com/anthropics/claude-code/issues/64205",
+      "title": "[Feature Request] Background task execution without conversation blocking in VSCode Claude extension",
+      "impact": "not_applicable",
+      "categories": [
+        "ide"
+      ],
+      "tokenkey_status": "not_applicable",
+      "rationale": "Client-side claude-code concern (ide); not a gateway/relay relevance signal.",
+      "updated_at": "2026-05-31T11:56:52Z"
+    },
+    {
+      "upstream": "anthropics/claude-code#64207",
+      "url": "https://github.com/anthropics/claude-code/issues/64207",
+      "title": "[FEATURE] Terminal (TUI): inline colored annotations + deferred batch reply to specific blocks of Claude's output (reviving #45904)",
+      "impact": "not_applicable",
+      "categories": [
+        "ide",
+        "terminal",
+        "platform"
+      ],
+      "tokenkey_status": "not_applicable",
+      "rationale": "Client-side claude-code concern (ide, terminal, platform); not a gateway/relay relevance signal.",
+      "updated_at": "2026-05-31T12:13:00Z"
+    },
+    {
+      "upstream": "anthropics/claude-code#64210",
+      "url": "https://github.com/anthropics/claude-code/issues/64210",
+      "title": "V8 out-of-memory crashes (SIGABRT) freeze/kill the TUI during long sessions on macOS",
+      "impact": "not_applicable",
+      "categories": [
+        "ide",
+        "terminal"
+      ],
+      "tokenkey_status": "not_applicable",
+      "rationale": "Client-side claude-code concern (ide, terminal); not a gateway/relay relevance signal.",
+      "updated_at": "2026-05-31T12:36:10Z"
+    },
+    {
+      "upstream": "anthropics/claude-code#64211",
+      "url": "https://github.com/anthropics/claude-code/issues/64211",
+      "title": "Session cut mid-task by credit limit — no warning, context lost, costly model switch",
+      "impact": "not_applicable",
+      "categories": [
+        "platform"
+      ],
+      "tokenkey_status": "not_applicable",
+      "rationale": "Client-side claude-code concern (platform); not a gateway/relay relevance signal.",
+      "updated_at": "2026-05-31T12:41:09Z"
+    },
+    {
+      "upstream": "anthropics/claude-code#64214",
+      "url": "https://github.com/anthropics/claude-code/issues/64214",
+      "title": "[BUG] Agent View (Linux): mouse wheel sends arrow keys instead of scrolling attached session — works on macOS, fails on all Linux terminals",
+      "impact": "not_applicable",
+      "categories": [
+        "terminal"
+      ],
+      "tokenkey_status": "not_applicable",
+      "rationale": "Client-side claude-code concern (terminal); not a gateway/relay relevance signal.",
+      "updated_at": "2026-06-01T09:10:14Z"
+    },
+    {
+      "upstream": "anthropics/claude-code#64215",
+      "url": "https://github.com/anthropics/claude-code/issues/64215",
+      "title": "iPad browser (vscode.dev): newlines not rendered in message display",
+      "impact": "not_applicable",
+      "categories": [
+        "ide",
+        "terminal"
+      ],
+      "tokenkey_status": "not_applicable",
+      "rationale": "Client-side claude-code concern (ide, terminal); not a gateway/relay relevance signal.",
+      "updated_at": "2026-05-31T12:55:16Z"
+    },
+    {
+      "upstream": "anthropics/claude-code#64217",
+      "url": "https://github.com/anthropics/claude-code/issues/64217",
+      "title": "[Bug] Tool use regression in version 4.8 causing premature termination and parallel execution issues",
+      "impact": "not_applicable",
+      "categories": [
+        "terminal"
+      ],
+      "tokenkey_status": "not_applicable",
+      "rationale": "Client-side claude-code concern (terminal); not a gateway/relay relevance signal.",
+      "updated_at": "2026-05-31T13:51:00Z"
+    },
+    {
+      "upstream": "anthropics/claude-code#64218",
+      "url": "https://github.com/anthropics/claude-code/issues/64218",
+      "title": "[Bug] Bash tool executes commands multiple times with duplicate outputs",
+      "impact": "not_applicable",
+      "categories": [
+        "terminal"
+      ],
+      "tokenkey_status": "not_applicable",
+      "rationale": "Client-side claude-code concern (terminal); not a gateway/relay relevance signal.",
+      "updated_at": "2026-05-31T13:42:20Z"
+    },
+    {
+      "upstream": "anthropics/claude-code#64219",
+      "url": "https://github.com/anthropics/claude-code/issues/64219",
+      "title": "[Bug] Tool results delivered with multi-turn lag and flushed in batch",
+      "impact": "not_applicable",
+      "categories": [
+        "terminal",
+        "slash_hook"
+      ],
+      "tokenkey_status": "not_applicable",
+      "rationale": "Client-side claude-code concern (terminal, slash_hook); not a gateway/relay relevance signal.",
+      "updated_at": "2026-05-31T13:18:58Z"
+    },
+    {
+      "upstream": "anthropics/claude-code#64220",
+      "url": "https://github.com/anthropics/claude-code/issues/64220",
+      "title": "[BUG] /init silently misses source files in repos with many files due to Glob truncation",
+      "impact": "not_applicable",
+      "categories": [
+        "terminal",
+        "install",
+        "platform"
+      ],
+      "tokenkey_status": "not_applicable",
+      "rationale": "Client-side claude-code concern (terminal, install, platform); not a gateway/relay relevance signal.",
+      "updated_at": "2026-05-31T13:18:32Z"
+    },
+    {
+      "upstream": "anthropics/claude-code#64221",
+      "url": "https://github.com/anthropics/claude-code/issues/64221",
+      "title": "[Bug] Reasoning interruption in ultramode v4.8+ requires manual restart",
+      "impact": "not_applicable",
+      "categories": [
+        "terminal"
+      ],
+      "tokenkey_status": "not_applicable",
+      "rationale": "Client-side claude-code concern (terminal); not a gateway/relay relevance signal.",
+      "updated_at": "2026-05-31T13:26:51Z"
+    },
+    {
+      "upstream": "anthropics/claude-code#64222",
+      "url": "https://github.com/anthropics/claude-code/issues/64222",
+      "title": "[BUG] Android app: web-search permission modal fails to appear in remote-control Code session, leaving the model stuck in an execution loop (recoverable from PC, not from Android)",
+      "impact": "not_applicable",
+      "categories": [
+        "terminal"
+      ],
+      "tokenkey_status": "not_applicable",
+      "rationale": "Client-side claude-code concern (terminal); not a gateway/relay relevance signal.",
+      "updated_at": "2026-06-02T16:59:11Z"
+    },
+    {
+      "upstream": "anthropics/claude-code#64224",
+      "url": "https://github.com/anthropics/claude-code/issues/64224",
+      "title": "Feature: first-class GitCommit action (bypass Bash argv for commit messages)",
+      "impact": "not_applicable",
+      "categories": [
+        "slash_hook",
+        "platform"
+      ],
+      "tokenkey_status": "not_applicable",
+      "rationale": "Client-side claude-code concern (slash_hook, platform); not a gateway/relay relevance signal.",
+      "updated_at": "2026-05-31T13:34:50Z"
+    },
+    {
+      "upstream": "anthropics/claude-code#64225",
+      "url": "https://github.com/anthropics/claude-code/issues/64225",
+      "title": "[BUG]",
+      "impact": "not_applicable",
+      "categories": [
+        "ide",
+        "terminal"
+      ],
+      "tokenkey_status": "not_applicable",
+      "rationale": "Client-side claude-code concern (ide, terminal); not a gateway/relay relevance signal.",
+      "updated_at": "2026-05-31T15:16:29Z"
+    },
+    {
+      "upstream": "anthropics/claude-code#64226",
+      "url": "https://github.com/anthropics/claude-code/issues/64226",
+      "title": "[BUG]",
+      "impact": "not_applicable",
+      "categories": [
+        "terminal",
+        "slash_hook",
+        "platform"
+      ],
+      "tokenkey_status": "not_applicable",
+      "rationale": "Client-side claude-code concern (terminal, slash_hook, platform); not a gateway/relay relevance signal.",
+      "updated_at": "2026-05-31T13:39:18Z"
+    },
+    {
+      "upstream": "anthropics/claude-code#64228",
+      "url": "https://github.com/anthropics/claude-code/issues/64228",
+      "title": "Tool results delayed and duplicated in interactive sessions (v2.1.158, Linux, multiple concurrent sessions)",
+      "impact": "not_applicable",
+      "categories": [
+        "terminal",
+        "slash_hook"
+      ],
+      "tokenkey_status": "not_applicable",
+      "rationale": "Client-side claude-code concern (terminal, slash_hook); not a gateway/relay relevance signal.",
+      "updated_at": "2026-05-31T20:29:07Z"
+    },
+    {
+      "upstream": "anthropics/claude-code#64230",
+      "url": "https://github.com/anthropics/claude-code/issues/64230",
+      "title": "False positive safety block on legitimate security audit tasks (Supabase RLS review, pnpm audit)",
+      "impact": "not_applicable",
+      "categories": [
+        "install"
+      ],
+      "tokenkey_status": "not_applicable",
+      "rationale": "Client-side claude-code concern (install); not a gateway/relay relevance signal.",
+      "updated_at": "2026-06-01T04:04:42Z"
+    },
+    {
+      "upstream": "anthropics/claude-code#64231",
+      "url": "https://github.com/anthropics/claude-code/issues/64231",
+      "title": "[FEATURE] programmatic conversation renaming in Claude Cowork",
+      "impact": "not_applicable",
+      "categories": [
+        "mcp"
+      ],
+      "tokenkey_status": "not_applicable",
+      "rationale": "Client-side claude-code concern (mcp); not a gateway/relay relevance signal.",
+      "updated_at": "2026-05-31T14:12:44Z"
+    },
+    {
+      "upstream": "anthropics/claude-code#64234",
+      "url": "https://github.com/anthropics/claude-code/issues/64234",
+      "title": "[BUG] Cowork \"Download failed\" on macOS — claude-code-vm runtime missing from app bundle",
+      "impact": "not_applicable",
+      "categories": [
+        "terminal",
+        "install"
+      ],
+      "tokenkey_status": "not_applicable",
+      "rationale": "Client-side claude-code concern (terminal, install); not a gateway/relay relevance signal.",
+      "updated_at": "2026-05-31T14:36:12Z"
+    },
+    {
+      "upstream": "anthropics/claude-code#64238",
+      "url": "https://github.com/anthropics/claude-code/issues/64238",
+      "title": "[FEATURE] Decouple LSP diagnostic auto-push from the LSP tool (keep navigation, drop publishDiagnostics)",
+      "impact": "not_applicable",
+      "categories": [
+        "plugin",
+        "slash_hook"
+      ],
+      "tokenkey_status": "not_applicable",
+      "rationale": "Client-side claude-code concern (plugin, slash_hook); not a gateway/relay relevance signal.",
+      "updated_at": "2026-05-31T14:50:31Z"
+    },
+    {
+      "upstream": "anthropics/claude-code#64239",
+      "url": "https://github.com/anthropics/claude-code/issues/64239",
+      "title": "[BUG] typescript-lsp pushes stale diagnostics on 2.1.158 (post-#17979) in TS project-references/composite workspaces",
+      "impact": "not_applicable",
+      "categories": [
+        "plugin",
+        "platform"
+      ],
+      "tokenkey_status": "not_applicable",
+      "rationale": "Client-side claude-code concern (plugin, platform); not a gateway/relay relevance signal.",
+      "updated_at": "2026-05-31T14:51:52Z"
+    },
+    {
+      "upstream": "anthropics/claude-code#64240",
+      "url": "https://github.com/anthropics/claude-code/issues/64240",
+      "title": "[BUG] Remote-control sessions (browser/mobile) silently drop attachments — shown as sent, never reach the model",
+      "impact": "not_applicable",
+      "categories": [
+        "ide",
+        "terminal",
+        "platform"
+      ],
+      "tokenkey_status": "not_applicable",
+      "rationale": "Client-side claude-code concern (ide, terminal, platform); not a gateway/relay relevance signal.",
+      "updated_at": "2026-05-31T14:54:33Z"
+    },
+    {
+      "upstream": "anthropics/claude-code#64242",
+      "url": "https://github.com/anthropics/claude-code/issues/64242",
+      "title": "iOS Dispatch sessions from mobile fail to spawn reliably",
+      "impact": "not_applicable",
+      "categories": [
+        "platform"
+      ],
+      "tokenkey_status": "not_applicable",
+      "rationale": "Client-side claude-code concern (platform); not a gateway/relay relevance signal.",
+      "updated_at": "2026-05-31T15:11:34Z"
+    },
+    {
+      "upstream": "anthropics/claude-code#64243",
+      "url": "https://github.com/anthropics/claude-code/issues/64243",
+      "title": "[BUG] Unable to copy `%PDF-1.6` text",
+      "impact": "not_applicable",
+      "categories": [
+        "terminal"
+      ],
+      "tokenkey_status": "not_applicable",
+      "rationale": "Client-side claude-code concern (terminal); not a gateway/relay relevance signal.",
+      "updated_at": "2026-05-31T15:15:04Z"
+    },
+    {
+      "upstream": "anthropics/claude-code#64244",
+      "url": "https://github.com/anthropics/claude-code/issues/64244",
+      "title": "Dispatch needs user-level persistent persona / identity injection",
+      "impact": "not_applicable",
+      "categories": [
+        "ide",
+        "mcp",
+        "slash_hook",
+        "platform"
+      ],
+      "tokenkey_status": "not_applicable",
+      "rationale": "Client-side claude-code concern (ide, mcp, slash_hook, platform); not a gateway/relay relevance signal.",
+      "updated_at": "2026-05-31T15:15:49Z"
+    },
+    {
+      "upstream": "anthropics/claude-code#64247",
+      "url": "https://github.com/anthropics/claude-code/issues/64247",
+      "title": "[Bug] Parallel tool calls cancel all siblings on single error, which appears to cause model confusion",
+      "impact": "not_applicable",
+      "categories": [
+        "terminal"
+      ],
+      "tokenkey_status": "not_applicable",
+      "rationale": "Client-side claude-code concern (terminal); not a gateway/relay relevance signal.",
+      "updated_at": "2026-05-31T17:35:40Z"
+    },
+    {
+      "upstream": "anthropics/claude-code#64248",
+      "url": "https://github.com/anthropics/claude-code/issues/64248",
+      "title": "[BUG] naming convention should not use \"-\" as the replacement for \"/\" as it creates file and directories that start with \"-\".",
+      "impact": "not_applicable",
+      "categories": [
+        "terminal"
+      ],
+      "tokenkey_status": "not_applicable",
+      "rationale": "Client-side claude-code concern (terminal); not a gateway/relay relevance signal.",
+      "updated_at": "2026-05-31T15:29:48Z"
+    },
+    {
+      "upstream": "anthropics/claude-code#64249",
+      "url": "https://github.com/anthropics/claude-code/issues/64249",
+      "title": "[Bug] Agent stalls without token consumption during execution",
+      "impact": "not_applicable",
+      "categories": [
+        "terminal"
+      ],
+      "tokenkey_status": "not_applicable",
+      "rationale": "Client-side claude-code concern (terminal); not a gateway/relay relevance signal.",
+      "updated_at": "2026-05-31T15:39:56Z"
+    },
+    {
+      "upstream": "anthropics/claude-code#64250",
+      "url": "https://github.com/anthropics/claude-code/issues/64250",
+      "title": "Advisor tool completes in UI but result never injected into model context (under Remote Control)",
+      "impact": "not_applicable",
+      "categories": [
+        "terminal",
+        "mcp"
+      ],
+      "tokenkey_status": "not_applicable",
+      "rationale": "Client-side claude-code concern (terminal, mcp); not a gateway/relay relevance signal.",
+      "updated_at": "2026-05-31T15:40:08Z"
+    },
+    {
+      "upstream": "anthropics/claude-code#64252",
+      "url": "https://github.com/anthropics/claude-code/issues/64252",
+      "title": "macOS: keybinding hint shows 'meta+w' instead of 'Option+w' (⌥W)",
+      "impact": "not_applicable",
+      "categories": [
+        "slash_hook",
+        "platform"
+      ],
+      "tokenkey_status": "not_applicable",
+      "rationale": "Client-side claude-code concern (slash_hook, platform); not a gateway/relay relevance signal.",
+      "updated_at": "2026-05-31T15:54:48Z"
+    },
+    {
+      "upstream": "anthropics/claude-code#64253",
+      "url": "https://github.com/anthropics/claude-code/issues/64253",
+      "title": "[BUG] Windows + Git Bash: tengu_cobalt_ridge experiment silently force-enables the PowerShell tool & \"Shell: PowerShell\", causing wrong-shell retries (token waste)",
+      "impact": "not_applicable",
+      "categories": [
+        "terminal",
+        "slash_hook",
+        "install",
+        "platform"
+      ],
+      "tokenkey_status": "not_applicable",
+      "rationale": "Client-side claude-code concern (terminal, slash_hook, install, platform); not a gateway/relay relevance signal.",
+      "updated_at": "2026-06-01T00:35:42Z"
+    },
+    {
+      "upstream": "anthropics/claude-code#64258",
+      "url": "https://github.com/anthropics/claude-code/issues/64258",
+      "title": "[BUG] the cowork VM startup failure (HYPERVISOR_VIRT_DISABLED) is showing as a thread-blocking modal",
+      "impact": "not_applicable",
+      "categories": [
+        "terminal",
+        "platform"
+      ],
+      "tokenkey_status": "not_applicable",
+      "rationale": "Client-side claude-code concern (terminal, platform); not a gateway/relay relevance signal.",
+      "updated_at": "2026-05-31T16:13:03Z"
+    },
+    {
+      "upstream": "anthropics/claude-code#64261",
+      "url": "https://github.com/anthropics/claude-code/issues/64261",
+      "title": "[Bug] Claude responding in Japanese when prompted in Chinese",
+      "impact": "not_applicable",
+      "categories": [
+        "terminal"
+      ],
+      "tokenkey_status": "not_applicable",
+      "rationale": "Client-side claude-code concern (terminal); not a gateway/relay relevance signal.",
+      "updated_at": "2026-05-31T16:32:41Z"
+    },
+    {
+      "upstream": "anthropics/claude-code#64262",
+      "url": "https://github.com/anthropics/claude-code/issues/64262",
+      "title": "[FEATURE] Allow users to opt out of post-compaction continuation injection via CLAUDE.md",
+      "impact": "not_applicable",
+      "categories": [
+        "ide"
+      ],
+      "tokenkey_status": "not_applicable",
+      "rationale": "Client-side claude-code concern (ide); not a gateway/relay relevance signal.",
+      "updated_at": "2026-05-31T16:46:05Z"
+    },
+    {
+      "upstream": "anthropics/claude-code#64263",
+      "url": "https://github.com/anthropics/claude-code/issues/64263",
+      "title": "[BUG] agent stuck: git-rebase preference + auto-mode -> blocked force pushes -> requires human intervention",
+      "impact": "not_applicable",
+      "categories": [
+        "terminal"
+      ],
+      "tokenkey_status": "not_applicable",
+      "rationale": "Client-side claude-code concern (terminal); not a gateway/relay relevance signal.",
+      "updated_at": "2026-05-31T16:48:30Z"
+    },
+    {
+      "upstream": "anthropics/claude-code#64264",
+      "url": "https://github.com/anthropics/claude-code/issues/64264",
+      "title": "[Feature] Add a user-facing toggle for spinner verbs / tool-use summaries in Claude Desktop",
+      "impact": "not_applicable",
+      "categories": [
+        "terminal",
+        "slash_hook"
+      ],
+      "tokenkey_status": "not_applicable",
+      "rationale": "Client-side claude-code concern (terminal, slash_hook); not a gateway/relay relevance signal.",
+      "updated_at": "2026-05-31T16:49:58Z"
+    },
+    {
+      "upstream": "anthropics/claude-code#64265",
+      "url": "https://github.com/anthropics/claude-code/issues/64265",
+      "title": "[BUG] Headless mode (`-p --output-format stream-json`) breaks AskUserQuestion handling — model continues on assumptions instead of stopping",
+      "impact": "not_applicable",
+      "categories": [
+        "terminal",
+        "slash_hook"
+      ],
+      "tokenkey_status": "not_applicable",
+      "rationale": "Client-side claude-code concern (terminal, slash_hook); not a gateway/relay relevance signal.",
+      "updated_at": "2026-05-31T16:57:35Z"
+    },
+    {
+      "upstream": "anthropics/claude-code#64268",
+      "url": "https://github.com/anthropics/claude-code/issues/64268",
+      "title": "[Bug] v2.1.156+ regression: native Read/Bash return fabricated-but-plausible content, triggering agent confabulation cascades",
+      "impact": "not_applicable",
+      "categories": [
+        "mcp"
+      ],
+      "tokenkey_status": "not_applicable",
+      "rationale": "Client-side claude-code concern (mcp); not a gateway/relay relevance signal.",
+      "updated_at": "2026-05-31T16:58:16Z"
+    },
+    {
+      "upstream": "anthropics/claude-code#64271",
+      "url": "https://github.com/anthropics/claude-code/issues/64271",
+      "title": "`claude --bg` code-writing sessions stall on permission prompts with no non-interactive way to reply (acceptEdits insufficient)",
+      "impact": "not_applicable",
+      "categories": [
+        "terminal",
+        "plugin",
+        "platform"
+      ],
+      "tokenkey_status": "not_applicable",
+      "rationale": "Client-side claude-code concern (terminal, plugin, platform); not a gateway/relay relevance signal.",
+      "updated_at": "2026-05-31T19:24:29Z"
+    },
+    {
+      "upstream": "anthropics/claude-code#64272",
+      "url": "https://github.com/anthropics/claude-code/issues/64272",
+      "title": "Docs: clarify that `claude --bg` / background dispatch sessions do not carry `agent_id` in hook payloads",
+      "impact": "not_applicable",
+      "categories": [
+        "terminal",
+        "plugin",
+        "slash_hook"
+      ],
+      "tokenkey_status": "not_applicable",
+      "rationale": "Client-side claude-code concern (terminal, plugin, slash_hook); not a gateway/relay relevance signal.",
+      "updated_at": "2026-05-31T17:23:49Z"
+    },
+    {
+      "upstream": "anthropics/claude-code#64273",
+      "url": "https://github.com/anthropics/claude-code/issues/64273",
+      "title": "Windows: background daemon keeps a directory handle after `claude rm`, blocking directory deletion",
+      "impact": "not_applicable",
+      "categories": [
+        "terminal",
+        "platform"
+      ],
+      "tokenkey_status": "not_applicable",
+      "rationale": "Client-side claude-code concern (terminal, platform); not a gateway/relay relevance signal.",
+      "updated_at": "2026-05-31T17:24:05Z"
+    },
+    {
+      "upstream": "anthropics/claude-code#64274",
+      "url": "https://github.com/anthropics/claude-code/issues/64274",
+      "title": "[Bug] Auto-accept mode ignores directory containment check for home paths ending in period",
+      "impact": "not_applicable",
+      "categories": [
+        "terminal",
+        "plugin"
+      ],
+      "tokenkey_status": "not_applicable",
+      "rationale": "Client-side claude-code concern (terminal, plugin); not a gateway/relay relevance signal.",
+      "updated_at": "2026-05-31T17:38:15Z"
+    },
+    {
+      "upstream": "anthropics/claude-code#64275",
+      "url": "https://github.com/anthropics/claude-code/issues/64275",
+      "title": "[BUG] `/insights` skill: AI-generated sections empty (returns {})",
+      "impact": "not_applicable",
+      "categories": [
+        "terminal"
+      ],
+      "tokenkey_status": "not_applicable",
+      "rationale": "Client-side claude-code concern (terminal); not a gateway/relay relevance signal.",
+      "updated_at": "2026-05-31T17:42:58Z"
+    },
+    {
+      "upstream": "anthropics/claude-code#64276",
+      "url": "https://github.com/anthropics/claude-code/issues/64276",
+      "title": "[BUG] LSP client never sends textDocument/didClose, leaking language-server resources until OOM",
+      "impact": "not_applicable",
+      "categories": [
+        "terminal",
+        "plugin",
+        "install"
+      ],
+      "tokenkey_status": "not_applicable",
+      "rationale": "Client-side claude-code concern (terminal, plugin, install); not a gateway/relay relevance signal.",
+      "updated_at": "2026-05-31T17:48:44Z"
+    },
+    {
+      "upstream": "anthropics/claude-code#64277",
+      "url": "https://github.com/anthropics/claude-code/issues/64277",
+      "title": "autoCompactEnabled does not trigger automatically despite being set to true",
+      "impact": "not_applicable",
+      "categories": [
+        "slash_hook"
+      ],
+      "tokenkey_status": "not_applicable",
+      "rationale": "Client-side claude-code concern (slash_hook); not a gateway/relay relevance signal.",
+      "updated_at": "2026-06-01T02:08:13Z"
+    },
+    {
+      "upstream": "anthropics/claude-code#64279",
+      "url": "https://github.com/anthropics/claude-code/issues/64279",
+      "title": "[Bug] Claude 4.8 model stuck in infinite loop executing spurious bash commands",
+      "impact": "not_applicable",
+      "categories": [
+        "ide",
+        "terminal"
+      ],
+      "tokenkey_status": "not_applicable",
+      "rationale": "Client-side claude-code concern (ide, terminal); not a gateway/relay relevance signal.",
+      "updated_at": "2026-06-01T03:03:11Z"
+    },
+    {
+      "upstream": "anthropics/claude-code#64282",
+      "url": "https://github.com/anthropics/claude-code/issues/64282",
+      "title": "[FEATURE] Per-banner \"Don't show again\" dismissal for MCP connection notifications",
+      "impact": "not_applicable",
+      "categories": [
+        "mcp",
+        "platform"
+      ],
+      "tokenkey_status": "not_applicable",
+      "rationale": "Client-side claude-code concern (mcp, platform); not a gateway/relay relevance signal.",
+      "updated_at": "2026-05-31T18:03:44Z"
+    },
+    {
+      "upstream": "anthropics/claude-code#64283",
+      "url": "https://github.com/anthropics/claude-code/issues/64283",
+      "title": "[Bug] Session cost significantly higher than expected; parallel agent forking causing excessive API usage",
+      "impact": "not_applicable",
+      "categories": [
+        "terminal",
+        "platform"
+      ],
+      "tokenkey_status": "not_applicable",
+      "rationale": "Client-side claude-code concern (terminal, platform); not a gateway/relay relevance signal.",
+      "updated_at": "2026-05-31T18:05:06Z"
+    },
+    {
+      "upstream": "anthropics/claude-code#64285",
+      "url": "https://github.com/anthropics/claude-code/issues/64285",
+      "title": "[Bug] Excessive token consumption on basic operations",
+      "impact": "not_applicable",
+      "categories": [
+        "ide",
+        "terminal"
+      ],
+      "tokenkey_status": "not_applicable",
+      "rationale": "Client-side claude-code concern (ide, terminal); not a gateway/relay relevance signal.",
+      "updated_at": "2026-05-31T18:13:55Z"
+    },
+    {
+      "upstream": "anthropics/claude-code#64286",
+      "url": "https://github.com/anthropics/claude-code/issues/64286",
+      "title": "[Bug] Claude Code fabricated test results and pushed untested code to main branch (Opus 4.8 @ Effort = High)",
+      "impact": "not_applicable",
+      "categories": [
+        "terminal"
+      ],
+      "tokenkey_status": "not_applicable",
+      "rationale": "Client-side claude-code concern (terminal); not a gateway/relay relevance signal.",
+      "updated_at": "2026-05-31T18:22:55Z"
+    },
+    {
+      "upstream": "anthropics/claude-code#64288",
+      "url": "https://github.com/anthropics/claude-code/issues/64288",
+      "title": "Ordered-list markdown in submitted messages gets auto-renumbered (e.g. '2.'/'5.' → '1.'/'2.'), clobbering intended numbering",
+      "impact": "not_applicable",
+      "categories": [
+        "terminal"
+      ],
+      "tokenkey_status": "not_applicable",
+      "rationale": "Client-side claude-code concern (terminal); not a gateway/relay relevance signal.",
+      "updated_at": "2026-05-31T18:16:08Z"
+    },
+    {
+      "upstream": "anthropics/claude-code#64289",
+      "url": "https://github.com/anthropics/claude-code/issues/64289",
+      "title": "Permission/question dialogs do not render in Ctrl+O transcript mode (UI hangs indefinitely)",
+      "impact": "not_applicable",
+      "categories": [
+        "terminal",
+        "install"
+      ],
+      "tokenkey_status": "not_applicable",
+      "rationale": "Client-side claude-code concern (terminal, install); not a gateway/relay relevance signal.",
+      "updated_at": "2026-05-31T18:19:48Z"
+    },
+    {
+      "upstream": "anthropics/claude-code#64290",
+      "url": "https://github.com/anthropics/claude-code/issues/64290",
+      "title": "[BUG] claude recommends adding non-existent directory to PATH",
+      "impact": "not_applicable",
+      "categories": [
+        "terminal",
+        "install"
+      ],
+      "tokenkey_status": "not_applicable",
+      "rationale": "Client-side claude-code concern (terminal, install); not a gateway/relay relevance signal.",
+      "updated_at": "2026-05-31T18:23:21Z"
+    },
+    {
+      "upstream": "anthropics/claude-code#64291",
+      "url": "https://github.com/anthropics/claude-code/issues/64291",
+      "title": "[Bug] Serializer-complete rule violation in conversation state management",
+      "impact": "not_applicable",
+      "categories": [
+        "terminal"
+      ],
+      "tokenkey_status": "not_applicable",
+      "rationale": "Client-side claude-code concern (terminal); not a gateway/relay relevance signal.",
+      "updated_at": "2026-05-31T18:26:25Z"
+    },
+    {
+      "upstream": "anthropics/claude-code#64292",
+      "url": "https://github.com/anthropics/claude-code/issues/64292",
+      "title": "[Bug] Auto-update failed - /doctor command produced no relevant output",
+      "impact": "not_applicable",
+      "categories": [
+        "terminal"
+      ],
+      "tokenkey_status": "not_applicable",
+      "rationale": "Client-side claude-code concern (terminal); not a gateway/relay relevance signal.",
+      "updated_at": "2026-05-31T18:33:16Z"
+    },
+    {
+      "upstream": "anthropics/claude-code#64293",
+      "url": "https://github.com/anthropics/claude-code/issues/64293",
+      "title": "[BUG] Personal repositories not showing in Claude Code repo picker",
+      "impact": "not_applicable",
+      "categories": [
+        "terminal",
+        "install"
+      ],
+      "tokenkey_status": "not_applicable",
+      "rationale": "Client-side claude-code concern (terminal, install); not a gateway/relay relevance signal.",
+      "updated_at": "2026-06-03T04:45:53Z"
+    },
+    {
+      "upstream": "anthropics/claude-code#64294",
+      "url": "https://github.com/anthropics/claude-code/issues/64294",
+      "title": "Files being truncated by edit in cowork with no warning and way below the 32kb limit",
+      "impact": "not_applicable",
+      "categories": [
+        "terminal",
+        "platform"
+      ],
+      "tokenkey_status": "not_applicable",
+      "rationale": "Client-side claude-code concern (terminal, platform); not a gateway/relay relevance signal.",
+      "updated_at": "2026-05-31T18:42:13Z"
+    },
+    {
+      "upstream": "anthropics/claude-code#64295",
+      "url": "https://github.com/anthropics/claude-code/issues/64295",
+      "title": "[BUG] Opus 4.7 excess token usage in Windows - 7K tokens used 52%",
+      "impact": "not_applicable",
+      "categories": [
+        "terminal",
+        "platform"
+      ],
+      "tokenkey_status": "not_applicable",
+      "rationale": "Client-side claude-code concern (terminal, platform); not a gateway/relay relevance signal.",
+      "updated_at": "2026-05-31T18:53:17Z"
+    },
+    {
+      "upstream": "anthropics/claude-code#64296",
+      "url": "https://github.com/anthropics/claude-code/issues/64296",
+      "title": "MCP: re-enumerate tools mid-session for remote-control sessions (mcp_reconnect works but is unreachable)",
+      "impact": "not_applicable",
+      "categories": [
+        "mcp"
+      ],
+      "tokenkey_status": "not_applicable",
+      "rationale": "Client-side claude-code concern (mcp); not a gateway/relay relevance signal.",
+      "updated_at": "2026-05-31T22:06:54Z"
+    },
+    {
+      "upstream": "anthropics/claude-code#64297",
+      "url": "https://github.com/anthropics/claude-code/issues/64297",
+      "title": "[BUG] claude code harness sent \"data has changed\" system reminder with 10-days old date, claude code accepted it",
+      "impact": "not_applicable",
+      "categories": [
+        "ide",
+        "terminal",
+        "slash_hook",
+        "platform"
+      ],
+      "tokenkey_status": "not_applicable",
+      "rationale": "Client-side claude-code concern (ide, terminal, slash_hook, platform); not a gateway/relay relevance signal.",
+      "updated_at": "2026-06-02T07:55:17Z"
+    },
+    {
+      "upstream": "anthropics/claude-code#64299",
+      "url": "https://github.com/anthropics/claude-code/issues/64299",
+      "title": "[Bug] Agent ignores user instructions, commands, and skills",
+      "impact": "not_applicable",
+      "categories": [
+        "terminal"
+      ],
+      "tokenkey_status": "not_applicable",
+      "rationale": "Client-side claude-code concern (terminal); not a gateway/relay relevance signal.",
+      "updated_at": "2026-06-01T13:06:01Z"
+    },
+    {
+      "upstream": "anthropics/claude-code#64300",
+      "url": "https://github.com/anthropics/claude-code/issues/64300",
+      "title": "`acceptEdits` mode does not extend to `additionalDirectories` (Edit/Write still prompt per-file)",
+      "impact": "not_applicable",
+      "categories": [
+        "ide"
+      ],
+      "tokenkey_status": "not_applicable",
+      "rationale": "Client-side claude-code concern (ide); not a gateway/relay relevance signal.",
+      "updated_at": "2026-05-31T19:23:30Z"
+    },
+    {
+      "upstream": "anthropics/claude-code#64301",
+      "url": "https://github.com/anthropics/claude-code/issues/64301",
+      "title": "Bash sandbox (bubblewrap) corrupts `!` to `\\!` in commands, making the sandbox unusable for agentic workflows",
+      "impact": "not_applicable",
+      "categories": [
+        "slash_hook",
+        "install"
+      ],
+      "tokenkey_status": "not_applicable",
+      "rationale": "Client-side claude-code concern (slash_hook, install); not a gateway/relay relevance signal.",
+      "updated_at": "2026-05-31T19:24:17Z"
+    },
+    {
+      "upstream": "anthropics/claude-code#64303",
+      "url": "https://github.com/anthropics/claude-code/issues/64303",
+      "title": "Workflow run shows \"Running 2032m\" indefinitely after the agent has died; cannot be stopped via UI Stop button or TaskStop (Run ID / Task ID both unknown)",
+      "impact": "not_applicable",
+      "categories": [
+        "plugin",
+        "platform"
+      ],
+      "tokenkey_status": "not_applicable",
+      "rationale": "Client-side claude-code concern (plugin, platform); not a gateway/relay relevance signal.",
+      "updated_at": "2026-05-31T19:57:20Z"
+    },
+    {
+      "upstream": "anthropics/claude-code#64304",
+      "url": "https://github.com/anthropics/claude-code/issues/64304",
+      "title": "Session title diverges between Desktop app and mobile/web — two independent title stores that never reconcile",
+      "impact": "not_applicable",
+      "categories": [
+        "ide",
+        "terminal",
+        "slash_hook",
+        "platform"
+      ],
+      "tokenkey_status": "not_applicable",
+      "rationale": "Client-side claude-code concern (ide, terminal, slash_hook, platform); not a gateway/relay relevance signal.",
+      "updated_at": "2026-05-31T20:13:25Z"
+    },
+    {
+      "upstream": "anthropics/claude-code#64309",
+      "url": "https://github.com/anthropics/claude-code/issues/64309",
+      "title": "Benign `node -e` regex script false-flagged as \"Fork bomb detected\"",
+      "impact": "not_applicable",
+      "categories": [
+        "ide",
+        "terminal"
+      ],
+      "tokenkey_status": "not_applicable",
+      "rationale": "Client-side claude-code concern (ide, terminal); not a gateway/relay relevance signal.",
+      "updated_at": "2026-05-31T20:01:29Z"
+    },
+    {
+      "upstream": "anthropics/claude-code#64310",
+      "url": "https://github.com/anthropics/claude-code/issues/64310",
+      "title": "Claude Code deleted client video files without confirmation — data loss on production work",
+      "impact": "not_applicable",
+      "categories": [
+        "platform"
+      ],
+      "tokenkey_status": "not_applicable",
+      "rationale": "Client-side claude-code concern (platform); not a gateway/relay relevance signal.",
+      "updated_at": "2026-05-31T20:55:32Z"
+    },
+    {
+      "upstream": "anthropics/claude-code#64311",
+      "url": "https://github.com/anthropics/claude-code/issues/64311",
+      "title": "Managed/team-seat config bypasses MCP tool-search deferral — claude.ai connector schemas re-inject into messages every turn (CC 2.1.158)",
+      "impact": "not_applicable",
+      "categories": [
+        "mcp",
+        "slash_hook"
+      ],
+      "tokenkey_status": "not_applicable",
+      "rationale": "Client-side claude-code concern (mcp, slash_hook); not a gateway/relay relevance signal.",
+      "updated_at": "2026-05-31T20:07:40Z"
+    },
+    {
+      "upstream": "anthropics/claude-code#64312",
+      "url": "https://github.com/anthropics/claude-code/issues/64312",
+      "title": "Claude Code context window not resetting — stuck at 1M instead of 200k on Pro",
+      "impact": "not_applicable",
+      "categories": [
+        "terminal",
+        "platform"
+      ],
+      "tokenkey_status": "not_applicable",
+      "rationale": "Client-side claude-code concern (terminal, platform); not a gateway/relay relevance signal.",
+      "updated_at": "2026-05-31T20:07:46Z"
+    },
+    {
+      "upstream": "anthropics/claude-code#64313",
+      "url": "https://github.com/anthropics/claude-code/issues/64313",
+      "title": "Feedback: Claude should observe existing layout structure before adding fixed/static UI elements",
+      "impact": "not_applicable",
+      "categories": [
+        "terminal"
+      ],
+      "tokenkey_status": "not_applicable",
+      "rationale": "Client-side claude-code concern (terminal); not a gateway/relay relevance signal.",
+      "updated_at": "2026-05-31T20:25:19Z"
+    },
+    {
+      "upstream": "anthropics/claude-code#64314",
+      "url": "https://github.com/anthropics/claude-code/issues/64314",
+      "title": "[Bug] Stray token \"count\" injected before tool calls causes parse failure in Claude Code",
+      "impact": "not_applicable",
+      "categories": [
+        "terminal",
+        "mcp"
+      ],
+      "tokenkey_status": "not_applicable",
+      "rationale": "Client-side claude-code concern (terminal, mcp); not a gateway/relay relevance signal.",
+      "updated_at": "2026-05-31T20:26:20Z"
+    },
+    {
+      "upstream": "anthropics/claude-code#64315",
+      "url": "https://github.com/anthropics/claude-code/issues/64315",
+      "title": "Agent tool: `isolation: \"worktree\"` creates worktree in session repo, not target repo, breaking parallel cross-repo work",
+      "impact": "not_applicable",
+      "categories": [
+        "plugin"
+      ],
+      "tokenkey_status": "not_applicable",
+      "rationale": "Client-side claude-code concern (plugin); not a gateway/relay relevance signal.",
+      "updated_at": "2026-05-31T20:26:53Z"
+    },
+    {
+      "upstream": "anthropics/claude-code#64316",
+      "url": "https://github.com/anthropics/claude-code/issues/64316",
+      "title": "[BUG] MCP: structuredContent overrides content field, losing actual tool response",
+      "impact": "not_applicable",
+      "categories": [
+        "ide",
+        "terminal",
+        "mcp",
+        "platform"
+      ],
+      "tokenkey_status": "not_applicable",
+      "rationale": "Client-side claude-code concern (ide, terminal, mcp, platform); not a gateway/relay relevance signal.",
+      "updated_at": "2026-05-31T20:46:50Z"
+    },
+    {
+      "upstream": "anthropics/claude-code#64318",
+      "url": "https://github.com/anthropics/claude-code/issues/64318",
+      "title": "computer-use MCP: browsers reported \"(not installed)\" on macOS when Spotlight is disabled, despite LaunchServices having them registered",
+      "impact": "not_applicable",
+      "categories": [
+        "mcp",
+        "install",
+        "platform"
+      ],
+      "tokenkey_status": "not_applicable",
+      "rationale": "Client-side claude-code concern (mcp, install, platform); not a gateway/relay relevance signal.",
+      "updated_at": "2026-05-31T20:32:48Z"
+    },
+    {
+      "upstream": "anthropics/claude-code#64319",
+      "url": "https://github.com/anthropics/claude-code/issues/64319",
+      "title": "Model autonomously deployed to production without user authorization",
+      "impact": "not_applicable",
+      "categories": [
+        "platform"
+      ],
+      "tokenkey_status": "not_applicable",
+      "rationale": "Client-side claude-code concern (platform); not a gateway/relay relevance signal.",
+      "updated_at": "2026-06-01T00:01:56Z"
+    },
+    {
+      "upstream": "anthropics/claude-code#64320",
+      "url": "https://github.com/anthropics/claude-code/issues/64320",
+      "title": "[BUG] Cowork shows \"yukonSilver not supported (status=unsupported)\" on Windows 11 Pro with 11th Gen Intel i5-1155G7 — VM never initializes",
+      "impact": "not_applicable",
+      "categories": [
+        "terminal",
+        "install",
+        "platform"
+      ],
+      "tokenkey_status": "not_applicable",
+      "rationale": "Client-side claude-code concern (terminal, install, platform); not a gateway/relay relevance signal.",
+      "updated_at": "2026-05-31T20:38:21Z"
+    },
+    {
+      "upstream": "anthropics/claude-code#64324",
+      "url": "https://github.com/anthropics/claude-code/issues/64324",
+      "title": "[Bug] Claude Opus 4.8 API returning increased hallucinations",
+      "impact": "not_applicable",
+      "categories": [
+        "terminal"
+      ],
+      "tokenkey_status": "not_applicable",
+      "rationale": "Client-side claude-code concern (terminal); not a gateway/relay relevance signal.",
+      "updated_at": "2026-06-01T17:17:47Z"
+    },
+    {
+      "upstream": "anthropics/claude-code#64325",
+      "url": "https://github.com/anthropics/claude-code/issues/64325",
+      "title": "[Bug] Opus 4.8 hallucinating security incidents and fabricating evidence during long tasks",
+      "impact": "not_applicable",
+      "categories": [
+        "terminal",
+        "slash_hook"
+      ],
+      "tokenkey_status": "not_applicable",
+      "rationale": "Client-side claude-code concern (terminal, slash_hook); not a gateway/relay relevance signal.",
+      "updated_at": "2026-05-31T21:10:37Z"
+    },
+    {
+      "upstream": "anthropics/claude-code#64326",
+      "url": "https://github.com/anthropics/claude-code/issues/64326",
+      "title": "[Feature Request] PostToolUse hook で output 文字列を改変 (REDACT) する機能の追加",
+      "impact": "not_applicable",
+      "categories": [
+        "slash_hook"
+      ],
+      "tokenkey_status": "not_applicable",
+      "rationale": "Client-side claude-code concern (slash_hook); not a gateway/relay relevance signal.",
+      "updated_at": "2026-05-31T21:08:29Z"
+    },
+    {
+      "upstream": "anthropics/claude-code#64331",
+      "url": "https://github.com/anthropics/claude-code/issues/64331",
+      "title": "[FEATURE] Plan mode — AskUserQuestion modal covers the agent's analysis and can't be minimized",
+      "impact": "not_applicable",
+      "categories": [
+        "ide",
+        "terminal"
+      ],
+      "tokenkey_status": "not_applicable",
+      "rationale": "Client-side claude-code concern (ide, terminal); not a gateway/relay relevance signal.",
+      "updated_at": "2026-05-31T21:26:43Z"
+    },
+    {
+      "upstream": "anthropics/claude-code#64332",
+      "url": "https://github.com/anthropics/claude-code/issues/64332",
+      "title": "[BUG] Dispatch thread permanently stuck — server-side reset required",
+      "impact": "not_applicable",
+      "categories": [
+        "terminal",
+        "platform"
+      ],
+      "tokenkey_status": "not_applicable",
+      "rationale": "Client-side claude-code concern (terminal, platform); not a gateway/relay relevance signal.",
+      "updated_at": "2026-05-31T21:29:58Z"
+    },
+    {
+      "upstream": "anthropics/claude-code#64333",
+      "url": "https://github.com/anthropics/claude-code/issues/64333",
+      "title": "Batched/parallel tool calls: one failure cancels all siblings; Edit old_string match failures (Windows CRLF)",
+      "impact": "not_applicable",
+      "categories": [
+        "mcp",
+        "platform"
+      ],
+      "tokenkey_status": "not_applicable",
+      "rationale": "Client-side claude-code concern (mcp, platform); not a gateway/relay relevance signal.",
+      "updated_at": "2026-05-31T21:35:08Z"
+    },
+    {
+      "upstream": "anthropics/claude-code#64334",
+      "url": "https://github.com/anthropics/claude-code/issues/64334",
+      "title": "Bash command with 2>&1 causes ~12min spinner hang with token usage climbing during the stall",
+      "impact": "not_applicable",
+      "categories": [
+        "terminal",
+        "slash_hook"
+      ],
+      "tokenkey_status": "not_applicable",
+      "rationale": "Client-side claude-code concern (terminal, slash_hook); not a gateway/relay relevance signal.",
+      "updated_at": "2026-05-31T21:42:17Z"
+    },
+    {
+      "upstream": "anthropics/claude-code#64337",
+      "url": "https://github.com/anthropics/claude-code/issues/64337",
+      "title": "Bug: Remote Control via remoteControlAtStartup has no persistent indicator — startup notice scrolls off, nothing in status line / corner",
+      "impact": "not_applicable",
+      "categories": [
+        "terminal",
+        "slash_hook"
+      ],
+      "tokenkey_status": "not_applicable",
+      "rationale": "Client-side claude-code concern (terminal, slash_hook); not a gateway/relay relevance signal.",
+      "updated_at": "2026-05-31T22:08:11Z"
+    },
+    {
+      "upstream": "anthropics/claude-code#64338",
+      "url": "https://github.com/anthropics/claude-code/issues/64338",
+      "title": "[FEATURE] PreToolUse hook: let \"ask\" decisions set the default-highlighted prompt option",
+      "impact": "not_applicable",
+      "categories": [
+        "terminal",
+        "plugin",
+        "slash_hook",
+        "install"
+      ],
+      "tokenkey_status": "not_applicable",
+      "rationale": "Client-side claude-code concern (terminal, plugin, slash_hook, install); not a gateway/relay relevance signal.",
+      "updated_at": "2026-06-01T21:40:02Z"
+    },
+    {
+      "upstream": "anthropics/claude-code#64340",
+      "url": "https://github.com/anthropics/claude-code/issues/64340",
+      "title": "[Feature Request] Improve readline keybinding compatibility for word navigation (alt-f/alt-b)",
+      "impact": "not_applicable",
+      "categories": [
+        "terminal",
+        "slash_hook"
+      ],
+      "tokenkey_status": "not_applicable",
+      "rationale": "Client-side claude-code concern (terminal, slash_hook); not a gateway/relay relevance signal.",
+      "updated_at": "2026-05-31T22:25:52Z"
+    },
+    {
+      "upstream": "anthropics/claude-code#64341",
+      "url": "https://github.com/anthropics/claude-code/issues/64341",
+      "title": "[Bug] Model version inconsistency across devices with same account, requires reinstall",
+      "impact": "not_applicable",
+      "categories": [
+        "terminal",
+        "install"
+      ],
+      "tokenkey_status": "not_applicable",
+      "rationale": "Client-side claude-code concern (terminal, install); not a gateway/relay relevance signal.",
+      "updated_at": "2026-05-31T22:25:07Z"
+    },
+    {
+      "upstream": "anthropics/claude-code#64343",
+      "url": "https://github.com/anthropics/claude-code/issues/64343",
+      "title": "[Bug] Excessive token consumption from repeated echo tool calls",
+      "impact": "not_applicable",
+      "categories": [
+        "terminal"
+      ],
+      "tokenkey_status": "not_applicable",
+      "rationale": "Client-side claude-code concern (terminal); not a gateway/relay relevance signal.",
+      "updated_at": "2026-05-31T22:37:22Z"
+    },
+    {
+      "upstream": "anthropics/claude-code#64349",
+      "url": "https://github.com/anthropics/claude-code/issues/64349",
+      "title": "Claude Code VS Code extension forces 1M context on Pro plan - Windows",
+      "impact": "not_applicable",
+      "categories": [
+        "ide",
+        "terminal",
+        "slash_hook",
+        "install",
+        "platform"
+      ],
+      "tokenkey_status": "not_applicable",
+      "rationale": "Client-side claude-code concern (ide, terminal, slash_hook, install, platform); not a gateway/relay relevance signal.",
+      "updated_at": "2026-06-03T06:49:26Z"
+    },
+    {
+      "upstream": "anthropics/claude-code#64351",
+      "url": "https://github.com/anthropics/claude-code/issues/64351",
+      "title": "[Feature Request] Selective Context Compaction for Partial Message Pruning",
+      "impact": "not_applicable",
+      "categories": [
+        "terminal"
+      ],
+      "tokenkey_status": "not_applicable",
+      "rationale": "Client-side claude-code concern (terminal); not a gateway/relay relevance signal.",
+      "updated_at": "2026-05-31T23:06:48Z"
+    },
+    {
+      "upstream": "anthropics/claude-code#64352",
+      "url": "https://github.com/anthropics/claude-code/issues/64352",
+      "title": "Unprocessable image in context burns credits with no recovery path",
+      "impact": "not_applicable",
+      "categories": [
+        "ide",
+        "terminal"
+      ],
+      "tokenkey_status": "not_applicable",
+      "rationale": "Client-side claude-code concern (ide, terminal); not a gateway/relay relevance signal.",
+      "updated_at": "2026-06-01T03:15:38Z"
+    },
+    {
+      "upstream": "anthropics/claude-code#64353",
+      "url": "https://github.com/anthropics/claude-code/issues/64353",
+      "title": "Image attachments silently fail to upload when message has no text",
+      "impact": "not_applicable",
+      "categories": [
+        "platform"
+      ],
+      "tokenkey_status": "not_applicable",
+      "rationale": "Client-side claude-code concern (platform); not a gateway/relay relevance signal.",
+      "updated_at": "2026-05-31T23:20:10Z"
+    },
+    {
+      "upstream": "anthropics/claude-code#64356",
+      "url": "https://github.com/anthropics/claude-code/issues/64356",
+      "title": "[Bug] Agent stops responding after calling advisor tool",
+      "impact": "not_applicable",
+      "categories": [
+        "terminal"
+      ],
+      "tokenkey_status": "not_applicable",
+      "rationale": "Client-side claude-code concern (terminal); not a gateway/relay relevance signal.",
+      "updated_at": "2026-05-31T23:40:00Z"
+    },
+    {
+      "upstream": "anthropics/claude-code#64358",
+      "url": "https://github.com/anthropics/claude-code/issues/64358",
+      "title": "Update banner should show the new version (and ideally a one-line summary)",
+      "impact": "not_applicable",
+      "categories": [
+        "install",
+        "platform"
+      ],
+      "tokenkey_status": "not_applicable",
+      "rationale": "Client-side claude-code concern (install, platform); not a gateway/relay relevance signal.",
+      "updated_at": "2026-06-01T20:15:24Z"
+    },
+    {
+      "upstream": "anthropics/claude-code#64360",
+      "url": "https://github.com/anthropics/claude-code/issues/64360",
+      "title": "[BUG] Claude reaches usage limits waaaay to fast im comparison to just yesterday",
+      "impact": "not_applicable",
+      "categories": [
+        "terminal"
+      ],
+      "tokenkey_status": "not_applicable",
+      "rationale": "Client-side claude-code concern (terminal); not a gateway/relay relevance signal.",
+      "updated_at": "2026-06-01T00:54:21Z"
+    },
+    {
+      "upstream": "anthropics/claude-code#64361",
+      "url": "https://github.com/anthropics/claude-code/issues/64361",
+      "title": "SessionStart hooks crash when dispatcher routes through prompt-hook path expecting ToolUseContext",
+      "impact": "not_applicable",
+      "categories": [
+        "slash_hook"
+      ],
+      "tokenkey_status": "not_applicable",
+      "rationale": "Client-side claude-code concern (slash_hook); not a gateway/relay relevance signal.",
+      "updated_at": "2026-06-01T00:54:53Z"
+    },
+    {
+      "upstream": "anthropics/claude-code#64362",
+      "url": "https://github.com/anthropics/claude-code/issues/64362",
+      "title": "[Bug] Agent dispatch consumes excessive tokens without course-correction mechanism",
+      "impact": "not_applicable",
+      "categories": [
+        "terminal"
+      ],
+      "tokenkey_status": "not_applicable",
+      "rationale": "Client-side claude-code concern (terminal); not a gateway/relay relevance signal.",
+      "updated_at": "2026-06-01T03:07:07Z"
+    },
+    {
+      "upstream": "anthropics/claude-code#64363",
+      "url": "https://github.com/anthropics/claude-code/issues/64363",
+      "title": "Permission dialog: make button order configurable",
+      "impact": "not_applicable",
+      "categories": [
+        "slash_hook"
+      ],
+      "tokenkey_status": "not_applicable",
+      "rationale": "Client-side claude-code concern (slash_hook); not a gateway/relay relevance signal.",
+      "updated_at": "2026-06-01T02:47:16Z"
+    },
+    {
+      "upstream": "anthropics/claude-code#64365",
+      "url": "https://github.com/anthropics/claude-code/issues/64365",
+      "title": "[BUG] Claude Code executed destructive command (adb shell pm clear) against explicit user instruction, causing permanent data loss",
+      "impact": "not_applicable",
+      "categories": [
+        "terminal",
+        "platform"
+      ],
+      "tokenkey_status": "not_applicable",
+      "rationale": "Client-side claude-code concern (terminal, platform); not a gateway/relay relevance signal.",
+      "updated_at": "2026-06-01T03:07:00Z"
+    },
+    {
+      "upstream": "anthropics/claude-code#64366",
+      "url": "https://github.com/anthropics/claude-code/issues/64366",
+      "title": "[BUG] Unbounded MCP server fan-out across Cowork/agent sessions exhausts RAM and kernel-panics macOS (4 panics + forced power-off on M2 Max / 32 GB)",
+      "impact": "not_applicable",
+      "categories": [
+        "terminal",
+        "mcp"
+      ],
+      "tokenkey_status": "not_applicable",
+      "rationale": "Client-side claude-code concern (terminal, mcp); not a gateway/relay relevance signal.",
+      "updated_at": "2026-06-02T14:12:50Z"
+    },
+    {
+      "upstream": "anthropics/claude-code#64367",
+      "url": "https://github.com/anthropics/claude-code/issues/64367",
+      "title": "Conversational-deferral (patcher) behavior evades anti-defer hooks: file-content scope + ≥2-occurrence threshold blind spots",
+      "impact": "not_applicable",
+      "categories": [
+        "slash_hook"
+      ],
+      "tokenkey_status": "not_applicable",
+      "rationale": "Client-side claude-code concern (slash_hook); not a gateway/relay relevance signal.",
+      "updated_at": "2026-06-01T01:38:29Z"
+    },
+    {
+      "upstream": "anthropics/claude-code#64368",
+      "url": "https://github.com/anthropics/claude-code/issues/64368",
+      "title": "[Bug] Auto-compact triggered during commit skill causes context limit errors",
+      "impact": "not_applicable",
+      "categories": [
+        "terminal"
+      ],
+      "tokenkey_status": "not_applicable",
+      "rationale": "Client-side claude-code concern (terminal); not a gateway/relay relevance signal.",
+      "updated_at": "2026-06-01T01:41:32Z"
+    },
+    {
+      "upstream": "anthropics/claude-code#64371",
+      "url": "https://github.com/anthropics/claude-code/issues/64371",
+      "title": "Ability to delete conversation portions from context messages",
+      "impact": "not_applicable",
+      "categories": [
+        "terminal"
+      ],
+      "tokenkey_status": "not_applicable",
+      "rationale": "Client-side claude-code concern (terminal); not a gateway/relay relevance signal.",
+      "updated_at": "2026-06-01T03:16:29Z"
+    },
+    {
+      "upstream": "anthropics/claude-code#64372",
+      "url": "https://github.com/anthropics/claude-code/issues/64372",
+      "title": "[BUG] Routine scheduler skips Monday when timezone is UTC+8 (SGT/CST) — weekday check applied in UTC instead of local time",
+      "impact": "not_applicable",
+      "categories": [
+        "terminal"
+      ],
+      "tokenkey_status": "not_applicable",
+      "rationale": "Client-side claude-code concern (terminal); not a gateway/relay relevance signal.",
+      "updated_at": "2026-06-01T01:53:52Z"
+    },
+    {
+      "upstream": "anthropics/claude-code#64375",
+      "url": "https://github.com/anthropics/claude-code/issues/64375",
+      "title": "[Bug] Frequent tool execution errors with Claude 4.8 Opus model",
+      "impact": "not_applicable",
+      "categories": [
+        "ide",
+        "terminal"
+      ],
+      "tokenkey_status": "not_applicable",
+      "rationale": "Client-side claude-code concern (ide, terminal); not a gateway/relay relevance signal.",
+      "updated_at": "2026-06-01T02:27:18Z"
+    },
+    {
+      "upstream": "anthropics/claude-code#64376",
+      "url": "https://github.com/anthropics/claude-code/issues/64376",
+      "title": "[FEATURE] Multiple subscription account",
+      "impact": "not_applicable",
+      "categories": [
+        "terminal",
+        "platform"
+      ],
+      "tokenkey_status": "not_applicable",
+      "rationale": "Client-side claude-code concern (terminal, platform); not a gateway/relay relevance signal.",
+      "updated_at": "2026-06-01T02:03:33Z"
+    },
+    {
+      "upstream": "anthropics/claude-code#64377",
+      "url": "https://github.com/anthropics/claude-code/issues/64377",
+      "title": "[BUG] Why I can not use Sonnet even I have enough quota?!",
+      "impact": "not_applicable",
+      "categories": [
+        "terminal",
+        "platform"
+      ],
+      "tokenkey_status": "not_applicable",
+      "rationale": "Client-side claude-code concern (terminal, platform); not a gateway/relay relevance signal.",
+      "updated_at": "2026-06-01T16:12:40Z"
+    },
+    {
+      "upstream": "anthropics/claude-code#64378",
+      "url": "https://github.com/anthropics/claude-code/issues/64378",
+      "title": "illegal hardware instruction\" on Intel Core i5-3470S (Ivy Bridge, no AVX2) - crashes on startup",
+      "impact": "not_applicable",
+      "categories": [
+        "terminal",
+        "install"
+      ],
+      "tokenkey_status": "not_applicable",
+      "rationale": "Client-side claude-code concern (terminal, install); not a gateway/relay relevance signal.",
+      "updated_at": "2026-06-01T03:06:59Z"
+    },
+    {
+      "upstream": "anthropics/claude-code#64380",
+      "url": "https://github.com/anthropics/claude-code/issues/64380",
+      "title": "[BUG] iPad: app crashes (SIGABRT) when tapping \"Default\" environment picker — UICollectionView invalid scroll index path",
+      "impact": "not_applicable",
+      "categories": [
+        "terminal"
+      ],
+      "tokenkey_status": "not_applicable",
+      "rationale": "Client-side claude-code concern (terminal); not a gateway/relay relevance signal.",
+      "updated_at": "2026-06-01T03:06:58Z"
+    },
+    {
+      "upstream": "anthropics/claude-code#64381",
+      "url": "https://github.com/anthropics/claude-code/issues/64381",
+      "title": "[FEATURE] Computer Use support in Claude Code CLI on Windows",
+      "impact": "not_applicable",
+      "categories": [
+        "terminal",
+        "mcp",
+        "platform"
+      ],
+      "tokenkey_status": "not_applicable",
+      "rationale": "Client-side claude-code concern (terminal, mcp, platform); not a gateway/relay relevance signal.",
+      "updated_at": "2026-06-03T03:12:31Z"
+    },
+    {
+      "upstream": "anthropics/claude-code#64389",
+      "url": "https://github.com/anthropics/claude-code/issues/64389",
+      "title": "PreToolUse(Bash) hook returning permissionDecision: \"defer\" causes \"[Tool result missing due to internal error]\"",
+      "impact": "not_applicable",
+      "categories": [
+        "ide",
+        "slash_hook"
+      ],
+      "tokenkey_status": "not_applicable",
+      "rationale": "Client-side claude-code concern (ide, slash_hook); not a gateway/relay relevance signal.",
+      "updated_at": "2026-06-01T03:59:51Z"
+    },
+    {
+      "upstream": "anthropics/claude-code#64390",
+      "url": "https://github.com/anthropics/claude-code/issues/64390",
+      "title": "Tool-result transport desync/replay/fabrication in claude remote-control daemon under large parallel tool batches",
+      "impact": "not_applicable",
+      "categories": [
+        "terminal",
+        "mcp"
+      ],
+      "tokenkey_status": "not_applicable",
+      "rationale": "Client-side claude-code concern (terminal, mcp); not a gateway/relay relevance signal.",
+      "updated_at": "2026-06-01T04:02:22Z"
+    },
+    {
+      "upstream": "anthropics/claude-code#64391",
+      "url": "https://github.com/anthropics/claude-code/issues/64391",
+      "title": "[BUG] Warning \"Near weekly limit\" triggered at only 26% weekly usage",
+      "impact": "not_applicable",
+      "categories": [
+        "terminal",
+        "platform"
+      ],
+      "tokenkey_status": "not_applicable",
+      "rationale": "Client-side claude-code concern (terminal, platform); not a gateway/relay relevance signal.",
+      "updated_at": "2026-06-01T04:03:43Z"
+    },
+    {
+      "upstream": "anthropics/claude-code#64394",
+      "url": "https://github.com/anthropics/claude-code/issues/64394",
+      "title": "Feature request: UEStudio (UltraEdit Studio) IDE extension",
+      "impact": "not_applicable",
+      "categories": [
+        "ide",
+        "platform"
+      ],
+      "tokenkey_status": "not_applicable",
+      "rationale": "Client-side claude-code concern (ide, platform); not a gateway/relay relevance signal.",
+      "updated_at": "2026-06-01T04:24:53Z"
+    },
+    {
+      "upstream": "anthropics/claude-code#64395",
+      "url": "https://github.com/anthropics/claude-code/issues/64395",
+      "title": "[BUG] feature-dev plugin breaks Ctrl+V (paste) in Claude Code on Windows",
+      "impact": "not_applicable",
+      "categories": [
+        "terminal",
+        "plugin",
+        "slash_hook",
+        "platform"
+      ],
+      "tokenkey_status": "not_applicable",
+      "rationale": "Client-side claude-code concern (terminal, plugin, slash_hook, platform); not a gateway/relay relevance signal.",
+      "updated_at": "2026-06-01T04:37:46Z"
+    },
+    {
+      "upstream": "anthropics/claude-code#64398",
+      "url": "https://github.com/anthropics/claude-code/issues/64398",
+      "title": "[BUG] Pro plan blocked by \"Usage credits required for 1M context\" — no workaround works, quota available",
+      "impact": "not_applicable",
+      "categories": [
+        "ide",
+        "terminal",
+        "slash_hook",
+        "platform"
+      ],
+      "tokenkey_status": "not_applicable",
+      "rationale": "Client-side claude-code concern (ide, terminal, slash_hook, platform); not a gateway/relay relevance signal.",
+      "updated_at": "2026-06-01T05:19:16Z"
+    },
+    {
+      "upstream": "anthropics/claude-code#64399",
+      "url": "https://github.com/anthropics/claude-code/issues/64399",
+      "title": "[Bug] VSCode extension terminal setup writes keybindings to DEFAULT PROFILE instead of selected profile",
+      "impact": "not_applicable",
+      "categories": [
+        "ide",
+        "terminal",
+        "slash_hook"
+      ],
+      "tokenkey_status": "not_applicable",
+      "rationale": "Client-side claude-code concern (ide, terminal, slash_hook); not a gateway/relay relevance signal.",
+      "updated_at": "2026-06-01T05:29:43Z"
+    },
+    {
+      "upstream": "anthropics/claude-code#64400",
+      "url": "https://github.com/anthropics/claude-code/issues/64400",
+      "title": "[BUG] Keyword highlight inconsistently preserved in queued messages",
+      "impact": "not_applicable",
+      "categories": [
+        "terminal"
+      ],
+      "tokenkey_status": "not_applicable",
+      "rationale": "Client-side claude-code concern (terminal); not a gateway/relay relevance signal.",
+      "updated_at": "2026-06-01T05:20:49Z"
+    },
+    {
+      "upstream": "anthropics/claude-code#64401",
+      "url": "https://github.com/anthropics/claude-code/issues/64401",
+      "title": "[UX] Can't switch model without clearing typed input — need keybinding or inline shortcut",
+      "impact": "not_applicable",
+      "categories": [
+        "slash_hook"
+      ],
+      "tokenkey_status": "not_applicable",
+      "rationale": "Client-side claude-code concern (slash_hook); not a gateway/relay relevance signal.",
+      "updated_at": "2026-06-01T05:23:40Z"
+    },
+    {
+      "upstream": "anthropics/claude-code#64403",
+      "url": "https://github.com/anthropics/claude-code/issues/64403",
+      "title": "[BUG] Session history silently wiped after app update — no server-side backup, no export, no warning",
+      "impact": "not_applicable",
+      "categories": [
+        "terminal"
+      ],
+      "tokenkey_status": "not_applicable",
+      "rationale": "Client-side claude-code concern (terminal); not a gateway/relay relevance signal.",
+      "updated_at": "2026-06-01T08:40:38Z"
+    },
+    {
+      "upstream": "anthropics/claude-code#64404",
+      "url": "https://github.com/anthropics/claude-code/issues/64404",
+      "title": "[Bug] Infinite loop when displaying `court` word",
+      "impact": "not_applicable",
+      "categories": [
+        "terminal"
+      ],
+      "tokenkey_status": "not_applicable",
+      "rationale": "Client-side claude-code concern (terminal); not a gateway/relay relevance signal.",
+      "updated_at": "2026-06-01T05:58:31Z"
+    },
+    {
+      "upstream": "anthropics/claude-code#64406",
+      "url": "https://github.com/anthropics/claude-code/issues/64406",
+      "title": "[FEATURE] Allow PreToolUse hook output to render before tool execution (non-blocking)",
+      "impact": "not_applicable",
+      "categories": [
+        "terminal",
+        "mcp",
+        "slash_hook"
+      ],
+      "tokenkey_status": "not_applicable",
+      "rationale": "Client-side claude-code concern (terminal, mcp, slash_hook); not a gateway/relay relevance signal.",
+      "updated_at": "2026-06-01T06:05:15Z"
+    },
+    {
+      "upstream": "anthropics/claude-code#64407",
+      "url": "https://github.com/anthropics/claude-code/issues/64407",
+      "title": "Feature Request: Chinese / multilingual UI localization for permission prompts",
+      "impact": "not_applicable",
+      "categories": [
+        "slash_hook"
+      ],
+      "tokenkey_status": "not_applicable",
+      "rationale": "Client-side claude-code concern (slash_hook); not a gateway/relay relevance signal.",
+      "updated_at": "2026-06-01T06:23:19Z"
+    },
+    {
+      "upstream": "anthropics/claude-code#64411",
+      "url": "https://github.com/anthropics/claude-code/issues/64411",
+      "title": "Feature: Hot-reload harness (version/plugins) for running background sessions without losing conversation history",
+      "impact": "not_applicable",
+      "categories": [
+        "plugin",
+        "slash_hook"
+      ],
+      "tokenkey_status": "not_applicable",
+      "rationale": "Client-side claude-code concern (plugin, slash_hook); not a gateway/relay relevance signal.",
+      "updated_at": "2026-06-01T06:50:47Z"
+    },
+    {
+      "upstream": "anthropics/claude-code#64412",
+      "url": "https://github.com/anthropics/claude-code/issues/64412",
+      "title": "[BUG] Stdio MCP server receives a CLAUDE_CODE_SESSION_ID different from the value passed to hooks / Bash tool on --resume sessions",
+      "impact": "not_applicable",
+      "categories": [
+        "mcp",
+        "plugin",
+        "slash_hook"
+      ],
+      "tokenkey_status": "not_applicable",
+      "rationale": "Client-side claude-code concern (mcp, plugin, slash_hook); not a gateway/relay relevance signal.",
+      "updated_at": "2026-06-01T06:53:59Z"
+    },
+    {
+      "upstream": "anthropics/claude-code#64413",
+      "url": "https://github.com/anthropics/claude-code/issues/64413",
+      "title": "[BUG] \"workflow\" keyword in user message forces model to invoke Workflow tool even in purely conversational/investigative context",
+      "impact": "not_applicable",
+      "categories": [
+        "terminal",
+        "slash_hook"
+      ],
+      "tokenkey_status": "not_applicable",
+      "rationale": "Client-side claude-code concern (terminal, slash_hook); not a gateway/relay relevance signal.",
+      "updated_at": "2026-06-01T07:04:42Z"
+    },
+    {
+      "upstream": "anthropics/claude-code#64415",
+      "url": "https://github.com/anthropics/claude-code/issues/64415",
+      "title": "[FEATURE] Programmatic session rename API for skills/agents",
+      "impact": "not_applicable",
+      "categories": [
+        "mcp",
+        "slash_hook",
+        "platform"
+      ],
+      "tokenkey_status": "not_applicable",
+      "rationale": "Client-side claude-code concern (mcp, slash_hook, platform); not a gateway/relay relevance signal.",
+      "updated_at": "2026-06-01T07:18:38Z"
+    },
+    {
+      "upstream": "anthropics/claude-code#64416",
+      "url": "https://github.com/anthropics/claude-code/issues/64416",
+      "title": "[BUG] Claude spent 33+ minutes and 18k+ tokens debugging a Gradle build that was actually just an Android Studio version incompatibility",
+      "impact": "not_applicable",
+      "categories": [
+        "terminal"
+      ],
+      "tokenkey_status": "not_applicable",
+      "rationale": "Client-side claude-code concern (terminal); not a gateway/relay relevance signal.",
+      "updated_at": "2026-06-01T07:20:02Z"
+    },
+    {
+      "upstream": "anthropics/claude-code#64417",
+      "url": "https://github.com/anthropics/claude-code/issues/64417",
+      "title": "Project memory bleeds across accounts — personal project context loads in work account session",
+      "impact": "not_applicable",
+      "categories": [
+        "terminal"
+      ],
+      "tokenkey_status": "not_applicable",
+      "rationale": "Client-side claude-code concern (terminal); not a gateway/relay relevance signal.",
+      "updated_at": "2026-06-01T07:20:58Z"
+    },
+    {
+      "upstream": "anthropics/claude-code#64419",
+      "url": "https://github.com/anthropics/claude-code/issues/64419",
+      "title": "[Bug] Missing /remote command implementation",
+      "impact": "not_applicable",
+      "categories": [
+        "terminal"
+      ],
+      "tokenkey_status": "not_applicable",
+      "rationale": "Client-side claude-code concern (terminal); not a gateway/relay relevance signal.",
+      "updated_at": "2026-06-01T07:36:21Z"
+    },
+    {
+      "upstream": "anthropics/claude-code#64421",
+      "url": "https://github.com/anthropics/claude-code/issues/64421",
+      "title": "[BUG] Max 20x account consumed 20% 5hr of tokens in 5mins with one session and lesss than 5k token usage",
+      "impact": "not_applicable",
+      "categories": [
+        "terminal"
+      ],
+      "tokenkey_status": "not_applicable",
+      "rationale": "Client-side claude-code concern (terminal); not a gateway/relay relevance signal.",
+      "updated_at": "2026-06-01T07:51:04Z"
+    },
+    {
+      "upstream": "anthropics/claude-code#64429",
+      "url": "https://github.com/anthropics/claude-code/issues/64429",
+      "title": "[Bug] Satisfaction poll UI causes accidental low ratings due to unclear alternatives presentation",
+      "impact": "not_applicable",
+      "categories": [
+        "terminal"
+      ],
+      "tokenkey_status": "not_applicable",
+      "rationale": "Client-side claude-code concern (terminal); not a gateway/relay relevance signal.",
+      "updated_at": "2026-06-01T08:13:48Z"
+    },
+    {
+      "upstream": "anthropics/claude-code#64430",
+      "url": "https://github.com/anthropics/claude-code/issues/64430",
+      "title": "[VS Code] Renaming a session in Session History panel does not persist (reverts to auto-generated title)",
+      "impact": "not_applicable",
+      "categories": [
+        "ide",
+        "plugin",
+        "slash_hook",
+        "platform"
+      ],
+      "tokenkey_status": "not_applicable",
+      "rationale": "Client-side claude-code concern (ide, plugin, slash_hook, platform); not a gateway/relay relevance signal.",
+      "updated_at": "2026-06-01T08:22:40Z"
+    },
+    {
+      "upstream": "anthropics/claude-code#64431",
+      "url": "https://github.com/anthropics/claude-code/issues/64431",
+      "title": "/plugin install fails with \"source type your Claude Code version does not support\" for a marketplace plugin whose source is \".\" (reproduces on latest)",
+      "impact": "not_applicable",
+      "categories": [
+        "plugin",
+        "install"
+      ],
+      "tokenkey_status": "not_applicable",
+      "rationale": "Client-side claude-code concern (plugin, install); not a gateway/relay relevance signal.",
+      "updated_at": "2026-06-01T08:29:01Z"
+    },
+    {
+      "upstream": "anthropics/claude-code#64433",
+      "url": "https://github.com/anthropics/claude-code/issues/64433",
+      "title": "[BUG] Desktop local-agent (Claude Code): 900s session idle timeout tears down the computer-use connector and never re-registers it on resume",
+      "impact": "not_applicable",
+      "categories": [
+        "terminal",
+        "platform"
+      ],
+      "tokenkey_status": "not_applicable",
+      "rationale": "Client-side claude-code concern (terminal, platform); not a gateway/relay relevance signal.",
+      "updated_at": "2026-06-01T08:36:02Z"
+    },
+    {
+      "upstream": "anthropics/claude-code#64434",
+      "url": "https://github.com/anthropics/claude-code/issues/64434",
+      "title": "[Bug] Claude unable to fix recurring overlay issue across multiple prompts",
+      "impact": "not_applicable",
+      "categories": [
+        "terminal"
+      ],
+      "tokenkey_status": "not_applicable",
+      "rationale": "Client-side claude-code concern (terminal); not a gateway/relay relevance signal.",
+      "updated_at": "2026-06-01T08:35:51Z"
+    },
+    {
+      "upstream": "anthropics/claude-code#64435",
+      "url": "https://github.com/anthropics/claude-code/issues/64435",
+      "title": "[Bug] Persistent display overlay issue not resolved across multiple prompts",
+      "impact": "not_applicable",
+      "categories": [
+        "terminal"
+      ],
+      "tokenkey_status": "not_applicable",
+      "rationale": "Client-side claude-code concern (terminal); not a gateway/relay relevance signal.",
+      "updated_at": "2026-06-01T08:38:33Z"
+    },
+    {
+      "upstream": "anthropics/claude-code#64440",
+      "url": "https://github.com/anthropics/claude-code/issues/64440",
+      "title": "[Bug] Ultrareview consumed free credit on crash with zero findings",
+      "impact": "not_applicable",
+      "categories": [
+        "terminal"
+      ],
+      "tokenkey_status": "not_applicable",
+      "rationale": "Client-side claude-code concern (terminal); not a gateway/relay relevance signal.",
+      "updated_at": "2026-06-01T09:06:13Z"
+    },
+    {
+      "upstream": "anthropics/claude-code#64442",
+      "url": "https://github.com/anthropics/claude-code/issues/64442",
+      "title": "Bridge session disappears from desktop session picker after archive→unarchive cycle",
+      "impact": "not_applicable",
+      "categories": [
+        "terminal",
+        "platform"
+      ],
+      "tokenkey_status": "not_applicable",
+      "rationale": "Client-side claude-code concern (terminal, platform); not a gateway/relay relevance signal.",
+      "updated_at": "2026-06-01T09:13:50Z"
+    },
+    {
+      "upstream": "anthropics/claude-code#64443",
+      "url": "https://github.com/anthropics/claude-code/issues/64443",
+      "title": "[BUG] \"Usage credits required for 1M context\" error persists after plan recharge on VS Code extension",
+      "impact": "not_applicable",
+      "categories": [
+        "ide",
+        "terminal",
+        "platform"
+      ],
+      "tokenkey_status": "not_applicable",
+      "rationale": "Client-side claude-code concern (ide, terminal, platform); not a gateway/relay relevance signal.",
+      "updated_at": "2026-06-01T09:12:42Z"
+    },
+    {
+      "upstream": "anthropics/claude-code#64444",
+      "url": "https://github.com/anthropics/claude-code/issues/64444",
+      "title": "[BUG]",
+      "impact": "not_applicable",
+      "categories": [
+        "terminal",
+        "platform"
+      ],
+      "tokenkey_status": "not_applicable",
+      "rationale": "Client-side claude-code concern (terminal, platform); not a gateway/relay relevance signal.",
+      "updated_at": "2026-06-01T09:17:05Z"
+    },
+    {
+      "upstream": "anthropics/claude-code#64447",
+      "url": "https://github.com/anthropics/claude-code/issues/64447",
+      "title": "[Bug] Claude Code stuck in infinite loop awaiting user choice response",
+      "impact": "not_applicable",
+      "categories": [
+        "ide",
+        "terminal",
+        "slash_hook"
+      ],
+      "tokenkey_status": "not_applicable",
+      "rationale": "Client-side claude-code concern (ide, terminal, slash_hook); not a gateway/relay relevance signal.",
+      "updated_at": "2026-06-01T09:33:39Z"
+    },
+    {
+      "upstream": "anthropics/claude-code#64448",
+      "url": "https://github.com/anthropics/claude-code/issues/64448",
+      "title": "[FEATURE] Option to disable terminal title override in Cursor/VS Code",
+      "impact": "not_applicable",
+      "categories": [
+        "ide",
+        "terminal",
+        "slash_hook"
+      ],
+      "tokenkey_status": "not_applicable",
+      "rationale": "Client-side claude-code concern (ide, terminal, slash_hook); not a gateway/relay relevance signal.",
+      "updated_at": "2026-06-01T09:45:16Z"
+    },
+    {
+      "upstream": "anthropics/claude-code#64449",
+      "url": "https://github.com/anthropics/claude-code/issues/64449",
+      "title": "Persistent default session color (settings.json key or launch flag)",
+      "impact": "not_applicable",
+      "categories": [
+        "terminal",
+        "slash_hook"
+      ],
+      "tokenkey_status": "not_applicable",
+      "rationale": "Client-side claude-code concern (terminal, slash_hook); not a gateway/relay relevance signal.",
+      "updated_at": "2026-06-01T09:49:17Z"
+    },
+    {
+      "upstream": "anthropics/claude-code#64450",
+      "url": "https://github.com/anthropics/claude-code/issues/64450",
+      "title": "[BUG] Claude misspells username in working directory path, causing permission prompts",
+      "impact": "not_applicable",
+      "categories": [
+        "ide",
+        "terminal"
+      ],
+      "tokenkey_status": "not_applicable",
+      "rationale": "Client-side claude-code concern (ide, terminal); not a gateway/relay relevance signal.",
+      "updated_at": "2026-06-01T09:51:08Z"
+    },
+    {
+      "upstream": "anthropics/claude-code#64451",
+      "url": "https://github.com/anthropics/claude-code/issues/64451",
+      "title": "[BUG] Explorer window opens after installation on Windows",
+      "impact": "not_applicable",
+      "categories": [
+        "terminal",
+        "install",
+        "platform"
+      ],
+      "tokenkey_status": "not_applicable",
+      "rationale": "Client-side claude-code concern (terminal, install, platform); not a gateway/relay relevance signal.",
+      "updated_at": "2026-06-01T09:59:07Z"
+    },
+    {
+      "upstream": "anthropics/claude-code#64452",
+      "url": "https://github.com/anthropics/claude-code/issues/64452",
+      "title": "Background session: Workflow subagent with isolation:\"worktree\" is blocked from Write/Edit into its own worktree",
+      "impact": "not_applicable",
+      "categories": [
+        "plugin",
+        "slash_hook"
+      ],
+      "tokenkey_status": "not_applicable",
+      "rationale": "Client-side claude-code concern (plugin, slash_hook); not a gateway/relay relevance signal.",
+      "updated_at": "2026-06-01T15:29:07Z"
+    },
+    {
+      "upstream": "anthropics/claude-code#64453",
+      "url": "https://github.com/anthropics/claude-code/issues/64453",
+      "title": "[BUG] API Error: Unable to connect to API (ECONNRESET)",
+      "impact": "not_applicable",
+      "categories": [
+        "terminal"
+      ],
+      "tokenkey_status": "not_applicable",
+      "rationale": "Client-side claude-code concern (terminal); not a gateway/relay relevance signal.",
+      "updated_at": "2026-06-01T10:10:03Z"
+    },
+    {
+      "upstream": "anthropics/claude-code#64454",
+      "url": "https://github.com/anthropics/claude-code/issues/64454",
+      "title": "[Bug] Claude fails to fix overlay issues despite fresh sessions and image context",
+      "impact": "not_applicable",
+      "categories": [
+        "terminal"
+      ],
+      "tokenkey_status": "not_applicable",
+      "rationale": "Client-side claude-code concern (terminal); not a gateway/relay relevance signal.",
+      "updated_at": "2026-06-01T10:16:15Z"
+    },
+    {
+      "upstream": "anthropics/claude-code#64455",
+      "url": "https://github.com/anthropics/claude-code/issues/64455",
+      "title": "Mobile: stuck on stale \"usage limit reached\" reply after top-up while Extra Usage is active (desktop works)",
+      "impact": "not_applicable",
+      "categories": [
+        "terminal"
+      ],
+      "tokenkey_status": "not_applicable",
+      "rationale": "Client-side claude-code concern (terminal); not a gateway/relay relevance signal.",
+      "updated_at": "2026-06-01T10:17:15Z"
+    },
+    {
+      "upstream": "anthropics/claude-code#64456",
+      "url": "https://github.com/anthropics/claude-code/issues/64456",
+      "title": "[BUG] Desktop offline while using Dispatch",
+      "impact": "not_applicable",
+      "categories": [
+        "terminal",
+        "platform"
+      ],
+      "tokenkey_status": "not_applicable",
+      "rationale": "Client-side claude-code concern (terminal, platform); not a gateway/relay relevance signal.",
+      "updated_at": "2026-06-01T10:24:54Z"
+    },
+    {
+      "upstream": "anthropics/claude-code#64458",
+      "url": "https://github.com/anthropics/claude-code/issues/64458",
+      "title": "[BUG] Claude defaults to `.claude` despite having set `CLAUDE_CONFIG_DIR`",
+      "impact": "not_applicable",
+      "categories": [
+        "ide",
+        "terminal",
+        "plugin",
+        "install"
+      ],
+      "tokenkey_status": "not_applicable",
+      "rationale": "Client-side claude-code concern (ide, terminal, plugin, install); not a gateway/relay relevance signal.",
+      "updated_at": "2026-06-01T10:56:06Z"
+    },
+    {
+      "upstream": "anthropics/claude-code#64460",
+      "url": "https://github.com/anthropics/claude-code/issues/64460",
+      "title": "[FEATURE] Configurable subscribe_pr_activity wake-message text (settings or hook)",
+      "impact": "not_applicable",
+      "categories": [
+        "mcp",
+        "slash_hook"
+      ],
+      "tokenkey_status": "not_applicable",
+      "rationale": "Client-side claude-code concern (mcp, slash_hook); not a gateway/relay relevance signal.",
+      "updated_at": "2026-06-01T10:47:48Z"
+    },
+    {
+      "upstream": "anthropics/claude-code#64461",
+      "url": "https://github.com/anthropics/claude-code/issues/64461",
+      "title": "Plugin harness resolves skill base directory to marketplaces/ instead of installed cache/ path",
+      "impact": "not_applicable",
+      "categories": [
+        "plugin",
+        "slash_hook",
+        "install"
+      ],
+      "tokenkey_status": "not_applicable",
+      "rationale": "Client-side claude-code concern (plugin, slash_hook, install); not a gateway/relay relevance signal.",
+      "updated_at": "2026-06-01T10:57:04Z"
+    },
+    {
+      "upstream": "anthropics/claude-code#64463",
+      "url": "https://github.com/anthropics/claude-code/issues/64463",
+      "title": "[FEATURE] In-session agent view (← navigation) should be scopeable to the current project",
+      "impact": "not_applicable",
+      "categories": [
+        "slash_hook"
+      ],
+      "tokenkey_status": "not_applicable",
+      "rationale": "Client-side claude-code concern (slash_hook); not a gateway/relay relevance signal.",
+      "updated_at": "2026-06-01T11:11:04Z"
+    },
+    {
+      "upstream": "anthropics/claude-code#64464",
+      "url": "https://github.com/anthropics/claude-code/issues/64464",
+      "title": "Docs say `claude_desktop_config.json` MCP servers \"will not appear in the Code tab,\" but the desktop app injects them into Code sessions",
+      "impact": "not_applicable",
+      "categories": [
+        "mcp",
+        "plugin",
+        "platform"
+      ],
+      "tokenkey_status": "not_applicable",
+      "rationale": "Client-side claude-code concern (mcp, plugin, platform); not a gateway/relay relevance signal.",
+      "updated_at": "2026-06-01T11:18:34Z"
+    },
+    {
+      "upstream": "anthropics/claude-code#64466",
+      "url": "https://github.com/anthropics/claude-code/issues/64466",
+      "title": "Code-tab Customize -> Skills is missing skills that are present in ~/.claude/skills (non-deterministic; / menu and engine load them all)",
+      "impact": "not_applicable",
+      "categories": [
+        "terminal",
+        "plugin",
+        "install",
+        "platform"
+      ],
+      "tokenkey_status": "not_applicable",
+      "rationale": "Client-side claude-code concern (terminal, plugin, install, platform); not a gateway/relay relevance signal.",
+      "updated_at": "2026-06-01T11:50:56Z"
+    },
+    {
+      "upstream": "anthropics/claude-code#64467",
+      "url": "https://github.com/anthropics/claude-code/issues/64467",
+      "title": "[BUG] 1M context model switch without selecting the option",
+      "impact": "not_applicable",
+      "categories": [
+        "ide",
+        "terminal",
+        "platform"
+      ],
+      "tokenkey_status": "not_applicable",
+      "rationale": "Client-side claude-code concern (ide, terminal, platform); not a gateway/relay relevance signal.",
+      "updated_at": "2026-06-01T13:46:59Z"
+    },
+    {
+      "upstream": "anthropics/claude-code#64469",
+      "url": "https://github.com/anthropics/claude-code/issues/64469",
+      "title": "usage error on claude",
+      "impact": "not_applicable",
+      "categories": [
+        "ide",
+        "terminal"
+      ],
+      "tokenkey_status": "not_applicable",
+      "rationale": "Client-side claude-code concern (ide, terminal); not a gateway/relay relevance signal.",
+      "updated_at": "2026-06-02T07:38:47Z"
+    },
+    {
+      "upstream": "anthropics/claude-code#64470",
+      "url": "https://github.com/anthropics/claude-code/issues/64470",
+      "title": "Telegram plugin (0.0.6) inbound inject silently dropped — CC host doesn't declare experimental.claude/channel capability",
+      "impact": "not_applicable",
+      "categories": [
+        "mcp",
+        "plugin",
+        "install"
+      ],
+      "tokenkey_status": "not_applicable",
+      "rationale": "Client-side claude-code concern (mcp, plugin, install); not a gateway/relay relevance signal.",
+      "updated_at": "2026-06-01T12:21:26Z"
+    },
+    {
+      "upstream": "anthropics/claude-code#64471",
+      "url": "https://github.com/anthropics/claude-code/issues/64471",
+      "title": "[BUG] Sub-agent messages render in wrong vertical order — insertion position resets on main↔sub-agent context switch",
+      "impact": "not_applicable",
+      "categories": [
+        "terminal",
+        "platform"
+      ],
+      "tokenkey_status": "not_applicable",
+      "rationale": "Client-side claude-code concern (terminal, platform); not a gateway/relay relevance signal.",
+      "updated_at": "2026-06-01T12:23:29Z"
+    },
+    {
+      "upstream": "anthropics/claude-code#64472",
+      "url": "https://github.com/anthropics/claude-code/issues/64472",
+      "title": "Feature Request: Add Chinese (Simplified) localization / i18n support",
+      "impact": "not_applicable",
+      "categories": [
+        "slash_hook"
+      ],
+      "tokenkey_status": "not_applicable",
+      "rationale": "Client-side claude-code concern (slash_hook); not a gateway/relay relevance signal.",
+      "updated_at": "2026-06-01T12:30:12Z"
+    },
+    {
+      "upstream": "anthropics/claude-code#64474",
+      "url": "https://github.com/anthropics/claude-code/issues/64474",
+      "title": "[BUG] Fullscreen TUI: failed Bash tool output is empty when expanded",
+      "impact": "not_applicable",
+      "categories": [
+        "terminal"
+      ],
+      "tokenkey_status": "not_applicable",
+      "rationale": "Client-side claude-code concern (terminal); not a gateway/relay relevance signal.",
+      "updated_at": "2026-06-01T12:31:24Z"
+    },
+    {
+      "upstream": "anthropics/claude-code#64476",
+      "url": "https://github.com/anthropics/claude-code/issues/64476",
+      "title": "[FEATURE] Show remaining usage limits (5h/7 days) in VSCode extension and via CLI command",
+      "impact": "not_applicable",
+      "categories": [
+        "ide",
+        "terminal"
+      ],
+      "tokenkey_status": "not_applicable",
+      "rationale": "Client-side claude-code concern (ide, terminal); not a gateway/relay relevance signal.",
+      "updated_at": "2026-06-01T17:40:45Z"
+    },
+    {
+      "upstream": "anthropics/claude-code#64479",
+      "url": "https://github.com/anthropics/claude-code/issues/64479",
+      "title": "[Bug] Edit tool fails on mixed literal/escape Unicode in multi-line old_string",
+      "impact": "not_applicable",
+      "categories": [
+        "terminal"
+      ],
+      "tokenkey_status": "not_applicable",
+      "rationale": "Client-side claude-code concern (terminal); not a gateway/relay relevance signal.",
+      "updated_at": "2026-06-01T12:40:14Z"
+    },
+    {
+      "upstream": "anthropics/claude-code#64480",
+      "url": "https://github.com/anthropics/claude-code/issues/64480",
+      "title": "[BUG] Claude Max invoice paid but account remains past_due; Claude Code access blocked and cancellation page stuck",
+      "impact": "not_applicable",
+      "categories": [
+        "ide",
+        "terminal"
+      ],
+      "tokenkey_status": "not_applicable",
+      "rationale": "Client-side claude-code concern (ide, terminal); not a gateway/relay relevance signal.",
+      "updated_at": "2026-06-01T13:16:16Z"
+    },
+    {
+      "upstream": "anthropics/claude-code#64481",
+      "url": "https://github.com/anthropics/claude-code/issues/64481",
+      "title": "Claude rewrote committed application code without preserving prior state, causing loss of user work",
+      "impact": "not_applicable",
+      "categories": [
+        "terminal",
+        "install"
+      ],
+      "tokenkey_status": "not_applicable",
+      "rationale": "Client-side claude-code concern (terminal, install); not a gateway/relay relevance signal.",
+      "updated_at": "2026-06-01T12:55:54Z"
+    },
+    {
+      "upstream": "anthropics/claude-code#64483",
+      "url": "https://github.com/anthropics/claude-code/issues/64483",
+      "title": "[FEATURE] Support expertise-aware delegation as a first-class agent behaviour",
+      "impact": "not_applicable",
+      "categories": [
+        "slash_hook"
+      ],
+      "tokenkey_status": "not_applicable",
+      "rationale": "Client-side claude-code concern (slash_hook); not a gateway/relay relevance signal.",
+      "updated_at": "2026-06-01T12:57:50Z"
+    },
+    {
+      "upstream": "anthropics/claude-code#64484",
+      "url": "https://github.com/anthropics/claude-code/issues/64484",
+      "title": "Feature request: setting to hide/collapse file edit diffs in terminal transcript",
+      "impact": "not_applicable",
+      "categories": [
+        "terminal",
+        "slash_hook"
+      ],
+      "tokenkey_status": "not_applicable",
+      "rationale": "Client-side claude-code concern (terminal, slash_hook); not a gateway/relay relevance signal.",
+      "updated_at": "2026-06-01T13:12:19Z"
+    },
+    {
+      "upstream": "anthropics/claude-code#64485",
+      "url": "https://github.com/anthropics/claude-code/issues/64485",
+      "title": "[BUG] CronCreate: lacks predicate-gated execution and context isolation, leading to large unintended costs on repeated trivial checks",
+      "impact": "not_applicable",
+      "categories": [
+        "terminal",
+        "platform"
+      ],
+      "tokenkey_status": "not_applicable",
+      "rationale": "Client-side claude-code concern (terminal, platform); not a gateway/relay relevance signal.",
+      "updated_at": "2026-06-01T13:12:23Z"
+    },
+    {
+      "upstream": "anthropics/claude-code#64486",
+      "url": "https://github.com/anthropics/claude-code/issues/64486",
+      "title": "I'm Claude Code, an agentic coding CLI. However, I don't see a specific error message or bug report in your message to analyze. Please share: 1. The error message or unexpected behavior you're experiencing 2. What you were trying to do when it occurred 3.",
+      "impact": "not_applicable",
+      "categories": [
+        "ide",
+        "terminal",
+        "install"
+      ],
+      "tokenkey_status": "not_applicable",
+      "rationale": "Client-side claude-code concern (ide, terminal, install); not a gateway/relay relevance signal.",
+      "updated_at": "2026-06-01T13:17:14Z"
+    },
+    {
+      "upstream": "anthropics/claude-code#64488",
+      "url": "https://github.com/anthropics/claude-code/issues/64488",
+      "title": "[Bug] Claude Code ignores instructions and generates errors to consume tokens",
+      "impact": "not_applicable",
+      "categories": [
+        "ide",
+        "terminal"
+      ],
+      "tokenkey_status": "not_applicable",
+      "rationale": "Client-side claude-code concern (ide, terminal); not a gateway/relay relevance signal.",
+      "updated_at": "2026-06-01T13:20:38Z"
+    },
+    {
+      "upstream": "anthropics/claude-code#64490",
+      "url": "https://github.com/anthropics/claude-code/issues/64490",
+      "title": "Last sentence/line of response disappears in terminal output",
+      "impact": "not_applicable",
+      "categories": [
+        "terminal",
+        "install"
+      ],
+      "tokenkey_status": "not_applicable",
+      "rationale": "Client-side claude-code concern (terminal, install); not a gateway/relay relevance signal.",
+      "updated_at": "2026-06-01T13:23:44Z"
+    },
+    {
+      "upstream": "anthropics/claude-code#64491",
+      "url": "https://github.com/anthropics/claude-code/issues/64491",
+      "title": "[BUG] Claude Code Usage Limits Consumed Automatically Without Any Usage",
+      "impact": "not_applicable",
+      "categories": [
+        "ide",
+        "terminal",
+        "platform"
+      ],
+      "tokenkey_status": "not_applicable",
+      "rationale": "Client-side claude-code concern (ide, terminal, platform); not a gateway/relay relevance signal.",
+      "updated_at": "2026-06-01T13:33:59Z"
+    },
+    {
+      "upstream": "anthropics/claude-code#64494",
+      "url": "https://github.com/anthropics/claude-code/issues/64494",
+      "title": "[BUG] Claude in Chrome extension no longer registers MCP tools with Claude Code (VS Code)",
+      "impact": "not_applicable",
+      "categories": [
+        "ide",
+        "terminal",
+        "mcp",
+        "install",
+        "platform"
+      ],
+      "tokenkey_status": "not_applicable",
+      "rationale": "Client-side claude-code concern (ide, terminal, mcp, install, platform); not a gateway/relay relevance signal.",
+      "updated_at": "2026-06-01T14:02:36Z"
+    },
+    {
+      "upstream": "anthropics/claude-code#64495",
+      "url": "https://github.com/anthropics/claude-code/issues/64495",
+      "title": "[BUG] Yearly Pro subscription demoted to Free (losing Claude Code access)",
+      "impact": "not_applicable",
+      "categories": [
+        "terminal"
+      ],
+      "tokenkey_status": "not_applicable",
+      "rationale": "Client-side claude-code concern (terminal); not a gateway/relay relevance signal.",
+      "updated_at": "2026-06-02T11:44:38Z"
+    },
+    {
+      "upstream": "anthropics/claude-code#64496",
+      "url": "https://github.com/anthropics/claude-code/issues/64496",
+      "title": "[Bug] Model execution hangs indefinitely during task processing",
+      "impact": "not_applicable",
+      "categories": [
+        "terminal"
+      ],
+      "tokenkey_status": "not_applicable",
+      "rationale": "Client-side claude-code concern (terminal); not a gateway/relay relevance signal.",
+      "updated_at": "2026-06-01T14:11:56Z"
+    },
+    {
+      "upstream": "anthropics/claude-code#64498",
+      "url": "https://github.com/anthropics/claude-code/issues/64498",
+      "title": "[Feature Request] Add command to query current session ID in running CLI",
+      "impact": "not_applicable",
+      "categories": [
+        "terminal"
+      ],
+      "tokenkey_status": "not_applicable",
+      "rationale": "Client-side claude-code concern (terminal); not a gateway/relay relevance signal.",
+      "updated_at": "2026-06-01T14:13:30Z"
+    },
+    {
+      "upstream": "anthropics/claude-code#64499",
+      "url": "https://github.com/anthropics/claude-code/issues/64499",
+      "title": "[BUG] Blank TUI hang on startup with parent-directory project state",
+      "impact": "not_applicable",
+      "categories": [
+        "terminal",
+        "mcp"
+      ],
+      "tokenkey_status": "not_applicable",
+      "rationale": "Client-side claude-code concern (terminal, mcp); not a gateway/relay relevance signal.",
+      "updated_at": "2026-06-01T14:22:28Z"
+    },
+    {
+      "upstream": "anthropics/claude-code#64500",
+      "url": "https://github.com/anthropics/claude-code/issues/64500",
+      "title": "[Bug] Tool call parsing repeatedly fails causing extended session hangs",
+      "impact": "not_applicable",
+      "categories": [
+        "terminal"
+      ],
+      "tokenkey_status": "not_applicable",
+      "rationale": "Client-side claude-code concern (terminal); not a gateway/relay relevance signal.",
+      "updated_at": "2026-06-01T14:23:26Z"
+    },
+    {
+      "upstream": "anthropics/claude-code#64501",
+      "url": "https://github.com/anthropics/claude-code/issues/64501",
+      "title": "Display active model + reasoning effort in VS Code extension UI",
+      "impact": "not_applicable",
+      "categories": [
+        "ide",
+        "terminal",
+        "slash_hook"
+      ],
+      "tokenkey_status": "not_applicable",
+      "rationale": "Client-side claude-code concern (ide, terminal, slash_hook); not a gateway/relay relevance signal.",
+      "updated_at": "2026-06-01T14:34:59Z"
+    },
+    {
+      "upstream": "anthropics/claude-code#64502",
+      "url": "https://github.com/anthropics/claude-code/issues/64502",
+      "title": "Feature request: option to disable \"Pull request status couldn't be checked\" notification for no-PR workflows",
+      "impact": "not_applicable",
+      "categories": [
+        "plugin",
+        "slash_hook"
+      ],
+      "tokenkey_status": "not_applicable",
+      "rationale": "Client-side claude-code concern (plugin, slash_hook); not a gateway/relay relevance signal.",
+      "updated_at": "2026-06-02T20:16:10Z"
+    },
+    {
+      "upstream": "anthropics/claude-code#64503",
+      "url": "https://github.com/anthropics/claude-code/issues/64503",
+      "title": "[BUG] Claude Code Analytics not updated since May 12",
+      "impact": "not_applicable",
+      "categories": [
+        "terminal"
+      ],
+      "tokenkey_status": "not_applicable",
+      "rationale": "Client-side claude-code concern (terminal); not a gateway/relay relevance signal.",
+      "updated_at": "2026-06-03T05:37:13Z"
+    },
+    {
+      "upstream": "anthropics/claude-code#64504",
+      "url": "https://github.com/anthropics/claude-code/issues/64504",
+      "title": "[BUG] bug——\"auto compaction not triggering at 95-100% context usage on Opus 4.6, version 2.1.159, have to manually run /compact\"",
+      "impact": "not_applicable",
+      "categories": [
+        "terminal"
+      ],
+      "tokenkey_status": "not_applicable",
+      "rationale": "Client-side claude-code concern (terminal); not a gateway/relay relevance signal.",
+      "updated_at": "2026-06-01T15:08:07Z"
+    },
+    {
+      "upstream": "anthropics/claude-code#64506",
+      "url": "https://github.com/anthropics/claude-code/issues/64506",
+      "title": "[Bug] Tool call parsing fails with long multibyte/CJK string arguments",
+      "impact": "not_applicable",
+      "categories": [
+        "terminal"
+      ],
+      "tokenkey_status": "not_applicable",
+      "rationale": "Client-side claude-code concern (terminal); not a gateway/relay relevance signal.",
+      "updated_at": "2026-06-01T15:15:28Z"
+    },
+    {
+      "upstream": "anthropics/claude-code#64508",
+      "url": "https://github.com/anthropics/claude-code/issues/64508",
+      "title": "[BUG] [Linux] Massive RAM spike (300MB → 10GB) due to background indexation",
+      "impact": "not_applicable",
+      "categories": [
+        "ide",
+        "terminal",
+        "install"
+      ],
+      "tokenkey_status": "not_applicable",
+      "rationale": "Client-side claude-code concern (ide, terminal, install); not a gateway/relay relevance signal.",
+      "updated_at": "2026-06-01T15:17:52Z"
+    },
+    {
+      "upstream": "anthropics/claude-code#64509",
+      "url": "https://github.com/anthropics/claude-code/issues/64509",
+      "title": "Feature request: option to auto-remove git worktrees on session exit (skip keep/remove prompt)",
+      "impact": "not_applicable",
+      "categories": [
+        "slash_hook"
+      ],
+      "tokenkey_status": "not_applicable",
+      "rationale": "Client-side claude-code concern (slash_hook); not a gateway/relay relevance signal.",
+      "updated_at": "2026-06-01T15:26:54Z"
+    },
+    {
+      "upstream": "anthropics/claude-code#64511",
+      "url": "https://github.com/anthropics/claude-code/issues/64511",
+      "title": "VS Code: panel text stuck in narrow column after resize, does not reflow",
+      "impact": "not_applicable",
+      "categories": [
+        "ide",
+        "terminal"
+      ],
+      "tokenkey_status": "not_applicable",
+      "rationale": "Client-side claude-code concern (ide, terminal); not a gateway/relay relevance signal.",
+      "updated_at": "2026-06-01T15:28:48Z"
+    },
+    {
+      "upstream": "anthropics/claude-code#64512",
+      "url": "https://github.com/anthropics/claude-code/issues/64512",
+      "title": "[Cowork] MSIX: Write/Glob succeed but Read fails on session dirs until folder mounted",
+      "impact": "not_applicable",
+      "categories": [
+        "install",
+        "platform"
+      ],
+      "tokenkey_status": "not_applicable",
+      "rationale": "Client-side claude-code concern (install, platform); not a gateway/relay relevance signal.",
+      "updated_at": "2026-06-01T15:33:35Z"
+    },
+    {
+      "upstream": "anthropics/claude-code#64513",
+      "url": "https://github.com/anthropics/claude-code/issues/64513",
+      "title": "[FEATURE] Allow changing the primary working directory mid-session (live /cd)",
+      "impact": "not_applicable",
+      "categories": [
+        "slash_hook"
+      ],
+      "tokenkey_status": "not_applicable",
+      "rationale": "Client-side claude-code concern (slash_hook); not a gateway/relay relevance signal.",
+      "updated_at": "2026-06-01T15:31:11Z"
+    },
+    {
+      "upstream": "anthropics/claude-code#64515",
+      "url": "https://github.com/anthropics/claude-code/issues/64515",
+      "title": "Active Claude Code chat tabs are not restored on VS Code restart (webview tabs dropped; no WebviewPanelSerializer)",
+      "impact": "not_applicable",
+      "categories": [
+        "ide"
+      ],
+      "tokenkey_status": "not_applicable",
+      "rationale": "Client-side claude-code concern (ide); not a gateway/relay relevance signal.",
+      "updated_at": "2026-06-02T20:15:22Z"
+    },
+    {
+      "upstream": "anthropics/claude-code#64517",
+      "url": "https://github.com/anthropics/claude-code/issues/64517",
+      "title": "[BUG] Claude Code with GUI doesn't work after plugin update in PHPStorm",
+      "impact": "not_applicable",
+      "categories": [
+        "ide",
+        "terminal",
+        "plugin",
+        "platform"
+      ],
+      "tokenkey_status": "not_applicable",
+      "rationale": "Client-side claude-code concern (ide, terminal, plugin, platform); not a gateway/relay relevance signal.",
+      "updated_at": "2026-06-01T15:42:33Z"
+    },
+    {
+      "upstream": "anthropics/claude-code#64518",
+      "url": "https://github.com/anthropics/claude-code/issues/64518",
+      "title": "[BUG] CLAUDE.md not loaded when working directory is a UNC path (Windows)",
+      "impact": "not_applicable",
+      "categories": [
+        "ide",
+        "terminal",
+        "slash_hook",
+        "platform"
+      ],
+      "tokenkey_status": "not_applicable",
+      "rationale": "Client-side claude-code concern (ide, terminal, slash_hook, platform); not a gateway/relay relevance signal.",
+      "updated_at": "2026-06-01T16:00:04Z"
+    },
+    {
+      "upstream": "anthropics/claude-code#64521",
+      "url": "https://github.com/anthropics/claude-code/issues/64521",
+      "title": "Claude Code CLI does not honor claude.ai MCP connector \"approval required\" settings",
+      "impact": "not_applicable",
+      "categories": [
+        "terminal",
+        "mcp"
+      ],
+      "tokenkey_status": "not_applicable",
+      "rationale": "Client-side claude-code concern (terminal, mcp); not a gateway/relay relevance signal.",
+      "updated_at": "2026-06-02T03:14:08Z"
+    },
+    {
+      "upstream": "anthropics/claude-code#64522",
+      "url": "https://github.com/anthropics/claude-code/issues/64522",
+      "title": "[Bug] macOS sleep inhibitor continuously respawns caffeinate preventing system sleep",
+      "impact": "not_applicable",
+      "categories": [
+        "terminal"
+      ],
+      "tokenkey_status": "not_applicable",
+      "rationale": "Client-side claude-code concern (terminal); not a gateway/relay relevance signal.",
+      "updated_at": "2026-06-01T16:10:07Z"
+    },
+    {
+      "upstream": "anthropics/claude-code#64523",
+      "url": "https://github.com/anthropics/claude-code/issues/64523",
+      "title": "[BUG] cowork with dispatch does work",
+      "impact": "not_applicable",
+      "categories": [
+        "terminal"
+      ],
+      "tokenkey_status": "not_applicable",
+      "rationale": "Client-side claude-code concern (terminal); not a gateway/relay relevance signal.",
+      "updated_at": "2026-06-01T16:15:03Z"
+    },
+    {
+      "upstream": "anthropics/claude-code#64524",
+      "url": "https://github.com/anthropics/claude-code/issues/64524",
+      "title": "Workflow tool triggers on any message mentioning \"workflow\" — trigger is too broad",
+      "impact": "not_applicable",
+      "categories": [
+        "slash_hook"
+      ],
+      "tokenkey_status": "not_applicable",
+      "rationale": "Client-side claude-code concern (slash_hook); not a gateway/relay relevance signal.",
+      "updated_at": "2026-06-01T17:41:47Z"
+    },
+    {
+      "upstream": "anthropics/claude-code#64525",
+      "url": "https://github.com/anthropics/claude-code/issues/64525",
+      "title": "[BUG] Auto permission mode: approval prompt (URL + content) mutates to a different pending tool call while user is reviewing",
+      "impact": "not_applicable",
+      "categories": [
+        "terminal",
+        "plugin"
+      ],
+      "tokenkey_status": "not_applicable",
+      "rationale": "Client-side claude-code concern (terminal, plugin); not a gateway/relay relevance signal.",
+      "updated_at": "2026-06-01T16:31:06Z"
+    },
+    {
+      "upstream": "anthropics/claude-code#64526",
+      "url": "https://github.com/anthropics/claude-code/issues/64526",
+      "title": "[Bug Report] Unable to process request - missing bug report details",
+      "impact": "not_applicable",
+      "categories": [
+        "terminal"
+      ],
+      "tokenkey_status": "not_applicable",
+      "rationale": "Client-side claude-code concern (terminal); not a gateway/relay relevance signal.",
+      "updated_at": "2026-06-01T16:27:38Z"
+    },
+    {
+      "upstream": "anthropics/claude-code#64527",
+      "url": "https://github.com/anthropics/claude-code/issues/64527",
+      "title": "[Bug] Tool Invocation Failure Blocking Workflow Execution",
+      "impact": "not_applicable",
+      "categories": [
+        "terminal"
+      ],
+      "tokenkey_status": "not_applicable",
+      "rationale": "Client-side claude-code concern (terminal); not a gateway/relay relevance signal.",
+      "updated_at": "2026-06-01T16:31:18Z"
+    },
+    {
+      "upstream": "anthropics/claude-code#64529",
+      "url": "https://github.com/anthropics/claude-code/issues/64529",
+      "title": "[FEATURE]",
+      "impact": "not_applicable",
+      "categories": [
+        "ide",
+        "terminal"
+      ],
+      "tokenkey_status": "not_applicable",
+      "rationale": "Client-side claude-code concern (ide, terminal); not a gateway/relay relevance signal.",
+      "updated_at": "2026-06-01T16:31:16Z"
+    },
+    {
+      "upstream": "anthropics/claude-code#64531",
+      "url": "https://github.com/anthropics/claude-code/issues/64531",
+      "title": "I don't have enough context to generate a GitHub issue title from your message. Your text appears to be in Traditional Chinese and translates to something like \"I'll help you create and push directly using the gh CLI.\" However, this seems to be a statemen",
+      "impact": "not_applicable",
+      "categories": [
+        "terminal"
+      ],
+      "tokenkey_status": "not_applicable",
+      "rationale": "Client-side claude-code concern (terminal); not a gateway/relay relevance signal.",
+      "updated_at": "2026-06-01T16:41:26Z"
+    },
+    {
+      "upstream": "anthropics/claude-code#64532",
+      "url": "https://github.com/anthropics/claude-code/issues/64532",
+      "title": "[BUG] CLAUDE.md not read at start of session",
+      "impact": "not_applicable",
+      "categories": [
+        "terminal"
+      ],
+      "tokenkey_status": "not_applicable",
+      "rationale": "Client-side claude-code concern (terminal); not a gateway/relay relevance signal.",
+      "updated_at": "2026-06-01T16:43:36Z"
+    },
+    {
+      "upstream": "anthropics/claude-code#64534",
+      "url": "https://github.com/anthropics/claude-code/issues/64534",
+      "title": "Dispatch feature ignores CLAUDE_CODE_DISABLE_1M_CONTEXT — \"Usage credits required for 1M context\" blocks background agents",
+      "impact": "not_applicable",
+      "categories": [
+        "slash_hook"
+      ],
+      "tokenkey_status": "not_applicable",
+      "rationale": "Client-side claude-code concern (slash_hook); not a gateway/relay relevance signal.",
+      "updated_at": "2026-06-01T18:52:14Z"
+    },
+    {
+      "upstream": "anthropics/claude-code#64535",
+      "url": "https://github.com/anthropics/claude-code/issues/64535",
+      "title": "Claude Code 2.1.159 crashes with General Protection Fault on VirtualBox (Xubuntu 24.04)",
+      "impact": "not_applicable",
+      "categories": [
+        "terminal",
+        "install"
+      ],
+      "tokenkey_status": "not_applicable",
+      "rationale": "Client-side claude-code concern (terminal, install); not a gateway/relay relevance signal.",
+      "updated_at": "2026-06-01T17:06:28Z"
+    },
+    {
+      "upstream": "anthropics/claude-code#64536",
+      "url": "https://github.com/anthropics/claude-code/issues/64536",
+      "title": "[Bug] jdtls-lsp spawns per-subagent instances causing >50 GB RAM exhaustion in large Java workspaces",
+      "impact": "not_applicable",
+      "categories": [
+        "ide",
+        "mcp",
+        "plugin",
+        "install"
+      ],
+      "tokenkey_status": "not_applicable",
+      "rationale": "Client-side claude-code concern (ide, mcp, plugin, install); not a gateway/relay relevance signal.",
+      "updated_at": "2026-06-01T18:41:52Z"
+    },
+    {
+      "upstream": "anthropics/claude-code#64537",
+      "url": "https://github.com/anthropics/claude-code/issues/64537",
+      "title": "[Bug] Agent tool docstring references SendMessage but deferred tools don't expose it",
+      "impact": "not_applicable",
+      "categories": [
+        "terminal"
+      ],
+      "tokenkey_status": "not_applicable",
+      "rationale": "Client-side claude-code concern (terminal); not a gateway/relay relevance signal.",
+      "updated_at": "2026-06-01T17:39:14Z"
+    },
+    {
+      "upstream": "anthropics/claude-code#64538",
+      "url": "https://github.com/anthropics/claude-code/issues/64538",
+      "title": "Claude in Chrome — turnApprovedDomains Gate 1 hard-denies all non-pre-approved domains, no approval prompt fires (v1.0.74, Windows 11)",
+      "impact": "not_applicable",
+      "categories": [
+        "ide",
+        "terminal",
+        "mcp",
+        "platform"
+      ],
+      "tokenkey_status": "not_applicable",
+      "rationale": "Client-side claude-code concern (ide, terminal, mcp, platform); not a gateway/relay relevance signal.",
+      "updated_at": "2026-06-01T17:46:07Z"
+    },
+    {
+      "upstream": "anthropics/claude-code#64541",
+      "url": "https://github.com/anthropics/claude-code/issues/64541",
+      "title": "MCP stdio server fails to start at session init with no error surfaced (silent no-spawn)",
+      "impact": "not_applicable",
+      "categories": [
+        "mcp",
+        "install"
+      ],
+      "tokenkey_status": "not_applicable",
+      "rationale": "Client-side claude-code concern (mcp, install); not a gateway/relay relevance signal.",
+      "updated_at": "2026-06-01T18:35:17Z"
+    },
+    {
+      "upstream": "anthropics/claude-code#64543",
+      "url": "https://github.com/anthropics/claude-code/issues/64543",
+      "title": "Unicode/emoji glyphs rendered as empty boxes on Manjaro Linux (kitty + tmux)",
+      "impact": "not_applicable",
+      "categories": [
+        "terminal",
+        "install"
+      ],
+      "tokenkey_status": "not_applicable",
+      "rationale": "Client-side claude-code concern (terminal, install); not a gateway/relay relevance signal.",
+      "updated_at": "2026-06-01T17:59:54Z"
+    },
+    {
+      "upstream": "anthropics/claude-code#64544",
+      "url": "https://github.com/anthropics/claude-code/issues/64544",
+      "title": "[Bug] API Error: Usage credits required for 1M context with standard model selected",
+      "impact": "not_applicable",
+      "categories": [
+        "ide",
+        "terminal",
+        "slash_hook"
+      ],
+      "tokenkey_status": "not_applicable",
+      "rationale": "Client-side claude-code concern (ide, terminal, slash_hook); not a gateway/relay relevance signal.",
+      "updated_at": "2026-06-02T07:27:44Z"
+    },
+    {
+      "upstream": "anthropics/claude-code#64548",
+      "url": "https://github.com/anthropics/claude-code/issues/64548",
+      "title": "[Bug] org-plugins skills unavailable until 10-minute periodic sync fires — race condition between SkillsPlugin sync and custom-3p:org-plugins install on every startup",
+      "impact": "not_applicable",
+      "categories": [
+        "plugin",
+        "install"
+      ],
+      "tokenkey_status": "not_applicable",
+      "rationale": "Client-side claude-code concern (plugin, install); not a gateway/relay relevance signal.",
+      "updated_at": "2026-06-01T18:38:34Z"
+    },
+    {
+      "upstream": "anthropics/claude-code#64549",
+      "url": "https://github.com/anthropics/claude-code/issues/64549",
+      "title": "[BUG] Claude CLI will not use \"cd\", rendering it unable to run commands in a container",
+      "impact": "not_applicable",
+      "categories": [
+        "terminal"
+      ],
+      "tokenkey_status": "not_applicable",
+      "rationale": "Client-side claude-code concern (terminal); not a gateway/relay relevance signal.",
+      "updated_at": "2026-06-01T18:53:16Z"
+    },
+    {
+      "upstream": "anthropics/claude-code#64551",
+      "url": "https://github.com/anthropics/claude-code/issues/64551",
+      "title": "[BUG] spawn ENAMETOOLONG",
+      "impact": "not_applicable",
+      "categories": [
+        "terminal",
+        "install",
+        "platform"
+      ],
+      "tokenkey_status": "not_applicable",
+      "rationale": "Client-side claude-code concern (terminal, install, platform); not a gateway/relay relevance signal.",
+      "updated_at": "2026-06-01T19:13:07Z"
+    },
+    {
+      "upstream": "anthropics/claude-code#64552",
+      "url": "https://github.com/anthropics/claude-code/issues/64552",
+      "title": "[BUG] MCP connector stuck on disambiguation UUID after conflicting plugin is uninstalled",
+      "impact": "not_applicable",
+      "categories": [
+        "terminal",
+        "mcp",
+        "plugin",
+        "install"
+      ],
+      "tokenkey_status": "not_applicable",
+      "rationale": "Client-side claude-code concern (terminal, mcp, plugin, install); not a gateway/relay relevance signal.",
+      "updated_at": "2026-06-01T19:32:08Z"
+    },
+    {
+      "upstream": "anthropics/claude-code#64553",
+      "url": "https://github.com/anthropics/claude-code/issues/64553",
+      "title": "[FEATURE] Configurable diff view background colors",
+      "impact": "not_applicable",
+      "categories": [
+        "terminal",
+        "slash_hook",
+        "platform"
+      ],
+      "tokenkey_status": "not_applicable",
+      "rationale": "Client-side claude-code concern (terminal, slash_hook, platform); not a gateway/relay relevance signal.",
+      "updated_at": "2026-06-01T19:28:31Z"
+    },
+    {
+      "upstream": "anthropics/claude-code#64554",
+      "url": "https://github.com/anthropics/claude-code/issues/64554",
+      "title": "[Bug] Update process fails despite health check passing",
+      "impact": "not_applicable",
+      "categories": [
+        "terminal"
+      ],
+      "tokenkey_status": "not_applicable",
+      "rationale": "Client-side claude-code concern (terminal); not a gateway/relay relevance signal.",
+      "updated_at": "2026-06-01T19:28:49Z"
+    },
+    {
+      "upstream": "anthropics/claude-code#64556",
+      "url": "https://github.com/anthropics/claude-code/issues/64556",
+      "title": "Bedrock streaming: no idle timeout on hung connections",
+      "impact": "not_applicable",
+      "categories": [
+        "terminal",
+        "platform"
+      ],
+      "tokenkey_status": "not_applicable",
+      "rationale": "Client-side claude-code concern (terminal, platform); not a gateway/relay relevance signal.",
+      "updated_at": "2026-06-01T19:54:52Z"
+    },
+    {
+      "upstream": "anthropics/claude-code#64557",
+      "url": "https://github.com/anthropics/claude-code/issues/64557",
+      "title": "[BUG] Billing: Max 5x plan incorrectly downgraded to Free mid-cycle, double-charged $230",
+      "impact": "not_applicable",
+      "categories": [
+        "terminal"
+      ],
+      "tokenkey_status": "not_applicable",
+      "rationale": "Client-side claude-code concern (terminal); not a gateway/relay relevance signal.",
+      "updated_at": "2026-06-01T20:08:16Z"
+    },
+    {
+      "upstream": "anthropics/claude-code#64558",
+      "url": "https://github.com/anthropics/claude-code/issues/64558",
+      "title": "Cyber/AUP classifier false-positives inside spawned subagents block legitimate multi-agent design review",
+      "impact": "not_applicable",
+      "categories": [
+        "plugin"
+      ],
+      "tokenkey_status": "not_applicable",
+      "rationale": "Client-side claude-code concern (plugin); not a gateway/relay relevance signal.",
+      "updated_at": "2026-06-03T06:12:29Z"
+    },
+    {
+      "upstream": "anthropics/claude-code#64559",
+      "url": "https://github.com/anthropics/claude-code/issues/64559",
+      "title": "[BUG] Auto mode ran an unrequested wildcard `rm` in a user directory and deleted user files with no confirmation",
+      "impact": "not_applicable",
+      "categories": [
+        "terminal",
+        "slash_hook"
+      ],
+      "tokenkey_status": "not_applicable",
+      "rationale": "Client-side claude-code concern (terminal, slash_hook); not a gateway/relay relevance signal.",
+      "updated_at": "2026-06-01T20:19:26Z"
+    },
+    {
+      "upstream": "anthropics/claude-code#64560",
+      "url": "https://github.com/anthropics/claude-code/issues/64560",
+      "title": "[BUG] Only Part of the Dialog Can be Used to Move Window",
+      "impact": "not_applicable",
+      "categories": [
+        "terminal",
+        "platform"
+      ],
+      "tokenkey_status": "not_applicable",
+      "rationale": "Client-side claude-code concern (terminal, platform); not a gateway/relay relevance signal.",
+      "updated_at": "2026-06-01T20:39:00Z"
+    },
+    {
+      "upstream": "anthropics/claude-code#64562",
+      "url": "https://github.com/anthropics/claude-code/issues/64562",
+      "title": "Glob tool silently returns empty for anchored patterns (non-globstar first segment) on Windows",
+      "impact": "not_applicable",
+      "categories": [
+        "platform"
+      ],
+      "tokenkey_status": "not_applicable",
+      "rationale": "Client-side claude-code concern (platform); not a gateway/relay relevance signal.",
+      "updated_at": "2026-06-01T20:47:18Z"
+    },
+    {
+      "upstream": "anthropics/claude-code#64563",
+      "url": "https://github.com/anthropics/claude-code/issues/64563",
+      "title": "Linux x64 binary in v2.1.159 installs as invalid executable (exec format error)",
+      "impact": "not_applicable",
+      "categories": [
+        "terminal",
+        "install",
+        "platform"
+      ],
+      "tokenkey_status": "not_applicable",
+      "rationale": "Client-side claude-code concern (terminal, install, platform); not a gateway/relay relevance signal.",
+      "updated_at": "2026-06-01T20:56:33Z"
+    },
+    {
+      "upstream": "anthropics/claude-code#64564",
+      "url": "https://github.com/anthropics/claude-code/issues/64564",
+      "title": "[Feature Request] Allow Claude Code to access and retrieve credentials",
+      "impact": "not_applicable",
+      "categories": [
+        "ide",
+        "terminal"
+      ],
+      "tokenkey_status": "not_applicable",
+      "rationale": "Client-side claude-code concern (ide, terminal); not a gateway/relay relevance signal.",
+      "updated_at": "2026-06-01T20:53:18Z"
+    },
+    {
+      "upstream": "anthropics/claude-code#64565",
+      "url": "https://github.com/anthropics/claude-code/issues/64565",
+      "title": "Statusline: support right/center alignment",
+      "impact": "not_applicable",
+      "categories": [
+        "terminal",
+        "slash_hook"
+      ],
+      "tokenkey_status": "not_applicable",
+      "rationale": "Client-side claude-code concern (terminal, slash_hook); not a gateway/relay relevance signal.",
+      "updated_at": "2026-06-01T21:05:25Z"
+    },
+    {
+      "upstream": "anthropics/claude-code#64568",
+      "url": "https://github.com/anthropics/claude-code/issues/64568",
+      "title": "[BUG] Pressing Esc to exit /btw mode rejects the pending tool-use prompt instead of just exiting the mode",
+      "impact": "not_applicable",
+      "categories": [
+        "slash_hook"
+      ],
+      "tokenkey_status": "not_applicable",
+      "rationale": "Client-side claude-code concern (slash_hook); not a gateway/relay relevance signal.",
+      "updated_at": "2026-06-01T21:12:26Z"
+    },
+    {
+      "upstream": "anthropics/claude-code#64569",
+      "url": "https://github.com/anthropics/claude-code/issues/64569",
+      "title": "[BUG] Claude Code Session Model Cache Breaks Env Var Overrides",
+      "impact": "not_applicable",
+      "categories": [
+        "ide",
+        "terminal"
+      ],
+      "tokenkey_status": "not_applicable",
+      "rationale": "Client-side claude-code concern (ide, terminal); not a gateway/relay relevance signal.",
+      "updated_at": "2026-06-01T21:14:37Z"
+    },
+    {
+      "upstream": "anthropics/claude-code#64570",
+      "url": "https://github.com/anthropics/claude-code/issues/64570",
+      "title": "[Bug] /btw panel arrow key scrolling not functional",
+      "impact": "not_applicable",
+      "categories": [
+        "terminal"
+      ],
+      "tokenkey_status": "not_applicable",
+      "rationale": "Client-side claude-code concern (terminal); not a gateway/relay relevance signal.",
+      "updated_at": "2026-06-01T21:23:32Z"
+    },
+    {
+      "upstream": "anthropics/claude-code#64571",
+      "url": "https://github.com/anthropics/claude-code/issues/64571",
+      "title": "Feature request: interactive hook output type for TUI picker/selection",
+      "impact": "not_applicable",
+      "categories": [
+        "terminal",
+        "slash_hook"
+      ],
+      "tokenkey_status": "not_applicable",
+      "rationale": "Client-side claude-code concern (terminal, slash_hook); not a gateway/relay relevance signal.",
+      "updated_at": "2026-06-01T22:33:48Z"
+    },
+    {
+      "upstream": "anthropics/claude-code#64572",
+      "url": "https://github.com/anthropics/claude-code/issues/64572",
+      "title": "[Feature Request] Add configurable worktree base path with template support",
+      "impact": "not_applicable",
+      "categories": [
+        "terminal"
+      ],
+      "tokenkey_status": "not_applicable",
+      "rationale": "Client-side claude-code concern (terminal); not a gateway/relay relevance signal.",
+      "updated_at": "2026-06-01T21:33:53Z"
+    },
+    {
+      "upstream": "anthropics/claude-code#64573",
+      "url": "https://github.com/anthropics/claude-code/issues/64573",
+      "title": "[Feature Request] Generate session summaries in the response language",
+      "impact": "not_applicable",
+      "categories": [
+        "terminal"
+      ],
+      "tokenkey_status": "not_applicable",
+      "rationale": "Client-side claude-code concern (terminal); not a gateway/relay relevance signal.",
+      "updated_at": "2026-06-01T21:42:35Z"
+    },
+    {
+      "upstream": "anthropics/claude-code#64575",
+      "url": "https://github.com/anthropics/claude-code/issues/64575",
+      "title": "[FEATURE] Agents view: add search/filter to find sessions by name or prompt",
+      "impact": "not_applicable",
+      "categories": [
+        "terminal"
+      ],
+      "tokenkey_status": "not_applicable",
+      "rationale": "Client-side claude-code concern (terminal); not a gateway/relay relevance signal.",
+      "updated_at": "2026-06-01T21:41:36Z"
+    },
+    {
+      "upstream": "anthropics/claude-code#64576",
+      "url": "https://github.com/anthropics/claude-code/issues/64576",
+      "title": "[Bug] Auto mode classifier incorrectly blocks previously allowed operations",
+      "impact": "not_applicable",
+      "categories": [
+        "terminal"
+      ],
+      "tokenkey_status": "not_applicable",
+      "rationale": "Client-side claude-code concern (terminal); not a gateway/relay relevance signal.",
+      "updated_at": "2026-06-01T21:56:33Z"
+    },
+    {
+      "upstream": "anthropics/claude-code#64577",
+      "url": "https://github.com/anthropics/claude-code/issues/64577",
+      "title": "[BUG] Bash tool hides errors and hangs from non-terminating commands when output is piped through `tail`/`head` (or any EOF-buffering filter)",
+      "impact": "not_applicable",
+      "categories": [
+        "terminal",
+        "install"
+      ],
+      "tokenkey_status": "not_applicable",
+      "rationale": "Client-side claude-code concern (terminal, install); not a gateway/relay relevance signal.",
+      "updated_at": "2026-06-01T21:54:42Z"
+    },
+    {
+      "upstream": "anthropics/claude-code#64580",
+      "url": "https://github.com/anthropics/claude-code/issues/64580",
+      "title": "[Bug] Unclear error message during update operation",
+      "impact": "not_applicable",
+      "categories": [
+        "terminal"
+      ],
+      "tokenkey_status": "not_applicable",
+      "rationale": "Client-side claude-code concern (terminal); not a gateway/relay relevance signal.",
+      "updated_at": "2026-06-01T22:12:17Z"
+    },
+    {
+      "upstream": "anthropics/claude-code#64581",
+      "url": "https://github.com/anthropics/claude-code/issues/64581",
+      "title": "[BUG] Cowork code crashes",
+      "impact": "not_applicable",
+      "categories": [
+        "terminal"
+      ],
+      "tokenkey_status": "not_applicable",
+      "rationale": "Client-side claude-code concern (terminal); not a gateway/relay relevance signal.",
+      "updated_at": "2026-06-01T22:16:02Z"
+    },
+    {
+      "upstream": "anthropics/claude-code#64586",
+      "url": "https://github.com/anthropics/claude-code/issues/64586",
+      "title": "[Bug] Auto-mode classifier intermittently blocks legitimate bash commands despite explicit authorization",
+      "impact": "not_applicable",
+      "categories": [
+        "terminal"
+      ],
+      "tokenkey_status": "not_applicable",
+      "rationale": "Client-side claude-code concern (terminal); not a gateway/relay relevance signal.",
+      "updated_at": "2026-06-01T23:04:59Z"
+    },
+    {
+      "upstream": "anthropics/claude-code#64592",
+      "url": "https://github.com/anthropics/claude-code/issues/64592",
+      "title": "[BUG] Cowork — VM service not running on Windows 11 (fresh repro + workaround; extends closed #54891 / #61559 cluster)",
+      "impact": "not_applicable",
+      "categories": [
+        "install",
+        "platform"
+      ],
+      "tokenkey_status": "not_applicable",
+      "rationale": "Client-side claude-code concern (install, platform); not a gateway/relay relevance signal.",
+      "updated_at": "2026-06-01T23:36:48Z"
+    },
+    {
+      "upstream": "anthropics/claude-code#64593",
+      "url": "https://github.com/anthropics/claude-code/issues/64593",
+      "title": "[FEATURE] Programmatic session rename API for sidebar titles",
+      "impact": "not_applicable",
+      "categories": [
+        "slash_hook"
+      ],
+      "tokenkey_status": "not_applicable",
+      "rationale": "Client-side claude-code concern (slash_hook); not a gateway/relay relevance signal.",
+      "updated_at": "2026-06-01T23:49:37Z"
+    },
+    {
+      "upstream": "anthropics/claude-code#64594",
+      "url": "https://github.com/anthropics/claude-code/issues/64594",
+      "title": "Bash tool inherits harness stdin by default — should close it for non-interactive children",
+      "impact": "not_applicable",
+      "categories": [
+        "terminal",
+        "slash_hook"
+      ],
+      "tokenkey_status": "not_applicable",
+      "rationale": "Client-side claude-code concern (terminal, slash_hook); not a gateway/relay relevance signal.",
+      "updated_at": "2026-06-02T00:00:33Z"
+    },
+    {
+      "upstream": "anthropics/claude-code#64595",
+      "url": "https://github.com/anthropics/claude-code/issues/64595",
+      "title": "Welcome banner shows stale \"What should Claude call you?\" value — not refreshed after the setting is changed",
+      "impact": "not_applicable",
+      "categories": [
+        "terminal",
+        "slash_hook",
+        "platform"
+      ],
+      "tokenkey_status": "not_applicable",
+      "rationale": "Client-side claude-code concern (terminal, slash_hook, platform); not a gateway/relay relevance signal.",
+      "updated_at": "2026-06-02T00:06:42Z"
+    },
+    {
+      "upstream": "anthropics/claude-code#64596",
+      "url": "https://github.com/anthropics/claude-code/issues/64596",
+      "title": "[BUG] Write/Edit tools leave NULL-byte tail padding when shortening files (no O_TRUNC) on Windows + virtiofs",
+      "impact": "not_applicable",
+      "categories": [
+        "platform"
+      ],
+      "tokenkey_status": "not_applicable",
+      "rationale": "Client-side claude-code concern (platform); not a gateway/relay relevance signal.",
+      "updated_at": "2026-06-02T01:09:58Z"
+    },
+    {
+      "upstream": "anthropics/claude-code#64597",
+      "url": "https://github.com/anthropics/claude-code/issues/64597",
+      "title": "[BUG] Write/Edit tools slice CJK characters mid-UTF-8-sequence, leaving partial 0xe3/0xe4 lead bytes at file tail",
+      "impact": "not_applicable",
+      "categories": [
+        "terminal",
+        "platform"
+      ],
+      "tokenkey_status": "not_applicable",
+      "rationale": "Client-side claude-code concern (terminal, platform); not a gateway/relay relevance signal.",
+      "updated_at": "2026-06-02T01:10:03Z"
+    },
+    {
+      "upstream": "anthropics/claude-code#64598",
+      "url": "https://github.com/anthropics/claude-code/issues/64598",
+      "title": "[BUG] Read tool serves cached payload after failed Write, masking on-disk corruption (no cache invalidation on write)",
+      "impact": "not_applicable",
+      "categories": [
+        "mcp",
+        "plugin",
+        "platform"
+      ],
+      "tokenkey_status": "not_applicable",
+      "rationale": "Client-side claude-code concern (mcp, plugin, platform); not a gateway/relay relevance signal.",
+      "updated_at": "2026-06-02T01:10:08Z"
+    },
+    {
+      "upstream": "anthropics/claude-code#64599",
+      "url": "https://github.com/anthropics/claude-code/issues/64599",
+      "title": "[BUG] Edit raises \"File has been unexpectedly modified\" on CRLF files, Write silently converts CRLF on Windows",
+      "impact": "not_applicable",
+      "categories": [
+        "plugin",
+        "platform"
+      ],
+      "tokenkey_status": "not_applicable",
+      "rationale": "Client-side claude-code concern (plugin, platform); not a gateway/relay relevance signal.",
+      "updated_at": "2026-06-02T00:06:15Z"
+    },
+    {
+      "upstream": "anthropics/claude-code#64600",
+      "url": "https://github.com/anthropics/claude-code/issues/64600",
+      "title": "[BUG] Concurrent writes to .claude.json by parallel workers + MCP truncate the file mid-JSON, triggering cascading agent spawn",
+      "impact": "not_applicable",
+      "categories": [
+        "mcp",
+        "plugin",
+        "slash_hook",
+        "platform"
+      ],
+      "tokenkey_status": "not_applicable",
+      "rationale": "Client-side claude-code concern (mcp, plugin, slash_hook, platform); not a gateway/relay relevance signal.",
+      "updated_at": "2026-06-02T08:11:08Z"
+    },
+    {
+      "upstream": "anthropics/claude-code#64601",
+      "url": "https://github.com/anthropics/claude-code/issues/64601",
+      "title": "[BUG] Edit/Write tool corrupts accented characters in Windows-1252 (cp1252)",
+      "impact": "not_applicable",
+      "categories": [
+        "ide",
+        "terminal",
+        "platform"
+      ],
+      "tokenkey_status": "not_applicable",
+      "rationale": "Client-side claude-code concern (ide, terminal, platform); not a gateway/relay relevance signal.",
+      "updated_at": "2026-06-02T00:16:24Z"
+    },
+    {
+      "upstream": "anthropics/claude-code#64605",
+      "url": "https://github.com/anthropics/claude-code/issues/64605",
+      "title": "Chip-spawned task runs on primary checkout instead of fresh worktree",
+      "impact": "not_applicable",
+      "categories": [
+        "mcp",
+        "platform"
+      ],
+      "tokenkey_status": "not_applicable",
+      "rationale": "Client-side claude-code concern (mcp, platform); not a gateway/relay relevance signal.",
+      "updated_at": "2026-06-03T00:30:51Z"
+    },
+    {
+      "upstream": "anthropics/claude-code#64611",
+      "url": "https://github.com/anthropics/claude-code/issues/64611",
+      "title": "Allow disabling chat-input edge-of-text history fallback (up/down to history when cursor at first/last line)",
+      "impact": "not_applicable",
+      "categories": [
+        "slash_hook"
+      ],
+      "tokenkey_status": "not_applicable",
+      "rationale": "Client-side claude-code concern (slash_hook); not a gateway/relay relevance signal.",
+      "updated_at": "2026-06-02T01:13:55Z"
+    },
+    {
+      "upstream": "anthropics/claude-code#64612",
+      "url": "https://github.com/anthropics/claude-code/issues/64612",
+      "title": "[FEATURE] Separate opt-out for promotional/referral spinner notices — and stop coloring them in the error-red palette",
+      "impact": "not_applicable",
+      "categories": [
+        "terminal",
+        "slash_hook"
+      ],
+      "tokenkey_status": "not_applicable",
+      "rationale": "Client-side claude-code concern (terminal, slash_hook); not a gateway/relay relevance signal.",
+      "updated_at": "2026-06-02T01:21:47Z"
+    },
+    {
+      "upstream": "anthropics/claude-code#64614",
+      "url": "https://github.com/anthropics/claude-code/issues/64614",
+      "title": "[BUG] Claude Desktop: 4-minute hard timeout on remote/hosted MCP tool calls — not configurable",
+      "impact": "not_applicable",
+      "categories": [
+        "ide",
+        "terminal",
+        "mcp"
+      ],
+      "tokenkey_status": "not_applicable",
+      "rationale": "Client-side claude-code concern (ide, terminal, mcp); not a gateway/relay relevance signal.",
+      "updated_at": "2026-06-02T02:01:29Z"
+    },
+    {
+      "upstream": "anthropics/claude-code#64617",
+      "url": "https://github.com/anthropics/claude-code/issues/64617",
+      "title": "[BUG]",
+      "impact": "not_applicable",
+      "categories": [
+        "terminal",
+        "install"
+      ],
+      "tokenkey_status": "not_applicable",
+      "rationale": "Client-side claude-code concern (terminal, install); not a gateway/relay relevance signal.",
+      "updated_at": "2026-06-02T02:31:41Z"
+    },
+    {
+      "upstream": "anthropics/claude-code#64619",
+      "url": "https://github.com/anthropics/claude-code/issues/64619",
+      "title": "[BUG] Automatic Context Compaction Fails After Large Codebase Analysis, Causing Excessive Token Usage",
+      "impact": "not_applicable",
+      "categories": [
+        "terminal",
+        "plugin",
+        "platform"
+      ],
+      "tokenkey_status": "not_applicable",
+      "rationale": "Client-side claude-code concern (terminal, plugin, platform); not a gateway/relay relevance signal.",
+      "updated_at": "2026-06-02T11:19:14Z"
+    },
+    {
+      "upstream": "anthropics/claude-code#64620",
+      "url": "https://github.com/anthropics/claude-code/issues/64620",
+      "title": "[BUG] Feature Request: Add Chinese (Simplified) language support for UI",
+      "impact": "not_applicable",
+      "categories": [
+        "terminal",
+        "platform"
+      ],
+      "tokenkey_status": "not_applicable",
+      "rationale": "Client-side claude-code concern (terminal, platform); not a gateway/relay relevance signal.",
+      "updated_at": "2026-06-02T02:44:03Z"
+    },
+    {
+      "upstream": "anthropics/claude-code#64622",
+      "url": "https://github.com/anthropics/claude-code/issues/64622",
+      "title": "[BUG] claude mcp serve exposes Agent tool but registry is empty",
+      "impact": "not_applicable",
+      "categories": [
+        "mcp",
+        "plugin",
+        "install",
+        "platform"
+      ],
+      "tokenkey_status": "not_applicable",
+      "rationale": "Client-side claude-code concern (mcp, plugin, install, platform); not a gateway/relay relevance signal.",
+      "updated_at": "2026-06-02T02:54:20Z"
+    },
+    {
+      "upstream": "anthropics/claude-code#64623",
+      "url": "https://github.com/anthropics/claude-code/issues/64623",
+      "title": "Backspace on empty Chat input exits session — should be no-op; only /exit should quit",
+      "impact": "not_applicable",
+      "categories": [
+        "terminal",
+        "slash_hook"
+      ],
+      "tokenkey_status": "not_applicable",
+      "rationale": "Client-side claude-code concern (terminal, slash_hook); not a gateway/relay relevance signal.",
+      "updated_at": "2026-06-02T02:57:31Z"
+    },
+    {
+      "upstream": "anthropics/claude-code#64624",
+      "url": "https://github.com/anthropics/claude-code/issues/64624",
+      "title": "Feature: Real-time steering — send message mid-generation without queueing",
+      "impact": "not_applicable",
+      "categories": [
+        "slash_hook"
+      ],
+      "tokenkey_status": "not_applicable",
+      "rationale": "Client-side claude-code concern (slash_hook); not a gateway/relay relevance signal.",
+      "updated_at": "2026-06-02T02:58:49Z"
+    },
+    {
+      "upstream": "anthropics/claude-code#64626",
+      "url": "https://github.com/anthropics/claude-code/issues/64626",
+      "title": "SessionStart hook: make the ~10000-char additionalContext per-value cap configurable",
+      "impact": "not_applicable",
+      "categories": [
+        "terminal",
+        "slash_hook"
+      ],
+      "tokenkey_status": "not_applicable",
+      "rationale": "Client-side claude-code concern (terminal, slash_hook); not a gateway/relay relevance signal.",
+      "updated_at": "2026-06-02T03:14:23Z"
+    },
+    {
+      "upstream": "anthropics/claude-code#64628",
+      "url": "https://github.com/anthropics/claude-code/issues/64628",
+      "title": "[BUG] claude code ignores CLAUDE_CODE_DISABLE_1M_CONTEXT settings",
+      "impact": "not_applicable",
+      "categories": [
+        "terminal",
+        "slash_hook"
+      ],
+      "tokenkey_status": "not_applicable",
+      "rationale": "Client-side claude-code concern (terminal, slash_hook); not a gateway/relay relevance signal.",
+      "updated_at": "2026-06-02T03:38:47Z"
+    },
+    {
+      "upstream": "anthropics/claude-code#64629",
+      "url": "https://github.com/anthropics/claude-code/issues/64629",
+      "title": "Permission dialog: number key selection unreliable (~40% failure rate) while Enter works consistently",
+      "impact": "not_applicable",
+      "categories": [
+        "terminal"
+      ],
+      "tokenkey_status": "not_applicable",
+      "rationale": "Client-side claude-code concern (terminal); not a gateway/relay relevance signal.",
+      "updated_at": "2026-06-02T03:26:10Z"
+    },
+    {
+      "upstream": "anthropics/claude-code#64630",
+      "url": "https://github.com/anthropics/claude-code/issues/64630",
+      "title": "[BUG] Claude on MacOS does not use default browser for logging in",
+      "impact": "not_applicable",
+      "categories": [
+        "ide",
+        "terminal"
+      ],
+      "tokenkey_status": "not_applicable",
+      "rationale": "Client-side claude-code concern (ide, terminal); not a gateway/relay relevance signal.",
+      "updated_at": "2026-06-02T03:24:37Z"
+    },
+    {
+      "upstream": "anthropics/claude-code#64631",
+      "url": "https://github.com/anthropics/claude-code/issues/64631",
+      "title": "[BUG] The authorization pop-up cannot be displayed",
+      "impact": "not_applicable",
+      "categories": [
+        "ide",
+        "terminal",
+        "plugin"
+      ],
+      "tokenkey_status": "not_applicable",
+      "rationale": "Client-side claude-code concern (ide, terminal, plugin); not a gateway/relay relevance signal.",
+      "updated_at": "2026-06-02T03:30:27Z"
+    },
+    {
+      "upstream": "anthropics/claude-code#64632",
+      "url": "https://github.com/anthropics/claude-code/issues/64632",
+      "title": "A simple message but takes forever to load the response and not even genaerting tokens. I need more information about the bug to generate an appropriate issue title. The text provided only shows a \"Noodling...\" message.",
+      "impact": "not_applicable",
+      "categories": [
+        "terminal",
+        "install"
+      ],
+      "tokenkey_status": "not_applicable",
+      "rationale": "Client-side claude-code concern (terminal, install); not a gateway/relay relevance signal.",
+      "updated_at": "2026-06-02T03:41:58Z"
+    },
+    {
+      "upstream": "anthropics/claude-code#64634",
+      "url": "https://github.com/anthropics/claude-code/issues/64634",
+      "title": "[BUG] Continue 在顶部 + 长列表把它顶出屏外 + Enter 在条目上不是确认",
+      "impact": "not_applicable",
+      "categories": [
+        "terminal"
+      ],
+      "tokenkey_status": "not_applicable",
+      "rationale": "Client-side claude-code concern (terminal); not a gateway/relay relevance signal.",
+      "updated_at": "2026-06-02T03:53:30Z"
+    },
+    {
+      "upstream": "anthropics/claude-code#64635",
+      "url": "https://github.com/anthropics/claude-code/issues/64635",
+      "title": "[Bug] Normal CLI session misclassified as background job, blocking Edit/Write tools",
+      "impact": "not_applicable",
+      "categories": [
+        "terminal",
+        "slash_hook"
+      ],
+      "tokenkey_status": "not_applicable",
+      "rationale": "Client-side claude-code concern (terminal, slash_hook); not a gateway/relay relevance signal.",
+      "updated_at": "2026-06-02T03:54:41Z"
+    },
+    {
+      "upstream": "anthropics/claude-code#64637",
+      "url": "https://github.com/anthropics/claude-code/issues/64637",
+      "title": "[DOCS] Permission modes protected-path docs omit shell startup files and `~/.config/git/`",
+      "impact": "not_applicable",
+      "categories": [
+        "ide",
+        "mcp"
+      ],
+      "tokenkey_status": "not_applicable",
+      "rationale": "Client-side claude-code concern (ide, mcp); not a gateway/relay relevance signal.",
+      "updated_at": "2026-06-02T04:22:40Z"
+    },
+    {
+      "upstream": "anthropics/claude-code#64638",
+      "url": "https://github.com/anthropics/claude-code/issues/64638",
+      "title": "[FEATURE] Option to disable \"Yes, and don't ask again\" in permission dialog",
+      "impact": "not_applicable",
+      "categories": [
+        "slash_hook"
+      ],
+      "tokenkey_status": "not_applicable",
+      "rationale": "Client-side claude-code concern (slash_hook); not a gateway/relay relevance signal.",
+      "updated_at": "2026-06-02T04:23:17Z"
+    },
+    {
+      "upstream": "anthropics/claude-code#64639",
+      "url": "https://github.com/anthropics/claude-code/issues/64639",
+      "title": "[DOCS] acceptEdits docs omit prompt-protected build-tool config files",
+      "impact": "not_applicable",
+      "categories": [
+        "ide",
+        "mcp",
+        "platform"
+      ],
+      "tokenkey_status": "not_applicable",
+      "rationale": "Client-side claude-code concern (ide, mcp, platform); not a gateway/relay relevance signal.",
+      "updated_at": "2026-06-02T04:23:50Z"
+    },
+    {
+      "upstream": "anthropics/claude-code#64640",
+      "url": "https://github.com/anthropics/claude-code/issues/64640",
+      "title": "[Bug] Remote-control sessions incorrectly inherit multi-agent worktree isolation defaults",
+      "impact": "not_applicable",
+      "categories": [
+        "terminal"
+      ],
+      "tokenkey_status": "not_applicable",
+      "rationale": "Client-side claude-code concern (terminal); not a gateway/relay relevance signal.",
+      "updated_at": "2026-06-02T04:41:07Z"
+    },
+    {
+      "upstream": "anthropics/claude-code#64642",
+      "url": "https://github.com/anthropics/claude-code/issues/64642",
+      "title": "[DOCS] Fullscreen docs omit WSL Windows-clipboard behavior for copy-on-select",
+      "impact": "not_applicable",
+      "categories": [
+        "terminal",
+        "platform"
+      ],
+      "tokenkey_status": "not_applicable",
+      "rationale": "Client-side claude-code concern (terminal, platform); not a gateway/relay relevance signal.",
+      "updated_at": "2026-06-02T04:25:38Z"
+    },
+    {
+      "upstream": "anthropics/claude-code#64643",
+      "url": "https://github.com/anthropics/claude-code/issues/64643",
+      "title": "Feature: PostAssistantMessage hook with display-modification capability (inline image rendering / OSC 1337 / Sixel passthrough)",
+      "impact": "not_applicable",
+      "categories": [
+        "ide",
+        "terminal",
+        "plugin",
+        "slash_hook"
+      ],
+      "tokenkey_status": "not_applicable",
+      "rationale": "Client-side claude-code concern (ide, terminal, plugin, slash_hook); not a gateway/relay relevance signal.",
+      "updated_at": "2026-06-02T04:26:40Z"
+    },
+    {
+      "upstream": "anthropics/claude-code#64647",
+      "url": "https://github.com/anthropics/claude-code/issues/64647",
+      "title": "[DOCS] Workflows docs still tell users to type `workflow` after the trigger keyword changed to `ultracode`",
+      "impact": "not_applicable",
+      "categories": [
+        "platform"
+      ],
+      "tokenkey_status": "not_applicable",
+      "rationale": "Client-side claude-code concern (platform); not a gateway/relay relevance signal.",
+      "updated_at": "2026-06-02T04:29:44Z"
+    },
+    {
+      "upstream": "anthropics/claude-code#64649",
+      "url": "https://github.com/anthropics/claude-code/issues/64649",
+      "title": "[BUG] /plugin list returns empty output for plugins installed from third-party marketplace",
+      "impact": "not_applicable",
+      "categories": [
+        "plugin",
+        "install"
+      ],
+      "tokenkey_status": "not_applicable",
+      "rationale": "Client-side claude-code concern (plugin, install); not a gateway/relay relevance signal.",
+      "updated_at": "2026-06-02T04:58:27Z"
+    },
+    {
+      "upstream": "anthropics/claude-code#64650",
+      "url": "https://github.com/anthropics/claude-code/issues/64650",
+      "title": "[Bug Report] Unable to process - no issue details provided",
+      "impact": "not_applicable",
+      "categories": [
+        "ide",
+        "terminal"
+      ],
+      "tokenkey_status": "not_applicable",
+      "rationale": "Client-side claude-code concern (ide, terminal); not a gateway/relay relevance signal.",
+      "updated_at": "2026-06-02T04:38:58Z"
+    },
+    {
+      "upstream": "anthropics/claude-code#64652",
+      "url": "https://github.com/anthropics/claude-code/issues/64652",
+      "title": "[BUG]",
+      "impact": "not_applicable",
+      "categories": [
+        "terminal",
+        "platform"
+      ],
+      "tokenkey_status": "not_applicable",
+      "rationale": "Client-side claude-code concern (terminal, platform); not a gateway/relay relevance signal.",
+      "updated_at": "2026-06-02T04:53:22Z"
+    },
+    {
+      "upstream": "anthropics/claude-code#64653",
+      "url": "https://github.com/anthropics/claude-code/issues/64653",
+      "title": "[Bug] Crash related to Bun runtime",
+      "impact": "not_applicable",
+      "categories": [
+        "terminal"
+      ],
+      "tokenkey_status": "not_applicable",
+      "rationale": "Client-side claude-code concern (terminal); not a gateway/relay relevance signal.",
+      "updated_at": "2026-06-02T04:59:05Z"
+    },
+    {
+      "upstream": "anthropics/claude-code#64655",
+      "url": "https://github.com/anthropics/claude-code/issues/64655",
+      "title": "Embedded preview pane: webview overlays entire window (covers chat/sidebar) + preview_screenshot times out - Windows 11, desktop 1.9659.2",
+      "impact": "not_applicable",
+      "categories": [
+        "terminal",
+        "platform"
+      ],
+      "tokenkey_status": "not_applicable",
+      "rationale": "Client-side claude-code concern (terminal, platform); not a gateway/relay relevance signal.",
+      "updated_at": "2026-06-02T05:32:00Z"
+    },
+    {
+      "upstream": "anthropics/claude-code#64656",
+      "url": "https://github.com/anthropics/claude-code/issues/64656",
+      "title": "[Bug] MCP Server Setup Configuration Error",
+      "impact": "not_applicable",
+      "categories": [
+        "terminal",
+        "mcp"
+      ],
+      "tokenkey_status": "not_applicable",
+      "rationale": "Client-side claude-code concern (terminal, mcp); not a gateway/relay relevance signal.",
+      "updated_at": "2026-06-02T05:31:35Z"
+    },
+    {
+      "upstream": "anthropics/claude-code#64657",
+      "url": "https://github.com/anthropics/claude-code/issues/64657",
+      "title": "[BUG] Left arrow key clears entire conversation with no confirmation and no undo",
+      "impact": "not_applicable",
+      "categories": [
+        "plugin"
+      ],
+      "tokenkey_status": "not_applicable",
+      "rationale": "Client-side claude-code concern (plugin); not a gateway/relay relevance signal.",
+      "updated_at": "2026-06-02T16:17:07Z"
+    },
+    {
+      "upstream": "anthropics/claude-code#64659",
+      "url": "https://github.com/anthropics/claude-code/issues/64659",
+      "title": "[Bug] remote-by-default setting incorrectly attaches new sessions to existing remote sessions",
+      "impact": "not_applicable",
+      "categories": [
+        "terminal"
+      ],
+      "tokenkey_status": "not_applicable",
+      "rationale": "Client-side claude-code concern (terminal); not a gateway/relay relevance signal.",
+      "updated_at": "2026-06-02T06:04:35Z"
+    },
+    {
+      "upstream": "anthropics/claude-code#64661",
+      "url": "https://github.com/anthropics/claude-code/issues/64661",
+      "title": "[BUG] Claude Pro subscription auto-terminated and refunded after 2 days, no violations, no suspension, no user action",
+      "impact": "not_applicable",
+      "categories": [
+        "terminal",
+        "platform"
+      ],
+      "tokenkey_status": "not_applicable",
+      "rationale": "Client-side claude-code concern (terminal, platform); not a gateway/relay relevance signal.",
+      "updated_at": "2026-06-02T06:03:31Z"
+    },
+    {
+      "upstream": "anthropics/claude-code#64663",
+      "url": "https://github.com/anthropics/claude-code/issues/64663",
+      "title": "[Bug] Anthropic API Error: Stream idle timeout - partial response received",
+      "impact": "not_applicable",
+      "categories": [
+        "terminal"
+      ],
+      "tokenkey_status": "not_applicable",
+      "rationale": "Client-side claude-code concern (terminal); not a gateway/relay relevance signal.",
+      "updated_at": "2026-06-02T06:13:05Z"
+    },
+    {
+      "upstream": "anthropics/claude-code#64665",
+      "url": "https://github.com/anthropics/claude-code/issues/64665",
+      "title": "Tool call intermittently emitted as malformed plaintext ('court') instead of executing",
+      "impact": "not_applicable",
+      "categories": [
+        "terminal",
+        "mcp"
+      ],
+      "tokenkey_status": "not_applicable",
+      "rationale": "Client-side claude-code concern (terminal, mcp); not a gateway/relay relevance signal.",
+      "updated_at": "2026-06-02T06:42:29Z"
+    },
+    {
+      "upstream": "anthropics/claude-code#64668",
+      "url": "https://github.com/anthropics/claude-code/issues/64668",
+      "title": "[BUG] Selecting text repeats lines",
+      "impact": "not_applicable",
+      "categories": [
+        "ide",
+        "terminal"
+      ],
+      "tokenkey_status": "not_applicable",
+      "rationale": "Client-side claude-code concern (ide, terminal); not a gateway/relay relevance signal.",
+      "updated_at": "2026-06-02T06:55:45Z"
+    },
+    {
+      "upstream": "anthropics/claude-code#64670",
+      "url": "https://github.com/anthropics/claude-code/issues/64670",
+      "title": "[FEATURE] Collapsible / minimizable AskUserQuestion widget",
+      "impact": "not_applicable",
+      "categories": [
+        "terminal"
+      ],
+      "tokenkey_status": "not_applicable",
+      "rationale": "Client-side claude-code concern (terminal); not a gateway/relay relevance signal.",
+      "updated_at": "2026-06-02T07:02:47Z"
+    },
+    {
+      "upstream": "anthropics/claude-code#64671",
+      "url": "https://github.com/anthropics/claude-code/issues/64671",
+      "title": "[BUG] Claude for Windows: MCP servers fail with UtilityProcess spawn timeout (hardcoded 5s spawn timeout)",
+      "impact": "not_applicable",
+      "categories": [
+        "ide",
+        "mcp",
+        "install",
+        "platform"
+      ],
+      "tokenkey_status": "not_applicable",
+      "rationale": "Client-side claude-code concern (ide, mcp, install, platform); not a gateway/relay relevance signal.",
+      "updated_at": "2026-06-02T07:02:41Z"
+    },
+    {
+      "upstream": "anthropics/claude-code#64674",
+      "url": "https://github.com/anthropics/claude-code/issues/64674",
+      "title": "[FEATURE] Allow customization of message right-click context menu",
+      "impact": "not_applicable",
+      "categories": [
+        "terminal",
+        "slash_hook"
+      ],
+      "tokenkey_status": "not_applicable",
+      "rationale": "Client-side claude-code concern (terminal, slash_hook); not a gateway/relay relevance signal.",
+      "updated_at": "2026-06-02T07:23:38Z"
+    },
+    {
+      "upstream": "anthropics/claude-code#64676",
+      "url": "https://github.com/anthropics/claude-code/issues/64676",
+      "title": "Claude in Chrome: native host spawns but Claude Code CLI never attaches to bridge socket — \"Browser extension is not connected\" (macOS 26.2 + Chrome 148)",
+      "impact": "not_applicable",
+      "categories": [
+        "ide",
+        "mcp",
+        "install"
+      ],
+      "tokenkey_status": "not_applicable",
+      "rationale": "Client-side claude-code concern (ide, mcp, install); not a gateway/relay relevance signal.",
+      "updated_at": "2026-06-02T09:14:05Z"
+    },
+    {
+      "upstream": "anthropics/claude-code#64680",
+      "url": "https://github.com/anthropics/claude-code/issues/64680",
+      "title": "[BUG]",
+      "impact": "not_applicable",
+      "categories": [
+        "terminal"
+      ],
+      "tokenkey_status": "not_applicable",
+      "rationale": "Client-side claude-code concern (terminal); not a gateway/relay relevance signal.",
+      "updated_at": "2026-06-02T08:11:16Z"
+    },
+    {
+      "upstream": "anthropics/claude-code#64681",
+      "url": "https://github.com/anthropics/claude-code/issues/64681",
+      "title": "[Bug] Model defaults to soft prompting despite explicit in-context instructions for strict schemas",
+      "impact": "not_applicable",
+      "categories": [
+        "terminal"
+      ],
+      "tokenkey_status": "not_applicable",
+      "rationale": "Client-side claude-code concern (terminal); not a gateway/relay relevance signal.",
+      "updated_at": "2026-06-02T08:08:29Z"
+    },
+    {
+      "upstream": "anthropics/claude-code#64685",
+      "url": "https://github.com/anthropics/claude-code/issues/64685",
+      "title": "[BUG] macOS: Claude Desktop can't run hooks/git in TCC-protected folders (~/Documents) — `disclaimer` disclaims TCC responsibility, git getcwd() → \"Operation not permitted\"",
+      "impact": "not_applicable",
+      "categories": [
+        "slash_hook"
+      ],
+      "tokenkey_status": "not_applicable",
+      "rationale": "Client-side claude-code concern (slash_hook); not a gateway/relay relevance signal.",
+      "updated_at": "2026-06-02T08:16:43Z"
+    },
+    {
+      "upstream": "anthropics/claude-code#64686",
+      "url": "https://github.com/anthropics/claude-code/issues/64686",
+      "title": "Claude Code extension hides Codex (OpenAI) panel after VS Code restart",
+      "impact": "not_applicable",
+      "categories": [
+        "ide",
+        "terminal",
+        "install",
+        "platform"
+      ],
+      "tokenkey_status": "not_applicable",
+      "rationale": "Client-side claude-code concern (ide, terminal, install, platform); not a gateway/relay relevance signal.",
+      "updated_at": "2026-06-02T08:20:05Z"
+    },
+    {
+      "upstream": "anthropics/claude-code#64687",
+      "url": "https://github.com/anthropics/claude-code/issues/64687",
+      "title": "[BUG] The custom statusLine command loses the branch indicator in ongoing sessions.",
+      "impact": "not_applicable",
+      "categories": [
+        "terminal",
+        "slash_hook"
+      ],
+      "tokenkey_status": "not_applicable",
+      "rationale": "Client-side claude-code concern (terminal, slash_hook); not a gateway/relay relevance signal.",
+      "updated_at": "2026-06-02T08:31:00Z"
+    },
+    {
+      "upstream": "anthropics/claude-code#64688",
+      "url": "https://github.com/anthropics/claude-code/issues/64688",
+      "title": "[BUG] Hook processes flash visible console windows on Windows when Claude Code runs inside WebStorm terminal (ConPTY)",
+      "impact": "not_applicable",
+      "categories": [
+        "ide",
+        "terminal",
+        "slash_hook",
+        "platform"
+      ],
+      "tokenkey_status": "not_applicable",
+      "rationale": "Client-side claude-code concern (ide, terminal, slash_hook, platform); not a gateway/relay relevance signal.",
+      "updated_at": "2026-06-02T08:32:06Z"
+    },
+    {
+      "upstream": "anthropics/claude-code#64689",
+      "url": "https://github.com/anthropics/claude-code/issues/64689",
+      "title": "[BUG] VSCode extension: PowerShell permission prompt only shows Yes/No — missing \"allow for session/project/always\" options",
+      "impact": "not_applicable",
+      "categories": [
+        "ide",
+        "terminal",
+        "slash_hook",
+        "platform"
+      ],
+      "tokenkey_status": "not_applicable",
+      "rationale": "Client-side claude-code concern (ide, terminal, slash_hook, platform); not a gateway/relay relevance signal.",
+      "updated_at": "2026-06-02T09:01:33Z"
+    },
+    {
+      "upstream": "anthropics/claude-code#64690",
+      "url": "https://github.com/anthropics/claude-code/issues/64690",
+      "title": "[BUG] opus 4.8 Tool invocation XML tags intermittently corrupted — antml:invoke rendered as raw text",
+      "impact": "not_applicable",
+      "categories": [
+        "terminal",
+        "mcp"
+      ],
+      "tokenkey_status": "not_applicable",
+      "rationale": "Client-side claude-code concern (terminal, mcp); not a gateway/relay relevance signal.",
+      "updated_at": "2026-06-02T08:43:41Z"
+    },
+    {
+      "upstream": "anthropics/claude-code#64691",
+      "url": "https://github.com/anthropics/claude-code/issues/64691",
+      "title": "[Bug] Wide markdown tables render with overlapping rows and misaligned borders on resize",
+      "impact": "not_applicable",
+      "categories": [
+        "terminal"
+      ],
+      "tokenkey_status": "not_applicable",
+      "rationale": "Client-side claude-code concern (terminal); not a gateway/relay relevance signal.",
+      "updated_at": "2026-06-02T08:56:10Z"
+    },
+    {
+      "upstream": "anthropics/claude-code#64693",
+      "url": "https://github.com/anthropics/claude-code/issues/64693",
+      "title": "[BUG] /effort changes a permanent, global setting without disclosing that it does",
+      "impact": "not_applicable",
+      "categories": [
+        "terminal",
+        "slash_hook"
+      ],
+      "tokenkey_status": "not_applicable",
+      "rationale": "Client-side claude-code concern (terminal, slash_hook); not a gateway/relay relevance signal.",
+      "updated_at": "2026-06-02T09:00:38Z"
+    },
+    {
+      "upstream": "anthropics/claude-code#64694",
+      "url": "https://github.com/anthropics/claude-code/issues/64694",
+      "title": "[Bug] claude agents: session-name column is fixed-narrow and truncates names even on wide terminals",
+      "impact": "not_applicable",
+      "categories": [
+        "terminal",
+        "slash_hook"
+      ],
+      "tokenkey_status": "not_applicable",
+      "rationale": "Client-side claude-code concern (terminal, slash_hook); not a gateway/relay relevance signal.",
+      "updated_at": "2026-06-02T09:30:29Z"
+    },
+    {
+      "upstream": "anthropics/claude-code#64695",
+      "url": "https://github.com/anthropics/claude-code/issues/64695",
+      "title": "[Bug] Tool Call Parsing Failed - Unable to Parse Model Response",
+      "impact": "not_applicable",
+      "categories": [
+        "terminal"
+      ],
+      "tokenkey_status": "not_applicable",
+      "rationale": "Client-side claude-code concern (terminal); not a gateway/relay relevance signal.",
+      "updated_at": "2026-06-02T09:18:00Z"
+    },
+    {
+      "upstream": "anthropics/claude-code#64696",
+      "url": "https://github.com/anthropics/claude-code/issues/64696",
+      "title": "[Bug] Agent process not updated after Claude Code binary upgrade",
+      "impact": "not_applicable",
+      "categories": [
+        "terminal"
+      ],
+      "tokenkey_status": "not_applicable",
+      "rationale": "Client-side claude-code concern (terminal); not a gateway/relay relevance signal.",
+      "updated_at": "2026-06-02T09:31:10Z"
+    },
+    {
+      "upstream": "anthropics/claude-code#64699",
+      "url": "https://github.com/anthropics/claude-code/issues/64699",
+      "title": "Hooks stop firing entirely after editing settings.local.json — Desktop 2.1.156 Windows",
+      "impact": "not_applicable",
+      "categories": [
+        "slash_hook",
+        "platform"
+      ],
+      "tokenkey_status": "not_applicable",
+      "rationale": "Client-side claude-code concern (slash_hook, platform); not a gateway/relay relevance signal.",
+      "updated_at": "2026-06-02T09:43:31Z"
+    },
+    {
+      "upstream": "anthropics/claude-code#64702",
+      "url": "https://github.com/anthropics/claude-code/issues/64702",
+      "title": "[FEATURE] Allow sharing/co-management of scheduled routines (remote agents) with teammates",
+      "impact": "not_applicable",
+      "categories": [
+        "mcp"
+      ],
+      "tokenkey_status": "not_applicable",
+      "rationale": "Client-side claude-code concern (mcp); not a gateway/relay relevance signal.",
+      "updated_at": "2026-06-02T10:33:25Z"
+    },
+    {
+      "upstream": "anthropics/claude-code#64703",
+      "url": "https://github.com/anthropics/claude-code/issues/64703",
+      "title": "[BUG] Sessions created in VS Code extension not visible in web/FleetView UI — asymmetric session visibility",
+      "impact": "not_applicable",
+      "categories": [
+        "ide"
+      ],
+      "tokenkey_status": "not_applicable",
+      "rationale": "Client-side claude-code concern (ide); not a gateway/relay relevance signal.",
+      "updated_at": "2026-06-02T10:23:48Z"
+    },
+    {
+      "upstream": "anthropics/claude-code#64704",
+      "url": "https://github.com/anthropics/claude-code/issues/64704",
+      "title": "[FEATURE REQUEST] Claude Code attribution changes commit authorship metadata and GitHub contributor history",
+      "impact": "not_applicable",
+      "categories": [
+        "terminal",
+        "platform"
+      ],
+      "tokenkey_status": "not_applicable",
+      "rationale": "Client-side claude-code concern (terminal, platform); not a gateway/relay relevance signal.",
+      "updated_at": "2026-06-02T10:10:25Z"
+    },
+    {
+      "upstream": "anthropics/claude-code#64706",
+      "url": "https://github.com/anthropics/claude-code/issues/64706",
+      "title": "Agent tool ignores `effort:` frontmatter in subagent .md files — inherits global effortLevel instead",
+      "impact": "not_applicable",
+      "categories": [
+        "plugin",
+        "slash_hook"
+      ],
+      "tokenkey_status": "not_applicable",
+      "rationale": "Client-side claude-code concern (plugin, slash_hook); not a gateway/relay relevance signal.",
+      "updated_at": "2026-06-02T10:01:53Z"
+    },
+    {
+      "upstream": "anthropics/claude-code#64709",
+      "url": "https://github.com/anthropics/claude-code/issues/64709",
+      "title": "[Bug Report] Unable to generate issue title - no bug report content provided",
+      "impact": "not_applicable",
+      "categories": [
+        "terminal"
+      ],
+      "tokenkey_status": "not_applicable",
+      "rationale": "Client-side claude-code concern (terminal); not a gateway/relay relevance signal.",
+      "updated_at": "2026-06-02T10:29:14Z"
+    },
+    {
+      "upstream": "anthropics/claude-code#64712",
+      "url": "https://github.com/anthropics/claude-code/issues/64712",
+      "title": "Agent stripped a gitignored config the running app depended on, then claimed the fix was 'verified/works in test' without ever loading the UI",
+      "impact": "not_applicable",
+      "categories": [
+        "terminal",
+        "platform"
+      ],
+      "tokenkey_status": "not_applicable",
+      "rationale": "Client-side claude-code concern (terminal, platform); not a gateway/relay relevance signal.",
+      "updated_at": "2026-06-02T10:44:45Z"
+    },
+    {
+      "upstream": "anthropics/claude-code#64713",
+      "url": "https://github.com/anthropics/claude-code/issues/64713",
+      "title": "[Feature Request] Add stream mode to hide personal information on welcome screen",
+      "impact": "not_applicable",
+      "categories": [
+        "terminal"
+      ],
+      "tokenkey_status": "not_applicable",
+      "rationale": "Client-side claude-code concern (terminal); not a gateway/relay relevance signal.",
+      "updated_at": "2026-06-02T10:48:23Z"
+    },
+    {
+      "upstream": "anthropics/claude-code#64714",
+      "url": "https://github.com/anthropics/claude-code/issues/64714",
+      "title": "Bring back a clickable expand/collapse arrow for thinking blocks (mouse, not keyboard)",
+      "impact": "not_applicable",
+      "categories": [
+        "ide",
+        "slash_hook",
+        "platform"
+      ],
+      "tokenkey_status": "not_applicable",
+      "rationale": "Client-side claude-code concern (ide, slash_hook, platform); not a gateway/relay relevance signal.",
+      "updated_at": "2026-06-02T10:49:35Z"
+    },
+    {
+      "upstream": "anthropics/claude-code#64717",
+      "url": "https://github.com/anthropics/claude-code/issues/64717",
+      "title": "[BUG] Claude Code v2.1.160 forces 1M context on Windows VS Code, blocks session continuation after error",
+      "impact": "not_applicable",
+      "categories": [
+        "ide",
+        "terminal",
+        "platform"
+      ],
+      "tokenkey_status": "not_applicable",
+      "rationale": "Client-side claude-code concern (ide, terminal, platform); not a gateway/relay relevance signal.",
+      "updated_at": "2026-06-02T23:51:08Z"
+    },
+    {
+      "upstream": "anthropics/claude-code#64720",
+      "url": "https://github.com/anthropics/claude-code/issues/64720",
+      "title": "[BUG] Error with copy in linux mint",
+      "impact": "not_applicable",
+      "categories": [
+        "terminal"
+      ],
+      "tokenkey_status": "not_applicable",
+      "rationale": "Client-side claude-code concern (terminal); not a gateway/relay relevance signal.",
+      "updated_at": "2026-06-02T11:25:45Z"
+    },
+    {
+      "upstream": "anthropics/claude-code#64723",
+      "url": "https://github.com/anthropics/claude-code/issues/64723",
+      "title": "[FEATURE] Allow customization of CLI spinner verbs",
+      "impact": "not_applicable",
+      "categories": [
+        "terminal",
+        "slash_hook"
+      ],
+      "tokenkey_status": "not_applicable",
+      "rationale": "Client-side claude-code concern (terminal, slash_hook); not a gateway/relay relevance signal.",
+      "updated_at": "2026-06-02T12:04:41Z"
+    },
+    {
+      "upstream": "anthropics/claude-code#64724",
+      "url": "https://github.com/anthropics/claude-code/issues/64724",
+      "title": "[Bug] Claude Code responds in Japanese when input is in Chinese",
+      "impact": "not_applicable",
+      "categories": [
+        "terminal",
+        "mcp",
+        "plugin"
+      ],
+      "tokenkey_status": "not_applicable",
+      "rationale": "Client-side claude-code concern (terminal, mcp, plugin); not a gateway/relay relevance signal.",
+      "updated_at": "2026-06-02T12:10:09Z"
+    },
+    {
+      "upstream": "anthropics/claude-code#64726",
+      "url": "https://github.com/anthropics/claude-code/issues/64726",
+      "title": "[Bug] Terminal chat paste input stops working after multiple turns",
+      "impact": "not_applicable",
+      "categories": [
+        "ide",
+        "terminal",
+        "plugin"
+      ],
+      "tokenkey_status": "not_applicable",
+      "rationale": "Client-side claude-code concern (ide, terminal, plugin); not a gateway/relay relevance signal.",
+      "updated_at": "2026-06-02T12:16:47Z"
+    },
+    {
+      "upstream": "anthropics/claude-code#64727",
+      "url": "https://github.com/anthropics/claude-code/issues/64727",
+      "title": "[BUG] Code blocks with RTL text (Hebrew/Arabic) render LTR — bidi layout is broken",
+      "impact": "not_applicable",
+      "categories": [
+        "terminal",
+        "platform"
+      ],
+      "tokenkey_status": "not_applicable",
+      "rationale": "Client-side claude-code concern (terminal, platform); not a gateway/relay relevance signal.",
+      "updated_at": "2026-06-02T16:40:45Z"
+    },
+    {
+      "upstream": "anthropics/claude-code#64729",
+      "url": "https://github.com/anthropics/claude-code/issues/64729",
+      "title": "Claude Code repeatedly rediscovers solved problems",
+      "impact": "not_applicable",
+      "categories": [
+        "mcp",
+        "install"
+      ],
+      "tokenkey_status": "not_applicable",
+      "rationale": "Client-side claude-code concern (mcp, install); not a gateway/relay relevance signal.",
+      "updated_at": "2026-06-03T03:04:44Z"
+    },
+    {
+      "upstream": "anthropics/claude-code#64731",
+      "url": "https://github.com/anthropics/claude-code/issues/64731",
+      "title": "Code tab (cowork) OOM-crashes: /stats loads all ~/.claude/projects transcripts unbounded; ~/git-as-file makes project scanner walk all of $HOME",
+      "impact": "not_applicable",
+      "categories": [
+        "plugin",
+        "install"
+      ],
+      "tokenkey_status": "not_applicable",
+      "rationale": "Client-side claude-code concern (plugin, install); not a gateway/relay relevance signal.",
+      "updated_at": "2026-06-02T16:23:44Z"
+    },
+    {
+      "upstream": "anthropics/claude-code#64732",
+      "url": "https://github.com/anthropics/claude-code/issues/64732",
+      "title": "[FEATURE] deep-research workflow: ask blocked-source fallback before fan-out",
+      "impact": "not_applicable",
+      "categories": [
+        "ide"
+      ],
+      "tokenkey_status": "not_applicable",
+      "rationale": "Client-side claude-code concern (ide); not a gateway/relay relevance signal.",
+      "updated_at": "2026-06-02T12:46:14Z"
+    },
+    {
+      "upstream": "anthropics/claude-code#64733",
+      "url": "https://github.com/anthropics/claude-code/issues/64733",
+      "title": "[BUG] Regression in 2.1.160 after removing workflow keyword",
+      "impact": "not_applicable",
+      "categories": [
+        "terminal",
+        "plugin"
+      ],
+      "tokenkey_status": "not_applicable",
+      "rationale": "Client-side claude-code concern (terminal, plugin); not a gateway/relay relevance signal.",
+      "updated_at": "2026-06-02T12:50:59Z"
+    },
+    {
+      "upstream": "anthropics/claude-code#64734",
+      "url": "https://github.com/anthropics/claude-code/issues/64734",
+      "title": "[BUG] Tool calls silently fail/truncate after interrupting an in-progress subagent-driven execution loop",
+      "impact": "not_applicable",
+      "categories": [
+        "terminal",
+        "plugin",
+        "platform"
+      ],
+      "tokenkey_status": "not_applicable",
+      "rationale": "Client-side claude-code concern (terminal, plugin, platform); not a gateway/relay relevance signal.",
+      "updated_at": "2026-06-03T06:19:49Z"
+    },
+    {
+      "upstream": "anthropics/claude-code#64738",
+      "url": "https://github.com/anthropics/claude-code/issues/64738",
+      "title": "[FEATURE] add a setting to make the Claude panel ignore Windows High Contrast",
+      "impact": "not_applicable",
+      "categories": [
+        "ide",
+        "terminal",
+        "slash_hook",
+        "platform"
+      ],
+      "tokenkey_status": "not_applicable",
+      "rationale": "Client-side claude-code concern (ide, terminal, slash_hook, platform); not a gateway/relay relevance signal.",
+      "updated_at": "2026-06-02T13:03:42Z"
+    },
+    {
+      "upstream": "anthropics/claude-code#64739",
+      "url": "https://github.com/anthropics/claude-code/issues/64739",
+      "title": "[BUG] 1M token issue",
+      "impact": "not_applicable",
+      "categories": [
+        "terminal",
+        "platform"
+      ],
+      "tokenkey_status": "not_applicable",
+      "rationale": "Client-side claude-code concern (terminal, platform); not a gateway/relay relevance signal.",
+      "updated_at": "2026-06-02T13:06:41Z"
+    },
+    {
+      "upstream": "anthropics/claude-code#64741",
+      "url": "https://github.com/anthropics/claude-code/issues/64741",
+      "title": "Extension host memory leak in Remote-WSL leads to renderer OOM crash",
+      "impact": "not_applicable",
+      "categories": [
+        "ide",
+        "terminal",
+        "platform"
+      ],
+      "tokenkey_status": "not_applicable",
+      "rationale": "Client-side claude-code concern (ide, terminal, platform); not a gateway/relay relevance signal.",
+      "updated_at": "2026-06-02T13:09:46Z"
+    },
+    {
+      "upstream": "anthropics/claude-code#64743",
+      "url": "https://github.com/anthropics/claude-code/issues/64743",
+      "title": "Code tab accumulates hundreds of empty auto-created sessions (body = \"settings dialogue dismissed\")",
+      "impact": "not_applicable",
+      "categories": [
+        "terminal"
+      ],
+      "tokenkey_status": "not_applicable",
+      "rationale": "Client-side claude-code concern (terminal); not a gateway/relay relevance signal.",
+      "updated_at": "2026-06-02T13:20:12Z"
+    },
+    {
+      "upstream": "anthropics/claude-code#64744",
+      "url": "https://github.com/anthropics/claude-code/issues/64744",
+      "title": "[BUG] ScheduleWakeup persists after Ctrl+C, daemon auto-respawns loop unattended causing unbounded token spend",
+      "impact": "not_applicable",
+      "categories": [
+        "terminal"
+      ],
+      "tokenkey_status": "not_applicable",
+      "rationale": "Client-side claude-code concern (terminal); not a gateway/relay relevance signal.",
+      "updated_at": "2026-06-03T00:27:31Z"
+    },
+    {
+      "upstream": "anthropics/claude-code#64745",
+      "url": "https://github.com/anthropics/claude-code/issues/64745",
+      "title": "[FEATURE] Allow entering dev credentials on local domains (.test, .local, localhost)",
+      "impact": "not_applicable",
+      "categories": [
+        "mcp"
+      ],
+      "tokenkey_status": "not_applicable",
+      "rationale": "Client-side claude-code concern (mcp); not a gateway/relay relevance signal.",
+      "updated_at": "2026-06-02T13:28:15Z"
+    },
+    {
+      "upstream": "anthropics/claude-code#64746",
+      "url": "https://github.com/anthropics/claude-code/issues/64746",
+      "title": "Cowork VM connection timeout on Windows 11 Pro ARM64 - guest agent never connects",
+      "impact": "not_applicable",
+      "categories": [
+        "terminal",
+        "install",
+        "platform"
+      ],
+      "tokenkey_status": "not_applicable",
+      "rationale": "Client-side claude-code concern (terminal, install, platform); not a gateway/relay relevance signal.",
+      "updated_at": "2026-06-02T13:29:26Z"
+    },
+    {
+      "upstream": "anthropics/claude-code#64747",
+      "url": "https://github.com/anthropics/claude-code/issues/64747",
+      "title": "Claude Code Opus failed a user for 3 days straight - requesting refund",
+      "impact": "not_applicable",
+      "categories": [
+        "install"
+      ],
+      "tokenkey_status": "not_applicable",
+      "rationale": "Client-side claude-code concern (install); not a gateway/relay relevance signal.",
+      "updated_at": "2026-06-02T13:35:41Z"
+    },
+    {
+      "upstream": "anthropics/claude-code#64748",
+      "url": "https://github.com/anthropics/claude-code/issues/64748",
+      "title": "Remote Control: no per-message provenance — injected/meta messages are indistinguishable from local input in the transcript",
+      "impact": "not_applicable",
+      "categories": [
+        "ide",
+        "terminal"
+      ],
+      "tokenkey_status": "not_applicable",
+      "rationale": "Client-side claude-code concern (ide, terminal); not a gateway/relay relevance signal.",
+      "updated_at": "2026-06-02T13:50:08Z"
+    },
+    {
+      "upstream": "anthropics/claude-code#64749",
+      "url": "https://github.com/anthropics/claude-code/issues/64749",
+      "title": "[Bug] Agent modifying source code when executing one-time scripts",
+      "impact": "not_applicable",
+      "categories": [
+        "terminal"
+      ],
+      "tokenkey_status": "not_applicable",
+      "rationale": "Client-side claude-code concern (terminal); not a gateway/relay relevance signal.",
+      "updated_at": "2026-06-02T13:55:29Z"
+    },
+    {
+      "upstream": "anthropics/claude-code#64751",
+      "url": "https://github.com/anthropics/claude-code/issues/64751",
+      "title": "[BUG] Workflow subagents balloon to ~2GB each and aren't cleaned up — regression 2.1.156 (OK) → 2.1.160",
+      "impact": "not_applicable",
+      "categories": [
+        "plugin",
+        "install"
+      ],
+      "tokenkey_status": "not_applicable",
+      "rationale": "Client-side claude-code concern (plugin, install); not a gateway/relay relevance signal.",
+      "updated_at": "2026-06-02T14:05:56Z"
+    },
+    {
+      "upstream": "anthropics/claude-code#64752",
+      "url": "https://github.com/anthropics/claude-code/issues/64752",
+      "title": "[BUG] Working directory reverts to old path after update restart (v2.1.160)",
+      "impact": "not_applicable",
+      "categories": [
+        "terminal",
+        "platform"
+      ],
+      "tokenkey_status": "not_applicable",
+      "rationale": "Client-side claude-code concern (terminal, platform); not a gateway/relay relevance signal.",
+      "updated_at": "2026-06-02T14:07:18Z"
+    },
+    {
+      "upstream": "anthropics/claude-code#64753",
+      "url": "https://github.com/anthropics/claude-code/issues/64753",
+      "title": "[BUG] TUI render desyncs into transient in-place character scrambling when multiple agents run concurrently (self-recovers)",
+      "impact": "not_applicable",
+      "categories": [
+        "terminal",
+        "plugin"
+      ],
+      "tokenkey_status": "not_applicable",
+      "rationale": "Client-side claude-code concern (terminal, plugin); not a gateway/relay relevance signal.",
+      "updated_at": "2026-06-02T14:13:43Z"
+    },
+    {
+      "upstream": "anthropics/claude-code#64755",
+      "url": "https://github.com/anthropics/claude-code/issues/64755",
+      "title": "[Feature Request] Reduce over-complexity in task decomposition and improve efficiency",
+      "impact": "not_applicable",
+      "categories": [
+        "terminal"
+      ],
+      "tokenkey_status": "not_applicable",
+      "rationale": "Client-side claude-code concern (terminal); not a gateway/relay relevance signal.",
+      "updated_at": "2026-06-02T14:15:46Z"
+    },
+    {
+      "upstream": "anthropics/claude-code#64756",
+      "url": "https://github.com/anthropics/claude-code/issues/64756",
+      "title": "VS Code/Cursor: Claude panel restores blank after Remote-SSH reconnect (deserializeWebviewPanel does not rehydrate conversation)",
+      "impact": "not_applicable",
+      "categories": [
+        "ide",
+        "terminal"
+      ],
+      "tokenkey_status": "not_applicable",
+      "rationale": "Client-side claude-code concern (ide, terminal); not a gateway/relay relevance signal.",
+      "updated_at": "2026-06-02T14:10:39Z"
+    },
+    {
+      "upstream": "anthropics/claude-code#64757",
+      "url": "https://github.com/anthropics/claude-code/issues/64757",
+      "title": "Support inverted layout (input at top, output flowing down) for vertical monitor workflows",
+      "impact": "not_applicable",
+      "categories": [
+        "terminal",
+        "slash_hook"
+      ],
+      "tokenkey_status": "not_applicable",
+      "rationale": "Client-side claude-code concern (terminal, slash_hook); not a gateway/relay relevance signal.",
+      "updated_at": "2026-06-02T14:13:55Z"
+    },
+    {
+      "upstream": "anthropics/claude-code#64758",
+      "url": "https://github.com/anthropics/claude-code/issues/64758",
+      "title": "[Bug] MCP error occurs without clear error message or context",
+      "impact": "not_applicable",
+      "categories": [
+        "ide",
+        "terminal",
+        "mcp"
+      ],
+      "tokenkey_status": "not_applicable",
+      "rationale": "Client-side claude-code concern (ide, terminal, mcp); not a gateway/relay relevance signal.",
+      "updated_at": "2026-06-02T14:19:12Z"
+    },
+    {
+      "upstream": "anthropics/claude-code#64759",
+      "url": "https://github.com/anthropics/claude-code/issues/64759",
+      "title": "[Bug Report] Unable to process request - no details provided",
+      "impact": "not_applicable",
+      "categories": [
+        "terminal"
+      ],
+      "tokenkey_status": "not_applicable",
+      "rationale": "Client-side claude-code concern (terminal); not a gateway/relay relevance signal.",
+      "updated_at": "2026-06-02T14:21:37Z"
+    },
+    {
+      "upstream": "anthropics/claude-code#64761",
+      "url": "https://github.com/anthropics/claude-code/issues/64761",
+      "title": "[BUG] tarda de 10-20 minutos para resolver un problema!",
+      "impact": "not_applicable",
+      "categories": [
+        "terminal"
+      ],
+      "tokenkey_status": "not_applicable",
+      "rationale": "Client-side claude-code concern (terminal); not a gateway/relay relevance signal.",
+      "updated_at": "2026-06-02T14:25:55Z"
+    },
+    {
+      "upstream": "anthropics/claude-code#64763",
+      "url": "https://github.com/anthropics/claude-code/issues/64763",
+      "title": "[BUG] Desktop (Windows): marketplace plugin skills never appear — \"Skipping manifest write for out-of-bounds installPath\" for ~/.claude/plugins/cache",
+      "impact": "not_applicable",
+      "categories": [
+        "mcp",
+        "plugin",
+        "install",
+        "platform"
+      ],
+      "tokenkey_status": "not_applicable",
+      "rationale": "Client-side claude-code concern (mcp, plugin, install, platform); not a gateway/relay relevance signal.",
+      "updated_at": "2026-06-02T14:28:52Z"
+    },
+    {
+      "upstream": "anthropics/claude-code#64764",
+      "url": "https://github.com/anthropics/claude-code/issues/64764",
+      "title": "Opus 4.8: false '1M context credits required' on standard-context session after /clear",
+      "impact": "not_applicable",
+      "categories": [
+        "plugin"
+      ],
+      "tokenkey_status": "not_applicable",
+      "rationale": "Client-side claude-code concern (plugin); not a gateway/relay relevance signal.",
+      "updated_at": "2026-06-02T15:27:07Z"
+    },
+    {
+      "upstream": "anthropics/claude-code#64765",
+      "url": "https://github.com/anthropics/claude-code/issues/64765",
+      "title": "[BUG]",
+      "impact": "not_applicable",
+      "categories": [
+        "terminal",
+        "platform"
+      ],
+      "tokenkey_status": "not_applicable",
+      "rationale": "Client-side claude-code concern (terminal, platform); not a gateway/relay relevance signal.",
+      "updated_at": "2026-06-02T14:32:09Z"
+    },
+    {
+      "upstream": "anthropics/claude-code#64767",
+      "url": "https://github.com/anthropics/claude-code/issues/64767",
+      "title": "[FEATURE] Support structured orchestration as a first-class agent behaviour",
+      "impact": "not_applicable",
+      "categories": [
+        "plugin",
+        "slash_hook"
+      ],
+      "tokenkey_status": "not_applicable",
+      "rationale": "Client-side claude-code concern (plugin, slash_hook); not a gateway/relay relevance signal.",
+      "updated_at": "2026-06-03T03:00:06Z"
+    },
+    {
+      "upstream": "anthropics/claude-code#64768",
+      "url": "https://github.com/anthropics/claude-code/issues/64768",
+      "title": "[Bug] MCP server not properly initialized - /doctor command fails to detect configuration errors",
+      "impact": "not_applicable",
+      "categories": [
+        "terminal",
+        "mcp"
+      ],
+      "tokenkey_status": "not_applicable",
+      "rationale": "Client-side claude-code concern (terminal, mcp); not a gateway/relay relevance signal.",
+      "updated_at": "2026-06-02T15:40:18Z"
+    },
+    {
+      "upstream": "anthropics/claude-code#64769",
+      "url": "https://github.com/anthropics/claude-code/issues/64769",
+      "title": "[Feature Request] Add effort level transparency and dynamic model switching capability",
+      "impact": "not_applicable",
+      "categories": [
+        "ide",
+        "terminal"
+      ],
+      "tokenkey_status": "not_applicable",
+      "rationale": "Client-side claude-code concern (ide, terminal); not a gateway/relay relevance signal.",
+      "updated_at": "2026-06-02T14:58:27Z"
+    },
+    {
+      "upstream": "anthropics/claude-code#64771",
+      "url": "https://github.com/anthropics/claude-code/issues/64771",
+      "title": "[Bug] Resumed sessions ignore [1m] context spec again (regression, previously fixed in #60548)",
+      "impact": "not_applicable",
+      "categories": [
+        "slash_hook",
+        "install"
+      ],
+      "tokenkey_status": "not_applicable",
+      "rationale": "Client-side claude-code concern (slash_hook, install); not a gateway/relay relevance signal.",
+      "updated_at": "2026-06-02T15:02:21Z"
+    },
+    {
+      "upstream": "anthropics/claude-code#64773",
+      "url": "https://github.com/anthropics/claude-code/issues/64773",
+      "title": "[BUG] CLAUDE_AUTOCOMPACT_PCT_OVERRIDE not triggering at configured threshold (v2.1.156)",
+      "impact": "not_applicable",
+      "categories": [
+        "terminal",
+        "slash_hook",
+        "platform"
+      ],
+      "tokenkey_status": "not_applicable",
+      "rationale": "Client-side claude-code concern (terminal, slash_hook, platform); not a gateway/relay relevance signal.",
+      "updated_at": "2026-06-02T17:08:20Z"
+    },
+    {
+      "upstream": "anthropics/claude-code#64775",
+      "url": "https://github.com/anthropics/claude-code/issues/64775",
+      "title": "[BUG] Claude for PowerPoint add-in disabled when comments panel opens on slide with existing comment thread",
+      "impact": "not_applicable",
+      "categories": [
+        "terminal",
+        "platform"
+      ],
+      "tokenkey_status": "not_applicable",
+      "rationale": "Client-side claude-code concern (terminal, platform); not a gateway/relay relevance signal.",
+      "updated_at": "2026-06-02T15:11:16Z"
+    },
+    {
+      "upstream": "anthropics/claude-code#64776",
+      "url": "https://github.com/anthropics/claude-code/issues/64776",
+      "title": "[BUG] Desktop App: AskUserQuestion tool hides most of the message",
+      "impact": "not_applicable",
+      "categories": [
+        "terminal",
+        "platform"
+      ],
+      "tokenkey_status": "not_applicable",
+      "rationale": "Client-side claude-code concern (terminal, platform); not a gateway/relay relevance signal.",
+      "updated_at": "2026-06-02T15:12:01Z"
+    },
+    {
+      "upstream": "anthropics/claude-code#64778",
+      "url": "https://github.com/anthropics/claude-code/issues/64778",
+      "title": "[Bug] `/doctor` command dismisses diagnostics without displaying MCP setup issues",
+      "impact": "not_applicable",
+      "categories": [
+        "terminal",
+        "mcp",
+        "slash_hook"
+      ],
+      "tokenkey_status": "not_applicable",
+      "rationale": "Client-side claude-code concern (terminal, mcp, slash_hook); not a gateway/relay relevance signal.",
+      "updated_at": "2026-06-02T15:19:18Z"
+    },
+    {
+      "upstream": "anthropics/claude-code#64779",
+      "url": "https://github.com/anthropics/claude-code/issues/64779",
+      "title": "Connect claude.ai Projects to Claude Code (VS Code / CLI)",
+      "impact": "not_applicable",
+      "categories": [
+        "ide",
+        "terminal"
+      ],
+      "tokenkey_status": "not_applicable",
+      "rationale": "Client-side claude-code concern (ide, terminal); not a gateway/relay relevance signal.",
+      "updated_at": "2026-06-02T15:18:57Z"
+    },
+    {
+      "upstream": "anthropics/claude-code#64781",
+      "url": "https://github.com/anthropics/claude-code/issues/64781",
+      "title": "[BUG] Welcome screen flashes and collapses to the minimal header once a project has a CLAUDE.md — driven by a sticky hasCompletedProjectOnboarding flag",
+      "impact": "not_applicable",
+      "categories": [
+        "terminal",
+        "mcp"
+      ],
+      "tokenkey_status": "not_applicable",
+      "rationale": "Client-side claude-code concern (terminal, mcp); not a gateway/relay relevance signal.",
+      "updated_at": "2026-06-02T15:29:34Z"
+    },
+    {
+      "upstream": "anthropics/claude-code#64783",
+      "url": "https://github.com/anthropics/claude-code/issues/64783",
+      "title": "[MODEL] Claude commits to git before user can review the proposed commit message",
+      "impact": "not_applicable",
+      "categories": [
+        "slash_hook"
+      ],
+      "tokenkey_status": "not_applicable",
+      "rationale": "Client-side claude-code concern (slash_hook); not a gateway/relay relevance signal.",
+      "updated_at": "2026-06-02T15:44:17Z"
+    },
+    {
+      "upstream": "anthropics/claude-code#64785",
+      "url": "https://github.com/anthropics/claude-code/issues/64785",
+      "title": "Desktop app: infinite React render loop causes OOM crash, kills Chrome",
+      "impact": "not_applicable",
+      "categories": [
+        "terminal",
+        "platform"
+      ],
+      "tokenkey_status": "not_applicable",
+      "rationale": "Client-side claude-code concern (terminal, platform); not a gateway/relay relevance signal.",
+      "updated_at": "2026-06-02T15:49:21Z"
+    },
+    {
+      "upstream": "anthropics/claude-code#64789",
+      "url": "https://github.com/anthropics/claude-code/issues/64789",
+      "title": "[BUG] Claude code cannot connect to the internet",
+      "impact": "not_applicable",
+      "categories": [
+        "terminal"
+      ],
+      "tokenkey_status": "not_applicable",
+      "rationale": "Client-side claude-code concern (terminal); not a gateway/relay relevance signal.",
+      "updated_at": "2026-06-02T15:52:42Z"
+    },
+    {
+      "upstream": "anthropics/claude-code#64790",
+      "url": "https://github.com/anthropics/claude-code/issues/64790",
+      "title": "[Feature Request] Support sudo command execution for system-level operations",
+      "impact": "not_applicable",
+      "categories": [
+        "terminal"
+      ],
+      "tokenkey_status": "not_applicable",
+      "rationale": "Client-side claude-code concern (terminal); not a gateway/relay relevance signal.",
+      "updated_at": "2026-06-02T15:56:23Z"
+    },
+    {
+      "upstream": "anthropics/claude-code#64792",
+      "url": "https://github.com/anthropics/claude-code/issues/64792",
+      "title": "[BUG] Sandbox denies writes to shared .git inside a linked git worktree — git commit/add/push fail with EPERM, despite documented worktree allowance (v2.1.160)",
+      "impact": "not_applicable",
+      "categories": [
+        "terminal",
+        "slash_hook"
+      ],
+      "tokenkey_status": "not_applicable",
+      "rationale": "Client-side claude-code concern (terminal, slash_hook); not a gateway/relay relevance signal.",
+      "updated_at": "2026-06-02T16:23:19Z"
+    },
+    {
+      "upstream": "anthropics/claude-code#64793",
+      "url": "https://github.com/anthropics/claude-code/issues/64793",
+      "title": "[Bug] Claude Code not respecting user-defined rules and constraints inconsistently",
+      "impact": "not_applicable",
+      "categories": [
+        "ide",
+        "terminal"
+      ],
+      "tokenkey_status": "not_applicable",
+      "rationale": "Client-side claude-code concern (ide, terminal); not a gateway/relay relevance signal.",
+      "updated_at": "2026-06-02T16:27:23Z"
+    },
+    {
+      "upstream": "anthropics/claude-code#64794",
+      "url": "https://github.com/anthropics/claude-code/issues/64794",
+      "title": "[BUG] Windows Desktop MSIX wedged in Status: Servicing — RemovePackage 0x80073CFA → AddPackage 0x80073D28, no user-space recovery",
+      "impact": "not_applicable",
+      "categories": [
+        "terminal",
+        "install",
+        "platform"
+      ],
+      "tokenkey_status": "not_applicable",
+      "rationale": "Client-side claude-code concern (terminal, install, platform); not a gateway/relay relevance signal.",
+      "updated_at": "2026-06-02T16:38:55Z"
+    },
+    {
+      "upstream": "anthropics/claude-code#64795",
+      "url": "https://github.com/anthropics/claude-code/issues/64795",
+      "title": "[BUG] Marketplaces tab fails to add marketplace — externalHttp/firstPartyApi routing error",
+      "impact": "not_applicable",
+      "categories": [
+        "terminal",
+        "plugin",
+        "platform"
+      ],
+      "tokenkey_status": "not_applicable",
+      "rationale": "Client-side claude-code concern (terminal, plugin, platform); not a gateway/relay relevance signal.",
+      "updated_at": "2026-06-02T16:34:28Z"
+    },
+    {
+      "upstream": "anthropics/claude-code#64798",
+      "url": "https://github.com/anthropics/claude-code/issues/64798",
+      "title": "[Bug] Black background with no text displayed after user input",
+      "impact": "not_applicable",
+      "categories": [
+        "terminal"
+      ],
+      "tokenkey_status": "not_applicable",
+      "rationale": "Client-side claude-code concern (terminal); not a gateway/relay relevance signal.",
+      "updated_at": "2026-06-02T16:43:58Z"
+    },
+    {
+      "upstream": "anthropics/claude-code#64799",
+      "url": "https://github.com/anthropics/claude-code/issues/64799",
+      "title": "[BUG] bwrap sandbox broken on merged-usr systems (Arch): \"Can't mount tmpfs on /newroot/lib64\" — enableWeakerNestedSandbox does not fix it, MCP servers fail to start",
+      "impact": "not_applicable",
+      "categories": [
+        "terminal",
+        "mcp"
+      ],
+      "tokenkey_status": "not_applicable",
+      "rationale": "Client-side claude-code concern (terminal, mcp); not a gateway/relay relevance signal.",
+      "updated_at": "2026-06-02T16:38:58Z"
+    },
+    {
+      "upstream": "anthropics/claude-code#64800",
+      "url": "https://github.com/anthropics/claude-code/issues/64800",
+      "title": "[BUG] Claude Code with Auto Mode abandone skill, act on its own",
+      "impact": "not_applicable",
+      "categories": [
+        "terminal"
+      ],
+      "tokenkey_status": "not_applicable",
+      "rationale": "Client-side claude-code concern (terminal); not a gateway/relay relevance signal.",
+      "updated_at": "2026-06-02T16:40:50Z"
+    },
+    {
+      "upstream": "anthropics/claude-code#64803",
+      "url": "https://github.com/anthropics/claude-code/issues/64803",
+      "title": "[Regression] Thinking blocks no longer expand on click in VSCode extension (v2.1.160)",
+      "impact": "not_applicable",
+      "categories": [
+        "ide",
+        "slash_hook",
+        "platform"
+      ],
+      "tokenkey_status": "not_applicable",
+      "rationale": "Client-side claude-code concern (ide, slash_hook, platform); not a gateway/relay relevance signal.",
+      "updated_at": "2026-06-02T16:46:49Z"
+    },
+    {
+      "upstream": "anthropics/claude-code#64804",
+      "url": "https://github.com/anthropics/claude-code/issues/64804",
+      "title": "[BUG] Enter inserts a newline instead of submitting; keybindings.json override is ignored",
+      "impact": "not_applicable",
+      "categories": [
+        "terminal",
+        "slash_hook",
+        "platform"
+      ],
+      "tokenkey_status": "not_applicable",
+      "rationale": "Client-side claude-code concern (terminal, slash_hook, platform); not a gateway/relay relevance signal.",
+      "updated_at": "2026-06-02T16:45:47Z"
+    },
+    {
+      "upstream": "anthropics/claude-code#64805",
+      "url": "https://github.com/anthropics/claude-code/issues/64805",
+      "title": "[FEATURE] Visible context-window usage indicator in Cowork (parity with Codex / Claude Code status line)",
+      "impact": "not_applicable",
+      "categories": [
+        "ide"
+      ],
+      "tokenkey_status": "not_applicable",
+      "rationale": "Client-side claude-code concern (ide); not a gateway/relay relevance signal.",
+      "updated_at": "2026-06-02T17:11:54Z"
+    },
+    {
+      "upstream": "anthropics/claude-code#64806",
+      "url": "https://github.com/anthropics/claude-code/issues/64806",
+      "title": "[Bug] `/team-onboarding` command not finding any user sessions",
+      "impact": "not_applicable",
+      "categories": [
+        "terminal"
+      ],
+      "tokenkey_status": "not_applicable",
+      "rationale": "Client-side claude-code concern (terminal); not a gateway/relay relevance signal.",
+      "updated_at": "2026-06-02T16:56:52Z"
+    },
+    {
+      "upstream": "anthropics/claude-code#64808",
+      "url": "https://github.com/anthropics/claude-code/issues/64808",
+      "title": "[Bug] Sonnet 4.6 degradation: Unable to port previously working logic across codebases",
+      "impact": "not_applicable",
+      "categories": [
+        "terminal"
+      ],
+      "tokenkey_status": "not_applicable",
+      "rationale": "Client-side claude-code concern (terminal); not a gateway/relay relevance signal.",
+      "updated_at": "2026-06-02T17:07:27Z"
+    },
+    {
+      "upstream": "anthropics/claude-code#64809",
+      "url": "https://github.com/anthropics/claude-code/issues/64809",
+      "title": "[BUG] event log tool_decision.tool_parameters.bash_command - bash_command captures leading variable assignment instead of the actual command",
+      "impact": "not_applicable",
+      "categories": [
+        "terminal"
+      ],
+      "tokenkey_status": "not_applicable",
+      "rationale": "Client-side claude-code concern (terminal); not a gateway/relay relevance signal.",
+      "updated_at": "2026-06-02T17:01:17Z"
+    },
+    {
+      "upstream": "anthropics/claude-code#64810",
+      "url": "https://github.com/anthropics/claude-code/issues/64810",
+      "title": "Memory-directory writes always prompt for permission; allow-list and acceptEdits don't bypass it, \"don't ask again\" doesn't persist",
+      "impact": "not_applicable",
+      "categories": [
+        "slash_hook"
+      ],
+      "tokenkey_status": "not_applicable",
+      "rationale": "Client-side claude-code concern (slash_hook); not a gateway/relay relevance signal.",
+      "updated_at": "2026-06-03T06:03:26Z"
+    },
+    {
+      "upstream": "anthropics/claude-code#64811",
+      "url": "https://github.com/anthropics/claude-code/issues/64811",
+      "title": "[Bug] Doctor command not displaying setup errors",
+      "impact": "not_applicable",
+      "categories": [
+        "terminal"
+      ],
+      "tokenkey_status": "not_applicable",
+      "rationale": "Client-side claude-code concern (terminal); not a gateway/relay relevance signal.",
+      "updated_at": "2026-06-02T17:12:06Z"
+    },
+    {
+      "upstream": "anthropics/claude-code#64812",
+      "url": "https://github.com/anthropics/claude-code/issues/64812",
+      "title": "[Bug] Agent conflates inferred conclusions with empirical measurements, enabling unsafe production deployments",
+      "impact": "not_applicable",
+      "categories": [
+        "terminal"
+      ],
+      "tokenkey_status": "not_applicable",
+      "rationale": "Client-side claude-code concern (terminal); not a gateway/relay relevance signal.",
+      "updated_at": "2026-06-02T17:21:34Z"
+    },
+    {
+      "upstream": "anthropics/claude-code#64813",
+      "url": "https://github.com/anthropics/claude-code/issues/64813",
+      "title": "[BUG] Context window uses more than available somehow?",
+      "impact": "not_applicable",
+      "categories": [
+        "terminal"
+      ],
+      "tokenkey_status": "not_applicable",
+      "rationale": "Client-side claude-code concern (terminal); not a gateway/relay relevance signal.",
+      "updated_at": "2026-06-02T17:19:43Z"
+    },
+    {
+      "upstream": "anthropics/claude-code#64815",
+      "url": "https://github.com/anthropics/claude-code/issues/64815",
+      "title": "[FEATURE] Built-in branch diff badge (\"+X −Y\") has no hide/disable option — distracting on long-lived branches",
+      "impact": "not_applicable",
+      "categories": [
+        "slash_hook"
+      ],
+      "tokenkey_status": "not_applicable",
+      "rationale": "Client-side claude-code concern (slash_hook); not a gateway/relay relevance signal.",
+      "updated_at": "2026-06-02T17:29:29Z"
+    },
+    {
+      "upstream": "anthropics/claude-code#64816",
+      "url": "https://github.com/anthropics/claude-code/issues/64816",
+      "title": "[Bug] Usage Policy violation when requesting crash reproduction test",
+      "impact": "not_applicable",
+      "categories": [
+        "terminal"
+      ],
+      "tokenkey_status": "not_applicable",
+      "rationale": "Client-side claude-code concern (terminal); not a gateway/relay relevance signal.",
+      "updated_at": "2026-06-02T17:36:53Z"
+    },
+    {
+      "upstream": "anthropics/claude-code#64817",
+      "url": "https://github.com/anthropics/claude-code/issues/64817",
+      "title": "ultracode: true in settings.json does not inject session-start system-reminder",
+      "impact": "not_applicable",
+      "categories": [
+        "slash_hook"
+      ],
+      "tokenkey_status": "not_applicable",
+      "rationale": "Client-side claude-code concern (slash_hook); not a gateway/relay relevance signal.",
+      "updated_at": "2026-06-02T17:34:46Z"
+    },
+    {
+      "upstream": "anthropics/claude-code#64818",
+      "url": "https://github.com/anthropics/claude-code/issues/64818",
+      "title": "Claude Desktop: gkinstall temp directories not cleaned up, accumulating 100GB+ of disk space",
+      "impact": "not_applicable",
+      "categories": [
+        "install"
+      ],
+      "tokenkey_status": "not_applicable",
+      "rationale": "Client-side claude-code concern (install); not a gateway/relay relevance signal.",
+      "updated_at": "2026-06-02T17:34:31Z"
+    },
+    {
+      "upstream": "anthropics/claude-code#64819",
+      "url": "https://github.com/anthropics/claude-code/issues/64819",
+      "title": "[Bug Report] Unable to process issue - no bug report provided",
+      "impact": "not_applicable",
+      "categories": [
+        "ide",
+        "terminal"
+      ],
+      "tokenkey_status": "not_applicable",
+      "rationale": "Client-side claude-code concern (ide, terminal); not a gateway/relay relevance signal.",
+      "updated_at": "2026-06-02T17:35:06Z"
+    },
+    {
+      "upstream": "anthropics/claude-code#64821",
+      "url": "https://github.com/anthropics/claude-code/issues/64821",
+      "title": "Unable to access cowork despite subscription",
+      "impact": "not_applicable",
+      "categories": [
+        "terminal",
+        "platform"
+      ],
+      "tokenkey_status": "not_applicable",
+      "rationale": "Client-side claude-code concern (terminal, platform); not a gateway/relay relevance signal.",
+      "updated_at": "2026-06-02T17:52:09Z"
+    },
+    {
+      "upstream": "anthropics/claude-code#64823",
+      "url": "https://github.com/anthropics/claude-code/issues/64823",
+      "title": "[BUG] Session names update to later messages instead of staying anchored to the first message",
+      "impact": "not_applicable",
+      "categories": [
+        "terminal"
+      ],
+      "tokenkey_status": "not_applicable",
+      "rationale": "Client-side claude-code concern (terminal); not a gateway/relay relevance signal.",
+      "updated_at": "2026-06-02T18:03:11Z"
+    },
+    {
+      "upstream": "anthropics/claude-code#64824",
+      "url": "https://github.com/anthropics/claude-code/issues/64824",
+      "title": "[BAD BEHAVIOR(?)] MCP setup validation fails and /doctor command cannot resolve issues",
+      "impact": "not_applicable",
+      "categories": [
+        "terminal",
+        "mcp"
+      ],
+      "tokenkey_status": "not_applicable",
+      "rationale": "Client-side claude-code concern (terminal, mcp); not a gateway/relay relevance signal.",
+      "updated_at": "2026-06-02T18:08:08Z"
+    },
+    {
+      "upstream": "anthropics/claude-code#64825",
+      "url": "https://github.com/anthropics/claude-code/issues/64825",
+      "title": "[Bug] Drag-and-drop images not supported in text-based Claude Code CLI",
+      "impact": "not_applicable",
+      "categories": [
+        "terminal"
+      ],
+      "tokenkey_status": "not_applicable",
+      "rationale": "Client-side claude-code concern (terminal); not a gateway/relay relevance signal.",
+      "updated_at": "2026-06-02T18:07:00Z"
+    },
+    {
+      "upstream": "anthropics/claude-code#64826",
+      "url": "https://github.com/anthropics/claude-code/issues/64826",
+      "title": "[BUG] unable to copy paste from ssh terminal despite it is advertised you could",
+      "impact": "not_applicable",
+      "categories": [
+        "terminal"
+      ],
+      "tokenkey_status": "not_applicable",
+      "rationale": "Client-side claude-code concern (terminal); not a gateway/relay relevance signal.",
+      "updated_at": "2026-06-02T18:09:57Z"
+    },
+    {
+      "upstream": "anthropics/claude-code#64828",
+      "url": "https://github.com/anthropics/claude-code/issues/64828",
+      "title": "[BUG] Repo-level .claude/settings.json not loaded when session is rooted at a parent directory",
+      "impact": "not_applicable",
+      "categories": [
+        "terminal",
+        "slash_hook",
+        "platform"
+      ],
+      "tokenkey_status": "not_applicable",
+      "rationale": "Client-side claude-code concern (terminal, slash_hook, platform); not a gateway/relay relevance signal.",
+      "updated_at": "2026-06-02T18:18:41Z"
+    },
+    {
+      "upstream": "anthropics/claude-code#64830",
+      "url": "https://github.com/anthropics/claude-code/issues/64830",
+      "title": "[Bug] Excessive verbosity in unprompted detailed responses",
+      "impact": "not_applicable",
+      "categories": [
+        "ide",
+        "terminal"
+      ],
+      "tokenkey_status": "not_applicable",
+      "rationale": "Client-side claude-code concern (ide, terminal); not a gateway/relay relevance signal.",
+      "updated_at": "2026-06-02T18:41:02Z"
+    },
+    {
+      "upstream": "anthropics/claude-code#64833",
+      "url": "https://github.com/anthropics/claude-code/issues/64833",
+      "title": "Sub-agent tool calls/logs incorrectly visible in VS Code extension 2.1.160 (hidden correctly in 2.1.39)",
+      "impact": "not_applicable",
+      "categories": [
+        "ide",
+        "install"
+      ],
+      "tokenkey_status": "not_applicable",
+      "rationale": "Client-side claude-code concern (ide, install); not a gateway/relay relevance signal.",
+      "updated_at": "2026-06-02T18:52:49Z"
+    },
+    {
+      "upstream": "anthropics/claude-code#64834",
+      "url": "https://github.com/anthropics/claude-code/issues/64834",
+      "title": "[BUG] Speech-to-text microphone is broken and visually ugly — please fix urgently",
+      "impact": "not_applicable",
+      "categories": [
+        "terminal",
+        "platform"
+      ],
+      "tokenkey_status": "not_applicable",
+      "rationale": "Client-side claude-code concern (terminal, platform); not a gateway/relay relevance signal.",
+      "updated_at": "2026-06-02T18:54:58Z"
+    },
+    {
+      "upstream": "anthropics/claude-code#64835",
+      "url": "https://github.com/anthropics/claude-code/issues/64835",
+      "title": "I'm ready to help generate a GitHub issue title for Claude Code. However, I don't see a bug report in your message - you've provided the instructions but no actual bug report to analyze. Please share the bug report details, and I'll generate an appropriat",
+      "impact": "not_applicable",
+      "categories": [
+        "terminal"
+      ],
+      "tokenkey_status": "not_applicable",
+      "rationale": "Client-side claude-code concern (terminal); not a gateway/relay relevance signal.",
+      "updated_at": "2026-06-02T18:59:26Z"
+    },
+    {
+      "upstream": "anthropics/claude-code#64836",
+      "url": "https://github.com/anthropics/claude-code/issues/64836",
+      "title": "[Bug] Session name not displayed in prompt bar when resuming named session",
+      "impact": "not_applicable",
+      "categories": [
+        "terminal"
+      ],
+      "tokenkey_status": "not_applicable",
+      "rationale": "Client-side claude-code concern (terminal); not a gateway/relay relevance signal.",
+      "updated_at": "2026-06-02T19:02:34Z"
+    },
+    {
+      "upstream": "anthropics/claude-code#64837",
+      "url": "https://github.com/anthropics/claude-code/issues/64837",
+      "title": "[MODEL] Sonnet 4.6 Working Directory at New Conversation",
+      "impact": "not_applicable",
+      "categories": [
+        "terminal"
+      ],
+      "tokenkey_status": "not_applicable",
+      "rationale": "Client-side claude-code concern (terminal); not a gateway/relay relevance signal.",
+      "updated_at": "2026-06-02T19:14:52Z"
+    },
+    {
+      "upstream": "anthropics/claude-code#64839",
+      "url": "https://github.com/anthropics/claude-code/issues/64839",
+      "title": "[BUG] Background subagents run indefinitely with no visible progress indicator or timeout, causing 3+ hour waits with no way to check status or interrupt without killing the entire session.",
+      "impact": "not_applicable",
+      "categories": [
+        "terminal",
+        "plugin",
+        "install",
+        "platform"
+      ],
+      "tokenkey_status": "not_applicable",
+      "rationale": "Client-side claude-code concern (terminal, plugin, install, platform); not a gateway/relay relevance signal.",
+      "updated_at": "2026-06-02T19:27:51Z"
+    },
+    {
+      "upstream": "anthropics/claude-code#64840",
+      "url": "https://github.com/anthropics/claude-code/issues/64840",
+      "title": "[Feature Request] Remove unnecessary verbal disclaimers.. All of them. They waste energy, time, tokens and money. Stop the rot.",
+      "impact": "not_applicable",
+      "categories": [
+        "terminal"
+      ],
+      "tokenkey_status": "not_applicable",
+      "rationale": "Client-side claude-code concern (terminal); not a gateway/relay relevance signal.",
+      "updated_at": "2026-06-02T21:22:59Z"
+    },
+    {
+      "upstream": "anthropics/claude-code#64842",
+      "url": "https://github.com/anthropics/claude-code/issues/64842",
+      "title": "Subagent ignores explicit instruction to skip test execution",
+      "impact": "not_applicable",
+      "categories": [
+        "plugin",
+        "platform"
+      ],
+      "tokenkey_status": "not_applicable",
+      "rationale": "Client-side claude-code concern (plugin, platform); not a gateway/relay relevance signal.",
+      "updated_at": "2026-06-02T19:28:59Z"
+    },
+    {
+      "upstream": "anthropics/claude-code#64843",
+      "url": "https://github.com/anthropics/claude-code/issues/64843",
+      "title": "Desktop: Scheduled task sessions don't appear under 'Scheduled' section in sidebar",
+      "impact": "not_applicable",
+      "categories": [
+        "terminal",
+        "platform"
+      ],
+      "tokenkey_status": "not_applicable",
+      "rationale": "Client-side claude-code concern (terminal, platform); not a gateway/relay relevance signal.",
+      "updated_at": "2026-06-02T19:35:16Z"
+    },
+    {
+      "upstream": "anthropics/claude-code#64844",
+      "url": "https://github.com/anthropics/claude-code/issues/64844",
+      "title": "[BUG] VSCode session picker sorts by file mtime, not last in-file activity — bulk mtime restamps scramble order and age labels",
+      "impact": "not_applicable",
+      "categories": [
+        "ide",
+        "terminal"
+      ],
+      "tokenkey_status": "not_applicable",
+      "rationale": "Client-side claude-code concern (ide, terminal); not a gateway/relay relevance signal.",
+      "updated_at": "2026-06-02T19:38:24Z"
+    },
+    {
+      "upstream": "anthropics/claude-code#64845",
+      "url": "https://github.com/anthropics/claude-code/issues/64845",
+      "title": "[BUG] desktop app shows the pricing page despite having an active Pro subscription.",
+      "impact": "not_applicable",
+      "categories": [
+        "terminal"
+      ],
+      "tokenkey_status": "not_applicable",
+      "rationale": "Client-side claude-code concern (terminal); not a gateway/relay relevance signal.",
+      "updated_at": "2026-06-02T19:58:58Z"
+    },
+    {
+      "upstream": "anthropics/claude-code#64847",
+      "url": "https://github.com/anthropics/claude-code/issues/64847",
+      "title": "[BUG] Plan mode indicator: ⏸ emoji renders too close to \"plan\" label text",
+      "impact": "not_applicable",
+      "categories": [
+        "terminal",
+        "platform"
+      ],
+      "tokenkey_status": "not_applicable",
+      "rationale": "Client-side claude-code concern (terminal, platform); not a gateway/relay relevance signal.",
+      "updated_at": "2026-06-02T20:16:57Z"
+    },
+    {
+      "upstream": "anthropics/claude-code#64849",
+      "url": "https://github.com/anthropics/claude-code/issues/64849",
+      "title": "[BUG] Settings: Clicking \"Bypass permissions\" link in chat does not scroll to the setting",
+      "impact": "not_applicable",
+      "categories": [
+        "terminal"
+      ],
+      "tokenkey_status": "not_applicable",
+      "rationale": "Client-side claude-code concern (terminal); not a gateway/relay relevance signal.",
+      "updated_at": "2026-06-02T20:22:09Z"
+    },
+    {
+      "upstream": "anthropics/claude-code#64851",
+      "url": "https://github.com/anthropics/claude-code/issues/64851",
+      "title": "Hook harness passes main checkout cwd instead of worktree cwd in payload",
+      "impact": "not_applicable",
+      "categories": [
+        "slash_hook"
+      ],
+      "tokenkey_status": "not_applicable",
+      "rationale": "Client-side claude-code concern (slash_hook); not a gateway/relay relevance signal.",
+      "updated_at": "2026-06-02T20:37:38Z"
+    },
+    {
+      "upstream": "anthropics/claude-code#64853",
+      "url": "https://github.com/anthropics/claude-code/issues/64853",
+      "title": "[BUG] Cowork: skill scripts silently truncated on disk at a token boundary, passing py_compile and becoming canonical",
+      "impact": "not_applicable",
+      "categories": [
+        "terminal",
+        "plugin",
+        "install",
+        "platform"
+      ],
+      "tokenkey_status": "not_applicable",
+      "rationale": "Client-side claude-code concern (terminal, plugin, install, platform); not a gateway/relay relevance signal.",
+      "updated_at": "2026-06-02T20:58:46Z"
+    },
+    {
+      "upstream": "anthropics/claude-code#64855",
+      "url": "https://github.com/anthropics/claude-code/issues/64855",
+      "title": "[FEATURE] Bindable bash-mode submit actions — enter = run+stay, shift+enter = run+exit",
+      "impact": "not_applicable",
+      "categories": [
+        "terminal",
+        "slash_hook"
+      ],
+      "tokenkey_status": "not_applicable",
+      "rationale": "Client-side claude-code concern (terminal, slash_hook); not a gateway/relay relevance signal.",
+      "updated_at": "2026-06-02T20:46:22Z"
+    },
+    {
+      "upstream": "anthropics/claude-code#64856",
+      "url": "https://github.com/anthropics/claude-code/issues/64856",
+      "title": "[BUG] Claude Code falsely claims it can accept and read pasted screenshots in the terminal, even though terminals do not support image input.",
+      "impact": "not_applicable",
+      "categories": [
+        "ide",
+        "terminal",
+        "platform"
+      ],
+      "tokenkey_status": "not_applicable",
+      "rationale": "Client-side claude-code concern (ide, terminal, platform); not a gateway/relay relevance signal.",
+      "updated_at": "2026-06-02T20:46:58Z"
+    },
+    {
+      "upstream": "anthropics/claude-code#64858",
+      "url": "https://github.com/anthropics/claude-code/issues/64858",
+      "title": "[BUG] Launcher branch chip shows \".invalid\" for repos using git's reftable backend (reads .git/HEAD directly)",
+      "impact": "not_applicable",
+      "categories": [
+        "terminal"
+      ],
+      "tokenkey_status": "not_applicable",
+      "rationale": "Client-side claude-code concern (terminal); not a gateway/relay relevance signal.",
+      "updated_at": "2026-06-02T21:03:21Z"
+    },
+    {
+      "upstream": "anthropics/claude-code#64861",
+      "url": "https://github.com/anthropics/claude-code/issues/64861",
+      "title": "[Bug] MCP Server Setup Failed",
+      "impact": "not_applicable",
+      "categories": [
+        "ide",
+        "terminal",
+        "mcp"
+      ],
+      "tokenkey_status": "not_applicable",
+      "rationale": "Client-side claude-code concern (ide, terminal, mcp); not a gateway/relay relevance signal.",
+      "updated_at": "2026-06-02T21:36:14Z"
+    },
+    {
+      "upstream": "anthropics/claude-code#64863",
+      "url": "https://github.com/anthropics/claude-code/issues/64863",
+      "title": "[FEATURE] Markdown Response Copy",
+      "impact": "not_applicable",
+      "categories": [
+        "ide",
+        "terminal"
+      ],
+      "tokenkey_status": "not_applicable",
+      "rationale": "Client-side claude-code concern (ide, terminal); not a gateway/relay relevance signal.",
+      "updated_at": "2026-06-02T21:42:55Z"
+    },
+    {
+      "upstream": "anthropics/claude-code#64864",
+      "url": "https://github.com/anthropics/claude-code/issues/64864",
+      "title": "Bun crash on Windows: integer overflow panic in Allocator during HTTP long timeout cleanup",
+      "impact": "not_applicable",
+      "categories": [
+        "mcp",
+        "platform"
+      ],
+      "tokenkey_status": "not_applicable",
+      "rationale": "Client-side claude-code concern (mcp, platform); not a gateway/relay relevance signal.",
+      "updated_at": "2026-06-02T21:46:14Z"
+    },
+    {
+      "upstream": "anthropics/claude-code#64865",
+      "url": "https://github.com/anthropics/claude-code/issues/64865",
+      "title": "[Bug] Claude ignores worktree boundaries despite global instructions",
+      "impact": "not_applicable",
+      "categories": [
+        "ide",
+        "terminal"
+      ],
+      "tokenkey_status": "not_applicable",
+      "rationale": "Client-side claude-code concern (ide, terminal); not a gateway/relay relevance signal.",
+      "updated_at": "2026-06-02T21:57:29Z"
+    },
+    {
+      "upstream": "anthropics/claude-code#64867",
+      "url": "https://github.com/anthropics/claude-code/issues/64867",
+      "title": "[BUG] Code tab fails with \"Host denied (verification failed)\" on Windows 11 Insider Preview 26220 — VM never created, HCS error 0xC0370103",
+      "impact": "not_applicable",
+      "categories": [
+        "terminal",
+        "install",
+        "platform"
+      ],
+      "tokenkey_status": "not_applicable",
+      "rationale": "Client-side claude-code concern (terminal, install, platform); not a gateway/relay relevance signal.",
+      "updated_at": "2026-06-03T03:41:20Z"
+    },
+    {
+      "upstream": "anthropics/claude-code#64868",
+      "url": "https://github.com/anthropics/claude-code/issues/64868",
+      "title": "Refund request — Claude Code did not deliver promised functionality",
+      "impact": "not_applicable",
+      "categories": [
+        "ide"
+      ],
+      "tokenkey_status": "not_applicable",
+      "rationale": "Client-side claude-code concern (ide); not a gateway/relay relevance signal.",
+      "updated_at": "2026-06-02T22:03:13Z"
+    },
+    {
+      "upstream": "anthropics/claude-code#64869",
+      "url": "https://github.com/anthropics/claude-code/issues/64869",
+      "title": "[Bug / Edge Case] Opus 4.7 Alignment Drift triggers automated T&S false-positive ban, blocking claude-code evaluation",
+      "impact": "not_applicable",
+      "categories": [
+        "terminal"
+      ],
+      "tokenkey_status": "not_applicable",
+      "rationale": "Client-side claude-code concern (terminal); not a gateway/relay relevance signal.",
+      "updated_at": "2026-06-02T22:15:13Z"
+    },
+    {
+      "upstream": "anthropics/claude-code#64872",
+      "url": "https://github.com/anthropics/claude-code/issues/64872",
+      "title": "[Bug] Simultaneous feedback request and number input prompt causes UX conflict",
+      "impact": "not_applicable",
+      "categories": [
+        "terminal"
+      ],
+      "tokenkey_status": "not_applicable",
+      "rationale": "Client-side claude-code concern (terminal); not a gateway/relay relevance signal.",
+      "updated_at": "2026-06-02T22:14:53Z"
+    },
+    {
+      "upstream": "anthropics/claude-code#64874",
+      "url": "https://github.com/anthropics/claude-code/issues/64874",
+      "title": "[Bug] Rolling usage window resets abruptly instead of decreasing gradually",
+      "impact": "not_applicable",
+      "categories": [
+        "terminal"
+      ],
+      "tokenkey_status": "not_applicable",
+      "rationale": "Client-side claude-code concern (terminal); not a gateway/relay relevance signal.",
+      "updated_at": "2026-06-02T22:26:07Z"
+    },
+    {
+      "upstream": "anthropics/claude-code#64875",
+      "url": "https://github.com/anthropics/claude-code/issues/64875",
+      "title": "[BUG] Uninstalling pluging is not wiping off properly still remains in the cache",
+      "impact": "not_applicable",
+      "categories": [
+        "terminal",
+        "plugin",
+        "slash_hook",
+        "install",
+        "platform"
+      ],
+      "tokenkey_status": "not_applicable",
+      "rationale": "Client-side claude-code concern (terminal, plugin, slash_hook, install, platform); not a gateway/relay relevance signal.",
+      "updated_at": "2026-06-02T22:48:11Z"
+    },
+    {
+      "upstream": "anthropics/claude-code#64876",
+      "url": "https://github.com/anthropics/claude-code/issues/64876",
+      "title": "[BUG] Drag and Drop + Screenshot Support Stopped Working",
+      "impact": "not_applicable",
+      "categories": [
+        "ide",
+        "terminal",
+        "platform"
+      ],
+      "tokenkey_status": "not_applicable",
+      "rationale": "Client-side claude-code concern (ide, terminal, platform); not a gateway/relay relevance signal.",
+      "updated_at": "2026-06-02T22:50:07Z"
+    },
+    {
+      "upstream": "anthropics/claude-code#64877",
+      "url": "https://github.com/anthropics/claude-code/issues/64877",
+      "title": "I don't see a bug report in your message - you've only provided a file path to a screenshot. To help you generate an appropriate GitHub issue title, please share: 1. A description of the bug you encountered 2. What error message or unexpected behavior oc",
+      "impact": "not_applicable",
+      "categories": [
+        "terminal"
+      ],
+      "tokenkey_status": "not_applicable",
+      "rationale": "Client-side claude-code concern (terminal); not a gateway/relay relevance signal.",
+      "updated_at": "2026-06-02T22:55:16Z"
+    },
+    {
+      "upstream": "anthropics/claude-code#64879",
+      "url": "https://github.com/anthropics/claude-code/issues/64879",
+      "title": "[BUG] claude://cowork/new?file= deeplink reuses the prior deeplink's session instead of opening a new one (file gets attached to existing session)",
+      "impact": "not_applicable",
+      "categories": [
+        "terminal"
+      ],
+      "tokenkey_status": "not_applicable",
+      "rationale": "Client-side claude-code concern (terminal); not a gateway/relay relevance signal.",
+      "updated_at": "2026-06-02T22:55:36Z"
+    },
+    {
+      "upstream": "anthropics/claude-code#64883",
+      "url": "https://github.com/anthropics/claude-code/issues/64883",
+      "title": "[BUG][Desktop][macOS 26] Code tab kills entire app — rootfs.img redownload loop (disk-write jetsam); crashes even with all connectors disabled",
+      "impact": "not_applicable",
+      "categories": [
+        "terminal",
+        "mcp"
+      ],
+      "tokenkey_status": "not_applicable",
+      "rationale": "Client-side claude-code concern (terminal, mcp); not a gateway/relay relevance signal.",
+      "updated_at": "2026-06-03T04:39:34Z"
+    },
+    {
+      "upstream": "anthropics/claude-code#64884",
+      "url": "https://github.com/anthropics/claude-code/issues/64884",
+      "title": "[Bug] Claude makes excessive assumptions and implements unrequested features instead of clarifying intent",
+      "impact": "not_applicable",
+      "categories": [
+        "terminal",
+        "platform"
+      ],
+      "tokenkey_status": "not_applicable",
+      "rationale": "Client-side claude-code concern (terminal, platform); not a gateway/relay relevance signal.",
+      "updated_at": "2026-06-02T23:07:44Z"
+    },
+    {
+      "upstream": "anthropics/claude-code#64887",
+      "url": "https://github.com/anthropics/claude-code/issues/64887",
+      "title": "[BUG] **Title:** Claude Desktop loses active session when app relaunches for update — no warning, no recovery",
+      "impact": "not_applicable",
+      "categories": [
+        "terminal",
+        "mcp"
+      ],
+      "tokenkey_status": "not_applicable",
+      "rationale": "Client-side claude-code concern (terminal, mcp); not a gateway/relay relevance signal.",
+      "updated_at": "2026-06-02T23:17:32Z"
+    },
+    {
+      "upstream": "anthropics/claude-code#64888",
+      "url": "https://github.com/anthropics/claude-code/issues/64888",
+      "title": "[BUG] Claude Code maxes out CPU usage even when idle",
+      "impact": "not_applicable",
+      "categories": [
+        "terminal"
+      ],
+      "tokenkey_status": "not_applicable",
+      "rationale": "Client-side claude-code concern (terminal); not a gateway/relay relevance signal.",
+      "updated_at": "2026-06-02T23:17:49Z"
+    },
+    {
+      "upstream": "anthropics/claude-code#64889",
+      "url": "https://github.com/anthropics/claude-code/issues/64889",
+      "title": "Claude Code 2.1.113+ crashes on startup (SIGILL in bundled Bun 1.3.14) on Intel Emerald Rapids / Ubuntu 24.04",
+      "impact": "not_applicable",
+      "categories": [
+        "slash_hook",
+        "install"
+      ],
+      "tokenkey_status": "not_applicable",
+      "rationale": "Client-side claude-code concern (slash_hook, install); not a gateway/relay relevance signal.",
+      "updated_at": "2026-06-02T23:21:42Z"
+    },
+    {
+      "upstream": "anthropics/claude-code#64890",
+      "url": "https://github.com/anthropics/claude-code/issues/64890",
+      "title": "[Bug] Claude Code stops execution without error message",
+      "impact": "not_applicable",
+      "categories": [
+        "terminal"
+      ],
+      "tokenkey_status": "not_applicable",
+      "rationale": "Client-side claude-code concern (terminal); not a gateway/relay relevance signal.",
+      "updated_at": "2026-06-02T23:35:05Z"
+    },
+    {
+      "upstream": "anthropics/claude-code#64891",
+      "url": "https://github.com/anthropics/claude-code/issues/64891",
+      "title": "[BUG] CoworkVMService causes BSOD (HYPERVISOR_ERROR 0x00020001) on AMD Ryzen 9 5950X — hvax64.exe unhandled page fault every startup",
+      "impact": "not_applicable",
+      "categories": [
+        "terminal",
+        "install",
+        "platform"
+      ],
+      "tokenkey_status": "not_applicable",
+      "rationale": "Client-side claude-code concern (terminal, install, platform); not a gateway/relay relevance signal.",
+      "updated_at": "2026-06-02T23:32:50Z"
+    },
+    {
+      "upstream": "anthropics/claude-code#64895",
+      "url": "https://github.com/anthropics/claude-code/issues/64895",
+      "title": "Recents does not distinguish remote from local sessions (P0); causes silent delete and no-op model picker",
+      "impact": "not_applicable",
+      "categories": [
+        "terminal"
+      ],
+      "tokenkey_status": "not_applicable",
+      "rationale": "Client-side claude-code concern (terminal); not a gateway/relay relevance signal.",
+      "updated_at": "2026-06-03T00:36:09Z"
+    },
+    {
+      "upstream": "anthropics/claude-code#64896",
+      "url": "https://github.com/anthropics/claude-code/issues/64896",
+      "title": "[Bug] Setup validation fails with \"4 setup issues: MPC\"",
+      "impact": "not_applicable",
+      "categories": [
+        "terminal"
+      ],
+      "tokenkey_status": "not_applicable",
+      "rationale": "Client-side claude-code concern (terminal); not a gateway/relay relevance signal.",
+      "updated_at": "2026-06-03T00:02:08Z"
+    },
+    {
+      "upstream": "anthropics/claude-code#64897",
+      "url": "https://github.com/anthropics/claude-code/issues/64897",
+      "title": "Anthropic training CLaude to provide misinformation and garbage other LLM Models, when Claude makes just as many mistakes that are also detrimental.",
+      "impact": "not_applicable",
+      "categories": [
+        "terminal"
+      ],
+      "tokenkey_status": "not_applicable",
+      "rationale": "Client-side claude-code concern (terminal); not a gateway/relay relevance signal.",
+      "updated_at": "2026-06-03T00:02:50Z"
+    },
+    {
+      "upstream": "anthropics/claude-code#64898",
+      "url": "https://github.com/anthropics/claude-code/issues/64898",
+      "title": "[FEATURE] Allow hooks to spawn subagents / background agents (programmatic dispatch from hook events)",
+      "impact": "not_applicable",
+      "categories": [
+        "mcp",
+        "plugin",
+        "slash_hook"
+      ],
+      "tokenkey_status": "not_applicable",
+      "rationale": "Client-side claude-code concern (mcp, plugin, slash_hook); not a gateway/relay relevance signal.",
+      "updated_at": "2026-06-03T00:06:13Z"
+    },
+    {
+      "upstream": "anthropics/claude-code#64899",
+      "url": "https://github.com/anthropics/claude-code/issues/64899",
+      "title": "Ctrl+V image paste does not attach the image in Agent View when interacting with a background agent session (attach/peek) — terminal CLI",
+      "impact": "not_applicable",
+      "categories": [
+        "terminal"
+      ],
+      "tokenkey_status": "not_applicable",
+      "rationale": "Client-side claude-code concern (terminal); not a gateway/relay relevance signal.",
+      "updated_at": "2026-06-03T00:20:40Z"
+    },
+    {
+      "upstream": "anthropics/claude-code#64902",
+      "url": "https://github.com/anthropics/claude-code/issues/64902",
+      "title": "[BUG] Dispatch Deskop Appears offline in desktop. Will not connect to mobile.",
+      "impact": "not_applicable",
+      "categories": [
+        "terminal",
+        "platform"
+      ],
+      "tokenkey_status": "not_applicable",
+      "rationale": "Client-side claude-code concern (terminal, platform); not a gateway/relay relevance signal.",
+      "updated_at": "2026-06-03T00:10:47Z"
+    },
+    {
+      "upstream": "anthropics/claude-code#64903",
+      "url": "https://github.com/anthropics/claude-code/issues/64903",
+      "title": "[FEATURE] Surface expandable extended-thinking blocks in Cowork (parity with chat)",
+      "impact": "not_applicable",
+      "categories": [
+        "terminal"
+      ],
+      "tokenkey_status": "not_applicable",
+      "rationale": "Client-side claude-code concern (terminal); not a gateway/relay relevance signal.",
+      "updated_at": "2026-06-03T00:57:34Z"
+    },
+    {
+      "upstream": "anthropics/claude-code#64906",
+      "url": "https://github.com/anthropics/claude-code/issues/64906",
+      "title": "[Bug] MCP setup validation false positives in doctor command",
+      "impact": "not_applicable",
+      "categories": [
+        "terminal",
+        "mcp"
+      ],
+      "tokenkey_status": "not_applicable",
+      "rationale": "Client-side claude-code concern (terminal, mcp); not a gateway/relay relevance signal.",
+      "updated_at": "2026-06-03T00:45:50Z"
+    },
+    {
+      "upstream": "anthropics/claude-code#64907",
+      "url": "https://github.com/anthropics/claude-code/issues/64907",
+      "title": "[FEATURE] Prioritize open/editor files in @ file reference autocomplete suggestions",
+      "impact": "not_applicable",
+      "categories": [
+        "ide"
+      ],
+      "tokenkey_status": "not_applicable",
+      "rationale": "Client-side claude-code concern (ide); not a gateway/relay relevance signal.",
+      "updated_at": "2026-06-03T00:57:26Z"
+    },
+    {
+      "upstream": "anthropics/claude-code#64908",
+      "url": "https://github.com/anthropics/claude-code/issues/64908",
+      "title": "[Feature Request] Reduce argumentative responses and unnecessary debate in code generation",
+      "impact": "not_applicable",
+      "categories": [
+        "terminal"
+      ],
+      "tokenkey_status": "not_applicable",
+      "rationale": "Client-side claude-code concern (terminal); not a gateway/relay relevance signal.",
+      "updated_at": "2026-06-03T00:59:07Z"
+    },
+    {
+      "upstream": "anthropics/claude-code#64909",
+      "url": "https://github.com/anthropics/claude-code/issues/64909",
+      "title": "Sub-agents dispatched via Task tool have empty MCP tool registry — parent's MCP server connections don't propagate to sub-agent process",
+      "impact": "not_applicable",
+      "categories": [
+        "terminal",
+        "mcp",
+        "plugin"
+      ],
+      "tokenkey_status": "not_applicable",
+      "rationale": "Client-side claude-code concern (terminal, mcp, plugin); not a gateway/relay relevance signal.",
+      "updated_at": "2026-06-03T02:05:17Z"
+    },
+    {
+      "upstream": "anthropics/claude-code#64910",
+      "url": "https://github.com/anthropics/claude-code/issues/64910",
+      "title": "[Bug] Timezone handling causing unexpected interruptions",
+      "impact": "not_applicable",
+      "categories": [
+        "terminal"
+      ],
+      "tokenkey_status": "not_applicable",
+      "rationale": "Client-side claude-code concern (terminal); not a gateway/relay relevance signal.",
+      "updated_at": "2026-06-03T01:10:15Z"
+    },
+    {
+      "upstream": "anthropics/claude-code#64913",
+      "url": "https://github.com/anthropics/claude-code/issues/64913",
+      "title": "[BUG] Weekly usage meter resets ~4 days early (overnight) despite /usage stating \"Resets Sat 5:00 AM\" -- Max (20x)",
+      "impact": "not_applicable",
+      "categories": [
+        "terminal",
+        "platform"
+      ],
+      "tokenkey_status": "not_applicable",
+      "rationale": "Client-side claude-code concern (terminal, platform); not a gateway/relay relevance signal.",
+      "updated_at": "2026-06-03T01:22:15Z"
+    },
+    {
+      "upstream": "anthropics/claude-code#64914",
+      "url": "https://github.com/anthropics/claude-code/issues/64914",
+      "title": "[Bug] Plugin output style not discovered or activated when plugin is enabled",
+      "impact": "not_applicable",
+      "categories": [
+        "terminal",
+        "plugin",
+        "slash_hook"
+      ],
+      "tokenkey_status": "not_applicable",
+      "rationale": "Client-side claude-code concern (terminal, plugin, slash_hook); not a gateway/relay relevance signal.",
+      "updated_at": "2026-06-03T01:21:56Z"
+    },
+    {
+      "upstream": "anthropics/claude-code#64915",
+      "url": "https://github.com/anthropics/claude-code/issues/64915",
+      "title": "[BUG] Cannot Copy/Paste Text from Claude Code Chat Output",
+      "impact": "not_applicable",
+      "categories": [
+        "terminal",
+        "slash_hook"
+      ],
+      "tokenkey_status": "not_applicable",
+      "rationale": "Client-side claude-code concern (terminal, slash_hook); not a gateway/relay relevance signal.",
+      "updated_at": "2026-06-03T01:26:22Z"
+    },
+    {
+      "upstream": "anthropics/claude-code#64916",
+      "url": "https://github.com/anthropics/claude-code/issues/64916",
+      "title": "[Feature Request] Document agent view and keyboard shortcuts (Ctrl+X) in official documentation",
+      "impact": "not_applicable",
+      "categories": [
+        "terminal",
+        "slash_hook"
+      ],
+      "tokenkey_status": "not_applicable",
+      "rationale": "Client-side claude-code concern (terminal, slash_hook); not a gateway/relay relevance signal.",
+      "updated_at": "2026-06-03T01:28:17Z"
+    },
+    {
+      "upstream": "anthropics/claude-code#64917",
+      "url": "https://github.com/anthropics/claude-code/issues/64917",
+      "title": "[Bug] Inaccurate skill documentation: find misclassified as unconditionally auto-allowed",
+      "impact": "not_applicable",
+      "categories": [
+        "terminal"
+      ],
+      "tokenkey_status": "not_applicable",
+      "rationale": "Client-side claude-code concern (terminal); not a gateway/relay relevance signal.",
+      "updated_at": "2026-06-03T01:35:56Z"
+    },
+    {
+      "upstream": "anthropics/claude-code#64918",
+      "url": "https://github.com/anthropics/claude-code/issues/64918",
+      "title": "[BUG] v2.1.150 darwin-arm64: npm install silently truncates native binary (~213 MB → ~63 MB), causing \"killed\" on launch and auto-update infinite loop",
+      "impact": "not_applicable",
+      "categories": [
+        "terminal",
+        "install"
+      ],
+      "tokenkey_status": "not_applicable",
+      "rationale": "Client-side claude-code concern (terminal, install); not a gateway/relay relevance signal.",
+      "updated_at": "2026-06-03T01:45:27Z"
+    },
+    {
+      "upstream": "anthropics/claude-code#64919",
+      "url": "https://github.com/anthropics/claude-code/issues/64919",
+      "title": "[BUG] [BUG] Claude Code VS Code Extension v2.1.161 Forces 1M Context on Pro Plan Without Request — Blocks All Usage on macOS",
+      "impact": "not_applicable",
+      "categories": [
+        "ide",
+        "terminal",
+        "slash_hook",
+        "install"
+      ],
+      "tokenkey_status": "not_applicable",
+      "rationale": "Client-side claude-code concern (ide, terminal, slash_hook, install); not a gateway/relay relevance signal.",
+      "updated_at": "2026-06-03T01:54:07Z"
+    },
+    {
+      "upstream": "anthropics/claude-code#64920",
+      "url": "https://github.com/anthropics/claude-code/issues/64920",
+      "title": "Parallel tool calls cancel sibling calls when one fails",
+      "impact": "not_applicable",
+      "categories": [
+        "platform"
+      ],
+      "tokenkey_status": "not_applicable",
+      "rationale": "Client-side claude-code concern (platform); not a gateway/relay relevance signal.",
+      "updated_at": "2026-06-03T01:50:00Z"
+    },
+    {
+      "upstream": "anthropics/claude-code#64921",
+      "url": "https://github.com/anthropics/claude-code/issues/64921",
+      "title": "Bash tool silently promotes long-running commands to background without warning",
+      "impact": "not_applicable",
+      "categories": [
+        "install",
+        "platform"
+      ],
+      "tokenkey_status": "not_applicable",
+      "rationale": "Client-side claude-code concern (install, platform); not a gateway/relay relevance signal.",
+      "updated_at": "2026-06-03T01:46:17Z"
+    },
+    {
+      "upstream": "anthropics/claude-code#64925",
+      "url": "https://github.com/anthropics/claude-code/issues/64925",
+      "title": "[BUG] Detached/new thread window is missing features: IME double-input, no sidebar, plan panel not shown (macOS desktop app)",
+      "impact": "not_applicable",
+      "categories": [
+        "terminal"
+      ],
+      "tokenkey_status": "not_applicable",
+      "rationale": "Client-side claude-code concern (terminal); not a gateway/relay relevance signal.",
+      "updated_at": "2026-06-03T02:01:28Z"
+    },
+    {
+      "upstream": "anthropics/claude-code#64926",
+      "url": "https://github.com/anthropics/claude-code/issues/64926",
+      "title": "[FEATURE] Dev container support in Claude Code desktop app",
+      "impact": "not_applicable",
+      "categories": [
+        "ide"
+      ],
+      "tokenkey_status": "not_applicable",
+      "rationale": "Client-side claude-code concern (ide); not a gateway/relay relevance signal.",
+      "updated_at": "2026-06-03T02:17:42Z"
+    },
+    {
+      "upstream": "anthropics/claude-code#64927",
+      "url": "https://github.com/anthropics/claude-code/issues/64927",
+      "title": "[FEATURE] VS Code integrated browser support",
+      "impact": "not_applicable",
+      "categories": [
+        "ide"
+      ],
+      "tokenkey_status": "not_applicable",
+      "rationale": "Client-side claude-code concern (ide); not a gateway/relay relevance signal.",
+      "updated_at": "2026-06-03T02:15:47Z"
+    },
+    {
+      "upstream": "anthropics/claude-code#64928",
+      "url": "https://github.com/anthropics/claude-code/issues/64928",
+      "title": "[BUG] Gift code silently consumed when redeemed over active subscription. Never applied after first gift expires",
+      "impact": "not_applicable",
+      "categories": [
+        "terminal"
+      ],
+      "tokenkey_status": "not_applicable",
+      "rationale": "Client-side claude-code concern (terminal); not a gateway/relay relevance signal.",
+      "updated_at": "2026-06-03T02:20:59Z"
+    },
+    {
+      "upstream": "anthropics/claude-code#64930",
+      "url": "https://github.com/anthropics/claude-code/issues/64930",
+      "title": "built-in spoken read-back of Claude's replies (accessibility / hands-free)",
+      "impact": "not_applicable",
+      "categories": [
+        "terminal",
+        "slash_hook",
+        "platform"
+      ],
+      "tokenkey_status": "not_applicable",
+      "rationale": "Client-side claude-code concern (terminal, slash_hook, platform); not a gateway/relay relevance signal.",
+      "updated_at": "2026-06-03T02:29:52Z"
+    },
+    {
+      "upstream": "anthropics/claude-code#64931",
+      "url": "https://github.com/anthropics/claude-code/issues/64931",
+      "title": "[Bug] MCP initialization fails at session startup",
+      "impact": "not_applicable",
+      "categories": [
+        "terminal",
+        "mcp"
+      ],
+      "tokenkey_status": "not_applicable",
+      "rationale": "Client-side claude-code concern (terminal, mcp); not a gateway/relay relevance signal.",
+      "updated_at": "2026-06-03T02:31:43Z"
+    },
+    {
+      "upstream": "anthropics/claude-code#64932",
+      "url": "https://github.com/anthropics/claude-code/issues/64932",
+      "title": "[BUG] @mentioning files doesn't autocomplete for files with spaces in the filename",
+      "impact": "not_applicable",
+      "categories": [
+        "terminal"
+      ],
+      "tokenkey_status": "not_applicable",
+      "rationale": "Client-side claude-code concern (terminal); not a gateway/relay relevance signal.",
+      "updated_at": "2026-06-03T02:45:36Z"
+    },
+    {
+      "upstream": "anthropics/claude-code#64933",
+      "url": "https://github.com/anthropics/claude-code/issues/64933",
+      "title": "[BUG] Mac desktop app creates two authorization tokens per login, causing usage credits drain instead of Pro plan billing",
+      "impact": "not_applicable",
+      "categories": [
+        "terminal"
+      ],
+      "tokenkey_status": "not_applicable",
+      "rationale": "Client-side claude-code concern (terminal); not a gateway/relay relevance signal.",
+      "updated_at": "2026-06-03T02:48:31Z"
+    },
+    {
+      "upstream": "anthropics/claude-code#64934",
+      "url": "https://github.com/anthropics/claude-code/issues/64934",
+      "title": "[Bug] Repeated ANTML prefix error on message retry",
+      "impact": "not_applicable",
+      "categories": [
+        "terminal"
+      ],
+      "tokenkey_status": "not_applicable",
+      "rationale": "Client-side claude-code concern (terminal); not a gateway/relay relevance signal.",
+      "updated_at": "2026-06-03T03:07:07Z"
+    },
+    {
+      "upstream": "anthropics/claude-code#64935",
+      "url": "https://github.com/anthropics/claude-code/issues/64935",
+      "title": "Pasting an image during a focus change wedges the input loop — terminal floods prompt with SGR mouse escape sequences, Ctrl-C swallowed",
+      "impact": "not_applicable",
+      "categories": [
+        "terminal",
+        "mcp"
+      ],
+      "tokenkey_status": "not_applicable",
+      "rationale": "Client-side claude-code concern (terminal, mcp); not a gateway/relay relevance signal.",
+      "updated_at": "2026-06-03T03:12:43Z"
+    },
+    {
+      "upstream": "anthropics/claude-code#64936",
+      "url": "https://github.com/anthropics/claude-code/issues/64936",
+      "title": "[BUG] Repeated failures and token waste when parsing dpu.kev under QNX 8.0 using Claude terminal",
+      "impact": "not_applicable",
+      "categories": [
+        "terminal"
+      ],
+      "tokenkey_status": "not_applicable",
+      "rationale": "Client-side claude-code concern (terminal); not a gateway/relay relevance signal.",
+      "updated_at": "2026-06-03T03:09:44Z"
+    },
+    {
+      "upstream": "anthropics/claude-code#64937",
+      "url": "https://github.com/anthropics/claude-code/issues/64937",
+      "title": "[Feature Request] Improve task planning and verification discipline in agentic workflows",
+      "impact": "not_applicable",
+      "categories": [
+        "terminal"
+      ],
+      "tokenkey_status": "not_applicable",
+      "rationale": "Client-side claude-code concern (terminal); not a gateway/relay relevance signal.",
+      "updated_at": "2026-06-03T03:13:26Z"
+    },
+    {
+      "upstream": "anthropics/claude-code#64938",
+      "url": "https://github.com/anthropics/claude-code/issues/64938",
+      "title": "[BUG] Excessive token consumption in web search workflows - exponential token usage growth",
+      "impact": "not_applicable",
+      "categories": [
+        "ide",
+        "terminal"
+      ],
+      "tokenkey_status": "not_applicable",
+      "rationale": "Client-side claude-code concern (ide, terminal); not a gateway/relay relevance signal.",
+      "updated_at": "2026-06-03T03:35:04Z"
+    },
+    {
+      "upstream": "anthropics/claude-code#64940",
+      "url": "https://github.com/anthropics/claude-code/issues/64940",
+      "title": "[Bug] Tool invocation fails with string output interference",
+      "impact": "not_applicable",
+      "categories": [
+        "terminal"
+      ],
+      "tokenkey_status": "not_applicable",
+      "rationale": "Client-side claude-code concern (terminal); not a gateway/relay relevance signal.",
+      "updated_at": "2026-06-03T03:37:18Z"
+    },
+    {
+      "upstream": "anthropics/claude-code#64943",
+      "url": "https://github.com/anthropics/claude-code/issues/64943",
+      "title": "[BUG] Voice mode regression on Windows — disconnects immediately after latest Claude Code update",
+      "impact": "not_applicable",
+      "categories": [
+        "terminal",
+        "platform"
+      ],
+      "tokenkey_status": "not_applicable",
+      "rationale": "Client-side claude-code concern (terminal, platform); not a gateway/relay relevance signal.",
+      "updated_at": "2026-06-03T04:02:02Z"
+    },
+    {
+      "upstream": "anthropics/claude-code#64945",
+      "url": "https://github.com/anthropics/claude-code/issues/64945",
+      "title": "[BUG] New session freezes on initialization when marketingskills repository is attached",
+      "impact": "not_applicable",
+      "categories": [
+        "terminal"
+      ],
+      "tokenkey_status": "not_applicable",
+      "rationale": "Client-side claude-code concern (terminal); not a gateway/relay relevance signal.",
+      "updated_at": "2026-06-03T04:11:14Z"
+    },
+    {
+      "upstream": "anthropics/claude-code#64946",
+      "url": "https://github.com/anthropics/claude-code/issues/64946",
+      "title": "NotificationManager: assertion error removing selection listener on editor change",
+      "impact": "not_applicable",
+      "categories": [
+        "ide",
+        "mcp",
+        "plugin"
+      ],
+      "tokenkey_status": "not_applicable",
+      "rationale": "Client-side claude-code concern (ide, mcp, plugin); not a gateway/relay relevance signal.",
+      "updated_at": "2026-06-03T04:19:35Z"
+    },
+    {
+      "upstream": "anthropics/claude-code#64948",
+      "url": "https://github.com/anthropics/claude-code/issues/64948",
+      "title": "[Feature Request] Disable automatic branch creation for Claude Code operations",
+      "impact": "not_applicable",
+      "categories": [
+        "terminal"
+      ],
+      "tokenkey_status": "not_applicable",
+      "rationale": "Client-side claude-code concern (terminal); not a gateway/relay relevance signal.",
+      "updated_at": "2026-06-03T04:37:27Z"
+    },
+    {
+      "upstream": "anthropics/claude-code#64949",
+      "url": "https://github.com/anthropics/claude-code/issues/64949",
+      "title": "[Bug] Max20 plan usage credits consumed despite available included allowances",
+      "impact": "not_applicable",
+      "categories": [
+        "terminal"
+      ],
+      "tokenkey_status": "not_applicable",
+      "rationale": "Client-side claude-code concern (terminal); not a gateway/relay relevance signal.",
+      "updated_at": "2026-06-03T04:39:15Z"
+    },
+    {
+      "upstream": "anthropics/claude-code#64951",
+      "url": "https://github.com/anthropics/claude-code/issues/64951",
+      "title": "EnterWorktree should support entering existing worktrees via path parameter",
+      "impact": "not_applicable",
+      "categories": [
+        "slash_hook",
+        "install"
+      ],
+      "tokenkey_status": "not_applicable",
+      "rationale": "Client-side claude-code concern (slash_hook, install); not a gateway/relay relevance signal.",
+      "updated_at": "2026-06-03T04:55:46Z"
+    },
+    {
+      "upstream": "anthropics/claude-code#64952",
+      "url": "https://github.com/anthropics/claude-code/issues/64952",
+      "title": "[Feature Request] Add option to disable dynamic terminal tab-title updates",
+      "impact": "not_applicable",
+      "categories": [
+        "terminal",
+        "slash_hook"
+      ],
+      "tokenkey_status": "not_applicable",
+      "rationale": "Client-side claude-code concern (terminal, slash_hook); not a gateway/relay relevance signal.",
+      "updated_at": "2026-06-03T04:55:55Z"
+    },
+    {
+      "upstream": "anthropics/claude-code#64953",
+      "url": "https://github.com/anthropics/claude-code/issues/64953",
+      "title": "[Bug] Anthropic API Error: Usage credits required for 1M context window",
+      "impact": "not_applicable",
+      "categories": [
+        "terminal"
+      ],
+      "tokenkey_status": "not_applicable",
+      "rationale": "Client-side claude-code concern (terminal); not a gateway/relay relevance signal.",
+      "updated_at": "2026-06-03T05:18:20Z"
+    },
+    {
+      "upstream": "anthropics/claude-code#64954",
+      "url": "https://github.com/anthropics/claude-code/issues/64954",
+      "title": "[BUG] Sonnect 4.6 1M context is not available in claude desktop app but available in terminal mode with same enterprise account",
+      "impact": "not_applicable",
+      "categories": [
+        "terminal"
+      ],
+      "tokenkey_status": "not_applicable",
+      "rationale": "Client-side claude-code concern (terminal); not a gateway/relay relevance signal.",
+      "updated_at": "2026-06-03T05:14:09Z"
+    },
+    {
+      "upstream": "anthropics/claude-code#64956",
+      "url": "https://github.com/anthropics/claude-code/issues/64956",
+      "title": "[BUG] Plugins not loading from marketplace after adding claude-plugins-official",
+      "impact": "not_applicable",
+      "categories": [
+        "ide",
+        "terminal",
+        "plugin",
+        "install"
+      ],
+      "tokenkey_status": "not_applicable",
+      "rationale": "Client-side claude-code concern (ide, terminal, plugin, install); not a gateway/relay relevance signal.",
+      "updated_at": "2026-06-03T05:32:35Z"
+    },
+    {
+      "upstream": "anthropics/claude-code#64957",
+      "url": "https://github.com/anthropics/claude-code/issues/64957",
+      "title": "[FEATURE] VSCode extension: make notification body clickable to navigate to the Claude tab (not just the View button)",
+      "impact": "not_applicable",
+      "categories": [
+        "ide"
+      ],
+      "tokenkey_status": "not_applicable",
+      "rationale": "Client-side claude-code concern (ide); not a gateway/relay relevance signal.",
+      "updated_at": "2026-06-03T05:59:49Z"
+    },
+    {
+      "upstream": "anthropics/claude-code#64958",
+      "url": "https://github.com/anthropics/claude-code/issues/64958",
+      "title": "[Bug] MCP setup fails silently after `/doctor` command execution",
+      "impact": "not_applicable",
+      "categories": [
+        "terminal",
+        "mcp"
+      ],
+      "tokenkey_status": "not_applicable",
+      "rationale": "Client-side claude-code concern (terminal, mcp); not a gateway/relay relevance signal.",
+      "updated_at": "2026-06-03T06:02:02Z"
+    },
+    {
+      "upstream": "anthropics/claude-code#64959",
+      "url": "https://github.com/anthropics/claude-code/issues/64959",
+      "title": "Plugin interactive uninstall does not clean up settings.json entry",
+      "impact": "not_applicable",
+      "categories": [
+        "plugin",
+        "slash_hook",
+        "install"
+      ],
+      "tokenkey_status": "not_applicable",
+      "rationale": "Client-side claude-code concern (plugin, slash_hook, install); not a gateway/relay relevance signal.",
+      "updated_at": "2026-06-03T06:01:33Z"
+    },
+    {
+      "upstream": "anthropics/claude-code#64961",
+      "url": "https://github.com/anthropics/claude-code/issues/64961",
+      "title": "[BUG] Opus 4.7/4.8 token usage regressed 2-3x after update; Opus 4.8 also disconnects frequently",
+      "impact": "not_applicable",
+      "categories": [
+        "terminal"
+      ],
+      "tokenkey_status": "not_applicable",
+      "rationale": "Client-side claude-code concern (terminal); not a gateway/relay relevance signal.",
+      "updated_at": "2026-06-03T06:08:39Z"
+    },
+    {
+      "upstream": "anthropics/claude-code#64962",
+      "url": "https://github.com/anthropics/claude-code/issues/64962",
+      "title": "[Bug] MCP Setup Issue Detected at Startup",
+      "impact": "not_applicable",
+      "categories": [
+        "terminal",
+        "mcp"
+      ],
+      "tokenkey_status": "not_applicable",
+      "rationale": "Client-side claude-code concern (terminal, mcp); not a gateway/relay relevance signal.",
+      "updated_at": "2026-06-03T06:12:45Z"
+    },
+    {
+      "upstream": "anthropics/claude-code#64963",
+      "url": "https://github.com/anthropics/claude-code/issues/64963",
+      "title": "I'm ready to help generate GitHub issue titles for Claude Code bugs and feature requests. However, I don't see a bug report in your message. Please provide the bug report details, and I'll create a concise, technical issue title following the guidelines yo",
+      "impact": "not_applicable",
+      "categories": [
+        "terminal"
+      ],
+      "tokenkey_status": "not_applicable",
+      "rationale": "Client-side claude-code concern (terminal); not a gateway/relay relevance signal.",
+      "updated_at": "2026-06-03T06:17:10Z"
+    },
+    {
+      "upstream": "anthropics/claude-code#64964",
+      "url": "https://github.com/anthropics/claude-code/issues/64964",
+      "title": "[FEATURE] Support Dynamic Refresh / Live Progress Updates in Claude Code",
+      "impact": "not_applicable",
+      "categories": [
+        "terminal"
+      ],
+      "tokenkey_status": "not_applicable",
+      "rationale": "Client-side claude-code concern (terminal); not a gateway/relay relevance signal.",
+      "updated_at": "2026-06-03T06:19:32Z"
+    },
+    {
+      "upstream": "anthropics/claude-code#64965",
+      "url": "https://github.com/anthropics/claude-code/issues/64965",
+      "title": "[BUG] When creating an agent via \"Create new agent\" from the /agents menu, Claude embeds the entire Memory system prompt to the agent file",
+      "impact": "not_applicable",
+      "categories": [
+        "terminal",
+        "plugin"
+      ],
+      "tokenkey_status": "not_applicable",
+      "rationale": "Client-side claude-code concern (terminal, plugin); not a gateway/relay relevance signal.",
+      "updated_at": "2026-06-03T06:17:50Z"
+    },
+    {
+      "upstream": "anthropics/claude-code#64966",
+      "url": "https://github.com/anthropics/claude-code/issues/64966",
+      "title": "Claude in Chrome: extension binds the Claude Code native host, host listens on its bridge socket, but the interactive CLI session never attaches → \"Browser extension is not connected",
+      "impact": "not_applicable",
+      "categories": [
+        "ide",
+        "mcp",
+        "install"
+      ],
+      "tokenkey_status": "not_applicable",
+      "rationale": "Client-side claude-code concern (ide, mcp, install); not a gateway/relay relevance signal.",
+      "updated_at": "2026-06-03T06:33:09Z"
+    },
+    {
+      "upstream": "anthropics/claude-code#64967",
+      "url": "https://github.com/anthropics/claude-code/issues/64967",
+      "title": "[Bug] MCP Server Connection Failed in `/doctor` Command",
+      "impact": "not_applicable",
+      "categories": [
+        "terminal",
+        "mcp"
+      ],
+      "tokenkey_status": "not_applicable",
+      "rationale": "Client-side claude-code concern (terminal, mcp); not a gateway/relay relevance signal.",
+      "updated_at": "2026-06-03T06:35:11Z"
+    },
+    {
+      "upstream": "anthropics/claude-code#64968",
+      "url": "https://github.com/anthropics/claude-code/issues/64968",
+      "title": "[FEATURE] Syntax highlighting in VS Code extension chat panel (re-opening closed requests)",
+      "impact": "not_applicable",
+      "categories": [
+        "ide",
+        "terminal"
+      ],
+      "tokenkey_status": "not_applicable",
+      "rationale": "Client-side claude-code concern (ide, terminal); not a gateway/relay relevance signal.",
+      "updated_at": "2026-06-03T06:44:32Z"
+    },
+    {
+      "upstream": "anthropics/claude-code#64969",
+      "url": "https://github.com/anthropics/claude-code/issues/64969",
+      "title": "[Bug] Tool call parsing failure with retry exhaustion",
+      "impact": "not_applicable",
+      "categories": [
+        "terminal"
+      ],
+      "tokenkey_status": "not_applicable",
+      "rationale": "Client-side claude-code concern (terminal); not a gateway/relay relevance signal.",
+      "updated_at": "2026-06-03T06:49:30Z"
+    },
+    {
+      "upstream": "anthropics/claude-code#64971",
+      "url": "https://github.com/anthropics/claude-code/issues/64971",
+      "title": "I'm ready to help generate a technical GitHub issue title for Claude Code. However, I don't see a bug report in your message. Could you please provide the bug report details that you'd like me to create a title for?",
+      "impact": "not_applicable",
+      "categories": [
+        "terminal"
+      ],
+      "tokenkey_status": "not_applicable",
+      "rationale": "Client-side claude-code concern (terminal); not a gateway/relay relevance signal.",
+      "updated_at": "2026-06-03T06:54:47Z"
+    },
+    {
+      "upstream": "anthropics/claude-code#7075",
+      "url": "https://github.com/anthropics/claude-code/issues/7075",
+      "title": "Feature request: Claude Code profiles with isolated memory, commands, hooks, and settings",
+      "impact": "not_applicable",
+      "categories": [
+        "plugin",
+        "slash_hook"
+      ],
+      "tokenkey_status": "not_applicable",
+      "rationale": "Client-side claude-code concern (plugin, slash_hook); not a gateway/relay relevance signal.",
+      "updated_at": "2026-06-02T17:07:41Z"
+    },
+    {
+      "upstream": "anthropics/claude-code#7134",
+      "url": "https://github.com/anthropics/claude-code/issues/7134",
+      "title": "[BUG] Claude Code does not respect file encoding, corrupts Windows-1252 files",
+      "impact": "not_applicable",
+      "categories": [
+        "ide",
+        "terminal",
+        "platform"
+      ],
+      "tokenkey_status": "not_applicable",
+      "rationale": "Client-side claude-code concern (ide, terminal, platform); not a gateway/relay relevance signal.",
+      "updated_at": "2026-06-01T21:08:36Z"
+    },
+    {
+      "upstream": "anthropics/claude-code#7387",
+      "url": "https://github.com/anthropics/claude-code/issues/7387",
+      "title": "[BUG] Shell script occasionally fails due to crazy escaping",
+      "impact": "not_applicable",
+      "categories": [
+        "terminal"
+      ],
+      "tokenkey_status": "not_applicable",
+      "rationale": "Client-side claude-code concern (terminal); not a gateway/relay relevance signal.",
+      "updated_at": "2026-06-01T05:30:17Z"
+    },
+    {
+      "upstream": "anthropics/claude-code#7490",
+      "url": "https://github.com/anthropics/claude-code/issues/7490",
+      "title": "[FEATURE] Allow users to configure which shell the Bash tool uses or inherit initial shell",
+      "impact": "not_applicable",
+      "categories": [
+        "mcp",
+        "slash_hook"
+      ],
+      "tokenkey_status": "not_applicable",
+      "rationale": "Client-side claude-code concern (mcp, slash_hook); not a gateway/relay relevance signal.",
+      "updated_at": "2026-06-03T06:26:59Z"
+    },
+    {
+      "upstream": "anthropics/claude-code#8856",
+      "url": "https://github.com/anthropics/claude-code/issues/8856",
+      "title": "Memory leak: Missing cleanup for /tmp/claude-*-cwd working directory tracking files",
+      "impact": "not_applicable",
+      "categories": [
+        "install"
+      ],
+      "tokenkey_status": "not_applicable",
+      "rationale": "Client-side claude-code concern (install); not a gateway/relay relevance signal.",
+      "updated_at": "2026-06-03T00:05:05Z"
+    },
+    {
+      "upstream": "anthropics/claude-code#9796",
+      "url": "https://github.com/anthropics/claude-code/issues/9796",
+      "title": "[BUG] Context compaction erases .claude/project-context.md instructions",
+      "impact": "not_applicable",
+      "categories": [
+        "terminal"
+      ],
+      "tokenkey_status": "not_applicable",
+      "rationale": "Client-side claude-code concern (terminal); not a gateway/relay relevance signal.",
+      "updated_at": "2026-06-02T12:31:41Z"
+    },
+    {
+      "upstream": "anthropics/claude-code#11315",
+      "url": "https://github.com/anthropics/claude-code/issues/11315",
+      "title": "Critical Memory Leak: Claude Code Consumed 129GB RAM and Caused System Freeze",
+      "impact": "unknown_low_signal",
+      "categories": [],
+      "tokenkey_status": "not_applicable",
+      "rationale": "No gateway/relay-relevant keywords; treated as not-our-surface.",
+      "updated_at": "2026-06-01T17:46:52Z"
+    },
+    {
+      "upstream": "anthropics/claude-code#14228",
+      "url": "https://github.com/anthropics/claude-code/issues/14228",
+      "title": "Feature Request: Claude Code Should Access User's claude.ai Memory and Context",
+      "impact": "unknown_low_signal",
+      "categories": [],
+      "tokenkey_status": "not_applicable",
+      "rationale": "No gateway/relay-relevant keywords; treated as not-our-surface.",
+      "updated_at": "2026-06-03T05:03:24Z"
+    },
+    {
+      "upstream": "anthropics/claude-code#16329",
+      "url": "https://github.com/anthropics/claude-code/issues/16329",
+      "title": "[FEATURE] Add support for AWS Bedrock service_tier parameter (flex, priority, reserved, default)",
+      "impact": "unknown_low_signal",
+      "categories": [],
+      "tokenkey_status": "not_applicable",
+      "rationale": "No gateway/relay-relevant keywords; treated as not-our-surface.",
+      "updated_at": "2026-06-02T20:56:11Z"
+    },
+    {
+      "upstream": "anthropics/claude-code#1757",
+      "url": "https://github.com/anthropics/claude-code/issues/1757",
+      "title": "[BUG] Claude code requires users to constantly login",
+      "impact": "unknown_low_signal",
+      "categories": [],
+      "tokenkey_status": "not_applicable",
+      "rationale": "No gateway/relay-relevant keywords; treated as not-our-surface.",
+      "updated_at": "2026-06-02T22:53:05Z"
+    },
+    {
+      "upstream": "anthropics/claude-code#18550",
+      "url": "https://github.com/anthropics/claude-code/issues/18550",
+      "title": "[FEATURE] Automatic Cost Tracking and Reporting",
+      "impact": "unknown_low_signal",
+      "categories": [],
+      "tokenkey_status": "not_applicable",
+      "rationale": "No gateway/relay-relevant keywords; treated as not-our-surface.",
+      "updated_at": "2026-06-02T11:32:28Z"
+    },
+    {
+      "upstream": "anthropics/claude-code#19471",
+      "url": "https://github.com/anthropics/claude-code/issues/19471",
+      "title": "[BUG] CLAUDE.md instructions completely ignored after context compaction",
+      "impact": "unknown_low_signal",
+      "categories": [],
+      "tokenkey_status": "not_applicable",
+      "rationale": "No gateway/relay-relevant keywords; treated as not-our-surface.",
+      "updated_at": "2026-06-01T22:46:22Z"
+    },
+    {
+      "upstream": "anthropics/claude-code#23626",
+      "url": "https://github.com/anthropics/claude-code/issues/23626",
+      "title": "[FEATURE] Support diff comparison against branches other than main",
+      "impact": "unknown_low_signal",
+      "categories": [],
+      "tokenkey_status": "not_applicable",
+      "rationale": "No gateway/relay-relevant keywords; treated as not-our-surface.",
+      "updated_at": "2026-06-02T03:31:03Z"
+    },
+    {
+      "upstream": "anthropics/claude-code#24963",
+      "url": "https://github.com/anthropics/claude-code/issues/24963",
+      "title": "[FEATURE] Support for multiple accounts / profiles",
+      "impact": "unknown_low_signal",
+      "categories": [],
+      "tokenkey_status": "not_applicable",
+      "rationale": "No gateway/relay-relevant keywords; treated as not-our-surface.",
+      "updated_at": "2026-06-03T00:06:34Z"
+    },
+    {
+      "upstream": "anthropics/claude-code#26466",
+      "url": "https://github.com/anthropics/claude-code/issues/26466",
+      "title": "Go-based CLI tools (gh, terraform, etc.) fail with TLS error due to built-in HTTPS proxy",
+      "impact": "unknown_low_signal",
+      "categories": [],
+      "tokenkey_status": "not_applicable",
+      "rationale": "No gateway/relay-relevant keywords; treated as not-our-surface.",
+      "updated_at": "2026-06-02T17:26:44Z"
+    },
+    {
+      "upstream": "anthropics/claude-code#30031",
+      "url": "https://github.com/anthropics/claude-code/issues/30031",
+      "title": "Feature Request: Support multiple account login and switching (like `gh auth switch`)",
+      "impact": "unknown_low_signal",
+      "categories": [],
+      "tokenkey_status": "not_applicable",
+      "rationale": "No gateway/relay-relevant keywords; treated as not-our-surface.",
+      "updated_at": "2026-06-03T00:09:52Z"
+    },
+    {
+      "upstream": "anthropics/claude-code#33060",
+      "url": "https://github.com/anthropics/claude-code/issues/33060",
+      "title": "Welcome box not shown when launching from home directory",
+      "impact": "unknown_low_signal",
+      "categories": [],
+      "tokenkey_status": "not_applicable",
+      "rationale": "No gateway/relay-relevant keywords; treated as not-our-surface.",
+      "updated_at": "2026-05-31T10:41:37Z"
+    },
+    {
+      "upstream": "anthropics/claude-code#36151",
+      "url": "https://github.com/anthropics/claude-code/issues/36151",
+      "title": "[FEATURE] Multi-account switching in Claude Mobile app without shared email",
+      "impact": "unknown_low_signal",
+      "categories": [],
+      "tokenkey_status": "not_applicable",
+      "rationale": "No gateway/relay-relevant keywords; treated as not-our-surface.",
+      "updated_at": "2026-06-02T08:41:39Z"
+    },
+    {
+      "upstream": "anthropics/claude-code#43755",
+      "url": "https://github.com/anthropics/claude-code/issues/43755",
+      "title": "[FEATURE] Per-prompt rewind/undo in Desktop App",
+      "impact": "unknown_low_signal",
+      "categories": [],
+      "tokenkey_status": "not_applicable",
+      "rationale": "No gateway/relay-relevant keywords; treated as not-our-surface.",
+      "updated_at": "2026-06-01T22:45:52Z"
+    },
+    {
+      "upstream": "anthropics/claude-code#44166",
+      "url": "https://github.com/anthropics/claude-code/issues/44166",
+      "title": "Option to exempt CLAUDE.md / auto-memory from compaction",
+      "impact": "unknown_low_signal",
+      "categories": [],
+      "tokenkey_status": "not_applicable",
+      "rationale": "No gateway/relay-relevant keywords; treated as not-our-surface.",
+      "updated_at": "2026-06-01T22:46:22Z"
+    },
+    {
+      "upstream": "anthropics/claude-code#44933",
+      "url": "https://github.com/anthropics/claude-code/issues/44933",
+      "title": "[FEATURE REQUEST] Cowork: Set a default project folder that auto-loads on session start",
+      "impact": "unknown_low_signal",
+      "categories": [],
+      "tokenkey_status": "not_applicable",
+      "rationale": "No gateway/relay-relevant keywords; treated as not-our-surface.",
+      "updated_at": "2026-06-01T22:40:05Z"
+    },
+    {
+      "upstream": "anthropics/claude-code#45005",
+      "url": "https://github.com/anthropics/claude-code/issues/45005",
+      "title": "[MODEL] Claude fabricated cost estimate for GPU training, caused $38.73 in unconfirmed charges",
+      "impact": "unknown_low_signal",
+      "categories": [],
+      "tokenkey_status": "not_applicable",
+      "rationale": "No gateway/relay-relevant keywords; treated as not-our-surface.",
+      "updated_at": "2026-06-01T22:45:47Z"
+    },
+    {
+      "upstream": "anthropics/claude-code#46251",
+      "url": "https://github.com/anthropics/claude-code/issues/46251",
+      "title": "[FEATURE] Rating scale labels are confusing for non-English speakers",
+      "impact": "unknown_low_signal",
+      "categories": [],
+      "tokenkey_status": "not_applicable",
+      "rationale": "No gateway/relay-relevant keywords; treated as not-our-surface.",
+      "updated_at": "2026-06-01T12:03:26Z"
+    },
+    {
+      "upstream": "anthropics/claude-code#46940",
+      "url": "https://github.com/anthropics/claude-code/issues/46940",
+      "title": "Claude fabricates test results - reports ALL PASSED when tests are FAILING",
+      "impact": "unknown_low_signal",
+      "categories": [],
+      "tokenkey_status": "not_applicable",
+      "rationale": "No gateway/relay-relevant keywords; treated as not-our-surface.",
+      "updated_at": "2026-06-01T22:45:48Z"
+    },
+    {
+      "upstream": "anthropics/claude-code#46943",
+      "url": "https://github.com/anthropics/claude-code/issues/46943",
+      "title": "Mobile client for Claude Code (iOS/Android)",
+      "impact": "unknown_low_signal",
+      "categories": [],
+      "tokenkey_status": "not_applicable",
+      "rationale": "No gateway/relay-relevant keywords; treated as not-our-surface.",
+      "updated_at": "2026-06-01T19:34:10Z"
+    },
+    {
+      "upstream": "anthropics/claude-code#47509",
+      "url": "https://github.com/anthropics/claude-code/issues/47509",
+      "title": "feat: Team plan needs a Max 20x equivalent tier for power users",
+      "impact": "unknown_low_signal",
+      "categories": [],
+      "tokenkey_status": "not_applicable",
+      "rationale": "No gateway/relay-relevant keywords; treated as not-our-surface.",
+      "updated_at": "2026-06-03T05:33:12Z"
+    },
+    {
+      "upstream": "anthropics/claude-code#49084",
+      "url": "https://github.com/anthropics/claude-code/issues/49084",
+      "title": "Feature request: expose timestamps to Claude as structured data for time-aware reasoning",
+      "impact": "unknown_low_signal",
+      "categories": [],
+      "tokenkey_status": "not_applicable",
+      "rationale": "No gateway/relay-relevant keywords; treated as not-our-surface.",
+      "updated_at": "2026-06-02T15:01:43Z"
+    },
+    {
+      "upstream": "anthropics/claude-code#4953",
+      "url": "https://github.com/anthropics/claude-code/issues/4953",
+      "title": "Claude Code Memory Leak - Process Grows to 120+ GB RAM and Gets OOM Killed",
+      "impact": "unknown_low_signal",
+      "categories": [],
+      "tokenkey_status": "not_applicable",
+      "rationale": "No gateway/relay-relevant keywords; treated as not-our-surface.",
+      "updated_at": "2026-06-03T00:05:19Z"
+    },
+    {
+      "upstream": "anthropics/claude-code#50246",
+      "url": "https://github.com/anthropics/claude-code/issues/50246",
+      "title": "Feature Request: Message queue mode — queue messages instead of interrupting active tasks",
+      "impact": "unknown_low_signal",
+      "categories": [],
+      "tokenkey_status": "not_applicable",
+      "rationale": "No gateway/relay-relevant keywords; treated as not-our-surface.",
+      "updated_at": "2026-06-02T14:09:35Z"
+    },
+    {
+      "upstream": "anthropics/claude-code#50529",
+      "url": "https://github.com/anthropics/claude-code/issues/50529",
+      "title": "[FEATURE] add optional timezone field (IANA tz, e.g. America/Los_Angeles) to scheduled-trigger cron expressions",
+      "impact": "unknown_low_signal",
+      "categories": [],
+      "tokenkey_status": "not_applicable",
+      "rationale": "No gateway/relay-relevant keywords; treated as not-our-surface.",
+      "updated_at": "2026-06-02T09:10:54Z"
+    },
+    {
+      "upstream": "anthropics/claude-code#50894",
+      "url": "https://github.com/anthropics/claude-code/issues/50894",
+      "title": "Focus mode hides substantive assistant messages, not just tool output",
+      "impact": "unknown_low_signal",
+      "categories": [],
+      "tokenkey_status": "not_applicable",
+      "rationale": "No gateway/relay-relevant keywords; treated as not-our-surface.",
+      "updated_at": "2026-06-01T22:45:52Z"
+    },
+    {
+      "upstream": "anthropics/claude-code#51791",
+      "url": "https://github.com/anthropics/claude-code/issues/51791",
+      "title": "[FEATURE] Allow renaming session titles after creation",
+      "impact": "unknown_low_signal",
+      "categories": [],
+      "tokenkey_status": "not_applicable",
+      "rationale": "No gateway/relay-relevant keywords; treated as not-our-surface.",
+      "updated_at": "2026-06-02T15:52:47Z"
+    },
+    {
+      "upstream": "anthropics/claude-code#52214",
+      "url": "https://github.com/anthropics/claude-code/issues/52214",
+      "title": "[FEATURE] Add 24-hour time format support in /usage dialog",
+      "impact": "unknown_low_signal",
+      "categories": [],
+      "tokenkey_status": "not_applicable",
+      "rationale": "No gateway/relay-relevant keywords; treated as not-our-surface.",
+      "updated_at": "2026-06-02T22:44:32Z"
+    },
+    {
+      "upstream": "anthropics/claude-code#52477",
+      "url": "https://github.com/anthropics/claude-code/issues/52477",
+      "title": "[MODEL] Claude overrode explicit pronouns in user memory and defaulted to male bias",
+      "impact": "unknown_low_signal",
+      "categories": [],
+      "tokenkey_status": "not_applicable",
+      "rationale": "No gateway/relay-relevant keywords; treated as not-our-surface.",
+      "updated_at": "2026-06-01T05:35:36Z"
+    },
+    {
+      "upstream": "anthropics/claude-code#53225",
+      "url": "https://github.com/anthropics/claude-code/issues/53225",
+      "title": "Desktop app shows no recovery option when working directory has been moved or deleted",
+      "impact": "unknown_low_signal",
+      "categories": [],
+      "tokenkey_status": "not_applicable",
+      "rationale": "No gateway/relay-relevant keywords; treated as not-our-surface.",
+      "updated_at": "2026-06-01T22:45:29Z"
+    },
+    {
+      "upstream": "anthropics/claude-code#53939",
+      "url": "https://github.com/anthropics/claude-code/issues/53939",
+      "title": "[BUG] /ultrareview completes cloud-side but CLI reports 'failed' and /tasks does not list the run",
+      "impact": "unknown_low_signal",
+      "categories": [],
+      "tokenkey_status": "not_applicable",
+      "rationale": "No gateway/relay-relevant keywords; treated as not-our-surface.",
+      "updated_at": "2026-05-31T10:41:53Z"
+    },
+    {
+      "upstream": "anthropics/claude-code#54019",
+      "url": "https://github.com/anthropics/claude-code/issues/54019",
+      "title": "Add a quick thumbs up/down reaction to responses so users can give feedback without triggering a new AI reply.",
+      "impact": "unknown_low_signal",
+      "categories": [],
+      "tokenkey_status": "not_applicable",
+      "rationale": "No gateway/relay-relevant keywords; treated as not-our-surface.",
+      "updated_at": "2026-06-02T11:32:35Z"
+    },
+    {
+      "upstream": "anthropics/claude-code#54517",
+      "url": "https://github.com/anthropics/claude-code/issues/54517",
+      "title": "[FEATURE] Allow scheduled agent / Routine runs to appear in Recents or be pinnable in the sidebar",
+      "impact": "unknown_low_signal",
+      "categories": [],
+      "tokenkey_status": "not_applicable",
+      "rationale": "No gateway/relay-relevant keywords; treated as not-our-surface.",
+      "updated_at": "2026-05-31T10:41:17Z"
+    },
+    {
+      "upstream": "anthropics/claude-code#54924",
+      "url": "https://github.com/anthropics/claude-code/issues/54924",
+      "title": "[BUG] SSH option not available in Claude Code Desktop when using external API provider",
+      "impact": "unknown_low_signal",
+      "categories": [],
+      "tokenkey_status": "not_applicable",
+      "rationale": "No gateway/relay-relevant keywords; treated as not-our-surface.",
+      "updated_at": "2026-06-01T22:45:22Z"
+    },
+    {
+      "upstream": "anthropics/claude-code#54964",
+      "url": "https://github.com/anthropics/claude-code/issues/54964",
+      "title": "[FEATURE] Google Vertex support for Remote Control features",
+      "impact": "unknown_low_signal",
+      "categories": [],
+      "tokenkey_status": "not_applicable",
+      "rationale": "No gateway/relay-relevant keywords; treated as not-our-surface.",
+      "updated_at": "2026-05-31T21:15:45Z"
+    },
+    {
+      "upstream": "anthropics/claude-code#56927",
+      "url": "https://github.com/anthropics/claude-code/issues/56927",
+      "title": "CLAUDE.md: @ file import fails silently for paths containing spaces (e.g. iCloud Drive on macOS)",
+      "impact": "unknown_low_signal",
+      "categories": [],
+      "tokenkey_status": "not_applicable",
+      "rationale": "No gateway/relay-relevant keywords; treated as not-our-surface.",
+      "updated_at": "2026-06-03T02:43:53Z"
+    },
+    {
+      "upstream": "anthropics/claude-code#57177",
+      "url": "https://github.com/anthropics/claude-code/issues/57177",
+      "title": "[FEATURE] Allow configuring the Cowork workspace base path (Documents/Claude)",
+      "impact": "unknown_low_signal",
+      "categories": [],
+      "tokenkey_status": "not_applicable",
+      "rationale": "No gateway/relay-relevant keywords; treated as not-our-surface.",
+      "updated_at": "2026-06-01T18:55:40Z"
+    },
+    {
+      "upstream": "anthropics/claude-code#57441",
+      "url": "https://github.com/anthropics/claude-code/issues/57441",
+      "title": "[MODEL] Model self-assigns out-of-scope work without user confirmation, persists for hours despite time pressure",
+      "impact": "unknown_low_signal",
+      "categories": [],
+      "tokenkey_status": "not_applicable",
+      "rationale": "No gateway/relay-relevant keywords; treated as not-our-surface.",
+      "updated_at": "2026-06-02T22:44:10Z"
+    },
+    {
+      "upstream": "anthropics/claude-code#58198",
+      "url": "https://github.com/anthropics/claude-code/issues/58198",
+      "title": "[BUG] Permission prompt events (and user response) not serialized to session jsonl",
+      "impact": "unknown_low_signal",
+      "categories": [],
+      "tokenkey_status": "not_applicable",
+      "rationale": "No gateway/relay-relevant keywords; treated as not-our-surface.",
+      "updated_at": "2026-06-01T12:03:29Z"
+    },
+    {
+      "upstream": "anthropics/claude-code#58768",
+      "url": "https://github.com/anthropics/claude-code/issues/58768",
+      "title": "AskUserQuestion answers invisible to auto-mode permission classifier — destructive calls re-blocked after explicit consent",
+      "impact": "unknown_low_signal",
+      "categories": [],
+      "tokenkey_status": "not_applicable",
+      "rationale": "No gateway/relay-relevant keywords; treated as not-our-surface.",
+      "updated_at": "2026-06-01T22:45:44Z"
+    },
+    {
+      "upstream": "anthropics/claude-code#58860",
+      "url": "https://github.com/anthropics/claude-code/issues/58860",
+      "title": "[DOCS] Vertex AI workload identity federation docs missing `ANTHROPIC_WORKSPACE_ID` workspace-scoping guidance",
+      "impact": "unknown_low_signal",
+      "categories": [],
+      "tokenkey_status": "not_applicable",
+      "rationale": "No gateway/relay-relevant keywords; treated as not-our-surface.",
+      "updated_at": "2026-06-01T01:13:19Z"
+    },
+    {
+      "upstream": "anthropics/claude-code#58870",
+      "url": "https://github.com/anthropics/claude-code/issues/58870",
+      "title": "[DOCS] Gateway background session naming docs omit main-model fallback when no Haiku model is configured",
+      "impact": "unknown_low_signal",
+      "categories": [],
+      "tokenkey_status": "not_applicable",
+      "rationale": "No gateway/relay-relevant keywords; treated as not-our-surface.",
+      "updated_at": "2026-06-01T01:11:37Z"
+    },
+    {
+      "upstream": "anthropics/claude-code#59255",
+      "url": "https://github.com/anthropics/claude-code/issues/59255",
+      "title": "Remote Control 웹 세션 연결 후 CLI 대화 스트림이 전혀 표시되지 않음",
+      "impact": "unknown_low_signal",
+      "categories": [],
+      "tokenkey_status": "not_applicable",
+      "rationale": "No gateway/relay-relevant keywords; treated as not-our-surface.",
+      "updated_at": "2026-06-01T12:02:02Z"
+    },
+    {
+      "upstream": "anthropics/claude-code#59411",
+      "url": "https://github.com/anthropics/claude-code/issues/59411",
+      "title": "[FEATURE] Hot-Context Checkpoints for Faster Forked Agent Workflows",
+      "impact": "unknown_low_signal",
+      "categories": [],
+      "tokenkey_status": "not_applicable",
+      "rationale": "No gateway/relay-relevant keywords; treated as not-our-surface.",
+      "updated_at": "2026-05-31T10:41:17Z"
+    },
+    {
+      "upstream": "anthropics/claude-code#59570",
+      "url": "https://github.com/anthropics/claude-code/issues/59570",
+      "title": "Web sessions don't pull submodules even when both repos are granted access",
+      "impact": "unknown_low_signal",
+      "categories": [],
+      "tokenkey_status": "not_applicable",
+      "rationale": "No gateway/relay-relevant keywords; treated as not-our-surface.",
+      "updated_at": "2026-06-01T12:01:59Z"
+    },
+    {
+      "upstream": "anthropics/claude-code#59591",
+      "url": "https://github.com/anthropics/claude-code/issues/59591",
+      "title": "[DOCS] Worktree cleanup docs omit failed-removal safety behavior for gitignored and in-progress files",
+      "impact": "unknown_low_signal",
+      "categories": [],
+      "tokenkey_status": "not_applicable",
+      "rationale": "No gateway/relay-relevant keywords; treated as not-our-surface.",
+      "updated_at": "2026-06-01T01:04:47Z"
+    },
+    {
+      "upstream": "anthropics/claude-code#59598",
+      "url": "https://github.com/anthropics/claude-code/issues/59598",
+      "title": "Give background agents awareness of peer agents in the same repo",
+      "impact": "unknown_low_signal",
+      "categories": [],
+      "tokenkey_status": "not_applicable",
+      "rationale": "No gateway/relay-relevant keywords; treated as not-our-surface.",
+      "updated_at": "2026-06-01T12:02:24Z"
+    },
+    {
+      "upstream": "anthropics/claude-code#59624",
+      "url": "https://github.com/anthropics/claude-code/issues/59624",
+      "title": "Routines: allow manual reordering of routines in the list",
+      "impact": "unknown_low_signal",
+      "categories": [],
+      "tokenkey_status": "not_applicable",
+      "rationale": "No gateway/relay-relevant keywords; treated as not-our-surface.",
+      "updated_at": "2026-05-31T10:41:41Z"
+    },
+    {
+      "upstream": "anthropics/claude-code#59625",
+      "url": "https://github.com/anthropics/claude-code/issues/59625",
+      "title": "Routines: add setting to set Calendar as the default tab",
+      "impact": "unknown_low_signal",
+      "categories": [],
+      "tokenkey_status": "not_applicable",
+      "rationale": "No gateway/relay-relevant keywords; treated as not-our-surface.",
+      "updated_at": "2026-05-31T10:41:42Z"
+    },
+    {
+      "upstream": "anthropics/claude-code#59641",
+      "url": "https://github.com/anthropics/claude-code/issues/59641",
+      "title": "Sessions not synced across Claude Code surfaces (CLI, desktop app, web)",
+      "impact": "unknown_low_signal",
+      "categories": [],
+      "tokenkey_status": "not_applicable",
+      "rationale": "No gateway/relay-relevant keywords; treated as not-our-surface.",
+      "updated_at": "2026-05-31T10:41:51Z"
+    },
+    {
+      "upstream": "anthropics/claude-code#59680",
+      "url": "https://github.com/anthropics/claude-code/issues/59680",
+      "title": "Sonnet model shows AUTO permission mode but fails with error",
+      "impact": "unknown_low_signal",
+      "categories": [],
+      "tokenkey_status": "not_applicable",
+      "rationale": "No gateway/relay-relevant keywords; treated as not-our-surface.",
+      "updated_at": "2026-06-01T12:02:12Z"
+    },
+    {
+      "upstream": "anthropics/claude-code#59691",
+      "url": "https://github.com/anthropics/claude-code/issues/59691",
+      "title": "Agent View: undocumented behavior — are run_in_background child processes killed when the supervisor reaps an idle session after ~1h?",
+      "impact": "unknown_low_signal",
+      "categories": [],
+      "tokenkey_status": "not_applicable",
+      "rationale": "No gateway/relay-relevant keywords; treated as not-our-surface.",
+      "updated_at": "2026-06-01T22:45:12Z"
+    },
+    {
+      "upstream": "anthropics/claude-code#59694",
+      "url": "https://github.com/anthropics/claude-code/issues/59694",
+      "title": "Feature request: inline annotations in .md files visible to Claude Code",
+      "impact": "unknown_low_signal",
+      "categories": [],
+      "tokenkey_status": "not_applicable",
+      "rationale": "No gateway/relay-relevant keywords; treated as not-our-surface.",
+      "updated_at": "2026-06-01T22:45:10Z"
+    },
+    {
+      "upstream": "anthropics/claude-code#59695",
+      "url": "https://github.com/anthropics/claude-code/issues/59695",
+      "title": "Permission dialog toggle label is clickable but clicking it changes the value — counterintuitive UX",
+      "impact": "unknown_low_signal",
+      "categories": [],
+      "tokenkey_status": "not_applicable",
+      "rationale": "No gateway/relay-relevant keywords; treated as not-our-surface.",
+      "updated_at": "2026-06-01T22:45:10Z"
+    },
+    {
+      "upstream": "anthropics/claude-code#59716",
+      "url": "https://github.com/anthropics/claude-code/issues/59716",
+      "title": "[FEATURE] Configurable initial vim mode for each new prompt",
+      "impact": "unknown_low_signal",
+      "categories": [],
+      "tokenkey_status": "not_applicable",
+      "rationale": "No gateway/relay-relevant keywords; treated as not-our-surface.",
+      "updated_at": "2026-06-01T12:02:23Z"
+    },
+    {
+      "upstream": "anthropics/claude-code#59847",
+      "url": "https://github.com/anthropics/claude-code/issues/59847",
+      "title": "Plan mode ExitPlanMode button misleadingly shows 'ready to code' prompt",
+      "impact": "unknown_low_signal",
+      "categories": [],
+      "tokenkey_status": "not_applicable",
+      "rationale": "No gateway/relay-relevant keywords; treated as not-our-surface.",
+      "updated_at": "2026-06-01T12:03:31Z"
+    },
+    {
+      "upstream": "anthropics/claude-code#59864",
+      "url": "https://github.com/anthropics/claude-code/issues/59864",
+      "title": "claude -p: ScheduleWakeup / Cron* tools advertised in print mode where they have no execution semantics",
+      "impact": "unknown_low_signal",
+      "categories": [],
+      "tokenkey_status": "not_applicable",
+      "rationale": "No gateway/relay-relevant keywords; treated as not-our-surface.",
+      "updated_at": "2026-06-01T22:45:17Z"
+    },
+    {
+      "upstream": "anthropics/claude-code#59904",
+      "url": "https://github.com/anthropics/claude-code/issues/59904",
+      "title": "[FEATURE] Dreaming: surface CLAUDE.md promotion candidates to humans",
+      "impact": "unknown_low_signal",
+      "categories": [],
+      "tokenkey_status": "not_applicable",
+      "rationale": "No gateway/relay-relevant keywords; treated as not-our-surface.",
+      "updated_at": "2026-06-02T11:32:04Z"
+    },
+    {
+      "upstream": "anthropics/claude-code#59984",
+      "url": "https://github.com/anthropics/claude-code/issues/59984",
+      "title": "Worktree status bar: 'Create PR' button should respect custom /pr skills and reflect merged state",
+      "impact": "unknown_low_signal",
+      "categories": [],
+      "tokenkey_status": "not_applicable",
+      "rationale": "No gateway/relay-relevant keywords; treated as not-our-surface.",
+      "updated_at": "2026-06-01T22:45:48Z"
+    },
+    {
+      "upstream": "anthropics/claude-code#60005",
+      "url": "https://github.com/anthropics/claude-code/issues/60005",
+      "title": "[FEATURE] Push notification when scheduled routine/agent session starts",
+      "impact": "unknown_low_signal",
+      "categories": [],
+      "tokenkey_status": "not_applicable",
+      "rationale": "No gateway/relay-relevant keywords; treated as not-our-surface.",
+      "updated_at": "2026-06-01T22:45:59Z"
+    },
+    {
+      "upstream": "anthropics/claude-code#60027",
+      "url": "https://github.com/anthropics/claude-code/issues/60027",
+      "title": "`!` injection: `&&` chain drops commands after sudo (works fine in fresh shell)",
+      "impact": "unknown_low_signal",
+      "categories": [],
+      "tokenkey_status": "not_applicable",
+      "rationale": "No gateway/relay-relevant keywords; treated as not-our-surface.",
+      "updated_at": "2026-06-01T22:46:12Z"
+    },
+    {
+      "upstream": "anthropics/claude-code#60068",
+      "url": "https://github.com/anthropics/claude-code/issues/60068",
+      "title": "Agent modifies explicitly specified file paths without authorization",
+      "impact": "unknown_low_signal",
+      "categories": [],
+      "tokenkey_status": "not_applicable",
+      "rationale": "No gateway/relay-relevant keywords; treated as not-our-surface.",
+      "updated_at": "2026-06-02T22:44:16Z"
+    },
+    {
+      "upstream": "anthropics/claude-code#60108",
+      "url": "https://github.com/anthropics/claude-code/issues/60108",
+      "title": "[FEATURE] Floating Window Option for \"Side-Chats\" for streamers so they can ..",
+      "impact": "unknown_low_signal",
+      "categories": [],
+      "tokenkey_status": "not_applicable",
+      "rationale": "No gateway/relay-relevant keywords; treated as not-our-surface.",
+      "updated_at": "2026-06-02T11:32:34Z"
+    },
+    {
+      "upstream": "anthropics/claude-code#60111",
+      "url": "https://github.com/anthropics/claude-code/issues/60111",
+      "title": "Feature: Switch working directory and start new session via chat command in desktop app",
+      "impact": "unknown_low_signal",
+      "categories": [],
+      "tokenkey_status": "not_applicable",
+      "rationale": "No gateway/relay-relevant keywords; treated as not-our-surface.",
+      "updated_at": "2026-06-02T11:32:30Z"
+    },
+    {
+      "upstream": "anthropics/claude-code#60257",
+      "url": "https://github.com/anthropics/claude-code/issues/60257",
+      "title": "[FEATURE] Don't block Edit tool for files read in session it was forked from",
+      "impact": "unknown_low_signal",
+      "categories": [],
+      "tokenkey_status": "not_applicable",
+      "rationale": "No gateway/relay-relevant keywords; treated as not-our-surface.",
+      "updated_at": "2026-06-02T22:44:12Z"
+    },
+    {
+      "upstream": "anthropics/claude-code#60328",
+      "url": "https://github.com/anthropics/claude-code/issues/60328",
+      "title": "/ultrareview: two free runs consumed by failed sessions + two seed-bundle launch errors",
+      "impact": "unknown_low_signal",
+      "categories": [],
+      "tokenkey_status": "not_applicable",
+      "rationale": "No gateway/relay-relevant keywords; treated as not-our-surface.",
+      "updated_at": "2026-06-02T22:44:43Z"
+    },
+    {
+      "upstream": "anthropics/claude-code#60329",
+      "url": "https://github.com/anthropics/claude-code/issues/60329",
+      "title": "ExitPlanMode conflates 'exit plan mode' with 'approve and execute plan'",
+      "impact": "unknown_low_signal",
+      "categories": [],
+      "tokenkey_status": "not_applicable",
+      "rationale": "No gateway/relay-relevant keywords; treated as not-our-surface.",
+      "updated_at": "2026-06-02T22:44:44Z"
+    },
+    {
+      "upstream": "anthropics/claude-code#60354",
+      "url": "https://github.com/anthropics/claude-code/issues/60354",
+      "title": "Voice indicator shows recording state after message is submitted",
+      "impact": "unknown_low_signal",
+      "categories": [],
+      "tokenkey_status": "not_applicable",
+      "rationale": "No gateway/relay-relevant keywords; treated as not-our-surface.",
+      "updated_at": "2026-06-02T22:44:54Z"
+    },
+    {
+      "upstream": "anthropics/claude-code#60411",
+      "url": "https://github.com/anthropics/claude-code/issues/60411",
+      "title": "[DOCS] Background side-query docs omit main-model fallback for gateways and Bedrock Mantle",
+      "impact": "unknown_low_signal",
+      "categories": [],
+      "tokenkey_status": "not_applicable",
+      "rationale": "No gateway/relay-relevant keywords; treated as not-our-surface.",
+      "updated_at": "2026-06-01T01:30:47Z"
+    },
+    {
+      "upstream": "anthropics/claude-code#60492",
+      "url": "https://github.com/anthropics/claude-code/issues/60492",
+      "title": "[Bug] Agent invents timestamp when writing to files — currentDate injected but no currentTime",
+      "impact": "unknown_low_signal",
+      "categories": [],
+      "tokenkey_status": "not_applicable",
+      "rationale": "No gateway/relay-relevant keywords; treated as not-our-surface.",
+      "updated_at": "2026-06-02T15:01:44Z"
+    },
+    {
+      "upstream": "anthropics/claude-code#60668",
+      "url": "https://github.com/anthropics/claude-code/issues/60668",
+      "title": "[FEATURE] Setting to suppress Ultraplan prompt in plan mode",
+      "impact": "unknown_low_signal",
+      "categories": [],
+      "tokenkey_status": "not_applicable",
+      "rationale": "No gateway/relay-relevant keywords; treated as not-our-surface.",
+      "updated_at": "2026-06-02T17:18:42Z"
+    },
+    {
+      "upstream": "anthropics/claude-code#60848",
+      "url": "https://github.com/anthropics/claude-code/issues/60848",
+      "title": "Ambiguous 'Don't ask me again' option in session resume prompt",
+      "impact": "unknown_low_signal",
+      "categories": [],
+      "tokenkey_status": "not_applicable",
+      "rationale": "No gateway/relay-relevant keywords; treated as not-our-surface.",
+      "updated_at": "2026-06-03T00:44:06Z"
+    },
+    {
+      "upstream": "anthropics/claude-code#60955",
+      "url": "https://github.com/anthropics/claude-code/issues/60955",
+      "title": "[DOCS] Undocumented \"Classify session states\" and its impact on privacy and costs",
+      "impact": "unknown_low_signal",
+      "categories": [],
+      "tokenkey_status": "not_applicable",
+      "rationale": "No gateway/relay-relevant keywords; treated as not-our-surface.",
+      "updated_at": "2026-06-02T00:07:52Z"
+    },
+    {
+      "upstream": "anthropics/claude-code#61111",
+      "url": "https://github.com/anthropics/claude-code/issues/61111",
+      "title": "Remote Claude Code session (desktop app): GitHubPrManager spawns local `gh` with remote cwd → misleading ENOENT",
+      "impact": "unknown_low_signal",
+      "categories": [],
+      "tokenkey_status": "not_applicable",
+      "rationale": "No gateway/relay-relevant keywords; treated as not-our-surface.",
+      "updated_at": "2026-06-01T08:05:02Z"
+    },
+    {
+      "upstream": "anthropics/claude-code#61625",
+      "url": "https://github.com/anthropics/claude-code/issues/61625",
+      "title": "[Bug] Anthropic API Usage Policy classifier false positive on security terminology",
+      "impact": "unknown_low_signal",
+      "categories": [],
+      "tokenkey_status": "not_applicable",
+      "rationale": "No gateway/relay-relevant keywords; treated as not-our-surface.",
+      "updated_at": "2026-06-01T06:33:03Z"
+    },
+    {
+      "upstream": "anthropics/claude-code#61643",
+      "url": "https://github.com/anthropics/claude-code/issues/61643",
+      "title": "Conversation permanently blocked after credential-related context — rewind doesn't help",
+      "impact": "unknown_low_signal",
+      "categories": [],
+      "tokenkey_status": "not_applicable",
+      "rationale": "No gateway/relay-relevant keywords; treated as not-our-surface.",
+      "updated_at": "2026-06-01T03:51:51Z"
+    },
+    {
+      "upstream": "anthropics/claude-code#61672",
+      "url": "https://github.com/anthropics/claude-code/issues/61672",
+      "title": "[Feature Request] Add per-message timestamps and session clock for reliable time tracking",
+      "impact": "unknown_low_signal",
+      "categories": [],
+      "tokenkey_status": "not_applicable",
+      "rationale": "No gateway/relay-relevant keywords; treated as not-our-surface.",
+      "updated_at": "2026-06-02T15:01:27Z"
+    },
+    {
+      "upstream": "anthropics/claude-code#61830",
+      "url": "https://github.com/anthropics/claude-code/issues/61830",
+      "title": "[BUG] System prompt constant qD4 unconditionally injects security-adjacent text into every session, priming the API cyber classifier",
+      "impact": "unknown_low_signal",
+      "categories": [],
+      "tokenkey_status": "not_applicable",
+      "rationale": "No gateway/relay-relevant keywords; treated as not-our-surface.",
+      "updated_at": "2026-06-01T06:33:13Z"
+    },
+    {
+      "upstream": "anthropics/claude-code#62229",
+      "url": "https://github.com/anthropics/claude-code/issues/62229",
+      "title": "[MODEL] Opus 4.7 stole my money",
+      "impact": "unknown_low_signal",
+      "categories": [],
+      "tokenkey_status": "not_applicable",
+      "rationale": "No gateway/relay-relevant keywords; treated as not-our-surface.",
+      "updated_at": "2026-05-31T13:35:25Z"
+    },
+    {
+      "upstream": "anthropics/claude-code#6235",
+      "url": "https://github.com/anthropics/claude-code/issues/6235",
+      "title": "Feature Request: Support AGENTS.md.",
+      "impact": "unknown_low_signal",
+      "categories": [],
+      "tokenkey_status": "not_applicable",
+      "rationale": "No gateway/relay-relevant keywords; treated as not-our-surface.",
+      "updated_at": "2026-06-03T04:23:27Z"
+    },
+    {
+      "upstream": "anthropics/claude-code#63130",
+      "url": "https://github.com/anthropics/claude-code/issues/63130",
+      "title": "macOS TCC popup still recurring on v2.1.153 — \"2.1.153\" would like to access data from other apps",
+      "impact": "unknown_low_signal",
+      "categories": [],
+      "tokenkey_status": "not_applicable",
+      "rationale": "No gateway/relay-relevant keywords; treated as not-our-surface.",
+      "updated_at": "2026-06-01T09:03:52Z"
+    },
+    {
+      "upstream": "anthropics/claude-code#63142",
+      "url": "https://github.com/anthropics/claude-code/issues/63142",
+      "title": "Path-scoped rules and subdirectory CLAUDE.md not loaded when creating new files matching the pattern",
+      "impact": "unknown_low_signal",
+      "categories": [],
+      "tokenkey_status": "not_applicable",
+      "rationale": "No gateway/relay-relevant keywords; treated as not-our-surface.",
+      "updated_at": "2026-06-02T10:41:03Z"
+    },
+    {
+      "upstream": "anthropics/claude-code#63732",
+      "url": "https://github.com/anthropics/claude-code/issues/63732",
+      "title": "Edit tool silently substitutes Unicode smart quotes for ASCII double quotes in shell scripts",
+      "impact": "unknown_low_signal",
+      "categories": [],
+      "tokenkey_status": "not_applicable",
+      "rationale": "No gateway/relay-relevant keywords; treated as not-our-surface.",
+      "updated_at": "2026-05-31T20:03:13Z"
+    },
+    {
+      "upstream": "anthropics/claude-code#63853",
+      "url": "https://github.com/anthropics/claude-code/issues/63853",
+      "title": "[feature] Path-rewrite enforcement when isolation: \"worktree\" is set on Agent tool",
+      "impact": "unknown_low_signal",
+      "categories": [],
+      "tokenkey_status": "not_applicable",
+      "rationale": "No gateway/relay-relevant keywords; treated as not-our-surface.",
+      "updated_at": "2026-06-01T14:38:34Z"
+    },
+    {
+      "upstream": "anthropics/claude-code#63909",
+      "url": "https://github.com/anthropics/claude-code/issues/63909",
+      "title": "Task runner reports ENOSPC on subprocess output despite disk having free space",
+      "impact": "unknown_low_signal",
+      "categories": [],
+      "tokenkey_status": "not_applicable",
+      "rationale": "No gateway/relay-relevant keywords; treated as not-our-surface.",
+      "updated_at": "2026-06-01T18:19:14Z"
+    },
+    {
+      "upstream": "anthropics/claude-code#64053",
+      "url": "https://github.com/anthropics/claude-code/issues/64053",
+      "title": "Agent deflects with \"untouched by my change\" after its own change breaks previously-passing tests — needs accountability-first framing",
+      "impact": "unknown_low_signal",
+      "categories": [],
+      "tokenkey_status": "not_applicable",
+      "rationale": "No gateway/relay-relevant keywords; treated as not-our-surface.",
+      "updated_at": "2026-05-31T21:52:05Z"
+    },
+    {
+      "upstream": "anthropics/claude-code#64171",
+      "url": "https://github.com/anthropics/claude-code/issues/64171",
+      "title": "Feedback: noticeable reliability regression — agent edits from memory, silent Edit failures shipped broken code to prod",
+      "impact": "unknown_low_signal",
+      "categories": [],
+      "tokenkey_status": "not_applicable",
+      "rationale": "No gateway/relay-relevant keywords; treated as not-our-surface.",
+      "updated_at": "2026-05-31T20:25:45Z"
+    },
+    {
+      "upstream": "anthropics/claude-code#64175",
+      "url": "https://github.com/anthropics/claude-code/issues/64175",
+      "title": "Claude Code wastes user quota with repeated trial-and-error instead of verifying calculations before coding",
+      "impact": "unknown_low_signal",
+      "categories": [],
+      "tokenkey_status": "not_applicable",
+      "rationale": "No gateway/relay-relevant keywords; treated as not-our-surface.",
+      "updated_at": "2026-06-02T04:02:39Z"
+    },
+    {
+      "upstream": "anthropics/claude-code#64191",
+      "url": "https://github.com/anthropics/claude-code/issues/64191",
+      "title": "`/desktop` fails: \"Cannot determine working directory … transcript may be incomplete\" after EnterWorktree→ExitWorktree (transcript fragmented across project dirs; bridge-session record has no cwd)",
+      "impact": "unknown_low_signal",
+      "categories": [],
+      "tokenkey_status": "not_applicable",
+      "rationale": "No gateway/relay-relevant keywords; treated as not-our-surface.",
+      "updated_at": "2026-05-31T10:50:36Z"
+    },
+    {
+      "upstream": "anthropics/claude-code#64198",
+      "url": "https://github.com/anthropics/claude-code/issues/64198",
+      "title": "[MODEL] False-positive cyber-safety block on benign Minecraft mod documentation task",
+      "impact": "unknown_low_signal",
+      "categories": [],
+      "tokenkey_status": "not_applicable",
+      "rationale": "No gateway/relay-relevant keywords; treated as not-our-surface.",
+      "updated_at": "2026-05-31T11:13:48Z"
+    },
+    {
+      "upstream": "anthropics/claude-code#64236",
+      "url": "https://github.com/anthropics/claude-code/issues/64236",
+      "title": "[MODEL] Claude Code + Opus 4.8 frequently echos hello world during planning",
+      "impact": "unknown_low_signal",
+      "categories": [],
+      "tokenkey_status": "not_applicable",
+      "rationale": "No gateway/relay-relevant keywords; treated as not-our-surface.",
+      "updated_at": "2026-05-31T23:48:48Z"
+    },
+    {
+      "upstream": "anthropics/claude-code#64245",
+      "url": "https://github.com/anthropics/claude-code/issues/64245",
+      "title": "[FEATURE] Multiple account",
+      "impact": "unknown_low_signal",
+      "categories": [],
+      "tokenkey_status": "not_applicable",
+      "rationale": "No gateway/relay-relevant keywords; treated as not-our-surface.",
+      "updated_at": "2026-05-31T15:16:59Z"
+    },
+    {
+      "upstream": "anthropics/claude-code#64255",
+      "url": "https://github.com/anthropics/claude-code/issues/64255",
+      "title": "Auto mode selected at plan approval persists after execution completes",
+      "impact": "unknown_low_signal",
+      "categories": [],
+      "tokenkey_status": "not_applicable",
+      "rationale": "No gateway/relay-relevant keywords; treated as not-our-surface.",
+      "updated_at": "2026-05-31T15:55:54Z"
+    },
+    {
+      "upstream": "anthropics/claude-code#64259",
+      "url": "https://github.com/anthropics/claude-code/issues/64259",
+      "title": "Enriched input signal for Claude Code - Eyeballs for non-verbal communication cues",
+      "impact": "unknown_low_signal",
+      "categories": [],
+      "tokenkey_status": "not_applicable",
+      "rationale": "No gateway/relay-relevant keywords; treated as not-our-surface.",
+      "updated_at": "2026-05-31T16:17:08Z"
+    },
+    {
+      "upstream": "anthropics/claude-code#64266",
+      "url": "https://github.com/anthropics/claude-code/issues/64266",
+      "title": "Agent tool model parameter should accept full model IDs, not just tier names",
+      "impact": "unknown_low_signal",
+      "categories": [],
+      "tokenkey_status": "not_applicable",
+      "rationale": "No gateway/relay-relevant keywords; treated as not-our-surface.",
+      "updated_at": "2026-05-31T16:55:11Z"
+    },
+    {
+      "upstream": "anthropics/claude-code#64270",
+      "url": "https://github.com/anthropics/claude-code/issues/64270",
+      "title": "[FEATURE]",
+      "impact": "unknown_low_signal",
+      "categories": [],
+      "tokenkey_status": "not_applicable",
+      "rationale": "No gateway/relay-relevant keywords; treated as not-our-surface.",
+      "updated_at": "2026-05-31T17:20:26Z"
+    },
+    {
+      "upstream": "anthropics/claude-code#64287",
+      "url": "https://github.com/anthropics/claude-code/issues/64287",
+      "title": "[UX] Add first-class false-positive reporting for safety guardrail blocks",
+      "impact": "unknown_low_signal",
+      "categories": [],
+      "tokenkey_status": "not_applicable",
+      "rationale": "No gateway/relay-relevant keywords; treated as not-our-surface.",
+      "updated_at": "2026-06-01T18:49:18Z"
+    },
+    {
+      "upstream": "anthropics/claude-code#64302",
+      "url": "https://github.com/anthropics/claude-code/issues/64302",
+      "title": "Feature Request: Show usage stats in account dropdown menu",
+      "impact": "unknown_low_signal",
+      "categories": [],
+      "tokenkey_status": "not_applicable",
+      "rationale": "No gateway/relay-relevant keywords; treated as not-our-surface.",
+      "updated_at": "2026-05-31T19:37:42Z"
+    },
+    {
+      "upstream": "anthropics/claude-code#64307",
+      "url": "https://github.com/anthropics/claude-code/issues/64307",
+      "title": "[BUG] Cowork: uploaded context lands in the project mount, not mnt/uploads/",
+      "impact": "unknown_low_signal",
+      "categories": [],
+      "tokenkey_status": "not_applicable",
+      "rationale": "No gateway/relay-relevant keywords; treated as not-our-surface.",
+      "updated_at": "2026-05-31T19:55:06Z"
+    },
+    {
+      "upstream": "anthropics/claude-code#64335",
+      "url": "https://github.com/anthropics/claude-code/issues/64335",
+      "title": "[MODEL] Porting JS to TS Relies Too Much On Feedback From TSC",
+      "impact": "unknown_low_signal",
+      "categories": [],
+      "tokenkey_status": "not_applicable",
+      "rationale": "No gateway/relay-relevant keywords; treated as not-our-surface.",
+      "updated_at": "2026-05-31T21:42:03Z"
+    },
+    {
+      "upstream": "anthropics/claude-code#64342",
+      "url": "https://github.com/anthropics/claude-code/issues/64342",
+      "title": "Display `~/` instead of full `/Users/<name>/` in tool call path labels",
+      "impact": "unknown_low_signal",
+      "categories": [],
+      "tokenkey_status": "not_applicable",
+      "rationale": "No gateway/relay-relevant keywords; treated as not-our-surface.",
+      "updated_at": "2026-05-31T22:35:16Z"
+    },
+    {
+      "upstream": "anthropics/claude-code#64348",
+      "url": "https://github.com/anthropics/claude-code/issues/64348",
+      "title": "[FEATURE] Dynamic Workflow Feature List",
+      "impact": "unknown_low_signal",
+      "categories": [],
+      "tokenkey_status": "not_applicable",
+      "rationale": "No gateway/relay-relevant keywords; treated as not-our-surface.",
+      "updated_at": "2026-05-31T22:48:15Z"
+    },
+    {
+      "upstream": "anthropics/claude-code#64354",
+      "url": "https://github.com/anthropics/claude-code/issues/64354",
+      "title": "[Feature Request] Sidebar: nest sub-folders within the same Git repo as separate project blocks",
+      "impact": "unknown_low_signal",
+      "categories": [],
+      "tokenkey_status": "not_applicable",
+      "rationale": "No gateway/relay-relevant keywords; treated as not-our-surface.",
+      "updated_at": "2026-06-01T02:56:54Z"
+    },
+    {
+      "upstream": "anthropics/claude-code#64370",
+      "url": "https://github.com/anthropics/claude-code/issues/64370",
+      "title": "Auto-compact not triggering until <10% context remaining",
+      "impact": "unknown_low_signal",
+      "categories": [],
+      "tokenkey_status": "not_applicable",
+      "rationale": "No gateway/relay-relevant keywords; treated as not-our-surface.",
+      "updated_at": "2026-06-02T03:57:19Z"
+    },
+    {
+      "upstream": "anthropics/claude-code#64373",
+      "url": "https://github.com/anthropics/claude-code/issues/64373",
+      "title": "[Bug] Workflow agent marked complete on Anthropic API policy violation error",
+      "impact": "unknown_low_signal",
+      "categories": [],
+      "tokenkey_status": "not_applicable",
+      "rationale": "No gateway/relay-relevant keywords; treated as not-our-surface.",
+      "updated_at": "2026-06-01T03:07:01Z"
+    },
+    {
+      "upstream": "anthropics/claude-code#64382",
+      "url": "https://github.com/anthropics/claude-code/issues/64382",
+      "title": "Claude Code repeatedly makes code changes without explicit user approval",
+      "impact": "unknown_low_signal",
+      "categories": [],
+      "tokenkey_status": "not_applicable",
+      "rationale": "No gateway/relay-relevant keywords; treated as not-our-surface.",
+      "updated_at": "2026-06-01T03:06:05Z"
+    },
+    {
+      "upstream": "anthropics/claude-code#64385",
+      "url": "https://github.com/anthropics/claude-code/issues/64385",
+      "title": "Chinese IME input: characters overwritten/dropped when editing mid-text",
+      "impact": "unknown_low_signal",
+      "categories": [],
+      "tokenkey_status": "not_applicable",
+      "rationale": "No gateway/relay-relevant keywords; treated as not-our-surface.",
+      "updated_at": "2026-06-01T03:47:58Z"
+    },
+    {
+      "upstream": "anthropics/claude-code#64405",
+      "url": "https://github.com/anthropics/claude-code/issues/64405",
+      "title": "[BUG] cyber-safeguard false-positives block legitimate ESP-IDF firmware flashing / eFuse provisioning — one hit poisons the whole session and bills me for the cleanup",
+      "impact": "unknown_low_signal",
+      "categories": [],
+      "tokenkey_status": "not_applicable",
+      "rationale": "No gateway/relay-relevant keywords; treated as not-our-surface.",
+      "updated_at": "2026-06-02T16:44:57Z"
+    },
+    {
+      "upstream": "anthropics/claude-code#64473",
+      "url": "https://github.com/anthropics/claude-code/issues/64473",
+      "title": "Claude Code edited out-of-scope backend files during a scoped Blade/frontend task, without disclosure",
+      "impact": "unknown_low_signal",
+      "categories": [],
+      "tokenkey_status": "not_applicable",
+      "rationale": "No gateway/relay-relevant keywords; treated as not-our-surface.",
+      "updated_at": "2026-06-01T12:30:48Z"
+    },
+    {
+      "upstream": "anthropics/claude-code#64507",
+      "url": "https://github.com/anthropics/claude-code/issues/64507",
+      "title": "[BUG] /doctor unavailable in desktop GUI; report commands differ across surfaces",
+      "impact": "unknown_low_signal",
+      "categories": [],
+      "tokenkey_status": "not_applicable",
+      "rationale": "No gateway/relay-relevant keywords; treated as not-our-surface.",
+      "updated_at": "2026-06-01T23:54:03Z"
+    },
+    {
+      "upstream": "anthropics/claude-code#64555",
+      "url": "https://github.com/anthropics/claude-code/issues/64555",
+      "title": "/usage weekly bar dropped ~88% → 3% after a usage-credit purchase, reset date unchanged",
+      "impact": "unknown_low_signal",
+      "categories": [],
+      "tokenkey_status": "not_applicable",
+      "rationale": "No gateway/relay-relevant keywords; treated as not-our-surface.",
+      "updated_at": "2026-06-01T19:50:03Z"
+    },
+    {
+      "upstream": "anthropics/claude-code#64590",
+      "url": "https://github.com/anthropics/claude-code/issues/64590",
+      "title": "[FEATURE] Toggle between verbose output for real-time update of the CLI output",
+      "impact": "unknown_low_signal",
+      "categories": [],
+      "tokenkey_status": "not_applicable",
+      "rationale": "No gateway/relay-relevant keywords; treated as not-our-surface.",
+      "updated_at": "2026-06-01T23:22:57Z"
+    },
+    {
+      "upstream": "anthropics/claude-code#64604",
+      "url": "https://github.com/anthropics/claude-code/issues/64604",
+      "title": "Remote-agent / routine GitHub PR subscriptions don't deliver pull_request_review or pull_request_review_comment events",
+      "impact": "unknown_low_signal",
+      "categories": [],
+      "tokenkey_status": "not_applicable",
+      "rationale": "No gateway/relay-relevant keywords; treated as not-our-surface.",
+      "updated_at": "2026-06-02T00:27:54Z"
+    },
+    {
+      "upstream": "anthropics/claude-code#64621",
+      "url": "https://github.com/anthropics/claude-code/issues/64621",
+      "title": "Opus 4.8 prioritizes system-prompt behaviors over my actual prompt and ignores explicit \"don't do X\" instructions",
+      "impact": "unknown_low_signal",
+      "categories": [],
+      "tokenkey_status": "not_applicable",
+      "rationale": "No gateway/relay-relevant keywords; treated as not-our-surface.",
+      "updated_at": "2026-06-02T02:46:23Z"
+    },
+    {
+      "upstream": "anthropics/claude-code#64627",
+      "url": "https://github.com/anthropics/claude-code/issues/64627",
+      "title": "Background Workflow runs are killed at a ~13-min task timeout with no completion/death signal",
+      "impact": "unknown_low_signal",
+      "categories": [],
+      "tokenkey_status": "not_applicable",
+      "rationale": "No gateway/relay-relevant keywords; treated as not-our-surface.",
+      "updated_at": "2026-06-02T03:10:59Z"
+    },
+    {
+      "upstream": "anthropics/claude-code#64641",
+      "url": "https://github.com/anthropics/claude-code/issues/64641",
+      "title": "[DOCS] Tools reference omits `grep`/`egrep`/`fgrep` as read-before-edit views",
+      "impact": "unknown_low_signal",
+      "categories": [],
+      "tokenkey_status": "not_applicable",
+      "rationale": "No gateway/relay-relevant keywords; treated as not-our-surface.",
+      "updated_at": "2026-06-02T04:29:31Z"
+    },
+    {
+      "upstream": "anthropics/claude-code#64644",
+      "url": "https://github.com/anthropics/claude-code/issues/64644",
+      "title": "[DOCS] Auto mode docs still say Bedrock, Vertex, and Foundry are unsupported",
+      "impact": "unknown_low_signal",
+      "categories": [],
+      "tokenkey_status": "not_applicable",
+      "rationale": "No gateway/relay-relevant keywords; treated as not-our-surface.",
+      "updated_at": "2026-06-02T04:26:48Z"
+    },
+    {
+      "upstream": "anthropics/claude-code#64645",
+      "url": "https://github.com/anthropics/claude-code/issues/64645",
+      "title": "[DOCS] Background session docs omit SIGTERM-first teardown for shell subprocesses",
+      "impact": "unknown_low_signal",
+      "categories": [],
+      "tokenkey_status": "not_applicable",
+      "rationale": "No gateway/relay-relevant keywords; treated as not-our-surface.",
+      "updated_at": "2026-06-02T04:27:43Z"
+    },
+    {
+      "upstream": "anthropics/claude-code#64673",
+      "url": "https://github.com/anthropics/claude-code/issues/64673",
+      "title": "Deferred tools appear in tool list but fail to execute in voice mode",
+      "impact": "unknown_low_signal",
+      "categories": [],
+      "tokenkey_status": "not_applicable",
+      "rationale": "No gateway/relay-relevant keywords; treated as not-our-surface.",
+      "updated_at": "2026-06-02T07:26:47Z"
+    },
+    {
+      "upstream": "anthropics/claude-code#64678",
+      "url": "https://github.com/anthropics/claude-code/issues/64678",
+      "title": "Refund request for recent Claude Max USD 100 charge - OSINT/research work not performed",
+      "impact": "unknown_low_signal",
+      "categories": [],
+      "tokenkey_status": "not_applicable",
+      "rationale": "No gateway/relay-relevant keywords; treated as not-our-surface.",
+      "updated_at": "2026-06-02T07:49:25Z"
+    },
+    {
+      "upstream": "anthropics/claude-code#64682",
+      "url": "https://github.com/anthropics/claude-code/issues/64682",
+      "title": "[MODEL] Claude committed and pushed to GitHub without user approval, violating explicit memory rule",
+      "impact": "unknown_low_signal",
+      "categories": [],
+      "tokenkey_status": "not_applicable",
+      "rationale": "No gateway/relay-relevant keywords; treated as not-our-surface.",
+      "updated_at": "2026-06-03T02:06:13Z"
+    },
+    {
+      "upstream": "anthropics/claude-code#64697",
+      "url": "https://github.com/anthropics/claude-code/issues/64697",
+      "title": "[Bug] Knowledge Cutoff Boundary: Confidently False Negation of Recent Facts",
+      "impact": "unknown_low_signal",
+      "categories": [],
+      "tokenkey_status": "not_applicable",
+      "rationale": "No gateway/relay-relevant keywords; treated as not-our-surface.",
+      "updated_at": "2026-06-02T09:38:43Z"
+    },
+    {
+      "upstream": "anthropics/claude-code#64708",
+      "url": "https://github.com/anthropics/claude-code/issues/64708",
+      "title": "[FEATURE] Path-scoped rules should trigger on Write and Edit, not only on Read",
+      "impact": "unknown_low_signal",
+      "categories": [],
+      "tokenkey_status": "not_applicable",
+      "rationale": "No gateway/relay-relevant keywords; treated as not-our-surface.",
+      "updated_at": "2026-06-02T11:28:20Z"
+    },
+    {
+      "upstream": "anthropics/claude-code#64725",
+      "url": "https://github.com/anthropics/claude-code/issues/64725",
+      "title": "/stats current/longest streak under-reports continuous runs — anchored to a late-April data gap, not full activity history",
+      "impact": "unknown_low_signal",
+      "categories": [],
+      "tokenkey_status": "not_applicable",
+      "rationale": "No gateway/relay-relevant keywords; treated as not-our-surface.",
+      "updated_at": "2026-06-02T14:55:58Z"
+    },
+    {
+      "upstream": "anthropics/claude-code#64736",
+      "url": "https://github.com/anthropics/claude-code/issues/64736",
+      "title": "Stickers easter egg prompts for credit card info unexpectedly",
+      "impact": "unknown_low_signal",
+      "categories": [],
+      "tokenkey_status": "not_applicable",
+      "rationale": "No gateway/relay-relevant keywords; treated as not-our-surface.",
+      "updated_at": "2026-06-02T13:04:22Z"
+    },
+    {
+      "upstream": "anthropics/claude-code#64760",
+      "url": "https://github.com/anthropics/claude-code/issues/64760",
+      "title": "Code tab: sessions sync only one direction across devices on the same account",
+      "impact": "unknown_low_signal",
+      "categories": [],
+      "tokenkey_status": "not_applicable",
+      "rationale": "No gateway/relay-relevant keywords; treated as not-our-surface.",
+      "updated_at": "2026-06-02T14:26:08Z"
+    },
+    {
+      "upstream": "anthropics/claude-code#64786",
+      "url": "https://github.com/anthropics/claude-code/issues/64786",
+      "title": "[FEATURE] Allow the order of chats vs projects to be configurable in the sidebar of the app",
+      "impact": "unknown_low_signal",
+      "categories": [],
+      "tokenkey_status": "not_applicable",
+      "rationale": "No gateway/relay-relevant keywords; treated as not-our-surface.",
+      "updated_at": "2026-06-02T16:03:55Z"
+    },
+    {
+      "upstream": "anthropics/claude-code#64788",
+      "url": "https://github.com/anthropics/claude-code/issues/64788",
+      "title": "[FEATURE] cleanupScopeDirs — per-directory scope control for cleanupPeriodDays sweep",
+      "impact": "unknown_low_signal",
+      "categories": [],
+      "tokenkey_status": "not_applicable",
+      "rationale": "No gateway/relay-relevant keywords; treated as not-our-surface.",
+      "updated_at": "2026-06-02T15:51:35Z"
+    },
+    {
+      "upstream": "anthropics/claude-code#64831",
+      "url": "https://github.com/anthropics/claude-code/issues/64831",
+      "title": "Auto-mode classifier repeatedly blocks user-authorized credential operations, ignores explicit user approval",
+      "impact": "unknown_low_signal",
+      "categories": [],
+      "tokenkey_status": "not_applicable",
+      "rationale": "No gateway/relay-relevant keywords; treated as not-our-surface.",
+      "updated_at": "2026-06-02T18:47:21Z"
+    },
+    {
+      "upstream": "anthropics/claude-code#64841",
+      "url": "https://github.com/anthropics/claude-code/issues/64841",
+      "title": "Remote Control: iPhone app shows \"No sessions found\" even with Enable remote control by default ON",
+      "impact": "unknown_low_signal",
+      "categories": [],
+      "tokenkey_status": "not_applicable",
+      "rationale": "No gateway/relay-relevant keywords; treated as not-our-surface.",
+      "updated_at": "2026-06-02T19:23:35Z"
+    },
+    {
+      "upstream": "anthropics/claude-code#64862",
+      "url": "https://github.com/anthropics/claude-code/issues/64862",
+      "title": "[Bug] Claude Code repeatedly bypasses agreed Scrum story lifecycle — commits without compiling, skips tests, ignores direct instructions, fabricates excuses",
+      "impact": "unknown_low_signal",
+      "categories": [],
+      "tokenkey_status": "not_applicable",
+      "rationale": "No gateway/relay-relevant keywords; treated as not-our-surface.",
+      "updated_at": "2026-06-02T21:40:46Z"
+    },
+    {
+      "upstream": "anthropics/claude-code#64866",
+      "url": "https://github.com/anthropics/claude-code/issues/64866",
+      "title": "Model fails to connect adjacent logical steps (downloads large file without saving, then needs to re-download)",
+      "impact": "unknown_low_signal",
+      "categories": [],
+      "tokenkey_status": "not_applicable",
+      "rationale": "No gateway/relay-relevant keywords; treated as not-our-surface.",
+      "updated_at": "2026-06-02T22:03:53Z"
+    },
+    {
+      "upstream": "anthropics/claude-code#64870",
+      "url": "https://github.com/anthropics/claude-code/issues/64870",
+      "title": "[FEATURE] Can you please change the RSS feed name from \"Changelog\" to something like \"Claude Changelog\".",
+      "impact": "unknown_low_signal",
+      "categories": [],
+      "tokenkey_status": "not_applicable",
+      "rationale": "No gateway/relay-relevant keywords; treated as not-our-surface.",
+      "updated_at": "2026-06-02T22:11:56Z"
+    },
+    {
+      "upstream": "anthropics/claude-code#64871",
+      "url": "https://github.com/anthropics/claude-code/issues/64871",
+      "title": "Feature request: /usage and status bar should reflect live account billing, not local session data",
+      "impact": "unknown_low_signal",
+      "categories": [],
+      "tokenkey_status": "not_applicable",
+      "rationale": "No gateway/relay-relevant keywords; treated as not-our-surface.",
+      "updated_at": "2026-06-02T22:13:56Z"
+    },
+    {
+      "upstream": "anthropics/claude-code#64873",
+      "url": "https://github.com/anthropics/claude-code/issues/64873",
+      "title": "Feature request: Statusline monthly usage from Anthropic API (per-user)",
+      "impact": "unknown_low_signal",
+      "categories": [],
+      "tokenkey_status": "not_applicable",
+      "rationale": "No gateway/relay-relevant keywords; treated as not-our-surface.",
+      "updated_at": "2026-06-02T22:26:01Z"
+    },
+    {
+      "upstream": "anthropics/claude-code#64878",
+      "url": "https://github.com/anthropics/claude-code/issues/64878",
+      "title": "[DOCS] Working directory no longer exists:",
+      "impact": "unknown_low_signal",
+      "categories": [],
+      "tokenkey_status": "not_applicable",
+      "rationale": "No gateway/relay-relevant keywords; treated as not-our-surface.",
+      "updated_at": "2026-06-02T22:52:58Z"
+    },
+    {
+      "upstream": "anthropics/claude-code#64892",
+      "url": "https://github.com/anthropics/claude-code/issues/64892",
+      "title": "[FEATURE] --continue should not fail when no session exists yet (fallback to new session)",
+      "impact": "unknown_low_signal",
+      "categories": [],
+      "tokenkey_status": "not_applicable",
+      "rationale": "No gateway/relay-relevant keywords; treated as not-our-surface.",
+      "updated_at": "2026-06-02T23:39:53Z"
+    },
+    {
+      "upstream": "anthropics/claude-code#895",
+      "url": "https://github.com/anthropics/claude-code/issues/895",
+      "title": "Error: InputValidationError: Write failed due to the following issue: The required parameter `content` is missing",
+      "impact": "unknown_low_signal",
+      "categories": [],
+      "tokenkey_status": "not_applicable",
+      "rationale": "No gateway/relay-relevant keywords; treated as not-our-surface.",
+      "updated_at": "2026-06-03T06:08:50Z"
+    }
+  ]
+}


### PR DESCRIPTION
## Summary
- Refresh `.cache/anthropic/cc-triage.json` from the latest anthropics/claude-code issues.
- Update `.cache/anthropic/cc-fixes.json` from current TokenKey main fact checks.
- Keep watchdog workflow/script/fact-check metadata in sync with the refreshed cache.

## Watchdog report
# Anthropic Claude-Code Issue Watchdog Report

- Run URL: https://github.com/youxuanxue/sub2api/actions/runs/26868830505
- Repository SHA: `ca5d6281bbc72e7681c1fc87272199dbfacf97f1`
- Generated at: `2026-06-03T06:57:27Z`
- Upstream issues scanned: `2988`
- Fact checks: `1`
- Fixed facts verified: `1`
- High/critical unresolved: `0`

## Fixed facts verified

- anthropics/claude-code#61348 via youxuanxue/sub2api#514, youxuanxue/sub2api#518


## Test plan
- [x] `python3 -m json.tool .cache/anthropic/cc-triage.json`
- [x] `python3 -m json.tool .cache/anthropic/cc-fixes.json`
- [x] `python3 -m json.tool .cache/anthropic/cc-fact-checks.json`
- [x] `python3 -m py_compile scripts/upstream/issue-watchdog.py`
- [x] `python3 -m json.tool .cache/anthropic-cc-issue-watchdog/report.json`
- [x] `python3 -m json.tool .cache/anthropic-cc-issue-watchdog/agent-input.json`
