### PR TITLE
perf(scheduler): UpdateLastUsed 只刷 slim meta 键，消除 Redis 写放大 (upstream #1723)

### DIFF
--- a/backend/internal/repository/scheduler_cache.go
+++ b/backend/internal/repository/scheduler_cache.go
@@ -235,6 +235,27 @@ func (c *schedulerCache) DeleteAccount(ctx context.Context, accountID int64) err
 	return c.rdb.Del(ctx, schedulerAccountKey(id), schedulerAccountMetaKey(id)).Err()
 }
 
+// UpdateLastUsed 仅刷新调度热路径实际读取的 slim metadata 键
+// （sched:meta:<id>），不再触碰完整账号键（sched:acc:<id>）。
+//
+// 背景（upstream Wei-Shaw/sub2api#1723）：
+// 旧实现每次 LastUsedAt bump 都要对完整账号键做 MGET + 反序列化 + 重新
+// marshal + SET，仅为改一个时间戳字段。实测完整账号 JSON 单条 3-12 KB，
+// 单部署 6.5 天即向 Redis 写入 1.85 TB（SET 占全部命令 58.6%），在多机
+// 跨公网连 Redis 的部署里直接转化为带宽账单，单机部署则是无谓的
+// CPU / 网络开销与调度延迟。TokenKey 此前还在同一路径额外重写了 meta 键，
+// 把读写放大又加重一层。
+//
+// 安全性：调度热读 GetSnapshot 只 MGET sched:meta:<id> 做 LRU(LastUsedAt)
+// tiebreak；完整账号键 sched:acc:<id> 只在 sticky 命中后 hydrate 凭据
+// （getSchedulableAccount / hydrateSelectedAccount）时读取，用于转发而非
+// LRU 决策。因此完整键的 LastUsedAt 略微陈旧无害——它会在下一次快照重建
+// （SetSnapshot）或任意账号变更（SetAccount）时随完整账号一并刷新。
+// sched:acc 与 sched:meta 始终成对写入/删除（writeAccounts / DeleteAccount）
+// 且均无 TTL，故 meta 存在即 full 存在，不存在二者漂移。
+//
+// 效果：单次 LastUsedAt 更新的读写载荷从 ~12 KB 降到 slim meta 量级
+// （~1 KB），去掉了完整账号键的整段读 + 写放大。
 func (c *schedulerCache) UpdateLastUsed(ctx context.Context, updates map[int64]time.Time) error {
 	if len(updates) == 0 {
 		return nil
@@ -243,7 +264,7 @@ func (c *schedulerCache) UpdateLastUsed(ctx context.Context, updates map[int64]t
 	keys := make([]string, 0, len(updates))
 	ids := make([]int64, 0, len(updates))
 	for id := range updates {
-		keys = append(keys, schedulerAccountKey(strconv.FormatInt(id, 10)))
+		keys = append(keys, schedulerAccountMetaKey(strconv.FormatInt(id, 10)))
 		ids = append(ids, id)
 	}
 
@@ -262,16 +283,13 @@ func (c *schedulerCache) UpdateLastUsed(ctx context.Context, updates map[int64]t
 			return err
 		}
 		account.LastUsedAt = ptrTime(updates[ids[i]])
-		updated, err := json.Marshal(account)
-		if err != nil {
-			return err
-		}
+		// 解出的已是 slim meta；重新 buildSchedulerMetadataAccount 保持
+		// 白名单形状幂等，避免任何字段漂移写回。
 		metaPayload, err := json.Marshal(buildSchedulerMetadataAccount(*account))
 		if err != nil {
 			return err
 		}
-		pipe.Set(ctx, keys[i], updated, 0)
-		pipe.Set(ctx, schedulerAccountMetaKey(strconv.FormatInt(ids[i], 10)), metaPayload, 0)
+		pipe.Set(ctx, keys[i], metaPayload, 0)
 	}
 	_, err = pipe.Exec(ctx)
 	return err

--- a/backend/internal/repository/scheduler_cache_integration_test.go
+++ b/backend/internal/repository/scheduler_cache_integration_test.go
@@ -4,6 +4,7 @@ package repository
 
 import (
 	"context"
+	"strconv"
 	"strings"
 	"testing"
 	"time"
@@ -112,4 +113,80 @@ func TestSchedulerCacheSnapshotUsesSlimMetadataButKeepsFullAccount(t *testing.T)
 	require.Equal(t, strings.Repeat("x", 4096), full.GetCredential("huge_blob"))
 	require.Len(t, full.AccountGroups, 1)
 	require.NotNil(t, full.AccountGroups[0].Group)
+}
+
+// TestSchedulerCacheUpdateLastUsedOnlyTouchesMetaKey 回归保护 upstream
+// Wei-Shaw/sub2api#1723：UpdateLastUsed 只应刷新调度热路径读取的 slim meta
+// 键（sched:meta:<id>），绝不重写完整账号键（sched:acc:<id>）。重写完整账号
+// JSON（实测 3-12 KB）仅为 bump 一个时间戳，会造成巨大的 Redis 读写放大。
+func TestSchedulerCacheUpdateLastUsedOnlyTouchesMetaKey(t *testing.T) {
+	ctx := context.Background()
+	rdb := testRedis(t)
+	cache := NewSchedulerCache(rdb)
+
+	bucket := service.SchedulerBucket{GroupID: 3, Platform: service.PlatformAnthropic, Mode: service.SchedulerModeSingle}
+	t0 := time.Now().UTC().Truncate(time.Second).Add(-time.Hour)
+	t1 := t0.Add(time.Hour)
+
+	account := service.Account{
+		ID:          202,
+		Name:        "claude-lru",
+		Platform:    service.PlatformAnthropic,
+		Type:        service.AccountTypeOAuth,
+		Status:      service.StatusActive,
+		Schedulable: true,
+		Concurrency: 2,
+		Priority:    1,
+		LastUsedAt:  &t0,
+		Credentials: map[string]any{
+			"api_key":      "anthropic-api-key",
+			"access_token": "secret-access-token",
+			"huge_blob":    strings.Repeat("x", 8192),
+		},
+		Extra: map[string]any{
+			"base_rpm":         28,
+			"max_sessions":     30,
+			"mixed_scheduling": true,
+		},
+		GroupIDs: []int64{bucket.GroupID},
+		AccountGroups: []service.AccountGroup{
+			{AccountID: 202, GroupID: bucket.GroupID, Priority: 1},
+		},
+	}
+
+	require.NoError(t, cache.SetSnapshot(ctx, bucket, []service.Account{account}))
+
+	fullKey := schedulerAccountKey(strconv.FormatInt(account.ID, 10))
+	rawBefore, err := rdb.Get(ctx, fullKey).Result()
+	require.NoError(t, err)
+	require.NotEmpty(t, rawBefore)
+
+	// 触发 LastUsedAt bump（调度热路径每个 flush 周期都会走到这里）。
+	require.NoError(t, cache.UpdateLastUsed(ctx, map[int64]time.Time{account.ID: t1}))
+
+	// 核心断言：完整账号键的字节必须完全不变 —— 没有写放大。
+	rawAfter, err := rdb.Get(ctx, fullKey).Result()
+	require.NoError(t, err)
+	require.Equal(t, rawBefore, rawAfter,
+		"UpdateLastUsed 不得重写完整账号键 sched:acc:<id>（#1723 写放大回归）")
+
+	// 调度 LRU 读取的 meta 键必须反映新的 LastUsedAt。
+	snapshot, hit, err := cache.GetSnapshot(ctx, bucket)
+	require.NoError(t, err)
+	require.True(t, hit)
+	require.Len(t, snapshot, 1)
+	require.NotNil(t, snapshot[0].LastUsedAt)
+	require.True(t, snapshot[0].LastUsedAt.Equal(t1),
+		"meta 键的 LastUsedAt 应被刷新为最新值，供 LRU tiebreak 使用")
+
+	// 完整账号键仍可 hydrate 出完整凭据；其 LastUsedAt 保持旧值是被接受的
+	// 契约——它不参与 LRU，会在下次快照重建/账号变更时刷新。
+	full, err := cache.GetAccount(ctx, account.ID)
+	require.NoError(t, err)
+	require.NotNil(t, full)
+	require.Equal(t, "secret-access-token", full.GetCredential("access_token"))
+	require.Equal(t, strings.Repeat("x", 8192), full.GetCredential("huge_blob"))
+	require.NotNil(t, full.LastUsedAt)
+	require.True(t, full.LastUsedAt.Equal(t0),
+		"完整账号键的 LastUsedAt 在 UpdateLastUsed 后保持旧值（不重写即不刷新，契约如此）")
 }

--- a/backend/internal/repository/scheduler_snapshot_outbox_integration_test.go
+++ b/backend/internal/repository/scheduler_snapshot_outbox_integration_test.go
@@ -52,6 +52,36 @@ func TestSchedulerSnapshotOutboxReplay(t *testing.T) {
 	svc.Start()
 	t.Cleanup(svc.Stop)
 
+	// 该断言验证的是 outbox 重放把 last_used 传播进【调度热读快照】（sched:meta
+	// 键，GetSnapshot 读取的就是它）。ungrouped openai 账号属于默认桶
+	// {GroupID:0, openai, single}。
+	//
+	// 注意：不能像旧版那样断言 cache.GetAccount（完整账号键 sched:acc）——
+	// 自 #1723 起 outbox 的 account_last_used 路径只刷 sched:meta，完整键由快照
+	// 重建/账号变更刷新。若仍断言完整键，本测试会改为被 startup rebuild 的副作用
+	// 兜过（名实不符、对 outbox 回归零覆盖）。
+	bucket := service.SchedulerBucket{GroupID: 0, Platform: service.PlatformOpenAI, Mode: service.SchedulerModeSingle}
+	snapshotHasAccount := func() (*service.Account, bool) {
+		snap, hit, err := cache.GetSnapshot(ctx, bucket)
+		if err != nil || !hit {
+			return nil, false
+		}
+		for _, a := range snap {
+			if a != nil && a.ID == account.ID {
+				return a, true
+			}
+		}
+		return nil, false
+	}
+
+	// 先等 startup rebuild 把账号灌入快照（此时 LastUsedAt 仍为 nil）。rebuild
+	// 只在启动时跑一次（FullRebuildIntervalSeconds=0 已禁用周期重建），过此 gate
+	// 之后唯一能更新快照 meta 的路径就是 outbox 重放本身。
+	require.Eventually(t, func() bool {
+		_, ok := snapshotHasAccount()
+		return ok
+	}, 5*time.Second, 100*time.Millisecond, "startup rebuild 应先把账号写入 openai/0/single 快照")
+
 	require.NoError(t, accountRepo.UpdateLastUsed(ctx, account.ID))
 	updated, err := accountRepo.GetByID(ctx, account.ID)
 	require.NoError(t, err)
@@ -59,10 +89,10 @@ func TestSchedulerSnapshotOutboxReplay(t *testing.T) {
 	expectedUnix := updated.LastUsedAt.Unix()
 
 	require.Eventually(t, func() bool {
-		cached, err := cache.GetAccount(ctx, account.ID)
-		if err != nil || cached == nil || cached.LastUsedAt == nil {
+		a, ok := snapshotHasAccount()
+		if !ok || a.LastUsedAt == nil {
 			return false
 		}
-		return cached.LastUsedAt.Unix() == expectedUnix
+		return a.LastUsedAt.Unix() == expectedUnix
 	}, 5*time.Second, 100*time.Millisecond)
 }


### PR DESCRIPTION
## 背景与选题（上帝视角甄别）

从 `.cache/upstream/*`（TokenKey 对上游 Wei-Shaw/sub2api open issues 的本地 triage 台账，1100 条）中，按**对线上 TokenKey 的真实影响与价值**筛选高 signal 候选，并逐条对照当前 TK 代码核实「是否仍是真实残留缺陷」（而非已修 / 不适用的关键词命中）：

| Upstream | 主题 | 对照 TK 代码后的结论 |
|---|---|---|
| **#1723** | `UpdateLastUsed` Redis 写放大（实测 1.85 TB / 6.5 天） | **仍存在，且 TK 更重** —— 本 PR 修复 |
| #1662 | scheduler cache 过滤掉 OpenAI WS flags 导致选号失败 | **已修**：TK `filterSchedulerExtra` 已放行全部 WS flags |
| #2733 | PG 不可达时内存无界增长 → 宿主 OOM | **架构上已不适用**：TK ops 错误日志已是有界 channel + 丢弃 + 落盘 DLQ |

聚焦（乔布斯标准）：不为凑数把已修/不适用的 issue 塞进 PR，只做**唯一真实残留**的那一个高价值缺陷，做到精品级（修复 + 真实容器集成测试守护 + 全量 preflight 绿）。

## 问题（upstream #1723）

调度热路径每次 `LastUsedAt` bump，都要对完整账号键 `sched:acc:<id>` 做 `MGET → 反序列化 → 改一个时间戳 → 重新 marshal → SET`。报告方实测完整账号 JSON 单条 3-12 KB：

```
6.5 天：total_net_input_bytes 1.88 TB，SET 占全部命令 58.6%（3.38 亿次）
sched:acc:* 是最大的 key（avg 2.5 KB，最大 12 KB）
```

多机跨公网连 Redis 时，这直接转化为带宽账单；单机部署也是无谓的 CPU/网络开销与调度延迟。**TokenKey 此前还在同一函数里额外重写了 `sched:meta:<id>` 键**，把读写放大又加重了一层。

## 修复

只读写调度热路径**实际消费**的 slim metadata 键：

- `GetSnapshot`（LRU 调度热读）只 `MGET sched:meta:<id>` 做 `LastUsedAt` tiebreak；
- 完整账号键 `sched:acc:<id>` 只在 sticky 命中后 `hydrate` 凭据转发时读取（`getSchedulableAccount` / `hydrateSelectedAccount`），**不参与 LRU 决策**。

因此 `UpdateLastUsed` 改为只对 `sched:meta:<id>` 读改写，彻底去掉完整账号键的整段读 + 写放大。单次更新载荷从 ~12 KB 降到 slim meta 量级（~1 KB）。

**安全性**：完整键 `LastUsedAt` 略微陈旧无害 —— 它会在下次快照重建（`SetSnapshot`）或任意账号变更（`SetAccount`）时随完整账号刷新；`sched:acc` 与 `sched:meta` 始终成对写入/删除且均无 TTL，meta 存在即 full 存在，不会漂移。

## 验证

- 新增集成测试 `TestSchedulerCacheUpdateLastUsedOnlyTouchesMetaKey`（真实 Postgres + Redis 容器）：
  1. `UpdateLastUsed` 后**完整账号键字节完全不变**（核心：无写放大回归）；
  2. meta 键 `LastUsedAt` 刷新为最新值（LRU 仍正确）；
  3. 完整键仍可 hydrate 完整凭据，其 `LastUsedAt` 保持旧值（契约钉死）。
- `go test -tags=integration ./internal/repository/` → 新旧两个 scheduler cache 测试均 PASS。
- `go test -tags=unit ./...` 全绿；`golangci-lint ./internal/repository/...` 0 issues。
- `scripts/preflight.sh`（含全部 sub2api 检查）PASS。

## 合规

- 纯后端调度缓存改动，commit 携带 `no-web-impact`。
- 触及 upstream-shaped 路径 `backend/internal/repository/scheduler_cache.go`，commit 携带 `upstream-touch-guarded`，并由新增回归测试守护。
- 未删除任何 upstream 符号（§5.x）；改动为现有 TK 已修改函数内的最小逻辑收敛。
- **合并方式：Squash and merge**（TK-originated fix，§5.y）。

🤖 Generated with [Claude Code](https://claude.com/claude-code)
