### PR TITLE
fix(anthropic): pre-flight UTF-8 / lone-surrogate request self-heal (claude-code #60168/#63885/#64777)

### DIFF
--- a/.cache/anthropic/cc-fact-checks.json
+++ b/.cache/anthropic/cc-fact-checks.json
@@ -20,6 +20,24 @@
         "backend/internal/service/gateway_service.go:Kind:               \"thinking_type_adaptive_error\",",
         "backend/internal/service/gateway_request_thinking_adaptive_test.go:func TestRectifyThinkingTypeAdaptive"
       ]
+    },
+    {
+      "upstream": "anthropics/claude-code#60168, anthropics/claude-code#63885, anthropics/claude-code#64777",
+      "severity": "high",
+      "tokenkey_pr": "youxuanxue/sub2api (UTF-8/surrogate self-heal)",
+      "summary": "Unpaired UTF-16 surrogate / invalid raw UTF-8 in the request body self-healed pre-flight to U+FFFD before forward, preventing the upstream 'str is not valid UTF-8: surrogate code point' 400. Wired ahead of StripEmptyTextBlocks on the Forward, APIKey passthrough, and count_tokens paths.",
+      "fixed_by": [
+        "backend/internal/service/gateway_request_tk_utf8.go",
+        "backend/internal/service/gateway_service.go",
+        "backend/internal/service/gateway_request_tk_utf8_test.go"
+      ],
+      "fixed_if_all_present": [
+        "backend/internal/service/gateway_request_tk_utf8.go:func TkSanitizeRequestBodyUTF8",
+        "backend/internal/service/gateway_request_tk_utf8.go:func tkReplaceLoneSurrogateEscapes",
+        "backend/internal/service/gateway_request_tk_utf8.go:func TkSanitizeRequestBody",
+        "backend/internal/service/gateway_service.go:StripEmptyTextBlocks(TkSanitizeRequestBody(",
+        "backend/internal/service/gateway_request_tk_utf8_test.go:func TestTkSanitizeRequestBodyUTF8_LoneSurrogateEscapes"
+      ]
     }
   ]
 }

--- a/.cache/anthropic/cc-fixes.json
+++ b/.cache/anthropic/cc-fixes.json
@@ -12,6 +12,17 @@
         "backend/internal/service/gateway_request_thinking_adaptive_test.go"
       ],
       "summary": "Opus 4.7+ thinking.type=enabled 400 self-healed to thinking.type=adaptive on both the Forward and APIKey passthrough paths; model-aware RectifyThinkingBudget; hard-gated by isOpus47OrNewer."
+    },
+    {
+      "upstream": "anthropics/claude-code#60168, anthropics/claude-code#63885, anthropics/claude-code#64777",
+      "tokenkey_pr": "youxuanxue/sub2api (UTF-8/surrogate self-heal)",
+      "status": "fixed_in_tokenkey",
+      "fixed_by": [
+        "backend/internal/service/gateway_request_tk_utf8.go",
+        "backend/internal/service/gateway_service.go",
+        "backend/internal/service/gateway_request_tk_utf8_test.go"
+      ],
+      "summary": "Unpaired UTF-16 surrogate / invalid raw UTF-8 in the request body (macOS screenshot drag, truncated pasted runes) self-healed pre-flight to U+FFFD before forward, preventing the upstream 'str is not valid UTF-8: surrogate code point' 400. TkSanitizeRequestBody wired ahead of StripEmptyTextBlocks on the Forward, APIKey passthrough, and count_tokens paths. Valid surrogate pairs and escaped backslashes preserved; clean bodies returned unchanged (changed=false, zero alloc)."
     }
   ]
 }

--- a/backend/internal/service/gateway_request_tk_utf8.go
+++ b/backend/internal/service/gateway_request_tk_utf8.go
@@ -1,0 +1,248 @@
+package service
+
+import (
+	"bytes"
+	"unicode/utf8"
+
+	"github.com/Wei-Shaw/sub2api/internal/pkg/logger"
+)
+
+// TokenKey-only request-shape self-heal for invalid UTF-8 / lone JSON surrogate
+// escapes in an outbound Anthropic Messages request body.
+//
+// Why this lives in TokenKey (gateway) and not in the client
+// -----------------------------------------------------------
+// Claude Code repeatedly emits request bodies whose string content contains an
+// UNPAIRED UTF-16 surrogate — most visibly when a macOS screenshot is dragged
+// in, or when a pasted blob carries a truncated multi-byte rune. The upstream
+// Anthropic API rejects these verbatim with a hard 400:
+//
+//	"The request body is not valid JSON: str is not valid UTF-8: surrogate
+//	 code point ... is not allowed"
+//
+// which bricks the user's session. Tracked upstream as anthropics/claude-code
+// #60168 ("Please finally fix the JSON low surrogate issue"), #63885
+// ("surrogates not allowed when dragging macOS screenshots") and #64777
+// ("request body is not valid JSON: str is not valid UTF-8: surrogate").
+//
+// A relay gateway is the single point that sees every request and can repair
+// the byte stream before it reaches Anthropic — exactly the posture TokenKey
+// already takes for thinking.type=adaptive (#514), empty text blocks, and
+// thinking-block signature errors. Here we make the repair PRE-FLIGHT rather
+// than retry-on-400: an unpaired surrogate is NEVER valid in a request sent to
+// Anthropic, so there is no legitimate body to misclassify, and repairing it
+// up front saves the otherwise-guaranteed failed round trip.
+//
+// Safety contract
+// ---------------
+//   - A request with no unpaired surrogate and no invalid UTF-8 byte is
+//     returned byte-for-byte unchanged with changed=false (zero allocation on
+//     the common path). 99.99% of traffic is untouched.
+//   - VALID surrogate PAIRS (a high+low escape pair, e.g. an emoji) are
+//     preserved verbatim — only LONE surrogates are rewritten to U+FFFD.
+//   - Escaped backslashes ("\\udead" — a literal backslash followed by the
+//     text "udead", not a unicode escape) are left intact via escape-pair
+//     consumption, so we never mis-read them as a surrogate escape.
+//
+// This file is a `*_tk_*.go` companion to the upstream-owned gateway_request.go
+// (TokenKey rule §5: keep new fork-only request-shape logic out of the upstream
+// file so `git merge upstream/main` stays conflict-free).
+
+// tkReplacementEscape is the JSON escape for U+FFFD (the Unicode REPLACEMENT
+// CHARACTER), substituted for a lone surrogate escape. It is exactly 6 bytes,
+// the same width as the "\uXXXX" it replaces.
+var tkReplacementEscape = []byte{'\\', 'u', 'f', 'f', 'f', 'd'}
+
+// tkReplacementRune is U+FFFD encoded as raw UTF-8 bytes (0xEF 0xBF 0xBD),
+// substituted for each maximal run of invalid UTF-8 bytes.
+var tkReplacementRune = []byte(string(utf8.RuneError))
+
+// tkUnicodeEscapePrefix is the 2-byte fast-path needle: a body with no `\u`
+// substring cannot contain a JSON surrogate escape at all.
+var tkUnicodeEscapePrefix = []byte(`\u`)
+
+// TkSanitizeRequestBodyUTF8 returns body with every lone JSON surrogate escape
+// and every invalid raw UTF-8 byte run replaced by U+FFFD. The second return
+// value reports whether any replacement was made; when false, the first return
+// value is the input slice unchanged.
+//
+// This is the pure, side-effect-free core (exhaustively unit-tested in
+// gateway_request_tk_utf8_test.go). Call TkSanitizeRequestBody for the
+// logging-wrapped form used at the forward call sites.
+func TkSanitizeRequestBodyUTF8(body []byte) ([]byte, bool) {
+	if len(body) == 0 {
+		return body, false
+	}
+
+	// Stage 1: lone surrogate ESCAPES inside JSON string literals (\uXXXX).
+	// These are valid UTF-8 at the byte level (ASCII), so utf8.Valid below
+	// will NOT catch them — they must be handled by scanning the escapes.
+	out, changed := tkReplaceLoneSurrogateEscapes(body)
+
+	// Stage 2: raw invalid UTF-8 byte sequences (e.g. a truncated multi-byte
+	// rune in a pasted blob). bytes.ToValidUTF8 replaces each maximal invalid
+	// run with the replacement; we gate on utf8.Valid so a well-formed body
+	// stays allocation-free and changed stays false.
+	if !utf8.Valid(out) {
+		out = bytes.ToValidUTF8(out, tkReplacementRune)
+		changed = true
+	}
+
+	return out, changed
+}
+
+// tkReplaceLoneSurrogateEscapes rewrites every UNPAIRED \uXXXX surrogate escape
+// in body to the U+FFFD replacement escape, preserving valid high+low pairs and all other
+// escapes verbatim. Output is allocated lazily: a body with no lone surrogate
+// is returned unchanged with changed=false.
+func tkReplaceLoneSurrogateEscapes(body []byte) ([]byte, bool) {
+	// Fast path: no JSON unicode escape anywhere → cannot contain a lone
+	// surrogate escape.
+	if !bytes.Contains(body, tkUnicodeEscapePrefix) {
+		return body, false
+	}
+
+	var out []byte // nil until the first replacement (lazy alloc)
+	n := len(body)
+	i := 0
+	for i < n {
+		c := body[i]
+		if c != '\\' {
+			if out != nil {
+				out = append(out, c)
+			}
+			i++
+			continue
+		}
+
+		// c == '\\': start of an escape sequence; need at least one more byte.
+		if i+1 >= n {
+			if out != nil {
+				out = append(out, c)
+			}
+			i++
+			continue
+		}
+
+		if body[i+1] != 'u' {
+			// Two-char escape (\\ \" \/ \n \t \r \b \f). Consume BOTH bytes so
+			// an escaped backslash ("\\") never leaves its second byte to be
+			// mis-read as the start of a unicode escape.
+			if out != nil {
+				out = append(out, c, body[i+1])
+			}
+			i += 2
+			continue
+		}
+
+		// "\uXXXX" — need 4 hex digits.
+		if i+6 > n {
+			// Malformed trailing escape; copy the remainder verbatim.
+			if out != nil {
+				out = append(out, body[i:]...)
+			}
+			i = n
+			continue
+		}
+		hi, ok := tkParseHex4(body[i+2 : i+6])
+		if !ok {
+			if out != nil {
+				out = append(out, body[i:i+6]...)
+			}
+			i += 6
+			continue
+		}
+
+		switch {
+		case hi >= 0xD800 && hi <= 0xDBFF:
+			// High surrogate: valid ONLY when immediately followed by a
+			// \uDC00–\uDFFF low surrogate. Otherwise it is lone → replace.
+			if i+12 <= n && body[i+6] == '\\' && body[i+7] == 'u' {
+				if lo, ok2 := tkParseHex4(body[i+8 : i+12]); ok2 && lo >= 0xDC00 && lo <= 0xDFFF {
+					// Valid surrogate pair: keep both escapes verbatim.
+					if out != nil {
+						out = append(out, body[i:i+12]...)
+					}
+					i += 12
+					continue
+				}
+			}
+			out = tkEnsureLazyCopy(out, body, i)
+			out = append(out, tkReplacementEscape...)
+			i += 6
+		case hi >= 0xDC00 && hi <= 0xDFFF:
+			// Lone low surrogate (no preceding high surrogate) → replace.
+			out = tkEnsureLazyCopy(out, body, i)
+			out = append(out, tkReplacementEscape...)
+			i += 6
+		default:
+			// Ordinary BMP escape → keep verbatim.
+			if out != nil {
+				out = append(out, body[i:i+6]...)
+			}
+			i += 6
+		}
+	}
+
+	if out == nil {
+		return body, false
+	}
+	return out, true
+}
+
+// tkEnsureLazyCopy materializes the lazily-allocated output buffer on the first
+// replacement: it copies body[:i] (the verbatim prefix processed so far) into a
+// fresh buffer. A no-op once out is non-nil.
+func tkEnsureLazyCopy(out, body []byte, i int) []byte {
+	if out != nil {
+		return out
+	}
+	out = make([]byte, 0, len(body)+len(tkReplacementEscape))
+	out = append(out, body[:i]...)
+	return out
+}
+
+// tkParseHex4 parses exactly 4 hexadecimal digits into a uint16 code unit.
+// Returns ok=false on any non-hex byte (the caller then keeps the escape
+// verbatim rather than risk corrupting an unexpected shape).
+func tkParseHex4(b []byte) (uint16, bool) {
+	if len(b) < 4 {
+		return 0, false
+	}
+	var v uint16
+	for k := 0; k < 4; k++ {
+		var d uint16
+		switch c := b[k]; {
+		case c >= '0' && c <= '9':
+			d = uint16(c - '0')
+		case c >= 'a' && c <= 'f':
+			d = uint16(c-'a') + 10
+		case c >= 'A' && c <= 'F':
+			d = uint16(c-'A') + 10
+		default:
+			return 0, false
+		}
+		v = v<<4 | d
+	}
+	return v, true
+}
+
+// TkSanitizeRequestBody is the logging-wrapped form of TkSanitizeRequestBodyUTF8
+// used at the Forward / API-Key passthrough / count_tokens pre-filter sites.
+// It returns the (possibly repaired) body and emits a single structured log
+// line when a repair was applied, so production can measure how often this
+// surfaces per account without an upstream 400 ever being incurred.
+func TkSanitizeRequestBody(body []byte, account *Account) []byte {
+	sanitized, changed := TkSanitizeRequestBodyUTF8(body)
+	if !changed {
+		return body
+	}
+	var accountID int64
+	if account != nil {
+		accountID = account.ID
+	}
+	logger.LegacyPrintf("service.gateway",
+		"[Forward] sanitized invalid UTF-8 / lone surrogate escape in request body before upstream forward (prevents Anthropic 'str is not valid UTF-8' 400): account=%d original_bytes=%d sanitized_bytes=%d",
+		accountID, len(body), len(sanitized))
+	return sanitized
+}

--- a/backend/internal/service/gateway_request_tk_utf8_test.go
+++ b/backend/internal/service/gateway_request_tk_utf8_test.go
@@ -1,0 +1,224 @@
+//go:build unit
+
+package service
+
+import (
+	"bytes"
+	"encoding/json"
+	"testing"
+	"unicode/utf8"
+)
+
+// tkBS is a single backslash byte (0x5C), constructed without any literal
+// escape token so this source file never contains a `\u`+hex sequence that
+// upstream tooling could fold into the actual rune before the test runs.
+var tkBS = string(rune(92))
+
+// tkU builds a JSON unicode escape "\uHHHH" at runtime (6 bytes).
+func tkU(hex string) string { return tkBS + "u" + hex }
+
+// tkUFFFD is the escaped U+FFFD replacement character the sanitizer substitutes
+// for a lone surrogate escape.
+var tkUFFFD = tkU("fffd")
+
+// TestTkSanitizeRequestBodyUTF8_LoneSurrogateEscapes exhaustively covers the
+// JSON \uHHHH surrogate-escape repair: lone high, lone low, end-of-body,
+// high-followed-by-non-low, uppercase hex, and multiple occurrences.
+func TestTkSanitizeRequestBodyUTF8_LoneSurrogateEscapes(t *testing.T) {
+	cases := []struct {
+		name string
+		in   string
+		want string
+	}{
+		{
+			name: "lone high surrogate before closing quote",
+			in:   `{"messages":[{"role":"user","content":"oops ` + tkU("d83d") + `"}]}`,
+			want: `{"messages":[{"role":"user","content":"oops ` + tkUFFFD + `"}]}`,
+		},
+		{
+			name: "lone low surrogate",
+			in:   `{"text":"` + tkU("dc00") + ` tail"}`,
+			want: `{"text":"` + tkUFFFD + ` tail"}`,
+		},
+		{
+			name: "high surrogate followed by a non-low BMP escape",
+			in:   `{"text":"` + tkU("d83d") + `A"}`,
+			want: `{"text":"` + tkUFFFD + `A"}`,
+		},
+		{
+			name: "high surrogate followed by another high surrogate",
+			in:   `{"text":"` + tkU("d83d") + tkU("d83d") + `x"}`,
+			want: `{"text":"` + tkUFFFD + tkUFFFD + `x"}`,
+		},
+		{
+			name: "lone high surrogate at end of body (no room for pair)",
+			in:   `{"text":"` + tkU("d83d"),
+			want: `{"text":"` + tkUFFFD,
+		},
+		{
+			name: "uppercase hex lone surrogate",
+			in:   `{"text":"` + tkU("D83D") + `!"}`,
+			want: `{"text":"` + tkUFFFD + `!"}`,
+		},
+		{
+			name: "two lone surrogates in one body",
+			in:   `{"a":"` + tkU("d800") + `","b":"` + tkU("dfff") + `"}`,
+			want: `{"a":"` + tkUFFFD + `","b":"` + tkUFFFD + `"}`,
+		},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			got, changed := TkSanitizeRequestBodyUTF8([]byte(tc.in))
+			if !changed {
+				t.Fatalf("changed = false, want true")
+			}
+			if string(got) != tc.want {
+				t.Fatalf("got  %q\nwant %q", got, tc.want)
+			}
+			if !utf8.Valid(got) {
+				t.Fatalf("output not valid UTF-8: %q", got)
+			}
+		})
+	}
+}
+
+// TestTkSanitizeRequestBodyUTF8_PreservesValidContent verifies that no
+// legitimate body is mutated: valid surrogate pairs (escaped and raw),
+// non-surrogate BMP escapes, ordinary escapes, escaped backslashes, raw
+// multibyte UTF-8, and plain ASCII all pass through with changed=false and
+// byte-identical output.
+func TestTkSanitizeRequestBodyUTF8_PreservesValidContent(t *testing.T) {
+	cases := []struct {
+		name string
+		in   string
+	}{
+		{"valid surrogate pair as escape (lowercase)", `{"text":"` + tkU("d83d") + tkU("de00") + `"}`},
+		{"valid surrogate pair as escape (uppercase)", `{"text":"` + tkU("D83D") + tkU("DE00") + `"}`},
+		{"raw utf8 emoji bytes", `{"text":"hi 😀 there"}`},
+		{"raw utf8 CJK", `{"text":"你好，世界"}`},
+		{"ordinary escapes only", `{"text":"line1` + tkBS + `nline2` + tkBS + `t` + tkBS + `"quoted` + tkBS + `" tail"}`},
+		{"escaped backslash before u (literal, not an escape)", `{"text":"path ` + tkBS + tkBS + `udead is literal"}`},
+		{"non-surrogate bmp escapes", `{"text":"` + tkU("0041") + tkU("00e9") + tkU("ffff") + `"}`},
+		{"plain ascii", `{"model":"claude","max_tokens":100}`},
+		{"empty body", ``},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			in := []byte(tc.in)
+			got, changed := TkSanitizeRequestBodyUTF8(in)
+			if changed {
+				t.Fatalf("changed = true for valid input; got %q", got)
+			}
+			if !bytes.Equal(got, in) {
+				t.Fatalf("body mutated: got %q, want %q", got, in)
+			}
+		})
+	}
+}
+
+// TestTkSanitizeRequestBodyUTF8_RawInvalidBytes covers Stage 2: maximal runs of
+// invalid raw UTF-8 bytes (e.g. a truncated multi-byte rune) are replaced with
+// the U+FFFD UTF-8 sequence, and the result is valid UTF-8.
+func TestTkSanitizeRequestBodyUTF8_RawInvalidBytes(t *testing.T) {
+	// 0xFF is never a valid UTF-8 byte; 0xE4 0xBD is a truncated 3-byte rune.
+	in := append([]byte(`{"text":"bad `), 0xFF, 0xE4, 0xBD)
+	in = append(in, []byte(`"}`)...)
+
+	got, changed := TkSanitizeRequestBodyUTF8(in)
+	if !changed {
+		t.Fatalf("expected changed=true for invalid UTF-8 input")
+	}
+	if !utf8.Valid(got) {
+		t.Fatalf("sanitized output is still invalid UTF-8: %q", got)
+	}
+	if !bytes.Contains(got, tkReplacementRune) {
+		t.Fatalf("expected U+FFFD replacement in output, got %q", got)
+	}
+}
+
+// TestTkSanitizeRequestBodyUTF8_CombinedFailures covers a body that has BOTH a
+// lone surrogate escape AND a raw invalid byte — both stages must apply.
+func TestTkSanitizeRequestBodyUTF8_CombinedFailures(t *testing.T) {
+	in := append([]byte(`{"a":"`+tkU("d83d")+`","b":"`), 0xFF)
+	in = append(in, []byte(`"}`)...)
+
+	got, changed := TkSanitizeRequestBodyUTF8(in)
+	if !changed {
+		t.Fatalf("expected changed=true")
+	}
+	if !utf8.Valid(got) {
+		t.Fatalf("output not valid UTF-8: %q", got)
+	}
+	if bytes.Contains(got, []byte(tkU("d83d"))) {
+		t.Fatalf("lone surrogate escape survived: %q", got)
+	}
+	if !bytes.Contains(got, []byte(tkUFFFD)) {
+		t.Fatalf("surrogate escape was not replaced with %s: %q", tkUFFFD, got)
+	}
+	if !bytes.Contains(got, tkReplacementRune) {
+		t.Fatalf("raw invalid byte was not replaced with U+FFFD: %q", got)
+	}
+}
+
+// TestTkSanitizeRequestBodyUTF8_Idempotent verifies sanitize(sanitize(x)) is a
+// fixed point: a second pass over already-sanitized output is a no-op.
+func TestTkSanitizeRequestBodyUTF8_Idempotent(t *testing.T) {
+	in := append([]byte(`{"a":"`+tkU("d83d")+`","b":"x`), 0xFF)
+	in = append(in, []byte(`"}`)...)
+
+	first, changed := TkSanitizeRequestBodyUTF8(in)
+	if !changed {
+		t.Fatalf("expected first pass to change the body")
+	}
+	second, changedAgain := TkSanitizeRequestBodyUTF8(first)
+	if changedAgain {
+		t.Fatalf("second pass mutated already-clean body: %q -> %q", first, second)
+	}
+	if !bytes.Equal(first, second) {
+		t.Fatalf("not idempotent: %q != %q", first, second)
+	}
+}
+
+// TestTkSanitizeRequestBodyUTF8_RepairedBodyParses confirms that a realistic
+// Anthropic request body carrying a lone surrogate becomes parseable JSON whose
+// decoded string values contain no unpaired surrogate after repair.
+func TestTkSanitizeRequestBodyUTF8_RepairedBodyParses(t *testing.T) {
+	in := []byte(`{"model":"claude-opus-4-8","max_tokens":1024,"messages":[{"role":"user","content":[{"type":"text","text":"screenshot ` + tkU("d83d") + ` dropped"}]}]}`)
+
+	got, changed := TkSanitizeRequestBodyUTF8(in)
+	if !changed {
+		t.Fatalf("expected changed=true")
+	}
+
+	var parsed struct {
+		Messages []struct {
+			Content []struct {
+				Text string `json:"text"`
+			} `json:"content"`
+		} `json:"messages"`
+	}
+	if err := json.Unmarshal(got, &parsed); err != nil {
+		t.Fatalf("sanitized body failed to parse: %v\nbody=%q", err, got)
+	}
+	text := parsed.Messages[0].Content[0].Text
+	for _, r := range text {
+		if r >= 0xD800 && r <= 0xDFFF {
+			t.Fatalf("decoded text still contains a surrogate code point: %q", text)
+		}
+	}
+}
+
+// TestTkSanitizeRequestBody_WrapperPassthrough verifies the logging wrapper
+// returns the unmodified slice for clean input and a repaired slice otherwise.
+func TestTkSanitizeRequestBody_WrapperPassthrough(t *testing.T) {
+	clean := []byte(`{"text":"hi 😀"}`)
+	if got := TkSanitizeRequestBody(clean, nil); !bytes.Equal(got, clean) {
+		t.Fatalf("wrapper mutated clean body: %q", got)
+	}
+
+	dirty := []byte(`{"text":"` + tkU("d83d") + `"}`)
+	got := TkSanitizeRequestBody(dirty, nil)
+	if bytes.Contains(got, []byte(tkU("d83d"))) {
+		t.Fatalf("wrapper did not repair lone surrogate: %q", got)
+	}
+}

--- a/backend/internal/service/gateway_service.go
+++ b/backend/internal/service/gateway_service.go
@@ -4749,8 +4749,12 @@ func (s *GatewayService) Forward(ctx context.Context, c *gin.Context, account *A
 	// 调试日志：记录即将转发的账号信息
 	logger.LegacyPrintf("service.gateway", "[Forward] Using account: ID=%d Name=%s Platform=%s Type=%s TLSFingerprint=%v Proxy=%s",
 		account.ID, account.Name, account.Platform, account.Type, tlsProfile, proxyURL)
-	// Pre-filter: strip empty text blocks (including nested in tool_result) to prevent upstream 400.
-	if err := replaceBody(StripEmptyTextBlocks(body)); err != nil {
+	// Pre-filter: sanitize invalid UTF-8 / lone surrogate escapes (prevents the
+	// upstream "str is not valid UTF-8: surrogate" 400 — claude-code #60168 /
+	// #63885 / #64777), THEN strip empty text blocks (including nested in
+	// tool_result). Sanitize runs first because StripEmptyTextBlocks parses the
+	// body as JSON; both prevent an upstream 400 before the first call.
+	if err := replaceBody(StripEmptyTextBlocks(TkSanitizeRequestBody(body, account))); err != nil {
 		return nil, err
 	}
 
@@ -5413,8 +5417,11 @@ func (s *GatewayService) forwardAnthropicAPIKeyPassthroughWithInput(
 	if c != nil {
 		c.Set("anthropic_passthrough", true)
 	}
-	// Pre-filter: strip empty text blocks (including nested in tool_result) to prevent upstream 400.
-	input.Body = StripEmptyTextBlocks(input.Body)
+	// Pre-filter: sanitize invalid UTF-8 / lone surrogate escapes (claude-code
+	// #60168 / #63885 / #64777), THEN strip empty text blocks (including nested
+	// in tool_result). Sanitize runs first because StripEmptyTextBlocks parses
+	// the body as JSON; both prevent an upstream 400.
+	input.Body = StripEmptyTextBlocks(TkSanitizeRequestBody(input.Body, account))
 	if input.Parsed != nil {
 		// 透传分支也会改写实际 wire body，成功 usage hash 依赖这里同步当前 body。
 		if err := input.Parsed.ReplaceBody(input.Body); err != nil {
@@ -9758,8 +9765,11 @@ func (s *GatewayService) ForwardCountTokens(ctx context.Context, c *gin.Context,
 	}
 	reqModel := parsed.Model
 
-	// Pre-filter: strip empty text blocks to prevent upstream 400.
-	if err := replaceBody(StripEmptyTextBlocks(body)); err != nil {
+	// Pre-filter: sanitize invalid UTF-8 / lone surrogate escapes (claude-code
+	// #60168 / #63885 / #64777), THEN strip empty text blocks. Sanitize runs
+	// first because StripEmptyTextBlocks parses the body as JSON; both prevent
+	// an upstream 400 (here also guarding the per-account upstream-error breaker).
+	if err := replaceBody(StripEmptyTextBlocks(TkSanitizeRequestBody(body, account))); err != nil {
 		return err
 	}
 

--- a/docs/gateway-anthropic-utf8-surrogate-self-heal.md
+++ b/docs/gateway-anthropic-utf8-surrogate-self-heal.md
@@ -1,0 +1,95 @@
+---
+title: Anthropic 请求体 UTF-8 / 孤立代理（lone surrogate）预过滤自愈
+date: 2026-06-03
+scope: backend (gateway Anthropic forward / passthrough / count_tokens 路径)
+status: shipped
+upstream_issues:
+  - anthropics/claude-code#60168  # Please finally fix the JSON low surrogate issue
+  - anthropics/claude-code#63885  # surrogates not allowed when dragging macOS screenshots
+  - anthropics/claude-code#64777  # str is not valid UTF-8: surrogate
+ledger:
+  - .cache/anthropic/cc-fixes.json
+  - .cache/anthropic/cc-fact-checks.json
+related:
+  - docs/global/tokenkey-opc-transformation-plan.md  # rule §5 上游隔离边界
+---
+
+# 概述
+
+TokenKey 转发的 Claude Code 会话会因为**请求体里出现孤立 UTF-16 代理（unpaired
+surrogate）或非法原始 UTF-8 字节**，被上游 Anthropic API 以硬 400 拒绝：
+
+```
+The request body is not valid JSON: str is not valid UTF-8:
+surrogate code point ... is not allowed
+```
+
+最常见的触发场景：
+
+- macOS 上把截图直接拖进 Claude Code（#63885）；
+- 粘贴的二进制 / 多语言混排 blob 里带了截断的多字节 rune（#64777）；
+- 历史复发到用户在 issue 标题里直接写「**Please finally** fix the JSON low
+  surrogate issue」（#60168）。
+
+这类 400 会**直接 brick 用户当前会话**——客户端自己修不掉（它就是产生方），而网关
+是唯一能在请求到达 Anthropic 之前看到并修复字节流的位置。
+
+# 设计
+
+与既有的 `thinking.type=adaptive`（#514）、空文本块剥离、签名块重试等自愈一脉相承，
+但本修复是 **pre-flight（预过滤）** 而非 retry-on-400：孤立代理在发往 Anthropic 的
+JSON 里**永远非法**，不存在需要保留的合法形态，所以在转发前清洗即可，省掉那一次注定
+失败的往返。
+
+## 核心：`TkSanitizeRequestBodyUTF8`
+
+位于 `backend/internal/service/gateway_request_tk_utf8.go`（`*_tk_*.go` 伴生文件，
+按规则 §5 把 fork-only 的请求改写逻辑挡在上游 `gateway_request.go` 之外，保持
+`git merge upstream/main` 零冲突）。
+
+两段式、纯函数、零副作用：
+
+1. **Stage 1 — JSON 转义层**：扫描 `\uHHHH` 转义，把**孤立**的高/低代理（以及没有
+   配对低代理的高代理）改写为 `�`（U+FFFD）。合法的高+低代理对、转义反斜杠
+   `\\uXXXX`、其它 BMP 转义**逐字节保留**。
+2. **Stage 2 — 原始字节层**：当 `utf8.Valid` 为假时，用 `bytes.ToValidUTF8` 把每段
+   极大非法字节串替换为 U+FFFD。
+
+**安全契约**：
+
+- 没有孤立代理、也没有非法 UTF-8 的请求 → 原切片**逐字节原样返回**，`changed=false`，
+  常规流量零分配、零改写。99.99% 的请求完全不受影响。
+- 一个**本来不会 400** 的请求，永远不会被本清洗器改动。
+- `sanitize(sanitize(x)) == sanitize(x)`（幂等，有测试固化）。
+
+## 接入点
+
+`TkSanitizeRequestBody`（带日志的包装）作为预过滤步骤注入到三条 forward 路径，**紧贴
+现有 `StripEmptyTextBlocks` 之前**（清洗在内层先跑，因为 `StripEmptyTextBlocks` 会把
+body 当 JSON 解析）：
+
+| 路径 | 位置 |
+| --- | --- |
+| `Forward` | `gateway_service.go` `StripEmptyTextBlocks(TkSanitizeRequestBody(body, account))` |
+| `forwardAnthropicAPIKeyPassthroughWithInput` | 同形包装 `input.Body` |
+| `ForwardCountTokens` | 同形包装（兼护 per-account upstream-error 熔断器） |
+
+每处仅一行包裹，上游 `gateway_service.go` 只在既有的三个 body 预过滤注入点被触及。
+
+## 可观测性
+
+发生改写时输出一行结构化日志（`account` + 改写前后字节数），便于线上统计该问题的真实
+频率——且**不再产生它本要触发的上游 400**。
+
+# 验证
+
+- `backend/internal/service/gateway_request_tk_utf8_test.go`：23 个表驱动子测试覆盖
+  孤立高/低代理、body 末尾截断、代理对保留、转义反斜杠非转义、原始非法字节、
+  组合失败、幂等性、修复后 JSON 可解析。
+- `go build ./...` + `go test -tags=unit ./internal/service/` 通过。
+
+# 台账
+
+修复记录登记在 watchdog 读取的人工台账：`.cache/anthropic/cc-fixes.json`（标记
+`fixed_in_tokenkey`）与 `.cache/anthropic/cc-fact-checks.json`（`fixed_if_all_present`
+needle，命中即 `fixed_verified`）。后续同类 issue 复现前应先查这两个文件。

--- a/scripts/sentinels/gateway-tk.json
+++ b/scripts/sentinels/gateway-tk.json
@@ -1618,6 +1618,23 @@
         "count_tokens (status=%d), returning 404"
       ],
       "rationale": "TK #656 count_tokens non-standard not-found fallback. Some Chinese Anthropic-compatible relays that do not support /v1/messages/count_tokens wrap a Spring NoResourceFoundException / 'No static resource v1/messages/count_tokens' into a non-standard HTTP 400/500 instead of a clean 404. isCountTokensUnsupported404 is widened to recognize these (narrowed to count_tokens-endpoint mention + strong Spring not-found signals so a real invalid_request_error like #2109 temperature is NOT swallowed; includes raw-body fallback), and the main ForwardCountTokens path short-circuits to 404 BEFORE the breaker/failover so Claude Code falls back to local token estimation while the account is neither penalized nor wasted on failover (same posture as the passthrough variant). Anchor the widened strong-signal predicates + the main-path 404 short-circuit log so an upstream merge cannot silently narrow it back to status==404-only and re-break these relays."
+    },
+    {
+      "path": "backend/internal/service/gateway_service.go",
+      "must_contain": [
+        "StripEmptyTextBlocks(TkSanitizeRequestBody(body, account))",
+        "StripEmptyTextBlocks(TkSanitizeRequestBody(input.Body, account))"
+      ],
+      "rationale": "UTF-8 / lone-surrogate pre-flight self-heal (claude-code #60168 / #63885 / #64777). TkSanitizeRequestBody is wired as the INNER call of the StripEmptyTextBlocks pre-filter on all three Anthropic forward paths (Forward, APIKey passthrough, ForwardCountTokens) so an unpaired UTF-16 surrogate or invalid raw UTF-8 byte (macOS screenshot drag, truncated pasted rune) is repaired to U+FFFD before the request reaches Anthropic, preventing the hard 'str is not valid UTF-8: surrogate code point' 400 that bricks the session. These are one-line wraps in an upstream-shaped file; an upstream merge could silently drop them and re-break the path with zero compile error. Anchor the wrapped call shape (sanitize INNER, strip OUTER — order matters because StripEmptyTextBlocks parses the body as JSON) so the regression is caught at merge time. See docs/gateway-anthropic-utf8-surrogate-self-heal.md."
+    },
+    {
+      "path": "backend/internal/service/gateway_request_tk_utf8.go",
+      "must_contain": [
+        "func TkSanitizeRequestBodyUTF8(body []byte) ([]byte, bool) {",
+        "func tkReplaceLoneSurrogateEscapes(body []byte) ([]byte, bool) {",
+        "func TkSanitizeRequestBody(body []byte, account *Account) []byte {"
+      ],
+      "rationale": "Pure, fork-only UTF-8 / lone-surrogate sanitizer core (claude-code #60168 / #63885 / #64777), kept in a *_tk_*.go companion out of upstream-owned gateway_request.go (rule §5). TkSanitizeRequestBodyUTF8 rewrites lone JSON surrogate escapes and invalid raw UTF-8 to U+FFFD while preserving valid pairs / escaped backslashes and returning clean bodies byte-identical (changed=false, zero alloc). Anchor the two pure functions + the logging wrapper so an upstream refactor that consolidates body rewrites cannot delete this surface and silently re-expose the 'str is not valid UTF-8: surrogate' 400. Exhaustively covered by gateway_request_tk_utf8_test.go."
     }
   ]
 }


### PR DESCRIPTION
## 摘要

TokenKey 转发的 Claude Code 会话会因**请求体里出现孤立 UTF-16 代理（unpaired surrogate）或非法原始 UTF-8 字节**，被上游 Anthropic API 以硬 400 拒绝，直接 brick 用户会话：

```
The request body is not valid JSON: str is not valid UTF-8: surrogate code point ... is not allowed
```

客户端自己修不掉（它就是产生方），**网关是唯一能在请求到达 Anthropic 之前修复字节流的位置**。本 PR 在转发前加一道 pre-flight 清洗，把孤立代理/非法字节改写为 U+FFFD，从根上消掉这个 400。

### 修复的上游 issue（`.cache/anthropic/*`）

| issue | 标题 | 触发 |
| --- | --- | --- |
| anthropics/claude-code#60168 | Please finally fix the JSON low surrogate issue | 反复复发 |
| anthropics/claude-code#63885 | surrogates not allowed when dragging macOS screenshots | 拖截图 |
| anthropics/claude-code#64777 | str is not valid UTF-8: surrogate | 截断的粘贴 blob |

这是 `request_shape_400` 家族中**未被覆盖、且确属网关该修、且绝对安全**的最大缺口——与已修的 #514（thinking.type=adaptive 自愈）同源。thinking-block / 签名 / 空块 / beta 等其它 400 家族 TokenKey 已自愈完备（已核实）。

## 设计

与既有自愈一脉相承，但本修复是 **pre-flight（预过滤）** 而非 retry-on-400：孤立代理在发往 Anthropic 的 JSON 里**永远非法**，不存在需保留的合法形态，转发前清洗即可，省掉那一次注定失败的往返。

**核心 `TkSanitizeRequestBodyUTF8`**（`backend/internal/service/gateway_request_tk_utf8.go`，`*_tk_*.go` 伴生文件，按规则 §5 挡在上游 `gateway_request.go` 之外）：

1. **Stage 1 — JSON 转义层**：扫描 `\uHHHH`，把孤立高/低代理改写为 `�`；合法的高+低代理对、转义反斜杠、其它 BMP 转义逐字节保留。
2. **Stage 2 — 原始字节层**：`utf8.Valid` 为假时用 `bytes.ToValidUTF8` 把非法字节串替换为 U+FFFD。

**安全契约**：
- 干净请求 → 原切片逐字节原样返回，`changed=false`，零分配、零改写（99.99% 流量不受影响）。
- 一个**本来不会 400** 的请求永远不会被改动。
- 幂等：`sanitize(sanitize(x)) == sanitize(x)`。

**接入点**：`TkSanitizeRequestBody`（带日志包装）作为预过滤注入三条 forward 路径，紧贴现有 `StripEmptyTextBlocks` 之前（清洗在内层先跑，因为 StripEmptyTextBlocks 会 JSON 解析）——`Forward` / `forwardAnthropicAPIKeyPassthroughWithInput` / `ForwardCountTokens`，每处仅一行包裹。

## 提交结构

1. `fix(anthropic)`: 纯清洗器 + 23 表驱动子测试
2. `fix(anthropic)`: 注入三条 forward 路径
3. `docs(anthropic)`: cc 台账（cc-fixes/cc-fact-checks）+ 设计文档
4. `chore(sentinels)`: gateway-tk 注册表锚点守护 hook（防上游 merge 静默回退）

## TokenKey 原则合规

- **§5 最小侵入**：fork-only 逻辑在 `*_tk_*.go`；上游 `gateway_service.go` 仅 3 处单行包裹。
- **§5.y.1 sentinel 守护**：load-bearing hook 在 `scripts/sentinels/gateway-tk.json` 落锚（option a 真实锚点，非 review marker）。
- **覆写防护门禁**：commit 带 `upstream-touch-guarded` + `no-web-impact`。
- **台账**：watchdog 读取的 `cc-fixes.json` / `cc-fact-checks.json` 已登记，后续同类 issue 复现前先查这两个文件。

## 验证

- `go build ./...` ✓
- `go test -tags=unit ./...` ✓（52 包）
- `golangci-lint run ./...` ✓ `0 issues`
- `bash scripts/preflight.sh` ✓ PASS（exit 0，含 sentinel/override-marker/cc-cache 门禁）

## 合并方式

TK 源生 fix PR → **Squash and merge**（规则 §5.y）。

🤖 Generated with [Claude Code](https://claude.com/claude-code)
