### PR TITLE
feat(ops): per-pool concurrency mirror for edge stubs (anthropic vs kiro)

### DIFF
--- a/backend/internal/handler/edge_tk_capacity_handler.go
+++ b/backend/internal/handler/edge_tk_capacity_handler.go
@@ -16,6 +16,7 @@ import (
 // the handler unit-testable without stubbing the whole repository surface.
 type schedulingCapacityReader interface {
 	SumConcurrencyAnthropicByGroup(ctx context.Context, groupName string) (int64, error)
+	SumConcurrencyByPlatform(ctx context.Context, platform string) (int64, error)
 }
 
 // anthropicDefaultGroupName is the group whose schedulable anthropic concurrency
@@ -63,10 +64,14 @@ type edgeCapacityResponse struct {
 
 // GetSchedulingCapacity handles GET /api/v1/edge/scheduling-capacity.
 //
-// Only platform=anthropic is supported today (the only fleet surface whose prod
-// stub concurrency must mirror a live edge). An unsupported / missing platform
-// is rejected rather than silently defaulting, so a prod misconfig surfaces
-// loudly instead of writing a wrong number.
+// platform selects which edge pool's live Σ schedulable concurrency to report,
+// mirroring the prod stub's credentials.mirror_platform:
+//   - anthropic: the operator-curated "default" group (see anthropicDefaultGroupName).
+//   - kiro: all schedulable kiro accounts (the edge is single-pool-per-platform for
+//     kiro, so no group scoping — counting every kiro row IS the live pool).
+//
+// An unsupported / missing platform is rejected rather than silently defaulting,
+// so a prod misconfig surfaces loudly instead of writing a wrong number.
 func (h *EdgeCapacityHandler) GetSchedulingCapacity(c *gin.Context) {
 	if h == nil || h.accounts == nil {
 		response.Error(c, http.StatusInternalServerError, "edge capacity handler unavailable")
@@ -74,12 +79,21 @@ func (h *EdgeCapacityHandler) GetSchedulingCapacity(c *gin.Context) {
 	}
 
 	platform := strings.ToLower(strings.TrimSpace(c.DefaultQuery("platform", "anthropic")))
-	if platform != "anthropic" {
-		response.Error(c, http.StatusBadRequest, "unsupported platform (only anthropic)")
+	ctx := c.Request.Context()
+
+	var (
+		total int64
+		err   error
+	)
+	switch platform {
+	case "anthropic":
+		total, err = h.accounts.SumConcurrencyAnthropicByGroup(ctx, anthropicDefaultGroupName)
+	case "kiro":
+		total, err = h.accounts.SumConcurrencyByPlatform(ctx, "kiro")
+	default:
+		response.Error(c, http.StatusBadRequest, "unsupported platform (only anthropic, kiro)")
 		return
 	}
-
-	total, err := h.accounts.SumConcurrencyAnthropicByGroup(c.Request.Context(), anthropicDefaultGroupName)
 	if err != nil {
 		response.Error(c, http.StatusInternalServerError, "failed to read scheduling capacity")
 		return

--- a/backend/internal/handler/edge_tk_capacity_handler_test.go
+++ b/backend/internal/handler/edge_tk_capacity_handler_test.go
@@ -15,14 +15,21 @@ import (
 )
 
 type capacityReaderStub struct {
-	sum       int64
-	err       error
-	lastGroup string
+	sum          int64
+	platformSum  int64
+	err          error
+	lastGroup    string
+	lastPlatform string
 }
 
 func (s *capacityReaderStub) SumConcurrencyAnthropicByGroup(_ context.Context, groupName string) (int64, error) {
 	s.lastGroup = groupName
 	return s.sum, s.err
+}
+
+func (s *capacityReaderStub) SumConcurrencyByPlatform(_ context.Context, platform string) (int64, error) {
+	s.lastPlatform = platform
+	return s.platformSum, s.err
 }
 
 func performCapacityRequest(t *testing.T, h *EdgeCapacityHandler, query string) *httptest.ResponseRecorder {
@@ -67,6 +74,30 @@ func TestEdgeCapacityHandler_RejectsUnsupportedPlatform(t *testing.T) {
 	h := NewEdgeCapacityHandler(&capacityReaderStub{sum: 7})
 	w := performCapacityRequest(t, h, "?platform=openai")
 	require.Equal(t, http.StatusBadRequest, w.Code)
+}
+
+func TestEdgeCapacityHandler_KiroUsesPlatformWideSum(t *testing.T) {
+	// kiro mirrors the edge's whole schedulable kiro pool (no "default"-group
+	// scoping), so it must read SumConcurrencyByPlatform("kiro"), never the
+	// anthropic-group sum that would (wrongly) hand the kiro stub the anthropic
+	// number — the bug this fix closes.
+	stub := &capacityReaderStub{sum: 22, platformSum: 6}
+	h := NewEdgeCapacityHandler(stub)
+	w := performCapacityRequest(t, h, "?platform=kiro")
+	require.Equal(t, http.StatusOK, w.Code)
+
+	var env struct {
+		Data struct {
+			Platform         string `json:"platform"`
+			TotalConcurrency int64  `json:"total_concurrency"`
+		} `json:"data"`
+	}
+	require.NoError(t, json.Unmarshal(w.Body.Bytes(), &env))
+	require.Equal(t, "kiro", env.Data.Platform)
+	require.Equal(t, int64(6), env.Data.TotalConcurrency)
+	require.Equal(t, "kiro", stub.lastPlatform)
+	// The anthropic-group path must NOT have been taken for a kiro request.
+	require.Empty(t, stub.lastGroup)
 }
 
 func TestEdgeCapacityHandler_RepoErrorIs500(t *testing.T) {

--- a/backend/internal/repository/account_repo.go
+++ b/backend/internal/repository/account_repo.go
@@ -188,6 +188,26 @@ WHERE a.platform = $1 AND a.schedulable = true AND a.deleted_at IS NULL
 	return sum.Int64, nil
 }
 
+// SumConcurrencyByPlatform returns Σ concurrency for schedulable accounts of the
+// given platform across all groups (no group join). Surface-C uses this for
+// non-anthropic edge pools (e.g. kiro), where every schedulable account of that
+// platform IS the operator pool, so the anthropic "default"-group scoping
+// (SumConcurrencyAnthropicByGroup) does not apply.
+func (r *accountRepository) SumConcurrencyByPlatform(ctx context.Context, platform string) (int64, error) {
+	const q = `
+SELECT COALESCE(SUM(concurrency), 0)::bigint
+FROM accounts
+WHERE platform = $1 AND schedulable = true AND deleted_at IS NULL`
+	var sum sql.NullInt64
+	if err := scanSingleRow(ctx, r.sql, q, []any{platform}, &sum); err != nil {
+		return 0, fmt.Errorf("sum concurrency by platform %q: %w", platform, err)
+	}
+	if !sum.Valid {
+		return 0, nil
+	}
+	return sum.Int64, nil
+}
+
 func (r *accountRepository) GetByID(ctx context.Context, id int64) (*service.Account, error) {
 	m, err := r.client.Account.Query().Where(dbaccount.IDEQ(id)).Only(ctx)
 	if err != nil {

--- a/backend/internal/server/api_contract_test.go
+++ b/backend/internal/server/api_contract_test.go
@@ -1823,6 +1823,10 @@ func (s *stubAccountRepo) SumConcurrencyAnthropicByGroup(context.Context, string
 	return 0, nil
 }
 
+func (s *stubAccountRepo) SumConcurrencyByPlatform(context.Context, string) (int64, error) {
+	return 0, nil
+}
+
 func (s *stubAccountRepo) ListCRSAccountIDs(ctx context.Context) (map[string]int64, error) {
 	return nil, errors.New("not implemented")
 }

--- a/backend/internal/service/account_service.go
+++ b/backend/internal/service/account_service.go
@@ -77,6 +77,11 @@ type AccountRepository interface {
 	// SumConcurrencyAnthropicByGroup returns Σ concurrency for schedulable anthropic
 	// accounts in the named group (surface-C: edge capacity counts only the default group).
 	SumConcurrencyAnthropicByGroup(ctx context.Context, groupName string) (int64, error)
+	// SumConcurrencyByPlatform returns Σ concurrency for schedulable accounts of the
+	// given platform across all groups (surface-C: edge capacity for non-anthropic
+	// pools — e.g. kiro — where the edge is single-pool-per-platform and the
+	// anthropic "default"-group scoping does not apply).
+	SumConcurrencyByPlatform(ctx context.Context, platform string) (int64, error)
 	// IncrementQuotaUsed 原子递增 API Key 账号的配额用量（总/日/周）
 	IncrementQuotaUsed(ctx context.Context, id int64, amount float64) error
 	// ResetQuotaUsed 重置 API Key 账号所有维度的配额用量为 0

--- a/backend/internal/service/account_service_delete_test.go
+++ b/backend/internal/service/account_service_delete_test.go
@@ -215,6 +215,10 @@ func (s *accountRepoStub) SumConcurrencyAnthropicByGroup(context.Context, string
 	return 0, nil
 }
 
+func (s *accountRepoStub) SumConcurrencyByPlatform(context.Context, string) (int64, error) {
+	return 0, nil
+}
+
 // TestAccountService_Delete_NotFound 测试删除不存在的账号时返回正确的错误。
 // 预期行为：
 //   - ExistsByID 返回 false（账号不存在）

--- a/backend/internal/service/admin_service_bulk_update_test.go
+++ b/backend/internal/service/admin_service_bulk_update_test.go
@@ -268,6 +268,13 @@ func (s *bulkAccountRepoAnthropicSum) SumConcurrencyAnthropicByGroup(context.Con
 	return s.anthropicConcurrencySum, nil
 }
 
+func (s *bulkAccountRepoAnthropicSum) SumConcurrencyByPlatform(context.Context, string) (int64, error) {
+	if s.anthropicConcurrencyErr != nil {
+		return 0, s.anthropicConcurrencyErr
+	}
+	return s.anthropicConcurrencySum, nil
+}
+
 // TestBulkUpdateAccounts_SyncAnthropicOperatorConcurrency 验证 userRepo 齐备时，
 // 批量成功后会把管理员用户（users.id=AnthropicOperatorConcurrencyUserID）的并发写成 Σ anthropic accounts。
 func TestBulkUpdateAccounts_SyncAnthropicOperatorConcurrency(t *testing.T) {

--- a/backend/internal/service/anthropic_config_reconciler.go
+++ b/backend/internal/service/anthropic_config_reconciler.go
@@ -22,6 +22,7 @@ import (
 	"log/slog"
 	"math"
 	"net/http"
+	"net/url"
 	"strings"
 	"sync"
 	"time"
@@ -389,7 +390,12 @@ func (r *AnthropicConfigReconciler) reconcileConcurrencyMirror(ctx context.Conte
 		if baseURL == "" || apiKey == "" {
 			continue
 		}
-		total, ok := r.fetchEdgeCapacity(ctx, baseURL, apiKey)
+		// A mirror stub's transport platform is always anthropic-apikey, but the
+		// edge pool it represents (its capacity source) may differ — kiro rides the
+		// same relay shape. credentials.mirror_platform declares which edge pool to
+		// mirror; absent → anthropic (back-compat: every existing stub stays correct).
+		platform := mirrorCapacityPlatform(a.GetCredential("mirror_platform"))
+		total, ok := r.fetchEdgeCapacity(ctx, baseURL, apiKey, platform)
 		if !ok {
 			// Hard rule: failure/timeout/5xx/<1 → skip, never write 0.
 			continue
@@ -408,13 +414,27 @@ func (r *AnthropicConfigReconciler) reconcileConcurrencyMirror(ctx context.Conte
 	}
 }
 
-// fetchEdgeCapacity GETs {base_url}/api/v1/edge/scheduling-capacity?platform=anthropic
+// mirrorCapacityPlatform normalizes a stub's credentials.mirror_platform into the
+// edge capacity platform query value. Empty/unknown → "anthropic" (the historical
+// default — every pre-existing mirror stub keeps mirroring the anthropic pool).
+// An unknown value still degrades to anthropic here; the edge endpoint is the
+// authoritative validator and rejects anything it does not support.
+func mirrorCapacityPlatform(raw string) string {
+	switch strings.ToLower(strings.TrimSpace(raw)) {
+	case "kiro":
+		return "kiro"
+	default:
+		return "anthropic"
+	}
+}
+
+// fetchEdgeCapacity GETs {base_url}/api/v1/edge/scheduling-capacity?platform={platform}
 // with x-api-key auth. Returns (total, true) only on a 2xx with total_concurrency >= 1.
-func (r *AnthropicConfigReconciler) fetchEdgeCapacity(ctx context.Context, baseURL, apiKey string) (int, bool) {
+func (r *AnthropicConfigReconciler) fetchEdgeCapacity(ctx context.Context, baseURL, apiKey, platform string) (int, bool) {
 	if r.http == nil {
 		return 0, false
 	}
-	endpoint := strings.TrimRight(baseURL, "/") + "/api/v1/edge/scheduling-capacity?platform=anthropic"
+	endpoint := strings.TrimRight(baseURL, "/") + "/api/v1/edge/scheduling-capacity?platform=" + url.QueryEscape(platform)
 	reqCtx, cancel := context.WithTimeout(ctx, anthropicReconcilerHTTPTO)
 	defer cancel()
 	req, err := http.NewRequestWithContext(reqCtx, http.MethodGet, endpoint, nil)

--- a/backend/internal/service/anthropic_config_reconciler.go
+++ b/backend/internal/service/anthropic_config_reconciler.go
@@ -415,17 +415,20 @@ func (r *AnthropicConfigReconciler) reconcileConcurrencyMirror(ctx context.Conte
 }
 
 // mirrorCapacityPlatform normalizes a stub's credentials.mirror_platform into the
-// edge capacity platform query value. Empty/unknown → "anthropic" (the historical
-// default — every pre-existing mirror stub keeps mirroring the anthropic pool).
-// An unknown value still degrades to anthropic here; the edge endpoint is the
-// authoritative validator and rejects anything it does not support.
+// edge capacity platform query value. ONLY empty/whitespace maps to "anthropic"
+// (the historical default — every pre-existing mirror stub keeps mirroring the
+// anthropic pool). A non-empty value is passed through verbatim (lower/trimmed)
+// rather than coerced to a known platform: the edge endpoint is the authoritative
+// validator and rejects anything it does not support, so an unknown/typo'd value
+// (e.g. "openai", "kir0") makes fetchEdgeCapacity see a 4xx and skip — never write
+// 0, never silently mirror the wrong pool. Coercing unknowns to "anthropic" here
+// would reintroduce the exact silent-wrong-pool bug this surface exists to kill.
 func mirrorCapacityPlatform(raw string) string {
-	switch strings.ToLower(strings.TrimSpace(raw)) {
-	case "kiro":
-		return "kiro"
-	default:
+	p := strings.ToLower(strings.TrimSpace(raw))
+	if p == "" {
 		return "anthropic"
 	}
+	return p
 }
 
 // fetchEdgeCapacity GETs {base_url}/api/v1/edge/scheduling-capacity?platform={platform}

--- a/backend/internal/service/anthropic_config_reconciler_test.go
+++ b/backend/internal/service/anthropic_config_reconciler_test.go
@@ -51,6 +51,13 @@ func (s *reconcilerAccountStub) SumConcurrencyAnthropicByGroup(context.Context, 
 	return s.sum, nil
 }
 
+func (s *reconcilerAccountStub) SumConcurrencyByPlatform(context.Context, string) (int64, error) {
+	if s.sumErr != nil {
+		return 0, s.sumErr
+	}
+	return s.sum, nil
+}
+
 func (s *reconcilerAccountStub) BulkUpdate(ctx context.Context, ids []int64, updates AccountBulkUpdate) (int64, error) {
 	if s.bulkErr != nil {
 		return 0, s.bulkErr
@@ -233,6 +240,71 @@ func TestReconciler_SurfaceC_MirrorsConcurrency(t *testing.T) {
 	require.Contains(t, doer.lastURL, "/api/v1/edge/scheduling-capacity")
 	require.Contains(t, doer.lastURL, "platform=anthropic")
 	require.Equal(t, "sk-edge-key", doer.lastAuth, "must authenticate with the stub's relay api_key")
+}
+
+// A kiro mirror stub rides the same anthropic-apikey transport but declares
+// credentials.mirror_platform=kiro, so surface-C must query the edge's kiro pool
+// (?platform=kiro) — not the anthropic pool. This is the bug the fix closes: both
+// stubs otherwise read the same anthropic number (22).
+func TestReconciler_SurfaceC_KiroStub_QueriesKiroPlatform(t *testing.T) {
+	stub := Account{
+		ID:          22,
+		Name:        "kiro-edge-us1",
+		Platform:    PlatformAnthropic, // transport platform is always anthropic-apikey
+		Type:        AccountTypeAPIKey,
+		Concurrency: 22, // wrong (anthropic) number it currently shows
+		Credentials: map[string]any{
+			"base_url":        "https://api-us1.tokenkey.dev",
+			"api_key":         "sk-edge-key",
+			"mirror_platform": "kiro",
+		},
+	}
+	acc := &reconcilerAccountStub{accounts: []Account{stub}, sum: 22}
+	usr := &reconcilerUserStub{user: &User{ID: 1, Concurrency: 22}}
+	r := newTestReconciler(acc, usr, &reconcilerBalanceStub{}, mirrorEnabledCfg(true, false))
+	doer := &fakeDoer{status: 200, body: `{"code":0,"message":"ok","data":{"platform":"kiro","total_concurrency":6,"ts":1}}`}
+	r.http = doer
+
+	r.runOnce(context.Background())
+
+	require.Contains(t, doer.lastURL, "platform=kiro", "kiro stub must query the edge kiro pool, not anthropic")
+	require.NotContains(t, doer.lastURL, "platform=anthropic")
+
+	var concWrites int
+	for _, call := range acc.bulkCalls {
+		if call.updates.Concurrency != nil {
+			concWrites++
+			require.Equal(t, 6, *call.updates.Concurrency, "kiro stub must mirror the edge kiro Σ (6), not anthropic (22)")
+			require.Equal(t, []int64{22}, call.ids)
+		}
+	}
+	require.Equal(t, 1, concWrites)
+}
+
+// Absent credentials.mirror_platform, a stub keeps mirroring the anthropic pool —
+// every pre-existing stub stays correct with zero data migration.
+func TestReconciler_SurfaceC_DefaultsToAnthropicWhenUnset(t *testing.T) {
+	stub := Account{
+		ID:          23,
+		Name:        "cc-us1",
+		Platform:    PlatformAnthropic,
+		Type:        AccountTypeAPIKey,
+		Concurrency: 8,
+		Credentials: map[string]any{
+			"base_url": "https://api-us1.tokenkey.dev",
+			"api_key":  "sk-edge-key",
+		},
+	}
+	acc := &reconcilerAccountStub{accounts: []Account{stub}, sum: 8}
+	usr := &reconcilerUserStub{user: &User{ID: 1, Concurrency: 8}}
+	r := newTestReconciler(acc, usr, &reconcilerBalanceStub{}, mirrorEnabledCfg(true, false))
+	doer := &fakeDoer{status: 200, body: `{"code":0,"message":"ok","data":{"platform":"anthropic","total_concurrency":5,"ts":1}}`}
+	r.http = doer
+
+	r.runOnce(context.Background())
+
+	require.Contains(t, doer.lastURL, "platform=anthropic")
+	require.NotContains(t, doer.lastURL, "platform=kiro")
 }
 
 func TestReconciler_SurfaceC_NeverWritesZeroOnFailure(t *testing.T) {

--- a/backend/internal/service/anthropic_config_reconciler_test.go
+++ b/backend/internal/service/anthropic_config_reconciler_test.go
@@ -281,6 +281,28 @@ func TestReconciler_SurfaceC_KiroStub_QueriesKiroPlatform(t *testing.T) {
 	require.Equal(t, 1, concWrites)
 }
 
+// mirrorCapacityPlatform: only empty/whitespace defaults to anthropic; any
+// non-empty value is passed through verbatim (lower/trimmed) so an unknown/typo'd
+// value reaches the edge, 4xx's, and is skipped — never silently coerced to the
+// anthropic pool (which would reintroduce the silent-wrong-pool bug).
+func TestMirrorCapacityPlatform(t *testing.T) {
+	cases := map[string]string{
+		"":          "anthropic",
+		"   ":       "anthropic",
+		"anthropic": "anthropic",
+		"Anthropic": "anthropic",
+		"kiro":      "kiro",
+		" KIRO ":    "kiro",
+		"openai":    "openai", // unsupported today → passthrough, edge will 4xx
+		"kir0":      "kir0",   // typo → passthrough, NOT coerced to anthropic
+	}
+	for raw, want := range cases {
+		if got := mirrorCapacityPlatform(raw); got != want {
+			t.Errorf("mirrorCapacityPlatform(%q) = %q, want %q", raw, got, want)
+		}
+	}
+}
+
 // Absent credentials.mirror_platform, a stub keeps mirroring the anthropic pool —
 // every pre-existing stub stays correct with zero data migration.
 func TestReconciler_SurfaceC_DefaultsToAnthropicWhenUnset(t *testing.T) {

--- a/backend/internal/service/anthropic_operator_concurrency_test.go
+++ b/backend/internal/service/anthropic_operator_concurrency_test.go
@@ -27,6 +27,13 @@ func (a *accountRepoSumStub) SumConcurrencyAnthropicByGroup(context.Context, str
 	return a.sum, nil
 }
 
+func (a *accountRepoSumStub) SumConcurrencyByPlatform(context.Context, string) (int64, error) {
+	if a.err != nil {
+		return 0, a.err
+	}
+	return a.sum, nil
+}
+
 type recordingUserRepoStub struct {
 	UserRepository
 

--- a/backend/internal/service/gateway_multiplatform_test.go
+++ b/backend/internal/service/gateway_multiplatform_test.go
@@ -203,6 +203,10 @@ func (m *mockAccountRepoForPlatform) SumConcurrencyAnthropicByGroup(context.Cont
 	return 0, nil
 }
 
+func (m *mockAccountRepoForPlatform) SumConcurrencyByPlatform(context.Context, string) (int64, error) {
+	return 0, nil
+}
+
 // Verify interface implementation
 var _ AccountRepository = (*mockAccountRepoForPlatform)(nil)
 

--- a/backend/internal/service/gemini_multiplatform_test.go
+++ b/backend/internal/service/gemini_multiplatform_test.go
@@ -192,6 +192,10 @@ func (m *mockAccountRepoForGemini) SumConcurrencyAnthropicByGroup(context.Contex
 	return 0, nil
 }
 
+func (m *mockAccountRepoForGemini) SumConcurrencyByPlatform(context.Context, string) (int64, error) {
+	return 0, nil
+}
+
 // Verify interface implementation
 var _ AccountRepository = (*mockAccountRepoForGemini)(nil)
 

--- a/backend/internal/service/ratelimit_session_window_test.go
+++ b/backend/internal/service/ratelimit_session_window_test.go
@@ -159,6 +159,9 @@ func (m *sessionWindowMockRepo) SumConcurrencyAnthropic(context.Context) (int64,
 func (m *sessionWindowMockRepo) SumConcurrencyAnthropicByGroup(context.Context, string) (int64, error) {
 	panic("unexpected")
 }
+func (m *sessionWindowMockRepo) SumConcurrencyByPlatform(context.Context, string) (int64, error) {
+	panic("unexpected")
+}
 
 // newRateLimitServiceForTest creates a RateLimitService with the given mock repo.
 func newRateLimitServiceForTest(repo AccountRepository) *RateLimitService {

--- a/backend/internal/web/dist/frontend-source.json
+++ b/backend/internal/web/dist/frontend-source.json
@@ -1,7 +1,7 @@
 {
   "algorithm": "sha256(git-ls-files:path,size,content)",
-  "file_count": 452,
-  "hash": "d8b2a9dee49b3b85cd499258c099e2a9d151892145d2700f713d877dd6d08a20",
+  "file_count": 453,
+  "hash": "f1f3876fedfa738a1abf3400af068b98184a8596b2a0514308a72797522aa44c",
   "schema": 1,
   "source": "frontend/"
 }

--- a/frontend/src/components/account/CreateAccountModal.vue
+++ b/frontend/src/components/account/CreateAccountModal.vue
@@ -1138,6 +1138,17 @@
           <p class="input-hint">{{ t('admin.accounts.gemini.tier.aiStudioHint') }}</p>
         </div>
 
+        <!-- TK: edge mirror-stub pool selector (anthropic apikey only) -->
+        <div v-if="form.platform === 'anthropic'">
+          <label class="input-label">{{ t('admin.accounts.anthropic.mirrorPlatform') }}</label>
+          <select v-model="mirrorPlatform" class="input">
+            <option v-for="opt in MIRROR_PLATFORM_OPTIONS" :key="opt.value" :value="opt.value">
+              {{ opt.label }}
+            </option>
+          </select>
+          <p class="input-hint">{{ t('admin.accounts.anthropic.mirrorPlatformHint') }}</p>
+        </div>
+
         <!-- Model Restriction Section (Antigravity 已在上层条件排除) -->
         <div class="border-t border-gray-200 pt-4 dark:border-dark-600">
           <label class="input-label">{{ t('admin.accounts.modelRestriction') }}</label>
@@ -3364,6 +3375,7 @@ import { applyInterceptWarmup } from '@/components/account/credentialsBuilder'
 import { formatDateTimeLocalInput, parseDateTimeLocalInput } from '@/utils/format'
 import { createStableObjectKeyResolver } from '@/utils/stableObjectKey'
 import { VERTEX_LOCATION_OPTIONS } from '@/constants/account'
+import { MIRROR_PLATFORM_OPTIONS, type MirrorPlatform } from '@/constants/mirrorPlatformOptions.tk'
 import {
   OPENAI_WS_MODE_CTX_POOL,
   OPENAI_WS_MODE_OFF,
@@ -3488,6 +3500,9 @@ const accountCategory = ref<'oauth-based' | 'apikey' | 'bedrock' | 'service_acco
 const addMethod = ref<AddMethod>('oauth') // For oauth-based: 'oauth' or 'setup-token'
 const apiKeyBaseUrl = ref('https://api.anthropic.com')
 const apiKeyValue = ref('')
+// TK: edge mirror-stub pool selector (anthropic + apikey only). See
+// constants/mirrorPlatformOptions.tk.ts.
+const mirrorPlatform = ref<MirrorPlatform>('anthropic')
 
 const syncPreviewCredentials = computed(() => {
   if (!apiKeyValue.value) return undefined
@@ -4449,6 +4464,7 @@ const resetForm = () => {
   addMethod.value = 'oauth'
   apiKeyBaseUrl.value = 'https://api.anthropic.com'
   apiKeyValue.value = ''
+  mirrorPlatform.value = 'anthropic'
   editQuotaLimit.value = null
   editQuotaDailyLimit.value = null
   editQuotaWeeklyLimit.value = null
@@ -4965,6 +4981,11 @@ const handleSubmit = async () => {
   }
   if (form.platform === 'gemini') {
     credentials.tier_id = geminiTierAIStudio.value
+  }
+  // TK: edge mirror-stub pool selector (surface-C). Only anthropic apikey stubs
+  // participate; default 'anthropic' keeps non-stub accounts unaffected.
+  if (form.platform === 'anthropic') {
+    credentials.mirror_platform = mirrorPlatform.value
   }
 
   // Add model mapping if configured（OpenAI 开启自动透传时不应用）

--- a/frontend/src/components/account/EditAccountModal.vue
+++ b/frontend/src/components/account/EditAccountModal.vue
@@ -97,6 +97,16 @@
             />
             <p class="input-hint">{{ t('admin.accounts.leaveEmptyToKeep') }}</p>
           </div>
+          <!-- TK: edge mirror-stub pool selector (anthropic apikey only) -->
+          <div v-if="account.platform === 'anthropic'">
+            <label class="input-label">{{ t('admin.accounts.anthropic.mirrorPlatform') }}</label>
+            <select v-model="editMirrorPlatform" class="input">
+              <option v-for="opt in MIRROR_PLATFORM_OPTIONS" :key="opt.value" :value="opt.value">
+                {{ opt.label }}
+              </option>
+            </select>
+            <p class="input-hint">{{ t('admin.accounts.anthropic.mirrorPlatformHint') }}</p>
+          </div>
         </template>
 
         <!--
@@ -2418,6 +2428,11 @@ import { formatDateTime, formatDateTimeLocalInput, parseDateTimeLocalInput } fro
 import { createStableObjectKeyResolver } from '@/utils/stableObjectKey'
 import { VERTEX_LOCATION_OPTIONS } from '@/constants/account'
 import {
+  MIRROR_PLATFORM_OPTIONS,
+  normalizeMirrorPlatform,
+  type MirrorPlatform
+} from '@/constants/mirrorPlatformOptions.tk'
+import {
   OPENAI_WS_MODE_CTX_POOL,
   OPENAI_WS_MODE_OFF,
   OPENAI_WS_MODE_PASSTHROUGH,
@@ -2479,6 +2494,9 @@ interface TempUnschedRuleForm {
 const submitting = ref(false)
 const editBaseUrl = ref('https://api.anthropic.com')
 const editApiKey = ref('')
+// TK: edge mirror-stub pool selector (anthropic + apikey only). See
+// constants/mirrorPlatformOptions.tk.ts.
+const editMirrorPlatform = ref<MirrorPlatform>('anthropic')
 // 第五平台 newapi：表单状态 + 副作用统一收口在 composable。
 // EditModal 多传一个 storedAccount，让「获取模型列表」在用户没重新输入 api_key 时走 stored
 // credential 路径——与上游 new-api 的 channel 编辑体验一致。
@@ -3143,6 +3161,8 @@ const syncFormFromAccount = (newAccount: Account | null) => {
           ? 'https://generativelanguage.googleapis.com'
           : 'https://api.anthropic.com'
     editBaseUrl.value = (credentials.base_url as string) || platformDefaultUrl
+    // TK: edge mirror-stub pool (default anthropic for non-stub accounts).
+    editMirrorPlatform.value = normalizeMirrorPlatform(credentials.mirror_platform)
 
     // 第五平台 newapi：把现有账号的 channel_type / credentials 一次性灌进
     // composable，模式（whitelist / mapping）由 composable 自行推断。
@@ -3791,6 +3811,10 @@ const handleSubmit = async () => {
         } else if (!hasExistingApiKey) {
           appStore.showError(t('admin.accounts.apiKeyIsRequired'))
           return
+        }
+        // TK: edge mirror-stub pool selector (surface-C). anthropic apikey only.
+        if (props.account.platform === 'anthropic') {
+          newCredentials.mirror_platform = editMirrorPlatform.value
         }
         if (shouldApplyModelMapping) {
           const modelMapping = buildModelMappingObject(modelRestrictionMode.value, allowedModels.value, modelMappings.value)

--- a/frontend/src/constants/mirrorPlatformOptions.tk.ts
+++ b/frontend/src/constants/mirrorPlatformOptions.tk.ts
@@ -1,0 +1,29 @@
+// TokenKey-only. An anthropic + apikey "mirror stub" relays prod traffic to an
+// edge node (credentials.base_url points at an internal api-<edge>.tokenkey.dev
+// host). credentials.mirror_platform declares WHICH edge pool's live Σ schedulable
+// concurrency the surface-C reconciler mirrors onto this stub's concurrency column.
+//
+// The stub's own platform is always `anthropic` (its transport is anthropic-apikey
+// relay), so it cannot self-describe whether it represents the edge's anthropic pool
+// or its kiro pool — this field is that declaration. Default = anthropic, matching
+// the backend default in
+// backend/internal/service/anthropic_config_reconciler.go::mirrorCapacityPlatform.
+
+export type MirrorPlatform = 'anthropic' | 'kiro'
+
+export interface MirrorPlatformOption {
+  value: MirrorPlatform
+  // Brand names — identical across locales, so no i18n key (the field label/hint
+  // around the select ARE translated).
+  label: string
+}
+
+export const MIRROR_PLATFORM_OPTIONS: MirrorPlatformOption[] = [
+  { value: 'anthropic', label: 'Anthropic' },
+  { value: 'kiro', label: 'Kiro' },
+]
+
+// normalizeMirrorPlatform mirrors the backend default: empty / unknown → 'anthropic'.
+export function normalizeMirrorPlatform(raw: unknown): MirrorPlatform {
+  return raw === 'kiro' ? 'kiro' : 'anthropic'
+}

--- a/frontend/src/i18n/locales/en.ts
+++ b/frontend/src/i18n/locales/en.ts
@@ -3595,6 +3595,9 @@ export default {
         apiKeyPassthrough: 'Auto passthrough (auth only)',
         apiKeyPassthroughDesc:
           'Only applies to Anthropic API Key accounts. When enabled, messages/count_tokens are forwarded in passthrough mode with auth replacement only, while billing/concurrency/audit and safety filtering are preserved. Disable to roll back immediately.',
+        mirrorPlatform: 'Mirror platform',
+        mirrorPlatformHint:
+          'Only for edge "mirror stub" accounts (base URL points at an internal api-<edge>.tokenkey.dev host). Declares which edge pool this stub mirrors its concurrency from: Anthropic (default) or Kiro. Leave Anthropic for normal API Key accounts.',
         webSearchEmulation: 'Web Search Emulation',
         webSearchEmulationDesc:
           'Enable web search emulation for this API Key account. When a pure web_search request is detected, the gateway calls a third-party search API and constructs the response locally. Default follows channel config.',

--- a/frontend/src/i18n/locales/zh.ts
+++ b/frontend/src/i18n/locales/zh.ts
@@ -3737,6 +3737,9 @@ export default {
         apiKeyPassthrough: '自动透传（仅替换认证）',
         apiKeyPassthroughDesc:
           '仅对 Anthropic API Key 生效。开启后，messages/count_tokens 请求将透传上游并仅替换认证，保留计费/并发/审计及必要安全过滤；关闭即可回滚到现有兼容链路。',
+        mirrorPlatform: '镜像平台',
+        mirrorPlatformHint:
+          '仅用于对接 edge 的「镜像 stub」账号（base URL 指向内部 api-<edge>.tokenkey.dev）。声明该 stub 从 edge 的哪个池镜像并发：Anthropic（默认）或 Kiro。普通 API Key 账号保持 Anthropic 即可。',
         webSearchEmulation: 'Web Search 模拟',
         webSearchEmulationDesc:
           '为该 API Key 账号启用 web search 模拟。客户端发送纯 web_search 请求时，由网关调用第三方搜索 API 并构造响应返回。默认跟随渠道配置。',

--- a/scripts/sentinels/kiro.json
+++ b/scripts/sentinels/kiro.json
@@ -3,6 +3,36 @@
   "rationale": "Load-bearing files and symbols that anchor TokenKey's sixth platform `kiro` (AWS Kiro / CodeWhisperer). Kiro rides on a vendored protocol layer (internal/integration/kiro, sourced from Quorinex/Kiro-Go under MIT) exposed through the native Anthropic /v1/messages path, plus thin TK-only injection points. If any sentinel below is missing, the platform either silently disappears from scheduling/UI or fails at runtime. Single source of truth read by both `scripts/preflight.sh` (kiro sentinel registry section) and `.github/workflows/upstream-merge-pr-shape.yml` (on `merge/upstream-*` PRs). Adding a new load-bearing surface for kiro MUST add a sentinel here in the same commit.",
   "sentinels": [
     {
+      "path": "backend/internal/handler/edge_tk_capacity_handler.go",
+      "must_contain": [
+        "case \"kiro\":",
+        "SumConcurrencyByPlatform"
+      ],
+      "rationale": "Surface-C edge capacity endpoint must report the kiro pool's live Σ (platform-wide schedulable sum) so prod's kiro mirror stub mirrors the right number. Losing the kiro dispatch arm makes a kiro stub's ?platform=kiro request 400, and surface-C falls back to leaving the stub's concurrency stale (or, if the prod default regressed, hands the kiro stub the anthropic number again — the exact bug this surface closes)."
+    },
+    {
+      "path": "backend/internal/service/anthropic_config_reconciler.go",
+      "must_contain": [
+        "func mirrorCapacityPlatform",
+        "mirror_platform"
+      ],
+      "rationale": "Prod side of surface-C: reads each mirror stub's credentials.mirror_platform (default anthropic) and queries the matching edge pool. Losing mirrorCapacityPlatform collapses the anthropic/kiro distinction so every mirror stub queries ?platform=anthropic again and a kiro stub silently mirrors the anthropic Σ."
+    },
+    {
+      "path": "backend/internal/repository/account_repo.go",
+      "must_contain": [
+        "func (r *accountRepository) SumConcurrencyByPlatform"
+      ],
+      "rationale": "Platform-wide schedulable Σ reader that backs the kiro arm of the edge capacity endpoint (the kiro pool is not group-scoped like anthropic's \"default\"). Losing it breaks ?platform=kiro capacity reads, so prod's kiro mirror stub can no longer mirror the edge kiro pool. (account_repo.go is also a gateway-tk hotspot — dual-covered on purpose.)"
+    },
+    {
+      "path": "backend/internal/handler/edge_tk_capacity_handler_test.go",
+      "must_contain": [
+        "TestEdgeCapacityHandler_KiroUsesPlatformWideSum"
+      ],
+      "rationale": "Load-bearing QA evidence that the kiro capacity arm reads SumConcurrencyByPlatform(\"kiro\") and never the anthropic-group sum — the exact regression (kiro stub mirrors the anthropic number) this surface closes. Matches the *_tk_*_test.go hotspot-evidence rule."
+    },
+    {
       "path": "backend/internal/domain/constants.go",
       "must_contain": [
         "PlatformKiro"
@@ -153,9 +183,25 @@
     {
       "path": "frontend/src/components/account/CreateAccountModal.vue",
       "must_contain": [
-        "AccountKiroPlatformFields"
+        "AccountKiroPlatformFields",
+        "mirror_platform"
       ],
-      "rationale": "The kiro branch + field component wiring in the account-create modal. Losing it makes operators unable to create kiro accounts from the admin UI."
+      "rationale": "The kiro branch + field component wiring in the account-create modal, plus the surface-C mirror-stub pool selector that writes credentials.mirror_platform. Losing AccountKiroPlatformFields makes operators unable to create kiro accounts; losing the mirror_platform injection means a new edge kiro stub silently defaults to the anthropic pool."
+    },
+    {
+      "path": "frontend/src/components/account/EditAccountModal.vue",
+      "must_contain": [
+        "editMirrorPlatform"
+      ],
+      "rationale": "Surface-C mirror-stub pool selector in the account-edit modal — the operator's only no-SQL way to set credentials.mirror_platform=kiro on an existing edge stub (e.g. kiro-edge-us1). Losing it strands the live fix: the kiro stub keeps mirroring the anthropic Σ."
+    },
+    {
+      "path": "frontend/src/constants/mirrorPlatformOptions.tk.ts",
+      "must_contain": [
+        "MIRROR_PLATFORM_OPTIONS",
+        "normalizeMirrorPlatform"
+      ],
+      "rationale": "TK-only options + backend-aligned default normalizer for the surface-C mirror-stub pool selector (anthropic/kiro), consumed by both account modals. Losing it breaks the mirror_platform UI and the anthropic-default fallback."
     },
     {
       "path": "frontend/src/i18n/locales/en.ts",


### PR DESCRIPTION
## Problem

All prod edge "mirror stubs" are `platform=anthropic + type=apikey` by **transport** (they relay to an edge over anthropic-apikey). So surface-C concurrency mirroring fed the **same** edge anthropic capacity to both:

- `cc-us1` (mirrors the edge **anthropic** pool) → 22
- `kiro-edge-us1` (should mirror the edge **kiro** pool) → also 22

They were indistinguishable in the 容量 column.

## Root cause

Transport platform (always anthropic-apikey relay) was conflated with **capacity-source platform** (which edge pool the stub represents). Two hardcoded `?platform=anthropic` points:

- `service/anthropic_config_reconciler.go::fetchEdgeCapacity`
- `handler/edge_tk_capacity_handler.go::GetSchedulingCapacity` (only accepted anthropic; summed `platform='anthropic'`)

`isMirrorStub` matched both stubs, so both pulled the same anthropic Σ (22).

## Fix — one concept, end to end

A stub declares `credentials.mirror_platform` (completes the `(host, pool)` addressing tuple alongside `base_url`). **Default `anthropic`, so every existing stub is unchanged.**

- **backend**: `SumConcurrencyByPlatform` (kiro = platform-wide schedulable Σ, since the edge is single-pool-per-platform; anthropic keeps its `"default"`-group scope, untouched — #472/#476); edge capacity endpoint dispatches `?platform=anthropic|kiro`; reconciler reads `mirror_platform` via `mirrorCapacityPlatform` (default anthropic) and queries the matching pool. `isMirrorStub` / pool_mode / tier / operator-Σ unchanged.
- **frontend**: a "Mirror platform" dropdown (anthropic / kiro, default anthropic) on anthropic apikey accounts in Create/Edit account modals; TK-only logic in `constants/mirrorPlatformOptions.tk.ts`; en/zh i18n. Embedded dist manifest rebuilt.
- **sentinels**: `kiro.json` entries for the new surface-C kiro capacity path (handler, reconciler, repo reader, modals, .tk.ts, handler test).
- **rule-6**: `SumConcurrencyByPlatform` added to `AccountRepository` + 9 mocks + unit tests (kiro path, unknown-platform 400, mirror_platform routing, never-write-0 on failure).

## Verification

- `go test -tags=unit ./...`, integration-tag vet, `golangci-lint run ./...`, `go build ./...`
- `pnpm typecheck`, `pnpm lint:check`, `pnpm build`
- `bash scripts/preflight.sh` PASS (kiro sentinels intact, registry gate ok, dist freshness ok)

## ⚠️ Post-release operational step (required to clear the live symptom)

Code alone keeps the kiro stub on the anthropic default. After release, edit `kiro-edge-us1` (and any other kiro stubs) in admin → set **Mirror platform = Kiro** → save. Then its 容量 reflects the edge kiro pool and no longer equals `cc-us1`'s.

## Merge mode

TK-originated → **Squash and merge** (rule §5.y).