### PR TITLE
chore: refresh claude-code issue cache

### DIFF
--- a/.cache/anthropic/cc-triage.json
+++ b/.cache/anthropic/cc-triage.json
@@ -4,10 +4,10 @@
   "generated_from": "GitHub REST API issues?state=open; pull requests excluded; gateway-relevance filtered",
   "rationale": "TokenKey-local triage cache for anthropics/claude-code issues, filtered for gateway/relay relevance. Most claude-code issues are client-side (IDE/terminal/MCP) and are marked not_applicable. Only human-pinned MANUAL_TRIAGE high/critical entries become fix candidates.",
   "counts": {
-    "needs_review": 403,
-    "medium": 20,
-    "not_applicable": 1171,
-    "unknown_low_signal": 135
+    "needs_review": 414,
+    "medium": 22,
+    "not_applicable": 1284,
+    "unknown_low_signal": 151
   },
   "issues": [
     {
@@ -23,16 +23,28 @@
       "updated_at": "2026-06-01T17:46:05Z"
     },
     {
-      "upstream": "anthropics/claude-code#15542",
-      "url": "https://github.com/anthropics/claude-code/issues/15542",
-      "title": "[FEATURE] Enable Claude Code to access chat history in Claude App",
+      "upstream": "anthropics/claude-code#13585",
+      "url": "https://github.com/anthropics/claude-code/issues/13585",
+      "title": "Add Quota Information Access to Claude Code CLI",
       "impact": "needs_review",
       "categories": [
-        "auth_token"
+        "rate_limit"
       ],
       "tokenkey_status": "candidate_unverified",
       "rationale": "Gateway/relay-relevant keyword match; not yet manually verified against TokenKey code.",
-      "updated_at": "2026-05-31T17:58:47Z"
+      "updated_at": "2026-06-03T14:54:48Z"
+    },
+    {
+      "upstream": "anthropics/claude-code#17668",
+      "url": "https://github.com/anthropics/claude-code/issues/17668",
+      "title": "[Feature Request] MCP Context Isolation - Assign MCPs to Forked Agent/Skill Contexts",
+      "impact": "needs_review",
+      "categories": [
+        "fingerprint_ua"
+      ],
+      "tokenkey_status": "candidate_unverified",
+      "rationale": "Gateway/relay-relevant keyword match; not yet manually verified against TokenKey code.",
+      "updated_at": "2026-06-03T13:22:32Z"
     },
     {
       "upstream": "anthropics/claude-code#20131",
@@ -60,6 +72,18 @@
       "updated_at": "2026-06-02T14:24:20Z"
     },
     {
+      "upstream": "anthropics/claude-code#20944",
+      "url": "https://github.com/anthropics/claude-code/issues/20944",
+      "title": "[FEATURE] - Add Setting to Disable Automatic IDE Selection Context",
+      "impact": "needs_review",
+      "categories": [
+        "request_shape_400"
+      ],
+      "tokenkey_status": "candidate_unverified",
+      "rationale": "Gateway/relay-relevant keyword match; not yet manually verified against TokenKey code.",
+      "updated_at": "2026-06-03T12:51:14Z"
+    },
+    {
       "upstream": "anthropics/claude-code#25979",
       "url": "https://github.com/anthropics/claude-code/issues/25979",
       "title": "[BUG] Claude Code hangs indefinitely when API streaming connection stalls (no read timeout)",
@@ -72,6 +96,18 @@
       "updated_at": "2026-06-01T17:18:18Z"
     },
     {
+      "upstream": "anthropics/claude-code#26168",
+      "url": "https://github.com/anthropics/claude-code/issues/26168",
+      "title": "[DOCS] No centralized reference for all Claude Code files and directories on disk",
+      "impact": "needs_review",
+      "categories": [
+        "auth_token"
+      ],
+      "tokenkey_status": "candidate_unverified",
+      "rationale": "Gateway/relay-relevant keyword match; not yet manually verified against TokenKey code.",
+      "updated_at": "2026-06-03T11:40:20Z"
+    },
+    {
       "upstream": "anthropics/claude-code#26281",
       "url": "https://github.com/anthropics/claude-code/issues/26281",
       "title": "[BUG] MCP OAuth tokens without expires_in and refresh_token silently expires",
@@ -82,6 +118,18 @@
       "tokenkey_status": "candidate_unverified",
       "rationale": "Gateway/relay-relevant keyword match; not yet manually verified against TokenKey code.",
       "updated_at": "2026-06-02T22:52:59Z"
+    },
+    {
+      "upstream": "anthropics/claude-code#27027",
+      "url": "https://github.com/anthropics/claude-code/issues/27027",
+      "title": "[DOCS] `@` file-path docs missing guidance on corrected-path suggestions for missing repo-folder prefixes",
+      "impact": "needs_review",
+      "categories": [
+        "model_lifecycle"
+      ],
+      "tokenkey_status": "candidate_unverified",
+      "rationale": "Gateway/relay-relevant keyword match; not yet manually verified against TokenKey code.",
+      "updated_at": "2026-06-03T11:40:55Z"
     },
     {
       "upstream": "anthropics/claude-code#27263",
@@ -145,6 +193,18 @@
       "updated_at": "2026-06-02T22:10:59Z"
     },
     {
+      "upstream": "anthropics/claude-code#33704",
+      "url": "https://github.com/anthropics/claude-code/issues/33704",
+      "title": "[DOCS] MCP OAuth docs omit re-authentication behavior after refresh token expiry",
+      "impact": "needs_review",
+      "categories": [
+        "auth_token"
+      ],
+      "tokenkey_status": "candidate_unverified",
+      "rationale": "Gateway/relay-relevant keyword match; not yet manually verified against TokenKey code.",
+      "updated_at": "2026-06-03T11:39:41Z"
+    },
+    {
       "upstream": "anthropics/claude-code#33978",
       "url": "https://github.com/anthropics/claude-code/issues/33978",
       "title": "[FEATURE] Built-in Usage Analytics Command (claude usage) — Consolidates 10+ Open Issues",
@@ -156,6 +216,18 @@
       "tokenkey_status": "candidate_unverified",
       "rationale": "Gateway/relay-relevant keyword match; not yet manually verified against TokenKey code.",
       "updated_at": "2026-06-01T17:48:58Z"
+    },
+    {
+      "upstream": "anthropics/claude-code#34277",
+      "url": "https://github.com/anthropics/claude-code/issues/34277",
+      "title": "[DOCS] Permissions docs missing Bash cmd: specifier syntax for permission rules",
+      "impact": "needs_review",
+      "categories": [
+        "model_lifecycle"
+      ],
+      "tokenkey_status": "candidate_unverified",
+      "rationale": "Gateway/relay-relevant keyword match; not yet manually verified against TokenKey code.",
+      "updated_at": "2026-06-03T11:39:49Z"
     },
     {
       "upstream": "anthropics/claude-code#34281",
@@ -218,6 +290,30 @@
       "updated_at": "2026-06-03T04:57:51Z"
     },
     {
+      "upstream": "anthropics/claude-code#38568",
+      "url": "https://github.com/anthropics/claude-code/issues/38568",
+      "title": "[DOCS] Document that WebFetch identifies as `Claude-User` so site operators can allow or block it via `robots.txt`",
+      "impact": "needs_review",
+      "categories": [
+        "fingerprint_ua"
+      ],
+      "tokenkey_status": "candidate_unverified",
+      "rationale": "Gateway/relay-relevant keyword match; not yet manually verified against TokenKey code.",
+      "updated_at": "2026-06-03T11:40:42Z"
+    },
+    {
+      "upstream": "anthropics/claude-code#38618",
+      "url": "https://github.com/anthropics/claude-code/issues/38618",
+      "title": "[Bug] Anthropic API Error: Safety Classifier Unavailable - Auto Mode Blocked for Tool Execution",
+      "impact": "needs_review",
+      "categories": [
+        "model_lifecycle"
+      ],
+      "tokenkey_status": "candidate_unverified",
+      "rationale": "Gateway/relay-relevant keyword match; not yet manually verified against TokenKey code.",
+      "updated_at": "2026-06-03T16:46:31Z"
+    },
+    {
       "upstream": "anthropics/claude-code#38896",
       "url": "https://github.com/anthropics/claude-code/issues/38896",
       "title": "[Bug] API Error: Rate limit reached despite 0% usage",
@@ -242,6 +338,18 @@
       "updated_at": "2026-06-02T08:13:03Z"
     },
     {
+      "upstream": "anthropics/claude-code#39610",
+      "url": "https://github.com/anthropics/claude-code/issues/39610",
+      "title": "[DOCS] MCP `headersHelper` docs missing per-server `CLAUDE_CODE_MCP_SERVER_NAME` and `CLAUDE_CODE_MCP_SERVER_URL` variables",
+      "impact": "needs_review",
+      "categories": [
+        "auth_token"
+      ],
+      "tokenkey_status": "candidate_unverified",
+      "rationale": "Gateway/relay-relevant keyword match; not yet manually verified against TokenKey code.",
+      "updated_at": "2026-06-03T11:40:40Z"
+    },
+    {
       "upstream": "anthropics/claude-code#40769",
       "url": "https://github.com/anthropics/claude-code/issues/40769",
       "title": "[BUG] Cloud scheduled tasks: gRPC/HTTP2 blocked by sandbox TLS proxy to googleapis.com",
@@ -252,6 +360,43 @@
       "tokenkey_status": "candidate_unverified",
       "rationale": "Gateway/relay-relevant keyword match; not yet manually verified against TokenKey code.",
       "updated_at": "2026-06-02T22:44:27Z"
+    },
+    {
+      "upstream": "anthropics/claude-code#41788",
+      "url": "https://github.com/anthropics/claude-code/issues/41788",
+      "title": "Max 20 plan: rate limit 100% exhausted within ~70 minutes after reset (never happened before v2.1.89)",
+      "impact": "needs_review",
+      "categories": [
+        "rate_limit",
+        "prompt_caching"
+      ],
+      "tokenkey_status": "candidate_unverified",
+      "rationale": "Gateway/relay-relevant keyword match; not yet manually verified against TokenKey code.",
+      "updated_at": "2026-06-03T19:44:22Z"
+    },
+    {
+      "upstream": "anthropics/claude-code#41795",
+      "url": "https://github.com/anthropics/claude-code/issues/41795",
+      "title": "[DOCS] MCP docs omit multi-block error content guidance for server authors",
+      "impact": "needs_review",
+      "categories": [
+        "request_shape_400"
+      ],
+      "tokenkey_status": "candidate_unverified",
+      "rationale": "Gateway/relay-relevant keyword match; not yet manually verified against TokenKey code.",
+      "updated_at": "2026-06-03T11:40:54Z"
+    },
+    {
+      "upstream": "anthropics/claude-code#42316",
+      "url": "https://github.com/anthropics/claude-code/issues/42316",
+      "title": "[DOCS] Rate-limit options dialog is undocumented",
+      "impact": "needs_review",
+      "categories": [
+        "rate_limit"
+      ],
+      "tokenkey_status": "candidate_unverified",
+      "rationale": "Gateway/relay-relevant keyword match; not yet manually verified against TokenKey code.",
+      "updated_at": "2026-06-03T11:40:45Z"
     },
     {
       "upstream": "anthropics/claude-code#42850",
@@ -289,6 +434,18 @@
       "tokenkey_status": "candidate_unverified",
       "rationale": "Gateway/relay-relevant keyword match; not yet manually verified against TokenKey code.",
       "updated_at": "2026-06-01T12:02:16Z"
+    },
+    {
+      "upstream": "anthropics/claude-code#44243",
+      "url": "https://github.com/anthropics/claude-code/issues/44243",
+      "title": "Feature request: Support multiple Slack workspaces in the built-in Slack connector",
+      "impact": "needs_review",
+      "categories": [
+        "auth_token"
+      ],
+      "tokenkey_status": "candidate_unverified",
+      "rationale": "Gateway/relay-relevant keyword match; not yet manually verified against TokenKey code.",
+      "updated_at": "2026-06-03T13:14:01Z"
     },
     {
       "upstream": "anthropics/claude-code#44778",
@@ -503,6 +660,19 @@
       "updated_at": "2026-06-02T08:51:37Z"
     },
     {
+      "upstream": "anthropics/claude-code#50141",
+      "url": "https://github.com/anthropics/claude-code/issues/50141",
+      "title": "[DOCS] Environment variables reference missing `CLAUDE_CODE_EXTRA_BODY` request-body override documentation",
+      "impact": "needs_review",
+      "categories": [
+        "beta_header_drift",
+        "request_shape_400"
+      ],
+      "tokenkey_status": "candidate_unverified",
+      "rationale": "Gateway/relay-relevant keyword match; not yet manually verified against TokenKey code.",
+      "updated_at": "2026-06-03T11:39:43Z"
+    },
+    {
       "upstream": "anthropics/claude-code#50486",
       "url": "https://github.com/anthropics/claude-code/issues/50486",
       "title": "feat(plugins): namespace plugin skills with plugin name prefix like commands",
@@ -566,17 +736,28 @@
       "updated_at": "2026-06-01T12:02:18Z"
     },
     {
-      "upstream": "anthropics/claude-code#51267",
-      "url": "https://github.com/anthropics/claude-code/issues/51267",
-      "title": "[BUG] Remote Control (mobile): session silently hangs mid-execution; only local Esc recovers it — no remote unstick mechanism",
+      "upstream": "anthropics/claude-code#51312",
+      "url": "https://github.com/anthropics/claude-code/issues/51312",
+      "title": "[BUG] Preview server cannot read files from ~/Desktop on macOS despite Full Disk Access",
       "impact": "needs_review",
       "categories": [
-        "request_shape_400",
+        "model_lifecycle"
+      ],
+      "tokenkey_status": "candidate_unverified",
+      "rationale": "Gateway/relay-relevant keyword match; not yet manually verified against TokenKey code.",
+      "updated_at": "2026-06-03T18:44:29Z"
+    },
+    {
+      "upstream": "anthropics/claude-code#51371",
+      "url": "https://github.com/anthropics/claude-code/issues/51371",
+      "title": "[DOCS] Bash tool docs missing `gh` GitHub API rate-limit hint behavior",
+      "impact": "needs_review",
+      "categories": [
         "rate_limit"
       ],
       "tokenkey_status": "candidate_unverified",
       "rationale": "Gateway/relay-relevant keyword match; not yet manually verified against TokenKey code.",
-      "updated_at": "2026-05-31T19:43:12Z"
+      "updated_at": "2026-06-03T11:40:04Z"
     },
     {
       "upstream": "anthropics/claude-code#51398",
@@ -592,6 +773,18 @@
       "updated_at": "2026-06-01T08:23:34Z"
     },
     {
+      "upstream": "anthropics/claude-code#51784",
+      "url": "https://github.com/anthropics/claude-code/issues/51784",
+      "title": "[DOCS] Authentication docs missing recovery guidance for expired `CLAUDE_CODE_OAUTH_TOKEN`",
+      "impact": "needs_review",
+      "categories": [
+        "auth_token"
+      ],
+      "tokenkey_status": "candidate_unverified",
+      "rationale": "Gateway/relay-relevant keyword match; not yet manually verified against TokenKey code.",
+      "updated_at": "2026-06-03T11:40:09Z"
+    },
+    {
       "upstream": "anthropics/claude-code#51798",
       "url": "https://github.com/anthropics/claude-code/issues/51798",
       "title": "[BUG] PreToolUse permissionDecision: \"allow\" no longer suppresses prompt for Bash with dangerouslyDisableSandbox: true (2.1.116+ regression)",
@@ -601,7 +794,7 @@
       ],
       "tokenkey_status": "candidate_unverified",
       "rationale": "Gateway/relay-relevant keyword match; not yet manually verified against TokenKey code.",
-      "updated_at": "2026-06-01T03:40:02Z"
+      "updated_at": "2026-06-03T12:43:45Z"
     },
     {
       "upstream": "anthropics/claude-code#51802",
@@ -652,6 +845,42 @@
       "updated_at": "2026-06-01T22:46:16Z"
     },
     {
+      "upstream": "anthropics/claude-code#52200",
+      "url": "https://github.com/anthropics/claude-code/issues/52200",
+      "title": "[DOCS] MCP docs don't explain `/mcp` reconnect flow for `headersHelper` and custom-header auth recovery",
+      "impact": "needs_review",
+      "categories": [
+        "auth_token"
+      ],
+      "tokenkey_status": "candidate_unverified",
+      "rationale": "Gateway/relay-relevant keyword match; not yet manually verified against TokenKey code.",
+      "updated_at": "2026-06-03T11:40:13Z"
+    },
+    {
+      "upstream": "anthropics/claude-code#52202",
+      "url": "https://github.com/anthropics/claude-code/issues/52202",
+      "title": "[DOCS] Authentication docs omit OAuth refresh behavior when the server revokes a token early",
+      "impact": "needs_review",
+      "categories": [
+        "auth_token"
+      ],
+      "tokenkey_status": "candidate_unverified",
+      "rationale": "Gateway/relay-relevant keyword match; not yet manually verified against TokenKey code.",
+      "updated_at": "2026-06-03T11:40:12Z"
+    },
+    {
+      "upstream": "anthropics/claude-code#52203",
+      "url": "https://github.com/anthropics/claude-code/issues/52203",
+      "title": "[DOCS] Authentication docs omit `/login` behavior when `CLAUDE_CODE_OAUTH_TOKEN` is set",
+      "impact": "needs_review",
+      "categories": [
+        "auth_token"
+      ],
+      "tokenkey_status": "candidate_unverified",
+      "rationale": "Gateway/relay-relevant keyword match; not yet manually verified against TokenKey code.",
+      "updated_at": "2026-06-03T11:40:31Z"
+    },
+    {
       "upstream": "anthropics/claude-code#52482",
       "url": "https://github.com/anthropics/claude-code/issues/52482",
       "title": "[BUG] Model drifts full-width CJK punctuation to half-width in Edit's old_string, causing silent \"String to replace not found\"",
@@ -676,6 +905,30 @@
       "updated_at": "2026-06-03T10:15:56Z"
     },
     {
+      "upstream": "anthropics/claude-code#52620",
+      "url": "https://github.com/anthropics/claude-code/issues/52620",
+      "title": "[DOCS] MCP OAuth docs omit `client_secret_post` support for pre-configured credentials",
+      "impact": "needs_review",
+      "categories": [
+        "auth_token"
+      ],
+      "tokenkey_status": "candidate_unverified",
+      "rationale": "Gateway/relay-relevant keyword match; not yet manually verified against TokenKey code.",
+      "updated_at": "2026-06-03T11:40:26Z"
+    },
+    {
+      "upstream": "anthropics/claude-code#52626",
+      "url": "https://github.com/anthropics/claude-code/issues/52626",
+      "title": "[DOCS] `/status` docs omit MCP server state reporting and disabled status",
+      "impact": "needs_review",
+      "categories": [
+        "auth_token"
+      ],
+      "tokenkey_status": "candidate_unverified",
+      "rationale": "Gateway/relay-relevant keyword match; not yet manually verified against TokenKey code.",
+      "updated_at": "2026-06-03T11:40:32Z"
+    },
+    {
       "upstream": "anthropics/claude-code#52765",
       "url": "https://github.com/anthropics/claude-code/issues/52765",
       "title": "[BUG] Server is busy Claude cowork desktop error",
@@ -697,7 +950,7 @@
       ],
       "tokenkey_status": "candidate_unverified",
       "rationale": "Gateway/relay-relevant keyword match; not yet manually verified against TokenKey code.",
-      "updated_at": "2026-06-02T11:56:19Z"
+      "updated_at": "2026-06-03T21:15:41Z"
     },
     {
       "upstream": "anthropics/claude-code#53610",
@@ -762,6 +1015,18 @@
       "updated_at": "2026-06-01T12:03:32Z"
     },
     {
+      "upstream": "anthropics/claude-code#54171",
+      "url": "https://github.com/anthropics/claude-code/issues/54171",
+      "title": "[DOCS] Agent SDK MCP docs omit `mcp_authenticate` `redirectUri` usage for custom schemes and Claude.ai connectors",
+      "impact": "needs_review",
+      "categories": [
+        "auth_token"
+      ],
+      "tokenkey_status": "candidate_unverified",
+      "rationale": "Gateway/relay-relevant keyword match; not yet manually verified against TokenKey code.",
+      "updated_at": "2026-06-03T11:40:00Z"
+    },
+    {
       "upstream": "anthropics/claude-code#54225",
       "url": "https://github.com/anthropics/claude-code/issues/54225",
       "title": "[BUG] Sharing picture without text in Claude Code via Windows App causes session to stall permanently",
@@ -783,7 +1048,7 @@
       ],
       "tokenkey_status": "candidate_unverified",
       "rationale": "Gateway/relay-relevant keyword match; not yet manually verified against TokenKey code.",
-      "updated_at": "2026-06-02T22:03:47Z"
+      "updated_at": "2026-06-03T21:32:01Z"
     },
     {
       "upstream": "anthropics/claude-code#54434",
@@ -811,6 +1076,18 @@
       "tokenkey_status": "candidate_unverified",
       "rationale": "Gateway/relay-relevant keyword match; not yet manually verified against TokenKey code.",
       "updated_at": "2026-06-01T11:05:04Z"
+    },
+    {
+      "upstream": "anthropics/claude-code#54471",
+      "url": "https://github.com/anthropics/claude-code/issues/54471",
+      "title": "[DOCS] OpenTelemetry monitoring docs do not document numeric `api_request` / `api_error` attribute types",
+      "impact": "needs_review",
+      "categories": [
+        "prompt_caching"
+      ],
+      "tokenkey_status": "candidate_unverified",
+      "rationale": "Gateway/relay-relevant keyword match; not yet manually verified against TokenKey code.",
+      "updated_at": "2026-06-03T11:40:56Z"
     },
     {
       "upstream": "anthropics/claude-code#54588",
@@ -971,20 +1248,6 @@
       "updated_at": "2026-06-02T11:32:29Z"
     },
     {
-      "upstream": "anthropics/claude-code#56075",
-      "url": "https://github.com/anthropics/claude-code/issues/56075",
-      "title": "[BUG] Single README.md edit burns entire 5-hour Max 5x window in 9m 39s (Opus 4.7 1M, resumed session, v2.1.126, JetBrains, Windows)",
-      "impact": "needs_review",
-      "categories": [
-        "rate_limit",
-        "model_lifecycle",
-        "prompt_caching"
-      ],
-      "tokenkey_status": "candidate_unverified",
-      "rationale": "Gateway/relay-relevant keyword match; not yet manually verified against TokenKey code.",
-      "updated_at": "2026-05-31T22:11:19Z"
-    },
-    {
       "upstream": "anthropics/claude-code#56356",
       "url": "https://github.com/anthropics/claude-code/issues/56356",
       "title": "Opus 4.7 returns no thinking blocks even with --thinking adaptive --thinking-display summarized",
@@ -1008,6 +1271,18 @@
       "tokenkey_status": "candidate_unverified",
       "rationale": "Gateway/relay-relevant keyword match; not yet manually verified against TokenKey code.",
       "updated_at": "2026-06-02T23:22:34Z"
+    },
+    {
+      "upstream": "anthropics/claude-code#56829",
+      "url": "https://github.com/anthropics/claude-code/issues/56829",
+      "title": "[BUG] Multiple system-reminder Blocks Cause Model to Drop User Message on AWS Bedrock",
+      "impact": "needs_review",
+      "categories": [
+        "model_lifecycle"
+      ],
+      "tokenkey_status": "candidate_unverified",
+      "rationale": "Gateway/relay-relevant keyword match; not yet manually verified against TokenKey code.",
+      "updated_at": "2026-06-03T17:50:46Z"
     },
     {
       "upstream": "anthropics/claude-code#56872",
@@ -1057,6 +1332,20 @@
       "tokenkey_status": "candidate_unverified",
       "rationale": "Gateway/relay-relevant keyword match; not yet manually verified against TokenKey code.",
       "updated_at": "2026-06-03T08:01:05Z"
+    },
+    {
+      "upstream": "anthropics/claude-code#57200",
+      "url": "https://github.com/anthropics/claude-code/issues/57200",
+      "title": "[BUG] Claude ignores instructions and violates rules consistently",
+      "impact": "needs_review",
+      "categories": [
+        "auth_token",
+        "model_lifecycle",
+        "fingerprint_ua"
+      ],
+      "tokenkey_status": "candidate_unverified",
+      "rationale": "Gateway/relay-relevant keyword match; not yet manually verified against TokenKey code.",
+      "updated_at": "2026-06-03T16:09:46Z"
     },
     {
       "upstream": "anthropics/claude-code#57242",
@@ -1166,6 +1455,18 @@
       "tokenkey_status": "candidate_unverified",
       "rationale": "Gateway/relay-relevant keyword match; not yet manually verified against TokenKey code.",
       "updated_at": "2026-06-03T04:56:29Z"
+    },
+    {
+      "upstream": "anthropics/claude-code#59102",
+      "url": "https://github.com/anthropics/claude-code/issues/59102",
+      "title": "[BUG] MCP server error notifications render as \"[object Object]\" instead of the error message",
+      "impact": "needs_review",
+      "categories": [
+        "auth_token"
+      ],
+      "tokenkey_status": "candidate_unverified",
+      "rationale": "Gateway/relay-relevant keyword match; not yet manually verified against TokenKey code.",
+      "updated_at": "2026-06-03T10:42:39Z"
     },
     {
       "upstream": "anthropics/claude-code#59108",
@@ -1280,18 +1581,6 @@
       "tokenkey_status": "candidate_unverified",
       "rationale": "Gateway/relay-relevant keyword match; not yet manually verified against TokenKey code.",
       "updated_at": "2026-06-01T01:04:54Z"
-    },
-    {
-      "upstream": "anthropics/claude-code#59621",
-      "url": "https://github.com/anthropics/claude-code/issues/59621",
-      "title": "[BUG] Review crashed before producing findings",
-      "impact": "needs_review",
-      "categories": [
-        "rate_limit"
-      ],
-      "tokenkey_status": "candidate_unverified",
-      "rationale": "Gateway/relay-relevant keyword match; not yet manually verified against TokenKey code.",
-      "updated_at": "2026-05-31T23:05:00Z"
     },
     {
       "upstream": "anthropics/claude-code#59634",
@@ -1782,6 +2071,18 @@
       "updated_at": "2026-06-02T11:33:09Z"
     },
     {
+      "upstream": "anthropics/claude-code#60177",
+      "url": "https://github.com/anthropics/claude-code/issues/60177",
+      "title": "[MODEL] Claude marks tasks done without testing — 12 days, 51 commits, still broken (Opus 4.x)",
+      "impact": "needs_review",
+      "categories": [
+        "request_shape_400"
+      ],
+      "tokenkey_status": "candidate_unverified",
+      "rationale": "Gateway/relay-relevant keyword match; not yet manually verified against TokenKey code.",
+      "updated_at": "2026-06-03T16:09:40Z"
+    },
+    {
       "upstream": "anthropics/claude-code#60197",
       "url": "https://github.com/anthropics/claude-code/issues/60197",
       "title": "[BUG] Edit tool silently misses some Edits in a rapid Edit + git mv + commit sequence (selective miss within same commit; refuted hypothesis 2 vs 1+3 still open)",
@@ -1817,6 +2118,18 @@
       "tokenkey_status": "candidate_unverified",
       "rationale": "Gateway/relay-relevant keyword match; not yet manually verified against TokenKey code.",
       "updated_at": "2026-06-02T22:44:05Z"
+    },
+    {
+      "upstream": "anthropics/claude-code#60231",
+      "url": "https://github.com/anthropics/claude-code/issues/60231",
+      "title": "[BUG] No Claude Environment Selector in Claude Code Routines, so cannot access Network APIs.",
+      "impact": "needs_review",
+      "categories": [
+        "fingerprint_ua"
+      ],
+      "tokenkey_status": "candidate_unverified",
+      "rationale": "Gateway/relay-relevant keyword match; not yet manually verified against TokenKey code.",
+      "updated_at": "2026-06-03T11:39:28Z"
     },
     {
       "upstream": "anthropics/claude-code#60252",
@@ -1943,7 +2256,7 @@
       ],
       "tokenkey_status": "candidate_unverified",
       "rationale": "Gateway/relay-relevant keyword match; not yet manually verified against TokenKey code.",
-      "updated_at": "2026-06-03T05:02:50Z"
+      "updated_at": "2026-06-03T16:26:03Z"
     },
     {
       "upstream": "anthropics/claude-code#60669",
@@ -1955,7 +2268,7 @@
       ],
       "tokenkey_status": "candidate_unverified",
       "rationale": "Gateway/relay-relevant keyword match; not yet manually verified against TokenKey code.",
-      "updated_at": "2026-06-02T14:58:36Z"
+      "updated_at": "2026-06-03T19:09:09Z"
     },
     {
       "upstream": "anthropics/claude-code#61012",
@@ -1967,7 +2280,7 @@
       ],
       "tokenkey_status": "candidate_unverified",
       "rationale": "Gateway/relay-relevant keyword match; not yet manually verified against TokenKey code.",
-      "updated_at": "2026-06-02T20:21:45Z"
+      "updated_at": "2026-06-03T14:16:48Z"
     },
     {
       "upstream": "anthropics/claude-code#61313",
@@ -1980,6 +2293,18 @@
       "tokenkey_status": "candidate_unverified",
       "rationale": "Gateway/relay-relevant keyword match; not yet manually verified against TokenKey code.",
       "updated_at": "2026-06-02T10:41:06Z"
+    },
+    {
+      "upstream": "anthropics/claude-code#61370",
+      "url": "https://github.com/anthropics/claude-code/issues/61370",
+      "title": "[BUG] Voice mode silently captures no audio in 2.1.148 (accessibility regression)",
+      "impact": "needs_review",
+      "categories": [
+        "fingerprint_ua"
+      ],
+      "tokenkey_status": "candidate_unverified",
+      "rationale": "Gateway/relay-relevant keyword match; not yet manually verified against TokenKey code.",
+      "updated_at": "2026-06-03T16:17:40Z"
     },
     {
       "upstream": "anthropics/claude-code#61634",
@@ -2015,21 +2340,7 @@
       ],
       "tokenkey_status": "candidate_unverified",
       "rationale": "Gateway/relay-relevant keyword match; not yet manually verified against TokenKey code.",
-      "updated_at": "2026-06-02T23:43:02Z"
-    },
-    {
-      "upstream": "anthropics/claude-code#61890",
-      "url": "https://github.com/anthropics/claude-code/issues/61890",
-      "title": "[BUG] Remote Control: \"is not yet enabled for your account\" persists for Max user across all documented troubleshooting steps",
-      "impact": "needs_review",
-      "categories": [
-        "rate_limit",
-        "auth_token",
-        "fingerprint_ua"
-      ],
-      "tokenkey_status": "candidate_unverified",
-      "rationale": "Gateway/relay-relevant keyword match; not yet manually verified against TokenKey code.",
-      "updated_at": "2026-05-31T21:49:13Z"
+      "updated_at": "2026-06-03T20:43:27Z"
     },
     {
       "upstream": "anthropics/claude-code#61895",
@@ -2056,18 +2367,6 @@
       "updated_at": "2026-06-01T06:32:40Z"
     },
     {
-      "upstream": "anthropics/claude-code#62015",
-      "url": "https://github.com/anthropics/claude-code/issues/62015",
-      "title": "[BUG] Claude Code corrupted FlutterFlow project via deprecated proto field in MCP integration — server-level damage, project completely frozen",
-      "impact": "needs_review",
-      "categories": [
-        "model_lifecycle"
-      ],
-      "tokenkey_status": "candidate_unverified",
-      "rationale": "Gateway/relay-relevant keyword match; not yet manually verified against TokenKey code.",
-      "updated_at": "2026-05-31T11:01:53Z"
-    },
-    {
       "upstream": "anthropics/claude-code#62063",
       "url": "https://github.com/anthropics/claude-code/issues/62063",
       "title": "[BUG] Claude Code defaults to 1M context on fresh session with no workaround on Pro plan",
@@ -2077,7 +2376,7 @@
       ],
       "tokenkey_status": "candidate_unverified",
       "rationale": "Gateway/relay-relevant keyword match; not yet manually verified against TokenKey code.",
-      "updated_at": "2026-06-03T07:47:31Z"
+      "updated_at": "2026-06-03T18:03:34Z"
     },
     {
       "upstream": "anthropics/claude-code#62265",
@@ -2165,18 +2464,6 @@
       "updated_at": "2026-06-02T08:42:31Z"
     },
     {
-      "upstream": "anthropics/claude-code#62885",
-      "url": "https://github.com/anthropics/claude-code/issues/62885",
-      "title": "[Bug] Anthropic API Error: Missing corresponding server_tool_use block for advisor_tool_result",
-      "impact": "needs_review",
-      "categories": [
-        "request_shape_400"
-      ],
-      "tokenkey_status": "candidate_unverified",
-      "rationale": "Gateway/relay-relevant keyword match; not yet manually verified against TokenKey code.",
-      "updated_at": "2026-05-31T22:55:48Z"
-    },
-    {
       "upstream": "anthropics/claude-code#62924",
       "url": "https://github.com/anthropics/claude-code/issues/62924",
       "title": "[BUG] Remote Control bridge fails with \"/login\" on macOS desktop app despite valid claude.ai auth",
@@ -2212,33 +2499,7 @@
       ],
       "tokenkey_status": "candidate_unverified",
       "rationale": "Gateway/relay-relevant keyword match; not yet manually verified against TokenKey code.",
-      "updated_at": "2026-06-03T07:05:50Z"
-    },
-    {
-      "upstream": "anthropics/claude-code#63120",
-      "url": "https://github.com/anthropics/claude-code/issues/63120",
-      "title": "[BUG] 2.1.153 silently discards tools/list response from rmcp 0.12.0 HTTP MCP server (works in 2.1.152, wire-identical handshake)",
-      "impact": "needs_review",
-      "categories": [
-        "request_shape_400",
-        "fingerprint_ua"
-      ],
-      "tokenkey_status": "candidate_unverified",
-      "rationale": "Gateway/relay-relevant keyword match; not yet manually verified against TokenKey code.",
-      "updated_at": "2026-05-31T20:19:43Z"
-    },
-    {
-      "upstream": "anthropics/claude-code#63141",
-      "url": "https://github.com/anthropics/claude-code/issues/63141",
-      "title": "Subagents on Pro 1M tier: trivial probes pass, real workloads fail at first tool call (probe-vs-workload divergence)",
-      "impact": "needs_review",
-      "categories": [
-        "auth_token",
-        "model_lifecycle"
-      ],
-      "tokenkey_status": "candidate_unverified",
-      "rationale": "Gateway/relay-relevant keyword match; not yet manually verified against TokenKey code.",
-      "updated_at": "2026-05-31T12:35:09Z"
+      "updated_at": "2026-06-03T17:12:00Z"
     },
     {
       "upstream": "anthropics/claude-code#63147",
@@ -2251,32 +2512,6 @@
       "tokenkey_status": "candidate_unverified",
       "rationale": "Gateway/relay-relevant keyword match; not yet manually verified against TokenKey code.",
       "updated_at": "2026-06-01T01:45:00Z"
-    },
-    {
-      "upstream": "anthropics/claude-code#63192",
-      "url": "https://github.com/anthropics/claude-code/issues/63192",
-      "title": "Cancelling a parallel tool-call batch corrupts thinking blocks -> 400 \"thinking blocks cannot be modified\" permanently wedges the session",
-      "impact": "needs_review",
-      "categories": [
-        "request_shape_400",
-        "model_lifecycle",
-        "new_endpoints"
-      ],
-      "tokenkey_status": "candidate_unverified",
-      "rationale": "Gateway/relay-relevant keyword match; not yet manually verified against TokenKey code.",
-      "updated_at": "2026-05-31T19:24:52Z"
-    },
-    {
-      "upstream": "anthropics/claude-code#63199",
-      "url": "https://github.com/anthropics/claude-code/issues/63199",
-      "title": "[Bug] Anthropic API Error: Cannot Modify Thinking Blocks in Assistant Messages",
-      "impact": "needs_review",
-      "categories": [
-        "request_shape_400"
-      ],
-      "tokenkey_status": "candidate_unverified",
-      "rationale": "Gateway/relay-relevant keyword match; not yet manually verified against TokenKey code.",
-      "updated_at": "2026-05-31T13:57:19Z"
     },
     {
       "upstream": "anthropics/claude-code#63275",
@@ -2330,30 +2565,6 @@
       "updated_at": "2026-06-02T08:47:45Z"
     },
     {
-      "upstream": "anthropics/claude-code#63396",
-      "url": "https://github.com/anthropics/claude-code/issues/63396",
-      "title": "[BUG] CLI 2.1.154 builds invalid request after context ops (compact/clear/model-switch): system role at messages[0], and modified signed thinking blocks → 400 Error -> Wedged",
-      "impact": "needs_review",
-      "categories": [
-        "request_shape_400"
-      ],
-      "tokenkey_status": "candidate_unverified",
-      "rationale": "Gateway/relay-relevant keyword match; not yet manually verified against TokenKey code.",
-      "updated_at": "2026-05-31T15:16:36Z"
-    },
-    {
-      "upstream": "anthropics/claude-code#63420",
-      "url": "https://github.com/anthropics/claude-code/issues/63420",
-      "title": "[Bug] Anthropic API Error: Cannot modify thinking blocks in assistant message",
-      "impact": "needs_review",
-      "categories": [
-        "request_shape_400"
-      ],
-      "tokenkey_status": "candidate_unverified",
-      "rationale": "Gateway/relay-relevant keyword match; not yet manually verified against TokenKey code.",
-      "updated_at": "2026-05-31T11:33:50Z"
-    },
-    {
       "upstream": "anthropics/claude-code#63454",
       "url": "https://github.com/anthropics/claude-code/issues/63454",
       "title": "[BUG] API Error: 400 Failed to deserialize the JSON body into the target type",
@@ -2400,6 +2611,19 @@
       "tokenkey_status": "candidate_unverified",
       "rationale": "Gateway/relay-relevant keyword match; not yet manually verified against TokenKey code.",
       "updated_at": "2026-06-01T01:32:54Z"
+    },
+    {
+      "upstream": "anthropics/claude-code#63601",
+      "url": "https://github.com/anthropics/claude-code/issues/63601",
+      "title": "[BUG] Long-session compaction loses Write/Edit tool-use history → model misattributes its own work to the user",
+      "impact": "needs_review",
+      "categories": [
+        "request_shape_400",
+        "model_lifecycle"
+      ],
+      "tokenkey_status": "candidate_unverified",
+      "rationale": "Gateway/relay-relevant keyword match; not yet manually verified against TokenKey code.",
+      "updated_at": "2026-06-03T18:04:14Z"
     },
     {
       "upstream": "anthropics/claude-code#63634",
@@ -2451,31 +2675,6 @@
       "updated_at": "2026-06-01T18:22:08Z"
     },
     {
-      "upstream": "anthropics/claude-code#63685",
-      "url": "https://github.com/anthropics/claude-code/issues/63685",
-      "title": "Your organization has disabled Claude subscription access for Claude Code · Use an Anthropic API key instead, or ask your admin to enable access",
-      "impact": "needs_review",
-      "categories": [
-        "auth_token"
-      ],
-      "tokenkey_status": "candidate_unverified",
-      "rationale": "Gateway/relay-relevant keyword match; not yet manually verified against TokenKey code.",
-      "updated_at": "2026-05-31T17:38:36Z"
-    },
-    {
-      "upstream": "anthropics/claude-code#63693",
-      "url": "https://github.com/anthropics/claude-code/issues/63693",
-      "title": "[FEATURE] Expose model configuration for subagents in dynamic workflows",
-      "impact": "needs_review",
-      "categories": [
-        "rate_limit",
-        "model_lifecycle"
-      ],
-      "tokenkey_status": "candidate_unverified",
-      "rationale": "Gateway/relay-relevant keyword match; not yet manually verified against TokenKey code.",
-      "updated_at": "2026-05-31T22:34:46Z"
-    },
-    {
       "upstream": "anthropics/claude-code#63751",
       "url": "https://github.com/anthropics/claude-code/issues/63751",
       "title": "[BUG] AUP/cyber-safeguard false positives on legitimate own-software hardening; one hit contaminates entire session",
@@ -2498,7 +2697,7 @@
       ],
       "tokenkey_status": "candidate_unverified",
       "rationale": "Gateway/relay-relevant keyword match; not yet manually verified against TokenKey code.",
-      "updated_at": "2026-06-02T16:12:23Z"
+      "updated_at": "2026-06-03T17:11:17Z"
     },
     {
       "upstream": "anthropics/claude-code#63797",
@@ -2525,19 +2724,6 @@
       "updated_at": "2026-06-03T03:58:32Z"
     },
     {
-      "upstream": "anthropics/claude-code#63825",
-      "url": "https://github.com/anthropics/claude-code/issues/63825",
-      "title": "[BUG] TypeError \"undefined is not an object (evaluating 'H.replace')\" replaces Bash tool output",
-      "impact": "needs_review",
-      "categories": [
-        "request_shape_400",
-        "new_endpoints"
-      ],
-      "tokenkey_status": "candidate_unverified",
-      "rationale": "Gateway/relay-relevant keyword match; not yet manually verified against TokenKey code.",
-      "updated_at": "2026-05-31T12:44:07Z"
-    },
-    {
       "upstream": "anthropics/claude-code#63861",
       "url": "https://github.com/anthropics/claude-code/issues/63861",
       "title": "[BUG] Opus 4.8 in Claude Code declares work \"verified\" / \"done\" without running the canonical build — false-green regression vs. Opus 4.7",
@@ -2549,18 +2735,6 @@
       "tokenkey_status": "candidate_unverified",
       "rationale": "Gateway/relay-relevant keyword match; not yet manually verified against TokenKey code.",
       "updated_at": "2026-06-01T01:18:08Z"
-    },
-    {
-      "upstream": "anthropics/claude-code#63869",
-      "url": "https://github.com/anthropics/claude-code/issues/63869",
-      "title": "[BUG] API Error: 400 — thinking or redacted_thinking blocks in the latest assistant message cannot be modified.",
-      "impact": "needs_review",
-      "categories": [
-        "request_shape_400"
-      ],
-      "tokenkey_status": "candidate_unverified",
-      "rationale": "Gateway/relay-relevant keyword match; not yet manually verified against TokenKey code.",
-      "updated_at": "2026-05-31T19:47:15Z"
     },
     {
       "upstream": "anthropics/claude-code#63870",
@@ -2584,7 +2758,7 @@
       ],
       "tokenkey_status": "candidate_unverified",
       "rationale": "Gateway/relay-relevant keyword match; not yet manually verified against TokenKey code.",
-      "updated_at": "2026-06-03T08:58:13Z"
+      "updated_at": "2026-06-03T10:56:07Z"
     },
     {
       "upstream": "anthropics/claude-code#63880",
@@ -2649,6 +2823,18 @@
       "updated_at": "2026-06-03T07:44:02Z"
     },
     {
+      "upstream": "anthropics/claude-code#63919",
+      "url": "https://github.com/anthropics/claude-code/issues/63919",
+      "title": "[BUG] Login succeeds but every request immediately returns \"Not logged in\" (macOS, OAuth)",
+      "impact": "needs_review",
+      "categories": [
+        "auth_token"
+      ],
+      "tokenkey_status": "candidate_unverified",
+      "rationale": "Gateway/relay-relevant keyword match; not yet manually verified against TokenKey code.",
+      "updated_at": "2026-06-03T14:24:17Z"
+    },
+    {
       "upstream": "anthropics/claude-code#63929",
       "url": "https://github.com/anthropics/claude-code/issues/63929",
       "title": "[BUG] Server is temporarily limiting requests",
@@ -2658,7 +2844,7 @@
       ],
       "tokenkey_status": "candidate_unverified",
       "rationale": "Gateway/relay-relevant keyword match; not yet manually verified against TokenKey code.",
-      "updated_at": "2026-06-02T02:02:09Z"
+      "updated_at": "2026-06-03T15:36:37Z"
     },
     {
       "upstream": "anthropics/claude-code#63930",
@@ -2675,21 +2861,6 @@
       "updated_at": "2026-06-01T17:31:12Z"
     },
     {
-      "upstream": "anthropics/claude-code#63966",
-      "url": "https://github.com/anthropics/claude-code/issues/63966",
-      "title": "[BUG] Tool-call results empty in live UI then flush late/out-of-order (Bash, Read, MCP, advisor) — macOS, Opus 4.8, parallel batches",
-      "impact": "needs_review",
-      "categories": [
-        "request_shape_400",
-        "auth_token",
-        "model_lifecycle",
-        "new_endpoints"
-      ],
-      "tokenkey_status": "candidate_unverified",
-      "rationale": "Gateway/relay-relevant keyword match; not yet manually verified against TokenKey code.",
-      "updated_at": "2026-05-31T23:33:17Z"
-    },
-    {
       "upstream": "anthropics/claude-code#64007",
       "url": "https://github.com/anthropics/claude-code/issues/64007",
       "title": "cct = TUI: turn-transition render omission — content recorded in .jsonl but absent from scrollback (2 incidents across 2 versions)",
@@ -2700,20 +2871,6 @@
       "tokenkey_status": "candidate_unverified",
       "rationale": "Gateway/relay-relevant keyword match; not yet manually verified against TokenKey code.",
       "updated_at": "2026-06-01T21:11:50Z"
-    },
-    {
-      "upstream": "anthropics/claude-code#64030",
-      "url": "https://github.com/anthropics/claude-code/issues/64030",
-      "title": "CLI surfaces transient 429 \"rate_limit_error\" to user with no backoff/retry; session sits idle until user types `continue`",
-      "impact": "needs_review",
-      "categories": [
-        "request_shape_400",
-        "rate_limit",
-        "auth_token"
-      ],
-      "tokenkey_status": "candidate_unverified",
-      "rationale": "Gateway/relay-relevant keyword match; not yet manually verified against TokenKey code.",
-      "updated_at": "2026-05-31T23:47:00Z"
     },
     {
       "upstream": "anthropics/claude-code#64034",
@@ -2728,6 +2885,18 @@
       "updated_at": "2026-06-02T03:19:49Z"
     },
     {
+      "upstream": "anthropics/claude-code#64037",
+      "url": "https://github.com/anthropics/claude-code/issues/64037",
+      "title": "Context hit 1M token limit with no auto-compaction and no recovery path",
+      "impact": "needs_review",
+      "categories": [
+        "model_lifecycle"
+      ],
+      "tokenkey_status": "candidate_unverified",
+      "rationale": "Gateway/relay-relevant keyword match; not yet manually verified against TokenKey code.",
+      "updated_at": "2026-06-03T18:36:43Z"
+    },
+    {
       "upstream": "anthropics/claude-code#64047",
       "url": "https://github.com/anthropics/claude-code/issues/64047",
       "title": "[BUG] Automatic parallel-tool-call cancellation is indistinguishable from a user interrupt",
@@ -2738,32 +2907,6 @@
       "tokenkey_status": "candidate_unverified",
       "rationale": "Gateway/relay-relevant keyword match; not yet manually verified against TokenKey code.",
       "updated_at": "2026-06-01T19:01:41Z"
-    },
-    {
-      "upstream": "anthropics/claude-code#64049",
-      "url": "https://github.com/anthropics/claude-code/issues/64049",
-      "title": "[MODEL] Opus 4.8 (max effort) likely hallucinated a prompt-injection in tool output, then acted on it for many turns",
-      "impact": "needs_review",
-      "categories": [
-        "request_shape_400",
-        "model_lifecycle"
-      ],
-      "tokenkey_status": "candidate_unverified",
-      "rationale": "Gateway/relay-relevant keyword match; not yet manually verified against TokenKey code.",
-      "updated_at": "2026-05-31T16:19:46Z"
-    },
-    {
-      "upstream": "anthropics/claude-code#64065",
-      "url": "https://github.com/anthropics/claude-code/issues/64065",
-      "title": "Opus 4.8 / xhigh / Claude Code: model asserts specific tool-output values BEFORE the tool calls return — model self-diagnoses the bug in-context but keeps doing it",
-      "impact": "needs_review",
-      "categories": [
-        "request_shape_400",
-        "model_lifecycle"
-      ],
-      "tokenkey_status": "candidate_unverified",
-      "rationale": "Gateway/relay-relevant keyword match; not yet manually verified against TokenKey code.",
-      "updated_at": "2026-05-31T19:56:17Z"
     },
     {
       "upstream": "anthropics/claude-code#64080",
@@ -2777,19 +2920,7 @@
       ],
       "tokenkey_status": "candidate_unverified",
       "rationale": "Gateway/relay-relevant keyword match; not yet manually verified against TokenKey code.",
-      "updated_at": "2026-06-01T16:43:04Z"
-    },
-    {
-      "upstream": "anthropics/claude-code#64088",
-      "url": "https://github.com/anthropics/claude-code/issues/64088",
-      "title": "[BUG] API Error: Server is temporarily limiting requests (not your usage limit) · Rate limited",
-      "impact": "needs_review",
-      "categories": [
-        "rate_limit"
-      ],
-      "tokenkey_status": "candidate_unverified",
-      "rationale": "Gateway/relay-relevant keyword match; not yet manually verified against TokenKey code.",
-      "updated_at": "2026-05-31T15:45:42Z"
+      "updated_at": "2026-06-03T13:45:32Z"
     },
     {
       "upstream": "anthropics/claude-code#64097",
@@ -2856,107 +2987,6 @@
       "updated_at": "2026-06-02T16:45:10Z"
     },
     {
-      "upstream": "anthropics/claude-code#64177",
-      "url": "https://github.com/anthropics/claude-code/issues/64177",
-      "title": "Workflow counts API-errored subagents as \"completed\"; 429/500/529 storm under multi-agent load",
-      "impact": "needs_review",
-      "categories": [
-        "rate_limit",
-        "model_lifecycle"
-      ],
-      "tokenkey_status": "candidate_unverified",
-      "rationale": "Gateway/relay-relevant keyword match; not yet manually verified against TokenKey code.",
-      "updated_at": "2026-05-31T21:17:05Z"
-    },
-    {
-      "upstream": "anthropics/claude-code#64190",
-      "url": "https://github.com/anthropics/claude-code/issues/64190",
-      "title": "After /compact on Opus 4.8 (1M), whole tool calls emitted as <invoke> text instead of executing (not seen on 4.7)",
-      "impact": "needs_review",
-      "categories": [
-        "request_shape_400",
-        "model_lifecycle"
-      ],
-      "tokenkey_status": "candidate_unverified",
-      "rationale": "Gateway/relay-relevant keyword match; not yet manually verified against TokenKey code.",
-      "updated_at": "2026-05-31T10:46:01Z"
-    },
-    {
-      "upstream": "anthropics/claude-code#64195",
-      "url": "https://github.com/anthropics/claude-code/issues/64195",
-      "title": "[Feature Request] Restore deprecated Claude Opus versions (4.6, 4.7) with deprecation warnings",
-      "impact": "needs_review",
-      "categories": [
-        "model_lifecycle"
-      ],
-      "tokenkey_status": "candidate_unverified",
-      "rationale": "Gateway/relay-relevant keyword match; not yet manually verified against TokenKey code.",
-      "updated_at": "2026-05-31T11:02:21Z"
-    },
-    {
-      "upstream": "anthropics/claude-code#64196",
-      "url": "https://github.com/anthropics/claude-code/issues/64196",
-      "title": "Claude Pro: 1M context limit breaks active workflows without warning",
-      "impact": "needs_review",
-      "categories": [
-        "request_shape_400"
-      ],
-      "tokenkey_status": "candidate_unverified",
-      "rationale": "Gateway/relay-relevant keyword match; not yet manually verified against TokenKey code.",
-      "updated_at": "2026-05-31T13:21:42Z"
-    },
-    {
-      "upstream": "anthropics/claude-code#64209",
-      "url": "https://github.com/anthropics/claude-code/issues/64209",
-      "title": "[Bug] Tool-layer unreliability in long/compacted sessions: duplicated results, delayed delivery, empty/garbled file reads",
-      "impact": "needs_review",
-      "categories": [
-        "model_lifecycle"
-      ],
-      "tokenkey_status": "candidate_unverified",
-      "rationale": "Gateway/relay-relevant keyword match; not yet manually verified against TokenKey code.",
-      "updated_at": "2026-05-31T19:13:08Z"
-    },
-    {
-      "upstream": "anthropics/claude-code#64212",
-      "url": "https://github.com/anthropics/claude-code/issues/64212",
-      "title": "[MODEL] Opus 4.8 (xhigh): claims work verified when it isn't, self-contradicts, and over-parallelizes contradictory tool calls — on a low-complexity codebase",
-      "impact": "needs_review",
-      "categories": [
-        "model_lifecycle",
-        "new_endpoints",
-        "fingerprint_ua"
-      ],
-      "tokenkey_status": "candidate_unverified",
-      "rationale": "Gateway/relay-relevant keyword match; not yet manually verified against TokenKey code.",
-      "updated_at": "2026-05-31T14:42:58Z"
-    },
-    {
-      "upstream": "anthropics/claude-code#64213",
-      "url": "https://github.com/anthropics/claude-code/issues/64213",
-      "title": "[BUG] 400 \"thinking/redacted_thinking blocks cannot be modified\" bricks session after large multi-tool turns",
-      "impact": "needs_review",
-      "categories": [
-        "request_shape_400",
-        "new_endpoints"
-      ],
-      "tokenkey_status": "candidate_unverified",
-      "rationale": "Gateway/relay-relevant keyword match; not yet manually verified against TokenKey code.",
-      "updated_at": "2026-05-31T14:57:48Z"
-    },
-    {
-      "upstream": "anthropics/claude-code#64216",
-      "url": "https://github.com/anthropics/claude-code/issues/64216",
-      "title": "[Bug] Increased tool call failures and retry attempts with Opus model",
-      "impact": "needs_review",
-      "categories": [
-        "model_lifecycle"
-      ],
-      "tokenkey_status": "candidate_unverified",
-      "rationale": "Gateway/relay-relevant keyword match; not yet manually verified against TokenKey code.",
-      "updated_at": "2026-05-31T13:02:32Z"
-    },
-    {
       "upstream": "anthropics/claude-code#64227",
       "url": "https://github.com/anthropics/claude-code/issues/64227",
       "title": "Claude Code repeatedly made unauthorized destructive changes, ignored explicit rules, and permanently destroyed user data across multiple sessions[MODEL]",
@@ -2967,43 +2997,6 @@
       "tokenkey_status": "candidate_unverified",
       "rationale": "Gateway/relay-relevant keyword match; not yet manually verified against TokenKey code.",
       "updated_at": "2026-06-01T21:39:58Z"
-    },
-    {
-      "upstream": "anthropics/claude-code#64229",
-      "url": "https://github.com/anthropics/claude-code/issues/64229",
-      "title": "Server-side tool (server_tool_use) emitted but no result returned; response reports stop_reason: end_turn",
-      "impact": "needs_review",
-      "categories": [
-        "request_shape_400",
-        "model_lifecycle"
-      ],
-      "tokenkey_status": "candidate_unverified",
-      "rationale": "Gateway/relay-relevant keyword match; not yet manually verified against TokenKey code.",
-      "updated_at": "2026-05-31T21:18:01Z"
-    },
-    {
-      "upstream": "anthropics/claude-code#64232",
-      "url": "https://github.com/anthropics/claude-code/issues/64232",
-      "title": "[Bug] Single-use OAuth refresh token consumed by test copy invalidates production token",
-      "impact": "needs_review",
-      "categories": [
-        "auth_token"
-      ],
-      "tokenkey_status": "candidate_unverified",
-      "rationale": "Gateway/relay-relevant keyword match; not yet manually verified against TokenKey code.",
-      "updated_at": "2026-05-31T14:15:03Z"
-    },
-    {
-      "upstream": "anthropics/claude-code#64233",
-      "url": "https://github.com/anthropics/claude-code/issues/64233",
-      "title": "[BUG] Windows: stopShellPty on tab switch kills session with exit code 4294967295 — regression in May 27+ build",
-      "impact": "needs_review",
-      "categories": [
-        "auth_token"
-      ],
-      "tokenkey_status": "candidate_unverified",
-      "rationale": "Gateway/relay-relevant keyword match; not yet manually verified against TokenKey code.",
-      "updated_at": "2026-05-31T14:23:03Z"
     },
     {
       "upstream": "anthropics/claude-code#64235",
@@ -3019,44 +3012,6 @@
       "updated_at": "2026-06-01T04:21:58Z"
     },
     {
-      "upstream": "anthropics/claude-code#64237",
-      "url": "https://github.com/anthropics/claude-code/issues/64237",
-      "title": "Expose a way to disable parallel tool execution (the API's disable_parallel_tool_use) in Claude Code",
-      "impact": "needs_review",
-      "categories": [
-        "request_shape_400",
-        "model_lifecycle",
-        "new_endpoints"
-      ],
-      "tokenkey_status": "candidate_unverified",
-      "rationale": "Gateway/relay-relevant keyword match; not yet manually verified against TokenKey code.",
-      "updated_at": "2026-05-31T14:50:17Z"
-    },
-    {
-      "upstream": "anthropics/claude-code#64241",
-      "url": "https://github.com/anthropics/claude-code/issues/64241",
-      "title": "run_in_background silently kills active processes and reports success (exit code 0)",
-      "impact": "needs_review",
-      "categories": [
-        "auth_token"
-      ],
-      "tokenkey_status": "candidate_unverified",
-      "rationale": "Gateway/relay-relevant keyword match; not yet manually verified against TokenKey code.",
-      "updated_at": "2026-05-31T15:09:53Z"
-    },
-    {
-      "upstream": "anthropics/claude-code#64246",
-      "url": "https://github.com/anthropics/claude-code/issues/64246",
-      "title": "Parallel tool-call batch cascades \"Cancelled\" to independent calls when one fails",
-      "impact": "needs_review",
-      "categories": [
-        "model_lifecycle"
-      ],
-      "tokenkey_status": "candidate_unverified",
-      "rationale": "Gateway/relay-relevant keyword match; not yet manually verified against TokenKey code.",
-      "updated_at": "2026-05-31T20:00:39Z"
-    },
-    {
       "upstream": "anthropics/claude-code#64251",
       "url": "https://github.com/anthropics/claude-code/issues/64251",
       "title": "[BUG] Claude Code query worker dies silently on Windows — `--version` works, but every query produces no output (exit 0); VS Code extension shows \"Query closed before response received\"",
@@ -3068,31 +3023,6 @@
       "tokenkey_status": "candidate_unverified",
       "rationale": "Gateway/relay-relevant keyword match; not yet manually verified against TokenKey code.",
       "updated_at": "2026-06-02T03:14:12Z"
-    },
-    {
-      "upstream": "anthropics/claude-code#64256",
-      "url": "https://github.com/anthropics/claude-code/issues/64256",
-      "title": "[BUG] Persistent server-side session billing phantom usage — cannot be killed from client",
-      "impact": "needs_review",
-      "categories": [
-        "auth_token",
-        "new_endpoints"
-      ],
-      "tokenkey_status": "candidate_unverified",
-      "rationale": "Gateway/relay-relevant keyword match; not yet manually verified against TokenKey code.",
-      "updated_at": "2026-05-31T16:00:37Z"
-    },
-    {
-      "upstream": "anthropics/claude-code#64257",
-      "url": "https://github.com/anthropics/claude-code/issues/64257",
-      "title": "opus-4-8 appears to re-fetch identical tool results after normal (non-error) returns — 2-3x vs opus-4-7",
-      "impact": "needs_review",
-      "categories": [
-        "prompt_caching"
-      ],
-      "tokenkey_status": "candidate_unverified",
-      "rationale": "Gateway/relay-relevant keyword match; not yet manually verified against TokenKey code.",
-      "updated_at": "2026-06-01T00:01:49Z"
     },
     {
       "upstream": "anthropics/claude-code#64260",
@@ -3109,19 +3039,6 @@
       "updated_at": "2026-06-02T20:18:07Z"
     },
     {
-      "upstream": "anthropics/claude-code#64269",
-      "url": "https://github.com/anthropics/claude-code/issues/64269",
-      "title": "C:/Program Files/Git/schedule fails with \"trouble connecting with your remote claude.ai account\" — persistent, no public status incident",
-      "impact": "needs_review",
-      "categories": [
-        "auth_token",
-        "fingerprint_ua"
-      ],
-      "tokenkey_status": "candidate_unverified",
-      "rationale": "Gateway/relay-relevant keyword match; not yet manually verified against TokenKey code.",
-      "updated_at": "2026-05-31T17:11:18Z"
-    },
-    {
       "upstream": "anthropics/claude-code#64278",
       "url": "https://github.com/anthropics/claude-code/issues/64278",
       "title": "/compact fails with 'thinking or redacted_thinking blocks cannot be modified' error when context is too long",
@@ -3132,80 +3049,6 @@
       "tokenkey_status": "candidate_unverified",
       "rationale": "Gateway/relay-relevant keyword match; not yet manually verified against TokenKey code.",
       "updated_at": "2026-06-03T10:18:50Z"
-    },
-    {
-      "upstream": "anthropics/claude-code#64284",
-      "url": "https://github.com/anthropics/claude-code/issues/64284",
-      "title": "[Bug] File read errors not surfaced, causing hallucinations in tool use",
-      "impact": "needs_review",
-      "categories": [
-        "rate_limit",
-        "auth_token",
-        "prompt_caching"
-      ],
-      "tokenkey_status": "candidate_unverified",
-      "rationale": "Gateway/relay-relevant keyword match; not yet manually verified against TokenKey code.",
-      "updated_at": "2026-05-31T22:18:26Z"
-    },
-    {
-      "upstream": "anthropics/claude-code#64317",
-      "url": "https://github.com/anthropics/claude-code/issues/64317",
-      "title": "Intermittent tool-result corruption: stale/replayed output + sibling cancellation (v2.1.143)",
-      "impact": "needs_review",
-      "categories": [
-        "request_shape_400"
-      ],
-      "tokenkey_status": "candidate_unverified",
-      "rationale": "Gateway/relay-relevant keyword match; not yet manually verified against TokenKey code.",
-      "updated_at": "2026-05-31T20:55:33Z"
-    },
-    {
-      "upstream": "anthropics/claude-code#64321",
-      "url": "https://github.com/anthropics/claude-code/issues/64321",
-      "title": "[BUG]",
-      "impact": "needs_review",
-      "categories": [
-        "request_shape_400"
-      ],
-      "tokenkey_status": "candidate_unverified",
-      "rationale": "Gateway/relay-relevant keyword match; not yet manually verified against TokenKey code.",
-      "updated_at": "2026-05-31T20:42:55Z"
-    },
-    {
-      "upstream": "anthropics/claude-code#64322",
-      "url": "https://github.com/anthropics/claude-code/issues/64322",
-      "title": "Worktree isolation: Edit-tool path validation + drift-detection in task-notification payload",
-      "impact": "needs_review",
-      "categories": [
-        "model_lifecycle"
-      ],
-      "tokenkey_status": "candidate_unverified",
-      "rationale": "Gateway/relay-relevant keyword match; not yet manually verified against TokenKey code.",
-      "updated_at": "2026-05-31T20:57:27Z"
-    },
-    {
-      "upstream": "anthropics/claude-code#64327",
-      "url": "https://github.com/anthropics/claude-code/issues/64327",
-      "title": "[BUG] API Error: Server is temporarily limiting requests (not your usage limit) · Rate limited",
-      "impact": "needs_review",
-      "categories": [
-        "rate_limit"
-      ],
-      "tokenkey_status": "candidate_unverified",
-      "rationale": "Gateway/relay-relevant keyword match; not yet manually verified against TokenKey code.",
-      "updated_at": "2026-05-31T21:08:41Z"
-    },
-    {
-      "upstream": "anthropics/claude-code#64328",
-      "url": "https://github.com/anthropics/claude-code/issues/64328",
-      "title": "[BUG] Workflow harness retries indefinitely on HTTP 429 rate_limit — 97 agents, 2M tokens burned in 34 seconds ()",
-      "impact": "needs_review",
-      "categories": [
-        "rate_limit"
-      ],
-      "tokenkey_status": "candidate_unverified",
-      "rationale": "Gateway/relay-relevant keyword match; not yet manually verified against TokenKey code.",
-      "updated_at": "2026-05-31T21:27:01Z"
     },
     {
       "upstream": "anthropics/claude-code#64329",
@@ -3220,18 +3063,6 @@
       "updated_at": "2026-06-01T03:04:27Z"
     },
     {
-      "upstream": "anthropics/claude-code#64330",
-      "url": "https://github.com/anthropics/claude-code/issues/64330",
-      "title": "[BUG] Installer places binary in VS Code Snap directory, leading to silent uninstallation on Ubuntu",
-      "impact": "needs_review",
-      "categories": [
-        "prompt_caching"
-      ],
-      "tokenkey_status": "candidate_unverified",
-      "rationale": "Gateway/relay-relevant keyword match; not yet manually verified against TokenKey code.",
-      "updated_at": "2026-05-31T21:21:49Z"
-    },
-    {
       "upstream": "anthropics/claude-code#64336",
       "url": "https://github.com/anthropics/claude-code/issues/64336",
       "title": "Multiple profile directories (~/.claude-a, ~/.claude-b) require independent re-logins despite sharing the same account",
@@ -3242,30 +3073,6 @@
       "tokenkey_status": "candidate_unverified",
       "rationale": "Gateway/relay-relevant keyword match; not yet manually verified against TokenKey code.",
       "updated_at": "2026-06-01T03:07:07Z"
-    },
-    {
-      "upstream": "anthropics/claude-code#64339",
-      "url": "https://github.com/anthropics/claude-code/issues/64339",
-      "title": "[BUG] Thousands of ghost \"root-server\" sessions regenerate on every launch, crashing the app — survive full uninstall/reinstall and all known data clearing",
-      "impact": "needs_review",
-      "categories": [
-        "model_lifecycle"
-      ],
-      "tokenkey_status": "candidate_unverified",
-      "rationale": "Gateway/relay-relevant keyword match; not yet manually verified against TokenKey code.",
-      "updated_at": "2026-05-31T22:18:55Z"
-    },
-    {
-      "upstream": "anthropics/claude-code#64345",
-      "url": "https://github.com/anthropics/claude-code/issues/64345",
-      "title": "[MODEL] Claude ignored instructions/configuration (also: Claude made incorrect assumptions)",
-      "impact": "needs_review",
-      "categories": [
-        "new_endpoints"
-      ],
-      "tokenkey_status": "candidate_unverified",
-      "rationale": "Gateway/relay-relevant keyword match; not yet manually verified against TokenKey code.",
-      "updated_at": "2026-05-31T22:48:37Z"
     },
     {
       "upstream": "anthropics/claude-code#64346",
@@ -3611,7 +3418,7 @@
       ],
       "tokenkey_status": "candidate_unverified",
       "rationale": "Gateway/relay-relevant keyword match; not yet manually verified against TokenKey code.",
-      "updated_at": "2026-06-01T12:31:52Z"
+      "updated_at": "2026-06-03T10:43:57Z"
     },
     {
       "upstream": "anthropics/claude-code#64477",
@@ -4417,7 +4224,7 @@
       ],
       "tokenkey_status": "candidate_unverified",
       "rationale": "Gateway/relay-relevant keyword match; not yet manually verified against TokenKey code.",
-      "updated_at": "2026-06-02T16:39:49Z"
+      "updated_at": "2026-06-03T17:01:44Z"
     },
     {
       "upstream": "anthropics/claude-code#64797",
@@ -4482,18 +4289,6 @@
       "updated_at": "2026-06-02T17:43:24Z"
     },
     {
-      "upstream": "anthropics/claude-code#64832",
-      "url": "https://github.com/anthropics/claude-code/issues/64832",
-      "title": "Suspected Node.js subprocess leak in v2.1.160 — ~115 node processes exhaust RAM, trigger system-wide OOM",
-      "impact": "needs_review",
-      "categories": [
-        "request_shape_400"
-      ],
-      "tokenkey_status": "candidate_unverified",
-      "rationale": "Gateway/relay-relevant keyword match; not yet manually verified against TokenKey code.",
-      "updated_at": "2026-06-03T00:21:03Z"
-    },
-    {
       "upstream": "anthropics/claude-code#64838",
       "url": "https://github.com/anthropics/claude-code/issues/64838",
       "title": "[BUG] Cowork remote MCP connector — \"Couldn't reach the MCP server\" with auth state desync, reference ID returned for support lookup",
@@ -4503,7 +4298,7 @@
       ],
       "tokenkey_status": "candidate_unverified",
       "rationale": "Gateway/relay-relevant keyword match; not yet manually verified against TokenKey code.",
-      "updated_at": "2026-06-02T20:36:30Z"
+      "updated_at": "2026-06-03T12:51:27Z"
     },
     {
       "upstream": "anthropics/claude-code#64846",
@@ -4861,7 +4656,7 @@
       ],
       "tokenkey_status": "candidate_unverified",
       "rationale": "Gateway/relay-relevant keyword match; not yet manually verified against TokenKey code.",
-      "updated_at": "2026-06-03T10:10:16Z"
+      "updated_at": "2026-06-03T10:46:16Z"
     },
     {
       "upstream": "anthropics/claude-code#64974",
@@ -4873,7 +4668,7 @@
       ],
       "tokenkey_status": "candidate_unverified",
       "rationale": "Gateway/relay-relevant keyword match; not yet manually verified against TokenKey code.",
-      "updated_at": "2026-06-03T07:07:27Z"
+      "updated_at": "2026-06-03T19:39:25Z"
     },
     {
       "upstream": "anthropics/claude-code#64977",
@@ -4885,7 +4680,7 @@
       ],
       "tokenkey_status": "candidate_unverified",
       "rationale": "Gateway/relay-relevant keyword match; not yet manually verified against TokenKey code.",
-      "updated_at": "2026-06-03T07:24:22Z"
+      "updated_at": "2026-06-03T19:58:38Z"
     },
     {
       "upstream": "anthropics/claude-code#64982",
@@ -4961,6 +4756,324 @@
       "updated_at": "2026-06-03T10:00:10Z"
     },
     {
+      "upstream": "anthropics/claude-code#65029",
+      "url": "https://github.com/anthropics/claude-code/issues/65029",
+      "title": "[BUG] 1M context auto-switch triggers at ~72% usage and cannot be disabled via env var",
+      "impact": "needs_review",
+      "categories": [
+        "model_lifecycle"
+      ],
+      "tokenkey_status": "candidate_unverified",
+      "rationale": "Gateway/relay-relevant keyword match; not yet manually verified against TokenKey code.",
+      "updated_at": "2026-06-03T11:15:11Z"
+    },
+    {
+      "upstream": "anthropics/claude-code#65030",
+      "url": "https://github.com/anthropics/claude-code/issues/65030",
+      "title": "Add raw token count fields to statusline input JSON",
+      "impact": "needs_review",
+      "categories": [
+        "prompt_caching"
+      ],
+      "tokenkey_status": "candidate_unverified",
+      "rationale": "Gateway/relay-relevant keyword match; not yet manually verified against TokenKey code.",
+      "updated_at": "2026-06-03T11:26:34Z"
+    },
+    {
+      "upstream": "anthropics/claude-code#65036",
+      "url": "https://github.com/anthropics/claude-code/issues/65036",
+      "title": "[BUG] MCP OAuth: Claude doesn't auto-refresh access tokens, daily \"Connection expired\" despite valid refresh token",
+      "impact": "needs_review",
+      "categories": [
+        "beta_header_drift",
+        "auth_token"
+      ],
+      "tokenkey_status": "candidate_unverified",
+      "rationale": "Gateway/relay-relevant keyword match; not yet manually verified against TokenKey code.",
+      "updated_at": "2026-06-03T17:53:29Z"
+    },
+    {
+      "upstream": "anthropics/claude-code#65051",
+      "url": "https://github.com/anthropics/claude-code/issues/65051",
+      "title": "[Bug] Background (daemon) sessions drop assistant text blocks from transcript when response mixes text with tool_use (regression 2.1.160 → 2.1.161)",
+      "impact": "needs_review",
+      "categories": [
+        "request_shape_400",
+        "model_lifecycle"
+      ],
+      "tokenkey_status": "candidate_unverified",
+      "rationale": "Gateway/relay-relevant keyword match; not yet manually verified against TokenKey code.",
+      "updated_at": "2026-06-03T15:36:12Z"
+    },
+    {
+      "upstream": "anthropics/claude-code#65054",
+      "url": "https://github.com/anthropics/claude-code/issues/65054",
+      "title": "org_level_disabled error with active Pro subscription as personal org admin",
+      "impact": "needs_review",
+      "categories": [
+        "auth_token"
+      ],
+      "tokenkey_status": "candidate_unverified",
+      "rationale": "Gateway/relay-relevant keyword match; not yet manually verified against TokenKey code.",
+      "updated_at": "2026-06-03T13:03:07Z"
+    },
+    {
+      "upstream": "anthropics/claude-code#65065",
+      "url": "https://github.com/anthropics/claude-code/issues/65065",
+      "title": "[Bug] OAuth login fails in tmux environment",
+      "impact": "needs_review",
+      "categories": [
+        "auth_token"
+      ],
+      "tokenkey_status": "candidate_unverified",
+      "rationale": "Gateway/relay-relevant keyword match; not yet manually verified against TokenKey code.",
+      "updated_at": "2026-06-03T17:33:42Z"
+    },
+    {
+      "upstream": "anthropics/claude-code#65081",
+      "url": "https://github.com/anthropics/claude-code/issues/65081",
+      "title": "[BUG] Indica que Bun 1.3.14 crashea en VMs Hyper-V sin AVX expuesto y que debería usar un fallback con Node.js. Es un bug legítimo que afecta a muchos usuarios en VPS Hyper-V.",
+      "impact": "needs_review",
+      "categories": [
+        "model_lifecycle"
+      ],
+      "tokenkey_status": "candidate_unverified",
+      "rationale": "Gateway/relay-relevant keyword match; not yet manually verified against TokenKey code.",
+      "updated_at": "2026-06-03T15:30:01Z"
+    },
+    {
+      "upstream": "anthropics/claude-code#65082",
+      "url": "https://github.com/anthropics/claude-code/issues/65082",
+      "title": "Session interrupted by \"Usage credits required for 1M context\" error",
+      "impact": "needs_review",
+      "categories": [
+        "model_lifecycle"
+      ],
+      "tokenkey_status": "candidate_unverified",
+      "rationale": "Gateway/relay-relevant keyword match; not yet manually verified against TokenKey code.",
+      "updated_at": "2026-06-03T15:34:35Z"
+    },
+    {
+      "upstream": "anthropics/claude-code#65085",
+      "url": "https://github.com/anthropics/claude-code/issues/65085",
+      "title": "[BUG] Model emits Cyrillic homoglyphs in generated identifiers (branch names)",
+      "impact": "needs_review",
+      "categories": [
+        "model_lifecycle"
+      ],
+      "tokenkey_status": "candidate_unverified",
+      "rationale": "Gateway/relay-relevant keyword match; not yet manually verified against TokenKey code.",
+      "updated_at": "2026-06-03T15:38:12Z"
+    },
+    {
+      "upstream": "anthropics/claude-code#65094",
+      "url": "https://github.com/anthropics/claude-code/issues/65094",
+      "title": "claude -p does not wait for --mcp-config MCP servers before the first turn (async connect → tools missing); regression 2.1.110→2.1.119",
+      "impact": "needs_review",
+      "categories": [
+        "request_shape_400"
+      ],
+      "tokenkey_status": "candidate_unverified",
+      "rationale": "Gateway/relay-relevant keyword match; not yet manually verified against TokenKey code.",
+      "updated_at": "2026-06-03T15:57:19Z"
+    },
+    {
+      "upstream": "anthropics/claude-code#65098",
+      "url": "https://github.com/anthropics/claude-code/issues/65098",
+      "title": "Context compaction corrupts server-side tool pairs (advisor_tool_result without server_tool_use)",
+      "impact": "needs_review",
+      "categories": [
+        "request_shape_400"
+      ],
+      "tokenkey_status": "candidate_unverified",
+      "rationale": "Gateway/relay-relevant keyword match; not yet manually verified against TokenKey code.",
+      "updated_at": "2026-06-03T16:02:13Z"
+    },
+    {
+      "upstream": "anthropics/claude-code#65100",
+      "url": "https://github.com/anthropics/claude-code/issues/65100",
+      "title": "Zoho Projects MCP connector returns HTTP 500 on all API calls for Zoho CRM Plus accounts",
+      "impact": "needs_review",
+      "categories": [
+        "auth_token"
+      ],
+      "tokenkey_status": "candidate_unverified",
+      "rationale": "Gateway/relay-relevant keyword match; not yet manually verified against TokenKey code.",
+      "updated_at": "2026-06-03T16:34:12Z"
+    },
+    {
+      "upstream": "anthropics/claude-code#65101",
+      "url": "https://github.com/anthropics/claude-code/issues/65101",
+      "title": "[BUG] oauth_org_not_allowed on personal Pro account — subscription access blocked without any changes",
+      "impact": "needs_review",
+      "categories": [
+        "auth_token",
+        "fingerprint_ua"
+      ],
+      "tokenkey_status": "candidate_unverified",
+      "rationale": "Gateway/relay-relevant keyword match; not yet manually verified against TokenKey code.",
+      "updated_at": "2026-06-03T16:38:35Z"
+    },
+    {
+      "upstream": "anthropics/claude-code#65102",
+      "url": "https://github.com/anthropics/claude-code/issues/65102",
+      "title": "[BUG] API Error: Server is temporarily limiting requests (not your usage limit) · Rate limited",
+      "impact": "needs_review",
+      "categories": [
+        "rate_limit"
+      ],
+      "tokenkey_status": "candidate_unverified",
+      "rationale": "Gateway/relay-relevant keyword match; not yet manually verified against TokenKey code.",
+      "updated_at": "2026-06-03T16:41:45Z"
+    },
+    {
+      "upstream": "anthropics/claude-code#65106",
+      "url": "https://github.com/anthropics/claude-code/issues/65106",
+      "title": "I'm ready to help generate a GitHub issue title for Claude Code, but I don't see a bug report in your message. Could you please provide the bug report details that you'd like me to convert into a concise issue title?",
+      "impact": "needs_review",
+      "categories": [
+        "auth_token"
+      ],
+      "tokenkey_status": "candidate_unverified",
+      "rationale": "Gateway/relay-relevant keyword match; not yet manually verified against TokenKey code.",
+      "updated_at": "2026-06-03T17:03:37Z"
+    },
+    {
+      "upstream": "anthropics/claude-code#65108",
+      "url": "https://github.com/anthropics/claude-code/issues/65108",
+      "title": "ScheduleWakeup loop: status updates not visible to user at wakeups + 60s interval drifts to 71-107s",
+      "impact": "needs_review",
+      "categories": [
+        "model_lifecycle"
+      ],
+      "tokenkey_status": "candidate_unverified",
+      "rationale": "Gateway/relay-relevant keyword match; not yet manually verified against TokenKey code.",
+      "updated_at": "2026-06-03T17:18:35Z"
+    },
+    {
+      "upstream": "anthropics/claude-code#65130",
+      "url": "https://github.com/anthropics/claude-code/issues/65130",
+      "title": "[Bug] Tool calls intermittently emitted as plain text instead of structured blocks, causing parse failures and hard hangs on retry",
+      "impact": "needs_review",
+      "categories": [
+        "request_shape_400",
+        "model_lifecycle"
+      ],
+      "tokenkey_status": "candidate_unverified",
+      "rationale": "Gateway/relay-relevant keyword match; not yet manually verified against TokenKey code.",
+      "updated_at": "2026-06-03T18:00:57Z"
+    },
+    {
+      "upstream": "anthropics/claude-code#65148",
+      "url": "https://github.com/anthropics/claude-code/issues/65148",
+      "title": "[BUG]",
+      "impact": "needs_review",
+      "categories": [
+        "model_lifecycle"
+      ],
+      "tokenkey_status": "candidate_unverified",
+      "rationale": "Gateway/relay-relevant keyword match; not yet manually verified against TokenKey code.",
+      "updated_at": "2026-06-03T19:19:51Z"
+    },
+    {
+      "upstream": "anthropics/claude-code#65152",
+      "url": "https://github.com/anthropics/claude-code/issues/65152",
+      "title": "Haiku subagent made 15 unauthorized file changes when asked to run 2 commands",
+      "impact": "needs_review",
+      "categories": [
+        "auth_token"
+      ],
+      "tokenkey_status": "candidate_unverified",
+      "rationale": "Gateway/relay-relevant keyword match; not yet manually verified against TokenKey code.",
+      "updated_at": "2026-06-03T19:48:26Z"
+    },
+    {
+      "upstream": "anthropics/claude-code#65155",
+      "url": "https://github.com/anthropics/claude-code/issues/65155",
+      "title": "I'd be happy to help you create a GitHub issue title, but I need more information about the problem you're experiencing with Claude Code. Could you please provide: 1. **What error or unexpected behavior are you seeing?** (include any error messages) 2. *",
+      "impact": "needs_review",
+      "categories": [
+        "request_shape_400"
+      ],
+      "tokenkey_status": "candidate_unverified",
+      "rationale": "Gateway/relay-relevant keyword match; not yet manually verified against TokenKey code.",
+      "updated_at": "2026-06-03T20:09:31Z"
+    },
+    {
+      "upstream": "anthropics/claude-code#65158",
+      "url": "https://github.com/anthropics/claude-code/issues/65158",
+      "title": "[BUG] --json-schema flag hangs/produces zero output under Bedrock",
+      "impact": "needs_review",
+      "categories": [
+        "model_lifecycle"
+      ],
+      "tokenkey_status": "candidate_unverified",
+      "rationale": "Gateway/relay-relevant keyword match; not yet manually verified against TokenKey code.",
+      "updated_at": "2026-06-03T20:14:33Z"
+    },
+    {
+      "upstream": "anthropics/claude-code#65162",
+      "url": "https://github.com/anthropics/claude-code/issues/65162",
+      "title": "[MODEL] Uses PowerShell here-string (@'...'@) inside the Bash tool on Windows, silently corrupting a git commit message",
+      "impact": "needs_review",
+      "categories": [
+        "model_lifecycle"
+      ],
+      "tokenkey_status": "candidate_unverified",
+      "rationale": "Gateway/relay-relevant keyword match; not yet manually verified against TokenKey code.",
+      "updated_at": "2026-06-03T20:25:39Z"
+    },
+    {
+      "upstream": "anthropics/claude-code#65165",
+      "url": "https://github.com/anthropics/claude-code/issues/65165",
+      "title": "CLAUDE CODE SE BLOQUEO",
+      "impact": "needs_review",
+      "categories": [
+        "model_lifecycle"
+      ],
+      "tokenkey_status": "candidate_unverified",
+      "rationale": "Gateway/relay-relevant keyword match; not yet manually verified against TokenKey code.",
+      "updated_at": "2026-06-03T20:33:17Z"
+    },
+    {
+      "upstream": "anthropics/claude-code#65172",
+      "url": "https://github.com/anthropics/claude-code/issues/65172",
+      "title": "[BUG] Claude Code DevOps subagent runbook missed an 8.5-day AWS cost anomaly despite explicit daily monitoring requests — $80 burn, structural gap",
+      "impact": "needs_review",
+      "categories": [
+        "request_shape_400",
+        "new_endpoints"
+      ],
+      "tokenkey_status": "candidate_unverified",
+      "rationale": "Gateway/relay-relevant keyword match; not yet manually verified against TokenKey code.",
+      "updated_at": "2026-06-03T21:19:35Z"
+    },
+    {
+      "upstream": "anthropics/claude-code#65175",
+      "url": "https://github.com/anthropics/claude-code/issues/65175",
+      "title": "[BUG] Opus 4.8 refusal on benign code-audit prompt — false positive Usage Policy block",
+      "impact": "needs_review",
+      "categories": [
+        "request_shape_400",
+        "model_lifecycle"
+      ],
+      "tokenkey_status": "candidate_unverified",
+      "rationale": "Gateway/relay-relevant keyword match; not yet manually verified against TokenKey code.",
+      "updated_at": "2026-06-03T21:23:12Z"
+    },
+    {
+      "upstream": "anthropics/claude-code#65179",
+      "url": "https://github.com/anthropics/claude-code/issues/65179",
+      "title": "Feature: hook callback control-plane (local server + per-invocation UUID) so hooks can trigger session operations like compaction",
+      "impact": "needs_review",
+      "categories": [
+        "request_shape_400"
+      ],
+      "tokenkey_status": "candidate_unverified",
+      "rationale": "Gateway/relay-relevant keyword match; not yet manually verified against TokenKey code.",
+      "updated_at": "2026-06-03T21:53:33Z"
+    },
+    {
       "upstream": "anthropics/claude-code#8327",
       "url": "https://github.com/anthropics/claude-code/issues/8327",
       "title": "[Bug/Documentation] 'Organization has been disabled' error when ANTHROPIC_API_KEY overrides Max/Pro subscription",
@@ -4997,6 +5110,30 @@
       "updated_at": "2026-06-02T23:21:45Z"
     },
     {
+      "upstream": "anthropics/claude-code#34278",
+      "url": "https://github.com/anthropics/claude-code/issues/34278",
+      "title": "[DOCS] Context window docs missing auto-compaction circuit breaker behavior (stops after 3 failures)",
+      "impact": "medium",
+      "categories": [
+        "token_limits"
+      ],
+      "tokenkey_status": "not_prioritized",
+      "rationale": "Possible gateway compatibility/streaming impact, but not a high-severity relay signal in this pass.",
+      "updated_at": "2026-06-03T11:39:51Z"
+    },
+    {
+      "upstream": "anthropics/claude-code#34835",
+      "url": "https://github.com/anthropics/claude-code/issues/34835",
+      "title": "[FEATURE] The ability to queue up messages.via asking the user for further info on user input.",
+      "impact": "medium",
+      "categories": [
+        "effort_structured"
+      ],
+      "tokenkey_status": "not_prioritized",
+      "rationale": "Possible gateway compatibility/streaming impact, but not a high-severity relay signal in this pass.",
+      "updated_at": "2026-06-03T18:00:36Z"
+    },
+    {
       "upstream": "anthropics/claude-code#36678",
       "url": "https://github.com/anthropics/claude-code/issues/36678",
       "title": "Expose session_id and context_window usage to the AI model",
@@ -5008,6 +5145,18 @@
       "tokenkey_status": "not_prioritized",
       "rationale": "Possible gateway compatibility/streaming impact, but not a high-severity relay signal in this pass.",
       "updated_at": "2026-06-02T11:31:43Z"
+    },
+    {
+      "upstream": "anthropics/claude-code#41265",
+      "url": "https://github.com/anthropics/claude-code/issues/41265",
+      "title": "[DOCS] Headless and Agent SDK docs do not explain error result payloads beyond subtype names",
+      "impact": "medium",
+      "categories": [
+        "effort_structured"
+      ],
+      "tokenkey_status": "not_prioritized",
+      "rationale": "Possible gateway compatibility/streaming impact, but not a high-severity relay signal in this pass.",
+      "updated_at": "2026-06-03T11:39:53Z"
     },
     {
       "upstream": "anthropics/claude-code#52819",
@@ -5067,31 +5216,7 @@
       ],
       "tokenkey_status": "not_prioritized",
       "rationale": "Possible gateway compatibility/streaming impact, but not a high-severity relay signal in this pass.",
-      "updated_at": "2026-06-01T17:51:07Z"
-    },
-    {
-      "upstream": "anthropics/claude-code#64028",
-      "url": "https://github.com/anthropics/claude-code/issues/64028",
-      "title": "claude --bg daemon idle-exit (5s) races client handshake → \"socket missing\"",
-      "impact": "medium",
-      "categories": [
-        "streaming_sse"
-      ],
-      "tokenkey_status": "not_prioritized",
-      "rationale": "Possible gateway compatibility/streaming impact, but not a high-severity relay signal in this pass.",
-      "updated_at": "2026-05-31T21:18:44Z"
-    },
-    {
-      "upstream": "anthropics/claude-code#64280",
-      "url": "https://github.com/anthropics/claude-code/issues/64280",
-      "title": "Wrong Charges of extra credits!!",
-      "impact": "medium",
-      "categories": [
-        "token_limits"
-      ],
-      "tokenkey_status": "not_prioritized",
-      "rationale": "Possible gateway compatibility/streaming impact, but not a high-severity relay signal in this pass.",
-      "updated_at": "2026-05-31T17:52:44Z"
+      "updated_at": "2026-06-03T11:34:15Z"
     },
     {
       "upstream": "anthropics/claude-code#64408",
@@ -5116,7 +5241,7 @@
       ],
       "tokenkey_status": "not_prioritized",
       "rationale": "Possible gateway compatibility/streaming impact, but not a high-severity relay signal in this pass.",
-      "updated_at": "2026-06-01T08:16:13Z"
+      "updated_at": "2026-06-03T14:35:58Z"
     },
     {
       "upstream": "anthropics/claude-code#64445",
@@ -5128,7 +5253,7 @@
       ],
       "tokenkey_status": "not_prioritized",
       "rationale": "Possible gateway compatibility/streaming impact, but not a high-severity relay signal in this pass.",
-      "updated_at": "2026-06-01T11:44:23Z"
+      "updated_at": "2026-06-03T10:26:19Z"
     },
     {
       "upstream": "anthropics/claude-code#64468",
@@ -5176,7 +5301,7 @@
       ],
       "tokenkey_status": "not_prioritized",
       "rationale": "Possible gateway compatibility/streaming impact, but not a high-severity relay signal in this pass.",
-      "updated_at": "2026-06-03T03:05:07Z"
+      "updated_at": "2026-06-03T13:02:45Z"
     },
     {
       "upstream": "anthropics/claude-code#64740",
@@ -5225,6 +5350,18 @@
       "tokenkey_status": "not_prioritized",
       "rationale": "Possible gateway compatibility/streaming impact, but not a high-severity relay signal in this pass.",
       "updated_at": "2026-06-02T18:38:16Z"
+    },
+    {
+      "upstream": "anthropics/claude-code#65107",
+      "url": "https://github.com/anthropics/claude-code/issues/65107",
+      "title": "Model behavior: gated readiness words (\"mergeable\") emitted from single API signal despite explicit repeated in-context prohibition",
+      "impact": "medium",
+      "categories": [
+        "token_limits"
+      ],
+      "tokenkey_status": "not_prioritized",
+      "rationale": "Possible gateway compatibility/streaming impact, but not a high-severity relay signal in this pass.",
+      "updated_at": "2026-06-03T17:14:29Z"
     },
     {
       "upstream": "anthropics/claude-code#11447",
@@ -5303,6 +5440,18 @@
       "updated_at": "2026-06-01T17:01:05Z"
     },
     {
+      "upstream": "anthropics/claude-code#13843",
+      "url": "https://github.com/anthropics/claude-code/issues/13843",
+      "title": "Share conversation context from Claude.ai to Claude Code",
+      "impact": "not_applicable",
+      "categories": [
+        "terminal"
+      ],
+      "tokenkey_status": "not_applicable",
+      "rationale": "Client-side claude-code concern (terminal); not a gateway/relay relevance signal.",
+      "updated_at": "2026-06-03T15:59:09Z"
+    },
+    {
       "upstream": "anthropics/claude-code#14131",
       "url": "https://github.com/anthropics/claude-code/issues/14131",
       "title": "[BUG] German umlauts (ä, ö, ü) randomly replaced with ASCII substitutes (ae, oe, ue)",
@@ -5327,6 +5476,18 @@
       "updated_at": "2026-06-02T11:18:55Z"
     },
     {
+      "upstream": "anthropics/claude-code#14836",
+      "url": "https://github.com/anthropics/claude-code/issues/14836",
+      "title": "[BUG] /skills command doesn't find skills in symlinked directories",
+      "impact": "not_applicable",
+      "categories": [
+        "terminal"
+      ],
+      "tokenkey_status": "not_applicable",
+      "rationale": "Client-side claude-code concern (terminal); not a gateway/relay relevance signal.",
+      "updated_at": "2026-06-03T11:14:54Z"
+    },
+    {
       "upstream": "anthropics/claude-code#1509",
       "url": "https://github.com/anthropics/claude-code/issues/1509",
       "title": "[BUG] Claude code spitting out random characters in user input area while running",
@@ -5339,18 +5500,17 @@
       "updated_at": "2026-06-01T08:07:53Z"
     },
     {
-      "upstream": "anthropics/claude-code#15199",
-      "url": "https://github.com/anthropics/claude-code/issues/15199",
-      "title": "[BUG] CLI output formatting artifacts break copy/paste - workarounds waste tokens",
+      "upstream": "anthropics/claude-code#15637",
+      "url": "https://github.com/anthropics/claude-code/issues/15637",
+      "title": "Hardcoded /tmp/claude paths break on Termux (Android)",
       "impact": "not_applicable",
       "categories": [
-        "ide",
         "terminal",
-        "platform"
+        "install"
       ],
       "tokenkey_status": "not_applicable",
-      "rationale": "Client-side claude-code concern (ide, terminal, platform); not a gateway/relay relevance signal.",
-      "updated_at": "2026-05-31T20:55:46Z"
+      "rationale": "Client-side claude-code concern (terminal, install); not a gateway/relay relevance signal.",
+      "updated_at": "2026-06-03T21:47:40Z"
     },
     {
       "upstream": "anthropics/claude-code#15942",
@@ -5431,6 +5591,57 @@
       "updated_at": "2026-06-02T22:44:35Z"
     },
     {
+      "upstream": "anthropics/claude-code#17432",
+      "url": "https://github.com/anthropics/claude-code/issues/17432",
+      "title": "Feature Request: India-Specific Pricing Plans (INR) for Claude & Claude Code",
+      "impact": "not_applicable",
+      "categories": [
+        "ide"
+      ],
+      "tokenkey_status": "not_applicable",
+      "rationale": "Client-side claude-code concern (ide); not a gateway/relay relevance signal.",
+      "updated_at": "2026-06-03T19:42:20Z"
+    },
+    {
+      "upstream": "anthropics/claude-code#17968",
+      "url": "https://github.com/anthropics/claude-code/issues/17968",
+      "title": "[FEATURE] Support JSONC format for settings files (settings.jsonc)",
+      "impact": "not_applicable",
+      "categories": [
+        "ide",
+        "slash_hook",
+        "install"
+      ],
+      "tokenkey_status": "not_applicable",
+      "rationale": "Client-side claude-code concern (ide, slash_hook, install); not a gateway/relay relevance signal.",
+      "updated_at": "2026-06-03T16:37:19Z"
+    },
+    {
+      "upstream": "anthropics/claude-code#18061",
+      "url": "https://github.com/anthropics/claude-code/issues/18061",
+      "title": "[DOCS] Contradiction regarding WSL support for Chrome integration between documentation and changelog",
+      "impact": "not_applicable",
+      "categories": [
+        "ide",
+        "platform"
+      ],
+      "tokenkey_status": "not_applicable",
+      "rationale": "Client-side claude-code concern (ide, platform); not a gateway/relay relevance signal.",
+      "updated_at": "2026-06-03T11:40:56Z"
+    },
+    {
+      "upstream": "anthropics/claude-code#18170",
+      "url": "https://github.com/anthropics/claude-code/issues/18170",
+      "title": "Copy/paste from terminal includes unwanted indentation and trailing spaces",
+      "impact": "not_applicable",
+      "categories": [
+        "terminal"
+      ],
+      "tokenkey_status": "not_applicable",
+      "rationale": "Client-side claude-code concern (terminal); not a gateway/relay relevance signal.",
+      "updated_at": "2026-06-03T21:27:07Z"
+    },
+    {
       "upstream": "anthropics/claude-code#18435",
       "url": "https://github.com/anthropics/claude-code/issues/18435",
       "title": "[FEATURE] Add the ability to manage multiple Claude accounts within the Claude Desktop app with easy switching between profiles.",
@@ -5456,6 +5667,18 @@
       "tokenkey_status": "not_applicable",
       "rationale": "Client-side claude-code concern (terminal, slash_hook); not a gateway/relay relevance signal.",
       "updated_at": "2026-06-01T21:04:21Z"
+    },
+    {
+      "upstream": "anthropics/claude-code#20412",
+      "url": "https://github.com/anthropics/claude-code/issues/20412",
+      "title": "Claude.ai MCP servers auto-injected into Claude Code without opt-in — causes OOM crashes on resource-constrained systems",
+      "impact": "not_applicable",
+      "categories": [
+        "mcp"
+      ],
+      "tokenkey_status": "not_applicable",
+      "rationale": "Client-side claude-code concern (mcp); not a gateway/relay relevance signal.",
+      "updated_at": "2026-06-03T20:38:58Z"
     },
     {
       "upstream": "anthropics/claude-code#20697",
@@ -5507,7 +5730,7 @@
       ],
       "tokenkey_status": "not_applicable",
       "rationale": "Client-side claude-code concern (terminal, slash_hook); not a gateway/relay relevance signal.",
-      "updated_at": "2026-06-03T04:23:36Z"
+      "updated_at": "2026-06-03T18:37:46Z"
     },
     {
       "upstream": "anthropics/claude-code#24055",
@@ -5560,18 +5783,41 @@
       "updated_at": "2026-06-02T07:35:51Z"
     },
     {
-      "upstream": "anthropics/claude-code#25128",
-      "url": "https://github.com/anthropics/claude-code/issues/25128",
-      "title": "[BUG] Drag and drop not working in VS Code extension chat panel (works in terminal CLI)",
+      "upstream": "anthropics/claude-code#24798",
+      "url": "https://github.com/anthropics/claude-code/issues/24798",
+      "title": "Inter-session communication for multi-Claude workflows",
+      "impact": "not_applicable",
+      "categories": [
+        "terminal"
+      ],
+      "tokenkey_status": "not_applicable",
+      "rationale": "Client-side claude-code concern (terminal); not a gateway/relay relevance signal.",
+      "updated_at": "2026-06-03T17:09:46Z"
+    },
+    {
+      "upstream": "anthropics/claude-code#25434",
+      "url": "https://github.com/anthropics/claude-code/issues/25434",
+      "title": "[DOCS] Session docs missing nested-Claude launch guard behavior and recovery guidance",
+      "impact": "not_applicable",
+      "categories": [
+        "terminal"
+      ],
+      "tokenkey_status": "not_applicable",
+      "rationale": "Client-side claude-code concern (terminal); not a gateway/relay relevance signal.",
+      "updated_at": "2026-06-03T11:40:38Z"
+    },
+    {
+      "upstream": "anthropics/claude-code#25456",
+      "url": "https://github.com/anthropics/claude-code/issues/25456",
+      "title": "[DOCS] @-mention anchor fragment syntax (`@file.md#section`) is undocumented",
       "impact": "not_applicable",
       "categories": [
         "ide",
-        "terminal",
-        "platform"
+        "terminal"
       ],
       "tokenkey_status": "not_applicable",
-      "rationale": "Client-side claude-code concern (ide, terminal, platform); not a gateway/relay relevance signal.",
-      "updated_at": "2026-05-31T17:45:56Z"
+      "rationale": "Client-side claude-code concern (ide, terminal); not a gateway/relay relevance signal.",
+      "updated_at": "2026-06-03T11:40:36Z"
     },
     {
       "upstream": "anthropics/claude-code#25791",
@@ -5586,6 +5832,18 @@
       "tokenkey_status": "not_applicable",
       "rationale": "Client-side claude-code concern (terminal, mcp, platform); not a gateway/relay relevance signal.",
       "updated_at": "2026-06-02T17:27:11Z"
+    },
+    {
+      "upstream": "anthropics/claude-code#26165",
+      "url": "https://github.com/anthropics/claude-code/issues/26165",
+      "title": "[DOCS] VS Code docs should clarify relationship between vscode.dev and Claude Code on the web",
+      "impact": "not_applicable",
+      "categories": [
+        "ide"
+      ],
+      "tokenkey_status": "not_applicable",
+      "rationale": "Client-side claude-code concern (ide); not a gateway/relay relevance signal.",
+      "updated_at": "2026-06-03T11:40:36Z"
     },
     {
       "upstream": "anthropics/claude-code#26224",
@@ -5611,6 +5869,30 @@
       "tokenkey_status": "not_applicable",
       "rationale": "Client-side claude-code concern (ide); not a gateway/relay relevance signal.",
       "updated_at": "2026-06-02T13:16:51Z"
+    },
+    {
+      "upstream": "anthropics/claude-code#26904",
+      "url": "https://github.com/anthropics/claude-code/issues/26904",
+      "title": "[FEATURE] Add /delete command to delete current session",
+      "impact": "not_applicable",
+      "categories": [
+        "terminal"
+      ],
+      "tokenkey_status": "not_applicable",
+      "rationale": "Client-side claude-code concern (terminal); not a gateway/relay relevance signal.",
+      "updated_at": "2026-06-03T17:55:40Z"
+    },
+    {
+      "upstream": "anthropics/claude-code#27018",
+      "url": "https://github.com/anthropics/claude-code/issues/27018",
+      "title": "[DOCS] `plugin enable`/`plugin disable` docs still show `--scope` default as `user`",
+      "impact": "not_applicable",
+      "categories": [
+        "plugin"
+      ],
+      "tokenkey_status": "not_applicable",
+      "rationale": "Client-side claude-code concern (plugin); not a gateway/relay relevance signal.",
+      "updated_at": "2026-06-03T11:40:48Z"
     },
     {
       "upstream": "anthropics/claude-code#27302",
@@ -5652,6 +5934,19 @@
       "updated_at": "2026-06-03T08:28:54Z"
     },
     {
+      "upstream": "anthropics/claude-code#28240",
+      "url": "https://github.com/anthropics/claude-code/issues/28240",
+      "title": "[BUG] Permission prompt incorrectly triggers on cd instead of the actual command in compound bash statements",
+      "impact": "not_applicable",
+      "categories": [
+        "terminal",
+        "platform"
+      ],
+      "tokenkey_status": "not_applicable",
+      "rationale": "Client-side claude-code concern (terminal, platform); not a gateway/relay relevance signal.",
+      "updated_at": "2026-06-03T15:41:22Z"
+    },
+    {
       "upstream": "anthropics/claude-code#28300",
       "url": "https://github.com/anthropics/claude-code/issues/28300",
       "title": "[FEATURE] Multi-agent collaboration across machines (Agent-to-Agent protocol)",
@@ -5662,7 +5957,19 @@
       ],
       "tokenkey_status": "not_applicable",
       "rationale": "Client-side claude-code concern (terminal, mcp); not a gateway/relay relevance signal.",
-      "updated_at": "2026-06-01T00:32:42Z"
+      "updated_at": "2026-06-03T21:31:45Z"
+    },
+    {
+      "upstream": "anthropics/claude-code#28372",
+      "url": "https://github.com/anthropics/claude-code/issues/28372",
+      "title": "[DOCS] Hooks: add stability warning for many parallel hooks on the same matcher",
+      "impact": "not_applicable",
+      "categories": [
+        "slash_hook"
+      ],
+      "tokenkey_status": "not_applicable",
+      "rationale": "Client-side claude-code concern (slash_hook); not a gateway/relay relevance signal.",
+      "updated_at": "2026-06-03T11:40:47Z"
     },
     {
       "upstream": "anthropics/claude-code#28508",
@@ -5744,6 +6051,30 @@
       "updated_at": "2026-06-01T08:30:00Z"
     },
     {
+      "upstream": "anthropics/claude-code#29508",
+      "url": "https://github.com/anthropics/claude-code/issues/29508",
+      "title": "[DOCS] Interactive mode docs omit persistent \"Always copy full response\" behavior in `/copy`",
+      "impact": "not_applicable",
+      "categories": [
+        "slash_hook"
+      ],
+      "tokenkey_status": "not_applicable",
+      "rationale": "Client-side claude-code concern (slash_hook); not a gateway/relay relevance signal.",
+      "updated_at": "2026-06-03T11:40:52Z"
+    },
+    {
+      "upstream": "anthropics/claude-code#29580",
+      "url": "https://github.com/anthropics/claude-code/issues/29580",
+      "title": "[BUG] DISABLE_TELEMETRY=1 breaks remote-control with misleading \"not yet enabled\" error",
+      "impact": "not_applicable",
+      "categories": [
+        "terminal"
+      ],
+      "tokenkey_status": "not_applicable",
+      "rationale": "Client-side claude-code concern (terminal); not a gateway/relay relevance signal.",
+      "updated_at": "2026-06-03T16:51:46Z"
+    },
+    {
       "upstream": "anthropics/claude-code#29937",
       "url": "https://github.com/anthropics/claude-code/issues/29937",
       "title": "[BUG] Terminal rendering corruption in tmux - text overlaps and overwrites previous output",
@@ -5766,6 +6097,18 @@
       "tokenkey_status": "not_applicable",
       "rationale": "Client-side claude-code concern (terminal); not a gateway/relay relevance signal.",
       "updated_at": "2026-06-02T22:44:37Z"
+    },
+    {
+      "upstream": "anthropics/claude-code#30199",
+      "url": "https://github.com/anthropics/claude-code/issues/30199",
+      "title": "Ink focus-out re-render triggers iTerm2 activity indicator on tab switch",
+      "impact": "not_applicable",
+      "categories": [
+        "terminal"
+      ],
+      "tokenkey_status": "not_applicable",
+      "rationale": "Client-side claude-code concern (terminal); not a gateway/relay relevance signal.",
+      "updated_at": "2026-06-03T18:12:16Z"
     },
     {
       "upstream": "anthropics/claude-code#30232",
@@ -5793,18 +6136,6 @@
       "updated_at": "2026-06-01T05:31:08Z"
     },
     {
-      "upstream": "anthropics/claude-code#30519",
-      "url": "https://github.com/anthropics/claude-code/issues/30519",
-      "title": "Permissions matching is fundamentally broken — 30+ open issues, no staff engagement, community building workarounds",
-      "impact": "not_applicable",
-      "categories": [
-        "slash_hook"
-      ],
-      "tokenkey_status": "not_applicable",
-      "rationale": "Client-side claude-code concern (slash_hook); not a gateway/relay relevance signal.",
-      "updated_at": "2026-05-31T22:40:15Z"
-    },
-    {
       "upstream": "anthropics/claude-code#30533",
       "url": "https://github.com/anthropics/claude-code/issues/30533",
       "title": "[FEATURE] Microsoft 365 MCP:Add support for reading email attachments",
@@ -5815,18 +6146,6 @@
       "tokenkey_status": "not_applicable",
       "rationale": "Client-side claude-code concern (mcp); not a gateway/relay relevance signal.",
       "updated_at": "2026-06-01T18:40:35Z"
-    },
-    {
-      "upstream": "anthropics/claude-code#30660",
-      "url": "https://github.com/anthropics/claude-code/issues/30660",
-      "title": "Stream extended thinking output in real-time during interactive mode",
-      "impact": "not_applicable",
-      "categories": [
-        "terminal"
-      ],
-      "tokenkey_status": "not_applicable",
-      "rationale": "Client-side claude-code concern (terminal); not a gateway/relay relevance signal.",
-      "updated_at": "2026-05-31T13:42:40Z"
     },
     {
       "upstream": "anthropics/claude-code#31012",
@@ -5856,6 +6175,71 @@
       "updated_at": "2026-06-02T06:22:19Z"
     },
     {
+      "upstream": "anthropics/claude-code#31352",
+      "url": "https://github.com/anthropics/claude-code/issues/31352",
+      "title": "[DOCS] Interactive command reference missing `/color` reset variants (`default`, `gray`, `reset`, `none`)",
+      "impact": "not_applicable",
+      "categories": [
+        "terminal",
+        "slash_hook"
+      ],
+      "tokenkey_status": "not_applicable",
+      "rationale": "Client-side claude-code concern (terminal, slash_hook); not a gateway/relay relevance signal.",
+      "updated_at": "2026-06-03T11:40:47Z"
+    },
+    {
+      "upstream": "anthropics/claude-code#31678",
+      "url": "https://github.com/anthropics/claude-code/issues/31678",
+      "title": "[DOCS] Plugin marketplace docs missing @ ref separator and update behavior for pinned marketplaces",
+      "impact": "not_applicable",
+      "categories": [
+        "plugin",
+        "install"
+      ],
+      "tokenkey_status": "not_applicable",
+      "rationale": "Client-side claude-code concern (plugin, install); not a gateway/relay relevance signal.",
+      "updated_at": "2026-06-03T11:39:40Z"
+    },
+    {
+      "upstream": "anthropics/claude-code#31682",
+      "url": "https://github.com/anthropics/claude-code/issues/31682",
+      "title": "[DOCS] MCP docs missing plugin-provided server deduplication behavior",
+      "impact": "not_applicable",
+      "categories": [
+        "mcp",
+        "plugin"
+      ],
+      "tokenkey_status": "not_applicable",
+      "rationale": "Client-side claude-code concern (mcp, plugin); not a gateway/relay relevance signal.",
+      "updated_at": "2026-06-03T11:39:39Z"
+    },
+    {
+      "upstream": "anthropics/claude-code#31683",
+      "url": "https://github.com/anthropics/claude-code/issues/31683",
+      "title": "[DOCS] Sub-agents docs missing background agent completion notification content and output file path",
+      "impact": "not_applicable",
+      "categories": [
+        "plugin"
+      ],
+      "tokenkey_status": "not_applicable",
+      "rationale": "Client-side claude-code concern (plugin); not a gateway/relay relevance signal.",
+      "updated_at": "2026-06-03T11:39:40Z"
+    },
+    {
+      "upstream": "anthropics/claude-code#31684",
+      "url": "https://github.com/anthropics/claude-code/issues/31684",
+      "title": "[DOCS] Plugin uninstall docs missing settings.local.json behavior for project-scoped plugins",
+      "impact": "not_applicable",
+      "categories": [
+        "plugin",
+        "slash_hook",
+        "install"
+      ],
+      "tokenkey_status": "not_applicable",
+      "rationale": "Client-side claude-code concern (plugin, slash_hook, install); not a gateway/relay relevance signal.",
+      "updated_at": "2026-06-03T11:39:38Z"
+    },
+    {
       "upstream": "anthropics/claude-code#31977",
       "url": "https://github.com/anthropics/claude-code/issues/31977",
       "title": "[BUG] In-process team agents lack the Agent tool (cannot spawn subagents)",
@@ -5880,34 +6264,6 @@
       "updated_at": "2026-06-03T00:39:21Z"
     },
     {
-      "upstream": "anthropics/claude-code#32362",
-      "url": "https://github.com/anthropics/claude-code/issues/32362",
-      "title": "[Feature Request] Zed IDE integration support",
-      "impact": "not_applicable",
-      "categories": [
-        "ide",
-        "terminal",
-        "plugin"
-      ],
-      "tokenkey_status": "not_applicable",
-      "rationale": "Client-side claude-code concern (ide, terminal, plugin); not a gateway/relay relevance signal.",
-      "updated_at": "2026-05-31T22:03:07Z"
-    },
-    {
-      "upstream": "anthropics/claude-code#32364",
-      "url": "https://github.com/anthropics/claude-code/issues/32364",
-      "title": "[FEATURE] Support OpenTelemetry (OTel) configuration in Claude Code on the Web (claude.ai/code)",
-      "impact": "not_applicable",
-      "categories": [
-        "ide",
-        "slash_hook",
-        "platform"
-      ],
-      "tokenkey_status": "not_applicable",
-      "rationale": "Client-side claude-code concern (ide, slash_hook, platform); not a gateway/relay relevance signal.",
-      "updated_at": "2026-05-31T23:44:49Z"
-    },
-    {
       "upstream": "anthropics/claude-code#32508",
       "url": "https://github.com/anthropics/claude-code/issues/32508",
       "title": "[MODEL] System prompt \"Output efficiency\" section causes action-before-understanding bias, degrading code quality",
@@ -5920,17 +6276,18 @@
       "updated_at": "2026-06-01T22:46:17Z"
     },
     {
-      "upstream": "anthropics/claude-code#32524",
-      "url": "https://github.com/anthropics/claude-code/issues/32524",
-      "title": "[BUG] MCP tool parameters with type: number are sent as strings to MCP servers",
+      "upstream": "anthropics/claude-code#32791",
+      "url": "https://github.com/anthropics/claude-code/issues/32791",
+      "title": "Image paste (Ctrl+V) stopped working in Windows Terminal",
       "impact": "not_applicable",
       "categories": [
-        "mcp",
-        "install"
+        "terminal",
+        "slash_hook",
+        "platform"
       ],
       "tokenkey_status": "not_applicable",
-      "rationale": "Client-side claude-code concern (mcp, install); not a gateway/relay relevance signal.",
-      "updated_at": "2026-05-31T19:54:10Z"
+      "rationale": "Client-side claude-code concern (terminal, slash_hook, platform); not a gateway/relay relevance signal.",
+      "updated_at": "2026-06-03T15:44:54Z"
     },
     {
       "upstream": "anthropics/claude-code#33242",
@@ -5944,6 +6301,19 @@
       "tokenkey_status": "not_applicable",
       "rationale": "Client-side claude-code concern (ide, terminal); not a gateway/relay relevance signal.",
       "updated_at": "2026-06-02T11:32:14Z"
+    },
+    {
+      "upstream": "anthropics/claude-code#33707",
+      "url": "https://github.com/anthropics/claude-code/issues/33707",
+      "title": "[DOCS] Plugin marketplace docs omit Git submodule-backed plugin source support",
+      "impact": "not_applicable",
+      "categories": [
+        "plugin",
+        "install"
+      ],
+      "tokenkey_status": "not_applicable",
+      "rationale": "Client-side claude-code concern (plugin, install); not a gateway/relay relevance signal.",
+      "updated_at": "2026-06-03T11:39:35Z"
     },
     {
       "upstream": "anthropics/claude-code#33932",
@@ -5985,6 +6355,32 @@
       "updated_at": "2026-06-01T06:50:53Z"
     },
     {
+      "upstream": "anthropics/claude-code#34275",
+      "url": "https://github.com/anthropics/claude-code/issues/34275",
+      "title": "[DOCS] Worktree settings page missing prose explanation and cross-link for worktree.sparsePaths",
+      "impact": "not_applicable",
+      "categories": [
+        "plugin",
+        "install"
+      ],
+      "tokenkey_status": "not_applicable",
+      "rationale": "Client-side claude-code concern (plugin, install); not a gateway/relay relevance signal.",
+      "updated_at": "2026-06-03T11:40:49Z"
+    },
+    {
+      "upstream": "anthropics/claude-code#34280",
+      "url": "https://github.com/anthropics/claude-code/issues/34280",
+      "title": "[DOCS] Sub-agents docs missing behavior guarantee that killing a background agent preserves partial results",
+      "impact": "not_applicable",
+      "categories": [
+        "plugin",
+        "slash_hook"
+      ],
+      "tokenkey_status": "not_applicable",
+      "rationale": "Client-side claude-code concern (plugin, slash_hook); not a gateway/relay relevance signal.",
+      "updated_at": "2026-06-03T11:39:48Z"
+    },
+    {
       "upstream": "anthropics/claude-code#34556",
       "url": "https://github.com/anthropics/claude-code/issues/34556",
       "title": "Feature Request: Persistent Memory Across Context Compactions (59 compactions, built our own)",
@@ -5997,6 +6393,19 @@
       "updated_at": "2026-06-01T16:27:31Z"
     },
     {
+      "upstream": "anthropics/claude-code#35145",
+      "url": "https://github.com/anthropics/claude-code/issues/35145",
+      "title": "[DOCS] VS Code docs omit `macOptionClickForcesSelection`",
+      "impact": "not_applicable",
+      "categories": [
+        "ide",
+        "platform"
+      ],
+      "tokenkey_status": "not_applicable",
+      "rationale": "Client-side claude-code concern (ide, platform); not a gateway/relay relevance signal.",
+      "updated_at": "2026-06-03T11:40:49Z"
+    },
+    {
       "upstream": "anthropics/claude-code#35148",
       "url": "https://github.com/anthropics/claude-code/issues/35148",
       "title": "[BUG] Logo and \"Thinking\" animation colors are dull/washed-out inside tmux",
@@ -6007,6 +6416,31 @@
       "tokenkey_status": "not_applicable",
       "rationale": "Client-side claude-code concern (terminal); not a gateway/relay relevance signal.",
       "updated_at": "2026-06-02T12:34:31Z"
+    },
+    {
+      "upstream": "anthropics/claude-code#35150",
+      "url": "https://github.com/anthropics/claude-code/issues/35150",
+      "title": "Allow tools/skills to programmatically clear context and inject a continuation prompt",
+      "impact": "not_applicable",
+      "categories": [
+        "ide",
+        "slash_hook"
+      ],
+      "tokenkey_status": "not_applicable",
+      "rationale": "Client-side claude-code concern (ide, slash_hook); not a gateway/relay relevance signal.",
+      "updated_at": "2026-06-03T20:25:37Z"
+    },
+    {
+      "upstream": "anthropics/claude-code#35628",
+      "url": "https://github.com/anthropics/claude-code/issues/35628",
+      "title": "[DOCS] CLI reference missing --worktree skill and hook loading behavior",
+      "impact": "not_applicable",
+      "categories": [
+        "slash_hook"
+      ],
+      "tokenkey_status": "not_applicable",
+      "rationale": "Client-side claude-code concern (slash_hook); not a gateway/relay relevance signal.",
+      "updated_at": "2026-06-03T11:40:51Z"
     },
     {
       "upstream": "anthropics/claude-code#35637",
@@ -6089,6 +6523,20 @@
       "updated_at": "2026-06-02T10:57:29Z"
     },
     {
+      "upstream": "anthropics/claude-code#36857",
+      "url": "https://github.com/anthropics/claude-code/issues/36857",
+      "title": "[DOCS] MCP docs missing collapsed \"Queried {server}\" display for read/search tool calls",
+      "impact": "not_applicable",
+      "categories": [
+        "terminal",
+        "mcp",
+        "slash_hook"
+      ],
+      "tokenkey_status": "not_applicable",
+      "rationale": "Client-side claude-code concern (terminal, mcp, slash_hook); not a gateway/relay relevance signal.",
+      "updated_at": "2026-06-03T11:40:50Z"
+    },
+    {
       "upstream": "anthropics/claude-code#36884",
       "url": "https://github.com/anthropics/claude-code/issues/36884",
       "title": "VS Code extension ignores Edit/Write permission rules in settings files",
@@ -6101,6 +6549,42 @@
       "tokenkey_status": "not_applicable",
       "rationale": "Client-side claude-code concern (ide, slash_hook, platform); not a gateway/relay relevance signal.",
       "updated_at": "2026-06-03T08:19:40Z"
+    },
+    {
+      "upstream": "anthropics/claude-code#37273",
+      "url": "https://github.com/anthropics/claude-code/issues/37273",
+      "title": "Cowork: Context compaction permanently removes scrollable conversation history from UI",
+      "impact": "not_applicable",
+      "categories": [
+        "terminal"
+      ],
+      "tokenkey_status": "not_applicable",
+      "rationale": "Client-side claude-code concern (terminal); not a gateway/relay relevance signal.",
+      "updated_at": "2026-06-03T19:03:28Z"
+    },
+    {
+      "upstream": "anthropics/claude-code#37413",
+      "url": "https://github.com/anthropics/claude-code/issues/37413",
+      "title": "[BUG] Cowork (Not Claude Code) 1M context window unavailable on Max 5x — regression from March 20",
+      "impact": "not_applicable",
+      "categories": [
+        "terminal"
+      ],
+      "tokenkey_status": "not_applicable",
+      "rationale": "Client-side claude-code concern (terminal); not a gateway/relay relevance signal.",
+      "updated_at": "2026-06-03T11:24:45Z"
+    },
+    {
+      "upstream": "anthropics/claude-code#37796",
+      "url": "https://github.com/anthropics/claude-code/issues/37796",
+      "title": "Copied text includes 2-space leading indentation from rendered output",
+      "impact": "not_applicable",
+      "categories": [
+        "terminal"
+      ],
+      "tokenkey_status": "not_applicable",
+      "rationale": "Client-side claude-code concern (terminal); not a gateway/relay relevance signal.",
+      "updated_at": "2026-06-03T15:47:35Z"
     },
     {
       "upstream": "anthropics/claude-code#37989",
@@ -6144,6 +6628,44 @@
       "updated_at": "2026-06-01T08:08:26Z"
     },
     {
+      "upstream": "anthropics/claude-code#38562",
+      "url": "https://github.com/anthropics/claude-code/issues/38562",
+      "title": "[DOCS] Pasted images now insert an `[Image #N]` chip at cursor — docs don't describe this positional-reference behavior",
+      "impact": "not_applicable",
+      "categories": [
+        "terminal",
+        "slash_hook",
+        "platform"
+      ],
+      "tokenkey_status": "not_applicable",
+      "rationale": "Client-side claude-code concern (terminal, slash_hook, platform); not a gateway/relay relevance signal.",
+      "updated_at": "2026-06-03T11:40:39Z"
+    },
+    {
+      "upstream": "anthropics/claude-code#38575",
+      "url": "https://github.com/anthropics/claude-code/issues/38575",
+      "title": "[DOCS] Agent SDK session resume docs incomplete — hook messages can silently corrupt history reconstruction",
+      "impact": "not_applicable",
+      "categories": [
+        "slash_hook"
+      ],
+      "tokenkey_status": "not_applicable",
+      "rationale": "Client-side claude-code concern (slash_hook); not a gateway/relay relevance signal.",
+      "updated_at": "2026-06-03T11:39:55Z"
+    },
+    {
+      "upstream": "anthropics/claude-code#38859",
+      "url": "https://github.com/anthropics/claude-code/issues/38859",
+      "title": "Background agents cannot get Bash permissions — bypassPermissions ignored for Agent tool",
+      "impact": "not_applicable",
+      "categories": [
+        "slash_hook"
+      ],
+      "tokenkey_status": "not_applicable",
+      "rationale": "Client-side claude-code concern (slash_hook); not a gateway/relay relevance signal.",
+      "updated_at": "2026-06-03T20:09:06Z"
+    },
+    {
       "upstream": "anthropics/claude-code#38928",
       "url": "https://github.com/anthropics/claude-code/issues/38928",
       "title": "Explore agent always fails with \"Prompt is too long\" when many MCP tools are connected",
@@ -6154,7 +6676,7 @@
       ],
       "tokenkey_status": "not_applicable",
       "rationale": "Client-side claude-code concern (mcp, plugin); not a gateway/relay relevance signal.",
-      "updated_at": "2026-06-02T04:39:01Z"
+      "updated_at": "2026-06-03T19:00:05Z"
     },
     {
       "upstream": "anthropics/claude-code#38993",
@@ -6226,6 +6748,32 @@
       "updated_at": "2026-06-02T11:33:01Z"
     },
     {
+      "upstream": "anthropics/claude-code#39619",
+      "url": "https://github.com/anthropics/claude-code/issues/39619",
+      "title": "[DOCS] Plugin docs omit managed-policy behavior for force-disabled plugins",
+      "impact": "not_applicable",
+      "categories": [
+        "plugin",
+        "slash_hook",
+        "install"
+      ],
+      "tokenkey_status": "not_applicable",
+      "rationale": "Client-side claude-code concern (plugin, slash_hook, install); not a gateway/relay relevance signal.",
+      "updated_at": "2026-06-03T11:40:43Z"
+    },
+    {
+      "upstream": "anthropics/claude-code#39625",
+      "url": "https://github.com/anthropics/claude-code/issues/39625",
+      "title": "[DOCS] Computer use docs missing multi-monitor display-switching guidance",
+      "impact": "not_applicable",
+      "categories": [
+        "terminal"
+      ],
+      "tokenkey_status": "not_applicable",
+      "rationale": "Client-side claude-code concern (terminal); not a gateway/relay relevance signal.",
+      "updated_at": "2026-06-03T11:39:43Z"
+    },
+    {
       "upstream": "anthropics/claude-code#39663",
       "url": "https://github.com/anthropics/claude-code/issues/39663",
       "title": "Context is lost when Claude suggests restarting — should auto-save a session summary before restart",
@@ -6249,6 +6797,32 @@
       "tokenkey_status": "not_applicable",
       "rationale": "Client-side claude-code concern (platform); not a gateway/relay relevance signal.",
       "updated_at": "2026-06-02T14:43:16Z"
+    },
+    {
+      "upstream": "anthropics/claude-code#40120",
+      "url": "https://github.com/anthropics/claude-code/issues/40120",
+      "title": "[DOCS] Search and @ file autocomplete docs omit Jujutsu/Sapling metadata exclusions",
+      "impact": "not_applicable",
+      "categories": [
+        "ide",
+        "install"
+      ],
+      "tokenkey_status": "not_applicable",
+      "rationale": "Client-side claude-code concern (ide, install); not a gateway/relay relevance signal.",
+      "updated_at": "2026-06-03T11:39:36Z"
+    },
+    {
+      "upstream": "anthropics/claude-code#40122",
+      "url": "https://github.com/anthropics/claude-code/issues/40122",
+      "title": "[DOCS] VS Code docs missing \"Not responding\" status guidance for long-running operations",
+      "impact": "not_applicable",
+      "categories": [
+        "ide",
+        "terminal"
+      ],
+      "tokenkey_status": "not_applicable",
+      "rationale": "Client-side claude-code concern (ide, terminal); not a gateway/relay relevance signal.",
+      "updated_at": "2026-06-03T11:39:37Z"
     },
     {
       "upstream": "anthropics/claude-code#40123",
@@ -6331,6 +6905,32 @@
       "updated_at": "2026-06-02T13:36:59Z"
     },
     {
+      "upstream": "anthropics/claude-code#41264",
+      "url": "https://github.com/anthropics/claude-code/issues/41264",
+      "title": "[DOCS] `/stats` docs omit date ranges, retention semantics, and usage aggregation details",
+      "impact": "not_applicable",
+      "categories": [
+        "plugin"
+      ],
+      "tokenkey_status": "not_applicable",
+      "rationale": "Client-side claude-code concern (plugin); not a gateway/relay relevance signal.",
+      "updated_at": "2026-06-03T11:39:49Z"
+    },
+    {
+      "upstream": "anthropics/claude-code#41268",
+      "url": "https://github.com/anthropics/claude-code/issues/41268",
+      "title": "[DOCS] Built-in commands reference missing `/env` coverage for PowerShell tool",
+      "impact": "not_applicable",
+      "categories": [
+        "plugin",
+        "slash_hook",
+        "platform"
+      ],
+      "tokenkey_status": "not_applicable",
+      "rationale": "Client-side claude-code concern (plugin, slash_hook, platform); not a gateway/relay relevance signal.",
+      "updated_at": "2026-06-03T11:39:50Z"
+    },
+    {
       "upstream": "anthropics/claude-code#41581",
       "url": "https://github.com/anthropics/claude-code/issues/41581",
       "title": "[BUG] Max subscription downgraded to Free plan without any action from user",
@@ -6354,6 +6954,42 @@
       "tokenkey_status": "not_applicable",
       "rationale": "Client-side claude-code concern (mcp, plugin); not a gateway/relay relevance signal.",
       "updated_at": "2026-06-02T02:59:18Z"
+    },
+    {
+      "upstream": "anthropics/claude-code#41797",
+      "url": "https://github.com/anthropics/claude-code/issues/41797",
+      "title": "[DOCS] Hooks and Bash tool docs omit stale-read warning for formatter/linter workflows",
+      "impact": "not_applicable",
+      "categories": [
+        "slash_hook"
+      ],
+      "tokenkey_status": "not_applicable",
+      "rationale": "Client-side claude-code concern (slash_hook); not a gateway/relay relevance signal.",
+      "updated_at": "2026-06-03T11:40:41Z"
+    },
+    {
+      "upstream": "anthropics/claude-code#41799",
+      "url": "https://github.com/anthropics/claude-code/issues/41799",
+      "title": "[DOCS] Hooks docs omit >50K output file-path preview behavior",
+      "impact": "not_applicable",
+      "categories": [
+        "slash_hook"
+      ],
+      "tokenkey_status": "not_applicable",
+      "rationale": "Client-side claude-code concern (slash_hook); not a gateway/relay relevance signal.",
+      "updated_at": "2026-06-03T11:40:17Z"
+    },
+    {
+      "upstream": "anthropics/claude-code#41801",
+      "url": "https://github.com/anthropics/claude-code/issues/41801",
+      "title": "[DOCS] PowerShell tool docs omit PS 5.1 quoted-whitespace prompt behavior",
+      "impact": "not_applicable",
+      "categories": [
+        "platform"
+      ],
+      "tokenkey_status": "not_applicable",
+      "rationale": "Client-side claude-code concern (platform); not a gateway/relay relevance signal.",
+      "updated_at": "2026-06-03T11:40:42Z"
     },
     {
       "upstream": "anthropics/claude-code#42029",
@@ -6380,6 +7016,31 @@
       "updated_at": "2026-06-02T11:15:50Z"
     },
     {
+      "upstream": "anthropics/claude-code#42317",
+      "url": "https://github.com/anthropics/claude-code/issues/42317",
+      "title": "[DOCS] Format-on-save hooks don't document consecutive edit behavior",
+      "impact": "not_applicable",
+      "categories": [
+        "slash_hook",
+        "install"
+      ],
+      "tokenkey_status": "not_applicable",
+      "rationale": "Client-side claude-code concern (slash_hook, install); not a gateway/relay relevance signal.",
+      "updated_at": "2026-06-03T11:39:57Z"
+    },
+    {
+      "upstream": "anthropics/claude-code#42318",
+      "url": "https://github.com/anthropics/claude-code/issues/42318",
+      "title": "[DOCS] PowerShell docs omit key permission-check behavior",
+      "impact": "not_applicable",
+      "categories": [
+        "platform"
+      ],
+      "tokenkey_status": "not_applicable",
+      "rationale": "Client-side claude-code concern (platform); not a gateway/relay relevance signal.",
+      "updated_at": "2026-06-03T11:40:44Z"
+    },
+    {
       "upstream": "anthropics/claude-code#42486",
       "url": "https://github.com/anthropics/claude-code/issues/42486",
       "title": "--dangerously-load-development-channels should support skipping the confirmation dialog",
@@ -6393,7 +7054,7 @@
       ],
       "tokenkey_status": "not_applicable",
       "rationale": "Client-side claude-code concern (terminal, mcp, plugin, slash_hook, platform); not a gateway/relay relevance signal.",
-      "updated_at": "2026-06-03T01:13:13Z"
+      "updated_at": "2026-06-03T15:16:04Z"
     },
     {
       "upstream": "anthropics/claude-code#42776",
@@ -6471,7 +7132,7 @@
       ],
       "tokenkey_status": "not_applicable",
       "rationale": "Client-side claude-code concern (ide, terminal, platform); not a gateway/relay relevance signal.",
-      "updated_at": "2026-06-03T08:50:45Z"
+      "updated_at": "2026-06-03T19:52:28Z"
     },
     {
       "upstream": "anthropics/claude-code#43719",
@@ -6591,19 +7252,6 @@
       "updated_at": "2026-06-01T12:03:11Z"
     },
     {
-      "upstream": "anthropics/claude-code#44892",
-      "url": "https://github.com/anthropics/claude-code/issues/44892",
-      "title": "Support spinnerVerbs customization in desktop app",
-      "impact": "not_applicable",
-      "categories": [
-        "terminal",
-        "slash_hook"
-      ],
-      "tokenkey_status": "not_applicable",
-      "rationale": "Client-side claude-code concern (terminal, slash_hook); not a gateway/relay relevance signal.",
-      "updated_at": "2026-05-31T16:51:13Z"
-    },
-    {
       "upstream": "anthropics/claude-code#44941",
       "url": "https://github.com/anthropics/claude-code/issues/44941",
       "title": "[BUG] Auto mode is not showing up in the VS code extension on windows",
@@ -6615,7 +7263,19 @@
       ],
       "tokenkey_status": "not_applicable",
       "rationale": "Client-side claude-code concern (ide, terminal, platform); not a gateway/relay relevance signal.",
-      "updated_at": "2026-06-02T01:18:06Z"
+      "updated_at": "2026-06-03T11:22:29Z"
+    },
+    {
+      "upstream": "anthropics/claude-code#45297",
+      "url": "https://github.com/anthropics/claude-code/issues/45297",
+      "title": "[BUG] Cowork: Folder does not support UNC under Windows",
+      "impact": "not_applicable",
+      "categories": [
+        "platform"
+      ],
+      "tokenkey_status": "not_applicable",
+      "rationale": "Client-side claude-code concern (platform); not a gateway/relay relevance signal.",
+      "updated_at": "2026-06-03T19:25:30Z"
     },
     {
       "upstream": "anthropics/claude-code#45390",
@@ -6643,6 +7303,18 @@
       "tokenkey_status": "not_applicable",
       "rationale": "Client-side claude-code concern (ide, terminal, slash_hook, platform); not a gateway/relay relevance signal.",
       "updated_at": "2026-06-01T22:27:33Z"
+    },
+    {
+      "upstream": "anthropics/claude-code#45625",
+      "url": "https://github.com/anthropics/claude-code/issues/45625",
+      "title": "[FEATURE] LSP findReferences should work across TypeScript monorepo project references",
+      "impact": "not_applicable",
+      "categories": [
+        "ide"
+      ],
+      "tokenkey_status": "not_applicable",
+      "rationale": "Client-side claude-code concern (ide); not a gateway/relay relevance signal.",
+      "updated_at": "2026-06-03T11:39:32Z"
     },
     {
       "upstream": "anthropics/claude-code#45692",
@@ -6746,6 +7418,18 @@
       "tokenkey_status": "not_applicable",
       "rationale": "Client-side claude-code concern (terminal); not a gateway/relay relevance signal.",
       "updated_at": "2026-06-02T11:32:59Z"
+    },
+    {
+      "upstream": "anthropics/claude-code#46724",
+      "url": "https://github.com/anthropics/claude-code/issues/46724",
+      "title": "[Bug] Global claude.md instructions not being consistently applied",
+      "impact": "not_applicable",
+      "categories": [
+        "install"
+      ],
+      "tokenkey_status": "not_applicable",
+      "rationale": "Client-side claude-code concern (install); not a gateway/relay relevance signal.",
+      "updated_at": "2026-06-03T11:40:10Z"
     },
     {
       "upstream": "anthropics/claude-code#47023",
@@ -6985,6 +7669,30 @@
       "updated_at": "2026-06-02T15:54:37Z"
     },
     {
+      "upstream": "anthropics/claude-code#48867",
+      "url": "https://github.com/anthropics/claude-code/issues/48867",
+      "title": "[DOCS] Headless and Agent SDK docs omit session auto-title background request behavior",
+      "impact": "not_applicable",
+      "categories": [
+        "terminal"
+      ],
+      "tokenkey_status": "not_applicable",
+      "rationale": "Client-side claude-code concern (terminal); not a gateway/relay relevance signal.",
+      "updated_at": "2026-06-03T11:39:47Z"
+    },
+    {
+      "upstream": "anthropics/claude-code#48949",
+      "url": "https://github.com/anthropics/claude-code/issues/48949",
+      "title": "Persistent always-on Remote Control option for desktop app",
+      "impact": "not_applicable",
+      "categories": [
+        "platform"
+      ],
+      "tokenkey_status": "not_applicable",
+      "rationale": "Client-side claude-code concern (platform); not a gateway/relay relevance signal.",
+      "updated_at": "2026-06-03T11:15:47Z"
+    },
+    {
       "upstream": "anthropics/claude-code#49184",
       "url": "https://github.com/anthropics/claude-code/issues/49184",
       "title": "[BUG] Agent spawning steals tmux focus from the user's pane",
@@ -7061,6 +7769,20 @@
       "updated_at": "2026-06-01T22:45:36Z"
     },
     {
+      "upstream": "anthropics/claude-code#49917",
+      "url": "https://github.com/anthropics/claude-code/issues/49917",
+      "title": "[BUG] Claude Desktop Windows installer fails with AddPackage HRESULT 0x80073CF6 after an earlier \"successful\" install left the package in an inconsistent state",
+      "impact": "not_applicable",
+      "categories": [
+        "terminal",
+        "install",
+        "platform"
+      ],
+      "tokenkey_status": "not_applicable",
+      "rationale": "Client-side claude-code concern (terminal, install, platform); not a gateway/relay relevance signal.",
+      "updated_at": "2026-06-03T17:34:17Z"
+    },
+    {
       "upstream": "anthropics/claude-code#49933",
       "url": "https://github.com/anthropics/claude-code/issues/49933",
       "title": "[Feature Request] Native WSL Remote Integration for Claude Code Desktop on Windows",
@@ -7088,6 +7810,31 @@
       "tokenkey_status": "not_applicable",
       "rationale": "Client-side claude-code concern (ide, plugin, install); not a gateway/relay relevance signal.",
       "updated_at": "2026-06-02T22:44:53Z"
+    },
+    {
+      "upstream": "anthropics/claude-code#50139",
+      "url": "https://github.com/anthropics/claude-code/issues/50139",
+      "title": "[DOCS] Subagent docs don't explain message routing when viewing a running subagent",
+      "impact": "not_applicable",
+      "categories": [
+        "plugin"
+      ],
+      "tokenkey_status": "not_applicable",
+      "rationale": "Client-side claude-code concern (plugin); not a gateway/relay relevance signal.",
+      "updated_at": "2026-06-03T11:39:45Z"
+    },
+    {
+      "upstream": "anthropics/claude-code#50145",
+      "url": "https://github.com/anthropics/claude-code/issues/50145",
+      "title": "[DOCS] Plugin installation troubleshooting missing `range-conflict` dependency guidance",
+      "impact": "not_applicable",
+      "categories": [
+        "plugin",
+        "install"
+      ],
+      "tokenkey_status": "not_applicable",
+      "rationale": "Client-side claude-code concern (plugin, install); not a gateway/relay relevance signal.",
+      "updated_at": "2026-06-03T11:39:45Z"
     },
     {
       "upstream": "anthropics/claude-code#50159",
@@ -7126,7 +7873,7 @@
       ],
       "tokenkey_status": "not_applicable",
       "rationale": "Client-side claude-code concern (install); not a gateway/relay relevance signal.",
-      "updated_at": "2026-06-03T05:56:18Z"
+      "updated_at": "2026-06-03T12:13:47Z"
     },
     {
       "upstream": "anthropics/claude-code#50277",
@@ -7141,6 +7888,18 @@
       "tokenkey_status": "not_applicable",
       "rationale": "Client-side claude-code concern (ide, terminal, platform); not a gateway/relay relevance signal.",
       "updated_at": "2026-06-02T22:44:26Z"
+    },
+    {
+      "upstream": "anthropics/claude-code#50302",
+      "url": "https://github.com/anthropics/claude-code/issues/50302",
+      "title": "Allow switching project context (working directory) mid-session",
+      "impact": "not_applicable",
+      "categories": [
+        "slash_hook"
+      ],
+      "tokenkey_status": "not_applicable",
+      "rationale": "Client-side claude-code concern (slash_hook); not a gateway/relay relevance signal.",
+      "updated_at": "2026-06-03T11:39:27Z"
     },
     {
       "upstream": "anthropics/claude-code#50303",
@@ -7331,22 +8090,7 @@
       ],
       "tokenkey_status": "not_applicable",
       "rationale": "Client-side claude-code concern (mcp); not a gateway/relay relevance signal.",
-      "updated_at": "2026-06-02T11:32:36Z"
-    },
-    {
-      "upstream": "anthropics/claude-code#51143",
-      "url": "https://github.com/anthropics/claude-code/issues/51143",
-      "title": "[BUG] Claude Desktop persistent blank/white screen on Windows — Cowork unusable, multiple reinstalls have no effect",
-      "impact": "not_applicable",
-      "categories": [
-        "terminal",
-        "slash_hook",
-        "install",
-        "platform"
-      ],
-      "tokenkey_status": "not_applicable",
-      "rationale": "Client-side claude-code concern (terminal, slash_hook, install, platform); not a gateway/relay relevance signal.",
-      "updated_at": "2026-05-31T17:34:44Z"
+      "updated_at": "2026-06-03T21:27:13Z"
     },
     {
       "upstream": "anthropics/claude-code#51213",
@@ -7362,6 +8106,71 @@
       "updated_at": "2026-06-01T11:55:22Z"
     },
     {
+      "upstream": "anthropics/claude-code#51366",
+      "url": "https://github.com/anthropics/claude-code/issues/51366",
+      "title": "[DOCS] /terminal-setup docs omit fullscreen scroll-sensitivity setup for VS Code, Cursor, and Windsurf",
+      "impact": "not_applicable",
+      "categories": [
+        "ide",
+        "terminal",
+        "slash_hook",
+        "install"
+      ],
+      "tokenkey_status": "not_applicable",
+      "rationale": "Client-side claude-code concern (ide, terminal, slash_hook, install); not a gateway/relay relevance signal.",
+      "updated_at": "2026-06-03T11:40:05Z"
+    },
+    {
+      "upstream": "anthropics/claude-code#51368",
+      "url": "https://github.com/anthropics/claude-code/issues/51368",
+      "title": "[DOCS] Settings docs omit `/config` search matching for option values",
+      "impact": "not_applicable",
+      "categories": [
+        "plugin"
+      ],
+      "tokenkey_status": "not_applicable",
+      "rationale": "Client-side claude-code concern (plugin); not a gateway/relay relevance signal.",
+      "updated_at": "2026-06-03T11:40:06Z"
+    },
+    {
+      "upstream": "anthropics/claude-code#51369",
+      "url": "https://github.com/anthropics/claude-code/issues/51369",
+      "title": "[DOCS] /doctor command reference missing \"works while Claude is responding\" behavior",
+      "impact": "not_applicable",
+      "categories": [
+        "slash_hook"
+      ],
+      "tokenkey_status": "not_applicable",
+      "rationale": "Client-side claude-code concern (slash_hook); not a gateway/relay relevance signal.",
+      "updated_at": "2026-06-03T11:40:03Z"
+    },
+    {
+      "upstream": "anthropics/claude-code#51374",
+      "url": "https://github.com/anthropics/claude-code/issues/51374",
+      "title": "[DOCS] Interactive mode reference omits Cmd+Left/Cmd+Right line navigation",
+      "impact": "not_applicable",
+      "categories": [
+        "ide",
+        "terminal",
+        "slash_hook"
+      ],
+      "tokenkey_status": "not_applicable",
+      "rationale": "Client-side claude-code concern (ide, terminal, slash_hook); not a gateway/relay relevance signal.",
+      "updated_at": "2026-06-03T11:40:05Z"
+    },
+    {
+      "upstream": "anthropics/claude-code#51376",
+      "url": "https://github.com/anthropics/claude-code/issues/51376",
+      "title": "[DOCS] Worktree docs omit mid-session command behavior for `/tui` and `/update`",
+      "impact": "not_applicable",
+      "categories": [
+        "terminal"
+      ],
+      "tokenkey_status": "not_applicable",
+      "rationale": "Client-side claude-code concern (terminal); not a gateway/relay relevance signal.",
+      "updated_at": "2026-06-03T11:40:08Z"
+    },
+    {
       "upstream": "anthropics/claude-code#51677",
       "url": "https://github.com/anthropics/claude-code/issues/51677",
       "title": "[BUG] Codicon font blocked by webview CSP font-src — diff markers render as tofu on 2.1.116 (extends #26836)",
@@ -7375,6 +8184,84 @@
       "tokenkey_status": "not_applicable",
       "rationale": "Client-side claude-code concern (ide, terminal, install, platform); not a gateway/relay relevance signal.",
       "updated_at": "2026-06-02T22:44:03Z"
+    },
+    {
+      "upstream": "anthropics/claude-code#51686",
+      "url": "https://github.com/anthropics/claude-code/issues/51686",
+      "title": "[BUG] CLAUDE.md language/dialect instructions drift during long sessions (Spanish voseo leaks into neutral-Spanish output)",
+      "impact": "not_applicable",
+      "categories": [
+        "terminal"
+      ],
+      "tokenkey_status": "not_applicable",
+      "rationale": "Client-side claude-code concern (terminal); not a gateway/relay relevance signal.",
+      "updated_at": "2026-06-03T16:56:28Z"
+    },
+    {
+      "upstream": "anthropics/claude-code#51773",
+      "url": "https://github.com/anthropics/claude-code/issues/51773",
+      "title": "[DOCS] Plugin install docs missing already-installed dependency repair behavior",
+      "impact": "not_applicable",
+      "categories": [
+        "plugin",
+        "install"
+      ],
+      "tokenkey_status": "not_applicable",
+      "rationale": "Client-side claude-code concern (plugin, install); not a gateway/relay relevance signal.",
+      "updated_at": "2026-06-03T11:39:52Z"
+    },
+    {
+      "upstream": "anthropics/claude-code#51777",
+      "url": "https://github.com/anthropics/claude-code/issues/51777",
+      "title": "[DOCS] Tools reference missing Advisor Tool documentation",
+      "impact": "not_applicable",
+      "categories": [
+        "mcp",
+        "plugin",
+        "slash_hook"
+      ],
+      "tokenkey_status": "not_applicable",
+      "rationale": "Client-side claude-code concern (mcp, plugin, slash_hook); not a gateway/relay relevance signal.",
+      "updated_at": "2026-06-03T11:39:52Z"
+    },
+    {
+      "upstream": "anthropics/claude-code#51779",
+      "url": "https://github.com/anthropics/claude-code/issues/51779",
+      "title": "[DOCS] cleanupPeriodDays retention docs omit tasks, backups, and shell-snapshots",
+      "impact": "not_applicable",
+      "categories": [
+        "plugin"
+      ],
+      "tokenkey_status": "not_applicable",
+      "rationale": "Client-side claude-code concern (plugin); not a gateway/relay relevance signal.",
+      "updated_at": "2026-06-03T11:39:47Z"
+    },
+    {
+      "upstream": "anthropics/claude-code#51781",
+      "url": "https://github.com/anthropics/claude-code/issues/51781",
+      "title": "[DOCS] Native macOS/Linux builds still document `Glob` and `Grep` as separate tools",
+      "impact": "not_applicable",
+      "categories": [
+        "install",
+        "platform"
+      ],
+      "tokenkey_status": "not_applicable",
+      "rationale": "Client-side claude-code concern (install, platform); not a gateway/relay relevance signal.",
+      "updated_at": "2026-06-03T10:31:11Z"
+    },
+    {
+      "upstream": "anthropics/claude-code#51785",
+      "url": "https://github.com/anthropics/claude-code/issues/51785",
+      "title": "[DOCS] MCP elicitation documentation missing print and Agent SDK handling",
+      "impact": "not_applicable",
+      "categories": [
+        "terminal",
+        "mcp",
+        "slash_hook"
+      ],
+      "tokenkey_status": "not_applicable",
+      "rationale": "Client-side claude-code concern (terminal, mcp, slash_hook); not a gateway/relay relevance signal.",
+      "updated_at": "2026-06-03T11:40:08Z"
     },
     {
       "upstream": "anthropics/claude-code#51815",
@@ -7456,19 +8343,6 @@
       "updated_at": "2026-06-02T22:44:20Z"
     },
     {
-      "upstream": "anthropics/claude-code#52153",
-      "url": "https://github.com/anthropics/claude-code/issues/52153",
-      "title": "[Bug] Excessive token consumption per prompt with Opus 4.7 1M context model",
-      "impact": "not_applicable",
-      "categories": [
-        "mcp",
-        "platform"
-      ],
-      "tokenkey_status": "not_applicable",
-      "rationale": "Client-side claude-code concern (mcp, platform); not a gateway/relay relevance signal.",
-      "updated_at": "2026-05-31T18:30:59Z"
-    },
-    {
       "upstream": "anthropics/claude-code#52166",
       "url": "https://github.com/anthropics/claude-code/issues/52166",
       "title": "CLI pauses execution when terminal/composer loses focus",
@@ -7479,6 +8353,56 @@
       "tokenkey_status": "not_applicable",
       "rationale": "Client-side claude-code concern (terminal); not a gateway/relay relevance signal.",
       "updated_at": "2026-06-02T11:32:41Z"
+    },
+    {
+      "upstream": "anthropics/claude-code#52192",
+      "url": "https://github.com/anthropics/claude-code/issues/52192",
+      "title": "[DOCS] Update docs missing `DISABLE_UPDATES` env var behavior",
+      "impact": "not_applicable",
+      "categories": [
+        "plugin",
+        "slash_hook"
+      ],
+      "tokenkey_status": "not_applicable",
+      "rationale": "Client-side claude-code concern (plugin, slash_hook); not a gateway/relay relevance signal.",
+      "updated_at": "2026-06-03T11:40:11Z"
+    },
+    {
+      "upstream": "anthropics/claude-code#52197",
+      "url": "https://github.com/anthropics/claude-code/issues/52197",
+      "title": "[DOCS] `/color` command docs missing Remote Control accent color sync behavior",
+      "impact": "not_applicable",
+      "categories": [
+        "terminal"
+      ],
+      "tokenkey_status": "not_applicable",
+      "rationale": "Client-side claude-code concern (terminal); not a gateway/relay relevance signal.",
+      "updated_at": "2026-06-03T11:40:15Z"
+    },
+    {
+      "upstream": "anthropics/claude-code#52206",
+      "url": "https://github.com/anthropics/claude-code/issues/52206",
+      "title": "[DOCS] Plugin install docs do not explain reinstall behavior for already-installed plugins or dependency repair",
+      "impact": "not_applicable",
+      "categories": [
+        "plugin",
+        "install"
+      ],
+      "tokenkey_status": "not_applicable",
+      "rationale": "Client-side claude-code concern (plugin, install); not a gateway/relay relevance signal.",
+      "updated_at": "2026-06-03T11:40:17Z"
+    },
+    {
+      "upstream": "anthropics/claude-code#52207",
+      "url": "https://github.com/anthropics/claude-code/issues/52207",
+      "title": "[DOCS] Subagent resume docs omit `cwd` continuity for `SendMessage` resumes",
+      "impact": "not_applicable",
+      "categories": [
+        "plugin"
+      ],
+      "tokenkey_status": "not_applicable",
+      "rationale": "Client-side claude-code concern (plugin); not a gateway/relay relevance signal.",
+      "updated_at": "2026-06-03T11:40:14Z"
     },
     {
       "upstream": "anthropics/claude-code#52252",
@@ -7492,19 +8416,6 @@
       "tokenkey_status": "not_applicable",
       "rationale": "Client-side claude-code concern (terminal, platform); not a gateway/relay relevance signal.",
       "updated_at": "2026-06-02T19:33:17Z"
-    },
-    {
-      "upstream": "anthropics/claude-code#52390",
-      "url": "https://github.com/anthropics/claude-code/issues/52390",
-      "title": "[BUG] CLAUDE_AUTOCOMPACT_PCT_OVERRIDE=50 does not trigger autocompact — context reaches 100% requiring manual /compact",
-      "impact": "not_applicable",
-      "categories": [
-        "plugin",
-        "slash_hook"
-      ],
-      "tokenkey_status": "not_applicable",
-      "rationale": "Client-side claude-code concern (plugin, slash_hook); not a gateway/relay relevance signal.",
-      "updated_at": "2026-05-31T13:43:03Z"
     },
     {
       "upstream": "anthropics/claude-code#52509",
@@ -7533,6 +8444,157 @@
       "updated_at": "2026-06-02T14:54:15Z"
     },
     {
+      "upstream": "anthropics/claude-code#52603",
+      "url": "https://github.com/anthropics/claude-code/issues/52603",
+      "title": "[DOCS] Environment variables reference missing `CLAUDE_CODE_HIDE_CWD` startup logo option",
+      "impact": "not_applicable",
+      "categories": [
+        "terminal",
+        "slash_hook"
+      ],
+      "tokenkey_status": "not_applicable",
+      "rationale": "Client-side claude-code concern (terminal, slash_hook); not a gateway/relay relevance signal.",
+      "updated_at": "2026-06-03T11:40:24Z"
+    },
+    {
+      "upstream": "anthropics/claude-code#52605",
+      "url": "https://github.com/anthropics/claude-code/issues/52605",
+      "title": "[DOCS] `--agent` and `agent` setting docs omit session `permissionMode` behavior",
+      "impact": "not_applicable",
+      "categories": [
+        "plugin",
+        "slash_hook"
+      ],
+      "tokenkey_status": "not_applicable",
+      "rationale": "Client-side claude-code concern (plugin, slash_hook); not a gateway/relay relevance signal.",
+      "updated_at": "2026-06-03T11:40:21Z"
+    },
+    {
+      "upstream": "anthropics/claude-code#52606",
+      "url": "https://github.com/anthropics/claude-code/issues/52606",
+      "title": "[DOCS] Permission docs omit PowerShell auto-approval behavior",
+      "impact": "not_applicable",
+      "categories": [
+        "terminal",
+        "platform"
+      ],
+      "tokenkey_status": "not_applicable",
+      "rationale": "Client-side claude-code concern (terminal, platform); not a gateway/relay relevance signal.",
+      "updated_at": "2026-06-03T11:40:23Z"
+    },
+    {
+      "upstream": "anthropics/claude-code#52607",
+      "url": "https://github.com/anthropics/claude-code/issues/52607",
+      "title": "[DOCS] Hook input references omit `duration_ms` for `PostToolUse` and `PostToolUseFailure`",
+      "impact": "not_applicable",
+      "categories": [
+        "slash_hook"
+      ],
+      "tokenkey_status": "not_applicable",
+      "rationale": "Client-side claude-code concern (slash_hook); not a gateway/relay relevance signal.",
+      "updated_at": "2026-06-03T11:40:23Z"
+    },
+    {
+      "upstream": "anthropics/claude-code#52609",
+      "url": "https://github.com/anthropics/claude-code/issues/52609",
+      "title": "[DOCS] Vim mode docs omit Esc-in-INSERT interrupt behavior",
+      "impact": "not_applicable",
+      "categories": [
+        "terminal",
+        "slash_hook"
+      ],
+      "tokenkey_status": "not_applicable",
+      "rationale": "Client-side claude-code concern (terminal, slash_hook); not a gateway/relay relevance signal.",
+      "updated_at": "2026-06-03T11:40:19Z"
+    },
+    {
+      "upstream": "anthropics/claude-code#52610",
+      "url": "https://github.com/anthropics/claude-code/issues/52610",
+      "title": "[DOCS] Terminal output docs missing remote-host behavior for `owner/repo#N` links",
+      "impact": "not_applicable",
+      "categories": [
+        "terminal"
+      ],
+      "tokenkey_status": "not_applicable",
+      "rationale": "Client-side claude-code concern (terminal); not a gateway/relay relevance signal.",
+      "updated_at": "2026-06-03T11:40:22Z"
+    },
+    {
+      "upstream": "anthropics/claude-code#52611",
+      "url": "https://github.com/anthropics/claude-code/issues/52611",
+      "title": "[DOCS] Managed marketplace restrictions docs omit blockedMarketplaces pattern entries",
+      "impact": "not_applicable",
+      "categories": [
+        "plugin"
+      ],
+      "tokenkey_status": "not_applicable",
+      "rationale": "Client-side claude-code concern (plugin); not a gateway/relay relevance signal.",
+      "updated_at": "2026-06-03T11:40:25Z"
+    },
+    {
+      "upstream": "anthropics/claude-code#52618",
+      "url": "https://github.com/anthropics/claude-code/issues/52618",
+      "title": "[DOCS] Slash commands docs omit `@` file references in arguments, including absolute paths",
+      "impact": "not_applicable",
+      "categories": [
+        "slash_hook"
+      ],
+      "tokenkey_status": "not_applicable",
+      "rationale": "Client-side claude-code concern (slash_hook); not a gateway/relay relevance signal.",
+      "updated_at": "2026-06-03T11:40:18Z"
+    },
+    {
+      "upstream": "anthropics/claude-code#52619",
+      "url": "https://github.com/anthropics/claude-code/issues/52619",
+      "title": "[DOCS] MCP docs omit remote-header env-var expansion coverage for SSE/WebSocket",
+      "impact": "not_applicable",
+      "categories": [
+        "mcp"
+      ],
+      "tokenkey_status": "not_applicable",
+      "rationale": "Client-side claude-code concern (mcp); not a gateway/relay relevance signal.",
+      "updated_at": "2026-06-03T11:40:34Z"
+    },
+    {
+      "upstream": "anthropics/claude-code#52621",
+      "url": "https://github.com/anthropics/claude-code/issues/52621",
+      "title": "[DOCS] /skills command docs missing prompt-prefill selection behavior",
+      "impact": "not_applicable",
+      "categories": [
+        "plugin",
+        "slash_hook"
+      ],
+      "tokenkey_status": "not_applicable",
+      "rationale": "Client-side claude-code concern (plugin, slash_hook); not a gateway/relay relevance signal.",
+      "updated_at": "2026-06-03T11:40:28Z"
+    },
+    {
+      "upstream": "anthropics/claude-code#52623",
+      "url": "https://github.com/anthropics/claude-code/issues/52623",
+      "title": "[DOCS] Plugin MCP server docs omit optional blank `userConfig` substitution behavior",
+      "impact": "not_applicable",
+      "categories": [
+        "mcp",
+        "plugin",
+        "slash_hook"
+      ],
+      "tokenkey_status": "not_applicable",
+      "rationale": "Client-side claude-code concern (mcp, plugin, slash_hook); not a gateway/relay relevance signal.",
+      "updated_at": "2026-06-03T11:40:30Z"
+    },
+    {
+      "upstream": "anthropics/claude-code#52624",
+      "url": "https://github.com/anthropics/claude-code/issues/52624",
+      "title": "[DOCS] Plan mode docs omit `/plan open` and existing-plan reuse behavior",
+      "impact": "not_applicable",
+      "categories": [
+        "slash_hook"
+      ],
+      "tokenkey_status": "not_applicable",
+      "rationale": "Client-side claude-code concern (slash_hook); not a gateway/relay relevance signal.",
+      "updated_at": "2026-06-03T11:40:27Z"
+    },
+    {
       "upstream": "anthropics/claude-code#52625",
       "url": "https://github.com/anthropics/claude-code/issues/52625",
       "title": "[BUG] Claude code disabled by org administration on personal account",
@@ -7543,6 +8605,20 @@
       "tokenkey_status": "not_applicable",
       "rationale": "Client-side claude-code concern (terminal); not a gateway/relay relevance signal.",
       "updated_at": "2026-06-01T22:45:45Z"
+    },
+    {
+      "upstream": "anthropics/claude-code#52631",
+      "url": "https://github.com/anthropics/claude-code/issues/52631",
+      "title": "[DOCS] VS Code docs missing voice dictation setup and macOS microphone permission behavior",
+      "impact": "not_applicable",
+      "categories": [
+        "ide",
+        "terminal",
+        "slash_hook"
+      ],
+      "tokenkey_status": "not_applicable",
+      "rationale": "Client-side claude-code concern (ide, terminal, slash_hook); not a gateway/relay relevance signal.",
+      "updated_at": "2026-06-03T11:40:28Z"
     },
     {
       "upstream": "anthropics/claude-code#52691",
@@ -7619,6 +8695,61 @@
       "updated_at": "2026-06-02T15:01:28Z"
     },
     {
+      "upstream": "anthropics/claude-code#53071",
+      "url": "https://github.com/anthropics/claude-code/issues/53071",
+      "title": "[DOCS] Bash tool docs missing `AI_AGENT` subprocess environment variable",
+      "impact": "not_applicable",
+      "categories": [
+        "mcp",
+        "plugin"
+      ],
+      "tokenkey_status": "not_applicable",
+      "rationale": "Client-side claude-code concern (mcp, plugin); not a gateway/relay relevance signal.",
+      "updated_at": "2026-06-03T11:40:35Z"
+    },
+    {
+      "upstream": "anthropics/claude-code#53073",
+      "url": "https://github.com/anthropics/claude-code/issues/53073",
+      "title": "[DOCS] MCP docs omit Esc interrupt behavior for stdio tool calls",
+      "impact": "not_applicable",
+      "categories": [
+        "terminal",
+        "mcp",
+        "slash_hook"
+      ],
+      "tokenkey_status": "not_applicable",
+      "rationale": "Client-side claude-code concern (terminal, mcp, slash_hook); not a gateway/relay relevance signal.",
+      "updated_at": "2026-06-03T11:40:29Z"
+    },
+    {
+      "upstream": "anthropics/claude-code#53076",
+      "url": "https://github.com/anthropics/claude-code/issues/53076",
+      "title": "[DOCS] Plugin marketplace docs missing unrecognized source format behavior",
+      "impact": "not_applicable",
+      "categories": [
+        "plugin",
+        "install"
+      ],
+      "tokenkey_status": "not_applicable",
+      "rationale": "Client-side claude-code concern (plugin, install); not a gateway/relay relevance signal.",
+      "updated_at": "2026-06-03T11:40:37Z"
+    },
+    {
+      "upstream": "anthropics/claude-code#53078",
+      "url": "https://github.com/anthropics/claude-code/issues/53078",
+      "title": "[DOCS] VS Code docs should clarify `/usage` opens the Account & Usage dialog",
+      "impact": "not_applicable",
+      "categories": [
+        "ide",
+        "terminal",
+        "mcp",
+        "plugin"
+      ],
+      "tokenkey_status": "not_applicable",
+      "rationale": "Client-side claude-code concern (ide, terminal, mcp, plugin); not a gateway/relay relevance signal.",
+      "updated_at": "2026-06-03T11:40:33Z"
+    },
+    {
       "upstream": "anthropics/claude-code#53096",
       "url": "https://github.com/anthropics/claude-code/issues/53096",
       "title": "[BUG] Team Org Account rejected -> resulting in account banned for suspicious signals.",
@@ -7687,6 +8818,18 @@
       "updated_at": "2026-06-02T11:45:25Z"
     },
     {
+      "upstream": "anthropics/claude-code#53470",
+      "url": "https://github.com/anthropics/claude-code/issues/53470",
+      "title": "[BUG] CCR trigger stuck in 'setting up container' for 2+ days, no way to cancel",
+      "impact": "not_applicable",
+      "categories": [
+        "terminal"
+      ],
+      "tokenkey_status": "not_applicable",
+      "rationale": "Client-side claude-code concern (terminal); not a gateway/relay relevance signal.",
+      "updated_at": "2026-06-03T10:41:06Z"
+    },
+    {
       "upstream": "anthropics/claude-code#53484",
       "url": "https://github.com/anthropics/claude-code/issues/53484",
       "title": "Chat search omits Code chats currently open in other windows; no body-text index for Code chats",
@@ -7697,20 +8840,6 @@
       "tokenkey_status": "not_applicable",
       "rationale": "Client-side claude-code concern (platform); not a gateway/relay relevance signal.",
       "updated_at": "2026-06-02T11:33:15Z"
-    },
-    {
-      "upstream": "anthropics/claude-code#53492",
-      "url": "https://github.com/anthropics/claude-code/issues/53492",
-      "title": "[Bug] Duplicate output in terminal causing content duplication",
-      "impact": "not_applicable",
-      "categories": [
-        "terminal",
-        "mcp",
-        "plugin"
-      ],
-      "tokenkey_status": "not_applicable",
-      "rationale": "Client-side claude-code concern (terminal, mcp, plugin); not a gateway/relay relevance signal.",
-      "updated_at": "2026-05-31T17:16:07Z"
     },
     {
       "upstream": "anthropics/claude-code#53638",
@@ -7789,6 +8918,124 @@
       "updated_at": "2026-06-01T18:55:14Z"
     },
     {
+      "upstream": "anthropics/claude-code#54160",
+      "url": "https://github.com/anthropics/claude-code/issues/54160",
+      "title": "[DOCS] Skills command docs missing type-to-filter search box",
+      "impact": "not_applicable",
+      "categories": [
+        "terminal",
+        "plugin",
+        "slash_hook"
+      ],
+      "tokenkey_status": "not_applicable",
+      "rationale": "Client-side claude-code concern (terminal, plugin, slash_hook); not a gateway/relay relevance signal.",
+      "updated_at": "2026-06-03T11:39:58Z"
+    },
+    {
+      "upstream": "anthropics/claude-code#54162",
+      "url": "https://github.com/anthropics/claude-code/issues/54162",
+      "title": "[DOCS] Interactive mode docs omit overflow dialog scrolling controls",
+      "impact": "not_applicable",
+      "categories": [
+        "terminal",
+        "slash_hook"
+      ],
+      "tokenkey_status": "not_applicable",
+      "rationale": "Client-side claude-code concern (terminal, slash_hook); not a gateway/relay relevance signal.",
+      "updated_at": "2026-06-03T11:39:58Z"
+    },
+    {
+      "upstream": "anthropics/claude-code#54163",
+      "url": "https://github.com/anthropics/claude-code/issues/54163",
+      "title": "[DOCS] Forked subagent docs still say interactive-only for SDK and `claude -p`",
+      "impact": "not_applicable",
+      "categories": [
+        "plugin"
+      ],
+      "tokenkey_status": "not_applicable",
+      "rationale": "Client-side claude-code concern (plugin); not a gateway/relay relevance signal.",
+      "updated_at": "2026-06-03T11:40:01Z"
+    },
+    {
+      "upstream": "anthropics/claude-code#54167",
+      "url": "https://github.com/anthropics/claude-code/issues/54167",
+      "title": "[DOCS] Language setting docs omit terminal tab session title localization",
+      "impact": "not_applicable",
+      "categories": [
+        "terminal"
+      ],
+      "tokenkey_status": "not_applicable",
+      "rationale": "Client-side claude-code concern (terminal); not a gateway/relay relevance signal.",
+      "updated_at": "2026-06-03T11:39:56Z"
+    },
+    {
+      "upstream": "anthropics/claude-code#54168",
+      "url": "https://github.com/anthropics/claude-code/issues/54168",
+      "title": "[DOCS] MCP docs do not explain deduplication for Claude.ai connectors with the same upstream URL",
+      "impact": "not_applicable",
+      "categories": [
+        "mcp",
+        "plugin"
+      ],
+      "tokenkey_status": "not_applicable",
+      "rationale": "Client-side claude-code concern (mcp, plugin); not a gateway/relay relevance signal.",
+      "updated_at": "2026-06-03T11:39:55Z"
+    },
+    {
+      "upstream": "anthropics/claude-code#54170",
+      "url": "https://github.com/anthropics/claude-code/issues/54170",
+      "title": "[DOCS] Code intelligence docs omit click-to-expand LSP diagnostic summaries",
+      "impact": "not_applicable",
+      "categories": [
+        "terminal",
+        "mcp",
+        "plugin",
+        "slash_hook"
+      ],
+      "tokenkey_status": "not_applicable",
+      "rationale": "Client-side claude-code concern (terminal, mcp, plugin, slash_hook); not a gateway/relay relevance signal.",
+      "updated_at": "2026-06-03T11:40:00Z"
+    },
+    {
+      "upstream": "anthropics/claude-code#54173",
+      "url": "https://github.com/anthropics/claude-code/issues/54173",
+      "title": "[DOCS] Voice dictation docs omit VS Code speechLanguage fallback",
+      "impact": "not_applicable",
+      "categories": [
+        "ide"
+      ],
+      "tokenkey_status": "not_applicable",
+      "rationale": "Client-side claude-code concern (ide); not a gateway/relay relevance signal.",
+      "updated_at": "2026-06-03T11:39:59Z"
+    },
+    {
+      "upstream": "anthropics/claude-code#54174",
+      "url": "https://github.com/anthropics/claude-code/issues/54174",
+      "title": "[DOCS] VS Code `/context` command missing native token usage dialog behavior",
+      "impact": "not_applicable",
+      "categories": [
+        "ide",
+        "terminal",
+        "mcp",
+        "plugin"
+      ],
+      "tokenkey_status": "not_applicable",
+      "rationale": "Client-side claude-code concern (ide, terminal, mcp, plugin); not a gateway/relay relevance signal.",
+      "updated_at": "2026-06-03T11:40:33Z"
+    },
+    {
+      "upstream": "anthropics/claude-code#54175",
+      "url": "https://github.com/anthropics/claude-code/issues/54175",
+      "title": "[DOCS] Bash tool docs omit deleted or moved launch-directory recovery behavior",
+      "impact": "not_applicable",
+      "categories": [
+        "plugin"
+      ],
+      "tokenkey_status": "not_applicable",
+      "rationale": "Client-side claude-code concern (plugin); not a gateway/relay relevance signal.",
+      "updated_at": "2026-06-03T11:40:02Z"
+    },
+    {
       "upstream": "anthropics/claude-code#54254",
       "url": "https://github.com/anthropics/claude-code/issues/54254",
       "title": "[FEATURE] /handover — user-curated session hand-off with fresh context",
@@ -7824,18 +9071,6 @@
       "tokenkey_status": "not_applicable",
       "rationale": "Client-side claude-code concern (terminal); not a gateway/relay relevance signal.",
       "updated_at": "2026-06-01T12:02:22Z"
-    },
-    {
-      "upstream": "anthropics/claude-code#54394",
-      "url": "https://github.com/anthropics/claude-code/issues/54394",
-      "title": "[BUG] v2.1.117 embedded ugrep wrapper amplifies regex backtracking from grep-process-OOM into V8-heap-OOM (8 GB ceiling) — host freezes on WSL2",
-      "impact": "not_applicable",
-      "categories": [
-        "slash_hook"
-      ],
-      "tokenkey_status": "not_applicable",
-      "rationale": "Client-side claude-code concern (slash_hook); not a gateway/relay relevance signal.",
-      "updated_at": "2026-05-31T13:20:31Z"
     },
     {
       "upstream": "anthropics/claude-code#54440",
@@ -8008,19 +9243,6 @@
       "tokenkey_status": "not_applicable",
       "rationale": "Client-side claude-code concern (slash_hook, platform); not a gateway/relay relevance signal.",
       "updated_at": "2026-06-01T09:35:28Z"
-    },
-    {
-      "upstream": "anthropics/claude-code#55254",
-      "url": "https://github.com/anthropics/claude-code/issues/55254",
-      "title": "[BUG] Something went wrong Try sending your message again. If it keeps happening, share feedback so we can investigate. The session stopped responding. Send your message again to resume with a fresh process.",
-      "impact": "not_applicable",
-      "categories": [
-        "terminal",
-        "platform"
-      ],
-      "tokenkey_status": "not_applicable",
-      "rationale": "Client-side claude-code concern (terminal, platform); not a gateway/relay relevance signal.",
-      "updated_at": "2026-05-31T15:57:46Z"
     },
     {
       "upstream": "anthropics/claude-code#55457",
@@ -8379,6 +9601,19 @@
       "updated_at": "2026-06-02T21:26:28Z"
     },
     {
+      "upstream": "anthropics/claude-code#57019",
+      "url": "https://github.com/anthropics/claude-code/issues/57019",
+      "title": "Feature Request: Show TodoWrite task list in Claude.app Tasks panel",
+      "impact": "not_applicable",
+      "categories": [
+        "terminal",
+        "plugin"
+      ],
+      "tokenkey_status": "not_applicable",
+      "rationale": "Client-side claude-code concern (terminal, plugin); not a gateway/relay relevance signal.",
+      "updated_at": "2026-06-03T17:19:41Z"
+    },
+    {
       "upstream": "anthropics/claude-code#57132",
       "url": "https://github.com/anthropics/claude-code/issues/57132",
       "title": "[Bug] Allow rules under `~/.claude/` show as loaded per /permissions but don't match at runtime",
@@ -8403,6 +9638,20 @@
       "tokenkey_status": "not_applicable",
       "rationale": "Client-side claude-code concern (terminal, install, platform); not a gateway/relay relevance signal.",
       "updated_at": "2026-06-03T06:15:20Z"
+    },
+    {
+      "upstream": "anthropics/claude-code#57161",
+      "url": "https://github.com/anthropics/claude-code/issues/57161",
+      "title": "[BUG] Personal GitHub repos not showing in Claude Code web repo picker despite app installed and connector connected",
+      "impact": "not_applicable",
+      "categories": [
+        "terminal",
+        "install",
+        "platform"
+      ],
+      "tokenkey_status": "not_applicable",
+      "rationale": "Client-side claude-code concern (terminal, install, platform); not a gateway/relay relevance signal.",
+      "updated_at": "2026-06-03T12:36:41Z"
     },
     {
       "upstream": "anthropics/claude-code#57178",
@@ -8457,34 +9706,6 @@
       "updated_at": "2026-06-01T12:12:26Z"
     },
     {
-      "upstream": "anthropics/claude-code#57371",
-      "url": "https://github.com/anthropics/claude-code/issues/57371",
-      "title": "Claude Desktop (Windows): provide a way to disable the bundled Cowork background service (CoworkVMService) for users who don't use Cowork",
-      "impact": "not_applicable",
-      "categories": [
-        "ide",
-        "install",
-        "platform"
-      ],
-      "tokenkey_status": "not_applicable",
-      "rationale": "Client-side claude-code concern (ide, install, platform); not a gateway/relay relevance signal.",
-      "updated_at": "2026-05-31T17:57:36Z"
-    },
-    {
-      "upstream": "anthropics/claude-code#57580",
-      "url": "https://github.com/anthropics/claude-code/issues/57580",
-      "title": "macOS: PTY file descriptors leaked across a long Bash-heavy session, exhausting kern.tty.ptmx_max (forkpty / posix_openpt fail with ENXIO system-wide)",
-      "impact": "not_applicable",
-      "categories": [
-        "ide",
-        "terminal",
-        "install"
-      ],
-      "tokenkey_status": "not_applicable",
-      "rationale": "Client-side claude-code concern (ide, terminal, install); not a gateway/relay relevance signal.",
-      "updated_at": "2026-05-31T13:07:42Z"
-    },
-    {
       "upstream": "anthropics/claude-code#57601",
       "url": "https://github.com/anthropics/claude-code/issues/57601",
       "title": "[BUG] Rewind option visible in picker but selecting any anchor returns 'Can't rewind to this message' (v2.1.119, CLI)",
@@ -8510,6 +9731,19 @@
       "tokenkey_status": "not_applicable",
       "rationale": "Client-side claude-code concern (ide, plugin); not a gateway/relay relevance signal.",
       "updated_at": "2026-06-03T01:41:16Z"
+    },
+    {
+      "upstream": "anthropics/claude-code#57691",
+      "url": "https://github.com/anthropics/claude-code/issues/57691",
+      "title": "[BUG] Chat scroll is constrained to most recent assistant turn while AskUserQuestion card is showing",
+      "impact": "not_applicable",
+      "categories": [
+        "ide",
+        "terminal"
+      ],
+      "tokenkey_status": "not_applicable",
+      "rationale": "Client-side claude-code concern (ide, terminal); not a gateway/relay relevance signal.",
+      "updated_at": "2026-06-03T20:04:22Z"
     },
     {
       "upstream": "anthropics/claude-code#57700",
@@ -8698,19 +9932,6 @@
       "updated_at": "2026-06-02T11:32:47Z"
     },
     {
-      "upstream": "anthropics/claude-code#58332",
-      "url": "https://github.com/anthropics/claude-code/issues/58332",
-      "title": "[FEATURE] Multi-LSP per file extension: let linting servers coexist with type servers — or tell us it won't happen",
-      "impact": "not_applicable",
-      "categories": [
-        "ide",
-        "plugin"
-      ],
-      "tokenkey_status": "not_applicable",
-      "rationale": "Client-side claude-code concern (ide, plugin); not a gateway/relay relevance signal.",
-      "updated_at": "2026-05-31T14:09:24Z"
-    },
-    {
       "upstream": "anthropics/claude-code#58333",
       "url": "https://github.com/anthropics/claude-code/issues/58333",
       "title": "claude update: false-positive \"~/.local/bin is not in your PATH\" warning when it actually is",
@@ -8738,19 +9959,6 @@
       "updated_at": "2026-06-02T11:32:27Z"
     },
     {
-      "upstream": "anthropics/claude-code#58429",
-      "url": "https://github.com/anthropics/claude-code/issues/58429",
-      "title": "[A11y feature request] Built-in option to speak Claude's responses aloud",
-      "impact": "not_applicable",
-      "categories": [
-        "terminal",
-        "slash_hook"
-      ],
-      "tokenkey_status": "not_applicable",
-      "rationale": "Client-side claude-code concern (terminal, slash_hook); not a gateway/relay relevance signal.",
-      "updated_at": "2026-05-31T23:03:50Z"
-    },
-    {
       "upstream": "anthropics/claude-code#58444",
       "url": "https://github.com/anthropics/claude-code/issues/58444",
       "title": "HTTP MCP Servers Don't Auto-Reconnect After Transient Startup Failures",
@@ -8775,6 +9983,19 @@
       "tokenkey_status": "not_applicable",
       "rationale": "Client-side claude-code concern (ide, slash_hook, platform); not a gateway/relay relevance signal.",
       "updated_at": "2026-06-01T12:02:15Z"
+    },
+    {
+      "upstream": "anthropics/claude-code#58518",
+      "url": "https://github.com/anthropics/claude-code/issues/58518",
+      "title": "[BUG] Paste image not working",
+      "impact": "not_applicable",
+      "categories": [
+        "terminal",
+        "platform"
+      ],
+      "tokenkey_status": "not_applicable",
+      "rationale": "Client-side claude-code concern (terminal, platform); not a gateway/relay relevance signal.",
+      "updated_at": "2026-06-03T15:44:42Z"
     },
     {
       "upstream": "anthropics/claude-code#58522",
@@ -9166,6 +10387,19 @@
       "updated_at": "2026-06-02T11:31:58Z"
     },
     {
+      "upstream": "anthropics/claude-code#59195",
+      "url": "https://github.com/anthropics/claude-code/issues/59195",
+      "title": "[FEATURE] Persistent Todo List panel in sidebar (alongside Activity / Plan)",
+      "impact": "not_applicable",
+      "categories": [
+        "ide",
+        "terminal"
+      ],
+      "tokenkey_status": "not_applicable",
+      "rationale": "Client-side claude-code concern (ide, terminal); not a gateway/relay relevance signal.",
+      "updated_at": "2026-06-03T17:19:32Z"
+    },
+    {
       "upstream": "anthropics/claude-code#59245",
       "url": "https://github.com/anthropics/claude-code/issues/59245",
       "title": "Feature request: surface AskUserQuestion through the MCP channel API so plugins can proxy it",
@@ -9194,7 +10428,7 @@
       ],
       "tokenkey_status": "not_applicable",
       "rationale": "Client-side claude-code concern (ide, plugin, slash_hook, install); not a gateway/relay relevance signal.",
-      "updated_at": "2026-06-03T09:14:53Z"
+      "updated_at": "2026-06-03T13:17:49Z"
     },
     {
       "upstream": "anthropics/claude-code#59258",
@@ -9507,7 +10741,7 @@
       ],
       "tokenkey_status": "not_applicable",
       "rationale": "Client-side claude-code concern (ide, terminal); not a gateway/relay relevance signal.",
-      "updated_at": "2026-06-01T12:02:06Z"
+      "updated_at": "2026-06-03T19:16:19Z"
     },
     {
       "upstream": "anthropics/claude-code#59672",
@@ -9688,19 +10922,6 @@
       "updated_at": "2026-06-01T12:03:09Z"
     },
     {
-      "upstream": "anthropics/claude-code#59723",
-      "url": "https://github.com/anthropics/claude-code/issues/59723",
-      "title": "Chrome MCP returns `permission_required` with no UI to approve domain",
-      "impact": "not_applicable",
-      "categories": [
-        "ide",
-        "mcp"
-      ],
-      "tokenkey_status": "not_applicable",
-      "rationale": "Client-side claude-code concern (ide, mcp); not a gateway/relay relevance signal.",
-      "updated_at": "2026-05-31T19:35:21Z"
-    },
-    {
       "upstream": "anthropics/claude-code#59726",
       "url": "https://github.com/anthropics/claude-code/issues/59726",
       "title": "[BUG] ENAMETOOLONG creating ~/.claude/projects/ when cwd is long (eCryptfs NAME_MAX=143); reproduces via Claude Desktop cowork bootstrap",
@@ -9811,6 +11032,21 @@
       "tokenkey_status": "not_applicable",
       "rationale": "Client-side claude-code concern (terminal); not a gateway/relay relevance signal.",
       "updated_at": "2026-06-01T12:02:36Z"
+    },
+    {
+      "upstream": "anthropics/claude-code#59750",
+      "url": "https://github.com/anthropics/claude-code/issues/59750",
+      "title": "[BUG] claude agents TUI fully unresponsive on Windows Terminal — broken rendering + dead input loop (2.1.143)",
+      "impact": "not_applicable",
+      "categories": [
+        "terminal",
+        "slash_hook",
+        "install",
+        "platform"
+      ],
+      "tokenkey_status": "not_applicable",
+      "rationale": "Client-side claude-code concern (terminal, slash_hook, install, platform); not a gateway/relay relevance signal.",
+      "updated_at": "2026-06-03T17:25:19Z"
     },
     {
       "upstream": "anthropics/claude-code#59751",
@@ -10484,6 +11720,20 @@
       "updated_at": "2026-06-02T11:32:01Z"
     },
     {
+      "upstream": "anthropics/claude-code#59883",
+      "url": "https://github.com/anthropics/claude-code/issues/59883",
+      "title": "/desktop command fails on Windows Store (MSIX) installation",
+      "impact": "not_applicable",
+      "categories": [
+        "slash_hook",
+        "install",
+        "platform"
+      ],
+      "tokenkey_status": "not_applicable",
+      "rationale": "Client-side claude-code concern (slash_hook, install, platform); not a gateway/relay relevance signal.",
+      "updated_at": "2026-06-03T21:43:13Z"
+    },
+    {
       "upstream": "anthropics/claude-code#59890",
       "url": "https://github.com/anthropics/claude-code/issues/59890",
       "title": "Add message-count alert feature (20 messages per chat)",
@@ -10827,6 +12077,20 @@
       "tokenkey_status": "not_applicable",
       "rationale": "Client-side claude-code concern (ide, terminal, platform); not a gateway/relay relevance signal.",
       "updated_at": "2026-06-01T22:46:03Z"
+    },
+    {
+      "upstream": "anthropics/claude-code#60012",
+      "url": "https://github.com/anthropics/claude-code/issues/60012",
+      "title": "[BUG] On Windows with English as the primary system language, spell check in Claude Code only checks the primary language (English).",
+      "impact": "not_applicable",
+      "categories": [
+        "terminal",
+        "install",
+        "platform"
+      ],
+      "tokenkey_status": "not_applicable",
+      "rationale": "Client-side claude-code concern (terminal, install, platform); not a gateway/relay relevance signal.",
+      "updated_at": "2026-06-03T10:23:58Z"
     },
     {
       "upstream": "anthropics/claude-code#60018",
@@ -11281,7 +12545,7 @@
       ],
       "tokenkey_status": "not_applicable",
       "rationale": "Client-side claude-code concern (terminal, install, platform); not a gateway/relay relevance signal.",
-      "updated_at": "2026-06-02T11:32:52Z"
+      "updated_at": "2026-06-03T16:00:03Z"
     },
     {
       "upstream": "anthropics/claude-code#60143",
@@ -11549,6 +12813,45 @@
       "updated_at": "2026-06-02T22:44:08Z"
     },
     {
+      "upstream": "anthropics/claude-code#60227",
+      "url": "https://github.com/anthropics/claude-code/issues/60227",
+      "title": "[FEATURE] Optimize spacing between terminal task icons and content",
+      "impact": "not_applicable",
+      "categories": [
+        "terminal"
+      ],
+      "tokenkey_status": "not_applicable",
+      "rationale": "Client-side claude-code concern (terminal); not a gateway/relay relevance signal.",
+      "updated_at": "2026-06-03T11:39:26Z"
+    },
+    {
+      "upstream": "anthropics/claude-code#60229",
+      "url": "https://github.com/anthropics/claude-code/issues/60229",
+      "title": "[FEATURE] Turboquantum compressor for Snapdragon Adreno",
+      "impact": "not_applicable",
+      "categories": [
+        "mcp",
+        "install"
+      ],
+      "tokenkey_status": "not_applicable",
+      "rationale": "Client-side claude-code concern (mcp, install); not a gateway/relay relevance signal.",
+      "updated_at": "2026-06-03T11:39:27Z"
+    },
+    {
+      "upstream": "anthropics/claude-code#60239",
+      "url": "https://github.com/anthropics/claude-code/issues/60239",
+      "title": "Docs/bug: statusLine.command silently fails on Windows when path contains unquoted backslashes (Git Bash interaction)",
+      "impact": "not_applicable",
+      "categories": [
+        "terminal",
+        "slash_hook",
+        "platform"
+      ],
+      "tokenkey_status": "not_applicable",
+      "rationale": "Client-side claude-code concern (terminal, slash_hook, platform); not a gateway/relay relevance signal.",
+      "updated_at": "2026-06-03T11:39:30Z"
+    },
+    {
       "upstream": "anthropics/claude-code#60240",
       "url": "https://github.com/anthropics/claude-code/issues/60240",
       "title": "Settings migration silently removes user's explicit model pin without notification or backup",
@@ -11559,6 +12862,32 @@
       "tokenkey_status": "not_applicable",
       "rationale": "Client-side claude-code concern (slash_hook); not a gateway/relay relevance signal.",
       "updated_at": "2026-06-02T22:44:11Z"
+    },
+    {
+      "upstream": "anthropics/claude-code#60241",
+      "url": "https://github.com/anthropics/claude-code/issues/60241",
+      "title": "[FEATURE] Expose AgentView as a rebindable context in keybindings.json (attach / detach actions)",
+      "impact": "not_applicable",
+      "categories": [
+        "terminal",
+        "slash_hook"
+      ],
+      "tokenkey_status": "not_applicable",
+      "rationale": "Client-side claude-code concern (terminal, slash_hook); not a gateway/relay relevance signal.",
+      "updated_at": "2026-06-03T11:39:31Z"
+    },
+    {
+      "upstream": "anthropics/claude-code#60243",
+      "url": "https://github.com/anthropics/claude-code/issues/60243",
+      "title": "[BUG] [Cowork] present_files cards truncate path and omit filename, making multiple files visually indistinguishable",
+      "impact": "not_applicable",
+      "categories": [
+        "terminal",
+        "platform"
+      ],
+      "tokenkey_status": "not_applicable",
+      "rationale": "Client-side claude-code concern (terminal, platform); not a gateway/relay relevance signal.",
+      "updated_at": "2026-06-03T11:39:30Z"
     },
     {
       "upstream": "anthropics/claude-code#60246",
@@ -11989,7 +13318,7 @@
       ],
       "tokenkey_status": "not_applicable",
       "rationale": "Client-side claude-code concern (ide, terminal, platform); not a gateway/relay relevance signal.",
-      "updated_at": "2026-06-01T06:33:09Z"
+      "updated_at": "2026-06-03T20:38:44Z"
     },
     {
       "upstream": "anthropics/claude-code#60369",
@@ -12005,6 +13334,31 @@
       "updated_at": "2026-06-02T22:45:00Z"
     },
     {
+      "upstream": "anthropics/claude-code#60372",
+      "url": "https://github.com/anthropics/claude-code/issues/60372",
+      "title": "False-positive 'violative cyber content' block on innocuous fiction-naming prompt",
+      "impact": "not_applicable",
+      "categories": [
+        "terminal"
+      ],
+      "tokenkey_status": "not_applicable",
+      "rationale": "Client-side claude-code concern (terminal); not a gateway/relay relevance signal.",
+      "updated_at": "2026-06-03T11:39:34Z"
+    },
+    {
+      "upstream": "anthropics/claude-code#60375",
+      "url": "https://github.com/anthropics/claude-code/issues/60375",
+      "title": "Plugin skills loaded twice: from marketplace clone and installed cache",
+      "impact": "not_applicable",
+      "categories": [
+        "plugin",
+        "install"
+      ],
+      "tokenkey_status": "not_applicable",
+      "rationale": "Client-side claude-code concern (plugin, install); not a gateway/relay relevance signal.",
+      "updated_at": "2026-06-03T11:39:54Z"
+    },
+    {
       "upstream": "anthropics/claude-code#60415",
       "url": "https://github.com/anthropics/claude-code/issues/60415",
       "title": "[DOCS] Agent view docs omit recovery guidance for an unresponsive background service",
@@ -12015,6 +13369,19 @@
       "tokenkey_status": "not_applicable",
       "rationale": "Client-side claude-code concern (terminal); not a gateway/relay relevance signal.",
       "updated_at": "2026-06-01T01:30:08Z"
+    },
+    {
+      "upstream": "anthropics/claude-code#60493",
+      "url": "https://github.com/anthropics/claude-code/issues/60493",
+      "title": "[BUG] GitHub repos not visible in Claude Code web repo picker despite app installed",
+      "impact": "not_applicable",
+      "categories": [
+        "terminal",
+        "platform"
+      ],
+      "tokenkey_status": "not_applicable",
+      "rationale": "Client-side claude-code concern (terminal, platform); not a gateway/relay relevance signal.",
+      "updated_at": "2026-06-03T19:12:39Z"
     },
     {
       "upstream": "anthropics/claude-code#60694",
@@ -12050,7 +13417,7 @@
       ],
       "tokenkey_status": "not_applicable",
       "rationale": "Client-side claude-code concern (plugin); not a gateway/relay relevance signal.",
-      "updated_at": "2026-05-31T14:12:12Z"
+      "updated_at": "2026-06-03T18:42:38Z"
     },
     {
       "upstream": "anthropics/claude-code#60844",
@@ -12146,6 +13513,19 @@
       "updated_at": "2026-06-02T00:05:13Z"
     },
     {
+      "upstream": "anthropics/claude-code#61268",
+      "url": "https://github.com/anthropics/claude-code/issues/61268",
+      "title": "[BUG] Security: permissions.deny rules not working",
+      "impact": "not_applicable",
+      "categories": [
+        "terminal",
+        "slash_hook"
+      ],
+      "tokenkey_status": "not_applicable",
+      "rationale": "Client-side claude-code concern (terminal, slash_hook); not a gateway/relay relevance signal.",
+      "updated_at": "2026-06-03T10:38:53Z"
+    },
+    {
       "upstream": "anthropics/claude-code#61315",
       "url": "https://github.com/anthropics/claude-code/issues/61315",
       "title": "[BUG] Sub-agent dispatched via Agent tool stalls silently on MCP permission gate — no surface to parent CLI UI",
@@ -12196,18 +13576,6 @@
       "tokenkey_status": "not_applicable",
       "rationale": "Client-side claude-code concern (terminal); not a gateway/relay relevance signal.",
       "updated_at": "2026-06-02T09:04:36Z"
-    },
-    {
-      "upstream": "anthropics/claude-code#61484",
-      "url": "https://github.com/anthropics/claude-code/issues/61484",
-      "title": "Feature request: add \"Copy selection\" to right-click menu",
-      "impact": "not_applicable",
-      "categories": [
-        "platform"
-      ],
-      "tokenkey_status": "not_applicable",
-      "rationale": "Client-side claude-code concern (platform); not a gateway/relay relevance signal.",
-      "updated_at": "2026-06-01T00:16:29Z"
     },
     {
       "upstream": "anthropics/claude-code#61491",
@@ -12318,20 +13686,6 @@
       "updated_at": "2026-06-01T06:28:15Z"
     },
     {
-      "upstream": "anthropics/claude-code#61681",
-      "url": "https://github.com/anthropics/claude-code/issues/61681",
-      "title": "Sonnet dispatched via Agent tool fails with \"1M context required\" error",
-      "impact": "not_applicable",
-      "categories": [
-        "plugin",
-        "slash_hook",
-        "platform"
-      ],
-      "tokenkey_status": "not_applicable",
-      "rationale": "Client-side claude-code concern (plugin, slash_hook, platform); not a gateway/relay relevance signal.",
-      "updated_at": "2026-05-31T15:04:59Z"
-    },
-    {
       "upstream": "anthropics/claude-code#61682",
       "url": "https://github.com/anthropics/claude-code/issues/61682",
       "title": "[BUG] GitHub connector shows \"Connected\" but exposes no tools in Cowork (Windows 11, app v1.8555.2.0)",
@@ -12355,7 +13709,7 @@
       ],
       "tokenkey_status": "not_applicable",
       "rationale": "Client-side claude-code concern (terminal, platform); not a gateway/relay relevance signal.",
-      "updated_at": "2026-06-03T08:37:17Z"
+      "updated_at": "2026-06-03T18:54:45Z"
     },
     {
       "upstream": "anthropics/claude-code#61703",
@@ -12500,7 +13854,7 @@
       ],
       "tokenkey_status": "not_applicable",
       "rationale": "Client-side claude-code concern (ide, terminal); not a gateway/relay relevance signal.",
-      "updated_at": "2026-06-03T08:13:28Z"
+      "updated_at": "2026-06-03T13:39:44Z"
     },
     {
       "upstream": "anthropics/claude-code#62149",
@@ -12554,7 +13908,7 @@
       ],
       "tokenkey_status": "not_applicable",
       "rationale": "Client-side claude-code concern (ide, terminal, slash_hook, platform); not a gateway/relay relevance signal.",
-      "updated_at": "2026-06-02T19:22:01Z"
+      "updated_at": "2026-06-03T14:08:35Z"
     },
     {
       "upstream": "anthropics/claude-code#62259",
@@ -12647,7 +14001,7 @@
       ],
       "tokenkey_status": "not_applicable",
       "rationale": "Client-side claude-code concern (terminal); not a gateway/relay relevance signal.",
-      "updated_at": "2026-06-03T05:53:17Z"
+      "updated_at": "2026-06-03T18:51:49Z"
     },
     {
       "upstream": "anthropics/claude-code#62487",
@@ -12664,19 +14018,29 @@
       "updated_at": "2026-06-01T09:34:20Z"
     },
     {
-      "upstream": "anthropics/claude-code#62537",
-      "url": "https://github.com/anthropics/claude-code/issues/62537",
-      "title": "[BUG] Windows: PowerShell tool absent from schema when Git Bash is on PATH, despite pwsh.exe being present and detectable",
+      "upstream": "anthropics/claude-code#62493",
+      "url": "https://github.com/anthropics/claude-code/issues/62493",
+      "title": "AskUserQuestion overlay obscures the assistant's previous message",
       "impact": "not_applicable",
       "categories": [
         "terminal",
-        "slash_hook",
-        "install",
         "platform"
       ],
       "tokenkey_status": "not_applicable",
-      "rationale": "Client-side claude-code concern (terminal, slash_hook, install, platform); not a gateway/relay relevance signal.",
-      "updated_at": "2026-05-31T21:33:04Z"
+      "rationale": "Client-side claude-code concern (terminal, platform); not a gateway/relay relevance signal.",
+      "updated_at": "2026-06-03T16:06:16Z"
+    },
+    {
+      "upstream": "anthropics/claude-code#62534",
+      "url": "https://github.com/anthropics/claude-code/issues/62534",
+      "title": "Long streamed responses occasionally triplicate sections of output",
+      "impact": "not_applicable",
+      "categories": [
+        "terminal"
+      ],
+      "tokenkey_status": "not_applicable",
+      "rationale": "Client-side claude-code concern (terminal); not a gateway/relay relevance signal.",
+      "updated_at": "2026-06-03T20:57:51Z"
     },
     {
       "upstream": "anthropics/claude-code#62585",
@@ -12702,7 +14066,7 @@
       ],
       "tokenkey_status": "not_applicable",
       "rationale": "Client-side claude-code concern (ide, terminal); not a gateway/relay relevance signal.",
-      "updated_at": "2026-06-01T06:33:16Z"
+      "updated_at": "2026-06-03T20:34:23Z"
     },
     {
       "upstream": "anthropics/claude-code#62623",
@@ -12851,7 +14215,7 @@
       ],
       "tokenkey_status": "not_applicable",
       "rationale": "Client-side claude-code concern (terminal, install); not a gateway/relay relevance signal.",
-      "updated_at": "2026-06-01T05:59:26Z"
+      "updated_at": "2026-06-03T18:49:44Z"
     },
     {
       "upstream": "anthropics/claude-code#62890",
@@ -12965,7 +14329,7 @@
       ],
       "tokenkey_status": "not_applicable",
       "rationale": "Client-side claude-code concern (terminal, slash_hook); not a gateway/relay relevance signal.",
-      "updated_at": "2026-06-03T03:26:38Z"
+      "updated_at": "2026-06-03T17:05:15Z"
     },
     {
       "upstream": "anthropics/claude-code#63060",
@@ -12977,20 +14341,21 @@
       ],
       "tokenkey_status": "not_applicable",
       "rationale": "Client-side claude-code concern (terminal); not a gateway/relay relevance signal.",
-      "updated_at": "2026-06-03T09:35:09Z"
+      "updated_at": "2026-06-03T20:12:43Z"
     },
     {
-      "upstream": "anthropics/claude-code#63138",
-      "url": "https://github.com/anthropics/claude-code/issues/63138",
-      "title": "[Bug] VSCode terminal output displays corrupted text with garbled symbols",
+      "upstream": "anthropics/claude-code#63190",
+      "url": "https://github.com/anthropics/claude-code/issues/63190",
+      "title": "[FEATURE] Deferred Messages — Queue Input for End of Turn",
       "impact": "not_applicable",
       "categories": [
         "ide",
-        "terminal"
+        "terminal",
+        "slash_hook"
       ],
       "tokenkey_status": "not_applicable",
-      "rationale": "Client-side claude-code concern (ide, terminal); not a gateway/relay relevance signal.",
-      "updated_at": "2026-05-31T22:50:24Z"
+      "rationale": "Client-side claude-code concern (ide, terminal, slash_hook); not a gateway/relay relevance signal.",
+      "updated_at": "2026-06-03T18:00:49Z"
     },
     {
       "upstream": "anthropics/claude-code#63238",
@@ -13085,6 +14450,19 @@
       "updated_at": "2026-06-02T00:15:58Z"
     },
     {
+      "upstream": "anthropics/claude-code#63426",
+      "url": "https://github.com/anthropics/claude-code/issues/63426",
+      "title": "[Bug] Context window fills quickly and auto-compact not triggering at 80% threshold",
+      "impact": "not_applicable",
+      "categories": [
+        "ide",
+        "terminal"
+      ],
+      "tokenkey_status": "not_applicable",
+      "rationale": "Client-side claude-code concern (ide, terminal); not a gateway/relay relevance signal.",
+      "updated_at": "2026-06-03T14:36:03Z"
+    },
+    {
       "upstream": "anthropics/claude-code#63462",
       "url": "https://github.com/anthropics/claude-code/issues/63462",
       "title": "Phantom `⏺ Human:` lines appearing in transcript — assistant acts on instructions the user never typed",
@@ -13096,18 +14474,6 @@
       "tokenkey_status": "not_applicable",
       "rationale": "Client-side claude-code concern (terminal, slash_hook); not a gateway/relay relevance signal.",
       "updated_at": "2026-06-02T18:56:24Z"
-    },
-    {
-      "upstream": "anthropics/claude-code#63479",
-      "url": "https://github.com/anthropics/claude-code/issues/63479",
-      "title": "[BUG] CLAUDE_CODE_DISABLE_1M_CONTEXT ignored in 2.1.156",
-      "impact": "not_applicable",
-      "categories": [
-        "terminal"
-      ],
-      "tokenkey_status": "not_applicable",
-      "rationale": "Client-side claude-code concern (terminal); not a gateway/relay relevance signal.",
-      "updated_at": "2026-05-31T17:06:55Z"
     },
     {
       "upstream": "anthropics/claude-code#63488",
@@ -13134,7 +14500,7 @@
       ],
       "tokenkey_status": "not_applicable",
       "rationale": "Client-side claude-code concern (terminal, install); not a gateway/relay relevance signal.",
-      "updated_at": "2026-06-03T06:17:20Z"
+      "updated_at": "2026-06-03T13:26:18Z"
     },
     {
       "upstream": "anthropics/claude-code#63545",
@@ -13226,7 +14592,7 @@
       ],
       "tokenkey_status": "not_applicable",
       "rationale": "Client-side claude-code concern (terminal, slash_hook, install, platform); not a gateway/relay relevance signal.",
-      "updated_at": "2026-06-02T15:08:07Z"
+      "updated_at": "2026-06-03T20:25:25Z"
     },
     {
       "upstream": "anthropics/claude-code#63675",
@@ -13325,7 +14691,7 @@
       ],
       "tokenkey_status": "not_applicable",
       "rationale": "Client-side claude-code concern (terminal); not a gateway/relay relevance signal.",
-      "updated_at": "2026-06-01T16:55:50Z"
+      "updated_at": "2026-06-03T15:39:45Z"
     },
     {
       "upstream": "anthropics/claude-code#63800",
@@ -13364,19 +14730,6 @@
       "updated_at": "2026-06-01T04:35:43Z"
     },
     {
-      "upstream": "anthropics/claude-code#63881",
-      "url": "https://github.com/anthropics/claude-code/issues/63881",
-      "title": "[Bug] Parallel tool calls hang on Bash execution errors",
-      "impact": "not_applicable",
-      "categories": [
-        "ide",
-        "terminal"
-      ],
-      "tokenkey_status": "not_applicable",
-      "rationale": "Client-side claude-code concern (ide, terminal); not a gateway/relay relevance signal.",
-      "updated_at": "2026-05-31T11:14:54Z"
-    },
-    {
       "upstream": "anthropics/claude-code#63884",
       "url": "https://github.com/anthropics/claude-code/issues/63884",
       "title": "[MODEL] Opus 4.8 starts hallucinating results before parallel tasks finish",
@@ -13399,7 +14752,7 @@
       ],
       "tokenkey_status": "not_applicable",
       "rationale": "Client-side claude-code concern (slash_hook); not a gateway/relay relevance signal.",
-      "updated_at": "2026-06-01T15:23:01Z"
+      "updated_at": "2026-06-03T13:18:39Z"
     },
     {
       "upstream": "anthropics/claude-code#63904",
@@ -13424,7 +14777,7 @@
       ],
       "tokenkey_status": "not_applicable",
       "rationale": "Client-side claude-code concern (terminal); not a gateway/relay relevance signal.",
-      "updated_at": "2026-06-02T21:52:06Z"
+      "updated_at": "2026-06-03T15:45:46Z"
     },
     {
       "upstream": "anthropics/claude-code#63925",
@@ -13453,35 +14806,6 @@
       "updated_at": "2026-06-01T16:43:46Z"
     },
     {
-      "upstream": "anthropics/claude-code#63954",
-      "url": "https://github.com/anthropics/claude-code/issues/63954",
-      "title": "[BUG] Abnormal Session Limit Drain Since Opus 4.8 Rollout (May 28, 2026) — VSCode Extension, Pro Plan, Windows",
-      "impact": "not_applicable",
-      "categories": [
-        "ide",
-        "terminal",
-        "platform"
-      ],
-      "tokenkey_status": "not_applicable",
-      "rationale": "Client-side claude-code concern (ide, terminal, platform); not a gateway/relay relevance signal.",
-      "updated_at": "2026-05-31T23:46:59Z"
-    },
-    {
-      "upstream": "anthropics/claude-code#64001",
-      "url": "https://github.com/anthropics/claude-code/issues/64001",
-      "title": "[BUG] Plugin directory does not render in Claude Desktop",
-      "impact": "not_applicable",
-      "categories": [
-        "terminal",
-        "plugin",
-        "install",
-        "platform"
-      ],
-      "tokenkey_status": "not_applicable",
-      "rationale": "Client-side claude-code concern (terminal, plugin, install, platform); not a gateway/relay relevance signal.",
-      "updated_at": "2026-05-31T23:15:08Z"
-    },
-    {
       "upstream": "anthropics/claude-code#64020",
       "url": "https://github.com/anthropics/claude-code/issues/64020",
       "title": "Animated gradient drains battery. Still causes ~40% WindowServer CPU with prefersReducedMotion:true (regression / #25575 not fixed)",
@@ -13493,18 +14817,6 @@
       "tokenkey_status": "not_applicable",
       "rationale": "Client-side claude-code concern (terminal, slash_hook); not a gateway/relay relevance signal.",
       "updated_at": "2026-06-02T08:06:41Z"
-    },
-    {
-      "upstream": "anthropics/claude-code#64048",
-      "url": "https://github.com/anthropics/claude-code/issues/64048",
-      "title": "[MODEL] Claude confabulated a prompt-injection payload in a file before the file-read result returned",
-      "impact": "not_applicable",
-      "categories": [
-        "slash_hook"
-      ],
-      "tokenkey_status": "not_applicable",
-      "rationale": "Client-side claude-code concern (slash_hook); not a gateway/relay relevance signal.",
-      "updated_at": "2026-05-31T16:19:47Z"
     },
     {
       "upstream": "anthropics/claude-code#64086",
@@ -13543,109 +14855,6 @@
       "updated_at": "2026-06-02T23:15:41Z"
     },
     {
-      "upstream": "anthropics/claude-code#64144",
-      "url": "https://github.com/anthropics/claude-code/issues/64144",
-      "title": "In-flight /btw side conversation silently lost on Code -> Cowork -> Code switch (data loss)",
-      "impact": "not_applicable",
-      "categories": [
-        "terminal"
-      ],
-      "tokenkey_status": "not_applicable",
-      "rationale": "Client-side claude-code concern (terminal); not a gateway/relay relevance signal.",
-      "updated_at": "2026-05-31T22:17:37Z"
-    },
-    {
-      "upstream": "anthropics/claude-code#64192",
-      "url": "https://github.com/anthropics/claude-code/issues/64192",
-      "title": "TaskCreate 'task tools haven't been used recently' system-reminder fires repeatedly per long session — needs suppression knob (cross-repo from AaaS-Love/.claude#2048)",
-      "impact": "not_applicable",
-      "categories": [
-        "slash_hook"
-      ],
-      "tokenkey_status": "not_applicable",
-      "rationale": "Client-side claude-code concern (slash_hook); not a gateway/relay relevance signal.",
-      "updated_at": "2026-05-31T10:56:27Z"
-    },
-    {
-      "upstream": "anthropics/claude-code#64193",
-      "url": "https://github.com/anthropics/claude-code/issues/64193",
-      "title": "[Feature/UX] Yellow notification dot never clears on read + no way to configure dot behaviour",
-      "impact": "not_applicable",
-      "categories": [
-        "terminal",
-        "slash_hook",
-        "platform"
-      ],
-      "tokenkey_status": "not_applicable",
-      "rationale": "Client-side claude-code concern (terminal, slash_hook, platform); not a gateway/relay relevance signal.",
-      "updated_at": "2026-05-31T11:02:35Z"
-    },
-    {
-      "upstream": "anthropics/claude-code#64194",
-      "url": "https://github.com/anthropics/claude-code/issues/64194",
-      "title": "Token waste bug: Workflow spawned 44 parallel agents to read files instead of using git clone (2M tokens vs ~1000)",
-      "impact": "not_applicable",
-      "categories": [
-        "platform"
-      ],
-      "tokenkey_status": "not_applicable",
-      "rationale": "Client-side claude-code concern (platform); not a gateway/relay relevance signal.",
-      "updated_at": "2026-05-31T21:17:24Z"
-    },
-    {
-      "upstream": "anthropics/claude-code#64197",
-      "url": "https://github.com/anthropics/claude-code/issues/64197",
-      "title": "[BUG] macOS: npm/Homebrew install places native binary at bin/claude.exe, causing recurring \"claude.exe would like to access data from other apps\" TCC prompts",
-      "impact": "not_applicable",
-      "categories": [
-        "terminal",
-        "install",
-        "platform"
-      ],
-      "tokenkey_status": "not_applicable",
-      "rationale": "Client-side claude-code concern (terminal, install, platform); not a gateway/relay relevance signal.",
-      "updated_at": "2026-05-31T11:04:30Z"
-    },
-    {
-      "upstream": "anthropics/claude-code#64199",
-      "url": "https://github.com/anthropics/claude-code/issues/64199",
-      "title": "Unsent draft text lost when switching sessions (VS Code extension)",
-      "impact": "not_applicable",
-      "categories": [
-        "ide"
-      ],
-      "tokenkey_status": "not_applicable",
-      "rationale": "Client-side claude-code concern (ide); not a gateway/relay relevance signal.",
-      "updated_at": "2026-05-31T11:23:52Z"
-    },
-    {
-      "upstream": "anthropics/claude-code#64200",
-      "url": "https://github.com/anthropics/claude-code/issues/64200",
-      "title": "I'm ready to help generate a GitHub issue title for Claude Code, but I don't see a bug report in your message. Please provide the bug report details, and I'll create a concise technical issue title following the guidelines you've outlined.",
-      "impact": "not_applicable",
-      "categories": [
-        "ide",
-        "terminal"
-      ],
-      "tokenkey_status": "not_applicable",
-      "rationale": "Client-side claude-code concern (ide, terminal); not a gateway/relay relevance signal.",
-      "updated_at": "2026-05-31T11:21:18Z"
-    },
-    {
-      "upstream": "anthropics/claude-code#64201",
-      "url": "https://github.com/anthropics/claude-code/issues/64201",
-      "title": "[BUG] Title: Auth URL line-wraps in JetBrains IDE terminal, making clickable link invalid",
-      "impact": "not_applicable",
-      "categories": [
-        "ide",
-        "terminal",
-        "platform"
-      ],
-      "tokenkey_status": "not_applicable",
-      "rationale": "Client-side claude-code concern (ide, terminal, platform); not a gateway/relay relevance signal.",
-      "updated_at": "2026-05-31T11:24:28Z"
-    },
-    {
       "upstream": "anthropics/claude-code#64202",
       "url": "https://github.com/anthropics/claude-code/issues/64202",
       "title": "Regression in 2.1.158: claude -p hangs waiting for stdin EOF on Termux/arm64",
@@ -13656,81 +14865,6 @@
       "tokenkey_status": "not_applicable",
       "rationale": "Client-side claude-code concern (install); not a gateway/relay relevance signal.",
       "updated_at": "2026-06-02T01:28:06Z"
-    },
-    {
-      "upstream": "anthropics/claude-code#64203",
-      "url": "https://github.com/anthropics/claude-code/issues/64203",
-      "title": "[Bug Report: Model performance degradation on project tasks",
-      "impact": "not_applicable",
-      "categories": [
-        "terminal"
-      ],
-      "tokenkey_status": "not_applicable",
-      "rationale": "Client-side claude-code concern (terminal); not a gateway/relay relevance signal.",
-      "updated_at": "2026-05-31T11:49:18Z"
-    },
-    {
-      "upstream": "anthropics/claude-code#64204",
-      "url": "https://github.com/anthropics/claude-code/issues/64204",
-      "title": "[Feature Request] Message queuing for sequential task execution in VSCodeClaude extension",
-      "impact": "not_applicable",
-      "categories": [
-        "ide"
-      ],
-      "tokenkey_status": "not_applicable",
-      "rationale": "Client-side claude-code concern (ide); not a gateway/relay relevance signal.",
-      "updated_at": "2026-05-31T11:56:00Z"
-    },
-    {
-      "upstream": "anthropics/claude-code#64205",
-      "url": "https://github.com/anthropics/claude-code/issues/64205",
-      "title": "[Feature Request] Background task execution without conversation blocking in VSCode Claude extension",
-      "impact": "not_applicable",
-      "categories": [
-        "ide"
-      ],
-      "tokenkey_status": "not_applicable",
-      "rationale": "Client-side claude-code concern (ide); not a gateway/relay relevance signal.",
-      "updated_at": "2026-05-31T11:56:52Z"
-    },
-    {
-      "upstream": "anthropics/claude-code#64207",
-      "url": "https://github.com/anthropics/claude-code/issues/64207",
-      "title": "[FEATURE] Terminal (TUI): inline colored annotations + deferred batch reply to specific blocks of Claude's output (reviving #45904)",
-      "impact": "not_applicable",
-      "categories": [
-        "ide",
-        "terminal",
-        "platform"
-      ],
-      "tokenkey_status": "not_applicable",
-      "rationale": "Client-side claude-code concern (ide, terminal, platform); not a gateway/relay relevance signal.",
-      "updated_at": "2026-05-31T12:13:00Z"
-    },
-    {
-      "upstream": "anthropics/claude-code#64210",
-      "url": "https://github.com/anthropics/claude-code/issues/64210",
-      "title": "V8 out-of-memory crashes (SIGABRT) freeze/kill the TUI during long sessions on macOS",
-      "impact": "not_applicable",
-      "categories": [
-        "ide",
-        "terminal"
-      ],
-      "tokenkey_status": "not_applicable",
-      "rationale": "Client-side claude-code concern (ide, terminal); not a gateway/relay relevance signal.",
-      "updated_at": "2026-05-31T12:36:10Z"
-    },
-    {
-      "upstream": "anthropics/claude-code#64211",
-      "url": "https://github.com/anthropics/claude-code/issues/64211",
-      "title": "Session cut mid-task by credit limit — no warning, context lost, costly model switch",
-      "impact": "not_applicable",
-      "categories": [
-        "platform"
-      ],
-      "tokenkey_status": "not_applicable",
-      "rationale": "Client-side claude-code concern (platform); not a gateway/relay relevance signal.",
-      "updated_at": "2026-05-31T12:41:09Z"
     },
     {
       "upstream": "anthropics/claude-code#64214",
@@ -13745,82 +14879,6 @@
       "updated_at": "2026-06-01T09:10:14Z"
     },
     {
-      "upstream": "anthropics/claude-code#64215",
-      "url": "https://github.com/anthropics/claude-code/issues/64215",
-      "title": "iPad browser (vscode.dev): newlines not rendered in message display",
-      "impact": "not_applicable",
-      "categories": [
-        "ide",
-        "terminal"
-      ],
-      "tokenkey_status": "not_applicable",
-      "rationale": "Client-side claude-code concern (ide, terminal); not a gateway/relay relevance signal.",
-      "updated_at": "2026-05-31T12:55:16Z"
-    },
-    {
-      "upstream": "anthropics/claude-code#64217",
-      "url": "https://github.com/anthropics/claude-code/issues/64217",
-      "title": "[Bug] Tool use regression in version 4.8 causing premature termination and parallel execution issues",
-      "impact": "not_applicable",
-      "categories": [
-        "terminal"
-      ],
-      "tokenkey_status": "not_applicable",
-      "rationale": "Client-side claude-code concern (terminal); not a gateway/relay relevance signal.",
-      "updated_at": "2026-05-31T13:51:00Z"
-    },
-    {
-      "upstream": "anthropics/claude-code#64218",
-      "url": "https://github.com/anthropics/claude-code/issues/64218",
-      "title": "[Bug] Bash tool executes commands multiple times with duplicate outputs",
-      "impact": "not_applicable",
-      "categories": [
-        "terminal"
-      ],
-      "tokenkey_status": "not_applicable",
-      "rationale": "Client-side claude-code concern (terminal); not a gateway/relay relevance signal.",
-      "updated_at": "2026-05-31T13:42:20Z"
-    },
-    {
-      "upstream": "anthropics/claude-code#64219",
-      "url": "https://github.com/anthropics/claude-code/issues/64219",
-      "title": "[Bug] Tool results delivered with multi-turn lag and flushed in batch",
-      "impact": "not_applicable",
-      "categories": [
-        "terminal",
-        "slash_hook"
-      ],
-      "tokenkey_status": "not_applicable",
-      "rationale": "Client-side claude-code concern (terminal, slash_hook); not a gateway/relay relevance signal.",
-      "updated_at": "2026-05-31T13:18:58Z"
-    },
-    {
-      "upstream": "anthropics/claude-code#64220",
-      "url": "https://github.com/anthropics/claude-code/issues/64220",
-      "title": "[BUG] /init silently misses source files in repos with many files due to Glob truncation",
-      "impact": "not_applicable",
-      "categories": [
-        "terminal",
-        "install",
-        "platform"
-      ],
-      "tokenkey_status": "not_applicable",
-      "rationale": "Client-side claude-code concern (terminal, install, platform); not a gateway/relay relevance signal.",
-      "updated_at": "2026-05-31T13:18:32Z"
-    },
-    {
-      "upstream": "anthropics/claude-code#64221",
-      "url": "https://github.com/anthropics/claude-code/issues/64221",
-      "title": "[Bug] Reasoning interruption in ultramode v4.8+ requires manual restart",
-      "impact": "not_applicable",
-      "categories": [
-        "terminal"
-      ],
-      "tokenkey_status": "not_applicable",
-      "rationale": "Client-side claude-code concern (terminal); not a gateway/relay relevance signal.",
-      "updated_at": "2026-05-31T13:26:51Z"
-    },
-    {
       "upstream": "anthropics/claude-code#64222",
       "url": "https://github.com/anthropics/claude-code/issues/64222",
       "title": "[BUG] Android app: web-search permission modal fails to appear in remote-control Code session, leaving the model stuck in an execution loop (recoverable from PC, not from Android)",
@@ -13831,59 +14889,6 @@
       "tokenkey_status": "not_applicable",
       "rationale": "Client-side claude-code concern (terminal); not a gateway/relay relevance signal.",
       "updated_at": "2026-06-02T16:59:11Z"
-    },
-    {
-      "upstream": "anthropics/claude-code#64224",
-      "url": "https://github.com/anthropics/claude-code/issues/64224",
-      "title": "Feature: first-class GitCommit action (bypass Bash argv for commit messages)",
-      "impact": "not_applicable",
-      "categories": [
-        "slash_hook",
-        "platform"
-      ],
-      "tokenkey_status": "not_applicable",
-      "rationale": "Client-side claude-code concern (slash_hook, platform); not a gateway/relay relevance signal.",
-      "updated_at": "2026-05-31T13:34:50Z"
-    },
-    {
-      "upstream": "anthropics/claude-code#64225",
-      "url": "https://github.com/anthropics/claude-code/issues/64225",
-      "title": "[BUG]",
-      "impact": "not_applicable",
-      "categories": [
-        "ide",
-        "terminal"
-      ],
-      "tokenkey_status": "not_applicable",
-      "rationale": "Client-side claude-code concern (ide, terminal); not a gateway/relay relevance signal.",
-      "updated_at": "2026-05-31T15:16:29Z"
-    },
-    {
-      "upstream": "anthropics/claude-code#64226",
-      "url": "https://github.com/anthropics/claude-code/issues/64226",
-      "title": "[BUG]",
-      "impact": "not_applicable",
-      "categories": [
-        "terminal",
-        "slash_hook",
-        "platform"
-      ],
-      "tokenkey_status": "not_applicable",
-      "rationale": "Client-side claude-code concern (terminal, slash_hook, platform); not a gateway/relay relevance signal.",
-      "updated_at": "2026-05-31T13:39:18Z"
-    },
-    {
-      "upstream": "anthropics/claude-code#64228",
-      "url": "https://github.com/anthropics/claude-code/issues/64228",
-      "title": "Tool results delayed and duplicated in interactive sessions (v2.1.158, Linux, multiple concurrent sessions)",
-      "impact": "not_applicable",
-      "categories": [
-        "terminal",
-        "slash_hook"
-      ],
-      "tokenkey_status": "not_applicable",
-      "rationale": "Client-side claude-code concern (terminal, slash_hook); not a gateway/relay relevance signal.",
-      "updated_at": "2026-05-31T20:29:07Z"
     },
     {
       "upstream": "anthropics/claude-code#64230",
@@ -13898,110 +14903,6 @@
       "updated_at": "2026-06-01T04:04:42Z"
     },
     {
-      "upstream": "anthropics/claude-code#64231",
-      "url": "https://github.com/anthropics/claude-code/issues/64231",
-      "title": "[FEATURE] programmatic conversation renaming in Claude Cowork",
-      "impact": "not_applicable",
-      "categories": [
-        "mcp"
-      ],
-      "tokenkey_status": "not_applicable",
-      "rationale": "Client-side claude-code concern (mcp); not a gateway/relay relevance signal.",
-      "updated_at": "2026-05-31T14:12:44Z"
-    },
-    {
-      "upstream": "anthropics/claude-code#64234",
-      "url": "https://github.com/anthropics/claude-code/issues/64234",
-      "title": "[BUG] Cowork \"Download failed\" on macOS — claude-code-vm runtime missing from app bundle",
-      "impact": "not_applicable",
-      "categories": [
-        "terminal",
-        "install"
-      ],
-      "tokenkey_status": "not_applicable",
-      "rationale": "Client-side claude-code concern (terminal, install); not a gateway/relay relevance signal.",
-      "updated_at": "2026-05-31T14:36:12Z"
-    },
-    {
-      "upstream": "anthropics/claude-code#64238",
-      "url": "https://github.com/anthropics/claude-code/issues/64238",
-      "title": "[FEATURE] Decouple LSP diagnostic auto-push from the LSP tool (keep navigation, drop publishDiagnostics)",
-      "impact": "not_applicable",
-      "categories": [
-        "plugin",
-        "slash_hook"
-      ],
-      "tokenkey_status": "not_applicable",
-      "rationale": "Client-side claude-code concern (plugin, slash_hook); not a gateway/relay relevance signal.",
-      "updated_at": "2026-05-31T14:50:31Z"
-    },
-    {
-      "upstream": "anthropics/claude-code#64239",
-      "url": "https://github.com/anthropics/claude-code/issues/64239",
-      "title": "[BUG] typescript-lsp pushes stale diagnostics on 2.1.158 (post-#17979) in TS project-references/composite workspaces",
-      "impact": "not_applicable",
-      "categories": [
-        "plugin",
-        "platform"
-      ],
-      "tokenkey_status": "not_applicable",
-      "rationale": "Client-side claude-code concern (plugin, platform); not a gateway/relay relevance signal.",
-      "updated_at": "2026-05-31T14:51:52Z"
-    },
-    {
-      "upstream": "anthropics/claude-code#64240",
-      "url": "https://github.com/anthropics/claude-code/issues/64240",
-      "title": "[BUG] Remote-control sessions (browser/mobile) silently drop attachments — shown as sent, never reach the model",
-      "impact": "not_applicable",
-      "categories": [
-        "ide",
-        "terminal",
-        "platform"
-      ],
-      "tokenkey_status": "not_applicable",
-      "rationale": "Client-side claude-code concern (ide, terminal, platform); not a gateway/relay relevance signal.",
-      "updated_at": "2026-05-31T14:54:33Z"
-    },
-    {
-      "upstream": "anthropics/claude-code#64242",
-      "url": "https://github.com/anthropics/claude-code/issues/64242",
-      "title": "iOS Dispatch sessions from mobile fail to spawn reliably",
-      "impact": "not_applicable",
-      "categories": [
-        "platform"
-      ],
-      "tokenkey_status": "not_applicable",
-      "rationale": "Client-side claude-code concern (platform); not a gateway/relay relevance signal.",
-      "updated_at": "2026-05-31T15:11:34Z"
-    },
-    {
-      "upstream": "anthropics/claude-code#64243",
-      "url": "https://github.com/anthropics/claude-code/issues/64243",
-      "title": "[BUG] Unable to copy `%PDF-1.6` text",
-      "impact": "not_applicable",
-      "categories": [
-        "terminal"
-      ],
-      "tokenkey_status": "not_applicable",
-      "rationale": "Client-side claude-code concern (terminal); not a gateway/relay relevance signal.",
-      "updated_at": "2026-05-31T15:15:04Z"
-    },
-    {
-      "upstream": "anthropics/claude-code#64244",
-      "url": "https://github.com/anthropics/claude-code/issues/64244",
-      "title": "Dispatch needs user-level persistent persona / identity injection",
-      "impact": "not_applicable",
-      "categories": [
-        "ide",
-        "mcp",
-        "slash_hook",
-        "platform"
-      ],
-      "tokenkey_status": "not_applicable",
-      "rationale": "Client-side claude-code concern (ide, mcp, slash_hook, platform); not a gateway/relay relevance signal.",
-      "updated_at": "2026-05-31T15:15:49Z"
-    },
-    {
       "upstream": "anthropics/claude-code#64247",
       "url": "https://github.com/anthropics/claude-code/issues/64247",
       "title": "[Bug] Parallel tool calls cancel all siblings on single error, which appears to cause model confusion",
@@ -14011,57 +14912,7 @@
       ],
       "tokenkey_status": "not_applicable",
       "rationale": "Client-side claude-code concern (terminal); not a gateway/relay relevance signal.",
-      "updated_at": "2026-05-31T17:35:40Z"
-    },
-    {
-      "upstream": "anthropics/claude-code#64248",
-      "url": "https://github.com/anthropics/claude-code/issues/64248",
-      "title": "[BUG] naming convention should not use \"-\" as the replacement for \"/\" as it creates file and directories that start with \"-\".",
-      "impact": "not_applicable",
-      "categories": [
-        "terminal"
-      ],
-      "tokenkey_status": "not_applicable",
-      "rationale": "Client-side claude-code concern (terminal); not a gateway/relay relevance signal.",
-      "updated_at": "2026-05-31T15:29:48Z"
-    },
-    {
-      "upstream": "anthropics/claude-code#64249",
-      "url": "https://github.com/anthropics/claude-code/issues/64249",
-      "title": "[Bug] Agent stalls without token consumption during execution",
-      "impact": "not_applicable",
-      "categories": [
-        "terminal"
-      ],
-      "tokenkey_status": "not_applicable",
-      "rationale": "Client-side claude-code concern (terminal); not a gateway/relay relevance signal.",
-      "updated_at": "2026-05-31T15:39:56Z"
-    },
-    {
-      "upstream": "anthropics/claude-code#64250",
-      "url": "https://github.com/anthropics/claude-code/issues/64250",
-      "title": "Advisor tool completes in UI but result never injected into model context (under Remote Control)",
-      "impact": "not_applicable",
-      "categories": [
-        "terminal",
-        "mcp"
-      ],
-      "tokenkey_status": "not_applicable",
-      "rationale": "Client-side claude-code concern (terminal, mcp); not a gateway/relay relevance signal.",
-      "updated_at": "2026-05-31T15:40:08Z"
-    },
-    {
-      "upstream": "anthropics/claude-code#64252",
-      "url": "https://github.com/anthropics/claude-code/issues/64252",
-      "title": "macOS: keybinding hint shows 'meta+w' instead of 'Option+w' (⌥W)",
-      "impact": "not_applicable",
-      "categories": [
-        "slash_hook",
-        "platform"
-      ],
-      "tokenkey_status": "not_applicable",
-      "rationale": "Client-side claude-code concern (slash_hook, platform); not a gateway/relay relevance signal.",
-      "updated_at": "2026-05-31T15:54:48Z"
+      "updated_at": "2026-06-03T12:09:08Z"
     },
     {
       "upstream": "anthropics/claude-code#64253",
@@ -14089,161 +14940,7 @@
       ],
       "tokenkey_status": "not_applicable",
       "rationale": "Client-side claude-code concern (terminal, platform); not a gateway/relay relevance signal.",
-      "updated_at": "2026-05-31T16:13:03Z"
-    },
-    {
-      "upstream": "anthropics/claude-code#64261",
-      "url": "https://github.com/anthropics/claude-code/issues/64261",
-      "title": "[Bug] Claude responding in Japanese when prompted in Chinese",
-      "impact": "not_applicable",
-      "categories": [
-        "terminal"
-      ],
-      "tokenkey_status": "not_applicable",
-      "rationale": "Client-side claude-code concern (terminal); not a gateway/relay relevance signal.",
-      "updated_at": "2026-05-31T16:32:41Z"
-    },
-    {
-      "upstream": "anthropics/claude-code#64262",
-      "url": "https://github.com/anthropics/claude-code/issues/64262",
-      "title": "[FEATURE] Allow users to opt out of post-compaction continuation injection via CLAUDE.md",
-      "impact": "not_applicable",
-      "categories": [
-        "ide"
-      ],
-      "tokenkey_status": "not_applicable",
-      "rationale": "Client-side claude-code concern (ide); not a gateway/relay relevance signal.",
-      "updated_at": "2026-05-31T16:46:05Z"
-    },
-    {
-      "upstream": "anthropics/claude-code#64263",
-      "url": "https://github.com/anthropics/claude-code/issues/64263",
-      "title": "[BUG] agent stuck: git-rebase preference + auto-mode -> blocked force pushes -> requires human intervention",
-      "impact": "not_applicable",
-      "categories": [
-        "terminal"
-      ],
-      "tokenkey_status": "not_applicable",
-      "rationale": "Client-side claude-code concern (terminal); not a gateway/relay relevance signal.",
-      "updated_at": "2026-05-31T16:48:30Z"
-    },
-    {
-      "upstream": "anthropics/claude-code#64264",
-      "url": "https://github.com/anthropics/claude-code/issues/64264",
-      "title": "[Feature] Add a user-facing toggle for spinner verbs / tool-use summaries in Claude Desktop",
-      "impact": "not_applicable",
-      "categories": [
-        "terminal",
-        "slash_hook"
-      ],
-      "tokenkey_status": "not_applicable",
-      "rationale": "Client-side claude-code concern (terminal, slash_hook); not a gateway/relay relevance signal.",
-      "updated_at": "2026-05-31T16:49:58Z"
-    },
-    {
-      "upstream": "anthropics/claude-code#64265",
-      "url": "https://github.com/anthropics/claude-code/issues/64265",
-      "title": "[BUG] Headless mode (`-p --output-format stream-json`) breaks AskUserQuestion handling — model continues on assumptions instead of stopping",
-      "impact": "not_applicable",
-      "categories": [
-        "terminal",
-        "slash_hook"
-      ],
-      "tokenkey_status": "not_applicable",
-      "rationale": "Client-side claude-code concern (terminal, slash_hook); not a gateway/relay relevance signal.",
-      "updated_at": "2026-05-31T16:57:35Z"
-    },
-    {
-      "upstream": "anthropics/claude-code#64268",
-      "url": "https://github.com/anthropics/claude-code/issues/64268",
-      "title": "[Bug] v2.1.156+ regression: native Read/Bash return fabricated-but-plausible content, triggering agent confabulation cascades",
-      "impact": "not_applicable",
-      "categories": [
-        "mcp"
-      ],
-      "tokenkey_status": "not_applicable",
-      "rationale": "Client-side claude-code concern (mcp); not a gateway/relay relevance signal.",
-      "updated_at": "2026-05-31T16:58:16Z"
-    },
-    {
-      "upstream": "anthropics/claude-code#64271",
-      "url": "https://github.com/anthropics/claude-code/issues/64271",
-      "title": "`claude --bg` code-writing sessions stall on permission prompts with no non-interactive way to reply (acceptEdits insufficient)",
-      "impact": "not_applicable",
-      "categories": [
-        "terminal",
-        "plugin",
-        "platform"
-      ],
-      "tokenkey_status": "not_applicable",
-      "rationale": "Client-side claude-code concern (terminal, plugin, platform); not a gateway/relay relevance signal.",
-      "updated_at": "2026-05-31T19:24:29Z"
-    },
-    {
-      "upstream": "anthropics/claude-code#64272",
-      "url": "https://github.com/anthropics/claude-code/issues/64272",
-      "title": "Docs: clarify that `claude --bg` / background dispatch sessions do not carry `agent_id` in hook payloads",
-      "impact": "not_applicable",
-      "categories": [
-        "terminal",
-        "plugin",
-        "slash_hook"
-      ],
-      "tokenkey_status": "not_applicable",
-      "rationale": "Client-side claude-code concern (terminal, plugin, slash_hook); not a gateway/relay relevance signal.",
-      "updated_at": "2026-05-31T17:23:49Z"
-    },
-    {
-      "upstream": "anthropics/claude-code#64273",
-      "url": "https://github.com/anthropics/claude-code/issues/64273",
-      "title": "Windows: background daemon keeps a directory handle after `claude rm`, blocking directory deletion",
-      "impact": "not_applicable",
-      "categories": [
-        "terminal",
-        "platform"
-      ],
-      "tokenkey_status": "not_applicable",
-      "rationale": "Client-side claude-code concern (terminal, platform); not a gateway/relay relevance signal.",
-      "updated_at": "2026-05-31T17:24:05Z"
-    },
-    {
-      "upstream": "anthropics/claude-code#64274",
-      "url": "https://github.com/anthropics/claude-code/issues/64274",
-      "title": "[Bug] Auto-accept mode ignores directory containment check for home paths ending in period",
-      "impact": "not_applicable",
-      "categories": [
-        "terminal",
-        "plugin"
-      ],
-      "tokenkey_status": "not_applicable",
-      "rationale": "Client-side claude-code concern (terminal, plugin); not a gateway/relay relevance signal.",
-      "updated_at": "2026-05-31T17:38:15Z"
-    },
-    {
-      "upstream": "anthropics/claude-code#64275",
-      "url": "https://github.com/anthropics/claude-code/issues/64275",
-      "title": "[BUG] `/insights` skill: AI-generated sections empty (returns {})",
-      "impact": "not_applicable",
-      "categories": [
-        "terminal"
-      ],
-      "tokenkey_status": "not_applicable",
-      "rationale": "Client-side claude-code concern (terminal); not a gateway/relay relevance signal.",
-      "updated_at": "2026-05-31T17:42:58Z"
-    },
-    {
-      "upstream": "anthropics/claude-code#64276",
-      "url": "https://github.com/anthropics/claude-code/issues/64276",
-      "title": "[BUG] LSP client never sends textDocument/didClose, leaking language-server resources until OOM",
-      "impact": "not_applicable",
-      "categories": [
-        "terminal",
-        "plugin",
-        "install"
-      ],
-      "tokenkey_status": "not_applicable",
-      "rationale": "Client-side claude-code concern (terminal, plugin, install); not a gateway/relay relevance signal.",
-      "updated_at": "2026-05-31T17:48:44Z"
+      "updated_at": "2026-06-03T19:28:35Z"
     },
     {
       "upstream": "anthropics/claude-code#64277",
@@ -14271,119 +14968,6 @@
       "updated_at": "2026-06-01T03:03:11Z"
     },
     {
-      "upstream": "anthropics/claude-code#64282",
-      "url": "https://github.com/anthropics/claude-code/issues/64282",
-      "title": "[FEATURE] Per-banner \"Don't show again\" dismissal for MCP connection notifications",
-      "impact": "not_applicable",
-      "categories": [
-        "mcp",
-        "platform"
-      ],
-      "tokenkey_status": "not_applicable",
-      "rationale": "Client-side claude-code concern (mcp, platform); not a gateway/relay relevance signal.",
-      "updated_at": "2026-05-31T18:03:44Z"
-    },
-    {
-      "upstream": "anthropics/claude-code#64283",
-      "url": "https://github.com/anthropics/claude-code/issues/64283",
-      "title": "[Bug] Session cost significantly higher than expected; parallel agent forking causing excessive API usage",
-      "impact": "not_applicable",
-      "categories": [
-        "terminal",
-        "platform"
-      ],
-      "tokenkey_status": "not_applicable",
-      "rationale": "Client-side claude-code concern (terminal, platform); not a gateway/relay relevance signal.",
-      "updated_at": "2026-05-31T18:05:06Z"
-    },
-    {
-      "upstream": "anthropics/claude-code#64285",
-      "url": "https://github.com/anthropics/claude-code/issues/64285",
-      "title": "[Bug] Excessive token consumption on basic operations",
-      "impact": "not_applicable",
-      "categories": [
-        "ide",
-        "terminal"
-      ],
-      "tokenkey_status": "not_applicable",
-      "rationale": "Client-side claude-code concern (ide, terminal); not a gateway/relay relevance signal.",
-      "updated_at": "2026-05-31T18:13:55Z"
-    },
-    {
-      "upstream": "anthropics/claude-code#64286",
-      "url": "https://github.com/anthropics/claude-code/issues/64286",
-      "title": "[Bug] Claude Code fabricated test results and pushed untested code to main branch (Opus 4.8 @ Effort = High)",
-      "impact": "not_applicable",
-      "categories": [
-        "terminal"
-      ],
-      "tokenkey_status": "not_applicable",
-      "rationale": "Client-side claude-code concern (terminal); not a gateway/relay relevance signal.",
-      "updated_at": "2026-05-31T18:22:55Z"
-    },
-    {
-      "upstream": "anthropics/claude-code#64288",
-      "url": "https://github.com/anthropics/claude-code/issues/64288",
-      "title": "Ordered-list markdown in submitted messages gets auto-renumbered (e.g. '2.'/'5.' → '1.'/'2.'), clobbering intended numbering",
-      "impact": "not_applicable",
-      "categories": [
-        "terminal"
-      ],
-      "tokenkey_status": "not_applicable",
-      "rationale": "Client-side claude-code concern (terminal); not a gateway/relay relevance signal.",
-      "updated_at": "2026-05-31T18:16:08Z"
-    },
-    {
-      "upstream": "anthropics/claude-code#64289",
-      "url": "https://github.com/anthropics/claude-code/issues/64289",
-      "title": "Permission/question dialogs do not render in Ctrl+O transcript mode (UI hangs indefinitely)",
-      "impact": "not_applicable",
-      "categories": [
-        "terminal",
-        "install"
-      ],
-      "tokenkey_status": "not_applicable",
-      "rationale": "Client-side claude-code concern (terminal, install); not a gateway/relay relevance signal.",
-      "updated_at": "2026-05-31T18:19:48Z"
-    },
-    {
-      "upstream": "anthropics/claude-code#64290",
-      "url": "https://github.com/anthropics/claude-code/issues/64290",
-      "title": "[BUG] claude recommends adding non-existent directory to PATH",
-      "impact": "not_applicable",
-      "categories": [
-        "terminal",
-        "install"
-      ],
-      "tokenkey_status": "not_applicable",
-      "rationale": "Client-side claude-code concern (terminal, install); not a gateway/relay relevance signal.",
-      "updated_at": "2026-05-31T18:23:21Z"
-    },
-    {
-      "upstream": "anthropics/claude-code#64291",
-      "url": "https://github.com/anthropics/claude-code/issues/64291",
-      "title": "[Bug] Serializer-complete rule violation in conversation state management",
-      "impact": "not_applicable",
-      "categories": [
-        "terminal"
-      ],
-      "tokenkey_status": "not_applicable",
-      "rationale": "Client-side claude-code concern (terminal); not a gateway/relay relevance signal.",
-      "updated_at": "2026-05-31T18:26:25Z"
-    },
-    {
-      "upstream": "anthropics/claude-code#64292",
-      "url": "https://github.com/anthropics/claude-code/issues/64292",
-      "title": "[Bug] Auto-update failed - /doctor command produced no relevant output",
-      "impact": "not_applicable",
-      "categories": [
-        "terminal"
-      ],
-      "tokenkey_status": "not_applicable",
-      "rationale": "Client-side claude-code concern (terminal); not a gateway/relay relevance signal.",
-      "updated_at": "2026-05-31T18:33:16Z"
-    },
-    {
       "upstream": "anthropics/claude-code#64293",
       "url": "https://github.com/anthropics/claude-code/issues/64293",
       "title": "[BUG] Personal repositories not showing in Claude Code repo picker",
@@ -14395,44 +14979,6 @@
       "tokenkey_status": "not_applicable",
       "rationale": "Client-side claude-code concern (terminal, install); not a gateway/relay relevance signal.",
       "updated_at": "2026-06-03T04:45:53Z"
-    },
-    {
-      "upstream": "anthropics/claude-code#64294",
-      "url": "https://github.com/anthropics/claude-code/issues/64294",
-      "title": "Files being truncated by edit in cowork with no warning and way below the 32kb limit",
-      "impact": "not_applicable",
-      "categories": [
-        "terminal",
-        "platform"
-      ],
-      "tokenkey_status": "not_applicable",
-      "rationale": "Client-side claude-code concern (terminal, platform); not a gateway/relay relevance signal.",
-      "updated_at": "2026-05-31T18:42:13Z"
-    },
-    {
-      "upstream": "anthropics/claude-code#64295",
-      "url": "https://github.com/anthropics/claude-code/issues/64295",
-      "title": "[BUG] Opus 4.7 excess token usage in Windows - 7K tokens used 52%",
-      "impact": "not_applicable",
-      "categories": [
-        "terminal",
-        "platform"
-      ],
-      "tokenkey_status": "not_applicable",
-      "rationale": "Client-side claude-code concern (terminal, platform); not a gateway/relay relevance signal.",
-      "updated_at": "2026-05-31T18:53:17Z"
-    },
-    {
-      "upstream": "anthropics/claude-code#64296",
-      "url": "https://github.com/anthropics/claude-code/issues/64296",
-      "title": "MCP: re-enumerate tools mid-session for remote-control sessions (mcp_reconnect works but is unreachable)",
-      "impact": "not_applicable",
-      "categories": [
-        "mcp"
-      ],
-      "tokenkey_status": "not_applicable",
-      "rationale": "Client-side claude-code concern (mcp); not a gateway/relay relevance signal.",
-      "updated_at": "2026-05-31T22:06:54Z"
     },
     {
       "upstream": "anthropics/claude-code#64297",
@@ -14462,202 +15008,6 @@
       "updated_at": "2026-06-01T13:06:01Z"
     },
     {
-      "upstream": "anthropics/claude-code#64300",
-      "url": "https://github.com/anthropics/claude-code/issues/64300",
-      "title": "`acceptEdits` mode does not extend to `additionalDirectories` (Edit/Write still prompt per-file)",
-      "impact": "not_applicable",
-      "categories": [
-        "ide"
-      ],
-      "tokenkey_status": "not_applicable",
-      "rationale": "Client-side claude-code concern (ide); not a gateway/relay relevance signal.",
-      "updated_at": "2026-05-31T19:23:30Z"
-    },
-    {
-      "upstream": "anthropics/claude-code#64301",
-      "url": "https://github.com/anthropics/claude-code/issues/64301",
-      "title": "Bash sandbox (bubblewrap) corrupts `!` to `\\!` in commands, making the sandbox unusable for agentic workflows",
-      "impact": "not_applicable",
-      "categories": [
-        "slash_hook",
-        "install"
-      ],
-      "tokenkey_status": "not_applicable",
-      "rationale": "Client-side claude-code concern (slash_hook, install); not a gateway/relay relevance signal.",
-      "updated_at": "2026-05-31T19:24:17Z"
-    },
-    {
-      "upstream": "anthropics/claude-code#64303",
-      "url": "https://github.com/anthropics/claude-code/issues/64303",
-      "title": "Workflow run shows \"Running 2032m\" indefinitely after the agent has died; cannot be stopped via UI Stop button or TaskStop (Run ID / Task ID both unknown)",
-      "impact": "not_applicable",
-      "categories": [
-        "plugin",
-        "platform"
-      ],
-      "tokenkey_status": "not_applicable",
-      "rationale": "Client-side claude-code concern (plugin, platform); not a gateway/relay relevance signal.",
-      "updated_at": "2026-05-31T19:57:20Z"
-    },
-    {
-      "upstream": "anthropics/claude-code#64304",
-      "url": "https://github.com/anthropics/claude-code/issues/64304",
-      "title": "Session title diverges between Desktop app and mobile/web — two independent title stores that never reconcile",
-      "impact": "not_applicable",
-      "categories": [
-        "ide",
-        "terminal",
-        "slash_hook",
-        "platform"
-      ],
-      "tokenkey_status": "not_applicable",
-      "rationale": "Client-side claude-code concern (ide, terminal, slash_hook, platform); not a gateway/relay relevance signal.",
-      "updated_at": "2026-05-31T20:13:25Z"
-    },
-    {
-      "upstream": "anthropics/claude-code#64309",
-      "url": "https://github.com/anthropics/claude-code/issues/64309",
-      "title": "Benign `node -e` regex script false-flagged as \"Fork bomb detected\"",
-      "impact": "not_applicable",
-      "categories": [
-        "ide",
-        "terminal"
-      ],
-      "tokenkey_status": "not_applicable",
-      "rationale": "Client-side claude-code concern (ide, terminal); not a gateway/relay relevance signal.",
-      "updated_at": "2026-05-31T20:01:29Z"
-    },
-    {
-      "upstream": "anthropics/claude-code#64310",
-      "url": "https://github.com/anthropics/claude-code/issues/64310",
-      "title": "Claude Code deleted client video files without confirmation — data loss on production work",
-      "impact": "not_applicable",
-      "categories": [
-        "platform"
-      ],
-      "tokenkey_status": "not_applicable",
-      "rationale": "Client-side claude-code concern (platform); not a gateway/relay relevance signal.",
-      "updated_at": "2026-05-31T20:55:32Z"
-    },
-    {
-      "upstream": "anthropics/claude-code#64311",
-      "url": "https://github.com/anthropics/claude-code/issues/64311",
-      "title": "Managed/team-seat config bypasses MCP tool-search deferral — claude.ai connector schemas re-inject into messages every turn (CC 2.1.158)",
-      "impact": "not_applicable",
-      "categories": [
-        "mcp",
-        "slash_hook"
-      ],
-      "tokenkey_status": "not_applicable",
-      "rationale": "Client-side claude-code concern (mcp, slash_hook); not a gateway/relay relevance signal.",
-      "updated_at": "2026-05-31T20:07:40Z"
-    },
-    {
-      "upstream": "anthropics/claude-code#64312",
-      "url": "https://github.com/anthropics/claude-code/issues/64312",
-      "title": "Claude Code context window not resetting — stuck at 1M instead of 200k on Pro",
-      "impact": "not_applicable",
-      "categories": [
-        "terminal",
-        "platform"
-      ],
-      "tokenkey_status": "not_applicable",
-      "rationale": "Client-side claude-code concern (terminal, platform); not a gateway/relay relevance signal.",
-      "updated_at": "2026-05-31T20:07:46Z"
-    },
-    {
-      "upstream": "anthropics/claude-code#64313",
-      "url": "https://github.com/anthropics/claude-code/issues/64313",
-      "title": "Feedback: Claude should observe existing layout structure before adding fixed/static UI elements",
-      "impact": "not_applicable",
-      "categories": [
-        "terminal"
-      ],
-      "tokenkey_status": "not_applicable",
-      "rationale": "Client-side claude-code concern (terminal); not a gateway/relay relevance signal.",
-      "updated_at": "2026-05-31T20:25:19Z"
-    },
-    {
-      "upstream": "anthropics/claude-code#64314",
-      "url": "https://github.com/anthropics/claude-code/issues/64314",
-      "title": "[Bug] Stray token \"count\" injected before tool calls causes parse failure in Claude Code",
-      "impact": "not_applicable",
-      "categories": [
-        "terminal",
-        "mcp"
-      ],
-      "tokenkey_status": "not_applicable",
-      "rationale": "Client-side claude-code concern (terminal, mcp); not a gateway/relay relevance signal.",
-      "updated_at": "2026-05-31T20:26:20Z"
-    },
-    {
-      "upstream": "anthropics/claude-code#64315",
-      "url": "https://github.com/anthropics/claude-code/issues/64315",
-      "title": "Agent tool: `isolation: \"worktree\"` creates worktree in session repo, not target repo, breaking parallel cross-repo work",
-      "impact": "not_applicable",
-      "categories": [
-        "plugin"
-      ],
-      "tokenkey_status": "not_applicable",
-      "rationale": "Client-side claude-code concern (plugin); not a gateway/relay relevance signal.",
-      "updated_at": "2026-05-31T20:26:53Z"
-    },
-    {
-      "upstream": "anthropics/claude-code#64316",
-      "url": "https://github.com/anthropics/claude-code/issues/64316",
-      "title": "[BUG] MCP: structuredContent overrides content field, losing actual tool response",
-      "impact": "not_applicable",
-      "categories": [
-        "ide",
-        "terminal",
-        "mcp",
-        "platform"
-      ],
-      "tokenkey_status": "not_applicable",
-      "rationale": "Client-side claude-code concern (ide, terminal, mcp, platform); not a gateway/relay relevance signal.",
-      "updated_at": "2026-05-31T20:46:50Z"
-    },
-    {
-      "upstream": "anthropics/claude-code#64318",
-      "url": "https://github.com/anthropics/claude-code/issues/64318",
-      "title": "computer-use MCP: browsers reported \"(not installed)\" on macOS when Spotlight is disabled, despite LaunchServices having them registered",
-      "impact": "not_applicable",
-      "categories": [
-        "mcp",
-        "install",
-        "platform"
-      ],
-      "tokenkey_status": "not_applicable",
-      "rationale": "Client-side claude-code concern (mcp, install, platform); not a gateway/relay relevance signal.",
-      "updated_at": "2026-05-31T20:32:48Z"
-    },
-    {
-      "upstream": "anthropics/claude-code#64319",
-      "url": "https://github.com/anthropics/claude-code/issues/64319",
-      "title": "Model autonomously deployed to production without user authorization",
-      "impact": "not_applicable",
-      "categories": [
-        "platform"
-      ],
-      "tokenkey_status": "not_applicable",
-      "rationale": "Client-side claude-code concern (platform); not a gateway/relay relevance signal.",
-      "updated_at": "2026-06-01T00:01:56Z"
-    },
-    {
-      "upstream": "anthropics/claude-code#64320",
-      "url": "https://github.com/anthropics/claude-code/issues/64320",
-      "title": "[BUG] Cowork shows \"yukonSilver not supported (status=unsupported)\" on Windows 11 Pro with 11th Gen Intel i5-1155G7 — VM never initializes",
-      "impact": "not_applicable",
-      "categories": [
-        "terminal",
-        "install",
-        "platform"
-      ],
-      "tokenkey_status": "not_applicable",
-      "rationale": "Client-side claude-code concern (terminal, install, platform); not a gateway/relay relevance signal.",
-      "updated_at": "2026-05-31T20:38:21Z"
-    },
-    {
       "upstream": "anthropics/claude-code#64324",
       "url": "https://github.com/anthropics/claude-code/issues/64324",
       "title": "[Bug] Claude Opus 4.8 API returning increased hallucinations",
@@ -14668,96 +15018,6 @@
       "tokenkey_status": "not_applicable",
       "rationale": "Client-side claude-code concern (terminal); not a gateway/relay relevance signal.",
       "updated_at": "2026-06-01T17:17:47Z"
-    },
-    {
-      "upstream": "anthropics/claude-code#64325",
-      "url": "https://github.com/anthropics/claude-code/issues/64325",
-      "title": "[Bug] Opus 4.8 hallucinating security incidents and fabricating evidence during long tasks",
-      "impact": "not_applicable",
-      "categories": [
-        "terminal",
-        "slash_hook"
-      ],
-      "tokenkey_status": "not_applicable",
-      "rationale": "Client-side claude-code concern (terminal, slash_hook); not a gateway/relay relevance signal.",
-      "updated_at": "2026-05-31T21:10:37Z"
-    },
-    {
-      "upstream": "anthropics/claude-code#64326",
-      "url": "https://github.com/anthropics/claude-code/issues/64326",
-      "title": "[Feature Request] PostToolUse hook で output 文字列を改変 (REDACT) する機能の追加",
-      "impact": "not_applicable",
-      "categories": [
-        "slash_hook"
-      ],
-      "tokenkey_status": "not_applicable",
-      "rationale": "Client-side claude-code concern (slash_hook); not a gateway/relay relevance signal.",
-      "updated_at": "2026-05-31T21:08:29Z"
-    },
-    {
-      "upstream": "anthropics/claude-code#64331",
-      "url": "https://github.com/anthropics/claude-code/issues/64331",
-      "title": "[FEATURE] Plan mode — AskUserQuestion modal covers the agent's analysis and can't be minimized",
-      "impact": "not_applicable",
-      "categories": [
-        "ide",
-        "terminal"
-      ],
-      "tokenkey_status": "not_applicable",
-      "rationale": "Client-side claude-code concern (ide, terminal); not a gateway/relay relevance signal.",
-      "updated_at": "2026-05-31T21:26:43Z"
-    },
-    {
-      "upstream": "anthropics/claude-code#64332",
-      "url": "https://github.com/anthropics/claude-code/issues/64332",
-      "title": "[BUG] Dispatch thread permanently stuck — server-side reset required",
-      "impact": "not_applicable",
-      "categories": [
-        "terminal",
-        "platform"
-      ],
-      "tokenkey_status": "not_applicable",
-      "rationale": "Client-side claude-code concern (terminal, platform); not a gateway/relay relevance signal.",
-      "updated_at": "2026-05-31T21:29:58Z"
-    },
-    {
-      "upstream": "anthropics/claude-code#64333",
-      "url": "https://github.com/anthropics/claude-code/issues/64333",
-      "title": "Batched/parallel tool calls: one failure cancels all siblings; Edit old_string match failures (Windows CRLF)",
-      "impact": "not_applicable",
-      "categories": [
-        "mcp",
-        "platform"
-      ],
-      "tokenkey_status": "not_applicable",
-      "rationale": "Client-side claude-code concern (mcp, platform); not a gateway/relay relevance signal.",
-      "updated_at": "2026-05-31T21:35:08Z"
-    },
-    {
-      "upstream": "anthropics/claude-code#64334",
-      "url": "https://github.com/anthropics/claude-code/issues/64334",
-      "title": "Bash command with 2>&1 causes ~12min spinner hang with token usage climbing during the stall",
-      "impact": "not_applicable",
-      "categories": [
-        "terminal",
-        "slash_hook"
-      ],
-      "tokenkey_status": "not_applicable",
-      "rationale": "Client-side claude-code concern (terminal, slash_hook); not a gateway/relay relevance signal.",
-      "updated_at": "2026-05-31T21:42:17Z"
-    },
-    {
-      "upstream": "anthropics/claude-code#64337",
-      "url": "https://github.com/anthropics/claude-code/issues/64337",
-      "title": "Bug: Remote Control via remoteControlAtStartup has no persistent indicator — startup notice scrolls off, nothing in status line / corner",
-      "impact": "not_applicable",
-      "categories": [
-        "terminal",
-        "slash_hook"
-      ],
-      "tokenkey_status": "not_applicable",
-      "rationale": "Client-side claude-code concern (terminal, slash_hook); not a gateway/relay relevance signal.",
-      "updated_at": "2026-05-31T22:08:11Z"
     },
     {
       "upstream": "anthropics/claude-code#64338",
@@ -14775,44 +15035,6 @@
       "updated_at": "2026-06-01T21:40:02Z"
     },
     {
-      "upstream": "anthropics/claude-code#64340",
-      "url": "https://github.com/anthropics/claude-code/issues/64340",
-      "title": "[Feature Request] Improve readline keybinding compatibility for word navigation (alt-f/alt-b)",
-      "impact": "not_applicable",
-      "categories": [
-        "terminal",
-        "slash_hook"
-      ],
-      "tokenkey_status": "not_applicable",
-      "rationale": "Client-side claude-code concern (terminal, slash_hook); not a gateway/relay relevance signal.",
-      "updated_at": "2026-05-31T22:25:52Z"
-    },
-    {
-      "upstream": "anthropics/claude-code#64341",
-      "url": "https://github.com/anthropics/claude-code/issues/64341",
-      "title": "[Bug] Model version inconsistency across devices with same account, requires reinstall",
-      "impact": "not_applicable",
-      "categories": [
-        "terminal",
-        "install"
-      ],
-      "tokenkey_status": "not_applicable",
-      "rationale": "Client-side claude-code concern (terminal, install); not a gateway/relay relevance signal.",
-      "updated_at": "2026-05-31T22:25:07Z"
-    },
-    {
-      "upstream": "anthropics/claude-code#64343",
-      "url": "https://github.com/anthropics/claude-code/issues/64343",
-      "title": "[Bug] Excessive token consumption from repeated echo tool calls",
-      "impact": "not_applicable",
-      "categories": [
-        "terminal"
-      ],
-      "tokenkey_status": "not_applicable",
-      "rationale": "Client-side claude-code concern (terminal); not a gateway/relay relevance signal.",
-      "updated_at": "2026-05-31T22:37:22Z"
-    },
-    {
       "upstream": "anthropics/claude-code#64349",
       "url": "https://github.com/anthropics/claude-code/issues/64349",
       "title": "Claude Code VS Code extension forces 1M context on Pro plan - Windows",
@@ -14826,19 +15048,7 @@
       ],
       "tokenkey_status": "not_applicable",
       "rationale": "Client-side claude-code concern (ide, terminal, slash_hook, install, platform); not a gateway/relay relevance signal.",
-      "updated_at": "2026-06-03T08:37:36Z"
-    },
-    {
-      "upstream": "anthropics/claude-code#64351",
-      "url": "https://github.com/anthropics/claude-code/issues/64351",
-      "title": "[Feature Request] Selective Context Compaction for Partial Message Pruning",
-      "impact": "not_applicable",
-      "categories": [
-        "terminal"
-      ],
-      "tokenkey_status": "not_applicable",
-      "rationale": "Client-side claude-code concern (terminal); not a gateway/relay relevance signal.",
-      "updated_at": "2026-05-31T23:06:48Z"
+      "updated_at": "2026-06-03T16:35:04Z"
     },
     {
       "upstream": "anthropics/claude-code#64352",
@@ -14852,30 +15062,6 @@
       "tokenkey_status": "not_applicable",
       "rationale": "Client-side claude-code concern (ide, terminal); not a gateway/relay relevance signal.",
       "updated_at": "2026-06-01T03:15:38Z"
-    },
-    {
-      "upstream": "anthropics/claude-code#64353",
-      "url": "https://github.com/anthropics/claude-code/issues/64353",
-      "title": "Image attachments silently fail to upload when message has no text",
-      "impact": "not_applicable",
-      "categories": [
-        "platform"
-      ],
-      "tokenkey_status": "not_applicable",
-      "rationale": "Client-side claude-code concern (platform); not a gateway/relay relevance signal.",
-      "updated_at": "2026-05-31T23:20:10Z"
-    },
-    {
-      "upstream": "anthropics/claude-code#64356",
-      "url": "https://github.com/anthropics/claude-code/issues/64356",
-      "title": "[Bug] Agent stops responding after calling advisor tool",
-      "impact": "not_applicable",
-      "categories": [
-        "terminal"
-      ],
-      "tokenkey_status": "not_applicable",
-      "rationale": "Client-side claude-code concern (terminal); not a gateway/relay relevance signal.",
-      "updated_at": "2026-05-31T23:40:00Z"
     },
     {
       "upstream": "anthropics/claude-code#64358",
@@ -15220,7 +15406,7 @@
       ],
       "tokenkey_status": "not_applicable",
       "rationale": "Client-side claude-code concern (terminal); not a gateway/relay relevance signal.",
-      "updated_at": "2026-06-01T08:40:38Z"
+      "updated_at": "2026-06-03T19:49:26Z"
     },
     {
       "upstream": "anthropics/claude-code#64404",
@@ -15272,20 +15458,6 @@
       "tokenkey_status": "not_applicable",
       "rationale": "Client-side claude-code concern (plugin, slash_hook); not a gateway/relay relevance signal.",
       "updated_at": "2026-06-01T06:50:47Z"
-    },
-    {
-      "upstream": "anthropics/claude-code#64412",
-      "url": "https://github.com/anthropics/claude-code/issues/64412",
-      "title": "[BUG] Stdio MCP server receives a CLAUDE_CODE_SESSION_ID different from the value passed to hooks / Bash tool on --resume sessions",
-      "impact": "not_applicable",
-      "categories": [
-        "mcp",
-        "plugin",
-        "slash_hook"
-      ],
-      "tokenkey_status": "not_applicable",
-      "rationale": "Client-side claude-code concern (mcp, plugin, slash_hook); not a gateway/relay relevance signal.",
-      "updated_at": "2026-06-01T06:53:59Z"
     },
     {
       "upstream": "anthropics/claude-code#64413",
@@ -16039,7 +16211,7 @@
       ],
       "tokenkey_status": "not_applicable",
       "rationale": "Client-side claude-code concern (terminal); not a gateway/relay relevance signal.",
-      "updated_at": "2026-06-03T05:37:13Z"
+      "updated_at": "2026-06-03T11:39:53Z"
     },
     {
       "upstream": "anthropics/claude-code#64504",
@@ -16304,7 +16476,7 @@
       ],
       "tokenkey_status": "not_applicable",
       "rationale": "Client-side claude-code concern (slash_hook); not a gateway/relay relevance signal.",
-      "updated_at": "2026-06-01T18:52:14Z"
+      "updated_at": "2026-06-03T16:56:40Z"
     },
     {
       "upstream": "anthropics/claude-code#64535",
@@ -16516,7 +16688,7 @@
       ],
       "tokenkey_status": "not_applicable",
       "rationale": "Client-side claude-code concern (plugin); not a gateway/relay relevance signal.",
-      "updated_at": "2026-06-03T06:12:29Z"
+      "updated_at": "2026-06-03T10:30:56Z"
     },
     {
       "upstream": "anthropics/claude-code#64559",
@@ -16953,7 +17125,7 @@
       ],
       "tokenkey_status": "not_applicable",
       "rationale": "Client-side claude-code concern (terminal, plugin, platform); not a gateway/relay relevance signal.",
-      "updated_at": "2026-06-02T11:19:14Z"
+      "updated_at": "2026-06-03T18:04:21Z"
     },
     {
       "upstream": "anthropics/claude-code#64620",
@@ -17666,18 +17838,6 @@
       "updated_at": "2026-06-02T10:44:45Z"
     },
     {
-      "upstream": "anthropics/claude-code#64713",
-      "url": "https://github.com/anthropics/claude-code/issues/64713",
-      "title": "[Feature Request] Add stream mode to hide personal information on welcome screen",
-      "impact": "not_applicable",
-      "categories": [
-        "terminal"
-      ],
-      "tokenkey_status": "not_applicable",
-      "rationale": "Client-side claude-code concern (terminal); not a gateway/relay relevance signal.",
-      "updated_at": "2026-06-02T10:48:23Z"
-    },
-    {
       "upstream": "anthropics/claude-code#64714",
       "url": "https://github.com/anthropics/claude-code/issues/64714",
       "title": "Bring back a clickable expand/collapse arrow for thinking blocks (mouse, not keyboard)",
@@ -17782,7 +17942,7 @@
       ],
       "tokenkey_status": "not_applicable",
       "rationale": "Client-side claude-code concern (mcp, install); not a gateway/relay relevance signal.",
-      "updated_at": "2026-06-03T07:03:21Z"
+      "updated_at": "2026-06-03T11:02:51Z"
     },
     {
       "upstream": "anthropics/claude-code#64731",
@@ -17862,7 +18022,7 @@
       ],
       "tokenkey_status": "not_applicable",
       "rationale": "Client-side claude-code concern (terminal, platform); not a gateway/relay relevance signal.",
-      "updated_at": "2026-06-02T13:06:41Z"
+      "updated_at": "2026-06-03T10:26:41Z"
     },
     {
       "upstream": "anthropics/claude-code#64741",
@@ -17900,7 +18060,7 @@
       ],
       "tokenkey_status": "not_applicable",
       "rationale": "Client-side claude-code concern (terminal); not a gateway/relay relevance signal.",
-      "updated_at": "2026-06-03T00:27:31Z"
+      "updated_at": "2026-06-03T16:54:41Z"
     },
     {
       "upstream": "anthropics/claude-code#64745",
@@ -17926,7 +18086,7 @@
       ],
       "tokenkey_status": "not_applicable",
       "rationale": "Client-side claude-code concern (terminal, install, platform); not a gateway/relay relevance signal.",
-      "updated_at": "2026-06-03T07:59:38Z"
+      "updated_at": "2026-06-03T11:35:46Z"
     },
     {
       "upstream": "anthropics/claude-code#64747",
@@ -18213,20 +18373,6 @@
       "updated_at": "2026-06-02T15:12:01Z"
     },
     {
-      "upstream": "anthropics/claude-code#64778",
-      "url": "https://github.com/anthropics/claude-code/issues/64778",
-      "title": "[Bug] `/doctor` command dismisses diagnostics without displaying MCP setup issues",
-      "impact": "not_applicable",
-      "categories": [
-        "terminal",
-        "mcp",
-        "slash_hook"
-      ],
-      "tokenkey_status": "not_applicable",
-      "rationale": "Client-side claude-code concern (terminal, mcp, slash_hook); not a gateway/relay relevance signal.",
-      "updated_at": "2026-06-02T15:19:18Z"
-    },
-    {
       "upstream": "anthropics/claude-code#64779",
       "url": "https://github.com/anthropics/claude-code/issues/64779",
       "title": "Connect claude.ai Projects to Claude Code (VS Code / CLI)",
@@ -18502,7 +18648,7 @@
       ],
       "tokenkey_status": "not_applicable",
       "rationale": "Client-side claude-code concern (terminal); not a gateway/relay relevance signal.",
-      "updated_at": "2026-06-02T17:21:34Z"
+      "updated_at": "2026-06-03T17:23:20Z"
     },
     {
       "upstream": "anthropics/claude-code#64813",
@@ -18895,7 +19041,7 @@
       ],
       "tokenkey_status": "not_applicable",
       "rationale": "Client-side claude-code concern (terminal); not a gateway/relay relevance signal.",
-      "updated_at": "2026-06-02T21:03:21Z"
+      "updated_at": "2026-06-03T20:19:50Z"
     },
     {
       "upstream": "anthropics/claude-code#64861",
@@ -19292,7 +19438,7 @@
       ],
       "tokenkey_status": "not_applicable",
       "rationale": "Client-side claude-code concern (terminal, mcp, plugin); not a gateway/relay relevance signal.",
-      "updated_at": "2026-06-03T02:05:17Z"
+      "updated_at": "2026-06-03T18:58:43Z"
     },
     {
       "upstream": "anthropics/claude-code#64910",
@@ -19774,7 +19920,7 @@
       ],
       "tokenkey_status": "not_applicable",
       "rationale": "Client-side claude-code concern (terminal); not a gateway/relay relevance signal.",
-      "updated_at": "2026-06-03T10:08:41Z"
+      "updated_at": "2026-06-03T13:04:42Z"
     },
     {
       "upstream": "anthropics/claude-code#64962",
@@ -20162,7 +20308,7 @@
       ],
       "tokenkey_status": "not_applicable",
       "rationale": "Client-side claude-code concern (platform); not a gateway/relay relevance signal.",
-      "updated_at": "2026-06-03T09:24:35Z"
+      "updated_at": "2026-06-03T11:04:45Z"
     },
     {
       "upstream": "anthropics/claude-code#65008",
@@ -20252,7 +20398,7 @@
       ],
       "tokenkey_status": "not_applicable",
       "rationale": "Client-side claude-code concern (terminal, platform); not a gateway/relay relevance signal.",
-      "updated_at": "2026-06-03T10:02:16Z"
+      "updated_at": "2026-06-03T10:31:02Z"
     },
     {
       "upstream": "anthropics/claude-code#65017",
@@ -20276,7 +20422,7 @@
       ],
       "tokenkey_status": "not_applicable",
       "rationale": "Client-side claude-code concern (terminal); not a gateway/relay relevance signal.",
-      "updated_at": "2026-06-03T10:16:23Z"
+      "updated_at": "2026-06-03T10:24:03Z"
     },
     {
       "upstream": "anthropics/claude-code#65019",
@@ -20289,7 +20435,1431 @@
       ],
       "tokenkey_status": "not_applicable",
       "rationale": "Client-side claude-code concern (terminal, platform); not a gateway/relay relevance signal.",
-      "updated_at": "2026-06-03T10:19:24Z"
+      "updated_at": "2026-06-03T10:25:32Z"
+    },
+    {
+      "upstream": "anthropics/claude-code#65020",
+      "url": "https://github.com/anthropics/claude-code/issues/65020",
+      "title": "[Bug] Excessive token consumption on single message causing rapid usage limit depletion",
+      "impact": "not_applicable",
+      "categories": [
+        "terminal"
+      ],
+      "tokenkey_status": "not_applicable",
+      "rationale": "Client-side claude-code concern (terminal); not a gateway/relay relevance signal.",
+      "updated_at": "2026-06-03T10:25:34Z"
+    },
+    {
+      "upstream": "anthropics/claude-code#65021",
+      "url": "https://github.com/anthropics/claude-code/issues/65021",
+      "title": "[BUG] [VS Code Extension] Organization-level skills not loaded (only filesystem paths checked)",
+      "impact": "not_applicable",
+      "categories": [
+        "ide",
+        "terminal",
+        "mcp",
+        "plugin",
+        "platform"
+      ],
+      "tokenkey_status": "not_applicable",
+      "rationale": "Client-side claude-code concern (ide, terminal, mcp, plugin, platform); not a gateway/relay relevance signal.",
+      "updated_at": "2026-06-03T10:28:50Z"
+    },
+    {
+      "upstream": "anthropics/claude-code#65024",
+      "url": "https://github.com/anthropics/claude-code/issues/65024",
+      "title": "[BUG] Claude desktop app crashing as soon as I open it.",
+      "impact": "not_applicable",
+      "categories": [
+        "terminal",
+        "mcp",
+        "install"
+      ],
+      "tokenkey_status": "not_applicable",
+      "rationale": "Client-side claude-code concern (terminal, mcp, install); not a gateway/relay relevance signal.",
+      "updated_at": "2026-06-03T10:49:08Z"
+    },
+    {
+      "upstream": "anthropics/claude-code#65025",
+      "url": "https://github.com/anthropics/claude-code/issues/65025",
+      "title": "[Bug] Chat messages arrive out of order and delayed during long-running commands",
+      "impact": "not_applicable",
+      "categories": [
+        "terminal"
+      ],
+      "tokenkey_status": "not_applicable",
+      "rationale": "Client-side claude-code concern (terminal); not a gateway/relay relevance signal.",
+      "updated_at": "2026-06-03T10:53:49Z"
+    },
+    {
+      "upstream": "anthropics/claude-code#65026",
+      "url": "https://github.com/anthropics/claude-code/issues/65026",
+      "title": "[BUG] CLI self-aborts (SIGABRT) at ~6 GB RSS during long background Workflow runs — reproduced on 2.1.160 and 2.1.161 (WSL2)",
+      "impact": "not_applicable",
+      "categories": [
+        "terminal",
+        "plugin",
+        "install",
+        "platform"
+      ],
+      "tokenkey_status": "not_applicable",
+      "rationale": "Client-side claude-code concern (terminal, plugin, install, platform); not a gateway/relay relevance signal.",
+      "updated_at": "2026-06-03T18:58:57Z"
+    },
+    {
+      "upstream": "anthropics/claude-code#65028",
+      "url": "https://github.com/anthropics/claude-code/issues/65028",
+      "title": "[BUG] /compact fails with ECONNRESET at only 35% context data — no recovery path when API is intermittently unstable",
+      "impact": "not_applicable",
+      "categories": [
+        "ide",
+        "terminal",
+        "platform"
+      ],
+      "tokenkey_status": "not_applicable",
+      "rationale": "Client-side claude-code concern (ide, terminal, platform); not a gateway/relay relevance signal.",
+      "updated_at": "2026-06-03T11:06:07Z"
+    },
+    {
+      "upstream": "anthropics/claude-code#65031",
+      "url": "https://github.com/anthropics/claude-code/issues/65031",
+      "title": "[Bug] Feedback prompt appears when answering code instead of feedback",
+      "impact": "not_applicable",
+      "categories": [
+        "ide",
+        "terminal"
+      ],
+      "tokenkey_status": "not_applicable",
+      "rationale": "Client-side claude-code concern (ide, terminal); not a gateway/relay relevance signal.",
+      "updated_at": "2026-06-03T11:24:07Z"
+    },
+    {
+      "upstream": "anthropics/claude-code#65032",
+      "url": "https://github.com/anthropics/claude-code/issues/65032",
+      "title": "ultrareview crashed before producing findings — refund request (Windows, 2.1.161)",
+      "impact": "not_applicable",
+      "categories": [
+        "platform"
+      ],
+      "tokenkey_status": "not_applicable",
+      "rationale": "Client-side claude-code concern (platform); not a gateway/relay relevance signal.",
+      "updated_at": "2026-06-03T11:25:35Z"
+    },
+    {
+      "upstream": "anthropics/claude-code#65033",
+      "url": "https://github.com/anthropics/claude-code/issues/65033",
+      "title": "[BUG] La pantalla queda en blanco al abrir Claude Desktop en iMac, macOS M3, Sequoia 15.7.3",
+      "impact": "not_applicable",
+      "categories": [
+        "terminal"
+      ],
+      "tokenkey_status": "not_applicable",
+      "rationale": "Client-side claude-code concern (terminal); not a gateway/relay relevance signal.",
+      "updated_at": "2026-06-03T11:33:39Z"
+    },
+    {
+      "upstream": "anthropics/claude-code#65034",
+      "url": "https://github.com/anthropics/claude-code/issues/65034",
+      "title": "[Bug] Claude deletes environment files during code operations",
+      "impact": "not_applicable",
+      "categories": [
+        "terminal"
+      ],
+      "tokenkey_status": "not_applicable",
+      "rationale": "Client-side claude-code concern (terminal); not a gateway/relay relevance signal.",
+      "updated_at": "2026-06-03T11:38:32Z"
+    },
+    {
+      "upstream": "anthropics/claude-code#65035",
+      "url": "https://github.com/anthropics/claude-code/issues/65035",
+      "title": "[Bug] Auto-Compact Not Triggered",
+      "impact": "not_applicable",
+      "categories": [
+        "terminal"
+      ],
+      "tokenkey_status": "not_applicable",
+      "rationale": "Client-side claude-code concern (terminal); not a gateway/relay relevance signal.",
+      "updated_at": "2026-06-03T20:54:50Z"
+    },
+    {
+      "upstream": "anthropics/claude-code#65038",
+      "url": "https://github.com/anthropics/claude-code/issues/65038",
+      "title": "[BUG] Opening and closing agents screen makes CC close abruptly",
+      "impact": "not_applicable",
+      "categories": [
+        "terminal",
+        "platform"
+      ],
+      "tokenkey_status": "not_applicable",
+      "rationale": "Client-side claude-code concern (terminal, platform); not a gateway/relay relevance signal.",
+      "updated_at": "2026-06-03T12:06:24Z"
+    },
+    {
+      "upstream": "anthropics/claude-code#65039",
+      "url": "https://github.com/anthropics/claude-code/issues/65039",
+      "title": "Feature request: mouseReporting setting to allow X11 primary selection (highlight-to-copy)",
+      "impact": "not_applicable",
+      "categories": [
+        "terminal",
+        "slash_hook"
+      ],
+      "tokenkey_status": "not_applicable",
+      "rationale": "Client-side claude-code concern (terminal, slash_hook); not a gateway/relay relevance signal.",
+      "updated_at": "2026-06-03T11:54:42Z"
+    },
+    {
+      "upstream": "anthropics/claude-code#65040",
+      "url": "https://github.com/anthropics/claude-code/issues/65040",
+      "title": "[Feature Request] Support dynamic templates in session-name badge",
+      "impact": "not_applicable",
+      "categories": [
+        "ide",
+        "terminal",
+        "slash_hook"
+      ],
+      "tokenkey_status": "not_applicable",
+      "rationale": "Client-side claude-code concern (ide, terminal, slash_hook); not a gateway/relay relevance signal.",
+      "updated_at": "2026-06-03T11:58:53Z"
+    },
+    {
+      "upstream": "anthropics/claude-code#65041",
+      "url": "https://github.com/anthropics/claude-code/issues/65041",
+      "title": "[BUG] The usage dashboard isn't updated despite having worked with Claude code.",
+      "impact": "not_applicable",
+      "categories": [
+        "ide",
+        "terminal",
+        "platform"
+      ],
+      "tokenkey_status": "not_applicable",
+      "rationale": "Client-side claude-code concern (ide, terminal, platform); not a gateway/relay relevance signal.",
+      "updated_at": "2026-06-03T11:56:40Z"
+    },
+    {
+      "upstream": "anthropics/claude-code#65043",
+      "url": "https://github.com/anthropics/claude-code/issues/65043",
+      "title": "[Bug] Plugins warning message appears constantly in terminal output",
+      "impact": "not_applicable",
+      "categories": [
+        "terminal",
+        "plugin"
+      ],
+      "tokenkey_status": "not_applicable",
+      "rationale": "Client-side claude-code concern (terminal, plugin); not a gateway/relay relevance signal.",
+      "updated_at": "2026-06-03T12:04:15Z"
+    },
+    {
+      "upstream": "anthropics/claude-code#65045",
+      "url": "https://github.com/anthropics/claude-code/issues/65045",
+      "title": "App-wide input lag on Windows 11 Desktop (build 1.10628.0.0) - renderer main-thread blocking; continuation of closed #55149",
+      "impact": "not_applicable",
+      "categories": [
+        "terminal",
+        "mcp",
+        "platform"
+      ],
+      "tokenkey_status": "not_applicable",
+      "rationale": "Client-side claude-code concern (terminal, mcp, platform); not a gateway/relay relevance signal.",
+      "updated_at": "2026-06-03T12:11:57Z"
+    },
+    {
+      "upstream": "anthropics/claude-code#65047",
+      "url": "https://github.com/anthropics/claude-code/issues/65047",
+      "title": "Slash-command menu returns zero matches when query contains `.` (regression 2.1.160 → 2.1.161)",
+      "impact": "not_applicable",
+      "categories": [
+        "terminal",
+        "plugin",
+        "install",
+        "platform"
+      ],
+      "tokenkey_status": "not_applicable",
+      "rationale": "Client-side claude-code concern (terminal, plugin, install, platform); not a gateway/relay relevance signal.",
+      "updated_at": "2026-06-03T12:23:54Z"
+    },
+    {
+      "upstream": "anthropics/claude-code#65048",
+      "url": "https://github.com/anthropics/claude-code/issues/65048",
+      "title": "Autocompact regression since 2.1.153 (up to the latest 2.1.161 version): \"0% until auto-compact\" replaced by \"100% context used\", compaction never triggers",
+      "impact": "not_applicable",
+      "categories": [
+        "slash_hook",
+        "install"
+      ],
+      "tokenkey_status": "not_applicable",
+      "rationale": "Client-side claude-code concern (slash_hook, install); not a gateway/relay relevance signal.",
+      "updated_at": "2026-06-03T12:20:14Z"
+    },
+    {
+      "upstream": "anthropics/claude-code#65049",
+      "url": "https://github.com/anthropics/claude-code/issues/65049",
+      "title": "[Bug] Tool call parsing failed - unable to parse model response",
+      "impact": "not_applicable",
+      "categories": [
+        "terminal"
+      ],
+      "tokenkey_status": "not_applicable",
+      "rationale": "Client-side claude-code concern (terminal); not a gateway/relay relevance signal.",
+      "updated_at": "2026-06-03T12:42:03Z"
+    },
+    {
+      "upstream": "anthropics/claude-code#65050",
+      "url": "https://github.com/anthropics/claude-code/issues/65050",
+      "title": "Typing `//` no longer filters autocomplete to project skills whose frontmatter `name:` starts with `/` (regression in v2.1.160)",
+      "impact": "not_applicable",
+      "categories": [
+        "terminal",
+        "slash_hook"
+      ],
+      "tokenkey_status": "not_applicable",
+      "rationale": "Client-side claude-code concern (terminal, slash_hook); not a gateway/relay relevance signal.",
+      "updated_at": "2026-06-03T12:54:33Z"
+    },
+    {
+      "upstream": "anthropics/claude-code#65052",
+      "url": "https://github.com/anthropics/claude-code/issues/65052",
+      "title": "[BUG] the reset time stopped appearing in the notification is a UI regression",
+      "impact": "not_applicable",
+      "categories": [
+        "terminal",
+        "platform"
+      ],
+      "tokenkey_status": "not_applicable",
+      "rationale": "Client-side claude-code concern (terminal, platform); not a gateway/relay relevance signal.",
+      "updated_at": "2026-06-03T12:58:33Z"
+    },
+    {
+      "upstream": "anthropics/claude-code#65053",
+      "url": "https://github.com/anthropics/claude-code/issues/65053",
+      "title": "Cowork sessions crash with 1M context error — auto-compaction regression (tengu_slate_siskin disabled)",
+      "impact": "not_applicable",
+      "categories": [
+        "ide",
+        "terminal",
+        "slash_hook",
+        "platform"
+      ],
+      "tokenkey_status": "not_applicable",
+      "rationale": "Client-side claude-code concern (ide, terminal, slash_hook, platform); not a gateway/relay relevance signal.",
+      "updated_at": "2026-06-03T13:41:30Z"
+    },
+    {
+      "upstream": "anthropics/claude-code#65055",
+      "url": "https://github.com/anthropics/claude-code/issues/65055",
+      "title": "[Bug] Agent generates suboptimal solutions with increased defect introduction",
+      "impact": "not_applicable",
+      "categories": [
+        "terminal"
+      ],
+      "tokenkey_status": "not_applicable",
+      "rationale": "Client-side claude-code concern (terminal); not a gateway/relay relevance signal.",
+      "updated_at": "2026-06-03T13:07:00Z"
+    },
+    {
+      "upstream": "anthropics/claude-code#65056",
+      "url": "https://github.com/anthropics/claude-code/issues/65056",
+      "title": "[BUG] Bash command containing `python3` execute without permission prompt when no allow rules are configured and sandboxed",
+      "impact": "not_applicable",
+      "categories": [
+        "terminal",
+        "slash_hook"
+      ],
+      "tokenkey_status": "not_applicable",
+      "rationale": "Client-side claude-code concern (terminal, slash_hook); not a gateway/relay relevance signal.",
+      "updated_at": "2026-06-03T13:46:48Z"
+    },
+    {
+      "upstream": "anthropics/claude-code#65057",
+      "url": "https://github.com/anthropics/claude-code/issues/65057",
+      "title": "[FEATURE] Voice input support for hands-free prompting in Claude Code CLI",
+      "impact": "not_applicable",
+      "categories": [
+        "ide",
+        "terminal"
+      ],
+      "tokenkey_status": "not_applicable",
+      "rationale": "Client-side claude-code concern (ide, terminal); not a gateway/relay relevance signal.",
+      "updated_at": "2026-06-03T20:18:31Z"
+    },
+    {
+      "upstream": "anthropics/claude-code#65059",
+      "url": "https://github.com/anthropics/claude-code/issues/65059",
+      "title": "[BUG] vscode extension incorrectly prepends /usr/bin to PATH",
+      "impact": "not_applicable",
+      "categories": [
+        "ide",
+        "terminal",
+        "slash_hook",
+        "install"
+      ],
+      "tokenkey_status": "not_applicable",
+      "rationale": "Client-side claude-code concern (ide, terminal, slash_hook, install); not a gateway/relay relevance signal.",
+      "updated_at": "2026-06-03T13:38:53Z"
+    },
+    {
+      "upstream": "anthropics/claude-code#65060",
+      "url": "https://github.com/anthropics/claude-code/issues/65060",
+      "title": "[Bug] Tool Call Parsing Failed - Unable to Deserialize Model Response",
+      "impact": "not_applicable",
+      "categories": [
+        "terminal"
+      ],
+      "tokenkey_status": "not_applicable",
+      "rationale": "Client-side claude-code concern (terminal); not a gateway/relay relevance signal.",
+      "updated_at": "2026-06-03T13:37:57Z"
+    },
+    {
+      "upstream": "anthropics/claude-code#65061",
+      "url": "https://github.com/anthropics/claude-code/issues/65061",
+      "title": "[BUG] Desktop (Windows): Turkish speech transcribed as English — mic dictation ignores `language` setting",
+      "impact": "not_applicable",
+      "categories": [
+        "slash_hook",
+        "platform"
+      ],
+      "tokenkey_status": "not_applicable",
+      "rationale": "Client-side claude-code concern (slash_hook, platform); not a gateway/relay relevance signal.",
+      "updated_at": "2026-06-03T14:01:54Z"
+    },
+    {
+      "upstream": "anthropics/claude-code#65062",
+      "url": "https://github.com/anthropics/claude-code/issues/65062",
+      "title": "[claude.ai] Bulk conversation rename API / MCP tool for web and desktop",
+      "impact": "not_applicable",
+      "categories": [
+        "mcp"
+      ],
+      "tokenkey_status": "not_applicable",
+      "rationale": "Client-side claude-code concern (mcp); not a gateway/relay relevance signal.",
+      "updated_at": "2026-06-03T13:57:44Z"
+    },
+    {
+      "upstream": "anthropics/claude-code#65063",
+      "url": "https://github.com/anthropics/claude-code/issues/65063",
+      "title": "[Feature Request] Add concise flag to /context command for remote access",
+      "impact": "not_applicable",
+      "categories": [
+        "terminal"
+      ],
+      "tokenkey_status": "not_applicable",
+      "rationale": "Client-side claude-code concern (terminal); not a gateway/relay relevance signal.",
+      "updated_at": "2026-06-03T15:47:11Z"
+    },
+    {
+      "upstream": "anthropics/claude-code#65064",
+      "url": "https://github.com/anthropics/claude-code/issues/65064",
+      "title": "[BUG] claude code writes memory without asking for permission",
+      "impact": "not_applicable",
+      "categories": [
+        "terminal"
+      ],
+      "tokenkey_status": "not_applicable",
+      "rationale": "Client-side claude-code concern (terminal); not a gateway/relay relevance signal.",
+      "updated_at": "2026-06-03T15:38:10Z"
+    },
+    {
+      "upstream": "anthropics/claude-code#65066",
+      "url": "https://github.com/anthropics/claude-code/issues/65066",
+      "title": "[BUG] VZErrorDomain Code=1 - Workspace fails to start on M2 MacBook Pro",
+      "impact": "not_applicable",
+      "categories": [
+        "terminal"
+      ],
+      "tokenkey_status": "not_applicable",
+      "rationale": "Client-side claude-code concern (terminal); not a gateway/relay relevance signal.",
+      "updated_at": "2026-06-03T14:32:38Z"
+    },
+    {
+      "upstream": "anthropics/claude-code#65067",
+      "url": "https://github.com/anthropics/claude-code/issues/65067",
+      "title": "[Bug] Spurious ENOSPC errors in task output capture with racing cleanup deletes",
+      "impact": "not_applicable",
+      "categories": [
+        "terminal"
+      ],
+      "tokenkey_status": "not_applicable",
+      "rationale": "Client-side claude-code concern (terminal); not a gateway/relay relevance signal.",
+      "updated_at": "2026-06-03T14:32:35Z"
+    },
+    {
+      "upstream": "anthropics/claude-code#65068",
+      "url": "https://github.com/anthropics/claude-code/issues/65068",
+      "title": "[BUG] Manage Plugins UI writes incorrect source format to known_marketplaces.json, causing Plugins tab to show empty",
+      "impact": "not_applicable",
+      "categories": [
+        "ide",
+        "terminal",
+        "plugin"
+      ],
+      "tokenkey_status": "not_applicable",
+      "rationale": "Client-side claude-code concern (ide, terminal, plugin); not a gateway/relay relevance signal.",
+      "updated_at": "2026-06-03T14:32:12Z"
+    },
+    {
+      "upstream": "anthropics/claude-code#65069",
+      "url": "https://github.com/anthropics/claude-code/issues/65069",
+      "title": "[Feature Request] Add reviewer filter for GitHub \"Pull request review requested\" event",
+      "impact": "not_applicable",
+      "categories": [
+        "terminal"
+      ],
+      "tokenkey_status": "not_applicable",
+      "rationale": "Client-side claude-code concern (terminal); not a gateway/relay relevance signal.",
+      "updated_at": "2026-06-03T14:38:43Z"
+    },
+    {
+      "upstream": "anthropics/claude-code#65070",
+      "url": "https://github.com/anthropics/claude-code/issues/65070",
+      "title": "[Bug] Superpowers plugin fails to persist after installation",
+      "impact": "not_applicable",
+      "categories": [
+        "terminal",
+        "plugin",
+        "install"
+      ],
+      "tokenkey_status": "not_applicable",
+      "rationale": "Client-side claude-code concern (terminal, plugin, install); not a gateway/relay relevance signal.",
+      "updated_at": "2026-06-03T14:41:10Z"
+    },
+    {
+      "upstream": "anthropics/claude-code#65071",
+      "url": "https://github.com/anthropics/claude-code/issues/65071",
+      "title": "[FEATURE] Inherited Subagents",
+      "impact": "not_applicable",
+      "categories": [
+        "terminal",
+        "plugin",
+        "slash_hook"
+      ],
+      "tokenkey_status": "not_applicable",
+      "rationale": "Client-side claude-code concern (terminal, plugin, slash_hook); not a gateway/relay relevance signal.",
+      "updated_at": "2026-06-03T14:46:11Z"
+    },
+    {
+      "upstream": "anthropics/claude-code#65072",
+      "url": "https://github.com/anthropics/claude-code/issues/65072",
+      "title": "[BUG] Claude desktop fails to launch after applyin an update",
+      "impact": "not_applicable",
+      "categories": [
+        "terminal",
+        "platform"
+      ],
+      "tokenkey_status": "not_applicable",
+      "rationale": "Client-side claude-code concern (terminal, platform); not a gateway/relay relevance signal.",
+      "updated_at": "2026-06-03T14:47:41Z"
+    },
+    {
+      "upstream": "anthropics/claude-code#65073",
+      "url": "https://github.com/anthropics/claude-code/issues/65073",
+      "title": "[BUG] Code-font ligatures render `<=`/`>=` as `≤`/`≥` in inline code (mobile app) — masks exact tokens",
+      "impact": "not_applicable",
+      "categories": [
+        "terminal"
+      ],
+      "tokenkey_status": "not_applicable",
+      "rationale": "Client-side claude-code concern (terminal); not a gateway/relay relevance signal.",
+      "updated_at": "2026-06-03T14:48:51Z"
+    },
+    {
+      "upstream": "anthropics/claude-code#65074",
+      "url": "https://github.com/anthropics/claude-code/issues/65074",
+      "title": "Max Plan using Sonnet 4.6 API Error 1M",
+      "impact": "not_applicable",
+      "categories": [
+        "terminal"
+      ],
+      "tokenkey_status": "not_applicable",
+      "rationale": "Client-side claude-code concern (terminal); not a gateway/relay relevance signal.",
+      "updated_at": "2026-06-03T14:49:36Z"
+    },
+    {
+      "upstream": "anthropics/claude-code#65076",
+      "url": "https://github.com/anthropics/claude-code/issues/65076",
+      "title": "[BUG] Claude Code Desktop eager loading MCPs while Claude Code CLI lazy loading",
+      "impact": "not_applicable",
+      "categories": [
+        "terminal",
+        "mcp"
+      ],
+      "tokenkey_status": "not_applicable",
+      "rationale": "Client-side claude-code concern (terminal, mcp); not a gateway/relay relevance signal.",
+      "updated_at": "2026-06-03T14:57:10Z"
+    },
+    {
+      "upstream": "anthropics/claude-code#65077",
+      "url": "https://github.com/anthropics/claude-code/issues/65077",
+      "title": "[Bug] Keyboard shortcuts (option+delete, cmd+delete) not working in fullscreen TUI layout",
+      "impact": "not_applicable",
+      "categories": [
+        "terminal",
+        "slash_hook"
+      ],
+      "tokenkey_status": "not_applicable",
+      "rationale": "Client-side claude-code concern (terminal, slash_hook); not a gateway/relay relevance signal.",
+      "updated_at": "2026-06-03T15:01:10Z"
+    },
+    {
+      "upstream": "anthropics/claude-code#65079",
+      "url": "https://github.com/anthropics/claude-code/issues/65079",
+      "title": "[Bug] Session summary lacks project isolation - causes cross-project context contamination",
+      "impact": "not_applicable",
+      "categories": [
+        "terminal",
+        "plugin",
+        "slash_hook",
+        "platform"
+      ],
+      "tokenkey_status": "not_applicable",
+      "rationale": "Client-side claude-code concern (terminal, plugin, slash_hook, platform); not a gateway/relay relevance signal.",
+      "updated_at": "2026-06-03T15:02:46Z"
+    },
+    {
+      "upstream": "anthropics/claude-code#65080",
+      "url": "https://github.com/anthropics/claude-code/issues/65080",
+      "title": "You've hit your session limit · resets 12pm (America/Los_Angeles)",
+      "impact": "not_applicable",
+      "categories": [
+        "terminal"
+      ],
+      "tokenkey_status": "not_applicable",
+      "rationale": "Client-side claude-code concern (terminal); not a gateway/relay relevance signal.",
+      "updated_at": "2026-06-03T15:39:26Z"
+    },
+    {
+      "upstream": "anthropics/claude-code#65083",
+      "url": "https://github.com/anthropics/claude-code/issues/65083",
+      "title": "[Bug] MCP servers not activating/mcp",
+      "impact": "not_applicable",
+      "categories": [
+        "ide",
+        "terminal",
+        "mcp"
+      ],
+      "tokenkey_status": "not_applicable",
+      "rationale": "Client-side claude-code concern (ide, terminal, mcp); not a gateway/relay relevance signal.",
+      "updated_at": "2026-06-03T15:30:57Z"
+    },
+    {
+      "upstream": "anthropics/claude-code#65084",
+      "url": "https://github.com/anthropics/claude-code/issues/65084",
+      "title": "[BUG]",
+      "impact": "not_applicable",
+      "categories": [
+        "terminal"
+      ],
+      "tokenkey_status": "not_applicable",
+      "rationale": "Client-side claude-code concern (terminal); not a gateway/relay relevance signal.",
+      "updated_at": "2026-06-03T15:49:03Z"
+    },
+    {
+      "upstream": "anthropics/claude-code#65086",
+      "url": "https://github.com/anthropics/claude-code/issues/65086",
+      "title": "[BUG] False ENOSPC error reported for subprocesses with no stdout and non-zero exit code",
+      "impact": "not_applicable",
+      "categories": [
+        "terminal"
+      ],
+      "tokenkey_status": "not_applicable",
+      "rationale": "Client-side claude-code concern (terminal); not a gateway/relay relevance signal.",
+      "updated_at": "2026-06-03T15:40:31Z"
+    },
+    {
+      "upstream": "anthropics/claude-code#65087",
+      "url": "https://github.com/anthropics/claude-code/issues/65087",
+      "title": "[BUG] Ctrl+C stops interrupting in a long, heavy background-agent session (macOS TUI, v2.1.161); concurrent fresh sessions interrupt fine",
+      "impact": "not_applicable",
+      "categories": [
+        "terminal",
+        "mcp",
+        "plugin",
+        "slash_hook",
+        "install",
+        "platform"
+      ],
+      "tokenkey_status": "not_applicable",
+      "rationale": "Client-side claude-code concern (terminal, mcp, plugin, slash_hook, install, platform); not a gateway/relay relevance signal.",
+      "updated_at": "2026-06-03T18:58:32Z"
+    },
+    {
+      "upstream": "anthropics/claude-code#65088",
+      "url": "https://github.com/anthropics/claude-code/issues/65088",
+      "title": "[BUG] Agent Teams mates hidden and unopenable if more than 6 Agents when collapsed into \"background tasks\"",
+      "impact": "not_applicable",
+      "categories": [
+        "terminal",
+        "platform"
+      ],
+      "tokenkey_status": "not_applicable",
+      "rationale": "Client-side claude-code concern (terminal, platform); not a gateway/relay relevance signal.",
+      "updated_at": "2026-06-03T15:44:18Z"
+    },
+    {
+      "upstream": "anthropics/claude-code#65089",
+      "url": "https://github.com/anthropics/claude-code/issues/65089",
+      "title": "Read tool PDF support broken on Windows — sandbox rejects pdftoppm from all locations",
+      "impact": "not_applicable",
+      "categories": [
+        "terminal",
+        "install",
+        "platform"
+      ],
+      "tokenkey_status": "not_applicable",
+      "rationale": "Client-side claude-code concern (terminal, install, platform); not a gateway/relay relevance signal.",
+      "updated_at": "2026-06-03T15:46:04Z"
+    },
+    {
+      "upstream": "anthropics/claude-code#65090",
+      "url": "https://github.com/anthropics/claude-code/issues/65090",
+      "title": "Claude desktop app leaks pseudo-terminals (/dev/ptmx masters), exhausting the macOS pty pool",
+      "impact": "not_applicable",
+      "categories": [
+        "ide",
+        "terminal"
+      ],
+      "tokenkey_status": "not_applicable",
+      "rationale": "Client-side claude-code concern (ide, terminal); not a gateway/relay relevance signal.",
+      "updated_at": "2026-06-03T15:47:05Z"
+    },
+    {
+      "upstream": "anthropics/claude-code#65091",
+      "url": "https://github.com/anthropics/claude-code/issues/65091",
+      "title": "[Bug] Agent unfocused reasoning dilutes code quality and introduces bugs",
+      "impact": "not_applicable",
+      "categories": [
+        "terminal"
+      ],
+      "tokenkey_status": "not_applicable",
+      "rationale": "Client-side claude-code concern (terminal); not a gateway/relay relevance signal.",
+      "updated_at": "2026-06-03T15:48:27Z"
+    },
+    {
+      "upstream": "anthropics/claude-code#65092",
+      "url": "https://github.com/anthropics/claude-code/issues/65092",
+      "title": "[Bug Report] Unable to process request - missing bug report details",
+      "impact": "not_applicable",
+      "categories": [
+        "ide",
+        "terminal"
+      ],
+      "tokenkey_status": "not_applicable",
+      "rationale": "Client-side claude-code concern (ide, terminal); not a gateway/relay relevance signal.",
+      "updated_at": "2026-06-03T15:50:59Z"
+    },
+    {
+      "upstream": "anthropics/claude-code#65093",
+      "url": "https://github.com/anthropics/claude-code/issues/65093",
+      "title": "[Bug] Transient network loss is recorded as a persistent install_failed; \"Auto-update failed\" banner never clears after reconnect (Windows native, already on latest)",
+      "impact": "not_applicable",
+      "categories": [
+        "terminal",
+        "install",
+        "platform"
+      ],
+      "tokenkey_status": "not_applicable",
+      "rationale": "Client-side claude-code concern (terminal, install, platform); not a gateway/relay relevance signal.",
+      "updated_at": "2026-06-03T15:52:01Z"
+    },
+    {
+      "upstream": "anthropics/claude-code#65095",
+      "url": "https://github.com/anthropics/claude-code/issues/65095",
+      "title": "[BUG] When Running Agent Teams and Subagents you cannot select the sub agent.",
+      "impact": "not_applicable",
+      "categories": [
+        "terminal",
+        "plugin"
+      ],
+      "tokenkey_status": "not_applicable",
+      "rationale": "Client-side claude-code concern (terminal, plugin); not a gateway/relay relevance signal.",
+      "updated_at": "2026-06-03T16:00:56Z"
+    },
+    {
+      "upstream": "anthropics/claude-code#65096",
+      "url": "https://github.com/anthropics/claude-code/issues/65096",
+      "title": "[Bug] Cross-model session resumption ignores target model budget, reports misleading spend limit error",
+      "impact": "not_applicable",
+      "categories": [
+        "terminal",
+        "platform"
+      ],
+      "tokenkey_status": "not_applicable",
+      "rationale": "Client-side claude-code concern (terminal, platform); not a gateway/relay relevance signal.",
+      "updated_at": "2026-06-03T15:57:56Z"
+    },
+    {
+      "upstream": "anthropics/claude-code#65097",
+      "url": "https://github.com/anthropics/claude-code/issues/65097",
+      "title": "Local transcript deletion (30-day TTL) should be configurable independently of data sharing",
+      "impact": "not_applicable",
+      "categories": [
+        "slash_hook"
+      ],
+      "tokenkey_status": "not_applicable",
+      "rationale": "Client-side claude-code concern (slash_hook); not a gateway/relay relevance signal.",
+      "updated_at": "2026-06-03T17:18:32Z"
+    },
+    {
+      "upstream": "anthropics/claude-code#65099",
+      "url": "https://github.com/anthropics/claude-code/issues/65099",
+      "title": "[BUG] [BUG] /goal (and /plan) ignore an explicit cancel — Stop hook keeps blocking turn termination after the goal is cancelled, especially after auto-compaction / multi-session resume",
+      "impact": "not_applicable",
+      "categories": [
+        "terminal",
+        "slash_hook"
+      ],
+      "tokenkey_status": "not_applicable",
+      "rationale": "Client-side claude-code concern (terminal, slash_hook); not a gateway/relay relevance signal.",
+      "updated_at": "2026-06-03T16:34:43Z"
+    },
+    {
+      "upstream": "anthropics/claude-code#65103",
+      "url": "https://github.com/anthropics/claude-code/issues/65103",
+      "title": "[Bug] Claude 3.5 Sonnet over-executing without explicit user request",
+      "impact": "not_applicable",
+      "categories": [
+        "terminal"
+      ],
+      "tokenkey_status": "not_applicable",
+      "rationale": "Client-side claude-code concern (terminal); not a gateway/relay relevance signal.",
+      "updated_at": "2026-06-03T16:43:51Z"
+    },
+    {
+      "upstream": "anthropics/claude-code#65104",
+      "url": "https://github.com/anthropics/claude-code/issues/65104",
+      "title": "Input box clips first 1-2 characters in Alacritty on Windows (works in Windows Terminal)",
+      "impact": "not_applicable",
+      "categories": [
+        "terminal",
+        "platform"
+      ],
+      "tokenkey_status": "not_applicable",
+      "rationale": "Client-side claude-code concern (terminal, platform); not a gateway/relay relevance signal.",
+      "updated_at": "2026-06-03T16:57:46Z"
+    },
+    {
+      "upstream": "anthropics/claude-code#65105",
+      "url": "https://github.com/anthropics/claude-code/issues/65105",
+      "title": "[BUG] Visual Studio says API Error: Usage credits required for 1M context",
+      "impact": "not_applicable",
+      "categories": [
+        "ide",
+        "terminal",
+        "platform"
+      ],
+      "tokenkey_status": "not_applicable",
+      "rationale": "Client-side claude-code concern (ide, terminal, platform); not a gateway/relay relevance signal.",
+      "updated_at": "2026-06-03T17:00:01Z"
+    },
+    {
+      "upstream": "anthropics/claude-code#65109",
+      "url": "https://github.com/anthropics/claude-code/issues/65109",
+      "title": "Feature: Auto-compact without confirmation when context reaches threshold (e.g. 90%)",
+      "impact": "not_applicable",
+      "categories": [
+        "slash_hook",
+        "platform"
+      ],
+      "tokenkey_status": "not_applicable",
+      "rationale": "Client-side claude-code concern (slash_hook, platform); not a gateway/relay relevance signal.",
+      "updated_at": "2026-06-03T17:18:43Z"
+    },
+    {
+      "upstream": "anthropics/claude-code#65110",
+      "url": "https://github.com/anthropics/claude-code/issues/65110",
+      "title": "ClickUp MCP tool availability",
+      "impact": "not_applicable",
+      "categories": [
+        "mcp"
+      ],
+      "tokenkey_status": "not_applicable",
+      "rationale": "Client-side claude-code concern (mcp); not a gateway/relay relevance signal.",
+      "updated_at": "2026-06-03T17:22:10Z"
+    },
+    {
+      "upstream": "anthropics/claude-code#65112",
+      "url": "https://github.com/anthropics/claude-code/issues/65112",
+      "title": "You've hit your session limit · resets 4:40pm (America/Toronto)",
+      "impact": "not_applicable",
+      "categories": [
+        "terminal",
+        "mcp"
+      ],
+      "tokenkey_status": "not_applicable",
+      "rationale": "Client-side claude-code concern (terminal, mcp); not a gateway/relay relevance signal.",
+      "updated_at": "2026-06-03T17:27:54Z"
+    },
+    {
+      "upstream": "anthropics/claude-code#65113",
+      "url": "https://github.com/anthropics/claude-code/issues/65113",
+      "title": "[FEATURE] Cowork: allow switching model mid-conversation (model is locked after the first message)",
+      "impact": "not_applicable",
+      "categories": [
+        "platform"
+      ],
+      "tokenkey_status": "not_applicable",
+      "rationale": "Client-side claude-code concern (platform); not a gateway/relay relevance signal.",
+      "updated_at": "2026-06-03T17:30:06Z"
+    },
+    {
+      "upstream": "anthropics/claude-code#65114",
+      "url": "https://github.com/anthropics/claude-code/issues/65114",
+      "title": "[FEATURE] Cowork: give users a manual /compact (user-initiated compaction)",
+      "impact": "not_applicable",
+      "categories": [
+        "platform"
+      ],
+      "tokenkey_status": "not_applicable",
+      "rationale": "Client-side claude-code concern (platform); not a gateway/relay relevance signal.",
+      "updated_at": "2026-06-03T17:27:22Z"
+    },
+    {
+      "upstream": "anthropics/claude-code#65115",
+      "url": "https://github.com/anthropics/claude-code/issues/65115",
+      "title": "[Bug] /loop /clear command not working",
+      "impact": "not_applicable",
+      "categories": [
+        "ide",
+        "terminal"
+      ],
+      "tokenkey_status": "not_applicable",
+      "rationale": "Client-side claude-code concern (ide, terminal); not a gateway/relay relevance signal.",
+      "updated_at": "2026-06-03T20:25:01Z"
+    },
+    {
+      "upstream": "anthropics/claude-code#65116",
+      "url": "https://github.com/anthropics/claude-code/issues/65116",
+      "title": "[Bug] Anthropic API Error: Usage Policy violation on normal coding requests",
+      "impact": "not_applicable",
+      "categories": [
+        "terminal"
+      ],
+      "tokenkey_status": "not_applicable",
+      "rationale": "Client-side claude-code concern (terminal); not a gateway/relay relevance signal.",
+      "updated_at": "2026-06-03T17:33:17Z"
+    },
+    {
+      "upstream": "anthropics/claude-code#65117",
+      "url": "https://github.com/anthropics/claude-code/issues/65117",
+      "title": "[BUG] Vertical scrollbar disappears intermittently when using background agents (reproducible across multiple terminals)",
+      "impact": "not_applicable",
+      "categories": [
+        "terminal",
+        "platform"
+      ],
+      "tokenkey_status": "not_applicable",
+      "rationale": "Client-side claude-code concern (terminal, platform); not a gateway/relay relevance signal.",
+      "updated_at": "2026-06-03T17:44:26Z"
+    },
+    {
+      "upstream": "anthropics/claude-code#65118",
+      "url": "https://github.com/anthropics/claude-code/issues/65118",
+      "title": "[BUG] [BUG] Cloud mode repository picker only shows 4 repos out of 11 accessible repositories",
+      "impact": "not_applicable",
+      "categories": [
+        "terminal",
+        "platform"
+      ],
+      "tokenkey_status": "not_applicable",
+      "rationale": "Client-side claude-code concern (terminal, platform); not a gateway/relay relevance signal.",
+      "updated_at": "2026-06-03T17:32:26Z"
+    },
+    {
+      "upstream": "anthropics/claude-code#65120",
+      "url": "https://github.com/anthropics/claude-code/issues/65120",
+      "title": "[BUG] PostToolUse hook stdout/stderr never surfaces in agent context",
+      "impact": "not_applicable",
+      "categories": [
+        "slash_hook"
+      ],
+      "tokenkey_status": "not_applicable",
+      "rationale": "Client-side claude-code concern (slash_hook); not a gateway/relay relevance signal.",
+      "updated_at": "2026-06-03T17:42:14Z"
+    },
+    {
+      "upstream": "anthropics/claude-code#65122",
+      "url": "https://github.com/anthropics/claude-code/issues/65122",
+      "title": "Feature request: harness-level Bash-output secret redaction (3 leak incidents in 6 days, willing to contribute regex set + test suite)",
+      "impact": "not_applicable",
+      "categories": [
+        "slash_hook",
+        "install",
+        "platform"
+      ],
+      "tokenkey_status": "not_applicable",
+      "rationale": "Client-side claude-code concern (slash_hook, install, platform); not a gateway/relay relevance signal.",
+      "updated_at": "2026-06-03T17:43:33Z"
+    },
+    {
+      "upstream": "anthropics/claude-code#65124",
+      "url": "https://github.com/anthropics/claude-code/issues/65124",
+      "title": "[BUG] Instant depletion of usage on claude desktop",
+      "impact": "not_applicable",
+      "categories": [
+        "terminal"
+      ],
+      "tokenkey_status": "not_applicable",
+      "rationale": "Client-side claude-code concern (terminal); not a gateway/relay relevance signal.",
+      "updated_at": "2026-06-03T17:53:22Z"
+    },
+    {
+      "upstream": "anthropics/claude-code#65125",
+      "url": "https://github.com/anthropics/claude-code/issues/65125",
+      "title": "[BUG] Claude Code for VSCode don't loading models list",
+      "impact": "not_applicable",
+      "categories": [
+        "ide",
+        "terminal"
+      ],
+      "tokenkey_status": "not_applicable",
+      "rationale": "Client-side claude-code concern (ide, terminal); not a gateway/relay relevance signal.",
+      "updated_at": "2026-06-03T17:45:51Z"
+    },
+    {
+      "upstream": "anthropics/claude-code#65126",
+      "url": "https://github.com/anthropics/claude-code/issues/65126",
+      "title": "[Bug] /remote-control ignores /rename session name, defaults to random name",
+      "impact": "not_applicable",
+      "categories": [
+        "terminal"
+      ],
+      "tokenkey_status": "not_applicable",
+      "rationale": "Client-side claude-code concern (terminal); not a gateway/relay relevance signal.",
+      "updated_at": "2026-06-03T17:49:51Z"
+    },
+    {
+      "upstream": "anthropics/claude-code#65127",
+      "url": "https://github.com/anthropics/claude-code/issues/65127",
+      "title": "[BUG] French accented characters frequently omitted across all Claude products",
+      "impact": "not_applicable",
+      "categories": [
+        "terminal"
+      ],
+      "tokenkey_status": "not_applicable",
+      "rationale": "Client-side claude-code concern (terminal); not a gateway/relay relevance signal.",
+      "updated_at": "2026-06-03T17:50:54Z"
+    },
+    {
+      "upstream": "anthropics/claude-code#65128",
+      "url": "https://github.com/anthropics/claude-code/issues/65128",
+      "title": "VM Connection timeout after 60 seconds",
+      "impact": "not_applicable",
+      "categories": [
+        "terminal",
+        "platform"
+      ],
+      "tokenkey_status": "not_applicable",
+      "rationale": "Client-side claude-code concern (terminal, platform); not a gateway/relay relevance signal.",
+      "updated_at": "2026-06-03T17:50:02Z"
+    },
+    {
+      "upstream": "anthropics/claude-code#65133",
+      "url": "https://github.com/anthropics/claude-code/issues/65133",
+      "title": "[Bug] Auto-update failed - /doctor recommended for diagnosis",
+      "impact": "not_applicable",
+      "categories": [
+        "terminal"
+      ],
+      "tokenkey_status": "not_applicable",
+      "rationale": "Client-side claude-code concern (terminal); not a gateway/relay relevance signal.",
+      "updated_at": "2026-06-03T18:16:24Z"
+    },
+    {
+      "upstream": "anthropics/claude-code#65134",
+      "url": "https://github.com/anthropics/claude-code/issues/65134",
+      "title": "[Feature Request] Allow dynamic /effort adjustment during prompt execution",
+      "impact": "not_applicable",
+      "categories": [
+        "terminal"
+      ],
+      "tokenkey_status": "not_applicable",
+      "rationale": "Client-side claude-code concern (terminal); not a gateway/relay relevance signal.",
+      "updated_at": "2026-06-03T19:36:59Z"
+    },
+    {
+      "upstream": "anthropics/claude-code#65135",
+      "url": "https://github.com/anthropics/claude-code/issues/65135",
+      "title": "[Feature Request] Add token usage visualization and context management at checkpoints",
+      "impact": "not_applicable",
+      "categories": [
+        "ide",
+        "terminal"
+      ],
+      "tokenkey_status": "not_applicable",
+      "rationale": "Client-side claude-code concern (ide, terminal); not a gateway/relay relevance signal.",
+      "updated_at": "2026-06-03T18:24:36Z"
+    },
+    {
+      "upstream": "anthropics/claude-code#65136",
+      "url": "https://github.com/anthropics/claude-code/issues/65136",
+      "title": "[Bug] Persistent display text \"PR #260\" cannot be removed after session reset",
+      "impact": "not_applicable",
+      "categories": [
+        "terminal"
+      ],
+      "tokenkey_status": "not_applicable",
+      "rationale": "Client-side claude-code concern (terminal); not a gateway/relay relevance signal.",
+      "updated_at": "2026-06-03T18:36:43Z"
+    },
+    {
+      "upstream": "anthropics/claude-code#65137",
+      "url": "https://github.com/anthropics/claude-code/issues/65137",
+      "title": "[Bug] Input prompt characters conflict with feedback/sharing shortcuts",
+      "impact": "not_applicable",
+      "categories": [
+        "ide",
+        "terminal",
+        "slash_hook"
+      ],
+      "tokenkey_status": "not_applicable",
+      "rationale": "Client-side claude-code concern (ide, terminal, slash_hook); not a gateway/relay relevance signal.",
+      "updated_at": "2026-06-03T18:44:55Z"
+    },
+    {
+      "upstream": "anthropics/claude-code#65139",
+      "url": "https://github.com/anthropics/claude-code/issues/65139",
+      "title": "[BUG] Usage Limit",
+      "impact": "not_applicable",
+      "categories": [
+        "terminal",
+        "platform"
+      ],
+      "tokenkey_status": "not_applicable",
+      "rationale": "Client-side claude-code concern (terminal, platform); not a gateway/relay relevance signal.",
+      "updated_at": "2026-06-03T19:01:36Z"
+    },
+    {
+      "upstream": "anthropics/claude-code#65140",
+      "url": "https://github.com/anthropics/claude-code/issues/65140",
+      "title": "[FEATURE] Option to restore the detailed/colored dynamic workflow progress display (removed in 2.1.152)",
+      "impact": "not_applicable",
+      "categories": [
+        "terminal",
+        "slash_hook",
+        "install"
+      ],
+      "tokenkey_status": "not_applicable",
+      "rationale": "Client-side claude-code concern (terminal, slash_hook, install); not a gateway/relay relevance signal.",
+      "updated_at": "2026-06-03T19:02:16Z"
+    },
+    {
+      "upstream": "anthropics/claude-code#65141",
+      "url": "https://github.com/anthropics/claude-code/issues/65141",
+      "title": "Suggest /login command in auth error messages",
+      "impact": "not_applicable",
+      "categories": [
+        "ide",
+        "plugin"
+      ],
+      "tokenkey_status": "not_applicable",
+      "rationale": "Client-side claude-code concern (ide, plugin); not a gateway/relay relevance signal.",
+      "updated_at": "2026-06-03T19:07:25Z"
+    },
+    {
+      "upstream": "anthropics/claude-code#65142",
+      "url": "https://github.com/anthropics/claude-code/issues/65142",
+      "title": "MCP tools inaccessible in --agent mode even with explicit --mcp-config flag",
+      "impact": "not_applicable",
+      "categories": [
+        "mcp",
+        "plugin"
+      ],
+      "tokenkey_status": "not_applicable",
+      "rationale": "Client-side claude-code concern (mcp, plugin); not a gateway/relay relevance signal.",
+      "updated_at": "2026-06-03T19:15:31Z"
+    },
+    {
+      "upstream": "anthropics/claude-code#65143",
+      "url": "https://github.com/anthropics/claude-code/issues/65143",
+      "title": "[BUG] SSO Sign-in on desktop app creating new user",
+      "impact": "not_applicable",
+      "categories": [
+        "terminal"
+      ],
+      "tokenkey_status": "not_applicable",
+      "rationale": "Client-side claude-code concern (terminal); not a gateway/relay relevance signal.",
+      "updated_at": "2026-06-03T19:08:59Z"
+    },
+    {
+      "upstream": "anthropics/claude-code#65145",
+      "url": "https://github.com/anthropics/claude-code/issues/65145",
+      "title": "[BUG] Sonnet 4.6 implementing several not requested changes in code and admitting it.",
+      "impact": "not_applicable",
+      "categories": [
+        "ide",
+        "terminal",
+        "platform"
+      ],
+      "tokenkey_status": "not_applicable",
+      "rationale": "Client-side claude-code concern (ide, terminal, platform); not a gateway/relay relevance signal.",
+      "updated_at": "2026-06-03T19:12:29Z"
+    },
+    {
+      "upstream": "anthropics/claude-code#65146",
+      "url": "https://github.com/anthropics/claude-code/issues/65146",
+      "title": "[Feature Request] Add session rename and dynamic color customization commands",
+      "impact": "not_applicable",
+      "categories": [
+        "terminal"
+      ],
+      "tokenkey_status": "not_applicable",
+      "rationale": "Client-side claude-code concern (terminal); not a gateway/relay relevance signal.",
+      "updated_at": "2026-06-03T19:13:58Z"
+    },
+    {
+      "upstream": "anthropics/claude-code#65149",
+      "url": "https://github.com/anthropics/claude-code/issues/65149",
+      "title": "[Bug] Claude ignores user instructions and executes without approval despite repeated prompting",
+      "impact": "not_applicable",
+      "categories": [
+        "terminal"
+      ],
+      "tokenkey_status": "not_applicable",
+      "rationale": "Client-side claude-code concern (terminal); not a gateway/relay relevance signal.",
+      "updated_at": "2026-06-03T19:38:43Z"
+    },
+    {
+      "upstream": "anthropics/claude-code#65150",
+      "url": "https://github.com/anthropics/claude-code/issues/65150",
+      "title": "Claude Code requires 1M context credits for standard agentic tasks on Pro plan",
+      "impact": "not_applicable",
+      "categories": [
+        "terminal",
+        "platform"
+      ],
+      "tokenkey_status": "not_applicable",
+      "rationale": "Client-side claude-code concern (terminal, platform); not a gateway/relay relevance signal.",
+      "updated_at": "2026-06-03T19:39:28Z"
+    },
+    {
+      "upstream": "anthropics/claude-code#65153",
+      "url": "https://github.com/anthropics/claude-code/issues/65153",
+      "title": "[Bug] Escape key in /btw modal closes parent task instead of modal",
+      "impact": "not_applicable",
+      "categories": [
+        "terminal"
+      ],
+      "tokenkey_status": "not_applicable",
+      "rationale": "Client-side claude-code concern (terminal); not a gateway/relay relevance signal.",
+      "updated_at": "2026-06-03T19:49:23Z"
+    },
+    {
+      "upstream": "anthropics/claude-code#65154",
+      "url": "https://github.com/anthropics/claude-code/issues/65154",
+      "title": "[BUG] Image paste from clipboard takes minutes (broken since ~2.1.150) on Windows 11",
+      "impact": "not_applicable",
+      "categories": [
+        "terminal",
+        "install",
+        "platform"
+      ],
+      "tokenkey_status": "not_applicable",
+      "rationale": "Client-side claude-code concern (terminal, install, platform); not a gateway/relay relevance signal.",
+      "updated_at": "2026-06-03T19:53:46Z"
+    },
+    {
+      "upstream": "anthropics/claude-code#65156",
+      "url": "https://github.com/anthropics/claude-code/issues/65156",
+      "title": "[BUG] Unknown --effort value 'ultracode'",
+      "impact": "not_applicable",
+      "categories": [
+        "terminal"
+      ],
+      "tokenkey_status": "not_applicable",
+      "rationale": "Client-side claude-code concern (terminal); not a gateway/relay relevance signal.",
+      "updated_at": "2026-06-03T20:06:48Z"
+    },
+    {
+      "upstream": "anthropics/claude-code#65157",
+      "url": "https://github.com/anthropics/claude-code/issues/65157",
+      "title": "[BUG] No repos match in claude code web version even though github app is installed",
+      "impact": "not_applicable",
+      "categories": [
+        "terminal",
+        "platform"
+      ],
+      "tokenkey_status": "not_applicable",
+      "rationale": "Client-side claude-code concern (terminal, platform); not a gateway/relay relevance signal.",
+      "updated_at": "2026-06-03T20:07:53Z"
+    },
+    {
+      "upstream": "anthropics/claude-code#65159",
+      "url": "https://github.com/anthropics/claude-code/issues/65159",
+      "title": "Slash command arguments are stripped before submission in Cowork desktop client",
+      "impact": "not_applicable",
+      "categories": [
+        "slash_hook"
+      ],
+      "tokenkey_status": "not_applicable",
+      "rationale": "Client-side claude-code concern (slash_hook); not a gateway/relay relevance signal.",
+      "updated_at": "2026-06-03T20:26:22Z"
+    },
+    {
+      "upstream": "anthropics/claude-code#65160",
+      "url": "https://github.com/anthropics/claude-code/issues/65160",
+      "title": "[Bug] MCP Server Setup Configuration Issues",
+      "impact": "not_applicable",
+      "categories": [
+        "terminal",
+        "mcp"
+      ],
+      "tokenkey_status": "not_applicable",
+      "rationale": "Client-side claude-code concern (terminal, mcp); not a gateway/relay relevance signal.",
+      "updated_at": "2026-06-03T20:23:39Z"
+    },
+    {
+      "upstream": "anthropics/claude-code#65163",
+      "url": "https://github.com/anthropics/claude-code/issues/65163",
+      "title": "[Bug Report] Unable to determine issue from empty report",
+      "impact": "not_applicable",
+      "categories": [
+        "terminal"
+      ],
+      "tokenkey_status": "not_applicable",
+      "rationale": "Client-side claude-code concern (terminal); not a gateway/relay relevance signal.",
+      "updated_at": "2026-06-03T20:32:08Z"
+    },
+    {
+      "upstream": "anthropics/claude-code#65164",
+      "url": "https://github.com/anthropics/claude-code/issues/65164",
+      "title": "[Bug] Excessive agent spawning causes extended execution times and performance degradation",
+      "impact": "not_applicable",
+      "categories": [
+        "terminal"
+      ],
+      "tokenkey_status": "not_applicable",
+      "rationale": "Client-side claude-code concern (terminal); not a gateway/relay relevance signal.",
+      "updated_at": "2026-06-03T20:36:00Z"
+    },
+    {
+      "upstream": "anthropics/claude-code#65167",
+      "url": "https://github.com/anthropics/claude-code/issues/65167",
+      "title": "[BUG] VS Code Manage Plugins panel renders only Installed — available list & search missing in v2.1.161 (native binary returns 196 available)",
+      "impact": "not_applicable",
+      "categories": [
+        "ide",
+        "terminal",
+        "plugin",
+        "install"
+      ],
+      "tokenkey_status": "not_applicable",
+      "rationale": "Client-side claude-code concern (ide, terminal, plugin, install); not a gateway/relay relevance signal.",
+      "updated_at": "2026-06-03T20:36:10Z"
+    },
+    {
+      "upstream": "anthropics/claude-code#65168",
+      "url": "https://github.com/anthropics/claude-code/issues/65168",
+      "title": "[Feature Request] Display completion timestamp in operation duration summary",
+      "impact": "not_applicable",
+      "categories": [
+        "terminal"
+      ],
+      "tokenkey_status": "not_applicable",
+      "rationale": "Client-side claude-code concern (terminal); not a gateway/relay relevance signal.",
+      "updated_at": "2026-06-03T20:57:20Z"
+    },
+    {
+      "upstream": "anthropics/claude-code#65169",
+      "url": "https://github.com/anthropics/claude-code/issues/65169",
+      "title": "PostToolUse hook does not fire for Agent tool completions",
+      "impact": "not_applicable",
+      "categories": [
+        "mcp",
+        "plugin",
+        "slash_hook"
+      ],
+      "tokenkey_status": "not_applicable",
+      "rationale": "Client-side claude-code concern (mcp, plugin, slash_hook); not a gateway/relay relevance signal.",
+      "updated_at": "2026-06-03T20:58:27Z"
+    },
+    {
+      "upstream": "anthropics/claude-code#65170",
+      "url": "https://github.com/anthropics/claude-code/issues/65170",
+      "title": "I don't see a bug report or issue description in your message - only a Request ID. Could you please provide the actual bug report details so I can generate an appropriate GitHub issue title?",
+      "impact": "not_applicable",
+      "categories": [
+        "terminal"
+      ],
+      "tokenkey_status": "not_applicable",
+      "rationale": "Client-side claude-code concern (terminal); not a gateway/relay relevance signal.",
+      "updated_at": "2026-06-03T21:08:34Z"
+    },
+    {
+      "upstream": "anthropics/claude-code#65171",
+      "url": "https://github.com/anthropics/claude-code/issues/65171",
+      "title": "[Windows] Option to suppress console windows for child processes spawned by the CLI (Bash tool, npm/npx, plugins)",
+      "impact": "not_applicable",
+      "categories": [
+        "plugin",
+        "slash_hook",
+        "install",
+        "platform"
+      ],
+      "tokenkey_status": "not_applicable",
+      "rationale": "Client-side claude-code concern (plugin, slash_hook, install, platform); not a gateway/relay relevance signal.",
+      "updated_at": "2026-06-03T21:17:49Z"
+    },
+    {
+      "upstream": "anthropics/claude-code#65173",
+      "url": "https://github.com/anthropics/claude-code/issues/65173",
+      "title": "Auto-memory not persisted across sessions despite standing instruction — causes significant token waste",
+      "impact": "not_applicable",
+      "categories": [
+        "slash_hook"
+      ],
+      "tokenkey_status": "not_applicable",
+      "rationale": "Client-side claude-code concern (slash_hook); not a gateway/relay relevance signal.",
+      "updated_at": "2026-06-03T21:23:10Z"
+    },
+    {
+      "upstream": "anthropics/claude-code#65174",
+      "url": "https://github.com/anthropics/claude-code/issues/65174",
+      "title": "[BUG] Underscore in shell functions broken",
+      "impact": "not_applicable",
+      "categories": [
+        "ide",
+        "terminal"
+      ],
+      "tokenkey_status": "not_applicable",
+      "rationale": "Client-side claude-code concern (ide, terminal); not a gateway/relay relevance signal.",
+      "updated_at": "2026-06-03T21:20:47Z"
+    },
+    {
+      "upstream": "anthropics/claude-code#65176",
+      "url": "https://github.com/anthropics/claude-code/issues/65176",
+      "title": "Claude for Chrome 1.0.74 — Chrome 148 / macOS 26.5 NSCGSTransaction race condition crashes",
+      "impact": "not_applicable",
+      "categories": [
+        "ide",
+        "terminal",
+        "mcp",
+        "platform"
+      ],
+      "tokenkey_status": "not_applicable",
+      "rationale": "Client-side claude-code concern (ide, terminal, mcp, platform); not a gateway/relay relevance signal.",
+      "updated_at": "2026-06-03T21:36:31Z"
+    },
+    {
+      "upstream": "anthropics/claude-code#65178",
+      "url": "https://github.com/anthropics/claude-code/issues/65178",
+      "title": "[Bug] Claude ignoring user instructions in Claude Code CLI",
+      "impact": "not_applicable",
+      "categories": [
+        "terminal"
+      ],
+      "tokenkey_status": "not_applicable",
+      "rationale": "Client-side claude-code concern (terminal); not a gateway/relay relevance signal.",
+      "updated_at": "2026-06-03T21:50:38Z"
+    },
+    {
+      "upstream": "anthropics/claude-code#65180",
+      "url": "https://github.com/anthropics/claude-code/issues/65180",
+      "title": "[Bug] `/exit` command not recognized or documented",
+      "impact": "not_applicable",
+      "categories": [
+        "terminal"
+      ],
+      "tokenkey_status": "not_applicable",
+      "rationale": "Client-side claude-code concern (terminal); not a gateway/relay relevance signal.",
+      "updated_at": "2026-06-03T21:58:48Z"
     },
     {
       "upstream": "anthropics/claude-code#7075",
@@ -20344,6 +21914,19 @@
       "updated_at": "2026-06-03T06:26:59Z"
     },
     {
+      "upstream": "anthropics/claude-code#8034",
+      "url": "https://github.com/anthropics/claude-code/issues/8034",
+      "title": "/terminal-setup does not support GNOME Terminal",
+      "impact": "not_applicable",
+      "categories": [
+        "ide",
+        "terminal"
+      ],
+      "tokenkey_status": "not_applicable",
+      "rationale": "Client-side claude-code concern (ide, terminal); not a gateway/relay relevance signal.",
+      "updated_at": "2026-06-03T18:18:54Z"
+    },
+    {
       "upstream": "anthropics/claude-code#8856",
       "url": "https://github.com/anthropics/claude-code/issues/8856",
       "title": "Memory leak: Missing cleanup for /tmp/claude-*-cwd working directory tracking files",
@@ -20365,7 +21948,7 @@
       ],
       "tokenkey_status": "not_applicable",
       "rationale": "Client-side claude-code concern (terminal); not a gateway/relay relevance signal.",
-      "updated_at": "2026-06-02T12:31:41Z"
+      "updated_at": "2026-06-03T19:03:46Z"
     },
     {
       "upstream": "anthropics/claude-code#11315",
@@ -20396,6 +21979,16 @@
       "tokenkey_status": "not_applicable",
       "rationale": "No gateway/relay-relevant keywords; treated as not-our-surface.",
       "updated_at": "2026-06-02T20:56:11Z"
+    },
+    {
+      "upstream": "anthropics/claude-code#16561",
+      "url": "https://github.com/anthropics/claude-code/issues/16561",
+      "title": "Feature: Parse compound Bash commands and match each component against permissions",
+      "impact": "unknown_low_signal",
+      "categories": [],
+      "tokenkey_status": "not_applicable",
+      "rationale": "No gateway/relay-relevant keywords; treated as not-our-surface.",
+      "updated_at": "2026-06-03T15:01:03Z"
     },
     {
       "upstream": "anthropics/claude-code#1757",
@@ -20458,6 +22051,16 @@
       "updated_at": "2026-06-02T17:26:44Z"
     },
     {
+      "upstream": "anthropics/claude-code#28043",
+      "url": "https://github.com/anthropics/claude-code/issues/28043",
+      "title": "[DOCS] Bash tool docs missing login-shell default behavior change and `CLAUDE_BASH_NO_LOGIN` context",
+      "impact": "unknown_low_signal",
+      "categories": [],
+      "tokenkey_status": "not_applicable",
+      "rationale": "No gateway/relay-relevant keywords; treated as not-our-surface.",
+      "updated_at": "2026-06-03T11:40:53Z"
+    },
+    {
       "upstream": "anthropics/claude-code#30031",
       "url": "https://github.com/anthropics/claude-code/issues/30031",
       "title": "Feature Request: Support multiple account login and switching (like `gh auth switch`)",
@@ -20468,6 +22071,36 @@
       "updated_at": "2026-06-03T00:09:52Z"
     },
     {
+      "upstream": "anthropics/claude-code#30799",
+      "url": "https://github.com/anthropics/claude-code/issues/30799",
+      "title": "[DOCS] Model configuration page missing model removal and automatic migration behavior",
+      "impact": "unknown_low_signal",
+      "categories": [],
+      "tokenkey_status": "not_applicable",
+      "rationale": "No gateway/relay-relevant keywords; treated as not-our-surface.",
+      "updated_at": "2026-06-03T11:40:52Z"
+    },
+    {
+      "upstream": "anthropics/claude-code#33318",
+      "url": "https://github.com/anthropics/claude-code/issues/33318",
+      "title": "[DOCS] Setup and system requirements docs omit Linux glibc compatibility floor clarified by v2.1.73 fix",
+      "impact": "unknown_low_signal",
+      "categories": [],
+      "tokenkey_status": "not_applicable",
+      "rationale": "No gateway/relay-relevant keywords; treated as not-our-surface.",
+      "updated_at": "2026-06-03T11:39:38Z"
+    },
+    {
+      "upstream": "anthropics/claude-code#34153",
+      "url": "https://github.com/anthropics/claude-code/issues/34153",
+      "title": "[DOCS] Memory documentation missing last-modified timestamps and freshness reasoning",
+      "impact": "unknown_low_signal",
+      "categories": [],
+      "tokenkey_status": "not_applicable",
+      "rationale": "No gateway/relay-relevant keywords; treated as not-our-surface.",
+      "updated_at": "2026-06-03T11:39:36Z"
+    },
+    {
       "upstream": "anthropics/claude-code#36151",
       "url": "https://github.com/anthropics/claude-code/issues/36151",
       "title": "[FEATURE] Multi-account switching in Claude Mobile app without shared email",
@@ -20476,6 +22109,26 @@
       "tokenkey_status": "not_applicable",
       "rationale": "No gateway/relay-relevant keywords; treated as not-our-surface.",
       "updated_at": "2026-06-03T07:12:00Z"
+    },
+    {
+      "upstream": "anthropics/claude-code#40043",
+      "url": "https://github.com/anthropics/claude-code/issues/40043",
+      "title": "Allow removal of local folders from a Cowork project's context",
+      "impact": "unknown_low_signal",
+      "categories": [],
+      "tokenkey_status": "not_applicable",
+      "rationale": "No gateway/relay-relevant keywords; treated as not-our-surface.",
+      "updated_at": "2026-06-03T16:39:15Z"
+    },
+    {
+      "upstream": "anthropics/claude-code#41794",
+      "url": "https://github.com/anthropics/claude-code/issues/41794",
+      "title": "[DOCS] Headless docs omit deferred tool resumption with `-p --continue` and `--resume`",
+      "impact": "unknown_low_signal",
+      "categories": [],
+      "tokenkey_status": "not_applicable",
+      "rationale": "No gateway/relay-relevant keywords; treated as not-our-surface.",
+      "updated_at": "2026-06-03T11:40:46Z"
     },
     {
       "upstream": "anthropics/claude-code#43755",
@@ -20558,6 +22211,16 @@
       "updated_at": "2026-06-03T05:33:12Z"
     },
     {
+      "upstream": "anthropics/claude-code#48858",
+      "url": "https://github.com/anthropics/claude-code/issues/48858",
+      "title": "[DOCS] Scheduled tasks docs omit `--resume`/`--continue` restoration",
+      "impact": "unknown_low_signal",
+      "categories": [],
+      "tokenkey_status": "not_applicable",
+      "rationale": "No gateway/relay-relevant keywords; treated as not-our-surface.",
+      "updated_at": "2026-06-03T11:39:46Z"
+    },
+    {
       "upstream": "anthropics/claude-code#49084",
       "url": "https://github.com/anthropics/claude-code/issues/49084",
       "title": "Feature request: expose timestamps to Claude as structured data for time-aware reasoning",
@@ -20578,6 +22241,16 @@
       "updated_at": "2026-06-03T00:05:19Z"
     },
     {
+      "upstream": "anthropics/claude-code#50137",
+      "url": "https://github.com/anthropics/claude-code/issues/50137",
+      "title": "[DOCS] Session recap docs missing auto-trigger and draft-input behavior",
+      "impact": "unknown_low_signal",
+      "categories": [],
+      "tokenkey_status": "not_applicable",
+      "rationale": "No gateway/relay-relevant keywords; treated as not-our-surface.",
+      "updated_at": "2026-06-03T11:39:44Z"
+    },
+    {
       "upstream": "anthropics/claude-code#50246",
       "url": "https://github.com/anthropics/claude-code/issues/50246",
       "title": "Feature Request: Message queue mode — queue messages instead of interrupting active tasks",
@@ -20585,7 +22258,7 @@
       "categories": [],
       "tokenkey_status": "not_applicable",
       "rationale": "No gateway/relay-relevant keywords; treated as not-our-surface.",
-      "updated_at": "2026-06-02T14:09:35Z"
+      "updated_at": "2026-06-03T18:00:02Z"
     },
     {
       "upstream": "anthropics/claude-code#50529",
@@ -20608,6 +22281,26 @@
       "updated_at": "2026-06-01T22:45:52Z"
     },
     {
+      "upstream": "anthropics/claude-code#51373",
+      "url": "https://github.com/anthropics/claude-code/issues/51373",
+      "title": "[DOCS] Sandboxing docs overstate auto-allow behavior for dangerous `rm`/`rmdir` paths",
+      "impact": "unknown_low_signal",
+      "categories": [],
+      "tokenkey_status": "not_applicable",
+      "rationale": "No gateway/relay-relevant keywords; treated as not-our-surface.",
+      "updated_at": "2026-06-03T11:40:14Z"
+    },
+    {
+      "upstream": "anthropics/claude-code#51783",
+      "url": "https://github.com/anthropics/claude-code/issues/51783",
+      "title": "[DOCS] WebFetch docs missing large-HTML truncation behavior",
+      "impact": "unknown_low_signal",
+      "categories": [],
+      "tokenkey_status": "not_applicable",
+      "rationale": "No gateway/relay-relevant keywords; treated as not-our-surface.",
+      "updated_at": "2026-06-03T11:40:07Z"
+    },
+    {
       "upstream": "anthropics/claude-code#51791",
       "url": "https://github.com/anthropics/claude-code/issues/51791",
       "title": "[FEATURE] Allow renaming session titles after creation",
@@ -20616,6 +22309,36 @@
       "tokenkey_status": "not_applicable",
       "rationale": "No gateway/relay-relevant keywords; treated as not-our-surface.",
       "updated_at": "2026-06-02T15:52:47Z"
+    },
+    {
+      "upstream": "anthropics/claude-code#52194",
+      "url": "https://github.com/anthropics/claude-code/issues/52194",
+      "title": "[DOCS] Auto mode docs omit `\"$defaults\"` sentinel for extending built-in rules",
+      "impact": "unknown_low_signal",
+      "categories": [],
+      "tokenkey_status": "not_applicable",
+      "rationale": "No gateway/relay-relevant keywords; treated as not-our-surface.",
+      "updated_at": "2026-06-03T11:40:11Z"
+    },
+    {
+      "upstream": "anthropics/claude-code#52204",
+      "url": "https://github.com/anthropics/claude-code/issues/52204",
+      "title": "[DOCS] Permission modes page shows auto mode instead of bypass permissions after `--dangerously-skip-permissions`",
+      "impact": "unknown_low_signal",
+      "categories": [],
+      "tokenkey_status": "not_applicable",
+      "rationale": "No gateway/relay-relevant keywords; treated as not-our-surface.",
+      "updated_at": "2026-06-03T11:40:16Z"
+    },
+    {
+      "upstream": "anthropics/claude-code#52205",
+      "url": "https://github.com/anthropics/claude-code/issues/52205",
+      "title": "[DOCS] Forked session storage docs still describe each transcript as a full copy",
+      "impact": "unknown_low_signal",
+      "categories": [],
+      "tokenkey_status": "not_applicable",
+      "rationale": "No gateway/relay-relevant keywords; treated as not-our-surface.",
+      "updated_at": "2026-06-03T11:40:20Z"
     },
     {
       "upstream": "anthropics/claude-code#52214",
@@ -20638,6 +22361,36 @@
       "updated_at": "2026-06-01T05:35:36Z"
     },
     {
+      "upstream": "anthropics/claude-code#52622",
+      "url": "https://github.com/anthropics/claude-code/issues/52622",
+      "title": "[DOCS] /export command docs omit actual-conversation model behavior",
+      "impact": "unknown_low_signal",
+      "categories": [],
+      "tokenkey_status": "not_applicable",
+      "rationale": "No gateway/relay-relevant keywords; treated as not-our-surface.",
+      "updated_at": "2026-06-03T11:40:25Z"
+    },
+    {
+      "upstream": "anthropics/claude-code#52627",
+      "url": "https://github.com/anthropics/claude-code/issues/52627",
+      "title": "[DOCS] Agent SDK Read tool docs omit size-cap behavior and `parts` output",
+      "impact": "unknown_low_signal",
+      "categories": [],
+      "tokenkey_status": "not_applicable",
+      "rationale": "No gateway/relay-relevant keywords; treated as not-our-surface.",
+      "updated_at": "2026-06-03T11:40:30Z"
+    },
+    {
+      "upstream": "anthropics/claude-code#53075",
+      "url": "https://github.com/anthropics/claude-code/issues/53075",
+      "title": "[DOCS] Analytics docs should clarify telemetry opt-out effects on API and Enterprise usage metrics",
+      "impact": "unknown_low_signal",
+      "categories": [],
+      "tokenkey_status": "not_applicable",
+      "rationale": "No gateway/relay-relevant keywords; treated as not-our-surface.",
+      "updated_at": "2026-06-03T11:40:39Z"
+    },
+    {
       "upstream": "anthropics/claude-code#53225",
       "url": "https://github.com/anthropics/claude-code/issues/53225",
       "title": "Desktop app shows no recovery option when working directory has been moved or deleted",
@@ -20646,6 +22399,16 @@
       "tokenkey_status": "not_applicable",
       "rationale": "No gateway/relay-relevant keywords; treated as not-our-surface.",
       "updated_at": "2026-06-01T22:45:29Z"
+    },
+    {
+      "upstream": "anthropics/claude-code#53514",
+      "url": "https://github.com/anthropics/claude-code/issues/53514",
+      "title": "Reopening: \"Continue\" leads to massive context carry-over into new 5h limit, thus when implementation stops half-way and you are asked to wait, the next session quota is reduced massively.",
+      "impact": "unknown_low_signal",
+      "categories": [],
+      "tokenkey_status": "not_applicable",
+      "rationale": "No gateway/relay-relevant keywords; treated as not-our-surface.",
+      "updated_at": "2026-06-03T11:39:29Z"
     },
     {
       "upstream": "anthropics/claude-code#54019",
@@ -20658,6 +22421,16 @@
       "updated_at": "2026-06-02T11:32:35Z"
     },
     {
+      "upstream": "anthropics/claude-code#54517",
+      "url": "https://github.com/anthropics/claude-code/issues/54517",
+      "title": "[FEATURE] Allow scheduled agent / Routine runs to appear in Recents or be pinnable in the sidebar",
+      "impact": "unknown_low_signal",
+      "categories": [],
+      "tokenkey_status": "not_applicable",
+      "rationale": "No gateway/relay-relevant keywords; treated as not-our-surface.",
+      "updated_at": "2026-06-03T16:03:57Z"
+    },
+    {
       "upstream": "anthropics/claude-code#54924",
       "url": "https://github.com/anthropics/claude-code/issues/54924",
       "title": "[BUG] SSH option not available in Claude Code Desktop when using external API provider",
@@ -20666,16 +22439,6 @@
       "tokenkey_status": "not_applicable",
       "rationale": "No gateway/relay-relevant keywords; treated as not-our-surface.",
       "updated_at": "2026-06-01T22:45:22Z"
-    },
-    {
-      "upstream": "anthropics/claude-code#54964",
-      "url": "https://github.com/anthropics/claude-code/issues/54964",
-      "title": "[FEATURE] Google Vertex support for Remote Control features",
-      "impact": "unknown_low_signal",
-      "categories": [],
-      "tokenkey_status": "not_applicable",
-      "rationale": "No gateway/relay-relevant keywords; treated as not-our-surface.",
-      "updated_at": "2026-05-31T21:15:45Z"
     },
     {
       "upstream": "anthropics/claude-code#56927",
@@ -20928,6 +22691,26 @@
       "updated_at": "2026-06-02T11:32:30Z"
     },
     {
+      "upstream": "anthropics/claude-code#60195",
+      "url": "https://github.com/anthropics/claude-code/issues/60195",
+      "title": "[FEATURE] Allow sub-agents to restart gracefully after network outage",
+      "impact": "unknown_low_signal",
+      "categories": [],
+      "tokenkey_status": "not_applicable",
+      "rationale": "No gateway/relay-relevant keywords; treated as not-our-surface.",
+      "updated_at": "2026-06-03T11:39:33Z"
+    },
+    {
+      "upstream": "anthropics/claude-code#60199",
+      "url": "https://github.com/anthropics/claude-code/issues/60199",
+      "title": "Agent Teams: shutdown_request approval doesn't terminate teammate; reply delivery occasionally drops content",
+      "impact": "unknown_low_signal",
+      "categories": [],
+      "tokenkey_status": "not_applicable",
+      "rationale": "No gateway/relay-relevant keywords; treated as not-our-surface.",
+      "updated_at": "2026-06-03T11:39:33Z"
+    },
+    {
       "upstream": "anthropics/claude-code#60257",
       "url": "https://github.com/anthropics/claude-code/issues/60257",
       "title": "[FEATURE] Don't block Edit tool for files read in session it was forked from",
@@ -21068,16 +22851,6 @@
       "updated_at": "2026-06-01T06:33:13Z"
     },
     {
-      "upstream": "anthropics/claude-code#62229",
-      "url": "https://github.com/anthropics/claude-code/issues/62229",
-      "title": "[MODEL] Opus 4.7 stole my money",
-      "impact": "unknown_low_signal",
-      "categories": [],
-      "tokenkey_status": "not_applicable",
-      "rationale": "No gateway/relay-relevant keywords; treated as not-our-surface.",
-      "updated_at": "2026-05-31T13:35:25Z"
-    },
-    {
       "upstream": "anthropics/claude-code#6235",
       "url": "https://github.com/anthropics/claude-code/issues/6235",
       "title": "Feature Request: Support AGENTS.md.",
@@ -21108,14 +22881,14 @@
       "updated_at": "2026-06-02T10:41:03Z"
     },
     {
-      "upstream": "anthropics/claude-code#63732",
-      "url": "https://github.com/anthropics/claude-code/issues/63732",
-      "title": "Edit tool silently substitutes Unicode smart quotes for ASCII double quotes in shell scripts",
+      "upstream": "anthropics/claude-code#63356",
+      "url": "https://github.com/anthropics/claude-code/issues/63356",
+      "title": "[MODEL] Sub-agents (Haiku) over-edit structured config files despite explicit \"surgical edits only\" instructions",
       "impact": "unknown_low_signal",
       "categories": [],
       "tokenkey_status": "not_applicable",
       "rationale": "No gateway/relay-relevant keywords; treated as not-our-surface.",
-      "updated_at": "2026-05-31T20:03:13Z"
+      "updated_at": "2026-06-03T21:52:58Z"
     },
     {
       "upstream": "anthropics/claude-code#63853",
@@ -21138,26 +22911,6 @@
       "updated_at": "2026-06-01T18:19:14Z"
     },
     {
-      "upstream": "anthropics/claude-code#64053",
-      "url": "https://github.com/anthropics/claude-code/issues/64053",
-      "title": "Agent deflects with \"untouched by my change\" after its own change breaks previously-passing tests — needs accountability-first framing",
-      "impact": "unknown_low_signal",
-      "categories": [],
-      "tokenkey_status": "not_applicable",
-      "rationale": "No gateway/relay-relevant keywords; treated as not-our-surface.",
-      "updated_at": "2026-05-31T21:52:05Z"
-    },
-    {
-      "upstream": "anthropics/claude-code#64171",
-      "url": "https://github.com/anthropics/claude-code/issues/64171",
-      "title": "Feedback: noticeable reliability regression — agent edits from memory, silent Edit failures shipped broken code to prod",
-      "impact": "unknown_low_signal",
-      "categories": [],
-      "tokenkey_status": "not_applicable",
-      "rationale": "No gateway/relay-relevant keywords; treated as not-our-surface.",
-      "updated_at": "2026-05-31T20:25:45Z"
-    },
-    {
       "upstream": "anthropics/claude-code#64175",
       "url": "https://github.com/anthropics/claude-code/issues/64175",
       "title": "Claude Code wastes user quota with repeated trial-and-error instead of verifying calculations before coding",
@@ -21168,86 +22921,6 @@
       "updated_at": "2026-06-02T04:02:39Z"
     },
     {
-      "upstream": "anthropics/claude-code#64191",
-      "url": "https://github.com/anthropics/claude-code/issues/64191",
-      "title": "`/desktop` fails: \"Cannot determine working directory … transcript may be incomplete\" after EnterWorktree→ExitWorktree (transcript fragmented across project dirs; bridge-session record has no cwd)",
-      "impact": "unknown_low_signal",
-      "categories": [],
-      "tokenkey_status": "not_applicable",
-      "rationale": "No gateway/relay-relevant keywords; treated as not-our-surface.",
-      "updated_at": "2026-05-31T10:50:36Z"
-    },
-    {
-      "upstream": "anthropics/claude-code#64198",
-      "url": "https://github.com/anthropics/claude-code/issues/64198",
-      "title": "[MODEL] False-positive cyber-safety block on benign Minecraft mod documentation task",
-      "impact": "unknown_low_signal",
-      "categories": [],
-      "tokenkey_status": "not_applicable",
-      "rationale": "No gateway/relay-relevant keywords; treated as not-our-surface.",
-      "updated_at": "2026-05-31T11:13:48Z"
-    },
-    {
-      "upstream": "anthropics/claude-code#64236",
-      "url": "https://github.com/anthropics/claude-code/issues/64236",
-      "title": "[MODEL] Claude Code + Opus 4.8 frequently echos hello world during planning",
-      "impact": "unknown_low_signal",
-      "categories": [],
-      "tokenkey_status": "not_applicable",
-      "rationale": "No gateway/relay-relevant keywords; treated as not-our-surface.",
-      "updated_at": "2026-05-31T23:48:48Z"
-    },
-    {
-      "upstream": "anthropics/claude-code#64245",
-      "url": "https://github.com/anthropics/claude-code/issues/64245",
-      "title": "[FEATURE] Multiple account",
-      "impact": "unknown_low_signal",
-      "categories": [],
-      "tokenkey_status": "not_applicable",
-      "rationale": "No gateway/relay-relevant keywords; treated as not-our-surface.",
-      "updated_at": "2026-05-31T15:16:59Z"
-    },
-    {
-      "upstream": "anthropics/claude-code#64255",
-      "url": "https://github.com/anthropics/claude-code/issues/64255",
-      "title": "Auto mode selected at plan approval persists after execution completes",
-      "impact": "unknown_low_signal",
-      "categories": [],
-      "tokenkey_status": "not_applicable",
-      "rationale": "No gateway/relay-relevant keywords; treated as not-our-surface.",
-      "updated_at": "2026-05-31T15:55:54Z"
-    },
-    {
-      "upstream": "anthropics/claude-code#64259",
-      "url": "https://github.com/anthropics/claude-code/issues/64259",
-      "title": "Enriched input signal for Claude Code - Eyeballs for non-verbal communication cues",
-      "impact": "unknown_low_signal",
-      "categories": [],
-      "tokenkey_status": "not_applicable",
-      "rationale": "No gateway/relay-relevant keywords; treated as not-our-surface.",
-      "updated_at": "2026-05-31T16:17:08Z"
-    },
-    {
-      "upstream": "anthropics/claude-code#64266",
-      "url": "https://github.com/anthropics/claude-code/issues/64266",
-      "title": "Agent tool model parameter should accept full model IDs, not just tier names",
-      "impact": "unknown_low_signal",
-      "categories": [],
-      "tokenkey_status": "not_applicable",
-      "rationale": "No gateway/relay-relevant keywords; treated as not-our-surface.",
-      "updated_at": "2026-05-31T16:55:11Z"
-    },
-    {
-      "upstream": "anthropics/claude-code#64270",
-      "url": "https://github.com/anthropics/claude-code/issues/64270",
-      "title": "[FEATURE]",
-      "impact": "unknown_low_signal",
-      "categories": [],
-      "tokenkey_status": "not_applicable",
-      "rationale": "No gateway/relay-relevant keywords; treated as not-our-surface.",
-      "updated_at": "2026-05-31T17:20:26Z"
-    },
-    {
       "upstream": "anthropics/claude-code#64287",
       "url": "https://github.com/anthropics/claude-code/issues/64287",
       "title": "[UX] Add first-class false-positive reporting for safety guardrail blocks",
@@ -21256,56 +22929,6 @@
       "tokenkey_status": "not_applicable",
       "rationale": "No gateway/relay-relevant keywords; treated as not-our-surface.",
       "updated_at": "2026-06-01T18:49:18Z"
-    },
-    {
-      "upstream": "anthropics/claude-code#64302",
-      "url": "https://github.com/anthropics/claude-code/issues/64302",
-      "title": "Feature Request: Show usage stats in account dropdown menu",
-      "impact": "unknown_low_signal",
-      "categories": [],
-      "tokenkey_status": "not_applicable",
-      "rationale": "No gateway/relay-relevant keywords; treated as not-our-surface.",
-      "updated_at": "2026-05-31T19:37:42Z"
-    },
-    {
-      "upstream": "anthropics/claude-code#64307",
-      "url": "https://github.com/anthropics/claude-code/issues/64307",
-      "title": "[BUG] Cowork: uploaded context lands in the project mount, not mnt/uploads/",
-      "impact": "unknown_low_signal",
-      "categories": [],
-      "tokenkey_status": "not_applicable",
-      "rationale": "No gateway/relay-relevant keywords; treated as not-our-surface.",
-      "updated_at": "2026-05-31T19:55:06Z"
-    },
-    {
-      "upstream": "anthropics/claude-code#64335",
-      "url": "https://github.com/anthropics/claude-code/issues/64335",
-      "title": "[MODEL] Porting JS to TS Relies Too Much On Feedback From TSC",
-      "impact": "unknown_low_signal",
-      "categories": [],
-      "tokenkey_status": "not_applicable",
-      "rationale": "No gateway/relay-relevant keywords; treated as not-our-surface.",
-      "updated_at": "2026-05-31T21:42:03Z"
-    },
-    {
-      "upstream": "anthropics/claude-code#64342",
-      "url": "https://github.com/anthropics/claude-code/issues/64342",
-      "title": "Display `~/` instead of full `/Users/<name>/` in tool call path labels",
-      "impact": "unknown_low_signal",
-      "categories": [],
-      "tokenkey_status": "not_applicable",
-      "rationale": "No gateway/relay-relevant keywords; treated as not-our-surface.",
-      "updated_at": "2026-05-31T22:35:16Z"
-    },
-    {
-      "upstream": "anthropics/claude-code#64348",
-      "url": "https://github.com/anthropics/claude-code/issues/64348",
-      "title": "[FEATURE] Dynamic Workflow Feature List",
-      "impact": "unknown_low_signal",
-      "categories": [],
-      "tokenkey_status": "not_applicable",
-      "rationale": "No gateway/relay-relevant keywords; treated as not-our-surface.",
-      "updated_at": "2026-05-31T22:48:15Z"
     },
     {
       "upstream": "anthropics/claude-code#64354",
@@ -21325,7 +22948,7 @@
       "categories": [],
       "tokenkey_status": "not_applicable",
       "rationale": "No gateway/relay-relevant keywords; treated as not-our-surface.",
-      "updated_at": "2026-06-02T03:57:19Z"
+      "updated_at": "2026-06-03T14:36:01Z"
     },
     {
       "upstream": "anthropics/claude-code#64373",
@@ -21588,16 +23211,6 @@
       "updated_at": "2026-06-02T19:23:35Z"
     },
     {
-      "upstream": "anthropics/claude-code#64862",
-      "url": "https://github.com/anthropics/claude-code/issues/64862",
-      "title": "[Bug] Claude Code repeatedly bypasses agreed Scrum story lifecycle — commits without compiling, skips tests, ignores direct instructions, fabricates excuses",
-      "impact": "unknown_low_signal",
-      "categories": [],
-      "tokenkey_status": "not_applicable",
-      "rationale": "No gateway/relay-relevant keywords; treated as not-our-surface.",
-      "updated_at": "2026-06-02T21:40:46Z"
-    },
-    {
       "upstream": "anthropics/claude-code#64866",
       "url": "https://github.com/anthropics/claude-code/issues/64866",
       "title": "Model fails to connect adjacent logical steps (downloads large file without saving, then needs to re-download)",
@@ -21706,6 +23319,136 @@
       "tokenkey_status": "not_applicable",
       "rationale": "No gateway/relay-relevant keywords; treated as not-our-surface.",
       "updated_at": "2026-06-03T09:11:25Z"
+    },
+    {
+      "upstream": "anthropics/claude-code#65023",
+      "url": "https://github.com/anthropics/claude-code/issues/65023",
+      "title": "[BUG] Routine runs stuck in 'Needs input' only show on home screen, never in the left sidebar (Desktop app)",
+      "impact": "unknown_low_signal",
+      "categories": [],
+      "tokenkey_status": "not_applicable",
+      "rationale": "No gateway/relay-relevant keywords; treated as not-our-surface.",
+      "updated_at": "2026-06-03T10:41:14Z"
+    },
+    {
+      "upstream": "anthropics/claude-code#65027",
+      "url": "https://github.com/anthropics/claude-code/issues/65027",
+      "title": "Surface active ghost text suggestion in conversation context",
+      "impact": "unknown_low_signal",
+      "categories": [],
+      "tokenkey_status": "not_applicable",
+      "rationale": "No gateway/relay-relevant keywords; treated as not-our-surface.",
+      "updated_at": "2026-06-03T11:04:24Z"
+    },
+    {
+      "upstream": "anthropics/claude-code#65042",
+      "url": "https://github.com/anthropics/claude-code/issues/65042",
+      "title": "I don't see any bug report content in your message - only a screenshot file path. Could you please share the actual error message, logs, or description of the issue you're experiencing with Claude Code? Once you provide the details of the bug, I'll be ab",
+      "impact": "unknown_low_signal",
+      "categories": [],
+      "tokenkey_status": "not_applicable",
+      "rationale": "No gateway/relay-relevant keywords; treated as not-our-surface.",
+      "updated_at": "2026-06-03T12:37:12Z"
+    },
+    {
+      "upstream": "anthropics/claude-code#65058",
+      "url": "https://github.com/anthropics/claude-code/issues/65058",
+      "title": "Feature request: /memories command to show loaded memory files",
+      "impact": "unknown_low_signal",
+      "categories": [],
+      "tokenkey_status": "not_applicable",
+      "rationale": "No gateway/relay-relevant keywords; treated as not-our-surface.",
+      "updated_at": "2026-06-03T13:35:07Z"
+    },
+    {
+      "upstream": "anthropics/claude-code#65075",
+      "url": "https://github.com/anthropics/claude-code/issues/65075",
+      "title": "Link Claude Code sessions to CLAUDE.md for cross-device sync",
+      "impact": "unknown_low_signal",
+      "categories": [],
+      "tokenkey_status": "not_applicable",
+      "rationale": "No gateway/relay-relevant keywords; treated as not-our-surface.",
+      "updated_at": "2026-06-03T14:51:33Z"
+    },
+    {
+      "upstream": "anthropics/claude-code#65078",
+      "url": "https://github.com/anthropics/claude-code/issues/65078",
+      "title": "[FEATURE] Add option to create a new session when `--resume` is passed via CLI",
+      "impact": "unknown_low_signal",
+      "categories": [],
+      "tokenkey_status": "not_applicable",
+      "rationale": "No gateway/relay-relevant keywords; treated as not-our-surface.",
+      "updated_at": "2026-06-03T15:03:28Z"
+    },
+    {
+      "upstream": "anthropics/claude-code#65119",
+      "url": "https://github.com/anthropics/claude-code/issues/65119",
+      "title": "Babysit agents stop with 'socket connection closed unexpectedly' API error",
+      "impact": "unknown_low_signal",
+      "categories": [],
+      "tokenkey_status": "not_applicable",
+      "rationale": "No gateway/relay-relevant keywords; treated as not-our-surface.",
+      "updated_at": "2026-06-03T17:34:01Z"
+    },
+    {
+      "upstream": "anthropics/claude-code#65121",
+      "url": "https://github.com/anthropics/claude-code/issues/65121",
+      "title": "[bug] \"✗ Auto-update failed · Run /doctor\" in status bar causes background agents to stop during long-running sessions",
+      "impact": "unknown_low_signal",
+      "categories": [],
+      "tokenkey_status": "not_applicable",
+      "rationale": "No gateway/relay-relevant keywords; treated as not-our-surface.",
+      "updated_at": "2026-06-03T17:50:03Z"
+    },
+    {
+      "upstream": "anthropics/claude-code#65123",
+      "url": "https://github.com/anthropics/claude-code/issues/65123",
+      "title": "[FEATURE] Allow Org level control of \"Delete sessions stored by Antrhopic\"",
+      "impact": "unknown_low_signal",
+      "categories": [],
+      "tokenkey_status": "not_applicable",
+      "rationale": "No gateway/relay-relevant keywords; treated as not-our-surface.",
+      "updated_at": "2026-06-03T17:45:29Z"
+    },
+    {
+      "upstream": "anthropics/claude-code#65129",
+      "url": "https://github.com/anthropics/claude-code/issues/65129",
+      "title": "[FEATURE] Button to copy message in mobile app Claude Code",
+      "impact": "unknown_low_signal",
+      "categories": [],
+      "tokenkey_status": "not_applicable",
+      "rationale": "No gateway/relay-relevant keywords; treated as not-our-surface.",
+      "updated_at": "2026-06-03T17:59:55Z"
+    },
+    {
+      "upstream": "anthropics/claude-code#65138",
+      "url": "https://github.com/anthropics/claude-code/issues/65138",
+      "title": "Remote routines on private GitHub repos auto-disabled with auto_disabled_repo_access after first run",
+      "impact": "unknown_low_signal",
+      "categories": [],
+      "tokenkey_status": "not_applicable",
+      "rationale": "No gateway/relay-relevant keywords; treated as not-our-surface.",
+      "updated_at": "2026-06-03T18:46:02Z"
+    },
+    {
+      "upstream": "anthropics/claude-code#65166",
+      "url": "https://github.com/anthropics/claude-code/issues/65166",
+      "title": "darwin-x64: false \"temp filesystem is full (0MB free) / ENOSPC\" — statfs().bsize=0 makes the empty-output explainer always report disk-full",
+      "impact": "unknown_low_signal",
+      "categories": [],
+      "tokenkey_status": "not_applicable",
+      "rationale": "No gateway/relay-relevant keywords; treated as not-our-surface.",
+      "updated_at": "2026-06-03T20:35:30Z"
+    },
+    {
+      "upstream": "anthropics/claude-code#65177",
+      "url": "https://github.com/anthropics/claude-code/issues/65177",
+      "title": "Web (claude.ai/code): session groups don't persist across environments/devices — sessions appear \"Ungrouped\"",
+      "impact": "unknown_low_signal",
+      "categories": [],
+      "tokenkey_status": "not_applicable",
+      "rationale": "No gateway/relay-relevant keywords; treated as not-our-surface.",
+      "updated_at": "2026-06-03T21:57:10Z"
     },
     {
       "upstream": "anthropics/claude-code#895",


### PR DESCRIPTION
## Summary
- Refresh `.cache/anthropic/cc-triage.json` from the latest anthropics/claude-code issues.
- Update `.cache/anthropic/cc-fixes.json` from current TokenKey main fact checks.
- Keep watchdog workflow/script/fact-check metadata in sync with the refreshed cache.

## Watchdog report
# Anthropic Claude-Code Issue Watchdog Report

- Run URL: https://github.com/youxuanxue/sub2api/actions/runs/26915620422
- Repository SHA: `3d6dc856a14d39a25ad2ad279f1ad7f5b77d11a8`
- Generated at: `2026-06-03T21:59:41Z`
- Upstream issues scanned: `2987`
- Fact checks: `3`
- Fixed facts verified: `3`
- High/critical unresolved: `0`

## Fixed facts verified

- anthropics/claude-code#61348 via youxuanxue/sub2api#514, youxuanxue/sub2api#518
- anthropics/claude-code#60168, anthropics/claude-code#63885, anthropics/claude-code#64777 via youxuanxue/sub2api (UTF-8/surrogate self-heal)
- anthropics/claude-code#60913 via youxuanxue/sub2api ([1m] context-window model-alias strip)


## Test plan
- [x] `python3 -m json.tool .cache/anthropic/cc-triage.json`
- [x] `python3 -m json.tool .cache/anthropic/cc-fixes.json`
- [x] `python3 -m json.tool .cache/anthropic/cc-fact-checks.json`
- [x] `python3 -m py_compile scripts/upstream/issue-watchdog.py`
- [x] `python3 -m json.tool .cache/anthropic-cc-issue-watchdog/report.json`
- [x] `python3 -m json.tool .cache/anthropic-cc-issue-watchdog/agent-input.json`
