### PR TITLE
chore(tier): raise anthropic L1-L5 baselines (base_rpm/buffer +50%, max_sessions ladder, window_cost=800, cache_ttl on)

### DIFF
--- a/backend/internal/baseline/anthropic-oauth-stability-baselines-tiered.json
+++ b/backend/internal/baseline/anthropic-oauth-stability-baselines-tiered.json
@@ -132,13 +132,13 @@
           "rate_multiplier": 1.0
         },
         "extra": {
-          "base_rpm": 14,
-          "rpm_sticky_buffer": 5,
-          "max_sessions": 30,
+          "base_rpm": 21,
+          "rpm_sticky_buffer": 8,
+          "max_sessions": 45,
           "session_idle_timeout_minutes": 8,
-          "window_cost_limit": 600,
+          "window_cost_limit": 800,
           "window_cost_sticky_reserve": 0,
-          "cache_ttl_override_enabled": false
+          "cache_ttl_override_enabled": true
         }
       }
     },
@@ -150,13 +150,13 @@
           "rate_multiplier": 1.0
         },
         "extra": {
-          "base_rpm": 28,
-          "rpm_sticky_buffer": 10,
-          "max_sessions": 60,
+          "base_rpm": 42,
+          "rpm_sticky_buffer": 15,
+          "max_sessions": 90,
           "session_idle_timeout_minutes": 8,
-          "window_cost_limit": 600,
+          "window_cost_limit": 800,
           "window_cost_sticky_reserve": 0,
-          "cache_ttl_override_enabled": false
+          "cache_ttl_override_enabled": true
         }
       }
     },
@@ -168,11 +168,11 @@
           "rate_multiplier": 1.0
         },
         "extra": {
-          "base_rpm": 42,
-          "rpm_sticky_buffer": 15,
-          "max_sessions": 90,
+          "base_rpm": 63,
+          "rpm_sticky_buffer": 23,
+          "max_sessions": 120,
           "session_idle_timeout_minutes": 8,
-          "window_cost_limit": 600,
+          "window_cost_limit": 800,
           "window_cost_sticky_reserve": 0
         }
       }
@@ -185,11 +185,11 @@
           "rate_multiplier": 1.0
         },
         "extra": {
-          "base_rpm": 56,
-          "rpm_sticky_buffer": 20,
-          "max_sessions": 120,
+          "base_rpm": 84,
+          "rpm_sticky_buffer": 30,
+          "max_sessions": 150,
           "session_idle_timeout_minutes": 8,
-          "window_cost_limit": 600,
+          "window_cost_limit": 800,
           "window_cost_sticky_reserve": 0
         }
       }
@@ -202,11 +202,11 @@
           "rate_multiplier": 1.0
         },
         "extra": {
-          "base_rpm": 56,
-          "rpm_sticky_buffer": 20,
-          "max_sessions": 150,
+          "base_rpm": 84,
+          "rpm_sticky_buffer": 30,
+          "max_sessions": 180,
           "session_idle_timeout_minutes": 8,
-          "window_cost_limit": 600,
+          "window_cost_limit": 800,
           "window_cost_sticky_reserve": 0
         }
       }

--- a/backend/internal/baseline/tier_test.go
+++ b/backend/internal/baseline/tier_test.go
@@ -26,33 +26,42 @@ func TestLoadTierBaselineDoc(t *testing.T) {
 	}
 }
 
+// TestEffectiveBaselineForTier verifies the MERGE MECHANISM (shared_baseline +
+// per-tier overlay), not specific numeric values. Effective account fields and
+// tier-only extra keys are compared against the loaded doc itself, so legitimate
+// baseline value changes (e.g. an across-the-board RPM bump) never require a test
+// edit — the JSON stays the single source of truth.
 func TestEffectiveBaselineForTier(t *testing.T) {
-	// l4 baseline from anthropic-oauth-stability-baselines-tiered.json:
-	// account.concurrency=10 priority=4; extra.base_rpm=56 max_sessions=120 rpm_sticky_buffer=20
+	doc, err := LoadTierBaselineDoc()
+	if err != nil {
+		t.Fatalf("LoadTierBaselineDoc: %v", err)
+	}
 	eff, err := EffectiveBaselineForTier("L4") // case-insensitive
 	if err != nil {
 		t.Fatalf("EffectiveBaselineForTier: %v", err)
 	}
-	if eff.Concurrency != 10 || eff.Priority != 4 {
-		t.Fatalf("l4 concurrency/priority = %d/%d want 10/4", eff.Concurrency, eff.Priority)
+	tier := doc.Tiers["l4"]
+	// account fields wired from tiers[l4].baseline.account (self-consistent, no magic numbers)
+	if eff.Concurrency != tier.Baseline.Account.Concurrency || eff.Priority != tier.Baseline.Account.Priority {
+		t.Fatalf("l4 concurrency/priority = %d/%d want %d/%d",
+			eff.Concurrency, eff.Priority, tier.Baseline.Account.Concurrency, tier.Baseline.Account.Priority)
 	}
-	if eff.RateMultiplier != 1.0 {
-		t.Fatalf("l4 rate_multiplier = %v want 1.0", eff.RateMultiplier)
+	if eff.RateMultiplier != tier.Baseline.Account.RateMultiplier {
+		t.Fatalf("l4 rate_multiplier = %v want %v", eff.RateMultiplier, tier.Baseline.Account.RateMultiplier)
 	}
-	// shared extra key present
+	// shared extra keys carried into the merge
 	if v, _ := eff.Extra["rpm_strategy"].(string); v != "tiered" {
 		t.Fatalf("expected shared extra rpm_strategy=tiered, got %v", eff.Extra["rpm_strategy"])
 	}
-	// shared enable_tls_fingerprint present
 	if v, _ := eff.Extra["enable_tls_fingerprint"].(bool); !v {
 		t.Fatalf("expected enable_tls_fingerprint=true in merged extra")
 	}
-	// tier-specific extra overrides/adds: base_rpm=56 (JSON number -> float64)
-	if v, _ := eff.Extra["base_rpm"].(float64); v != 56 {
-		t.Fatalf("l4 base_rpm = %v want 56", eff.Extra["base_rpm"])
+	// tier-only extra overlaid: value equals the per-tier source (mechanism, not a literal)
+	if eff.Extra["base_rpm"] != tier.Baseline.Extra["base_rpm"] {
+		t.Fatalf("l4 base_rpm = %v want %v (overlaid from tier)", eff.Extra["base_rpm"], tier.Baseline.Extra["base_rpm"])
 	}
-	if v, _ := eff.Extra["max_sessions"].(float64); v != 120 {
-		t.Fatalf("l4 max_sessions = %v want 120", eff.Extra["max_sessions"])
+	if eff.Extra["max_sessions"] != tier.Baseline.Extra["max_sessions"] {
+		t.Fatalf("l4 max_sessions = %v want %v (overlaid from tier)", eff.Extra["max_sessions"], tier.Baseline.Extra["max_sessions"])
 	}
 	// credentials carried from shared_baseline
 	if _, ok := eff.Credentials["temp_unschedulable_rules"]; !ok {
@@ -68,14 +77,48 @@ func TestEffectiveBaselineForTier(t *testing.T) {
 	}
 }
 
-func TestEffectiveBaselineForTier_LowerOverridesShared(t *testing.T) {
-	// l1 sets cache_ttl_override_enabled=false, overriding shared true.
-	eff, err := EffectiveBaselineForTier("l1")
+// TestTierLadderInvariants asserts structural invariants that hold regardless of
+// the exact numeric baselines, so value-only changes don't churn this test:
+//   - every tier loads and carries the required positive extra caps
+//   - shared extra keys are overlaid onto every tier
+//   - priority follows tier order (l1..l5 -> 1..5)
+//   - the RPM / session / cost ladder is monotonic non-decreasing l1 -> l5
+func TestTierLadderInvariants(t *testing.T) {
+	order, err := TierOrder()
 	if err != nil {
-		t.Fatalf("EffectiveBaselineForTier l1: %v", err)
+		t.Fatalf("TierOrder: %v", err)
 	}
-	if v, ok := eff.Extra["cache_ttl_override_enabled"].(bool); !ok || v {
-		t.Fatalf("l1 cache_ttl_override_enabled = %v want false", eff.Extra["cache_ttl_override_enabled"])
+	requiredCaps := []string{"base_rpm", "rpm_sticky_buffer", "max_sessions", "window_cost_limit"}
+	ladder := []string{"base_rpm", "max_sessions", "window_cost_limit"}
+	prev := map[string]float64{}
+	for i, name := range order {
+		eff, err := EffectiveBaselineForTier(name)
+		if err != nil {
+			t.Fatalf("EffectiveBaselineForTier %q: %v", name, err)
+		}
+		if eff.Priority != i+1 {
+			t.Fatalf("%s priority = %d want %d (tier order)", name, eff.Priority, i+1)
+		}
+		if eff.Concurrency <= 0 {
+			t.Fatalf("%s concurrency = %d want > 0", name, eff.Concurrency)
+		}
+		// shared overlay present on every tier
+		if v, _ := eff.Extra["rpm_strategy"].(string); v != "tiered" {
+			t.Fatalf("%s missing shared rpm_strategy=tiered", name)
+		}
+		for _, k := range requiredCaps {
+			v, ok := eff.Extra[k].(float64)
+			if !ok || v <= 0 {
+				t.Fatalf("%s extra[%q] = %v want float64 > 0", name, k, eff.Extra[k])
+			}
+		}
+		for _, k := range ladder {
+			v := eff.Extra[k].(float64)
+			if v < prev[k] {
+				t.Fatalf("%s extra[%q] = %v < lower tier %v (ladder must be non-decreasing)", name, k, v, prev[k])
+			}
+			prev[k] = v
+		}
 	}
 }
 

--- a/backend/migrations/tk_012_create_tiers_and_account_tier_id.sql
+++ b/backend/migrations/tk_012_create_tiers_and_account_tier_id.sql
@@ -57,11 +57,11 @@ CREATE INDEX IF NOT EXISTS ix_accounts_tier_id ON accounts (tier_id) WHERE delet
 -- preflight/CI failure (plan risk #6 — tiers-table-vs-git projection drift).
 INSERT INTO tiers (name, concurrency, priority, rate_multiplier, base_rpm, max_sessions, rpm_sticky_buffer, session_idle_timeout_minutes, window_cost_limit, window_cost_sticky_reserve, cache_ttl_override_enabled, cache_ttl_override_target, tls_profile_name)
 VALUES
-    ('l1',  4, 1, 1.0, 14,  30,  5, 8, 600, 0, false, '1h', 'tk_canonical_cc_oauth'),
-    ('l2',  6, 2, 1.0, 28,  60, 10, 8, 600, 0, false, '1h', 'tk_canonical_cc_oauth'),
-    ('l3',  8, 3, 1.0, 42,  90, 15, 8, 600, 0, true,  '1h', 'tk_canonical_cc_oauth'),
-    ('l4', 10, 4, 1.0, 56, 120, 20, 8, 600, 0, true,  '1h', 'tk_canonical_cc_oauth'),
-    ('l5', 12, 5, 1.0, 56, 150, 20, 8, 600, 0, true,  '1h', 'tk_canonical_cc_oauth')
+    ('l1',  4, 1, 1.0, 21,  45,  8, 8, 800, 0, true, '1h', 'tk_canonical_cc_oauth'),
+    ('l2',  6, 2, 1.0, 42,  90, 15, 8, 800, 0, true, '1h', 'tk_canonical_cc_oauth'),
+    ('l3',  8, 3, 1.0, 63, 120, 23, 8, 800, 0, true, '1h', 'tk_canonical_cc_oauth'),
+    ('l4', 10, 4, 1.0, 84, 150, 30, 8, 800, 0, true, '1h', 'tk_canonical_cc_oauth'),
+    ('l5', 12, 5, 1.0, 84, 180, 30, 8, 800, 0, true, '1h', 'tk_canonical_cc_oauth')
 ON CONFLICT (name) DO NOTHING;
 
 -- Backfill tier_id for existing anthropic OAuth accounts that carry the legacy

--- a/deploy/aws/stage0/anthropic-oauth-stability-baselines-tiered.json
+++ b/deploy/aws/stage0/anthropic-oauth-stability-baselines-tiered.json
@@ -132,13 +132,13 @@
           "rate_multiplier": 1.0
         },
         "extra": {
-          "base_rpm": 14,
-          "rpm_sticky_buffer": 5,
-          "max_sessions": 30,
+          "base_rpm": 21,
+          "rpm_sticky_buffer": 8,
+          "max_sessions": 45,
           "session_idle_timeout_minutes": 8,
-          "window_cost_limit": 600,
+          "window_cost_limit": 800,
           "window_cost_sticky_reserve": 0,
-          "cache_ttl_override_enabled": false
+          "cache_ttl_override_enabled": true
         }
       }
     },
@@ -150,13 +150,13 @@
           "rate_multiplier": 1.0
         },
         "extra": {
-          "base_rpm": 28,
-          "rpm_sticky_buffer": 10,
-          "max_sessions": 60,
+          "base_rpm": 42,
+          "rpm_sticky_buffer": 15,
+          "max_sessions": 90,
           "session_idle_timeout_minutes": 8,
-          "window_cost_limit": 600,
+          "window_cost_limit": 800,
           "window_cost_sticky_reserve": 0,
-          "cache_ttl_override_enabled": false
+          "cache_ttl_override_enabled": true
         }
       }
     },
@@ -168,11 +168,11 @@
           "rate_multiplier": 1.0
         },
         "extra": {
-          "base_rpm": 42,
-          "rpm_sticky_buffer": 15,
-          "max_sessions": 90,
+          "base_rpm": 63,
+          "rpm_sticky_buffer": 23,
+          "max_sessions": 120,
           "session_idle_timeout_minutes": 8,
-          "window_cost_limit": 600,
+          "window_cost_limit": 800,
           "window_cost_sticky_reserve": 0
         }
       }
@@ -185,11 +185,11 @@
           "rate_multiplier": 1.0
         },
         "extra": {
-          "base_rpm": 56,
-          "rpm_sticky_buffer": 20,
-          "max_sessions": 120,
+          "base_rpm": 84,
+          "rpm_sticky_buffer": 30,
+          "max_sessions": 150,
           "session_idle_timeout_minutes": 8,
-          "window_cost_limit": 600,
+          "window_cost_limit": 800,
           "window_cost_sticky_reserve": 0
         }
       }
@@ -202,11 +202,11 @@
           "rate_multiplier": 1.0
         },
         "extra": {
-          "base_rpm": 56,
-          "rpm_sticky_buffer": 20,
-          "max_sessions": 150,
+          "base_rpm": 84,
+          "rpm_sticky_buffer": 30,
+          "max_sessions": 180,
           "session_idle_timeout_minutes": 8,
-          "window_cost_limit": 600,
+          "window_cost_limit": 800,
           "window_cost_sticky_reserve": 0
         }
       }


### PR DESCRIPTION
## What

Raises the anthropic OAuth stability **tier baselines** (l1–l5). The runtime `tiers` table is re-asserted from the embedded baseline on every `TierService` startup (`ensureSeededFromBaseline`), so editing the baseline is the **only durable path** — a direct DB / admin-UI write is reverted on the next container restart.

| tier | base_rpm | rpm_sticky_buffer | max_sessions | window_cost_limit | cache_ttl_override | red zone (base+buf) |
|---|---|---|---|---|---|---|
| l1 | 14→**21** | 5→**8** | 30→**45** | 600→**800** | →**on** | 29 |
| l2 | 28→**42** | 10→**15** | 60→**90** | 600→**800** | →**on** | 57 |
| l3 | 42→**63** | 15→**23** | 90→**120** | 600→**800** | on | 86 |
| l4 | 56→**84** | 20→**30** | 120→**150** | 600→**800** | on | 114 |
| l5 | 56→**84** | 20→**30** | 150→**180** | 600→**800** | on | 114 |

- `base_rpm` / `rpm_sticky_buffer` are **+50%** across the board (.5 rounded up).
- `max_sessions` is a hand-set ladder (l1/l2 +50%; l3–l5 = 120/150/180).
- `window_cost_limit` 600→800 (all tiers); `cache_ttl_override` on for all (l1/l2 flipped `false`→`true`; l3–l5 already inherit the shared `true`).
- `concurrency` / `priority` / `rate_multiplier` / `session_idle_timeout` **unchanged**.

## Why

prod/us2/us5 traffic profiling showed single-account **l2** edges hitting the `base_rpm` red zone (38) on RPM spikes → `no available accounts` 503s chaining back to prod mirror accounts. Raising the ladder lifts the local ceilings (l2 red zone **38 → 57**).

## Single-source sync (preflight gate `check-tier-baseline-embed.py`)

Three mechanically-enforced copies kept byte/value identical:
- `deploy/aws/stage0/...json` — canonical (go:embed can't reach outside the backend module)
- `backend/internal/baseline/...json` — embedded mirror, byte-identical
- `backend/migrations/tk_012` INSERT seed — `== JSON-effective` values

The `tk_012` edit only affects **fresh installs** (`ON CONFLICT DO NOTHING`; existing DBs already seeded). Live values are governed by the startup reseed regardless.

## Tests

`tier_test.go` refactored to assert the **merge mechanism + ladder invariants** (effective values compared against the loaded doc; monotonic non-decreasing ladder) instead of hard-coded magic numbers — so value-only bumps no longer require a test edit (this PR's later max_sessions change touched **no** test).

- `go test -tags=unit ./...` ✅
- `golangci-lint run ./internal/baseline/...` ✅ (0 issues)
- `scripts/preflight.sh` ✅ (full sub2api gate set)

## Rollout

Takes effect only after **release + deploy** (container restart triggers reseed across prod + all deployable edges). Not included in this PR.

🤖 Generated with [Claude Code](https://claude.com/claude-code)