### PR TITLE
fix(ledger): repair Wei-Shaw/sub2api#1318 fact-check anchor drift

### DIFF
--- a/.cache/upstream/fact-checks.json
+++ b/.cache/upstream/fact-checks.json
@@ -376,7 +376,7 @@
       ],
       "fixed_if_all_present": [
         "backend/internal/service/openai_gateway_service.go:upstream Wei-Shaw/sub2api#1318",
-        "backend/internal/service/openai_gateway_service.go:shouldDisable := s.handleOpenAIAccountUpstreamError(ctx, account, resp.StatusCode, resp.Header, body)",
+        "backend/internal/service/openai_gateway_service.go:shouldDisable := s.handleOpenAIAccountUpstreamError(ctx, account, resp.StatusCode, resp.Header, body",
         "backend/internal/service/openai_oauth_passthrough_test.go:TestOpenAIGatewayService_OpenAIPassthrough_TempUnschedRuleTriggersFailover"
       ]
     },

--- a/.cache/upstream/triage.json
+++ b/.cache/upstream/triage.json
@@ -4,8 +4,8 @@
   "generated_from": "GitHub REST API issues?state=open; pull requests excluded",
   "rationale": "TokenKey-local triage cache for upstream open issues. Use this file before re-triaging upstream issues; update entries when TokenKey fixes, dismisses, or reclassifies an issue.",
   "counts": {
-    "needs_review": 410,
-    "fixed": 37,
+    "needs_review": 409,
+    "fixed": 38,
     "needs_prod_validation": 2,
     "medium": 123,
     "not_applicable": 1,
@@ -298,19 +298,6 @@
       "tokenkey_status": "candidate_unverified",
       "rationale": "Keyword match for production-sensitive area; not yet manually verified against TokenKey code.",
       "updated_at": "2026-04-19T10:53:21Z"
-    },
-    {
-      "upstream": "Wei-Shaw/sub2api#1318",
-      "url": "https://github.com/Wei-Shaw/sub2api/issues/1318",
-      "title": "[bug] openai_passthrough 命中临时不可调度规则后未触发 failover",
-      "impact": "needs_review",
-      "categories": [
-        "rate_limit_cooldown",
-        "image_oauth"
-      ],
-      "tokenkey_status": "candidate_unverified",
-      "rationale": "Keyword match for production-sensitive area; not yet manually verified against TokenKey code.",
-      "updated_at": "2026-03-26T06:47:06Z"
     },
     {
       "upstream": "Wei-Shaw/sub2api#1331",
@@ -6684,6 +6671,19 @@
       "tokenkey_status": "fixed_in_tokenkey",
       "rationale": "Non-stream buffered SSE->JSON handlers in both the OpenAI gateway (/v1/chat/completions, /v1/messages) and the Anthropic-backed gateway forward paths (Responses, Chat Completions) now explicitly set Content-Type: application/json after WriteFilteredHeaders. Without this, the upstream SSE Content-Type (text/event-stream) leaks onto JSON bodies because gin's render.writeContentType only writes when no Content-Type is set, breaking OpenAI-SDK consumers that branch on Content-Type.",
       "updated_at": "2026-05-15T12:00:37Z"
+    },
+    {
+      "upstream": "Wei-Shaw/sub2api#1318",
+      "url": "https://github.com/Wei-Shaw/sub2api/issues/1318",
+      "title": "[bug] openai_passthrough 命中临时不可调度规则后未触发 failover",
+      "impact": "fixed",
+      "categories": [
+        "rate_limit_cooldown",
+        "image_oauth"
+      ],
+      "tokenkey_status": "fixed_in_tokenkey",
+      "rationale": "openai_passthrough now propagates HandleUpstreamError's shouldDisable signal: when a temp-unschedulable rule (or any policy that marks the account unschedulable — 402 deactivated_workspace, OAuth 401, organization disabled, etc.) fires, handleErrorResponsePassthrough returns UpstreamFailoverError and emits ops Kind=failover instead of writing the upstream error straight back to the client. This closes the half-applied state where the account got disabled but the in-flight request was still completed on it.",
+      "updated_at": "2026-03-26T06:47:06Z"
     },
     {
       "upstream": "Wei-Shaw/sub2api#1322",


### PR DESCRIPTION
## 背景

每日 watchdog 运行 #539 在 **"Fact checks missing"** 下点名 `Wei-Shaw/sub2api#1318`:fix-ledger 里该 issue 的 fact-check 锚点已 drift,无法在 working tree 中解析。这是 #538/#539 两次 watchdog 扫描中唯一被明确标记待处理、且对 TK 有真实价值的可执行项。

(同批评估的另两个生产相关候选均已在 TK 处理:**#2708** lib/pq goroutine 泄漏已被 `conn_max_lifetime_minutes=30` / `conn_max_idle_time_minutes=5` 默认缓解;**#2232** images/edits gpt-image-2 在 TK 重写的 responses-bridge 下不复现,`openai_images_responses.go` 总是把 `image_generation` tool 追加进 `tools`。)

## 根因

#1318 的 failover 修复**完好在 main 上**:
- marker `backend/internal/service/openai_gateway_service.go:3689` (`upstream Wei-Shaw/sub2api#1318`)
- `shouldDisable → UpstreamFailoverError` 接线 (3703–3726),命中临时不可调度规则时返回 failover 而非把上游错误直接回写
- pin 测试 `TestOpenAIGatewayService_OpenAIPassthrough_TempUnschedRuleTriggersFailover` 本地 **PASS**

锚点 drift 的原因:`handleOpenAIAccountUpstreamError` 新增了 `reqModel` 参数,旧锚点 `...resp.Header, body)` 不再是 `...resp.Header, body, reqModel)` 的子串(`check_fact` 用整文件 `needle in text` 子串匹配)。

## 修复

- 将锚点截到末尾 `)` 之前 → 匹配当前签名,且对未来追加参数免疫。
- `apply-fix-ledger.py --ledger upstream --apply` 传播:`#1318` 由 `candidate_unverified` → `fixed_in_tokenkey`(counts `fixed 37→38`、`needs_review 410→409`),`fixes.json` 已含该项。

价值:watchdog 不再每天误报、不会重新把已修的 #1318 选成候选;trailer-scoped fix-ledger 门禁恢复能证明该 failover 修复仍在 main。

## 验证

- [x] `go test -tags=unit ./internal/service -run ...TempUnschedRuleTriggersFailover` PASS
- [x] 三个 `#1318` 锚点全部 `check_fact` resolve
- [x] `.cache/upstream/{fact-checks,triage,fixes}.json` JSON 合法
- [x] `scripts/preflight.sh` PASS(含 fix-ledger 一致性 upstream+anthropic 均 ok)

Upstream-Fixes: Wei-Shaw/sub2api#1318

🤖 Generated with [Claude Code](https://claude.com/claude-code)