### PR TITLE
fix(stage0): skip pre-drain when outgoing container unhealthy (deploy-primitive trap that kept uk1 down)

### DIFF
--- a/ops/stage0/deploy_via_ssm.sh
+++ b/ops/stage0/deploy_via_ssm.sh
@@ -16,6 +16,14 @@
 #   3. Send SIGUSR1 to tokenkey → wait for /health/inflight to report
 #      draining=true && in_flight=0 (pre-drain so live SSE finishes). Only now
 #      does Caddy active health (health_uri /health) remove the old upstream.
+#      SKIPPED when the outgoing container is not `healthy`: a crash-looping /
+#      unhealthy container has no in-flight to drain (Caddy already flipped it
+#      out at /health!=200), and SIGUSR1 + the inflight-wait would block the
+#      full ~76s on a container whose `docker exec wget` never answers —
+#      starving the new container's health window and tripping the rollback
+#      trap, which then restores the (broken) previous image. That exact loop
+#      kept uk1 pinned to a crash-looping image on 2026-06-03; gating the drain
+#      on old-container health lets a deploy recover an already-broken node.
 #   4. `compose up -d --no-deps --force-recreate tokenkey`. The image is
 #      already on disk from step 2, so this is just stop-old + start-new.
 #      `--force-recreate` is load-bearing: step 3 already flipped drainFlag=true
@@ -82,15 +90,15 @@ jq -n --arg tag "${TAG}" '{
     ("echo === deploy stage0 to tag=" + $tag + " ==="),
     ("BACKUP=/var/lib/tokenkey/.env.before-" + $tag),
     "sudo cp -a /var/lib/tokenkey/.env \"$BACKUP\"",
-    "rollback() { rc=$?; echo \"::warning::deploy failed; restoring previous tokenkey image\"; if [ -f \"$BACKUP\" ]; then sudo cp -a \"$BACKUP\" /var/lib/tokenkey/.env; cd /var/lib/tokenkey && sudo docker compose --env-file .env up -d --no-deps --force-recreate tokenkey || true; for i in 1 2 3 4 5 6 7 8 9 10 11 12; do s=$(sudo docker inspect tokenkey --format '\''{{.State.Health.Status}}'\'' 2>/dev/null || echo missing); echo \"rollback try $i: $s\"; [ \"$s\" = healthy ] && break; sleep 5; done; sudo docker logs tokenkey --since 2m 2>&1 | tail -50 || true; fi; exit $rc; }",
+    "rollback() { rc=$?; echo \"::warning::deploy failed; restoring previous tokenkey image\"; if [ -f \"$BACKUP\" ]; then sudo cp -a \"$BACKUP\" /var/lib/tokenkey/.env; cd /var/lib/tokenkey && sudo docker compose --env-file .env up -d --no-deps --force-recreate tokenkey || true; for i in 1 2 3 4 5 6 7 8 9 10 11 12; do s=$(sudo docker inspect tokenkey --format '\''{{.State.Health.Status}}'\'' 2>/dev/null || echo missing); echo \"rollback try $i: $s\"; [ \"$s\" = healthy ] && break; sleep 5; done; [ \"$s\" = healthy ] || echo \"::error::rollback restored the previous image but it is ALSO not healthy (health=$s) — node requires MANUAL intervention; do NOT assume service is restored\"; sudo docker logs tokenkey --since 2m 2>&1 | tail -50 || true; fi; exit $rc; }",
     "trap rollback ERR",
     ("sudo sed -i '\''s|sub2api:[^[:space:]]*|sub2api:" + $tag + "|'\'' /var/lib/tokenkey/.env"),
     "if ! grep -q '\''^SERVER_FRONTEND_URL='\'' /var/lib/tokenkey/.env; then d=$(sed -n '\''s/^API_DOMAIN=//p'\'' /var/lib/tokenkey/.env | head -1); if [ -n \"$d\" ]; then echo \"SERVER_FRONTEND_URL=https://$d\" | sudo tee -a /var/lib/tokenkey/.env >/dev/null; echo \"ensured SERVER_FRONTEND_URL=https://$d\"; else echo \"API_DOMAIN empty; skip SERVER_FRONTEND_URL backfill\"; fi; else echo \"SERVER_FRONTEND_URL already present\"; fi",
     "echo \"=== pull new image BEFORE drain (old container keeps serving 100% traffic) ===\"",
     "cd /var/lib/tokenkey && sudo docker compose --env-file .env pull tokenkey",
-    "echo === pre-drain: SIGUSR1 + wait in_flight=0 ===",
-    "sudo docker kill -s USR1 tokenkey 2>/dev/null || echo \"pre-drain: container not running (first deploy?)\"",
-    "for i in $(seq 1 38); do body=$(sudo docker exec tokenkey wget -q -T 3 -O - http://localhost:8080/health/inflight 2>/dev/null); n=$(printf '\''%s'\'' \"$body\" | sed -n '\''s/.*\"in_flight\":\\([0-9]*\\).*/\\1/p'\''); if printf '\''%s'\'' \"$body\" | grep -q '\''\"draining\":true'\''; then d=true; else d=false; fi; echo \"pre-drain: draining=$d in_flight=${n:-?} try=$i/38\"; [ \"$d\" = true ] && [ \"${n:-1}\" = 0 ] && break; sleep 2; done",
+    "echo \"=== pre-drain: SIGUSR1 + wait in_flight=0 (only when outgoing container healthy) ===\"",
+    "OLD_HEALTH=$(sudo docker inspect tokenkey --format '\''{{if .State.Health}}{{.State.Health.Status}}{{else}}none{{end}}'\'' 2>/dev/null || echo missing); echo \"pre-drain: outgoing container health=$OLD_HEALTH\"",
+    "if [ \"$OLD_HEALTH\" = healthy ]; then sudo docker kill -s USR1 tokenkey 2>/dev/null || true; for i in $(seq 1 38); do body=$(sudo docker exec tokenkey wget -q -T 3 -O - http://localhost:8080/health/inflight 2>/dev/null); n=$(printf '\''%s'\'' \"$body\" | sed -n '\''s/.*\"in_flight\":\\([0-9]*\\).*/\\1/p'\''); if printf '\''%s'\'' \"$body\" | grep -q '\''\"draining\":true'\''; then d=true; else d=false; fi; echo \"pre-drain: draining=$d in_flight=${n:-?} try=$i/38\"; [ \"$d\" = true ] && [ \"${n:-1}\" = 0 ] && break; sleep 2; done; else echo \"pre-drain SKIPPED: outgoing container not healthy (health=$OLD_HEALTH) — Caddy already flipped it out, nothing to drain; straight to recreate (avoids burning the ~76s drain budget on a crash-looping container, which previously starved the new container health window and tripped the rollback trap — uk1 2026-06-03)\"; fi",
     "echo \"=== swap: stop-old + start-new (image already on disk from pull above) ===\"",
     "cd /var/lib/tokenkey && sudo docker compose --env-file .env up -d --no-deps --force-recreate tokenkey",
     "for i in 1 2 3 4 5 6 7 8 9 10 11 12; do s=$(sudo docker inspect tokenkey --format '\''{{.State.Health.Status}}'\'' 2>/dev/null || echo missing); echo \"try $i: $s\"; [ \"$s\" = healthy ] && break; sleep 5; done",


### PR DESCRIPTION
## Why

During the `1.7.66` rollout, the SSM deploy primitive (`ops/stage0/deploy_via_ssm.sh`) could **not** recover a node whose current container was crash-looping. A good `1.7.66` image booted clean, but the deploy reverted it to the broken `1.7.65` every time. uk1 only recovered via a manual `compose up` that bypassed the primitive.

Two interacting flaws:

1. **Pre-drain runs against a dead container.** Step 3 sends `SIGUSR1` then loops up to `38×2s = 76s` waiting for the *outgoing* container's `/health/inflight` to report `in_flight=0`. On a crash-looping container, `docker exec tokenkey wget` never answers → the loop burns the full ~76s. That starves the new container's `12×5s = 60s` health window (and pushes total runtime toward the SSM timeout), so the health gate fails.
2. **The `trap rollback ERR` then restores the previous (broken) image.** It `cp`s the backup `.env` (pre-deploy tag) back and recreates — but the pre-deploy tag *was the crash-looping one*, so the node stays broken. Every retry repeated this.

Net effect on 2026-06-03: uk1 stuck on crash-looping `1.7.65`; the migration fix in `1.7.66` was correct and booted clean, but the primitive reverted it.

## What

1. **Gate the pre-drain on the outgoing container's health.** A non-`healthy` container has no in-flight to drain (Caddy already removed it from the upstream pool at `/health!=200`), so skip `SIGUSR1` + the inflight-wait and go straight to recreate — giving the new container the full health window. The normal **zero-downtime** path (healthy old container → drain → swap) is unchanged.
2. **Loud rollback failure.** When the rollback's restored image is *also* not healthy, emit `::error::… node requires MANUAL intervention` instead of silently implying service was restored.
3. Doc comment (step 3) updated to explain the skip-when-unhealthy behavior + the uk1 incident.

With this, a deploy can **self-recover an already-broken node** (the exact uk1 case): old container unhealthy → skip drain → recreate good image → reaches healthy → no trap.

## Validation

- `jq` emits valid JSON (21 commands).
- Reconstructed remote host script passes `bash -n` (caught and fixed an unquoted-paren echo before commit).
- `scripts/checks/check-stage0-ssm-host-parse.sh` → OK (the host-parse guard hardened for exactly this class of break).
- `bash scripts/preflight.sh` → PASS.

Pure ops shell-script change; no app/web/DB surface (`no-web-impact`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)