### PR TITLE
chore: refresh claude-code issue cache

### DIFF
--- a/.cache/anthropic/cc-triage.json
+++ b/.cache/anthropic/cc-triage.json
@@ -4,10 +4,10 @@
   "generated_from": "GitHub REST API issues?state=open; pull requests excluded; gateway-relevance filtered",
   "rationale": "TokenKey-local triage cache for anthropics/claude-code issues, filtered for gateway/relay relevance. Most claude-code issues are client-side (IDE/terminal/MCP) and are marked not_applicable. Only human-pinned MANUAL_TRIAGE high/critical entries become fix candidates.",
   "counts": {
-    "needs_review": 403,
-    "medium": 20,
-    "not_applicable": 1171,
-    "unknown_low_signal": 135
+    "needs_review": 440,
+    "medium": 24,
+    "not_applicable": 1330,
+    "unknown_low_signal": 176
   },
   "issues": [
     {
@@ -23,16 +23,40 @@
       "updated_at": "2026-06-01T17:46:05Z"
     },
     {
-      "upstream": "anthropics/claude-code#15542",
-      "url": "https://github.com/anthropics/claude-code/issues/15542",
-      "title": "[FEATURE] Enable Claude Code to access chat history in Claude App",
+      "upstream": "anthropics/claude-code#13585",
+      "url": "https://github.com/anthropics/claude-code/issues/13585",
+      "title": "Add Quota Information Access to Claude Code CLI",
       "impact": "needs_review",
       "categories": [
-        "auth_token"
+        "rate_limit"
       ],
       "tokenkey_status": "candidate_unverified",
       "rationale": "Gateway/relay-relevant keyword match; not yet manually verified against TokenKey code.",
-      "updated_at": "2026-05-31T17:58:47Z"
+      "updated_at": "2026-06-03T14:54:48Z"
+    },
+    {
+      "upstream": "anthropics/claude-code#17668",
+      "url": "https://github.com/anthropics/claude-code/issues/17668",
+      "title": "[Feature Request] MCP Context Isolation - Assign MCPs to Forked Agent/Skill Contexts",
+      "impact": "needs_review",
+      "categories": [
+        "fingerprint_ua"
+      ],
+      "tokenkey_status": "candidate_unverified",
+      "rationale": "Gateway/relay-relevant keyword match; not yet manually verified against TokenKey code.",
+      "updated_at": "2026-06-03T13:22:32Z"
+    },
+    {
+      "upstream": "anthropics/claude-code#18028",
+      "url": "https://github.com/anthropics/claude-code/issues/18028",
+      "title": "API Streaming Stalls Causing 59-138 Second Delays and Timeouts",
+      "impact": "needs_review",
+      "categories": [
+        "request_shape_400"
+      ],
+      "tokenkey_status": "candidate_unverified",
+      "rationale": "Gateway/relay-relevant keyword match; not yet manually verified against TokenKey code.",
+      "updated_at": "2026-06-03T22:45:59Z"
     },
     {
       "upstream": "anthropics/claude-code#20131",
@@ -60,6 +84,31 @@
       "updated_at": "2026-06-02T14:24:20Z"
     },
     {
+      "upstream": "anthropics/claude-code#20944",
+      "url": "https://github.com/anthropics/claude-code/issues/20944",
+      "title": "[FEATURE] - Add Setting to Disable Automatic IDE Selection Context",
+      "impact": "needs_review",
+      "categories": [
+        "request_shape_400"
+      ],
+      "tokenkey_status": "candidate_unverified",
+      "rationale": "Gateway/relay-relevant keyword match; not yet manually verified against TokenKey code.",
+      "updated_at": "2026-06-03T12:51:14Z"
+    },
+    {
+      "upstream": "anthropics/claude-code#22435",
+      "url": "https://github.com/anthropics/claude-code/issues/22435",
+      "title": "[BUG] Inconsistent and Undisclosed Quota Accounting Changes in Claude Max Plan. Legal liability claim ready.",
+      "impact": "needs_review",
+      "categories": [
+        "rate_limit",
+        "auth_token"
+      ],
+      "tokenkey_status": "candidate_unverified",
+      "rationale": "Gateway/relay-relevant keyword match; not yet manually verified against TokenKey code.",
+      "updated_at": "2026-06-04T12:42:05Z"
+    },
+    {
       "upstream": "anthropics/claude-code#25979",
       "url": "https://github.com/anthropics/claude-code/issues/25979",
       "title": "[BUG] Claude Code hangs indefinitely when API streaming connection stalls (no read timeout)",
@@ -72,6 +121,30 @@
       "updated_at": "2026-06-01T17:18:18Z"
     },
     {
+      "upstream": "anthropics/claude-code#26166",
+      "url": "https://github.com/anthropics/claude-code/issues/26166",
+      "title": "[DOCS] VS Code extension data storage path undocumented beyond uninstall cleanup",
+      "impact": "needs_review",
+      "categories": [
+        "auth_token"
+      ],
+      "tokenkey_status": "candidate_unverified",
+      "rationale": "Gateway/relay-relevant keyword match; not yet manually verified against TokenKey code.",
+      "updated_at": "2026-06-03T22:45:00Z"
+    },
+    {
+      "upstream": "anthropics/claude-code#26168",
+      "url": "https://github.com/anthropics/claude-code/issues/26168",
+      "title": "[DOCS] No centralized reference for all Claude Code files and directories on disk",
+      "impact": "needs_review",
+      "categories": [
+        "auth_token"
+      ],
+      "tokenkey_status": "candidate_unverified",
+      "rationale": "Gateway/relay-relevant keyword match; not yet manually verified against TokenKey code.",
+      "updated_at": "2026-06-03T11:40:20Z"
+    },
+    {
       "upstream": "anthropics/claude-code#26281",
       "url": "https://github.com/anthropics/claude-code/issues/26281",
       "title": "[BUG] MCP OAuth tokens without expires_in and refresh_token silently expires",
@@ -82,6 +155,18 @@
       "tokenkey_status": "candidate_unverified",
       "rationale": "Gateway/relay-relevant keyword match; not yet manually verified against TokenKey code.",
       "updated_at": "2026-06-02T22:52:59Z"
+    },
+    {
+      "upstream": "anthropics/claude-code#27027",
+      "url": "https://github.com/anthropics/claude-code/issues/27027",
+      "title": "[DOCS] `@` file-path docs missing guidance on corrected-path suggestions for missing repo-folder prefixes",
+      "impact": "needs_review",
+      "categories": [
+        "model_lifecycle"
+      ],
+      "tokenkey_status": "candidate_unverified",
+      "rationale": "Gateway/relay-relevant keyword match; not yet manually verified against TokenKey code.",
+      "updated_at": "2026-06-03T11:40:55Z"
     },
     {
       "upstream": "anthropics/claude-code#27263",
@@ -132,6 +217,18 @@
       "updated_at": "2026-06-02T15:01:21Z"
     },
     {
+      "upstream": "anthropics/claude-code#31422",
+      "url": "https://github.com/anthropics/claude-code/issues/31422",
+      "title": "[Cowork] User-created skills stored in ephemeral session dirs — silently deleted on cleanup",
+      "impact": "needs_review",
+      "categories": [
+        "prompt_caching"
+      ],
+      "tokenkey_status": "candidate_unverified",
+      "rationale": "Gateway/relay-relevant keyword match; not yet manually verified against TokenKey code.",
+      "updated_at": "2026-06-04T08:03:42Z"
+    },
+    {
       "upstream": "anthropics/claude-code#32982",
       "url": "https://github.com/anthropics/claude-code/issues/32982",
       "title": "[BUG] Remote Control sessions die after ~20 min idle — server TTL ignores keepalives",
@@ -145,6 +242,18 @@
       "updated_at": "2026-06-02T22:10:59Z"
     },
     {
+      "upstream": "anthropics/claude-code#33704",
+      "url": "https://github.com/anthropics/claude-code/issues/33704",
+      "title": "[DOCS] MCP OAuth docs omit re-authentication behavior after refresh token expiry",
+      "impact": "needs_review",
+      "categories": [
+        "auth_token"
+      ],
+      "tokenkey_status": "candidate_unverified",
+      "rationale": "Gateway/relay-relevant keyword match; not yet manually verified against TokenKey code.",
+      "updated_at": "2026-06-03T11:39:41Z"
+    },
+    {
       "upstream": "anthropics/claude-code#33978",
       "url": "https://github.com/anthropics/claude-code/issues/33978",
       "title": "[FEATURE] Built-in Usage Analytics Command (claude usage) — Consolidates 10+ Open Issues",
@@ -156,6 +265,18 @@
       "tokenkey_status": "candidate_unverified",
       "rationale": "Gateway/relay-relevant keyword match; not yet manually verified against TokenKey code.",
       "updated_at": "2026-06-01T17:48:58Z"
+    },
+    {
+      "upstream": "anthropics/claude-code#34277",
+      "url": "https://github.com/anthropics/claude-code/issues/34277",
+      "title": "[DOCS] Permissions docs missing Bash cmd: specifier syntax for permission rules",
+      "impact": "needs_review",
+      "categories": [
+        "model_lifecycle"
+      ],
+      "tokenkey_status": "candidate_unverified",
+      "rationale": "Gateway/relay-relevant keyword match; not yet manually verified against TokenKey code.",
+      "updated_at": "2026-06-03T11:39:49Z"
     },
     {
       "upstream": "anthropics/claude-code#34281",
@@ -218,6 +339,30 @@
       "updated_at": "2026-06-03T04:57:51Z"
     },
     {
+      "upstream": "anthropics/claude-code#38568",
+      "url": "https://github.com/anthropics/claude-code/issues/38568",
+      "title": "[DOCS] Document that WebFetch identifies as `Claude-User` so site operators can allow or block it via `robots.txt`",
+      "impact": "needs_review",
+      "categories": [
+        "fingerprint_ua"
+      ],
+      "tokenkey_status": "candidate_unverified",
+      "rationale": "Gateway/relay-relevant keyword match; not yet manually verified against TokenKey code.",
+      "updated_at": "2026-06-03T11:40:42Z"
+    },
+    {
+      "upstream": "anthropics/claude-code#38618",
+      "url": "https://github.com/anthropics/claude-code/issues/38618",
+      "title": "[Bug] Anthropic API Error: Safety Classifier Unavailable - Auto Mode Blocked for Tool Execution",
+      "impact": "needs_review",
+      "categories": [
+        "model_lifecycle"
+      ],
+      "tokenkey_status": "candidate_unverified",
+      "rationale": "Gateway/relay-relevant keyword match; not yet manually verified against TokenKey code.",
+      "updated_at": "2026-06-04T05:17:38Z"
+    },
+    {
       "upstream": "anthropics/claude-code#38896",
       "url": "https://github.com/anthropics/claude-code/issues/38896",
       "title": "[Bug] API Error: Rate limit reached despite 0% usage",
@@ -242,6 +387,18 @@
       "updated_at": "2026-06-02T08:13:03Z"
     },
     {
+      "upstream": "anthropics/claude-code#39610",
+      "url": "https://github.com/anthropics/claude-code/issues/39610",
+      "title": "[DOCS] MCP `headersHelper` docs missing per-server `CLAUDE_CODE_MCP_SERVER_NAME` and `CLAUDE_CODE_MCP_SERVER_URL` variables",
+      "impact": "needs_review",
+      "categories": [
+        "auth_token"
+      ],
+      "tokenkey_status": "candidate_unverified",
+      "rationale": "Gateway/relay-relevant keyword match; not yet manually verified against TokenKey code.",
+      "updated_at": "2026-06-03T11:40:40Z"
+    },
+    {
       "upstream": "anthropics/claude-code#40769",
       "url": "https://github.com/anthropics/claude-code/issues/40769",
       "title": "[BUG] Cloud scheduled tasks: gRPC/HTTP2 blocked by sandbox TLS proxy to googleapis.com",
@@ -254,6 +411,67 @@
       "updated_at": "2026-06-02T22:44:27Z"
     },
     {
+      "upstream": "anthropics/claude-code#41788",
+      "url": "https://github.com/anthropics/claude-code/issues/41788",
+      "title": "Max 20 plan: rate limit 100% exhausted within ~70 minutes after reset (never happened before v2.1.89)",
+      "impact": "needs_review",
+      "categories": [
+        "rate_limit",
+        "prompt_caching"
+      ],
+      "tokenkey_status": "candidate_unverified",
+      "rationale": "Gateway/relay-relevant keyword match; not yet manually verified against TokenKey code.",
+      "updated_at": "2026-06-03T19:44:22Z"
+    },
+    {
+      "upstream": "anthropics/claude-code#41795",
+      "url": "https://github.com/anthropics/claude-code/issues/41795",
+      "title": "[DOCS] MCP docs omit multi-block error content guidance for server authors",
+      "impact": "needs_review",
+      "categories": [
+        "request_shape_400"
+      ],
+      "tokenkey_status": "candidate_unverified",
+      "rationale": "Gateway/relay-relevant keyword match; not yet manually verified against TokenKey code.",
+      "updated_at": "2026-06-03T11:40:54Z"
+    },
+    {
+      "upstream": "anthropics/claude-code#42309",
+      "url": "https://github.com/anthropics/claude-code/issues/42309",
+      "title": "[DOCS] `--resume` prompt cache behavior with deferred tools, MCP servers, and custom agents is undocumented",
+      "impact": "needs_review",
+      "categories": [
+        "prompt_caching"
+      ],
+      "tokenkey_status": "candidate_unverified",
+      "rationale": "Gateway/relay-relevant keyword match; not yet manually verified against TokenKey code.",
+      "updated_at": "2026-06-04T11:06:42Z"
+    },
+    {
+      "upstream": "anthropics/claude-code#42316",
+      "url": "https://github.com/anthropics/claude-code/issues/42316",
+      "title": "[DOCS] Rate-limit options dialog is undocumented",
+      "impact": "needs_review",
+      "categories": [
+        "rate_limit"
+      ],
+      "tokenkey_status": "candidate_unverified",
+      "rationale": "Gateway/relay-relevant keyword match; not yet manually verified against TokenKey code.",
+      "updated_at": "2026-06-03T11:40:45Z"
+    },
+    {
+      "upstream": "anthropics/claude-code#42705",
+      "url": "https://github.com/anthropics/claude-code/issues/42705",
+      "title": "[BUG] WMI Corrupted by thread killing at Rate-Limit being hit",
+      "impact": "needs_review",
+      "categories": [
+        "rate_limit"
+      ],
+      "tokenkey_status": "candidate_unverified",
+      "rationale": "Gateway/relay-relevant keyword match; not yet manually verified against TokenKey code.",
+      "updated_at": "2026-06-04T11:07:06Z"
+    },
+    {
       "upstream": "anthropics/claude-code#42850",
       "url": "https://github.com/anthropics/claude-code/issues/42850",
       "title": "[BUG] Remote Control returns \"disabled by your organization's policy\" on Team plan despite admin toggle being ON",
@@ -264,6 +482,19 @@
       "tokenkey_status": "candidate_unverified",
       "rationale": "Gateway/relay-relevant keyword match; not yet manually verified against TokenKey code.",
       "updated_at": "2026-06-01T22:45:44Z"
+    },
+    {
+      "upstream": "anthropics/claude-code#42873",
+      "url": "https://github.com/anthropics/claude-code/issues/42873",
+      "title": "[DOCS] `/claude-api` skill docs omit agent design guidance topics",
+      "impact": "needs_review",
+      "categories": [
+        "prompt_caching",
+        "new_endpoints"
+      ],
+      "tokenkey_status": "candidate_unverified",
+      "rationale": "Gateway/relay-relevant keyword match; not yet manually verified against TokenKey code.",
+      "updated_at": "2026-06-04T02:42:58Z"
     },
     {
       "upstream": "anthropics/claude-code#43000",
@@ -279,28 +510,29 @@
       "updated_at": "2026-06-02T22:53:42Z"
     },
     {
-      "upstream": "anthropics/claude-code#44101",
-      "url": "https://github.com/anthropics/claude-code/issues/44101",
-      "title": "Auto mode cannot be enabled via UI despite meeting all requirements (Team plan, Sonnet 4.6, admin enabled)",
+      "upstream": "anthropics/claude-code#43363",
+      "url": "https://github.com/anthropics/claude-code/issues/43363",
+      "title": "[DOCS] Resume previous conversations docs missing prompt-cache expiry uncached-token hint",
       "impact": "needs_review",
       "categories": [
-        "model_lifecycle"
+        "auth_token",
+        "prompt_caching"
       ],
       "tokenkey_status": "candidate_unverified",
       "rationale": "Gateway/relay-relevant keyword match; not yet manually verified against TokenKey code.",
-      "updated_at": "2026-06-01T12:02:16Z"
+      "updated_at": "2026-06-04T11:06:39Z"
     },
     {
-      "upstream": "anthropics/claude-code#44778",
-      "url": "https://github.com/anthropics/claude-code/issues/44778",
-      "title": "[Bug] System events delivered as user-role messages cause model to fabricate user consent and act on it",
+      "upstream": "anthropics/claude-code#44243",
+      "url": "https://github.com/anthropics/claude-code/issues/44243",
+      "title": "Feature request: Support multiple Slack workspaces in the built-in Slack connector",
       "impact": "needs_review",
       "categories": [
         "auth_token"
       ],
       "tokenkey_status": "candidate_unverified",
       "rationale": "Gateway/relay-relevant keyword match; not yet manually verified against TokenKey code.",
-      "updated_at": "2026-06-01T01:20:04Z"
+      "updated_at": "2026-06-03T13:14:01Z"
     },
     {
       "upstream": "anthropics/claude-code#44805",
@@ -314,19 +546,6 @@
       "tokenkey_status": "candidate_unverified",
       "rationale": "Gateway/relay-relevant keyword match; not yet manually verified against TokenKey code.",
       "updated_at": "2026-06-01T21:12:50Z"
-    },
-    {
-      "upstream": "anthropics/claude-code#44980",
-      "url": "https://github.com/anthropics/claude-code/issues/44980",
-      "title": "[SECURITY] Claude Teams: Custom MCP connectors expose shared credentials to all team members — no per-user scoping",
-      "impact": "needs_review",
-      "categories": [
-        "auth_token",
-        "fingerprint_ua"
-      ],
-      "tokenkey_status": "candidate_unverified",
-      "rationale": "Gateway/relay-relevant keyword match; not yet manually verified against TokenKey code.",
-      "updated_at": "2026-06-01T12:02:04Z"
     },
     {
       "upstream": "anthropics/claude-code#45729",
@@ -351,6 +570,19 @@
       "tokenkey_status": "candidate_unverified",
       "rationale": "Gateway/relay-relevant keyword match; not yet manually verified against TokenKey code.",
       "updated_at": "2026-06-02T22:44:48Z"
+    },
+    {
+      "upstream": "anthropics/claude-code#46640",
+      "url": "https://github.com/anthropics/claude-code/issues/46640",
+      "title": "[BUG] HTTP MCP server without auth triggers OAuth probe in VS Code extension, fails with 404",
+      "impact": "needs_review",
+      "categories": [
+        "auth_token",
+        "model_lifecycle"
+      ],
+      "tokenkey_status": "candidate_unverified",
+      "rationale": "Gateway/relay-relevant keyword match; not yet manually verified against TokenKey code.",
+      "updated_at": "2026-06-03T22:45:48Z"
     },
     {
       "upstream": "anthropics/claude-code#46846",
@@ -392,6 +624,18 @@
       "updated_at": "2026-06-01T22:45:59Z"
     },
     {
+      "upstream": "anthropics/claude-code#47971",
+      "url": "https://github.com/anthropics/claude-code/issues/47971",
+      "title": "[BUG] Cowork VM timeout on Windows 11 Home Build 26200 — all prerequisites met",
+      "impact": "needs_review",
+      "categories": [
+        "model_lifecycle"
+      ],
+      "tokenkey_status": "candidate_unverified",
+      "rationale": "Gateway/relay-relevant keyword match; not yet manually verified against TokenKey code.",
+      "updated_at": "2026-06-04T11:07:30Z"
+    },
+    {
       "upstream": "anthropics/claude-code#48011",
       "url": "https://github.com/anthropics/claude-code/issues/48011",
       "title": "[FEATURE] Make OAuth/admin base URL configurable like ANTHROPIC_BASE_URL",
@@ -414,7 +658,7 @@
       ],
       "tokenkey_status": "candidate_unverified",
       "rationale": "Gateway/relay-relevant keyword match; not yet manually verified against TokenKey code.",
-      "updated_at": "2026-06-03T08:00:56Z"
+      "updated_at": "2026-06-04T00:25:46Z"
     },
     {
       "upstream": "anthropics/claude-code#48806",
@@ -467,6 +711,30 @@
       "updated_at": "2026-06-02T21:03:51Z"
     },
     {
+      "upstream": "anthropics/claude-code#49289",
+      "url": "https://github.com/anthropics/claude-code/issues/49289",
+      "title": "[DOCS] Commands reference missing `/less-permission-prompts` bundled skill",
+      "impact": "needs_review",
+      "categories": [
+        "new_endpoints"
+      ],
+      "tokenkey_status": "candidate_unverified",
+      "rationale": "Gateway/relay-relevant keyword match; not yet manually verified against TokenKey code.",
+      "updated_at": "2026-06-03T22:44:52Z"
+    },
+    {
+      "upstream": "anthropics/claude-code#49312",
+      "url": "https://github.com/anthropics/claude-code/issues/49312",
+      "title": "[DOCS] Third-party provider docs missing 429 troubleshooting guidance for Bedrock, Vertex, and Foundry",
+      "impact": "needs_review",
+      "categories": [
+        "rate_limit"
+      ],
+      "tokenkey_status": "candidate_unverified",
+      "rationale": "Gateway/relay-relevant keyword match; not yet manually verified against TokenKey code.",
+      "updated_at": "2026-06-03T22:44:53Z"
+    },
+    {
       "upstream": "anthropics/claude-code#49322",
       "url": "https://github.com/anthropics/claude-code/issues/49322",
       "title": "[BUG] Opus 4.7 thinking summaries not rendered in VS Code extension",
@@ -501,6 +769,31 @@
       "tokenkey_status": "candidate_unverified",
       "rationale": "Gateway/relay-relevant keyword match; not yet manually verified against TokenKey code.",
       "updated_at": "2026-06-02T08:51:37Z"
+    },
+    {
+      "upstream": "anthropics/claude-code#50123",
+      "url": "https://github.com/anthropics/claude-code/issues/50123",
+      "title": "[DOCS] Remote Control docs missing `/extra-usage` support for mobile/web clients",
+      "impact": "needs_review",
+      "categories": [
+        "rate_limit"
+      ],
+      "tokenkey_status": "candidate_unverified",
+      "rationale": "Gateway/relay-relevant keyword match; not yet manually verified against TokenKey code.",
+      "updated_at": "2026-06-03T22:44:57Z"
+    },
+    {
+      "upstream": "anthropics/claude-code#50141",
+      "url": "https://github.com/anthropics/claude-code/issues/50141",
+      "title": "[DOCS] Environment variables reference missing `CLAUDE_CODE_EXTRA_BODY` request-body override documentation",
+      "impact": "needs_review",
+      "categories": [
+        "beta_header_drift",
+        "request_shape_400"
+      ],
+      "tokenkey_status": "candidate_unverified",
+      "rationale": "Gateway/relay-relevant keyword match; not yet manually verified against TokenKey code.",
+      "updated_at": "2026-06-03T11:39:43Z"
     },
     {
       "upstream": "anthropics/claude-code#50486",
@@ -541,6 +834,30 @@
       "updated_at": "2026-06-02T22:44:45Z"
     },
     {
+      "upstream": "anthropics/claude-code#50719",
+      "url": "https://github.com/anthropics/claude-code/issues/50719",
+      "title": "[BUG] Computer Use: all clicks blocked by Dock layer-20 hit-test surface on macOS 26.4/26.4.1 (regression from pre-26.4)",
+      "impact": "needs_review",
+      "categories": [
+        "request_shape_400"
+      ],
+      "tokenkey_status": "candidate_unverified",
+      "rationale": "Gateway/relay-relevant keyword match; not yet manually verified against TokenKey code.",
+      "updated_at": "2026-06-03T22:45:30Z"
+    },
+    {
+      "upstream": "anthropics/claude-code#50982",
+      "url": "https://github.com/anthropics/claude-code/issues/50982",
+      "title": "Desktop (Windows): remote SSH session loses UI message history after reboot",
+      "impact": "needs_review",
+      "categories": [
+        "request_shape_400"
+      ],
+      "tokenkey_status": "candidate_unverified",
+      "rationale": "Gateway/relay-relevant keyword match; not yet manually verified against TokenKey code.",
+      "updated_at": "2026-06-04T09:21:09Z"
+    },
+    {
       "upstream": "anthropics/claude-code#50994",
       "url": "https://github.com/anthropics/claude-code/issues/50994",
       "title": "[BUG] Billing between claude.ai and claud code is confusing.",
@@ -554,42 +871,57 @@
       "updated_at": "2026-06-02T11:32:18Z"
     },
     {
-      "upstream": "anthropics/claude-code#51096",
-      "url": "https://github.com/anthropics/claude-code/issues/51096",
-      "title": "[BUG] Unable to specify AWS eu-central-1 as a region when using a Bedrock API key",
+      "upstream": "anthropics/claude-code#51164",
+      "url": "https://github.com/anthropics/claude-code/issues/51164",
+      "title": "[BUG] Persistent mid-stream ECONNRESET on large-context sessions (v1/messages?beta=true)",
       "impact": "needs_review",
       "categories": [
-        "auth_token"
+        "beta_header_drift",
+        "request_shape_400",
+        "rate_limit",
+        "auth_token",
+        "model_lifecycle",
+        "fingerprint_ua"
       ],
       "tokenkey_status": "candidate_unverified",
       "rationale": "Gateway/relay-relevant keyword match; not yet manually verified against TokenKey code.",
-      "updated_at": "2026-06-01T12:02:18Z"
+      "updated_at": "2026-06-03T22:45:44Z"
     },
     {
-      "upstream": "anthropics/claude-code#51267",
-      "url": "https://github.com/anthropics/claude-code/issues/51267",
-      "title": "[BUG] Remote Control (mobile): session silently hangs mid-execution; only local Esc recovers it — no remote unstick mechanism",
+      "upstream": "anthropics/claude-code#51312",
+      "url": "https://github.com/anthropics/claude-code/issues/51312",
+      "title": "[BUG] Preview server cannot read files from ~/Desktop on macOS despite Full Disk Access",
       "impact": "needs_review",
       "categories": [
-        "request_shape_400",
+        "model_lifecycle"
+      ],
+      "tokenkey_status": "candidate_unverified",
+      "rationale": "Gateway/relay-relevant keyword match; not yet manually verified against TokenKey code.",
+      "updated_at": "2026-06-03T18:44:29Z"
+    },
+    {
+      "upstream": "anthropics/claude-code#51371",
+      "url": "https://github.com/anthropics/claude-code/issues/51371",
+      "title": "[DOCS] Bash tool docs missing `gh` GitHub API rate-limit hint behavior",
+      "impact": "needs_review",
+      "categories": [
         "rate_limit"
       ],
       "tokenkey_status": "candidate_unverified",
       "rationale": "Gateway/relay-relevant keyword match; not yet manually verified against TokenKey code.",
-      "updated_at": "2026-05-31T19:43:12Z"
+      "updated_at": "2026-06-03T11:40:04Z"
     },
     {
-      "upstream": "anthropics/claude-code#51398",
-      "url": "https://github.com/anthropics/claude-code/issues/51398",
-      "title": "Cowork Desktop: ${CLAUDE_PLUGIN_DATA} is not persistent across conversations (MCP plugin tokens lost on every new conversation)",
+      "upstream": "anthropics/claude-code#51784",
+      "url": "https://github.com/anthropics/claude-code/issues/51784",
+      "title": "[DOCS] Authentication docs missing recovery guidance for expired `CLAUDE_CODE_OAUTH_TOKEN`",
       "impact": "needs_review",
       "categories": [
-        "request_shape_400",
         "auth_token"
       ],
       "tokenkey_status": "candidate_unverified",
       "rationale": "Gateway/relay-relevant keyword match; not yet manually verified against TokenKey code.",
-      "updated_at": "2026-06-01T08:23:34Z"
+      "updated_at": "2026-06-03T11:40:09Z"
     },
     {
       "upstream": "anthropics/claude-code#51798",
@@ -601,7 +933,7 @@
       ],
       "tokenkey_status": "candidate_unverified",
       "rationale": "Gateway/relay-relevant keyword match; not yet manually verified against TokenKey code.",
-      "updated_at": "2026-06-01T03:40:02Z"
+      "updated_at": "2026-06-03T12:43:45Z"
     },
     {
       "upstream": "anthropics/claude-code#51802",
@@ -637,7 +969,7 @@
       ],
       "tokenkey_status": "candidate_unverified",
       "rationale": "Gateway/relay-relevant keyword match; not yet manually verified against TokenKey code.",
-      "updated_at": "2026-06-03T00:26:58Z"
+      "updated_at": "2026-06-04T06:40:20Z"
     },
     {
       "upstream": "anthropics/claude-code#52135",
@@ -652,16 +984,40 @@
       "updated_at": "2026-06-01T22:46:16Z"
     },
     {
-      "upstream": "anthropics/claude-code#52482",
-      "url": "https://github.com/anthropics/claude-code/issues/52482",
-      "title": "[BUG] Model drifts full-width CJK punctuation to half-width in Edit's old_string, causing silent \"String to replace not found\"",
+      "upstream": "anthropics/claude-code#52200",
+      "url": "https://github.com/anthropics/claude-code/issues/52200",
+      "title": "[DOCS] MCP docs don't explain `/mcp` reconnect flow for `headersHelper` and custom-header auth recovery",
       "impact": "needs_review",
       "categories": [
-        "model_lifecycle"
+        "auth_token"
       ],
       "tokenkey_status": "candidate_unverified",
       "rationale": "Gateway/relay-relevant keyword match; not yet manually verified against TokenKey code.",
-      "updated_at": "2026-06-01T13:09:20Z"
+      "updated_at": "2026-06-03T11:40:13Z"
+    },
+    {
+      "upstream": "anthropics/claude-code#52202",
+      "url": "https://github.com/anthropics/claude-code/issues/52202",
+      "title": "[DOCS] Authentication docs omit OAuth refresh behavior when the server revokes a token early",
+      "impact": "needs_review",
+      "categories": [
+        "auth_token"
+      ],
+      "tokenkey_status": "candidate_unverified",
+      "rationale": "Gateway/relay-relevant keyword match; not yet manually verified against TokenKey code.",
+      "updated_at": "2026-06-03T11:40:12Z"
+    },
+    {
+      "upstream": "anthropics/claude-code#52203",
+      "url": "https://github.com/anthropics/claude-code/issues/52203",
+      "title": "[DOCS] Authentication docs omit `/login` behavior when `CLAUDE_CODE_OAUTH_TOKEN` is set",
+      "impact": "needs_review",
+      "categories": [
+        "auth_token"
+      ],
+      "tokenkey_status": "candidate_unverified",
+      "rationale": "Gateway/relay-relevant keyword match; not yet manually verified against TokenKey code.",
+      "updated_at": "2026-06-03T11:40:31Z"
     },
     {
       "upstream": "anthropics/claude-code#52492",
@@ -676,16 +1032,40 @@
       "updated_at": "2026-06-03T10:15:56Z"
     },
     {
-      "upstream": "anthropics/claude-code#52765",
-      "url": "https://github.com/anthropics/claude-code/issues/52765",
-      "title": "[BUG] Server is busy Claude cowork desktop error",
+      "upstream": "anthropics/claude-code#52601",
+      "url": "https://github.com/anthropics/claude-code/issues/52601",
+      "title": "[DOCS] Settings docs still place `/config` preferences in `~/.claude.json` instead of `~/.claude/settings.json`",
       "impact": "needs_review",
       "categories": [
         "auth_token"
       ],
       "tokenkey_status": "candidate_unverified",
       "rationale": "Gateway/relay-relevant keyword match; not yet manually verified against TokenKey code.",
-      "updated_at": "2026-06-01T04:38:13Z"
+      "updated_at": "2026-06-03T22:45:01Z"
+    },
+    {
+      "upstream": "anthropics/claude-code#52620",
+      "url": "https://github.com/anthropics/claude-code/issues/52620",
+      "title": "[DOCS] MCP OAuth docs omit `client_secret_post` support for pre-configured credentials",
+      "impact": "needs_review",
+      "categories": [
+        "auth_token"
+      ],
+      "tokenkey_status": "candidate_unverified",
+      "rationale": "Gateway/relay-relevant keyword match; not yet manually verified against TokenKey code.",
+      "updated_at": "2026-06-03T11:40:26Z"
+    },
+    {
+      "upstream": "anthropics/claude-code#52626",
+      "url": "https://github.com/anthropics/claude-code/issues/52626",
+      "title": "[DOCS] `/status` docs omit MCP server state reporting and disabled status",
+      "impact": "needs_review",
+      "categories": [
+        "auth_token"
+      ],
+      "tokenkey_status": "candidate_unverified",
+      "rationale": "Gateway/relay-relevant keyword match; not yet manually verified against TokenKey code.",
+      "updated_at": "2026-06-03T11:40:32Z"
     },
     {
       "upstream": "anthropics/claude-code#52871",
@@ -697,19 +1077,19 @@
       ],
       "tokenkey_status": "candidate_unverified",
       "rationale": "Gateway/relay-relevant keyword match; not yet manually verified against TokenKey code.",
-      "updated_at": "2026-06-02T11:56:19Z"
+      "updated_at": "2026-06-03T21:15:41Z"
     },
     {
-      "upstream": "anthropics/claude-code#53610",
-      "url": "https://github.com/anthropics/claude-code/issues/53610",
-      "title": "[Feature] Multi-agent runtime needs mechanical enforcement: 9 gaps that defeat unattended overnight operation",
+      "upstream": "anthropics/claude-code#53513",
+      "url": "https://github.com/anthropics/claude-code/issues/53513",
+      "title": "[FEATURE] Add opt-out config for thinking block clearing on idle session resume",
       "impact": "needs_review",
       "categories": [
         "prompt_caching"
       ],
       "tokenkey_status": "candidate_unverified",
       "rationale": "Gateway/relay-relevant keyword match; not yet manually verified against TokenKey code.",
-      "updated_at": "2026-06-01T12:03:30Z"
+      "updated_at": "2026-06-03T22:45:52Z"
     },
     {
       "upstream": "anthropics/claude-code#53648",
@@ -750,28 +1130,29 @@
       "updated_at": "2026-06-02T01:51:54Z"
     },
     {
-      "upstream": "anthropics/claude-code#54018",
-      "url": "https://github.com/anthropics/claude-code/issues/54018",
-      "title": "[BUG] Async subagent loops are silently dropped when the parent has concurrent activity",
+      "upstream": "anthropics/claude-code#53983",
+      "url": "https://github.com/anthropics/claude-code/issues/53983",
+      "title": "Claude systematically claims migration/porting tasks complete when critical logic is dormant or missing",
       "impact": "needs_review",
       "categories": [
-        "request_shape_400"
+        "request_shape_400",
+        "rate_limit"
       ],
       "tokenkey_status": "candidate_unverified",
       "rationale": "Gateway/relay-relevant keyword match; not yet manually verified against TokenKey code.",
-      "updated_at": "2026-06-01T12:03:32Z"
+      "updated_at": "2026-06-04T11:07:10Z"
     },
     {
-      "upstream": "anthropics/claude-code#54225",
-      "url": "https://github.com/anthropics/claude-code/issues/54225",
-      "title": "[BUG] Sharing picture without text in Claude Code via Windows App causes session to stall permanently",
+      "upstream": "anthropics/claude-code#54171",
+      "url": "https://github.com/anthropics/claude-code/issues/54171",
+      "title": "[DOCS] Agent SDK MCP docs omit `mcp_authenticate` `redirectUri` usage for custom schemes and Claude.ai connectors",
       "impact": "needs_review",
       "categories": [
-        "request_shape_400"
+        "auth_token"
       ],
       "tokenkey_status": "candidate_unverified",
       "rationale": "Gateway/relay-relevant keyword match; not yet manually verified against TokenKey code.",
-      "updated_at": "2026-06-01T12:02:05Z"
+      "updated_at": "2026-06-03T11:40:00Z"
     },
     {
       "upstream": "anthropics/claude-code#54393",
@@ -783,7 +1164,7 @@
       ],
       "tokenkey_status": "candidate_unverified",
       "rationale": "Gateway/relay-relevant keyword match; not yet manually verified against TokenKey code.",
-      "updated_at": "2026-06-02T22:03:47Z"
+      "updated_at": "2026-06-03T21:32:01Z"
     },
     {
       "upstream": "anthropics/claude-code#54434",
@@ -800,17 +1181,16 @@
       "updated_at": "2026-06-01T17:18:17Z"
     },
     {
-      "upstream": "anthropics/claude-code#54443",
-      "url": "https://github.com/anthropics/claude-code/issues/54443",
-      "title": "[BUG] OAuth refresh returns 400 after early 401 before local expiresAt; concurrent sessions forced to /login",
+      "upstream": "anthropics/claude-code#54471",
+      "url": "https://github.com/anthropics/claude-code/issues/54471",
+      "title": "[DOCS] OpenTelemetry monitoring docs do not document numeric `api_request` / `api_error` attribute types",
       "impact": "needs_review",
       "categories": [
-        "request_shape_400",
-        "auth_token"
+        "prompt_caching"
       ],
       "tokenkey_status": "candidate_unverified",
       "rationale": "Gateway/relay-relevant keyword match; not yet manually verified against TokenKey code.",
-      "updated_at": "2026-06-01T11:05:04Z"
+      "updated_at": "2026-06-03T11:40:56Z"
     },
     {
       "upstream": "anthropics/claude-code#54588",
@@ -849,6 +1229,21 @@
       "updated_at": "2026-06-02T22:44:29Z"
     },
     {
+      "upstream": "anthropics/claude-code#54682",
+      "url": "https://github.com/anthropics/claude-code/issues/54682",
+      "title": "Opus 4.7 in autonomous mode: registers placeholder as completed, claims unverified deploys, fails to close — catastrophic for production work",
+      "impact": "needs_review",
+      "categories": [
+        "request_shape_400",
+        "model_lifecycle",
+        "prompt_caching",
+        "fingerprint_ua"
+      ],
+      "tokenkey_status": "candidate_unverified",
+      "rationale": "Gateway/relay-relevant keyword match; not yet manually verified against TokenKey code.",
+      "updated_at": "2026-06-04T11:07:08Z"
+    },
+    {
       "upstream": "anthropics/claude-code#54817",
       "url": "https://github.com/anthropics/claude-code/issues/54817",
       "title": "[Bug] Claude Code 4.7 regression: degraded reasoning and project context loss",
@@ -859,18 +1254,6 @@
       "tokenkey_status": "candidate_unverified",
       "rationale": "Gateway/relay-relevant keyword match; not yet manually verified against TokenKey code.",
       "updated_at": "2026-06-02T22:44:10Z"
-    },
-    {
-      "upstream": "anthropics/claude-code#55021",
-      "url": "https://github.com/anthropics/claude-code/issues/55021",
-      "title": "Microsoft 365 MCP connector shows 'Needs Auth' in VS Code despite being connected in desktop app",
-      "impact": "needs_review",
-      "categories": [
-        "auth_token"
-      ],
-      "tokenkey_status": "candidate_unverified",
-      "rationale": "Gateway/relay-relevant keyword match; not yet manually verified against TokenKey code.",
-      "updated_at": "2026-06-01T12:02:01Z"
     },
     {
       "upstream": "anthropics/claude-code#55051",
@@ -897,6 +1280,43 @@
       "updated_at": "2026-06-01T22:45:57Z"
     },
     {
+      "upstream": "anthropics/claude-code#55192",
+      "url": "https://github.com/anthropics/claude-code/issues/55192",
+      "title": "[DOCS] Image too large error docs still say pasted images remain in history and require manual removal",
+      "impact": "needs_review",
+      "categories": [
+        "request_shape_400"
+      ],
+      "tokenkey_status": "candidate_unverified",
+      "rationale": "Gateway/relay-relevant keyword match; not yet manually verified against TokenKey code.",
+      "updated_at": "2026-06-03T22:45:00Z"
+    },
+    {
+      "upstream": "anthropics/claude-code#55193",
+      "url": "https://github.com/anthropics/claude-code/issues/55193",
+      "title": "[DOCS] Login troubleshooting page missing \"OAuth not allowed for organization\" guidance",
+      "impact": "needs_review",
+      "categories": [
+        "auth_token",
+        "fingerprint_ua"
+      ],
+      "tokenkey_status": "candidate_unverified",
+      "rationale": "Gateway/relay-relevant keyword match; not yet manually verified against TokenKey code.",
+      "updated_at": "2026-06-03T22:45:04Z"
+    },
+    {
+      "upstream": "anthropics/claude-code#55194",
+      "url": "https://github.com/anthropics/claude-code/issues/55194",
+      "title": "[DOCS] OAuth login troubleshooting missing timeout guidance for slow, proxied, and IPv6-only environments",
+      "impact": "needs_review",
+      "categories": [
+        "auth_token"
+      ],
+      "tokenkey_status": "candidate_unverified",
+      "rationale": "Gateway/relay-relevant keyword match; not yet manually verified against TokenKey code.",
+      "updated_at": "2026-06-04T11:06:40Z"
+    },
+    {
       "upstream": "anthropics/claude-code#55455",
       "url": "https://github.com/anthropics/claude-code/issues/55455",
       "title": "[BUG] Token drift in parallel Write tool calls: repeated path prefix produces real-word substitution (\"shane\" → \"seine\")",
@@ -907,6 +1327,18 @@
       "tokenkey_status": "candidate_unverified",
       "rationale": "Gateway/relay-relevant keyword match; not yet manually verified against TokenKey code.",
       "updated_at": "2026-06-01T22:45:16Z"
+    },
+    {
+      "upstream": "anthropics/claude-code#55465",
+      "url": "https://github.com/anthropics/claude-code/issues/55465",
+      "title": "[BUG] Claude Desktop for Windows — MSIX Installs Successfully but App Cannot Launch (Entry Point Missing / Broken)",
+      "impact": "needs_review",
+      "categories": [
+        "model_lifecycle"
+      ],
+      "tokenkey_status": "candidate_unverified",
+      "rationale": "Gateway/relay-relevant keyword match; not yet manually verified against TokenKey code.",
+      "updated_at": "2026-06-03T22:45:57Z"
     },
     {
       "upstream": "anthropics/claude-code#55598",
@@ -921,16 +1353,16 @@
       "updated_at": "2026-06-01T22:46:13Z"
     },
     {
-      "upstream": "anthropics/claude-code#55910",
-      "url": "https://github.com/anthropics/claude-code/issues/55910",
-      "title": "API content filter blocks Contributor Covenant 2.1 verbatim output",
+      "upstream": "anthropics/claude-code#55879",
+      "url": "https://github.com/anthropics/claude-code/issues/55879",
+      "title": "[BUG] Claude Desktop blank screen on Windows + Cowork unusable + sandbox API errors — Max subscriber, 9-day outage",
       "impact": "needs_review",
       "categories": [
         "request_shape_400"
       ],
       "tokenkey_status": "candidate_unverified",
       "rationale": "Gateway/relay-relevant keyword match; not yet manually verified against TokenKey code.",
-      "updated_at": "2026-06-01T12:02:31Z"
+      "updated_at": "2026-06-04T11:07:36Z"
     },
     {
       "upstream": "anthropics/claude-code#55954",
@@ -971,20 +1403,6 @@
       "updated_at": "2026-06-02T11:32:29Z"
     },
     {
-      "upstream": "anthropics/claude-code#56075",
-      "url": "https://github.com/anthropics/claude-code/issues/56075",
-      "title": "[BUG] Single README.md edit burns entire 5-hour Max 5x window in 9m 39s (Opus 4.7 1M, resumed session, v2.1.126, JetBrains, Windows)",
-      "impact": "needs_review",
-      "categories": [
-        "rate_limit",
-        "model_lifecycle",
-        "prompt_caching"
-      ],
-      "tokenkey_status": "candidate_unverified",
-      "rationale": "Gateway/relay-relevant keyword match; not yet manually verified against TokenKey code.",
-      "updated_at": "2026-05-31T22:11:19Z"
-    },
-    {
       "upstream": "anthropics/claude-code#56356",
       "url": "https://github.com/anthropics/claude-code/issues/56356",
       "title": "Opus 4.7 returns no thinking blocks even with --thinking adaptive --thinking-display summarized",
@@ -995,7 +1413,7 @@
       ],
       "tokenkey_status": "candidate_unverified",
       "rationale": "Gateway/relay-relevant keyword match; not yet manually verified against TokenKey code.",
-      "updated_at": "2026-06-01T15:17:33Z"
+      "updated_at": "2026-06-04T04:32:07Z"
     },
     {
       "upstream": "anthropics/claude-code#56633",
@@ -1010,41 +1428,28 @@
       "updated_at": "2026-06-02T23:22:34Z"
     },
     {
-      "upstream": "anthropics/claude-code#56872",
-      "url": "https://github.com/anthropics/claude-code/issues/56872",
-      "title": "MCP server \"ide\" connection fails immediately on startup - IntelliJ IDEA plugin 0.1.14-beta",
+      "upstream": "anthropics/claude-code#56829",
+      "url": "https://github.com/anthropics/claude-code/issues/56829",
+      "title": "[BUG] Multiple system-reminder Blocks Cause Model to Drop User Message on AWS Bedrock",
       "impact": "needs_review",
       "categories": [
-        "request_shape_400"
+        "model_lifecycle"
       ],
       "tokenkey_status": "candidate_unverified",
       "rationale": "Gateway/relay-relevant keyword match; not yet manually verified against TokenKey code.",
-      "updated_at": "2026-06-01T10:50:11Z"
+      "updated_at": "2026-06-03T17:50:46Z"
     },
     {
-      "upstream": "anthropics/claude-code#56978",
-      "url": "https://github.com/anthropics/claude-code/issues/56978",
-      "title": "Graceful handling when hitting usage limits mid-session",
+      "upstream": "anthropics/claude-code#56843",
+      "url": "https://github.com/anthropics/claude-code/issues/56843",
+      "title": "Add sandbox mode/status to statusline data fields",
       "impact": "needs_review",
       "categories": [
         "rate_limit"
       ],
       "tokenkey_status": "candidate_unverified",
       "rationale": "Gateway/relay-relevant keyword match; not yet manually verified against TokenKey code.",
-      "updated_at": "2026-06-01T05:37:07Z"
-    },
-    {
-      "upstream": "anthropics/claude-code#56984",
-      "url": "https://github.com/anthropics/claude-code/issues/56984",
-      "title": "[BUG] CLAUDE_CODE_EXTRA_BODY thinking config breaks WebSearch and WebFetch on Opus 4.7 [1m]",
-      "impact": "needs_review",
-      "categories": [
-        "request_shape_400",
-        "model_lifecycle"
-      ],
-      "tokenkey_status": "candidate_unverified",
-      "rationale": "Gateway/relay-relevant keyword match; not yet manually verified against TokenKey code.",
-      "updated_at": "2026-06-01T12:03:27Z"
+      "updated_at": "2026-06-04T07:25:36Z"
     },
     {
       "upstream": "anthropics/claude-code#56988",
@@ -1059,6 +1464,20 @@
       "updated_at": "2026-06-03T08:01:05Z"
     },
     {
+      "upstream": "anthropics/claude-code#57200",
+      "url": "https://github.com/anthropics/claude-code/issues/57200",
+      "title": "[BUG] Claude ignores instructions and violates rules consistently",
+      "impact": "needs_review",
+      "categories": [
+        "auth_token",
+        "model_lifecycle",
+        "fingerprint_ua"
+      ],
+      "tokenkey_status": "candidate_unverified",
+      "rationale": "Gateway/relay-relevant keyword match; not yet manually verified against TokenKey code.",
+      "updated_at": "2026-06-04T01:23:26Z"
+    },
+    {
       "upstream": "anthropics/claude-code#57242",
       "url": "https://github.com/anthropics/claude-code/issues/57242",
       "title": "Windows 11: Claude Code interactive claude command frozen in all terminals; non‑interactive and doctor work",
@@ -1069,6 +1488,30 @@
       "tokenkey_status": "candidate_unverified",
       "rationale": "Gateway/relay-relevant keyword match; not yet manually verified against TokenKey code.",
       "updated_at": "2026-06-02T03:15:17Z"
+    },
+    {
+      "upstream": "anthropics/claude-code#57285",
+      "url": "https://github.com/anthropics/claude-code/issues/57285",
+      "title": "[BUG] claude auth logout claims success but does not actually clear the persisted authentication state on Claude Code v2.1.133 (macOS)",
+      "impact": "needs_review",
+      "categories": [
+        "auth_token"
+      ],
+      "tokenkey_status": "candidate_unverified",
+      "rationale": "Gateway/relay-relevant keyword match; not yet manually verified against TokenKey code.",
+      "updated_at": "2026-06-03T22:45:39Z"
+    },
+    {
+      "upstream": "anthropics/claude-code#57328",
+      "url": "https://github.com/anthropics/claude-code/issues/57328",
+      "title": "[Claude-Sonnet-4-6] - Copy file error, never learns correct method in Windows",
+      "impact": "needs_review",
+      "categories": [
+        "model_lifecycle"
+      ],
+      "tokenkey_status": "candidate_unverified",
+      "rationale": "Gateway/relay-relevant keyword match; not yet manually verified against TokenKey code.",
+      "updated_at": "2026-06-04T11:07:08Z"
     },
     {
       "upstream": "anthropics/claude-code#57492",
@@ -1083,6 +1526,18 @@
       "updated_at": "2026-06-02T10:48:35Z"
     },
     {
+      "upstream": "anthropics/claude-code#58084",
+      "url": "https://github.com/anthropics/claude-code/issues/58084",
+      "title": "Plugin install pipeline strips top-level dotfiles (.mcp.json, .npmrc), breaking channel plugins",
+      "impact": "needs_review",
+      "categories": [
+        "auth_token"
+      ],
+      "tokenkey_status": "candidate_unverified",
+      "rationale": "Gateway/relay-relevant keyword match; not yet manually verified against TokenKey code.",
+      "updated_at": "2026-06-04T11:07:31Z"
+    },
+    {
       "upstream": "anthropics/claude-code#58217",
       "url": "https://github.com/anthropics/claude-code/issues/58217",
       "title": "[BUG]Advisor tool injects same-tier opus calls into every opus subagent, doubling spend invisibly",
@@ -1093,19 +1548,6 @@
       "tokenkey_status": "candidate_unverified",
       "rationale": "Gateway/relay-relevant keyword match; not yet manually verified against TokenKey code.",
       "updated_at": "2026-06-02T22:44:17Z"
-    },
-    {
-      "upstream": "anthropics/claude-code#58294",
-      "url": "https://github.com/anthropics/claude-code/issues/58294",
-      "title": "MCP tool calls to api.anthropic.com blocked by Cloudflare WAF (SQL injection rule false positive)",
-      "impact": "needs_review",
-      "categories": [
-        "model_lifecycle",
-        "fingerprint_ua"
-      ],
-      "tokenkey_status": "candidate_unverified",
-      "rationale": "Gateway/relay-relevant keyword match; not yet manually verified against TokenKey code.",
-      "updated_at": "2026-06-01T09:29:28Z"
     },
     {
       "upstream": "anthropics/claude-code#58392",
@@ -1132,30 +1574,6 @@
       "updated_at": "2026-06-01T22:45:51Z"
     },
     {
-      "upstream": "anthropics/claude-code#58859",
-      "url": "https://github.com/anthropics/claude-code/issues/58859",
-      "title": "[DOCS] Plugin docs missing `CLAUDE_CODE_PLUGIN_PREFER_HTTPS` for GitHub sources",
-      "impact": "needs_review",
-      "categories": [
-        "fingerprint_ua"
-      ],
-      "tokenkey_status": "candidate_unverified",
-      "rationale": "Gateway/relay-relevant keyword match; not yet manually verified against TokenKey code.",
-      "updated_at": "2026-06-01T01:11:37Z"
-    },
-    {
-      "upstream": "anthropics/claude-code#58879",
-      "url": "https://github.com/anthropics/claude-code/issues/58879",
-      "title": "[DOCS] Agent view omits 5-minute retirement for empty idle background sessions",
-      "impact": "needs_review",
-      "categories": [
-        "model_lifecycle"
-      ],
-      "tokenkey_status": "candidate_unverified",
-      "rationale": "Gateway/relay-relevant keyword match; not yet manually verified against TokenKey code.",
-      "updated_at": "2026-06-01T01:08:39Z"
-    },
-    {
       "upstream": "anthropics/claude-code#58933",
       "url": "https://github.com/anthropics/claude-code/issues/58933",
       "title": "Claude Code provides no in-session determinism mechanism, forcing automation users onto the metered Agent SDK path",
@@ -1168,29 +1586,28 @@
       "updated_at": "2026-06-03T04:56:29Z"
     },
     {
-      "upstream": "anthropics/claude-code#59108",
-      "url": "https://github.com/anthropics/claude-code/issues/59108",
-      "title": "[BUG] `claude -p` / `claude --print` has control-plane parity risks across hooks, permissions, skills, MCP, auth, and subagents",
+      "upstream": "anthropics/claude-code#59102",
+      "url": "https://github.com/anthropics/claude-code/issues/59102",
+      "title": "[BUG] MCP server error notifications render as \"[object Object]\" instead of the error message",
       "impact": "needs_review",
       "categories": [
-        "beta_header_drift",
+        "auth_token"
+      ],
+      "tokenkey_status": "candidate_unverified",
+      "rationale": "Gateway/relay-relevant keyword match; not yet manually verified against TokenKey code.",
+      "updated_at": "2026-06-03T10:42:39Z"
+    },
+    {
+      "upstream": "anthropics/claude-code#59402",
+      "url": "https://github.com/anthropics/claude-code/issues/59402",
+      "title": "Security blocked trying to defend my system!",
+      "impact": "needs_review",
+      "categories": [
         "fingerprint_ua"
       ],
       "tokenkey_status": "candidate_unverified",
       "rationale": "Gateway/relay-relevant keyword match; not yet manually verified against TokenKey code.",
-      "updated_at": "2026-06-01T03:41:03Z"
-    },
-    {
-      "upstream": "anthropics/claude-code#59281",
-      "url": "https://github.com/anthropics/claude-code/issues/59281",
-      "title": "API Error 529 and 500",
-      "impact": "needs_review",
-      "categories": [
-        "rate_limit"
-      ],
-      "tokenkey_status": "candidate_unverified",
-      "rationale": "Gateway/relay-relevant keyword match; not yet manually verified against TokenKey code.",
-      "updated_at": "2026-06-01T12:02:48Z"
+      "updated_at": "2026-06-03T23:35:23Z"
     },
     {
       "upstream": "anthropics/claude-code#59451",
@@ -1218,29 +1635,41 @@
       "updated_at": "2026-06-02T11:33:17Z"
     },
     {
-      "upstream": "anthropics/claude-code#59564",
-      "url": "https://github.com/anthropics/claude-code/issues/59564",
-      "title": "[BUG] Cowork VM worker (vmwp.exe) overwrites host-side filesystem changes with stale VM-cached content on session startup",
+      "upstream": "anthropics/claude-code#59502",
+      "url": "https://github.com/anthropics/claude-code/issues/59502",
+      "title": "Feature request: programmatic /effort and /model switching for multi-agent orchestration",
       "impact": "needs_review",
       "categories": [
-        "model_lifecycle",
-        "fingerprint_ua"
+        "rate_limit",
+        "prompt_caching"
       ],
       "tokenkey_status": "candidate_unverified",
       "rationale": "Gateway/relay-relevant keyword match; not yet manually verified against TokenKey code.",
-      "updated_at": "2026-06-01T12:01:57Z"
+      "updated_at": "2026-06-04T11:07:39Z"
     },
     {
-      "upstream": "anthropics/claude-code#59572",
-      "url": "https://github.com/anthropics/claude-code/issues/59572",
-      "title": "[BUG] Weekly \"all models\" counter dropping mid-cycle without reset (Max, Opus 4.7)",
+      "upstream": "anthropics/claude-code#59503",
+      "url": "https://github.com/anthropics/claude-code/issues/59503",
+      "title": "[BUG] CLAUDE.md is injected twice into context at session start in VSCode native extension (using in Cursor)",
       "impact": "needs_review",
       "categories": [
         "prompt_caching"
       ],
       "tokenkey_status": "candidate_unverified",
       "rationale": "Gateway/relay-relevant keyword match; not yet manually verified against TokenKey code.",
-      "updated_at": "2026-06-01T13:12:53Z"
+      "updated_at": "2026-06-04T11:07:49Z"
+    },
+    {
+      "upstream": "anthropics/claude-code#59532",
+      "url": "https://github.com/anthropics/claude-code/issues/59532",
+      "title": "[BUG] Cowork: User messages remain in pulsating in-flight state after session-switch — regression / incomplete-fix variant of the #26805 / #26921 / #44776 cluster (macOS, May 2026)",
+      "impact": "needs_review",
+      "categories": [
+        "model_lifecycle"
+      ],
+      "tokenkey_status": "candidate_unverified",
+      "rationale": "Gateway/relay-relevant keyword match; not yet manually verified against TokenKey code.",
+      "updated_at": "2026-06-04T11:07:35Z"
     },
     {
       "upstream": "anthropics/claude-code#59573",
@@ -1258,40 +1687,16 @@
       "updated_at": "2026-06-02T11:31:55Z"
     },
     {
-      "upstream": "anthropics/claude-code#59582",
-      "url": "https://github.com/anthropics/claude-code/issues/59582",
-      "title": "[DOCS] Background sessions docs omit effort-level persistence across idle wake",
+      "upstream": "anthropics/claude-code#59618",
+      "url": "https://github.com/anthropics/claude-code/issues/59618",
+      "title": "[BUG] Korean text degrades to repeated \"측\" tokens in long mixed-language responses",
       "impact": "needs_review",
       "categories": [
         "model_lifecycle"
       ],
       "tokenkey_status": "candidate_unverified",
       "rationale": "Gateway/relay-relevant keyword match; not yet manually verified against TokenKey code.",
-      "updated_at": "2026-06-01T01:33:40Z"
-    },
-    {
-      "upstream": "anthropics/claude-code#59590",
-      "url": "https://github.com/anthropics/claude-code/issues/59590",
-      "title": "[DOCS] `claude --bg --dangerously-skip-permissions` persistence across retire/wake is undocumented",
-      "impact": "needs_review",
-      "categories": [
-        "model_lifecycle"
-      ],
-      "tokenkey_status": "candidate_unverified",
-      "rationale": "Gateway/relay-relevant keyword match; not yet manually verified against TokenKey code.",
-      "updated_at": "2026-06-01T01:04:54Z"
-    },
-    {
-      "upstream": "anthropics/claude-code#59621",
-      "url": "https://github.com/anthropics/claude-code/issues/59621",
-      "title": "[BUG] Review crashed before producing findings",
-      "impact": "needs_review",
-      "categories": [
-        "rate_limit"
-      ],
-      "tokenkey_status": "candidate_unverified",
-      "rationale": "Gateway/relay-relevant keyword match; not yet manually verified against TokenKey code.",
-      "updated_at": "2026-05-31T23:05:00Z"
+      "updated_at": "2026-06-03T22:45:26Z"
     },
     {
       "upstream": "anthropics/claude-code#59634",
@@ -1330,104 +1735,6 @@
       "updated_at": "2026-06-01T22:45:08Z"
     },
     {
-      "upstream": "anthropics/claude-code#59700",
-      "url": "https://github.com/anthropics/claude-code/issues/59700",
-      "title": "[BUG] org:create_api_key scope silently dropped from OAuth grant — Remote Control permanently broken on Max subscription",
-      "impact": "needs_review",
-      "categories": [
-        "rate_limit",
-        "auth_token"
-      ],
-      "tokenkey_status": "candidate_unverified",
-      "rationale": "Gateway/relay-relevant keyword match; not yet manually verified against TokenKey code.",
-      "updated_at": "2026-06-01T12:03:07Z"
-    },
-    {
-      "upstream": "anthropics/claude-code#59711",
-      "url": "https://github.com/anthropics/claude-code/issues/59711",
-      "title": "[BUG] Transcribing that should have been reproduced verbatim",
-      "impact": "needs_review",
-      "categories": [
-        "model_lifecycle"
-      ],
-      "tokenkey_status": "candidate_unverified",
-      "rationale": "Gateway/relay-relevant keyword match; not yet manually verified against TokenKey code.",
-      "updated_at": "2026-06-01T12:02:21Z"
-    },
-    {
-      "upstream": "anthropics/claude-code#59725",
-      "url": "https://github.com/anthropics/claude-code/issues/59725",
-      "title": "Slack MCP (mcp.slack.com) OAuth stores empty accessToken after completing flow; complete_authentication also broken",
-      "impact": "needs_review",
-      "categories": [
-        "auth_token"
-      ],
-      "tokenkey_status": "candidate_unverified",
-      "rationale": "Gateway/relay-relevant keyword match; not yet manually verified against TokenKey code.",
-      "updated_at": "2026-06-01T12:03:13Z"
-    },
-    {
-      "upstream": "anthropics/claude-code#59742",
-      "url": "https://github.com/anthropics/claude-code/issues/59742",
-      "title": "Built-in channel-reply guardrail for channel-routed plugins (e.g. Telegram)",
-      "impact": "needs_review",
-      "categories": [
-        "request_shape_400"
-      ],
-      "tokenkey_status": "candidate_unverified",
-      "rationale": "Gateway/relay-relevant keyword match; not yet manually verified against TokenKey code.",
-      "updated_at": "2026-06-01T12:03:03Z"
-    },
-    {
-      "upstream": "anthropics/claude-code#59746",
-      "url": "https://github.com/anthropics/claude-code/issues/59746",
-      "title": "[Bug] Anthropic API Error: 500 Internal Server Error with Claude 3.5 Opus",
-      "impact": "needs_review",
-      "categories": [
-        "request_shape_400"
-      ],
-      "tokenkey_status": "candidate_unverified",
-      "rationale": "Gateway/relay-relevant keyword match; not yet manually verified against TokenKey code.",
-      "updated_at": "2026-06-01T12:02:34Z"
-    },
-    {
-      "upstream": "anthropics/claude-code#59754",
-      "url": "https://github.com/anthropics/claude-code/issues/59754",
-      "title": "I don't have a bug report to analyze. Please provide the bug report or issue description so I can generate an appropriate GitHub issue title.",
-      "impact": "needs_review",
-      "categories": [
-        "request_shape_400",
-        "auth_token"
-      ],
-      "tokenkey_status": "candidate_unverified",
-      "rationale": "Gateway/relay-relevant keyword match; not yet manually verified against TokenKey code.",
-      "updated_at": "2026-06-01T12:02:38Z"
-    },
-    {
-      "upstream": "anthropics/claude-code#59791",
-      "url": "https://github.com/anthropics/claude-code/issues/59791",
-      "title": "[Bug] Anthropic API Error: Server rate limiting preventing all sessions",
-      "impact": "needs_review",
-      "categories": [
-        "rate_limit"
-      ],
-      "tokenkey_status": "candidate_unverified",
-      "rationale": "Gateway/relay-relevant keyword match; not yet manually verified against TokenKey code.",
-      "updated_at": "2026-06-01T12:03:02Z"
-    },
-    {
-      "upstream": "anthropics/claude-code#59809",
-      "url": "https://github.com/anthropics/claude-code/issues/59809",
-      "title": "QuickBooks connector stuck in 'Requested' status with no management options (no three dots, Remove button, or Cancel option)",
-      "impact": "needs_review",
-      "categories": [
-        "auth_token"
-      ],
-      "tokenkey_status": "candidate_unverified",
-      "rationale": "Gateway/relay-relevant keyword match; not yet manually verified against TokenKey code.",
-      "updated_at": "2026-06-01T12:03:16Z"
-    },
-    {
       "upstream": "anthropics/claude-code#59831",
       "url": "https://github.com/anthropics/claude-code/issues/59831",
       "title": "[BUG] Claude Desktop Cowork freezes at “Authenticating” — LocalAgentModeSessions OAuth exchange never completes",
@@ -1452,18 +1759,6 @@
       "updated_at": "2026-06-02T22:42:33Z"
     },
     {
-      "upstream": "anthropics/claude-code#59843",
-      "url": "https://github.com/anthropics/claude-code/issues/59843",
-      "title": "[BUG] Approving a plan via \"Plan Approved\" UI button drops session into `default` mode instead of restoring prior permission mode",
-      "impact": "needs_review",
-      "categories": [
-        "request_shape_400"
-      ],
-      "tokenkey_status": "candidate_unverified",
-      "rationale": "Gateway/relay-relevant keyword match; not yet manually verified against TokenKey code.",
-      "updated_at": "2026-06-01T12:03:37Z"
-    },
-    {
       "upstream": "anthropics/claude-code#59844",
       "url": "https://github.com/anthropics/claude-code/issues/59844",
       "title": "`showThinkingSummaries: true` silently no-ops on Opus 4.7 in non-interactive surfaces (VS Code extension, SDK, `--print`): one-line CLI fix or one-line extension fix",
@@ -1477,29 +1772,28 @@
       "updated_at": "2026-06-02T17:55:30Z"
     },
     {
-      "upstream": "anthropics/claude-code#59849",
-      "url": "https://github.com/anthropics/claude-code/issues/59849",
-      "title": "Voice dictation mic button silently fails — audio captured but no transcript inserted (desktop app, Windows)",
+      "upstream": "anthropics/claude-code#59872",
+      "url": "https://github.com/anthropics/claude-code/issues/59872",
+      "title": "Opus 4.6 cache_read tokens counted at full rate despite cache hits on Max 20x",
       "impact": "needs_review",
       "categories": [
-        "auth_token",
+        "prompt_caching"
+      ],
+      "tokenkey_status": "candidate_unverified",
+      "rationale": "Gateway/relay-relevant keyword match; not yet manually verified against TokenKey code.",
+      "updated_at": "2026-06-03T22:45:51Z"
+    },
+    {
+      "upstream": "anthropics/claude-code#59881",
+      "url": "https://github.com/anthropics/claude-code/issues/59881",
+      "title": "[Bug] Custom project agents in .claude/agents/ not resolvable as subagents via Agent tool",
+      "impact": "needs_review",
+      "categories": [
         "model_lifecycle"
       ],
       "tokenkey_status": "candidate_unverified",
       "rationale": "Gateway/relay-relevant keyword match; not yet manually verified against TokenKey code.",
-      "updated_at": "2026-06-01T12:03:34Z"
-    },
-    {
-      "upstream": "anthropics/claude-code#59854",
-      "url": "https://github.com/anthropics/claude-code/issues/59854",
-      "title": "[BUG] Cowork — GitHub connector unusable: OAuth DCR unsupported, UI shows misleading state, Disconnect button dead",
-      "impact": "needs_review",
-      "categories": [
-        "auth_token"
-      ],
-      "tokenkey_status": "candidate_unverified",
-      "rationale": "Gateway/relay-relevant keyword match; not yet manually verified against TokenKey code.",
-      "updated_at": "2026-06-01T12:03:39Z"
+      "updated_at": "2026-06-04T11:07:04Z"
     },
     {
       "upstream": "anthropics/claude-code#59886",
@@ -1782,6 +2076,18 @@
       "updated_at": "2026-06-02T11:33:09Z"
     },
     {
+      "upstream": "anthropics/claude-code#60177",
+      "url": "https://github.com/anthropics/claude-code/issues/60177",
+      "title": "[MODEL] Claude marks tasks done without testing — 12 days, 51 commits, still broken (Opus 4.x)",
+      "impact": "needs_review",
+      "categories": [
+        "request_shape_400"
+      ],
+      "tokenkey_status": "candidate_unverified",
+      "rationale": "Gateway/relay-relevant keyword match; not yet manually verified against TokenKey code.",
+      "updated_at": "2026-06-04T01:23:21Z"
+    },
+    {
       "upstream": "anthropics/claude-code#60197",
       "url": "https://github.com/anthropics/claude-code/issues/60197",
       "title": "[BUG] Edit tool silently misses some Edits in a rapid Edit + git mv + commit sequence (selective miss within same commit; refuted hypothesis 2 vs 1+3 still open)",
@@ -1819,6 +2125,18 @@
       "updated_at": "2026-06-02T22:44:05Z"
     },
     {
+      "upstream": "anthropics/claude-code#60231",
+      "url": "https://github.com/anthropics/claude-code/issues/60231",
+      "title": "[BUG] No Claude Environment Selector in Claude Code Routines, so cannot access Network APIs.",
+      "impact": "needs_review",
+      "categories": [
+        "fingerprint_ua"
+      ],
+      "tokenkey_status": "candidate_unverified",
+      "rationale": "Gateway/relay-relevant keyword match; not yet manually verified against TokenKey code.",
+      "updated_at": "2026-06-03T11:39:28Z"
+    },
+    {
       "upstream": "anthropics/claude-code#60252",
       "url": "https://github.com/anthropics/claude-code/issues/60252",
       "title": "[BUG] --strict-mcp-config with empty --mcp-config still fetches MCP registry and attempts user-configured servers",
@@ -1831,6 +2149,30 @@
       "tokenkey_status": "candidate_unverified",
       "rationale": "Gateway/relay-relevant keyword match; not yet manually verified against TokenKey code.",
       "updated_at": "2026-06-02T22:44:11Z"
+    },
+    {
+      "upstream": "anthropics/claude-code#60260",
+      "url": "https://github.com/anthropics/claude-code/issues/60260",
+      "title": "MCP OAuth completes but token is not honored — server stays in 'Needs authentication'",
+      "impact": "needs_review",
+      "categories": [
+        "auth_token"
+      ],
+      "tokenkey_status": "candidate_unverified",
+      "rationale": "Gateway/relay-relevant keyword match; not yet manually verified against TokenKey code.",
+      "updated_at": "2026-06-04T11:07:47Z"
+    },
+    {
+      "upstream": "anthropics/claude-code#60283",
+      "url": "https://github.com/anthropics/claude-code/issues/60283",
+      "title": "[BUG] Excessive token consumption — task halted mid-execution with zero output (macOS)",
+      "impact": "needs_review",
+      "categories": [
+        "model_lifecycle"
+      ],
+      "tokenkey_status": "candidate_unverified",
+      "rationale": "Gateway/relay-relevant keyword match; not yet manually verified against TokenKey code.",
+      "updated_at": "2026-06-04T00:13:00Z"
     },
     {
       "upstream": "anthropics/claude-code#60284",
@@ -1869,6 +2211,18 @@
       "updated_at": "2026-06-02T22:44:42Z"
     },
     {
+      "upstream": "anthropics/claude-code#60308",
+      "url": "https://github.com/anthropics/claude-code/issues/60308",
+      "title": "/ultrareview fails: seed bundle import error from Firestore",
+      "impact": "needs_review",
+      "categories": [
+        "model_lifecycle"
+      ],
+      "tokenkey_status": "candidate_unverified",
+      "rationale": "Gateway/relay-relevant keyword match; not yet manually verified against TokenKey code.",
+      "updated_at": "2026-06-04T11:07:21Z"
+    },
+    {
       "upstream": "anthropics/claude-code#60313",
       "url": "https://github.com/anthropics/claude-code/issues/60313",
       "title": "[BUG] Cloud session permanently stuck on \"API Error 400: text content blocks must be non-empty\" — no in-app recovery path",
@@ -1896,6 +2250,18 @@
       "updated_at": "2026-06-02T22:44:38Z"
     },
     {
+      "upstream": "anthropics/claude-code#60326",
+      "url": "https://github.com/anthropics/claude-code/issues/60326",
+      "title": "OAuthError on \"Start new coding session\" — repeated failure preventing session creation",
+      "impact": "needs_review",
+      "categories": [
+        "auth_token"
+      ],
+      "tokenkey_status": "candidate_unverified",
+      "rationale": "Gateway/relay-relevant keyword match; not yet manually verified against TokenKey code.",
+      "updated_at": "2026-06-04T11:06:58Z"
+    },
+    {
       "upstream": "anthropics/claude-code#60327",
       "url": "https://github.com/anthropics/claude-code/issues/60327",
       "title": "[FEATURE]: way for Claude Code to query an externally-maintained design system (e.g. Claude Design)",
@@ -1908,6 +2274,18 @@
       "updated_at": "2026-06-02T22:44:49Z"
     },
     {
+      "upstream": "anthropics/claude-code#60340",
+      "url": "https://github.com/anthropics/claude-code/issues/60340",
+      "title": "Model fabricated a command in technical repro steps instead of using known context",
+      "impact": "needs_review",
+      "categories": [
+        "model_lifecycle"
+      ],
+      "tokenkey_status": "candidate_unverified",
+      "rationale": "Gateway/relay-relevant keyword match; not yet manually verified against TokenKey code.",
+      "updated_at": "2026-06-03T22:45:12Z"
+    },
+    {
       "upstream": "anthropics/claude-code#60364",
       "url": "https://github.com/anthropics/claude-code/issues/60364",
       "title": "Slack MCP via browser session tokens (xoxc/xoxd) unreliable on Enterprise Grid — request first-class OAuth-based Slack MCP",
@@ -1918,6 +2296,56 @@
       "tokenkey_status": "candidate_unverified",
       "rationale": "Gateway/relay-relevant keyword match; not yet manually verified against TokenKey code.",
       "updated_at": "2026-06-02T22:44:58Z"
+    },
+    {
+      "upstream": "anthropics/claude-code#60376",
+      "url": "https://github.com/anthropics/claude-code/issues/60376",
+      "title": "Claude Code Opus 4.7 (1M): repeated discipline failures cascading into 6 red CI runs in one session",
+      "impact": "needs_review",
+      "categories": [
+        "model_lifecycle"
+      ],
+      "tokenkey_status": "candidate_unverified",
+      "rationale": "Gateway/relay-relevant keyword match; not yet manually verified against TokenKey code.",
+      "updated_at": "2026-06-04T11:07:39Z"
+    },
+    {
+      "upstream": "anthropics/claude-code#60395",
+      "url": "https://github.com/anthropics/claude-code/issues/60395",
+      "title": "[BUG] OAuth Token Exchange not completed in 2.1.143 with non-DCR AS (Cloudflare Access for SaaS) — server side curl-verified, regression suspected from 2.1.80",
+      "impact": "needs_review",
+      "categories": [
+        "auth_token",
+        "model_lifecycle",
+        "fingerprint_ua"
+      ],
+      "tokenkey_status": "candidate_unverified",
+      "rationale": "Gateway/relay-relevant keyword match; not yet manually verified against TokenKey code.",
+      "updated_at": "2026-06-04T11:06:50Z"
+    },
+    {
+      "upstream": "anthropics/claude-code#60403",
+      "url": "https://github.com/anthropics/claude-code/issues/60403",
+      "title": "[Bug] Unauthorized access to Samsung TV app development/testing environment",
+      "impact": "needs_review",
+      "categories": [
+        "auth_token"
+      ],
+      "tokenkey_status": "candidate_unverified",
+      "rationale": "Gateway/relay-relevant keyword match; not yet manually verified against TokenKey code.",
+      "updated_at": "2026-06-04T11:06:53Z"
+    },
+    {
+      "upstream": "anthropics/claude-code#60426",
+      "url": "https://github.com/anthropics/claude-code/issues/60426",
+      "title": "[BUG] DUPLICATES: #16159 -- API Error: Output blocked by content filtering policy when attempting to write CODE_OF_CONDUCT.md",
+      "impact": "needs_review",
+      "categories": [
+        "request_shape_400"
+      ],
+      "tokenkey_status": "candidate_unverified",
+      "rationale": "Gateway/relay-relevant keyword match; not yet manually verified against TokenKey code.",
+      "updated_at": "2026-06-03T22:45:15Z"
     },
     {
       "upstream": "anthropics/claude-code#60438",
@@ -1933,6 +2361,164 @@
       "updated_at": "2026-06-01T19:08:07Z"
     },
     {
+      "upstream": "anthropics/claude-code#60442",
+      "url": "https://github.com/anthropics/claude-code/issues/60442",
+      "title": "[Bug] Sub-agent `rm -rf` with case-insensitive path collision destroys workspace; no sandbox, confirmation, or orchestrator interception",
+      "impact": "needs_review",
+      "categories": [
+        "model_lifecycle"
+      ],
+      "tokenkey_status": "candidate_unverified",
+      "rationale": "Gateway/relay-relevant keyword match; not yet manually verified against TokenKey code.",
+      "updated_at": "2026-06-03T22:45:23Z"
+    },
+    {
+      "upstream": "anthropics/claude-code#60446",
+      "url": "https://github.com/anthropics/claude-code/issues/60446",
+      "title": "VSCode extension webview: 'Unsupported content type: server_tool_use / advisor_tool_result' when advisor tool is invoked",
+      "impact": "needs_review",
+      "categories": [
+        "request_shape_400"
+      ],
+      "tokenkey_status": "candidate_unverified",
+      "rationale": "Gateway/relay-relevant keyword match; not yet manually verified against TokenKey code.",
+      "updated_at": "2026-06-03T22:45:24Z"
+    },
+    {
+      "upstream": "anthropics/claude-code#60456",
+      "url": "https://github.com/anthropics/claude-code/issues/60456",
+      "title": "[BUG] CLI crashes (exit code 1) on unhandled McpError -32001 AbortError during tool_use",
+      "impact": "needs_review",
+      "categories": [
+        "request_shape_400"
+      ],
+      "tokenkey_status": "candidate_unverified",
+      "rationale": "Gateway/relay-relevant keyword match; not yet manually verified against TokenKey code.",
+      "updated_at": "2026-06-03T22:45:34Z"
+    },
+    {
+      "upstream": "anthropics/claude-code#60466",
+      "url": "https://github.com/anthropics/claude-code/issues/60466",
+      "title": "[BUG] tools.10.model: 'claude-sonnet-4-6' cannot be used as an advisor when the request model is 'claude-opus-4-7'.",
+      "impact": "needs_review",
+      "categories": [
+        "request_shape_400",
+        "model_lifecycle"
+      ],
+      "tokenkey_status": "candidate_unverified",
+      "rationale": "Gateway/relay-relevant keyword match; not yet manually verified against TokenKey code.",
+      "updated_at": "2026-06-03T22:45:33Z"
+    },
+    {
+      "upstream": "anthropics/claude-code#60490",
+      "url": "https://github.com/anthropics/claude-code/issues/60490",
+      "title": "[BUG] Stop hook exit code 2 downgraded to non-blocking when stderr contains unrelated 'no such file'",
+      "impact": "needs_review",
+      "categories": [
+        "model_lifecycle"
+      ],
+      "tokenkey_status": "candidate_unverified",
+      "rationale": "Gateway/relay-relevant keyword match; not yet manually verified against TokenKey code.",
+      "updated_at": "2026-06-03T22:45:43Z"
+    },
+    {
+      "upstream": "anthropics/claude-code#60502",
+      "url": "https://github.com/anthropics/claude-code/issues/60502",
+      "title": "Expose `anthropic-ratelimit-*` response headers as OpenTelemetry attributes on `api_request`",
+      "impact": "needs_review",
+      "categories": [
+        "rate_limit",
+        "prompt_caching"
+      ],
+      "tokenkey_status": "candidate_unverified",
+      "rationale": "Gateway/relay-relevant keyword match; not yet manually verified against TokenKey code.",
+      "updated_at": "2026-06-03T22:45:43Z"
+    },
+    {
+      "upstream": "anthropics/claude-code#60520",
+      "url": "https://github.com/anthropics/claude-code/issues/60520",
+      "title": "CCD CycleHealth crashes with \"undefined is not an object (evaluating '$.input_tokens')\" on API errors",
+      "impact": "needs_review",
+      "categories": [
+        "rate_limit"
+      ],
+      "tokenkey_status": "candidate_unverified",
+      "rationale": "Gateway/relay-relevant keyword match; not yet manually verified against TokenKey code.",
+      "updated_at": "2026-06-03T22:45:50Z"
+    },
+    {
+      "upstream": "anthropics/claude-code#60521",
+      "url": "https://github.com/anthropics/claude-code/issues/60521",
+      "title": "[BUG] MCP server (HTTP/SSE type) times out after OAuth authentication completes",
+      "impact": "needs_review",
+      "categories": [
+        "auth_token"
+      ],
+      "tokenkey_status": "candidate_unverified",
+      "rationale": "Gateway/relay-relevant keyword match; not yet manually verified against TokenKey code.",
+      "updated_at": "2026-06-03T22:45:51Z"
+    },
+    {
+      "upstream": "anthropics/claude-code#60523",
+      "url": "https://github.com/anthropics/claude-code/issues/60523",
+      "title": "[Regression] advisor() still breaks sessions post-compaction via parentUuid tree mismatch -- root cause identified, workaround script included",
+      "impact": "needs_review",
+      "categories": [
+        "request_shape_400"
+      ],
+      "tokenkey_status": "candidate_unverified",
+      "rationale": "Gateway/relay-relevant keyword match; not yet manually verified against TokenKey code.",
+      "updated_at": "2026-06-04T06:44:24Z"
+    },
+    {
+      "upstream": "anthropics/claude-code#60542",
+      "url": "https://github.com/anthropics/claude-code/issues/60542",
+      "title": "C:/Program Files/Git/compact leaves session in inconsistent state when it fails mid-execution (e.g. rate limit)",
+      "impact": "needs_review",
+      "categories": [
+        "rate_limit"
+      ],
+      "tokenkey_status": "candidate_unverified",
+      "rationale": "Gateway/relay-relevant keyword match; not yet manually verified against TokenKey code.",
+      "updated_at": "2026-06-04T11:07:15Z"
+    },
+    {
+      "upstream": "anthropics/claude-code#60547",
+      "url": "https://github.com/anthropics/claude-code/issues/60547",
+      "title": "--bare mode should respect --tools flag to allow adding tools back (e.g. Agent, Skill)",
+      "impact": "needs_review",
+      "categories": [
+        "request_shape_400"
+      ],
+      "tokenkey_status": "candidate_unverified",
+      "rationale": "Gateway/relay-relevant keyword match; not yet manually verified against TokenKey code.",
+      "updated_at": "2026-06-03T22:46:01Z"
+    },
+    {
+      "upstream": "anthropics/claude-code#60562",
+      "url": "https://github.com/anthropics/claude-code/issues/60562",
+      "title": "[BUG] Server-side rate limits break parallel agent workflows — request transparent auto-retry",
+      "impact": "needs_review",
+      "categories": [
+        "rate_limit"
+      ],
+      "tokenkey_status": "candidate_unverified",
+      "rationale": "Gateway/relay-relevant keyword match; not yet manually verified against TokenKey code.",
+      "updated_at": "2026-06-04T11:06:59Z"
+    },
+    {
+      "upstream": "anthropics/claude-code#60577",
+      "url": "https://github.com/anthropics/claude-code/issues/60577",
+      "title": "Transient 529 Overloaded API errors abort long-running tasks with no auto-recovery",
+      "impact": "needs_review",
+      "categories": [
+        "rate_limit"
+      ],
+      "tokenkey_status": "candidate_unverified",
+      "rationale": "Gateway/relay-relevant keyword match; not yet manually verified against TokenKey code.",
+      "updated_at": "2026-06-04T11:07:13Z"
+    },
+    {
       "upstream": "anthropics/claude-code#60583",
       "url": "https://github.com/anthropics/claude-code/issues/60583",
       "title": "[BUG] Cross-session blindness causes three-stage failure: incomplete refactor → misdiagnosis → unauthorized revert",
@@ -1943,7 +2529,80 @@
       ],
       "tokenkey_status": "candidate_unverified",
       "rationale": "Gateway/relay-relevant keyword match; not yet manually verified against TokenKey code.",
-      "updated_at": "2026-06-03T05:02:50Z"
+      "updated_at": "2026-06-04T05:03:43Z"
+    },
+    {
+      "upstream": "anthropics/claude-code#60595",
+      "url": "https://github.com/anthropics/claude-code/issues/60595",
+      "title": "[Bug] Claude 4.6 Sonnet (max) generating reasoning data outside thinking blocks",
+      "impact": "needs_review",
+      "categories": [
+        "request_shape_400",
+        "auth_token"
+      ],
+      "tokenkey_status": "candidate_unverified",
+      "rationale": "Gateway/relay-relevant keyword match; not yet manually verified against TokenKey code.",
+      "updated_at": "2026-06-04T11:07:10Z"
+    },
+    {
+      "upstream": "anthropics/claude-code#60598",
+      "url": "https://github.com/anthropics/claude-code/issues/60598",
+      "title": "Investigate: should TodoWrite allow marking multiple todos complete in one call?",
+      "impact": "needs_review",
+      "categories": [
+        "new_endpoints"
+      ],
+      "tokenkey_status": "candidate_unverified",
+      "rationale": "Gateway/relay-relevant keyword match; not yet manually verified against TokenKey code.",
+      "updated_at": "2026-06-04T11:07:11Z"
+    },
+    {
+      "upstream": "anthropics/claude-code#60629",
+      "url": "https://github.com/anthropics/claude-code/issues/60629",
+      "title": "You're out of usage credits · resets 2:50pm (America/New_York)",
+      "impact": "needs_review",
+      "categories": [
+        "rate_limit"
+      ],
+      "tokenkey_status": "candidate_unverified",
+      "rationale": "Gateway/relay-relevant keyword match; not yet manually verified against TokenKey code.",
+      "updated_at": "2026-06-04T11:07:28Z"
+    },
+    {
+      "upstream": "anthropics/claude-code#60635",
+      "url": "https://github.com/anthropics/claude-code/issues/60635",
+      "title": "/ultrareview: billed cloud action triggered by default Return key with no cost confirmation",
+      "impact": "needs_review",
+      "categories": [
+        "model_lifecycle"
+      ],
+      "tokenkey_status": "candidate_unverified",
+      "rationale": "Gateway/relay-relevant keyword match; not yet manually verified against TokenKey code.",
+      "updated_at": "2026-06-04T11:07:46Z"
+    },
+    {
+      "upstream": "anthropics/claude-code#60648",
+      "url": "https://github.com/anthropics/claude-code/issues/60648",
+      "title": "My account Max 5x got organization has been disabled when using Claude CLI",
+      "impact": "needs_review",
+      "categories": [
+        "request_shape_400"
+      ],
+      "tokenkey_status": "candidate_unverified",
+      "rationale": "Gateway/relay-relevant keyword match; not yet manually verified against TokenKey code.",
+      "updated_at": "2026-06-04T11:07:37Z"
+    },
+    {
+      "upstream": "anthropics/claude-code#60652",
+      "url": "https://github.com/anthropics/claude-code/issues/60652",
+      "title": "[FEATURE] Custom system prompt support in desktop app and VS Code extension (parity with CLI --system-prompt-file)",
+      "impact": "needs_review",
+      "categories": [
+        "prompt_caching"
+      ],
+      "tokenkey_status": "candidate_unverified",
+      "rationale": "Gateway/relay-relevant keyword match; not yet manually verified against TokenKey code.",
+      "updated_at": "2026-06-04T11:07:40Z"
     },
     {
       "upstream": "anthropics/claude-code#60669",
@@ -1955,7 +2614,7 @@
       ],
       "tokenkey_status": "candidate_unverified",
       "rationale": "Gateway/relay-relevant keyword match; not yet manually verified against TokenKey code.",
-      "updated_at": "2026-06-02T14:58:36Z"
+      "updated_at": "2026-06-03T19:09:09Z"
     },
     {
       "upstream": "anthropics/claude-code#61012",
@@ -1967,7 +2626,7 @@
       ],
       "tokenkey_status": "candidate_unverified",
       "rationale": "Gateway/relay-relevant keyword match; not yet manually verified against TokenKey code.",
-      "updated_at": "2026-06-02T20:21:45Z"
+      "updated_at": "2026-06-03T14:16:48Z"
     },
     {
       "upstream": "anthropics/claude-code#61313",
@@ -1982,28 +2641,16 @@
       "updated_at": "2026-06-02T10:41:06Z"
     },
     {
-      "upstream": "anthropics/claude-code#61634",
-      "url": "https://github.com/anthropics/claude-code/issues/61634",
-      "title": "[BUG] False-positive Usage Policy refusal mid-stream on a markdown comparison table",
+      "upstream": "anthropics/claude-code#61370",
+      "url": "https://github.com/anthropics/claude-code/issues/61370",
+      "title": "[BUG] Voice mode silently captures no audio in 2.1.148 (accessibility regression)",
       "impact": "needs_review",
       "categories": [
-        "model_lifecycle"
+        "fingerprint_ua"
       ],
       "tokenkey_status": "candidate_unverified",
       "rationale": "Gateway/relay-relevant keyword match; not yet manually verified against TokenKey code.",
-      "updated_at": "2026-06-01T06:32:30Z"
-    },
-    {
-      "upstream": "anthropics/claude-code#61646",
-      "url": "https://github.com/anthropics/claude-code/issues/61646",
-      "title": "False-positive cyber-safeguard intervention on legitimate systems-engineering work in Claude Code",
-      "impact": "needs_review",
-      "categories": [
-        "auth_token"
-      ],
-      "tokenkey_status": "candidate_unverified",
-      "rationale": "Gateway/relay-relevant keyword match; not yet manually verified against TokenKey code.",
-      "updated_at": "2026-06-01T06:33:00Z"
+      "updated_at": "2026-06-03T16:17:40Z"
     },
     {
       "upstream": "anthropics/claude-code#61889",
@@ -2015,21 +2662,7 @@
       ],
       "tokenkey_status": "candidate_unverified",
       "rationale": "Gateway/relay-relevant keyword match; not yet manually verified against TokenKey code.",
-      "updated_at": "2026-06-02T23:43:02Z"
-    },
-    {
-      "upstream": "anthropics/claude-code#61890",
-      "url": "https://github.com/anthropics/claude-code/issues/61890",
-      "title": "[BUG] Remote Control: \"is not yet enabled for your account\" persists for Max user across all documented troubleshooting steps",
-      "impact": "needs_review",
-      "categories": [
-        "rate_limit",
-        "auth_token",
-        "fingerprint_ua"
-      ],
-      "tokenkey_status": "candidate_unverified",
-      "rationale": "Gateway/relay-relevant keyword match; not yet manually verified against TokenKey code.",
-      "updated_at": "2026-05-31T21:49:13Z"
+      "updated_at": "2026-06-04T06:12:57Z"
     },
     {
       "upstream": "anthropics/claude-code#61895",
@@ -2044,30 +2677,6 @@
       "updated_at": "2026-06-02T17:32:48Z"
     },
     {
-      "upstream": "anthropics/claude-code#61941",
-      "url": "https://github.com/anthropics/claude-code/issues/61941",
-      "title": "[Bug] Usage Policy cyber-safeguards block parallel headless Task() subagents doing localhost QA",
-      "impact": "needs_review",
-      "categories": [
-        "model_lifecycle"
-      ],
-      "tokenkey_status": "candidate_unverified",
-      "rationale": "Gateway/relay-relevant keyword match; not yet manually verified against TokenKey code.",
-      "updated_at": "2026-06-01T06:32:40Z"
-    },
-    {
-      "upstream": "anthropics/claude-code#62015",
-      "url": "https://github.com/anthropics/claude-code/issues/62015",
-      "title": "[BUG] Claude Code corrupted FlutterFlow project via deprecated proto field in MCP integration — server-level damage, project completely frozen",
-      "impact": "needs_review",
-      "categories": [
-        "model_lifecycle"
-      ],
-      "tokenkey_status": "candidate_unverified",
-      "rationale": "Gateway/relay-relevant keyword match; not yet manually verified against TokenKey code.",
-      "updated_at": "2026-05-31T11:01:53Z"
-    },
-    {
       "upstream": "anthropics/claude-code#62063",
       "url": "https://github.com/anthropics/claude-code/issues/62063",
       "title": "[BUG] Claude Code defaults to 1M context on fresh session with no workaround on Pro plan",
@@ -2077,19 +2686,7 @@
       ],
       "tokenkey_status": "candidate_unverified",
       "rationale": "Gateway/relay-relevant keyword match; not yet manually verified against TokenKey code.",
-      "updated_at": "2026-06-03T07:47:31Z"
-    },
-    {
-      "upstream": "anthropics/claude-code#62265",
-      "url": "https://github.com/anthropics/claude-code/issues/62265",
-      "title": "Usage cap: single ~30k-token prompt (no subagents) burned 38% of 5h Max 20x limit on Opus 4.7",
-      "impact": "needs_review",
-      "categories": [
-        "model_lifecycle"
-      ],
-      "tokenkey_status": "candidate_unverified",
-      "rationale": "Gateway/relay-relevant keyword match; not yet manually verified against TokenKey code.",
-      "updated_at": "2026-06-01T08:37:30Z"
+      "updated_at": "2026-06-04T12:44:02Z"
     },
     {
       "upstream": "anthropics/claude-code#62314",
@@ -2103,18 +2700,6 @@
       "tokenkey_status": "candidate_unverified",
       "rationale": "Gateway/relay-relevant keyword match; not yet manually verified against TokenKey code.",
       "updated_at": "2026-06-01T14:46:59Z"
-    },
-    {
-      "upstream": "anthropics/claude-code#62353",
-      "url": "https://github.com/anthropics/claude-code/issues/62353",
-      "title": "[BUG] --resume normalizes model ID, breaking custom API endpoints that require the original model name",
-      "impact": "needs_review",
-      "categories": [
-        "auth_token"
-      ],
-      "tokenkey_status": "candidate_unverified",
-      "rationale": "Gateway/relay-relevant keyword match; not yet manually verified against TokenKey code.",
-      "updated_at": "2026-06-01T03:55:31Z"
     },
     {
       "upstream": "anthropics/claude-code#62376",
@@ -2174,7 +2759,7 @@
       ],
       "tokenkey_status": "candidate_unverified",
       "rationale": "Gateway/relay-relevant keyword match; not yet manually verified against TokenKey code.",
-      "updated_at": "2026-05-31T22:55:48Z"
+      "updated_at": "2026-06-04T00:17:52Z"
     },
     {
       "upstream": "anthropics/claude-code#62924",
@@ -2212,71 +2797,7 @@
       ],
       "tokenkey_status": "candidate_unverified",
       "rationale": "Gateway/relay-relevant keyword match; not yet manually verified against TokenKey code.",
-      "updated_at": "2026-06-03T07:05:50Z"
-    },
-    {
-      "upstream": "anthropics/claude-code#63120",
-      "url": "https://github.com/anthropics/claude-code/issues/63120",
-      "title": "[BUG] 2.1.153 silently discards tools/list response from rmcp 0.12.0 HTTP MCP server (works in 2.1.152, wire-identical handshake)",
-      "impact": "needs_review",
-      "categories": [
-        "request_shape_400",
-        "fingerprint_ua"
-      ],
-      "tokenkey_status": "candidate_unverified",
-      "rationale": "Gateway/relay-relevant keyword match; not yet manually verified against TokenKey code.",
-      "updated_at": "2026-05-31T20:19:43Z"
-    },
-    {
-      "upstream": "anthropics/claude-code#63141",
-      "url": "https://github.com/anthropics/claude-code/issues/63141",
-      "title": "Subagents on Pro 1M tier: trivial probes pass, real workloads fail at first tool call (probe-vs-workload divergence)",
-      "impact": "needs_review",
-      "categories": [
-        "auth_token",
-        "model_lifecycle"
-      ],
-      "tokenkey_status": "candidate_unverified",
-      "rationale": "Gateway/relay-relevant keyword match; not yet manually verified against TokenKey code.",
-      "updated_at": "2026-05-31T12:35:09Z"
-    },
-    {
-      "upstream": "anthropics/claude-code#63147",
-      "url": "https://github.com/anthropics/claude-code/issues/63147",
-      "title": "Resuming an extended-thinking session fails permanently with 400 \"thinking blocks cannot be modified\" (transcript stores thinking text as empty but keeps signature)",
-      "impact": "needs_review",
-      "categories": [
-        "request_shape_400"
-      ],
-      "tokenkey_status": "candidate_unverified",
-      "rationale": "Gateway/relay-relevant keyword match; not yet manually verified against TokenKey code.",
-      "updated_at": "2026-06-01T01:45:00Z"
-    },
-    {
-      "upstream": "anthropics/claude-code#63192",
-      "url": "https://github.com/anthropics/claude-code/issues/63192",
-      "title": "Cancelling a parallel tool-call batch corrupts thinking blocks -> 400 \"thinking blocks cannot be modified\" permanently wedges the session",
-      "impact": "needs_review",
-      "categories": [
-        "request_shape_400",
-        "model_lifecycle",
-        "new_endpoints"
-      ],
-      "tokenkey_status": "candidate_unverified",
-      "rationale": "Gateway/relay-relevant keyword match; not yet manually verified against TokenKey code.",
-      "updated_at": "2026-05-31T19:24:52Z"
-    },
-    {
-      "upstream": "anthropics/claude-code#63199",
-      "url": "https://github.com/anthropics/claude-code/issues/63199",
-      "title": "[Bug] Anthropic API Error: Cannot Modify Thinking Blocks in Assistant Messages",
-      "impact": "needs_review",
-      "categories": [
-        "request_shape_400"
-      ],
-      "tokenkey_status": "candidate_unverified",
-      "rationale": "Gateway/relay-relevant keyword match; not yet manually verified against TokenKey code.",
-      "updated_at": "2026-05-31T13:57:19Z"
+      "updated_at": "2026-06-03T17:12:00Z"
     },
     {
       "upstream": "anthropics/claude-code#63275",
@@ -2290,20 +2811,6 @@
       "tokenkey_status": "candidate_unverified",
       "rationale": "Gateway/relay-relevant keyword match; not yet manually verified against TokenKey code.",
       "updated_at": "2026-06-02T15:51:18Z"
-    },
-    {
-      "upstream": "anthropics/claude-code#63335",
-      "url": "https://github.com/anthropics/claude-code/issues/63335",
-      "title": "Extended thinking: signed thinking block 'cannot be modified' (400) permanently wedges session",
-      "impact": "needs_review",
-      "categories": [
-        "request_shape_400",
-        "new_endpoints",
-        "fingerprint_ua"
-      ],
-      "tokenkey_status": "candidate_unverified",
-      "rationale": "Gateway/relay-relevant keyword match; not yet manually verified against TokenKey code.",
-      "updated_at": "2026-06-01T12:21:15Z"
     },
     {
       "upstream": "anthropics/claude-code#63358",
@@ -2339,19 +2846,7 @@
       ],
       "tokenkey_status": "candidate_unverified",
       "rationale": "Gateway/relay-relevant keyword match; not yet manually verified against TokenKey code.",
-      "updated_at": "2026-05-31T15:16:36Z"
-    },
-    {
-      "upstream": "anthropics/claude-code#63420",
-      "url": "https://github.com/anthropics/claude-code/issues/63420",
-      "title": "[Bug] Anthropic API Error: Cannot modify thinking blocks in assistant message",
-      "impact": "needs_review",
-      "categories": [
-        "request_shape_400"
-      ],
-      "tokenkey_status": "candidate_unverified",
-      "rationale": "Gateway/relay-relevant keyword match; not yet manually verified against TokenKey code.",
-      "updated_at": "2026-05-31T11:33:50Z"
+      "updated_at": "2026-06-04T02:22:01Z"
     },
     {
       "upstream": "anthropics/claude-code#63454",
@@ -2378,28 +2873,17 @@
       "updated_at": "2026-06-03T08:26:41Z"
     },
     {
-      "upstream": "anthropics/claude-code#63499",
-      "url": "https://github.com/anthropics/claude-code/issues/63499",
-      "title": "[BUG] /compact fails with cyber safeguards false positive during legitimate defensive security session",
+      "upstream": "anthropics/claude-code#63601",
+      "url": "https://github.com/anthropics/claude-code/issues/63601",
+      "title": "[BUG] Long-session compaction loses Write/Edit tool-use history → model misattributes its own work to the user",
       "impact": "needs_review",
       "categories": [
-        "fingerprint_ua"
-      ],
-      "tokenkey_status": "candidate_unverified",
-      "rationale": "Gateway/relay-relevant keyword match; not yet manually verified against TokenKey code.",
-      "updated_at": "2026-06-01T06:32:38Z"
-    },
-    {
-      "upstream": "anthropics/claude-code#63538",
-      "url": "https://github.com/anthropics/claude-code/issues/63538",
-      "title": "Model fabricates tool output (and even a user instruction) when a parallel batch is partially cancelled / appears empty",
-      "impact": "needs_review",
-      "categories": [
+        "request_shape_400",
         "model_lifecycle"
       ],
       "tokenkey_status": "candidate_unverified",
       "rationale": "Gateway/relay-relevant keyword match; not yet manually verified against TokenKey code.",
-      "updated_at": "2026-06-01T01:32:54Z"
+      "updated_at": "2026-06-03T18:04:14Z"
     },
     {
       "upstream": "anthropics/claude-code#63634",
@@ -2412,31 +2896,7 @@
       ],
       "tokenkey_status": "candidate_unverified",
       "rationale": "Gateway/relay-relevant keyword match; not yet manually verified against TokenKey code.",
-      "updated_at": "2026-06-03T07:47:26Z"
-    },
-    {
-      "upstream": "anthropics/claude-code#63642",
-      "url": "https://github.com/anthropics/claude-code/issues/63642",
-      "title": "[BUG] Claude hangs with no output on Linux Mint despite all-green",
-      "impact": "needs_review",
-      "categories": [
-        "auth_token"
-      ],
-      "tokenkey_status": "candidate_unverified",
-      "rationale": "Gateway/relay-relevant keyword match; not yet manually verified against TokenKey code.",
-      "updated_at": "2026-06-01T09:22:26Z"
-    },
-    {
-      "upstream": "anthropics/claude-code#63654",
-      "url": "https://github.com/anthropics/claude-code/issues/63654",
-      "title": "/model picker does not list newly available models (Opus 4.7, 4.8)",
-      "impact": "needs_review",
-      "categories": [
-        "model_lifecycle"
-      ],
-      "tokenkey_status": "candidate_unverified",
-      "rationale": "Gateway/relay-relevant keyword match; not yet manually verified against TokenKey code.",
-      "updated_at": "2026-06-01T10:43:05Z"
+      "updated_at": "2026-06-04T10:00:28Z"
     },
     {
       "upstream": "anthropics/claude-code#63677",
@@ -2449,31 +2909,6 @@
       "tokenkey_status": "candidate_unverified",
       "rationale": "Gateway/relay-relevant keyword match; not yet manually verified against TokenKey code.",
       "updated_at": "2026-06-01T18:22:08Z"
-    },
-    {
-      "upstream": "anthropics/claude-code#63685",
-      "url": "https://github.com/anthropics/claude-code/issues/63685",
-      "title": "Your organization has disabled Claude subscription access for Claude Code · Use an Anthropic API key instead, or ask your admin to enable access",
-      "impact": "needs_review",
-      "categories": [
-        "auth_token"
-      ],
-      "tokenkey_status": "candidate_unverified",
-      "rationale": "Gateway/relay-relevant keyword match; not yet manually verified against TokenKey code.",
-      "updated_at": "2026-05-31T17:38:36Z"
-    },
-    {
-      "upstream": "anthropics/claude-code#63693",
-      "url": "https://github.com/anthropics/claude-code/issues/63693",
-      "title": "[FEATURE] Expose model configuration for subagents in dynamic workflows",
-      "impact": "needs_review",
-      "categories": [
-        "rate_limit",
-        "model_lifecycle"
-      ],
-      "tokenkey_status": "candidate_unverified",
-      "rationale": "Gateway/relay-relevant keyword match; not yet manually verified against TokenKey code.",
-      "updated_at": "2026-05-31T22:34:46Z"
     },
     {
       "upstream": "anthropics/claude-code#63751",
@@ -2498,19 +2933,7 @@
       ],
       "tokenkey_status": "candidate_unverified",
       "rationale": "Gateway/relay-relevant keyword match; not yet manually verified against TokenKey code.",
-      "updated_at": "2026-06-02T16:12:23Z"
-    },
-    {
-      "upstream": "anthropics/claude-code#63797",
-      "url": "https://github.com/anthropics/claude-code/issues/63797",
-      "title": "Bash/Read tool results intermittently return empty (then flush late, redundantly) on Linux — NOT length/concurrency-correlated; same symptom as stale-closed #36038",
-      "impact": "needs_review",
-      "categories": [
-        "request_shape_400"
-      ],
-      "tokenkey_status": "candidate_unverified",
-      "rationale": "Gateway/relay-relevant keyword match; not yet manually verified against TokenKey code.",
-      "updated_at": "2026-06-01T03:38:44Z"
+      "updated_at": "2026-06-03T17:11:17Z"
     },
     {
       "upstream": "anthropics/claude-code#63806",
@@ -2525,44 +2948,6 @@
       "updated_at": "2026-06-03T03:58:32Z"
     },
     {
-      "upstream": "anthropics/claude-code#63825",
-      "url": "https://github.com/anthropics/claude-code/issues/63825",
-      "title": "[BUG] TypeError \"undefined is not an object (evaluating 'H.replace')\" replaces Bash tool output",
-      "impact": "needs_review",
-      "categories": [
-        "request_shape_400",
-        "new_endpoints"
-      ],
-      "tokenkey_status": "candidate_unverified",
-      "rationale": "Gateway/relay-relevant keyword match; not yet manually verified against TokenKey code.",
-      "updated_at": "2026-05-31T12:44:07Z"
-    },
-    {
-      "upstream": "anthropics/claude-code#63861",
-      "url": "https://github.com/anthropics/claude-code/issues/63861",
-      "title": "[BUG] Opus 4.8 in Claude Code declares work \"verified\" / \"done\" without running the canonical build — false-green regression vs. Opus 4.7",
-      "impact": "needs_review",
-      "categories": [
-        "model_lifecycle",
-        "new_endpoints"
-      ],
-      "tokenkey_status": "candidate_unverified",
-      "rationale": "Gateway/relay-relevant keyword match; not yet manually verified against TokenKey code.",
-      "updated_at": "2026-06-01T01:18:08Z"
-    },
-    {
-      "upstream": "anthropics/claude-code#63869",
-      "url": "https://github.com/anthropics/claude-code/issues/63869",
-      "title": "[BUG] API Error: 400 — thinking or redacted_thinking blocks in the latest assistant message cannot be modified.",
-      "impact": "needs_review",
-      "categories": [
-        "request_shape_400"
-      ],
-      "tokenkey_status": "candidate_unverified",
-      "rationale": "Gateway/relay-relevant keyword match; not yet manually verified against TokenKey code.",
-      "updated_at": "2026-05-31T19:47:15Z"
-    },
-    {
       "upstream": "anthropics/claude-code#63870",
       "url": "https://github.com/anthropics/claude-code/issues/63870",
       "title": "[BUG] Bash tool calls emitted as raw <invoke> text instead of executing",
@@ -2572,7 +2957,7 @@
       ],
       "tokenkey_status": "candidate_unverified",
       "rationale": "Gateway/relay-relevant keyword match; not yet manually verified against TokenKey code.",
-      "updated_at": "2026-06-03T01:25:16Z"
+      "updated_at": "2026-06-03T23:39:08Z"
     },
     {
       "upstream": "anthropics/claude-code#63875",
@@ -2584,7 +2969,7 @@
       ],
       "tokenkey_status": "candidate_unverified",
       "rationale": "Gateway/relay-relevant keyword match; not yet manually verified against TokenKey code.",
-      "updated_at": "2026-06-03T08:58:13Z"
+      "updated_at": "2026-06-04T11:18:34Z"
     },
     {
       "upstream": "anthropics/claude-code#63880",
@@ -2613,30 +2998,6 @@
       "updated_at": "2026-06-02T08:56:48Z"
     },
     {
-      "upstream": "anthropics/claude-code#63886",
-      "url": "https://github.com/anthropics/claude-code/issues/63886",
-      "title": "Your organization has disabled Claude subscription access for Claude Code · Use an Anthropic API key instead, or ask your admin to enable access",
-      "impact": "needs_review",
-      "categories": [
-        "auth_token"
-      ],
-      "tokenkey_status": "candidate_unverified",
-      "rationale": "Gateway/relay-relevant keyword match; not yet manually verified against TokenKey code.",
-      "updated_at": "2026-06-01T08:17:53Z"
-    },
-    {
-      "upstream": "anthropics/claude-code#63887",
-      "url": "https://github.com/anthropics/claude-code/issues/63887",
-      "title": "[Bug] Agent spams no-op echo probe commands to flush shell output",
-      "impact": "needs_review",
-      "categories": [
-        "model_lifecycle"
-      ],
-      "tokenkey_status": "candidate_unverified",
-      "rationale": "Gateway/relay-relevant keyword match; not yet manually verified against TokenKey code.",
-      "updated_at": "2026-06-01T02:45:45Z"
-    },
-    {
       "upstream": "anthropics/claude-code#63896",
       "url": "https://github.com/anthropics/claude-code/issues/63896",
       "title": "[BUG] Error: Error during compaction: API Error: Usage credits required for 1M context · turn on usage credits at claude.ai/settings/usage, or use --model to switch to standard context",
@@ -2646,7 +3007,19 @@
       ],
       "tokenkey_status": "candidate_unverified",
       "rationale": "Gateway/relay-relevant keyword match; not yet manually verified against TokenKey code.",
-      "updated_at": "2026-06-03T07:44:02Z"
+      "updated_at": "2026-06-04T09:17:17Z"
+    },
+    {
+      "upstream": "anthropics/claude-code#63919",
+      "url": "https://github.com/anthropics/claude-code/issues/63919",
+      "title": "[BUG] Login succeeds but every request immediately returns \"Not logged in\" (macOS, OAuth)",
+      "impact": "needs_review",
+      "categories": [
+        "auth_token"
+      ],
+      "tokenkey_status": "candidate_unverified",
+      "rationale": "Gateway/relay-relevant keyword match; not yet manually verified against TokenKey code.",
+      "updated_at": "2026-06-03T14:24:17Z"
     },
     {
       "upstream": "anthropics/claude-code#63929",
@@ -2658,7 +3031,7 @@
       ],
       "tokenkey_status": "candidate_unverified",
       "rationale": "Gateway/relay-relevant keyword match; not yet manually verified against TokenKey code.",
-      "updated_at": "2026-06-02T02:02:09Z"
+      "updated_at": "2026-06-04T08:04:05Z"
     },
     {
       "upstream": "anthropics/claude-code#63930",
@@ -2675,21 +3048,6 @@
       "updated_at": "2026-06-01T17:31:12Z"
     },
     {
-      "upstream": "anthropics/claude-code#63966",
-      "url": "https://github.com/anthropics/claude-code/issues/63966",
-      "title": "[BUG] Tool-call results empty in live UI then flush late/out-of-order (Bash, Read, MCP, advisor) — macOS, Opus 4.8, parallel batches",
-      "impact": "needs_review",
-      "categories": [
-        "request_shape_400",
-        "auth_token",
-        "model_lifecycle",
-        "new_endpoints"
-      ],
-      "tokenkey_status": "candidate_unverified",
-      "rationale": "Gateway/relay-relevant keyword match; not yet manually verified against TokenKey code.",
-      "updated_at": "2026-05-31T23:33:17Z"
-    },
-    {
       "upstream": "anthropics/claude-code#64007",
       "url": "https://github.com/anthropics/claude-code/issues/64007",
       "title": "cct = TUI: turn-transition render omission — content recorded in .jsonl but absent from scrollback (2 incidents across 2 versions)",
@@ -2700,20 +3058,6 @@
       "tokenkey_status": "candidate_unverified",
       "rationale": "Gateway/relay-relevant keyword match; not yet manually verified against TokenKey code.",
       "updated_at": "2026-06-01T21:11:50Z"
-    },
-    {
-      "upstream": "anthropics/claude-code#64030",
-      "url": "https://github.com/anthropics/claude-code/issues/64030",
-      "title": "CLI surfaces transient 429 \"rate_limit_error\" to user with no backoff/retry; session sits idle until user types `continue`",
-      "impact": "needs_review",
-      "categories": [
-        "request_shape_400",
-        "rate_limit",
-        "auth_token"
-      ],
-      "tokenkey_status": "candidate_unverified",
-      "rationale": "Gateway/relay-relevant keyword match; not yet manually verified against TokenKey code.",
-      "updated_at": "2026-05-31T23:47:00Z"
     },
     {
       "upstream": "anthropics/claude-code#64034",
@@ -2728,6 +3072,18 @@
       "updated_at": "2026-06-02T03:19:49Z"
     },
     {
+      "upstream": "anthropics/claude-code#64037",
+      "url": "https://github.com/anthropics/claude-code/issues/64037",
+      "title": "Context hit 1M token limit with no auto-compaction and no recovery path",
+      "impact": "needs_review",
+      "categories": [
+        "model_lifecycle"
+      ],
+      "tokenkey_status": "candidate_unverified",
+      "rationale": "Gateway/relay-relevant keyword match; not yet manually verified against TokenKey code.",
+      "updated_at": "2026-06-03T18:36:43Z"
+    },
+    {
       "upstream": "anthropics/claude-code#64047",
       "url": "https://github.com/anthropics/claude-code/issues/64047",
       "title": "[BUG] Automatic parallel-tool-call cancellation is indistinguishable from a user interrupt",
@@ -2738,32 +3094,6 @@
       "tokenkey_status": "candidate_unverified",
       "rationale": "Gateway/relay-relevant keyword match; not yet manually verified against TokenKey code.",
       "updated_at": "2026-06-01T19:01:41Z"
-    },
-    {
-      "upstream": "anthropics/claude-code#64049",
-      "url": "https://github.com/anthropics/claude-code/issues/64049",
-      "title": "[MODEL] Opus 4.8 (max effort) likely hallucinated a prompt-injection in tool output, then acted on it for many turns",
-      "impact": "needs_review",
-      "categories": [
-        "request_shape_400",
-        "model_lifecycle"
-      ],
-      "tokenkey_status": "candidate_unverified",
-      "rationale": "Gateway/relay-relevant keyword match; not yet manually verified against TokenKey code.",
-      "updated_at": "2026-05-31T16:19:46Z"
-    },
-    {
-      "upstream": "anthropics/claude-code#64065",
-      "url": "https://github.com/anthropics/claude-code/issues/64065",
-      "title": "Opus 4.8 / xhigh / Claude Code: model asserts specific tool-output values BEFORE the tool calls return — model self-diagnoses the bug in-context but keeps doing it",
-      "impact": "needs_review",
-      "categories": [
-        "request_shape_400",
-        "model_lifecycle"
-      ],
-      "tokenkey_status": "candidate_unverified",
-      "rationale": "Gateway/relay-relevant keyword match; not yet manually verified against TokenKey code.",
-      "updated_at": "2026-05-31T19:56:17Z"
     },
     {
       "upstream": "anthropics/claude-code#64080",
@@ -2777,31 +3107,7 @@
       ],
       "tokenkey_status": "candidate_unverified",
       "rationale": "Gateway/relay-relevant keyword match; not yet manually verified against TokenKey code.",
-      "updated_at": "2026-06-01T16:43:04Z"
-    },
-    {
-      "upstream": "anthropics/claude-code#64088",
-      "url": "https://github.com/anthropics/claude-code/issues/64088",
-      "title": "[BUG] API Error: Server is temporarily limiting requests (not your usage limit) · Rate limited",
-      "impact": "needs_review",
-      "categories": [
-        "rate_limit"
-      ],
-      "tokenkey_status": "candidate_unverified",
-      "rationale": "Gateway/relay-relevant keyword match; not yet manually verified against TokenKey code.",
-      "updated_at": "2026-05-31T15:45:42Z"
-    },
-    {
-      "upstream": "anthropics/claude-code#64097",
-      "url": "https://github.com/anthropics/claude-code/issues/64097",
-      "title": "[Bug] Claude Opus 4.8 emits malformed tool calls with parsing errors",
-      "impact": "needs_review",
-      "categories": [
-        "model_lifecycle"
-      ],
-      "tokenkey_status": "candidate_unverified",
-      "rationale": "Gateway/relay-relevant keyword match; not yet manually verified against TokenKey code.",
-      "updated_at": "2026-06-01T12:33:17Z"
+      "updated_at": "2026-06-03T13:45:32Z"
     },
     {
       "upstream": "anthropics/claude-code#64127",
@@ -2856,107 +3162,6 @@
       "updated_at": "2026-06-02T16:45:10Z"
     },
     {
-      "upstream": "anthropics/claude-code#64177",
-      "url": "https://github.com/anthropics/claude-code/issues/64177",
-      "title": "Workflow counts API-errored subagents as \"completed\"; 429/500/529 storm under multi-agent load",
-      "impact": "needs_review",
-      "categories": [
-        "rate_limit",
-        "model_lifecycle"
-      ],
-      "tokenkey_status": "candidate_unverified",
-      "rationale": "Gateway/relay-relevant keyword match; not yet manually verified against TokenKey code.",
-      "updated_at": "2026-05-31T21:17:05Z"
-    },
-    {
-      "upstream": "anthropics/claude-code#64190",
-      "url": "https://github.com/anthropics/claude-code/issues/64190",
-      "title": "After /compact on Opus 4.8 (1M), whole tool calls emitted as <invoke> text instead of executing (not seen on 4.7)",
-      "impact": "needs_review",
-      "categories": [
-        "request_shape_400",
-        "model_lifecycle"
-      ],
-      "tokenkey_status": "candidate_unverified",
-      "rationale": "Gateway/relay-relevant keyword match; not yet manually verified against TokenKey code.",
-      "updated_at": "2026-05-31T10:46:01Z"
-    },
-    {
-      "upstream": "anthropics/claude-code#64195",
-      "url": "https://github.com/anthropics/claude-code/issues/64195",
-      "title": "[Feature Request] Restore deprecated Claude Opus versions (4.6, 4.7) with deprecation warnings",
-      "impact": "needs_review",
-      "categories": [
-        "model_lifecycle"
-      ],
-      "tokenkey_status": "candidate_unverified",
-      "rationale": "Gateway/relay-relevant keyword match; not yet manually verified against TokenKey code.",
-      "updated_at": "2026-05-31T11:02:21Z"
-    },
-    {
-      "upstream": "anthropics/claude-code#64196",
-      "url": "https://github.com/anthropics/claude-code/issues/64196",
-      "title": "Claude Pro: 1M context limit breaks active workflows without warning",
-      "impact": "needs_review",
-      "categories": [
-        "request_shape_400"
-      ],
-      "tokenkey_status": "candidate_unverified",
-      "rationale": "Gateway/relay-relevant keyword match; not yet manually verified against TokenKey code.",
-      "updated_at": "2026-05-31T13:21:42Z"
-    },
-    {
-      "upstream": "anthropics/claude-code#64209",
-      "url": "https://github.com/anthropics/claude-code/issues/64209",
-      "title": "[Bug] Tool-layer unreliability in long/compacted sessions: duplicated results, delayed delivery, empty/garbled file reads",
-      "impact": "needs_review",
-      "categories": [
-        "model_lifecycle"
-      ],
-      "tokenkey_status": "candidate_unverified",
-      "rationale": "Gateway/relay-relevant keyword match; not yet manually verified against TokenKey code.",
-      "updated_at": "2026-05-31T19:13:08Z"
-    },
-    {
-      "upstream": "anthropics/claude-code#64212",
-      "url": "https://github.com/anthropics/claude-code/issues/64212",
-      "title": "[MODEL] Opus 4.8 (xhigh): claims work verified when it isn't, self-contradicts, and over-parallelizes contradictory tool calls — on a low-complexity codebase",
-      "impact": "needs_review",
-      "categories": [
-        "model_lifecycle",
-        "new_endpoints",
-        "fingerprint_ua"
-      ],
-      "tokenkey_status": "candidate_unverified",
-      "rationale": "Gateway/relay-relevant keyword match; not yet manually verified against TokenKey code.",
-      "updated_at": "2026-05-31T14:42:58Z"
-    },
-    {
-      "upstream": "anthropics/claude-code#64213",
-      "url": "https://github.com/anthropics/claude-code/issues/64213",
-      "title": "[BUG] 400 \"thinking/redacted_thinking blocks cannot be modified\" bricks session after large multi-tool turns",
-      "impact": "needs_review",
-      "categories": [
-        "request_shape_400",
-        "new_endpoints"
-      ],
-      "tokenkey_status": "candidate_unverified",
-      "rationale": "Gateway/relay-relevant keyword match; not yet manually verified against TokenKey code.",
-      "updated_at": "2026-05-31T14:57:48Z"
-    },
-    {
-      "upstream": "anthropics/claude-code#64216",
-      "url": "https://github.com/anthropics/claude-code/issues/64216",
-      "title": "[Bug] Increased tool call failures and retry attempts with Opus model",
-      "impact": "needs_review",
-      "categories": [
-        "model_lifecycle"
-      ],
-      "tokenkey_status": "candidate_unverified",
-      "rationale": "Gateway/relay-relevant keyword match; not yet manually verified against TokenKey code.",
-      "updated_at": "2026-05-31T13:02:32Z"
-    },
-    {
       "upstream": "anthropics/claude-code#64227",
       "url": "https://github.com/anthropics/claude-code/issues/64227",
       "title": "Claude Code repeatedly made unauthorized destructive changes, ignored explicit rules, and permanently destroyed user data across multiple sessions[MODEL]",
@@ -2967,94 +3172,6 @@
       "tokenkey_status": "candidate_unverified",
       "rationale": "Gateway/relay-relevant keyword match; not yet manually verified against TokenKey code.",
       "updated_at": "2026-06-01T21:39:58Z"
-    },
-    {
-      "upstream": "anthropics/claude-code#64229",
-      "url": "https://github.com/anthropics/claude-code/issues/64229",
-      "title": "Server-side tool (server_tool_use) emitted but no result returned; response reports stop_reason: end_turn",
-      "impact": "needs_review",
-      "categories": [
-        "request_shape_400",
-        "model_lifecycle"
-      ],
-      "tokenkey_status": "candidate_unverified",
-      "rationale": "Gateway/relay-relevant keyword match; not yet manually verified against TokenKey code.",
-      "updated_at": "2026-05-31T21:18:01Z"
-    },
-    {
-      "upstream": "anthropics/claude-code#64232",
-      "url": "https://github.com/anthropics/claude-code/issues/64232",
-      "title": "[Bug] Single-use OAuth refresh token consumed by test copy invalidates production token",
-      "impact": "needs_review",
-      "categories": [
-        "auth_token"
-      ],
-      "tokenkey_status": "candidate_unverified",
-      "rationale": "Gateway/relay-relevant keyword match; not yet manually verified against TokenKey code.",
-      "updated_at": "2026-05-31T14:15:03Z"
-    },
-    {
-      "upstream": "anthropics/claude-code#64233",
-      "url": "https://github.com/anthropics/claude-code/issues/64233",
-      "title": "[BUG] Windows: stopShellPty on tab switch kills session with exit code 4294967295 — regression in May 27+ build",
-      "impact": "needs_review",
-      "categories": [
-        "auth_token"
-      ],
-      "tokenkey_status": "candidate_unverified",
-      "rationale": "Gateway/relay-relevant keyword match; not yet manually verified against TokenKey code.",
-      "updated_at": "2026-05-31T14:23:03Z"
-    },
-    {
-      "upstream": "anthropics/claude-code#64235",
-      "url": "https://github.com/anthropics/claude-code/issues/64235",
-      "title": "Regression (since 2026-05-29): intermittent \"tool call was malformed and could not be parsed\" — tool_use block absent on a stop_reason=tool_use turn",
-      "impact": "needs_review",
-      "categories": [
-        "request_shape_400",
-        "model_lifecycle"
-      ],
-      "tokenkey_status": "candidate_unverified",
-      "rationale": "Gateway/relay-relevant keyword match; not yet manually verified against TokenKey code.",
-      "updated_at": "2026-06-01T04:21:58Z"
-    },
-    {
-      "upstream": "anthropics/claude-code#64237",
-      "url": "https://github.com/anthropics/claude-code/issues/64237",
-      "title": "Expose a way to disable parallel tool execution (the API's disable_parallel_tool_use) in Claude Code",
-      "impact": "needs_review",
-      "categories": [
-        "request_shape_400",
-        "model_lifecycle",
-        "new_endpoints"
-      ],
-      "tokenkey_status": "candidate_unverified",
-      "rationale": "Gateway/relay-relevant keyword match; not yet manually verified against TokenKey code.",
-      "updated_at": "2026-05-31T14:50:17Z"
-    },
-    {
-      "upstream": "anthropics/claude-code#64241",
-      "url": "https://github.com/anthropics/claude-code/issues/64241",
-      "title": "run_in_background silently kills active processes and reports success (exit code 0)",
-      "impact": "needs_review",
-      "categories": [
-        "auth_token"
-      ],
-      "tokenkey_status": "candidate_unverified",
-      "rationale": "Gateway/relay-relevant keyword match; not yet manually verified against TokenKey code.",
-      "updated_at": "2026-05-31T15:09:53Z"
-    },
-    {
-      "upstream": "anthropics/claude-code#64246",
-      "url": "https://github.com/anthropics/claude-code/issues/64246",
-      "title": "Parallel tool-call batch cascades \"Cancelled\" to independent calls when one fails",
-      "impact": "needs_review",
-      "categories": [
-        "model_lifecycle"
-      ],
-      "tokenkey_status": "candidate_unverified",
-      "rationale": "Gateway/relay-relevant keyword match; not yet manually verified against TokenKey code.",
-      "updated_at": "2026-05-31T20:00:39Z"
     },
     {
       "upstream": "anthropics/claude-code#64251",
@@ -3068,31 +3185,6 @@
       "tokenkey_status": "candidate_unverified",
       "rationale": "Gateway/relay-relevant keyword match; not yet manually verified against TokenKey code.",
       "updated_at": "2026-06-02T03:14:12Z"
-    },
-    {
-      "upstream": "anthropics/claude-code#64256",
-      "url": "https://github.com/anthropics/claude-code/issues/64256",
-      "title": "[BUG] Persistent server-side session billing phantom usage — cannot be killed from client",
-      "impact": "needs_review",
-      "categories": [
-        "auth_token",
-        "new_endpoints"
-      ],
-      "tokenkey_status": "candidate_unverified",
-      "rationale": "Gateway/relay-relevant keyword match; not yet manually verified against TokenKey code.",
-      "updated_at": "2026-05-31T16:00:37Z"
-    },
-    {
-      "upstream": "anthropics/claude-code#64257",
-      "url": "https://github.com/anthropics/claude-code/issues/64257",
-      "title": "opus-4-8 appears to re-fetch identical tool results after normal (non-error) returns — 2-3x vs opus-4-7",
-      "impact": "needs_review",
-      "categories": [
-        "prompt_caching"
-      ],
-      "tokenkey_status": "candidate_unverified",
-      "rationale": "Gateway/relay-relevant keyword match; not yet manually verified against TokenKey code.",
-      "updated_at": "2026-06-01T00:01:49Z"
     },
     {
       "upstream": "anthropics/claude-code#64260",
@@ -3109,19 +3201,6 @@
       "updated_at": "2026-06-02T20:18:07Z"
     },
     {
-      "upstream": "anthropics/claude-code#64269",
-      "url": "https://github.com/anthropics/claude-code/issues/64269",
-      "title": "C:/Program Files/Git/schedule fails with \"trouble connecting with your remote claude.ai account\" — persistent, no public status incident",
-      "impact": "needs_review",
-      "categories": [
-        "auth_token",
-        "fingerprint_ua"
-      ],
-      "tokenkey_status": "candidate_unverified",
-      "rationale": "Gateway/relay-relevant keyword match; not yet manually verified against TokenKey code.",
-      "updated_at": "2026-05-31T17:11:18Z"
-    },
-    {
       "upstream": "anthropics/claude-code#64278",
       "url": "https://github.com/anthropics/claude-code/issues/64278",
       "title": "/compact fails with 'thinking or redacted_thinking blocks cannot be modified' error when context is too long",
@@ -3134,154 +3213,6 @@
       "updated_at": "2026-06-03T10:18:50Z"
     },
     {
-      "upstream": "anthropics/claude-code#64284",
-      "url": "https://github.com/anthropics/claude-code/issues/64284",
-      "title": "[Bug] File read errors not surfaced, causing hallucinations in tool use",
-      "impact": "needs_review",
-      "categories": [
-        "rate_limit",
-        "auth_token",
-        "prompt_caching"
-      ],
-      "tokenkey_status": "candidate_unverified",
-      "rationale": "Gateway/relay-relevant keyword match; not yet manually verified against TokenKey code.",
-      "updated_at": "2026-05-31T22:18:26Z"
-    },
-    {
-      "upstream": "anthropics/claude-code#64317",
-      "url": "https://github.com/anthropics/claude-code/issues/64317",
-      "title": "Intermittent tool-result corruption: stale/replayed output + sibling cancellation (v2.1.143)",
-      "impact": "needs_review",
-      "categories": [
-        "request_shape_400"
-      ],
-      "tokenkey_status": "candidate_unverified",
-      "rationale": "Gateway/relay-relevant keyword match; not yet manually verified against TokenKey code.",
-      "updated_at": "2026-05-31T20:55:33Z"
-    },
-    {
-      "upstream": "anthropics/claude-code#64321",
-      "url": "https://github.com/anthropics/claude-code/issues/64321",
-      "title": "[BUG]",
-      "impact": "needs_review",
-      "categories": [
-        "request_shape_400"
-      ],
-      "tokenkey_status": "candidate_unverified",
-      "rationale": "Gateway/relay-relevant keyword match; not yet manually verified against TokenKey code.",
-      "updated_at": "2026-05-31T20:42:55Z"
-    },
-    {
-      "upstream": "anthropics/claude-code#64322",
-      "url": "https://github.com/anthropics/claude-code/issues/64322",
-      "title": "Worktree isolation: Edit-tool path validation + drift-detection in task-notification payload",
-      "impact": "needs_review",
-      "categories": [
-        "model_lifecycle"
-      ],
-      "tokenkey_status": "candidate_unverified",
-      "rationale": "Gateway/relay-relevant keyword match; not yet manually verified against TokenKey code.",
-      "updated_at": "2026-05-31T20:57:27Z"
-    },
-    {
-      "upstream": "anthropics/claude-code#64327",
-      "url": "https://github.com/anthropics/claude-code/issues/64327",
-      "title": "[BUG] API Error: Server is temporarily limiting requests (not your usage limit) · Rate limited",
-      "impact": "needs_review",
-      "categories": [
-        "rate_limit"
-      ],
-      "tokenkey_status": "candidate_unverified",
-      "rationale": "Gateway/relay-relevant keyword match; not yet manually verified against TokenKey code.",
-      "updated_at": "2026-05-31T21:08:41Z"
-    },
-    {
-      "upstream": "anthropics/claude-code#64328",
-      "url": "https://github.com/anthropics/claude-code/issues/64328",
-      "title": "[BUG] Workflow harness retries indefinitely on HTTP 429 rate_limit — 97 agents, 2M tokens burned in 34 seconds ()",
-      "impact": "needs_review",
-      "categories": [
-        "rate_limit"
-      ],
-      "tokenkey_status": "candidate_unverified",
-      "rationale": "Gateway/relay-relevant keyword match; not yet manually verified against TokenKey code.",
-      "updated_at": "2026-05-31T21:27:01Z"
-    },
-    {
-      "upstream": "anthropics/claude-code#64329",
-      "url": "https://github.com/anthropics/claude-code/issues/64329",
-      "title": "Opus 4.8 Model stated multiple unverified claims as fact and fabricates specifics within a single session",
-      "impact": "needs_review",
-      "categories": [
-        "model_lifecycle"
-      ],
-      "tokenkey_status": "candidate_unverified",
-      "rationale": "Gateway/relay-relevant keyword match; not yet manually verified against TokenKey code.",
-      "updated_at": "2026-06-01T03:04:27Z"
-    },
-    {
-      "upstream": "anthropics/claude-code#64330",
-      "url": "https://github.com/anthropics/claude-code/issues/64330",
-      "title": "[BUG] Installer places binary in VS Code Snap directory, leading to silent uninstallation on Ubuntu",
-      "impact": "needs_review",
-      "categories": [
-        "prompt_caching"
-      ],
-      "tokenkey_status": "candidate_unverified",
-      "rationale": "Gateway/relay-relevant keyword match; not yet manually verified against TokenKey code.",
-      "updated_at": "2026-05-31T21:21:49Z"
-    },
-    {
-      "upstream": "anthropics/claude-code#64336",
-      "url": "https://github.com/anthropics/claude-code/issues/64336",
-      "title": "Multiple profile directories (~/.claude-a, ~/.claude-b) require independent re-logins despite sharing the same account",
-      "impact": "needs_review",
-      "categories": [
-        "auth_token"
-      ],
-      "tokenkey_status": "candidate_unverified",
-      "rationale": "Gateway/relay-relevant keyword match; not yet manually verified against TokenKey code.",
-      "updated_at": "2026-06-01T03:07:07Z"
-    },
-    {
-      "upstream": "anthropics/claude-code#64339",
-      "url": "https://github.com/anthropics/claude-code/issues/64339",
-      "title": "[BUG] Thousands of ghost \"root-server\" sessions regenerate on every launch, crashing the app — survive full uninstall/reinstall and all known data clearing",
-      "impact": "needs_review",
-      "categories": [
-        "model_lifecycle"
-      ],
-      "tokenkey_status": "candidate_unverified",
-      "rationale": "Gateway/relay-relevant keyword match; not yet manually verified against TokenKey code.",
-      "updated_at": "2026-05-31T22:18:55Z"
-    },
-    {
-      "upstream": "anthropics/claude-code#64345",
-      "url": "https://github.com/anthropics/claude-code/issues/64345",
-      "title": "[MODEL] Claude ignored instructions/configuration (also: Claude made incorrect assumptions)",
-      "impact": "needs_review",
-      "categories": [
-        "new_endpoints"
-      ],
-      "tokenkey_status": "candidate_unverified",
-      "rationale": "Gateway/relay-relevant keyword match; not yet manually verified against TokenKey code.",
-      "updated_at": "2026-05-31T22:48:37Z"
-    },
-    {
-      "upstream": "anthropics/claude-code#64346",
-      "url": "https://github.com/anthropics/claude-code/issues/64346",
-      "title": "Parallel tool calls: one benign tool error cancels all sibling calls → agent misreads as broken shell and flails",
-      "impact": "needs_review",
-      "categories": [
-        "request_shape_400",
-        "model_lifecycle",
-        "new_endpoints"
-      ],
-      "tokenkey_status": "candidate_unverified",
-      "rationale": "Gateway/relay-relevant keyword match; not yet manually verified against TokenKey code.",
-      "updated_at": "2026-06-01T01:13:16Z"
-    },
-    {
       "upstream": "anthropics/claude-code#64350",
       "url": "https://github.com/anthropics/claude-code/issues/64350",
       "title": "MCP gateway WAF blocks legitimate tool-call bodies (SQL/shell/config text)",
@@ -3292,57 +3223,6 @@
       "tokenkey_status": "candidate_unverified",
       "rationale": "Gateway/relay-relevant keyword match; not yet manually verified against TokenKey code.",
       "updated_at": "2026-06-01T15:36:34Z"
-    },
-    {
-      "upstream": "anthropics/claude-code#64355",
-      "url": "https://github.com/anthropics/claude-code/issues/64355",
-      "title": "[BUG] Opus deleted entire repository without realizing it (corrupt tool call?)",
-      "impact": "needs_review",
-      "categories": [
-        "new_endpoints"
-      ],
-      "tokenkey_status": "candidate_unverified",
-      "rationale": "Gateway/relay-relevant keyword match; not yet manually verified against TokenKey code.",
-      "updated_at": "2026-06-01T12:49:50Z"
-    },
-    {
-      "upstream": "anthropics/claude-code#64357",
-      "url": "https://github.com/anthropics/claude-code/issues/64357",
-      "title": "[Bug] Anthropic API Error: Cannot modify thinking blocks in assistant message",
-      "impact": "needs_review",
-      "categories": [
-        "request_shape_400",
-        "fingerprint_ua"
-      ],
-      "tokenkey_status": "candidate_unverified",
-      "rationale": "Gateway/relay-relevant keyword match; not yet manually verified against TokenKey code.",
-      "updated_at": "2026-06-01T03:07:06Z"
-    },
-    {
-      "upstream": "anthropics/claude-code#64359",
-      "url": "https://github.com/anthropics/claude-code/issues/64359",
-      "title": "Opus 4.8 burns 5h limit in ~30min on operational work; no signal to downgrade to Sonnet",
-      "impact": "needs_review",
-      "categories": [
-        "rate_limit",
-        "model_lifecycle"
-      ],
-      "tokenkey_status": "candidate_unverified",
-      "rationale": "Gateway/relay-relevant keyword match; not yet manually verified against TokenKey code.",
-      "updated_at": "2026-06-01T01:13:04Z"
-    },
-    {
-      "upstream": "anthropics/claude-code#64364",
-      "url": "https://github.com/anthropics/claude-code/issues/64364",
-      "title": "opus-4-8 re-fetches identical tool results after normal (non-error) returns — ~2-3× vs opus-4-7",
-      "impact": "needs_review",
-      "categories": [
-        "model_lifecycle",
-        "prompt_caching"
-      ],
-      "tokenkey_status": "candidate_unverified",
-      "rationale": "Gateway/relay-relevant keyword match; not yet manually verified against TokenKey code.",
-      "updated_at": "2026-06-01T01:32:07Z"
     },
     {
       "upstream": "anthropics/claude-code#64386",
@@ -3358,55 +3238,6 @@
       "updated_at": "2026-06-01T14:38:45Z"
     },
     {
-      "upstream": "anthropics/claude-code#64387",
-      "url": "https://github.com/anthropics/claude-code/issues/64387",
-      "title": "[BUG] Linear MCP OAuth /authorize endpoint redirects to deprecated gdrive install URL",
-      "impact": "needs_review",
-      "categories": [
-        "auth_token",
-        "model_lifecycle"
-      ],
-      "tokenkey_status": "candidate_unverified",
-      "rationale": "Gateway/relay-relevant keyword match; not yet manually verified against TokenKey code.",
-      "updated_at": "2026-06-01T03:53:24Z"
-    },
-    {
-      "upstream": "anthropics/claude-code#64388",
-      "url": "https://github.com/anthropics/claude-code/issues/64388",
-      "title": "Foundry: `/context` shows 200k cap even with 1M beta enabled and `effectiveWindow=1M` confirmed",
-      "impact": "needs_review",
-      "categories": [
-        "model_lifecycle"
-      ],
-      "tokenkey_status": "candidate_unverified",
-      "rationale": "Gateway/relay-relevant keyword match; not yet manually verified against TokenKey code.",
-      "updated_at": "2026-06-01T04:04:26Z"
-    },
-    {
-      "upstream": "anthropics/claude-code#64392",
-      "url": "https://github.com/anthropics/claude-code/issues/64392",
-      "title": "[Bug] Tool calls executing incorrectly and deleting files unintentionally",
-      "impact": "needs_review",
-      "categories": [
-        "auth_token"
-      ],
-      "tokenkey_status": "candidate_unverified",
-      "rationale": "Gateway/relay-relevant keyword match; not yet manually verified against TokenKey code.",
-      "updated_at": "2026-06-01T06:08:41Z"
-    },
-    {
-      "upstream": "anthropics/claude-code#64393",
-      "url": "https://github.com/anthropics/claude-code/issues/64393",
-      "title": "[BUG] Desktop SSH: turns completed while client is disconnected never appear in UI",
-      "impact": "needs_review",
-      "categories": [
-        "new_endpoints"
-      ],
-      "tokenkey_status": "candidate_unverified",
-      "rationale": "Gateway/relay-relevant keyword match; not yet manually verified against TokenKey code.",
-      "updated_at": "2026-06-01T04:31:04Z"
-    },
-    {
       "upstream": "anthropics/claude-code#64397",
       "url": "https://github.com/anthropics/claude-code/issues/64397",
       "title": "[Bug] CCR routines: 3 structural observability gaps — RemoteTrigger.run HTTP 400 + unmerged claude/* fire artifacts + MCP-permission-prompt deadlocks",
@@ -3417,18 +3248,6 @@
       "tokenkey_status": "candidate_unverified",
       "rationale": "Gateway/relay-relevant keyword match; not yet manually verified against TokenKey code.",
       "updated_at": "2026-06-02T16:18:56Z"
-    },
-    {
-      "upstream": "anthropics/claude-code#64402",
-      "url": "https://github.com/anthropics/claude-code/issues/64402",
-      "title": "[Bug] askUserQuestion tool executes twice after user responds",
-      "impact": "needs_review",
-      "categories": [
-        "auth_token"
-      ],
-      "tokenkey_status": "candidate_unverified",
-      "rationale": "Gateway/relay-relevant keyword match; not yet manually verified against TokenKey code.",
-      "updated_at": "2026-06-01T05:30:40Z"
     },
     {
       "upstream": "anthropics/claude-code#64409",
@@ -3442,19 +3261,7 @@
       ],
       "tokenkey_status": "candidate_unverified",
       "rationale": "Gateway/relay-relevant keyword match; not yet manually verified against TokenKey code.",
-      "updated_at": "2026-06-01T06:43:55Z"
-    },
-    {
-      "upstream": "anthropics/claude-code#64414",
-      "url": "https://github.com/anthropics/claude-code/issues/64414",
-      "title": "[BUG] Cowork omits anthropic-workspace-id header on custom gateway (Code works)",
-      "impact": "needs_review",
-      "categories": [
-        "request_shape_400"
-      ],
-      "tokenkey_status": "candidate_unverified",
-      "rationale": "Gateway/relay-relevant keyword match; not yet manually verified against TokenKey code.",
-      "updated_at": "2026-06-01T07:15:23Z"
+      "updated_at": "2026-06-04T09:01:36Z"
     },
     {
       "upstream": "anthropics/claude-code#64418",
@@ -3482,66 +3289,6 @@
       "updated_at": "2026-06-02T14:35:41Z"
     },
     {
-      "upstream": "anthropics/claude-code#64424",
-      "url": "https://github.com/anthropics/claude-code/issues/64424",
-      "title": "[DOCS] Per-feature platform availability is not discoverable in docs",
-      "impact": "needs_review",
-      "categories": [
-        "prompt_caching"
-      ],
-      "tokenkey_status": "candidate_unverified",
-      "rationale": "Gateway/relay-relevant keyword match; not yet manually verified against TokenKey code.",
-      "updated_at": "2026-06-01T08:00:53Z"
-    },
-    {
-      "upstream": "anthropics/claude-code#64425",
-      "url": "https://github.com/anthropics/claude-code/issues/64425",
-      "title": "Remote folder connection fails with \"Host denied (verification failed)\" for specific hostname",
-      "impact": "needs_review",
-      "categories": [
-        "auth_token"
-      ],
-      "tokenkey_status": "candidate_unverified",
-      "rationale": "Gateway/relay-relevant keyword match; not yet manually verified against TokenKey code.",
-      "updated_at": "2026-06-01T08:04:34Z"
-    },
-    {
-      "upstream": "anthropics/claude-code#64426",
-      "url": "https://github.com/anthropics/claude-code/issues/64426",
-      "title": "Bash tool silently strips -flag tokens when a command has a command substitution with a nested $",
-      "impact": "needs_review",
-      "categories": [
-        "model_lifecycle"
-      ],
-      "tokenkey_status": "candidate_unverified",
-      "rationale": "Gateway/relay-relevant keyword match; not yet manually verified against TokenKey code.",
-      "updated_at": "2026-06-01T08:05:56Z"
-    },
-    {
-      "upstream": "anthropics/claude-code#64427",
-      "url": "https://github.com/anthropics/claude-code/issues/64427",
-      "title": "[BUG] Pro plan — 1M context error blocks all requests",
-      "impact": "needs_review",
-      "categories": [
-        "model_lifecycle"
-      ],
-      "tokenkey_status": "candidate_unverified",
-      "rationale": "Gateway/relay-relevant keyword match; not yet manually verified against TokenKey code.",
-      "updated_at": "2026-06-01T08:08:58Z"
-    },
-    {
-      "upstream": "anthropics/claude-code#64432",
-      "url": "https://github.com/anthropics/claude-code/issues/64432",
-      "title": "dontAsk: Write allow-list broken for all path forms on Windows native (2.1.145); PreToolUse hook confirmed workaround",
-      "impact": "needs_review",
-      "categories": [
-        "auth_token"
-      ],
-      "tokenkey_status": "candidate_unverified",
-      "rationale": "Gateway/relay-relevant keyword match; not yet manually verified against TokenKey code.",
-      "updated_at": "2026-06-01T12:21:27Z"
-    },
-    {
       "upstream": "anthropics/claude-code#64436",
       "url": "https://github.com/anthropics/claude-code/issues/64436",
       "title": "Background sessions (claude agents) drop work-phase OTEL logs (user_prompt/api_request) on shutdown",
@@ -3554,54 +3301,6 @@
       "updated_at": "2026-06-01T16:04:13Z"
     },
     {
-      "upstream": "anthropics/claude-code#64438",
-      "url": "https://github.com/anthropics/claude-code/issues/64438",
-      "title": "[Bug] Anthropic API Error: Server temporarily limiting requests due to rate limiting",
-      "impact": "needs_review",
-      "categories": [
-        "rate_limit"
-      ],
-      "tokenkey_status": "candidate_unverified",
-      "rationale": "Gateway/relay-relevant keyword match; not yet manually verified against TokenKey code.",
-      "updated_at": "2026-06-01T09:16:09Z"
-    },
-    {
-      "upstream": "anthropics/claude-code#64439",
-      "url": "https://github.com/anthropics/claude-code/issues/64439",
-      "title": "[BUG] /ultrareview consumes a free trial when the run fails with a server-side rate limit",
-      "impact": "needs_review",
-      "categories": [
-        "rate_limit"
-      ],
-      "tokenkey_status": "candidate_unverified",
-      "rationale": "Gateway/relay-relevant keyword match; not yet manually verified against TokenKey code.",
-      "updated_at": "2026-06-01T13:55:28Z"
-    },
-    {
-      "upstream": "anthropics/claude-code#64462",
-      "url": "https://github.com/anthropics/claude-code/issues/64462",
-      "title": "You've hit your limit · resets 6:30pm (Asia/Calcutta)",
-      "impact": "needs_review",
-      "categories": [
-        "rate_limit"
-      ],
-      "tokenkey_status": "candidate_unverified",
-      "rationale": "Gateway/relay-relevant keyword match; not yet manually verified against TokenKey code.",
-      "updated_at": "2026-06-01T11:06:55Z"
-    },
-    {
-      "upstream": "anthropics/claude-code#64465",
-      "url": "https://github.com/anthropics/claude-code/issues/64465",
-      "title": "[Feature Request] Add confirmation prompt before submitting critical feedback",
-      "impact": "needs_review",
-      "categories": [
-        "auth_token"
-      ],
-      "tokenkey_status": "candidate_unverified",
-      "rationale": "Gateway/relay-relevant keyword match; not yet manually verified against TokenKey code.",
-      "updated_at": "2026-06-01T11:36:44Z"
-    },
-    {
       "upstream": "anthropics/claude-code#64475",
       "url": "https://github.com/anthropics/claude-code/issues/64475",
       "title": "MCP stdio transport dropped on unrecognized notifications/progress token, corrupting in-flight tools/call",
@@ -3611,7 +3310,7 @@
       ],
       "tokenkey_status": "candidate_unverified",
       "rationale": "Gateway/relay-relevant keyword match; not yet manually verified against TokenKey code.",
-      "updated_at": "2026-06-01T12:31:52Z"
+      "updated_at": "2026-06-03T10:43:57Z"
     },
     {
       "upstream": "anthropics/claude-code#64477",
@@ -3624,30 +3323,6 @@
       "tokenkey_status": "candidate_unverified",
       "rationale": "Gateway/relay-relevant keyword match; not yet manually verified against TokenKey code.",
       "updated_at": "2026-06-01T15:25:04Z"
-    },
-    {
-      "upstream": "anthropics/claude-code#64478",
-      "url": "https://github.com/anthropics/claude-code/issues/64478",
-      "title": "[BUG] VSCode UI",
-      "impact": "needs_review",
-      "categories": [
-        "model_lifecycle"
-      ],
-      "tokenkey_status": "candidate_unverified",
-      "rationale": "Gateway/relay-relevant keyword match; not yet manually verified against TokenKey code.",
-      "updated_at": "2026-06-01T12:40:57Z"
-    },
-    {
-      "upstream": "anthropics/claude-code#64482",
-      "url": "https://github.com/anthropics/claude-code/issues/64482",
-      "title": "Hosted Microsoft 365 MCP server OAuth fails with AADSTS900971: No reply address provided",
-      "impact": "needs_review",
-      "categories": [
-        "auth_token"
-      ],
-      "tokenkey_status": "candidate_unverified",
-      "rationale": "Gateway/relay-relevant keyword match; not yet manually verified against TokenKey code.",
-      "updated_at": "2026-06-01T12:53:37Z"
     },
     {
       "upstream": "anthropics/claude-code#64493",
@@ -4013,7 +3688,7 @@
       ],
       "tokenkey_status": "candidate_unverified",
       "rationale": "Gateway/relay-relevant keyword match; not yet manually verified against TokenKey code.",
-      "updated_at": "2026-06-02T03:38:24Z"
+      "updated_at": "2026-06-04T07:29:01Z"
     },
     {
       "upstream": "anthropics/claude-code#64636",
@@ -4061,7 +3736,7 @@
       ],
       "tokenkey_status": "candidate_unverified",
       "rationale": "Gateway/relay-relevant keyword match; not yet manually verified against TokenKey code.",
-      "updated_at": "2026-06-02T20:23:10Z"
+      "updated_at": "2026-06-04T12:31:53Z"
     },
     {
       "upstream": "anthropics/claude-code#64654",
@@ -4249,18 +3924,6 @@
       "updated_at": "2026-06-02T10:03:37Z"
     },
     {
-      "upstream": "anthropics/claude-code#64710",
-      "url": "https://github.com/anthropics/claude-code/issues/64710",
-      "title": "[BUG] Desktop app injects an EMPTY `ANTHROPIC_API_KEY=\"\"` into Claude Code sessions, which disables Remote Control (false positive of the 2.1.139 API-key guard)",
-      "impact": "needs_review",
-      "categories": [
-        "auth_token"
-      ],
-      "tokenkey_status": "candidate_unverified",
-      "rationale": "Gateway/relay-relevant keyword match; not yet manually verified against TokenKey code.",
-      "updated_at": "2026-06-02T10:32:27Z"
-    },
-    {
       "upstream": "anthropics/claude-code#64715",
       "url": "https://github.com/anthropics/claude-code/issues/64715",
       "title": "[BUG] MSIX/Store install does not register claude:// protocol handler → OAuth login loops indefinitely",
@@ -4367,7 +4030,7 @@
       ],
       "tokenkey_status": "candidate_unverified",
       "rationale": "Gateway/relay-relevant keyword match; not yet manually verified against TokenKey code.",
-      "updated_at": "2026-06-03T05:09:22Z"
+      "updated_at": "2026-06-04T09:05:17Z"
     },
     {
       "upstream": "anthropics/claude-code#64777",
@@ -4417,7 +4080,7 @@
       ],
       "tokenkey_status": "candidate_unverified",
       "rationale": "Gateway/relay-relevant keyword match; not yet manually verified against TokenKey code.",
-      "updated_at": "2026-06-02T16:39:49Z"
+      "updated_at": "2026-06-03T17:01:44Z"
     },
     {
       "upstream": "anthropics/claude-code#64797",
@@ -4482,18 +4145,6 @@
       "updated_at": "2026-06-02T17:43:24Z"
     },
     {
-      "upstream": "anthropics/claude-code#64832",
-      "url": "https://github.com/anthropics/claude-code/issues/64832",
-      "title": "Suspected Node.js subprocess leak in v2.1.160 — ~115 node processes exhaust RAM, trigger system-wide OOM",
-      "impact": "needs_review",
-      "categories": [
-        "request_shape_400"
-      ],
-      "tokenkey_status": "candidate_unverified",
-      "rationale": "Gateway/relay-relevant keyword match; not yet manually verified against TokenKey code.",
-      "updated_at": "2026-06-03T00:21:03Z"
-    },
-    {
       "upstream": "anthropics/claude-code#64838",
       "url": "https://github.com/anthropics/claude-code/issues/64838",
       "title": "[BUG] Cowork remote MCP connector — \"Couldn't reach the MCP server\" with auth state desync, reference ID returned for support lookup",
@@ -4503,7 +4154,7 @@
       ],
       "tokenkey_status": "candidate_unverified",
       "rationale": "Gateway/relay-relevant keyword match; not yet manually verified against TokenKey code.",
-      "updated_at": "2026-06-02T20:36:30Z"
+      "updated_at": "2026-06-03T12:51:27Z"
     },
     {
       "upstream": "anthropics/claude-code#64846",
@@ -4540,7 +4191,7 @@
       ],
       "tokenkey_status": "candidate_unverified",
       "rationale": "Gateway/relay-relevant keyword match; not yet manually verified against TokenKey code.",
-      "updated_at": "2026-06-02T20:31:37Z"
+      "updated_at": "2026-06-04T02:04:29Z"
     },
     {
       "upstream": "anthropics/claude-code#64852",
@@ -4640,7 +4291,7 @@
       ],
       "tokenkey_status": "candidate_unverified",
       "rationale": "Gateway/relay-relevant keyword match; not yet manually verified against TokenKey code.",
-      "updated_at": "2026-06-02T23:39:05Z"
+      "updated_at": "2026-06-04T05:20:57Z"
     },
     {
       "upstream": "anthropics/claude-code#64894",
@@ -4765,7 +4416,7 @@
       ],
       "tokenkey_status": "candidate_unverified",
       "rationale": "Gateway/relay-relevant keyword match; not yet manually verified against TokenKey code.",
-      "updated_at": "2026-06-03T03:40:41Z"
+      "updated_at": "2026-06-04T07:22:48Z"
     },
     {
       "upstream": "anthropics/claude-code#64941",
@@ -4849,7 +4500,7 @@
       ],
       "tokenkey_status": "candidate_unverified",
       "rationale": "Gateway/relay-relevant keyword match; not yet manually verified against TokenKey code.",
-      "updated_at": "2026-06-03T06:59:42Z"
+      "updated_at": "2026-06-04T04:58:43Z"
     },
     {
       "upstream": "anthropics/claude-code#64970",
@@ -4861,7 +4512,7 @@
       ],
       "tokenkey_status": "candidate_unverified",
       "rationale": "Gateway/relay-relevant keyword match; not yet manually verified against TokenKey code.",
-      "updated_at": "2026-06-03T10:10:16Z"
+      "updated_at": "2026-06-04T08:24:38Z"
     },
     {
       "upstream": "anthropics/claude-code#64974",
@@ -4873,7 +4524,7 @@
       ],
       "tokenkey_status": "candidate_unverified",
       "rationale": "Gateway/relay-relevant keyword match; not yet manually verified against TokenKey code.",
-      "updated_at": "2026-06-03T07:07:27Z"
+      "updated_at": "2026-06-03T19:39:25Z"
     },
     {
       "upstream": "anthropics/claude-code#64977",
@@ -4885,7 +4536,7 @@
       ],
       "tokenkey_status": "candidate_unverified",
       "rationale": "Gateway/relay-relevant keyword match; not yet manually verified against TokenKey code.",
-      "updated_at": "2026-06-03T07:24:22Z"
+      "updated_at": "2026-06-03T19:58:38Z"
     },
     {
       "upstream": "anthropics/claude-code#64982",
@@ -4961,6 +4612,791 @@
       "updated_at": "2026-06-03T10:00:10Z"
     },
     {
+      "upstream": "anthropics/claude-code#65029",
+      "url": "https://github.com/anthropics/claude-code/issues/65029",
+      "title": "[BUG] 1M context auto-switch triggers at ~72% usage and cannot be disabled via env var",
+      "impact": "needs_review",
+      "categories": [
+        "model_lifecycle"
+      ],
+      "tokenkey_status": "candidate_unverified",
+      "rationale": "Gateway/relay-relevant keyword match; not yet manually verified against TokenKey code.",
+      "updated_at": "2026-06-03T11:15:11Z"
+    },
+    {
+      "upstream": "anthropics/claude-code#65030",
+      "url": "https://github.com/anthropics/claude-code/issues/65030",
+      "title": "Add raw token count fields to statusline input JSON",
+      "impact": "needs_review",
+      "categories": [
+        "prompt_caching"
+      ],
+      "tokenkey_status": "candidate_unverified",
+      "rationale": "Gateway/relay-relevant keyword match; not yet manually verified against TokenKey code.",
+      "updated_at": "2026-06-03T11:26:34Z"
+    },
+    {
+      "upstream": "anthropics/claude-code#65036",
+      "url": "https://github.com/anthropics/claude-code/issues/65036",
+      "title": "[BUG] MCP OAuth: Claude doesn't auto-refresh access tokens, daily \"Connection expired\" despite valid refresh token",
+      "impact": "needs_review",
+      "categories": [
+        "beta_header_drift",
+        "auth_token"
+      ],
+      "tokenkey_status": "candidate_unverified",
+      "rationale": "Gateway/relay-relevant keyword match; not yet manually verified against TokenKey code.",
+      "updated_at": "2026-06-03T17:53:29Z"
+    },
+    {
+      "upstream": "anthropics/claude-code#65051",
+      "url": "https://github.com/anthropics/claude-code/issues/65051",
+      "title": "[Bug] Background (daemon) sessions drop assistant text blocks from transcript when response mixes text with tool_use (regression 2.1.160 → 2.1.161)",
+      "impact": "needs_review",
+      "categories": [
+        "request_shape_400",
+        "model_lifecycle"
+      ],
+      "tokenkey_status": "candidate_unverified",
+      "rationale": "Gateway/relay-relevant keyword match; not yet manually verified against TokenKey code.",
+      "updated_at": "2026-06-03T15:36:12Z"
+    },
+    {
+      "upstream": "anthropics/claude-code#65054",
+      "url": "https://github.com/anthropics/claude-code/issues/65054",
+      "title": "org_level_disabled error with active Pro subscription as personal org admin",
+      "impact": "needs_review",
+      "categories": [
+        "auth_token"
+      ],
+      "tokenkey_status": "candidate_unverified",
+      "rationale": "Gateway/relay-relevant keyword match; not yet manually verified against TokenKey code.",
+      "updated_at": "2026-06-04T12:23:43Z"
+    },
+    {
+      "upstream": "anthropics/claude-code#65065",
+      "url": "https://github.com/anthropics/claude-code/issues/65065",
+      "title": "[Bug] OAuth login fails in tmux environment",
+      "impact": "needs_review",
+      "categories": [
+        "auth_token"
+      ],
+      "tokenkey_status": "candidate_unverified",
+      "rationale": "Gateway/relay-relevant keyword match; not yet manually verified against TokenKey code.",
+      "updated_at": "2026-06-03T17:33:42Z"
+    },
+    {
+      "upstream": "anthropics/claude-code#65081",
+      "url": "https://github.com/anthropics/claude-code/issues/65081",
+      "title": "[BUG] Indica que Bun 1.3.14 crashea en VMs Hyper-V sin AVX expuesto y que debería usar un fallback con Node.js. Es un bug legítimo que afecta a muchos usuarios en VPS Hyper-V.",
+      "impact": "needs_review",
+      "categories": [
+        "model_lifecycle"
+      ],
+      "tokenkey_status": "candidate_unverified",
+      "rationale": "Gateway/relay-relevant keyword match; not yet manually verified against TokenKey code.",
+      "updated_at": "2026-06-03T15:30:01Z"
+    },
+    {
+      "upstream": "anthropics/claude-code#65082",
+      "url": "https://github.com/anthropics/claude-code/issues/65082",
+      "title": "Session interrupted by \"Usage credits required for 1M context\" error",
+      "impact": "needs_review",
+      "categories": [
+        "model_lifecycle"
+      ],
+      "tokenkey_status": "candidate_unverified",
+      "rationale": "Gateway/relay-relevant keyword match; not yet manually verified against TokenKey code.",
+      "updated_at": "2026-06-03T15:34:35Z"
+    },
+    {
+      "upstream": "anthropics/claude-code#65085",
+      "url": "https://github.com/anthropics/claude-code/issues/65085",
+      "title": "[BUG] Model emits Cyrillic homoglyphs in generated identifiers (branch names)",
+      "impact": "needs_review",
+      "categories": [
+        "model_lifecycle"
+      ],
+      "tokenkey_status": "candidate_unverified",
+      "rationale": "Gateway/relay-relevant keyword match; not yet manually verified against TokenKey code.",
+      "updated_at": "2026-06-03T15:38:12Z"
+    },
+    {
+      "upstream": "anthropics/claude-code#65094",
+      "url": "https://github.com/anthropics/claude-code/issues/65094",
+      "title": "claude -p does not wait for --mcp-config MCP servers before the first turn (async connect → tools missing); regression 2.1.110→2.1.119",
+      "impact": "needs_review",
+      "categories": [
+        "request_shape_400"
+      ],
+      "tokenkey_status": "candidate_unverified",
+      "rationale": "Gateway/relay-relevant keyword match; not yet manually verified against TokenKey code.",
+      "updated_at": "2026-06-03T15:57:19Z"
+    },
+    {
+      "upstream": "anthropics/claude-code#65098",
+      "url": "https://github.com/anthropics/claude-code/issues/65098",
+      "title": "Context compaction corrupts server-side tool pairs (advisor_tool_result without server_tool_use)",
+      "impact": "needs_review",
+      "categories": [
+        "request_shape_400"
+      ],
+      "tokenkey_status": "candidate_unverified",
+      "rationale": "Gateway/relay-relevant keyword match; not yet manually verified against TokenKey code.",
+      "updated_at": "2026-06-03T16:02:13Z"
+    },
+    {
+      "upstream": "anthropics/claude-code#65100",
+      "url": "https://github.com/anthropics/claude-code/issues/65100",
+      "title": "Zoho Projects MCP connector returns HTTP 500 on all API calls for Zoho CRM Plus accounts",
+      "impact": "needs_review",
+      "categories": [
+        "auth_token"
+      ],
+      "tokenkey_status": "candidate_unverified",
+      "rationale": "Gateway/relay-relevant keyword match; not yet manually verified against TokenKey code.",
+      "updated_at": "2026-06-03T16:34:12Z"
+    },
+    {
+      "upstream": "anthropics/claude-code#65101",
+      "url": "https://github.com/anthropics/claude-code/issues/65101",
+      "title": "[BUG] oauth_org_not_allowed on personal Pro account — subscription access blocked without any changes",
+      "impact": "needs_review",
+      "categories": [
+        "auth_token",
+        "fingerprint_ua"
+      ],
+      "tokenkey_status": "candidate_unverified",
+      "rationale": "Gateway/relay-relevant keyword match; not yet manually verified against TokenKey code.",
+      "updated_at": "2026-06-03T16:38:35Z"
+    },
+    {
+      "upstream": "anthropics/claude-code#65102",
+      "url": "https://github.com/anthropics/claude-code/issues/65102",
+      "title": "[BUG] API Error: Server is temporarily limiting requests (not your usage limit) · Rate limited",
+      "impact": "needs_review",
+      "categories": [
+        "rate_limit"
+      ],
+      "tokenkey_status": "candidate_unverified",
+      "rationale": "Gateway/relay-relevant keyword match; not yet manually verified against TokenKey code.",
+      "updated_at": "2026-06-03T16:41:45Z"
+    },
+    {
+      "upstream": "anthropics/claude-code#65106",
+      "url": "https://github.com/anthropics/claude-code/issues/65106",
+      "title": "I'm ready to help generate a GitHub issue title for Claude Code, but I don't see a bug report in your message. Could you please provide the bug report details that you'd like me to convert into a concise issue title?",
+      "impact": "needs_review",
+      "categories": [
+        "auth_token"
+      ],
+      "tokenkey_status": "candidate_unverified",
+      "rationale": "Gateway/relay-relevant keyword match; not yet manually verified against TokenKey code.",
+      "updated_at": "2026-06-03T17:03:37Z"
+    },
+    {
+      "upstream": "anthropics/claude-code#65108",
+      "url": "https://github.com/anthropics/claude-code/issues/65108",
+      "title": "ScheduleWakeup loop: status updates not visible to user at wakeups + 60s interval drifts to 71-107s",
+      "impact": "needs_review",
+      "categories": [
+        "model_lifecycle"
+      ],
+      "tokenkey_status": "candidate_unverified",
+      "rationale": "Gateway/relay-relevant keyword match; not yet manually verified against TokenKey code.",
+      "updated_at": "2026-06-03T17:18:35Z"
+    },
+    {
+      "upstream": "anthropics/claude-code#65130",
+      "url": "https://github.com/anthropics/claude-code/issues/65130",
+      "title": "[Bug] Tool calls intermittently emitted as plain text instead of structured blocks, causing parse failures and hard hangs on retry",
+      "impact": "needs_review",
+      "categories": [
+        "request_shape_400",
+        "model_lifecycle"
+      ],
+      "tokenkey_status": "candidate_unverified",
+      "rationale": "Gateway/relay-relevant keyword match; not yet manually verified against TokenKey code.",
+      "updated_at": "2026-06-03T18:00:57Z"
+    },
+    {
+      "upstream": "anthropics/claude-code#65148",
+      "url": "https://github.com/anthropics/claude-code/issues/65148",
+      "title": "[BUG]",
+      "impact": "needs_review",
+      "categories": [
+        "model_lifecycle"
+      ],
+      "tokenkey_status": "candidate_unverified",
+      "rationale": "Gateway/relay-relevant keyword match; not yet manually verified against TokenKey code.",
+      "updated_at": "2026-06-03T19:19:51Z"
+    },
+    {
+      "upstream": "anthropics/claude-code#65152",
+      "url": "https://github.com/anthropics/claude-code/issues/65152",
+      "title": "Haiku subagent made 15 unauthorized file changes when asked to run 2 commands",
+      "impact": "needs_review",
+      "categories": [
+        "auth_token"
+      ],
+      "tokenkey_status": "candidate_unverified",
+      "rationale": "Gateway/relay-relevant keyword match; not yet manually verified against TokenKey code.",
+      "updated_at": "2026-06-03T19:48:26Z"
+    },
+    {
+      "upstream": "anthropics/claude-code#65155",
+      "url": "https://github.com/anthropics/claude-code/issues/65155",
+      "title": "I'd be happy to help you create a GitHub issue title, but I need more information about the problem you're experiencing with Claude Code. Could you please provide: 1. **What error or unexpected behavior are you seeing?** (include any error messages) 2. *",
+      "impact": "needs_review",
+      "categories": [
+        "request_shape_400"
+      ],
+      "tokenkey_status": "candidate_unverified",
+      "rationale": "Gateway/relay-relevant keyword match; not yet manually verified against TokenKey code.",
+      "updated_at": "2026-06-03T20:09:31Z"
+    },
+    {
+      "upstream": "anthropics/claude-code#65158",
+      "url": "https://github.com/anthropics/claude-code/issues/65158",
+      "title": "[BUG] --json-schema flag hangs/produces zero output under Bedrock",
+      "impact": "needs_review",
+      "categories": [
+        "model_lifecycle"
+      ],
+      "tokenkey_status": "candidate_unverified",
+      "rationale": "Gateway/relay-relevant keyword match; not yet manually verified against TokenKey code.",
+      "updated_at": "2026-06-03T20:14:33Z"
+    },
+    {
+      "upstream": "anthropics/claude-code#65162",
+      "url": "https://github.com/anthropics/claude-code/issues/65162",
+      "title": "[MODEL] Uses PowerShell here-string (@'...'@) inside the Bash tool on Windows, silently corrupting a git commit message",
+      "impact": "needs_review",
+      "categories": [
+        "model_lifecycle"
+      ],
+      "tokenkey_status": "candidate_unverified",
+      "rationale": "Gateway/relay-relevant keyword match; not yet manually verified against TokenKey code.",
+      "updated_at": "2026-06-03T20:25:39Z"
+    },
+    {
+      "upstream": "anthropics/claude-code#65165",
+      "url": "https://github.com/anthropics/claude-code/issues/65165",
+      "title": "CLAUDE CODE SE BLOQUEO",
+      "impact": "needs_review",
+      "categories": [
+        "model_lifecycle"
+      ],
+      "tokenkey_status": "candidate_unverified",
+      "rationale": "Gateway/relay-relevant keyword match; not yet manually verified against TokenKey code.",
+      "updated_at": "2026-06-03T20:33:17Z"
+    },
+    {
+      "upstream": "anthropics/claude-code#65172",
+      "url": "https://github.com/anthropics/claude-code/issues/65172",
+      "title": "[BUG] Claude Code DevOps subagent runbook missed an 8.5-day AWS cost anomaly despite explicit daily monitoring requests — $80 burn, structural gap",
+      "impact": "needs_review",
+      "categories": [
+        "request_shape_400",
+        "new_endpoints"
+      ],
+      "tokenkey_status": "candidate_unverified",
+      "rationale": "Gateway/relay-relevant keyword match; not yet manually verified against TokenKey code.",
+      "updated_at": "2026-06-03T22:02:48Z"
+    },
+    {
+      "upstream": "anthropics/claude-code#65175",
+      "url": "https://github.com/anthropics/claude-code/issues/65175",
+      "title": "[BUG] Opus 4.8 refusal on benign code-audit prompt — false positive Usage Policy block",
+      "impact": "needs_review",
+      "categories": [
+        "request_shape_400",
+        "model_lifecycle"
+      ],
+      "tokenkey_status": "candidate_unverified",
+      "rationale": "Gateway/relay-relevant keyword match; not yet manually verified against TokenKey code.",
+      "updated_at": "2026-06-04T08:25:06Z"
+    },
+    {
+      "upstream": "anthropics/claude-code#65179",
+      "url": "https://github.com/anthropics/claude-code/issues/65179",
+      "title": "Feature: hook callback control-plane (local server + per-invocation UUID) so hooks can trigger session operations like compaction",
+      "impact": "needs_review",
+      "categories": [
+        "request_shape_400"
+      ],
+      "tokenkey_status": "candidate_unverified",
+      "rationale": "Gateway/relay-relevant keyword match; not yet manually verified against TokenKey code.",
+      "updated_at": "2026-06-03T21:53:33Z"
+    },
+    {
+      "upstream": "anthropics/claude-code#65187",
+      "url": "https://github.com/anthropics/claude-code/issues/65187",
+      "title": "[DOCS] Permissions docs under-specify Windows path matching and Read deny behavior in Grep/Glob",
+      "impact": "needs_review",
+      "categories": [
+        "model_lifecycle"
+      ],
+      "tokenkey_status": "candidate_unverified",
+      "rationale": "Gateway/relay-relevant keyword match; not yet manually verified against TokenKey code.",
+      "updated_at": "2026-06-03T22:29:29Z"
+    },
+    {
+      "upstream": "anthropics/claude-code#65190",
+      "url": "https://github.com/anthropics/claude-code/issues/65190",
+      "title": "[DOCS] Agent view docs omit recovery when `←` backgrounding cannot start the background service",
+      "impact": "needs_review",
+      "categories": [
+        "rate_limit"
+      ],
+      "tokenkey_status": "candidate_unverified",
+      "rationale": "Gateway/relay-relevant keyword match; not yet manually verified against TokenKey code.",
+      "updated_at": "2026-06-03T22:29:30Z"
+    },
+    {
+      "upstream": "anthropics/claude-code#65192",
+      "url": "https://github.com/anthropics/claude-code/issues/65192",
+      "title": "[DOCS] Runtime error docs omit compact warning-line presentation for failed turns",
+      "impact": "needs_review",
+      "categories": [
+        "rate_limit"
+      ],
+      "tokenkey_status": "candidate_unverified",
+      "rationale": "Gateway/relay-relevant keyword match; not yet manually verified against TokenKey code.",
+      "updated_at": "2026-06-03T22:29:34Z"
+    },
+    {
+      "upstream": "anthropics/claude-code#65193",
+      "url": "https://github.com/anthropics/claude-code/issues/65193",
+      "title": "[DOCS] Setup and agent view docs omit endpoint-security scan delays for new binaries after v2.1.162",
+      "impact": "needs_review",
+      "categories": [
+        "rate_limit"
+      ],
+      "tokenkey_status": "candidate_unverified",
+      "rationale": "Gateway/relay-relevant keyword match; not yet manually verified against TokenKey code.",
+      "updated_at": "2026-06-03T22:29:38Z"
+    },
+    {
+      "upstream": "anthropics/claude-code#65194",
+      "url": "https://github.com/anthropics/claude-code/issues/65194",
+      "title": "[DOCS] Agent view docs omit no-errno spawn failure diagnostics for background dispatches",
+      "impact": "needs_review",
+      "categories": [
+        "rate_limit"
+      ],
+      "tokenkey_status": "candidate_unverified",
+      "rationale": "Gateway/relay-relevant keyword match; not yet manually verified against TokenKey code.",
+      "updated_at": "2026-06-03T22:29:33Z"
+    },
+    {
+      "upstream": "anthropics/claude-code#65197",
+      "url": "https://github.com/anthropics/claude-code/issues/65197",
+      "title": "[Bug] Anthropic API Error: Cannot modify thinking blocks in assistant message",
+      "impact": "needs_review",
+      "categories": [
+        "request_shape_400"
+      ],
+      "tokenkey_status": "candidate_unverified",
+      "rationale": "Gateway/relay-relevant keyword match; not yet manually verified against TokenKey code.",
+      "updated_at": "2026-06-03T22:41:52Z"
+    },
+    {
+      "upstream": "anthropics/claude-code#65207",
+      "url": "https://github.com/anthropics/claude-code/issues/65207",
+      "title": "[BUG] No repositories showing in Routines repo picker — requesting index reset",
+      "impact": "needs_review",
+      "categories": [
+        "auth_token"
+      ],
+      "tokenkey_status": "candidate_unverified",
+      "rationale": "Gateway/relay-relevant keyword match; not yet manually verified against TokenKey code.",
+      "updated_at": "2026-06-03T23:32:26Z"
+    },
+    {
+      "upstream": "anthropics/claude-code#65208",
+      "url": "https://github.com/anthropics/claude-code/issues/65208",
+      "title": "[BUG] Desktop + Bedrock: Haiku 4.5 sent as bare model ID (not inference profile) on Scheduled Task follow-ups → intermittent 400 \"invalid model identifier\"",
+      "impact": "needs_review",
+      "categories": [
+        "request_shape_400",
+        "model_lifecycle"
+      ],
+      "tokenkey_status": "candidate_unverified",
+      "rationale": "Gateway/relay-relevant keyword match; not yet manually verified against TokenKey code.",
+      "updated_at": "2026-06-03T23:39:39Z"
+    },
+    {
+      "upstream": "anthropics/claude-code#65212",
+      "url": "https://github.com/anthropics/claude-code/issues/65212",
+      "title": "[BUG] API Error: Server is temporarily limiting requests (not your usage limit) · Rate limited",
+      "impact": "needs_review",
+      "categories": [
+        "rate_limit"
+      ],
+      "tokenkey_status": "candidate_unverified",
+      "rationale": "Gateway/relay-relevant keyword match; not yet manually verified against TokenKey code.",
+      "updated_at": "2026-06-03T23:44:31Z"
+    },
+    {
+      "upstream": "anthropics/claude-code#65213",
+      "url": "https://github.com/anthropics/claude-code/issues/65213",
+      "title": "[Bug] Multiple Claude Code versions running simultaneously with version locks",
+      "impact": "needs_review",
+      "categories": [
+        "auth_token",
+        "prompt_caching"
+      ],
+      "tokenkey_status": "candidate_unverified",
+      "rationale": "Gateway/relay-relevant keyword match; not yet manually verified against TokenKey code.",
+      "updated_at": "2026-06-03T23:50:51Z"
+    },
+    {
+      "upstream": "anthropics/claude-code#65218",
+      "url": "https://github.com/anthropics/claude-code/issues/65218",
+      "title": "[Bug] Multiple Claude Code version processes running simultaneously causing resource conflicts",
+      "impact": "needs_review",
+      "categories": [
+        "rate_limit",
+        "auth_token",
+        "prompt_caching"
+      ],
+      "tokenkey_status": "candidate_unverified",
+      "rationale": "Gateway/relay-relevant keyword match; not yet manually verified against TokenKey code.",
+      "updated_at": "2026-06-04T00:12:16Z"
+    },
+    {
+      "upstream": "anthropics/claude-code#65221",
+      "url": "https://github.com/anthropics/claude-code/issues/65221",
+      "title": "[Bug] Tool call parsing error: malformed request",
+      "impact": "needs_review",
+      "categories": [
+        "request_shape_400"
+      ],
+      "tokenkey_status": "candidate_unverified",
+      "rationale": "Gateway/relay-relevant keyword match; not yet manually verified against TokenKey code.",
+      "updated_at": "2026-06-04T00:21:29Z"
+    },
+    {
+      "upstream": "anthropics/claude-code#65222",
+      "url": "https://github.com/anthropics/claude-code/issues/65222",
+      "title": "Background subagents die permanently on transient server-side rate limits instead of retrying with backoff",
+      "impact": "needs_review",
+      "categories": [
+        "rate_limit"
+      ],
+      "tokenkey_status": "candidate_unverified",
+      "rationale": "Gateway/relay-relevant keyword match; not yet manually verified against TokenKey code.",
+      "updated_at": "2026-06-04T00:59:21Z"
+    },
+    {
+      "upstream": "anthropics/claude-code#65225",
+      "url": "https://github.com/anthropics/claude-code/issues/65225",
+      "title": "[BUG] False-positive AUP block on Stop-hook auto-continuation — hook's own gate-override instructions pattern-match as guardrail evasion",
+      "impact": "needs_review",
+      "categories": [
+        "model_lifecycle"
+      ],
+      "tokenkey_status": "candidate_unverified",
+      "rationale": "Gateway/relay-relevant keyword match; not yet manually verified against TokenKey code.",
+      "updated_at": "2026-06-04T00:52:49Z"
+    },
+    {
+      "upstream": "anthropics/claude-code#65230",
+      "url": "https://github.com/anthropics/claude-code/issues/65230",
+      "title": "Bug: Opus 4.8 outputs tool calls as code fences instead of executing them",
+      "impact": "needs_review",
+      "categories": [
+        "model_lifecycle"
+      ],
+      "tokenkey_status": "candidate_unverified",
+      "rationale": "Gateway/relay-relevant keyword match; not yet manually verified against TokenKey code.",
+      "updated_at": "2026-06-04T00:52:24Z"
+    },
+    {
+      "upstream": "anthropics/claude-code#65241",
+      "url": "https://github.com/anthropics/claude-code/issues/65241",
+      "title": "[FEATURE] Notification system for VS Code extension — limit reset, task complete, session events",
+      "impact": "needs_review",
+      "categories": [
+        "rate_limit"
+      ],
+      "tokenkey_status": "candidate_unverified",
+      "rationale": "Gateway/relay-relevant keyword match; not yet manually verified against TokenKey code.",
+      "updated_at": "2026-06-04T01:57:49Z"
+    },
+    {
+      "upstream": "anthropics/claude-code#65247",
+      "url": "https://github.com/anthropics/claude-code/issues/65247",
+      "title": "claude-opus-4-8: Extreme latency (>13 min) and repeated malformed tool calls with Extended Thinking + large cache_read context",
+      "impact": "needs_review",
+      "categories": [
+        "rate_limit",
+        "model_lifecycle",
+        "prompt_caching"
+      ],
+      "tokenkey_status": "candidate_unverified",
+      "rationale": "Gateway/relay-relevant keyword match; not yet manually verified against TokenKey code.",
+      "updated_at": "2026-06-04T02:52:34Z"
+    },
+    {
+      "upstream": "anthropics/claude-code#65248",
+      "url": "https://github.com/anthropics/claude-code/issues/65248",
+      "title": "[BUG] Tool calls intermittently emitted as literal text (stray \"count\" + raw <invoke>) instead of executing — Opus 4.8, long Edit-heavy session",
+      "impact": "needs_review",
+      "categories": [
+        "request_shape_400"
+      ],
+      "tokenkey_status": "candidate_unverified",
+      "rationale": "Gateway/relay-relevant keyword match; not yet manually verified against TokenKey code.",
+      "updated_at": "2026-06-04T03:01:56Z"
+    },
+    {
+      "upstream": "anthropics/claude-code#65255",
+      "url": "https://github.com/anthropics/claude-code/issues/65255",
+      "title": "[BUG] Task tools always fail with EPERM (utimensat on lockfile) when CLAUDE_CONFIG_DIR is on Cloud Storage FUSE (Cloud Run + Agent SDK)",
+      "impact": "needs_review",
+      "categories": [
+        "request_shape_400",
+        "model_lifecycle"
+      ],
+      "tokenkey_status": "candidate_unverified",
+      "rationale": "Gateway/relay-relevant keyword match; not yet manually verified against TokenKey code.",
+      "updated_at": "2026-06-04T03:32:34Z"
+    },
+    {
+      "upstream": "anthropics/claude-code#65267",
+      "url": "https://github.com/anthropics/claude-code/issues/65267",
+      "title": "Claude acts on phantom/hallucinated instructions and defends them with circular reasoning when challenged",
+      "impact": "needs_review",
+      "categories": [
+        "model_lifecycle"
+      ],
+      "tokenkey_status": "candidate_unverified",
+      "rationale": "Gateway/relay-relevant keyword match; not yet manually verified against TokenKey code.",
+      "updated_at": "2026-06-04T04:48:17Z"
+    },
+    {
+      "upstream": "anthropics/claude-code#65268",
+      "url": "https://github.com/anthropics/claude-code/issues/65268",
+      "title": "[Feature Request] Remove or deprecate non-functional plugins",
+      "impact": "needs_review",
+      "categories": [
+        "model_lifecycle"
+      ],
+      "tokenkey_status": "candidate_unverified",
+      "rationale": "Gateway/relay-relevant keyword match; not yet manually verified against TokenKey code.",
+      "updated_at": "2026-06-04T04:49:49Z"
+    },
+    {
+      "upstream": "anthropics/claude-code#65277",
+      "url": "https://github.com/anthropics/claude-code/issues/65277",
+      "title": "[Bug] Anthropic API Error: Server-side rate limiting without retry guidance",
+      "impact": "needs_review",
+      "categories": [
+        "rate_limit"
+      ],
+      "tokenkey_status": "candidate_unverified",
+      "rationale": "Gateway/relay-relevant keyword match; not yet manually verified against TokenKey code.",
+      "updated_at": "2026-06-04T06:20:42Z"
+    },
+    {
+      "upstream": "anthropics/claude-code#65281",
+      "url": "https://github.com/anthropics/claude-code/issues/65281",
+      "title": "Feature Request: Allow User-Level Config to Take Priority Over Project-Level Config",
+      "impact": "needs_review",
+      "categories": [
+        "model_lifecycle"
+      ],
+      "tokenkey_status": "candidate_unverified",
+      "rationale": "Gateway/relay-relevant keyword match; not yet manually verified against TokenKey code.",
+      "updated_at": "2026-06-04T06:28:03Z"
+    },
+    {
+      "upstream": "anthropics/claude-code#65288",
+      "url": "https://github.com/anthropics/claude-code/issues/65288",
+      "title": "[DOCS] How do I run on prompt caching for Claude API key?",
+      "impact": "needs_review",
+      "categories": [
+        "prompt_caching"
+      ],
+      "tokenkey_status": "candidate_unverified",
+      "rationale": "Gateway/relay-relevant keyword match; not yet manually verified against TokenKey code.",
+      "updated_at": "2026-06-04T07:13:20Z"
+    },
+    {
+      "upstream": "anthropics/claude-code#65293",
+      "url": "https://github.com/anthropics/claude-code/issues/65293",
+      "title": "[Bug] Skill listing context budget exceeded with truncated descriptions",
+      "impact": "needs_review",
+      "categories": [
+        "rate_limit",
+        "auth_token",
+        "prompt_caching"
+      ],
+      "tokenkey_status": "candidate_unverified",
+      "rationale": "Gateway/relay-relevant keyword match; not yet manually verified against TokenKey code.",
+      "updated_at": "2026-06-04T07:34:26Z"
+    },
+    {
+      "upstream": "anthropics/claude-code#65296",
+      "url": "https://github.com/anthropics/claude-code/issues/65296",
+      "title": "[Bug] Agent inappropriately gates legitimate business tasks behind mandatory confidential document disclosure",
+      "impact": "needs_review",
+      "categories": [
+        "model_lifecycle"
+      ],
+      "tokenkey_status": "candidate_unverified",
+      "rationale": "Gateway/relay-relevant keyword match; not yet manually verified against TokenKey code.",
+      "updated_at": "2026-06-04T07:37:15Z"
+    },
+    {
+      "upstream": "anthropics/claude-code#65302",
+      "url": "https://github.com/anthropics/claude-code/issues/65302",
+      "title": "[Feature Request] Add linting/filtering for non-technical comments in generated code",
+      "impact": "needs_review",
+      "categories": [
+        "prompt_caching"
+      ],
+      "tokenkey_status": "candidate_unverified",
+      "rationale": "Gateway/relay-relevant keyword match; not yet manually verified against TokenKey code.",
+      "updated_at": "2026-06-04T08:06:19Z"
+    },
+    {
+      "upstream": "anthropics/claude-code#65305",
+      "url": "https://github.com/anthropics/claude-code/issues/65305",
+      "title": "[BUG] Claude for Chrome: Authorize button causes infinite loop — X-Frame-Options: sameorigin blocks OAuth",
+      "impact": "needs_review",
+      "categories": [
+        "auth_token"
+      ],
+      "tokenkey_status": "candidate_unverified",
+      "rationale": "Gateway/relay-relevant keyword match; not yet manually verified against TokenKey code.",
+      "updated_at": "2026-06-04T08:19:03Z"
+    },
+    {
+      "upstream": "anthropics/claude-code#65312",
+      "url": "https://github.com/anthropics/claude-code/issues/65312",
+      "title": "Context window severely reduced as of 2026-06-04 — breaking daily development workflows",
+      "impact": "needs_review",
+      "categories": [
+        "request_shape_400"
+      ],
+      "tokenkey_status": "candidate_unverified",
+      "rationale": "Gateway/relay-relevant keyword match; not yet manually verified against TokenKey code.",
+      "updated_at": "2026-06-04T08:58:21Z"
+    },
+    {
+      "upstream": "anthropics/claude-code#65315",
+      "url": "https://github.com/anthropics/claude-code/issues/65315",
+      "title": "Error UX: throttle 'not your usage limit' vs opaque 'invalid_request' indistinguishable on Max plan",
+      "impact": "needs_review",
+      "categories": [
+        "request_shape_400",
+        "rate_limit"
+      ],
+      "tokenkey_status": "candidate_unverified",
+      "rationale": "Gateway/relay-relevant keyword match; not yet manually verified against TokenKey code.",
+      "updated_at": "2026-06-04T09:06:15Z"
+    },
+    {
+      "upstream": "anthropics/claude-code#65320",
+      "url": "https://github.com/anthropics/claude-code/issues/65320",
+      "title": "setup-token OAuth token returns 401 Invalid bearer token with claude -p on Max subscription (interactive login on same account works)",
+      "impact": "needs_review",
+      "categories": [
+        "auth_token"
+      ],
+      "tokenkey_status": "candidate_unverified",
+      "rationale": "Gateway/relay-relevant keyword match; not yet manually verified against TokenKey code.",
+      "updated_at": "2026-06-04T09:23:23Z"
+    },
+    {
+      "upstream": "anthropics/claude-code#65328",
+      "url": "https://github.com/anthropics/claude-code/issues/65328",
+      "title": "[BUG] Wave of false-positive Usage Policy blocks since 2026-06-03 ~17:00 UTC — 15 blocked requests across unrelated projects, Italian-language prompts, local config audited clean",
+      "impact": "needs_review",
+      "categories": [
+        "model_lifecycle"
+      ],
+      "tokenkey_status": "candidate_unverified",
+      "rationale": "Gateway/relay-relevant keyword match; not yet manually verified against TokenKey code.",
+      "updated_at": "2026-06-04T11:43:01Z"
+    },
+    {
+      "upstream": "anthropics/claude-code#65330",
+      "url": "https://github.com/anthropics/claude-code/issues/65330",
+      "title": "[BUG] Desktop App (Cowork/local agent mode): AskUserQuestion never renders — hangs until session stop auto-denies (regression since 2026-06-03; re-filing locked #26940)",
+      "impact": "needs_review",
+      "categories": [
+        "request_shape_400",
+        "model_lifecycle"
+      ],
+      "tokenkey_status": "candidate_unverified",
+      "rationale": "Gateway/relay-relevant keyword match; not yet manually verified against TokenKey code.",
+      "updated_at": "2026-06-04T09:46:32Z"
+    },
+    {
+      "upstream": "anthropics/claude-code#65336",
+      "url": "https://github.com/anthropics/claude-code/issues/65336",
+      "title": "[Billing Bug] Charged extra usage due to caching failure (1M token compaction) + 2 day outage - Support Refusing Refund",
+      "impact": "needs_review",
+      "categories": [
+        "prompt_caching"
+      ],
+      "tokenkey_status": "candidate_unverified",
+      "rationale": "Gateway/relay-relevant keyword match; not yet manually verified against TokenKey code.",
+      "updated_at": "2026-06-04T10:08:40Z"
+    },
+    {
+      "upstream": "anthropics/claude-code#65339",
+      "url": "https://github.com/anthropics/claude-code/issues/65339",
+      "title": "[BUG] Assistant text after tool results dropped from TUI · regression in v2.1.162 · partially persists on v2.1.161 (follow-up to #24691)",
+      "impact": "needs_review",
+      "categories": [
+        "prompt_caching"
+      ],
+      "tokenkey_status": "candidate_unverified",
+      "rationale": "Gateway/relay-relevant keyword match; not yet manually verified against TokenKey code.",
+      "updated_at": "2026-06-04T10:19:00Z"
+    },
+    {
+      "upstream": "anthropics/claude-code#65347",
+      "url": "https://github.com/anthropics/claude-code/issues/65347",
+      "title": "[BUG] Claude Code wasted significant paid quota on a task it should have flagged as high-risk upfront",
+      "impact": "needs_review",
+      "categories": [
+        "model_lifecycle"
+      ],
+      "tokenkey_status": "candidate_unverified",
+      "rationale": "Gateway/relay-relevant keyword match; not yet manually verified against TokenKey code.",
+      "updated_at": "2026-06-04T11:08:14Z"
+    },
+    {
+      "upstream": "anthropics/claude-code#65359",
+      "url": "https://github.com/anthropics/claude-code/issues/65359",
+      "title": "Error: 'usage credits required for 1M context' when session grows long on non-1M model",
+      "impact": "needs_review",
+      "categories": [
+        "model_lifecycle"
+      ],
+      "tokenkey_status": "candidate_unverified",
+      "rationale": "Gateway/relay-relevant keyword match; not yet manually verified against TokenKey code.",
+      "updated_at": "2026-06-04T12:03:37Z"
+    },
+    {
+      "upstream": "anthropics/claude-code#65363",
+      "url": "https://github.com/anthropics/claude-code/issues/65363",
+      "title": "Degenerate token repetition in long sessions, only stoppable by user interrupt",
+      "impact": "needs_review",
+      "categories": [
+        "model_lifecycle"
+      ],
+      "tokenkey_status": "candidate_unverified",
+      "rationale": "Gateway/relay-relevant keyword match; not yet manually verified against TokenKey code.",
+      "updated_at": "2026-06-04T12:11:48Z"
+    },
+    {
       "upstream": "anthropics/claude-code#8327",
       "url": "https://github.com/anthropics/claude-code/issues/8327",
       "title": "[Bug/Documentation] 'Organization has been disabled' error when ANTHROPIC_API_KEY overrides Max/Pro subscription",
@@ -4994,7 +5430,31 @@
       ],
       "tokenkey_status": "not_prioritized",
       "rationale": "Possible gateway compatibility/streaming impact, but not a high-severity relay signal in this pass.",
-      "updated_at": "2026-06-02T23:21:45Z"
+      "updated_at": "2026-06-04T01:51:11Z"
+    },
+    {
+      "upstream": "anthropics/claude-code#34278",
+      "url": "https://github.com/anthropics/claude-code/issues/34278",
+      "title": "[DOCS] Context window docs missing auto-compaction circuit breaker behavior (stops after 3 failures)",
+      "impact": "medium",
+      "categories": [
+        "token_limits"
+      ],
+      "tokenkey_status": "not_prioritized",
+      "rationale": "Possible gateway compatibility/streaming impact, but not a high-severity relay signal in this pass.",
+      "updated_at": "2026-06-03T11:39:51Z"
+    },
+    {
+      "upstream": "anthropics/claude-code#34835",
+      "url": "https://github.com/anthropics/claude-code/issues/34835",
+      "title": "[FEATURE] The ability to queue up messages.via asking the user for further info on user input.",
+      "impact": "medium",
+      "categories": [
+        "effort_structured"
+      ],
+      "tokenkey_status": "not_prioritized",
+      "rationale": "Possible gateway compatibility/streaming impact, but not a high-severity relay signal in this pass.",
+      "updated_at": "2026-06-03T18:00:36Z"
     },
     {
       "upstream": "anthropics/claude-code#36678",
@@ -5010,6 +5470,30 @@
       "updated_at": "2026-06-02T11:31:43Z"
     },
     {
+      "upstream": "anthropics/claude-code#41265",
+      "url": "https://github.com/anthropics/claude-code/issues/41265",
+      "title": "[DOCS] Headless and Agent SDK docs do not explain error result payloads beyond subtype names",
+      "impact": "medium",
+      "categories": [
+        "effort_structured"
+      ],
+      "tokenkey_status": "not_prioritized",
+      "rationale": "Possible gateway compatibility/streaming impact, but not a high-severity relay signal in this pass.",
+      "updated_at": "2026-06-03T11:39:53Z"
+    },
+    {
+      "upstream": "anthropics/claude-code#41617",
+      "url": "https://github.com/anthropics/claude-code/issues/41617",
+      "title": "Excessive token consumption after recent updates (Max plan)",
+      "impact": "medium",
+      "categories": [
+        "token_limits"
+      ],
+      "tokenkey_status": "not_prioritized",
+      "rationale": "Possible gateway compatibility/streaming impact, but not a high-severity relay signal in this pass.",
+      "updated_at": "2026-06-04T03:27:29Z"
+    },
+    {
       "upstream": "anthropics/claude-code#52819",
       "url": "https://github.com/anthropics/claude-code/issues/52819",
       "title": "ultrareview crashed before producing findings — free credit consumed",
@@ -5020,6 +5504,18 @@
       "tokenkey_status": "not_prioritized",
       "rationale": "Possible gateway compatibility/streaming impact, but not a high-severity relay signal in this pass.",
       "updated_at": "2026-06-02T22:44:07Z"
+    },
+    {
+      "upstream": "anthropics/claude-code#55297",
+      "url": "https://github.com/anthropics/claude-code/issues/55297",
+      "title": "[BUG] claude -p with active Agent Team: 'shut down before final response' system-reminder fires every assistant turn, persists after team cleanup, induces premature shutdown (regression introduced in 2.1.126)",
+      "impact": "medium",
+      "categories": [
+        "token_limits"
+      ],
+      "tokenkey_status": "not_prioritized",
+      "rationale": "Possible gateway compatibility/streaming impact, but not a high-severity relay signal in this pass.",
+      "updated_at": "2026-06-04T01:56:13Z"
     },
     {
       "upstream": "anthropics/claude-code#55814",
@@ -5046,18 +5542,6 @@
       "updated_at": "2026-06-02T11:33:06Z"
     },
     {
-      "upstream": "anthropics/claude-code#63024",
-      "url": "https://github.com/anthropics/claude-code/issues/63024",
-      "title": "Add option to hide email address from welcome banner",
-      "impact": "medium",
-      "categories": [
-        "effort_structured"
-      ],
-      "tokenkey_status": "not_prioritized",
-      "rationale": "Possible gateway compatibility/streaming impact, but not a high-severity relay signal in this pass.",
-      "updated_at": "2026-06-01T03:58:07Z"
-    },
-    {
       "upstream": "anthropics/claude-code#63456",
       "url": "https://github.com/anthropics/claude-code/issues/63456",
       "title": "Opus 4.8 not selectable in CLI `/model` despite being available on account",
@@ -5067,43 +5551,7 @@
       ],
       "tokenkey_status": "not_prioritized",
       "rationale": "Possible gateway compatibility/streaming impact, but not a high-severity relay signal in this pass.",
-      "updated_at": "2026-06-01T17:51:07Z"
-    },
-    {
-      "upstream": "anthropics/claude-code#64028",
-      "url": "https://github.com/anthropics/claude-code/issues/64028",
-      "title": "claude --bg daemon idle-exit (5s) races client handshake → \"socket missing\"",
-      "impact": "medium",
-      "categories": [
-        "streaming_sse"
-      ],
-      "tokenkey_status": "not_prioritized",
-      "rationale": "Possible gateway compatibility/streaming impact, but not a high-severity relay signal in this pass.",
-      "updated_at": "2026-05-31T21:18:44Z"
-    },
-    {
-      "upstream": "anthropics/claude-code#64280",
-      "url": "https://github.com/anthropics/claude-code/issues/64280",
-      "title": "Wrong Charges of extra credits!!",
-      "impact": "medium",
-      "categories": [
-        "token_limits"
-      ],
-      "tokenkey_status": "not_prioritized",
-      "rationale": "Possible gateway compatibility/streaming impact, but not a high-severity relay signal in this pass.",
-      "updated_at": "2026-05-31T17:52:44Z"
-    },
-    {
-      "upstream": "anthropics/claude-code#64408",
-      "url": "https://github.com/anthropics/claude-code/issues/64408",
-      "title": "[Bug] Multilingual token mixing in extended context with web search and bash execution",
-      "impact": "medium",
-      "categories": [
-        "token_limits"
-      ],
-      "tokenkey_status": "not_prioritized",
-      "rationale": "Possible gateway compatibility/streaming impact, but not a high-severity relay signal in this pass.",
-      "updated_at": "2026-06-01T06:28:16Z"
+      "updated_at": "2026-06-03T11:34:15Z"
     },
     {
       "upstream": "anthropics/claude-code#64428",
@@ -5116,7 +5564,7 @@
       ],
       "tokenkey_status": "not_prioritized",
       "rationale": "Possible gateway compatibility/streaming impact, but not a high-severity relay signal in this pass.",
-      "updated_at": "2026-06-01T08:16:13Z"
+      "updated_at": "2026-06-03T14:35:58Z"
     },
     {
       "upstream": "anthropics/claude-code#64445",
@@ -5128,19 +5576,7 @@
       ],
       "tokenkey_status": "not_prioritized",
       "rationale": "Possible gateway compatibility/streaming impact, but not a high-severity relay signal in this pass.",
-      "updated_at": "2026-06-01T11:44:23Z"
-    },
-    {
-      "upstream": "anthropics/claude-code#64468",
-      "url": "https://github.com/anthropics/claude-code/issues/64468",
-      "title": "[FEATURE] Allow manually overriding session status + a 'Closed'/'Archived' state in agent view",
-      "impact": "medium",
-      "categories": [
-        "streaming_sse"
-      ],
-      "tokenkey_status": "not_prioritized",
-      "rationale": "Possible gateway compatibility/streaming impact, but not a high-severity relay signal in this pass.",
-      "updated_at": "2026-06-01T11:58:39Z"
+      "updated_at": "2026-06-03T10:26:19Z"
     },
     {
       "upstream": "anthropics/claude-code#64546",
@@ -5176,7 +5612,7 @@
       ],
       "tokenkey_status": "not_prioritized",
       "rationale": "Possible gateway compatibility/streaming impact, but not a high-severity relay signal in this pass.",
-      "updated_at": "2026-06-03T03:05:07Z"
+      "updated_at": "2026-06-03T13:02:45Z"
     },
     {
       "upstream": "anthropics/claude-code#64740",
@@ -5227,28 +5663,52 @@
       "updated_at": "2026-06-02T18:38:16Z"
     },
     {
-      "upstream": "anthropics/claude-code#11447",
-      "url": "https://github.com/anthropics/claude-code/issues/11447",
-      "title": "[BUG] Claude can't edit files that use tabs for indentation",
-      "impact": "not_applicable",
+      "upstream": "anthropics/claude-code#65107",
+      "url": "https://github.com/anthropics/claude-code/issues/65107",
+      "title": "Model behavior: gated readiness words (\"mergeable\") emitted from single API signal despite explicit repeated in-context prohibition",
+      "impact": "medium",
       "categories": [
-        "terminal"
+        "token_limits"
       ],
-      "tokenkey_status": "not_applicable",
-      "rationale": "Client-side claude-code concern (terminal); not a gateway/relay relevance signal.",
-      "updated_at": "2026-06-01T09:43:28Z"
+      "tokenkey_status": "not_prioritized",
+      "rationale": "Possible gateway compatibility/streaming impact, but not a high-severity relay signal in this pass.",
+      "updated_at": "2026-06-03T17:14:29Z"
     },
     {
-      "upstream": "anthropics/claude-code#12346",
-      "url": "https://github.com/anthropics/claude-code/issues/12346",
-      "title": "[FEATURE] Add GitLab Integration (Repository Connection, MRs, Mobile Access)",
-      "impact": "not_applicable",
+      "upstream": "anthropics/claude-code#65206",
+      "url": "https://github.com/anthropics/claude-code/issues/65206",
+      "title": "[BUG] Desktop Code tab: /workflows works but /deep-research & ultracode can't initiate a run (workflows toggle ON)",
+      "impact": "medium",
       "categories": [
-        "ide"
+        "effort_structured"
       ],
-      "tokenkey_status": "not_applicable",
-      "rationale": "Client-side claude-code concern (ide); not a gateway/relay relevance signal.",
-      "updated_at": "2026-06-01T11:31:08Z"
+      "tokenkey_status": "not_prioritized",
+      "rationale": "Possible gateway compatibility/streaming impact, but not a high-severity relay signal in this pass.",
+      "updated_at": "2026-06-04T10:14:31Z"
+    },
+    {
+      "upstream": "anthropics/claude-code#65290",
+      "url": "https://github.com/anthropics/claude-code/issues/65290",
+      "title": "[FEATURE] Warn user before context window limit is reached (not after)",
+      "impact": "medium",
+      "categories": [
+        "token_limits"
+      ],
+      "tokenkey_status": "not_prioritized",
+      "rationale": "Possible gateway compatibility/streaming impact, but not a high-severity relay signal in this pass.",
+      "updated_at": "2026-06-04T07:20:10Z"
+    },
+    {
+      "upstream": "anthropics/claude-code#65292",
+      "url": "https://github.com/anthropics/claude-code/issues/65292",
+      "title": "[FEATURE] Real-time cost/token usage display and warnings in Claude Code",
+      "impact": "medium",
+      "categories": [
+        "token_limits"
+      ],
+      "tokenkey_status": "not_prioritized",
+      "rationale": "Possible gateway compatibility/streaming impact, but not a high-severity relay signal in this pass.",
+      "updated_at": "2026-06-04T08:42:10Z"
     },
     {
       "upstream": "anthropics/claude-code#12531",
@@ -5300,19 +5760,19 @@
       ],
       "tokenkey_status": "not_applicable",
       "rationale": "Client-side claude-code concern (terminal); not a gateway/relay relevance signal.",
-      "updated_at": "2026-06-01T17:01:05Z"
+      "updated_at": "2026-06-04T02:12:56Z"
     },
     {
-      "upstream": "anthropics/claude-code#14131",
-      "url": "https://github.com/anthropics/claude-code/issues/14131",
-      "title": "[BUG] German umlauts (ä, ö, ü) randomly replaced with ASCII substitutes (ae, oe, ue)",
+      "upstream": "anthropics/claude-code#13843",
+      "url": "https://github.com/anthropics/claude-code/issues/13843",
+      "title": "Share conversation context from Claude.ai to Claude Code",
       "impact": "not_applicable",
       "categories": [
         "terminal"
       ],
       "tokenkey_status": "not_applicable",
       "rationale": "Client-side claude-code concern (terminal); not a gateway/relay relevance signal.",
-      "updated_at": "2026-06-01T05:07:58Z"
+      "updated_at": "2026-06-03T15:59:09Z"
     },
     {
       "upstream": "anthropics/claude-code#14200",
@@ -5327,16 +5787,16 @@
       "updated_at": "2026-06-02T11:18:55Z"
     },
     {
-      "upstream": "anthropics/claude-code#1509",
-      "url": "https://github.com/anthropics/claude-code/issues/1509",
-      "title": "[BUG] Claude code spitting out random characters in user input area while running",
+      "upstream": "anthropics/claude-code#14836",
+      "url": "https://github.com/anthropics/claude-code/issues/14836",
+      "title": "[BUG] /skills command doesn't find skills in symlinked directories",
       "impact": "not_applicable",
       "categories": [
         "terminal"
       ],
       "tokenkey_status": "not_applicable",
       "rationale": "Client-side claude-code concern (terminal); not a gateway/relay relevance signal.",
-      "updated_at": "2026-06-01T08:07:53Z"
+      "updated_at": "2026-06-03T11:14:54Z"
     },
     {
       "upstream": "anthropics/claude-code#15199",
@@ -5350,7 +5810,20 @@
       ],
       "tokenkey_status": "not_applicable",
       "rationale": "Client-side claude-code concern (ide, terminal, platform); not a gateway/relay relevance signal.",
-      "updated_at": "2026-05-31T20:55:46Z"
+      "updated_at": "2026-06-03T21:26:14Z"
+    },
+    {
+      "upstream": "anthropics/claude-code#15637",
+      "url": "https://github.com/anthropics/claude-code/issues/15637",
+      "title": "Hardcoded /tmp/claude paths break on Termux (Android)",
+      "impact": "not_applicable",
+      "categories": [
+        "terminal",
+        "install"
+      ],
+      "tokenkey_status": "not_applicable",
+      "rationale": "Client-side claude-code concern (terminal, install); not a gateway/relay relevance signal.",
+      "updated_at": "2026-06-03T21:47:40Z"
     },
     {
       "upstream": "anthropics/claude-code#15942",
@@ -5366,7 +5839,7 @@
       ],
       "tokenkey_status": "not_applicable",
       "rationale": "Client-side claude-code concern (ide, terminal, plugin, slash_hook, platform); not a gateway/relay relevance signal.",
-      "updated_at": "2026-06-03T10:18:21Z"
+      "updated_at": "2026-06-04T11:22:51Z"
     },
     {
       "upstream": "anthropics/claude-code#16135",
@@ -5393,6 +5866,19 @@
       "updated_at": "2026-06-03T08:36:58Z"
     },
     {
+      "upstream": "anthropics/claude-code#16236",
+      "url": "https://github.com/anthropics/claude-code/issues/16236",
+      "title": "Feature Request: Conversation Branching for Context-Preserving Exploration",
+      "impact": "not_applicable",
+      "categories": [
+        "ide",
+        "plugin"
+      ],
+      "tokenkey_status": "not_applicable",
+      "rationale": "Client-side claude-code concern (ide, plugin); not a gateway/relay relevance signal.",
+      "updated_at": "2026-06-04T11:07:26Z"
+    },
+    {
       "upstream": "anthropics/claude-code#16446",
       "url": "https://github.com/anthropics/claude-code/issues/16446",
       "title": "[FEATURE] LaTeX rendering in \"Claude Code for VS Code\" plugin",
@@ -5404,7 +5890,7 @@
       ],
       "tokenkey_status": "not_applicable",
       "rationale": "Client-side claude-code concern (ide, terminal, plugin); not a gateway/relay relevance signal.",
-      "updated_at": "2026-06-01T20:35:24Z"
+      "updated_at": "2026-06-04T02:11:21Z"
     },
     {
       "upstream": "anthropics/claude-code#16507",
@@ -5431,6 +5917,71 @@
       "updated_at": "2026-06-02T22:44:35Z"
     },
     {
+      "upstream": "anthropics/claude-code#17149",
+      "url": "https://github.com/anthropics/claude-code/issues/17149",
+      "title": "[BUG] LSP workspaceSymbol operation sends empty query parameter",
+      "impact": "not_applicable",
+      "categories": [
+        "terminal",
+        "install",
+        "platform"
+      ],
+      "tokenkey_status": "not_applicable",
+      "rationale": "Client-side claude-code concern (terminal, install, platform); not a gateway/relay relevance signal.",
+      "updated_at": "2026-06-04T00:46:58Z"
+    },
+    {
+      "upstream": "anthropics/claude-code#17432",
+      "url": "https://github.com/anthropics/claude-code/issues/17432",
+      "title": "Feature Request: India-Specific Pricing Plans (INR) for Claude & Claude Code",
+      "impact": "not_applicable",
+      "categories": [
+        "ide"
+      ],
+      "tokenkey_status": "not_applicable",
+      "rationale": "Client-side claude-code concern (ide); not a gateway/relay relevance signal.",
+      "updated_at": "2026-06-03T19:42:20Z"
+    },
+    {
+      "upstream": "anthropics/claude-code#17968",
+      "url": "https://github.com/anthropics/claude-code/issues/17968",
+      "title": "[FEATURE] Support JSONC format for settings files (settings.jsonc)",
+      "impact": "not_applicable",
+      "categories": [
+        "ide",
+        "slash_hook",
+        "install"
+      ],
+      "tokenkey_status": "not_applicable",
+      "rationale": "Client-side claude-code concern (ide, slash_hook, install); not a gateway/relay relevance signal.",
+      "updated_at": "2026-06-03T16:37:19Z"
+    },
+    {
+      "upstream": "anthropics/claude-code#18061",
+      "url": "https://github.com/anthropics/claude-code/issues/18061",
+      "title": "[DOCS] Contradiction regarding WSL support for Chrome integration between documentation and changelog",
+      "impact": "not_applicable",
+      "categories": [
+        "ide",
+        "platform"
+      ],
+      "tokenkey_status": "not_applicable",
+      "rationale": "Client-side claude-code concern (ide, platform); not a gateway/relay relevance signal.",
+      "updated_at": "2026-06-03T11:40:56Z"
+    },
+    {
+      "upstream": "anthropics/claude-code#18170",
+      "url": "https://github.com/anthropics/claude-code/issues/18170",
+      "title": "Copy/paste from terminal includes unwanted indentation and trailing spaces",
+      "impact": "not_applicable",
+      "categories": [
+        "terminal"
+      ],
+      "tokenkey_status": "not_applicable",
+      "rationale": "Client-side claude-code concern (terminal); not a gateway/relay relevance signal.",
+      "updated_at": "2026-06-03T21:27:07Z"
+    },
+    {
       "upstream": "anthropics/claude-code#18435",
       "url": "https://github.com/anthropics/claude-code/issues/18435",
       "title": "[FEATURE] Add the ability to manage multiple Claude accounts within the Claude Desktop app with easy switching between profiles.",
@@ -5442,7 +5993,19 @@
       ],
       "tokenkey_status": "not_applicable",
       "rationale": "Client-side claude-code concern (ide, mcp, slash_hook); not a gateway/relay relevance signal.",
-      "updated_at": "2026-06-01T13:05:18Z"
+      "updated_at": "2026-06-04T10:53:07Z"
+    },
+    {
+      "upstream": "anthropics/claude-code#19426",
+      "url": "https://github.com/anthropics/claude-code/issues/19426",
+      "title": "[DOCS] Undocumented \"Clear Context\" transition options in Plan Mode",
+      "impact": "not_applicable",
+      "categories": [
+        "ide"
+      ],
+      "tokenkey_status": "not_applicable",
+      "rationale": "Client-side claude-code concern (ide); not a gateway/relay relevance signal.",
+      "updated_at": "2026-06-03T22:44:52Z"
     },
     {
       "upstream": "anthropics/claude-code#19976",
@@ -5456,6 +6019,31 @@
       "tokenkey_status": "not_applicable",
       "rationale": "Client-side claude-code concern (terminal, slash_hook); not a gateway/relay relevance signal.",
       "updated_at": "2026-06-01T21:04:21Z"
+    },
+    {
+      "upstream": "anthropics/claude-code#20412",
+      "url": "https://github.com/anthropics/claude-code/issues/20412",
+      "title": "Claude.ai MCP servers auto-injected into Claude Code without opt-in — causes OOM crashes on resource-constrained systems",
+      "impact": "not_applicable",
+      "categories": [
+        "mcp"
+      ],
+      "tokenkey_status": "not_applicable",
+      "rationale": "Client-side claude-code concern (mcp); not a gateway/relay relevance signal.",
+      "updated_at": "2026-06-03T20:38:58Z"
+    },
+    {
+      "upstream": "anthropics/claude-code#20473",
+      "url": "https://github.com/anthropics/claude-code/issues/20473",
+      "title": "[BUG] PowerPoint By Anthropic MCP Connector",
+      "impact": "not_applicable",
+      "categories": [
+        "terminal",
+        "mcp"
+      ],
+      "tokenkey_status": "not_applicable",
+      "rationale": "Client-side claude-code concern (terminal, mcp); not a gateway/relay relevance signal.",
+      "updated_at": "2026-06-03T22:45:41Z"
     },
     {
       "upstream": "anthropics/claude-code#20697",
@@ -5507,7 +6095,7 @@
       ],
       "tokenkey_status": "not_applicable",
       "rationale": "Client-side claude-code concern (terminal, slash_hook); not a gateway/relay relevance signal.",
-      "updated_at": "2026-06-03T04:23:36Z"
+      "updated_at": "2026-06-03T18:37:46Z"
     },
     {
       "upstream": "anthropics/claude-code#24055",
@@ -5560,18 +6148,41 @@
       "updated_at": "2026-06-02T07:35:51Z"
     },
     {
-      "upstream": "anthropics/claude-code#25128",
-      "url": "https://github.com/anthropics/claude-code/issues/25128",
-      "title": "[BUG] Drag and drop not working in VS Code extension chat panel (works in terminal CLI)",
+      "upstream": "anthropics/claude-code#24798",
+      "url": "https://github.com/anthropics/claude-code/issues/24798",
+      "title": "Inter-session communication for multi-Claude workflows",
+      "impact": "not_applicable",
+      "categories": [
+        "terminal"
+      ],
+      "tokenkey_status": "not_applicable",
+      "rationale": "Client-side claude-code concern (terminal); not a gateway/relay relevance signal.",
+      "updated_at": "2026-06-03T17:09:46Z"
+    },
+    {
+      "upstream": "anthropics/claude-code#25434",
+      "url": "https://github.com/anthropics/claude-code/issues/25434",
+      "title": "[DOCS] Session docs missing nested-Claude launch guard behavior and recovery guidance",
+      "impact": "not_applicable",
+      "categories": [
+        "terminal"
+      ],
+      "tokenkey_status": "not_applicable",
+      "rationale": "Client-side claude-code concern (terminal); not a gateway/relay relevance signal.",
+      "updated_at": "2026-06-03T11:40:38Z"
+    },
+    {
+      "upstream": "anthropics/claude-code#25456",
+      "url": "https://github.com/anthropics/claude-code/issues/25456",
+      "title": "[DOCS] @-mention anchor fragment syntax (`@file.md#section`) is undocumented",
       "impact": "not_applicable",
       "categories": [
         "ide",
-        "terminal",
-        "platform"
+        "terminal"
       ],
       "tokenkey_status": "not_applicable",
-      "rationale": "Client-side claude-code concern (ide, terminal, platform); not a gateway/relay relevance signal.",
-      "updated_at": "2026-05-31T17:45:56Z"
+      "rationale": "Client-side claude-code concern (ide, terminal); not a gateway/relay relevance signal.",
+      "updated_at": "2026-06-03T11:40:36Z"
     },
     {
       "upstream": "anthropics/claude-code#25791",
@@ -5586,6 +6197,18 @@
       "tokenkey_status": "not_applicable",
       "rationale": "Client-side claude-code concern (terminal, mcp, platform); not a gateway/relay relevance signal.",
       "updated_at": "2026-06-02T17:27:11Z"
+    },
+    {
+      "upstream": "anthropics/claude-code#26165",
+      "url": "https://github.com/anthropics/claude-code/issues/26165",
+      "title": "[DOCS] VS Code docs should clarify relationship between vscode.dev and Claude Code on the web",
+      "impact": "not_applicable",
+      "categories": [
+        "ide"
+      ],
+      "tokenkey_status": "not_applicable",
+      "rationale": "Client-side claude-code concern (ide); not a gateway/relay relevance signal.",
+      "updated_at": "2026-06-03T11:40:36Z"
     },
     {
       "upstream": "anthropics/claude-code#26224",
@@ -5611,6 +6234,42 @@
       "tokenkey_status": "not_applicable",
       "rationale": "Client-side claude-code concern (ide); not a gateway/relay relevance signal.",
       "updated_at": "2026-06-02T13:16:51Z"
+    },
+    {
+      "upstream": "anthropics/claude-code#2682",
+      "url": "https://github.com/anthropics/claude-code/issues/2682",
+      "title": "[BUG] \"MCP Tools Not Available in Conversation Interface Despite Successful Connection\"",
+      "impact": "not_applicable",
+      "categories": [
+        "mcp"
+      ],
+      "tokenkey_status": "not_applicable",
+      "rationale": "Client-side claude-code concern (mcp); not a gateway/relay relevance signal.",
+      "updated_at": "2026-06-04T11:49:44Z"
+    },
+    {
+      "upstream": "anthropics/claude-code#26904",
+      "url": "https://github.com/anthropics/claude-code/issues/26904",
+      "title": "[FEATURE] Add /delete command to delete current session",
+      "impact": "not_applicable",
+      "categories": [
+        "terminal"
+      ],
+      "tokenkey_status": "not_applicable",
+      "rationale": "Client-side claude-code concern (terminal); not a gateway/relay relevance signal.",
+      "updated_at": "2026-06-03T17:55:40Z"
+    },
+    {
+      "upstream": "anthropics/claude-code#27018",
+      "url": "https://github.com/anthropics/claude-code/issues/27018",
+      "title": "[DOCS] `plugin enable`/`plugin disable` docs still show `--scope` default as `user`",
+      "impact": "not_applicable",
+      "categories": [
+        "plugin"
+      ],
+      "tokenkey_status": "not_applicable",
+      "rationale": "Client-side claude-code concern (plugin); not a gateway/relay relevance signal.",
+      "updated_at": "2026-06-03T11:40:48Z"
     },
     {
       "upstream": "anthropics/claude-code#27302",
@@ -5640,6 +6299,19 @@
       "updated_at": "2026-06-02T15:54:45Z"
     },
     {
+      "upstream": "anthropics/claude-code#27725",
+      "url": "https://github.com/anthropics/claude-code/issues/27725",
+      "title": "[FEATURE] Detachable OS-level windows in desktop app for split screen",
+      "impact": "not_applicable",
+      "categories": [
+        "terminal",
+        "platform"
+      ],
+      "tokenkey_status": "not_applicable",
+      "rationale": "Client-side claude-code concern (terminal, platform); not a gateway/relay relevance signal.",
+      "updated_at": "2026-06-04T05:38:17Z"
+    },
+    {
       "upstream": "anthropics/claude-code#2805",
       "url": "https://github.com/anthropics/claude-code/issues/2805",
       "title": "[BUG] Claude Code consistently creates files with Windows line endings on Linux systems",
@@ -5652,6 +6324,19 @@
       "updated_at": "2026-06-03T08:28:54Z"
     },
     {
+      "upstream": "anthropics/claude-code#28240",
+      "url": "https://github.com/anthropics/claude-code/issues/28240",
+      "title": "[BUG] Permission prompt incorrectly triggers on cd instead of the actual command in compound bash statements",
+      "impact": "not_applicable",
+      "categories": [
+        "terminal",
+        "platform"
+      ],
+      "tokenkey_status": "not_applicable",
+      "rationale": "Client-side claude-code concern (terminal, platform); not a gateway/relay relevance signal.",
+      "updated_at": "2026-06-03T15:41:22Z"
+    },
+    {
       "upstream": "anthropics/claude-code#28300",
       "url": "https://github.com/anthropics/claude-code/issues/28300",
       "title": "[FEATURE] Multi-agent collaboration across machines (Agent-to-Agent protocol)",
@@ -5662,7 +6347,19 @@
       ],
       "tokenkey_status": "not_applicable",
       "rationale": "Client-side claude-code concern (terminal, mcp); not a gateway/relay relevance signal.",
-      "updated_at": "2026-06-01T00:32:42Z"
+      "updated_at": "2026-06-03T21:31:45Z"
+    },
+    {
+      "upstream": "anthropics/claude-code#28372",
+      "url": "https://github.com/anthropics/claude-code/issues/28372",
+      "title": "[DOCS] Hooks: add stability warning for many parallel hooks on the same matcher",
+      "impact": "not_applicable",
+      "categories": [
+        "slash_hook"
+      ],
+      "tokenkey_status": "not_applicable",
+      "rationale": "Client-side claude-code concern (slash_hook); not a gateway/relay relevance signal.",
+      "updated_at": "2026-06-03T11:40:47Z"
     },
     {
       "upstream": "anthropics/claude-code#28508",
@@ -5703,19 +6400,17 @@
       "updated_at": "2026-06-03T04:51:08Z"
     },
     {
-      "upstream": "anthropics/claude-code#2933",
-      "url": "https://github.com/anthropics/claude-code/issues/2933",
-      "title": "VS Code Extension Ignores Global dangerously-skip-permissions Setting",
+      "upstream": "anthropics/claude-code#29359",
+      "url": "https://github.com/anthropics/claude-code/issues/29359",
+      "title": "[BUG] Failed to start Claude's workspace on Domain Computer",
       "impact": "not_applicable",
       "categories": [
-        "ide",
         "terminal",
-        "slash_hook",
-        "install"
+        "platform"
       ],
       "tokenkey_status": "not_applicable",
-      "rationale": "Client-side claude-code concern (ide, terminal, slash_hook, install); not a gateway/relay relevance signal.",
-      "updated_at": "2026-06-01T12:15:24Z"
+      "rationale": "Client-side claude-code concern (terminal, platform); not a gateway/relay relevance signal.",
+      "updated_at": "2026-06-03T22:45:55Z"
     },
     {
       "upstream": "anthropics/claude-code#29423",
@@ -5731,17 +6426,40 @@
       "updated_at": "2026-06-01T22:46:21Z"
     },
     {
-      "upstream": "anthropics/claude-code#29449",
-      "url": "https://github.com/anthropics/claude-code/issues/29449",
-      "title": "[BUG] \"Remote Control environments are not available for your account.\" for Claude Code Pro Plan user",
+      "upstream": "anthropics/claude-code#29508",
+      "url": "https://github.com/anthropics/claude-code/issues/29508",
+      "title": "[DOCS] Interactive mode docs omit persistent \"Always copy full response\" behavior in `/copy`",
       "impact": "not_applicable",
       "categories": [
-        "ide",
+        "slash_hook"
+      ],
+      "tokenkey_status": "not_applicable",
+      "rationale": "Client-side claude-code concern (slash_hook); not a gateway/relay relevance signal.",
+      "updated_at": "2026-06-03T11:40:52Z"
+    },
+    {
+      "upstream": "anthropics/claude-code#29580",
+      "url": "https://github.com/anthropics/claude-code/issues/29580",
+      "title": "[BUG] DISABLE_TELEMETRY=1 breaks remote-control with misleading \"not yet enabled\" error",
+      "impact": "not_applicable",
+      "categories": [
         "terminal"
       ],
       "tokenkey_status": "not_applicable",
-      "rationale": "Client-side claude-code concern (ide, terminal); not a gateway/relay relevance signal.",
-      "updated_at": "2026-06-01T08:30:00Z"
+      "rationale": "Client-side claude-code concern (terminal); not a gateway/relay relevance signal.",
+      "updated_at": "2026-06-03T16:51:46Z"
+    },
+    {
+      "upstream": "anthropics/claude-code#29796",
+      "url": "https://github.com/anthropics/claude-code/issues/29796",
+      "title": "[BUG] remote-control command not recognized - \"Unknown skill: remote-control\"",
+      "impact": "not_applicable",
+      "categories": [
+        "terminal"
+      ],
+      "tokenkey_status": "not_applicable",
+      "rationale": "Client-side claude-code concern (terminal); not a gateway/relay relevance signal.",
+      "updated_at": "2026-06-03T22:45:25Z"
     },
     {
       "upstream": "anthropics/claude-code#29937",
@@ -5768,6 +6486,31 @@
       "updated_at": "2026-06-02T22:44:37Z"
     },
     {
+      "upstream": "anthropics/claude-code#30154",
+      "url": "https://github.com/anthropics/claude-code/issues/30154",
+      "title": "FEATURE: Multi-window support in Claude Code Desktop",
+      "impact": "not_applicable",
+      "categories": [
+        "terminal",
+        "platform"
+      ],
+      "tokenkey_status": "not_applicable",
+      "rationale": "Client-side claude-code concern (terminal, platform); not a gateway/relay relevance signal.",
+      "updated_at": "2026-06-04T08:57:14Z"
+    },
+    {
+      "upstream": "anthropics/claude-code#30199",
+      "url": "https://github.com/anthropics/claude-code/issues/30199",
+      "title": "Ink focus-out re-render triggers iTerm2 activity indicator on tab switch",
+      "impact": "not_applicable",
+      "categories": [
+        "terminal"
+      ],
+      "tokenkey_status": "not_applicable",
+      "rationale": "Client-side claude-code concern (terminal); not a gateway/relay relevance signal.",
+      "updated_at": "2026-06-03T18:12:16Z"
+    },
+    {
       "upstream": "anthropics/claude-code#30232",
       "url": "https://github.com/anthropics/claude-code/issues/30232",
       "title": "Show status line during permission prompts and user questions",
@@ -5778,31 +6521,6 @@
       "tokenkey_status": "not_applicable",
       "rationale": "Client-side claude-code concern (terminal); not a gateway/relay relevance signal.",
       "updated_at": "2026-06-02T11:32:39Z"
-    },
-    {
-      "upstream": "anthropics/claude-code#30407",
-      "url": "https://github.com/anthropics/claude-code/issues/30407",
-      "title": "[workflow issue] all issues get auto-closed without review??",
-      "impact": "not_applicable",
-      "categories": [
-        "ide",
-        "terminal"
-      ],
-      "tokenkey_status": "not_applicable",
-      "rationale": "Client-side claude-code concern (ide, terminal); not a gateway/relay relevance signal.",
-      "updated_at": "2026-06-01T05:31:08Z"
-    },
-    {
-      "upstream": "anthropics/claude-code#30519",
-      "url": "https://github.com/anthropics/claude-code/issues/30519",
-      "title": "Permissions matching is fundamentally broken — 30+ open issues, no staff engagement, community building workarounds",
-      "impact": "not_applicable",
-      "categories": [
-        "slash_hook"
-      ],
-      "tokenkey_status": "not_applicable",
-      "rationale": "Client-side claude-code concern (slash_hook); not a gateway/relay relevance signal.",
-      "updated_at": "2026-05-31T22:40:15Z"
     },
     {
       "upstream": "anthropics/claude-code#30533",
@@ -5817,16 +6535,16 @@
       "updated_at": "2026-06-01T18:40:35Z"
     },
     {
-      "upstream": "anthropics/claude-code#30660",
-      "url": "https://github.com/anthropics/claude-code/issues/30660",
-      "title": "Stream extended thinking output in real-time during interactive mode",
+      "upstream": "anthropics/claude-code#30897",
+      "url": "https://github.com/anthropics/claude-code/issues/30897",
+      "title": "Feature Request: InstructionsLoaded Hook — Batch Event, Content Hashes, and Context Injection",
       "impact": "not_applicable",
       "categories": [
-        "terminal"
+        "slash_hook"
       ],
       "tokenkey_status": "not_applicable",
-      "rationale": "Client-side claude-code concern (terminal); not a gateway/relay relevance signal.",
-      "updated_at": "2026-05-31T13:42:40Z"
+      "rationale": "Client-side claude-code concern (slash_hook); not a gateway/relay relevance signal.",
+      "updated_at": "2026-06-04T11:07:41Z"
     },
     {
       "upstream": "anthropics/claude-code#31012",
@@ -5856,6 +6574,71 @@
       "updated_at": "2026-06-02T06:22:19Z"
     },
     {
+      "upstream": "anthropics/claude-code#31352",
+      "url": "https://github.com/anthropics/claude-code/issues/31352",
+      "title": "[DOCS] Interactive command reference missing `/color` reset variants (`default`, `gray`, `reset`, `none`)",
+      "impact": "not_applicable",
+      "categories": [
+        "terminal",
+        "slash_hook"
+      ],
+      "tokenkey_status": "not_applicable",
+      "rationale": "Client-side claude-code concern (terminal, slash_hook); not a gateway/relay relevance signal.",
+      "updated_at": "2026-06-03T11:40:47Z"
+    },
+    {
+      "upstream": "anthropics/claude-code#31678",
+      "url": "https://github.com/anthropics/claude-code/issues/31678",
+      "title": "[DOCS] Plugin marketplace docs missing @ ref separator and update behavior for pinned marketplaces",
+      "impact": "not_applicable",
+      "categories": [
+        "plugin",
+        "install"
+      ],
+      "tokenkey_status": "not_applicable",
+      "rationale": "Client-side claude-code concern (plugin, install); not a gateway/relay relevance signal.",
+      "updated_at": "2026-06-03T11:39:40Z"
+    },
+    {
+      "upstream": "anthropics/claude-code#31682",
+      "url": "https://github.com/anthropics/claude-code/issues/31682",
+      "title": "[DOCS] MCP docs missing plugin-provided server deduplication behavior",
+      "impact": "not_applicable",
+      "categories": [
+        "mcp",
+        "plugin"
+      ],
+      "tokenkey_status": "not_applicable",
+      "rationale": "Client-side claude-code concern (mcp, plugin); not a gateway/relay relevance signal.",
+      "updated_at": "2026-06-03T11:39:39Z"
+    },
+    {
+      "upstream": "anthropics/claude-code#31683",
+      "url": "https://github.com/anthropics/claude-code/issues/31683",
+      "title": "[DOCS] Sub-agents docs missing background agent completion notification content and output file path",
+      "impact": "not_applicable",
+      "categories": [
+        "plugin"
+      ],
+      "tokenkey_status": "not_applicable",
+      "rationale": "Client-side claude-code concern (plugin); not a gateway/relay relevance signal.",
+      "updated_at": "2026-06-03T11:39:40Z"
+    },
+    {
+      "upstream": "anthropics/claude-code#31684",
+      "url": "https://github.com/anthropics/claude-code/issues/31684",
+      "title": "[DOCS] Plugin uninstall docs missing settings.local.json behavior for project-scoped plugins",
+      "impact": "not_applicable",
+      "categories": [
+        "plugin",
+        "slash_hook",
+        "install"
+      ],
+      "tokenkey_status": "not_applicable",
+      "rationale": "Client-side claude-code concern (plugin, slash_hook, install); not a gateway/relay relevance signal.",
+      "updated_at": "2026-06-03T11:39:38Z"
+    },
+    {
       "upstream": "anthropics/claude-code#31977",
       "url": "https://github.com/anthropics/claude-code/issues/31977",
       "title": "[BUG] In-process team agents lack the Agent tool (cannot spawn subagents)",
@@ -5880,34 +6663,6 @@
       "updated_at": "2026-06-03T00:39:21Z"
     },
     {
-      "upstream": "anthropics/claude-code#32362",
-      "url": "https://github.com/anthropics/claude-code/issues/32362",
-      "title": "[Feature Request] Zed IDE integration support",
-      "impact": "not_applicable",
-      "categories": [
-        "ide",
-        "terminal",
-        "plugin"
-      ],
-      "tokenkey_status": "not_applicable",
-      "rationale": "Client-side claude-code concern (ide, terminal, plugin); not a gateway/relay relevance signal.",
-      "updated_at": "2026-05-31T22:03:07Z"
-    },
-    {
-      "upstream": "anthropics/claude-code#32364",
-      "url": "https://github.com/anthropics/claude-code/issues/32364",
-      "title": "[FEATURE] Support OpenTelemetry (OTel) configuration in Claude Code on the Web (claude.ai/code)",
-      "impact": "not_applicable",
-      "categories": [
-        "ide",
-        "slash_hook",
-        "platform"
-      ],
-      "tokenkey_status": "not_applicable",
-      "rationale": "Client-side claude-code concern (ide, slash_hook, platform); not a gateway/relay relevance signal.",
-      "updated_at": "2026-05-31T23:44:49Z"
-    },
-    {
       "upstream": "anthropics/claude-code#32508",
       "url": "https://github.com/anthropics/claude-code/issues/32508",
       "title": "[MODEL] System prompt \"Output efficiency\" section causes action-before-understanding bias, degrading code quality",
@@ -5920,17 +6675,30 @@
       "updated_at": "2026-06-01T22:46:17Z"
     },
     {
-      "upstream": "anthropics/claude-code#32524",
-      "url": "https://github.com/anthropics/claude-code/issues/32524",
-      "title": "[BUG] MCP tool parameters with type: number are sent as strings to MCP servers",
+      "upstream": "anthropics/claude-code#32791",
+      "url": "https://github.com/anthropics/claude-code/issues/32791",
+      "title": "Image paste (Ctrl+V) stopped working in Windows Terminal",
       "impact": "not_applicable",
       "categories": [
-        "mcp",
-        "install"
+        "terminal",
+        "slash_hook",
+        "platform"
       ],
       "tokenkey_status": "not_applicable",
-      "rationale": "Client-side claude-code concern (mcp, install); not a gateway/relay relevance signal.",
-      "updated_at": "2026-05-31T19:54:10Z"
+      "rationale": "Client-side claude-code concern (terminal, slash_hook, platform); not a gateway/relay relevance signal.",
+      "updated_at": "2026-06-03T15:44:54Z"
+    },
+    {
+      "upstream": "anthropics/claude-code#33045",
+      "url": "https://github.com/anthropics/claude-code/issues/33045",
+      "title": "[BUG] Agent tool isolation: \"worktree\" has no effect for team agents — agent runs in main repo",
+      "impact": "not_applicable",
+      "categories": [
+        "terminal"
+      ],
+      "tokenkey_status": "not_applicable",
+      "rationale": "Client-side claude-code concern (terminal); not a gateway/relay relevance signal.",
+      "updated_at": "2026-06-04T11:06:49Z"
     },
     {
       "upstream": "anthropics/claude-code#33242",
@@ -5946,6 +6714,19 @@
       "updated_at": "2026-06-02T11:32:14Z"
     },
     {
+      "upstream": "anthropics/claude-code#33707",
+      "url": "https://github.com/anthropics/claude-code/issues/33707",
+      "title": "[DOCS] Plugin marketplace docs omit Git submodule-backed plugin source support",
+      "impact": "not_applicable",
+      "categories": [
+        "plugin",
+        "install"
+      ],
+      "tokenkey_status": "not_applicable",
+      "rationale": "Client-side claude-code concern (plugin, install); not a gateway/relay relevance signal.",
+      "updated_at": "2026-06-03T11:39:35Z"
+    },
+    {
       "upstream": "anthropics/claude-code#33932",
       "url": "https://github.com/anthropics/claude-code/issues/33932",
       "title": "[FEATURE] VS Code Extension: Diff review UI similar to GitHub Copilot Edits Review",
@@ -5959,19 +6740,6 @@
       "updated_at": "2026-06-03T06:05:04Z"
     },
     {
-      "upstream": "anthropics/claude-code#34229",
-      "url": "https://github.com/anthropics/claude-code/issues/34229",
-      "title": "[BUG] Phone verification",
-      "impact": "not_applicable",
-      "categories": [
-        "terminal",
-        "plugin"
-      ],
-      "tokenkey_status": "not_applicable",
-      "rationale": "Client-side claude-code concern (terminal, plugin); not a gateway/relay relevance signal.",
-      "updated_at": "2026-06-01T02:01:42Z"
-    },
-    {
       "upstream": "anthropics/claude-code#34255",
       "url": "https://github.com/anthropics/claude-code/issues/34255",
       "title": "[BUG] Remote Control: automatic reconnection doesn't work -- connection drops silently with no recovery",
@@ -5982,7 +6750,47 @@
       ],
       "tokenkey_status": "not_applicable",
       "rationale": "Client-side claude-code concern (terminal, slash_hook); not a gateway/relay relevance signal.",
-      "updated_at": "2026-06-01T06:50:53Z"
+      "updated_at": "2026-06-04T02:00:09Z"
+    },
+    {
+      "upstream": "anthropics/claude-code#34275",
+      "url": "https://github.com/anthropics/claude-code/issues/34275",
+      "title": "[DOCS] Worktree settings page missing prose explanation and cross-link for worktree.sparsePaths",
+      "impact": "not_applicable",
+      "categories": [
+        "plugin",
+        "install"
+      ],
+      "tokenkey_status": "not_applicable",
+      "rationale": "Client-side claude-code concern (plugin, install); not a gateway/relay relevance signal.",
+      "updated_at": "2026-06-03T11:40:49Z"
+    },
+    {
+      "upstream": "anthropics/claude-code#34280",
+      "url": "https://github.com/anthropics/claude-code/issues/34280",
+      "title": "[DOCS] Sub-agents docs missing behavior guarantee that killing a background agent preserves partial results",
+      "impact": "not_applicable",
+      "categories": [
+        "plugin",
+        "slash_hook"
+      ],
+      "tokenkey_status": "not_applicable",
+      "rationale": "Client-side claude-code concern (plugin, slash_hook); not a gateway/relay relevance signal.",
+      "updated_at": "2026-06-03T11:39:48Z"
+    },
+    {
+      "upstream": "anthropics/claude-code#34332",
+      "url": "https://github.com/anthropics/claude-code/issues/34332",
+      "title": "Opus 4.6 (1M context): autocompact triggers at ~76K tokens — 92% of context window wasted",
+      "impact": "not_applicable",
+      "categories": [
+        "plugin",
+        "slash_hook",
+        "platform"
+      ],
+      "tokenkey_status": "not_applicable",
+      "rationale": "Client-side claude-code concern (plugin, slash_hook, platform); not a gateway/relay relevance signal.",
+      "updated_at": "2026-06-04T05:04:02Z"
     },
     {
       "upstream": "anthropics/claude-code#34556",
@@ -5997,6 +6805,19 @@
       "updated_at": "2026-06-01T16:27:31Z"
     },
     {
+      "upstream": "anthropics/claude-code#35145",
+      "url": "https://github.com/anthropics/claude-code/issues/35145",
+      "title": "[DOCS] VS Code docs omit `macOptionClickForcesSelection`",
+      "impact": "not_applicable",
+      "categories": [
+        "ide",
+        "platform"
+      ],
+      "tokenkey_status": "not_applicable",
+      "rationale": "Client-side claude-code concern (ide, platform); not a gateway/relay relevance signal.",
+      "updated_at": "2026-06-03T11:40:49Z"
+    },
+    {
       "upstream": "anthropics/claude-code#35148",
       "url": "https://github.com/anthropics/claude-code/issues/35148",
       "title": "[BUG] Logo and \"Thinking\" animation colors are dull/washed-out inside tmux",
@@ -6007,6 +6828,31 @@
       "tokenkey_status": "not_applicable",
       "rationale": "Client-side claude-code concern (terminal); not a gateway/relay relevance signal.",
       "updated_at": "2026-06-02T12:34:31Z"
+    },
+    {
+      "upstream": "anthropics/claude-code#35150",
+      "url": "https://github.com/anthropics/claude-code/issues/35150",
+      "title": "Allow tools/skills to programmatically clear context and inject a continuation prompt",
+      "impact": "not_applicable",
+      "categories": [
+        "ide",
+        "slash_hook"
+      ],
+      "tokenkey_status": "not_applicable",
+      "rationale": "Client-side claude-code concern (ide, slash_hook); not a gateway/relay relevance signal.",
+      "updated_at": "2026-06-03T20:25:37Z"
+    },
+    {
+      "upstream": "anthropics/claude-code#35628",
+      "url": "https://github.com/anthropics/claude-code/issues/35628",
+      "title": "[DOCS] CLI reference missing --worktree skill and hook loading behavior",
+      "impact": "not_applicable",
+      "categories": [
+        "slash_hook"
+      ],
+      "tokenkey_status": "not_applicable",
+      "rationale": "Client-side claude-code concern (slash_hook); not a gateway/relay relevance signal.",
+      "updated_at": "2026-06-03T11:40:51Z"
     },
     {
       "upstream": "anthropics/claude-code#35637",
@@ -6049,6 +6895,19 @@
       "updated_at": "2026-06-03T08:31:00Z"
     },
     {
+      "upstream": "anthropics/claude-code#36258",
+      "url": "https://github.com/anthropics/claude-code/issues/36258",
+      "title": "[FEATURE] Cowork: Make \"Allow once\" easier to select in MCP permission dialogs",
+      "impact": "not_applicable",
+      "categories": [
+        "mcp",
+        "slash_hook"
+      ],
+      "tokenkey_status": "not_applicable",
+      "rationale": "Client-side claude-code concern (mcp, slash_hook); not a gateway/relay relevance signal.",
+      "updated_at": "2026-06-04T07:31:16Z"
+    },
+    {
       "upstream": "anthropics/claude-code#36411",
       "url": "https://github.com/anthropics/claude-code/issues/36411",
       "title": "[BUG] Telegram MCP plugin: inbound notifications/claude/channel never delivered to session (outbound works)",
@@ -6077,6 +6936,20 @@
       "updated_at": "2026-06-02T11:32:10Z"
     },
     {
+      "upstream": "anthropics/claude-code#36700",
+      "url": "https://github.com/anthropics/claude-code/issues/36700",
+      "title": "Cowork remote plugins: no path to force-update stale marketplace cache (Windows)",
+      "impact": "not_applicable",
+      "categories": [
+        "plugin",
+        "install",
+        "platform"
+      ],
+      "tokenkey_status": "not_applicable",
+      "rationale": "Client-side claude-code concern (plugin, install, platform); not a gateway/relay relevance signal.",
+      "updated_at": "2026-06-03T23:58:04Z"
+    },
+    {
       "upstream": "anthropics/claude-code#36797",
       "url": "https://github.com/anthropics/claude-code/issues/36797",
       "title": "[Bug] Authentication redirect loops to onboarding for existing account with active subscription",
@@ -6087,6 +6960,20 @@
       "tokenkey_status": "not_applicable",
       "rationale": "Client-side claude-code concern (terminal); not a gateway/relay relevance signal.",
       "updated_at": "2026-06-02T10:57:29Z"
+    },
+    {
+      "upstream": "anthropics/claude-code#36857",
+      "url": "https://github.com/anthropics/claude-code/issues/36857",
+      "title": "[DOCS] MCP docs missing collapsed \"Queried {server}\" display for read/search tool calls",
+      "impact": "not_applicable",
+      "categories": [
+        "terminal",
+        "mcp",
+        "slash_hook"
+      ],
+      "tokenkey_status": "not_applicable",
+      "rationale": "Client-side claude-code concern (terminal, mcp, slash_hook); not a gateway/relay relevance signal.",
+      "updated_at": "2026-06-03T11:40:50Z"
     },
     {
       "upstream": "anthropics/claude-code#36884",
@@ -6103,6 +6990,54 @@
       "updated_at": "2026-06-03T08:19:40Z"
     },
     {
+      "upstream": "anthropics/claude-code#37273",
+      "url": "https://github.com/anthropics/claude-code/issues/37273",
+      "title": "Cowork: Context compaction permanently removes scrollable conversation history from UI",
+      "impact": "not_applicable",
+      "categories": [
+        "terminal"
+      ],
+      "tokenkey_status": "not_applicable",
+      "rationale": "Client-side claude-code concern (terminal); not a gateway/relay relevance signal.",
+      "updated_at": "2026-06-03T19:03:28Z"
+    },
+    {
+      "upstream": "anthropics/claude-code#37413",
+      "url": "https://github.com/anthropics/claude-code/issues/37413",
+      "title": "[BUG] Cowork (Not Claude Code) 1M context window unavailable on Max 5x — regression from March 20",
+      "impact": "not_applicable",
+      "categories": [
+        "terminal"
+      ],
+      "tokenkey_status": "not_applicable",
+      "rationale": "Client-side claude-code concern (terminal); not a gateway/relay relevance signal.",
+      "updated_at": "2026-06-03T11:24:45Z"
+    },
+    {
+      "upstream": "anthropics/claude-code#37796",
+      "url": "https://github.com/anthropics/claude-code/issues/37796",
+      "title": "Copied text includes 2-space leading indentation from rendered output",
+      "impact": "not_applicable",
+      "categories": [
+        "terminal"
+      ],
+      "tokenkey_status": "not_applicable",
+      "rationale": "Client-side claude-code concern (terminal); not a gateway/relay relevance signal.",
+      "updated_at": "2026-06-03T15:47:35Z"
+    },
+    {
+      "upstream": "anthropics/claude-code#37891",
+      "url": "https://github.com/anthropics/claude-code/issues/37891",
+      "title": "Make task tool reminder interval configurable",
+      "impact": "not_applicable",
+      "categories": [
+        "slash_hook"
+      ],
+      "tokenkey_status": "not_applicable",
+      "rationale": "Client-side claude-code concern (slash_hook); not a gateway/relay relevance signal.",
+      "updated_at": "2026-06-04T11:06:48Z"
+    },
+    {
       "upstream": "anthropics/claude-code#37989",
       "url": "https://github.com/anthropics/claude-code/issues/37989",
       "title": "[BUG] Clicking file links in Read tool call results doesn't open binary files (e.g. PNG) in VSCode",
@@ -6117,31 +7052,68 @@
       "updated_at": "2026-06-03T07:49:26Z"
     },
     {
-      "upstream": "anthropics/claude-code#38005",
-      "url": "https://github.com/anthropics/claude-code/issues/38005",
-      "title": "RTL (Right-to-Left) Support for Hebrew & Arabic in Claude Desktop / Cowork",
+      "upstream": "anthropics/claude-code#38008",
+      "url": "https://github.com/anthropics/claude-code/issues/38008",
+      "title": "Desktop app: Claude Code plugin marketplace shows Co-Work plugins instead of CLI plugins",
       "impact": "not_applicable",
       "categories": [
-        "ide",
-        "terminal"
+        "plugin"
       ],
       "tokenkey_status": "not_applicable",
-      "rationale": "Client-side claude-code concern (ide, terminal); not a gateway/relay relevance signal.",
-      "updated_at": "2026-06-01T12:03:13Z"
+      "rationale": "Client-side claude-code concern (plugin); not a gateway/relay relevance signal.",
+      "updated_at": "2026-06-03T22:45:53Z"
     },
     {
-      "upstream": "anthropics/claude-code#38129",
-      "url": "https://github.com/anthropics/claude-code/issues/38129",
-      "title": "[BUG] Cowork web GUI unavailable on Linux -- only macOS and Windows supported",
+      "upstream": "anthropics/claude-code#38562",
+      "url": "https://github.com/anthropics/claude-code/issues/38562",
+      "title": "[DOCS] Pasted images now insert an `[Image #N]` chip at cursor — docs don't describe this positional-reference behavior",
       "impact": "not_applicable",
       "categories": [
         "terminal",
-        "install",
+        "slash_hook",
         "platform"
       ],
       "tokenkey_status": "not_applicable",
-      "rationale": "Client-side claude-code concern (terminal, install, platform); not a gateway/relay relevance signal.",
-      "updated_at": "2026-06-01T08:08:26Z"
+      "rationale": "Client-side claude-code concern (terminal, slash_hook, platform); not a gateway/relay relevance signal.",
+      "updated_at": "2026-06-03T11:40:39Z"
+    },
+    {
+      "upstream": "anthropics/claude-code#38575",
+      "url": "https://github.com/anthropics/claude-code/issues/38575",
+      "title": "[DOCS] Agent SDK session resume docs incomplete — hook messages can silently corrupt history reconstruction",
+      "impact": "not_applicable",
+      "categories": [
+        "slash_hook"
+      ],
+      "tokenkey_status": "not_applicable",
+      "rationale": "Client-side claude-code concern (slash_hook); not a gateway/relay relevance signal.",
+      "updated_at": "2026-06-03T11:39:55Z"
+    },
+    {
+      "upstream": "anthropics/claude-code#38686",
+      "url": "https://github.com/anthropics/claude-code/issues/38686",
+      "title": "Ralph Loop plugin: stop-hook.sh missing execute permission on Linux",
+      "impact": "not_applicable",
+      "categories": [
+        "plugin",
+        "slash_hook",
+        "install"
+      ],
+      "tokenkey_status": "not_applicable",
+      "rationale": "Client-side claude-code concern (plugin, slash_hook, install); not a gateway/relay relevance signal.",
+      "updated_at": "2026-06-04T05:11:46Z"
+    },
+    {
+      "upstream": "anthropics/claude-code#38859",
+      "url": "https://github.com/anthropics/claude-code/issues/38859",
+      "title": "Background agents cannot get Bash permissions — bypassPermissions ignored for Agent tool",
+      "impact": "not_applicable",
+      "categories": [
+        "slash_hook"
+      ],
+      "tokenkey_status": "not_applicable",
+      "rationale": "Client-side claude-code concern (slash_hook); not a gateway/relay relevance signal.",
+      "updated_at": "2026-06-03T20:09:06Z"
     },
     {
       "upstream": "anthropics/claude-code#38928",
@@ -6154,7 +7126,7 @@
       ],
       "tokenkey_status": "not_applicable",
       "rationale": "Client-side claude-code concern (mcp, plugin); not a gateway/relay relevance signal.",
-      "updated_at": "2026-06-02T04:39:01Z"
+      "updated_at": "2026-06-03T19:00:05Z"
     },
     {
       "upstream": "anthropics/claude-code#38993",
@@ -6183,18 +7155,32 @@
       "updated_at": "2026-06-01T22:45:24Z"
     },
     {
-      "upstream": "anthropics/claude-code#39161",
-      "url": "https://github.com/anthropics/claude-code/issues/39161",
-      "title": "[BUG] Cowork ARM64: VM boots but guest never connects — \"VM connection timeout after 60 seconds",
+      "upstream": "anthropics/claude-code#39114",
+      "url": "https://github.com/anthropics/claude-code/issues/39114",
+      "title": "[DOCS] Interactive mode missing repo-qualified syntax for clickable issue/PR references",
       "impact": "not_applicable",
       "categories": [
+        "ide",
         "terminal",
-        "install",
+        "mcp",
         "platform"
       ],
       "tokenkey_status": "not_applicable",
-      "rationale": "Client-side claude-code concern (terminal, install, platform); not a gateway/relay relevance signal.",
-      "updated_at": "2026-06-01T10:07:45Z"
+      "rationale": "Client-side claude-code concern (ide, terminal, mcp, platform); not a gateway/relay relevance signal.",
+      "updated_at": "2026-06-03T22:45:02Z"
+    },
+    {
+      "upstream": "anthropics/claude-code#39195",
+      "url": "https://github.com/anthropics/claude-code/issues/39195",
+      "title": "Support shared memory across multiple projects (not just global or per-project)",
+      "impact": "not_applicable",
+      "categories": [
+        "slash_hook",
+        "install"
+      ],
+      "tokenkey_status": "not_applicable",
+      "rationale": "Client-side claude-code concern (slash_hook, install); not a gateway/relay relevance signal.",
+      "updated_at": "2026-06-04T11:07:23Z"
     },
     {
       "upstream": "anthropics/claude-code#39472",
@@ -6226,6 +7212,32 @@
       "updated_at": "2026-06-02T11:33:01Z"
     },
     {
+      "upstream": "anthropics/claude-code#39619",
+      "url": "https://github.com/anthropics/claude-code/issues/39619",
+      "title": "[DOCS] Plugin docs omit managed-policy behavior for force-disabled plugins",
+      "impact": "not_applicable",
+      "categories": [
+        "plugin",
+        "slash_hook",
+        "install"
+      ],
+      "tokenkey_status": "not_applicable",
+      "rationale": "Client-side claude-code concern (plugin, slash_hook, install); not a gateway/relay relevance signal.",
+      "updated_at": "2026-06-03T11:40:43Z"
+    },
+    {
+      "upstream": "anthropics/claude-code#39625",
+      "url": "https://github.com/anthropics/claude-code/issues/39625",
+      "title": "[DOCS] Computer use docs missing multi-monitor display-switching guidance",
+      "impact": "not_applicable",
+      "categories": [
+        "terminal"
+      ],
+      "tokenkey_status": "not_applicable",
+      "rationale": "Client-side claude-code concern (terminal); not a gateway/relay relevance signal.",
+      "updated_at": "2026-06-03T11:39:43Z"
+    },
+    {
       "upstream": "anthropics/claude-code#39663",
       "url": "https://github.com/anthropics/claude-code/issues/39663",
       "title": "Context is lost when Claude suggests restarting — should auto-save a session summary before restart",
@@ -6251,6 +7263,32 @@
       "updated_at": "2026-06-02T14:43:16Z"
     },
     {
+      "upstream": "anthropics/claude-code#40120",
+      "url": "https://github.com/anthropics/claude-code/issues/40120",
+      "title": "[DOCS] Search and @ file autocomplete docs omit Jujutsu/Sapling metadata exclusions",
+      "impact": "not_applicable",
+      "categories": [
+        "ide",
+        "install"
+      ],
+      "tokenkey_status": "not_applicable",
+      "rationale": "Client-side claude-code concern (ide, install); not a gateway/relay relevance signal.",
+      "updated_at": "2026-06-03T11:39:36Z"
+    },
+    {
+      "upstream": "anthropics/claude-code#40122",
+      "url": "https://github.com/anthropics/claude-code/issues/40122",
+      "title": "[DOCS] VS Code docs missing \"Not responding\" status guidance for long-running operations",
+      "impact": "not_applicable",
+      "categories": [
+        "ide",
+        "terminal"
+      ],
+      "tokenkey_status": "not_applicable",
+      "rationale": "Client-side claude-code concern (ide, terminal); not a gateway/relay relevance signal.",
+      "updated_at": "2026-06-03T11:39:37Z"
+    },
+    {
       "upstream": "anthropics/claude-code#40123",
       "url": "https://github.com/anthropics/claude-code/issues/40123",
       "title": "[DOCS] Read tool docs omit compact line-number output and unchanged re-read deduplication",
@@ -6262,18 +7300,6 @@
       "tokenkey_status": "not_applicable",
       "rationale": "Client-side claude-code concern (plugin, slash_hook); not a gateway/relay relevance signal.",
       "updated_at": "2026-06-02T22:44:46Z"
-    },
-    {
-      "upstream": "anthropics/claude-code#40173",
-      "url": "https://github.com/anthropics/claude-code/issues/40173",
-      "title": "Claude-in-Chrome: Server-side domain blocking breaks legitimate business automation",
-      "impact": "not_applicable",
-      "categories": [
-        "ide"
-      ],
-      "tokenkey_status": "not_applicable",
-      "rationale": "Client-side claude-code concern (ide); not a gateway/relay relevance signal.",
-      "updated_at": "2026-06-01T06:25:41Z"
     },
     {
       "upstream": "anthropics/claude-code#40198",
@@ -6331,6 +7357,32 @@
       "updated_at": "2026-06-02T13:36:59Z"
     },
     {
+      "upstream": "anthropics/claude-code#41264",
+      "url": "https://github.com/anthropics/claude-code/issues/41264",
+      "title": "[DOCS] `/stats` docs omit date ranges, retention semantics, and usage aggregation details",
+      "impact": "not_applicable",
+      "categories": [
+        "plugin"
+      ],
+      "tokenkey_status": "not_applicable",
+      "rationale": "Client-side claude-code concern (plugin); not a gateway/relay relevance signal.",
+      "updated_at": "2026-06-03T11:39:49Z"
+    },
+    {
+      "upstream": "anthropics/claude-code#41268",
+      "url": "https://github.com/anthropics/claude-code/issues/41268",
+      "title": "[DOCS] Built-in commands reference missing `/env` coverage for PowerShell tool",
+      "impact": "not_applicable",
+      "categories": [
+        "plugin",
+        "slash_hook",
+        "platform"
+      ],
+      "tokenkey_status": "not_applicable",
+      "rationale": "Client-side claude-code concern (plugin, slash_hook, platform); not a gateway/relay relevance signal.",
+      "updated_at": "2026-06-03T11:39:50Z"
+    },
+    {
       "upstream": "anthropics/claude-code#41581",
       "url": "https://github.com/anthropics/claude-code/issues/41581",
       "title": "[BUG] Max subscription downgraded to Free plan without any action from user",
@@ -6356,16 +7408,40 @@
       "updated_at": "2026-06-02T02:59:18Z"
     },
     {
-      "upstream": "anthropics/claude-code#42029",
-      "url": "https://github.com/anthropics/claude-code/issues/42029",
-      "title": "Enter key not sending command",
+      "upstream": "anthropics/claude-code#41797",
+      "url": "https://github.com/anthropics/claude-code/issues/41797",
+      "title": "[DOCS] Hooks and Bash tool docs omit stale-read warning for formatter/linter workflows",
       "impact": "not_applicable",
       "categories": [
-        "terminal"
+        "slash_hook"
       ],
       "tokenkey_status": "not_applicable",
-      "rationale": "Client-side claude-code concern (terminal); not a gateway/relay relevance signal.",
-      "updated_at": "2026-06-01T07:20:03Z"
+      "rationale": "Client-side claude-code concern (slash_hook); not a gateway/relay relevance signal.",
+      "updated_at": "2026-06-03T11:40:41Z"
+    },
+    {
+      "upstream": "anthropics/claude-code#41799",
+      "url": "https://github.com/anthropics/claude-code/issues/41799",
+      "title": "[DOCS] Hooks docs omit >50K output file-path preview behavior",
+      "impact": "not_applicable",
+      "categories": [
+        "slash_hook"
+      ],
+      "tokenkey_status": "not_applicable",
+      "rationale": "Client-side claude-code concern (slash_hook); not a gateway/relay relevance signal.",
+      "updated_at": "2026-06-03T11:40:17Z"
+    },
+    {
+      "upstream": "anthropics/claude-code#41801",
+      "url": "https://github.com/anthropics/claude-code/issues/41801",
+      "title": "[DOCS] PowerShell tool docs omit PS 5.1 quoted-whitespace prompt behavior",
+      "impact": "not_applicable",
+      "categories": [
+        "platform"
+      ],
+      "tokenkey_status": "not_applicable",
+      "rationale": "Client-side claude-code concern (platform); not a gateway/relay relevance signal.",
+      "updated_at": "2026-06-03T11:40:42Z"
     },
     {
       "upstream": "anthropics/claude-code#42264",
@@ -6378,6 +7454,31 @@
       "tokenkey_status": "not_applicable",
       "rationale": "Client-side claude-code concern (terminal); not a gateway/relay relevance signal.",
       "updated_at": "2026-06-02T11:15:50Z"
+    },
+    {
+      "upstream": "anthropics/claude-code#42317",
+      "url": "https://github.com/anthropics/claude-code/issues/42317",
+      "title": "[DOCS] Format-on-save hooks don't document consecutive edit behavior",
+      "impact": "not_applicable",
+      "categories": [
+        "slash_hook",
+        "install"
+      ],
+      "tokenkey_status": "not_applicable",
+      "rationale": "Client-side claude-code concern (slash_hook, install); not a gateway/relay relevance signal.",
+      "updated_at": "2026-06-03T11:39:57Z"
+    },
+    {
+      "upstream": "anthropics/claude-code#42318",
+      "url": "https://github.com/anthropics/claude-code/issues/42318",
+      "title": "[DOCS] PowerShell docs omit key permission-check behavior",
+      "impact": "not_applicable",
+      "categories": [
+        "platform"
+      ],
+      "tokenkey_status": "not_applicable",
+      "rationale": "Client-side claude-code concern (platform); not a gateway/relay relevance signal.",
+      "updated_at": "2026-06-03T11:40:44Z"
     },
     {
       "upstream": "anthropics/claude-code#42486",
@@ -6393,7 +7494,32 @@
       ],
       "tokenkey_status": "not_applicable",
       "rationale": "Client-side claude-code concern (terminal, mcp, plugin, slash_hook, platform); not a gateway/relay relevance signal.",
-      "updated_at": "2026-06-03T01:13:13Z"
+      "updated_at": "2026-06-03T15:16:04Z"
+    },
+    {
+      "upstream": "anthropics/claude-code#42671",
+      "url": "https://github.com/anthropics/claude-code/issues/42671",
+      "title": "Remote Control: messages sent from phone do not arrive in CLI (one-way communication)",
+      "impact": "not_applicable",
+      "categories": [
+        "terminal"
+      ],
+      "tokenkey_status": "not_applicable",
+      "rationale": "Client-side claude-code concern (terminal); not a gateway/relay relevance signal.",
+      "updated_at": "2026-06-04T04:24:05Z"
+    },
+    {
+      "upstream": "anthropics/claude-code#4276",
+      "url": "https://github.com/anthropics/claude-code/issues/4276",
+      "title": "Feature Request: Extend Environment Variable Expansion to `settings.json` files",
+      "impact": "not_applicable",
+      "categories": [
+        "mcp",
+        "slash_hook"
+      ],
+      "tokenkey_status": "not_applicable",
+      "rationale": "Client-side claude-code concern (mcp, slash_hook); not a gateway/relay relevance signal.",
+      "updated_at": "2026-06-04T07:59:34Z"
     },
     {
       "upstream": "anthropics/claude-code#42776",
@@ -6460,6 +7586,43 @@
       "updated_at": "2026-06-02T15:48:01Z"
     },
     {
+      "upstream": "anthropics/claude-code#43364",
+      "url": "https://github.com/anthropics/claude-code/issues/43364",
+      "title": "[DOCS] Fullscreen docs conflict on Escape interrupt vs clear-selection behavior",
+      "impact": "not_applicable",
+      "categories": [
+        "terminal",
+        "slash_hook"
+      ],
+      "tokenkey_status": "not_applicable",
+      "rationale": "Client-side claude-code concern (terminal, slash_hook); not a gateway/relay relevance signal.",
+      "updated_at": "2026-06-04T11:06:40Z"
+    },
+    {
+      "upstream": "anthropics/claude-code#43405",
+      "url": "https://github.com/anthropics/claude-code/issues/43405",
+      "title": "Bug: Discord plugin permission requests cannot be approved from Discord",
+      "impact": "not_applicable",
+      "categories": [
+        "plugin"
+      ],
+      "tokenkey_status": "not_applicable",
+      "rationale": "Client-side claude-code concern (plugin); not a gateway/relay relevance signal.",
+      "updated_at": "2026-06-04T11:07:31Z"
+    },
+    {
+      "upstream": "anthropics/claude-code#43454",
+      "url": "https://github.com/anthropics/claude-code/issues/43454",
+      "title": "[BUG] apply-seccomp fails on Linux - cannot write /proc/self/setgroups",
+      "impact": "not_applicable",
+      "categories": [
+        "terminal"
+      ],
+      "tokenkey_status": "not_applicable",
+      "rationale": "Client-side claude-code concern (terminal); not a gateway/relay relevance signal.",
+      "updated_at": "2026-06-03T22:30:53Z"
+    },
+    {
       "upstream": "anthropics/claude-code#43477",
       "url": "https://github.com/anthropics/claude-code/issues/43477",
       "title": "[BUG] Copying text (Ctrl+C) from Claude Code window in VS Code fails",
@@ -6471,7 +7634,7 @@
       ],
       "tokenkey_status": "not_applicable",
       "rationale": "Client-side claude-code concern (ide, terminal, platform); not a gateway/relay relevance signal.",
-      "updated_at": "2026-06-03T08:50:45Z"
+      "updated_at": "2026-06-03T19:52:28Z"
     },
     {
       "upstream": "anthropics/claude-code#43719",
@@ -6485,6 +7648,20 @@
       "tokenkey_status": "not_applicable",
       "rationale": "Client-side claude-code concern (terminal, slash_hook); not a gateway/relay relevance signal.",
       "updated_at": "2026-06-03T10:11:50Z"
+    },
+    {
+      "upstream": "anthropics/claude-code#43933",
+      "url": "https://github.com/anthropics/claude-code/issues/43933",
+      "title": "[SONNET] Claude Sonnet ignores explicit CLAUDE.md rules, memory files, and gameplan instructions — repeatedly deviates despite corrections",
+      "impact": "not_applicable",
+      "categories": [
+        "ide",
+        "terminal",
+        "mcp"
+      ],
+      "tokenkey_status": "not_applicable",
+      "rationale": "Client-side claude-code concern (ide, terminal, mcp); not a gateway/relay relevance signal.",
+      "updated_at": "2026-06-03T22:45:16Z"
     },
     {
       "upstream": "anthropics/claude-code#44163",
@@ -6513,17 +7690,30 @@
       "updated_at": "2026-06-03T04:52:47Z"
     },
     {
-      "upstream": "anthropics/claude-code#44567",
-      "url": "https://github.com/anthropics/claude-code/issues/44567",
-      "title": "[BUG] bwrap fails in a worktree when .claude/skills is a symlink in a repository",
+      "upstream": "anthropics/claude-code#44456",
+      "url": "https://github.com/anthropics/claude-code/issues/44456",
+      "title": "CLI discards logical symlink path, uses realpath — degrades usability in deep directory trees",
       "impact": "not_applicable",
       "categories": [
+        "ide",
         "terminal",
-        "slash_hook"
+        "platform"
       ],
       "tokenkey_status": "not_applicable",
-      "rationale": "Client-side claude-code concern (terminal, slash_hook); not a gateway/relay relevance signal.",
-      "updated_at": "2026-06-01T05:58:16Z"
+      "rationale": "Client-side claude-code concern (ide, terminal, platform); not a gateway/relay relevance signal.",
+      "updated_at": "2026-06-03T22:45:17Z"
+    },
+    {
+      "upstream": "anthropics/claude-code#44559",
+      "url": "https://github.com/anthropics/claude-code/issues/44559",
+      "title": "[BUG] Session not logging into Subscription, using API credits instead.",
+      "impact": "not_applicable",
+      "categories": [
+        "terminal"
+      ],
+      "tokenkey_status": "not_applicable",
+      "rationale": "Client-side claude-code concern (terminal); not a gateway/relay relevance signal.",
+      "updated_at": "2026-06-03T22:45:30Z"
     },
     {
       "upstream": "anthropics/claude-code#4462",
@@ -6579,31 +7769,6 @@
       "updated_at": "2026-06-02T17:41:14Z"
     },
     {
-      "upstream": "anthropics/claude-code#44826",
-      "url": "https://github.com/anthropics/claude-code/issues/44826",
-      "title": "MCP parameter parser silently swallows args on mismatched close tag",
-      "impact": "not_applicable",
-      "categories": [
-        "mcp"
-      ],
-      "tokenkey_status": "not_applicable",
-      "rationale": "Client-side claude-code concern (mcp); not a gateway/relay relevance signal.",
-      "updated_at": "2026-06-01T12:03:11Z"
-    },
-    {
-      "upstream": "anthropics/claude-code#44892",
-      "url": "https://github.com/anthropics/claude-code/issues/44892",
-      "title": "Support spinnerVerbs customization in desktop app",
-      "impact": "not_applicable",
-      "categories": [
-        "terminal",
-        "slash_hook"
-      ],
-      "tokenkey_status": "not_applicable",
-      "rationale": "Client-side claude-code concern (terminal, slash_hook); not a gateway/relay relevance signal.",
-      "updated_at": "2026-05-31T16:51:13Z"
-    },
-    {
       "upstream": "anthropics/claude-code#44941",
       "url": "https://github.com/anthropics/claude-code/issues/44941",
       "title": "[BUG] Auto mode is not showing up in the VS code extension on windows",
@@ -6615,19 +7780,19 @@
       ],
       "tokenkey_status": "not_applicable",
       "rationale": "Client-side claude-code concern (ide, terminal, platform); not a gateway/relay relevance signal.",
-      "updated_at": "2026-06-02T01:18:06Z"
+      "updated_at": "2026-06-03T11:22:29Z"
     },
     {
-      "upstream": "anthropics/claude-code#45390",
-      "url": "https://github.com/anthropics/claude-code/issues/45390",
-      "title": "[Bug] 1M context incorrectly requires extra usage on Max plan",
+      "upstream": "anthropics/claude-code#45297",
+      "url": "https://github.com/anthropics/claude-code/issues/45297",
+      "title": "[BUG] Cowork: Folder does not support UNC under Windows",
       "impact": "not_applicable",
       "categories": [
-        "terminal"
+        "platform"
       ],
       "tokenkey_status": "not_applicable",
-      "rationale": "Client-side claude-code concern (terminal); not a gateway/relay relevance signal.",
-      "updated_at": "2026-06-01T01:18:50Z"
+      "rationale": "Client-side claude-code concern (platform); not a gateway/relay relevance signal.",
+      "updated_at": "2026-06-03T19:25:30Z"
     },
     {
       "upstream": "anthropics/claude-code#45596",
@@ -6642,7 +7807,32 @@
       ],
       "tokenkey_status": "not_applicable",
       "rationale": "Client-side claude-code concern (ide, terminal, slash_hook, platform); not a gateway/relay relevance signal.",
-      "updated_at": "2026-06-01T22:27:33Z"
+      "updated_at": "2026-06-04T05:24:49Z"
+    },
+    {
+      "upstream": "anthropics/claude-code#45625",
+      "url": "https://github.com/anthropics/claude-code/issues/45625",
+      "title": "[FEATURE] LSP findReferences should work across TypeScript monorepo project references",
+      "impact": "not_applicable",
+      "categories": [
+        "ide"
+      ],
+      "tokenkey_status": "not_applicable",
+      "rationale": "Client-side claude-code concern (ide); not a gateway/relay relevance signal.",
+      "updated_at": "2026-06-03T11:39:32Z"
+    },
+    {
+      "upstream": "anthropics/claude-code#45690",
+      "url": "https://github.com/anthropics/claude-code/issues/45690",
+      "title": "[FEATURE] Add keyboard shortcut for switching between Code sessions in Claude Desktop",
+      "impact": "not_applicable",
+      "categories": [
+        "terminal",
+        "slash_hook"
+      ],
+      "tokenkey_status": "not_applicable",
+      "rationale": "Client-side claude-code concern (terminal, slash_hook); not a gateway/relay relevance signal.",
+      "updated_at": "2026-06-03T22:46:02Z"
     },
     {
       "upstream": "anthropics/claude-code#45692",
@@ -6658,6 +7848,20 @@
       "tokenkey_status": "not_applicable",
       "rationale": "Client-side claude-code concern (ide, terminal, plugin, platform); not a gateway/relay relevance signal.",
       "updated_at": "2026-06-01T18:08:01Z"
+    },
+    {
+      "upstream": "anthropics/claude-code#45712",
+      "url": "https://github.com/anthropics/claude-code/issues/45712",
+      "title": "[BUG] Opus produces garbled multi-script output (Cyrillic/CJK/Tibetan mixed into English), triggers misleading usage policy violation",
+      "impact": "not_applicable",
+      "categories": [
+        "terminal",
+        "plugin",
+        "platform"
+      ],
+      "tokenkey_status": "not_applicable",
+      "rationale": "Client-side claude-code concern (terminal, plugin, platform); not a gateway/relay relevance signal.",
+      "updated_at": "2026-06-04T11:06:47Z"
     },
     {
       "upstream": "anthropics/claude-code#45717",
@@ -6682,7 +7886,20 @@
       ],
       "tokenkey_status": "not_applicable",
       "rationale": "Client-side claude-code concern (plugin); not a gateway/relay relevance signal.",
-      "updated_at": "2026-06-02T04:51:51Z"
+      "updated_at": "2026-06-04T05:11:09Z"
+    },
+    {
+      "upstream": "anthropics/claude-code#45845",
+      "url": "https://github.com/anthropics/claude-code/issues/45845",
+      "title": "[Bug] Plan file overwrites existing plan file loses tracking content when creating new plan",
+      "impact": "not_applicable",
+      "categories": [
+        "terminal",
+        "platform"
+      ],
+      "tokenkey_status": "not_applicable",
+      "rationale": "Client-side claude-code concern (terminal, platform); not a gateway/relay relevance signal.",
+      "updated_at": "2026-06-04T11:07:07Z"
     },
     {
       "upstream": "anthropics/claude-code#45942",
@@ -6748,6 +7965,18 @@
       "updated_at": "2026-06-02T11:32:59Z"
     },
     {
+      "upstream": "anthropics/claude-code#46724",
+      "url": "https://github.com/anthropics/claude-code/issues/46724",
+      "title": "[Bug] Global claude.md instructions not being consistently applied",
+      "impact": "not_applicable",
+      "categories": [
+        "install"
+      ],
+      "tokenkey_status": "not_applicable",
+      "rationale": "Client-side claude-code concern (install); not a gateway/relay relevance signal.",
+      "updated_at": "2026-06-03T11:40:10Z"
+    },
+    {
       "upstream": "anthropics/claude-code#47023",
       "url": "https://github.com/anthropics/claude-code/issues/47023",
       "title": "[PROPOSAL] Expose compact/session lifecycle hooks for external memory layers",
@@ -6761,17 +7990,19 @@
       "updated_at": "2026-06-03T07:03:40Z"
     },
     {
-      "upstream": "anthropics/claude-code#47056",
-      "url": "https://github.com/anthropics/claude-code/issues/47056",
-      "title": "[Bug] CLAUDE_CONFIG_DIR env var ignored; still loads ~/.claude/CLAUDE.md",
+      "upstream": "anthropics/claude-code#47083",
+      "url": "https://github.com/anthropics/claude-code/issues/47083",
+      "title": "VS Code extension: inconsistent UI behavior across entry points",
       "impact": "not_applicable",
       "categories": [
         "ide",
-        "terminal"
+        "terminal",
+        "install",
+        "platform"
       ],
       "tokenkey_status": "not_applicable",
-      "rationale": "Client-side claude-code concern (ide, terminal); not a gateway/relay relevance signal.",
-      "updated_at": "2026-06-01T12:02:20Z"
+      "rationale": "Client-side claude-code concern (ide, terminal, install, platform); not a gateway/relay relevance signal.",
+      "updated_at": "2026-06-04T11:07:44Z"
     },
     {
       "upstream": "anthropics/claude-code#47154",
@@ -6784,6 +8015,20 @@
       "tokenkey_status": "not_applicable",
       "rationale": "Client-side claude-code concern (terminal); not a gateway/relay relevance signal.",
       "updated_at": "2026-06-01T19:19:29Z"
+    },
+    {
+      "upstream": "anthropics/claude-code#47327",
+      "url": "https://github.com/anthropics/claude-code/issues/47327",
+      "title": "[BUG] Cowork tab disabled — yukonSilver \"unsupported\" on Windows 11 Pro x64 (ongoing since March 2026)",
+      "impact": "not_applicable",
+      "categories": [
+        "terminal",
+        "install",
+        "platform"
+      ],
+      "tokenkey_status": "not_applicable",
+      "rationale": "Client-side claude-code concern (terminal, install, platform); not a gateway/relay relevance signal.",
+      "updated_at": "2026-06-04T11:07:52Z"
     },
     {
       "upstream": "anthropics/claude-code#47336",
@@ -6837,7 +8082,32 @@
       ],
       "tokenkey_status": "not_applicable",
       "rationale": "Client-side claude-code concern (ide, plugin); not a gateway/relay relevance signal.",
-      "updated_at": "2026-06-03T07:57:58Z"
+      "updated_at": "2026-06-04T08:44:43Z"
+    },
+    {
+      "upstream": "anthropics/claude-code#47679",
+      "url": "https://github.com/anthropics/claude-code/issues/47679",
+      "title": "Feature Request: Allow programmatic access to /rename and /color from tools/skills",
+      "impact": "not_applicable",
+      "categories": [
+        "ide",
+        "terminal"
+      ],
+      "tokenkey_status": "not_applicable",
+      "rationale": "Client-side claude-code concern (ide, terminal); not a gateway/relay relevance signal.",
+      "updated_at": "2026-06-04T11:07:36Z"
+    },
+    {
+      "upstream": "anthropics/claude-code#47683",
+      "url": "https://github.com/anthropics/claude-code/issues/47683",
+      "title": "/buddy command removed — was told pet would persist",
+      "impact": "not_applicable",
+      "categories": [
+        "platform"
+      ],
+      "tokenkey_status": "not_applicable",
+      "rationale": "Client-side claude-code concern (platform); not a gateway/relay relevance signal.",
+      "updated_at": "2026-06-04T11:07:00Z"
     },
     {
       "upstream": "anthropics/claude-code#47733",
@@ -6934,19 +8204,6 @@
       "updated_at": "2026-06-02T16:41:57Z"
     },
     {
-      "upstream": "anthropics/claude-code#48641",
-      "url": "https://github.com/anthropics/claude-code/issues/48641",
-      "title": "[FEATURE] VS Code extension: click-to-copy affordance on code blocks in Claude responses",
-      "impact": "not_applicable",
-      "categories": [
-        "ide",
-        "terminal"
-      ],
-      "tokenkey_status": "not_applicable",
-      "rationale": "Client-side claude-code concern (ide, terminal); not a gateway/relay relevance signal.",
-      "updated_at": "2026-06-01T12:44:22Z"
-    },
-    {
       "upstream": "anthropics/claude-code#48680",
       "url": "https://github.com/anthropics/claude-code/issues/48680",
       "title": "[BUG] claude.ai marketplace MCP server instructions inject into context on every session regardless of Tool Search",
@@ -6983,6 +8240,30 @@
       "tokenkey_status": "not_applicable",
       "rationale": "Client-side claude-code concern (terminal); not a gateway/relay relevance signal.",
       "updated_at": "2026-06-02T15:54:37Z"
+    },
+    {
+      "upstream": "anthropics/claude-code#48867",
+      "url": "https://github.com/anthropics/claude-code/issues/48867",
+      "title": "[DOCS] Headless and Agent SDK docs omit session auto-title background request behavior",
+      "impact": "not_applicable",
+      "categories": [
+        "terminal"
+      ],
+      "tokenkey_status": "not_applicable",
+      "rationale": "Client-side claude-code concern (terminal); not a gateway/relay relevance signal.",
+      "updated_at": "2026-06-03T11:39:47Z"
+    },
+    {
+      "upstream": "anthropics/claude-code#48949",
+      "url": "https://github.com/anthropics/claude-code/issues/48949",
+      "title": "Persistent always-on Remote Control option for desktop app",
+      "impact": "not_applicable",
+      "categories": [
+        "platform"
+      ],
+      "tokenkey_status": "not_applicable",
+      "rationale": "Client-side claude-code concern (platform); not a gateway/relay relevance signal.",
+      "updated_at": "2026-06-03T11:15:47Z"
     },
     {
       "upstream": "anthropics/claude-code#49184",
@@ -7025,6 +8306,45 @@
       "updated_at": "2026-06-02T11:43:19Z"
     },
     {
+      "upstream": "anthropics/claude-code#49298",
+      "url": "https://github.com/anthropics/claude-code/issues/49298",
+      "title": "[DOCS] Bedrock and Vertex setup wizard docs missing rerun details for config path, existing pins, and 1M options",
+      "impact": "not_applicable",
+      "categories": [
+        "plugin",
+        "slash_hook"
+      ],
+      "tokenkey_status": "not_applicable",
+      "rationale": "Client-side claude-code concern (plugin, slash_hook); not a gateway/relay relevance signal.",
+      "updated_at": "2026-06-03T22:44:51Z"
+    },
+    {
+      "upstream": "anthropics/claude-code#49301",
+      "url": "https://github.com/anthropics/claude-code/issues/49301",
+      "title": "[DOCS] `/skills` docs omit estimated-token-count sorting and the `t` toggle",
+      "impact": "not_applicable",
+      "categories": [
+        "mcp",
+        "plugin",
+        "slash_hook"
+      ],
+      "tokenkey_status": "not_applicable",
+      "rationale": "Client-side claude-code concern (mcp, plugin, slash_hook); not a gateway/relay relevance signal.",
+      "updated_at": "2026-06-03T22:44:49Z"
+    },
+    {
+      "upstream": "anthropics/claude-code#49308",
+      "url": "https://github.com/anthropics/claude-code/issues/49308",
+      "title": "[DOCS] Headless stream-json init event missing `plugin_errors` documentation",
+      "impact": "not_applicable",
+      "categories": [
+        "plugin"
+      ],
+      "tokenkey_status": "not_applicable",
+      "rationale": "Client-side claude-code concern (plugin); not a gateway/relay relevance signal.",
+      "updated_at": "2026-06-03T22:44:48Z"
+    },
+    {
       "upstream": "anthropics/claude-code#49536",
       "url": "https://github.com/anthropics/claude-code/issues/49536",
       "title": "[BUG] Limits got reset early - Huge loss of usage",
@@ -7061,6 +8381,33 @@
       "updated_at": "2026-06-01T22:45:36Z"
     },
     {
+      "upstream": "anthropics/claude-code#49837",
+      "url": "https://github.com/anthropics/claude-code/issues/49837",
+      "title": "[Bug] Auto Mode Classifier uses Opus 4.7 instead of Sonnet",
+      "impact": "not_applicable",
+      "categories": [
+        "terminal",
+        "slash_hook"
+      ],
+      "tokenkey_status": "not_applicable",
+      "rationale": "Client-side claude-code concern (terminal, slash_hook); not a gateway/relay relevance signal.",
+      "updated_at": "2026-06-03T22:45:21Z"
+    },
+    {
+      "upstream": "anthropics/claude-code#49917",
+      "url": "https://github.com/anthropics/claude-code/issues/49917",
+      "title": "[BUG] Claude Desktop Windows installer fails with AddPackage HRESULT 0x80073CF6 after an earlier \"successful\" install left the package in an inconsistent state",
+      "impact": "not_applicable",
+      "categories": [
+        "terminal",
+        "install",
+        "platform"
+      ],
+      "tokenkey_status": "not_applicable",
+      "rationale": "Client-side claude-code concern (terminal, install, platform); not a gateway/relay relevance signal.",
+      "updated_at": "2026-06-04T08:57:29Z"
+    },
+    {
       "upstream": "anthropics/claude-code#49933",
       "url": "https://github.com/anthropics/claude-code/issues/49933",
       "title": "[Feature Request] Native WSL Remote Integration for Claude Code Desktop on Windows",
@@ -7088,6 +8435,131 @@
       "tokenkey_status": "not_applicable",
       "rationale": "Client-side claude-code concern (ide, plugin, install); not a gateway/relay relevance signal.",
       "updated_at": "2026-06-02T22:44:53Z"
+    },
+    {
+      "upstream": "anthropics/claude-code#50122",
+      "url": "https://github.com/anthropics/claude-code/issues/50122",
+      "title": "[DOCS] `/loop` docs omit pending wakeup cancellation and resume label behavior",
+      "impact": "not_applicable",
+      "categories": [
+        "terminal"
+      ],
+      "tokenkey_status": "not_applicable",
+      "rationale": "Client-side claude-code concern (terminal); not a gateway/relay relevance signal.",
+      "updated_at": "2026-06-03T22:44:53Z"
+    },
+    {
+      "upstream": "anthropics/claude-code#50129",
+      "url": "https://github.com/anthropics/claude-code/issues/50129",
+      "title": "[DOCS] Subagent docs missing 10-minute stall timeout and failure behavior",
+      "impact": "not_applicable",
+      "categories": [
+        "plugin"
+      ],
+      "tokenkey_status": "not_applicable",
+      "rationale": "Client-side claude-code concern (plugin); not a gateway/relay relevance signal.",
+      "updated_at": "2026-06-03T22:44:55Z"
+    },
+    {
+      "upstream": "anthropics/claude-code#50130",
+      "url": "https://github.com/anthropics/claude-code/issues/50130",
+      "title": "[DOCS] Interactive mode/security docs omit full-command transcript behavior for multiline Bash commands that start with comments",
+      "impact": "not_applicable",
+      "categories": [
+        "terminal"
+      ],
+      "tokenkey_status": "not_applicable",
+      "rationale": "Client-side claude-code concern (terminal); not a gateway/relay relevance signal.",
+      "updated_at": "2026-06-03T22:44:55Z"
+    },
+    {
+      "upstream": "anthropics/claude-code#50131",
+      "url": "https://github.com/anthropics/claude-code/issues/50131",
+      "title": "[DOCS] Permissions docs missing macOS `/private/*` dangerous `rm` targets",
+      "impact": "not_applicable",
+      "categories": [
+        "install"
+      ],
+      "tokenkey_status": "not_applicable",
+      "rationale": "Client-side claude-code concern (install); not a gateway/relay relevance signal.",
+      "updated_at": "2026-06-03T22:44:57Z"
+    },
+    {
+      "upstream": "anthropics/claude-code#50132",
+      "url": "https://github.com/anthropics/claude-code/issues/50132",
+      "title": "[DOCS] Permissions docs outdated Bash deny-rule exec-wrapper matching",
+      "impact": "not_applicable",
+      "categories": [
+        "install"
+      ],
+      "tokenkey_status": "not_applicable",
+      "rationale": "Client-side claude-code concern (install); not a gateway/relay relevance signal.",
+      "updated_at": "2026-06-03T22:44:58Z"
+    },
+    {
+      "upstream": "anthropics/claude-code#50136",
+      "url": "https://github.com/anthropics/claude-code/issues/50136",
+      "title": "[DOCS] Agent SDK markdown preview docs omit table support",
+      "impact": "not_applicable",
+      "categories": [
+        "terminal"
+      ],
+      "tokenkey_status": "not_applicable",
+      "rationale": "Client-side claude-code concern (terminal); not a gateway/relay relevance signal.",
+      "updated_at": "2026-06-03T22:44:54Z"
+    },
+    {
+      "upstream": "anthropics/claude-code#50139",
+      "url": "https://github.com/anthropics/claude-code/issues/50139",
+      "title": "[DOCS] Subagent docs don't explain message routing when viewing a running subagent",
+      "impact": "not_applicable",
+      "categories": [
+        "plugin"
+      ],
+      "tokenkey_status": "not_applicable",
+      "rationale": "Client-side claude-code concern (plugin); not a gateway/relay relevance signal.",
+      "updated_at": "2026-06-03T11:39:45Z"
+    },
+    {
+      "upstream": "anthropics/claude-code#50145",
+      "url": "https://github.com/anthropics/claude-code/issues/50145",
+      "title": "[DOCS] Plugin installation troubleshooting missing `range-conflict` dependency guidance",
+      "impact": "not_applicable",
+      "categories": [
+        "plugin",
+        "install"
+      ],
+      "tokenkey_status": "not_applicable",
+      "rationale": "Client-side claude-code concern (plugin, install); not a gateway/relay relevance signal.",
+      "updated_at": "2026-06-03T11:39:45Z"
+    },
+    {
+      "upstream": "anthropics/claude-code#50147",
+      "url": "https://github.com/anthropics/claude-code/issues/50147",
+      "title": "[DOCS] Remote Control docs omit session archival behavior when Claude Code exits",
+      "impact": "not_applicable",
+      "categories": [
+        "ide",
+        "terminal"
+      ],
+      "tokenkey_status": "not_applicable",
+      "rationale": "Client-side claude-code concern (ide, terminal); not a gateway/relay relevance signal.",
+      "updated_at": "2026-06-03T22:44:59Z"
+    },
+    {
+      "upstream": "anthropics/claude-code#50157",
+      "url": "https://github.com/anthropics/claude-code/issues/50157",
+      "title": "[BUG] Claude in Chrome extension (v1.0.68) blocks navigation to claude.ai — breaking MCP browser automation after recent update",
+      "impact": "not_applicable",
+      "categories": [
+        "ide",
+        "terminal",
+        "mcp",
+        "install"
+      ],
+      "tokenkey_status": "not_applicable",
+      "rationale": "Client-side claude-code concern (ide, terminal, mcp, install); not a gateway/relay relevance signal.",
+      "updated_at": "2026-06-04T11:06:46Z"
     },
     {
       "upstream": "anthropics/claude-code#50159",
@@ -7126,7 +8598,7 @@
       ],
       "tokenkey_status": "not_applicable",
       "rationale": "Client-side claude-code concern (install); not a gateway/relay relevance signal.",
-      "updated_at": "2026-06-03T05:56:18Z"
+      "updated_at": "2026-06-03T12:13:47Z"
     },
     {
       "upstream": "anthropics/claude-code#50277",
@@ -7143,6 +8615,18 @@
       "updated_at": "2026-06-02T22:44:26Z"
     },
     {
+      "upstream": "anthropics/claude-code#50302",
+      "url": "https://github.com/anthropics/claude-code/issues/50302",
+      "title": "Allow switching project context (working directory) mid-session",
+      "impact": "not_applicable",
+      "categories": [
+        "slash_hook"
+      ],
+      "tokenkey_status": "not_applicable",
+      "rationale": "Client-side claude-code concern (slash_hook); not a gateway/relay relevance signal.",
+      "updated_at": "2026-06-03T11:39:27Z"
+    },
+    {
       "upstream": "anthropics/claude-code#50303",
       "url": "https://github.com/anthropics/claude-code/issues/50303",
       "title": "[BUG] `--allowedTools` has no effect when permission bypass flags are active",
@@ -7155,34 +8639,6 @@
       "tokenkey_status": "not_applicable",
       "rationale": "Client-side claude-code concern (ide, terminal, platform); not a gateway/relay relevance signal.",
       "updated_at": "2026-06-02T22:44:43Z"
-    },
-    {
-      "upstream": "anthropics/claude-code#50396",
-      "url": "https://github.com/anthropics/claude-code/issues/50396",
-      "title": "[Feature Request] Clear Context and Accept plan is missing from Claude Desktop",
-      "impact": "not_applicable",
-      "categories": [
-        "terminal",
-        "slash_hook"
-      ],
-      "tokenkey_status": "not_applicable",
-      "rationale": "Client-side claude-code concern (terminal, slash_hook); not a gateway/relay relevance signal.",
-      "updated_at": "2026-06-01T12:02:25Z"
-    },
-    {
-      "upstream": "anthropics/claude-code#50423",
-      "url": "https://github.com/anthropics/claude-code/issues/50423",
-      "title": "[BUG] VS Code extension doesn't load Chrome browser tools in chat panel despite docs stating @browser should work (Linux)",
-      "impact": "not_applicable",
-      "categories": [
-        "ide",
-        "terminal",
-        "mcp",
-        "install"
-      ],
-      "tokenkey_status": "not_applicable",
-      "rationale": "Client-side claude-code concern (ide, terminal, mcp, install); not a gateway/relay relevance signal.",
-      "updated_at": "2026-06-01T03:16:57Z"
     },
     {
       "upstream": "anthropics/claude-code#50451",
@@ -7222,12 +8678,12 @@
       ],
       "tokenkey_status": "not_applicable",
       "rationale": "Client-side claude-code concern (terminal, platform); not a gateway/relay relevance signal.",
-      "updated_at": "2026-06-02T12:06:44Z"
+      "updated_at": "2026-06-04T11:57:19Z"
     },
     {
-      "upstream": "anthropics/claude-code#50722",
-      "url": "https://github.com/anthropics/claude-code/issues/50722",
-      "title": "[BUG] Cowork tab missing in Mac desktop app on latest build, personal account",
+      "upstream": "anthropics/claude-code#50817",
+      "url": "https://github.com/anthropics/claude-code/issues/50817",
+      "title": "[BUG] Claude carelessly deletes uncommited work by dropping git stash that failed to pop (commonly repeating pattern)",
       "impact": "not_applicable",
       "categories": [
         "terminal",
@@ -7235,7 +8691,7 @@
       ],
       "tokenkey_status": "not_applicable",
       "rationale": "Client-side claude-code concern (terminal, platform); not a gateway/relay relevance signal.",
-      "updated_at": "2026-06-01T12:03:18Z"
+      "updated_at": "2026-06-04T11:07:13Z"
     },
     {
       "upstream": "anthropics/claude-code#50873",
@@ -7297,18 +8753,6 @@
       "updated_at": "2026-06-03T10:07:33Z"
     },
     {
-      "upstream": "anthropics/claude-code#50975",
-      "url": "https://github.com/anthropics/claude-code/issues/50975",
-      "title": "Write tool silently converts full-width CJK punctuation to half-width ASCII when overwriting files",
-      "impact": "not_applicable",
-      "categories": [
-        "terminal"
-      ],
-      "tokenkey_status": "not_applicable",
-      "rationale": "Client-side claude-code concern (terminal); not a gateway/relay relevance signal.",
-      "updated_at": "2026-06-01T13:09:58Z"
-    },
-    {
       "upstream": "anthropics/claude-code#51008",
       "url": "https://github.com/anthropics/claude-code/issues/51008",
       "title": "Skills appear duplicated/triplicated in the slash command list",
@@ -7331,35 +8775,72 @@
       ],
       "tokenkey_status": "not_applicable",
       "rationale": "Client-side claude-code concern (mcp); not a gateway/relay relevance signal.",
-      "updated_at": "2026-06-02T11:32:36Z"
+      "updated_at": "2026-06-03T21:27:13Z"
     },
     {
-      "upstream": "anthropics/claude-code#51143",
-      "url": "https://github.com/anthropics/claude-code/issues/51143",
-      "title": "[BUG] Claude Desktop persistent blank/white screen on Windows — Cowork unusable, multiple reinstalls have no effect",
+      "upstream": "anthropics/claude-code#51366",
+      "url": "https://github.com/anthropics/claude-code/issues/51366",
+      "title": "[DOCS] /terminal-setup docs omit fullscreen scroll-sensitivity setup for VS Code, Cursor, and Windsurf",
       "impact": "not_applicable",
       "categories": [
+        "ide",
         "terminal",
         "slash_hook",
-        "install",
-        "platform"
+        "install"
       ],
       "tokenkey_status": "not_applicable",
-      "rationale": "Client-side claude-code concern (terminal, slash_hook, install, platform); not a gateway/relay relevance signal.",
-      "updated_at": "2026-05-31T17:34:44Z"
+      "rationale": "Client-side claude-code concern (ide, terminal, slash_hook, install); not a gateway/relay relevance signal.",
+      "updated_at": "2026-06-03T11:40:05Z"
     },
     {
-      "upstream": "anthropics/claude-code#51213",
-      "url": "https://github.com/anthropics/claude-code/issues/51213",
-      "title": "[BUG] Titlebar buttons overlap and hide Claude’s top menu on RTL Windows languages (Hebrew/Arabic)",
+      "upstream": "anthropics/claude-code#51368",
+      "url": "https://github.com/anthropics/claude-code/issues/51368",
+      "title": "[DOCS] Settings docs omit `/config` search matching for option values",
       "impact": "not_applicable",
       "categories": [
-        "terminal",
-        "platform"
+        "plugin"
       ],
       "tokenkey_status": "not_applicable",
-      "rationale": "Client-side claude-code concern (terminal, platform); not a gateway/relay relevance signal.",
-      "updated_at": "2026-06-01T11:55:22Z"
+      "rationale": "Client-side claude-code concern (plugin); not a gateway/relay relevance signal.",
+      "updated_at": "2026-06-03T11:40:06Z"
+    },
+    {
+      "upstream": "anthropics/claude-code#51369",
+      "url": "https://github.com/anthropics/claude-code/issues/51369",
+      "title": "[DOCS] /doctor command reference missing \"works while Claude is responding\" behavior",
+      "impact": "not_applicable",
+      "categories": [
+        "slash_hook"
+      ],
+      "tokenkey_status": "not_applicable",
+      "rationale": "Client-side claude-code concern (slash_hook); not a gateway/relay relevance signal.",
+      "updated_at": "2026-06-03T11:40:03Z"
+    },
+    {
+      "upstream": "anthropics/claude-code#51374",
+      "url": "https://github.com/anthropics/claude-code/issues/51374",
+      "title": "[DOCS] Interactive mode reference omits Cmd+Left/Cmd+Right line navigation",
+      "impact": "not_applicable",
+      "categories": [
+        "ide",
+        "terminal",
+        "slash_hook"
+      ],
+      "tokenkey_status": "not_applicable",
+      "rationale": "Client-side claude-code concern (ide, terminal, slash_hook); not a gateway/relay relevance signal.",
+      "updated_at": "2026-06-03T11:40:05Z"
+    },
+    {
+      "upstream": "anthropics/claude-code#51376",
+      "url": "https://github.com/anthropics/claude-code/issues/51376",
+      "title": "[DOCS] Worktree docs omit mid-session command behavior for `/tui` and `/update`",
+      "impact": "not_applicable",
+      "categories": [
+        "terminal"
+      ],
+      "tokenkey_status": "not_applicable",
+      "rationale": "Client-side claude-code concern (terminal); not a gateway/relay relevance signal.",
+      "updated_at": "2026-06-03T11:40:08Z"
     },
     {
       "upstream": "anthropics/claude-code#51677",
@@ -7375,6 +8856,84 @@
       "tokenkey_status": "not_applicable",
       "rationale": "Client-side claude-code concern (ide, terminal, install, platform); not a gateway/relay relevance signal.",
       "updated_at": "2026-06-02T22:44:03Z"
+    },
+    {
+      "upstream": "anthropics/claude-code#51686",
+      "url": "https://github.com/anthropics/claude-code/issues/51686",
+      "title": "[BUG] CLAUDE.md language/dialect instructions drift during long sessions (Spanish voseo leaks into neutral-Spanish output)",
+      "impact": "not_applicable",
+      "categories": [
+        "terminal"
+      ],
+      "tokenkey_status": "not_applicable",
+      "rationale": "Client-side claude-code concern (terminal); not a gateway/relay relevance signal.",
+      "updated_at": "2026-06-03T16:56:28Z"
+    },
+    {
+      "upstream": "anthropics/claude-code#51773",
+      "url": "https://github.com/anthropics/claude-code/issues/51773",
+      "title": "[DOCS] Plugin install docs missing already-installed dependency repair behavior",
+      "impact": "not_applicable",
+      "categories": [
+        "plugin",
+        "install"
+      ],
+      "tokenkey_status": "not_applicable",
+      "rationale": "Client-side claude-code concern (plugin, install); not a gateway/relay relevance signal.",
+      "updated_at": "2026-06-03T11:39:52Z"
+    },
+    {
+      "upstream": "anthropics/claude-code#51777",
+      "url": "https://github.com/anthropics/claude-code/issues/51777",
+      "title": "[DOCS] Tools reference missing Advisor Tool documentation",
+      "impact": "not_applicable",
+      "categories": [
+        "mcp",
+        "plugin",
+        "slash_hook"
+      ],
+      "tokenkey_status": "not_applicable",
+      "rationale": "Client-side claude-code concern (mcp, plugin, slash_hook); not a gateway/relay relevance signal.",
+      "updated_at": "2026-06-03T11:39:52Z"
+    },
+    {
+      "upstream": "anthropics/claude-code#51779",
+      "url": "https://github.com/anthropics/claude-code/issues/51779",
+      "title": "[DOCS] cleanupPeriodDays retention docs omit tasks, backups, and shell-snapshots",
+      "impact": "not_applicable",
+      "categories": [
+        "plugin"
+      ],
+      "tokenkey_status": "not_applicable",
+      "rationale": "Client-side claude-code concern (plugin); not a gateway/relay relevance signal.",
+      "updated_at": "2026-06-03T11:39:47Z"
+    },
+    {
+      "upstream": "anthropics/claude-code#51781",
+      "url": "https://github.com/anthropics/claude-code/issues/51781",
+      "title": "[DOCS] Native macOS/Linux builds still document `Glob` and `Grep` as separate tools",
+      "impact": "not_applicable",
+      "categories": [
+        "install",
+        "platform"
+      ],
+      "tokenkey_status": "not_applicable",
+      "rationale": "Client-side claude-code concern (install, platform); not a gateway/relay relevance signal.",
+      "updated_at": "2026-06-03T10:31:11Z"
+    },
+    {
+      "upstream": "anthropics/claude-code#51785",
+      "url": "https://github.com/anthropics/claude-code/issues/51785",
+      "title": "[DOCS] MCP elicitation documentation missing print and Agent SDK handling",
+      "impact": "not_applicable",
+      "categories": [
+        "terminal",
+        "mcp",
+        "slash_hook"
+      ],
+      "tokenkey_status": "not_applicable",
+      "rationale": "Client-side claude-code concern (terminal, mcp, slash_hook); not a gateway/relay relevance signal.",
+      "updated_at": "2026-06-03T11:40:08Z"
     },
     {
       "upstream": "anthropics/claude-code#51815",
@@ -7404,16 +8963,16 @@
       "updated_at": "2026-06-03T06:06:11Z"
     },
     {
-      "upstream": "anthropics/claude-code#52075",
-      "url": "https://github.com/anthropics/claude-code/issues/52075",
-      "title": "[BUG] Permissions prompt despite bypass",
+      "upstream": "anthropics/claude-code#51998",
+      "url": "https://github.com/anthropics/claude-code/issues/51998",
+      "title": "Feature Request: Session Templates / Forking - Save compressed state as starting point for new sessions",
       "impact": "not_applicable",
       "categories": [
-        "terminal"
+        "ide"
       ],
       "tokenkey_status": "not_applicable",
-      "rationale": "Client-side claude-code concern (terminal); not a gateway/relay relevance signal.",
-      "updated_at": "2026-06-01T12:03:12Z"
+      "rationale": "Client-side claude-code concern (ide); not a gateway/relay relevance signal.",
+      "updated_at": "2026-06-04T11:07:23Z"
     },
     {
       "upstream": "anthropics/claude-code#52099",
@@ -7456,19 +9015,6 @@
       "updated_at": "2026-06-02T22:44:20Z"
     },
     {
-      "upstream": "anthropics/claude-code#52153",
-      "url": "https://github.com/anthropics/claude-code/issues/52153",
-      "title": "[Bug] Excessive token consumption per prompt with Opus 4.7 1M context model",
-      "impact": "not_applicable",
-      "categories": [
-        "mcp",
-        "platform"
-      ],
-      "tokenkey_status": "not_applicable",
-      "rationale": "Client-side claude-code concern (mcp, platform); not a gateway/relay relevance signal.",
-      "updated_at": "2026-05-31T18:30:59Z"
-    },
-    {
       "upstream": "anthropics/claude-code#52166",
       "url": "https://github.com/anthropics/claude-code/issues/52166",
       "title": "CLI pauses execution when terminal/composer loses focus",
@@ -7481,6 +9027,68 @@
       "updated_at": "2026-06-02T11:32:41Z"
     },
     {
+      "upstream": "anthropics/claude-code#52187",
+      "url": "https://github.com/anthropics/claude-code/issues/52187",
+      "title": "1M context window removed from Opus 4.6 API billing users — regression",
+      "impact": "not_applicable",
+      "categories": [
+        "slash_hook"
+      ],
+      "tokenkey_status": "not_applicable",
+      "rationale": "Client-side claude-code concern (slash_hook); not a gateway/relay relevance signal.",
+      "updated_at": "2026-06-04T11:07:21Z"
+    },
+    {
+      "upstream": "anthropics/claude-code#52192",
+      "url": "https://github.com/anthropics/claude-code/issues/52192",
+      "title": "[DOCS] Update docs missing `DISABLE_UPDATES` env var behavior",
+      "impact": "not_applicable",
+      "categories": [
+        "plugin",
+        "slash_hook"
+      ],
+      "tokenkey_status": "not_applicable",
+      "rationale": "Client-side claude-code concern (plugin, slash_hook); not a gateway/relay relevance signal.",
+      "updated_at": "2026-06-03T11:40:11Z"
+    },
+    {
+      "upstream": "anthropics/claude-code#52197",
+      "url": "https://github.com/anthropics/claude-code/issues/52197",
+      "title": "[DOCS] `/color` command docs missing Remote Control accent color sync behavior",
+      "impact": "not_applicable",
+      "categories": [
+        "terminal"
+      ],
+      "tokenkey_status": "not_applicable",
+      "rationale": "Client-side claude-code concern (terminal); not a gateway/relay relevance signal.",
+      "updated_at": "2026-06-03T11:40:15Z"
+    },
+    {
+      "upstream": "anthropics/claude-code#52206",
+      "url": "https://github.com/anthropics/claude-code/issues/52206",
+      "title": "[DOCS] Plugin install docs do not explain reinstall behavior for already-installed plugins or dependency repair",
+      "impact": "not_applicable",
+      "categories": [
+        "plugin",
+        "install"
+      ],
+      "tokenkey_status": "not_applicable",
+      "rationale": "Client-side claude-code concern (plugin, install); not a gateway/relay relevance signal.",
+      "updated_at": "2026-06-03T11:40:17Z"
+    },
+    {
+      "upstream": "anthropics/claude-code#52207",
+      "url": "https://github.com/anthropics/claude-code/issues/52207",
+      "title": "[DOCS] Subagent resume docs omit `cwd` continuity for `SendMessage` resumes",
+      "impact": "not_applicable",
+      "categories": [
+        "plugin"
+      ],
+      "tokenkey_status": "not_applicable",
+      "rationale": "Client-side claude-code concern (plugin); not a gateway/relay relevance signal.",
+      "updated_at": "2026-06-03T11:40:14Z"
+    },
+    {
       "upstream": "anthropics/claude-code#52252",
       "url": "https://github.com/anthropics/claude-code/issues/52252",
       "title": "[BUG] Cowork sandbox disk at 100% capacity — base image too large for allocated disk",
@@ -7491,20 +9099,22 @@
       ],
       "tokenkey_status": "not_applicable",
       "rationale": "Client-side claude-code concern (terminal, platform); not a gateway/relay relevance signal.",
-      "updated_at": "2026-06-02T19:33:17Z"
+      "updated_at": "2026-06-04T07:08:00Z"
     },
     {
-      "upstream": "anthropics/claude-code#52390",
-      "url": "https://github.com/anthropics/claude-code/issues/52390",
-      "title": "[BUG] CLAUDE_AUTOCOMPACT_PCT_OVERRIDE=50 does not trigger autocompact — context reaches 100% requiring manual /compact",
+      "upstream": "anthropics/claude-code#52472",
+      "url": "https://github.com/anthropics/claude-code/issues/52472",
+      "title": "[Bug] Weekly usage limit reset occurring before scheduled reset time & new week ends in 5 days, not 7 days",
       "impact": "not_applicable",
       "categories": [
-        "plugin",
-        "slash_hook"
+        "ide",
+        "terminal",
+        "mcp",
+        "plugin"
       ],
       "tokenkey_status": "not_applicable",
-      "rationale": "Client-side claude-code concern (plugin, slash_hook); not a gateway/relay relevance signal.",
-      "updated_at": "2026-05-31T13:43:03Z"
+      "rationale": "Client-side claude-code concern (ide, terminal, mcp, plugin); not a gateway/relay relevance signal.",
+      "updated_at": "2026-06-04T00:40:39Z"
     },
     {
       "upstream": "anthropics/claude-code#52509",
@@ -7533,6 +9143,157 @@
       "updated_at": "2026-06-02T14:54:15Z"
     },
     {
+      "upstream": "anthropics/claude-code#52603",
+      "url": "https://github.com/anthropics/claude-code/issues/52603",
+      "title": "[DOCS] Environment variables reference missing `CLAUDE_CODE_HIDE_CWD` startup logo option",
+      "impact": "not_applicable",
+      "categories": [
+        "terminal",
+        "slash_hook"
+      ],
+      "tokenkey_status": "not_applicable",
+      "rationale": "Client-side claude-code concern (terminal, slash_hook); not a gateway/relay relevance signal.",
+      "updated_at": "2026-06-03T11:40:24Z"
+    },
+    {
+      "upstream": "anthropics/claude-code#52605",
+      "url": "https://github.com/anthropics/claude-code/issues/52605",
+      "title": "[DOCS] `--agent` and `agent` setting docs omit session `permissionMode` behavior",
+      "impact": "not_applicable",
+      "categories": [
+        "plugin",
+        "slash_hook"
+      ],
+      "tokenkey_status": "not_applicable",
+      "rationale": "Client-side claude-code concern (plugin, slash_hook); not a gateway/relay relevance signal.",
+      "updated_at": "2026-06-03T11:40:21Z"
+    },
+    {
+      "upstream": "anthropics/claude-code#52606",
+      "url": "https://github.com/anthropics/claude-code/issues/52606",
+      "title": "[DOCS] Permission docs omit PowerShell auto-approval behavior",
+      "impact": "not_applicable",
+      "categories": [
+        "terminal",
+        "platform"
+      ],
+      "tokenkey_status": "not_applicable",
+      "rationale": "Client-side claude-code concern (terminal, platform); not a gateway/relay relevance signal.",
+      "updated_at": "2026-06-03T11:40:23Z"
+    },
+    {
+      "upstream": "anthropics/claude-code#52607",
+      "url": "https://github.com/anthropics/claude-code/issues/52607",
+      "title": "[DOCS] Hook input references omit `duration_ms` for `PostToolUse` and `PostToolUseFailure`",
+      "impact": "not_applicable",
+      "categories": [
+        "slash_hook"
+      ],
+      "tokenkey_status": "not_applicable",
+      "rationale": "Client-side claude-code concern (slash_hook); not a gateway/relay relevance signal.",
+      "updated_at": "2026-06-03T11:40:23Z"
+    },
+    {
+      "upstream": "anthropics/claude-code#52609",
+      "url": "https://github.com/anthropics/claude-code/issues/52609",
+      "title": "[DOCS] Vim mode docs omit Esc-in-INSERT interrupt behavior",
+      "impact": "not_applicable",
+      "categories": [
+        "terminal",
+        "slash_hook"
+      ],
+      "tokenkey_status": "not_applicable",
+      "rationale": "Client-side claude-code concern (terminal, slash_hook); not a gateway/relay relevance signal.",
+      "updated_at": "2026-06-03T11:40:19Z"
+    },
+    {
+      "upstream": "anthropics/claude-code#52610",
+      "url": "https://github.com/anthropics/claude-code/issues/52610",
+      "title": "[DOCS] Terminal output docs missing remote-host behavior for `owner/repo#N` links",
+      "impact": "not_applicable",
+      "categories": [
+        "terminal"
+      ],
+      "tokenkey_status": "not_applicable",
+      "rationale": "Client-side claude-code concern (terminal); not a gateway/relay relevance signal.",
+      "updated_at": "2026-06-03T11:40:22Z"
+    },
+    {
+      "upstream": "anthropics/claude-code#52611",
+      "url": "https://github.com/anthropics/claude-code/issues/52611",
+      "title": "[DOCS] Managed marketplace restrictions docs omit blockedMarketplaces pattern entries",
+      "impact": "not_applicable",
+      "categories": [
+        "plugin"
+      ],
+      "tokenkey_status": "not_applicable",
+      "rationale": "Client-side claude-code concern (plugin); not a gateway/relay relevance signal.",
+      "updated_at": "2026-06-03T11:40:25Z"
+    },
+    {
+      "upstream": "anthropics/claude-code#52618",
+      "url": "https://github.com/anthropics/claude-code/issues/52618",
+      "title": "[DOCS] Slash commands docs omit `@` file references in arguments, including absolute paths",
+      "impact": "not_applicable",
+      "categories": [
+        "slash_hook"
+      ],
+      "tokenkey_status": "not_applicable",
+      "rationale": "Client-side claude-code concern (slash_hook); not a gateway/relay relevance signal.",
+      "updated_at": "2026-06-03T11:40:18Z"
+    },
+    {
+      "upstream": "anthropics/claude-code#52619",
+      "url": "https://github.com/anthropics/claude-code/issues/52619",
+      "title": "[DOCS] MCP docs omit remote-header env-var expansion coverage for SSE/WebSocket",
+      "impact": "not_applicable",
+      "categories": [
+        "mcp"
+      ],
+      "tokenkey_status": "not_applicable",
+      "rationale": "Client-side claude-code concern (mcp); not a gateway/relay relevance signal.",
+      "updated_at": "2026-06-03T11:40:34Z"
+    },
+    {
+      "upstream": "anthropics/claude-code#52621",
+      "url": "https://github.com/anthropics/claude-code/issues/52621",
+      "title": "[DOCS] /skills command docs missing prompt-prefill selection behavior",
+      "impact": "not_applicable",
+      "categories": [
+        "plugin",
+        "slash_hook"
+      ],
+      "tokenkey_status": "not_applicable",
+      "rationale": "Client-side claude-code concern (plugin, slash_hook); not a gateway/relay relevance signal.",
+      "updated_at": "2026-06-03T11:40:28Z"
+    },
+    {
+      "upstream": "anthropics/claude-code#52623",
+      "url": "https://github.com/anthropics/claude-code/issues/52623",
+      "title": "[DOCS] Plugin MCP server docs omit optional blank `userConfig` substitution behavior",
+      "impact": "not_applicable",
+      "categories": [
+        "mcp",
+        "plugin",
+        "slash_hook"
+      ],
+      "tokenkey_status": "not_applicable",
+      "rationale": "Client-side claude-code concern (mcp, plugin, slash_hook); not a gateway/relay relevance signal.",
+      "updated_at": "2026-06-03T11:40:30Z"
+    },
+    {
+      "upstream": "anthropics/claude-code#52624",
+      "url": "https://github.com/anthropics/claude-code/issues/52624",
+      "title": "[DOCS] Plan mode docs omit `/plan open` and existing-plan reuse behavior",
+      "impact": "not_applicable",
+      "categories": [
+        "slash_hook"
+      ],
+      "tokenkey_status": "not_applicable",
+      "rationale": "Client-side claude-code concern (slash_hook); not a gateway/relay relevance signal.",
+      "updated_at": "2026-06-03T11:40:27Z"
+    },
+    {
       "upstream": "anthropics/claude-code#52625",
       "url": "https://github.com/anthropics/claude-code/issues/52625",
       "title": "[BUG] Claude code disabled by org administration on personal account",
@@ -7545,29 +9306,18 @@
       "updated_at": "2026-06-01T22:45:45Z"
     },
     {
-      "upstream": "anthropics/claude-code#52691",
-      "url": "https://github.com/anthropics/claude-code/issues/52691",
-      "title": "[Bug] Anthropic API Error: Usage Policy false positive issue blocking operations",
+      "upstream": "anthropics/claude-code#52631",
+      "url": "https://github.com/anthropics/claude-code/issues/52631",
+      "title": "[DOCS] VS Code docs missing voice dictation setup and macOS microphone permission behavior",
       "impact": "not_applicable",
       "categories": [
+        "ide",
         "terminal",
-        "platform"
+        "slash_hook"
       ],
       "tokenkey_status": "not_applicable",
-      "rationale": "Client-side claude-code concern (terminal, platform); not a gateway/relay relevance signal.",
-      "updated_at": "2026-06-01T06:32:27Z"
-    },
-    {
-      "upstream": "anthropics/claude-code#52724",
-      "url": "https://github.com/anthropics/claude-code/issues/52724",
-      "title": "[Bug] Config save not triggered on Enter key press",
-      "impact": "not_applicable",
-      "categories": [
-        "terminal"
-      ],
-      "tokenkey_status": "not_applicable",
-      "rationale": "Client-side claude-code concern (terminal); not a gateway/relay relevance signal.",
-      "updated_at": "2026-06-01T08:05:07Z"
+      "rationale": "Client-side claude-code concern (ide, terminal, slash_hook); not a gateway/relay relevance signal.",
+      "updated_at": "2026-06-03T11:40:28Z"
     },
     {
       "upstream": "anthropics/claude-code#52793",
@@ -7619,16 +9369,59 @@
       "updated_at": "2026-06-02T15:01:28Z"
     },
     {
-      "upstream": "anthropics/claude-code#53096",
-      "url": "https://github.com/anthropics/claude-code/issues/53096",
-      "title": "[BUG] Team Org Account rejected -> resulting in account banned for suspicious signals.",
+      "upstream": "anthropics/claude-code#53071",
+      "url": "https://github.com/anthropics/claude-code/issues/53071",
+      "title": "[DOCS] Bash tool docs missing `AI_AGENT` subprocess environment variable",
       "impact": "not_applicable",
       "categories": [
-        "terminal"
+        "mcp",
+        "plugin"
       ],
       "tokenkey_status": "not_applicable",
-      "rationale": "Client-side claude-code concern (terminal); not a gateway/relay relevance signal.",
-      "updated_at": "2026-06-01T12:03:17Z"
+      "rationale": "Client-side claude-code concern (mcp, plugin); not a gateway/relay relevance signal.",
+      "updated_at": "2026-06-03T11:40:35Z"
+    },
+    {
+      "upstream": "anthropics/claude-code#53073",
+      "url": "https://github.com/anthropics/claude-code/issues/53073",
+      "title": "[DOCS] MCP docs omit Esc interrupt behavior for stdio tool calls",
+      "impact": "not_applicable",
+      "categories": [
+        "terminal",
+        "mcp",
+        "slash_hook"
+      ],
+      "tokenkey_status": "not_applicable",
+      "rationale": "Client-side claude-code concern (terminal, mcp, slash_hook); not a gateway/relay relevance signal.",
+      "updated_at": "2026-06-03T11:40:29Z"
+    },
+    {
+      "upstream": "anthropics/claude-code#53076",
+      "url": "https://github.com/anthropics/claude-code/issues/53076",
+      "title": "[DOCS] Plugin marketplace docs missing unrecognized source format behavior",
+      "impact": "not_applicable",
+      "categories": [
+        "plugin",
+        "install"
+      ],
+      "tokenkey_status": "not_applicable",
+      "rationale": "Client-side claude-code concern (plugin, install); not a gateway/relay relevance signal.",
+      "updated_at": "2026-06-03T11:40:37Z"
+    },
+    {
+      "upstream": "anthropics/claude-code#53078",
+      "url": "https://github.com/anthropics/claude-code/issues/53078",
+      "title": "[DOCS] VS Code docs should clarify `/usage` opens the Account & Usage dialog",
+      "impact": "not_applicable",
+      "categories": [
+        "ide",
+        "terminal",
+        "mcp",
+        "plugin"
+      ],
+      "tokenkey_status": "not_applicable",
+      "rationale": "Client-side claude-code concern (ide, terminal, mcp, plugin); not a gateway/relay relevance signal.",
+      "updated_at": "2026-06-03T11:40:33Z"
     },
     {
       "upstream": "anthropics/claude-code#53134",
@@ -7687,6 +9480,30 @@
       "updated_at": "2026-06-02T11:45:25Z"
     },
     {
+      "upstream": "anthropics/claude-code#53432",
+      "url": "https://github.com/anthropics/claude-code/issues/53432",
+      "title": "claude update bails out on false-positive npm-global detection when npm prefix == native install bin dir",
+      "impact": "not_applicable",
+      "categories": [
+        "install"
+      ],
+      "tokenkey_status": "not_applicable",
+      "rationale": "Client-side claude-code concern (install); not a gateway/relay relevance signal.",
+      "updated_at": "2026-06-03T22:45:19Z"
+    },
+    {
+      "upstream": "anthropics/claude-code#53470",
+      "url": "https://github.com/anthropics/claude-code/issues/53470",
+      "title": "[BUG] CCR trigger stuck in 'setting up container' for 2+ days, no way to cancel",
+      "impact": "not_applicable",
+      "categories": [
+        "terminal"
+      ],
+      "tokenkey_status": "not_applicable",
+      "rationale": "Client-side claude-code concern (terminal); not a gateway/relay relevance signal.",
+      "updated_at": "2026-06-03T10:41:06Z"
+    },
+    {
       "upstream": "anthropics/claude-code#53484",
       "url": "https://github.com/anthropics/claude-code/issues/53484",
       "title": "Chat search omits Code chats currently open in other windows; no body-text index for Code chats",
@@ -7699,20 +9516,6 @@
       "updated_at": "2026-06-02T11:33:15Z"
     },
     {
-      "upstream": "anthropics/claude-code#53492",
-      "url": "https://github.com/anthropics/claude-code/issues/53492",
-      "title": "[Bug] Duplicate output in terminal causing content duplication",
-      "impact": "not_applicable",
-      "categories": [
-        "terminal",
-        "mcp",
-        "plugin"
-      ],
-      "tokenkey_status": "not_applicable",
-      "rationale": "Client-side claude-code concern (terminal, mcp, plugin); not a gateway/relay relevance signal.",
-      "updated_at": "2026-05-31T17:16:07Z"
-    },
-    {
       "upstream": "anthropics/claude-code#53638",
       "url": "https://github.com/anthropics/claude-code/issues/53638",
       "title": "Claude Code Desktop silently uses project API keys for billing instead of subscription",
@@ -7723,19 +9526,6 @@
       "tokenkey_status": "not_applicable",
       "rationale": "Client-side claude-code concern (terminal); not a gateway/relay relevance signal.",
       "updated_at": "2026-06-02T11:32:17Z"
-    },
-    {
-      "upstream": "anthropics/claude-code#53940",
-      "url": "https://github.com/anthropics/claude-code/issues/53940",
-      "title": "[BUG] Cowork Edit/Write tools silently truncate files via byte-conservation buffer cap (deterministic, fires at all file sizes)",
-      "impact": "not_applicable",
-      "categories": [
-        "terminal",
-        "platform"
-      ],
-      "tokenkey_status": "not_applicable",
-      "rationale": "Client-side claude-code concern (terminal, platform); not a gateway/relay relevance signal.",
-      "updated_at": "2026-06-01T07:20:12Z"
     },
     {
       "upstream": "anthropics/claude-code#53987",
@@ -7789,53 +9579,122 @@
       "updated_at": "2026-06-01T18:55:14Z"
     },
     {
-      "upstream": "anthropics/claude-code#54254",
-      "url": "https://github.com/anthropics/claude-code/issues/54254",
-      "title": "[FEATURE] /handover — user-curated session hand-off with fresh context",
+      "upstream": "anthropics/claude-code#54160",
+      "url": "https://github.com/anthropics/claude-code/issues/54160",
+      "title": "[DOCS] Skills command docs missing type-to-filter search box",
       "impact": "not_applicable",
       "categories": [
+        "terminal",
+        "plugin",
         "slash_hook"
       ],
       "tokenkey_status": "not_applicable",
-      "rationale": "Client-side claude-code concern (slash_hook); not a gateway/relay relevance signal.",
-      "updated_at": "2026-06-01T10:13:55Z"
+      "rationale": "Client-side claude-code concern (terminal, plugin, slash_hook); not a gateway/relay relevance signal.",
+      "updated_at": "2026-06-03T11:39:58Z"
     },
     {
-      "upstream": "anthropics/claude-code#54370",
-      "url": "https://github.com/anthropics/claude-code/issues/54370",
-      "title": "Schedule skill / RemoteTrigger API doesn't see MCP connectors connected on Team workspace",
+      "upstream": "anthropics/claude-code#54162",
+      "url": "https://github.com/anthropics/claude-code/issues/54162",
+      "title": "[DOCS] Interactive mode docs omit overflow dialog scrolling controls",
       "impact": "not_applicable",
       "categories": [
-        "mcp",
-        "platform"
+        "terminal",
+        "slash_hook"
       ],
       "tokenkey_status": "not_applicable",
-      "rationale": "Client-side claude-code concern (mcp, platform); not a gateway/relay relevance signal.",
-      "updated_at": "2026-06-01T08:03:37Z"
+      "rationale": "Client-side claude-code concern (terminal, slash_hook); not a gateway/relay relevance signal.",
+      "updated_at": "2026-06-03T11:39:58Z"
     },
     {
-      "upstream": "anthropics/claude-code#54392",
-      "url": "https://github.com/anthropics/claude-code/issues/54392",
-      "title": "[Bug] Session CPU usage spikes to 100% repeatedly",
+      "upstream": "anthropics/claude-code#54163",
+      "url": "https://github.com/anthropics/claude-code/issues/54163",
+      "title": "[DOCS] Forked subagent docs still say interactive-only for SDK and `claude -p`",
+      "impact": "not_applicable",
+      "categories": [
+        "plugin"
+      ],
+      "tokenkey_status": "not_applicable",
+      "rationale": "Client-side claude-code concern (plugin); not a gateway/relay relevance signal.",
+      "updated_at": "2026-06-03T11:40:01Z"
+    },
+    {
+      "upstream": "anthropics/claude-code#54167",
+      "url": "https://github.com/anthropics/claude-code/issues/54167",
+      "title": "[DOCS] Language setting docs omit terminal tab session title localization",
       "impact": "not_applicable",
       "categories": [
         "terminal"
       ],
       "tokenkey_status": "not_applicable",
       "rationale": "Client-side claude-code concern (terminal); not a gateway/relay relevance signal.",
-      "updated_at": "2026-06-01T12:02:22Z"
+      "updated_at": "2026-06-03T11:39:56Z"
     },
     {
-      "upstream": "anthropics/claude-code#54394",
-      "url": "https://github.com/anthropics/claude-code/issues/54394",
-      "title": "[BUG] v2.1.117 embedded ugrep wrapper amplifies regex backtracking from grep-process-OOM into V8-heap-OOM (8 GB ceiling) — host freezes on WSL2",
+      "upstream": "anthropics/claude-code#54168",
+      "url": "https://github.com/anthropics/claude-code/issues/54168",
+      "title": "[DOCS] MCP docs do not explain deduplication for Claude.ai connectors with the same upstream URL",
       "impact": "not_applicable",
       "categories": [
+        "mcp",
+        "plugin"
+      ],
+      "tokenkey_status": "not_applicable",
+      "rationale": "Client-side claude-code concern (mcp, plugin); not a gateway/relay relevance signal.",
+      "updated_at": "2026-06-03T11:39:55Z"
+    },
+    {
+      "upstream": "anthropics/claude-code#54170",
+      "url": "https://github.com/anthropics/claude-code/issues/54170",
+      "title": "[DOCS] Code intelligence docs omit click-to-expand LSP diagnostic summaries",
+      "impact": "not_applicable",
+      "categories": [
+        "terminal",
+        "mcp",
+        "plugin",
         "slash_hook"
       ],
       "tokenkey_status": "not_applicable",
-      "rationale": "Client-side claude-code concern (slash_hook); not a gateway/relay relevance signal.",
-      "updated_at": "2026-05-31T13:20:31Z"
+      "rationale": "Client-side claude-code concern (terminal, mcp, plugin, slash_hook); not a gateway/relay relevance signal.",
+      "updated_at": "2026-06-03T11:40:00Z"
+    },
+    {
+      "upstream": "anthropics/claude-code#54173",
+      "url": "https://github.com/anthropics/claude-code/issues/54173",
+      "title": "[DOCS] Voice dictation docs omit VS Code speechLanguage fallback",
+      "impact": "not_applicable",
+      "categories": [
+        "ide"
+      ],
+      "tokenkey_status": "not_applicable",
+      "rationale": "Client-side claude-code concern (ide); not a gateway/relay relevance signal.",
+      "updated_at": "2026-06-03T11:39:59Z"
+    },
+    {
+      "upstream": "anthropics/claude-code#54174",
+      "url": "https://github.com/anthropics/claude-code/issues/54174",
+      "title": "[DOCS] VS Code `/context` command missing native token usage dialog behavior",
+      "impact": "not_applicable",
+      "categories": [
+        "ide",
+        "terminal",
+        "mcp",
+        "plugin"
+      ],
+      "tokenkey_status": "not_applicable",
+      "rationale": "Client-side claude-code concern (ide, terminal, mcp, plugin); not a gateway/relay relevance signal.",
+      "updated_at": "2026-06-03T11:40:33Z"
+    },
+    {
+      "upstream": "anthropics/claude-code#54175",
+      "url": "https://github.com/anthropics/claude-code/issues/54175",
+      "title": "[DOCS] Bash tool docs omit deleted or moved launch-directory recovery behavior",
+      "impact": "not_applicable",
+      "categories": [
+        "plugin"
+      ],
+      "tokenkey_status": "not_applicable",
+      "rationale": "Client-side claude-code concern (plugin); not a gateway/relay relevance signal.",
+      "updated_at": "2026-06-03T11:40:02Z"
     },
     {
       "upstream": "anthropics/claude-code#54440",
@@ -7864,6 +9723,18 @@
       "updated_at": "2026-06-01T21:42:28Z"
     },
     {
+      "upstream": "anthropics/claude-code#54528",
+      "url": "https://github.com/anthropics/claude-code/issues/54528",
+      "title": "[BUG] Remote agent runs stuck on \"Setting up a cloud container\" — cannot cancel",
+      "impact": "not_applicable",
+      "categories": [
+        "terminal"
+      ],
+      "tokenkey_status": "not_applicable",
+      "rationale": "Client-side claude-code concern (terminal); not a gateway/relay relevance signal.",
+      "updated_at": "2026-06-04T10:57:35Z"
+    },
+    {
       "upstream": "anthropics/claude-code#54580",
       "url": "https://github.com/anthropics/claude-code/issues/54580",
       "title": "Feature request: Expose context usage to hooks for autonomous session handoff",
@@ -7887,34 +9758,6 @@
       "tokenkey_status": "not_applicable",
       "rationale": "Client-side claude-code concern (terminal); not a gateway/relay relevance signal.",
       "updated_at": "2026-06-02T22:09:29Z"
-    },
-    {
-      "upstream": "anthropics/claude-code#54647",
-      "url": "https://github.com/anthropics/claude-code/issues/54647",
-      "title": "[BUG] disableAutoUpdates should not lock the entire third-party inference UI",
-      "impact": "not_applicable",
-      "categories": [
-        "terminal",
-        "install"
-      ],
-      "tokenkey_status": "not_applicable",
-      "rationale": "Client-side claude-code concern (terminal, install); not a gateway/relay relevance signal.",
-      "updated_at": "2026-06-01T11:22:40Z"
-    },
-    {
-      "upstream": "anthropics/claude-code#54670",
-      "url": "https://github.com/anthropics/claude-code/issues/54670",
-      "title": "[FEATURE] VSCode extension: Copy chat response as markdown source",
-      "impact": "not_applicable",
-      "categories": [
-        "ide",
-        "terminal",
-        "slash_hook",
-        "platform"
-      ],
-      "tokenkey_status": "not_applicable",
-      "rationale": "Client-side claude-code concern (ide, terminal, slash_hook, platform); not a gateway/relay relevance signal.",
-      "updated_at": "2026-06-01T12:44:39Z"
     },
     {
       "upstream": "anthropics/claude-code#54813",
@@ -7956,17 +9799,16 @@
       "updated_at": "2026-06-02T06:47:27Z"
     },
     {
-      "upstream": "anthropics/claude-code#54879",
-      "url": "https://github.com/anthropics/claude-code/issues/54879",
-      "title": "[Bug] Auto-mode yields to user after Agent tool returns instead of continuing pipeline",
+      "upstream": "anthropics/claude-code#54904",
+      "url": "https://github.com/anthropics/claude-code/issues/54904",
+      "title": "[BUG] Background full checkout fails with not-a-git-repo when worktree mode is on for a repo with submodules",
       "impact": "not_applicable",
       "categories": [
-        "terminal",
-        "plugin"
+        "terminal"
       ],
       "tokenkey_status": "not_applicable",
-      "rationale": "Client-side claude-code concern (terminal, plugin); not a gateway/relay relevance signal.",
-      "updated_at": "2026-06-01T12:03:33Z"
+      "rationale": "Client-side claude-code concern (terminal); not a gateway/relay relevance signal.",
+      "updated_at": "2026-06-04T11:06:44Z"
     },
     {
       "upstream": "anthropics/claude-code#55023",
@@ -7984,6 +9826,18 @@
       "updated_at": "2026-06-02T11:33:16Z"
     },
     {
+      "upstream": "anthropics/claude-code#55092",
+      "url": "https://github.com/anthropics/claude-code/issues/55092",
+      "title": "[FEATURE] Persist panel layout settings between sessions",
+      "impact": "not_applicable",
+      "categories": [
+        "slash_hook"
+      ],
+      "tokenkey_status": "not_applicable",
+      "rationale": "Client-side claude-code concern (slash_hook); not a gateway/relay relevance signal.",
+      "updated_at": "2026-06-03T22:45:54Z"
+    },
+    {
       "upstream": "anthropics/claude-code#55107",
       "url": "https://github.com/anthropics/claude-code/issues/55107",
       "title": "[BUG] Failed to resume session: EINVAL: invalid argument, stat 'C:\\Users\\username",
@@ -7997,30 +9851,30 @@
       "updated_at": "2026-06-01T14:22:23Z"
     },
     {
-      "upstream": "anthropics/claude-code#5512",
-      "url": "https://github.com/anthropics/claude-code/issues/5512",
-      "title": "Feature Request: Add /copy command to copy messages to clipboard",
+      "upstream": "anthropics/claude-code#55188",
+      "url": "https://github.com/anthropics/claude-code/issues/55188",
+      "title": "[DOCS] Auto mode docs missing stalled permission-check spinner state",
+      "impact": "not_applicable",
+      "categories": [
+        "terminal"
+      ],
+      "tokenkey_status": "not_applicable",
+      "rationale": "Client-side claude-code concern (terminal); not a gateway/relay relevance signal.",
+      "updated_at": "2026-06-04T11:06:38Z"
+    },
+    {
+      "upstream": "anthropics/claude-code#55190",
+      "url": "https://github.com/anthropics/claude-code/issues/55190",
+      "title": "[DOCS] PowerShell tool docs do not mention supported Windows PowerShell 7 discovery sources",
       "impact": "not_applicable",
       "categories": [
         "slash_hook",
+        "install",
         "platform"
       ],
       "tokenkey_status": "not_applicable",
-      "rationale": "Client-side claude-code concern (slash_hook, platform); not a gateway/relay relevance signal.",
-      "updated_at": "2026-06-01T09:35:28Z"
-    },
-    {
-      "upstream": "anthropics/claude-code#55254",
-      "url": "https://github.com/anthropics/claude-code/issues/55254",
-      "title": "[BUG] Something went wrong Try sending your message again. If it keeps happening, share feedback so we can investigate. The session stopped responding. Send your message again to resume with a fresh process.",
-      "impact": "not_applicable",
-      "categories": [
-        "terminal",
-        "platform"
-      ],
-      "tokenkey_status": "not_applicable",
-      "rationale": "Client-side claude-code concern (terminal, platform); not a gateway/relay relevance signal.",
-      "updated_at": "2026-05-31T15:57:46Z"
+      "rationale": "Client-side claude-code concern (slash_hook, install, platform); not a gateway/relay relevance signal.",
+      "updated_at": "2026-06-03T22:45:04Z"
     },
     {
       "upstream": "anthropics/claude-code#55457",
@@ -8047,17 +9901,20 @@
       "updated_at": "2026-06-02T13:19:40Z"
     },
     {
-      "upstream": "anthropics/claude-code#55580",
-      "url": "https://github.com/anthropics/claude-code/issues/55580",
-      "title": "[FEATURE] User-controlled allowlist override for server-side domain blocks (Claude in Chrome)",
+      "upstream": "anthropics/claude-code#55558",
+      "url": "https://github.com/anthropics/claude-code/issues/55558",
+      "title": "[Bug] Permission mode \"auto\" not inherited in new sessions and cannot be set mid-session",
       "impact": "not_applicable",
       "categories": [
-        "ide",
+        "terminal",
+        "mcp",
+        "plugin",
+        "slash_hook",
         "platform"
       ],
       "tokenkey_status": "not_applicable",
-      "rationale": "Client-side claude-code concern (ide, platform); not a gateway/relay relevance signal.",
-      "updated_at": "2026-06-01T07:31:39Z"
+      "rationale": "Client-side claude-code concern (terminal, mcp, plugin, slash_hook, platform); not a gateway/relay relevance signal.",
+      "updated_at": "2026-06-03T22:45:46Z"
     },
     {
       "upstream": "anthropics/claude-code#55586",
@@ -8157,18 +10014,6 @@
       "updated_at": "2026-06-02T00:34:55Z"
     },
     {
-      "upstream": "anthropics/claude-code#55854",
-      "url": "https://github.com/anthropics/claude-code/issues/55854",
-      "title": "[FEATURE] Permission prompts: never use a number for \"No\"; treat stray digits as \"Yes\" fallback",
-      "impact": "not_applicable",
-      "categories": [
-        "terminal"
-      ],
-      "tokenkey_status": "not_applicable",
-      "rationale": "Client-side claude-code concern (terminal); not a gateway/relay relevance signal.",
-      "updated_at": "2026-06-01T05:35:59Z"
-    },
-    {
       "upstream": "anthropics/claude-code#55863",
       "url": "https://github.com/anthropics/claude-code/issues/55863",
       "title": "[BUG] Session recap (post_turn_summary) never renders in VSCode extension, only in CLI",
@@ -8184,28 +10029,31 @@
       "updated_at": "2026-06-02T11:33:13Z"
     },
     {
-      "upstream": "anthropics/claude-code#55915",
-      "url": "https://github.com/anthropics/claude-code/issues/55915",
-      "title": "Add option to configure week start day (Monday) for welcome page heatmap",
+      "upstream": "anthropics/claude-code#55917",
+      "url": "https://github.com/anthropics/claude-code/issues/55917",
+      "title": "[BUG] Can't upgrade Pro → Max: payment authentication fails on every card/method",
       "impact": "not_applicable",
       "categories": [
-        "slash_hook"
+        "terminal"
       ],
       "tokenkey_status": "not_applicable",
-      "rationale": "Client-side claude-code concern (slash_hook); not a gateway/relay relevance signal.",
-      "updated_at": "2026-06-01T05:35:46Z"
+      "rationale": "Client-side claude-code concern (terminal); not a gateway/relay relevance signal.",
+      "updated_at": "2026-06-04T11:06:41Z"
     },
     {
-      "upstream": "anthropics/claude-code#55945",
-      "url": "https://github.com/anthropics/claude-code/issues/55945",
-      "title": "[FEATURE] Hook which fires when you run out of tokens; expose time when they will be available again",
+      "upstream": "anthropics/claude-code#56013",
+      "url": "https://github.com/anthropics/claude-code/issues/56013",
+      "title": "[BUG] [VSCode]",
       "impact": "not_applicable",
       "categories": [
-        "slash_hook"
+        "ide",
+        "terminal",
+        "install",
+        "platform"
       ],
       "tokenkey_status": "not_applicable",
-      "rationale": "Client-side claude-code concern (slash_hook); not a gateway/relay relevance signal.",
-      "updated_at": "2026-06-01T05:36:22Z"
+      "rationale": "Client-side claude-code concern (ide, terminal, install, platform); not a gateway/relay relevance signal.",
+      "updated_at": "2026-06-03T22:45:55Z"
     },
     {
       "upstream": "anthropics/claude-code#56017",
@@ -8244,19 +10092,6 @@
       "tokenkey_status": "not_applicable",
       "rationale": "Client-side claude-code concern (mcp, slash_hook); not a gateway/relay relevance signal.",
       "updated_at": "2026-06-01T22:45:43Z"
-    },
-    {
-      "upstream": "anthropics/claude-code#56300",
-      "url": "https://github.com/anthropics/claude-code/issues/56300",
-      "title": "[BUG] Claude start session with 100% usage!",
-      "impact": "not_applicable",
-      "categories": [
-        "terminal",
-        "platform"
-      ],
-      "tokenkey_status": "not_applicable",
-      "rationale": "Client-side claude-code concern (terminal, platform); not a gateway/relay relevance signal.",
-      "updated_at": "2026-06-01T12:02:10Z"
     },
     {
       "upstream": "anthropics/claude-code#56335",
@@ -8351,19 +10186,6 @@
       "updated_at": "2026-06-02T22:03:36Z"
     },
     {
-      "upstream": "anthropics/claude-code#56952",
-      "url": "https://github.com/anthropics/claude-code/issues/56952",
-      "title": "[BUG] Claude Code Desktop SSH to Hostinger KVM4 VPS - process.spawn exits with code 1 on every message",
-      "impact": "not_applicable",
-      "categories": [
-        "terminal",
-        "platform"
-      ],
-      "tokenkey_status": "not_applicable",
-      "rationale": "Client-side claude-code concern (terminal, platform); not a gateway/relay relevance signal.",
-      "updated_at": "2026-06-01T12:03:14Z"
-    },
-    {
       "upstream": "anthropics/claude-code#56965",
       "url": "https://github.com/anthropics/claude-code/issues/56965",
       "title": "Claude in Chrome v1.0.70: `permission_required` regression continues from #53630 — approval popup never renders, all MCP navigations blocked",
@@ -8377,6 +10199,19 @@
       "tokenkey_status": "not_applicable",
       "rationale": "Client-side claude-code concern (ide, terminal, mcp, platform); not a gateway/relay relevance signal.",
       "updated_at": "2026-06-02T21:26:28Z"
+    },
+    {
+      "upstream": "anthropics/claude-code#57019",
+      "url": "https://github.com/anthropics/claude-code/issues/57019",
+      "title": "Feature Request: Show TodoWrite task list in Claude.app Tasks panel",
+      "impact": "not_applicable",
+      "categories": [
+        "terminal",
+        "plugin"
+      ],
+      "tokenkey_status": "not_applicable",
+      "rationale": "Client-side claude-code concern (terminal, plugin); not a gateway/relay relevance signal.",
+      "updated_at": "2026-06-03T17:19:41Z"
     },
     {
       "upstream": "anthropics/claude-code#57132",
@@ -8402,7 +10237,21 @@
       ],
       "tokenkey_status": "not_applicable",
       "rationale": "Client-side claude-code concern (terminal, install, platform); not a gateway/relay relevance signal.",
-      "updated_at": "2026-06-03T06:15:20Z"
+      "updated_at": "2026-06-04T07:56:35Z"
+    },
+    {
+      "upstream": "anthropics/claude-code#57161",
+      "url": "https://github.com/anthropics/claude-code/issues/57161",
+      "title": "[BUG] Personal GitHub repos not showing in Claude Code web repo picker despite app installed and connector connected",
+      "impact": "not_applicable",
+      "categories": [
+        "terminal",
+        "install",
+        "platform"
+      ],
+      "tokenkey_status": "not_applicable",
+      "rationale": "Client-side claude-code concern (terminal, install, platform); not a gateway/relay relevance signal.",
+      "updated_at": "2026-06-03T12:36:41Z"
     },
     {
       "upstream": "anthropics/claude-code#57178",
@@ -8445,6 +10294,18 @@
       "updated_at": "2026-06-02T12:14:48Z"
     },
     {
+      "upstream": "anthropics/claude-code#57286",
+      "url": "https://github.com/anthropics/claude-code/issues/57286",
+      "title": "Bug: Remote Control initialization fails with \"Remote Control failed to connect: Remote Control initialization failed\"",
+      "impact": "not_applicable",
+      "categories": [
+        "terminal"
+      ],
+      "tokenkey_status": "not_applicable",
+      "rationale": "Client-side claude-code concern (terminal); not a gateway/relay relevance signal.",
+      "updated_at": "2026-06-03T23:09:02Z"
+    },
+    {
       "upstream": "anthropics/claude-code#57295",
       "url": "https://github.com/anthropics/claude-code/issues/57295",
       "title": "[BUG] Claude tries to get the project owner's attention with @Human, but that's me.",
@@ -8454,35 +10315,7 @@
       ],
       "tokenkey_status": "not_applicable",
       "rationale": "Client-side claude-code concern (terminal); not a gateway/relay relevance signal.",
-      "updated_at": "2026-06-01T12:12:26Z"
-    },
-    {
-      "upstream": "anthropics/claude-code#57371",
-      "url": "https://github.com/anthropics/claude-code/issues/57371",
-      "title": "Claude Desktop (Windows): provide a way to disable the bundled Cowork background service (CoworkVMService) for users who don't use Cowork",
-      "impact": "not_applicable",
-      "categories": [
-        "ide",
-        "install",
-        "platform"
-      ],
-      "tokenkey_status": "not_applicable",
-      "rationale": "Client-side claude-code concern (ide, install, platform); not a gateway/relay relevance signal.",
-      "updated_at": "2026-05-31T17:57:36Z"
-    },
-    {
-      "upstream": "anthropics/claude-code#57580",
-      "url": "https://github.com/anthropics/claude-code/issues/57580",
-      "title": "macOS: PTY file descriptors leaked across a long Bash-heavy session, exhausting kern.tty.ptmx_max (forkpty / posix_openpt fail with ENXIO system-wide)",
-      "impact": "not_applicable",
-      "categories": [
-        "ide",
-        "terminal",
-        "install"
-      ],
-      "tokenkey_status": "not_applicable",
-      "rationale": "Client-side claude-code concern (ide, terminal, install); not a gateway/relay relevance signal.",
-      "updated_at": "2026-05-31T13:07:42Z"
+      "updated_at": "2026-06-04T11:45:49Z"
     },
     {
       "upstream": "anthropics/claude-code#57601",
@@ -8510,6 +10343,19 @@
       "tokenkey_status": "not_applicable",
       "rationale": "Client-side claude-code concern (ide, plugin); not a gateway/relay relevance signal.",
       "updated_at": "2026-06-03T01:41:16Z"
+    },
+    {
+      "upstream": "anthropics/claude-code#57691",
+      "url": "https://github.com/anthropics/claude-code/issues/57691",
+      "title": "[BUG] Chat scroll is constrained to most recent assistant turn while AskUserQuestion card is showing",
+      "impact": "not_applicable",
+      "categories": [
+        "ide",
+        "terminal"
+      ],
+      "tokenkey_status": "not_applicable",
+      "rationale": "Client-side claude-code concern (ide, terminal); not a gateway/relay relevance signal.",
+      "updated_at": "2026-06-03T20:04:22Z"
     },
     {
       "upstream": "anthropics/claude-code#57700",
@@ -8550,19 +10396,7 @@
       ],
       "tokenkey_status": "not_applicable",
       "rationale": "Client-side claude-code concern (ide); not a gateway/relay relevance signal.",
-      "updated_at": "2026-06-02T23:34:09Z"
-    },
-    {
-      "upstream": "anthropics/claude-code#57859",
-      "url": "https://github.com/anthropics/claude-code/issues/57859",
-      "title": "Claude desktop app's PR/CI panel can't find `gh` because PATH is `/usr/bin:/bin:/usr/sbin:/sbin` (LSEnvironment override)",
-      "impact": "not_applicable",
-      "categories": [
-        "install"
-      ],
-      "tokenkey_status": "not_applicable",
-      "rationale": "Client-side claude-code concern (install); not a gateway/relay relevance signal.",
-      "updated_at": "2026-06-01T08:05:03Z"
+      "updated_at": "2026-06-03T22:22:54Z"
     },
     {
       "upstream": "anthropics/claude-code#57862",
@@ -8643,7 +10477,7 @@
       ],
       "tokenkey_status": "not_applicable",
       "rationale": "Client-side claude-code concern (terminal, slash_hook, platform); not a gateway/relay relevance signal.",
-      "updated_at": "2026-06-01T22:46:11Z"
+      "updated_at": "2026-06-04T08:27:40Z"
     },
     {
       "upstream": "anthropics/claude-code#58144",
@@ -8698,19 +10532,6 @@
       "updated_at": "2026-06-02T11:32:47Z"
     },
     {
-      "upstream": "anthropics/claude-code#58332",
-      "url": "https://github.com/anthropics/claude-code/issues/58332",
-      "title": "[FEATURE] Multi-LSP per file extension: let linting servers coexist with type servers — or tell us it won't happen",
-      "impact": "not_applicable",
-      "categories": [
-        "ide",
-        "plugin"
-      ],
-      "tokenkey_status": "not_applicable",
-      "rationale": "Client-side claude-code concern (ide, plugin); not a gateway/relay relevance signal.",
-      "updated_at": "2026-05-31T14:09:24Z"
-    },
-    {
       "upstream": "anthropics/claude-code#58333",
       "url": "https://github.com/anthropics/claude-code/issues/58333",
       "title": "claude update: false-positive \"~/.local/bin is not in your PATH\" warning when it actually is",
@@ -8738,17 +10559,16 @@
       "updated_at": "2026-06-02T11:32:27Z"
     },
     {
-      "upstream": "anthropics/claude-code#58429",
-      "url": "https://github.com/anthropics/claude-code/issues/58429",
-      "title": "[A11y feature request] Built-in option to speak Claude's responses aloud",
+      "upstream": "anthropics/claude-code#58412",
+      "url": "https://github.com/anthropics/claude-code/issues/58412",
+      "title": "Session rename in sidebar reverts after clicking elsewhere",
       "impact": "not_applicable",
       "categories": [
-        "terminal",
-        "slash_hook"
+        "ide"
       ],
       "tokenkey_status": "not_applicable",
-      "rationale": "Client-side claude-code concern (terminal, slash_hook); not a gateway/relay relevance signal.",
-      "updated_at": "2026-05-31T23:03:50Z"
+      "rationale": "Client-side claude-code concern (ide); not a gateway/relay relevance signal.",
+      "updated_at": "2026-06-03T22:45:28Z"
     },
     {
       "upstream": "anthropics/claude-code#58444",
@@ -8763,18 +10583,17 @@
       "updated_at": "2026-06-01T17:58:49Z"
     },
     {
-      "upstream": "anthropics/claude-code#58504",
-      "url": "https://github.com/anthropics/claude-code/issues/58504",
-      "title": "[BUG] VSCode 2.1.139: acceptEdits / Edit automatically mode still prompts for Edit tool approval (regression persists since v2.1.79)",
+      "upstream": "anthropics/claude-code#58518",
+      "url": "https://github.com/anthropics/claude-code/issues/58518",
+      "title": "[BUG] Paste image not working",
       "impact": "not_applicable",
       "categories": [
-        "ide",
-        "slash_hook",
+        "terminal",
         "platform"
       ],
       "tokenkey_status": "not_applicable",
-      "rationale": "Client-side claude-code concern (ide, slash_hook, platform); not a gateway/relay relevance signal.",
-      "updated_at": "2026-06-01T12:02:15Z"
+      "rationale": "Client-side claude-code concern (terminal, platform); not a gateway/relay relevance signal.",
+      "updated_at": "2026-06-03T15:44:42Z"
     },
     {
       "upstream": "anthropics/claude-code#58522",
@@ -8787,6 +10606,20 @@
       "tokenkey_status": "not_applicable",
       "rationale": "Client-side claude-code concern (terminal); not a gateway/relay relevance signal.",
       "updated_at": "2026-06-02T22:44:56Z"
+    },
+    {
+      "upstream": "anthropics/claude-code#58588",
+      "url": "https://github.com/anthropics/claude-code/issues/58588",
+      "title": "[FEATURE] Allow /rename and /color to be set programmatically at session start",
+      "impact": "not_applicable",
+      "categories": [
+        "terminal",
+        "slash_hook",
+        "platform"
+      ],
+      "tokenkey_status": "not_applicable",
+      "rationale": "Client-side claude-code concern (terminal, slash_hook, platform); not a gateway/relay relevance signal.",
+      "updated_at": "2026-06-04T09:21:52Z"
     },
     {
       "upstream": "anthropics/claude-code#58614",
@@ -8815,6 +10648,18 @@
       "tokenkey_status": "not_applicable",
       "rationale": "Client-side claude-code concern (terminal, slash_hook); not a gateway/relay relevance signal.",
       "updated_at": "2026-06-02T22:44:18Z"
+    },
+    {
+      "upstream": "anthropics/claude-code#58648",
+      "url": "https://github.com/anthropics/claude-code/issues/58648",
+      "title": "[BUG] CLI truncates a >~146 KB user message line on stdin when preceded by another NDJSON line (`--input-format stream-json`)",
+      "impact": "not_applicable",
+      "categories": [
+        "terminal"
+      ],
+      "tokenkey_status": "not_applicable",
+      "rationale": "Client-side claude-code concern (terminal); not a gateway/relay relevance signal.",
+      "updated_at": "2026-06-03T22:45:42Z"
     },
     {
       "upstream": "anthropics/claude-code#58660",
@@ -8894,20 +10739,6 @@
       "updated_at": "2026-06-03T04:00:47Z"
     },
     {
-      "upstream": "anthropics/claude-code#58780",
-      "url": "https://github.com/anthropics/claude-code/issues/58780",
-      "title": "[BUG] VSCode extension: copy button on completed code blocks flickers during streaming",
-      "impact": "not_applicable",
-      "categories": [
-        "ide",
-        "terminal",
-        "install"
-      ],
-      "tokenkey_status": "not_applicable",
-      "rationale": "Client-side claude-code concern (ide, terminal, install); not a gateway/relay relevance signal.",
-      "updated_at": "2026-06-01T12:44:18Z"
-    },
-    {
       "upstream": "anthropics/claude-code#58784",
       "url": "https://github.com/anthropics/claude-code/issues/58784",
       "title": "[BUG] Claude Code process exited with code 1",
@@ -8918,19 +10749,6 @@
       "tokenkey_status": "not_applicable",
       "rationale": "Client-side claude-code concern (terminal); not a gateway/relay relevance signal.",
       "updated_at": "2026-06-01T22:45:54Z"
-    },
-    {
-      "upstream": "anthropics/claude-code#58793",
-      "url": "https://github.com/anthropics/claude-code/issues/58793",
-      "title": "Claude Desktop window is completely blank",
-      "impact": "not_applicable",
-      "categories": [
-        "terminal",
-        "platform"
-      ],
-      "tokenkey_status": "not_applicable",
-      "rationale": "Client-side claude-code concern (terminal, platform); not a gateway/relay relevance signal.",
-      "updated_at": "2026-06-01T07:39:06Z"
     },
     {
       "upstream": "anthropics/claude-code#58821",
@@ -8944,92 +10762,6 @@
       "tokenkey_status": "not_applicable",
       "rationale": "Client-side claude-code concern (terminal, platform); not a gateway/relay relevance signal.",
       "updated_at": "2026-06-02T23:34:42Z"
-    },
-    {
-      "upstream": "anthropics/claude-code#58862",
-      "url": "https://github.com/anthropics/claude-code/issues/58862",
-      "title": "[DOCS] `/feedback` docs omit recent-session attachment options for cross-session issues",
-      "impact": "not_applicable",
-      "categories": [
-        "install"
-      ],
-      "tokenkey_status": "not_applicable",
-      "rationale": "Client-side claude-code concern (install); not a gateway/relay relevance signal.",
-      "updated_at": "2026-06-01T01:12:03Z"
-    },
-    {
-      "upstream": "anthropics/claude-code#58864",
-      "url": "https://github.com/anthropics/claude-code/issues/58864",
-      "title": "[DOCS] Auto mode docs omit that `permissions.ask` rules still trigger manual approval prompts",
-      "impact": "not_applicable",
-      "categories": [
-        "slash_hook"
-      ],
-      "tokenkey_status": "not_applicable",
-      "rationale": "Client-side claude-code concern (slash_hook); not a gateway/relay relevance signal.",
-      "updated_at": "2026-06-01T01:11:29Z"
-    },
-    {
-      "upstream": "anthropics/claude-code#58866",
-      "url": "https://github.com/anthropics/claude-code/issues/58866",
-      "title": "[DOCS] Extended thinking docs omit the amber spinner state during long thinking periods",
-      "impact": "not_applicable",
-      "categories": [
-        "terminal"
-      ],
-      "tokenkey_status": "not_applicable",
-      "rationale": "Client-side claude-code concern (terminal); not a gateway/relay relevance signal.",
-      "updated_at": "2026-06-01T01:11:28Z"
-    },
-    {
-      "upstream": "anthropics/claude-code#58867",
-      "url": "https://github.com/anthropics/claude-code/issues/58867",
-      "title": "[DOCS] Plugin manager docs omit fullscreen tab and search navigation controls",
-      "impact": "not_applicable",
-      "categories": [
-        "plugin"
-      ],
-      "tokenkey_status": "not_applicable",
-      "rationale": "Client-side claude-code concern (plugin); not a gateway/relay relevance signal.",
-      "updated_at": "2026-06-01T01:11:17Z"
-    },
-    {
-      "upstream": "anthropics/claude-code#58871",
-      "url": "https://github.com/anthropics/claude-code/issues/58871",
-      "title": "[DOCS] Interactive mode docs omit interrupted-prompt Up-arrow history behavior",
-      "impact": "not_applicable",
-      "categories": [
-        "slash_hook"
-      ],
-      "tokenkey_status": "not_applicable",
-      "rationale": "Client-side claude-code concern (slash_hook); not a gateway/relay relevance signal.",
-      "updated_at": "2026-06-01T01:11:09Z"
-    },
-    {
-      "upstream": "anthropics/claude-code#58872",
-      "url": "https://github.com/anthropics/claude-code/issues/58872",
-      "title": "[DOCS] `/tui` docs omit that running background shells and subagents block renderer switching",
-      "impact": "not_applicable",
-      "categories": [
-        "terminal",
-        "plugin"
-      ],
-      "tokenkey_status": "not_applicable",
-      "rationale": "Client-side claude-code concern (terminal, plugin); not a gateway/relay relevance signal.",
-      "updated_at": "2026-06-01T01:08:40Z"
-    },
-    {
-      "upstream": "anthropics/claude-code#58873",
-      "url": "https://github.com/anthropics/claude-code/issues/58873",
-      "title": "[DOCS] Plugin marketplace docs omit deleted-`ref` behavior when `sha` is pinned",
-      "impact": "not_applicable",
-      "categories": [
-        "plugin",
-        "install"
-      ],
-      "tokenkey_status": "not_applicable",
-      "rationale": "Client-side claude-code concern (plugin, install); not a gateway/relay relevance signal.",
-      "updated_at": "2026-06-01T01:09:07Z"
     },
     {
       "upstream": "anthropics/claude-code#58895",
@@ -9060,6 +10792,19 @@
       "updated_at": "2026-06-02T11:32:34Z"
     },
     {
+      "upstream": "anthropics/claude-code#58923",
+      "url": "https://github.com/anthropics/claude-code/issues/58923",
+      "title": "[BUG] Claude code CLI cannot paste Image",
+      "impact": "not_applicable",
+      "categories": [
+        "terminal",
+        "platform"
+      ],
+      "tokenkey_status": "not_applicable",
+      "rationale": "Client-side claude-code concern (terminal, platform); not a gateway/relay relevance signal.",
+      "updated_at": "2026-06-03T22:45:17Z"
+    },
+    {
       "upstream": "anthropics/claude-code#58924",
       "url": "https://github.com/anthropics/claude-code/issues/58924",
       "title": "Project-scope .mcp.json silently skipped during startup in 2.1.141 (native, Linux)",
@@ -9087,16 +10832,16 @@
       "updated_at": "2026-06-02T22:43:58Z"
     },
     {
-      "upstream": "anthropics/claude-code#58966",
-      "url": "https://github.com/anthropics/claude-code/issues/58966",
-      "title": "[FEATURE] Inverse of background mode: archive agent from Agent View without destroying data",
+      "upstream": "anthropics/claude-code#58954",
+      "url": "https://github.com/anthropics/claude-code/issues/58954",
+      "title": "[BUG] Cowork Desktop (Mac): No way to unarchive an archived project",
       "impact": "not_applicable",
       "categories": [
-        "slash_hook"
+        "terminal"
       ],
       "tokenkey_status": "not_applicable",
-      "rationale": "Client-side claude-code concern (slash_hook); not a gateway/relay relevance signal.",
-      "updated_at": "2026-06-01T12:03:25Z"
+      "rationale": "Client-side claude-code concern (terminal); not a gateway/relay relevance signal.",
+      "updated_at": "2026-06-04T11:07:25Z"
     },
     {
       "upstream": "anthropics/claude-code#59032",
@@ -9111,47 +10856,18 @@
       "updated_at": "2026-06-01T22:45:06Z"
     },
     {
-      "upstream": "anthropics/claude-code#59057",
-      "url": "https://github.com/anthropics/claude-code/issues/59057",
-      "title": "[BUG] Chat history empty when workspace is on a mapped network drive (Windows)",
+      "upstream": "anthropics/claude-code#59182",
+      "url": "https://github.com/anthropics/claude-code/issues/59182",
+      "title": "Misleading 'CI checks unavailable' when CC session cwd is not a git repo",
       "impact": "not_applicable",
       "categories": [
-        "ide",
         "terminal",
+        "install",
         "platform"
       ],
       "tokenkey_status": "not_applicable",
-      "rationale": "Client-side claude-code concern (ide, terminal, platform); not a gateway/relay relevance signal.",
-      "updated_at": "2026-06-01T12:03:21Z"
-    },
-    {
-      "upstream": "anthropics/claude-code#59136",
-      "url": "https://github.com/anthropics/claude-code/issues/59136",
-      "title": "Agent window model selection limited to Haiku 4.5 in VS Code Insiders",
-      "impact": "not_applicable",
-      "categories": [
-        "ide"
-      ],
-      "tokenkey_status": "not_applicable",
-      "rationale": "Client-side claude-code concern (ide); not a gateway/relay relevance signal.",
-      "updated_at": "2026-06-01T12:27:23Z"
-    },
-    {
-      "upstream": "anthropics/claude-code#59139",
-      "url": "https://github.com/anthropics/claude-code/issues/59139",
-      "title": "[Cowork UI] \"Unhandled case: [object Object]\" banner — MCP tool-result envelope + SDK stream-end-with-error renderer paths",
-      "impact": "not_applicable",
-      "categories": [
-        "ide",
-        "terminal",
-        "mcp",
-        "plugin",
-        "slash_hook",
-        "platform"
-      ],
-      "tokenkey_status": "not_applicable",
-      "rationale": "Client-side claude-code concern (ide, terminal, mcp, plugin, slash_hook, platform); not a gateway/relay relevance signal.",
-      "updated_at": "2026-06-01T12:01:54Z"
+      "rationale": "Client-side claude-code concern (terminal, install, platform); not a gateway/relay relevance signal.",
+      "updated_at": "2026-06-03T22:45:36Z"
     },
     {
       "upstream": "anthropics/claude-code#59191",
@@ -9166,20 +10882,17 @@
       "updated_at": "2026-06-02T11:31:58Z"
     },
     {
-      "upstream": "anthropics/claude-code#59245",
-      "url": "https://github.com/anthropics/claude-code/issues/59245",
-      "title": "Feature request: surface AskUserQuestion through the MCP channel API so plugins can proxy it",
+      "upstream": "anthropics/claude-code#59195",
+      "url": "https://github.com/anthropics/claude-code/issues/59195",
+      "title": "[FEATURE] Persistent Todo List panel in sidebar (alongside Activity / Plan)",
       "impact": "not_applicable",
       "categories": [
         "ide",
-        "terminal",
-        "mcp",
-        "plugin",
-        "slash_hook"
+        "terminal"
       ],
       "tokenkey_status": "not_applicable",
-      "rationale": "Client-side claude-code concern (ide, terminal, mcp, plugin, slash_hook); not a gateway/relay relevance signal.",
-      "updated_at": "2026-06-01T12:01:59Z"
+      "rationale": "Client-side claude-code concern (ide, terminal); not a gateway/relay relevance signal.",
+      "updated_at": "2026-06-03T17:19:32Z"
     },
     {
       "upstream": "anthropics/claude-code#59248",
@@ -9194,58 +10907,7 @@
       ],
       "tokenkey_status": "not_applicable",
       "rationale": "Client-side claude-code concern (ide, plugin, slash_hook, install); not a gateway/relay relevance signal.",
-      "updated_at": "2026-06-03T09:14:53Z"
-    },
-    {
-      "upstream": "anthropics/claude-code#59258",
-      "url": "https://github.com/anthropics/claude-code/issues/59258",
-      "title": "[DOCS] Plugin docs omit root-level `SKILL.md` discovery without a `skills/` subdirectory",
-      "impact": "not_applicable",
-      "categories": [
-        "plugin",
-        "slash_hook",
-        "install"
-      ],
-      "tokenkey_status": "not_applicable",
-      "rationale": "Client-side claude-code concern (plugin, slash_hook, install); not a gateway/relay relevance signal.",
-      "updated_at": "2026-06-01T01:09:07Z"
-    },
-    {
-      "upstream": "anthropics/claude-code#59259",
-      "url": "https://github.com/anthropics/claude-code/issues/59259",
-      "title": "[DOCS] Plugin details docs omit LSP servers in `/plugin` and `claude plugin details`",
-      "impact": "not_applicable",
-      "categories": [
-        "mcp",
-        "plugin"
-      ],
-      "tokenkey_status": "not_applicable",
-      "rationale": "Client-side claude-code concern (mcp, plugin); not a gateway/relay relevance signal.",
-      "updated_at": "2026-06-01T01:08:17Z"
-    },
-    {
-      "upstream": "anthropics/claude-code#59260",
-      "url": "https://github.com/anthropics/claude-code/issues/59260",
-      "title": "[DOCS] `/web-setup` docs omit warning before replacing an existing GitHub App connection",
-      "impact": "not_applicable",
-      "categories": [
-        "terminal"
-      ],
-      "tokenkey_status": "not_applicable",
-      "rationale": "Client-side claude-code concern (terminal); not a gateway/relay relevance signal.",
-      "updated_at": "2026-06-01T01:08:03Z"
-    },
-    {
-      "upstream": "anthropics/claude-code#59282",
-      "url": "https://github.com/anthropics/claude-code/issues/59282",
-      "title": "[Bug] Desktop Projects \"Recent\" sort uses stale timestamps instead of chat activity",
-      "impact": "not_applicable",
-      "categories": [
-        "terminal"
-      ],
-      "tokenkey_status": "not_applicable",
-      "rationale": "Client-side claude-code concern (terminal); not a gateway/relay relevance signal.",
-      "updated_at": "2026-06-01T12:18:57Z"
+      "updated_at": "2026-06-04T01:56:11Z"
     },
     {
       "upstream": "anthropics/claude-code#59309",
@@ -9284,32 +10946,6 @@
       "updated_at": "2026-06-02T09:47:45Z"
     },
     {
-      "upstream": "anthropics/claude-code#59405",
-      "url": "https://github.com/anthropics/claude-code/issues/59405",
-      "title": "[Bug] Claude Code skips UI modules when building from Claude.com shared prompts with screenshots",
-      "impact": "not_applicable",
-      "categories": [
-        "terminal",
-        "plugin"
-      ],
-      "tokenkey_status": "not_applicable",
-      "rationale": "Client-side claude-code concern (terminal, plugin); not a gateway/relay relevance signal.",
-      "updated_at": "2026-06-01T12:02:26Z"
-    },
-    {
-      "upstream": "anthropics/claude-code#59423",
-      "url": "https://github.com/anthropics/claude-code/issues/59423",
-      "title": "\"N skill descriptions dropped\" — empty descriptions for duplicate SKILL.md between plugins/marketplaces/ and plugins/cache/",
-      "impact": "not_applicable",
-      "categories": [
-        "plugin",
-        "install"
-      ],
-      "tokenkey_status": "not_applicable",
-      "rationale": "Client-side claude-code concern (plugin, install); not a gateway/relay relevance signal.",
-      "updated_at": "2026-06-01T12:02:11Z"
-    },
-    {
       "upstream": "anthropics/claude-code#59492",
       "url": "https://github.com/anthropics/claude-code/issues/59492",
       "title": "[FEATURE] Native /restart and /handoff: consolidating 9 open requests + 2 working prototypes",
@@ -9339,123 +10975,6 @@
       "updated_at": "2026-06-01T22:45:11Z"
     },
     {
-      "upstream": "anthropics/claude-code#59559",
-      "url": "https://github.com/anthropics/claude-code/issues/59559",
-      "title": "[BUG] Claude Code Hangs and Thinks Longer on Godot Specific Projects",
-      "impact": "not_applicable",
-      "categories": [
-        "ide",
-        "terminal",
-        "platform"
-      ],
-      "tokenkey_status": "not_applicable",
-      "rationale": "Client-side claude-code concern (ide, terminal, platform); not a gateway/relay relevance signal.",
-      "updated_at": "2026-06-01T12:01:55Z"
-    },
-    {
-      "upstream": "anthropics/claude-code#59562",
-      "url": "https://github.com/anthropics/claude-code/issues/59562",
-      "title": "[BUG] /rename command is self-defeating",
-      "impact": "not_applicable",
-      "categories": [
-        "terminal"
-      ],
-      "tokenkey_status": "not_applicable",
-      "rationale": "Client-side claude-code concern (terminal); not a gateway/relay relevance signal.",
-      "updated_at": "2026-06-01T12:01:56Z"
-    },
-    {
-      "upstream": "anthropics/claude-code#59567",
-      "url": "https://github.com/anthropics/claude-code/issues/59567",
-      "title": "[BUG] Edit tool writes to a sibling worktree's copy of a file (silent), instead of the cwd worktree, when both checkouts have the same tracked path",
-      "impact": "not_applicable",
-      "categories": [
-        "terminal"
-      ],
-      "tokenkey_status": "not_applicable",
-      "rationale": "Client-side claude-code concern (terminal); not a gateway/relay relevance signal.",
-      "updated_at": "2026-06-01T12:01:58Z"
-    },
-    {
-      "upstream": "anthropics/claude-code#59574",
-      "url": "https://github.com/anthropics/claude-code/issues/59574",
-      "title": "[BUG] Latest claude.code version (2.1.142) is massively degraded in (tokens per context/memory(recovery)/inference/etc.)",
-      "impact": "not_applicable",
-      "categories": [
-        "terminal",
-        "mcp",
-        "platform"
-      ],
-      "tokenkey_status": "not_applicable",
-      "rationale": "Client-side claude-code concern (terminal, mcp, platform); not a gateway/relay relevance signal.",
-      "updated_at": "2026-06-01T12:02:00Z"
-    },
-    {
-      "upstream": "anthropics/claude-code#59579",
-      "url": "https://github.com/anthropics/claude-code/issues/59579",
-      "title": "[DOCS] `/plugin` marketplace browse pane projected context cost estimates are undocumented",
-      "impact": "not_applicable",
-      "categories": [
-        "mcp",
-        "plugin"
-      ],
-      "tokenkey_status": "not_applicable",
-      "rationale": "Client-side claude-code concern (mcp, plugin); not a gateway/relay relevance signal.",
-      "updated_at": "2026-06-01T01:05:30Z"
-    },
-    {
-      "upstream": "anthropics/claude-code#59584",
-      "url": "https://github.com/anthropics/claude-code/issues/59584",
-      "title": "[DOCS] `/goal` docs do not explain evaluator waits for background shells or delegated subagents",
-      "impact": "not_applicable",
-      "categories": [
-        "plugin",
-        "slash_hook"
-      ],
-      "tokenkey_status": "not_applicable",
-      "rationale": "Client-side claude-code concern (plugin, slash_hook); not a gateway/relay relevance signal.",
-      "updated_at": "2026-06-01T01:04:55Z"
-    },
-    {
-      "upstream": "anthropics/claude-code#59588",
-      "url": "https://github.com/anthropics/claude-code/issues/59588",
-      "title": "[DOCS] PowerShell tool docs still describe opt-in rollout instead of default-enable behavior for Bedrock, Vertex, and Foundry on Windows",
-      "impact": "not_applicable",
-      "categories": [
-        "slash_hook",
-        "platform"
-      ],
-      "tokenkey_status": "not_applicable",
-      "rationale": "Client-side claude-code concern (slash_hook, platform); not a gateway/relay relevance signal.",
-      "updated_at": "2026-06-01T01:05:11Z"
-    },
-    {
-      "upstream": "anthropics/claude-code#59592",
-      "url": "https://github.com/anthropics/claude-code/issues/59592",
-      "title": "[DOCS] Background-session docs omit macOS Full Disk Access behavior for protected home folders",
-      "impact": "not_applicable",
-      "categories": [
-        "terminal",
-        "mcp",
-        "plugin"
-      ],
-      "tokenkey_status": "not_applicable",
-      "rationale": "Client-side claude-code concern (terminal, mcp, plugin); not a gateway/relay relevance signal.",
-      "updated_at": "2026-06-01T01:32:47Z"
-    },
-    {
-      "upstream": "anthropics/claude-code#59595",
-      "url": "https://github.com/anthropics/claude-code/issues/59595",
-      "title": "[DOCS] `/bg` and `←` detach docs omit `--allow-dangerously-skip-permissions` preservation for backgrounded sessions",
-      "impact": "not_applicable",
-      "categories": [
-        "plugin"
-      ],
-      "tokenkey_status": "not_applicable",
-      "rationale": "Client-side claude-code concern (plugin); not a gateway/relay relevance signal.",
-      "updated_at": "2026-06-01T01:04:23Z"
-    },
-    {
       "upstream": "anthropics/claude-code#59628",
       "url": "https://github.com/anthropics/claude-code/issues/59628",
       "title": "Worktree sessions can edit files in the parent main checkout with no guardrail",
@@ -9466,35 +10985,20 @@
       ],
       "tokenkey_status": "not_applicable",
       "rationale": "Client-side claude-code concern (slash_hook, platform); not a gateway/relay relevance signal.",
-      "updated_at": "2026-06-03T02:51:57Z"
+      "updated_at": "2026-06-04T00:07:13Z"
     },
     {
-      "upstream": "anthropics/claude-code#59656",
-      "url": "https://github.com/anthropics/claude-code/issues/59656",
-      "title": "[BUG] Max user, Claude unusable 3x issues - 1. 1M context error 2. repeated auto compaction after 1/2 messages 3. Single word prompt \"too long\"",
+      "upstream": "anthropics/claude-code#59666",
+      "url": "https://github.com/anthropics/claude-code/issues/59666",
+      "title": "Memory and instructions not effectively followed across sessions - repeated mistakes waste tokens and user time",
       "impact": "not_applicable",
       "categories": [
-        "ide",
-        "terminal"
-      ],
-      "tokenkey_status": "not_applicable",
-      "rationale": "Client-side claude-code concern (ide, terminal); not a gateway/relay relevance signal.",
-      "updated_at": "2026-06-01T12:02:27Z"
-    },
-    {
-      "upstream": "anthropics/claude-code#59661",
-      "url": "https://github.com/anthropics/claude-code/issues/59661",
-      "title": "Alt+V image paste broken on Windows (regression — accessibility impact for eye-gaze-only users)",
-      "impact": "not_applicable",
-      "categories": [
-        "terminal",
-        "plugin",
-        "slash_hook",
+        "mcp",
         "platform"
       ],
       "tokenkey_status": "not_applicable",
-      "rationale": "Client-side claude-code concern (terminal, plugin, slash_hook, platform); not a gateway/relay relevance signal.",
-      "updated_at": "2026-06-01T12:02:29Z"
+      "rationale": "Client-side claude-code concern (mcp, platform); not a gateway/relay relevance signal.",
+      "updated_at": "2026-06-04T11:07:05Z"
     },
     {
       "upstream": "anthropics/claude-code#59670",
@@ -9507,7 +11011,7 @@
       ],
       "tokenkey_status": "not_applicable",
       "rationale": "Client-side claude-code concern (ide, terminal); not a gateway/relay relevance signal.",
-      "updated_at": "2026-06-01T12:02:06Z"
+      "updated_at": "2026-06-03T19:16:19Z"
     },
     {
       "upstream": "anthropics/claude-code#59672",
@@ -9524,30 +11028,6 @@
       "updated_at": "2026-06-01T22:45:31Z"
     },
     {
-      "upstream": "anthropics/claude-code#59675",
-      "url": "https://github.com/anthropics/claude-code/issues/59675",
-      "title": "Feature Request: A7A (I OBJECT!) and MEH (Close But No Cigar) — Two AI Accountability Buttons",
-      "impact": "not_applicable",
-      "categories": [
-        "slash_hook"
-      ],
-      "tokenkey_status": "not_applicable",
-      "rationale": "Client-side claude-code concern (slash_hook); not a gateway/relay relevance signal.",
-      "updated_at": "2026-06-01T12:02:08Z"
-    },
-    {
-      "upstream": "anthropics/claude-code#59676",
-      "url": "https://github.com/anthropics/claude-code/issues/59676",
-      "title": "Feature Request: A7A (I OBJECT!) and MEH (Close But No Cigar) — Two AI Accountability Buttons",
-      "impact": "not_applicable",
-      "categories": [
-        "slash_hook"
-      ],
-      "tokenkey_status": "not_applicable",
-      "rationale": "Client-side claude-code concern (slash_hook); not a gateway/relay relevance signal.",
-      "updated_at": "2026-06-01T12:02:09Z"
-    },
-    {
       "upstream": "anthropics/claude-code#59683",
       "url": "https://github.com/anthropics/claude-code/issues/59683",
       "title": "[FEATURE] Files panel (macOS Desktop): render symlinked directories as expandable folders",
@@ -9560,19 +11040,6 @@
       "tokenkey_status": "not_applicable",
       "rationale": "Client-side claude-code concern (ide, terminal, platform); not a gateway/relay relevance signal.",
       "updated_at": "2026-06-01T22:45:03Z"
-    },
-    {
-      "upstream": "anthropics/claude-code#59685",
-      "url": "https://github.com/anthropics/claude-code/issues/59685",
-      "title": "[BUG] Broken access control",
-      "impact": "not_applicable",
-      "categories": [
-        "ide",
-        "terminal"
-      ],
-      "tokenkey_status": "not_applicable",
-      "rationale": "Client-side claude-code concern (ide, terminal); not a gateway/relay relevance signal.",
-      "updated_at": "2026-06-01T12:03:22Z"
     },
     {
       "upstream": "anthropics/claude-code#59686",
@@ -9600,41 +11067,19 @@
       "updated_at": "2026-06-01T22:45:09Z"
     },
     {
-      "upstream": "anthropics/claude-code#59698",
-      "url": "https://github.com/anthropics/claude-code/issues/59698",
-      "title": "[Bug] Vim motion h/l not supported for effort selection in /model command",
-      "impact": "not_applicable",
-      "categories": [
-        "terminal"
-      ],
-      "tokenkey_status": "not_applicable",
-      "rationale": "Client-side claude-code concern (terminal); not a gateway/relay relevance signal.",
-      "updated_at": "2026-06-01T12:02:14Z"
-    },
-    {
-      "upstream": "anthropics/claude-code#59704",
-      "url": "https://github.com/anthropics/claude-code/issues/59704",
-      "title": "Expose per-session/bg-job state visually in the terminal (extend agent-view color cues to split panes)",
+      "upstream": "anthropics/claude-code#59697",
+      "url": "https://github.com/anthropics/claude-code/issues/59697",
+      "title": "Desktop rewind fails on conversation-only sessions: not on active chain (chain size 2/N)",
       "impact": "not_applicable",
       "categories": [
         "terminal",
-        "slash_hook"
-      ],
-      "tokenkey_status": "not_applicable",
-      "rationale": "Client-side claude-code concern (terminal, slash_hook); not a gateway/relay relevance signal.",
-      "updated_at": "2026-06-01T12:02:17Z"
-    },
-    {
-      "upstream": "anthropics/claude-code#59706",
-      "url": "https://github.com/anthropics/claude-code/issues/59706",
-      "title": "Community Workaround for #22903 — CDP Connector gives Claude browser eyes/hands today",
-      "impact": "not_applicable",
-      "categories": [
+        "plugin",
+        "install",
         "platform"
       ],
       "tokenkey_status": "not_applicable",
-      "rationale": "Client-side claude-code concern (platform); not a gateway/relay relevance signal.",
-      "updated_at": "2026-06-01T12:02:19Z"
+      "rationale": "Client-side claude-code concern (terminal, plugin, install, platform); not a gateway/relay relevance signal.",
+      "updated_at": "2026-06-03T22:45:27Z"
     },
     {
       "upstream": "anthropics/claude-code#59709",
@@ -9646,19 +11091,7 @@
       ],
       "tokenkey_status": "not_applicable",
       "rationale": "Client-side claude-code concern (terminal); not a gateway/relay relevance signal.",
-      "updated_at": "2026-06-01T12:03:19Z"
-    },
-    {
-      "upstream": "anthropics/claude-code#59710",
-      "url": "https://github.com/anthropics/claude-code/issues/59710",
-      "title": "Slack MCP Connector: Add support for mark-as-read (conversations.mark)",
-      "impact": "not_applicable",
-      "categories": [
-        "mcp"
-      ],
-      "tokenkey_status": "not_applicable",
-      "rationale": "Client-side claude-code concern (mcp); not a gateway/relay relevance signal.",
-      "updated_at": "2026-06-01T12:02:21Z"
+      "updated_at": "2026-06-03T23:06:15Z"
     },
     {
       "upstream": "anthropics/claude-code#59713",
@@ -9675,57 +11108,6 @@
       "updated_at": "2026-06-02T22:44:29Z"
     },
     {
-      "upstream": "anthropics/claude-code#59717",
-      "url": "https://github.com/anthropics/claude-code/issues/59717",
-      "title": "[Bug] Claude Code creates single Agent instead of Team when explicitly requested",
-      "impact": "not_applicable",
-      "categories": [
-        "terminal",
-        "slash_hook"
-      ],
-      "tokenkey_status": "not_applicable",
-      "rationale": "Client-side claude-code concern (terminal, slash_hook); not a gateway/relay relevance signal.",
-      "updated_at": "2026-06-01T12:03:09Z"
-    },
-    {
-      "upstream": "anthropics/claude-code#59723",
-      "url": "https://github.com/anthropics/claude-code/issues/59723",
-      "title": "Chrome MCP returns `permission_required` with no UI to approve domain",
-      "impact": "not_applicable",
-      "categories": [
-        "ide",
-        "mcp"
-      ],
-      "tokenkey_status": "not_applicable",
-      "rationale": "Client-side claude-code concern (ide, mcp); not a gateway/relay relevance signal.",
-      "updated_at": "2026-05-31T19:35:21Z"
-    },
-    {
-      "upstream": "anthropics/claude-code#59726",
-      "url": "https://github.com/anthropics/claude-code/issues/59726",
-      "title": "[BUG] ENAMETOOLONG creating ~/.claude/projects/ when cwd is long (eCryptfs NAME_MAX=143); reproduces via Claude Desktop cowork bootstrap",
-      "impact": "not_applicable",
-      "categories": [
-        "install"
-      ],
-      "tokenkey_status": "not_applicable",
-      "rationale": "Client-side claude-code concern (install); not a gateway/relay relevance signal.",
-      "updated_at": "2026-06-01T12:02:28Z"
-    },
-    {
-      "upstream": "anthropics/claude-code#59735",
-      "url": "https://github.com/anthropics/claude-code/issues/59735",
-      "title": "[Bug] Diff view text unreadable on light terminal backgrounds without theme configuration",
-      "impact": "not_applicable",
-      "categories": [
-        "terminal",
-        "slash_hook"
-      ],
-      "tokenkey_status": "not_applicable",
-      "rationale": "Client-side claude-code concern (terminal, slash_hook); not a gateway/relay relevance signal.",
-      "updated_at": "2026-06-01T12:02:30Z"
-    },
-    {
       "upstream": "anthropics/claude-code#59736",
       "url": "https://github.com/anthropics/claude-code/issues/59736",
       "title": "Desktop 3p Code sessions disappear from UI after restart while JSONL transcripts remain on disk",
@@ -9737,31 +11119,6 @@
       "tokenkey_status": "not_applicable",
       "rationale": "Client-side claude-code concern (ide, platform); not a gateway/relay relevance signal.",
       "updated_at": "2026-06-01T23:14:19Z"
-    },
-    {
-      "upstream": "anthropics/claude-code#59737",
-      "url": "https://github.com/anthropics/claude-code/issues/59737",
-      "title": "[Bug] Claude Code ignores $COLORTERM=truecolor in foot terminal, downgrades to 16-color",
-      "impact": "not_applicable",
-      "categories": [
-        "terminal",
-        "install"
-      ],
-      "tokenkey_status": "not_applicable",
-      "rationale": "Client-side claude-code concern (terminal, install); not a gateway/relay relevance signal.",
-      "updated_at": "2026-06-01T12:02:31Z"
-    },
-    {
-      "upstream": "anthropics/claude-code#59740",
-      "url": "https://github.com/anthropics/claude-code/issues/59740",
-      "title": "[FEATURE] Allow users to manually dismiss \"Needs input\" state in Claude Code Desktop",
-      "impact": "not_applicable",
-      "categories": [
-        "terminal"
-      ],
-      "tokenkey_status": "not_applicable",
-      "rationale": "Client-side claude-code concern (terminal); not a gateway/relay relevance signal.",
-      "updated_at": "2026-06-01T12:02:32Z"
     },
     {
       "upstream": "anthropics/claude-code#59741",
@@ -9777,432 +11134,9 @@
       "updated_at": "2026-06-01T22:45:28Z"
     },
     {
-      "upstream": "anthropics/claude-code#59747",
-      "url": "https://github.com/anthropics/claude-code/issues/59747",
-      "title": "[Bug] Anthropic API Error: 500 Internal Server Error",
-      "impact": "not_applicable",
-      "categories": [
-        "terminal"
-      ],
-      "tokenkey_status": "not_applicable",
-      "rationale": "Client-side claude-code concern (terminal); not a gateway/relay relevance signal.",
-      "updated_at": "2026-06-01T12:02:35Z"
-    },
-    {
-      "upstream": "anthropics/claude-code#59748",
-      "url": "https://github.com/anthropics/claude-code/issues/59748",
-      "title": "[BUG] API Error: 500 Internal server error.",
-      "impact": "not_applicable",
-      "categories": [
-        "terminal"
-      ],
-      "tokenkey_status": "not_applicable",
-      "rationale": "Client-side claude-code concern (terminal); not a gateway/relay relevance signal.",
-      "updated_at": "2026-06-01T12:02:52Z"
-    },
-    {
-      "upstream": "anthropics/claude-code#59749",
-      "url": "https://github.com/anthropics/claude-code/issues/59749",
-      "title": "[Bug] Claude Code desktop app on macOS not accepting prompt input",
-      "impact": "not_applicable",
-      "categories": [
-        "terminal"
-      ],
-      "tokenkey_status": "not_applicable",
-      "rationale": "Client-side claude-code concern (terminal); not a gateway/relay relevance signal.",
-      "updated_at": "2026-06-01T12:02:36Z"
-    },
-    {
-      "upstream": "anthropics/claude-code#59751",
-      "url": "https://github.com/anthropics/claude-code/issues/59751",
-      "title": "[Bug] Anthropic API Error: 500 Internal Server Error",
-      "impact": "not_applicable",
-      "categories": [
-        "terminal"
-      ],
-      "tokenkey_status": "not_applicable",
-      "rationale": "Client-side claude-code concern (terminal); not a gateway/relay relevance signal.",
-      "updated_at": "2026-06-01T12:02:37Z"
-    },
-    {
-      "upstream": "anthropics/claude-code#59752",
-      "url": "https://github.com/anthropics/claude-code/issues/59752",
-      "title": "[Bug] Anthropic API Error: High 500 error rate on requests",
-      "impact": "not_applicable",
-      "categories": [
-        "terminal"
-      ],
-      "tokenkey_status": "not_applicable",
-      "rationale": "Client-side claude-code concern (terminal); not a gateway/relay relevance signal.",
-      "updated_at": "2026-06-01T12:02:38Z"
-    },
-    {
-      "upstream": "anthropics/claude-code#59753",
-      "url": "https://github.com/anthropics/claude-code/issues/59753",
-      "title": "[Bug] Anthropic API Error: 500 Internal Server Error",
-      "impact": "not_applicable",
-      "categories": [
-        "ide",
-        "terminal"
-      ],
-      "tokenkey_status": "not_applicable",
-      "rationale": "Client-side claude-code concern (ide, terminal); not a gateway/relay relevance signal.",
-      "updated_at": "2026-06-01T12:02:50Z"
-    },
-    {
-      "upstream": "anthropics/claude-code#59755",
-      "url": "https://github.com/anthropics/claude-code/issues/59755",
-      "title": "[Bug] Anthropic API Error: 500 Internal Server Error",
-      "impact": "not_applicable",
-      "categories": [
-        "terminal"
-      ],
-      "tokenkey_status": "not_applicable",
-      "rationale": "Client-side claude-code concern (terminal); not a gateway/relay relevance signal.",
-      "updated_at": "2026-06-01T12:02:39Z"
-    },
-    {
-      "upstream": "anthropics/claude-code#59756",
-      "url": "https://github.com/anthropics/claude-code/issues/59756",
-      "title": "[Bug] Anthropic API Error: 500 Internal Server Error",
-      "impact": "not_applicable",
-      "categories": [
-        "terminal"
-      ],
-      "tokenkey_status": "not_applicable",
-      "rationale": "Client-side claude-code concern (terminal); not a gateway/relay relevance signal.",
-      "updated_at": "2026-06-01T12:02:40Z"
-    },
-    {
-      "upstream": "anthropics/claude-code#59758",
-      "url": "https://github.com/anthropics/claude-code/issues/59758",
-      "title": "[Bug] Anthropic API Error: 500 Internal Server Error",
-      "impact": "not_applicable",
-      "categories": [
-        "terminal"
-      ],
-      "tokenkey_status": "not_applicable",
-      "rationale": "Client-side claude-code concern (terminal); not a gateway/relay relevance signal.",
-      "updated_at": "2026-06-01T12:02:41Z"
-    },
-    {
-      "upstream": "anthropics/claude-code#59759",
-      "url": "https://github.com/anthropics/claude-code/issues/59759",
-      "title": "[Bug] Anthropic API Error: 500 Internal Server Error occurring frequently",
-      "impact": "not_applicable",
-      "categories": [
-        "terminal"
-      ],
-      "tokenkey_status": "not_applicable",
-      "rationale": "Client-side claude-code concern (terminal); not a gateway/relay relevance signal.",
-      "updated_at": "2026-06-01T12:03:01Z"
-    },
-    {
-      "upstream": "anthropics/claude-code#59760",
-      "url": "https://github.com/anthropics/claude-code/issues/59760",
-      "title": "[Bug] Anthropic API Error: 500 Internal Server Error",
-      "impact": "not_applicable",
-      "categories": [
-        "ide",
-        "terminal"
-      ],
-      "tokenkey_status": "not_applicable",
-      "rationale": "Client-side claude-code concern (ide, terminal); not a gateway/relay relevance signal.",
-      "updated_at": "2026-06-01T12:02:42Z"
-    },
-    {
-      "upstream": "anthropics/claude-code#59761",
-      "url": "https://github.com/anthropics/claude-code/issues/59761",
-      "title": "[Bug] Anthropic API Error: 500 Internal Server Error",
-      "impact": "not_applicable",
-      "categories": [
-        "terminal"
-      ],
-      "tokenkey_status": "not_applicable",
-      "rationale": "Client-side claude-code concern (terminal); not a gateway/relay relevance signal.",
-      "updated_at": "2026-06-01T12:02:43Z"
-    },
-    {
-      "upstream": "anthropics/claude-code#59762",
-      "url": "https://github.com/anthropics/claude-code/issues/59762",
-      "title": "[Bug] Anthropic API Error: 500 Internal Server Error",
-      "impact": "not_applicable",
-      "categories": [
-        "terminal"
-      ],
-      "tokenkey_status": "not_applicable",
-      "rationale": "Client-side claude-code concern (terminal); not a gateway/relay relevance signal.",
-      "updated_at": "2026-06-01T12:02:44Z"
-    },
-    {
-      "upstream": "anthropics/claude-code#59763",
-      "url": "https://github.com/anthropics/claude-code/issues/59763",
-      "title": "[Bug] Anthropic API Error: 500 Internal Server Error",
-      "impact": "not_applicable",
-      "categories": [
-        "terminal"
-      ],
-      "tokenkey_status": "not_applicable",
-      "rationale": "Client-side claude-code concern (terminal); not a gateway/relay relevance signal.",
-      "updated_at": "2026-06-01T12:02:45Z"
-    },
-    {
-      "upstream": "anthropics/claude-code#59764",
-      "url": "https://github.com/anthropics/claude-code/issues/59764",
-      "title": "[Bug] Anthropic API Error: Internal Server Error (500)",
-      "impact": "not_applicable",
-      "categories": [
-        "ide",
-        "terminal"
-      ],
-      "tokenkey_status": "not_applicable",
-      "rationale": "Client-side claude-code concern (ide, terminal); not a gateway/relay relevance signal.",
-      "updated_at": "2026-06-01T12:02:46Z"
-    },
-    {
-      "upstream": "anthropics/claude-code#59765",
-      "url": "https://github.com/anthropics/claude-code/issues/59765",
-      "title": "[Bug] Anthropic API Error: 500 Internal Server Error",
-      "impact": "not_applicable",
-      "categories": [
-        "terminal"
-      ],
-      "tokenkey_status": "not_applicable",
-      "rationale": "Client-side claude-code concern (terminal); not a gateway/relay relevance signal.",
-      "updated_at": "2026-06-01T12:02:47Z"
-    },
-    {
-      "upstream": "anthropics/claude-code#59766",
-      "url": "https://github.com/anthropics/claude-code/issues/59766",
-      "title": "[Bug] Anthropic API Error: 500 Internal Server Error",
-      "impact": "not_applicable",
-      "categories": [
-        "ide",
-        "terminal"
-      ],
-      "tokenkey_status": "not_applicable",
-      "rationale": "Client-side claude-code concern (ide, terminal); not a gateway/relay relevance signal.",
-      "updated_at": "2026-06-01T12:02:58Z"
-    },
-    {
-      "upstream": "anthropics/claude-code#59767",
-      "url": "https://github.com/anthropics/claude-code/issues/59767",
-      "title": "[Bug] Anthropic API Error: 500 Internal Server Error",
-      "impact": "not_applicable",
-      "categories": [
-        "terminal",
-        "platform"
-      ],
-      "tokenkey_status": "not_applicable",
-      "rationale": "Client-side claude-code concern (terminal, platform); not a gateway/relay relevance signal.",
-      "updated_at": "2026-06-01T12:02:57Z"
-    },
-    {
-      "upstream": "anthropics/claude-code#59768",
-      "url": "https://github.com/anthropics/claude-code/issues/59768",
-      "title": "[Bug] Anthropic API Error: Internal server error (500)",
-      "impact": "not_applicable",
-      "categories": [
-        "ide",
-        "terminal"
-      ],
-      "tokenkey_status": "not_applicable",
-      "rationale": "Client-side claude-code concern (ide, terminal); not a gateway/relay relevance signal.",
-      "updated_at": "2026-06-01T12:02:56Z"
-    },
-    {
-      "upstream": "anthropics/claude-code#59769",
-      "url": "https://github.com/anthropics/claude-code/issues/59769",
-      "title": "[Bug] Internal Server Error: HTTP 500 Response from Anthropic API",
-      "impact": "not_applicable",
-      "categories": [
-        "terminal",
-        "mcp",
-        "plugin",
-        "install"
-      ],
-      "tokenkey_status": "not_applicable",
-      "rationale": "Client-side claude-code concern (terminal, mcp, plugin, install); not a gateway/relay relevance signal.",
-      "updated_at": "2026-06-01T12:02:49Z"
-    },
-    {
-      "upstream": "anthropics/claude-code#59770",
-      "url": "https://github.com/anthropics/claude-code/issues/59770",
-      "title": "[Bug] Anthropic API Error: 500 Internal Server Error across all sessions",
-      "impact": "not_applicable",
-      "categories": [
-        "terminal"
-      ],
-      "tokenkey_status": "not_applicable",
-      "rationale": "Client-side claude-code concern (terminal); not a gateway/relay relevance signal.",
-      "updated_at": "2026-06-01T12:02:54Z"
-    },
-    {
-      "upstream": "anthropics/claude-code#59771",
-      "url": "https://github.com/anthropics/claude-code/issues/59771",
-      "title": "[Bug] Anthropic API Error: HTTP 500 Internal Server Error",
-      "impact": "not_applicable",
-      "categories": [
-        "terminal"
-      ],
-      "tokenkey_status": "not_applicable",
-      "rationale": "Client-side claude-code concern (terminal); not a gateway/relay relevance signal.",
-      "updated_at": "2026-06-01T12:02:51Z"
-    },
-    {
-      "upstream": "anthropics/claude-code#59772",
-      "url": "https://github.com/anthropics/claude-code/issues/59772",
-      "title": "[Bug] Anthropic API Error: 500 Internal Server Error",
-      "impact": "not_applicable",
-      "categories": [
-        "terminal"
-      ],
-      "tokenkey_status": "not_applicable",
-      "rationale": "Client-side claude-code concern (terminal); not a gateway/relay relevance signal.",
-      "updated_at": "2026-06-01T12:02:52Z"
-    },
-    {
-      "upstream": "anthropics/claude-code#59774",
-      "url": "https://github.com/anthropics/claude-code/issues/59774",
-      "title": "[Bug] Anthropic API Error: 500 Internal Server Error",
-      "impact": "not_applicable",
-      "categories": [
-        "terminal"
-      ],
-      "tokenkey_status": "not_applicable",
-      "rationale": "Client-side claude-code concern (terminal); not a gateway/relay relevance signal.",
-      "updated_at": "2026-06-01T12:02:53Z"
-    },
-    {
-      "upstream": "anthropics/claude-code#59775",
-      "url": "https://github.com/anthropics/claude-code/issues/59775",
-      "title": "[Bug] Anthropic API Error: 500 Internal Server Error",
-      "impact": "not_applicable",
-      "categories": [
-        "terminal"
-      ],
-      "tokenkey_status": "not_applicable",
-      "rationale": "Client-side claude-code concern (terminal); not a gateway/relay relevance signal.",
-      "updated_at": "2026-06-01T12:02:55Z"
-    },
-    {
-      "upstream": "anthropics/claude-code#59776",
-      "url": "https://github.com/anthropics/claude-code/issues/59776",
-      "title": "[Bug] Anthropic API Error: 500 Internal Server Error",
-      "impact": "not_applicable",
-      "categories": [
-        "terminal",
-        "mcp"
-      ],
-      "tokenkey_status": "not_applicable",
-      "rationale": "Client-side claude-code concern (terminal, mcp); not a gateway/relay relevance signal.",
-      "updated_at": "2026-06-01T12:02:58Z"
-    },
-    {
-      "upstream": "anthropics/claude-code#59778",
-      "url": "https://github.com/anthropics/claude-code/issues/59778",
-      "title": "[Bug] Anthropic API Error: 500 Internal Server Error",
-      "impact": "not_applicable",
-      "categories": [
-        "terminal"
-      ],
-      "tokenkey_status": "not_applicable",
-      "rationale": "Client-side claude-code concern (terminal); not a gateway/relay relevance signal.",
-      "updated_at": "2026-06-01T12:02:59Z"
-    },
-    {
-      "upstream": "anthropics/claude-code#59779",
-      "url": "https://github.com/anthropics/claude-code/issues/59779",
-      "title": "[Bug] Anthropic API Error: 500 Internal Server Error",
-      "impact": "not_applicable",
-      "categories": [
-        "terminal"
-      ],
-      "tokenkey_status": "not_applicable",
-      "rationale": "Client-side claude-code concern (terminal); not a gateway/relay relevance signal.",
-      "updated_at": "2026-06-01T12:03:00Z"
-    },
-    {
-      "upstream": "anthropics/claude-code#59781",
-      "url": "https://github.com/anthropics/claude-code/issues/59781",
-      "title": "[Bug] Anthropic API Error: 500 Internal Server Error",
-      "impact": "not_applicable",
-      "categories": [
-        "terminal"
-      ],
-      "tokenkey_status": "not_applicable",
-      "rationale": "Client-side claude-code concern (terminal); not a gateway/relay relevance signal.",
-      "updated_at": "2026-06-01T12:03:23Z"
-    },
-    {
-      "upstream": "anthropics/claude-code#59787",
-      "url": "https://github.com/anthropics/claude-code/issues/59787",
-      "title": "Harness silently truncates Write content at literal `<` character + drops bare `<parameter>` tags (XML-parser overreach on content payloads)",
-      "impact": "not_applicable",
-      "categories": [
-        "terminal",
-        "mcp"
-      ],
-      "tokenkey_status": "not_applicable",
-      "rationale": "Client-side claude-code concern (terminal, mcp); not a gateway/relay relevance signal.",
-      "updated_at": "2026-06-01T12:03:10Z"
-    },
-    {
-      "upstream": "anthropics/claude-code#59794",
-      "url": "https://github.com/anthropics/claude-code/issues/59794",
-      "title": "[BUG] Claude workspace VM fails silently after service crash — app never attempts to restart the Windows service",
-      "impact": "not_applicable",
-      "categories": [
-        "terminal",
-        "platform"
-      ],
-      "tokenkey_status": "not_applicable",
-      "rationale": "Client-side claude-code concern (terminal, platform); not a gateway/relay relevance signal.",
-      "updated_at": "2026-06-01T12:03:04Z"
-    },
-    {
-      "upstream": "anthropics/claude-code#59795",
-      "url": "https://github.com/anthropics/claude-code/issues/59795",
-      "title": "[Bug] bash: .claude/hooks/skill-instructions-hook.sh: No such file or directory",
-      "impact": "not_applicable",
-      "categories": [
-        "terminal",
-        "slash_hook"
-      ],
-      "tokenkey_status": "not_applicable",
-      "rationale": "Client-side claude-code concern (terminal, slash_hook); not a gateway/relay relevance signal.",
-      "updated_at": "2026-06-01T12:03:05Z"
-    },
-    {
-      "upstream": "anthropics/claude-code#59797",
-      "url": "https://github.com/anthropics/claude-code/issues/59797",
-      "title": "Single Click to copy last question and answer.",
-      "impact": "not_applicable",
-      "categories": [
-        "terminal"
-      ],
-      "tokenkey_status": "not_applicable",
-      "rationale": "Client-side claude-code concern (terminal); not a gateway/relay relevance signal.",
-      "updated_at": "2026-06-01T12:03:07Z"
-    },
-    {
-      "upstream": "anthropics/claude-code#59801",
-      "url": "https://github.com/anthropics/claude-code/issues/59801",
-      "title": "[BUG] fakechat MCP server silently drops all but the first file when multiple attachments are passed to reply tool",
-      "impact": "not_applicable",
-      "categories": [
-        "terminal",
-        "mcp",
-        "platform"
-      ],
-      "tokenkey_status": "not_applicable",
-      "rationale": "Client-side claude-code concern (terminal, mcp, platform); not a gateway/relay relevance signal.",
-      "updated_at": "2026-06-01T12:03:06Z"
-    },
-    {
-      "upstream": "anthropics/claude-code#59802",
-      "url": "https://github.com/anthropics/claude-code/issues/59802",
-      "title": "[BUG] Claude Desktop autostart entry crashes Windows 11 Settings > Apps > Startup (SettingsHandlers_Startup.dll 0xc0000005)",
+      "upstream": "anthropics/claude-code#59750",
+      "url": "https://github.com/anthropics/claude-code/issues/59750",
+      "title": "[BUG] claude agents TUI fully unresponsive on Windows Terminal — broken rendering + dead input loop (2.1.143)",
       "impact": "not_applicable",
       "categories": [
         "terminal",
@@ -10212,20 +11146,33 @@
       ],
       "tokenkey_status": "not_applicable",
       "rationale": "Client-side claude-code concern (terminal, slash_hook, install, platform); not a gateway/relay relevance signal.",
-      "updated_at": "2026-06-01T12:03:09Z"
+      "updated_at": "2026-06-03T17:25:19Z"
     },
     {
-      "upstream": "anthropics/claude-code#59815",
-      "url": "https://github.com/anthropics/claude-code/issues/59815",
-      "title": "[BUG] Claude-code app window doesn't scroll to end of respons",
+      "upstream": "anthropics/claude-code#59818",
+      "url": "https://github.com/anthropics/claude-code/issues/59818",
+      "title": "[Feature Request] Add /fork command to create parallel session branches from existing context",
+      "impact": "not_applicable",
+      "categories": [
+        "ide",
+        "terminal"
+      ],
+      "tokenkey_status": "not_applicable",
+      "rationale": "Client-side claude-code concern (ide, terminal); not a gateway/relay relevance signal.",
+      "updated_at": "2026-06-04T11:06:49Z"
+    },
+    {
+      "upstream": "anthropics/claude-code#59822",
+      "url": "https://github.com/anthropics/claude-code/issues/59822",
+      "title": "[BUG] UserPromptSubmit Hook does not Display Reason in Claude Code Desktop",
       "impact": "not_applicable",
       "categories": [
         "terminal",
-        "platform"
+        "slash_hook"
       ],
       "tokenkey_status": "not_applicable",
-      "rationale": "Client-side claude-code concern (terminal, platform); not a gateway/relay relevance signal.",
-      "updated_at": "2026-06-01T12:03:15Z"
+      "rationale": "Client-side claude-code concern (terminal, slash_hook); not a gateway/relay relevance signal.",
+      "updated_at": "2026-06-04T11:07:50Z"
     },
     {
       "upstream": "anthropics/claude-code#59826",
@@ -10240,84 +11187,18 @@
       "updated_at": "2026-06-01T22:45:15Z"
     },
     {
-      "upstream": "anthropics/claude-code#59832",
-      "url": "https://github.com/anthropics/claude-code/issues/59832",
-      "title": "[Bug] Anthropic API Error: 500 Internal Server Error",
-      "impact": "not_applicable",
-      "categories": [
-        "ide",
-        "terminal"
-      ],
-      "tokenkey_status": "not_applicable",
-      "rationale": "Client-side claude-code concern (ide, terminal); not a gateway/relay relevance signal.",
-      "updated_at": "2026-06-01T12:03:19Z"
-    },
-    {
-      "upstream": "anthropics/claude-code#59834",
-      "url": "https://github.com/anthropics/claude-code/issues/59834",
-      "title": "Feature request: Unified session history sync across VS Code extension, desktop app, and CLI",
-      "impact": "not_applicable",
-      "categories": [
-        "ide",
-        "platform"
-      ],
-      "tokenkey_status": "not_applicable",
-      "rationale": "Client-side claude-code concern (ide, platform); not a gateway/relay relevance signal.",
-      "updated_at": "2026-06-01T12:03:20Z"
-    },
-    {
-      "upstream": "anthropics/claude-code#59835",
-      "url": "https://github.com/anthropics/claude-code/issues/59835",
-      "title": "MCP stdio servers using rmcp >= 0.2 show 'tools fetch failed' — client not sending initialized notification",
-      "impact": "not_applicable",
-      "categories": [
-        "mcp",
-        "install"
-      ],
-      "tokenkey_status": "not_applicable",
-      "rationale": "Client-side claude-code concern (mcp, install); not a gateway/relay relevance signal.",
-      "updated_at": "2026-06-01T12:03:24Z"
-    },
-    {
-      "upstream": "anthropics/claude-code#59837",
-      "url": "https://github.com/anthropics/claude-code/issues/59837",
-      "title": "[BUG] Cowork create_scheduled_task hangs silently 180s on Windows - regression in v1.7196.0",
+      "upstream": "anthropics/claude-code#59833",
+      "url": "https://github.com/anthropics/claude-code/issues/59833",
+      "title": "[BUG] PowerShell tool fails Exit 1, empty stdout/stderr on Windows 10 DE-locale (v2.1.142, all environmental causes ruled out)",
       "impact": "not_applicable",
       "categories": [
         "terminal",
-        "mcp",
+        "install",
         "platform"
       ],
       "tokenkey_status": "not_applicable",
-      "rationale": "Client-side claude-code concern (terminal, mcp, platform); not a gateway/relay relevance signal.",
-      "updated_at": "2026-06-01T12:03:37Z"
-    },
-    {
-      "upstream": "anthropics/claude-code#59838",
-      "url": "https://github.com/anthropics/claude-code/issues/59838",
-      "title": "Agent Teams: allow per-teammate cwd and additional working directories (subsets of the lead's access) at spawn time",
-      "impact": "not_applicable",
-      "categories": [
-        "mcp",
-        "plugin",
-        "slash_hook"
-      ],
-      "tokenkey_status": "not_applicable",
-      "rationale": "Client-side claude-code concern (mcp, plugin, slash_hook); not a gateway/relay relevance signal.",
-      "updated_at": "2026-06-01T12:03:29Z"
-    },
-    {
-      "upstream": "anthropics/claude-code#59842",
-      "url": "https://github.com/anthropics/claude-code/issues/59842",
-      "title": "Compact display mode for tool calls (collapse Bash/Write to one-line summaries)",
-      "impact": "not_applicable",
-      "categories": [
-        "terminal",
-        "slash_hook"
-      ],
-      "tokenkey_status": "not_applicable",
-      "rationale": "Client-side claude-code concern (terminal, slash_hook); not a gateway/relay relevance signal.",
-      "updated_at": "2026-06-01T12:03:35Z"
+      "rationale": "Client-side claude-code concern (terminal, install, platform); not a gateway/relay relevance signal.",
+      "updated_at": "2026-06-03T22:45:18Z"
     },
     {
       "upstream": "anthropics/claude-code#59846",
@@ -10344,32 +11225,6 @@
       "tokenkey_status": "not_applicable",
       "rationale": "Client-side claude-code concern (terminal, platform); not a gateway/relay relevance signal.",
       "updated_at": "2026-06-02T11:32:38Z"
-    },
-    {
-      "upstream": "anthropics/claude-code#59852",
-      "url": "https://github.com/anthropics/claude-code/issues/59852",
-      "title": "[Bug] Desktop hijacks mouse XButton1/XButton2 with no opt-out — accidentally switches active chat during normal use",
-      "impact": "not_applicable",
-      "categories": [
-        "terminal",
-        "slash_hook",
-        "platform"
-      ],
-      "tokenkey_status": "not_applicable",
-      "rationale": "Client-side claude-code concern (terminal, slash_hook, platform); not a gateway/relay relevance signal.",
-      "updated_at": "2026-06-01T12:03:36Z"
-    },
-    {
-      "upstream": "anthropics/claude-code#59853",
-      "url": "https://github.com/anthropics/claude-code/issues/59853",
-      "title": "VS Code: model picker collapsed row shows stale model name (Sonnet 4.6) when Default (Opus 4.7) is selected",
-      "impact": "not_applicable",
-      "categories": [
-        "ide"
-      ],
-      "tokenkey_status": "not_applicable",
-      "rationale": "Client-side claude-code concern (ide); not a gateway/relay relevance signal.",
-      "updated_at": "2026-06-01T12:03:40Z"
     },
     {
       "upstream": "anthropics/claude-code#59855",
@@ -10419,6 +11274,19 @@
       "tokenkey_status": "not_applicable",
       "rationale": "Client-side claude-code concern (ide, terminal); not a gateway/relay relevance signal.",
       "updated_at": "2026-06-01T22:45:16Z"
+    },
+    {
+      "upstream": "anthropics/claude-code#59870",
+      "url": "https://github.com/anthropics/claude-code/issues/59870",
+      "title": "settings.json: top-level `hooks` key dropped when granting a permission",
+      "impact": "not_applicable",
+      "categories": [
+        "slash_hook",
+        "install"
+      ],
+      "tokenkey_status": "not_applicable",
+      "rationale": "Client-side claude-code concern (slash_hook, install); not a gateway/relay relevance signal.",
+      "updated_at": "2026-06-03T22:45:11Z"
     },
     {
       "upstream": "anthropics/claude-code#59874",
@@ -10482,6 +11350,20 @@
       "tokenkey_status": "not_applicable",
       "rationale": "Client-side claude-code concern (terminal); not a gateway/relay relevance signal.",
       "updated_at": "2026-06-02T11:32:01Z"
+    },
+    {
+      "upstream": "anthropics/claude-code#59883",
+      "url": "https://github.com/anthropics/claude-code/issues/59883",
+      "title": "/desktop command fails on Windows Store (MSIX) installation",
+      "impact": "not_applicable",
+      "categories": [
+        "slash_hook",
+        "install",
+        "platform"
+      ],
+      "tokenkey_status": "not_applicable",
+      "rationale": "Client-side claude-code concern (slash_hook, install, platform); not a gateway/relay relevance signal.",
+      "updated_at": "2026-06-04T01:14:51Z"
     },
     {
       "upstream": "anthropics/claude-code#59890",
@@ -10663,6 +11545,19 @@
       "updated_at": "2026-06-01T22:45:40Z"
     },
     {
+      "upstream": "anthropics/claude-code#59952",
+      "url": "https://github.com/anthropics/claude-code/issues/59952",
+      "title": "[BUG] Bug where Japanese CJK characters are misaligned at the line break position",
+      "impact": "not_applicable",
+      "categories": [
+        "ide",
+        "terminal"
+      ],
+      "tokenkey_status": "not_applicable",
+      "rationale": "Client-side claude-code concern (ide, terminal); not a gateway/relay relevance signal.",
+      "updated_at": "2026-06-03T22:45:56Z"
+    },
+    {
       "upstream": "anthropics/claude-code#59957",
       "url": "https://github.com/anthropics/claude-code/issues/59957",
       "title": "[BUG] CoWork Deleted All Content from a Cowork Workspace",
@@ -10827,6 +11722,33 @@
       "tokenkey_status": "not_applicable",
       "rationale": "Client-side claude-code concern (ide, terminal, platform); not a gateway/relay relevance signal.",
       "updated_at": "2026-06-01T22:46:03Z"
+    },
+    {
+      "upstream": "anthropics/claude-code#60012",
+      "url": "https://github.com/anthropics/claude-code/issues/60012",
+      "title": "[BUG] On Windows with English as the primary system language, spell check in Claude Code only checks the primary language (English).",
+      "impact": "not_applicable",
+      "categories": [
+        "terminal",
+        "install",
+        "platform"
+      ],
+      "tokenkey_status": "not_applicable",
+      "rationale": "Client-side claude-code concern (terminal, install, platform); not a gateway/relay relevance signal.",
+      "updated_at": "2026-06-03T10:23:58Z"
+    },
+    {
+      "upstream": "anthropics/claude-code#60015",
+      "url": "https://github.com/anthropics/claude-code/issues/60015",
+      "title": "[BUG] /remote-control not available on Claude Pro plan - \"not yet enabled for your account\"",
+      "impact": "not_applicable",
+      "categories": [
+        "terminal",
+        "slash_hook"
+      ],
+      "tokenkey_status": "not_applicable",
+      "rationale": "Client-side claude-code concern (terminal, slash_hook); not a gateway/relay relevance signal.",
+      "updated_at": "2026-06-04T11:07:17Z"
     },
     {
       "upstream": "anthropics/claude-code#60018",
@@ -11244,6 +12166,21 @@
       "updated_at": "2026-06-03T06:06:48Z"
     },
     {
+      "upstream": "anthropics/claude-code#60121",
+      "url": "https://github.com/anthropics/claude-code/issues/60121",
+      "title": "[BUG] Claude Desktop 1.7196.0 (macOS): \"Can't rewind to this message\" persists with no plugins installed — plugin-independent variant of #57206",
+      "impact": "not_applicable",
+      "categories": [
+        "terminal",
+        "plugin",
+        "slash_hook",
+        "install"
+      ],
+      "tokenkey_status": "not_applicable",
+      "rationale": "Client-side claude-code concern (terminal, plugin, slash_hook, install); not a gateway/relay relevance signal.",
+      "updated_at": "2026-06-03T22:45:34Z"
+    },
+    {
       "upstream": "anthropics/claude-code#60123",
       "url": "https://github.com/anthropics/claude-code/issues/60123",
       "title": "[BUG]",
@@ -11270,6 +12207,36 @@
       "updated_at": "2026-06-02T11:32:42Z"
     },
     {
+      "upstream": "anthropics/claude-code#60128",
+      "url": "https://github.com/anthropics/claude-code/issues/60128",
+      "title": "[BUG] Subagent dispatches can silently fail when context-budget forcing function is injected — no error surfaced to orchestrator",
+      "impact": "not_applicable",
+      "categories": [
+        "terminal",
+        "plugin",
+        "slash_hook"
+      ],
+      "tokenkey_status": "not_applicable",
+      "rationale": "Client-side claude-code concern (terminal, plugin, slash_hook); not a gateway/relay relevance signal.",
+      "updated_at": "2026-06-03T22:45:40Z"
+    },
+    {
+      "upstream": "anthropics/claude-code#60132",
+      "url": "https://github.com/anthropics/claude-code/issues/60132",
+      "title": "Claude in Chrome extension lost connection to Claude Code after Chrome updated to v148",
+      "impact": "not_applicable",
+      "categories": [
+        "ide",
+        "terminal",
+        "mcp",
+        "install",
+        "platform"
+      ],
+      "tokenkey_status": "not_applicable",
+      "rationale": "Client-side claude-code concern (ide, terminal, mcp, install, platform); not a gateway/relay relevance signal.",
+      "updated_at": "2026-06-03T22:45:29Z"
+    },
+    {
       "upstream": "anthropics/claude-code#60136",
       "url": "https://github.com/anthropics/claude-code/issues/60136",
       "title": "[BUG] Claude Desktop silently disappears after UAC prompt on Windows 11",
@@ -11281,7 +12248,7 @@
       ],
       "tokenkey_status": "not_applicable",
       "rationale": "Client-side claude-code concern (terminal, install, platform); not a gateway/relay relevance signal.",
-      "updated_at": "2026-06-02T11:32:52Z"
+      "updated_at": "2026-06-03T16:00:03Z"
     },
     {
       "upstream": "anthropics/claude-code#60143",
@@ -11549,6 +12516,59 @@
       "updated_at": "2026-06-02T22:44:08Z"
     },
     {
+      "upstream": "anthropics/claude-code#60227",
+      "url": "https://github.com/anthropics/claude-code/issues/60227",
+      "title": "[FEATURE] Optimize spacing between terminal task icons and content",
+      "impact": "not_applicable",
+      "categories": [
+        "terminal"
+      ],
+      "tokenkey_status": "not_applicable",
+      "rationale": "Client-side claude-code concern (terminal); not a gateway/relay relevance signal.",
+      "updated_at": "2026-06-03T11:39:26Z"
+    },
+    {
+      "upstream": "anthropics/claude-code#60229",
+      "url": "https://github.com/anthropics/claude-code/issues/60229",
+      "title": "[FEATURE] Turboquantum compressor for Snapdragon Adreno",
+      "impact": "not_applicable",
+      "categories": [
+        "mcp",
+        "install"
+      ],
+      "tokenkey_status": "not_applicable",
+      "rationale": "Client-side claude-code concern (mcp, install); not a gateway/relay relevance signal.",
+      "updated_at": "2026-06-03T11:39:27Z"
+    },
+    {
+      "upstream": "anthropics/claude-code#60233",
+      "url": "https://github.com/anthropics/claude-code/issues/60233",
+      "title": "[Bug] Sub-agent recursive delete via typo'd path destroys codebase on NTFS",
+      "impact": "not_applicable",
+      "categories": [
+        "terminal",
+        "install",
+        "platform"
+      ],
+      "tokenkey_status": "not_applicable",
+      "rationale": "Client-side claude-code concern (terminal, install, platform); not a gateway/relay relevance signal.",
+      "updated_at": "2026-06-03T22:45:22Z"
+    },
+    {
+      "upstream": "anthropics/claude-code#60239",
+      "url": "https://github.com/anthropics/claude-code/issues/60239",
+      "title": "Docs/bug: statusLine.command silently fails on Windows when path contains unquoted backslashes (Git Bash interaction)",
+      "impact": "not_applicable",
+      "categories": [
+        "terminal",
+        "slash_hook",
+        "platform"
+      ],
+      "tokenkey_status": "not_applicable",
+      "rationale": "Client-side claude-code concern (terminal, slash_hook, platform); not a gateway/relay relevance signal.",
+      "updated_at": "2026-06-03T11:39:30Z"
+    },
+    {
       "upstream": "anthropics/claude-code#60240",
       "url": "https://github.com/anthropics/claude-code/issues/60240",
       "title": "Settings migration silently removes user's explicit model pin without notification or backup",
@@ -11559,6 +12579,32 @@
       "tokenkey_status": "not_applicable",
       "rationale": "Client-side claude-code concern (slash_hook); not a gateway/relay relevance signal.",
       "updated_at": "2026-06-02T22:44:11Z"
+    },
+    {
+      "upstream": "anthropics/claude-code#60241",
+      "url": "https://github.com/anthropics/claude-code/issues/60241",
+      "title": "[FEATURE] Expose AgentView as a rebindable context in keybindings.json (attach / detach actions)",
+      "impact": "not_applicable",
+      "categories": [
+        "terminal",
+        "slash_hook"
+      ],
+      "tokenkey_status": "not_applicable",
+      "rationale": "Client-side claude-code concern (terminal, slash_hook); not a gateway/relay relevance signal.",
+      "updated_at": "2026-06-03T11:39:31Z"
+    },
+    {
+      "upstream": "anthropics/claude-code#60243",
+      "url": "https://github.com/anthropics/claude-code/issues/60243",
+      "title": "[BUG] [Cowork] present_files cards truncate path and omit filename, making multiple files visually indistinguishable",
+      "impact": "not_applicable",
+      "categories": [
+        "terminal",
+        "platform"
+      ],
+      "tokenkey_status": "not_applicable",
+      "rationale": "Client-side claude-code concern (terminal, platform); not a gateway/relay relevance signal.",
+      "updated_at": "2026-06-03T11:39:30Z"
     },
     {
       "upstream": "anthropics/claude-code#60246",
@@ -11614,6 +12660,18 @@
       "tokenkey_status": "not_applicable",
       "rationale": "Client-side claude-code concern (terminal, install, platform); not a gateway/relay relevance signal.",
       "updated_at": "2026-06-02T22:44:13Z"
+    },
+    {
+      "upstream": "anthropics/claude-code#60264",
+      "url": "https://github.com/anthropics/claude-code/issues/60264",
+      "title": "[BUG] CLI output was not valid JSON. This may indicate an error during startup. Output: Invalid configuration in /etc/srt-settings/f64bc828-10de-4853-8c01-44a45d9c86b5.json:",
+      "impact": "not_applicable",
+      "categories": [
+        "terminal"
+      ],
+      "tokenkey_status": "not_applicable",
+      "rationale": "Client-side claude-code concern (terminal); not a gateway/relay relevance signal.",
+      "updated_at": "2026-06-04T11:07:03Z"
     },
     {
       "upstream": "anthropics/claude-code#60266",
@@ -11816,6 +12874,21 @@
       "updated_at": "2026-06-02T22:44:41Z"
     },
     {
+      "upstream": "anthropics/claude-code#60323",
+      "url": "https://github.com/anthropics/claude-code/issues/60323",
+      "title": "TaskCreate reminder fires despite explicit \"Do NOT use TaskCreate\" directive in CLAUDE.md",
+      "impact": "not_applicable",
+      "categories": [
+        "terminal",
+        "mcp",
+        "slash_hook",
+        "platform"
+      ],
+      "tokenkey_status": "not_applicable",
+      "rationale": "Client-side claude-code concern (terminal, mcp, slash_hook, platform); not a gateway/relay relevance signal.",
+      "updated_at": "2026-06-03T22:45:12Z"
+    },
+    {
       "upstream": "anthropics/claude-code#60324",
       "url": "https://github.com/anthropics/claude-code/issues/60324",
       "title": "[Feature Request] Add setting to disable automatic PR badge display in UI",
@@ -11826,6 +12899,18 @@
       "tokenkey_status": "not_applicable",
       "rationale": "Client-side claude-code concern (terminal); not a gateway/relay relevance signal.",
       "updated_at": "2026-06-02T22:44:50Z"
+    },
+    {
+      "upstream": "anthropics/claude-code#60325",
+      "url": "https://github.com/anthropics/claude-code/issues/60325",
+      "title": "find/grep shadow functions launch a nested agent instead of bfs/ugrep on 2.1.143 (ARGV0 dispatch broken, silent data corruption)",
+      "impact": "not_applicable",
+      "categories": [
+        "slash_hook"
+      ],
+      "tokenkey_status": "not_applicable",
+      "rationale": "Client-side claude-code concern (slash_hook); not a gateway/relay relevance signal.",
+      "updated_at": "2026-06-03T22:45:14Z"
     },
     {
       "upstream": "anthropics/claude-code#60332",
@@ -11939,6 +13024,20 @@
       "updated_at": "2026-06-02T22:44:55Z"
     },
     {
+      "upstream": "anthropics/claude-code#60360",
+      "url": "https://github.com/anthropics/claude-code/issues/60360",
+      "title": "Model occasionally emits or fabricates `Human:` turns when woken by Monitor task-notifications with no fresh user input",
+      "impact": "not_applicable",
+      "categories": [
+        "terminal",
+        "mcp",
+        "install"
+      ],
+      "tokenkey_status": "not_applicable",
+      "rationale": "Client-side claude-code concern (terminal, mcp, install); not a gateway/relay relevance signal.",
+      "updated_at": "2026-06-04T11:07:00Z"
+    },
+    {
       "upstream": "anthropics/claude-code#60362",
       "url": "https://github.com/anthropics/claude-code/issues/60362",
       "title": "[Bug] Firestore not found error during seed bundle import after web-setup",
@@ -11989,7 +13088,7 @@
       ],
       "tokenkey_status": "not_applicable",
       "rationale": "Client-side claude-code concern (ide, terminal, platform); not a gateway/relay relevance signal.",
-      "updated_at": "2026-06-01T06:33:09Z"
+      "updated_at": "2026-06-03T20:38:44Z"
     },
     {
       "upstream": "anthropics/claude-code#60369",
@@ -12005,28 +13104,1058 @@
       "updated_at": "2026-06-02T22:45:00Z"
     },
     {
-      "upstream": "anthropics/claude-code#60415",
-      "url": "https://github.com/anthropics/claude-code/issues/60415",
-      "title": "[DOCS] Agent view docs omit recovery guidance for an unresponsive background service",
+      "upstream": "anthropics/claude-code#60372",
+      "url": "https://github.com/anthropics/claude-code/issues/60372",
+      "title": "False-positive 'violative cyber content' block on innocuous fiction-naming prompt",
       "impact": "not_applicable",
       "categories": [
         "terminal"
       ],
       "tokenkey_status": "not_applicable",
       "rationale": "Client-side claude-code concern (terminal); not a gateway/relay relevance signal.",
-      "updated_at": "2026-06-01T01:30:08Z"
+      "updated_at": "2026-06-03T11:39:34Z"
     },
     {
-      "upstream": "anthropics/claude-code#60694",
-      "url": "https://github.com/anthropics/claude-code/issues/60694",
-      "title": "[DOCS] Agent view docs omit voice dictation support in the peek-panel reply input",
+      "upstream": "anthropics/claude-code#60374",
+      "url": "https://github.com/anthropics/claude-code/issues/60374",
+      "title": "[BUG] --dangerously-skip-permissions does not bypass project-level \"ask\" rules in .claude/settings.json",
+      "impact": "not_applicable",
+      "categories": [
+        "terminal",
+        "plugin",
+        "slash_hook",
+        "platform"
+      ],
+      "tokenkey_status": "not_applicable",
+      "rationale": "Client-side claude-code concern (terminal, plugin, slash_hook, platform); not a gateway/relay relevance signal.",
+      "updated_at": "2026-06-03T22:45:14Z"
+    },
+    {
+      "upstream": "anthropics/claude-code#60375",
+      "url": "https://github.com/anthropics/claude-code/issues/60375",
+      "title": "Plugin skills loaded twice: from marketplace clone and installed cache",
+      "impact": "not_applicable",
+      "categories": [
+        "plugin",
+        "install"
+      ],
+      "tokenkey_status": "not_applicable",
+      "rationale": "Client-side claude-code concern (plugin, install); not a gateway/relay relevance signal.",
+      "updated_at": "2026-06-03T11:39:54Z"
+    },
+    {
+      "upstream": "anthropics/claude-code#60377",
+      "url": "https://github.com/anthropics/claude-code/issues/60377",
+      "title": "Routine runs list rows don't appear clickable",
+      "impact": "not_applicable",
+      "categories": [
+        "terminal"
+      ],
+      "tokenkey_status": "not_applicable",
+      "rationale": "Client-side claude-code concern (terminal); not a gateway/relay relevance signal.",
+      "updated_at": "2026-06-04T11:06:43Z"
+    },
+    {
+      "upstream": "anthropics/claude-code#60381",
+      "url": "https://github.com/anthropics/claude-code/issues/60381",
+      "title": "[Bug] Claude repeatedly adds HTTP basic auth despite no requirement specification",
+      "impact": "not_applicable",
+      "categories": [
+        "terminal"
+      ],
+      "tokenkey_status": "not_applicable",
+      "rationale": "Client-side claude-code concern (terminal); not a gateway/relay relevance signal.",
+      "updated_at": "2026-06-04T11:06:42Z"
+    },
+    {
+      "upstream": "anthropics/claude-code#60382",
+      "url": "https://github.com/anthropics/claude-code/issues/60382",
+      "title": "[BUG] Slack tools return empty `Text:` for bot messages using legacy `attachments[]` field",
+      "impact": "not_applicable",
+      "categories": [
+        "terminal",
+        "mcp"
+      ],
+      "tokenkey_status": "not_applicable",
+      "rationale": "Client-side claude-code concern (terminal, mcp); not a gateway/relay relevance signal.",
+      "updated_at": "2026-06-04T11:06:45Z"
+    },
+    {
+      "upstream": "anthropics/claude-code#60390",
+      "url": "https://github.com/anthropics/claude-code/issues/60390",
+      "title": "`/resume` accumulates \"phantom sessions\" — sessionId allocated + speculative ai-title written before picker shown, never reaped on cancel",
       "impact": "not_applicable",
       "categories": [
         "slash_hook"
       ],
       "tokenkey_status": "not_applicable",
       "rationale": "Client-side claude-code concern (slash_hook); not a gateway/relay relevance signal.",
-      "updated_at": "2026-06-01T01:29:24Z"
+      "updated_at": "2026-06-04T11:06:45Z"
+    },
+    {
+      "upstream": "anthropics/claude-code#60393",
+      "url": "https://github.com/anthropics/claude-code/issues/60393",
+      "title": "[Feature Request] Add ANTHROPIC_CUSTOM_USER_AGENT environment variable for subagent tracking",
+      "impact": "not_applicable",
+      "categories": [
+        "terminal",
+        "plugin"
+      ],
+      "tokenkey_status": "not_applicable",
+      "rationale": "Client-side claude-code concern (terminal, plugin); not a gateway/relay relevance signal.",
+      "updated_at": "2026-06-04T11:06:47Z"
+    },
+    {
+      "upstream": "anthropics/claude-code#60398",
+      "url": "https://github.com/anthropics/claude-code/issues/60398",
+      "title": "[FEATURE] Configurable session name color indicators in the sidebar",
+      "impact": "not_applicable",
+      "categories": [
+        "terminal",
+        "slash_hook"
+      ],
+      "tokenkey_status": "not_applicable",
+      "rationale": "Client-side claude-code concern (terminal, slash_hook); not a gateway/relay relevance signal.",
+      "updated_at": "2026-06-04T11:06:51Z"
+    },
+    {
+      "upstream": "anthropics/claude-code#60400",
+      "url": "https://github.com/anthropics/claude-code/issues/60400",
+      "title": "[DOCS] Background subagent docs omit elapsed duration shown in completion notifications",
+      "impact": "not_applicable",
+      "categories": [
+        "plugin"
+      ],
+      "tokenkey_status": "not_applicable",
+      "rationale": "Client-side claude-code concern (plugin); not a gateway/relay relevance signal.",
+      "updated_at": "2026-06-04T11:06:52Z"
+    },
+    {
+      "upstream": "anthropics/claude-code#60402",
+      "url": "https://github.com/anthropics/claude-code/issues/60402",
+      "title": "[DOCS] `/plugin` discover flow docs omit the new last-updated metadata shown for plugins",
+      "impact": "not_applicable",
+      "categories": [
+        "plugin",
+        "install"
+      ],
+      "tokenkey_status": "not_applicable",
+      "rationale": "Client-side claude-code concern (plugin, install); not a gateway/relay relevance signal.",
+      "updated_at": "2026-06-04T11:06:53Z"
+    },
+    {
+      "upstream": "anthropics/claude-code#60404",
+      "url": "https://github.com/anthropics/claude-code/issues/60404",
+      "title": "[DOCS] Model configuration docs still say `/model` selections persist across restarts",
+      "impact": "not_applicable",
+      "categories": [
+        "slash_hook"
+      ],
+      "tokenkey_status": "not_applicable",
+      "rationale": "Client-side claude-code concern (slash_hook); not a gateway/relay relevance signal.",
+      "updated_at": "2026-06-04T11:06:54Z"
+    },
+    {
+      "upstream": "anthropics/claude-code#60405",
+      "url": "https://github.com/anthropics/claude-code/issues/60405",
+      "title": "[DOCS] Read tool docs omit text fallback for files with image extensions but non-image contents",
+      "impact": "not_applicable",
+      "categories": [
+        "ide"
+      ],
+      "tokenkey_status": "not_applicable",
+      "rationale": "Client-side claude-code concern (ide); not a gateway/relay relevance signal.",
+      "updated_at": "2026-06-03T22:45:06Z"
+    },
+    {
+      "upstream": "anthropics/claude-code#60408",
+      "url": "https://github.com/anthropics/claude-code/issues/60408",
+      "title": "[DOCS] Custom tools docs do not explain unsupported MCP image MIME fallback",
+      "impact": "not_applicable",
+      "categories": [
+        "terminal",
+        "mcp"
+      ],
+      "tokenkey_status": "not_applicable",
+      "rationale": "Client-side claude-code concern (terminal, mcp); not a gateway/relay relevance signal.",
+      "updated_at": "2026-06-03T22:45:08Z"
+    },
+    {
+      "upstream": "anthropics/claude-code#60413",
+      "url": "https://github.com/anthropics/claude-code/issues/60413",
+      "title": "[DOCS] Agent view docs omit background shell-command rows and completed-row behavior",
+      "impact": "not_applicable",
+      "categories": [
+        "terminal"
+      ],
+      "tokenkey_status": "not_applicable",
+      "rationale": "Client-side claude-code concern (terminal); not a gateway/relay relevance signal.",
+      "updated_at": "2026-06-03T22:45:08Z"
+    },
+    {
+      "upstream": "anthropics/claude-code#60414",
+      "url": "https://github.com/anthropics/claude-code/issues/60414",
+      "title": "[DOCS] Agent view docs omit that `/bg` and `←` keep directories added with `/add-dir`",
+      "impact": "not_applicable",
+      "categories": [
+        "terminal",
+        "mcp",
+        "plugin"
+      ],
+      "tokenkey_status": "not_applicable",
+      "rationale": "Client-side claude-code concern (terminal, mcp, plugin); not a gateway/relay relevance signal.",
+      "updated_at": "2026-06-03T22:45:09Z"
+    },
+    {
+      "upstream": "anthropics/claude-code#60417",
+      "url": "https://github.com/anthropics/claude-code/issues/60417",
+      "title": "[DOCS] Background-session docs omit `--bg --name` post-spawn confirmation output",
+      "impact": "not_applicable",
+      "categories": [
+        "terminal"
+      ],
+      "tokenkey_status": "not_applicable",
+      "rationale": "Client-side claude-code concern (terminal); not a gateway/relay relevance signal.",
+      "updated_at": "2026-06-03T22:45:09Z"
+    },
+    {
+      "upstream": "anthropics/claude-code#60419",
+      "url": "https://github.com/anthropics/claude-code/issues/60419",
+      "title": "[DOCS] `/plugin marketplace` docs omit `CLAUDE_CODE_PLUGIN_PREFER_HTTPS` behavior for GitHub `owner/repo`",
+      "impact": "not_applicable",
+      "categories": [
+        "plugin"
+      ],
+      "tokenkey_status": "not_applicable",
+      "rationale": "Client-side claude-code concern (plugin); not a gateway/relay relevance signal.",
+      "updated_at": "2026-06-03T22:45:10Z"
+    },
+    {
+      "upstream": "anthropics/claude-code#60425",
+      "url": "https://github.com/anthropics/claude-code/issues/60425",
+      "title": "/diff: stage untracked files from inside the diff view",
+      "impact": "not_applicable",
+      "categories": [
+        "terminal"
+      ],
+      "tokenkey_status": "not_applicable",
+      "rationale": "Client-side claude-code concern (terminal); not a gateway/relay relevance signal.",
+      "updated_at": "2026-06-03T22:45:15Z"
+    },
+    {
+      "upstream": "anthropics/claude-code#60431",
+      "url": "https://github.com/anthropics/claude-code/issues/60431",
+      "title": "[BUG] Desktop App: Files panel loses open files when switching sessions",
+      "impact": "not_applicable",
+      "categories": [
+        "terminal"
+      ],
+      "tokenkey_status": "not_applicable",
+      "rationale": "Client-side claude-code concern (terminal); not a gateway/relay relevance signal.",
+      "updated_at": "2026-06-03T22:45:21Z"
+    },
+    {
+      "upstream": "anthropics/claude-code#60432",
+      "url": "https://github.com/anthropics/claude-code/issues/60432",
+      "title": "[FEATURE] Desktop App: Add live Markdown preview in Files panel",
+      "impact": "not_applicable",
+      "categories": [
+        "ide",
+        "terminal",
+        "platform"
+      ],
+      "tokenkey_status": "not_applicable",
+      "rationale": "Client-side claude-code concern (ide, terminal, platform); not a gateway/relay relevance signal.",
+      "updated_at": "2026-06-03T22:45:19Z"
+    },
+    {
+      "upstream": "anthropics/claude-code#60434",
+      "url": "https://github.com/anthropics/claude-code/issues/60434",
+      "title": "[BUG] Option 3 'tell Claude what to do differently' input is clobbered by incoming permission requests",
+      "impact": "not_applicable",
+      "categories": [
+        "terminal"
+      ],
+      "tokenkey_status": "not_applicable",
+      "rationale": "Client-side claude-code concern (terminal); not a gateway/relay relevance signal.",
+      "updated_at": "2026-06-03T22:45:20Z"
+    },
+    {
+      "upstream": "anthropics/claude-code#60441",
+      "url": "https://github.com/anthropics/claude-code/issues/60441",
+      "title": "[BUG] Persistent ECONNRESET error on Mac for 2 weeks - UNABLE TO USE CLAUDE FOR ANYTHING FOR ANY SESSION",
+      "impact": "not_applicable",
+      "categories": [
+        "terminal"
+      ],
+      "tokenkey_status": "not_applicable",
+      "rationale": "Client-side claude-code concern (terminal); not a gateway/relay relevance signal.",
+      "updated_at": "2026-06-03T22:45:22Z"
+    },
+    {
+      "upstream": "anthropics/claude-code#60447",
+      "url": "https://github.com/anthropics/claude-code/issues/60447",
+      "title": "Plan view in Claude Desktop (Code mode) shows images from a different session",
+      "impact": "not_applicable",
+      "categories": [
+        "terminal"
+      ],
+      "tokenkey_status": "not_applicable",
+      "rationale": "Client-side claude-code concern (terminal); not a gateway/relay relevance signal.",
+      "updated_at": "2026-06-03T22:45:24Z"
+    },
+    {
+      "upstream": "anthropics/claude-code#60450",
+      "url": "https://github.com/anthropics/claude-code/issues/60450",
+      "title": "Folder chip opens OS folder picker on first click instead of Recent dropdown (Windows desktop app)",
+      "impact": "not_applicable",
+      "categories": [
+        "terminal",
+        "platform"
+      ],
+      "tokenkey_status": "not_applicable",
+      "rationale": "Client-side claude-code concern (terminal, platform); not a gateway/relay relevance signal.",
+      "updated_at": "2026-06-03T22:45:26Z"
+    },
+    {
+      "upstream": "anthropics/claude-code#60452",
+      "url": "https://github.com/anthropics/claude-code/issues/60452",
+      "title": "[BUG] Cursor: markdown tables render at a different width than surrounding text in the same response (longstanding)",
+      "impact": "not_applicable",
+      "categories": [
+        "ide",
+        "terminal"
+      ],
+      "tokenkey_status": "not_applicable",
+      "rationale": "Client-side claude-code concern (ide, terminal); not a gateway/relay relevance signal.",
+      "updated_at": "2026-06-03T22:45:28Z"
+    },
+    {
+      "upstream": "anthropics/claude-code#60455",
+      "url": "https://github.com/anthropics/claude-code/issues/60455",
+      "title": "[Windows] Background session supervisor exits after 5s idle instead of documented ~1 hour",
+      "impact": "not_applicable",
+      "categories": [
+        "slash_hook",
+        "install",
+        "platform"
+      ],
+      "tokenkey_status": "not_applicable",
+      "rationale": "Client-side claude-code concern (slash_hook, install, platform); not a gateway/relay relevance signal.",
+      "updated_at": "2026-06-03T22:45:33Z"
+    },
+    {
+      "upstream": "anthropics/claude-code#60457",
+      "url": "https://github.com/anthropics/claude-code/issues/60457",
+      "title": "[Bug] Events not displaying on calendar and map views",
+      "impact": "not_applicable",
+      "categories": [
+        "terminal"
+      ],
+      "tokenkey_status": "not_applicable",
+      "rationale": "Client-side claude-code concern (terminal); not a gateway/relay relevance signal.",
+      "updated_at": "2026-06-03T22:45:29Z"
+    },
+    {
+      "upstream": "anthropics/claude-code#60463",
+      "url": "https://github.com/anthropics/claude-code/issues/60463",
+      "title": "[Bug] Auto mode circuit-breaker permanently disabled after declining opt-in dialog",
+      "impact": "not_applicable",
+      "categories": [
+        "terminal",
+        "slash_hook"
+      ],
+      "tokenkey_status": "not_applicable",
+      "rationale": "Client-side claude-code concern (terminal, slash_hook); not a gateway/relay relevance signal.",
+      "updated_at": "2026-06-03T22:45:32Z"
+    },
+    {
+      "upstream": "anthropics/claude-code#60464",
+      "url": "https://github.com/anthropics/claude-code/issues/60464",
+      "title": "[Bug] No scrollback buffer in terminal output",
+      "impact": "not_applicable",
+      "categories": [
+        "terminal"
+      ],
+      "tokenkey_status": "not_applicable",
+      "rationale": "Client-side claude-code concern (terminal); not a gateway/relay relevance signal.",
+      "updated_at": "2026-06-03T22:45:32Z"
+    },
+    {
+      "upstream": "anthropics/claude-code#60469",
+      "url": "https://github.com/anthropics/claude-code/issues/60469",
+      "title": "[BUG] vscode extension session names are not persisted after restart",
+      "impact": "not_applicable",
+      "categories": [
+        "ide",
+        "terminal",
+        "platform"
+      ],
+      "tokenkey_status": "not_applicable",
+      "rationale": "Client-side claude-code concern (ide, terminal, platform); not a gateway/relay relevance signal.",
+      "updated_at": "2026-06-03T22:45:35Z"
+    },
+    {
+      "upstream": "anthropics/claude-code#60475",
+      "url": "https://github.com/anthropics/claude-code/issues/60475",
+      "title": "[Bug] Auto-compact triggers unintended agent behavior and unsafe git checkout during rollback",
+      "impact": "not_applicable",
+      "categories": [
+        "terminal"
+      ],
+      "tokenkey_status": "not_applicable",
+      "rationale": "Client-side claude-code concern (terminal); not a gateway/relay relevance signal.",
+      "updated_at": "2026-06-04T11:07:18Z"
+    },
+    {
+      "upstream": "anthropics/claude-code#60479",
+      "url": "https://github.com/anthropics/claude-code/issues/60479",
+      "title": "[Bug] Background agent continues running after CLI exit, /resume fails with attachment error",
+      "impact": "not_applicable",
+      "categories": [
+        "terminal"
+      ],
+      "tokenkey_status": "not_applicable",
+      "rationale": "Client-side claude-code concern (terminal); not a gateway/relay relevance signal.",
+      "updated_at": "2026-06-03T22:45:37Z"
+    },
+    {
+      "upstream": "anthropics/claude-code#60484",
+      "url": "https://github.com/anthropics/claude-code/issues/60484",
+      "title": "Let me scroll through an old session before committing to resume it",
+      "impact": "not_applicable",
+      "categories": [
+        "terminal"
+      ],
+      "tokenkey_status": "not_applicable",
+      "rationale": "Client-side claude-code concern (terminal); not a gateway/relay relevance signal.",
+      "updated_at": "2026-06-04T11:07:43Z"
+    },
+    {
+      "upstream": "anthropics/claude-code#60486",
+      "url": "https://github.com/anthropics/claude-code/issues/60486",
+      "title": "[BUG] statusline-setup agent generates jq-dependent script that fails on Windows",
+      "impact": "not_applicable",
+      "categories": [
+        "terminal",
+        "platform"
+      ],
+      "tokenkey_status": "not_applicable",
+      "rationale": "Client-side claude-code concern (terminal, platform); not a gateway/relay relevance signal.",
+      "updated_at": "2026-06-03T22:45:38Z"
+    },
+    {
+      "upstream": "anthropics/claude-code#60488",
+      "url": "https://github.com/anthropics/claude-code/issues/60488",
+      "title": "[BUG] Claude Code escapes systemd transient scope at startup, defeating user-imposed memory caps",
+      "impact": "not_applicable",
+      "categories": [
+        "terminal",
+        "mcp"
+      ],
+      "tokenkey_status": "not_applicable",
+      "rationale": "Client-side claude-code concern (terminal, mcp); not a gateway/relay relevance signal.",
+      "updated_at": "2026-06-03T22:45:58Z"
+    },
+    {
+      "upstream": "anthropics/claude-code#60489",
+      "url": "https://github.com/anthropics/claude-code/issues/60489",
+      "title": "[BUG] Core CLI tools (Bash/Read/Write/Edit) silently missing during backend degradation — May 18-19 2026",
+      "impact": "not_applicable",
+      "categories": [
+        "terminal"
+      ],
+      "tokenkey_status": "not_applicable",
+      "rationale": "Client-side claude-code concern (terminal); not a gateway/relay relevance signal.",
+      "updated_at": "2026-06-03T22:45:58Z"
+    },
+    {
+      "upstream": "anthropics/claude-code#60493",
+      "url": "https://github.com/anthropics/claude-code/issues/60493",
+      "title": "[BUG] GitHub repos not visible in Claude Code web repo picker despite app installed",
+      "impact": "not_applicable",
+      "categories": [
+        "terminal",
+        "platform"
+      ],
+      "tokenkey_status": "not_applicable",
+      "rationale": "Client-side claude-code concern (terminal, platform); not a gateway/relay relevance signal.",
+      "updated_at": "2026-06-03T22:31:56Z"
+    },
+    {
+      "upstream": "anthropics/claude-code#60495",
+      "url": "https://github.com/anthropics/claude-code/issues/60495",
+      "title": "[FEATURE]",
+      "impact": "not_applicable",
+      "categories": [
+        "terminal"
+      ],
+      "tokenkey_status": "not_applicable",
+      "rationale": "Client-side claude-code concern (terminal); not a gateway/relay relevance signal.",
+      "updated_at": "2026-06-03T22:45:38Z"
+    },
+    {
+      "upstream": "anthropics/claude-code#60496",
+      "url": "https://github.com/anthropics/claude-code/issues/60496",
+      "title": "[Feature Request] Standardize prompt option numbering to prevent muscle memory confusion",
+      "impact": "not_applicable",
+      "categories": [
+        "terminal"
+      ],
+      "tokenkey_status": "not_applicable",
+      "rationale": "Client-side claude-code concern (terminal); not a gateway/relay relevance signal.",
+      "updated_at": "2026-06-03T22:45:40Z"
+    },
+    {
+      "upstream": "anthropics/claude-code#60497",
+      "url": "https://github.com/anthropics/claude-code/issues/60497",
+      "title": "Background/agent isolation: \"worktree\" creates worktrees without firing the WorktreeCreate hook",
+      "impact": "not_applicable",
+      "categories": [
+        "terminal",
+        "slash_hook"
+      ],
+      "tokenkey_status": "not_applicable",
+      "rationale": "Client-side claude-code concern (terminal, slash_hook); not a gateway/relay relevance signal.",
+      "updated_at": "2026-06-03T22:45:42Z"
+    },
+    {
+      "upstream": "anthropics/claude-code#60499",
+      "url": "https://github.com/anthropics/claude-code/issues/60499",
+      "title": "[BUG] ide references are not working in agents mode",
+      "impact": "not_applicable",
+      "categories": [
+        "ide",
+        "terminal"
+      ],
+      "tokenkey_status": "not_applicable",
+      "rationale": "Client-side claude-code concern (ide, terminal); not a gateway/relay relevance signal.",
+      "updated_at": "2026-06-03T22:45:59Z"
+    },
+    {
+      "upstream": "anthropics/claude-code#60505",
+      "url": "https://github.com/anthropics/claude-code/issues/60505",
+      "title": "[BUG] Agent sends blank text responses, breaking conversation flow",
+      "impact": "not_applicable",
+      "categories": [
+        "ide",
+        "terminal",
+        "platform"
+      ],
+      "tokenkey_status": "not_applicable",
+      "rationale": "Client-side claude-code concern (ide, terminal, platform); not a gateway/relay relevance signal.",
+      "updated_at": "2026-06-03T22:45:45Z"
+    },
+    {
+      "upstream": "anthropics/claude-code#60508",
+      "url": "https://github.com/anthropics/claude-code/issues/60508",
+      "title": "awaySummary recap is one-way: assistant cannot see or access it",
+      "impact": "not_applicable",
+      "categories": [
+        "terminal"
+      ],
+      "tokenkey_status": "not_applicable",
+      "rationale": "Client-side claude-code concern (terminal); not a gateway/relay relevance signal.",
+      "updated_at": "2026-06-04T11:07:19Z"
+    },
+    {
+      "upstream": "anthropics/claude-code#60512",
+      "url": "https://github.com/anthropics/claude-code/issues/60512",
+      "title": "[BUG] Project-scope `enabledPlugins` is silently ignored when Claude Code is launched from a subdirectory",
+      "impact": "not_applicable",
+      "categories": [
+        "terminal",
+        "plugin",
+        "slash_hook",
+        "install"
+      ],
+      "tokenkey_status": "not_applicable",
+      "rationale": "Client-side claude-code concern (terminal, plugin, slash_hook, install); not a gateway/relay relevance signal.",
+      "updated_at": "2026-06-03T22:45:46Z"
+    },
+    {
+      "upstream": "anthropics/claude-code#60514",
+      "url": "https://github.com/anthropics/claude-code/issues/60514",
+      "title": "[FEATURE] Single-key model cycling keybinding (re-file of #38966)",
+      "impact": "not_applicable",
+      "categories": [
+        "terminal",
+        "slash_hook"
+      ],
+      "tokenkey_status": "not_applicable",
+      "rationale": "Client-side claude-code concern (terminal, slash_hook); not a gateway/relay relevance signal.",
+      "updated_at": "2026-06-04T11:07:02Z"
+    },
+    {
+      "upstream": "anthropics/claude-code#60515",
+      "url": "https://github.com/anthropics/claude-code/issues/60515",
+      "title": "[BUG] allowed-tools in skill SKILL.md only auto-approves the first Bash call per session, subsequent calls prompt for permission",
+      "impact": "not_applicable",
+      "categories": [
+        "terminal",
+        "plugin",
+        "install"
+      ],
+      "tokenkey_status": "not_applicable",
+      "rationale": "Client-side claude-code concern (terminal, plugin, install); not a gateway/relay relevance signal.",
+      "updated_at": "2026-06-04T08:28:22Z"
+    },
+    {
+      "upstream": "anthropics/claude-code#60516",
+      "url": "https://github.com/anthropics/claude-code/issues/60516",
+      "title": "[Feature Request] Add PreVoiceInput hook or voice.enabled-when condition for conditional voice-mode gating",
+      "impact": "not_applicable",
+      "categories": [
+        "terminal",
+        "slash_hook"
+      ],
+      "tokenkey_status": "not_applicable",
+      "rationale": "Client-side claude-code concern (terminal, slash_hook); not a gateway/relay relevance signal.",
+      "updated_at": "2026-06-03T22:45:47Z"
+    },
+    {
+      "upstream": "anthropics/claude-code#60519",
+      "url": "https://github.com/anthropics/claude-code/issues/60519",
+      "title": "[BUG] Memory files bypass acceptEdits diff confirmation — no user review before write",
+      "impact": "not_applicable",
+      "categories": [
+        "terminal"
+      ],
+      "tokenkey_status": "not_applicable",
+      "rationale": "Client-side claude-code concern (terminal); not a gateway/relay relevance signal.",
+      "updated_at": "2026-06-03T22:45:49Z"
+    },
+    {
+      "upstream": "anthropics/claude-code#60537",
+      "url": "https://github.com/anthropics/claude-code/issues/60537",
+      "title": "Two parallel sessions with distinct UUIDs and labels silently routed input to a single PID",
+      "impact": "not_applicable",
+      "categories": [
+        "ide",
+        "platform"
+      ],
+      "tokenkey_status": "not_applicable",
+      "rationale": "Client-side claude-code concern (ide, platform); not a gateway/relay relevance signal.",
+      "updated_at": "2026-06-04T11:07:03Z"
+    },
+    {
+      "upstream": "anthropics/claude-code#60541",
+      "url": "https://github.com/anthropics/claude-code/issues/60541",
+      "title": "[BUG][Windows] Desktop app ignores defaultMode: bypassPermissions in settings.json — mode picker missing \"Bypass permissions\" option",
+      "impact": "not_applicable",
+      "categories": [
+        "terminal",
+        "slash_hook",
+        "platform"
+      ],
+      "tokenkey_status": "not_applicable",
+      "rationale": "Client-side claude-code concern (terminal, slash_hook, platform); not a gateway/relay relevance signal.",
+      "updated_at": "2026-06-03T22:46:00Z"
+    },
+    {
+      "upstream": "anthropics/claude-code#60549",
+      "url": "https://github.com/anthropics/claude-code/issues/60549",
+      "title": "[BUG] Cowork plugin browser does not honor `displayName` field (CLI works, UI parity gap)",
+      "impact": "not_applicable",
+      "categories": [
+        "terminal",
+        "plugin",
+        "install"
+      ],
+      "tokenkey_status": "not_applicable",
+      "rationale": "Client-side claude-code concern (terminal, plugin, install); not a gateway/relay relevance signal.",
+      "updated_at": "2026-06-03T22:46:03Z"
+    },
+    {
+      "upstream": "anthropics/claude-code#60555",
+      "url": "https://github.com/anthropics/claude-code/issues/60555",
+      "title": "[FEATURE] ToolBuild hooks: Pre & Post",
+      "impact": "not_applicable",
+      "categories": [
+        "mcp"
+      ],
+      "tokenkey_status": "not_applicable",
+      "rationale": "Client-side claude-code concern (mcp); not a gateway/relay relevance signal.",
+      "updated_at": "2026-06-04T11:06:57Z"
+    },
+    {
+      "upstream": "anthropics/claude-code#60569",
+      "url": "https://github.com/anthropics/claude-code/issues/60569",
+      "title": "[FEATURE] Add an `/auth` command to manage the active authentication provider",
+      "impact": "not_applicable",
+      "categories": [
+        "terminal",
+        "slash_hook"
+      ],
+      "tokenkey_status": "not_applicable",
+      "rationale": "Client-side claude-code concern (terminal, slash_hook); not a gateway/relay relevance signal.",
+      "updated_at": "2026-06-04T11:06:56Z"
+    },
+    {
+      "upstream": "anthropics/claude-code#60578",
+      "url": "https://github.com/anthropics/claude-code/issues/60578",
+      "title": "[FEATURE] Toggleable columns in agent view: model, effort, and context usage",
+      "impact": "not_applicable",
+      "categories": [
+        "terminal",
+        "plugin",
+        "slash_hook"
+      ],
+      "tokenkey_status": "not_applicable",
+      "rationale": "Client-side claude-code concern (terminal, plugin, slash_hook); not a gateway/relay relevance signal.",
+      "updated_at": "2026-06-04T11:07:01Z"
+    },
+    {
+      "upstream": "anthropics/claude-code#60588",
+      "url": "https://github.com/anthropics/claude-code/issues/60588",
+      "title": "EnterWorktree ignores worktree.baseRef: \"fresh\" — still branches from local HEAD (v2.1.144)",
+      "impact": "not_applicable",
+      "categories": [
+        "slash_hook"
+      ],
+      "tokenkey_status": "not_applicable",
+      "rationale": "Client-side claude-code concern (slash_hook); not a gateway/relay relevance signal.",
+      "updated_at": "2026-06-04T11:07:05Z"
+    },
+    {
+      "upstream": "anthropics/claude-code#60589",
+      "url": "https://github.com/anthropics/claude-code/issues/60589",
+      "title": "[BUG] VS Code extension: opening a new editor tab causes 300-500 ms main-thread stalls in the webview",
+      "impact": "not_applicable",
+      "categories": [
+        "ide",
+        "terminal",
+        "install",
+        "platform"
+      ],
+      "tokenkey_status": "not_applicable",
+      "rationale": "Client-side claude-code concern (ide, terminal, install, platform); not a gateway/relay relevance signal.",
+      "updated_at": "2026-06-04T11:07:18Z"
+    },
+    {
+      "upstream": "anthropics/claude-code#60599",
+      "url": "https://github.com/anthropics/claude-code/issues/60599",
+      "title": "[FEATURE] Namespace plugin MCP server registrations to prevent cross-plugin collisions",
+      "impact": "not_applicable",
+      "categories": [
+        "mcp",
+        "plugin",
+        "install"
+      ],
+      "tokenkey_status": "not_applicable",
+      "rationale": "Client-side claude-code concern (mcp, plugin, install); not a gateway/relay relevance signal.",
+      "updated_at": "2026-06-04T11:07:12Z"
+    },
+    {
+      "upstream": "anthropics/claude-code#60602",
+      "url": "https://github.com/anthropics/claude-code/issues/60602",
+      "title": "[FEATURE] Subject-Tagged Context Capsules.",
+      "impact": "not_applicable",
+      "categories": [
+        "terminal"
+      ],
+      "tokenkey_status": "not_applicable",
+      "rationale": "Client-side claude-code concern (terminal); not a gateway/relay relevance signal.",
+      "updated_at": "2026-06-04T11:07:22Z"
+    },
+    {
+      "upstream": "anthropics/claude-code#60603",
+      "url": "https://github.com/anthropics/claude-code/issues/60603",
+      "title": "[Feature Request] Session compaction should preserve list item ordering to prevent information corruption",
+      "impact": "not_applicable",
+      "categories": [
+        "terminal"
+      ],
+      "tokenkey_status": "not_applicable",
+      "rationale": "Client-side claude-code concern (terminal); not a gateway/relay relevance signal.",
+      "updated_at": "2026-06-04T11:07:16Z"
+    },
+    {
+      "upstream": "anthropics/claude-code#60609",
+      "url": "https://github.com/anthropics/claude-code/issues/60609",
+      "title": "[BUG] [Backend] Exception in plugin Claude Code [Beta] (0.1.14-beta)",
+      "impact": "not_applicable",
+      "categories": [
+        "ide",
+        "terminal",
+        "mcp",
+        "plugin"
+      ],
+      "tokenkey_status": "not_applicable",
+      "rationale": "Client-side claude-code concern (ide, terminal, mcp, plugin); not a gateway/relay relevance signal.",
+      "updated_at": "2026-06-04T11:07:20Z"
+    },
+    {
+      "upstream": "anthropics/claude-code#60613",
+      "url": "https://github.com/anthropics/claude-code/issues/60613",
+      "title": "[BUG] Auto-mode classifier hard-blocks all mongosh invocations once a \"prod\"-named DB appears in context, even after user explicit authorization and switch to a separate database",
+      "impact": "not_applicable",
+      "categories": [
+        "terminal"
+      ],
+      "tokenkey_status": "not_applicable",
+      "rationale": "Client-side claude-code concern (terminal); not a gateway/relay relevance signal.",
+      "updated_at": "2026-06-04T11:07:24Z"
+    },
+    {
+      "upstream": "anthropics/claude-code#60619",
+      "url": "https://github.com/anthropics/claude-code/issues/60619",
+      "title": "ultrareview fails with \"firestore: not found\" on every attempt after credit top-up",
+      "impact": "not_applicable",
+      "categories": [
+        "platform"
+      ],
+      "tokenkey_status": "not_applicable",
+      "rationale": "Client-side claude-code concern (platform); not a gateway/relay relevance signal.",
+      "updated_at": "2026-06-04T11:07:26Z"
+    },
+    {
+      "upstream": "anthropics/claude-code#60620",
+      "url": "https://github.com/anthropics/claude-code/issues/60620",
+      "title": "Claude Code agent harness writes broken per-worktree core.hooksPath",
+      "impact": "not_applicable",
+      "categories": [
+        "terminal",
+        "slash_hook",
+        "install",
+        "platform"
+      ],
+      "tokenkey_status": "not_applicable",
+      "rationale": "Client-side claude-code concern (terminal, slash_hook, install, platform); not a gateway/relay relevance signal.",
+      "updated_at": "2026-06-04T11:07:29Z"
+    },
+    {
+      "upstream": "anthropics/claude-code#60621",
+      "url": "https://github.com/anthropics/claude-code/issues/60621",
+      "title": "Allow custom or disabled terminal window title",
+      "impact": "not_applicable",
+      "categories": [
+        "terminal"
+      ],
+      "tokenkey_status": "not_applicable",
+      "rationale": "Client-side claude-code concern (terminal); not a gateway/relay relevance signal.",
+      "updated_at": "2026-06-04T11:07:27Z"
+    },
+    {
+      "upstream": "anthropics/claude-code#60623",
+      "url": "https://github.com/anthropics/claude-code/issues/60623",
+      "title": "[FEATURE] Add \"Open Editors\" / attach all open tabs as chat context",
+      "impact": "not_applicable",
+      "categories": [
+        "ide",
+        "slash_hook"
+      ],
+      "tokenkey_status": "not_applicable",
+      "rationale": "Client-side claude-code concern (ide, slash_hook); not a gateway/relay relevance signal.",
+      "updated_at": "2026-06-04T11:07:28Z"
+    },
+    {
+      "upstream": "anthropics/claude-code#60630",
+      "url": "https://github.com/anthropics/claude-code/issues/60630",
+      "title": "[BUG] Long-CI-wait + Monitor: every poll forces an assistant response, turning the chat into a wall of '·' (compounding #50258 / #55400)",
+      "impact": "not_applicable",
+      "categories": [
+        "terminal",
+        "slash_hook"
+      ],
+      "tokenkey_status": "not_applicable",
+      "rationale": "Client-side claude-code concern (terminal, slash_hook); not a gateway/relay relevance signal.",
+      "updated_at": "2026-06-04T11:07:32Z"
+    },
+    {
+      "upstream": "anthropics/claude-code#60638",
+      "url": "https://github.com/anthropics/claude-code/issues/60638",
+      "title": "[FEATURE] Add OSC 0 setting of title whenever the session name is set/changes",
+      "impact": "not_applicable",
+      "categories": [
+        "terminal"
+      ],
+      "tokenkey_status": "not_applicable",
+      "rationale": "Client-side claude-code concern (terminal); not a gateway/relay relevance signal.",
+      "updated_at": "2026-06-04T11:07:51Z"
+    },
+    {
+      "upstream": "anthropics/claude-code#60642",
+      "url": "https://github.com/anthropics/claude-code/issues/60642",
+      "title": "[BUG] \"/desktop\" command not available for AWS Bedrock",
+      "impact": "not_applicable",
+      "categories": [
+        "terminal"
+      ],
+      "tokenkey_status": "not_applicable",
+      "rationale": "Client-side claude-code concern (terminal); not a gateway/relay relevance signal.",
+      "updated_at": "2026-06-04T11:07:34Z"
+    },
+    {
+      "upstream": "anthropics/claude-code#60651",
+      "url": "https://github.com/anthropics/claude-code/issues/60651",
+      "title": "Cowork: Host-Mac AppleScript bridge for native macOS app integration",
+      "impact": "not_applicable",
+      "categories": [
+        "terminal",
+        "mcp",
+        "slash_hook",
+        "install"
+      ],
+      "tokenkey_status": "not_applicable",
+      "rationale": "Client-side claude-code concern (terminal, mcp, slash_hook, install); not a gateway/relay relevance signal.",
+      "updated_at": "2026-06-04T11:07:38Z"
+    },
+    {
+      "upstream": "anthropics/claude-code#60654",
+      "url": "https://github.com/anthropics/claude-code/issues/60654",
+      "title": "Claude misinterprets ADO PR status enum (1=Active read as \"merged\")",
+      "impact": "not_applicable",
+      "categories": [
+        "mcp"
+      ],
+      "tokenkey_status": "not_applicable",
+      "rationale": "Client-side claude-code concern (mcp); not a gateway/relay relevance signal.",
+      "updated_at": "2026-06-04T11:07:43Z"
+    },
+    {
+      "upstream": "anthropics/claude-code#60658",
+      "url": "https://github.com/anthropics/claude-code/issues/60658",
+      "title": "[BUG] Scheduled task lastRunAt advances without skill execution — silent false-positive on macOS",
+      "impact": "not_applicable",
+      "categories": [
+        "mcp",
+        "platform"
+      ],
+      "tokenkey_status": "not_applicable",
+      "rationale": "Client-side claude-code concern (mcp, platform); not a gateway/relay relevance signal.",
+      "updated_at": "2026-06-04T11:07:48Z"
+    },
+    {
+      "upstream": "anthropics/claude-code#60660",
+      "url": "https://github.com/anthropics/claude-code/issues/60660",
+      "title": "[BUG] Cowork: \"Download failed\" error after files validated successfully (Windows 11 Home, MSIX install)",
+      "impact": "not_applicable",
+      "categories": [
+        "terminal",
+        "install",
+        "platform"
+      ],
+      "tokenkey_status": "not_applicable",
+      "rationale": "Client-side claude-code concern (terminal, install, platform); not a gateway/relay relevance signal.",
+      "updated_at": "2026-06-04T11:07:45Z"
+    },
+    {
+      "upstream": "anthropics/claude-code#60666",
+      "url": "https://github.com/anthropics/claude-code/issues/60666",
+      "title": "Claude avoids necessary work and optimizes for completion over correctness",
+      "impact": "not_applicable",
+      "categories": [
+        "slash_hook"
+      ],
+      "tokenkey_status": "not_applicable",
+      "rationale": "Client-side claude-code concern (slash_hook); not a gateway/relay relevance signal.",
+      "updated_at": "2026-06-04T11:07:47Z"
+    },
+    {
+      "upstream": "anthropics/claude-code#60667",
+      "url": "https://github.com/anthropics/claude-code/issues/60667",
+      "title": "[BUG] Cowork scheduled tasks missing from desktop sidebar — only subset rendered; macOS; tasks exist on disk and run correctly",
+      "impact": "not_applicable",
+      "categories": [
+        "terminal",
+        "mcp",
+        "platform"
+      ],
+      "tokenkey_status": "not_applicable",
+      "rationale": "Client-side claude-code concern (terminal, mcp, platform); not a gateway/relay relevance signal.",
+      "updated_at": "2026-06-04T11:07:49Z"
+    },
+    {
+      "upstream": "anthropics/claude-code#60672",
+      "url": "https://github.com/anthropics/claude-code/issues/60672",
+      "title": "Process-level \"active session in this repo\" tracking, with built-in cross-repo + multi-tmux collision guards",
+      "impact": "not_applicable",
+      "categories": [
+        "ide",
+        "mcp",
+        "slash_hook",
+        "platform"
+      ],
+      "tokenkey_status": "not_applicable",
+      "rationale": "Client-side claude-code concern (ide, mcp, slash_hook, platform); not a gateway/relay relevance signal.",
+      "updated_at": "2026-06-04T11:07:51Z"
+    },
+    {
+      "upstream": "anthropics/claude-code#60680",
+      "url": "https://github.com/anthropics/claude-code/issues/60680",
+      "title": "[BUG] /usage statistics keep old account stats when you change accounts",
+      "impact": "not_applicable",
+      "categories": [
+        "ide",
+        "terminal"
+      ],
+      "tokenkey_status": "not_applicable",
+      "rationale": "Client-side claude-code concern (ide, terminal); not a gateway/relay relevance signal.",
+      "updated_at": "2026-06-04T11:07:53Z"
+    },
+    {
+      "upstream": "anthropics/claude-code#60682",
+      "url": "https://github.com/anthropics/claude-code/issues/60682",
+      "title": "[BUG] /autofix-pr fails with \"Claude GitHub app must be installed\" despite app being installed",
+      "impact": "not_applicable",
+      "categories": [
+        "install"
+      ],
+      "tokenkey_status": "not_applicable",
+      "rationale": "Client-side claude-code concern (install); not a gateway/relay relevance signal.",
+      "updated_at": "2026-06-04T11:07:54Z"
+    },
+    {
+      "upstream": "anthropics/claude-code#60690",
+      "url": "https://github.com/anthropics/claude-code/issues/60690",
+      "title": "[DOCS] Agent view docs omit the awaiting-input count in the `claude agents` terminal tab title",
+      "impact": "not_applicable",
+      "categories": [
+        "terminal"
+      ],
+      "tokenkey_status": "not_applicable",
+      "rationale": "Client-side claude-code concern (terminal); not a gateway/relay relevance signal.",
+      "updated_at": "2026-06-04T11:07:54Z"
+    },
+    {
+      "upstream": "anthropics/claude-code#60691",
+      "url": "https://github.com/anthropics/claude-code/issues/60691",
+      "title": "[DOCS] Fullscreen docs omit mouse hover/click behavior for slash command and @-mention suggestion lists",
+      "impact": "not_applicable",
+      "categories": [
+        "terminal",
+        "plugin",
+        "slash_hook"
+      ],
+      "tokenkey_status": "not_applicable",
+      "rationale": "Client-side claude-code concern (terminal, plugin, slash_hook); not a gateway/relay relevance signal.",
+      "updated_at": "2026-06-04T11:07:55Z"
+    },
+    {
+      "upstream": "anthropics/claude-code#60692",
+      "url": "https://github.com/anthropics/claude-code/issues/60692",
+      "title": "[DOCS] Stop and SubagentStop hook input docs omit `background_tasks` and `session_crons`",
+      "impact": "not_applicable",
+      "categories": [
+        "plugin",
+        "slash_hook"
+      ],
+      "tokenkey_status": "not_applicable",
+      "rationale": "Client-side claude-code concern (plugin, slash_hook); not a gateway/relay relevance signal.",
+      "updated_at": "2026-06-04T11:07:56Z"
+    },
+    {
+      "upstream": "anthropics/claude-code#60693",
+      "url": "https://github.com/anthropics/claude-code/issues/60693",
+      "title": "[DOCS] Permission mode docs do not define the safe env-var allowlist for Bash auto-approval",
+      "impact": "not_applicable",
+      "categories": [
+        "terminal"
+      ],
+      "tokenkey_status": "not_applicable",
+      "rationale": "Client-side claude-code concern (terminal); not a gateway/relay relevance signal.",
+      "updated_at": "2026-06-04T11:07:56Z"
     },
     {
       "upstream": "anthropics/claude-code#60711",
@@ -12050,7 +14179,7 @@
       ],
       "tokenkey_status": "not_applicable",
       "rationale": "Client-side claude-code concern (plugin); not a gateway/relay relevance signal.",
-      "updated_at": "2026-05-31T14:12:12Z"
+      "updated_at": "2026-06-03T18:42:38Z"
     },
     {
       "upstream": "anthropics/claude-code#60844",
@@ -12080,44 +14209,20 @@
       "updated_at": "2026-06-02T06:49:22Z"
     },
     {
-      "upstream": "anthropics/claude-code#60975",
-      "url": "https://github.com/anthropics/claude-code/issues/60975",
-      "title": "Agent View / FleetView: allow specifying a starting directory (cwd) when spawning a new agent so it boots with the correct project context",
+      "upstream": "anthropics/claude-code#60945",
+      "url": "https://github.com/anthropics/claude-code/issues/60945",
+      "title": "[BUG] Two identical Claude Code icons appear in activity bar after installing a single extension",
       "impact": "not_applicable",
       "categories": [
+        "ide",
         "terminal",
-        "mcp",
         "plugin",
-        "slash_hook"
-      ],
-      "tokenkey_status": "not_applicable",
-      "rationale": "Client-side claude-code concern (terminal, mcp, plugin, slash_hook); not a gateway/relay relevance signal.",
-      "updated_at": "2026-06-01T12:42:06Z"
-    },
-    {
-      "upstream": "anthropics/claude-code#61088",
-      "url": "https://github.com/anthropics/claude-code/issues/61088",
-      "title": "[BUG] False positive: Usage Policy violation triggered by legitimate input",
-      "impact": "not_applicable",
-      "categories": [
-        "terminal",
+        "install",
         "platform"
       ],
       "tokenkey_status": "not_applicable",
-      "rationale": "Client-side claude-code concern (terminal, platform); not a gateway/relay relevance signal.",
-      "updated_at": "2026-06-01T06:33:06Z"
-    },
-    {
-      "upstream": "anthropics/claude-code#61142",
-      "url": "https://github.com/anthropics/claude-code/issues/61142",
-      "title": "[MODEL] Korean output corruption — words replaced with \"영역\" token in long responses",
-      "impact": "not_applicable",
-      "categories": [
-        "platform"
-      ],
-      "tokenkey_status": "not_applicable",
-      "rationale": "Client-side claude-code concern (platform); not a gateway/relay relevance signal.",
-      "updated_at": "2026-06-01T01:47:55Z"
+      "rationale": "Client-side claude-code concern (ide, terminal, plugin, install, platform); not a gateway/relay relevance signal.",
+      "updated_at": "2026-06-04T08:00:28Z"
     },
     {
       "upstream": "anthropics/claude-code#61147",
@@ -12146,32 +14251,17 @@
       "updated_at": "2026-06-02T00:05:13Z"
     },
     {
-      "upstream": "anthropics/claude-code#61315",
-      "url": "https://github.com/anthropics/claude-code/issues/61315",
-      "title": "[BUG] Sub-agent dispatched via Agent tool stalls silently on MCP permission gate — no surface to parent CLI UI",
+      "upstream": "anthropics/claude-code#61268",
+      "url": "https://github.com/anthropics/claude-code/issues/61268",
+      "title": "[BUG] Security: permissions.deny rules not working",
       "impact": "not_applicable",
       "categories": [
         "terminal",
-        "mcp",
-        "plugin",
         "slash_hook"
       ],
       "tokenkey_status": "not_applicable",
-      "rationale": "Client-side claude-code concern (terminal, mcp, plugin, slash_hook); not a gateway/relay relevance signal.",
-      "updated_at": "2026-06-01T03:40:23Z"
-    },
-    {
-      "upstream": "anthropics/claude-code#61339",
-      "url": "https://github.com/anthropics/claude-code/issues/61339",
-      "title": "[BUG] Double-charged after Max 5x plan silently downgraded to Free mid-cycle",
-      "impact": "not_applicable",
-      "categories": [
-        "terminal",
-        "platform"
-      ],
-      "tokenkey_status": "not_applicable",
-      "rationale": "Client-side claude-code concern (terminal, platform); not a gateway/relay relevance signal.",
-      "updated_at": "2026-06-01T06:31:12Z"
+      "rationale": "Client-side claude-code concern (terminal, slash_hook); not a gateway/relay relevance signal.",
+      "updated_at": "2026-06-03T10:38:53Z"
     },
     {
       "upstream": "anthropics/claude-code#61405",
@@ -12196,18 +14286,6 @@
       "tokenkey_status": "not_applicable",
       "rationale": "Client-side claude-code concern (terminal); not a gateway/relay relevance signal.",
       "updated_at": "2026-06-02T09:04:36Z"
-    },
-    {
-      "upstream": "anthropics/claude-code#61484",
-      "url": "https://github.com/anthropics/claude-code/issues/61484",
-      "title": "Feature request: add \"Copy selection\" to right-click menu",
-      "impact": "not_applicable",
-      "categories": [
-        "platform"
-      ],
-      "tokenkey_status": "not_applicable",
-      "rationale": "Client-side claude-code concern (platform); not a gateway/relay relevance signal.",
-      "updated_at": "2026-06-01T00:16:29Z"
     },
     {
       "upstream": "anthropics/claude-code#61491",
@@ -12291,47 +14369,6 @@
       "updated_at": "2026-06-03T01:20:46Z"
     },
     {
-      "upstream": "anthropics/claude-code#61638",
-      "url": "https://github.com/anthropics/claude-code/issues/61638",
-      "title": "False positive on Claude Code Usage Policy classifier — please stop over-flagging legitimate engineering work",
-      "impact": "not_applicable",
-      "categories": [
-        "terminal",
-        "mcp"
-      ],
-      "tokenkey_status": "not_applicable",
-      "rationale": "Client-side claude-code concern (terminal, mcp); not a gateway/relay relevance signal.",
-      "updated_at": "2026-06-01T06:32:32Z"
-    },
-    {
-      "upstream": "anthropics/claude-code#61642",
-      "url": "https://github.com/anthropics/claude-code/issues/61642",
-      "title": "[BUG] False-positive Usage Policy (AUP) violation on benign FPGA/hardware engineering waveform analysis",
-      "impact": "not_applicable",
-      "categories": [
-        "ide",
-        "terminal",
-        "platform"
-      ],
-      "tokenkey_status": "not_applicable",
-      "rationale": "Client-side claude-code concern (ide, terminal, platform); not a gateway/relay relevance signal.",
-      "updated_at": "2026-06-01T06:28:15Z"
-    },
-    {
-      "upstream": "anthropics/claude-code#61681",
-      "url": "https://github.com/anthropics/claude-code/issues/61681",
-      "title": "Sonnet dispatched via Agent tool fails with \"1M context required\" error",
-      "impact": "not_applicable",
-      "categories": [
-        "plugin",
-        "slash_hook",
-        "platform"
-      ],
-      "tokenkey_status": "not_applicable",
-      "rationale": "Client-side claude-code concern (plugin, slash_hook, platform); not a gateway/relay relevance signal.",
-      "updated_at": "2026-05-31T15:04:59Z"
-    },
-    {
       "upstream": "anthropics/claude-code#61682",
       "url": "https://github.com/anthropics/claude-code/issues/61682",
       "title": "[BUG] GitHub connector shows \"Connected\" but exposes no tools in Cowork (Windows 11, app v1.8555.2.0)",
@@ -12342,7 +14379,7 @@
       ],
       "tokenkey_status": "not_applicable",
       "rationale": "Client-side claude-code concern (terminal, platform); not a gateway/relay relevance signal.",
-      "updated_at": "2026-06-03T01:47:22Z"
+      "updated_at": "2026-06-04T01:58:27Z"
     },
     {
       "upstream": "anthropics/claude-code#61692",
@@ -12355,33 +14392,7 @@
       ],
       "tokenkey_status": "not_applicable",
       "rationale": "Client-side claude-code concern (terminal, platform); not a gateway/relay relevance signal.",
-      "updated_at": "2026-06-03T08:37:17Z"
-    },
-    {
-      "upstream": "anthropics/claude-code#61703",
-      "url": "https://github.com/anthropics/claude-code/issues/61703",
-      "title": "False Usage Limit and Request blocked",
-      "impact": "not_applicable",
-      "categories": [
-        "terminal",
-        "platform"
-      ],
-      "tokenkey_status": "not_applicable",
-      "rationale": "Client-side claude-code concern (terminal, platform); not a gateway/relay relevance signal.",
-      "updated_at": "2026-06-01T05:29:26Z"
-    },
-    {
-      "upstream": "anthropics/claude-code#61762",
-      "url": "https://github.com/anthropics/claude-code/issues/61762",
-      "title": "[FEATURE] Jetbrains plugin should support setting parent folder as working folder",
-      "impact": "not_applicable",
-      "categories": [
-        "ide",
-        "plugin"
-      ],
-      "tokenkey_status": "not_applicable",
-      "rationale": "Client-side claude-code concern (ide, plugin); not a gateway/relay relevance signal.",
-      "updated_at": "2026-06-01T02:03:20Z"
+      "updated_at": "2026-06-03T18:54:45Z"
     },
     {
       "upstream": "anthropics/claude-code#61807",
@@ -12438,18 +14449,6 @@
       "updated_at": "2026-06-01T16:35:13Z"
     },
     {
-      "upstream": "anthropics/claude-code#62071",
-      "url": "https://github.com/anthropics/claude-code/issues/62071",
-      "title": "[Bug] Usage Policy classifier stuck in blocked state for legitimate kernel security work",
-      "impact": "not_applicable",
-      "categories": [
-        "terminal"
-      ],
-      "tokenkey_status": "not_applicable",
-      "rationale": "Client-side claude-code concern (terminal); not a gateway/relay relevance signal.",
-      "updated_at": "2026-06-01T06:28:17Z"
-    },
-    {
       "upstream": "anthropics/claude-code#62072",
       "url": "https://github.com/anthropics/claude-code/issues/62072",
       "title": "[BUG] Cowork on macOS 1.8555.2 — zero MCP tools bind in any install path (.mcpb + SDK bridge + Custom Connectors + project .mcp.json); spawn pipeline missing --mcp-config since 2026-05-23 auto-update",
@@ -12478,18 +14477,6 @@
       "updated_at": "2026-06-03T10:19:10Z"
     },
     {
-      "upstream": "anthropics/claude-code#62096",
-      "url": "https://github.com/anthropics/claude-code/issues/62096",
-      "title": "[BUG] subscribe_pr_activity delivers human review events but not bot review events (from GitHub Apps like chatgpt-codex-connector[bot] and gemini-code-assist[bot])",
-      "impact": "not_applicable",
-      "categories": [
-        "terminal"
-      ],
-      "tokenkey_status": "not_applicable",
-      "rationale": "Client-side claude-code concern (terminal); not a gateway/relay relevance signal.",
-      "updated_at": "2026-06-01T13:47:44Z"
-    },
-    {
       "upstream": "anthropics/claude-code#62123",
       "url": "https://github.com/anthropics/claude-code/issues/62123",
       "title": "[Bug] Anthropic API Error: Model's tool call could not be parsed (retry also failed)",
@@ -12500,7 +14487,7 @@
       ],
       "tokenkey_status": "not_applicable",
       "rationale": "Client-side claude-code concern (ide, terminal); not a gateway/relay relevance signal.",
-      "updated_at": "2026-06-03T08:13:28Z"
+      "updated_at": "2026-06-04T04:19:15Z"
     },
     {
       "upstream": "anthropics/claude-code#62149",
@@ -12518,16 +14505,18 @@
       "updated_at": "2026-06-02T04:19:00Z"
     },
     {
-      "upstream": "anthropics/claude-code#62191",
-      "url": "https://github.com/anthropics/claude-code/issues/62191",
-      "title": "[Bug] VERY sensitive cyber-safeguards",
+      "upstream": "anthropics/claude-code#62180",
+      "url": "https://github.com/anthropics/claude-code/issues/62180",
+      "title": "[FEATURE] Cursor-style inline edit popup (Ctrl+K) for VS Code Claude extension",
       "impact": "not_applicable",
       "categories": [
-        "terminal"
+        "ide",
+        "terminal",
+        "slash_hook"
       ],
       "tokenkey_status": "not_applicable",
-      "rationale": "Client-side claude-code concern (terminal); not a gateway/relay relevance signal.",
-      "updated_at": "2026-06-01T06:32:35Z"
+      "rationale": "Client-side claude-code concern (ide, terminal, slash_hook); not a gateway/relay relevance signal.",
+      "updated_at": "2026-06-04T00:41:15Z"
     },
     {
       "upstream": "anthropics/claude-code#62194",
@@ -12554,7 +14543,21 @@
       ],
       "tokenkey_status": "not_applicable",
       "rationale": "Client-side claude-code concern (ide, terminal, slash_hook, platform); not a gateway/relay relevance signal.",
-      "updated_at": "2026-06-02T19:22:01Z"
+      "updated_at": "2026-06-04T11:47:15Z"
+    },
+    {
+      "upstream": "anthropics/claude-code#62212",
+      "url": "https://github.com/anthropics/claude-code/issues/62212",
+      "title": "[BUG] Segmentation fault at address 0x8 on startup - Windows 11 (Bun baseline build)",
+      "impact": "not_applicable",
+      "categories": [
+        "terminal",
+        "install",
+        "platform"
+      ],
+      "tokenkey_status": "not_applicable",
+      "rationale": "Client-side claude-code concern (terminal, install, platform); not a gateway/relay relevance signal.",
+      "updated_at": "2026-06-04T06:55:10Z"
     },
     {
       "upstream": "anthropics/claude-code#62259",
@@ -12597,6 +14600,20 @@
       "tokenkey_status": "not_applicable",
       "rationale": "Client-side claude-code concern (ide, terminal, slash_hook, platform); not a gateway/relay relevance signal.",
       "updated_at": "2026-06-02T20:16:23Z"
+    },
+    {
+      "upstream": "anthropics/claude-code#62284",
+      "url": "https://github.com/anthropics/claude-code/issues/62284",
+      "title": "Remote Control: can read session from mobile but cannot send messages back",
+      "impact": "not_applicable",
+      "categories": [
+        "terminal",
+        "slash_hook",
+        "platform"
+      ],
+      "tokenkey_status": "not_applicable",
+      "rationale": "Client-side claude-code concern (terminal, slash_hook, platform); not a gateway/relay relevance signal.",
+      "updated_at": "2026-06-04T00:54:13Z"
     },
     {
       "upstream": "anthropics/claude-code#62333",
@@ -12647,49 +14664,45 @@
       ],
       "tokenkey_status": "not_applicable",
       "rationale": "Client-side claude-code concern (terminal); not a gateway/relay relevance signal.",
-      "updated_at": "2026-06-03T05:53:17Z"
+      "updated_at": "2026-06-03T18:51:49Z"
     },
     {
-      "upstream": "anthropics/claude-code#62487",
-      "url": "https://github.com/anthropics/claude-code/issues/62487",
-      "title": "[BUG] Switching to mimo-v2.5-pro fails after reading images in mimo-v2.5",
+      "upstream": "anthropics/claude-code#62476",
+      "url": "https://github.com/anthropics/claude-code/issues/62476",
+      "title": "[BUG] Claude Code silently deletes conversation transcripts after 30 days by default",
       "impact": "not_applicable",
       "categories": [
-        "ide",
+        "terminal",
+        "slash_hook"
+      ],
+      "tokenkey_status": "not_applicable",
+      "rationale": "Client-side claude-code concern (terminal, slash_hook); not a gateway/relay relevance signal.",
+      "updated_at": "2026-06-04T02:28:54Z"
+    },
+    {
+      "upstream": "anthropics/claude-code#62493",
+      "url": "https://github.com/anthropics/claude-code/issues/62493",
+      "title": "AskUserQuestion overlay obscures the assistant's previous message",
+      "impact": "not_applicable",
+      "categories": [
         "terminal",
         "platform"
       ],
       "tokenkey_status": "not_applicable",
-      "rationale": "Client-side claude-code concern (ide, terminal, platform); not a gateway/relay relevance signal.",
-      "updated_at": "2026-06-01T09:34:20Z"
+      "rationale": "Client-side claude-code concern (terminal, platform); not a gateway/relay relevance signal.",
+      "updated_at": "2026-06-03T16:06:16Z"
     },
     {
-      "upstream": "anthropics/claude-code#62537",
-      "url": "https://github.com/anthropics/claude-code/issues/62537",
-      "title": "[BUG] Windows: PowerShell tool absent from schema when Git Bash is on PATH, despite pwsh.exe being present and detectable",
+      "upstream": "anthropics/claude-code#62534",
+      "url": "https://github.com/anthropics/claude-code/issues/62534",
+      "title": "Long streamed responses occasionally triplicate sections of output",
       "impact": "not_applicable",
       "categories": [
-        "terminal",
-        "slash_hook",
-        "install",
-        "platform"
+        "terminal"
       ],
       "tokenkey_status": "not_applicable",
-      "rationale": "Client-side claude-code concern (terminal, slash_hook, install, platform); not a gateway/relay relevance signal.",
-      "updated_at": "2026-05-31T21:33:04Z"
-    },
-    {
-      "upstream": "anthropics/claude-code#62585",
-      "url": "https://github.com/anthropics/claude-code/issues/62585",
-      "title": "Remote Control \"not yet enabled\" on Max plan — v2.1.126 (Arch Linux)",
-      "impact": "not_applicable",
-      "categories": [
-        "terminal",
-        "plugin"
-      ],
-      "tokenkey_status": "not_applicable",
-      "rationale": "Client-side claude-code concern (terminal, plugin); not a gateway/relay relevance signal.",
-      "updated_at": "2026-06-01T09:01:51Z"
+      "rationale": "Client-side claude-code concern (terminal); not a gateway/relay relevance signal.",
+      "updated_at": "2026-06-03T20:57:51Z"
     },
     {
       "upstream": "anthropics/claude-code#62619",
@@ -12702,7 +14715,7 @@
       ],
       "tokenkey_status": "not_applicable",
       "rationale": "Client-side claude-code concern (ide, terminal); not a gateway/relay relevance signal.",
-      "updated_at": "2026-06-01T06:33:16Z"
+      "updated_at": "2026-06-04T12:43:45Z"
     },
     {
       "upstream": "anthropics/claude-code#62623",
@@ -12851,7 +14864,7 @@
       ],
       "tokenkey_status": "not_applicable",
       "rationale": "Client-side claude-code concern (terminal, install); not a gateway/relay relevance signal.",
-      "updated_at": "2026-06-01T05:59:26Z"
+      "updated_at": "2026-06-03T18:49:44Z"
     },
     {
       "upstream": "anthropics/claude-code#62890",
@@ -12893,20 +14906,6 @@
       "updated_at": "2026-06-02T15:26:03Z"
     },
     {
-      "upstream": "anthropics/claude-code#62967",
-      "url": "https://github.com/anthropics/claude-code/issues/62967",
-      "title": "[BUG] Claude in Chrome v1.0.74 — MCP bridge navigation and read tools wedge after May 27 update",
-      "impact": "not_applicable",
-      "categories": [
-        "ide",
-        "terminal",
-        "mcp"
-      ],
-      "tokenkey_status": "not_applicable",
-      "rationale": "Client-side claude-code concern (ide, terminal, mcp); not a gateway/relay relevance signal.",
-      "updated_at": "2026-06-01T03:39:14Z"
-    },
-    {
       "upstream": "anthropics/claude-code#63002",
       "url": "https://github.com/anthropics/claude-code/issues/63002",
       "title": "[Bug] Thread context stale after sleep/resume, returns outdated date and calendar data",
@@ -12919,42 +14918,6 @@
       "updated_at": "2026-06-02T07:54:19Z"
     },
     {
-      "upstream": "anthropics/claude-code#63012",
-      "url": "https://github.com/anthropics/claude-code/issues/63012",
-      "title": "[BUG] API 500 ERROR \"Attempt N/10... Retrying in Xs...\" MAKING CLAUDE CODE UNUSEABLE",
-      "impact": "not_applicable",
-      "categories": [
-        "terminal"
-      ],
-      "tokenkey_status": "not_applicable",
-      "rationale": "Client-side claude-code concern (terminal); not a gateway/relay relevance signal.",
-      "updated_at": "2026-06-01T06:47:02Z"
-    },
-    {
-      "upstream": "anthropics/claude-code#63037",
-      "url": "https://github.com/anthropics/claude-code/issues/63037",
-      "title": "[DOCS] Agent view docs omit macOS Privacy & Security identity for background agents",
-      "impact": "not_applicable",
-      "categories": [
-        "terminal"
-      ],
-      "tokenkey_status": "not_applicable",
-      "rationale": "Client-side claude-code concern (terminal); not a gateway/relay relevance signal.",
-      "updated_at": "2026-06-01T01:27:48Z"
-    },
-    {
-      "upstream": "anthropics/claude-code#63040",
-      "url": "https://github.com/anthropics/claude-code/issues/63040",
-      "title": "[DOCS] Background session docs omit `$CLAUDE_JOB_DIR` temp-file behavior",
-      "impact": "not_applicable",
-      "categories": [
-        "platform"
-      ],
-      "tokenkey_status": "not_applicable",
-      "rationale": "Client-side claude-code concern (platform); not a gateway/relay relevance signal.",
-      "updated_at": "2026-06-01T01:27:58Z"
-    },
-    {
       "upstream": "anthropics/claude-code#63048",
       "url": "https://github.com/anthropics/claude-code/issues/63048",
       "title": "/code-review skill: silent fallback to main...HEAD reviews other people's commits, and JSON-only output is hard to read",
@@ -12965,7 +14928,7 @@
       ],
       "tokenkey_status": "not_applicable",
       "rationale": "Client-side claude-code concern (terminal, slash_hook); not a gateway/relay relevance signal.",
-      "updated_at": "2026-06-03T03:26:38Z"
+      "updated_at": "2026-06-03T17:05:15Z"
     },
     {
       "upstream": "anthropics/claude-code#63060",
@@ -12977,20 +14940,34 @@
       ],
       "tokenkey_status": "not_applicable",
       "rationale": "Client-side claude-code concern (terminal); not a gateway/relay relevance signal.",
-      "updated_at": "2026-06-03T09:35:09Z"
+      "updated_at": "2026-06-04T11:53:32Z"
     },
     {
-      "upstream": "anthropics/claude-code#63138",
-      "url": "https://github.com/anthropics/claude-code/issues/63138",
-      "title": "[Bug] VSCode terminal output displays corrupted text with garbled symbols",
+      "upstream": "anthropics/claude-code#63075",
+      "url": "https://github.com/anthropics/claude-code/issues/63075",
+      "title": "[BUG] Cowork crashes on every message, no VM logs generated, missing AppData\\Roaming\\Claude",
+      "impact": "not_applicable",
+      "categories": [
+        "terminal",
+        "platform"
+      ],
+      "tokenkey_status": "not_applicable",
+      "rationale": "Client-side claude-code concern (terminal, platform); not a gateway/relay relevance signal.",
+      "updated_at": "2026-06-03T22:20:02Z"
+    },
+    {
+      "upstream": "anthropics/claude-code#63190",
+      "url": "https://github.com/anthropics/claude-code/issues/63190",
+      "title": "[FEATURE] Deferred Messages — Queue Input for End of Turn",
       "impact": "not_applicable",
       "categories": [
         "ide",
-        "terminal"
+        "terminal",
+        "slash_hook"
       ],
       "tokenkey_status": "not_applicable",
-      "rationale": "Client-side claude-code concern (ide, terminal); not a gateway/relay relevance signal.",
-      "updated_at": "2026-05-31T22:50:24Z"
+      "rationale": "Client-side claude-code concern (ide, terminal, slash_hook); not a gateway/relay relevance signal.",
+      "updated_at": "2026-06-03T18:00:49Z"
     },
     {
       "upstream": "anthropics/claude-code#63238",
@@ -13018,42 +14995,16 @@
       "updated_at": "2026-06-03T08:20:30Z"
     },
     {
-      "upstream": "anthropics/claude-code#63298",
-      "url": "https://github.com/anthropics/claude-code/issues/63298",
-      "title": "[DOCS] Agent view dispatch input docs incorrectly imply `/logout` dispatches as a prompt",
+      "upstream": "anthropics/claude-code#63319",
+      "url": "https://github.com/anthropics/claude-code/issues/63319",
+      "title": "[DOCS] Managed MCP policy docs omit invalid `allowedMcpServers`/`deniedMcpServers` entry behavior",
       "impact": "not_applicable",
       "categories": [
-        "slash_hook"
+        "mcp"
       ],
       "tokenkey_status": "not_applicable",
-      "rationale": "Client-side claude-code concern (slash_hook); not a gateway/relay relevance signal.",
-      "updated_at": "2026-06-01T01:38:10Z"
-    },
-    {
-      "upstream": "anthropics/claude-code#63304",
-      "url": "https://github.com/anthropics/claude-code/issues/63304",
-      "title": "VSCode Chrome integration silently fails: 3 distinct bugs",
-      "impact": "not_applicable",
-      "categories": [
-        "ide",
-        "mcp",
-        "install"
-      ],
-      "tokenkey_status": "not_applicable",
-      "rationale": "Client-side claude-code concern (ide, mcp, install); not a gateway/relay relevance signal.",
-      "updated_at": "2026-06-01T12:16:26Z"
-    },
-    {
-      "upstream": "anthropics/claude-code#63315",
-      "url": "https://github.com/anthropics/claude-code/issues/63315",
-      "title": "[DOCS] Background session docs omit worktree-isolation behavior for spawned subagents",
-      "impact": "not_applicable",
-      "categories": [
-        "plugin"
-      ],
-      "tokenkey_status": "not_applicable",
-      "rationale": "Client-side claude-code concern (plugin); not a gateway/relay relevance signal.",
-      "updated_at": "2026-06-01T01:27:14Z"
+      "rationale": "Client-side claude-code concern (mcp); not a gateway/relay relevance signal.",
+      "updated_at": "2026-06-04T00:49:09Z"
     },
     {
       "upstream": "anthropics/claude-code#63353",
@@ -13085,6 +15036,35 @@
       "updated_at": "2026-06-02T00:15:58Z"
     },
     {
+      "upstream": "anthropics/claude-code#63415",
+      "url": "https://github.com/anthropics/claude-code/issues/63415",
+      "title": "[FEATURE] Team-Agents: stable naming + live stand-up (field report from a working setup)",
+      "impact": "not_applicable",
+      "categories": [
+        "ide",
+        "terminal",
+        "plugin",
+        "slash_hook",
+        "install"
+      ],
+      "tokenkey_status": "not_applicable",
+      "rationale": "Client-side claude-code concern (ide, terminal, plugin, slash_hook, install); not a gateway/relay relevance signal.",
+      "updated_at": "2026-06-04T06:54:25Z"
+    },
+    {
+      "upstream": "anthropics/claude-code#63426",
+      "url": "https://github.com/anthropics/claude-code/issues/63426",
+      "title": "[Bug] Context window fills quickly and auto-compact not triggering at 80% threshold",
+      "impact": "not_applicable",
+      "categories": [
+        "ide",
+        "terminal"
+      ],
+      "tokenkey_status": "not_applicable",
+      "rationale": "Client-side claude-code concern (ide, terminal); not a gateway/relay relevance signal.",
+      "updated_at": "2026-06-03T14:36:03Z"
+    },
+    {
       "upstream": "anthropics/claude-code#63462",
       "url": "https://github.com/anthropics/claude-code/issues/63462",
       "title": "Phantom `⏺ Human:` lines appearing in transcript — assistant acts on instructions the user never typed",
@@ -13096,18 +15076,6 @@
       "tokenkey_status": "not_applicable",
       "rationale": "Client-side claude-code concern (terminal, slash_hook); not a gateway/relay relevance signal.",
       "updated_at": "2026-06-02T18:56:24Z"
-    },
-    {
-      "upstream": "anthropics/claude-code#63479",
-      "url": "https://github.com/anthropics/claude-code/issues/63479",
-      "title": "[BUG] CLAUDE_CODE_DISABLE_1M_CONTEXT ignored in 2.1.156",
-      "impact": "not_applicable",
-      "categories": [
-        "terminal"
-      ],
-      "tokenkey_status": "not_applicable",
-      "rationale": "Client-side claude-code concern (terminal); not a gateway/relay relevance signal.",
-      "updated_at": "2026-05-31T17:06:55Z"
     },
     {
       "upstream": "anthropics/claude-code#63488",
@@ -13134,7 +15102,7 @@
       ],
       "tokenkey_status": "not_applicable",
       "rationale": "Client-side claude-code concern (terminal, install); not a gateway/relay relevance signal.",
-      "updated_at": "2026-06-03T06:17:20Z"
+      "updated_at": "2026-06-03T13:26:18Z"
     },
     {
       "upstream": "anthropics/claude-code#63545",
@@ -13187,18 +15155,6 @@
       "updated_at": "2026-06-03T09:53:47Z"
     },
     {
-      "upstream": "anthropics/claude-code#63609",
-      "url": "https://github.com/anthropics/claude-code/issues/63609",
-      "title": "Illegal Instruction crash on CPUs without AVX since v2.1.113",
-      "impact": "not_applicable",
-      "categories": [
-        "install"
-      ],
-      "tokenkey_status": "not_applicable",
-      "rationale": "Client-side claude-code concern (install); not a gateway/relay relevance signal.",
-      "updated_at": "2026-06-01T12:02:34Z"
-    },
-    {
       "upstream": "anthropics/claude-code#63650",
       "url": "https://github.com/anthropics/claude-code/issues/63650",
       "title": "[BUG] Claude Desktop blurry on high-DPI ultrawide display due to MSIX packaging blocking DPI override",
@@ -13226,7 +15182,7 @@
       ],
       "tokenkey_status": "not_applicable",
       "rationale": "Client-side claude-code concern (terminal, slash_hook, install, platform); not a gateway/relay relevance signal.",
-      "updated_at": "2026-06-02T15:08:07Z"
+      "updated_at": "2026-06-04T12:02:04Z"
     },
     {
       "upstream": "anthropics/claude-code#63675",
@@ -13255,19 +15211,6 @@
       "updated_at": "2026-06-02T15:47:18Z"
     },
     {
-      "upstream": "anthropics/claude-code#63722",
-      "url": "https://github.com/anthropics/claude-code/issues/63722",
-      "title": "[BUG] [Enterprise] CoworkVMService deadlocks MSIX updates on Windows 11 — fleet-wide",
-      "impact": "not_applicable",
-      "categories": [
-        "terminal",
-        "platform"
-      ],
-      "tokenkey_status": "not_applicable",
-      "rationale": "Client-side claude-code concern (terminal, platform); not a gateway/relay relevance signal.",
-      "updated_at": "2026-06-01T12:33:27Z"
-    },
-    {
       "upstream": "anthropics/claude-code#63725",
       "url": "https://github.com/anthropics/claude-code/issues/63725",
       "title": "Workflow tool triggers on keyword 'workflow' in normal conversation",
@@ -13280,42 +15223,6 @@
       "updated_at": "2026-06-02T17:13:03Z"
     },
     {
-      "upstream": "anthropics/claude-code#63743",
-      "url": "https://github.com/anthropics/claude-code/issues/63743",
-      "title": "Regression (2.1.149 → 2.1.156): 1Password `op` CLI session broke in Bash tool calls on macOS",
-      "impact": "not_applicable",
-      "categories": [
-        "terminal"
-      ],
-      "tokenkey_status": "not_applicable",
-      "rationale": "Client-side claude-code concern (terminal); not a gateway/relay relevance signal.",
-      "updated_at": "2026-06-01T13:42:03Z"
-    },
-    {
-      "upstream": "anthropics/claude-code#63752",
-      "url": "https://github.com/anthropics/claude-code/issues/63752",
-      "title": "[Bug] Overly aggressive content filter blocks legitimate infrastructure debugging of timeout issues",
-      "impact": "not_applicable",
-      "categories": [
-        "terminal"
-      ],
-      "tokenkey_status": "not_applicable",
-      "rationale": "Client-side claude-code concern (terminal); not a gateway/relay relevance signal.",
-      "updated_at": "2026-06-01T06:28:22Z"
-    },
-    {
-      "upstream": "anthropics/claude-code#63755",
-      "url": "https://github.com/anthropics/claude-code/issues/63755",
-      "title": "[FEATURE] Add workflow tool to cloud scheduled tasks",
-      "impact": "not_applicable",
-      "categories": [
-        "mcp"
-      ],
-      "tokenkey_status": "not_applicable",
-      "rationale": "Client-side claude-code concern (mcp); not a gateway/relay relevance signal.",
-      "updated_at": "2026-06-01T07:12:51Z"
-    },
-    {
       "upstream": "anthropics/claude-code#63761",
       "url": "https://github.com/anthropics/claude-code/issues/63761",
       "title": "[Bug] Anthropic API Error: Usage credits required for 1M context with 1M context disabled",
@@ -13325,19 +15232,20 @@
       ],
       "tokenkey_status": "not_applicable",
       "rationale": "Client-side claude-code concern (terminal); not a gateway/relay relevance signal.",
-      "updated_at": "2026-06-01T16:55:50Z"
+      "updated_at": "2026-06-03T15:39:45Z"
     },
     {
-      "upstream": "anthropics/claude-code#63800",
-      "url": "https://github.com/anthropics/claude-code/issues/63800",
-      "title": "[Bug] opus 4.8 hangs indefinitely on tool calls after extended usage, freezes on messages ending with \"let me...\"",
+      "upstream": "anthropics/claude-code#63765",
+      "url": "https://github.com/anthropics/claude-code/issues/63765",
+      "title": "Renamed session titles don't persist + first user prompt ignored + panels reflow on new content",
       "impact": "not_applicable",
       "categories": [
-        "terminal"
+        "ide",
+        "platform"
       ],
       "tokenkey_status": "not_applicable",
-      "rationale": "Client-side claude-code concern (terminal); not a gateway/relay relevance signal.",
-      "updated_at": "2026-06-01T07:44:30Z"
+      "rationale": "Client-side claude-code concern (ide, platform); not a gateway/relay relevance signal.",
+      "updated_at": "2026-06-04T10:14:58Z"
     },
     {
       "upstream": "anthropics/claude-code#63839",
@@ -13352,44 +15260,6 @@
       "updated_at": "2026-06-01T21:11:40Z"
     },
     {
-      "upstream": "anthropics/claude-code#63860",
-      "url": "https://github.com/anthropics/claude-code/issues/63860",
-      "title": "[FEATURE] raw terminal output option",
-      "impact": "not_applicable",
-      "categories": [
-        "terminal"
-      ],
-      "tokenkey_status": "not_applicable",
-      "rationale": "Client-side claude-code concern (terminal); not a gateway/relay relevance signal.",
-      "updated_at": "2026-06-01T04:35:43Z"
-    },
-    {
-      "upstream": "anthropics/claude-code#63881",
-      "url": "https://github.com/anthropics/claude-code/issues/63881",
-      "title": "[Bug] Parallel tool calls hang on Bash execution errors",
-      "impact": "not_applicable",
-      "categories": [
-        "ide",
-        "terminal"
-      ],
-      "tokenkey_status": "not_applicable",
-      "rationale": "Client-side claude-code concern (ide, terminal); not a gateway/relay relevance signal.",
-      "updated_at": "2026-05-31T11:14:54Z"
-    },
-    {
-      "upstream": "anthropics/claude-code#63884",
-      "url": "https://github.com/anthropics/claude-code/issues/63884",
-      "title": "[MODEL] Opus 4.8 starts hallucinating results before parallel tasks finish",
-      "impact": "not_applicable",
-      "categories": [
-        "ide",
-        "terminal"
-      ],
-      "tokenkey_status": "not_applicable",
-      "rationale": "Client-side claude-code concern (ide, terminal); not a gateway/relay relevance signal.",
-      "updated_at": "2026-06-01T00:20:18Z"
-    },
-    {
       "upstream": "anthropics/claude-code#63903",
       "url": "https://github.com/anthropics/claude-code/issues/63903",
       "title": "[BUG] autoMemoryEnabled=false does not suppress the ~11-16k memory preamble (re: closed #44829)",
@@ -13399,7 +15269,7 @@
       ],
       "tokenkey_status": "not_applicable",
       "rationale": "Client-side claude-code concern (slash_hook); not a gateway/relay relevance signal.",
-      "updated_at": "2026-06-01T15:23:01Z"
+      "updated_at": "2026-06-03T13:18:39Z"
     },
     {
       "upstream": "anthropics/claude-code#63904",
@@ -13412,7 +15282,7 @@
       ],
       "tokenkey_status": "not_applicable",
       "rationale": "Client-side claude-code concern (terminal, platform); not a gateway/relay relevance signal.",
-      "updated_at": "2026-06-03T09:34:16Z"
+      "updated_at": "2026-06-04T09:33:24Z"
     },
     {
       "upstream": "anthropics/claude-code#63908",
@@ -13424,7 +15294,7 @@
       ],
       "tokenkey_status": "not_applicable",
       "rationale": "Client-side claude-code concern (terminal); not a gateway/relay relevance signal.",
-      "updated_at": "2026-06-02T21:52:06Z"
+      "updated_at": "2026-06-03T23:38:36Z"
     },
     {
       "upstream": "anthropics/claude-code#63925",
@@ -13453,35 +15323,6 @@
       "updated_at": "2026-06-01T16:43:46Z"
     },
     {
-      "upstream": "anthropics/claude-code#63954",
-      "url": "https://github.com/anthropics/claude-code/issues/63954",
-      "title": "[BUG] Abnormal Session Limit Drain Since Opus 4.8 Rollout (May 28, 2026) — VSCode Extension, Pro Plan, Windows",
-      "impact": "not_applicable",
-      "categories": [
-        "ide",
-        "terminal",
-        "platform"
-      ],
-      "tokenkey_status": "not_applicable",
-      "rationale": "Client-side claude-code concern (ide, terminal, platform); not a gateway/relay relevance signal.",
-      "updated_at": "2026-05-31T23:46:59Z"
-    },
-    {
-      "upstream": "anthropics/claude-code#64001",
-      "url": "https://github.com/anthropics/claude-code/issues/64001",
-      "title": "[BUG] Plugin directory does not render in Claude Desktop",
-      "impact": "not_applicable",
-      "categories": [
-        "terminal",
-        "plugin",
-        "install",
-        "platform"
-      ],
-      "tokenkey_status": "not_applicable",
-      "rationale": "Client-side claude-code concern (terminal, plugin, install, platform); not a gateway/relay relevance signal.",
-      "updated_at": "2026-05-31T23:15:08Z"
-    },
-    {
       "upstream": "anthropics/claude-code#64020",
       "url": "https://github.com/anthropics/claude-code/issues/64020",
       "title": "Animated gradient drains battery. Still causes ~40% WindowServer CPU with prefersReducedMotion:true (regression / #25575 not fixed)",
@@ -13493,30 +15334,6 @@
       "tokenkey_status": "not_applicable",
       "rationale": "Client-side claude-code concern (terminal, slash_hook); not a gateway/relay relevance signal.",
       "updated_at": "2026-06-02T08:06:41Z"
-    },
-    {
-      "upstream": "anthropics/claude-code#64048",
-      "url": "https://github.com/anthropics/claude-code/issues/64048",
-      "title": "[MODEL] Claude confabulated a prompt-injection payload in a file before the file-read result returned",
-      "impact": "not_applicable",
-      "categories": [
-        "slash_hook"
-      ],
-      "tokenkey_status": "not_applicable",
-      "rationale": "Client-side claude-code concern (slash_hook); not a gateway/relay relevance signal.",
-      "updated_at": "2026-05-31T16:19:47Z"
-    },
-    {
-      "upstream": "anthropics/claude-code#64086",
-      "url": "https://github.com/anthropics/claude-code/issues/64086",
-      "title": "Feature request: j/k vim navigation in interactive selection menus (e.g. /effort)",
-      "impact": "not_applicable",
-      "categories": [
-        "terminal"
-      ],
-      "tokenkey_status": "not_applicable",
-      "rationale": "Client-side claude-code concern (terminal); not a gateway/relay relevance signal.",
-      "updated_at": "2026-06-01T05:14:53Z"
     },
     {
       "upstream": "anthropics/claude-code#64108",
@@ -13543,109 +15360,6 @@
       "updated_at": "2026-06-02T23:15:41Z"
     },
     {
-      "upstream": "anthropics/claude-code#64144",
-      "url": "https://github.com/anthropics/claude-code/issues/64144",
-      "title": "In-flight /btw side conversation silently lost on Code -> Cowork -> Code switch (data loss)",
-      "impact": "not_applicable",
-      "categories": [
-        "terminal"
-      ],
-      "tokenkey_status": "not_applicable",
-      "rationale": "Client-side claude-code concern (terminal); not a gateway/relay relevance signal.",
-      "updated_at": "2026-05-31T22:17:37Z"
-    },
-    {
-      "upstream": "anthropics/claude-code#64192",
-      "url": "https://github.com/anthropics/claude-code/issues/64192",
-      "title": "TaskCreate 'task tools haven't been used recently' system-reminder fires repeatedly per long session — needs suppression knob (cross-repo from AaaS-Love/.claude#2048)",
-      "impact": "not_applicable",
-      "categories": [
-        "slash_hook"
-      ],
-      "tokenkey_status": "not_applicable",
-      "rationale": "Client-side claude-code concern (slash_hook); not a gateway/relay relevance signal.",
-      "updated_at": "2026-05-31T10:56:27Z"
-    },
-    {
-      "upstream": "anthropics/claude-code#64193",
-      "url": "https://github.com/anthropics/claude-code/issues/64193",
-      "title": "[Feature/UX] Yellow notification dot never clears on read + no way to configure dot behaviour",
-      "impact": "not_applicable",
-      "categories": [
-        "terminal",
-        "slash_hook",
-        "platform"
-      ],
-      "tokenkey_status": "not_applicable",
-      "rationale": "Client-side claude-code concern (terminal, slash_hook, platform); not a gateway/relay relevance signal.",
-      "updated_at": "2026-05-31T11:02:35Z"
-    },
-    {
-      "upstream": "anthropics/claude-code#64194",
-      "url": "https://github.com/anthropics/claude-code/issues/64194",
-      "title": "Token waste bug: Workflow spawned 44 parallel agents to read files instead of using git clone (2M tokens vs ~1000)",
-      "impact": "not_applicable",
-      "categories": [
-        "platform"
-      ],
-      "tokenkey_status": "not_applicable",
-      "rationale": "Client-side claude-code concern (platform); not a gateway/relay relevance signal.",
-      "updated_at": "2026-05-31T21:17:24Z"
-    },
-    {
-      "upstream": "anthropics/claude-code#64197",
-      "url": "https://github.com/anthropics/claude-code/issues/64197",
-      "title": "[BUG] macOS: npm/Homebrew install places native binary at bin/claude.exe, causing recurring \"claude.exe would like to access data from other apps\" TCC prompts",
-      "impact": "not_applicable",
-      "categories": [
-        "terminal",
-        "install",
-        "platform"
-      ],
-      "tokenkey_status": "not_applicable",
-      "rationale": "Client-side claude-code concern (terminal, install, platform); not a gateway/relay relevance signal.",
-      "updated_at": "2026-05-31T11:04:30Z"
-    },
-    {
-      "upstream": "anthropics/claude-code#64199",
-      "url": "https://github.com/anthropics/claude-code/issues/64199",
-      "title": "Unsent draft text lost when switching sessions (VS Code extension)",
-      "impact": "not_applicable",
-      "categories": [
-        "ide"
-      ],
-      "tokenkey_status": "not_applicable",
-      "rationale": "Client-side claude-code concern (ide); not a gateway/relay relevance signal.",
-      "updated_at": "2026-05-31T11:23:52Z"
-    },
-    {
-      "upstream": "anthropics/claude-code#64200",
-      "url": "https://github.com/anthropics/claude-code/issues/64200",
-      "title": "I'm ready to help generate a GitHub issue title for Claude Code, but I don't see a bug report in your message. Please provide the bug report details, and I'll create a concise technical issue title following the guidelines you've outlined.",
-      "impact": "not_applicable",
-      "categories": [
-        "ide",
-        "terminal"
-      ],
-      "tokenkey_status": "not_applicable",
-      "rationale": "Client-side claude-code concern (ide, terminal); not a gateway/relay relevance signal.",
-      "updated_at": "2026-05-31T11:21:18Z"
-    },
-    {
-      "upstream": "anthropics/claude-code#64201",
-      "url": "https://github.com/anthropics/claude-code/issues/64201",
-      "title": "[BUG] Title: Auth URL line-wraps in JetBrains IDE terminal, making clickable link invalid",
-      "impact": "not_applicable",
-      "categories": [
-        "ide",
-        "terminal",
-        "platform"
-      ],
-      "tokenkey_status": "not_applicable",
-      "rationale": "Client-side claude-code concern (ide, terminal, platform); not a gateway/relay relevance signal.",
-      "updated_at": "2026-05-31T11:24:28Z"
-    },
-    {
       "upstream": "anthropics/claude-code#64202",
       "url": "https://github.com/anthropics/claude-code/issues/64202",
       "title": "Regression in 2.1.158: claude -p hangs waiting for stdin EOF on Termux/arm64",
@@ -13656,169 +15370,6 @@
       "tokenkey_status": "not_applicable",
       "rationale": "Client-side claude-code concern (install); not a gateway/relay relevance signal.",
       "updated_at": "2026-06-02T01:28:06Z"
-    },
-    {
-      "upstream": "anthropics/claude-code#64203",
-      "url": "https://github.com/anthropics/claude-code/issues/64203",
-      "title": "[Bug Report: Model performance degradation on project tasks",
-      "impact": "not_applicable",
-      "categories": [
-        "terminal"
-      ],
-      "tokenkey_status": "not_applicable",
-      "rationale": "Client-side claude-code concern (terminal); not a gateway/relay relevance signal.",
-      "updated_at": "2026-05-31T11:49:18Z"
-    },
-    {
-      "upstream": "anthropics/claude-code#64204",
-      "url": "https://github.com/anthropics/claude-code/issues/64204",
-      "title": "[Feature Request] Message queuing for sequential task execution in VSCodeClaude extension",
-      "impact": "not_applicable",
-      "categories": [
-        "ide"
-      ],
-      "tokenkey_status": "not_applicable",
-      "rationale": "Client-side claude-code concern (ide); not a gateway/relay relevance signal.",
-      "updated_at": "2026-05-31T11:56:00Z"
-    },
-    {
-      "upstream": "anthropics/claude-code#64205",
-      "url": "https://github.com/anthropics/claude-code/issues/64205",
-      "title": "[Feature Request] Background task execution without conversation blocking in VSCode Claude extension",
-      "impact": "not_applicable",
-      "categories": [
-        "ide"
-      ],
-      "tokenkey_status": "not_applicable",
-      "rationale": "Client-side claude-code concern (ide); not a gateway/relay relevance signal.",
-      "updated_at": "2026-05-31T11:56:52Z"
-    },
-    {
-      "upstream": "anthropics/claude-code#64207",
-      "url": "https://github.com/anthropics/claude-code/issues/64207",
-      "title": "[FEATURE] Terminal (TUI): inline colored annotations + deferred batch reply to specific blocks of Claude's output (reviving #45904)",
-      "impact": "not_applicable",
-      "categories": [
-        "ide",
-        "terminal",
-        "platform"
-      ],
-      "tokenkey_status": "not_applicable",
-      "rationale": "Client-side claude-code concern (ide, terminal, platform); not a gateway/relay relevance signal.",
-      "updated_at": "2026-05-31T12:13:00Z"
-    },
-    {
-      "upstream": "anthropics/claude-code#64210",
-      "url": "https://github.com/anthropics/claude-code/issues/64210",
-      "title": "V8 out-of-memory crashes (SIGABRT) freeze/kill the TUI during long sessions on macOS",
-      "impact": "not_applicable",
-      "categories": [
-        "ide",
-        "terminal"
-      ],
-      "tokenkey_status": "not_applicable",
-      "rationale": "Client-side claude-code concern (ide, terminal); not a gateway/relay relevance signal.",
-      "updated_at": "2026-05-31T12:36:10Z"
-    },
-    {
-      "upstream": "anthropics/claude-code#64211",
-      "url": "https://github.com/anthropics/claude-code/issues/64211",
-      "title": "Session cut mid-task by credit limit — no warning, context lost, costly model switch",
-      "impact": "not_applicable",
-      "categories": [
-        "platform"
-      ],
-      "tokenkey_status": "not_applicable",
-      "rationale": "Client-side claude-code concern (platform); not a gateway/relay relevance signal.",
-      "updated_at": "2026-05-31T12:41:09Z"
-    },
-    {
-      "upstream": "anthropics/claude-code#64214",
-      "url": "https://github.com/anthropics/claude-code/issues/64214",
-      "title": "[BUG] Agent View (Linux): mouse wheel sends arrow keys instead of scrolling attached session — works on macOS, fails on all Linux terminals",
-      "impact": "not_applicable",
-      "categories": [
-        "terminal"
-      ],
-      "tokenkey_status": "not_applicable",
-      "rationale": "Client-side claude-code concern (terminal); not a gateway/relay relevance signal.",
-      "updated_at": "2026-06-01T09:10:14Z"
-    },
-    {
-      "upstream": "anthropics/claude-code#64215",
-      "url": "https://github.com/anthropics/claude-code/issues/64215",
-      "title": "iPad browser (vscode.dev): newlines not rendered in message display",
-      "impact": "not_applicable",
-      "categories": [
-        "ide",
-        "terminal"
-      ],
-      "tokenkey_status": "not_applicable",
-      "rationale": "Client-side claude-code concern (ide, terminal); not a gateway/relay relevance signal.",
-      "updated_at": "2026-05-31T12:55:16Z"
-    },
-    {
-      "upstream": "anthropics/claude-code#64217",
-      "url": "https://github.com/anthropics/claude-code/issues/64217",
-      "title": "[Bug] Tool use regression in version 4.8 causing premature termination and parallel execution issues",
-      "impact": "not_applicable",
-      "categories": [
-        "terminal"
-      ],
-      "tokenkey_status": "not_applicable",
-      "rationale": "Client-side claude-code concern (terminal); not a gateway/relay relevance signal.",
-      "updated_at": "2026-05-31T13:51:00Z"
-    },
-    {
-      "upstream": "anthropics/claude-code#64218",
-      "url": "https://github.com/anthropics/claude-code/issues/64218",
-      "title": "[Bug] Bash tool executes commands multiple times with duplicate outputs",
-      "impact": "not_applicable",
-      "categories": [
-        "terminal"
-      ],
-      "tokenkey_status": "not_applicable",
-      "rationale": "Client-side claude-code concern (terminal); not a gateway/relay relevance signal.",
-      "updated_at": "2026-05-31T13:42:20Z"
-    },
-    {
-      "upstream": "anthropics/claude-code#64219",
-      "url": "https://github.com/anthropics/claude-code/issues/64219",
-      "title": "[Bug] Tool results delivered with multi-turn lag and flushed in batch",
-      "impact": "not_applicable",
-      "categories": [
-        "terminal",
-        "slash_hook"
-      ],
-      "tokenkey_status": "not_applicable",
-      "rationale": "Client-side claude-code concern (terminal, slash_hook); not a gateway/relay relevance signal.",
-      "updated_at": "2026-05-31T13:18:58Z"
-    },
-    {
-      "upstream": "anthropics/claude-code#64220",
-      "url": "https://github.com/anthropics/claude-code/issues/64220",
-      "title": "[BUG] /init silently misses source files in repos with many files due to Glob truncation",
-      "impact": "not_applicable",
-      "categories": [
-        "terminal",
-        "install",
-        "platform"
-      ],
-      "tokenkey_status": "not_applicable",
-      "rationale": "Client-side claude-code concern (terminal, install, platform); not a gateway/relay relevance signal.",
-      "updated_at": "2026-05-31T13:18:32Z"
-    },
-    {
-      "upstream": "anthropics/claude-code#64221",
-      "url": "https://github.com/anthropics/claude-code/issues/64221",
-      "title": "[Bug] Reasoning interruption in ultramode v4.8+ requires manual restart",
-      "impact": "not_applicable",
-      "categories": [
-        "terminal"
-      ],
-      "tokenkey_status": "not_applicable",
-      "rationale": "Client-side claude-code concern (terminal); not a gateway/relay relevance signal.",
-      "updated_at": "2026-05-31T13:26:51Z"
     },
     {
       "upstream": "anthropics/claude-code#64222",
@@ -13833,175 +15384,6 @@
       "updated_at": "2026-06-02T16:59:11Z"
     },
     {
-      "upstream": "anthropics/claude-code#64224",
-      "url": "https://github.com/anthropics/claude-code/issues/64224",
-      "title": "Feature: first-class GitCommit action (bypass Bash argv for commit messages)",
-      "impact": "not_applicable",
-      "categories": [
-        "slash_hook",
-        "platform"
-      ],
-      "tokenkey_status": "not_applicable",
-      "rationale": "Client-side claude-code concern (slash_hook, platform); not a gateway/relay relevance signal.",
-      "updated_at": "2026-05-31T13:34:50Z"
-    },
-    {
-      "upstream": "anthropics/claude-code#64225",
-      "url": "https://github.com/anthropics/claude-code/issues/64225",
-      "title": "[BUG]",
-      "impact": "not_applicable",
-      "categories": [
-        "ide",
-        "terminal"
-      ],
-      "tokenkey_status": "not_applicable",
-      "rationale": "Client-side claude-code concern (ide, terminal); not a gateway/relay relevance signal.",
-      "updated_at": "2026-05-31T15:16:29Z"
-    },
-    {
-      "upstream": "anthropics/claude-code#64226",
-      "url": "https://github.com/anthropics/claude-code/issues/64226",
-      "title": "[BUG]",
-      "impact": "not_applicable",
-      "categories": [
-        "terminal",
-        "slash_hook",
-        "platform"
-      ],
-      "tokenkey_status": "not_applicable",
-      "rationale": "Client-side claude-code concern (terminal, slash_hook, platform); not a gateway/relay relevance signal.",
-      "updated_at": "2026-05-31T13:39:18Z"
-    },
-    {
-      "upstream": "anthropics/claude-code#64228",
-      "url": "https://github.com/anthropics/claude-code/issues/64228",
-      "title": "Tool results delayed and duplicated in interactive sessions (v2.1.158, Linux, multiple concurrent sessions)",
-      "impact": "not_applicable",
-      "categories": [
-        "terminal",
-        "slash_hook"
-      ],
-      "tokenkey_status": "not_applicable",
-      "rationale": "Client-side claude-code concern (terminal, slash_hook); not a gateway/relay relevance signal.",
-      "updated_at": "2026-05-31T20:29:07Z"
-    },
-    {
-      "upstream": "anthropics/claude-code#64230",
-      "url": "https://github.com/anthropics/claude-code/issues/64230",
-      "title": "False positive safety block on legitimate security audit tasks (Supabase RLS review, pnpm audit)",
-      "impact": "not_applicable",
-      "categories": [
-        "install"
-      ],
-      "tokenkey_status": "not_applicable",
-      "rationale": "Client-side claude-code concern (install); not a gateway/relay relevance signal.",
-      "updated_at": "2026-06-01T04:04:42Z"
-    },
-    {
-      "upstream": "anthropics/claude-code#64231",
-      "url": "https://github.com/anthropics/claude-code/issues/64231",
-      "title": "[FEATURE] programmatic conversation renaming in Claude Cowork",
-      "impact": "not_applicable",
-      "categories": [
-        "mcp"
-      ],
-      "tokenkey_status": "not_applicable",
-      "rationale": "Client-side claude-code concern (mcp); not a gateway/relay relevance signal.",
-      "updated_at": "2026-05-31T14:12:44Z"
-    },
-    {
-      "upstream": "anthropics/claude-code#64234",
-      "url": "https://github.com/anthropics/claude-code/issues/64234",
-      "title": "[BUG] Cowork \"Download failed\" on macOS — claude-code-vm runtime missing from app bundle",
-      "impact": "not_applicable",
-      "categories": [
-        "terminal",
-        "install"
-      ],
-      "tokenkey_status": "not_applicable",
-      "rationale": "Client-side claude-code concern (terminal, install); not a gateway/relay relevance signal.",
-      "updated_at": "2026-05-31T14:36:12Z"
-    },
-    {
-      "upstream": "anthropics/claude-code#64238",
-      "url": "https://github.com/anthropics/claude-code/issues/64238",
-      "title": "[FEATURE] Decouple LSP diagnostic auto-push from the LSP tool (keep navigation, drop publishDiagnostics)",
-      "impact": "not_applicable",
-      "categories": [
-        "plugin",
-        "slash_hook"
-      ],
-      "tokenkey_status": "not_applicable",
-      "rationale": "Client-side claude-code concern (plugin, slash_hook); not a gateway/relay relevance signal.",
-      "updated_at": "2026-05-31T14:50:31Z"
-    },
-    {
-      "upstream": "anthropics/claude-code#64239",
-      "url": "https://github.com/anthropics/claude-code/issues/64239",
-      "title": "[BUG] typescript-lsp pushes stale diagnostics on 2.1.158 (post-#17979) in TS project-references/composite workspaces",
-      "impact": "not_applicable",
-      "categories": [
-        "plugin",
-        "platform"
-      ],
-      "tokenkey_status": "not_applicable",
-      "rationale": "Client-side claude-code concern (plugin, platform); not a gateway/relay relevance signal.",
-      "updated_at": "2026-05-31T14:51:52Z"
-    },
-    {
-      "upstream": "anthropics/claude-code#64240",
-      "url": "https://github.com/anthropics/claude-code/issues/64240",
-      "title": "[BUG] Remote-control sessions (browser/mobile) silently drop attachments — shown as sent, never reach the model",
-      "impact": "not_applicable",
-      "categories": [
-        "ide",
-        "terminal",
-        "platform"
-      ],
-      "tokenkey_status": "not_applicable",
-      "rationale": "Client-side claude-code concern (ide, terminal, platform); not a gateway/relay relevance signal.",
-      "updated_at": "2026-05-31T14:54:33Z"
-    },
-    {
-      "upstream": "anthropics/claude-code#64242",
-      "url": "https://github.com/anthropics/claude-code/issues/64242",
-      "title": "iOS Dispatch sessions from mobile fail to spawn reliably",
-      "impact": "not_applicable",
-      "categories": [
-        "platform"
-      ],
-      "tokenkey_status": "not_applicable",
-      "rationale": "Client-side claude-code concern (platform); not a gateway/relay relevance signal.",
-      "updated_at": "2026-05-31T15:11:34Z"
-    },
-    {
-      "upstream": "anthropics/claude-code#64243",
-      "url": "https://github.com/anthropics/claude-code/issues/64243",
-      "title": "[BUG] Unable to copy `%PDF-1.6` text",
-      "impact": "not_applicable",
-      "categories": [
-        "terminal"
-      ],
-      "tokenkey_status": "not_applicable",
-      "rationale": "Client-side claude-code concern (terminal); not a gateway/relay relevance signal.",
-      "updated_at": "2026-05-31T15:15:04Z"
-    },
-    {
-      "upstream": "anthropics/claude-code#64244",
-      "url": "https://github.com/anthropics/claude-code/issues/64244",
-      "title": "Dispatch needs user-level persistent persona / identity injection",
-      "impact": "not_applicable",
-      "categories": [
-        "ide",
-        "mcp",
-        "slash_hook",
-        "platform"
-      ],
-      "tokenkey_status": "not_applicable",
-      "rationale": "Client-side claude-code concern (ide, mcp, slash_hook, platform); not a gateway/relay relevance signal.",
-      "updated_at": "2026-05-31T15:15:49Z"
-    },
-    {
       "upstream": "anthropics/claude-code#64247",
       "url": "https://github.com/anthropics/claude-code/issues/64247",
       "title": "[Bug] Parallel tool calls cancel all siblings on single error, which appears to cause model confusion",
@@ -14011,72 +15393,7 @@
       ],
       "tokenkey_status": "not_applicable",
       "rationale": "Client-side claude-code concern (terminal); not a gateway/relay relevance signal.",
-      "updated_at": "2026-05-31T17:35:40Z"
-    },
-    {
-      "upstream": "anthropics/claude-code#64248",
-      "url": "https://github.com/anthropics/claude-code/issues/64248",
-      "title": "[BUG] naming convention should not use \"-\" as the replacement for \"/\" as it creates file and directories that start with \"-\".",
-      "impact": "not_applicable",
-      "categories": [
-        "terminal"
-      ],
-      "tokenkey_status": "not_applicable",
-      "rationale": "Client-side claude-code concern (terminal); not a gateway/relay relevance signal.",
-      "updated_at": "2026-05-31T15:29:48Z"
-    },
-    {
-      "upstream": "anthropics/claude-code#64249",
-      "url": "https://github.com/anthropics/claude-code/issues/64249",
-      "title": "[Bug] Agent stalls without token consumption during execution",
-      "impact": "not_applicable",
-      "categories": [
-        "terminal"
-      ],
-      "tokenkey_status": "not_applicable",
-      "rationale": "Client-side claude-code concern (terminal); not a gateway/relay relevance signal.",
-      "updated_at": "2026-05-31T15:39:56Z"
-    },
-    {
-      "upstream": "anthropics/claude-code#64250",
-      "url": "https://github.com/anthropics/claude-code/issues/64250",
-      "title": "Advisor tool completes in UI but result never injected into model context (under Remote Control)",
-      "impact": "not_applicable",
-      "categories": [
-        "terminal",
-        "mcp"
-      ],
-      "tokenkey_status": "not_applicable",
-      "rationale": "Client-side claude-code concern (terminal, mcp); not a gateway/relay relevance signal.",
-      "updated_at": "2026-05-31T15:40:08Z"
-    },
-    {
-      "upstream": "anthropics/claude-code#64252",
-      "url": "https://github.com/anthropics/claude-code/issues/64252",
-      "title": "macOS: keybinding hint shows 'meta+w' instead of 'Option+w' (⌥W)",
-      "impact": "not_applicable",
-      "categories": [
-        "slash_hook",
-        "platform"
-      ],
-      "tokenkey_status": "not_applicable",
-      "rationale": "Client-side claude-code concern (slash_hook, platform); not a gateway/relay relevance signal.",
-      "updated_at": "2026-05-31T15:54:48Z"
-    },
-    {
-      "upstream": "anthropics/claude-code#64253",
-      "url": "https://github.com/anthropics/claude-code/issues/64253",
-      "title": "[BUG] Windows + Git Bash: tengu_cobalt_ridge experiment silently force-enables the PowerShell tool & \"Shell: PowerShell\", causing wrong-shell retries (token waste)",
-      "impact": "not_applicable",
-      "categories": [
-        "terminal",
-        "slash_hook",
-        "install",
-        "platform"
-      ],
-      "tokenkey_status": "not_applicable",
-      "rationale": "Client-side claude-code concern (terminal, slash_hook, install, platform); not a gateway/relay relevance signal.",
-      "updated_at": "2026-06-01T00:35:42Z"
+      "updated_at": "2026-06-03T12:09:08Z"
     },
     {
       "upstream": "anthropics/claude-code#64258",
@@ -14089,299 +15406,7 @@
       ],
       "tokenkey_status": "not_applicable",
       "rationale": "Client-side claude-code concern (terminal, platform); not a gateway/relay relevance signal.",
-      "updated_at": "2026-05-31T16:13:03Z"
-    },
-    {
-      "upstream": "anthropics/claude-code#64261",
-      "url": "https://github.com/anthropics/claude-code/issues/64261",
-      "title": "[Bug] Claude responding in Japanese when prompted in Chinese",
-      "impact": "not_applicable",
-      "categories": [
-        "terminal"
-      ],
-      "tokenkey_status": "not_applicable",
-      "rationale": "Client-side claude-code concern (terminal); not a gateway/relay relevance signal.",
-      "updated_at": "2026-05-31T16:32:41Z"
-    },
-    {
-      "upstream": "anthropics/claude-code#64262",
-      "url": "https://github.com/anthropics/claude-code/issues/64262",
-      "title": "[FEATURE] Allow users to opt out of post-compaction continuation injection via CLAUDE.md",
-      "impact": "not_applicable",
-      "categories": [
-        "ide"
-      ],
-      "tokenkey_status": "not_applicable",
-      "rationale": "Client-side claude-code concern (ide); not a gateway/relay relevance signal.",
-      "updated_at": "2026-05-31T16:46:05Z"
-    },
-    {
-      "upstream": "anthropics/claude-code#64263",
-      "url": "https://github.com/anthropics/claude-code/issues/64263",
-      "title": "[BUG] agent stuck: git-rebase preference + auto-mode -> blocked force pushes -> requires human intervention",
-      "impact": "not_applicable",
-      "categories": [
-        "terminal"
-      ],
-      "tokenkey_status": "not_applicable",
-      "rationale": "Client-side claude-code concern (terminal); not a gateway/relay relevance signal.",
-      "updated_at": "2026-05-31T16:48:30Z"
-    },
-    {
-      "upstream": "anthropics/claude-code#64264",
-      "url": "https://github.com/anthropics/claude-code/issues/64264",
-      "title": "[Feature] Add a user-facing toggle for spinner verbs / tool-use summaries in Claude Desktop",
-      "impact": "not_applicable",
-      "categories": [
-        "terminal",
-        "slash_hook"
-      ],
-      "tokenkey_status": "not_applicable",
-      "rationale": "Client-side claude-code concern (terminal, slash_hook); not a gateway/relay relevance signal.",
-      "updated_at": "2026-05-31T16:49:58Z"
-    },
-    {
-      "upstream": "anthropics/claude-code#64265",
-      "url": "https://github.com/anthropics/claude-code/issues/64265",
-      "title": "[BUG] Headless mode (`-p --output-format stream-json`) breaks AskUserQuestion handling — model continues on assumptions instead of stopping",
-      "impact": "not_applicable",
-      "categories": [
-        "terminal",
-        "slash_hook"
-      ],
-      "tokenkey_status": "not_applicable",
-      "rationale": "Client-side claude-code concern (terminal, slash_hook); not a gateway/relay relevance signal.",
-      "updated_at": "2026-05-31T16:57:35Z"
-    },
-    {
-      "upstream": "anthropics/claude-code#64268",
-      "url": "https://github.com/anthropics/claude-code/issues/64268",
-      "title": "[Bug] v2.1.156+ regression: native Read/Bash return fabricated-but-plausible content, triggering agent confabulation cascades",
-      "impact": "not_applicable",
-      "categories": [
-        "mcp"
-      ],
-      "tokenkey_status": "not_applicable",
-      "rationale": "Client-side claude-code concern (mcp); not a gateway/relay relevance signal.",
-      "updated_at": "2026-05-31T16:58:16Z"
-    },
-    {
-      "upstream": "anthropics/claude-code#64271",
-      "url": "https://github.com/anthropics/claude-code/issues/64271",
-      "title": "`claude --bg` code-writing sessions stall on permission prompts with no non-interactive way to reply (acceptEdits insufficient)",
-      "impact": "not_applicable",
-      "categories": [
-        "terminal",
-        "plugin",
-        "platform"
-      ],
-      "tokenkey_status": "not_applicable",
-      "rationale": "Client-side claude-code concern (terminal, plugin, platform); not a gateway/relay relevance signal.",
-      "updated_at": "2026-05-31T19:24:29Z"
-    },
-    {
-      "upstream": "anthropics/claude-code#64272",
-      "url": "https://github.com/anthropics/claude-code/issues/64272",
-      "title": "Docs: clarify that `claude --bg` / background dispatch sessions do not carry `agent_id` in hook payloads",
-      "impact": "not_applicable",
-      "categories": [
-        "terminal",
-        "plugin",
-        "slash_hook"
-      ],
-      "tokenkey_status": "not_applicable",
-      "rationale": "Client-side claude-code concern (terminal, plugin, slash_hook); not a gateway/relay relevance signal.",
-      "updated_at": "2026-05-31T17:23:49Z"
-    },
-    {
-      "upstream": "anthropics/claude-code#64273",
-      "url": "https://github.com/anthropics/claude-code/issues/64273",
-      "title": "Windows: background daemon keeps a directory handle after `claude rm`, blocking directory deletion",
-      "impact": "not_applicable",
-      "categories": [
-        "terminal",
-        "platform"
-      ],
-      "tokenkey_status": "not_applicable",
-      "rationale": "Client-side claude-code concern (terminal, platform); not a gateway/relay relevance signal.",
-      "updated_at": "2026-05-31T17:24:05Z"
-    },
-    {
-      "upstream": "anthropics/claude-code#64274",
-      "url": "https://github.com/anthropics/claude-code/issues/64274",
-      "title": "[Bug] Auto-accept mode ignores directory containment check for home paths ending in period",
-      "impact": "not_applicable",
-      "categories": [
-        "terminal",
-        "plugin"
-      ],
-      "tokenkey_status": "not_applicable",
-      "rationale": "Client-side claude-code concern (terminal, plugin); not a gateway/relay relevance signal.",
-      "updated_at": "2026-05-31T17:38:15Z"
-    },
-    {
-      "upstream": "anthropics/claude-code#64275",
-      "url": "https://github.com/anthropics/claude-code/issues/64275",
-      "title": "[BUG] `/insights` skill: AI-generated sections empty (returns {})",
-      "impact": "not_applicable",
-      "categories": [
-        "terminal"
-      ],
-      "tokenkey_status": "not_applicable",
-      "rationale": "Client-side claude-code concern (terminal); not a gateway/relay relevance signal.",
-      "updated_at": "2026-05-31T17:42:58Z"
-    },
-    {
-      "upstream": "anthropics/claude-code#64276",
-      "url": "https://github.com/anthropics/claude-code/issues/64276",
-      "title": "[BUG] LSP client never sends textDocument/didClose, leaking language-server resources until OOM",
-      "impact": "not_applicable",
-      "categories": [
-        "terminal",
-        "plugin",
-        "install"
-      ],
-      "tokenkey_status": "not_applicable",
-      "rationale": "Client-side claude-code concern (terminal, plugin, install); not a gateway/relay relevance signal.",
-      "updated_at": "2026-05-31T17:48:44Z"
-    },
-    {
-      "upstream": "anthropics/claude-code#64277",
-      "url": "https://github.com/anthropics/claude-code/issues/64277",
-      "title": "autoCompactEnabled does not trigger automatically despite being set to true",
-      "impact": "not_applicable",
-      "categories": [
-        "slash_hook"
-      ],
-      "tokenkey_status": "not_applicable",
-      "rationale": "Client-side claude-code concern (slash_hook); not a gateway/relay relevance signal.",
-      "updated_at": "2026-06-01T02:08:13Z"
-    },
-    {
-      "upstream": "anthropics/claude-code#64279",
-      "url": "https://github.com/anthropics/claude-code/issues/64279",
-      "title": "[Bug] Claude 4.8 model stuck in infinite loop executing spurious bash commands",
-      "impact": "not_applicable",
-      "categories": [
-        "ide",
-        "terminal"
-      ],
-      "tokenkey_status": "not_applicable",
-      "rationale": "Client-side claude-code concern (ide, terminal); not a gateway/relay relevance signal.",
-      "updated_at": "2026-06-01T03:03:11Z"
-    },
-    {
-      "upstream": "anthropics/claude-code#64282",
-      "url": "https://github.com/anthropics/claude-code/issues/64282",
-      "title": "[FEATURE] Per-banner \"Don't show again\" dismissal for MCP connection notifications",
-      "impact": "not_applicable",
-      "categories": [
-        "mcp",
-        "platform"
-      ],
-      "tokenkey_status": "not_applicable",
-      "rationale": "Client-side claude-code concern (mcp, platform); not a gateway/relay relevance signal.",
-      "updated_at": "2026-05-31T18:03:44Z"
-    },
-    {
-      "upstream": "anthropics/claude-code#64283",
-      "url": "https://github.com/anthropics/claude-code/issues/64283",
-      "title": "[Bug] Session cost significantly higher than expected; parallel agent forking causing excessive API usage",
-      "impact": "not_applicable",
-      "categories": [
-        "terminal",
-        "platform"
-      ],
-      "tokenkey_status": "not_applicable",
-      "rationale": "Client-side claude-code concern (terminal, platform); not a gateway/relay relevance signal.",
-      "updated_at": "2026-05-31T18:05:06Z"
-    },
-    {
-      "upstream": "anthropics/claude-code#64285",
-      "url": "https://github.com/anthropics/claude-code/issues/64285",
-      "title": "[Bug] Excessive token consumption on basic operations",
-      "impact": "not_applicable",
-      "categories": [
-        "ide",
-        "terminal"
-      ],
-      "tokenkey_status": "not_applicable",
-      "rationale": "Client-side claude-code concern (ide, terminal); not a gateway/relay relevance signal.",
-      "updated_at": "2026-05-31T18:13:55Z"
-    },
-    {
-      "upstream": "anthropics/claude-code#64286",
-      "url": "https://github.com/anthropics/claude-code/issues/64286",
-      "title": "[Bug] Claude Code fabricated test results and pushed untested code to main branch (Opus 4.8 @ Effort = High)",
-      "impact": "not_applicable",
-      "categories": [
-        "terminal"
-      ],
-      "tokenkey_status": "not_applicable",
-      "rationale": "Client-side claude-code concern (terminal); not a gateway/relay relevance signal.",
-      "updated_at": "2026-05-31T18:22:55Z"
-    },
-    {
-      "upstream": "anthropics/claude-code#64288",
-      "url": "https://github.com/anthropics/claude-code/issues/64288",
-      "title": "Ordered-list markdown in submitted messages gets auto-renumbered (e.g. '2.'/'5.' → '1.'/'2.'), clobbering intended numbering",
-      "impact": "not_applicable",
-      "categories": [
-        "terminal"
-      ],
-      "tokenkey_status": "not_applicable",
-      "rationale": "Client-side claude-code concern (terminal); not a gateway/relay relevance signal.",
-      "updated_at": "2026-05-31T18:16:08Z"
-    },
-    {
-      "upstream": "anthropics/claude-code#64289",
-      "url": "https://github.com/anthropics/claude-code/issues/64289",
-      "title": "Permission/question dialogs do not render in Ctrl+O transcript mode (UI hangs indefinitely)",
-      "impact": "not_applicable",
-      "categories": [
-        "terminal",
-        "install"
-      ],
-      "tokenkey_status": "not_applicable",
-      "rationale": "Client-side claude-code concern (terminal, install); not a gateway/relay relevance signal.",
-      "updated_at": "2026-05-31T18:19:48Z"
-    },
-    {
-      "upstream": "anthropics/claude-code#64290",
-      "url": "https://github.com/anthropics/claude-code/issues/64290",
-      "title": "[BUG] claude recommends adding non-existent directory to PATH",
-      "impact": "not_applicable",
-      "categories": [
-        "terminal",
-        "install"
-      ],
-      "tokenkey_status": "not_applicable",
-      "rationale": "Client-side claude-code concern (terminal, install); not a gateway/relay relevance signal.",
-      "updated_at": "2026-05-31T18:23:21Z"
-    },
-    {
-      "upstream": "anthropics/claude-code#64291",
-      "url": "https://github.com/anthropics/claude-code/issues/64291",
-      "title": "[Bug] Serializer-complete rule violation in conversation state management",
-      "impact": "not_applicable",
-      "categories": [
-        "terminal"
-      ],
-      "tokenkey_status": "not_applicable",
-      "rationale": "Client-side claude-code concern (terminal); not a gateway/relay relevance signal.",
-      "updated_at": "2026-05-31T18:26:25Z"
-    },
-    {
-      "upstream": "anthropics/claude-code#64292",
-      "url": "https://github.com/anthropics/claude-code/issues/64292",
-      "title": "[Bug] Auto-update failed - /doctor command produced no relevant output",
-      "impact": "not_applicable",
-      "categories": [
-        "terminal"
-      ],
-      "tokenkey_status": "not_applicable",
-      "rationale": "Client-side claude-code concern (terminal); not a gateway/relay relevance signal.",
-      "updated_at": "2026-05-31T18:33:16Z"
+      "updated_at": "2026-06-03T19:28:35Z"
     },
     {
       "upstream": "anthropics/claude-code#64293",
@@ -14395,44 +15420,6 @@
       "tokenkey_status": "not_applicable",
       "rationale": "Client-side claude-code concern (terminal, install); not a gateway/relay relevance signal.",
       "updated_at": "2026-06-03T04:45:53Z"
-    },
-    {
-      "upstream": "anthropics/claude-code#64294",
-      "url": "https://github.com/anthropics/claude-code/issues/64294",
-      "title": "Files being truncated by edit in cowork with no warning and way below the 32kb limit",
-      "impact": "not_applicable",
-      "categories": [
-        "terminal",
-        "platform"
-      ],
-      "tokenkey_status": "not_applicable",
-      "rationale": "Client-side claude-code concern (terminal, platform); not a gateway/relay relevance signal.",
-      "updated_at": "2026-05-31T18:42:13Z"
-    },
-    {
-      "upstream": "anthropics/claude-code#64295",
-      "url": "https://github.com/anthropics/claude-code/issues/64295",
-      "title": "[BUG] Opus 4.7 excess token usage in Windows - 7K tokens used 52%",
-      "impact": "not_applicable",
-      "categories": [
-        "terminal",
-        "platform"
-      ],
-      "tokenkey_status": "not_applicable",
-      "rationale": "Client-side claude-code concern (terminal, platform); not a gateway/relay relevance signal.",
-      "updated_at": "2026-05-31T18:53:17Z"
-    },
-    {
-      "upstream": "anthropics/claude-code#64296",
-      "url": "https://github.com/anthropics/claude-code/issues/64296",
-      "title": "MCP: re-enumerate tools mid-session for remote-control sessions (mcp_reconnect works but is unreachable)",
-      "impact": "not_applicable",
-      "categories": [
-        "mcp"
-      ],
-      "tokenkey_status": "not_applicable",
-      "rationale": "Client-side claude-code concern (mcp); not a gateway/relay relevance signal.",
-      "updated_at": "2026-05-31T22:06:54Z"
     },
     {
       "upstream": "anthropics/claude-code#64297",
@@ -14450,214 +15437,6 @@
       "updated_at": "2026-06-02T07:55:17Z"
     },
     {
-      "upstream": "anthropics/claude-code#64299",
-      "url": "https://github.com/anthropics/claude-code/issues/64299",
-      "title": "[Bug] Agent ignores user instructions, commands, and skills",
-      "impact": "not_applicable",
-      "categories": [
-        "terminal"
-      ],
-      "tokenkey_status": "not_applicable",
-      "rationale": "Client-side claude-code concern (terminal); not a gateway/relay relevance signal.",
-      "updated_at": "2026-06-01T13:06:01Z"
-    },
-    {
-      "upstream": "anthropics/claude-code#64300",
-      "url": "https://github.com/anthropics/claude-code/issues/64300",
-      "title": "`acceptEdits` mode does not extend to `additionalDirectories` (Edit/Write still prompt per-file)",
-      "impact": "not_applicable",
-      "categories": [
-        "ide"
-      ],
-      "tokenkey_status": "not_applicable",
-      "rationale": "Client-side claude-code concern (ide); not a gateway/relay relevance signal.",
-      "updated_at": "2026-05-31T19:23:30Z"
-    },
-    {
-      "upstream": "anthropics/claude-code#64301",
-      "url": "https://github.com/anthropics/claude-code/issues/64301",
-      "title": "Bash sandbox (bubblewrap) corrupts `!` to `\\!` in commands, making the sandbox unusable for agentic workflows",
-      "impact": "not_applicable",
-      "categories": [
-        "slash_hook",
-        "install"
-      ],
-      "tokenkey_status": "not_applicable",
-      "rationale": "Client-side claude-code concern (slash_hook, install); not a gateway/relay relevance signal.",
-      "updated_at": "2026-05-31T19:24:17Z"
-    },
-    {
-      "upstream": "anthropics/claude-code#64303",
-      "url": "https://github.com/anthropics/claude-code/issues/64303",
-      "title": "Workflow run shows \"Running 2032m\" indefinitely after the agent has died; cannot be stopped via UI Stop button or TaskStop (Run ID / Task ID both unknown)",
-      "impact": "not_applicable",
-      "categories": [
-        "plugin",
-        "platform"
-      ],
-      "tokenkey_status": "not_applicable",
-      "rationale": "Client-side claude-code concern (plugin, platform); not a gateway/relay relevance signal.",
-      "updated_at": "2026-05-31T19:57:20Z"
-    },
-    {
-      "upstream": "anthropics/claude-code#64304",
-      "url": "https://github.com/anthropics/claude-code/issues/64304",
-      "title": "Session title diverges between Desktop app and mobile/web — two independent title stores that never reconcile",
-      "impact": "not_applicable",
-      "categories": [
-        "ide",
-        "terminal",
-        "slash_hook",
-        "platform"
-      ],
-      "tokenkey_status": "not_applicable",
-      "rationale": "Client-side claude-code concern (ide, terminal, slash_hook, platform); not a gateway/relay relevance signal.",
-      "updated_at": "2026-05-31T20:13:25Z"
-    },
-    {
-      "upstream": "anthropics/claude-code#64309",
-      "url": "https://github.com/anthropics/claude-code/issues/64309",
-      "title": "Benign `node -e` regex script false-flagged as \"Fork bomb detected\"",
-      "impact": "not_applicable",
-      "categories": [
-        "ide",
-        "terminal"
-      ],
-      "tokenkey_status": "not_applicable",
-      "rationale": "Client-side claude-code concern (ide, terminal); not a gateway/relay relevance signal.",
-      "updated_at": "2026-05-31T20:01:29Z"
-    },
-    {
-      "upstream": "anthropics/claude-code#64310",
-      "url": "https://github.com/anthropics/claude-code/issues/64310",
-      "title": "Claude Code deleted client video files without confirmation — data loss on production work",
-      "impact": "not_applicable",
-      "categories": [
-        "platform"
-      ],
-      "tokenkey_status": "not_applicable",
-      "rationale": "Client-side claude-code concern (platform); not a gateway/relay relevance signal.",
-      "updated_at": "2026-05-31T20:55:32Z"
-    },
-    {
-      "upstream": "anthropics/claude-code#64311",
-      "url": "https://github.com/anthropics/claude-code/issues/64311",
-      "title": "Managed/team-seat config bypasses MCP tool-search deferral — claude.ai connector schemas re-inject into messages every turn (CC 2.1.158)",
-      "impact": "not_applicable",
-      "categories": [
-        "mcp",
-        "slash_hook"
-      ],
-      "tokenkey_status": "not_applicable",
-      "rationale": "Client-side claude-code concern (mcp, slash_hook); not a gateway/relay relevance signal.",
-      "updated_at": "2026-05-31T20:07:40Z"
-    },
-    {
-      "upstream": "anthropics/claude-code#64312",
-      "url": "https://github.com/anthropics/claude-code/issues/64312",
-      "title": "Claude Code context window not resetting — stuck at 1M instead of 200k on Pro",
-      "impact": "not_applicable",
-      "categories": [
-        "terminal",
-        "platform"
-      ],
-      "tokenkey_status": "not_applicable",
-      "rationale": "Client-side claude-code concern (terminal, platform); not a gateway/relay relevance signal.",
-      "updated_at": "2026-05-31T20:07:46Z"
-    },
-    {
-      "upstream": "anthropics/claude-code#64313",
-      "url": "https://github.com/anthropics/claude-code/issues/64313",
-      "title": "Feedback: Claude should observe existing layout structure before adding fixed/static UI elements",
-      "impact": "not_applicable",
-      "categories": [
-        "terminal"
-      ],
-      "tokenkey_status": "not_applicable",
-      "rationale": "Client-side claude-code concern (terminal); not a gateway/relay relevance signal.",
-      "updated_at": "2026-05-31T20:25:19Z"
-    },
-    {
-      "upstream": "anthropics/claude-code#64314",
-      "url": "https://github.com/anthropics/claude-code/issues/64314",
-      "title": "[Bug] Stray token \"count\" injected before tool calls causes parse failure in Claude Code",
-      "impact": "not_applicable",
-      "categories": [
-        "terminal",
-        "mcp"
-      ],
-      "tokenkey_status": "not_applicable",
-      "rationale": "Client-side claude-code concern (terminal, mcp); not a gateway/relay relevance signal.",
-      "updated_at": "2026-05-31T20:26:20Z"
-    },
-    {
-      "upstream": "anthropics/claude-code#64315",
-      "url": "https://github.com/anthropics/claude-code/issues/64315",
-      "title": "Agent tool: `isolation: \"worktree\"` creates worktree in session repo, not target repo, breaking parallel cross-repo work",
-      "impact": "not_applicable",
-      "categories": [
-        "plugin"
-      ],
-      "tokenkey_status": "not_applicable",
-      "rationale": "Client-side claude-code concern (plugin); not a gateway/relay relevance signal.",
-      "updated_at": "2026-05-31T20:26:53Z"
-    },
-    {
-      "upstream": "anthropics/claude-code#64316",
-      "url": "https://github.com/anthropics/claude-code/issues/64316",
-      "title": "[BUG] MCP: structuredContent overrides content field, losing actual tool response",
-      "impact": "not_applicable",
-      "categories": [
-        "ide",
-        "terminal",
-        "mcp",
-        "platform"
-      ],
-      "tokenkey_status": "not_applicable",
-      "rationale": "Client-side claude-code concern (ide, terminal, mcp, platform); not a gateway/relay relevance signal.",
-      "updated_at": "2026-05-31T20:46:50Z"
-    },
-    {
-      "upstream": "anthropics/claude-code#64318",
-      "url": "https://github.com/anthropics/claude-code/issues/64318",
-      "title": "computer-use MCP: browsers reported \"(not installed)\" on macOS when Spotlight is disabled, despite LaunchServices having them registered",
-      "impact": "not_applicable",
-      "categories": [
-        "mcp",
-        "install",
-        "platform"
-      ],
-      "tokenkey_status": "not_applicable",
-      "rationale": "Client-side claude-code concern (mcp, install, platform); not a gateway/relay relevance signal.",
-      "updated_at": "2026-05-31T20:32:48Z"
-    },
-    {
-      "upstream": "anthropics/claude-code#64319",
-      "url": "https://github.com/anthropics/claude-code/issues/64319",
-      "title": "Model autonomously deployed to production without user authorization",
-      "impact": "not_applicable",
-      "categories": [
-        "platform"
-      ],
-      "tokenkey_status": "not_applicable",
-      "rationale": "Client-side claude-code concern (platform); not a gateway/relay relevance signal.",
-      "updated_at": "2026-06-01T00:01:56Z"
-    },
-    {
-      "upstream": "anthropics/claude-code#64320",
-      "url": "https://github.com/anthropics/claude-code/issues/64320",
-      "title": "[BUG] Cowork shows \"yukonSilver not supported (status=unsupported)\" on Windows 11 Pro with 11th Gen Intel i5-1155G7 — VM never initializes",
-      "impact": "not_applicable",
-      "categories": [
-        "terminal",
-        "install",
-        "platform"
-      ],
-      "tokenkey_status": "not_applicable",
-      "rationale": "Client-side claude-code concern (terminal, install, platform); not a gateway/relay relevance signal.",
-      "updated_at": "2026-05-31T20:38:21Z"
-    },
-    {
       "upstream": "anthropics/claude-code#64324",
       "url": "https://github.com/anthropics/claude-code/issues/64324",
       "title": "[Bug] Claude Opus 4.8 API returning increased hallucinations",
@@ -14668,96 +15447,6 @@
       "tokenkey_status": "not_applicable",
       "rationale": "Client-side claude-code concern (terminal); not a gateway/relay relevance signal.",
       "updated_at": "2026-06-01T17:17:47Z"
-    },
-    {
-      "upstream": "anthropics/claude-code#64325",
-      "url": "https://github.com/anthropics/claude-code/issues/64325",
-      "title": "[Bug] Opus 4.8 hallucinating security incidents and fabricating evidence during long tasks",
-      "impact": "not_applicable",
-      "categories": [
-        "terminal",
-        "slash_hook"
-      ],
-      "tokenkey_status": "not_applicable",
-      "rationale": "Client-side claude-code concern (terminal, slash_hook); not a gateway/relay relevance signal.",
-      "updated_at": "2026-05-31T21:10:37Z"
-    },
-    {
-      "upstream": "anthropics/claude-code#64326",
-      "url": "https://github.com/anthropics/claude-code/issues/64326",
-      "title": "[Feature Request] PostToolUse hook で output 文字列を改変 (REDACT) する機能の追加",
-      "impact": "not_applicable",
-      "categories": [
-        "slash_hook"
-      ],
-      "tokenkey_status": "not_applicable",
-      "rationale": "Client-side claude-code concern (slash_hook); not a gateway/relay relevance signal.",
-      "updated_at": "2026-05-31T21:08:29Z"
-    },
-    {
-      "upstream": "anthropics/claude-code#64331",
-      "url": "https://github.com/anthropics/claude-code/issues/64331",
-      "title": "[FEATURE] Plan mode — AskUserQuestion modal covers the agent's analysis and can't be minimized",
-      "impact": "not_applicable",
-      "categories": [
-        "ide",
-        "terminal"
-      ],
-      "tokenkey_status": "not_applicable",
-      "rationale": "Client-side claude-code concern (ide, terminal); not a gateway/relay relevance signal.",
-      "updated_at": "2026-05-31T21:26:43Z"
-    },
-    {
-      "upstream": "anthropics/claude-code#64332",
-      "url": "https://github.com/anthropics/claude-code/issues/64332",
-      "title": "[BUG] Dispatch thread permanently stuck — server-side reset required",
-      "impact": "not_applicable",
-      "categories": [
-        "terminal",
-        "platform"
-      ],
-      "tokenkey_status": "not_applicable",
-      "rationale": "Client-side claude-code concern (terminal, platform); not a gateway/relay relevance signal.",
-      "updated_at": "2026-05-31T21:29:58Z"
-    },
-    {
-      "upstream": "anthropics/claude-code#64333",
-      "url": "https://github.com/anthropics/claude-code/issues/64333",
-      "title": "Batched/parallel tool calls: one failure cancels all siblings; Edit old_string match failures (Windows CRLF)",
-      "impact": "not_applicable",
-      "categories": [
-        "mcp",
-        "platform"
-      ],
-      "tokenkey_status": "not_applicable",
-      "rationale": "Client-side claude-code concern (mcp, platform); not a gateway/relay relevance signal.",
-      "updated_at": "2026-05-31T21:35:08Z"
-    },
-    {
-      "upstream": "anthropics/claude-code#64334",
-      "url": "https://github.com/anthropics/claude-code/issues/64334",
-      "title": "Bash command with 2>&1 causes ~12min spinner hang with token usage climbing during the stall",
-      "impact": "not_applicable",
-      "categories": [
-        "terminal",
-        "slash_hook"
-      ],
-      "tokenkey_status": "not_applicable",
-      "rationale": "Client-side claude-code concern (terminal, slash_hook); not a gateway/relay relevance signal.",
-      "updated_at": "2026-05-31T21:42:17Z"
-    },
-    {
-      "upstream": "anthropics/claude-code#64337",
-      "url": "https://github.com/anthropics/claude-code/issues/64337",
-      "title": "Bug: Remote Control via remoteControlAtStartup has no persistent indicator — startup notice scrolls off, nothing in status line / corner",
-      "impact": "not_applicable",
-      "categories": [
-        "terminal",
-        "slash_hook"
-      ],
-      "tokenkey_status": "not_applicable",
-      "rationale": "Client-side claude-code concern (terminal, slash_hook); not a gateway/relay relevance signal.",
-      "updated_at": "2026-05-31T22:08:11Z"
     },
     {
       "upstream": "anthropics/claude-code#64338",
@@ -14775,44 +15464,6 @@
       "updated_at": "2026-06-01T21:40:02Z"
     },
     {
-      "upstream": "anthropics/claude-code#64340",
-      "url": "https://github.com/anthropics/claude-code/issues/64340",
-      "title": "[Feature Request] Improve readline keybinding compatibility for word navigation (alt-f/alt-b)",
-      "impact": "not_applicable",
-      "categories": [
-        "terminal",
-        "slash_hook"
-      ],
-      "tokenkey_status": "not_applicable",
-      "rationale": "Client-side claude-code concern (terminal, slash_hook); not a gateway/relay relevance signal.",
-      "updated_at": "2026-05-31T22:25:52Z"
-    },
-    {
-      "upstream": "anthropics/claude-code#64341",
-      "url": "https://github.com/anthropics/claude-code/issues/64341",
-      "title": "[Bug] Model version inconsistency across devices with same account, requires reinstall",
-      "impact": "not_applicable",
-      "categories": [
-        "terminal",
-        "install"
-      ],
-      "tokenkey_status": "not_applicable",
-      "rationale": "Client-side claude-code concern (terminal, install); not a gateway/relay relevance signal.",
-      "updated_at": "2026-05-31T22:25:07Z"
-    },
-    {
-      "upstream": "anthropics/claude-code#64343",
-      "url": "https://github.com/anthropics/claude-code/issues/64343",
-      "title": "[Bug] Excessive token consumption from repeated echo tool calls",
-      "impact": "not_applicable",
-      "categories": [
-        "terminal"
-      ],
-      "tokenkey_status": "not_applicable",
-      "rationale": "Client-side claude-code concern (terminal); not a gateway/relay relevance signal.",
-      "updated_at": "2026-05-31T22:37:22Z"
-    },
-    {
       "upstream": "anthropics/claude-code#64349",
       "url": "https://github.com/anthropics/claude-code/issues/64349",
       "title": "Claude Code VS Code extension forces 1M context on Pro plan - Windows",
@@ -14826,56 +15477,7 @@
       ],
       "tokenkey_status": "not_applicable",
       "rationale": "Client-side claude-code concern (ide, terminal, slash_hook, install, platform); not a gateway/relay relevance signal.",
-      "updated_at": "2026-06-03T08:37:36Z"
-    },
-    {
-      "upstream": "anthropics/claude-code#64351",
-      "url": "https://github.com/anthropics/claude-code/issues/64351",
-      "title": "[Feature Request] Selective Context Compaction for Partial Message Pruning",
-      "impact": "not_applicable",
-      "categories": [
-        "terminal"
-      ],
-      "tokenkey_status": "not_applicable",
-      "rationale": "Client-side claude-code concern (terminal); not a gateway/relay relevance signal.",
-      "updated_at": "2026-05-31T23:06:48Z"
-    },
-    {
-      "upstream": "anthropics/claude-code#64352",
-      "url": "https://github.com/anthropics/claude-code/issues/64352",
-      "title": "Unprocessable image in context burns credits with no recovery path",
-      "impact": "not_applicable",
-      "categories": [
-        "ide",
-        "terminal"
-      ],
-      "tokenkey_status": "not_applicable",
-      "rationale": "Client-side claude-code concern (ide, terminal); not a gateway/relay relevance signal.",
-      "updated_at": "2026-06-01T03:15:38Z"
-    },
-    {
-      "upstream": "anthropics/claude-code#64353",
-      "url": "https://github.com/anthropics/claude-code/issues/64353",
-      "title": "Image attachments silently fail to upload when message has no text",
-      "impact": "not_applicable",
-      "categories": [
-        "platform"
-      ],
-      "tokenkey_status": "not_applicable",
-      "rationale": "Client-side claude-code concern (platform); not a gateway/relay relevance signal.",
-      "updated_at": "2026-05-31T23:20:10Z"
-    },
-    {
-      "upstream": "anthropics/claude-code#64356",
-      "url": "https://github.com/anthropics/claude-code/issues/64356",
-      "title": "[Bug] Agent stops responding after calling advisor tool",
-      "impact": "not_applicable",
-      "categories": [
-        "terminal"
-      ],
-      "tokenkey_status": "not_applicable",
-      "rationale": "Client-side claude-code concern (terminal); not a gateway/relay relevance signal.",
-      "updated_at": "2026-05-31T23:40:00Z"
+      "updated_at": "2026-06-04T06:20:59Z"
     },
     {
       "upstream": "anthropics/claude-code#64358",
@@ -14891,67 +15493,6 @@
       "updated_at": "2026-06-01T20:15:24Z"
     },
     {
-      "upstream": "anthropics/claude-code#64360",
-      "url": "https://github.com/anthropics/claude-code/issues/64360",
-      "title": "[BUG] Claude reaches usage limits waaaay to fast im comparison to just yesterday",
-      "impact": "not_applicable",
-      "categories": [
-        "terminal"
-      ],
-      "tokenkey_status": "not_applicable",
-      "rationale": "Client-side claude-code concern (terminal); not a gateway/relay relevance signal.",
-      "updated_at": "2026-06-01T00:54:21Z"
-    },
-    {
-      "upstream": "anthropics/claude-code#64361",
-      "url": "https://github.com/anthropics/claude-code/issues/64361",
-      "title": "SessionStart hooks crash when dispatcher routes through prompt-hook path expecting ToolUseContext",
-      "impact": "not_applicable",
-      "categories": [
-        "slash_hook"
-      ],
-      "tokenkey_status": "not_applicable",
-      "rationale": "Client-side claude-code concern (slash_hook); not a gateway/relay relevance signal.",
-      "updated_at": "2026-06-01T00:54:53Z"
-    },
-    {
-      "upstream": "anthropics/claude-code#64362",
-      "url": "https://github.com/anthropics/claude-code/issues/64362",
-      "title": "[Bug] Agent dispatch consumes excessive tokens without course-correction mechanism",
-      "impact": "not_applicable",
-      "categories": [
-        "terminal"
-      ],
-      "tokenkey_status": "not_applicable",
-      "rationale": "Client-side claude-code concern (terminal); not a gateway/relay relevance signal.",
-      "updated_at": "2026-06-01T03:07:07Z"
-    },
-    {
-      "upstream": "anthropics/claude-code#64363",
-      "url": "https://github.com/anthropics/claude-code/issues/64363",
-      "title": "Permission dialog: make button order configurable",
-      "impact": "not_applicable",
-      "categories": [
-        "slash_hook"
-      ],
-      "tokenkey_status": "not_applicable",
-      "rationale": "Client-side claude-code concern (slash_hook); not a gateway/relay relevance signal.",
-      "updated_at": "2026-06-01T02:47:16Z"
-    },
-    {
-      "upstream": "anthropics/claude-code#64365",
-      "url": "https://github.com/anthropics/claude-code/issues/64365",
-      "title": "[BUG] Claude Code executed destructive command (adb shell pm clear) against explicit user instruction, causing permanent data loss",
-      "impact": "not_applicable",
-      "categories": [
-        "terminal",
-        "platform"
-      ],
-      "tokenkey_status": "not_applicable",
-      "rationale": "Client-side claude-code concern (terminal, platform); not a gateway/relay relevance signal.",
-      "updated_at": "2026-06-01T03:07:00Z"
-    },
-    {
       "upstream": "anthropics/claude-code#64366",
       "url": "https://github.com/anthropics/claude-code/issues/64366",
       "title": "[BUG] Unbounded MCP server fan-out across Cowork/agent sessions exhausts RAM and kernel-panics macOS (4 panics + forced power-off on M2 Max / 32 GB)",
@@ -14965,80 +15506,6 @@
       "updated_at": "2026-06-02T14:12:50Z"
     },
     {
-      "upstream": "anthropics/claude-code#64367",
-      "url": "https://github.com/anthropics/claude-code/issues/64367",
-      "title": "Conversational-deferral (patcher) behavior evades anti-defer hooks: file-content scope + ≥2-occurrence threshold blind spots",
-      "impact": "not_applicable",
-      "categories": [
-        "slash_hook"
-      ],
-      "tokenkey_status": "not_applicable",
-      "rationale": "Client-side claude-code concern (slash_hook); not a gateway/relay relevance signal.",
-      "updated_at": "2026-06-01T01:38:29Z"
-    },
-    {
-      "upstream": "anthropics/claude-code#64368",
-      "url": "https://github.com/anthropics/claude-code/issues/64368",
-      "title": "[Bug] Auto-compact triggered during commit skill causes context limit errors",
-      "impact": "not_applicable",
-      "categories": [
-        "terminal"
-      ],
-      "tokenkey_status": "not_applicable",
-      "rationale": "Client-side claude-code concern (terminal); not a gateway/relay relevance signal.",
-      "updated_at": "2026-06-01T01:41:32Z"
-    },
-    {
-      "upstream": "anthropics/claude-code#64371",
-      "url": "https://github.com/anthropics/claude-code/issues/64371",
-      "title": "Ability to delete conversation portions from context messages",
-      "impact": "not_applicable",
-      "categories": [
-        "terminal"
-      ],
-      "tokenkey_status": "not_applicable",
-      "rationale": "Client-side claude-code concern (terminal); not a gateway/relay relevance signal.",
-      "updated_at": "2026-06-01T03:16:29Z"
-    },
-    {
-      "upstream": "anthropics/claude-code#64372",
-      "url": "https://github.com/anthropics/claude-code/issues/64372",
-      "title": "[BUG] Routine scheduler skips Monday when timezone is UTC+8 (SGT/CST) — weekday check applied in UTC instead of local time",
-      "impact": "not_applicable",
-      "categories": [
-        "terminal"
-      ],
-      "tokenkey_status": "not_applicable",
-      "rationale": "Client-side claude-code concern (terminal); not a gateway/relay relevance signal.",
-      "updated_at": "2026-06-01T01:53:52Z"
-    },
-    {
-      "upstream": "anthropics/claude-code#64375",
-      "url": "https://github.com/anthropics/claude-code/issues/64375",
-      "title": "[Bug] Frequent tool execution errors with Claude 4.8 Opus model",
-      "impact": "not_applicable",
-      "categories": [
-        "ide",
-        "terminal"
-      ],
-      "tokenkey_status": "not_applicable",
-      "rationale": "Client-side claude-code concern (ide, terminal); not a gateway/relay relevance signal.",
-      "updated_at": "2026-06-01T02:27:18Z"
-    },
-    {
-      "upstream": "anthropics/claude-code#64376",
-      "url": "https://github.com/anthropics/claude-code/issues/64376",
-      "title": "[FEATURE] Multiple subscription account",
-      "impact": "not_applicable",
-      "categories": [
-        "terminal",
-        "platform"
-      ],
-      "tokenkey_status": "not_applicable",
-      "rationale": "Client-side claude-code concern (terminal, platform); not a gateway/relay relevance signal.",
-      "updated_at": "2026-06-01T02:03:33Z"
-    },
-    {
       "upstream": "anthropics/claude-code#64377",
       "url": "https://github.com/anthropics/claude-code/issues/64377",
       "title": "[BUG] Why I can not use Sonnet even I have enough quota?!",
@@ -15050,31 +15517,6 @@
       "tokenkey_status": "not_applicable",
       "rationale": "Client-side claude-code concern (terminal, platform); not a gateway/relay relevance signal.",
       "updated_at": "2026-06-01T16:12:40Z"
-    },
-    {
-      "upstream": "anthropics/claude-code#64378",
-      "url": "https://github.com/anthropics/claude-code/issues/64378",
-      "title": "illegal hardware instruction\" on Intel Core i5-3470S (Ivy Bridge, no AVX2) - crashes on startup",
-      "impact": "not_applicable",
-      "categories": [
-        "terminal",
-        "install"
-      ],
-      "tokenkey_status": "not_applicable",
-      "rationale": "Client-side claude-code concern (terminal, install); not a gateway/relay relevance signal.",
-      "updated_at": "2026-06-01T03:06:59Z"
-    },
-    {
-      "upstream": "anthropics/claude-code#64380",
-      "url": "https://github.com/anthropics/claude-code/issues/64380",
-      "title": "[BUG] iPad: app crashes (SIGABRT) when tapping \"Default\" environment picker — UICollectionView invalid scroll index path",
-      "impact": "not_applicable",
-      "categories": [
-        "terminal"
-      ],
-      "tokenkey_status": "not_applicable",
-      "rationale": "Client-side claude-code concern (terminal); not a gateway/relay relevance signal.",
-      "updated_at": "2026-06-01T03:06:58Z"
     },
     {
       "upstream": "anthropics/claude-code#64381",
@@ -15091,126 +15533,6 @@
       "updated_at": "2026-06-03T08:33:47Z"
     },
     {
-      "upstream": "anthropics/claude-code#64389",
-      "url": "https://github.com/anthropics/claude-code/issues/64389",
-      "title": "PreToolUse(Bash) hook returning permissionDecision: \"defer\" causes \"[Tool result missing due to internal error]\"",
-      "impact": "not_applicable",
-      "categories": [
-        "ide",
-        "slash_hook"
-      ],
-      "tokenkey_status": "not_applicable",
-      "rationale": "Client-side claude-code concern (ide, slash_hook); not a gateway/relay relevance signal.",
-      "updated_at": "2026-06-01T03:59:51Z"
-    },
-    {
-      "upstream": "anthropics/claude-code#64390",
-      "url": "https://github.com/anthropics/claude-code/issues/64390",
-      "title": "Tool-result transport desync/replay/fabrication in claude remote-control daemon under large parallel tool batches",
-      "impact": "not_applicable",
-      "categories": [
-        "terminal",
-        "mcp"
-      ],
-      "tokenkey_status": "not_applicable",
-      "rationale": "Client-side claude-code concern (terminal, mcp); not a gateway/relay relevance signal.",
-      "updated_at": "2026-06-01T04:02:22Z"
-    },
-    {
-      "upstream": "anthropics/claude-code#64391",
-      "url": "https://github.com/anthropics/claude-code/issues/64391",
-      "title": "[BUG] Warning \"Near weekly limit\" triggered at only 26% weekly usage",
-      "impact": "not_applicable",
-      "categories": [
-        "terminal",
-        "platform"
-      ],
-      "tokenkey_status": "not_applicable",
-      "rationale": "Client-side claude-code concern (terminal, platform); not a gateway/relay relevance signal.",
-      "updated_at": "2026-06-01T04:03:43Z"
-    },
-    {
-      "upstream": "anthropics/claude-code#64394",
-      "url": "https://github.com/anthropics/claude-code/issues/64394",
-      "title": "Feature request: UEStudio (UltraEdit Studio) IDE extension",
-      "impact": "not_applicable",
-      "categories": [
-        "ide",
-        "platform"
-      ],
-      "tokenkey_status": "not_applicable",
-      "rationale": "Client-side claude-code concern (ide, platform); not a gateway/relay relevance signal.",
-      "updated_at": "2026-06-01T04:24:53Z"
-    },
-    {
-      "upstream": "anthropics/claude-code#64395",
-      "url": "https://github.com/anthropics/claude-code/issues/64395",
-      "title": "[BUG] feature-dev plugin breaks Ctrl+V (paste) in Claude Code on Windows",
-      "impact": "not_applicable",
-      "categories": [
-        "terminal",
-        "plugin",
-        "slash_hook",
-        "platform"
-      ],
-      "tokenkey_status": "not_applicable",
-      "rationale": "Client-side claude-code concern (terminal, plugin, slash_hook, platform); not a gateway/relay relevance signal.",
-      "updated_at": "2026-06-01T04:37:46Z"
-    },
-    {
-      "upstream": "anthropics/claude-code#64398",
-      "url": "https://github.com/anthropics/claude-code/issues/64398",
-      "title": "[BUG] Pro plan blocked by \"Usage credits required for 1M context\" — no workaround works, quota available",
-      "impact": "not_applicable",
-      "categories": [
-        "ide",
-        "terminal",
-        "slash_hook",
-        "platform"
-      ],
-      "tokenkey_status": "not_applicable",
-      "rationale": "Client-side claude-code concern (ide, terminal, slash_hook, platform); not a gateway/relay relevance signal.",
-      "updated_at": "2026-06-01T05:19:16Z"
-    },
-    {
-      "upstream": "anthropics/claude-code#64399",
-      "url": "https://github.com/anthropics/claude-code/issues/64399",
-      "title": "[Bug] VSCode extension terminal setup writes keybindings to DEFAULT PROFILE instead of selected profile",
-      "impact": "not_applicable",
-      "categories": [
-        "ide",
-        "terminal",
-        "slash_hook"
-      ],
-      "tokenkey_status": "not_applicable",
-      "rationale": "Client-side claude-code concern (ide, terminal, slash_hook); not a gateway/relay relevance signal.",
-      "updated_at": "2026-06-01T05:29:43Z"
-    },
-    {
-      "upstream": "anthropics/claude-code#64400",
-      "url": "https://github.com/anthropics/claude-code/issues/64400",
-      "title": "[BUG] Keyword highlight inconsistently preserved in queued messages",
-      "impact": "not_applicable",
-      "categories": [
-        "terminal"
-      ],
-      "tokenkey_status": "not_applicable",
-      "rationale": "Client-side claude-code concern (terminal); not a gateway/relay relevance signal.",
-      "updated_at": "2026-06-01T05:20:49Z"
-    },
-    {
-      "upstream": "anthropics/claude-code#64401",
-      "url": "https://github.com/anthropics/claude-code/issues/64401",
-      "title": "[UX] Can't switch model without clearing typed input — need keybinding or inline shortcut",
-      "impact": "not_applicable",
-      "categories": [
-        "slash_hook"
-      ],
-      "tokenkey_status": "not_applicable",
-      "rationale": "Client-side claude-code concern (slash_hook); not a gateway/relay relevance signal.",
-      "updated_at": "2026-06-01T05:23:40Z"
-    },
-    {
       "upstream": "anthropics/claude-code#64403",
       "url": "https://github.com/anthropics/claude-code/issues/64403",
       "title": "[BUG] Session history silently wiped after app update — no server-side backup, no export, no warning",
@@ -15220,344 +15542,7 @@
       ],
       "tokenkey_status": "not_applicable",
       "rationale": "Client-side claude-code concern (terminal); not a gateway/relay relevance signal.",
-      "updated_at": "2026-06-01T08:40:38Z"
-    },
-    {
-      "upstream": "anthropics/claude-code#64404",
-      "url": "https://github.com/anthropics/claude-code/issues/64404",
-      "title": "[Bug] Infinite loop when displaying `court` word",
-      "impact": "not_applicable",
-      "categories": [
-        "terminal"
-      ],
-      "tokenkey_status": "not_applicable",
-      "rationale": "Client-side claude-code concern (terminal); not a gateway/relay relevance signal.",
-      "updated_at": "2026-06-01T05:58:31Z"
-    },
-    {
-      "upstream": "anthropics/claude-code#64406",
-      "url": "https://github.com/anthropics/claude-code/issues/64406",
-      "title": "[FEATURE] Allow PreToolUse hook output to render before tool execution (non-blocking)",
-      "impact": "not_applicable",
-      "categories": [
-        "terminal",
-        "mcp",
-        "slash_hook"
-      ],
-      "tokenkey_status": "not_applicable",
-      "rationale": "Client-side claude-code concern (terminal, mcp, slash_hook); not a gateway/relay relevance signal.",
-      "updated_at": "2026-06-01T06:05:15Z"
-    },
-    {
-      "upstream": "anthropics/claude-code#64407",
-      "url": "https://github.com/anthropics/claude-code/issues/64407",
-      "title": "Feature Request: Chinese / multilingual UI localization for permission prompts",
-      "impact": "not_applicable",
-      "categories": [
-        "slash_hook"
-      ],
-      "tokenkey_status": "not_applicable",
-      "rationale": "Client-side claude-code concern (slash_hook); not a gateway/relay relevance signal.",
-      "updated_at": "2026-06-01T06:23:19Z"
-    },
-    {
-      "upstream": "anthropics/claude-code#64411",
-      "url": "https://github.com/anthropics/claude-code/issues/64411",
-      "title": "Feature: Hot-reload harness (version/plugins) for running background sessions without losing conversation history",
-      "impact": "not_applicable",
-      "categories": [
-        "plugin",
-        "slash_hook"
-      ],
-      "tokenkey_status": "not_applicable",
-      "rationale": "Client-side claude-code concern (plugin, slash_hook); not a gateway/relay relevance signal.",
-      "updated_at": "2026-06-01T06:50:47Z"
-    },
-    {
-      "upstream": "anthropics/claude-code#64412",
-      "url": "https://github.com/anthropics/claude-code/issues/64412",
-      "title": "[BUG] Stdio MCP server receives a CLAUDE_CODE_SESSION_ID different from the value passed to hooks / Bash tool on --resume sessions",
-      "impact": "not_applicable",
-      "categories": [
-        "mcp",
-        "plugin",
-        "slash_hook"
-      ],
-      "tokenkey_status": "not_applicable",
-      "rationale": "Client-side claude-code concern (mcp, plugin, slash_hook); not a gateway/relay relevance signal.",
-      "updated_at": "2026-06-01T06:53:59Z"
-    },
-    {
-      "upstream": "anthropics/claude-code#64413",
-      "url": "https://github.com/anthropics/claude-code/issues/64413",
-      "title": "[BUG] \"workflow\" keyword in user message forces model to invoke Workflow tool even in purely conversational/investigative context",
-      "impact": "not_applicable",
-      "categories": [
-        "terminal",
-        "slash_hook"
-      ],
-      "tokenkey_status": "not_applicable",
-      "rationale": "Client-side claude-code concern (terminal, slash_hook); not a gateway/relay relevance signal.",
-      "updated_at": "2026-06-01T07:04:42Z"
-    },
-    {
-      "upstream": "anthropics/claude-code#64415",
-      "url": "https://github.com/anthropics/claude-code/issues/64415",
-      "title": "[FEATURE] Programmatic session rename API for skills/agents",
-      "impact": "not_applicable",
-      "categories": [
-        "mcp",
-        "slash_hook",
-        "platform"
-      ],
-      "tokenkey_status": "not_applicable",
-      "rationale": "Client-side claude-code concern (mcp, slash_hook, platform); not a gateway/relay relevance signal.",
-      "updated_at": "2026-06-01T07:18:38Z"
-    },
-    {
-      "upstream": "anthropics/claude-code#64416",
-      "url": "https://github.com/anthropics/claude-code/issues/64416",
-      "title": "[BUG] Claude spent 33+ minutes and 18k+ tokens debugging a Gradle build that was actually just an Android Studio version incompatibility",
-      "impact": "not_applicable",
-      "categories": [
-        "terminal"
-      ],
-      "tokenkey_status": "not_applicable",
-      "rationale": "Client-side claude-code concern (terminal); not a gateway/relay relevance signal.",
-      "updated_at": "2026-06-01T07:20:02Z"
-    },
-    {
-      "upstream": "anthropics/claude-code#64417",
-      "url": "https://github.com/anthropics/claude-code/issues/64417",
-      "title": "Project memory bleeds across accounts — personal project context loads in work account session",
-      "impact": "not_applicable",
-      "categories": [
-        "terminal"
-      ],
-      "tokenkey_status": "not_applicable",
-      "rationale": "Client-side claude-code concern (terminal); not a gateway/relay relevance signal.",
-      "updated_at": "2026-06-01T07:20:58Z"
-    },
-    {
-      "upstream": "anthropics/claude-code#64419",
-      "url": "https://github.com/anthropics/claude-code/issues/64419",
-      "title": "[Bug] Missing /remote command implementation",
-      "impact": "not_applicable",
-      "categories": [
-        "terminal"
-      ],
-      "tokenkey_status": "not_applicable",
-      "rationale": "Client-side claude-code concern (terminal); not a gateway/relay relevance signal.",
-      "updated_at": "2026-06-01T07:36:21Z"
-    },
-    {
-      "upstream": "anthropics/claude-code#64421",
-      "url": "https://github.com/anthropics/claude-code/issues/64421",
-      "title": "[BUG] Max 20x account consumed 20% 5hr of tokens in 5mins with one session and lesss than 5k token usage",
-      "impact": "not_applicable",
-      "categories": [
-        "terminal"
-      ],
-      "tokenkey_status": "not_applicable",
-      "rationale": "Client-side claude-code concern (terminal); not a gateway/relay relevance signal.",
-      "updated_at": "2026-06-01T07:51:04Z"
-    },
-    {
-      "upstream": "anthropics/claude-code#64429",
-      "url": "https://github.com/anthropics/claude-code/issues/64429",
-      "title": "[Bug] Satisfaction poll UI causes accidental low ratings due to unclear alternatives presentation",
-      "impact": "not_applicable",
-      "categories": [
-        "terminal"
-      ],
-      "tokenkey_status": "not_applicable",
-      "rationale": "Client-side claude-code concern (terminal); not a gateway/relay relevance signal.",
-      "updated_at": "2026-06-01T08:13:48Z"
-    },
-    {
-      "upstream": "anthropics/claude-code#64430",
-      "url": "https://github.com/anthropics/claude-code/issues/64430",
-      "title": "[VS Code] Renaming a session in Session History panel does not persist (reverts to auto-generated title)",
-      "impact": "not_applicable",
-      "categories": [
-        "ide",
-        "plugin",
-        "slash_hook",
-        "platform"
-      ],
-      "tokenkey_status": "not_applicable",
-      "rationale": "Client-side claude-code concern (ide, plugin, slash_hook, platform); not a gateway/relay relevance signal.",
-      "updated_at": "2026-06-01T08:22:40Z"
-    },
-    {
-      "upstream": "anthropics/claude-code#64431",
-      "url": "https://github.com/anthropics/claude-code/issues/64431",
-      "title": "/plugin install fails with \"source type your Claude Code version does not support\" for a marketplace plugin whose source is \".\" (reproduces on latest)",
-      "impact": "not_applicable",
-      "categories": [
-        "plugin",
-        "install"
-      ],
-      "tokenkey_status": "not_applicable",
-      "rationale": "Client-side claude-code concern (plugin, install); not a gateway/relay relevance signal.",
-      "updated_at": "2026-06-01T08:29:01Z"
-    },
-    {
-      "upstream": "anthropics/claude-code#64433",
-      "url": "https://github.com/anthropics/claude-code/issues/64433",
-      "title": "[BUG] Desktop local-agent (Claude Code): 900s session idle timeout tears down the computer-use connector and never re-registers it on resume",
-      "impact": "not_applicable",
-      "categories": [
-        "terminal",
-        "platform"
-      ],
-      "tokenkey_status": "not_applicable",
-      "rationale": "Client-side claude-code concern (terminal, platform); not a gateway/relay relevance signal.",
-      "updated_at": "2026-06-01T08:36:02Z"
-    },
-    {
-      "upstream": "anthropics/claude-code#64434",
-      "url": "https://github.com/anthropics/claude-code/issues/64434",
-      "title": "[Bug] Claude unable to fix recurring overlay issue across multiple prompts",
-      "impact": "not_applicable",
-      "categories": [
-        "terminal"
-      ],
-      "tokenkey_status": "not_applicable",
-      "rationale": "Client-side claude-code concern (terminal); not a gateway/relay relevance signal.",
-      "updated_at": "2026-06-01T08:35:51Z"
-    },
-    {
-      "upstream": "anthropics/claude-code#64435",
-      "url": "https://github.com/anthropics/claude-code/issues/64435",
-      "title": "[Bug] Persistent display overlay issue not resolved across multiple prompts",
-      "impact": "not_applicable",
-      "categories": [
-        "terminal"
-      ],
-      "tokenkey_status": "not_applicable",
-      "rationale": "Client-side claude-code concern (terminal); not a gateway/relay relevance signal.",
-      "updated_at": "2026-06-01T08:38:33Z"
-    },
-    {
-      "upstream": "anthropics/claude-code#64440",
-      "url": "https://github.com/anthropics/claude-code/issues/64440",
-      "title": "[Bug] Ultrareview consumed free credit on crash with zero findings",
-      "impact": "not_applicable",
-      "categories": [
-        "terminal"
-      ],
-      "tokenkey_status": "not_applicable",
-      "rationale": "Client-side claude-code concern (terminal); not a gateway/relay relevance signal.",
-      "updated_at": "2026-06-01T09:06:13Z"
-    },
-    {
-      "upstream": "anthropics/claude-code#64442",
-      "url": "https://github.com/anthropics/claude-code/issues/64442",
-      "title": "Bridge session disappears from desktop session picker after archive→unarchive cycle",
-      "impact": "not_applicable",
-      "categories": [
-        "terminal",
-        "platform"
-      ],
-      "tokenkey_status": "not_applicable",
-      "rationale": "Client-side claude-code concern (terminal, platform); not a gateway/relay relevance signal.",
-      "updated_at": "2026-06-01T09:13:50Z"
-    },
-    {
-      "upstream": "anthropics/claude-code#64443",
-      "url": "https://github.com/anthropics/claude-code/issues/64443",
-      "title": "[BUG] \"Usage credits required for 1M context\" error persists after plan recharge on VS Code extension",
-      "impact": "not_applicable",
-      "categories": [
-        "ide",
-        "terminal",
-        "platform"
-      ],
-      "tokenkey_status": "not_applicable",
-      "rationale": "Client-side claude-code concern (ide, terminal, platform); not a gateway/relay relevance signal.",
-      "updated_at": "2026-06-01T09:12:42Z"
-    },
-    {
-      "upstream": "anthropics/claude-code#64444",
-      "url": "https://github.com/anthropics/claude-code/issues/64444",
-      "title": "[BUG]",
-      "impact": "not_applicable",
-      "categories": [
-        "terminal",
-        "platform"
-      ],
-      "tokenkey_status": "not_applicable",
-      "rationale": "Client-side claude-code concern (terminal, platform); not a gateway/relay relevance signal.",
-      "updated_at": "2026-06-01T09:17:05Z"
-    },
-    {
-      "upstream": "anthropics/claude-code#64447",
-      "url": "https://github.com/anthropics/claude-code/issues/64447",
-      "title": "[Bug] Claude Code stuck in infinite loop awaiting user choice response",
-      "impact": "not_applicable",
-      "categories": [
-        "ide",
-        "terminal",
-        "slash_hook"
-      ],
-      "tokenkey_status": "not_applicable",
-      "rationale": "Client-side claude-code concern (ide, terminal, slash_hook); not a gateway/relay relevance signal.",
-      "updated_at": "2026-06-01T09:33:39Z"
-    },
-    {
-      "upstream": "anthropics/claude-code#64448",
-      "url": "https://github.com/anthropics/claude-code/issues/64448",
-      "title": "[FEATURE] Option to disable terminal title override in Cursor/VS Code",
-      "impact": "not_applicable",
-      "categories": [
-        "ide",
-        "terminal",
-        "slash_hook"
-      ],
-      "tokenkey_status": "not_applicable",
-      "rationale": "Client-side claude-code concern (ide, terminal, slash_hook); not a gateway/relay relevance signal.",
-      "updated_at": "2026-06-01T09:45:16Z"
-    },
-    {
-      "upstream": "anthropics/claude-code#64449",
-      "url": "https://github.com/anthropics/claude-code/issues/64449",
-      "title": "Persistent default session color (settings.json key or launch flag)",
-      "impact": "not_applicable",
-      "categories": [
-        "terminal",
-        "slash_hook"
-      ],
-      "tokenkey_status": "not_applicable",
-      "rationale": "Client-side claude-code concern (terminal, slash_hook); not a gateway/relay relevance signal.",
-      "updated_at": "2026-06-01T09:49:17Z"
-    },
-    {
-      "upstream": "anthropics/claude-code#64450",
-      "url": "https://github.com/anthropics/claude-code/issues/64450",
-      "title": "[BUG] Claude misspells username in working directory path, causing permission prompts",
-      "impact": "not_applicable",
-      "categories": [
-        "ide",
-        "terminal"
-      ],
-      "tokenkey_status": "not_applicable",
-      "rationale": "Client-side claude-code concern (ide, terminal); not a gateway/relay relevance signal.",
-      "updated_at": "2026-06-01T09:51:08Z"
-    },
-    {
-      "upstream": "anthropics/claude-code#64451",
-      "url": "https://github.com/anthropics/claude-code/issues/64451",
-      "title": "[BUG] Explorer window opens after installation on Windows",
-      "impact": "not_applicable",
-      "categories": [
-        "terminal",
-        "install",
-        "platform"
-      ],
-      "tokenkey_status": "not_applicable",
-      "rationale": "Client-side claude-code concern (terminal, install, platform); not a gateway/relay relevance signal.",
-      "updated_at": "2026-06-01T09:59:07Z"
+      "updated_at": "2026-06-03T23:36:30Z"
     },
     {
       "upstream": "anthropics/claude-code#64452",
@@ -15573,152 +15558,6 @@
       "updated_at": "2026-06-01T15:29:07Z"
     },
     {
-      "upstream": "anthropics/claude-code#64453",
-      "url": "https://github.com/anthropics/claude-code/issues/64453",
-      "title": "[BUG] API Error: Unable to connect to API (ECONNRESET)",
-      "impact": "not_applicable",
-      "categories": [
-        "terminal"
-      ],
-      "tokenkey_status": "not_applicable",
-      "rationale": "Client-side claude-code concern (terminal); not a gateway/relay relevance signal.",
-      "updated_at": "2026-06-01T10:10:03Z"
-    },
-    {
-      "upstream": "anthropics/claude-code#64454",
-      "url": "https://github.com/anthropics/claude-code/issues/64454",
-      "title": "[Bug] Claude fails to fix overlay issues despite fresh sessions and image context",
-      "impact": "not_applicable",
-      "categories": [
-        "terminal"
-      ],
-      "tokenkey_status": "not_applicable",
-      "rationale": "Client-side claude-code concern (terminal); not a gateway/relay relevance signal.",
-      "updated_at": "2026-06-01T10:16:15Z"
-    },
-    {
-      "upstream": "anthropics/claude-code#64455",
-      "url": "https://github.com/anthropics/claude-code/issues/64455",
-      "title": "Mobile: stuck on stale \"usage limit reached\" reply after top-up while Extra Usage is active (desktop works)",
-      "impact": "not_applicable",
-      "categories": [
-        "terminal"
-      ],
-      "tokenkey_status": "not_applicable",
-      "rationale": "Client-side claude-code concern (terminal); not a gateway/relay relevance signal.",
-      "updated_at": "2026-06-01T10:17:15Z"
-    },
-    {
-      "upstream": "anthropics/claude-code#64456",
-      "url": "https://github.com/anthropics/claude-code/issues/64456",
-      "title": "[BUG] Desktop offline while using Dispatch",
-      "impact": "not_applicable",
-      "categories": [
-        "terminal",
-        "platform"
-      ],
-      "tokenkey_status": "not_applicable",
-      "rationale": "Client-side claude-code concern (terminal, platform); not a gateway/relay relevance signal.",
-      "updated_at": "2026-06-01T10:24:54Z"
-    },
-    {
-      "upstream": "anthropics/claude-code#64458",
-      "url": "https://github.com/anthropics/claude-code/issues/64458",
-      "title": "[BUG] Claude defaults to `.claude` despite having set `CLAUDE_CONFIG_DIR`",
-      "impact": "not_applicable",
-      "categories": [
-        "ide",
-        "terminal",
-        "plugin",
-        "install"
-      ],
-      "tokenkey_status": "not_applicable",
-      "rationale": "Client-side claude-code concern (ide, terminal, plugin, install); not a gateway/relay relevance signal.",
-      "updated_at": "2026-06-01T10:56:06Z"
-    },
-    {
-      "upstream": "anthropics/claude-code#64460",
-      "url": "https://github.com/anthropics/claude-code/issues/64460",
-      "title": "[FEATURE] Configurable subscribe_pr_activity wake-message text (settings or hook)",
-      "impact": "not_applicable",
-      "categories": [
-        "mcp",
-        "slash_hook"
-      ],
-      "tokenkey_status": "not_applicable",
-      "rationale": "Client-side claude-code concern (mcp, slash_hook); not a gateway/relay relevance signal.",
-      "updated_at": "2026-06-01T10:47:48Z"
-    },
-    {
-      "upstream": "anthropics/claude-code#64461",
-      "url": "https://github.com/anthropics/claude-code/issues/64461",
-      "title": "Plugin harness resolves skill base directory to marketplaces/ instead of installed cache/ path",
-      "impact": "not_applicable",
-      "categories": [
-        "plugin",
-        "slash_hook",
-        "install"
-      ],
-      "tokenkey_status": "not_applicable",
-      "rationale": "Client-side claude-code concern (plugin, slash_hook, install); not a gateway/relay relevance signal.",
-      "updated_at": "2026-06-01T10:57:04Z"
-    },
-    {
-      "upstream": "anthropics/claude-code#64463",
-      "url": "https://github.com/anthropics/claude-code/issues/64463",
-      "title": "[FEATURE] In-session agent view (← navigation) should be scopeable to the current project",
-      "impact": "not_applicable",
-      "categories": [
-        "slash_hook"
-      ],
-      "tokenkey_status": "not_applicable",
-      "rationale": "Client-side claude-code concern (slash_hook); not a gateway/relay relevance signal.",
-      "updated_at": "2026-06-01T11:11:04Z"
-    },
-    {
-      "upstream": "anthropics/claude-code#64464",
-      "url": "https://github.com/anthropics/claude-code/issues/64464",
-      "title": "Docs say `claude_desktop_config.json` MCP servers \"will not appear in the Code tab,\" but the desktop app injects them into Code sessions",
-      "impact": "not_applicable",
-      "categories": [
-        "mcp",
-        "plugin",
-        "platform"
-      ],
-      "tokenkey_status": "not_applicable",
-      "rationale": "Client-side claude-code concern (mcp, plugin, platform); not a gateway/relay relevance signal.",
-      "updated_at": "2026-06-01T11:18:34Z"
-    },
-    {
-      "upstream": "anthropics/claude-code#64466",
-      "url": "https://github.com/anthropics/claude-code/issues/64466",
-      "title": "Code-tab Customize -> Skills is missing skills that are present in ~/.claude/skills (non-deterministic; / menu and engine load them all)",
-      "impact": "not_applicable",
-      "categories": [
-        "terminal",
-        "plugin",
-        "install",
-        "platform"
-      ],
-      "tokenkey_status": "not_applicable",
-      "rationale": "Client-side claude-code concern (terminal, plugin, install, platform); not a gateway/relay relevance signal.",
-      "updated_at": "2026-06-01T11:50:56Z"
-    },
-    {
-      "upstream": "anthropics/claude-code#64467",
-      "url": "https://github.com/anthropics/claude-code/issues/64467",
-      "title": "[BUG] 1M context model switch without selecting the option",
-      "impact": "not_applicable",
-      "categories": [
-        "ide",
-        "terminal",
-        "platform"
-      ],
-      "tokenkey_status": "not_applicable",
-      "rationale": "Client-side claude-code concern (ide, terminal, platform); not a gateway/relay relevance signal.",
-      "updated_at": "2026-06-01T13:46:59Z"
-    },
-    {
       "upstream": "anthropics/claude-code#64469",
       "url": "https://github.com/anthropics/claude-code/issues/64469",
       "title": "usage error on claude",
@@ -15729,58 +15568,7 @@
       ],
       "tokenkey_status": "not_applicable",
       "rationale": "Client-side claude-code concern (ide, terminal); not a gateway/relay relevance signal.",
-      "updated_at": "2026-06-03T07:47:34Z"
-    },
-    {
-      "upstream": "anthropics/claude-code#64470",
-      "url": "https://github.com/anthropics/claude-code/issues/64470",
-      "title": "Telegram plugin (0.0.6) inbound inject silently dropped — CC host doesn't declare experimental.claude/channel capability",
-      "impact": "not_applicable",
-      "categories": [
-        "mcp",
-        "plugin",
-        "install"
-      ],
-      "tokenkey_status": "not_applicable",
-      "rationale": "Client-side claude-code concern (mcp, plugin, install); not a gateway/relay relevance signal.",
-      "updated_at": "2026-06-01T12:21:26Z"
-    },
-    {
-      "upstream": "anthropics/claude-code#64471",
-      "url": "https://github.com/anthropics/claude-code/issues/64471",
-      "title": "[BUG] Sub-agent messages render in wrong vertical order — insertion position resets on main↔sub-agent context switch",
-      "impact": "not_applicable",
-      "categories": [
-        "terminal",
-        "platform"
-      ],
-      "tokenkey_status": "not_applicable",
-      "rationale": "Client-side claude-code concern (terminal, platform); not a gateway/relay relevance signal.",
-      "updated_at": "2026-06-01T12:23:29Z"
-    },
-    {
-      "upstream": "anthropics/claude-code#64472",
-      "url": "https://github.com/anthropics/claude-code/issues/64472",
-      "title": "Feature Request: Add Chinese (Simplified) localization / i18n support",
-      "impact": "not_applicable",
-      "categories": [
-        "slash_hook"
-      ],
-      "tokenkey_status": "not_applicable",
-      "rationale": "Client-side claude-code concern (slash_hook); not a gateway/relay relevance signal.",
-      "updated_at": "2026-06-01T12:30:12Z"
-    },
-    {
-      "upstream": "anthropics/claude-code#64474",
-      "url": "https://github.com/anthropics/claude-code/issues/64474",
-      "title": "[BUG] Fullscreen TUI: failed Bash tool output is empty when expanded",
-      "impact": "not_applicable",
-      "categories": [
-        "terminal"
-      ],
-      "tokenkey_status": "not_applicable",
-      "rationale": "Client-side claude-code concern (terminal); not a gateway/relay relevance signal.",
-      "updated_at": "2026-06-01T12:31:24Z"
+      "updated_at": "2026-06-04T01:20:43Z"
     },
     {
       "upstream": "anthropics/claude-code#64476",
@@ -15794,152 +15582,6 @@
       "tokenkey_status": "not_applicable",
       "rationale": "Client-side claude-code concern (ide, terminal); not a gateway/relay relevance signal.",
       "updated_at": "2026-06-01T17:40:45Z"
-    },
-    {
-      "upstream": "anthropics/claude-code#64479",
-      "url": "https://github.com/anthropics/claude-code/issues/64479",
-      "title": "[Bug] Edit tool fails on mixed literal/escape Unicode in multi-line old_string",
-      "impact": "not_applicable",
-      "categories": [
-        "terminal"
-      ],
-      "tokenkey_status": "not_applicable",
-      "rationale": "Client-side claude-code concern (terminal); not a gateway/relay relevance signal.",
-      "updated_at": "2026-06-01T12:40:14Z"
-    },
-    {
-      "upstream": "anthropics/claude-code#64480",
-      "url": "https://github.com/anthropics/claude-code/issues/64480",
-      "title": "[BUG] Claude Max invoice paid but account remains past_due; Claude Code access blocked and cancellation page stuck",
-      "impact": "not_applicable",
-      "categories": [
-        "ide",
-        "terminal"
-      ],
-      "tokenkey_status": "not_applicable",
-      "rationale": "Client-side claude-code concern (ide, terminal); not a gateway/relay relevance signal.",
-      "updated_at": "2026-06-01T13:16:16Z"
-    },
-    {
-      "upstream": "anthropics/claude-code#64481",
-      "url": "https://github.com/anthropics/claude-code/issues/64481",
-      "title": "Claude rewrote committed application code without preserving prior state, causing loss of user work",
-      "impact": "not_applicable",
-      "categories": [
-        "terminal",
-        "install"
-      ],
-      "tokenkey_status": "not_applicable",
-      "rationale": "Client-side claude-code concern (terminal, install); not a gateway/relay relevance signal.",
-      "updated_at": "2026-06-01T12:55:54Z"
-    },
-    {
-      "upstream": "anthropics/claude-code#64483",
-      "url": "https://github.com/anthropics/claude-code/issues/64483",
-      "title": "[FEATURE] Support expertise-aware delegation as a first-class agent behaviour",
-      "impact": "not_applicable",
-      "categories": [
-        "slash_hook"
-      ],
-      "tokenkey_status": "not_applicable",
-      "rationale": "Client-side claude-code concern (slash_hook); not a gateway/relay relevance signal.",
-      "updated_at": "2026-06-01T12:57:50Z"
-    },
-    {
-      "upstream": "anthropics/claude-code#64484",
-      "url": "https://github.com/anthropics/claude-code/issues/64484",
-      "title": "Feature request: setting to hide/collapse file edit diffs in terminal transcript",
-      "impact": "not_applicable",
-      "categories": [
-        "terminal",
-        "slash_hook"
-      ],
-      "tokenkey_status": "not_applicable",
-      "rationale": "Client-side claude-code concern (terminal, slash_hook); not a gateway/relay relevance signal.",
-      "updated_at": "2026-06-01T13:12:19Z"
-    },
-    {
-      "upstream": "anthropics/claude-code#64485",
-      "url": "https://github.com/anthropics/claude-code/issues/64485",
-      "title": "[BUG] CronCreate: lacks predicate-gated execution and context isolation, leading to large unintended costs on repeated trivial checks",
-      "impact": "not_applicable",
-      "categories": [
-        "terminal",
-        "platform"
-      ],
-      "tokenkey_status": "not_applicable",
-      "rationale": "Client-side claude-code concern (terminal, platform); not a gateway/relay relevance signal.",
-      "updated_at": "2026-06-01T13:12:23Z"
-    },
-    {
-      "upstream": "anthropics/claude-code#64486",
-      "url": "https://github.com/anthropics/claude-code/issues/64486",
-      "title": "I'm Claude Code, an agentic coding CLI. However, I don't see a specific error message or bug report in your message to analyze. Please share: 1. The error message or unexpected behavior you're experiencing 2. What you were trying to do when it occurred 3.",
-      "impact": "not_applicable",
-      "categories": [
-        "ide",
-        "terminal",
-        "install"
-      ],
-      "tokenkey_status": "not_applicable",
-      "rationale": "Client-side claude-code concern (ide, terminal, install); not a gateway/relay relevance signal.",
-      "updated_at": "2026-06-01T13:17:14Z"
-    },
-    {
-      "upstream": "anthropics/claude-code#64488",
-      "url": "https://github.com/anthropics/claude-code/issues/64488",
-      "title": "[Bug] Claude Code ignores instructions and generates errors to consume tokens",
-      "impact": "not_applicable",
-      "categories": [
-        "ide",
-        "terminal"
-      ],
-      "tokenkey_status": "not_applicable",
-      "rationale": "Client-side claude-code concern (ide, terminal); not a gateway/relay relevance signal.",
-      "updated_at": "2026-06-01T13:20:38Z"
-    },
-    {
-      "upstream": "anthropics/claude-code#64490",
-      "url": "https://github.com/anthropics/claude-code/issues/64490",
-      "title": "Last sentence/line of response disappears in terminal output",
-      "impact": "not_applicable",
-      "categories": [
-        "terminal",
-        "install"
-      ],
-      "tokenkey_status": "not_applicable",
-      "rationale": "Client-side claude-code concern (terminal, install); not a gateway/relay relevance signal.",
-      "updated_at": "2026-06-01T13:23:44Z"
-    },
-    {
-      "upstream": "anthropics/claude-code#64491",
-      "url": "https://github.com/anthropics/claude-code/issues/64491",
-      "title": "[BUG] Claude Code Usage Limits Consumed Automatically Without Any Usage",
-      "impact": "not_applicable",
-      "categories": [
-        "ide",
-        "terminal",
-        "platform"
-      ],
-      "tokenkey_status": "not_applicable",
-      "rationale": "Client-side claude-code concern (ide, terminal, platform); not a gateway/relay relevance signal.",
-      "updated_at": "2026-06-01T13:33:59Z"
-    },
-    {
-      "upstream": "anthropics/claude-code#64494",
-      "url": "https://github.com/anthropics/claude-code/issues/64494",
-      "title": "[BUG] Claude in Chrome extension no longer registers MCP tools with Claude Code (VS Code)",
-      "impact": "not_applicable",
-      "categories": [
-        "ide",
-        "terminal",
-        "mcp",
-        "install",
-        "platform"
-      ],
-      "tokenkey_status": "not_applicable",
-      "rationale": "Client-side claude-code concern (ide, terminal, mcp, install, platform); not a gateway/relay relevance signal.",
-      "updated_at": "2026-06-01T14:02:36Z"
     },
     {
       "upstream": "anthropics/claude-code#64495",
@@ -15963,19 +15605,7 @@
       ],
       "tokenkey_status": "not_applicable",
       "rationale": "Client-side claude-code concern (terminal); not a gateway/relay relevance signal.",
-      "updated_at": "2026-06-01T14:11:56Z"
-    },
-    {
-      "upstream": "anthropics/claude-code#64498",
-      "url": "https://github.com/anthropics/claude-code/issues/64498",
-      "title": "[Feature Request] Add command to query current session ID in running CLI",
-      "impact": "not_applicable",
-      "categories": [
-        "terminal"
-      ],
-      "tokenkey_status": "not_applicable",
-      "rationale": "Client-side claude-code concern (terminal); not a gateway/relay relevance signal.",
-      "updated_at": "2026-06-01T14:13:30Z"
+      "updated_at": "2026-06-03T23:02:32Z"
     },
     {
       "upstream": "anthropics/claude-code#64499",
@@ -16039,7 +15669,7 @@
       ],
       "tokenkey_status": "not_applicable",
       "rationale": "Client-side claude-code concern (terminal); not a gateway/relay relevance signal.",
-      "updated_at": "2026-06-03T05:37:13Z"
+      "updated_at": "2026-06-03T11:39:53Z"
     },
     {
       "upstream": "anthropics/claude-code#64504",
@@ -16304,7 +15934,7 @@
       ],
       "tokenkey_status": "not_applicable",
       "rationale": "Client-side claude-code concern (slash_hook); not a gateway/relay relevance signal.",
-      "updated_at": "2026-06-01T18:52:14Z"
+      "updated_at": "2026-06-03T16:56:40Z"
     },
     {
       "upstream": "anthropics/claude-code#64535",
@@ -16516,7 +16146,7 @@
       ],
       "tokenkey_status": "not_applicable",
       "rationale": "Client-side claude-code concern (plugin); not a gateway/relay relevance signal.",
-      "updated_at": "2026-06-03T06:12:29Z"
+      "updated_at": "2026-06-03T10:30:56Z"
     },
     {
       "upstream": "anthropics/claude-code#64559",
@@ -16529,7 +16159,7 @@
       ],
       "tokenkey_status": "not_applicable",
       "rationale": "Client-side claude-code concern (terminal, slash_hook); not a gateway/relay relevance signal.",
-      "updated_at": "2026-06-01T20:19:26Z"
+      "updated_at": "2026-06-04T08:27:40Z"
     },
     {
       "upstream": "anthropics/claude-code#64560",
@@ -16555,20 +16185,6 @@
       "tokenkey_status": "not_applicable",
       "rationale": "Client-side claude-code concern (platform); not a gateway/relay relevance signal.",
       "updated_at": "2026-06-01T20:47:18Z"
-    },
-    {
-      "upstream": "anthropics/claude-code#64563",
-      "url": "https://github.com/anthropics/claude-code/issues/64563",
-      "title": "Linux x64 binary in v2.1.159 installs as invalid executable (exec format error)",
-      "impact": "not_applicable",
-      "categories": [
-        "terminal",
-        "install",
-        "platform"
-      ],
-      "tokenkey_status": "not_applicable",
-      "rationale": "Client-side claude-code concern (terminal, install, platform); not a gateway/relay relevance signal.",
-      "updated_at": "2026-06-01T20:56:33Z"
     },
     {
       "upstream": "anthropics/claude-code#64564",
@@ -16953,7 +16569,7 @@
       ],
       "tokenkey_status": "not_applicable",
       "rationale": "Client-side claude-code concern (terminal, plugin, platform); not a gateway/relay relevance signal.",
-      "updated_at": "2026-06-02T11:19:14Z"
+      "updated_at": "2026-06-04T05:03:08Z"
     },
     {
       "upstream": "anthropics/claude-code#64620",
@@ -17666,18 +17282,6 @@
       "updated_at": "2026-06-02T10:44:45Z"
     },
     {
-      "upstream": "anthropics/claude-code#64713",
-      "url": "https://github.com/anthropics/claude-code/issues/64713",
-      "title": "[Feature Request] Add stream mode to hide personal information on welcome screen",
-      "impact": "not_applicable",
-      "categories": [
-        "terminal"
-      ],
-      "tokenkey_status": "not_applicable",
-      "rationale": "Client-side claude-code concern (terminal); not a gateway/relay relevance signal.",
-      "updated_at": "2026-06-02T10:48:23Z"
-    },
-    {
       "upstream": "anthropics/claude-code#64714",
       "url": "https://github.com/anthropics/claude-code/issues/64714",
       "title": "Bring back a clickable expand/collapse arrow for thinking blocks (mouse, not keyboard)",
@@ -17782,7 +17386,7 @@
       ],
       "tokenkey_status": "not_applicable",
       "rationale": "Client-side claude-code concern (mcp, install); not a gateway/relay relevance signal.",
-      "updated_at": "2026-06-03T07:03:21Z"
+      "updated_at": "2026-06-03T11:02:51Z"
     },
     {
       "upstream": "anthropics/claude-code#64731",
@@ -17862,7 +17466,7 @@
       ],
       "tokenkey_status": "not_applicable",
       "rationale": "Client-side claude-code concern (terminal, platform); not a gateway/relay relevance signal.",
-      "updated_at": "2026-06-02T13:06:41Z"
+      "updated_at": "2026-06-03T10:26:41Z"
     },
     {
       "upstream": "anthropics/claude-code#64741",
@@ -17900,7 +17504,7 @@
       ],
       "tokenkey_status": "not_applicable",
       "rationale": "Client-side claude-code concern (terminal); not a gateway/relay relevance signal.",
-      "updated_at": "2026-06-03T00:27:31Z"
+      "updated_at": "2026-06-03T16:54:41Z"
     },
     {
       "upstream": "anthropics/claude-code#64745",
@@ -17926,7 +17530,7 @@
       ],
       "tokenkey_status": "not_applicable",
       "rationale": "Client-side claude-code concern (terminal, install, platform); not a gateway/relay relevance signal.",
-      "updated_at": "2026-06-03T07:59:38Z"
+      "updated_at": "2026-06-03T11:35:46Z"
     },
     {
       "upstream": "anthropics/claude-code#64747",
@@ -18131,7 +17735,7 @@
       ],
       "tokenkey_status": "not_applicable",
       "rationale": "Client-side claude-code concern (plugin, slash_hook); not a gateway/relay relevance signal.",
-      "updated_at": "2026-06-03T03:00:06Z"
+      "updated_at": "2026-06-04T00:59:53Z"
     },
     {
       "upstream": "anthropics/claude-code#64768",
@@ -18144,7 +17748,7 @@
       ],
       "tokenkey_status": "not_applicable",
       "rationale": "Client-side claude-code concern (terminal, mcp); not a gateway/relay relevance signal.",
-      "updated_at": "2026-06-02T15:40:18Z"
+      "updated_at": "2026-06-04T00:44:14Z"
     },
     {
       "upstream": "anthropics/claude-code#64769",
@@ -18210,21 +17814,7 @@
       ],
       "tokenkey_status": "not_applicable",
       "rationale": "Client-side claude-code concern (terminal, platform); not a gateway/relay relevance signal.",
-      "updated_at": "2026-06-02T15:12:01Z"
-    },
-    {
-      "upstream": "anthropics/claude-code#64778",
-      "url": "https://github.com/anthropics/claude-code/issues/64778",
-      "title": "[Bug] `/doctor` command dismisses diagnostics without displaying MCP setup issues",
-      "impact": "not_applicable",
-      "categories": [
-        "terminal",
-        "mcp",
-        "slash_hook"
-      ],
-      "tokenkey_status": "not_applicable",
-      "rationale": "Client-side claude-code concern (terminal, mcp, slash_hook); not a gateway/relay relevance signal.",
-      "updated_at": "2026-06-02T15:19:18Z"
+      "updated_at": "2026-06-04T09:34:51Z"
     },
     {
       "upstream": "anthropics/claude-code#64779",
@@ -18300,19 +17890,6 @@
       "tokenkey_status": "not_applicable",
       "rationale": "Client-side claude-code concern (terminal); not a gateway/relay relevance signal.",
       "updated_at": "2026-06-02T15:56:23Z"
-    },
-    {
-      "upstream": "anthropics/claude-code#64792",
-      "url": "https://github.com/anthropics/claude-code/issues/64792",
-      "title": "[BUG] Sandbox denies writes to shared .git inside a linked git worktree — git commit/add/push fail with EPERM, despite documented worktree allowance (v2.1.160)",
-      "impact": "not_applicable",
-      "categories": [
-        "terminal",
-        "slash_hook"
-      ],
-      "tokenkey_status": "not_applicable",
-      "rationale": "Client-side claude-code concern (terminal, slash_hook); not a gateway/relay relevance signal.",
-      "updated_at": "2026-06-02T16:23:19Z"
     },
     {
       "upstream": "anthropics/claude-code#64793",
@@ -18502,7 +18079,7 @@
       ],
       "tokenkey_status": "not_applicable",
       "rationale": "Client-side claude-code concern (terminal); not a gateway/relay relevance signal.",
-      "updated_at": "2026-06-02T17:21:34Z"
+      "updated_at": "2026-06-03T17:23:20Z"
     },
     {
       "upstream": "anthropics/claude-code#64813",
@@ -18895,7 +18472,7 @@
       ],
       "tokenkey_status": "not_applicable",
       "rationale": "Client-side claude-code concern (terminal); not a gateway/relay relevance signal.",
-      "updated_at": "2026-06-02T21:03:21Z"
+      "updated_at": "2026-06-03T20:19:50Z"
     },
     {
       "upstream": "anthropics/claude-code#64861",
@@ -19292,7 +18869,7 @@
       ],
       "tokenkey_status": "not_applicable",
       "rationale": "Client-side claude-code concern (terminal, mcp, plugin); not a gateway/relay relevance signal.",
-      "updated_at": "2026-06-03T02:05:17Z"
+      "updated_at": "2026-06-03T18:58:43Z"
     },
     {
       "upstream": "anthropics/claude-code#64910",
@@ -19305,19 +18882,6 @@
       "tokenkey_status": "not_applicable",
       "rationale": "Client-side claude-code concern (terminal); not a gateway/relay relevance signal.",
       "updated_at": "2026-06-03T01:10:15Z"
-    },
-    {
-      "upstream": "anthropics/claude-code#64913",
-      "url": "https://github.com/anthropics/claude-code/issues/64913",
-      "title": "[BUG] Weekly usage meter resets ~4 days early (overnight) despite /usage stating \"Resets Sat 5:00 AM\" -- Max (20x)",
-      "impact": "not_applicable",
-      "categories": [
-        "terminal",
-        "platform"
-      ],
-      "tokenkey_status": "not_applicable",
-      "rationale": "Client-side claude-code concern (terminal, platform); not a gateway/relay relevance signal.",
-      "updated_at": "2026-06-03T01:22:15Z"
     },
     {
       "upstream": "anthropics/claude-code#64914",
@@ -19360,18 +18924,6 @@
       "updated_at": "2026-06-03T01:28:17Z"
     },
     {
-      "upstream": "anthropics/claude-code#64917",
-      "url": "https://github.com/anthropics/claude-code/issues/64917",
-      "title": "[Bug] Inaccurate skill documentation: find misclassified as unconditionally auto-allowed",
-      "impact": "not_applicable",
-      "categories": [
-        "terminal"
-      ],
-      "tokenkey_status": "not_applicable",
-      "rationale": "Client-side claude-code concern (terminal); not a gateway/relay relevance signal.",
-      "updated_at": "2026-06-03T01:35:56Z"
-    },
-    {
       "upstream": "anthropics/claude-code#64918",
       "url": "https://github.com/anthropics/claude-code/issues/64918",
       "title": "[BUG] v2.1.150 darwin-arm64: npm install silently truncates native binary (~213 MB → ~63 MB), causing \"killed\" on launch and auto-update infinite loop",
@@ -19397,7 +18949,7 @@
       ],
       "tokenkey_status": "not_applicable",
       "rationale": "Client-side claude-code concern (ide, terminal, slash_hook, install); not a gateway/relay relevance signal.",
-      "updated_at": "2026-06-03T01:54:07Z"
+      "updated_at": "2026-06-04T00:07:14Z"
     },
     {
       "upstream": "anthropics/claude-code#64920",
@@ -19521,7 +19073,7 @@
       ],
       "tokenkey_status": "not_applicable",
       "rationale": "Client-side claude-code concern (terminal); not a gateway/relay relevance signal.",
-      "updated_at": "2026-06-03T02:48:31Z"
+      "updated_at": "2026-06-04T01:41:22Z"
     },
     {
       "upstream": "anthropics/claude-code#64934",
@@ -19774,7 +19326,7 @@
       ],
       "tokenkey_status": "not_applicable",
       "rationale": "Client-side claude-code concern (terminal); not a gateway/relay relevance signal.",
-      "updated_at": "2026-06-03T10:08:41Z"
+      "updated_at": "2026-06-03T13:04:42Z"
     },
     {
       "upstream": "anthropics/claude-code#64962",
@@ -19924,7 +19476,7 @@
       ],
       "tokenkey_status": "not_applicable",
       "rationale": "Client-side claude-code concern (terminal); not a gateway/relay relevance signal.",
-      "updated_at": "2026-06-03T07:34:41Z"
+      "updated_at": "2026-06-04T08:02:02Z"
     },
     {
       "upstream": "anthropics/claude-code#64980",
@@ -20162,7 +19714,7 @@
       ],
       "tokenkey_status": "not_applicable",
       "rationale": "Client-side claude-code concern (platform); not a gateway/relay relevance signal.",
-      "updated_at": "2026-06-03T09:24:35Z"
+      "updated_at": "2026-06-03T11:04:45Z"
     },
     {
       "upstream": "anthropics/claude-code#65008",
@@ -20252,7 +19804,7 @@
       ],
       "tokenkey_status": "not_applicable",
       "rationale": "Client-side claude-code concern (terminal, platform); not a gateway/relay relevance signal.",
-      "updated_at": "2026-06-03T10:02:16Z"
+      "updated_at": "2026-06-03T10:31:02Z"
     },
     {
       "upstream": "anthropics/claude-code#65017",
@@ -20276,7 +19828,7 @@
       ],
       "tokenkey_status": "not_applicable",
       "rationale": "Client-side claude-code concern (terminal); not a gateway/relay relevance signal.",
-      "updated_at": "2026-06-03T10:16:23Z"
+      "updated_at": "2026-06-03T10:24:03Z"
     },
     {
       "upstream": "anthropics/claude-code#65019",
@@ -20289,7 +19841,3005 @@
       ],
       "tokenkey_status": "not_applicable",
       "rationale": "Client-side claude-code concern (terminal, platform); not a gateway/relay relevance signal.",
-      "updated_at": "2026-06-03T10:19:24Z"
+      "updated_at": "2026-06-04T10:41:58Z"
+    },
+    {
+      "upstream": "anthropics/claude-code#65020",
+      "url": "https://github.com/anthropics/claude-code/issues/65020",
+      "title": "[Bug] Excessive token consumption on single message causing rapid usage limit depletion",
+      "impact": "not_applicable",
+      "categories": [
+        "terminal"
+      ],
+      "tokenkey_status": "not_applicable",
+      "rationale": "Client-side claude-code concern (terminal); not a gateway/relay relevance signal.",
+      "updated_at": "2026-06-03T10:25:34Z"
+    },
+    {
+      "upstream": "anthropics/claude-code#65021",
+      "url": "https://github.com/anthropics/claude-code/issues/65021",
+      "title": "[BUG] [VS Code Extension] Organization-level skills not loaded (only filesystem paths checked)",
+      "impact": "not_applicable",
+      "categories": [
+        "ide",
+        "terminal",
+        "mcp",
+        "plugin",
+        "platform"
+      ],
+      "tokenkey_status": "not_applicable",
+      "rationale": "Client-side claude-code concern (ide, terminal, mcp, plugin, platform); not a gateway/relay relevance signal.",
+      "updated_at": "2026-06-03T10:28:50Z"
+    },
+    {
+      "upstream": "anthropics/claude-code#65024",
+      "url": "https://github.com/anthropics/claude-code/issues/65024",
+      "title": "[BUG] Claude desktop app crashing as soon as I open it.",
+      "impact": "not_applicable",
+      "categories": [
+        "terminal",
+        "mcp",
+        "install"
+      ],
+      "tokenkey_status": "not_applicable",
+      "rationale": "Client-side claude-code concern (terminal, mcp, install); not a gateway/relay relevance signal.",
+      "updated_at": "2026-06-03T10:49:08Z"
+    },
+    {
+      "upstream": "anthropics/claude-code#65025",
+      "url": "https://github.com/anthropics/claude-code/issues/65025",
+      "title": "[Bug] Chat messages arrive out of order and delayed during long-running commands",
+      "impact": "not_applicable",
+      "categories": [
+        "terminal"
+      ],
+      "tokenkey_status": "not_applicable",
+      "rationale": "Client-side claude-code concern (terminal); not a gateway/relay relevance signal.",
+      "updated_at": "2026-06-03T10:53:49Z"
+    },
+    {
+      "upstream": "anthropics/claude-code#65026",
+      "url": "https://github.com/anthropics/claude-code/issues/65026",
+      "title": "[BUG] CLI self-aborts (SIGABRT) at ~6 GB RSS during long background Workflow runs — reproduced on 2.1.160 and 2.1.161 (WSL2)",
+      "impact": "not_applicable",
+      "categories": [
+        "terminal",
+        "plugin",
+        "install",
+        "platform"
+      ],
+      "tokenkey_status": "not_applicable",
+      "rationale": "Client-side claude-code concern (terminal, plugin, install, platform); not a gateway/relay relevance signal.",
+      "updated_at": "2026-06-03T18:58:57Z"
+    },
+    {
+      "upstream": "anthropics/claude-code#65028",
+      "url": "https://github.com/anthropics/claude-code/issues/65028",
+      "title": "[BUG] /compact fails with ECONNRESET at only 35% context data — no recovery path when API is intermittently unstable",
+      "impact": "not_applicable",
+      "categories": [
+        "ide",
+        "terminal",
+        "platform"
+      ],
+      "tokenkey_status": "not_applicable",
+      "rationale": "Client-side claude-code concern (ide, terminal, platform); not a gateway/relay relevance signal.",
+      "updated_at": "2026-06-03T11:06:07Z"
+    },
+    {
+      "upstream": "anthropics/claude-code#65031",
+      "url": "https://github.com/anthropics/claude-code/issues/65031",
+      "title": "[Bug] Feedback prompt appears when answering code instead of feedback",
+      "impact": "not_applicable",
+      "categories": [
+        "ide",
+        "terminal"
+      ],
+      "tokenkey_status": "not_applicable",
+      "rationale": "Client-side claude-code concern (ide, terminal); not a gateway/relay relevance signal.",
+      "updated_at": "2026-06-03T11:24:07Z"
+    },
+    {
+      "upstream": "anthropics/claude-code#65032",
+      "url": "https://github.com/anthropics/claude-code/issues/65032",
+      "title": "ultrareview crashed before producing findings — refund request (Windows, 2.1.161)",
+      "impact": "not_applicable",
+      "categories": [
+        "platform"
+      ],
+      "tokenkey_status": "not_applicable",
+      "rationale": "Client-side claude-code concern (platform); not a gateway/relay relevance signal.",
+      "updated_at": "2026-06-03T11:25:35Z"
+    },
+    {
+      "upstream": "anthropics/claude-code#65033",
+      "url": "https://github.com/anthropics/claude-code/issues/65033",
+      "title": "[BUG] La pantalla queda en blanco al abrir Claude Desktop en iMac, macOS M3, Sequoia 15.7.3",
+      "impact": "not_applicable",
+      "categories": [
+        "terminal"
+      ],
+      "tokenkey_status": "not_applicable",
+      "rationale": "Client-side claude-code concern (terminal); not a gateway/relay relevance signal.",
+      "updated_at": "2026-06-03T11:33:39Z"
+    },
+    {
+      "upstream": "anthropics/claude-code#65034",
+      "url": "https://github.com/anthropics/claude-code/issues/65034",
+      "title": "[Bug] Claude deletes environment files during code operations",
+      "impact": "not_applicable",
+      "categories": [
+        "terminal"
+      ],
+      "tokenkey_status": "not_applicable",
+      "rationale": "Client-side claude-code concern (terminal); not a gateway/relay relevance signal.",
+      "updated_at": "2026-06-03T11:38:32Z"
+    },
+    {
+      "upstream": "anthropics/claude-code#65035",
+      "url": "https://github.com/anthropics/claude-code/issues/65035",
+      "title": "[Bug] Auto-Compact Not Triggered",
+      "impact": "not_applicable",
+      "categories": [
+        "terminal"
+      ],
+      "tokenkey_status": "not_applicable",
+      "rationale": "Client-side claude-code concern (terminal); not a gateway/relay relevance signal.",
+      "updated_at": "2026-06-03T20:54:50Z"
+    },
+    {
+      "upstream": "anthropics/claude-code#65038",
+      "url": "https://github.com/anthropics/claude-code/issues/65038",
+      "title": "[BUG] Opening and closing agents screen makes CC close abruptly",
+      "impact": "not_applicable",
+      "categories": [
+        "terminal",
+        "platform"
+      ],
+      "tokenkey_status": "not_applicable",
+      "rationale": "Client-side claude-code concern (terminal, platform); not a gateway/relay relevance signal.",
+      "updated_at": "2026-06-03T12:06:24Z"
+    },
+    {
+      "upstream": "anthropics/claude-code#65039",
+      "url": "https://github.com/anthropics/claude-code/issues/65039",
+      "title": "Feature request: mouseReporting setting to allow X11 primary selection (highlight-to-copy)",
+      "impact": "not_applicable",
+      "categories": [
+        "terminal",
+        "slash_hook"
+      ],
+      "tokenkey_status": "not_applicable",
+      "rationale": "Client-side claude-code concern (terminal, slash_hook); not a gateway/relay relevance signal.",
+      "updated_at": "2026-06-03T11:54:42Z"
+    },
+    {
+      "upstream": "anthropics/claude-code#65040",
+      "url": "https://github.com/anthropics/claude-code/issues/65040",
+      "title": "[Feature Request] Support dynamic templates in session-name badge",
+      "impact": "not_applicable",
+      "categories": [
+        "ide",
+        "terminal",
+        "slash_hook"
+      ],
+      "tokenkey_status": "not_applicable",
+      "rationale": "Client-side claude-code concern (ide, terminal, slash_hook); not a gateway/relay relevance signal.",
+      "updated_at": "2026-06-03T11:58:53Z"
+    },
+    {
+      "upstream": "anthropics/claude-code#65041",
+      "url": "https://github.com/anthropics/claude-code/issues/65041",
+      "title": "[BUG] The usage dashboard isn't updated despite having worked with Claude code.",
+      "impact": "not_applicable",
+      "categories": [
+        "ide",
+        "terminal",
+        "platform"
+      ],
+      "tokenkey_status": "not_applicable",
+      "rationale": "Client-side claude-code concern (ide, terminal, platform); not a gateway/relay relevance signal.",
+      "updated_at": "2026-06-03T11:56:40Z"
+    },
+    {
+      "upstream": "anthropics/claude-code#65043",
+      "url": "https://github.com/anthropics/claude-code/issues/65043",
+      "title": "[Bug] Plugins warning message appears constantly in terminal output",
+      "impact": "not_applicable",
+      "categories": [
+        "terminal",
+        "plugin"
+      ],
+      "tokenkey_status": "not_applicable",
+      "rationale": "Client-side claude-code concern (terminal, plugin); not a gateway/relay relevance signal.",
+      "updated_at": "2026-06-03T12:04:15Z"
+    },
+    {
+      "upstream": "anthropics/claude-code#65045",
+      "url": "https://github.com/anthropics/claude-code/issues/65045",
+      "title": "App-wide input lag on Windows 11 Desktop (build 1.10628.0.0) - renderer main-thread blocking; continuation of closed #55149",
+      "impact": "not_applicable",
+      "categories": [
+        "terminal",
+        "mcp",
+        "platform"
+      ],
+      "tokenkey_status": "not_applicable",
+      "rationale": "Client-side claude-code concern (terminal, mcp, platform); not a gateway/relay relevance signal.",
+      "updated_at": "2026-06-03T12:11:57Z"
+    },
+    {
+      "upstream": "anthropics/claude-code#65047",
+      "url": "https://github.com/anthropics/claude-code/issues/65047",
+      "title": "Slash-command menu returns zero matches when query contains `.` (regression 2.1.160 → 2.1.161)",
+      "impact": "not_applicable",
+      "categories": [
+        "terminal",
+        "plugin",
+        "install",
+        "platform"
+      ],
+      "tokenkey_status": "not_applicable",
+      "rationale": "Client-side claude-code concern (terminal, plugin, install, platform); not a gateway/relay relevance signal.",
+      "updated_at": "2026-06-04T09:11:36Z"
+    },
+    {
+      "upstream": "anthropics/claude-code#65048",
+      "url": "https://github.com/anthropics/claude-code/issues/65048",
+      "title": "Autocompact regression since 2.1.153 (up to the latest 2.1.161 version): \"0% until auto-compact\" replaced by \"100% context used\", compaction never triggers",
+      "impact": "not_applicable",
+      "categories": [
+        "slash_hook",
+        "install"
+      ],
+      "tokenkey_status": "not_applicable",
+      "rationale": "Client-side claude-code concern (slash_hook, install); not a gateway/relay relevance signal.",
+      "updated_at": "2026-06-03T12:20:14Z"
+    },
+    {
+      "upstream": "anthropics/claude-code#65049",
+      "url": "https://github.com/anthropics/claude-code/issues/65049",
+      "title": "[Bug] Tool call parsing failed - unable to parse model response",
+      "impact": "not_applicable",
+      "categories": [
+        "terminal"
+      ],
+      "tokenkey_status": "not_applicable",
+      "rationale": "Client-side claude-code concern (terminal); not a gateway/relay relevance signal.",
+      "updated_at": "2026-06-03T12:42:03Z"
+    },
+    {
+      "upstream": "anthropics/claude-code#65050",
+      "url": "https://github.com/anthropics/claude-code/issues/65050",
+      "title": "Typing `//` no longer filters autocomplete to project skills whose frontmatter `name:` starts with `/` (regression in v2.1.160)",
+      "impact": "not_applicable",
+      "categories": [
+        "terminal",
+        "slash_hook"
+      ],
+      "tokenkey_status": "not_applicable",
+      "rationale": "Client-side claude-code concern (terminal, slash_hook); not a gateway/relay relevance signal.",
+      "updated_at": "2026-06-03T12:54:33Z"
+    },
+    {
+      "upstream": "anthropics/claude-code#65052",
+      "url": "https://github.com/anthropics/claude-code/issues/65052",
+      "title": "[BUG] the reset time stopped appearing in the notification is a UI regression",
+      "impact": "not_applicable",
+      "categories": [
+        "terminal",
+        "platform"
+      ],
+      "tokenkey_status": "not_applicable",
+      "rationale": "Client-side claude-code concern (terminal, platform); not a gateway/relay relevance signal.",
+      "updated_at": "2026-06-03T12:58:33Z"
+    },
+    {
+      "upstream": "anthropics/claude-code#65053",
+      "url": "https://github.com/anthropics/claude-code/issues/65053",
+      "title": "Cowork sessions crash with 1M context error — auto-compaction regression (tengu_slate_siskin disabled)",
+      "impact": "not_applicable",
+      "categories": [
+        "ide",
+        "terminal",
+        "slash_hook",
+        "platform"
+      ],
+      "tokenkey_status": "not_applicable",
+      "rationale": "Client-side claude-code concern (ide, terminal, slash_hook, platform); not a gateway/relay relevance signal.",
+      "updated_at": "2026-06-03T13:41:30Z"
+    },
+    {
+      "upstream": "anthropics/claude-code#65055",
+      "url": "https://github.com/anthropics/claude-code/issues/65055",
+      "title": "[Bug] Agent generates suboptimal solutions with increased defect introduction",
+      "impact": "not_applicable",
+      "categories": [
+        "terminal"
+      ],
+      "tokenkey_status": "not_applicable",
+      "rationale": "Client-side claude-code concern (terminal); not a gateway/relay relevance signal.",
+      "updated_at": "2026-06-03T13:07:00Z"
+    },
+    {
+      "upstream": "anthropics/claude-code#65056",
+      "url": "https://github.com/anthropics/claude-code/issues/65056",
+      "title": "[BUG] Bash command containing `python3` execute without permission prompt when no allow rules are configured and sandboxed",
+      "impact": "not_applicable",
+      "categories": [
+        "terminal",
+        "slash_hook"
+      ],
+      "tokenkey_status": "not_applicable",
+      "rationale": "Client-side claude-code concern (terminal, slash_hook); not a gateway/relay relevance signal.",
+      "updated_at": "2026-06-03T13:46:48Z"
+    },
+    {
+      "upstream": "anthropics/claude-code#65057",
+      "url": "https://github.com/anthropics/claude-code/issues/65057",
+      "title": "[FEATURE] Voice input support for hands-free prompting in Claude Code CLI",
+      "impact": "not_applicable",
+      "categories": [
+        "ide",
+        "terminal"
+      ],
+      "tokenkey_status": "not_applicable",
+      "rationale": "Client-side claude-code concern (ide, terminal); not a gateway/relay relevance signal.",
+      "updated_at": "2026-06-03T20:18:31Z"
+    },
+    {
+      "upstream": "anthropics/claude-code#65059",
+      "url": "https://github.com/anthropics/claude-code/issues/65059",
+      "title": "[BUG] vscode extension incorrectly prepends /usr/bin to PATH",
+      "impact": "not_applicable",
+      "categories": [
+        "ide",
+        "terminal",
+        "slash_hook",
+        "install"
+      ],
+      "tokenkey_status": "not_applicable",
+      "rationale": "Client-side claude-code concern (ide, terminal, slash_hook, install); not a gateway/relay relevance signal.",
+      "updated_at": "2026-06-04T06:53:32Z"
+    },
+    {
+      "upstream": "anthropics/claude-code#65060",
+      "url": "https://github.com/anthropics/claude-code/issues/65060",
+      "title": "[Bug] Tool Call Parsing Failed - Unable to Deserialize Model Response",
+      "impact": "not_applicable",
+      "categories": [
+        "terminal"
+      ],
+      "tokenkey_status": "not_applicable",
+      "rationale": "Client-side claude-code concern (terminal); not a gateway/relay relevance signal.",
+      "updated_at": "2026-06-03T13:37:57Z"
+    },
+    {
+      "upstream": "anthropics/claude-code#65061",
+      "url": "https://github.com/anthropics/claude-code/issues/65061",
+      "title": "[BUG] Desktop (Windows): Turkish speech transcribed as English — mic dictation ignores `language` setting",
+      "impact": "not_applicable",
+      "categories": [
+        "slash_hook",
+        "platform"
+      ],
+      "tokenkey_status": "not_applicable",
+      "rationale": "Client-side claude-code concern (slash_hook, platform); not a gateway/relay relevance signal.",
+      "updated_at": "2026-06-03T14:01:54Z"
+    },
+    {
+      "upstream": "anthropics/claude-code#65062",
+      "url": "https://github.com/anthropics/claude-code/issues/65062",
+      "title": "[claude.ai] Bulk conversation rename API / MCP tool for web and desktop",
+      "impact": "not_applicable",
+      "categories": [
+        "mcp"
+      ],
+      "tokenkey_status": "not_applicable",
+      "rationale": "Client-side claude-code concern (mcp); not a gateway/relay relevance signal.",
+      "updated_at": "2026-06-03T13:57:44Z"
+    },
+    {
+      "upstream": "anthropics/claude-code#65063",
+      "url": "https://github.com/anthropics/claude-code/issues/65063",
+      "title": "[Feature Request] Add concise flag to /context command for remote access",
+      "impact": "not_applicable",
+      "categories": [
+        "terminal"
+      ],
+      "tokenkey_status": "not_applicable",
+      "rationale": "Client-side claude-code concern (terminal); not a gateway/relay relevance signal.",
+      "updated_at": "2026-06-03T15:47:11Z"
+    },
+    {
+      "upstream": "anthropics/claude-code#65064",
+      "url": "https://github.com/anthropics/claude-code/issues/65064",
+      "title": "[BUG] claude code writes memory without asking for permission",
+      "impact": "not_applicable",
+      "categories": [
+        "terminal"
+      ],
+      "tokenkey_status": "not_applicable",
+      "rationale": "Client-side claude-code concern (terminal); not a gateway/relay relevance signal.",
+      "updated_at": "2026-06-04T05:40:44Z"
+    },
+    {
+      "upstream": "anthropics/claude-code#65066",
+      "url": "https://github.com/anthropics/claude-code/issues/65066",
+      "title": "[BUG] VZErrorDomain Code=1 - Workspace fails to start on M2 MacBook Pro",
+      "impact": "not_applicable",
+      "categories": [
+        "terminal"
+      ],
+      "tokenkey_status": "not_applicable",
+      "rationale": "Client-side claude-code concern (terminal); not a gateway/relay relevance signal.",
+      "updated_at": "2026-06-03T14:32:38Z"
+    },
+    {
+      "upstream": "anthropics/claude-code#65067",
+      "url": "https://github.com/anthropics/claude-code/issues/65067",
+      "title": "[Bug] Spurious ENOSPC errors in task output capture with racing cleanup deletes",
+      "impact": "not_applicable",
+      "categories": [
+        "terminal"
+      ],
+      "tokenkey_status": "not_applicable",
+      "rationale": "Client-side claude-code concern (terminal); not a gateway/relay relevance signal.",
+      "updated_at": "2026-06-03T14:32:35Z"
+    },
+    {
+      "upstream": "anthropics/claude-code#65068",
+      "url": "https://github.com/anthropics/claude-code/issues/65068",
+      "title": "[BUG] Manage Plugins UI writes incorrect source format to known_marketplaces.json, causing Plugins tab to show empty",
+      "impact": "not_applicable",
+      "categories": [
+        "ide",
+        "terminal",
+        "plugin"
+      ],
+      "tokenkey_status": "not_applicable",
+      "rationale": "Client-side claude-code concern (ide, terminal, plugin); not a gateway/relay relevance signal.",
+      "updated_at": "2026-06-03T14:32:12Z"
+    },
+    {
+      "upstream": "anthropics/claude-code#65069",
+      "url": "https://github.com/anthropics/claude-code/issues/65069",
+      "title": "[Feature Request] Add reviewer filter for GitHub \"Pull request review requested\" event",
+      "impact": "not_applicable",
+      "categories": [
+        "terminal"
+      ],
+      "tokenkey_status": "not_applicable",
+      "rationale": "Client-side claude-code concern (terminal); not a gateway/relay relevance signal.",
+      "updated_at": "2026-06-03T14:38:43Z"
+    },
+    {
+      "upstream": "anthropics/claude-code#65070",
+      "url": "https://github.com/anthropics/claude-code/issues/65070",
+      "title": "[Bug] Superpowers plugin fails to persist after installation",
+      "impact": "not_applicable",
+      "categories": [
+        "terminal",
+        "plugin",
+        "install"
+      ],
+      "tokenkey_status": "not_applicable",
+      "rationale": "Client-side claude-code concern (terminal, plugin, install); not a gateway/relay relevance signal.",
+      "updated_at": "2026-06-03T14:41:10Z"
+    },
+    {
+      "upstream": "anthropics/claude-code#65071",
+      "url": "https://github.com/anthropics/claude-code/issues/65071",
+      "title": "[FEATURE] Inherited Subagents",
+      "impact": "not_applicable",
+      "categories": [
+        "terminal",
+        "plugin",
+        "slash_hook"
+      ],
+      "tokenkey_status": "not_applicable",
+      "rationale": "Client-side claude-code concern (terminal, plugin, slash_hook); not a gateway/relay relevance signal.",
+      "updated_at": "2026-06-03T14:46:11Z"
+    },
+    {
+      "upstream": "anthropics/claude-code#65072",
+      "url": "https://github.com/anthropics/claude-code/issues/65072",
+      "title": "[BUG] Claude desktop fails to launch after applyin an update",
+      "impact": "not_applicable",
+      "categories": [
+        "terminal",
+        "platform"
+      ],
+      "tokenkey_status": "not_applicable",
+      "rationale": "Client-side claude-code concern (terminal, platform); not a gateway/relay relevance signal.",
+      "updated_at": "2026-06-03T14:47:41Z"
+    },
+    {
+      "upstream": "anthropics/claude-code#65073",
+      "url": "https://github.com/anthropics/claude-code/issues/65073",
+      "title": "[BUG] Code-font ligatures render `<=`/`>=` as `≤`/`≥` in inline code (mobile app) — masks exact tokens",
+      "impact": "not_applicable",
+      "categories": [
+        "terminal"
+      ],
+      "tokenkey_status": "not_applicable",
+      "rationale": "Client-side claude-code concern (terminal); not a gateway/relay relevance signal.",
+      "updated_at": "2026-06-03T14:48:51Z"
+    },
+    {
+      "upstream": "anthropics/claude-code#65074",
+      "url": "https://github.com/anthropics/claude-code/issues/65074",
+      "title": "Max Plan using Sonnet 4.6 API Error 1M",
+      "impact": "not_applicable",
+      "categories": [
+        "terminal"
+      ],
+      "tokenkey_status": "not_applicable",
+      "rationale": "Client-side claude-code concern (terminal); not a gateway/relay relevance signal.",
+      "updated_at": "2026-06-03T14:49:36Z"
+    },
+    {
+      "upstream": "anthropics/claude-code#65076",
+      "url": "https://github.com/anthropics/claude-code/issues/65076",
+      "title": "[BUG] Claude Code Desktop eager loading MCPs while Claude Code CLI lazy loading",
+      "impact": "not_applicable",
+      "categories": [
+        "terminal",
+        "mcp"
+      ],
+      "tokenkey_status": "not_applicable",
+      "rationale": "Client-side claude-code concern (terminal, mcp); not a gateway/relay relevance signal.",
+      "updated_at": "2026-06-03T14:57:10Z"
+    },
+    {
+      "upstream": "anthropics/claude-code#65077",
+      "url": "https://github.com/anthropics/claude-code/issues/65077",
+      "title": "[Bug] Keyboard shortcuts (option+delete, cmd+delete) not working in fullscreen TUI layout",
+      "impact": "not_applicable",
+      "categories": [
+        "terminal",
+        "slash_hook"
+      ],
+      "tokenkey_status": "not_applicable",
+      "rationale": "Client-side claude-code concern (terminal, slash_hook); not a gateway/relay relevance signal.",
+      "updated_at": "2026-06-03T15:01:10Z"
+    },
+    {
+      "upstream": "anthropics/claude-code#65079",
+      "url": "https://github.com/anthropics/claude-code/issues/65079",
+      "title": "[Bug] Session summary lacks project isolation - causes cross-project context contamination",
+      "impact": "not_applicable",
+      "categories": [
+        "terminal",
+        "plugin",
+        "slash_hook",
+        "platform"
+      ],
+      "tokenkey_status": "not_applicable",
+      "rationale": "Client-side claude-code concern (terminal, plugin, slash_hook, platform); not a gateway/relay relevance signal.",
+      "updated_at": "2026-06-03T15:02:46Z"
+    },
+    {
+      "upstream": "anthropics/claude-code#65080",
+      "url": "https://github.com/anthropics/claude-code/issues/65080",
+      "title": "You've hit your session limit · resets 12pm (America/Los_Angeles)",
+      "impact": "not_applicable",
+      "categories": [
+        "terminal"
+      ],
+      "tokenkey_status": "not_applicable",
+      "rationale": "Client-side claude-code concern (terminal); not a gateway/relay relevance signal.",
+      "updated_at": "2026-06-03T15:39:26Z"
+    },
+    {
+      "upstream": "anthropics/claude-code#65083",
+      "url": "https://github.com/anthropics/claude-code/issues/65083",
+      "title": "[Bug] MCP servers not activating/mcp",
+      "impact": "not_applicable",
+      "categories": [
+        "ide",
+        "terminal",
+        "mcp"
+      ],
+      "tokenkey_status": "not_applicable",
+      "rationale": "Client-side claude-code concern (ide, terminal, mcp); not a gateway/relay relevance signal.",
+      "updated_at": "2026-06-03T15:30:57Z"
+    },
+    {
+      "upstream": "anthropics/claude-code#65084",
+      "url": "https://github.com/anthropics/claude-code/issues/65084",
+      "title": "[BUG]",
+      "impact": "not_applicable",
+      "categories": [
+        "terminal"
+      ],
+      "tokenkey_status": "not_applicable",
+      "rationale": "Client-side claude-code concern (terminal); not a gateway/relay relevance signal.",
+      "updated_at": "2026-06-03T15:49:03Z"
+    },
+    {
+      "upstream": "anthropics/claude-code#65086",
+      "url": "https://github.com/anthropics/claude-code/issues/65086",
+      "title": "[BUG] False ENOSPC error reported for subprocesses with no stdout and non-zero exit code",
+      "impact": "not_applicable",
+      "categories": [
+        "terminal"
+      ],
+      "tokenkey_status": "not_applicable",
+      "rationale": "Client-side claude-code concern (terminal); not a gateway/relay relevance signal.",
+      "updated_at": "2026-06-03T15:40:31Z"
+    },
+    {
+      "upstream": "anthropics/claude-code#65087",
+      "url": "https://github.com/anthropics/claude-code/issues/65087",
+      "title": "[BUG] Ctrl+C stops interrupting in a long, heavy background-agent session (macOS TUI, v2.1.161); concurrent fresh sessions interrupt fine",
+      "impact": "not_applicable",
+      "categories": [
+        "terminal",
+        "mcp",
+        "plugin",
+        "slash_hook",
+        "install",
+        "platform"
+      ],
+      "tokenkey_status": "not_applicable",
+      "rationale": "Client-side claude-code concern (terminal, mcp, plugin, slash_hook, install, platform); not a gateway/relay relevance signal.",
+      "updated_at": "2026-06-03T18:58:32Z"
+    },
+    {
+      "upstream": "anthropics/claude-code#65088",
+      "url": "https://github.com/anthropics/claude-code/issues/65088",
+      "title": "[BUG] Agent Teams mates hidden and unopenable if more than 6 Agents when collapsed into \"background tasks\"",
+      "impact": "not_applicable",
+      "categories": [
+        "terminal",
+        "platform"
+      ],
+      "tokenkey_status": "not_applicable",
+      "rationale": "Client-side claude-code concern (terminal, platform); not a gateway/relay relevance signal.",
+      "updated_at": "2026-06-03T15:44:18Z"
+    },
+    {
+      "upstream": "anthropics/claude-code#65089",
+      "url": "https://github.com/anthropics/claude-code/issues/65089",
+      "title": "Read tool PDF support broken on Windows — sandbox rejects pdftoppm from all locations",
+      "impact": "not_applicable",
+      "categories": [
+        "terminal",
+        "install",
+        "platform"
+      ],
+      "tokenkey_status": "not_applicable",
+      "rationale": "Client-side claude-code concern (terminal, install, platform); not a gateway/relay relevance signal.",
+      "updated_at": "2026-06-03T15:46:04Z"
+    },
+    {
+      "upstream": "anthropics/claude-code#65090",
+      "url": "https://github.com/anthropics/claude-code/issues/65090",
+      "title": "Claude desktop app leaks pseudo-terminals (/dev/ptmx masters), exhausting the macOS pty pool",
+      "impact": "not_applicable",
+      "categories": [
+        "ide",
+        "terminal"
+      ],
+      "tokenkey_status": "not_applicable",
+      "rationale": "Client-side claude-code concern (ide, terminal); not a gateway/relay relevance signal.",
+      "updated_at": "2026-06-03T15:47:05Z"
+    },
+    {
+      "upstream": "anthropics/claude-code#65091",
+      "url": "https://github.com/anthropics/claude-code/issues/65091",
+      "title": "[Bug] Agent unfocused reasoning dilutes code quality and introduces bugs",
+      "impact": "not_applicable",
+      "categories": [
+        "terminal"
+      ],
+      "tokenkey_status": "not_applicable",
+      "rationale": "Client-side claude-code concern (terminal); not a gateway/relay relevance signal.",
+      "updated_at": "2026-06-03T15:48:27Z"
+    },
+    {
+      "upstream": "anthropics/claude-code#65092",
+      "url": "https://github.com/anthropics/claude-code/issues/65092",
+      "title": "[Bug Report] Unable to process request - missing bug report details",
+      "impact": "not_applicable",
+      "categories": [
+        "ide",
+        "terminal"
+      ],
+      "tokenkey_status": "not_applicable",
+      "rationale": "Client-side claude-code concern (ide, terminal); not a gateway/relay relevance signal.",
+      "updated_at": "2026-06-03T15:50:59Z"
+    },
+    {
+      "upstream": "anthropics/claude-code#65093",
+      "url": "https://github.com/anthropics/claude-code/issues/65093",
+      "title": "[Bug] Transient network loss is recorded as a persistent install_failed; \"Auto-update failed\" banner never clears after reconnect (Windows native, already on latest)",
+      "impact": "not_applicable",
+      "categories": [
+        "terminal",
+        "install",
+        "platform"
+      ],
+      "tokenkey_status": "not_applicable",
+      "rationale": "Client-side claude-code concern (terminal, install, platform); not a gateway/relay relevance signal.",
+      "updated_at": "2026-06-03T15:52:01Z"
+    },
+    {
+      "upstream": "anthropics/claude-code#65095",
+      "url": "https://github.com/anthropics/claude-code/issues/65095",
+      "title": "[BUG] When Running Agent Teams and Subagents you cannot select the sub agent.",
+      "impact": "not_applicable",
+      "categories": [
+        "terminal",
+        "plugin"
+      ],
+      "tokenkey_status": "not_applicable",
+      "rationale": "Client-side claude-code concern (terminal, plugin); not a gateway/relay relevance signal.",
+      "updated_at": "2026-06-03T16:00:56Z"
+    },
+    {
+      "upstream": "anthropics/claude-code#65096",
+      "url": "https://github.com/anthropics/claude-code/issues/65096",
+      "title": "[Bug] Cross-model session resumption ignores target model budget, reports misleading spend limit error",
+      "impact": "not_applicable",
+      "categories": [
+        "terminal",
+        "platform"
+      ],
+      "tokenkey_status": "not_applicable",
+      "rationale": "Client-side claude-code concern (terminal, platform); not a gateway/relay relevance signal.",
+      "updated_at": "2026-06-03T15:57:56Z"
+    },
+    {
+      "upstream": "anthropics/claude-code#65097",
+      "url": "https://github.com/anthropics/claude-code/issues/65097",
+      "title": "Local transcript deletion (30-day TTL) should be configurable independently of data sharing",
+      "impact": "not_applicable",
+      "categories": [
+        "slash_hook"
+      ],
+      "tokenkey_status": "not_applicable",
+      "rationale": "Client-side claude-code concern (slash_hook); not a gateway/relay relevance signal.",
+      "updated_at": "2026-06-03T17:18:32Z"
+    },
+    {
+      "upstream": "anthropics/claude-code#65099",
+      "url": "https://github.com/anthropics/claude-code/issues/65099",
+      "title": "[BUG] [BUG] /goal (and /plan) ignore an explicit cancel — Stop hook keeps blocking turn termination after the goal is cancelled, especially after auto-compaction / multi-session resume",
+      "impact": "not_applicable",
+      "categories": [
+        "terminal",
+        "slash_hook"
+      ],
+      "tokenkey_status": "not_applicable",
+      "rationale": "Client-side claude-code concern (terminal, slash_hook); not a gateway/relay relevance signal.",
+      "updated_at": "2026-06-03T16:34:43Z"
+    },
+    {
+      "upstream": "anthropics/claude-code#65103",
+      "url": "https://github.com/anthropics/claude-code/issues/65103",
+      "title": "[Bug] Claude 3.5 Sonnet over-executing without explicit user request",
+      "impact": "not_applicable",
+      "categories": [
+        "terminal"
+      ],
+      "tokenkey_status": "not_applicable",
+      "rationale": "Client-side claude-code concern (terminal); not a gateway/relay relevance signal.",
+      "updated_at": "2026-06-03T16:43:51Z"
+    },
+    {
+      "upstream": "anthropics/claude-code#65104",
+      "url": "https://github.com/anthropics/claude-code/issues/65104",
+      "title": "Input box clips first 1-2 characters in Alacritty on Windows (works in Windows Terminal)",
+      "impact": "not_applicable",
+      "categories": [
+        "terminal",
+        "platform"
+      ],
+      "tokenkey_status": "not_applicable",
+      "rationale": "Client-side claude-code concern (terminal, platform); not a gateway/relay relevance signal.",
+      "updated_at": "2026-06-03T16:57:46Z"
+    },
+    {
+      "upstream": "anthropics/claude-code#65105",
+      "url": "https://github.com/anthropics/claude-code/issues/65105",
+      "title": "[BUG] Visual Studio says API Error: Usage credits required for 1M context",
+      "impact": "not_applicable",
+      "categories": [
+        "ide",
+        "terminal",
+        "platform"
+      ],
+      "tokenkey_status": "not_applicable",
+      "rationale": "Client-side claude-code concern (ide, terminal, platform); not a gateway/relay relevance signal.",
+      "updated_at": "2026-06-03T17:00:01Z"
+    },
+    {
+      "upstream": "anthropics/claude-code#65109",
+      "url": "https://github.com/anthropics/claude-code/issues/65109",
+      "title": "Feature: Auto-compact without confirmation when context reaches threshold (e.g. 90%)",
+      "impact": "not_applicable",
+      "categories": [
+        "slash_hook",
+        "platform"
+      ],
+      "tokenkey_status": "not_applicable",
+      "rationale": "Client-side claude-code concern (slash_hook, platform); not a gateway/relay relevance signal.",
+      "updated_at": "2026-06-03T17:18:43Z"
+    },
+    {
+      "upstream": "anthropics/claude-code#65110",
+      "url": "https://github.com/anthropics/claude-code/issues/65110",
+      "title": "ClickUp MCP tool availability",
+      "impact": "not_applicable",
+      "categories": [
+        "mcp"
+      ],
+      "tokenkey_status": "not_applicable",
+      "rationale": "Client-side claude-code concern (mcp); not a gateway/relay relevance signal.",
+      "updated_at": "2026-06-03T17:22:10Z"
+    },
+    {
+      "upstream": "anthropics/claude-code#65112",
+      "url": "https://github.com/anthropics/claude-code/issues/65112",
+      "title": "You've hit your session limit · resets 4:40pm (America/Toronto)",
+      "impact": "not_applicable",
+      "categories": [
+        "terminal",
+        "mcp"
+      ],
+      "tokenkey_status": "not_applicable",
+      "rationale": "Client-side claude-code concern (terminal, mcp); not a gateway/relay relevance signal.",
+      "updated_at": "2026-06-03T17:27:54Z"
+    },
+    {
+      "upstream": "anthropics/claude-code#65113",
+      "url": "https://github.com/anthropics/claude-code/issues/65113",
+      "title": "[FEATURE] Cowork: allow switching model mid-conversation (model is locked after the first message)",
+      "impact": "not_applicable",
+      "categories": [
+        "platform"
+      ],
+      "tokenkey_status": "not_applicable",
+      "rationale": "Client-side claude-code concern (platform); not a gateway/relay relevance signal.",
+      "updated_at": "2026-06-03T17:30:06Z"
+    },
+    {
+      "upstream": "anthropics/claude-code#65114",
+      "url": "https://github.com/anthropics/claude-code/issues/65114",
+      "title": "[FEATURE] Cowork: give users a manual /compact (user-initiated compaction)",
+      "impact": "not_applicable",
+      "categories": [
+        "platform"
+      ],
+      "tokenkey_status": "not_applicable",
+      "rationale": "Client-side claude-code concern (platform); not a gateway/relay relevance signal.",
+      "updated_at": "2026-06-03T17:27:22Z"
+    },
+    {
+      "upstream": "anthropics/claude-code#65115",
+      "url": "https://github.com/anthropics/claude-code/issues/65115",
+      "title": "[Bug] /loop /clear command not working",
+      "impact": "not_applicable",
+      "categories": [
+        "ide",
+        "terminal"
+      ],
+      "tokenkey_status": "not_applicable",
+      "rationale": "Client-side claude-code concern (ide, terminal); not a gateway/relay relevance signal.",
+      "updated_at": "2026-06-03T20:25:01Z"
+    },
+    {
+      "upstream": "anthropics/claude-code#65116",
+      "url": "https://github.com/anthropics/claude-code/issues/65116",
+      "title": "[Bug] Anthropic API Error: Usage Policy violation on normal coding requests",
+      "impact": "not_applicable",
+      "categories": [
+        "terminal"
+      ],
+      "tokenkey_status": "not_applicable",
+      "rationale": "Client-side claude-code concern (terminal); not a gateway/relay relevance signal.",
+      "updated_at": "2026-06-03T17:33:17Z"
+    },
+    {
+      "upstream": "anthropics/claude-code#65117",
+      "url": "https://github.com/anthropics/claude-code/issues/65117",
+      "title": "[BUG] Vertical scrollbar disappears intermittently when using background agents (reproducible across multiple terminals)",
+      "impact": "not_applicable",
+      "categories": [
+        "terminal",
+        "platform"
+      ],
+      "tokenkey_status": "not_applicable",
+      "rationale": "Client-side claude-code concern (terminal, platform); not a gateway/relay relevance signal.",
+      "updated_at": "2026-06-03T17:44:26Z"
+    },
+    {
+      "upstream": "anthropics/claude-code#65118",
+      "url": "https://github.com/anthropics/claude-code/issues/65118",
+      "title": "[BUG] [BUG] Cloud mode repository picker only shows 4 repos out of 11 accessible repositories",
+      "impact": "not_applicable",
+      "categories": [
+        "terminal",
+        "platform"
+      ],
+      "tokenkey_status": "not_applicable",
+      "rationale": "Client-side claude-code concern (terminal, platform); not a gateway/relay relevance signal.",
+      "updated_at": "2026-06-03T17:32:26Z"
+    },
+    {
+      "upstream": "anthropics/claude-code#65120",
+      "url": "https://github.com/anthropics/claude-code/issues/65120",
+      "title": "[BUG] PostToolUse hook stdout/stderr never surfaces in agent context",
+      "impact": "not_applicable",
+      "categories": [
+        "slash_hook"
+      ],
+      "tokenkey_status": "not_applicable",
+      "rationale": "Client-side claude-code concern (slash_hook); not a gateway/relay relevance signal.",
+      "updated_at": "2026-06-03T17:42:14Z"
+    },
+    {
+      "upstream": "anthropics/claude-code#65122",
+      "url": "https://github.com/anthropics/claude-code/issues/65122",
+      "title": "Feature request: harness-level Bash-output secret redaction (3 leak incidents in 6 days, willing to contribute regex set + test suite)",
+      "impact": "not_applicable",
+      "categories": [
+        "slash_hook",
+        "install",
+        "platform"
+      ],
+      "tokenkey_status": "not_applicable",
+      "rationale": "Client-side claude-code concern (slash_hook, install, platform); not a gateway/relay relevance signal.",
+      "updated_at": "2026-06-03T17:43:33Z"
+    },
+    {
+      "upstream": "anthropics/claude-code#65124",
+      "url": "https://github.com/anthropics/claude-code/issues/65124",
+      "title": "[BUG] Instant depletion of usage on claude desktop",
+      "impact": "not_applicable",
+      "categories": [
+        "terminal"
+      ],
+      "tokenkey_status": "not_applicable",
+      "rationale": "Client-side claude-code concern (terminal); not a gateway/relay relevance signal.",
+      "updated_at": "2026-06-03T17:53:22Z"
+    },
+    {
+      "upstream": "anthropics/claude-code#65126",
+      "url": "https://github.com/anthropics/claude-code/issues/65126",
+      "title": "[Bug] /remote-control ignores /rename session name, defaults to random name",
+      "impact": "not_applicable",
+      "categories": [
+        "terminal"
+      ],
+      "tokenkey_status": "not_applicable",
+      "rationale": "Client-side claude-code concern (terminal); not a gateway/relay relevance signal.",
+      "updated_at": "2026-06-03T17:49:51Z"
+    },
+    {
+      "upstream": "anthropics/claude-code#65127",
+      "url": "https://github.com/anthropics/claude-code/issues/65127",
+      "title": "[BUG] French accented characters frequently omitted across all Claude products",
+      "impact": "not_applicable",
+      "categories": [
+        "terminal"
+      ],
+      "tokenkey_status": "not_applicable",
+      "rationale": "Client-side claude-code concern (terminal); not a gateway/relay relevance signal.",
+      "updated_at": "2026-06-03T17:50:54Z"
+    },
+    {
+      "upstream": "anthropics/claude-code#65128",
+      "url": "https://github.com/anthropics/claude-code/issues/65128",
+      "title": "VM Connection timeout after 60 seconds",
+      "impact": "not_applicable",
+      "categories": [
+        "terminal",
+        "platform"
+      ],
+      "tokenkey_status": "not_applicable",
+      "rationale": "Client-side claude-code concern (terminal, platform); not a gateway/relay relevance signal.",
+      "updated_at": "2026-06-03T17:50:02Z"
+    },
+    {
+      "upstream": "anthropics/claude-code#65133",
+      "url": "https://github.com/anthropics/claude-code/issues/65133",
+      "title": "[Bug] Auto-update failed - /doctor recommended for diagnosis",
+      "impact": "not_applicable",
+      "categories": [
+        "terminal"
+      ],
+      "tokenkey_status": "not_applicable",
+      "rationale": "Client-side claude-code concern (terminal); not a gateway/relay relevance signal.",
+      "updated_at": "2026-06-03T18:16:24Z"
+    },
+    {
+      "upstream": "anthropics/claude-code#65134",
+      "url": "https://github.com/anthropics/claude-code/issues/65134",
+      "title": "[Feature Request] Allow dynamic /effort adjustment during prompt execution",
+      "impact": "not_applicable",
+      "categories": [
+        "terminal"
+      ],
+      "tokenkey_status": "not_applicable",
+      "rationale": "Client-side claude-code concern (terminal); not a gateway/relay relevance signal.",
+      "updated_at": "2026-06-03T19:36:59Z"
+    },
+    {
+      "upstream": "anthropics/claude-code#65135",
+      "url": "https://github.com/anthropics/claude-code/issues/65135",
+      "title": "[Feature Request] Add token usage visualization and context management at checkpoints",
+      "impact": "not_applicable",
+      "categories": [
+        "ide",
+        "terminal"
+      ],
+      "tokenkey_status": "not_applicable",
+      "rationale": "Client-side claude-code concern (ide, terminal); not a gateway/relay relevance signal.",
+      "updated_at": "2026-06-03T18:24:36Z"
+    },
+    {
+      "upstream": "anthropics/claude-code#65136",
+      "url": "https://github.com/anthropics/claude-code/issues/65136",
+      "title": "[Bug] Persistent display text \"PR #260\" cannot be removed after session reset",
+      "impact": "not_applicable",
+      "categories": [
+        "terminal"
+      ],
+      "tokenkey_status": "not_applicable",
+      "rationale": "Client-side claude-code concern (terminal); not a gateway/relay relevance signal.",
+      "updated_at": "2026-06-03T18:36:43Z"
+    },
+    {
+      "upstream": "anthropics/claude-code#65137",
+      "url": "https://github.com/anthropics/claude-code/issues/65137",
+      "title": "[Bug] Input prompt characters conflict with feedback/sharing shortcuts",
+      "impact": "not_applicable",
+      "categories": [
+        "ide",
+        "terminal",
+        "slash_hook"
+      ],
+      "tokenkey_status": "not_applicable",
+      "rationale": "Client-side claude-code concern (ide, terminal, slash_hook); not a gateway/relay relevance signal.",
+      "updated_at": "2026-06-03T18:44:55Z"
+    },
+    {
+      "upstream": "anthropics/claude-code#65139",
+      "url": "https://github.com/anthropics/claude-code/issues/65139",
+      "title": "[BUG] Usage Limit",
+      "impact": "not_applicable",
+      "categories": [
+        "terminal",
+        "platform"
+      ],
+      "tokenkey_status": "not_applicable",
+      "rationale": "Client-side claude-code concern (terminal, platform); not a gateway/relay relevance signal.",
+      "updated_at": "2026-06-03T19:01:36Z"
+    },
+    {
+      "upstream": "anthropics/claude-code#65140",
+      "url": "https://github.com/anthropics/claude-code/issues/65140",
+      "title": "[FEATURE] Option to restore the detailed/colored dynamic workflow progress display (removed in 2.1.152)",
+      "impact": "not_applicable",
+      "categories": [
+        "terminal",
+        "slash_hook",
+        "install"
+      ],
+      "tokenkey_status": "not_applicable",
+      "rationale": "Client-side claude-code concern (terminal, slash_hook, install); not a gateway/relay relevance signal.",
+      "updated_at": "2026-06-03T19:02:16Z"
+    },
+    {
+      "upstream": "anthropics/claude-code#65141",
+      "url": "https://github.com/anthropics/claude-code/issues/65141",
+      "title": "Suggest /login command in auth error messages",
+      "impact": "not_applicable",
+      "categories": [
+        "ide",
+        "plugin"
+      ],
+      "tokenkey_status": "not_applicable",
+      "rationale": "Client-side claude-code concern (ide, plugin); not a gateway/relay relevance signal.",
+      "updated_at": "2026-06-03T19:07:25Z"
+    },
+    {
+      "upstream": "anthropics/claude-code#65142",
+      "url": "https://github.com/anthropics/claude-code/issues/65142",
+      "title": "MCP tools inaccessible in --agent mode even with explicit --mcp-config flag",
+      "impact": "not_applicable",
+      "categories": [
+        "mcp",
+        "plugin"
+      ],
+      "tokenkey_status": "not_applicable",
+      "rationale": "Client-side claude-code concern (mcp, plugin); not a gateway/relay relevance signal.",
+      "updated_at": "2026-06-03T19:15:31Z"
+    },
+    {
+      "upstream": "anthropics/claude-code#65143",
+      "url": "https://github.com/anthropics/claude-code/issues/65143",
+      "title": "[BUG] SSO Sign-in on desktop app creating new user",
+      "impact": "not_applicable",
+      "categories": [
+        "terminal"
+      ],
+      "tokenkey_status": "not_applicable",
+      "rationale": "Client-side claude-code concern (terminal); not a gateway/relay relevance signal.",
+      "updated_at": "2026-06-03T19:08:59Z"
+    },
+    {
+      "upstream": "anthropics/claude-code#65145",
+      "url": "https://github.com/anthropics/claude-code/issues/65145",
+      "title": "[BUG] Sonnet 4.6 implementing several not requested changes in code and admitting it.",
+      "impact": "not_applicable",
+      "categories": [
+        "ide",
+        "terminal",
+        "platform"
+      ],
+      "tokenkey_status": "not_applicable",
+      "rationale": "Client-side claude-code concern (ide, terminal, platform); not a gateway/relay relevance signal.",
+      "updated_at": "2026-06-03T19:12:29Z"
+    },
+    {
+      "upstream": "anthropics/claude-code#65146",
+      "url": "https://github.com/anthropics/claude-code/issues/65146",
+      "title": "[Feature Request] Add session rename and dynamic color customization commands",
+      "impact": "not_applicable",
+      "categories": [
+        "terminal"
+      ],
+      "tokenkey_status": "not_applicable",
+      "rationale": "Client-side claude-code concern (terminal); not a gateway/relay relevance signal.",
+      "updated_at": "2026-06-03T19:13:58Z"
+    },
+    {
+      "upstream": "anthropics/claude-code#65149",
+      "url": "https://github.com/anthropics/claude-code/issues/65149",
+      "title": "[Bug] Claude ignores user instructions and executes without approval despite repeated prompting",
+      "impact": "not_applicable",
+      "categories": [
+        "terminal"
+      ],
+      "tokenkey_status": "not_applicable",
+      "rationale": "Client-side claude-code concern (terminal); not a gateway/relay relevance signal.",
+      "updated_at": "2026-06-03T19:38:43Z"
+    },
+    {
+      "upstream": "anthropics/claude-code#65150",
+      "url": "https://github.com/anthropics/claude-code/issues/65150",
+      "title": "Claude Code requires 1M context credits for standard agentic tasks on Pro plan",
+      "impact": "not_applicable",
+      "categories": [
+        "terminal",
+        "platform"
+      ],
+      "tokenkey_status": "not_applicable",
+      "rationale": "Client-side claude-code concern (terminal, platform); not a gateway/relay relevance signal.",
+      "updated_at": "2026-06-03T19:39:28Z"
+    },
+    {
+      "upstream": "anthropics/claude-code#65153",
+      "url": "https://github.com/anthropics/claude-code/issues/65153",
+      "title": "[Bug] Escape key in /btw modal closes parent task instead of modal",
+      "impact": "not_applicable",
+      "categories": [
+        "terminal"
+      ],
+      "tokenkey_status": "not_applicable",
+      "rationale": "Client-side claude-code concern (terminal); not a gateway/relay relevance signal.",
+      "updated_at": "2026-06-03T19:49:23Z"
+    },
+    {
+      "upstream": "anthropics/claude-code#65154",
+      "url": "https://github.com/anthropics/claude-code/issues/65154",
+      "title": "[BUG] Image paste from clipboard takes minutes (broken since ~2.1.150) on Windows 11",
+      "impact": "not_applicable",
+      "categories": [
+        "terminal",
+        "install",
+        "platform"
+      ],
+      "tokenkey_status": "not_applicable",
+      "rationale": "Client-side claude-code concern (terminal, install, platform); not a gateway/relay relevance signal.",
+      "updated_at": "2026-06-03T19:53:46Z"
+    },
+    {
+      "upstream": "anthropics/claude-code#65156",
+      "url": "https://github.com/anthropics/claude-code/issues/65156",
+      "title": "[BUG] Unknown --effort value 'ultracode'",
+      "impact": "not_applicable",
+      "categories": [
+        "terminal"
+      ],
+      "tokenkey_status": "not_applicable",
+      "rationale": "Client-side claude-code concern (terminal); not a gateway/relay relevance signal.",
+      "updated_at": "2026-06-03T20:06:48Z"
+    },
+    {
+      "upstream": "anthropics/claude-code#65157",
+      "url": "https://github.com/anthropics/claude-code/issues/65157",
+      "title": "[BUG] No repos match in claude code web version even though github app is installed",
+      "impact": "not_applicable",
+      "categories": [
+        "terminal",
+        "platform"
+      ],
+      "tokenkey_status": "not_applicable",
+      "rationale": "Client-side claude-code concern (terminal, platform); not a gateway/relay relevance signal.",
+      "updated_at": "2026-06-03T20:07:53Z"
+    },
+    {
+      "upstream": "anthropics/claude-code#65159",
+      "url": "https://github.com/anthropics/claude-code/issues/65159",
+      "title": "Slash command arguments are stripped before submission in Cowork desktop client",
+      "impact": "not_applicable",
+      "categories": [
+        "slash_hook"
+      ],
+      "tokenkey_status": "not_applicable",
+      "rationale": "Client-side claude-code concern (slash_hook); not a gateway/relay relevance signal.",
+      "updated_at": "2026-06-03T20:26:22Z"
+    },
+    {
+      "upstream": "anthropics/claude-code#65160",
+      "url": "https://github.com/anthropics/claude-code/issues/65160",
+      "title": "[Bug] MCP Server Setup Configuration Issues",
+      "impact": "not_applicable",
+      "categories": [
+        "terminal",
+        "mcp"
+      ],
+      "tokenkey_status": "not_applicable",
+      "rationale": "Client-side claude-code concern (terminal, mcp); not a gateway/relay relevance signal.",
+      "updated_at": "2026-06-03T20:23:39Z"
+    },
+    {
+      "upstream": "anthropics/claude-code#65163",
+      "url": "https://github.com/anthropics/claude-code/issues/65163",
+      "title": "[Bug Report] Unable to determine issue from empty report",
+      "impact": "not_applicable",
+      "categories": [
+        "terminal"
+      ],
+      "tokenkey_status": "not_applicable",
+      "rationale": "Client-side claude-code concern (terminal); not a gateway/relay relevance signal.",
+      "updated_at": "2026-06-03T20:32:08Z"
+    },
+    {
+      "upstream": "anthropics/claude-code#65164",
+      "url": "https://github.com/anthropics/claude-code/issues/65164",
+      "title": "[Bug] Excessive agent spawning causes extended execution times and performance degradation",
+      "impact": "not_applicable",
+      "categories": [
+        "terminal"
+      ],
+      "tokenkey_status": "not_applicable",
+      "rationale": "Client-side claude-code concern (terminal); not a gateway/relay relevance signal.",
+      "updated_at": "2026-06-03T20:36:00Z"
+    },
+    {
+      "upstream": "anthropics/claude-code#65167",
+      "url": "https://github.com/anthropics/claude-code/issues/65167",
+      "title": "[BUG] VS Code Manage Plugins panel renders only Installed — available list & search missing in v2.1.161 (native binary returns 196 available)",
+      "impact": "not_applicable",
+      "categories": [
+        "ide",
+        "terminal",
+        "plugin",
+        "install"
+      ],
+      "tokenkey_status": "not_applicable",
+      "rationale": "Client-side claude-code concern (ide, terminal, plugin, install); not a gateway/relay relevance signal.",
+      "updated_at": "2026-06-03T20:36:10Z"
+    },
+    {
+      "upstream": "anthropics/claude-code#65168",
+      "url": "https://github.com/anthropics/claude-code/issues/65168",
+      "title": "[Feature Request] Display completion timestamp in operation duration summary",
+      "impact": "not_applicable",
+      "categories": [
+        "terminal"
+      ],
+      "tokenkey_status": "not_applicable",
+      "rationale": "Client-side claude-code concern (terminal); not a gateway/relay relevance signal.",
+      "updated_at": "2026-06-03T20:57:20Z"
+    },
+    {
+      "upstream": "anthropics/claude-code#65169",
+      "url": "https://github.com/anthropics/claude-code/issues/65169",
+      "title": "PostToolUse hook does not fire for Agent tool completions",
+      "impact": "not_applicable",
+      "categories": [
+        "mcp",
+        "plugin",
+        "slash_hook"
+      ],
+      "tokenkey_status": "not_applicable",
+      "rationale": "Client-side claude-code concern (mcp, plugin, slash_hook); not a gateway/relay relevance signal.",
+      "updated_at": "2026-06-04T01:29:34Z"
+    },
+    {
+      "upstream": "anthropics/claude-code#65170",
+      "url": "https://github.com/anthropics/claude-code/issues/65170",
+      "title": "I don't see a bug report or issue description in your message - only a Request ID. Could you please provide the actual bug report details so I can generate an appropriate GitHub issue title?",
+      "impact": "not_applicable",
+      "categories": [
+        "terminal"
+      ],
+      "tokenkey_status": "not_applicable",
+      "rationale": "Client-side claude-code concern (terminal); not a gateway/relay relevance signal.",
+      "updated_at": "2026-06-03T21:08:34Z"
+    },
+    {
+      "upstream": "anthropics/claude-code#65171",
+      "url": "https://github.com/anthropics/claude-code/issues/65171",
+      "title": "[Windows] Option to suppress console windows for child processes spawned by the CLI (Bash tool, npm/npx, plugins)",
+      "impact": "not_applicable",
+      "categories": [
+        "plugin",
+        "slash_hook",
+        "install",
+        "platform"
+      ],
+      "tokenkey_status": "not_applicable",
+      "rationale": "Client-side claude-code concern (plugin, slash_hook, install, platform); not a gateway/relay relevance signal.",
+      "updated_at": "2026-06-03T21:17:49Z"
+    },
+    {
+      "upstream": "anthropics/claude-code#65173",
+      "url": "https://github.com/anthropics/claude-code/issues/65173",
+      "title": "Auto-memory not persisted across sessions despite standing instruction — causes significant token waste",
+      "impact": "not_applicable",
+      "categories": [
+        "slash_hook"
+      ],
+      "tokenkey_status": "not_applicable",
+      "rationale": "Client-side claude-code concern (slash_hook); not a gateway/relay relevance signal.",
+      "updated_at": "2026-06-03T23:01:54Z"
+    },
+    {
+      "upstream": "anthropics/claude-code#65174",
+      "url": "https://github.com/anthropics/claude-code/issues/65174",
+      "title": "[BUG] Underscore in shell functions broken",
+      "impact": "not_applicable",
+      "categories": [
+        "ide",
+        "terminal"
+      ],
+      "tokenkey_status": "not_applicable",
+      "rationale": "Client-side claude-code concern (ide, terminal); not a gateway/relay relevance signal.",
+      "updated_at": "2026-06-03T21:20:47Z"
+    },
+    {
+      "upstream": "anthropics/claude-code#65176",
+      "url": "https://github.com/anthropics/claude-code/issues/65176",
+      "title": "Claude for Chrome 1.0.74 — Chrome 148 / macOS 26.5 NSCGSTransaction race condition crashes",
+      "impact": "not_applicable",
+      "categories": [
+        "ide",
+        "terminal",
+        "mcp",
+        "platform"
+      ],
+      "tokenkey_status": "not_applicable",
+      "rationale": "Client-side claude-code concern (ide, terminal, mcp, platform); not a gateway/relay relevance signal.",
+      "updated_at": "2026-06-03T21:36:31Z"
+    },
+    {
+      "upstream": "anthropics/claude-code#65178",
+      "url": "https://github.com/anthropics/claude-code/issues/65178",
+      "title": "[Bug] Claude ignoring user instructions in Claude Code CLI",
+      "impact": "not_applicable",
+      "categories": [
+        "terminal"
+      ],
+      "tokenkey_status": "not_applicable",
+      "rationale": "Client-side claude-code concern (terminal); not a gateway/relay relevance signal.",
+      "updated_at": "2026-06-03T22:53:53Z"
+    },
+    {
+      "upstream": "anthropics/claude-code#65180",
+      "url": "https://github.com/anthropics/claude-code/issues/65180",
+      "title": "[Bug] `/exit` command not recognized or documented",
+      "impact": "not_applicable",
+      "categories": [
+        "terminal"
+      ],
+      "tokenkey_status": "not_applicable",
+      "rationale": "Client-side claude-code concern (terminal); not a gateway/relay relevance signal.",
+      "updated_at": "2026-06-03T22:01:10Z"
+    },
+    {
+      "upstream": "anthropics/claude-code#65181",
+      "url": "https://github.com/anthropics/claude-code/issues/65181",
+      "title": "Pasted/AirDropped file attachments land in unreadable sandbox path on macOS",
+      "impact": "not_applicable",
+      "categories": [
+        "terminal"
+      ],
+      "tokenkey_status": "not_applicable",
+      "rationale": "Client-side claude-code concern (terminal); not a gateway/relay relevance signal.",
+      "updated_at": "2026-06-03T22:23:31Z"
+    },
+    {
+      "upstream": "anthropics/claude-code#65183",
+      "url": "https://github.com/anthropics/claude-code/issues/65183",
+      "title": "[DOCS] `--tools` docs omit native-build `Grep`/`Glob` behavior with embedded search",
+      "impact": "not_applicable",
+      "categories": [
+        "plugin",
+        "slash_hook",
+        "install",
+        "platform"
+      ],
+      "tokenkey_status": "not_applicable",
+      "rationale": "Client-side claude-code concern (plugin, slash_hook, install, platform); not a gateway/relay relevance signal.",
+      "updated_at": "2026-06-03T22:29:34Z"
+    },
+    {
+      "upstream": "anthropics/claude-code#65184",
+      "url": "https://github.com/anthropics/claude-code/issues/65184",
+      "title": "[DOCS] Remote Control docs still describe a startup message/banner instead of the persistent footer pill session link",
+      "impact": "not_applicable",
+      "categories": [
+        "ide"
+      ],
+      "tokenkey_status": "not_applicable",
+      "rationale": "Client-side claude-code concern (ide); not a gateway/relay relevance signal.",
+      "updated_at": "2026-06-03T22:29:19Z"
+    },
+    {
+      "upstream": "anthropics/claude-code#65185",
+      "url": "https://github.com/anthropics/claude-code/issues/65185",
+      "title": "[DOCS] Config directory docs omit read-only/unwritable startup fallback",
+      "impact": "not_applicable",
+      "categories": [
+        "mcp",
+        "plugin",
+        "install",
+        "platform"
+      ],
+      "tokenkey_status": "not_applicable",
+      "rationale": "Client-side claude-code concern (mcp, plugin, install, platform); not a gateway/relay relevance signal.",
+      "updated_at": "2026-06-03T22:29:20Z"
+    },
+    {
+      "upstream": "anthropics/claude-code#65189",
+      "url": "https://github.com/anthropics/claude-code/issues/65189",
+      "title": "[DOCS] `claude agents` image-paste docs omit peek-panel reply input behavior",
+      "impact": "not_applicable",
+      "categories": [
+        "slash_hook"
+      ],
+      "tokenkey_status": "not_applicable",
+      "rationale": "Client-side claude-code concern (slash_hook); not a gateway/relay relevance signal.",
+      "updated_at": "2026-06-03T22:29:26Z"
+    },
+    {
+      "upstream": "anthropics/claude-code#65191",
+      "url": "https://github.com/anthropics/claude-code/issues/65191",
+      "title": "[DOCS] Deep links docs still describe launch warnings as above-input banners",
+      "impact": "not_applicable",
+      "categories": [
+        "terminal"
+      ],
+      "tokenkey_status": "not_applicable",
+      "rationale": "Client-side claude-code concern (terminal); not a gateway/relay relevance signal.",
+      "updated_at": "2026-06-03T22:29:31Z"
+    },
+    {
+      "upstream": "anthropics/claude-code#65195",
+      "url": "https://github.com/anthropics/claude-code/issues/65195",
+      "title": "[Bug] Claude 4.8 code generation quality degradation with x-high effort setting",
+      "impact": "not_applicable",
+      "categories": [
+        "terminal"
+      ],
+      "tokenkey_status": "not_applicable",
+      "rationale": "Client-side claude-code concern (terminal); not a gateway/relay relevance signal.",
+      "updated_at": "2026-06-03T22:43:44Z"
+    },
+    {
+      "upstream": "anthropics/claude-code#65196",
+      "url": "https://github.com/anthropics/claude-code/issues/65196",
+      "title": "[FEATURE] Display the context usage in the main ui",
+      "impact": "not_applicable",
+      "categories": [
+        "terminal"
+      ],
+      "tokenkey_status": "not_applicable",
+      "rationale": "Client-side claude-code concern (terminal); not a gateway/relay relevance signal.",
+      "updated_at": "2026-06-03T22:53:13Z"
+    },
+    {
+      "upstream": "anthropics/claude-code#65198",
+      "url": "https://github.com/anthropics/claude-code/issues/65198",
+      "title": "[Bug] MCP Server Authentication Failed: Indeed MCP Connection Error -32429",
+      "impact": "not_applicable",
+      "categories": [
+        "terminal",
+        "mcp"
+      ],
+      "tokenkey_status": "not_applicable",
+      "rationale": "Client-side claude-code concern (terminal, mcp); not a gateway/relay relevance signal.",
+      "updated_at": "2026-06-03T22:42:03Z"
+    },
+    {
+      "upstream": "anthropics/claude-code#65199",
+      "url": "https://github.com/anthropics/claude-code/issues/65199",
+      "title": "[BUG] i upgraded plan and message still showing over limit and button 'retry'",
+      "impact": "not_applicable",
+      "categories": [
+        "terminal",
+        "platform"
+      ],
+      "tokenkey_status": "not_applicable",
+      "rationale": "Client-side claude-code concern (terminal, platform); not a gateway/relay relevance signal.",
+      "updated_at": "2026-06-03T22:42:08Z"
+    },
+    {
+      "upstream": "anthropics/claude-code#65201",
+      "url": "https://github.com/anthropics/claude-code/issues/65201",
+      "title": "Cowork (Desktop local-agent-mode) doesn't refresh an installed plugin after a marketplace version bump",
+      "impact": "not_applicable",
+      "categories": [
+        "plugin",
+        "install"
+      ],
+      "tokenkey_status": "not_applicable",
+      "rationale": "Client-side claude-code concern (plugin, install); not a gateway/relay relevance signal.",
+      "updated_at": "2026-06-03T22:57:11Z"
+    },
+    {
+      "upstream": "anthropics/claude-code#65202",
+      "url": "https://github.com/anthropics/claude-code/issues/65202",
+      "title": "I'm ready to help generate a GitHub issue title for Claude Code. However, I don't see a bug report in your message. Please provide the bug report or issue description, and I'll create a concise, technical GitHub issue title following the guidelines you'v",
+      "impact": "not_applicable",
+      "categories": [
+        "terminal"
+      ],
+      "tokenkey_status": "not_applicable",
+      "rationale": "Client-side claude-code concern (terminal); not a gateway/relay relevance signal.",
+      "updated_at": "2026-06-03T22:57:31Z"
+    },
+    {
+      "upstream": "anthropics/claude-code#65204",
+      "url": "https://github.com/anthropics/claude-code/issues/65204",
+      "title": "[Bug] Unable to process request - missing bug report details",
+      "impact": "not_applicable",
+      "categories": [
+        "terminal"
+      ],
+      "tokenkey_status": "not_applicable",
+      "rationale": "Client-side claude-code concern (terminal); not a gateway/relay relevance signal.",
+      "updated_at": "2026-06-03T23:23:44Z"
+    },
+    {
+      "upstream": "anthropics/claude-code#65205",
+      "url": "https://github.com/anthropics/claude-code/issues/65205",
+      "title": "[BUG] Claude Cowork defaults to 1M context on Pro plan, throwing \"Usage credits required\" error (Ignores env variables)",
+      "impact": "not_applicable",
+      "categories": [
+        "terminal"
+      ],
+      "tokenkey_status": "not_applicable",
+      "rationale": "Client-side claude-code concern (terminal); not a gateway/relay relevance signal.",
+      "updated_at": "2026-06-03T23:27:53Z"
+    },
+    {
+      "upstream": "anthropics/claude-code#65209",
+      "url": "https://github.com/anthropics/claude-code/issues/65209",
+      "title": "[Bug] Multiple Claude installations conflict at ~/.local/bin/claude",
+      "impact": "not_applicable",
+      "categories": [
+        "terminal",
+        "install"
+      ],
+      "tokenkey_status": "not_applicable",
+      "rationale": "Client-side claude-code concern (terminal, install); not a gateway/relay relevance signal.",
+      "updated_at": "2026-06-03T23:33:00Z"
+    },
+    {
+      "upstream": "anthropics/claude-code#65211",
+      "url": "https://github.com/anthropics/claude-code/issues/65211",
+      "title": "[BUG] Grep/Glob restore opt-in (2.1.162) only works via --allowedTools CLI args — settings.json permission rules are ignored",
+      "impact": "not_applicable",
+      "categories": [
+        "slash_hook"
+      ],
+      "tokenkey_status": "not_applicable",
+      "rationale": "Client-side claude-code concern (slash_hook); not a gateway/relay relevance signal.",
+      "updated_at": "2026-06-03T23:37:19Z"
+    },
+    {
+      "upstream": "anthropics/claude-code#65214",
+      "url": "https://github.com/anthropics/claude-code/issues/65214",
+      "title": "MCP tool call arguments may not be serialised with correct types — integers and arrays arrive at server as strings",
+      "impact": "not_applicable",
+      "categories": [
+        "mcp"
+      ],
+      "tokenkey_status": "not_applicable",
+      "rationale": "Client-side claude-code concern (mcp); not a gateway/relay relevance signal.",
+      "updated_at": "2026-06-03T23:51:19Z"
+    },
+    {
+      "upstream": "anthropics/claude-code#65215",
+      "url": "https://github.com/anthropics/claude-code/issues/65215",
+      "title": "[BUG] Copy Path on a rendered relative file link resolves against cwd, not the linked file's own directory",
+      "impact": "not_applicable",
+      "categories": [
+        "terminal",
+        "platform"
+      ],
+      "tokenkey_status": "not_applicable",
+      "rationale": "Client-side claude-code concern (terminal, platform); not a gateway/relay relevance signal.",
+      "updated_at": "2026-06-03T23:54:10Z"
+    },
+    {
+      "upstream": "anthropics/claude-code#65216",
+      "url": "https://github.com/anthropics/claude-code/issues/65216",
+      "title": "Worktree-relocated background agent sessions crash-loop on reopen from the agents view (\"No conversation found with session ID\")",
+      "impact": "not_applicable",
+      "categories": [
+        "terminal"
+      ],
+      "tokenkey_status": "not_applicable",
+      "rationale": "Client-side claude-code concern (terminal); not a gateway/relay relevance signal.",
+      "updated_at": "2026-06-04T00:30:24Z"
+    },
+    {
+      "upstream": "anthropics/claude-code#65217",
+      "url": "https://github.com/anthropics/claude-code/issues/65217",
+      "title": "[BUG] Empty ANTHROPIC_AUTH_TOKEN injected into the Code shell breaks the official anthropic SDK (malformed Authorization: Bearer) in child processes",
+      "impact": "not_applicable",
+      "categories": [
+        "terminal",
+        "install",
+        "platform"
+      ],
+      "tokenkey_status": "not_applicable",
+      "rationale": "Client-side claude-code concern (terminal, install, platform); not a gateway/relay relevance signal.",
+      "updated_at": "2026-06-03T23:57:51Z"
+    },
+    {
+      "upstream": "anthropics/claude-code#65219",
+      "url": "https://github.com/anthropics/claude-code/issues/65219",
+      "title": "[BUG] Exit-time resume hint silently skipped when session exits inside a .claude/worktrees/ worktree (transcript check uses cwd-at-exit)",
+      "impact": "not_applicable",
+      "categories": [
+        "terminal",
+        "plugin"
+      ],
+      "tokenkey_status": "not_applicable",
+      "rationale": "Client-side claude-code concern (terminal, plugin); not a gateway/relay relevance signal.",
+      "updated_at": "2026-06-04T00:11:01Z"
+    },
+    {
+      "upstream": "anthropics/claude-code#65220",
+      "url": "https://github.com/anthropics/claude-code/issues/65220",
+      "title": "[BUG] Unable to open Task Manager, some Windows Settings, etc. because of Claude",
+      "impact": "not_applicable",
+      "categories": [
+        "terminal",
+        "platform"
+      ],
+      "tokenkey_status": "not_applicable",
+      "rationale": "Client-side claude-code concern (terminal, platform); not a gateway/relay relevance signal.",
+      "updated_at": "2026-06-04T00:23:30Z"
+    },
+    {
+      "upstream": "anthropics/claude-code#65226",
+      "url": "https://github.com/anthropics/claude-code/issues/65226",
+      "title": "[Bug Report] Unable to process - insufficient context provided",
+      "impact": "not_applicable",
+      "categories": [
+        "ide",
+        "terminal"
+      ],
+      "tokenkey_status": "not_applicable",
+      "rationale": "Client-side claude-code concern (ide, terminal); not a gateway/relay relevance signal.",
+      "updated_at": "2026-06-04T00:48:56Z"
+    },
+    {
+      "upstream": "anthropics/claude-code#65227",
+      "url": "https://github.com/anthropics/claude-code/issues/65227",
+      "title": "Claude Code switched from subscription to API-credit billing without user action — no indicator until spend limits hit",
+      "impact": "not_applicable",
+      "categories": [
+        "ide",
+        "terminal"
+      ],
+      "tokenkey_status": "not_applicable",
+      "rationale": "Client-side claude-code concern (ide, terminal); not a gateway/relay relevance signal.",
+      "updated_at": "2026-06-04T00:52:45Z"
+    },
+    {
+      "upstream": "anthropics/claude-code#65228",
+      "url": "https://github.com/anthropics/claude-code/issues/65228",
+      "title": "Arrow up/down always navigate prompt history (no edge-aware line nav); keybindings.json override ignored in Ghostty",
+      "impact": "not_applicable",
+      "categories": [
+        "terminal",
+        "slash_hook"
+      ],
+      "tokenkey_status": "not_applicable",
+      "rationale": "Client-side claude-code concern (terminal, slash_hook); not a gateway/relay relevance signal.",
+      "updated_at": "2026-06-04T00:50:11Z"
+    },
+    {
+      "upstream": "anthropics/claude-code#65229",
+      "url": "https://github.com/anthropics/claude-code/issues/65229",
+      "title": "[BUG] Edit tool silently destroys some files in OneDrive-synced folders via non-deterministic delete-then-rename race (Windows)",
+      "impact": "not_applicable",
+      "categories": [
+        "ide",
+        "platform"
+      ],
+      "tokenkey_status": "not_applicable",
+      "rationale": "Client-side claude-code concern (ide, platform); not a gateway/relay relevance signal.",
+      "updated_at": "2026-06-04T01:11:41Z"
+    },
+    {
+      "upstream": "anthropics/claude-code#65231",
+      "url": "https://github.com/anthropics/claude-code/issues/65231",
+      "title": "[Bug] MCP Setup Configuration Error",
+      "impact": "not_applicable",
+      "categories": [
+        "terminal",
+        "mcp"
+      ],
+      "tokenkey_status": "not_applicable",
+      "rationale": "Client-side claude-code concern (terminal, mcp); not a gateway/relay relevance signal.",
+      "updated_at": "2026-06-04T01:04:22Z"
+    },
+    {
+      "upstream": "anthropics/claude-code#65232",
+      "url": "https://github.com/anthropics/claude-code/issues/65232",
+      "title": "[BUG] Claude exits immediately to PowerShell prompt without any error message",
+      "impact": "not_applicable",
+      "categories": [
+        "terminal",
+        "platform"
+      ],
+      "tokenkey_status": "not_applicable",
+      "rationale": "Client-side claude-code concern (terminal, platform); not a gateway/relay relevance signal.",
+      "updated_at": "2026-06-04T01:06:08Z"
+    },
+    {
+      "upstream": "anthropics/claude-code#65234",
+      "url": "https://github.com/anthropics/claude-code/issues/65234",
+      "title": "[Bug] Background shells from run_in_background never reaped; no UI to manage leaked processes",
+      "impact": "not_applicable",
+      "categories": [
+        "terminal"
+      ],
+      "tokenkey_status": "not_applicable",
+      "rationale": "Client-side claude-code concern (terminal); not a gateway/relay relevance signal.",
+      "updated_at": "2026-06-04T01:28:08Z"
+    },
+    {
+      "upstream": "anthropics/claude-code#65235",
+      "url": "https://github.com/anthropics/claude-code/issues/65235",
+      "title": "[BUG] Status bar indicators (plan mode, auto-accept edits) are overwritten by \"Paste again to expand\" prompt when pasting large text",
+      "impact": "not_applicable",
+      "categories": [
+        "ide",
+        "terminal",
+        "slash_hook"
+      ],
+      "tokenkey_status": "not_applicable",
+      "rationale": "Client-side claude-code concern (ide, terminal, slash_hook); not a gateway/relay relevance signal.",
+      "updated_at": "2026-06-04T02:51:39Z"
+    },
+    {
+      "upstream": "anthropics/claude-code#65238",
+      "url": "https://github.com/anthropics/claude-code/issues/65238",
+      "title": "[Bug] MCP setup issue",
+      "impact": "not_applicable",
+      "categories": [
+        "ide",
+        "terminal",
+        "mcp"
+      ],
+      "tokenkey_status": "not_applicable",
+      "rationale": "Client-side claude-code concern (ide, terminal, mcp); not a gateway/relay relevance signal.",
+      "updated_at": "2026-06-04T01:39:59Z"
+    },
+    {
+      "upstream": "anthropics/claude-code#65239",
+      "url": "https://github.com/anthropics/claude-code/issues/65239",
+      "title": "[BUG] Claude Desktop crashes after ~7-8s on macOS 26 (Tahoe) — disk-writes resource limit exceeded by Code/Cowork VM init",
+      "impact": "not_applicable",
+      "categories": [
+        "terminal",
+        "install"
+      ],
+      "tokenkey_status": "not_applicable",
+      "rationale": "Client-side claude-code concern (terminal, install); not a gateway/relay relevance signal.",
+      "updated_at": "2026-06-04T01:53:31Z"
+    },
+    {
+      "upstream": "anthropics/claude-code#65240",
+      "url": "https://github.com/anthropics/claude-code/issues/65240",
+      "title": "[BUG] undefined is not an object (evaluating '_.thinking.trim')",
+      "impact": "not_applicable",
+      "categories": [
+        "terminal",
+        "platform"
+      ],
+      "tokenkey_status": "not_applicable",
+      "rationale": "Client-side claude-code concern (terminal, platform); not a gateway/relay relevance signal.",
+      "updated_at": "2026-06-04T01:59:01Z"
+    },
+    {
+      "upstream": "anthropics/claude-code#65242",
+      "url": "https://github.com/anthropics/claude-code/issues/65242",
+      "title": "[FEATURE] Notification system for VS Code extension — limit reset, task complete, session events",
+      "impact": "not_applicable",
+      "categories": [
+        "ide",
+        "terminal",
+        "platform"
+      ],
+      "tokenkey_status": "not_applicable",
+      "rationale": "Client-side claude-code concern (ide, terminal, platform); not a gateway/relay relevance signal.",
+      "updated_at": "2026-06-04T02:13:51Z"
+    },
+    {
+      "upstream": "anthropics/claude-code#65243",
+      "url": "https://github.com/anthropics/claude-code/issues/65243",
+      "title": "[FEATURE] Customizing Claude Code terminal tab names for GNOME on Debian",
+      "impact": "not_applicable",
+      "categories": [
+        "ide",
+        "terminal"
+      ],
+      "tokenkey_status": "not_applicable",
+      "rationale": "Client-side claude-code concern (ide, terminal); not a gateway/relay relevance signal.",
+      "updated_at": "2026-06-04T02:06:34Z"
+    },
+    {
+      "upstream": "anthropics/claude-code#65244",
+      "url": "https://github.com/anthropics/claude-code/issues/65244",
+      "title": "[FEATURE] Add \"chat\" permission mode: skip tool pool assembly for conversational sessions",
+      "impact": "not_applicable",
+      "categories": [
+        "ide"
+      ],
+      "tokenkey_status": "not_applicable",
+      "rationale": "Client-side claude-code concern (ide); not a gateway/relay relevance signal.",
+      "updated_at": "2026-06-04T02:21:34Z"
+    },
+    {
+      "upstream": "anthropics/claude-code#65245",
+      "url": "https://github.com/anthropics/claude-code/issues/65245",
+      "title": "[BUG] [Cowork] Korean text garbled output with Sonnet model - vowel corruption and syllable dropping",
+      "impact": "not_applicable",
+      "categories": [
+        "terminal",
+        "platform"
+      ],
+      "tokenkey_status": "not_applicable",
+      "rationale": "Client-side claude-code concern (terminal, platform); not a gateway/relay relevance signal.",
+      "updated_at": "2026-06-04T02:24:13Z"
+    },
+    {
+      "upstream": "anthropics/claude-code#65246",
+      "url": "https://github.com/anthropics/claude-code/issues/65246",
+      "title": "I need more specific information about the actual bug or issue you're experiencing with Claude Code to create a proper GitHub issue title. Could you please provide: 1. What were you trying to do? 2. What happened instead? 3. Any error messages or unexpec",
+      "impact": "not_applicable",
+      "categories": [
+        "terminal"
+      ],
+      "tokenkey_status": "not_applicable",
+      "rationale": "Client-side claude-code concern (terminal); not a gateway/relay relevance signal.",
+      "updated_at": "2026-06-04T02:47:45Z"
+    },
+    {
+      "upstream": "anthropics/claude-code#65249",
+      "url": "https://github.com/anthropics/claude-code/issues/65249",
+      "title": "You've hit your session limit · resets 11:10pm (America/Los_Angeles)",
+      "impact": "not_applicable",
+      "categories": [
+        "terminal"
+      ],
+      "tokenkey_status": "not_applicable",
+      "rationale": "Client-side claude-code concern (terminal); not a gateway/relay relevance signal.",
+      "updated_at": "2026-06-04T03:18:45Z"
+    },
+    {
+      "upstream": "anthropics/claude-code#65250",
+      "url": "https://github.com/anthropics/claude-code/issues/65250",
+      "title": "[Bug] Vietnamese character input not supported in terminal",
+      "impact": "not_applicable",
+      "categories": [
+        "terminal"
+      ],
+      "tokenkey_status": "not_applicable",
+      "rationale": "Client-side claude-code concern (terminal); not a gateway/relay relevance signal.",
+      "updated_at": "2026-06-04T03:21:25Z"
+    },
+    {
+      "upstream": "anthropics/claude-code#65251",
+      "url": "https://github.com/anthropics/claude-code/issues/65251",
+      "title": "[Bug] Bash tool output capture fails with false \"disk full\" (ENOSPC) error on macOS",
+      "impact": "not_applicable",
+      "categories": [
+        "terminal"
+      ],
+      "tokenkey_status": "not_applicable",
+      "rationale": "Client-side claude-code concern (terminal); not a gateway/relay relevance signal.",
+      "updated_at": "2026-06-04T03:20:03Z"
+    },
+    {
+      "upstream": "anthropics/claude-code#65252",
+      "url": "https://github.com/anthropics/claude-code/issues/65252",
+      "title": "[BUG] /schedule skill fails with \"trouble connecting with your remote claude.ai account\"",
+      "impact": "not_applicable",
+      "categories": [
+        "terminal",
+        "install",
+        "platform"
+      ],
+      "tokenkey_status": "not_applicable",
+      "rationale": "Client-side claude-code concern (terminal, install, platform); not a gateway/relay relevance signal.",
+      "updated_at": "2026-06-04T03:24:42Z"
+    },
+    {
+      "upstream": "anthropics/claude-code#65253",
+      "url": "https://github.com/anthropics/claude-code/issues/65253",
+      "title": "[Feature Request] Add command aliases for builtin commands",
+      "impact": "not_applicable",
+      "categories": [
+        "terminal"
+      ],
+      "tokenkey_status": "not_applicable",
+      "rationale": "Client-side claude-code concern (terminal); not a gateway/relay relevance signal.",
+      "updated_at": "2026-06-04T03:34:03Z"
+    },
+    {
+      "upstream": "anthropics/claude-code#65254",
+      "url": "https://github.com/anthropics/claude-code/issues/65254",
+      "title": "[BUG] Not Responding",
+      "impact": "not_applicable",
+      "categories": [
+        "terminal"
+      ],
+      "tokenkey_status": "not_applicable",
+      "rationale": "Client-side claude-code concern (terminal); not a gateway/relay relevance signal.",
+      "updated_at": "2026-06-04T03:31:19Z"
+    },
+    {
+      "upstream": "anthropics/claude-code#65256",
+      "url": "https://github.com/anthropics/claude-code/issues/65256",
+      "title": "[Bug] Anthropic API Error: Usage credits required for 1M context window",
+      "impact": "not_applicable",
+      "categories": [
+        "terminal"
+      ],
+      "tokenkey_status": "not_applicable",
+      "rationale": "Client-side claude-code concern (terminal); not a gateway/relay relevance signal.",
+      "updated_at": "2026-06-04T03:36:52Z"
+    },
+    {
+      "upstream": "anthropics/claude-code#65258",
+      "url": "https://github.com/anthropics/claude-code/issues/65258",
+      "title": "[BUG] Everything I do is a violation",
+      "impact": "not_applicable",
+      "categories": [
+        "terminal"
+      ],
+      "tokenkey_status": "not_applicable",
+      "rationale": "Client-side claude-code concern (terminal); not a gateway/relay relevance signal.",
+      "updated_at": "2026-06-04T03:51:41Z"
+    },
+    {
+      "upstream": "anthropics/claude-code#65259",
+      "url": "https://github.com/anthropics/claude-code/issues/65259",
+      "title": "[FEATURE] Auto-infer blockedBy edges from interface changes + an in-graph merge/test gate for Agent Teams",
+      "impact": "not_applicable",
+      "categories": [
+        "plugin"
+      ],
+      "tokenkey_status": "not_applicable",
+      "rationale": "Client-side claude-code concern (plugin); not a gateway/relay relevance signal.",
+      "updated_at": "2026-06-04T03:57:31Z"
+    },
+    {
+      "upstream": "anthropics/claude-code#65260",
+      "url": "https://github.com/anthropics/claude-code/issues/65260",
+      "title": "VS Code: moving chat from side panel to main window breaks modals and resets permissions",
+      "impact": "not_applicable",
+      "categories": [
+        "ide"
+      ],
+      "tokenkey_status": "not_applicable",
+      "rationale": "Client-side claude-code concern (ide); not a gateway/relay relevance signal.",
+      "updated_at": "2026-06-04T04:07:35Z"
+    },
+    {
+      "upstream": "anthropics/claude-code#65261",
+      "url": "https://github.com/anthropics/claude-code/issues/65261",
+      "title": "VS Code: effort toggle is unreliable and has no in-chat observability",
+      "impact": "not_applicable",
+      "categories": [
+        "ide"
+      ],
+      "tokenkey_status": "not_applicable",
+      "rationale": "Client-side claude-code concern (ide); not a gateway/relay relevance signal.",
+      "updated_at": "2026-06-04T04:11:00Z"
+    },
+    {
+      "upstream": "anthropics/claude-code#65262",
+      "url": "https://github.com/anthropics/claude-code/issues/65262",
+      "title": "[FEATURE] plugin support use /compact command automatic",
+      "impact": "not_applicable",
+      "categories": [
+        "plugin"
+      ],
+      "tokenkey_status": "not_applicable",
+      "rationale": "Client-side claude-code concern (plugin); not a gateway/relay relevance signal.",
+      "updated_at": "2026-06-04T04:17:12Z"
+    },
+    {
+      "upstream": "anthropics/claude-code#65263",
+      "url": "https://github.com/anthropics/claude-code/issues/65263",
+      "title": "Claude Code generates an invalid plugin.json (author as string) for marketplace plugins that ship no manifest — /doctor flags it",
+      "impact": "not_applicable",
+      "categories": [
+        "plugin",
+        "install",
+        "platform"
+      ],
+      "tokenkey_status": "not_applicable",
+      "rationale": "Client-side claude-code concern (plugin, install, platform); not a gateway/relay relevance signal.",
+      "updated_at": "2026-06-04T04:15:19Z"
+    },
+    {
+      "upstream": "anthropics/claude-code#65265",
+      "url": "https://github.com/anthropics/claude-code/issues/65265",
+      "title": "[BUG] claude.exe not compatible with Windows 11 Insider build 26200 (version 2.1.162)",
+      "impact": "not_applicable",
+      "categories": [
+        "terminal",
+        "install",
+        "platform"
+      ],
+      "tokenkey_status": "not_applicable",
+      "rationale": "Client-side claude-code concern (terminal, install, platform); not a gateway/relay relevance signal.",
+      "updated_at": "2026-06-04T04:23:43Z"
+    },
+    {
+      "upstream": "anthropics/claude-code#65266",
+      "url": "https://github.com/anthropics/claude-code/issues/65266",
+      "title": "[BUG] subscribe_pr_activity wake-message references send_later tool that isn't available in cloud_default",
+      "impact": "not_applicable",
+      "categories": [
+        "mcp"
+      ],
+      "tokenkey_status": "not_applicable",
+      "rationale": "Client-side claude-code concern (mcp); not a gateway/relay relevance signal.",
+      "updated_at": "2026-06-04T04:27:49Z"
+    },
+    {
+      "upstream": "anthropics/claude-code#65269",
+      "url": "https://github.com/anthropics/claude-code/issues/65269",
+      "title": "[FEATURE] Pin prompt/composer box to bottom of terminal pane (CLI TUI)",
+      "impact": "not_applicable",
+      "categories": [
+        "ide",
+        "terminal",
+        "slash_hook"
+      ],
+      "tokenkey_status": "not_applicable",
+      "rationale": "Client-side claude-code concern (ide, terminal, slash_hook); not a gateway/relay relevance signal.",
+      "updated_at": "2026-06-04T05:08:06Z"
+    },
+    {
+      "upstream": "anthropics/claude-code#65270",
+      "url": "https://github.com/anthropics/claude-code/issues/65270",
+      "title": "[BUG] Claude Code App, pc crash",
+      "impact": "not_applicable",
+      "categories": [
+        "terminal",
+        "platform"
+      ],
+      "tokenkey_status": "not_applicable",
+      "rationale": "Client-side claude-code concern (terminal, platform); not a gateway/relay relevance signal.",
+      "updated_at": "2026-06-04T05:22:50Z"
+    },
+    {
+      "upstream": "anthropics/claude-code#65271",
+      "url": "https://github.com/anthropics/claude-code/issues/65271",
+      "title": "[Bug] API Error: Usage Policy violation on simple requests",
+      "impact": "not_applicable",
+      "categories": [
+        "terminal"
+      ],
+      "tokenkey_status": "not_applicable",
+      "rationale": "Client-side claude-code concern (terminal); not a gateway/relay relevance signal.",
+      "updated_at": "2026-06-04T09:07:06Z"
+    },
+    {
+      "upstream": "anthropics/claude-code#65272",
+      "url": "https://github.com/anthropics/claude-code/issues/65272",
+      "title": "[BUG] File Pane can't open files in a secondary/added folder — \"outside the session folder\" in multi-folder sessions",
+      "impact": "not_applicable",
+      "categories": [
+        "ide",
+        "terminal",
+        "platform"
+      ],
+      "tokenkey_status": "not_applicable",
+      "rationale": "Client-side claude-code concern (ide, terminal, platform); not a gateway/relay relevance signal.",
+      "updated_at": "2026-06-04T05:29:26Z"
+    },
+    {
+      "upstream": "anthropics/claude-code#65274",
+      "url": "https://github.com/anthropics/claude-code/issues/65274",
+      "title": "[Bug] Fork session allows main session to execute instructions without explicit user confirmation",
+      "impact": "not_applicable",
+      "categories": [
+        "terminal"
+      ],
+      "tokenkey_status": "not_applicable",
+      "rationale": "Client-side claude-code concern (terminal); not a gateway/relay relevance signal.",
+      "updated_at": "2026-06-04T05:41:31Z"
+    },
+    {
+      "upstream": "anthropics/claude-code#65275",
+      "url": "https://github.com/anthropics/claude-code/issues/65275",
+      "title": "[BUG] cannot references files/folders within brackets or suggestions",
+      "impact": "not_applicable",
+      "categories": [
+        "terminal"
+      ],
+      "tokenkey_status": "not_applicable",
+      "rationale": "Client-side claude-code concern (terminal); not a gateway/relay relevance signal.",
+      "updated_at": "2026-06-04T05:46:17Z"
+    },
+    {
+      "upstream": "anthropics/claude-code#65276",
+      "url": "https://github.com/anthropics/claude-code/issues/65276",
+      "title": "[Bug] Instruction-Transfer Failure: Explicit Rules Not Applied Across File/Context Boundaries",
+      "impact": "not_applicable",
+      "categories": [
+        "terminal",
+        "slash_hook"
+      ],
+      "tokenkey_status": "not_applicable",
+      "rationale": "Client-side claude-code concern (terminal, slash_hook); not a gateway/relay relevance signal.",
+      "updated_at": "2026-06-04T05:57:36Z"
+    },
+    {
+      "upstream": "anthropics/claude-code#65278",
+      "url": "https://github.com/anthropics/claude-code/issues/65278",
+      "title": "[Bug] Agent ignores repeated user instructions to stop actions",
+      "impact": "not_applicable",
+      "categories": [
+        "terminal"
+      ],
+      "tokenkey_status": "not_applicable",
+      "rationale": "Client-side claude-code concern (terminal); not a gateway/relay relevance signal.",
+      "updated_at": "2026-06-04T06:04:47Z"
+    },
+    {
+      "upstream": "anthropics/claude-code#65279",
+      "url": "https://github.com/anthropics/claude-code/issues/65279",
+      "title": "[BUG] Planning window code blocks unreadable on light VSCode themes (white text on light gray)",
+      "impact": "not_applicable",
+      "categories": [
+        "ide",
+        "terminal"
+      ],
+      "tokenkey_status": "not_applicable",
+      "rationale": "Client-side claude-code concern (ide, terminal); not a gateway/relay relevance signal.",
+      "updated_at": "2026-06-04T08:40:55Z"
+    },
+    {
+      "upstream": "anthropics/claude-code#65280",
+      "url": "https://github.com/anthropics/claude-code/issues/65280",
+      "title": "[FEATURE] Claude Code CLI: Suggest writing large text to a file instead of pasting in prompt for token efficiency",
+      "impact": "not_applicable",
+      "categories": [
+        "terminal"
+      ],
+      "tokenkey_status": "not_applicable",
+      "rationale": "Client-side claude-code concern (terminal); not a gateway/relay relevance signal.",
+      "updated_at": "2026-06-04T06:24:08Z"
+    },
+    {
+      "upstream": "anthropics/claude-code#65282",
+      "url": "https://github.com/anthropics/claude-code/issues/65282",
+      "title": "[BUG]",
+      "impact": "not_applicable",
+      "categories": [
+        "terminal",
+        "install",
+        "platform"
+      ],
+      "tokenkey_status": "not_applicable",
+      "rationale": "Client-side claude-code concern (terminal, install, platform); not a gateway/relay relevance signal.",
+      "updated_at": "2026-06-04T06:37:22Z"
+    },
+    {
+      "upstream": "anthropics/claude-code#65283",
+      "url": "https://github.com/anthropics/claude-code/issues/65283",
+      "title": "[BUG] Claude Code stuck with \"Usage credits required for 1M context\" even after /clear and available usage limit",
+      "impact": "not_applicable",
+      "categories": [
+        "terminal",
+        "mcp",
+        "platform"
+      ],
+      "tokenkey_status": "not_applicable",
+      "rationale": "Client-side claude-code concern (terminal, mcp, platform); not a gateway/relay relevance signal.",
+      "updated_at": "2026-06-04T10:10:50Z"
+    },
+    {
+      "upstream": "anthropics/claude-code#65284",
+      "url": "https://github.com/anthropics/claude-code/issues/65284",
+      "title": "OSC8 hyperlink span incorrectly includes trailing ) from markdown image syntax",
+      "impact": "not_applicable",
+      "categories": [
+        "ide",
+        "terminal"
+      ],
+      "tokenkey_status": "not_applicable",
+      "rationale": "Client-side claude-code concern (ide, terminal); not a gateway/relay relevance signal.",
+      "updated_at": "2026-06-04T07:44:07Z"
+    },
+    {
+      "upstream": "anthropics/claude-code#65285",
+      "url": "https://github.com/anthropics/claude-code/issues/65285",
+      "title": "now,new version v2.1.162 ,this issue is not Resolve",
+      "impact": "not_applicable",
+      "categories": [
+        "ide"
+      ],
+      "tokenkey_status": "not_applicable",
+      "rationale": "Client-side claude-code concern (ide); not a gateway/relay relevance signal.",
+      "updated_at": "2026-06-04T06:57:42Z"
+    },
+    {
+      "upstream": "anthropics/claude-code#65287",
+      "url": "https://github.com/anthropics/claude-code/issues/65287",
+      "title": "[Bug] MCP server error without descriptive message",
+      "impact": "not_applicable",
+      "categories": [
+        "terminal",
+        "mcp"
+      ],
+      "tokenkey_status": "not_applicable",
+      "rationale": "Client-side claude-code concern (terminal, mcp); not a gateway/relay relevance signal.",
+      "updated_at": "2026-06-04T07:13:25Z"
+    },
+    {
+      "upstream": "anthropics/claude-code#65289",
+      "url": "https://github.com/anthropics/claude-code/issues/65289",
+      "title": "[Bug] Tool call parsing failures on first attempt with successful identical retry across all tool types",
+      "impact": "not_applicable",
+      "categories": [
+        "terminal",
+        "mcp",
+        "slash_hook"
+      ],
+      "tokenkey_status": "not_applicable",
+      "rationale": "Client-side claude-code concern (terminal, mcp, slash_hook); not a gateway/relay relevance signal.",
+      "updated_at": "2026-06-04T08:04:51Z"
+    },
+    {
+      "upstream": "anthropics/claude-code#65291",
+      "url": "https://github.com/anthropics/claude-code/issues/65291",
+      "title": "[Bug Report: Unable to process - no issue details provided]",
+      "impact": "not_applicable",
+      "categories": [
+        "terminal"
+      ],
+      "tokenkey_status": "not_applicable",
+      "rationale": "Client-side claude-code concern (terminal); not a gateway/relay relevance signal.",
+      "updated_at": "2026-06-04T07:18:33Z"
+    },
+    {
+      "upstream": "anthropics/claude-code#65294",
+      "url": "https://github.com/anthropics/claude-code/issues/65294",
+      "title": "[BUG] cant remove old Routine session runs which enforce Routine limit which is not valid",
+      "impact": "not_applicable",
+      "categories": [
+        "terminal"
+      ],
+      "tokenkey_status": "not_applicable",
+      "rationale": "Client-side claude-code concern (terminal); not a gateway/relay relevance signal.",
+      "updated_at": "2026-06-04T07:30:47Z"
+    },
+    {
+      "upstream": "anthropics/claude-code#65297",
+      "url": "https://github.com/anthropics/claude-code/issues/65297",
+      "title": "[BUG] Bash sandbox fabricates phantom unreadable files when a hidden/denyRead path doesn't exist — breaks dotnet/SourceLink builds",
+      "impact": "not_applicable",
+      "categories": [
+        "terminal",
+        "platform"
+      ],
+      "tokenkey_status": "not_applicable",
+      "rationale": "Client-side claude-code concern (terminal, platform); not a gateway/relay relevance signal.",
+      "updated_at": "2026-06-04T08:05:44Z"
+    },
+    {
+      "upstream": "anthropics/claude-code#65298",
+      "url": "https://github.com/anthropics/claude-code/issues/65298",
+      "title": "[Bug] acceptEdits defaultMode not persisted; Write permissions reset after first file operation",
+      "impact": "not_applicable",
+      "categories": [
+        "terminal",
+        "plugin",
+        "slash_hook"
+      ],
+      "tokenkey_status": "not_applicable",
+      "rationale": "Client-side claude-code concern (terminal, plugin, slash_hook); not a gateway/relay relevance signal.",
+      "updated_at": "2026-06-04T07:42:14Z"
+    },
+    {
+      "upstream": "anthropics/claude-code#65300",
+      "url": "https://github.com/anthropics/claude-code/issues/65300",
+      "title": "[BUG]",
+      "impact": "not_applicable",
+      "categories": [
+        "ide",
+        "terminal"
+      ],
+      "tokenkey_status": "not_applicable",
+      "rationale": "Client-side claude-code concern (ide, terminal); not a gateway/relay relevance signal.",
+      "updated_at": "2026-06-04T07:56:37Z"
+    },
+    {
+      "upstream": "anthropics/claude-code#65301",
+      "url": "https://github.com/anthropics/claude-code/issues/65301",
+      "title": "[Feature Request] Display command descriptions in autocomplete dropdown",
+      "impact": "not_applicable",
+      "categories": [
+        "terminal",
+        "slash_hook"
+      ],
+      "tokenkey_status": "not_applicable",
+      "rationale": "Client-side claude-code concern (terminal, slash_hook); not a gateway/relay relevance signal.",
+      "updated_at": "2026-06-04T08:05:11Z"
+    },
+    {
+      "upstream": "anthropics/claude-code#65303",
+      "url": "https://github.com/anthropics/claude-code/issues/65303",
+      "title": "I don't see a bug report in your message. Please provide the bug report details so I can generate an appropriate GitHub issue title for you.",
+      "impact": "not_applicable",
+      "categories": [
+        "terminal"
+      ],
+      "tokenkey_status": "not_applicable",
+      "rationale": "Client-side claude-code concern (terminal); not a gateway/relay relevance signal.",
+      "updated_at": "2026-06-04T08:11:37Z"
+    },
+    {
+      "upstream": "anthropics/claude-code#65304",
+      "url": "https://github.com/anthropics/claude-code/issues/65304",
+      "title": "Title: UserPromptSubmit hook returns mirrored Hebrew text and intercepts all chat messages",
+      "impact": "not_applicable",
+      "categories": [
+        "terminal",
+        "slash_hook",
+        "platform"
+      ],
+      "tokenkey_status": "not_applicable",
+      "rationale": "Client-side claude-code concern (terminal, slash_hook, platform); not a gateway/relay relevance signal.",
+      "updated_at": "2026-06-04T08:10:27Z"
+    },
+    {
+      "upstream": "anthropics/claude-code#65306",
+      "url": "https://github.com/anthropics/claude-code/issues/65306",
+      "title": "I don't have any bug report content to analyze. Please provide the bug report details so I can generate an appropriate GitHub issue title.",
+      "impact": "not_applicable",
+      "categories": [
+        "terminal"
+      ],
+      "tokenkey_status": "not_applicable",
+      "rationale": "Client-side claude-code concern (terminal); not a gateway/relay relevance signal.",
+      "updated_at": "2026-06-04T08:16:42Z"
+    },
+    {
+      "upstream": "anthropics/claude-code#65307",
+      "url": "https://github.com/anthropics/claude-code/issues/65307",
+      "title": "[Bug] Claude Code fails to resolve issues in Electron apps across multiple attempts, even with Opus model",
+      "impact": "not_applicable",
+      "categories": [
+        "terminal"
+      ],
+      "tokenkey_status": "not_applicable",
+      "rationale": "Client-side claude-code concern (terminal); not a gateway/relay relevance signal.",
+      "updated_at": "2026-06-04T08:30:39Z"
+    },
+    {
+      "upstream": "anthropics/claude-code#65308",
+      "url": "https://github.com/anthropics/claude-code/issues/65308",
+      "title": "[Bug] Thinking process display unclear to users; red color causes confusion about error status",
+      "impact": "not_applicable",
+      "categories": [
+        "terminal"
+      ],
+      "tokenkey_status": "not_applicable",
+      "rationale": "Client-side claude-code concern (terminal); not a gateway/relay relevance signal.",
+      "updated_at": "2026-06-04T08:42:39Z"
+    },
+    {
+      "upstream": "anthropics/claude-code#65309",
+      "url": "https://github.com/anthropics/claude-code/issues/65309",
+      "title": "Windows: Claude Code sets FILE_ATTRIBUTE_READONLY on its own ~/.claude subdirs, breaking Bash tool (EEXIST on session-env mkdir)",
+      "impact": "not_applicable",
+      "categories": [
+        "ide",
+        "mcp",
+        "plugin",
+        "slash_hook",
+        "install",
+        "platform"
+      ],
+      "tokenkey_status": "not_applicable",
+      "rationale": "Client-side claude-code concern (ide, mcp, plugin, slash_hook, install, platform); not a gateway/relay relevance signal.",
+      "updated_at": "2026-06-04T08:46:43Z"
+    },
+    {
+      "upstream": "anthropics/claude-code#65311",
+      "url": "https://github.com/anthropics/claude-code/issues/65311",
+      "title": "Add option to collapse unchanged lines in desktop diff viewer",
+      "impact": "not_applicable",
+      "categories": [
+        "terminal"
+      ],
+      "tokenkey_status": "not_applicable",
+      "rationale": "Client-side claude-code concern (terminal); not a gateway/relay relevance signal.",
+      "updated_at": "2026-06-04T08:53:44Z"
+    },
+    {
+      "upstream": "anthropics/claude-code#65316",
+      "url": "https://github.com/anthropics/claude-code/issues/65316",
+      "title": "[Bug] Safety instructions ignored in agentic execution",
+      "impact": "not_applicable",
+      "categories": [
+        "terminal"
+      ],
+      "tokenkey_status": "not_applicable",
+      "rationale": "Client-side claude-code concern (terminal); not a gateway/relay relevance signal.",
+      "updated_at": "2026-06-04T09:11:49Z"
+    },
+    {
+      "upstream": "anthropics/claude-code#65317",
+      "url": "https://github.com/anthropics/claude-code/issues/65317",
+      "title": "[BUG] Title: /doctor false positive: flags standalone installer binary as leftover npm global install.",
+      "impact": "not_applicable",
+      "categories": [
+        "terminal",
+        "install"
+      ],
+      "tokenkey_status": "not_applicable",
+      "rationale": "Client-side claude-code concern (terminal, install); not a gateway/relay relevance signal.",
+      "updated_at": "2026-06-04T09:16:05Z"
+    },
+    {
+      "upstream": "anthropics/claude-code#65318",
+      "url": "https://github.com/anthropics/claude-code/issues/65318",
+      "title": "[Bug] Tool call malformed causes silent turn termination without auto-retry",
+      "impact": "not_applicable",
+      "categories": [
+        "terminal"
+      ],
+      "tokenkey_status": "not_applicable",
+      "rationale": "Client-side claude-code concern (terminal); not a gateway/relay relevance signal.",
+      "updated_at": "2026-06-04T09:23:02Z"
+    },
+    {
+      "upstream": "anthropics/claude-code#65319",
+      "url": "https://github.com/anthropics/claude-code/issues/65319",
+      "title": "[Bug] Anthropic API Error: Usage Policy violation on harmless prompts in plan mode",
+      "impact": "not_applicable",
+      "categories": [
+        "terminal"
+      ],
+      "tokenkey_status": "not_applicable",
+      "rationale": "Client-side claude-code concern (terminal); not a gateway/relay relevance signal.",
+      "updated_at": "2026-06-04T09:18:08Z"
+    },
+    {
+      "upstream": "anthropics/claude-code#65321",
+      "url": "https://github.com/anthropics/claude-code/issues/65321",
+      "title": "[Feature Request] Persistent project context for virtual environments and repeated patterns",
+      "impact": "not_applicable",
+      "categories": [
+        "terminal"
+      ],
+      "tokenkey_status": "not_applicable",
+      "rationale": "Client-side claude-code concern (terminal); not a gateway/relay relevance signal.",
+      "updated_at": "2026-06-04T12:02:05Z"
+    },
+    {
+      "upstream": "anthropics/claude-code#65323",
+      "url": "https://github.com/anthropics/claude-code/issues/65323",
+      "title": "[BUG] Mouse-wheel/trackpad scroll far too fast in fullscreen TUI on Cursor (macOS), even at CLAUDE_CODE_SCROLL_SPEED=1",
+      "impact": "not_applicable",
+      "categories": [
+        "ide",
+        "terminal"
+      ],
+      "tokenkey_status": "not_applicable",
+      "rationale": "Client-side claude-code concern (ide, terminal); not a gateway/relay relevance signal.",
+      "updated_at": "2026-06-04T09:32:12Z"
+    },
+    {
+      "upstream": "anthropics/claude-code#65324",
+      "url": "https://github.com/anthropics/claude-code/issues/65324",
+      "title": "[WEBSITE BUG] claude.ai/restricted just redirects to claude.ai/new homepage.",
+      "impact": "not_applicable",
+      "categories": [
+        "terminal",
+        "platform"
+      ],
+      "tokenkey_status": "not_applicable",
+      "rationale": "Client-side claude-code concern (terminal, platform); not a gateway/relay relevance signal.",
+      "updated_at": "2026-06-04T09:26:27Z"
+    },
+    {
+      "upstream": "anthropics/claude-code#65325",
+      "url": "https://github.com/anthropics/claude-code/issues/65325",
+      "title": "[BUG] Native memory leak in Claude Code - 844GB/hour growth rate",
+      "impact": "not_applicable",
+      "categories": [
+        "terminal"
+      ],
+      "tokenkey_status": "not_applicable",
+      "rationale": "Client-side claude-code concern (terminal); not a gateway/relay relevance signal.",
+      "updated_at": "2026-06-04T09:33:01Z"
+    },
+    {
+      "upstream": "anthropics/claude-code#65326",
+      "url": "https://github.com/anthropics/claude-code/issues/65326",
+      "title": "[BUG] https://github.com/anthropics/claude-code/issues",
+      "impact": "not_applicable",
+      "categories": [
+        "ide",
+        "terminal",
+        "plugin",
+        "slash_hook",
+        "platform"
+      ],
+      "tokenkey_status": "not_applicable",
+      "rationale": "Client-side claude-code concern (ide, terminal, plugin, slash_hook, platform); not a gateway/relay relevance signal.",
+      "updated_at": "2026-06-04T09:37:59Z"
+    },
+    {
+      "upstream": "anthropics/claude-code#65327",
+      "url": "https://github.com/anthropics/claude-code/issues/65327",
+      "title": "Configurable session title language + per-session summary tooltip for easier session discovery",
+      "impact": "not_applicable",
+      "categories": [
+        "slash_hook"
+      ],
+      "tokenkey_status": "not_applicable",
+      "rationale": "Client-side claude-code concern (slash_hook); not a gateway/relay relevance signal.",
+      "updated_at": "2026-06-04T09:42:12Z"
+    },
+    {
+      "upstream": "anthropics/claude-code#65329",
+      "url": "https://github.com/anthropics/claude-code/issues/65329",
+      "title": "[BUG] Dispatch (Cowork beta) ignores selected standard model and calls 1M context model — \"Usage credits required for 1M context\"",
+      "impact": "not_applicable",
+      "categories": [
+        "terminal",
+        "slash_hook",
+        "platform"
+      ],
+      "tokenkey_status": "not_applicable",
+      "rationale": "Client-side claude-code concern (terminal, slash_hook, platform); not a gateway/relay relevance signal.",
+      "updated_at": "2026-06-04T09:50:59Z"
+    },
+    {
+      "upstream": "anthropics/claude-code#65331",
+      "url": "https://github.com/anthropics/claude-code/issues/65331",
+      "title": "Voice: \"No audio detected\" in long-running session after default input device changes (macOS)",
+      "impact": "not_applicable",
+      "categories": [
+        "terminal"
+      ],
+      "tokenkey_status": "not_applicable",
+      "rationale": "Client-side claude-code concern (terminal); not a gateway/relay relevance signal.",
+      "updated_at": "2026-06-04T09:49:45Z"
+    },
+    {
+      "upstream": "anthropics/claude-code#65332",
+      "url": "https://github.com/anthropics/claude-code/issues/65332",
+      "title": "I need bug report details to generate an issue title. Please provide the bug report or feature request information you'd like me to create a GitHub issue title for.",
+      "impact": "not_applicable",
+      "categories": [
+        "terminal"
+      ],
+      "tokenkey_status": "not_applicable",
+      "rationale": "Client-side claude-code concern (terminal); not a gateway/relay relevance signal.",
+      "updated_at": "2026-06-04T09:54:57Z"
+    },
+    {
+      "upstream": "anthropics/claude-code#65333",
+      "url": "https://github.com/anthropics/claude-code/issues/65333",
+      "title": "Server-side session state regression: active sessions disappear from active views across mobile / web / desktop after GUI 1.10628.2 (embedded CLI 2.1.161) update on 2026-06-03",
+      "impact": "not_applicable",
+      "categories": [
+        "install"
+      ],
+      "tokenkey_status": "not_applicable",
+      "rationale": "Client-side claude-code concern (install); not a gateway/relay relevance signal.",
+      "updated_at": "2026-06-04T09:59:21Z"
+    },
+    {
+      "upstream": "anthropics/claude-code#65334",
+      "url": "https://github.com/anthropics/claude-code/issues/65334",
+      "title": "[BUG] when session context reach 100%,no auto compact",
+      "impact": "not_applicable",
+      "categories": [
+        "terminal"
+      ],
+      "tokenkey_status": "not_applicable",
+      "rationale": "Client-side claude-code concern (terminal); not a gateway/relay relevance signal.",
+      "updated_at": "2026-06-04T09:59:21Z"
+    },
+    {
+      "upstream": "anthropics/claude-code#65335",
+      "url": "https://github.com/anthropics/claude-code/issues/65335",
+      "title": "[BUG] Race condition in .claude.json config writes causes \"Unexpected EOF\" on concurrent startups",
+      "impact": "not_applicable",
+      "categories": [
+        "ide",
+        "terminal",
+        "platform"
+      ],
+      "tokenkey_status": "not_applicable",
+      "rationale": "Client-side claude-code concern (ide, terminal, platform); not a gateway/relay relevance signal.",
+      "updated_at": "2026-06-04T09:59:46Z"
+    },
+    {
+      "upstream": "anthropics/claude-code#65337",
+      "url": "https://github.com/anthropics/claude-code/issues/65337",
+      "title": "[BUG] Plugin versioning does not resolve correct version from local folder marketplaces",
+      "impact": "not_applicable",
+      "categories": [
+        "plugin",
+        "install"
+      ],
+      "tokenkey_status": "not_applicable",
+      "rationale": "Client-side claude-code concern (plugin, install); not a gateway/relay relevance signal.",
+      "updated_at": "2026-06-04T10:15:45Z"
+    },
+    {
+      "upstream": "anthropics/claude-code#65338",
+      "url": "https://github.com/anthropics/claude-code/issues/65338",
+      "title": "[BUG] Windows (CP950/Big5): IME-typed Chinese input corrupted — console Big5 bytes decoded as UTF-8, garbled text sent to model",
+      "impact": "not_applicable",
+      "categories": [
+        "ide",
+        "terminal",
+        "platform"
+      ],
+      "tokenkey_status": "not_applicable",
+      "rationale": "Client-side claude-code concern (ide, terminal, platform); not a gateway/relay relevance signal.",
+      "updated_at": "2026-06-04T10:11:27Z"
+    },
+    {
+      "upstream": "anthropics/claude-code#65340",
+      "url": "https://github.com/anthropics/claude-code/issues/65340",
+      "title": "[BUG] compact",
+      "impact": "not_applicable",
+      "categories": [
+        "terminal",
+        "platform"
+      ],
+      "tokenkey_status": "not_applicable",
+      "rationale": "Client-side claude-code concern (terminal, platform); not a gateway/relay relevance signal.",
+      "updated_at": "2026-06-04T10:20:55Z"
+    },
+    {
+      "upstream": "anthropics/claude-code#65341",
+      "url": "https://github.com/anthropics/claude-code/issues/65341",
+      "title": "[BUG] Claude Desktop (MSIX) black/white screen on Windows — GPU rendering fails, complete workaround included",
+      "impact": "not_applicable",
+      "categories": [
+        "ide",
+        "terminal",
+        "install",
+        "platform"
+      ],
+      "tokenkey_status": "not_applicable",
+      "rationale": "Client-side claude-code concern (ide, terminal, install, platform); not a gateway/relay relevance signal.",
+      "updated_at": "2026-06-04T10:17:50Z"
+    },
+    {
+      "upstream": "anthropics/claude-code#65342",
+      "url": "https://github.com/anthropics/claude-code/issues/65342",
+      "title": "Show current git branch in the desktop app UI (header or status bar)",
+      "impact": "not_applicable",
+      "categories": [
+        "terminal"
+      ],
+      "tokenkey_status": "not_applicable",
+      "rationale": "Client-side claude-code concern (terminal); not a gateway/relay relevance signal.",
+      "updated_at": "2026-06-04T10:31:11Z"
+    },
+    {
+      "upstream": "anthropics/claude-code#65343",
+      "url": "https://github.com/anthropics/claude-code/issues/65343",
+      "title": "[BUG] Claude Desktop tray icon black on Windows when Windows mode is Dark",
+      "impact": "not_applicable",
+      "categories": [
+        "terminal",
+        "platform"
+      ],
+      "tokenkey_status": "not_applicable",
+      "rationale": "Client-side claude-code concern (terminal, platform); not a gateway/relay relevance signal.",
+      "updated_at": "2026-06-04T10:32:43Z"
+    },
+    {
+      "upstream": "anthropics/claude-code#65345",
+      "url": "https://github.com/anthropics/claude-code/issues/65345",
+      "title": "[FEATURE] Always show session identifier in status line, even before /rename",
+      "impact": "not_applicable",
+      "categories": [
+        "terminal"
+      ],
+      "tokenkey_status": "not_applicable",
+      "rationale": "Client-side claude-code concern (terminal); not a gateway/relay relevance signal.",
+      "updated_at": "2026-06-04T10:46:31Z"
+    },
+    {
+      "upstream": "anthropics/claude-code#65346",
+      "url": "https://github.com/anthropics/claude-code/issues/65346",
+      "title": "[BUG] Cowork sandbox fails to connect on Windows ARM64 despite sucessful VM boot and file operations",
+      "impact": "not_applicable",
+      "categories": [
+        "terminal",
+        "install",
+        "platform"
+      ],
+      "tokenkey_status": "not_applicable",
+      "rationale": "Client-side claude-code concern (terminal, install, platform); not a gateway/relay relevance signal.",
+      "updated_at": "2026-06-04T10:52:03Z"
+    },
+    {
+      "upstream": "anthropics/claude-code#65348",
+      "url": "https://github.com/anthropics/claude-code/issues/65348",
+      "title": "Bash tool silently returns empty output when /tmp/claude-$UID/ exceeds an auto-applied tmpfs quota (systemd ≥256 + kernel ≥6.6)",
+      "impact": "not_applicable",
+      "categories": [
+        "terminal"
+      ],
+      "tokenkey_status": "not_applicable",
+      "rationale": "Client-side claude-code concern (terminal); not a gateway/relay relevance signal.",
+      "updated_at": "2026-06-04T11:28:56Z"
+    },
+    {
+      "upstream": "anthropics/claude-code#65349",
+      "url": "https://github.com/anthropics/claude-code/issues/65349",
+      "title": "[BUG] New prompt from agents dashboard inherits the highlighted session's working directory instead of the shell's cwd",
+      "impact": "not_applicable",
+      "categories": [
+        "terminal",
+        "slash_hook"
+      ],
+      "tokenkey_status": "not_applicable",
+      "rationale": "Client-side claude-code concern (terminal, slash_hook); not a gateway/relay relevance signal.",
+      "updated_at": "2026-06-04T11:12:06Z"
+    },
+    {
+      "upstream": "anthropics/claude-code#65350",
+      "url": "https://github.com/anthropics/claude-code/issues/65350",
+      "title": "vercel@claude-plugins-official contains keychain credential extraction targeting ANTHROPIC_AUTH_TOKEN",
+      "impact": "not_applicable",
+      "categories": [
+        "plugin",
+        "install"
+      ],
+      "tokenkey_status": "not_applicable",
+      "rationale": "Client-side claude-code concern (plugin, install); not a gateway/relay relevance signal.",
+      "updated_at": "2026-06-04T11:16:20Z"
+    },
+    {
+      "upstream": "anthropics/claude-code#65352",
+      "url": "https://github.com/anthropics/claude-code/issues/65352",
+      "title": "[Bug] Anthropic API Error: Safety filter incorrectly blocking legitimate app development requests",
+      "impact": "not_applicable",
+      "categories": [
+        "terminal"
+      ],
+      "tokenkey_status": "not_applicable",
+      "rationale": "Client-side claude-code concern (terminal); not a gateway/relay relevance signal.",
+      "updated_at": "2026-06-04T11:31:04Z"
+    },
+    {
+      "upstream": "anthropics/claude-code#65353",
+      "url": "https://github.com/anthropics/claude-code/issues/65353",
+      "title": "[BUG] Path collision in project state directory still exists (Reopening #7009)",
+      "impact": "not_applicable",
+      "categories": [
+        "terminal"
+      ],
+      "tokenkey_status": "not_applicable",
+      "rationale": "Client-side claude-code concern (terminal); not a gateway/relay relevance signal.",
+      "updated_at": "2026-06-04T11:32:58Z"
+    },
+    {
+      "upstream": "anthropics/claude-code#65354",
+      "url": "https://github.com/anthropics/claude-code/issues/65354",
+      "title": "Cowork persists full remoteMcpServersConfig (~7.5 MB) into every session record; store grows to 6.6 GB and Claude Desktop fails to launch",
+      "impact": "not_applicable",
+      "categories": [
+        "ide",
+        "terminal",
+        "mcp",
+        "install",
+        "platform"
+      ],
+      "tokenkey_status": "not_applicable",
+      "rationale": "Client-side claude-code concern (ide, terminal, mcp, install, platform); not a gateway/relay relevance signal.",
+      "updated_at": "2026-06-04T11:35:39Z"
+    },
+    {
+      "upstream": "anthropics/claude-code#65355",
+      "url": "https://github.com/anthropics/claude-code/issues/65355",
+      "title": "[BUG] Claude for Windows (desktop): built-in /create-pr (GitHub) runs instead of project custom command; terminal & VS Code work correctly",
+      "impact": "not_applicable",
+      "categories": [
+        "ide",
+        "terminal",
+        "plugin",
+        "slash_hook",
+        "install",
+        "platform"
+      ],
+      "tokenkey_status": "not_applicable",
+      "rationale": "Client-side claude-code concern (ide, terminal, plugin, slash_hook, install, platform); not a gateway/relay relevance signal.",
+      "updated_at": "2026-06-04T11:40:13Z"
+    },
+    {
+      "upstream": "anthropics/claude-code#65356",
+      "url": "https://github.com/anthropics/claude-code/issues/65356",
+      "title": "[FEATURE] deniedMcpServers does not suppress Enterprise (claude.ai) connector context injection",
+      "impact": "not_applicable",
+      "categories": [
+        "slash_hook"
+      ],
+      "tokenkey_status": "not_applicable",
+      "rationale": "Client-side claude-code concern (slash_hook); not a gateway/relay relevance signal.",
+      "updated_at": "2026-06-04T11:40:20Z"
+    },
+    {
+      "upstream": "anthropics/claude-code#65357",
+      "url": "https://github.com/anthropics/claude-code/issues/65357",
+      "title": "[BUG] Dispatch shows desktop \"Asleep\"/offline then hangs indefinitely on a fresh thread, despite healthy local setup (macOS, Max)",
+      "impact": "not_applicable",
+      "categories": [
+        "terminal"
+      ],
+      "tokenkey_status": "not_applicable",
+      "rationale": "Client-side claude-code concern (terminal); not a gateway/relay relevance signal.",
+      "updated_at": "2026-06-04T11:45:59Z"
+    },
+    {
+      "upstream": "anthropics/claude-code#65358",
+      "url": "https://github.com/anthropics/claude-code/issues/65358",
+      "title": "[Bug] Claude refuses to fill in password fields in testing environment",
+      "impact": "not_applicable",
+      "categories": [
+        "terminal"
+      ],
+      "tokenkey_status": "not_applicable",
+      "rationale": "Client-side claude-code concern (terminal); not a gateway/relay relevance signal.",
+      "updated_at": "2026-06-04T11:51:24Z"
+    },
+    {
+      "upstream": "anthropics/claude-code#65364",
+      "url": "https://github.com/anthropics/claude-code/issues/65364",
+      "title": "I need the bug report content to generate an issue title. Please provide the bug report or error description for Claude Code.",
+      "impact": "not_applicable",
+      "categories": [
+        "terminal"
+      ],
+      "tokenkey_status": "not_applicable",
+      "rationale": "Client-side claude-code concern (terminal); not a gateway/relay relevance signal.",
+      "updated_at": "2026-06-04T12:06:27Z"
+    },
+    {
+      "upstream": "anthropics/claude-code#65365",
+      "url": "https://github.com/anthropics/claude-code/issues/65365",
+      "title": "[Bug Report] Unable to process request without issue details",
+      "impact": "not_applicable",
+      "categories": [
+        "ide",
+        "terminal"
+      ],
+      "tokenkey_status": "not_applicable",
+      "rationale": "Client-side claude-code concern (ide, terminal); not a gateway/relay relevance signal.",
+      "updated_at": "2026-06-04T12:13:10Z"
+    },
+    {
+      "upstream": "anthropics/claude-code#65366",
+      "url": "https://github.com/anthropics/claude-code/issues/65366",
+      "title": "[Bug Report: Unable to determine issue from empty report]",
+      "impact": "not_applicable",
+      "categories": [
+        "terminal"
+      ],
+      "tokenkey_status": "not_applicable",
+      "rationale": "Client-side claude-code concern (terminal); not a gateway/relay relevance signal.",
+      "updated_at": "2026-06-04T12:20:18Z"
+    },
+    {
+      "upstream": "anthropics/claude-code#65367",
+      "url": "https://github.com/anthropics/claude-code/issues/65367",
+      "title": "[BUG] False-positive AUP block on legitimate comparative-genomics annotation (Request ID included)",
+      "impact": "not_applicable",
+      "categories": [
+        "terminal"
+      ],
+      "tokenkey_status": "not_applicable",
+      "rationale": "Client-side claude-code concern (terminal); not a gateway/relay relevance signal.",
+      "updated_at": "2026-06-04T12:20:53Z"
+    },
+    {
+      "upstream": "anthropics/claude-code#65368",
+      "url": "https://github.com/anthropics/claude-code/issues/65368",
+      "title": "Hooks fail with \"posix_spawn '/bin/sh' ENOENT\" when the session cwd is deleted (worktree cleanup); spawn should fall back to an existing cwd",
+      "impact": "not_applicable",
+      "categories": [
+        "slash_hook"
+      ],
+      "tokenkey_status": "not_applicable",
+      "rationale": "Client-side claude-code concern (slash_hook); not a gateway/relay relevance signal.",
+      "updated_at": "2026-06-04T12:30:11Z"
+    },
+    {
+      "upstream": "anthropics/claude-code#65369",
+      "url": "https://github.com/anthropics/claude-code/issues/65369",
+      "title": "[Bug] MCP /doctor command reports persistent setup issues that cannot be resolved",
+      "impact": "not_applicable",
+      "categories": [
+        "terminal",
+        "mcp"
+      ],
+      "tokenkey_status": "not_applicable",
+      "rationale": "Client-side claude-code concern (terminal, mcp); not a gateway/relay relevance signal.",
+      "updated_at": "2026-06-04T12:31:53Z"
+    },
+    {
+      "upstream": "anthropics/claude-code#65370",
+      "url": "https://github.com/anthropics/claude-code/issues/65370",
+      "title": "[Bug] MCP server setup and configuration issues",
+      "impact": "not_applicable",
+      "categories": [
+        "terminal",
+        "mcp"
+      ],
+      "tokenkey_status": "not_applicable",
+      "rationale": "Client-side claude-code concern (terminal, mcp); not a gateway/relay relevance signal.",
+      "updated_at": "2026-06-04T12:32:44Z"
+    },
+    {
+      "upstream": "anthropics/claude-code#65371",
+      "url": "https://github.com/anthropics/claude-code/issues/65371",
+      "title": "Support auto-invoke of skills via settings.json (SessionStart hook)",
+      "impact": "not_applicable",
+      "categories": [
+        "slash_hook"
+      ],
+      "tokenkey_status": "not_applicable",
+      "rationale": "Client-side claude-code concern (slash_hook); not a gateway/relay relevance signal.",
+      "updated_at": "2026-06-04T12:40:38Z"
     },
     {
       "upstream": "anthropics/claude-code#7075",
@@ -20319,18 +22869,6 @@
       "updated_at": "2026-06-01T21:08:36Z"
     },
     {
-      "upstream": "anthropics/claude-code#7387",
-      "url": "https://github.com/anthropics/claude-code/issues/7387",
-      "title": "[BUG] Shell script occasionally fails due to crazy escaping",
-      "impact": "not_applicable",
-      "categories": [
-        "terminal"
-      ],
-      "tokenkey_status": "not_applicable",
-      "rationale": "Client-side claude-code concern (terminal); not a gateway/relay relevance signal.",
-      "updated_at": "2026-06-01T05:30:17Z"
-    },
-    {
       "upstream": "anthropics/claude-code#7490",
       "url": "https://github.com/anthropics/claude-code/issues/7490",
       "title": "[FEATURE] Allow users to configure which shell the Bash tool uses or inherit initial shell",
@@ -20342,6 +22880,19 @@
       "tokenkey_status": "not_applicable",
       "rationale": "Client-side claude-code concern (mcp, slash_hook); not a gateway/relay relevance signal.",
       "updated_at": "2026-06-03T06:26:59Z"
+    },
+    {
+      "upstream": "anthropics/claude-code#8034",
+      "url": "https://github.com/anthropics/claude-code/issues/8034",
+      "title": "/terminal-setup does not support GNOME Terminal",
+      "impact": "not_applicable",
+      "categories": [
+        "ide",
+        "terminal"
+      ],
+      "tokenkey_status": "not_applicable",
+      "rationale": "Client-side claude-code concern (ide, terminal); not a gateway/relay relevance signal.",
+      "updated_at": "2026-06-03T18:18:54Z"
     },
     {
       "upstream": "anthropics/claude-code#8856",
@@ -20365,7 +22916,7 @@
       ],
       "tokenkey_status": "not_applicable",
       "rationale": "Client-side claude-code concern (terminal); not a gateway/relay relevance signal.",
-      "updated_at": "2026-06-02T12:31:41Z"
+      "updated_at": "2026-06-03T19:03:46Z"
     },
     {
       "upstream": "anthropics/claude-code#11315",
@@ -20396,6 +22947,16 @@
       "tokenkey_status": "not_applicable",
       "rationale": "No gateway/relay-relevant keywords; treated as not-our-surface.",
       "updated_at": "2026-06-02T20:56:11Z"
+    },
+    {
+      "upstream": "anthropics/claude-code#16561",
+      "url": "https://github.com/anthropics/claude-code/issues/16561",
+      "title": "Feature: Parse compound Bash commands and match each component against permissions",
+      "impact": "unknown_low_signal",
+      "categories": [],
+      "tokenkey_status": "not_applicable",
+      "rationale": "No gateway/relay-relevant keywords; treated as not-our-surface.",
+      "updated_at": "2026-06-04T05:13:53Z"
     },
     {
       "upstream": "anthropics/claude-code#1757",
@@ -20458,6 +23019,16 @@
       "updated_at": "2026-06-02T17:26:44Z"
     },
     {
+      "upstream": "anthropics/claude-code#28043",
+      "url": "https://github.com/anthropics/claude-code/issues/28043",
+      "title": "[DOCS] Bash tool docs missing login-shell default behavior change and `CLAUDE_BASH_NO_LOGIN` context",
+      "impact": "unknown_low_signal",
+      "categories": [],
+      "tokenkey_status": "not_applicable",
+      "rationale": "No gateway/relay-relevant keywords; treated as not-our-surface.",
+      "updated_at": "2026-06-03T11:40:53Z"
+    },
+    {
       "upstream": "anthropics/claude-code#30031",
       "url": "https://github.com/anthropics/claude-code/issues/30031",
       "title": "Feature Request: Support multiple account login and switching (like `gh auth switch`)",
@@ -20468,6 +23039,76 @@
       "updated_at": "2026-06-03T00:09:52Z"
     },
     {
+      "upstream": "anthropics/claude-code#30799",
+      "url": "https://github.com/anthropics/claude-code/issues/30799",
+      "title": "[DOCS] Model configuration page missing model removal and automatic migration behavior",
+      "impact": "unknown_low_signal",
+      "categories": [],
+      "tokenkey_status": "not_applicable",
+      "rationale": "No gateway/relay-relevant keywords; treated as not-our-surface.",
+      "updated_at": "2026-06-03T11:40:52Z"
+    },
+    {
+      "upstream": "anthropics/claude-code#30949",
+      "url": "https://github.com/anthropics/claude-code/issues/30949",
+      "title": "[DOCS] Skills docs should document interactive-tool exception to `allowed-tools` auto-approval behavior",
+      "impact": "unknown_low_signal",
+      "categories": [],
+      "tokenkey_status": "not_applicable",
+      "rationale": "No gateway/relay-relevant keywords; treated as not-our-surface.",
+      "updated_at": "2026-06-03T22:44:59Z"
+    },
+    {
+      "upstream": "anthropics/claude-code#31677",
+      "url": "https://github.com/anthropics/claude-code/issues/31677",
+      "title": "[DOCS] /fork documentation missing plan file isolation behavior",
+      "impact": "unknown_low_signal",
+      "categories": [],
+      "tokenkey_status": "not_applicable",
+      "rationale": "No gateway/relay-relevant keywords; treated as not-our-surface.",
+      "updated_at": "2026-06-03T22:44:58Z"
+    },
+    {
+      "upstream": "anthropics/claude-code#31679",
+      "url": "https://github.com/anthropics/claude-code/issues/31679",
+      "title": "[DOCS] --print flag docs missing team agent interaction caveat",
+      "impact": "unknown_low_signal",
+      "categories": [],
+      "tokenkey_status": "not_applicable",
+      "rationale": "No gateway/relay-relevant keywords; treated as not-our-surface.",
+      "updated_at": "2026-06-03T22:44:56Z"
+    },
+    {
+      "upstream": "anthropics/claude-code#33318",
+      "url": "https://github.com/anthropics/claude-code/issues/33318",
+      "title": "[DOCS] Setup and system requirements docs omit Linux glibc compatibility floor clarified by v2.1.73 fix",
+      "impact": "unknown_low_signal",
+      "categories": [],
+      "tokenkey_status": "not_applicable",
+      "rationale": "No gateway/relay-relevant keywords; treated as not-our-surface.",
+      "updated_at": "2026-06-03T11:39:38Z"
+    },
+    {
+      "upstream": "anthropics/claude-code#33502",
+      "url": "https://github.com/anthropics/claude-code/issues/33502",
+      "title": "[FEATURE] When setting up a folder in the CLAUD CODE GUI, please add it to the recent list so that it can be deleted.",
+      "impact": "unknown_low_signal",
+      "categories": [],
+      "tokenkey_status": "not_applicable",
+      "rationale": "No gateway/relay-relevant keywords; treated as not-our-surface.",
+      "updated_at": "2026-06-04T05:52:28Z"
+    },
+    {
+      "upstream": "anthropics/claude-code#34153",
+      "url": "https://github.com/anthropics/claude-code/issues/34153",
+      "title": "[DOCS] Memory documentation missing last-modified timestamps and freshness reasoning",
+      "impact": "unknown_low_signal",
+      "categories": [],
+      "tokenkey_status": "not_applicable",
+      "rationale": "No gateway/relay-relevant keywords; treated as not-our-surface.",
+      "updated_at": "2026-06-03T11:39:36Z"
+    },
+    {
       "upstream": "anthropics/claude-code#36151",
       "url": "https://github.com/anthropics/claude-code/issues/36151",
       "title": "[FEATURE] Multi-account switching in Claude Mobile app without shared email",
@@ -20476,6 +23117,56 @@
       "tokenkey_status": "not_applicable",
       "rationale": "No gateway/relay-relevant keywords; treated as not-our-surface.",
       "updated_at": "2026-06-03T07:12:00Z"
+    },
+    {
+      "upstream": "anthropics/claude-code#39678",
+      "url": "https://github.com/anthropics/claude-code/issues/39678",
+      "title": "Claude Code Review incorrectly reports overage limit reached when spend is $0/$250",
+      "impact": "unknown_low_signal",
+      "categories": [],
+      "tokenkey_status": "not_applicable",
+      "rationale": "No gateway/relay-relevant keywords; treated as not-our-surface.",
+      "updated_at": "2026-06-04T11:01:14Z"
+    },
+    {
+      "upstream": "anthropics/claude-code#39907",
+      "url": "https://github.com/anthropics/claude-code/issues/39907",
+      "title": "Claude falsely claims completed task 3 times when it was never done",
+      "impact": "unknown_low_signal",
+      "categories": [],
+      "tokenkey_status": "not_applicable",
+      "rationale": "No gateway/relay-relevant keywords; treated as not-our-surface.",
+      "updated_at": "2026-06-04T11:07:09Z"
+    },
+    {
+      "upstream": "anthropics/claude-code#40043",
+      "url": "https://github.com/anthropics/claude-code/issues/40043",
+      "title": "Allow removal of local folders from a Cowork project's context",
+      "impact": "unknown_low_signal",
+      "categories": [],
+      "tokenkey_status": "not_applicable",
+      "rationale": "No gateway/relay-relevant keywords; treated as not-our-surface.",
+      "updated_at": "2026-06-03T16:39:15Z"
+    },
+    {
+      "upstream": "anthropics/claude-code#41794",
+      "url": "https://github.com/anthropics/claude-code/issues/41794",
+      "title": "[DOCS] Headless docs omit deferred tool resumption with `-p --continue` and `--resume`",
+      "impact": "unknown_low_signal",
+      "categories": [],
+      "tokenkey_status": "not_applicable",
+      "rationale": "No gateway/relay-relevant keywords; treated as not-our-surface.",
+      "updated_at": "2026-06-03T11:40:46Z"
+    },
+    {
+      "upstream": "anthropics/claude-code#43356",
+      "url": "https://github.com/anthropics/claude-code/issues/43356",
+      "title": "[DOCS] Bedrock onboarding docs omit login-screen setup wizard",
+      "impact": "unknown_low_signal",
+      "categories": [],
+      "tokenkey_status": "not_applicable",
+      "rationale": "No gateway/relay-relevant keywords; treated as not-our-surface.",
+      "updated_at": "2026-06-03T22:45:03Z"
     },
     {
       "upstream": "anthropics/claude-code#43755",
@@ -20518,14 +23209,14 @@
       "updated_at": "2026-06-01T22:45:47Z"
     },
     {
-      "upstream": "anthropics/claude-code#46251",
-      "url": "https://github.com/anthropics/claude-code/issues/46251",
-      "title": "[FEATURE] Rating scale labels are confusing for non-English speakers",
+      "upstream": "anthropics/claude-code#46561",
+      "url": "https://github.com/anthropics/claude-code/issues/46561",
+      "title": "/compact resurrects /loop skill context, causing stale cron jobs to keep executing after user stopped the loop",
       "impact": "unknown_low_signal",
       "categories": [],
       "tokenkey_status": "not_applicable",
       "rationale": "No gateway/relay-relevant keywords; treated as not-our-surface.",
-      "updated_at": "2026-06-01T12:03:26Z"
+      "updated_at": "2026-06-04T11:07:45Z"
     },
     {
       "upstream": "anthropics/claude-code#46940",
@@ -20558,6 +23249,26 @@
       "updated_at": "2026-06-03T05:33:12Z"
     },
     {
+      "upstream": "anthropics/claude-code#48858",
+      "url": "https://github.com/anthropics/claude-code/issues/48858",
+      "title": "[DOCS] Scheduled tasks docs omit `--resume`/`--continue` restoration",
+      "impact": "unknown_low_signal",
+      "categories": [],
+      "tokenkey_status": "not_applicable",
+      "rationale": "No gateway/relay-relevant keywords; treated as not-our-surface.",
+      "updated_at": "2026-06-03T11:39:46Z"
+    },
+    {
+      "upstream": "anthropics/claude-code#48861",
+      "url": "https://github.com/anthropics/claude-code/issues/48861",
+      "title": "[DOCS] Bash timeout limit missing from tool and SDK references",
+      "impact": "unknown_low_signal",
+      "categories": [],
+      "tokenkey_status": "not_applicable",
+      "rationale": "No gateway/relay-relevant keywords; treated as not-our-surface.",
+      "updated_at": "2026-06-03T22:44:49Z"
+    },
+    {
       "upstream": "anthropics/claude-code#49084",
       "url": "https://github.com/anthropics/claude-code/issues/49084",
       "title": "Feature request: expose timestamps to Claude as structured data for time-aware reasoning",
@@ -20566,6 +23277,26 @@
       "tokenkey_status": "not_applicable",
       "rationale": "No gateway/relay-relevant keywords; treated as not-our-surface.",
       "updated_at": "2026-06-02T15:01:43Z"
+    },
+    {
+      "upstream": "anthropics/claude-code#49295",
+      "url": "https://github.com/anthropics/claude-code/issues/49295",
+      "title": "[DOCS] Permissions docs still say Bash commands always prompt despite read-only exceptions",
+      "impact": "unknown_low_signal",
+      "categories": [],
+      "tokenkey_status": "not_applicable",
+      "rationale": "No gateway/relay-relevant keywords; treated as not-our-surface.",
+      "updated_at": "2026-06-03T22:44:51Z"
+    },
+    {
+      "upstream": "anthropics/claude-code#49297",
+      "url": "https://github.com/anthropics/claude-code/issues/49297",
+      "title": "[DOCS] Plan mode docs missing prompt-based plan filename behavior",
+      "impact": "unknown_low_signal",
+      "categories": [],
+      "tokenkey_status": "not_applicable",
+      "rationale": "No gateway/relay-relevant keywords; treated as not-our-surface.",
+      "updated_at": "2026-06-03T22:44:50Z"
     },
     {
       "upstream": "anthropics/claude-code#4953",
@@ -20578,6 +23309,16 @@
       "updated_at": "2026-06-03T00:05:19Z"
     },
     {
+      "upstream": "anthropics/claude-code#50137",
+      "url": "https://github.com/anthropics/claude-code/issues/50137",
+      "title": "[DOCS] Session recap docs missing auto-trigger and draft-input behavior",
+      "impact": "unknown_low_signal",
+      "categories": [],
+      "tokenkey_status": "not_applicable",
+      "rationale": "No gateway/relay-relevant keywords; treated as not-our-surface.",
+      "updated_at": "2026-06-03T11:39:44Z"
+    },
+    {
       "upstream": "anthropics/claude-code#50246",
       "url": "https://github.com/anthropics/claude-code/issues/50246",
       "title": "Feature Request: Message queue mode — queue messages instead of interrupting active tasks",
@@ -20585,7 +23326,7 @@
       "categories": [],
       "tokenkey_status": "not_applicable",
       "rationale": "No gateway/relay-relevant keywords; treated as not-our-surface.",
-      "updated_at": "2026-06-02T14:09:35Z"
+      "updated_at": "2026-06-03T18:00:02Z"
     },
     {
       "upstream": "anthropics/claude-code#50529",
@@ -20598,6 +23339,16 @@
       "updated_at": "2026-06-02T09:10:54Z"
     },
     {
+      "upstream": "anthropics/claude-code#5088",
+      "url": "https://github.com/anthropics/claude-code/issues/5088",
+      "title": "Claude Account Disabled After Payment for Claude Code Max 5x Plan",
+      "impact": "unknown_low_signal",
+      "categories": [],
+      "tokenkey_status": "not_applicable",
+      "rationale": "No gateway/relay-relevant keywords; treated as not-our-surface.",
+      "updated_at": "2026-06-04T01:40:54Z"
+    },
+    {
       "upstream": "anthropics/claude-code#50894",
       "url": "https://github.com/anthropics/claude-code/issues/50894",
       "title": "Focus mode hides substantive assistant messages, not just tool output",
@@ -20606,6 +23357,26 @@
       "tokenkey_status": "not_applicable",
       "rationale": "No gateway/relay-relevant keywords; treated as not-our-surface.",
       "updated_at": "2026-06-01T22:45:52Z"
+    },
+    {
+      "upstream": "anthropics/claude-code#51373",
+      "url": "https://github.com/anthropics/claude-code/issues/51373",
+      "title": "[DOCS] Sandboxing docs overstate auto-allow behavior for dangerous `rm`/`rmdir` paths",
+      "impact": "unknown_low_signal",
+      "categories": [],
+      "tokenkey_status": "not_applicable",
+      "rationale": "No gateway/relay-relevant keywords; treated as not-our-surface.",
+      "updated_at": "2026-06-03T11:40:14Z"
+    },
+    {
+      "upstream": "anthropics/claude-code#51783",
+      "url": "https://github.com/anthropics/claude-code/issues/51783",
+      "title": "[DOCS] WebFetch docs missing large-HTML truncation behavior",
+      "impact": "unknown_low_signal",
+      "categories": [],
+      "tokenkey_status": "not_applicable",
+      "rationale": "No gateway/relay-relevant keywords; treated as not-our-surface.",
+      "updated_at": "2026-06-03T11:40:07Z"
     },
     {
       "upstream": "anthropics/claude-code#51791",
@@ -20618,6 +23389,36 @@
       "updated_at": "2026-06-02T15:52:47Z"
     },
     {
+      "upstream": "anthropics/claude-code#52194",
+      "url": "https://github.com/anthropics/claude-code/issues/52194",
+      "title": "[DOCS] Auto mode docs omit `\"$defaults\"` sentinel for extending built-in rules",
+      "impact": "unknown_low_signal",
+      "categories": [],
+      "tokenkey_status": "not_applicable",
+      "rationale": "No gateway/relay-relevant keywords; treated as not-our-surface.",
+      "updated_at": "2026-06-03T11:40:11Z"
+    },
+    {
+      "upstream": "anthropics/claude-code#52204",
+      "url": "https://github.com/anthropics/claude-code/issues/52204",
+      "title": "[DOCS] Permission modes page shows auto mode instead of bypass permissions after `--dangerously-skip-permissions`",
+      "impact": "unknown_low_signal",
+      "categories": [],
+      "tokenkey_status": "not_applicable",
+      "rationale": "No gateway/relay-relevant keywords; treated as not-our-surface.",
+      "updated_at": "2026-06-03T11:40:16Z"
+    },
+    {
+      "upstream": "anthropics/claude-code#52205",
+      "url": "https://github.com/anthropics/claude-code/issues/52205",
+      "title": "[DOCS] Forked session storage docs still describe each transcript as a full copy",
+      "impact": "unknown_low_signal",
+      "categories": [],
+      "tokenkey_status": "not_applicable",
+      "rationale": "No gateway/relay-relevant keywords; treated as not-our-surface.",
+      "updated_at": "2026-06-03T11:40:20Z"
+    },
+    {
       "upstream": "anthropics/claude-code#52214",
       "url": "https://github.com/anthropics/claude-code/issues/52214",
       "title": "[FEATURE] Add 24-hour time format support in /usage dialog",
@@ -20628,14 +23429,34 @@
       "updated_at": "2026-06-02T22:44:32Z"
     },
     {
-      "upstream": "anthropics/claude-code#52477",
-      "url": "https://github.com/anthropics/claude-code/issues/52477",
-      "title": "[MODEL] Claude overrode explicit pronouns in user memory and defaulted to male bias",
+      "upstream": "anthropics/claude-code#52622",
+      "url": "https://github.com/anthropics/claude-code/issues/52622",
+      "title": "[DOCS] /export command docs omit actual-conversation model behavior",
       "impact": "unknown_low_signal",
       "categories": [],
       "tokenkey_status": "not_applicable",
       "rationale": "No gateway/relay-relevant keywords; treated as not-our-surface.",
-      "updated_at": "2026-06-01T05:35:36Z"
+      "updated_at": "2026-06-03T11:40:25Z"
+    },
+    {
+      "upstream": "anthropics/claude-code#52627",
+      "url": "https://github.com/anthropics/claude-code/issues/52627",
+      "title": "[DOCS] Agent SDK Read tool docs omit size-cap behavior and `parts` output",
+      "impact": "unknown_low_signal",
+      "categories": [],
+      "tokenkey_status": "not_applicable",
+      "rationale": "No gateway/relay-relevant keywords; treated as not-our-surface.",
+      "updated_at": "2026-06-03T11:40:30Z"
+    },
+    {
+      "upstream": "anthropics/claude-code#53075",
+      "url": "https://github.com/anthropics/claude-code/issues/53075",
+      "title": "[DOCS] Analytics docs should clarify telemetry opt-out effects on API and Enterprise usage metrics",
+      "impact": "unknown_low_signal",
+      "categories": [],
+      "tokenkey_status": "not_applicable",
+      "rationale": "No gateway/relay-relevant keywords; treated as not-our-surface.",
+      "updated_at": "2026-06-03T11:40:39Z"
     },
     {
       "upstream": "anthropics/claude-code#53225",
@@ -20648,6 +23469,16 @@
       "updated_at": "2026-06-01T22:45:29Z"
     },
     {
+      "upstream": "anthropics/claude-code#53514",
+      "url": "https://github.com/anthropics/claude-code/issues/53514",
+      "title": "Reopening: \"Continue\" leads to massive context carry-over into new 5h limit, thus when implementation stops half-way and you are asked to wait, the next session quota is reduced massively.",
+      "impact": "unknown_low_signal",
+      "categories": [],
+      "tokenkey_status": "not_applicable",
+      "rationale": "No gateway/relay-relevant keywords; treated as not-our-surface.",
+      "updated_at": "2026-06-03T11:39:29Z"
+    },
+    {
       "upstream": "anthropics/claude-code#54019",
       "url": "https://github.com/anthropics/claude-code/issues/54019",
       "title": "Add a quick thumbs up/down reaction to responses so users can give feedback without triggering a new AI reply.",
@@ -20656,6 +23487,16 @@
       "tokenkey_status": "not_applicable",
       "rationale": "No gateway/relay-relevant keywords; treated as not-our-surface.",
       "updated_at": "2026-06-02T11:32:35Z"
+    },
+    {
+      "upstream": "anthropics/claude-code#54517",
+      "url": "https://github.com/anthropics/claude-code/issues/54517",
+      "title": "[FEATURE] Allow scheduled agent / Routine runs to appear in Recents or be pinnable in the sidebar",
+      "impact": "unknown_low_signal",
+      "categories": [],
+      "tokenkey_status": "not_applicable",
+      "rationale": "No gateway/relay-relevant keywords; treated as not-our-surface.",
+      "updated_at": "2026-06-03T16:03:57Z"
     },
     {
       "upstream": "anthropics/claude-code#54924",
@@ -20668,14 +23509,24 @@
       "updated_at": "2026-06-01T22:45:22Z"
     },
     {
-      "upstream": "anthropics/claude-code#54964",
-      "url": "https://github.com/anthropics/claude-code/issues/54964",
-      "title": "[FEATURE] Google Vertex support for Remote Control features",
+      "upstream": "anthropics/claude-code#55196",
+      "url": "https://github.com/anthropics/claude-code/issues/55196",
+      "title": "[DOCS] Remote Control troubleshooting missing trusted-device unenrolled failure",
       "impact": "unknown_low_signal",
       "categories": [],
       "tokenkey_status": "not_applicable",
       "rationale": "No gateway/relay-relevant keywords; treated as not-our-surface.",
-      "updated_at": "2026-05-31T21:15:45Z"
+      "updated_at": "2026-06-04T11:06:38Z"
+    },
+    {
+      "upstream": "anthropics/claude-code#55971",
+      "url": "https://github.com/anthropics/claude-code/issues/55971",
+      "title": "[FEATURE] Threaded replies in chat — reply button on each message bubble with numbered topics",
+      "impact": "unknown_low_signal",
+      "categories": [],
+      "tokenkey_status": "not_applicable",
+      "rationale": "No gateway/relay-relevant keywords; treated as not-our-surface.",
+      "updated_at": "2026-06-04T11:07:16Z"
     },
     {
       "upstream": "anthropics/claude-code#56927",
@@ -20708,16 +23559,6 @@
       "updated_at": "2026-06-02T22:44:10Z"
     },
     {
-      "upstream": "anthropics/claude-code#58198",
-      "url": "https://github.com/anthropics/claude-code/issues/58198",
-      "title": "[BUG] Permission prompt events (and user response) not serialized to session jsonl",
-      "impact": "unknown_low_signal",
-      "categories": [],
-      "tokenkey_status": "not_applicable",
-      "rationale": "No gateway/relay-relevant keywords; treated as not-our-surface.",
-      "updated_at": "2026-06-01T12:03:29Z"
-    },
-    {
       "upstream": "anthropics/claude-code#58768",
       "url": "https://github.com/anthropics/claude-code/issues/58768",
       "title": "AskUserQuestion answers invisible to auto-mode permission classifier — destructive calls re-blocked after explicit consent",
@@ -20728,74 +23569,14 @@
       "updated_at": "2026-06-01T22:45:44Z"
     },
     {
-      "upstream": "anthropics/claude-code#58860",
-      "url": "https://github.com/anthropics/claude-code/issues/58860",
-      "title": "[DOCS] Vertex AI workload identity federation docs missing `ANTHROPIC_WORKSPACE_ID` workspace-scoping guidance",
+      "upstream": "anthropics/claude-code#59566",
+      "url": "https://github.com/anthropics/claude-code/issues/59566",
+      "title": "[BUG] Opus 4.7 reproduces same defect class within session despite active CLAUDE.md + persisted auto-memory + Sidecar mitigation",
       "impact": "unknown_low_signal",
       "categories": [],
       "tokenkey_status": "not_applicable",
       "rationale": "No gateway/relay-relevant keywords; treated as not-our-surface.",
-      "updated_at": "2026-06-01T01:13:19Z"
-    },
-    {
-      "upstream": "anthropics/claude-code#58870",
-      "url": "https://github.com/anthropics/claude-code/issues/58870",
-      "title": "[DOCS] Gateway background session naming docs omit main-model fallback when no Haiku model is configured",
-      "impact": "unknown_low_signal",
-      "categories": [],
-      "tokenkey_status": "not_applicable",
-      "rationale": "No gateway/relay-relevant keywords; treated as not-our-surface.",
-      "updated_at": "2026-06-01T01:11:37Z"
-    },
-    {
-      "upstream": "anthropics/claude-code#59255",
-      "url": "https://github.com/anthropics/claude-code/issues/59255",
-      "title": "Remote Control 웹 세션 연결 후 CLI 대화 스트림이 전혀 표시되지 않음",
-      "impact": "unknown_low_signal",
-      "categories": [],
-      "tokenkey_status": "not_applicable",
-      "rationale": "No gateway/relay-relevant keywords; treated as not-our-surface.",
-      "updated_at": "2026-06-01T12:02:02Z"
-    },
-    {
-      "upstream": "anthropics/claude-code#59570",
-      "url": "https://github.com/anthropics/claude-code/issues/59570",
-      "title": "Web sessions don't pull submodules even when both repos are granted access",
-      "impact": "unknown_low_signal",
-      "categories": [],
-      "tokenkey_status": "not_applicable",
-      "rationale": "No gateway/relay-relevant keywords; treated as not-our-surface.",
-      "updated_at": "2026-06-01T12:01:59Z"
-    },
-    {
-      "upstream": "anthropics/claude-code#59591",
-      "url": "https://github.com/anthropics/claude-code/issues/59591",
-      "title": "[DOCS] Worktree cleanup docs omit failed-removal safety behavior for gitignored and in-progress files",
-      "impact": "unknown_low_signal",
-      "categories": [],
-      "tokenkey_status": "not_applicable",
-      "rationale": "No gateway/relay-relevant keywords; treated as not-our-surface.",
-      "updated_at": "2026-06-01T01:04:47Z"
-    },
-    {
-      "upstream": "anthropics/claude-code#59598",
-      "url": "https://github.com/anthropics/claude-code/issues/59598",
-      "title": "Give background agents awareness of peer agents in the same repo",
-      "impact": "unknown_low_signal",
-      "categories": [],
-      "tokenkey_status": "not_applicable",
-      "rationale": "No gateway/relay-relevant keywords; treated as not-our-surface.",
-      "updated_at": "2026-06-01T12:02:24Z"
-    },
-    {
-      "upstream": "anthropics/claude-code#59680",
-      "url": "https://github.com/anthropics/claude-code/issues/59680",
-      "title": "Sonnet model shows AUTO permission mode but fails with error",
-      "impact": "unknown_low_signal",
-      "categories": [],
-      "tokenkey_status": "not_applicable",
-      "rationale": "No gateway/relay-relevant keywords; treated as not-our-surface.",
-      "updated_at": "2026-06-01T12:02:12Z"
+      "updated_at": "2026-06-03T22:45:10Z"
     },
     {
       "upstream": "anthropics/claude-code#59691",
@@ -20828,24 +23609,14 @@
       "updated_at": "2026-06-01T22:45:10Z"
     },
     {
-      "upstream": "anthropics/claude-code#59716",
-      "url": "https://github.com/anthropics/claude-code/issues/59716",
-      "title": "[FEATURE] Configurable initial vim mode for each new prompt",
+      "upstream": "anthropics/claude-code#59858",
+      "url": "https://github.com/anthropics/claude-code/issues/59858",
+      "title": "[BUG] Extra usage spend limit not enforced as hard cap – charged 250% of configured cap with no notification or stop",
       "impact": "unknown_low_signal",
       "categories": [],
       "tokenkey_status": "not_applicable",
       "rationale": "No gateway/relay-relevant keywords; treated as not-our-surface.",
-      "updated_at": "2026-06-01T12:02:23Z"
-    },
-    {
-      "upstream": "anthropics/claude-code#59847",
-      "url": "https://github.com/anthropics/claude-code/issues/59847",
-      "title": "Plan mode ExitPlanMode button misleadingly shows 'ready to code' prompt",
-      "impact": "unknown_low_signal",
-      "categories": [],
-      "tokenkey_status": "not_applicable",
-      "rationale": "No gateway/relay-relevant keywords; treated as not-our-surface.",
-      "updated_at": "2026-06-01T12:03:31Z"
+      "updated_at": "2026-06-03T22:45:36Z"
     },
     {
       "upstream": "anthropics/claude-code#59864",
@@ -20928,6 +23699,26 @@
       "updated_at": "2026-06-02T11:32:30Z"
     },
     {
+      "upstream": "anthropics/claude-code#60195",
+      "url": "https://github.com/anthropics/claude-code/issues/60195",
+      "title": "[FEATURE] Allow sub-agents to restart gracefully after network outage",
+      "impact": "unknown_low_signal",
+      "categories": [],
+      "tokenkey_status": "not_applicable",
+      "rationale": "No gateway/relay-relevant keywords; treated as not-our-surface.",
+      "updated_at": "2026-06-03T11:39:33Z"
+    },
+    {
+      "upstream": "anthropics/claude-code#60199",
+      "url": "https://github.com/anthropics/claude-code/issues/60199",
+      "title": "Agent Teams: shutdown_request approval doesn't terminate teammate; reply delivery occasionally drops content",
+      "impact": "unknown_low_signal",
+      "categories": [],
+      "tokenkey_status": "not_applicable",
+      "rationale": "No gateway/relay-relevant keywords; treated as not-our-surface.",
+      "updated_at": "2026-06-03T11:39:33Z"
+    },
+    {
       "upstream": "anthropics/claude-code#60257",
       "url": "https://github.com/anthropics/claude-code/issues/60257",
       "title": "[FEATURE] Don't block Edit tool for files read in session it was forked from",
@@ -20958,6 +23749,16 @@
       "updated_at": "2026-06-02T22:44:44Z"
     },
     {
+      "upstream": "anthropics/claude-code#60337",
+      "url": "https://github.com/anthropics/claude-code/issues/60337",
+      "title": "[MODEL] CLAUDE.md loading protocol silently skipped at session start",
+      "impact": "unknown_low_signal",
+      "categories": [],
+      "tokenkey_status": "not_applicable",
+      "rationale": "No gateway/relay-relevant keywords; treated as not-our-surface.",
+      "updated_at": "2026-06-03T22:45:13Z"
+    },
+    {
       "upstream": "anthropics/claude-code#60354",
       "url": "https://github.com/anthropics/claude-code/issues/60354",
       "title": "Voice indicator shows recording state after message is submitted",
@@ -20968,14 +23769,54 @@
       "updated_at": "2026-06-02T22:44:54Z"
     },
     {
-      "upstream": "anthropics/claude-code#60411",
-      "url": "https://github.com/anthropics/claude-code/issues/60411",
-      "title": "[DOCS] Background side-query docs omit main-model fallback for gateways and Bedrock Mantle",
+      "upstream": "anthropics/claude-code#60399",
+      "url": "https://github.com/anthropics/claude-code/issues/60399",
+      "title": "[DOCS] `/resume` docs still describe the session picker as interactive-only and omit background-session support",
       "impact": "unknown_low_signal",
       "categories": [],
       "tokenkey_status": "not_applicable",
       "rationale": "No gateway/relay-relevant keywords; treated as not-our-surface.",
-      "updated_at": "2026-06-01T01:30:47Z"
+      "updated_at": "2026-06-04T11:06:52Z"
+    },
+    {
+      "upstream": "anthropics/claude-code#60406",
+      "url": "https://github.com/anthropics/claude-code/issues/60406",
+      "title": "[DOCS] `tools-reference` still says `head` and `tail` do not satisfy read-before-edit",
+      "impact": "unknown_low_signal",
+      "categories": [],
+      "tokenkey_status": "not_applicable",
+      "rationale": "No gateway/relay-relevant keywords; treated as not-our-surface.",
+      "updated_at": "2026-06-03T22:45:06Z"
+    },
+    {
+      "upstream": "anthropics/claude-code#60409",
+      "url": "https://github.com/anthropics/claude-code/issues/60409",
+      "title": "[DOCS] Skill live-reload docs do not define whether non-Markdown supporting files trigger reloads",
+      "impact": "unknown_low_signal",
+      "categories": [],
+      "tokenkey_status": "not_applicable",
+      "rationale": "No gateway/relay-relevant keywords; treated as not-our-surface.",
+      "updated_at": "2026-06-03T22:45:07Z"
+    },
+    {
+      "upstream": "anthropics/claude-code#60410",
+      "url": "https://github.com/anthropics/claude-code/issues/60410",
+      "title": "Automated QA workflows blocked by per-command approval — need batch/session approval mode",
+      "impact": "unknown_low_signal",
+      "categories": [],
+      "tokenkey_status": "not_applicable",
+      "rationale": "No gateway/relay-relevant keywords; treated as not-our-surface.",
+      "updated_at": "2026-06-03T22:45:39Z"
+    },
+    {
+      "upstream": "anthropics/claude-code#60453",
+      "url": "https://github.com/anthropics/claude-code/issues/60453",
+      "title": "A.I. caught a needed change and found a solve all by itself",
+      "impact": "unknown_low_signal",
+      "categories": [],
+      "tokenkey_status": "not_applicable",
+      "rationale": "No gateway/relay-relevant keywords; treated as not-our-surface.",
+      "updated_at": "2026-06-03T22:45:31Z"
     },
     {
       "upstream": "anthropics/claude-code#60492",
@@ -20988,6 +23829,96 @@
       "updated_at": "2026-06-02T15:01:44Z"
     },
     {
+      "upstream": "anthropics/claude-code#60517",
+      "url": "https://github.com/anthropics/claude-code/issues/60517",
+      "title": "opus 4.6 and opus 4.7 the quality is not the same. This is now the second time i had to use a second grade model deepseek v4 so fix opus mistakes.",
+      "impact": "unknown_low_signal",
+      "categories": [],
+      "tokenkey_status": "not_applicable",
+      "rationale": "No gateway/relay-relevant keywords; treated as not-our-surface.",
+      "updated_at": "2026-06-03T22:45:49Z"
+    },
+    {
+      "upstream": "anthropics/claude-code#60526",
+      "url": "https://github.com/anthropics/claude-code/issues/60526",
+      "title": "Remote control session lost after context compaction — task ID not preserved in summary",
+      "impact": "unknown_low_signal",
+      "categories": [],
+      "tokenkey_status": "not_applicable",
+      "rationale": "No gateway/relay-relevant keywords; treated as not-our-surface.",
+      "updated_at": "2026-06-04T11:07:14Z"
+    },
+    {
+      "upstream": "anthropics/claude-code#60530",
+      "url": "https://github.com/anthropics/claude-code/issues/60530",
+      "title": "Claude breaks 'no code' / Ask-mode convention when it finds actionable gaps during an investigation",
+      "impact": "unknown_low_signal",
+      "categories": [],
+      "tokenkey_status": "not_applicable",
+      "rationale": "No gateway/relay-relevant keywords; treated as not-our-surface.",
+      "updated_at": "2026-06-03T22:45:56Z"
+    },
+    {
+      "upstream": "anthropics/claude-code#60570",
+      "url": "https://github.com/anthropics/claude-code/issues/60570",
+      "title": "Routines: option to deliver output via email",
+      "impact": "unknown_low_signal",
+      "categories": [],
+      "tokenkey_status": "not_applicable",
+      "rationale": "No gateway/relay-relevant keywords; treated as not-our-surface.",
+      "updated_at": "2026-06-04T11:06:56Z"
+    },
+    {
+      "upstream": "anthropics/claude-code#60573",
+      "url": "https://github.com/anthropics/claude-code/issues/60573",
+      "title": "Feature request: list/resume Claude Code sessions across all project directories",
+      "impact": "unknown_low_signal",
+      "categories": [],
+      "tokenkey_status": "not_applicable",
+      "rationale": "No gateway/relay-relevant keywords; treated as not-our-surface.",
+      "updated_at": "2026-06-04T11:06:58Z"
+    },
+    {
+      "upstream": "anthropics/claude-code#60636",
+      "url": "https://github.com/anthropics/claude-code/issues/60636",
+      "title": "Sesli komut destegi istiyorum",
+      "impact": "unknown_low_signal",
+      "categories": [],
+      "tokenkey_status": "not_applicable",
+      "rationale": "No gateway/relay-relevant keywords; treated as not-our-surface.",
+      "updated_at": "2026-06-04T11:07:33Z"
+    },
+    {
+      "upstream": "anthropics/claude-code#60641",
+      "url": "https://github.com/anthropics/claude-code/issues/60641",
+      "title": "/cost estimate does not account for inference_geo pricing multiplier",
+      "impact": "unknown_low_signal",
+      "categories": [],
+      "tokenkey_status": "not_applicable",
+      "rationale": "No gateway/relay-relevant keywords; treated as not-our-surface.",
+      "updated_at": "2026-06-04T11:07:33Z"
+    },
+    {
+      "upstream": "anthropics/claude-code#60644",
+      "url": "https://github.com/anthropics/claude-code/issues/60644",
+      "title": "[BUG] Approval prompt hidden when tool detail view (Ctrl+O) is expanded",
+      "impact": "unknown_low_signal",
+      "categories": [],
+      "tokenkey_status": "not_applicable",
+      "rationale": "No gateway/relay-relevant keywords; treated as not-our-surface.",
+      "updated_at": "2026-06-04T11:07:41Z"
+    },
+    {
+      "upstream": "anthropics/claude-code#60653",
+      "url": "https://github.com/anthropics/claude-code/issues/60653",
+      "title": "Feature Request: Localize UI labels (e.g. 'Recents') to Japanese",
+      "impact": "unknown_low_signal",
+      "categories": [],
+      "tokenkey_status": "not_applicable",
+      "rationale": "No gateway/relay-relevant keywords; treated as not-our-surface.",
+      "updated_at": "2026-06-04T11:07:42Z"
+    },
+    {
       "upstream": "anthropics/claude-code#60668",
       "url": "https://github.com/anthropics/claude-code/issues/60668",
       "title": "[FEATURE] Setting to suppress Ultraplan prompt in plan mode",
@@ -20996,6 +23927,16 @@
       "tokenkey_status": "not_applicable",
       "rationale": "No gateway/relay-relevant keywords; treated as not-our-surface.",
       "updated_at": "2026-06-02T17:18:42Z"
+    },
+    {
+      "upstream": "anthropics/claude-code#60674",
+      "url": "https://github.com/anthropics/claude-code/issues/60674",
+      "title": "Feature request: expose account usage limits (session/weekly %) in CLI",
+      "impact": "unknown_low_signal",
+      "categories": [],
+      "tokenkey_status": "not_applicable",
+      "rationale": "No gateway/relay-relevant keywords; treated as not-our-surface.",
+      "updated_at": "2026-06-03T23:04:39Z"
     },
     {
       "upstream": "anthropics/claude-code#60848",
@@ -21018,36 +23959,6 @@
       "updated_at": "2026-06-02T00:07:52Z"
     },
     {
-      "upstream": "anthropics/claude-code#61111",
-      "url": "https://github.com/anthropics/claude-code/issues/61111",
-      "title": "Remote Claude Code session (desktop app): GitHubPrManager spawns local `gh` with remote cwd → misleading ENOENT",
-      "impact": "unknown_low_signal",
-      "categories": [],
-      "tokenkey_status": "not_applicable",
-      "rationale": "No gateway/relay-relevant keywords; treated as not-our-surface.",
-      "updated_at": "2026-06-01T08:05:02Z"
-    },
-    {
-      "upstream": "anthropics/claude-code#61625",
-      "url": "https://github.com/anthropics/claude-code/issues/61625",
-      "title": "[Bug] Anthropic API Usage Policy classifier false positive on security terminology",
-      "impact": "unknown_low_signal",
-      "categories": [],
-      "tokenkey_status": "not_applicable",
-      "rationale": "No gateway/relay-relevant keywords; treated as not-our-surface.",
-      "updated_at": "2026-06-01T06:33:03Z"
-    },
-    {
-      "upstream": "anthropics/claude-code#61643",
-      "url": "https://github.com/anthropics/claude-code/issues/61643",
-      "title": "Conversation permanently blocked after credential-related context — rewind doesn't help",
-      "impact": "unknown_low_signal",
-      "categories": [],
-      "tokenkey_status": "not_applicable",
-      "rationale": "No gateway/relay-relevant keywords; treated as not-our-surface.",
-      "updated_at": "2026-06-01T03:51:51Z"
-    },
-    {
       "upstream": "anthropics/claude-code#61672",
       "url": "https://github.com/anthropics/claude-code/issues/61672",
       "title": "[Feature Request] Add per-message timestamps and session clock for reliable time tracking",
@@ -21058,26 +23969,6 @@
       "updated_at": "2026-06-02T15:01:27Z"
     },
     {
-      "upstream": "anthropics/claude-code#61830",
-      "url": "https://github.com/anthropics/claude-code/issues/61830",
-      "title": "[BUG] System prompt constant qD4 unconditionally injects security-adjacent text into every session, priming the API cyber classifier",
-      "impact": "unknown_low_signal",
-      "categories": [],
-      "tokenkey_status": "not_applicable",
-      "rationale": "No gateway/relay-relevant keywords; treated as not-our-surface.",
-      "updated_at": "2026-06-01T06:33:13Z"
-    },
-    {
-      "upstream": "anthropics/claude-code#62229",
-      "url": "https://github.com/anthropics/claude-code/issues/62229",
-      "title": "[MODEL] Opus 4.7 stole my money",
-      "impact": "unknown_low_signal",
-      "categories": [],
-      "tokenkey_status": "not_applicable",
-      "rationale": "No gateway/relay-relevant keywords; treated as not-our-surface.",
-      "updated_at": "2026-05-31T13:35:25Z"
-    },
-    {
       "upstream": "anthropics/claude-code#6235",
       "url": "https://github.com/anthropics/claude-code/issues/6235",
       "title": "Feature Request: Support AGENTS.md.",
@@ -21085,17 +23976,7 @@
       "categories": [],
       "tokenkey_status": "not_applicable",
       "rationale": "No gateway/relay-relevant keywords; treated as not-our-surface.",
-      "updated_at": "2026-06-03T04:23:27Z"
-    },
-    {
-      "upstream": "anthropics/claude-code#63130",
-      "url": "https://github.com/anthropics/claude-code/issues/63130",
-      "title": "macOS TCC popup still recurring on v2.1.153 — \"2.1.153\" would like to access data from other apps",
-      "impact": "unknown_low_signal",
-      "categories": [],
-      "tokenkey_status": "not_applicable",
-      "rationale": "No gateway/relay-relevant keywords; treated as not-our-surface.",
-      "updated_at": "2026-06-01T09:03:52Z"
+      "updated_at": "2026-06-04T06:02:19Z"
     },
     {
       "upstream": "anthropics/claude-code#63142",
@@ -21108,14 +23989,24 @@
       "updated_at": "2026-06-02T10:41:03Z"
     },
     {
-      "upstream": "anthropics/claude-code#63732",
-      "url": "https://github.com/anthropics/claude-code/issues/63732",
-      "title": "Edit tool silently substitutes Unicode smart quotes for ASCII double quotes in shell scripts",
+      "upstream": "anthropics/claude-code#63356",
+      "url": "https://github.com/anthropics/claude-code/issues/63356",
+      "title": "[MODEL] Sub-agents (Haiku) over-edit structured config files despite explicit \"surgical edits only\" instructions",
       "impact": "unknown_low_signal",
       "categories": [],
       "tokenkey_status": "not_applicable",
       "rationale": "No gateway/relay-relevant keywords; treated as not-our-surface.",
-      "updated_at": "2026-05-31T20:03:13Z"
+      "updated_at": "2026-06-03T21:52:58Z"
+    },
+    {
+      "upstream": "anthropics/claude-code#63540",
+      "url": "https://github.com/anthropics/claude-code/issues/63540",
+      "title": "Workflow tool: script parse errors always blame \"TypeScript syntax\" even for plain-JS errors (misleading)",
+      "impact": "unknown_low_signal",
+      "categories": [],
+      "tokenkey_status": "not_applicable",
+      "rationale": "No gateway/relay-relevant keywords; treated as not-our-surface.",
+      "updated_at": "2026-06-04T02:04:04Z"
     },
     {
       "upstream": "anthropics/claude-code#63853",
@@ -21138,26 +24029,6 @@
       "updated_at": "2026-06-01T18:19:14Z"
     },
     {
-      "upstream": "anthropics/claude-code#64053",
-      "url": "https://github.com/anthropics/claude-code/issues/64053",
-      "title": "Agent deflects with \"untouched by my change\" after its own change breaks previously-passing tests — needs accountability-first framing",
-      "impact": "unknown_low_signal",
-      "categories": [],
-      "tokenkey_status": "not_applicable",
-      "rationale": "No gateway/relay-relevant keywords; treated as not-our-surface.",
-      "updated_at": "2026-05-31T21:52:05Z"
-    },
-    {
-      "upstream": "anthropics/claude-code#64171",
-      "url": "https://github.com/anthropics/claude-code/issues/64171",
-      "title": "Feedback: noticeable reliability regression — agent edits from memory, silent Edit failures shipped broken code to prod",
-      "impact": "unknown_low_signal",
-      "categories": [],
-      "tokenkey_status": "not_applicable",
-      "rationale": "No gateway/relay-relevant keywords; treated as not-our-surface.",
-      "updated_at": "2026-05-31T20:25:45Z"
-    },
-    {
       "upstream": "anthropics/claude-code#64175",
       "url": "https://github.com/anthropics/claude-code/issues/64175",
       "title": "Claude Code wastes user quota with repeated trial-and-error instead of verifying calculations before coding",
@@ -21168,86 +24039,6 @@
       "updated_at": "2026-06-02T04:02:39Z"
     },
     {
-      "upstream": "anthropics/claude-code#64191",
-      "url": "https://github.com/anthropics/claude-code/issues/64191",
-      "title": "`/desktop` fails: \"Cannot determine working directory … transcript may be incomplete\" after EnterWorktree→ExitWorktree (transcript fragmented across project dirs; bridge-session record has no cwd)",
-      "impact": "unknown_low_signal",
-      "categories": [],
-      "tokenkey_status": "not_applicable",
-      "rationale": "No gateway/relay-relevant keywords; treated as not-our-surface.",
-      "updated_at": "2026-05-31T10:50:36Z"
-    },
-    {
-      "upstream": "anthropics/claude-code#64198",
-      "url": "https://github.com/anthropics/claude-code/issues/64198",
-      "title": "[MODEL] False-positive cyber-safety block on benign Minecraft mod documentation task",
-      "impact": "unknown_low_signal",
-      "categories": [],
-      "tokenkey_status": "not_applicable",
-      "rationale": "No gateway/relay-relevant keywords; treated as not-our-surface.",
-      "updated_at": "2026-05-31T11:13:48Z"
-    },
-    {
-      "upstream": "anthropics/claude-code#64236",
-      "url": "https://github.com/anthropics/claude-code/issues/64236",
-      "title": "[MODEL] Claude Code + Opus 4.8 frequently echos hello world during planning",
-      "impact": "unknown_low_signal",
-      "categories": [],
-      "tokenkey_status": "not_applicable",
-      "rationale": "No gateway/relay-relevant keywords; treated as not-our-surface.",
-      "updated_at": "2026-05-31T23:48:48Z"
-    },
-    {
-      "upstream": "anthropics/claude-code#64245",
-      "url": "https://github.com/anthropics/claude-code/issues/64245",
-      "title": "[FEATURE] Multiple account",
-      "impact": "unknown_low_signal",
-      "categories": [],
-      "tokenkey_status": "not_applicable",
-      "rationale": "No gateway/relay-relevant keywords; treated as not-our-surface.",
-      "updated_at": "2026-05-31T15:16:59Z"
-    },
-    {
-      "upstream": "anthropics/claude-code#64255",
-      "url": "https://github.com/anthropics/claude-code/issues/64255",
-      "title": "Auto mode selected at plan approval persists after execution completes",
-      "impact": "unknown_low_signal",
-      "categories": [],
-      "tokenkey_status": "not_applicable",
-      "rationale": "No gateway/relay-relevant keywords; treated as not-our-surface.",
-      "updated_at": "2026-05-31T15:55:54Z"
-    },
-    {
-      "upstream": "anthropics/claude-code#64259",
-      "url": "https://github.com/anthropics/claude-code/issues/64259",
-      "title": "Enriched input signal for Claude Code - Eyeballs for non-verbal communication cues",
-      "impact": "unknown_low_signal",
-      "categories": [],
-      "tokenkey_status": "not_applicable",
-      "rationale": "No gateway/relay-relevant keywords; treated as not-our-surface.",
-      "updated_at": "2026-05-31T16:17:08Z"
-    },
-    {
-      "upstream": "anthropics/claude-code#64266",
-      "url": "https://github.com/anthropics/claude-code/issues/64266",
-      "title": "Agent tool model parameter should accept full model IDs, not just tier names",
-      "impact": "unknown_low_signal",
-      "categories": [],
-      "tokenkey_status": "not_applicable",
-      "rationale": "No gateway/relay-relevant keywords; treated as not-our-surface.",
-      "updated_at": "2026-05-31T16:55:11Z"
-    },
-    {
-      "upstream": "anthropics/claude-code#64270",
-      "url": "https://github.com/anthropics/claude-code/issues/64270",
-      "title": "[FEATURE]",
-      "impact": "unknown_low_signal",
-      "categories": [],
-      "tokenkey_status": "not_applicable",
-      "rationale": "No gateway/relay-relevant keywords; treated as not-our-surface.",
-      "updated_at": "2026-05-31T17:20:26Z"
-    },
-    {
       "upstream": "anthropics/claude-code#64287",
       "url": "https://github.com/anthropics/claude-code/issues/64287",
       "title": "[UX] Add first-class false-positive reporting for safety guardrail blocks",
@@ -21255,67 +24046,7 @@
       "categories": [],
       "tokenkey_status": "not_applicable",
       "rationale": "No gateway/relay-relevant keywords; treated as not-our-surface.",
-      "updated_at": "2026-06-01T18:49:18Z"
-    },
-    {
-      "upstream": "anthropics/claude-code#64302",
-      "url": "https://github.com/anthropics/claude-code/issues/64302",
-      "title": "Feature Request: Show usage stats in account dropdown menu",
-      "impact": "unknown_low_signal",
-      "categories": [],
-      "tokenkey_status": "not_applicable",
-      "rationale": "No gateway/relay-relevant keywords; treated as not-our-surface.",
-      "updated_at": "2026-05-31T19:37:42Z"
-    },
-    {
-      "upstream": "anthropics/claude-code#64307",
-      "url": "https://github.com/anthropics/claude-code/issues/64307",
-      "title": "[BUG] Cowork: uploaded context lands in the project mount, not mnt/uploads/",
-      "impact": "unknown_low_signal",
-      "categories": [],
-      "tokenkey_status": "not_applicable",
-      "rationale": "No gateway/relay-relevant keywords; treated as not-our-surface.",
-      "updated_at": "2026-05-31T19:55:06Z"
-    },
-    {
-      "upstream": "anthropics/claude-code#64335",
-      "url": "https://github.com/anthropics/claude-code/issues/64335",
-      "title": "[MODEL] Porting JS to TS Relies Too Much On Feedback From TSC",
-      "impact": "unknown_low_signal",
-      "categories": [],
-      "tokenkey_status": "not_applicable",
-      "rationale": "No gateway/relay-relevant keywords; treated as not-our-surface.",
-      "updated_at": "2026-05-31T21:42:03Z"
-    },
-    {
-      "upstream": "anthropics/claude-code#64342",
-      "url": "https://github.com/anthropics/claude-code/issues/64342",
-      "title": "Display `~/` instead of full `/Users/<name>/` in tool call path labels",
-      "impact": "unknown_low_signal",
-      "categories": [],
-      "tokenkey_status": "not_applicable",
-      "rationale": "No gateway/relay-relevant keywords; treated as not-our-surface.",
-      "updated_at": "2026-05-31T22:35:16Z"
-    },
-    {
-      "upstream": "anthropics/claude-code#64348",
-      "url": "https://github.com/anthropics/claude-code/issues/64348",
-      "title": "[FEATURE] Dynamic Workflow Feature List",
-      "impact": "unknown_low_signal",
-      "categories": [],
-      "tokenkey_status": "not_applicable",
-      "rationale": "No gateway/relay-relevant keywords; treated as not-our-surface.",
-      "updated_at": "2026-05-31T22:48:15Z"
-    },
-    {
-      "upstream": "anthropics/claude-code#64354",
-      "url": "https://github.com/anthropics/claude-code/issues/64354",
-      "title": "[Feature Request] Sidebar: nest sub-folders within the same Git repo as separate project blocks",
-      "impact": "unknown_low_signal",
-      "categories": [],
-      "tokenkey_status": "not_applicable",
-      "rationale": "No gateway/relay-relevant keywords; treated as not-our-surface.",
-      "updated_at": "2026-06-01T02:56:54Z"
+      "updated_at": "2026-06-04T05:55:18Z"
     },
     {
       "upstream": "anthropics/claude-code#64370",
@@ -21325,37 +24056,7 @@
       "categories": [],
       "tokenkey_status": "not_applicable",
       "rationale": "No gateway/relay-relevant keywords; treated as not-our-surface.",
-      "updated_at": "2026-06-02T03:57:19Z"
-    },
-    {
-      "upstream": "anthropics/claude-code#64373",
-      "url": "https://github.com/anthropics/claude-code/issues/64373",
-      "title": "[Bug] Workflow agent marked complete on Anthropic API policy violation error",
-      "impact": "unknown_low_signal",
-      "categories": [],
-      "tokenkey_status": "not_applicable",
-      "rationale": "No gateway/relay-relevant keywords; treated as not-our-surface.",
-      "updated_at": "2026-06-01T03:07:01Z"
-    },
-    {
-      "upstream": "anthropics/claude-code#64382",
-      "url": "https://github.com/anthropics/claude-code/issues/64382",
-      "title": "Claude Code repeatedly makes code changes without explicit user approval",
-      "impact": "unknown_low_signal",
-      "categories": [],
-      "tokenkey_status": "not_applicable",
-      "rationale": "No gateway/relay-relevant keywords; treated as not-our-surface.",
-      "updated_at": "2026-06-01T03:06:05Z"
-    },
-    {
-      "upstream": "anthropics/claude-code#64385",
-      "url": "https://github.com/anthropics/claude-code/issues/64385",
-      "title": "Chinese IME input: characters overwritten/dropped when editing mid-text",
-      "impact": "unknown_low_signal",
-      "categories": [],
-      "tokenkey_status": "not_applicable",
-      "rationale": "No gateway/relay-relevant keywords; treated as not-our-surface.",
-      "updated_at": "2026-06-01T03:47:58Z"
+      "updated_at": "2026-06-03T14:36:01Z"
     },
     {
       "upstream": "anthropics/claude-code#64405",
@@ -21366,16 +24067,6 @@
       "tokenkey_status": "not_applicable",
       "rationale": "No gateway/relay-relevant keywords; treated as not-our-surface.",
       "updated_at": "2026-06-02T16:44:57Z"
-    },
-    {
-      "upstream": "anthropics/claude-code#64473",
-      "url": "https://github.com/anthropics/claude-code/issues/64473",
-      "title": "Claude Code edited out-of-scope backend files during a scoped Blade/frontend task, without disclosure",
-      "impact": "unknown_low_signal",
-      "categories": [],
-      "tokenkey_status": "not_applicable",
-      "rationale": "No gateway/relay-relevant keywords; treated as not-our-surface.",
-      "updated_at": "2026-06-01T12:30:48Z"
     },
     {
       "upstream": "anthropics/claude-code#64507",
@@ -21588,16 +24279,6 @@
       "updated_at": "2026-06-02T19:23:35Z"
     },
     {
-      "upstream": "anthropics/claude-code#64862",
-      "url": "https://github.com/anthropics/claude-code/issues/64862",
-      "title": "[Bug] Claude Code repeatedly bypasses agreed Scrum story lifecycle — commits without compiling, skips tests, ignores direct instructions, fabricates excuses",
-      "impact": "unknown_low_signal",
-      "categories": [],
-      "tokenkey_status": "not_applicable",
-      "rationale": "No gateway/relay-relevant keywords; treated as not-our-surface.",
-      "updated_at": "2026-06-02T21:40:46Z"
-    },
-    {
       "upstream": "anthropics/claude-code#64866",
       "url": "https://github.com/anthropics/claude-code/issues/64866",
       "title": "Model fails to connect adjacent logical steps (downloads large file without saving, then needs to re-download)",
@@ -21706,6 +24387,286 @@
       "tokenkey_status": "not_applicable",
       "rationale": "No gateway/relay-relevant keywords; treated as not-our-surface.",
       "updated_at": "2026-06-03T09:11:25Z"
+    },
+    {
+      "upstream": "anthropics/claude-code#65023",
+      "url": "https://github.com/anthropics/claude-code/issues/65023",
+      "title": "[BUG] Routine runs stuck in 'Needs input' only show on home screen, never in the left sidebar (Desktop app)",
+      "impact": "unknown_low_signal",
+      "categories": [],
+      "tokenkey_status": "not_applicable",
+      "rationale": "No gateway/relay-relevant keywords; treated as not-our-surface.",
+      "updated_at": "2026-06-03T10:41:14Z"
+    },
+    {
+      "upstream": "anthropics/claude-code#65027",
+      "url": "https://github.com/anthropics/claude-code/issues/65027",
+      "title": "Surface active ghost text suggestion in conversation context",
+      "impact": "unknown_low_signal",
+      "categories": [],
+      "tokenkey_status": "not_applicable",
+      "rationale": "No gateway/relay-relevant keywords; treated as not-our-surface.",
+      "updated_at": "2026-06-03T11:04:24Z"
+    },
+    {
+      "upstream": "anthropics/claude-code#65042",
+      "url": "https://github.com/anthropics/claude-code/issues/65042",
+      "title": "I don't see any bug report content in your message - only a screenshot file path. Could you please share the actual error message, logs, or description of the issue you're experiencing with Claude Code? Once you provide the details of the bug, I'll be ab",
+      "impact": "unknown_low_signal",
+      "categories": [],
+      "tokenkey_status": "not_applicable",
+      "rationale": "No gateway/relay-relevant keywords; treated as not-our-surface.",
+      "updated_at": "2026-06-03T12:37:12Z"
+    },
+    {
+      "upstream": "anthropics/claude-code#65058",
+      "url": "https://github.com/anthropics/claude-code/issues/65058",
+      "title": "Feature request: /memories command to show loaded memory files",
+      "impact": "unknown_low_signal",
+      "categories": [],
+      "tokenkey_status": "not_applicable",
+      "rationale": "No gateway/relay-relevant keywords; treated as not-our-surface.",
+      "updated_at": "2026-06-03T13:35:07Z"
+    },
+    {
+      "upstream": "anthropics/claude-code#65075",
+      "url": "https://github.com/anthropics/claude-code/issues/65075",
+      "title": "Link Claude Code sessions to CLAUDE.md for cross-device sync",
+      "impact": "unknown_low_signal",
+      "categories": [],
+      "tokenkey_status": "not_applicable",
+      "rationale": "No gateway/relay-relevant keywords; treated as not-our-surface.",
+      "updated_at": "2026-06-03T14:51:33Z"
+    },
+    {
+      "upstream": "anthropics/claude-code#65078",
+      "url": "https://github.com/anthropics/claude-code/issues/65078",
+      "title": "[FEATURE] Add option to create a new session when `--resume` is passed via CLI",
+      "impact": "unknown_low_signal",
+      "categories": [],
+      "tokenkey_status": "not_applicable",
+      "rationale": "No gateway/relay-relevant keywords; treated as not-our-surface.",
+      "updated_at": "2026-06-03T15:03:28Z"
+    },
+    {
+      "upstream": "anthropics/claude-code#65119",
+      "url": "https://github.com/anthropics/claude-code/issues/65119",
+      "title": "Babysit agents stop with 'socket connection closed unexpectedly' API error",
+      "impact": "unknown_low_signal",
+      "categories": [],
+      "tokenkey_status": "not_applicable",
+      "rationale": "No gateway/relay-relevant keywords; treated as not-our-surface.",
+      "updated_at": "2026-06-03T17:34:01Z"
+    },
+    {
+      "upstream": "anthropics/claude-code#65121",
+      "url": "https://github.com/anthropics/claude-code/issues/65121",
+      "title": "[bug] \"✗ Auto-update failed · Run /doctor\" in status bar causes background agents to stop during long-running sessions",
+      "impact": "unknown_low_signal",
+      "categories": [],
+      "tokenkey_status": "not_applicable",
+      "rationale": "No gateway/relay-relevant keywords; treated as not-our-surface.",
+      "updated_at": "2026-06-03T17:50:03Z"
+    },
+    {
+      "upstream": "anthropics/claude-code#65123",
+      "url": "https://github.com/anthropics/claude-code/issues/65123",
+      "title": "[FEATURE] Allow Org level control of \"Delete sessions stored by Antrhopic\"",
+      "impact": "unknown_low_signal",
+      "categories": [],
+      "tokenkey_status": "not_applicable",
+      "rationale": "No gateway/relay-relevant keywords; treated as not-our-surface.",
+      "updated_at": "2026-06-03T17:45:29Z"
+    },
+    {
+      "upstream": "anthropics/claude-code#65129",
+      "url": "https://github.com/anthropics/claude-code/issues/65129",
+      "title": "[FEATURE] Button to copy message in mobile app Claude Code",
+      "impact": "unknown_low_signal",
+      "categories": [],
+      "tokenkey_status": "not_applicable",
+      "rationale": "No gateway/relay-relevant keywords; treated as not-our-surface.",
+      "updated_at": "2026-06-03T17:59:55Z"
+    },
+    {
+      "upstream": "anthropics/claude-code#65138",
+      "url": "https://github.com/anthropics/claude-code/issues/65138",
+      "title": "Remote routines on private GitHub repos auto-disabled with auto_disabled_repo_access after first run",
+      "impact": "unknown_low_signal",
+      "categories": [],
+      "tokenkey_status": "not_applicable",
+      "rationale": "No gateway/relay-relevant keywords; treated as not-our-surface.",
+      "updated_at": "2026-06-03T18:46:02Z"
+    },
+    {
+      "upstream": "anthropics/claude-code#65166",
+      "url": "https://github.com/anthropics/claude-code/issues/65166",
+      "title": "darwin-x64: false \"temp filesystem is full (0MB free) / ENOSPC\" — statfs().bsize=0 makes the empty-output explainer always report disk-full",
+      "impact": "unknown_low_signal",
+      "categories": [],
+      "tokenkey_status": "not_applicable",
+      "rationale": "No gateway/relay-relevant keywords; treated as not-our-surface.",
+      "updated_at": "2026-06-03T20:35:30Z"
+    },
+    {
+      "upstream": "anthropics/claude-code#65177",
+      "url": "https://github.com/anthropics/claude-code/issues/65177",
+      "title": "Web (claude.ai/code): session groups don't persist across environments/devices — sessions appear \"Ungrouped\"",
+      "impact": "unknown_low_signal",
+      "categories": [],
+      "tokenkey_status": "not_applicable",
+      "rationale": "No gateway/relay-relevant keywords; treated as not-our-surface.",
+      "updated_at": "2026-06-03T21:57:10Z"
+    },
+    {
+      "upstream": "anthropics/claude-code#65182",
+      "url": "https://github.com/anthropics/claude-code/issues/65182",
+      "title": "[DOCS] `claude agents --json` docs omit the `waitingFor` field for blocked sessions",
+      "impact": "unknown_low_signal",
+      "categories": [],
+      "tokenkey_status": "not_applicable",
+      "rationale": "No gateway/relay-relevant keywords; treated as not-our-surface.",
+      "updated_at": "2026-06-03T22:29:15Z"
+    },
+    {
+      "upstream": "anthropics/claude-code#65186",
+      "url": "https://github.com/anthropics/claude-code/issues/65186",
+      "title": "[DOCS] WebFetch permission docs omit rule precedence over built-in preapproved domains",
+      "impact": "unknown_low_signal",
+      "categories": [],
+      "tokenkey_status": "not_applicable",
+      "rationale": "No gateway/relay-relevant keywords; treated as not-our-surface.",
+      "updated_at": "2026-06-03T22:29:29Z"
+    },
+    {
+      "upstream": "anthropics/claude-code#65200",
+      "url": "https://github.com/anthropics/claude-code/issues/65200",
+      "title": "[FEATURE] Display real-time session and weekly limits in the main ui",
+      "impact": "unknown_low_signal",
+      "categories": [],
+      "tokenkey_status": "not_applicable",
+      "rationale": "No gateway/relay-relevant keywords; treated as not-our-surface.",
+      "updated_at": "2026-06-03T22:55:26Z"
+    },
+    {
+      "upstream": "anthropics/claude-code#65203",
+      "url": "https://github.com/anthropics/claude-code/issues/65203",
+      "title": "[MODEL]",
+      "impact": "unknown_low_signal",
+      "categories": [],
+      "tokenkey_status": "not_applicable",
+      "rationale": "No gateway/relay-relevant keywords; treated as not-our-surface.",
+      "updated_at": "2026-06-03T23:09:30Z"
+    },
+    {
+      "upstream": "anthropics/claude-code#65224",
+      "url": "https://github.com/anthropics/claude-code/issues/65224",
+      "title": "[iOS] Unsent message drafts lost when switching sessions",
+      "impact": "unknown_low_signal",
+      "categories": [],
+      "tokenkey_status": "not_applicable",
+      "rationale": "No gateway/relay-relevant keywords; treated as not-our-surface.",
+      "updated_at": "2026-06-04T00:47:14Z"
+    },
+    {
+      "upstream": "anthropics/claude-code#65233",
+      "url": "https://github.com/anthropics/claude-code/issues/65233",
+      "title": "[Bug] --bg-pty-host processes spin to ~99% CPU per process while wrapped --bg-spare is idle (v2.1.162, macOS)",
+      "impact": "unknown_low_signal",
+      "categories": [],
+      "tokenkey_status": "not_applicable",
+      "rationale": "No gateway/relay-relevant keywords; treated as not-our-surface.",
+      "updated_at": "2026-06-04T01:19:21Z"
+    },
+    {
+      "upstream": "anthropics/claude-code#65237",
+      "url": "https://github.com/anthropics/claude-code/issues/65237",
+      "title": "Project picker shows duplicate Recent rows for one folder due to path-casing (case-insensitive APFS): /Dev vs /dev",
+      "impact": "unknown_low_signal",
+      "categories": [],
+      "tokenkey_status": "not_applicable",
+      "rationale": "No gateway/relay-relevant keywords; treated as not-our-surface.",
+      "updated_at": "2026-06-04T02:17:21Z"
+    },
+    {
+      "upstream": "anthropics/claude-code#65257",
+      "url": "https://github.com/anthropics/claude-code/issues/65257",
+      "title": "[BUG] Path-scoped `.claude/rules/` not injected when Claude is launched from a subdirectory (glob matched against launch CWD, not project root)",
+      "impact": "unknown_low_signal",
+      "categories": [],
+      "tokenkey_status": "not_applicable",
+      "rationale": "No gateway/relay-relevant keywords; treated as not-our-surface.",
+      "updated_at": "2026-06-04T03:36:50Z"
+    },
+    {
+      "upstream": "anthropics/claude-code#65264",
+      "url": "https://github.com/anthropics/claude-code/issues/65264",
+      "title": "[FEATURE] Headless enqueue: send a message to a running background session (non-interactive)",
+      "impact": "unknown_low_signal",
+      "categories": [],
+      "tokenkey_status": "not_applicable",
+      "rationale": "No gateway/relay-relevant keywords; treated as not-our-surface.",
+      "updated_at": "2026-06-04T04:21:15Z"
+    },
+    {
+      "upstream": "anthropics/claude-code#65273",
+      "url": "https://github.com/anthropics/claude-code/issues/65273",
+      "title": "claude agents --json returns subset of agents shown in interactive agent view",
+      "impact": "unknown_low_signal",
+      "categories": [],
+      "tokenkey_status": "not_applicable",
+      "rationale": "No gateway/relay-relevant keywords; treated as not-our-surface.",
+      "updated_at": "2026-06-04T05:45:30Z"
+    },
+    {
+      "upstream": "anthropics/claude-code#65295",
+      "url": "https://github.com/anthropics/claude-code/issues/65295",
+      "title": "[FEATURE] Incremental `CLAUDE.md` updates using last-scanned commit hash",
+      "impact": "unknown_low_signal",
+      "categories": [],
+      "tokenkey_status": "not_applicable",
+      "rationale": "No gateway/relay-relevant keywords; treated as not-our-surface.",
+      "updated_at": "2026-06-04T07:35:42Z"
+    },
+    {
+      "upstream": "anthropics/claude-code#65299",
+      "url": "https://github.com/anthropics/claude-code/issues/65299",
+      "title": "[FEATURE] Routines: create runs as shared (Team) sessions by default",
+      "impact": "unknown_low_signal",
+      "categories": [],
+      "tokenkey_status": "not_applicable",
+      "rationale": "No gateway/relay-relevant keywords; treated as not-our-surface.",
+      "updated_at": "2026-06-04T07:44:07Z"
+    },
+    {
+      "upstream": "anthropics/claude-code#65313",
+      "url": "https://github.com/anthropics/claude-code/issues/65313",
+      "title": "[FEATURE] Configurable Storage Location for VM Bundles",
+      "impact": "unknown_low_signal",
+      "categories": [],
+      "tokenkey_status": "not_applicable",
+      "rationale": "No gateway/relay-relevant keywords; treated as not-our-surface.",
+      "updated_at": "2026-06-04T09:04:44Z"
+    },
+    {
+      "upstream": "anthropics/claude-code#65360",
+      "url": "https://github.com/anthropics/claude-code/issues/65360",
+      "title": "Esc immediately after Return silently loses the just-submitted message (unrecoverable)",
+      "impact": "unknown_low_signal",
+      "categories": [],
+      "tokenkey_status": "not_applicable",
+      "rationale": "No gateway/relay-relevant keywords; treated as not-our-surface.",
+      "updated_at": "2026-06-04T12:03:43Z"
+    },
+    {
+      "upstream": "anthropics/claude-code#65361",
+      "url": "https://github.com/anthropics/claude-code/issues/65361",
+      "title": "[BUG] /resume does not list recently renamed sessions despite JSONL files existing on disk",
+      "impact": "unknown_low_signal",
+      "categories": [],
+      "tokenkey_status": "not_applicable",
+      "rationale": "No gateway/relay-relevant keywords; treated as not-our-surface.",
+      "updated_at": "2026-06-04T11:59:10Z"
     },
     {
       "upstream": "anthropics/claude-code#895",


### PR DESCRIPTION
## Summary
- Refresh `.cache/anthropic/cc-triage.json` from the latest anthropics/claude-code issues.
- Update `.cache/anthropic/cc-fixes.json` from current TokenKey main fact checks.
- Keep watchdog workflow/script/fact-check metadata in sync with the refreshed cache.

## Watchdog report
# Anthropic Claude-Code Issue Watchdog Report

- Run URL: https://github.com/youxuanxue/sub2api/actions/runs/26952535104
- Repository SHA: `48ea88d0cbc5c2db8f6f5139c760080489a3496a`
- Generated at: `2026-06-04T12:46:06Z`
- Upstream issues scanned: `2985`
- Fact checks: `3`
- Fixed facts verified: `3`
- High/critical unresolved: `0`

## Fixed facts verified

- anthropics/claude-code#61348 via youxuanxue/sub2api#514, youxuanxue/sub2api#518
- anthropics/claude-code#60168, anthropics/claude-code#63885, anthropics/claude-code#64777 via youxuanxue/sub2api (UTF-8/surrogate self-heal)
- anthropics/claude-code#60913 via youxuanxue/sub2api ([1m] context-window model-alias strip)


## Test plan
- [x] `python3 -m json.tool .cache/anthropic/cc-triage.json`
- [x] `python3 -m json.tool .cache/anthropic/cc-fixes.json`
- [x] `python3 -m json.tool .cache/anthropic/cc-fact-checks.json`
- [x] `python3 -m py_compile scripts/upstream/issue-watchdog.py`
- [x] `python3 -m json.tool .cache/anthropic-cc-issue-watchdog/report.json`
- [x] `python3 -m json.tool .cache/anthropic-cc-issue-watchdog/agent-input.json`
