### PR TITLE
fix(ops): cc check-env honors cc0 env + current egress default 16.147.170.3

### DIFF
--- a/ops/anthropic/capture-cc-fingerprint.sh
+++ b/ops/anthropic/capture-cc-fingerprint.sh
@@ -265,6 +265,13 @@ cmd_capture() {
 
 cmd_check_env() {
   require_cmd python3
+  # Honor the operator's egress/proxy config (CC0_EXPECT_EGRESS_IP, CC0_SOCKS5,
+  # CC0_GOST_HTTP_*) instead of the python fallbacks. Matches capture-http-
+  # comprehensive.sh; without this the check reports a stale default egress IP.
+  if [[ -f "${HOME}/.config/cc0/env" ]]; then
+    # shellcheck disable=SC1091
+    source "${HOME}/.config/cc0/env"
+  fi
   local args=()
   while [[ $# -gt 0 ]]; do
     case "$1" in

--- a/ops/anthropic/capture_cc_fingerprint.py
+++ b/ops/anthropic/capture_cc_fingerprint.py
@@ -687,7 +687,9 @@ def run_check_env(
     socks = os.environ.get("CC0_SOCKS5", "127.0.0.1:1093")
     gost_host = os.environ.get("CC0_GOST_HTTP_HOST", "127.0.0.1")
     gost_port = int(os.environ.get("CC0_GOST_HTTP_PORT", "11800"))
-    expect_ip = os.environ.get("CC0_EXPECT_EGRESS_IP", "13.134.80.182")
+    # Fallback only — the operator's ~/.config/cc0/env CC0_EXPECT_EGRESS_IP wins.
+    # Current canonical cc0 SOCKS-chain egress (see docs/spec-delta-cc-2.1.16x.md).
+    expect_ip = os.environ.get("CC0_EXPECT_EGRESS_IP", "16.147.170.3")
     try:
         socks_host, socks_port = _parse_host_port(socks, default_host="127.0.0.1")
     except ValueError as exc:


### PR DESCRIPTION
## Problem

`bash ops/anthropic/capture-cc-fingerprint.sh check env` reported a spurious
`cc0.egress FAIL: 16.147.170.3 != expected 13.134.80.182` even though the
operator's `~/.config/cc0/env` already sets `CC0_EXPECT_EGRESS_IP=16.147.170.3`
(the live gost-chain egress, matching `docs/spec-delta-cc-2.1.161/2.1.162.md`).

Root cause: `cmd_check_env` `exec`'d the python check **without sourcing**
`~/.config/cc0/env`, so none of the `CC0_*` knobs reached it, and the egress
check fell back to the python default — which was the **stale** `13.134.80.182`
(a former cc0 egress).

## Fix (ops tooling only, `no-web-impact`)

- `capture-cc-fingerprint.sh` `cmd_check_env`: source `~/.config/cc0/env` when
  present (same as `capture-http-comprehensive.sh`) so the operator's config wins.
- `capture_cc_fingerprint.py`: bump the `CC0_EXPECT_EGRESS_IP` fallback
  `13.134.80.182 → 16.147.170.3` for callers that don't source the env file
  (e.g. the daily hook). The env var still overrides.

The two remaining `13.134.80.182` references in `deploy/aws/lightsail/` are edge
**uk1's Porkbun DNS A record** — a different, current value, left untouched.

## Verify

`bash ops/anthropic/capture-cc-fingerprint.sh check env --relax-desktop`
→ `ok=6 warn=1 fail=0`, `cc0.egress OK egress 16.147.170.3 via gost`
(only WARN is Claude.app not running). Ops unit tests 13 passed; `bash -n` clean;
`scripts/preflight.sh` full suite PASS.

🤖 Generated with [Claude Code](https://claude.com/claude-code)