### PR TITLE
chore(dev-rules): bump 子模块至 56b45be (claude launcher 收编 + e2e UI 规则)

### DIFF
--- a/.cursor/rules/dev-rules-convention.mdc
+++ b/.cursor/rules/dev-rules-convention.mdc
@@ -25,6 +25,7 @@ alwaysApply: true
 ~/.claude/commands/   → dev-rules/commands/
 ~/.claude/CLAUDE.md   → dev-rules/global/CLAUDE.md
 ~/.claude/skills      → ~/.cursor/skills
+~/.local/bin/<name>   → dev-rules/global/bin/<name>（CLI launcher；secret 留本机 ~/.claude/*.json 不入库）
 ~/.codex/AGENTS.md    → dev-rules/global/CLAUDE.md（Codex 与 Claude 同一宪法）
 ~/.codex/skills/<name>→ ~/.cursor/skills/<name>（逐个叠加，不动 Codex 自带 .system/default.rules）
 ```


### PR DESCRIPTION
## 变更

dev-rules 子模块 2a53224 → 56b45be，并 `sync.sh --local` resync `.cursor/rules`。带入 dev-rules main 变更：

- **global/bin claude launcher 收编**（#69 #70）：claude-kiro / doubao / ds → 单一实现 claude-with-token
- **test-philosophy §3**（#68）：e2e 必须经真实 UI（Playwright）

`.cursor/rules/*.mdc` 为 sync 产物（real copy），非手编。

## 验证

`scripts/preflight.sh`（含 sub2api 项目段）+ pre-push 检查 PASS。

🤖 Generated with [Claude Code](https://claude.com/claude-code)