### PR TITLE
feat(admin): 账号容量列内嵌今日用量(tokens/$cost),全账号类型

### DIFF
--- a/backend/internal/web/dist/frontend-source.json
+++ b/backend/internal/web/dist/frontend-source.json
@@ -1,7 +1,7 @@
 {
   "algorithm": "sha256(git-ls-files:path,size,content)",
   "file_count": 454,
-  "hash": "dcc25f62849c9837a0b12b37a46408e681b99f8c6d0a0da11d6773b384a64f04",
+  "hash": "7d87eea5a1ce4d69bcd23bf7141bd6eb32898cbc3ffcfeea63a25f89d840224f",
   "schema": 1,
   "source": "frontend/"
 }

--- a/frontend/src/components/account/AccountCapacityCell.vue
+++ b/frontend/src/components/account/AccountCapacityCell.vue
@@ -32,18 +32,35 @@
     <QuotaBadge v-if="showDailyQuota" :used="account.quota_daily_used ?? 0" :limit="account.quota_daily_limit!" label="D" />
     <QuotaBadge v-if="showWeeklyQuota" :used="account.quota_weekly_used ?? 0" :limit="account.quota_weekly_limit!" label="W" />
     <QuotaBadge v-if="showTotalQuota" :used="account.quota_used ?? 0" :limit="account.quota_limit!" />
+
+    <!-- 今日用量（tokens + 计费），全账号类型；数据由父组件注入 -->
+    <span
+      v-if="todayStats"
+      :class="['inline-flex items-center gap-1 rounded-md px-1.5 py-px text-[10px] font-medium leading-tight', todayUsageClass]"
+      :title="todayTooltip"
+    >
+      <svg class="h-2.5 w-2.5" fill="none" viewBox="0 0 24 24" stroke="currentColor" stroke-width="2">
+        <path stroke-linecap="round" stroke-linejoin="round" d="M6.75 3v2.25M17.25 3v2.25M3 18.75V7.5a2.25 2.25 0 012.25-2.25h13.5A2.25 2.25 0 0121 7.5v11.25m-18 0A2.25 2.25 0 005.25 21h13.5A2.25 2.25 0 0021 18.75m-18 0v-7.5A2.25 2.25 0 015.25 9h13.5A2.25 2.25 0 0121 11.25v7.5" />
+      </svg>
+      <span class="font-mono">{{ formatTokensK(todayStats.tokens) }}</span>
+      <span class="text-gray-400 dark:text-gray-500">·</span>
+      <span class="font-mono">{{ formatCurrency(todayStats.cost) }}</span>
+    </span>
   </div>
 </template>
 
 <script setup lang="ts">
 import { computed } from 'vue'
 import { useI18n } from 'vue-i18n'
-import type { Account } from '@/types'
+import type { Account, WindowStats } from '@/types'
+import { formatCurrency, formatTokensK } from '@/utils/format'
 import CapacityBadge from '@/components/account/CapacityBadge.vue'
 import QuotaBadge from '@/components/account/QuotaBadge.vue'
 
 const props = defineProps<{
   account: Account
+  // 今日用量（tokens + 计费），由父组件按账号 ID 注入；全账号类型通用。
+  todayStats?: WindowStats | null
 }>()
 
 const { t } = useI18n()
@@ -181,6 +198,27 @@ const formatCost = (value: number | null | undefined) => {
   if (value === null || value === undefined) return '0'
   return value.toFixed(2)
 }
+
+// ====== 今日用量（全账号类型；0 值灰显以暴露异常，如 kiro 当前 0 计费） ======
+const hasTodayUsage = computed(() => {
+  const s = props.todayStats
+  return !!s && ((s.tokens ?? 0) > 0 || (s.cost ?? 0) > 0)
+})
+
+const todayUsageClass = computed(() =>
+  hasTodayUsage.value
+    ? 'bg-indigo-50 text-indigo-600 dark:bg-indigo-900/20 dark:text-indigo-300'
+    : 'bg-gray-100 text-gray-400 dark:bg-gray-800 dark:text-gray-500'
+)
+
+const todayTooltip = computed(() => {
+  const s = props.todayStats
+  if (!s) return ''
+  return t('admin.accounts.capacity.today.tooltip', {
+    requests: s.requests ?? 0,
+    cost: formatCurrency(s.cost)
+  })
+})
 
 // ====== 配额 ======
 const isQuotaEligible = computed(() => props.account.type === 'apikey' || props.account.type === 'bedrock')

--- a/frontend/src/i18n/locales/en.ts
+++ b/frontend/src/i18n/locales/en.ts
@@ -3329,6 +3329,9 @@ export default {
           exceeded: 'Quota exceeded, account paused',
           normal: 'Quota normal'
         },
+        today: {
+          tooltip: "Today's usage: {requests} requests · billed {cost}"
+        },
       },
       tempUnschedulable: {
         title: 'Temp Unschedulable',

--- a/frontend/src/i18n/locales/zh.ts
+++ b/frontend/src/i18n/locales/zh.ts
@@ -3365,6 +3365,9 @@ export default {
           exceeded: '配额已用完，账号暂停调度',
           normal: '配额正常'
         },
+        today: {
+          tooltip: '今日用量：{requests} 次请求 · 计费 {cost}'
+        },
       },
       clearRateLimit: '清除速率限制',
       resetQuota: '重置配额',

--- a/frontend/src/views/admin/AccountsView.vue
+++ b/frontend/src/views/admin/AccountsView.vue
@@ -227,7 +227,7 @@
             </div>
           </template>
           <template #cell-capacity="{ row }">
-            <AccountCapacityCell :account="row" />
+            <AccountCapacityCell :account="row" :today-stats="todayStatsByAccountId[String(row.id)] ?? null" />
           </template>
           <template #cell-status="{ row }">
             <div class="flex items-center gap-1.5">
@@ -562,11 +562,12 @@ const buildDefaultTodayStats = (): WindowStats => ({
 })
 
 const refreshTodayStatsBatch = async () => {
-  // Why this checks both columns:
+  // Why this checks these columns:
   // - today_stats column shows dedicated today's metrics.
   // - usage column also embeds today's stats for Key/Bedrock rows.
-  // So we only skip fetching when BOTH columns are hidden.
-  if (hiddenColumns.has('today_stats') && hiddenColumns.has('usage')) {
+  // - capacity column now embeds a today usage badge for ALL account types.
+  // So we only skip fetching when ALL three columns are hidden.
+  if (hiddenColumns.has('today_stats') && hiddenColumns.has('usage') && hiddenColumns.has('capacity')) {
     todayStatsLoading.value = false
     todayStatsError.value = null
     return

--- a/frontend/src/views/admin/EdgeAccountsView.vue
+++ b/frontend/src/views/admin/EdgeAccountsView.vue
@@ -145,7 +145,7 @@
                     <span v-if="acct.channel_type" class="text-gray-400 dark:text-gray-500"> · ch{{ acct.channel_type }}</span>
                   </td>
                   <td class="px-4 py-2 align-top">
-                    <AccountCapacityCell :account="toAccountLike(acct)" />
+                    <AccountCapacityCell :account="toAccountLike(acct)" :today-stats="toWindowStats(acct)" />
                   </td>
                   <td class="px-4 py-2 align-top">
                     <AccountUsageCell

--- a/scripts/sentinels/frontend-tk.json
+++ b/scripts/sentinels/frontend-tk.json
@@ -460,6 +460,14 @@
         "title: 'Edge 账号'"
       ],
       "rationale": "TK-only Chinese i18n for the Edge Accounts page — the zh counterpart of the en.ts edge-accounts anchor. Guards against an upstream locale-file rewrite silently dropping the block."
+    },
+    {
+      "path": "frontend/src/components/account/AccountCapacityCell.vue",
+      "must_contain": [
+        "todayStats",
+        "capacity.today.tooltip"
+      ],
+      "rationale": "TK adds a today-usage badge (tokens·$cost) for ALL account types in the capacity column (admin accounts page + edge accounts page). The `todayStats` prop and the `admin.accounts.capacity.today.tooltip` i18n key are the TK-only contract; an upstream merge that rewrites this capacity cell could silently drop the today-usage badge — it would compile fine, just lose the feature (and the deliberate 0-value grey-out that surfaces anomalies like kiro's current 0-billing). Sentinel guards that the badge survives upstream convergence."
     }
   ]
 }


### PR DESCRIPTION
## 背景

线上排查发现 **kiro 平台 100% 请求 0-token/0-cost**(详见伴随的 kiro 计费修复 PR)。本 PR 让账号管理界面能**一眼看到每个账号今日用量**,既方便日常管理,也让此类异常(kiro 显示「今日 0 · $0.00」灰显)直接暴露在 UI 上。

## 改动(纯前端,后端零改动)

在**账号管理页**(AccountsView)与 **Edge 账号页**(EdgeAccountsView)的【容量】列内嵌今日用量 badge(`tokens · $cost`),对**所有账号类型**生效。

- `AccountCapacityCell.vue`:新增 `todayStats` prop + 今日 badge,复用 `formatTokensK`/`formatCurrency`;**0 值灰显**(暴露异常)
- `AccountsView.vue`:把 `todayStatsByAccountId` 注入容量列;放宽 today-stats 加载 guard(容量列恒需 → 三列全隐藏才跳过加载)
- `EdgeAccountsView.vue`:容量列注入 `toWindowStats`(today_stats 数据已全链路贯通 edge→prod→前端)
- i18n `zh`/`en` 新增 `capacity.today.tooltip`
- `frontend-tk.json`:为新 badge 契约加 sentinel 锚(防上游 merge 静默冲掉)
- 刷新 embedded dist source manifest

复用已有后端能力:`getBatchTodayStats` / `GetAccountWindowStatsBatch`(GROUP BY account_id 的今日 tokens/cost 聚合),**无需后端改动**。

## 验证

- `pnpm typecheck` ✅
- `pnpm lint:check` ✅(唯一 warning 为 pre-existing,与本改动无关)
- `scripts/preflight.sh` ✅ PASS

🤖 Generated with [Claude Code](https://claude.com/claude-code)