### PR TITLE
feat(edge-lightsail): register us6/us7 (us-east-1 va1/va2) adopt entries

### DIFF
--- a/.github/workflows/deploy-edge-lightsail-stage0.yml
+++ b/.github/workflows/deploy-edge-lightsail-stage0.yml
@@ -18,6 +18,8 @@ on:
           - us3
           - us4
           - us5
+          - us6
+          - us7
       operation:
         description: "provision creates Lightsail instance; upgrade/rollback use SSM; smoke verifies."
         required: true

--- a/deploy/aws/cloudformation/cicd-oidc.yaml
+++ b/deploy/aws/cloudformation/cicd-oidc.yaml
@@ -16,7 +16,7 @@ Parameters:
     Description: GitHub <owner>/<repo> allowed to assume the role.
   AllowedSubjects:
     Type: CommaDelimitedList
-    Default: "repo:youxuanxue/sub2api:ref:refs/heads/main,repo:youxuanxue/sub2api:environment:prod,repo:youxuanxue/sub2api:environment:edge-uk1,repo:youxuanxue/sub2api:environment:edge-fra1,repo:youxuanxue/sub2api:environment:edge-us1,repo:youxuanxue/sub2api:environment:edge-us2,repo:youxuanxue/sub2api:environment:edge-us3,repo:youxuanxue/sub2api:environment:edge-us4,repo:youxuanxue/sub2api:environment:edge-us5"
+    Default: "repo:youxuanxue/sub2api:ref:refs/heads/main,repo:youxuanxue/sub2api:environment:prod,repo:youxuanxue/sub2api:environment:edge-uk1,repo:youxuanxue/sub2api:environment:edge-fra1,repo:youxuanxue/sub2api:environment:edge-us1,repo:youxuanxue/sub2api:environment:edge-us2,repo:youxuanxue/sub2api:environment:edge-us3,repo:youxuanxue/sub2api:environment:edge-us4,repo:youxuanxue/sub2api:environment:edge-us5,repo:youxuanxue/sub2api:environment:edge-us6,repo:youxuanxue/sub2api:environment:edge-us7"
     Description: >-
       Full OIDC sub claims (StringLike patterns) allowed to assume the role.
       Default allows main (for ops-daily-diagnostics.yml),

--- a/deploy/aws/lightsail/edge-targets-lightsail.json
+++ b/deploy/aws/lightsail/edge-targets-lightsail.json
@@ -141,6 +141,40 @@
       "monthly_budget_usd": 12,
       "ssm_prefix": "/tokenkey/lightsail/us5",
       "purpose": "us-west-2-oregon-egress-2 (pre-provisioned StaticIp-or-2 / tokenkey-edge-us-or2-ls)"
+    },
+    "us6": {
+      "deployable": true,
+      "profile": "edge-lightsail-minimal",
+      "swap_gib": 2,
+      "lightsail_region": "us-east-1",
+      "ec2_equivalent_region": "us-east-1",
+      "availability_zone": "us-east-1a",
+      "domain": "api-us6.tokenkey.dev",
+      "porkbun_a_ipv4": "3.212.130.21",
+      "instance_name": "edge-ls-us-va-1",
+      "static_ip_name": "StaticIp-va-1",
+      "bundle_id": "micro_3_0",
+      "blueprint_id": "amazon_linux_2023",
+      "monthly_budget_usd": 12,
+      "ssm_prefix": "/tokenkey/lightsail/us6",
+      "purpose": "us-east-1-virginia-egress (adopted console-created edge-ls-us-va-1 / StaticIp-va-1; egress pollution-probed clean 2026-06-04)"
+    },
+    "us7": {
+      "deployable": true,
+      "profile": "edge-lightsail-minimal",
+      "swap_gib": 2,
+      "lightsail_region": "us-east-1",
+      "ec2_equivalent_region": "us-east-1",
+      "availability_zone": "us-east-1a",
+      "domain": "api-us7.tokenkey.dev",
+      "porkbun_a_ipv4": "44.216.223.210",
+      "instance_name": "edge-ls-us-va-2",
+      "static_ip_name": "StaticIp-va-2",
+      "bundle_id": "micro_3_0",
+      "blueprint_id": "amazon_linux_2023",
+      "monthly_budget_usd": 12,
+      "ssm_prefix": "/tokenkey/lightsail/us7",
+      "purpose": "us-east-1-virginia-egress (adopted console-created edge-ls-us-va-2 / StaticIp-va-2; egress pollution-probed clean 2026-06-04)"
     }
   }
 }


### PR DESCRIPTION
## What

Adopt two console-created **bare** Lightsail instances in **us-east-1 Zone A** as TokenKey Stage0 edges `us6` / `us7` (adopt path — `instance_name`/`static_ip_name` set to the real AWS resource names, not the `tokenkey-edge-<id>-ls` default):

| edge | instance_name | static_ip_name | egress IP | domain |
|---|---|---|---|---|
| us6 | `edge-ls-us-va-1` | `StaticIp-va-1` | 3.212.130.21 | api-us6.tokenkey.dev |
| us7 | `edge-ls-us-va-2` | `StaticIp-va-2` | 44.216.223.210 | api-us7.tokenkey.dev |

Both `micro_3_0` / `amazon_linux_2023`, matching `edge-lightsail-minimal`. Adds `us6`/`us7` to the `deploy-edge-lightsail-stage0` workflow `edge_id` choice list.

## Why us-east-1 (note for reviewers)

The team previously fled us-east-1 after `100.48.129.133` pollution (us2 migrated to us-east-2). Before adopting, both egress IPs were **pollution-probed** from the instances themselves on 2026-06-04: anthropic `405`, openai `401`, google `403 unregistered` — all normal app-level auth/method errors, **no** Cloudflare challenge / "unusual activity" / connection-reset signatures. Neither IP is in `edge-polluted-ips.json`.

## Follow-up (not in this PR — infra)

These land outside the repo after merge / on the branch ref:
1. OIDC `AllowedSubjects` += `environment:edge-us6`, `environment:edge-us7` (cicd-oidc live-stack override).
2. GitHub Environments `edge-us6`/`edge-us7` with `EDGE_ACME_EMAIL` + `EDGE_MAIN_GATEWAY_ALLOWED_CIDR`.
3. `provision recreate=true` (DESTROYS the bare instances, **keeps** Static IP) → installs TokenKey stack + SSM Hybrid, tag `1.7.68`.
4. Porkbun A records `api-us6`/`api-us7`, then renew cert + smoke.

## Test
- `python3 deploy/aws/lightsail/resolve-edge-lightsail-target.py --edge-id us6|us7` → correct anchors.
- `resolve-edge-target.py --list-deployable` includes us6/us7.
- `scripts/preflight.sh` PASS (incl. edge platform exclusivity, lightsail OIDC perm coverage).

🤖 Generated with [Claude Code](https://claude.com/claude-code)