### PR TITLE
fix(kiro): ModelAvailability enum 补 kiro + 模型不支持时停止吞成空 200

### DIFF
--- a/backend/ent/migrate/schema.go
+++ b/backend/ent/migrate/schema.go
@@ -813,7 +813,7 @@ var (
 		{Name: "id", Type: field.TypeInt64, Increment: true},
 		{Name: "created_at", Type: field.TypeTime, SchemaType: map[string]string{"postgres": "timestamptz"}},
 		{Name: "updated_at", Type: field.TypeTime, SchemaType: map[string]string{"postgres": "timestamptz"}},
-		{Name: "platform", Type: field.TypeEnum, Enums: []string{"openai", "anthropic", "gemini", "antigravity", "newapi"}},
+		{Name: "platform", Type: field.TypeEnum, Enums: []string{"openai", "anthropic", "gemini", "antigravity", "newapi", "kiro"}},
 		{Name: "model_id", Type: field.TypeString, Size: 200},
 		{Name: "status", Type: field.TypeEnum, Enums: []string{"ok", "stale", "unreachable", "untested"}, Default: "untested"},
 		{Name: "last_seen_ok_at", Type: field.TypeTime, Nullable: true},

--- a/backend/ent/modelavailability/modelavailability.go
+++ b/backend/ent/modelavailability/modelavailability.go
@@ -104,6 +104,7 @@ const (
 	PlatformGemini      Platform = "gemini"
 	PlatformAntigravity Platform = "antigravity"
 	PlatformNewapi      Platform = "newapi"
+	PlatformKiro        Platform = "kiro"
 )
 
 func (pl Platform) String() string {
@@ -113,7 +114,7 @@ func (pl Platform) String() string {
 // PlatformValidator is a validator for the "platform" field enum values. It is called by the builders before save.
 func PlatformValidator(pl Platform) error {
 	switch pl {
-	case PlatformOpenai, PlatformAnthropic, PlatformGemini, PlatformAntigravity, PlatformNewapi:
+	case PlatformOpenai, PlatformAnthropic, PlatformGemini, PlatformAntigravity, PlatformNewapi, PlatformKiro:
 		return nil
 	default:
 		return fmt.Errorf("modelavailability: invalid enum value for platform field: %q", pl)

--- a/backend/ent/schema/model_availability.go
+++ b/backend/ent/schema/model_availability.go
@@ -58,7 +58,7 @@ func (ModelAvailability) Mixin() []ent.Mixin {
 func (ModelAvailability) Fields() []ent.Field {
 	return []ent.Field{
 		field.Enum("platform").
-			Values("openai", "anthropic", "gemini", "antigravity", "newapi"),
+			Values("openai", "anthropic", "gemini", "antigravity", "newapi", "kiro"),
 		field.String("model_id").
 			NotEmpty().
 			MaxLen(200),

--- a/backend/internal/handler/gateway_handler.go
+++ b/backend/internal/handler/gateway_handler.go
@@ -787,6 +787,15 @@ func (h *GatewayHandler) Messages(c *gin.Context) {
 					return
 				}
 
+				// Kiro upstream rejected the model (HTTP 400 INVALID_MODEL_ID):
+				// return 400 immediately with a clear message, no failover (every
+				// Kiro account rejects the same unknown model identically).
+				var kiroInvalidModelErr *service.KiroInvalidModelError
+				if errors.As(err, &kiroInvalidModelErr) {
+					h.errorResponse(c, http.StatusBadRequest, "invalid_request_error", kiroInvalidModelErr.ClientMessage())
+					return
+				}
+
 				// TK canonical-OAuth ingress UA reject: 403 immediately, no failover.
 				// See gateway_service_tk_canonical_oauth_guard.go.
 				var canonicalUARejectErr *service.CanonicalIngressUARejectedError

--- a/backend/internal/service/kiro_gateway_service.go
+++ b/backend/internal/service/kiro_gateway_service.go
@@ -158,7 +158,7 @@ func (s *KiroGatewayService) forwardNonStreaming(
 	}
 
 	if err := kiroproto.CallKiroAPIWithDoer(doer, kiroAcct, payload, callback); err != nil {
-		return nil, fmt.Errorf("kiro upstream call failed: %w", err)
+		return nil, classifyKiroForwardError(err, model)
 	}
 	if callbackErr != nil {
 		return nil, fmt.Errorf("kiro stream error: %w", callbackErr)
@@ -234,7 +234,11 @@ func (s *KiroGatewayService) forwardStreaming(
 		}
 	}
 
-	enc.writeMessageStart()
+	// message_start is emitted lazily on first content (see kiroSSEEncoder
+	// ensureBlock / writeToolUse). Emitting it eagerly here would set
+	// enc.started=true before the upstream call, defeating the post-call
+	// `!enc.started` guard and turning an upstream 400 (e.g. INVALID_MODEL_ID)
+	// into a clean empty 200 stream that the handler never sees as an error.
 
 	callback := &kiroproto.KiroStreamCallback{
 		OnText: func(text string, isThinking bool) {
@@ -273,11 +277,17 @@ func (s *KiroGatewayService) forwardStreaming(
 
 	// If the upstream failed before producing any content, surface the error so
 	// the handler can decide on failover instead of emitting a half-finished
-	// SSE stream. (Once content has begun we close out the stream cleanly.)
+	// SSE stream. (Once content has begun — enc.started — we close out the
+	// stream cleanly because the client has already received a 200 + bytes.)
+	// classifyKiroForwardError maps a recognized HTTP 400 INVALID_MODEL_ID into
+	// a typed *KiroInvalidModelError so the handler can return a clean 400.
 	if callErr != nil && !enc.started {
-		return nil, fmt.Errorf("kiro upstream call failed: %w", callErr)
+		return nil, classifyKiroForwardError(callErr, model)
 	}
 
+	// Upstream succeeded but produced no content (enc.started still false):
+	// emit message_start lazily here so the closing events form a valid stream.
+	enc.writeMessageStart()
 	enc.closeOpenBlock()
 	enc.writeMessageDelta(outputToks)
 	enc.writeMessageStop()

--- a/backend/internal/service/kiro_gateway_service_test.go
+++ b/backend/internal/service/kiro_gateway_service_test.go
@@ -244,6 +244,123 @@ func TestKiroGatewayService_Forward_Streaming(t *testing.T) {
 	require.Contains(t, out, "event: message_stop")
 }
 
+// kiroStatusUpstream returns a canned non-200 response with a fixed body,
+// modeling the Kiro upstream rejecting a request (e.g. 400 INVALID_MODEL_ID).
+// The vendored CallKiroAPIWithDoer reads the body into its error string, so all
+// three endpoints in the fallback list see the same rejection.
+type kiroStatusUpstream struct {
+	status int
+	body   string
+}
+
+func (u *kiroStatusUpstream) Do(*http.Request, string, int64, int) (*http.Response, error) {
+	return nil, fmt.Errorf("unexpected Do call")
+}
+
+func (u *kiroStatusUpstream) DoWithTLS(_ *http.Request, _ string, _ int64, _ int, _ *tlsfingerprint.Profile) (*http.Response, error) {
+	return &http.Response{
+		StatusCode: u.status,
+		Header:     make(http.Header),
+		Body:       io.NopCloser(bytes.NewReader([]byte(u.body))),
+	}, nil
+}
+
+// Bug2: upstream returns 400 INVALID_MODEL_ID *before* any content is produced.
+// The fix makes message_start lazy, so enc.started stays false and Forward must
+// return a typed *KiroInvalidModelError instead of closing out a clean empty
+// 200 SSE stream (the old "200 lie").
+func TestKiroGatewayService_Forward_Streaming_InvalidModel_NoEmpty200(t *testing.T) {
+	gin.SetMode(gin.TestMode)
+	rec := httptest.NewRecorder()
+	c, _ := gin.CreateTestContext(rec)
+
+	upstream := &kiroStatusUpstream{
+		status: http.StatusBadRequest,
+		body:   `{"reason":"INVALID_MODEL_ID","message":"model not found"}`,
+	}
+	svc := NewKiroGatewayService(upstream, nil, newKiroSettingService("true", nil))
+
+	body, _ := json.Marshal(map[string]any{
+		"model":      "claude-haiku-4.5",
+		"messages":   []map[string]any{{"role": "user", "content": "hi"}},
+		"max_tokens": 16,
+		"stream":     true,
+	})
+	parsed := &ParsedRequest{Body: NewRequestBodyRef(body), Model: "claude-haiku-4.5", Stream: true}
+
+	result, err := svc.Forward(context.Background(), c, newKiroAccountForTest(), parsed, time.Now())
+	require.Error(t, err)
+	require.Nil(t, result)
+
+	// Error must be the typed invalid-model error carrying status 400 + model.
+	var invalidModelErr *KiroInvalidModelError
+	require.ErrorAs(t, err, &invalidModelErr)
+	require.Equal(t, 400, invalidModelErr.StatusCode)
+	require.Equal(t, "claude-haiku-4.5", invalidModelErr.Model)
+	require.Contains(t, invalidModelErr.ClientMessage(), "not supported by Kiro")
+
+	// No SSE was written: the old bug emitted message_start eagerly and returned
+	// a clean empty 200 stream. The fix must write nothing to the client.
+	require.Empty(t, rec.Body.String(), "no SSE bytes may be written before a pre-content 400")
+	require.NotContains(t, rec.Body.String(), "message_start")
+}
+
+func TestKiroGatewayService_Forward_NonStreaming_InvalidModel(t *testing.T) {
+	gin.SetMode(gin.TestMode)
+	rec := httptest.NewRecorder()
+	c, _ := gin.CreateTestContext(rec)
+
+	upstream := &kiroStatusUpstream{
+		status: http.StatusBadRequest,
+		body:   `{"reason":"INVALID_MODEL_ID"}`,
+	}
+	svc := NewKiroGatewayService(upstream, nil, newKiroSettingService("true", nil))
+
+	body, _ := json.Marshal(map[string]any{
+		"model":    "claude-haiku-4.5",
+		"messages": []map[string]any{{"role": "user", "content": "hi"}},
+		"stream":   false,
+	})
+	parsed := &ParsedRequest{Body: NewRequestBodyRef(body), Model: "claude-haiku-4.5", Stream: false}
+
+	result, err := svc.Forward(context.Background(), c, newKiroAccountForTest(), parsed, time.Now())
+	require.Error(t, err)
+	require.Nil(t, result)
+	var invalidModelErr *KiroInvalidModelError
+	require.ErrorAs(t, err, &invalidModelErr)
+	require.Equal(t, "claude-haiku-4.5", invalidModelErr.Model)
+}
+
+func TestClassifyKiroForwardError(t *testing.T) {
+	// 400 + INVALID_MODEL_ID → typed error.
+	err := classifyKiroForwardError(
+		fmt.Errorf("HTTP 400 from CodeWhisperer: {\"reason\":\"INVALID_MODEL_ID\"}"),
+		"claude-haiku-4.5",
+	)
+	var invalidModelErr *KiroInvalidModelError
+	require.ErrorAs(t, err, &invalidModelErr)
+	require.Equal(t, "claude-haiku-4.5", invalidModelErr.Model)
+
+	// 400 without the INVALID_MODEL_ID marker → generic wrapped error, NOT typed.
+	other := classifyKiroForwardError(
+		fmt.Errorf("HTTP 400 from CodeWhisperer: {\"reason\":\"THROTTLED\"}"),
+		"claude-haiku-4.5",
+	)
+	require.Error(t, other)
+	require.NotErrorAs(t, other, &invalidModelErr)
+	require.Contains(t, other.Error(), "kiro upstream call failed")
+
+	// 500 with the marker substring → still not classified as invalid-model.
+	notFourHundred := classifyKiroForwardError(
+		fmt.Errorf("HTTP 500 from CodeWhisperer: INVALID_MODEL_ID"),
+		"claude-haiku-4.5",
+	)
+	require.NotErrorAs(t, notFourHundred, &invalidModelErr)
+
+	// nil passes through.
+	require.NoError(t, classifyKiroForwardError(nil, "m"))
+}
+
 func TestKiroGatewayService_Forward_DisabledErrors(t *testing.T) {
 	gin.SetMode(gin.TestMode)
 	rec := httptest.NewRecorder()

--- a/backend/internal/service/kiro_gateway_service_tk_errors.go
+++ b/backend/internal/service/kiro_gateway_service_tk_errors.go
@@ -1,0 +1,74 @@
+package service
+
+import (
+	"fmt"
+	"strings"
+)
+
+// KiroInvalidModelError is a typed, status-carrying error raised when the Kiro
+// (sixth platform) upstream rejects a request with HTTP 400 INVALID_MODEL_ID —
+// i.e. the requested model is not one the Kiro/CodeWhisperer backend serves.
+//
+// It mirrors the BetaBlockedError / PromptTooLongError pattern so the gateway
+// handler can `errors.As` it and return a clean 400 invalid_request_error to the
+// client instead of the previous failure mode, where forwardStreaming had
+// already emitted message_start (started=true), the `!enc.started` guard was
+// defeated, and the request returned an empty but "successful" 200 SSE stream.
+//
+// A model-unsupported error is intentionally NOT a cross-account failover
+// trigger: every Kiro account would reject the same unknown model identically,
+// so failover would only burn accounts before returning the same 400.
+type KiroInvalidModelError struct {
+	StatusCode int
+	Model      string
+	Body       string
+}
+
+func (e *KiroInvalidModelError) Error() string {
+	return fmt.Sprintf("kiro invalid model %q: status=%d", e.Model, e.StatusCode)
+}
+
+// ClientMessage is the operator/end-user-facing text written into the relay
+// error body. Kept terse and model-scoped so the caller knows exactly which
+// model the Kiro platform refused.
+func (e *KiroInvalidModelError) ClientMessage() string {
+	return fmt.Sprintf("model %s is not supported by Kiro", e.Model)
+}
+
+// classifyKiroForwardError inspects an error returned by the vendored Kiro API
+// call path and, if it recognizes an HTTP 400 INVALID_MODEL_ID rejection,
+// wraps it as a typed *KiroInvalidModelError. Any other error is wrapped with
+// the historical "kiro upstream call failed" prefix so existing log/behavior is
+// preserved.
+//
+// The vendored client formats non-200 responses as
+//
+//	HTTP <code> from <endpoint>: <raw upstream body>
+//
+// (see internal/integration/kiro/client.go CallKiroAPIWithDoer). We match on
+// the literal "HTTP 400" prefix plus the upstream "INVALID_MODEL_ID" marker so
+// an unrelated 400 (or a 400 with a different reason) does not get mislabeled
+// as a model error.
+func classifyKiroForwardError(err error, model string) error {
+	if err == nil {
+		return nil
+	}
+	msg := err.Error()
+	if isKiroInvalidModelError(msg) {
+		return &KiroInvalidModelError{
+			StatusCode: 400,
+			Model:      model,
+			Body:       msg,
+		}
+	}
+	return fmt.Errorf("kiro upstream call failed: %w", err)
+}
+
+// isKiroInvalidModelError reports whether the formatted upstream error string
+// represents an HTTP 400 INVALID_MODEL_ID rejection.
+func isKiroInvalidModelError(msg string) bool {
+	if !strings.Contains(msg, "HTTP 400") {
+		return false
+	}
+	return strings.Contains(strings.ToUpper(msg), "INVALID_MODEL_ID")
+}

--- a/backend/internal/service/kiro_sse_encoder.go
+++ b/backend/internal/service/kiro_sse_encoder.go
@@ -72,11 +72,15 @@ func (e *kiroSSEEncoder) writeMessageStart() {
 }
 
 // ensureBlock opens a content block of the requested kind, closing any
-// previously open block of a different kind first.
+// previously open block of a different kind first. It lazily emits message_start
+// on first content so that an upstream failure occurring before any content
+// arrives leaves enc.started == false (the caller's `!enc.started` guard then
+// surfaces the error instead of closing out a clean empty 200 stream).
 func (e *kiroSSEEncoder) ensureBlock(kind kiroBlockKind) {
 	if e.openBlock == kind {
 		return
 	}
+	e.writeMessageStart()
 	e.closeOpenBlock()
 
 	var cb map[string]any
@@ -125,6 +129,7 @@ func (e *kiroSSEEncoder) writeThinkingDelta(text string) {
 // Kiro delivers tool uses whole (not incrementally), so the input is serialized
 // as a single partial_json delta.
 func (e *kiroSSEEncoder) writeToolUse(tu kiroproto.KiroToolUse) {
+	e.writeMessageStart()
 	e.closeOpenBlock()
 	e.stopReason = "tool_use"
 

--- a/backend/migrations/tk_016_allow_kiro_model_availability_platform.sql
+++ b/backend/migrations/tk_016_allow_kiro_model_availability_platform.sql
@@ -1,0 +1,22 @@
+-- TK migration 016: allow 'kiro' (sixth platform) in model_availability.platform CHECK constraint.
+--
+-- Why a new migration instead of editing tk_009:
+--   tk_009 has already been applied on prod/edge nodes. TokenKey's migration runner enforces a
+--   checksum guard — editing an already-applied migration changes its checksum and makes every
+--   node refuse to start (and the deploy trap then rolls back to the prior bad image, pinning the
+--   node). So the platform-set extension MUST land as a NEW, idempotent migration.
+--
+-- Symptom this fixes: every kiro gateway forward logged `pricing.availability.record_failed`
+--   with `ent: validator failed ... invalid enum value for platform field: "kiro"`. The enum gap
+--   was two-layered — the ent Go PlatformValidator (regenerated via `go generate ./ent`) AND this
+--   DB CHECK. This migration closes the DB layer; the ent layer closes via the schema edit.
+--
+-- Idempotent: DROP CONSTRAINT IF EXISTS + re-ADD with the full platform set, mirroring the
+--   135_allow_email_oauth_provider_types.sql范式. Safe to re-run.
+
+ALTER TABLE model_availability
+    DROP CONSTRAINT IF EXISTS model_availability_platform_check;
+
+ALTER TABLE model_availability
+    ADD CONSTRAINT model_availability_platform_check
+    CHECK (platform IN ('openai', 'anthropic', 'gemini', 'antigravity', 'newapi', 'kiro'));

--- a/scripts/sentinels/kiro.json
+++ b/scripts/sentinels/kiro.json
@@ -109,18 +109,21 @@
       "must_contain": [
         "type KiroGatewayService",
         "func (s *KiroGatewayService) Forward",
-        "IsKiroEnabled"
+        "IsKiroEnabled",
+        "callErr != nil && !enc.started",
+        "classifyKiroForwardError"
       ],
-      "rationale": "The sixth-platform forwarder: translates /v1/messages onto the Kiro EventStream upstream and enforces the second ToS/enable gate (IsKiroEnabled). Losing it makes every kiro request fail or, worse, bypass the enable gate."
+      "rationale": "The sixth-platform forwarder: translates /v1/messages onto the Kiro EventStream upstream and enforces the second ToS/enable gate (IsKiroEnabled). The `callErr != nil && !enc.started` guard + classifyKiroForwardError are load-bearing: message_start is emitted lazily (see kiro_sse_encoder ensureBlock/writeToolUse), so an upstream failure before any content arrives surfaces an error instead of the old empty-but-200 SSE stream (the 'pre-content 400 returns a clean 200 lie' bug). An upstream merge that reintroduces an eager enc.writeMessageStart() before the upstream call, or drops the classifier, regresses this."
     },
     {
       "path": "backend/internal/service/kiro_sse_encoder.go",
       "must_contain": [
         "kiroSSEEncoder",
         "message_start",
-        "content_block_delta"
+        "content_block_delta",
+        "func (e *kiroSSEEncoder) ensureBlock"
       ],
-      "rationale": "Translates Kiro callbacks into the canonical Anthropic SSE event sequence. Losing it breaks streaming /v1/messages response shape for kiro accounts (clients hang or mis-parse)."
+      "rationale": "Translates Kiro callbacks into the canonical Anthropic SSE event sequence. Losing it breaks streaming /v1/messages response shape for kiro accounts (clients hang or mis-parse). ensureBlock (and writeToolUse) lazily call writeMessageStart on first content; writeMessageStart is idempotent (`if e.started { return }`). This laziness is what keeps enc.started false on a pre-content upstream 400 so the gateway service can surface the error instead of a clean empty 200 stream."
     },
     {
       "path": "backend/internal/service/gateway_service.go",
@@ -165,9 +168,19 @@
     {
       "path": "backend/internal/handler/gateway_handler.go",
       "must_contain": [
-        "account.IsKiro()"
+        "account.IsKiro()",
+        "service.KiroInvalidModelError"
       ],
-      "rationale": "The RPM-increment gate (both the streaming and non-streaming paths) admits kiro accounts via `|| account.IsKiro()`. An upstream merge that rewrites these gates must preserve the kiro arm, or kiro accounts skip RPM accounting and bypass the per-account rate limit."
+      "rationale": "The RPM-increment gate (both the streaming and non-streaming paths) admits kiro accounts via `|| account.IsKiro()`. An upstream merge that rewrites these gates must preserve the kiro arm, or kiro accounts skip RPM accounting and bypass the per-account rate limit. The KiroInvalidModelError errors.As branch returns a clean 400 invalid_request_error (no cross-account failover) when the Kiro upstream rejects the model; losing it reverts to the silent empty-200 / failover-churn behavior."
+    },
+    {
+      "path": "backend/internal/service/kiro_gateway_service_tk_errors.go",
+      "must_contain": [
+        "type KiroInvalidModelError",
+        "func classifyKiroForwardError",
+        "INVALID_MODEL_ID"
+      ],
+      "rationale": "TK-only typed error + classifier for the Kiro upstream HTTP 400 INVALID_MODEL_ID rejection. classifyKiroForwardError is called from both forwardStreaming and forwardNonStreaming; the handler errors.As-es the typed *KiroInvalidModelError to emit a model-scoped 400. Losing this file makes kiro model-unsupported errors fall back to the generic forward-error path (opaque 500 / unwanted failover)."
     },
     {
       "path": "backend/internal/service/wire.go",


### PR DESCRIPTION
修复两个 kiro 平台专属 bug(线上 edge us1 日志实测),各自独立 commit、可独立 revert。

## Bug 1 — `pricing.availability.record_failed`(每笔 kiro 请求)
ent `ModelAvailability.platform` enum 缺 `kiro`,两层都拒绝(ent Go `PlatformValidator` + DB CHECK `tk_009`)。
- `ent/schema/model_availability.go` 追加 `"kiro"` → `go generate ./ent`(commit `ent/`)。
- 新增 `migrations/tk_016_*.sql`:幂等 `DROP CONSTRAINT IF EXISTS` + 6 平台集 `ADD CHECK`;**不改已应用的 tk_009**(checksum 守卫,改了会全网拒绝启动)。

## Bug 2 — `claude-haiku-4-5` 在 kiro 返 400 INVALID_MODEL_ID 却被吞成空 200
根因:`forwardStreaming` 在调上游**前**就 `writeMessageStart()` 置 `started=true`,上游 400 回来后守卫 `!enc.started` 失效 → 吐出干净的空 200。
- **A**:延迟 `writeMessageStart` 到首个内容(`kiro_sse_encoder.go` 惰性 emit,幂等);上游产出内容前 400 → `Forward` 正确返回 error。
- **B**:新 TK 文件 `kiro_gateway_service_tk_errors.go` 的 `KiroInvalidModelError` + `classifyKiroForwardError`(识别 `HTTP 400`+`INVALID_MODEL_ID`);`gateway_handler.go` 追加 1 个 thin `errors.As` 分支返回 `400 invalid_request_error "model X is not supported by Kiro"`。无 fallback(按决策=明确报错)。
- 测试:pre-content-400 流式/非流式断言类型化错误 + **零 SSE 字节**;classifier 单测表。成功流式测试仍通过。

## 验证
- `go build ./...` / `go test -tags=unit ./...` / `go test ./...` / `golangci-lint` 全过
- `scripts/preflight.sh` 每个 commit 前后 PASS
- sentinel `kiro.json` 扩锚(31→32)锁住 lazy-start 守卫/classifier/error 文件/handler 分支
- markers:Bug1 `no-web-impact`+`no-upstream-touch`(model_availability.go 确认 TK-only);Bug2 `no-web-impact`+`upstream-touch-guarded`

🤖 Generated with [Claude Code](https://claude.com/claude-code)