### PR TITLE
fix(kiro): 本地 token 估算修复第六平台 100% 0-计费

### DIFF
--- a/backend/go.mod
+++ b/backend/go.mod
@@ -42,6 +42,7 @@ require (
 	github.com/testcontainers/testcontainers-go/modules/redis v0.40.0
 	github.com/tidwall/gjson v1.18.0
 	github.com/tidwall/sjson v1.2.5
+	github.com/tiktoken-go/tokenizer v0.6.2
 	github.com/waffo-com/waffo-go v1.3.1
 	github.com/wechatpay-apiv3/wechatpay-go v0.2.21
 	github.com/zeromicro/go-zero v1.9.4
@@ -135,7 +136,6 @@ require (
 	github.com/google/go-cmp v0.7.0 // indirect
 	github.com/google/go-querystring v1.1.0 // indirect
 	github.com/google/go-tpm v0.9.8 // indirect
-	github.com/google/subcommands v1.2.0 // indirect
 	github.com/grafana/pyroscope-go v1.2.7 // indirect
 	github.com/grafana/pyroscope-go/godeltaprof v0.1.9 // indirect
 	github.com/grpc-ecosystem/grpc-gateway/v2 v2.27.3 // indirect
@@ -211,7 +211,6 @@ require (
 	github.com/testcontainers/testcontainers-go v0.40.0 // indirect
 	github.com/tidwall/match v1.1.1 // indirect
 	github.com/tidwall/pretty v1.2.0 // indirect
-	github.com/tiktoken-go/tokenizer v0.6.2 // indirect
 	github.com/tinylib/msgp v1.6.3 // indirect
 	github.com/tklauser/go-sysconf v0.3.12 // indirect
 	github.com/tklauser/numcpus v0.6.1 // indirect

--- a/backend/go.sum
+++ b/backend/go.sum
@@ -228,8 +228,6 @@ github.com/google/go-tpm-tools v0.3.13-0.20230620182252-4639ecce2aba/go.mod h1:E
 github.com/google/gofuzz v1.0.0/go.mod h1:dBl0BpW6vV/+mYPU4Po3pmUjxk6FQPldtuIdl/M65Eg=
 github.com/google/pprof v0.0.0-20250317173921-a4b03ec1a45e h1:ijClszYn+mADRFY17kjQEVQ1XRhq2/JR1M3sGqeJoxs=
 github.com/google/pprof v0.0.0-20250317173921-a4b03ec1a45e/go.mod h1:boTsfXsheKC2y+lKOCMpSfarhxDeIzfZG1jqGcPl3cA=
-github.com/google/subcommands v1.2.0 h1:vWQspBTo2nEqTUFita5/KeEWlUL8kQObDFbub/EN9oE=
-github.com/google/subcommands v1.2.0/go.mod h1:ZjhPrFU+Olkh9WazFPsl27BQ4UPiG37m3yTrtFlrHVk=
 github.com/google/uuid v1.1.2/go.mod h1:TIyPZe4MgqvfeYDBFedMoGGpEw/LqOeaOT+nhxU+yHo=
 github.com/google/uuid v1.6.0 h1:NIvaJDMOsjHA8n1jAhLSgzrAzy1Hgr+hNrb57e+94F0=
 github.com/google/uuid v1.6.0/go.mod h1:TIyPZe4MgqvfeYDBFedMoGGpEw/LqOeaOT+nhxU+yHo=
@@ -311,8 +309,6 @@ github.com/mattn/go-isatty v0.0.12/go.mod h1:cbi8OIDigv2wuxKPP5vlRcQ1OAZbq2CE4Ky
 github.com/mattn/go-isatty v0.0.16/go.mod h1:kYGgaQfpe5nmfYZH+SKPsOc2e4SrIfOl2e/yFXSvRLM=
 github.com/mattn/go-isatty v0.0.20 h1:xfD0iDuEKnDkl03q4limB+vH+GxLEtL/jb4xVJSWWEY=
 github.com/mattn/go-isatty v0.0.20/go.mod h1:W+V8PltTTMOvKvAeJH7IuucS94S2C6jfK/D7dTCTo3Y=
-github.com/mattn/go-runewidth v0.0.15 h1:UNAjwbU9l54TA3KzvqLGxwWjHmMgBUVhBiTjelZgg3U=
-github.com/mattn/go-runewidth v0.0.15/go.mod h1:Jdepj2loyihRzMpdS35Xk/zdY8IAYHsh153qUoGf23w=
 github.com/mattn/go-sqlite3 v2.0.3+incompatible h1:gXHsfypPkaMZrKbD5209QV9jbUTJKjyR5WD3HYQSd+U=
 github.com/mattn/go-sqlite3 v2.0.3+incompatible/go.mod h1:FPy6KqzDD04eiIsT53CuJW3U88zkxoIYsOqkbpncsNc=
 github.com/mdelapenya/tlscert v0.2.0 h1:7H81W6Z/4weDvZBNOfQte5GpIMo0lGYEeWbkGp5LJHI=
@@ -357,8 +353,6 @@ github.com/ncruces/go-strftime v1.0.0 h1:HMFp8mLCTPp341M/ZnA4qaf7ZlsbTc+miZjCLOF
 github.com/ncruces/go-strftime v1.0.0/go.mod h1:Fwc5htZGVVkseilnfgOVb9mKy6w1naJmn9CehxcKcls=
 github.com/nxadm/tail v1.4.8 h1:nPr65rt6Y5JFSKQO7qToXr7pePgD6Gwiw05lkbyAQTE=
 github.com/nxadm/tail v1.4.8/go.mod h1:+ncqLTQzXmGhMZNUePPaPqPvBxHAIsmXswZKocGu+AU=
-github.com/olekukonko/tablewriter v0.0.5 h1:P2Ga83D34wi1o9J6Wh1mRuqd4mF/x/lgBS7N7AbDhec=
-github.com/olekukonko/tablewriter v0.0.5/go.mod h1:hPp6KlRPjbx+hW8ykQs1w3UBbZlj6HuIJcUGPhkA7kY=
 github.com/onsi/ginkgo v1.16.5 h1:8xi0RTUf59SOSfEtZMvwTvXYMzG4gV23XVHOZiXNtnE=
 github.com/onsi/ginkgo v1.16.5/go.mod h1:+E8gABHa3K6zRBolWtd+ROzc/U5bkGt0FwiG042wbpU=
 github.com/onsi/gomega v1.18.1 h1:M1GfJqGRrBrrGGsbxzV5dqM2U2ApXefZCQpkukxYRLE=
@@ -404,8 +398,6 @@ github.com/refraction-networking/utls v1.8.2 h1:j4Q1gJj0xngdeH+Ox/qND11aEfhpgoEv
 github.com/refraction-networking/utls v1.8.2/go.mod h1:jkSOEkLqn+S/jtpEHPOsVv/4V4EVnelwbMQl4vCWXAM=
 github.com/remyoudompheng/bigfft v0.0.0-20230129092748-24d4a6f8daec h1:W09IVJc94icq4NjY3clb7Lk8O1qJ8BdBEF8z0ibU0rE=
 github.com/remyoudompheng/bigfft v0.0.0-20230129092748-24d4a6f8daec/go.mod h1:qqbHyh8v60DhA7CoWK5oRCqLrMHRGoxYCSS9EjAz6Eo=
-github.com/rivo/uniseg v0.2.0 h1:S1pD9weZBuJdFmowNwbpi7BJ8TNftyUImj/0WQi72jY=
-github.com/rivo/uniseg v0.2.0/go.mod h1:J6wj4VEh+S6ZtnVlnTBMWIodfgj8LQOQFoIToxlJtxc=
 github.com/robfig/cron/v3 v3.0.1 h1:WdRxkvbJztn8LMz/QEvLN5sBU+xKpSqwwUO1Pjr4qDs=
 github.com/robfig/cron/v3 v3.0.1/go.mod h1:eQICP3HwyT7UooqI/z+Ov+PtYAWygg1TEWWzGIFLtro=
 github.com/rogpeppe/go-internal v1.13.1 h1:KvO1DLK/DRN07sQ1LQKScxyZJuNnedQ5/wKSR38lUII=
@@ -446,8 +438,6 @@ github.com/spf13/afero v1.11.0 h1:WJQKhtpdm3v2IzqG8VMqrr6Rf3UYpEF239Jy9wNepM8=
 github.com/spf13/afero v1.11.0/go.mod h1:GH9Y3pIexgf1MTIWtNGyogA5MwRIDXGUr+hbWNoBjkY=
 github.com/spf13/cast v1.6.0 h1:GEiTHELF+vaR5dhz3VqZfFSzZjYbgeKDpBxQVS4GYJ0=
 github.com/spf13/cast v1.6.0/go.mod h1:ancEpBxwJDODSW/UG4rDrAqiKolqNNh2DX3mk86cAdo=
-github.com/spf13/cobra v1.7.0 h1:hyqWnYt1ZQShIddO5kBpj3vu05/++x6tJ6dg8EC572I=
-github.com/spf13/cobra v1.7.0/go.mod h1:uLxZILRyS/50WlhOIKD7W6V5bgeIt+4sICxh6uRMrb0=
 github.com/spf13/pflag v1.0.5 h1:iy+VFUOCP1a+8yFto/drg2CJ5u0yRoB7fZw3DKv/JXA=
 github.com/spf13/pflag v1.0.5/go.mod h1:McXfInJRrz4CZXVZOBLb0bTZqETkiAhM9Iw0y3An2Bg=
 github.com/spf13/viper v1.18.2 h1:LUXCnvUvSM6FXAsj6nnfc8Q2tp1dIgUfY9Kc8GsSOiQ=

--- a/backend/internal/integration/kiro/estimate.go
+++ b/backend/internal/integration/kiro/estimate.go
@@ -1,0 +1,222 @@
+package kiro
+
+import (
+	"encoding/json"
+	"strings"
+	"sync"
+
+	"github.com/tiktoken-go/tokenizer"
+)
+
+// Token estimation for the Kiro (sixth platform) CodeWhisperer upstream.
+//
+// Kiro's EventStream upstream returns *credits only* — it never reports
+// input/output token counts. Without estimation every Kiro request bills as
+// input=output=cost=0 (100% free). This package estimates token usage locally
+// with the cl100k_base tokenizer so the downstream billing pipeline
+// (RecordUsage → CalculateCostUnified) can charge against the mapped claude-*
+// price table exactly as the native Anthropic platform does.
+//
+// Calibration choices (approved):
+//   - cl100k_base encoding (close enough to Anthropic's tokenizer for billing).
+//   - No conservative multiplier: cl100k naturally over-counts CJK text, which
+//     is the operator-safe direction.
+//   - Kiro has no cache semantics: cache token fields stay 0, never fabricated.
+//   - Estimates are tagged with billing_tier="kiro-estimated" by the caller.
+
+// KiroEstimatedBillingTier is the billing_tier label stamped on Kiro usage logs
+// so operators can distinguish estimated billing from upstream-reported billing.
+const KiroEstimatedBillingTier = "kiro-estimated"
+
+var (
+	estCodec     tokenizer.Codec
+	estCodecOnce sync.Once
+)
+
+// codec lazily initializes and caches the cl100k_base tokenizer. A nil return
+// means initialization failed; callers fall back to the rune heuristic.
+func codec() tokenizer.Codec {
+	estCodecOnce.Do(func() {
+		if c, err := tokenizer.Get(tokenizer.Cl100kBase); err == nil {
+			estCodec = c
+		}
+	})
+	return estCodec
+}
+
+// countTokens returns an estimated token count for s. It uses cl100k_base when
+// available and falls back to a len([]rune)/4 heuristic on any encode failure.
+// It never panics and never returns 0 for non-empty input (the fallback floors
+// at 1 token for any non-empty string).
+func countTokens(s string) int {
+	if s == "" {
+		return 0
+	}
+	if c := codec(); c != nil {
+		if n, err := c.Count(s); err == nil {
+			return n
+		}
+	}
+	return fallbackCount(s)
+}
+
+// fallbackCount approximates token count as ~4 chars/token, flooring at 1 for
+// any non-empty string so we never silently bill an interaction as free.
+func fallbackCount(s string) int {
+	if s == "" {
+		return 0
+	}
+	n := len([]rune(s)) / 4
+	if n < 1 {
+		n = 1
+	}
+	return n
+}
+
+// EstimateInputTokens estimates the prompt-side token count for a Kiro request.
+//
+// Counted (mirrors what is actually sent upstream):
+//   - system prompt (string or []SystemBlock, flattened),
+//   - every message's text content,
+//   - tool_result text (the tool output echoed back into the prompt),
+//   - tool_use Input JSON (assistant tool calls in history),
+//   - tools definitions: name + description + serialized input_schema.
+//
+// Skipped: image blocks (binary, not text-tokenized).
+func EstimateInputTokens(req *ClaudeRequest) int {
+	if req == nil {
+		return 0
+	}
+
+	parts := make([]string, 0, 8)
+
+	// System prompt (raw flatten — same shape extractSystemPrompt produces).
+	if sys := extractSystemPrompt(req.System); sys != "" {
+		parts = append(parts, sys)
+	}
+
+	// Messages: text + tool_result text + tool_use Input JSON.
+	for i := range req.Messages {
+		parts = appendMessageContentForEstimate(parts, req.Messages[i].Content)
+	}
+
+	total := countTokens(strings.Join(parts, "\n"))
+
+	// Tools definitions count as input (the model sees them in the prompt).
+	total += estimateToolsTokens(req.Tools)
+
+	return total
+}
+
+// appendMessageContentForEstimate flattens one message's content into parts for
+// estimation. It handles the string form and the []ContentBlock form, pulling
+// text, tool_result text, and tool_use Input JSON; image blocks are skipped.
+func appendMessageContentForEstimate(parts []string, content any) []string {
+	if s, ok := content.(string); ok {
+		if s != "" {
+			parts = append(parts, s)
+		}
+		return parts
+	}
+
+	blocks, ok := content.([]any)
+	if !ok {
+		return parts
+	}
+	for _, raw := range blocks {
+		block, ok := raw.(map[string]any)
+		if !ok {
+			continue
+		}
+		switch blockType, _ := block["type"].(string); blockType {
+		case "text", "input_text":
+			if t, ok := block["text"].(string); ok && t != "" {
+				parts = append(parts, t)
+			}
+		case "tool_result":
+			// tool_result content is echoed back into the prompt; count its text.
+			if txt, _ := extractToolResultContent(block["content"]); txt != "" {
+				parts = append(parts, txt)
+			}
+		case "tool_use":
+			// Assistant tool call sitting in history: count its serialized input.
+			if js := marshalJSONForEstimate(block["input"]); js != "" {
+				parts = append(parts, js)
+			}
+			if name, ok := block["name"].(string); ok && name != "" {
+				parts = append(parts, name)
+			}
+		case "image", "image_url", "input_image":
+			// Skipped: binary, not text-tokenized.
+		}
+	}
+	return parts
+}
+
+// estimateToolsTokens counts the tokens contributed by tool definitions:
+// name + description + the serialized input_schema for each tool.
+func estimateToolsTokens(tools []ClaudeTool) int {
+	if len(tools) == 0 {
+		return 0
+	}
+	parts := make([]string, 0, len(tools)*3)
+	for i := range tools {
+		t := tools[i]
+		if t.Name != "" {
+			parts = append(parts, t.Name)
+		}
+		if t.Description != "" {
+			parts = append(parts, t.Description)
+		}
+		if js := marshalJSONForEstimate(t.InputSchema); js != "" {
+			parts = append(parts, js)
+		}
+	}
+	return countTokens(strings.Join(parts, "\n"))
+}
+
+// EstimateOutputTokens estimates the completion-side token count for a Kiro
+// response: assistant text + thinking/reasoning text + serialized tool_use
+// blocks (id + name + input). All three are billed as output.
+func EstimateOutputTokens(text, thinking string, toolUses []KiroToolUse) int {
+	parts := make([]string, 0, 2+len(toolUses)*3)
+	if text != "" {
+		parts = append(parts, text)
+	}
+	if thinking != "" {
+		parts = append(parts, thinking)
+	}
+	for i := range toolUses {
+		tu := toolUses[i]
+		if tu.Name != "" {
+			parts = append(parts, tu.Name)
+		}
+		if tu.ToolUseID != "" {
+			parts = append(parts, tu.ToolUseID)
+		}
+		if js := marshalJSONForEstimate(tu.Input); js != "" {
+			parts = append(parts, js)
+		}
+	}
+	return countTokens(strings.Join(parts, "\n"))
+}
+
+// marshalJSONForEstimate serializes v to compact JSON for token estimation.
+// Nil / empty maps and marshal failures yield an empty string (no tokens).
+func marshalJSONForEstimate(v any) string {
+	if v == nil {
+		return ""
+	}
+	if m, ok := v.(map[string]any); ok && len(m) == 0 {
+		return ""
+	}
+	js, err := json.Marshal(v)
+	if err != nil {
+		return ""
+	}
+	s := string(js)
+	if s == "null" || s == "{}" || s == "[]" {
+		return ""
+	}
+	return s
+}

--- a/backend/internal/integration/kiro/estimate_test.go
+++ b/backend/internal/integration/kiro/estimate_test.go
@@ -1,0 +1,194 @@
+//go:build unit
+
+package kiro
+
+import "testing"
+
+// TestCountTokens_NonEmptyNeverZero asserts that the tokenizer path returns a
+// positive, reasonable count for ordinary text and never zero for non-empty
+// input.
+func TestCountTokens_NonEmptyNeverZero(t *testing.T) {
+	if got := countTokens(""); got != 0 {
+		t.Fatalf("countTokens(empty) = %d, want 0", got)
+	}
+
+	// "hello world" tokenizes to 2 tokens under cl100k_base; assert non-zero and
+	// in a sane band rather than an exact value (tokenizer impl may shift).
+	got := countTokens("hello world")
+	if got <= 0 {
+		t.Fatalf("countTokens(hello world) = %d, want > 0", got)
+	}
+	if got > 10 {
+		t.Fatalf("countTokens(hello world) = %d, unexpectedly large", got)
+	}
+}
+
+// TestFallbackCount_FloorsAtOne asserts the rune-heuristic fallback never
+// returns 0 for non-empty input (which would silently bill an interaction as
+// free), and approximates ~4 chars/token for longer strings.
+func TestFallbackCount_FloorsAtOne(t *testing.T) {
+	if got := fallbackCount(""); got != 0 {
+		t.Fatalf("fallbackCount(empty) = %d, want 0", got)
+	}
+	if got := fallbackCount("a"); got != 1 {
+		t.Fatalf("fallbackCount(short) = %d, want 1 (floor)", got)
+	}
+	// 40 ASCII chars → ~10 tokens.
+	long := ""
+	for i := 0; i < 40; i++ {
+		long += "x"
+	}
+	if got := fallbackCount(long); got != 10 {
+		t.Fatalf("fallbackCount(40 chars) = %d, want 10", got)
+	}
+}
+
+// TestEstimateInputTokens_CountsSystemMessagesToolsAndToolUse asserts the input
+// estimate is non-zero and grows with system prompt, message text, tool
+// definitions, tool_use input JSON, and tool_result text.
+func TestEstimateInputTokens_CountsSystemMessagesToolsAndToolUse(t *testing.T) {
+	if got := EstimateInputTokens(nil); got != 0 {
+		t.Fatalf("EstimateInputTokens(nil) = %d, want 0", got)
+	}
+
+	// Baseline: a single short user message.
+	base := &ClaudeRequest{
+		Model: "claude-sonnet-4-5",
+		Messages: []ClaudeMessage{
+			{Role: "user", Content: "What is the weather in Paris today?"},
+		},
+	}
+	baseTok := EstimateInputTokens(base)
+	if baseTok <= 0 {
+		t.Fatalf("baseline input tokens = %d, want > 0", baseTok)
+	}
+
+	// Adding a system prompt must increase the estimate.
+	withSystem := &ClaudeRequest{
+		Model:    "claude-sonnet-4-5",
+		System:   "You are a meticulous and concise travel assistant. Always answer briefly.",
+		Messages: base.Messages,
+	}
+	if got := EstimateInputTokens(withSystem); got <= baseTok {
+		t.Fatalf("with system = %d, want > baseline %d", got, baseTok)
+	}
+
+	// Adding tools (name + description + input_schema) must increase the estimate.
+	withTools := &ClaudeRequest{
+		Model:    "claude-sonnet-4-5",
+		Messages: base.Messages,
+		Tools: []ClaudeTool{
+			{
+				Name:        "get_weather",
+				Description: "Fetch the current weather for a given city and country.",
+				InputSchema: map[string]any{
+					"type": "object",
+					"properties": map[string]any{
+						"city":    map[string]any{"type": "string"},
+						"country": map[string]any{"type": "string"},
+					},
+					"required": []any{"city"},
+				},
+			},
+		},
+	}
+	if got := EstimateInputTokens(withTools); got <= baseTok {
+		t.Fatalf("with tools = %d, want > baseline %d", got, baseTok)
+	}
+
+	// Block-shaped content with tool_use input JSON and tool_result text.
+	withBlocks := &ClaudeRequest{
+		Model: "claude-sonnet-4-5",
+		Messages: []ClaudeMessage{
+			{Role: "user", Content: "Look up the weather please."},
+			{Role: "assistant", Content: []any{
+				map[string]any{
+					"type": "tool_use",
+					"id":   "toolu_1",
+					"name": "get_weather",
+					"input": map[string]any{
+						"city":    "Paris",
+						"country": "France",
+					},
+				},
+			}},
+			{Role: "user", Content: []any{
+				map[string]any{
+					"type":        "tool_result",
+					"tool_use_id": "toolu_1",
+					"content":     "It is 21 degrees and sunny in Paris.",
+				},
+			}},
+		},
+	}
+	if got := EstimateInputTokens(withBlocks); got <= 0 {
+		t.Fatalf("block-shaped input tokens = %d, want > 0", got)
+	}
+}
+
+// TestEstimateInputTokens_SkipsImages asserts image blocks do not contribute
+// tokens (they are binary and not text-tokenized).
+func TestEstimateInputTokens_SkipsImages(t *testing.T) {
+	textOnly := &ClaudeRequest{
+		Messages: []ClaudeMessage{
+			{Role: "user", Content: []any{
+				map[string]any{"type": "text", "text": "describe this"},
+			}},
+		},
+	}
+	withImage := &ClaudeRequest{
+		Messages: []ClaudeMessage{
+			{Role: "user", Content: []any{
+				map[string]any{"type": "text", "text": "describe this"},
+				map[string]any{
+					"type": "image",
+					"source": map[string]any{
+						"type":       "base64",
+						"media_type": "image/png",
+						"data":       "iVBORw0KGgoAAAANSUhEUgAAAAEAAAABCAQAAAC1HAwCAAAAC0lEQVR42mNk+M9QDwADhgGAWjR9awAAAABJRU5ErkJggg==",
+					},
+				},
+			}},
+		},
+	}
+	if EstimateInputTokens(withImage) != EstimateInputTokens(textOnly) {
+		t.Fatalf("image block changed input estimate; images must be skipped")
+	}
+}
+
+// TestEstimateOutputTokens_CountsTextThinkingAndToolUse asserts the output
+// estimate sums assistant text, thinking, and serialized tool_use blocks.
+func TestEstimateOutputTokens_CountsTextThinkingAndToolUse(t *testing.T) {
+	if got := EstimateOutputTokens("", "", nil); got != 0 {
+		t.Fatalf("EstimateOutputTokens(empty) = %d, want 0", got)
+	}
+
+	textOnly := EstimateOutputTokens("The weather in Paris is sunny.", "", nil)
+	if textOnly <= 0 {
+		t.Fatalf("text-only output tokens = %d, want > 0", textOnly)
+	}
+
+	withThinking := EstimateOutputTokens(
+		"The weather in Paris is sunny.",
+		"Let me reason about the user's request before answering.",
+		nil,
+	)
+	if withThinking <= textOnly {
+		t.Fatalf("with thinking = %d, want > text-only %d", withThinking, textOnly)
+	}
+
+	withTools := EstimateOutputTokens(
+		"",
+		"",
+		[]KiroToolUse{
+			{
+				ToolUseID: "toolu_99",
+				Name:      "get_weather",
+				Input:     map[string]any{"city": "Paris", "country": "France"},
+			},
+		},
+	)
+	if withTools <= 0 {
+		t.Fatalf("tool_use-only output tokens = %d, want > 0", withTools)
+	}
+}

--- a/backend/internal/service/gateway_service.go
+++ b/backend/internal/service/gateway_service.go
@@ -527,6 +527,12 @@ type ForwardResult struct {
 	ClientDisconnect bool // 客户端是否在流式传输过程中断开
 	ReasoningEffort  *string
 
+	// BillingTier is an optional billing-tier label persisted onto the usage log.
+	// TK: the Kiro (sixth platform) path sets "kiro-estimated" to mark that the
+	// token counts were estimated locally (Kiro upstream reports credits only,
+	// never tokens). Empty means no tier label (the common token-billing case).
+	BillingTier string
+
 	// 图片生成计费字段（图片生成模型使用）
 	ImageCount         int    // 生成的图片数量
 	ImageSize          string // 最终计费尺寸 "1K", "2K", "4K"
@@ -9592,6 +9598,7 @@ func (s *GatewayService) buildRecordUsageLog(
 		RequestedModel:        requestedModel,
 		UpstreamModel:         optionalNonEqualStringPtr(result.UpstreamModel, result.Model),
 		ReasoningEffort:       result.ReasoningEffort,
+		BillingTier:           optionalTrimmedStringPtr(result.BillingTier),
 		InboundEndpoint:       optionalTrimmedStringPtr(input.InboundEndpoint),
 		UpstreamEndpoint:      optionalTrimmedStringPtr(input.UpstreamEndpoint),
 		InputTokens:           result.Usage.InputTokens,

--- a/backend/internal/service/kiro_gateway_service.go
+++ b/backend/internal/service/kiro_gateway_service.go
@@ -5,6 +5,7 @@ import (
 	"encoding/json"
 	"errors"
 	"fmt"
+	"log/slog"
 	"net/http"
 	"sync"
 	"time"
@@ -112,9 +113,9 @@ func (s *KiroGatewayService) Forward(
 	}
 
 	if req.Stream {
-		return s.forwardStreaming(ctx, c, doer, kiroAcct, payload, requestID, model, startTime)
+		return s.forwardStreaming(ctx, c, doer, kiroAcct, payload, &req, requestID, model, startTime)
 	}
-	return s.forwardNonStreaming(ctx, c, doer, kiroAcct, payload, requestID, model, startTime)
+	return s.forwardNonStreaming(ctx, c, doer, kiroAcct, payload, &req, requestID, model, startTime)
 }
 
 // forwardNonStreaming accumulates text/thinking/tool-use then writes a single
@@ -125,6 +126,7 @@ func (s *KiroGatewayService) forwardNonStreaming(
 	doer kiroproto.HTTPDoer,
 	kiroAcct *kiroproto.Account,
 	payload *kiroproto.KiroPayload,
+	req *kiroproto.ClaudeRequest,
 	requestID, model string,
 	startTime time.Time,
 ) (*ForwardResult, error) {
@@ -132,8 +134,6 @@ func (s *KiroGatewayService) forwardNonStreaming(
 		textBuf     string
 		thinkingBuf string
 		toolUses    []kiroproto.KiroToolUse
-		inputTokens int
-		outputToks  int
 		callbackErr error
 	)
 
@@ -148,9 +148,10 @@ func (s *KiroGatewayService) forwardNonStreaming(
 		OnToolUse: func(tu kiroproto.KiroToolUse) {
 			toolUses = append(toolUses, tu)
 		},
-		OnComplete: func(in, out int) {
-			inputTokens = in
-			outputToks = out
+		// Kiro upstream reports no token usage; OnComplete(in,out) is always (0,0).
+		// We estimate token usage locally below instead of trusting these values.
+		OnCredits: func(credits float64) {
+			logKiroCredits(kiroAcct, model, credits)
 		},
 		OnError: func(err error) {
 			callbackErr = err
@@ -163,6 +164,10 @@ func (s *KiroGatewayService) forwardNonStreaming(
 	if callbackErr != nil {
 		return nil, fmt.Errorf("kiro stream error: %w", callbackErr)
 	}
+
+	// Estimate token usage (Kiro upstream returns credits only — see estimate.go).
+	inputTokens := kiroproto.EstimateInputTokens(req)
+	outputToks := kiroproto.EstimateOutputTokens(textBuf, thinkingBuf, toolUses)
 
 	resp := kiroproto.KiroToClaudeResponse(
 		textBuf, thinkingBuf, false, toolUses, inputTokens, outputToks, model,
@@ -181,6 +186,7 @@ func (s *KiroGatewayService) forwardNonStreaming(
 		UpstreamModel: kiroproto.MapModel(model),
 		Stream:        false,
 		Duration:      time.Since(startTime),
+		BillingTier:   kiroproto.KiroEstimatedBillingTier,
 	}, nil
 }
 
@@ -194,6 +200,7 @@ func (s *KiroGatewayService) forwardStreaming(
 	doer kiroproto.HTTPDoer,
 	kiroAcct *kiroproto.Account,
 	payload *kiroproto.KiroPayload,
+	req *kiroproto.ClaudeRequest,
 	requestID, model string,
 	startTime time.Time,
 ) (*ForwardResult, error) {
@@ -221,8 +228,9 @@ func (s *KiroGatewayService) forwardStreaming(
 
 	var (
 		mu          sync.Mutex
-		inputTokens int
-		outputToks  int
+		textBuf     string
+		thinkingBuf string
+		toolUses    []kiroproto.KiroToolUse
 		callbackErr error
 		firstTokMs  *int
 	)
@@ -242,8 +250,10 @@ func (s *KiroGatewayService) forwardStreaming(
 			defer mu.Unlock()
 			markFirstToken()
 			if isThinking {
+				thinkingBuf += text
 				enc.writeThinkingDelta(text)
 			} else {
+				textBuf += text
 				enc.writeTextDelta(text)
 			}
 		},
@@ -251,13 +261,13 @@ func (s *KiroGatewayService) forwardStreaming(
 			mu.Lock()
 			defer mu.Unlock()
 			markFirstToken()
+			toolUses = append(toolUses, tu)
 			enc.writeToolUse(tu)
 		},
-		OnComplete: func(in, out int) {
-			mu.Lock()
-			defer mu.Unlock()
-			inputTokens = in
-			outputToks = out
+		// Kiro upstream reports no token usage; OnComplete(in,out) is always (0,0).
+		// We estimate token usage locally below instead of trusting these values.
+		OnCredits: func(credits float64) {
+			logKiroCredits(kiroAcct, model, credits)
 		},
 		OnError: func(err error) {
 			mu.Lock()
@@ -277,6 +287,10 @@ func (s *KiroGatewayService) forwardStreaming(
 	if callErr != nil && !enc.started {
 		return nil, fmt.Errorf("kiro upstream call failed: %w", callErr)
 	}
+
+	// Estimate token usage (Kiro upstream returns credits only — see estimate.go).
+	inputTokens := kiroproto.EstimateInputTokens(req)
+	outputToks := kiroproto.EstimateOutputTokens(textBuf, thinkingBuf, toolUses)
 
 	enc.closeOpenBlock()
 	enc.writeMessageDelta(outputToks)
@@ -298,5 +312,21 @@ func (s *KiroGatewayService) forwardStreaming(
 		Stream:        true,
 		Duration:      time.Since(startTime),
 		FirstTokenMs:  firstTokMs,
+		BillingTier:   kiroproto.KiroEstimatedBillingTier,
 	}, nil
+}
+
+// logKiroCredits records the Kiro upstream credits cost at info level for
+// observability. Credits are NOT used for billing (we estimate tokens instead);
+// this is a passive side channel to reconcile estimated cost against upstream.
+func logKiroCredits(account *kiroproto.Account, model string, credits float64) {
+	var accountID string
+	if account != nil {
+		accountID = account.ID
+	}
+	slog.Info("kiro upstream credits",
+		"account_id", accountID,
+		"model", model,
+		"credits", credits,
+	)
 }

--- a/backend/internal/service/kiro_gateway_service_test.go
+++ b/backend/internal/service/kiro_gateway_service_test.go
@@ -195,8 +195,12 @@ func TestKiroGatewayService_Forward_NonStreaming(t *testing.T) {
 	require.NotNil(t, result)
 	require.True(t, upstream.gotRequest)
 	require.False(t, result.Stream)
-	require.Equal(t, 12, result.Usage.InputTokens)
-	require.Equal(t, 5, result.Usage.OutputTokens)
+	// Kiro upstream reports credits only (never tokens); usage is estimated
+	// locally from request/response content, so token counts must be positive
+	// and the billing tier marked as estimated.
+	require.Positive(t, result.Usage.InputTokens)
+	require.Positive(t, result.Usage.OutputTokens)
+	require.Equal(t, "kiro-estimated", result.BillingTier)
 	require.Equal(t, "claude-sonnet-4", result.Model)
 	require.NotEmpty(t, result.RequestID)
 
@@ -231,8 +235,10 @@ func TestKiroGatewayService_Forward_Streaming(t *testing.T) {
 	require.NoError(t, err)
 	require.NotNil(t, result)
 	require.True(t, result.Stream)
-	require.Equal(t, 8, result.Usage.InputTokens)
-	require.Equal(t, 3, result.Usage.OutputTokens)
+	// Estimated usage (Kiro upstream reports credits only).
+	require.Positive(t, result.Usage.InputTokens)
+	require.Positive(t, result.Usage.OutputTokens)
+	require.Equal(t, "kiro-estimated", result.BillingTier)
 
 	out := rec.Body.String()
 	require.Contains(t, out, "event: message_start")

--- a/scripts/sentinels/kiro.json
+++ b/scripts/sentinels/kiro.json
@@ -71,6 +71,15 @@
       "rationale": "Anthropic <-> Kiro request/response translation. Without it the /v1/messages -> CodeWhisperer bridge cannot build a payload or decode the reply."
     },
     {
+      "path": "backend/internal/integration/kiro/estimate.go",
+      "must_contain": [
+        "func EstimateInputTokens",
+        "func EstimateOutputTokens",
+        "KiroEstimatedBillingTier"
+      ],
+      "rationale": "Local cl100k_base token estimation for kiro billing. The Kiro EventStream upstream reports credits only (never tokens), so without this estimator every kiro request bills input=output=cost=0 (100% free). Losing EstimateInputTokens/EstimateOutputTokens silently regresses kiro back to free; losing KiroEstimatedBillingTier drops the billing_tier=\"kiro-estimated\" provenance label operators use to distinguish estimated from upstream-reported billing."
+    },
+    {
       "path": "backend/internal/integration/kiro/client.go",
       "must_contain": [
         "func CallKiroAPIWithDoer",
@@ -109,9 +118,12 @@
       "must_contain": [
         "type KiroGatewayService",
         "func (s *KiroGatewayService) Forward",
-        "IsKiroEnabled"
+        "IsKiroEnabled",
+        "kiroproto.EstimateInputTokens",
+        "kiroproto.EstimateOutputTokens",
+        "BillingTier:   kiroproto.KiroEstimatedBillingTier"
       ],
-      "rationale": "The sixth-platform forwarder: translates /v1/messages onto the Kiro EventStream upstream and enforces the second ToS/enable gate (IsKiroEnabled). Losing it makes every kiro request fail or, worse, bypass the enable gate."
+      "rationale": "The sixth-platform forwarder: translates /v1/messages onto the Kiro EventStream upstream and enforces the second ToS/enable gate (IsKiroEnabled). It also estimates token usage locally (EstimateInputTokens/EstimateOutputTokens) and stamps ForwardResult.BillingTier=\"kiro-estimated\", because the Kiro upstream reports credits only — without these calls both forward paths return Usage{0,0} and kiro bills as 100% free. Losing the forwarder makes every kiro request fail or bypass the enable gate; losing the estimate/BillingTier wiring silently regresses kiro to free billing."
     },
     {
       "path": "backend/internal/service/kiro_sse_encoder.go",
@@ -126,9 +138,10 @@
       "path": "backend/internal/service/gateway_service.go",
       "must_contain": [
         "account.IsKiro()",
-        "kiroGateway"
+        "kiroGateway",
+        "BillingTier:           optionalTrimmedStringPtr(result.BillingTier)"
       ],
-      "rationale": "The Forward() dispatch injection point (next to IsBedrock) + the GatewayService.kiroGateway field. An upstream merge that rewrites Forward() or NewGatewayService() must preserve this branch, or kiro accounts silently fall through to the Anthropic path and fail."
+      "rationale": "The Forward() dispatch injection point (next to IsBedrock) + the GatewayService.kiroGateway field, plus the ForwardResult.BillingTier -> UsageLog.BillingTier passthrough in buildRecordUsageLog that persists the kiro \"kiro-estimated\" provenance label. An upstream merge that rewrites Forward()/NewGatewayService() must preserve the dispatch branch (or kiro accounts fall through to the Anthropic path and fail); an upstream merge that rewrites buildRecordUsageLog must preserve the BillingTier line (or kiro usage logs lose the estimated-billing label even though estimation still runs)."
     },
     {
       "path": "backend/internal/handler/admin/account_handler_tk_kiro_validate.go",


### PR DESCRIPTION
修复 kiro(第六平台 CodeWhisperer)线上 **100% 请求 0-token / 0-cost / 完全免费** 的计费缺陷。

## 根因
CodeWhisperer EventStream 只返回 `meteringEvent.usage`(float credits),**不返回 token 计数**;`updateTokensFromEvent` 找 token 字段恒得 0 → `OnComplete(0,0)` → `ForwardResult.Usage` 恒为 0 → 定价×0 → 余额不扣。

## 方案(口径已经产品决策拍板:标准 token 价估算)
本地用 `tiktoken-go` cl100k_base 估算 token 填入 `ForwardResult.Usage`,下游 `RecordUsage → CalculateCostUnified` 按 claude-* 定价出账(定价已覆盖,无需新增)。

- **input** = system + 各 message 文本 + tool_result 文本 + tool_use Input JSON + **tools 定义(name+description+input_schema)计入**;图片 block 跳过。
- **output** = 响应 text + thinking + tool_use 全部计入。
- **cache 恒 0**(kiro 无 cache 语义,绝不虚报 cache_read/creation)。
- **不乘保守系数**(cl100k 对 CJK 天然略高估 = 运营安全侧,不少收)。
- codec 包级 `sync.Once` 缓存;`countTokens` 失败回退 `len([]rune)/4`(floor≥1,非空绝不返 0、不 panic)。
- **billing_tier = "kiro-estimated"**:复用现有 `usage_log.billing_tier` 列标注估算计费(零 schema 成本),便于报表区分;经 `ForwardResult.BillingTier` 透传,空值不影响其它平台。
- **OnCredits** 接线把上游 credits 落 info 日志(观测旁路,不参与计费,便于日后校准)。

## 改动
- 新增 `internal/integration/kiro/estimate.go`(+ 单测):估算函数 + codec + `KiroEstimatedBillingTier`。
- `kiro_gateway_service.go`:`&req` 透传两路;流式累积 text/thinking/tool_use;两处 `ForwardResult.Usage` 用估算;接 `OnCredits`。
- `gateway_service.go`(上游,thin injection):`ForwardResult` 加 `BillingTier` 字段 + `buildRecordUsageLog` 一行落库。
- `go.mod`:tiktoken 提为 direct(tidy 副作用剔除一个未引用 indirect dep)。
- `kiro.json` sentinel 扩锚,锁定估算与 BillingTier 注入点防上游 merge 退回免费。

## 验证
- `go build ./...` / `go test -tags=unit ./...` / `go test ./...` / `golangci-lint` 全过
- `scripts/preflight.sh` PASS
- markers:`no-web-impact` + `upstream-touch-guarded`(gateway_service.go 上游文件,append-only)

## 已知取舍(符合方案)
input 用原始 system 估算(非运行时 filter 后版本),选确定性优先、略高估的运营安全侧;cl100k 与 Anthropic tokenizer 的 CJK 偏差是方案明确接受的安全侧选择。

🤖 Generated with [Claude Code](https://claude.com/claude-code)