### PR TITLE
feat(kiro): 第六平台计费修复 + 两 bug + 容量列今日用量(三线集成)

### DIFF
--- a/backend/ent/migrate/schema.go
+++ b/backend/ent/migrate/schema.go
@@ -813,7 +813,7 @@ var (
 		{Name: "id", Type: field.TypeInt64, Increment: true},
 		{Name: "created_at", Type: field.TypeTime, SchemaType: map[string]string{"postgres": "timestamptz"}},
 		{Name: "updated_at", Type: field.TypeTime, SchemaType: map[string]string{"postgres": "timestamptz"}},
-		{Name: "platform", Type: field.TypeEnum, Enums: []string{"openai", "anthropic", "gemini", "antigravity", "newapi"}},
+		{Name: "platform", Type: field.TypeEnum, Enums: []string{"openai", "anthropic", "gemini", "antigravity", "newapi", "kiro"}},
 		{Name: "model_id", Type: field.TypeString, Size: 200},
 		{Name: "status", Type: field.TypeEnum, Enums: []string{"ok", "stale", "unreachable", "untested"}, Default: "untested"},
 		{Name: "last_seen_ok_at", Type: field.TypeTime, Nullable: true},

--- a/backend/ent/modelavailability/modelavailability.go
+++ b/backend/ent/modelavailability/modelavailability.go
@@ -104,6 +104,7 @@ const (
 	PlatformGemini      Platform = "gemini"
 	PlatformAntigravity Platform = "antigravity"
 	PlatformNewapi      Platform = "newapi"
+	PlatformKiro        Platform = "kiro"
 )
 
 func (pl Platform) String() string {
@@ -113,7 +114,7 @@ func (pl Platform) String() string {
 // PlatformValidator is a validator for the "platform" field enum values. It is called by the builders before save.
 func PlatformValidator(pl Platform) error {
 	switch pl {
-	case PlatformOpenai, PlatformAnthropic, PlatformGemini, PlatformAntigravity, PlatformNewapi:
+	case PlatformOpenai, PlatformAnthropic, PlatformGemini, PlatformAntigravity, PlatformNewapi, PlatformKiro:
 		return nil
 	default:
 		return fmt.Errorf("modelavailability: invalid enum value for platform field: %q", pl)

--- a/backend/ent/schema/model_availability.go
+++ b/backend/ent/schema/model_availability.go
@@ -58,7 +58,7 @@ func (ModelAvailability) Mixin() []ent.Mixin {
 func (ModelAvailability) Fields() []ent.Field {
 	return []ent.Field{
 		field.Enum("platform").
-			Values("openai", "anthropic", "gemini", "antigravity", "newapi"),
+			Values("openai", "anthropic", "gemini", "antigravity", "newapi", "kiro"),
 		field.String("model_id").
 			NotEmpty().
 			MaxLen(200),

--- a/backend/go.mod
+++ b/backend/go.mod
@@ -42,6 +42,7 @@ require (
 	github.com/testcontainers/testcontainers-go/modules/redis v0.40.0
 	github.com/tidwall/gjson v1.18.0
 	github.com/tidwall/sjson v1.2.5
+	github.com/tiktoken-go/tokenizer v0.6.2
 	github.com/waffo-com/waffo-go v1.3.1
 	github.com/wechatpay-apiv3/wechatpay-go v0.2.21
 	github.com/zeromicro/go-zero v1.9.4
@@ -135,7 +136,6 @@ require (
 	github.com/google/go-cmp v0.7.0 // indirect
 	github.com/google/go-querystring v1.1.0 // indirect
 	github.com/google/go-tpm v0.9.8 // indirect
-	github.com/google/subcommands v1.2.0 // indirect
 	github.com/grafana/pyroscope-go v1.2.7 // indirect
 	github.com/grafana/pyroscope-go/godeltaprof v0.1.9 // indirect
 	github.com/grpc-ecosystem/grpc-gateway/v2 v2.27.3 // indirect
@@ -211,7 +211,6 @@ require (
 	github.com/testcontainers/testcontainers-go v0.40.0 // indirect
 	github.com/tidwall/match v1.1.1 // indirect
 	github.com/tidwall/pretty v1.2.0 // indirect
-	github.com/tiktoken-go/tokenizer v0.6.2 // indirect
 	github.com/tinylib/msgp v1.6.3 // indirect
 	github.com/tklauser/go-sysconf v0.3.12 // indirect
 	github.com/tklauser/numcpus v0.6.1 // indirect

--- a/backend/go.sum
+++ b/backend/go.sum
@@ -228,8 +228,6 @@ github.com/google/go-tpm-tools v0.3.13-0.20230620182252-4639ecce2aba/go.mod h1:E
 github.com/google/gofuzz v1.0.0/go.mod h1:dBl0BpW6vV/+mYPU4Po3pmUjxk6FQPldtuIdl/M65Eg=
 github.com/google/pprof v0.0.0-20250317173921-a4b03ec1a45e h1:ijClszYn+mADRFY17kjQEVQ1XRhq2/JR1M3sGqeJoxs=
 github.com/google/pprof v0.0.0-20250317173921-a4b03ec1a45e/go.mod h1:boTsfXsheKC2y+lKOCMpSfarhxDeIzfZG1jqGcPl3cA=
-github.com/google/subcommands v1.2.0 h1:vWQspBTo2nEqTUFita5/KeEWlUL8kQObDFbub/EN9oE=
-github.com/google/subcommands v1.2.0/go.mod h1:ZjhPrFU+Olkh9WazFPsl27BQ4UPiG37m3yTrtFlrHVk=
 github.com/google/uuid v1.1.2/go.mod h1:TIyPZe4MgqvfeYDBFedMoGGpEw/LqOeaOT+nhxU+yHo=
 github.com/google/uuid v1.6.0 h1:NIvaJDMOsjHA8n1jAhLSgzrAzy1Hgr+hNrb57e+94F0=
 github.com/google/uuid v1.6.0/go.mod h1:TIyPZe4MgqvfeYDBFedMoGGpEw/LqOeaOT+nhxU+yHo=
@@ -311,8 +309,6 @@ github.com/mattn/go-isatty v0.0.12/go.mod h1:cbi8OIDigv2wuxKPP5vlRcQ1OAZbq2CE4Ky
 github.com/mattn/go-isatty v0.0.16/go.mod h1:kYGgaQfpe5nmfYZH+SKPsOc2e4SrIfOl2e/yFXSvRLM=
 github.com/mattn/go-isatty v0.0.20 h1:xfD0iDuEKnDkl03q4limB+vH+GxLEtL/jb4xVJSWWEY=
 github.com/mattn/go-isatty v0.0.20/go.mod h1:W+V8PltTTMOvKvAeJH7IuucS94S2C6jfK/D7dTCTo3Y=
-github.com/mattn/go-runewidth v0.0.15 h1:UNAjwbU9l54TA3KzvqLGxwWjHmMgBUVhBiTjelZgg3U=
-github.com/mattn/go-runewidth v0.0.15/go.mod h1:Jdepj2loyihRzMpdS35Xk/zdY8IAYHsh153qUoGf23w=
 github.com/mattn/go-sqlite3 v2.0.3+incompatible h1:gXHsfypPkaMZrKbD5209QV9jbUTJKjyR5WD3HYQSd+U=
 github.com/mattn/go-sqlite3 v2.0.3+incompatible/go.mod h1:FPy6KqzDD04eiIsT53CuJW3U88zkxoIYsOqkbpncsNc=
 github.com/mdelapenya/tlscert v0.2.0 h1:7H81W6Z/4weDvZBNOfQte5GpIMo0lGYEeWbkGp5LJHI=
@@ -357,8 +353,6 @@ github.com/ncruces/go-strftime v1.0.0 h1:HMFp8mLCTPp341M/ZnA4qaf7ZlsbTc+miZjCLOF
 github.com/ncruces/go-strftime v1.0.0/go.mod h1:Fwc5htZGVVkseilnfgOVb9mKy6w1naJmn9CehxcKcls=
 github.com/nxadm/tail v1.4.8 h1:nPr65rt6Y5JFSKQO7qToXr7pePgD6Gwiw05lkbyAQTE=
 github.com/nxadm/tail v1.4.8/go.mod h1:+ncqLTQzXmGhMZNUePPaPqPvBxHAIsmXswZKocGu+AU=
-github.com/olekukonko/tablewriter v0.0.5 h1:P2Ga83D34wi1o9J6Wh1mRuqd4mF/x/lgBS7N7AbDhec=
-github.com/olekukonko/tablewriter v0.0.5/go.mod h1:hPp6KlRPjbx+hW8ykQs1w3UBbZlj6HuIJcUGPhkA7kY=
 github.com/onsi/ginkgo v1.16.5 h1:8xi0RTUf59SOSfEtZMvwTvXYMzG4gV23XVHOZiXNtnE=
 github.com/onsi/ginkgo v1.16.5/go.mod h1:+E8gABHa3K6zRBolWtd+ROzc/U5bkGt0FwiG042wbpU=
 github.com/onsi/gomega v1.18.1 h1:M1GfJqGRrBrrGGsbxzV5dqM2U2ApXefZCQpkukxYRLE=
@@ -404,8 +398,6 @@ github.com/refraction-networking/utls v1.8.2 h1:j4Q1gJj0xngdeH+Ox/qND11aEfhpgoEv
 github.com/refraction-networking/utls v1.8.2/go.mod h1:jkSOEkLqn+S/jtpEHPOsVv/4V4EVnelwbMQl4vCWXAM=
 github.com/remyoudompheng/bigfft v0.0.0-20230129092748-24d4a6f8daec h1:W09IVJc94icq4NjY3clb7Lk8O1qJ8BdBEF8z0ibU0rE=
 github.com/remyoudompheng/bigfft v0.0.0-20230129092748-24d4a6f8daec/go.mod h1:qqbHyh8v60DhA7CoWK5oRCqLrMHRGoxYCSS9EjAz6Eo=
-github.com/rivo/uniseg v0.2.0 h1:S1pD9weZBuJdFmowNwbpi7BJ8TNftyUImj/0WQi72jY=
-github.com/rivo/uniseg v0.2.0/go.mod h1:J6wj4VEh+S6ZtnVlnTBMWIodfgj8LQOQFoIToxlJtxc=
 github.com/robfig/cron/v3 v3.0.1 h1:WdRxkvbJztn8LMz/QEvLN5sBU+xKpSqwwUO1Pjr4qDs=
 github.com/robfig/cron/v3 v3.0.1/go.mod h1:eQICP3HwyT7UooqI/z+Ov+PtYAWygg1TEWWzGIFLtro=
 github.com/rogpeppe/go-internal v1.13.1 h1:KvO1DLK/DRN07sQ1LQKScxyZJuNnedQ5/wKSR38lUII=
@@ -446,8 +438,6 @@ github.com/spf13/afero v1.11.0 h1:WJQKhtpdm3v2IzqG8VMqrr6Rf3UYpEF239Jy9wNepM8=
 github.com/spf13/afero v1.11.0/go.mod h1:GH9Y3pIexgf1MTIWtNGyogA5MwRIDXGUr+hbWNoBjkY=
 github.com/spf13/cast v1.6.0 h1:GEiTHELF+vaR5dhz3VqZfFSzZjYbgeKDpBxQVS4GYJ0=
 github.com/spf13/cast v1.6.0/go.mod h1:ancEpBxwJDODSW/UG4rDrAqiKolqNNh2DX3mk86cAdo=
-github.com/spf13/cobra v1.7.0 h1:hyqWnYt1ZQShIddO5kBpj3vu05/++x6tJ6dg8EC572I=
-github.com/spf13/cobra v1.7.0/go.mod h1:uLxZILRyS/50WlhOIKD7W6V5bgeIt+4sICxh6uRMrb0=
 github.com/spf13/pflag v1.0.5 h1:iy+VFUOCP1a+8yFto/drg2CJ5u0yRoB7fZw3DKv/JXA=
 github.com/spf13/pflag v1.0.5/go.mod h1:McXfInJRrz4CZXVZOBLb0bTZqETkiAhM9Iw0y3An2Bg=
 github.com/spf13/viper v1.18.2 h1:LUXCnvUvSM6FXAsj6nnfc8Q2tp1dIgUfY9Kc8GsSOiQ=

--- a/backend/internal/handler/gateway_handler.go
+++ b/backend/internal/handler/gateway_handler.go
@@ -787,6 +787,15 @@ func (h *GatewayHandler) Messages(c *gin.Context) {
 					return
 				}
 
+				// Kiro upstream rejected the model (HTTP 400 INVALID_MODEL_ID):
+				// return 400 immediately with a clear message, no failover (every
+				// Kiro account rejects the same unknown model identically).
+				var kiroInvalidModelErr *service.KiroInvalidModelError
+				if errors.As(err, &kiroInvalidModelErr) {
+					h.errorResponse(c, http.StatusBadRequest, "invalid_request_error", kiroInvalidModelErr.ClientMessage())
+					return
+				}
+
 				// TK canonical-OAuth ingress UA reject: 403 immediately, no failover.
 				// See gateway_service_tk_canonical_oauth_guard.go.
 				var canonicalUARejectErr *service.CanonicalIngressUARejectedError

--- a/backend/internal/integration/kiro/estimate.go
+++ b/backend/internal/integration/kiro/estimate.go
@@ -1,0 +1,222 @@
+package kiro
+
+import (
+	"encoding/json"
+	"strings"
+	"sync"
+
+	"github.com/tiktoken-go/tokenizer"
+)
+
+// Token estimation for the Kiro (sixth platform) CodeWhisperer upstream.
+//
+// Kiro's EventStream upstream returns *credits only* — it never reports
+// input/output token counts. Without estimation every Kiro request bills as
+// input=output=cost=0 (100% free). This package estimates token usage locally
+// with the cl100k_base tokenizer so the downstream billing pipeline
+// (RecordUsage → CalculateCostUnified) can charge against the mapped claude-*
+// price table exactly as the native Anthropic platform does.
+//
+// Calibration choices (approved):
+//   - cl100k_base encoding (close enough to Anthropic's tokenizer for billing).
+//   - No conservative multiplier: cl100k naturally over-counts CJK text, which
+//     is the operator-safe direction.
+//   - Kiro has no cache semantics: cache token fields stay 0, never fabricated.
+//   - Estimates are tagged with billing_tier="kiro-estimated" by the caller.
+
+// KiroEstimatedBillingTier is the billing_tier label stamped on Kiro usage logs
+// so operators can distinguish estimated billing from upstream-reported billing.
+const KiroEstimatedBillingTier = "kiro-estimated"
+
+var (
+	estCodec     tokenizer.Codec
+	estCodecOnce sync.Once
+)
+
+// codec lazily initializes and caches the cl100k_base tokenizer. A nil return
+// means initialization failed; callers fall back to the rune heuristic.
+func codec() tokenizer.Codec {
+	estCodecOnce.Do(func() {
+		if c, err := tokenizer.Get(tokenizer.Cl100kBase); err == nil {
+			estCodec = c
+		}
+	})
+	return estCodec
+}
+
+// countTokens returns an estimated token count for s. It uses cl100k_base when
+// available and falls back to a len([]rune)/4 heuristic on any encode failure.
+// It never panics and never returns 0 for non-empty input (the fallback floors
+// at 1 token for any non-empty string).
+func countTokens(s string) int {
+	if s == "" {
+		return 0
+	}
+	if c := codec(); c != nil {
+		if n, err := c.Count(s); err == nil {
+			return n
+		}
+	}
+	return fallbackCount(s)
+}
+
+// fallbackCount approximates token count as ~4 chars/token, flooring at 1 for
+// any non-empty string so we never silently bill an interaction as free.
+func fallbackCount(s string) int {
+	if s == "" {
+		return 0
+	}
+	n := len([]rune(s)) / 4
+	if n < 1 {
+		n = 1
+	}
+	return n
+}
+
+// EstimateInputTokens estimates the prompt-side token count for a Kiro request.
+//
+// Counted (mirrors what is actually sent upstream):
+//   - system prompt (string or []SystemBlock, flattened),
+//   - every message's text content,
+//   - tool_result text (the tool output echoed back into the prompt),
+//   - tool_use Input JSON (assistant tool calls in history),
+//   - tools definitions: name + description + serialized input_schema.
+//
+// Skipped: image blocks (binary, not text-tokenized).
+func EstimateInputTokens(req *ClaudeRequest) int {
+	if req == nil {
+		return 0
+	}
+
+	parts := make([]string, 0, 8)
+
+	// System prompt (raw flatten — same shape extractSystemPrompt produces).
+	if sys := extractSystemPrompt(req.System); sys != "" {
+		parts = append(parts, sys)
+	}
+
+	// Messages: text + tool_result text + tool_use Input JSON.
+	for i := range req.Messages {
+		parts = appendMessageContentForEstimate(parts, req.Messages[i].Content)
+	}
+
+	total := countTokens(strings.Join(parts, "\n"))
+
+	// Tools definitions count as input (the model sees them in the prompt).
+	total += estimateToolsTokens(req.Tools)
+
+	return total
+}
+
+// appendMessageContentForEstimate flattens one message's content into parts for
+// estimation. It handles the string form and the []ContentBlock form, pulling
+// text, tool_result text, and tool_use Input JSON; image blocks are skipped.
+func appendMessageContentForEstimate(parts []string, content any) []string {
+	if s, ok := content.(string); ok {
+		if s != "" {
+			parts = append(parts, s)
+		}
+		return parts
+	}
+
+	blocks, ok := content.([]any)
+	if !ok {
+		return parts
+	}
+	for _, raw := range blocks {
+		block, ok := raw.(map[string]any)
+		if !ok {
+			continue
+		}
+		switch blockType, _ := block["type"].(string); blockType {
+		case "text", "input_text":
+			if t, ok := block["text"].(string); ok && t != "" {
+				parts = append(parts, t)
+			}
+		case "tool_result":
+			// tool_result content is echoed back into the prompt; count its text.
+			if txt, _ := extractToolResultContent(block["content"]); txt != "" {
+				parts = append(parts, txt)
+			}
+		case "tool_use":
+			// Assistant tool call sitting in history: count its serialized input.
+			if js := marshalJSONForEstimate(block["input"]); js != "" {
+				parts = append(parts, js)
+			}
+			if name, ok := block["name"].(string); ok && name != "" {
+				parts = append(parts, name)
+			}
+		case "image", "image_url", "input_image":
+			// Skipped: binary, not text-tokenized.
+		}
+	}
+	return parts
+}
+
+// estimateToolsTokens counts the tokens contributed by tool definitions:
+// name + description + the serialized input_schema for each tool.
+func estimateToolsTokens(tools []ClaudeTool) int {
+	if len(tools) == 0 {
+		return 0
+	}
+	parts := make([]string, 0, len(tools)*3)
+	for i := range tools {
+		t := tools[i]
+		if t.Name != "" {
+			parts = append(parts, t.Name)
+		}
+		if t.Description != "" {
+			parts = append(parts, t.Description)
+		}
+		if js := marshalJSONForEstimate(t.InputSchema); js != "" {
+			parts = append(parts, js)
+		}
+	}
+	return countTokens(strings.Join(parts, "\n"))
+}
+
+// EstimateOutputTokens estimates the completion-side token count for a Kiro
+// response: assistant text + thinking/reasoning text + serialized tool_use
+// blocks (id + name + input). All three are billed as output.
+func EstimateOutputTokens(text, thinking string, toolUses []KiroToolUse) int {
+	parts := make([]string, 0, 2+len(toolUses)*3)
+	if text != "" {
+		parts = append(parts, text)
+	}
+	if thinking != "" {
+		parts = append(parts, thinking)
+	}
+	for i := range toolUses {
+		tu := toolUses[i]
+		if tu.Name != "" {
+			parts = append(parts, tu.Name)
+		}
+		if tu.ToolUseID != "" {
+			parts = append(parts, tu.ToolUseID)
+		}
+		if js := marshalJSONForEstimate(tu.Input); js != "" {
+			parts = append(parts, js)
+		}
+	}
+	return countTokens(strings.Join(parts, "\n"))
+}
+
+// marshalJSONForEstimate serializes v to compact JSON for token estimation.
+// Nil / empty maps and marshal failures yield an empty string (no tokens).
+func marshalJSONForEstimate(v any) string {
+	if v == nil {
+		return ""
+	}
+	if m, ok := v.(map[string]any); ok && len(m) == 0 {
+		return ""
+	}
+	js, err := json.Marshal(v)
+	if err != nil {
+		return ""
+	}
+	s := string(js)
+	if s == "null" || s == "{}" || s == "[]" {
+		return ""
+	}
+	return s
+}

--- a/backend/internal/integration/kiro/estimate_test.go
+++ b/backend/internal/integration/kiro/estimate_test.go
@@ -1,0 +1,194 @@
+//go:build unit
+
+package kiro
+
+import "testing"
+
+// TestCountTokens_NonEmptyNeverZero asserts that the tokenizer path returns a
+// positive, reasonable count for ordinary text and never zero for non-empty
+// input.
+func TestCountTokens_NonEmptyNeverZero(t *testing.T) {
+	if got := countTokens(""); got != 0 {
+		t.Fatalf("countTokens(empty) = %d, want 0", got)
+	}
+
+	// "hello world" tokenizes to 2 tokens under cl100k_base; assert non-zero and
+	// in a sane band rather than an exact value (tokenizer impl may shift).
+	got := countTokens("hello world")
+	if got <= 0 {
+		t.Fatalf("countTokens(hello world) = %d, want > 0", got)
+	}
+	if got > 10 {
+		t.Fatalf("countTokens(hello world) = %d, unexpectedly large", got)
+	}
+}
+
+// TestFallbackCount_FloorsAtOne asserts the rune-heuristic fallback never
+// returns 0 for non-empty input (which would silently bill an interaction as
+// free), and approximates ~4 chars/token for longer strings.
+func TestFallbackCount_FloorsAtOne(t *testing.T) {
+	if got := fallbackCount(""); got != 0 {
+		t.Fatalf("fallbackCount(empty) = %d, want 0", got)
+	}
+	if got := fallbackCount("a"); got != 1 {
+		t.Fatalf("fallbackCount(short) = %d, want 1 (floor)", got)
+	}
+	// 40 ASCII chars → ~10 tokens.
+	long := ""
+	for i := 0; i < 40; i++ {
+		long += "x"
+	}
+	if got := fallbackCount(long); got != 10 {
+		t.Fatalf("fallbackCount(40 chars) = %d, want 10", got)
+	}
+}
+
+// TestEstimateInputTokens_CountsSystemMessagesToolsAndToolUse asserts the input
+// estimate is non-zero and grows with system prompt, message text, tool
+// definitions, tool_use input JSON, and tool_result text.
+func TestEstimateInputTokens_CountsSystemMessagesToolsAndToolUse(t *testing.T) {
+	if got := EstimateInputTokens(nil); got != 0 {
+		t.Fatalf("EstimateInputTokens(nil) = %d, want 0", got)
+	}
+
+	// Baseline: a single short user message.
+	base := &ClaudeRequest{
+		Model: "claude-sonnet-4-5",
+		Messages: []ClaudeMessage{
+			{Role: "user", Content: "What is the weather in Paris today?"},
+		},
+	}
+	baseTok := EstimateInputTokens(base)
+	if baseTok <= 0 {
+		t.Fatalf("baseline input tokens = %d, want > 0", baseTok)
+	}
+
+	// Adding a system prompt must increase the estimate.
+	withSystem := &ClaudeRequest{
+		Model:    "claude-sonnet-4-5",
+		System:   "You are a meticulous and concise travel assistant. Always answer briefly.",
+		Messages: base.Messages,
+	}
+	if got := EstimateInputTokens(withSystem); got <= baseTok {
+		t.Fatalf("with system = %d, want > baseline %d", got, baseTok)
+	}
+
+	// Adding tools (name + description + input_schema) must increase the estimate.
+	withTools := &ClaudeRequest{
+		Model:    "claude-sonnet-4-5",
+		Messages: base.Messages,
+		Tools: []ClaudeTool{
+			{
+				Name:        "get_weather",
+				Description: "Fetch the current weather for a given city and country.",
+				InputSchema: map[string]any{
+					"type": "object",
+					"properties": map[string]any{
+						"city":    map[string]any{"type": "string"},
+						"country": map[string]any{"type": "string"},
+					},
+					"required": []any{"city"},
+				},
+			},
+		},
+	}
+	if got := EstimateInputTokens(withTools); got <= baseTok {
+		t.Fatalf("with tools = %d, want > baseline %d", got, baseTok)
+	}
+
+	// Block-shaped content with tool_use input JSON and tool_result text.
+	withBlocks := &ClaudeRequest{
+		Model: "claude-sonnet-4-5",
+		Messages: []ClaudeMessage{
+			{Role: "user", Content: "Look up the weather please."},
+			{Role: "assistant", Content: []any{
+				map[string]any{
+					"type": "tool_use",
+					"id":   "toolu_1",
+					"name": "get_weather",
+					"input": map[string]any{
+						"city":    "Paris",
+						"country": "France",
+					},
+				},
+			}},
+			{Role: "user", Content: []any{
+				map[string]any{
+					"type":        "tool_result",
+					"tool_use_id": "toolu_1",
+					"content":     "It is 21 degrees and sunny in Paris.",
+				},
+			}},
+		},
+	}
+	if got := EstimateInputTokens(withBlocks); got <= 0 {
+		t.Fatalf("block-shaped input tokens = %d, want > 0", got)
+	}
+}
+
+// TestEstimateInputTokens_SkipsImages asserts image blocks do not contribute
+// tokens (they are binary and not text-tokenized).
+func TestEstimateInputTokens_SkipsImages(t *testing.T) {
+	textOnly := &ClaudeRequest{
+		Messages: []ClaudeMessage{
+			{Role: "user", Content: []any{
+				map[string]any{"type": "text", "text": "describe this"},
+			}},
+		},
+	}
+	withImage := &ClaudeRequest{
+		Messages: []ClaudeMessage{
+			{Role: "user", Content: []any{
+				map[string]any{"type": "text", "text": "describe this"},
+				map[string]any{
+					"type": "image",
+					"source": map[string]any{
+						"type":       "base64",
+						"media_type": "image/png",
+						"data":       "iVBORw0KGgoAAAANSUhEUgAAAAEAAAABCAQAAAC1HAwCAAAAC0lEQVR42mNk+M9QDwADhgGAWjR9awAAAABJRU5ErkJggg==",
+					},
+				},
+			}},
+		},
+	}
+	if EstimateInputTokens(withImage) != EstimateInputTokens(textOnly) {
+		t.Fatalf("image block changed input estimate; images must be skipped")
+	}
+}
+
+// TestEstimateOutputTokens_CountsTextThinkingAndToolUse asserts the output
+// estimate sums assistant text, thinking, and serialized tool_use blocks.
+func TestEstimateOutputTokens_CountsTextThinkingAndToolUse(t *testing.T) {
+	if got := EstimateOutputTokens("", "", nil); got != 0 {
+		t.Fatalf("EstimateOutputTokens(empty) = %d, want 0", got)
+	}
+
+	textOnly := EstimateOutputTokens("The weather in Paris is sunny.", "", nil)
+	if textOnly <= 0 {
+		t.Fatalf("text-only output tokens = %d, want > 0", textOnly)
+	}
+
+	withThinking := EstimateOutputTokens(
+		"The weather in Paris is sunny.",
+		"Let me reason about the user's request before answering.",
+		nil,
+	)
+	if withThinking <= textOnly {
+		t.Fatalf("with thinking = %d, want > text-only %d", withThinking, textOnly)
+	}
+
+	withTools := EstimateOutputTokens(
+		"",
+		"",
+		[]KiroToolUse{
+			{
+				ToolUseID: "toolu_99",
+				Name:      "get_weather",
+				Input:     map[string]any{"city": "Paris", "country": "France"},
+			},
+		},
+	)
+	if withTools <= 0 {
+		t.Fatalf("tool_use-only output tokens = %d, want > 0", withTools)
+	}
+}

--- a/backend/internal/service/gateway_service.go
+++ b/backend/internal/service/gateway_service.go
@@ -527,6 +527,12 @@ type ForwardResult struct {
 	ClientDisconnect bool // 客户端是否在流式传输过程中断开
 	ReasoningEffort  *string
 
+	// BillingTier is an optional billing-tier label persisted onto the usage log.
+	// TK: the Kiro (sixth platform) path sets "kiro-estimated" to mark that the
+	// token counts were estimated locally (Kiro upstream reports credits only,
+	// never tokens). Empty means no tier label (the common token-billing case).
+	BillingTier string
+
 	// 图片生成计费字段（图片生成模型使用）
 	ImageCount         int    // 生成的图片数量
 	ImageSize          string // 最终计费尺寸 "1K", "2K", "4K"
@@ -9592,6 +9598,7 @@ func (s *GatewayService) buildRecordUsageLog(
 		RequestedModel:        requestedModel,
 		UpstreamModel:         optionalNonEqualStringPtr(result.UpstreamModel, result.Model),
 		ReasoningEffort:       result.ReasoningEffort,
+		BillingTier:           optionalTrimmedStringPtr(result.BillingTier),
 		InboundEndpoint:       optionalTrimmedStringPtr(input.InboundEndpoint),
 		UpstreamEndpoint:      optionalTrimmedStringPtr(input.UpstreamEndpoint),
 		InputTokens:           result.Usage.InputTokens,

--- a/backend/internal/service/kiro_gateway_service.go
+++ b/backend/internal/service/kiro_gateway_service.go
@@ -159,7 +159,7 @@ func (s *KiroGatewayService) forwardNonStreaming(
 	}
 
 	if err := kiroproto.CallKiroAPIWithDoer(doer, kiroAcct, payload, callback); err != nil {
-		return nil, fmt.Errorf("kiro upstream call failed: %w", err)
+		return nil, classifyKiroForwardError(err, model)
 	}
 	if callbackErr != nil {
 		return nil, fmt.Errorf("kiro stream error: %w", callbackErr)
@@ -242,7 +242,11 @@ func (s *KiroGatewayService) forwardStreaming(
 		}
 	}
 
-	enc.writeMessageStart()
+	// message_start is emitted lazily on first content (see kiroSSEEncoder
+	// ensureBlock / writeToolUse). Emitting it eagerly here would set
+	// enc.started=true before the upstream call, defeating the post-call
+	// `!enc.started` guard and turning an upstream 400 (e.g. INVALID_MODEL_ID)
+	// into a clean empty 200 stream that the handler never sees as an error.
 
 	callback := &kiroproto.KiroStreamCallback{
 		OnText: func(text string, isThinking bool) {
@@ -283,15 +287,21 @@ func (s *KiroGatewayService) forwardStreaming(
 
 	// If the upstream failed before producing any content, surface the error so
 	// the handler can decide on failover instead of emitting a half-finished
-	// SSE stream. (Once content has begun we close out the stream cleanly.)
+	// SSE stream. (Once content has begun — enc.started — we close out the
+	// stream cleanly because the client has already received a 200 + bytes.)
+	// classifyKiroForwardError maps a recognized HTTP 400 INVALID_MODEL_ID into
+	// a typed *KiroInvalidModelError so the handler can return a clean 400.
 	if callErr != nil && !enc.started {
-		return nil, fmt.Errorf("kiro upstream call failed: %w", callErr)
+		return nil, classifyKiroForwardError(callErr, model)
 	}
 
 	// Estimate token usage (Kiro upstream returns credits only — see estimate.go).
 	inputTokens := kiroproto.EstimateInputTokens(req)
 	outputToks := kiroproto.EstimateOutputTokens(textBuf, thinkingBuf, toolUses)
 
+	// Upstream succeeded but produced no content (enc.started still false):
+	// emit message_start lazily here so the closing events form a valid stream.
+	enc.writeMessageStart()
 	enc.closeOpenBlock()
 	enc.writeMessageDelta(outputToks)
 	enc.writeMessageStop()

--- a/backend/internal/service/kiro_gateway_service.go
+++ b/backend/internal/service/kiro_gateway_service.go
@@ -5,6 +5,7 @@ import (
 	"encoding/json"
 	"errors"
 	"fmt"
+	"log/slog"
 	"net/http"
 	"sync"
 	"time"
@@ -112,9 +113,9 @@ func (s *KiroGatewayService) Forward(
 	}
 
 	if req.Stream {
-		return s.forwardStreaming(ctx, c, doer, kiroAcct, payload, requestID, model, startTime)
+		return s.forwardStreaming(ctx, c, doer, kiroAcct, payload, &req, requestID, model, startTime)
 	}
-	return s.forwardNonStreaming(ctx, c, doer, kiroAcct, payload, requestID, model, startTime)
+	return s.forwardNonStreaming(ctx, c, doer, kiroAcct, payload, &req, requestID, model, startTime)
 }
 
 // forwardNonStreaming accumulates text/thinking/tool-use then writes a single
@@ -125,6 +126,7 @@ func (s *KiroGatewayService) forwardNonStreaming(
 	doer kiroproto.HTTPDoer,
 	kiroAcct *kiroproto.Account,
 	payload *kiroproto.KiroPayload,
+	req *kiroproto.ClaudeRequest,
 	requestID, model string,
 	startTime time.Time,
 ) (*ForwardResult, error) {
@@ -132,8 +134,6 @@ func (s *KiroGatewayService) forwardNonStreaming(
 		textBuf     string
 		thinkingBuf string
 		toolUses    []kiroproto.KiroToolUse
-		inputTokens int
-		outputToks  int
 		callbackErr error
 	)
 
@@ -148,9 +148,10 @@ func (s *KiroGatewayService) forwardNonStreaming(
 		OnToolUse: func(tu kiroproto.KiroToolUse) {
 			toolUses = append(toolUses, tu)
 		},
-		OnComplete: func(in, out int) {
-			inputTokens = in
-			outputToks = out
+		// Kiro upstream reports no token usage; OnComplete(in,out) is always (0,0).
+		// We estimate token usage locally below instead of trusting these values.
+		OnCredits: func(credits float64) {
+			logKiroCredits(kiroAcct, model, credits)
 		},
 		OnError: func(err error) {
 			callbackErr = err
@@ -163,6 +164,10 @@ func (s *KiroGatewayService) forwardNonStreaming(
 	if callbackErr != nil {
 		return nil, fmt.Errorf("kiro stream error: %w", callbackErr)
 	}
+
+	// Estimate token usage (Kiro upstream returns credits only — see estimate.go).
+	inputTokens := kiroproto.EstimateInputTokens(req)
+	outputToks := kiroproto.EstimateOutputTokens(textBuf, thinkingBuf, toolUses)
 
 	resp := kiroproto.KiroToClaudeResponse(
 		textBuf, thinkingBuf, false, toolUses, inputTokens, outputToks, model,
@@ -181,6 +186,7 @@ func (s *KiroGatewayService) forwardNonStreaming(
 		UpstreamModel: kiroproto.MapModel(model),
 		Stream:        false,
 		Duration:      time.Since(startTime),
+		BillingTier:   kiroproto.KiroEstimatedBillingTier,
 	}, nil
 }
 
@@ -194,6 +200,7 @@ func (s *KiroGatewayService) forwardStreaming(
 	doer kiroproto.HTTPDoer,
 	kiroAcct *kiroproto.Account,
 	payload *kiroproto.KiroPayload,
+	req *kiroproto.ClaudeRequest,
 	requestID, model string,
 	startTime time.Time,
 ) (*ForwardResult, error) {
@@ -221,8 +228,9 @@ func (s *KiroGatewayService) forwardStreaming(
 
 	var (
 		mu          sync.Mutex
-		inputTokens int
-		outputToks  int
+		textBuf     string
+		thinkingBuf string
+		toolUses    []kiroproto.KiroToolUse
 		callbackErr error
 		firstTokMs  *int
 	)
@@ -242,8 +250,10 @@ func (s *KiroGatewayService) forwardStreaming(
 			defer mu.Unlock()
 			markFirstToken()
 			if isThinking {
+				thinkingBuf += text
 				enc.writeThinkingDelta(text)
 			} else {
+				textBuf += text
 				enc.writeTextDelta(text)
 			}
 		},
@@ -251,13 +261,13 @@ func (s *KiroGatewayService) forwardStreaming(
 			mu.Lock()
 			defer mu.Unlock()
 			markFirstToken()
+			toolUses = append(toolUses, tu)
 			enc.writeToolUse(tu)
 		},
-		OnComplete: func(in, out int) {
-			mu.Lock()
-			defer mu.Unlock()
-			inputTokens = in
-			outputToks = out
+		// Kiro upstream reports no token usage; OnComplete(in,out) is always (0,0).
+		// We estimate token usage locally below instead of trusting these values.
+		OnCredits: func(credits float64) {
+			logKiroCredits(kiroAcct, model, credits)
 		},
 		OnError: func(err error) {
 			mu.Lock()
@@ -277,6 +287,10 @@ func (s *KiroGatewayService) forwardStreaming(
 	if callErr != nil && !enc.started {
 		return nil, fmt.Errorf("kiro upstream call failed: %w", callErr)
 	}
+
+	// Estimate token usage (Kiro upstream returns credits only — see estimate.go).
+	inputTokens := kiroproto.EstimateInputTokens(req)
+	outputToks := kiroproto.EstimateOutputTokens(textBuf, thinkingBuf, toolUses)
 
 	enc.closeOpenBlock()
 	enc.writeMessageDelta(outputToks)
@@ -298,5 +312,21 @@ func (s *KiroGatewayService) forwardStreaming(
 		Stream:        true,
 		Duration:      time.Since(startTime),
 		FirstTokenMs:  firstTokMs,
+		BillingTier:   kiroproto.KiroEstimatedBillingTier,
 	}, nil
+}
+
+// logKiroCredits records the Kiro upstream credits cost at info level for
+// observability. Credits are NOT used for billing (we estimate tokens instead);
+// this is a passive side channel to reconcile estimated cost against upstream.
+func logKiroCredits(account *kiroproto.Account, model string, credits float64) {
+	var accountID string
+	if account != nil {
+		accountID = account.ID
+	}
+	slog.Info("kiro upstream credits",
+		"account_id", accountID,
+		"model", model,
+		"credits", credits,
+	)
 }

--- a/backend/internal/service/kiro_gateway_service_test.go
+++ b/backend/internal/service/kiro_gateway_service_test.go
@@ -195,8 +195,12 @@ func TestKiroGatewayService_Forward_NonStreaming(t *testing.T) {
 	require.NotNil(t, result)
 	require.True(t, upstream.gotRequest)
 	require.False(t, result.Stream)
-	require.Equal(t, 12, result.Usage.InputTokens)
-	require.Equal(t, 5, result.Usage.OutputTokens)
+	// Kiro upstream reports credits only (never tokens); usage is estimated
+	// locally from request/response content, so token counts must be positive
+	// and the billing tier marked as estimated.
+	require.Positive(t, result.Usage.InputTokens)
+	require.Positive(t, result.Usage.OutputTokens)
+	require.Equal(t, "kiro-estimated", result.BillingTier)
 	require.Equal(t, "claude-sonnet-4", result.Model)
 	require.NotEmpty(t, result.RequestID)
 
@@ -231,8 +235,10 @@ func TestKiroGatewayService_Forward_Streaming(t *testing.T) {
 	require.NoError(t, err)
 	require.NotNil(t, result)
 	require.True(t, result.Stream)
-	require.Equal(t, 8, result.Usage.InputTokens)
-	require.Equal(t, 3, result.Usage.OutputTokens)
+	// Estimated usage (Kiro upstream reports credits only).
+	require.Positive(t, result.Usage.InputTokens)
+	require.Positive(t, result.Usage.OutputTokens)
+	require.Equal(t, "kiro-estimated", result.BillingTier)
 
 	out := rec.Body.String()
 	require.Contains(t, out, "event: message_start")

--- a/backend/internal/service/kiro_gateway_service_test.go
+++ b/backend/internal/service/kiro_gateway_service_test.go
@@ -250,6 +250,123 @@ func TestKiroGatewayService_Forward_Streaming(t *testing.T) {
 	require.Contains(t, out, "event: message_stop")
 }
 
+// kiroStatusUpstream returns a canned non-200 response with a fixed body,
+// modeling the Kiro upstream rejecting a request (e.g. 400 INVALID_MODEL_ID).
+// The vendored CallKiroAPIWithDoer reads the body into its error string, so all
+// three endpoints in the fallback list see the same rejection.
+type kiroStatusUpstream struct {
+	status int
+	body   string
+}
+
+func (u *kiroStatusUpstream) Do(*http.Request, string, int64, int) (*http.Response, error) {
+	return nil, fmt.Errorf("unexpected Do call")
+}
+
+func (u *kiroStatusUpstream) DoWithTLS(_ *http.Request, _ string, _ int64, _ int, _ *tlsfingerprint.Profile) (*http.Response, error) {
+	return &http.Response{
+		StatusCode: u.status,
+		Header:     make(http.Header),
+		Body:       io.NopCloser(bytes.NewReader([]byte(u.body))),
+	}, nil
+}
+
+// Bug2: upstream returns 400 INVALID_MODEL_ID *before* any content is produced.
+// The fix makes message_start lazy, so enc.started stays false and Forward must
+// return a typed *KiroInvalidModelError instead of closing out a clean empty
+// 200 SSE stream (the old "200 lie").
+func TestKiroGatewayService_Forward_Streaming_InvalidModel_NoEmpty200(t *testing.T) {
+	gin.SetMode(gin.TestMode)
+	rec := httptest.NewRecorder()
+	c, _ := gin.CreateTestContext(rec)
+
+	upstream := &kiroStatusUpstream{
+		status: http.StatusBadRequest,
+		body:   `{"reason":"INVALID_MODEL_ID","message":"model not found"}`,
+	}
+	svc := NewKiroGatewayService(upstream, nil, newKiroSettingService("true", nil))
+
+	body, _ := json.Marshal(map[string]any{
+		"model":      "claude-haiku-4.5",
+		"messages":   []map[string]any{{"role": "user", "content": "hi"}},
+		"max_tokens": 16,
+		"stream":     true,
+	})
+	parsed := &ParsedRequest{Body: NewRequestBodyRef(body), Model: "claude-haiku-4.5", Stream: true}
+
+	result, err := svc.Forward(context.Background(), c, newKiroAccountForTest(), parsed, time.Now())
+	require.Error(t, err)
+	require.Nil(t, result)
+
+	// Error must be the typed invalid-model error carrying status 400 + model.
+	var invalidModelErr *KiroInvalidModelError
+	require.ErrorAs(t, err, &invalidModelErr)
+	require.Equal(t, 400, invalidModelErr.StatusCode)
+	require.Equal(t, "claude-haiku-4.5", invalidModelErr.Model)
+	require.Contains(t, invalidModelErr.ClientMessage(), "not supported by Kiro")
+
+	// No SSE was written: the old bug emitted message_start eagerly and returned
+	// a clean empty 200 stream. The fix must write nothing to the client.
+	require.Empty(t, rec.Body.String(), "no SSE bytes may be written before a pre-content 400")
+	require.NotContains(t, rec.Body.String(), "message_start")
+}
+
+func TestKiroGatewayService_Forward_NonStreaming_InvalidModel(t *testing.T) {
+	gin.SetMode(gin.TestMode)
+	rec := httptest.NewRecorder()
+	c, _ := gin.CreateTestContext(rec)
+
+	upstream := &kiroStatusUpstream{
+		status: http.StatusBadRequest,
+		body:   `{"reason":"INVALID_MODEL_ID"}`,
+	}
+	svc := NewKiroGatewayService(upstream, nil, newKiroSettingService("true", nil))
+
+	body, _ := json.Marshal(map[string]any{
+		"model":    "claude-haiku-4.5",
+		"messages": []map[string]any{{"role": "user", "content": "hi"}},
+		"stream":   false,
+	})
+	parsed := &ParsedRequest{Body: NewRequestBodyRef(body), Model: "claude-haiku-4.5", Stream: false}
+
+	result, err := svc.Forward(context.Background(), c, newKiroAccountForTest(), parsed, time.Now())
+	require.Error(t, err)
+	require.Nil(t, result)
+	var invalidModelErr *KiroInvalidModelError
+	require.ErrorAs(t, err, &invalidModelErr)
+	require.Equal(t, "claude-haiku-4.5", invalidModelErr.Model)
+}
+
+func TestClassifyKiroForwardError(t *testing.T) {
+	// 400 + INVALID_MODEL_ID → typed error.
+	err := classifyKiroForwardError(
+		fmt.Errorf("HTTP 400 from CodeWhisperer: {\"reason\":\"INVALID_MODEL_ID\"}"),
+		"claude-haiku-4.5",
+	)
+	var invalidModelErr *KiroInvalidModelError
+	require.ErrorAs(t, err, &invalidModelErr)
+	require.Equal(t, "claude-haiku-4.5", invalidModelErr.Model)
+
+	// 400 without the INVALID_MODEL_ID marker → generic wrapped error, NOT typed.
+	other := classifyKiroForwardError(
+		fmt.Errorf("HTTP 400 from CodeWhisperer: {\"reason\":\"THROTTLED\"}"),
+		"claude-haiku-4.5",
+	)
+	require.Error(t, other)
+	require.NotErrorAs(t, other, &invalidModelErr)
+	require.Contains(t, other.Error(), "kiro upstream call failed")
+
+	// 500 with the marker substring → still not classified as invalid-model.
+	notFourHundred := classifyKiroForwardError(
+		fmt.Errorf("HTTP 500 from CodeWhisperer: INVALID_MODEL_ID"),
+		"claude-haiku-4.5",
+	)
+	require.NotErrorAs(t, notFourHundred, &invalidModelErr)
+
+	// nil passes through.
+	require.NoError(t, classifyKiroForwardError(nil, "m"))
+}
+
 func TestKiroGatewayService_Forward_DisabledErrors(t *testing.T) {
 	gin.SetMode(gin.TestMode)
 	rec := httptest.NewRecorder()

--- a/backend/internal/service/kiro_gateway_service_tk_errors.go
+++ b/backend/internal/service/kiro_gateway_service_tk_errors.go
@@ -1,0 +1,74 @@
+package service
+
+import (
+	"fmt"
+	"strings"
+)
+
+// KiroInvalidModelError is a typed, status-carrying error raised when the Kiro
+// (sixth platform) upstream rejects a request with HTTP 400 INVALID_MODEL_ID —
+// i.e. the requested model is not one the Kiro/CodeWhisperer backend serves.
+//
+// It mirrors the BetaBlockedError / PromptTooLongError pattern so the gateway
+// handler can `errors.As` it and return a clean 400 invalid_request_error to the
+// client instead of the previous failure mode, where forwardStreaming had
+// already emitted message_start (started=true), the `!enc.started` guard was
+// defeated, and the request returned an empty but "successful" 200 SSE stream.
+//
+// A model-unsupported error is intentionally NOT a cross-account failover
+// trigger: every Kiro account would reject the same unknown model identically,
+// so failover would only burn accounts before returning the same 400.
+type KiroInvalidModelError struct {
+	StatusCode int
+	Model      string
+	Body       string
+}
+
+func (e *KiroInvalidModelError) Error() string {
+	return fmt.Sprintf("kiro invalid model %q: status=%d", e.Model, e.StatusCode)
+}
+
+// ClientMessage is the operator/end-user-facing text written into the relay
+// error body. Kept terse and model-scoped so the caller knows exactly which
+// model the Kiro platform refused.
+func (e *KiroInvalidModelError) ClientMessage() string {
+	return fmt.Sprintf("model %s is not supported by Kiro", e.Model)
+}
+
+// classifyKiroForwardError inspects an error returned by the vendored Kiro API
+// call path and, if it recognizes an HTTP 400 INVALID_MODEL_ID rejection,
+// wraps it as a typed *KiroInvalidModelError. Any other error is wrapped with
+// the historical "kiro upstream call failed" prefix so existing log/behavior is
+// preserved.
+//
+// The vendored client formats non-200 responses as
+//
+//	HTTP <code> from <endpoint>: <raw upstream body>
+//
+// (see internal/integration/kiro/client.go CallKiroAPIWithDoer). We match on
+// the literal "HTTP 400" prefix plus the upstream "INVALID_MODEL_ID" marker so
+// an unrelated 400 (or a 400 with a different reason) does not get mislabeled
+// as a model error.
+func classifyKiroForwardError(err error, model string) error {
+	if err == nil {
+		return nil
+	}
+	msg := err.Error()
+	if isKiroInvalidModelError(msg) {
+		return &KiroInvalidModelError{
+			StatusCode: 400,
+			Model:      model,
+			Body:       msg,
+		}
+	}
+	return fmt.Errorf("kiro upstream call failed: %w", err)
+}
+
+// isKiroInvalidModelError reports whether the formatted upstream error string
+// represents an HTTP 400 INVALID_MODEL_ID rejection.
+func isKiroInvalidModelError(msg string) bool {
+	if !strings.Contains(msg, "HTTP 400") {
+		return false
+	}
+	return strings.Contains(strings.ToUpper(msg), "INVALID_MODEL_ID")
+}

--- a/backend/internal/service/kiro_sse_encoder.go
+++ b/backend/internal/service/kiro_sse_encoder.go
@@ -72,11 +72,15 @@ func (e *kiroSSEEncoder) writeMessageStart() {
 }
 
 // ensureBlock opens a content block of the requested kind, closing any
-// previously open block of a different kind first.
+// previously open block of a different kind first. It lazily emits message_start
+// on first content so that an upstream failure occurring before any content
+// arrives leaves enc.started == false (the caller's `!enc.started` guard then
+// surfaces the error instead of closing out a clean empty 200 stream).
 func (e *kiroSSEEncoder) ensureBlock(kind kiroBlockKind) {
 	if e.openBlock == kind {
 		return
 	}
+	e.writeMessageStart()
 	e.closeOpenBlock()
 
 	var cb map[string]any
@@ -125,6 +129,7 @@ func (e *kiroSSEEncoder) writeThinkingDelta(text string) {
 // Kiro delivers tool uses whole (not incrementally), so the input is serialized
 // as a single partial_json delta.
 func (e *kiroSSEEncoder) writeToolUse(tu kiroproto.KiroToolUse) {
+	e.writeMessageStart()
 	e.closeOpenBlock()
 	e.stopReason = "tool_use"
 

--- a/backend/internal/web/dist/frontend-source.json
+++ b/backend/internal/web/dist/frontend-source.json
@@ -1,7 +1,7 @@
 {
   "algorithm": "sha256(git-ls-files:path,size,content)",
   "file_count": 454,
-  "hash": "dcc25f62849c9837a0b12b37a46408e681b99f8c6d0a0da11d6773b384a64f04",
+  "hash": "7d87eea5a1ce4d69bcd23bf7141bd6eb32898cbc3ffcfeea63a25f89d840224f",
   "schema": 1,
   "source": "frontend/"
 }

--- a/backend/migrations/tk_016_allow_kiro_model_availability_platform.sql
+++ b/backend/migrations/tk_016_allow_kiro_model_availability_platform.sql
@@ -1,0 +1,22 @@
+-- TK migration 016: allow 'kiro' (sixth platform) in model_availability.platform CHECK constraint.
+--
+-- Why a new migration instead of editing tk_009:
+--   tk_009 has already been applied on prod/edge nodes. TokenKey's migration runner enforces a
+--   checksum guard — editing an already-applied migration changes its checksum and makes every
+--   node refuse to start (and the deploy trap then rolls back to the prior bad image, pinning the
+--   node). So the platform-set extension MUST land as a NEW, idempotent migration.
+--
+-- Symptom this fixes: every kiro gateway forward logged `pricing.availability.record_failed`
+--   with `ent: validator failed ... invalid enum value for platform field: "kiro"`. The enum gap
+--   was two-layered — the ent Go PlatformValidator (regenerated via `go generate ./ent`) AND this
+--   DB CHECK. This migration closes the DB layer; the ent layer closes via the schema edit.
+--
+-- Idempotent: DROP CONSTRAINT IF EXISTS + re-ADD with the full platform set, mirroring the
+--   135_allow_email_oauth_provider_types.sql范式. Safe to re-run.
+
+ALTER TABLE model_availability
+    DROP CONSTRAINT IF EXISTS model_availability_platform_check;
+
+ALTER TABLE model_availability
+    ADD CONSTRAINT model_availability_platform_check
+    CHECK (platform IN ('openai', 'anthropic', 'gemini', 'antigravity', 'newapi', 'kiro'));

--- a/frontend/src/components/account/AccountCapacityCell.vue
+++ b/frontend/src/components/account/AccountCapacityCell.vue
@@ -32,18 +32,35 @@
     <QuotaBadge v-if="showDailyQuota" :used="account.quota_daily_used ?? 0" :limit="account.quota_daily_limit!" label="D" />
     <QuotaBadge v-if="showWeeklyQuota" :used="account.quota_weekly_used ?? 0" :limit="account.quota_weekly_limit!" label="W" />
     <QuotaBadge v-if="showTotalQuota" :used="account.quota_used ?? 0" :limit="account.quota_limit!" />
+
+    <!-- 今日用量（tokens + 计费），全账号类型；数据由父组件注入 -->
+    <span
+      v-if="todayStats"
+      :class="['inline-flex items-center gap-1 rounded-md px-1.5 py-px text-[10px] font-medium leading-tight', todayUsageClass]"
+      :title="todayTooltip"
+    >
+      <svg class="h-2.5 w-2.5" fill="none" viewBox="0 0 24 24" stroke="currentColor" stroke-width="2">
+        <path stroke-linecap="round" stroke-linejoin="round" d="M6.75 3v2.25M17.25 3v2.25M3 18.75V7.5a2.25 2.25 0 012.25-2.25h13.5A2.25 2.25 0 0121 7.5v11.25m-18 0A2.25 2.25 0 005.25 21h13.5A2.25 2.25 0 0021 18.75m-18 0v-7.5A2.25 2.25 0 015.25 9h13.5A2.25 2.25 0 0121 11.25v7.5" />
+      </svg>
+      <span class="font-mono">{{ formatTokensK(todayStats.tokens) }}</span>
+      <span class="text-gray-400 dark:text-gray-500">·</span>
+      <span class="font-mono">{{ formatCurrency(todayStats.cost) }}</span>
+    </span>
   </div>
 </template>
 
 <script setup lang="ts">
 import { computed } from 'vue'
 import { useI18n } from 'vue-i18n'
-import type { Account } from '@/types'
+import type { Account, WindowStats } from '@/types'
+import { formatCurrency, formatTokensK } from '@/utils/format'
 import CapacityBadge from '@/components/account/CapacityBadge.vue'
 import QuotaBadge from '@/components/account/QuotaBadge.vue'
 
 const props = defineProps<{
   account: Account
+  // 今日用量（tokens + 计费），由父组件按账号 ID 注入；全账号类型通用。
+  todayStats?: WindowStats | null
 }>()
 
 const { t } = useI18n()
@@ -181,6 +198,27 @@ const formatCost = (value: number | null | undefined) => {
   if (value === null || value === undefined) return '0'
   return value.toFixed(2)
 }
+
+// ====== 今日用量（全账号类型；0 值灰显以暴露异常，如 kiro 当前 0 计费） ======
+const hasTodayUsage = computed(() => {
+  const s = props.todayStats
+  return !!s && ((s.tokens ?? 0) > 0 || (s.cost ?? 0) > 0)
+})
+
+const todayUsageClass = computed(() =>
+  hasTodayUsage.value
+    ? 'bg-indigo-50 text-indigo-600 dark:bg-indigo-900/20 dark:text-indigo-300'
+    : 'bg-gray-100 text-gray-400 dark:bg-gray-800 dark:text-gray-500'
+)
+
+const todayTooltip = computed(() => {
+  const s = props.todayStats
+  if (!s) return ''
+  return t('admin.accounts.capacity.today.tooltip', {
+    requests: s.requests ?? 0,
+    cost: formatCurrency(s.cost)
+  })
+})
 
 // ====== 配额 ======
 const isQuotaEligible = computed(() => props.account.type === 'apikey' || props.account.type === 'bedrock')

--- a/frontend/src/i18n/locales/en.ts
+++ b/frontend/src/i18n/locales/en.ts
@@ -3329,6 +3329,9 @@ export default {
           exceeded: 'Quota exceeded, account paused',
           normal: 'Quota normal'
         },
+        today: {
+          tooltip: "Today's usage: {requests} requests · billed {cost}"
+        },
       },
       tempUnschedulable: {
         title: 'Temp Unschedulable',

--- a/frontend/src/i18n/locales/zh.ts
+++ b/frontend/src/i18n/locales/zh.ts
@@ -3365,6 +3365,9 @@ export default {
           exceeded: '配额已用完，账号暂停调度',
           normal: '配额正常'
         },
+        today: {
+          tooltip: '今日用量：{requests} 次请求 · 计费 {cost}'
+        },
       },
       clearRateLimit: '清除速率限制',
       resetQuota: '重置配额',

--- a/frontend/src/views/admin/AccountsView.vue
+++ b/frontend/src/views/admin/AccountsView.vue
@@ -227,7 +227,7 @@
             </div>
           </template>
           <template #cell-capacity="{ row }">
-            <AccountCapacityCell :account="row" />
+            <AccountCapacityCell :account="row" :today-stats="todayStatsByAccountId[String(row.id)] ?? null" />
           </template>
           <template #cell-status="{ row }">
             <div class="flex items-center gap-1.5">
@@ -562,11 +562,12 @@ const buildDefaultTodayStats = (): WindowStats => ({
 })
 
 const refreshTodayStatsBatch = async () => {
-  // Why this checks both columns:
+  // Why this checks these columns:
   // - today_stats column shows dedicated today's metrics.
   // - usage column also embeds today's stats for Key/Bedrock rows.
-  // So we only skip fetching when BOTH columns are hidden.
-  if (hiddenColumns.has('today_stats') && hiddenColumns.has('usage')) {
+  // - capacity column now embeds a today usage badge for ALL account types.
+  // So we only skip fetching when ALL three columns are hidden.
+  if (hiddenColumns.has('today_stats') && hiddenColumns.has('usage') && hiddenColumns.has('capacity')) {
     todayStatsLoading.value = false
     todayStatsError.value = null
     return

--- a/frontend/src/views/admin/EdgeAccountsView.vue
+++ b/frontend/src/views/admin/EdgeAccountsView.vue
@@ -145,7 +145,7 @@
                     <span v-if="acct.channel_type" class="text-gray-400 dark:text-gray-500"> · ch{{ acct.channel_type }}</span>
                   </td>
                   <td class="px-4 py-2 align-top">
-                    <AccountCapacityCell :account="toAccountLike(acct)" />
+                    <AccountCapacityCell :account="toAccountLike(acct)" :today-stats="toWindowStats(acct)" />
                   </td>
                   <td class="px-4 py-2 align-top">
                     <AccountUsageCell

--- a/scripts/sentinels/frontend-tk.json
+++ b/scripts/sentinels/frontend-tk.json
@@ -460,6 +460,14 @@
         "title: 'Edge 账号'"
       ],
       "rationale": "TK-only Chinese i18n for the Edge Accounts page — the zh counterpart of the en.ts edge-accounts anchor. Guards against an upstream locale-file rewrite silently dropping the block."
+    },
+    {
+      "path": "frontend/src/components/account/AccountCapacityCell.vue",
+      "must_contain": [
+        "todayStats",
+        "capacity.today.tooltip"
+      ],
+      "rationale": "TK adds a today-usage badge (tokens·$cost) for ALL account types in the capacity column (admin accounts page + edge accounts page). The `todayStats` prop and the `admin.accounts.capacity.today.tooltip` i18n key are the TK-only contract; an upstream merge that rewrites this capacity cell could silently drop the today-usage badge — it would compile fine, just lose the feature (and the deliberate 0-value grey-out that surfaces anomalies like kiro's current 0-billing). Sentinel guards that the badge survives upstream convergence."
     }
   ]
 }

--- a/scripts/sentinels/kiro.json
+++ b/scripts/sentinels/kiro.json
@@ -71,6 +71,15 @@
       "rationale": "Anthropic <-> Kiro request/response translation. Without it the /v1/messages -> CodeWhisperer bridge cannot build a payload or decode the reply."
     },
     {
+      "path": "backend/internal/integration/kiro/estimate.go",
+      "must_contain": [
+        "func EstimateInputTokens",
+        "func EstimateOutputTokens",
+        "KiroEstimatedBillingTier"
+      ],
+      "rationale": "Local cl100k_base token estimation for kiro billing. The Kiro EventStream upstream reports credits only (never tokens), so without this estimator every kiro request bills input=output=cost=0 (100% free). Losing EstimateInputTokens/EstimateOutputTokens silently regresses kiro back to free; losing KiroEstimatedBillingTier drops the billing_tier=\"kiro-estimated\" provenance label operators use to distinguish estimated from upstream-reported billing."
+    },
+    {
       "path": "backend/internal/integration/kiro/client.go",
       "must_contain": [
         "func CallKiroAPIWithDoer",
@@ -109,9 +118,12 @@
       "must_contain": [
         "type KiroGatewayService",
         "func (s *KiroGatewayService) Forward",
-        "IsKiroEnabled"
+        "IsKiroEnabled",
+        "kiroproto.EstimateInputTokens",
+        "kiroproto.EstimateOutputTokens",
+        "BillingTier:   kiroproto.KiroEstimatedBillingTier"
       ],
-      "rationale": "The sixth-platform forwarder: translates /v1/messages onto the Kiro EventStream upstream and enforces the second ToS/enable gate (IsKiroEnabled). Losing it makes every kiro request fail or, worse, bypass the enable gate."
+      "rationale": "The sixth-platform forwarder: translates /v1/messages onto the Kiro EventStream upstream and enforces the second ToS/enable gate (IsKiroEnabled). It also estimates token usage locally (EstimateInputTokens/EstimateOutputTokens) and stamps ForwardResult.BillingTier=\"kiro-estimated\", because the Kiro upstream reports credits only — without these calls both forward paths return Usage{0,0} and kiro bills as 100% free. Losing the forwarder makes every kiro request fail or bypass the enable gate; losing the estimate/BillingTier wiring silently regresses kiro to free billing."
     },
     {
       "path": "backend/internal/service/kiro_sse_encoder.go",
@@ -126,9 +138,10 @@
       "path": "backend/internal/service/gateway_service.go",
       "must_contain": [
         "account.IsKiro()",
-        "kiroGateway"
+        "kiroGateway",
+        "BillingTier:           optionalTrimmedStringPtr(result.BillingTier)"
       ],
-      "rationale": "The Forward() dispatch injection point (next to IsBedrock) + the GatewayService.kiroGateway field. An upstream merge that rewrites Forward() or NewGatewayService() must preserve this branch, or kiro accounts silently fall through to the Anthropic path and fail."
+      "rationale": "The Forward() dispatch injection point (next to IsBedrock) + the GatewayService.kiroGateway field, plus the ForwardResult.BillingTier -> UsageLog.BillingTier passthrough in buildRecordUsageLog that persists the kiro \"kiro-estimated\" provenance label. An upstream merge that rewrites Forward()/NewGatewayService() must preserve the dispatch branch (or kiro accounts fall through to the Anthropic path and fail); an upstream merge that rewrites buildRecordUsageLog must preserve the BillingTier line (or kiro usage logs lose the estimated-billing label even though estimation still runs)."
     },
     {
       "path": "backend/internal/handler/admin/account_handler_tk_kiro_validate.go",

--- a/scripts/sentinels/kiro.json
+++ b/scripts/sentinels/kiro.json
@@ -121,18 +121,21 @@
         "IsKiroEnabled",
         "kiroproto.EstimateInputTokens",
         "kiroproto.EstimateOutputTokens",
-        "BillingTier:   kiroproto.KiroEstimatedBillingTier"
+        "BillingTier:   kiroproto.KiroEstimatedBillingTier",
+        "callErr != nil && !enc.started",
+        "classifyKiroForwardError"
       ],
-      "rationale": "The sixth-platform forwarder: translates /v1/messages onto the Kiro EventStream upstream and enforces the second ToS/enable gate (IsKiroEnabled). It also estimates token usage locally (EstimateInputTokens/EstimateOutputTokens) and stamps ForwardResult.BillingTier=\"kiro-estimated\", because the Kiro upstream reports credits only — without these calls both forward paths return Usage{0,0} and kiro bills as 100% free. Losing the forwarder makes every kiro request fail or bypass the enable gate; losing the estimate/BillingTier wiring silently regresses kiro to free billing."
+      "rationale": "The sixth-platform forwarder: translates /v1/messages onto the Kiro EventStream upstream and enforces the second ToS/enable gate (IsKiroEnabled). It estimates token usage locally (EstimateInputTokens/EstimateOutputTokens) and stamps ForwardResult.BillingTier=\"kiro-estimated\", because the Kiro upstream reports credits only — without these calls both forward paths return Usage{0,0} and kiro bills as 100% free. The `callErr != nil && !enc.started` guard + classifyKiroForwardError are equally load-bearing: message_start is emitted lazily (see kiro_sse_encoder ensureBlock/writeToolUse), so an upstream failure before any content arrives surfaces a typed error instead of the old empty-but-200 SSE stream (the 'pre-content 400 returns a clean 200 lie' bug). An upstream merge that drops the estimate/BillingTier wiring (regresses kiro to free billing), reintroduces an eager enc.writeMessageStart() before the upstream call, or drops the classifier, regresses one of these."
     },
     {
       "path": "backend/internal/service/kiro_sse_encoder.go",
       "must_contain": [
         "kiroSSEEncoder",
         "message_start",
-        "content_block_delta"
+        "content_block_delta",
+        "func (e *kiroSSEEncoder) ensureBlock"
       ],
-      "rationale": "Translates Kiro callbacks into the canonical Anthropic SSE event sequence. Losing it breaks streaming /v1/messages response shape for kiro accounts (clients hang or mis-parse)."
+      "rationale": "Translates Kiro callbacks into the canonical Anthropic SSE event sequence. Losing it breaks streaming /v1/messages response shape for kiro accounts (clients hang or mis-parse). ensureBlock (and writeToolUse) lazily call writeMessageStart on first content; writeMessageStart is idempotent (`if e.started { return }`). This laziness is what keeps enc.started false on a pre-content upstream 400 so the gateway service can surface the error instead of a clean empty 200 stream."
     },
     {
       "path": "backend/internal/service/gateway_service.go",
@@ -178,9 +181,19 @@
     {
       "path": "backend/internal/handler/gateway_handler.go",
       "must_contain": [
-        "account.IsKiro()"
+        "account.IsKiro()",
+        "service.KiroInvalidModelError"
       ],
-      "rationale": "The RPM-increment gate (both the streaming and non-streaming paths) admits kiro accounts via `|| account.IsKiro()`. An upstream merge that rewrites these gates must preserve the kiro arm, or kiro accounts skip RPM accounting and bypass the per-account rate limit."
+      "rationale": "The RPM-increment gate (both the streaming and non-streaming paths) admits kiro accounts via `|| account.IsKiro()`. An upstream merge that rewrites these gates must preserve the kiro arm, or kiro accounts skip RPM accounting and bypass the per-account rate limit. The KiroInvalidModelError errors.As branch returns a clean 400 invalid_request_error (no cross-account failover) when the Kiro upstream rejects the model; losing it reverts to the silent empty-200 / failover-churn behavior."
+    },
+    {
+      "path": "backend/internal/service/kiro_gateway_service_tk_errors.go",
+      "must_contain": [
+        "type KiroInvalidModelError",
+        "func classifyKiroForwardError",
+        "INVALID_MODEL_ID"
+      ],
+      "rationale": "TK-only typed error + classifier for the Kiro upstream HTTP 400 INVALID_MODEL_ID rejection. classifyKiroForwardError is called from both forwardStreaming and forwardNonStreaming; the handler errors.As-es the typed *KiroInvalidModelError to emit a model-scoped 400. Losing this file makes kiro model-unsupported errors fall back to the generic forward-error path (opaque 500 / unwanted failover)."
     },
     {
       "path": "backend/internal/service/wire.go",


### PR DESCRIPTION
**集成 PR**:把三条独立线合到一处用于本地部署 + e2e 整体走查。等价于 #554 + #557 + #556。

## 内容(4 commit)
1. `feat(admin)`:账号容量列内嵌今日用量 badge(tokens·$cost,全类型,0 灰显)— 原 #554
2. `fix(kiro)`:本地 token 估算填 Usage,billing_tier="kiro-estimated",修复 100% 0-计费 — 原 #557
3. `fix(kiro)`:ModelAvailability enum 补 kiro(ent + tk_016 DB CHECK)— 原 #556 Bug1
4. `fix(kiro)`:延迟 message_start + 类型化 400,模型不支持时停止吞成空 200 — 原 #556 Bug2

## 合并冲突解决
Line B 与 Line C 都改 `kiro_gateway_service.go`(forwardStreaming 尾部)与 `kiro.json`:
- **kiro_gateway_service.go**:两段逻辑无冲突,都保留——先本地估算 `inputTokens/outputToks`(供 `writeMessageDelta` 和 `ForwardResult.Usage`),再 lazy `enc.writeMessageStart()`(空内容流的合法收尾)。
- **kiro.json**:合并两组 sentinel anchors(estimate/BillingTier + lazy-start guard/classifier),rationale 合并。

## 验证
- 合并包 `go build ./internal/service/... ./internal/integration/kiro/... ./internal/handler/...` ✅
- 本地单测 + CI 全套(见 checks)
- 本 PR 用于本地 Stage0 部署 + e2e 真实 UI 走查

🤖 Generated with [Claude Code](https://claude.com/claude-code)