### PR TITLE
feat(kiro): self-heal kiro account priority to a baseline (hard-enforce 10)

### DIFF
--- a/backend/internal/pkg/kiro/constants.go
+++ b/backend/internal/pkg/kiro/constants.go
@@ -23,6 +23,15 @@ import (
 // internal/integration/kiro layer so both UA-building paths stay consistent.
 const UserAgentVersionEnv = "KIRO_IDE_USER_AGENT_VERSION"
 
+// DefaultKiroAccountPriority is the HARD-ENFORCED scheduler priority baseline for
+// every active kiro-platform account. The anthropic config reconciler value-syncs
+// each kiro account's priority column to this constant on every tick (skip-if-aligned),
+// so after a DB rebuild or for a newly-created kiro account, priority deterministically
+// returns to this baseline. Smaller priority wins in the scheduler; kiro rides its own
+// isolated pool and is NOT part of the anthropic window-rebalance pipeline, so this
+// kiro-scoped value-sync does not conflict with that pipeline's priority ownership.
+const DefaultKiroAccountPriority = 10
+
 // SDK version strings carried in the aws-sdk-js style User-Agent. These mirror
 // the values the real Kiro IDE emits; bump together with KiroIDEVersion when a
 // new Kiro client ships and the fingerprint is re-aligned.

--- a/backend/internal/service/anthropic_config_reconciler.go
+++ b/backend/internal/service/anthropic_config_reconciler.go
@@ -266,6 +266,11 @@ func (r *AnthropicConfigReconciler) runOnce(ctx context.Context) {
 
 	// Step tier-drift: REPORT ONLY.
 	r.reportTierDrift(accounts)
+
+	// Step kiro-priority: HARD-ENFORCE kiro account priority baseline. Fetches its
+	// own kiro account list (the list above is anthropic-only). Kiro-scoped; does
+	// not touch anthropic priority (owned by the window-rebalance pipeline).
+	r.reconcileKiroPriorityBaseline(ctx)
 }
 
 // reconcileTierConcurrency value-syncs each tier-bound anthropic OAUTH account's

--- a/backend/internal/service/anthropic_config_reconciler_test.go
+++ b/backend/internal/service/anthropic_config_reconciler_test.go
@@ -17,12 +17,13 @@ import (
 // --- stubs -------------------------------------------------------------------
 
 type reconcilerAccountStub struct {
-	accounts  []Account
-	sum       int64
-	bulkCalls []bulkUpdateCall
-	listErr   error
-	sumErr    error
-	bulkErr   error
+	accounts   []Account            // default list (back-compat for existing tests)
+	byPlatform map[string][]Account // optional per-platform override (runOnce now lists anthropic AND kiro)
+	sum        int64
+	bulkCalls  []bulkUpdateCall
+	listErr    error
+	sumErr     error
+	bulkErr    error
 }
 
 type bulkUpdateCall struct {
@@ -33,6 +34,9 @@ type bulkUpdateCall struct {
 func (s *reconcilerAccountStub) ListByPlatform(ctx context.Context, platform string) ([]Account, error) {
 	if s.listErr != nil {
 		return nil, s.listErr
+	}
+	if s.byPlatform != nil {
+		return s.byPlatform[platform], nil // absent platform → empty list
 	}
 	return s.accounts, nil
 }
@@ -426,4 +430,48 @@ func TestReconciler_BalanceFloor_DisabledByConfig(t *testing.T) {
 	r.runOnce(context.Background())
 
 	require.Empty(t, bal.setCalls, "balance floor must be a no-op when the toggle is off")
+}
+
+// --- kiro priority baseline self-heal ---------------------------------------
+
+func TestReconciler_KiroPriorityBaseline_ValueSync(t *testing.T) {
+	kiroAcct := Account{ID: 70, Name: "kiro-a", Platform: PlatformKiro, Type: AccountTypeOAuth, Priority: 3}
+	acc := &reconcilerAccountStub{byPlatform: map[string][]Account{PlatformKiro: {kiroAcct}}}
+	usr := &reconcilerUserStub{user: &User{ID: 1, Concurrency: 0}}
+	r := newTestReconciler(acc, usr, &reconcilerBalanceStub{}, mirrorEnabledCfg(false, false))
+
+	r.runOnce(context.Background())
+
+	require.Len(t, acc.bulkCalls, 1, "kiro account with priority!=10 must be value-synced")
+	require.Equal(t, []int64{70}, acc.bulkCalls[0].ids)
+	require.NotNil(t, acc.bulkCalls[0].updates.Priority)
+	require.Equal(t, 10, *acc.bulkCalls[0].updates.Priority, "kiro priority must be hard-enforced to baseline 10")
+	require.Nil(t, acc.bulkCalls[0].updates.Concurrency, "priority sync must not touch concurrency")
+}
+
+func TestReconciler_KiroPriorityBaseline_AlreadyAligned_NoWrite(t *testing.T) {
+	kiroAcct := Account{ID: 71, Name: "kiro-b", Platform: PlatformKiro, Type: AccountTypeOAuth, Priority: 10}
+	acc := &reconcilerAccountStub{byPlatform: map[string][]Account{PlatformKiro: {kiroAcct}}}
+	usr := &reconcilerUserStub{user: &User{ID: 1, Concurrency: 0}}
+	r := newTestReconciler(acc, usr, &reconcilerBalanceStub{}, mirrorEnabledCfg(false, false))
+
+	r.runOnce(context.Background())
+
+	require.Empty(t, acc.bulkCalls, "kiro account already at baseline 10 must not be written")
+}
+
+func TestReconciler_KiroPriorityBaseline_NonKiroUntouched(t *testing.T) {
+	anth := Account{ID: 72, Name: "anth", Platform: PlatformAnthropic, Type: AccountTypeOAuth, Priority: 5}
+	acc := &reconcilerAccountStub{byPlatform: map[string][]Account{
+		PlatformAnthropic: {anth},
+		// kiro absent → empty list → no kiro writes
+	}}
+	usr := &reconcilerUserStub{user: &User{ID: 1, Concurrency: 0}}
+	r := newTestReconciler(acc, usr, &reconcilerBalanceStub{}, mirrorEnabledCfg(false, false))
+
+	r.runOnce(context.Background())
+
+	for _, c := range acc.bulkCalls {
+		require.Nil(t, c.updates.Priority, "non-kiro accounts must never receive a priority value-sync")
+	}
 }

--- a/backend/internal/service/anthropic_config_reconciler_tk_kiro_priority.go
+++ b/backend/internal/service/anthropic_config_reconciler_tk_kiro_priority.go
@@ -1,0 +1,48 @@
+package service
+
+import (
+	"context"
+	"log/slog"
+
+	kiro "github.com/Wei-Shaw/sub2api/internal/pkg/kiro"
+)
+
+// reconcileKiroPriorityBaseline HARD-ENFORCES every active kiro account's priority
+// column to kiro.DefaultKiroAccountPriority (value-sync, skip-if-aligned) — the same
+// shape as Step T's tier-concurrency value-sync. This is a kiro-scoped concept: kiro
+// schedules in its own isolated pool and is NOT in the anthropic window-rebalance
+// pipeline, so writing kiro priority here does NOT violate the reconciler's rule that
+// it never writes anthropic priority. BulkUpdate auto-enqueues a scheduler_outbox
+// event so the live snapshot picks up the corrected priority.
+//
+// It lives on the anthropic-named reconciler purely to reuse its ticker + redis leader
+// lock + account store + BulkUpdate outbox path (most minimal; no new goroutine or
+// wiring). It fetches its OWN kiro account list — runOnce's list is anthropic-only.
+func (r *AnthropicConfigReconciler) reconcileKiroPriorityBaseline(ctx context.Context) {
+	if r == nil || r.accounts == nil {
+		return
+	}
+	accounts, err := r.accounts.ListByPlatform(ctx, PlatformKiro)
+	if err != nil {
+		slog.Warn("anthropic config reconciler: list kiro accounts failed (priority baseline)", "err", err)
+		return
+	}
+	const want = kiro.DefaultKiroAccountPriority
+	for i := range accounts {
+		a := &accounts[i]
+		if !a.IsKiro() { // belt-and-suspenders; ListByPlatform already filters
+			continue
+		}
+		if a.Priority == want {
+			continue // already aligned
+		}
+		w := want
+		if _, err := r.accounts.BulkUpdate(ctx, []int64{a.ID}, AccountBulkUpdate{Priority: &w}); err != nil {
+			slog.Warn("anthropic config reconciler: kiro priority baseline value-sync write failed",
+				"account_id", a.ID, "account_name", a.Name, "want", want, "err", err)
+			continue
+		}
+		slog.Info("anthropic config reconciler: kiro priority baseline value-synced (local deployment only)",
+			"account_id", a.ID, "account_name", a.Name, "priority", want)
+	}
+}

--- a/scripts/sentinels/kiro.json
+++ b/scripts/sentinels/kiro.json
@@ -14,9 +14,10 @@
       "path": "backend/internal/service/anthropic_config_reconciler.go",
       "must_contain": [
         "func mirrorCapacityPlatform",
-        "mirror_platform"
+        "mirror_platform",
+        "r.reconcileKiroPriorityBaseline(ctx)"
       ],
-      "rationale": "Prod side of surface-C: reads each mirror stub's credentials.mirror_platform (default anthropic) and queries the matching edge pool. Losing mirrorCapacityPlatform collapses the anthropic/kiro distinction so every mirror stub queries ?platform=anthropic again and a kiro stub silently mirrors the anthropic Σ."
+      "rationale": "Prod side of surface-C: reads each mirror stub's credentials.mirror_platform (default anthropic) and queries the matching edge pool. Losing mirrorCapacityPlatform collapses the anthropic/kiro distinction so every mirror stub queries ?platform=anthropic again and a kiro stub silently mirrors the anthropic Σ. The r.reconcileKiroPriorityBaseline(ctx) call in runOnce is the wiring of the kiro priority self-heal step; losing the call leaves the step defined but never run."
     },
     {
       "path": "backend/internal/repository/account_repo.go",
@@ -51,9 +52,19 @@
       "must_contain": [
         "StreamingUserAgent",
         "BuildUserAgent",
-        "DefaultKiroIDEVersion"
+        "DefaultKiroIDEVersion",
+        "DefaultKiroAccountPriority"
       ],
-      "rationale": "TK-side canonical KiroIDE client identity + User-Agent builder used for fingerprint mimicry. If dropped, kiro egress loses its KiroIDE-<ver> UA and is trivially distinguishable from the real client."
+      "rationale": "TK-side canonical KiroIDE client identity + User-Agent builder used for fingerprint mimicry. If dropped, kiro egress loses its KiroIDE-<ver> UA and is trivially distinguishable from the real client. DefaultKiroAccountPriority is the single-source baseline the config reconciler hard-enforces onto every kiro account's priority; losing it would drop the kiro priority self-heal."
+    },
+    {
+      "path": "backend/internal/service/anthropic_config_reconciler_tk_kiro_priority.go",
+      "must_contain": [
+        "func (r *AnthropicConfigReconciler) reconcileKiroPriorityBaseline",
+        "ListByPlatform(ctx, PlatformKiro)",
+        "DefaultKiroAccountPriority"
+      ],
+      "rationale": "Kiro priority baseline self-heal: value-syncs every active kiro account's priority to kiro.DefaultKiroAccountPriority each reconciler tick (kiro is in neither the tier system nor the window-rebalance pipeline). Losing this step means kiro account priority silently regresses to the 0 zero-value on DB rebuild / new account creation. The call site is guarded by the reconcileKiroPriorityBaseline anchor on anthropic_config_reconciler.go."
     },
     {
       "path": "backend/internal/integration/kiro/VENDORED_FROM.md",


### PR DESCRIPTION
## Why

The fleet's only kiro account (`kiro-us1-real`, us1) had `priority=0` — the Go zero-value default — because **kiro is managed by neither the tier system nor the window-rebalance pipeline** (both are anthropic-OAuth-only). A manual fix to 10 is **not durable**: it's lost on a DB rebuild, and any newly-created kiro account defaults back to 0. This codifies a deterministic baseline so rebuilt nodes and new kiro accounts automatically return to it.

## What

A minimal, kiro-scoped step on the **existing** `AnthropicConfigReconciler` (reusing its ticker + Redis leader lock + `BulkUpdate`):

- **`reconcileKiroPriorityBaseline`** value-syncs every active kiro account's `priority` to the baseline each tick (skip-if-aligned), mirroring Step T's tier-concurrency value-sync. `BulkUpdate` auto-enqueues the `scheduler_outbox` event so the live scheduler snapshot refreshes (same propagation the admin API uses).
- **Hard-enforce** (`priority != 10 → set 10`), as requested — so "all kiro at 10 / new accounts auto-return to 10". kiro rides its own isolated pool and is **not** in the window-rebalance pipeline, so this does **not** violate the reconciler's rule that it never writes *anthropic* priority.
- Baseline is a single-source constant `kiro.DefaultKiroAccountPriority = 10`.

### Changes
- `internal/pkg/kiro/constants.go` — `DefaultKiroAccountPriority = 10`.
- `internal/service/anthropic_config_reconciler_tk_kiro_priority.go` (new) — the step (own `ListByPlatform("kiro")` fetch; runOnce's list is anthropic-only).
- `internal/service/anthropic_config_reconciler.go` — one call at the end of `runOnce`.
- `internal/service/anthropic_config_reconciler_test.go` — stub gains optional `byPlatform` map (backward-compatible; runOnce now lists anthropic **and** kiro) + 3 unit tests.
- `scripts/sentinels/kiro.json` — new sentinel entry guarding the self-heal surface + anchors for `DefaultKiroAccountPriority` and the runOnce call site (the new surface is load-bearing; loss → silent priority regression to 0).

### Not changed
No interface change (`reconcilerAccountStore` already has `ListByPlatform`+`BulkUpdate`), no config/viper/wire change (always-on under the reconciler's interval gate; nodes with zero kiro accounts no-op on the empty list), no import cycle.

### Trade-off (acknowledged)
Hard-enforce means you can't manually set a single kiro account to a different priority (next tick reverts it). That's the requested "all kiro → 10" semantics.

## Validation
- `go build ./...` ✓
- `go test -tags unit ./internal/service/ -run TestReconciler_Kiro` ✓ (value-sync / already-aligned / non-kiro-untouched)
- `go test -tags=unit ./...` — full unit suite green ✓
- `check-kiro.py` 32/32 intact; `check-registry-update-gate.py` ✓; `bash scripts/preflight.sh` PASS

## Rollout
After merge → release/deploy: the reconciler value-syncs `kiro-us1-real` to 10 each tick (idempotent with the manual fix already applied); new/rebuilt kiro accounts auto-return to 10 within one tick. Verify on us1: `priority=10` + the `kiro priority baseline value-synced` log line.

🤖 Generated with [Claude Code](https://claude.com/claude-code)