### PR TITLE
fix(health): /health/live 与 /health/inflight 不再被 SPA fallback 遮蔽

### DIFF
--- a/backend/internal/web/embed_on.go
+++ b/backend/internal/web/embed_on.go
@@ -329,6 +329,11 @@ func shouldBypassEmbeddedFrontend(path string) bool {
 		strings.HasPrefix(trimmed, "/antigravity/") ||
 		strings.HasPrefix(trimmed, "/setup/") ||
 		trimmed == "/health" ||
+		// /health/live (docker healthcheck) 与 /health/inflight (deploy drain 轮询)
+		// 是真 JSON 探针端点，必须绕过 SPA fallback——否则被 catch-all 中间件返回
+		// index.html，deploy_via_ssm.sh 的 in_flight=0 等待会空转满 ~76s（已在
+		// prod 1.7.68 实测坐实）。见 internal/server/routes/common.go 的注册。
+		strings.HasPrefix(trimmed, "/health/") ||
 		trimmed == "/responses" ||
 		strings.HasPrefix(trimmed, "/responses/") ||
 		strings.HasPrefix(trimmed, "/images/")

--- a/backend/internal/web/embed_test.go
+++ b/backend/internal/web/embed_test.go
@@ -439,6 +439,8 @@ func TestFrontendServer_Middleware(t *testing.T) {
 			"/antigravity/test",
 			"/setup/init",
 			"/health",
+			"/health/live",
+			"/health/inflight",
 			"/responses",
 			"/responses/compact",
 		}
@@ -685,6 +687,8 @@ func TestServeEmbeddedFrontend(t *testing.T) {
 			"/antigravity/test",
 			"/setup/init",
 			"/health",
+			"/health/live",
+			"/health/inflight",
 			"/responses",
 			"/responses/compact",
 		}


### PR DESCRIPTION
## 背景
prod 单节点发版真空调研时，SSM 实测发现 **prod 1.7.68** 容器内 loopback：
- `/health` → `{"status":"ok"}` ✓
- `/health/live` → SPA HTML ✗
- `/health/inflight` → SPA HTML ✗

## 根因
`backend/internal/web/embed_on.go` 的 `shouldBypassEmbeddedFrontend()` 只精确匹配 `trimmed == "/health"`，漏了 `/health/` 子路径。SPA fallback 是**全局中间件**（`router.go` 在路由注册前 `r.Use(frontendServer.Middleware())`），未 bypass 的 `/health/live`、`/health/inflight` 被 catch-all 返回 `index.html`，永远到不了 `routes/common.go` 已正确注册的 JSON handler。两条 serving 路径（`FrontendServer.Middleware` + legacy `ServeEmbeddedFrontend`）共用此 bypass 函数。

## 影响
- **`deploy_via_ssm.sh` drain 空转**：轮询 `/health/inflight` 等 `in_flight=0`，拿到 HTML → 永远等不到 → 空转满 38×2s≈76s 才 force-recreate，每次发版真空被放大。
- **docker healthcheck 语义错位**：`/health/live` 返回 HTML（碰巧 200 仍判 healthy），liveness 探针实际探到 SPA 首页。

## 修复
bypass 列表把 `/health` 扩为覆盖 `/health/` 子树（精确 `/health` + `HasPrefix "/health/"`），与 `middleware/inflight.go` 的 `isHealthProbePath` 已用的 `/health/` 模式一致。

## 测试
`embed_test.go` 两处 `skips_api_routes` 加 `/health/live`、`/health/inflight`，`go test -tags embed` 下均 PASS。（`serves_index_*`/`serves_static` 的失败是本地占位 dist 的预存基线，已 stash 对照确认与本改动无关；CI release 构建真 dist 后通过。）

## 风险
TK 自有代码（health 端点 commit 29a9b73f 加时漏子路径），非 upstream。改动是 bypass 列表加前缀，无 API/前端影响（`no-web-impact`）。

🤖 Generated with [Claude Code](https://claude.com/claude-code)