### PR TITLE
feat(ops): remediate P0 parallel — batch SSM + parallel edges

### DIFF
--- a/.cursor/skills/tokenkey-anthropic-oauth-config/SKILL.md
+++ b/.cursor/skills/tokenkey-anthropic-oauth-config/SKILL.md
@@ -91,9 +91,12 @@ python3 $MGR apply  --plan $JOBDIR/plan-guard-drift-fix.json \
   --confirm yes-apply-anthropic-config-cascade --sync-runtime
 python3 $MGR verify --plan $JOBDIR/plan-guard-drift-fix.json     # drift_count 必须=0
 #   3b) 或一键：snapshot → check → plan → apply(--sync-runtime) → verify → check
+#   默认 P0 加速：每 edge 1 次 SSM bundle snapshot + 1 次 batch guard；跨 edge 并行
+#   （--parallel-edges N，默认 6）；apply/sync-runtime 按 instance 分组并行。
 python3 $MGR remediate-guard-drift \
   --confirm yes-apply-anthropic-config-cascade \
   --job-dir $JOBDIR/remediate
+# 回退旧路径（慢）：加 --legacy-guard，snapshot/guard 仍并行但 guard 恢复 1+N SSM/edge
 
 # Stage 4 — HTTP UA / mimicry 运行时同步（settings + Redis 指纹缓存）
 # UA semver + mimicry manifest 默认从 deploy/aws/stage0/anthropic-http-mimicry-baselines.json 解析

--- a/ops/anthropic/check-edge-oauth-stability.py
+++ b/ops/anthropic/check-edge-oauth-stability.py
@@ -383,6 +383,112 @@ SELECT jsonb_pretty(jsonb_build_object(
 """.strip()
 
 
+def _guard_live_payload_object_sql(*, target_from: str) -> str:
+    """JSON object for one OAuth account row; ``target_from`` is a FROM clause source
+    (e.g. ``target`` CTE, or ``(SELECT * FROM accounts WHERE id = t.id) target``)."""
+    return f"""
+jsonb_build_object(
+  'found', EXISTS(SELECT 1 FROM {target_from}),
+  'account', (
+    SELECT CASE WHEN COUNT(*) = 0 THEN NULL ELSE jsonb_build_object(
+      'id', max(id),
+      'name', max(name),
+      'platform', max(platform),
+      'type', max(type),
+      'proxy_id', max(proxy_id),
+      'concurrency', max(concurrency),
+      'load_factor', max(load_factor),
+      'priority', max(priority),
+      'rate_multiplier', max(rate_multiplier),
+      'auto_pause_on_expired', bool_or(auto_pause_on_expired),
+      'channel_type', max(channel_type),
+      'stability_tier', max(NULLIF(extra->>'stability_tier', '')),
+      'status', max(status),
+      'error_message', max(error_message),
+      'last_used_at', max(last_used_at)
+    ) END
+    FROM {target_from}
+  ),
+  'credentials', (
+    SELECT COALESCE(jsonb_object_agg(key, value ORDER BY key), '{{}}'::jsonb)
+    FROM {target_from}, jsonb_each(credentials)
+    WHERE key IN (
+      'intercept_warmup_requests',
+      'temp_unschedulable_enabled',
+      'temp_unschedulable_rules'
+    )
+  ),
+  'extra', (
+    SELECT COALESCE(jsonb_object_agg(key, value ORDER BY key), '{{}}'::jsonb)
+    FROM {target_from}, jsonb_each(extra)
+    WHERE key IN (
+      'enable_tls_fingerprint',
+      'tls_fingerprint_profile_id',
+      'base_rpm',
+      'rpm_strategy',
+      'rpm_sticky_buffer',
+      'user_msg_queue_mode',
+      'max_sessions',
+      'session_idle_timeout_minutes',
+      'session_id_masking_enabled',
+      'cache_ttl_override_enabled',
+      'cache_ttl_override_target',
+      'window_cost_limit',
+      'window_cost_sticky_reserve',
+      'custom_base_url_enabled',
+      'custom_base_url'
+    )
+  ),
+  'groups', (
+    SELECT jsonb_build_object(
+      'ids', COALESCE(jsonb_agg(g.id ORDER BY g.id), '[]'::jsonb),
+      'names', COALESCE(jsonb_agg(g.name ORDER BY g.name), '[]'::jsonb)
+    )
+    FROM {target_from} t
+    LEFT JOIN account_groups ag ON ag.account_id = t.id
+    LEFT JOIN groups g ON g.id = ag.group_id
+    WHERE g.id IS NOT NULL
+  ),
+  'tls_profile', (
+    SELECT CASE WHEN p.id IS NULL THEN NULL ELSE jsonb_build_object(
+      'name', p.name,
+      'description', p.description,
+      'enable_grease', p.enable_grease,
+      'cipher_suites', COALESCE(p.cipher_suites, '[]'::jsonb),
+      'curves', COALESCE(p.curves, '[]'::jsonb),
+      'point_formats', COALESCE(p.point_formats, '[]'::jsonb),
+      'signature_algorithms', COALESCE(p.signature_algorithms, '[]'::jsonb),
+      'alpn_protocols', COALESCE(p.alpn_protocols, '[]'::jsonb),
+      'supported_versions', COALESCE(p.supported_versions, '[]'::jsonb),
+      'key_share_groups', COALESCE(p.key_share_groups, '[]'::jsonb),
+      'psk_modes', COALESCE(p.psk_modes, '[]'::jsonb),
+      'extensions', COALESCE(p.extensions, '[]'::jsonb)
+    ) END
+    FROM {target_from} t
+    LEFT JOIN tls_fingerprint_profiles p
+      ON p.id = NULLIF(t.extra->>'tls_fingerprint_profile_id', '')::bigint
+  )
+)
+""".strip()
+
+
+def build_all_oauth_guard_live_batch_query() -> str:
+    """One round-trip: live guard payload for every anthropic OAuth account on the node."""
+    payload = _guard_live_payload_object_sql(
+        target_from="(SELECT * FROM accounts WHERE id = t.id) target"
+    )
+    return f"""
+SELECT COALESCE(jsonb_agg(
+  jsonb_build_object('account_name', t.name) || ({payload}),
+  '[]'::jsonb
+)
+FROM accounts t
+WHERE t.platform = 'anthropic'
+  AND t.type = 'oauth'
+  AND t.deleted_at IS NULL;
+""".strip()
+
+
 def run_remote_query(edge: dict[str, Any], instance_id: str, sql: str, *, comment: str) -> tuple[str, str]:
     remote = "sudo docker exec -i tokenkey-postgres psql -U tokenkey -d tokenkey -t -A -v ON_ERROR_STOP=1"
     command = f"set -euo pipefail\n{remote} <<'SQL'\n{sql}\nSQL"

--- a/ops/anthropic/check-edge-oauth-stability.py
+++ b/ops/anthropic/check-edge-oauth-stability.py
@@ -384,8 +384,13 @@ SELECT jsonb_pretty(jsonb_build_object(
 
 
 def _guard_live_payload_object_sql(*, target_from: str) -> str:
-    """JSON object for one OAuth account row; ``target_from`` is a FROM clause source
-    (e.g. ``target`` CTE, or ``(SELECT * FROM accounts WHERE id = t.id) target``)."""
+    """JSON object for one OAuth account row.
+
+    ``target_from`` must be a single relation NAME that is safe to re-alias —
+    fragments here do both ``FROM {target_from}`` and ``FROM {target_from} t``,
+    so an already-aliased subquery (``(SELECT …) target``) would double-alias.
+    Pass a CTE name (``target``): the per-account ``build_live_query`` and the
+    batch ``build_all_oauth_guard_live_batch_query`` both bind one that way."""
     return f"""
 jsonb_build_object(
   'found', EXISTS(SELECT 1 FROM {target_from}),

--- a/ops/anthropic/check-edge-oauth-stability.py
+++ b/ops/anthropic/check-edge-oauth-stability.py
@@ -473,19 +473,25 @@ jsonb_build_object(
 
 
 def build_all_oauth_guard_live_batch_query() -> str:
-    """One round-trip: live guard payload for every anthropic OAuth account on the node."""
-    payload = _guard_live_payload_object_sql(
-        target_from="(SELECT * FROM accounts WHERE id = t.id) target"
-    )
+    """One round-trip: live guard payload for every anthropic OAuth account on the node.
+
+    Per row we bind a correlated ``target`` CTE (same name the payload fragments
+    reference), mirroring the single-account ``build_live_query`` shape so the
+    shared ``_guard_live_payload_object_sql`` projection stays valid verbatim.
+    """
+    payload = _guard_live_payload_object_sql(target_from="target")
     return f"""
 SELECT COALESCE(jsonb_agg(
-  jsonb_build_object('account_name', t.name) || ({payload}),
-  '[]'::jsonb
-)
-FROM accounts t
-WHERE t.platform = 'anthropic'
-  AND t.type = 'oauth'
-  AND t.deleted_at IS NULL;
+  jsonb_build_object('account_name', a.name) || (
+    WITH target AS (SELECT * FROM accounts WHERE id = a.id)
+    SELECT {payload}
+  )
+  ORDER BY a.name
+), '[]'::jsonb)
+FROM accounts a
+WHERE a.platform = 'anthropic'
+  AND a.type = 'oauth'
+  AND a.deleted_at IS NULL;
 """.strip()
 
 

--- a/ops/anthropic/manage-anthropic-config.py
+++ b/ops/anthropic/manage-anthropic-config.py
@@ -64,6 +64,8 @@ Guard-drift remediation (replaces manual plan-tier-bump × N + merge):
                          account whose guard status is ``drift``
   remediate-guard-drift — snapshot → check → plan-guard-drift-fix → apply
                           (--sync-runtime) → verify → check
+                          (P0: bundle snapshot + batch guard + parallel edges;
+                          --parallel-edges N default 6; --legacy-guard for旧路径)
 
 History
 -------
@@ -124,7 +126,9 @@ import pathlib
 import re
 import subprocess
 import sys
-from typing import Any
+from collections import defaultdict
+from concurrent.futures import ThreadPoolExecutor, as_completed
+from typing import Any, Callable
 
 REPO_ROOT = pathlib.Path(__file__).resolve().parents[2]
 EDGE_MATRIX = REPO_ROOT / "deploy/aws/stage0/edge-targets.json"
@@ -215,6 +219,7 @@ SNAPSHOT_VERSION = 7
 # (all types incl. api-key) on that same DB — avoids drift when Anthropic pool sizing changes.
 
 ADMIN_OPERATOR_USER_CONCURRENCY_SYNC_ID = 1
+DEFAULT_PARALLEL_EDGES = 6
 
 
 # --------------------------------------------------------------------------
@@ -439,6 +444,39 @@ def ssm_run_shell(region: str, instance_id: str, shell_script: str, comment: str
     return stdout, cid, success, stderr
 
 
+def _parallel_edges_workers(requested: int | None) -> int:
+    if requested is None or requested < 1:
+        return DEFAULT_PARALLEL_EDGES
+    return requested
+
+
+def _run_parallel_ordered(
+    items: list[Any],
+    fn: Callable[[Any], Any],
+    workers: int,
+    *,
+    label: str,
+) -> list[Any]:
+    """Run ``fn`` over ``items`` with a thread pool; return results in input order."""
+    if not items:
+        return []
+    if workers <= 1 or len(items) == 1:
+        return [fn(item) for item in items]
+    workers = min(workers, len(items))
+    out: list[Any | None] = [None] * len(items)
+    with ThreadPoolExecutor(max_workers=workers) as pool:
+        futures = {pool.submit(fn, item): idx for idx, item in enumerate(items)}
+        for fut in as_completed(futures):
+            idx = futures[fut]
+            try:
+                out[idx] = fut.result()
+            except SystemExit:
+                raise
+            except Exception as exc:
+                fail(f"{label} parallel task {idx} failed: {exc}")
+    return out  # type: ignore[return-value]
+
+
 # --------------------------------------------------------------------------
 # Runtime sync (settings UA + Redis fingerprint cache)
 # --------------------------------------------------------------------------
@@ -590,37 +628,54 @@ def _deployable_edge_targets_from_snapshot(snap: dict) -> list[str]:
     return out
 
 
+def _runtime_sync_one_target(
+    target: str,
+    ua_version: str,
+    job_dir: pathlib.Path | None,
+    *,
+    mimicry_manifest_json: str | None,
+) -> dict[str, Any]:
+    label, region, instance_id = _resolve_runtime_sync_target(target)
+    shell = render_runtime_sync_shell(ua_version, mimicry_manifest_json)
+    if job_dir is not None:
+        safe = target.replace(":", "-")
+        (job_dir / f"sync-runtime-{safe}.sh").write_text(shell)
+    stdout, cid, ok, stderr = ssm_run_shell(
+        region, instance_id, shell,
+        f"sync-runtime {label} ua={ua_version}",
+    )
+    if not ok:
+        print(f"sync-runtime: FAILED on {label} cid={cid}", file=sys.stderr)
+    return {
+        "target": target,
+        "target_label": label,
+        "ssm_command_id": cid,
+        "ok": ok,
+        "stdout_preview": stdout[-1200:],
+        "stderr_preview": stderr,
+    }
+
+
 def _run_runtime_sync(
     targets: list[str],
     ua_version: str,
     job_dir: pathlib.Path | None,
     *,
     mimicry_manifest_json: str | None = None,
+    parallel_edges: int | None = None,
 ) -> tuple[bool, list[dict]]:
-    results: list[dict] = []
-    ok_all = True
-    for target in targets:
-        label, region, instance_id = _resolve_runtime_sync_target(target)
-        shell = render_runtime_sync_shell(ua_version, mimicry_manifest_json)
-        if job_dir is not None:
-            safe = target.replace(":", "-")
-            (job_dir / f"sync-runtime-{safe}.sh").write_text(shell)
-        stdout, cid, ok, stderr = ssm_run_shell(
-            region, instance_id, shell,
-            f"sync-runtime {label} ua={ua_version}",
+    if not targets:
+        return True, []
+    workers = _parallel_edges_workers(parallel_edges)
+    print(f"sync-runtime: {len(targets)} target(s) parallel_workers={workers}", file=sys.stderr)
+
+    def _work(target: str) -> dict[str, Any]:
+        return _runtime_sync_one_target(
+            target, ua_version, job_dir, mimicry_manifest_json=mimicry_manifest_json,
         )
-        results.append({
-            "target": target,
-            "target_label": label,
-            "ssm_command_id": cid,
-            "ok": ok,
-            "stdout_preview": stdout[-1200:],
-            "stderr_preview": stderr,
-        })
-        if not ok:
-            ok_all = False
-            print(f"sync-runtime: FAILED on {label} cid={cid}", file=sys.stderr)
-            break
+
+    results = _run_parallel_ordered(targets, _work, workers, label="sync-runtime")
+    ok_all = all(r.get("ok") for r in results)
     return ok_all, results
 
 
@@ -670,7 +725,11 @@ def cmd_sync_runtime(args: argparse.Namespace) -> int:
         job_dir.mkdir(parents=True, exist_ok=True)
     manifest_json = _http_mimicry_manifest_json()
     ok, results = _run_runtime_sync(
-        targets, ua_version, job_dir, mimicry_manifest_json=manifest_json,
+        targets,
+        ua_version,
+        job_dir,
+        mimicry_manifest_json=manifest_json,
+        parallel_edges=getattr(args, "parallel_edges", None),
     )
     report = {
         "version": 1,
@@ -859,6 +918,140 @@ def _read_operator_balance(region: str, instance_id: str, label: str) -> dict:
     }
 
 
+def _sql_select_body(sql: str) -> str:
+    """Strip the leading SELECT so the fragment can sit inside jsonb_build_object."""
+    body = sql.strip()
+    if body.upper().startswith("SELECT "):
+        return body[7:].strip()
+    return body
+
+
+EDGE_CAPTURE_BUNDLE_SQL = f"""
+SELECT jsonb_build_object(
+  'oauth_accounts', ({_sql_select_body(EDGE_ACCOUNTS_SQL)}),
+  'anthropic_groups', ({_sql_select_body(ANTHROPIC_GROUPS_SQL)}),
+  'tiers', ({_sql_select_body(TIERS_SQL)}),
+  'operator_concurrency', ({_sql_select_body(OPERATOR_CONCURRENCY_SQL)}),
+  'operator_balance', ({_sql_select_body(OPERATOR_BALANCE_SQL)})
+);
+""".strip()
+
+PROD_CAPTURE_BUNDLE_SQL = f"""
+SELECT jsonb_build_object(
+  'anthropic_stubs', ({_sql_select_body(PROD_STUBS_SQL)}),
+  'anthropic_groups', ({_sql_select_body(ANTHROPIC_GROUPS_SQL)}),
+  'tiers', ({_sql_select_body(TIERS_SQL)}),
+  'operator_concurrency', ({_sql_select_body(OPERATOR_CONCURRENCY_SQL)})
+);
+""".strip()
+
+
+def _parse_operator_balance_obj(obj: dict) -> dict:
+    bal = obj.get("operator_user_balance")
+    if bal is not None:
+        try:
+            bal = float(bal)
+        except (TypeError, ValueError):
+            bal = None
+    return {
+        "operator_user_balance": bal,
+        "operator_user_exists": bool(obj.get("operator_user_exists")),
+    }
+
+
+def _capture_edge_bundle(
+    eid: str,
+    ident: Any,
+    *,
+    ec2_stack: str,
+) -> dict[str, Any]:
+    """One SSM round-trip per edge for snapshot fields."""
+    raw, _ = ssm_run_sql(
+        ident.region,
+        ident.instance_id,
+        EDGE_CAPTURE_BUNDLE_SQL,
+        f"snapshot bundle: edge {eid}",
+    )
+    try:
+        bundle = json.loads(raw) if raw else {}
+    except json.JSONDecodeError:
+        bundle = {}
+    op = bundle.get("operator_concurrency") or {}
+    bal = _parse_operator_balance_obj(bundle.get("operator_balance") or {})
+    tiers_raw = bundle.get("tiers")
+    return {
+        "deployable": True,
+        "instance_id": ident.instance_id,
+        "region": ident.region,
+        "stack": ident.ec2_stack or ec2_stack or "",
+        "domain": ident.domain,
+        "ssm_routing": ident.routing,
+        "oauth_accounts": bundle.get("oauth_accounts") or [],
+        "anthropic_groups": bundle.get("anthropic_groups") or [],
+        "tiers": tiers_raw if isinstance(tiers_raw, list) else [],
+        "operator_user_concurrency": op.get("operator_user_concurrency"),
+        "schedulable_concurrency_sum": op.get("schedulable_concurrency_sum"),
+        "operator_user_balance": bal["operator_user_balance"],
+        "operator_user_exists": bal["operator_user_exists"],
+    }
+
+
+def _capture_prod_bundle(region: str, prod_inst: str) -> dict[str, Any]:
+    raw, _ = ssm_run_sql(
+        region,
+        prod_inst,
+        PROD_CAPTURE_BUNDLE_SQL,
+        "snapshot bundle: prod",
+    )
+    try:
+        bundle = json.loads(raw) if raw else {}
+    except json.JSONDecodeError:
+        bundle = {}
+    op = bundle.get("operator_concurrency") or {}
+    tiers_raw = bundle.get("tiers")
+    return {
+        "instance_id": prod_inst,
+        "region": region,
+        "stack": PROD_TARGET["stack"],
+        "domain": PROD_TARGET["domain"],
+        "anthropic_stubs": bundle.get("anthropic_stubs") or [],
+        "anthropic_groups": bundle.get("anthropic_groups") or [],
+        "tiers": tiers_raw if isinstance(tiers_raw, list) else [],
+        "operator_user_concurrency": op.get("operator_user_concurrency"),
+        "schedulable_concurrency_sum": op.get("schedulable_concurrency_sum"),
+    }
+
+
+def _snapshot_edge_task(task: tuple[str, dict | None, dict | None, bool, bool]) -> tuple[str, dict]:
+    """Worker for parallel snapshot: (eid, ec2_t, ls_t, deploy, allow_planned)."""
+    eid, ec2_t, ls_t, deploy, allow_planned = task
+    region = (ec2_t or {}).get("region") or (ls_t or {}).get("lightsail_region")
+    stack = (ec2_t or {}).get("stack") or ""
+    if not deploy and not allow_planned:
+        return eid, {
+            "deployable": False,
+            "skipped_reason": f"edge {eid} is planned; pass --allow-planned to include",
+            "region": region,
+            "stack": stack,
+        }
+    if not deploy and allow_planned:
+        return eid, {
+            "deployable": False,
+            "skipped_reason": f"edge {eid} is planned (--allow-planned)",
+            "region": region,
+            "stack": stack,
+        }
+    try:
+        ident = _EDGE_SSM.resolve_edge_execution_identity(REPO_ROOT, eid)
+    except SystemExit:
+        return eid, {"error": f"could not resolve SSM instance for edge {eid}"}
+    print(
+        f"snapshot: edge {eid} instance={ident.instance_id} routing={ident.routing} (bundle)",
+        file=sys.stderr,
+    )
+    return eid, _capture_edge_bundle(eid, ident, ec2_stack=stack)
+
+
 def cmd_snapshot(args: argparse.Namespace) -> int:
     edge_matrix = load_json_file(EDGE_MATRIX, "edge matrix")
     ls_targets = _EDGE_ROUTING.load_lightsail_targets(REPO_ROOT)
@@ -866,62 +1059,19 @@ def cmd_snapshot(args: argparse.Namespace) -> int:
 
     edges: dict[str, dict] = {}
     merged = _EDGE_ROUTING.merged_edge_ids(edge_matrix, ls_targets)
-
+    workers = _parallel_edges_workers(getattr(args, "parallel_edges", None))
+    tasks: list[tuple[str, dict | None, dict | None, bool, bool]] = []
     for eid in merged:
         ec2_t = ec2_targets.get(eid)
         ls_t = ls_targets.get(eid)
         deploy = _EDGE_ROUTING.edge_effective_deployable(ec2_t, ls_t)
-        if not deploy and not args.allow_planned:
-            edges[eid] = {
-                "deployable": False,
-                "skipped_reason": f"edge {eid} is planned; pass --allow-planned to include",
-                "region": (ec2_t or {}).get("region") or (ls_t or {}).get("lightsail_region"),
-                "stack": (ec2_t or {}).get("stack") or "",
-            }
-            continue
-        if not deploy and args.allow_planned:
-            edges[eid] = {
-                "deployable": False,
-                "skipped_reason": f"edge {eid} is planned (--allow-planned)",
-                "region": (ec2_t or {}).get("region") or (ls_t or {}).get("lightsail_region"),
-                "stack": (ec2_t or {}).get("stack") or "",
-            }
-            continue
-        try:
-            ident = _EDGE_SSM.resolve_edge_execution_identity(REPO_ROOT, eid)
-        except SystemExit:
-            edges[eid] = {"error": f"could not resolve SSM instance for edge {eid}"}
-            continue
-        print(
-            f"snapshot: edge {eid} instance={ident.instance_id} routing={ident.routing}",
-            file=sys.stderr,
-        )
-        accts_raw, _ = ssm_run_sql(
-            ident.region, ident.instance_id, EDGE_ACCOUNTS_SQL,
-            f"snapshot: edge {eid} oauth accounts",
-        )
-        groups_raw, _ = ssm_run_sql(
-            ident.region, ident.instance_id, ANTHROPIC_GROUPS_SQL,
-            f"snapshot: edge {eid} anthropic groups",
-        )
-        op = _read_operator_concurrency(ident.region, ident.instance_id, f"edge {eid}")
-        bal = _read_operator_balance(ident.region, ident.instance_id, f"edge {eid}")
-        tiers = _read_tiers(ident.region, ident.instance_id, f"edge {eid}")
-        edges[eid] = {
-            "deployable": True,
-            "instance_id": ident.instance_id,
-            "region": ident.region,
-            "stack": ident.ec2_stack or (ec2_t or {}).get("stack") or "",
-            "domain": ident.domain,
-            "ssm_routing": ident.routing,
-            "oauth_accounts": json.loads(accts_raw) if accts_raw else [],
-            "anthropic_groups": json.loads(groups_raw) if groups_raw else [],
-            "tiers": tiers,
-            "operator_user_concurrency": op["operator_user_concurrency"],
-            "schedulable_concurrency_sum": op["schedulable_concurrency_sum"],
-            "operator_user_balance": bal["operator_user_balance"],
-            "operator_user_exists": bal["operator_user_exists"],
-        }
+        tasks.append((eid, ec2_t, ls_t, deploy, bool(args.allow_planned)))
+    if tasks:
+        print(f"snapshot: {len(tasks)} edge(s) parallel_workers={workers}", file=sys.stderr)
+        for eid, edge in _run_parallel_ordered(
+            tasks, _snapshot_edge_task, workers, label="snapshot",
+        ):
+            edges[eid] = edge
 
     prod_view: dict[str, Any]
     if getattr(args, "skip_prod", False):
@@ -929,26 +1079,8 @@ def cmd_snapshot(args: argparse.Namespace) -> int:
     else:
         try:
             prod_inst = resolve_instance_id(PROD_TARGET["region"], PROD_TARGET["stack"])
-            print(f"snapshot: prod instance={prod_inst}", file=sys.stderr)
-            stubs_raw, _ = ssm_run_sql(PROD_TARGET["region"], prod_inst, PROD_STUBS_SQL,
-                                        "snapshot: prod anthropic stubs")
-            groups_raw, _ = ssm_run_sql(
-                PROD_TARGET["region"], prod_inst, ANTHROPIC_GROUPS_SQL,
-                "snapshot: prod anthropic groups",
-            )
-            prod_op = _read_operator_concurrency(PROD_TARGET["region"], prod_inst, "prod")
-            prod_tiers = _read_tiers(PROD_TARGET["region"], prod_inst, "prod")
-            prod_view = {
-                "instance_id": prod_inst,
-                "region": PROD_TARGET["region"],
-                "stack": PROD_TARGET["stack"],
-                "domain": PROD_TARGET["domain"],
-                "anthropic_stubs": json.loads(stubs_raw) if stubs_raw else [],
-                "anthropic_groups": json.loads(groups_raw) if groups_raw else [],
-                "tiers": prod_tiers,
-                "operator_user_concurrency": prod_op["operator_user_concurrency"],
-                "schedulable_concurrency_sum": prod_op["schedulable_concurrency_sum"],
-            }
+            print(f"snapshot: prod instance={prod_inst} (bundle)", file=sys.stderr)
+            prod_view = _capture_prod_bundle(PROD_TARGET["region"], prod_inst)
         except SystemExit:
             print("snapshot: prod failed to resolve instance (skipping prod view; "
                   "plan-stub-pool will fail-loud if invoked)", file=sys.stderr)
@@ -1321,7 +1453,12 @@ def _run_http_ua_checks_live(edge_ids: list[str], expected: dict) -> list[dict]:
 def cmd_check(args: argparse.Namespace) -> int:
     snapshot = load_json_file(pathlib.Path(args.snapshot), "snapshot") if args.snapshot else None
     edge_ids = _edge_ids_for_check(snapshot, bool(args.allow_planned))
-    report = _run_check_guards(edge_ids, bool(args.allow_planned))
+    report = _run_check_guards(
+        edge_ids,
+        bool(args.allow_planned),
+        parallel_edges=getattr(args, "parallel_edges", None),
+        legacy_guard=bool(getattr(args, "legacy_guard", False)),
+    )
     policy = _load_operator_balance_policy()
     if snapshot is not None:
         if snapshot.get("version") != SNAPSHOT_VERSION:
@@ -1410,15 +1547,165 @@ def _edge_ids_for_check(snapshot: dict | None, allow_planned: bool) -> list[str]
     return _EDGE_ROUTING.iter_effective_deployable_edge_ids(edge_matrix, ls_targets)
 
 
-def _run_check_guards(edge_ids: list[str], allow_planned: bool) -> dict:
-    sub_results: list[dict] = []
-    for eid in edge_ids:
-        sub_results.append(_run_guard(
+def _guard_items_from_batch(
+    edge_id: str,
+    edge_meta: dict[str, Any],
+    batch_rows: list[Any],
+    baseline: dict[str, Any],
+    *,
+    default_tier: str = "",
+) -> list[dict[str, Any]]:
+    items: list[dict[str, Any]] = []
+    if not batch_rows:
+        items.append({
+            "edge": {**edge_meta},
+            "account_name": "all",
+            "status": "ok",
+            "diff_count": 0,
+            "diffs": [],
+            "accounts_found": 0,
+            "sql_path": None,
+        })
+        return items
+    for row in batch_rows:
+        if not isinstance(row, dict):
+            continue
+        account_name = str(
+            row.get("account_name") or (row.get("account") or {}).get("name") or ""
+        ).strip()
+        live = {k: v for k, v in row.items() if k != "account_name"}
+        try:
+            effective = _GUARD.resolve_effective_baseline(
+                baseline,
+                live,
+                edge_id=edge_id,
+                account_name=account_name,
+                default_tier=default_tier,
+            )
+            diffs = _GUARD.compare_live_to_baseline(live, effective)
+            items.append({
+                "edge": {**edge_meta},
+                "account_name": account_name,
+                "account_stability_tier": (live.get("account") or {}).get("stability_tier"),
+                "baseline_tier": effective.get("selected_tier"),
+                "tier_source": effective.get("tier_source"),
+                "status": "ok" if not diffs else "drift",
+                "diff_count": len(diffs),
+                "diffs": diffs,
+                "sql_path": None,
+            })
+        except _GUARD.CheckError as exc:
+            items.append({
+                "edge": {**edge_meta},
+                "account_name": account_name,
+                "status": "error",
+                "diff_count": 0,
+                "diffs": [],
+                "error_message": exc.args[0] if exc.args else "unknown error",
+                "sql_path": None,
+            })
+    return items
+
+
+def _run_guard_batch_for_edge(eid: str, allow_planned: bool) -> dict[str, Any]:
+    """One SSM round-trip per edge; local compare (same semantics as guard --account-name all)."""
+    baseline = load_json_file(TIER_BASELINES, "tier baseline")
+    try:
+        ident = _EDGE_SSM.resolve_edge_execution_identity(REPO_ROOT, eid)
+    except SystemExit:
+        return {
+            "exit_code": 2,
+            "description": f"edge-oauth-stability edge={eid}",
+            "report": None,
+        }
+    raw, cid = ssm_run_sql(
+        ident.region,
+        ident.instance_id,
+        _GUARD.build_all_oauth_guard_live_batch_query(),
+        f"guard batch edge={eid}",
+    )
+    try:
+        batch_rows = json.loads(raw) if raw else []
+    except json.JSONDecodeError:
+        batch_rows = []
+    if not isinstance(batch_rows, list):
+        batch_rows = []
+    edge_meta = {
+        "edge_id": eid,
+        "region": ident.region,
+        "instance_id": ident.instance_id,
+        "allow_planned": allow_planned,
+    }
+    items = _guard_items_from_batch(eid, edge_meta, batch_rows, baseline)
+    drift_count = sum(1 for x in items if x.get("status") == "drift")
+    error_count = sum(1 for x in items if x.get("status") == "error")
+    exit_code = 1 if drift_count or error_count else 0
+    report = {
+        "mode": "batch",
+        "selector": {
+            "edge_id": eid,
+            "account_name": "all",
+            "allow_planned": allow_planned,
+        },
+        "summary": {
+            "edge_total": 1,
+            "excluded_edge_total": 0,
+            "account_result_total": len(items),
+            "ok_count": sum(1 for x in items if x.get("status") == "ok"),
+            "drift_count": drift_count,
+            "error_count": error_count,
+        },
+        "excluded_edges": [],
+        "items": items,
+        "ssm_command_id": cid,
+    }
+    return {
+        "exit_code": exit_code,
+        "description": f"edge-oauth-stability edge={eid}",
+        "report": report,
+    }
+
+
+def _run_check_guards(
+    edge_ids: list[str],
+    allow_planned: bool,
+    *,
+    parallel_edges: int | None = None,
+    legacy_guard: bool = False,
+) -> dict:
+    workers = _parallel_edges_workers(parallel_edges)
+
+    def _legacy_one(eid: str) -> dict[str, Any]:
+        return _run_guard(
             ["python3", str(OPS_DIR / "check-edge-oauth-stability.py"),
              "--edge-id", eid, "--account-name", "all", "--json"]
             + (["--allow-planned"] if allow_planned else []),
             f"edge-oauth-stability edge={eid}",
-        ))
+        )
+
+    def _batch_one(eid: str) -> dict[str, Any]:
+        return _run_guard_batch_for_edge(eid, allow_planned)
+
+    if legacy_guard:
+        print(
+            f"check-guards: legacy subprocess {len(edge_ids)} edge(s) "
+            f"parallel_workers={workers}",
+            file=sys.stderr,
+        )
+        sub_results = _run_parallel_ordered(
+            edge_ids, _legacy_one, workers, label="guard-legacy",
+        )
+        guard_mode = "legacy-subprocess"
+    else:
+        print(
+            f"check-guards: batch-ssm {len(edge_ids)} edge(s) parallel_workers={workers}",
+            file=sys.stderr,
+        )
+        sub_results = _run_parallel_ordered(
+            edge_ids, _batch_one, workers, label="guard-batch",
+        )
+        guard_mode = "batch-ssm"
+
     any_violation = any(sr.get("exit_code", 0) not in (0, None) for sr in sub_results)
     return {
         "version": 2,
@@ -1426,6 +1713,7 @@ def _run_check_guards(edge_ids: list[str], allow_planned: bool) -> dict:
         "edges_in_scope": edge_ids,
         "any_violation": any_violation,
         "guards": sub_results,
+        "guard_mode": guard_mode,
     }
 
 
@@ -1470,7 +1758,12 @@ def cmd_plan_guard_drift_fix(args: argparse.Namespace) -> int:
         check_report = load_json_file(pathlib.Path(args.check_report), "check report")
     else:
         edge_ids = _edge_ids_for_check(snap, bool(args.allow_planned))
-        check_report = _run_check_guards(edge_ids, bool(args.allow_planned))
+        check_report = _run_check_guards(
+            edge_ids,
+            bool(args.allow_planned),
+            parallel_edges=getattr(args, "parallel_edges", None),
+            legacy_guard=bool(getattr(args, "legacy_guard", False)),
+        )
     drift_accounts = _iter_guard_drift_accounts(check_report)
     tiers = _load_tier_baselines()
     actions: list[dict] = []
@@ -1536,16 +1829,30 @@ def cmd_remediate_guard_drift(args: argparse.Namespace) -> int:
     check_path = job_dir / "check.json"
     plan_path = job_dir / "plan-guard-drift-fix.json"
 
-    print(f"remediate: job_dir={job_dir}", file=sys.stderr)
+    parallel = getattr(args, "parallel_edges", None)
+    legacy_guard = bool(getattr(args, "legacy_guard", False))
+    print(
+        f"remediate: job_dir={job_dir} parallel_edges={_parallel_edges_workers(parallel)} "
+        f"guard_mode={'legacy-subprocess' if legacy_guard else 'batch-ssm'}",
+        file=sys.stderr,
+    )
     rc = cmd_snapshot(argparse.Namespace(
-        out=str(snap_path), allow_planned=args.allow_planned, skip_prod=False,
+        out=str(snap_path),
+        allow_planned=args.allow_planned,
+        skip_prod=False,
+        parallel_edges=parallel,
     ))
     if rc != 0:
         return rc
 
     snap = load_json_file(snap_path, "snapshot")
     edge_ids = _edge_ids_for_check(snap, bool(args.allow_planned))
-    check_report = _run_check_guards(edge_ids, bool(args.allow_planned))
+    check_report = _run_check_guards(
+        edge_ids,
+        bool(args.allow_planned),
+        parallel_edges=parallel,
+        legacy_guard=legacy_guard,
+    )
     check_path.write_text(json.dumps(check_report, indent=2, ensure_ascii=False))
     if not check_report.get("any_violation"):
         print("remediate: check clean — nothing to apply", file=sys.stderr)
@@ -1582,6 +1889,7 @@ def cmd_remediate_guard_drift(args: argparse.Namespace) -> int:
         sync_runtime=not args.skip_runtime_sync,
         skip_prod_runtime_sync=args.skip_prod_runtime_sync,
         sync_runtime_ua_version=None,
+        parallel_edges=parallel,
     ))
     if rc != 0:
         return rc
@@ -1592,11 +1900,17 @@ def cmd_remediate_guard_drift(args: argparse.Namespace) -> int:
         allow_planned=args.allow_planned,
         skip_prod=False,
         json=False,
+        parallel_edges=parallel,
     ))
     if rc != 0:
         return rc
 
-    final_check = _run_check_guards(edge_ids, bool(args.allow_planned))
+    final_check = _run_check_guards(
+        edge_ids,
+        bool(args.allow_planned),
+        parallel_edges=parallel,
+        legacy_guard=legacy_guard,
+    )
     (job_dir / "check-after.json").write_text(
         json.dumps(final_check, indent=2, ensure_ascii=False)
     )
@@ -2696,6 +3010,147 @@ def render_prod_concurrency_mirror_sql(stub_updates: list[dict]) -> str:
     return "".join(parts)
 
 
+def _apply_group_instance_key(action: dict) -> tuple[str, str, str]:
+    """Group key (region, instance_id, label) — same instance runs steps serially."""
+    kind = action["kind"]
+    tgt = action["target"]
+    if kind == "edge_account_tier":
+        edge_id = tgt["edge_id"]
+        region, instance_id, label = _resolve_edge_target(edge_id)
+        return region, instance_id, label
+    if kind == "edge_operator_concurrency":
+        edge_id = tgt["edge_id"]
+        region, instance_id, label = _resolve_edge_target(edge_id)
+        return region, instance_id, label
+    if kind == "edge_operator_balance":
+        edge_id = tgt["edge_id"]
+        region, instance_id, label = _resolve_edge_target(edge_id)
+        return region, instance_id, label
+    if kind in ("prod_stub_pool", "prod_concurrency_mirror"):
+        region, instance_id, label = _resolve_prod_target()
+        return region, instance_id, label
+    if kind == "anthropic_group_claude_code_only":
+        if tgt.get("env") == "edge":
+            edge_id = tgt["edge_id"]
+            region, instance_id, label = _resolve_edge_target(edge_id)
+            return region, instance_id, label
+        region, instance_id, label = _resolve_prod_target()
+        return region, instance_id, label
+    fail(f"unknown action.kind {kind!r}")
+
+
+def _execute_apply_action(action: dict, job_dir: pathlib.Path) -> dict[str, Any]:
+    step = action["step"]
+    kind = action["kind"]
+    tgt = action["target"]
+    v = action.get("variables", {})
+    if kind == "edge_account_tier":
+        edge_id = tgt["edge_id"]
+        account_name = tgt["account_name"]
+        label = f"step{step:02d}-edge-{edge_id}-{kind}-{account_name}".replace("/", "-")
+        sql = render_edge_account_tier_sql(v["account_name"], v["stability_tier"], edge_id)
+        region, instance_id, target_label = _resolve_edge_target(edge_id)
+    elif kind == "prod_stub_pool":
+        account_id = v["account_id"]
+        account_name = tgt["account_name"]
+        label = f"step{step:02d}-prod-{kind}-{account_name}".replace("/", "-")
+        sql = render_prod_stub_pool_sql(
+            int(account_id), account_name,
+            bool(v["pool_mode_enabled"]), int(v["pool_mode_retry_count"]),
+        )
+        region, instance_id, target_label = _resolve_prod_target()
+    elif kind == "edge_operator_concurrency":
+        edge_id = tgt["edge_id"]
+        label = f"step{step:02d}-edge-{edge_id}-{kind}".replace("/", "-")
+        sql = render_edge_operator_concurrency_sql(edge_id)
+        region, instance_id, target_label = _resolve_edge_target(edge_id)
+    elif kind == "prod_concurrency_mirror":
+        label = f"step{step:02d}-prod-{kind}".replace("/", "-")
+        sql = render_prod_concurrency_mirror_sql(v.get("stub_updates") or [])
+        region, instance_id, target_label = _resolve_prod_target()
+    elif kind == "anthropic_group_claude_code_only":
+        env = tgt.get("env")
+        want = bool(v.get("claude_code_only", True))
+        if env == "edge":
+            edge_id = tgt["edge_id"]
+            label = f"step{step:02d}-edge-{edge_id}-{kind}".replace("/", "-")
+            sql = render_anthropic_group_claude_code_sql(want)
+            region, instance_id, target_label = _resolve_edge_target(edge_id)
+        elif env == "prod":
+            label = f"step{step:02d}-prod-{kind}".replace("/", "-")
+            sql = render_anthropic_group_claude_code_sql(want)
+            region, instance_id, target_label = _resolve_prod_target()
+        else:
+            fail(f"anthropic_group_claude_code_only: unknown target.env {env!r}")
+    elif kind == "edge_operator_balance":
+        edge_id = tgt["edge_id"]
+        label = f"step{step:02d}-edge-{edge_id}-{kind}".replace("/", "-")
+        default_bal = float(v["default_balance"])
+        sql = render_edge_operator_balance_sql(
+            default_bal,
+            user_id=int(v.get("operator_user_id", ADMIN_OPERATOR_USER_CONCURRENCY_SYNC_ID)),
+        )
+        region, instance_id, target_label = _resolve_edge_target(edge_id)
+    else:
+        fail(f"unknown action.kind {kind!r} (orchestrator handles edge_account_tier | "
+             f"prod_stub_pool | edge_operator_concurrency | prod_concurrency_mirror | "
+             f"anthropic_group_claude_code_only | edge_operator_balance)")
+
+    sql_path = job_dir / f"{label}.sql"
+    sql_path.write_text(sql)
+    sql_b64 = base64.b64encode(sql.encode("utf-8")).decode("ascii")
+    print(f"apply: step{step:02d} {kind} → {target_label}  (sql={sql_path})",
+          file=sys.stderr)
+    stdout, cid, ssm_ok, stderr = ssm_run_sql_b64(
+        region, instance_id, sql_b64,
+        f"apply step {step} {kind} on {target_label}",
+    )
+    result: dict[str, Any] = {
+        "step": step,
+        "kind": kind,
+        "target_label": target_label,
+        "sql_path": str(sql_path),
+        "ssm_command_id": cid,
+        "ssm_ok": ssm_ok,
+        "stdout_preview": stdout[-1200:],
+        "stderr_preview": stderr,
+        "expected_after": action.get("expected_after"),
+        "ok": ssm_ok,
+    }
+    if not ssm_ok:
+        result["error"] = (
+            "SSM ResponseCode != 0; remote SQL likely failed (DO-block RAISE or "
+            "psql ON_ERROR_STOP). Inspect via: "
+            f"aws ssm get-command-invocation --region {region} "
+            f"--instance-id {instance_id} --command-id {cid}"
+        )
+    if result["ok"] and kind == "edge_operator_balance":
+        uid = int(v.get("operator_user_id", ADMIN_OPERATOR_USER_CONCURRENCY_SYNC_ID))
+        cache_ok = _invalidate_operator_balance_cache(
+            region, instance_id, uid,
+            f"apply step {step} edge_operator_balance cache flush on {target_label}",
+        )
+        result["billing_cache_invalidate_ok"] = cache_ok
+        if not cache_ok:
+            result["ok"] = False
+            result["error"] = "billing:balance Redis DEL failed after balance UPDATE"
+    if not result["ok"]:
+        print(f"apply: step{step:02d} FAILED. cid={cid}", file=sys.stderr)
+    return result
+
+
+def _execute_apply_group(actions: list[dict], job_dir: pathlib.Path) -> list[dict]:
+    """Serial apply on one Postgres instance (one edge or prod)."""
+    ordered = sorted(actions, key=lambda a: a["step"])
+    results: list[dict] = []
+    for action in ordered:
+        result = _execute_apply_action(action, job_dir)
+        results.append(result)
+        if not result["ok"]:
+            break
+    return results
+
+
 def cmd_apply(args: argparse.Namespace) -> int:
     plan_path = pathlib.Path(args.plan)
     plan = load_json_file(plan_path, "plan")
@@ -2713,110 +3168,35 @@ def cmd_apply(args: argparse.Namespace) -> int:
     job_dir.mkdir(parents=True, exist_ok=True)
     print(f"apply: job_dir={job_dir}", file=sys.stderr)
 
-    results: list[dict] = []
-    actions = plan.get("actions") or []
+    actions = sorted(plan.get("actions") or [], key=lambda a: a["step"])
+    groups: dict[tuple[str, str, str], list[dict]] = defaultdict(list)
     for action in actions:
-        step = action["step"]
-        kind = action["kind"]
-        tgt = action["target"]
-        v = action.get("variables", {})
-        if kind == "edge_account_tier":
-            edge_id = tgt["edge_id"]
-            account_name = tgt["account_name"]
-            label = f"step{step:02d}-edge-{edge_id}-{kind}-{account_name}".replace("/", "-")
-            sql = render_edge_account_tier_sql(v["account_name"], v["stability_tier"], edge_id)
-            region, instance_id, target_label = _resolve_edge_target(edge_id)
-        elif kind == "prod_stub_pool":
-            account_id = v["account_id"]
-            account_name = tgt["account_name"]
-            label = f"step{step:02d}-prod-{kind}-{account_name}".replace("/", "-")
-            sql = render_prod_stub_pool_sql(
-                int(account_id), account_name,
-                bool(v["pool_mode_enabled"]), int(v["pool_mode_retry_count"]),
-            )
-            region, instance_id, target_label = _resolve_prod_target()
-        elif kind == "edge_operator_concurrency":
-            edge_id = tgt["edge_id"]
-            label = f"step{step:02d}-edge-{edge_id}-{kind}".replace("/", "-")
-            sql = render_edge_operator_concurrency_sql(edge_id)
-            region, instance_id, target_label = _resolve_edge_target(edge_id)
-        elif kind == "prod_concurrency_mirror":
-            label = f"step{step:02d}-prod-{kind}".replace("/", "-")
-            sql = render_prod_concurrency_mirror_sql(v.get("stub_updates") or [])
-            region, instance_id, target_label = _resolve_prod_target()
-        elif kind == "anthropic_group_claude_code_only":
-            env = tgt.get("env")
-            want = bool(v.get("claude_code_only", True))
-            if env == "edge":
-                edge_id = tgt["edge_id"]
-                label = f"step{step:02d}-edge-{edge_id}-{kind}".replace("/", "-")
-                sql = render_anthropic_group_claude_code_sql(want)
-                region, instance_id, target_label = _resolve_edge_target(edge_id)
-            elif env == "prod":
-                label = f"step{step:02d}-prod-{kind}".replace("/", "-")
-                sql = render_anthropic_group_claude_code_sql(want)
-                region, instance_id, target_label = _resolve_prod_target()
-            else:
-                fail(f"anthropic_group_claude_code_only: unknown target.env {env!r}")
-        elif kind == "edge_operator_balance":
-            edge_id = tgt["edge_id"]
-            label = f"step{step:02d}-edge-{edge_id}-{kind}".replace("/", "-")
-            default_bal = float(v["default_balance"])
-            sql = render_edge_operator_balance_sql(
-                default_bal, user_id=int(v.get("operator_user_id", ADMIN_OPERATOR_USER_CONCURRENCY_SYNC_ID)),
-            )
-            region, instance_id, target_label = _resolve_edge_target(edge_id)
-        else:
-            fail(f"unknown action.kind {kind!r} (orchestrator handles edge_account_tier | "
-                 f"prod_stub_pool | edge_operator_concurrency | prod_concurrency_mirror | "
-                 f"anthropic_group_claude_code_only | edge_operator_balance)")
-            return 2  # unreachable, pacifies static analysis
+        groups[_apply_group_instance_key(action)].append(action)
 
-        sql_path = job_dir / f"{label}.sql"
-        sql_path.write_text(sql)
-        sql_b64 = base64.b64encode(sql.encode("utf-8")).decode("ascii")
-        print(f"apply: step{step:02d} {kind} → {target_label}  (sql={sql_path})",
-              file=sys.stderr)
-        stdout, cid, ssm_ok, stderr = ssm_run_sql_b64(
-            region, instance_id, sql_b64,
-            f"apply step {step} {kind} on {target_label}",
+    workers = _parallel_edges_workers(getattr(args, "parallel_edges", None))
+    group_items = list(groups.items())
+    if len(group_items) > 1 and workers > 1:
+        apply_workers = min(workers, len(group_items))
+        print(
+            f"apply: {len(actions)} step(s) in {len(group_items)} instance group(s) "
+            f"parallel_workers={apply_workers}",
+            file=sys.stderr,
         )
-        # edge_account_tier template returns relation rows, not jsonb — we
-        # trust the transaction commit and defer field-level verification
-        # to Stage 5 verify.
-        result = {
-            "step": step,
-            "kind": kind,
-            "target_label": target_label,
-            "sql_path": str(sql_path),
-            "ssm_command_id": cid,
-            "ssm_ok": ssm_ok,
-            "stdout_preview": stdout[-1200:],
-            "stderr_preview": stderr,
-            "expected_after": action.get("expected_after"),
-            "ok": ssm_ok,
-        }
-        if not ssm_ok:
-            result["error"] = (
-                "SSM ResponseCode != 0; remote SQL likely failed (DO-block RAISE or "
-                "psql ON_ERROR_STOP). Inspect via: "
-                f"aws ssm get-command-invocation --region {region} "
-                f"--instance-id {instance_id} --command-id {cid}"
-            )
-        results.append(result)
-        if result["ok"] and kind == "edge_operator_balance":
-            uid = int(v.get("operator_user_id", ADMIN_OPERATOR_USER_CONCURRENCY_SYNC_ID))
-            cache_ok = _invalidate_operator_balance_cache(
-                region, instance_id, uid,
-                f"apply step {step} edge_operator_balance cache flush on {target_label}",
-            )
-            result["billing_cache_invalidate_ok"] = cache_ok
-            if not cache_ok:
-                result["ok"] = False
-                result["error"] = "billing:balance Redis DEL failed after balance UPDATE"
-        if not result["ok"]:
-            print(f"apply: step{step:02d} FAILED — stopping. cid={cid}", file=sys.stderr)
-            break
+        group_results = _run_parallel_ordered(
+            group_items,
+            lambda item: _execute_apply_group(item[1], job_dir),
+            apply_workers,
+            label="apply",
+        )
+    else:
+        group_results = [
+            _execute_apply_group(item[1], job_dir) for item in group_items
+        ]
+
+    results: list[dict] = []
+    for gr in group_results:
+        results.extend(gr)
+    results.sort(key=lambda r: r["step"])
 
     success = all(r["ok"] for r in results) and len(results) == len(actions)
     report = {
@@ -2848,7 +3228,11 @@ def cmd_apply(args: argparse.Namespace) -> int:
                 file=sys.stderr,
             )
             rt_ok, rt_results = _run_runtime_sync(
-                rt_targets, ua_version, job_dir, mimicry_manifest_json=manifest_json,
+                rt_targets,
+                ua_version,
+                job_dir,
+                mimicry_manifest_json=manifest_json,
+                parallel_edges=getattr(args, "parallel_edges", None),
             )
             runtime_sync_report = {
                 "ua_version": ua_version,
@@ -2897,6 +3281,7 @@ def cmd_verify(args: argparse.Namespace) -> int:
         out=str(snap_path),
         allow_planned=args.allow_planned,
         skip_prod=not plan_needs_prod and bool(getattr(args, "skip_prod", False)),
+        parallel_edges=getattr(args, "parallel_edges", None),
     )
     rc = cmd_snapshot(snap_args)
     if rc != 0:
@@ -3039,6 +3424,27 @@ def cmd_verify(args: argparse.Namespace) -> int:
 # Dispatch
 # --------------------------------------------------------------------------
 
+def _add_parallel_edges_arg(sp: argparse.ArgumentParser) -> None:
+    sp.add_argument(
+        "--parallel-edges",
+        type=int,
+        default=None,
+        metavar="N",
+        help=(
+            f"max concurrent edge/target workers for SSM I/O "
+            f"(default {DEFAULT_PARALLEL_EDGES})"
+        ),
+    )
+
+
+def _add_legacy_guard_arg(sp: argparse.ArgumentParser) -> None:
+    sp.add_argument(
+        "--legacy-guard",
+        action="store_true",
+        help="use per-account subprocess guard (slow); default is one batch SSM per edge",
+    )
+
+
 def main() -> int:
     ap = argparse.ArgumentParser(
         description=__doc__.split("\n\n", 1)[0] if __doc__ else "",
@@ -3053,6 +3459,7 @@ def main() -> int:
                     help="include planned edges from merged EC2 + Lightsail matrix keys")
     sp.add_argument("--skip-prod", action="store_true",
                     help="skip the prod stub query (offline / lab runs that only need edge data)")
+    _add_parallel_edges_arg(sp)
     sp.set_defaults(handler=cmd_snapshot)
 
     sp = sub.add_parser("check", help="run edge OAuth stability guard for each edge in scope")
@@ -3060,6 +3467,8 @@ def main() -> int:
     sp.add_argument("--allow-planned", action="store_true",
                     help="expand edge IDs in scope via merged matrices (see snapshot)")
     sp.add_argument("--json", action="store_true")
+    _add_parallel_edges_arg(sp)
+    _add_legacy_guard_arg(sp)
     sp.set_defaults(handler=cmd_check)
 
     sp = sub.add_parser("plan-edge-account-tier",
@@ -3182,6 +3591,7 @@ def main() -> int:
         "--sync-runtime-ua-version",
         help="override UA semver for sync-runtime (default: parse tk_canonical_cc_oauth.json)",
     )
+    _add_parallel_edges_arg(sp)
     sp.set_defaults(handler=cmd_apply)
 
     sp = sub.add_parser(
@@ -3211,6 +3621,7 @@ def main() -> int:
     sp.add_argument("--job-dir", help="write rendered remote shell scripts here")
     sp.add_argument("--out", help="write JSON report")
     sp.add_argument("--json", action="store_true")
+    _add_parallel_edges_arg(sp)
     sp.set_defaults(handler=cmd_sync_runtime)
 
     sp = sub.add_parser(
@@ -3248,6 +3659,8 @@ def main() -> int:
         action="store_true",
         help="sync-runtime on edges only (omit prod)",
     )
+    _add_parallel_edges_arg(sp)
+    _add_legacy_guard_arg(sp)
     sp.set_defaults(handler=cmd_remediate_guard_drift)
 
     sp = sub.add_parser("verify",
@@ -3259,6 +3672,7 @@ def main() -> int:
     sp.add_argument("--skip-prod", action="store_true",
                     help="skip the re-snapshot's prod query when the plan has no prod_stub_pool actions")
     sp.add_argument("--json", action="store_true")
+    _add_parallel_edges_arg(sp)
     sp.set_defaults(handler=cmd_verify)
 
     args = ap.parse_args()

--- a/ops/anthropic/manage-anthropic-config.py
+++ b/ops/anthropic/manage-anthropic-config.py
@@ -918,30 +918,35 @@ def _read_operator_balance(region: str, instance_id: str, label: str) -> dict:
     }
 
 
-def _sql_select_body(sql: str) -> str:
-    """Strip the leading SELECT so the fragment can sit inside jsonb_build_object."""
+def _sql_as_subquery(sql: str) -> str:
+    """Normalize a standalone ``SELECT … ;`` statement into a scalar-subquery body.
+
+    The leading ``SELECT`` is kept (so the fragment is a valid subquery once
+    wrapped in ``(...)`` inside ``jsonb_build_object``) and the trailing
+    statement terminator is dropped — a ``;`` inside ``(...)`` is a syntax error.
+    """
     body = sql.strip()
-    if body.upper().startswith("SELECT "):
-        return body[7:].strip()
+    if body.endswith(";"):
+        body = body[:-1].rstrip()
     return body
 
 
 EDGE_CAPTURE_BUNDLE_SQL = f"""
 SELECT jsonb_build_object(
-  'oauth_accounts', ({_sql_select_body(EDGE_ACCOUNTS_SQL)}),
-  'anthropic_groups', ({_sql_select_body(ANTHROPIC_GROUPS_SQL)}),
-  'tiers', ({_sql_select_body(TIERS_SQL)}),
-  'operator_concurrency', ({_sql_select_body(OPERATOR_CONCURRENCY_SQL)}),
-  'operator_balance', ({_sql_select_body(OPERATOR_BALANCE_SQL)})
+  'oauth_accounts', ({_sql_as_subquery(EDGE_ACCOUNTS_SQL)}),
+  'anthropic_groups', ({_sql_as_subquery(ANTHROPIC_GROUPS_SQL)}),
+  'tiers', ({_sql_as_subquery(TIERS_SQL)}),
+  'operator_concurrency', ({_sql_as_subquery(OPERATOR_CONCURRENCY_SQL)}),
+  'operator_balance', ({_sql_as_subquery(OPERATOR_BALANCE_SQL)})
 );
 """.strip()
 
 PROD_CAPTURE_BUNDLE_SQL = f"""
 SELECT jsonb_build_object(
-  'anthropic_stubs', ({_sql_select_body(PROD_STUBS_SQL)}),
-  'anthropic_groups', ({_sql_select_body(ANTHROPIC_GROUPS_SQL)}),
-  'tiers', ({_sql_select_body(TIERS_SQL)}),
-  'operator_concurrency', ({_sql_select_body(OPERATOR_CONCURRENCY_SQL)})
+  'anthropic_stubs', ({_sql_as_subquery(PROD_STUBS_SQL)}),
+  'anthropic_groups', ({_sql_as_subquery(ANTHROPIC_GROUPS_SQL)}),
+  'tiers', ({_sql_as_subquery(TIERS_SQL)}),
+  'operator_concurrency', ({_sql_as_subquery(OPERATOR_CONCURRENCY_SQL)})
 );
 """.strip()
 

--- a/ops/anthropic/test_manage_anthropic_config_parallel.py
+++ b/ops/anthropic/test_manage_anthropic_config_parallel.py
@@ -4,7 +4,11 @@ from __future__ import annotations
 
 import importlib.util
 import json
+import os
 import pathlib
+import re
+import shutil
+import subprocess
 import time
 import unittest
 from unittest import mock
@@ -36,18 +40,116 @@ class ParallelOrderedTest(unittest.TestCase):
         self.assertEqual(len(seen), 5)
 
 
-class SqlBundleTest(unittest.TestCase):
-    def test_sql_select_body_strips_leading_select(self) -> None:
-        self.assertEqual(
-            mgr._sql_select_body("SELECT 1 AS x"),
-            "1 AS x",
+# --------------------------------------------------------------------------
+# Generated-SQL structural validity — deterministic, DB-less guard.
+#
+# Substring assertions (assertIn 'jsonb_agg') cannot tell valid SQL from a
+# Postgres syntax error. These three checks map 1:1 to the syntax bugs that
+# shipped past the mocked tests and only surfaced against a real Postgres:
+#   * unbalanced parens          -> an unclosed COALESCE(... aggregate
+#   * a ';' inside the statement -> a reused SELECT … ; embedded in a subquery
+#   * a (subquery) value missing -> _sql_*_body stripping the leading SELECT,
+#     a leading SELECT/WITH         yielding `(COALESCE(...) FROM ...)`
+# All generated capture/guard SQL must pass them.
+# --------------------------------------------------------------------------
+def _assert_sql_structural(test: unittest.TestCase, sql: str) -> None:
+    test.assertEqual(
+        sql.count("("), sql.count(")"),
+        f"unbalanced parentheses in generated SQL:\n{sql}",
+    )
+    body = sql.rstrip()
+    if body.endswith(";"):
+        body = body[:-1]
+    test.assertNotIn(
+        ";", body,
+        f"interior ';' (statement terminator inside a subquery) in:\n{sql}",
+    )
+    # Every `'key', (` scalar-subquery value must open with SELECT or WITH.
+    for m in re.finditer(r"'\w+',\s*\(\s*([A-Za-z]+)", sql):
+        test.assertIn(
+            m.group(1).upper(), {"SELECT", "WITH"},
+            f"subquery value does not begin with SELECT/WITH (token "
+            f"{m.group(1)!r}) in:\n{sql}",
         )
+
+
+def _generated_sqls() -> dict[str, str]:
+    return {
+        "EDGE_CAPTURE_BUNDLE_SQL": mgr.EDGE_CAPTURE_BUNDLE_SQL,
+        "PROD_CAPTURE_BUNDLE_SQL": mgr.PROD_CAPTURE_BUNDLE_SQL,
+        "guard_batch": guard.build_all_oauth_guard_live_batch_query(),
+    }
+
+
+class SqlBundleTest(unittest.TestCase):
+    def test_sql_as_subquery_keeps_select_strips_terminator(self) -> None:
+        # Must keep SELECT (so `(...)` is a valid subquery) and drop the
+        # trailing ';' (a ';' inside `(...)` is a syntax error).
+        self.assertEqual(mgr._sql_as_subquery("SELECT 1 AS x;"), "SELECT 1 AS x")
+        self.assertEqual(
+            mgr._sql_as_subquery("\nSELECT a FROM t WHERE b;\n"),
+            "SELECT a FROM t WHERE b",
+        )
+
+    def test_generated_capture_and_guard_sql_are_structurally_valid(self) -> None:
+        for name, sql in _generated_sqls().items():
+            with self.subTest(sql=name):
+                _assert_sql_structural(self, sql)
 
     def test_edge_capture_bundle_aggregates_snapshot_fragments(self) -> None:
         sql = mgr.EDGE_CAPTURE_BUNDLE_SQL
         self.assertIn("oauth_accounts", sql)
         self.assertIn("anthropic_groups", sql)
         self.assertIn("operator_balance", sql)
+
+
+@unittest.skipUnless(
+    os.environ.get("TK_SQL_EXEC_PSQL") and shutil.which("psql"),
+    "set TK_SQL_EXEC_PSQL=<conninfo> with a reachable empty Postgres to "
+    "execute generated SQL against a real parser",
+)
+class GeneratedSqlExecutesOnPostgresTest(unittest.TestCase):
+    """Authoritative artifact check: parse+execute every generated query on a
+    real Postgres (the structural test above is the always-on DB-less floor).
+
+    The DSN points at any empty Postgres; this test creates the minimal schema
+    the queries touch, runs them under ON_ERROR_STOP, and fails on any syntax
+    or column-resolution error."""
+
+    _SCHEMA = """
+CREATE TABLE accounts(id bigint, name text, platform text, type text, status text,
+  schedulable boolean, concurrency int, load_factor numeric, priority int, channel_type int,
+  rate_multiplier numeric, auto_pause_on_expired boolean, proxy_id bigint, error_message text,
+  last_used_at timestamptz, credentials jsonb DEFAULT '{}', extra jsonb DEFAULT '{}',
+  deleted_at timestamptz);
+CREATE TABLE groups(id bigint, name text, platform text, status text, claude_code_only boolean,
+  fallback_group_id bigint, deleted_at timestamptz);
+CREATE TABLE account_groups(account_id bigint, group_id bigint);
+CREATE TABLE users(id bigint, balance numeric, concurrency int, deleted_at timestamptz);
+CREATE TABLE tiers(name text, concurrency int, priority int, rate_multiplier numeric, base_rpm int,
+  rpm_sticky_buffer int, max_sessions int, session_idle_timeout_minutes int, window_cost_limit int,
+  window_cost_sticky_reserve int, cache_ttl_override_enabled boolean, cache_ttl_override_target text,
+  tls_profile_name text);
+CREATE TABLE tls_fingerprint_profiles(id bigint, name text, description text, enable_grease boolean,
+  cipher_suites jsonb, curves jsonb, point_formats jsonb, signature_algorithms jsonb,
+  alpn_protocols jsonb, supported_versions jsonb, key_share_groups jsonb, psk_modes jsonb,
+  extensions jsonb);
+"""
+
+    def _psql(self, sql: str) -> None:
+        conninfo = os.environ["TK_SQL_EXEC_PSQL"]
+        proc = subprocess.run(
+            ["psql", conninfo, "-v", "ON_ERROR_STOP=1", "-q", "-t", "-A", "-f", "-"],
+            input=sql, text=True, capture_output=True,
+        )
+        if proc.returncode != 0:
+            self.fail(f"psql rejected generated SQL:\n{proc.stderr}\n---\n{sql}")
+
+    def test_all_generated_sql_executes(self) -> None:
+        self._psql(self._SCHEMA)
+        for name, sql in _generated_sqls().items():
+            with self.subTest(sql=name):
+                self._psql(sql if sql.rstrip().endswith(";") else sql + ";")
 
 
 class GuardBatchTest(unittest.TestCase):

--- a/ops/anthropic/test_manage_anthropic_config_parallel.py
+++ b/ops/anthropic/test_manage_anthropic_config_parallel.py
@@ -1,0 +1,164 @@
+#!/usr/bin/env python3
+"""Unit tests for remediate P0 parallel + batch guard paths (stdlib-only)."""
+from __future__ import annotations
+
+import importlib.util
+import json
+import pathlib
+import time
+import unittest
+from unittest import mock
+
+_MOD_PATH = pathlib.Path(__file__).resolve().parent / "manage-anthropic-config.py"
+_spec = importlib.util.spec_from_file_location("manage_anthropic_config", _MOD_PATH)
+mgr = importlib.util.module_from_spec(_spec)
+assert _spec and _spec.loader
+_spec.loader.exec_module(mgr)
+
+_GUARD_PATH = pathlib.Path(__file__).resolve().parent / "check-edge-oauth-stability.py"
+_guard_spec = importlib.util.spec_from_file_location("check_edge_oauth_stability", _GUARD_PATH)
+guard = importlib.util.module_from_spec(_guard_spec)
+assert _guard_spec and _guard_spec.loader
+_guard_spec.loader.exec_module(guard)
+
+
+class ParallelOrderedTest(unittest.TestCase):
+    def test_run_parallel_ordered_preserves_input_order(self) -> None:
+        seen: list[int] = []
+
+        def work(n: int) -> int:
+            time.sleep(0.02 * (5 - n))
+            seen.append(n)
+            return n * 10
+
+        out = mgr._run_parallel_ordered(list(range(5)), work, 4, label="test")
+        self.assertEqual(out, [0, 10, 20, 30, 40])
+        self.assertEqual(len(seen), 5)
+
+
+class SqlBundleTest(unittest.TestCase):
+    def test_sql_select_body_strips_leading_select(self) -> None:
+        self.assertEqual(
+            mgr._sql_select_body("SELECT 1 AS x"),
+            "1 AS x",
+        )
+
+    def test_edge_capture_bundle_aggregates_snapshot_fragments(self) -> None:
+        sql = mgr.EDGE_CAPTURE_BUNDLE_SQL
+        self.assertIn("oauth_accounts", sql)
+        self.assertIn("anthropic_groups", sql)
+        self.assertIn("operator_balance", sql)
+
+
+class GuardBatchTest(unittest.TestCase):
+    def test_build_all_oauth_batch_query_aggregates_accounts(self) -> None:
+        sql = guard.build_all_oauth_guard_live_batch_query()
+        self.assertIn("jsonb_agg", sql)
+        self.assertIn("platform = 'anthropic'", sql)
+        self.assertIn("type = 'oauth'", sql)
+
+    def test_guard_items_from_batch_reports_tls_drift(self) -> None:
+        baseline = mgr.load_json_file(mgr.TIER_BASELINES, "tier baseline")
+        live_row = {
+            "account_name": "acct-a",
+            "found": True,
+            "account": {
+                "name": "acct-a",
+                "platform": "anthropic",
+                "type": "oauth",
+                "stability_tier": "l5",
+                "concurrency": 10,
+                "priority": 50,
+                "rate_multiplier": 1.0,
+                "auto_pause_on_expired": True,
+                "channel_type": 0,
+            },
+            "credentials": baseline["shared_baseline"]["credentials"],
+            "extra": {
+                "enable_tls_fingerprint": True,
+                "tls_fingerprint_profile_id": "999",
+            },
+            "groups": {"ids": [], "names": []},
+            "tls_profile": {"name": "wrong-profile"},
+        }
+        items = mgr._guard_items_from_batch(
+            "uk1",
+            {"edge_id": "uk1", "region": "eu-west-2", "instance_id": "i-test"},
+            [live_row],
+            baseline,
+        )
+        self.assertEqual(len(items), 1)
+        self.assertEqual(items[0]["status"], "drift")
+        self.assertGreater(items[0]["diff_count"], 0)
+
+    def test_run_guard_batch_for_edge_uses_one_ssm_call(self) -> None:
+        baseline = mgr.load_json_file(mgr.TIER_BASELINES, "tier baseline")
+        tier_key = "l5"
+        tier_base = mgr._GUARD.effective_baseline_for_tier(baseline, tier_key)
+        acct = tier_base["baseline"]["account"]
+        live_payload = {
+            "found": True,
+            "account": {
+                **acct,
+                "name": "acct-b",
+                "stability_tier": tier_key,
+            },
+            "credentials": tier_base["baseline"]["credentials"],
+            "extra": {
+                k: v for k, v in tier_base["baseline"]["extra"].items()
+                if k not in guard.TIER_MANAGED_EXTRA_KEYS
+            },
+            "groups": {"ids": [], "names": []},
+            "tls_profile": tier_base["baseline"]["tls_profile"],
+        }
+        batch_json = [
+            {"account_name": "acct-b", **live_payload},
+        ]
+        ident = mock.Mock(
+            region="eu-west-2",
+            instance_id="i-mock",
+            domain="api-uk1.tokenkey.dev",
+            routing="lightsail",
+        )
+        with mock.patch.object(
+            mgr._EDGE_SSM,
+            "resolve_edge_execution_identity",
+            return_value=ident,
+        ), mock.patch.object(
+            mgr,
+            "ssm_run_sql",
+            return_value=(json.dumps(batch_json), "cid-mock"),
+        ) as ssm_mock:
+            result = mgr._run_guard_batch_for_edge("uk1", allow_planned=False)
+
+        self.assertEqual(ssm_mock.call_count, 1)
+        self.assertEqual(result["exit_code"], 0)
+        self.assertEqual(result["report"]["summary"]["drift_count"], 0)
+
+
+class ApplyGroupKeyTest(unittest.TestCase):
+    def test_apply_group_key_same_edge_same_instance(self) -> None:
+        with mock.patch.object(
+            mgr,
+            "_resolve_edge_target",
+            return_value=("eu-west-2", "i-uk1", "edge:uk1"),
+        ):
+            a1 = {
+                "step": 1,
+                "kind": "edge_account_tier",
+                "target": {"edge_id": "uk1", "account_name": "a"},
+                "variables": {},
+            }
+            a2 = {
+                "step": 2,
+                "kind": "edge_account_tier",
+                "target": {"edge_id": "uk1", "account_name": "b"},
+                "variables": {},
+            }
+            k1 = mgr._apply_group_instance_key(a1)
+            k2 = mgr._apply_group_instance_key(a2)
+        self.assertEqual(k1, k2)
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Summary
- **R1**: `snapshot` pulls each edge via one bundled SSM query (`EDGE_CAPTURE_BUNDLE_SQL`); prod uses `PROD_CAPTURE_BUNDLE_SQL`. Edges run in parallel (`--parallel-edges`, default 6).
- **R1**: `check` / `remediate` guard uses **one batch SSM per edge** + in-process `compare_live_to_baseline` (replaces subprocess `1+N` SSM per edge). Escape hatch: `--legacy-guard`.
- **R2**: `apply` groups plan steps by Postgres instance (serial within edge/prod, parallel across instances). `sync-runtime` targets run in parallel.

## Risk
常规风险 — ops orchestrator only; no API/DB schema change. Parallel apply only groups by `(region, instance_id)` so same-edge transactions stay serial.

## Validation
- `python3 -m unittest ops.anthropic.test_manage_anthropic_config_parallel -v` — 7 tests OK
- `python3 -m unittest discover -s ops/anthropic -p 'test_manage_anthropic_config*.py'` — 76 tests OK
- `./scripts/preflight.sh` — PASS (pre-commit)

Made with [Cursor](https://cursor.com)