### PR TITLE
fix(tier): ApplyTier materializes full baseline + reconciler self-heals TLS/credentials/UA

### DIFF
--- a/backend/cmd/server/wire_gen.go
+++ b/backend/cmd/server/wire_gen.go
@@ -295,7 +295,7 @@ func initializeApplication(buildInfo handler.BuildInfo) (*Application, error) {
 	opsScheduledReportService := service.ProvideOpsScheduledReportService(opsService, userService, emailService, redisClient, configConfig)
 	rateLimitExpiryRepository := repository.NewRateLimitExpiryRepository(db)
 	schedulerRateLimitReaper := service.ProvideSchedulerRateLimitReaper(rateLimitExpiryRepository, configConfig)
-	anthropicConfigReconciler := service.ProvideAnthropicConfigReconciler(accountRepository, userRepository, adminService, tierService, configConfig, redisClient)
+	anthropicConfigReconciler := service.ProvideAnthropicConfigReconciler(accountRepository, userRepository, adminService, tierService, accountTierService, tlsFingerprintProfileService, settingService, configConfig, redisClient)
 	tokenRefreshService := service.ProvideTokenRefreshService(accountRepository, oAuthService, openAIOAuthService, geminiOAuthService, antigravityOAuthService, compositeTokenCacheInvalidator, schedulerCache, configConfig, tempUnschedCache, privacyClientFactory, proxyRepository, oAuthRefreshAPI, openAIGatewayService)
 	accountExpiryService := service.ProvideAccountExpiryService(accountRepository)
 	subscriptionExpiryService := service.ProvideSubscriptionExpiryService(userSubscriptionRepository, settingRepository, notificationEmailService)

--- a/backend/go.sum
+++ b/backend/go.sum
@@ -228,6 +228,8 @@ github.com/google/go-tpm-tools v0.3.13-0.20230620182252-4639ecce2aba/go.mod h1:E
 github.com/google/gofuzz v1.0.0/go.mod h1:dBl0BpW6vV/+mYPU4Po3pmUjxk6FQPldtuIdl/M65Eg=
 github.com/google/pprof v0.0.0-20250317173921-a4b03ec1a45e h1:ijClszYn+mADRFY17kjQEVQ1XRhq2/JR1M3sGqeJoxs=
 github.com/google/pprof v0.0.0-20250317173921-a4b03ec1a45e/go.mod h1:boTsfXsheKC2y+lKOCMpSfarhxDeIzfZG1jqGcPl3cA=
+github.com/google/subcommands v1.2.0 h1:vWQspBTo2nEqTUFita5/KeEWlUL8kQObDFbub/EN9oE=
+github.com/google/subcommands v1.2.0/go.mod h1:ZjhPrFU+Olkh9WazFPsl27BQ4UPiG37m3yTrtFlrHVk=
 github.com/google/uuid v1.1.2/go.mod h1:TIyPZe4MgqvfeYDBFedMoGGpEw/LqOeaOT+nhxU+yHo=
 github.com/google/uuid v1.6.0 h1:NIvaJDMOsjHA8n1jAhLSgzrAzy1Hgr+hNrb57e+94F0=
 github.com/google/uuid v1.6.0/go.mod h1:TIyPZe4MgqvfeYDBFedMoGGpEw/LqOeaOT+nhxU+yHo=

--- a/backend/internal/baseline/anthropic-http-mimicry-baselines.json
+++ b/backend/internal/baseline/anthropic-http-mimicry-baselines.json
@@ -1,0 +1,27 @@
+{
+  "schema_version": 1,
+  "cc_version": "2.1.162",
+  "description": "Canonical OAuth HTTP mimicry betas for Claude Code CLI. Live wire values are driven at runtime by settings.claude_code_http_mimicry_manifest (sync-runtime / plan-http-mimicry-sync). Compile-time defaults in backend/internal/pkg/claude/constants.go catch up on the release train.",
+  "sonnet_opus": [
+    "claude-code-20250219",
+    "oauth-2025-04-20",
+    "interleaved-thinking-2025-05-14",
+    "thinking-token-count-2026-05-13",
+    "context-management-2025-06-27",
+    "prompt-caching-scope-2026-01-05",
+    "advisor-tool-2026-03-01",
+    "advanced-tool-use-2025-11-20",
+    "extended-cache-ttl-2025-04-11",
+    "cache-diagnosis-2026-04-07"
+  ],
+  "haiku": [
+    "oauth-2025-04-20",
+    "interleaved-thinking-2025-05-14",
+    "thinking-token-count-2026-05-13",
+    "context-management-2025-06-27",
+    "prompt-caching-scope-2026-01-05",
+    "advisor-tool-2026-03-01",
+    "structured-outputs-2025-12-15",
+    "cache-diagnosis-2026-04-07"
+  ]
+}

--- a/backend/internal/baseline/embed.go
+++ b/backend/internal/baseline/embed.go
@@ -17,9 +17,16 @@ var tierBaselineJSON []byte
 //go:embed anthropic-stub-pool-baselines.json
 var stubPoolBaselineJSON []byte
 
+//go:embed anthropic-http-mimicry-baselines.json
+var httpMimicryBaselineJSON []byte
+
 // RawTierBaselineJSON returns the embedded tier baseline document bytes.
 // Exposed for the sentinel/test to compare against the deploy/aws/stage0 source.
 func RawTierBaselineJSON() []byte { return tierBaselineJSON }
 
 // RawStubPoolBaselineJSON returns the embedded stub-pool policy bytes.
 func RawStubPoolBaselineJSON() []byte { return stubPoolBaselineJSON }
+
+// RawHTTPMimicryBaselineJSON returns the embedded Claude Code HTTP mimicry policy
+// bytes (UA version + per-model betas). Exposed for the sentinel/test.
+func RawHTTPMimicryBaselineJSON() []byte { return httpMimicryBaselineJSON }

--- a/backend/internal/baseline/http_mimicry.go
+++ b/backend/internal/baseline/http_mimicry.go
@@ -1,0 +1,52 @@
+package baseline
+
+import (
+	"encoding/json"
+	"fmt"
+	"strings"
+	"sync"
+)
+
+// HTTPMimicryBaseline mirrors anthropic-http-mimicry-baselines.json: the canonical
+// Claude Code OAuth UA version + per-model anthropic-beta token lists. It is the
+// single source of truth the per-node config reconciler self-heals the
+// settings.claude_code_user_agent_version / claude_code_http_mimicry_manifest
+// runtime knobs toward, so a fresh node acquires the canonical UA without an
+// operator sync-runtime round-trip.
+type HTTPMimicryBaseline struct {
+	SchemaVersion int      `json:"schema_version"`
+	CCVersion     string   `json:"cc_version"`
+	SonnetOpus    []string `json:"sonnet_opus"`
+	Haiku         []string `json:"haiku"`
+}
+
+var (
+	mimicryDocOnce sync.Once
+	mimicryDoc     *HTTPMimicryBaseline
+	mimicryDocErr  error
+)
+
+// LoadHTTPMimicryBaseline parses the embedded HTTP mimicry baseline once and caches it.
+func LoadHTTPMimicryBaseline() (*HTTPMimicryBaseline, error) {
+	mimicryDocOnce.Do(func() {
+		doc := &HTTPMimicryBaseline{}
+		if err := json.Unmarshal(httpMimicryBaselineJSON, doc); err != nil {
+			mimicryDocErr = fmt.Errorf("parse embedded http mimicry baseline: %w", err)
+			return
+		}
+		if doc.SchemaVersion < 1 {
+			mimicryDocErr = fmt.Errorf("embedded http mimicry baseline schema_version < 1")
+			return
+		}
+		if strings.TrimSpace(doc.CCVersion) == "" {
+			mimicryDocErr = fmt.Errorf("embedded http mimicry baseline cc_version is empty")
+			return
+		}
+		if len(doc.SonnetOpus) == 0 || len(doc.Haiku) == 0 {
+			mimicryDocErr = fmt.Errorf("embedded http mimicry baseline has empty sonnet_opus/haiku")
+			return
+		}
+		mimicryDoc = doc
+	})
+	return mimicryDoc, mimicryDocErr
+}

--- a/backend/internal/service/account_tier_service_tk.go
+++ b/backend/internal/service/account_tier_service_tk.go
@@ -5,6 +5,7 @@ import (
 	"fmt"
 	"log/slog"
 
+	"github.com/Wei-Shaw/sub2api/internal/baseline"
 	"github.com/Wei-Shaw/sub2api/internal/model"
 )
 
@@ -14,20 +15,36 @@ import (
 // tier-drift report and the migration backfill key off it.
 const AccountTierExtraKey = "stability_tier"
 
-// AccountTierService binds a single anthropic OAUTH account to a stability tier
-// on THIS deployment's database. In the reference-table model "apply tier" =
-//   - set account.tier_id (per-tier config — base_rpm / max_sessions / window /
-//     ... — is resolved at runtime from the tiers table, NOT copied here);
+// AccountTierService binds a single anthropic OAUTH / setup-token account to a
+// stability tier on THIS deployment's database AND materializes the full
+// shared_baseline so "apply tier" yields a COMPLETE account in one shot. In the
+// reference-table model "apply tier" =
+//   - set account.tier_id (per-tier NUMERIC config — base_rpm / max_sessions /
+//     window / ... — is resolved at runtime from the tiers table, NOT copied here);
 //   - value-sync account.concurrency from the tier row (concurrency stays a
 //     persisted column on the scheduler hot path; see reconciler Step T for the
 //     steady-state re-assertion);
-//   - persist the canonical TLS fingerprint binding (stable; profile CONTENT
-//     fans out via the TLS pub/sub, this only pins which profile id);
-//   - it NEVER overwrites the shared TLS profile content (fixes the old冲刷) and
-//     NEVER copies rpm/sessions/window into the account's extra.
+//   - ensure the canonical TLS fingerprint profile ROW EXISTS (GetOrUpsertByName
+//     from the embedded shared_baseline) and pin account.extra.tls_fingerprint_
+//     profile_id to it. This fixes the historical root cause: the old path only
+//     *looked up* the id (GetByName) and silently left the binding empty when the
+//     row was missing, so the account ran on the built-in default ClientHello;
+//   - write the shared_baseline credentials self-protection template
+//     (temp_unschedulable_enabled / temp_unschedulable_rules /
+//     intercept_warmup_requests) — OAuth tokens are preserved by
+//     MergePreservingSensitiveCreds in UpdateAccount;
+//   - write the shared_baseline extra mimicry/template flags (enable_tls_
+//     fingerprint / rpm_strategy / session_id_masking_enabled / ...);
+//   - value-sync priority to the tier baseline (post-#551 all tiers are uniform
+//     priority=1; the old "priority owned by window-rebalance pipeline" carve-out
+//     no longer applies to anthropic — see reconciler kiro-priority for the same
+//     shape).
 //
-// It deliberately does NOT touch priority — accounts.priority is owned by the
-// window-rebalance pipeline. Fleet fan-out stays with the ops/anthropic pipeline.
+// It NEVER copies the tier-managed NUMERIC extra keys (base_rpm / max_sessions /
+// window / cache_ttl_override_*) into the account — those overlay at runtime from
+// the tiers table (model.IsTierManagedExtraKey strips them). Fleet fan-out stays
+// with the ops/anthropic pipeline; the per-node reconciler re-asserts this same
+// complete shape (it calls ApplyTier) so any creation path self-heals.
 type AccountTierService struct {
 	adminSvc AdminService
 	tierSvc  *TierService
@@ -71,47 +88,76 @@ func (s *AccountTierService) ApplyTier(ctx context.Context, accountID int64, tie
 		return nil, fmt.Errorf("unknown tier %q", tier)
 	}
 
-	// Resolve the canonical TLS fingerprint profile id for the binding (stable;
-	// the profile CONTENT is owned by the pipeline / TLS pub/sub, we only pin
-	// which id). Prefer the tier row's explicit id; else resolve by name. A
-	// missing id would make the runtime fall back to the built-in default — but
-	// that is non-fatal for the binding, so we only warn.
-	var tlsProfileID int64
-	if row.TLSProfileID != nil && *row.TLSProfileID > 0 {
-		tlsProfileID = *row.TLSProfileID
-	} else if row.TLSProfileName != nil && *row.TLSProfileName != "" && s.tlsSvc != nil {
-		if p, err := s.tlsSvc.GetByName(ctx, *row.TLSProfileName); err == nil && p != nil {
-			tlsProfileID = p.ID
-		}
+	// Load the merged shared_baseline for this tier (TLS spec + credentials +
+	// extra template + priority). The embedded baseline JSON is the single source
+	// of truth; the Python fleet pipeline upserts the same content.
+	eff, err := baseline.EffectiveBaselineForTier(row.Name)
+	if err != nil {
+		return nil, fmt.Errorf("load tier baseline %q: %w", row.Name, err)
 	}
 
-	// Build the desired extra: preserve the account's existing (non-tier-managed)
-	// extra, pin the TLS binding + tier label. The tier-managed numeric keys
-	// (base_rpm / ...) are intentionally NOT written — they are resolved at
-	// runtime from the tier row, and repo.Update strips any overlaid copies.
-	extra := make(map[string]any, len(account.Extra)+3)
+	// Ensure the canonical TLS profile ROW EXISTS (upsert by name) and bind its id.
+	// GetOrUpsertByName creates-if-absent and returns the row id — this is the fix
+	// for "tls_fingerprint_profiles has no tk_canonical_cc_oauth" → silent fallback
+	// to the built-in default ClientHello. A missing TLS service or a failed upsert
+	// is now FATAL (return error): an unbound canonical profile is exactly the bug
+	// we are eliminating, so it must not pass silently.
+	if s.tlsSvc == nil {
+		return nil, fmt.Errorf("tls fingerprint service unavailable; cannot ensure canonical profile %q", eff.TLSProfileName)
+	}
+	prof, err := s.tlsSvc.GetOrUpsertByName(ctx, eff.CanonicalTLSProfile())
+	if err != nil {
+		return nil, fmt.Errorf("ensure canonical TLS profile %q: %w", eff.TLSProfileName, err)
+	}
+	tlsProfileID := prof.ID
+
+	// desired extra = account's own non-tier-managed extra, overlaid with the
+	// shared_baseline template flags (enable_tls_fingerprint / rpm_strategy /
+	// session_id_masking_enabled / ...), plus the TLS binding + tier label. The
+	// tier-managed NUMERIC keys (base_rpm / max_sessions / window / cache_ttl_*)
+	// are stripped from BOTH sides — they overlay at runtime from the tiers table.
+	extra := make(map[string]any, len(account.Extra)+len(eff.Extra)+2)
 	for k, v := range account.Extra {
 		if model.IsTierManagedExtraKey(k) {
 			continue
 		}
 		extra[k] = v
 	}
-	extra["enable_tls_fingerprint"] = true
-	if tlsProfileID > 0 {
-		extra["tls_fingerprint_profile_id"] = tlsProfileID
+	for k, v := range eff.Extra {
+		if model.IsTierManagedExtraKey(k) {
+			continue
+		}
+		extra[k] = v
 	}
+	extra["tls_fingerprint_profile_id"] = tlsProfileID
 	extra[AccountTierExtraKey] = row.Name
+
+	// desired credentials = the account's existing (full, unredacted — GetAccount →
+	// repo.GetByID returns real tokens at the service layer) credentials overlaid
+	// with the shared_baseline credentials template (temp_unschedulable_* +
+	// intercept_warmup_requests). UpdateAccount runs MergePreservingSensitiveCreds,
+	// so OAuth tokens are doubly safe; copying existing creds through also avoids
+	// dropping any non-sensitive metadata.
+	creds := make(map[string]any, len(account.Credentials)+len(eff.Credentials))
+	for k, v := range account.Credentials {
+		creds[k] = v
+	}
+	for k, v := range eff.Credentials {
+		creds[k] = v
+	}
 
 	tierID := row.ID
 	concurrency := row.Concurrency
 	rateMultiplier := row.RateMultiplier
+	priority := eff.Priority // post-#551 uniform baseline priority (value-sync)
 
 	input := &UpdateAccountInput{
 		TierID:         &tierID,
 		Concurrency:    &concurrency, // value-sync from tier (hot-path column)
+		Priority:       &priority,    // value-sync to baseline (post-#551 uniform)
 		RateMultiplier: &rateMultiplier,
+		Credentials:    creds,
 		Extra:          extra,
-		// Priority intentionally omitted — owned by the window-rebalance pipeline.
 	}
 
 	updated, err := s.adminSvc.UpdateAccount(ctx, accountID, input)
@@ -119,12 +165,13 @@ func (s *AccountTierService) ApplyTier(ctx context.Context, accountID int64, tie
 		return nil, err
 	}
 
-	slog.Info("account tier bound (local deployment only)",
+	slog.Info("account tier applied — full baseline materialized (local deployment only)",
 		"account_id", accountID,
 		"account_name", account.Name,
 		"tier", row.Name,
 		"tier_id", tierID,
 		"concurrency", concurrency,
+		"priority", priority,
 		"tls_fingerprint_profile_id", tlsProfileID,
 	)
 	return updated, nil

--- a/backend/internal/service/account_tier_service_tk_test.go
+++ b/backend/internal/service/account_tier_service_tk_test.go
@@ -87,6 +87,57 @@ func tierServiceWithL4(t *testing.T) *TierService {
 	return NewTierService(repo, nil)
 }
 
+// stubTLSRepo is an in-memory TLSFingerprintProfileRepository for unit tests.
+// It lets us exercise GetOrUpsertByName (create-if-absent / update-in-place)
+// without a DB. Create assigns a monotonic id; Update replaces by id.
+type stubTLSRepo struct {
+	rows   []*model.TLSFingerprintProfile
+	nextID int64
+	create int // number of Create calls (asserts "profile was materialized")
+	update int // number of Update calls (asserts idempotent re-apply)
+}
+
+func (r *stubTLSRepo) List(ctx context.Context) ([]*model.TLSFingerprintProfile, error) {
+	return r.rows, nil
+}
+
+func (r *stubTLSRepo) GetByID(ctx context.Context, id int64) (*model.TLSFingerprintProfile, error) {
+	for _, p := range r.rows {
+		if p.ID == id {
+			return p, nil
+		}
+	}
+	return nil, nil
+}
+
+func (r *stubTLSRepo) Create(ctx context.Context, p *model.TLSFingerprintProfile) (*model.TLSFingerprintProfile, error) {
+	r.create++
+	r.nextID++
+	p.ID = r.nextID
+	r.rows = append(r.rows, p)
+	return p, nil
+}
+
+func (r *stubTLSRepo) Update(ctx context.Context, p *model.TLSFingerprintProfile) (*model.TLSFingerprintProfile, error) {
+	r.update++
+	for i, x := range r.rows {
+		if x.ID == p.ID {
+			r.rows[i] = p
+			return p, nil
+		}
+	}
+	return p, nil
+}
+
+func (r *stubTLSRepo) Delete(ctx context.Context, id int64) error { return nil }
+
+// tlsServiceWithRepo builds a real TLSFingerprintProfileService over the given
+// stub repo (nil cache — invalidateAndNotify is nil-cache safe).
+func tlsServiceWithRepo(t *testing.T, repo *stubTLSRepo) *TLSFingerprintProfileService {
+	t.Helper()
+	return NewTLSFingerprintProfileService(repo, nil)
+}
+
 func TestApplyTier_RejectsNonAnthropic(t *testing.T) {
 	svc := NewAccountTierService(
 		&stubAdminServiceForTier{getAccount: &Account{Platform: PlatformOpenAI, Type: AccountTypeOAuth}},
@@ -115,7 +166,7 @@ func TestApplyTier_SetupTokenBindsTier(t *testing.T) {
 		Platform: PlatformAnthropic,
 		Type:     AccountTypeSetupToken,
 	}}
-	svc := NewAccountTierService(admin, tierServiceWithL4(t), nil)
+	svc := NewAccountTierService(admin, tierServiceWithL4(t), tlsServiceWithRepo(t, &stubTLSRepo{}))
 
 	_, err := svc.ApplyTier(context.Background(), 9, "l4")
 	require.NoError(t, err)
@@ -158,7 +209,7 @@ func TestApplyTier_OAuthBindsTierAndValueSyncsConcurrency(t *testing.T) {
 		// stale tier-managed extra that must NOT be persisted back.
 		Extra: map[string]any{"base_rpm": 999, "rpm_strategy": "tiered"},
 	}}
-	svc := NewAccountTierService(admin, tierServiceWithL4(t), nil)
+	svc := NewAccountTierService(admin, tierServiceWithL4(t), tlsServiceWithRepo(t, &stubTLSRepo{}))
 
 	_, err := svc.ApplyTier(context.Background(), 7, "l4")
 	require.NoError(t, err)
@@ -169,11 +220,97 @@ func TestApplyTier_OAuthBindsTierAndValueSyncsConcurrency(t *testing.T) {
 	require.Equal(t, int64(4), *in.TierID, "must bind tier_id")
 	require.NotNil(t, in.Concurrency)
 	require.Equal(t, 8, *in.Concurrency, "must value-sync concurrency from tier")
-	require.Nil(t, in.Priority, "must NOT write priority (window pipeline owns it)")
+	// post-#551: ApplyTier value-syncs priority to the baseline (uniform = 1).
+	require.NotNil(t, in.Priority, "must write priority (post-#551 uniform baseline)")
+	require.Equal(t, 1, *in.Priority, "priority value-synced to baseline")
 
 	require.Equal(t, "l4", in.Extra["stability_tier"])
 	require.Equal(t, true, in.Extra["enable_tls_fingerprint"])
 	require.Equal(t, "tiered", in.Extra["rpm_strategy"], "non-tier extra preserved")
 	_, hasBaseRPM := in.Extra["base_rpm"]
 	require.False(t, hasBaseRPM, "tier-managed numeric extra must NOT be copied onto the account")
+}
+
+// TestApplyTier_CreatesAndBindsCanonicalTLSProfile is the regression for the
+// reported bug: operator added an OAuth account + set tier, but the
+// tls_fingerprint_profiles table had no tk_canonical_cc_oauth row, so the
+// account ran on the built-in default ClientHello. ApplyTier must now CREATE the
+// canonical profile (GetOrUpsertByName) and bind the account to its id.
+func TestApplyTier_CreatesAndBindsCanonicalTLSProfile(t *testing.T) {
+	admin := &stubAdminServiceForTier{getAccount: &Account{
+		ID: 7, Platform: PlatformAnthropic, Type: AccountTypeOAuth,
+	}}
+	tlsRepo := &stubTLSRepo{} // empty — no canonical profile exists yet
+	svc := NewAccountTierService(admin, tierServiceWithL4(t), tlsServiceWithRepo(t, tlsRepo))
+
+	_, err := svc.ApplyTier(context.Background(), 7, "l4")
+	require.NoError(t, err)
+	require.Equal(t, 1, tlsRepo.create, "canonical TLS profile row must be CREATED when absent")
+	require.Len(t, tlsRepo.rows, 1)
+	require.Equal(t, "tk_canonical_cc_oauth", tlsRepo.rows[0].Name)
+
+	in := admin.updateInput
+	require.NotNil(t, in)
+	// the account must be bound to the freshly-created profile id (not 0).
+	boundID := parseExtraInt(in.Extra["tls_fingerprint_profile_id"])
+	require.Equal(t, int(tlsRepo.rows[0].ID), boundID, "account must bind the canonical profile id")
+	require.NotZero(t, boundID, "binding must not be empty (the root-cause bug)")
+	require.Equal(t, true, in.Extra["enable_tls_fingerprint"])
+}
+
+// TestApplyTier_WritesCredentialsTemplate asserts the 403 self-protection /
+// warmup credentials template is materialized, and OAuth tokens are preserved.
+func TestApplyTier_WritesCredentialsTemplate(t *testing.T) {
+	admin := &stubAdminServiceForTier{getAccount: &Account{
+		ID: 7, Platform: PlatformAnthropic, Type: AccountTypeOAuth,
+		Credentials: map[string]any{"access_token": "tok-abc", "refresh_token": "ref-xyz"},
+	}}
+	svc := NewAccountTierService(admin, tierServiceWithL4(t), tlsServiceWithRepo(t, &stubTLSRepo{}))
+
+	_, err := svc.ApplyTier(context.Background(), 7, "l4")
+	require.NoError(t, err)
+	in := admin.updateInput
+	require.NotNil(t, in.Credentials)
+	require.Equal(t, true, in.Credentials["temp_unschedulable_enabled"], "self-protection template written")
+	require.NotNil(t, in.Credentials["temp_unschedulable_rules"], "403 disable rules written")
+	require.Equal(t, true, in.Credentials["intercept_warmup_requests"], "warmup intercept written")
+	// existing OAuth tokens carried through (also protected by MergePreservingSensitiveCreds).
+	require.Equal(t, "tok-abc", in.Credentials["access_token"], "OAuth access_token preserved")
+	require.Equal(t, "ref-xyz", in.Credentials["refresh_token"], "OAuth refresh_token preserved")
+}
+
+// TestApplyTier_Idempotent re-applies the same tier: the second call must UPDATE
+// the existing canonical profile in place (not create a duplicate), keeping the
+// same bound id — this is the property the reconciler self-heal relies on.
+func TestApplyTier_Idempotent(t *testing.T) {
+	admin := &stubAdminServiceForTier{getAccount: &Account{
+		ID: 7, Platform: PlatformAnthropic, Type: AccountTypeOAuth,
+	}}
+	tlsRepo := &stubTLSRepo{}
+	svc := NewAccountTierService(admin, tierServiceWithL4(t), tlsServiceWithRepo(t, tlsRepo))
+
+	_, err := svc.ApplyTier(context.Background(), 7, "l4")
+	require.NoError(t, err)
+	firstID := parseExtraInt(admin.updateInput.Extra["tls_fingerprint_profile_id"])
+
+	_, err = svc.ApplyTier(context.Background(), 7, "l4")
+	require.NoError(t, err)
+	secondID := parseExtraInt(admin.updateInput.Extra["tls_fingerprint_profile_id"])
+
+	require.Equal(t, 1, tlsRepo.create, "second apply must NOT create a duplicate profile")
+	require.GreaterOrEqual(t, tlsRepo.update, 1, "second apply updates the existing profile in place")
+	require.Equal(t, firstID, secondID, "bound profile id is stable across re-apply")
+	require.Len(t, tlsRepo.rows, 1, "exactly one canonical profile row")
+}
+
+// TestApplyTier_FailsLoudWithoutTLSService: an unbound canonical profile is the
+// bug we are eliminating — a missing TLS service must be a hard error, not a warn.
+func TestApplyTier_FailsLoudWithoutTLSService(t *testing.T) {
+	admin := &stubAdminServiceForTier{getAccount: &Account{
+		ID: 7, Platform: PlatformAnthropic, Type: AccountTypeOAuth,
+	}}
+	svc := NewAccountTierService(admin, tierServiceWithL4(t), nil)
+	_, err := svc.ApplyTier(context.Background(), 7, "l4")
+	require.Error(t, err, "missing TLS service must fail loud (no silent built-in fallback)")
+	require.Nil(t, admin.updateInput, "must not write the account when the binding can't be ensured")
 }

--- a/backend/internal/service/anthropic_config_reconciler.go
+++ b/backend/internal/service/anthropic_config_reconciler.go
@@ -320,8 +320,9 @@ func (r *AnthropicConfigReconciler) runOnce(ctx context.Context) {
 	r.reportTierDrift(accounts)
 
 	// Step kiro-priority: HARD-ENFORCE kiro account priority baseline. Fetches its
-	// own kiro account list (the list above is anthropic-only). Kiro-scoped; does
-	// not touch anthropic priority (owned by the window-rebalance pipeline).
+	// own kiro account list (the list above is anthropic-only). Kiro-scoped; the
+	// anthropic-side priority value-sync lives in Step baseline above (kiro
+	// schedules in its own isolated pool).
 	r.reconcileKiroPriorityBaseline(ctx)
 
 	// Step UA: self-heal the deployment-level Claude Code UA + mimicry manifest
@@ -347,8 +348,11 @@ func (r *AnthropicConfigReconciler) reconcileClaudeCodeMimicry(ctx context.Conte
 // reconcileTierConcurrency value-syncs each tier-bound anthropic OAUTH account's
 // concurrency column from its tier row. concurrency stays a persisted column on
 // the scheduler hot path; the tier table is the write-source. BulkUpdate already
-// enqueues an outbox account_changed event → snapshot rebuild. NEVER writes
-// priority (owned by the window-rebalance pipeline).
+// enqueues an outbox account_changed event → snapshot rebuild. It does NOT write
+// priority — priority is value-synced to the uniform post-#551 baseline by Step
+// baseline (reconcileAccountBaselineDrift → ApplyTier). Note: CRSSyncService
+// (on-demand admin import) and the admin UI also set anthropic-oauth priority;
+// Step baseline intentionally reconverges those to the uniform tier baseline.
 func (r *AnthropicConfigReconciler) reconcileTierConcurrency(ctx context.Context, accounts []Account) {
 	if r.tiers == nil {
 		return

--- a/backend/internal/service/anthropic_config_reconciler.go
+++ b/backend/internal/service/anthropic_config_reconciler.go
@@ -9,9 +9,17 @@ package service
 //   - It ONLY ever writes THIS deployment's own database. It never pretends to
 //     cover the fleet — fleet fan-out stays with the Python pipeline.
 //   - Safe items are self-healed (operator Σ, stub pool_mode, edge balance floor,
-//     surface-C concurrency mirror). A single account's tier field drift is
-//     REPORTED ONLY (slog.Warn) — never silently rewritten, because tier is set
-//     explicitly via the admin UI ApplyTier action.
+//     surface-C concurrency mirror). A single account's tier NUMERIC field drift
+//     (base_rpm / max_sessions / window — overlaid at runtime from the tiers
+//     table) is REPORTED ONLY (slog.Warn) — never silently rewritten, because the
+//     tier NUMBER is set explicitly via the admin UI ApplyTier action.
+//   - shared_baseline INFRASTRUCTURE, by contrast, IS self-healed (Step baseline):
+//     the canonical TLS profile's existence + the account's binding to it, the
+//     credentials self-protection template, and the (post-#551 uniform) priority.
+//     These are tier-independent and were the root cause of silent built-in-default
+//     TLS fallback when an account was created without the profile row present.
+//     Self-heal re-runs the SAME complete write path (ApplyTier), so any creation
+//     path (admin UI, bare SQL) converges.
 //   - surface C (concurrency mirror) NEVER writes 0 on a failed/timed-out/5xx
 //     edge read — it skips the stub and leaves the prior value intact.
 
@@ -29,6 +37,7 @@ import (
 
 	"github.com/Wei-Shaw/sub2api/internal/baseline"
 	"github.com/Wei-Shaw/sub2api/internal/config"
+	"github.com/Wei-Shaw/sub2api/internal/model"
 
 	"github.com/google/uuid"
 	"github.com/redis/go-redis/v9"
@@ -85,24 +94,52 @@ type httpDoer interface {
 	Do(req *http.Request) (*http.Response, error)
 }
 
-// reconcilerTierResolver resolves a tier's desired concurrency (Step T value-sync).
-// *TierService satisfies it; nil-safe (Step T no-ops when absent).
+// reconcilerTierResolver resolves a tier's desired concurrency (Step T value-sync)
+// and its name (Step baseline self-heal, which re-applies the tier by name).
+// *TierService satisfies it; nil-safe (steps no-op when absent).
 type reconcilerTierResolver interface {
 	ResolveConcurrency(tierID int64) (int, bool)
+	ResolveName(tierID int64) (string, bool)
+}
+
+// reconcilerTierApplier re-applies a tier onto an account — the single complete
+// "materialize shared_baseline" write path (TLS profile ensure+bind, credentials
+// template, extra flags, priority, concurrency). *AccountTierService satisfies it.
+// nil-safe (Step baseline no-ops when absent).
+type reconcilerTierApplier interface {
+	ApplyTier(ctx context.Context, accountID int64, tier string) (*Account, error)
+}
+
+// reconcilerTLSProfileResolver reads a TLS profile by id so the baseline drift
+// check can detect a DANGLING binding (id set but the row was deleted / renamed).
+// *TLSFingerprintProfileService satisfies it. nil → that sub-check is skipped.
+type reconcilerTLSProfileResolver interface {
+	GetByID(ctx context.Context, id int64) (*model.TLSFingerprintProfile, error)
+}
+
+// reconcilerMimicrySettings self-heals the deployment-level Claude Code UA +
+// mimicry manifest settings toward the embedded baseline (the in-process
+// equivalent of ops `sync-runtime`). *SettingService satisfies it. nil → Step UA
+// no-ops.
+type reconcilerMimicrySettings interface {
+	EnsureClaudeCodeMimicryBaseline(ctx context.Context) (bool, error)
 }
 
 // AnthropicConfigReconciler runs a single ticker that, each tick, acquires a
 // redis leader lock (best-effort; degrades to lockless on no redis) and runs the
 // safe-item self-heal + tier-drift report against the local DB.
 type AnthropicConfigReconciler struct {
-	accounts   reconcilerAccountStore
-	users      reconcilerUserStore
-	balance    reconcilerBalanceSetter
-	tiers      reconcilerTierResolver
-	cfg        *config.Config
-	redis      *redis.Client
-	http       httpDoer
-	instanceID string
+	accounts    reconcilerAccountStore
+	users       reconcilerUserStore
+	balance     reconcilerBalanceSetter
+	tiers       reconcilerTierResolver
+	tierApplier reconcilerTierApplier
+	tlsProfiles reconcilerTLSProfileResolver
+	mimicry     reconcilerMimicrySettings
+	cfg         *config.Config
+	redis       *redis.Client
+	http        httpDoer
+	instanceID  string
 
 	stopCh   chan struct{}
 	stopOnce sync.Once
@@ -114,24 +151,32 @@ type AnthropicConfigReconciler struct {
 
 // NewAnthropicConfigReconciler constructs the reconciler. A nil accounts/users
 // store produces a no-op on Start, keeping wire wiring safe for minimal test deps.
+// tierApplier/tlsProfiles may be nil — the baseline self-heal step degrades to a
+// no-op (applier absent) or skips the dangling-binding sub-check (resolver absent).
 func NewAnthropicConfigReconciler(
 	accounts reconcilerAccountStore,
 	users reconcilerUserStore,
 	balance reconcilerBalanceSetter,
 	tiers reconcilerTierResolver,
+	tierApplier reconcilerTierApplier,
+	tlsProfiles reconcilerTLSProfileResolver,
+	mimicry reconcilerMimicrySettings,
 	cfg *config.Config,
 	redisClient *redis.Client,
 ) *AnthropicConfigReconciler {
 	return &AnthropicConfigReconciler{
-		accounts:   accounts,
-		users:      users,
-		balance:    balance,
-		tiers:      tiers,
-		cfg:        cfg,
-		redis:      redisClient,
-		http:       &http.Client{Timeout: anthropicReconcilerHTTPTO},
-		instanceID: uuid.NewString(),
-		stopCh:     make(chan struct{}),
+		accounts:    accounts,
+		users:       users,
+		balance:     balance,
+		tiers:       tiers,
+		tierApplier: tierApplier,
+		tlsProfiles: tlsProfiles,
+		mimicry:     mimicry,
+		cfg:         cfg,
+		redis:       redisClient,
+		http:        &http.Client{Timeout: anthropicReconcilerHTTPTO},
+		instanceID:  uuid.NewString(),
+		stopCh:      make(chan struct{}),
 	}
 }
 
@@ -249,6 +294,13 @@ func (r *AnthropicConfigReconciler) runOnce(ctx context.Context) {
 	// Step A so the operator Σ reflects any concurrency it just re-asserted.
 	r.reconcileTierConcurrency(ctx, accounts)
 
+	// Step baseline: self-heal shared_baseline INFRASTRUCTURE (canonical TLS
+	// profile existence + binding, credentials self-protection template, uniform
+	// priority) for tier-bound anthropic OAuth/setup-token accounts by re-running
+	// ApplyTier when drifted. Idempotent; the single complete write path. This is
+	// what makes "operator just sets the tier" yield a fully-configured account.
+	r.reconcileAccountBaselineDrift(ctx, accounts)
+
 	// Step C: surface-C concurrency mirror (prod). Runs before the operator Σ
 	// sync so the Σ reflects any concurrency it just wrote.
 	if r.cfg != nil && r.cfg.Gateway.Scheduling.AnthropicConfigReconcilerConcurrencyMirrorEnabled {
@@ -271,6 +323,25 @@ func (r *AnthropicConfigReconciler) runOnce(ctx context.Context) {
 	// own kiro account list (the list above is anthropic-only). Kiro-scoped; does
 	// not touch anthropic priority (owned by the window-rebalance pipeline).
 	r.reconcileKiroPriorityBaseline(ctx)
+
+	// Step UA: self-heal the deployment-level Claude Code UA + mimicry manifest
+	// settings toward the embedded baseline (in-process `sync-runtime`). Runs once
+	// per tick (deployment-scoped, not per-account) so a fresh node auto-acquires
+	// the canonical UA without an operator round-trip.
+	r.reconcileClaudeCodeMimicry(ctx)
+}
+
+// reconcileClaudeCodeMimicry self-heals the Claude Code UA / mimicry settings.
+// nil-safe (no-op when the SettingService dep is absent).
+func (r *AnthropicConfigReconciler) reconcileClaudeCodeMimicry(ctx context.Context) {
+	if r == nil || r.mimicry == nil {
+		return
+	}
+	if changed, err := r.mimicry.EnsureClaudeCodeMimicryBaseline(ctx); err != nil {
+		slog.Warn("anthropic config reconciler: claude code mimicry self-heal failed", "err", err)
+	} else if changed {
+		slog.Info("anthropic config reconciler: claude code mimicry settings self-healed (local deployment only)")
+	}
 }
 
 // reconcileTierConcurrency value-syncs each tier-bound anthropic OAUTH account's

--- a/backend/internal/service/anthropic_config_reconciler_test.go
+++ b/backend/internal/service/anthropic_config_reconciler_test.go
@@ -10,6 +10,7 @@ import (
 	"testing"
 
 	"github.com/Wei-Shaw/sub2api/internal/config"
+	"github.com/Wei-Shaw/sub2api/internal/model"
 
 	"github.com/stretchr/testify/require"
 )
@@ -122,15 +123,117 @@ func (d *fakeDoer) Do(req *http.Request) (*http.Response, error) {
 }
 
 func newTestReconciler(acc *reconcilerAccountStub, usr *reconcilerUserStub, bal *reconcilerBalanceStub, cfg *config.Config) *AnthropicConfigReconciler {
-	r := NewAnthropicConfigReconciler(acc, usr, bal, nil, cfg, nil)
+	r := NewAnthropicConfigReconciler(acc, usr, bal, nil, nil, nil, nil, cfg, nil)
 	return r
 }
 
+// --- Step baseline (account shared_baseline self-heal) stubs + tests ----------
+
+type stubTierApplier struct {
+	calls []int64 // account ids ApplyTier was invoked on
+}
+
+func (s *stubTierApplier) ApplyTier(ctx context.Context, accountID int64, tier string) (*Account, error) {
+	s.calls = append(s.calls, accountID)
+	return &Account{ID: accountID}, nil
+}
+
+type stubTLSByID struct {
+	byID map[int64]*model.TLSFingerprintProfile
+}
+
+func (s *stubTLSByID) GetByID(ctx context.Context, id int64) (*model.TLSFingerprintProfile, error) {
+	return s.byID[id], nil
+}
+
+func baselineSelfHealReconciler(applier *stubTierApplier, tls *stubTLSByID) *AnthropicConfigReconciler {
+	tiers := &stubTierConcurrency{names: map[int64]string{2: "l2"}} // tier_id 2 → "l2"
+	return NewAnthropicConfigReconciler(nil, nil, nil, tiers, applier, tls, nil, nil, nil)
+}
+
+func tierID2() *int64 { v := int64(2); return &v }
+
+func TestReconcileAccountBaselineDrift_HealsUnboundTLS(t *testing.T) {
+	applier := &stubTierApplier{}
+	r := baselineSelfHealReconciler(applier, &stubTLSByID{})
+	// tier-bound oauth account with priority=1 but NO tls binding → drift.
+	accts := []Account{{
+		ID: 7, Platform: PlatformAnthropic, Type: AccountTypeOAuth, TierID: tierID2(),
+		Priority: 1,
+		Extra:    map[string]any{"enable_tls_fingerprint": true},
+	}}
+	r.reconcileAccountBaselineDrift(context.Background(), accts)
+	require.Equal(t, []int64{7}, applier.calls, "unbound TLS must trigger ApplyTier self-heal")
+}
+
+func TestReconcileAccountBaselineDrift_HealsPriorityDrift(t *testing.T) {
+	applier := &stubTierApplier{}
+	tls := &stubTLSByID{byID: map[int64]*model.TLSFingerprintProfile{5: {ID: 5, Name: "tk_canonical_cc_oauth"}}}
+	r := baselineSelfHealReconciler(applier, tls)
+	// fully bound + credentials present, but priority=2 (≠ baseline 1) → drift.
+	accts := []Account{{
+		ID: 8, Platform: PlatformAnthropic, Type: AccountTypeSetupToken, TierID: tierID2(),
+		Priority:    2,
+		Extra:       map[string]any{"enable_tls_fingerprint": true, "tls_fingerprint_profile_id": int64(5)},
+		Credentials: map[string]any{"temp_unschedulable_enabled": true, "temp_unschedulable_rules": []any{}, "intercept_warmup_requests": true},
+	}}
+	r.reconcileAccountBaselineDrift(context.Background(), accts)
+	require.Equal(t, []int64{8}, applier.calls, "priority drift must trigger ApplyTier self-heal")
+}
+
+func TestReconcileAccountBaselineDrift_SkipsAligned(t *testing.T) {
+	applier := &stubTierApplier{}
+	tls := &stubTLSByID{byID: map[int64]*model.TLSFingerprintProfile{5: {ID: 5, Name: "tk_canonical_cc_oauth"}}}
+	r := baselineSelfHealReconciler(applier, tls)
+	// fully aligned: priority=1, bound to canonical row, flag on, creds template present.
+	accts := []Account{{
+		ID: 9, Platform: PlatformAnthropic, Type: AccountTypeOAuth, TierID: tierID2(),
+		Priority:    1,
+		Extra:       map[string]any{"enable_tls_fingerprint": true, "tls_fingerprint_profile_id": int64(5)},
+		Credentials: map[string]any{"temp_unschedulable_enabled": true, "temp_unschedulable_rules": []any{}, "intercept_warmup_requests": true},
+	}}
+	r.reconcileAccountBaselineDrift(context.Background(), accts)
+	require.Empty(t, applier.calls, "aligned account must NOT be re-applied (skip-if-aligned)")
+}
+
+func TestReconcileAccountBaselineDrift_HealsDanglingBinding(t *testing.T) {
+	applier := &stubTierApplier{}
+	// id 5 bound but the profile row does not exist (deleted) → dangling.
+	r := baselineSelfHealReconciler(applier, &stubTLSByID{byID: map[int64]*model.TLSFingerprintProfile{}})
+	accts := []Account{{
+		ID: 10, Platform: PlatformAnthropic, Type: AccountTypeOAuth, TierID: tierID2(),
+		Priority:    1,
+		Extra:       map[string]any{"enable_tls_fingerprint": true, "tls_fingerprint_profile_id": int64(5)},
+		Credentials: map[string]any{"temp_unschedulable_enabled": true, "temp_unschedulable_rules": []any{}, "intercept_warmup_requests": true},
+	}}
+	r.reconcileAccountBaselineDrift(context.Background(), accts)
+	require.Equal(t, []int64{10}, applier.calls, "dangling TLS binding must trigger ApplyTier self-heal")
+}
+
+func TestReconcileAccountBaselineDrift_SkipsApikeyStub(t *testing.T) {
+	applier := &stubTierApplier{}
+	r := baselineSelfHealReconciler(applier, &stubTLSByID{})
+	// apikey mirror stub is not OAuth/setup-token → never re-applied.
+	accts := []Account{{
+		ID: 11, Platform: PlatformAnthropic, Type: AccountTypeAPIKey, TierID: tierID2(), Priority: 9,
+	}}
+	r.reconcileAccountBaselineDrift(context.Background(), accts)
+	require.Empty(t, applier.calls, "apikey stub must be skipped")
+}
+
 // stubTierConcurrency is a minimal reconcilerTierResolver for Step T tests.
-type stubTierConcurrency struct{ conc map[int64]int }
+type stubTierConcurrency struct {
+	conc  map[int64]int
+	names map[int64]string
+}
 
 func (s *stubTierConcurrency) ResolveConcurrency(tierID int64) (int, bool) {
 	v, ok := s.conc[tierID]
+	return v, ok
+}
+
+func (s *stubTierConcurrency) ResolveName(tierID int64) (string, bool) {
+	v, ok := s.names[tierID]
 	return v, ok
 }
 

--- a/backend/internal/service/anthropic_config_reconciler_tk_account_baseline.go
+++ b/backend/internal/service/anthropic_config_reconciler_tk_account_baseline.go
@@ -1,0 +1,93 @@
+package service
+
+import (
+	"context"
+	"log/slog"
+
+	"github.com/Wei-Shaw/sub2api/internal/baseline"
+)
+
+// reconcileAccountBaselineDrift self-heals the shared_baseline INFRASTRUCTURE for
+// every tier-bound anthropic OAuth/setup-token account on THIS node: the canonical
+// TLS profile's existence + the account's binding to it, the credentials
+// self-protection template, and the (post-#551 uniform) priority. When any drift
+// is detected it re-runs the SAME complete write path the admin UI uses
+// (AccountTierService.ApplyTier), so a missing TLS profile row, a dangling
+// binding, a missing 403 self-protection rule, or a stale priority all converge —
+// no matter how the account was created (admin UI, bare SQL, partial apply).
+//
+// It deliberately does NOT touch tier NUMERIC fields (base_rpm / max_sessions /
+// window) — those overlay at runtime from the tiers table and stay report-only
+// (reportTierDrift). Mirrors reconcileKiroPriorityBaseline's skip-if-aligned shape
+// and reuses the reconciler's ticker + redis leader lock; ApplyTier itself
+// enqueues the snapshot-rebuild outbox event via UpdateAccount.
+func (r *AnthropicConfigReconciler) reconcileAccountBaselineDrift(ctx context.Context, accounts []Account) {
+	if r == nil || r.tierApplier == nil || r.tiers == nil {
+		return // applier/resolver not wired (minimal test deps) → no-op
+	}
+	for i := range accounts {
+		a := &accounts[i]
+		if a.TierID == nil || *a.TierID <= 0 || !a.IsAnthropicOAuthOrSetupToken() {
+			continue
+		}
+		tierName, ok := r.tiers.ResolveName(*a.TierID)
+		if !ok || tierName == "" {
+			continue
+		}
+		eff, err := baseline.EffectiveBaselineForTier(tierName)
+		if err != nil {
+			slog.Warn("anthropic config reconciler: load tier baseline failed (account baseline self-heal)",
+				"account_id", a.ID, "tier", tierName, "err", err)
+			continue
+		}
+		reason := r.accountBaselineDriftReason(ctx, a, eff)
+		if reason == "" {
+			continue // aligned → skip (no write)
+		}
+		if _, err := r.tierApplier.ApplyTier(ctx, a.ID, tierName); err != nil {
+			slog.Warn("anthropic config reconciler: account baseline self-heal (ApplyTier) failed",
+				"account_id", a.ID, "account_name", a.Name, "tier", tierName, "reason", reason, "err", err)
+			continue
+		}
+		slog.Info("anthropic config reconciler: account baseline self-healed via ApplyTier (local deployment only)",
+			"account_id", a.ID, "account_name", a.Name, "tier", tierName, "reason", reason)
+	}
+}
+
+// accountBaselineDriftReason returns a short reason string when the account drifts
+// from the shared_baseline infrastructure, or "" when aligned. Checks are
+// account-side (cheap) plus an optional dangling-binding lookup; on a TLS resolver
+// error it conservatively does NOT report drift (never flap on a transient read).
+func (r *AnthropicConfigReconciler) accountBaselineDriftReason(ctx context.Context, a *Account, eff *baseline.EffectiveTierBaseline) string {
+	// priority: post-#551 uniform baseline value (value-synced).
+	if a.Priority != eff.Priority {
+		return "priority"
+	}
+	// enable_tls_fingerprint flag must be on.
+	if v, _ := a.Extra["enable_tls_fingerprint"].(bool); !v {
+		return "tls_fingerprint_disabled"
+	}
+	// TLS binding: id must be present AND resolve to a row named canonical. A
+	// missing id is the reported root cause (silent built-in default fallback);
+	// a dangling id (row deleted/renamed) is the harder case the resolver catches.
+	id := a.GetTLSFingerprintProfileID()
+	if id <= 0 {
+		return "tls_profile_unbound"
+	}
+	if r.tlsProfiles != nil {
+		if prof, err := r.tlsProfiles.GetByID(ctx, id); err == nil {
+			if prof == nil || prof.Name != eff.TLSProfileName {
+				return "tls_profile_dangling"
+			}
+		}
+		// err != nil → skip this sub-check (conservative; don't flap on read error)
+	}
+	// credentials self-protection template keys must be present (presence, not
+	// value-equality — avoids fighting benign operator edits).
+	for k := range eff.Credentials {
+		if _, ok := a.Credentials[k]; !ok {
+			return "credentials_template_missing"
+		}
+	}
+	return ""
+}

--- a/backend/internal/service/anthropic_config_reconciler_tk_kiro_priority.go
+++ b/backend/internal/service/anthropic_config_reconciler_tk_kiro_priority.go
@@ -10,10 +10,11 @@ import (
 // reconcileKiroPriorityBaseline HARD-ENFORCES every active kiro account's priority
 // column to kiro.DefaultKiroAccountPriority (value-sync, skip-if-aligned) — the same
 // shape as Step T's tier-concurrency value-sync. This is a kiro-scoped concept: kiro
-// schedules in its own isolated pool and is NOT in the anthropic window-rebalance
-// pipeline, so writing kiro priority here does NOT violate the reconciler's rule that
-// it never writes anthropic priority. BulkUpdate auto-enqueues a scheduler_outbox
-// event so the live snapshot picks up the corrected priority.
+// schedules in its own isolated pool with its OWN priority baseline constant,
+// distinct from the anthropic tier baseline that Step baseline value-syncs. Both
+// platforms now value-sync priority from their respective baselines; this step just
+// carries kiro's. BulkUpdate auto-enqueues a scheduler_outbox event so the live
+// snapshot picks up the corrected priority.
 //
 // It lives on the anthropic-named reconciler purely to reuse its ticker + redis leader
 // lock + account store + BulkUpdate outbox path (most minimal; no new goroutine or

--- a/backend/internal/service/setting_service_tk_mimicry_selfheal.go
+++ b/backend/internal/service/setting_service_tk_mimicry_selfheal.go
@@ -1,0 +1,121 @@
+package service
+
+import (
+	"context"
+	"encoding/json"
+	"errors"
+	"fmt"
+	"log/slog"
+	"reflect"
+	"time"
+
+	"github.com/Wei-Shaw/sub2api/internal/baseline"
+)
+
+// EnsureClaudeCodeMimicryBaseline self-heals the two deployment-level Claude Code
+// HTTP mimicry runtime knobs — settings.claude_code_user_agent_version and
+// settings.claude_code_http_mimicry_manifest — toward the embedded
+// anthropic-http-mimicry-baselines.json. It is the in-process equivalent of the
+// ops pipeline's `sync-runtime`, so a freshly-deployed node acquires the canonical
+// UA + betas WITHOUT an operator round-trip (the check's http_ua_drift gate).
+//
+// Comparison is SEMANTIC (parse + field compare), not byte-exact, so it never
+// fights the Python sync-runtime when both write equivalent JSON. Returns whether
+// it wrote anything. Caches are invalidated on write so the change takes effect
+// immediately (the 60s TTL would otherwise lag).
+func (s *SettingService) EnsureClaudeCodeMimicryBaseline(ctx context.Context) (bool, error) {
+	if s == nil || s.settingRepo == nil {
+		return false, nil
+	}
+	doc, err := baseline.LoadHTTPMimicryBaseline()
+	if err != nil {
+		return false, fmt.Errorf("load http mimicry baseline: %w", err)
+	}
+	if ctx == nil {
+		ctx = context.Background()
+	}
+
+	wantUA := NormalizeClaudeCodeUserAgentVersion(doc.CCVersion)
+	if wantUA == "" {
+		return false, fmt.Errorf("http mimicry baseline cc_version %q is not a valid UA version", doc.CCVersion)
+	}
+	// Build the desired manifest and run it THROUGH the parser so the stored value
+	// is byte-stable across ticks (ParseClaudeCodeHTTPMimicryManifest dedups /
+	// normalizes beta tokens — comparing raw-vs-normalized would loop forever).
+	wantBytes, err := json.Marshal(&ClaudeCodeHTTPMimicryManifest{
+		SchemaVersion: doc.SchemaVersion,
+		CCVersion:     wantUA,
+		SonnetOpus:    doc.SonnetOpus,
+		Haiku:         doc.Haiku,
+	})
+	if err != nil {
+		return false, fmt.Errorf("marshal baseline mimicry manifest: %w", err)
+	}
+	wantManifest := ParseClaudeCodeHTTPMimicryManifest(string(wantBytes))
+	if wantManifest == nil {
+		return false, fmt.Errorf("embedded http mimicry baseline is not a valid manifest")
+	}
+
+	changed := false
+
+	// --- UA version ---
+	curUARaw, err := s.settingRepo.GetValue(ctx, SettingKeyClaudeCodeUserAgentVersion)
+	if err != nil && !errors.Is(err, ErrSettingNotFound) {
+		return false, fmt.Errorf("read %s: %w", SettingKeyClaudeCodeUserAgentVersion, err)
+	}
+	if NormalizeClaudeCodeUserAgentVersion(curUARaw) != wantUA {
+		if err := s.settingRepo.Set(ctx, SettingKeyClaudeCodeUserAgentVersion, wantUA); err != nil {
+			return changed, fmt.Errorf("write %s: %w", SettingKeyClaudeCodeUserAgentVersion, err)
+		}
+		changed = true
+	}
+
+	// --- mimicry manifest (semantic compare) ---
+	curManifestRaw, err := s.settingRepo.GetValue(ctx, SettingKeyClaudeCodeHTTPMimicryManifest)
+	if err != nil && !errors.Is(err, ErrSettingNotFound) {
+		return changed, fmt.Errorf("read %s: %w", SettingKeyClaudeCodeHTTPMimicryManifest, err)
+	}
+	if !mimicryManifestEquivalent(ParseClaudeCodeHTTPMimicryManifest(curManifestRaw), wantManifest) {
+		encoded, err := json.Marshal(wantManifest)
+		if err != nil {
+			return changed, fmt.Errorf("marshal desired mimicry manifest: %w", err)
+		}
+		if err := s.settingRepo.Set(ctx, SettingKeyClaudeCodeHTTPMimicryManifest, string(encoded)); err != nil {
+			return changed, fmt.Errorf("write %s: %w", SettingKeyClaudeCodeHTTPMimicryManifest, err)
+		}
+		changed = true
+	}
+
+	if changed {
+		s.invalidateClaudeCodeMimicryCaches(wantUA)
+		slog.Info("claude code mimicry runtime self-healed to baseline (local deployment only)",
+			"cc_version", wantUA)
+	}
+	return changed, nil
+}
+
+// invalidateClaudeCodeMimicryCaches drops the in-process UA + manifest caches so
+// the next read reflects the just-written values immediately (mirrors the
+// UpdateSettings writeback path).
+func (s *SettingService) invalidateClaudeCodeMimicryCaches(wantUA string) {
+	s.claudeCodeUAVersionSF.Forget("claude_code_user_agent_version")
+	s.claudeCodeUAVersionCache.Store(&cachedClaudeCodeUserAgentVersion{
+		version:   wantUA,
+		expiresAt: time.Now().Add(claudeCodeUserAgentVersionCacheTTL).UnixNano(),
+	})
+	s.claudeCodeMimicryManifestSF.Forget("claude_code_http_mimicry_manifest")
+	// Clear the manifest cache so the next getter re-parses from DB (avoids
+	// re-deriving the parsed struct here).
+	s.claudeCodeMimicryManifestCache.Store((*cachedClaudeCodeHTTPMimicryManifest)(nil))
+}
+
+// mimicryManifestEquivalent reports whether two parsed manifests carry the same
+// canonical wire values (cc_version + the two beta lists). nil current → not equal.
+func mimicryManifestEquivalent(cur, want *ClaudeCodeHTTPMimicryManifest) bool {
+	if cur == nil || want == nil {
+		return false
+	}
+	return cur.CCVersion == want.CCVersion &&
+		reflect.DeepEqual(cur.SonnetOpus, want.SonnetOpus) &&
+		reflect.DeepEqual(cur.Haiku, want.Haiku)
+}

--- a/backend/internal/service/setting_service_tk_mimicry_selfheal_test.go
+++ b/backend/internal/service/setting_service_tk_mimicry_selfheal_test.go
@@ -1,0 +1,76 @@
+//go:build unit
+
+package service
+
+import (
+	"context"
+	"testing"
+
+	"github.com/Wei-Shaw/sub2api/internal/baseline"
+
+	"github.com/stretchr/testify/require"
+)
+
+// mimicrySettingRepoStub implements just GetValue/Set (embeds the interface so
+// the unused methods panic if unexpectedly called).
+type mimicrySettingRepoStub struct {
+	SettingRepository
+	values map[string]string
+	sets   int
+}
+
+func (s *mimicrySettingRepoStub) GetValue(ctx context.Context, key string) (string, error) {
+	if v, ok := s.values[key]; ok {
+		return v, nil
+	}
+	return "", ErrSettingNotFound
+}
+
+func (s *mimicrySettingRepoStub) Set(ctx context.Context, key, value string) error {
+	if s.values == nil {
+		s.values = map[string]string{}
+	}
+	s.values[key] = value
+	s.sets++
+	return nil
+}
+
+func TestEnsureClaudeCodeMimicryBaseline_WritesWhenUnsetThenIdempotent(t *testing.T) {
+	doc, err := baseline.LoadHTTPMimicryBaseline()
+	require.NoError(t, err)
+	wantUA := NormalizeClaudeCodeUserAgentVersion(doc.CCVersion)
+
+	repo := &mimicrySettingRepoStub{values: map[string]string{}}
+	svc := &SettingService{settingRepo: repo}
+
+	// 1) unset → both keys written.
+	changed, err := svc.EnsureClaudeCodeMimicryBaseline(context.Background())
+	require.NoError(t, err)
+	require.True(t, changed, "unset settings must be self-healed")
+	require.Equal(t, wantUA, repo.values[SettingKeyClaudeCodeUserAgentVersion])
+	m := ParseClaudeCodeHTTPMimicryManifest(repo.values[SettingKeyClaudeCodeHTTPMimicryManifest])
+	require.NotNil(t, m, "written manifest must parse")
+	require.Equal(t, wantUA, m.CCVersion)
+	require.NotEmpty(t, m.SonnetOpus)
+	require.NotEmpty(t, m.Haiku)
+
+	// 2) idempotent: aligned → no further writes (guards the every-tick-write loop).
+	setsAfterFirst := repo.sets
+	changed2, err := svc.EnsureClaudeCodeMimicryBaseline(context.Background())
+	require.NoError(t, err)
+	require.False(t, changed2, "aligned settings must NOT be rewritten")
+	require.Equal(t, setsAfterFirst, repo.sets, "no extra Set calls on aligned state")
+}
+
+func TestEnsureClaudeCodeMimicryBaseline_HealsStaleUA(t *testing.T) {
+	repo := &mimicrySettingRepoStub{values: map[string]string{
+		SettingKeyClaudeCodeUserAgentVersion: "1.0.0", // stale
+	}}
+	svc := &SettingService{settingRepo: repo}
+	changed, err := svc.EnsureClaudeCodeMimicryBaseline(context.Background())
+	require.NoError(t, err)
+	require.True(t, changed)
+
+	doc, _ := baseline.LoadHTTPMimicryBaseline()
+	require.Equal(t, NormalizeClaudeCodeUserAgentVersion(doc.CCVersion), repo.values[SettingKeyClaudeCodeUserAgentVersion])
+}

--- a/backend/internal/service/tier_service.go
+++ b/backend/internal/service/tier_service.go
@@ -189,6 +189,16 @@ func (s *TierService) ResolveConcurrency(tierID int64) (int, bool) {
 	return t.Concurrency, true
 }
 
+// ResolveName 返回 tier id 对应的名字（如 "l4"），未知 id 返回 false。
+// reconciler 的账号 baseline 自愈用它把 tier_id 反解成名字再 ApplyTier（按名重应用）。
+func (s *TierService) ResolveName(tierID int64) (string, bool) {
+	t := s.lookupByID(tierID)
+	if t == nil {
+		return "", false
+	}
+	return t.Name, true
+}
+
 func (s *TierService) lookupByID(id int64) *model.Tier {
 	s.localMu.RLock()
 	t := s.byID[id]

--- a/backend/internal/service/wire.go
+++ b/backend/internal/service/wire.go
@@ -250,10 +250,13 @@ func ProvideAnthropicConfigReconciler(
 	userRepo UserRepository,
 	adminSvc AdminService,
 	tierSvc *TierService,
+	tierApplier *AccountTierService,
+	tlsSvc *TLSFingerprintProfileService,
+	settingSvc *SettingService,
 	cfg *config.Config,
 	redisClient *redis.Client,
 ) *AnthropicConfigReconciler {
-	rec := NewAnthropicConfigReconciler(accountRepo, userRepo, adminSvc, tierSvc, cfg, redisClient)
+	rec := NewAnthropicConfigReconciler(accountRepo, userRepo, adminSvc, tierSvc, tierApplier, tlsSvc, settingSvc, cfg, redisClient)
 	rec.Start()
 	return rec
 }

--- a/scripts/sentinels/check-tier-baseline-embed.py
+++ b/scripts/sentinels/check-tier-baseline-embed.py
@@ -20,6 +20,8 @@ Compared pairs (semantic JSON equality — key order / whitespace ignored):
     == backend/internal/baseline/anthropic-oauth-stability-baselines-tiered.json
   deploy/aws/stage0/anthropic-stub-pool-baselines.json
     == backend/internal/baseline/anthropic-stub-pool-baselines.json
+  deploy/aws/stage0/anthropic-http-mimicry-baselines.json
+    == backend/internal/baseline/anthropic-http-mimicry-baselines.json
 
 Third assertion (migration immutability):
   backend/migrations/tk_012_...sql tiers seed == FROZEN_TK012_SEED (its original,
@@ -62,6 +64,10 @@ TIER_BASELINE_NAME = "anthropic-oauth-stability-baselines-tiered.json"
 PAIRS = [
     "anthropic-oauth-stability-baselines-tiered.json",
     "anthropic-stub-pool-baselines.json",
+    # HTTP mimicry baseline (UA version + per-model betas) — embedded so the
+    # config reconciler self-heals settings.claude_code_user_agent_version /
+    # claude_code_http_mimicry_manifest toward it without an operator sync-runtime.
+    "anthropic-http-mimicry-baselines.json",
 ]
 
 # Column order of the tk_012 `INSERT INTO tiers (...)` seed.
@@ -269,7 +275,7 @@ def main() -> int:
 
     if ok_all:
         if not args.quiet:
-            for name, _ in results[:2]:
+            for name, _ in results[: len(PAIRS)]:
                 print(f"OK: embedded {name} matches deploy/aws/stage0 source")
             print("OK: tk_012 migration seed matches its frozen original (immutable)")
         return 0
@@ -291,7 +297,7 @@ def main() -> int:
             "change is genuinely needed, add a NEW migration (never edit tk_012).",
             file=sys.stderr,
         )
-        if all(ok for _, ok in results[:2]):
+        if all(ok for _, ok in results[: len(PAIRS)]):
             return 1
 
     print("FAIL: embedded anthropic baseline DRIFT vs deploy/aws/stage0 source", file=sys.stderr)

--- a/scripts/sentinels/gateway-tk.json
+++ b/scripts/sentinels/gateway-tk.json
@@ -1325,10 +1325,11 @@
       "path": "backend/internal/service/account_tier_service_tk.go",
       "must_contain": [
         "func (s *AccountTierService) ApplyTier(",
-        "extra[\"enable_tls_fingerprint\"] = true",
+        "s.tlsSvc.GetOrUpsertByName(ctx, eff.CanonicalTLSProfile())",
+        "extra[\"tls_fingerprint_profile_id\"] = tlsProfileID",
         "AccountTierExtraKey"
       ],
-      "rationale": "TK per-account tier-apply service: the UI 'Set Tier' action that replaces the high-frequency ops/anthropic SSM fan-out for a single deployment. ApplyTier accepts anthropic OAuth AND setup-token accounts (both are subject to 5h window + session control per Account.IsAnthropicOAuthOrSetupToken); api-key / mirror stubs and other platforms are rejected. It derives the desired account config from the embedded tier baseline (concurrency/priority/rate_multiplier + merged extra + shared credentials), upserts the canonical TLS fingerprint profile, pins enable_tls_fingerprint + tls_fingerprint_profile_id + stability_tier on extra, and persists via the existing UpdateAccount path (which runs the operator-Σ sync). Writes ONLY this deployment's DB. Silent upstream-merge deletion would break the admin Set-Tier UI flow."
+      "rationale": "TK per-account tier-apply service: the UI 'Set Tier' action that replaces the high-frequency ops/anthropic SSM fan-out for a single deployment. ApplyTier accepts anthropic OAuth AND setup-token accounts (both are subject to 5h window + session control per Account.IsAnthropicOAuthOrSetupToken); api-key / mirror stubs and other platforms are rejected. It derives the desired account config from the embedded tier baseline (concurrency/priority/rate_multiplier + merged extra + shared credentials), CREATES-IF-ABSENT the canonical TLS fingerprint profile via GetOrUpsertByName (the GetByName-only lookup was the root cause of silent built-in-default ClientHello fallback when the profile row was missing), binds tls_fingerprint_profile_id + pins the shared_baseline extra/credentials template + priority on the account, and persists via the existing UpdateAccount path (which runs the operator-Σ sync). The per-node config reconciler re-runs this same path to self-heal any creation path. Writes ONLY this deployment's DB. The GetOrUpsertByName + tls_fingerprint_profile_id binding anchors are the regression guard for the fix; silent upstream-merge deletion would break the admin Set-Tier UI flow and reintroduce the unbound-TLS bug."
     },
     {
       "path": "backend/internal/handler/admin/account_handler_tk_tier.go",


### PR DESCRIPTION
## Problem

Operator added an anthropic OAuth account and set a tier, but `tls_fingerprint_profiles` had **no `tk_canonical_cc_oauth` row** → the account silently ran on the **built-in default ClientHello** (plus missing credentials self-protection template and `priority` drift). This is exactly the drift surfaced by `tokenkey-anthropic-oauth-config check all`.

## Root cause

`AccountTierService.ApplyTier` only *looked up* the canonical TLS profile id via the **read-only `GetByName`** — when the row was absent it left the binding empty and merely **warned** (`"non-fatal for the binding, so we only warn"`). It also never wrote the `shared_baseline` credentials/extra template or `priority`. The only thing that upserted the profile was the operator-laptop Python `remediate-guard-drift`, which the account-creation path never runs.

## Fix (three layers)

**L1 — `ApplyTier` is now a complete, idempotent "materialize shared_baseline"** (`account_tier_service_tk.go`)
- `GetByName` → **`GetOrUpsertByName`**: creates-if-absent the canonical TLS profile and binds its id (**fail-loud**, not a silent warn).
- Writes the credentials self-protection template (`temp_unschedulable_*` + `intercept_warmup_requests`) — OAuth tokens preserved by `MergePreservingSensitiveCreds`.
- Writes the extra mimicry flags + `priority = baseline` (post-#551 uniform).

**L2 — Per-node reconciler self-heals shared_baseline INFRASTRUCTURE** (`anthropic_config_reconciler_tk_account_baseline.go`)
- Detects unbound/dangling TLS, missing credentials template, or priority drift on tier-bound oauth/setup-token accounts → re-runs `ApplyTier` (single write path). Any creation path (admin UI, bare SQL) converges. Tier **NUMERIC** fields stay report-only.

**L3 — Reconciler self-heals deployment-level Claude Code UA + mimicry settings** (`setting_service_tk_mimicry_selfheal.go` + baseline embed)
- In-process `sync-runtime`: a fresh node acquires the canonical UA/manifest from an embedded baseline without an operator round-trip (kills the `http_ua_drift` on freshly-deployed edges). Adds the embedded `anthropic-http-mimicry-baselines.json` + a `check-tier-baseline-embed.py` sentinel pair to prevent split-brain.

## Net effect — operator's "4 steps"

1. OAuth auth (new account) → 2. **set tier (this step now auto-completes TLS profile create+bind / credentials limit+self-protection template / extra / priority / concurrency)** → 3. bind group → 4. enable schedulable. UA and operator balance self-heal via the reconciler. The operator never touches the TLS template library, error/rate-limit rules, or UA again.

## Reused existing building blocks
`baseline.EffectiveBaselineForTier` / `EffectiveTierBaseline.CanonicalTLSProfile`, `TLSFingerprintProfileService.GetOrUpsertByName`, `MergePreservingSensitiveCreds`, `reconcileKiroPriorityBaseline` shape, `ClaudeCodeHTTPMimicryManifest` / `ParseClaudeCodeHTTPMimicryManifest`.

## Tests / gates (all green)
- `go test -tags=unit ./...` (full, incl. internal/server contract) + `-tags=integration ./internal/{service,repository,setup,server}/...`
- `golangci-lint run ./...` — 0 issues
- `go generate ./cmd/server` (wire regenerated)
- `scripts/preflight.sh` PASS — sentinel anchor for `account_tier_service_tk.go` updated to guard the fix (`GetOrUpsertByName` + `tls_fingerprint_profile_id` binding)

New unit coverage: ApplyTier create+bind / credentials+token-preserve / priority / **idempotent** / fail-loud-without-tls; reconciler heal (unbound/priority/dangling) + skip (aligned/apikey); UA self-heal (unset/idempotent/stale).

## Merge mode
TK-originated fix → **Squash and merge** (per CLAUDE.md §5.y).

🤖 Generated with [Claude Code](https://claude.com/claude-code)