### PR TITLE
fix(usage): OpenAI Codex 5h 用量百分比不再反算（与 7d 对称直传 used%）

### DIFF
--- a/backend/internal/service/account_test_service_openai_test.go
+++ b/backend/internal/service/account_test_service_openai_test.go
@@ -132,7 +132,7 @@ func TestAccountTestService_OpenAISuccessPersistsSnapshotFromHeaders(t *testing.
 	require.Len(t, upstream.requests, 1)
 	require.Equal(t, HTTPUpstreamProfileOpenAI, HTTPUpstreamProfileFromContext(upstream.requests[0].Context()))
 	require.NotEmpty(t, repo.updatedExtra)
-	require.Equal(t, 58.0, repo.updatedExtra["codex_5h_used_percent"])
+	require.Equal(t, 42.0, repo.updatedExtra["codex_5h_used_percent"])
 	require.Equal(t, 88.0, repo.updatedExtra["codex_7d_used_percent"])
 	require.Contains(t, recorder.Body.String(), "test_complete")
 }
@@ -170,7 +170,7 @@ func TestAccountTestService_OpenAI429PersistsSnapshotAndRateLimitState(t *testin
 	resp.Header.Set("x-codex-primary-used-percent", "100")
 	resp.Header.Set("x-codex-primary-reset-after-seconds", "604800")
 	resp.Header.Set("x-codex-primary-window-minutes", "10080")
-	resp.Header.Set("x-codex-secondary-used-percent", "0")
+	resp.Header.Set("x-codex-secondary-used-percent", "100")
 	resp.Header.Set("x-codex-secondary-reset-after-seconds", "18000")
 	resp.Header.Set("x-codex-secondary-window-minutes", "300")
 

--- a/backend/internal/service/account_usage_service_test.go
+++ b/backend/internal/service/account_usage_service_test.go
@@ -73,7 +73,7 @@ func TestExtractOpenAICodexProbeUpdatesAccepts429WithCodexHeaders(t *testing.T) 
 	headers.Set("x-codex-primary-used-percent", "100")
 	headers.Set("x-codex-primary-reset-after-seconds", "604800")
 	headers.Set("x-codex-primary-window-minutes", "10080")
-	headers.Set("x-codex-secondary-used-percent", "0")
+	headers.Set("x-codex-secondary-used-percent", "100")
 	headers.Set("x-codex-secondary-reset-after-seconds", "18000")
 	headers.Set("x-codex-secondary-window-minutes", "300")
 

--- a/backend/internal/service/openai_gateway_service.go
+++ b/backend/internal/service/openai_gateway_service.go
@@ -126,21 +126,18 @@ type NormalizedCodexLimits struct {
 	Window7dMinutes *int
 }
 
-func normalizeCodexFiveHourUsedPercent(raw *float64) *float64 {
-	if raw == nil {
-		return nil
-	}
-	// OpenAI's 5h Codex quota header is remaining%, despite the upstream header
-	// name saying "used"; the canonical codex_5h_used_percent field stores used%.
-	used := 100 - *raw
-	if used < 0 {
-		used = 0
-	}
-	return &used
-}
-
 // Normalize converts primary/secondary fields to canonical 5h/7d fields.
 // Strategy: Compare window_minutes to determine which is 5h vs 7d.
+//
+// Both the 5h and 7d `x-codex-*-used-percent` headers carry **used** percent
+// (higher = more consumed), matching the literal header name. An earlier change
+// (b65dde63, 2026-05-31) assumed the 5h header was remaining% and applied
+// `100-raw`; that was wrong. Disproved by prod capture on 2026-06-04
+// (GPT-pro1: 5h window=300min raw used=1; GPT-pro2: raw used=0) plus the
+// physical constraint that the 5h window is a sub-interval of 7d — a 5h that is
+// 99% used cannot coexist with a 7d that is 1% used. 5h is now passed through
+// like 7d. Do NOT reintroduce a 100-raw inversion without a fresh raw-header
+// capture proving remaining% semantics.
 // Returns nil if snapshot is nil or has no useful data.
 func (s *OpenAICodexUsageSnapshot) Normalize() *NormalizedCodexLimits {
 	if s == nil {
@@ -197,7 +194,7 @@ func (s *OpenAICodexUsageSnapshot) Normalize() *NormalizedCodexLimits {
 
 	// Assign values
 	if use5hFromPrimary {
-		result.Used5hPercent = normalizeCodexFiveHourUsedPercent(s.PrimaryUsedPercent)
+		result.Used5hPercent = s.PrimaryUsedPercent
 		result.Reset5hSeconds = s.PrimaryResetAfterSeconds
 		result.Window5hMinutes = s.PrimaryWindowMinutes
 		result.Used7dPercent = s.SecondaryUsedPercent
@@ -207,7 +204,7 @@ func (s *OpenAICodexUsageSnapshot) Normalize() *NormalizedCodexLimits {
 		result.Used7dPercent = s.PrimaryUsedPercent
 		result.Reset7dSeconds = s.PrimaryResetAfterSeconds
 		result.Window7dMinutes = s.PrimaryWindowMinutes
-		result.Used5hPercent = normalizeCodexFiveHourUsedPercent(s.SecondaryUsedPercent)
+		result.Used5hPercent = s.SecondaryUsedPercent
 		result.Reset5hSeconds = s.SecondaryResetAfterSeconds
 		result.Window5hMinutes = s.SecondaryWindowMinutes
 	}
@@ -6224,7 +6221,9 @@ func ParseCodexRateLimitHeaders(headers http.Header) *OpenAICodexUsageSnapshot {
 		return nil
 	}
 
-	// Primary (weekly) limits
+	// Primary window limits. The 5h/7d window assignment is NOT fixed to
+	// primary/secondary — Normalize() decides it from window_minutes. used-percent
+	// is consumed%. (prod commonly sends primary=5h(300min), secondary=7d(10080min).)
 	if v := parseFloat("x-codex-primary-used-percent"); v != nil {
 		snapshot.PrimaryUsedPercent = v
 		hasData = true
@@ -6238,7 +6237,7 @@ func ParseCodexRateLimitHeaders(headers http.Header) *OpenAICodexUsageSnapshot {
 		hasData = true
 	}
 
-	// Secondary (5h) limits
+	// Secondary window limits (window assignment via Normalize(); used-percent is consumed%).
 	if v := parseFloat("x-codex-secondary-used-percent"); v != nil {
 		snapshot.SecondaryUsedPercent = v
 		hasData = true

--- a/backend/internal/service/openai_gateway_service_codex_snapshot_test.go
+++ b/backend/internal/service/openai_gateway_service_codex_snapshot_test.go
@@ -104,11 +104,14 @@ func TestBuildCodexUsageExtraUpdates_UsesSnapshotUpdatedAt(t *testing.T) {
 	}
 }
 
-func TestBuildCodexUsageExtraUpdates_NormalizesFiveHourRemainingToUsedPercent(t *testing.T) {
+// 5h used-percent is passed through as consumed% (same as 7d), NOT inverted.
+// Here primary window=10080(7d), secondary window=300(5h): 7d=primary used=93,
+// 5h=secondary used=6. See Normalize() doc for the b65dde63 inversion regression.
+func TestBuildCodexUsageExtraUpdates_FiveHourUsedPercentPassthrough(t *testing.T) {
 	primaryUsed := 93.0
 	primaryReset := 86400
 	primaryWindow := 10080
-	secondaryRemaining := 6.0
+	secondaryUsed := 6.0
 	secondaryReset := 3600
 	secondaryWindow := 300
 
@@ -116,7 +119,7 @@ func TestBuildCodexUsageExtraUpdates_NormalizesFiveHourRemainingToUsedPercent(t 
 		PrimaryUsedPercent:         &primaryUsed,
 		PrimaryResetAfterSeconds:   &primaryReset,
 		PrimaryWindowMinutes:       &primaryWindow,
-		SecondaryUsedPercent:       &secondaryRemaining,
+		SecondaryUsedPercent:       &secondaryUsed,
 		SecondaryResetAfterSeconds: &secondaryReset,
 		SecondaryWindowMinutes:     &secondaryWindow,
 		UpdatedAt:                  "2026-05-30T07:04:09Z",
@@ -130,8 +133,8 @@ func TestBuildCodexUsageExtraUpdates_NormalizesFiveHourRemainingToUsedPercent(t 
 	if got := updates["codex_secondary_used_percent"]; got != 6.0 {
 		t.Fatalf("codex_secondary_used_percent = %v, want raw upstream value 6", got)
 	}
-	if got := updates["codex_5h_used_percent"]; got != 94.0 {
-		t.Fatalf("codex_5h_used_percent = %v, want 94", got)
+	if got := updates["codex_5h_used_percent"]; got != 6.0 {
+		t.Fatalf("codex_5h_used_percent = %v, want 6 (used%% passthrough, no 100-raw inversion)", got)
 	}
 	if got := updates["codex_7d_used_percent"]; got != 93.0 {
 		t.Fatalf("codex_7d_used_percent = %v, want 93", got)
@@ -223,4 +226,56 @@ func TestBuildCodexUsageExtraUpdates_WithoutNormalizedWindowFields(t *testing.T)
 	if _, ok := updates["codex_7d_reset_at"]; ok {
 		t.Fatalf("did not expect codex_7d_reset_at in updates: %v", updates["codex_7d_reset_at"])
 	}
+}
+
+// TestNormalize_ProdLayoutUsedPercentPassthrough pins used-percent semantics to
+// the real prod header layout captured 2026-06-04 (prod i-0e4a90677f0450277):
+// GPT-pro1 primary(window=300min, used=1) + secondary(window=10080min, used=1);
+// GPT-pro2 primary(window=300min, used=0). primary IS the 5h window (smaller),
+// secondary IS the 7d window. used-percent is consumed%, passed through as-is.
+// Regression guard against the b65dde63 100-raw inversion that rendered these
+// idle accounts as 99%/100% and (for raw=0) tripped is5hExhausted.
+func TestNormalize_ProdLayoutUsedPercentPassthrough(t *testing.T) {
+	win5h := 300
+	win7d := 10080
+
+	t.Run("GPT-pro1 idle: 5h=1 7d=1", func(t *testing.T) {
+		used := 1.0
+		snapshot := &OpenAICodexUsageSnapshot{
+			PrimaryUsedPercent:     &used,
+			PrimaryWindowMinutes:   &win5h, // 5h (smaller window)
+			SecondaryUsedPercent:   &used,
+			SecondaryWindowMinutes: &win7d, // 7d
+		}
+		n := snapshot.Normalize()
+		if n == nil {
+			t.Fatal("expected non-nil normalized")
+		}
+		if n.Used5hPercent == nil || *n.Used5hPercent != 1.0 {
+			t.Fatalf("Used5hPercent = %v, want 1 (consumed%%, no 100-raw inversion)", n.Used5hPercent)
+		}
+		if n.Used7dPercent == nil || *n.Used7dPercent != 1.0 {
+			t.Fatalf("Used7dPercent = %v, want 1", n.Used7dPercent)
+		}
+		if n.Window5hMinutes == nil || *n.Window5hMinutes != 300 {
+			t.Fatalf("Window5hMinutes = %v, want 300 (5h is the smaller window)", n.Window5hMinutes)
+		}
+	})
+
+	t.Run("GPT-pro2 idle: 5h=0 must NOT invert to 100", func(t *testing.T) {
+		used := 0.0
+		snapshot := &OpenAICodexUsageSnapshot{
+			PrimaryUsedPercent:     &used,
+			PrimaryWindowMinutes:   &win5h, // 5h
+			SecondaryUsedPercent:   &used,
+			SecondaryWindowMinutes: &win7d, // 7d
+		}
+		n := snapshot.Normalize()
+		if n == nil {
+			t.Fatal("expected non-nil normalized")
+		}
+		if n.Used5hPercent == nil || *n.Used5hPercent != 0.0 {
+			t.Fatalf("Used5hPercent = %v, want 0 (must NOT invert to 100 / trip is5hExhausted)", n.Used5hPercent)
+		}
+	})
 }

--- a/backend/internal/service/openai_gateway_service_test.go
+++ b/backend/internal/service/openai_gateway_service_test.go
@@ -1800,7 +1800,7 @@ func TestOpenAIUpdateCodexUsageSnapshotFromHeaders(t *testing.T) {
 
 	select {
 	case updates := <-repo.updateExtraCalls:
-		require.Equal(t, 88.0, updates["codex_5h_used_percent"])
+		require.Equal(t, 12.0, updates["codex_5h_used_percent"])
 		require.Equal(t, 34.0, updates["codex_7d_used_percent"])
 		require.Equal(t, 600, updates["codex_5h_reset_after_seconds"])
 		require.Equal(t, 86400, updates["codex_7d_reset_after_seconds"])

--- a/backend/internal/service/ratelimit_service_openai_test.go
+++ b/backend/internal/service/ratelimit_service_openai_test.go
@@ -51,7 +51,7 @@ func TestCalculateOpenAI429ResetTime_5hExhausted(t *testing.T) {
 	headers.Set("x-codex-primary-used-percent", "50")
 	headers.Set("x-codex-primary-reset-after-seconds", "500000")
 	headers.Set("x-codex-primary-window-minutes", "10080") // 7 days
-	headers.Set("x-codex-secondary-used-percent", "0")
+	headers.Set("x-codex-secondary-used-percent", "100")   // 5h exhausted (used%)
 	headers.Set("x-codex-secondary-reset-after-seconds", "3600") // 1 hour
 	headers.Set("x-codex-secondary-window-minutes", "300")       // 5 hours
 
@@ -115,7 +115,7 @@ func TestCalculateOpenAI429ResetTime_ReversedWindowOrder(t *testing.T) {
 
 	// Test when OpenAI sends primary as 5h and secondary as 7d (reversed)
 	headers := http.Header{}
-	headers.Set("x-codex-primary-used-percent", "0")           // This is 5h remaining%
+	headers.Set("x-codex-primary-used-percent", "100")         // This is 5h, exhausted (used%)
 	headers.Set("x-codex-primary-reset-after-seconds", "3600") // 1 hour
 	headers.Set("x-codex-primary-window-minutes", "300")       // 5 hours - smaller!
 	headers.Set("x-codex-secondary-used-percent", "50")
@@ -173,7 +173,7 @@ func TestHandle429_OpenAIPersistsCodexSnapshotImmediately(t *testing.T) {
 	headers.Set("x-codex-primary-used-percent", "100")
 	headers.Set("x-codex-primary-reset-after-seconds", "604800")
 	headers.Set("x-codex-primary-window-minutes", "10080")
-	headers.Set("x-codex-secondary-used-percent", "0")
+	headers.Set("x-codex-secondary-used-percent", "100")
 	headers.Set("x-codex-secondary-reset-after-seconds", "18000")
 	headers.Set("x-codex-secondary-window-minutes", "300")
 
@@ -217,7 +217,7 @@ func TestNormalizedCodexLimits(t *testing.T) {
 	pUsed := 100.0
 	pReset := 384607
 	pWindow := 10080
-	sRemaining := 3.0
+	sUsed := 3.0
 	sReset := 17369
 	sWindow := 300
 
@@ -225,7 +225,7 @@ func TestNormalizedCodexLimits(t *testing.T) {
 		PrimaryUsedPercent:         &pUsed,
 		PrimaryResetAfterSeconds:   &pReset,
 		PrimaryWindowMinutes:       &pWindow,
-		SecondaryUsedPercent:       &sRemaining,
+		SecondaryUsedPercent:       &sUsed,
 		SecondaryResetAfterSeconds: &sReset,
 		SecondaryWindowMinutes:     &sWindow,
 	}
@@ -242,8 +242,8 @@ func TestNormalizedCodexLimits(t *testing.T) {
 	if normalized.Reset7dSeconds == nil || *normalized.Reset7dSeconds != 384607 {
 		t.Errorf("expected Reset7dSeconds=384607, got %v", normalized.Reset7dSeconds)
 	}
-	if normalized.Used5hPercent == nil || *normalized.Used5hPercent != 97.0 {
-		t.Errorf("expected Used5hPercent=97, got %v", normalized.Used5hPercent)
+	if normalized.Used5hPercent == nil || *normalized.Used5hPercent != 3.0 {
+		t.Errorf("expected Used5hPercent=3, got %v", normalized.Used5hPercent)
 	}
 	if normalized.Reset5hSeconds == nil || *normalized.Reset5hSeconds != 17369 {
 		t.Errorf("expected Reset5hSeconds=17369, got %v", normalized.Reset5hSeconds)
@@ -331,11 +331,11 @@ func TestRateLimitService_HandleUpstreamError_403FallsBackToRawBody(t *testing.T
 
 func TestNormalizedCodexLimits_OnlySecondaryData(t *testing.T) {
 	// Test when only secondary has data, no window_minutes
-	sRemaining := 60.0
+	sUsed := 60.0
 	sReset := 3000
 
 	snapshot := &OpenAICodexUsageSnapshot{
-		SecondaryUsedPercent:       &sRemaining,
+		SecondaryUsedPercent:       &sUsed,
 		SecondaryResetAfterSeconds: &sReset,
 		// No window_minutes, no primary data
 	}
@@ -347,8 +347,8 @@ func TestNormalizedCodexLimits_OnlySecondaryData(t *testing.T) {
 
 	// Legacy assumption: primary=7d, secondary=5h
 	// So secondary goes to 5h
-	if normalized.Used5hPercent == nil || *normalized.Used5hPercent != 40.0 {
-		t.Errorf("expected Used5hPercent=40, got %v", normalized.Used5hPercent)
+	if normalized.Used5hPercent == nil || *normalized.Used5hPercent != 60.0 {
+		t.Errorf("expected Used5hPercent=60, got %v", normalized.Used5hPercent)
 	}
 	if normalized.Reset5hSeconds == nil || *normalized.Reset5hSeconds != 3000 {
 		t.Errorf("expected Reset5hSeconds=3000, got %v", normalized.Reset5hSeconds)
@@ -363,13 +363,13 @@ func TestNormalizedCodexLimits_BothDataNoWindowMinutes(t *testing.T) {
 	// Test when both have data but no window_minutes
 	pUsed := 100.0
 	pReset := 400000
-	sRemaining := 30.0
+	sUsed := 50.0
 	sReset := 10000
 
 	snapshot := &OpenAICodexUsageSnapshot{
 		PrimaryUsedPercent:         &pUsed,
 		PrimaryResetAfterSeconds:   &pReset,
-		SecondaryUsedPercent:       &sRemaining,
+		SecondaryUsedPercent:       &sUsed,
 		SecondaryResetAfterSeconds: &sReset,
 		// No window_minutes
 	}
@@ -386,8 +386,8 @@ func TestNormalizedCodexLimits_BothDataNoWindowMinutes(t *testing.T) {
 	if normalized.Reset7dSeconds == nil || *normalized.Reset7dSeconds != 400000 {
 		t.Errorf("expected Reset7dSeconds=400000, got %v", normalized.Reset7dSeconds)
 	}
-	if normalized.Used5hPercent == nil || *normalized.Used5hPercent != 70.0 {
-		t.Errorf("expected Used5hPercent=70, got %v", normalized.Used5hPercent)
+	if normalized.Used5hPercent == nil || *normalized.Used5hPercent != 50.0 {
+		t.Errorf("expected Used5hPercent=50, got %v", normalized.Used5hPercent)
 	}
 	if normalized.Reset5hSeconds == nil || *normalized.Reset5hSeconds != 10000 {
 		t.Errorf("expected Reset5hSeconds=10000, got %v", normalized.Reset5hSeconds)
@@ -418,7 +418,7 @@ func TestCalculateOpenAI429ResetTime_UserProvidedScenario(t *testing.T) {
 	// This is the exact scenario from the user:
 	// codex_7d_used_percent: 100
 	// codex_7d_reset_after_seconds: 384607 (约4.5天后重置)
-	// codex_5h_used_percent: 97 (from upstream 3% remaining)
+	// codex_5h_used_percent: 3 (current 5h window barely used; 7d累计已满被限)
 	// codex_5h_reset_after_seconds: 17369 (约4.8小时后重置)
 
 	svc := &RateLimitService{}

--- a/scripts/sentinels/gateway-tk.json
+++ b/scripts/sentinels/gateway-tk.json
@@ -1676,6 +1676,15 @@
         "var tkContextWindowAliasSuffix = regexp.MustCompile("
       ],
       "rationale": "Pure, fork-only Claude Code context-window model-alias stripper (claude-code #60913 / #50803 / #53031 / #55504 / #34143), kept in a *_tk_*.go companion out of upstream-owned gateway_service.go (rule §5). tkStripContextWindowModelAlias removes a trailing bracketed alias such as '[1m]' that cc serializes verbatim into the API model field on resume/continue/compact — Anthropic answers 404 not_found_error and the client silently falls back to the bare 200K model (paid 1M context lost, no error surfaced). The trailing-anchored regexp keeps a legitimate id (never contains brackets) a byte-for-byte no-op; the context-1m beta header flows through separately so the bare id still activates the 1M window. Anchor the pure function + the regexp guard so an upstream refactor that consolidates model normalization cannot delete this surface and silently re-expose the 404 + 200K downgrade. Exhaustively covered by gateway_anthropic_context_window_alias_tk_test.go."
+    },
+    {
+      "path": "backend/internal/service/openai_gateway_service.go",
+      "must_contain": [
+        "result.Used5hPercent = s.PrimaryUsedPercent",
+        "result.Used5hPercent = s.SecondaryUsedPercent",
+        "Do NOT reintroduce a 100-raw inversion"
+      ],
+      "rationale": "Codex 5h/7d usage-window used-percent must stay a straight passthrough of the upstream x-codex-*-used-percent headers (consumed%), NOT inverted. Commit b65dde63 (2026-05-31) wrapped 5h in normalizeCodexFiveHourUsedPercent (used=100-raw) on the wrong assumption the header was remaining%; that rendered idle accounts as 99%/100% on the admin account card AND tripped is5hExhausted (ratelimit_service.go) for raw=0 accounts, applying a bogus multi-hour 429 cooldown. Disproved by prod capture 2026-06-04 (i-0e4a90677f0450277): GPT-pro1 5h window=300min raw used=1, GPT-pro2 used=0, both barely used; plus the physical constraint that the 5h window is a sub-interval of 7d. Anchor the two passthrough assignments plus the do-not-reintroduce warning so a future upstream merge or refactor cannot silently re-add the inversion. Regression test: TestNormalize_ProdLayoutUsedPercentPassthrough."
     }
   ]
 }


### PR DESCRIPTION
## 背景

admin 账号卡片上 OpenAI OAuth 账号的 **5h 进度条普遍显示反了**：真没用的账号显示接近满（99%/100%），真用满的会显示空。线上排查（用户的 GPT-pro1/pro2 充值半个月没用却显示 5h 99%/100%）定位到根因。

## 根因

`b65dde63`（2026-05-31「修正 OpenAI 5h 用量百分比语义」）给 5h 加了一段反算 `used = 100 - raw`，**误判** 上游 `x-codex-*-used-percent` 头为「剩余」百分比。实际是「已用」语义。

**prod 实测坐实**（2026-06-04，`i-0e4a90677f0450277`，新鲜快照）：

| 账号 | 上游 5h(primary,300min) raw used | 上游 7d(secondary,10080min) raw used | 卡片显示 5h |
|---|---|---|---|
| GPT-pro1 | 1 | 1 | 99% ❌ |
| GPT-pro2 | 0 | 0 | 100% ❌ |

证据链：物理约束（5h 是 7d 子区间，5h 99% 不可能 7d 1%）+ header 字面名 `used` + 反算引入前旧快照显示正常 + 作者据以反算的 `UserProvidedScenario`（7d=100/5h raw=3）在 used 语义下完全自洽（7d 累计满、5h 窗口刚滚动）。

## 影响面（不止显示）

`ratelimit_service.go` 与 `ratelimit_service_tk_openai_burst.go` 用 `Used5hPercent >= 100` 判「5h 耗尽」。真没用的账号（raw=0→反算 100）在收到 429 时被**误判 5h 耗尽**、套上错误的多小时冷却。

## 改动

- 删除 `normalizeCodexFiveHourUsedPercent`，`Normalize()` 两处 5h 直传 used%（与 7d 对称）
- 修正 `ParseCodexRateLimitHeaders` 误导的 primary=weekly/secondary=5h 注释（窗口归属由 `window_minutes` 决定）
- 回退 `b65dde63` 把整套测试翻成 remaining 语义的断言
- 新增 `TestNormalize_ProdLayoutUsedPercentPassthrough`（带 prod provenance + raw=0 边界）
- `gateway-tk.json` 加 sentinel 钉住 used 直传，防 upstream merge/重构再加回反算

## 存量数据

无需迁移：已写错的 `codex_5h_used_percent` 在下一个 probe 周期（≤10min TTL 或点「查询」）被新逻辑覆盖纠正，用户卡片一个周期内自愈。

## 验证

- `go build ./...` ✓
- `go test -tags=unit ./...` ✓（52 包 ok / 0 FAIL）
- `golangci-lint run ./internal/service/...` ✓（0 issues）
- `scripts/preflight.sh` ✓ PASS

🤖 Generated with [Claude Code](https://claude.com/claude-code)