### PR TITLE
fix(openai): enforce codex_cli_only at every gateway entry (Wei-Shaw/sub2api#3014)

### DIFF
--- a/.cache/upstream/fact-checks.json
+++ b/.cache/upstream/fact-checks.json
@@ -529,6 +529,44 @@
         "backend/internal/server/http.go:tkResolveTrustedProxies(cfg.Server.TrustedProxies)",
         "backend/internal/server/http_tk_trusted_proxies_test.go:TestTkTrustedProxiesClientIPResolution"
       ]
+    },
+    {
+      "upstream": "Wei-Shaw/sub2api#3014",
+      "severity": "high",
+      "summary": "codex_cli_only 访问控制绕过：限制此前只在 /v1/responses (Forward) 生效，普通非 Codex 客户端可经 /v1/chat/completions 兼容入口（内部转 Responses 后转发）继续使用受限 OAuth 账号。修复抽出共享 enforceCodexClientRestriction，在所有 OpenAI 网关转发入口统一执行：/responses、/v1/chat/completions、图片 OAuth 路径（forwardOpenAIImagesOAuth）；拒绝返回普通错误而非 *UpstreamFailoverError，确保不会 failover 到另一个账号而再次绕过策略。同时修掉既有脏 403：业务限流类拒绝已写完整响应时，handler 兜底 ensureForwardErrorResponse 不再追加错误帧污染 body。未开启 codex_cli_only 的账号为零成本 no-op。",
+      "fixed_by": [
+        "backend/internal/service/openai_gateway_service.go",
+        "backend/internal/service/openai_gateway_chat_completions.go",
+        "backend/internal/service/openai_images_responses.go",
+        "backend/internal/handler/openai_gateway_handler.go",
+        "backend/internal/service/openai_gateway_service_codex_cli_only_test.go",
+        "backend/internal/handler/openai_gateway_handler_test.go"
+      ],
+      "fixed_if_all_present": [
+        "backend/internal/service/openai_gateway_service.go:func (s *OpenAIGatewayService) enforceCodexClientRestriction(ctx context.Context, c *gin.Context, account *Account, body []byte) error {",
+        "backend/internal/service/openai_gateway_chat_completions.go:if err := s.enforceCodexClientRestriction(ctx, c, account, body); err != nil {",
+        "backend/internal/service/openai_images_responses.go:if err := s.enforceCodexClientRestriction(ctx, c, account, nil); err != nil {",
+        "backend/internal/handler/openai_gateway_handler.go:if service.HasOpsClientBusinessLimited(c) {",
+        "backend/internal/service/openai_gateway_service_codex_cli_only_test.go:TestForwardAsChatCompletions_CodexCliOnlyBlocksCompatEntry",
+        "backend/internal/handler/openai_gateway_handler_test.go:TestOpenAIGatewayEnsureForwardErrorResponse_SkipsAfterBusinessLimited"
+      ]
+    },
+    {
+      "upstream": "Wei-Shaw/sub2api#3025",
+      "tokenkey_pr": "youxuanxue/sub2api#568",
+      "severity": "high",
+      "summary": "OAuth/pro 账号 5h Codex 用量百分比显示异常（100-raw 反转）：上游 x-codex-*-used-percent（5h 与 7d）都直接携带 used%（消耗百分比），此前 b65dde63 误以为是 remaining% 而对 5h 套了 used=100-raw 反算，导致空闲号在 admin 账号卡显示 99%/100%，并误触 is5hExhausted 给 raw=0 账号挂上数小时 429 cooldown。#568 移除反算，5h 与 7d 对称直传 used%；窗口归属由 Normalize() 按 window_minutes 判定，非固定 primary/secondary。已由 scripts/sentinels/gateway-tk.json 钉住，防 merge/重构再加回反算。",
+      "fixed_by": [
+        "backend/internal/service/openai_gateway_service.go",
+        "backend/internal/service/openai_gateway_service_codex_snapshot_test.go",
+        "scripts/sentinels/gateway-tk.json"
+      ],
+      "fixed_if_all_present": [
+        "backend/internal/service/openai_gateway_service.go:result.Used5hPercent = s.PrimaryUsedPercent",
+        "backend/internal/service/openai_gateway_service.go:result.Used5hPercent = s.SecondaryUsedPercent",
+        "backend/internal/service/openai_gateway_service.go:Do NOT reintroduce a 100-raw inversion",
+        "backend/internal/service/openai_gateway_service_codex_snapshot_test.go:TestNormalize_ProdLayoutUsedPercentPassthrough"
+      ]
     }
   ]
 }

--- a/.cache/upstream/fixes.json
+++ b/.cache/upstream/fixes.json
@@ -596,6 +596,30 @@
         "backend/internal/pkg/claude/constants.go"
       ],
       "summary": "设计性差异非缺陷：Haiku OAuth mimic 刻意用独立 beta 集 FullClaudeCodeHaikuMimicryBetas（cc 2.1.160 structured-outputs 抓包，OMITS claude-code beta + advanced-tool-use，加 structured-outputs），运行时可经 claude_code_http_mimicry_manifest 热改。修正 gateway_service.go 误导注释（原称 Haiku 'includes claude-code beta'/'cc 2.1.152' 与实际 token 集矛盾）。无行为变更；如未来抓包确认 Haiku 真带 claude-code beta，改常量或下发 manifest。"
+    },
+    {
+      "upstream": "Wei-Shaw/sub2api#3014",
+      "status": "fixed_in_tokenkey",
+      "fixed_by": [
+        "backend/internal/service/openai_gateway_service.go",
+        "backend/internal/service/openai_gateway_chat_completions.go",
+        "backend/internal/service/openai_images_responses.go",
+        "backend/internal/handler/openai_gateway_handler.go",
+        "backend/internal/service/openai_gateway_service_codex_cli_only_test.go",
+        "backend/internal/handler/openai_gateway_handler_test.go"
+      ],
+      "summary": "codex_cli_only 访问控制绕过：限制此前只在 /v1/responses (Forward) 生效，普通非 Codex 客户端可经 /v1/chat/completions 兼容入口（内部转 Responses 后转发）继续使用受限 OAuth 账号。修复抽出共享 enforceCodexClientRestriction，在所有 OpenAI 网关转发入口统一执行：/responses、/v1/chat/completions、图片 OAuth 路径（forwardOpenAIImagesOAuth）；拒绝返回普通错误而非 *UpstreamFailoverError，确保不会 failover 到另一个账号而再次绕过策略。同时修掉既有脏 403：业务限流类拒绝已写完整响应时，handler 兜底 ensureForwardErrorResponse 不再追加错误帧污染 body。未开启 codex_cli_only 的账号为零成本 no-op。"
+    },
+    {
+      "upstream": "Wei-Shaw/sub2api#3025",
+      "tokenkey_pr": "youxuanxue/sub2api#568",
+      "status": "fixed_in_tokenkey",
+      "fixed_by": [
+        "backend/internal/service/openai_gateway_service.go",
+        "backend/internal/service/openai_gateway_service_codex_snapshot_test.go",
+        "scripts/sentinels/gateway-tk.json"
+      ],
+      "summary": "OAuth/pro 账号 5h Codex 用量百分比显示异常（100-raw 反转）：上游 x-codex-*-used-percent（5h 与 7d）都直接携带 used%（消耗百分比），此前 b65dde63 误以为是 remaining% 而对 5h 套了 used=100-raw 反算，导致空闲号在 admin 账号卡显示 99%/100%，并误触 is5hExhausted 给 raw=0 账号挂上数小时 429 cooldown。#568 移除反算，5h 与 7d 对称直传 used%；窗口归属由 Normalize() 按 window_minutes 判定，非固定 primary/secondary。已由 scripts/sentinels/gateway-tk.json 钉住，防 merge/重构再加回反算。"
     }
   ]
 }

--- a/backend/internal/handler/openai_gateway_handler.go
+++ b/backend/internal/handler/openai_gateway_handler.go
@@ -1881,6 +1881,14 @@ func (h *OpenAIGatewayHandler) ensureForwardErrorResponse(c *gin.Context, stream
 	if c == nil || c.Writer == nil {
 		return false
 	}
+	// 客户端业务限流类拒绝（codex_cli_only / IP 限制 / feature gate 等）在 service 层
+	// 已写出一个完整的客户端响应（如 403 JSON）。此处若再补写错误帧，会把已提交的
+	// 响应体污染成 `{"error":...}event: response.failed...` 这种畸形内容
+	// （gin 不阻止 commit 之后的写入）。这类拒绝不依赖兜底补写，直接跳过。
+	// 见 upstream Wei-Shaw/sub2api#3014。
+	if service.HasOpsClientBusinessLimited(c) {
+		return false
+	}
 	// 旧实现在 Writer.Written 时直接 return false，导致 ping 已 flush 之后的
 	// 上游错误（http2 timeout、连接中断等）完全无法把错误传给客户端——
 	// HTTP 200 已锁死，TCP 直接 EOF，Codex CLI 报 "stream closed before response.completed"。

--- a/backend/internal/handler/openai_gateway_handler_test.go
+++ b/backend/internal/handler/openai_gateway_handler_test.go
@@ -1579,3 +1579,31 @@ func runOpenAIResponsesWebSocketUsageLogCase(t *testing.T, tc openAIResponsesWSU
 func testStringPtr(v string) *string {
 	return &v
 }
+
+// TestOpenAIGatewayEnsureForwardErrorResponse_SkipsAfterBusinessLimited 回归
+// upstream Wei-Shaw/sub2api#3014 的修复：service 层 codex_cli_only 拒绝已写出干净
+// 403 并打业务限流标记后，handler 兜底不得再追加错误帧，否则 403 body 会被污染成
+// `{"error":...}event: response.failed...`（gin 不阻止 commit 之后的写入）。
+func TestOpenAIGatewayEnsureForwardErrorResponse_SkipsAfterBusinessLimited(t *testing.T) {
+	gin.SetMode(gin.TestMode)
+	w := httptest.NewRecorder()
+	c, _ := gin.CreateTestContext(w)
+	c.Request = httptest.NewRequest(http.MethodPost, "/v1/chat/completions", nil)
+
+	service.MarkOpsClientBusinessLimited(c, service.OpsClientBusinessLimitedReasonLocalPolicyDenied)
+	c.JSON(http.StatusForbidden, gin.H{"error": gin.H{
+		"type":    "forbidden_error",
+		"message": "This account only allows Codex official clients",
+	}})
+
+	h := &OpenAIGatewayHandler{}
+	wrote := h.ensureForwardErrorResponse(c, false)
+
+	require.False(t, wrote)
+	require.Equal(t, http.StatusForbidden, w.Code)
+	require.NotContains(t, w.Body.String(), "response.failed")
+	require.NotContains(t, w.Body.String(), "event: error")
+	require.NotContains(t, w.Body.String(), "Upstream request failed")
+	var parsed map[string]any
+	require.NoError(t, json.Unmarshal(w.Body.Bytes(), &parsed))
+}

--- a/backend/internal/service/openai_gateway_chat_completions.go
+++ b/backend/internal/service/openai_gateway_chat_completions.go
@@ -64,6 +64,14 @@ func (s *OpenAIGatewayService) ForwardAsChatCompletions(
 	promptCacheKey string,
 	defaultMappedModel string,
 ) (*OpenAIForwardResult, error) {
+	// codex_cli_only 必须在入口处执行，且要早于任何上游转发分支——否则普通客户端
+	// 可经 /v1/chat/completions 兼容入口（内部转 Responses 后转发）绕过只在
+	// /responses 生效的限制。见 upstream Wei-Shaw/sub2api#3014。
+	// 对未开启该策略的账号（含 APIKey 账号）是零成本 no-op。
+	if err := s.enforceCodexClientRestriction(ctx, c, account, body); err != nil {
+		return nil, err
+	}
+
 	// 入口分流：APIKey 账号 + 强制或已探测确认上游不支持 Responses，走 CC 直转。
 	// 自动模式下标记缺失（未探测）按"现状即证据"原则继续走下方原 Responses 转换路径。
 	if account.Type == AccountTypeAPIKey && !openai_compat.ShouldUseResponsesAPI(account.Extra) {

--- a/backend/internal/service/openai_gateway_service.go
+++ b/backend/internal/service/openai_gateway_service.go
@@ -948,6 +948,39 @@ func (s *OpenAIGatewayService) detectCodexClientRestriction(c *gin.Context, acco
 	return s.getCodexClientRestrictionDetector().Detect(c, account, globalAllowedClients)
 }
 
+// errCodexClientRestricted 标记请求因账号 codex_cli_only 策略被拒绝。
+// 它是普通错误（非 *UpstreamFailoverError），所以网关 handler 不会据此切换账号——
+// 对一个受限账号 failover 到另一个账号会绕过运营对该账号的本地策略预期
+// （见 upstream Wei-Shaw/sub2api#3014 建议修复第 5 点）。
+var errCodexClientRestricted = errors.New("codex_cli_only restriction: only codex official clients are allowed")
+
+// enforceCodexClientRestriction 在 OpenAI 网关任一转发入口执行账号的 codex_cli_only 策略。
+//
+// 当账号开启 codex_cli_only 且请求客户端不在放行名单内时，写出 403 并返回
+// errCodexClientRestricted，调用方据此直接 return，不再转发上游、也不 failover。
+// 请求被放行（或账号未开启该策略）时返回 nil——对未开启策略的账号是零成本 no-op。
+//
+// 该 helper 是 codex_cli_only 在所有 OpenAI 网关入口的单一执行点：/responses
+// (Forward)、/v1/chat/completions (ForwardAsChatCompletions)、图片 OAuth 路径
+// (forwardOpenAIImagesOAuth) 共用同一套检测，避免任何兼容入口绕过限制。
+// 见 upstream Wei-Shaw/sub2api#3014：此前限制只在 /responses 生效，普通客户端
+// 可通过 /v1/chat/completions 兼容入口继续使用受限账号。
+func (s *OpenAIGatewayService) enforceCodexClientRestriction(ctx context.Context, c *gin.Context, account *Account, body []byte) error {
+	restrictionResult := s.detectCodexClientRestriction(c, account)
+	logCodexCLIOnlyDetection(ctx, c, account, getAPIKeyIDFromContext(c), restrictionResult, body)
+	if restrictionResult.Enabled && !restrictionResult.Matched {
+		MarkOpsClientBusinessLimited(c, OpsClientBusinessLimitedReasonLocalPolicyDenied)
+		c.JSON(http.StatusForbidden, gin.H{
+			"error": gin.H{
+				"type":    "forbidden_error",
+				"message": "This account only allows Codex official clients",
+			},
+		})
+		return errCodexClientRestricted
+	}
+	return nil
+}
+
 func getAPIKeyIDFromContext(c *gin.Context) int64 {
 	if c == nil {
 		return 0
@@ -2437,18 +2470,10 @@ func (s *OpenAIGatewayService) handleFailoverSideEffects(ctx context.Context, re
 func (s *OpenAIGatewayService) Forward(ctx context.Context, c *gin.Context, account *Account, body []byte) (*OpenAIForwardResult, error) {
 	startTime := time.Now()
 
-	restrictionResult := s.detectCodexClientRestriction(c, account)
-	apiKeyID := getAPIKeyIDFromContext(c)
-	logCodexCLIOnlyDetection(ctx, c, account, apiKeyID, restrictionResult, body)
-	if restrictionResult.Enabled && !restrictionResult.Matched {
-		MarkOpsClientBusinessLimited(c, OpsClientBusinessLimitedReasonLocalPolicyDenied)
-		c.JSON(http.StatusForbidden, gin.H{
-			"error": gin.H{
-				"type":    "forbidden_error",
-				"message": "This account only allows Codex official clients",
-			},
-		})
-		return nil, errors.New("codex_cli_only restriction: only codex official clients are allowed")
+	// codex_cli_only 在所有 OpenAI 网关入口共用 enforceCodexClientRestriction 执行
+	// （/responses、/v1/chat/completions、图片 OAuth），避免兼容入口绕过限制。
+	if err := s.enforceCodexClientRestriction(ctx, c, account, body); err != nil {
+		return nil, err
 	}
 
 	originalBody := body

--- a/backend/internal/service/openai_gateway_service_codex_cli_only_test.go
+++ b/backend/internal/service/openai_gateway_service_codex_cli_only_test.go
@@ -394,3 +394,77 @@ func TestOpenAIGatewayService_Forward_ModelCapacityErrorTriggersFailoverAndSameA
 	require.Contains(t, string(failoverErr.ResponseBody), "Selected model is at capacity")
 	require.False(t, c.Writer.Written(), "service 层应返回 failover 错误给上层重试/换号，而不是直接向客户端写响应")
 }
+
+func TestEnforceCodexClientRestriction(t *testing.T) {
+	gin.SetMode(gin.TestMode)
+	account := &Account{Platform: PlatformOpenAI, Type: AccountTypeOAuth, Extra: map[string]any{"codex_cli_only": true}}
+
+	newCtx := func() (*gin.Context, *httptest.ResponseRecorder) {
+		rec := httptest.NewRecorder()
+		c, _ := gin.CreateTestContext(rec)
+		c.Request = httptest.NewRequest(http.MethodPost, "/v1/chat/completions", nil)
+		c.Request.Header.Set("User-Agent", "curl/8.7.1")
+		return c, rec
+	}
+
+	t.Run("非官方客户端写出干净 403 并返回 sentinel 错误", func(t *testing.T) {
+		svc := &OpenAIGatewayService{codexDetector: &stubCodexRestrictionDetector{
+			result: CodexClientRestrictionDetectionResult{Enabled: true, Matched: false, Reason: CodexClientRestrictionReasonNotMatchedUA},
+		}}
+		c, rec := newCtx()
+
+		err := svc.enforceCodexClientRestriction(context.Background(), c, account, nil)
+		require.ErrorIs(t, err, errCodexClientRestricted)
+		require.Equal(t, http.StatusForbidden, rec.Code)
+		require.Contains(t, rec.Body.String(), "only allows Codex official clients")
+		require.True(t, HasOpsClientBusinessLimited(c))
+		// 响应体必须是单个干净 JSON，不含被追加的 SSE/error 终止帧。
+		require.NotContains(t, rec.Body.String(), "response.failed")
+		require.NotContains(t, rec.Body.String(), "event: error")
+	})
+
+	t.Run("命中官方客户端时放行且不写响应", func(t *testing.T) {
+		svc := &OpenAIGatewayService{codexDetector: &stubCodexRestrictionDetector{
+			result: CodexClientRestrictionDetectionResult{Enabled: true, Matched: true, Reason: CodexClientRestrictionReasonMatchedUA},
+		}}
+		c, _ := newCtx()
+
+		err := svc.enforceCodexClientRestriction(context.Background(), c, account, nil)
+		require.NoError(t, err)
+		require.False(t, c.Writer.Written())
+	})
+
+	t.Run("账号未开启策略时是零成本 no-op", func(t *testing.T) {
+		svc := &OpenAIGatewayService{codexDetector: &stubCodexRestrictionDetector{
+			result: CodexClientRestrictionDetectionResult{Enabled: false, Matched: false, Reason: CodexClientRestrictionReasonDisabled},
+		}}
+		c, _ := newCtx()
+
+		err := svc.enforceCodexClientRestriction(context.Background(), c, account, nil)
+		require.NoError(t, err)
+		require.False(t, c.Writer.Written())
+	})
+}
+
+// TestForwardAsChatCompletions_CodexCliOnlyBlocksCompatEntry 复刻 upstream
+// Wei-Shaw/sub2api#3014：codex_cli_only 账号经 /v1/chat/completions 兼容入口被
+// 普通客户端调用时，必须在转发上游之前返回 403——此前限制只在 /responses 生效，
+// 该兼容入口可绕过限制。
+func TestForwardAsChatCompletions_CodexCliOnlyBlocksCompatEntry(t *testing.T) {
+	gin.SetMode(gin.TestMode)
+	svc := &OpenAIGatewayService{codexDetector: &stubCodexRestrictionDetector{
+		result: CodexClientRestrictionDetectionResult{Enabled: true, Matched: false, Reason: CodexClientRestrictionReasonNotMatchedUA},
+	}}
+	rec := httptest.NewRecorder()
+	c, _ := gin.CreateTestContext(rec)
+	c.Request = httptest.NewRequest(http.MethodPost, "/v1/chat/completions", nil)
+	c.Request.Header.Set("User-Agent", "curl/8.7.1")
+	account := &Account{Platform: PlatformOpenAI, Type: AccountTypeOAuth, Extra: map[string]any{"codex_cli_only": true}}
+	body := []byte(`{"model":"gpt-5.1","messages":[{"role":"user","content":"hi"}],"stream":false,"max_tokens":1}`)
+
+	result, err := svc.ForwardAsChatCompletions(context.Background(), c, account, body, "", "")
+	require.Nil(t, result)
+	require.ErrorIs(t, err, errCodexClientRestricted)
+	require.Equal(t, http.StatusForbidden, rec.Code)
+	require.Contains(t, rec.Body.String(), "only allows Codex official clients")
+}

--- a/backend/internal/service/openai_images_responses.go
+++ b/backend/internal/service/openai_images_responses.go
@@ -1130,6 +1130,12 @@ func (s *OpenAIGatewayService) forwardOpenAIImagesOAuth(
 	if err := validateOpenAIImagesModel(requestModel); err != nil {
 		return nil, err
 	}
+	// codex_cli_only 同样覆盖图片 OAuth 入口：受限账号的图片生成/编辑请求也只允许
+	// 官方客户端，避免经 /v1/images/* 绕过 /responses 上的限制。见
+	// upstream Wei-Shaw/sub2api#3014。未开启策略的账号是零成本 no-op。
+	if err := s.enforceCodexClientRestriction(ctx, c, account, nil); err != nil {
+		return nil, err
+	}
 	logger.LegacyPrintf(
 		"service.openai_gateway",
 		"[OpenAI] Images request routing request_model=%s endpoint=%s account_type=%s uploads=%d",

--- a/scripts/sentinels/gateway-tk.json
+++ b/scripts/sentinels/gateway-tk.json
@@ -1699,6 +1699,35 @@
         "defaultOpenAIMessagesDispatchOpusMappedModel   = \"gpt-5.5\""
       ],
       "rationale": "Code-default opus family mapping must stay gpt-5.5 (TK override of the upstream gpt-5.4 default; gpt-5.4 returned upstream 404 model_not_found on Codex OAuth accounts). This default is the zero-config fleet-wide fallback for claude-named requests on BOTH /v1/messages dispatch and /v1/chat/completions; an upstream merge restoring gpt-5.4 compiles clean but silently re-breaks opus traffic. Frontend mirror: frontend/src/views/admin/groupsMessagesDispatch.ts."
+    },
+    {
+      "path": "backend/internal/service/openai_gateway_service.go",
+      "must_contain": [
+        "func (s *OpenAIGatewayService) enforceCodexClientRestriction(ctx context.Context, c *gin.Context, account *Account, body []byte) error {",
+        "if err := s.enforceCodexClientRestriction(ctx, c, account, body); err != nil {"
+      ],
+      "rationale": "codex_cli_only (only Codex official clients) must be enforced at EVERY OpenAI gateway forward entry point through the single helper enforceCodexClientRestriction — not only on /v1/responses (Forward). Upstream Wei-Shaw/sub2api#3014: enforcement living only inside Forward let plain clients reach a restricted OAuth account via the /v1/chat/completions compat entry (internally converted to Responses), bypassing the policy. Anchor the helper definition + the Forward call site so a future merge/refactor cannot drop the shared enforcement back into a single endpoint and silently re-open the bypass. The rejection returns a plain error (NOT *UpstreamFailoverError) so handlers do not fail over to another account and re-bypass the per-account policy. Regression test: TestForwardAsChatCompletions_CodexCliOnlyBlocksCompatEntry."
+    },
+    {
+      "path": "backend/internal/service/openai_gateway_chat_completions.go",
+      "must_contain": [
+        "if err := s.enforceCodexClientRestriction(ctx, c, account, body); err != nil {"
+      ],
+      "rationale": "ForwardAsChatCompletions must run enforceCodexClientRestriction at the very top, before any upstream-forward branch — this is the entry that upstream Wei-Shaw/sub2api#3014 reported as bypassable (a restricted OAuth account reachable by non-Codex clients via /v1/chat/completions). Removing this call re-opens the access-control bypass. No-op for accounts that have not enabled codex_cli_only."
+    },
+    {
+      "path": "backend/internal/service/openai_images_responses.go",
+      "must_contain": [
+        "if err := s.enforceCodexClientRestriction(ctx, c, account, nil); err != nil {"
+      ],
+      "rationale": "forwardOpenAIImagesOAuth must run enforceCodexClientRestriction so codex_cli_only also covers the image generation/edit OAuth entry (/v1/images/*), preventing the same-class bypass as upstream Wei-Shaw/sub2api#3014 via an image surface. No-op for accounts that have not enabled codex_cli_only."
+    },
+    {
+      "path": "backend/internal/handler/openai_gateway_handler.go",
+      "must_contain": [
+        "if service.HasOpsClientBusinessLimited(c) {"
+      ],
+      "rationale": "ensureForwardErrorResponse must short-circuit when a client-business-limited rejection (codex_cli_only / IP restriction / feature gate) already wrote a complete client-facing response. Without this guard the fallback appends another error frame and corrupts the committed body into `{\"error\":...}event: response.failed...` (gin does not block writes after commit). Introduced with the upstream Wei-Shaw/sub2api#3014 fix; removing it brings back the dirty-403 body."
     }
   ]
 }


### PR DESCRIPTION
## 背景

审查 issue watchdog 缓存刷新 PR(#549/#543)时，从 #543 新增候选里发现 **Wei-Shaw/sub2api#3014** —— 一个对线上影响最大的访问控制绕过缺陷，确认在 TokenKey 当前代码同样存在。

## 缺陷

`codex_cli_only`（受限 OAuth 账号只允许 Codex 官方客户端）此前**只在 `/v1/responses`(`Forward()`)生效**。同一受限账号，普通非 Codex 客户端（如 `curl`）打 **`/v1/chat/completions`** 兼容入口（内部转 Responses 后转发上游）就能**绕过限制**——而 chat/completions 是绝大多数 OpenAI 兼容 SDK 的默认端点，等于该策略在最常用入口形同虚设。图片 OAuth 入口存在同类绕过。

## 修复

- 抽出共享 `enforceCodexClientRestriction()` 作为 codex_cli_only 在所有 OpenAI 网关转发入口的**单一执行点**；`Forward()` 改调它（行为逐字等价）。
- `ForwardAsChatCompletions()` 入口补齐 —— 关闭报告的绕过。
- `forwardOpenAIImagesOAuth()`（图片 OAuth）补齐 —— 关闭同类绕过。
- 拒绝返回**普通错误**（非 `*UpstreamFailoverError`），handler 不会 failover 到另一账号再次绕过策略（对应 issue 建议第 5 点）。
- 守卫 `ensureForwardErrorResponse`：业务限流类拒绝（codex_cli_only / IP 限制 / feature gate）已写完整响应时不再追加错误帧，修掉既有脏 403(`{"error":...}event: response.failed...`，实测 gin 在 commit 后仍会追加写入)。
- 对未开启 codex_cli_only 的账号是**零成本 no-op**。

## 防护与台账

- `scripts/sentinels/gateway-tk.json` 新增 4 条 sentinel 钉住三入口执行点 + handler 守卫，防未来 merge/重构再次漏掉任一入口而重开绕过。
- `.cache/upstream/fact-checks.json` + `fixes.json` 记录 #3014；并**补登** #568 已修但漏记的 #3025(Codex 5h used% 直传)fact-check，避免 watchdog 重复重提。

## 测试与门禁

- `go test -tags=unit ./...` 全绿；`golangci-lint run` 0 issues；unit+integration 双 build tag 编译通过；`go vet` 干净。
- `scripts/preflight.sh` PASS（含 sentinel registry gate / fix-ledger consistency / no-web-impact）。
- 新增回归：`TestEnforceCodexClientRestriction`、`TestForwardAsChatCompletions_CodexCliOnlyBlocksCompatEntry`、`TestOpenAIGatewayEnsureForwardErrorResponse_SkipsAfterBusinessLimited`。

## 其余候选结论（未改动，附说明）

- **#2245**(Responses SSE 不完整回 200)：TK 已全面处理(`writeResponsesFailedSSE` 注入 `response.failed` + `FinalizeAnthropicResponsesStream` + 可选 short-stream buffer)；triage 现为人工 pin `known_protocol_limitation`，未在本 PR 翻转。
- **#2232**(images/edits OAuth `tool_choice not found in tools`)：TK 构造请求时 `tools`/`tool_choice` 一致，不可复现(上游自身 bug)；人工 pin `needs_tokenkey_review`。
- **#2410**(运维归因)：开放增强项，非正确性缺陷，保持 `needs_tokenkey_review`。

合并方式：TK feature PR → **Squash and merge**。

🤖 Generated with [Claude Code](https://claude.com/claude-code)
