### PR TITLE
fix(auth): refresh-token 轮转加宽限期，消除多标签页并发刷新误判登出

### DIFF
--- a/backend/internal/service/auth_service.go
+++ b/backend/internal/service/auth_service.go
@@ -1573,11 +1573,16 @@ func (s *AuthService) RefreshTokenPair(ctx context.Context, refreshToken string)
 		return nil, ErrTokenRevoked
 	}
 
-	// Token轮转：立即使旧Token失效
-	if err := s.refreshTokenCache.DeleteRefreshToken(ctx, tokenHash); err != nil {
-		logger.LegacyPrintf("service.auth", "[Auth] Failed to delete old refresh token: %v", err)
-		// 继续处理，不影响主流程
+	// TK: 宽限期内对已轮转 token 的并发/重复刷新，幂等重发新 token 对，不判重放。
+	// 放在 active/version 安全校验之后，确保被禁用/改密的账号仍会在上面被撤销。
+	// 详见 auth_service_tk_refresh_grace.go。
+	if data.RotatedAt != nil {
+		return s.tkReissueWithinGrace(ctx, user, data)
 	}
+
+	// Token轮转：标记旧Token已轮转并保留极短宽限窗口（替代立即硬删），让宽限期内的
+	// 并发刷新走上面的幂等分支，而非被误判为重放攻击。窗口后由 Redis TTL 自动失效。
+	s.tkMarkRotatedWithGrace(ctx, tokenHash, data)
 
 	// 生成新的Token对，保持同一个家族ID
 	pair, err := s.GenerateTokenPair(ctx, user, data.FamilyID)

--- a/backend/internal/service/auth_service.go
+++ b/backend/internal/service/auth_service.go
@@ -1573,11 +1573,11 @@ func (s *AuthService) RefreshTokenPair(ctx context.Context, refreshToken string)
 		return nil, ErrTokenRevoked
 	}
 
-	// TK: 宽限期内对已轮转 token 的并发/重复刷新，幂等重发新 token 对，不判重放。
+	// TK: 已轮转的 token：宽限窗口内的并发/重复刷新幂等重发，超窗口按真正的重放处理。
 	// 放在 active/version 安全校验之后，确保被禁用/改密的账号仍会在上面被撤销。
 	// 详见 auth_service_tk_refresh_grace.go。
 	if data.RotatedAt != nil {
-		return s.tkReissueWithinGrace(ctx, user, data)
+		return s.tkRefreshRotatedWithinGrace(ctx, user, data)
 	}
 
 	// Token轮转：标记旧Token已轮转并保留极短宽限窗口（替代立即硬删），让宽限期内的

--- a/backend/internal/service/auth_service_tk_refresh_grace.go
+++ b/backend/internal/service/auth_service_tk_refresh_grace.go
@@ -37,9 +37,19 @@ func (s *AuthService) tkMarkRotatedWithGrace(ctx context.Context, tokenHash stri
 	}
 }
 
-// tkReissueWithinGrace 处理宽限窗口内对已轮转 token 的重复刷新：保持同一 family 重新签发
-// 一对有效 token，不删 family、不报重放攻击。user/active/version 校验在调用点已通过。
-func (s *AuthService) tkReissueWithinGrace(ctx context.Context, user *User, data *RefreshTokenData) (*TokenPairWithUser, error) {
+// tkRefreshRotatedWithinGrace 处理对一个已轮转 token 的再次刷新。仅当仍在宽限窗口内
+// 才视为"同一次刷新"的并发/重复，保持同一 family 幂等重发一对有效 token、不报重放；
+// 一旦超出窗口，即按真正的重放攻击处理（撤销整个 family）。
+//
+// 宽限边界在这里显式判定（time.Since(RotatedAt)），不依赖底层缓存的 TTL 驱逐时序——
+// 这样重放检测的窗口由代码而非 Redis 过期这一副作用保证，对未来更换/新增缓存后端
+// （含可能的内存兜底）依然成立。user/active/version 校验在调用点已通过。
+func (s *AuthService) tkRefreshRotatedWithinGrace(ctx context.Context, user *User, data *RefreshTokenData) (*TokenPairWithUser, error) {
+	if data.RotatedAt == nil || time.Since(*data.RotatedAt) > tkRefreshRotationGrace {
+		// 超出宽限窗口：真正的重放，撤销整个 family（与原始重放检测语义一致）。
+		_ = s.refreshTokenCache.DeleteTokenFamily(ctx, data.FamilyID)
+		return nil, ErrRefreshTokenInvalid
+	}
 	pair, err := s.GenerateTokenPair(ctx, user, data.FamilyID)
 	if err != nil {
 		return nil, err

--- a/backend/internal/service/auth_service_tk_refresh_grace.go
+++ b/backend/internal/service/auth_service_tk_refresh_grace.go
@@ -38,16 +38,19 @@ func (s *AuthService) tkMarkRotatedWithGrace(ctx context.Context, tokenHash stri
 }
 
 // tkRefreshRotatedWithinGrace 处理对一个已轮转 token 的再次刷新。仅当仍在宽限窗口内
-// 才视为"同一次刷新"的并发/重复，保持同一 family 幂等重发一对有效 token、不报重放；
-// 一旦超出窗口，即按真正的重放攻击处理（撤销整个 family）。
+// 才视为"同一次刷新"的并发/重复，保持同一 family 幂等重发一对有效 token、不报重放。
 //
 // 宽限边界在这里显式判定（time.Since(RotatedAt)），不依赖底层缓存的 TTL 驱逐时序——
 // 这样重放检测的窗口由代码而非 Redis 过期这一副作用保证，对未来更换/新增缓存后端
-// （含可能的内存兜底）依然成立。user/active/version 校验在调用点已通过。
+// （含可能的内存兜底）依然成立。
+//
+// 超出窗口时与原始的"token 不存在"重放路径保持完全一致：返回 ErrRefreshTokenInvalid，
+// 不撤销 family。正常情况下 Redis 已按 TTL 驱逐该记录、走 RefreshTokenPair 里的 not-found
+// 分支；这里是记录意外存活时的兜底，必须给出与那条分支相同的结果，否则一个迟到的过期标签页
+// 会连带把同 family 里刚签发的有效 token 一起删掉、误伤活跃会话。user/active/version
+// 校验在调用点已通过。
 func (s *AuthService) tkRefreshRotatedWithinGrace(ctx context.Context, user *User, data *RefreshTokenData) (*TokenPairWithUser, error) {
 	if data.RotatedAt == nil || time.Since(*data.RotatedAt) > tkRefreshRotationGrace {
-		// 超出宽限窗口：真正的重放，撤销整个 family（与原始重放检测语义一致）。
-		_ = s.refreshTokenCache.DeleteTokenFamily(ctx, data.FamilyID)
 		return nil, ErrRefreshTokenInvalid
 	}
 	pair, err := s.GenerateTokenPair(ctx, user, data.FamilyID)

--- a/backend/internal/service/auth_service_tk_refresh_grace.go
+++ b/backend/internal/service/auth_service_tk_refresh_grace.go
@@ -1,0 +1,51 @@
+package service
+
+import (
+	"context"
+	"time"
+
+	"github.com/Wei-Shaw/sub2api/internal/pkg/logger"
+)
+
+// TK: refresh token 轮转宽限期（idempotent refresh）。
+//
+// 背景：刷新采用轮转——一次刷新成功后旧 refresh token 立即失效。但管理后台常开多个
+// 标签页，且前端 proactive 定时刷新与 401 拦截器刷新是两条互不共享 single-flight 的
+// 路径，access token 又只有 1h，导致同一个旧 refresh token 经常被近乎同时地刷新两次。
+// 原实现里第二个请求会命中"token 不存在"→ 被判为 possible reuse attack → 强制登出。
+// 线上日志证实这是运营者一天被踢出多次的唯一来源。
+//
+// 方案：旧 token 轮转后不立即硬删，而是标记 RotatedAt 并保留一个很短的宽限窗口。窗口内
+// 同一旧 token 的重复刷新被视为"同一次刷新"，幂等地重新签发有效 token 对、不报攻击；
+// 窗口过后旧记录由 Redis TTL 自动消失，再用该 token 仍会命中"不存在"→ 保留真正的重放检测。
+//
+// 安全取舍：宽限窗口内，被盗 refresh token 的重放会被容忍（秒级）。对 admin-only、极低
+// 流量的内部网关，该风险可忽略，换取消除每天多次的误登出。
+const tkRefreshRotationGrace = 10 * time.Second
+
+// tkMarkRotatedWithGrace 替代轮转时的硬删除：把记录标记为已轮转，并以很短的宽限 TTL
+// 重写回缓存，让它在宽限期后自动过期。失败时退化为不可恢复（调用方继续主流程，旧 token
+// 最终随原 TTL 失效），不影响新 token 的签发。
+func (s *AuthService) tkMarkRotatedWithGrace(ctx context.Context, tokenHash string, data *RefreshTokenData) {
+	now := time.Now()
+	rotated := *data
+	rotated.RotatedAt = &now
+	if err := s.refreshTokenCache.StoreRefreshToken(ctx, tokenHash, &rotated, tkRefreshRotationGrace); err != nil {
+		logger.LegacyPrintf("service.auth", "[Auth] Failed to mark refresh token rotated (grace); falling back to delete: %v", err)
+		// 回退：宽限标记失败则按旧行为硬删，宁可偶发一次误判也不让旧 token 长期有效。
+		_ = s.refreshTokenCache.DeleteRefreshToken(ctx, tokenHash)
+	}
+}
+
+// tkReissueWithinGrace 处理宽限窗口内对已轮转 token 的重复刷新：保持同一 family 重新签发
+// 一对有效 token，不删 family、不报重放攻击。user/active/version 校验在调用点已通过。
+func (s *AuthService) tkReissueWithinGrace(ctx context.Context, user *User, data *RefreshTokenData) (*TokenPairWithUser, error) {
+	pair, err := s.GenerateTokenPair(ctx, user, data.FamilyID)
+	if err != nil {
+		return nil, err
+	}
+	return &TokenPairWithUser{
+		TokenPair: *pair,
+		UserRole:  user.Role,
+	}, nil
+}

--- a/backend/internal/service/auth_service_tk_refresh_grace_test.go
+++ b/backend/internal/service/auth_service_tk_refresh_grace_test.go
@@ -170,9 +170,10 @@ func TestRefreshTokenPair_AfterGraceExpiry_StillDetectsReplay(t *testing.T) {
 	}
 }
 
-func TestRefreshTokenPair_RotatedPastGrace_RevokesEvenIfRecordSurvives(t *testing.T) {
-	// 防御性：即便底层缓存未按 TTL 驱逐（这里记录仍在但 RotatedAt 已超窗口），
-	// 也必须按重放处理并撤销 family——重放窗口由代码判定，不依赖缓存过期时序。
+func TestRefreshTokenPair_RotatedPastGrace_InvalidWithoutFamilyNuke(t *testing.T) {
+	// 防御性：即便底层缓存未按 TTL 驱逐（记录仍在但 RotatedAt 已超窗口），重放窗口也由
+	// 代码判定而非缓存过期时序——必须给出与"token 不存在"重放路径完全一致的结果：
+	// ErrRefreshTokenInvalid，且**不**撤销 family（否则会误伤同 family 刚签发的活跃会话）。
 	cache := newStatefulRefreshCache()
 	user := activeUser()
 	raw := seedToken(cache, user)
@@ -184,8 +185,8 @@ func TestRefreshTokenPair_RotatedPastGrace_RevokesEvenIfRecordSurvives(t *testin
 	if !errors.Is(err, ErrRefreshTokenInvalid) {
 		t.Fatalf("rotated token past grace must be ErrRefreshTokenInvalid, got: %v", err)
 	}
-	if len(cache.deletedFamily) == 0 {
-		t.Fatalf("rotated token past grace must revoke the token family")
+	if len(cache.deletedFamily) != 0 {
+		t.Fatalf("past-grace replay must NOT nuke the family (mirrors not-found path), deleted=%v", cache.deletedFamily)
 	}
 }
 

--- a/backend/internal/service/auth_service_tk_refresh_grace_test.go
+++ b/backend/internal/service/auth_service_tk_refresh_grace_test.go
@@ -170,6 +170,25 @@ func TestRefreshTokenPair_AfterGraceExpiry_StillDetectsReplay(t *testing.T) {
 	}
 }
 
+func TestRefreshTokenPair_RotatedPastGrace_RevokesEvenIfRecordSurvives(t *testing.T) {
+	// 防御性：即便底层缓存未按 TTL 驱逐（这里记录仍在但 RotatedAt 已超窗口），
+	// 也必须按重放处理并撤销 family——重放窗口由代码判定，不依赖缓存过期时序。
+	cache := newStatefulRefreshCache()
+	user := activeUser()
+	raw := seedToken(cache, user)
+	stale := time.Now().Add(-(tkRefreshRotationGrace + time.Second))
+	cache.store[hashToken(raw)].RotatedAt = &stale
+	svc := newTestAuthServiceForGrace(&userRepoStub{user: user}, cache)
+
+	_, err := svc.RefreshTokenPair(context.Background(), raw)
+	if !errors.Is(err, ErrRefreshTokenInvalid) {
+		t.Fatalf("rotated token past grace must be ErrRefreshTokenInvalid, got: %v", err)
+	}
+	if len(cache.deletedFamily) == 0 {
+		t.Fatalf("rotated token past grace must revoke the token family")
+	}
+}
+
 func TestRefreshTokenPair_TokenVersionMismatch_StillRevokes(t *testing.T) {
 	cache := newStatefulRefreshCache()
 	user := activeUser()

--- a/backend/internal/service/auth_service_tk_refresh_grace_test.go
+++ b/backend/internal/service/auth_service_tk_refresh_grace_test.go
@@ -1,0 +1,188 @@
+//go:build unit
+
+package service
+
+import (
+	"context"
+	"errors"
+	"testing"
+	"time"
+
+	"github.com/Wei-Shaw/sub2api/internal/config"
+)
+
+// statefulRefreshCache 是一个有状态的内存 RefreshTokenCache，用于验证轮转宽限期行为：
+// 它真实地存/取/删记录，并支持手动 evict 模拟 Redis 短 TTL 过期。
+type statefulRefreshCache struct {
+	store         map[string]*RefreshTokenData
+	deletedFamily []string
+}
+
+func newStatefulRefreshCache() *statefulRefreshCache {
+	return &statefulRefreshCache{store: map[string]*RefreshTokenData{}}
+}
+
+func (c *statefulRefreshCache) evict(tokenHash string) { delete(c.store, tokenHash) }
+
+func (c *statefulRefreshCache) StoreRefreshToken(_ context.Context, tokenHash string, data *RefreshTokenData, _ time.Duration) error {
+	cloned := *data
+	c.store[tokenHash] = &cloned
+	return nil
+}
+
+func (c *statefulRefreshCache) GetRefreshToken(_ context.Context, tokenHash string) (*RefreshTokenData, error) {
+	if d, ok := c.store[tokenHash]; ok {
+		cloned := *d
+		return &cloned, nil
+	}
+	return nil, ErrRefreshTokenNotFound
+}
+
+func (c *statefulRefreshCache) DeleteRefreshToken(_ context.Context, tokenHash string) error {
+	delete(c.store, tokenHash)
+	return nil
+}
+
+func (c *statefulRefreshCache) DeleteUserRefreshTokens(_ context.Context, _ int64) error { return nil }
+
+func (c *statefulRefreshCache) DeleteTokenFamily(_ context.Context, familyID string) error {
+	c.deletedFamily = append(c.deletedFamily, familyID)
+	return nil
+}
+
+func (c *statefulRefreshCache) AddToUserTokenSet(_ context.Context, _ int64, _ string, _ time.Duration) error {
+	return nil
+}
+
+func (c *statefulRefreshCache) AddToFamilyTokenSet(_ context.Context, _ string, _ string, _ time.Duration) error {
+	return nil
+}
+
+func (c *statefulRefreshCache) GetUserTokenHashes(_ context.Context, _ int64) ([]string, error) {
+	return nil, nil
+}
+
+func (c *statefulRefreshCache) GetFamilyTokenHashes(_ context.Context, _ string) ([]string, error) {
+	return nil, nil
+}
+
+func (c *statefulRefreshCache) IsTokenInFamily(_ context.Context, _ string, _ string) (bool, error) {
+	return false, nil
+}
+
+func newTestAuthServiceForGrace(repo *userRepoStub, cache RefreshTokenCache) *AuthService {
+	cfg := &config.Config{
+		JWT: config.JWTConfig{
+			Secret:                 "test-secret-test-secret-test-secret",
+			ExpireHour:             1,
+			RefreshTokenExpireDays: 30,
+		},
+	}
+	return NewAuthService(
+		nil, repo, nil, cache, cfg,
+		nil, nil, nil, nil, nil, nil, nil, nil,
+	)
+}
+
+func activeUser() *User {
+	return &User{
+		ID:                   42,
+		Email:                "op@example.com",
+		Role:                 RoleAdmin,
+		Status:               StatusActive,
+		TokenVersion:         7,
+		TokenVersionResolved: true, // 直接用 TokenVersion，绕过密码哈希指纹
+	}
+}
+
+// seedToken 在缓存里写入一个未轮转的 refresh token，返回原始 token 字符串。
+func seedToken(c *statefulRefreshCache, user *User) string {
+	raw := refreshTokenPrefix + "0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef"
+	c.store[hashToken(raw)] = &RefreshTokenData{
+		UserID:       user.ID,
+		TokenVersion: resolvedTokenVersion(user),
+		FamilyID:     "fam-1",
+		CreatedAt:    time.Now(),
+		ExpiresAt:    time.Now().Add(30 * 24 * time.Hour),
+	}
+	return raw
+}
+
+func TestRefreshTokenPair_FirstRotation_MarksRotatedNotDeleted(t *testing.T) {
+	cache := newStatefulRefreshCache()
+	user := activeUser()
+	raw := seedToken(cache, user)
+	svc := newTestAuthServiceForGrace(&userRepoStub{user: user}, cache)
+
+	pair, err := svc.RefreshTokenPair(context.Background(), raw)
+	if err != nil {
+		t.Fatalf("first rotation failed: %v", err)
+	}
+	if pair.AccessToken == "" || pair.RefreshToken == "" {
+		t.Fatalf("expected new token pair, got %+v", pair)
+	}
+	old := cache.store[hashToken(raw)]
+	if old == nil {
+		t.Fatalf("old token must NOT be hard-deleted during grace window")
+	}
+	if old.RotatedAt == nil {
+		t.Fatalf("old token must be marked RotatedAt after first rotation")
+	}
+}
+
+func TestRefreshTokenPair_WithinGrace_DuplicateRefresh_NoReuseAttack(t *testing.T) {
+	cache := newStatefulRefreshCache()
+	user := activeUser()
+	raw := seedToken(cache, user)
+	svc := newTestAuthServiceForGrace(&userRepoStub{user: user}, cache)
+
+	if _, err := svc.RefreshTokenPair(context.Background(), raw); err != nil {
+		t.Fatalf("first refresh failed: %v", err)
+	}
+	// 第二次用同一个旧 token（宽限窗口内，记录仍在且已 RotatedAt）→ 必须幂等成功，不报重放。
+	pair, err := svc.RefreshTokenPair(context.Background(), raw)
+	if err != nil {
+		t.Fatalf("within-grace duplicate refresh must succeed, got: %v", err)
+	}
+	if pair.AccessToken == "" || pair.RefreshToken == "" {
+		t.Fatalf("within-grace refresh must reissue a valid pair, got %+v", pair)
+	}
+	if len(cache.deletedFamily) != 0 {
+		t.Fatalf("within-grace refresh must NOT delete the token family, deleted=%v", cache.deletedFamily)
+	}
+}
+
+func TestRefreshTokenPair_AfterGraceExpiry_StillDetectsReplay(t *testing.T) {
+	cache := newStatefulRefreshCache()
+	user := activeUser()
+	raw := seedToken(cache, user)
+	svc := newTestAuthServiceForGrace(&userRepoStub{user: user}, cache)
+
+	if _, err := svc.RefreshTokenPair(context.Background(), raw); err != nil {
+		t.Fatalf("first refresh failed: %v", err)
+	}
+	// 模拟宽限期后 Redis 短 TTL 到期：旧记录消失。
+	cache.evict(hashToken(raw))
+
+	_, err := svc.RefreshTokenPair(context.Background(), raw)
+	if !errors.Is(err, ErrRefreshTokenInvalid) {
+		t.Fatalf("after grace, reused token must be ErrRefreshTokenInvalid, got: %v", err)
+	}
+}
+
+func TestRefreshTokenPair_TokenVersionMismatch_StillRevokes(t *testing.T) {
+	cache := newStatefulRefreshCache()
+	user := activeUser()
+	raw := seedToken(cache, user)
+	// 模拟改密：用户当前 TokenVersion 与记录里的不一致。
+	user.TokenVersion = 999
+	svc := newTestAuthServiceForGrace(&userRepoStub{user: user}, cache)
+
+	_, err := svc.RefreshTokenPair(context.Background(), raw)
+	if !errors.Is(err, ErrTokenRevoked) {
+		t.Fatalf("password-change (version mismatch) must return ErrTokenRevoked, got: %v", err)
+	}
+	if len(cache.deletedFamily) == 0 {
+		t.Fatalf("version mismatch must delete the token family")
+	}
+}

--- a/backend/internal/service/refresh_token_cache.go
+++ b/backend/internal/service/refresh_token_cache.go
@@ -17,6 +17,10 @@ type RefreshTokenData struct {
 	FamilyID     string    `json:"family_id"`     // Token家族ID，用于防重放攻击
 	CreatedAt    time.Time `json:"created_at"`
 	ExpiresAt    time.Time `json:"expires_at"`
+	// TK: 轮转宽限期标记。非 nil = 该 token 已被轮转，正处于宽限窗口内。
+	// 用于把"并发/多标签页的重复刷新"与"真正的重放攻击"区分开（见
+	// auth_service_tk_refresh_grace.go）。旧记录反序列化时该字段为 nil，向后兼容，无需迁移。
+	RotatedAt *time.Time `json:"rotated_at,omitempty"`
 }
 
 // RefreshTokenCache 管理Refresh Token的Redis缓存


### PR DESCRIPTION
## 背景

运营者反馈登录管理后台**一天被强制重新登录约 5 次**。

线上日志排查(prod + us1 + 7 个 Lightsail edge,近 24h,只读 SSM 探针)定论:全队唯一会导致强制登出的刷新失败都是 refresh-token 轮转把**正常的并发/多标签页刷新**误判为 `possible reuse attack`(prod 3 / us1 2 / 各 edge 0–2,共 11 次,分散在各小时)。

**已排除**:Redis 淘汰/不稳定(`evicted_keys=0`、`noeviction`、refresh/DB 错误 0)、JWT secret 轮换(持久化在 PG、`jwt_secret_autogen=0`)、改密/TokenVersion(`token_revoked=0`)、refresh token 过期(30d)。

**根因机制**:access token 仅 1h(`JWT_EXPIRE_HOUR=1` 全队一致)→ 刷新频繁;刷新成功即删旧 token(`auth_service.go`),第二个并发请求(另一标签页 / 前端 proactive 定时器与 401 拦截器两条互不共享 single-flight 的刷新路径)拿同一个已删除的旧 token → `GetRefreshToken` not found → `ErrRefreshTokenInvalid` → 前端清 localStorage 跳 `/login`。

## 修复

refresh-token 轮转后**不立即硬删**,而是标记 `RotatedAt` 并保留一个 **10s 宽限窗口**:
- 窗口内同一旧 token 的并发/重复刷新 → 视为同一次刷新,**幂等重发**有效 token 对、**不报攻击**;
- 窗口过后旧记录由 Redis 短 TTL 自动消失,再用该 token → 仍判 `reuse attack`(**重放检测完整保留**);
- 改密/禁用/版本不符/过期的硬撤销路径(`DeleteTokenFamily` 等)**全部不变**。

**安全取舍**:宽限窗口内被盗 token 的重放会被容忍(秒级);对 admin-only、极低流量的内部网关该风险可忽略,换取消除每天多次误登出。已在代码注释写明。

## 改动(三处文件均 upstream-owned,最小侵入)

- `refresh_token_cache.go`:`RefreshTokenData` 加向后兼容字段 `RotatedAt *time.Time`(旧 Redis 记录反序列化为 nil,无需迁移)。**未改接口** → 无需改任何测试 stub。
- 新增 `auth_service_tk_refresh_grace.go`(TK companion):`tkRefreshRotationGrace=10s`、`tkMarkRotatedWithGrace`、`tkReissueWithinGrace`。
- `auth_service.go` `RefreshTokenPair`:注入宽限内幂等分支 + 用 mark-rotated 替代第 1577 行硬删。
- 新增单测 `auth_service_tk_refresh_grace_test.go`:首次轮转 / 宽限内重复不报攻击 / 宽限后仍拦截重放 / 改密仍 revoke。

## 验证

- `go build ./...` ✅
- `go test -tags=unit ./...`(全包)✅
- `golangci-lint run ./internal/service/...` → 0 issues ✅
- `go test -tags=integration ./internal/service/... ./internal/repository/...` ✅
- `bash scripts/preflight.sh` → PASS ✅
- 发版后线上核验:复用本次探针,各节点 `possible reuse attack` 计数应趋于 0;运营者实测一天不再被登出。

## 后续(本 PR 不含)

- (可选)延长 access token TTL(`JWT_EXPIRE_HOUR` 1→12,deploy 模板)进一步降低刷新频率。
- 前端跨标签页 + 跨路径刷新单飞(`BroadcastChannel`/Web Locks)——有宽限期后边际收益下降,作为收尾。
- 运维:清理 Lightsail uk1 陈旧 `mi-*` SSM 注册(`mi-01c0bdb720b8204bf` 自 2026-05-24 ConnectionLost)。

🤖 Generated with [Claude Code](https://claude.com/claude-code)