### PR TITLE
chore: refresh claude-code issue cache

### DIFF
--- a/.cache/anthropic/cc-triage.json
+++ b/.cache/anthropic/cc-triage.json
@@ -4,24 +4,12 @@
   "generated_from": "GitHub REST API issues?state=open; pull requests excluded; gateway-relevance filtered",
   "rationale": "TokenKey-local triage cache for anthropics/claude-code issues, filtered for gateway/relay relevance. Most claude-code issues are client-side (IDE/terminal/MCP) and are marked not_applicable. Only human-pinned MANUAL_TRIAGE high/critical entries become fix candidates.",
   "counts": {
-    "needs_review": 440,
-    "medium": 24,
-    "not_applicable": 1330,
-    "unknown_low_signal": 176
+    "needs_review": 437,
+    "medium": 28,
+    "not_applicable": 1376,
+    "unknown_low_signal": 170
   },
   "issues": [
-    {
-      "upstream": "anthropics/claude-code#11008",
-      "url": "https://github.com/anthropics/claude-code/issues/11008",
-      "title": "[FEATURE] Expose token usage and cost data in hook inputs",
-      "impact": "needs_review",
-      "categories": [
-        "prompt_caching"
-      ],
-      "tokenkey_status": "candidate_unverified",
-      "rationale": "Gateway/relay-relevant keyword match; not yet manually verified against TokenKey code.",
-      "updated_at": "2026-06-01T17:46:05Z"
-    },
     {
       "upstream": "anthropics/claude-code#13585",
       "url": "https://github.com/anthropics/claude-code/issues/13585",
@@ -93,7 +81,7 @@
       ],
       "tokenkey_status": "candidate_unverified",
       "rationale": "Gateway/relay-relevant keyword match; not yet manually verified against TokenKey code.",
-      "updated_at": "2026-06-03T12:51:14Z"
+      "updated_at": "2026-06-04T21:57:10Z"
     },
     {
       "upstream": "anthropics/claude-code#22435",
@@ -109,16 +97,16 @@
       "updated_at": "2026-06-04T12:42:05Z"
     },
     {
-      "upstream": "anthropics/claude-code#25979",
-      "url": "https://github.com/anthropics/claude-code/issues/25979",
-      "title": "[BUG] Claude Code hangs indefinitely when API streaming connection stalls (no read timeout)",
+      "upstream": "anthropics/claude-code#23315",
+      "url": "https://github.com/anthropics/claude-code/issues/23315",
+      "title": "🐛 Bug: Claude Code charges users twice - API billing AND prepaid credits consumed simultaneously",
       "impact": "needs_review",
       "categories": [
-        "request_shape_400"
+        "auth_token"
       ],
       "tokenkey_status": "candidate_unverified",
       "rationale": "Gateway/relay-relevant keyword match; not yet manually verified against TokenKey code.",
-      "updated_at": "2026-06-01T17:18:18Z"
+      "updated_at": "2026-06-04T22:32:56Z"
     },
     {
       "upstream": "anthropics/claude-code#26166",
@@ -229,6 +217,30 @@
       "updated_at": "2026-06-04T08:03:42Z"
     },
     {
+      "upstream": "anthropics/claude-code#32368",
+      "url": "https://github.com/anthropics/claude-code/issues/32368",
+      "title": "Agent Teams: Spawned teammates don't inherit model configuration from team lead",
+      "impact": "needs_review",
+      "categories": [
+        "fingerprint_ua"
+      ],
+      "tokenkey_status": "candidate_unverified",
+      "rationale": "Gateway/relay-relevant keyword match; not yet manually verified against TokenKey code.",
+      "updated_at": "2026-06-04T22:33:09Z"
+    },
+    {
+      "upstream": "anthropics/claude-code#32544",
+      "url": "https://github.com/anthropics/claude-code/issues/32544",
+      "title": "[BUG] Bug: Extra Usage charged despite available plan capacity + false rate limit errors in Claude Code",
+      "impact": "needs_review",
+      "categories": [
+        "rate_limit"
+      ],
+      "tokenkey_status": "candidate_unverified",
+      "rationale": "Gateway/relay-relevant keyword match; not yet manually verified against TokenKey code.",
+      "updated_at": "2026-06-04T19:12:26Z"
+    },
+    {
       "upstream": "anthropics/claude-code#32982",
       "url": "https://github.com/anthropics/claude-code/issues/32982",
       "title": "[BUG] Remote Control sessions die after ~20 min idle — server TTL ignores keepalives",
@@ -252,19 +264,6 @@
       "tokenkey_status": "candidate_unverified",
       "rationale": "Gateway/relay-relevant keyword match; not yet manually verified against TokenKey code.",
       "updated_at": "2026-06-03T11:39:41Z"
-    },
-    {
-      "upstream": "anthropics/claude-code#33978",
-      "url": "https://github.com/anthropics/claude-code/issues/33978",
-      "title": "[FEATURE] Built-in Usage Analytics Command (claude usage) — Consolidates 10+ Open Issues",
-      "impact": "needs_review",
-      "categories": [
-        "rate_limit",
-        "prompt_caching"
-      ],
-      "tokenkey_status": "candidate_unverified",
-      "rationale": "Gateway/relay-relevant keyword match; not yet manually verified against TokenKey code.",
-      "updated_at": "2026-06-01T17:48:58Z"
     },
     {
       "upstream": "anthropics/claude-code#34277",
@@ -303,6 +302,18 @@
       "updated_at": "2026-06-02T22:53:02Z"
     },
     {
+      "upstream": "anthropics/claude-code#34476",
+      "url": "https://github.com/anthropics/claude-code/issues/34476",
+      "title": "No way to cancel/stop spawned agent team without killing the session",
+      "impact": "needs_review",
+      "categories": [
+        "auth_token"
+      ],
+      "tokenkey_status": "candidate_unverified",
+      "rationale": "Gateway/relay-relevant keyword match; not yet manually verified against TokenKey code.",
+      "updated_at": "2026-06-04T14:17:24Z"
+    },
+    {
       "upstream": "anthropics/claude-code#36670",
       "url": "https://github.com/anthropics/claude-code/issues/36670",
       "title": "[BUG] Team agent teammates don't inherit [1m] context window variant from leader (v2.1.80)",
@@ -336,7 +347,7 @@
       ],
       "tokenkey_status": "candidate_unverified",
       "rationale": "Gateway/relay-relevant keyword match; not yet manually verified against TokenKey code.",
-      "updated_at": "2026-06-03T04:57:51Z"
+      "updated_at": "2026-06-04T21:57:33Z"
     },
     {
       "upstream": "anthropics/claude-code#38568",
@@ -411,6 +422,18 @@
       "updated_at": "2026-06-02T22:44:27Z"
     },
     {
+      "upstream": "anthropics/claude-code#41533",
+      "url": "https://github.com/anthropics/claude-code/issues/41533",
+      "title": "CLAUDE_CODE_USE_FOUNDRY (Azure Foundry) no longer works in desktop app since recent update",
+      "impact": "needs_review",
+      "categories": [
+        "auth_token"
+      ],
+      "tokenkey_status": "candidate_unverified",
+      "rationale": "Gateway/relay-relevant keyword match; not yet manually verified against TokenKey code.",
+      "updated_at": "2026-06-04T22:33:23Z"
+    },
+    {
       "upstream": "anthropics/claude-code#41788",
       "url": "https://github.com/anthropics/claude-code/issues/41788",
       "title": "Max 20 plan: rate limit 100% exhausted within ~70 minutes after reset (never happened before v2.1.89)",
@@ -470,18 +493,6 @@
       "tokenkey_status": "candidate_unverified",
       "rationale": "Gateway/relay-relevant keyword match; not yet manually verified against TokenKey code.",
       "updated_at": "2026-06-04T11:07:06Z"
-    },
-    {
-      "upstream": "anthropics/claude-code#42850",
-      "url": "https://github.com/anthropics/claude-code/issues/42850",
-      "title": "[BUG] Remote Control returns \"disabled by your organization's policy\" on Team plan despite admin toggle being ON",
-      "impact": "needs_review",
-      "categories": [
-        "auth_token"
-      ],
-      "tokenkey_status": "candidate_unverified",
-      "rationale": "Gateway/relay-relevant keyword match; not yet manually verified against TokenKey code.",
-      "updated_at": "2026-06-01T22:45:44Z"
     },
     {
       "upstream": "anthropics/claude-code#42873",
@@ -545,19 +556,7 @@
       ],
       "tokenkey_status": "candidate_unverified",
       "rationale": "Gateway/relay-relevant keyword match; not yet manually verified against TokenKey code.",
-      "updated_at": "2026-06-01T21:12:50Z"
-    },
-    {
-      "upstream": "anthropics/claude-code#45729",
-      "url": "https://github.com/anthropics/claude-code/issues/45729",
-      "title": "[BUG] Claude Code for VS Code hangs in 2.1.78+",
-      "impact": "needs_review",
-      "categories": [
-        "auth_token"
-      ],
-      "tokenkey_status": "candidate_unverified",
-      "rationale": "Gateway/relay-relevant keyword match; not yet manually verified against TokenKey code.",
-      "updated_at": "2026-06-01T22:45:19Z"
+      "updated_at": "2026-06-04T15:03:24Z"
     },
     {
       "upstream": "anthropics/claude-code#46328",
@@ -585,16 +584,16 @@
       "updated_at": "2026-06-03T22:45:48Z"
     },
     {
-      "upstream": "anthropics/claude-code#46846",
-      "url": "https://github.com/anthropics/claude-code/issues/46846",
-      "title": "Language instruction ignored: Claude responds in Japanese despite explicit Traditional Chinese requirement in CLAUDE.md",
+      "upstream": "anthropics/claude-code#46751",
+      "url": "https://github.com/anthropics/claude-code/issues/46751",
+      "title": "[Feature Request] Remove or make optional resume summary/compaction prompt on session resume",
       "impact": "needs_review",
       "categories": [
-        "model_lifecycle"
+        "request_shape_400"
       ],
       "tokenkey_status": "candidate_unverified",
       "rationale": "Gateway/relay-relevant keyword match; not yet manually verified against TokenKey code.",
-      "updated_at": "2026-06-01T22:45:31Z"
+      "updated_at": "2026-06-04T14:34:05Z"
     },
     {
       "upstream": "anthropics/claude-code#46917",
@@ -609,19 +608,6 @@
       "tokenkey_status": "candidate_unverified",
       "rationale": "Gateway/relay-relevant keyword match; not yet manually verified against TokenKey code.",
       "updated_at": "2026-06-02T16:33:43Z"
-    },
-    {
-      "upstream": "anthropics/claude-code#47488",
-      "url": "https://github.com/anthropics/claude-code/issues/47488",
-      "title": "[BUG] Cowork: Agent tool `model` parameter silently ignored — all sub-agents routed to Haiku",
-      "impact": "needs_review",
-      "categories": [
-        "model_lifecycle",
-        "prompt_caching"
-      ],
-      "tokenkey_status": "candidate_unverified",
-      "rationale": "Gateway/relay-relevant keyword match; not yet manually verified against TokenKey code.",
-      "updated_at": "2026-06-01T22:45:59Z"
     },
     {
       "upstream": "anthropics/claude-code#47971",
@@ -659,30 +645,6 @@
       "tokenkey_status": "candidate_unverified",
       "rationale": "Gateway/relay-relevant keyword match; not yet manually verified against TokenKey code.",
       "updated_at": "2026-06-04T00:25:46Z"
-    },
-    {
-      "upstream": "anthropics/claude-code#48806",
-      "url": "https://github.com/anthropics/claude-code/issues/48806",
-      "title": "[BUG] Claude in Chrome + Control Chrome Failures in Cowork Mode",
-      "impact": "needs_review",
-      "categories": [
-        "fingerprint_ua"
-      ],
-      "tokenkey_status": "candidate_unverified",
-      "rationale": "Gateway/relay-relevant keyword match; not yet manually verified against TokenKey code.",
-      "updated_at": "2026-06-01T22:46:05Z"
-    },
-    {
-      "upstream": "anthropics/claude-code#48965",
-      "url": "https://github.com/anthropics/claude-code/issues/48965",
-      "title": "Feature: Multi-session coordination primitives (cross-session messaging, session registry, compaction-resistant state, shared task board)",
-      "impact": "needs_review",
-      "categories": [
-        "prompt_caching"
-      ],
-      "tokenkey_status": "candidate_unverified",
-      "rationale": "Gateway/relay-relevant keyword match; not yet manually verified against TokenKey code.",
-      "updated_at": "2026-06-01T20:44:39Z"
     },
     {
       "upstream": "anthropics/claude-code#49038",
@@ -747,18 +709,6 @@
       "updated_at": "2026-06-02T15:04:49Z"
     },
     {
-      "upstream": "anthropics/claude-code#49572",
-      "url": "https://github.com/anthropics/claude-code/issues/49572",
-      "title": "[Bug] Authentication fails with --bare flag despite successful login",
-      "impact": "needs_review",
-      "categories": [
-        "rate_limit"
-      ],
-      "tokenkey_status": "candidate_unverified",
-      "rationale": "Gateway/relay-relevant keyword match; not yet manually verified against TokenKey code.",
-      "updated_at": "2026-06-01T16:24:36Z"
-    },
-    {
       "upstream": "anthropics/claude-code#49747",
       "url": "https://github.com/anthropics/claude-code/issues/49747",
       "title": "[BUG] Opus 4.7 mixes legacy XML tool-use format into JSON tool calls on longer payloads",
@@ -796,16 +746,16 @@
       "updated_at": "2026-06-03T11:39:43Z"
     },
     {
-      "upstream": "anthropics/claude-code#50486",
-      "url": "https://github.com/anthropics/claude-code/issues/50486",
-      "title": "feat(plugins): namespace plugin skills with plugin name prefix like commands",
+      "upstream": "anthropics/claude-code#50516",
+      "url": "https://github.com/anthropics/claude-code/issues/50516",
+      "title": "Allow opting out of the per-Read \"malware\" system-reminder — defense is porous and cost is non-consensual",
       "impact": "needs_review",
       "categories": [
         "model_lifecycle"
       ],
       "tokenkey_status": "candidate_unverified",
       "rationale": "Gateway/relay-relevant keyword match; not yet manually verified against TokenKey code.",
-      "updated_at": "2026-06-01T19:15:24Z"
+      "updated_at": "2026-06-04T22:33:06Z"
     },
     {
       "upstream": "anthropics/claude-code#50559",
@@ -844,6 +794,19 @@
       "tokenkey_status": "candidate_unverified",
       "rationale": "Gateway/relay-relevant keyword match; not yet manually verified against TokenKey code.",
       "updated_at": "2026-06-03T22:45:30Z"
+    },
+    {
+      "upstream": "anthropics/claude-code#50779",
+      "url": "https://github.com/anthropics/claude-code/issues/50779",
+      "title": "[BUG] Agent Teams: inbox messages to team lead deferred until stop_reason=end_turn (buried during tool_use chains)",
+      "impact": "needs_review",
+      "categories": [
+        "request_shape_400",
+        "model_lifecycle"
+      ],
+      "tokenkey_status": "candidate_unverified",
+      "rationale": "Gateway/relay-relevant keyword match; not yet manually verified against TokenKey code.",
+      "updated_at": "2026-06-04T22:33:36Z"
     },
     {
       "upstream": "anthropics/claude-code#50982",
@@ -909,7 +872,7 @@
       ],
       "tokenkey_status": "candidate_unverified",
       "rationale": "Gateway/relay-relevant keyword match; not yet manually verified against TokenKey code.",
-      "updated_at": "2026-06-03T11:40:04Z"
+      "updated_at": "2026-06-04T23:47:00Z"
     },
     {
       "upstream": "anthropics/claude-code#51784",
@@ -921,7 +884,7 @@
       ],
       "tokenkey_status": "candidate_unverified",
       "rationale": "Gateway/relay-relevant keyword match; not yet manually verified against TokenKey code.",
-      "updated_at": "2026-06-03T11:40:09Z"
+      "updated_at": "2026-06-04T23:48:50Z"
     },
     {
       "upstream": "anthropics/claude-code#51798",
@@ -945,7 +908,7 @@
       ],
       "tokenkey_status": "candidate_unverified",
       "rationale": "Gateway/relay-relevant keyword match; not yet manually verified against TokenKey code.",
-      "updated_at": "2026-06-01T22:45:30Z"
+      "updated_at": "2026-06-04T13:34:06Z"
     },
     {
       "upstream": "anthropics/claude-code#51940",
@@ -972,16 +935,16 @@
       "updated_at": "2026-06-04T06:40:20Z"
     },
     {
-      "upstream": "anthropics/claude-code#52135",
-      "url": "https://github.com/anthropics/claude-code/issues/52135",
-      "title": "[BUG] Max (20x) weekly limit depletes disproportionately — 51% mid-week, ~17% within minutes of session reset",
+      "upstream": "anthropics/claude-code#52137",
+      "url": "https://github.com/anthropics/claude-code/issues/52137",
+      "title": "[FEATURE] Implement SEP-1686 (Tasks) client support to unblock long-running MCP tool calls in Cowork / Desktop",
       "impact": "needs_review",
       "categories": [
         "model_lifecycle"
       ],
       "tokenkey_status": "candidate_unverified",
       "rationale": "Gateway/relay-relevant keyword match; not yet manually verified against TokenKey code.",
-      "updated_at": "2026-06-01T22:46:16Z"
+      "updated_at": "2026-06-04T22:33:24Z"
     },
     {
       "upstream": "anthropics/claude-code#52200",
@@ -993,7 +956,7 @@
       ],
       "tokenkey_status": "candidate_unverified",
       "rationale": "Gateway/relay-relevant keyword match; not yet manually verified against TokenKey code.",
-      "updated_at": "2026-06-03T11:40:13Z"
+      "updated_at": "2026-06-04T23:43:46Z"
     },
     {
       "upstream": "anthropics/claude-code#52202",
@@ -1005,7 +968,7 @@
       ],
       "tokenkey_status": "candidate_unverified",
       "rationale": "Gateway/relay-relevant keyword match; not yet manually verified against TokenKey code.",
-      "updated_at": "2026-06-03T11:40:12Z"
+      "updated_at": "2026-06-04T23:42:17Z"
     },
     {
       "upstream": "anthropics/claude-code#52203",
@@ -1017,7 +980,7 @@
       ],
       "tokenkey_status": "candidate_unverified",
       "rationale": "Gateway/relay-relevant keyword match; not yet manually verified against TokenKey code.",
-      "updated_at": "2026-06-03T11:40:31Z"
+      "updated_at": "2026-06-04T23:41:22Z"
     },
     {
       "upstream": "anthropics/claude-code#52492",
@@ -1041,7 +1004,7 @@
       ],
       "tokenkey_status": "candidate_unverified",
       "rationale": "Gateway/relay-relevant keyword match; not yet manually verified against TokenKey code.",
-      "updated_at": "2026-06-03T22:45:01Z"
+      "updated_at": "2026-06-04T23:38:04Z"
     },
     {
       "upstream": "anthropics/claude-code#52620",
@@ -1053,7 +1016,7 @@
       ],
       "tokenkey_status": "candidate_unverified",
       "rationale": "Gateway/relay-relevant keyword match; not yet manually verified against TokenKey code.",
-      "updated_at": "2026-06-03T11:40:26Z"
+      "updated_at": "2026-06-04T23:24:46Z"
     },
     {
       "upstream": "anthropics/claude-code#52626",
@@ -1065,7 +1028,19 @@
       ],
       "tokenkey_status": "candidate_unverified",
       "rationale": "Gateway/relay-relevant keyword match; not yet manually verified against TokenKey code.",
-      "updated_at": "2026-06-03T11:40:32Z"
+      "updated_at": "2026-06-04T23:25:55Z"
+    },
+    {
+      "upstream": "anthropics/claude-code#52765",
+      "url": "https://github.com/anthropics/claude-code/issues/52765",
+      "title": "[BUG] Server is busy Claude cowork desktop error",
+      "impact": "needs_review",
+      "categories": [
+        "auth_token"
+      ],
+      "tokenkey_status": "candidate_unverified",
+      "rationale": "Gateway/relay-relevant keyword match; not yet manually verified against TokenKey code.",
+      "updated_at": "2026-06-04T12:52:19Z"
     },
     {
       "upstream": "anthropics/claude-code#52871",
@@ -1077,7 +1052,7 @@
       ],
       "tokenkey_status": "candidate_unverified",
       "rationale": "Gateway/relay-relevant keyword match; not yet manually verified against TokenKey code.",
-      "updated_at": "2026-06-03T21:15:41Z"
+      "updated_at": "2026-06-04T16:26:17Z"
     },
     {
       "upstream": "anthropics/claude-code#53513",
@@ -1152,7 +1127,7 @@
       ],
       "tokenkey_status": "candidate_unverified",
       "rationale": "Gateway/relay-relevant keyword match; not yet manually verified against TokenKey code.",
-      "updated_at": "2026-06-03T11:40:00Z"
+      "updated_at": "2026-06-04T22:56:25Z"
     },
     {
       "upstream": "anthropics/claude-code#54393",
@@ -1164,21 +1139,7 @@
       ],
       "tokenkey_status": "candidate_unverified",
       "rationale": "Gateway/relay-relevant keyword match; not yet manually verified against TokenKey code.",
-      "updated_at": "2026-06-03T21:32:01Z"
-    },
-    {
-      "upstream": "anthropics/claude-code#54434",
-      "url": "https://github.com/anthropics/claude-code/issues/54434",
-      "title": "[Bug] SSE stream stalls in long-running sessions without message_stop event",
-      "impact": "needs_review",
-      "categories": [
-        "rate_limit",
-        "auth_token",
-        "model_lifecycle"
-      ],
-      "tokenkey_status": "candidate_unverified",
-      "rationale": "Gateway/relay-relevant keyword match; not yet manually verified against TokenKey code.",
-      "updated_at": "2026-06-01T17:18:17Z"
+      "updated_at": "2026-06-04T14:17:09Z"
     },
     {
       "upstream": "anthropics/claude-code#54471",
@@ -1190,31 +1151,7 @@
       ],
       "tokenkey_status": "candidate_unverified",
       "rationale": "Gateway/relay-relevant keyword match; not yet manually verified against TokenKey code.",
-      "updated_at": "2026-06-03T11:40:56Z"
-    },
-    {
-      "upstream": "anthropics/claude-code#54588",
-      "url": "https://github.com/anthropics/claude-code/issues/54588",
-      "title": "[BUG] Claude Max 20x subscription not recognized — account shows Free plan",
-      "impact": "needs_review",
-      "categories": [
-        "auth_token"
-      ],
-      "tokenkey_status": "candidate_unverified",
-      "rationale": "Gateway/relay-relevant keyword match; not yet manually verified against TokenKey code.",
-      "updated_at": "2026-06-01T22:45:50Z"
-    },
-    {
-      "upstream": "anthropics/claude-code#54595",
-      "url": "https://github.com/anthropics/claude-code/issues/54595",
-      "title": "Agent tool's foreground/sync dispatch silently removed and replaced with always-fork mode via undocumented Statsig rollout",
-      "impact": "needs_review",
-      "categories": [
-        "model_lifecycle"
-      ],
-      "tokenkey_status": "candidate_unverified",
-      "rationale": "Gateway/relay-relevant keyword match; not yet manually verified against TokenKey code.",
-      "updated_at": "2026-06-01T22:45:57Z"
+      "updated_at": "2026-06-04T22:55:53Z"
     },
     {
       "upstream": "anthropics/claude-code#54677",
@@ -1244,6 +1181,31 @@
       "updated_at": "2026-06-04T11:07:08Z"
     },
     {
+      "upstream": "anthropics/claude-code#54692",
+      "url": "https://github.com/anthropics/claude-code/issues/54692",
+      "title": "[Bug] Cloudflare HTTP 403 \"managed challenge\" blocking all API requests from Spectrum ISP IP range",
+      "impact": "needs_review",
+      "categories": [
+        "fingerprint_ua"
+      ],
+      "tokenkey_status": "candidate_unverified",
+      "rationale": "Gateway/relay-relevant keyword match; not yet manually verified against TokenKey code.",
+      "updated_at": "2026-06-04T22:33:15Z"
+    },
+    {
+      "upstream": "anthropics/claude-code#54750",
+      "url": "https://github.com/anthropics/claude-code/issues/54750",
+      "title": "Bug: Claude Code current session limit reaches 100% despite low visible local session usage",
+      "impact": "needs_review",
+      "categories": [
+        "model_lifecycle",
+        "prompt_caching"
+      ],
+      "tokenkey_status": "candidate_unverified",
+      "rationale": "Gateway/relay-relevant keyword match; not yet manually verified against TokenKey code.",
+      "updated_at": "2026-06-04T22:33:08Z"
+    },
+    {
       "upstream": "anthropics/claude-code#54817",
       "url": "https://github.com/anthropics/claude-code/issues/54817",
       "title": "[Bug] Claude Code 4.7 regression: degraded reasoning and project context loss",
@@ -1268,18 +1230,6 @@
       "updated_at": "2026-06-02T22:44:56Z"
     },
     {
-      "upstream": "anthropics/claude-code#55121",
-      "url": "https://github.com/anthropics/claude-code/issues/55121",
-      "title": "[BUG] Token counter appears to omit sub-agent consumption, causing up to 10× undercount",
-      "impact": "needs_review",
-      "categories": [
-        "auth_token"
-      ],
-      "tokenkey_status": "candidate_unverified",
-      "rationale": "Gateway/relay-relevant keyword match; not yet manually verified against TokenKey code.",
-      "updated_at": "2026-06-01T22:45:57Z"
-    },
-    {
       "upstream": "anthropics/claude-code#55192",
       "url": "https://github.com/anthropics/claude-code/issues/55192",
       "title": "[DOCS] Image too large error docs still say pasted images remain in history and require manual removal",
@@ -1289,7 +1239,7 @@
       ],
       "tokenkey_status": "candidate_unverified",
       "rationale": "Gateway/relay-relevant keyword match; not yet manually verified against TokenKey code.",
-      "updated_at": "2026-06-03T22:45:00Z"
+      "updated_at": "2026-06-04T22:56:04Z"
     },
     {
       "upstream": "anthropics/claude-code#55193",
@@ -1302,7 +1252,7 @@
       ],
       "tokenkey_status": "candidate_unverified",
       "rationale": "Gateway/relay-relevant keyword match; not yet manually verified against TokenKey code.",
-      "updated_at": "2026-06-03T22:45:04Z"
+      "updated_at": "2026-06-04T22:47:10Z"
     },
     {
       "upstream": "anthropics/claude-code#55194",
@@ -1314,19 +1264,7 @@
       ],
       "tokenkey_status": "candidate_unverified",
       "rationale": "Gateway/relay-relevant keyword match; not yet manually verified against TokenKey code.",
-      "updated_at": "2026-06-04T11:06:40Z"
-    },
-    {
-      "upstream": "anthropics/claude-code#55455",
-      "url": "https://github.com/anthropics/claude-code/issues/55455",
-      "title": "[BUG] Token drift in parallel Write tool calls: repeated path prefix produces real-word substitution (\"shane\" → \"seine\")",
-      "impact": "needs_review",
-      "categories": [
-        "model_lifecycle"
-      ],
-      "tokenkey_status": "candidate_unverified",
-      "rationale": "Gateway/relay-relevant keyword match; not yet manually verified against TokenKey code.",
-      "updated_at": "2026-06-01T22:45:16Z"
+      "updated_at": "2026-06-04T22:48:19Z"
     },
     {
       "upstream": "anthropics/claude-code#55465",
@@ -1339,18 +1277,6 @@
       "tokenkey_status": "candidate_unverified",
       "rationale": "Gateway/relay-relevant keyword match; not yet manually verified against TokenKey code.",
       "updated_at": "2026-06-03T22:45:57Z"
-    },
-    {
-      "upstream": "anthropics/claude-code#55598",
-      "url": "https://github.com/anthropics/claude-code/issues/55598",
-      "title": "[FEATURE] Environment variables for default and max effort level (shared-host admin use case)",
-      "impact": "needs_review",
-      "categories": [
-        "prompt_caching"
-      ],
-      "tokenkey_status": "candidate_unverified",
-      "rationale": "Gateway/relay-relevant keyword match; not yet manually verified against TokenKey code.",
-      "updated_at": "2026-06-01T22:46:13Z"
     },
     {
       "upstream": "anthropics/claude-code#55879",
@@ -1550,28 +1476,16 @@
       "updated_at": "2026-06-02T22:44:17Z"
     },
     {
-      "upstream": "anthropics/claude-code#58392",
-      "url": "https://github.com/anthropics/claude-code/issues/58392",
-      "title": "Atlassian MCP plugin still on deprecated HTTP+SSE — 30 June 2026 cutoff (~7 weeks); re-filing closed #38853",
-      "impact": "needs_review",
-      "categories": [
-        "model_lifecycle"
-      ],
-      "tokenkey_status": "candidate_unverified",
-      "rationale": "Gateway/relay-relevant keyword match; not yet manually verified against TokenKey code.",
-      "updated_at": "2026-06-01T15:57:49Z"
-    },
-    {
-      "upstream": "anthropics/claude-code#58463",
-      "url": "https://github.com/anthropics/claude-code/issues/58463",
-      "title": "[Regression bug] TranscriptEvent write delay: AskUserQuestion tool_use event not written to session.jsonl until user responds.",
+      "upstream": "anthropics/claude-code#58590",
+      "url": "https://github.com/anthropics/claude-code/issues/58590",
+      "title": "[BUG] WebSearch tool fails with \"deepseek-reasoner does not support this tool_choice\" for all Chinese and English queries",
       "impact": "needs_review",
       "categories": [
         "request_shape_400"
       ],
       "tokenkey_status": "candidate_unverified",
       "rationale": "Gateway/relay-relevant keyword match; not yet manually verified against TokenKey code.",
-      "updated_at": "2026-06-01T22:45:51Z"
+      "updated_at": "2026-06-04T22:33:47Z"
     },
     {
       "upstream": "anthropics/claude-code#58933",
@@ -1711,42 +1625,6 @@
       "updated_at": "2026-06-02T11:32:00Z"
     },
     {
-      "upstream": "anthropics/claude-code#59687",
-      "url": "https://github.com/anthropics/claude-code/issues/59687",
-      "title": "[BUG] ultrareview crashes before producing findings — credits consumed but no results returned",
-      "impact": "needs_review",
-      "categories": [
-        "rate_limit"
-      ],
-      "tokenkey_status": "candidate_unverified",
-      "rationale": "Gateway/relay-relevant keyword match; not yet manually verified against TokenKey code.",
-      "updated_at": "2026-06-01T22:45:08Z"
-    },
-    {
-      "upstream": "anthropics/claude-code#59689",
-      "url": "https://github.com/anthropics/claude-code/issues/59689",
-      "title": "[BUG] \"Prompt is too long\" error mid-response, session stuck with --resume for 8+ hours",
-      "impact": "needs_review",
-      "categories": [
-        "model_lifecycle"
-      ],
-      "tokenkey_status": "candidate_unverified",
-      "rationale": "Gateway/relay-relevant keyword match; not yet manually verified against TokenKey code.",
-      "updated_at": "2026-06-01T22:45:08Z"
-    },
-    {
-      "upstream": "anthropics/claude-code#59831",
-      "url": "https://github.com/anthropics/claude-code/issues/59831",
-      "title": "[BUG] Claude Desktop Cowork freezes at “Authenticating” — LocalAgentModeSessions OAuth exchange never completes",
-      "impact": "needs_review",
-      "categories": [
-        "auth_token"
-      ],
-      "tokenkey_status": "candidate_unverified",
-      "rationale": "Gateway/relay-relevant keyword match; not yet manually verified against TokenKey code.",
-      "updated_at": "2026-06-01T22:45:14Z"
-    },
-    {
       "upstream": "anthropics/claude-code#59841",
       "url": "https://github.com/anthropics/claude-code/issues/59841",
       "title": "[Feature/Policy] Provide an interactive-auth path for ACP/editor integrations so human-paced Claude Code use isn't billed as autonomous Agent SDK usage",
@@ -1808,128 +1686,6 @@
       "updated_at": "2026-06-02T11:31:52Z"
     },
     {
-      "upstream": "anthropics/claude-code#59927",
-      "url": "https://github.com/anthropics/claude-code/issues/59927",
-      "title": "[BUG] ExitPlanMode \"Yes, clear context and use auto mode\" registers as rejection — infinite plan-mode loop (regression of #33479 / #33870)",
-      "impact": "needs_review",
-      "categories": [
-        "request_shape_400"
-      ],
-      "tokenkey_status": "candidate_unverified",
-      "rationale": "Gateway/relay-relevant keyword match; not yet manually verified against TokenKey code.",
-      "updated_at": "2026-06-01T22:45:26Z"
-    },
-    {
-      "upstream": "anthropics/claude-code#59934",
-      "url": "https://github.com/anthropics/claude-code/issues/59934",
-      "title": "[BUG] MSIX auto-update mid-session: AppContainer Job race breaks launch AND orphans the in-flight conversation (two-bug cascade, both with working fixes)",
-      "impact": "needs_review",
-      "categories": [
-        "request_shape_400"
-      ],
-      "tokenkey_status": "candidate_unverified",
-      "rationale": "Gateway/relay-relevant keyword match; not yet manually verified against TokenKey code.",
-      "updated_at": "2026-06-01T22:45:32Z"
-    },
-    {
-      "upstream": "anthropics/claude-code#59937",
-      "url": "https://github.com/anthropics/claude-code/issues/59937",
-      "title": "[BUG] Forced to Reauth after sleep",
-      "impact": "needs_review",
-      "categories": [
-        "auth_token"
-      ],
-      "tokenkey_status": "candidate_unverified",
-      "rationale": "Gateway/relay-relevant keyword match; not yet manually verified against TokenKey code.",
-      "updated_at": "2026-06-01T22:45:33Z"
-    },
-    {
-      "upstream": "anthropics/claude-code#59951",
-      "url": "https://github.com/anthropics/claude-code/issues/59951",
-      "title": "[FEATURE] - [Telemetry] Opt-in for verbatim plugin/skill labels on token.usage and cost.usage metrics",
-      "impact": "needs_review",
-      "categories": [
-        "prompt_caching"
-      ],
-      "tokenkey_status": "candidate_unverified",
-      "rationale": "Gateway/relay-relevant keyword match; not yet manually verified against TokenKey code.",
-      "updated_at": "2026-06-01T20:54:53Z"
-    },
-    {
-      "upstream": "anthropics/claude-code#59953",
-      "url": "https://github.com/anthropics/claude-code/issues/59953",
-      "title": "GitHub MCP returns 403 \"not authorized to use this Copilot feature\" on Claude Code web; OAuth fallback renders misleading \"Server Turned Down → Google Drive\" page",
-      "impact": "needs_review",
-      "categories": [
-        "auth_token",
-        "fingerprint_ua"
-      ],
-      "tokenkey_status": "candidate_unverified",
-      "rationale": "Gateway/relay-relevant keyword match; not yet manually verified against TokenKey code.",
-      "updated_at": "2026-06-01T22:45:38Z"
-    },
-    {
-      "upstream": "anthropics/claude-code#59973",
-      "url": "https://github.com/anthropics/claude-code/issues/59973",
-      "title": "session usage jumped 30% per prompt in less then 1 minute of entering the prompt",
-      "impact": "needs_review",
-      "categories": [
-        "rate_limit"
-      ],
-      "tokenkey_status": "candidate_unverified",
-      "rationale": "Gateway/relay-relevant keyword match; not yet manually verified against TokenKey code.",
-      "updated_at": "2026-06-01T22:45:46Z"
-    },
-    {
-      "upstream": "anthropics/claude-code#59975",
-      "url": "https://github.com/anthropics/claude-code/issues/59975",
-      "title": "[FEATURE] Expose runtime metadata (token usage, context %, compaction status) to the model inside the conversation",
-      "impact": "needs_review",
-      "categories": [
-        "prompt_caching"
-      ],
-      "tokenkey_status": "candidate_unverified",
-      "rationale": "Gateway/relay-relevant keyword match; not yet manually verified against TokenKey code.",
-      "updated_at": "2026-06-01T22:45:46Z"
-    },
-    {
-      "upstream": "anthropics/claude-code#59985",
-      "url": "https://github.com/anthropics/claude-code/issues/59985",
-      "title": "[Bug] Model generates confident but inaccurate responses on unfamiliar domains without uncertainty signaling",
-      "impact": "needs_review",
-      "categories": [
-        "request_shape_400"
-      ],
-      "tokenkey_status": "candidate_unverified",
-      "rationale": "Gateway/relay-relevant keyword match; not yet manually verified against TokenKey code.",
-      "updated_at": "2026-06-01T22:45:49Z"
-    },
-    {
-      "upstream": "anthropics/claude-code#60001",
-      "url": "https://github.com/anthropics/claude-code/issues/60001",
-      "title": "Background-Agent completion notifications drop silently when ≥3 parallel run_in_background agents dispatched",
-      "impact": "needs_review",
-      "categories": [
-        "model_lifecycle"
-      ],
-      "tokenkey_status": "candidate_unverified",
-      "rationale": "Gateway/relay-relevant keyword match; not yet manually verified against TokenKey code.",
-      "updated_at": "2026-06-01T20:44:53Z"
-    },
-    {
-      "upstream": "anthropics/claude-code#60033",
-      "url": "https://github.com/anthropics/claude-code/issues/60033",
-      "title": "Built-in Write tool: large escape-dense content intermittently yields malformed tool-input JSON; retry resends identical payload and also fails",
-      "impact": "needs_review",
-      "categories": [
-        "request_shape_400",
-        "model_lifecycle"
-      ],
-      "tokenkey_status": "candidate_unverified",
-      "rationale": "Gateway/relay-relevant keyword match; not yet manually verified against TokenKey code.",
-      "updated_at": "2026-06-01T22:46:15Z"
-    },
-    {
       "upstream": "anthropics/claude-code#60042",
       "url": "https://github.com/anthropics/claude-code/issues/60042",
       "title": "[BUG] AskUserQuestion fails with \"Tool permission stream closed before response received\" when dispatched in a parallel batch alongside other tool calls",
@@ -1940,19 +1696,6 @@
       "tokenkey_status": "candidate_unverified",
       "rationale": "Gateway/relay-relevant keyword match; not yet manually verified against TokenKey code.",
       "updated_at": "2026-06-02T11:32:05Z"
-    },
-    {
-      "upstream": "anthropics/claude-code#60046",
-      "url": "https://github.com/anthropics/claude-code/issues/60046",
-      "title": "[MODEL] Repeated unresearched API changes broke production business system; explicit welfare instructions ignored throughout",
-      "impact": "needs_review",
-      "categories": [
-        "auth_token",
-        "model_lifecycle"
-      ],
-      "tokenkey_status": "candidate_unverified",
-      "rationale": "Gateway/relay-relevant keyword match; not yet manually verified against TokenKey code.",
-      "updated_at": "2026-06-01T22:46:18Z"
     },
     {
       "upstream": "anthropics/claude-code#60051",
@@ -2348,17 +2091,16 @@
       "updated_at": "2026-06-03T22:45:15Z"
     },
     {
-      "upstream": "anthropics/claude-code#60438",
-      "url": "https://github.com/anthropics/claude-code/issues/60438",
-      "title": "Persistent HTTP 429 on auto-mode classifier (xml_s1), account-side config",
+      "upstream": "anthropics/claude-code#60436",
+      "url": "https://github.com/anthropics/claude-code/issues/60436",
+      "title": "[BUG] Claude Code 2.1.144 binary crashes immediately when spawned from VS Code (any mode), works fine from Terminal.app",
       "impact": "needs_review",
       "categories": [
-        "rate_limit",
-        "model_lifecycle"
+        "auth_token"
       ],
       "tokenkey_status": "candidate_unverified",
       "rationale": "Gateway/relay-relevant keyword match; not yet manually verified against TokenKey code.",
-      "updated_at": "2026-06-01T19:08:07Z"
+      "updated_at": "2026-06-04T22:33:26Z"
     },
     {
       "upstream": "anthropics/claude-code#60442",
@@ -2495,6 +2237,30 @@
       "updated_at": "2026-06-03T22:46:01Z"
     },
     {
+      "upstream": "anthropics/claude-code#60554",
+      "url": "https://github.com/anthropics/claude-code/issues/60554",
+      "title": "[BUG] Background-shell counter under-counts SSH-wrapped Bash invocations (v2.1.144)",
+      "impact": "needs_review",
+      "categories": [
+        "request_shape_400"
+      ],
+      "tokenkey_status": "candidate_unverified",
+      "rationale": "Gateway/relay-relevant keyword match; not yet manually verified against TokenKey code.",
+      "updated_at": "2026-06-04T22:32:58Z"
+    },
+    {
+      "upstream": "anthropics/claude-code#60560",
+      "url": "https://github.com/anthropics/claude-code/issues/60560",
+      "title": "[Bug] Skill listing context truncation with insufficient budget allocation",
+      "impact": "needs_review",
+      "categories": [
+        "rate_limit"
+      ],
+      "tokenkey_status": "candidate_unverified",
+      "rationale": "Gateway/relay-relevant keyword match; not yet manually verified against TokenKey code.",
+      "updated_at": "2026-06-04T22:33:00Z"
+    },
+    {
       "upstream": "anthropics/claude-code#60562",
       "url": "https://github.com/anthropics/claude-code/issues/60562",
       "title": "[BUG] Server-side rate limits break parallel agent workflows — request transparent auto-retry",
@@ -2505,6 +2271,18 @@
       "tokenkey_status": "candidate_unverified",
       "rationale": "Gateway/relay-relevant keyword match; not yet manually verified against TokenKey code.",
       "updated_at": "2026-06-04T11:06:59Z"
+    },
+    {
+      "upstream": "anthropics/claude-code#60564",
+      "url": "https://github.com/anthropics/claude-code/issues/60564",
+      "title": "Feature request: AssistantMessageDelta hook for streaming-aware tooling (TTS, telemetry, mirror)",
+      "impact": "needs_review",
+      "categories": [
+        "new_endpoints"
+      ],
+      "tokenkey_status": "candidate_unverified",
+      "rationale": "Gateway/relay-relevant keyword match; not yet manually verified against TokenKey code.",
+      "updated_at": "2026-06-04T22:33:02Z"
     },
     {
       "upstream": "anthropics/claude-code#60577",
@@ -2617,6 +2395,120 @@
       "updated_at": "2026-06-03T19:09:09Z"
     },
     {
+      "upstream": "anthropics/claude-code#60684",
+      "url": "https://github.com/anthropics/claude-code/issues/60684",
+      "title": "[BUG] `Read` tool returns \"file unchanged\" after external on-disk edits, serving a stale cached snapshot",
+      "impact": "needs_review",
+      "categories": [
+        "request_shape_400",
+        "model_lifecycle"
+      ],
+      "tokenkey_status": "candidate_unverified",
+      "rationale": "Gateway/relay-relevant keyword match; not yet manually verified against TokenKey code.",
+      "updated_at": "2026-06-04T22:33:13Z"
+    },
+    {
+      "upstream": "anthropics/claude-code#60709",
+      "url": "https://github.com/anthropics/claude-code/issues/60709",
+      "title": "Claude repeatedly commits/pushes git changes without user confirmation despite memory entries and explicit corrections",
+      "impact": "needs_review",
+      "categories": [
+        "model_lifecycle"
+      ],
+      "tokenkey_status": "candidate_unverified",
+      "rationale": "Gateway/relay-relevant keyword match; not yet manually verified against TokenKey code.",
+      "updated_at": "2026-06-04T22:33:08Z"
+    },
+    {
+      "upstream": "anthropics/claude-code#60726",
+      "url": "https://github.com/anthropics/claude-code/issues/60726",
+      "title": "[BUG] decision_type field on tool_result OTEL events not populated in ~70% of cases since v2.1.143",
+      "impact": "needs_review",
+      "categories": [
+        "request_shape_400"
+      ],
+      "tokenkey_status": "candidate_unverified",
+      "rationale": "Gateway/relay-relevant keyword match; not yet manually verified against TokenKey code.",
+      "updated_at": "2026-06-04T22:33:17Z"
+    },
+    {
+      "upstream": "anthropics/claude-code#60751",
+      "url": "https://github.com/anthropics/claude-code/issues/60751",
+      "title": "[BUG] usage limit with sonnet (default) with 70% of my 5 hour window available.",
+      "impact": "needs_review",
+      "categories": [
+        "request_shape_400",
+        "rate_limit",
+        "model_lifecycle"
+      ],
+      "tokenkey_status": "candidate_unverified",
+      "rationale": "Gateway/relay-relevant keyword match; not yet manually verified against TokenKey code.",
+      "updated_at": "2026-06-04T22:33:27Z"
+    },
+    {
+      "upstream": "anthropics/claude-code#60766",
+      "url": "https://github.com/anthropics/claude-code/issues/60766",
+      "title": "API Error: cache_control cannot be set for empty text blocks when sending image-only message",
+      "impact": "needs_review",
+      "categories": [
+        "request_shape_400"
+      ],
+      "tokenkey_status": "candidate_unverified",
+      "rationale": "Gateway/relay-relevant keyword match; not yet manually verified against TokenKey code.",
+      "updated_at": "2026-06-04T22:33:31Z"
+    },
+    {
+      "upstream": "anthropics/claude-code#60768",
+      "url": "https://github.com/anthropics/claude-code/issues/60768",
+      "title": "[BUG] Claude Code VS code plugin attached file never gone",
+      "impact": "needs_review",
+      "categories": [
+        "model_lifecycle"
+      ],
+      "tokenkey_status": "candidate_unverified",
+      "rationale": "Gateway/relay-relevant keyword match; not yet manually verified against TokenKey code.",
+      "updated_at": "2026-06-04T22:33:34Z"
+    },
+    {
+      "upstream": "anthropics/claude-code#60770",
+      "url": "https://github.com/anthropics/claude-code/issues/60770",
+      "title": "Image-only message sends empty text block with cache_control, 400s and kills conversation",
+      "impact": "needs_review",
+      "categories": [
+        "request_shape_400",
+        "prompt_caching"
+      ],
+      "tokenkey_status": "candidate_unverified",
+      "rationale": "Gateway/relay-relevant keyword match; not yet manually verified against TokenKey code.",
+      "updated_at": "2026-06-04T22:33:42Z"
+    },
+    {
+      "upstream": "anthropics/claude-code#60799",
+      "url": "https://github.com/anthropics/claude-code/issues/60799",
+      "title": "Notarize the macOS claude CLI binary — un-notarized binary causes syspolicyd / XProtect YARA scanning storm on Sequoia (15+)",
+      "impact": "needs_review",
+      "categories": [
+        "rate_limit",
+        "model_lifecycle"
+      ],
+      "tokenkey_status": "candidate_unverified",
+      "rationale": "Gateway/relay-relevant keyword match; not yet manually verified against TokenKey code.",
+      "updated_at": "2026-06-04T22:33:47Z"
+    },
+    {
+      "upstream": "anthropics/claude-code#60943",
+      "url": "https://github.com/anthropics/claude-code/issues/60943",
+      "title": "[FEATURE] External wake signal for interactive sessions",
+      "impact": "needs_review",
+      "categories": [
+        "rate_limit",
+        "new_endpoints"
+      ],
+      "tokenkey_status": "candidate_unverified",
+      "rationale": "Gateway/relay-relevant keyword match; not yet manually verified against TokenKey code.",
+      "updated_at": "2026-06-04T15:21:34Z"
+    },
+    {
       "upstream": "anthropics/claude-code#61012",
       "url": "https://github.com/anthropics/claude-code/issues/61012",
       "title": "Usage limit reached repeatedly without active use — Pro plan",
@@ -2627,6 +2519,18 @@
       "tokenkey_status": "candidate_unverified",
       "rationale": "Gateway/relay-relevant keyword match; not yet manually verified against TokenKey code.",
       "updated_at": "2026-06-03T14:16:48Z"
+    },
+    {
+      "upstream": "anthropics/claude-code#61282",
+      "url": "https://github.com/anthropics/claude-code/issues/61282",
+      "title": "[BUG] Auto mode missing from VS Code extension picker on Linux despite canEnterAuto=true (works in terminal CLI and Windows extension)",
+      "impact": "needs_review",
+      "categories": [
+        "model_lifecycle"
+      ],
+      "tokenkey_status": "candidate_unverified",
+      "rationale": "Gateway/relay-relevant keyword match; not yet manually verified against TokenKey code.",
+      "updated_at": "2026-06-04T22:05:34Z"
     },
     {
       "upstream": "anthropics/claude-code#61313",
@@ -2677,6 +2581,18 @@
       "updated_at": "2026-06-02T17:32:48Z"
     },
     {
+      "upstream": "anthropics/claude-code#62015",
+      "url": "https://github.com/anthropics/claude-code/issues/62015",
+      "title": "[BUG] Claude Code corrupted FlutterFlow project via deprecated proto field in MCP integration — server-level damage, project completely frozen",
+      "impact": "needs_review",
+      "categories": [
+        "model_lifecycle"
+      ],
+      "tokenkey_status": "candidate_unverified",
+      "rationale": "Gateway/relay-relevant keyword match; not yet manually verified against TokenKey code.",
+      "updated_at": "2026-06-04T14:07:02Z"
+    },
+    {
       "upstream": "anthropics/claude-code#62063",
       "url": "https://github.com/anthropics/claude-code/issues/62063",
       "title": "[BUG] Claude Code defaults to 1M context on fresh session with no workaround on Pro plan",
@@ -2686,20 +2602,7 @@
       ],
       "tokenkey_status": "candidate_unverified",
       "rationale": "Gateway/relay-relevant keyword match; not yet manually verified against TokenKey code.",
-      "updated_at": "2026-06-04T12:44:02Z"
-    },
-    {
-      "upstream": "anthropics/claude-code#62314",
-      "url": "https://github.com/anthropics/claude-code/issues/62314",
-      "title": "Sonnet 4.6 routes every request to long-context tier on Claude Desktop 2.1.149 (429 'Usage credits required')",
-      "impact": "needs_review",
-      "categories": [
-        "rate_limit",
-        "model_lifecycle"
-      ],
-      "tokenkey_status": "candidate_unverified",
-      "rationale": "Gateway/relay-relevant keyword match; not yet manually verified against TokenKey code.",
-      "updated_at": "2026-06-01T14:46:59Z"
+      "updated_at": "2026-06-04T21:53:07Z"
     },
     {
       "upstream": "anthropics/claude-code#62376",
@@ -2762,18 +2665,6 @@
       "updated_at": "2026-06-04T00:17:52Z"
     },
     {
-      "upstream": "anthropics/claude-code#62924",
-      "url": "https://github.com/anthropics/claude-code/issues/62924",
-      "title": "[BUG] Remote Control bridge fails with \"/login\" on macOS desktop app despite valid claude.ai auth",
-      "impact": "needs_review",
-      "categories": [
-        "auth_token"
-      ],
-      "tokenkey_status": "candidate_unverified",
-      "rationale": "Gateway/relay-relevant keyword match; not yet manually verified against TokenKey code.",
-      "updated_at": "2026-06-01T20:06:28Z"
-    },
-    {
       "upstream": "anthropics/claude-code#62983",
       "url": "https://github.com/anthropics/claude-code/issues/62983",
       "title": "Opus 4.7 behavioral regression: loaded instruction-following discipline degraded in recent Claude Code/Cowork updates",
@@ -2797,7 +2688,31 @@
       ],
       "tokenkey_status": "candidate_unverified",
       "rationale": "Gateway/relay-relevant keyword match; not yet manually verified against TokenKey code.",
-      "updated_at": "2026-06-03T17:12:00Z"
+      "updated_at": "2026-06-04T15:44:01Z"
+    },
+    {
+      "upstream": "anthropics/claude-code#63143",
+      "url": "https://github.com/anthropics/claude-code/issues/63143",
+      "title": "AskUserQuestion: cancelling during extended thinking poisons the whole session with 400 'thinking blocks cannot be modified' (2.1.153); concurrent prompts overwrite each other",
+      "impact": "needs_review",
+      "categories": [
+        "request_shape_400"
+      ],
+      "tokenkey_status": "candidate_unverified",
+      "rationale": "Gateway/relay-relevant keyword match; not yet manually verified against TokenKey code.",
+      "updated_at": "2026-06-04T18:45:59Z"
+    },
+    {
+      "upstream": "anthropics/claude-code#63147",
+      "url": "https://github.com/anthropics/claude-code/issues/63147",
+      "title": "Resuming an extended-thinking session fails permanently with 400 \"thinking blocks cannot be modified\" (transcript stores thinking text as empty but keeps signature)",
+      "impact": "needs_review",
+      "categories": [
+        "request_shape_400"
+      ],
+      "tokenkey_status": "candidate_unverified",
+      "rationale": "Gateway/relay-relevant keyword match; not yet manually verified against TokenKey code.",
+      "updated_at": "2026-06-04T22:59:46Z"
     },
     {
       "upstream": "anthropics/claude-code#63275",
@@ -2886,6 +2801,19 @@
       "updated_at": "2026-06-03T18:04:14Z"
     },
     {
+      "upstream": "anthropics/claude-code#63604",
+      "url": "https://github.com/anthropics/claude-code/issues/63604",
+      "title": "[BUG] Opus 4.8 repeatedly emits malformed tool_use blocks, entire response discarded (4.7 works fine)",
+      "impact": "needs_review",
+      "categories": [
+        "request_shape_400",
+        "model_lifecycle"
+      ],
+      "tokenkey_status": "candidate_unverified",
+      "rationale": "Gateway/relay-relevant keyword match; not yet manually verified against TokenKey code.",
+      "updated_at": "2026-06-04T17:33:00Z"
+    },
+    {
       "upstream": "anthropics/claude-code#63634",
       "url": "https://github.com/anthropics/claude-code/issues/63634",
       "title": "[Bug] /compact fails with \"Usage credits required for 1M context\" even after /model set to Sonnet 4.6",
@@ -2897,30 +2825,6 @@
       "tokenkey_status": "candidate_unverified",
       "rationale": "Gateway/relay-relevant keyword match; not yet manually verified against TokenKey code.",
       "updated_at": "2026-06-04T10:00:28Z"
-    },
-    {
-      "upstream": "anthropics/claude-code#63677",
-      "url": "https://github.com/anthropics/claude-code/issues/63677",
-      "title": "[BUG] Using the 2.1.156 version of the Claude Code for VS Code extension",
-      "impact": "needs_review",
-      "categories": [
-        "request_shape_400"
-      ],
-      "tokenkey_status": "candidate_unverified",
-      "rationale": "Gateway/relay-relevant keyword match; not yet manually verified against TokenKey code.",
-      "updated_at": "2026-06-01T18:22:08Z"
-    },
-    {
-      "upstream": "anthropics/claude-code#63751",
-      "url": "https://github.com/anthropics/claude-code/issues/63751",
-      "title": "[BUG] AUP/cyber-safeguard false positives on legitimate own-software hardening; one hit contaminates entire session",
-      "impact": "needs_review",
-      "categories": [
-        "model_lifecycle"
-      ],
-      "tokenkey_status": "candidate_unverified",
-      "rationale": "Gateway/relay-relevant keyword match; not yet manually verified against TokenKey code.",
-      "updated_at": "2026-06-01T15:56:52Z"
     },
     {
       "upstream": "anthropics/claude-code#63754",
@@ -2945,7 +2849,7 @@
       ],
       "tokenkey_status": "candidate_unverified",
       "rationale": "Gateway/relay-relevant keyword match; not yet manually verified against TokenKey code.",
-      "updated_at": "2026-06-03T03:58:32Z"
+      "updated_at": "2026-06-04T19:20:25Z"
     },
     {
       "upstream": "anthropics/claude-code#63870",
@@ -2969,20 +2873,7 @@
       ],
       "tokenkey_status": "candidate_unverified",
       "rationale": "Gateway/relay-relevant keyword match; not yet manually verified against TokenKey code.",
-      "updated_at": "2026-06-04T11:18:34Z"
-    },
-    {
-      "upstream": "anthropics/claude-code#63880",
-      "url": "https://github.com/anthropics/claude-code/issues/63880",
-      "title": "[Bug] Advisor narrates but then fails to make tool calls",
-      "impact": "needs_review",
-      "categories": [
-        "request_shape_400",
-        "model_lifecycle"
-      ],
-      "tokenkey_status": "candidate_unverified",
-      "rationale": "Gateway/relay-relevant keyword match; not yet manually verified against TokenKey code.",
-      "updated_at": "2026-06-01T17:17:46Z"
+      "updated_at": "2026-06-04T18:46:24Z"
     },
     {
       "upstream": "anthropics/claude-code#63885",
@@ -3007,7 +2898,7 @@
       ],
       "tokenkey_status": "candidate_unverified",
       "rationale": "Gateway/relay-relevant keyword match; not yet manually verified against TokenKey code.",
-      "updated_at": "2026-06-04T09:17:17Z"
+      "updated_at": "2026-06-04T21:02:58Z"
     },
     {
       "upstream": "anthropics/claude-code#63919",
@@ -3034,32 +2925,6 @@
       "updated_at": "2026-06-04T08:04:05Z"
     },
     {
-      "upstream": "anthropics/claude-code#63930",
-      "url": "https://github.com/anthropics/claude-code/issues/63930",
-      "title": "Prompt cache fully re-created after turns with many parallel tool calls (cache_read collapses to system+tools floor) — ~74% of cache writes wasted on Opus 4.8 / v2.1.15x",
-      "impact": "needs_review",
-      "categories": [
-        "request_shape_400",
-        "model_lifecycle",
-        "prompt_caching"
-      ],
-      "tokenkey_status": "candidate_unverified",
-      "rationale": "Gateway/relay-relevant keyword match; not yet manually verified against TokenKey code.",
-      "updated_at": "2026-06-01T17:31:12Z"
-    },
-    {
-      "upstream": "anthropics/claude-code#64007",
-      "url": "https://github.com/anthropics/claude-code/issues/64007",
-      "title": "cct = TUI: turn-transition render omission — content recorded in .jsonl but absent from scrollback (2 incidents across 2 versions)",
-      "impact": "needs_review",
-      "categories": [
-        "request_shape_400"
-      ],
-      "tokenkey_status": "candidate_unverified",
-      "rationale": "Gateway/relay-relevant keyword match; not yet manually verified against TokenKey code.",
-      "updated_at": "2026-06-01T21:11:50Z"
-    },
-    {
       "upstream": "anthropics/claude-code#64034",
       "url": "https://github.com/anthropics/claude-code/issues/64034",
       "title": "[Bug] Context usage discrepancy between CLI and web/desktop UI causing incorrect billing",
@@ -3082,18 +2947,6 @@
       "tokenkey_status": "candidate_unverified",
       "rationale": "Gateway/relay-relevant keyword match; not yet manually verified against TokenKey code.",
       "updated_at": "2026-06-03T18:36:43Z"
-    },
-    {
-      "upstream": "anthropics/claude-code#64047",
-      "url": "https://github.com/anthropics/claude-code/issues/64047",
-      "title": "[BUG] Automatic parallel-tool-call cancellation is indistinguishable from a user interrupt",
-      "impact": "needs_review",
-      "categories": [
-        "new_endpoints"
-      ],
-      "tokenkey_status": "candidate_unverified",
-      "rationale": "Gateway/relay-relevant keyword match; not yet manually verified against TokenKey code.",
-      "updated_at": "2026-06-01T19:01:41Z"
     },
     {
       "upstream": "anthropics/claude-code#64080",
@@ -3149,31 +3002,6 @@
       "updated_at": "2026-06-03T08:40:22Z"
     },
     {
-      "upstream": "anthropics/claude-code#64168",
-      "url": "https://github.com/anthropics/claude-code/issues/64168",
-      "title": "[BUG] VS Code extension subprocess init timeout on WSL2/Ubuntu 26.04 — CLI fully healthy (stream-json handshake works from terminal)",
-      "impact": "needs_review",
-      "categories": [
-        "auth_token",
-        "model_lifecycle"
-      ],
-      "tokenkey_status": "candidate_unverified",
-      "rationale": "Gateway/relay-relevant keyword match; not yet manually verified against TokenKey code.",
-      "updated_at": "2026-06-02T16:45:10Z"
-    },
-    {
-      "upstream": "anthropics/claude-code#64227",
-      "url": "https://github.com/anthropics/claude-code/issues/64227",
-      "title": "Claude Code repeatedly made unauthorized destructive changes, ignored explicit rules, and permanently destroyed user data across multiple sessions[MODEL]",
-      "impact": "needs_review",
-      "categories": [
-        "auth_token"
-      ],
-      "tokenkey_status": "candidate_unverified",
-      "rationale": "Gateway/relay-relevant keyword match; not yet manually verified against TokenKey code.",
-      "updated_at": "2026-06-01T21:39:58Z"
-    },
-    {
       "upstream": "anthropics/claude-code#64251",
       "url": "https://github.com/anthropics/claude-code/issues/64251",
       "title": "[BUG] Claude Code query worker dies silently on Windows — `--version` works, but every query produces no output (exit 0); VS Code extension shows \"Query closed before response received\"",
@@ -3213,29 +3041,16 @@
       "updated_at": "2026-06-03T10:18:50Z"
     },
     {
-      "upstream": "anthropics/claude-code#64350",
-      "url": "https://github.com/anthropics/claude-code/issues/64350",
-      "title": "MCP gateway WAF blocks legitimate tool-call bodies (SQL/shell/config text)",
+      "upstream": "anthropics/claude-code#64322",
+      "url": "https://github.com/anthropics/claude-code/issues/64322",
+      "title": "Worktree isolation: Edit-tool path validation + drift-detection in task-notification payload",
       "impact": "needs_review",
       "categories": [
-        "fingerprint_ua"
+        "model_lifecycle"
       ],
       "tokenkey_status": "candidate_unverified",
       "rationale": "Gateway/relay-relevant keyword match; not yet manually verified against TokenKey code.",
-      "updated_at": "2026-06-01T15:36:34Z"
-    },
-    {
-      "upstream": "anthropics/claude-code#64386",
-      "url": "https://github.com/anthropics/claude-code/issues/64386",
-      "title": "[FEATURE] Annotate thinking blocks at JSONL save-time with corruption-trigger context (meta-fix for the #10199 duplicate-issue pile)",
-      "impact": "needs_review",
-      "categories": [
-        "request_shape_400",
-        "new_endpoints"
-      ],
-      "tokenkey_status": "candidate_unverified",
-      "rationale": "Gateway/relay-relevant keyword match; not yet manually verified against TokenKey code.",
-      "updated_at": "2026-06-01T14:38:45Z"
+      "updated_at": "2026-06-04T17:47:57Z"
     },
     {
       "upstream": "anthropics/claude-code#64397",
@@ -3289,6 +3104,18 @@
       "updated_at": "2026-06-02T14:35:41Z"
     },
     {
+      "upstream": "anthropics/claude-code#64427",
+      "url": "https://github.com/anthropics/claude-code/issues/64427",
+      "title": "[BUG] Pro plan — 1M context error blocks all requests",
+      "impact": "needs_review",
+      "categories": [
+        "model_lifecycle"
+      ],
+      "tokenkey_status": "candidate_unverified",
+      "rationale": "Gateway/relay-relevant keyword match; not yet manually verified against TokenKey code.",
+      "updated_at": "2026-06-04T19:33:25Z"
+    },
+    {
       "upstream": "anthropics/claude-code#64436",
       "url": "https://github.com/anthropics/claude-code/issues/64436",
       "title": "Background sessions (claude agents) drop work-phase OTEL logs (user_prompt/api_request) on shutdown",
@@ -3298,7 +3125,7 @@
       ],
       "tokenkey_status": "candidate_unverified",
       "rationale": "Gateway/relay-relevant keyword match; not yet manually verified against TokenKey code.",
-      "updated_at": "2026-06-01T16:04:13Z"
+      "updated_at": "2026-06-04T20:21:02Z"
     },
     {
       "upstream": "anthropics/claude-code#64475",
@@ -3322,19 +3149,7 @@
       ],
       "tokenkey_status": "candidate_unverified",
       "rationale": "Gateway/relay-relevant keyword match; not yet manually verified against TokenKey code.",
-      "updated_at": "2026-06-01T15:25:04Z"
-    },
-    {
-      "upstream": "anthropics/claude-code#64493",
-      "url": "https://github.com/anthropics/claude-code/issues/64493",
-      "title": "FleetView bg-session dispatcher defaults to Opus 4.7 instead of latest model; ignores ANTHROPIC_MODEL and settings.json `model`",
-      "impact": "needs_review",
-      "categories": [
-        "model_lifecycle"
-      ],
-      "tokenkey_status": "candidate_unverified",
-      "rationale": "Gateway/relay-relevant keyword match; not yet manually verified against TokenKey code.",
-      "updated_at": "2026-06-01T15:31:44Z"
+      "updated_at": "2026-06-04T15:44:04Z"
     },
     {
       "upstream": "anthropics/claude-code#64497",
@@ -3349,68 +3164,6 @@
       "updated_at": "2026-06-02T08:26:09Z"
     },
     {
-      "upstream": "anthropics/claude-code#64505",
-      "url": "https://github.com/anthropics/claude-code/issues/64505",
-      "title": "[BUG] Desktop app renderer OOMs at ~2.7 GB V8 heap within 15–50s when Dispatch is active (macOS 26.5, M5 Pro)",
-      "impact": "needs_review",
-      "categories": [
-        "model_lifecycle"
-      ],
-      "tokenkey_status": "candidate_unverified",
-      "rationale": "Gateway/relay-relevant keyword match; not yet manually verified against TokenKey code.",
-      "updated_at": "2026-06-01T18:59:30Z"
-    },
-    {
-      "upstream": "anthropics/claude-code#64510",
-      "url": "https://github.com/anthropics/claude-code/issues/64510",
-      "title": "[BUG] No supported way to disable only the context_management beta — breaks Claude Code on HIPAA-flagged orgs without ZDR (first-party Anthropic API)",
-      "impact": "needs_review",
-      "categories": [
-        "beta_header_drift",
-        "request_shape_400"
-      ],
-      "tokenkey_status": "candidate_unverified",
-      "rationale": "Gateway/relay-relevant keyword match; not yet manually verified against TokenKey code.",
-      "updated_at": "2026-06-01T15:28:43Z"
-    },
-    {
-      "upstream": "anthropics/claude-code#64514",
-      "url": "https://github.com/anthropics/claude-code/issues/64514",
-      "title": "Claude main AI is not following user-defined workflows and exceeds command scope",
-      "impact": "needs_review",
-      "categories": [
-        "auth_token"
-      ],
-      "tokenkey_status": "candidate_unverified",
-      "rationale": "Gateway/relay-relevant keyword match; not yet manually verified against TokenKey code.",
-      "updated_at": "2026-06-01T15:35:05Z"
-    },
-    {
-      "upstream": "anthropics/claude-code#64516",
-      "url": "https://github.com/anthropics/claude-code/issues/64516",
-      "title": "Claude main AI is not following user-defined workflows and exceeds command scope",
-      "impact": "needs_review",
-      "categories": [
-        "auth_token"
-      ],
-      "tokenkey_status": "candidate_unverified",
-      "rationale": "Gateway/relay-relevant keyword match; not yet manually verified against TokenKey code.",
-      "updated_at": "2026-06-01T15:40:42Z"
-    },
-    {
-      "upstream": "anthropics/claude-code#64533",
-      "url": "https://github.com/anthropics/claude-code/issues/64533",
-      "title": "Multi-minute first-byte stalls on claude-opus-4-8[1m], compounded by auto-mode classifier timeouts — sessions near-unusable",
-      "impact": "needs_review",
-      "categories": [
-        "auth_token",
-        "model_lifecycle"
-      ],
-      "tokenkey_status": "candidate_unverified",
-      "rationale": "Gateway/relay-relevant keyword match; not yet manually verified against TokenKey code.",
-      "updated_at": "2026-06-01T18:35:14Z"
-    },
-    {
       "upstream": "anthropics/claude-code#64539",
       "url": "https://github.com/anthropics/claude-code/issues/64539",
       "title": "Harness-injected control text and tool-result content share one untagged channel — independent of phrasing",
@@ -3421,31 +3174,6 @@
       "tokenkey_status": "candidate_unverified",
       "rationale": "Gateway/relay-relevant keyword match; not yet manually verified against TokenKey code.",
       "updated_at": "2026-06-02T18:24:16Z"
-    },
-    {
-      "upstream": "anthropics/claude-code#64540",
-      "url": "https://github.com/anthropics/claude-code/issues/64540",
-      "title": "Opus 4.7 (1M context) — confident assertion of stale data, fabricated dates, over-scripted simple operations",
-      "impact": "needs_review",
-      "categories": [
-        "model_lifecycle",
-        "prompt_caching"
-      ],
-      "tokenkey_status": "candidate_unverified",
-      "rationale": "Gateway/relay-relevant keyword match; not yet manually verified against TokenKey code.",
-      "updated_at": "2026-06-01T17:52:21Z"
-    },
-    {
-      "upstream": "anthropics/claude-code#64545",
-      "url": "https://github.com/anthropics/claude-code/issues/64545",
-      "title": "[Bug] Anthropic API Error: 400 Could not process image",
-      "impact": "needs_review",
-      "categories": [
-        "request_shape_400"
-      ],
-      "tokenkey_status": "candidate_unverified",
-      "rationale": "Gateway/relay-relevant keyword match; not yet manually verified against TokenKey code.",
-      "updated_at": "2026-06-01T18:11:12Z"
     },
     {
       "upstream": "anthropics/claude-code#64547",
@@ -3460,54 +3188,6 @@
       "updated_at": "2026-06-02T04:10:54Z"
     },
     {
-      "upstream": "anthropics/claude-code#64550",
-      "url": "https://github.com/anthropics/claude-code/issues/64550",
-      "title": "[BUG] Agent Teams (in-process): team-lead \"active agent\" pointer sticks on a teammate after a long/compacted session — lead routes AS the teammate, Agent spawns fail \"Teammates cannot spawn other teammates\"",
-      "impact": "needs_review",
-      "categories": [
-        "model_lifecycle"
-      ],
-      "tokenkey_status": "candidate_unverified",
-      "rationale": "Gateway/relay-relevant keyword match; not yet manually verified against TokenKey code.",
-      "updated_at": "2026-06-01T19:13:18Z"
-    },
-    {
-      "upstream": "anthropics/claude-code#64561",
-      "url": "https://github.com/anthropics/claude-code/issues/64561",
-      "title": "[BUG] Malformed/unparseable tool call: the raw tool-call markup (full parameter payload) is rendered to the user as message text",
-      "impact": "needs_review",
-      "categories": [
-        "model_lifecycle"
-      ],
-      "tokenkey_status": "candidate_unverified",
-      "rationale": "Gateway/relay-relevant keyword match; not yet manually verified against TokenKey code.",
-      "updated_at": "2026-06-01T20:27:11Z"
-    },
-    {
-      "upstream": "anthropics/claude-code#64566",
-      "url": "https://github.com/anthropics/claude-code/issues/64566",
-      "title": "[Feature Request] Add `promptStyle` config option for rate-limit/decision prompts",
-      "impact": "needs_review",
-      "categories": [
-        "rate_limit"
-      ],
-      "tokenkey_status": "candidate_unverified",
-      "rationale": "Gateway/relay-relevant keyword match; not yet manually verified against TokenKey code.",
-      "updated_at": "2026-06-01T21:08:52Z"
-    },
-    {
-      "upstream": "anthropics/claude-code#64567",
-      "url": "https://github.com/anthropics/claude-code/issues/64567",
-      "title": "[BUG] cct = TUI: permission-gate render-duplication",
-      "impact": "needs_review",
-      "categories": [
-        "request_shape_400"
-      ],
-      "tokenkey_status": "candidate_unverified",
-      "rationale": "Gateway/relay-relevant keyword match; not yet manually verified against TokenKey code.",
-      "updated_at": "2026-06-01T21:10:52Z"
-    },
-    {
       "upstream": "anthropics/claude-code#64574",
       "url": "https://github.com/anthropics/claude-code/issues/64574",
       "title": "Claude Code AI ignored direct user instructions, resulting in financial loss of $112.77",
@@ -3518,42 +3198,6 @@
       "tokenkey_status": "candidate_unverified",
       "rationale": "Gateway/relay-relevant keyword match; not yet manually verified against TokenKey code.",
       "updated_at": "2026-06-02T05:46:24Z"
-    },
-    {
-      "upstream": "anthropics/claude-code#64578",
-      "url": "https://github.com/anthropics/claude-code/issues/64578",
-      "title": "[BUG] Managed MCP server tools permanently stuck in \"Needs Approval\" — users cannot approve unlisted tools, contradicting docs and UI",
-      "impact": "needs_review",
-      "categories": [
-        "auth_token"
-      ],
-      "tokenkey_status": "candidate_unverified",
-      "rationale": "Gateway/relay-relevant keyword match; not yet manually verified against TokenKey code.",
-      "updated_at": "2026-06-01T21:56:49Z"
-    },
-    {
-      "upstream": "anthropics/claude-code#64579",
-      "url": "https://github.com/anthropics/claude-code/issues/64579",
-      "title": "[Bug] Tool call parsing fails with unrecoverable error",
-      "impact": "needs_review",
-      "categories": [
-        "model_lifecycle"
-      ],
-      "tokenkey_status": "candidate_unverified",
-      "rationale": "Gateway/relay-relevant keyword match; not yet manually verified against TokenKey code.",
-      "updated_at": "2026-06-01T22:08:21Z"
-    },
-    {
-      "upstream": "anthropics/claude-code#64582",
-      "url": "https://github.com/anthropics/claude-code/issues/64582",
-      "title": "[BUG] extensibility.py follows symlinks in project-controlled guidance file, sending local file content to API",
-      "impact": "needs_review",
-      "categories": [
-        "auth_token"
-      ],
-      "tokenkey_status": "candidate_unverified",
-      "rationale": "Gateway/relay-relevant keyword match; not yet manually verified against TokenKey code.",
-      "updated_at": "2026-06-01T22:17:56Z"
     },
     {
       "upstream": "anthropics/claude-code#64585",
@@ -3736,7 +3380,7 @@
       ],
       "tokenkey_status": "candidate_unverified",
       "rationale": "Gateway/relay-relevant keyword match; not yet manually verified against TokenKey code.",
-      "updated_at": "2026-06-04T12:31:53Z"
+      "updated_at": "2026-06-04T22:32:38Z"
     },
     {
       "upstream": "anthropics/claude-code#64654",
@@ -3945,7 +3589,7 @@
       ],
       "tokenkey_status": "candidate_unverified",
       "rationale": "Gateway/relay-relevant keyword match; not yet manually verified against TokenKey code.",
-      "updated_at": "2026-06-03T07:21:48Z"
+      "updated_at": "2026-06-04T21:17:24Z"
     },
     {
       "upstream": "anthropics/claude-code#64730",
@@ -3957,7 +3601,7 @@
       ],
       "tokenkey_status": "candidate_unverified",
       "rationale": "Gateway/relay-relevant keyword match; not yet manually verified against TokenKey code.",
-      "updated_at": "2026-06-02T12:38:51Z"
+      "updated_at": "2026-06-04T20:39:10Z"
     },
     {
       "upstream": "anthropics/claude-code#64735",
@@ -4054,7 +3698,7 @@
       ],
       "tokenkey_status": "candidate_unverified",
       "rationale": "Gateway/relay-relevant keyword match; not yet manually verified against TokenKey code.",
-      "updated_at": "2026-06-02T15:47:30Z"
+      "updated_at": "2026-06-04T14:48:32Z"
     },
     {
       "upstream": "anthropics/claude-code#64791",
@@ -4659,7 +4303,7 @@
       ],
       "tokenkey_status": "candidate_unverified",
       "rationale": "Gateway/relay-relevant keyword match; not yet manually verified against TokenKey code.",
-      "updated_at": "2026-06-03T15:36:12Z"
+      "updated_at": "2026-06-04T13:26:25Z"
     },
     {
       "upstream": "anthropics/claude-code#65054",
@@ -5300,18 +4944,6 @@
       "updated_at": "2026-06-04T09:06:15Z"
     },
     {
-      "upstream": "anthropics/claude-code#65320",
-      "url": "https://github.com/anthropics/claude-code/issues/65320",
-      "title": "setup-token OAuth token returns 401 Invalid bearer token with claude -p on Max subscription (interactive login on same account works)",
-      "impact": "needs_review",
-      "categories": [
-        "auth_token"
-      ],
-      "tokenkey_status": "candidate_unverified",
-      "rationale": "Gateway/relay-relevant keyword match; not yet manually verified against TokenKey code.",
-      "updated_at": "2026-06-04T09:23:23Z"
-    },
-    {
       "upstream": "anthropics/claude-code#65328",
       "url": "https://github.com/anthropics/claude-code/issues/65328",
       "title": "[BUG] Wave of false-positive Usage Policy blocks since 2026-06-03 ~17:00 UTC — 15 blocked requests across unrelated projects, Italian-language prompts, local config audited clean",
@@ -5321,7 +4953,7 @@
       ],
       "tokenkey_status": "candidate_unverified",
       "rationale": "Gateway/relay-relevant keyword match; not yet manually verified against TokenKey code.",
-      "updated_at": "2026-06-04T11:43:01Z"
+      "updated_at": "2026-06-04T22:50:14Z"
     },
     {
       "upstream": "anthropics/claude-code#65330",
@@ -5358,7 +4990,7 @@
       ],
       "tokenkey_status": "candidate_unverified",
       "rationale": "Gateway/relay-relevant keyword match; not yet manually verified against TokenKey code.",
-      "updated_at": "2026-06-04T10:19:00Z"
+      "updated_at": "2026-06-04T18:53:25Z"
     },
     {
       "upstream": "anthropics/claude-code#65347",
@@ -5382,7 +5014,7 @@
       ],
       "tokenkey_status": "candidate_unverified",
       "rationale": "Gateway/relay-relevant keyword match; not yet manually verified against TokenKey code.",
-      "updated_at": "2026-06-04T12:03:37Z"
+      "updated_at": "2026-06-04T19:31:23Z"
     },
     {
       "upstream": "anthropics/claude-code#65363",
@@ -5397,6 +5029,350 @@
       "updated_at": "2026-06-04T12:11:48Z"
     },
     {
+      "upstream": "anthropics/claude-code#65373",
+      "url": "https://github.com/anthropics/claude-code/issues/65373",
+      "title": "[BUG] Remote Control model picker accepts taps that have no effect, displays wrong \"current model\" checkmark",
+      "impact": "needs_review",
+      "categories": [
+        "beta_header_drift",
+        "model_lifecycle"
+      ],
+      "tokenkey_status": "candidate_unverified",
+      "rationale": "Gateway/relay-relevant keyword match; not yet manually verified against TokenKey code.",
+      "updated_at": "2026-06-04T13:09:51Z"
+    },
+    {
+      "upstream": "anthropics/claude-code#65384",
+      "url": "https://github.com/anthropics/claude-code/issues/65384",
+      "title": "[BUG] advisor_tool_results",
+      "impact": "needs_review",
+      "categories": [
+        "request_shape_400"
+      ],
+      "tokenkey_status": "candidate_unverified",
+      "rationale": "Gateway/relay-relevant keyword match; not yet manually verified against TokenKey code.",
+      "updated_at": "2026-06-04T14:01:02Z"
+    },
+    {
+      "upstream": "anthropics/claude-code#65385",
+      "url": "https://github.com/anthropics/claude-code/issues/65385",
+      "title": "[BUG] Sonnet 4.6 silently skips required Read of spilled-over UserPromptSubmit hook additionalContext file — Opus reads it 100% of the time under identical config",
+      "impact": "needs_review",
+      "categories": [
+        "request_shape_400"
+      ],
+      "tokenkey_status": "candidate_unverified",
+      "rationale": "Gateway/relay-relevant keyword match; not yet manually verified against TokenKey code.",
+      "updated_at": "2026-06-04T14:00:49Z"
+    },
+    {
+      "upstream": "anthropics/claude-code#65395",
+      "url": "https://github.com/anthropics/claude-code/issues/65395",
+      "title": "[BUG] ant beta:worker v1.9.0 — empty tool output → 400 \"minimum string length is 1\" → permanently wedged session (archived-redelivery loop)",
+      "impact": "needs_review",
+      "categories": [
+        "beta_header_drift",
+        "request_shape_400"
+      ],
+      "tokenkey_status": "candidate_unverified",
+      "rationale": "Gateway/relay-relevant keyword match; not yet manually verified against TokenKey code.",
+      "updated_at": "2026-06-04T14:49:17Z"
+    },
+    {
+      "upstream": "anthropics/claude-code#65397",
+      "url": "https://github.com/anthropics/claude-code/issues/65397",
+      "title": "[Bug] Rate limit error causes disproportionate quota consumption",
+      "impact": "needs_review",
+      "categories": [
+        "rate_limit"
+      ],
+      "tokenkey_status": "candidate_unverified",
+      "rationale": "Gateway/relay-relevant keyword match; not yet manually verified against TokenKey code.",
+      "updated_at": "2026-06-04T14:50:57Z"
+    },
+    {
+      "upstream": "anthropics/claude-code#65406",
+      "url": "https://github.com/anthropics/claude-code/issues/65406",
+      "title": "[BUG] Abnormal token consumption on Claude for Mac Pro plan — persisting after June 2 outage resolution - Reference issue #41930",
+      "impact": "needs_review",
+      "categories": [
+        "model_lifecycle"
+      ],
+      "tokenkey_status": "candidate_unverified",
+      "rationale": "Gateway/relay-relevant keyword match; not yet manually verified against TokenKey code.",
+      "updated_at": "2026-06-04T15:43:48Z"
+    },
+    {
+      "upstream": "anthropics/claude-code#65407",
+      "url": "https://github.com/anthropics/claude-code/issues/65407",
+      "title": "[Bug] Anthropic API Error: False positive content policy violations on localhost development",
+      "impact": "needs_review",
+      "categories": [
+        "request_shape_400"
+      ],
+      "tokenkey_status": "candidate_unverified",
+      "rationale": "Gateway/relay-relevant keyword match; not yet manually verified against TokenKey code.",
+      "updated_at": "2026-06-04T21:16:32Z"
+    },
+    {
+      "upstream": "anthropics/claude-code#65408",
+      "url": "https://github.com/anthropics/claude-code/issues/65408",
+      "title": "claude.ai connector via mcp-proxy.anthropic.com rejected with mcp_unauthorized_after_token_refresh while claude.ai backend uses the same grant successfully (OAuth 2.1 refresh rotation race)",
+      "impact": "needs_review",
+      "categories": [
+        "auth_token"
+      ],
+      "tokenkey_status": "candidate_unverified",
+      "rationale": "Gateway/relay-relevant keyword match; not yet manually verified against TokenKey code.",
+      "updated_at": "2026-06-04T15:49:34Z"
+    },
+    {
+      "upstream": "anthropics/claude-code#65410",
+      "url": "https://github.com/anthropics/claude-code/issues/65410",
+      "title": "Assistant answer text silently dropped: \"narration\" content blocks not rendered and persisted as empty thinking blocks",
+      "impact": "needs_review",
+      "categories": [
+        "request_shape_400",
+        "model_lifecycle"
+      ],
+      "tokenkey_status": "candidate_unverified",
+      "rationale": "Gateway/relay-relevant keyword match; not yet manually verified against TokenKey code.",
+      "updated_at": "2026-06-04T15:58:59Z"
+    },
+    {
+      "upstream": "anthropics/claude-code#65413",
+      "url": "https://github.com/anthropics/claude-code/issues/65413",
+      "title": "[BUG] MCP stdio: tool result written by server in <100ms is never processed — 3-min stall, then \"[Tool result missing due to internal error]\" (Windows, 2.1.162)",
+      "impact": "needs_review",
+      "categories": [
+        "model_lifecycle"
+      ],
+      "tokenkey_status": "candidate_unverified",
+      "rationale": "Gateway/relay-relevant keyword match; not yet manually verified against TokenKey code.",
+      "updated_at": "2026-06-04T16:22:30Z"
+    },
+    {
+      "upstream": "anthropics/claude-code#65415",
+      "url": "https://github.com/anthropics/claude-code/issues/65415",
+      "title": "[BUG] MacOS Claude app adding and removing ephemeral menu bar icon",
+      "impact": "needs_review",
+      "categories": [
+        "prompt_caching"
+      ],
+      "tokenkey_status": "candidate_unverified",
+      "rationale": "Gateway/relay-relevant keyword match; not yet manually verified against TokenKey code.",
+      "updated_at": "2026-06-04T16:29:27Z"
+    },
+    {
+      "upstream": "anthropics/claude-code#65418",
+      "url": "https://github.com/anthropics/claude-code/issues/65418",
+      "title": "/context reports incorrect context window ceiling (200k) when actual session window is 1M",
+      "impact": "needs_review",
+      "categories": [
+        "request_shape_400",
+        "model_lifecycle"
+      ],
+      "tokenkey_status": "candidate_unverified",
+      "rationale": "Gateway/relay-relevant keyword match; not yet manually verified against TokenKey code.",
+      "updated_at": "2026-06-04T16:41:56Z"
+    },
+    {
+      "upstream": "anthropics/claude-code#65422",
+      "url": "https://github.com/anthropics/claude-code/issues/65422",
+      "title": "[BUG] Error when trying to install Claude Desktop",
+      "impact": "needs_review",
+      "categories": [
+        "model_lifecycle"
+      ],
+      "tokenkey_status": "candidate_unverified",
+      "rationale": "Gateway/relay-relevant keyword match; not yet manually verified against TokenKey code.",
+      "updated_at": "2026-06-04T17:01:13Z"
+    },
+    {
+      "upstream": "anthropics/claude-code#65424",
+      "url": "https://github.com/anthropics/claude-code/issues/65424",
+      "title": "[Bug] /remote-control hangs indefinitely with false progress assertions",
+      "impact": "needs_review",
+      "categories": [
+        "model_lifecycle"
+      ],
+      "tokenkey_status": "candidate_unverified",
+      "rationale": "Gateway/relay-relevant keyword match; not yet manually verified against TokenKey code.",
+      "updated_at": "2026-06-04T17:03:26Z"
+    },
+    {
+      "upstream": "anthropics/claude-code#65429",
+      "url": "https://github.com/anthropics/claude-code/issues/65429",
+      "title": "[BUG] System prompt consumes ~9.3M tokens on every session after installing Claude Desktop on Windows (WSL setup)",
+      "impact": "needs_review",
+      "categories": [
+        "auth_token"
+      ],
+      "tokenkey_status": "candidate_unverified",
+      "rationale": "Gateway/relay-relevant keyword match; not yet manually verified against TokenKey code.",
+      "updated_at": "2026-06-04T17:54:32Z"
+    },
+    {
+      "upstream": "anthropics/claude-code#65450",
+      "url": "https://github.com/anthropics/claude-code/issues/65450",
+      "title": "Support skipping GCP auth in Vertex AI mode for proxy-based deployments",
+      "impact": "needs_review",
+      "categories": [
+        "request_shape_400",
+        "auth_token"
+      ],
+      "tokenkey_status": "candidate_unverified",
+      "rationale": "Gateway/relay-relevant keyword match; not yet manually verified against TokenKey code.",
+      "updated_at": "2026-06-04T21:45:05Z"
+    },
+    {
+      "upstream": "anthropics/claude-code#65457",
+      "url": "https://github.com/anthropics/claude-code/issues/65457",
+      "title": "[MODEL] Claude raised my stress levels, causing me stomach aches",
+      "impact": "needs_review",
+      "categories": [
+        "auth_token",
+        "model_lifecycle"
+      ],
+      "tokenkey_status": "candidate_unverified",
+      "rationale": "Gateway/relay-relevant keyword match; not yet manually verified against TokenKey code.",
+      "updated_at": "2026-06-04T20:43:22Z"
+    },
+    {
+      "upstream": "anthropics/claude-code#65459",
+      "url": "https://github.com/anthropics/claude-code/issues/65459",
+      "title": "[Bug] Claude Sonnet ignores user instructions and makes unauthorized code changes",
+      "impact": "needs_review",
+      "categories": [
+        "auth_token"
+      ],
+      "tokenkey_status": "candidate_unverified",
+      "rationale": "Gateway/relay-relevant keyword match; not yet manually verified against TokenKey code.",
+      "updated_at": "2026-06-04T19:38:12Z"
+    },
+    {
+      "upstream": "anthropics/claude-code#65463",
+      "url": "https://github.com/anthropics/claude-code/issues/65463",
+      "title": "User-scope MCP server (`mcp add --scope user`) silently disappeared from `~/.claude.json` under heavy concurrent session load",
+      "impact": "needs_review",
+      "categories": [
+        "auth_token"
+      ],
+      "tokenkey_status": "candidate_unverified",
+      "rationale": "Gateway/relay-relevant keyword match; not yet manually verified against TokenKey code.",
+      "updated_at": "2026-06-04T20:04:42Z"
+    },
+    {
+      "upstream": "anthropics/claude-code#65464",
+      "url": "https://github.com/anthropics/claude-code/issues/65464",
+      "title": "[BUG] CC + Opus 4.8: `ScheduleWakeup` constantly re-injects workflow slash command as an apparent user invocation, causing an unrequested re-run of entire workflow",
+      "impact": "needs_review",
+      "categories": [
+        "model_lifecycle"
+      ],
+      "tokenkey_status": "candidate_unverified",
+      "rationale": "Gateway/relay-relevant keyword match; not yet manually verified against TokenKey code.",
+      "updated_at": "2026-06-04T23:46:45Z"
+    },
+    {
+      "upstream": "anthropics/claude-code#65466",
+      "url": "https://github.com/anthropics/claude-code/issues/65466",
+      "title": "[BUG] claude auth login succeeds but OAuth token not readable in new sessions (macOS, native binary install)",
+      "impact": "needs_review",
+      "categories": [
+        "auth_token"
+      ],
+      "tokenkey_status": "candidate_unverified",
+      "rationale": "Gateway/relay-relevant keyword match; not yet manually verified against TokenKey code.",
+      "updated_at": "2026-06-04T20:14:13Z"
+    },
+    {
+      "upstream": "anthropics/claude-code#65469",
+      "url": "https://github.com/anthropics/claude-code/issues/65469",
+      "title": "[FEATURE] Batch MCP reauthentication (`/mcp reauthenticate-all`)",
+      "impact": "needs_review",
+      "categories": [
+        "auth_token"
+      ],
+      "tokenkey_status": "candidate_unverified",
+      "rationale": "Gateway/relay-relevant keyword match; not yet manually verified against TokenKey code.",
+      "updated_at": "2026-06-04T20:29:52Z"
+    },
+    {
+      "upstream": "anthropics/claude-code#65474",
+      "url": "https://github.com/anthropics/claude-code/issues/65474",
+      "title": "[Bug] claude CLI silently exits on transient network errors during tool-use turns (no retry, no backoff)",
+      "impact": "needs_review",
+      "categories": [
+        "model_lifecycle"
+      ],
+      "tokenkey_status": "candidate_unverified",
+      "rationale": "Gateway/relay-relevant keyword match; not yet manually verified against TokenKey code.",
+      "updated_at": "2026-06-04T20:57:54Z"
+    },
+    {
+      "upstream": "anthropics/claude-code#65477",
+      "url": "https://github.com/anthropics/claude-code/issues/65477",
+      "title": "[BUG] Unauthorized git push to production",
+      "impact": "needs_review",
+      "categories": [
+        "auth_token",
+        "model_lifecycle"
+      ],
+      "tokenkey_status": "candidate_unverified",
+      "rationale": "Gateway/relay-relevant keyword match; not yet manually verified against TokenKey code.",
+      "updated_at": "2026-06-04T21:46:14Z"
+    },
+    {
+      "upstream": "anthropics/claude-code#65490",
+      "url": "https://github.com/anthropics/claude-code/issues/65490",
+      "title": "[BUG] Claude Code unusable on Pro plan due to 1M context bug — request for fix or credit",
+      "impact": "needs_review",
+      "categories": [
+        "model_lifecycle"
+      ],
+      "tokenkey_status": "candidate_unverified",
+      "rationale": "Gateway/relay-relevant keyword match; not yet manually verified against TokenKey code.",
+      "updated_at": "2026-06-04T22:05:13Z"
+    },
+    {
+      "upstream": "anthropics/claude-code#65505",
+      "url": "https://github.com/anthropics/claude-code/issues/65505",
+      "title": "[bug] Opus adaptive-thinking summaries never display in non-interactive frontends (VS Code extension): showThinkingSummaries gated behind isInteractive",
+      "impact": "needs_review",
+      "categories": [
+        "request_shape_400",
+        "model_lifecycle"
+      ],
+      "tokenkey_status": "candidate_unverified",
+      "rationale": "Gateway/relay-relevant keyword match; not yet manually verified against TokenKey code.",
+      "updated_at": "2026-06-04T22:26:16Z"
+    },
+    {
+      "upstream": "anthropics/claude-code#65506",
+      "url": "https://github.com/anthropics/claude-code/issues/65506",
+      "title": "[BUG]Cannot authenticate Claude Code on headless remote server (VPS)",
+      "impact": "needs_review",
+      "categories": [
+        "auth_token"
+      ],
+      "tokenkey_status": "candidate_unverified",
+      "rationale": "Gateway/relay-relevant keyword match; not yet manually verified against TokenKey code.",
+      "updated_at": "2026-06-04T22:29:31Z"
+    },
+    {
+      "upstream": "anthropics/claude-code#65514",
+      "url": "https://github.com/anthropics/claude-code/issues/65514",
+      "title": "[BUG] Usage credits required for 1M context - Pro plan blocked despite 17% usage",
+      "impact": "needs_review",
+      "categories": [
+        "model_lifecycle"
+      ],
+      "tokenkey_status": "candidate_unverified",
+      "rationale": "Gateway/relay-relevant keyword match; not yet manually verified against TokenKey code.",
+      "updated_at": "2026-06-04T23:43:42Z"
+    },
+    {
       "upstream": "anthropics/claude-code#8327",
       "url": "https://github.com/anthropics/claude-code/issues/8327",
       "title": "[Bug/Documentation] 'Organization has been disabled' error when ANTHROPIC_API_KEY overrides Max/Pro subscription",
@@ -5409,16 +5385,16 @@
       "updated_at": "2026-06-02T20:35:55Z"
     },
     {
-      "upstream": "anthropics/claude-code#8938",
-      "url": "https://github.com/anthropics/claude-code/issues/8938",
-      "title": "[BUG] claude setup-token/CLAUDE_CODE_OAUTH_TOKEN is not enough to authenticate claude",
-      "impact": "needs_review",
+      "upstream": "anthropics/claude-code#12925",
+      "url": "https://github.com/anthropics/claude-code/issues/12925",
+      "title": "Linear Integration: Assign issues to Claude Code to trigger cloud agent sessions",
+      "impact": "medium",
       "categories": [
-        "auth_token"
+        "effort_structured"
       ],
-      "tokenkey_status": "candidate_unverified",
-      "rationale": "Gateway/relay-relevant keyword match; not yet manually verified against TokenKey code.",
-      "updated_at": "2026-06-01T15:09:44Z"
+      "tokenkey_status": "not_prioritized",
+      "rationale": "Possible gateway compatibility/streaming impact, but not a high-severity relay signal in this pass.",
+      "updated_at": "2026-06-04T14:35:16Z"
     },
     {
       "upstream": "anthropics/claude-code#22264",
@@ -5518,18 +5494,6 @@
       "updated_at": "2026-06-04T01:56:13Z"
     },
     {
-      "upstream": "anthropics/claude-code#55814",
-      "url": "https://github.com/anthropics/claude-code/issues/55814",
-      "title": "ultrareview crashed before producing findings — refund request",
-      "impact": "medium",
-      "categories": [
-        "token_limits"
-      ],
-      "tokenkey_status": "not_prioritized",
-      "rationale": "Possible gateway compatibility/streaming impact, but not a high-severity relay signal in this pass.",
-      "updated_at": "2026-06-01T22:46:04Z"
-    },
-    {
       "upstream": "anthropics/claude-code#60109",
       "url": "https://github.com/anthropics/claude-code/issues/60109",
       "title": "/usage Session view shows stale or cross-session data",
@@ -5540,6 +5504,31 @@
       "tokenkey_status": "not_prioritized",
       "rationale": "Possible gateway compatibility/streaming impact, but not a high-severity relay signal in this pass.",
       "updated_at": "2026-06-02T11:33:06Z"
+    },
+    {
+      "upstream": "anthropics/claude-code#60715",
+      "url": "https://github.com/anthropics/claude-code/issues/60715",
+      "title": "[MODEL] building simple etl process to generate html dashboard for Trading from Fidelity",
+      "impact": "medium",
+      "categories": [
+        "effort_structured"
+      ],
+      "tokenkey_status": "not_prioritized",
+      "rationale": "Possible gateway compatibility/streaming impact, but not a high-severity relay signal in this pass.",
+      "updated_at": "2026-06-04T22:33:11Z"
+    },
+    {
+      "upstream": "anthropics/claude-code#60733",
+      "url": "https://github.com/anthropics/claude-code/issues/60733",
+      "title": "Model uses N sequential Edit calls for bulk renumbering instead of single sed/Write",
+      "impact": "medium",
+      "categories": [
+        "token_limits",
+        "effort_structured"
+      ],
+      "tokenkey_status": "not_prioritized",
+      "rationale": "Possible gateway compatibility/streaming impact, but not a high-severity relay signal in this pass.",
+      "updated_at": "2026-06-04T22:33:21Z"
     },
     {
       "upstream": "anthropics/claude-code#63456",
@@ -5576,19 +5565,7 @@
       ],
       "tokenkey_status": "not_prioritized",
       "rationale": "Possible gateway compatibility/streaming impact, but not a high-severity relay signal in this pass.",
-      "updated_at": "2026-06-03T10:26:19Z"
-    },
-    {
-      "upstream": "anthropics/claude-code#64546",
-      "url": "https://github.com/anthropics/claude-code/issues/64546",
-      "title": "[BUG] Context window display shows stale \"Messages\" count from previous session on new session start — corrects after first message",
-      "impact": "medium",
-      "categories": [
-        "token_limits"
-      ],
-      "tokenkey_status": "not_prioritized",
-      "rationale": "Possible gateway compatibility/streaming impact, but not a high-severity relay signal in this pass.",
-      "updated_at": "2026-06-01T18:30:50Z"
+      "updated_at": "2026-06-04T20:33:42Z"
     },
     {
       "upstream": "anthropics/claude-code#64692",
@@ -5709,6 +5686,42 @@
       "tokenkey_status": "not_prioritized",
       "rationale": "Possible gateway compatibility/streaming impact, but not a high-severity relay signal in this pass.",
       "updated_at": "2026-06-04T08:42:10Z"
+    },
+    {
+      "upstream": "anthropics/claude-code#65414",
+      "url": "https://github.com/anthropics/claude-code/issues/65414",
+      "title": "[Behavioral] embedded-ripgrep V8-heap unbounded on file-listing (GH#54394 second spawn route)",
+      "impact": "medium",
+      "categories": [
+        "token_limits"
+      ],
+      "tokenkey_status": "not_prioritized",
+      "rationale": "Possible gateway compatibility/streaming impact, but not a high-severity relay signal in this pass.",
+      "updated_at": "2026-06-04T16:31:08Z"
+    },
+    {
+      "upstream": "anthropics/claude-code#65472",
+      "url": "https://github.com/anthropics/claude-code/issues/65472",
+      "title": "Under conflict, a Claude Code agent refused capable legitimate actions, misreported its own capability and behavior, and denied the user's accurate perception",
+      "impact": "medium",
+      "categories": [
+        "token_limits"
+      ],
+      "tokenkey_status": "not_prioritized",
+      "rationale": "Possible gateway compatibility/streaming impact, but not a high-severity relay signal in this pass.",
+      "updated_at": "2026-06-04T22:24:35Z"
+    },
+    {
+      "upstream": "anthropics/claude-code#65515",
+      "url": "https://github.com/anthropics/claude-code/issues/65515",
+      "title": "Enhancement: Hybrid Memory Architecture to Replace Full Conversation History in Context Window",
+      "impact": "medium",
+      "categories": [
+        "token_limits"
+      ],
+      "tokenkey_status": "not_prioritized",
+      "rationale": "Possible gateway compatibility/streaming impact, but not a high-severity relay signal in this pass.",
+      "updated_at": "2026-06-04T23:44:48Z"
     },
     {
       "upstream": "anthropics/claude-code#12531",
@@ -5842,18 +5855,6 @@
       "updated_at": "2026-06-04T11:22:51Z"
     },
     {
-      "upstream": "anthropics/claude-code#16135",
-      "url": "https://github.com/anthropics/claude-code/issues/16135",
-      "title": "Background process termination crashes Claude Code in Docker containers",
-      "impact": "not_applicable",
-      "categories": [
-        "terminal"
-      ],
-      "tokenkey_status": "not_applicable",
-      "rationale": "Client-side claude-code concern (terminal); not a gateway/relay relevance signal.",
-      "updated_at": "2026-06-01T22:45:05Z"
-    },
-    {
       "upstream": "anthropics/claude-code#16157",
       "url": "https://github.com/anthropics/claude-code/issues/16157",
       "title": "[BUG] Instantly hitting usage limits with Max subscription",
@@ -5928,7 +5929,7 @@
       ],
       "tokenkey_status": "not_applicable",
       "rationale": "Client-side claude-code concern (terminal, install, platform); not a gateway/relay relevance signal.",
-      "updated_at": "2026-06-04T00:46:58Z"
+      "updated_at": "2026-06-04T15:44:28Z"
     },
     {
       "upstream": "anthropics/claude-code#17432",
@@ -5982,6 +5983,18 @@
       "updated_at": "2026-06-03T21:27:07Z"
     },
     {
+      "upstream": "anthropics/claude-code#18241",
+      "url": "https://github.com/anthropics/claude-code/issues/18241",
+      "title": "[BUG] Context percentage mismatch between /context, statusline API, and internal limit trigger",
+      "impact": "not_applicable",
+      "categories": [
+        "terminal"
+      ],
+      "tokenkey_status": "not_applicable",
+      "rationale": "Client-side claude-code concern (terminal); not a gateway/relay relevance signal.",
+      "updated_at": "2026-06-04T19:55:13Z"
+    },
+    {
       "upstream": "anthropics/claude-code#18435",
       "url": "https://github.com/anthropics/claude-code/issues/18435",
       "title": "[FEATURE] Add the ability to manage multiple Claude accounts within the Claude Desktop app with easy switching between profiles.",
@@ -6006,19 +6019,6 @@
       "tokenkey_status": "not_applicable",
       "rationale": "Client-side claude-code concern (ide); not a gateway/relay relevance signal.",
       "updated_at": "2026-06-03T22:44:52Z"
-    },
-    {
-      "upstream": "anthropics/claude-code#19976",
-      "url": "https://github.com/anthropics/claude-code/issues/19976",
-      "title": "[FEATURE] Support terminal notifications when running inside tmux",
-      "impact": "not_applicable",
-      "categories": [
-        "terminal",
-        "slash_hook"
-      ],
-      "tokenkey_status": "not_applicable",
-      "rationale": "Client-side claude-code concern (terminal, slash_hook); not a gateway/relay relevance signal.",
-      "updated_at": "2026-06-01T21:04:21Z"
     },
     {
       "upstream": "anthropics/claude-code#20412",
@@ -6056,6 +6056,18 @@
       "tokenkey_status": "not_applicable",
       "rationale": "Client-side claude-code concern (slash_hook); not a gateway/relay relevance signal.",
       "updated_at": "2026-06-03T09:10:34Z"
+    },
+    {
+      "upstream": "anthropics/claude-code#2102",
+      "url": "https://github.com/anthropics/claude-code/issues/2102",
+      "title": "Clipboard Image Parsing Failure on macOS Screenshot Utility",
+      "impact": "not_applicable",
+      "categories": [
+        "terminal"
+      ],
+      "tokenkey_status": "not_applicable",
+      "rationale": "Client-side claude-code concern (terminal); not a gateway/relay relevance signal.",
+      "updated_at": "2026-06-04T14:34:59Z"
     },
     {
       "upstream": "anthropics/claude-code#21051",
@@ -6111,19 +6123,6 @@
       "updated_at": "2026-06-02T23:06:02Z"
     },
     {
-      "upstream": "anthropics/claude-code#24285",
-      "url": "https://github.com/anthropics/claude-code/issues/24285",
-      "title": "[BUG] Can't see Claude's thinking anymore",
-      "impact": "not_applicable",
-      "categories": [
-        "terminal",
-        "platform"
-      ],
-      "tokenkey_status": "not_applicable",
-      "rationale": "Client-side claude-code concern (terminal, platform); not a gateway/relay relevance signal.",
-      "updated_at": "2026-06-01T18:56:09Z"
-    },
-    {
       "upstream": "anthropics/claude-code#2441",
       "url": "https://github.com/anthropics/claude-code/issues/2441",
       "title": "[FRE] Add timestamp to each message",
@@ -6158,6 +6157,18 @@
       "tokenkey_status": "not_applicable",
       "rationale": "Client-side claude-code concern (terminal); not a gateway/relay relevance signal.",
       "updated_at": "2026-06-03T17:09:46Z"
+    },
+    {
+      "upstream": "anthropics/claude-code#25018",
+      "url": "https://github.com/anthropics/claude-code/issues/25018",
+      "title": "[FEATURE] \"Add a VS Code setting to disable auto-opening diff tabs when Claude edits files.\"",
+      "impact": "not_applicable",
+      "categories": [
+        "ide"
+      ],
+      "tokenkey_status": "not_applicable",
+      "rationale": "Client-side claude-code concern (ide); not a gateway/relay relevance signal.",
+      "updated_at": "2026-06-04T19:24:18Z"
     },
     {
       "upstream": "anthropics/claude-code#25434",
@@ -6221,7 +6232,21 @@
       ],
       "tokenkey_status": "not_applicable",
       "rationale": "Client-side claude-code concern (terminal, platform); not a gateway/relay relevance signal.",
-      "updated_at": "2026-06-02T09:14:19Z"
+      "updated_at": "2026-06-04T18:53:16Z"
+    },
+    {
+      "upstream": "anthropics/claude-code#26302",
+      "url": "https://github.com/anthropics/claude-code/issues/26302",
+      "title": "[BUG] Claude Desktop 1.1.3189 severe UI lag and mouse stutter on Windows — performance regression after update",
+      "impact": "not_applicable",
+      "categories": [
+        "terminal",
+        "mcp",
+        "platform"
+      ],
+      "tokenkey_status": "not_applicable",
+      "rationale": "Client-side claude-code concern (terminal, mcp, platform); not a gateway/relay relevance signal.",
+      "updated_at": "2026-06-04T17:03:49Z"
     },
     {
       "upstream": "anthropics/claude-code#26784",
@@ -6324,6 +6349,19 @@
       "updated_at": "2026-06-03T08:28:54Z"
     },
     {
+      "upstream": "anthropics/claude-code#28125",
+      "url": "https://github.com/anthropics/claude-code/issues/28125",
+      "title": "[BUG] Cowork Can't add private GitHub marketplace",
+      "impact": "not_applicable",
+      "categories": [
+        "terminal",
+        "plugin"
+      ],
+      "tokenkey_status": "not_applicable",
+      "rationale": "Client-side claude-code concern (terminal, plugin); not a gateway/relay relevance signal.",
+      "updated_at": "2026-06-04T18:57:41Z"
+    },
+    {
       "upstream": "anthropics/claude-code#28240",
       "url": "https://github.com/anthropics/claude-code/issues/28240",
       "title": "[BUG] Permission prompt incorrectly triggers on cd instead of the actual command in compound bash statements",
@@ -6376,6 +6414,18 @@
       "updated_at": "2026-06-02T10:10:14Z"
     },
     {
+      "upstream": "anthropics/claude-code#28729",
+      "url": "https://github.com/anthropics/claude-code/issues/28729",
+      "title": "[FEATURE] Link a source control repo as the source for organization skills",
+      "impact": "not_applicable",
+      "categories": [
+        "plugin"
+      ],
+      "tokenkey_status": "not_applicable",
+      "rationale": "Client-side claude-code concern (plugin); not a gateway/relay relevance signal.",
+      "updated_at": "2026-06-04T15:03:58Z"
+    },
+    {
       "upstream": "anthropics/claude-code#28817",
       "url": "https://github.com/anthropics/claude-code/issues/28817",
       "title": "[Bug] Remote Control unavailable despite Pro plan authentication",
@@ -6411,19 +6461,6 @@
       "tokenkey_status": "not_applicable",
       "rationale": "Client-side claude-code concern (terminal, platform); not a gateway/relay relevance signal.",
       "updated_at": "2026-06-03T22:45:55Z"
-    },
-    {
-      "upstream": "anthropics/claude-code#29423",
-      "url": "https://github.com/anthropics/claude-code/issues/29423",
-      "title": "Task subagents do not load project CLAUDE.md or .claude/rules/ -- project configuration silently ignored",
-      "impact": "not_applicable",
-      "categories": [
-        "plugin",
-        "platform"
-      ],
-      "tokenkey_status": "not_applicable",
-      "rationale": "Client-side claude-code concern (plugin, platform); not a gateway/relay relevance signal.",
-      "updated_at": "2026-06-01T22:46:21Z"
     },
     {
       "upstream": "anthropics/claude-code#29508",
@@ -6496,7 +6533,7 @@
       ],
       "tokenkey_status": "not_applicable",
       "rationale": "Client-side claude-code concern (terminal, platform); not a gateway/relay relevance signal.",
-      "updated_at": "2026-06-04T08:57:14Z"
+      "updated_at": "2026-06-04T15:30:06Z"
     },
     {
       "upstream": "anthropics/claude-code#30199",
@@ -6523,16 +6560,19 @@
       "updated_at": "2026-06-02T11:32:39Z"
     },
     {
-      "upstream": "anthropics/claude-code#30533",
-      "url": "https://github.com/anthropics/claude-code/issues/30533",
-      "title": "[FEATURE] Microsoft 365 MCP:Add support for reading email attachments",
+      "upstream": "anthropics/claude-code#30492",
+      "url": "https://github.com/anthropics/claude-code/issues/30492",
+      "title": "[Feature Request] Real-time steering: priority message channel for redirecting Claude mid-execution",
       "impact": "not_applicable",
       "categories": [
-        "mcp"
+        "terminal",
+        "plugin",
+        "slash_hook",
+        "platform"
       ],
       "tokenkey_status": "not_applicable",
-      "rationale": "Client-side claude-code concern (mcp); not a gateway/relay relevance signal.",
-      "updated_at": "2026-06-01T18:40:35Z"
+      "rationale": "Client-side claude-code concern (terminal, plugin, slash_hook, platform); not a gateway/relay relevance signal.",
+      "updated_at": "2026-06-04T18:59:55Z"
     },
     {
       "upstream": "anthropics/claude-code#30897",
@@ -6639,18 +6679,6 @@
       "updated_at": "2026-06-03T11:39:38Z"
     },
     {
-      "upstream": "anthropics/claude-code#31977",
-      "url": "https://github.com/anthropics/claude-code/issues/31977",
-      "title": "[BUG] In-process team agents lack the Agent tool (cannot spawn subagents)",
-      "impact": "not_applicable",
-      "categories": [
-        "plugin"
-      ],
-      "tokenkey_status": "not_applicable",
-      "rationale": "Client-side claude-code concern (plugin); not a gateway/relay relevance signal.",
-      "updated_at": "2026-06-01T22:45:12Z"
-    },
-    {
       "upstream": "anthropics/claude-code#32005",
       "url": "https://github.com/anthropics/claude-code/issues/32005",
       "title": "[FEATURE] Support image/screenshot paste in Claude Code terminal",
@@ -6661,18 +6689,6 @@
       "tokenkey_status": "not_applicable",
       "rationale": "Client-side claude-code concern (terminal); not a gateway/relay relevance signal.",
       "updated_at": "2026-06-03T00:39:21Z"
-    },
-    {
-      "upstream": "anthropics/claude-code#32508",
-      "url": "https://github.com/anthropics/claude-code/issues/32508",
-      "title": "[MODEL] System prompt \"Output efficiency\" section causes action-before-understanding bias, degrading code quality",
-      "impact": "not_applicable",
-      "categories": [
-        "plugin"
-      ],
-      "tokenkey_status": "not_applicable",
-      "rationale": "Client-side claude-code concern (plugin); not a gateway/relay relevance signal.",
-      "updated_at": "2026-06-01T22:46:17Z"
     },
     {
       "upstream": "anthropics/claude-code#32791",
@@ -6793,18 +6809,6 @@
       "updated_at": "2026-06-04T05:04:02Z"
     },
     {
-      "upstream": "anthropics/claude-code#34556",
-      "url": "https://github.com/anthropics/claude-code/issues/34556",
-      "title": "Feature Request: Persistent Memory Across Context Compactions (59 compactions, built our own)",
-      "impact": "not_applicable",
-      "categories": [
-        "slash_hook"
-      ],
-      "tokenkey_status": "not_applicable",
-      "rationale": "Client-side claude-code concern (slash_hook); not a gateway/relay relevance signal.",
-      "updated_at": "2026-06-01T16:27:31Z"
-    },
-    {
       "upstream": "anthropics/claude-code#35145",
       "url": "https://github.com/anthropics/claude-code/issues/35145",
       "title": "[DOCS] VS Code docs omit `macOptionClickForcesSelection`",
@@ -6868,18 +6872,6 @@
       "updated_at": "2026-06-03T08:50:46Z"
     },
     {
-      "upstream": "anthropics/claude-code#35798",
-      "url": "https://github.com/anthropics/claude-code/issues/35798",
-      "title": "[BUG] # memory",
-      "impact": "not_applicable",
-      "categories": [
-        "terminal"
-      ],
-      "tokenkey_status": "not_applicable",
-      "rationale": "Client-side claude-code concern (terminal); not a gateway/relay relevance signal.",
-      "updated_at": "2026-06-01T22:46:01Z"
-    },
-    {
       "upstream": "anthropics/claude-code#36179",
       "url": "https://github.com/anthropics/claude-code/issues/36179",
       "title": "[BUG] Unsupported content type: redacted_thinking，Errors often occur when using the plugin.",
@@ -6892,7 +6884,7 @@
       ],
       "tokenkey_status": "not_applicable",
       "rationale": "Client-side claude-code concern (ide, terminal, plugin, platform); not a gateway/relay relevance signal.",
-      "updated_at": "2026-06-03T08:31:00Z"
+      "updated_at": "2026-06-04T22:57:30Z"
     },
     {
       "upstream": "anthropics/claude-code#36258",
@@ -6976,6 +6968,22 @@
       "updated_at": "2026-06-03T11:40:50Z"
     },
     {
+      "upstream": "anthropics/claude-code#36865",
+      "url": "https://github.com/anthropics/claude-code/issues/36865",
+      "title": "Every new cloud session immediately fails with \"No conversation found with session ID\". This happens with ALL new sessions, not just one.",
+      "impact": "not_applicable",
+      "categories": [
+        "ide",
+        "terminal",
+        "plugin",
+        "slash_hook",
+        "platform"
+      ],
+      "tokenkey_status": "not_applicable",
+      "rationale": "Client-side claude-code concern (ide, terminal, plugin, slash_hook, platform); not a gateway/relay relevance signal.",
+      "updated_at": "2026-06-04T22:33:37Z"
+    },
+    {
       "upstream": "anthropics/claude-code#36884",
       "url": "https://github.com/anthropics/claude-code/issues/36884",
       "title": "VS Code extension ignores Edit/Write permission rules in settings files",
@@ -7050,6 +7058,19 @@
       "tokenkey_status": "not_applicable",
       "rationale": "Client-side claude-code concern (ide, terminal, mcp); not a gateway/relay relevance signal.",
       "updated_at": "2026-06-03T07:49:26Z"
+    },
+    {
+      "upstream": "anthropics/claude-code#38005",
+      "url": "https://github.com/anthropics/claude-code/issues/38005",
+      "title": "RTL (Right-to-Left) Support for Hebrew & Arabic in Claude Desktop / Cowork",
+      "impact": "not_applicable",
+      "categories": [
+        "ide",
+        "terminal"
+      ],
+      "tokenkey_status": "not_applicable",
+      "rationale": "Client-side claude-code concern (ide, terminal); not a gateway/relay relevance signal.",
+      "updated_at": "2026-06-04T15:43:52Z"
     },
     {
       "upstream": "anthropics/claude-code#38008",
@@ -7139,20 +7160,7 @@
       ],
       "tokenkey_status": "not_applicable",
       "rationale": "Client-side claude-code concern (terminal, platform); not a gateway/relay relevance signal.",
-      "updated_at": "2026-06-02T13:12:29Z"
-    },
-    {
-      "upstream": "anthropics/claude-code#39027",
-      "url": "https://github.com/anthropics/claude-code/issues/39027",
-      "title": "Background task notifications trigger autonomous API calls — model responds as if it were the user",
-      "impact": "not_applicable",
-      "categories": [
-        "slash_hook",
-        "install"
-      ],
-      "tokenkey_status": "not_applicable",
-      "rationale": "Client-side claude-code concern (slash_hook, install); not a gateway/relay relevance signal.",
-      "updated_at": "2026-06-01T22:45:24Z"
+      "updated_at": "2026-06-04T21:16:14Z"
     },
     {
       "upstream": "anthropics/claude-code#39114",
@@ -7238,6 +7246,19 @@
       "updated_at": "2026-06-03T11:39:43Z"
     },
     {
+      "upstream": "anthropics/claude-code#39636",
+      "url": "https://github.com/anthropics/claude-code/issues/39636",
+      "title": "[BUG] Cowork VM guest kernel never boots on Snapdragon X Plus (ARM64) — connection timeout every attempt",
+      "impact": "not_applicable",
+      "categories": [
+        "terminal",
+        "platform"
+      ],
+      "tokenkey_status": "not_applicable",
+      "rationale": "Client-side claude-code concern (terminal, platform); not a gateway/relay relevance signal.",
+      "updated_at": "2026-06-04T13:36:36Z"
+    },
+    {
       "upstream": "anthropics/claude-code#39663",
       "url": "https://github.com/anthropics/claude-code/issues/39663",
       "title": "Context is lost when Claude suggests restarting — should auto-save a session summary before restart",
@@ -7314,7 +7335,7 @@
       ],
       "tokenkey_status": "not_applicable",
       "rationale": "Client-side claude-code concern (terminal, mcp, install, platform); not a gateway/relay relevance signal.",
-      "updated_at": "2026-06-03T09:33:31Z"
+      "updated_at": "2026-06-04T16:24:26Z"
     },
     {
       "upstream": "anthropics/claude-code#40897",
@@ -7357,6 +7378,22 @@
       "updated_at": "2026-06-02T13:36:59Z"
     },
     {
+      "upstream": "anthropics/claude-code#41242",
+      "url": "https://github.com/anthropics/claude-code/issues/41242",
+      "title": "[BUG] Claude Code sustained ~80% ECONNRESET failure rate — March 30, 2026 specifically from Boston Area",
+      "impact": "not_applicable",
+      "categories": [
+        "ide",
+        "terminal",
+        "mcp",
+        "install",
+        "platform"
+      ],
+      "tokenkey_status": "not_applicable",
+      "rationale": "Client-side claude-code concern (ide, terminal, mcp, install, platform); not a gateway/relay relevance signal.",
+      "updated_at": "2026-06-04T22:33:17Z"
+    },
+    {
       "upstream": "anthropics/claude-code#41264",
       "url": "https://github.com/anthropics/claude-code/issues/41264",
       "title": "[DOCS] `/stats` docs omit date ranges, retention semantics, and usage aggregation details",
@@ -7383,16 +7420,18 @@
       "updated_at": "2026-06-03T11:39:50Z"
     },
     {
-      "upstream": "anthropics/claude-code#41581",
-      "url": "https://github.com/anthropics/claude-code/issues/41581",
-      "title": "[BUG] Max subscription downgraded to Free plan without any action from user",
+      "upstream": "anthropics/claude-code#41414",
+      "url": "https://github.com/anthropics/claude-code/issues/41414",
+      "title": "[BUG] VSCode: Past Conversations dropdown missing most sessions (files intact on disk)",
       "impact": "not_applicable",
       "categories": [
-        "terminal"
+        "ide",
+        "terminal",
+        "platform"
       ],
       "tokenkey_status": "not_applicable",
-      "rationale": "Client-side claude-code concern (terminal); not a gateway/relay relevance signal.",
-      "updated_at": "2026-06-01T22:45:50Z"
+      "rationale": "Client-side claude-code concern (ide, terminal, platform); not a gateway/relay relevance signal.",
+      "updated_at": "2026-06-04T22:33:01Z"
     },
     {
       "upstream": "anthropics/claude-code#41737",
@@ -7533,7 +7572,7 @@
       ],
       "tokenkey_status": "not_applicable",
       "rationale": "Client-side claude-code concern (terminal, slash_hook, platform); not a gateway/relay relevance signal.",
-      "updated_at": "2026-06-02T08:07:12Z"
+      "updated_at": "2026-06-04T17:52:30Z"
     },
     {
       "upstream": "anthropics/claude-code#42975",
@@ -7549,31 +7588,6 @@
       "updated_at": "2026-06-02T11:32:12Z"
     },
     {
-      "upstream": "anthropics/claude-code#43013",
-      "url": "https://github.com/anthropics/claude-code/issues/43013",
-      "title": "[BUG] 🚨 `--continue` and `-p` are now seriously broken together in 2.1.90",
-      "impact": "not_applicable",
-      "categories": [
-        "terminal"
-      ],
-      "tokenkey_status": "not_applicable",
-      "rationale": "Client-side claude-code concern (terminal); not a gateway/relay relevance signal.",
-      "updated_at": "2026-06-01T19:40:28Z"
-    },
-    {
-      "upstream": "anthropics/claude-code#43113",
-      "url": "https://github.com/anthropics/claude-code/issues/43113",
-      "title": "[FEATURE] Add a flag that tells Claude Code to emit long lines for prose/markdown content and let the terminal emulator handle word wrapping, rather than inserting hard newline characters at word boundaries",
-      "impact": "not_applicable",
-      "categories": [
-        "terminal",
-        "platform"
-      ],
-      "tokenkey_status": "not_applicable",
-      "rationale": "Client-side claude-code concern (terminal, platform); not a gateway/relay relevance signal.",
-      "updated_at": "2026-06-01T19:56:18Z"
-    },
-    {
       "upstream": "anthropics/claude-code#43127",
       "url": "https://github.com/anthropics/claude-code/issues/43127",
       "title": "bug: installer places binary in ~/.local/bin but shell snapshot drops it from PATH, causing spurious startup warning",
@@ -7584,6 +7598,20 @@
       "tokenkey_status": "not_applicable",
       "rationale": "Client-side claude-code concern (install); not a gateway/relay relevance signal.",
       "updated_at": "2026-06-02T15:48:01Z"
+    },
+    {
+      "upstream": "anthropics/claude-code#43216",
+      "url": "https://github.com/anthropics/claude-code/issues/43216",
+      "title": "Feature request: per-project persistent color/theme settings",
+      "impact": "not_applicable",
+      "categories": [
+        "terminal",
+        "slash_hook",
+        "platform"
+      ],
+      "tokenkey_status": "not_applicable",
+      "rationale": "Client-side claude-code concern (terminal, slash_hook, platform); not a gateway/relay relevance signal.",
+      "updated_at": "2026-06-04T22:33:55Z"
     },
     {
       "upstream": "anthropics/claude-code#43364",
@@ -7664,18 +7692,6 @@
       "updated_at": "2026-06-03T22:45:16Z"
     },
     {
-      "upstream": "anthropics/claude-code#44163",
-      "url": "https://github.com/anthropics/claude-code/issues/44163",
-      "title": "[BUG] Gift Pro subscription auto-canceled + broken credit redemption link (Page not found)",
-      "impact": "not_applicable",
-      "categories": [
-        "terminal"
-      ],
-      "tokenkey_status": "not_applicable",
-      "rationale": "Client-side claude-code concern (terminal); not a gateway/relay relevance signal.",
-      "updated_at": "2026-06-01T22:45:56Z"
-    },
-    {
       "upstream": "anthropics/claude-code#44380",
       "url": "https://github.com/anthropics/claude-code/issues/44380",
       "title": "Channel messages don't wake idle sessions (--channels plugin)",
@@ -7688,6 +7704,19 @@
       "tokenkey_status": "not_applicable",
       "rationale": "Client-side claude-code concern (terminal, mcp, plugin); not a gateway/relay relevance signal.",
       "updated_at": "2026-06-03T04:52:47Z"
+    },
+    {
+      "upstream": "anthropics/claude-code#44423",
+      "url": "https://github.com/anthropics/claude-code/issues/44423",
+      "title": "Feature: custom border/frame color in settings.json",
+      "impact": "not_applicable",
+      "categories": [
+        "terminal",
+        "slash_hook"
+      ],
+      "tokenkey_status": "not_applicable",
+      "rationale": "Client-side claude-code concern (terminal, slash_hook); not a gateway/relay relevance signal.",
+      "updated_at": "2026-06-04T22:33:55Z"
     },
     {
       "upstream": "anthropics/claude-code#44456",
@@ -7726,20 +7755,6 @@
       "tokenkey_status": "not_applicable",
       "rationale": "Client-side claude-code concern (plugin); not a gateway/relay relevance signal.",
       "updated_at": "2026-06-02T19:22:42Z"
-    },
-    {
-      "upstream": "anthropics/claude-code#44648",
-      "url": "https://github.com/anthropics/claude-code/issues/44648",
-      "title": "[FEATURE] Persistent governance context to address context dilution",
-      "impact": "not_applicable",
-      "categories": [
-        "mcp",
-        "slash_hook",
-        "platform"
-      ],
-      "tokenkey_status": "not_applicable",
-      "rationale": "Client-side claude-code concern (mcp, slash_hook, platform); not a gateway/relay relevance signal.",
-      "updated_at": "2026-06-01T22:45:29Z"
     },
     {
       "upstream": "anthropics/claude-code#44752",
@@ -7792,7 +7807,22 @@
       ],
       "tokenkey_status": "not_applicable",
       "rationale": "Client-side claude-code concern (platform); not a gateway/relay relevance signal.",
-      "updated_at": "2026-06-03T19:25:30Z"
+      "updated_at": "2026-06-04T21:07:12Z"
+    },
+    {
+      "upstream": "anthropics/claude-code#45534",
+      "url": "https://github.com/anthropics/claude-code/issues/45534",
+      "title": "[BUG] Claude Code VSCode extension is NOT streaming response since 2.1.37",
+      "impact": "not_applicable",
+      "categories": [
+        "ide",
+        "terminal",
+        "install",
+        "platform"
+      ],
+      "tokenkey_status": "not_applicable",
+      "rationale": "Client-side claude-code concern (ide, terminal, install, platform); not a gateway/relay relevance signal.",
+      "updated_at": "2026-06-04T16:24:26Z"
     },
     {
       "upstream": "anthropics/claude-code#45596",
@@ -7835,21 +7865,6 @@
       "updated_at": "2026-06-03T22:46:02Z"
     },
     {
-      "upstream": "anthropics/claude-code#45692",
-      "url": "https://github.com/anthropics/claude-code/issues/45692",
-      "title": "[BUG] Jetbrains Plugin cannot connect properly on WSL",
-      "impact": "not_applicable",
-      "categories": [
-        "ide",
-        "terminal",
-        "plugin",
-        "platform"
-      ],
-      "tokenkey_status": "not_applicable",
-      "rationale": "Client-side claude-code concern (ide, terminal, plugin, platform); not a gateway/relay relevance signal.",
-      "updated_at": "2026-06-01T18:08:01Z"
-    },
-    {
       "upstream": "anthropics/claude-code#45712",
       "url": "https://github.com/anthropics/claude-code/issues/45712",
       "title": "[BUG] Opus produces garbled multi-script output (Cyrillic/CJK/Tibetan mixed into English), triggers misleading usage policy violation",
@@ -7862,19 +7877,6 @@
       "tokenkey_status": "not_applicable",
       "rationale": "Client-side claude-code concern (terminal, plugin, platform); not a gateway/relay relevance signal.",
       "updated_at": "2026-06-04T11:06:47Z"
-    },
-    {
-      "upstream": "anthropics/claude-code#45717",
-      "url": "https://github.com/anthropics/claude-code/issues/45717",
-      "title": "[BUG] Bash tool timeout kills Claude Code process (SIGTERM propagation), not just the child command",
-      "impact": "not_applicable",
-      "categories": [
-        "terminal",
-        "mcp"
-      ],
-      "tokenkey_status": "not_applicable",
-      "rationale": "Client-side claude-code concern (terminal, mcp); not a gateway/relay relevance signal.",
-      "updated_at": "2026-06-01T22:45:04Z"
     },
     {
       "upstream": "anthropics/claude-code#45810",
@@ -7928,29 +7930,16 @@
       "updated_at": "2026-06-02T11:32:22Z"
     },
     {
-      "upstream": "anthropics/claude-code#46083",
-      "url": "https://github.com/anthropics/claude-code/issues/46083",
-      "title": "[BUG] [workflow] No email warning when \"stale\" label is applied",
+      "upstream": "anthropics/claude-code#46444",
+      "url": "https://github.com/anthropics/claude-code/issues/46444",
+      "title": "Critical: Claude Code worktree auto-cleanup permanently deleted 10 days of uncommitted project work without any warning",
       "impact": "not_applicable",
       "categories": [
-        "terminal"
+        "platform"
       ],
       "tokenkey_status": "not_applicable",
-      "rationale": "Client-side claude-code concern (terminal); not a gateway/relay relevance signal.",
-      "updated_at": "2026-06-01T15:36:04Z"
-    },
-    {
-      "upstream": "anthropics/claude-code#46425",
-      "url": "https://github.com/anthropics/claude-code/issues/46425",
-      "title": "[FEATURE] VS Code extension: collapse large pasted text like terminal CLI does",
-      "impact": "not_applicable",
-      "categories": [
-        "ide",
-        "terminal"
-      ],
-      "tokenkey_status": "not_applicable",
-      "rationale": "Client-side claude-code concern (ide, terminal); not a gateway/relay relevance signal.",
-      "updated_at": "2026-06-01T22:46:07Z"
+      "rationale": "Client-side claude-code concern (platform); not a gateway/relay relevance signal.",
+      "updated_at": "2026-06-04T22:33:44Z"
     },
     {
       "upstream": "anthropics/claude-code#46616",
@@ -7963,6 +7952,21 @@
       "tokenkey_status": "not_applicable",
       "rationale": "Client-side claude-code concern (terminal); not a gateway/relay relevance signal.",
       "updated_at": "2026-06-02T11:32:59Z"
+    },
+    {
+      "upstream": "anthropics/claude-code#46664",
+      "url": "https://github.com/anthropics/claude-code/issues/46664",
+      "title": "[BUG] Plugin-registered WorktreeCreate hooks in hooks/hooks.json are never dispatched — settings.json hooks for the same event fire normally (2.1.101)",
+      "impact": "not_applicable",
+      "categories": [
+        "terminal",
+        "plugin",
+        "slash_hook",
+        "install"
+      ],
+      "tokenkey_status": "not_applicable",
+      "rationale": "Client-side claude-code concern (terminal, plugin, slash_hook, install); not a gateway/relay relevance signal.",
+      "updated_at": "2026-06-04T22:33:15Z"
     },
     {
       "upstream": "anthropics/claude-code#46724",
@@ -7987,7 +7991,7 @@
       ],
       "tokenkey_status": "not_applicable",
       "rationale": "Client-side claude-code concern (terminal, slash_hook); not a gateway/relay relevance signal.",
-      "updated_at": "2026-06-03T07:03:40Z"
+      "updated_at": "2026-06-04T17:01:58Z"
     },
     {
       "upstream": "anthropics/claude-code#47083",
@@ -8005,18 +8009,6 @@
       "updated_at": "2026-06-04T11:07:44Z"
     },
     {
-      "upstream": "anthropics/claude-code#47154",
-      "url": "https://github.com/anthropics/claude-code/issues/47154",
-      "title": "[Bug] Monitor tool missing from Claude Code v2.1.104 despite documentation stating it exists",
-      "impact": "not_applicable",
-      "categories": [
-        "terminal"
-      ],
-      "tokenkey_status": "not_applicable",
-      "rationale": "Client-side claude-code concern (terminal); not a gateway/relay relevance signal.",
-      "updated_at": "2026-06-01T19:19:29Z"
-    },
-    {
       "upstream": "anthropics/claude-code#47327",
       "url": "https://github.com/anthropics/claude-code/issues/47327",
       "title": "[BUG] Cowork tab disabled — yukonSilver \"unsupported\" on Windows 11 Pro x64 (ongoing since March 2026)",
@@ -8029,31 +8021,6 @@
       "tokenkey_status": "not_applicable",
       "rationale": "Client-side claude-code concern (terminal, install, platform); not a gateway/relay relevance signal.",
       "updated_at": "2026-06-04T11:07:52Z"
-    },
-    {
-      "upstream": "anthropics/claude-code#47336",
-      "url": "https://github.com/anthropics/claude-code/issues/47336",
-      "title": "[Bug] Agent hangs indefinitely without progress",
-      "impact": "not_applicable",
-      "categories": [
-        "ide",
-        "terminal"
-      ],
-      "tokenkey_status": "not_applicable",
-      "rationale": "Client-side claude-code concern (ide, terminal); not a gateway/relay relevance signal.",
-      "updated_at": "2026-06-01T22:45:36Z"
-    },
-    {
-      "upstream": "anthropics/claude-code#47378",
-      "url": "https://github.com/anthropics/claude-code/issues/47378",
-      "title": "MCP stdio transport: client kills stdin 2-5s after receiving successful tool response (chrome-devtools-mcp)",
-      "impact": "not_applicable",
-      "categories": [
-        "mcp"
-      ],
-      "tokenkey_status": "not_applicable",
-      "rationale": "Client-side claude-code concern (mcp); not a gateway/relay relevance signal.",
-      "updated_at": "2026-06-01T22:45:26Z"
     },
     {
       "upstream": "anthropics/claude-code#47400",
@@ -8123,21 +8090,6 @@
       "updated_at": "2026-06-02T17:05:26Z"
     },
     {
-      "upstream": "anthropics/claude-code#47853",
-      "url": "https://github.com/anthropics/claude-code/issues/47853",
-      "title": "[BUG] PreToolUse updatedInput silently ignored for Edit tool — works for Read and Bash",
-      "impact": "not_applicable",
-      "categories": [
-        "ide",
-        "plugin",
-        "slash_hook",
-        "platform"
-      ],
-      "tokenkey_status": "not_applicable",
-      "rationale": "Client-side claude-code concern (ide, plugin, slash_hook, platform); not a gateway/relay relevance signal.",
-      "updated_at": "2026-06-01T22:46:06Z"
-    },
-    {
       "upstream": "anthropics/claude-code#47899",
       "url": "https://github.com/anthropics/claude-code/issues/47899",
       "title": "Scheduled tasks dispatch but never execute — sessions stuck \"Running\" with zero turns, causing permanent skip-cascade",
@@ -8176,6 +8128,19 @@
       "updated_at": "2026-06-02T05:55:42Z"
     },
     {
+      "upstream": "anthropics/claude-code#48246",
+      "url": "https://github.com/anthropics/claude-code/issues/48246",
+      "title": "Feature request: Show agent/subagent task progress in terminal UI (parity with third-party tools)",
+      "impact": "not_applicable",
+      "categories": [
+        "terminal",
+        "plugin"
+      ],
+      "tokenkey_status": "not_applicable",
+      "rationale": "Client-side claude-code concern (terminal, plugin); not a gateway/relay relevance signal.",
+      "updated_at": "2026-06-04T22:33:57Z"
+    },
+    {
       "upstream": "anthropics/claude-code#48362",
       "url": "https://github.com/anthropics/claude-code/issues/48362",
       "title": "[BUG] Claude Desktop (Windows Store / MSIX): Code sessions silently fail to persist due to EXDEV error inside MSIX sandbox, even when everything is on C: — resolved by switching to Win32 installer",
@@ -8204,18 +8169,43 @@
       "updated_at": "2026-06-02T16:41:57Z"
     },
     {
-      "upstream": "anthropics/claude-code#48680",
-      "url": "https://github.com/anthropics/claude-code/issues/48680",
-      "title": "[BUG] claude.ai marketplace MCP server instructions inject into context on every session regardless of Tool Search",
+      "upstream": "anthropics/claude-code#48444",
+      "url": "https://github.com/anthropics/claude-code/issues/48444",
+      "title": "[BUG] Branch name not displayed in session toolbar on Claude Desktop v1.2581.0 (macOS)",
+      "impact": "not_applicable",
+      "categories": [
+        "terminal"
+      ],
+      "tokenkey_status": "not_applicable",
+      "rationale": "Client-side claude-code concern (terminal); not a gateway/relay relevance signal.",
+      "updated_at": "2026-06-04T22:23:26Z"
+    },
+    {
+      "upstream": "anthropics/claude-code#48559",
+      "url": "https://github.com/anthropics/claude-code/issues/48559",
+      "title": "[BUG] CLaude code Shows (RTL) and mixed-language content in corrupted way",
       "impact": "not_applicable",
       "categories": [
         "terminal",
-        "mcp",
-        "plugin"
+        "platform"
       ],
       "tokenkey_status": "not_applicable",
-      "rationale": "Client-side claude-code concern (terminal, mcp, plugin); not a gateway/relay relevance signal.",
-      "updated_at": "2026-06-01T15:36:27Z"
+      "rationale": "Client-side claude-code concern (terminal, platform); not a gateway/relay relevance signal.",
+      "updated_at": "2026-06-04T22:33:46Z"
+    },
+    {
+      "upstream": "anthropics/claude-code#48708",
+      "url": "https://github.com/anthropics/claude-code/issues/48708",
+      "title": "Show provenance/origin of slash commands (native, plugin, skill, author)",
+      "impact": "not_applicable",
+      "categories": [
+        "ide",
+        "plugin",
+        "slash_hook"
+      ],
+      "tokenkey_status": "not_applicable",
+      "rationale": "Client-side claude-code concern (ide, plugin, slash_hook); not a gateway/relay relevance signal.",
+      "updated_at": "2026-06-04T22:33:42Z"
     },
     {
       "upstream": "anthropics/claude-code#48765",
@@ -8266,6 +8256,21 @@
       "updated_at": "2026-06-03T11:15:47Z"
     },
     {
+      "upstream": "anthropics/claude-code#49063",
+      "url": "https://github.com/anthropics/claude-code/issues/49063",
+      "title": "UserPromptSubmit hook additionalContext not injected into model context in VSCode extension",
+      "impact": "not_applicable",
+      "categories": [
+        "ide",
+        "mcp",
+        "slash_hook",
+        "platform"
+      ],
+      "tokenkey_status": "not_applicable",
+      "rationale": "Client-side claude-code concern (ide, mcp, slash_hook, platform); not a gateway/relay relevance signal.",
+      "updated_at": "2026-06-04T22:32:59Z"
+    },
+    {
       "upstream": "anthropics/claude-code#49184",
       "url": "https://github.com/anthropics/claude-code/issues/49184",
       "title": "[BUG] Agent spawning steals tmux focus from the user's pane",
@@ -8277,19 +8282,6 @@
       "tokenkey_status": "not_applicable",
       "rationale": "Client-side claude-code concern (terminal, slash_hook); not a gateway/relay relevance signal.",
       "updated_at": "2026-06-02T22:44:58Z"
-    },
-    {
-      "upstream": "anthropics/claude-code#49272",
-      "url": "https://github.com/anthropics/claude-code/issues/49272",
-      "title": "[BUG] Cowork (desktop app): mkdir/os.makedirs does not persist to Windows filesystem — virtiofs FUSE_MKDIR not forwarded to Windows host",
-      "impact": "not_applicable",
-      "categories": [
-        "terminal",
-        "platform"
-      ],
-      "tokenkey_status": "not_applicable",
-      "rationale": "Client-side claude-code concern (terminal, platform); not a gateway/relay relevance signal.",
-      "updated_at": "2026-06-01T22:45:53Z"
     },
     {
       "upstream": "anthropics/claude-code#49282",
@@ -8345,18 +8337,6 @@
       "updated_at": "2026-06-03T22:44:48Z"
     },
     {
-      "upstream": "anthropics/claude-code#49536",
-      "url": "https://github.com/anthropics/claude-code/issues/49536",
-      "title": "[BUG] Limits got reset early - Huge loss of usage",
-      "impact": "not_applicable",
-      "categories": [
-        "terminal"
-      ],
-      "tokenkey_status": "not_applicable",
-      "rationale": "Client-side claude-code concern (terminal); not a gateway/relay relevance signal.",
-      "updated_at": "2026-06-01T22:45:38Z"
-    },
-    {
       "upstream": "anthropics/claude-code#49565",
       "url": "https://github.com/anthropics/claude-code/issues/49565",
       "title": "--no-session-persistence flag is ignored in 2.1.112 (regression from 2.1.104)",
@@ -8369,16 +8349,17 @@
       "updated_at": "2026-06-02T11:31:54Z"
     },
     {
-      "upstream": "anthropics/claude-code#49616",
-      "url": "https://github.com/anthropics/claude-code/issues/49616",
-      "title": "[BUG] Weekly usage limit reset 4+ hours before scheduled reset time",
+      "upstream": "anthropics/claude-code#49644",
+      "url": "https://github.com/anthropics/claude-code/issues/49644",
+      "title": "Feature request: Enable Terminal panel in remote/SSH sessions (desktop app)",
       "impact": "not_applicable",
       "categories": [
-        "terminal"
+        "terminal",
+        "platform"
       ],
       "tokenkey_status": "not_applicable",
-      "rationale": "Client-side claude-code concern (terminal); not a gateway/relay relevance signal.",
-      "updated_at": "2026-06-01T22:45:36Z"
+      "rationale": "Client-side claude-code concern (terminal, platform); not a gateway/relay relevance signal.",
+      "updated_at": "2026-06-04T22:33:48Z"
     },
     {
       "upstream": "anthropics/claude-code#49837",
@@ -8521,6 +8502,18 @@
       "updated_at": "2026-06-03T11:39:45Z"
     },
     {
+      "upstream": "anthropics/claude-code#50143",
+      "url": "https://github.com/anthropics/claude-code/issues/50143",
+      "title": "[DOCS] Tool search docs missing exact MCP tool-name matching guidance",
+      "impact": "not_applicable",
+      "categories": [
+        "mcp"
+      ],
+      "tokenkey_status": "not_applicable",
+      "rationale": "Client-side claude-code concern (mcp); not a gateway/relay relevance signal.",
+      "updated_at": "2026-06-04T22:33:41Z"
+    },
+    {
       "upstream": "anthropics/claude-code#50145",
       "url": "https://github.com/anthropics/claude-code/issues/50145",
       "title": "[DOCS] Plugin installation troubleshooting missing `range-conflict` dependency guidance",
@@ -8575,18 +8568,21 @@
       "updated_at": "2026-06-02T22:44:02Z"
     },
     {
-      "upstream": "anthropics/claude-code#50214",
-      "url": "https://github.com/anthropics/claude-code/issues/50214",
-      "title": "Add Russian language support for voice input in desktop app",
+      "upstream": "anthropics/claude-code#50267",
+      "url": "https://github.com/anthropics/claude-code/issues/50267",
+      "title": "[BUG] 2.1.114 regression: background subagents cannot write to paths listed in permissions.allow — works in 2.1.112",
       "impact": "not_applicable",
       "categories": [
+        "ide",
         "terminal",
+        "plugin",
         "slash_hook",
+        "install",
         "platform"
       ],
       "tokenkey_status": "not_applicable",
-      "rationale": "Client-side claude-code concern (terminal, slash_hook, platform); not a gateway/relay relevance signal.",
-      "updated_at": "2026-06-01T15:01:35Z"
+      "rationale": "Client-side claude-code concern (ide, terminal, plugin, slash_hook, install, platform); not a gateway/relay relevance signal.",
+      "updated_at": "2026-06-04T22:33:20Z"
     },
     {
       "upstream": "anthropics/claude-code#50270",
@@ -8639,6 +8635,18 @@
       "tokenkey_status": "not_applicable",
       "rationale": "Client-side claude-code concern (ide, terminal, platform); not a gateway/relay relevance signal.",
       "updated_at": "2026-06-02T22:44:43Z"
+    },
+    {
+      "upstream": "anthropics/claude-code#50443",
+      "url": "https://github.com/anthropics/claude-code/issues/50443",
+      "title": "Request: publish linux-ppc64le SEA binary (breaks POWER8+ / ppc64le users)",
+      "impact": "not_applicable",
+      "categories": [
+        "install"
+      ],
+      "tokenkey_status": "not_applicable",
+      "rationale": "Client-side claude-code concern (install); not a gateway/relay relevance signal.",
+      "updated_at": "2026-06-04T22:33:43Z"
     },
     {
       "upstream": "anthropics/claude-code#50451",
@@ -8694,22 +8702,6 @@
       "updated_at": "2026-06-04T11:07:13Z"
     },
     {
-      "upstream": "anthropics/claude-code#50873",
-      "url": "https://github.com/anthropics/claude-code/issues/50873",
-      "title": "[Bug] virtiofs mount serves truncated file contents to sandboxed environment while host files are clean",
-      "impact": "not_applicable",
-      "categories": [
-        "ide",
-        "terminal",
-        "mcp",
-        "install",
-        "platform"
-      ],
-      "tokenkey_status": "not_applicable",
-      "rationale": "Client-side claude-code concern (ide, terminal, mcp, install, platform); not a gateway/relay relevance signal.",
-      "updated_at": "2026-06-01T21:36:25Z"
-    },
-    {
       "upstream": "anthropics/claude-code#50892",
       "url": "https://github.com/anthropics/claude-code/issues/50892",
       "title": "[BUG] False positive usage policy violation on computational biology research content",
@@ -8753,17 +8745,16 @@
       "updated_at": "2026-06-03T10:07:33Z"
     },
     {
-      "upstream": "anthropics/claude-code#51008",
-      "url": "https://github.com/anthropics/claude-code/issues/51008",
-      "title": "Skills appear duplicated/triplicated in the slash command list",
+      "upstream": "anthropics/claude-code#50979",
+      "url": "https://github.com/anthropics/claude-code/issues/50979",
+      "title": "Allow disabling the built-in \"malware check\" system-reminder injected on Read tool results",
       "impact": "not_applicable",
       "categories": [
-        "slash_hook",
-        "install"
+        "slash_hook"
       ],
       "tokenkey_status": "not_applicable",
-      "rationale": "Client-side claude-code concern (slash_hook, install); not a gateway/relay relevance signal.",
-      "updated_at": "2026-06-01T22:45:06Z"
+      "rationale": "Client-side claude-code concern (slash_hook); not a gateway/relay relevance signal.",
+      "updated_at": "2026-06-04T22:33:07Z"
     },
     {
       "upstream": "anthropics/claude-code#51040",
@@ -8776,6 +8767,21 @@
       "tokenkey_status": "not_applicable",
       "rationale": "Client-side claude-code concern (mcp); not a gateway/relay relevance signal.",
       "updated_at": "2026-06-03T21:27:13Z"
+    },
+    {
+      "upstream": "anthropics/claude-code#51143",
+      "url": "https://github.com/anthropics/claude-code/issues/51143",
+      "title": "[BUG] Claude Desktop persistent blank/white screen on Windows — Cowork unusable, multiple reinstalls have no effect",
+      "impact": "not_applicable",
+      "categories": [
+        "terminal",
+        "slash_hook",
+        "install",
+        "platform"
+      ],
+      "tokenkey_status": "not_applicable",
+      "rationale": "Client-side claude-code concern (terminal, slash_hook, install, platform); not a gateway/relay relevance signal.",
+      "updated_at": "2026-06-04T16:49:37Z"
     },
     {
       "upstream": "anthropics/claude-code#51366",
@@ -8814,7 +8820,7 @@
       ],
       "tokenkey_status": "not_applicable",
       "rationale": "Client-side claude-code concern (slash_hook); not a gateway/relay relevance signal.",
-      "updated_at": "2026-06-03T11:40:03Z"
+      "updated_at": "2026-06-04T23:47:10Z"
     },
     {
       "upstream": "anthropics/claude-code#51374",
@@ -8828,7 +8834,7 @@
       ],
       "tokenkey_status": "not_applicable",
       "rationale": "Client-side claude-code concern (ide, terminal, slash_hook); not a gateway/relay relevance signal.",
-      "updated_at": "2026-06-03T11:40:05Z"
+      "updated_at": "2026-06-04T23:47:46Z"
     },
     {
       "upstream": "anthropics/claude-code#51376",
@@ -8840,7 +8846,20 @@
       ],
       "tokenkey_status": "not_applicable",
       "rationale": "Client-side claude-code concern (terminal); not a gateway/relay relevance signal.",
-      "updated_at": "2026-06-03T11:40:08Z"
+      "updated_at": "2026-06-04T23:48:24Z"
+    },
+    {
+      "upstream": "anthropics/claude-code#51385",
+      "url": "https://github.com/anthropics/claude-code/issues/51385",
+      "title": "[BUG] Microsoft 365 Connector fails after successful Entra authentication and valid MCP Server permissions",
+      "impact": "not_applicable",
+      "categories": [
+        "terminal",
+        "mcp"
+      ],
+      "tokenkey_status": "not_applicable",
+      "rationale": "Client-side claude-code concern (terminal, mcp); not a gateway/relay relevance signal.",
+      "updated_at": "2026-06-04T22:33:59Z"
     },
     {
       "upstream": "anthropics/claude-code#51677",
@@ -8880,7 +8899,7 @@
       ],
       "tokenkey_status": "not_applicable",
       "rationale": "Client-side claude-code concern (plugin, install); not a gateway/relay relevance signal.",
-      "updated_at": "2026-06-03T11:39:52Z"
+      "updated_at": "2026-06-04T23:47:52Z"
     },
     {
       "upstream": "anthropics/claude-code#51777",
@@ -8894,7 +8913,7 @@
       ],
       "tokenkey_status": "not_applicable",
       "rationale": "Client-side claude-code concern (mcp, plugin, slash_hook); not a gateway/relay relevance signal.",
-      "updated_at": "2026-06-03T11:39:52Z"
+      "updated_at": "2026-06-04T23:48:01Z"
     },
     {
       "upstream": "anthropics/claude-code#51779",
@@ -8906,7 +8925,7 @@
       ],
       "tokenkey_status": "not_applicable",
       "rationale": "Client-side claude-code concern (plugin); not a gateway/relay relevance signal.",
-      "updated_at": "2026-06-03T11:39:47Z"
+      "updated_at": "2026-06-04T23:47:38Z"
     },
     {
       "upstream": "anthropics/claude-code#51781",
@@ -8933,7 +8952,7 @@
       ],
       "tokenkey_status": "not_applicable",
       "rationale": "Client-side claude-code concern (terminal, mcp, slash_hook); not a gateway/relay relevance signal.",
-      "updated_at": "2026-06-03T11:40:08Z"
+      "updated_at": "2026-06-04T23:42:02Z"
     },
     {
       "upstream": "anthropics/claude-code#51815",
@@ -9015,6 +9034,19 @@
       "updated_at": "2026-06-02T22:44:20Z"
     },
     {
+      "upstream": "anthropics/claude-code#52160",
+      "url": "https://github.com/anthropics/claude-code/issues/52160",
+      "title": "[FEATURE] Strong visual cue about the window's state (running, prompt, idle), e.g. background color",
+      "impact": "not_applicable",
+      "categories": [
+        "terminal",
+        "platform"
+      ],
+      "tokenkey_status": "not_applicable",
+      "rationale": "Client-side claude-code concern (terminal, platform); not a gateway/relay relevance signal.",
+      "updated_at": "2026-06-04T22:33:54Z"
+    },
+    {
       "upstream": "anthropics/claude-code#52166",
       "url": "https://github.com/anthropics/claude-code/issues/52166",
       "title": "CLI pauses execution when terminal/composer loses focus",
@@ -9049,7 +9081,7 @@
       ],
       "tokenkey_status": "not_applicable",
       "rationale": "Client-side claude-code concern (plugin, slash_hook); not a gateway/relay relevance signal.",
-      "updated_at": "2026-06-03T11:40:11Z"
+      "updated_at": "2026-06-04T23:41:37Z"
     },
     {
       "upstream": "anthropics/claude-code#52197",
@@ -9061,7 +9093,7 @@
       ],
       "tokenkey_status": "not_applicable",
       "rationale": "Client-side claude-code concern (terminal); not a gateway/relay relevance signal.",
-      "updated_at": "2026-06-03T11:40:15Z"
+      "updated_at": "2026-06-04T23:41:08Z"
     },
     {
       "upstream": "anthropics/claude-code#52206",
@@ -9074,7 +9106,7 @@
       ],
       "tokenkey_status": "not_applicable",
       "rationale": "Client-side claude-code concern (plugin, install); not a gateway/relay relevance signal.",
-      "updated_at": "2026-06-03T11:40:17Z"
+      "updated_at": "2026-06-04T23:41:14Z"
     },
     {
       "upstream": "anthropics/claude-code#52207",
@@ -9086,7 +9118,7 @@
       ],
       "tokenkey_status": "not_applicable",
       "rationale": "Client-side claude-code concern (plugin); not a gateway/relay relevance signal.",
-      "updated_at": "2026-06-03T11:40:14Z"
+      "updated_at": "2026-06-04T23:36:29Z"
     },
     {
       "upstream": "anthropics/claude-code#52252",
@@ -9102,6 +9134,32 @@
       "updated_at": "2026-06-04T07:08:00Z"
     },
     {
+      "upstream": "anthropics/claude-code#52328",
+      "url": "https://github.com/anthropics/claude-code/issues/52328",
+      "title": "[BUG] `Monitor` `until`-loop self-matches when model uses `pgrep -f \"<cmdline>\"` as its check",
+      "impact": "not_applicable",
+      "categories": [
+        "terminal",
+        "mcp"
+      ],
+      "tokenkey_status": "not_applicable",
+      "rationale": "Client-side claude-code concern (terminal, mcp); not a gateway/relay relevance signal.",
+      "updated_at": "2026-06-04T22:33:11Z"
+    },
+    {
+      "upstream": "anthropics/claude-code#52420",
+      "url": "https://github.com/anthropics/claude-code/issues/52420",
+      "title": "Add a configurable verb for the post-turn completion line",
+      "impact": "not_applicable",
+      "categories": [
+        "terminal",
+        "slash_hook"
+      ],
+      "tokenkey_status": "not_applicable",
+      "rationale": "Client-side claude-code concern (terminal, slash_hook); not a gateway/relay relevance signal.",
+      "updated_at": "2026-06-04T22:33:40Z"
+    },
+    {
       "upstream": "anthropics/claude-code#52472",
       "url": "https://github.com/anthropics/claude-code/issues/52472",
       "title": "[Bug] Weekly usage limit reset occurring before scheduled reset time & new week ends in 5 days, not 7 days",
@@ -9115,20 +9173,6 @@
       "tokenkey_status": "not_applicable",
       "rationale": "Client-side claude-code concern (ide, terminal, mcp, plugin); not a gateway/relay relevance signal.",
       "updated_at": "2026-06-04T00:40:39Z"
-    },
-    {
-      "upstream": "anthropics/claude-code#52509",
-      "url": "https://github.com/anthropics/claude-code/issues/52509",
-      "title": "[BUG] Messages typed during \"Thinking/Deliberating/Manifesting\" state aren't delivered until user hits Escape",
-      "impact": "not_applicable",
-      "categories": [
-        "ide",
-        "terminal",
-        "platform"
-      ],
-      "tokenkey_status": "not_applicable",
-      "rationale": "Client-side claude-code concern (ide, terminal, platform); not a gateway/relay relevance signal.",
-      "updated_at": "2026-06-01T22:46:14Z"
     },
     {
       "upstream": "anthropics/claude-code#52518",
@@ -9153,7 +9197,7 @@
       ],
       "tokenkey_status": "not_applicable",
       "rationale": "Client-side claude-code concern (terminal, slash_hook); not a gateway/relay relevance signal.",
-      "updated_at": "2026-06-03T11:40:24Z"
+      "updated_at": "2026-06-04T23:36:35Z"
     },
     {
       "upstream": "anthropics/claude-code#52605",
@@ -9166,7 +9210,7 @@
       ],
       "tokenkey_status": "not_applicable",
       "rationale": "Client-side claude-code concern (plugin, slash_hook); not a gateway/relay relevance signal.",
-      "updated_at": "2026-06-03T11:40:21Z"
+      "updated_at": "2026-06-04T23:37:11Z"
     },
     {
       "upstream": "anthropics/claude-code#52606",
@@ -9179,7 +9223,7 @@
       ],
       "tokenkey_status": "not_applicable",
       "rationale": "Client-side claude-code concern (terminal, platform); not a gateway/relay relevance signal.",
-      "updated_at": "2026-06-03T11:40:23Z"
+      "updated_at": "2026-06-04T23:37:10Z"
     },
     {
       "upstream": "anthropics/claude-code#52607",
@@ -9191,7 +9235,7 @@
       ],
       "tokenkey_status": "not_applicable",
       "rationale": "Client-side claude-code concern (slash_hook); not a gateway/relay relevance signal.",
-      "updated_at": "2026-06-03T11:40:23Z"
+      "updated_at": "2026-06-04T23:36:23Z"
     },
     {
       "upstream": "anthropics/claude-code#52609",
@@ -9204,7 +9248,7 @@
       ],
       "tokenkey_status": "not_applicable",
       "rationale": "Client-side claude-code concern (terminal, slash_hook); not a gateway/relay relevance signal.",
-      "updated_at": "2026-06-03T11:40:19Z"
+      "updated_at": "2026-06-04T23:36:49Z"
     },
     {
       "upstream": "anthropics/claude-code#52610",
@@ -9216,7 +9260,7 @@
       ],
       "tokenkey_status": "not_applicable",
       "rationale": "Client-side claude-code concern (terminal); not a gateway/relay relevance signal.",
-      "updated_at": "2026-06-03T11:40:22Z"
+      "updated_at": "2026-06-04T23:36:58Z"
     },
     {
       "upstream": "anthropics/claude-code#52611",
@@ -9228,7 +9272,7 @@
       ],
       "tokenkey_status": "not_applicable",
       "rationale": "Client-side claude-code concern (plugin); not a gateway/relay relevance signal.",
-      "updated_at": "2026-06-03T11:40:25Z"
+      "updated_at": "2026-06-04T23:35:24Z"
     },
     {
       "upstream": "anthropics/claude-code#52618",
@@ -9240,7 +9284,7 @@
       ],
       "tokenkey_status": "not_applicable",
       "rationale": "Client-side claude-code concern (slash_hook); not a gateway/relay relevance signal.",
-      "updated_at": "2026-06-03T11:40:18Z"
+      "updated_at": "2026-06-04T23:27:08Z"
     },
     {
       "upstream": "anthropics/claude-code#52619",
@@ -9252,7 +9296,7 @@
       ],
       "tokenkey_status": "not_applicable",
       "rationale": "Client-side claude-code concern (mcp); not a gateway/relay relevance signal.",
-      "updated_at": "2026-06-03T11:40:34Z"
+      "updated_at": "2026-06-04T23:27:36Z"
     },
     {
       "upstream": "anthropics/claude-code#52621",
@@ -9265,7 +9309,7 @@
       ],
       "tokenkey_status": "not_applicable",
       "rationale": "Client-side claude-code concern (plugin, slash_hook); not a gateway/relay relevance signal.",
-      "updated_at": "2026-06-03T11:40:28Z"
+      "updated_at": "2026-06-04T23:26:27Z"
     },
     {
       "upstream": "anthropics/claude-code#52623",
@@ -9279,7 +9323,7 @@
       ],
       "tokenkey_status": "not_applicable",
       "rationale": "Client-side claude-code concern (mcp, plugin, slash_hook); not a gateway/relay relevance signal.",
-      "updated_at": "2026-06-03T11:40:30Z"
+      "updated_at": "2026-06-04T23:36:27Z"
     },
     {
       "upstream": "anthropics/claude-code#52624",
@@ -9291,19 +9335,7 @@
       ],
       "tokenkey_status": "not_applicable",
       "rationale": "Client-side claude-code concern (slash_hook); not a gateway/relay relevance signal.",
-      "updated_at": "2026-06-03T11:40:27Z"
-    },
-    {
-      "upstream": "anthropics/claude-code#52625",
-      "url": "https://github.com/anthropics/claude-code/issues/52625",
-      "title": "[BUG] Claude code disabled by org administration on personal account",
-      "impact": "not_applicable",
-      "categories": [
-        "terminal"
-      ],
-      "tokenkey_status": "not_applicable",
-      "rationale": "Client-side claude-code concern (terminal); not a gateway/relay relevance signal.",
-      "updated_at": "2026-06-01T22:45:45Z"
+      "updated_at": "2026-06-04T23:24:46Z"
     },
     {
       "upstream": "anthropics/claude-code#52631",
@@ -9317,7 +9349,7 @@
       ],
       "tokenkey_status": "not_applicable",
       "rationale": "Client-side claude-code concern (ide, terminal, slash_hook); not a gateway/relay relevance signal.",
-      "updated_at": "2026-06-03T11:40:28Z"
+      "updated_at": "2026-06-04T23:13:55Z"
     },
     {
       "upstream": "anthropics/claude-code#52793",
@@ -9330,19 +9362,6 @@
       "tokenkey_status": "not_applicable",
       "rationale": "Client-side claude-code concern (slash_hook); not a gateway/relay relevance signal.",
       "updated_at": "2026-06-02T11:31:59Z"
-    },
-    {
-      "upstream": "anthropics/claude-code#52924",
-      "url": "https://github.com/anthropics/claude-code/issues/52924",
-      "title": "TUI duplicates rendered text in scrollback on long sessions (Windows + Linux)",
-      "impact": "not_applicable",
-      "categories": [
-        "terminal",
-        "platform"
-      ],
-      "tokenkey_status": "not_applicable",
-      "rationale": "Client-side claude-code concern (terminal, platform); not a gateway/relay relevance signal.",
-      "updated_at": "2026-06-01T14:46:16Z"
     },
     {
       "upstream": "anthropics/claude-code#52926",
@@ -9379,7 +9398,7 @@
       ],
       "tokenkey_status": "not_applicable",
       "rationale": "Client-side claude-code concern (mcp, plugin); not a gateway/relay relevance signal.",
-      "updated_at": "2026-06-03T11:40:35Z"
+      "updated_at": "2026-06-04T23:11:47Z"
     },
     {
       "upstream": "anthropics/claude-code#53073",
@@ -9393,7 +9412,7 @@
       ],
       "tokenkey_status": "not_applicable",
       "rationale": "Client-side claude-code concern (terminal, mcp, slash_hook); not a gateway/relay relevance signal.",
-      "updated_at": "2026-06-03T11:40:29Z"
+      "updated_at": "2026-06-04T23:14:26Z"
     },
     {
       "upstream": "anthropics/claude-code#53076",
@@ -9406,7 +9425,7 @@
       ],
       "tokenkey_status": "not_applicable",
       "rationale": "Client-side claude-code concern (plugin, install); not a gateway/relay relevance signal.",
-      "updated_at": "2026-06-03T11:40:37Z"
+      "updated_at": "2026-06-04T23:11:19Z"
     },
     {
       "upstream": "anthropics/claude-code#53078",
@@ -9421,7 +9440,7 @@
       ],
       "tokenkey_status": "not_applicable",
       "rationale": "Client-side claude-code concern (ide, terminal, mcp, plugin); not a gateway/relay relevance signal.",
-      "updated_at": "2026-06-03T11:40:33Z"
+      "updated_at": "2026-06-04T23:11:13Z"
     },
     {
       "upstream": "anthropics/claude-code#53134",
@@ -9440,20 +9459,6 @@
       "updated_at": "2026-06-03T04:08:55Z"
     },
     {
-      "upstream": "anthropics/claude-code#53246",
-      "url": "https://github.com/anthropics/claude-code/issues/53246",
-      "title": "[BUG] In VSCode extension, is model switching via /model isolated per chat session? Seems like it might not be.",
-      "impact": "not_applicable",
-      "categories": [
-        "ide",
-        "terminal",
-        "platform"
-      ],
-      "tokenkey_status": "not_applicable",
-      "rationale": "Client-side claude-code concern (ide, terminal, platform); not a gateway/relay relevance signal.",
-      "updated_at": "2026-06-01T22:46:10Z"
-    },
-    {
       "upstream": "anthropics/claude-code#53260",
       "url": "https://github.com/anthropics/claude-code/issues/53260",
       "title": "Harness writes synthetic \"No response requested.\" turns when API returns empty content on auto-resume",
@@ -9468,6 +9473,34 @@
       "updated_at": "2026-06-02T11:32:13Z"
     },
     {
+      "upstream": "anthropics/claude-code#53281",
+      "url": "https://github.com/anthropics/claude-code/issues/53281",
+      "title": "[BUG] Code tab: local sessions crash immediately (exit code 1) — ccd_session/ccd_directory IPC failure",
+      "impact": "not_applicable",
+      "categories": [
+        "terminal",
+        "mcp",
+        "plugin"
+      ],
+      "tokenkey_status": "not_applicable",
+      "rationale": "Client-side claude-code concern (terminal, mcp, plugin); not a gateway/relay relevance signal.",
+      "updated_at": "2026-06-04T22:33:39Z"
+    },
+    {
+      "upstream": "anthropics/claude-code#53316",
+      "url": "https://github.com/anthropics/claude-code/issues/53316",
+      "title": "[BUG] /clear command doesnt work and it opens a new chat with the name of \"/clear\"",
+      "impact": "not_applicable",
+      "categories": [
+        "ide",
+        "terminal",
+        "platform"
+      ],
+      "tokenkey_status": "not_applicable",
+      "rationale": "Client-side claude-code concern (ide, terminal, platform); not a gateway/relay relevance signal.",
+      "updated_at": "2026-06-04T22:33:53Z"
+    },
+    {
       "upstream": "anthropics/claude-code#53346",
       "url": "https://github.com/anthropics/claude-code/issues/53346",
       "title": "⎿ API Error: Unable to connect to API...",
@@ -9478,6 +9511,20 @@
       "tokenkey_status": "not_applicable",
       "rationale": "Client-side claude-code concern (terminal); not a gateway/relay relevance signal.",
       "updated_at": "2026-06-02T11:45:25Z"
+    },
+    {
+      "upstream": "anthropics/claude-code#53427",
+      "url": "https://github.com/anthropics/claude-code/issues/53427",
+      "title": "Make the desktop \"Open in\" submenu configurable (currently hardcoded to VS Code / Cursor / Zed)",
+      "impact": "not_applicable",
+      "categories": [
+        "ide",
+        "terminal",
+        "slash_hook"
+      ],
+      "tokenkey_status": "not_applicable",
+      "rationale": "Client-side claude-code concern (ide, terminal, slash_hook); not a gateway/relay relevance signal.",
+      "updated_at": "2026-06-04T22:33:50Z"
     },
     {
       "upstream": "anthropics/claude-code#53432",
@@ -9554,31 +9601,6 @@
       "updated_at": "2026-06-02T11:31:57Z"
     },
     {
-      "upstream": "anthropics/claude-code#54117",
-      "url": "https://github.com/anthropics/claude-code/issues/54117",
-      "title": "[BUG] Claude Code (Opus 4.7) repeatedly fails to comply with global ~/.claude/CLAUDE.md and modular rules in ~/.claude/rules/ despite extensive auto-loaded documentation -- 41 logged violations across 60+ sessions",
-      "impact": "not_applicable",
-      "categories": [
-        "terminal",
-        "slash_hook"
-      ],
-      "tokenkey_status": "not_applicable",
-      "rationale": "Client-side claude-code concern (terminal, slash_hook); not a gateway/relay relevance signal.",
-      "updated_at": "2026-06-01T22:46:01Z"
-    },
-    {
-      "upstream": "anthropics/claude-code#54138",
-      "url": "https://github.com/anthropics/claude-code/issues/54138",
-      "title": "Cowork: artifacts folder hardcoded to Documents path, ignores selected project folder",
-      "impact": "not_applicable",
-      "categories": [
-        "terminal"
-      ],
-      "tokenkey_status": "not_applicable",
-      "rationale": "Client-side claude-code concern (terminal); not a gateway/relay relevance signal.",
-      "updated_at": "2026-06-01T18:55:14Z"
-    },
-    {
       "upstream": "anthropics/claude-code#54160",
       "url": "https://github.com/anthropics/claude-code/issues/54160",
       "title": "[DOCS] Skills command docs missing type-to-filter search box",
@@ -9590,7 +9612,7 @@
       ],
       "tokenkey_status": "not_applicable",
       "rationale": "Client-side claude-code concern (terminal, plugin, slash_hook); not a gateway/relay relevance signal.",
-      "updated_at": "2026-06-03T11:39:58Z"
+      "updated_at": "2026-06-04T23:12:05Z"
     },
     {
       "upstream": "anthropics/claude-code#54162",
@@ -9603,7 +9625,7 @@
       ],
       "tokenkey_status": "not_applicable",
       "rationale": "Client-side claude-code concern (terminal, slash_hook); not a gateway/relay relevance signal.",
-      "updated_at": "2026-06-03T11:39:58Z"
+      "updated_at": "2026-06-04T23:24:11Z"
     },
     {
       "upstream": "anthropics/claude-code#54163",
@@ -9615,7 +9637,7 @@
       ],
       "tokenkey_status": "not_applicable",
       "rationale": "Client-side claude-code concern (plugin); not a gateway/relay relevance signal.",
-      "updated_at": "2026-06-03T11:40:01Z"
+      "updated_at": "2026-06-04T23:11:42Z"
     },
     {
       "upstream": "anthropics/claude-code#54167",
@@ -9627,7 +9649,7 @@
       ],
       "tokenkey_status": "not_applicable",
       "rationale": "Client-side claude-code concern (terminal); not a gateway/relay relevance signal.",
-      "updated_at": "2026-06-03T11:39:56Z"
+      "updated_at": "2026-06-04T23:11:01Z"
     },
     {
       "upstream": "anthropics/claude-code#54168",
@@ -9640,7 +9662,7 @@
       ],
       "tokenkey_status": "not_applicable",
       "rationale": "Client-side claude-code concern (mcp, plugin); not a gateway/relay relevance signal.",
-      "updated_at": "2026-06-03T11:39:55Z"
+      "updated_at": "2026-06-04T22:56:20Z"
     },
     {
       "upstream": "anthropics/claude-code#54170",
@@ -9655,7 +9677,7 @@
       ],
       "tokenkey_status": "not_applicable",
       "rationale": "Client-side claude-code concern (terminal, mcp, plugin, slash_hook); not a gateway/relay relevance signal.",
-      "updated_at": "2026-06-03T11:40:00Z"
+      "updated_at": "2026-06-04T22:56:22Z"
     },
     {
       "upstream": "anthropics/claude-code#54173",
@@ -9667,7 +9689,7 @@
       ],
       "tokenkey_status": "not_applicable",
       "rationale": "Client-side claude-code concern (ide); not a gateway/relay relevance signal.",
-      "updated_at": "2026-06-03T11:39:59Z"
+      "updated_at": "2026-06-04T23:05:15Z"
     },
     {
       "upstream": "anthropics/claude-code#54174",
@@ -9682,7 +9704,7 @@
       ],
       "tokenkey_status": "not_applicable",
       "rationale": "Client-side claude-code concern (ide, terminal, mcp, plugin); not a gateway/relay relevance signal.",
-      "updated_at": "2026-06-03T11:40:33Z"
+      "updated_at": "2026-06-04T22:55:51Z"
     },
     {
       "upstream": "anthropics/claude-code#54175",
@@ -9694,7 +9716,21 @@
       ],
       "tokenkey_status": "not_applicable",
       "rationale": "Client-side claude-code concern (plugin); not a gateway/relay relevance signal.",
-      "updated_at": "2026-06-03T11:40:02Z"
+      "updated_at": "2026-06-04T23:07:32Z"
+    },
+    {
+      "upstream": "anthropics/claude-code#54197",
+      "url": "https://github.com/anthropics/claude-code/issues/54197",
+      "title": "[FEATURE] Surface MCP tool outputSchema to the model context, not just the renderer",
+      "impact": "not_applicable",
+      "categories": [
+        "ide",
+        "terminal",
+        "mcp"
+      ],
+      "tokenkey_status": "not_applicable",
+      "rationale": "Client-side claude-code concern (ide, terminal, mcp); not a gateway/relay relevance signal.",
+      "updated_at": "2026-06-04T22:33:19Z"
     },
     {
       "upstream": "anthropics/claude-code#54440",
@@ -9708,19 +9744,6 @@
       "tokenkey_status": "not_applicable",
       "rationale": "Client-side claude-code concern (slash_hook, platform); not a gateway/relay relevance signal.",
       "updated_at": "2026-06-02T05:31:32Z"
-    },
-    {
-      "upstream": "anthropics/claude-code#54461",
-      "url": "https://github.com/anthropics/claude-code/issues/54461",
-      "title": "Desktop app: cannot change primary working directory or open new chat",
-      "impact": "not_applicable",
-      "categories": [
-        "terminal",
-        "platform"
-      ],
-      "tokenkey_status": "not_applicable",
-      "rationale": "Client-side claude-code concern (terminal, platform); not a gateway/relay relevance signal.",
-      "updated_at": "2026-06-01T21:42:28Z"
     },
     {
       "upstream": "anthropics/claude-code#54528",
@@ -9760,17 +9783,30 @@
       "updated_at": "2026-06-02T22:09:29Z"
     },
     {
-      "upstream": "anthropics/claude-code#54813",
-      "url": "https://github.com/anthropics/claude-code/issues/54813",
-      "title": "[Bug] Auto Mode Classifier Incorrectly Denies Git Push Command",
+      "upstream": "anthropics/claude-code#54743",
+      "url": "https://github.com/anthropics/claude-code/issues/54743",
+      "title": "[BUG] PreToolUse/PostToolUse hook error: Cannot find module session-state.cjs",
       "impact": "not_applicable",
       "categories": [
-        "terminal",
-        "mcp"
+        "slash_hook"
       ],
       "tokenkey_status": "not_applicable",
-      "rationale": "Client-side claude-code concern (terminal, mcp); not a gateway/relay relevance signal.",
-      "updated_at": "2026-06-01T22:45:37Z"
+      "rationale": "Client-side claude-code concern (slash_hook); not a gateway/relay relevance signal.",
+      "updated_at": "2026-06-04T22:33:20Z"
+    },
+    {
+      "upstream": "anthropics/claude-code#54786",
+      "url": "https://github.com/anthropics/claude-code/issues/54786",
+      "title": "Stdio MCP server cwd field silently ignored on Windows (2.1.123)",
+      "impact": "not_applicable",
+      "categories": [
+        "ide",
+        "mcp",
+        "platform"
+      ],
+      "tokenkey_status": "not_applicable",
+      "rationale": "Client-side claude-code concern (ide, mcp, platform); not a gateway/relay relevance signal.",
+      "updated_at": "2026-06-04T22:33:28Z"
     },
     {
       "upstream": "anthropics/claude-code#54856",
@@ -9838,19 +9874,6 @@
       "updated_at": "2026-06-03T22:45:54Z"
     },
     {
-      "upstream": "anthropics/claude-code#55107",
-      "url": "https://github.com/anthropics/claude-code/issues/55107",
-      "title": "[BUG] Failed to resume session: EINVAL: invalid argument, stat 'C:\\Users\\username",
-      "impact": "not_applicable",
-      "categories": [
-        "terminal",
-        "platform"
-      ],
-      "tokenkey_status": "not_applicable",
-      "rationale": "Client-side claude-code concern (terminal, platform); not a gateway/relay relevance signal.",
-      "updated_at": "2026-06-01T14:22:23Z"
-    },
-    {
       "upstream": "anthropics/claude-code#55188",
       "url": "https://github.com/anthropics/claude-code/issues/55188",
       "title": "[DOCS] Auto mode docs missing stalled permission-check spinner state",
@@ -9860,7 +9883,7 @@
       ],
       "tokenkey_status": "not_applicable",
       "rationale": "Client-side claude-code concern (terminal); not a gateway/relay relevance signal.",
-      "updated_at": "2026-06-04T11:06:38Z"
+      "updated_at": "2026-06-04T22:55:51Z"
     },
     {
       "upstream": "anthropics/claude-code#55190",
@@ -9874,7 +9897,47 @@
       ],
       "tokenkey_status": "not_applicable",
       "rationale": "Client-side claude-code concern (slash_hook, install, platform); not a gateway/relay relevance signal.",
-      "updated_at": "2026-06-03T22:45:04Z"
+      "updated_at": "2026-06-04T22:58:11Z"
+    },
+    {
+      "upstream": "anthropics/claude-code#55354",
+      "url": "https://github.com/anthropics/claude-code/issues/55354",
+      "title": "[BUG] RemoteTrigger.list fixed at 20. Can't see my full list of routines even though they are running via API or UI after you have 20",
+      "impact": "not_applicable",
+      "categories": [
+        "terminal"
+      ],
+      "tokenkey_status": "not_applicable",
+      "rationale": "Client-side claude-code concern (terminal); not a gateway/relay relevance signal.",
+      "updated_at": "2026-06-04T22:33:56Z"
+    },
+    {
+      "upstream": "anthropics/claude-code#55404",
+      "url": "https://github.com/anthropics/claude-code/issues/55404",
+      "title": "[BUG] Cowork desktop app — bash workspace fails to start repeatedly across sessions",
+      "impact": "not_applicable",
+      "categories": [
+        "terminal",
+        "platform"
+      ],
+      "tokenkey_status": "not_applicable",
+      "rationale": "Client-side claude-code concern (terminal, platform); not a gateway/relay relevance signal.",
+      "updated_at": "2026-06-04T23:18:11Z"
+    },
+    {
+      "upstream": "anthropics/claude-code#55426",
+      "url": "https://github.com/anthropics/claude-code/issues/55426",
+      "title": "[Bug] Claude Code exits with code 1 during LocalSessions.setFocusedSession with loaded plugins",
+      "impact": "not_applicable",
+      "categories": [
+        "ide",
+        "terminal",
+        "mcp",
+        "plugin"
+      ],
+      "tokenkey_status": "not_applicable",
+      "rationale": "Client-side claude-code concern (ide, terminal, mcp, plugin); not a gateway/relay relevance signal.",
+      "updated_at": "2026-06-04T22:33:38Z"
     },
     {
       "upstream": "anthropics/claude-code#55457",
@@ -10014,6 +10077,18 @@
       "updated_at": "2026-06-02T00:34:55Z"
     },
     {
+      "upstream": "anthropics/claude-code#55842",
+      "url": "https://github.com/anthropics/claude-code/issues/55842",
+      "title": "[Feature Request] Unified user state across Cowork and Claude chat — shared memory, files, skills, connectors",
+      "impact": "not_applicable",
+      "categories": [
+        "plugin"
+      ],
+      "tokenkey_status": "not_applicable",
+      "rationale": "Client-side claude-code concern (plugin); not a gateway/relay relevance signal.",
+      "updated_at": "2026-06-04T22:33:24Z"
+    },
+    {
       "upstream": "anthropics/claude-code#55863",
       "url": "https://github.com/anthropics/claude-code/issues/55863",
       "title": "[BUG] Session recap (post_turn_summary) never renders in VSCode extension, only in CLI",
@@ -10081,46 +10156,33 @@
       "updated_at": "2026-06-02T08:17:40Z"
     },
     {
-      "upstream": "anthropics/claude-code#56268",
-      "url": "https://github.com/anthropics/claude-code/issues/56268",
-      "title": "claude -p silent-freeze when spawned from a long-running orchestrator (no stdout, deterministic 100% from direct spawn, probabilistic with bash wrap)",
-      "impact": "not_applicable",
-      "categories": [
-        "mcp",
-        "slash_hook"
-      ],
-      "tokenkey_status": "not_applicable",
-      "rationale": "Client-side claude-code concern (mcp, slash_hook); not a gateway/relay relevance signal.",
-      "updated_at": "2026-06-01T22:45:43Z"
-    },
-    {
-      "upstream": "anthropics/claude-code#56335",
-      "url": "https://github.com/anthropics/claude-code/issues/56335",
-      "title": "[BUG] claude process leaks to 74 GB virtual memory, causing full system OOM freeze",
+      "upstream": "anthropics/claude-code#56296",
+      "url": "https://github.com/anthropics/claude-code/issues/56296",
+      "title": "[BUG] Cowork tab overwrites entire claude_desktop_config.json instead of merging, breaking MCP server configurations",
       "impact": "not_applicable",
       "categories": [
         "terminal",
         "mcp",
         "plugin",
-        "slash_hook",
-        "install"
+        "install",
+        "platform"
       ],
       "tokenkey_status": "not_applicable",
-      "rationale": "Client-side claude-code concern (terminal, mcp, plugin, slash_hook, install); not a gateway/relay relevance signal.",
-      "updated_at": "2026-06-01T15:03:46Z"
+      "rationale": "Client-side claude-code concern (terminal, mcp, plugin, install, platform); not a gateway/relay relevance signal.",
+      "updated_at": "2026-06-04T22:33:40Z"
     },
     {
-      "upstream": "anthropics/claude-code#56618",
-      "url": "https://github.com/anthropics/claude-code/issues/56618",
-      "title": "[FEATURE] Add setting to right-align user messages in chat UI",
+      "upstream": "anthropics/claude-code#56606",
+      "url": "https://github.com/anthropics/claude-code/issues/56606",
+      "title": "[FEATURE] Native UI to switch Claude Desktop between 1P and 3P/Gateway inference modes",
       "impact": "not_applicable",
       "categories": [
         "ide",
-        "terminal"
+        "platform"
       ],
       "tokenkey_status": "not_applicable",
-      "rationale": "Client-side claude-code concern (ide, terminal); not a gateway/relay relevance signal.",
-      "updated_at": "2026-06-01T20:59:49Z"
+      "rationale": "Client-side claude-code concern (ide, platform); not a gateway/relay relevance signal.",
+      "updated_at": "2026-06-04T13:55:23Z"
     },
     {
       "upstream": "anthropics/claude-code#56637",
@@ -10133,6 +10195,20 @@
       "tokenkey_status": "not_applicable",
       "rationale": "Client-side claude-code concern (terminal); not a gateway/relay relevance signal.",
       "updated_at": "2026-06-02T09:54:32Z"
+    },
+    {
+      "upstream": "anthropics/claude-code#56740",
+      "url": "https://github.com/anthropics/claude-code/issues/56740",
+      "title": "[BUG] Claude Code plugin update — stale `gitCommitSha`",
+      "impact": "not_applicable",
+      "categories": [
+        "terminal",
+        "plugin",
+        "install"
+      ],
+      "tokenkey_status": "not_applicable",
+      "rationale": "Client-side claude-code concern (terminal, plugin, install); not a gateway/relay relevance signal.",
+      "updated_at": "2026-06-04T22:33:36Z"
     },
     {
       "upstream": "anthropics/claude-code#56778",
@@ -10160,6 +10236,34 @@
       "tokenkey_status": "not_applicable",
       "rationale": "Client-side claude-code concern (slash_hook); not a gateway/relay relevance signal.",
       "updated_at": "2026-06-02T15:02:20Z"
+    },
+    {
+      "upstream": "anthropics/claude-code#56860",
+      "url": "https://github.com/anthropics/claude-code/issues/56860",
+      "title": "Session hangs indefinitely with spinning thinking indicator — 3 confirmed variants (+ /btw MCP teardown)",
+      "impact": "not_applicable",
+      "categories": [
+        "terminal",
+        "mcp",
+        "platform"
+      ],
+      "tokenkey_status": "not_applicable",
+      "rationale": "Client-side claude-code concern (terminal, mcp, platform); not a gateway/relay relevance signal.",
+      "updated_at": "2026-06-04T22:33:45Z"
+    },
+    {
+      "upstream": "anthropics/claude-code#56895",
+      "url": "https://github.com/anthropics/claude-code/issues/56895",
+      "title": "[Billing Bug] Claude Max payment charged but account reverted to Free plan - invoice shows \"Paid\"",
+      "impact": "not_applicable",
+      "categories": [
+        "ide",
+        "terminal",
+        "platform"
+      ],
+      "tokenkey_status": "not_applicable",
+      "rationale": "Client-side claude-code concern (ide, terminal, platform); not a gateway/relay relevance signal.",
+      "updated_at": "2026-06-04T18:58:39Z"
     },
     {
       "upstream": "anthropics/claude-code#56906",
@@ -10294,6 +10398,18 @@
       "updated_at": "2026-06-02T12:14:48Z"
     },
     {
+      "upstream": "anthropics/claude-code#57278",
+      "url": "https://github.com/anthropics/claude-code/issues/57278",
+      "title": "Runaway Claude Code session consumed weekly limits during stalled/resumed failure state",
+      "impact": "not_applicable",
+      "categories": [
+        "terminal"
+      ],
+      "tokenkey_status": "not_applicable",
+      "rationale": "Client-side claude-code concern (terminal); not a gateway/relay relevance signal.",
+      "updated_at": "2026-06-04T16:51:14Z"
+    },
+    {
       "upstream": "anthropics/claude-code#57286",
       "url": "https://github.com/anthropics/claude-code/issues/57286",
       "title": "Bug: Remote Control initialization fails with \"Remote Control failed to connect: Remote Control initialization failed\"",
@@ -10315,21 +10431,7 @@
       ],
       "tokenkey_status": "not_applicable",
       "rationale": "Client-side claude-code concern (terminal); not a gateway/relay relevance signal.",
-      "updated_at": "2026-06-04T11:45:49Z"
-    },
-    {
-      "upstream": "anthropics/claude-code#57601",
-      "url": "https://github.com/anthropics/claude-code/issues/57601",
-      "title": "[BUG] Rewind option visible in picker but selecting any anchor returns 'Can't rewind to this message' (v2.1.119, CLI)",
-      "impact": "not_applicable",
-      "categories": [
-        "terminal",
-        "plugin",
-        "slash_hook"
-      ],
-      "tokenkey_status": "not_applicable",
-      "rationale": "Client-side claude-code concern (terminal, plugin, slash_hook); not a gateway/relay relevance signal.",
-      "updated_at": "2026-06-01T22:45:27Z"
+      "updated_at": "2026-06-04T19:56:30Z"
     },
     {
       "upstream": "anthropics/claude-code#57609",
@@ -10375,18 +10477,6 @@
       "updated_at": "2026-06-02T05:25:55Z"
     },
     {
-      "upstream": "anthropics/claude-code#57743",
-      "url": "https://github.com/anthropics/claude-code/issues/57743",
-      "title": "[FEATURE] Visual conventions for blocking questions and end-of-session summaries",
-      "impact": "not_applicable",
-      "categories": [
-        "terminal"
-      ],
-      "tokenkey_status": "not_applicable",
-      "rationale": "Client-side claude-code concern (terminal); not a gateway/relay relevance signal.",
-      "updated_at": "2026-06-01T22:46:09Z"
-    },
-    {
       "upstream": "anthropics/claude-code#57844",
       "url": "https://github.com/anthropics/claude-code/issues/57844",
       "title": "Preview panel: mobile/desktop viewport toggle button is gone",
@@ -10397,6 +10487,22 @@
       "tokenkey_status": "not_applicable",
       "rationale": "Client-side claude-code concern (ide); not a gateway/relay relevance signal.",
       "updated_at": "2026-06-03T22:22:54Z"
+    },
+    {
+      "upstream": "anthropics/claude-code#57846",
+      "url": "https://github.com/anthropics/claude-code/issues/57846",
+      "title": "[Bug] Chrome native host crashes with ERR_INVALID_ARG_TYPE on Windows named pipe creation",
+      "impact": "not_applicable",
+      "categories": [
+        "ide",
+        "terminal",
+        "mcp",
+        "install",
+        "platform"
+      ],
+      "tokenkey_status": "not_applicable",
+      "rationale": "Client-side claude-code concern (ide, terminal, mcp, install, platform); not a gateway/relay relevance signal.",
+      "updated_at": "2026-06-04T16:09:11Z"
     },
     {
       "upstream": "anthropics/claude-code#57862",
@@ -10411,6 +10517,20 @@
       "tokenkey_status": "not_applicable",
       "rationale": "Client-side claude-code concern (ide, terminal, plugin); not a gateway/relay relevance signal.",
       "updated_at": "2026-06-02T22:44:16Z"
+    },
+    {
+      "upstream": "anthropics/claude-code#57930",
+      "url": "https://github.com/anthropics/claude-code/issues/57930",
+      "title": "[BUG] Hamburger menu closes before tab selection in Claude Desktop",
+      "impact": "not_applicable",
+      "categories": [
+        "terminal",
+        "slash_hook",
+        "platform"
+      ],
+      "tokenkey_status": "not_applicable",
+      "rationale": "Client-side claude-code concern (terminal, slash_hook, platform); not a gateway/relay relevance signal.",
+      "updated_at": "2026-06-04T15:35:02Z"
     },
     {
       "upstream": "anthropics/claude-code#57947",
@@ -10437,21 +10557,6 @@
       "tokenkey_status": "not_applicable",
       "rationale": "Client-side claude-code concern (terminal); not a gateway/relay relevance signal.",
       "updated_at": "2026-06-02T11:33:18Z"
-    },
-    {
-      "upstream": "anthropics/claude-code#57998",
-      "url": "https://github.com/anthropics/claude-code/issues/57998",
-      "title": "[FEATURE] CLAUDE_DATA_DIR env var or config key to relocate %APPDATA%\\Claude\\ on Windows",
-      "impact": "not_applicable",
-      "categories": [
-        "ide",
-        "slash_hook",
-        "install",
-        "platform"
-      ],
-      "tokenkey_status": "not_applicable",
-      "rationale": "Client-side claude-code concern (ide, slash_hook, install, platform); not a gateway/relay relevance signal.",
-      "updated_at": "2026-06-01T17:00:20Z"
     },
     {
       "upstream": "anthropics/claude-code#58101",
@@ -10532,6 +10637,30 @@
       "updated_at": "2026-06-02T11:32:47Z"
     },
     {
+      "upstream": "anthropics/claude-code#58276",
+      "url": "https://github.com/anthropics/claude-code/issues/58276",
+      "title": "[BUG] 100% CPU / frozen UI during plan mode streaming — auto-mode + fast-mode hot-loop in reactive state",
+      "impact": "not_applicable",
+      "categories": [
+        "terminal"
+      ],
+      "tokenkey_status": "not_applicable",
+      "rationale": "Client-side claude-code concern (terminal); not a gateway/relay relevance signal.",
+      "updated_at": "2026-06-04T22:32:57Z"
+    },
+    {
+      "upstream": "anthropics/claude-code#58304",
+      "url": "https://github.com/anthropics/claude-code/issues/58304",
+      "title": "Cannot copy or paste text in Claude Code on Windows 11",
+      "impact": "not_applicable",
+      "categories": [
+        "platform"
+      ],
+      "tokenkey_status": "not_applicable",
+      "rationale": "Client-side claude-code concern (platform); not a gateway/relay relevance signal.",
+      "updated_at": "2026-06-04T22:33:53Z"
+    },
+    {
       "upstream": "anthropics/claude-code#58333",
       "url": "https://github.com/anthropics/claude-code/issues/58333",
       "title": "claude update: false-positive \"~/.local/bin is not in your PATH\" warning when it actually is",
@@ -10559,6 +10688,19 @@
       "updated_at": "2026-06-02T11:32:27Z"
     },
     {
+      "upstream": "anthropics/claude-code#58371",
+      "url": "https://github.com/anthropics/claude-code/issues/58371",
+      "title": "**Bug: Pro subscription not recognized in VS Code extension**[BUG]",
+      "impact": "not_applicable",
+      "categories": [
+        "ide",
+        "terminal"
+      ],
+      "tokenkey_status": "not_applicable",
+      "rationale": "Client-side claude-code concern (ide, terminal); not a gateway/relay relevance signal.",
+      "updated_at": "2026-06-04T22:33:52Z"
+    },
+    {
       "upstream": "anthropics/claude-code#58412",
       "url": "https://github.com/anthropics/claude-code/issues/58412",
       "title": "Session rename in sidebar reverts after clicking elsewhere",
@@ -10571,16 +10713,19 @@
       "updated_at": "2026-06-03T22:45:28Z"
     },
     {
-      "upstream": "anthropics/claude-code#58444",
-      "url": "https://github.com/anthropics/claude-code/issues/58444",
-      "title": "HTTP MCP Servers Don't Auto-Reconnect After Transient Startup Failures",
+      "upstream": "anthropics/claude-code#58517",
+      "url": "https://github.com/anthropics/claude-code/issues/58517",
+      "title": "MCP SSE transport ignores relative endpoint URLs; Streamable HTTP (type: http) silently not loaded",
       "impact": "not_applicable",
       "categories": [
-        "mcp"
+        "ide",
+        "mcp",
+        "install",
+        "platform"
       ],
       "tokenkey_status": "not_applicable",
-      "rationale": "Client-side claude-code concern (mcp); not a gateway/relay relevance signal.",
-      "updated_at": "2026-06-01T17:58:49Z"
+      "rationale": "Client-side claude-code concern (ide, mcp, install, platform); not a gateway/relay relevance signal.",
+      "updated_at": "2026-06-04T13:54:44Z"
     },
     {
       "upstream": "anthropics/claude-code#58518",
@@ -10662,19 +10807,6 @@
       "updated_at": "2026-06-03T22:45:42Z"
     },
     {
-      "upstream": "anthropics/claude-code#58660",
-      "url": "https://github.com/anthropics/claude-code/issues/58660",
-      "title": "Scroll wheel/trackpad should scroll agent transcript inside agent detail view",
-      "impact": "not_applicable",
-      "categories": [
-        "terminal",
-        "slash_hook"
-      ],
-      "tokenkey_status": "not_applicable",
-      "rationale": "Client-side claude-code concern (terminal, slash_hook); not a gateway/relay relevance signal.",
-      "updated_at": "2026-06-01T22:45:34Z"
-    },
-    {
       "upstream": "anthropics/claude-code#58671",
       "url": "https://github.com/anthropics/claude-code/issues/58671",
       "title": "Phantom user messages: text appears in transcript as user input that the user did not type",
@@ -10701,6 +10833,19 @@
       "updated_at": "2026-06-02T11:32:55Z"
     },
     {
+      "upstream": "anthropics/claude-code#58690",
+      "url": "https://github.com/anthropics/claude-code/issues/58690",
+      "title": "[BUG] Action confirmation prompt requires more than keypress to be dismissed",
+      "impact": "not_applicable",
+      "categories": [
+        "terminal",
+        "mcp"
+      ],
+      "tokenkey_status": "not_applicable",
+      "rationale": "Client-side claude-code concern (terminal, mcp); not a gateway/relay relevance signal.",
+      "updated_at": "2026-06-04T16:14:11Z"
+    },
+    {
       "upstream": "anthropics/claude-code#58717",
       "url": "https://github.com/anthropics/claude-code/issues/58717",
       "title": "[Bug] Claude replaces ASCII quotes with Unicode quotes in code generation, breaking syntax",
@@ -10711,19 +10856,6 @@
       "tokenkey_status": "not_applicable",
       "rationale": "Client-side claude-code concern (terminal); not a gateway/relay relevance signal.",
       "updated_at": "2026-06-02T11:33:06Z"
-    },
-    {
-      "upstream": "anthropics/claude-code#58732",
-      "url": "https://github.com/anthropics/claude-code/issues/58732",
-      "title": "claude.exe polls entire PATH for \\coder\\ (and other tools) every 30 seconds, including removable/archive drives",
-      "impact": "not_applicable",
-      "categories": [
-        "install",
-        "platform"
-      ],
-      "tokenkey_status": "not_applicable",
-      "rationale": "Client-side claude-code concern (install, platform); not a gateway/relay relevance signal.",
-      "updated_at": "2026-06-01T22:46:08Z"
     },
     {
       "upstream": "anthropics/claude-code#58750",
@@ -10739,16 +10871,16 @@
       "updated_at": "2026-06-03T04:00:47Z"
     },
     {
-      "upstream": "anthropics/claude-code#58784",
-      "url": "https://github.com/anthropics/claude-code/issues/58784",
-      "title": "[BUG] Claude Code process exited with code 1",
+      "upstream": "anthropics/claude-code#58779",
+      "url": "https://github.com/anthropics/claude-code/issues/58779",
+      "title": "iOS: send button unresponsive after entering an active Code session",
       "impact": "not_applicable",
       "categories": [
-        "terminal"
+        "install"
       ],
       "tokenkey_status": "not_applicable",
-      "rationale": "Client-side claude-code concern (terminal); not a gateway/relay relevance signal.",
-      "updated_at": "2026-06-01T22:45:54Z"
+      "rationale": "Client-side claude-code concern (install); not a gateway/relay relevance signal.",
+      "updated_at": "2026-06-04T22:33:01Z"
     },
     {
       "upstream": "anthropics/claude-code#58821",
@@ -10762,22 +10894,6 @@
       "tokenkey_status": "not_applicable",
       "rationale": "Client-side claude-code concern (terminal, platform); not a gateway/relay relevance signal.",
       "updated_at": "2026-06-02T23:34:42Z"
-    },
-    {
-      "upstream": "anthropics/claude-code#58895",
-      "url": "https://github.com/anthropics/claude-code/issues/58895",
-      "title": "[FEATURE] UserIdle hook event for proactive state persistence after N minutes of inactivity",
-      "impact": "not_applicable",
-      "categories": [
-        "ide",
-        "terminal",
-        "plugin",
-        "slash_hook",
-        "platform"
-      ],
-      "tokenkey_status": "not_applicable",
-      "rationale": "Client-side claude-code concern (ide, terminal, plugin, slash_hook, platform); not a gateway/relay relevance signal.",
-      "updated_at": "2026-06-01T22:45:41Z"
     },
     {
       "upstream": "anthropics/claude-code#58910",
@@ -10844,16 +10960,18 @@
       "updated_at": "2026-06-04T11:07:25Z"
     },
     {
-      "upstream": "anthropics/claude-code#59032",
-      "url": "https://github.com/anthropics/claude-code/issues/59032",
-      "title": "[BUG] Why is the /compact command so slow?",
+      "upstream": "anthropics/claude-code#59051",
+      "url": "https://github.com/anthropics/claude-code/issues/59051",
+      "title": "[BUG] Managed settings aren't validated causing silent failures",
       "impact": "not_applicable",
       "categories": [
-        "terminal"
+        "terminal",
+        "plugin",
+        "slash_hook"
       ],
       "tokenkey_status": "not_applicable",
-      "rationale": "Client-side claude-code concern (terminal); not a gateway/relay relevance signal.",
-      "updated_at": "2026-06-01T22:45:06Z"
+      "rationale": "Client-side claude-code concern (terminal, plugin, slash_hook); not a gateway/relay relevance signal.",
+      "updated_at": "2026-06-04T18:38:33Z"
     },
     {
       "upstream": "anthropics/claude-code#59182",
@@ -10910,16 +11028,18 @@
       "updated_at": "2026-06-04T01:56:11Z"
     },
     {
-      "upstream": "anthropics/claude-code#59309",
-      "url": "https://github.com/anthropics/claude-code/issues/59309",
-      "title": "CLAUDE.md rules not propagated to Agent subagents and weakened after context compaction",
+      "upstream": "anthropics/claude-code#59313",
+      "url": "https://github.com/anthropics/claude-code/issues/59313",
+      "title": "[Bug] REPL text flickering/blinking display issue",
       "impact": "not_applicable",
       "categories": [
-        "plugin"
+        "ide",
+        "terminal",
+        "install"
       ],
       "tokenkey_status": "not_applicable",
-      "rationale": "Client-side claude-code concern (plugin); not a gateway/relay relevance signal.",
-      "updated_at": "2026-06-01T22:46:20Z"
+      "rationale": "Client-side claude-code concern (ide, terminal, install); not a gateway/relay relevance signal.",
+      "updated_at": "2026-06-04T22:33:34Z"
     },
     {
       "upstream": "anthropics/claude-code#59336",
@@ -10946,6 +11066,21 @@
       "updated_at": "2026-06-02T09:47:45Z"
     },
     {
+      "upstream": "anthropics/claude-code#59408",
+      "url": "https://github.com/anthropics/claude-code/issues/59408",
+      "title": "[BUG] Ctrl+C and Ctrl+Shift+C silently clear prompt input with no confirmation or recovery",
+      "impact": "not_applicable",
+      "categories": [
+        "ide",
+        "terminal",
+        "slash_hook",
+        "platform"
+      ],
+      "tokenkey_status": "not_applicable",
+      "rationale": "Client-side claude-code concern (ide, terminal, slash_hook, platform); not a gateway/relay relevance signal.",
+      "updated_at": "2026-06-04T14:06:27Z"
+    },
+    {
       "upstream": "anthropics/claude-code#59492",
       "url": "https://github.com/anthropics/claude-code/issues/59492",
       "title": "[FEATURE] Native /restart and /handoff: consolidating 9 open requests + 2 working prototypes",
@@ -10961,18 +11096,6 @@
       "tokenkey_status": "not_applicable",
       "rationale": "Client-side claude-code concern (terminal, mcp, plugin, slash_hook, install, platform); not a gateway/relay relevance signal.",
       "updated_at": "2026-06-02T22:44:46Z"
-    },
-    {
-      "upstream": "anthropics/claude-code#59522",
-      "url": "https://github.com/anthropics/claude-code/issues/59522",
-      "title": "[BUG] terminal title \"icons\" no longer seem to accurately reflect status",
-      "impact": "not_applicable",
-      "categories": [
-        "terminal"
-      ],
-      "tokenkey_status": "not_applicable",
-      "rationale": "Client-side claude-code concern (terminal); not a gateway/relay relevance signal.",
-      "updated_at": "2026-06-01T22:45:11Z"
     },
     {
       "upstream": "anthropics/claude-code#59628",
@@ -11012,59 +11135,6 @@
       "tokenkey_status": "not_applicable",
       "rationale": "Client-side claude-code concern (ide, terminal); not a gateway/relay relevance signal.",
       "updated_at": "2026-06-03T19:16:19Z"
-    },
-    {
-      "upstream": "anthropics/claude-code#59672",
-      "url": "https://github.com/anthropics/claude-code/issues/59672",
-      "title": "[BUG] Windows VS Code terminal output becomes garbled (CJK-looking glyphs) after ~60–90 minutes of session",
-      "impact": "not_applicable",
-      "categories": [
-        "ide",
-        "terminal",
-        "platform"
-      ],
-      "tokenkey_status": "not_applicable",
-      "rationale": "Client-side claude-code concern (ide, terminal, platform); not a gateway/relay relevance signal.",
-      "updated_at": "2026-06-01T22:45:31Z"
-    },
-    {
-      "upstream": "anthropics/claude-code#59683",
-      "url": "https://github.com/anthropics/claude-code/issues/59683",
-      "title": "[FEATURE] Files panel (macOS Desktop): render symlinked directories as expandable folders",
-      "impact": "not_applicable",
-      "categories": [
-        "ide",
-        "terminal",
-        "platform"
-      ],
-      "tokenkey_status": "not_applicable",
-      "rationale": "Client-side claude-code concern (ide, terminal, platform); not a gateway/relay relevance signal.",
-      "updated_at": "2026-06-01T22:45:03Z"
-    },
-    {
-      "upstream": "anthropics/claude-code#59686",
-      "url": "https://github.com/anthropics/claude-code/issues/59686",
-      "title": "[Bug] Duplicate options displayed in command completion menu",
-      "impact": "not_applicable",
-      "categories": [
-        "ide",
-        "terminal"
-      ],
-      "tokenkey_status": "not_applicable",
-      "rationale": "Client-side claude-code concern (ide, terminal); not a gateway/relay relevance signal.",
-      "updated_at": "2026-06-01T22:45:07Z"
-    },
-    {
-      "upstream": "anthropics/claude-code#59693",
-      "url": "https://github.com/anthropics/claude-code/issues/59693",
-      "title": "[Feature Request] Support for alternative LLM providers beyond Anthropic Claude models",
-      "impact": "not_applicable",
-      "categories": [
-        "terminal"
-      ],
-      "tokenkey_status": "not_applicable",
-      "rationale": "Client-side claude-code concern (terminal); not a gateway/relay relevance signal.",
-      "updated_at": "2026-06-01T22:45:09Z"
     },
     {
       "upstream": "anthropics/claude-code#59697",
@@ -11121,19 +11191,6 @@
       "updated_at": "2026-06-01T23:14:19Z"
     },
     {
-      "upstream": "anthropics/claude-code#59741",
-      "url": "https://github.com/anthropics/claude-code/issues/59741",
-      "title": "Drag & Drop: Drop indicator desynchronizes from cursor position when scrolling during drag",
-      "impact": "not_applicable",
-      "categories": [
-        "terminal",
-        "platform"
-      ],
-      "tokenkey_status": "not_applicable",
-      "rationale": "Client-side claude-code concern (terminal, platform); not a gateway/relay relevance signal.",
-      "updated_at": "2026-06-01T22:45:28Z"
-    },
-    {
       "upstream": "anthropics/claude-code#59750",
       "url": "https://github.com/anthropics/claude-code/issues/59750",
       "title": "[BUG] claude agents TUI fully unresponsive on Windows Terminal — broken rendering + dead input loop (2.1.143)",
@@ -11173,18 +11230,6 @@
       "tokenkey_status": "not_applicable",
       "rationale": "Client-side claude-code concern (terminal, slash_hook); not a gateway/relay relevance signal.",
       "updated_at": "2026-06-04T11:07:50Z"
-    },
-    {
-      "upstream": "anthropics/claude-code#59826",
-      "url": "https://github.com/anthropics/claude-code/issues/59826",
-      "title": "Granting a permission from the VS Code extension requires hand-editing JSON",
-      "impact": "not_applicable",
-      "categories": [
-        "ide"
-      ],
-      "tokenkey_status": "not_applicable",
-      "rationale": "Client-side claude-code concern (ide); not a gateway/relay relevance signal.",
-      "updated_at": "2026-06-01T22:45:15Z"
     },
     {
       "upstream": "anthropics/claude-code#59833",
@@ -11239,43 +11284,6 @@
       "updated_at": "2026-06-03T08:59:04Z"
     },
     {
-      "upstream": "anthropics/claude-code#59860",
-      "url": "https://github.com/anthropics/claude-code/issues/59860",
-      "title": "[BUG] Long-running session degradation since v2.1.139, compounded by silent fast-mode model swap in v2.1.142 — no changelog, breaks pinned-model workflows, quantified waste",
-      "impact": "not_applicable",
-      "categories": [
-        "terminal"
-      ],
-      "tokenkey_status": "not_applicable",
-      "rationale": "Client-side claude-code concern (terminal); not a gateway/relay relevance signal.",
-      "updated_at": "2026-06-01T22:45:13Z"
-    },
-    {
-      "upstream": "anthropics/claude-code#59865",
-      "url": "https://github.com/anthropics/claude-code/issues/59865",
-      "title": "[BUG] Repeated violations of explicit rules in CLAUDE.md",
-      "impact": "not_applicable",
-      "categories": [
-        "terminal"
-      ],
-      "tokenkey_status": "not_applicable",
-      "rationale": "Client-side claude-code concern (terminal); not a gateway/relay relevance signal.",
-      "updated_at": "2026-06-01T22:45:14Z"
-    },
-    {
-      "upstream": "anthropics/claude-code#59868",
-      "url": "https://github.com/anthropics/claude-code/issues/59868",
-      "title": "Duplicate: VS Code model picker shows stale model name",
-      "impact": "not_applicable",
-      "categories": [
-        "ide",
-        "terminal"
-      ],
-      "tokenkey_status": "not_applicable",
-      "rationale": "Client-side claude-code concern (ide, terminal); not a gateway/relay relevance signal.",
-      "updated_at": "2026-06-01T22:45:16Z"
-    },
-    {
       "upstream": "anthropics/claude-code#59870",
       "url": "https://github.com/anthropics/claude-code/issues/59870",
       "title": "settings.json: top-level `hooks` key dropped when granting a permission",
@@ -11287,45 +11295,6 @@
       "tokenkey_status": "not_applicable",
       "rationale": "Client-side claude-code concern (slash_hook, install); not a gateway/relay relevance signal.",
       "updated_at": "2026-06-03T22:45:11Z"
-    },
-    {
-      "upstream": "anthropics/claude-code#59874",
-      "url": "https://github.com/anthropics/claude-code/issues/59874",
-      "title": "VS Code model picker shows stale model name after selecting default model",
-      "impact": "not_applicable",
-      "categories": [
-        "ide",
-        "terminal"
-      ],
-      "tokenkey_status": "not_applicable",
-      "rationale": "Client-side claude-code concern (ide, terminal); not a gateway/relay relevance signal.",
-      "updated_at": "2026-06-01T22:45:18Z"
-    },
-    {
-      "upstream": "anthropics/claude-code#59877",
-      "url": "https://github.com/anthropics/claude-code/issues/59877",
-      "title": "[Feature Request] Add vim keybindings to agent navigation menu",
-      "impact": "not_applicable",
-      "categories": [
-        "terminal",
-        "slash_hook"
-      ],
-      "tokenkey_status": "not_applicable",
-      "rationale": "Client-side claude-code concern (terminal, slash_hook); not a gateway/relay relevance signal.",
-      "updated_at": "2026-06-01T22:45:19Z"
-    },
-    {
-      "upstream": "anthropics/claude-code#59878",
-      "url": "https://github.com/anthropics/claude-code/issues/59878",
-      "title": "[BUG] VIBE CODED STUPID ANTHROPIC USAGE POLICY FLAGS EVERYTHING FOR NO REASON",
-      "impact": "not_applicable",
-      "categories": [
-        "terminal",
-        "platform"
-      ],
-      "tokenkey_status": "not_applicable",
-      "rationale": "Client-side claude-code concern (terminal, platform); not a gateway/relay relevance signal.",
-      "updated_at": "2026-06-01T22:45:20Z"
     },
     {
       "upstream": "anthropics/claude-code#59879",
@@ -11428,123 +11397,6 @@
       "updated_at": "2026-06-02T11:32:03Z"
     },
     {
-      "upstream": "anthropics/claude-code#59906",
-      "url": "https://github.com/anthropics/claude-code/issues/59906",
-      "title": "[Bug] Claude Code generating unrelated code output to user plan",
-      "impact": "not_applicable",
-      "categories": [
-        "terminal"
-      ],
-      "tokenkey_status": "not_applicable",
-      "rationale": "Client-side claude-code concern (terminal); not a gateway/relay relevance signal.",
-      "updated_at": "2026-06-01T22:45:22Z"
-    },
-    {
-      "upstream": "anthropics/claude-code#59907",
-      "url": "https://github.com/anthropics/claude-code/issues/59907",
-      "title": "CLAUDE_CODE_EXPERIMENTAL_AGENT_TEAMS auto-distributor injects orchestrator/team task descriptions into specialist contexts as fake teammate messages",
-      "impact": "not_applicable",
-      "categories": [
-        "plugin",
-        "slash_hook"
-      ],
-      "tokenkey_status": "not_applicable",
-      "rationale": "Client-side claude-code concern (plugin, slash_hook); not a gateway/relay relevance signal.",
-      "updated_at": "2026-06-01T22:45:55Z"
-    },
-    {
-      "upstream": "anthropics/claude-code#59917",
-      "url": "https://github.com/anthropics/claude-code/issues/59917",
-      "title": "[Feature Request] Auto-load multimodal files (PNG/HTML) from CLAUDE.md directories via @-imports",
-      "impact": "not_applicable",
-      "categories": [
-        "terminal",
-        "mcp",
-        "slash_hook"
-      ],
-      "tokenkey_status": "not_applicable",
-      "rationale": "Client-side claude-code concern (terminal, mcp, slash_hook); not a gateway/relay relevance signal.",
-      "updated_at": "2026-06-01T22:45:23Z"
-    },
-    {
-      "upstream": "anthropics/claude-code#59922",
-      "url": "https://github.com/anthropics/claude-code/issues/59922",
-      "title": "Plan mode session pinned to generated filename — can't redirect approval UI to a different plan file",
-      "impact": "not_applicable",
-      "categories": [
-        "ide",
-        "platform"
-      ],
-      "tokenkey_status": "not_applicable",
-      "rationale": "Client-side claude-code concern (ide, platform); not a gateway/relay relevance signal.",
-      "updated_at": "2026-06-01T22:45:24Z"
-    },
-    {
-      "upstream": "anthropics/claude-code#59923",
-      "url": "https://github.com/anthropics/claude-code/issues/59923",
-      "title": "[Bug] Conversation home directory incorrectly switches to nested test directory after compaction",
-      "impact": "not_applicable",
-      "categories": [
-        "terminal"
-      ],
-      "tokenkey_status": "not_applicable",
-      "rationale": "Client-side claude-code concern (terminal); not a gateway/relay relevance signal.",
-      "updated_at": "2026-06-01T22:45:25Z"
-    },
-    {
-      "upstream": "anthropics/claude-code#59929",
-      "url": "https://github.com/anthropics/claude-code/issues/59929",
-      "title": "[FEATURE]",
-      "impact": "not_applicable",
-      "categories": [
-        "mcp",
-        "plugin",
-        "slash_hook"
-      ],
-      "tokenkey_status": "not_applicable",
-      "rationale": "Client-side claude-code concern (mcp, plugin, slash_hook); not a gateway/relay relevance signal.",
-      "updated_at": "2026-06-01T22:45:27Z"
-    },
-    {
-      "upstream": "anthropics/claude-code#59938",
-      "url": "https://github.com/anthropics/claude-code/issues/59938",
-      "title": "[Bug] Claude Code commits and pushes changes without explicit user approval",
-      "impact": "not_applicable",
-      "categories": [
-        "ide",
-        "terminal"
-      ],
-      "tokenkey_status": "not_applicable",
-      "rationale": "Client-side claude-code concern (ide, terminal); not a gateway/relay relevance signal.",
-      "updated_at": "2026-06-01T22:45:33Z"
-    },
-    {
-      "upstream": "anthropics/claude-code#59939",
-      "url": "https://github.com/anthropics/claude-code/issues/59939",
-      "title": "[Bug] Stop hook error: Failed with non-blocking status code",
-      "impact": "not_applicable",
-      "categories": [
-        "ide",
-        "terminal",
-        "slash_hook"
-      ],
-      "tokenkey_status": "not_applicable",
-      "rationale": "Client-side claude-code concern (ide, terminal, slash_hook); not a gateway/relay relevance signal.",
-      "updated_at": "2026-06-01T22:45:35Z"
-    },
-    {
-      "upstream": "anthropics/claude-code#59950",
-      "url": "https://github.com/anthropics/claude-code/issues/59950",
-      "title": "[BUG] Fin AI agent claims it has no ability to pass messages to a human support",
-      "impact": "not_applicable",
-      "categories": [
-        "terminal"
-      ],
-      "tokenkey_status": "not_applicable",
-      "rationale": "Client-side claude-code concern (terminal); not a gateway/relay relevance signal.",
-      "updated_at": "2026-06-01T22:45:40Z"
-    },
-    {
       "upstream": "anthropics/claude-code#59952",
       "url": "https://github.com/anthropics/claude-code/issues/59952",
       "title": "[BUG] Bug where Japanese CJK characters are misaligned at the line break position",
@@ -11558,60 +11410,6 @@
       "updated_at": "2026-06-03T22:45:56Z"
     },
     {
-      "upstream": "anthropics/claude-code#59957",
-      "url": "https://github.com/anthropics/claude-code/issues/59957",
-      "title": "[BUG] CoWork Deleted All Content from a Cowork Workspace",
-      "impact": "not_applicable",
-      "categories": [
-        "terminal",
-        "plugin",
-        "install",
-        "platform"
-      ],
-      "tokenkey_status": "not_applicable",
-      "rationale": "Client-side claude-code concern (terminal, plugin, install, platform); not a gateway/relay relevance signal.",
-      "updated_at": "2026-06-01T22:45:39Z"
-    },
-    {
-      "upstream": "anthropics/claude-code#59960",
-      "url": "https://github.com/anthropics/claude-code/issues/59960",
-      "title": "[BUG] Remote Control registration ignores persisted /rename title after /resume",
-      "impact": "not_applicable",
-      "categories": [
-        "terminal"
-      ],
-      "tokenkey_status": "not_applicable",
-      "rationale": "Client-side claude-code concern (terminal); not a gateway/relay relevance signal.",
-      "updated_at": "2026-06-01T22:45:40Z"
-    },
-    {
-      "upstream": "anthropics/claude-code#59967",
-      "url": "https://github.com/anthropics/claude-code/issues/59967",
-      "title": "[BUG] Cowork / Claude Desktop (Windows MSIX): VM service fails to start ~48 hours after MSIX re-registration; named pipe never created",
-      "impact": "not_applicable",
-      "categories": [
-        "terminal",
-        "install",
-        "platform"
-      ],
-      "tokenkey_status": "not_applicable",
-      "rationale": "Client-side claude-code concern (terminal, install, platform); not a gateway/relay relevance signal.",
-      "updated_at": "2026-06-01T22:45:42Z"
-    },
-    {
-      "upstream": "anthropics/claude-code#59968",
-      "url": "https://github.com/anthropics/claude-code/issues/59968",
-      "title": "[BUG] Skill tool invoked from sub-agent doesn't inherit parent's Agent tool grant — collapses multi-agent skills into single-context self-affirmation",
-      "impact": "not_applicable",
-      "categories": [
-        "mcp",
-        "plugin"
-      ],
-      "tokenkey_status": "not_applicable",
-      "rationale": "Client-side claude-code concern (mcp, plugin); not a gateway/relay relevance signal.",
-      "updated_at": "2026-06-01T22:45:43Z"
-    },
-    {
       "upstream": "anthropics/claude-code#59969",
       "url": "https://github.com/anthropics/claude-code/issues/59969",
       "title": "[BUG] /goal and /permissions report \"not available in this environment\" in Claude Desktop Code tab (macOS)",
@@ -11623,19 +11421,6 @@
       "tokenkey_status": "not_applicable",
       "rationale": "Client-side claude-code concern (terminal, slash_hook); not a gateway/relay relevance signal.",
       "updated_at": "2026-06-02T22:43:56Z"
-    },
-    {
-      "upstream": "anthropics/claude-code#59988",
-      "url": "https://github.com/anthropics/claude-code/issues/59988",
-      "title": "Chrome crashes on any page-interacting MCP op (navigate / get_page_text) against a SharePoint Online tenant",
-      "impact": "not_applicable",
-      "categories": [
-        "ide",
-        "mcp"
-      ],
-      "tokenkey_status": "not_applicable",
-      "rationale": "Client-side claude-code concern (ide, mcp); not a gateway/relay relevance signal.",
-      "updated_at": "2026-06-01T22:45:58Z"
     },
     {
       "upstream": "anthropics/claude-code#59990",
@@ -11653,20 +11438,6 @@
       "updated_at": "2026-06-02T22:44:01Z"
     },
     {
-      "upstream": "anthropics/claude-code#59995",
-      "url": "https://github.com/anthropics/claude-code/issues/59995",
-      "title": "[FEATURE] File drag-and-drop in CLI (Windows Terminal)",
-      "impact": "not_applicable",
-      "categories": [
-        "ide",
-        "terminal",
-        "platform"
-      ],
-      "tokenkey_status": "not_applicable",
-      "rationale": "Client-side claude-code concern (ide, terminal, platform); not a gateway/relay relevance signal.",
-      "updated_at": "2026-06-01T22:45:54Z"
-    },
-    {
       "upstream": "anthropics/claude-code#60002",
       "url": "https://github.com/anthropics/claude-code/issues/60002",
       "title": "VSCode extension: \"Unhandled case: [object Object]\" banner orphans response, leaves chat stuck at \"Thinking…\"",
@@ -11680,48 +11451,6 @@
       "tokenkey_status": "not_applicable",
       "rationale": "Client-side claude-code concern (ide, terminal, mcp, platform); not a gateway/relay relevance signal.",
       "updated_at": "2026-06-02T22:44:17Z"
-    },
-    {
-      "upstream": "anthropics/claude-code#60006",
-      "url": "https://github.com/anthropics/claude-code/issues/60006",
-      "title": "EEXIST: file already exists, mkdir '.claude' on Windows startup",
-      "impact": "not_applicable",
-      "categories": [
-        "install",
-        "platform"
-      ],
-      "tokenkey_status": "not_applicable",
-      "rationale": "Client-side claude-code concern (install, platform); not a gateway/relay relevance signal.",
-      "updated_at": "2026-06-01T22:46:00Z"
-    },
-    {
-      "upstream": "anthropics/claude-code#60008",
-      "url": "https://github.com/anthropics/claude-code/issues/60008",
-      "title": "[BUG] Persistent ENOENT mkdir error in local-agent-mode-sessions on Windows — non-recursive mkdir attempted with sibling .json file path",
-      "impact": "not_applicable",
-      "categories": [
-        "ide",
-        "terminal",
-        "install",
-        "platform"
-      ],
-      "tokenkey_status": "not_applicable",
-      "rationale": "Client-side claude-code concern (ide, terminal, install, platform); not a gateway/relay relevance signal.",
-      "updated_at": "2026-06-01T22:46:02Z"
-    },
-    {
-      "upstream": "anthropics/claude-code#60011",
-      "url": "https://github.com/anthropics/claude-code/issues/60011",
-      "title": "[BUG] Claude Code extension crashes with virtual filesystem repos (vscode-vfs://)",
-      "impact": "not_applicable",
-      "categories": [
-        "ide",
-        "terminal",
-        "platform"
-      ],
-      "tokenkey_status": "not_applicable",
-      "rationale": "Client-side claude-code concern (ide, terminal, platform); not a gateway/relay relevance signal.",
-      "updated_at": "2026-06-01T22:46:03Z"
     },
     {
       "upstream": "anthropics/claude-code#60012",
@@ -11751,19 +11480,6 @@
       "updated_at": "2026-06-04T11:07:17Z"
     },
     {
-      "upstream": "anthropics/claude-code#60018",
-      "url": "https://github.com/anthropics/claude-code/issues/60018",
-      "title": "[BUG] /rewind does nothing in Windows desktop app (version 1.7196.0.0)",
-      "impact": "not_applicable",
-      "categories": [
-        "terminal",
-        "platform"
-      ],
-      "tokenkey_status": "not_applicable",
-      "rationale": "Client-side claude-code concern (terminal, platform); not a gateway/relay relevance signal.",
-      "updated_at": "2026-06-01T22:46:06Z"
-    },
-    {
       "upstream": "anthropics/claude-code#60020",
       "url": "https://github.com/anthropics/claude-code/issues/60020",
       "title": "[FEATURE] VS Code extension panel should display current model name passively",
@@ -11776,45 +11492,6 @@
       "updated_at": "2026-06-02T11:32:14Z"
     },
     {
-      "upstream": "anthropics/claude-code#60023",
-      "url": "https://github.com/anthropics/claude-code/issues/60023",
-      "title": "[Bug] ripgrep default color output corrupts text, --color=never workaroundSorr",
-      "impact": "not_applicable",
-      "categories": [
-        "terminal"
-      ],
-      "tokenkey_status": "not_applicable",
-      "rationale": "Client-side claude-code concern (terminal); not a gateway/relay relevance signal.",
-      "updated_at": "2026-06-01T22:46:08Z"
-    },
-    {
-      "upstream": "anthropics/claude-code#60025",
-      "url": "https://github.com/anthropics/claude-code/issues/60025",
-      "title": "Claude Code 2.1.143 hangs during subprocess initialization with UNC additionalDirectory",
-      "impact": "not_applicable",
-      "categories": [
-        "ide",
-        "plugin",
-        "slash_hook",
-        "platform"
-      ],
-      "tokenkey_status": "not_applicable",
-      "rationale": "Client-side claude-code concern (ide, plugin, slash_hook, platform); not a gateway/relay relevance signal.",
-      "updated_at": "2026-06-01T22:46:10Z"
-    },
-    {
-      "upstream": "anthropics/claude-code#60029",
-      "url": "https://github.com/anthropics/claude-code/issues/60029",
-      "title": "[BUG] SANDBOX ERROR CODE ENOSPC: no space left on device,",
-      "impact": "not_applicable",
-      "categories": [
-        "terminal"
-      ],
-      "tokenkey_status": "not_applicable",
-      "rationale": "Client-side claude-code concern (terminal); not a gateway/relay relevance signal.",
-      "updated_at": "2026-06-01T22:46:12Z"
-    },
-    {
       "upstream": "anthropics/claude-code#60030",
       "url": "https://github.com/anthropics/claude-code/issues/60030",
       "title": "[FEATURE] Accessibility/Usability feature for vs code extention.",
@@ -11825,45 +11502,6 @@
       "tokenkey_status": "not_applicable",
       "rationale": "Client-side claude-code concern (ide); not a gateway/relay relevance signal.",
       "updated_at": "2026-06-02T11:32:09Z"
-    },
-    {
-      "upstream": "anthropics/claude-code#60032",
-      "url": "https://github.com/anthropics/claude-code/issues/60032",
-      "title": "[Bug] Unreliable vocabulary data generation without official source validation",
-      "impact": "not_applicable",
-      "categories": [
-        "terminal"
-      ],
-      "tokenkey_status": "not_applicable",
-      "rationale": "Client-side claude-code concern (terminal); not a gateway/relay relevance signal.",
-      "updated_at": "2026-06-01T22:46:14Z"
-    },
-    {
-      "upstream": "anthropics/claude-code#60036",
-      "url": "https://github.com/anthropics/claude-code/issues/60036",
-      "title": "[FEATURE] Add a preflight checklist item requiring confirmation that user PII has been scrubbed, in every issue template in this repo",
-      "impact": "not_applicable",
-      "categories": [
-        "terminal",
-        "slash_hook"
-      ],
-      "tokenkey_status": "not_applicable",
-      "rationale": "Client-side claude-code concern (terminal, slash_hook); not a gateway/relay relevance signal.",
-      "updated_at": "2026-06-01T22:46:20Z"
-    },
-    {
-      "upstream": "anthropics/claude-code#60040",
-      "url": "https://github.com/anthropics/claude-code/issues/60040",
-      "title": "[Bug] Claude ignores explicit instructions to avoid shortcuts despite custom hooks and memory configuration",
-      "impact": "not_applicable",
-      "categories": [
-        "ide",
-        "terminal",
-        "slash_hook"
-      ],
-      "tokenkey_status": "not_applicable",
-      "rationale": "Client-side claude-code concern (ide, terminal, slash_hook); not a gateway/relay relevance signal.",
-      "updated_at": "2026-06-01T22:46:16Z"
     },
     {
       "upstream": "anthropics/claude-code#60043",
@@ -11909,18 +11547,6 @@
       "tokenkey_status": "not_applicable",
       "rationale": "Client-side claude-code concern (ide, mcp, slash_hook); not a gateway/relay relevance signal.",
       "updated_at": "2026-06-02T22:44:23Z"
-    },
-    {
-      "upstream": "anthropics/claude-code#60047",
-      "url": "https://github.com/anthropics/claude-code/issues/60047",
-      "title": "[Bug] Context Limit Reached on Initial Message",
-      "impact": "not_applicable",
-      "categories": [
-        "terminal"
-      ],
-      "tokenkey_status": "not_applicable",
-      "rationale": "Client-side claude-code concern (terminal); not a gateway/relay relevance signal.",
-      "updated_at": "2026-06-01T22:46:19Z"
     },
     {
       "upstream": "anthropics/claude-code#60049",
@@ -12441,6 +12067,18 @@
       "updated_at": "2026-06-02T22:44:04Z"
     },
     {
+      "upstream": "anthropics/claude-code#60204",
+      "url": "https://github.com/anthropics/claude-code/issues/60204",
+      "title": "[Feature] MCP tool description deduplication for servers with identical schemas",
+      "impact": "not_applicable",
+      "categories": [
+        "mcp"
+      ],
+      "tokenkey_status": "not_applicable",
+      "rationale": "Client-side claude-code concern (mcp); not a gateway/relay relevance signal.",
+      "updated_at": "2026-06-04T22:33:00Z"
+    },
+    {
       "upstream": "anthropics/claude-code#60205",
       "url": "https://github.com/anthropics/claude-code/issues/60205",
       "title": "[FEATURE] Project-scoped skills in Cowork (parity with Claude Code's `.claude/skills/`)",
@@ -12514,6 +12152,20 @@
       "tokenkey_status": "not_applicable",
       "rationale": "Client-side claude-code concern (terminal, platform); not a gateway/relay relevance signal.",
       "updated_at": "2026-06-02T22:44:08Z"
+    },
+    {
+      "upstream": "anthropics/claude-code#60224",
+      "url": "https://github.com/anthropics/claude-code/issues/60224",
+      "title": "stdio MCP server tools dropped when initialize exceeds probe timeout",
+      "impact": "not_applicable",
+      "categories": [
+        "mcp",
+        "install",
+        "platform"
+      ],
+      "tokenkey_status": "not_applicable",
+      "rationale": "Client-side claude-code concern (mcp, install, platform); not a gateway/relay relevance signal.",
+      "updated_at": "2026-06-04T22:33:58Z"
     },
     {
       "upstream": "anthropics/claude-code#60227",
@@ -12607,19 +12259,6 @@
       "updated_at": "2026-06-03T11:39:30Z"
     },
     {
-      "upstream": "anthropics/claude-code#60246",
-      "url": "https://github.com/anthropics/claude-code/issues/60246",
-      "title": "[DOCS] governance and security guidance for MCP server adoption in teams",
-      "impact": "not_applicable",
-      "categories": [
-        "mcp",
-        "install"
-      ],
-      "tokenkey_status": "not_applicable",
-      "rationale": "Client-side claude-code concern (mcp, install); not a gateway/relay relevance signal.",
-      "updated_at": "2026-06-01T22:25:27Z"
-    },
-    {
       "upstream": "anthropics/claude-code#60253",
       "url": "https://github.com/anthropics/claude-code/issues/60253",
       "title": "System prompt advertises uninstallable Cowork skills as \"available\"",
@@ -12633,6 +12272,18 @@
       "tokenkey_status": "not_applicable",
       "rationale": "Client-side claude-code concern (plugin, slash_hook, install, platform); not a gateway/relay relevance signal.",
       "updated_at": "2026-06-02T22:44:19Z"
+    },
+    {
+      "upstream": "anthropics/claude-code#60256",
+      "url": "https://github.com/anthropics/claude-code/issues/60256",
+      "title": "[BUG] Postgres network egress blocked even with full network permissions",
+      "impact": "not_applicable",
+      "categories": [
+        "terminal"
+      ],
+      "tokenkey_status": "not_applicable",
+      "rationale": "Client-side claude-code concern (terminal); not a gateway/relay relevance signal.",
+      "updated_at": "2026-06-04T14:52:40Z"
     },
     {
       "upstream": "anthropics/claude-code#60259",
@@ -12846,6 +12497,22 @@
       "tokenkey_status": "not_applicable",
       "rationale": "Client-side claude-code concern (ide, slash_hook); not a gateway/relay relevance signal.",
       "updated_at": "2026-06-02T22:44:35Z"
+    },
+    {
+      "upstream": "anthropics/claude-code#60317",
+      "url": "https://github.com/anthropics/claude-code/issues/60317",
+      "title": "Stillborn sessions: 16-28 generic `internal_error` events at startup, no API call made (2.1.132 + 2.1.133)",
+      "impact": "not_applicable",
+      "categories": [
+        "terminal",
+        "mcp",
+        "plugin",
+        "slash_hook",
+        "install"
+      ],
+      "tokenkey_status": "not_applicable",
+      "rationale": "Client-side claude-code concern (terminal, mcp, plugin, slash_hook, install); not a gateway/relay relevance signal.",
+      "updated_at": "2026-06-04T22:33:16Z"
     },
     {
       "upstream": "anthropics/claude-code#60321",
@@ -13228,32 +12895,7 @@
       ],
       "tokenkey_status": "not_applicable",
       "rationale": "Client-side claude-code concern (plugin); not a gateway/relay relevance signal.",
-      "updated_at": "2026-06-04T11:06:52Z"
-    },
-    {
-      "upstream": "anthropics/claude-code#60402",
-      "url": "https://github.com/anthropics/claude-code/issues/60402",
-      "title": "[DOCS] `/plugin` discover flow docs omit the new last-updated metadata shown for plugins",
-      "impact": "not_applicable",
-      "categories": [
-        "plugin",
-        "install"
-      ],
-      "tokenkey_status": "not_applicable",
-      "rationale": "Client-side claude-code concern (plugin, install); not a gateway/relay relevance signal.",
-      "updated_at": "2026-06-04T11:06:53Z"
-    },
-    {
-      "upstream": "anthropics/claude-code#60404",
-      "url": "https://github.com/anthropics/claude-code/issues/60404",
-      "title": "[DOCS] Model configuration docs still say `/model` selections persist across restarts",
-      "impact": "not_applicable",
-      "categories": [
-        "slash_hook"
-      ],
-      "tokenkey_status": "not_applicable",
-      "rationale": "Client-side claude-code concern (slash_hook); not a gateway/relay relevance signal.",
-      "updated_at": "2026-06-04T11:06:54Z"
+      "updated_at": "2026-06-04T22:48:38Z"
     },
     {
       "upstream": "anthropics/claude-code#60405",
@@ -13265,7 +12907,7 @@
       ],
       "tokenkey_status": "not_applicable",
       "rationale": "Client-side claude-code concern (ide); not a gateway/relay relevance signal.",
-      "updated_at": "2026-06-03T22:45:06Z"
+      "updated_at": "2026-06-04T22:48:22Z"
     },
     {
       "upstream": "anthropics/claude-code#60408",
@@ -13278,33 +12920,7 @@
       ],
       "tokenkey_status": "not_applicable",
       "rationale": "Client-side claude-code concern (terminal, mcp); not a gateway/relay relevance signal.",
-      "updated_at": "2026-06-03T22:45:08Z"
-    },
-    {
-      "upstream": "anthropics/claude-code#60413",
-      "url": "https://github.com/anthropics/claude-code/issues/60413",
-      "title": "[DOCS] Agent view docs omit background shell-command rows and completed-row behavior",
-      "impact": "not_applicable",
-      "categories": [
-        "terminal"
-      ],
-      "tokenkey_status": "not_applicable",
-      "rationale": "Client-side claude-code concern (terminal); not a gateway/relay relevance signal.",
-      "updated_at": "2026-06-03T22:45:08Z"
-    },
-    {
-      "upstream": "anthropics/claude-code#60414",
-      "url": "https://github.com/anthropics/claude-code/issues/60414",
-      "title": "[DOCS] Agent view docs omit that `/bg` and `←` keep directories added with `/add-dir`",
-      "impact": "not_applicable",
-      "categories": [
-        "terminal",
-        "mcp",
-        "plugin"
-      ],
-      "tokenkey_status": "not_applicable",
-      "rationale": "Client-side claude-code concern (terminal, mcp, plugin); not a gateway/relay relevance signal.",
-      "updated_at": "2026-06-03T22:45:09Z"
+      "updated_at": "2026-06-04T22:41:50Z"
     },
     {
       "upstream": "anthropics/claude-code#60417",
@@ -13316,7 +12932,7 @@
       ],
       "tokenkey_status": "not_applicable",
       "rationale": "Client-side claude-code concern (terminal); not a gateway/relay relevance signal.",
-      "updated_at": "2026-06-03T22:45:09Z"
+      "updated_at": "2026-06-04T22:41:15Z"
     },
     {
       "upstream": "anthropics/claude-code#60419",
@@ -13328,7 +12944,20 @@
       ],
       "tokenkey_status": "not_applicable",
       "rationale": "Client-side claude-code concern (plugin); not a gateway/relay relevance signal.",
-      "updated_at": "2026-06-03T22:45:10Z"
+      "updated_at": "2026-06-04T22:42:14Z"
+    },
+    {
+      "upstream": "anthropics/claude-code#60422",
+      "url": "https://github.com/anthropics/claude-code/issues/60422",
+      "title": "[BUG] Billing API-default bug",
+      "impact": "not_applicable",
+      "categories": [
+        "ide",
+        "terminal"
+      ],
+      "tokenkey_status": "not_applicable",
+      "rationale": "Client-side claude-code concern (ide, terminal); not a gateway/relay relevance signal.",
+      "updated_at": "2026-06-04T22:33:23Z"
     },
     {
       "upstream": "anthropics/claude-code#60425",
@@ -13580,7 +13209,7 @@
       ],
       "tokenkey_status": "not_applicable",
       "rationale": "Client-side claude-code concern (terminal, platform); not a gateway/relay relevance signal.",
-      "updated_at": "2026-06-03T22:31:56Z"
+      "updated_at": "2026-06-04T19:38:08Z"
     },
     {
       "upstream": "anthropics/claude-code#60495",
@@ -13767,6 +13396,45 @@
       "updated_at": "2026-06-03T22:46:03Z"
     },
     {
+      "upstream": "anthropics/claude-code#60551",
+      "url": "https://github.com/anthropics/claude-code/issues/60551",
+      "title": "[FEATURE] Add keyboard shortcut to open session context menu (Archive/Delete) in Claude Desktop",
+      "impact": "not_applicable",
+      "categories": [
+        "terminal",
+        "slash_hook",
+        "platform"
+      ],
+      "tokenkey_status": "not_applicable",
+      "rationale": "Client-side claude-code concern (terminal, slash_hook, platform); not a gateway/relay relevance signal.",
+      "updated_at": "2026-06-04T22:33:35Z"
+    },
+    {
+      "upstream": "anthropics/claude-code#60552",
+      "url": "https://github.com/anthropics/claude-code/issues/60552",
+      "title": "[FEATURE] preview_start should detect actual server port from stdout instead of requiring static port config",
+      "impact": "not_applicable",
+      "categories": [
+        "install"
+      ],
+      "tokenkey_status": "not_applicable",
+      "rationale": "Client-side claude-code concern (install); not a gateway/relay relevance signal.",
+      "updated_at": "2026-06-04T22:32:57Z"
+    },
+    {
+      "upstream": "anthropics/claude-code#60553",
+      "url": "https://github.com/anthropics/claude-code/issues/60553",
+      "title": "[BUG] Scheduled task sidebar badge counts do not refresh after on-disk cleanup; require app restart",
+      "impact": "not_applicable",
+      "categories": [
+        "terminal",
+        "slash_hook"
+      ],
+      "tokenkey_status": "not_applicable",
+      "rationale": "Client-side claude-code concern (terminal, slash_hook); not a gateway/relay relevance signal.",
+      "updated_at": "2026-06-04T22:32:58Z"
+    },
+    {
       "upstream": "anthropics/claude-code#60555",
       "url": "https://github.com/anthropics/claude-code/issues/60555",
       "title": "[FEATURE] ToolBuild hooks: Pre & Post",
@@ -13777,6 +13445,44 @@
       "tokenkey_status": "not_applicable",
       "rationale": "Client-side claude-code concern (mcp); not a gateway/relay relevance signal.",
       "updated_at": "2026-06-04T11:06:57Z"
+    },
+    {
+      "upstream": "anthropics/claude-code#60561",
+      "url": "https://github.com/anthropics/claude-code/issues/60561",
+      "title": "CLAUDE_CODE_PROJECT_DIR env var silently ignored — session JSONL still writes to in-tree .claude/projects/ (CLI 2.1.144, Windows)",
+      "impact": "not_applicable",
+      "categories": [
+        "install",
+        "platform"
+      ],
+      "tokenkey_status": "not_applicable",
+      "rationale": "Client-side claude-code concern (install, platform); not a gateway/relay relevance signal.",
+      "updated_at": "2026-06-04T22:33:03Z"
+    },
+    {
+      "upstream": "anthropics/claude-code#60565",
+      "url": "https://github.com/anthropics/claude-code/issues/60565",
+      "title": "Voice input produces large whitespace gaps in transcribed text",
+      "impact": "not_applicable",
+      "categories": [
+        "terminal",
+        "platform"
+      ],
+      "tokenkey_status": "not_applicable",
+      "rationale": "Client-side claude-code concern (terminal, platform); not a gateway/relay relevance signal.",
+      "updated_at": "2026-06-04T22:33:03Z"
+    },
+    {
+      "upstream": "anthropics/claude-code#60568",
+      "url": "https://github.com/anthropics/claude-code/issues/60568",
+      "title": "Remote Control: sessionTimeoutSeconds schema field is unwired (no CLI flag, no env var, no consumer)",
+      "impact": "not_applicable",
+      "categories": [
+        "install"
+      ],
+      "tokenkey_status": "not_applicable",
+      "rationale": "Client-side claude-code concern (install); not a gateway/relay relevance signal.",
+      "updated_at": "2026-06-04T22:33:04Z"
     },
     {
       "upstream": "anthropics/claude-code#60569",
@@ -13831,6 +13537,18 @@
       "tokenkey_status": "not_applicable",
       "rationale": "Client-side claude-code concern (ide, terminal, install, platform); not a gateway/relay relevance signal.",
       "updated_at": "2026-06-04T11:07:18Z"
+    },
+    {
+      "upstream": "anthropics/claude-code#60594",
+      "url": "https://github.com/anthropics/claude-code/issues/60594",
+      "title": "[FEATURE] /resume should work for compacted conversations",
+      "impact": "not_applicable",
+      "categories": [
+        "plugin"
+      ],
+      "tokenkey_status": "not_applicable",
+      "rationale": "Client-side claude-code concern (plugin); not a gateway/relay relevance signal.",
+      "updated_at": "2026-06-04T22:33:51Z"
     },
     {
       "upstream": "anthropics/claude-code#60599",
@@ -13999,7 +13717,7 @@
       ],
       "tokenkey_status": "not_applicable",
       "rationale": "Client-side claude-code concern (terminal, mcp, slash_hook, install); not a gateway/relay relevance signal.",
-      "updated_at": "2026-06-04T11:07:38Z"
+      "updated_at": "2026-06-04T13:28:26Z"
     },
     {
       "upstream": "anthropics/claude-code#60654",
@@ -14079,7 +13797,7 @@
       ],
       "tokenkey_status": "not_applicable",
       "rationale": "Client-side claude-code concern (ide, mcp, slash_hook, platform); not a gateway/relay relevance signal.",
-      "updated_at": "2026-06-04T11:07:51Z"
+      "updated_at": "2026-06-04T13:47:43Z"
     },
     {
       "upstream": "anthropics/claude-code#60680",
@@ -14107,18 +13825,6 @@
       "updated_at": "2026-06-04T11:07:54Z"
     },
     {
-      "upstream": "anthropics/claude-code#60690",
-      "url": "https://github.com/anthropics/claude-code/issues/60690",
-      "title": "[DOCS] Agent view docs omit the awaiting-input count in the `claude agents` terminal tab title",
-      "impact": "not_applicable",
-      "categories": [
-        "terminal"
-      ],
-      "tokenkey_status": "not_applicable",
-      "rationale": "Client-side claude-code concern (terminal); not a gateway/relay relevance signal.",
-      "updated_at": "2026-06-04T11:07:54Z"
-    },
-    {
       "upstream": "anthropics/claude-code#60691",
       "url": "https://github.com/anthropics/claude-code/issues/60691",
       "title": "[DOCS] Fullscreen docs omit mouse hover/click behavior for slash command and @-mention suggestion lists",
@@ -14130,7 +13836,7 @@
       ],
       "tokenkey_status": "not_applicable",
       "rationale": "Client-side claude-code concern (terminal, plugin, slash_hook); not a gateway/relay relevance signal.",
-      "updated_at": "2026-06-04T11:07:55Z"
+      "updated_at": "2026-06-04T22:41:49Z"
     },
     {
       "upstream": "anthropics/claude-code#60692",
@@ -14143,7 +13849,7 @@
       ],
       "tokenkey_status": "not_applicable",
       "rationale": "Client-side claude-code concern (plugin, slash_hook); not a gateway/relay relevance signal.",
-      "updated_at": "2026-06-04T11:07:56Z"
+      "updated_at": "2026-06-04T22:41:16Z"
     },
     {
       "upstream": "anthropics/claude-code#60693",
@@ -14155,7 +13861,31 @@
       ],
       "tokenkey_status": "not_applicable",
       "rationale": "Client-side claude-code concern (terminal); not a gateway/relay relevance signal.",
-      "updated_at": "2026-06-04T11:07:56Z"
+      "updated_at": "2026-06-04T22:42:35Z"
+    },
+    {
+      "upstream": "anthropics/claude-code#60700",
+      "url": "https://github.com/anthropics/claude-code/issues/60700",
+      "title": "Need: pre-output / pre-transmission scan layer",
+      "impact": "not_applicable",
+      "categories": [
+        "slash_hook"
+      ],
+      "tokenkey_status": "not_applicable",
+      "rationale": "Client-side claude-code concern (slash_hook); not a gateway/relay relevance signal.",
+      "updated_at": "2026-06-04T22:33:05Z"
+    },
+    {
+      "upstream": "anthropics/claude-code#60708",
+      "url": "https://github.com/anthropics/claude-code/issues/60708",
+      "title": "You've hit your session limit · resets 1pm (Australia/Brisbane)",
+      "impact": "not_applicable",
+      "categories": [
+        "terminal"
+      ],
+      "tokenkey_status": "not_applicable",
+      "rationale": "Client-side claude-code concern (terminal); not a gateway/relay relevance signal.",
+      "updated_at": "2026-06-04T22:33:10Z"
     },
     {
       "upstream": "anthropics/claude-code#60711",
@@ -14170,6 +13900,183 @@
       "updated_at": "2026-06-02T15:01:18Z"
     },
     {
+      "upstream": "anthropics/claude-code#60714",
+      "url": "https://github.com/anthropics/claude-code/issues/60714",
+      "title": "[Feature Request] Support advisor location in parent directory for nested projects",
+      "impact": "not_applicable",
+      "categories": [
+        "terminal"
+      ],
+      "tokenkey_status": "not_applicable",
+      "rationale": "Client-side claude-code concern (terminal); not a gateway/relay relevance signal.",
+      "updated_at": "2026-06-04T22:33:10Z"
+    },
+    {
+      "upstream": "anthropics/claude-code#60717",
+      "url": "https://github.com/anthropics/claude-code/issues/60717",
+      "title": "Session summaries claim 'code committed' when git commit/push never ran — misleads users across context boundaries",
+      "impact": "not_applicable",
+      "categories": [
+        "ide"
+      ],
+      "tokenkey_status": "not_applicable",
+      "rationale": "Client-side claude-code concern (ide); not a gateway/relay relevance signal.",
+      "updated_at": "2026-06-04T22:33:14Z"
+    },
+    {
+      "upstream": "anthropics/claude-code#60719",
+      "url": "https://github.com/anthropics/claude-code/issues/60719",
+      "title": "[Bug] File clobbering during Write tool operations with /fast mode",
+      "impact": "not_applicable",
+      "categories": [
+        "terminal"
+      ],
+      "tokenkey_status": "not_applicable",
+      "rationale": "Client-side claude-code concern (terminal); not a gateway/relay relevance signal.",
+      "updated_at": "2026-06-04T22:33:18Z"
+    },
+    {
+      "upstream": "anthropics/claude-code#60729",
+      "url": "https://github.com/anthropics/claude-code/issues/60729",
+      "title": "VSCode plugin + CLI sharing ~/.claude/settings.json causes failures on Windows",
+      "impact": "not_applicable",
+      "categories": [
+        "ide",
+        "terminal",
+        "plugin",
+        "slash_hook",
+        "install",
+        "platform"
+      ],
+      "tokenkey_status": "not_applicable",
+      "rationale": "Client-side claude-code concern (ide, terminal, plugin, slash_hook, install, platform); not a gateway/relay relevance signal.",
+      "updated_at": "2026-06-04T22:33:18Z"
+    },
+    {
+      "upstream": "anthropics/claude-code#60734",
+      "url": "https://github.com/anthropics/claude-code/issues/60734",
+      "title": "[BUG]",
+      "impact": "not_applicable",
+      "categories": [
+        "terminal",
+        "platform"
+      ],
+      "tokenkey_status": "not_applicable",
+      "rationale": "Client-side claude-code concern (terminal, platform); not a gateway/relay relevance signal.",
+      "updated_at": "2026-06-04T22:33:21Z"
+    },
+    {
+      "upstream": "anthropics/claude-code#60735",
+      "url": "https://github.com/anthropics/claude-code/issues/60735",
+      "title": "[BUG] Constant lying- when WILL IT END!!??",
+      "impact": "not_applicable",
+      "categories": [
+        "ide",
+        "terminal",
+        "plugin",
+        "slash_hook",
+        "platform"
+      ],
+      "tokenkey_status": "not_applicable",
+      "rationale": "Client-side claude-code concern (ide, terminal, plugin, slash_hook, platform); not a gateway/relay relevance signal.",
+      "updated_at": "2026-06-04T22:33:22Z"
+    },
+    {
+      "upstream": "anthropics/claude-code#60746",
+      "url": "https://github.com/anthropics/claude-code/issues/60746",
+      "title": "[BUG] Hook executor silent fail in v2.1.x — mid-session hooks never invoked despite registration",
+      "impact": "not_applicable",
+      "categories": [
+        "ide",
+        "terminal",
+        "plugin",
+        "slash_hook",
+        "install",
+        "platform"
+      ],
+      "tokenkey_status": "not_applicable",
+      "rationale": "Client-side claude-code concern (ide, terminal, plugin, slash_hook, install, platform); not a gateway/relay relevance signal.",
+      "updated_at": "2026-06-04T22:33:29Z"
+    },
+    {
+      "upstream": "anthropics/claude-code#60748",
+      "url": "https://github.com/anthropics/claude-code/issues/60748",
+      "title": "[BUG] Cowork Crashing!",
+      "impact": "not_applicable",
+      "categories": [
+        "terminal"
+      ],
+      "tokenkey_status": "not_applicable",
+      "rationale": "Client-side claude-code concern (terminal); not a gateway/relay relevance signal.",
+      "updated_at": "2026-06-04T22:33:25Z"
+    },
+    {
+      "upstream": "anthropics/claude-code#60749",
+      "url": "https://github.com/anthropics/claude-code/issues/60749",
+      "title": "claude.exe ugrep subprocess wedges holding 6-9 GB RAM; parent does not SIGKILL on timeout",
+      "impact": "not_applicable",
+      "categories": [
+        "terminal",
+        "mcp",
+        "install"
+      ],
+      "tokenkey_status": "not_applicable",
+      "rationale": "Client-side claude-code concern (terminal, mcp, install); not a gateway/relay relevance signal.",
+      "updated_at": "2026-06-04T22:33:30Z"
+    },
+    {
+      "upstream": "anthropics/claude-code#60750",
+      "url": "https://github.com/anthropics/claude-code/issues/60750",
+      "title": "[BUG] Claude Code version 2.1.139 indicate malware",
+      "impact": "not_applicable",
+      "categories": [
+        "terminal"
+      ],
+      "tokenkey_status": "not_applicable",
+      "rationale": "Client-side claude-code concern (terminal); not a gateway/relay relevance signal.",
+      "updated_at": "2026-06-04T22:33:25Z"
+    },
+    {
+      "upstream": "anthropics/claude-code#60752",
+      "url": "https://github.com/anthropics/claude-code/issues/60752",
+      "title": "[BUG] Sandbox write allowlist does not match filenames containing .. (e.g. advisory-db..lock)",
+      "impact": "not_applicable",
+      "categories": [
+        "ide",
+        "terminal",
+        "plugin",
+        "slash_hook"
+      ],
+      "tokenkey_status": "not_applicable",
+      "rationale": "Client-side claude-code concern (ide, terminal, plugin, slash_hook); not a gateway/relay relevance signal.",
+      "updated_at": "2026-06-04T22:33:28Z"
+    },
+    {
+      "upstream": "anthropics/claude-code#60756",
+      "url": "https://github.com/anthropics/claude-code/issues/60756",
+      "title": "C:/Program Files/Git/quit prints session ID for a session file that was never written (WSL + Windows path interop)",
+      "impact": "not_applicable",
+      "categories": [
+        "terminal",
+        "platform"
+      ],
+      "tokenkey_status": "not_applicable",
+      "rationale": "Client-side claude-code concern (terminal, platform); not a gateway/relay relevance signal.",
+      "updated_at": "2026-06-04T22:33:27Z"
+    },
+    {
+      "upstream": "anthropics/claude-code#60760",
+      "url": "https://github.com/anthropics/claude-code/issues/60760",
+      "title": "[Bug] Session usage quota consumed disproportionately on minimal Sonnet interactions",
+      "impact": "not_applicable",
+      "categories": [
+        "terminal"
+      ],
+      "tokenkey_status": "not_applicable",
+      "rationale": "Client-side claude-code concern (terminal); not a gateway/relay relevance signal.",
+      "updated_at": "2026-06-04T22:33:31Z"
+    },
+    {
       "upstream": "anthropics/claude-code#60763",
       "url": "https://github.com/anthropics/claude-code/issues/60763",
       "title": "[FEATURE] Subagents have no Agent/Task tool — recursive/nested subagent dispatch impossible",
@@ -14182,9 +14089,9 @@
       "updated_at": "2026-06-03T18:42:38Z"
     },
     {
-      "upstream": "anthropics/claude-code#60844",
-      "url": "https://github.com/anthropics/claude-code/issues/60844",
-      "title": "[Feature Request] Add NotebookRead tool for efficient Jupyter notebook cell extraction",
+      "upstream": "anthropics/claude-code#60765",
+      "url": "https://github.com/anthropics/claude-code/issues/60765",
+      "title": "[Bug] Terminal display corruption after Shopify CLI usage with non-ASCII character rendering",
       "impact": "not_applicable",
       "categories": [
         "ide",
@@ -14192,7 +14099,160 @@
       ],
       "tokenkey_status": "not_applicable",
       "rationale": "Client-side claude-code concern (ide, terminal); not a gateway/relay relevance signal.",
-      "updated_at": "2026-06-01T16:41:55Z"
+      "updated_at": "2026-06-04T22:33:32Z"
+    },
+    {
+      "upstream": "anthropics/claude-code#60769",
+      "url": "https://github.com/anthropics/claude-code/issues/60769",
+      "title": "Re-attaching to existing session ENOENTs after Homebrew Cask upgrade (stale versioned worker path)",
+      "impact": "not_applicable",
+      "categories": [
+        "install"
+      ],
+      "tokenkey_status": "not_applicable",
+      "rationale": "Client-side claude-code concern (install); not a gateway/relay relevance signal.",
+      "updated_at": "2026-06-04T17:08:41Z"
+    },
+    {
+      "upstream": "anthropics/claude-code#60772",
+      "url": "https://github.com/anthropics/claude-code/issues/60772",
+      "title": "[BUG] `autoUpdate: true` on git-sourced marketplace does not `git pull` the clone — silent across quit/relaunch (2.1.139)",
+      "impact": "not_applicable",
+      "categories": [
+        "terminal",
+        "plugin",
+        "install"
+      ],
+      "tokenkey_status": "not_applicable",
+      "rationale": "Client-side claude-code concern (terminal, plugin, install); not a gateway/relay relevance signal.",
+      "updated_at": "2026-06-04T22:33:44Z"
+    },
+    {
+      "upstream": "anthropics/claude-code#60781",
+      "url": "https://github.com/anthropics/claude-code/issues/60781",
+      "title": "C:/Program Files/Git/goal (and slash commands) pasted from mobile do not execute — requires follow-up prompt to fire",
+      "impact": "not_applicable",
+      "categories": [
+        "slash_hook"
+      ],
+      "tokenkey_status": "not_applicable",
+      "rationale": "Client-side claude-code concern (slash_hook); not a gateway/relay relevance signal.",
+      "updated_at": "2026-06-04T22:33:39Z"
+    },
+    {
+      "upstream": "anthropics/claude-code#60786",
+      "url": "https://github.com/anthropics/claude-code/issues/60786",
+      "title": "Feature request: configurable colour for user input in conversation display",
+      "impact": "not_applicable",
+      "categories": [
+        "terminal",
+        "slash_hook"
+      ],
+      "tokenkey_status": "not_applicable",
+      "rationale": "Client-side claude-code concern (terminal, slash_hook); not a gateway/relay relevance signal.",
+      "updated_at": "2026-06-04T22:34:00Z"
+    },
+    {
+      "upstream": "anthropics/claude-code#60797",
+      "url": "https://github.com/anthropics/claude-code/issues/60797",
+      "title": "VS Code extension — expose open tab list for multi-file context awareness",
+      "impact": "not_applicable",
+      "categories": [
+        "ide"
+      ],
+      "tokenkey_status": "not_applicable",
+      "rationale": "Client-side claude-code concern (ide); not a gateway/relay relevance signal.",
+      "updated_at": "2026-06-04T22:33:46Z"
+    },
+    {
+      "upstream": "anthropics/claude-code#60803",
+      "url": "https://github.com/anthropics/claude-code/issues/60803",
+      "title": "Explore subagent hallucinates \"respond text-only\" instructions from non-existent prior messages, refuses tools",
+      "impact": "not_applicable",
+      "categories": [
+        "plugin",
+        "slash_hook",
+        "install",
+        "platform"
+      ],
+      "tokenkey_status": "not_applicable",
+      "rationale": "Client-side claude-code concern (plugin, slash_hook, install, platform); not a gateway/relay relevance signal.",
+      "updated_at": "2026-06-04T22:33:51Z"
+    },
+    {
+      "upstream": "anthropics/claude-code#60805",
+      "url": "https://github.com/anthropics/claude-code/issues/60805",
+      "title": "[FEATURE] Chat-Titel in der Sprache des Gesprächs (Claude Code)",
+      "impact": "not_applicable",
+      "categories": [
+        "terminal"
+      ],
+      "tokenkey_status": "not_applicable",
+      "rationale": "Client-side claude-code concern (terminal); not a gateway/relay relevance signal.",
+      "updated_at": "2026-06-04T22:33:50Z"
+    },
+    {
+      "upstream": "anthropics/claude-code#60810",
+      "url": "https://github.com/anthropics/claude-code/issues/60810",
+      "title": "Support image viewing capability (view_image tool) like GitHub Copilot",
+      "impact": "not_applicable",
+      "categories": [
+        "ide"
+      ],
+      "tokenkey_status": "not_applicable",
+      "rationale": "Client-side claude-code concern (ide); not a gateway/relay relevance signal.",
+      "updated_at": "2026-06-04T22:33:52Z"
+    },
+    {
+      "upstream": "anthropics/claude-code#60816",
+      "url": "https://github.com/anthropics/claude-code/issues/60816",
+      "title": "[BUG] Claude Code is not working on the desktop app. It's working on the website and through VS Code, but it just won't work on the desktop app of Claude. It's been stuck for 3 days.",
+      "impact": "not_applicable",
+      "categories": [
+        "ide",
+        "terminal"
+      ],
+      "tokenkey_status": "not_applicable",
+      "rationale": "Client-side claude-code concern (ide, terminal); not a gateway/relay relevance signal.",
+      "updated_at": "2026-06-04T22:33:57Z"
+    },
+    {
+      "upstream": "anthropics/claude-code#60817",
+      "url": "https://github.com/anthropics/claude-code/issues/60817",
+      "title": "Routines stuck at \"Setting up a cloud container\" — never execute",
+      "impact": "not_applicable",
+      "categories": [
+        "terminal"
+      ],
+      "tokenkey_status": "not_applicable",
+      "rationale": "Client-side claude-code concern (terminal); not a gateway/relay relevance signal.",
+      "updated_at": "2026-06-04T22:33:56Z"
+    },
+    {
+      "upstream": "anthropics/claude-code#60819",
+      "url": "https://github.com/anthropics/claude-code/issues/60819",
+      "title": "[FEATURE] CI monitor: surface branch-out-of-date (BEHIND) alongside failing checks",
+      "impact": "not_applicable",
+      "categories": [
+        "terminal",
+        "slash_hook"
+      ],
+      "tokenkey_status": "not_applicable",
+      "rationale": "Client-side claude-code concern (terminal, slash_hook); not a gateway/relay relevance signal.",
+      "updated_at": "2026-06-04T22:33:58Z"
+    },
+    {
+      "upstream": "anthropics/claude-code#60823",
+      "url": "https://github.com/anthropics/claude-code/issues/60823",
+      "title": "VS Code extension: strip trailing newline when copying fenced code blocks (or make it configurable)",
+      "impact": "not_applicable",
+      "categories": [
+        "ide",
+        "terminal"
+      ],
+      "tokenkey_status": "not_applicable",
+      "rationale": "Client-side claude-code concern (ide, terminal); not a gateway/relay relevance signal.",
+      "updated_at": "2026-06-04T22:34:00Z"
     },
     {
       "upstream": "anthropics/claude-code#60875",
@@ -14316,45 +14376,6 @@
       "updated_at": "2026-06-03T08:56:52Z"
     },
     {
-      "upstream": "anthropics/claude-code#61559",
-      "url": "https://github.com/anthropics/claude-code/issues/61559",
-      "title": "Claude Desktop Cowork is failing to start a workspace on Windows.",
-      "impact": "not_applicable",
-      "categories": [
-        "terminal",
-        "install",
-        "platform"
-      ],
-      "tokenkey_status": "not_applicable",
-      "rationale": "Client-side claude-code concern (terminal, install, platform); not a gateway/relay relevance signal.",
-      "updated_at": "2026-06-01T18:54:17Z"
-    },
-    {
-      "upstream": "anthropics/claude-code#61582",
-      "url": "https://github.com/anthropics/claude-code/issues/61582",
-      "title": "[BUG] \"Relaunch to update\" applies the update immediately, with no changelog, no confirmation, and no option to defer",
-      "impact": "not_applicable",
-      "categories": [
-        "terminal"
-      ],
-      "tokenkey_status": "not_applicable",
-      "rationale": "Client-side claude-code concern (terminal); not a gateway/relay relevance signal.",
-      "updated_at": "2026-06-01T20:15:48Z"
-    },
-    {
-      "upstream": "anthropics/claude-code#61591",
-      "url": "https://github.com/anthropics/claude-code/issues/61591",
-      "title": "[DOCS] /usage docs omit the current limits-usage breakdown categories",
-      "impact": "not_applicable",
-      "categories": [
-        "mcp",
-        "plugin"
-      ],
-      "tokenkey_status": "not_applicable",
-      "rationale": "Client-side claude-code concern (mcp, plugin); not a gateway/relay relevance signal.",
-      "updated_at": "2026-06-01T17:49:07Z"
-    },
-    {
       "upstream": "anthropics/claude-code#61609",
       "url": "https://github.com/anthropics/claude-code/issues/61609",
       "title": "[BUG] Image paste (Ctrl+V) does not work in native WSL2 terminal on Windows 11",
@@ -14367,6 +14388,19 @@
       "tokenkey_status": "not_applicable",
       "rationale": "Client-side claude-code concern (ide, terminal, platform); not a gateway/relay relevance signal.",
       "updated_at": "2026-06-03T01:20:46Z"
+    },
+    {
+      "upstream": "anthropics/claude-code#61673",
+      "url": "https://github.com/anthropics/claude-code/issues/61673",
+      "title": "Bug: Desktop app shows \"Usage Limit Reached\" incorrectly",
+      "impact": "not_applicable",
+      "categories": [
+        "terminal",
+        "platform"
+      ],
+      "tokenkey_status": "not_applicable",
+      "rationale": "Client-side claude-code concern (terminal, platform); not a gateway/relay relevance signal.",
+      "updated_at": "2026-06-04T20:00:39Z"
     },
     {
       "upstream": "anthropics/claude-code#61682",
@@ -14395,22 +14429,6 @@
       "updated_at": "2026-06-03T18:54:45Z"
     },
     {
-      "upstream": "anthropics/claude-code#61807",
-      "url": "https://github.com/anthropics/claude-code/issues/61807",
-      "title": "[BUG] \"Install JetBrains plugin\" suggestion appears even when plugin is already installed",
-      "impact": "not_applicable",
-      "categories": [
-        "ide",
-        "terminal",
-        "plugin",
-        "install",
-        "platform"
-      ],
-      "tokenkey_status": "not_applicable",
-      "rationale": "Client-side claude-code concern (ide, terminal, plugin, install, platform); not a gateway/relay relevance signal.",
-      "updated_at": "2026-06-01T22:31:04Z"
-    },
-    {
       "upstream": "anthropics/claude-code#61927",
       "url": "https://github.com/anthropics/claude-code/issues/61927",
       "title": "[BUG] \"Pull request status couldn't be checked\" banner persistently appears on every session in worktree branches without an associated PR",
@@ -14433,35 +14451,22 @@
       ],
       "tokenkey_status": "not_applicable",
       "rationale": "Client-side claude-code concern (terminal); not a gateway/relay relevance signal.",
-      "updated_at": "2026-06-03T05:25:18Z"
+      "updated_at": "2026-06-04T21:46:56Z"
     },
     {
-      "upstream": "anthropics/claude-code#62052",
-      "url": "https://github.com/anthropics/claude-code/issues/62052",
-      "title": "Misleading \"Usage limit reached\" error when selecting Sonnet — actually a 1M context tier gate",
-      "impact": "not_applicable",
-      "categories": [
-        "terminal",
-        "platform"
-      ],
-      "tokenkey_status": "not_applicable",
-      "rationale": "Client-side claude-code concern (terminal, platform); not a gateway/relay relevance signal.",
-      "updated_at": "2026-06-01T16:35:13Z"
-    },
-    {
-      "upstream": "anthropics/claude-code#62072",
-      "url": "https://github.com/anthropics/claude-code/issues/62072",
-      "title": "[BUG] Cowork on macOS 1.8555.2 — zero MCP tools bind in any install path (.mcpb + SDK bridge + Custom Connectors + project .mcp.json); spawn pipeline missing --mcp-config since 2026-05-23 auto-update",
+      "upstream": "anthropics/claude-code#62012",
+      "url": "https://github.com/anthropics/claude-code/issues/62012",
+      "title": "[BUG] JetBrains lockfile with `runningInWindows: true` and `/mnt/<drive>/` path fails cwd match on Windows CLI",
       "impact": "not_applicable",
       "categories": [
         "ide",
-        "mcp",
+        "terminal",
         "plugin",
-        "install"
+        "platform"
       ],
       "tokenkey_status": "not_applicable",
-      "rationale": "Client-side claude-code concern (ide, mcp, plugin, install); not a gateway/relay relevance signal.",
-      "updated_at": "2026-06-01T18:58:46Z"
+      "rationale": "Client-side claude-code concern (ide, terminal, plugin, platform); not a gateway/relay relevance signal.",
+      "updated_at": "2026-06-04T22:47:09Z"
     },
     {
       "upstream": "anthropics/claude-code#62086",
@@ -14505,6 +14510,20 @@
       "updated_at": "2026-06-02T04:19:00Z"
     },
     {
+      "upstream": "anthropics/claude-code#62175",
+      "url": "https://github.com/anthropics/claude-code/issues/62175",
+      "title": "[BUG] claude.ai chat: 'Load tools when needed' setting doesn't actually defer connector schemas — context limit exceeded at ~11 connectors before first message",
+      "impact": "not_applicable",
+      "categories": [
+        "terminal",
+        "mcp",
+        "plugin"
+      ],
+      "tokenkey_status": "not_applicable",
+      "rationale": "Client-side claude-code concern (terminal, mcp, plugin); not a gateway/relay relevance signal.",
+      "updated_at": "2026-06-04T22:46:23Z"
+    },
+    {
       "upstream": "anthropics/claude-code#62180",
       "url": "https://github.com/anthropics/claude-code/issues/62180",
       "title": "[FEATURE] Cursor-style inline edit popup (Ctrl+K) for VS Code Claude extension",
@@ -14543,7 +14562,7 @@
       ],
       "tokenkey_status": "not_applicable",
       "rationale": "Client-side claude-code concern (ide, terminal, slash_hook, platform); not a gateway/relay relevance signal.",
-      "updated_at": "2026-06-04T11:47:15Z"
+      "updated_at": "2026-06-04T15:58:10Z"
     },
     {
       "upstream": "anthropics/claude-code#62212",
@@ -14641,6 +14660,20 @@
       "updated_at": "2026-06-02T07:42:16Z"
     },
     {
+      "upstream": "anthropics/claude-code#62362",
+      "url": "https://github.com/anthropics/claude-code/issues/62362",
+      "title": "AskUserQuestion: no way to view truncated preview content (\"X lines hidden\")",
+      "impact": "not_applicable",
+      "categories": [
+        "ide",
+        "terminal",
+        "slash_hook"
+      ],
+      "tokenkey_status": "not_applicable",
+      "rationale": "Client-side claude-code concern (ide, terminal, slash_hook); not a gateway/relay relevance signal.",
+      "updated_at": "2026-06-04T15:01:49Z"
+    },
+    {
       "upstream": "anthropics/claude-code#62454",
       "url": "https://github.com/anthropics/claude-code/issues/62454",
       "title": "[FEATURE] Always-visible / always-expanded tool call output in VS Code extension",
@@ -14655,6 +14688,19 @@
       "updated_at": "2026-06-03T09:40:48Z"
     },
     {
+      "upstream": "anthropics/claude-code#62462",
+      "url": "https://github.com/anthropics/claude-code/issues/62462",
+      "title": "Cannot copy text from Claude responses in interactive TUI (GNOME Terminal, Ubuntu 24.04)",
+      "impact": "not_applicable",
+      "categories": [
+        "terminal",
+        "slash_hook"
+      ],
+      "tokenkey_status": "not_applicable",
+      "rationale": "Client-side claude-code concern (terminal, slash_hook); not a gateway/relay relevance signal.",
+      "updated_at": "2026-06-04T20:05:37Z"
+    },
+    {
       "upstream": "anthropics/claude-code#62466",
       "url": "https://github.com/anthropics/claude-code/issues/62466",
       "title": "[BUG] Repeated \"Image couldn't be processed\" API errors consuming usage limit in Claude Code",
@@ -14664,7 +14710,7 @@
       ],
       "tokenkey_status": "not_applicable",
       "rationale": "Client-side claude-code concern (terminal); not a gateway/relay relevance signal.",
-      "updated_at": "2026-06-03T18:51:49Z"
+      "updated_at": "2026-06-04T16:17:45Z"
     },
     {
       "upstream": "anthropics/claude-code#62476",
@@ -14705,6 +14751,18 @@
       "updated_at": "2026-06-03T20:57:51Z"
     },
     {
+      "upstream": "anthropics/claude-code#62602",
+      "url": "https://github.com/anthropics/claude-code/issues/62602",
+      "title": "[FEATURE] Limited edit choices cause all or none approval decisions",
+      "impact": "not_applicable",
+      "categories": [
+        "terminal"
+      ],
+      "tokenkey_status": "not_applicable",
+      "rationale": "Client-side claude-code concern (terminal); not a gateway/relay relevance signal.",
+      "updated_at": "2026-06-04T16:17:55Z"
+    },
+    {
       "upstream": "anthropics/claude-code#62619",
       "url": "https://github.com/anthropics/claude-code/issues/62619",
       "title": "[BUG] False positive \"Usage Policy violation\" errors on normal coding requests",
@@ -14731,19 +14789,6 @@
       "updated_at": "2026-06-02T08:01:29Z"
     },
     {
-      "upstream": "anthropics/claude-code#62631",
-      "url": "https://github.com/anthropics/claude-code/issues/62631",
-      "title": "Inter-session coordination: wake / notify a parent session on child (sub-session) turn-end or idle",
-      "impact": "not_applicable",
-      "categories": [
-        "plugin",
-        "platform"
-      ],
-      "tokenkey_status": "not_applicable",
-      "rationale": "Client-side claude-code concern (plugin, platform); not a gateway/relay relevance signal.",
-      "updated_at": "2026-06-01T16:43:26Z"
-    },
-    {
       "upstream": "anthropics/claude-code#62659",
       "url": "https://github.com/anthropics/claude-code/issues/62659",
       "title": "[BUG] Windows: Bash tool (grand)children survive command completion/kill as unkillable orphans — no per-command Job Object, and `SILENT_BREAKAWAY_OK` defeats the one that exists",
@@ -14758,19 +14803,6 @@
       "tokenkey_status": "not_applicable",
       "rationale": "Client-side claude-code concern (terminal, mcp, plugin, install, platform); not a gateway/relay relevance signal.",
       "updated_at": "2026-06-01T23:49:55Z"
-    },
-    {
-      "upstream": "anthropics/claude-code#62671",
-      "url": "https://github.com/anthropics/claude-code/issues/62671",
-      "title": "[DOCS] `/usage` documentation omits large session files in limits breakdown",
-      "impact": "not_applicable",
-      "categories": [
-        "mcp",
-        "plugin"
-      ],
-      "tokenkey_status": "not_applicable",
-      "rationale": "Client-side claude-code concern (mcp, plugin); not a gateway/relay relevance signal.",
-      "updated_at": "2026-06-01T17:41:03Z"
     },
     {
       "upstream": "anthropics/claude-code#62681",
@@ -14826,19 +14858,6 @@
       "updated_at": "2026-06-03T04:48:56Z"
     },
     {
-      "upstream": "anthropics/claude-code#62729",
-      "url": "https://github.com/anthropics/claude-code/issues/62729",
-      "title": "[BUG] Claude Code crashed",
-      "impact": "not_applicable",
-      "categories": [
-        "terminal",
-        "platform"
-      ],
-      "tokenkey_status": "not_applicable",
-      "rationale": "Client-side claude-code concern (terminal, platform); not a gateway/relay relevance signal.",
-      "updated_at": "2026-06-01T16:55:15Z"
-    },
-    {
       "upstream": "anthropics/claude-code#62736",
       "url": "https://github.com/anthropics/claude-code/issues/62736",
       "title": "[BUG] 2.1.152 regression: arrow keys hijacked in prompt input (cursor cannot move down/left/right)",
@@ -14865,18 +14884,6 @@
       "tokenkey_status": "not_applicable",
       "rationale": "Client-side claude-code concern (terminal, install); not a gateway/relay relevance signal.",
       "updated_at": "2026-06-03T18:49:44Z"
-    },
-    {
-      "upstream": "anthropics/claude-code#62890",
-      "url": "https://github.com/anthropics/claude-code/issues/62890",
-      "title": "Tmux scrollback broken after May 26 update (v2.1.152)",
-      "impact": "not_applicable",
-      "categories": [
-        "terminal"
-      ],
-      "tokenkey_status": "not_applicable",
-      "rationale": "Client-side claude-code concern (terminal); not a gateway/relay relevance signal.",
-      "updated_at": "2026-06-01T17:06:17Z"
     },
     {
       "upstream": "anthropics/claude-code#62942",
@@ -14940,7 +14947,7 @@
       ],
       "tokenkey_status": "not_applicable",
       "rationale": "Client-side claude-code concern (terminal); not a gateway/relay relevance signal.",
-      "updated_at": "2026-06-04T11:53:32Z"
+      "updated_at": "2026-06-04T23:12:09Z"
     },
     {
       "upstream": "anthropics/claude-code#63075",
@@ -15005,6 +15012,18 @@
       "tokenkey_status": "not_applicable",
       "rationale": "Client-side claude-code concern (mcp); not a gateway/relay relevance signal.",
       "updated_at": "2026-06-04T00:49:09Z"
+    },
+    {
+      "upstream": "anthropics/claude-code#63336",
+      "url": "https://github.com/anthropics/claude-code/issues/63336",
+      "title": "RTL text support for Hebrew (and Arabic) in Claude Code",
+      "impact": "not_applicable",
+      "categories": [
+        "terminal"
+      ],
+      "tokenkey_status": "not_applicable",
+      "rationale": "Client-side claude-code concern (terminal); not a gateway/relay relevance signal.",
+      "updated_at": "2026-06-04T20:37:56Z"
     },
     {
       "upstream": "anthropics/claude-code#63353",
@@ -15105,18 +15124,6 @@
       "updated_at": "2026-06-03T13:26:18Z"
     },
     {
-      "upstream": "anthropics/claude-code#63545",
-      "url": "https://github.com/anthropics/claude-code/issues/63545",
-      "title": "Claude Code inside tmux: scroll hits input not scrollback, no rich mode (\"waiting for output\"), transcript not saved",
-      "impact": "not_applicable",
-      "categories": [
-        "terminal"
-      ],
-      "tokenkey_status": "not_applicable",
-      "rationale": "Client-side claude-code concern (terminal); not a gateway/relay relevance signal.",
-      "updated_at": "2026-06-01T17:06:20Z"
-    },
-    {
       "upstream": "anthropics/claude-code#63547",
       "url": "https://github.com/anthropics/claude-code/issues/63547",
       "title": "[Regression 1.9659.2] computer-use tools disconnect after first use in Code mode (Windows)",
@@ -15170,6 +15177,19 @@
       "updated_at": "2026-06-02T13:45:15Z"
     },
     {
+      "upstream": "anthropics/claude-code#63652",
+      "url": "https://github.com/anthropics/claude-code/issues/63652",
+      "title": "Add custom session label field in extension header",
+      "impact": "not_applicable",
+      "categories": [
+        "ide",
+        "terminal"
+      ],
+      "tokenkey_status": "not_applicable",
+      "rationale": "Client-side claude-code concern (ide, terminal); not a gateway/relay relevance signal.",
+      "updated_at": "2026-06-04T19:04:56Z"
+    },
+    {
       "upstream": "anthropics/claude-code#63670",
       "url": "https://github.com/anthropics/claude-code/issues/63670",
       "title": "Up/Down arrows jump to history instead of moving cursor through wrapped multi-line prompt input (all platforms; regressed ~2.1.15)",
@@ -15220,7 +15240,7 @@
       ],
       "tokenkey_status": "not_applicable",
       "rationale": "Client-side claude-code concern (plugin); not a gateway/relay relevance signal.",
-      "updated_at": "2026-06-02T17:13:03Z"
+      "updated_at": "2026-06-04T13:52:02Z"
     },
     {
       "upstream": "anthropics/claude-code#63761",
@@ -15232,7 +15252,7 @@
       ],
       "tokenkey_status": "not_applicable",
       "rationale": "Client-side claude-code concern (terminal); not a gateway/relay relevance signal.",
-      "updated_at": "2026-06-03T15:39:45Z"
+      "updated_at": "2026-06-04T23:24:54Z"
     },
     {
       "upstream": "anthropics/claude-code#63765",
@@ -15246,18 +15266,6 @@
       "tokenkey_status": "not_applicable",
       "rationale": "Client-side claude-code concern (ide, platform); not a gateway/relay relevance signal.",
       "updated_at": "2026-06-04T10:14:58Z"
-    },
-    {
-      "upstream": "anthropics/claude-code#63839",
-      "url": "https://github.com/anthropics/claude-code/issues/63839",
-      "title": "[BUG] Session not found on disk for all sessions except most recent after update to 1.9659.2 (May 28)",
-      "impact": "not_applicable",
-      "categories": [
-        "terminal"
-      ],
-      "tokenkey_status": "not_applicable",
-      "rationale": "Client-side claude-code concern (terminal); not a gateway/relay relevance signal.",
-      "updated_at": "2026-06-01T21:11:40Z"
     },
     {
       "upstream": "anthropics/claude-code#63903",
@@ -15320,7 +15328,19 @@
       ],
       "tokenkey_status": "not_applicable",
       "rationale": "Client-side claude-code concern (plugin, slash_hook); not a gateway/relay relevance signal.",
-      "updated_at": "2026-06-01T16:43:46Z"
+      "updated_at": "2026-06-04T20:28:16Z"
+    },
+    {
+      "upstream": "anthropics/claude-code#63969",
+      "url": "https://github.com/anthropics/claude-code/issues/63969",
+      "title": "Client-side soft session ceiling with graceful checkpoint for autonomous/subagent runs",
+      "impact": "not_applicable",
+      "categories": [
+        "plugin"
+      ],
+      "tokenkey_status": "not_applicable",
+      "rationale": "Client-side claude-code concern (plugin); not a gateway/relay relevance signal.",
+      "updated_at": "2026-06-04T14:11:18Z"
     },
     {
       "upstream": "anthropics/claude-code#64020",
@@ -15334,6 +15354,32 @@
       "tokenkey_status": "not_applicable",
       "rationale": "Client-side claude-code concern (terminal, slash_hook); not a gateway/relay relevance signal.",
       "updated_at": "2026-06-02T08:06:41Z"
+    },
+    {
+      "upstream": "anthropics/claude-code#64056",
+      "url": "https://github.com/anthropics/claude-code/issues/64056",
+      "title": "[BUG] Subagent autonomously ran destructive DELETE scripts against production data",
+      "impact": "not_applicable",
+      "categories": [
+        "terminal",
+        "plugin",
+        "platform"
+      ],
+      "tokenkey_status": "not_applicable",
+      "rationale": "Client-side claude-code concern (terminal, plugin, platform); not a gateway/relay relevance signal.",
+      "updated_at": "2026-06-04T18:00:53Z"
+    },
+    {
+      "upstream": "anthropics/claude-code#64084",
+      "url": "https://github.com/anthropics/claude-code/issues/64084",
+      "title": "[BUG] Dispatch conductor session grows unbounded with no rotation/compaction, forcing premium 1M-context billing",
+      "impact": "not_applicable",
+      "categories": [
+        "terminal"
+      ],
+      "tokenkey_status": "not_applicable",
+      "rationale": "Client-side claude-code concern (terminal); not a gateway/relay relevance signal.",
+      "updated_at": "2026-06-04T15:23:04Z"
     },
     {
       "upstream": "anthropics/claude-code#64108",
@@ -15437,31 +15483,16 @@
       "updated_at": "2026-06-02T07:55:17Z"
     },
     {
-      "upstream": "anthropics/claude-code#64324",
-      "url": "https://github.com/anthropics/claude-code/issues/64324",
-      "title": "[Bug] Claude Opus 4.8 API returning increased hallucinations",
+      "upstream": "anthropics/claude-code#64315",
+      "url": "https://github.com/anthropics/claude-code/issues/64315",
+      "title": "Agent tool: `isolation: \"worktree\"` creates worktree in session repo, not target repo, breaking parallel cross-repo work",
       "impact": "not_applicable",
       "categories": [
-        "terminal"
+        "plugin"
       ],
       "tokenkey_status": "not_applicable",
-      "rationale": "Client-side claude-code concern (terminal); not a gateway/relay relevance signal.",
-      "updated_at": "2026-06-01T17:17:47Z"
-    },
-    {
-      "upstream": "anthropics/claude-code#64338",
-      "url": "https://github.com/anthropics/claude-code/issues/64338",
-      "title": "[FEATURE] PreToolUse hook: let \"ask\" decisions set the default-highlighted prompt option",
-      "impact": "not_applicable",
-      "categories": [
-        "terminal",
-        "plugin",
-        "slash_hook",
-        "install"
-      ],
-      "tokenkey_status": "not_applicable",
-      "rationale": "Client-side claude-code concern (terminal, plugin, slash_hook, install); not a gateway/relay relevance signal.",
-      "updated_at": "2026-06-01T21:40:02Z"
+      "rationale": "Client-side claude-code concern (plugin); not a gateway/relay relevance signal.",
+      "updated_at": "2026-06-04T17:47:42Z"
     },
     {
       "upstream": "anthropics/claude-code#64349",
@@ -15480,19 +15511,6 @@
       "updated_at": "2026-06-04T06:20:59Z"
     },
     {
-      "upstream": "anthropics/claude-code#64358",
-      "url": "https://github.com/anthropics/claude-code/issues/64358",
-      "title": "Update banner should show the new version (and ideally a one-line summary)",
-      "impact": "not_applicable",
-      "categories": [
-        "install",
-        "platform"
-      ],
-      "tokenkey_status": "not_applicable",
-      "rationale": "Client-side claude-code concern (install, platform); not a gateway/relay relevance signal.",
-      "updated_at": "2026-06-01T20:15:24Z"
-    },
-    {
       "upstream": "anthropics/claude-code#64366",
       "url": "https://github.com/anthropics/claude-code/issues/64366",
       "title": "[BUG] Unbounded MCP server fan-out across Cowork/agent sessions exhausts RAM and kernel-panics macOS (4 panics + forced power-off on M2 Max / 32 GB)",
@@ -15504,19 +15522,6 @@
       "tokenkey_status": "not_applicable",
       "rationale": "Client-side claude-code concern (terminal, mcp); not a gateway/relay relevance signal.",
       "updated_at": "2026-06-02T14:12:50Z"
-    },
-    {
-      "upstream": "anthropics/claude-code#64377",
-      "url": "https://github.com/anthropics/claude-code/issues/64377",
-      "title": "[BUG] Why I can not use Sonnet even I have enough quota?!",
-      "impact": "not_applicable",
-      "categories": [
-        "terminal",
-        "platform"
-      ],
-      "tokenkey_status": "not_applicable",
-      "rationale": "Client-side claude-code concern (terminal, platform); not a gateway/relay relevance signal.",
-      "updated_at": "2026-06-01T16:12:40Z"
     },
     {
       "upstream": "anthropics/claude-code#64381",
@@ -15545,17 +15550,18 @@
       "updated_at": "2026-06-03T23:36:30Z"
     },
     {
-      "upstream": "anthropics/claude-code#64452",
-      "url": "https://github.com/anthropics/claude-code/issues/64452",
-      "title": "Background session: Workflow subagent with isolation:\"worktree\" is blocked from Write/Edit into its own worktree",
+      "upstream": "anthropics/claude-code#64461",
+      "url": "https://github.com/anthropics/claude-code/issues/64461",
+      "title": "Plugin harness resolves skill base directory to marketplaces/ instead of cache/ path",
       "impact": "not_applicable",
       "categories": [
         "plugin",
-        "slash_hook"
+        "slash_hook",
+        "install"
       ],
       "tokenkey_status": "not_applicable",
-      "rationale": "Client-side claude-code concern (plugin, slash_hook); not a gateway/relay relevance signal.",
-      "updated_at": "2026-06-01T15:29:07Z"
+      "rationale": "Client-side claude-code concern (plugin, slash_hook, install); not a gateway/relay relevance signal.",
+      "updated_at": "2026-06-04T19:26:04Z"
     },
     {
       "upstream": "anthropics/claude-code#64469",
@@ -15569,19 +15575,6 @@
       "tokenkey_status": "not_applicable",
       "rationale": "Client-side claude-code concern (ide, terminal); not a gateway/relay relevance signal.",
       "updated_at": "2026-06-04T01:20:43Z"
-    },
-    {
-      "upstream": "anthropics/claude-code#64476",
-      "url": "https://github.com/anthropics/claude-code/issues/64476",
-      "title": "[FEATURE] Show remaining usage limits (5h/7 days) in VSCode extension and via CLI command",
-      "impact": "not_applicable",
-      "categories": [
-        "ide",
-        "terminal"
-      ],
-      "tokenkey_status": "not_applicable",
-      "rationale": "Client-side claude-code concern (ide, terminal); not a gateway/relay relevance signal.",
-      "updated_at": "2026-06-01T17:40:45Z"
     },
     {
       "upstream": "anthropics/claude-code#64495",
@@ -15606,45 +15599,6 @@
       "tokenkey_status": "not_applicable",
       "rationale": "Client-side claude-code concern (terminal); not a gateway/relay relevance signal.",
       "updated_at": "2026-06-03T23:02:32Z"
-    },
-    {
-      "upstream": "anthropics/claude-code#64499",
-      "url": "https://github.com/anthropics/claude-code/issues/64499",
-      "title": "[BUG] Blank TUI hang on startup with parent-directory project state",
-      "impact": "not_applicable",
-      "categories": [
-        "terminal",
-        "mcp"
-      ],
-      "tokenkey_status": "not_applicable",
-      "rationale": "Client-side claude-code concern (terminal, mcp); not a gateway/relay relevance signal.",
-      "updated_at": "2026-06-01T14:22:28Z"
-    },
-    {
-      "upstream": "anthropics/claude-code#64500",
-      "url": "https://github.com/anthropics/claude-code/issues/64500",
-      "title": "[Bug] Tool call parsing repeatedly fails causing extended session hangs",
-      "impact": "not_applicable",
-      "categories": [
-        "terminal"
-      ],
-      "tokenkey_status": "not_applicable",
-      "rationale": "Client-side claude-code concern (terminal); not a gateway/relay relevance signal.",
-      "updated_at": "2026-06-01T14:23:26Z"
-    },
-    {
-      "upstream": "anthropics/claude-code#64501",
-      "url": "https://github.com/anthropics/claude-code/issues/64501",
-      "title": "Display active model + reasoning effort in VS Code extension UI",
-      "impact": "not_applicable",
-      "categories": [
-        "ide",
-        "terminal",
-        "slash_hook"
-      ],
-      "tokenkey_status": "not_applicable",
-      "rationale": "Client-side claude-code concern (ide, terminal, slash_hook); not a gateway/relay relevance signal.",
-      "updated_at": "2026-06-01T14:34:59Z"
     },
     {
       "upstream": "anthropics/claude-code#64502",
@@ -15672,94 +15626,6 @@
       "updated_at": "2026-06-03T11:39:53Z"
     },
     {
-      "upstream": "anthropics/claude-code#64504",
-      "url": "https://github.com/anthropics/claude-code/issues/64504",
-      "title": "[BUG] bug——\"auto compaction not triggering at 95-100% context usage on Opus 4.6, version 2.1.159, have to manually run /compact\"",
-      "impact": "not_applicable",
-      "categories": [
-        "terminal"
-      ],
-      "tokenkey_status": "not_applicable",
-      "rationale": "Client-side claude-code concern (terminal); not a gateway/relay relevance signal.",
-      "updated_at": "2026-06-01T15:08:07Z"
-    },
-    {
-      "upstream": "anthropics/claude-code#64506",
-      "url": "https://github.com/anthropics/claude-code/issues/64506",
-      "title": "[Bug] Tool call parsing fails with long multibyte/CJK string arguments",
-      "impact": "not_applicable",
-      "categories": [
-        "terminal"
-      ],
-      "tokenkey_status": "not_applicable",
-      "rationale": "Client-side claude-code concern (terminal); not a gateway/relay relevance signal.",
-      "updated_at": "2026-06-01T15:15:28Z"
-    },
-    {
-      "upstream": "anthropics/claude-code#64508",
-      "url": "https://github.com/anthropics/claude-code/issues/64508",
-      "title": "[BUG] [Linux] Massive RAM spike (300MB → 10GB) due to background indexation",
-      "impact": "not_applicable",
-      "categories": [
-        "ide",
-        "terminal",
-        "install"
-      ],
-      "tokenkey_status": "not_applicable",
-      "rationale": "Client-side claude-code concern (ide, terminal, install); not a gateway/relay relevance signal.",
-      "updated_at": "2026-06-01T15:17:52Z"
-    },
-    {
-      "upstream": "anthropics/claude-code#64509",
-      "url": "https://github.com/anthropics/claude-code/issues/64509",
-      "title": "Feature request: option to auto-remove git worktrees on session exit (skip keep/remove prompt)",
-      "impact": "not_applicable",
-      "categories": [
-        "slash_hook"
-      ],
-      "tokenkey_status": "not_applicable",
-      "rationale": "Client-side claude-code concern (slash_hook); not a gateway/relay relevance signal.",
-      "updated_at": "2026-06-01T15:26:54Z"
-    },
-    {
-      "upstream": "anthropics/claude-code#64511",
-      "url": "https://github.com/anthropics/claude-code/issues/64511",
-      "title": "VS Code: panel text stuck in narrow column after resize, does not reflow",
-      "impact": "not_applicable",
-      "categories": [
-        "ide",
-        "terminal"
-      ],
-      "tokenkey_status": "not_applicable",
-      "rationale": "Client-side claude-code concern (ide, terminal); not a gateway/relay relevance signal.",
-      "updated_at": "2026-06-01T15:28:48Z"
-    },
-    {
-      "upstream": "anthropics/claude-code#64512",
-      "url": "https://github.com/anthropics/claude-code/issues/64512",
-      "title": "[Cowork] MSIX: Write/Glob succeed but Read fails on session dirs until folder mounted",
-      "impact": "not_applicable",
-      "categories": [
-        "install",
-        "platform"
-      ],
-      "tokenkey_status": "not_applicable",
-      "rationale": "Client-side claude-code concern (install, platform); not a gateway/relay relevance signal.",
-      "updated_at": "2026-06-01T15:33:35Z"
-    },
-    {
-      "upstream": "anthropics/claude-code#64513",
-      "url": "https://github.com/anthropics/claude-code/issues/64513",
-      "title": "[FEATURE] Allow changing the primary working directory mid-session (live /cd)",
-      "impact": "not_applicable",
-      "categories": [
-        "slash_hook"
-      ],
-      "tokenkey_status": "not_applicable",
-      "rationale": "Client-side claude-code concern (slash_hook); not a gateway/relay relevance signal.",
-      "updated_at": "2026-06-01T15:31:11Z"
-    },
-    {
       "upstream": "anthropics/claude-code#64515",
       "url": "https://github.com/anthropics/claude-code/issues/64515",
       "title": "Active Claude Code chat tabs are not restored on VS Code restart (webview tabs dropped; no WebviewPanelSerializer)",
@@ -15770,36 +15636,6 @@
       "tokenkey_status": "not_applicable",
       "rationale": "Client-side claude-code concern (ide); not a gateway/relay relevance signal.",
       "updated_at": "2026-06-02T20:15:22Z"
-    },
-    {
-      "upstream": "anthropics/claude-code#64517",
-      "url": "https://github.com/anthropics/claude-code/issues/64517",
-      "title": "[BUG] Claude Code with GUI doesn't work after plugin update in PHPStorm",
-      "impact": "not_applicable",
-      "categories": [
-        "ide",
-        "terminal",
-        "plugin",
-        "platform"
-      ],
-      "tokenkey_status": "not_applicable",
-      "rationale": "Client-side claude-code concern (ide, terminal, plugin, platform); not a gateway/relay relevance signal.",
-      "updated_at": "2026-06-01T15:42:33Z"
-    },
-    {
-      "upstream": "anthropics/claude-code#64518",
-      "url": "https://github.com/anthropics/claude-code/issues/64518",
-      "title": "[BUG] CLAUDE.md not loaded when working directory is a UNC path (Windows)",
-      "impact": "not_applicable",
-      "categories": [
-        "ide",
-        "terminal",
-        "slash_hook",
-        "platform"
-      ],
-      "tokenkey_status": "not_applicable",
-      "rationale": "Client-side claude-code concern (ide, terminal, slash_hook, platform); not a gateway/relay relevance signal.",
-      "updated_at": "2026-06-01T16:00:04Z"
     },
     {
       "upstream": "anthropics/claude-code#64521",
@@ -15815,116 +15651,6 @@
       "updated_at": "2026-06-02T03:14:08Z"
     },
     {
-      "upstream": "anthropics/claude-code#64522",
-      "url": "https://github.com/anthropics/claude-code/issues/64522",
-      "title": "[Bug] macOS sleep inhibitor continuously respawns caffeinate preventing system sleep",
-      "impact": "not_applicable",
-      "categories": [
-        "terminal"
-      ],
-      "tokenkey_status": "not_applicable",
-      "rationale": "Client-side claude-code concern (terminal); not a gateway/relay relevance signal.",
-      "updated_at": "2026-06-01T16:10:07Z"
-    },
-    {
-      "upstream": "anthropics/claude-code#64523",
-      "url": "https://github.com/anthropics/claude-code/issues/64523",
-      "title": "[BUG] cowork with dispatch does work",
-      "impact": "not_applicable",
-      "categories": [
-        "terminal"
-      ],
-      "tokenkey_status": "not_applicable",
-      "rationale": "Client-side claude-code concern (terminal); not a gateway/relay relevance signal.",
-      "updated_at": "2026-06-01T16:15:03Z"
-    },
-    {
-      "upstream": "anthropics/claude-code#64524",
-      "url": "https://github.com/anthropics/claude-code/issues/64524",
-      "title": "Workflow tool triggers on any message mentioning \"workflow\" — trigger is too broad",
-      "impact": "not_applicable",
-      "categories": [
-        "slash_hook"
-      ],
-      "tokenkey_status": "not_applicable",
-      "rationale": "Client-side claude-code concern (slash_hook); not a gateway/relay relevance signal.",
-      "updated_at": "2026-06-01T17:41:47Z"
-    },
-    {
-      "upstream": "anthropics/claude-code#64525",
-      "url": "https://github.com/anthropics/claude-code/issues/64525",
-      "title": "[BUG] Auto permission mode: approval prompt (URL + content) mutates to a different pending tool call while user is reviewing",
-      "impact": "not_applicable",
-      "categories": [
-        "terminal",
-        "plugin"
-      ],
-      "tokenkey_status": "not_applicable",
-      "rationale": "Client-side claude-code concern (terminal, plugin); not a gateway/relay relevance signal.",
-      "updated_at": "2026-06-01T16:31:06Z"
-    },
-    {
-      "upstream": "anthropics/claude-code#64526",
-      "url": "https://github.com/anthropics/claude-code/issues/64526",
-      "title": "[Bug Report] Unable to process request - missing bug report details",
-      "impact": "not_applicable",
-      "categories": [
-        "terminal"
-      ],
-      "tokenkey_status": "not_applicable",
-      "rationale": "Client-side claude-code concern (terminal); not a gateway/relay relevance signal.",
-      "updated_at": "2026-06-01T16:27:38Z"
-    },
-    {
-      "upstream": "anthropics/claude-code#64527",
-      "url": "https://github.com/anthropics/claude-code/issues/64527",
-      "title": "[Bug] Tool Invocation Failure Blocking Workflow Execution",
-      "impact": "not_applicable",
-      "categories": [
-        "terminal"
-      ],
-      "tokenkey_status": "not_applicable",
-      "rationale": "Client-side claude-code concern (terminal); not a gateway/relay relevance signal.",
-      "updated_at": "2026-06-01T16:31:18Z"
-    },
-    {
-      "upstream": "anthropics/claude-code#64529",
-      "url": "https://github.com/anthropics/claude-code/issues/64529",
-      "title": "[FEATURE]",
-      "impact": "not_applicable",
-      "categories": [
-        "ide",
-        "terminal"
-      ],
-      "tokenkey_status": "not_applicable",
-      "rationale": "Client-side claude-code concern (ide, terminal); not a gateway/relay relevance signal.",
-      "updated_at": "2026-06-01T16:31:16Z"
-    },
-    {
-      "upstream": "anthropics/claude-code#64531",
-      "url": "https://github.com/anthropics/claude-code/issues/64531",
-      "title": "I don't have enough context to generate a GitHub issue title from your message. Your text appears to be in Traditional Chinese and translates to something like \"I'll help you create and push directly using the gh CLI.\" However, this seems to be a statemen",
-      "impact": "not_applicable",
-      "categories": [
-        "terminal"
-      ],
-      "tokenkey_status": "not_applicable",
-      "rationale": "Client-side claude-code concern (terminal); not a gateway/relay relevance signal.",
-      "updated_at": "2026-06-01T16:41:26Z"
-    },
-    {
-      "upstream": "anthropics/claude-code#64532",
-      "url": "https://github.com/anthropics/claude-code/issues/64532",
-      "title": "[BUG] CLAUDE.md not read at start of session",
-      "impact": "not_applicable",
-      "categories": [
-        "terminal"
-      ],
-      "tokenkey_status": "not_applicable",
-      "rationale": "Client-side claude-code concern (terminal); not a gateway/relay relevance signal.",
-      "updated_at": "2026-06-01T16:43:36Z"
-    },
-    {
       "upstream": "anthropics/claude-code#64534",
       "url": "https://github.com/anthropics/claude-code/issues/64534",
       "title": "Dispatch feature ignores CLAUDE_CODE_DISABLE_1M_CONTEXT — \"Usage credits required for 1M context\" blocks background agents",
@@ -15935,87 +15661,6 @@
       "tokenkey_status": "not_applicable",
       "rationale": "Client-side claude-code concern (slash_hook); not a gateway/relay relevance signal.",
       "updated_at": "2026-06-03T16:56:40Z"
-    },
-    {
-      "upstream": "anthropics/claude-code#64535",
-      "url": "https://github.com/anthropics/claude-code/issues/64535",
-      "title": "Claude Code 2.1.159 crashes with General Protection Fault on VirtualBox (Xubuntu 24.04)",
-      "impact": "not_applicable",
-      "categories": [
-        "terminal",
-        "install"
-      ],
-      "tokenkey_status": "not_applicable",
-      "rationale": "Client-side claude-code concern (terminal, install); not a gateway/relay relevance signal.",
-      "updated_at": "2026-06-01T17:06:28Z"
-    },
-    {
-      "upstream": "anthropics/claude-code#64536",
-      "url": "https://github.com/anthropics/claude-code/issues/64536",
-      "title": "[Bug] jdtls-lsp spawns per-subagent instances causing >50 GB RAM exhaustion in large Java workspaces",
-      "impact": "not_applicable",
-      "categories": [
-        "ide",
-        "mcp",
-        "plugin",
-        "install"
-      ],
-      "tokenkey_status": "not_applicable",
-      "rationale": "Client-side claude-code concern (ide, mcp, plugin, install); not a gateway/relay relevance signal.",
-      "updated_at": "2026-06-01T18:41:52Z"
-    },
-    {
-      "upstream": "anthropics/claude-code#64537",
-      "url": "https://github.com/anthropics/claude-code/issues/64537",
-      "title": "[Bug] Agent tool docstring references SendMessage but deferred tools don't expose it",
-      "impact": "not_applicable",
-      "categories": [
-        "terminal"
-      ],
-      "tokenkey_status": "not_applicable",
-      "rationale": "Client-side claude-code concern (terminal); not a gateway/relay relevance signal.",
-      "updated_at": "2026-06-01T17:39:14Z"
-    },
-    {
-      "upstream": "anthropics/claude-code#64538",
-      "url": "https://github.com/anthropics/claude-code/issues/64538",
-      "title": "Claude in Chrome — turnApprovedDomains Gate 1 hard-denies all non-pre-approved domains, no approval prompt fires (v1.0.74, Windows 11)",
-      "impact": "not_applicable",
-      "categories": [
-        "ide",
-        "terminal",
-        "mcp",
-        "platform"
-      ],
-      "tokenkey_status": "not_applicable",
-      "rationale": "Client-side claude-code concern (ide, terminal, mcp, platform); not a gateway/relay relevance signal.",
-      "updated_at": "2026-06-01T17:46:07Z"
-    },
-    {
-      "upstream": "anthropics/claude-code#64541",
-      "url": "https://github.com/anthropics/claude-code/issues/64541",
-      "title": "MCP stdio server fails to start at session init with no error surfaced (silent no-spawn)",
-      "impact": "not_applicable",
-      "categories": [
-        "mcp",
-        "install"
-      ],
-      "tokenkey_status": "not_applicable",
-      "rationale": "Client-side claude-code concern (mcp, install); not a gateway/relay relevance signal.",
-      "updated_at": "2026-06-01T18:35:17Z"
-    },
-    {
-      "upstream": "anthropics/claude-code#64543",
-      "url": "https://github.com/anthropics/claude-code/issues/64543",
-      "title": "Unicode/emoji glyphs rendered as empty boxes on Manjaro Linux (kitty + tmux)",
-      "impact": "not_applicable",
-      "categories": [
-        "terminal",
-        "install"
-      ],
-      "tokenkey_status": "not_applicable",
-      "rationale": "Client-side claude-code concern (terminal, install); not a gateway/relay relevance signal.",
-      "updated_at": "2026-06-01T17:59:54Z"
     },
     {
       "upstream": "anthropics/claude-code#64544",
@@ -16029,7 +15674,7 @@
       ],
       "tokenkey_status": "not_applicable",
       "rationale": "Client-side claude-code concern (ide, terminal, slash_hook); not a gateway/relay relevance signal.",
-      "updated_at": "2026-06-02T07:27:44Z"
+      "updated_at": "2026-06-04T17:24:51Z"
     },
     {
       "upstream": "anthropics/claude-code#64548",
@@ -16043,98 +15688,6 @@
       "tokenkey_status": "not_applicable",
       "rationale": "Client-side claude-code concern (plugin, install); not a gateway/relay relevance signal.",
       "updated_at": "2026-06-03T08:40:04Z"
-    },
-    {
-      "upstream": "anthropics/claude-code#64549",
-      "url": "https://github.com/anthropics/claude-code/issues/64549",
-      "title": "[BUG] Claude CLI will not use \"cd\", rendering it unable to run commands in a container",
-      "impact": "not_applicable",
-      "categories": [
-        "terminal"
-      ],
-      "tokenkey_status": "not_applicable",
-      "rationale": "Client-side claude-code concern (terminal); not a gateway/relay relevance signal.",
-      "updated_at": "2026-06-01T18:53:16Z"
-    },
-    {
-      "upstream": "anthropics/claude-code#64551",
-      "url": "https://github.com/anthropics/claude-code/issues/64551",
-      "title": "[BUG] spawn ENAMETOOLONG",
-      "impact": "not_applicable",
-      "categories": [
-        "terminal",
-        "install",
-        "platform"
-      ],
-      "tokenkey_status": "not_applicable",
-      "rationale": "Client-side claude-code concern (terminal, install, platform); not a gateway/relay relevance signal.",
-      "updated_at": "2026-06-01T19:13:07Z"
-    },
-    {
-      "upstream": "anthropics/claude-code#64552",
-      "url": "https://github.com/anthropics/claude-code/issues/64552",
-      "title": "[BUG] MCP connector stuck on disambiguation UUID after conflicting plugin is uninstalled",
-      "impact": "not_applicable",
-      "categories": [
-        "terminal",
-        "mcp",
-        "plugin",
-        "install"
-      ],
-      "tokenkey_status": "not_applicable",
-      "rationale": "Client-side claude-code concern (terminal, mcp, plugin, install); not a gateway/relay relevance signal.",
-      "updated_at": "2026-06-01T19:32:08Z"
-    },
-    {
-      "upstream": "anthropics/claude-code#64553",
-      "url": "https://github.com/anthropics/claude-code/issues/64553",
-      "title": "[FEATURE] Configurable diff view background colors",
-      "impact": "not_applicable",
-      "categories": [
-        "terminal",
-        "slash_hook",
-        "platform"
-      ],
-      "tokenkey_status": "not_applicable",
-      "rationale": "Client-side claude-code concern (terminal, slash_hook, platform); not a gateway/relay relevance signal.",
-      "updated_at": "2026-06-01T19:28:31Z"
-    },
-    {
-      "upstream": "anthropics/claude-code#64554",
-      "url": "https://github.com/anthropics/claude-code/issues/64554",
-      "title": "[Bug] Update process fails despite health check passing",
-      "impact": "not_applicable",
-      "categories": [
-        "terminal"
-      ],
-      "tokenkey_status": "not_applicable",
-      "rationale": "Client-side claude-code concern (terminal); not a gateway/relay relevance signal.",
-      "updated_at": "2026-06-01T19:28:49Z"
-    },
-    {
-      "upstream": "anthropics/claude-code#64556",
-      "url": "https://github.com/anthropics/claude-code/issues/64556",
-      "title": "Bedrock streaming: no idle timeout on hung connections",
-      "impact": "not_applicable",
-      "categories": [
-        "terminal",
-        "platform"
-      ],
-      "tokenkey_status": "not_applicable",
-      "rationale": "Client-side claude-code concern (terminal, platform); not a gateway/relay relevance signal.",
-      "updated_at": "2026-06-01T19:54:52Z"
-    },
-    {
-      "upstream": "anthropics/claude-code#64557",
-      "url": "https://github.com/anthropics/claude-code/issues/64557",
-      "title": "[BUG] Billing: Max 5x plan incorrectly downgraded to Free mid-cycle, double-charged $230",
-      "impact": "not_applicable",
-      "categories": [
-        "terminal"
-      ],
-      "tokenkey_status": "not_applicable",
-      "rationale": "Client-side claude-code concern (terminal); not a gateway/relay relevance signal.",
-      "updated_at": "2026-06-01T20:08:16Z"
     },
     {
       "upstream": "anthropics/claude-code#64558",
@@ -16160,192 +15713,6 @@
       "tokenkey_status": "not_applicable",
       "rationale": "Client-side claude-code concern (terminal, slash_hook); not a gateway/relay relevance signal.",
       "updated_at": "2026-06-04T08:27:40Z"
-    },
-    {
-      "upstream": "anthropics/claude-code#64560",
-      "url": "https://github.com/anthropics/claude-code/issues/64560",
-      "title": "[BUG] Only Part of the Dialog Can be Used to Move Window",
-      "impact": "not_applicable",
-      "categories": [
-        "terminal",
-        "platform"
-      ],
-      "tokenkey_status": "not_applicable",
-      "rationale": "Client-side claude-code concern (terminal, platform); not a gateway/relay relevance signal.",
-      "updated_at": "2026-06-01T20:39:00Z"
-    },
-    {
-      "upstream": "anthropics/claude-code#64562",
-      "url": "https://github.com/anthropics/claude-code/issues/64562",
-      "title": "Glob tool silently returns empty for anchored patterns (non-globstar first segment) on Windows",
-      "impact": "not_applicable",
-      "categories": [
-        "platform"
-      ],
-      "tokenkey_status": "not_applicable",
-      "rationale": "Client-side claude-code concern (platform); not a gateway/relay relevance signal.",
-      "updated_at": "2026-06-01T20:47:18Z"
-    },
-    {
-      "upstream": "anthropics/claude-code#64564",
-      "url": "https://github.com/anthropics/claude-code/issues/64564",
-      "title": "[Feature Request] Allow Claude Code to access and retrieve credentials",
-      "impact": "not_applicable",
-      "categories": [
-        "ide",
-        "terminal"
-      ],
-      "tokenkey_status": "not_applicable",
-      "rationale": "Client-side claude-code concern (ide, terminal); not a gateway/relay relevance signal.",
-      "updated_at": "2026-06-01T20:53:18Z"
-    },
-    {
-      "upstream": "anthropics/claude-code#64565",
-      "url": "https://github.com/anthropics/claude-code/issues/64565",
-      "title": "Statusline: support right/center alignment",
-      "impact": "not_applicable",
-      "categories": [
-        "terminal",
-        "slash_hook"
-      ],
-      "tokenkey_status": "not_applicable",
-      "rationale": "Client-side claude-code concern (terminal, slash_hook); not a gateway/relay relevance signal.",
-      "updated_at": "2026-06-01T21:05:25Z"
-    },
-    {
-      "upstream": "anthropics/claude-code#64568",
-      "url": "https://github.com/anthropics/claude-code/issues/64568",
-      "title": "[BUG] Pressing Esc to exit /btw mode rejects the pending tool-use prompt instead of just exiting the mode",
-      "impact": "not_applicable",
-      "categories": [
-        "slash_hook"
-      ],
-      "tokenkey_status": "not_applicable",
-      "rationale": "Client-side claude-code concern (slash_hook); not a gateway/relay relevance signal.",
-      "updated_at": "2026-06-01T21:12:26Z"
-    },
-    {
-      "upstream": "anthropics/claude-code#64569",
-      "url": "https://github.com/anthropics/claude-code/issues/64569",
-      "title": "[BUG] Claude Code Session Model Cache Breaks Env Var Overrides",
-      "impact": "not_applicable",
-      "categories": [
-        "ide",
-        "terminal"
-      ],
-      "tokenkey_status": "not_applicable",
-      "rationale": "Client-side claude-code concern (ide, terminal); not a gateway/relay relevance signal.",
-      "updated_at": "2026-06-01T21:14:37Z"
-    },
-    {
-      "upstream": "anthropics/claude-code#64570",
-      "url": "https://github.com/anthropics/claude-code/issues/64570",
-      "title": "[Bug] /btw panel arrow key scrolling not functional",
-      "impact": "not_applicable",
-      "categories": [
-        "terminal"
-      ],
-      "tokenkey_status": "not_applicable",
-      "rationale": "Client-side claude-code concern (terminal); not a gateway/relay relevance signal.",
-      "updated_at": "2026-06-01T21:23:32Z"
-    },
-    {
-      "upstream": "anthropics/claude-code#64571",
-      "url": "https://github.com/anthropics/claude-code/issues/64571",
-      "title": "Feature request: interactive hook output type for TUI picker/selection",
-      "impact": "not_applicable",
-      "categories": [
-        "terminal",
-        "slash_hook"
-      ],
-      "tokenkey_status": "not_applicable",
-      "rationale": "Client-side claude-code concern (terminal, slash_hook); not a gateway/relay relevance signal.",
-      "updated_at": "2026-06-01T22:33:48Z"
-    },
-    {
-      "upstream": "anthropics/claude-code#64572",
-      "url": "https://github.com/anthropics/claude-code/issues/64572",
-      "title": "[Feature Request] Add configurable worktree base path with template support",
-      "impact": "not_applicable",
-      "categories": [
-        "terminal"
-      ],
-      "tokenkey_status": "not_applicable",
-      "rationale": "Client-side claude-code concern (terminal); not a gateway/relay relevance signal.",
-      "updated_at": "2026-06-01T21:33:53Z"
-    },
-    {
-      "upstream": "anthropics/claude-code#64573",
-      "url": "https://github.com/anthropics/claude-code/issues/64573",
-      "title": "[Feature Request] Generate session summaries in the response language",
-      "impact": "not_applicable",
-      "categories": [
-        "terminal"
-      ],
-      "tokenkey_status": "not_applicable",
-      "rationale": "Client-side claude-code concern (terminal); not a gateway/relay relevance signal.",
-      "updated_at": "2026-06-01T21:42:35Z"
-    },
-    {
-      "upstream": "anthropics/claude-code#64575",
-      "url": "https://github.com/anthropics/claude-code/issues/64575",
-      "title": "[FEATURE] Agents view: add search/filter to find sessions by name or prompt",
-      "impact": "not_applicable",
-      "categories": [
-        "terminal"
-      ],
-      "tokenkey_status": "not_applicable",
-      "rationale": "Client-side claude-code concern (terminal); not a gateway/relay relevance signal.",
-      "updated_at": "2026-06-01T21:41:36Z"
-    },
-    {
-      "upstream": "anthropics/claude-code#64576",
-      "url": "https://github.com/anthropics/claude-code/issues/64576",
-      "title": "[Bug] Auto mode classifier incorrectly blocks previously allowed operations",
-      "impact": "not_applicable",
-      "categories": [
-        "terminal"
-      ],
-      "tokenkey_status": "not_applicable",
-      "rationale": "Client-side claude-code concern (terminal); not a gateway/relay relevance signal.",
-      "updated_at": "2026-06-01T21:56:33Z"
-    },
-    {
-      "upstream": "anthropics/claude-code#64577",
-      "url": "https://github.com/anthropics/claude-code/issues/64577",
-      "title": "[BUG] Bash tool hides errors and hangs from non-terminating commands when output is piped through `tail`/`head` (or any EOF-buffering filter)",
-      "impact": "not_applicable",
-      "categories": [
-        "terminal",
-        "install"
-      ],
-      "tokenkey_status": "not_applicable",
-      "rationale": "Client-side claude-code concern (terminal, install); not a gateway/relay relevance signal.",
-      "updated_at": "2026-06-01T21:54:42Z"
-    },
-    {
-      "upstream": "anthropics/claude-code#64580",
-      "url": "https://github.com/anthropics/claude-code/issues/64580",
-      "title": "[Bug] Unclear error message during update operation",
-      "impact": "not_applicable",
-      "categories": [
-        "terminal"
-      ],
-      "tokenkey_status": "not_applicable",
-      "rationale": "Client-side claude-code concern (terminal); not a gateway/relay relevance signal.",
-      "updated_at": "2026-06-01T22:12:17Z"
-    },
-    {
-      "upstream": "anthropics/claude-code#64581",
-      "url": "https://github.com/anthropics/claude-code/issues/64581",
-      "title": "[BUG] Cowork code crashes",
-      "impact": "not_applicable",
-      "categories": [
-        "terminal"
-      ],
-      "tokenkey_status": "not_applicable",
-      "rationale": "Client-side claude-code concern (terminal); not a gateway/relay relevance signal.",
-      "updated_at": "2026-06-01T22:16:02Z"
     },
     {
       "upstream": "anthropics/claude-code#64586",
@@ -16750,7 +16117,7 @@
       ],
       "tokenkey_status": "not_applicable",
       "rationale": "Client-side claude-code concern (slash_hook); not a gateway/relay relevance signal.",
-      "updated_at": "2026-06-02T04:23:17Z"
+      "updated_at": "2026-06-04T20:14:01Z"
     },
     {
       "upstream": "anthropics/claude-code#64639",
@@ -17386,7 +16753,7 @@
       ],
       "tokenkey_status": "not_applicable",
       "rationale": "Client-side claude-code concern (mcp, install); not a gateway/relay relevance signal.",
-      "updated_at": "2026-06-03T11:02:51Z"
+      "updated_at": "2026-06-04T13:43:04Z"
     },
     {
       "upstream": "anthropics/claude-code#64731",
@@ -18781,7 +18148,7 @@
       ],
       "tokenkey_status": "not_applicable",
       "rationale": "Client-side claude-code concern (mcp, plugin, slash_hook); not a gateway/relay relevance signal.",
-      "updated_at": "2026-06-03T00:06:13Z"
+      "updated_at": "2026-06-04T13:47:19Z"
     },
     {
       "upstream": "anthropics/claude-code#64899",
@@ -19326,7 +18693,7 @@
       ],
       "tokenkey_status": "not_applicable",
       "rationale": "Client-side claude-code concern (terminal); not a gateway/relay relevance signal.",
-      "updated_at": "2026-06-03T13:04:42Z"
+      "updated_at": "2026-06-04T21:47:49Z"
     },
     {
       "upstream": "anthropics/claude-code#64962",
@@ -19924,7 +19291,7 @@
       ],
       "tokenkey_status": "not_applicable",
       "rationale": "Client-side claude-code concern (ide, terminal, platform); not a gateway/relay relevance signal.",
-      "updated_at": "2026-06-03T11:06:07Z"
+      "updated_at": "2026-06-04T19:20:01Z"
     },
     {
       "upstream": "anthropics/claude-code#65031",
@@ -19973,7 +19340,7 @@
       ],
       "tokenkey_status": "not_applicable",
       "rationale": "Client-side claude-code concern (terminal); not a gateway/relay relevance signal.",
-      "updated_at": "2026-06-03T11:38:32Z"
+      "updated_at": "2026-06-04T20:18:59Z"
     },
     {
       "upstream": "anthropics/claude-code#65035",
@@ -20186,21 +19553,6 @@
       "tokenkey_status": "not_applicable",
       "rationale": "Client-side claude-code concern (ide, terminal); not a gateway/relay relevance signal.",
       "updated_at": "2026-06-03T20:18:31Z"
-    },
-    {
-      "upstream": "anthropics/claude-code#65059",
-      "url": "https://github.com/anthropics/claude-code/issues/65059",
-      "title": "[BUG] vscode extension incorrectly prepends /usr/bin to PATH",
-      "impact": "not_applicable",
-      "categories": [
-        "ide",
-        "terminal",
-        "slash_hook",
-        "install"
-      ],
-      "tokenkey_status": "not_applicable",
-      "rationale": "Client-side claude-code concern (ide, terminal, slash_hook, install); not a gateway/relay relevance signal.",
-      "updated_at": "2026-06-04T06:53:32Z"
     },
     {
       "upstream": "anthropics/claude-code#65060",
@@ -20429,7 +19781,7 @@
       ],
       "tokenkey_status": "not_applicable",
       "rationale": "Client-side claude-code concern (terminal); not a gateway/relay relevance signal.",
-      "updated_at": "2026-06-03T15:39:26Z"
+      "updated_at": "2026-06-04T15:56:41Z"
     },
     {
       "upstream": "anthropics/claude-code#65083",
@@ -20448,14 +19800,14 @@
     {
       "upstream": "anthropics/claude-code#65084",
       "url": "https://github.com/anthropics/claude-code/issues/65084",
-      "title": "[BUG]",
+      "title": "[BUG] cwd incorrectly inherited while in state-grouped agent view",
       "impact": "not_applicable",
       "categories": [
         "terminal"
       ],
       "tokenkey_status": "not_applicable",
       "rationale": "Client-side claude-code concern (terminal); not a gateway/relay relevance signal.",
-      "updated_at": "2026-06-03T15:49:03Z"
+      "updated_at": "2026-06-04T21:34:17Z"
     },
     {
       "upstream": "anthropics/claude-code#65086",
@@ -21058,7 +20410,7 @@
       ],
       "tokenkey_status": "not_applicable",
       "rationale": "Client-side claude-code concern (terminal); not a gateway/relay relevance signal.",
-      "updated_at": "2026-06-03T20:06:48Z"
+      "updated_at": "2026-06-04T19:07:02Z"
     },
     {
       "upstream": "anthropics/claude-code#65157",
@@ -22183,7 +21535,7 @@
       ],
       "tokenkey_status": "not_applicable",
       "rationale": "Client-side claude-code concern (terminal, plugin, slash_hook); not a gateway/relay relevance signal.",
-      "updated_at": "2026-06-04T07:42:14Z"
+      "updated_at": "2026-06-04T14:42:28Z"
     },
     {
       "upstream": "anthropics/claude-code#65300",
@@ -22361,7 +21713,7 @@
       ],
       "tokenkey_status": "not_applicable",
       "rationale": "Client-side claude-code concern (terminal); not a gateway/relay relevance signal.",
-      "updated_at": "2026-06-04T12:02:05Z"
+      "updated_at": "2026-06-04T19:02:43Z"
     },
     {
       "upstream": "anthropics/claude-code#65323",
@@ -22839,7 +22191,1302 @@
       ],
       "tokenkey_status": "not_applicable",
       "rationale": "Client-side claude-code concern (slash_hook); not a gateway/relay relevance signal.",
-      "updated_at": "2026-06-04T12:40:38Z"
+      "updated_at": "2026-06-04T12:48:57Z"
+    },
+    {
+      "upstream": "anthropics/claude-code#65372",
+      "url": "https://github.com/anthropics/claude-code/issues/65372",
+      "title": "Plugin marketplace auto-update rewrites .git/config of the user's current working directory",
+      "impact": "not_applicable",
+      "categories": [
+        "ide",
+        "plugin",
+        "install"
+      ],
+      "tokenkey_status": "not_applicable",
+      "rationale": "Client-side claude-code concern (ide, plugin, install); not a gateway/relay relevance signal.",
+      "updated_at": "2026-06-04T12:50:46Z"
+    },
+    {
+      "upstream": "anthropics/claude-code#65374",
+      "url": "https://github.com/anthropics/claude-code/issues/65374",
+      "title": "[BUG] Cowork-GlobalInstructions-Revert-Bug-Report_2026-06-03_v4",
+      "impact": "not_applicable",
+      "categories": [
+        "terminal"
+      ],
+      "tokenkey_status": "not_applicable",
+      "rationale": "Client-side claude-code concern (terminal); not a gateway/relay relevance signal.",
+      "updated_at": "2026-06-04T13:11:03Z"
+    },
+    {
+      "upstream": "anthropics/claude-code#65375",
+      "url": "https://github.com/anthropics/claude-code/issues/65375",
+      "title": "[Bug Report] Unable to process empty issue submission",
+      "impact": "not_applicable",
+      "categories": [
+        "ide",
+        "terminal"
+      ],
+      "tokenkey_status": "not_applicable",
+      "rationale": "Client-side claude-code concern (ide, terminal); not a gateway/relay relevance signal.",
+      "updated_at": "2026-06-04T13:16:59Z"
+    },
+    {
+      "upstream": "anthropics/claude-code#65376",
+      "url": "https://github.com/anthropics/claude-code/issues/65376",
+      "title": "[Bug] Claude Code ignores custom rules and .claude/ configuration files",
+      "impact": "not_applicable",
+      "categories": [
+        "terminal"
+      ],
+      "tokenkey_status": "not_applicable",
+      "rationale": "Client-side claude-code concern (terminal); not a gateway/relay relevance signal.",
+      "updated_at": "2026-06-04T13:27:11Z"
+    },
+    {
+      "upstream": "anthropics/claude-code#65378",
+      "url": "https://github.com/anthropics/claude-code/issues/65378",
+      "title": "Hooks fail with posix_spawn ENOENT when session cwd is deleted; request fallback cwd before spawning hooks",
+      "impact": "not_applicable",
+      "categories": [
+        "slash_hook"
+      ],
+      "tokenkey_status": "not_applicable",
+      "rationale": "Client-side claude-code concern (slash_hook); not a gateway/relay relevance signal.",
+      "updated_at": "2026-06-04T13:35:11Z"
+    },
+    {
+      "upstream": "anthropics/claude-code#65379",
+      "url": "https://github.com/anthropics/claude-code/issues/65379",
+      "title": "Auto-compact does not trigger after context exceeds 80%-100% (2.1.162)",
+      "impact": "not_applicable",
+      "categories": [
+        "ide",
+        "terminal",
+        "platform"
+      ],
+      "tokenkey_status": "not_applicable",
+      "rationale": "Client-side claude-code concern (ide, terminal, platform); not a gateway/relay relevance signal.",
+      "updated_at": "2026-06-04T13:44:34Z"
+    },
+    {
+      "upstream": "anthropics/claude-code#65380",
+      "url": "https://github.com/anthropics/claude-code/issues/65380",
+      "title": "Cursor extension: Claude Code tab is visible but never initialises after reopening Cursor (must open a new tab, losing the live session)",
+      "impact": "not_applicable",
+      "categories": [
+        "ide",
+        "terminal"
+      ],
+      "tokenkey_status": "not_applicable",
+      "rationale": "Client-side claude-code concern (ide, terminal); not a gateway/relay relevance signal.",
+      "updated_at": "2026-06-04T13:44:27Z"
+    },
+    {
+      "upstream": "anthropics/claude-code#65381",
+      "url": "https://github.com/anthropics/claude-code/issues/65381",
+      "title": "[BUG] Desktop auto-updater quit-and-installs while a Cowork task is running, killing the VM mid-task — updater should defer while VM sessions are active",
+      "impact": "not_applicable",
+      "categories": [
+        "ide",
+        "mcp",
+        "install"
+      ],
+      "tokenkey_status": "not_applicable",
+      "rationale": "Client-side claude-code concern (ide, mcp, install); not a gateway/relay relevance signal.",
+      "updated_at": "2026-06-04T13:55:03Z"
+    },
+    {
+      "upstream": "anthropics/claude-code#65382",
+      "url": "https://github.com/anthropics/claude-code/issues/65382",
+      "title": "[BUG] Cowork (macOS Desktop 1.9659.1): chat UI enters persistent broken state until app restart — messages stuck as ghost bubbles, AskUserQuestion never renders and is auto-denied (one confirmed trigger: webview connectivity loss)",
+      "impact": "not_applicable",
+      "categories": [
+        "terminal"
+      ],
+      "tokenkey_status": "not_applicable",
+      "rationale": "Client-side claude-code concern (terminal); not a gateway/relay relevance signal.",
+      "updated_at": "2026-06-04T14:11:34Z"
+    },
+    {
+      "upstream": "anthropics/claude-code#65383",
+      "url": "https://github.com/anthropics/claude-code/issues/65383",
+      "title": "[BUG] Claude is blocked from executing sleep commands",
+      "impact": "not_applicable",
+      "categories": [
+        "terminal",
+        "platform"
+      ],
+      "tokenkey_status": "not_applicable",
+      "rationale": "Client-side claude-code concern (terminal, platform); not a gateway/relay relevance signal.",
+      "updated_at": "2026-06-04T13:59:36Z"
+    },
+    {
+      "upstream": "anthropics/claude-code#65386",
+      "url": "https://github.com/anthropics/claude-code/issues/65386",
+      "title": "[Feature Request] Add setting to auto-approve or whitelist workflow executions",
+      "impact": "not_applicable",
+      "categories": [
+        "terminal"
+      ],
+      "tokenkey_status": "not_applicable",
+      "rationale": "Client-side claude-code concern (terminal); not a gateway/relay relevance signal.",
+      "updated_at": "2026-06-04T14:02:08Z"
+    },
+    {
+      "upstream": "anthropics/claude-code#65387",
+      "url": "https://github.com/anthropics/claude-code/issues/65387",
+      "title": "[Bug] Auto-commit triggered before issue resolution",
+      "impact": "not_applicable",
+      "categories": [
+        "terminal"
+      ],
+      "tokenkey_status": "not_applicable",
+      "rationale": "Client-side claude-code concern (terminal); not a gateway/relay relevance signal.",
+      "updated_at": "2026-06-04T14:04:58Z"
+    },
+    {
+      "upstream": "anthropics/claude-code#65388",
+      "url": "https://github.com/anthropics/claude-code/issues/65388",
+      "title": "[VSCode Extension] Custom session names revert after conversation continues",
+      "impact": "not_applicable",
+      "categories": [
+        "ide",
+        "slash_hook"
+      ],
+      "tokenkey_status": "not_applicable",
+      "rationale": "Client-side claude-code concern (ide, slash_hook); not a gateway/relay relevance signal.",
+      "updated_at": "2026-06-04T14:05:19Z"
+    },
+    {
+      "upstream": "anthropics/claude-code#65389",
+      "url": "https://github.com/anthropics/claude-code/issues/65389",
+      "title": "Subagent worktree isolation: Write/Edit sandbox CWD detaches from the git worktree (nested-worktree dispatch)",
+      "impact": "not_applicable",
+      "categories": [
+        "plugin",
+        "slash_hook"
+      ],
+      "tokenkey_status": "not_applicable",
+      "rationale": "Client-side claude-code concern (plugin, slash_hook); not a gateway/relay relevance signal.",
+      "updated_at": "2026-06-04T14:10:40Z"
+    },
+    {
+      "upstream": "anthropics/claude-code#65390",
+      "url": "https://github.com/anthropics/claude-code/issues/65390",
+      "title": "[Bug] BS command padding",
+      "impact": "not_applicable",
+      "categories": [
+        "terminal"
+      ],
+      "tokenkey_status": "not_applicable",
+      "rationale": "Client-side claude-code concern (terminal); not a gateway/relay relevance signal.",
+      "updated_at": "2026-06-04T14:13:59Z"
+    },
+    {
+      "upstream": "anthropics/claude-code#65391",
+      "url": "https://github.com/anthropics/claude-code/issues/65391",
+      "title": "Windows: native updater resolves install root via HOME while launcher/installer use USERPROFILE - claude update reports success but running binary never updates",
+      "impact": "not_applicable",
+      "categories": [
+        "install",
+        "platform"
+      ],
+      "tokenkey_status": "not_applicable",
+      "rationale": "Client-side claude-code concern (install, platform); not a gateway/relay relevance signal.",
+      "updated_at": "2026-06-04T14:29:50Z"
+    },
+    {
+      "upstream": "anthropics/claude-code#65392",
+      "url": "https://github.com/anthropics/claude-code/issues/65392",
+      "title": "[BUG] Pressing Ctrl-O (scrollback) while an AskUserQuestion is pending dismisses it as \"User declined to answer questions\"",
+      "impact": "not_applicable",
+      "categories": [
+        "terminal"
+      ],
+      "tokenkey_status": "not_applicable",
+      "rationale": "Client-side claude-code concern (terminal); not a gateway/relay relevance signal.",
+      "updated_at": "2026-06-04T21:04:10Z"
+    },
+    {
+      "upstream": "anthropics/claude-code#65393",
+      "url": "https://github.com/anthropics/claude-code/issues/65393",
+      "title": "Permission rules should (optionally) evaluate against the original input when a PreToolUse hook returns updatedInput",
+      "impact": "not_applicable",
+      "categories": [
+        "slash_hook",
+        "install"
+      ],
+      "tokenkey_status": "not_applicable",
+      "rationale": "Client-side claude-code concern (slash_hook, install); not a gateway/relay relevance signal.",
+      "updated_at": "2026-06-04T14:39:15Z"
+    },
+    {
+      "upstream": "anthropics/claude-code#65394",
+      "url": "https://github.com/anthropics/claude-code/issues/65394",
+      "title": "[BUG] Fullscreen renderer corrupts pasted multibyte UTF-8 (Korean/CJK) on Windows — bytes decoded as Latin-1; default renderer unaffected",
+      "impact": "not_applicable",
+      "categories": [
+        "ide",
+        "terminal",
+        "platform"
+      ],
+      "tokenkey_status": "not_applicable",
+      "rationale": "Client-side claude-code concern (ide, terminal, platform); not a gateway/relay relevance signal.",
+      "updated_at": "2026-06-04T14:41:23Z"
+    },
+    {
+      "upstream": "anthropics/claude-code#65396",
+      "url": "https://github.com/anthropics/claude-code/issues/65396",
+      "title": "Add a setting to hide the usage-limit warning banner in the chat UI",
+      "impact": "not_applicable",
+      "categories": [
+        "ide",
+        "slash_hook",
+        "platform"
+      ],
+      "tokenkey_status": "not_applicable",
+      "rationale": "Client-side claude-code concern (ide, slash_hook, platform); not a gateway/relay relevance signal.",
+      "updated_at": "2026-06-04T15:47:16Z"
+    },
+    {
+      "upstream": "anthropics/claude-code#65398",
+      "url": "https://github.com/anthropics/claude-code/issues/65398",
+      "title": "JetBrains plugin: mouse scroll stopped working in Claude Code panel",
+      "impact": "not_applicable",
+      "categories": [
+        "ide",
+        "terminal",
+        "plugin"
+      ],
+      "tokenkey_status": "not_applicable",
+      "rationale": "Client-side claude-code concern (ide, terminal, plugin); not a gateway/relay relevance signal.",
+      "updated_at": "2026-06-04T14:59:27Z"
+    },
+    {
+      "upstream": "anthropics/claude-code#65399",
+      "url": "https://github.com/anthropics/claude-code/issues/65399",
+      "title": "Cannot remove/change primary working directory, and stale folder paths are unrecoverable",
+      "impact": "not_applicable",
+      "categories": [
+        "terminal"
+      ],
+      "tokenkey_status": "not_applicable",
+      "rationale": "Client-side claude-code concern (terminal); not a gateway/relay relevance signal.",
+      "updated_at": "2026-06-04T15:09:47Z"
+    },
+    {
+      "upstream": "anthropics/claude-code#65400",
+      "url": "https://github.com/anthropics/claude-code/issues/65400",
+      "title": "No visual indicator distinguishing cloud sessions from local sessions in the session list (desktop)",
+      "impact": "not_applicable",
+      "categories": [
+        "terminal"
+      ],
+      "tokenkey_status": "not_applicable",
+      "rationale": "Client-side claude-code concern (terminal); not a gateway/relay relevance signal.",
+      "updated_at": "2026-06-04T15:15:42Z"
+    },
+    {
+      "upstream": "anthropics/claude-code#65401",
+      "url": "https://github.com/anthropics/claude-code/issues/65401",
+      "title": "[Bug] Bash tool stdout capture fails with spurious ENOSPC on macOS despite ample disk space",
+      "impact": "not_applicable",
+      "categories": [
+        "terminal"
+      ],
+      "tokenkey_status": "not_applicable",
+      "rationale": "Client-side claude-code concern (terminal); not a gateway/relay relevance signal.",
+      "updated_at": "2026-06-04T15:19:54Z"
+    },
+    {
+      "upstream": "anthropics/claude-code#65402",
+      "url": "https://github.com/anthropics/claude-code/issues/65402",
+      "title": "[Feature Request] Display message timestamps in local timezone for each turn",
+      "impact": "not_applicable",
+      "categories": [
+        "terminal"
+      ],
+      "tokenkey_status": "not_applicable",
+      "rationale": "Client-side claude-code concern (terminal); not a gateway/relay relevance signal.",
+      "updated_at": "2026-06-04T15:20:59Z"
+    },
+    {
+      "upstream": "anthropics/claude-code#65403",
+      "url": "https://github.com/anthropics/claude-code/issues/65403",
+      "title": "[BUG] PostToolUse updatedToolOutput still not honored for Bash tool — secrets leak into model context",
+      "impact": "not_applicable",
+      "categories": [
+        "terminal",
+        "slash_hook"
+      ],
+      "tokenkey_status": "not_applicable",
+      "rationale": "Client-side claude-code concern (terminal, slash_hook); not a gateway/relay relevance signal.",
+      "updated_at": "2026-06-04T15:26:05Z"
+    },
+    {
+      "upstream": "anthropics/claude-code#65404",
+      "url": "https://github.com/anthropics/claude-code/issues/65404",
+      "title": "[Bug] MCP setup initialization fails with multiple connection errors",
+      "impact": "not_applicable",
+      "categories": [
+        "terminal",
+        "mcp"
+      ],
+      "tokenkey_status": "not_applicable",
+      "rationale": "Client-side claude-code concern (terminal, mcp); not a gateway/relay relevance signal.",
+      "updated_at": "2026-06-04T15:35:54Z"
+    },
+    {
+      "upstream": "anthropics/claude-code#65405",
+      "url": "https://github.com/anthropics/claude-code/issues/65405",
+      "title": "[Bug] CLI incorrectly initializes as session manager instead of regular Claude session",
+      "impact": "not_applicable",
+      "categories": [
+        "terminal"
+      ],
+      "tokenkey_status": "not_applicable",
+      "rationale": "Client-side claude-code concern (terminal); not a gateway/relay relevance signal.",
+      "updated_at": "2026-06-04T15:59:18Z"
+    },
+    {
+      "upstream": "anthropics/claude-code#65409",
+      "url": "https://github.com/anthropics/claude-code/issues/65409",
+      "title": "[FEATURE] Per-session spend cap for interactive / auto mode (extend --max-budget-usd beyond -p)",
+      "impact": "not_applicable",
+      "categories": [
+        "slash_hook"
+      ],
+      "tokenkey_status": "not_applicable",
+      "rationale": "Client-side claude-code concern (slash_hook); not a gateway/relay relevance signal.",
+      "updated_at": "2026-06-04T17:00:31Z"
+    },
+    {
+      "upstream": "anthropics/claude-code#65411",
+      "url": "https://github.com/anthropics/claude-code/issues/65411",
+      "title": "[BUG] /btw queued-message panel renders with heavy irregular inverse-highlight bleed — hard to read",
+      "impact": "not_applicable",
+      "categories": [
+        "terminal"
+      ],
+      "tokenkey_status": "not_applicable",
+      "rationale": "Client-side claude-code concern (terminal); not a gateway/relay relevance signal.",
+      "updated_at": "2026-06-04T15:59:29Z"
+    },
+    {
+      "upstream": "anthropics/claude-code#65416",
+      "url": "https://github.com/anthropics/claude-code/issues/65416",
+      "title": "Active /goal Stop hook overrides an explicit user redirect (interrupt + handoff request)",
+      "impact": "not_applicable",
+      "categories": [
+        "slash_hook"
+      ],
+      "tokenkey_status": "not_applicable",
+      "rationale": "Client-side claude-code concern (slash_hook); not a gateway/relay relevance signal.",
+      "updated_at": "2026-06-04T16:34:50Z"
+    },
+    {
+      "upstream": "anthropics/claude-code#65417",
+      "url": "https://github.com/anthropics/claude-code/issues/65417",
+      "title": "[FEATURE] Expose active scheduled task (cron) state to status line scripts",
+      "impact": "not_applicable",
+      "categories": [
+        "terminal"
+      ],
+      "tokenkey_status": "not_applicable",
+      "rationale": "Client-side claude-code concern (terminal); not a gateway/relay relevance signal.",
+      "updated_at": "2026-06-04T16:37:12Z"
+    },
+    {
+      "upstream": "anthropics/claude-code#65419",
+      "url": "https://github.com/anthropics/claude-code/issues/65419",
+      "title": "[Bug] MCP Server Configuration Failed During Setup",
+      "impact": "not_applicable",
+      "categories": [
+        "ide",
+        "terminal",
+        "mcp"
+      ],
+      "tokenkey_status": "not_applicable",
+      "rationale": "Client-side claude-code concern (ide, terminal, mcp); not a gateway/relay relevance signal.",
+      "updated_at": "2026-06-04T16:45:18Z"
+    },
+    {
+      "upstream": "anthropics/claude-code#65420",
+      "url": "https://github.com/anthropics/claude-code/issues/65420",
+      "title": "[BUG] Plan upgrades can cause multiple org uuids for the same email and lead to double billing or denial of service",
+      "impact": "not_applicable",
+      "categories": [
+        "terminal",
+        "platform"
+      ],
+      "tokenkey_status": "not_applicable",
+      "rationale": "Client-side claude-code concern (terminal, platform); not a gateway/relay relevance signal.",
+      "updated_at": "2026-06-04T16:55:47Z"
+    },
+    {
+      "upstream": "anthropics/claude-code#65421",
+      "url": "https://github.com/anthropics/claude-code/issues/65421",
+      "title": "**[URGENT BILLING] Account disabled 24h after payment — Max plan 5x — Invoice ZSSGG6AO-0004 — 7 days without service**",
+      "impact": "not_applicable",
+      "categories": [
+        "terminal",
+        "platform"
+      ],
+      "tokenkey_status": "not_applicable",
+      "rationale": "Client-side claude-code concern (terminal, platform); not a gateway/relay relevance signal.",
+      "updated_at": "2026-06-04T17:37:52Z"
+    },
+    {
+      "upstream": "anthropics/claude-code#65423",
+      "url": "https://github.com/anthropics/claude-code/issues/65423",
+      "title": "[BUG] Parallel sub-agents permanently wedge after completing work — unkillable, ignore queued input, \"Tool result missing due to internal error\", 8h+ zombies (Windows, 2.1.162)",
+      "impact": "not_applicable",
+      "categories": [
+        "terminal",
+        "mcp",
+        "plugin",
+        "platform"
+      ],
+      "tokenkey_status": "not_applicable",
+      "rationale": "Client-side claude-code concern (terminal, mcp, plugin, platform); not a gateway/relay relevance signal.",
+      "updated_at": "2026-06-04T17:01:22Z"
+    },
+    {
+      "upstream": "anthropics/claude-code#65426",
+      "url": "https://github.com/anthropics/claude-code/issues/65426",
+      "title": "Cowork (desktop) can't update a custom git-marketplace plugin — reverts to old version on relaunch; blocks scheduled tasks",
+      "impact": "not_applicable",
+      "categories": [
+        "plugin",
+        "install"
+      ],
+      "tokenkey_status": "not_applicable",
+      "rationale": "Client-side claude-code concern (plugin, install); not a gateway/relay relevance signal.",
+      "updated_at": "2026-06-04T17:10:17Z"
+    },
+    {
+      "upstream": "anthropics/claude-code#65427",
+      "url": "https://github.com/anthropics/claude-code/issues/65427",
+      "title": "[Bug] Anthropic API Error: Tool Call Parse Failure",
+      "impact": "not_applicable",
+      "categories": [
+        "terminal"
+      ],
+      "tokenkey_status": "not_applicable",
+      "rationale": "Client-side claude-code concern (terminal); not a gateway/relay relevance signal.",
+      "updated_at": "2026-06-04T17:16:15Z"
+    },
+    {
+      "upstream": "anthropics/claude-code#65431",
+      "url": "https://github.com/anthropics/claude-code/issues/65431",
+      "title": "Feature request: Color-code sidebar sessions by status (active / paused / completed)",
+      "impact": "not_applicable",
+      "categories": [
+        "terminal",
+        "slash_hook"
+      ],
+      "tokenkey_status": "not_applicable",
+      "rationale": "Client-side claude-code concern (terminal, slash_hook); not a gateway/relay relevance signal.",
+      "updated_at": "2026-06-04T18:00:17Z"
+    },
+    {
+      "upstream": "anthropics/claude-code#65432",
+      "url": "https://github.com/anthropics/claude-code/issues/65432",
+      "title": "[BUG] Claude Desktop on Windows shows persistent gray screen with no UI elements",
+      "impact": "not_applicable",
+      "categories": [
+        "terminal",
+        "platform"
+      ],
+      "tokenkey_status": "not_applicable",
+      "rationale": "Client-side claude-code concern (terminal, platform); not a gateway/relay relevance signal.",
+      "updated_at": "2026-06-04T17:53:32Z"
+    },
+    {
+      "upstream": "anthropics/claude-code#65433",
+      "url": "https://github.com/anthropics/claude-code/issues/65433",
+      "title": "Permission matcher prompts for ls <python-interpreter-path> despite Bash(ls *) allow rule",
+      "impact": "not_applicable",
+      "categories": [
+        "terminal",
+        "slash_hook"
+      ],
+      "tokenkey_status": "not_applicable",
+      "rationale": "Client-side claude-code concern (terminal, slash_hook); not a gateway/relay relevance signal.",
+      "updated_at": "2026-06-04T17:57:29Z"
+    },
+    {
+      "upstream": "anthropics/claude-code#65434",
+      "url": "https://github.com/anthropics/claude-code/issues/65434",
+      "title": "[Bug] Potential networking configuration issue - request for diagnostic logs and tunnel verification",
+      "impact": "not_applicable",
+      "categories": [
+        "ide",
+        "terminal"
+      ],
+      "tokenkey_status": "not_applicable",
+      "rationale": "Client-side claude-code concern (ide, terminal); not a gateway/relay relevance signal.",
+      "updated_at": "2026-06-04T17:56:49Z"
+    },
+    {
+      "upstream": "anthropics/claude-code#65435",
+      "url": "https://github.com/anthropics/claude-code/issues/65435",
+      "title": "[FEATURE] Add a way to remove a working directory from the current session (counterpart to /add-dir)",
+      "impact": "not_applicable",
+      "categories": [
+        "slash_hook"
+      ],
+      "tokenkey_status": "not_applicable",
+      "rationale": "Client-side claude-code concern (slash_hook); not a gateway/relay relevance signal.",
+      "updated_at": "2026-06-04T18:01:49Z"
+    },
+    {
+      "upstream": "anthropics/claude-code#65437",
+      "url": "https://github.com/anthropics/claude-code/issues/65437",
+      "title": "[FEATURE] Plugin Manager: bucket view, overlap detection, and hygiene recommendations",
+      "impact": "not_applicable",
+      "categories": [
+        "plugin"
+      ],
+      "tokenkey_status": "not_applicable",
+      "rationale": "Client-side claude-code concern (plugin); not a gateway/relay relevance signal.",
+      "updated_at": "2026-06-04T20:03:45Z"
+    },
+    {
+      "upstream": "anthropics/claude-code#65438",
+      "url": "https://github.com/anthropics/claude-code/issues/65438",
+      "title": "Plugin cache: session-start .in_use PID locks are never reaped (285k accumulated), starving superseded-version cleanup",
+      "impact": "not_applicable",
+      "categories": [
+        "plugin",
+        "platform"
+      ],
+      "tokenkey_status": "not_applicable",
+      "rationale": "Client-side claude-code concern (plugin, platform); not a gateway/relay relevance signal.",
+      "updated_at": "2026-06-04T18:03:21Z"
+    },
+    {
+      "upstream": "anthropics/claude-code#65439",
+      "url": "https://github.com/anthropics/claude-code/issues/65439",
+      "title": "Chrome extension not working",
+      "impact": "not_applicable",
+      "categories": [
+        "ide",
+        "install"
+      ],
+      "tokenkey_status": "not_applicable",
+      "rationale": "Client-side claude-code concern (ide, install); not a gateway/relay relevance signal.",
+      "updated_at": "2026-06-04T18:07:38Z"
+    },
+    {
+      "upstream": "anthropics/claude-code#65440",
+      "url": "https://github.com/anthropics/claude-code/issues/65440",
+      "title": "[BUG] Subprocess initialization timeout (60s) on VSCode 1.123.0 with Node.js v24 — PendingMigrationError: navigator is now a global",
+      "impact": "not_applicable",
+      "categories": [
+        "ide",
+        "terminal",
+        "install",
+        "platform"
+      ],
+      "tokenkey_status": "not_applicable",
+      "rationale": "Client-side claude-code concern (ide, terminal, install, platform); not a gateway/relay relevance signal.",
+      "updated_at": "2026-06-04T18:13:18Z"
+    },
+    {
+      "upstream": "anthropics/claude-code#65441",
+      "url": "https://github.com/anthropics/claude-code/issues/65441",
+      "title": "Startup error: ENOENT scanning non-existent managed skills directory",
+      "impact": "not_applicable",
+      "categories": [
+        "install"
+      ],
+      "tokenkey_status": "not_applicable",
+      "rationale": "Client-side claude-code concern (install); not a gateway/relay relevance signal.",
+      "updated_at": "2026-06-04T18:13:00Z"
+    },
+    {
+      "upstream": "anthropics/claude-code#65442",
+      "url": "https://github.com/anthropics/claude-code/issues/65442",
+      "title": "[BUG] New session silently inherits the previous project's working directory with no warning — risks edits/commits in the wrong project",
+      "impact": "not_applicable",
+      "categories": [
+        "plugin"
+      ],
+      "tokenkey_status": "not_applicable",
+      "rationale": "Client-side claude-code concern (plugin); not a gateway/relay relevance signal.",
+      "updated_at": "2026-06-04T18:26:16Z"
+    },
+    {
+      "upstream": "anthropics/claude-code#65443",
+      "url": "https://github.com/anthropics/claude-code/issues/65443",
+      "title": "Desktop preview pane serves stale HTML — doesn't refresh on Reload after the file changes",
+      "impact": "not_applicable",
+      "categories": [
+        "terminal",
+        "platform"
+      ],
+      "tokenkey_status": "not_applicable",
+      "rationale": "Client-side claude-code concern (terminal, platform); not a gateway/relay relevance signal.",
+      "updated_at": "2026-06-04T18:29:14Z"
+    },
+    {
+      "upstream": "anthropics/claude-code#65445",
+      "url": "https://github.com/anthropics/claude-code/issues/65445",
+      "title": "[Bug] Directory permissions revoked during Claude Code execution",
+      "impact": "not_applicable",
+      "categories": [
+        "terminal"
+      ],
+      "tokenkey_status": "not_applicable",
+      "rationale": "Client-side claude-code concern (terminal); not a gateway/relay relevance signal.",
+      "updated_at": "2026-06-04T18:47:38Z"
+    },
+    {
+      "upstream": "anthropics/claude-code#65446",
+      "url": "https://github.com/anthropics/claude-code/issues/65446",
+      "title": "[FEATURE] Allow the Dynamic Workflows sandbox to execute external code / tools",
+      "impact": "not_applicable",
+      "categories": [
+        "plugin",
+        "install"
+      ],
+      "tokenkey_status": "not_applicable",
+      "rationale": "Client-side claude-code concern (plugin, install); not a gateway/relay relevance signal.",
+      "updated_at": "2026-06-04T18:56:13Z"
+    },
+    {
+      "upstream": "anthropics/claude-code#65447",
+      "url": "https://github.com/anthropics/claude-code/issues/65447",
+      "title": "[Bug] Claude misinterprets user clarification as agreement and repeats dismissed options",
+      "impact": "not_applicable",
+      "categories": [
+        "terminal"
+      ],
+      "tokenkey_status": "not_applicable",
+      "rationale": "Client-side claude-code concern (terminal); not a gateway/relay relevance signal.",
+      "updated_at": "2026-06-04T18:56:59Z"
+    },
+    {
+      "upstream": "anthropics/claude-code#65448",
+      "url": "https://github.com/anthropics/claude-code/issues/65448",
+      "title": "Fast mode toggle missing for Team/org account in Claude Desktop app, but works in CLI for same account",
+      "impact": "not_applicable",
+      "categories": [
+        "terminal"
+      ],
+      "tokenkey_status": "not_applicable",
+      "rationale": "Client-side claude-code concern (terminal); not a gateway/relay relevance signal.",
+      "updated_at": "2026-06-04T18:56:41Z"
+    },
+    {
+      "upstream": "anthropics/claude-code#65451",
+      "url": "https://github.com/anthropics/claude-code/issues/65451",
+      "title": ".claude.json workspace trust wiped by concurrent writes; path normalization stores duplicate false entries (Windows)",
+      "impact": "not_applicable",
+      "categories": [
+        "install",
+        "platform"
+      ],
+      "tokenkey_status": "not_applicable",
+      "rationale": "Client-side claude-code concern (install, platform); not a gateway/relay relevance signal.",
+      "updated_at": "2026-06-04T19:12:42Z"
+    },
+    {
+      "upstream": "anthropics/claude-code#65452",
+      "url": "https://github.com/anthropics/claude-code/issues/65452",
+      "title": "[Feature Request] Add option to defer queued message delivery until turn completion",
+      "impact": "not_applicable",
+      "categories": [
+        "terminal"
+      ],
+      "tokenkey_status": "not_applicable",
+      "rationale": "Client-side claude-code concern (terminal); not a gateway/relay relevance signal.",
+      "updated_at": "2026-06-04T19:09:52Z"
+    },
+    {
+      "upstream": "anthropics/claude-code#65453",
+      "url": "https://github.com/anthropics/claude-code/issues/65453",
+      "title": "[Bug] Malformed tool invocation tags cause silent parser failures in multi-step sessions",
+      "impact": "not_applicable",
+      "categories": [
+        "terminal",
+        "mcp"
+      ],
+      "tokenkey_status": "not_applicable",
+      "rationale": "Client-side claude-code concern (terminal, mcp); not a gateway/relay relevance signal.",
+      "updated_at": "2026-06-04T19:15:24Z"
+    },
+    {
+      "upstream": "anthropics/claude-code#65454",
+      "url": "https://github.com/anthropics/claude-code/issues/65454",
+      "title": "[Bug] Anthropic API Error: Usage Policy violation blocks entire session instead of allowing recovery",
+      "impact": "not_applicable",
+      "categories": [
+        "terminal"
+      ],
+      "tokenkey_status": "not_applicable",
+      "rationale": "Client-side claude-code concern (terminal); not a gateway/relay relevance signal.",
+      "updated_at": "2026-06-04T19:18:03Z"
+    },
+    {
+      "upstream": "anthropics/claude-code#65455",
+      "url": "https://github.com/anthropics/claude-code/issues/65455",
+      "title": "[Feature Request] Display release dates alongside version numbers in /release-notes",
+      "impact": "not_applicable",
+      "categories": [
+        "terminal"
+      ],
+      "tokenkey_status": "not_applicable",
+      "rationale": "Client-side claude-code concern (terminal); not a gateway/relay relevance signal.",
+      "updated_at": "2026-06-04T19:20:12Z"
+    },
+    {
+      "upstream": "anthropics/claude-code#65456",
+      "url": "https://github.com/anthropics/claude-code/issues/65456",
+      "title": "[FEATURE] Cross-project session handoff: spawn an autonomous session in another directory and read its results back",
+      "impact": "not_applicable",
+      "categories": [
+        "ide",
+        "plugin"
+      ],
+      "tokenkey_status": "not_applicable",
+      "rationale": "Client-side claude-code concern (ide, plugin); not a gateway/relay relevance signal.",
+      "updated_at": "2026-06-04T19:22:29Z"
+    },
+    {
+      "upstream": "anthropics/claude-code#65458",
+      "url": "https://github.com/anthropics/claude-code/issues/65458",
+      "title": "[Bug] Team workflow doesn't wait for lead approval before executing plans",
+      "impact": "not_applicable",
+      "categories": [
+        "terminal"
+      ],
+      "tokenkey_status": "not_applicable",
+      "rationale": "Client-side claude-code concern (terminal); not a gateway/relay relevance signal.",
+      "updated_at": "2026-06-04T19:39:47Z"
+    },
+    {
+      "upstream": "anthropics/claude-code#65461",
+      "url": "https://github.com/anthropics/claude-code/issues/65461",
+      "title": "[BUG] Prompt processing hangs after interrupting Claude",
+      "impact": "not_applicable",
+      "categories": [
+        "terminal",
+        "plugin"
+      ],
+      "tokenkey_status": "not_applicable",
+      "rationale": "Client-side claude-code concern (terminal, plugin); not a gateway/relay relevance signal.",
+      "updated_at": "2026-06-04T19:41:40Z"
+    },
+    {
+      "upstream": "anthropics/claude-code#65462",
+      "url": "https://github.com/anthropics/claude-code/issues/65462",
+      "title": "Remote Control: typed text disappears from input field on mobile",
+      "impact": "not_applicable",
+      "categories": [
+        "terminal",
+        "slash_hook"
+      ],
+      "tokenkey_status": "not_applicable",
+      "rationale": "Client-side claude-code concern (terminal, slash_hook); not a gateway/relay relevance signal.",
+      "updated_at": "2026-06-04T19:49:39Z"
+    },
+    {
+      "upstream": "anthropics/claude-code#65465",
+      "url": "https://github.com/anthropics/claude-code/issues/65465",
+      "title": "[BUG] Anthropic surveys popping out of nowhere asking for a 1 ,2, 3, 4",
+      "impact": "not_applicable",
+      "categories": [
+        "terminal",
+        "platform"
+      ],
+      "tokenkey_status": "not_applicable",
+      "rationale": "Client-side claude-code concern (terminal, platform); not a gateway/relay relevance signal.",
+      "updated_at": "2026-06-04T20:18:30Z"
+    },
+    {
+      "upstream": "anthropics/claude-code#65467",
+      "url": "https://github.com/anthropics/claude-code/issues/65467",
+      "title": "claude-in-chrome MCP: bridge fails silently — extension service worker never receives any message",
+      "impact": "not_applicable",
+      "categories": [
+        "ide",
+        "mcp",
+        "install"
+      ],
+      "tokenkey_status": "not_applicable",
+      "rationale": "Client-side claude-code concern (ide, mcp, install); not a gateway/relay relevance signal.",
+      "updated_at": "2026-06-04T22:34:04Z"
+    },
+    {
+      "upstream": "anthropics/claude-code#65468",
+      "url": "https://github.com/anthropics/claude-code/issues/65468",
+      "title": "iOS remote app: stranded scroll-to-bottom chevron makes AskUserQuestion Submit button non-interactable after foregrounding from push notification",
+      "impact": "not_applicable",
+      "categories": [
+        "terminal"
+      ],
+      "tokenkey_status": "not_applicable",
+      "rationale": "Client-side claude-code concern (terminal); not a gateway/relay relevance signal.",
+      "updated_at": "2026-06-04T20:31:13Z"
+    },
+    {
+      "upstream": "anthropics/claude-code#65470",
+      "url": "https://github.com/anthropics/claude-code/issues/65470",
+      "title": "[BUG] Claude Code for VS Code fork starts with a blank state",
+      "impact": "not_applicable",
+      "categories": [
+        "ide",
+        "terminal"
+      ],
+      "tokenkey_status": "not_applicable",
+      "rationale": "Client-side claude-code concern (ide, terminal); not a gateway/relay relevance signal.",
+      "updated_at": "2026-06-04T20:28:56Z"
+    },
+    {
+      "upstream": "anthropics/claude-code#65471",
+      "url": "https://github.com/anthropics/claude-code/issues/65471",
+      "title": "Voice dictation in Claude Desktop app captures audio but never transcribes (inserts a stray \"/\") on macOS",
+      "impact": "not_applicable",
+      "categories": [
+        "terminal",
+        "slash_hook",
+        "platform"
+      ],
+      "tokenkey_status": "not_applicable",
+      "rationale": "Client-side claude-code concern (terminal, slash_hook, platform); not a gateway/relay relevance signal.",
+      "updated_at": "2026-06-04T21:18:50Z"
+    },
+    {
+      "upstream": "anthropics/claude-code#65473",
+      "url": "https://github.com/anthropics/claude-code/issues/65473",
+      "title": "Claude-in-Chrome: list_connected_browsers returns 'not connected' despite extension installed and logged in",
+      "impact": "not_applicable",
+      "categories": [
+        "ide",
+        "mcp"
+      ],
+      "tokenkey_status": "not_applicable",
+      "rationale": "Client-side claude-code concern (ide, mcp); not a gateway/relay relevance signal.",
+      "updated_at": "2026-06-04T20:56:06Z"
+    },
+    {
+      "upstream": "anthropics/claude-code#65475",
+      "url": "https://github.com/anthropics/claude-code/issues/65475",
+      "title": "VSCode: Per-tab activity indicator (working vs. idle) for multiple Claude Code sessions",
+      "impact": "not_applicable",
+      "categories": [
+        "ide",
+        "terminal"
+      ],
+      "tokenkey_status": "not_applicable",
+      "rationale": "Client-side claude-code concern (ide, terminal); not a gateway/relay relevance signal.",
+      "updated_at": "2026-06-04T21:01:03Z"
+    },
+    {
+      "upstream": "anthropics/claude-code#65476",
+      "url": "https://github.com/anthropics/claude-code/issues/65476",
+      "title": "[FEATURE] Allow managed settings to control the \"Default\" model and model display labels in /model picker",
+      "impact": "not_applicable",
+      "categories": [
+        "slash_hook"
+      ],
+      "tokenkey_status": "not_applicable",
+      "rationale": "Client-side claude-code concern (slash_hook); not a gateway/relay relevance signal.",
+      "updated_at": "2026-06-04T21:05:42Z"
+    },
+    {
+      "upstream": "anthropics/claude-code#65478",
+      "url": "https://github.com/anthropics/claude-code/issues/65478",
+      "title": "Windows auto-update renames bin/claude.exe to .old with no atomic fallback - kills all concurrent sessions (terminals, agents, Cursor) at once (v2.1.162)",
+      "impact": "not_applicable",
+      "categories": [
+        "ide",
+        "terminal",
+        "install",
+        "platform"
+      ],
+      "tokenkey_status": "not_applicable",
+      "rationale": "Client-side claude-code concern (ide, terminal, install, platform); not a gateway/relay relevance signal.",
+      "updated_at": "2026-06-04T21:08:05Z"
+    },
+    {
+      "upstream": "anthropics/claude-code#65479",
+      "url": "https://github.com/anthropics/claude-code/issues/65479",
+      "title": "[BUG] VS Code 1.123 Agents Window: \"Error during execution\" + Extension Host unresponsive — \"No chat session found for resource: [object Object]\" (Windows, Vertex AI)",
+      "impact": "not_applicable",
+      "categories": [
+        "ide",
+        "mcp",
+        "plugin",
+        "install",
+        "platform"
+      ],
+      "tokenkey_status": "not_applicable",
+      "rationale": "Client-side claude-code concern (ide, mcp, plugin, install, platform); not a gateway/relay relevance signal.",
+      "updated_at": "2026-06-04T21:13:08Z"
+    },
+    {
+      "upstream": "anthropics/claude-code#65480",
+      "url": "https://github.com/anthropics/claude-code/issues/65480",
+      "title": "[BUG] bypassPermissions mode not accessible via Shift+Tab or CLI flags (v2.1.162, macOS)",
+      "impact": "not_applicable",
+      "categories": [
+        "terminal"
+      ],
+      "tokenkey_status": "not_applicable",
+      "rationale": "Client-side claude-code concern (terminal); not a gateway/relay relevance signal.",
+      "updated_at": "2026-06-04T21:31:25Z"
+    },
+    {
+      "upstream": "anthropics/claude-code#65481",
+      "url": "https://github.com/anthropics/claude-code/issues/65481",
+      "title": "Approving a plan from a remote session drops out of auto mode despite useAutoModeDuringPlan: true",
+      "impact": "not_applicable",
+      "categories": [
+        "terminal",
+        "slash_hook"
+      ],
+      "tokenkey_status": "not_applicable",
+      "rationale": "Client-side claude-code concern (terminal, slash_hook); not a gateway/relay relevance signal.",
+      "updated_at": "2026-06-04T21:29:43Z"
+    },
+    {
+      "upstream": "anthropics/claude-code#65482",
+      "url": "https://github.com/anthropics/claude-code/issues/65482",
+      "title": "[BUG] sandbox.network.allowedDomains cannot allow localhost — NO_PROXY bypass prevents proxy routing to local services",
+      "impact": "not_applicable",
+      "categories": [
+        "ide",
+        "slash_hook"
+      ],
+      "tokenkey_status": "not_applicable",
+      "rationale": "Client-side claude-code concern (ide, slash_hook); not a gateway/relay relevance signal.",
+      "updated_at": "2026-06-04T21:39:55Z"
+    },
+    {
+      "upstream": "anthropics/claude-code#65483",
+      "url": "https://github.com/anthropics/claude-code/issues/65483",
+      "title": "/doctor 1 error shown at startup but claude doctor output shows no errors",
+      "impact": "not_applicable",
+      "categories": [
+        "platform"
+      ],
+      "tokenkey_status": "not_applicable",
+      "rationale": "Client-side claude-code concern (platform); not a gateway/relay relevance signal.",
+      "updated_at": "2026-06-04T21:44:07Z"
+    },
+    {
+      "upstream": "anthropics/claude-code#65485",
+      "url": "https://github.com/anthropics/claude-code/issues/65485",
+      "title": "/doctor 1 error shown at startup but claude doctor output shows no errors",
+      "impact": "not_applicable",
+      "categories": [
+        "platform"
+      ],
+      "tokenkey_status": "not_applicable",
+      "rationale": "Client-side claude-code concern (platform); not a gateway/relay relevance signal.",
+      "updated_at": "2026-06-04T21:40:39Z"
+    },
+    {
+      "upstream": "anthropics/claude-code#65486",
+      "url": "https://github.com/anthropics/claude-code/issues/65486",
+      "title": "Ctrl+Z silently destroys active sessions — this is an unacceptable UX failure for a context-heavy tool",
+      "impact": "not_applicable",
+      "categories": [
+        "terminal",
+        "slash_hook"
+      ],
+      "tokenkey_status": "not_applicable",
+      "rationale": "Client-side claude-code concern (terminal, slash_hook); not a gateway/relay relevance signal.",
+      "updated_at": "2026-06-04T21:45:51Z"
+    },
+    {
+      "upstream": "anthropics/claude-code#65487",
+      "url": "https://github.com/anthropics/claude-code/issues/65487",
+      "title": "You've hit your session limit · resets 4:50am (Asia/Amman)",
+      "impact": "not_applicable",
+      "categories": [
+        "terminal"
+      ],
+      "tokenkey_status": "not_applicable",
+      "rationale": "Client-side claude-code concern (terminal); not a gateway/relay relevance signal.",
+      "updated_at": "2026-06-04T21:47:55Z"
+    },
+    {
+      "upstream": "anthropics/claude-code#65488",
+      "url": "https://github.com/anthropics/claude-code/issues/65488",
+      "title": "[BUG] Desktop app: auto-fix monitoring only subscribes to the first PR created in a session — later same-session PRs (visible in UI) get no review-comment/CI events",
+      "impact": "not_applicable",
+      "categories": [
+        "terminal"
+      ],
+      "tokenkey_status": "not_applicable",
+      "rationale": "Client-side claude-code concern (terminal); not a gateway/relay relevance signal.",
+      "updated_at": "2026-06-04T22:00:49Z"
+    },
+    {
+      "upstream": "anthropics/claude-code#65489",
+      "url": "https://github.com/anthropics/claude-code/issues/65489",
+      "title": "[FEATURE]",
+      "impact": "not_applicable",
+      "categories": [
+        "ide",
+        "mcp"
+      ],
+      "tokenkey_status": "not_applicable",
+      "rationale": "Client-side claude-code concern (ide, mcp); not a gateway/relay relevance signal.",
+      "updated_at": "2026-06-04T22:05:22Z"
+    },
+    {
+      "upstream": "anthropics/claude-code#65491",
+      "url": "https://github.com/anthropics/claude-code/issues/65491",
+      "title": "[DOCS] Managed settings docs omit `requiredMinimumVersion` and `requiredMaximumVersion`",
+      "impact": "not_applicable",
+      "categories": [
+        "install"
+      ],
+      "tokenkey_status": "not_applicable",
+      "rationale": "Client-side claude-code concern (install); not a gateway/relay relevance signal.",
+      "updated_at": "2026-06-04T22:09:28Z"
+    },
+    {
+      "upstream": "anthropics/claude-code#65492",
+      "url": "https://github.com/anthropics/claude-code/issues/65492",
+      "title": "[DOCS] `/plugin list` command and `--enabled`/`--disabled` filters are missing from plugin management docs",
+      "impact": "not_applicable",
+      "categories": [
+        "plugin",
+        "slash_hook",
+        "install"
+      ],
+      "tokenkey_status": "not_applicable",
+      "rationale": "Client-side claude-code concern (plugin, slash_hook, install); not a gateway/relay relevance signal.",
+      "updated_at": "2026-06-04T22:10:39Z"
+    },
+    {
+      "upstream": "anthropics/claude-code#65494",
+      "url": "https://github.com/anthropics/claude-code/issues/65494",
+      "title": "[DOCS] `/btw` docs omit the `c` shortcut for copying the raw markdown answer",
+      "impact": "not_applicable",
+      "categories": [
+        "terminal",
+        "slash_hook"
+      ],
+      "tokenkey_status": "not_applicable",
+      "rationale": "Client-side claude-code concern (terminal, slash_hook); not a gateway/relay relevance signal.",
+      "updated_at": "2026-06-04T22:11:39Z"
+    },
+    {
+      "upstream": "anthropics/claude-code#65495",
+      "url": "https://github.com/anthropics/claude-code/issues/65495",
+      "title": "[DOCS] Hooks reference still says `Stop`/`SubagentStop` cannot return `hookSpecificOutput.additionalContext`",
+      "impact": "not_applicable",
+      "categories": [
+        "plugin",
+        "slash_hook"
+      ],
+      "tokenkey_status": "not_applicable",
+      "rationale": "Client-side claude-code concern (plugin, slash_hook); not a gateway/relay relevance signal.",
+      "updated_at": "2026-06-04T22:12:36Z"
+    },
+    {
+      "upstream": "anthropics/claude-code#65496",
+      "url": "https://github.com/anthropics/claude-code/issues/65496",
+      "title": "[DOCS] `skills` docs do not explain `\\$` escaping for a literal `$` before digits in command bodies",
+      "impact": "not_applicable",
+      "categories": [
+        "terminal"
+      ],
+      "tokenkey_status": "not_applicable",
+      "rationale": "Client-side claude-code concern (terminal); not a gateway/relay relevance signal.",
+      "updated_at": "2026-06-04T22:16:26Z"
+    },
+    {
+      "upstream": "anthropics/claude-code#65497",
+      "url": "https://github.com/anthropics/claude-code/issues/65497",
+      "title": "[DOCS] `CLAUDE_CODE_SESSION_ID` env var docs still describe pre-v2.1.163 stdio MCP resume behavior",
+      "impact": "not_applicable",
+      "categories": [
+        "mcp",
+        "slash_hook",
+        "platform"
+      ],
+      "tokenkey_status": "not_applicable",
+      "rationale": "Client-side claude-code concern (mcp, slash_hook, platform); not a gateway/relay relevance signal.",
+      "updated_at": "2026-06-04T22:14:41Z"
+    },
+    {
+      "upstream": "anthropics/claude-code#65499",
+      "url": "https://github.com/anthropics/claude-code/issues/65499",
+      "title": "[DOCS] `CLAUDE_CODE_TMPDIR` docs overstate long-path `$TMPDIR` fallback for Bash commands",
+      "impact": "not_applicable",
+      "categories": [
+        "mcp",
+        "platform"
+      ],
+      "tokenkey_status": "not_applicable",
+      "rationale": "Client-side claude-code concern (mcp, platform); not a gateway/relay relevance signal.",
+      "updated_at": "2026-06-04T22:16:43Z"
+    },
+    {
+      "upstream": "anthropics/claude-code#65500",
+      "url": "https://github.com/anthropics/claude-code/issues/65500",
+      "title": "[Bug] deep-research workflow aborts entire run (and burns millions of tokens) when any schema-bound subagent fails to emit StructuredOutput",
+      "impact": "not_applicable",
+      "categories": [
+        "terminal",
+        "plugin"
+      ],
+      "tokenkey_status": "not_applicable",
+      "rationale": "Client-side claude-code concern (terminal, plugin); not a gateway/relay relevance signal.",
+      "updated_at": "2026-06-04T22:17:14Z"
+    },
+    {
+      "upstream": "anthropics/claude-code#65501",
+      "url": "https://github.com/anthropics/claude-code/issues/65501",
+      "title": "[DOCS] Hooks docs do not explain `if: \"Bash(...)\"` matching for subshells, backticks, and variable expansions",
+      "impact": "not_applicable",
+      "categories": [
+        "slash_hook",
+        "install"
+      ],
+      "tokenkey_status": "not_applicable",
+      "rationale": "Client-side claude-code concern (slash_hook, install); not a gateway/relay relevance signal.",
+      "updated_at": "2026-06-04T22:17:50Z"
+    },
+    {
+      "upstream": "anthropics/claude-code#65502",
+      "url": "https://github.com/anthropics/claude-code/issues/65502",
+      "title": "[DOCS] Permissions page omits `$HOME` matching for home-path `Read(...)` deny rules in Bash",
+      "impact": "not_applicable",
+      "categories": [
+        "ide"
+      ],
+      "tokenkey_status": "not_applicable",
+      "rationale": "Client-side claude-code concern (ide); not a gateway/relay relevance signal.",
+      "updated_at": "2026-06-04T22:18:42Z"
+    },
+    {
+      "upstream": "anthropics/claude-code#65503",
+      "url": "https://github.com/anthropics/claude-code/issues/65503",
+      "title": "[Bug] Claude Code incorrectly flags sanitized synthetic healthcare data as PHI",
+      "impact": "not_applicable",
+      "categories": [
+        "ide",
+        "terminal"
+      ],
+      "tokenkey_status": "not_applicable",
+      "rationale": "Client-side claude-code concern (ide, terminal); not a gateway/relay relevance signal.",
+      "updated_at": "2026-06-04T22:25:02Z"
+    },
+    {
+      "upstream": "anthropics/claude-code#65504",
+      "url": "https://github.com/anthropics/claude-code/issues/65504",
+      "title": "[Bug] Application hangs on loading projects/sessions across all clients",
+      "impact": "not_applicable",
+      "categories": [
+        "terminal"
+      ],
+      "tokenkey_status": "not_applicable",
+      "rationale": "Client-side claude-code concern (terminal); not a gateway/relay relevance signal.",
+      "updated_at": "2026-06-04T22:28:54Z"
+    },
+    {
+      "upstream": "anthropics/claude-code#65507",
+      "url": "https://github.com/anthropics/claude-code/issues/65507",
+      "title": "[Bug] Anthropic API Error: Policy Violation Blocks on Legitimate Daily Planning Workflows",
+      "impact": "not_applicable",
+      "categories": [
+        "terminal"
+      ],
+      "tokenkey_status": "not_applicable",
+      "rationale": "Client-side claude-code concern (terminal); not a gateway/relay relevance signal.",
+      "updated_at": "2026-06-04T22:31:37Z"
+    },
+    {
+      "upstream": "anthropics/claude-code#65508",
+      "url": "https://github.com/anthropics/claude-code/issues/65508",
+      "title": "[BUG] The model it's not working. Just crashed all my repos",
+      "impact": "not_applicable",
+      "categories": [
+        "terminal"
+      ],
+      "tokenkey_status": "not_applicable",
+      "rationale": "Client-side claude-code concern (terminal); not a gateway/relay relevance signal.",
+      "updated_at": "2026-06-04T22:40:35Z"
+    },
+    {
+      "upstream": "anthropics/claude-code#65509",
+      "url": "https://github.com/anthropics/claude-code/issues/65509",
+      "title": "[BUG] [platform::intellij] DiagnosticTools freezes the IDE for 10–35s on EDT (Rider 2026.1, 0.1.14-beta) — regression of closed #10813",
+      "impact": "not_applicable",
+      "categories": [
+        "ide",
+        "terminal",
+        "mcp",
+        "plugin",
+        "platform"
+      ],
+      "tokenkey_status": "not_applicable",
+      "rationale": "Client-side claude-code concern (ide, terminal, mcp, plugin, platform); not a gateway/relay relevance signal.",
+      "updated_at": "2026-06-04T22:55:34Z"
+    },
+    {
+      "upstream": "anthropics/claude-code#65510",
+      "url": "https://github.com/anthropics/claude-code/issues/65510",
+      "title": "[Feature Request] Restore rainbow superthink visual effect",
+      "impact": "not_applicable",
+      "categories": [
+        "terminal"
+      ],
+      "tokenkey_status": "not_applicable",
+      "rationale": "Client-side claude-code concern (terminal); not a gateway/relay relevance signal.",
+      "updated_at": "2026-06-04T22:57:18Z"
+    },
+    {
+      "upstream": "anthropics/claude-code#65511",
+      "url": "https://github.com/anthropics/claude-code/issues/65511",
+      "title": "[BUG] SessionEnd hook creates infinite recursive loop when spawning a claude CLI subprocess",
+      "impact": "not_applicable",
+      "categories": [
+        "ide",
+        "terminal",
+        "slash_hook"
+      ],
+      "tokenkey_status": "not_applicable",
+      "rationale": "Client-side claude-code concern (ide, terminal, slash_hook); not a gateway/relay relevance signal.",
+      "updated_at": "2026-06-04T23:06:38Z"
+    },
+    {
+      "upstream": "anthropics/claude-code#65512",
+      "url": "https://github.com/anthropics/claude-code/issues/65512",
+      "title": "opusplan downgrades plan mode to Sonnet past 200k — Claude Code regression (it previously auto-compacted at 200k and kept Opus)",
+      "impact": "not_applicable",
+      "categories": [
+        "terminal"
+      ],
+      "tokenkey_status": "not_applicable",
+      "rationale": "Client-side claude-code concern (terminal); not a gateway/relay relevance signal.",
+      "updated_at": "2026-06-04T23:19:44Z"
+    },
+    {
+      "upstream": "anthropics/claude-code#65513",
+      "url": "https://github.com/anthropics/claude-code/issues/65513",
+      "title": "[FEATURE] Allow plugin settings.json to ship more default settings (at minimum permissions, env, statusLine)",
+      "impact": "not_applicable",
+      "categories": [
+        "mcp",
+        "plugin",
+        "slash_hook",
+        "install"
+      ],
+      "tokenkey_status": "not_applicable",
+      "rationale": "Client-side claude-code concern (mcp, plugin, slash_hook, install); not a gateway/relay relevance signal.",
+      "updated_at": "2026-06-04T23:24:17Z"
     },
     {
       "upstream": "anthropics/claude-code#7075",
@@ -22853,20 +23500,6 @@
       "tokenkey_status": "not_applicable",
       "rationale": "Client-side claude-code concern (plugin, slash_hook); not a gateway/relay relevance signal.",
       "updated_at": "2026-06-02T17:07:41Z"
-    },
-    {
-      "upstream": "anthropics/claude-code#7134",
-      "url": "https://github.com/anthropics/claude-code/issues/7134",
-      "title": "[BUG] Claude Code does not respect file encoding, corrupts Windows-1252 files",
-      "impact": "not_applicable",
-      "categories": [
-        "ide",
-        "terminal",
-        "platform"
-      ],
-      "tokenkey_status": "not_applicable",
-      "rationale": "Client-side claude-code concern (ide, terminal, platform); not a gateway/relay relevance signal.",
-      "updated_at": "2026-06-01T21:08:36Z"
     },
     {
       "upstream": "anthropics/claude-code#7490",
@@ -22919,16 +23552,6 @@
       "updated_at": "2026-06-03T19:03:46Z"
     },
     {
-      "upstream": "anthropics/claude-code#11315",
-      "url": "https://github.com/anthropics/claude-code/issues/11315",
-      "title": "Critical Memory Leak: Claude Code Consumed 129GB RAM and Caused System Freeze",
-      "impact": "unknown_low_signal",
-      "categories": [],
-      "tokenkey_status": "not_applicable",
-      "rationale": "No gateway/relay-relevant keywords; treated as not-our-surface.",
-      "updated_at": "2026-06-01T17:46:52Z"
-    },
-    {
       "upstream": "anthropics/claude-code#14228",
       "url": "https://github.com/anthropics/claude-code/issues/14228",
       "title": "Feature Request: Claude Code Should Access User's claude.ai Memory and Context",
@@ -22937,6 +23560,16 @@
       "tokenkey_status": "not_applicable",
       "rationale": "No gateway/relay-relevant keywords; treated as not-our-surface.",
       "updated_at": "2026-06-03T05:03:24Z"
+    },
+    {
+      "upstream": "anthropics/claude-code#15436",
+      "url": "https://github.com/anthropics/claude-code/issues/15436",
+      "title": "[FEATURE] Auto-cleanup Chrome tab groups when Claude in Chrome sessions end",
+      "impact": "unknown_low_signal",
+      "categories": [],
+      "tokenkey_status": "not_applicable",
+      "rationale": "No gateway/relay-relevant keywords; treated as not-our-surface.",
+      "updated_at": "2026-06-04T20:29:36Z"
     },
     {
       "upstream": "anthropics/claude-code#16329",
@@ -22977,16 +23610,6 @@
       "tokenkey_status": "not_applicable",
       "rationale": "No gateway/relay-relevant keywords; treated as not-our-surface.",
       "updated_at": "2026-06-02T11:32:28Z"
-    },
-    {
-      "upstream": "anthropics/claude-code#19471",
-      "url": "https://github.com/anthropics/claude-code/issues/19471",
-      "title": "[BUG] CLAUDE.md instructions completely ignored after context compaction",
-      "impact": "unknown_low_signal",
-      "categories": [],
-      "tokenkey_status": "not_applicable",
-      "rationale": "No gateway/relay-relevant keywords; treated as not-our-surface.",
-      "updated_at": "2026-06-01T22:46:22Z"
     },
     {
       "upstream": "anthropics/claude-code#23626",
@@ -23119,6 +23742,16 @@
       "updated_at": "2026-06-03T07:12:00Z"
     },
     {
+      "upstream": "anthropics/claude-code#37974",
+      "url": "https://github.com/anthropics/claude-code/issues/37974",
+      "title": "Opus is being really stupid",
+      "impact": "unknown_low_signal",
+      "categories": [],
+      "tokenkey_status": "not_applicable",
+      "rationale": "No gateway/relay-relevant keywords; treated as not-our-surface.",
+      "updated_at": "2026-06-04T22:33:49Z"
+    },
+    {
       "upstream": "anthropics/claude-code#39678",
       "url": "https://github.com/anthropics/claude-code/issues/39678",
       "title": "Claude Code Review incorrectly reports overage limit reached when spend is $0/$250",
@@ -23169,46 +23802,6 @@
       "updated_at": "2026-06-03T22:45:03Z"
     },
     {
-      "upstream": "anthropics/claude-code#43755",
-      "url": "https://github.com/anthropics/claude-code/issues/43755",
-      "title": "[FEATURE] Per-prompt rewind/undo in Desktop App",
-      "impact": "unknown_low_signal",
-      "categories": [],
-      "tokenkey_status": "not_applicable",
-      "rationale": "No gateway/relay-relevant keywords; treated as not-our-surface.",
-      "updated_at": "2026-06-01T22:45:52Z"
-    },
-    {
-      "upstream": "anthropics/claude-code#44166",
-      "url": "https://github.com/anthropics/claude-code/issues/44166",
-      "title": "Option to exempt CLAUDE.md / auto-memory from compaction",
-      "impact": "unknown_low_signal",
-      "categories": [],
-      "tokenkey_status": "not_applicable",
-      "rationale": "No gateway/relay-relevant keywords; treated as not-our-surface.",
-      "updated_at": "2026-06-01T22:46:22Z"
-    },
-    {
-      "upstream": "anthropics/claude-code#44933",
-      "url": "https://github.com/anthropics/claude-code/issues/44933",
-      "title": "[FEATURE REQUEST] Cowork: Set a default project folder that auto-loads on session start",
-      "impact": "unknown_low_signal",
-      "categories": [],
-      "tokenkey_status": "not_applicable",
-      "rationale": "No gateway/relay-relevant keywords; treated as not-our-surface.",
-      "updated_at": "2026-06-01T22:40:05Z"
-    },
-    {
-      "upstream": "anthropics/claude-code#45005",
-      "url": "https://github.com/anthropics/claude-code/issues/45005",
-      "title": "[MODEL] Claude fabricated cost estimate for GPU training, caused $38.73 in unconfirmed charges",
-      "impact": "unknown_low_signal",
-      "categories": [],
-      "tokenkey_status": "not_applicable",
-      "rationale": "No gateway/relay-relevant keywords; treated as not-our-surface.",
-      "updated_at": "2026-06-01T22:45:47Z"
-    },
-    {
       "upstream": "anthropics/claude-code#46561",
       "url": "https://github.com/anthropics/claude-code/issues/46561",
       "title": "/compact resurrects /loop skill context, causing stale cron jobs to keep executing after user stopped the loop",
@@ -23219,24 +23812,14 @@
       "updated_at": "2026-06-04T11:07:45Z"
     },
     {
-      "upstream": "anthropics/claude-code#46940",
-      "url": "https://github.com/anthropics/claude-code/issues/46940",
-      "title": "Claude fabricates test results - reports ALL PASSED when tests are FAILING",
+      "upstream": "anthropics/claude-code#47503",
+      "url": "https://github.com/anthropics/claude-code/issues/47503",
+      "title": "Project-level skills in git worktrees not discovered since 2.1.104",
       "impact": "unknown_low_signal",
       "categories": [],
       "tokenkey_status": "not_applicable",
       "rationale": "No gateway/relay-relevant keywords; treated as not-our-surface.",
-      "updated_at": "2026-06-01T22:45:48Z"
-    },
-    {
-      "upstream": "anthropics/claude-code#46943",
-      "url": "https://github.com/anthropics/claude-code/issues/46943",
-      "title": "Mobile client for Claude Code (iOS/Android)",
-      "impact": "unknown_low_signal",
-      "categories": [],
-      "tokenkey_status": "not_applicable",
-      "rationale": "No gateway/relay-relevant keywords; treated as not-our-surface.",
-      "updated_at": "2026-06-01T19:34:10Z"
+      "updated_at": "2026-06-04T22:33:30Z"
     },
     {
       "upstream": "anthropics/claude-code#47509",
@@ -23247,6 +23830,26 @@
       "tokenkey_status": "not_applicable",
       "rationale": "No gateway/relay-relevant keywords; treated as not-our-surface.",
       "updated_at": "2026-06-03T05:33:12Z"
+    },
+    {
+      "upstream": "anthropics/claude-code#48024",
+      "url": "https://github.com/anthropics/claude-code/issues/48024",
+      "title": "Ultraplan teleport: refined plan does not return to originating CLI session",
+      "impact": "unknown_low_signal",
+      "categories": [],
+      "tokenkey_status": "not_applicable",
+      "rationale": "No gateway/relay-relevant keywords; treated as not-our-surface.",
+      "updated_at": "2026-06-04T18:22:02Z"
+    },
+    {
+      "upstream": "anthropics/claude-code#48129",
+      "url": "https://github.com/anthropics/claude-code/issues/48129",
+      "title": "Whoever signed off on auto-naming the load-bearing identifier of a document with random adjective+verb+surname owes the world an apology",
+      "impact": "unknown_low_signal",
+      "categories": [],
+      "tokenkey_status": "not_applicable",
+      "rationale": "No gateway/relay-relevant keywords; treated as not-our-surface.",
+      "updated_at": "2026-06-04T22:33:32Z"
     },
     {
       "upstream": "anthropics/claude-code#48858",
@@ -23326,7 +23929,7 @@
       "categories": [],
       "tokenkey_status": "not_applicable",
       "rationale": "No gateway/relay-relevant keywords; treated as not-our-surface.",
-      "updated_at": "2026-06-03T18:00:02Z"
+      "updated_at": "2026-06-04T17:04:08Z"
     },
     {
       "upstream": "anthropics/claude-code#50529",
@@ -23339,6 +23942,16 @@
       "updated_at": "2026-06-02T09:10:54Z"
     },
     {
+      "upstream": "anthropics/claude-code#50811",
+      "url": "https://github.com/anthropics/claude-code/issues/50811",
+      "title": "Max plan usage budget needs transparency: no way to know what you're paying for",
+      "impact": "unknown_low_signal",
+      "categories": [],
+      "tokenkey_status": "not_applicable",
+      "rationale": "No gateway/relay-relevant keywords; treated as not-our-surface.",
+      "updated_at": "2026-06-04T22:33:07Z"
+    },
+    {
       "upstream": "anthropics/claude-code#5088",
       "url": "https://github.com/anthropics/claude-code/issues/5088",
       "title": "Claude Account Disabled After Payment for Claude Code Max 5x Plan",
@@ -23349,16 +23962,6 @@
       "updated_at": "2026-06-04T01:40:54Z"
     },
     {
-      "upstream": "anthropics/claude-code#50894",
-      "url": "https://github.com/anthropics/claude-code/issues/50894",
-      "title": "Focus mode hides substantive assistant messages, not just tool output",
-      "impact": "unknown_low_signal",
-      "categories": [],
-      "tokenkey_status": "not_applicable",
-      "rationale": "No gateway/relay-relevant keywords; treated as not-our-surface.",
-      "updated_at": "2026-06-01T22:45:52Z"
-    },
-    {
       "upstream": "anthropics/claude-code#51373",
       "url": "https://github.com/anthropics/claude-code/issues/51373",
       "title": "[DOCS] Sandboxing docs overstate auto-allow behavior for dangerous `rm`/`rmdir` paths",
@@ -23366,7 +23969,7 @@
       "categories": [],
       "tokenkey_status": "not_applicable",
       "rationale": "No gateway/relay-relevant keywords; treated as not-our-surface.",
-      "updated_at": "2026-06-03T11:40:14Z"
+      "updated_at": "2026-06-04T23:48:02Z"
     },
     {
       "upstream": "anthropics/claude-code#51783",
@@ -23376,7 +23979,7 @@
       "categories": [],
       "tokenkey_status": "not_applicable",
       "rationale": "No gateway/relay-relevant keywords; treated as not-our-surface.",
-      "updated_at": "2026-06-03T11:40:07Z"
+      "updated_at": "2026-06-04T23:48:04Z"
     },
     {
       "upstream": "anthropics/claude-code#51791",
@@ -23396,7 +23999,7 @@
       "categories": [],
       "tokenkey_status": "not_applicable",
       "rationale": "No gateway/relay-relevant keywords; treated as not-our-surface.",
-      "updated_at": "2026-06-03T11:40:11Z"
+      "updated_at": "2026-06-04T23:41:13Z"
     },
     {
       "upstream": "anthropics/claude-code#52204",
@@ -23406,7 +24009,7 @@
       "categories": [],
       "tokenkey_status": "not_applicable",
       "rationale": "No gateway/relay-relevant keywords; treated as not-our-surface.",
-      "updated_at": "2026-06-03T11:40:16Z"
+      "updated_at": "2026-06-04T23:41:51Z"
     },
     {
       "upstream": "anthropics/claude-code#52205",
@@ -23416,7 +24019,7 @@
       "categories": [],
       "tokenkey_status": "not_applicable",
       "rationale": "No gateway/relay-relevant keywords; treated as not-our-surface.",
-      "updated_at": "2026-06-03T11:40:20Z"
+      "updated_at": "2026-06-04T23:40:49Z"
     },
     {
       "upstream": "anthropics/claude-code#52214",
@@ -23436,7 +24039,7 @@
       "categories": [],
       "tokenkey_status": "not_applicable",
       "rationale": "No gateway/relay-relevant keywords; treated as not-our-surface.",
-      "updated_at": "2026-06-03T11:40:25Z"
+      "updated_at": "2026-06-04T23:25:05Z"
     },
     {
       "upstream": "anthropics/claude-code#52627",
@@ -23446,7 +24049,7 @@
       "categories": [],
       "tokenkey_status": "not_applicable",
       "rationale": "No gateway/relay-relevant keywords; treated as not-our-surface.",
-      "updated_at": "2026-06-03T11:40:30Z"
+      "updated_at": "2026-06-04T23:28:07Z"
     },
     {
       "upstream": "anthropics/claude-code#53075",
@@ -23456,17 +24059,7 @@
       "categories": [],
       "tokenkey_status": "not_applicable",
       "rationale": "No gateway/relay-relevant keywords; treated as not-our-surface.",
-      "updated_at": "2026-06-03T11:40:39Z"
-    },
-    {
-      "upstream": "anthropics/claude-code#53225",
-      "url": "https://github.com/anthropics/claude-code/issues/53225",
-      "title": "Desktop app shows no recovery option when working directory has been moved or deleted",
-      "impact": "unknown_low_signal",
-      "categories": [],
-      "tokenkey_status": "not_applicable",
-      "rationale": "No gateway/relay-relevant keywords; treated as not-our-surface.",
-      "updated_at": "2026-06-01T22:45:29Z"
+      "updated_at": "2026-06-04T23:46:15Z"
     },
     {
       "upstream": "anthropics/claude-code#53514",
@@ -23499,16 +24092,6 @@
       "updated_at": "2026-06-03T16:03:57Z"
     },
     {
-      "upstream": "anthropics/claude-code#54924",
-      "url": "https://github.com/anthropics/claude-code/issues/54924",
-      "title": "[BUG] SSH option not available in Claude Code Desktop when using external API provider",
-      "impact": "unknown_low_signal",
-      "categories": [],
-      "tokenkey_status": "not_applicable",
-      "rationale": "No gateway/relay-relevant keywords; treated as not-our-surface.",
-      "updated_at": "2026-06-01T22:45:22Z"
-    },
-    {
       "upstream": "anthropics/claude-code#55196",
       "url": "https://github.com/anthropics/claude-code/issues/55196",
       "title": "[DOCS] Remote Control troubleshooting missing trusted-device unenrolled failure",
@@ -23516,7 +24099,7 @@
       "categories": [],
       "tokenkey_status": "not_applicable",
       "rationale": "No gateway/relay-relevant keywords; treated as not-our-surface.",
-      "updated_at": "2026-06-04T11:06:38Z"
+      "updated_at": "2026-06-04T22:47:28Z"
     },
     {
       "upstream": "anthropics/claude-code#55971",
@@ -23529,6 +24112,16 @@
       "updated_at": "2026-06-04T11:07:16Z"
     },
     {
+      "upstream": "anthropics/claude-code#56703",
+      "url": "https://github.com/anthropics/claude-code/issues/56703",
+      "title": "[FEATURE] Multiple account functionality",
+      "impact": "unknown_low_signal",
+      "categories": [],
+      "tokenkey_status": "not_applicable",
+      "rationale": "No gateway/relay-relevant keywords; treated as not-our-surface.",
+      "updated_at": "2026-06-04T22:33:13Z"
+    },
+    {
       "upstream": "anthropics/claude-code#56927",
       "url": "https://github.com/anthropics/claude-code/issues/56927",
       "title": "CLAUDE.md: @ file import fails silently for paths containing spaces (e.g. iCloud Drive on macOS)",
@@ -23537,16 +24130,6 @@
       "tokenkey_status": "not_applicable",
       "rationale": "No gateway/relay-relevant keywords; treated as not-our-surface.",
       "updated_at": "2026-06-03T02:43:53Z"
-    },
-    {
-      "upstream": "anthropics/claude-code#57177",
-      "url": "https://github.com/anthropics/claude-code/issues/57177",
-      "title": "[FEATURE] Allow configuring the Cowork workspace base path (Documents/Claude)",
-      "impact": "unknown_low_signal",
-      "categories": [],
-      "tokenkey_status": "not_applicable",
-      "rationale": "No gateway/relay-relevant keywords; treated as not-our-surface.",
-      "updated_at": "2026-06-01T18:55:40Z"
     },
     {
       "upstream": "anthropics/claude-code#57441",
@@ -23559,14 +24142,14 @@
       "updated_at": "2026-06-02T22:44:10Z"
     },
     {
-      "upstream": "anthropics/claude-code#58768",
-      "url": "https://github.com/anthropics/claude-code/issues/58768",
-      "title": "AskUserQuestion answers invisible to auto-mode permission classifier — destructive calls re-blocked after explicit consent",
+      "upstream": "anthropics/claude-code#58300",
+      "url": "https://github.com/anthropics/claude-code/issues/58300",
+      "title": "Repo-level alternative to per-user `~/.claude/projects/.../memory/` — visibility, portability, debuggability",
       "impact": "unknown_low_signal",
       "categories": [],
       "tokenkey_status": "not_applicable",
       "rationale": "No gateway/relay-relevant keywords; treated as not-our-surface.",
-      "updated_at": "2026-06-01T22:45:44Z"
+      "updated_at": "2026-06-04T22:33:12Z"
     },
     {
       "upstream": "anthropics/claude-code#59566",
@@ -23579,36 +24162,6 @@
       "updated_at": "2026-06-03T22:45:10Z"
     },
     {
-      "upstream": "anthropics/claude-code#59691",
-      "url": "https://github.com/anthropics/claude-code/issues/59691",
-      "title": "Agent View: undocumented behavior — are run_in_background child processes killed when the supervisor reaps an idle session after ~1h?",
-      "impact": "unknown_low_signal",
-      "categories": [],
-      "tokenkey_status": "not_applicable",
-      "rationale": "No gateway/relay-relevant keywords; treated as not-our-surface.",
-      "updated_at": "2026-06-01T22:45:12Z"
-    },
-    {
-      "upstream": "anthropics/claude-code#59694",
-      "url": "https://github.com/anthropics/claude-code/issues/59694",
-      "title": "Feature request: inline annotations in .md files visible to Claude Code",
-      "impact": "unknown_low_signal",
-      "categories": [],
-      "tokenkey_status": "not_applicable",
-      "rationale": "No gateway/relay-relevant keywords; treated as not-our-surface.",
-      "updated_at": "2026-06-01T22:45:10Z"
-    },
-    {
-      "upstream": "anthropics/claude-code#59695",
-      "url": "https://github.com/anthropics/claude-code/issues/59695",
-      "title": "Permission dialog toggle label is clickable but clicking it changes the value — counterintuitive UX",
-      "impact": "unknown_low_signal",
-      "categories": [],
-      "tokenkey_status": "not_applicable",
-      "rationale": "No gateway/relay-relevant keywords; treated as not-our-surface.",
-      "updated_at": "2026-06-01T22:45:10Z"
-    },
-    {
       "upstream": "anthropics/claude-code#59858",
       "url": "https://github.com/anthropics/claude-code/issues/59858",
       "title": "[BUG] Extra usage spend limit not enforced as hard cap – charged 250% of configured cap with no notification or stop",
@@ -23619,16 +24172,6 @@
       "updated_at": "2026-06-03T22:45:36Z"
     },
     {
-      "upstream": "anthropics/claude-code#59864",
-      "url": "https://github.com/anthropics/claude-code/issues/59864",
-      "title": "claude -p: ScheduleWakeup / Cron* tools advertised in print mode where they have no execution semantics",
-      "impact": "unknown_low_signal",
-      "categories": [],
-      "tokenkey_status": "not_applicable",
-      "rationale": "No gateway/relay-relevant keywords; treated as not-our-surface.",
-      "updated_at": "2026-06-01T22:45:17Z"
-    },
-    {
       "upstream": "anthropics/claude-code#59904",
       "url": "https://github.com/anthropics/claude-code/issues/59904",
       "title": "[FEATURE] Dreaming: surface CLAUDE.md promotion candidates to humans",
@@ -23637,36 +24180,6 @@
       "tokenkey_status": "not_applicable",
       "rationale": "No gateway/relay-relevant keywords; treated as not-our-surface.",
       "updated_at": "2026-06-02T11:32:04Z"
-    },
-    {
-      "upstream": "anthropics/claude-code#59984",
-      "url": "https://github.com/anthropics/claude-code/issues/59984",
-      "title": "Worktree status bar: 'Create PR' button should respect custom /pr skills and reflect merged state",
-      "impact": "unknown_low_signal",
-      "categories": [],
-      "tokenkey_status": "not_applicable",
-      "rationale": "No gateway/relay-relevant keywords; treated as not-our-surface.",
-      "updated_at": "2026-06-01T22:45:48Z"
-    },
-    {
-      "upstream": "anthropics/claude-code#60005",
-      "url": "https://github.com/anthropics/claude-code/issues/60005",
-      "title": "[FEATURE] Push notification when scheduled routine/agent session starts",
-      "impact": "unknown_low_signal",
-      "categories": [],
-      "tokenkey_status": "not_applicable",
-      "rationale": "No gateway/relay-relevant keywords; treated as not-our-surface.",
-      "updated_at": "2026-06-01T22:45:59Z"
-    },
-    {
-      "upstream": "anthropics/claude-code#60027",
-      "url": "https://github.com/anthropics/claude-code/issues/60027",
-      "title": "`!` injection: `&&` chain drops commands after sudo (works fine in fresh shell)",
-      "impact": "unknown_low_signal",
-      "categories": [],
-      "tokenkey_status": "not_applicable",
-      "rationale": "No gateway/relay-relevant keywords; treated as not-our-surface.",
-      "updated_at": "2026-06-01T22:46:12Z"
     },
     {
       "upstream": "anthropics/claude-code#60068",
@@ -23776,17 +24289,7 @@
       "categories": [],
       "tokenkey_status": "not_applicable",
       "rationale": "No gateway/relay-relevant keywords; treated as not-our-surface.",
-      "updated_at": "2026-06-04T11:06:52Z"
-    },
-    {
-      "upstream": "anthropics/claude-code#60406",
-      "url": "https://github.com/anthropics/claude-code/issues/60406",
-      "title": "[DOCS] `tools-reference` still says `head` and `tail` do not satisfy read-before-edit",
-      "impact": "unknown_low_signal",
-      "categories": [],
-      "tokenkey_status": "not_applicable",
-      "rationale": "No gateway/relay-relevant keywords; treated as not-our-surface.",
-      "updated_at": "2026-06-03T22:45:06Z"
+      "updated_at": "2026-06-04T22:47:17Z"
     },
     {
       "upstream": "anthropics/claude-code#60409",
@@ -23796,7 +24299,7 @@
       "categories": [],
       "tokenkey_status": "not_applicable",
       "rationale": "No gateway/relay-relevant keywords; treated as not-our-surface.",
-      "updated_at": "2026-06-03T22:45:07Z"
+      "updated_at": "2026-06-04T22:42:43Z"
     },
     {
       "upstream": "anthropics/claude-code#60410",
@@ -23939,6 +24442,36 @@
       "updated_at": "2026-06-03T23:04:39Z"
     },
     {
+      "upstream": "anthropics/claude-code#60723",
+      "url": "https://github.com/anthropics/claude-code/issues/60723",
+      "title": "[FEATURE] Add @claude review stop to unsubscribe a PR from push-triggered reviews",
+      "impact": "unknown_low_signal",
+      "categories": [],
+      "tokenkey_status": "not_applicable",
+      "rationale": "No gateway/relay-relevant keywords; treated as not-our-surface.",
+      "updated_at": "2026-06-04T22:33:33Z"
+    },
+    {
+      "upstream": "anthropics/claude-code#60777",
+      "url": "https://github.com/anthropics/claude-code/issues/60777",
+      "title": "[MODEL] Prevent Claude code from scanning the repo automatically before being asked!",
+      "impact": "unknown_low_signal",
+      "categories": [],
+      "tokenkey_status": "not_applicable",
+      "rationale": "No gateway/relay-relevant keywords; treated as not-our-surface.",
+      "updated_at": "2026-06-04T22:33:37Z"
+    },
+    {
+      "upstream": "anthropics/claude-code#60796",
+      "url": "https://github.com/anthropics/claude-code/issues/60796",
+      "title": "[FEATURE] /clear and specify model for next session at once, e.g., \"/clear -m sonnet\"",
+      "impact": "unknown_low_signal",
+      "categories": [],
+      "tokenkey_status": "not_applicable",
+      "rationale": "No gateway/relay-relevant keywords; treated as not-our-surface.",
+      "updated_at": "2026-06-04T22:33:48Z"
+    },
+    {
       "upstream": "anthropics/claude-code#60848",
       "url": "https://github.com/anthropics/claude-code/issues/60848",
       "title": "Ambiguous 'Don't ask me again' option in session resume prompt",
@@ -24009,14 +24542,14 @@
       "updated_at": "2026-06-04T02:04:04Z"
     },
     {
-      "upstream": "anthropics/claude-code#63853",
-      "url": "https://github.com/anthropics/claude-code/issues/63853",
-      "title": "[feature] Path-rewrite enforcement when isolation: \"worktree\" is set on Agent tool",
+      "upstream": "anthropics/claude-code#63763",
+      "url": "https://github.com/anthropics/claude-code/issues/63763",
+      "title": "[MODEL] generated a migration that dropped a column without explicit instruction, on a live database.",
       "impact": "unknown_low_signal",
       "categories": [],
       "tokenkey_status": "not_applicable",
       "rationale": "No gateway/relay-relevant keywords; treated as not-our-surface.",
-      "updated_at": "2026-06-01T14:38:34Z"
+      "updated_at": "2026-06-04T17:41:12Z"
     },
     {
       "upstream": "anthropics/claude-code#63909",
@@ -24026,7 +24559,7 @@
       "categories": [],
       "tokenkey_status": "not_applicable",
       "rationale": "No gateway/relay-relevant keywords; treated as not-our-surface.",
-      "updated_at": "2026-06-01T18:19:14Z"
+      "updated_at": "2026-06-04T15:16:28Z"
     },
     {
       "upstream": "anthropics/claude-code#64175",
@@ -24077,16 +24610,6 @@
       "tokenkey_status": "not_applicable",
       "rationale": "No gateway/relay-relevant keywords; treated as not-our-surface.",
       "updated_at": "2026-06-01T23:54:03Z"
-    },
-    {
-      "upstream": "anthropics/claude-code#64555",
-      "url": "https://github.com/anthropics/claude-code/issues/64555",
-      "title": "/usage weekly bar dropped ~88% → 3% after a usage-credit purchase, reset date unchanged",
-      "impact": "unknown_low_signal",
-      "categories": [],
-      "tokenkey_status": "not_applicable",
-      "rationale": "No gateway/relay-relevant keywords; treated as not-our-surface.",
-      "updated_at": "2026-06-01T19:50:03Z"
     },
     {
       "upstream": "anthropics/claude-code#64590",
@@ -24287,16 +24810,6 @@
       "tokenkey_status": "not_applicable",
       "rationale": "No gateway/relay-relevant keywords; treated as not-our-surface.",
       "updated_at": "2026-06-02T22:03:53Z"
-    },
-    {
-      "upstream": "anthropics/claude-code#64870",
-      "url": "https://github.com/anthropics/claude-code/issues/64870",
-      "title": "[FEATURE] Can you please change the RSS feed name from \"Changelog\" to something like \"Claude Changelog\".",
-      "impact": "unknown_low_signal",
-      "categories": [],
-      "tokenkey_status": "not_applicable",
-      "rationale": "No gateway/relay-relevant keywords; treated as not-our-surface.",
-      "updated_at": "2026-06-02T22:11:56Z"
     },
     {
       "upstream": "anthropics/claude-code#64871",
@@ -24576,17 +25089,7 @@
       "categories": [],
       "tokenkey_status": "not_applicable",
       "rationale": "No gateway/relay-relevant keywords; treated as not-our-surface.",
-      "updated_at": "2026-06-04T01:19:21Z"
-    },
-    {
-      "upstream": "anthropics/claude-code#65237",
-      "url": "https://github.com/anthropics/claude-code/issues/65237",
-      "title": "Project picker shows duplicate Recent rows for one folder due to path-casing (case-insensitive APFS): /Dev vs /dev",
-      "impact": "unknown_low_signal",
-      "categories": [],
-      "tokenkey_status": "not_applicable",
-      "rationale": "No gateway/relay-relevant keywords; treated as not-our-surface.",
-      "updated_at": "2026-06-04T02:17:21Z"
+      "updated_at": "2026-06-04T18:25:59Z"
     },
     {
       "upstream": "anthropics/claude-code#65257",
@@ -24667,6 +25170,76 @@
       "tokenkey_status": "not_applicable",
       "rationale": "No gateway/relay-relevant keywords; treated as not-our-surface.",
       "updated_at": "2026-06-04T11:59:10Z"
+    },
+    {
+      "upstream": "anthropics/claude-code#65377",
+      "url": "https://github.com/anthropics/claude-code/issues/65377",
+      "title": "FleetView header shows \"Commit changes\" button + diff counter on a clean working tree",
+      "impact": "unknown_low_signal",
+      "categories": [],
+      "tokenkey_status": "not_applicable",
+      "rationale": "No gateway/relay-relevant keywords; treated as not-our-surface.",
+      "updated_at": "2026-06-04T13:39:03Z"
+    },
+    {
+      "upstream": "anthropics/claude-code#65425",
+      "url": "https://github.com/anthropics/claude-code/issues/65425",
+      "title": "[BUG] Remote Control: message typed while agent is busy is lost when switching chats (un-sent draft discarded, no queue)",
+      "impact": "unknown_low_signal",
+      "categories": [],
+      "tokenkey_status": "not_applicable",
+      "rationale": "No gateway/relay-relevant keywords; treated as not-our-surface.",
+      "updated_at": "2026-06-04T17:15:10Z"
+    },
+    {
+      "upstream": "anthropics/claude-code#65436",
+      "url": "https://github.com/anthropics/claude-code/issues/65436",
+      "title": "[Bug] Android app intercepts remote-control URL but doesn't load the session",
+      "impact": "unknown_low_signal",
+      "categories": [],
+      "tokenkey_status": "not_applicable",
+      "rationale": "No gateway/relay-relevant keywords; treated as not-our-surface.",
+      "updated_at": "2026-06-04T17:58:35Z"
+    },
+    {
+      "upstream": "anthropics/claude-code#65444",
+      "url": "https://github.com/anthropics/claude-code/issues/65444",
+      "title": "/usage-credits blocked after quota reset: stale request state persists across periods",
+      "impact": "unknown_low_signal",
+      "categories": [],
+      "tokenkey_status": "not_applicable",
+      "rationale": "No gateway/relay-relevant keywords; treated as not-our-surface.",
+      "updated_at": "2026-06-04T18:40:56Z"
+    },
+    {
+      "upstream": "anthropics/claude-code#65449",
+      "url": "https://github.com/anthropics/claude-code/issues/65449",
+      "title": "[FEATURE] Desktop: Add diff filters for uncommitted changes and session changes",
+      "impact": "unknown_low_signal",
+      "categories": [],
+      "tokenkey_status": "not_applicable",
+      "rationale": "No gateway/relay-relevant keywords; treated as not-our-surface.",
+      "updated_at": "2026-06-04T19:04:48Z"
+    },
+    {
+      "upstream": "anthropics/claude-code#65493",
+      "url": "https://github.com/anthropics/claude-code/issues/65493",
+      "title": "built-in feedback command",
+      "impact": "unknown_low_signal",
+      "categories": [],
+      "tokenkey_status": "not_applicable",
+      "rationale": "No gateway/relay-relevant keywords; treated as not-our-surface.",
+      "updated_at": "2026-06-04T22:15:29Z"
+    },
+    {
+      "upstream": "anthropics/claude-code#65498",
+      "url": "https://github.com/anthropics/claude-code/issues/65498",
+      "title": "[DOCS] Headless docs omit `claude -p` background-shell cleanup after final result",
+      "impact": "unknown_low_signal",
+      "categories": [],
+      "tokenkey_status": "not_applicable",
+      "rationale": "No gateway/relay-relevant keywords; treated as not-our-surface.",
+      "updated_at": "2026-06-04T22:15:49Z"
     },
     {
       "upstream": "anthropics/claude-code#895",


### PR DESCRIPTION
## Summary
- Refresh `.cache/anthropic/cc-triage.json` from the latest anthropics/claude-code issues.
- Update `.cache/anthropic/cc-fixes.json` from current TokenKey main fact checks.
- Keep watchdog workflow/script/fact-check metadata in sync with the refreshed cache.

## Watchdog report
# Anthropic Claude-Code Issue Watchdog Report

- Run URL: https://github.com/youxuanxue/sub2api/actions/runs/26986502735
- Repository SHA: `3b8e34cde7c212bbda70e25cea86a7f5041cf464`
- Generated at: `2026-06-04T23:49:32Z`
- Upstream issues scanned: `2985`
- Fact checks: `3`
- Fixed facts verified: `3`
- High/critical unresolved: `0`

## Fixed facts verified

- anthropics/claude-code#61348 via youxuanxue/sub2api#514, youxuanxue/sub2api#518
- anthropics/claude-code#60168, anthropics/claude-code#63885, anthropics/claude-code#64777 via youxuanxue/sub2api (UTF-8/surrogate self-heal)
- anthropics/claude-code#60913 via youxuanxue/sub2api ([1m] context-window model-alias strip)


## Test plan
- [x] `python3 -m json.tool .cache/anthropic/cc-triage.json`
- [x] `python3 -m json.tool .cache/anthropic/cc-fixes.json`
- [x] `python3 -m json.tool .cache/anthropic/cc-fact-checks.json`
- [x] `python3 -m py_compile scripts/upstream/issue-watchdog.py`
- [x] `python3 -m json.tool .cache/anthropic-cc-issue-watchdog/report.json`
- [x] `python3 -m json.tool .cache/anthropic-cc-issue-watchdog/agent-input.json`
