### PR TITLE
fix(gateway): empty-pool fast-fail returns 429+Retry-After instead of 503

### DIFF
--- a/backend/internal/handler/gateway_handler.go
+++ b/backend/internal/handler/gateway_handler.go
@@ -325,7 +325,7 @@ func (h *GatewayHandler) Messages(c *gin.Context) {
 						zap.String("platform", platform),
 						zap.Error(err),
 					)
-					h.handleStreamingAwareError(c, http.StatusServiceUnavailable, "api_error", "No available accounts: "+err.Error(), streamStarted)
+					h.handleStreamingAwareError(c, tkNoAvailableAccounts(c), "api_error", "No available accounts: "+err.Error(), streamStarted)
 					return
 				}
 				action := fs.HandleSelectionExhausted(c.Request.Context())
@@ -374,7 +374,7 @@ func (h *GatewayHandler) Messages(c *gin.Context) {
 						zap.String("model", reqModel),
 						zap.String("platform", platform),
 					)
-					h.handleStreamingAwareError(c, http.StatusServiceUnavailable, "api_error", "No available accounts", streamStarted)
+					h.handleStreamingAwareError(c, tkNoAvailableAccounts(c), "api_error", "No available accounts", streamStarted)
 					return
 				}
 				accountWaitCounted := false
@@ -589,7 +589,7 @@ func (h *GatewayHandler) Messages(c *gin.Context) {
 						zap.Bool("fallback_used", fallbackUsed),
 						zap.Error(err),
 					)
-					h.handleStreamingAwareError(c, http.StatusServiceUnavailable, "api_error", "No available accounts: "+err.Error(), streamStarted)
+					h.handleStreamingAwareError(c, tkNoAvailableAccounts(c), "api_error", "No available accounts: "+err.Error(), streamStarted)
 					return
 				}
 				action := fs.HandleSelectionExhausted(c.Request.Context())
@@ -638,7 +638,7 @@ func (h *GatewayHandler) Messages(c *gin.Context) {
 						zap.String("model", reqModel),
 						zap.String("platform", platform),
 					)
-					h.handleStreamingAwareError(c, http.StatusServiceUnavailable, "api_error", "No available accounts", streamStarted)
+					h.handleStreamingAwareError(c, tkNoAvailableAccounts(c), "api_error", "No available accounts", streamStarted)
 					return
 				}
 				accountWaitCounted := false

--- a/backend/internal/handler/gateway_handler_chat_completions.go
+++ b/backend/internal/handler/gateway_handler_chat_completions.go
@@ -178,7 +178,7 @@ func (h *GatewayHandler) ChatCompletions(c *gin.Context) {
 		if err != nil {
 			if len(fs.FailedAccountIDs) == 0 {
 				markOpsRoutingCapacityLimitedIfNoAvailable(c, err)
-				h.chatCompletionsErrorResponse(c, http.StatusServiceUnavailable, "api_error", "No available accounts: "+err.Error())
+				h.chatCompletionsErrorResponse(c, tkNoAvailableAccounts(c), "api_error", "No available accounts: "+err.Error())
 				return
 			}
 			action := fs.HandleSelectionExhausted(c.Request.Context())
@@ -204,7 +204,7 @@ func (h *GatewayHandler) ChatCompletions(c *gin.Context) {
 		if !selection.Acquired {
 			if selection.WaitPlan == nil {
 				markOpsRoutingCapacityLimited(c)
-				h.chatCompletionsErrorResponse(c, http.StatusServiceUnavailable, "api_error", "No available accounts")
+				h.chatCompletionsErrorResponse(c, tkNoAvailableAccounts(c), "api_error", "No available accounts")
 				return
 			}
 			accountReleaseFunc, err = h.concurrencyHelper.AcquireAccountSlotWithWaitTimeout(

--- a/backend/internal/handler/gateway_handler_responses.go
+++ b/backend/internal/handler/gateway_handler_responses.go
@@ -182,7 +182,7 @@ func (h *GatewayHandler) Responses(c *gin.Context) {
 		if err != nil {
 			if len(fs.FailedAccountIDs) == 0 {
 				markOpsRoutingCapacityLimitedIfNoAvailable(c, err)
-				h.responsesErrorResponse(c, http.StatusServiceUnavailable, "api_error", "No available accounts: "+err.Error())
+				h.responsesErrorResponse(c, tkNoAvailableAccounts(c), "api_error", "No available accounts: "+err.Error())
 				return
 			}
 			action := fs.HandleSelectionExhausted(c.Request.Context())
@@ -208,7 +208,7 @@ func (h *GatewayHandler) Responses(c *gin.Context) {
 		if !selection.Acquired {
 			if selection.WaitPlan == nil {
 				markOpsRoutingCapacityLimited(c)
-				h.responsesErrorResponse(c, http.StatusServiceUnavailable, "api_error", "No available accounts")
+				h.responsesErrorResponse(c, tkNoAvailableAccounts(c), "api_error", "No available accounts")
 				return
 			}
 			accountReleaseFunc, err = h.concurrencyHelper.AcquireAccountSlotWithWaitTimeout(

--- a/backend/internal/handler/no_available_accounts_tk.go
+++ b/backend/internal/handler/no_available_accounts_tk.go
@@ -1,0 +1,40 @@
+package handler
+
+import (
+	"net/http"
+
+	"github.com/gin-gonic/gin"
+)
+
+// tkNoAvailableAccountsRetryAfterSeconds is the Retry-After hint (seconds) sent
+// with the empty-pool fast-fail. Short enough that a transient pool gap recovers
+// quickly; long enough that clients back off instead of immediately retrying.
+const tkNoAvailableAccountsRetryAfterSeconds = "5"
+
+// tkNoAvailableAccounts is the gateway response status when a scheduling pool has
+// no schedulable account ("No available accounts"). It deliberately returns 429
+// (Too Many Requests) + Retry-After instead of 503, setting the Retry-After header
+// as a side effect before the caller writes the body. Pass it in the status
+// position of any streaming-aware error writer, e.g.:
+//
+//	h.handleStreamingAwareError(c, tkNoAvailableAccounts(c), "api_error", "No available accounts", streamStarted)
+//
+// WHY 429 not 503 — prod flood incident 2026-06 (deepseek-v4-flash empty newapi
+// pool, single IP 58.213.121.60 peaking 1540 RPM):
+//   - Stage0 runs a single app upstream behind Caddy. Caddy passive health lists
+//     503 in unhealthy_status with max_fails=1, so one empty-pool 503 marks the
+//     sole upstream "down"; with no failover target every subsequent request
+//     (including the dashboard at https://api.tokenkey.dev/) stalls in
+//     lb_try_duration. A flood of empty-pool 503s thus synthesizes a fake
+//     backend outage and melts the node. 429 is NOT in unhealthy_status, so it
+//     never trips passive health.
+//   - 503 makes SDK clients retry aggressively (retry storm); 429 + Retry-After
+//     makes them back off.
+//
+// Go evaluates call arguments left-to-right before the call, so the header is set
+// before the error writer runs. For account-select failures the response has not
+// started, so the header lands on the wire.
+func tkNoAvailableAccounts(c *gin.Context) int {
+	c.Header("Retry-After", tkNoAvailableAccountsRetryAfterSeconds)
+	return http.StatusTooManyRequests
+}

--- a/backend/internal/handler/openai_chat_completions.go
+++ b/backend/internal/handler/openai_chat_completions.go
@@ -165,7 +165,7 @@ func (h *OpenAIGatewayHandler) ChatCompletions(c *gin.Context) {
 		}
 		if selection == nil || selection.Account == nil {
 			markOpsRoutingCapacityLimited(c)
-			h.handleStreamingAwareError(c, http.StatusServiceUnavailable, "api_error", "No available accounts", streamStarted)
+			h.handleStreamingAwareError(c, tkNoAvailableAccounts(c), "api_error", "No available accounts", streamStarted)
 			return
 		}
 		account := selection.Account

--- a/backend/internal/handler/openai_gateway_embeddings_images.go
+++ b/backend/internal/handler/openai_gateway_embeddings_images.go
@@ -173,7 +173,7 @@ func (h *OpenAIGatewayHandler) Embeddings(c *gin.Context) {
 			}
 		}
 		if selection == nil || selection.Account == nil {
-			h.handleStreamingAwareError(c, http.StatusServiceUnavailable, "api_error", "No available accounts", streamStarted)
+			h.handleStreamingAwareError(c, tkNoAvailableAccounts(c), "api_error", "No available accounts", streamStarted)
 			return
 		}
 		account := selection.Account
@@ -471,7 +471,7 @@ func (h *OpenAIGatewayHandler) ImageGenerations(c *gin.Context) {
 			}
 		}
 		if selection == nil || selection.Account == nil {
-			h.handleStreamingAwareError(c, http.StatusServiceUnavailable, "api_error", "No available accounts", streamStarted)
+			h.handleStreamingAwareError(c, tkNoAvailableAccounts(c), "api_error", "No available accounts", streamStarted)
 			return
 		}
 		account := selection.Account

--- a/backend/internal/handler/openai_gateway_handler.go
+++ b/backend/internal/handler/openai_gateway_handler.go
@@ -322,7 +322,7 @@ func (h *OpenAIGatewayHandler) Responses(c *gin.Context) {
 		}
 		if selection == nil || selection.Account == nil {
 			markOpsRoutingCapacityLimited(c)
-			h.handleStreamingAwareError(c, http.StatusServiceUnavailable, "api_error", "No available accounts", streamStarted)
+			h.handleStreamingAwareError(c, tkNoAvailableAccounts(c), "api_error", "No available accounts", streamStarted)
 			return
 		}
 		if previousResponseID != "" && selection != nil && selection.Account != nil {
@@ -756,7 +756,7 @@ func (h *OpenAIGatewayHandler) Messages(c *gin.Context) {
 		}
 		if selection == nil || selection.Account == nil {
 			markOpsRoutingCapacityLimited(c)
-			h.anthropicStreamingAwareError(c, http.StatusServiceUnavailable, "api_error", "No available accounts", streamStarted)
+			h.anthropicStreamingAwareError(c, tkNoAvailableAccounts(c), "api_error", "No available accounts", streamStarted)
 			return
 		}
 		account := selection.Account
@@ -1071,7 +1071,7 @@ func (h *OpenAIGatewayHandler) acquireResponsesAccountSlot(
 ) (func(), bool) {
 	if selection == nil || selection.Account == nil {
 		markOpsRoutingCapacityLimited(c)
-		h.handleStreamingAwareError(c, http.StatusServiceUnavailable, "api_error", "No available accounts", *streamStarted)
+		h.handleStreamingAwareError(c, tkNoAvailableAccounts(c), "api_error", "No available accounts", *streamStarted)
 		return nil, false
 	}
 
@@ -1082,7 +1082,7 @@ func (h *OpenAIGatewayHandler) acquireResponsesAccountSlot(
 	}
 	if selection.WaitPlan == nil {
 		markOpsRoutingCapacityLimited(c)
-		h.handleStreamingAwareError(c, http.StatusServiceUnavailable, "api_error", "No available accounts", *streamStarted)
+		h.handleStreamingAwareError(c, tkNoAvailableAccounts(c), "api_error", "No available accounts", *streamStarted)
 		return nil, false
 	}
 

--- a/scripts/sentinels/gateway-tk.json
+++ b/scripts/sentinels/gateway-tk.json
@@ -1728,6 +1728,15 @@
         "if service.HasOpsClientBusinessLimited(c) {"
       ],
       "rationale": "ensureForwardErrorResponse must short-circuit when a client-business-limited rejection (codex_cli_only / IP restriction / feature gate) already wrote a complete client-facing response. Without this guard the fallback appends another error frame and corrupts the committed body into `{\"error\":...}event: response.failed...` (gin does not block writes after commit). Introduced with the upstream Wei-Shaw/sub2api#3014 fix; removing it brings back the dirty-403 body."
+    },
+    {
+      "path": "backend/internal/handler/no_available_accounts_tk.go",
+      "must_contain": [
+        "func tkNoAvailableAccounts",
+        "http.StatusTooManyRequests",
+        "Retry-After"
+      ],
+      "rationale": "Empty-pool fast-fail returns 429+Retry-After (not 503) so Caddy passive-health on the single Stage0 upstream does not conflate an empty scheduling pool with a backend outage and stall all traffic incl. the dashboard. An upstream merge re-introducing 503 at the account-select call sites regresses the prod flood-containment fix (PR #572 / IP 58.213.121.60 1540 RPM incident)."
     }
   ]
 }


### PR DESCRIPTION
## What & why

从 #572 拆出的**根因止血**部分(backend-only)。原 #572 把它和「Caddy 自建镜像 + per-IP 限流」捆在一起——两者风险等级、回滚粒度、维护成本完全不同,本 PR 只保留零维护税、根因性的这一半。

调度池无可调度账号(`No available accounts`)时,15 个网关调用点原本全返 **503**。Stage0 是 Caddy 后面单 app 上游,passive-health 把 503 列进 `unhealthy_status` 且 `max_fails=1`,所以**一个空池 503 就把唯一上游标记为 down**,后续每个请求(含 dashboard)卡在 `lb_try_duration`。单 IP 洪泛一个空 newapi 池(deepseek-v4-flash, 58.213.121.60, 1540 RPM)由此**合成出一次假的后端宕机**,把 https://api.tokenkey.dev/ 拖垮。

改为经新 helper `tkNoAvailableAccounts(c)` 统一返 **429 + Retry-After: 5**:429 不在 Caddy `unhealthy_status`(永不误触 passive health),且让 SDK 客户端退避而非对 503 重试风暴。行为锚定在 `gateway-tk.json`,防上游合并静默回退。`/responses/compact` 的「无账号支持 compact」路径**故意保留 503**(能力不匹配,非瞬态,重试无益)。

## 与 #573 的关系(纵深防御)

#573 已从 Caddy passive `unhealthy_status` 删掉 503(拆放大器的一端)。本 PR 从**应用侧**让空池根本不再产生会被误判的 503,并叠加客户端退避——两道独立防线,#573 给不了 `Retry-After` 退避这一层。二者合并即闭环本次事故的「全站 503」症状。

## 代价

40 行 helper + 15 处调用点替换 + 9 行 sentinel 锚。零基础设施、零新依赖、零运维步骤。

## Notes

- `no-web-impact` + `upstream-touch-guarded` 已在 commit message;sentinel `gateway-tk.json` 同 commit 更新。
- 本地 `scripts/preflight.sh` 全绿;`go build ./...` + `go test -tags=unit ./internal/handler/` 通过。
- 合并方式:**Squash and merge**(TK-originated)。
- 拆分自 #572;#572 余下的 Caddy per-IP 限流退回 draft,待本 PR 上线后用线上数据决定是否仍需(见 #572 描述)。

🤖 Generated with [Claude Code](https://claude.com/claude-code)