### PR TITLE
ci: warm cross-arch Go build cache on main so release restores it

### DIFF
--- a/.github/workflows/backend-ci.yml
+++ b/.github/workflows/backend-ci.yml
@@ -313,10 +313,9 @@ jobs:
         run: |
           for arch in amd64 arm64; do
             echo "::group::go build linux/${arch}"
-            GOARCH="${arch}" go build ./cmd/server
+            GOARCH="${arch}" go build -o /dev/null ./cmd/server
             echo "::endgroup::"
           done
-          rm -f sub2api
 
   compile-smoke:
     if: (github.event_name == 'schedule' && github.event.schedule == '17 9 * * TUE') || (github.event_name == 'workflow_dispatch' && (inputs.suite == 'all' || inputs.suite == 'weekly-smoke'))

--- a/.github/workflows/backend-ci.yml
+++ b/.github/workflows/backend-ci.yml
@@ -250,6 +250,74 @@ jobs:
           CURRENT_PIN="$(tr -d '[:space:]' < .new-api-ref)"
           bash scripts/upstream/bump-new-api.sh "$CURRENT_PIN"
 
+  # Warm the cross-arch (amd64+arm64) Go build cache that release.yml consumes.
+  #
+  # WHY THIS JOB EXISTS: release.yml is triggered by `tag push`, so it runs on
+  # `refs/tags/vX.Y.Z`. GitHub Actions scopes cache restore to the current ref
+  # plus the DEFAULT BRANCH only — a cache saved on one tag ref is invisible to
+  # the next tag's run. The "rolling" cache release.yml saved on its own tag ref
+  # was therefore NEVER restored across releases (verified: every release logged
+  # `Cache not found for input keys: Linux-go-release-...`), so every release
+  # cold-compiled the full arm64 package set (~4m, ~79% of the GoReleaser step).
+  #
+  # Saving the same-keyed cache HERE — on `main`, the default branch — makes it
+  # readable from every tag-triggered release run. release.yml now restores it
+  # (restore-only) and only recompiles changed packages + relinks.
+  #
+  # Runs only on push to main (where the save lands on the default-branch ref);
+  # PR runs are pointless because their cache is PR-ref-scoped and release can't
+  # read it.
+  warm-release-cache:
+    if: github.event_name == 'push'
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v6
+      - uses: ./.github/actions/cache-and-checkout-new-api
+      - uses: actions/setup-go@v6
+        with:
+          go-version-file: backend/go.mod
+          check-latest: false
+          # The rolling cache below owns GOCACHE + GOMODCACHE; setup-go's
+          # go.sum-keyed cache is immutable and would never refresh the arm64
+          # cross-compile objects (same reasoning as release.yml).
+          cache: false
+      # Rolling cache: a run_id-unique SAVE key always re-saves at post-job; the
+      # restore-keys seed from the previous main warm cache so the build is
+      # incremental, not cold. Key prefix is IDENTICAL to release.yml's
+      # restore-keys so release restores exactly this entry. Go's cache is
+      # content-addressed, so a stale entry is unused, never wrong.
+      - name: Rolling Go build cache (amd64 + arm64 cross-compile)
+        uses: actions/cache@v4
+        with:
+          path: |
+            ~/.cache/go-build
+            ~/go/pkg/mod
+          key: ${{ runner.os }}-go-release-${{ hashFiles('backend/go.sum') }}-${{ github.run_id }}
+          restore-keys: |
+            ${{ runner.os }}-go-release-${{ hashFiles('backend/go.sum') }}-
+            ${{ runner.os }}-go-release-
+      - name: Verify Go version
+        run: |
+          go version | grep -q 'go1.26.4'
+      # Compile cmd/server for BOTH release arches to populate the cache.
+      # Flags mirror .goreleaser.yaml (CGO_ENABLED=0, linux) — but WITHOUT
+      # `-tags=embed`, so no frontend dist/ is required (embed_off.go satisfies
+      # `//go:build !embed`). The embed-gated files are a handful of tiny
+      # packages that recompile during release; deps + stdlib + all relay/
+      # service/handler objects — the ~79% bulk — are cached identically.
+      - name: Warm cross-arch Go build cache
+        working-directory: backend
+        env:
+          CGO_ENABLED: '0'
+          GOOS: linux
+        run: |
+          for arch in amd64 arm64; do
+            echo "::group::go build linux/${arch}"
+            GOARCH="${arch}" go build ./cmd/server
+            echo "::endgroup::"
+          done
+          rm -f sub2api
+
   compile-smoke:
     if: (github.event_name == 'schedule' && github.event.schedule == '17 9 * * TUE') || (github.event_name == 'workflow_dispatch' && (inputs.suite == 'all' || inputs.suite == 'weekly-smoke'))
     runs-on: ubuntu-latest

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -152,23 +152,28 @@ jobs:
           # lets the rolling cache below own GOCACHE + GOMODCACHE.
           cache: false
 
-      # Rolling Go cache for the cross-arch (amd64+arm64) GoReleaser compile.
-      # A run_id-unique SAVE key means the cache is ALWAYS re-saved at post-job;
-      # the restore-keys fall back to the most recent warm snapshot — which
-      # already holds BOTH arches' object files from the previous release — so a
-      # typical release only recompiles changed packages + relinks, instead of
-      # rebuilding arm64 from scratch. Go's cache is content-addressed, so a
+      # RESTORE-ONLY cross-arch (amd64+arm64) Go build cache.
+      #
+      # Release runs on a tag ref (`refs/tags/vX.Y.Z`). GitHub Actions scopes
+      # cache restore to the current ref + the DEFAULT BRANCH only, so a cache
+      # SAVED here (on the tag ref) is invisible to the next tag's release — the
+      # old `actions/cache@v4` save was pure dead weight (every release logged
+      # `Cache not found` and cold-compiled arm64 from scratch, ~4m). The warm
+      # cache is now produced by the `warm-release-cache` job in backend-ci.yml
+      # on push to `main` (the default branch), which IS readable from tag runs.
+      #
+      # `actions/cache/restore` (no post-job save) consumes that main-warmed
+      # entry via the shared `Linux-go-release-` key prefix and stops generating
+      # dead tag-scoped caches. Go's cache is content-addressed, so a slightly
       # stale entry (e.g. after a .new-api-ref bump) is simply unused, never
-      # wrong. First run after this change is a one-time cold build; budget note:
-      # each release writes a fresh ~1-2GB entry under the 10GB repo cache limit,
-      # GHA LRU-evicts the oldest, the freshest (what we need) always survives.
-      - name: Rolling Go build cache (amd64 + arm64 cross-compile)
-        uses: actions/cache@v4
+      # wrong — release recompiles only changed packages + relinks.
+      - name: Restore cross-arch Go build cache (warmed on main)
+        uses: actions/cache/restore@v4
         with:
           path: |
             ~/.cache/go-build
             ~/go/pkg/mod
-          key: ${{ runner.os }}-go-release-${{ hashFiles('backend/go.sum') }}-${{ github.run_id }}
+          key: ${{ runner.os }}-go-release-${{ hashFiles('backend/go.sum') }}
           restore-keys: |
             ${{ runner.os }}-go-release-${{ hashFiles('backend/go.sum') }}-
             ${{ runner.os }}-go-release-

--- a/scripts/checks/release-cache-key-parity.py
+++ b/scripts/checks/release-cache-key-parity.py
@@ -1,0 +1,143 @@
+#!/usr/bin/env python3
+"""Guard the cross-arch Go build-cache contract between two workflows.
+
+The release speed-up landed in PR #576 splits one cache across two workflow
+files that MUST agree, or the optimization silently reverts (release goes back
+to cold-compiling arm64 ~4m every time, with NO error — exactly the failure
+mode that went unnoticed for weeks before #576):
+
+  * .github/workflows/backend-ci.yml  — `warm-release-cache` job SAVES the cache
+    on `main` (the default branch) with `actions/cache@v4`.
+  * .github/workflows/release.yml     — RESTORES it on the tag ref with
+    `actions/cache/restore@v4` (restore-only; saving here would re-create the
+    dead tag-scoped caches #576 removed).
+
+The two invariants that, if broken, silently kill the speed-up:
+
+  1. KEY PREFIX PARITY — both files key on the identical prefix
+     `<runner.os>-go-release-<hashFiles(backend/go.sum)>`. Rename it in one file
+     only and release's restore-keys never match the warm cache again.
+  2. DIRECTIONALITY — backend-ci's go-release step uses the SAVING action
+     (`actions/cache@v4`); release's uses the RESTORE-ONLY action
+     (`actions/cache/restore@v4`). Re-adding a saver to release.yml resurrects
+     the per-tag-ref dead caches.
+
+Same doctrine as scripts/checks/merge-gate-parity.py: a soft "keep these two in
+sync" rule, hardened into a mechanical gate (global CLAUDE.md §5).
+"""
+
+from __future__ import annotations
+
+import argparse
+import pathlib
+import sys
+
+REPO_ROOT = pathlib.Path(__file__).resolve().parents[2]
+
+BACKEND_CI = REPO_ROOT / ".github" / "workflows" / "backend-ci.yml"
+RELEASE = REPO_ROOT / ".github" / "workflows" / "release.yml"
+
+# The shared cache-key prefix both files must agree on, verbatim (GitHub
+# expression syntax included — it is part of the literal key string).
+SHARED_KEY_PREFIX = "${{ runner.os }}-go-release-${{ hashFiles('backend/go.sum') }}"
+
+# Marker substring that identifies a go-release cache key line in either file.
+KEY_MARKER = "go-release"
+
+SAVE_ACTION = "actions/cache@v4"
+RESTORE_ACTION = "actions/cache/restore@v4"
+
+
+def _fail(quiet: bool, msg: str) -> None:
+    if not quiet:
+        sys.stderr.write(f"  FAIL: {msg}\n")
+
+
+def _action_for_first_key(lines: list[str]) -> str | None:
+    """Return the `uses:` action backing the FIRST go-release cache step.
+
+    Scans upward from the first NON-COMMENT line mentioning the key marker to the
+    nearest `uses:` line — that step's action is the one operating on the cache.
+    Comment lines are skipped because the rationale blocks in both workflows
+    reference `Linux-go-release-...` in prose, which would otherwise be matched
+    before the real `key:` line.
+    """
+    key_idx = next(
+        (i for i, ln in enumerate(lines)
+         if KEY_MARKER in ln and not ln.lstrip().startswith("#")),
+        None,
+    )
+    if key_idx is None:
+        return None
+    for i in range(key_idx, -1, -1):
+        stripped = lines[i].strip()
+        if stripped.startswith("uses:") or stripped.startswith("- uses:"):
+            return stripped.split("uses:", 1)[1].strip()
+    return None
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("--quiet", action="store_true", help="suppress non-error output")
+    args = parser.parse_args()
+
+    errors = 0
+
+    for path in (BACKEND_CI, RELEASE):
+        if not path.exists():
+            _fail(args.quiet, f"{path.relative_to(REPO_ROOT)} not found")
+            errors += 1
+
+    if errors:
+        return 1
+
+    ci_text = BACKEND_CI.read_text()
+    rel_text = RELEASE.read_text()
+
+    # Invariant 1: shared key prefix present in BOTH files.
+    if SHARED_KEY_PREFIX not in ci_text:
+        _fail(
+            args.quiet,
+            f"backend-ci.yml missing the shared cache-key prefix '{SHARED_KEY_PREFIX}'. "
+            "The warm-release-cache job must key on it so release.yml can restore the entry.",
+        )
+        errors += 1
+    if SHARED_KEY_PREFIX not in rel_text:
+        _fail(
+            args.quiet,
+            f"release.yml missing the shared cache-key prefix '{SHARED_KEY_PREFIX}'. "
+            "Its restore-keys must match the prefix the warm-release-cache job saves under, "
+            "or release silently cold-compiles arm64 again.",
+        )
+        errors += 1
+
+    # Invariant 2: directionality — backend-ci SAVES, release RESTORE-ONLY.
+    ci_action = _action_for_first_key(ci_text.splitlines())
+    rel_action = _action_for_first_key(rel_text.splitlines())
+
+    if ci_action != SAVE_ACTION:
+        _fail(
+            args.quiet,
+            f"backend-ci.yml go-release cache step must use '{SAVE_ACTION}' (it SAVES the warm "
+            f"cache on main); found '{ci_action}'.",
+        )
+        errors += 1
+    if rel_action != RESTORE_ACTION:
+        _fail(
+            args.quiet,
+            f"release.yml go-release cache step must use '{RESTORE_ACTION}' (restore-only); found "
+            f"'{rel_action}'. A saving '{SAVE_ACTION}' here resurrects the dead per-tag-ref caches "
+            "PR #576 removed — release saves on the tag ref, which no later tag can read.",
+        )
+        errors += 1
+
+    if errors:
+        return 1
+
+    if not args.quiet:
+        print("  ok: release/warm cache key prefix + directionality in sync")
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/scripts/preflight.sh
+++ b/scripts/preflight.sh
@@ -1246,6 +1246,22 @@ else
 fi
 
 echo ""
+echo "=== sub2api: release/warm Go cache key parity ==="
+# Keeps the cross-arch Go build-cache contract between backend-ci.yml's
+# `warm-release-cache` job (SAVES on main) and release.yml (RESTORE-ONLY on the
+# tag ref) mechanically coupled: identical key prefix + correct save/restore
+# directionality. Drift silently reverts the release speed-up to a cold arm64
+# compile with no error (the exact class that went unnoticed before PR #576).
+if ! command -v python3 >/dev/null 2>&1; then
+    echo "  FAIL: python3 not on PATH (required by release-cache-key-parity.py)"
+    errors=$((errors + 1))
+elif ! python3 ./scripts/checks/release-cache-key-parity.py --quiet; then
+    errors=$((errors + 1))
+else
+    echo "  ok: release/warm cache key prefix + directionality in sync"
+fi
+
+echo ""
 if [ "$errors" -eq 0 ]; then
     echo "=== preflight (with sub2api checks): PASS ==="
     exit 0


### PR DESCRIPTION
## Problem

`release.yml` is tag-triggered, so it runs on `refs/tags/vX.Y.Z`. GitHub Actions scopes cache **restore** to the current ref + the **default branch** only. The rolling Go build cache `release.yml` saved on its own tag ref was therefore **never** restored by the next tag's release — every release logged `Cache not found for input keys: Linux-go-release-...` and cold-compiled the full arm64 package set.

Evidence (v1.7.69, run 26963561153): `release` job 6m53s; GoReleaser `building binaries` (amd64+arm64 cross-compile) = **4m7s (~79%)**. `gh cache list` showed 8 `Linux-go-release-*` caches all pinned under `refs/heads/refs/tags/v1.7.x` (~6.9 GB), none readable by any future tag run.

## Fix (Option A — relocate cache production to the default branch)

- **`backend-ci.yml`**: new `warm-release-cache` job (push to `main` only) cross-compiles `cmd/server` for `amd64`+`arm64` (`CGO_ENABLED=0 GOOS=linux`, **no `-tags=embed`** → uses `embed_off.go`, so no frontend `dist/` needed) and saves the cache under the **same key prefix** on the default branch, where tag releases can read it. Rolling `run_id` save key keeps it fresh.
- **`release.yml`**: cache step `actions/cache@v4` → `actions/cache/restore@v4` (restore-only). It consumes the main-warmed entry via the shared `Linux-go-release-` prefix and stops minting dead tag-scoped caches.
- Purged the 8 dead tag-scoped go-release caches (6.91 GB) to free the 10 GB repo cache budget.

## Expected impact

`building binaries` ~4m → ~1–1.5m (recompile changed packages + relink only); `release` job ~6m53s → ~3.5min. **Takes effect after the next merge to `main`** warms the cache once; subsequent tag releases hit it. GHCR push (~1m29s, network) is untouched.

## Notes

- Pure `.github/workflows/` change; no backend/frontend surface touched (`no-web-impact` justification present).
- TK-originated chore → **Squash and merge** per CLAUDE.md §5.y.
- Cache correctness: Go's build cache is content-addressed, so a stale entry (e.g. after a `.new-api-ref` bump) is simply unused, never wrong.

🤖 Generated with [Claude Code](https://claude.com/claude-code)