### PR TITLE
fix(tier): anthropic priority owned by window-rebalance at runtime; reconciler stops reverting it

### DIFF
--- a/backend/internal/service/account_tier_service_tk.go
+++ b/backend/internal/service/account_tier_service_tk.go
@@ -35,16 +35,21 @@ const AccountTierExtraKey = "stability_tier"
 //     MergePreservingSensitiveCreds in UpdateAccount;
 //   - write the shared_baseline extra mimicry/template flags (enable_tls_
 //     fingerprint / rpm_strategy / session_id_masking_enabled / ...);
-//   - value-sync priority to the tier baseline (post-#551 all tiers are uniform
-//     priority=1; the old "priority owned by window-rebalance pipeline" carve-out
-//     no longer applies to anthropic — see reconciler kiro-priority for the same
-//     shape).
+//   - (operator-explicit ApplyTier ONLY) seed priority from the tier baseline.
+//     priority is a DYNAMIC runtime signal owned by the window-rebalance pipeline
+//     (ops/anthropic/rebalance-anthropic-priority.py): git baseline wins only at
+//     the apply/发版 moment, and the reconciler self-heal path
+//     (ReapplyBaselineInfra) deliberately does NOT touch priority — reverting it
+//     every tick would flatten the window-aware ordering rebalance just computed.
+//     Contrast kiro, which has no rebalance pipeline and is hard-pinned by
+//     reconcileKiroPriorityBaseline.
 //
 // It NEVER copies the tier-managed NUMERIC extra keys (base_rpm / max_sessions /
 // window / cache_ttl_override_*) into the account — those overlay at runtime from
 // the tiers table (model.IsTierManagedExtraKey strips them). Fleet fan-out stays
 // with the ops/anthropic pipeline; the per-node reconciler re-asserts this same
-// complete shape (it calls ApplyTier) so any creation path self-heals.
+// complete shape via ReapplyBaselineInfra (everything EXCEPT priority) so any
+// creation path self-heals without flattening the window-rebalance ordering.
 type AccountTierService struct {
 	adminSvc AdminService
 	tierSvc  *TierService
@@ -56,12 +61,34 @@ func NewAccountTierService(adminSvc AdminService, tierSvc *TierService, tlsSvc *
 	return &AccountTierService{adminSvc: adminSvc, tierSvc: tierSvc, tlsSvc: tlsSvc}
 }
 
-// ApplyTier binds the given account to `tier`. Only anthropic OAUTH and
+// ApplyTier is the operator-explicit path (admin UI "apply tier" / deploy seed).
+// It materializes the full shared_baseline AND seeds priority from the tier
+// baseline — this is the single git-is-source-of-truth moment for priority. Use
+// it when an operator deliberately (re)applies a tier; between applies the
+// window-rebalance pipeline owns runtime priority.
+func (s *AccountTierService) ApplyTier(ctx context.Context, accountID int64, tier string) (*Account, error) {
+	return s.applyTier(ctx, accountID, tier, true /* syncPriority */)
+}
+
+// ReapplyBaselineInfra is the reconciler self-heal path. It re-asserts the
+// shared_baseline INFRASTRUCTURE (TLS profile ensure+bind, credentials
+// self-protection template, extra mimicry flags, concurrency) but DELIBERATELY
+// does NOT touch priority: priority is a dynamic runtime signal owned by the
+// window-rebalance pipeline, and value-syncing it here on every tick would revert
+// rebalance's window-aware ordering back to the uniform baseline. Steady-state
+// self-heal must converge the infra without fighting the rebalance pipeline.
+func (s *AccountTierService) ReapplyBaselineInfra(ctx context.Context, accountID int64, tier string) (*Account, error) {
+	return s.applyTier(ctx, accountID, tier, false /* syncPriority */)
+}
+
+// applyTier binds the given account to `tier`. Only anthropic OAUTH and
 // setup-token accounts are accepted — these are the two types subject to 5h
 // window + session control (see Account.IsAnthropicOAuthOrSetupToken). apikey
 // mirror stubs and other platforms are rejected — applying a tier to a stub
-// would wipe its base_url/pool_mode.
-func (s *AccountTierService) ApplyTier(ctx context.Context, accountID int64, tier string) (*Account, error) {
+// would wipe its base_url/pool_mode. syncPriority gates whether priority is
+// value-synced to the tier baseline (true on the operator path, false on the
+// reconciler self-heal path); see ApplyTier / ReapplyBaselineInfra.
+func (s *AccountTierService) applyTier(ctx context.Context, accountID int64, tier string, syncPriority bool) (*Account, error) {
 	if s == nil || s.adminSvc == nil || s.tierSvc == nil {
 		return nil, fmt.Errorf("account tier service unavailable")
 	}
@@ -149,15 +176,20 @@ func (s *AccountTierService) ApplyTier(ctx context.Context, accountID int64, tie
 	tierID := row.ID
 	concurrency := row.Concurrency
 	rateMultiplier := row.RateMultiplier
-	priority := eff.Priority // post-#551 uniform baseline priority (value-sync)
 
 	input := &UpdateAccountInput{
 		TierID:         &tierID,
 		Concurrency:    &concurrency, // value-sync from tier (hot-path column)
-		Priority:       &priority,    // value-sync to baseline (post-#551 uniform)
 		RateMultiplier: &rateMultiplier,
 		Credentials:    creds,
 		Extra:          extra,
+	}
+	// priority is seeded from the tier baseline ONLY on the operator-explicit
+	// path (syncPriority). The reconciler self-heal path leaves priority untouched
+	// so the window-rebalance pipeline's runtime ordering is not flattened.
+	if syncPriority {
+		priority := eff.Priority
+		input.Priority = &priority
 	}
 
 	updated, err := s.adminSvc.UpdateAccount(ctx, accountID, input)
@@ -165,13 +197,13 @@ func (s *AccountTierService) ApplyTier(ctx context.Context, accountID int64, tie
 		return nil, err
 	}
 
-	slog.Info("account tier applied — full baseline materialized (local deployment only)",
+	slog.Info("account tier applied — baseline materialized (local deployment only)",
 		"account_id", accountID,
 		"account_name", account.Name,
 		"tier", row.Name,
 		"tier_id", tierID,
 		"concurrency", concurrency,
-		"priority", priority,
+		"priority_synced", syncPriority,
 		"tls_fingerprint_profile_id", tlsProfileID,
 	)
 	return updated, nil

--- a/backend/internal/service/account_tier_service_tk_test.go
+++ b/backend/internal/service/account_tier_service_tk_test.go
@@ -231,6 +231,33 @@ func TestApplyTier_OAuthBindsTierAndValueSyncsConcurrency(t *testing.T) {
 	require.False(t, hasBaseRPM, "tier-managed numeric extra must NOT be copied onto the account")
 }
 
+// TestReapplyBaselineInfra_DoesNotTouchPriority is the regression guarding the
+// reconciler self-heal path: it must re-assert the shared_baseline infrastructure
+// (tier_id / concurrency / TLS binding / extra flags) WITHOUT writing priority —
+// priority is owned at runtime by the window-rebalance pipeline, and value-syncing
+// it on every reconciler tick would flatten rebalance's window-aware ordering.
+func TestReapplyBaselineInfra_DoesNotTouchPriority(t *testing.T) {
+	admin := &stubAdminServiceForTier{getAccount: &Account{
+		ID:       7,
+		Platform: PlatformAnthropic,
+		Type:     AccountTypeOAuth,
+		Priority: 3, // a rebalance-assigned runtime priority that must survive
+	}}
+	svc := NewAccountTierService(admin, tierServiceWithL4(t), tlsServiceWithRepo(t, &stubTLSRepo{}))
+
+	_, err := svc.ReapplyBaselineInfra(context.Background(), 7, "l4")
+	require.NoError(t, err)
+	require.NotNil(t, admin.updateInput)
+
+	in := admin.updateInput
+	require.NotNil(t, in.TierID)
+	require.Equal(t, int64(4), *in.TierID, "self-heal still binds tier_id")
+	require.NotNil(t, in.Concurrency)
+	require.Equal(t, 8, *in.Concurrency, "self-heal still value-syncs concurrency")
+	require.Equal(t, true, in.Extra["enable_tls_fingerprint"], "self-heal still asserts infra flags")
+	require.Nil(t, in.Priority, "self-heal must NOT write priority (window-rebalance owns it)")
+}
+
 // TestApplyTier_CreatesAndBindsCanonicalTLSProfile is the regression for the
 // reported bug: operator added an OAuth account + set tier, but the
 // tls_fingerprint_profiles table had no tk_canonical_cc_oauth row, so the

--- a/backend/internal/service/anthropic_config_reconciler.go
+++ b/backend/internal/service/anthropic_config_reconciler.go
@@ -102,12 +102,13 @@ type reconcilerTierResolver interface {
 	ResolveName(tierID int64) (string, bool)
 }
 
-// reconcilerTierApplier re-applies a tier onto an account — the single complete
-// "materialize shared_baseline" write path (TLS profile ensure+bind, credentials
-// template, extra flags, priority, concurrency). *AccountTierService satisfies it.
-// nil-safe (Step baseline no-ops when absent).
+// reconcilerTierApplier re-asserts the shared_baseline INFRASTRUCTURE onto an
+// account (TLS profile ensure+bind, credentials template, extra flags,
+// concurrency) WITHOUT touching priority — priority is owned at runtime by the
+// window-rebalance pipeline, so the per-tick self-heal must not revert it.
+// *AccountTierService satisfies it. nil-safe (Step baseline no-ops when absent).
 type reconcilerTierApplier interface {
-	ApplyTier(ctx context.Context, accountID int64, tier string) (*Account, error)
+	ReapplyBaselineInfra(ctx context.Context, accountID int64, tier string) (*Account, error)
 }
 
 // reconcilerTLSProfileResolver reads a TLS profile by id so the baseline drift
@@ -295,10 +296,11 @@ func (r *AnthropicConfigReconciler) runOnce(ctx context.Context) {
 	r.reconcileTierConcurrency(ctx, accounts)
 
 	// Step baseline: self-heal shared_baseline INFRASTRUCTURE (canonical TLS
-	// profile existence + binding, credentials self-protection template, uniform
-	// priority) for tier-bound anthropic OAuth/setup-token accounts by re-running
-	// ApplyTier when drifted. Idempotent; the single complete write path. This is
-	// what makes "operator just sets the tier" yield a fully-configured account.
+	// profile existence + binding, credentials self-protection template, extra
+	// mimicry flags) for tier-bound anthropic OAuth/setup-token accounts by
+	// re-running ReapplyBaselineInfra when drifted. Idempotent. priority is NOT in
+	// this set — it is a dynamic runtime signal owned by the window-rebalance
+	// pipeline, and reverting it every tick would flatten that ordering.
 	r.reconcileAccountBaselineDrift(ctx, accounts)
 
 	// Step C: surface-C concurrency mirror (prod). Runs before the operator Σ
@@ -349,10 +351,11 @@ func (r *AnthropicConfigReconciler) reconcileClaudeCodeMimicry(ctx context.Conte
 // concurrency column from its tier row. concurrency stays a persisted column on
 // the scheduler hot path; the tier table is the write-source. BulkUpdate already
 // enqueues an outbox account_changed event → snapshot rebuild. It does NOT write
-// priority — priority is value-synced to the uniform post-#551 baseline by Step
-// baseline (reconcileAccountBaselineDrift → ApplyTier). Note: CRSSyncService
-// (on-demand admin import) and the admin UI also set anthropic-oauth priority;
-// Step baseline intentionally reconverges those to the uniform tier baseline.
+// priority — anthropic priority is a dynamic runtime signal owned by the
+// window-rebalance pipeline (ops/anthropic/rebalance-anthropic-priority.py); the
+// git baseline seeds it only on the operator-explicit ApplyTier path, and Step
+// baseline (ReapplyBaselineInfra) does NOT reconverge it. (kiro is the opposite —
+// hard-pinned by reconcileKiroPriorityBaseline, no rebalance pipeline.)
 func (r *AnthropicConfigReconciler) reconcileTierConcurrency(ctx context.Context, accounts []Account) {
 	if r.tiers == nil {
 		return

--- a/backend/internal/service/anthropic_config_reconciler_test.go
+++ b/backend/internal/service/anthropic_config_reconciler_test.go
@@ -130,10 +130,10 @@ func newTestReconciler(acc *reconcilerAccountStub, usr *reconcilerUserStub, bal 
 // --- Step baseline (account shared_baseline self-heal) stubs + tests ----------
 
 type stubTierApplier struct {
-	calls []int64 // account ids ApplyTier was invoked on
+	calls []int64 // account ids ReapplyBaselineInfra was invoked on
 }
 
-func (s *stubTierApplier) ApplyTier(ctx context.Context, accountID int64, tier string) (*Account, error) {
+func (s *stubTierApplier) ReapplyBaselineInfra(ctx context.Context, accountID int64, tier string) (*Account, error) {
 	s.calls = append(s.calls, accountID)
 	return &Account{ID: accountID}, nil
 }
@@ -166,11 +166,14 @@ func TestReconcileAccountBaselineDrift_HealsUnboundTLS(t *testing.T) {
 	require.Equal(t, []int64{7}, applier.calls, "unbound TLS must trigger ApplyTier self-heal")
 }
 
-func TestReconcileAccountBaselineDrift_HealsPriorityDrift(t *testing.T) {
+func TestReconcileAccountBaselineDrift_IgnoresPriorityDrift(t *testing.T) {
 	applier := &stubTierApplier{}
 	tls := &stubTLSByID{byID: map[int64]*model.TLSFingerprintProfile{5: {ID: 5, Name: "tk_canonical_cc_oauth"}}}
 	r := baselineSelfHealReconciler(applier, tls)
-	// fully bound + credentials present, but priority=2 (≠ baseline 1) → drift.
+	// fully bound infra + credentials present, but priority=2 (≠ baseline 1).
+	// priority is owned by the window-rebalance pipeline at runtime, so a drifted
+	// priority on an otherwise-aligned account must NOT trigger self-heal —
+	// otherwise the reconciler would flatten rebalance's window-aware ordering.
 	accts := []Account{{
 		ID: 8, Platform: PlatformAnthropic, Type: AccountTypeSetupToken, TierID: tierID2(),
 		Priority:    2,
@@ -178,7 +181,7 @@ func TestReconcileAccountBaselineDrift_HealsPriorityDrift(t *testing.T) {
 		Credentials: map[string]any{"temp_unschedulable_enabled": true, "temp_unschedulable_rules": []any{}, "intercept_warmup_requests": true},
 	}}
 	r.reconcileAccountBaselineDrift(context.Background(), accts)
-	require.Equal(t, []int64{8}, applier.calls, "priority drift must trigger ApplyTier self-heal")
+	require.Empty(t, applier.calls, "priority drift alone must NOT trigger self-heal (rebalance owns runtime priority)")
 }
 
 func TestReconcileAccountBaselineDrift_SkipsAligned(t *testing.T) {

--- a/backend/internal/service/anthropic_config_reconciler_tk_account_baseline.go
+++ b/backend/internal/service/anthropic_config_reconciler_tk_account_baseline.go
@@ -10,17 +10,21 @@ import (
 // reconcileAccountBaselineDrift self-heals the shared_baseline INFRASTRUCTURE for
 // every tier-bound anthropic OAuth/setup-token account on THIS node: the canonical
 // TLS profile's existence + the account's binding to it, the credentials
-// self-protection template, and the (post-#551 uniform) priority. When any drift
-// is detected it re-runs the SAME complete write path the admin UI uses
-// (AccountTierService.ApplyTier), so a missing TLS profile row, a dangling
-// binding, a missing 403 self-protection rule, or a stale priority all converge —
-// no matter how the account was created (admin UI, bare SQL, partial apply).
+// self-protection template, and the extra mimicry flags. When any drift is
+// detected it re-runs ReapplyBaselineInfra (the infra subset of the admin UI's
+// ApplyTier), so a missing TLS profile row, a dangling binding, or a missing 403
+// self-protection rule all converge — no matter how the account was created
+// (admin UI, bare SQL, partial apply).
 //
-// It deliberately does NOT touch tier NUMERIC fields (base_rpm / max_sessions /
-// window) — those overlay at runtime from the tiers table and stay report-only
+// It deliberately does NOT touch priority: priority is a dynamic runtime signal
+// owned by the window-rebalance pipeline (ops/anthropic/rebalance-anthropic-
+// priority.py); the git baseline seeds it only on the operator-explicit ApplyTier
+// path, and reverting it on every tick would flatten the window-aware ordering.
+// It also does NOT touch tier NUMERIC fields (base_rpm / max_sessions / window) —
+// those overlay at runtime from the tiers table and stay report-only
 // (reportTierDrift). Mirrors reconcileKiroPriorityBaseline's skip-if-aligned shape
-// and reuses the reconciler's ticker + redis leader lock; ApplyTier itself
-// enqueues the snapshot-rebuild outbox event via UpdateAccount.
+// and reuses the reconciler's ticker + redis leader lock; ReapplyBaselineInfra
+// itself enqueues the snapshot-rebuild outbox event via UpdateAccount.
 func (r *AnthropicConfigReconciler) reconcileAccountBaselineDrift(ctx context.Context, accounts []Account) {
 	if r == nil || r.tierApplier == nil || r.tiers == nil {
 		return // applier/resolver not wired (minimal test deps) → no-op
@@ -44,12 +48,12 @@ func (r *AnthropicConfigReconciler) reconcileAccountBaselineDrift(ctx context.Co
 		if reason == "" {
 			continue // aligned → skip (no write)
 		}
-		if _, err := r.tierApplier.ApplyTier(ctx, a.ID, tierName); err != nil {
-			slog.Warn("anthropic config reconciler: account baseline self-heal (ApplyTier) failed",
+		if _, err := r.tierApplier.ReapplyBaselineInfra(ctx, a.ID, tierName); err != nil {
+			slog.Warn("anthropic config reconciler: account baseline self-heal (ReapplyBaselineInfra) failed",
 				"account_id", a.ID, "account_name", a.Name, "tier", tierName, "reason", reason, "err", err)
 			continue
 		}
-		slog.Info("anthropic config reconciler: account baseline self-healed via ApplyTier (local deployment only)",
+		slog.Info("anthropic config reconciler: account baseline self-healed via ReapplyBaselineInfra (local deployment only)",
 			"account_id", a.ID, "account_name", a.Name, "tier", tierName, "reason", reason)
 	}
 }
@@ -59,10 +63,10 @@ func (r *AnthropicConfigReconciler) reconcileAccountBaselineDrift(ctx context.Co
 // account-side (cheap) plus an optional dangling-binding lookup; on a TLS resolver
 // error it conservatively does NOT report drift (never flap on a transient read).
 func (r *AnthropicConfigReconciler) accountBaselineDriftReason(ctx context.Context, a *Account, eff *baseline.EffectiveTierBaseline) string {
-	// priority: post-#551 uniform baseline value (value-synced).
-	if a.Priority != eff.Priority {
-		return "priority"
-	}
+	// priority is intentionally NOT checked here: it is a dynamic runtime signal
+	// owned by the window-rebalance pipeline. Self-healing it on every tick would
+	// flatten rebalance's window-aware ordering back to the uniform baseline. It is
+	// seeded from the git baseline only on the operator-explicit ApplyTier path.
 	// enable_tls_fingerprint flag must be on.
 	if v, _ := a.Extra["enable_tls_fingerprint"].(bool); !v {
 		return "tls_fingerprint_disabled"

--- a/ops/anthropic/rebalance-anthropic-priority.py
+++ b/ops/anthropic/rebalance-anthropic-priority.py
@@ -21,6 +21,14 @@ base=1: caps-only tiers — stability tier gates rate caps, not scheduling
 order), so the reset puts every tier on the same base and this pipeline's
 within-tier window rank is what orders accounts.
 
+Runtime ownership: this pipeline is the authoritative writer of
+accounts.priority between tier applies. The backend per-node config
+reconciler (AccountTierService.ReapplyBaselineInfra, called from
+anthropic_config_reconciler.go) deliberately does NOT self-heal priority —
+only the operator-explicit ApplyTier path seeds the git baseline at apply
+time, so the reconciler never reverts the window rank this pipeline writes.
+Do NOT re-introduce a per-tick priority revert in the reconciler.
+
 Stages
 ------
   1. snapshot — pull each deployable edge's anthropic OAuth accounts +

--- a/scripts/sentinels/gateway-tk.json
+++ b/scripts/sentinels/gateway-tk.json
@@ -1327,9 +1327,10 @@
         "func (s *AccountTierService) ApplyTier(",
         "s.tlsSvc.GetOrUpsertByName(ctx, eff.CanonicalTLSProfile())",
         "extra[\"tls_fingerprint_profile_id\"] = tlsProfileID",
-        "AccountTierExtraKey"
+        "AccountTierExtraKey",
+        "func (s *AccountTierService) ReapplyBaselineInfra("
       ],
-      "rationale": "TK per-account tier-apply service: the UI 'Set Tier' action that replaces the high-frequency ops/anthropic SSM fan-out for a single deployment. ApplyTier accepts anthropic OAuth AND setup-token accounts (both are subject to 5h window + session control per Account.IsAnthropicOAuthOrSetupToken); api-key / mirror stubs and other platforms are rejected. It derives the desired account config from the embedded tier baseline (concurrency/priority/rate_multiplier + merged extra + shared credentials), CREATES-IF-ABSENT the canonical TLS fingerprint profile via GetOrUpsertByName (the GetByName-only lookup was the root cause of silent built-in-default ClientHello fallback when the profile row was missing), binds tls_fingerprint_profile_id + pins the shared_baseline extra/credentials template + priority on the account, and persists via the existing UpdateAccount path (which runs the operator-Σ sync). The per-node config reconciler re-runs this same path to self-heal any creation path. Writes ONLY this deployment's DB. The GetOrUpsertByName + tls_fingerprint_profile_id binding anchors are the regression guard for the fix; silent upstream-merge deletion would break the admin Set-Tier UI flow and reintroduce the unbound-TLS bug."
+      "rationale": "TK per-account tier-apply service: the UI 'Set Tier' action that replaces the high-frequency ops/anthropic SSM fan-out for a single deployment. ApplyTier accepts anthropic OAuth AND setup-token accounts (both are subject to 5h window + session control per Account.IsAnthropicOAuthOrSetupToken); api-key / mirror stubs and other platforms are rejected. It derives the desired account config from the embedded tier baseline (concurrency/priority/rate_multiplier + merged extra + shared credentials), CREATES-IF-ABSENT the canonical TLS fingerprint profile via GetOrUpsertByName (the GetByName-only lookup was the root cause of silent built-in-default ClientHello fallback when the profile row was missing), binds tls_fingerprint_profile_id + pins the shared_baseline extra/credentials template + priority on the account, and persists via the existing UpdateAccount path (which runs the operator-Σ sync). The per-node config reconciler re-runs this same path to self-heal any creation path. Writes ONLY this deployment's DB. The GetOrUpsertByName + tls_fingerprint_profile_id binding anchors are the regression guard for the fix; silent upstream-merge deletion would break the admin Set-Tier UI flow and reintroduce the unbound-TLS bug. Priority ownership is split: ApplyTier (operator/admin-UI path) seeds priority from the git baseline at apply time, while ReapplyBaselineInfra (reconciler self-heal path) re-asserts TLS/credentials/extra-flag/concurrency infrastructure but NEVER writes priority — anthropic runtime priority is owned by the window-rebalance pipeline (ops/anthropic/rebalance-anthropic-priority.py). The ReapplyBaselineInfra anchor guards against a regression that re-introduces a per-tick priority revert and flattens the window-aware ordering."
     },
     {
       "path": "backend/internal/handler/admin/account_handler_tk_tier.go",
@@ -1503,6 +1504,15 @@
         "func (r *AnthropicConfigReconciler) reportTierDrift("
       ],
       "rationale": "Per-node in-process self-healer that drops the ops/anthropic high-frequency safe-item writes into the backend: operator-Σ alignment, prod stub pool_mode, edge balance floor, and the surface-C concurrency mirror — plus REPORT-ONLY tier drift (never silently rewrites a UI-set tier). The surface-C 'never write 0 on a failed edge read' invariant and the report-only tier-drift boundary are load-bearing correctness properties; a silent upstream-merge deletion or weakening must be caught."
+    },
+    {
+      "path": "backend/internal/service/anthropic_config_reconciler_tk_account_baseline.go",
+      "must_contain": [
+        "func (r *AnthropicConfigReconciler) reconcileAccountBaselineDrift(",
+        "r.tierApplier.ReapplyBaselineInfra(ctx, a.ID, tierName)",
+        "priority is intentionally NOT checked here"
+      ],
+      "rationale": "TK per-node account-baseline self-heal step. It re-asserts the shared_baseline INFRASTRUCTURE (canonical TLS profile existence + binding, credentials self-protection template, extra mimicry flags) via ReapplyBaselineInfra — NOT ApplyTier — so it never writes priority. anthropic runtime priority is owned by the window-rebalance pipeline (ops/anthropic/rebalance-anthropic-priority.py); the git baseline seeds it only on the operator-explicit ApplyTier path. The ReapplyBaselineInfra call anchor + the 'priority is intentionally NOT checked' anchor are the regression guard: a silent revert to ApplyTier (or re-adding a priority drift reason) would re-introduce a per-tick revert that flattens rebalance's window-aware ordering back to the uniform baseline."
     },
     {
       "path": "backend/internal/service/gateway_request.go",


### PR DESCRIPTION
## Problem

#565 made `ApplyTier` value-sync anthropic `priority` to the uniform git baseline (`priority:1` for every tier) and wired `reconcileAccountBaselineDrift` into the per-node reconcile loop to re-assert it. But `ops/anthropic/rebalance-anthropic-priority.py` (the documented, still-live `tokenkey-anthropic-oauth-priority-by-window` workflow) writes **non-uniform** priorities `base + rank` (1, 2, 3… by 5h/7d window remaining within a tier).

Result: the reconciler reverts rebalance's window-aware ordering back to uniform `1` on **every tick** — the rebalance pipeline's output is ephemeral, its `verify` shows perpetual drift, and operators waste effort. Two components shipping in 1.7.69 directly contradict each other on who owns `priority`.

Found during the `1.7.69 vs 1.7.68` release review.

## Fix

`priority` is a **dynamic runtime signal**, so git owns it only at apply time and the rebalance pipeline owns it between applies. Split the write path:

- **`ApplyTier`** (operator / admin-UI path) — still seeds priority from the git baseline. The single git-is-source-of-truth moment at apply/发版 time.
- **`ReapplyBaselineInfra`** (new; reconciler self-heal path) — re-asserts the shared_baseline INFRASTRUCTURE (TLS profile ensure+bind, credentials self-protection template, extra mimicry flags, concurrency) but **never writes priority**.
- reconciler interface + caller switched to `ReapplyBaselineInfra`; the `priority` reason is dropped from `accountBaselineDriftReason`.

Net: **git wins at apply time, the window-rebalance pipeline wins between applies, the reconciler no longer fights it.** `kiro` is unchanged (hard-pinned by `reconcileKiroPriorityBaseline`; it has no rebalance pipeline). TLS / credentials / extra-flag self-heal is unchanged.

## Sentinels

Added `ReapplyBaselineInfra` anchor on `account_tier_service_tk.go` and a new entry on `anthropic_config_reconciler_tk_account_baseline.go` asserting the self-heal calls the priority-preserving method — regression guard against a per-tick revert returning on a future upstream merge/refactor.

## Tests

- `TestReapplyBaselineInfra_DoesNotTouchPriority` — self-heal preserves a rebalance-assigned priority.
- `TestReconcileAccountBaselineDrift_IgnoresPriorityDrift` — priority drift alone no longer triggers self-heal.
- `TestApplyTier_OAuthBindsTierAndValueSyncsConcurrency` — operator path still seeds the baseline priority.

`go build ./...`, `go test -tags=unit ./internal/service/...`, and full `scripts/preflight.sh` all green locally.

🤖 Generated with [Claude Code](https://claude.com/claude-code)