### PR TITLE
chore(cc-fingerprint): align UA to cc 2.1.163 (pure version bump)

### DIFF
--- a/backend/internal/baseline/anthropic-http-mimicry-baselines.json
+++ b/backend/internal/baseline/anthropic-http-mimicry-baselines.json
@@ -1,6 +1,6 @@
 {
   "schema_version": 1,
-  "cc_version": "2.1.162",
+  "cc_version": "2.1.163",
   "description": "Canonical OAuth HTTP mimicry betas for Claude Code CLI. Live wire values are driven at runtime by settings.claude_code_http_mimicry_manifest (sync-runtime / plan-http-mimicry-sync). Compile-time defaults in backend/internal/pkg/claude/constants.go catch up on the release train.",
   "sonnet_opus": [
     "claude-code-20250219",

--- a/backend/internal/pkg/claude/constants.go
+++ b/backend/internal/pkg/claude/constants.go
@@ -81,7 +81,7 @@ const DefaultCacheControlTTL = "5m"
 // CLICurrentVersion 是 sub2api 当前对外伪装的 Claude Code CLI 版本号（三段 semver）。
 // 用于 billing attribution block 中的 cc_version=X.Y.Z.{fp} 前缀以及 fingerprint 计算。
 // 必须与 DefaultHeaders["User-Agent"] 中的版本号严格一致；不一致会被 Anthropic 判第三方。
-const CLICurrentVersion = "2.1.162"
+const CLICurrentVersion = "2.1.163"
 
 // JoinBetaHeader joins beta tokens into the wire anthropic-beta header value.
 func JoinBetaHeader(betas []string) string {
@@ -137,7 +137,7 @@ func FullClaudeCodeHaikuMimicryBetas() []string {
 // 包依赖方向为 service → claude，claude 无法反向 import service，故这里以同步字面量
 // 承载，由守卫测试强制对齐。
 var DefaultHeaders = map[string]string{
-	"User-Agent":                                "claude-cli/2.1.162 (external, sdk-cli)",
+	"User-Agent":                                "claude-cli/2.1.163 (external, sdk-cli)",
 	"X-Stainless-Lang":                          "js",
 	"X-Stainless-Package-Version":               "0.94.0",
 	"X-Stainless-OS":                            "MacOS",

--- a/backend/internal/service/identity_service.go
+++ b/backend/internal/service/identity_service.go
@@ -38,7 +38,7 @@ var (
 // / `StainlessPackageVersion:` 字面量做指纹基线巡检，computed 值会让它失明。
 // 字面量与 canonical 的一致性改由 identity_canonical_consistency_test.go 机械锁死。
 var defaultFingerprint = Fingerprint{
-	UserAgent:               "claude-cli/2.1.162 (external, sdk-cli)",
+	UserAgent:               "claude-cli/2.1.163 (external, sdk-cli)",
 	StainlessLang:           "js",
 	StainlessPackageVersion: "0.94.0",
 	StainlessOS:             "MacOS",

--- a/backend/internal/service/identity_service_tk_canonical_http.go
+++ b/backend/internal/service/identity_service_tk_canonical_http.go
@@ -56,7 +56,7 @@ const (
 	// neither env nor runtime resolver provides a value. Keep in sync with
 	// the most recent cc CLI release this build was validated against; the
 	// admin UI / runtime resolver is the normal update path going forward.
-	DefaultClaudeCodeUserAgentVersion = "2.1.162"
+	DefaultClaudeCodeUserAgentVersion = "2.1.163"
 
 	// canonicalUAPrefix / canonicalUASuffix wrap the version-only field.
 	// Matches the wire shape Anthropic observes from a real Claude Code CLI

--- a/deploy/aws/stage0/anthropic-http-mimicry-baselines.json
+++ b/deploy/aws/stage0/anthropic-http-mimicry-baselines.json
@@ -1,6 +1,6 @@
 {
   "schema_version": 1,
-  "cc_version": "2.1.162",
+  "cc_version": "2.1.163",
   "description": "Canonical OAuth HTTP mimicry betas for Claude Code CLI. Live wire values are driven at runtime by settings.claude_code_http_mimicry_manifest (sync-runtime / plan-http-mimicry-sync). Compile-time defaults in backend/internal/pkg/claude/constants.go catch up on the release train.",
   "sonnet_opus": [
     "claude-code-20250219",

--- a/deploy/aws/stage0/tk_canonical_cc_oauth.json
+++ b/deploy/aws/stage0/tk_canonical_cc_oauth.json
@@ -71,7 +71,7 @@
   ],
   "observed": {
     "model": "claude-haiku-4-5-20251001",
-    "user_agent": "claude-cli/2.1.162 (external, sdk-cli)",
+    "user_agent": "claude-cli/2.1.163 (external, sdk-cli)",
     "stainless_os": "MacOS",
     "stainless_arch": "arm64",
     "stainless_runtime": "node",

--- a/docs/spec-delta-cc-2.1.163.md
+++ b/docs/spec-delta-cc-2.1.163.md
@@ -1,0 +1,51 @@
+# spec-delta: cc fingerprint alignment 2.1.162 → 2.1.163
+
+## Background
+
+Claude Code patch `2.1.163` shipped. `/tokenkey-cc-fingerprint-alignment` capture
+against live cc (cc0-here, egress `16.147.170.3`) on 2026-06-04 shows this is a
+**pure User-Agent version bump** — no TLS drift, no actionable beta drift.
+
+## Capture evidence (ground truth = real cc 2.1.163)
+
+| field | tokenkey (2.1.162 baseline) | captured (2.1.163) | verdict |
+|---|---|---|---|
+| `tls.ja3_hash` | unchanged | unchanged | ✅ OK (no TLS profile change) |
+| `tls.ja3_raw` | unchanged | unchanged | ✅ OK |
+| `canonical.user_agent_version` | 2.1.162 | **2.1.163** | ❌ bump |
+| `mimic.cli_version` | 2.1.162 | **2.1.163** | ❌ bump |
+| `canonical/mimic.stainless_package_version` | 0.94.0 | 0.94.0 | ✅ OK |
+| `betas.sonnet_mimicry` | (10 betas) | same | ✅ OK |
+| `betas.haiku_mimicry` | (8 betas) | **bimodal** | ⚠️ INVESTIGATE (not actionable) |
+
+### haiku beta — bimodal A/B (pre-existing #429, NOT changed here)
+
+`capture-http-comprehensive.sh`: **11 haiku requests, 2 unique beta headers**,
+baseline matches variant **8/11**. This is the known server-side A/B gray release
+tracked in youxuanxue/sub2api#429 — `check` returns exit 0 (`needs_investigation`,
+not `has_actionable_mismatch`). The canonical `HaikuBetaHeader` is **left unchanged**;
+this PR does NOT touch any beta constant. Sonnet/opus betas single-valued and OK.
+
+## Delta
+
+### MODIFIED (UA version only — via `check-cc-version-sync.py --write`)
+
+Single hand-edited source: `deploy/aws/stage0/anthropic-http-mimicry-baselines.json`
+`cc_version` `2.1.162 → 2.1.163`. The sync script mechanically rewrote the 6 derived copies:
+
+- `backend/internal/pkg/claude/constants.go` — `CLICurrentVersion` + `DefaultHeaders["User-Agent"]`
+- `backend/internal/service/identity_service.go` — `defaultFingerprint.UserAgent`
+- `backend/internal/service/identity_service_tk_canonical_http.go` — `DefaultClaudeCodeUserAgentVersion`
+- `deploy/aws/stage0/tk_canonical_cc_oauth.json` — `observed.user_agent`
+- `ops/stage0/smoke_lib.sh` — dead snapshot
+
+### NOT CHANGED
+
+- TLS: `tk_canonical_cc_oauth.json` ja3 profile — unchanged (no ClientHello drift).
+- Betas: no `constants.go` beta constant touched (haiku bimodal is #429, baseline still valid).
+
+## Rollout
+
+UA has a runtime path: after merge run `ops/anthropic/cc_fingerprint_apply_http_runtime.sh`
+(settings `claude_code_user_agent_version` + Redis fingerprint DEL) — no image release
+required. Compile-time default catches up on the next scheduled release.

--- a/ops/stage0/smoke_lib.sh
+++ b/ops/stage0/smoke_lib.sh
@@ -49,7 +49,7 @@ if [[ -z "${_TK_SMOKE_LIB_LOADED:-}" ]]; then
   }
 
   smoke_default_claude_user_agent() {
-    printf '%s' "${TK_SMOKE_CLAUDE_USER_AGENT:-claude-cli/2.1.162 (external, sdk-cli)}"
+    printf '%s' "${TK_SMOKE_CLAUDE_USER_AGENT:-claude-cli/2.1.163 (external, sdk-cli)}"
   }
 
   # soft_degrade_or_exit — see post_deploy_smoke.sh header for contract.


### PR DESCRIPTION
## 抓包对齐（ground truth = real cc 2.1.163）

`/tokenkey-cc-fingerprint-alignment` 对 live cc 2.1.163（cc0-here，egress `16.147.170.3`，2026-06-04）抓包：

| 字段 | baseline (2.1.162) | captured (2.1.163) | verdict |
|---|---|---|---|
| `tls.ja3_hash` / `ja3_raw` | unchanged | unchanged | ✅ 无 TLS 漂移 |
| `canonical.user_agent_version` | 2.1.162 | **2.1.163** | ❌ bump |
| `mimic.cli_version` | 2.1.162 | **2.1.163** | ❌ bump |
| `stainless_package_version` | 0.94.0 | 0.94.0 | ✅ |
| `betas.sonnet_mimicry` | (10) | same | ✅ |
| `betas.haiku_mimicry` | (8) | **bimodal** | ⚠️ INVESTIGATE（非 actionable） |

**纯 UA 版本 bump**，无 TLS 漂移、无 actionable beta 漂移。

### haiku beta = 已知 #429 A/B 灰度（本 PR 不动）

comprehensive：11 次 haiku 请求，2 种 beta header，baseline 命中变体 **8/11**。这是服务端 A/B（youxuanxue/sub2api#429），`check` 退 0（needs_investigation，非 has_actionable_mismatch）。**未触碰任何 beta 常量**。

## 变更

- 单一手改源 `deploy/aws/stage0/anthropic-http-mimicry-baselines.json` `cc_version` 2.1.162→2.1.163
- `check-cc-version-sync.py --write` 机械重写 6 份派生副本（4 Go 编译默认 + 2 死快照）
- `backend/internal/baseline/` embed 镜像 byte-sync（go:embed 跨模块拷贝）
- `docs/spec-delta-cc-2.1.163.md` 记录抓包证据 + beta 分布

## 验证

- `check-cc-version-sync.py --selftest && check`：6 副本一致 ✓
- `go test -tags=unit ./internal/pkg/claude/... -run TestFullClaudeCode` ✓
- `python3 -m unittest test_capture_cc_fingerprint.py`：13 tests OK ✓
- `scripts/preflight.sh` PASS

## Rollout

UA 有 runtime 路径：merge 后 `ops/anthropic/cc_fingerprint_apply_http_runtime.sh`（settings + Redis fingerprint DEL），**无需发版**；compile default 跟下一班 release。

🤖 Generated with [Claude Code](https://claude.com/claude-code)