### PR TITLE
fix(docs-sync): add id-token:write permission for OIDC credentials

### DIFF
--- a/.github/workflows/sync-docs-to-pages.yml
+++ b/.github/workflows/sync-docs-to-pages.yml
@@ -28,6 +28,10 @@ on:
         required: false
         default: ''
 
+permissions:
+  contents: read
+  id-token: write   # required for OIDC → AWS credentials exchange
+
 concurrency:
   group: sync-docs-to-pages
   cancel-in-progress: true


### PR DESCRIPTION
## Summary

缺少 `permissions: id-token: write` 导致 OIDC token 无法生成，AWS 凭证加载失败。

```
##[error]Credentials could not be loaded, please check your action inputs: Could not load credentials from any providers
```

参照 `deploy-stage0.yml` 补上权限块。

## Risk

低风险：仅 workflow 权限声明，不改变业务逻辑。

## Validation

preflight PASS。

Made with [Cursor](https://cursor.com)