### PR TITLE
fix(docs-sync): use flat commands array in SSM params JSON

### DIFF
--- a/ops/stage0/sync_docs_pages.sh
+++ b/ops/stage0/sync_docs_pages.sh
@@ -106,11 +106,14 @@ REMOTE_SCRIPT=$(printf '%s\n' "${remote_cmds[@]}")
 # Build SSM params JSON — write to ${OUTPUT_DIR}/ssm-params.json (same
 # convention as deploy_via_ssm.sh / sync_caddyfile_via_ssm.sh so the
 # check-stage0-ssm-host-parse.sh guard can validate the host script syntax).
+# Format: {"commands": ["cmd1", "cmd2", ...]} — flat array, NOT the
+# {"commands": {"Value": [...], "Type": "StringList"}} dict form which
+# causes a botocore ParamValidation error with aws-cli v2.
 mkdir -p "${OUTPUT_DIR}"
 params_file="${OUTPUT_DIR}/ssm-params.json"
 
 jq -n --arg script "$REMOTE_SCRIPT" \
-  '{"commands": {"Value": [$script], "Type": "StringList"}}' \
+  '{"commands": [$script]}' \
   > "$params_file"
 
 region_args=()


### PR DESCRIPTION
## Summary
- 修复 `ops/stage0/sync_docs_pages.sh` 中 SSM `send-command --parameters` 的 JSON 格式
- 之前格式：`{"commands": {"Value": [...], "Type": "StringList"}}` → botocore 报 `ParamValidation: Invalid type for parameter Parameters.commands, valid types: list/tuple`
- 修正格式：`{"commands": [...]}` — 与 `sync_caddyfile_via_ssm.sh` 保持一致

## Risk
低风险：仅修改 SSM 参数 JSON 格式，逻辑不变，`check-stage0-ssm-host-parse.sh` 验证通过。

## Validation
- `bash -n ops/stage0/sync_docs_pages.sh` — syntax OK
- `bash scripts/checks/check-stage0-ssm-host-parse.sh` — all 4 checks pass
- `scripts/preflight.sh` — PASS

upstream-touch-trivial
no-web-impact

Made with [Cursor](https://cursor.com)