### PR TITLE
docs(public): add TokenKey-style book icon for custom menu pages

### DIFF
--- a/docs/public/icons/book.svg
+++ b/docs/public/icons/book.svg
@@ -1,0 +1,3 @@
+<svg xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" stroke="currentColor" stroke-width="1.5">
+  <path stroke-linecap="round" stroke-linejoin="round" d="M12 6.042A8.967 8.967 0 0 0 6 3.75c-1.052 0-2.062.18-3 .512v14.25A8.987 8.987 0 0 1 6 18c2.305 0 4.408.867 6 2.292m0-14.25a8.966 8.966 0 0 1 6-2.292c1.052 0 2.062.18 3 .512v14.25A8.987 8.987 0 0 0 18 18a8.967 8.967 0 0 0-6 2.292m0-14.25v14.25" />
+</svg>


### PR DESCRIPTION
## Summary
- 新增 `docs/public/icons/book.svg`，与 TokenKey 侧边栏 Heroicons outline 风格一致（24×24、`stroke="currentColor"`、`stroke-width="1.5"`）
- 供 Admin → Settings → 自定义菜单上传，配合 `md:user-guide-claude-code` 页面入口

## Risk
低风险：仅新增静态 SVG 资源，无运行时行为变更。

## Validation
- `scripts/preflight.sh` — PASS
- 上传路径：Admin → Settings → 自定义菜单 → 上传 SVG → 选 `docs/public/icons/book.svg`

no-web-impact

Made with [Cursor](https://cursor.com)