### PR TITLE
fix(openai): send codex-mini-latest to ChatGPT OAuth backend instead of gpt-5.3-codex

### DIFF
--- a/backend/internal/service/openai_codex_transform.go
+++ b/backend/internal/service/openai_codex_transform.go
@@ -833,9 +833,21 @@ func normalizeOpenAIResponsesImageOnlyModel(reqBody map[string]any) bool {
 	return modified
 }
 
+// chatGPTOAuthUpstreamModelNames maps internal canonical model names to the
+// identifiers accepted by the ChatGPT OAuth backend (chatgpt.com).
+// The ChatGPT internal Codex API requires "codex-mini-latest" and rejects
+// "gpt-5.3-codex" with 400 "not supported when using Codex with a ChatGPT account".
+var chatGPTOAuthUpstreamModelNames = map[string]string{
+	"gpt-5.3-codex": "codex-mini-latest",
+}
+
 func normalizeOpenAIModelForUpstream(account *Account, model string) string {
 	if account == nil || account.Type == AccountTypeOAuth {
-		return normalizeCodexModel(model)
+		normalized := normalizeCodexModel(model)
+		if upstream, ok := chatGPTOAuthUpstreamModelNames[normalized]; ok {
+			return upstream
+		}
+		return normalized
 	}
 	return strings.TrimSpace(model)
 }

--- a/backend/internal/service/openai_model_mapping_test.go
+++ b/backend/internal/service/openai_model_mapping_test.go
@@ -268,6 +268,30 @@ func TestNormalizeOpenAIModelForUpstream(t *testing.T) {
 			want:    "codex-auto-review",
 		},
 		{
+			name:    "oauth maps gpt-5.3-codex to codex-mini-latest for ChatGPT backend",
+			account: &Account{Type: AccountTypeOAuth},
+			model:   "gpt-5.3-codex",
+			want:    "codex-mini-latest",
+		},
+		{
+			name:    "oauth maps gpt-5.3 alias to codex-mini-latest for ChatGPT backend",
+			account: &Account{Type: AccountTypeOAuth},
+			model:   "gpt-5.3",
+			want:    "codex-mini-latest",
+		},
+		{
+			name:    "oauth maps codex-mini-latest alias to codex-mini-latest for ChatGPT backend",
+			account: &Account{Type: AccountTypeOAuth},
+			model:   "codex-mini-latest",
+			want:    "codex-mini-latest",
+		},
+		{
+			name:    "oauth spark model not remapped",
+			account: &Account{Type: AccountTypeOAuth},
+			model:   "gpt-5.3-codex-spark",
+			want:    "gpt-5.3-codex-spark",
+		},
+		{
 			name:    "apikey preserves custom compatible model",
 			account: &Account{Type: AccountTypeAPIKey},
 			model:   "gemini-3-flash-preview",

--- a/scripts/sentinels/gateway-tk.json
+++ b/scripts/sentinels/gateway-tk.json
@@ -501,6 +501,14 @@
       "rationale": "Focused regression anchors for upstream #2500 covering both function_call and hop-2 item_reference replay ids with real nanoid-shaped call_<id> values."
     },
     {
+      "path": "backend/internal/service/openai_codex_transform.go",
+      "must_contain": [
+        "chatGPTOAuthUpstreamModelNames",
+        "codex-mini-latest"
+      ],
+      "rationale": "ChatGPT OAuth backend rejects gpt-5.3-codex with 400 'not supported when using Codex with a ChatGPT account'; the accepted wire name is codex-mini-latest. This reverse-mapping table in normalizeOpenAIModelForUpstream is the only gate preventing the internal canonical name from leaking to the upstream API."
+    },
+    {
       "path": "backend/internal/service/openai_gateway_service.go",
       "must_contain": [
         "openAICompatSSEFrame",


### PR DESCRIPTION
## Summary

OpenAI 的 ChatGPT OAuth 后端（chatgpt.com）将 \`gpt-5.3-codex\` 改为拒绝，返回 HTTP 400 \`"The 'gpt-5.3-codex' model is not supported when using Codex with a ChatGPT account"\`。上游接受的 wire model 是 \`codex-mini-latest\`。

修复：在 \`normalizeOpenAIModelForUpstream\` 中为 OAuth 账号增加 \`chatGPTOAuthUpstreamModelNames\` 反向映射表，将内部 canonical name \`gpt-5.3-codex\` → \`codex-mini-latest\` 后再发给上游。计费和展示仍使用内部名称，只改 wire model。

同步更新 \`gateway-tk.json\` sentinel，锚定新映射表防止漂移。

## Risk

常规风险。仅影响 OAuth 账号上游 model 名称，不改路由逻辑、不改 billing、不改 DB。

## Validation

- \`go build ./...\` 通过
- \`TestNormalizeOpenAIModelForUpstream\` 全绿（含 4 个新 case：gpt-5.3-codex、gpt-5.3 alias、codex-mini-latest passthrough、spark not remapped）
- \`preflight.sh\` 全绿（sentinel registry update gate ok）

Made with [Cursor](https://cursor.com)