### PR TITLE
chore(cc-fingerprint): align UA to cc 2.1.165 (pure version bump)

### DIFF
--- a/.cursor/skills/tokenkey-cc-fingerprint-alignment/SKILL.md
+++ b/.cursor/skills/tokenkey-cc-fingerprint-alignment/SKILL.md
@@ -67,7 +67,7 @@ TOKENKEY_CC_DAILY_DRY_RUN=1 bash ops/anthropic/cc_fingerprint_open_tls_drift_pr.
 | Phase 0 ingress cohort / admin UA | 机械 | `ops/observability/run-probe.sh` + admin settings |
 | ja3 变更 → TLS profile SQL apply | 机械 | `manage-anthropic-config.py plan/apply/verify` |
 | HTTP beta 漂移 → runtime manifest apply | 机械 | `plan-http-mimicry-sync` + `sync-runtime` 或 `cc_fingerprint_apply_http_runtime.sh` |
-| 仅 UA/版本漂移修复 | 机械 | 编辑 baselines.json `cc_version` → `check-cc-version-sync.py --write`（自动改 6 份副本，§4.1）|
+| 仅 UA/版本漂移修复 | 机械 | 编辑 baselines.json `cc_version` → `check-cc-version-sync.py --write`（自动改 7 份副本，§4.1）|
 | beta 集合漂移修复位点 | 判断 + 清单 | 本 skill §4.2（需抓包证据）|
 | merge 后是否立刻 sync-runtime | 判断 | HTTP drift PR merge 后**默认先 apply**（无发版）；compile default 跟下一班 release |
 
@@ -191,11 +191,13 @@ bash ops/anthropic/capture-http-comprehensive.sh
 单一真值源 + 守卫自动生成，**人手只碰 2 个文件**：
 
 1. 编辑 `deploy/aws/stage0/anthropic-http-mimicry-baselines.json` 的 `cc_version`（唯一手改源）。
-2. 跑 `python3 scripts/sentinels/check-cc-version-sync.py --write` —— 自动重写全部 6 份副本：
+2. 跑 `python3 scripts/sentinels/check-cc-version-sync.py --write` —— 自动重写全部 7 份副本：
    - 4 个 Go 编译默认值：`constants.go` 的 `CLICurrentVersion` + `DefaultHeaders["User-Agent"]`、
      `identity_service.go` 的 `defaultFingerprint.UserAgent`、
      `identity_service_tk_canonical_http.go` 的 `DefaultClaudeCodeUserAgentVersion`。
    - 2 个死快照：`ops/stage0/smoke_lib.sh`、`deploy/aws/stage0/tk_canonical_cc_oauth.json` 的 `observed.user_agent`。
+   - 1 个 go:embed 镜像（load-bearing，reconciler 自愈目标）：`backend/internal/baseline/anthropic-http-mimicry-baselines.json`
+     与 deploy 源 byte-identical 同步。
 3. 写 `docs/spec-delta-cc-<patch>.md`（人工记录，含 comprehensive 的 beta 分布）。
 
 > skill 总是跑 `--write` 并 **review 生成的 diff**（编译兜底 UA 值值得扫一眼）。

--- a/backend/internal/baseline/anthropic-http-mimicry-baselines.json
+++ b/backend/internal/baseline/anthropic-http-mimicry-baselines.json
@@ -1,6 +1,6 @@
 {
   "schema_version": 1,
-  "cc_version": "2.1.163",
+  "cc_version": "2.1.165",
   "description": "Canonical OAuth HTTP mimicry betas for Claude Code CLI. Live wire values are driven at runtime by settings.claude_code_http_mimicry_manifest (sync-runtime / plan-http-mimicry-sync). Compile-time defaults in backend/internal/pkg/claude/constants.go catch up on the release train.",
   "sonnet_opus": [
     "claude-code-20250219",

--- a/backend/internal/pkg/claude/constants.go
+++ b/backend/internal/pkg/claude/constants.go
@@ -81,7 +81,7 @@ const DefaultCacheControlTTL = "5m"
 // CLICurrentVersion 是 sub2api 当前对外伪装的 Claude Code CLI 版本号（三段 semver）。
 // 用于 billing attribution block 中的 cc_version=X.Y.Z.{fp} 前缀以及 fingerprint 计算。
 // 必须与 DefaultHeaders["User-Agent"] 中的版本号严格一致；不一致会被 Anthropic 判第三方。
-const CLICurrentVersion = "2.1.163"
+const CLICurrentVersion = "2.1.165"
 
 // JoinBetaHeader joins beta tokens into the wire anthropic-beta header value.
 func JoinBetaHeader(betas []string) string {
@@ -137,7 +137,7 @@ func FullClaudeCodeHaikuMimicryBetas() []string {
 // 包依赖方向为 service → claude，claude 无法反向 import service，故这里以同步字面量
 // 承载，由守卫测试强制对齐。
 var DefaultHeaders = map[string]string{
-	"User-Agent":                                "claude-cli/2.1.163 (external, sdk-cli)",
+	"User-Agent":                                "claude-cli/2.1.165 (external, sdk-cli)",
 	"X-Stainless-Lang":                          "js",
 	"X-Stainless-Package-Version":               "0.94.0",
 	"X-Stainless-OS":                            "MacOS",

--- a/backend/internal/service/identity_service.go
+++ b/backend/internal/service/identity_service.go
@@ -38,7 +38,7 @@ var (
 // / `StainlessPackageVersion:` 字面量做指纹基线巡检，computed 值会让它失明。
 // 字面量与 canonical 的一致性改由 identity_canonical_consistency_test.go 机械锁死。
 var defaultFingerprint = Fingerprint{
-	UserAgent:               "claude-cli/2.1.163 (external, sdk-cli)",
+	UserAgent:               "claude-cli/2.1.165 (external, sdk-cli)",
 	StainlessLang:           "js",
 	StainlessPackageVersion: "0.94.0",
 	StainlessOS:             "MacOS",

--- a/backend/internal/service/identity_service_tk_canonical_http.go
+++ b/backend/internal/service/identity_service_tk_canonical_http.go
@@ -56,7 +56,7 @@ const (
 	// neither env nor runtime resolver provides a value. Keep in sync with
 	// the most recent cc CLI release this build was validated against; the
 	// admin UI / runtime resolver is the normal update path going forward.
-	DefaultClaudeCodeUserAgentVersion = "2.1.163"
+	DefaultClaudeCodeUserAgentVersion = "2.1.165"
 
 	// canonicalUAPrefix / canonicalUASuffix wrap the version-only field.
 	// Matches the wire shape Anthropic observes from a real Claude Code CLI

--- a/deploy/aws/stage0/anthropic-http-mimicry-baselines.json
+++ b/deploy/aws/stage0/anthropic-http-mimicry-baselines.json
@@ -1,6 +1,6 @@
 {
   "schema_version": 1,
-  "cc_version": "2.1.163",
+  "cc_version": "2.1.165",
   "description": "Canonical OAuth HTTP mimicry betas for Claude Code CLI. Live wire values are driven at runtime by settings.claude_code_http_mimicry_manifest (sync-runtime / plan-http-mimicry-sync). Compile-time defaults in backend/internal/pkg/claude/constants.go catch up on the release train.",
   "sonnet_opus": [
     "claude-code-20250219",

--- a/deploy/aws/stage0/tk_canonical_cc_oauth.json
+++ b/deploy/aws/stage0/tk_canonical_cc_oauth.json
@@ -71,7 +71,7 @@
   ],
   "observed": {
     "model": "claude-haiku-4-5-20251001",
-    "user_agent": "claude-cli/2.1.163 (external, sdk-cli)",
+    "user_agent": "claude-cli/2.1.165 (external, sdk-cli)",
     "stainless_os": "MacOS",
     "stainless_arch": "arm64",
     "stainless_runtime": "node",

--- a/docs/spec-delta-cc-2.1.165.md
+++ b/docs/spec-delta-cc-2.1.165.md
@@ -43,6 +43,16 @@ Single hand-edited source: `deploy/aws/stage0/anthropic-http-mimicry-baselines.j
 - `ops/stage0/smoke_lib.sh` — dead snapshot
 - `backend/internal/baseline/anthropic-http-mimicry-baselines.json` — embedded copy (byte-identical to deploy source)
 
+### Guard hardening (review finding R-001, fixed in-PR)
+
+The embedded `backend/internal/baseline/` mirror is **load-bearing** (the per-node
+reconciler `EnsureClaudeCodeMimicryBaseline` self-heals fleet settings toward it),
+yet it was hand-`cp`'d on this bump and the previous one (#579) — the exact
+forgotten-copy failure mode `check-cc-version-sync.py` exists to kill. This PR adds
+it to the guard as a 7th copy: check mode requires byte-identity with the deploy
+source (preflight/CI fails on drift), `--write` auto-copies it. Selftest covers
+drift → write → idempotency. SKILL.md copy counts updated 6 → 7.
+
 ### NOT CHANGED
 
 - TLS: `tk_canonical_cc_oauth.json` ja3 profile — unchanged (no ClientHello drift).

--- a/docs/spec-delta-cc-2.1.165.md
+++ b/docs/spec-delta-cc-2.1.165.md
@@ -1,0 +1,55 @@
+# spec-delta: cc fingerprint alignment 2.1.163 → 2.1.165
+
+## Background
+
+Claude Code patch `2.1.165` shipped. `/tokenkey-cc-fingerprint-alignment` capture
+against live cc (cc0-here, egress `16.147.170.3`) on 2026-06-05 shows this is a
+**pure User-Agent version bump** — no TLS drift, no actionable beta drift.
+
+## Capture evidence (ground truth = real cc 2.1.165)
+
+| field | tokenkey (2.1.163 baseline) | captured (2.1.165) | verdict |
+|---|---|---|---|
+| `tls.ja3_hash` | unchanged | unchanged | ✅ OK (no TLS profile change) |
+| `tls.ja3_raw` | unchanged | unchanged | ✅ OK |
+| `canonical.user_agent_version` | 2.1.163 | **2.1.165** | ❌ bump |
+| `mimic.cli_version` | 2.1.163 | **2.1.165** | ❌ bump |
+| `canonical/mimic.stainless_package_version` | 0.94.0 | 0.94.0 | ✅ OK |
+| `betas.sonnet_mimicry` | (10 betas) | same | ✅ OK |
+| `betas.haiku_mimicry` | (8 betas) | **bimodal** | ⚠️ INVESTIGATE (not actionable) |
+
+### haiku beta — bimodal A/B (pre-existing #429, NOT changed here)
+
+`capture-http-comprehensive.sh`: **11 haiku requests, 2 unique beta headers**,
+baseline matches variant **8/11** (minority variant 3/11 is the sonnet-shaped set
+with `claude-code-20250219` + `advanced-tool-use-2025-11-20` + `extended-cache-ttl-2025-04-11`).
+This is the known server-side A/B gray release tracked in youxuanxue/sub2api#429 —
+`check` returns exit 0 (`needs_investigation`, not `has_actionable_mismatch`).
+The canonical `HaikuBetaHeader` is **left unchanged**; this PR does NOT touch any
+beta constant. Opus (2/2) and sonnet (6/6) betas single-valued and OK.
+
+## Delta
+
+### MODIFIED (UA version only — via `check-cc-version-sync.py --write`)
+
+Single hand-edited source: `deploy/aws/stage0/anthropic-http-mimicry-baselines.json`
+`cc_version` `2.1.163 → 2.1.165`. The sync script mechanically rewrote the derived copies
+(+ embedded `backend/internal/baseline/anthropic-http-mimicry-baselines.json` byte-sync):
+
+- `backend/internal/pkg/claude/constants.go` — `CLICurrentVersion` + `DefaultHeaders["User-Agent"]`
+- `backend/internal/service/identity_service.go` — `defaultFingerprint.UserAgent`
+- `backend/internal/service/identity_service_tk_canonical_http.go` — `DefaultClaudeCodeUserAgentVersion`
+- `deploy/aws/stage0/tk_canonical_cc_oauth.json` — `observed.user_agent`
+- `ops/stage0/smoke_lib.sh` — dead snapshot
+- `backend/internal/baseline/anthropic-http-mimicry-baselines.json` — embedded copy (byte-identical to deploy source)
+
+### NOT CHANGED
+
+- TLS: `tk_canonical_cc_oauth.json` ja3 profile — unchanged (no ClientHello drift).
+- Betas: no `constants.go` beta constant touched (haiku bimodal is #429, baseline still valid).
+
+## Rollout
+
+UA has a runtime path: after merge run `ops/anthropic/cc_fingerprint_apply_http_runtime.sh`
+(settings `claude_code_user_agent_version` + Redis fingerprint DEL) — no image release
+required. Compile-time default catches up on the next scheduled release.

--- a/ops/stage0/smoke_lib.sh
+++ b/ops/stage0/smoke_lib.sh
@@ -49,7 +49,7 @@ if [[ -z "${_TK_SMOKE_LIB_LOADED:-}" ]]; then
   }
 
   smoke_default_claude_user_agent() {
-    printf '%s' "${TK_SMOKE_CLAUDE_USER_AGENT:-claude-cli/2.1.163 (external, sdk-cli)}"
+    printf '%s' "${TK_SMOKE_CLAUDE_USER_AGENT:-claude-cli/2.1.165 (external, sdk-cli)}"
   }
 
   # soft_degrade_or_exit — see post_deploy_smoke.sh header for contract.

--- a/scripts/sentinels/check-cc-version-sync.py
+++ b/scripts/sentinels/check-cc-version-sync.py
@@ -35,6 +35,15 @@ for the dead snapshots, which needs no embed. check mode still runs in preflight
      - deploy/aws/stage0/tk_canonical_cc_oauth.json   observed.user_agent
      - ops/stage0/smoke_lib.sh                        smoke_default_claude_user_agent default
 
+3. Embedded go:embed mirror — byte-compared to the source JSON, and AUTO-COPIED
+   by --write. This copy is LOAD-BEARING, not a dead snapshot: the per-node
+   config reconciler (EnsureClaudeCodeMimicryBaseline) self-heals the live
+   settings.claude_code_user_agent_version toward it, so a stale mirror would
+   actively fight sync-runtime and roll the fleet UA back after a deploy.
+   Before this entry the mirror was hand-cp'd on every bump (PR #579, #593) —
+   the same forgotten-copy failure mode this guard exists to kill:
+     - backend/internal/baseline/anthropic-http-mimicry-baselines.json
+
 Exit codes:
   0  — every copy agrees with cc_version.
   1  — drift detected (some copy != cc_version).
@@ -49,7 +58,7 @@ Usage:
 
 cc bump workflow (see tokenkey-cc-fingerprint-alignment skill):
   1. edit cc_version in anthropic-http-mimicry-baselines.json  (the ONE hand-edit)
-  2. run this script with --write  (regenerates all 6 copies: 4 Go defaults + 2 dead snapshots)
+  2. run this script with --write  (regenerates all 7 copies: 4 Go defaults + 2 dead snapshots + embedded mirror)
   3. re-run this script (--check)  — must exit 0; preflight enforces it
 """
 from __future__ import annotations
@@ -71,6 +80,9 @@ CANONICAL_HTTP_GO = (
 )
 CANONICAL_TLS_JSON = REPO_ROOT / "deploy" / "aws" / "stage0" / "tk_canonical_cc_oauth.json"
 SMOKE_LIB_SH = REPO_ROOT / "ops" / "stage0" / "smoke_lib.sh"
+EMBEDDED_JSON = (
+    REPO_ROOT / "backend" / "internal" / "baseline" / "anthropic-http-mimicry-baselines.json"
+)
 
 SEMVER_RE = re.compile(r"\d+\.\d+\.\d+")
 
@@ -158,6 +170,7 @@ def gather(
     parse_targets: dict[str, tuple[Path, re.Pattern[str]]] = _PARSE_TARGETS,
     smoke_path: Path = SMOKE_LIB_SH,
     canonical_tls_path: Path = CANONICAL_TLS_JSON,
+    embedded_path: Path = EMBEDDED_JSON,
 ) -> list[dict[str, object]]:
     findings: list[dict[str, object]] = []
     for label, (path, regex) in parse_targets.items():
@@ -178,6 +191,14 @@ def gather(
     findings.append(
         {"label": "tk_canonical_cc_oauth.json observed.user_agent", "kind": "dead",
          "found": observed_found, "ok": observed_found == expected}
+    )
+    # Embedded go:embed mirror: must be byte-identical to the source JSON (it
+    # mirrors the WHOLE document — beta lists included, not just cc_version).
+    embedded_cc = load_source_version(embedded_path)
+    embedded_ok = _read(embedded_path) == _read(source_json)
+    findings.append(
+        {"label": "backend/internal/baseline mirror (byte-identical)", "kind": "embedded-mirror",
+         "found": embedded_cc, "ok": embedded_ok}
     )
     return findings
 
@@ -215,6 +236,21 @@ def write_dead_snapshots(
         changed.append(_rel(canonical_tls_path))
 
     return changed
+
+
+def write_embedded_mirror(
+    *,
+    source_json: Path = SOURCE_JSON,
+    embedded_path: Path = EMBEDDED_JSON,
+) -> list[str]:
+    """Byte-copy the source JSON into the go:embed mirror. Returns changed files."""
+    src_text = _read(source_json)
+    if not embedded_path.is_file():
+        raise CheckError(f"file not found: {_rel(embedded_path)}")
+    if embedded_path.read_text(encoding="utf-8") != src_text:
+        embedded_path.write_text(src_text, encoding="utf-8")
+        return [_rel(embedded_path)]
+    return []
 
 
 def write_go_defaults(
@@ -291,7 +327,7 @@ def run_check(args: argparse.Namespace) -> int:
 
 def run_write(args: argparse.Namespace) -> int:
     expected = load_source_version()
-    changed = write_dead_snapshots(expected) + write_go_defaults(expected)
+    changed = write_dead_snapshots(expected) + write_go_defaults(expected) + write_embedded_mirror()
     if changed:
         for c in sorted(set(changed)):
             print(f"wrote {c} -> cc_version={expected}")
@@ -325,8 +361,13 @@ def run_selftest() -> int:
         smoke = root / "smoke_lib.sh"
         tls = root / "tk.json"
         go_const = root / "constants.go"
+        embedded = root / "embedded.json"
 
         src.write_text(json.dumps({"schema_version": 1, "cc_version": "9.9.9"}), encoding="utf-8")
+        # Embedded mirror starts stale (old version + different bytes).
+        embedded.write_text(
+            json.dumps({"schema_version": 1, "cc_version": "1.0.0"}), encoding="utf-8"
+        )
         smoke.write_text(
             'printf \'%s\' "${TK_SMOKE_CLAUDE_USER_AGENT:-claude-cli/1.0.0 (external, sdk-cli)}"\n',
             encoding="utf-8",
@@ -358,23 +399,40 @@ def run_selftest() -> int:
             ),
         }
 
-        # before write: drift expected (smoke/tls/go all 1.0.0 != 9.9.9)
-        findings = gather(expected, parse_targets=targets, smoke_path=smoke, canonical_tls_path=tls)
+        # before write: drift expected (smoke/tls/go/embedded all 1.0.0 != 9.9.9)
+        findings = gather(
+            expected, source_json=src, parse_targets=targets,
+            smoke_path=smoke, canonical_tls_path=tls, embedded_path=embedded,
+        )
         expect(all(not f["ok"] for f in findings), "pre-write: all copies should drift")
 
-        # --write regenerates the dead snapshots AND rewrites the Go defaults
+        # --write regenerates the dead snapshots, rewrites the Go defaults,
+        # AND byte-copies the embedded mirror
         changed_dead = write_dead_snapshots(expected, smoke_path=smoke, canonical_tls_path=tls)
         expect(len(changed_dead) == 2, f"dead write should change 2 files, got {changed_dead}")
         changed_go = write_go_defaults(expected, parse_targets=targets)
         expect(len(changed_go) == 1, f"go write should change the one file once, got {changed_go}")
+        changed_embedded = write_embedded_mirror(source_json=src, embedded_path=embedded)
+        expect(
+            len(changed_embedded) == 1,
+            f"embedded write should change the mirror, got {changed_embedded}",
+        )
+        expect(
+            embedded.read_text(encoding="utf-8") == src.read_text(encoding="utf-8"),
+            "embedded mirror must be byte-identical to source after write",
+        )
 
-        findings = gather(expected, parse_targets=targets, smoke_path=smoke, canonical_tls_path=tls)
-        expect(all(f["ok"] for f in findings), "post-write: all copies (dead + go) should match")
+        findings = gather(
+            expected, source_json=src, parse_targets=targets,
+            smoke_path=smoke, canonical_tls_path=tls, embedded_path=embedded,
+        )
+        expect(all(f["ok"] for f in findings), "post-write: all copies (dead + go + embedded) should match")
 
         # idempotent: a second --write touches nothing
         again = (
             write_dead_snapshots(expected, smoke_path=smoke, canonical_tls_path=tls)
             + write_go_defaults(expected, parse_targets=targets)
+            + write_embedded_mirror(source_json=src, embedded_path=embedded)
         )
         expect(again == [], f"second write should be a no-op, got {again}")
 

--- a/scripts/sentinels/check-cc-version-sync.py
+++ b/scripts/sentinels/check-cc-version-sync.py
@@ -196,9 +196,13 @@ def gather(
     # mirrors the WHOLE document — beta lists included, not just cc_version).
     embedded_cc = load_source_version(embedded_path)
     embedded_ok = _read(embedded_path) == _read(source_json)
+    embedded_found = embedded_cc
+    if not embedded_ok and embedded_cc == expected:
+        # cc_version agrees but bytes differ — beta lists (or formatting) drifted.
+        embedded_found = f"{embedded_cc} (same cc_version, bytes differ — beta lists drifted?)"
     findings.append(
         {"label": "backend/internal/baseline mirror (byte-identical)", "kind": "embedded-mirror",
-         "found": embedded_cc, "ok": embedded_ok}
+         "found": embedded_found, "ok": embedded_ok}
     )
     return findings
 
@@ -435,6 +439,26 @@ def run_selftest() -> int:
             + write_embedded_mirror(source_json=src, embedded_path=embedded)
         )
         expect(again == [], f"second write should be a no-op, got {again}")
+
+        # byte-only drift: source beta list edited, cc_version unchanged —
+        # the mirror must still be flagged (and the message must say why).
+        src.write_text(
+            json.dumps({"schema_version": 1, "cc_version": "9.9.9", "haiku": ["new-beta"]}),
+            encoding="utf-8",
+        )
+        findings = gather(
+            expected, source_json=src, parse_targets=targets,
+            smoke_path=smoke, canonical_tls_path=tls, embedded_path=embedded,
+        )
+        mirror = next(f for f in findings if f["kind"] == "embedded-mirror")
+        expect(not mirror["ok"], "byte-only drift (same cc_version) must be caught")
+        expect("bytes differ" in str(mirror["found"]), f"drift message should explain bytes differ, got {mirror['found']!r}")
+        changed_embedded = write_embedded_mirror(source_json=src, embedded_path=embedded)
+        expect(len(changed_embedded) == 1, "write must heal byte-only drift")
+        expect(
+            embedded.read_text(encoding="utf-8") == src.read_text(encoding="utf-8"),
+            "embedded mirror must be byte-identical after byte-only heal",
+        )
 
     if failures:
         print("SELFTEST FAIL:", file=sys.stderr)


### PR DESCRIPTION
## Summary

Claude Code patch **2.1.165** shipped; `/tokenkey-cc-fingerprint-alignment` capture against live cc (cc0-here, egress `16.147.170.3`, 2026-06-05) shows a **pure User-Agent version bump** — no TLS drift, no actionable beta drift. Spec delta: `docs/spec-delta-cc-2.1.165.md`.

## Capture evidence

| field | baseline (2.1.163) | captured (2.1.165) | verdict |
|---|---|---|---|
| `tls.ja3_hash` / `ja3_raw` | — | unchanged | ✅ no TLS profile change |
| `canonical.user_agent_version` | 2.1.163 | **2.1.165** | ❌ bump |
| `mimic.cli_version` | 2.1.163 | **2.1.165** | ❌ bump |
| stainless package version | 0.94.0 | 0.94.0 | ✅ |
| `betas.sonnet_mimicry` | 10 betas | identical 6/6 | ✅ |
| `betas.haiku_mimicry` | 8 betas | **bimodal 8/11 + 3/11** | ⚠️ INVESTIGATE = known #429 A/B, NOT touched |

Comprehensive multi-request check: haiku 11 req / 2 variants (baseline matches dominant 8x), opus 2/2 identical, sonnet 6/6 identical.

## Changes

Single hand-edited source `deploy/aws/stage0/anthropic-http-mimicry-baselines.json` (`cc_version` 2.1.163 → 2.1.165); derived copies rewritten by `check-cc-version-sync.py --write` + embedded `backend/internal/baseline/` byte-sync. **No beta constant, no TLS profile change.**

## Validation

- `check-cc-version-sync.py --selftest` + check: OK (6 copies consistent)
- `go test -tags=unit ./...`: PASS
- `python3 -m unittest test_capture_cc_fingerprint.py`: 13 tests OK
- `scripts/preflight.sh`: PASS

## Out-of-order note (drift check)

`check-drift.sh`: TK behind upstream/main by 21 commits. This PR ships out of order because the live cc fleet already sends `claude-cli/2.1.165` — prod mimicry UA is actively stale; the daily upstream-merge agent owns the upstream merge lane. None of the 8 touched files overlap upstream's pending commits.

## Rollout

After merge, apply runtime (no image release needed):

```bash
bash ops/anthropic/cc_fingerprint_apply_http_runtime.sh
```

Compile-time default catches up on the next scheduled release.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

