### PR TITLE
fix(anthropic): skip Feishu 429 digest for downstream empty-pool stubs

### DIFF
--- a/backend/internal/service/ratelimit_service.go
+++ b/backend/internal/service/ratelimit_service.go
@@ -460,6 +460,15 @@ func (s *RateLimitService) HandleUpstreamError(ctx context.Context, account *Acc
 	case 404:
 		shouldDisable = s.handle404(ctx, account, upstreamMsg, responseBody)
 	case 429:
+		// TK (prod 2026-06): edges empty-pool fast-fail is 429+Retry-After, not
+		// 503. Same downstream-exhaustion semantics as handleAnthropicUpstreamError
+		// skip path — do not classify as upstream rate-limit cooldown / Feishu 429.
+		if account.Platform == PlatformAnthropic && tkSkipDownstreamNoAvailableAccountsPenalty(statusCode, upstreamMsg, responseBody) {
+			slog.Info("anthropic_downstream_no_available_accounts_skip_penalty",
+				"account_id", account.ID,
+				"status_code", statusCode)
+			return true
+		}
 		// handle429 returns true when SetRateLimited landed on an upstream-
 		// provided reset time. If so, suppress the ladder's parallel
 		// SetTempUnschedulable write (last-write-wins would otherwise
@@ -1006,7 +1015,7 @@ func (s *RateLimitService) handleAnthropicUpstreamError(ctx context.Context, acc
 	// in-flight request over to the next stub (return true) but leave stub health
 	// untouched: no counter advance, no SetTempUnschedulable. See
 	// tkIsDownstreamNoAvailableAccounts.
-	if statusCode == http.StatusServiceUnavailable && tkIsDownstreamNoAvailableAccounts(upstreamMsg, responseBody) {
+	if tkSkipDownstreamNoAvailableAccountsPenalty(statusCode, upstreamMsg, responseBody) {
 		slog.Info("anthropic_downstream_no_available_accounts_skip_penalty",
 			"account_id", account.ID,
 			"status_code", statusCode)

--- a/backend/internal/service/ratelimit_service_tk_downstream_no_available.go
+++ b/backend/internal/service/ratelimit_service_tk_downstream_no_available.go
@@ -1,6 +1,9 @@
 package service
 
-import "strings"
+import (
+	"net/http"
+	"strings"
+)
 
 // tkIsDownstreamNoAvailableAccounts reports whether an Anthropic upstream error
 // is the downstream gateway's own "no available accounts" pool-exhaustion signal
@@ -11,11 +14,13 @@ import "strings"
 // only through per-edge api-key mirror "stub" accounts (cc-us1 / cc-uk1 / …) that
 // forward to the corresponding edge. When a thin edge pool (e.g. uk1 has a single
 // schedulable OAuth account) briefly saturates on a burst of parallel Claude Code
-// haiku background requests, the edge returns a 503 whose body is *our own*
-// gateway error envelope: {"type":"error","error":{"type":"api_error",
+// haiku background requests, the edge returns a 503 or 429 (since 2026-06 empty-
+// pool fast-fail uses 429+Retry-After; see handler/no_available_accounts_tk.go)
+// whose body is *our own* gateway error envelope:
+// {"type":"error","error":{"type":"api_error",
 // "message":"No available accounts: no available accounts"}}.
 //
-// That 503 is a transient *downstream* capacity blip — the forwarding stub itself
+// That response is a transient *downstream* capacity blip — the forwarding stub itself
 // is perfectly healthy. Counting it toward the per-account anthropic_upstream_error
 // threshold (handleAnthropicUpstreamErrorWithOptions) lets a 3-request edge burst
 // trip the 3/3 ladder and cool the whole edge stub for 10 minutes
@@ -27,11 +32,24 @@ import "strings"
 // The phrase "no available accounts" is TokenKey's own internal scheduler string
 // (service.ErrNoAvailableAccounts, rendered by the gateway handlers as an
 // "api_error"); Anthropic's real API never emits it, so a case-insensitive match
-// on a 503 body is a specific signal of downstream pool exhaustion.
+// on the body is a specific signal of downstream pool exhaustion (status may be
+// 503 legacy or 429 current empty-pool fast-fail).
 func tkIsDownstreamNoAvailableAccounts(upstreamMsg string, responseBody []byte) bool {
 	needle := ErrNoAvailableAccounts.Error() // "no available accounts"
 	if strings.Contains(strings.ToLower(upstreamMsg), needle) {
 		return true
 	}
 	return strings.Contains(strings.ToLower(string(responseBody)), needle)
+}
+
+// tkSkipDownstreamNoAvailableAccountsPenalty is true when an Anthropic upstream
+// response is our own downstream gateway's empty-pool signal (503 or 429). Such
+// hits must fail over without handle429 cooldown, anthropic_upstream_error ladder
+// writes, or Feishu digest "限流冷却（429）" — the stub is healthy; the
+// forwarded-to edge pool is empty or saturated.
+func tkSkipDownstreamNoAvailableAccountsPenalty(statusCode int, upstreamMsg string, responseBody []byte) bool {
+	if statusCode != http.StatusServiceUnavailable && statusCode != http.StatusTooManyRequests {
+		return false
+	}
+	return tkIsDownstreamNoAvailableAccounts(upstreamMsg, responseBody)
 }

--- a/backend/internal/service/ratelimit_service_tk_downstream_no_available_test.go
+++ b/backend/internal/service/ratelimit_service_tk_downstream_no_available_test.go
@@ -23,6 +23,14 @@ func TestTkIsDownstreamNoAvailableAccounts(t *testing.T) {
 	require.False(t, tkIsDownstreamNoAvailableAccounts("", []byte(`{}`)))
 }
 
+func TestTkSkipDownstreamNoAvailableAccountsPenalty(t *testing.T) {
+	body := []byte(`{"type":"error","error":{"type":"api_error","message":"No available accounts: no available accounts"}}`)
+	require.True(t, tkSkipDownstreamNoAvailableAccountsPenalty(http.StatusServiceUnavailable, "", body))
+	require.True(t, tkSkipDownstreamNoAvailableAccountsPenalty(http.StatusTooManyRequests, "", body))
+	require.False(t, tkSkipDownstreamNoAvailableAccountsPenalty(http.StatusBadGateway, "", body))
+	require.False(t, tkSkipDownstreamNoAvailableAccountsPenalty(http.StatusTooManyRequests, "", []byte(`{"error":{"type":"rate_limit_error","message":"slow down"}}`)))
+}
+
 // prod incident 2026-05-31: a downstream edge stub returning 503 "no available
 // accounts" (a transient edge pool-capacity blip) must fail the request over to
 // the next stub WITHOUT advancing the per-account cooldown counter or cooling the
@@ -44,6 +52,29 @@ func TestRateLimitService_HandleUpstreamError_DownstreamNoAvailable_DoesNotPenal
 	require.Equal(t, 0, repo.tempCalls, "downstream no-available 503 must never write temp_unschedulable")
 	require.Equal(t, 0, repo.setErrorCalls)
 	require.Empty(t, counter.incrementIDs, "downstream no-available 503 must NOT advance the cooldown counter")
+}
+
+// prod 2026-06: empty-pool fast-fail now returns 429+Retry-After (not 503). The
+// prod mirror stub must fail over without handle429 cooldown or Feishu "限流冷却".
+func TestRateLimitService_HandleUpstreamError_DownstreamNoAvailable429_DoesNotPenalizeStub(t *testing.T) {
+	repo := &rateLimitAccountRepoStub{}
+	counter := &anthropicUpstreamErrorCounterCacheStub{counts: []int64{1, 2, 3, 4, 5}}
+	service := NewRateLimitService(repo, nil, &config.Config{}, nil, nil)
+	service.SetAnthropicUpstreamErrorCounterCache(counter)
+	account := &Account{ID: 4042, Platform: PlatformAnthropic, Type: AccountTypeAPIKey}
+
+	body := []byte(`{"type":"error","error":{"type":"api_error","message":"No available accounts: no available accounts"}}`)
+	headers := http.Header{}
+	headers.Set("Retry-After", "5")
+	for i := 0; i < 5; i++ {
+		shouldDisable := service.HandleUpstreamError(context.Background(), account, http.StatusTooManyRequests, headers, body)
+		require.True(t, shouldDisable, "iteration %d: downstream 429 no-available must fail over to the next stub", i)
+	}
+
+	require.Equal(t, 0, repo.setRateLimitedCalls, "downstream no-available 429 must not write SetRateLimited")
+	require.Equal(t, 0, repo.tempCalls, "downstream no-available 429 must never write temp_unschedulable")
+	require.Equal(t, 0, repo.setErrorCalls)
+	require.Empty(t, counter.incrementIDs, "downstream no-available 429 must NOT advance the cooldown counter")
 }
 
 // Regression: a genuine Anthropic upstream 503 (no "no available accounts" body)

--- a/scripts/sentinels/gateway-tk.json
+++ b/scripts/sentinels/gateway-tk.json
@@ -1284,10 +1284,10 @@
       "must_contain": [
         "tkIsAnthropicClientInducedBadRequest(responseBody)",
         "s.tkClampOpenAIRateLimitReset(ctx, account.ID",
-        "tkIsDownstreamNoAvailableAccounts(upstreamMsg, responseBody)",
+        "tkSkipDownstreamNoAvailableAccountsPenalty(statusCode, upstreamMsg, responseBody)",
         "anthropic_downstream_no_available_accounts_skip_penalty"
       ],
-      "rationale": "TK#2608: client-induced Anthropic 400 invalid_request_error must not advance the per-account cooldown counter (else an external caller can pause a shared OAuth subscription account). TK#1981: opt-in clamp of long OpenAI 429 resets so released accounts are re-probed by traffic instead of idling. Prod incident 2026-05-31: a downstream 503 whose body is our own 'no available accounts' pool-exhaustion signal (a thin edge bursting on parallel haiku background requests, surfaced through a prod per-edge mirror stub) must fail over to the next stub WITHOUT advancing the anthropic_upstream_error counter — else a 3-503 edge burst trips the 3/3 ladder and cools the whole edge stub for 10 minutes, collapsing the prod pool (self-inflicted 503 amplifier)."
+      "rationale": "TK#2608: client-induced Anthropic 400 invalid_request_error must not advance the per-account cooldown counter (else an external caller can pause a shared OAuth subscription account). TK#1981: opt-in clamp of long OpenAI 429 resets so released accounts are re-probed by traffic instead of idling. Prod incident 2026-05-31 / 2026-06: a downstream 503 or 429 whose body is our own 'no available accounts' pool-exhaustion signal (edge empty pool or thin-pool burst, surfaced through a prod per-edge mirror stub) must fail over to the next stub WITHOUT handle429 cooldown, anthropic_upstream_error counter advance, or Feishu digest '限流冷却（429）' — else intentional edge shutdown or a brief edge burst cools the whole stub and collapses the prod pool."
     },
     {
       "path": "backend/internal/service/ratelimit_service_tk_client_induced_400.go",
@@ -1301,9 +1301,10 @@
       "path": "backend/internal/service/ratelimit_service_tk_downstream_no_available.go",
       "must_contain": [
         "func tkIsDownstreamNoAvailableAccounts",
+        "func tkSkipDownstreamNoAvailableAccountsPenalty",
         "ErrNoAvailableAccounts.Error()"
       ],
-      "rationale": "Prod incident 2026-05-31: the predicate distinguishing a downstream gateway's own 'no available accounts' pool-exhaustion 503 (transient edge capacity blip on a forwarded-to pool) from a genuine account-health upstream error. Removing it lets a brief edge-side haiku burst trip the 3/3 anthropic_upstream_error ladder and 10-minute-cool the prod mirror stub for that whole edge, reintroducing the self-inflicted 503 amplifier."
+      "rationale": "Prod incident 2026-05-31 / 2026-06: predicates distinguishing a downstream gateway's own 'no available accounts' pool-exhaustion 503/429 (transient edge capacity blip or intentional edge shutdown on a forwarded-to pool) from a genuine account-health upstream rate limit. Removing them lets empty-pool 429 hit handle429 + Feishu '限流冷却' noise and reintroduces the self-inflicted stub-cooldown amplifier."
     },
     {
       "path": "backend/internal/service/openai_gateway_service_tk_implicit_throttle.go",


### PR DESCRIPTION
## Summary

- Extend the downstream empty-pool exemption (previously 503-only) to **429**, matching edge empty-pool fast-fail (`No available accounts` + `Retry-After: 5`).
- Prod mirror stubs (`cc-us1`, `cc-us2`, …) now **fail over only**: no `SetRateLimited`, no anthropic_upstream_error ladder, no Feishu digest line under「限流冷却（429）」.
- Genuine Anthropic `rate_limit_error` 429 behavior is unchanged.

## Risk

常规风险 / 低风险：仅 ratelimit 告警与 stub 冷却路径；无公共 API 契约变化。

## Validation

- `go test -tags=unit ./internal/service/ -run 'DownstreamNoAvailable|TestTkSkipDownstream' -count=1` — PASS
- `./scripts/preflight.sh` — PASS (pre-commit)


Made with [Cursor](https://cursor.com)