### PR TITLE
fix(edge-accounts): skip operator-disabled mirror stubs in fanout

### DIFF
--- a/backend/internal/service/edge_accounts_aggregator_tk.go
+++ b/backend/internal/service/edge_accounts_aggregator_tk.go
@@ -154,6 +154,16 @@ func discoverEdgeTargets(accounts []Account, re *regexp.Regexp) []edgeTarget {
 		if !isAnthropicMirrorStub(acct, re) {
 			continue
 		}
+		// Skip operator-disabled stubs: a disabled mirror stub means the edge was
+		// deliberately taken out of rotation (e.g. a decommissioned region whose
+		// DNS no longer resolves). Fanning out to it every refresh only ever
+		// surfaces a permanent failure card and risks an 8s timeout if its host
+		// blackholes — neither is useful on a read-only overview. 'error' (a
+		// transient runtime state) is intentionally NOT skipped: the edge may
+		// still be reachable, and another stub for the same base_url may cover it.
+		if acct.Status == StatusDisabled {
+			continue
+		}
 		baseURL := normalizeEdgeBaseURL(acct.GetCredential("base_url"))
 		apiKey := strings.TrimSpace(acct.GetCredential("api_key"))
 		if baseURL == "" || apiKey == "" {

--- a/backend/internal/service/edge_accounts_aggregator_tk_test.go
+++ b/backend/internal/service/edge_accounts_aggregator_tk_test.go
@@ -120,6 +120,42 @@ func TestEdgeAccountsAggregator_FanoutDedupAndErrorIsolation(t *testing.T) {
 	require.NotContains(t, doer.keysSeen, "example.com")
 }
 
+func TestEdgeAccountsAggregator_SkipsDisabledStub(t *testing.T) {
+	disabled := mirrorStub(1, "https://api-fra1.tokenkey.dev", "key-fra1")
+	disabled.Status = StatusDisabled
+	// us6 has a disabled stub listed before an active one for the same base_url:
+	// the disabled one is skipped, the active one still covers the edge.
+	us6Disabled := mirrorStub(2, "https://api-us6.tokenkey.dev", "key-us6-old")
+	us6Disabled.Status = StatusDisabled
+	us6Active := mirrorStub(3, "https://api-us6.tokenkey.dev", "key-us6")
+	us6Active.Status = StatusActive
+	// us7's only stub is in 'error' (transient) — must NOT be skipped.
+	us7Err := mirrorStub(4, "https://api-us7.tokenkey.dev", "key-us7")
+	us7Err.Status = "error"
+
+	store := &edgeAccountsStoreStub{accounts: []Account{disabled, us6Disabled, us6Active, us7Err}}
+	doer := &fakeEdgeDoer{bodyByHost: map[string]string{
+		"api-us6.tokenkey.dev": `{"code":0,"data":{"accounts":[]}}`,
+		"api-us7.tokenkey.dev": `{"code":0,"data":{"accounts":[]}}`,
+	}}
+
+	agg := NewEdgeAccountsAggregator(store, doer)
+	out, err := agg.Aggregate(context.Background(), "anthropic")
+	require.NoError(t, err)
+
+	// fra1 (disabled-only) dropped entirely; us6 + us7 remain (sorted).
+	require.Len(t, out.Edges, 2)
+	require.Equal(t, "us6", out.Edges[0].EdgeID)
+	require.Equal(t, "us7", out.Edges[1].EdgeID)
+
+	// Disabled fra1 was never polled.
+	require.NotContains(t, doer.keysSeen, "api-fra1.tokenkey.dev")
+	// us6 used the ACTIVE stub's key (the disabled one ahead of it was skipped).
+	require.Equal(t, "key-us6", doer.keysSeen["api-us6.tokenkey.dev"])
+	// us7 in 'error' state is still reachable and was polled.
+	require.Equal(t, "key-us7", doer.keysSeen["api-us7.tokenkey.dev"])
+}
+
 func TestEdgeAccountsAggregator_Non2xxIsError(t *testing.T) {
 	store := &edgeAccountsStoreStub{accounts: []Account{
 		mirrorStub(1, "https://api-us1.tokenkey.dev", "key-us1"),

--- a/scripts/sentinels/gateway-tk.json
+++ b/scripts/sentinels/gateway-tk.json
@@ -1482,9 +1482,10 @@
         "func (a *EdgeAccountsAggregator) MintAdminSession(",
         "func isAnthropicMirrorStub(",
         "req.Header.Set(\"x-api-key\", t.apiKey)",
-        "never a failed aggregate"
+        "never a failed aggregate",
+        "if acct.Status == StatusDisabled {"
       ],
-      "rationale": "Prod-side cross-edge aggregator (consumer of GET /api/v1/edge/accounts). Discovers edges via the local anthropic mirror stubs (same {base_url, api_key} pairs surface-C uses — zero new secret) and fans out concurrently. Two load-bearing properties: (1) per-edge failure isolation — a timeout/non-2xx/decode error on one edge yields {ok:false,error} and never fails the whole aggregate; (2) it authenticates each edge with the stub's x-api-key. A silent upstream-merge weakening (e.g. propagating a single edge error to the whole response, or dropping the mirror-stub predicate) must be caught."
+      "rationale": "Prod-side cross-edge aggregator (consumer of GET /api/v1/edge/accounts). Discovers edges via the local anthropic mirror stubs (same {base_url, api_key} pairs surface-C uses — zero new secret) and fans out concurrently. Load-bearing properties: (1) per-edge failure isolation — a timeout/non-2xx/decode error on one edge yields {ok:false,error} and never fails the whole aggregate; (2) it authenticates each edge with the stub's x-api-key; (3) operator-disabled mirror stubs are skipped at discovery so a decommissioned edge (dead DNS / blackholed host) cannot drag every refresh into the per-edge 8s timeout. A silent upstream-merge weakening (e.g. propagating a single edge error to the whole response, dropping the mirror-stub predicate, or re-polling disabled stubs) must be caught."
     },
     {
       "path": "backend/internal/handler/admin/edge_accounts_handler_tk.go",


### PR DESCRIPTION
## 背景

排查「prod /admin/edge-accounts 页面很慢」时发现：该页后端 \`EdgeAccountsAggregator\` 从本地 anthropic api-key mirror stub 发现 edge 并并行扇出读取每个 edge 的账号清单（信号量 16，单 edge 8s 超时，无缓存）。

线上取证结论：稳态接口很快（**p50 96ms / p95 293ms**），用户遇到的 8s 慢是 v1.7.71 edge 滚动重启窗口内的瞬时现象，**不是常态 bug**。但排查中暴露一个真实瑕疵 —— 本 PR 修这一个。

## 问题

\`discoverEdgeTargets\` 只按 platform / type / base_url 正则过滤 mirror stub，**不看 \`status\`**。所以一个被运营手动置为 \`status=disabled\` 的 stub（典型：已退役的 fra1，account id=41，DNS 已不解析）仍会在**每 30s 自动刷新**时被 curl 一遍：

- 页面常驻一张永远失败的 fra1 卡片；
- 若该死节点的 host 是黑洞（丢包而非拒连），还会把单 edge 拖到 8s 超时上限，并因并行扇出 \`wg.Wait()\` 拖慢整次聚合首屏。

线上实测：fra1 当前是快速失败（DNS 7ms 返回），所以暂未造成延迟，但失败卡片常驻、且一旦 DNS 行为变化即有 8s 风险。

## 改动

\`discoverEdgeTargets\` 在发现阶段跳过 \`status=disabled\` 的 stub。

- \`error\`（运行时瞬时态）**不跳过**：edge 可能仍可达，且同 base_url 的另一个 stub 可能覆盖它。
- 同步更新 \`scripts/sentinels/gateway-tk.json\`，把该跳过逻辑登记为第 3 条 load-bearing 属性，防止上游合并静默回退。

## 验证

- \`go test -tags=unit ./internal/service/ -run TestEdgeAccountsAggregator\` 通过（新增 \`TestEdgeAccountsAggregator_SkipsDisabledStub\`：disabled-only 的 fra1 被丢弃、同 base_url 有 active stub 时仍覆盖、error 态仍扇出）
- \`go build ./...\` 通过
- \`golangci-lint\` 对改动文件无新 issue
- \`scripts/preflight.sh\` 全绿（含 sentinel registry update gate）

纯后端改动（\`*_tk_*.go\` + sentinel JSON），无前端影响。

🤖 Generated with [Claude Code](https://claude.com/claude-code)