### PR TITLE
fix(ops): append Beijing time to Feishu alert timestamps

### DIFF
--- a/backend/internal/service/account_incident_notifier_tk.go
+++ b/backend/internal/service/account_incident_notifier_tk.go
@@ -327,7 +327,7 @@ func buildAccountIncidentPermanentText(site string, account *Account, reason str
 		escapeFeishuText(accountGroupNames(account)),
 		escapeFeishuText(cls.kindZh),
 		escapeFeishuText(strings.TrimSpace(reason)),
-		escapeFeishuText(now.Format(time.RFC3339)),
+		escapeFeishuText(formatAlertTime(now)),
 		escapeFeishuText(cls.advice),
 	)
 }
@@ -335,7 +335,7 @@ func buildAccountIncidentPermanentText(site string, account *Account, reason str
 func buildAccountIncidentDigestText(site string, entries []*accountIncidentDigestEntry, now time.Time) string {
 	lines := make([]string, 0, len(entries)+1)
 	lines = append(lines, fmt.Sprintf("**节点**：%s\n**时间**：%s\n\n临时冷却（自愈类）聚合摘要：",
-		escapeFeishuText(site), escapeFeishuText(now.Format(time.RFC3339))))
+		escapeFeishuText(site), escapeFeishuText(formatAlertTime(now))))
 	for _, e := range entries {
 		samples := strings.Join(e.accountSamples, ", ")
 		if len(e.accountIDs) > len(e.accountSamples) {
@@ -377,6 +377,13 @@ func accountGroupNames(account *Account) string {
 		return "-"
 	}
 	return strings.Join(names, ",")
+}
+
+var bjLoc = time.FixedZone("Asia/Shanghai", 8*60*60)
+
+func formatAlertTime(t time.Time) string {
+	bj := t.In(bjLoc)
+	return fmt.Sprintf("%s（北京时间 %s）", t.UTC().Format(time.RFC3339), bj.Format("15:04:05"))
 }
 
 func accountIncidentDedupeKey(site string, accountID int64, reasonClass string) string {

--- a/backend/internal/service/account_incident_notifier_tk_test.go
+++ b/backend/internal/service/account_incident_notifier_tk_test.go
@@ -128,6 +128,14 @@ func TestClassifyIncident(t *testing.T) {
 	}
 }
 
+func TestFormatAlertTime(t *testing.T) {
+	t.Parallel()
+	utc := time.Date(2026, 6, 5, 10, 31, 34, 0, time.UTC)
+	got := formatAlertTime(utc)
+	require.Contains(t, got, "2026-06-05T10:31:34Z")
+	require.Contains(t, got, "北京时间 18:31:34")
+}
+
 func TestSiteFromFrontendURL(t *testing.T) {
 	t.Parallel()
 	cases := map[string]string{

--- a/backend/internal/service/ops_feishu_notifier_tk.go
+++ b/backend/internal/service/ops_feishu_notifier_tk.go
@@ -218,7 +218,7 @@ func buildOpsFeishuAlertText(rule *OpsAlertRule, event *OpsAlertEvent, nodeLabel
 		escapeFeishuText(thresholdValue),
 		escapeFeishuText(metricValue),
 		escapeFeishuText(dimensions),
-		escapeFeishuText(event.FiredAt.Format(time.RFC3339)),
+		escapeFeishuText(formatAlertTime(event.FiredAt)),
 		advice,
 	)
 }


### PR DESCRIPTION
## Summary
- Feishu alert timestamps now show Beijing time alongside UTC, e.g. `2026-06-05T10:31:34Z（北京时间 18:31:34）`
- Applies to all three alert types: permanent account incidents, temporary cooldown digests, and ops P0 rule alerts

## Risk
Low — display-only change, no behavior/contract impact.

## Validation
- `go test -tags=unit -run 'TestFormatAlertTime|TestNotify|TestFlush|TestPermanentDedupe|TestSendPanic|TestClassifyIncident|TestSiteFromFrontendURL|TestOpsFeishu' ./internal/service/` all pass


Made with [Cursor](https://cursor.com)