### PR TITLE
fix(anthropic): scope unified-window 429 cooldown to model class, not whole account (G4)

### DIFF
--- a/backend/internal/service/model_rate_limit.go
+++ b/backend/internal/service/model_rate_limit.go
@@ -46,6 +46,15 @@ func (a *Account) isModelRateLimitedWithContext(ctx context.Context, requestedMo
 		}
 	case PlatformGemini:
 		modelKey = resolveFinalGeminiModelKey(ctx, requestedModel)
+	case PlatformAnthropic:
+		// TK G4: a unified-window 429 (opus 5h/7d exhausted) is cooled at
+		// (account × model class) scope, not the whole account. Honour the
+		// class-scope key alongside the exact-model-name key so a cooled opus
+		// keeps sibling sonnet/haiku schedulable. See
+		// ratelimit_service_tk_model_cooldown.go.
+		if a.tkAnthropicModelClassRateLimitActive(requestedModel) {
+			return true
+		}
 	}
 	modelKey = strings.TrimSpace(modelKey)
 	if modelKey == "" {
@@ -81,6 +90,13 @@ func (a *Account) GetModelRateLimitRemainingTimeWithContext(ctx context.Context,
 		if familyRemaining := a.getRateLimitRemainingForKey(antigravityGeminiModelRateLimitKey); familyRemaining > remaining {
 			return familyRemaining
 		}
+	}
+	// TK G4: surface the longer of the exact-model and model-class cooldowns
+	// so retry/backoff hints reflect the real time-to-availability for an
+	// Anthropic unified-window class cooldown. See
+	// ratelimit_service_tk_model_cooldown.go.
+	if classRemaining := a.tkAnthropicModelClassRateLimitRemaining(requestedModel); classRemaining > remaining {
+		return classRemaining
 	}
 	return remaining
 }

--- a/backend/internal/service/ratelimit_service.go
+++ b/backend/internal/service/ratelimit_service.go
@@ -475,7 +475,7 @@ func (s *RateLimitService) HandleUpstreamError(ctx context.Context, account *Acc
 		// race a less-precise local cooldown over the just-written reset).
 		// The 3/3 + tier counters still advance so persistent failure
 		// still escalates.
-		rateLimitSet := s.handle429(ctx, account, headers, responseBody)
+		rateLimitSet := s.handle429(ctx, account, headers, responseBody, requestedModel...)
 		if account.Platform == PlatformAnthropic {
 			shouldDisable = s.handleAnthropicUpstreamErrorWithOptions(ctx, account, statusCode, upstreamMsg, responseBody, rateLimitSet)
 		} else {
@@ -1384,7 +1384,7 @@ func findAnthropicNotFoundModel(text string) string {
 // advance so persistent failure still escalates — only the
 // SetTempUnschedulable write is suppressed when the more authoritative
 // SetRateLimited has just landed.
-func (s *RateLimitService) handle429(ctx context.Context, account *Account, headers http.Header, responseBody []byte) bool {
+func (s *RateLimitService) handle429(ctx context.Context, account *Account, headers http.Header, responseBody []byte, requestedModel ...string) bool {
 	// 1. OpenAI 平台：优先尝试解析 x-codex-* 响应头（用于 rate_limit_exceeded）
 	if account.Platform == PlatformOpenAI {
 		persistOpenAI429PlanType(ctx, s.accountRepo, account, responseBody)
@@ -1405,6 +1405,19 @@ func (s *RateLimitService) handle429(ctx context.Context, account *Account, head
 
 	// 2. Anthropic 平台：尝试解析 per-window 头（5h / 7d），选择实际触发的窗口
 	if result := calculateAnthropic429ResetTime(headers); result != nil {
+		// TK G4: a unified-window (5h/7d) exhaustion is tied to a specific
+		// model class (typically opus, which burns the shared window
+		// fastest). When we know the requested model's class, cool only
+		// (account × class) instead of the whole account, so healthy
+		// sonnet/haiku on the same account keep scheduling. Returns true
+		// (authoritative) when the model-scoped write landed, so the caller
+		// still suppresses the 3/3 ladder cooldown. Falls through to the
+		// account-level path below when the model class is unknown (e.g. no
+		// model context at the call site) or the write failed.
+		// See ratelimit_service_tk_model_cooldown.go.
+		if len(requestedModel) > 0 && s.tkTryAnthropicModelScopedCooldown(ctx, account, requestedModel[0], result) {
+			return true
+		}
 		s.notifyAccountSchedulingBlocked(account, result.resetAt, "429")
 		if err := s.accountRepo.SetRateLimited(ctx, account.ID, result.resetAt); err != nil {
 			slog.Warn("rate_limit_set_failed", "account_id", account.ID, "error", err)

--- a/backend/internal/service/ratelimit_service.go
+++ b/backend/internal/service/ratelimit_service.go
@@ -1425,14 +1425,8 @@ func (s *RateLimitService) handle429(ctx context.Context, account *Account, head
 		}
 
 		// 更新 session window：优先使用 5h-reset 头精确计算，否则从 resetAt 反推
-		windowEnd := result.resetAt
-		if result.fiveHourReset != nil {
-			windowEnd = *result.fiveHourReset
-		}
-		windowStart := windowEnd.Add(-5 * time.Hour)
-		if err := s.accountRepo.UpdateSessionWindow(ctx, account.ID, &windowStart, &windowEnd, "rejected"); err != nil {
-			slog.Warn("rate_limit_update_session_window_failed", "account_id", account.ID, "error", err)
-		}
+		// （与模型级冷却路径共用 tkUpdateAnthropic5hSessionWindow，保证两条路径写入一致）
+		s.tkUpdateAnthropic5hSessionWindow(ctx, account.ID, result)
 
 		slog.Info("anthropic_account_rate_limited", "account_id", account.ID, "reset_at", result.resetAt, "reset_in", time.Until(result.resetAt).Truncate(time.Second))
 		return true

--- a/backend/internal/service/ratelimit_service_401_test.go
+++ b/backend/internal/service/ratelimit_service_401_test.go
@@ -41,6 +41,11 @@ type rateLimitAccountRepoStub struct {
 	// instead of the whole account.
 	modelRateLimitCalls []rateLimitStubModelCall
 	modelRateLimitErr   error
+
+	// TK G4: assert the account-global 5h session window is still recorded on
+	// the model-scoped cooldown path (operator usage gauge depends on it).
+	updateSessionWindowCalls int
+	lastSessionWindowStatus  string
 }
 
 type rateLimitStubModelCall struct {
@@ -57,6 +62,12 @@ func (r *rateLimitAccountRepoStub) SetModelRateLimit(ctx context.Context, id int
 	}
 	r.modelRateLimitCalls = append(r.modelRateLimitCalls, call)
 	return r.modelRateLimitErr
+}
+
+func (r *rateLimitAccountRepoStub) UpdateSessionWindow(ctx context.Context, id int64, start, end *time.Time, status string) error {
+	r.updateSessionWindowCalls++
+	r.lastSessionWindowStatus = status
+	return nil
 }
 
 func (r *rateLimitAccountRepoStub) SetError(ctx context.Context, id int64, errorMsg string) error {

--- a/backend/internal/service/ratelimit_service_401_test.go
+++ b/backend/internal/service/ratelimit_service_401_test.go
@@ -35,6 +35,28 @@ type rateLimitAccountRepoStub struct {
 	// TempUnschedulableReason holds the prior 403 TempUnschedState so
 	// wasTempUnschedByStatusCode(reason, 403) returns true.
 	tempReasonOnGet string
+
+	// TK G4: track per-(account × scope) model-rate-limit writes so tests can
+	// assert that an Anthropic unified-window 429 cools the model class scope
+	// instead of the whole account.
+	modelRateLimitCalls []rateLimitStubModelCall
+	modelRateLimitErr   error
+}
+
+type rateLimitStubModelCall struct {
+	accountID int64
+	scope     string
+	resetAt   time.Time
+	reason    string
+}
+
+func (r *rateLimitAccountRepoStub) SetModelRateLimit(ctx context.Context, id int64, scope string, resetAt time.Time, reason ...string) error {
+	call := rateLimitStubModelCall{accountID: id, scope: scope, resetAt: resetAt}
+	if len(reason) > 0 {
+		call.reason = reason[0]
+	}
+	r.modelRateLimitCalls = append(r.modelRateLimitCalls, call)
+	return r.modelRateLimitErr
 }
 
 func (r *rateLimitAccountRepoStub) SetError(ctx context.Context, id int64, errorMsg string) error {

--- a/backend/internal/service/ratelimit_service_tk_model_cooldown.go
+++ b/backend/internal/service/ratelimit_service_tk_model_cooldown.go
@@ -145,6 +145,16 @@ func (s *RateLimitService) tkTryAnthropicModelScopedCooldown(
 		return false
 	}
 
+	// The unified 5h window is exhausted at the ACCOUNT level (it's the shared
+	// window across all model classes — that's exactly why upstream 429'd).
+	// Even though the cooldown is scoped to the model class for SCHEDULING, the
+	// account's 5h-window state is account-global truth and must still be
+	// recorded, so the Setup-Token usage gauge (estimateSetupTokenUsage, fed by
+	// SessionWindow*) keeps reflecting reality. This mirrors the account-level
+	// path's UpdateSessionWindow write — only the cooldown scope changed, not
+	// the window signal.
+	s.tkUpdateAnthropic5hSessionWindow(ctx, account.ID, result)
+
 	slog.Info("anthropic_model_class_rate_limited",
 		"account_id", account.ID,
 		"scope", scopeKey,
@@ -152,6 +162,25 @@ func (s *RateLimitService) tkTryAnthropicModelScopedCooldown(
 		"reset_at", resetAt,
 		"reset_in", time.Until(resetAt).Truncate(time.Second))
 	return true
+}
+
+// tkUpdateAnthropic5hSessionWindow records the account-global 5h window as
+// "rejected" from an Anthropic unified-window 429 result. Shared by the
+// model-scoped cooldown path and the account-level path so the Setup-Token
+// usage estimation stays consistent regardless of cooldown scope. Prefers the
+// precise 5h-reset header; otherwise back-derives the window from resetAt.
+func (s *RateLimitService) tkUpdateAnthropic5hSessionWindow(ctx context.Context, accountID int64, result *anthropic429Result) {
+	if s == nil || s.accountRepo == nil || result == nil {
+		return
+	}
+	windowEnd := result.resetAt
+	if result.fiveHourReset != nil {
+		windowEnd = *result.fiveHourReset
+	}
+	windowStart := windowEnd.Add(-5 * time.Hour)
+	if err := s.accountRepo.UpdateSessionWindow(ctx, accountID, &windowStart, &windowEnd, "rejected"); err != nil {
+		slog.Warn("rate_limit_update_session_window_failed", "account_id", accountID, "error", err)
+	}
 }
 
 // tkAnthropicModelClassRateLimitActive reports whether the account is in a

--- a/backend/internal/service/ratelimit_service_tk_model_cooldown.go
+++ b/backend/internal/service/ratelimit_service_tk_model_cooldown.go
@@ -1,0 +1,184 @@
+package service
+
+import (
+	"context"
+	"log/slog"
+	"strings"
+	"time"
+)
+
+// TK G4 — model-dimension cooldown for Anthropic unified-window 429s.
+//
+// Background (prod 2026-06, edge us6, account edge-ls-oh-3-d): Anthropic
+// subscription (OAuth) accounts share a rolling "unified 5h / 7d" usage
+// window across ALL model classes. When the heaviest class (typically opus)
+// burns through the 5h window, upstream returns a real 429 rate_limit_error
+// and handle429 parses the anthropic-ratelimit-unified-5h-* headers
+// (is_5h_exceeded=true / reset_5h=<unix>). The legacy behaviour then called
+// SetRateLimited, which is ACCOUNT-LEVEL: it pulled the whole account out of
+// scheduling until reset. But sonnet/haiku on that same account were still
+// perfectly healthy — only opus's slice of the 5h window was exhausted. The
+// account-level cooldown amplified "opus window full" into "entire account
+// offline", wasting healthy sonnet/haiku capacity for ~1h.
+//
+// G4 fix: when the 429 is provably tied to a model class (5h/7d unified
+// window exceeded AND we know the requested model's class), scope the
+// cooldown to (account × model class) instead of the whole account. The opus
+// class is cooled until reset; sonnet/haiku on the same account keep
+// scheduling. Hard account failures (401/403 auth, credit balance, org
+// disabled, KYC, 529 overloaded, fallback no-reset 429) are NOT model-related
+// and keep their account-level behaviour unchanged.
+//
+// Convergence: this reuses the existing per-(account × scope) cooldown
+// mechanism already in account.Extra["model_rate_limits"] — the same store
+// written by SetModelRateLimit (404 model-not-found, antigravity credits,
+// gemini code-assist) and read by the scheduler's
+// IsSchedulableForModelWithContext → isModelRateLimitedWithContext gate. We
+// add a model-CLASS scope key (anthropic:class:opus|sonnet|haiku) mirroring
+// the antigravity "antigravity:gemini" family-key precedent, so no new
+// repository interface method, no parallel Redis layer, and no second source
+// of truth the scheduler must learn to consult. The store is durable
+// (accounts.extra JSONB + scheduler snapshot via outbox) and self-expiring
+// (reads compare time.Now() against rate_limit_reset_at), exactly matching
+// the "transient state with a reset time" shape this feature needs.
+
+const (
+	// anthropicModelClassRateLimitPrefix namespaces the model-class cooldown
+	// scope keys so they never collide with exact-model-name scope keys
+	// written by the 404 / model-not-found path.
+	anthropicModelClassRateLimitPrefix = "anthropic:class:"
+
+	anthropicModelClassOpus    = "opus"
+	anthropicModelClassSonnet  = "sonnet"
+	anthropicModelClassHaiku   = "haiku"
+	anthropicModelClassUnknown = ""
+
+	// tkAnthropicModelCooldownReason is recorded on the model_rate_limits
+	// entry so operators / debug tooling can distinguish a unified-window
+	// model-class cooldown from a 404 model-not-found cooldown.
+	tkAnthropicModelCooldownReason = "anthropic_unified_window_exceeded"
+)
+
+// tkAnthropicModelClass normalizes an Anthropic model name to its capacity
+// class (opus / sonnet / haiku). Returns "" when the class can't be
+// determined — callers MUST treat unknown as "not model-scoped" and fall
+// back to account-level handling rather than guessing.
+//
+// Matching is substring-based and case-insensitive so it survives version
+// suffixes, [1m] context tags, date stamps, and provider prefixes
+// (e.g. "claude-opus-4-8[1m]", "anthropic/claude-3-5-haiku-20241022").
+func tkAnthropicModelClass(model string) string {
+	name := strings.ToLower(strings.TrimSpace(model))
+	if name == "" {
+		return anthropicModelClassUnknown
+	}
+	switch {
+	case strings.Contains(name, "opus"):
+		return anthropicModelClassOpus
+	case strings.Contains(name, "sonnet"):
+		return anthropicModelClassSonnet
+	case strings.Contains(name, "haiku"):
+		return anthropicModelClassHaiku
+	default:
+		return anthropicModelClassUnknown
+	}
+}
+
+// tkAnthropicModelClassScopeKey builds the model_rate_limits scope key for a
+// model class, or "" if the class is unknown.
+func tkAnthropicModelClassScopeKey(class string) string {
+	if class == anthropicModelClassUnknown {
+		return ""
+	}
+	return anthropicModelClassRateLimitPrefix + class
+}
+
+// tkAnthropicModelClassScopeKeyForModel resolves a requested model name to its
+// model-class scope key, or "" when the class can't be determined.
+func tkAnthropicModelClassScopeKeyForModel(model string) string {
+	return tkAnthropicModelClassScopeKey(tkAnthropicModelClass(model))
+}
+
+// tkTryAnthropicModelScopedCooldown attempts to write a (account × model
+// class) cooldown for an Anthropic unified-window 429 instead of an
+// account-level SetRateLimited.
+//
+// It returns true ONLY when the cooldown was written at model-class scope —
+// i.e. this is an Anthropic account, the 429 is a unified-window-exceeded
+// signal, AND the requested model resolves to a known class. In that case the
+// caller MUST NOT also call account-level SetRateLimited (that would re-create
+// the very amplification G4 removes). It still counts as an authoritative
+// upstream cooldown for the purpose of suppressing the 3/3 ladder write, so
+// the caller treats a true return like the account-level rate-limit path.
+//
+// It returns false in every other case (non-Anthropic, no model class known,
+// or repo write failure), and the caller falls back to the existing
+// account-level behaviour — preserving correctness for hard account failures
+// and for the no-model-context call sites.
+func (s *RateLimitService) tkTryAnthropicModelScopedCooldown(
+	ctx context.Context,
+	account *Account,
+	requestedModel string,
+	result *anthropic429Result,
+) bool {
+	if s == nil || s.accountRepo == nil || account == nil || result == nil {
+		return false
+	}
+	if account.Platform != PlatformAnthropic {
+		return false
+	}
+	scopeKey := tkAnthropicModelClassScopeKeyForModel(requestedModel)
+	if scopeKey == "" {
+		// Unknown model class (or no model context at the call site): cannot
+		// safely narrow the cooldown — fall back to account-level so we never
+		// leave an exhausted window uncooled.
+		return false
+	}
+
+	resetAt := result.resetAt
+	s.notifyAccountSchedulingBlocked(account, resetAt, "429_model_class")
+	if err := s.accountRepo.SetModelRateLimit(ctx, account.ID, scopeKey, resetAt, tkAnthropicModelCooldownReason); err != nil {
+		slog.Warn("anthropic_model_class_rate_limit_failed",
+			"account_id", account.ID,
+			"scope", scopeKey,
+			"error", err)
+		return false
+	}
+
+	slog.Info("anthropic_model_class_rate_limited",
+		"account_id", account.ID,
+		"scope", scopeKey,
+		"requested_model", requestedModel,
+		"reset_at", resetAt,
+		"reset_in", time.Until(resetAt).Truncate(time.Second))
+	return true
+}
+
+// tkAnthropicModelClassRateLimitActive reports whether the account is in a
+// model-class cooldown for the given requested model. Mirrors the antigravity
+// family-key check in isModelRateLimitedWithContext: the scheduler consults
+// this in addition to the exact-model-name key so a class-scoped cooldown
+// (opus) keeps sibling classes (sonnet/haiku) schedulable.
+func (a *Account) tkAnthropicModelClassRateLimitActive(requestedModel string) bool {
+	if a == nil || a.Platform != PlatformAnthropic {
+		return false
+	}
+	scopeKey := tkAnthropicModelClassScopeKeyForModel(requestedModel)
+	if scopeKey == "" {
+		return false
+	}
+	return a.isRateLimitActiveForKey(scopeKey)
+}
+
+// tkAnthropicModelClassRateLimitRemaining returns the remaining cooldown for
+// the account's model-class scope of the given requested model (0 if none).
+func (a *Account) tkAnthropicModelClassRateLimitRemaining(requestedModel string) time.Duration {
+	if a == nil || a.Platform != PlatformAnthropic {
+		return 0
+	}
+	scopeKey := tkAnthropicModelClassScopeKeyForModel(requestedModel)
+	if scopeKey == "" {
+		return 0
+	}
+	return a.getRateLimitRemainingForKey(scopeKey)
+}

--- a/backend/internal/service/ratelimit_service_tk_model_cooldown_test.go
+++ b/backend/internal/service/ratelimit_service_tk_model_cooldown_test.go
@@ -1,0 +1,294 @@
+//go:build unit
+
+package service
+
+import (
+	"context"
+	"net/http"
+	"strconv"
+	"testing"
+	"time"
+
+	"github.com/Wei-Shaw/sub2api/internal/config"
+	"github.com/stretchr/testify/require"
+)
+
+// G4 — model-dimension cooldown for Anthropic unified-window 429s.
+//
+// Prod motivation (edge us6, account edge-ls-oh-3-d): opus burned the shared
+// 5h window, upstream returned a unified-window 429, and the legacy
+// account-level SetRateLimited pulled the WHOLE account out of scheduling —
+// taking healthy sonnet/haiku offline with it. G4 scopes that cooldown to
+// (account × model class) so only opus is cooled.
+
+func tkModelClassScope(class string) string {
+	return anthropicModelClassRateLimitPrefix + class
+}
+
+// --- tkAnthropicModelClass normalization boundaries ---------------------------
+
+func TestTkAnthropicModelClass_Boundaries(t *testing.T) {
+	cases := []struct {
+		model string
+		want  string
+	}{
+		{"claude-opus-4-8", anthropicModelClassOpus},
+		{"claude-opus-4-8[1m]", anthropicModelClassOpus},
+		{"anthropic/claude-3-opus-20240229", anthropicModelClassOpus},
+		{"CLAUDE-OPUS-4-6-THINKING", anthropicModelClassOpus},
+		{"claude-sonnet-4-5", anthropicModelClassSonnet},
+		{"claude-3-5-sonnet-20241022", anthropicModelClassSonnet},
+		{"claude-3-5-haiku-20241022", anthropicModelClassHaiku},
+		{"claude-haiku-4-5", anthropicModelClassHaiku},
+		{"  claude-opus-4-8  ", anthropicModelClassOpus},
+		{"", anthropicModelClassUnknown},
+		{"gpt-5.4", anthropicModelClassUnknown},
+		{"gemini-3-pro", anthropicModelClassUnknown},
+	}
+	for _, tc := range cases {
+		require.Equalf(t, tc.want, tkAnthropicModelClass(tc.model),
+			"model=%q", tc.model)
+	}
+}
+
+func TestTkAnthropicModelClassScopeKeyForModel(t *testing.T) {
+	require.Equal(t, tkModelClassScope("opus"), tkAnthropicModelClassScopeKeyForModel("claude-opus-4-8"))
+	require.Equal(t, tkModelClassScope("sonnet"), tkAnthropicModelClassScopeKeyForModel("claude-sonnet-4-5"))
+	require.Equal(t, tkModelClassScope("haiku"), tkAnthropicModelClassScopeKeyForModel("claude-3-5-haiku"))
+	require.Empty(t, tkAnthropicModelClassScopeKeyForModel("gpt-5.4"))
+	require.Empty(t, tkAnthropicModelClassScopeKeyForModel(""))
+}
+
+// --- write side: 5h exceeded → model-class cooldown, NOT account-level --------
+
+func anthropic5hExceededHeaders(resetAt int64) http.Header {
+	headers := http.Header{}
+	headers.Set("anthropic-ratelimit-unified-5h-utilization", "1.02")
+	headers.Set("anthropic-ratelimit-unified-5h-reset", strconv.FormatInt(resetAt, 10))
+	headers.Set("anthropic-ratelimit-unified-7d-utilization", "0.30")
+	headers.Set("anthropic-ratelimit-unified-7d-reset", strconv.FormatInt(resetAt+3600*24, 10))
+	return headers
+}
+
+func newG4RateLimitService(repo *rateLimitAccountRepoStub) *RateLimitService {
+	svc := NewRateLimitService(repo, nil, &config.Config{}, nil, nil)
+	svc.SetAnthropicUpstreamErrorCounterCache(&anthropicUpstreamErrorCounterCacheStub{
+		counts:     []int64{1},
+		tierCounts: []int64{0},
+	})
+	return svc
+}
+
+func TestG4_OpusUnifiedWindow429_CoolsModelClassNotAccount(t *testing.T) {
+	repo := &rateLimitAccountRepoStub{}
+	svc := newG4RateLimitService(repo)
+	account := &Account{ID: 901, Platform: PlatformAnthropic, Type: AccountTypeOAuth}
+
+	resetAt := time.Now().Add(90 * time.Minute).Unix()
+	shouldDisable := svc.HandleUpstreamError(
+		context.Background(),
+		account,
+		http.StatusTooManyRequests,
+		anthropic5hExceededHeaders(resetAt),
+		[]byte(`{"error":{"type":"rate_limit_error","message":"unified 5h limit reached"}}`),
+		"claude-opus-4-8",
+	)
+
+	// model-scoped cooldown is authoritative → account is not error-disabled
+	require.False(t, shouldDisable)
+	// account-level rate limit MUST NOT be written (that's the amplification G4 removes)
+	require.Equal(t, 0, repo.setRateLimitedCalls,
+		"unified-window opus 429 must NOT call account-level SetRateLimited")
+	require.Equal(t, 0, repo.tempCalls,
+		"authoritative model cooldown suppresses the 3/3 ladder temp-unschedulable")
+	// model-class cooldown for opus written exactly once
+	require.Len(t, repo.modelRateLimitCalls, 1)
+	call := repo.modelRateLimitCalls[0]
+	require.Equal(t, int64(901), call.accountID)
+	require.Equal(t, tkModelClassScope("opus"), call.scope)
+	require.Equal(t, tkAnthropicModelCooldownReason, call.reason)
+	require.WithinDuration(t, time.Unix(resetAt, 0), call.resetAt, 2*time.Second)
+}
+
+func TestG4_OpusCooled_SonnetHaikuStillSchedulable(t *testing.T) {
+	// Simulate the post-write account state: opus class cooled until reset.
+	resetAt := time.Now().Add(90 * time.Minute)
+	account := &Account{
+		ID:          902,
+		Platform:    PlatformAnthropic,
+		Type:        AccountTypeOAuth,
+		Status:      StatusActive,
+		Schedulable: true,
+		Extra: map[string]any{
+			modelRateLimitsKey: map[string]any{
+				tkModelClassScope("opus"): map[string]any{
+					"rate_limit_reset_at": resetAt.Format(time.RFC3339),
+					"reason":              tkAnthropicModelCooldownReason,
+				},
+			},
+		},
+	}
+
+	ctx := context.Background()
+	// opus is NOT schedulable (its class is cooled)
+	require.False(t, account.IsSchedulableForModelWithContext(ctx, "claude-opus-4-8"),
+		"opus must be unschedulable while its class window is exhausted")
+	// sonnet / haiku ARE still schedulable on the same account
+	require.True(t, account.IsSchedulableForModelWithContext(ctx, "claude-sonnet-4-5"),
+		"sonnet must stay schedulable when only opus class is cooled")
+	require.True(t, account.IsSchedulableForModelWithContext(ctx, "claude-3-5-haiku-20241022"),
+		"haiku must stay schedulable when only opus class is cooled")
+
+	// remaining-time hint reflects the class cooldown for opus, zero for siblings
+	require.InDelta(t, time.Until(resetAt).Seconds(),
+		account.GetRateLimitRemainingTimeWithContext(ctx, "claude-opus-4-8").Seconds(), 2)
+	require.Zero(t, account.GetRateLimitRemainingTimeWithContext(ctx, "claude-sonnet-4-5"))
+}
+
+func TestG4_ResetRecovery_OpusSchedulableAfterReset(t *testing.T) {
+	// reset already in the past → cooldown expired → opus schedulable again.
+	pastReset := time.Now().Add(-1 * time.Minute)
+	account := &Account{
+		ID:          903,
+		Platform:    PlatformAnthropic,
+		Type:        AccountTypeOAuth,
+		Status:      StatusActive,
+		Schedulable: true,
+		Extra: map[string]any{
+			modelRateLimitsKey: map[string]any{
+				tkModelClassScope("opus"): map[string]any{
+					"rate_limit_reset_at": pastReset.Format(time.RFC3339),
+				},
+			},
+		},
+	}
+	ctx := context.Background()
+	require.True(t, account.IsSchedulableForModelWithContext(ctx, "claude-opus-4-8"),
+		"opus must recover once the class cooldown reset time has passed")
+	require.Zero(t, account.GetRateLimitRemainingTimeWithContext(ctx, "claude-opus-4-8"))
+}
+
+// --- account-level errors stay account-level (NOT model-scoped) ---------------
+
+func TestG4_CreditBalance400_StaysAccountLevel(t *testing.T) {
+	repo := &rateLimitAccountRepoStub{}
+	svc := newG4RateLimitService(repo)
+	account := &Account{ID: 904, Platform: PlatformAnthropic, Type: AccountTypeAPIKey}
+
+	shouldDisable := svc.HandleUpstreamError(
+		context.Background(),
+		account,
+		http.StatusBadRequest,
+		http.Header{},
+		[]byte(`{"error":{"type":"invalid_request_error","message":"Your credit balance is too low"}}`),
+		"claude-opus-4-8",
+	)
+
+	require.True(t, shouldDisable, "credit balance exhaustion disables the whole account")
+	require.Empty(t, repo.modelRateLimitCalls,
+		"credit balance is an account-level failure, never model-scoped")
+	require.Greater(t, repo.setErrorCalls, 0, "credit balance → SetError (account-level)")
+}
+
+func TestG4_OAuth401_StaysAccountLevel(t *testing.T) {
+	repo := &rateLimitAccountRepoStub{}
+	svc := newG4RateLimitService(repo)
+	account := &Account{
+		ID:       905,
+		Platform: PlatformAnthropic,
+		Type:     AccountTypeOAuth,
+		Credentials: map[string]any{
+			"refresh_token": "rt-present",
+		},
+	}
+
+	svc.HandleUpstreamError(
+		context.Background(),
+		account,
+		http.StatusUnauthorized,
+		http.Header{},
+		[]byte(`{"error":{"type":"authentication_error","message":"invalid token"}}`),
+		"claude-opus-4-8",
+	)
+
+	require.Empty(t, repo.modelRateLimitCalls,
+		"401 auth failure is account-level (temp-unschedulable for token refresh), never model-scoped")
+	require.Greater(t, repo.tempCalls, 0, "OAuth 401 → SetTempUnschedulable (account-level)")
+}
+
+func TestG4_529Overloaded_StaysAccountLevel(t *testing.T) {
+	repo := &rateLimitAccountRepoStub{}
+	svc := NewRateLimitService(repo, nil, &config.Config{
+		RateLimit: config.RateLimitConfig{OverloadCooldownMinutes: 5},
+	}, nil, nil)
+	svc.SetAnthropicUpstreamErrorCounterCache(&anthropicUpstreamErrorCounterCacheStub{
+		counts:     []int64{1},
+		tierCounts: []int64{0},
+	})
+	account := &Account{ID: 906, Platform: PlatformAnthropic, Type: AccountTypeOAuth}
+
+	svc.HandleUpstreamError(
+		context.Background(),
+		account,
+		529,
+		http.Header{},
+		[]byte(`{"error":{"type":"overloaded_error","message":"overloaded"}}`),
+		"claude-opus-4-8",
+	)
+
+	require.Empty(t, repo.modelRateLimitCalls,
+		"529 overloaded is account-wide capacity pressure, never model-scoped")
+	require.Greater(t, repo.setOverloadedCalls, 0, "529 → SetOverloaded (account-level)")
+}
+
+// --- fallback: unknown model class → account-level ----------------------------
+
+func TestG4_UnknownModelClass_FallsBackToAccountLevel(t *testing.T) {
+	repo := &rateLimitAccountRepoStub{}
+	svc := newG4RateLimitService(repo)
+	account := &Account{ID: 907, Platform: PlatformAnthropic, Type: AccountTypeOAuth}
+
+	resetAt := time.Now().Add(90 * time.Minute).Unix()
+	svc.HandleUpstreamError(
+		context.Background(),
+		account,
+		http.StatusTooManyRequests,
+		anthropic5hExceededHeaders(resetAt),
+		[]byte(`{"error":{"type":"rate_limit_error","message":"unified 5h limit reached"}}`),
+		"some-non-anthropic-model",
+	)
+
+	require.Empty(t, repo.modelRateLimitCalls,
+		"unknown model class cannot be safely narrowed → no model-scoped write")
+	require.Equal(t, 1, repo.setRateLimitedCalls,
+		"unknown model class falls back to account-level SetRateLimited so the window is still cooled")
+}
+
+func TestG4_NoModelContext_FallsBackToAccountLevel(t *testing.T) {
+	repo := &rateLimitAccountRepoStub{}
+	svc := newG4RateLimitService(repo)
+	account := &Account{ID: 908, Platform: PlatformAnthropic, Type: AccountTypeOAuth}
+
+	resetAt := time.Now().Add(90 * time.Minute).Unix()
+	// No requestedModel argument — e.g. a call site that doesn't thread the model.
+	svc.HandleUpstreamError(
+		context.Background(),
+		account,
+		http.StatusTooManyRequests,
+		anthropic5hExceededHeaders(resetAt),
+		[]byte(`{"error":{"type":"rate_limit_error","message":"unified 5h limit reached"}}`),
+	)
+
+	require.Empty(t, repo.modelRateLimitCalls,
+		"no model context → cannot scope → no model-scoped write")
+	require.Equal(t, 1, repo.setRateLimitedCalls,
+		"no model context falls back to account-level SetRateLimited")
+}
+
+// --- non-Anthropic platforms are untouched ------------------------------------
+
+func TestG4_NonAnthropicPlatform_NoModelClassCooldown(t *testing.T) {
+	account := &Account{ID: 909, Platform: PlatformOpenAI}
+	require.False(t, account.tkAnthropicModelClassRateLimitActive("claude-opus-4-8"))
+	require.Zero(t, account.tkAnthropicModelClassRateLimitRemaining("claude-opus-4-8"))
+}

--- a/backend/internal/service/ratelimit_service_tk_model_cooldown_test.go
+++ b/backend/internal/service/ratelimit_service_tk_model_cooldown_test.go
@@ -108,6 +108,11 @@ func TestG4_OpusUnifiedWindow429_CoolsModelClassNotAccount(t *testing.T) {
 	require.Equal(t, tkModelClassScope("opus"), call.scope)
 	require.Equal(t, tkAnthropicModelCooldownReason, call.reason)
 	require.WithinDuration(t, time.Unix(resetAt, 0), call.resetAt, 2*time.Second)
+	// account-global 5h window is still recorded (operator usage gauge depends
+	// on it) — only the cooldown SCOPE narrowed, not the window signal.
+	require.Equal(t, 1, repo.updateSessionWindowCalls,
+		"model-scoped cooldown must still record the account-global 5h session window")
+	require.Equal(t, "rejected", repo.lastSessionWindowStatus)
 }
 
 func TestG4_OpusCooled_SonnetHaikuStillSchedulable(t *testing.T) {

--- a/scripts/sentinels/gateway-tk.json
+++ b/scripts/sentinels/gateway-tk.json
@@ -1757,6 +1757,34 @@
         "Retry-After"
       ],
       "rationale": "Empty-pool fast-fail returns 429+Retry-After (not 503) so Caddy passive-health on the single Stage0 upstream does not conflate an empty scheduling pool with a backend outage and stall all traffic incl. the dashboard. An upstream merge re-introducing 503 at the account-select call sites regresses the prod flood-containment fix (PR #572 / IP 58.213.121.60 1540 RPM incident)."
+    },
+    {
+      "path": "backend/internal/service/ratelimit_service_tk_model_cooldown.go",
+      "must_contain": [
+        "func tkAnthropicModelClass(model string) string",
+        "anthropicModelClassRateLimitPrefix = \"anthropic:class:\"",
+        "func (s *RateLimitService) tkTryAnthropicModelScopedCooldown(",
+        "SetModelRateLimit(ctx, account.ID, scopeKey, resetAt, tkAnthropicModelCooldownReason)",
+        "func (a *Account) tkAnthropicModelClassRateLimitActive(requestedModel string) bool"
+      ],
+      "rationale": "G4 model-dimension cooldown companion. Anthropic OAuth accounts share a unified 5h/7d window across model classes; when opus exhausts it, upstream returns a unified-window 429 and the LEGACY behaviour cooled the WHOLE account (SetRateLimited), taking healthy sonnet/haiku offline (prod edge us6, account edge-ls-oh-3-d). This file scopes that cooldown to (account x model class) via the existing model_rate_limits store with an 'anthropic:class:<opus|sonnet|haiku>' scope key (mirrors the antigravity 'antigravity:gemini' family-key precedent). Losing tkTryAnthropicModelScopedCooldown / tkAnthropicModelClass on an upstream merge would silently re-introduce the account-level amplification; this sentinel catches that."
+    },
+    {
+      "path": "backend/internal/service/ratelimit_service.go",
+      "must_contain": [
+        "if len(requestedModel) > 0 && s.tkTryAnthropicModelScopedCooldown(ctx, account, requestedModel[0], result) {",
+        "rateLimitSet := s.handle429(ctx, account, headers, responseBody, requestedModel...)"
+      ],
+      "rationale": "G4 injection point in the upstream-shaped handle429 / case-429 dispatch. The Anthropic per-window (5h/7d) branch must try the (account x model class) cooldown BEFORE the account-level SetRateLimited fallback, and the dispatch must thread requestedModel into handle429. An upstream merge that rewrites the 429 path or drops the requestedModel passthrough would silently revert G4 back to account-level cooldown; this sentinel anchors both the call and the threading."
+    },
+    {
+      "path": "backend/internal/service/model_rate_limit.go",
+      "must_contain": [
+        "case PlatformAnthropic:",
+        "if a.tkAnthropicModelClassRateLimitActive(requestedModel) {",
+        "a.tkAnthropicModelClassRateLimitRemaining(requestedModel)"
+      ],
+      "rationale": "G4 read-side gate. The scheduler's IsSchedulableForModelWithContext -> isModelRateLimitedWithContext gate must honour the Anthropic model-class scope key alongside the exact-model-name key, so a cooled opus class keeps sibling sonnet/haiku schedulable (and GetModelRateLimitRemainingTimeWithContext surfaces the class cooldown for retry hints). An upstream merge that rewrites this read path would drop the class-scope check and make the write-side G4 cooldown invisible to scheduling; this sentinel anchors the read injection."
     }
   ]
 }


### PR DESCRIPTION
## G4 — model-dimension cooldown for Anthropic unified-window 429s

### Goal
Converge the cooldown for Anthropic **unified-window (5h/7d) rate limits** from **account-level** to **(account × model class)** level. When opus exhausts the shared 5h window, only the opus class is cooled — healthy sonnet/haiku on the same account keep scheduling.

### Online root-cause (why this matters)
Anthropic subscription (OAuth) accounts share **one rolling "unified 5h/7d" usage window across ALL model classes**. When the heaviest class (typically opus, which burns fastest) exhausts the 5h window, upstream returns a real `429 rate_limit_error`. The gateway's `handle429` parses the `anthropic-ratelimit-unified-5h-*` headers (logged as `anthropic_429_window_analysis is_5h_exceeded=true / is_7d_exceeded=false / reset_5h=<unix>`).

The **previous behaviour** then called `SetRateLimited`, which is **account-level**: it pulled the *whole account* out of scheduling until reset (commonly ~1h).

**Prod evidence (edge us6, single account `edge-ls-oh-3-d`):** opus exhausted the 5h window with reset at 11:30, so the account-level cooldown took the entire account offline — **including the still-perfectly-healthy sonnet and haiku classes**. The account wasn't broken; only opus's slice of the shared window was full. The account-level cooldown amplified "opus window full" into "entire account offline", wasting healthy sonnet/haiku capacity for ~1h.

### Implementation
**Write side** (`handle429`, `ratelimit_service.go` + `ratelimit_service_tk_model_cooldown.go`):
- In the Anthropic per-window (5h/7d exceeded) branch, when the requested model resolves to a known class, write a **model-class-scoped** cooldown — scope key `anthropic:class:<opus|sonnet|haiku>` — via the existing `SetModelRateLimit` store, instead of account-level `SetRateLimited`.
- Returns authoritative `true` so the 3/3 ladder's `SetTempUnschedulable` write stays suppressed (preserves the existing last-write-wins semantics for the authoritative reset).
- `requestedModel` is threaded into `handle429` (the dispatch already had it as a variadic on `HandleUpstreamError`).

**Read side** (`model_rate_limit.go`):
- The scheduler's `IsSchedulableForModelWithContext` → `isModelRateLimitedWithContext` gate now honours the class-scope key alongside the exact-model-name key, mirroring the existing antigravity `antigravity:gemini` family-key precedent. `GetModelRateLimitRemainingTimeWithContext` surfaces the class cooldown for retry hints.
- The gate is consulted **uniformly** across load-balance, sticky-binding revalidation, and recheck paths (all route through `isAccountSchedulableForModelSelection`). A sticky binding to a cooled opus fails the model-selection gate and fails over to load-balance (which still finds the account viable for sonnet/haiku).

**Preserved account-level behaviour (NOT model-scoped):** 401/403 auth, credit balance, org disabled, KYC, 529 overloaded, and the no-reset-header 429 fallback. Unknown model class / no model context / non-Anthropic all fall back to the unchanged account-level path, so a window is never left uncooled.

### Key design decision — reuse the model_rate_limits store, not a parallel Redis layer
The existing `model_rate_limits` map in `account.Extra` is *already* the precise (account × scope) cooldown the scheduler consults:
- partitions cooldown by scope within an account,
- read by the scheduler's model-selection gate,
- durable (accounts.extra JSONB + scheduler snapshot via outbox),
- self-expiring (reads compare `time.Now()` against `rate_limit_reset_at`; cleared by `ClearModelRateLimits` on recovery).

A parallel Redis layer would mean a **second source of truth** the scheduler must also consult, a new repository interface method, and test-stub fan-out. Reusing the existing store with a class-scope key is the more convergent, lower-surface choice — no new interface, no second read path — and matches the antigravity family-key precedent. (Jobs lens: converge, don't add a parallel system.)

### Test coverage
`ratelimit_service_tk_model_cooldown_test.go`:
- opus 5h exceeded → **only opus class cooled**, account-level `SetRateLimited` NOT called, 3/3 ladder suppressed.
- opus cooled → **sonnet + haiku still schedulable** on the same account; remaining-time hint reflects opus cooldown, zero for siblings.
- reset recovery → opus schedulable again once reset passes.
- account-level errors stay account-level: credit balance 400 → `SetError`; OAuth 401 → `SetTempUnschedulable`; 529 → `SetOverloaded`; none write model-scoped.
- fallback: unknown model class / no model context → account-level `SetRateLimited`.
- model-class normalization boundaries: version suffixes, `[1m]` context tags, `anthropic/` provider prefixes, case-insensitivity, non-Anthropic models.

### Quality gates
- `go build ./...` (cross-repo new-api compiles) ✅
- `go test -tags=unit ./...` ✅
- `golangci-lint run ./...` — 0 issues ✅
- `go build -tags=integration ./...` ✅
- `bash scripts/preflight.sh` — PASS ✅

### Risk & trade-offs
- The model-class scope is **substring-based** (opus/sonnet/haiku). New Anthropic class names would need adding to `tkAnthropicModelClass` — but the fallback for an unknown class is the safe account-level path, so a new class never goes uncooled, it just isn't narrowed until added. Sentinel anchors in `scripts/sentinels/gateway-tk.json` guard the load-bearing G4 surfaces against silent removal on a future upstream merge.
- Out of scope by design (parallel PR owns these): G1/G2 client-induced 400/413 exemptions and downstream-gateway-error exemptions. This PR only touches the model-dimension cooldown.

🤖 Generated with [Claude Code](https://claude.com/claude-code)