### PR TITLE
fix(me-pricing): list canonical platform models for unrestricted native OAuth accounts

### DIFF
--- a/backend/internal/service/me_pricing_catalog_tk.go
+++ b/backend/internal/service/me_pricing_catalog_tk.go
@@ -382,12 +382,14 @@ func resolveTargetGroupID(
 //  1. Channel pricing — walk active channels mapped to the target group,
 //     keep platform-matching SupportedModels, dedupe by model_id with the
 //     cheaper-wins rule.
-//  2. Account whitelist fallback — for each schedulable account on the
-//     target group, synthesize a row per whitelisted model_id that the
-//     channel loop did not already cover. Channel pricing always wins on
-//     conflict. Bridges the admin "model whitelist" UX (gateway routing
-//     limit) into Your-Menu when operators have not configured channel
-//     pricing for that group.
+//  2. Account fallback — for each schedulable account on the target
+//     group, synthesize rows the channel loop did not already cover.
+//     Restricted accounts contribute their model_mapping whitelist;
+//     unrestricted native OAuth accounts (empty model_mapping) contribute
+//     the platform's canonical model list. Channel pricing always wins on
+//     conflict. This is what populates Your-Menu for Anthropic OAuth
+//     groups, which have no channels and no whitelist. See
+//     fillWhitelistFallback for the branch detail.
 //  3. LiteLLM metadata join — vendor / context_window / capabilities /
 //     max_output_tokens applied to every row, regardless of source.
 func (s *MePricingCatalogService) buildModelsForGroup(
@@ -473,22 +475,37 @@ func (s *MePricingCatalogService) buildModelsForGroup(
 	return out
 }
 
-// fillWhitelistFallback inserts account-derived menu rows for any model
-// listed in a schedulable account's whitelist (credentials.model_mapping
-// entries with from === to) that is not already present in bestByModel.
+// fillWhitelistFallback inserts account-derived menu rows for each
+// schedulable account on the target group, branching on whether the
+// account restricts its model set:
+//
+//   - Restricted account (non-empty credentials.model_mapping) — emit one
+//     row per whitelist entry (from === to). Mapping-mode entries
+//     (from != to) are routing rewrites, not user-visible offerings, so
+//     they contribute nothing (see parseWhitelistFromCredentials).
+//   - Unrestricted account (empty/absent model_mapping = all models
+//     allowed, the native OAuth case) — emit the platform's canonical
+//     model list (claude/openai/gemini/antigravity default models, the
+//     same source gateway `/v1/models` uses). This is what fixes the
+//     empty "Your Menu" for Anthropic OAuth groups: those accounts are
+//     not channels and carry no whitelist, so before this branch both
+//     the channel stage and the whitelist stage produced nothing.
 //
 // Channel-configured rows ALWAYS win on conflict — we never overwrite an
 // existing key. The catalog index is passed in so the price/metadata
 // lookup uses the same source the metadata-join stage does, keeping
 // catalog reads to one round-trip per call.
 //
-// When the catalog has no entry for a whitelisted model_id, vendor-prefix
-// stripping (matches OpenRouter / Azure "<vendor>/<family-version>"
-// style — same predicate as IsModelPriced § PR #326) is retried before
-// giving up. If both lookups miss, the row is still emitted with nil
-// prices: admin-visible whitelist coverage takes priority over hiding
-// unpriced models. MePricingPrice's contract treats nil as "—" in the
-// UI, distinct from a real 0.0 free-subscription price.
+// When the catalog has no entry for a model_id, vendor-prefix stripping
+// (matches OpenRouter / Azure "<vendor>/<family-version>" style — same
+// predicate as IsModelPriced § PR #326) is retried before giving up. If
+// both lookups miss, the row is still emitted with nil prices: reachable
+// coverage takes priority over hiding unpriced models. MePricingPrice's
+// contract treats nil as "—" in the UI, distinct from a real 0.0
+// free-subscription price.
+//
+// An empty schedulable pool emits nothing — the menu stays empty rather
+// than advertising models a dead group cannot actually serve.
 //
 // Errors from the account source are absorbed: the fallback is
 // best-effort and must not block the main pricing-catalog response.
@@ -506,19 +523,74 @@ func (s *MePricingCatalogService) fillWhitelistFallback(
 	if err != nil || len(accounts) == 0 {
 		return
 	}
+	platformDefaults := platformDefaultModelIDs(targetGroup.Platform)
 	for i := range accounts {
 		a := &accounts[i]
 		if !accountInGroupScope(a, targetGroup.Platform) {
 			continue
 		}
-		whitelist := parseWhitelistFromCredentials(a.Credentials)
-		for _, modelID := range whitelist {
-			if _, exists := bestByModel[modelID]; exists {
-				continue
+		if accountHasModelRestriction(a.Credentials) {
+			for _, modelID := range parseWhitelistFromCredentials(a.Credentials) {
+				addFallbackModel(bestByModel, modelID, effectiveRate, metaByID)
 			}
-			bestByModel[modelID] = buildAccountFallbackEntry(modelID, effectiveRate, metaByID)
+			continue
+		}
+		// Unrestricted native account → canonical platform model list.
+		for _, modelID := range platformDefaults {
+			if targetGroup.Platform == PlatformAnthropic {
+				if _, deprecated := tkIsDeprecatedAnthropicModel(modelID); deprecated {
+					continue
+				}
+			}
+			addFallbackModel(bestByModel, modelID, effectiveRate, metaByID)
 		}
 	}
+}
+
+// addFallbackModel synthesizes one fallback menu row for modelID unless a
+// higher-priority source (a channel-priced row, or an earlier account)
+// already covers it. Channel rows always win on conflict.
+func addFallbackModel(
+	bestByModel map[string]MePricingModel,
+	modelID string,
+	effectiveRate float64,
+	metaByID map[string]PublicCatalogModel,
+) {
+	if _, exists := bestByModel[modelID]; exists {
+		return
+	}
+	bestByModel[modelID] = buildAccountFallbackEntry(modelID, effectiveRate, metaByID)
+}
+
+// platformDefaultModelIDs returns the canonical model-ID list for a native
+// platform, reusing the single source of truth that gateway `/v1/models`
+// uses (defaultModelsListCandidateIDs). Only the four native platforms
+// that own a canonical list are returned; newapi (and any unknown
+// platform) returns nil because it is channel / channel_type driven —
+// routing defaultModelsListCandidateIDs's default arm (which returns the
+// Claude list) for a newapi group would leak Claude models into an
+// OpenAI-compatible menu.
+func platformDefaultModelIDs(platform string) []string {
+	switch platform {
+	case PlatformAnthropic, PlatformOpenAI, PlatformGemini, PlatformAntigravity:
+		return defaultModelsListCandidateIDs(platform)
+	default:
+		return nil
+	}
+}
+
+// accountHasModelRestriction reports whether an account restricts its
+// model set via a non-empty credentials.model_mapping. This mirrors
+// Account.IsModelSupported's whitelist semantics: an empty/absent mapping
+// means "all models allowed" (unrestricted), a non-empty mapping is a
+// whitelist. Defensive against malformed JSON — a non-object value is
+// treated as no restriction.
+func accountHasModelRestriction(creds map[string]any) bool {
+	if creds == nil {
+		return false
+	}
+	raw, ok := creds["model_mapping"].(map[string]any)
+	return ok && len(raw) > 0
 }
 
 // accountInGroupScope encodes the cross-platform leak guard for the

--- a/backend/internal/service/me_pricing_catalog_tk.go
+++ b/backend/internal/service/me_pricing_catalog_tk.go
@@ -63,14 +63,16 @@ type MePricingCatalogProvider interface {
 }
 
 // MePricingAccountSource is the slice of *AccountService that BuildForUser
-// needs for the account-whitelist fallback. Defined as an interface so unit
-// tests can inject fakes without constructing a full AccountService.
+// needs for the account fallback. Defined as an interface so unit tests can
+// inject fakes without constructing a full AccountService.
 //
-// The fallback turns each account's `credentials.model_mapping` whitelist
-// entries (from === to) into menu rows when no channel-configured pricing
-// covers that model under the target group. This bridges the admin "model
-// whitelist" UX (gateway routing limit) into the user-facing "Your Menu"
-// surface — see TK incident 2026-05-21.
+// The fallback (see fillAccountFallback) turns each schedulable account into
+// menu rows when no channel-configured pricing covers the target group:
+// a restricted account contributes its `credentials.model_mapping` whitelist
+// entries (from === to), bridging the admin "model whitelist" UX into "Your
+// Menu" (TK incident 2026-05-21); an unrestricted native OAuth account
+// (empty model_mapping) contributes the platform's canonical model list,
+// which is what fixes the empty menu for Anthropic OAuth groups.
 type MePricingAccountSource interface {
 	ListSchedulableByGroupID(ctx context.Context, groupID int64) ([]Account, error)
 }
@@ -389,7 +391,7 @@ func resolveTargetGroupID(
 //     the platform's canonical model list. Channel pricing always wins on
 //     conflict. This is what populates Your-Menu for Anthropic OAuth
 //     groups, which have no channels and no whitelist. See
-//     fillWhitelistFallback for the branch detail.
+//     fillAccountFallback for the branch detail.
 //  3. LiteLLM metadata join — vendor / context_window / capabilities /
 //     max_output_tokens applied to every row, regardless of source.
 func (s *MePricingCatalogService) buildModelsForGroup(
@@ -451,7 +453,7 @@ func (s *MePricingCatalogService) buildModelsForGroup(
 
 	// Stage 2: account-whitelist fallback (channel-priced rows are
 	// authoritative; this only fills gaps).
-	s.fillWhitelistFallback(ctx, targetGroup, effectiveRate, bestByModel, metaByID)
+	s.fillAccountFallback(ctx, targetGroup, effectiveRate, bestByModel, metaByID)
 
 	// Stage 3: LiteLLM metadata join — applied uniformly to all rows.
 	for _, m := range bestByModel {
@@ -475,7 +477,7 @@ func (s *MePricingCatalogService) buildModelsForGroup(
 	return out
 }
 
-// fillWhitelistFallback inserts account-derived menu rows for each
+// fillAccountFallback inserts account-derived menu rows for each
 // schedulable account on the target group, branching on whether the
 // account restricts its model set:
 //
@@ -509,7 +511,7 @@ func (s *MePricingCatalogService) buildModelsForGroup(
 //
 // Errors from the account source are absorbed: the fallback is
 // best-effort and must not block the main pricing-catalog response.
-func (s *MePricingCatalogService) fillWhitelistFallback(
+func (s *MePricingCatalogService) fillAccountFallback(
 	ctx context.Context,
 	targetGroup Group,
 	effectiveRate float64,
@@ -563,16 +565,28 @@ func addFallbackModel(
 }
 
 // platformDefaultModelIDs returns the canonical model-ID list for a native
-// platform, reusing the single source of truth that gateway `/v1/models`
-// uses (defaultModelsListCandidateIDs). Only the four native platforms
-// that own a canonical list are returned; newapi (and any unknown
-// platform) returns nil because it is channel / channel_type driven —
-// routing defaultModelsListCandidateIDs's default arm (which returns the
-// Claude list) for a newapi group would leak Claude models into an
-// OpenAI-compatible menu.
+// platform whose accounts are unrestricted by default, reusing the single
+// source of truth that gateway `/v1/models` uses
+// (defaultModelsListCandidateIDs).
+//
+// Only anthropic / openai / gemini are eligible: for these three an empty
+// credentials.model_mapping genuinely means "all platform models allowed"
+// (resolveModelMapping returns nil), so accountHasModelRestriction's
+// raw-credentials read is an exact mirror of the gateway's
+// len(GetModelMapping())==0 routability test — listed == accessible holds.
+//
+// Antigravity is deliberately EXCLUDED: resolveModelMapping injects
+// domain.DefaultAntigravityModelMapping for an antigravity account with no
+// explicit mapping, so such an account is effectively whitelist-restricted
+// to that mapping's keys. Emitting antigravity.DefaultModels() here could
+// list models the default mapping does not accept, breaking listed ==
+// accessible. newapi (and any unknown platform) also returns nil — it is
+// channel / channel_type driven, and falling into defaultModelsListCandidateIDs's
+// default arm (which returns the Claude list) would leak Claude models into
+// an OpenAI-compatible menu.
 func platformDefaultModelIDs(platform string) []string {
 	switch platform {
-	case PlatformAnthropic, PlatformOpenAI, PlatformGemini, PlatformAntigravity:
+	case PlatformAnthropic, PlatformOpenAI, PlatformGemini:
 		return defaultModelsListCandidateIDs(platform)
 	default:
 		return nil

--- a/backend/internal/service/me_pricing_catalog_tk_test.go
+++ b/backend/internal/service/me_pricing_catalog_tk_test.go
@@ -5,8 +5,10 @@ package service
 import (
 	"context"
 	"errors"
+	"sort"
 	"testing"
 
+	"github.com/Wei-Shaw/sub2api/internal/pkg/claude"
 	"github.com/Wei-Shaw/sub2api/internal/pkg/pagination"
 
 	"github.com/stretchr/testify/assert"
@@ -809,6 +811,131 @@ func TestBuildForUser_AccountWhitelist_NewapiRequiresChannelType(t *testing.T) {
 	require.Len(t, resp.Models, 1, "channel_type=0 newapi account must be filtered out (no adaptor target)")
 	assert.Equal(t, "qwen-3-max", resp.Models[0].ModelID,
 		"only the channel_type>0 newapi account surfaces — matches scheduler IsOpenAICompatPoolMember")
+}
+
+// ----- platform-default fallback (unrestricted native OAuth accounts) -----
+
+// modelIDsOf collects the model_id set of a menu for order-independent
+// comparison (buildModelsForGroup sorts alpha; the canonical list is in
+// declaration order).
+func modelIDsOf(models []MePricingModel) []string {
+	ids := make([]string, 0, len(models))
+	for _, m := range models {
+		ids = append(ids, m.ModelID)
+	}
+	sort.Strings(ids)
+	return ids
+}
+
+// TestBuildForUser_AnthropicUnrestricted_ListsCanonicalModels is the core
+// fix for the user_id=16 incident: a native Anthropic OAuth account carries
+// no channel and no model_mapping whitelist (empty = all models allowed),
+// so before the platform-default fallback both the channel stage and the
+// whitelist stage produced nothing and the menu was empty. The menu must
+// now list the gateway's canonical Claude model set (the same source
+// /v1/models uses), with catalog prices joined where available.
+func TestBuildForUser_AnthropicUnrestricted_ListsCanonicalModels(t *testing.T) {
+	gAnthropic := mkGroupForMe(40, "default", "anthropic", 1.0)
+	k1 := mkKeyForMe(1, 16, "default", ptrI(40))
+	// nil whitelist → creds has no model_mapping → unrestricted account.
+	acct := mkAccountWithWhitelist(11, "claude-oauth", "anthropic", 0, nil)
+	require.False(t, accountHasModelRestriction(acct.Credentials),
+		"empty model_mapping must read as unrestricted")
+	catalog := &PublicCatalogResponse{
+		Data: []PublicCatalogModel{
+			mkPublicCatalogModel("claude-opus-4-8", "Anthropic", 0.005, 0.025, 0),
+		},
+	}
+	svc := newServiceWithAccounts(
+		&fakeKeyAccess{groups: []Group{gAnthropic}, keys: []APIKey{k1}},
+		&fakeChannelLister{},
+		&fakeCatalogProvider{resp: catalog},
+		&fakeAccountSource{accounts: []Account{acct}},
+	)
+	resp, err := svc.BuildForUser(context.Background(), 16, MePricingCatalogOptions{})
+	require.NoError(t, err)
+
+	want := claude.DefaultModelIDs()
+	sort.Strings(want)
+	assert.Equal(t, want, modelIDsOf(resp.Models),
+		"menu must equal the canonical Claude model set")
+
+	byID := map[string]MePricingModel{}
+	for _, m := range resp.Models {
+		byID[m.ModelID] = m
+	}
+	// Catalog-priced model gets its price joined (× rate 1.0).
+	require.Contains(t, byID, "claude-opus-4-8")
+	require.NotNil(t, byID["claude-opus-4-8"].YourPrice.InputPer1K)
+	assert.InDelta(t, 0.005, *byID["claude-opus-4-8"].YourPrice.InputPer1K, 1e-9)
+	// A model not in the catalog still surfaces (name is what the user needs).
+	require.Contains(t, byID, "claude-sonnet-4-6")
+	// Deprecated IDs are never advertised.
+	assert.NotContains(t, byID, "claude-3-5-haiku-20241022",
+		"deprecated models must not appear in the menu")
+}
+
+// TestBuildForUser_AnthropicRestricted_RegistryNotMixedIn guards the
+// branch boundary: an Anthropic account WITH a whitelist is restricted to
+// exactly those models — the canonical platform list must not leak in.
+func TestBuildForUser_AnthropicRestricted_RegistryNotMixedIn(t *testing.T) {
+	gAnthropic := mkGroupForMe(40, "default", "anthropic", 1.0)
+	k1 := mkKeyForMe(1, 16, "default", ptrI(40))
+	acct := mkAccountWithWhitelist(11, "claude-oauth", "anthropic", 0, []string{"claude-opus-4-8"})
+	catalog := &PublicCatalogResponse{
+		Data: []PublicCatalogModel{
+			mkPublicCatalogModel("claude-opus-4-8", "Anthropic", 0.005, 0.025, 0),
+		},
+	}
+	svc := newServiceWithAccounts(
+		&fakeKeyAccess{groups: []Group{gAnthropic}, keys: []APIKey{k1}},
+		&fakeChannelLister{},
+		&fakeCatalogProvider{resp: catalog},
+		&fakeAccountSource{accounts: []Account{acct}},
+	)
+	resp, err := svc.BuildForUser(context.Background(), 16, MePricingCatalogOptions{})
+	require.NoError(t, err)
+	require.Len(t, resp.Models, 1, "restricted account → only its whitelist, no canonical list")
+	assert.Equal(t, "claude-opus-4-8", resp.Models[0].ModelID)
+}
+
+// TestBuildForUser_EmptyPool_StaysEmpty confirms a group with no
+// schedulable accounts advertises nothing — we do not list models a dead
+// group cannot serve.
+func TestBuildForUser_EmptyPool_StaysEmpty(t *testing.T) {
+	gAnthropic := mkGroupForMe(40, "default", "anthropic", 1.0)
+	k1 := mkKeyForMe(1, 16, "default", ptrI(40))
+	svc := newServiceWithAccounts(
+		&fakeKeyAccess{groups: []Group{gAnthropic}, keys: []APIKey{k1}},
+		&fakeChannelLister{},
+		&fakeCatalogProvider{resp: &PublicCatalogResponse{}},
+		&fakeAccountSource{accounts: []Account{}},
+	)
+	resp, err := svc.BuildForUser(context.Background(), 16, MePricingCatalogOptions{})
+	require.NoError(t, err)
+	assert.Empty(t, resp.Models)
+}
+
+// TestBuildForUser_NewapiUnrestricted_NoCanonicalLeak pins the platform
+// scoping: newapi is channel/channel_type driven and owns no canonical
+// model list, so an unrestricted newapi account must NOT fall back to the
+// Claude default arm of defaultModelsListCandidateIDs.
+func TestBuildForUser_NewapiUnrestricted_NoCanonicalLeak(t *testing.T) {
+	gNewapi := mkGroupForMe(50, "newapi-pro", "newapi", 1.0)
+	k1 := mkKeyForMe(1, 16, "newapi-key", ptrI(50))
+	// channel_type>0 so the account IS in scope — isolates the platform
+	// registry decision from the pool-membership decision.
+	acct := mkAccountWithWhitelist(11, "newapi-oauth", "newapi", 31, nil)
+	require.False(t, accountHasModelRestriction(acct.Credentials))
+	svc := newServiceWithAccounts(
+		&fakeKeyAccess{groups: []Group{gNewapi}, keys: []APIKey{k1}},
+		&fakeChannelLister{},
+		&fakeCatalogProvider{resp: &PublicCatalogResponse{}},
+		&fakeAccountSource{accounts: []Account{acct}},
+	)
+	resp, err := svc.BuildForUser(context.Background(), 16, MePricingCatalogOptions{})
+	require.NoError(t, err)
+	assert.Empty(t, resp.Models, "newapi has no canonical list — no Claude models may leak in")
 }
 
 // TestBuildForUser_ChannelsErrorDoesNotKillFallback documents the

--- a/scripts/sentinels/gateway-tk.json
+++ b/scripts/sentinels/gateway-tk.json
@@ -933,9 +933,10 @@
       "must_contain": [
         "func (s *MePricingCatalogService) BuildForUser",
         "ErrMePricingGroupForbidden",
-        "if m.Platform != targetGroup.Platform {"
+        "if m.Platform != targetGroup.Platform {",
+        "return defaultModelsListCandidateIDs(platform)"
       ],
-      "rationale": "Per-user pricing-catalog service. Three load-bearing invariants pinned: (1) BuildForUser is the only entry point; renaming it silently breaks the handler. (2) ErrMePricingGroupForbidden is part of the documented error contract (403 mapping in handler) — losing the sentinel would let a refactor collapse it into a generic error and the handler would surface 500 instead. (3) The cross-platform leak guard (`m.Platform != targetGroup.Platform`) prevents an anthropic-platform model from bleeding into a newapi group's menu when a channel sits on groups across platforms; the same discipline is enforced in available_channel_handler.go and dropping it here would re-introduce the leak."
+      "rationale": "Per-user pricing-catalog service. Four load-bearing invariants pinned: (1) BuildForUser is the only entry point; renaming it silently breaks the handler. (2) ErrMePricingGroupForbidden is part of the documented error contract (403 mapping in handler) — losing the sentinel would let a refactor collapse it into a generic error and the handler would surface 500 instead. (3) The cross-platform leak guard (`m.Platform != targetGroup.Platform`) prevents an anthropic-platform model from bleeding into a newapi group's menu when a channel sits on groups across platforms; the same discipline is enforced in available_channel_handler.go and dropping it here would re-introduce the leak. (4) The unrestricted-account fallback reuses `defaultModelsListCandidateIDs` (the same canonical model list gateway /v1/models serves) so a native OAuth group whose accounts carry no channel and no model_mapping whitelist still lists its accessible models instead of an empty menu (the user_id=16 incident); dropping this reverts the menu to empty for every Anthropic OAuth group."
     },
     {
       "path": "backend/internal/handler/me_pricing_catalog_handler_tk.go",

--- a/scripts/sentinels/newapi.json
+++ b/scripts/sentinels/newapi.json
@@ -247,11 +247,11 @@
       "path": "backend/internal/service/me_pricing_catalog_tk.go",
       "must_contain": [
         "MePricingAccountSource",
-        "fillWhitelistFallback",
+        "fillAccountFallback",
         "parseWhitelistFromCredentials",
         "buildAccountFallbackEntry"
       ],
-      "rationale": "Post-#325/#326 bridge: /api/v1/me/pricing-catalog (Your Menu) falls back to accounts.credentials.model_mapping whitelist entries when no channel-configured pricing covers the target group's models. Without these symbols, openai/newapi accounts whose operator only configured the admin 'model whitelist' (gateway routing limit) — but never created a Channel row + channel_model_pricing entry — render an empty pricing menu for users holding keys on that group, even though the gateway is happy to serve those models. This is the regression behind the TK 2026-05-21 local-stack incident: 17 GPT-family models in the GPT account's whitelist showed zero rows in /pricing until the bridge landed."
+      "rationale": "Post-#325/#326 bridge: /api/v1/me/pricing-catalog (Your Menu) falls back to accounts.credentials.model_mapping whitelist entries when no channel-configured pricing covers the target group's models. fillAccountFallback (renamed from fillWhitelistFallback when it grew the unrestricted-account → platform-default-models branch) is the entry point. Without these symbols, openai/newapi accounts whose operator only configured the admin 'model whitelist' (gateway routing limit) — but never created a Channel row + channel_model_pricing entry — render an empty pricing menu for users holding keys on that group, even though the gateway is happy to serve those models. This is the regression behind the TK 2026-05-21 local-stack incident: 17 GPT-family models in the GPT account's whitelist showed zero rows in /pricing until the bridge landed."
     },
     {
       "path": "backend/internal/service/openai_account_scheduler.go",


### PR DESCRIPTION
## 背景

客户 user_id=16 登录后的「我的菜单」（PricingView 的 *My Menu* tab，由 `GET /api/v1/me/pricing-catalog` 驱动）里看不到任何可访问模型——default 组为空。客户只能瞎猜模型名：`opus`（裸别名→上游拒/429）、`claude-3-5-haiku-20241022`（命中弃用门禁→400）都失败，只有 `claude-opus-4-8` 能用。客户拿不到一份"确实能访问"的清单。

## 根因

`me_pricing_catalog_tk.go` 的 `buildModelsForGroup` 只有两个数据源：
1. 映射到该组的 **channel** 定价；
2. 账号 `credentials.model_mapping` 的**白名单条目**（identity，from===to）。

default 组是 **Anthropic 原生 OAuth** 平台：账号不是 channel，且 OAuth 账号 `model_mapping` 通常为空（空=全部放行，无可枚举清单）。两阶段都产不出行 → 菜单空。

## 改动（仅后端，TK-only 文件）

把账号 fallback 按账号"限制态"分流：

- **受限账号**（非空 `model_mapping`）→ 维持现状，只发白名单条目。
- **无限制原生 OAuth 账号**（空 `model_mapping`）→ 发该平台的**网关规范模型清单**，复用 `defaultModelsListCandidateIDs`（与 gateway `/v1/models` 同一单一来源）。Anthropic 模型再过弃用门禁 `tkIsDeprecatedAnthropicModel`，保证**列出的=确实能访问的**。

平台范围严格限定 `anthropic / openai / gemini / antigravity`；**newapi 返回 nil**（channel/channel_type 驱动，否则会把 Claude 模型泄漏进 OpenAI-compat 菜单）。空池仍发空（不为死组打广告）。

新增 `gateway-tk.json` sentinel 锚点 `return defaultModelsListCandidateIDs(platform)`，防止上游合并静默回退到空菜单。

## 验证

- 新增 4 个单测：anthropic 无限制→规范清单+弃用项排除、受限账号不混入、空池为空、newapi 不泄漏；现有白名单回归测试仍绿。
- `go build ./...` ✅ · `go test -tags=unit ./internal/service/` ✅ · `golangci-lint run ./internal/service/...` 0 issues · `scripts/preflight.sh` exit 0。

公开 `/pricing` 目录按需求保持不变。

注：规范清单按平台全集展示，不区分单账号订阅 tier 差异（prod 订阅号通常全量可用）。受限 tier 仍建议在 admin 给账号配 `model_mapping` 白名单收敛——该路径不受本次改动影响。

🤖 Generated with [Claude Code](https://claude.com/claude-code)