### PR TITLE
fix(edge-accounts): surface prod stub 关调度 state on the cross-edge overview

### DIFF
--- a/backend/internal/service/edge_accounts_aggregator_tk.go
+++ b/backend/internal/service/edge_accounts_aggregator_tk.go
@@ -62,12 +62,22 @@ type edgeAccountsStore interface {
 // sanitized, credential-free edgeAccountDTO with its live capacity/today gauges)
 // is owned solely by the edge handler and the frontend TS type. Prod just relays
 // it verbatim, so adding an account field never requires touching this file.
+//
+// StubSchedulable mirrors the prod-side mirror stub's own scheduling toggle (the
+// account whose api-key prod uses to reach this edge). It is the operator's
+// "route prod traffic to this edge / don't" switch: turning scheduling off on the
+// stub (关调度) takes the edge out of prod rotation while leaving the edge itself
+// reachable. The overview lists the edge's own accounts regardless, so without
+// surfacing this the operator can't tell from the overview that prod has stopped
+// routing here. It is false only when the stub is reachable-but-paused; a fully
+// disabled stub is dropped from the aggregate entirely (see discoverEdgeTargets).
 type EdgeAccountsResult struct {
-	EdgeID   string            `json:"edge_id"`
-	BaseURL  string            `json:"base_url"`
-	OK       bool              `json:"ok"`
-	Error    string            `json:"error,omitempty"`
-	Accounts []json.RawMessage `json:"accounts"`
+	EdgeID          string            `json:"edge_id"`
+	BaseURL         string            `json:"base_url"`
+	OK              bool              `json:"ok"`
+	Error           string            `json:"error,omitempty"`
+	StubSchedulable bool              `json:"stub_schedulable"`
+	Accounts        []json.RawMessage `json:"accounts"`
 }
 
 // EdgeAccountsAggregate is the full cross-edge payload returned to the admin UI.
@@ -89,11 +99,14 @@ func NewEdgeAccountsAggregator(accounts edgeAccountsStore, client httpDoer) *Edg
 	return &EdgeAccountsAggregator{accounts: accounts, http: client}
 }
 
-// edgeTarget is a deduped {base_url, api_key, edge_id} discovered from a stub.
+// edgeTarget is a deduped {base_url, api_key, edge_id} discovered from a stub,
+// plus the stub's own scheduling toggle so the overview can show whether prod is
+// still routing to this edge (see EdgeAccountsResult.StubSchedulable).
 type edgeTarget struct {
-	edgeID  string
-	baseURL string
-	apiKey  string
+	edgeID      string
+	baseURL     string
+	apiKey      string
+	schedulable bool
 }
 
 // Aggregate discovers mirror-stub edges and concurrently reads each edge's
@@ -176,9 +189,10 @@ func discoverEdgeTargets(accounts []Account, re *regexp.Regexp) []edgeTarget {
 		}
 		seen[baseURL] = struct{}{}
 		targets = append(targets, edgeTarget{
-			edgeID:  edgeIDFromBaseURL(baseURL),
-			baseURL: baseURL,
-			apiKey:  apiKey,
+			edgeID:      edgeIDFromBaseURL(baseURL),
+			baseURL:     baseURL,
+			apiKey:      apiKey,
+			schedulable: acct.Schedulable,
 		})
 	}
 	return targets
@@ -221,7 +235,7 @@ func edgeIDFromBaseURL(baseURL string) string {
 // x-api-key auth and an 8s timeout. Any failure → {ok:false, error}, never a
 // panic and never a failed aggregate.
 func (a *EdgeAccountsAggregator) fetchEdgeAccounts(ctx context.Context, t edgeTarget, platform string) EdgeAccountsResult {
-	res := EdgeAccountsResult{EdgeID: t.edgeID, BaseURL: t.baseURL, Accounts: []json.RawMessage{}}
+	res := EdgeAccountsResult{EdgeID: t.edgeID, BaseURL: t.baseURL, StubSchedulable: t.schedulable, Accounts: []json.RawMessage{}}
 	if a.http == nil {
 		res.Error = "no http client"
 		return res

--- a/backend/internal/service/edge_accounts_aggregator_tk_test.go
+++ b/backend/internal/service/edge_accounts_aggregator_tk_test.go
@@ -58,10 +58,14 @@ func (f *fakeEdgeDoer) Do(req *http.Request) (*http.Response, error) {
 }
 
 func mirrorStub(id int64, baseURL, apiKey string) Account {
+	// A normal active mirror stub is schedulable (prod routes to its edge); the
+	// "关调度" cases flip Schedulable to false explicitly.
 	return Account{
-		ID:       id,
-		Platform: PlatformAnthropic,
-		Type:     AccountTypeAPIKey,
+		ID:          id,
+		Platform:    PlatformAnthropic,
+		Type:        AccountTypeAPIKey,
+		Status:      StatusActive,
+		Schedulable: true,
 		Credentials: map[string]any{
 			"base_url": baseURL,
 			"api_key":  apiKey,
@@ -102,14 +106,17 @@ func TestEdgeAccountsAggregator_FanoutDedupAndErrorIsolation(t *testing.T) {
 	require.Equal(t, "fra1", out.Edges[0].EdgeID)
 	require.Equal(t, "us1", out.Edges[1].EdgeID)
 
-	// fra1: transport error → ok:false, isolated (aggregate still succeeds).
+	// fra1: transport error → ok:false, isolated (aggregate still succeeds). The
+	// stub's scheduling toggle is reported regardless of reachability.
 	require.False(t, out.Edges[0].OK)
 	require.Contains(t, out.Edges[0].Error, "request failed")
 	require.Empty(t, out.Edges[0].Accounts)
+	require.True(t, out.Edges[0].StubSchedulable)
 
 	// us1: ok with one account; the FIRST stub's api_key is used (dedup kept first).
 	// Accounts are opaque json.RawMessage passthrough — assert on the raw JSON.
 	require.True(t, out.Edges[1].OK)
+	require.True(t, out.Edges[1].StubSchedulable)
 	require.Len(t, out.Edges[1].Accounts, 1)
 	require.Contains(t, string(out.Edges[1].Accounts[0]), `"id":11`)
 
@@ -154,6 +161,44 @@ func TestEdgeAccountsAggregator_SkipsDisabledStub(t *testing.T) {
 	require.Equal(t, "key-us6", doer.keysSeen["api-us6.tokenkey.dev"])
 	// us7 in 'error' state is still reachable and was polled.
 	require.Equal(t, "key-us7", doer.keysSeen["api-us7.tokenkey.dev"])
+}
+
+// TestEdgeAccountsAggregator_PausedStubStillListedButFlagged covers the operator
+// "关调度" case: the prod-side stub for an edge has scheduling turned off but is
+// still active. Unlike a fully disabled stub (dropped from the aggregate), a
+// paused stub's edge is still reachable, so it must STILL be polled and listed —
+// just flagged StubSchedulable=false so the overview shows prod has stopped
+// routing there. This is the gap the fix closes: before, the paused state was
+// invisible on the cross-edge overview.
+func TestEdgeAccountsAggregator_PausedStubStillListedButFlagged(t *testing.T) {
+	paused := mirrorStub(1, "https://api-us4.tokenkey.dev", "key-us4")
+	paused.Schedulable = false // 关调度: active but taken out of prod rotation
+	active := mirrorStub(2, "https://api-us1.tokenkey.dev", "key-us1")
+
+	store := &edgeAccountsStoreStub{accounts: []Account{paused, active}}
+	doer := &fakeEdgeDoer{bodyByHost: map[string]string{
+		"api-us4.tokenkey.dev": `{"code":0,"data":{"accounts":[{"id":41,"name":"x"}]}}`,
+		"api-us1.tokenkey.dev": `{"code":0,"data":{"accounts":[]}}`,
+	}}
+
+	agg := NewEdgeAccountsAggregator(store, doer)
+	out, err := agg.Aggregate(context.Background(), "anthropic")
+	require.NoError(t, err)
+
+	// Both edges present (sorted): us1 (schedulable) and us4 (paused).
+	require.Len(t, out.Edges, 2)
+	require.Equal(t, "us1", out.Edges[0].EdgeID)
+	require.Equal(t, "us4", out.Edges[1].EdgeID)
+
+	// us4 was still polled (reachable) and its accounts listed — the pause does
+	// not hide the edge, only flags it.
+	require.Equal(t, "key-us4", doer.keysSeen["api-us4.tokenkey.dev"])
+	require.True(t, out.Edges[1].OK)
+	require.Len(t, out.Edges[1].Accounts, 1)
+
+	// The pause is now visible: us4 flagged not-schedulable, us1 schedulable.
+	require.False(t, out.Edges[1].StubSchedulable)
+	require.True(t, out.Edges[0].StubSchedulable)
 }
 
 func TestEdgeAccountsAggregator_Non2xxIsError(t *testing.T) {

--- a/backend/internal/web/dist/frontend-source.json
+++ b/backend/internal/web/dist/frontend-source.json
@@ -1,7 +1,7 @@
 {
   "algorithm": "sha256(git-ls-files:path,size,content)",
   "file_count": 454,
-  "hash": "9f616ff03d1134d89c821b2fae334222d81061bb54e1d9ec75393cd8f54cb74e",
+  "hash": "1246a93b1d9f8176a94cbfe40a2e64419f97eb3d1c98916951ffa30cdd19e7f3",
   "schema": 1,
   "source": "frontend/"
 }

--- a/frontend/src/api/admin/edgeAccounts.ts
+++ b/frontend/src/api/admin/edgeAccounts.ts
@@ -84,12 +84,18 @@ export interface EdgeTodayStats {
 /**
  * One edge's slice of the aggregate. `ok` distinguishes a reachable edge (even
  * with zero accounts) from an unreachable one (`error` set).
+ *
+ * `stub_schedulable` mirrors the prod-side mirror stub's own scheduling toggle —
+ * prod's "route traffic to this edge / don't" switch. When false the stub was
+ * 关调度 (taken out of prod rotation) while the edge itself stays reachable, so the
+ * overview flags it; see backend service.EdgeAccountsResult.StubSchedulable.
  */
 export interface EdgeAccountsResult {
   edge_id: string
   base_url: string
   ok: boolean
   error?: string
+  stub_schedulable: boolean
   accounts: EdgeAccountSummary[]
 }
 

--- a/frontend/src/i18n/locales/en.ts
+++ b/frontend/src/i18n/locales/en.ts
@@ -3115,6 +3115,9 @@ export default {
       summaryFailed: '{count} unreachable',
       accountCount: '{count} accounts',
       schedulableCount: '{count} schedulable',
+      stubPaused: 'Scheduling off',
+      stubPausedHint:
+        'The prod-side stub for this edge is paused (关调度) — prod no longer routes traffic here, though the edge itself stays reachable.',
       columns: {
         name: 'Name',
         platformType: 'Platform / Type',

--- a/frontend/src/i18n/locales/zh.ts
+++ b/frontend/src/i18n/locales/zh.ts
@@ -3190,6 +3190,8 @@ export default {
       summaryFailed: '{count} 个不可达',
       accountCount: '{count} 个账号',
       schedulableCount: '{count} 个可调度',
+      stubPaused: '调度已关闭',
+      stubPausedHint: '该 edge 在 prod 侧的 stub 已关调度——prod 不再向其调度流量，但该 edge 本身仍可达。',
       columns: {
         name: '名称',
         platformType: '平台 / 类型',

--- a/frontend/src/views/admin/EdgeAccountsView.vue
+++ b/frontend/src/views/admin/EdgeAccountsView.vue
@@ -83,6 +83,16 @@
             <div class="flex min-w-0 items-center gap-3">
               <span :class="['inline-block h-2.5 w-2.5 flex-shrink-0 rounded-full', edge.ok ? 'bg-green-500' : 'bg-red-500']"></span>
               <span class="font-semibold text-gray-900 dark:text-white">{{ edge.edge_id }}</span>
+              <!-- The prod-side mirror stub for this edge was 关调度: the edge stays
+                   reachable but prod no longer routes traffic to it. Orthogonal to
+                   the ok/unreachable dot, so flag it explicitly here. -->
+              <span
+                v-if="!edge.stub_schedulable"
+                class="inline-flex flex-shrink-0 items-center rounded-md bg-amber-100 px-2 py-0.5 text-xs font-medium text-amber-700 dark:bg-amber-900/40 dark:text-amber-300"
+                :title="t('admin.edgeAccounts.stubPausedHint')"
+              >
+                {{ t('admin.edgeAccounts.stubPaused') }}
+              </span>
               <span class="truncate text-xs text-gray-400 dark:text-gray-500">{{ edge.base_url }}</span>
             </div>
             <div class="flex items-center gap-3 text-xs text-gray-500 dark:text-gray-400">

--- a/scripts/sentinels/frontend-tk.json
+++ b/scripts/sentinels/frontend-tk.json
@@ -387,9 +387,10 @@
       "must_contain": [
         "'/admin/edge-accounts'",
         "export const edgeAccountsAPI",
-        "adminSession"
+        "adminSession",
+        "stub_schedulable: boolean"
       ],
-      "rationale": "TK-only API client for the cross-edge read-only account overview (GET /admin/edge-accounts) plus the manage-accounts handoff (POST /admin/edge-accounts/:edge/admin-session, the adminSession method). Mirrors api/admin/tier.ts. Backs the Edge Accounts admin page; silent upstream-merge deletion would break its list or adminSession call. The EdgeAccountSummary type carries notes (the non-credential operator 备注) and is platform-agnostic — the page defaults to the backend 'all' sentinel so every platform's accounts are listed, not just anthropic."
+      "rationale": "TK-only API client for the cross-edge read-only account overview (GET /admin/edge-accounts) plus the manage-accounts handoff (POST /admin/edge-accounts/:edge/admin-session, the adminSession method). Mirrors api/admin/tier.ts. Backs the Edge Accounts admin page; silent upstream-merge deletion would break its list or adminSession call. The EdgeAccountSummary type carries notes (the non-credential operator 备注) and is platform-agnostic — the page defaults to the backend 'all' sentinel so every platform's accounts are listed, not just anthropic. The EdgeAccountsResult type carries stub_schedulable — the prod-side stub's scheduling toggle — so the view can flag an edge whose stub was 关调度 (out of prod rotation but still reachable); dropping it would silently regress that visibility."
     },
     {
       "path": "frontend/src/composables/useTkEdgeAccounts.ts",
@@ -415,9 +416,11 @@
         "AccountUsageCell",
         "AccountStatusIndicator",
         "toAccountLike",
-        "toUsageInfo"
+        "toUsageInfo",
+        "!edge.stub_schedulable",
+        "admin.edgeAccounts.stubPaused"
       ],
-      "rationale": "TK-only read-only admin page grouping accounts by edge. Renders the per-edge ok/failed/timeout state and a credential-free account table that REUSES the real admin AccountCapacityCell + AccountUsageCell (today + 5h/7d windows) via toAccountLike / toUsageInfo, so the overview's capacity + usage-window gauges stay pixel-aligned with the per-edge /admin/accounts page. Guards against silent upstream-merge deletion of the view or a refactor that drops the cell reuse (which would regress the page back to a sparse static table). Also reuses AccountStatusIndicator for the 状态 column (instead of a hand-rolled badge) so it matches the per-edge admin page's status semantics; dropping it would regress status display. The platformFilter dropdown (bound through setPlatform) and the acct.notes line under the name are load-bearing: the page defaults to ALL platforms (not anthropic-only) and shows the operator 备注 like the per-edge admin page — dropping either anchor regresses the cross-platform overview or hides the remark. openEdgeManage + the manageAccounts button are the jump-to-manage entry: they mint a handoff and open the edge's own /admin/accounts in a new tab; dropping them removes cross-edge account management."
+      "rationale": "TK-only read-only admin page grouping accounts by edge. Renders the per-edge ok/failed/timeout state and a credential-free account table that REUSES the real admin AccountCapacityCell + AccountUsageCell (today + 5h/7d windows) via toAccountLike / toUsageInfo, so the overview's capacity + usage-window gauges stay pixel-aligned with the per-edge /admin/accounts page. Guards against silent upstream-merge deletion of the view or a refactor that drops the cell reuse (which would regress the page back to a sparse static table). Also reuses AccountStatusIndicator for the 状态 column (instead of a hand-rolled badge) so it matches the per-edge admin page's status semantics; dropping it would regress status display. The platformFilter dropdown (bound through setPlatform) and the acct.notes line under the name are load-bearing: the page defaults to ALL platforms (not anthropic-only) and shows the operator 备注 like the per-edge admin page — dropping either anchor regresses the cross-platform overview or hides the remark. openEdgeManage + the manageAccounts button are the jump-to-manage entry: they mint a handoff and open the edge's own /admin/accounts in a new tab; dropping them removes cross-edge account management. The edge-header stubPaused badge (shown when !edge.stub_schedulable) is the one signal that a stub was 关调度 — prod stopped routing to a still-reachable edge; dropping it re-hides that state, the gap this surfacing closed."
     },
     {
       "path": "frontend/src/views/admin/EdgeHandoffView.vue",

--- a/scripts/sentinels/gateway-tk.json
+++ b/scripts/sentinels/gateway-tk.json
@@ -1483,9 +1483,10 @@
         "func isAnthropicMirrorStub(",
         "req.Header.Set(\"x-api-key\", t.apiKey)",
         "never a failed aggregate",
-        "if acct.Status == StatusDisabled {"
+        "if acct.Status == StatusDisabled {",
+        "StubSchedulable: t.schedulable"
       ],
-      "rationale": "Prod-side cross-edge aggregator (consumer of GET /api/v1/edge/accounts). Discovers edges via the local anthropic mirror stubs (same {base_url, api_key} pairs surface-C uses — zero new secret) and fans out concurrently. Load-bearing properties: (1) per-edge failure isolation — a timeout/non-2xx/decode error on one edge yields {ok:false,error} and never fails the whole aggregate; (2) it authenticates each edge with the stub's x-api-key; (3) operator-disabled mirror stubs are skipped at discovery so a decommissioned edge (dead DNS / blackholed host) cannot drag every refresh into the per-edge 8s timeout. A silent upstream-merge weakening (e.g. propagating a single edge error to the whole response, dropping the mirror-stub predicate, or re-polling disabled stubs) must be caught."
+      "rationale": "Prod-side cross-edge aggregator (consumer of GET /api/v1/edge/accounts). Discovers edges via the local anthropic mirror stubs (same {base_url, api_key} pairs surface-C uses — zero new secret) and fans out concurrently. Load-bearing properties: (1) per-edge failure isolation — a timeout/non-2xx/decode error on one edge yields {ok:false,error} and never fails the whole aggregate; (2) it authenticates each edge with the stub's x-api-key; (3) operator-disabled mirror stubs are skipped at discovery so a decommissioned edge (dead DNS / blackholed host) cannot drag every refresh into the per-edge 8s timeout; (4) each edge result carries StubSchedulable — the prod-side stub's own scheduling toggle — so the overview can flag an edge whose stub was 关调度 (taken out of prod rotation while still reachable), the gap that motivated surfacing this field. A silent upstream-merge weakening (e.g. propagating a single edge error to the whole response, dropping the mirror-stub predicate, re-polling disabled stubs, or dropping the StubSchedulable passthrough) must be caught."
     },
     {
       "path": "backend/internal/handler/admin/edge_accounts_handler_tk.go",


### PR DESCRIPTION
## 问题

`/admin/edge-accounts` 总览页通过 prod 本地的 anthropic **mirror stub**（如 `cc-us4`）发现每个 edge，再 fan-out 列出该 edge 自己的账号。但 stub 自身的「调度开关」(`schedulable`) 从未被透出。

当运营对 `cc-us4` stub **关调度**（`schedulable=false`，`status` 仍 `active`）——即把该 edge 移出 prod 调度轮换、但 edge 本身仍可达——总览页：

- 该 edge 仍出现、仍正常拉取并展示其账号；
- **却完全看不到「prod 已停止向该 edge 调度」这一事实**。

运营无法从总览页判断自己已经把某个 edge 关掉了。

## 修复

把 prod stub 自身的 `Schedulable` 经聚合器透到每个 edge 结果上（`EdgeAccountsResult.stub_schedulable`），并在 edge 卡片头部、当 `!stub_schedulable` 时打一个琥珀色 **「调度已关闭 / Scheduling off」** 徽章。

- 默认安静、异常时醒目，正交于「可达/不可达」绿点。
- **行为不变**：完全 disabled 的 stub 仍在发现阶段被丢弃（不 fan-out，避免 8s 超时）；关调度但仍 active 的 stub 仍被拉取、账号仍列出，只是多了徽章。
- 只透出 `stub_schedulable` 一个字段，精确对应运营的「关调度」动作，不引入 UI 用不到的字段。

## 改动范围（均为 TK-only edge-accounts 功能面）

| 层 | 文件 |
|---|---|
| 后端聚合器 | `edge_accounts_aggregator_tk.go`：`edgeTarget.schedulable` + `EdgeAccountsResult.StubSchedulable` 透传 |
| 后端单测 | `edge_accounts_aggregator_tk_test.go`：新增「关调度 stub 仍列出但被标记」用例 + 既有用例断言 |
| 前端类型 | `api/admin/edgeAccounts.ts`：`EdgeAccountsResult.stub_schedulable` |
| 前端视图 | `EdgeAccountsView.vue`：edge 头部徽章 |
| i18n | `en.ts` / `zh.ts`：`stubPaused` / `stubPausedHint` |
| 防护 | `sentinels/gateway-tk.json` + `frontend-tk.json`：为新 load-bearing 字段加锚点 |

## 验证

- `go test -tags=unit ./...` — 全绿
- `go build ./...` / `go vet` / `golangci-lint run ./internal/service/...` — 全绿
- `pnpm typecheck` / `pnpm lint:check` — 全绿（唯一 warning 为无关既有测试文件）
- `pnpm run build` — 重建嵌入式 dist（`frontend-source.json` 刷新）
- `scripts/preflight.sh` — **PASS**

## 合并方式

TK fix PR → **Squash and merge**（rule §5.y）。

🤖 Generated with [Claude Code](https://claude.com/claude-code)