### PR TITLE
fix(ops/openai): stop client-induced upstream 4xx from inflating upstream_error_rate (+ pass real status through on /v1/responses)

### DIFF
--- a/backend/internal/handler/ops_error_logger.go
+++ b/backend/internal/handler/ops_error_logger.go
@@ -1222,8 +1222,18 @@ func classifyOpsErrorLog(c *gin.Context, errType, message, code string, status i
 	routingCapacityLimited := isOpsRoutingCapacityLimited(c)
 	clientBusinessLimited := service.HasOpsClientBusinessLimited(c)
 	upstreamError := hasOpsUpstreamErrorContext(c)
-	if upstreamError && !routingCapacityLimited {
+	// TK: an upstream client-induced request rejection (invalid_request_error /
+	// request_too_large / 413 / unsupported-model-for-account) is caller-fault, not
+	// provider health. Own it to the client (request phase) instead of relabeling
+	// it as upstream/provider, so it stays OUT of upstream_error_rate and the
+	// provider-health P0 capacity alert. See tkUpstreamClientInducedRejection
+	// (prod P0 2026-06-05; mirrors the #602 amplifier boundary).
+	clientInducedUpstream := upstreamError && tkUpstreamClientInducedRejection(c)
+	if upstreamError && !routingCapacityLimited && !clientInducedUpstream {
 		phase = "upstream"
+	}
+	if clientInducedUpstream && !routingCapacityLimited {
+		phase = "request"
 	}
 	if clientBusinessLimited && !upstreamError && !routingCapacityLimited {
 		phase = "auth"

--- a/backend/internal/handler/ops_error_logger_tk_client_induced_upstream.go
+++ b/backend/internal/handler/ops_error_logger_tk_client_induced_upstream.go
@@ -1,0 +1,144 @@
+package handler
+
+import (
+	"strings"
+
+	"github.com/gin-gonic/gin"
+	"github.com/tidwall/gjson"
+
+	"github.com/Wei-Shaw/sub2api/internal/service"
+)
+
+// tkUpstreamClientInducedRejection reports whether the upstream error captured on
+// the request context is a CLIENT-induced request rejection — the caller asked
+// for something the upstream refuses on request-validation grounds (bad model,
+// malformed params, oversized body) — rather than an upstream/account-health
+// failure.
+//
+// Why this exists (prod P0 2026-06-05T14:21Z, upstream_error_rate=40.32% overall):
+// Codex / ChatGPT-OAuth OpenAI accounts answer HTTP 400 invalid_request_error
+// ("The 'gpt-4o' model is not supported when using Codex with a ChatGPT account.")
+// whenever a client requests a model that account *type* cannot serve. Those are
+// caller-fault request rejections, not provider outages — yet classifyOpsErrorLog
+// blindly relabels every error carrying an upstream status code as phase=upstream
+// / error_owner=provider, so a single client looping unsupported models floods
+// upstream_error_rate (the provider-health P0 capacity alert) and pages on-call.
+// The structured columns cannot disambiguate after the fact (provider_error_type
+// is NULL and error_type is the api_error wrapper), so the fix has to live at the
+// classification (write) layer where the upstream status + message are still on
+// the context.
+//
+// This deliberately mirrors the amplifier-side boundary in
+// ratelimit_service_tk_client_induced_400.go (#602 / upstream Wei-Shaw/sub2api#2608):
+// invalid_request_error + request_too_large (and the 413 status) are client-induced;
+// the account-level 4xx signals (organization disabled / credit balance exhausted /
+// identity verification required) are NOT — they stay provider-owned because they
+// genuinely report account health and SHOULD keep counting toward upstream_error_rate.
+func tkUpstreamClientInducedRejection(c *gin.Context) bool {
+	status := tkOpsUpstreamStatusCode(c)
+	// 413 request_too_large is always caller-fault: the body cleared TokenKey's
+	// local body-limit middleware (handler.request_body_limit) but exceeded the
+	// upstream's own cap, so reaching the account at all is a caller mistake.
+	if status == 413 {
+		return true
+	}
+	// Only request-validation 4xx are caller-fault. 401/403/404 and any 5xx stay
+	// provider-owned (account auth / availability / genuine upstream failure).
+	if status != 400 && status != 422 {
+		return false
+	}
+	body, msg := tkOpsUpstreamErrorText(c)
+	combined := strings.ToLower(strings.TrimSpace(msg + "\n" + body))
+	if combined == "" {
+		return false
+	}
+	if tkOpsIsAccountLevel4xx(combined) {
+		return false
+	}
+	// Structured signal first: the upstream error envelope type.
+	if et := strings.ToLower(strings.TrimSpace(gjson.Get(body, "error.type").String())); et == "invalid_request_error" || et == "request_too_large" {
+		return true
+	}
+	// Substring fallback for shapes where the structured type is wrapped or lost
+	// (e.g. OpenAI /v1/responses surfaces an "upstream_error" envelope while the
+	// real invalid_request_error message survives only in the upstream message).
+	return strings.Contains(combined, "invalid_request_error") ||
+		strings.Contains(combined, "request_too_large") ||
+		strings.Contains(combined, "request too large") ||
+		strings.Contains(combined, "is not supported when using")
+}
+
+// tkOpsIsAccountLevel4xx matches the upstream 4xx phrases that report account
+// health rather than a caller mistake. These keep error_owner=provider so they
+// still drive upstream_error_rate / the capacity alert.
+func tkOpsIsAccountLevel4xx(lower string) bool {
+	return strings.Contains(lower, "organization has been disabled") ||
+		strings.Contains(lower, "organization disabled") ||
+		strings.Contains(lower, "credit balance") ||
+		strings.Contains(lower, "identity verification") ||
+		strings.Contains(lower, "verify your identity")
+}
+
+// tkOpsUpstreamStatusCode returns the upstream HTTP status captured on the
+// context (single-field key first, then the most recent upstream error event),
+// or 0 when none is present.
+func tkOpsUpstreamStatusCode(c *gin.Context) int {
+	if c == nil {
+		return 0
+	}
+	if v, ok := c.Get(service.OpsUpstreamStatusCodeKey); ok {
+		switch t := v.(type) {
+		case int:
+			if t > 0 {
+				return t
+			}
+		case int64:
+			if t > 0 {
+				return int(t)
+			}
+		}
+	}
+	if v, ok := c.Get(service.OpsUpstreamErrorsKey); ok {
+		if events, ok := v.([]*service.OpsUpstreamErrorEvent); ok {
+			for i := len(events) - 1; i >= 0; i-- {
+				if events[i] != nil && events[i].UpstreamStatusCode > 0 {
+					return events[i].UpstreamStatusCode
+				}
+			}
+		}
+	}
+	return 0
+}
+
+// tkOpsUpstreamErrorText gathers the upstream error body and message captured on
+// the context. The single-field message key is preferred for msg; the most recent
+// upstream error event supplies the response body (and a message fallback).
+func tkOpsUpstreamErrorText(c *gin.Context) (body string, msg string) {
+	if c == nil {
+		return "", ""
+	}
+	if v, ok := c.Get(service.OpsUpstreamErrorMessageKey); ok {
+		if s, ok := v.(string); ok {
+			msg = s
+		}
+	}
+	if v, ok := c.Get(service.OpsUpstreamErrorsKey); ok {
+		if events, ok := v.([]*service.OpsUpstreamErrorEvent); ok {
+			for i := len(events) - 1; i >= 0; i-- {
+				if events[i] == nil {
+					continue
+				}
+				if body == "" && strings.TrimSpace(events[i].UpstreamResponseBody) != "" {
+					body = events[i].UpstreamResponseBody
+				}
+				if msg == "" && strings.TrimSpace(events[i].Message) != "" {
+					msg = events[i].Message
+				}
+				if body != "" && msg != "" {
+					break
+				}
+			}
+		}
+	}
+	return body, msg
+}

--- a/backend/internal/handler/ops_error_logger_tk_client_induced_upstream_test.go
+++ b/backend/internal/handler/ops_error_logger_tk_client_induced_upstream_test.go
@@ -1,0 +1,129 @@
+package handler
+
+import (
+	"net/http"
+	"net/http/httptest"
+	"testing"
+
+	"github.com/gin-gonic/gin"
+	"github.com/stretchr/testify/require"
+
+	"github.com/Wei-Shaw/sub2api/internal/service"
+)
+
+// Prod P0 2026-06-05T14:21Z: a client looping models the Codex / ChatGPT-OAuth
+// backend cannot serve drove upstream_error_rate to 40.32% (overall) because the
+// upstream 400 invalid_request_error rejections were classified as
+// error_owner=provider and counted as upstream/provider health failures.
+//
+// These tests pin the corrected classification: client-induced upstream 4xx are
+// owned by the client (phase=request, error_owner=client) so they drop out of the
+// upstream_excl filter behind upstream_error_rate, while genuine provider failures
+// and account-level 4xx keep counting.
+func TestClassifyOpsUpstreamClientInducedRejectionOwnedByClient(t *testing.T) {
+	gin.SetMode(gin.TestMode)
+
+	t.Run("openai chat/completions unsupported-model 400 (structured invalid_request_error body)", func(t *testing.T) {
+		rec := httptest.NewRecorder()
+		c, _ := gin.CreateTestContext(rec)
+		c.Set(service.OpsUpstreamErrorsKey, []*service.OpsUpstreamErrorEvent{{
+			UpstreamStatusCode:   http.StatusBadRequest,
+			UpstreamResponseBody: `{"error":{"message":"The 'gpt-5.4-nano' model is not supported when using Codex with a ChatGPT account.","type":"invalid_request_error"}}`,
+		}})
+
+		errType := normalizeOpsErrorType("api_error", "")
+		phase, isBusinessLimited, errorOwner, errorSource := classifyOpsErrorLog(c, errType, "Upstream request failed", "", http.StatusBadRequest)
+
+		require.Equal(t, "request", phase)
+		require.Equal(t, "client", errorOwner, "must NOT be provider — otherwise it feeds upstream_error_rate")
+		require.Equal(t, "client_request", errorSource)
+		require.False(t, isBusinessLimited)
+	})
+
+	t.Run("openai /v1/responses unsupported-model surfaced as wrapped upstream_error (msg-only signal)", func(t *testing.T) {
+		// On /v1/responses the surfaced envelope type is upstream_error and the
+		// final status is 502; the only client-induced signal is the upstream
+		// message. The upstream status on the context is still 400.
+		rec := httptest.NewRecorder()
+		c, _ := gin.CreateTestContext(rec)
+		service.SetOpsUpstreamError(c, http.StatusBadRequest,
+			"The 'codex-mini-latest' model is not supported when using Codex with a ChatGPT account.", "")
+
+		phase, _, errorOwner, _ := classifyOpsErrorLog(c, "upstream_error", "Upstream request failed", "", http.StatusBadGateway)
+
+		require.Equal(t, "request", phase)
+		require.Equal(t, "client", errorOwner)
+	})
+
+	t.Run("upstream 413 request_too_large is always client-induced", func(t *testing.T) {
+		rec := httptest.NewRecorder()
+		c, _ := gin.CreateTestContext(rec)
+		service.SetOpsUpstreamError(c, http.StatusRequestEntityTooLarge, "request too large", "")
+
+		phase, _, errorOwner, _ := classifyOpsErrorLog(c, "upstream_error", "request too large", "", http.StatusRequestEntityTooLarge)
+
+		require.Equal(t, "request", phase)
+		require.Equal(t, "client", errorOwner)
+	})
+
+	t.Run("upstream 400 invalid_request_error via message substring", func(t *testing.T) {
+		rec := httptest.NewRecorder()
+		c, _ := gin.CreateTestContext(rec)
+		service.SetOpsUpstreamError(c, http.StatusBadRequest,
+			`{"type":"error","error":{"type":"invalid_request_error","message":"messages: at least one message is required"}}`, "")
+
+		phase, _, errorOwner, _ := classifyOpsErrorLog(c, "api_error", "invalid request", "", http.StatusBadRequest)
+
+		require.Equal(t, "request", phase)
+		require.Equal(t, "client", errorOwner)
+	})
+}
+
+func TestClassifyOpsGenuineUpstreamErrorsStayProvider(t *testing.T) {
+	gin.SetMode(gin.TestMode)
+
+	cases := []struct {
+		name    string
+		status  int
+		message string
+		errType string
+		final   int
+	}{
+		{"upstream 500 internal", http.StatusInternalServerError, "internal server error", "upstream_error", http.StatusBadGateway},
+		{"upstream 401 account auth", http.StatusUnauthorized, "unauthorized", "authentication_error", http.StatusUnauthorized},
+		{"upstream 403 forbidden", http.StatusForbidden, "forbidden", "upstream_error", http.StatusForbidden},
+		{"account-level 400 organization disabled", http.StatusBadRequest, "This organization has been disabled.", "api_error", http.StatusBadRequest},
+		{"account-level 400 credit balance", http.StatusBadRequest, "Your credit balance is too low to access the API.", "api_error", http.StatusBadRequest},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			rec := httptest.NewRecorder()
+			c, _ := gin.CreateTestContext(rec)
+			service.SetOpsUpstreamError(c, tc.status, tc.message, "")
+
+			phase, _, errorOwner, _ := classifyOpsErrorLog(c, tc.errType, tc.message, "", tc.final)
+
+			require.Equal(t, "upstream", phase, "genuine provider/account-health errors must stay upstream")
+			require.Equal(t, "provider", errorOwner, "must keep counting toward upstream_error_rate")
+		})
+	}
+}
+
+// Routing capacity ("no available accounts") must still win over the
+// client-induced branch so the existing SLA-exclusion behaviour is preserved.
+func TestClassifyOpsRoutingCapacityWinsOverClientInduced(t *testing.T) {
+	gin.SetMode(gin.TestMode)
+	rec := httptest.NewRecorder()
+	c, _ := gin.CreateTestContext(rec)
+	markOpsRoutingCapacityLimited(c)
+	service.SetOpsUpstreamError(c, http.StatusBadRequest,
+		"The 'gpt-4o' model is not supported when using Codex with a ChatGPT account.", "")
+
+	phase, isBusinessLimited, errorOwner, _ := classifyOpsErrorLog(c, "api_error",
+		"No available accounts", "", http.StatusServiceUnavailable)
+
+	require.Equal(t, "routing", phase)
+	require.True(t, isBusinessLimited)
+	require.Equal(t, "platform", errorOwner)
+}

--- a/backend/internal/service/error_passthrough_runtime_test.go
+++ b/backend/internal/service/error_passthrough_runtime_test.go
@@ -62,30 +62,53 @@ func TestGatewayHandleErrorResponse_NoRuleKeepsDefault(t *testing.T) {
 	assert.Equal(t, "Upstream request failed", errField["message"])
 }
 
-func TestOpenAIHandleErrorResponse_NoRuleKeepsDefault(t *testing.T) {
+// Bug B (prod P0 2026-06-05): the native OpenAI error path (handleErrorResponse,
+// used by /v1/responses) must pass a client-induced upstream 4xx through with its
+// REAL status + the actionable upstream message instead of masking it as a generic
+// 502 "Upstream request failed". This brings it to parity with the
+// handleCompatErrorResponse path that /v1/chat/completions already uses. The
+// generic-502 default for non-client-4xx is still covered by the Anthropic
+// GatewayService test above.
+func TestOpenAIHandleErrorResponse_ClientInduced4xxPassesThrough(t *testing.T) {
 	gin.SetMode(gin.TestMode)
-	rec := httptest.NewRecorder()
-	c, _ := gin.CreateTestContext(rec)
+	const upstreamMsg = "The 'gpt-4o' model is not supported when using Codex with a ChatGPT account."
 
-	svc := &OpenAIGatewayService{}
-	respBody := []byte(`{"error":{"message":"Invalid schema for field messages"}}`)
-	resp := &http.Response{
-		StatusCode: http.StatusUnprocessableEntity,
-		Body:       io.NopCloser(bytes.NewReader(respBody)),
-		Header:     http.Header{},
+	cases := []struct {
+		name     string
+		status   int
+		wantType string
+	}{
+		{"400 invalid_request", http.StatusBadRequest, "invalid_request_error"},
+		{"404 not_found", http.StatusNotFound, "not_found_error"},
+		{"413 request_too_large", http.StatusRequestEntityTooLarge, "invalid_request_error"},
+		{"422 unprocessable", http.StatusUnprocessableEntity, "invalid_request_error"},
 	}
-	account := &Account{ID: 12, Platform: PlatformOpenAI, Type: AccountTypeAPIKey}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			rec := httptest.NewRecorder()
+			c, _ := gin.CreateTestContext(rec)
 
-	_, err := svc.handleErrorResponse(context.Background(), resp, c, account, nil)
-	require.Error(t, err)
-	assert.Equal(t, http.StatusBadGateway, rec.Code)
+			svc := &OpenAIGatewayService{}
+			respBody := []byte(`{"error":{"message":"` + upstreamMsg + `","type":"invalid_request_error"}}`)
+			resp := &http.Response{
+				StatusCode: tc.status,
+				Body:       io.NopCloser(bytes.NewReader(respBody)),
+				Header:     http.Header{},
+			}
+			account := &Account{ID: 12, Platform: PlatformOpenAI, Type: AccountTypeAPIKey}
 
-	var payload map[string]any
-	require.NoError(t, json.Unmarshal(rec.Body.Bytes(), &payload))
-	errField, ok := payload["error"].(map[string]any)
-	require.True(t, ok)
-	assert.Equal(t, "upstream_error", errField["type"])
-	assert.Equal(t, "Upstream request failed", errField["message"])
+			_, err := svc.handleErrorResponse(context.Background(), resp, c, account, nil)
+			require.Error(t, err)
+			assert.Equal(t, tc.status, rec.Code, "real upstream status must pass through, not 502")
+
+			var payload map[string]any
+			require.NoError(t, json.Unmarshal(rec.Body.Bytes(), &payload))
+			errField, ok := payload["error"].(map[string]any)
+			require.True(t, ok)
+			assert.Equal(t, tc.wantType, errField["type"])
+			assert.Equal(t, upstreamMsg, errField["message"], "actionable upstream message must survive")
+		})
+	}
 }
 
 func TestGeminiWriteGeminiMappedError_NoRuleKeepsDefault(t *testing.T) {

--- a/backend/internal/service/openai_gateway_service.go
+++ b/backend/internal/service/openai_gateway_service.go
@@ -4593,6 +4593,27 @@ func (s *OpenAIGatewayService) handleErrorResponse(
 		statusCode = http.StatusTooManyRequests
 		errType = "rate_limit_error"
 		errMsg = "Upstream rate limit exceeded, please retry later"
+	case 400, 404, 413, 422:
+		// TK (Bug B / prod P0 2026-06-05): a client-induced upstream request
+		// rejection (bad model / params / oversized body, e.g. Codex/ChatGPT-OAuth
+		// "The 'gpt-4o' model is not supported when using Codex with a ChatGPT
+		// account.") must pass through with its REAL status + the actionable
+		// upstream message, not be masked as a generic 502 "Upstream request
+		// failed". This brings the native /v1/responses path (handleErrorResponse)
+		// to parity with handleCompatErrorResponse — which /v1/chat/completions
+		// already uses and which already passes these through — and pairs with the
+		// ops-classification fix keeping these caller-fault 4xx out of
+		// upstream_error_rate. 401/402/403 stay masked as 502 on purpose: they are
+		// account-side (auth/billing/access) and must not leak to the caller.
+		statusCode = resp.StatusCode
+		errType = "invalid_request_error"
+		if resp.StatusCode == 404 {
+			errType = "not_found_error"
+		}
+		errMsg = upstreamMsg
+		if strings.TrimSpace(errMsg) == "" {
+			errMsg = "Upstream rejected the request"
+		}
 	default:
 		statusCode = http.StatusBadGateway
 		errType = "upstream_error"

--- a/backend/internal/service/openai_gateway_service_codex_cli_only_test.go
+++ b/backend/internal/service/openai_gateway_service_codex_cli_only_test.go
@@ -284,7 +284,10 @@ func TestOpenAIGatewayService_Forward_LogsInstructionsRequiredDetails(t *testing
 
 	_, err := svc.Forward(context.Background(), c, account, body)
 	require.Error(t, err)
-	require.Equal(t, http.StatusBadGateway, rec.Code)
+	// Bug B: a client-induced upstream 400 invalid_request_error (here a missing
+	// required parameter) now passes its REAL status through to the caller instead
+	// of being masked as a generic 502 "Upstream request failed".
+	require.Equal(t, http.StatusBadRequest, rec.Code)
 	require.Contains(t, err.Error(), "upstream error: 400")
 
 	require.True(t, logSink.ContainsMessageAtLevel("OpenAI 上游返回 Instructions are required，已记录请求详情用于排查", "warn"))

--- a/scripts/sentinels/gateway-tk.json
+++ b/scripts/sentinels/gateway-tk.json
@@ -1859,6 +1859,14 @@
         "TestClassifyOpsRoutingCapacityWinsOverClientInduced"
       ],
       "rationale": "Focused regressions proving the boundary: (1) upstream 400 invalid_request_error (structured body), the /v1/responses wrapped-upstream_error message shape, 413 request_too_large, and a generic invalid_request_error all classify as error_owner=client; (2) genuine upstream 5xx/401/403 and account-level 400s (organization disabled / credit balance) stay error_owner=provider so they keep counting toward upstream_error_rate; (3) routing-capacity 'no available accounts' still wins over the client-induced branch. Dropping these lets an upstream merge silently revert the prod-P0 fix through the classifier."
+    },
+    {
+      "path": "backend/internal/service/openai_gateway_service.go",
+      "must_contain": [
+        "case 400, 404, 413, 422:",
+        "errMsg = \"Upstream rejected the request\""
+      ],
+      "rationale": "Bug B (prod P0 2026-06-05): the native OpenAI error handler handleErrorResponse (used by /v1/responses) must pass a client-induced upstream 4xx (400/404/413/422 — e.g. Codex/ChatGPT-OAuth 'model is not supported when using Codex with a ChatGPT account') through with its REAL status + the actionable upstream message, instead of the legacy default that masked every non-special status as a generic 502 'Upstream request failed'. This is parity with handleCompatErrorResponse (used by /v1/chat/completions, which already passes these through) and pairs with the ops-classification fix. 401/402/403 stay masked as 502 on purpose (account-side auth/billing/access). An upstream merge that rewrites the status switch and drops this case re-introduces the 400->502 surfacing bug; this sentinel anchors the case and its fallback message."
     }
   ]
 }

--- a/scripts/sentinels/gateway-tk.json
+++ b/scripts/sentinels/gateway-tk.json
@@ -1828,6 +1828,37 @@
         "a.tkAnthropicModelClassRateLimitRemaining(requestedModel)"
       ],
       "rationale": "G4 read-side gate. The scheduler's IsSchedulableForModelWithContext -> isModelRateLimitedWithContext gate must honour the Anthropic model-class scope key alongside the exact-model-name key, so a cooled opus class keeps sibling sonnet/haiku schedulable (and GetModelRateLimitRemainingTimeWithContext surfaces the class cooldown for retry hints). An upstream merge that rewrites this read path would drop the class-scope check and make the write-side G4 cooldown invisible to scheduling; this sentinel anchors the read injection."
+    },
+    {
+      "path": "backend/internal/handler/ops_error_logger_tk_client_induced_upstream.go",
+      "must_contain": [
+        "func tkUpstreamClientInducedRejection(c *gin.Context) bool",
+        "func tkOpsIsAccountLevel4xx(lower string) bool",
+        "if status == 413 {",
+        "if status != 400 && status != 422 {",
+        "invalid_request_error",
+        "request_too_large",
+        "is not supported when using"
+      ],
+      "rationale": "Prod P0 2026-06-05T14:21Z (upstream_error_rate=40.32% overall, false page): a client looping models the Codex/ChatGPT-OAuth backend cannot serve made OpenAI return 400 invalid_request_error ('The X model is not supported when using Codex with a ChatGPT account.'); classifyOpsErrorLog relabelled every error carrying an upstream status code as phase=upstream / error_owner=provider, so these caller-fault rejections flooded the provider-health metric. This predicate (mirroring the #602 amplifier boundary in ratelimit_service_tk_client_induced_400.go) classifies invalid_request_error / request_too_large / 413 / unsupported-model-for-account as client-induced while KEEPING account-level 4xx (organization disabled / credit balance / identity verification) provider-owned. Dropping the 413 arm re-arms the oversized-body false-page; dropping the account-level guard would stop counting genuine account-health 400s; dropping the predicate restores the original false-P0."
+    },
+    {
+      "path": "backend/internal/handler/ops_error_logger.go",
+      "must_contain": [
+        "clientInducedUpstream := upstreamError && tkUpstreamClientInducedRejection(c)",
+        "if upstreamError && !routingCapacityLimited && !clientInducedUpstream {",
+        "if clientInducedUpstream && !routingCapacityLimited {"
+      ],
+      "rationale": "Injection point in classifyOpsErrorLog: an upstream client-induced 4xx must NOT take the upstream/provider phase override (which feeds error_owner=provider -> upstream_error_rate), and must instead be owned to the client (phase=request). routingCapacityLimited still wins last so 'no available accounts' SLA-exclusion is preserved. An upstream merge that rewrites this classifier and copies back the unconditional 'if upstreamError { phase = upstream }' shape silently restores the prod P0 false page; this sentinel anchors both the guard and the client-induced branch."
+    },
+    {
+      "path": "backend/internal/handler/ops_error_logger_tk_client_induced_upstream_test.go",
+      "must_contain": [
+        "TestClassifyOpsUpstreamClientInducedRejectionOwnedByClient",
+        "TestClassifyOpsGenuineUpstreamErrorsStayProvider",
+        "TestClassifyOpsRoutingCapacityWinsOverClientInduced"
+      ],
+      "rationale": "Focused regressions proving the boundary: (1) upstream 400 invalid_request_error (structured body), the /v1/responses wrapped-upstream_error message shape, 413 request_too_large, and a generic invalid_request_error all classify as error_owner=client; (2) genuine upstream 5xx/401/403 and account-level 400s (organization disabled / credit balance) stay error_owner=provider so they keep counting toward upstream_error_rate; (3) routing-capacity 'no available accounts' still wins over the client-induced branch. Dropping these lets an upstream merge silently revert the prod-P0 fix through the classifier."
     }
   ]
 }


### PR DESCRIPTION
Two coupled fixes for the prod P0 `upstream_error_rate=40.32%` (2026-06-05T14:21Z). Both stem from the same root: **client-induced upstream 4xx being treated as upstream/server failures.**

## Root cause (read-only triage)

P0 fired `upstream_error_rate=40.32%` (overall, >20%) on prod. `ops_error_logs` showed it was **not** capacity:

| evidence | finding |
|---|---|
| upstream_events 14:16–14:22 | all from OpenAI ChatGPT-OAuth (Codex) accounts **9 `GPT-pro1` / 48 `GPT-pro2`** |
| upstream message | `The '<model>' model is not supported when using Codex with a ChatGPT account.` (gpt-4o, gpt-5.2, codex-mini-latest, gpt-3.5-turbo…) |
| last-60-min | **28 of 30** "upstream errors" were these caller-fault 400s; only 1 openai 401 + 1 anthropic 502 genuine |
| accounts | healthy/schedulable — a client looped models the account *type* can't serve |

## Fix A — ops classification (the P0 metric)

`classifyOpsErrorLog` relabels **every** error with an upstream status code as `phase=upstream / error_owner=provider`; the metric SQL only excludes 429/529, so these 400s counted as provider health. Structured columns can't disambiguate after the fact (`provider_error_type` NULL, `error_type=api_error`), so the fix is at the **write/classification layer**.

Mirrors the **#602 amplifier boundary**: `invalid_request_error` / `request_too_large` / `413` / unsupported-model-for-account → `error_owner=client` (`phase=request`), dropping out of `upstream_error_rate`. Account-level 4xx (`organization disabled` / `credit balance` / `identity verification`) stay `provider`; routing-capacity `no available accounts` still wins.

## Fix B — `/v1/responses` status passthrough

Same incident also surfaced these upstream 400s to the Codex client as **502** (`/chat/completions` correctly returned 400). Cause: the native OpenAI error handler `handleErrorResponse` (used by `/v1/responses`, v1-forward, images) collapsed every non-special status to a generic 502 "Upstream request failed". `/chat/completions` was fine because it uses `handleCompatErrorResponse`, which already passes the real status + message through.

Fix: add a `400/404/413/422` case that passes the **real upstream status + the actionable upstream message** through (parity with `handleCompatErrorResponse`). `401/402/403` stay masked as 502 on purpose (account-side); `429`→429; `5xx`→502.

Together: those caller-fault 4xx no longer inflate `upstream_error_rate` **and** no longer reach the client as a server 5xx.

## Minimal-invasion shape

- Logic in TK companion `ops_error_logger_tk_client_induced_upstream.go`; upstream-shaped `ops_error_logger.go` gets a 3-line guard; `openai_gateway_service.go` gets one `switch` case.
- Focused regressions for both fixes; updated two existing tests that pinned the old 400→502 behaviour.
- 4 sentinels (gateway-tk.json) anchor both injection points + the new tests against silent upstream-merge revert.

## Validation

`go build ./...`, `go test -tags=unit ./internal/handler/ ./internal/service/` (full suites), `golangci-lint` (0 issues), `scripts/preflight.sh` — all green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)