### PR TITLE
fix(ops-cleanup): re-enable data-retention cleanup silently disabled by upstream default

### DIFF
--- a/backend/migrations/tk_017_enable_ops_cleanup.sql
+++ b/backend/migrations/tk_017_enable_ops_cleanup.sql
@@ -1,0 +1,40 @@
+-- TokenKey: re-enable ops data-retention cleanup that an upstream bug silently
+-- disabled.
+--
+-- Background (root cause, confirmed on prod 2026-06-06):
+--   Upstream's defaultOpsAdvancedSettings() seeds data_retention.cleanup_enabled
+--   = false, and GetOpsAdvancedSettings() auto-persists that default to the
+--   `settings` row on the FIRST read of the Ops settings page. computeEffective
+--   then lets the settings value override config (which defaults enabled=true),
+--   so the OpsCleanupService cron stops being scheduled the moment anyone opens
+--   the Ops settings page. On prod this left ops_cleanup un-run for a month
+--   (last_run 2026-05-06) while ops_system_logs (2.5GB) + ops_error_logs (1.7GB)
+--   grew unbounded — 4.3GB of the 6.3GB database.
+--
+-- Why a migration (not a Go change): the buggy default + override live in
+-- upstream-owned files (byte-identical to Wei-Shaw/sub2api). Per CLAUDE.md §5,
+-- TokenKey overrides upstream defaults via migration rather than editing the
+-- upstream function (same pattern as tk_003_default_backend_mode_enabled.sql).
+-- The upstream bug itself should be fixed at the source via a separate PR; this
+-- migration un-breaks the existing fleet (prod + every edge) on next deploy and
+-- the deploy restart reschedules the cron from the now-true setting.
+--
+-- Scope: surgical flip of cleanup_enabled false/missing -> true on the EXISTING
+-- settings row. It deliberately does NOT seed a fresh row and does NOT touch any
+-- other field (a partial seed would zero the retention ints, which the cleaner
+-- treats as "truncate all"). Fresh installs without a row are already enabled by
+-- config default until the upstream bug is fixed.
+--
+-- Idempotent: the WHERE clause only matches rows where cleanup_enabled is
+-- currently false or absent, so re-running is a no-op. Verified read-only
+-- against the live prod row before authoring (before=false -> after=true,
+-- error_log_retention_days and sibling fields preserved).
+
+UPDATE settings
+SET value = jsonb_set(value::jsonb, '{data_retention,cleanup_enabled}', 'true'::jsonb, true)::text,
+    updated_at = NOW()
+WHERE key = 'ops_advanced_settings'
+  AND value IS NOT NULL
+  AND jsonb_typeof(value::jsonb) = 'object'
+  AND jsonb_typeof(value::jsonb -> 'data_retention') = 'object'
+  AND COALESCE((value::jsonb #>> '{data_retention,cleanup_enabled}')::boolean, false) = false;


### PR DESCRIPTION
## 背景 / 根因（prod 只读诊断实证 2026-06-06）

线上 6.3GB 库里 **4.3GB 是运维日志**（ops_system_logs 2.5GB + ops_error_logs 1.7GB），不是缺 retention 功能——`OpsCleanupService` 默认开启、本就覆盖这两张表。诊断发现 `ops_cleanup` 心跳 **last_run 停在 2026-05-06**（其它 ops job 都在当天运行），且 `ops_advanced_settings.data_retention.cleanup_enabled = false`。

机制：上游 `defaultOpsAdvancedSettings()` 把 `cleanup_enabled` 默认成 `false`，`GetOpsAdvancedSettings()` 在**首次打开 Ops 设置页**时把该默认自动持久化进 settings 行，`computeEffective` 又让 settings 无条件覆盖 config（config 默认 `enabled=true`）——于是**任何人打开一次设置页，清理 cron 就被静默关停**。这段默认 + 覆盖逻辑与 Wei-Shaw/sub2api `upstream/main` **逐字节相同**，是上游行为。

## 方案（§5：覆写上游默认走迁移，不改上游 Go）

`tk_017_enable_ops_cleanup.sql`：对**已存在的** settings 行外科式把 `cleanup_enabled` false/缺失 → true（`jsonb_set`，幂等；保留 retention 天数与其它字段）。沿用 `tk_003` 的「迁移覆写上游默认」范式，不触碰上游函数（避免冲突面 / 可争议行为就地改）。

- **舰队级生效**：迁移在每次部署随 `ApplyMigrations` 跑一次，**prod + 每个 edge 统一修复**；部署重启让 `Start()` 从已 true 的设置重排 cron——无需逐 edge 手动开。
- **不 seed 新行**：部分 seed 会把 retention 整数置 0，而清理把 0 当「全表 truncate」——故只翻转已存在行。全新安装在无 settings 行时本就按 config 默认启用，其再破坏属上游 bug 范畴（见下）。

## 验证

- 只读核对**线上真实行**的精确 `jsonb_set` 变换：`before=false → after=true`，`error_log_retention_days` 保持 30，`ignore_count_tokens_errors` 等同级字段不变。
- `go test -tags=integration ./internal/repository/ -run TestMigrationsRunner_IsIdempotent` 通过（tk_017 顺序内干净应用 + 幂等）。
- `PREFLIGHT_BASE=origin/main scripts/preflight.sh` 全绿。
- `go test -tags=unit ./...` 通过；`golangci-lint` 0 issue。

## 不在本 PR（明确边界）

- **立即回收 4.3GB**：迁移在「下次部署」生效；若需发版前立刻回收，运营在 Admin UI 开启清理（触发 Reload）或单独授权 SSM 写。删行后磁盘文件需 `VACUUM FULL`/pg_repack 才缩；但 `pg_dump` 体积立即降到百 MB 级（满足 #587 出机演练目标）。
- **上游根治**：默认 false + 首次读自动持久化 + 无条件覆盖是上游 bug，建议另提 Wei-Shaw/sub2api issue/PR 从源头修（presence-aware + 默认随 config），TK 经常规合并受益。本迁移是兜底。
- retention 调参（如 14/7 天）：保持现有 30 天，运营可在 UI 调整。

no-web-impact

🤖 Generated with [Claude Code](https://claude.com/claude-code)