### PR TITLE
fix(stage0-deploy): self-heal SERVER_FRONTEND_URL compose mapping on deploy

### DIFF
--- a/ops/stage0/deploy_via_ssm.sh
+++ b/ops/stage0/deploy_via_ssm.sh
@@ -36,7 +36,16 @@
 #      also uses --force-recreate for the same reason).
 #
 # What this script INTENTIONALLY DOES NOT DO:
-#   - It does NOT refresh /var/lib/tokenkey/docker-compose.yml.
+#   - It does NOT wholesale-refresh /var/lib/tokenkey/docker-compose.yml.
+#     (Exception: it DOES self-heal one specific, additive line — the
+#     `SERVER_FRONTEND_URL=${SERVER_FRONTEND_URL:-}` env mapping in the tokenkey
+#     service — when absent. Edges provisioned before that mapping was added to
+#     the compose template carried a stale compose: the .env backfill below set
+#     SERVER_FRONTEND_URL, but with no compose mapping the var never reached the
+#     container, so alert cards showed node=unknown on us1/us2/us3/us4/us5/uk1
+#     [2026-06-06]. The insert is guarded by `! grep -q SERVER_FRONTEND_URL`, so
+#     it is a no-op on already-correct edges, and additive [one env line after
+#     the TZ line], so it cannot break an otherwise-valid compose.)
 #   - It does NOT refresh /var/lib/tokenkey/caddy/Caddyfile.
 #   Both files are written once at instance launch by UserData (gzip+base64
 #   decoded from SSM Parameter Store; see stage0-{single,edge}-ec2.yaml +
@@ -94,6 +103,7 @@ jq -n --arg tag "${TAG}" '{
     "trap rollback ERR",
     ("sudo sed -i '\''s|sub2api:[^[:space:]]*|sub2api:" + $tag + "|'\'' /var/lib/tokenkey/.env"),
     "if ! grep -q '\''^SERVER_FRONTEND_URL='\'' /var/lib/tokenkey/.env; then d=$(sed -n '\''s/^API_DOMAIN=//p'\'' /var/lib/tokenkey/.env | head -1); if [ -n \"$d\" ]; then echo \"SERVER_FRONTEND_URL=https://$d\" | sudo tee -a /var/lib/tokenkey/.env >/dev/null; echo \"ensured SERVER_FRONTEND_URL=https://$d\"; else echo \"API_DOMAIN empty; skip SERVER_FRONTEND_URL backfill\"; fi; else echo \"SERVER_FRONTEND_URL already present\"; fi",
+    ("if [ -f /var/lib/tokenkey/docker-compose.yml ] && ! grep -q '\''SERVER_FRONTEND_URL'\'' /var/lib/tokenkey/docker-compose.yml; then sudo cp -a /var/lib/tokenkey/docker-compose.yml /var/lib/tokenkey/docker-compose.yml.compose-before-" + $tag + "; sudo sed -i '\''/^      - TZ=/a\\      - SERVER_FRONTEND_URL=${SERVER_FRONTEND_URL:-}'\'' /var/lib/tokenkey/docker-compose.yml; if grep -q '\''SERVER_FRONTEND_URL'\'' /var/lib/tokenkey/docker-compose.yml; then echo ensured-compose-SERVER_FRONTEND_URL-mapping; else echo '\''::warning::failed to insert compose SERVER_FRONTEND_URL mapping'\''; fi; else echo compose-SERVER_FRONTEND_URL-mapping-present-or-no-compose; fi"),
     "echo \"=== pull new image BEFORE drain (old container keeps serving 100% traffic) ===\"",
     "cd /var/lib/tokenkey && sudo docker compose --env-file .env pull tokenkey",
     "echo \"=== pre-drain: SIGUSR1 + wait in_flight=0 (only when outgoing container healthy) ===\"",

--- a/ssm-params.json
+++ b/ssm-params.json
@@ -1,0 +1,26 @@
+{
+  "commands": [
+    "set -euo pipefail",
+    "echo === deploy stage0 to tag=1.7.99 ===",
+    "BACKUP=/var/lib/tokenkey/.env.before-1.7.99",
+    "sudo cp -a /var/lib/tokenkey/.env \"$BACKUP\"",
+    "rollback() { rc=$?; echo \"::warning::deploy failed; restoring previous tokenkey image\"; if [ -f \"$BACKUP\" ]; then sudo cp -a \"$BACKUP\" /var/lib/tokenkey/.env; cd /var/lib/tokenkey && sudo docker compose --env-file .env up -d --no-deps --force-recreate tokenkey || true; for i in 1 2 3 4 5 6 7 8 9 10 11 12; do s=$(sudo docker inspect tokenkey --format '{{.State.Health.Status}}' 2>/dev/null || echo missing); echo \"rollback try $i: $s\"; [ \"$s\" = healthy ] && break; sleep 5; done; [ \"$s\" = healthy ] || echo \"::error::rollback restored the previous image but it is ALSO not healthy (health=$s) — node requires MANUAL intervention; do NOT assume service is restored. next: deploy/aws/RUNBOOK-disaster-recovery.md — recovery decision tree + Agent handoff contract\"; sudo docker logs tokenkey --since 2m 2>&1 | tail -50 || true; fi; exit $rc; }",
+    "trap rollback ERR",
+    "sudo sed -i 's|sub2api:[^[:space:]]*|sub2api:1.7.99|' /var/lib/tokenkey/.env",
+    "if ! grep -q '^SERVER_FRONTEND_URL=' /var/lib/tokenkey/.env; then d=$(sed -n 's/^API_DOMAIN=//p' /var/lib/tokenkey/.env | head -1); if [ -n \"$d\" ]; then echo \"SERVER_FRONTEND_URL=https://$d\" | sudo tee -a /var/lib/tokenkey/.env >/dev/null; echo \"ensured SERVER_FRONTEND_URL=https://$d\"; else echo \"API_DOMAIN empty; skip SERVER_FRONTEND_URL backfill\"; fi; else echo \"SERVER_FRONTEND_URL already present\"; fi",
+    "if [ -f /var/lib/tokenkey/docker-compose.yml ] && ! grep -q 'SERVER_FRONTEND_URL' /var/lib/tokenkey/docker-compose.yml; then sudo cp -a /var/lib/tokenkey/docker-compose.yml /var/lib/tokenkey/docker-compose.yml.compose-before-1.7.99; sudo sed -i '/^      - TZ=/a\\      - SERVER_FRONTEND_URL=${SERVER_FRONTEND_URL:-}' /var/lib/tokenkey/docker-compose.yml; if grep -q 'SERVER_FRONTEND_URL' /var/lib/tokenkey/docker-compose.yml; then echo ensured-compose-SERVER_FRONTEND_URL-mapping; else echo '::warning::failed to insert compose SERVER_FRONTEND_URL mapping'; fi; else echo compose-SERVER_FRONTEND_URL-mapping-present-or-no-compose; fi",
+    "echo \"=== pull new image BEFORE drain (old container keeps serving 100% traffic) ===\"",
+    "cd /var/lib/tokenkey && sudo docker compose --env-file .env pull tokenkey",
+    "echo \"=== pre-drain: SIGUSR1 + wait in_flight=0 (only when outgoing container healthy) ===\"",
+    "OLD_HEALTH=$(sudo docker inspect tokenkey --format '{{if .State.Health}}{{.State.Health.Status}}{{else}}none{{end}}' 2>/dev/null || echo missing); echo \"pre-drain: outgoing container health=$OLD_HEALTH\"",
+    "if [ \"$OLD_HEALTH\" = healthy ]; then sudo docker kill -s USR1 tokenkey 2>/dev/null || true; for i in $(seq 1 38); do body=$(sudo docker exec tokenkey wget -q -T 3 -O - http://localhost:8080/health/inflight 2>/dev/null); n=$(printf '%s' \"$body\" | sed -n 's/.*\"in_flight\":\\([0-9]*\\).*/\\1/p'); if printf '%s' \"$body\" | grep -q '\"draining\":true'; then d=true; else d=false; fi; echo \"pre-drain: draining=$d in_flight=${n:-?} try=$i/38\"; [ \"$d\" = true ] && [ \"${n:-1}\" = 0 ] && break; sleep 2; done; else echo \"pre-drain SKIPPED: outgoing container not healthy (health=$OLD_HEALTH) — Caddy already flipped it out, nothing to drain; straight to recreate (avoids burning the ~76s drain budget on a crash-looping container, which previously starved the new container health window and tripped the rollback trap — uk1 2026-06-03)\"; fi",
+    "echo \"=== swap: stop-old + start-new (image already on disk from pull above) ===\"",
+    "cd /var/lib/tokenkey && sudo docker compose --env-file .env up -d --no-deps --force-recreate tokenkey",
+    "for i in 1 2 3 4 5 6 7 8 9 10 11 12; do s=$(sudo docker inspect tokenkey --format '{{.State.Health.Status}}' 2>/dev/null || echo missing); echo \"try $i: $s\"; [ \"$s\" = healthy ] && break; sleep 5; done",
+    "FINAL=$(sudo docker inspect tokenkey --format '{{.State.Health.Status}}' 2>/dev/null || echo missing)",
+    "if [ \"$FINAL\" != \"healthy\" ]; then echo \"::error::container did not reach healthy state (final=$FINAL)\"; sudo docker logs tokenkey --since 2m 2>&1 | tail -50; exit 1; fi",
+    "trap - ERR",
+    "cd /var/lib/tokenkey && sudo docker compose ps",
+    "sudo docker logs tokenkey --since 2m 2>&1 | tail -20"
+  ]
+}


### PR DESCRIPTION
## What & why

`deploy_via_ssm.sh` 已自愈 `.env` 的 `SERVER_FRONTEND_URL`,但**不刷新 compose**。2026-06 发现 drift:在 compose 模板加入该 env 映射**之前** provision 的 edge(us1/us2/us3/us4/us5/uk1)compose 缺
```
      - SERVER_FRONTEND_URL=${SERVER_FRONTEND_URL:-}
```
→ `.env` 有值也传不进容器 → 告警卡片 `node=unknown`(prod/us6/us7 模板较新,正常)。

## Fix

在既有 `.env` 回填之后,补一步**幂等的 compose 映射自愈**:仅当 compose 缺该行时,备份后在 tokenkey env 块的 `TZ` 行后插入一行,由后续 `force-recreate` 生效。
- 守卫 `! grep -q SERVER_FRONTEND_URL` → 已正确的 edge 为 **no-op**。
- **additive 一行**(insert after TZ),不会破坏合法 compose;失败打 `::warning::`,不中断部署(不在 ERR trap 内的致命路径)。
- 生成的 SSM 命令与本次**手动修复 6 个 edge 的命令逐字一致**(已在 6 个 GNU-sed Linux edge 验证可用)。

## 线上现状(本 PR 之外已处理)
6 个受影响 edge 已手动修复并验证:全 9 节点 `image=1.7.75` + `SERVER_FRONTEND_URL` 生效;**postgres/redis 未重建,零数据丢失**(只 `--no-deps --force-recreate tokenkey`)。本 PR 防止未来 re-provision / 新 edge 复发。

## Verification
- `scripts/checks/check-stage0-ssm-host-parse.sh`:`deploy_via_ssm.sh host script parses`(生成 JSON 合法 + `bash -n`)。
- 提取生成命令确认 sed 串 = `'/^      - TZ=/a\      - SERVER_FRONTEND_URL=${SERVER_FRONTEND_URL:-}'`(与手动修复一致)。
- `bash scripts/preflight.sh` 全绿。

## Notes
- 纯 ops 脚本 → commit 带 `no-web-impact`。TK fix → **Squash and merge**。不自动合并。

🤖 Generated with [Claude Code](https://claude.com/claude-code)