### PR TITLE
chore(cc-fingerprint): align UA to cc 2.1.166 (pure version bump)

### DIFF
--- a/backend/internal/baseline/anthropic-http-mimicry-baselines.json
+++ b/backend/internal/baseline/anthropic-http-mimicry-baselines.json
@@ -1,6 +1,6 @@
 {
   "schema_version": 1,
-  "cc_version": "2.1.165",
+  "cc_version": "2.1.166",
   "description": "Canonical OAuth HTTP mimicry betas for Claude Code CLI. Live wire values are driven at runtime by settings.claude_code_http_mimicry_manifest (sync-runtime / plan-http-mimicry-sync). Compile-time defaults in backend/internal/pkg/claude/constants.go catch up on the release train.",
   "sonnet_opus": [
     "claude-code-20250219",

--- a/backend/internal/pkg/claude/constants.go
+++ b/backend/internal/pkg/claude/constants.go
@@ -81,7 +81,7 @@ const DefaultCacheControlTTL = "5m"
 // CLICurrentVersion 是 sub2api 当前对外伪装的 Claude Code CLI 版本号（三段 semver）。
 // 用于 billing attribution block 中的 cc_version=X.Y.Z.{fp} 前缀以及 fingerprint 计算。
 // 必须与 DefaultHeaders["User-Agent"] 中的版本号严格一致；不一致会被 Anthropic 判第三方。
-const CLICurrentVersion = "2.1.165"
+const CLICurrentVersion = "2.1.166"
 
 // JoinBetaHeader joins beta tokens into the wire anthropic-beta header value.
 func JoinBetaHeader(betas []string) string {
@@ -137,7 +137,7 @@ func FullClaudeCodeHaikuMimicryBetas() []string {
 // 包依赖方向为 service → claude，claude 无法反向 import service，故这里以同步字面量
 // 承载，由守卫测试强制对齐。
 var DefaultHeaders = map[string]string{
-	"User-Agent":                                "claude-cli/2.1.165 (external, sdk-cli)",
+	"User-Agent":                                "claude-cli/2.1.166 (external, sdk-cli)",
 	"X-Stainless-Lang":                          "js",
 	"X-Stainless-Package-Version":               "0.94.0",
 	"X-Stainless-OS":                            "MacOS",

--- a/backend/internal/service/identity_service.go
+++ b/backend/internal/service/identity_service.go
@@ -38,7 +38,7 @@ var (
 // / `StainlessPackageVersion:` 字面量做指纹基线巡检，computed 值会让它失明。
 // 字面量与 canonical 的一致性改由 identity_canonical_consistency_test.go 机械锁死。
 var defaultFingerprint = Fingerprint{
-	UserAgent:               "claude-cli/2.1.165 (external, sdk-cli)",
+	UserAgent:               "claude-cli/2.1.166 (external, sdk-cli)",
 	StainlessLang:           "js",
 	StainlessPackageVersion: "0.94.0",
 	StainlessOS:             "MacOS",

--- a/backend/internal/service/identity_service_tk_canonical_http.go
+++ b/backend/internal/service/identity_service_tk_canonical_http.go
@@ -56,7 +56,7 @@ const (
 	// neither env nor runtime resolver provides a value. Keep in sync with
 	// the most recent cc CLI release this build was validated against; the
 	// admin UI / runtime resolver is the normal update path going forward.
-	DefaultClaudeCodeUserAgentVersion = "2.1.165"
+	DefaultClaudeCodeUserAgentVersion = "2.1.166"
 
 	// canonicalUAPrefix / canonicalUASuffix wrap the version-only field.
 	// Matches the wire shape Anthropic observes from a real Claude Code CLI

--- a/deploy/aws/stage0/anthropic-http-mimicry-baselines.json
+++ b/deploy/aws/stage0/anthropic-http-mimicry-baselines.json
@@ -1,6 +1,6 @@
 {
   "schema_version": 1,
-  "cc_version": "2.1.165",
+  "cc_version": "2.1.166",
   "description": "Canonical OAuth HTTP mimicry betas for Claude Code CLI. Live wire values are driven at runtime by settings.claude_code_http_mimicry_manifest (sync-runtime / plan-http-mimicry-sync). Compile-time defaults in backend/internal/pkg/claude/constants.go catch up on the release train.",
   "sonnet_opus": [
     "claude-code-20250219",

--- a/deploy/aws/stage0/tk_canonical_cc_oauth.json
+++ b/deploy/aws/stage0/tk_canonical_cc_oauth.json
@@ -71,7 +71,7 @@
   ],
   "observed": {
     "model": "claude-haiku-4-5-20251001",
-    "user_agent": "claude-cli/2.1.165 (external, sdk-cli)",
+    "user_agent": "claude-cli/2.1.166 (external, sdk-cli)",
     "stainless_os": "MacOS",
     "stainless_arch": "arm64",
     "stainless_runtime": "node",

--- a/docs/spec-delta-cc-2.1.166.md
+++ b/docs/spec-delta-cc-2.1.166.md
@@ -1,0 +1,60 @@
+# spec-delta: cc fingerprint alignment 2.1.165 → 2.1.166
+
+## Background
+
+Claude Code patch `2.1.166` shipped. `/tokenkey-cc-fingerprint-alignment` capture
+against live cc (cc0-here, egress `16.147.170.3`) on 2026-06-06 shows this is a
+**pure User-Agent version bump** — no TLS drift, no actionable beta drift.
+
+## Capture evidence (ground truth = real cc 2.1.166)
+
+| field | tokenkey (2.1.165 baseline) | captured (2.1.166) | verdict |
+|---|---|---|---|
+| `tls.ja3_hash` | unchanged | unchanged | ✅ OK (no TLS profile change) |
+| `tls.ja3_raw` | unchanged | unchanged | ✅ OK |
+| `canonical.user_agent_version` | 2.1.165 | **2.1.166** | ❌ bump |
+| `mimic.cli_version` | 2.1.165 | **2.1.166** | ❌ bump |
+| `canonical/mimic.stainless_package_version` | 0.94.0 | 0.94.0 | ✅ OK |
+| `betas.sonnet_mimicry` | (10 betas) | same | ✅ OK |
+| `betas.haiku_mimicry` | (8 betas) | **bimodal** | ⚠️ INVESTIGATE (not actionable) |
+
+### haiku beta — bimodal A/B (pre-existing #429, NOT changed here)
+
+`capture-http-comprehensive.sh`: **11 haiku requests, 2 unique beta headers**,
+baseline matches variant **8/11**. The minority variant (3/11) is the sonnet-shaped
+set with `claude-code-20250219` + `advanced-tool-use-2025-11-20` +
+`extended-cache-ttl-2025-04-11`. This is the known server-side A/B gray release
+tracked in youxuanxue/sub2api#429 — `check` returns exit 0 (`needs_investigation`,
+not `has_actionable_mismatch`). The canonical `HaikuBetaHeader` is **left
+unchanged**; this PR does NOT touch any beta constant. Opus (2/2) and sonnet (6/6)
+betas single-valued and OK.
+
+## Delta
+
+### MODIFIED (UA version only — via `check-cc-version-sync.py --write`)
+
+Single hand-edited source: `deploy/aws/stage0/anthropic-http-mimicry-baselines.json`
+`cc_version` `2.1.165 → 2.1.166`. The sync script mechanically rewrote the derived
+copies (7 total, incl. embedded byte-sync):
+
+- `backend/internal/pkg/claude/constants.go` — `CLICurrentVersion` + `DefaultHeaders["User-Agent"]`
+- `backend/internal/service/identity_service.go` — `defaultFingerprint.UserAgent`
+- `backend/internal/service/identity_service_tk_canonical_http.go` — `DefaultClaudeCodeUserAgentVersion`
+- `deploy/aws/stage0/tk_canonical_cc_oauth.json` — `observed.user_agent`
+- `ops/stage0/smoke_lib.sh` — dead snapshot
+- `backend/internal/baseline/anthropic-http-mimicry-baselines.json` — embedded copy (byte-identical to deploy source)
+
+### NOT CHANGED
+
+- TLS: `tk_canonical_cc_oauth.json` ja3 profile — unchanged (no ClientHello drift).
+- Betas: no `constants.go` beta constant touched (haiku bimodal is #429, baseline still valid).
+
+## Rollout
+
+UA has a runtime path: after merge run `ops/anthropic/cc_fingerprint_apply_http_runtime.sh`
+(settings `claude_code_user_agent_version` + Redis fingerprint DEL) — no image release
+required, **provided the target node binary carries the mimicry-selfheal monotonic
+ratchet** (v1.7.72 and earlier do NOT — their reconciler rolls a runtime UA bump back
+to the embedded value within one tick). For older binaries the only durable path is
+the next scheduled release, where the embedded baseline updates with the image and the
+reconciler converges automatically.

--- a/ops/stage0/smoke_lib.sh
+++ b/ops/stage0/smoke_lib.sh
@@ -49,7 +49,7 @@ if [[ -z "${_TK_SMOKE_LIB_LOADED:-}" ]]; then
   }
 
   smoke_default_claude_user_agent() {
-    printf '%s' "${TK_SMOKE_CLAUDE_USER_AGENT:-claude-cli/2.1.165 (external, sdk-cli)}"
+    printf '%s' "${TK_SMOKE_CLAUDE_USER_AGENT:-claude-cli/2.1.166 (external, sdk-cli)}"
   }
 
   # soft_degrade_or_exit — see post_deploy_smoke.sh header for contract.


### PR DESCRIPTION
## What

`/tokenkey-cc-fingerprint-alignment` capture against live cc **2.1.166** (cc0-here, egress `16.147.170.3`, 2026-06-06). Pure **UA version bump** `2.1.165 → 2.1.166` — no TLS drift, no actionable beta drift.

## Capture evidence (ground truth = real cc 2.1.166)

| field | tokenkey (2.1.165) | captured (2.1.166) | verdict |
|---|---|---|---|
| `tls.ja3_hash` / `ja3_raw` | unchanged | unchanged | ✅ OK (no TLS profile change) |
| `canonical.user_agent_version` | 2.1.165 | **2.1.166** | ❌ bump |
| `mimic.cli_version` | 2.1.165 | **2.1.166** | ❌ bump |
| `stainless_package_version` | 0.94.0 | 0.94.0 | ✅ OK |
| `betas.sonnet_mimicry` | 10 betas | same (6/6) | ✅ OK |
| `betas.haiku_mimicry` | 8 betas | **bimodal 8/11** | ⚠️ INVESTIGATE (#429, not actionable) |

`capture-http-comprehensive.sh`: 11 haiku / 6 sonnet / 2 opus requests. Haiku is the known #429 A/B gray release (baseline matches 8/11; minority 3/11 is the sonnet-shaped set). `check` exits 0 (`needs_investigation`, not `has_actionable_mismatch`). **No beta constant touched.**

## Delta (§4.1 UA-only path)

Single hand-edited source `deploy/aws/stage0/anthropic-http-mimicry-baselines.json` `cc_version`; derived 7 copies rewritten mechanically via `check-cc-version-sync.py --write` (incl. embedded `backend/internal/baseline/` byte-sync). No `tk_canonical_cc_oauth.json` ja3 change, no `constants.go` beta change.

## Verification

- `check-cc-version-sync.py --selftest` + check: 7 copies consistent
- `go test -tags=unit -count=1 ./internal/pkg/claude/...` ✅
- `python3 -m unittest ... test_capture_cc_fingerprint.py` (13 tests) ✅
- `scripts/preflight.sh` PASS (both commits)

## Rollout

UA has a runtime path: after merge run `ops/anthropic/cc_fingerprint_apply_http_runtime.sh` (no image release) — **only durable on nodes whose binary carries the mimicry-selfheal monotonic ratchet** (v1.7.72 and earlier roll a hot UA bump back within one tick; for those the next scheduled release is the durable path). Compile-time default catches up on the release train.

🤖 Generated with [Claude Code](https://claude.com/claude-code)