### PR TITLE
fix(dashboard): quick date presets apply on click so 近14天 actually loads 14 days

### DIFF
--- a/backend/internal/web/dist/frontend-source.json
+++ b/backend/internal/web/dist/frontend-source.json
@@ -1,7 +1,7 @@
 {
   "algorithm": "sha256(git-ls-files:path,size,content)",
   "file_count": 454,
-  "hash": "1246a93b1d9f8176a94cbfe40a2e64419f97eb3d1c98916951ffa30cdd19e7f3",
+  "hash": "2ab1d251254326d18a9721d0edb2a518b6df4109d5c2e32f6486279451717e6f",
   "schema": 1,
   "source": "frontend/"
 }

--- a/frontend/src/components/common/DateRangePicker.vue
+++ b/frontend/src/components/common/DateRangePicker.vue
@@ -249,6 +249,12 @@ const selectPreset = (preset: DatePreset) => {
   localStartDate.value = range.start
   localEndDate.value = range.end
   activePreset.value = preset.value
+  // A quick preset is a complete intent — apply it immediately and close,
+  // matching standard date-picker UX. Otherwise the trigger label flips to the
+  // preset (e.g. 近14天) while the still-unapplied range keeps driving requests,
+  // so the chart silently shows the previous window. Custom date inputs still
+  // require an explicit Apply click.
+  apply()
 }
 
 const onDateChange = () => {

--- a/frontend/src/components/common/__tests__/DateRangePicker.spec.ts
+++ b/frontend/src/components/common/__tests__/DateRangePicker.spec.ts
@@ -53,7 +53,7 @@ describe('DateRangePicker', () => {
     expect(wrapper.text()).toContain('Last 24 Hours')
   })
 
-  it('emits range updates with last24Hours preset when applied', async () => {
+  it('applies a quick preset immediately on click (no separate Apply needed)', async () => {
     const now = new Date()
     const today = formatLocalDate(now)
 
@@ -76,7 +76,9 @@ describe('DateRangePicker', () => {
     expect(presetButton).toBeDefined()
 
     await presetButton!.trigger('click')
-    await wrapper.find('.date-picker-apply').trigger('click')
+
+    // A quick preset is applied on the single click — no separate Apply step.
+    expect(wrapper.emitted('change')).toHaveLength(1)
 
     const nowAfterClick = new Date()
     const yesterdayAfterClick = new Date(nowAfterClick.getTime() - 24 * 60 * 60 * 1000)

--- a/frontend/src/views/admin/__tests__/DashboardView.daterange-repro.spec.ts
+++ b/frontend/src/views/admin/__tests__/DashboardView.daterange-repro.spec.ts
@@ -1,0 +1,158 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest'
+import { flushPromises, mount } from '@vue/test-utils'
+
+import DashboardView from '../DashboardView.vue'
+import DateRangePicker from '@/components/common/DateRangePicker.vue'
+import Select from '@/components/common/Select.vue'
+
+// Reproduction harness for the "Token 使用趋势 only shows 2 days" report.
+// Mounts the REAL DateRangePicker + Select (the two controls the operator drives)
+// and records the start_date/end_date/granularity actually sent to
+// /admin/dashboard/snapshot-v2 — instead of guessing from a screenshot.
+
+const { getSnapshotV2, getUserUsageTrend, getUserSpendingRanking } = vi.hoisted(() => ({
+  getSnapshotV2: vi.fn(),
+  getUserUsageTrend: vi.fn(),
+  getUserSpendingRanking: vi.fn()
+}))
+
+vi.mock('@/api/admin', () => ({
+  adminAPI: {
+    dashboard: { getSnapshotV2, getUserUsageTrend, getUserSpendingRanking }
+  }
+}))
+
+vi.mock('@/stores/app', () => ({
+  useAppStore: () => ({ showError: vi.fn() })
+}))
+
+vi.mock('vue-router', () => ({
+  useRouter: () => ({ push: vi.fn() })
+}))
+
+vi.mock('vue-i18n', async () => {
+  const actual = await vi.importActual<typeof import('vue-i18n')>('vue-i18n')
+  return {
+    ...actual,
+    useI18n: () => ({ t: (key: string) => key, locale: { value: 'en' } })
+  }
+})
+
+const createStats = () =>
+  Object.fromEntries(
+    [
+      'total_users', 'today_new_users', 'active_users', 'hourly_active_users',
+      'total_api_keys', 'active_api_keys', 'total_accounts', 'normal_accounts',
+      'error_accounts', 'ratelimit_accounts', 'overload_accounts', 'total_requests',
+      'total_input_tokens', 'total_output_tokens', 'total_cache_creation_tokens',
+      'total_cache_read_tokens', 'total_tokens', 'total_cost', 'total_actual_cost',
+      'total_account_cost', 'today_requests', 'today_input_tokens', 'today_output_tokens',
+      'today_cache_creation_tokens', 'today_cache_read_tokens', 'today_tokens',
+      'today_cost', 'today_actual_cost', 'today_account_cost', 'average_duration_ms',
+      'uptime', 'rpm', 'tpm'
+    ].map((k) => [k, 0])
+  )
+
+const mountDashboard = () =>
+  mount(DashboardView, {
+    global: {
+      stubs: {
+        AppLayout: { template: '<div><slot /></div>' },
+        LoadingSpinner: true,
+        Icon: true,
+        ModelDistributionChart: true,
+        TokenUsageTrend: true,
+        Line: true
+        // NOTE: DateRangePicker + Select are intentionally NOT stubbed.
+      }
+    }
+  })
+
+const lastSnapshotCall = () =>
+  getSnapshotV2.mock.calls.at(-1)?.[0] as
+    | { start_date: string; end_date: string; granularity: string }
+    | undefined
+
+// open the date picker and click a preset by its (mocked) label key
+const clickPreset = async (wrapper: ReturnType<typeof mountDashboard>, labelKey: string) => {
+  const dp = wrapper.findComponent(DateRangePicker)
+  await dp.find('.date-picker-trigger').trigger('click')
+  const presetBtn = dp.findAll('.date-picker-preset').find((b) => b.text() === labelKey)
+  if (!presetBtn) throw new Error(`preset not found: ${labelKey}`)
+  await presetBtn.trigger('click')
+}
+
+// open the granularity Select and click an option by its (mocked) label key
+const selectGranularity = async (wrapper: ReturnType<typeof mountDashboard>, labelKey: string) => {
+  const sel = wrapper.findComponent(Select)
+  await sel.find('button').trigger('click') // opens the (teleported) dropdown
+  await flushPromises()
+  // Select teleports its panel to document.body, so options live outside the wrapper.
+  const opts = Array.from(document.querySelectorAll('.select-option')) as HTMLElement[]
+  const opt = opts.find((o) => (o.textContent ?? '').trim().includes(labelKey))
+  if (!opt) {
+    throw new Error(
+      `granularity option not found: ${labelKey}; options=[${opts.map((o) => JSON.stringify(o.textContent)).join(', ')}]`
+    )
+  }
+  opt.dispatchEvent(new MouseEvent('click', { bubbles: true }))
+  await flushPromises()
+}
+
+describe('admin DashboardView — date-range / granularity request params', () => {
+  beforeEach(() => {
+    getSnapshotV2.mockReset()
+    getUserUsageTrend.mockReset()
+    getUserSpendingRanking.mockReset()
+    getSnapshotV2.mockResolvedValue({
+      stats: { ...createStats(), stats_updated_at: '', stats_stale: false },
+      trend: [],
+      models: []
+    })
+    getUserUsageTrend.mockResolvedValue({ trend: [] })
+    getUserSpendingRanking.mockResolvedValue({
+      ranking: [],
+      total_actual_cost: 0,
+      total_requests: 0,
+      total_tokens: 0
+    })
+  })
+
+  // Regression guard for the screenshot bug: selecting 近14天 used to only flip
+  // the trigger label without applying, so a subsequent granularity change still
+  // requested the default last-24h window (2 daily buckets) while the label read
+  // 近14天. A quick preset must take effect on click.
+  it('picking 近14天 preset applies immediately and a later 粒度→按天 keeps the 14-day window', async () => {
+    const wrapper = mountDashboard()
+    await flushPromises()
+
+    // baseline: default last-24h + hour
+    expect(lastSnapshotCall()).toMatchObject({ granularity: 'hour' })
+
+    await clickPreset(wrapper, 'dates.last14Days')
+    await selectGranularity(wrapper, 'admin.dashboard.day')
+    await flushPromises()
+
+    const call = lastSnapshotCall()!
+    const span =
+      (new Date(call.end_date).getTime() - new Date(call.start_date).getTime()) / 86400000
+
+    expect(call.granularity).toBe('day')
+    expect(span).toBeGreaterThanOrEqual(13) // a real ~14-day window, not 2 buckets
+  })
+
+  it('picking 近14天 preset alone sends a real 14-day window', async () => {
+    const wrapper = mountDashboard()
+    await flushPromises()
+
+    await clickPreset(wrapper, 'dates.last14Days')
+    await flushPromises()
+
+    const call = lastSnapshotCall()!
+    const span =
+      (new Date(call.end_date).getTime() - new Date(call.start_date).getTime()) / 86400000
+
+    expect(call.granularity).toBe('day')
+    expect(span).toBeGreaterThanOrEqual(13)
+  })
+})

--- a/ops/observability/probe-dashboard-aggregate-coverage.sh
+++ b/ops/observability/probe-dashboard-aggregate-coverage.sh
@@ -1,0 +1,77 @@
+#!/usr/bin/env bash
+# probe-dashboard-aggregate-coverage.sh — read-only diagnostic for the
+# "Token 使用趋势 only shows 2 days" bug. Confirms whether the pre-aggregated
+# dashboard tables (usage_dashboard_daily / hourly) are under-covered relative
+# to raw usage_logs, and reports the aggregation watermark.
+#
+# Runs INSIDE the TokenKey host (prod or edge) via run-probe.sh. Read-only.
+# Output is row_to_json so downstream parsing is field-named, not column-index.
+set -u
+
+PSQL='docker exec tokenkey-postgres psql -U tokenkey -d tokenkey -X -A -t'
+
+echo "=== meta ==="
+$PSQL -c "SELECT row_to_json(t) FROM (SELECT now() AT TIME ZONE 'UTC' AS now_utc) t;" 2>&1
+
+echo
+echo "=== usage_dashboard_daily coverage ==="
+$PSQL -c "
+SELECT row_to_json(t) FROM (
+  SELECT
+    count(*)                          AS row_count,
+    min(bucket_date)                  AS min_date,
+    max(bucket_date)                  AS max_date,
+    (max(bucket_date) - min(bucket_date)) AS span_days
+  FROM usage_dashboard_daily
+) t;" 2>&1
+
+echo
+echo "=== usage_dashboard_daily last 16 rows ==="
+$PSQL -c "
+SELECT row_to_json(t) FROM (
+  SELECT bucket_date, total_requests,
+         (input_tokens + output_tokens + cache_creation_tokens + cache_read_tokens) AS total_tokens,
+         computed_at
+  FROM usage_dashboard_daily
+  ORDER BY bucket_date DESC
+  LIMIT 16
+) t;" 2>&1
+
+echo
+echo "=== usage_dashboard_hourly coverage ==="
+$PSQL -c "
+SELECT row_to_json(t) FROM (
+  SELECT count(*) AS row_count, min(bucket_start) AS min_ts, max(bucket_start) AS max_ts
+  FROM usage_dashboard_hourly
+) t;" 2>&1
+
+echo
+echo "=== aggregation watermark ==="
+$PSQL -c "
+SELECT row_to_json(t) FROM (
+  SELECT id, last_aggregated_at,
+         (now() - last_aggregated_at) AS staleness
+  FROM usage_dashboard_aggregation_watermark
+) t;" 2>&1
+
+echo
+echo "=== raw usage_logs coverage (contrast) ==="
+$PSQL -c "
+SELECT row_to_json(t) FROM (
+  SELECT count(*)        AS row_count,
+         min(created_at)  AS min_ts,
+         max(created_at)  AS max_ts,
+         count(DISTINCT (created_at AT TIME ZONE 'UTC')::date) AS distinct_days
+  FROM usage_logs
+) t;" 2>&1
+
+echo
+echo "=== raw usage_logs per-day request counts, last 16 UTC days ==="
+$PSQL -c "
+SELECT row_to_json(t) FROM (
+  SELECT (created_at AT TIME ZONE 'UTC')::date AS day, count(*) AS requests
+  FROM usage_logs
+  WHERE created_at >= now() - interval '16 days'
+  GROUP BY 1
+  ORDER BY 1 DESC
+) t;" 2>&1


### PR DESCRIPTION
## 问题

仪表盘「Token 使用趋势」选「近14天 / 按天」却只显示 2 个数据点(如 06-05、06-06),看不到过去 14 天的分天用量。

## 根因(已用真实 UI 复现 + 生产实测坐实,排除两个错误方向)

共用组件 `DateRangePicker` 的 `selectPreset` **点快捷预设只更新显示标签 + 本地状态,不会真正生效** —— 必须再点「应用」按钮才 emit。用户点了「近14天」(标签变了)但没点应用,接着切了粒度触发重新加载(`@change="loadChartData"`),请求仍用**上次生效的默认近24h范围** → 跨 1 天 = 2 个按天桶,而标签误导性地显示「近14天」。

挂载**真实** `DateRangePicker` + `Select` 抓到的实际 `/admin/dashboard/snapshot-v2` 入参:

| 操作 | 选择器显示 | 实际发送 |
|---|---|---|
| 选「近14天」**不点应用** + 切「按天」 | `近14天` | `start=2026-06-05 end=2026-06-06 day` → 跨 1 天(复现截图) |
| 选「近14天」**点应用** | `近14天` | `start=2026-05-24 end=2026-06-06 day` → 跨 13 天(正常) |

**被排除的错误方向**(连生产只读探针实测):
- ❌ 定时任务删运维日志 —— 底部「最近使用 Top12」读原始 `usage_logs` 显示完整曲线,日志没删。
- ❌ 预聚合表没回填 / 被 retention 删 —— `usage_dashboard_daily` 实有 48 行(2026-04-20→今天),watermark 实时滚动,retention 默认 daily 730 天。后端从一开始就没问题。

## 修复

`selectPreset()` 末尾调 `apply()` —— **快捷预设单击即生效**(符合业界标准 datepicker UX);自定义日期输入仍需点「应用」。一处修复同时覆盖 **admin + 用户两个仪表盘**(共用组件)。

## 测试

- 新增 `DashboardView.daterange-repro.spec.ts`:挂真实 `DateRangePicker` + `Select`,断言实际 snapshot-v2 入参为真实 14 天窗口(非 2 桶)—— 回归护栏。
- 更新 `DateRangePicker.spec.ts` 为「单击即应用」行为。
- 新增只读生产探针 `ops/observability/probe-dashboard-aggregate-coverage.sh`(诊断聚合表/原始表覆盖度,经 `run-probe.sh --target prod`)。

本地全绿:`pnpm typecheck` / `eslint` / 相关 28 测试文件 103 用例通过;`scripts/preflight.sh` PASS(含 `upstream-touch-guarded` 覆写标记 + 重建嵌入 dist 源码哈希)。

🤖 Generated with [Claude Code](https://claude.com/claude-code)
