### PR TITLE
fix(data-layer): backups bucket policy must name role ARN directly (not account-root)

### DIFF
--- a/deploy/aws/cloudformation/stage0-backups.yaml
+++ b/deploy/aws/cloudformation/stage0-backups.yaml
@@ -22,13 +22,18 @@ Parameters:
     MinValue: 1
     MaxValue: 365
     Description: Days to keep each pg_dump copy before lifecycle expiry.
-  AppInstanceRolePattern:
+  AppInstanceRoleArn:
     Type: String
-    Default: tokenkey-prod-stage0-InstanceRole-*
     Description: >
-      IAM role NAME pattern (not ARN) of the app instance role allowed to write
-      backups. CFN auto-suffixes the prod InstanceRole, so a StringLike pattern
-      avoids hardcoding the suffix. The bucket policy grants this role only.
+      Exact IAM role ARN of the app instance role allowed to write backups, e.g.
+      arn:aws:iam::<acct>:role/tokenkey-prod-stage0-InstanceRole-XXXX (get it from
+      `aws cloudformation describe-stack-resources --stack-name tokenkey-prod-stage0
+      --query "StackResources[?LogicalResourceId=='InstanceRole'].PhysicalResourceId"`).
+      Must be the ROLE ARN named DIRECTLY as the bucket-policy Principal: an
+      account-root principal (arn:...:root) is only a delegation and would still
+      require an identity-based policy, which we deliberately avoid (no prod
+      instance-stack update). Naming the role ARN directly makes the bucket policy
+      alone sufficient (same-account resource-based grant).
 
 Resources:
   PgdumpBackupBucket:
@@ -76,30 +81,25 @@ Resources:
               Bool:
                 'aws:SecureTransport': 'false'
           # Grant the app instance role write (and read-for-restore) on the
-          # prod/pgdump/* prefix. Principal=account-root narrowed by
-          # aws:PrincipalArn StringLike to the InstanceRole name pattern, so we
-          # never need the CFN-generated role suffix and never touch the
-          # instance stack. Same-account: this resource policy alone authorizes.
+          # prod/pgdump/* prefix. The role ARN is named DIRECTLY as Principal —
+          # same-account resource-based grant is then sufficient on its own, so we
+          # never touch the prod instance stack. (An account-root principal is only
+          # a delegation and would ALSO require an identity policy — verified the
+          # hard way: it AccessDenied'd s3:PutObject on first activation.)
           - Sid: AllowAppInstanceRolePutGet
             Effect: Allow
             Principal:
-              AWS: !Sub 'arn:${AWS::Partition}:iam::${AWS::AccountId}:root'
+              AWS: !Ref AppInstanceRoleArn
             Action:
               - 's3:PutObject'
               - 's3:GetObject'
             Resource: !Sub '${PgdumpBackupBucket.Arn}/${Environment}/pgdump/*'
-            Condition:
-              StringLike:
-                'aws:PrincipalArn': !Sub 'arn:${AWS::Partition}:iam::${AWS::AccountId}:role/${AppInstanceRolePattern}'
           - Sid: AllowAppInstanceRoleList
             Effect: Allow
             Principal:
-              AWS: !Sub 'arn:${AWS::Partition}:iam::${AWS::AccountId}:root'
+              AWS: !Ref AppInstanceRoleArn
             Action: 's3:ListBucket'
             Resource: !GetAtt PgdumpBackupBucket.Arn
-            Condition:
-              StringLike:
-                'aws:PrincipalArn': !Sub 'arn:${AWS::Partition}:iam::${AWS::AccountId}:role/${AppInstanceRolePattern}'
 
 Outputs:
   BucketName:


### PR DESCRIPTION
## 问题（激活 #619 时实测发现）
#619 的 `stage0-backups.yaml` 用 `Principal: account-root + Condition aws:PrincipalArn StringLike role/*` 授 InstanceRole 写 S3，基于"同账号 bucket policy 单独即授权"的假设。**该假设对 account-root principal 不成立**——account-root 只是「委托给 IAM」，角色仍需 identity policy。激活时 `s3:PutObject` 报：
```
AccessDenied ... role/tokenkey-prod-stage0-InstanceRole-... is not authorized to perform s3:PutObject
because no identity-based policy allows the s3:PutObject action
```

## 修复
bucket policy 的 Principal **直接写角色 ARN**（同账号资源策略单独即足够，仍不碰 prod 实例栈）。参数 `AppInstanceRolePattern`(name glob) → `AppInstanceRoleArn`(精确 ARN，部署时传)。删掉 account-root + condition。

## 已验证
live prod 栈已用修正策略 re-deploy；off-box 实测通过——229MiB dump 已落 `s3://tokenkey-prod-pgdump-682751977094/prod/pgdump/`，journal 显示 `off-boxed ... -> s3://...`，无 AccessDenied。本 PR 把修复落 main 使仓库模板与 live 栈一致。

## 验证
`aws cloudformation validate-template` 通过；`PREFLIGHT_BASE=origin/main scripts/preflight.sh` 全绿（CFN version）；纯 deploy/ CFN 改动 → `no-web-impact`。

🤖 Generated with [Claude Code](https://claude.com/claude-code)