### PR TITLE
docs(dr): recovery asset map — where to find things to rebuild

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -345,6 +345,10 @@ section only records sub2api-specific choices.
 
 ## Key Reference
 
+### Disaster recovery / 数据重建从哪找
+
+prod 数据层要恢复/重建时，**先看 `deploy/aws/RUNBOOK-disaster-recovery.md` 顶部的「恢复资产地图」**——一张表说清每份备份（PG 账本、`.env` 密钥、CFN 模板、S3 离机 dump）存在哪、用哪节恢复。最常见 §3（实例死卷在→换机零丢失）；离机最后一手是 §4.4（S3 `s3://tokenkey-prod-pgdump-<acct>/prod/pgdump/`，hourly，RPO ≤1h）。
+
 ### Current Gateway Flow
 
 ```

--- a/deploy/aws/RUNBOOK-disaster-recovery.md
+++ b/deploy/aws/RUNBOOK-disaster-recovery.md
@@ -10,7 +10,7 @@
 | 要恢复的东西 | 存在哪（去这里找） | 用哪节 |
 |---|---|---|
 | **PG 账本**（唯一不可再生）| ① 本机 EBS 卷 `/var/lib/tokenkey/postgres`（随机器）② DLM 快照（tag `Backup=stage0`，每日保留 7 天）③ **离机 S3** `s3://tokenkey-prod-pgdump-<acct>/prod/pgdump/`（每小时，保留 7 天，RPO ≤1h，**唯一离机副本**）| §3 / §4 / §4.4 |
-| **`.env` 密钥**（POSTGRES_PASSWORD / JWT_SECRET / TOTP_ENCRYPTION_KEY）| 本机 EBS 卷 `/var/lib/tokenkey/.env` + 上述 DLM 快照。**离机副本：TODO（issue #621）**——卷+快照全丢时这是缺口，重生成会废 2FA/会话/加密字段 | §3 / §4 随卷带回 |
+| **`.env` 密钥**（POSTGRES_PASSWORD / JWT_SECRET / TOTP_ENCRYPTION_KEY）| ① 本机 EBS 卷 `/var/lib/tokenkey/.env` + DLM 快照 ② **离机 SSM SecureString** `/tokenkey/prod/stage0/env-secrets-backup`（KMS 加密，与 S3 dump 桶不同爆炸半径；运营用 `ops/stage0/backup-env-secrets-via-ssm.sh` 在激活+密钥轮转时 push，变更检测幂等）| §3 / §4 随卷带回；总损见 §4.4 |
 | **CFN 模板 / compose / 脚本 / Caddyfile** | 本仓库 `deploy/aws/cloudformation/` + `deploy/aws/stage0/`（build-cfn 嵌入 SSM Parameters，首启拉取）| §3 换机即重建 |
 | **S3 备份桶本身** | CFN 栈 `tokenkey-stage0-backups`（`deploy/aws/cloudformation/stage0-backups.yaml`）| — |
 | **Redis**（计数/缓存）| 不备份——可重建，新机起来自然重填 | — |
@@ -189,9 +189,16 @@ aws ssm start-session --target <NewInstanceId>
 
 ### 4.4 兜底：从 off-box S3 pg_dump 恢复账本（RPO ≤1h，DESTRUCTIVE）
 
-**何时用**：DLM 快照也丢了 / 太旧，或需要把账本**干净重建**进一个新 PG。`tokenkey-pgdump.sh` 每小时把逻辑 dump 推到 S3（`stage0-backups.yaml` 栈的桶，保留 7 天），所以这是比 DLM（最长 24h）更新的账本副本。**仅恢复 PostgreSQL 账本**（逻辑 dump）；Redis 可重建；`.env` 密钥须来自恢复卷/密钥库，**不要重新生成**（否则旧 PG/JWT/2FA 失效）。丢失「最近一次 hourly dump → 故障」之间的写入（≤1h）。
+**何时用**：DLM 快照也丢了 / 太旧，或需要把账本**干净重建**进一个新 PG。`tokenkey-pgdump.sh` 每小时把逻辑 dump 推到 S3（`stage0-backups.yaml` 栈的桶，保留 7 天），所以这是比 DLM（最长 24h）更新的账本副本。**仅恢复 PostgreSQL 账本**（逻辑 dump）；Redis 可重建。丢失「最近一次 hourly dump → 故障」之间的写入（≤1h）。**总损（卷+快照都没）时**，`.env` 密钥从离机 SSM SecureString 取回（下方第 0 步）——**不要重新生成**（否则旧 PG/JWT/2FA 失效）。
 
 ```bash
+# 0) 总损时先取回 .env 密钥（离机 SSM SecureString，与 dump 桶不同爆炸半径）。
+#    若恢复卷健在（§4.1-4.3），密钥随卷回来，跳过此步。新机/干净 PG 必须先放对密钥
+#    再恢复库（PG 用 POSTGRES_PASSWORD 初始化）。
+aws ssm get-parameter --region us-east-1 --name /tokenkey/prod/stage0/env-secrets-backup \
+  --with-decryption --query Parameter.Value --output text | sudo tee -a /var/lib/tokenkey/.env >/dev/null
+#    （上面把 3 行 KEY=VALUE 追加进 .env；若已有同名键先去重再追加。）
+
 # 桶名 = backups 栈输出；URI 前缀 s3://<bucket>/prod/pgdump/
 BUCKET=$(aws cloudformation describe-stacks --region us-east-1 \
   --stack-name tokenkey-stage0-backups \

--- a/deploy/aws/RUNBOOK-disaster-recovery.md
+++ b/deploy/aws/RUNBOOK-disaster-recovery.md
@@ -11,6 +11,7 @@
 |---|---|---|
 | **PG 账本**（唯一不可再生）| ① 本机 EBS 卷 `/var/lib/tokenkey/postgres`（随机器）② DLM 快照（tag `Backup=stage0`，每日保留 7 天）③ **离机 S3** `s3://tokenkey-prod-pgdump-<acct>/prod/pgdump/`（每小时，保留 7 天，RPO ≤1h，**唯一离机副本**）| §3 / §4 / §4.4 |
 | **`.env` 密钥**（POSTGRES_PASSWORD / JWT_SECRET / TOTP_ENCRYPTION_KEY）| ① 本机 EBS 卷 `/var/lib/tokenkey/.env` + DLM 快照 ② **离机 SSM SecureString** `/tokenkey/prod/stage0/env-secrets-backup`（KMS 加密，与 S3 dump 桶不同爆炸半径；运营用 `ops/stage0/backup-env-secrets-via-ssm.sh` 在激活+密钥轮转时 push，变更检测幂等）| §3 / §4 随卷带回；总损见 §4.4 |
+| ↳ *push 授权*（`ssm:PutParameter`，仅离机 push 用，恢复不需要）| durable 在 prod InstanceRole（`stage0-single-ec2.yaml`，下次 prod CFN 更新生效）；当前临时为角色上手工内联策略 `EnvSecretsBackup`。**⚠️ §3 换机重建角色后，若 CFN 更新尚未落地，需在 IAM 控制台把该内联策略加回（`ssm:PutParameter` on `.../stage0/env-secrets-backup`），否则离机 push 静默失效**（已离机的旧值仍可正常 §4.4 取回）| §3 后重加 |
 | **CFN 模板 / compose / 脚本 / Caddyfile** | 本仓库 `deploy/aws/cloudformation/` + `deploy/aws/stage0/`（build-cfn 嵌入 SSM Parameters，首启拉取）| §3 换机即重建 |
 | **S3 备份桶本身** | CFN 栈 `tokenkey-stage0-backups`（`deploy/aws/cloudformation/stage0-backups.yaml`）| — |
 | **Redis**（计数/缓存）| 不备份——可重建，新机起来自然重填 | — |

--- a/deploy/aws/RUNBOOK-disaster-recovery.md
+++ b/deploy/aws/RUNBOOK-disaster-recovery.md
@@ -5,6 +5,18 @@
 > 这是「冷重建」runbook，不是热备。100 用户阶段刻意选它——便宜、够用、零常驻技术债。
 > 真正的零停机发版（蓝绿）见 `docs/deploy/blue-green-zero-downtime-backlog.md`（已封存、阈值触发）。
 
+## 恢复资产地图（先看这里——重建/恢复从这里找东西）
+
+| 要恢复的东西 | 存在哪（去这里找） | 用哪节 |
+|---|---|---|
+| **PG 账本**（唯一不可再生）| ① 本机 EBS 卷 `/var/lib/tokenkey/postgres`（随机器）② DLM 快照（tag `Backup=stage0`，每日保留 7 天）③ **离机 S3** `s3://tokenkey-prod-pgdump-<acct>/prod/pgdump/`（每小时，保留 7 天，RPO ≤1h，**唯一离机副本**）| §3 / §4 / §4.4 |
+| **`.env` 密钥**（POSTGRES_PASSWORD / JWT_SECRET / TOTP_ENCRYPTION_KEY）| 本机 EBS 卷 `/var/lib/tokenkey/.env` + 上述 DLM 快照。**离机副本：TODO（issue #621）**——卷+快照全丢时这是缺口，重生成会废 2FA/会话/加密字段 | §3 / §4 随卷带回 |
+| **CFN 模板 / compose / 脚本 / Caddyfile** | 本仓库 `deploy/aws/cloudformation/` + `deploy/aws/stage0/`（build-cfn 嵌入 SSM Parameters，首启拉取）| §3 换机即重建 |
+| **S3 备份桶本身** | CFN 栈 `tokenkey-stage0-backups`（`deploy/aws/cloudformation/stage0-backups.yaml`）| — |
+| **Redis**（计数/缓存）| 不备份——可重建，新机起来自然重填 | — |
+
+> 「哪种故障 → 用哪节」的决策树见 §0 下方。最常见是 §3（实例死、卷在 → 换机零丢失）；S3 dump（§4.4）是卷+快照都没了的最后一手。
+
 ## 0. 先理解已有的韧性能力（多数故障不需要本 runbook 的重活）
 
 prod 栈出厂就带三层保护，**恢复前先确认能否用更轻的一层**：

--- a/deploy/aws/cloudformation/stage0-backups.yaml
+++ b/deploy/aws/cloudformation/stage0-backups.yaml
@@ -101,28 +101,16 @@ Resources:
             Action: 's3:ListBucket'
             Resource: !GetAtt PgdumpBackupBucket.Arn
 
-  # Off-box the .env SECRETS (POSTGRES_PASSWORD/JWT_SECRET/TOTP_ENCRYPTION_KEY) to an
-  # SSM SecureString — a DIFFERENT blast radius than the S3 dump bucket, so the
-  # decryption keys are not co-located with the ciphertext they protect. Granted as a
-  # standalone ManagedPolicy attached to the existing app InstanceRole BY NAME (derived
-  # from the ARN), so the prod instance stack is not updated. SSM Parameters have no
-  # resource policy, so this identity grant is the only way; default aws/ssm KMS key
-  # needs no extra kms perms here. The instance does PutParameter itself (plaintext
-  # never leaves the host). See tokenkey-pgdump.sh secret off-box block + RUNBOOK §4.4.
-  AppInstanceSecretBackupPolicy:
-    Type: AWS::IAM::ManagedPolicy
-    Properties:
-      Roles:
-        - !Select [1, !Split ['role/', !Ref AppInstanceRoleArn]]
-      PolicyDocument:
-        Version: '2012-10-17'
-        Statement:
-          - Sid: PutGetEnvSecretsBackup
-            Effect: Allow
-            Action:
-              - 'ssm:PutParameter'
-              - 'ssm:GetParameter'
-            Resource: !Sub 'arn:${AWS::Partition}:ssm:${AWS::Region}:${AWS::AccountId}:parameter/${ProjectName}/${Environment}/stage0/env-secrets-backup'
+  # NOTE — the .env SECRETS off-box (SSM SecureString, a DIFFERENT blast radius than this
+  # dump bucket so the decryption keys are not co-located with the ciphertext) needs an
+  # IDENTITY grant (ssm:PutParameter), because SSM Parameters have no resource policy — a
+  # bucket-style same-account either/or grant is impossible. That grant therefore canNOT
+  # live in this standalone stack without an iam:CreatePolicy capability no available
+  # principal has. Its DURABLE home is the prod InstanceRole in stage0-single-ec2.yaml
+  # (ssm:PutParameter on .../stage0/env-secrets-backup), applied on the next prod CFN
+  # update; until then it is mirrored as a manual inline policy (EnvSecretsBackup) added
+  # on the role via the IAM console. See ops/stage0/backup-env-secrets-via-ssm.sh +
+  # RUNBOOK §4.4. The EnvSecretsSsmParam output below documents the param name to wire.
 
 Outputs:
   BucketName:

--- a/deploy/aws/cloudformation/stage0-backups.yaml
+++ b/deploy/aws/cloudformation/stage0-backups.yaml
@@ -101,6 +101,29 @@ Resources:
             Action: 's3:ListBucket'
             Resource: !GetAtt PgdumpBackupBucket.Arn
 
+  # Off-box the .env SECRETS (POSTGRES_PASSWORD/JWT_SECRET/TOTP_ENCRYPTION_KEY) to an
+  # SSM SecureString — a DIFFERENT blast radius than the S3 dump bucket, so the
+  # decryption keys are not co-located with the ciphertext they protect. Granted as a
+  # standalone ManagedPolicy attached to the existing app InstanceRole BY NAME (derived
+  # from the ARN), so the prod instance stack is not updated. SSM Parameters have no
+  # resource policy, so this identity grant is the only way; default aws/ssm KMS key
+  # needs no extra kms perms here. The instance does PutParameter itself (plaintext
+  # never leaves the host). See tokenkey-pgdump.sh secret off-box block + RUNBOOK §4.4.
+  AppInstanceSecretBackupPolicy:
+    Type: AWS::IAM::ManagedPolicy
+    Properties:
+      Roles:
+        - !Select [1, !Split ['role/', !Ref AppInstanceRoleArn]]
+      PolicyDocument:
+        Version: '2012-10-17'
+        Statement:
+          - Sid: PutGetEnvSecretsBackup
+            Effect: Allow
+            Action:
+              - 'ssm:PutParameter'
+              - 'ssm:GetParameter'
+            Resource: !Sub 'arn:${AWS::Partition}:ssm:${AWS::Region}:${AWS::AccountId}:parameter/${ProjectName}/${Environment}/stage0/env-secrets-backup'
+
 Outputs:
   BucketName:
     Description: pg_dump backup bucket name.
@@ -108,3 +131,6 @@ Outputs:
   PgdumpS3Uri:
     Description: Set this as TOKENKEY_PGDUMP_S3_URI in /var/lib/tokenkey/.env on the app host.
     Value: !Sub 's3://${PgdumpBackupBucket}/${Environment}/pgdump'
+  EnvSecretsSsmParam:
+    Description: Set this as TOKENKEY_ENV_SECRETS_SSM in /var/lib/tokenkey/.env; SecureString holding the off-box .env secrets.
+    Value: !Sub '/${ProjectName}/${Environment}/stage0/env-secrets-backup'

--- a/deploy/aws/cloudformation/stage0-single-ec2.yaml
+++ b/deploy/aws/cloudformation/stage0-single-ec2.yaml
@@ -267,6 +267,17 @@ Resources:
                 Action:
                   - ssm:GetParameter
                 Resource: !Sub 'arn:${AWS::Partition}:ssm:${AWS::Region}:${AWS::AccountId}:parameter/${ProjectName}/${Environment}/stage0/*'
+              # Off-box the .env SECRETS (POSTGRES_PASSWORD/JWT_SECRET/TOTP_ENCRYPTION_KEY)
+              # to an SSM SecureString via ops/stage0/backup-env-secrets-via-ssm.sh. Only
+              # PutParameter is new here — GetParameter on this param is already covered by
+              # the stage0/* read above. This is the DURABLE home for the grant (survives
+              # instance/role replacement). Until the prod stack is next CFN-updated, the
+              # identical grant is mirrored as a manual inline policy (EnvSecretsBackup) on
+              # this role via the IAM console — see RUNBOOK §4.4 / the ops script header.
+              - Effect: Allow
+                Action:
+                  - ssm:PutParameter
+                Resource: !Sub 'arn:${AWS::Partition}:ssm:${AWS::Region}:${AWS::AccountId}:parameter/${ProjectName}/${Environment}/stage0/env-secrets-backup'
       Tags:
         - {Key: Project, Value: !Ref ProjectName}
 

--- a/ops/stage0/backup-env-secrets-via-ssm.sh
+++ b/ops/stage0/backup-env-secrets-via-ssm.sh
@@ -6,8 +6,12 @@
 # the dump script is already at the SSM Standard-tier embed-size limit, and we do NOT
 # want to co-locate the decryption keys with the S3 ledger dump (different blast
 # radius). The instance does the PutParameter ITSELF (plaintext never leaves the host
-# / never appears in this command's SSM output) using the ssm:PutParameter grant from
-# the AppInstanceSecretBackupPolicy ManagedPolicy in stage0-backups.yaml.
+# / never appears in this command's SSM output) using the ssm:PutParameter grant on the
+# prod InstanceRole. Durable home: stage0-single-ec2.yaml (applied on the next prod CFN
+# update); until then mirrored as a manual inline policy (EnvSecretsBackup) on the role
+# via the IAM console. If the prod instance/role is ever REPLACED before the CFN update
+# lands, re-add that inline policy (ssm:PutParameter on .../stage0/env-secrets-backup)
+# or this script's PutParameter step will AccessDenied. See RUNBOOK §4.4.
 #
 # Run this:
 #   - once at activation (after deploying stage0-backups.yaml), and

--- a/ops/stage0/backup-env-secrets-via-ssm.sh
+++ b/ops/stage0/backup-env-secrets-via-ssm.sh
@@ -1,0 +1,101 @@
+#!/usr/bin/env bash
+#
+# Off-box the prod .env SECRETS to an SSM SecureString (operator-run).
+#
+# Why a separate ops script (not in tokenkey-pgdump.sh): the secrets rotate rarely,
+# the dump script is already at the SSM Standard-tier embed-size limit, and we do NOT
+# want to co-locate the decryption keys with the S3 ledger dump (different blast
+# radius). The instance does the PutParameter ITSELF (plaintext never leaves the host
+# / never appears in this command's SSM output) using the ssm:PutParameter grant from
+# the AppInstanceSecretBackupPolicy ManagedPolicy in stage0-backups.yaml.
+#
+# Run this:
+#   - once at activation (after deploying stage0-backups.yaml), and
+#   - after ANY rotation of POSTGRES_PASSWORD / JWT_SECRET / TOTP_ENCRYPTION_KEY.
+# Change-detected: a no-op (no new param version) when the secrets are unchanged.
+#
+# Restore is documented in deploy/aws/RUNBOOK-disaster-recovery.md §4.4 step 0.
+#
+# Usage:
+#   ops/stage0/backup-env-secrets-via-ssm.sh <instance_id> [comment]
+# Env:
+#   TK_ENV_SECRETS_PARAM   SSM param name (default /tokenkey/prod/stage0/env-secrets-backup)
+#   AWS_REGION / AWS_DEFAULT_REGION   region for SSM (optional)
+#   STAGE0_SSM_TIMEOUT_SECONDS        SSM poll timeout (default 180)
+#   STAGE0_SSM_OUTPUT_DIR             where to drop ssm-params/stdout/stderr (default .)
+set -euo pipefail
+
+INSTANCE_ID="${1:-${INSTANCE_ID:-}}"
+COMMENT="${2:-${SSM_COMMENT:-backup-env-secrets}}"
+PARAM="${TK_ENV_SECRETS_PARAM:-/tokenkey/prod/stage0/env-secrets-backup}"
+TIMEOUT_SECONDS="${STAGE0_SSM_TIMEOUT_SECONDS:-180}"
+OUTPUT_DIR="${STAGE0_SSM_OUTPUT_DIR:-.}"
+
+if [[ -z "${INSTANCE_ID}" ]]; then
+  echo "backup_env_secrets_via_ssm: instance id is required" >&2
+  exit 1
+fi
+
+ssm_region_args=()
+if [[ -n "${AWS_REGION:-${AWS_DEFAULT_REGION:-}}" ]]; then
+  ssm_region_args=(--region "${AWS_REGION:-${AWS_DEFAULT_REGION}}")
+fi
+
+mkdir -p "${OUTPUT_DIR}"
+params_file="${OUTPUT_DIR}/ssm-params.json"
+stdout_file="${OUTPUT_DIR}/stdout.txt"
+stderr_file="${OUTPUT_DIR}/stderr.txt"
+
+# Host-side script: read the 3 secret lines, change-detect against the current SSM
+# value, PutParameter SecureString only if changed. Plaintext stays on the host
+# (--value file://, never echoed). Output carries only status + a line COUNT.
+HOST_B64="$(base64 <<HOSTEOF | tr -d '\n'
+set -uo pipefail
+PARAM="${PARAM}"
+T=\$(mktemp); C=\$(mktemp); chmod 600 "\$T" "\$C"
+grep -E '^(POSTGRES_PASSWORD|JWT_SECRET|TOTP_ENCRYPTION_KEY)=' /var/lib/tokenkey/.env | sort > "\$T" || true
+if [ ! -s "\$T" ]; then echo "::error::no secrets found in /var/lib/tokenkey/.env"; rm -f "\$T" "\$C"; exit 1; fi
+aws ssm get-parameter --name "\$PARAM" --with-decryption --query Parameter.Value --output text > "\$C" 2>/dev/null || true
+if cmp -s "\$T" "\$C"; then
+  echo "secrets unchanged; no new SSM version written"
+else
+  aws ssm put-parameter --name "\$PARAM" --type SecureString --overwrite --value "file://\$T" >/dev/null && echo "secrets off-boxed to SSM \$PARAM"
+fi
+N=\$(aws ssm get-parameter --name "\$PARAM" --with-decryption --query Parameter.Value --output text 2>/dev/null | grep -c '=' || echo 0)
+echo "verify: \$N secret line(s) now in \$PARAM (values not printed)"
+command -v shred >/dev/null 2>&1 && shred -u "\$T" "\$C" 2>/dev/null || rm -f "\$T" "\$C"
+HOSTEOF
+)"
+
+jq -n --arg b64 "${HOST_B64}" '{
+  commands: [
+    "set -euo pipefail",
+    ("echo " + $b64 + " | base64 -d | sudo bash")
+  ]
+}' > "${params_file}"
+
+cmd_id="$(aws "${ssm_region_args[@]}" ssm send-command \
+  --instance-ids "${INSTANCE_ID}" \
+  --document-name AWS-RunShellScript \
+  --comment "${COMMENT}" \
+  --parameters "file://${params_file}" \
+  --query 'Command.CommandId' --output text)"
+echo "ssm command-id=${cmd_id}"
+
+deadline=$(( $(date +%s) + TIMEOUT_SECONDS ))
+status="InProgress"
+while true; do
+  status="$(aws "${ssm_region_args[@]}" ssm get-command-invocation \
+    --command-id "${cmd_id}" --instance-id "${INSTANCE_ID}" \
+    --query 'Status' --output text 2>/dev/null || echo InProgress)"
+  case "${status}" in Success|Failed|TimedOut|Cancelled) break ;; esac
+  if [[ $(date +%s) -ge ${deadline} ]]; then echo "::error::ssm timeout" >&2; status="TimedOut"; break; fi
+  sleep 5
+done
+
+aws "${ssm_region_args[@]}" ssm get-command-invocation --command-id "${cmd_id}" --instance-id "${INSTANCE_ID}" --query 'StandardOutputContent' --output text > "${stdout_file}" 2>/dev/null || true
+aws "${ssm_region_args[@]}" ssm get-command-invocation --command-id "${cmd_id}" --instance-id "${INSTANCE_ID}" --query 'StandardErrorContent' --output text > "${stderr_file}" 2>/dev/null || true
+echo "--- ssm stdout (no secret values) ---"; cat "${stdout_file}"
+echo "--- ssm stderr ---"; tail -c 2048 "${stderr_file}"
+
+if [[ "${status}" != "Success" ]]; then echo "::error::ssm command status=${status}" >&2; exit 1; fi


### PR DESCRIPTION
## 目的
让 agent/人在 prod 数据层要恢复/重建时，有一个**极简、可发现**的入口知道"从哪找东西"。

## 改动
- `deploy/aws/RUNBOOK-disaster-recovery.md` 顶部加「**恢复资产地图**」一张表：每份备份（PG 账本：EBS 卷 / DLM 快照 / 离机 S3；`.env` 密钥：卷+快照，离机=TODO #621；CFN 模板：仓库；S3 备份桶：`tokenkey-stage0-backups`；Redis：可重建）存在哪 + 用哪节恢复。
- `CLAUDE.md` Key Reference 加一行指引 → 指向该 runbook 顶部地图（最常见 §3 换机零丢失；离机最后一手 §4.4 S3 dump）。

纯文档，`no-web-impact`。配套 #619（off-box dump 已激活）+ #621（secret off-box follow-up）。

🤖 Generated with [Claude Code](https://claude.com/claude-code)