### PR TITLE
fix(keys): UseKeyModal 推荐 ANTHROPIC_MODEL 用实测可服务的 claude-opus-4-8[1m]

### DIFF
--- a/backend/internal/web/dist/frontend-source.json
+++ b/backend/internal/web/dist/frontend-source.json
@@ -1,7 +1,7 @@
 {
   "algorithm": "sha256(git-ls-files:path,size,content)",
   "file_count": 454,
-  "hash": "5571a51ced4550287ac8c72da20e8c20137d05559bfabbf3d58340f372397c1a",
+  "hash": "0d56cd26d85ff53f94f90130ab1adeec4683e54284d9c1031d4023c88481cfc2",
   "schema": 1,
   "source": "frontend/"
 }

--- a/backend/internal/web/dist/frontend-source.json
+++ b/backend/internal/web/dist/frontend-source.json
@@ -1,7 +1,7 @@
 {
   "algorithm": "sha256(git-ls-files:path,size,content)",
   "file_count": 454,
-  "hash": "2ea8a3b2f3fa319141a1de50250e3354a4157c4427d5febd347f547461a1e376",
+  "hash": "5571a51ced4550287ac8c72da20e8c20137d05559bfabbf3d58340f372397c1a",
   "schema": 1,
   "source": "frontend/"
 }

--- a/frontend/src/components/keys/UseKeyModal.vue
+++ b/frontend/src/components/keys/UseKeyModal.vue
@@ -474,7 +474,16 @@ const currentFiles = computed((): FileConfig[] => {
 
 function generateAnthropicFiles(baseUrl: string, apiKey: string): FileConfig[] {
   // Recommended defaults (TokenKey + Claude Code; see code.claude.com env docs):
-  //   - model opus[1m] + DISABLE_ADAPTIVE_THINKING + fixed MAX_THINKING_TOKENS: 稳定思考预算
+  //   - model claude-opus-4-8[1m] + DISABLE_ADAPTIVE_THINKING + fixed MAX_THINKING_TOKENS: 稳定思考预算
+  //     NOTE: the model id MUST be a real, empirically-servable Anthropic id
+  //     (see backend supportedAnthropicCatalogModels, regenerated from a live
+  //     prod probe). A bare alias like `opus` is NOT servable: the gateway
+  //     strips the trailing `[1m]` context-window suffix (gateway_anthropic_
+  //     context_window_alias_tk.go) so `opus[1m]` collapses to `opus`, which is
+  //     rejected upstream as model-not-found and surfaced as 400 invalid_request
+  //     (PR #617). `claude-opus-4-8[1m]` collapses to the servable
+  //     `claude-opus-4-8` while the separate `context-1m-2025-08-07` beta header
+  //     still activates the 1M window.
   //   - CLAUDE_CODE_AUTOCOMPACT_PCT_OVERRIDE=60: 约 60% 上下文占用时触发自动压缩（1M 窗口下更稳）
   //   - 不默认开 DISABLE_NONESSENTIAL_TRAFFIC: 直连 Anthropic 时它会把 cache TTL 从 1h 砍到 5min
   let path: string
@@ -485,7 +494,7 @@ function generateAnthropicFiles(baseUrl: string, apiKey: string): FileConfig[] {
       path = 'Terminal'
       content = `export ANTHROPIC_BASE_URL="${baseUrl}"
 export ANTHROPIC_AUTH_TOKEN="${apiKey}"
-export ANTHROPIC_MODEL="opus[1m]"
+export ANTHROPIC_MODEL="claude-opus-4-8[1m]"
 
 # 防降智 + 控成本（详见 hint）
 export CLAUDE_CODE_DISABLE_ADAPTIVE_THINKING=1
@@ -501,7 +510,7 @@ export CLAUDE_CODE_AUTOCOMPACT_PCT_OVERRIDE=60
       path = 'Command Prompt'
       content = `set ANTHROPIC_BASE_URL=${baseUrl}
 set ANTHROPIC_AUTH_TOKEN=${apiKey}
-set ANTHROPIC_MODEL=opus[1m]
+set ANTHROPIC_MODEL=claude-opus-4-8[1m]
 
 set CLAUDE_CODE_DISABLE_ADAPTIVE_THINKING=1
 set MAX_THINKING_TOKENS=31999
@@ -516,7 +525,7 @@ REM set CLAUDE_CODE_MAKE_NO_MISTAKES=1`
       path = 'PowerShell'
       content = `$env:ANTHROPIC_BASE_URL="${baseUrl}"
 $env:ANTHROPIC_AUTH_TOKEN="${apiKey}"
-$env:ANTHROPIC_MODEL="opus[1m]"
+$env:ANTHROPIC_MODEL="claude-opus-4-8[1m]"
 
 $env:CLAUDE_CODE_DISABLE_ADAPTIVE_THINKING="1"
 $env:MAX_THINKING_TOKENS="31999"
@@ -537,7 +546,7 @@ $env:CLAUDE_CODE_AUTOCOMPACT_PCT_OVERRIDE="60"
     : '%userprofile%\\.claude\\settings.json'
 
   const vscodeContent = `{
-  "model": "opus[1m]",
+  "model": "claude-opus-4-8[1m]",
   "effortLevel": "high",
   "env": {
     "ANTHROPIC_BASE_URL": "${baseUrl}",

--- a/frontend/src/components/keys/UseKeyModal.vue
+++ b/frontend/src/components/keys/UseKeyModal.vue
@@ -700,23 +700,16 @@ function generateOpenCodeConfig(platform: string, baseUrl: string, apiKey: strin
       }
     }
   }
+  // NOTE: keep this catalog aligned with the empirically-servable OpenAI set
+  // (backend supportedOpenAICatalogModels, regenerated from a live prod probe —
+  // PR #608). gpt-5.2 was dropped here because the probe returned 502 on the
+  // chat/completions path opencode uses and it is retired from the servable
+  // allowlist + public catalog + Your Menu. gpt-5.3-codex / codex-mini-latest
+  // are intentionally LEFT for now: they 502 on the API-key chat/completions
+  // path but carry a codex-ws ChatGPT-OAuth reverse-mapping
+  // (normalizeOpenAIModelForUpstream, scripts/sentinels/gateway-tk.json), so
+  // their true servability needs a codex-ws probe before removal.
   const openaiModels = {
-    'gpt-5.2': {
-      name: 'GPT-5.2',
-      limit: {
-        context: 400000,
-        output: 128000
-      },
-      options: {
-        store: false
-      },
-      variants: {
-        low: {},
-        medium: {},
-        high: {},
-        xhigh: {}
-      }
-    },
     'gpt-5.5': {
       name: 'GPT-5.5',
       limit: {

--- a/frontend/src/components/keys/__tests__/UseKeyModal.spec.ts
+++ b/frontend/src/components/keys/__tests__/UseKeyModal.spec.ts
@@ -159,7 +159,7 @@ describe('UseKeyModal', () => {
     expect(joined).toContain('31999')
     expect(joined).toContain('CLAUDE_CODE_AUTOCOMPACT_PCT_OVERRIDE')
     expect(joined).toContain('60')
-    expect(joined).toContain('opus[1m]')
+    expect(joined).toContain('claude-opus-4-8[1m]')
     expect(joined).toContain('"effortLevel": "high"')
 
     const activeBlocks = codeBlocks.filter((s) => /^\s*export CLAUDE_CODE_DISABLE_NONESSENTIAL_TRAFFIC=1\s*$/m.test(s))

--- a/frontend/src/i18n/locales/en.ts
+++ b/frontend/src/i18n/locales/en.ts
@@ -879,7 +879,7 @@ export default {
       },
       claudeCode: {
         envHint:
-          'Recommended: model opus[1m]; disables adaptive thinking (avoids silent down-grading); pins thinking budget to 31999 tokens; triggers auto-compact at ~60% context use (CLAUDE_CODE_AUTOCOMPACT_PCT_OVERRIDE). The commented NONESSENTIAL_TRAFFIC flag should only be enabled when routing directly to Anthropic OAuth — otherwise upstream prompt cache TTL drops from 1h to 5min and token cost spikes.',
+          'Recommended: model claude-opus-4-8[1m]; disables adaptive thinking (avoids silent down-grading); pins thinking budget to 31999 tokens; triggers auto-compact at ~60% context use (CLAUDE_CODE_AUTOCOMPACT_PCT_OVERRIDE). The commented NONESSENTIAL_TRAFFIC flag should only be enabled when routing directly to Anthropic OAuth — otherwise upstream prompt cache TTL drops from 1h to 5min and token cost spikes.',
         vscodeHint:
           'Claude Code settings.json with effortLevel=high and all recommended env vars. Replace the file to apply.',
       },

--- a/frontend/src/i18n/locales/zh.ts
+++ b/frontend/src/i18n/locales/zh.ts
@@ -878,7 +878,7 @@ export default {
       },
       claudeCode: {
         envHint:
-          '推荐配置：模型 opus[1m]；禁用动态思考(防降智)；固定 31999 tokens 思考预算；约 60% 上下文占用时自动压缩（CLAUDE_CODE_AUTOCOMPACT_PCT_OVERRIDE）。注释掉的 NONESSENTIAL_TRAFFIC 标志仅在直连 Anthropic OAuth 时才考虑开启，否则会让上游 prompt cache TTL 从 1h 降到 5min，token 消耗暴涨。',
+          '推荐配置：模型 claude-opus-4-8[1m]；禁用动态思考(防降智)；固定 31999 tokens 思考预算；约 60% 上下文占用时自动压缩（CLAUDE_CODE_AUTOCOMPACT_PCT_OVERRIDE）。注释掉的 NONESSENTIAL_TRAFFIC 标志仅在直连 Anthropic OAuth 时才考虑开启，否则会让上游 prompt cache TTL 从 1h 降到 5min，token 消耗暴涨。',
         vscodeHint:
           'Claude Code settings.json：包含 effortLevel=high 与全部推荐 env，覆盖即可生效。'
       },

--- a/scripts/sentinels/frontend-tk.json
+++ b/scripts/sentinels/frontend-tk.json
@@ -486,6 +486,13 @@
         "opus_mapped_model: \"gpt-5.5\","
       ],
       "rationale": "Frontend mirror of the Go code-default opus family mapping (backend/internal/service/openai_messages_dispatch.go defaultOpenAIMessagesDispatchOpusMappedModel = gpt-5.5). The admin form prefills this value when group config is empty; if the two copies drift the UI shows a default the gateway will not apply. Keep both sides in lockstep."
+    },
+    {
+      "path": "frontend/src/components/keys/UseKeyModal.vue",
+      "must_contain": [
+        "claude-opus-4-8[1m]"
+      ],
+      "rationale": "The 'Use API Key' modal recommends ANTHROPIC_MODEL for Claude Code. The base id MUST be an empirically-servable Anthropic model (backend supportedAnthropicCatalogModels, regenerated from a live prod probe — PR #608), NOT a bare alias. The gateway strips the trailing [1m] context-window suffix (gateway_anthropic_context_window_alias_tk.go), so a bare 'opus[1m]' collapses to 'opus' and is rejected as a non-servable model name → 400 invalid_request (PR #617), while the user silently never gets 1M context. Pinning the servable id catches a regression back to the bare alias on upstream merge or careless edit. Advance this needle (and the modal's export/settings strings) together when the servable opus generation moves past claude-opus-4-8."
     }
   ]
 }


### PR DESCRIPTION
## 问题

「使用 API 密钥」弹窗（Claude Code 页签）推荐：

```
export ANTHROPIC_MODEL="opus[1m]"
```

但裸别名 `opus` **不在**实测可服务白名单内（#608 固化的 `supportedAnthropicCatalogModels`：`claude-opus-4-1/4-5/4-6/4-7/4-8`），用户照抄会直接失败：

1. 网关 `tkStripContextWindowModelAlias`（`gateway_anthropic_context_window_alias_tk.go`）剥掉尾部 `[1m]` 上下文窗口别名后，`opus[1m]` 塌成裸名 `opus`；
2. 裸名 `opus` 不可服务，按 #617「不可服务模型名=客户端错误」统一返回 `400 invalid_request`（并移出限流指标 / 不触发模型冷却）。

`[1m]` 后缀本身是对的——它只标记 1M 上下文，由独立的 `context-1m-2025-08-07` beta 头激活，网关剥离后不污染 model 字段。**问题只在基名用了裸别名。**

## 改动

`opus[1m]` → `claude-opus-4-8[1m]`（白名单里最新可服务 opus；网关塌成 servable 的 `claude-opus-4-8`，1M 窗口保留）。

- `UseKeyModal.vue`：unix / cmd / powershell 三处 `ANTHROPIC_MODEL` export + `~/.claude/settings.json` 的 `"model"` + 顶部推荐注释（补了为何不能用裸 `opus` 的说明）
- `i18n/locales/en.ts` / `zh.ts`：推荐配置 hint 文案
- `UseKeyModal.spec.ts`：断言更新
- `scripts/sentinels/frontend-tk.json`：新增保护性 sentinel，把「推荐模型必须是实测可服务 id」钉在 `UseKeyModal.vue`，防止以后回退成裸别名
- 重建嵌入式 `backend/internal/web/dist`

纯前端文案/常量修复，不触碰任何 upstream 行为锚点。

## 验证

- `pnpm vitest run UseKeyModal.spec.ts` 4/4 ✅
- `pnpm typecheck` ✅ · `pnpm lint:check` 0 error ✅
- `scripts/preflight.sh` PASS（含 sentinel registry gate + dist freshness）✅

🤖 Generated with [Claude Code](https://claude.com/claude-code)