### PR TITLE
fix(ops): exclude client-cancel (context canceled) upstream errors from upstream_error_rate (#625)

### DIFF
--- a/backend/internal/handler/ops_error_logger.go
+++ b/backend/internal/handler/ops_error_logger.go
@@ -1229,10 +1229,17 @@ func classifyOpsErrorLog(c *gin.Context, errType, message, code string, status i
 	// provider-health P0 capacity alert. See tkUpstreamClientInducedRejection
 	// (prod P0 2026-06-05; mirrors the #602 amplifier boundary).
 	clientInducedUpstream := upstreamError && tkUpstreamClientInducedRejection(c)
-	if upstreamError && !routingCapacityLimited && !clientInducedUpstream {
+	// TK (issue #625): a client/caller disconnect mid-flight surfaces as an upstream
+	// transport error with NO upstream HTTP status (context canceled). It is
+	// caller-fault, not provider health — own it to the client so one canceling
+	// client (and its prod->edge relay fan-out) cannot flood upstream_error_rate.
+	// See tkUpstreamClientCanceled (quad P0 2026-06-06; deadline-exceeded stays
+	// provider-owned).
+	clientCanceledUpstream := upstreamError && tkUpstreamClientCanceled(c)
+	if upstreamError && !routingCapacityLimited && !clientInducedUpstream && !clientCanceledUpstream {
 		phase = "upstream"
 	}
-	if clientInducedUpstream && !routingCapacityLimited {
+	if (clientInducedUpstream || clientCanceledUpstream) && !routingCapacityLimited {
 		phase = "request"
 	}
 	if clientBusinessLimited && !upstreamError && !routingCapacityLimited {

--- a/backend/internal/handler/ops_error_logger_tk_client_canceled.go
+++ b/backend/internal/handler/ops_error_logger_tk_client_canceled.go
@@ -1,0 +1,72 @@
+package handler
+
+import (
+	"context"
+	"errors"
+	"strings"
+
+	"github.com/gin-gonic/gin"
+)
+
+// tkUpstreamClientCanceled reports whether the upstream error captured on the
+// request context is a CLIENT/caller disconnect (Go context.Canceled) rather than
+// a provider/account-health failure or a server-side timeout.
+//
+// Why this exists (issue #625; prod + us2/us3/uk1 quad P0 2026-06-06T07:00-07:16Z):
+// a single automated client issuing non-streaming claude-opus-4-6 with a client
+// timeout shorter than opus latency cancels mid-flight. The outbound request fails
+// with `context canceled` and NO upstream HTTP status, so classifyOpsErrorLog
+// relabels it phase=upstream / error_owner=provider and it counts toward
+// upstream_error_rate (the provider-health P0 capacity alert). Because prod relays
+// the same request to edges via cc-* stub accounts, one client cancel propagates
+// down the chain (client -> prod -> stub -> edge -> anthropic) and each node
+// records its own 502 — so one canceling client floods upstream_error_rate on prod
+// AND every edge it fans out to at once.
+//
+// Owning it to the client (phase=request) drops it out of upstream_error_rate,
+// mirroring tkUpstreamClientInducedRejection. The fix lives at the per-node
+// classification layer: every node checks ITS OWN inbound cancellation, so the
+// same single predicate covers prod and all relayed edges uniformly.
+//
+// CAREFUL: context.Canceled (caller went away) is caller-fault and exempt; a
+// server/upstream timeout surfaces as context.DeadlineExceeded ("deadline
+// exceeded") and MUST stay provider-owned — it is genuine evidence of upstream
+// slowness and SHOULD keep counting toward upstream_error_rate.
+func tkUpstreamClientCanceled(c *gin.Context) bool {
+	if c == nil {
+		return false
+	}
+	// A definitive upstream HTTP status means we DID get an upstream verdict; that
+	// path is owned by status-based classification (provider health or
+	// tkUpstreamClientInducedRejection), never here.
+	if tkOpsUpstreamStatusCode(c) != 0 {
+		return false
+	}
+	// Primary signal: the inbound request context was canceled by the caller
+	// disconnecting. net/http cancels Request.Context() when the client connection
+	// goes away. A context error is either Canceled or DeadlineExceeded (never
+	// both); we accept only Canceled so server-side timeouts stay provider-owned.
+	if c.Request != nil {
+		if reqErr := c.Request.Context().Err(); errors.Is(reqErr, context.Canceled) {
+			return true
+		}
+	}
+	// Fallback: the captured upstream transport error text is a context
+	// cancellation. The forward-failure sites record the sanitized Go error
+	// (sanitizeUpstreamErrorMessage preserves the "context canceled" substring), so
+	// this catches the cancellation even when Request.Context() is unavailable.
+	body, msg := tkOpsUpstreamErrorText(c)
+	combined := strings.ToLower(strings.TrimSpace(msg + "\n" + body))
+	if combined == "" {
+		return false
+	}
+	// Must be the cancellation signature and NOT a deadline/timeout, which stays
+	// provider-owned.
+	if strings.Contains(combined, "deadline exceeded") ||
+		strings.Contains(combined, "timeout") ||
+		strings.Contains(combined, "timed out") {
+		return false
+	}
+	return strings.Contains(combined, "context canceled") ||
+		strings.Contains(combined, "context cancelled")
+}

--- a/backend/internal/handler/ops_error_logger_tk_client_canceled_test.go
+++ b/backend/internal/handler/ops_error_logger_tk_client_canceled_test.go
@@ -1,0 +1,123 @@
+package handler
+
+import (
+	"context"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+
+	"github.com/gin-gonic/gin"
+	"github.com/stretchr/testify/require"
+
+	"github.com/Wei-Shaw/sub2api/internal/service"
+)
+
+// Issue #625 (prod + us2/us3/uk1 quad P0 2026-06-06T07:00-07:16Z): a single client
+// issuing non-streaming claude-opus-4-6 with a short client timeout cancels
+// mid-flight. The outbound request fails with `context canceled` and NO upstream
+// HTTP status (upstream_status_code=null, final 502), so the classifier relabeled
+// it phase=upstream / error_owner=provider and it counted toward upstream_error_rate.
+// Because prod relays the same request to edges, one client cancel lit up prod AND
+// every relayed edge at once.
+//
+// These tests pin the corrected classification: a client-cancel upstream transport
+// error is owned by the client (phase=request, error_owner=client) so it drops out
+// of the upstream_excl filter behind upstream_error_rate, while server-side
+// deadline-exceeded timeouts and genuine provider failures keep counting.
+//
+// Setups mirror the gateway forward-failure site (gateway_service.go), which records
+// BOTH setOpsUpstreamError(c, 0, safeErr, "") and an appendOpsUpstreamError event
+// with UpstreamStatusCode=0, Kind="request_error", Message=safeErr — where safeErr
+// is the sanitized Go error (sanitizeUpstreamErrorMessage preserves "context
+// canceled"). hasOpsUpstreamErrorContext keys off the events array, so the event is
+// what makes upstreamError=true.
+func TestClassifyOpsUpstreamClientCanceledOwnedByClient(t *testing.T) {
+	gin.SetMode(gin.TestMode)
+
+	t.Run("context canceled transport error (status 0) via upstream event message", func(t *testing.T) {
+		rec := httptest.NewRecorder()
+		c, _ := gin.CreateTestContext(rec)
+		c.Set(service.OpsUpstreamErrorsKey, []*service.OpsUpstreamErrorEvent{{
+			UpstreamStatusCode: 0,
+			Kind:               "request_error",
+			Message:            `Post "https://api.anthropic.com/v1/messages?beta=true": context canceled`,
+		}})
+
+		phase, isBusinessLimited, errorOwner, errorSource := classifyOpsErrorLog(
+			c, "upstream_error", "Upstream request failed", "", http.StatusBadGateway)
+
+		require.Equal(t, "request", phase)
+		require.Equal(t, "client", errorOwner, "must NOT be provider — otherwise it feeds upstream_error_rate")
+		require.Equal(t, "client_request", errorSource)
+		require.False(t, isBusinessLimited)
+	})
+
+	t.Run("inbound request context canceled (event message lacks cancel signature) via Request.Context", func(t *testing.T) {
+		rec := httptest.NewRecorder()
+		c, _ := gin.CreateTestContext(rec)
+		ctx, cancel := context.WithCancel(context.Background())
+		cancel()
+		req, _ := http.NewRequestWithContext(ctx, http.MethodPost, "/v1/messages", nil)
+		c.Request = req
+		// Forward-failure event exists (status 0) but its message does not carry the
+		// cancel signature — Request.Context().Err()==context.Canceled is the signal.
+		c.Set(service.OpsUpstreamErrorsKey, []*service.OpsUpstreamErrorEvent{{
+			UpstreamStatusCode: 0,
+			Kind:               "request_error",
+			Message:            "Upstream request failed",
+		}})
+
+		phase, _, errorOwner, _ := classifyOpsErrorLog(
+			c, "upstream_error", "Upstream request failed", "", http.StatusBadGateway)
+
+		require.Equal(t, "request", phase)
+		require.Equal(t, "client", errorOwner)
+	})
+}
+
+// A server/upstream timeout surfaces as context.DeadlineExceeded ("deadline
+// exceeded") and is genuine evidence of upstream slowness — it MUST stay
+// provider-owned and keep counting toward upstream_error_rate.
+func TestClassifyOpsUpstreamDeadlineExceededStaysProvider(t *testing.T) {
+	gin.SetMode(gin.TestMode)
+
+	cases := []struct {
+		name    string
+		message string
+	}{
+		{"context deadline exceeded", `Post "https://api.anthropic.com/v1/messages": context deadline exceeded`},
+		{"i/o timeout", `dial tcp: i/o timeout`},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			rec := httptest.NewRecorder()
+			c, _ := gin.CreateTestContext(rec)
+			c.Set(service.OpsUpstreamErrorsKey, []*service.OpsUpstreamErrorEvent{{
+				UpstreamStatusCode: 0,
+				Kind:               "request_error",
+				Message:            tc.message,
+			}})
+
+			phase, _, errorOwner, _ := classifyOpsErrorLog(
+				c, "upstream_error", "Upstream request failed", "", http.StatusBadGateway)
+
+			require.Equal(t, "upstream", phase, "server-side timeout is genuine upstream evidence")
+			require.Equal(t, "provider", errorOwner, "must keep counting toward upstream_error_rate")
+		})
+	}
+}
+
+// A genuine upstream 5xx WITH a status code must never be misread as a client
+// cancel even if the connection later dropped — the status gate keeps it provider.
+func TestClassifyOpsUpstream5xxWithStatusStaysProviderNotCancel(t *testing.T) {
+	gin.SetMode(gin.TestMode)
+	rec := httptest.NewRecorder()
+	c, _ := gin.CreateTestContext(rec)
+	service.SetOpsUpstreamError(c, http.StatusInternalServerError, "internal server error", "")
+
+	phase, _, errorOwner, _ := classifyOpsErrorLog(
+		c, "upstream_error", "Upstream service temporarily unavailable", "", http.StatusBadGateway)
+
+	require.Equal(t, "upstream", phase)
+	require.Equal(t, "provider", errorOwner)
+}

--- a/scripts/sentinels/gateway-tk.json
+++ b/scripts/sentinels/gateway-tk.json
@@ -1854,10 +1854,11 @@
       "path": "backend/internal/handler/ops_error_logger.go",
       "must_contain": [
         "clientInducedUpstream := upstreamError && tkUpstreamClientInducedRejection(c)",
-        "if upstreamError && !routingCapacityLimited && !clientInducedUpstream {",
-        "if clientInducedUpstream && !routingCapacityLimited {"
+        "clientCanceledUpstream := upstreamError && tkUpstreamClientCanceled(c)",
+        "if upstreamError && !routingCapacityLimited && !clientInducedUpstream && !clientCanceledUpstream {",
+        "if (clientInducedUpstream || clientCanceledUpstream) && !routingCapacityLimited {"
       ],
-      "rationale": "Injection point in classifyOpsErrorLog: an upstream client-induced 4xx must NOT take the upstream/provider phase override (which feeds error_owner=provider -> upstream_error_rate), and must instead be owned to the client (phase=request). routingCapacityLimited still wins last so 'no available accounts' SLA-exclusion is preserved. An upstream merge that rewrites this classifier and copies back the unconditional 'if upstreamError { phase = upstream }' shape silently restores the prod P0 false page; this sentinel anchors both the guard and the client-induced branch."
+      "rationale": "Injection point in classifyOpsErrorLog: an upstream client-induced 4xx (tkUpstreamClientInducedRejection) AND a client/caller disconnect with no upstream status (tkUpstreamClientCanceled, issue #625) must NOT take the upstream/provider phase override (which feeds error_owner=provider -> upstream_error_rate), and must instead be owned to the client (phase=request). routingCapacityLimited still wins last so 'no available accounts' SLA-exclusion is preserved. An upstream merge that rewrites this classifier and copies back the unconditional 'if upstreamError { phase = upstream }' shape silently restores the prod P0 false page (and the quad-edge context-canceled false P0); this sentinel anchors the guard plus both the client-induced and client-canceled branches."
     },
     {
       "path": "backend/internal/handler/ops_error_logger_tk_client_induced_upstream_test.go",
@@ -1912,6 +1913,26 @@
         "service.IsAnthropicModelNotFound404([]byte(body), msg)"
       ],
       "rationale": "Path B metric truth (prod P0 2026-06-06, edge us5 upstream_error_rate=100%): an upstream 404 model-not-found is caller-fault, so tkUpstreamClientInducedRejection classifies it client-owned (phase=request) and it drops out of upstream_excl behind upstream_error_rate. It reuses the SAME service.IsAnthropicModelNotFound404 predicate as the gateway response path (B-2) so the metric classification can never drift from the client-facing 400 decision. The captured upstream status stays 404 even though the client gets a 400, so this MUST live in the classifier. An upstream merge that reverts the 404 branch to provider-owned re-fires the P0 on bad-model traffic; this sentinel pins the branch."
+    },
+    {
+      "path": "backend/internal/handler/ops_error_logger_tk_client_canceled.go",
+      "must_contain": [
+        "func tkUpstreamClientCanceled(c *gin.Context) bool",
+        "if tkOpsUpstreamStatusCode(c) != 0 {",
+        "errors.Is(reqErr, context.Canceled)",
+        "deadline exceeded",
+        "context canceled"
+      ],
+      "rationale": "Issue #625 (prod + us2/us3/uk1 quad P0 2026-06-06T07:00-07:16Z, false page): one client issuing non-streaming claude-opus-4-6 with a timeout shorter than opus latency cancelled mid-flight; the outbound request failed with `context canceled` and NO upstream HTTP status, so classifyOpsErrorLog relabelled it phase=upstream / error_owner=provider and it counted toward upstream_error_rate. Because prod relays the same request to edges via cc-* stub accounts, one cancel propagated down the chain and prod + every relayed edge each recorded a 502 -> simultaneous false P0 across the fleet. This predicate owns a client/caller disconnect to the client (phase=request) so it drops out of upstream_error_rate, mirroring tkUpstreamClientInducedRejection. The status gate (only status 0) keeps real upstream 5xx provider-owned; the deadline-exceeded/timeout exclusion keeps server-side timeouts provider-owned (genuine slowness evidence). Dropping the deadline exclusion would silently hide real upstream timeouts; dropping the predicate restores the quad-P0 false page."
+    },
+    {
+      "path": "backend/internal/handler/ops_error_logger_tk_client_canceled_test.go",
+      "must_contain": [
+        "TestClassifyOpsUpstreamClientCanceledOwnedByClient",
+        "TestClassifyOpsUpstreamDeadlineExceededStaysProvider",
+        "TestClassifyOpsUpstream5xxWithStatusStaysProviderNotCancel"
+      ],
+      "rationale": "Focused regressions proving the issue #625 boundary: (1) a status-0 `context canceled` transport error (and an inbound Request.Context() cancel with no cancel signature in the message) classify as error_owner=client so they drop out of upstream_error_rate; (2) status-0 `context deadline exceeded` and `i/o timeout` stay error_owner=provider so genuine upstream slowness keeps counting; (3) a real upstream 5xx WITH a status code stays provider via the status gate. Dropping these lets an upstream merge silently revert the quad-P0 fix through the classifier."
     }
   ]
 }


### PR DESCRIPTION
## 修什么

Fixes #625。把**客户端取消（Go `context canceled`）导致的 upstream 错误**从 `upstream_error_rate` 中排除，归为 caller-fault（phase=request / error_owner=client），对齐既有 `tkUpstreamClientInducedRejection`（#606）与 #602 amplifier 豁免边界。

## 为什么（2026-06-06 四连假 P0）

单一客户端对 prod 发**非流式 `claude-opus-4-6`**，客户端超时短于 opus 时延（prod 实测 p50 14s / p90 55s）→ 中途取消。出站请求以 `context canceled` 失败、**无 upstream HTTP 状态**，`classifyOpsErrorLog` 把它打成 `phase=upstream / error_owner=provider` 计入 `upstream_error_rate`（provider-health P0 容量告警）。

由于 prod 经 cc-* stub 账号 relay 到边，一次取消沿 `client → prod → stub → edge → anthropic` 整链传播，**prod + 每个被 relay 的边各记一次 502** → 同窗口四连假 P0（prod 36% / us2 80% / us3 86% / uk1 35%）。完整排障见 #625。

## 怎么修（最小侵入，单点覆盖全链）

修复落在**每个节点的 ops 分类层**——每个节点检查**自己**的入站取消，所以同一个谓词同时覆盖 prod 与所有被 relay 的边。

- 新增 companion `ops_error_logger_tk_client_canceled.go::tkUpstreamClientCanceled`：
  - gate：仅 `upstream_status == 0`（拿到真实上游状态的一律不在此处理，保持 provider）
  - 信号：`c.Request.Context().Err() == context.Canceled`（net/http 在客户端断开时取消请求 context）+ 捕获的 upstream 错误文本含 `context canceled` 兜底
  - **排除** `deadline exceeded` / `timeout` —— 服务端/上游超时是真实上游慢的证据，**保持 provider-owned，继续计入指标**
- `classifyOpsErrorLog` 注入：client-cancel 与既有 client-induced 4xx 一并归 `phase=request`；`routingCapacityLimited` 仍最后兜底（"no available accounts" SLA 排除不变）
- sentinel 锚点：更新被改写的 classifier 行 + 新增 companion/test 两个守卫条目

**惩罚侧未触及**：transport-cancel 返回的是**非 failover error**，事故期间四节点数百次 502 账号全程 `schedulable=true`，未触发账号冷却——故本 PR 不动 amplifier。

## 测试

- `TestClassifyOpsUpstreamClientCanceledOwnedByClient`：status-0 `context canceled`（消息信号 + `Request.Context()` 信号）→ owner=client
- `TestClassifyOpsUpstreamDeadlineExceededStaysProvider`：`context deadline exceeded` / `i/o timeout` → 保持 provider
- `TestClassifyOpsUpstream5xxWithStatusStaysProviderNotCancel`：带状态码的真 5xx → status gate 保持 provider

## PR Checklist

- [x] `go test -tags=unit ./...` 全绿（FAIL 0）
- [x] `golangci-lint run ./internal/handler/...` 0 issues；`go vet` clean
- [x] `go build ./...`（跨仓库 new-api 依赖编译通过）
- [x] `scripts/preflight.sh` PASS（含 sub2api 专项 + gateway-tk sentinel 200/200）
- [x] 纯后端：commit 带 `no-web-impact`
- [x] 改了 upstream-shaped `ops_error_logger.go`：commit 带 `upstream-touch-guarded`，且 sentinel 注册表同 PR 更新
- [x] 无 schema / 无 frontend / 无 `package.json` 改动
- [ ] 合并方式：**Squash and merge**（TK-originated fix）

🤖 Generated with [Claude Code](https://claude.com/claude-code)
