### PR TITLE
fix(tier-baseline): restore ascending concurrency ladder on L3/L4/L5 (12/16/20)

### DIFF
--- a/backend/internal/baseline/anthropic-oauth-stability-baselines-tiered.json
+++ b/backend/internal/baseline/anthropic-oauth-stability-baselines-tiered.json
@@ -163,7 +163,7 @@
     "l3": {
       "baseline": {
         "account": {
-          "concurrency": 15,
+          "concurrency": 12,
           "priority": 1,
           "rate_multiplier": 1.0
         },
@@ -180,7 +180,7 @@
     "l4": {
       "baseline": {
         "account": {
-          "concurrency": 15,
+          "concurrency": 16,
           "priority": 1,
           "rate_multiplier": 1.0
         },
@@ -197,7 +197,7 @@
     "l5": {
       "baseline": {
         "account": {
-          "concurrency": 15,
+          "concurrency": 20,
           "priority": 1,
           "rate_multiplier": 1.0
         },

--- a/deploy/aws/stage0/anthropic-oauth-stability-baselines-tiered.json
+++ b/deploy/aws/stage0/anthropic-oauth-stability-baselines-tiered.json
@@ -163,7 +163,7 @@
     "l3": {
       "baseline": {
         "account": {
-          "concurrency": 15,
+          "concurrency": 12,
           "priority": 1,
           "rate_multiplier": 1.0
         },
@@ -180,7 +180,7 @@
     "l4": {
       "baseline": {
         "account": {
-          "concurrency": 15,
+          "concurrency": 16,
           "priority": 1,
           "rate_multiplier": 1.0
         },
@@ -197,7 +197,7 @@
     "l5": {
       "baseline": {
         "account": {
-          "concurrency": 15,
+          "concurrency": 20,
           "priority": 1,
           "rate_multiplier": 1.0
         },


### PR DESCRIPTION
## Summary

#604 flattened L3/L4/L5 concurrency to **15/15/15**. This restores a proper **ascending ladder** so higher stability tiers get more concurrency headroom.

| concurrency | L1 | L2 | L3 | L4 | L5 |
|---|---|---|---|---|---|
| #604 (current main) | 4 | 6 | 15 | 15 | 15 |
| **this PR** | 4 | 6 | **12** | **16** | **20** |

Only the `concurrency` column changes; `base_rpm` / `max_sessions` / `rpm_sticky_buffer` and all other fields stay as #604 set them.

## Why it's safe

`concurrency` is **not** part of the monotonic-ladder invariant in `tier_test.go` (only `base_rpm` / `max_sessions` / `window_cost_limit` are), so 12<16<20 is fine and `max_sessions` (45/75/75/100/120) stays monotonic. Both baseline JSON copies kept byte-identical (embed sentinel).

## Rollout

- **Live now:** `manage-anthropic-config.py apply-tiers-live` (PR #627) pushes these committed values to the fleet's `tiers` table + `accounts.concurrency` immediately.
- **Durable:** the next routine release's `ensureSeededFromBaseline` reseeds the same values from the Go embed (== this JSON) → idempotent, zero drift.

## Test

- `go test -tags=unit ./internal/baseline/` PASS (ladder invariants)
- `scripts/sentinels/check-tier-baseline-embed.py` PASS (two files identical + embed)
- `scripts/preflight.sh` PASS

🤖 Generated with [Claude Code](https://claude.com/claude-code)