### PR TITLE
fix(anthropic): cool upstream-error tier once per episode, not per burst error (#623)

### DIFF
--- a/backend/internal/repository/anthropic_upstream_error_counter_cache.go
+++ b/backend/internal/repository/anthropic_upstream_error_counter_cache.go
@@ -3,14 +3,16 @@ package repository
 import (
 	"context"
 	"fmt"
+	"time"
 
 	"github.com/Wei-Shaw/sub2api/internal/service"
 	"github.com/redis/go-redis/v9"
 )
 
 const (
-	anthropicUpstreamErrorCounterPrefix = "anthropic_upstream_error_count:account:"
-	anthropicCooldownTierPrefix         = "anthropic_cooldown_tier:account:"
+	anthropicUpstreamErrorCounterPrefix   = "anthropic_upstream_error_count:account:"
+	anthropicCooldownTierPrefix           = "anthropic_cooldown_tier:account:"
+	anthropicCooldownEscalationSlotPrefix = "anthropic_cooldown_escalation_slot:account:"
 )
 
 var anthropicUpstreamErrorCounterIncrScript = redis.NewScript(`
@@ -93,4 +95,29 @@ func (c *anthropicUpstreamErrorCounterCache) GetAnthropicCooldownTierEscalations
 		return 0, fmt.Errorf("get anthropic cooldown tier escalations: %w", err)
 	}
 	return val, nil
+}
+
+func (c *anthropicUpstreamErrorCounterCache) AcquireAnthropicCooldownEscalationSlot(ctx context.Context, accountID int64, ttlSeconds int) (bool, error) {
+	key := fmt.Sprintf("%s%d", anthropicCooldownEscalationSlotPrefix, accountID)
+	if ttlSeconds < 1 {
+		ttlSeconds = 1
+	}
+	ok, err := c.rdb.SetNX(ctx, key, 1, time.Duration(ttlSeconds)*time.Second).Result()
+	if err != nil {
+		return false, fmt.Errorf("acquire anthropic cooldown escalation slot: %w", err)
+	}
+	return ok, nil
+}
+
+func (c *anthropicUpstreamErrorCounterCache) SetAnthropicCooldownEscalationSlotTTL(ctx context.Context, accountID int64, ttlSeconds int) error {
+	key := fmt.Sprintf("%s%d", anthropicCooldownEscalationSlotPrefix, accountID)
+	if ttlSeconds < 1 {
+		ttlSeconds = 1
+	}
+	return c.rdb.Expire(ctx, key, time.Duration(ttlSeconds)*time.Second).Err()
+}
+
+func (c *anthropicUpstreamErrorCounterCache) ResetAnthropicCooldownEscalationSlot(ctx context.Context, accountID int64) error {
+	key := fmt.Sprintf("%s%d", anthropicCooldownEscalationSlotPrefix, accountID)
+	return c.rdb.Del(ctx, key).Err()
 }

--- a/backend/internal/service/anthropic_upstream_error_counter.go
+++ b/backend/internal/service/anthropic_upstream_error_counter.go
@@ -31,4 +31,26 @@ type AnthropicUpstreamErrorCounterCache interface {
 	// the most recent window) or the cache backend is unhealthy.
 	IncrementAnthropicCooldownTierEscalations(ctx context.Context, ttlMinutes int) (int64, error)
 	GetAnthropicCooldownTierEscalations(ctx context.Context) (int64, error)
+
+	// Escalation slot is a per-account guard that lets the tier ladder escalate
+	// at most once per *failure episode* instead of once per error. A single
+	// fast burst — e.g. an edge rolling-upgrade swap window throwing several
+	// 503s in a few seconds (issue #623) — would otherwise re-run the threshold
+	// block per error and climb 30s → 2min → 10min within seconds, even though
+	// errors #2..n are racing in-flight requests from the SAME episode that
+	// error #1 already cooled the account for.
+	//
+	// AcquireAnthropicCooldownEscalationSlot does an atomic SET-if-absent with a
+	// placeholder TTL and returns whether THIS caller won the slot. The winner
+	// performs the escalation, then calls SetAnthropicCooldownEscalationSlotTTL
+	// to shrink the slot to exactly the cooldown it applied, so the slot
+	// auto-clears the moment the account would be rescheduled — a genuine
+	// re-trip after the cooldown expires is a new episode and escalates again
+	// (the ladder's documented "repeatedly trips ... inside 30 min" intent).
+	// Losers fail the in-flight request over without advancing the tier.
+	// Both are best-effort: a Redis failure must never under-protect a genuine
+	// persistent failure, so the caller falls back to escalating on error.
+	AcquireAnthropicCooldownEscalationSlot(ctx context.Context, accountID int64, ttlSeconds int) (bool, error)
+	SetAnthropicCooldownEscalationSlotTTL(ctx context.Context, accountID int64, ttlSeconds int) error
+	ResetAnthropicCooldownEscalationSlot(ctx context.Context, accountID int64) error
 }

--- a/backend/internal/service/ratelimit_service.go
+++ b/backend/internal/service/ratelimit_service.go
@@ -180,6 +180,14 @@ var anthropicCooldownTierLadder = []time.Duration{
 	10 * time.Minute,
 }
 
+// anthropicCooldownEscalationSlotMaxSeconds is the placeholder TTL a threshold
+// trip uses to win the per-account escalation slot before its real cooldown is
+// known. It equals the longest ladder cooldown so that a crash between winning
+// the slot and shrinking it to the real cooldown can over-suppress escalation
+// by at most one max-cooldown window — never under-protect. See issue #623 and
+// AnthropicUpstreamErrorCounterCache.AcquireAnthropicCooldownEscalationSlot.
+var anthropicCooldownEscalationSlotMaxSeconds = int(anthropicCooldownTierLadder[len(anthropicCooldownTierLadder)-1].Seconds())
+
 // NewRateLimitService 创建RateLimitService实例
 func NewRateLimitService(accountRepo AccountRepository, usageRepo UsageLogRepository, cfg *config.Config, geminiQuotaService *GeminiQuotaService, tempUnschedCache TempUnschedCache) *RateLimitService {
 	return &RateLimitService{
@@ -1117,6 +1125,37 @@ func (s *RateLimitService) handleAnthropicUpstreamErrorWithOptions(ctx context.C
 		return false
 	}
 
+	// Escalation slot (issue #623): only escalate the tier / (re)apply a cooldown
+	// once per *failure episode*. A single fast burst — e.g. an edge rolling-
+	// upgrade swap window throwing several 503s in a few seconds — otherwise
+	// re-runs this block per error and climbs 30s → 2min → 10min within seconds,
+	// even though errors #2..n are racing in-flight requests from the SAME
+	// episode that error #1 already cooled the account for. We win the slot atomically;
+	// a loser fails the in-flight request over (return true) WITHOUT advancing the
+	// tier or rewriting the cooldown. The slot auto-clears when the cooldown would
+	// have expired (shrunk below), so a genuine re-trip after the account is
+	// rescheduled is a new episode and escalates again — matching the ladder's
+	// documented "repeatedly trips ... inside 30 min" intent. Best-effort: on a
+	// Redis error we fall through and escalate as before so a persistent failure is
+	// never under-protected by a guard outage.
+	acquiredSlot := false
+	if won, slotErr := s.anthropicUpstreamErrorCounterCache.AcquireAnthropicCooldownEscalationSlot(ctx, account.ID, anthropicCooldownEscalationSlotMaxSeconds); slotErr != nil {
+		slog.Warn("anthropic_cooldown_escalation_slot_acquire_failed",
+			"account_id", account.ID,
+			"status_code", statusCode,
+			"error", slotErr)
+	} else if !won {
+		slog.Info("anthropic_upstream_error_escalation_suppressed_active_cooldown",
+			"account_id", account.ID,
+			"status_code", statusCode,
+			"count", count,
+			"threshold", threshold,
+			"pool_mode", account.IsPoolMode())
+		return true
+	} else {
+		acquiredSlot = true
+	}
+
 	// Pick the cooldown duration based on how many times this same account
 	// has tripped the threshold inside the last anthropicCooldownTierTTLMinutes.
 	// Best-effort: any Redis failure falls back to the shortest tier so we
@@ -1135,6 +1174,18 @@ func (s *RateLimitService) handleAnthropicUpstreamErrorWithOptions(ctx context.C
 		}
 	}
 	cooldown := anthropicCooldownTierLadder[tierIndex]
+
+	// Shrink the escalation slot to exactly this cooldown so the NEXT escalation
+	// can only happen after the account would have been rescheduled. Best-effort.
+	if acquiredSlot {
+		if ttlErr := s.anthropicUpstreamErrorCounterCache.SetAnthropicCooldownEscalationSlotTTL(ctx, account.ID, int(cooldown.Seconds())); ttlErr != nil {
+			slog.Warn("anthropic_cooldown_escalation_slot_ttl_failed",
+				"account_id", account.ID,
+				"status_code", statusCode,
+				"cooldown_seconds", int(cooldown.Seconds()),
+				"error", ttlErr)
+		}
+	}
 
 	// Emit a global "tier >= 1" escalation signal so ops_alert_evaluator can
 	// surface "persistent failure rising" without scanning every per-account
@@ -2079,6 +2130,12 @@ func (s *RateLimitService) ResetAnthropicUpstreamErrorCounter(ctx context.Contex
 	// 10-min escalation state forward.
 	if err := s.anthropicUpstreamErrorCounterCache.ResetAnthropicCooldownTier(ctx, accountID); err != nil {
 		slog.Warn("anthropic_cooldown_tier_reset_failed", "account_id", accountID, "error", err)
+	}
+	// And clear the per-episode escalation slot (issue #623) so a healed account
+	// can immediately cool again if it starts failing right after recovery,
+	// instead of waiting out a stale slot left from the previous episode.
+	if err := s.anthropicUpstreamErrorCounterCache.ResetAnthropicCooldownEscalationSlot(ctx, accountID); err != nil {
+		slog.Warn("anthropic_cooldown_escalation_slot_reset_failed", "account_id", accountID, "error", err)
 	}
 }
 

--- a/backend/internal/service/ratelimit_service_401_test.go
+++ b/backend/internal/service/ratelimit_service_401_test.go
@@ -157,6 +157,18 @@ type anthropicUpstreamErrorCounterCacheStub struct {
 	// total of the escalations slice length so reads stay consistent with
 	// writes without a real Redis backend.
 	escalationTTLMinutes []int
+
+	// Per-episode escalation slot guard (issue #623). slotResults scripts the
+	// AcquireAnthropicCooldownEscalationSlot return values in order; an empty
+	// slice means the slot is always free (won=true), preserving the default
+	// "escalate on every threshold trip" behaviour for tests that don't model
+	// bursts. slotErr forces an acquire error to exercise the best-effort
+	// fall-through path.
+	slotResults    []bool
+	slotErr        error
+	slotAcquireIDs []int64
+	slotTTLSeconds []int
+	slotResetCalls []int64
 }
 
 func (s *anthropicUpstreamErrorCounterCacheStub) IncrementAnthropicUpstreamErrorCount(_ context.Context, accountID int64, windowMinutes int) (int64, error) {
@@ -201,6 +213,29 @@ func (s *anthropicUpstreamErrorCounterCacheStub) IncrementAnthropicCooldownTierE
 
 func (s *anthropicUpstreamErrorCounterCacheStub) GetAnthropicCooldownTierEscalations(_ context.Context) (int64, error) {
 	return int64(len(s.escalationTTLMinutes)), nil
+}
+
+func (s *anthropicUpstreamErrorCounterCacheStub) AcquireAnthropicCooldownEscalationSlot(_ context.Context, accountID int64, _ int) (bool, error) {
+	s.slotAcquireIDs = append(s.slotAcquireIDs, accountID)
+	if s.slotErr != nil {
+		return false, s.slotErr
+	}
+	if len(s.slotResults) == 0 {
+		return true, nil
+	}
+	won := s.slotResults[0]
+	s.slotResults = s.slotResults[1:]
+	return won, nil
+}
+
+func (s *anthropicUpstreamErrorCounterCacheStub) SetAnthropicCooldownEscalationSlotTTL(_ context.Context, _ int64, ttlSeconds int) error {
+	s.slotTTLSeconds = append(s.slotTTLSeconds, ttlSeconds)
+	return nil
+}
+
+func (s *anthropicUpstreamErrorCounterCacheStub) ResetAnthropicCooldownEscalationSlot(_ context.Context, accountID int64) error {
+	s.slotResetCalls = append(s.slotResetCalls, accountID)
+	return nil
 }
 
 func (r *tokenCacheInvalidatorRecorder) InvalidateToken(ctx context.Context, account *Account) error {

--- a/backend/internal/service/ratelimit_service_403_test.go
+++ b/backend/internal/service/ratelimit_service_403_test.go
@@ -249,6 +249,66 @@ func TestRateLimitService_ResetAnthropicCounter_AlsoResetsCooldownTier(t *testin
 	service.ResetAnthropicUpstreamErrorCounter(context.Background(), 600)
 	require.Equal(t, []int64{600}, counter.resetCalls, "error counter reset must propagate")
 	require.Equal(t, []int64{600}, counter.tierResetCalls, "cooldown tier reset must propagate")
+	require.Equal(t, []int64{600}, counter.slotResetCalls, "escalation slot reset must propagate (issue #623)")
+}
+
+// Issue #623: a single fast burst of upstream errors (edge rolling-upgrade swap
+// window) must NOT climb the cooldown ladder from tier 0 to tier 2 within
+// seconds. Once the threshold trip cools the account (tier 0, 30s), the racing
+// in-flight errors of the SAME episode hold the escalation slot and are
+// suppressed — they fail over without advancing the tier or rewriting the
+// cooldown. A genuine re-trip after the slot expires (account rescheduled) is a
+// new episode and escalates normally (covered by the ladder test above).
+func TestRateLimitService_HandleUpstreamError_AnthropicBurstDoesNotEscalateWhileCooled(t *testing.T) {
+	repo := &rateLimitAccountRepoStub{}
+	counter := &anthropicUpstreamErrorCounterCacheStub{
+		// 5 errors in one burst: first 2 below threshold, then 3,4,5 at/above it.
+		counts: []int64{1, 2, 3, 4, 5},
+		// If the tier counter were ever consulted on the racing errors it would
+		// return 2 then 3 (tier 1, tier 2). The guard must prevent that.
+		tierCounts: []int64{1, 2, 3},
+		// First threshold trip (error #3) wins the slot; the two racing errors
+		// (#4, #5) lose it and must be suppressed.
+		slotResults: []bool{true, false, false},
+	}
+	service := NewRateLimitService(repo, nil, &config.Config{}, nil, nil)
+	service.SetAnthropicUpstreamErrorCounterCache(counter)
+	account := &Account{
+		ID:       623,
+		Platform: PlatformAnthropic,
+		Type:     AccountTypeAPIKey,
+		Credentials: map[string]any{
+			"pool_mode": true,
+		},
+	}
+
+	body := []byte(`{"error":{"message":"upstream request failed"}}`)
+	for i := 0; i < 5; i++ {
+		shouldDisable := service.HandleUpstreamError(context.Background(), account, http.StatusServiceUnavailable, http.Header{}, body)
+		if i < 2 {
+			require.False(t, shouldDisable, "iteration %d below threshold must not disable", i)
+		} else {
+			require.True(t, shouldDisable, "iteration %d at/above threshold must fail the request over", i)
+		}
+	}
+
+	// Exactly ONE cooldown write across the whole burst — the threshold crossing.
+	require.Equal(t, 1, repo.tempCalls, "burst must produce exactly one temp_unschedulable write, not one per error")
+	// The tier counter must only be advanced for the winning trip, never for the
+	// suppressed racing errors.
+	require.Equal(t, []int64{623}, counter.tierIncrementIDs, "tier must advance exactly once for the episode")
+	// The applied cooldown must be the shortest tier (30s), proving the burst did
+	// not climb to tier 1 (2min) or tier 2 (10min).
+	var state TempUnschedState
+	require.NoError(t, json.Unmarshal([]byte(repo.lastTempReason), &state))
+	require.Equal(t, http.StatusServiceUnavailable, state.StatusCode)
+	require.Equal(t, "anthropic_upstream_error", state.MatchedKeyword)
+	untilDelta := time.Until(time.Unix(state.UntilUnix, 0))
+	require.InDelta(t, 30*time.Second, untilDelta, float64(2*time.Second),
+		"burst must stay at tier-0 30s cooldown, got %s", untilDelta)
+	// The winning trip shrinks the slot to the real cooldown (30s); the suppressed
+	// errors must not have touched the slot TTL.
+	require.Equal(t, []int{30}, counter.slotTTLSeconds, "only the winning trip shrinks the slot to its cooldown")
 }
 
 // Carve-out: Anthropic accounts ignore the custom-error-codes allowlist so a

--- a/scripts/sentinels/gateway-tk.json
+++ b/scripts/sentinels/gateway-tk.json
@@ -201,15 +201,19 @@
         "ResetAnthropicCooldownTier",
         "IncrementAnthropicCooldownTierEscalations",
         "GetAnthropicCooldownTierEscalations",
-        "AnthropicCooldownTierEscalationsKey"
+        "AnthropicCooldownTierEscalationsKey",
+        "AcquireAnthropicCooldownEscalationSlot",
+        "SetAnthropicCooldownEscalationSlotTTL",
+        "ResetAnthropicCooldownEscalationSlot"
       ],
-      "rationale": "Interface seam for (a) per-account Anthropic upstream-error short-window counting, (b) per-account cooldown-tier escalation (30s → 2min → 10min), and (c) global tier>=1 escalation aggregation for ops alerts. If an upstream merge drops the tier methods, handleAnthropicUpstreamError silently collapses back to a fixed cooldown — losing the persistent-failure escalation that replaces PR #333's removed pool_mode immunity. The global escalation pair (Increment/Get) + exported key constant `AnthropicCooldownTierEscalationsKey` are the contract ops_alert_evaluator's `anthropic_cooldown_tier_escalation_count` metric reads from; dropping any one silently disables the alert."
+      "rationale": "Interface seam for (a) per-account Anthropic upstream-error short-window counting, (b) per-account cooldown-tier escalation (30s → 2min → 10min), and (c) global tier>=1 escalation aggregation for ops alerts. If an upstream merge drops the tier methods, handleAnthropicUpstreamError silently collapses back to a fixed cooldown — losing the persistent-failure escalation that replaces PR #333's removed pool_mode immunity. The global escalation pair (Increment/Get) + exported key constant `AnthropicCooldownTierEscalationsKey` are the contract ops_alert_evaluator's `anthropic_cooldown_tier_escalation_count` metric reads from; dropping any one silently disables the alert. The escalation-slot trio (Acquire/SetTTL/Reset, issue #623) is the per-episode guard that stops a single fast 5xx burst — e.g. an edge rolling-upgrade swap window — from climbing 30s→2min→10min within seconds; dropping it silently reintroduces that self-noise amplifier."
     },
     {
       "path": "backend/internal/repository/anthropic_upstream_error_counter_cache.go",
       "must_contain": [
         "anthropic_upstream_error_count:account:",
         "anthropic_cooldown_tier:account:",
+        "anthropic_cooldown_escalation_slot:account:",
         "service.AnthropicCooldownTierEscalationsKey",
         "NewAnthropicUpstreamErrorCounterCache",
         "IncrementAnthropicUpstreamErrorCount",
@@ -217,9 +221,12 @@
         "IncrementAnthropicCooldownTier",
         "ResetAnthropicCooldownTier",
         "IncrementAnthropicCooldownTierEscalations",
-        "GetAnthropicCooldownTierEscalations"
+        "GetAnthropicCooldownTierEscalations",
+        "AcquireAnthropicCooldownEscalationSlot",
+        "SetAnthropicCooldownEscalationSlotTTL",
+        "ResetAnthropicCooldownEscalationSlot"
       ],
-      "rationale": "Redis-backed atomic counters for (1) the per-account Anthropic upstream-error short window, (2) the per-account cooldown-tier escalation window, and (3) the global tier>=1 escalation aggregator that drives ops_alert_evaluator's anthropic_cooldown_tier_escalation_count metric. All three prefixes/keys (`anthropic_upstream_error_count:account:`, `anthropic_cooldown_tier:account:`, `AnthropicCooldownTierEscalationsKey` — the latter exported from the service package so the evaluator's Redis fallback and the repository writer share a single literal) must remain stable so all app replicas share the same threshold + tier + escalation state."
+      "rationale": "Redis-backed atomic counters for (1) the per-account Anthropic upstream-error short window, (2) the per-account cooldown-tier escalation window, (3) the global tier>=1 escalation aggregator that drives ops_alert_evaluator's anthropic_cooldown_tier_escalation_count metric, and (4) the per-episode escalation slot (`anthropic_cooldown_escalation_slot:account:`, issue #623) implemented as an atomic SET-NX guard so a single fast 5xx burst escalates the tier at most once instead of once per error. All prefixes/keys (`anthropic_upstream_error_count:account:`, `anthropic_cooldown_tier:account:`, `anthropic_cooldown_escalation_slot:account:`, `AnthropicCooldownTierEscalationsKey` — the latter exported from the service package so the evaluator's Redis fallback and the repository writer share a single literal) must remain stable so all app replicas share the same threshold + tier + escalation + slot state."
     },
     {
       "path": "backend/internal/service/wire.go",


### PR DESCRIPTION
## Problem (#623)

A Stage0 edge rolling upgrade has a sub-second window between the old container stopping and the new one becoming ready where Caddy has no healthy backend and returns 5xx to new requests. The prod stub pointing at that edge (`cc-usN`, `mirror_platform=anthropic`, `pool_mode`) catches a burst of 503s — in the v1.7.78 rollout, **5 in 8 seconds** — and climbs the Anthropic upstream-error cooldown ladder from **tier 0 (30s) → tier 2 (10min) within those 8 seconds**, marking the stub `temp_unschedulable` for ~10 minutes. Every edge rollout thus inflicts a ~10-min self-noise unschedulable window on its stub.

## Root cause

`handleAnthropicUpstreamErrorWithOptions` re-ran the tier-escalation block on **every** error at/above the 3/3 threshold. Errors #4 and #5 of a burst are racing in-flight requests from the **same failure episode** that error #3 already cooled the account for — yet each re-incremented the tier counter, so a single fast burst climbed the whole ladder. The ladder's documented intent is the opposite: escalate when an account *"repeatedly trips ... inside 30 min"*, i.e. across distinct episodes over time, not within one burst.

## Fix

Gate escalation on a per-account, **per-episode** atomic slot (Redis `SET NX`):

- The threshold trip that **wins** the slot escalates the tier + applies the cooldown, then **shrinks the slot TTL to exactly that cooldown** so it auto-clears the moment the account would be rescheduled.
- Racing errors of the same burst **lose** the slot and fail the in-flight request over **without** advancing the tier or rewriting the cooldown.
- A genuine **re-trip after the cooldown expires** finds the slot free and escalates normally — so a persistent bad upstream still climbs the ladder, just paced by its own cooldowns instead of by burst speed.

Net effect: an edge rollout now costs its stub **at most one bounded tier-0 (30s) blip** (absorbed by failover), instead of a 10-min tier-2 lockout.

### Alignment with #602 amplifier boundary

Preserved. Raw 5xx / genuine upstream errors still **count** — the 3/3 counter still fires, the request still fails over, the account still cools at tier 0. Only the *within-episode self-amplification* is removed. The edge-side root fix (health-gated blue-green to eliminate the 503 swap window) remains the separate **deferred backlog** item; this PR is the amplifier-side mitigation.

### Robustness

- **Best-effort throughout**: a Redis error on slot acquire falls through and escalates as before, so a persistent failure is never under-protected by a guard outage.
- The acquire→shrink is race-safe: the winner holds a placeholder TTL (= longest ladder cooldown) until it shrinks to the real cooldown, so a crash between the two can only *over-suppress* by at most one max-cooldown window, never under-protect.
- Recovery paths reset the slot alongside the error + tier counters.

## Tests

- New `TestRateLimitService_HandleUpstreamError_AnthropicBurstDoesNotEscalateWhileCooled`: a 5-error burst produces exactly one tier-0 (30s) cooldown, one tier increment, one `temp_unschedulable` write.
- Extended the reset test to assert the slot reset propagates.
- Existing ladder / pool-mode / escalation tests unchanged and green (the stub's slot defaults to "free" → existing escalation behaviour preserved).

## Sentinel

The new escalation-slot trio (`Acquire`/`SetTTL`/`Reset`) + the new Redis prefix are added to `scripts/sentinels/gateway-tk.json` so a future upstream merge cannot silently drop the guard.

## Verification

- `go test -tags=unit ./...` — PASS
- `go build ./...` — PASS
- `golangci-lint run ./internal/service/... ./internal/repository/...` — 0 issues
- `bash scripts/preflight.sh` — PASS

## Drift note

TK is 663 ahead / 86 behind `upstream/main` (the pre-existing drift tracked by the blocked upstream-merge agent, #578). This fix touches only **TK-authored** amplifier logic (`anthropic_upstream_error_counter*`, `ratelimit_service.go` TK cooldown block) and is orthogonal to the upstream merge, so it ships out of order rather than waiting on that independently-blocked merge.

Closes #623

🤖 Generated with [Claude Code](https://claude.com/claude-code)