### PR TITLE
feat(ops): 飞书账号冷却摘要标注上游限流维度（模型类 + 5h/7d 窗口）

### DIFF
--- a/backend/internal/service/account_incident_notifier_tk.go
+++ b/backend/internal/service/account_incident_notifier_tk.go
@@ -35,7 +35,11 @@ const (
 
 // AccountIncidentNotifier 是注入给 RateLimitService 的最小通知面（仿 AccountRuntimeBlocker）。
 type AccountIncidentNotifier interface {
-	NotifyAccountIncident(account *Account, until time.Time, reason string, kind AccountIncidentKind)
+	// detail (variadic, optional) is an upstream-dimension hint — e.g. the
+	// Anthropic 5h/7d usage window or the rate-limited model class — that the
+	// temporary-cooldown digest renders so operators see WHICH upstream limit
+	// fired. Variadic keeps non-enriched call sites untouched.
+	NotifyAccountIncident(account *Account, until time.Time, reason string, kind AccountIncidentKind, detail ...string)
 	// NotifyAccountRecovered 在账号"真实清除事件"(ClearRateLimit / RecoverAccountState /
 	// admin 重测恢复)时调用,对此前告警过的账号发一条即时恢复绿卡。事件驱动:纯定时器
 	// 到期自愈不经此路径,也不播报(原冷却卡已写明 until)。未告警账号调用为 no-op。
@@ -116,9 +120,13 @@ func classifyIncident(reason string, until time.Time, kind AccountIncidentKind) 
 	return incidentClass{true, IncidentKindTemporaryCooldown, "other", "账号临时冷却", "观察是否自愈"}
 }
 
-// accountIncidentDigestEntry 是临时冷却聚合 buffer 的单个 reasonClass 条目。
+// accountIncidentDigestEntry 是临时冷却聚合 buffer 的单个 (reasonClass × detail) 条目。
+// detail 是上游限流维度提示（如 Anthropic 5h/7d 用量窗口、被限流的模型类），用于把同一
+// reasonClass 下不同维度（如 opus·5h 与 sonnet·7d）拆成独立行,让运营一眼看清是哪个上游
+// 维度触发的冷却。空 detail 退化为按 reasonClass 聚合（与历史行为一致）。
 type accountIncidentDigestEntry struct {
 	reasonClass    string
+	detail         string
 	kindZh         string
 	advice         string
 	accountIDs     map[int64]struct{}
@@ -126,6 +134,15 @@ type accountIncidentDigestEntry struct {
 	count          int
 	firstAt        time.Time
 	lastAt         time.Time
+}
+
+// accountIncidentDigestKey 合成 digest 聚合键。detail 为空时退化为 reasonClass,保持历史
+// 键名（如 "429"）不变,使既有按 reasonClass 取数的调用与测试不受影响。
+func accountIncidentDigestKey(reasonClass, detail string) string {
+	if detail == "" {
+		return reasonClass
+	}
+	return reasonClass + "\x1f" + detail
 }
 
 // opsFeishuConfigProvider 是 notifier 读取飞书配置的最小面（*OpsService 天然满足）。
@@ -188,7 +205,7 @@ func (n *TKAccountIncidentNotifier) Stop() {
 	})
 }
 
-func (n *TKAccountIncidentNotifier) NotifyAccountIncident(account *Account, until time.Time, reason string, kind AccountIncidentKind) {
+func (n *TKAccountIncidentNotifier) NotifyAccountIncident(account *Account, until time.Time, reason string, kind AccountIncidentKind, detail ...string) {
 	if n == nil || account == nil {
 		return
 	}
@@ -198,10 +215,15 @@ func (n *TKAccountIncidentNotifier) NotifyAccountIncident(account *Account, unti
 	}
 	n.trackActive(account, cls, until)
 	if cls.kind == IncidentKindPermanentDisable {
+		// 永久失效是整账号下线,无上游维度细分语义 → 忽略 detail。
 		n.handlePermanent(account, reason, cls)
 		return
 	}
-	n.recordTemporary(account, cls)
+	d := ""
+	if len(detail) > 0 {
+		d = strings.TrimSpace(detail[0])
+	}
+	n.recordTemporary(account, cls, d)
 }
 
 // trackActive 登记/刷新账号的活跃事件台账(按 reasonClass 去重)。无论永久卡是否被去重抑制,
@@ -282,21 +304,24 @@ func (n *TKAccountIncidentNotifier) handlePermanent(account *Account, reason str
 	n.send(title, "red", body, fmt.Sprintf("account_id=%d reason=%s", account.ID, reason))
 }
 
-// recordTemporary: 仅写入聚合 buffer,不立即发。
-func (n *TKAccountIncidentNotifier) recordTemporary(account *Account, cls incidentClass) {
+// recordTemporary: 仅写入聚合 buffer,不立即发。detail 把同一 reasonClass 下不同上游
+// 维度（如 opus·5h、sonnet·7d）拆成独立条目。
+func (n *TKAccountIncidentNotifier) recordTemporary(account *Account, cls incidentClass, detail string) {
 	now := n.currentTime()
+	key := accountIncidentDigestKey(cls.reasonClass, detail)
 	n.mu.Lock()
 	defer n.mu.Unlock()
-	entry := n.digest[cls.reasonClass]
+	entry := n.digest[key]
 	if entry == nil {
 		entry = &accountIncidentDigestEntry{
 			reasonClass: cls.reasonClass,
+			detail:      detail,
 			kindZh:      cls.kindZh,
 			advice:      cls.advice,
 			accountIDs:  map[int64]struct{}{},
 			firstAt:     now,
 		}
-		n.digest[cls.reasonClass] = entry
+		n.digest[key] = entry
 	}
 	entry.count++
 	entry.lastAt = now
@@ -388,7 +413,12 @@ func (n *TKAccountIncidentNotifier) flushDigest() {
 	n.digest = map[string]*accountIncidentDigestEntry{}
 	n.mu.Unlock()
 
-	sort.Slice(entries, func(i, j int) bool { return entries[i].reasonClass < entries[j].reasonClass })
+	sort.Slice(entries, func(i, j int) bool {
+		if entries[i].reasonClass != entries[j].reasonClass {
+			return entries[i].reasonClass < entries[j].reasonClass
+		}
+		return entries[i].detail < entries[j].detail
+	})
 	now := n.currentTime()
 	title := fmt.Sprintf("TokenKey 账号临时冷却摘要 [%s]", n.siteID)
 	body := buildAccountIncidentDigestText(n.siteID, entries, now)
@@ -443,7 +473,7 @@ func buildAccountIncidentPermanentText(site string, account *Account, reason str
 }
 
 func buildAccountIncidentDigestText(site string, entries []*accountIncidentDigestEntry, now time.Time) string {
-	lines := make([]string, 0, len(entries)+1)
+	lines := make([]string, 0, len(entries)+2)
 	lines = append(lines, fmt.Sprintf("**节点**：%s\n**时间**：%s\n\n临时冷却（自愈类）聚合摘要：",
 		escapeFeishuText(site), escapeFeishuText(formatAlertTime(now))))
 	for _, e := range entries {
@@ -451,9 +481,19 @@ func buildAccountIncidentDigestText(site string, entries []*accountIncidentDiges
 		if len(e.accountIDs) > len(e.accountSamples) {
 			samples += fmt.Sprintf(" 等共%d个", len(e.accountIDs))
 		}
+		// detail（如 "opus·5h 窗口"）以 ｜ 分隔追加到类型后,把同一类型不同上游维度
+		// 拆成可区分的行;无 detail 时退化为历史形态。
+		label := e.kindZh
+		if e.detail != "" {
+			label = e.kindZh + "｜" + e.detail
+		}
 		lines = append(lines, fmt.Sprintf("- **%s**：%d 次 / %d 账号（%s）",
-			escapeFeishuText(e.kindZh), e.count, len(e.accountIDs), escapeFeishuText(samples)))
+			escapeFeishuText(label), e.count, len(e.accountIDs), escapeFeishuText(samples)))
 	}
+	// 认知纠正脚注:本摘要里的冷却全部是「上游对账号的限流/冷却」(账号级用量窗口 5h/7d
+	// 或上游错误策略),不是 TK 内部 rpm/并发/会话 配额。内部配额超限不会冷却账号,而是在
+	// 请求侧快速失败(HTTP 429 no available accounts),根本不进本摘要。详见 account 冷却汇聚点。
+	lines = append(lines, "\n说明：以上均为「上游对账号的限流/冷却」（账号级用量窗口 5h/7d 或上游错误策略），非 TK 内部 rpm/并发/会话 配额——内部配额超限只会让请求侧快速失败（HTTP 429 no available accounts），不计入本摘要。")
 	return strings.Join(lines, "\n")
 }
 

--- a/backend/internal/service/account_incident_notifier_tk_test.go
+++ b/backend/internal/service/account_incident_notifier_tk_test.go
@@ -200,6 +200,65 @@ func TestNotifyTemporaryBuffersUntilFlush(t *testing.T) {
 	n.mu.Unlock()
 }
 
+func TestModelClassCooldownDetailSubdividesDigest(t *testing.T) {
+	doer := &blockingFeishuDoer{done: make(chan struct{}, 1)}
+	n := newTestNotifier(&fakeIncidentConfigProvider{cfg: enabledFeishuConfig()}, doer, time.Unix(1700000000, 0))
+
+	// Same reasonClass (429_model_class) but two different upstream dimensions →
+	// must NOT collapse into one line; the operator needs to see opus vs sonnet.
+	n.NotifyAccountIncident(testAccount(1, "edge-ls-oh-3-d", "anthropic"), time.Now().Add(time.Hour), "429_model_class", IncidentKindUnknown, "opus·5h 窗口")
+	n.NotifyAccountIncident(testAccount(2, "cc-main", "anthropic"), time.Now().Add(time.Hour), "429_model_class", IncidentKindUnknown, "sonnet·7d 窗口")
+
+	n.mu.Lock()
+	require.Len(t, n.digest, 2, "two distinct details must produce two digest entries")
+	n.mu.Unlock()
+
+	n.flushDigest()
+	select {
+	case <-doer.done:
+	case <-time.After(2 * time.Second):
+		t.Fatal("digest flush did not send within 2s")
+	}
+	body := doer.lastBody()
+	require.Contains(t, body, "模型类限流冷却")
+	require.Contains(t, body, "opus·5h 窗口")
+	require.Contains(t, body, "sonnet·7d 窗口")
+	require.Contains(t, body, "edge-ls-oh-3-d")
+}
+
+func TestAccount429WindowDetailRendered(t *testing.T) {
+	doer := &blockingFeishuDoer{done: make(chan struct{}, 1)}
+	n := newTestNotifier(&fakeIncidentConfigProvider{cfg: enabledFeishuConfig()}, doer, time.Unix(1700000000, 0))
+
+	n.NotifyAccountIncident(testAccount(55, "cc-us6", "anthropic"), time.Now().Add(time.Hour), "429", IncidentKindUnknown, "5h 窗口")
+
+	n.flushDigest()
+	select {
+	case <-doer.done:
+	case <-time.After(2 * time.Second):
+		t.Fatal("digest flush did not send within 2s")
+	}
+	body := doer.lastBody()
+	require.Contains(t, body, "限流冷却（429）｜5h 窗口")
+	require.Contains(t, body, "cc-us6")
+	// Footer must correct the rpm/concurrency/session misconception (Q2).
+	require.Contains(t, body, "非 TK 内部 rpm/并发/会话 配额")
+	require.Contains(t, body, "no available accounts")
+}
+
+func TestEmptyDetailKeepsLegacyDigestKey(t *testing.T) {
+	doer := &blockingFeishuDoer{}
+	n := newTestNotifier(&fakeIncidentConfigProvider{cfg: enabledFeishuConfig()}, doer, time.Unix(1700000000, 0))
+
+	// No detail (e.g. OpenAI / fallback 429) must still aggregate under the bare
+	// reasonClass key, preserving historical behaviour.
+	n.NotifyAccountIncident(testAccount(9, "openai-1", "openai"), time.Now().Add(time.Minute), "429", IncidentKindUnknown)
+	n.mu.Lock()
+	require.NotNil(t, n.digest["429"], "empty-detail 429 must key under bare reasonClass")
+	require.Equal(t, "", n.digest["429"].detail)
+	n.mu.Unlock()
+}
+
 func TestFlushEmptyBufferDoesNotSend(t *testing.T) {
 	doer := &blockingFeishuDoer{}
 	n := newTestNotifier(&fakeIncidentConfigProvider{cfg: enabledFeishuConfig()}, doer, time.Unix(1700000000, 0))

--- a/backend/internal/service/ratelimit_service.go
+++ b/backend/internal/service/ratelimit_service.go
@@ -228,13 +228,19 @@ func (s *RateLimitService) SetAccountRuntimeBlocker(blocker AccountRuntimeBlocke
 	s.runtimeBlocker = blocker
 }
 
-func (s *RateLimitService) notifyAccountSchedulingBlocked(account *Account, until time.Time, reason string) {
+// notifyAccountSchedulingBlocked is the single funnel for every account
+// cooldown/disable. The optional detail (variadic so existing call sites stay
+// untouched) carries an upstream-dimension hint — e.g. the Anthropic 5h/7d
+// usage window or the model class — that the Feishu digest renders so operators
+// see WHICH upstream limit fired. detail is intentionally NOT forwarded to
+// BlockAccountScheduling: the runtime blocker keys off the stable reason string.
+func (s *RateLimitService) notifyAccountSchedulingBlocked(account *Account, until time.Time, reason string, detail ...string) {
 	if s == nil || s.runtimeBlocker == nil || account == nil {
 		return
 	}
 	s.runtimeBlocker.BlockAccountScheduling(account, until, reason)
 	// TK: 同一汇聚点上报账号失效事件给飞书（kind 由 reason 在 classifyIncident 内精确派生）。
-	s.notifyAccountIncident(account, until, reason, IncidentKindUnknown)
+	s.notifyAccountIncident(account, until, reason, IncidentKindUnknown, detail...)
 }
 
 func (s *RateLimitService) notifyAccountSchedulingBlockCleared(accountID int64) {
@@ -1510,7 +1516,8 @@ func (s *RateLimitService) handle429(ctx context.Context, account *Account, head
 		if len(requestedModel) > 0 && s.tkTryAnthropicModelScopedCooldown(ctx, account, requestedModel[0], result) {
 			return true
 		}
-		s.notifyAccountSchedulingBlocked(account, result.resetAt, "429")
+		// TK: 账号级 429 附上触发的上游用量窗口（5h/7d），进飞书摘要细分。
+		s.notifyAccountSchedulingBlocked(account, result.resetAt, "429", tkAnthropicWindowLabel(result))
 		if err := s.accountRepo.SetRateLimited(ctx, account.ID, result.resetAt); err != nil {
 			slog.Warn("rate_limit_set_failed", "account_id", account.ID, "error", err)
 			return false
@@ -1704,6 +1711,11 @@ func (s *RateLimitService) calculateOpenAI429ResetTime(headers http.Header) *tim
 type anthropic429Result struct {
 	resetAt       time.Time  // The correct reset time to use for SetRateLimited
 	fiveHourReset *time.Time // 5h window reset timestamp (for session window calculation), nil if not available
+	// window labels which unified usage window actually triggered the 429
+	// ("5h" / "7d" / "" when undetermined). TK: surfaced into the account
+	// cooldown Feishu digest so operators see WHICH upstream usage window
+	// rate-limited the account (not an internal rpm/concurrency/session cap).
+	window string
 }
 
 // calculateAnthropic429ResetTime parses Anthropic's per-window rate-limit headers
@@ -1746,18 +1758,25 @@ func calculateAnthropic429ResetTime(headers http.Header) *anthropic429Result {
 	)
 
 	// Select the correct reset time based on which window(s) are exceeded.
+	// window records which window the cooldown is attributed to (for the
+	// account-incident Feishu digest); it tracks the same branch as chosen.
 	var chosen *time.Time
+	var window string
 	switch {
 	case is5hExceeded && is7dExceeded:
 		// Both exceeded → prefer 7d (longer cooldown), fall back to 5h
 		chosen = reset7d
+		window = "7d"
 		if chosen == nil {
 			chosen = reset5h
+			window = "5h"
 		}
 	case is5hExceeded:
 		chosen = reset5h
+		window = "5h"
 	case is7dExceeded:
 		chosen = reset7d
+		window = "7d"
 	default:
 		// Neither flag clearly exceeded — pick the sooner reset as best guess
 		chosen = pickSooner(reset5h, reset7d)
@@ -1766,7 +1785,7 @@ func calculateAnthropic429ResetTime(headers http.Header) *anthropic429Result {
 	if chosen == nil {
 		return nil
 	}
-	return &anthropic429Result{resetAt: *chosen, fiveHourReset: reset5h}
+	return &anthropic429Result{resetAt: *chosen, fiveHourReset: reset5h, window: window}
 }
 
 // isAnthropicWindowExceeded checks whether a given Anthropic rate-limit window

--- a/backend/internal/service/ratelimit_service_anthropic_test.go
+++ b/backend/internal/service/ratelimit_service_anthropic_test.go
@@ -200,3 +200,72 @@ func makeHeader(key, value string) http.Header {
 	h.Set(key, value)
 	return h
 }
+
+// TestCalculateAnthropic429ResetTime_Window verifies the parsed result records
+// WHICH unified usage window triggered the 429 — the operator-facing dimension
+// surfaced into the account-cooldown Feishu digest.
+func TestCalculateAnthropic429ResetTime_Window(t *testing.T) {
+	cases := []struct {
+		name       string
+		util5h     string
+		util7d     string
+		wantWindow string
+	}{
+		{"only 5h exceeded", "1.02", "0.32", "5h"},
+		{"only 7d exceeded", "0.50", "1.05", "7d"},
+		{"both exceeded prefers 7d", "1.10", "1.02", "7d"},
+		{"neither exceeded undetermined", "0.95", "0.80", ""},
+	}
+	for _, c := range cases {
+		t.Run(c.name, func(t *testing.T) {
+			headers := http.Header{}
+			headers.Set("anthropic-ratelimit-unified-5h-utilization", c.util5h)
+			headers.Set("anthropic-ratelimit-unified-5h-reset", "1770998400")
+			headers.Set("anthropic-ratelimit-unified-7d-utilization", c.util7d)
+			headers.Set("anthropic-ratelimit-unified-7d-reset", "1771549200")
+
+			result := calculateAnthropic429ResetTime(headers)
+			if result == nil {
+				t.Fatal("expected non-nil result")
+			}
+			if result.window != c.wantWindow {
+				t.Errorf("window: want %q, got %q", c.wantWindow, result.window)
+			}
+		})
+	}
+}
+
+// TestTkAnthropicWindowLabel / TestTkAnthropicModelCooldownDetail cover the
+// digest-detail rendering helpers used by the two 429 cooldown call sites.
+func TestTkAnthropicWindowLabel(t *testing.T) {
+	if got := tkAnthropicWindowLabel(nil); got != "" {
+		t.Errorf("nil result: want empty, got %q", got)
+	}
+	if got := tkAnthropicWindowLabel(&anthropic429Result{}); got != "" {
+		t.Errorf("empty window: want empty, got %q", got)
+	}
+	if got := tkAnthropicWindowLabel(&anthropic429Result{window: "5h"}); got != "5h 窗口" {
+		t.Errorf("5h: want %q, got %q", "5h 窗口", got)
+	}
+}
+
+func TestTkAnthropicModelCooldownDetail(t *testing.T) {
+	cases := []struct {
+		name   string
+		class  string
+		result *anthropic429Result
+		want   string
+	}{
+		{"class and window", "opus", &anthropic429Result{window: "5h"}, "opus·5h 窗口"},
+		{"class no window", "sonnet", &anthropic429Result{}, "sonnet"},
+		{"no class but window", anthropicModelClassUnknown, &anthropic429Result{window: "7d"}, "7d 窗口"},
+		{"neither", anthropicModelClassUnknown, nil, ""},
+	}
+	for _, c := range cases {
+		t.Run(c.name, func(t *testing.T) {
+			if got := tkAnthropicModelCooldownDetail(c.class, c.result); got != c.want {
+				t.Errorf("want %q, got %q", c.want, got)
+			}
+		})
+	}
+}

--- a/backend/internal/service/ratelimit_service_tk_incident.go
+++ b/backend/internal/service/ratelimit_service_tk_incident.go
@@ -16,11 +16,14 @@ func (s *RateLimitService) SetAccountIncidentNotifier(n AccountIncidentNotifier)
 	s.incidentNotifier = n
 }
 
-func (s *RateLimitService) notifyAccountIncident(account *Account, until time.Time, reason string, kind AccountIncidentKind) {
+// notifyAccountIncident forwards to the notifier. The optional detail carries an
+// upstream-dimension hint (Anthropic 5h/7d window or model class) the digest
+// renders; variadic so non-enriched call sites stay unchanged.
+func (s *RateLimitService) notifyAccountIncident(account *Account, until time.Time, reason string, kind AccountIncidentKind, detail ...string) {
 	if s == nil || s.incidentNotifier == nil || account == nil {
 		return
 	}
-	s.incidentNotifier.NotifyAccountIncident(account, until, reason, kind)
+	s.incidentNotifier.NotifyAccountIncident(account, until, reason, kind, detail...)
 }
 
 // notifyAccountRecovered 在账号真实清除事件(ClearRateLimit / RecoverAccountState /

--- a/backend/internal/service/ratelimit_service_tk_model_cooldown.go
+++ b/backend/internal/service/ratelimit_service_tk_model_cooldown.go
@@ -127,7 +127,8 @@ func (s *RateLimitService) tkTryAnthropicModelScopedCooldown(
 	if account.Platform != PlatformAnthropic {
 		return false
 	}
-	scopeKey := tkAnthropicModelClassScopeKeyForModel(requestedModel)
+	class := tkAnthropicModelClass(requestedModel)
+	scopeKey := tkAnthropicModelClassScopeKey(class)
 	if scopeKey == "" {
 		// Unknown model class (or no model context at the call site): cannot
 		// safely narrow the cooldown — fall back to account-level so we never
@@ -136,7 +137,8 @@ func (s *RateLimitService) tkTryAnthropicModelScopedCooldown(
 	}
 
 	resetAt := result.resetAt
-	s.notifyAccountSchedulingBlocked(account, resetAt, "429_model_class")
+	// detail = 模型类[·窗口]，让飞书摘要直接显示被限流的是哪个模型类与上游用量窗口。
+	s.notifyAccountSchedulingBlocked(account, resetAt, "429_model_class", tkAnthropicModelCooldownDetail(class, result))
 	if err := s.accountRepo.SetModelRateLimit(ctx, account.ID, scopeKey, resetAt, tkAnthropicModelCooldownReason); err != nil {
 		slog.Warn("anthropic_model_class_rate_limit_failed",
 			"account_id", account.ID,
@@ -210,4 +212,30 @@ func (a *Account) tkAnthropicModelClassRateLimitRemaining(requestedModel string)
 		return 0
 	}
 	return a.getRateLimitRemainingForKey(scopeKey)
+}
+
+// tkAnthropicWindowLabel renders the unified usage window that triggered an
+// Anthropic 429 as a human-facing Feishu digest detail ("5h 窗口" / "7d 窗口"),
+// or "" when the window can't be determined. This is the operator-facing answer
+// to "which upstream dimension exceeded its limit" for account-level 429
+// cooldowns — it is the upstream usage window, NOT a TK internal cap.
+func tkAnthropicWindowLabel(result *anthropic429Result) string {
+	if result == nil || result.window == "" {
+		return ""
+	}
+	return result.window + " 窗口"
+}
+
+// tkAnthropicModelCooldownDetail renders the model-class 429 cooldown digest
+// detail as "<class>·<window> 窗口" (e.g. "opus·5h 窗口"), degrading to just the
+// class when the window is unknown, or to just the window when the class is
+// unknown. Empty when neither is known.
+func tkAnthropicModelCooldownDetail(class string, result *anthropic429Result) string {
+	if class == anthropicModelClassUnknown {
+		return tkAnthropicWindowLabel(result)
+	}
+	if w := tkAnthropicWindowLabel(result); w != "" {
+		return class + "·" + w
+	}
+	return class
 }

--- a/scripts/sentinels/gateway-tk.json
+++ b/scripts/sentinels/gateway-tk.json
@@ -1659,9 +1659,9 @@
     {
       "path": "backend/internal/service/ratelimit_service.go",
       "must_contain": [
-        "s.notifyAccountIncident(account, until, reason, IncidentKindUnknown)"
+        "s.notifyAccountIncident(account, until, reason, IncidentKindUnknown, detail...)"
       ],
-      "rationale": "账号失效 → 飞书告警的唯一挂钩点。notifyAccountSchedulingBlocked 是所有 13 个账号失效/冷却场景（auth_error / oauth_401 / 429 / 529 / 403temp / temp / custom / stream_timeout）的汇聚点；这一行把失效事件上报给 AccountIncidentNotifier（永久失效即时 P0 红头卡片、临时冷却聚合低频橙头摘要）。上游合并若重写 notifyAccountSchedulingBlocked 并丢掉此行，会让账号失效告警静默失效——运营再也收不到『某账号该重新 OAuth / 查 bug』，且无编译错误、极难发现。本 sentinel 捕获该 revert。"
+      "rationale": "账号失效 → 飞书告警的唯一挂钩点。notifyAccountSchedulingBlocked 是所有 13 个账号失效/冷却场景（auth_error / oauth_401 / 429 / 529 / 403temp / temp / custom / stream_timeout）的汇聚点；这一行把失效事件上报给 AccountIncidentNotifier（永久失效即时 P0 红头卡片、临时冷却聚合低频橙头摘要）。末尾的 detail... 透传上游限流维度提示（Anthropic 5h/7d 用量窗口、被限流的模型类）进飞书摘要，变参故非 enriched 挂钩点不受影响。上游合并若重写 notifyAccountSchedulingBlocked 并丢掉此行，会让账号失效告警静默失效——运营再也收不到『某账号该重新 OAuth / 查 bug』，且无编译错误、极难发现。本 sentinel 捕获该 revert。"
     },
     {
       "path": "backend/internal/service/account_incident_notifier_tk.go",


### PR DESCRIPTION
## 背景

2026-06-06 飞书「TokenKey 账号临时冷却摘要」两张卡片暴露两个盲点：

- **prod**：`限流冷却（429）：1 次 / 1 账号（cc-us6(#55)）`
- **edge-us6**：`模型类限流冷却（账号其它模型仍可调度）：1 次 / 1 账号（edge-ls-oh-3-d(#1)）`

运营无法从卡片看出：(1) 模型类限流冷却到底限的是**哪个模型类**；(2) 限流冷却（429）是**哪个上游维度**超阈值。

## 决策（上帝视角）

这张摘要里的所有冷却都经唯一汇聚点 `notifyAccountSchedulingBlocked`，其调用方**全部是上游错误驱动**（429/529/403/401/auth/temp_unschedulable）——**没有一条**由 TK 内部 rpm/并发/session 配额触发。内部配额超限只会让请求侧快速失败（HTTP 429 `no available accounts`），从不冷却账号，也根本不进这张摘要。

所以用户问的「是用户 concurrency 超了还是账号 concurrency 超了」基于一个误解。诚实的做法不是编造一个代码路径里不存在的内部配额归因，而是：①给出**真实的上游维度**（Anthropic 5h/7d 用量窗口 + 模型类）；②在卡片脚注里**纠正这个认知**。

## 改动（全部加性，收敛进 TK helper）

| 维度 | 之前 | 之后 |
|---|---|---|
| 模型类限流冷却 | `模型类限流冷却（账号其它模型仍可调度）` | `… ｜opus·5h 窗口` |
| 限流冷却（429） | `限流冷却（429）` | `限流冷却（429）｜5h 窗口` |
| 脚注 | 无 | 一句话说明「这是上游账号级限流，非 TK 内部 rpm/并发/会话 配额」 |

- `anthropic429Result` 增加 `window`（`5h`/`7d`/``），与已选 reset 分支同步设置。
- `notifyAccountSchedulingBlocked` / `notifyAccountIncident` / `AccountIncidentNotifier` 接口加**变参** `detail ...string`——既有调用点**逐字节不变**；detail **不**透传给 runtime blocker（它按稳定的 reason 字符串去重）。
- `429_model_class` 传 `<class>·<window> 窗口`；账号级 `429` 传 `<window> 窗口`。
- 摘要按 `(reasonClass × detail)` 细分，`opus·5h` 与 `sonnet·7d` 拆成独立行；空 detail 退化为历史的裸 reasonClass 键（向后兼容）。
- 更新 `scripts/sentinels/gateway-tk.json` 中该挂钩行的 sentinel literal（变参后仍 load-bearing）。

## 测试

- `calculateAnthropic429ResetTime` 的 `window` 标注（5h/7d/both/neither）
- `tkAnthropicWindowLabel` / `tkAnthropicModelCooldownDetail` helper
- 摘要按 detail 细分、卡片渲染、脚注存在、空 detail 保留历史键
- `go test -tags=unit ./...` 全绿；`golangci-lint run ./internal/service/` 0 issues；`scripts/preflight.sh` PASS

## 卡片示例（修复后）

```
临时冷却（自愈类）聚合摘要：
- 限流冷却（429）｜5h 窗口：1 次 / 1 账号（cc-us6(#55)）
- 模型类限流冷却（账号其它模型仍可调度）｜opus·5h 窗口：1 次 / 1 账号（edge-ls-oh-3-d(#1)）

说明：以上均为「上游对账号的限流/冷却」（账号级用量窗口 5h/7d 或上游错误策略），非 TK 内部 rpm/并发/会话 配额——内部配额超限只会让请求侧快速失败（HTTP 429 no available accounts），不计入本摘要。
```

## PR Checklist

- [x] `go test -tags=unit ./...` 通过
- [x] `golangci-lint run ./internal/service/` 无新增 issue
- [x] `go build ./...` 通过（跨仓库依赖编译）
- [x] 纯后端、无前端改动 → commit 带 `no-web-impact`
- [x] 触及 upstream-shaped `ratelimit_service.go`（加性）→ commit 带 `upstream-touch-guarded` 且同 PR 更新 sentinel literal
- [x] 无 upstream 符号删除；无 skip-ci 标记
- [x] 合并方式：**Squash and merge**（TK feature PR）

🤖 Generated with [Claude Code](https://claude.com/claude-code)
