### PR TITLE
feat(ops): per-API-key cancel-storm detector + Feishu alert (Phase 1, detect-only)

### DIFF
--- a/backend/internal/handler/ops_error_logger.go
+++ b/backend/internal/handler/ops_error_logger.go
@@ -554,6 +554,11 @@ func OpsErrorLoggerMiddleware(ops *service.OpsService) gin.HandlerFunc {
 		c.Writer = w
 		c.Next()
 
+		// TK: per-API-key cancel-storm detector. Runs on every terminal outcome
+		// (success + >=400), independent of the ops-monitoring master switch and
+		// of IgnoreContextCanceled log-skipping. No-op unless its own mode is on.
+		tkObserveCancelStorm(c, ops)
+
 		if ops == nil {
 			return
 		}

--- a/backend/internal/handler/ops_error_logger_tk_cancel_storm.go
+++ b/backend/internal/handler/ops_error_logger_tk_cancel_storm.go
@@ -1,0 +1,33 @@
+package handler
+
+// TK: thin chokepoint shim for the per-API-key cancel-storm detector.
+//
+// OpsErrorLoggerMiddleware runs once per inbound /v1 request after c.Next(), on
+// both the success and >=400 branches, so it is the single terminal-outcome
+// observation point. Internal retries/failover resolve to one terminal outcome
+// here, so each client request is counted exactly once. The heavy lifting (window
+// counting, threshold, Feishu alert) lives in service.OpsService.ObserveCancelStorm
+// and is a no-op unless cancel_storm_config mode is "detect_only".
+
+import (
+	middleware2 "github.com/Wei-Shaw/sub2api/internal/server/middleware"
+	"github.com/Wei-Shaw/sub2api/internal/service"
+	"github.com/gin-gonic/gin"
+)
+
+func tkObserveCancelStorm(c *gin.Context, ops *service.OpsService) {
+	if c == nil || ops == nil {
+		return
+	}
+	apiKey, ok := middleware2.GetAPIKeyFromContext(c)
+	if !ok || apiKey == nil || apiKey.ID == 0 {
+		return
+	}
+	model := ""
+	if v, exists := c.Get(opsModelKey); exists {
+		if s, ok := v.(string); ok {
+			model = s
+		}
+	}
+	ops.ObserveCancelStorm(apiKey.ID, apiKey.Name, model, tkUpstreamClientCanceled(c))
+}

--- a/backend/internal/service/domain_constants.go
+++ b/backend/internal/service/domain_constants.go
@@ -377,6 +377,11 @@ const (
 	// SettingKeyOpsAdvancedSettings stores JSON config for ops advanced settings (data retention, aggregation).
 	SettingKeyOpsAdvancedSettings = "ops_advanced_settings"
 
+	// SettingKeyCancelStormConfig stores JSON config for the TK per-API-key cancel-storm
+	// detector (mode off|detect_only + window/threshold knobs). Default off. See
+	// internal/service/ops_cancel_storm_tk.go and migrations/tk_018_seed_cancel_storm_config.sql.
+	SettingKeyCancelStormConfig = "cancel_storm_config"
+
 	// SettingKeyOpsRuntimeLogConfig stores JSON config for runtime log settings.
 	SettingKeyOpsRuntimeLogConfig = "ops_runtime_log_config"
 

--- a/backend/internal/service/ops_cancel_storm_tk.go
+++ b/backend/internal/service/ops_cancel_storm_tk.go
@@ -122,8 +122,9 @@ type cancelStormDetector struct {
 	cachedCfg    *CancelStormConfig
 	cfgFetchedAt time.Time
 
-	mu     sync.Mutex
-	states map[int64]*cancelStormWindow
+	mu          sync.Mutex
+	states      map[int64]*cancelStormWindow
+	lastSweepAt time.Time
 }
 
 func newCancelStormDetector(settingRepo SettingRepository, cfgProvider opsFeishuConfigProvider, siteID string) *cancelStormDetector {
@@ -246,12 +247,18 @@ func (d *cancelStormDetector) observe(apiKeyID int64, apiKeyName, model string, 
 	}
 }
 
-// sweepLocked bounds memory by dropping keys idle beyond a few windows. Only runs
-// when the map grows large, so steady state pays nothing. Caller holds d.mu.
+// sweepLocked bounds memory by dropping keys idle beyond a few windows. It only
+// engages once the map grows past the cap AND at most once per window, so the
+// O(n) scan is amortized and never runs on the per-request hot path under d.mu in
+// steady state. Caller holds d.mu.
 func (d *cancelStormDetector) sweepLocked(now time.Time, window time.Duration) {
 	if len(d.states) < cancelStormMaxTrackedKeys {
 		return
 	}
+	if !d.lastSweepAt.IsZero() && now.Sub(d.lastSweepAt) < window {
+		return
+	}
+	d.lastSweepAt = now
 	cutoff := 4 * window
 	for id, w := range d.states {
 		if now.Sub(w.lastSeen) > cutoff {

--- a/backend/internal/service/ops_cancel_storm_tk.go
+++ b/backend/internal/service/ops_cancel_storm_tk.go
@@ -1,0 +1,323 @@
+package service
+
+// TK: per-API-key "cancel-storm" detector — Phase 1 (detect + Feishu alert only).
+//
+// Why: an external automation client borrowing a TokenKey API key with short
+// client timeouts produced a context-canceled flood on opus relay traffic — the
+// "non-human harness" traffic shape that trips Anthropic's abuse filter and got
+// an irreplaceable subscription-OAuth account org-disabled. TokenKey had no
+// real-time signal (the incident was only reconstructed post-mortem). This counts
+// per-key cancel rate at the gateway terminal-outcome chokepoint
+// (OpsErrorLoggerMiddleware) and fires one Feishu card when a key crosses the
+// threshold, so operators see the storm as it happens.
+//
+// Scope: detect + alert ONLY. Auto-throttle (reducing the offending key's
+// concurrency) is intentionally a separate later PR — these thresholds must first
+// be calibrated against real traffic under detect_only before any enforcement.
+//
+// Counting is in-memory per process (tumbling window). TokenKey Stage0 runs a
+// single gateway container per node, so per-process counting is exact for the
+// shape this guards; if a node ever scales horizontally, move the counters to
+// Redis (the Phase 2 enforcement work introduces that substrate). The alert path
+// reuses the account-incident Feishu primitives (feishuCardPayload /
+// sendFeishuPayload) so the card shape + signing live in one place.
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"net/http"
+	"strings"
+	"sync"
+	"time"
+
+	"github.com/Wei-Shaw/sub2api/internal/pkg/logger"
+)
+
+const (
+	cancelStormModeOff        = "off"
+	cancelStormModeDetectOnly = "detect_only"
+
+	// cancelStormConfigTTL bounds how often the hot path reads the config setting
+	// from the DB. The common production state is mode=off, so this keeps the
+	// gateway path from doing a settings read on every request.
+	cancelStormConfigTTL = 10 * time.Second
+
+	// cancelStormMaxTrackedKeys caps the in-memory state map; beyond it idle
+	// entries are swept. A volume floor far above any realistic distinct-key count.
+	cancelStormMaxTrackedKeys = 4096
+)
+
+// CancelStormConfig is the JSON config stored under SettingKeyCancelStormConfig.
+// Phase 1 only: mode is "off" | "detect_only".
+type CancelStormConfig struct {
+	Mode                 string  `json:"mode"`
+	WindowSeconds        int     `json:"window_seconds"`
+	MinSampleCount       int     `json:"min_sample_count"`
+	CancelRateThreshold  float64 `json:"cancel_rate_threshold"`
+	MinCancelCount       int     `json:"min_cancel_count"`
+	AlertCooldownSeconds int     `json:"alert_cooldown_seconds"`
+	OpusOnly             bool    `json:"opus_only"`
+}
+
+func defaultCancelStormConfig() *CancelStormConfig {
+	return &CancelStormConfig{
+		Mode:                 cancelStormModeOff,
+		WindowSeconds:        60,
+		MinSampleCount:       20,
+		CancelRateThreshold:  0.5,
+		MinCancelCount:       0,
+		AlertCooldownSeconds: 600,
+		OpusOnly:             false,
+	}
+}
+
+// normalizeCancelStormConfig clamps values into safe ranges and forces an
+// unknown/typo'd mode to "off" (fail-safe: a misconfigured row never spams).
+func normalizeCancelStormConfig(c *CancelStormConfig) {
+	if c == nil {
+		return
+	}
+	if strings.TrimSpace(strings.ToLower(c.Mode)) == cancelStormModeDetectOnly {
+		c.Mode = cancelStormModeDetectOnly
+	} else {
+		c.Mode = cancelStormModeOff
+	}
+	if c.WindowSeconds <= 0 {
+		c.WindowSeconds = 60
+	}
+	if c.WindowSeconds > 3600 {
+		c.WindowSeconds = 3600
+	}
+	if c.MinSampleCount < 1 {
+		c.MinSampleCount = 1
+	}
+	if c.CancelRateThreshold <= 0 || c.CancelRateThreshold > 1 {
+		c.CancelRateThreshold = 0.5
+	}
+	if c.MinCancelCount < 0 {
+		c.MinCancelCount = 0
+	}
+	if c.AlertCooldownSeconds < 0 {
+		c.AlertCooldownSeconds = 0
+	}
+}
+
+type cancelStormWindow struct {
+	windowStart time.Time
+	total       int
+	canceled    int
+	lastAlertAt time.Time
+	lastSeen    time.Time
+}
+
+type cancelStormDetector struct {
+	settingRepo SettingRepository
+	cfgProvider opsFeishuConfigProvider
+	httpClient  opsFeishuHTTPDoer
+	siteID      string
+	now         func() time.Time
+
+	cfgMu        sync.Mutex
+	cachedCfg    *CancelStormConfig
+	cfgFetchedAt time.Time
+
+	mu     sync.Mutex
+	states map[int64]*cancelStormWindow
+}
+
+func newCancelStormDetector(settingRepo SettingRepository, cfgProvider opsFeishuConfigProvider, siteID string) *cancelStormDetector {
+	site := strings.TrimSpace(siteID)
+	if site == "" {
+		site = "unknown"
+	}
+	return &cancelStormDetector{
+		settingRepo: settingRepo,
+		cfgProvider: cfgProvider,
+		httpClient:  &http.Client{Timeout: opsFeishuWebhookTimeout},
+		siteID:      site,
+		now:         time.Now,
+		states:      map[int64]*cancelStormWindow{},
+	}
+}
+
+func (d *cancelStormDetector) currentTime() time.Time {
+	if d != nil && d.now != nil {
+		return d.now()
+	}
+	return time.Now()
+}
+
+// config returns the parsed config, cached for cancelStormConfigTTL so the hot
+// path does not hit the settings store on every request.
+func (d *cancelStormDetector) config() *CancelStormConfig {
+	now := d.currentTime()
+	d.cfgMu.Lock()
+	if d.cachedCfg != nil && now.Sub(d.cfgFetchedAt) < cancelStormConfigTTL {
+		cfg := d.cachedCfg
+		d.cfgMu.Unlock()
+		return cfg
+	}
+	d.cfgMu.Unlock()
+
+	cfg := d.loadConfig()
+
+	d.cfgMu.Lock()
+	d.cachedCfg = cfg
+	d.cfgFetchedAt = now
+	d.cfgMu.Unlock()
+	return cfg
+}
+
+func (d *cancelStormDetector) loadConfig() *CancelStormConfig {
+	def := defaultCancelStormConfig()
+	if d.settingRepo == nil {
+		return def
+	}
+	raw, err := d.settingRepo.GetValue(context.Background(), SettingKeyCancelStormConfig)
+	if err != nil {
+		// Missing row (migration not yet applied) or transient error -> safe
+		// default (off). Never block or error the gateway path.
+		return def
+	}
+	cfg := &CancelStormConfig{}
+	if jErr := json.Unmarshal([]byte(raw), cfg); jErr != nil {
+		return def
+	}
+	normalizeCancelStormConfig(cfg)
+	return cfg
+}
+
+// observe feeds one terminal request outcome into the per-key window and fires an
+// alert when the cancel rate crosses the configured threshold. No-op unless mode
+// is "detect_only".
+func (d *cancelStormDetector) observe(apiKeyID int64, apiKeyName, model string, canceled bool) {
+	if d == nil || apiKeyID <= 0 {
+		return
+	}
+	cfg := d.config()
+	if cfg.Mode != cancelStormModeDetectOnly {
+		return
+	}
+	if cfg.OpusOnly && !isOpusModel(model) {
+		return
+	}
+
+	now := d.currentTime()
+	window := time.Duration(cfg.WindowSeconds) * time.Second
+
+	d.mu.Lock()
+	w := d.states[apiKeyID]
+	if w == nil {
+		w = &cancelStormWindow{windowStart: now}
+		d.states[apiKeyID] = w
+	}
+	if now.Sub(w.windowStart) >= window {
+		// Tumbling reset; lastAlertAt is preserved across windows so the alert
+		// cooldown spans windows (otherwise every fresh window could re-alert).
+		w.windowStart = now
+		w.total = 0
+		w.canceled = 0
+	}
+	w.total++
+	if canceled {
+		w.canceled++
+	}
+	w.lastSeen = now
+
+	shouldAlert := false
+	var rate float64
+	var total, cancels int
+	if w.total >= cfg.MinSampleCount {
+		rate = float64(w.canceled) / float64(w.total)
+		crossed := rate >= cfg.CancelRateThreshold && w.canceled >= cfg.MinCancelCount
+		cooldownOK := w.lastAlertAt.IsZero() || now.Sub(w.lastAlertAt) >= time.Duration(cfg.AlertCooldownSeconds)*time.Second
+		if crossed && cooldownOK {
+			w.lastAlertAt = now
+			shouldAlert = true
+			total, cancels = w.total, w.canceled
+		}
+	}
+	d.sweepLocked(now, window)
+	d.mu.Unlock()
+
+	if shouldAlert {
+		go d.sendAlert(apiKeyID, apiKeyName, model, rate, total, cancels, cfg)
+	}
+}
+
+// sweepLocked bounds memory by dropping keys idle beyond a few windows. Only runs
+// when the map grows large, so steady state pays nothing. Caller holds d.mu.
+func (d *cancelStormDetector) sweepLocked(now time.Time, window time.Duration) {
+	if len(d.states) < cancelStormMaxTrackedKeys {
+		return
+	}
+	cutoff := 4 * window
+	for id, w := range d.states {
+		if now.Sub(w.lastSeen) > cutoff {
+			delete(d.states, id)
+		}
+	}
+}
+
+func (d *cancelStormDetector) sendAlert(apiKeyID int64, apiKeyName, model string, rate float64, total, canceled int, cfg *CancelStormConfig) {
+	defer func() {
+		if r := recover(); r != nil {
+			logger.LegacyPrintf("service.cancel_storm", "[CancelStorm] alert panic recovered: %v", r)
+		}
+	}()
+	if d == nil || d.cfgProvider == nil {
+		return
+	}
+	fcfg, err := d.cfgProvider.GetEmailNotificationConfig(context.Background())
+	if err != nil || fcfg == nil || !fcfg.Feishu.Enabled || strings.TrimSpace(fcfg.Feishu.WebhookURL) == "" {
+		return
+	}
+	ctx, cancel := context.WithTimeout(context.Background(), opsFeishuWebhookTimeout)
+	defer cancel()
+
+	title := "TokenKey 取消风暴"
+	if d.siteID != "" && d.siteID != "unknown" {
+		title = title + " · " + d.siteID
+	}
+	body := buildCancelStormText(d.siteID, apiKeyID, apiKeyName, model, rate, total, canceled, cfg, d.currentTime())
+	payload := feishuCardPayload(fcfg.Feishu, d.now, "orange", title, body)
+	if sErr := sendFeishuPayload(ctx, d.httpClient, fcfg.Feishu, payload); sErr != nil {
+		logger.LegacyPrintf("service.cancel_storm", "[CancelStorm] feishu send failed: %s", sErr.Error())
+	}
+}
+
+func buildCancelStormText(site string, apiKeyID int64, apiKeyName, model string, rate float64, total, canceled int, cfg *CancelStormConfig, now time.Time) string {
+	keyLabel := fmt.Sprintf("#%d", apiKeyID)
+	if name := strings.TrimSpace(apiKeyName); name != "" {
+		keyLabel = fmt.Sprintf("%s (#%d)", name, apiKeyID)
+	}
+	modelLabel := strings.TrimSpace(model)
+	if modelLabel == "" {
+		modelLabel = "-"
+	}
+	advice := "疑似外部客户端以短超时/程序化方式滥用该 key,持续高取消率会触发上游(Anthropic)滥用风控并可能封禁承载账号。建议核查该 key 来源,必要时降并发/限流或暂停该 key。"
+	return fmt.Sprintf("**节点**：%s\n**API Key**：%s\n**模型**：%s\n**取消率**：%.0f%%（%d/%d，窗口 %ds）\n**模式**：%s\n**时间**：%s\n\n**建议**：%s",
+		escapeFeishuText(site),
+		escapeFeishuText(keyLabel),
+		escapeFeishuText(modelLabel),
+		rate*100, canceled, total, cfg.WindowSeconds,
+		escapeFeishuText(cfg.Mode),
+		escapeFeishuText(formatAlertTime(now)),
+		advice,
+	)
+}
+
+func isOpusModel(model string) bool {
+	return strings.Contains(strings.ToLower(model), "opus")
+}
+
+// ObserveCancelStorm feeds one terminal request outcome (api key id + name, model,
+// whether the client canceled) into the per-key cancel-storm detector. No-op
+// unless cancel_storm_config mode is "detect_only". Safe on nil receiver / detector.
+func (s *OpsService) ObserveCancelStorm(apiKeyID int64, apiKeyName, model string, canceled bool) {
+	if s == nil || s.cancelStorm == nil {
+		return
+	}
+	s.cancelStorm.observe(apiKeyID, apiKeyName, model, canceled)
+}

--- a/backend/internal/service/ops_cancel_storm_tk_test.go
+++ b/backend/internal/service/ops_cancel_storm_tk_test.go
@@ -1,0 +1,187 @@
+//go:build unit
+
+package service
+
+import (
+	"context"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/require"
+)
+
+// minimal SettingRepository stub for exercising loadConfig (only GetValue matters).
+type cancelStormSettingRepo struct {
+	val string
+	err error
+}
+
+func (r *cancelStormSettingRepo) Get(context.Context, string) (*Setting, error)         { return nil, nil }
+func (r *cancelStormSettingRepo) GetValue(context.Context, string) (string, error)       { return r.val, r.err }
+func (r *cancelStormSettingRepo) Set(context.Context, string, string) error              { return nil }
+func (r *cancelStormSettingRepo) GetMultiple(context.Context, []string) (map[string]string, error) {
+	return nil, nil
+}
+func (r *cancelStormSettingRepo) SetMultiple(context.Context, map[string]string) error { return nil }
+func (r *cancelStormSettingRepo) GetAll(context.Context) (map[string]string, error)    { return nil, nil }
+func (r *cancelStormSettingRepo) Delete(context.Context, string) error                 { return nil }
+
+func newTestCancelStormDetector(cfg *CancelStormConfig, doer opsFeishuHTTPDoer, now time.Time) *cancelStormDetector {
+	d := newCancelStormDetector(nil, &fakeIncidentConfigProvider{cfg: enabledFeishuConfig()}, "edge-test")
+	if doer != nil {
+		d.httpClient = doer
+	}
+	d.now = func() time.Time { return now }
+	normalizeCancelStormConfig(cfg)
+	d.cachedCfg = cfg
+	// Pin the config cache well beyond any time the test advances to, so loadConfig
+	// (with a nil settingRepo) is never reached and the injected cfg is authoritative.
+	d.cfgFetchedAt = now.Add(time.Hour)
+	return d
+}
+
+func waitForFeishuCalls(t *testing.T, doer *blockingFeishuDoer, want int) {
+	t.Helper()
+	deadline := time.After(2 * time.Second)
+	for {
+		if doer.callCount() >= want {
+			return
+		}
+		select {
+		case <-deadline:
+			t.Fatalf("timeout waiting for %d feishu calls, got %d", want, doer.callCount())
+		case <-time.After(2 * time.Millisecond):
+		}
+	}
+}
+
+func TestCancelStormLoadConfig(t *testing.T) {
+	t.Run("valid json parsed and clamped", func(t *testing.T) {
+		repo := &cancelStormSettingRepo{val: `{"mode":"detect_only","window_seconds":120,"min_sample_count":30,"cancel_rate_threshold":0.7,"alert_cooldown_seconds":300,"opus_only":true}`}
+		d := newCancelStormDetector(repo, nil, "edge-test")
+		cfg := d.loadConfig()
+		require.Equal(t, cancelStormModeDetectOnly, cfg.Mode)
+		require.Equal(t, 120, cfg.WindowSeconds)
+		require.Equal(t, 30, cfg.MinSampleCount)
+		require.InDelta(t, 0.7, cfg.CancelRateThreshold, 1e-9)
+		require.True(t, cfg.OpusOnly)
+	})
+	t.Run("missing row falls back to default off", func(t *testing.T) {
+		repo := &cancelStormSettingRepo{err: ErrSettingNotFound}
+		cfg := newCancelStormDetector(repo, nil, "x").loadConfig()
+		require.Equal(t, cancelStormModeOff, cfg.Mode)
+	})
+	t.Run("corrupt json falls back to default off", func(t *testing.T) {
+		repo := &cancelStormSettingRepo{val: `{not json`}
+		cfg := newCancelStormDetector(repo, nil, "x").loadConfig()
+		require.Equal(t, cancelStormModeOff, cfg.Mode)
+	})
+	t.Run("unknown mode normalizes to off", func(t *testing.T) {
+		repo := &cancelStormSettingRepo{val: `{"mode":"enforce"}`}
+		cfg := newCancelStormDetector(repo, nil, "x").loadConfig()
+		require.Equal(t, cancelStormModeOff, cfg.Mode, "enforce not implemented in Phase 1 -> off")
+	})
+}
+
+func TestCancelStormModeOffNoAlert(t *testing.T) {
+	now := time.Unix(1700000000, 0)
+	doer := &blockingFeishuDoer{}
+	d := newTestCancelStormDetector(&CancelStormConfig{Mode: cancelStormModeOff, WindowSeconds: 60, MinSampleCount: 2}, doer, now)
+	for i := 0; i < 10; i++ {
+		d.observe(7, "borrowed-key", "claude-opus-4-8", true)
+	}
+	time.Sleep(30 * time.Millisecond)
+	require.Equal(t, 0, doer.callCount(), "mode=off must never alert")
+	require.Empty(t, d.states, "mode=off must not even count")
+}
+
+func TestCancelStormBelowMinSampleNoAlert(t *testing.T) {
+	now := time.Unix(1700000000, 0)
+	doer := &blockingFeishuDoer{}
+	d := newTestCancelStormDetector(&CancelStormConfig{Mode: cancelStormModeDetectOnly, WindowSeconds: 60, MinSampleCount: 5, CancelRateThreshold: 0.5}, doer, now)
+	// 4 requests all canceled: rate 1.0 but below the 5-sample floor.
+	for i := 0; i < 4; i++ {
+		d.observe(7, "k", "claude-opus-4-8", true)
+	}
+	time.Sleep(30 * time.Millisecond)
+	require.Equal(t, 0, doer.callCount())
+}
+
+func TestCancelStormCrossThresholdAlerts(t *testing.T) {
+	now := time.Unix(1700000000, 0)
+	doer := &blockingFeishuDoer{done: make(chan struct{}, 4)}
+	d := newTestCancelStormDetector(&CancelStormConfig{Mode: cancelStormModeDetectOnly, WindowSeconds: 60, MinSampleCount: 5, CancelRateThreshold: 0.5, AlertCooldownSeconds: 600}, doer, now)
+	// 5 requests, 3 canceled -> rate 0.6 >= 0.5 and total 5 >= 5 -> alert.
+	pattern := []bool{true, true, true, false, false}
+	for _, c := range pattern {
+		d.observe(7, "borrowed-key", "claude-opus-4-8", c)
+	}
+	waitForFeishuCalls(t, doer, 1)
+	body := doer.lastBody()
+	require.Contains(t, body, "borrowed-key (#7)")
+	require.Contains(t, body, "60%")
+}
+
+func TestCancelStormDedupWithinCooldown(t *testing.T) {
+	now := time.Unix(1700000000, 0)
+	doer := &blockingFeishuDoer{done: make(chan struct{}, 8)}
+	d := newTestCancelStormDetector(&CancelStormConfig{Mode: cancelStormModeDetectOnly, WindowSeconds: 600, MinSampleCount: 2, CancelRateThreshold: 0.5, AlertCooldownSeconds: 600}, doer, now)
+	for i := 0; i < 10; i++ {
+		d.observe(7, "k", "claude-opus-4-8", true)
+	}
+	waitForFeishuCalls(t, doer, 1)
+	time.Sleep(40 * time.Millisecond)
+	require.Equal(t, 1, doer.callCount(), "within cooldown only one alert per key")
+}
+
+func TestCancelStormOpusOnlyGatesNonOpus(t *testing.T) {
+	now := time.Unix(1700000000, 0)
+	doer := &blockingFeishuDoer{}
+	d := newTestCancelStormDetector(&CancelStormConfig{Mode: cancelStormModeDetectOnly, WindowSeconds: 60, MinSampleCount: 2, CancelRateThreshold: 0.5, OpusOnly: true}, doer, now)
+	for i := 0; i < 10; i++ {
+		d.observe(7, "k", "claude-sonnet-4-6", true)
+	}
+	time.Sleep(30 * time.Millisecond)
+	require.Equal(t, 0, doer.callCount(), "opus_only must skip non-opus models")
+	require.Empty(t, d.states)
+}
+
+func TestCancelStormWindowTumblingResets(t *testing.T) {
+	now := time.Unix(1700000000, 0)
+	cur := now
+	d := newCancelStormDetector(nil, &fakeIncidentConfigProvider{cfg: enabledFeishuConfig()}, "edge-test")
+	d.now = func() time.Time { return cur }
+	d.httpClient = &blockingFeishuDoer{}
+	cfg := &CancelStormConfig{Mode: cancelStormModeDetectOnly, WindowSeconds: 60, MinSampleCount: 100, CancelRateThreshold: 0.5}
+	normalizeCancelStormConfig(cfg)
+	d.cachedCfg = cfg
+	d.cfgFetchedAt = now.Add(time.Hour)
+
+	// Fill the first window with cancels (min_sample high so no alert).
+	for i := 0; i < 3; i++ {
+		d.observe(7, "k", "claude-opus-4-8", true)
+	}
+	d.mu.Lock()
+	require.Equal(t, 3, d.states[7].total)
+	require.Equal(t, 3, d.states[7].canceled)
+	d.mu.Unlock()
+
+	// Advance past the window; the next observe must reset, not accumulate.
+	cur = now.Add(61 * time.Second)
+	d.observe(7, "k", "claude-opus-4-8", false)
+	d.mu.Lock()
+	require.Equal(t, 1, d.states[7].total, "window must tumble-reset total")
+	require.Equal(t, 0, d.states[7].canceled, "old-window cancels must not carry over")
+	require.Equal(t, cur, d.states[7].windowStart)
+	d.mu.Unlock()
+}
+
+func TestCancelStormConfigNormalizeClamps(t *testing.T) {
+	c := &CancelStormConfig{Mode: "DETECT_ONLY", WindowSeconds: -5, MinSampleCount: 0, CancelRateThreshold: 9, AlertCooldownSeconds: -1}
+	normalizeCancelStormConfig(c)
+	require.Equal(t, cancelStormModeDetectOnly, c.Mode)
+	require.Equal(t, 60, c.WindowSeconds)
+	require.Equal(t, 1, c.MinSampleCount)
+	require.InDelta(t, 0.5, c.CancelRateThreshold, 1e-9)
+	require.Equal(t, 0, c.AlertCooldownSeconds)
+}

--- a/backend/internal/service/ops_service.go
+++ b/backend/internal/service/ops_service.go
@@ -46,6 +46,10 @@ type OpsService struct {
 	// UpdateOpsAdvancedSettings 写入新配置后调用，把最新的 quota auto-pause 全局默认阈值
 	// 立即同步到调度热路径读取的内存缓存，避免下次请求才能感知新值。
 	quotaAutoPauseSink func(OpsOpenAIAccountQuotaAutoPauseSettings)
+
+	// cancelStorm 是 TK per-API-key 取消风暴检测器（detect + 飞书告警，默认 off）。
+	// 在 NewOpsService 中构造，热路径经 ObserveCancelStorm 喂入。见 ops_cancel_storm_tk.go。
+	cancelStorm *cancelStormDetector
 }
 
 // CleanupReloader 由 OpsCleanupService 实现。
@@ -101,6 +105,12 @@ func NewOpsService(
 		systemLogSink:             systemLogSink,
 	}
 	svc.applyRuntimeLogConfigOnStartup(context.Background())
+	// TK: per-API-key cancel-storm detector (detect + Feishu alert, default off).
+	frontendURL := ""
+	if cfg != nil {
+		frontendURL = cfg.Server.FrontendURL
+	}
+	svc.cancelStorm = newCancelStormDetector(settingRepo, svc, siteFromFrontendURL(frontendURL))
 	return svc
 }
 

--- a/backend/migrations/tk_018_seed_cancel_storm_config.sql
+++ b/backend/migrations/tk_018_seed_cancel_storm_config.sql
@@ -1,0 +1,36 @@
+-- TokenKey: seed the per-API-key cancel-storm detector config. Default OFF.
+--
+-- Background: a single external automation client borrowing a TokenKey API key
+-- with short client timeouts produced a "cancel storm" (context-canceled flood)
+-- on opus relay traffic — the exact "non-human harness" traffic shape that trips
+-- Anthropic's abuse filter and got an irreplaceable subscription-OAuth account
+-- org-disabled. TokenKey had no real-time signal: the incident was only
+-- reconstructed post-mortem. This detector counts per-API-key cancel rate at the
+-- gateway terminal-outcome chokepoint and fires a Feishu alert when a key crosses
+-- the threshold, so operators see the storm as it happens and can act (Phase 1:
+-- detect + alert only; auto-throttle is a separate later PR).
+--
+-- Config shape (parsed by internal/service/ops_cancel_storm_tk.go):
+--   mode                  : "off" (default) | "detect_only". Only "detect_only" arms it.
+--   window_seconds        : tumbling counting window per key.
+--   min_sample_count      : minimum requests in a window before the rate is judged
+--                           (a volume floor so low-traffic keys never trip).
+--   cancel_rate_threshold : canceled/total ratio that counts as a storm (0..1).
+--   min_cancel_count      : optional absolute canceled floor (0 = rely on rate*samples).
+--   alert_cooldown_seconds: per-key alert de-dup window (anti-spam).
+--   opus_only             : optional gate to only count opus-family models.
+--
+-- Default mode is "off" so this migration is behaviorally inert on every existing
+-- fleet node until an operator flips it to "detect_only" via the settings row.
+-- These are STARTING values to be calibrated against real traffic under
+-- detect_only before any future enforcement is enabled.
+--
+-- Idempotent: ON CONFLICT (key) DO NOTHING so re-running and operator overrides
+-- are preserved; only fresh installs without the row get the default.
+
+INSERT INTO settings (key, value)
+VALUES (
+  'cancel_storm_config',
+  '{"mode":"off","window_seconds":60,"min_sample_count":20,"cancel_rate_threshold":0.5,"min_cancel_count":0,"alert_cooldown_seconds":600,"opus_only":false}'
+)
+ON CONFLICT (key) DO NOTHING;

--- a/scripts/sentinels/gateway-tk.json
+++ b/scripts/sentinels/gateway-tk.json
@@ -1940,6 +1940,13 @@
         "TestClassifyOpsUpstream5xxWithStatusStaysProviderNotCancel"
       ],
       "rationale": "Focused regressions proving the issue #625 boundary: (1) a status-0 `context canceled` transport error (and an inbound Request.Context() cancel with no cancel signature in the message) classify as error_owner=client so they drop out of upstream_error_rate; (2) status-0 `context deadline exceeded` and `i/o timeout` stay error_owner=provider so genuine upstream slowness keeps counting; (3) a real upstream 5xx WITH a status code stays provider via the status gate. Dropping these lets an upstream merge silently revert the quad-P0 fix through the classifier."
+    },
+    {
+      "path": "backend/internal/handler/ops_error_logger.go",
+      "must_contain": [
+        "tkObserveCancelStorm(c, ops)"
+      ],
+      "rationale": "Per-API-key cancel-storm detector chokepoint hook (PR #635, Phase 1 detect-only). OpsErrorLoggerMiddleware is the single terminal-outcome observation point on /v1; this one line right after c.Next() feeds every request (success + >=400, independent of the ops-monitoring master switch) into OpsService.ObserveCancelStorm so a borrowed key issuing a context-canceled flood (the non-human-harness shape that got a subscription-OAuth account org-disabled) raises a real-time Feishu alert. The hook is small and compile-clean if dropped, so an upstream merge could silently revert it and re-blind the fleet to cancel storms. This sentinel pins the literal call; the detector itself (window counting + threshold + alert) lives in ops_cancel_storm_tk.go, which a missing hook would leave dead."
     }
   ]
 }


### PR DESCRIPTION
## 背景

一个借 tk key、短超时、程序化猛打的外部客户端制造了 `context canceled` 风暴（前 1h 685 笔全 opus、64% 取消），这正是 Anthropic 滥用模型最敏感的「非真人 harness」流量画像，最终把一个不可替代的薄池订阅 OAuth 账号打到 `This organization has been disabled`（通常不可逆）。事件中 TokenKey **既没实时看见、也没在入口掐断**——只能事后逐分钟法医式重建。

本 PR 交付「**实时看见**」这一件最高杠杆的事：在网关终端出口按 API key 数取消率，越线即飞书告警。

## 范围（乔布斯审核后刻意收窄）

**只做检测 + 告警**（`mode: off | detect_only`，默认 `off`）。**自动降并发**（执行器）刻意留作独立的 Phase 2 PR——先用 `detect_only` 在真实流量上校准阈值，再上自动动作，避免误伤正常高并发客户端。这期间运营手上已有人工杠杆（禁用 key / 降用户并发）。

## 实现（最小侵入，挂在已接线的 OpsService 上，零新基建 / 零 DI 接线）

- **新增** `internal/service/ops_cancel_storm_tk.go` — `CancelStormConfig` + 10s 缓存的 `config()`（热路径不每请求读 DB）+ 内存 tumbling 窗口 `observe()`（按 key 计数、越线去重告警）+ `sendAlert()`（复用 `feishuCardPayload`/`sendFeishuPayload`）。
- **新增** `internal/handler/ops_error_logger_tk_cancel_storm.go` — 薄 shim，复用取消分类器 `tkUpstreamClientCanceled`。
- **新增** `migrations/tk_018_seed_cancel_storm_config.sql` — 幂等 seed，默认 `off`（`//go:embed *.sql` 自动发现）。
- **注入** `ops_error_logger.go`（`c.Next()` 后 1 行，覆盖成功/≥400 两分支、不受 ops 监控总开关影响）、`ops_service.go`（+字段/构造）、`domain_constants.go`（+1 常量）。共 20 行。

## 设计要点

- **每客户端请求精确计一次**：埋点在 `/v1` 终端出口跑一次，内部重试/failover 已收敛为单一终端结果。
- **稳态零开销**：`mode=off`（默认）时 `observe` 在 config 检查后立即返回，不进计数锁；全 fleet 行为惰性，运营翻 `detect_only` 才生效。
- **与 #628 豁免正交**：context-canceled 对上游健康仍是已豁免的假 P0，对账号封禁风险是真信号——本检测器独立计数，不依赖 ops_error_logs 落库（后者默认 `IgnoreContextCanceled`）。
- **计数粒度**：进程内内存窗口；Stage0 单容器/节点，对本风险形态精确。若节点横向扩容再迁 Redis（Phase 2 执行器会引入该底座）。

## 当前默认阈值（settings 热调）

60s 窗口 / ≥20 样本 / 取消率 ≥50% / 告警去重 600s。

## 验证

- `go build ./...` ✅
- `go test -tags=unit ./...`（全量）✅ — 含 8 个新单测：config 解析/clamp/损坏回退、mode=off 零计数、低样本不报、越线告警、cooldown 去重、opus_only 门、窗口翻转重置
- `golangci-lint run`（改动包）0 issues ✅
- `scripts/preflight.sh` PASS ✅（含 upstream-override marker：`upstream-touch-guarded`）

🤖 Generated with [Claude Code](https://claude.com/claude-code)