### PR TITLE
fix(ratelimit): account-wide Anthropic unified-window 429 cools whole account, not a model class

### DIFF
--- a/backend/internal/service/ratelimit_service_tk_model_cooldown.go
+++ b/backend/internal/service/ratelimit_service_tk_model_cooldown.go
@@ -7,40 +7,46 @@ import (
 	"time"
 )
 
-// TK G4 — model-dimension cooldown for Anthropic unified-window 429s.
+// TK G4 — model-dimension cooldown for Anthropic per-class sub-bucket 429s.
 //
-// Background (prod 2026-06, edge us6, account edge-ls-oh-3-d): Anthropic
-// subscription (OAuth) accounts share a rolling "unified 5h / 7d" usage
-// window across ALL model classes. When the heaviest class (typically opus)
-// burns through the 5h window, upstream returns a real 429 rate_limit_error
-// and handle429 parses the anthropic-ratelimit-unified-5h-* headers
-// (is_5h_exceeded=true / reset_5h=<unix>). The legacy behaviour then called
-// SetRateLimited, which is ACCOUNT-LEVEL: it pulled the whole account out of
-// scheduling until reset. But sonnet/haiku on that same account were still
-// perfectly healthy — only opus's slice of the 5h window was exhausted. The
-// account-level cooldown amplified "opus window full" into "entire account
-// offline", wasting healthy sonnet/haiku capacity for ~1h.
+// Background (prod 2026-06, edge us6, account edge-ls-oh-3-d): the original G4
+// belief was that an Anthropic "unified 5h / 7d" window 429 was tied to the
+// heaviest model class (typically opus) and that sonnet/haiku on the same
+// account stayed healthy — so it scoped the cooldown to (account × model
+// class) instead of pulling the whole account out of scheduling.
 //
-// G4 fix: when the 429 is provably tied to a model class (5h/7d unified
-// window exceeded AND we know the requested model's class), scope the
-// cooldown to (account × model class) instead of the whole account. The opus
-// class is cooled until reset; sonnet/haiku on the same account keep
-// scheduling. Hard account failures (401/403 auth, credit balance, org
-// disabled, KYC, 529 overloaded, fallback no-reset 429) are NOT model-related
-// and keep their account-level behaviour unchanged.
+// CORRECTION (direct upstream probe, edge-us3 account a1, 2026-06-06): the
+// account-level `anthropic-ratelimit-unified-5h-*` / `-7d-*` headers (NO
+// model-class suffix) are ACCOUNT-WIDE SHARED windows. With
+// `unified-7d-status: rejected` (utilization 1.0, surpassed-threshold 1.0) the
+// account returned HTTP 429 rate_limit_error to a *sonnet* request even though
+// `unified-7d_sonnet-status: allowed` / utilization 0.0 — i.e. a sibling
+// class's own sub-bucket having headroom does NOT let it through when the
+// overall window is rejected (`unified-status: rejected`,
+// `representative-claim: seven_day`). So the original premise is FALSE for an
+// account-wide window: exhausting it 429s every class regardless of per-class
+// sub-bucket. Cooling only the requested class there leaves sibling classes
+// (e.g. haiku) falsely "schedulable" and never marks the account rate-limited.
 //
-// Convergence: this reuses the existing per-(account × scope) cooldown
-// mechanism already in account.Extra["model_rate_limits"] — the same store
-// written by SetModelRateLimit (404 model-not-found, antigravity credits,
-// gemini code-assist) and read by the scheduler's
-// IsSchedulableForModelWithContext → isModelRateLimitedWithContext gate. We
-// add a model-CLASS scope key (anthropic:class:opus|sonnet|haiku) mirroring
-// the antigravity "antigravity:gemini" family-key precedent, so no new
-// repository interface method, no parallel Redis layer, and no second source
-// of truth the scheduler must learn to consult. The store is durable
-// (accounts.extra JSONB + scheduler snapshot via outbox) and self-expiring
-// (reads compare time.Now() against rate_limit_reset_at), exactly matching
-// the "transient state with a reset time" shape this feature needs.
+// Corrected behaviour: model-scope the cooldown ONLY when the 429 is NOT an
+// account-wide window exhaustion — i.e. a genuine per-class sub-bucket limit
+// (anthropic-ratelimit-unified-7d_<class>-status rejected while the overall
+// 5h/7d window is still allowed). When an account-wide window (5h or 7d) is
+// the surpassed one (anthropic429Result.window == "5h"/"7d"), this helper
+// declines (returns false) and the caller falls through to account-level
+// SetRateLimited so ALL classes are cooled until reset — matching the upstream
+// `unified-status: rejected` semantics. Hard account failures (401/403 auth,
+// credit balance, org disabled, KYC, 529 overloaded, fallback no-reset 429)
+// are not model-related and keep their account-level behaviour unchanged.
+//
+// Convergence: model-scoping (when it does apply) reuses the existing
+// per-(account × scope) cooldown mechanism already in
+// account.Extra["model_rate_limits"] — the same store written by
+// SetModelRateLimit (404 model-not-found, antigravity credits, gemini
+// code-assist) and read by the scheduler's IsSchedulableForModelWithContext →
+// isModelRateLimitedWithContext gate. The store is durable (accounts.extra
+// JSONB + scheduler snapshot via outbox) and self-expiring (reads compare
+// time.Now() against rate_limit_reset_at).
 
 const (
 	// anthropicModelClassRateLimitPrefix namespaces the model-class cooldown
@@ -57,6 +63,17 @@ const (
 	// entry so operators / debug tooling can distinguish a unified-window
 	// model-class cooldown from a 404 model-not-found cooldown.
 	tkAnthropicModelCooldownReason = "anthropic_unified_window_exceeded"
+
+	// anthropicUnifiedWindow5h / 7d are the account-wide (non-class-suffixed)
+	// unified window labels set on anthropic429Result.window by
+	// calculateAnthropic429ResetTime when the corresponding
+	// anthropic-ratelimit-unified-{5h,7d}-* header is surpassed. They mirror the
+	// literal strings that parser uses; an empty window means no account-wide
+	// window was surpassed (a genuine per-class sub-bucket limit), the only case
+	// where model-scoping is correct. See the package doc above for the
+	// edge-us3 upstream probe that established these are account-wide.
+	anthropicUnifiedWindow5h = "5h"
+	anthropicUnifiedWindow7d = "7d"
 )
 
 // tkAnthropicModelClass normalizes an Anthropic model name to its capacity
@@ -100,21 +117,25 @@ func tkAnthropicModelClassScopeKeyForModel(model string) string {
 }
 
 // tkTryAnthropicModelScopedCooldown attempts to write a (account × model
-// class) cooldown for an Anthropic unified-window 429 instead of an
-// account-level SetRateLimited.
+// class) cooldown for a genuine per-class Anthropic sub-bucket 429 instead of
+// an account-level SetRateLimited.
 //
 // It returns true ONLY when the cooldown was written at model-class scope —
-// i.e. this is an Anthropic account, the 429 is a unified-window-exceeded
-// signal, AND the requested model resolves to a known class. In that case the
-// caller MUST NOT also call account-level SetRateLimited (that would re-create
-// the very amplification G4 removes). It still counts as an authoritative
-// upstream cooldown for the purpose of suppressing the 3/3 ladder write, so
-// the caller treats a true return like the account-level rate-limit path.
+// i.e. this is an Anthropic account, the 429 is NOT an account-wide unified
+// window exhaustion (result.window is empty, so a per-class sub-bucket is the
+// binding limit), AND the requested model resolves to a known class. In that
+// case the caller MUST NOT also call account-level SetRateLimited. It still
+// counts as an authoritative upstream cooldown for the purpose of suppressing
+// the 3/3 ladder write, so the caller treats a true return like the
+// account-level rate-limit path.
 //
-// It returns false in every other case (non-Anthropic, no model class known,
-// or repo write failure), and the caller falls back to the existing
-// account-level behaviour — preserving correctness for hard account failures
-// and for the no-model-context call sites.
+// It returns false in every other case — crucially including when an
+// ACCOUNT-WIDE unified window (5h or 7d) is the surpassed one
+// (result.window == "5h"/"7d"): such windows are shared across all model
+// classes (edge-us3 upstream probe, 2026-06-06 — see package doc), so the
+// caller MUST fall through to account-level SetRateLimited to cool every
+// class. Also returns false for non-Anthropic, unknown/absent model class, or
+// repo write failure.
 func (s *RateLimitService) tkTryAnthropicModelScopedCooldown(
 	ctx context.Context,
 	account *Account,
@@ -125,6 +146,14 @@ func (s *RateLimitService) tkTryAnthropicModelScopedCooldown(
 		return false
 	}
 	if account.Platform != PlatformAnthropic {
+		return false
+	}
+	// Account-wide unified window (5h/7d) exhaustion blocks EVERY model class
+	// regardless of per-class sub-bucket headroom — model-scoping it would
+	// leave sibling classes falsely schedulable and never mark the account
+	// rate-limited. Decline so the caller does account-level SetRateLimited.
+	// Only an empty window (genuine per-class sub-bucket limit) is model-scoped.
+	if result.window == anthropicUnifiedWindow5h || result.window == anthropicUnifiedWindow7d {
 		return false
 	}
 	class := tkAnthropicModelClass(requestedModel)
@@ -147,16 +176,13 @@ func (s *RateLimitService) tkTryAnthropicModelScopedCooldown(
 		return false
 	}
 
-	// The unified 5h window is exhausted at the ACCOUNT level (it's the shared
-	// window across all model classes — that's exactly why upstream 429'd).
-	// Even though the cooldown is scoped to the model class for SCHEDULING, the
-	// account's 5h-window state is account-global truth and must still be
-	// recorded, so the Setup-Token usage gauge (estimateSetupTokenUsage, fed by
-	// SessionWindow*) keeps reflecting reality. This mirrors the account-level
-	// path's UpdateSessionWindow write — only the cooldown scope changed, not
-	// the window signal.
-	s.tkUpdateAnthropic5hSessionWindow(ctx, account.ID, result)
-
+	// NOTE: we intentionally do NOT write the account-global 5h session window
+	// ("rejected") here. This path now only runs for a genuine per-class
+	// sub-bucket limit (result.window == "", i.e. neither account-wide 5h nor
+	// 7d window was surpassed), so the account's shared 5h window is NOT
+	// rejected — forcing it would corrupt the Setup-Token usage gauge. The
+	// account-wide window path (caller's account-level branch) still calls
+	// tkUpdateAnthropic5hSessionWindow when an overall window is the trigger.
 	slog.Info("anthropic_model_class_rate_limited",
 		"account_id", account.ID,
 		"scope", scopeKey,

--- a/backend/internal/service/ratelimit_service_tk_model_cooldown_test.go
+++ b/backend/internal/service/ratelimit_service_tk_model_cooldown_test.go
@@ -13,13 +13,16 @@ import (
 	"github.com/stretchr/testify/require"
 )
 
-// G4 — model-dimension cooldown for Anthropic unified-window 429s.
+// G4 — model-dimension cooldown for Anthropic per-class sub-bucket 429s.
 //
-// Prod motivation (edge us6, account edge-ls-oh-3-d): opus burned the shared
-// 5h window, upstream returned a unified-window 429, and the legacy
-// account-level SetRateLimited pulled the WHOLE account out of scheduling —
-// taking healthy sonnet/haiku offline with it. G4 scopes that cooldown to
-// (account × model class) so only opus is cooled.
+// Corrected semantics (edge-us3 upstream probe, 2026-06-06): the account-wide
+// unified 5h/7d windows (anthropic-ratelimit-unified-{5h,7d}-*, no class
+// suffix) are SHARED across all model classes — exhausting one 429s every
+// class even when that class's own sub-bucket is allowed. So an account-wide
+// window exhaustion (anthropic429Result.window == "5h"/"7d") cools the WHOLE
+// account (account-level SetRateLimited); model-scoping is reserved for a
+// genuine per-class sub-bucket limit (window == "", neither overall window
+// surpassed) so siblings stay schedulable only when they truly have capacity.
 
 func tkModelClassScope(class string) string {
 	return anthropicModelClassRateLimitPrefix + class
@@ -59,13 +62,30 @@ func TestTkAnthropicModelClassScopeKeyForModel(t *testing.T) {
 	require.Empty(t, tkAnthropicModelClassScopeKeyForModel(""))
 }
 
-// --- write side: 5h exceeded → model-class cooldown, NOT account-level --------
+// --- write side: account-wide window exceeded → account-level, NOT model-scoped --
 
+// anthropic5hExceededHeaders models an ACCOUNT-WIDE 5h window exhaustion
+// (5h utilization >= 1.0). Per the corrected semantics this must cool the
+// whole account, never a single model class.
 func anthropic5hExceededHeaders(resetAt int64) http.Header {
 	headers := http.Header{}
 	headers.Set("anthropic-ratelimit-unified-5h-utilization", "1.02")
 	headers.Set("anthropic-ratelimit-unified-5h-reset", strconv.FormatInt(resetAt, 10))
 	headers.Set("anthropic-ratelimit-unified-7d-utilization", "0.30")
+	headers.Set("anthropic-ratelimit-unified-7d-reset", strconv.FormatInt(resetAt+3600*24, 10))
+	return headers
+}
+
+// anthropicPerClassNoOverallExceededHeaders models a genuine per-class
+// sub-bucket limit: neither account-wide 5h nor 7d window is surpassed, but
+// the upstream still 429'd (e.g. anthropic-ratelimit-unified-7d_opus-status
+// rejected). calculateAnthropic429ResetTime yields result.window == "" here,
+// which is the only case where model-scoping is correct.
+func anthropicPerClassNoOverallExceededHeaders(resetAt int64) http.Header {
+	headers := http.Header{}
+	headers.Set("anthropic-ratelimit-unified-5h-utilization", "0.30")
+	headers.Set("anthropic-ratelimit-unified-5h-reset", strconv.FormatInt(resetAt, 10))
+	headers.Set("anthropic-ratelimit-unified-7d-utilization", "0.40")
 	headers.Set("anthropic-ratelimit-unified-7d-reset", strconv.FormatInt(resetAt+3600*24, 10))
 	return headers
 }
@@ -79,7 +99,10 @@ func newG4RateLimitService(repo *rateLimitAccountRepoStub) *RateLimitService {
 	return svc
 }
 
-func TestG4_OpusUnifiedWindow429_CoolsModelClassNotAccount(t *testing.T) {
+func TestG4_OverallWindow429_CoolsAccountNotModelClass(t *testing.T) {
+	// An account-wide 5h window exhaustion blocks every model class (the shared
+	// window is rejected regardless of per-class sub-bucket headroom — edge-us3
+	// upstream probe). It MUST cool the whole account, not just opus.
 	repo := &rateLimitAccountRepoStub{}
 	svc := newG4RateLimitService(repo)
 	account := &Account{ID: 901, Platform: PlatformAnthropic, Type: AccountTypeOAuth}
@@ -94,29 +117,58 @@ func TestG4_OpusUnifiedWindow429_CoolsModelClassNotAccount(t *testing.T) {
 		"claude-opus-4-8",
 	)
 
-	// model-scoped cooldown is authoritative → account is not error-disabled
+	// rate-limited (not error-disabled) account
 	require.False(t, shouldDisable)
-	// account-level rate limit MUST NOT be written (that's the amplification G4 removes)
-	require.Equal(t, 0, repo.setRateLimitedCalls,
-		"unified-window opus 429 must NOT call account-level SetRateLimited")
+	// account-level rate limit IS written — the whole account is cooled
+	require.Equal(t, 1, repo.setRateLimitedCalls,
+		"account-wide 5h window exhaustion must call account-level SetRateLimited")
+	// NO model-class cooldown — that would falsely leave sibling classes schedulable
+	require.Empty(t, repo.modelRateLimitCalls,
+		"account-wide window exhaustion must NOT be model-scoped")
 	require.Equal(t, 0, repo.tempCalls,
-		"authoritative model cooldown suppresses the 3/3 ladder temp-unschedulable")
-	// model-class cooldown for opus written exactly once
-	require.Len(t, repo.modelRateLimitCalls, 1)
-	call := repo.modelRateLimitCalls[0]
-	require.Equal(t, int64(901), call.accountID)
-	require.Equal(t, tkModelClassScope("opus"), call.scope)
-	require.Equal(t, tkAnthropicModelCooldownReason, call.reason)
-	require.WithinDuration(t, time.Unix(resetAt, 0), call.resetAt, 2*time.Second)
-	// account-global 5h window is still recorded (operator usage gauge depends
-	// on it) — only the cooldown SCOPE narrowed, not the window signal.
+		"authoritative SetRateLimited suppresses the 3/3 ladder temp-unschedulable")
+	// account-global 5h session window recorded (operator usage gauge)
 	require.Equal(t, 1, repo.updateSessionWindowCalls,
-		"model-scoped cooldown must still record the account-global 5h session window")
+		"account-level path records the account-global 5h session window")
 	require.Equal(t, "rejected", repo.lastSessionWindowStatus)
 }
 
+func TestG4_PerClassSubBucket429_ModelScopedSiblingsSchedulable(t *testing.T) {
+	// Genuine per-class sub-bucket limit: neither overall 5h nor 7d window is
+	// surpassed (result.window == ""), so model-scoping is correct — only the
+	// requested class is cooled and the account-global window is NOT touched.
+	repo := &rateLimitAccountRepoStub{}
+	svc := newG4RateLimitService(repo)
+	account := &Account{ID: 921, Platform: PlatformAnthropic, Type: AccountTypeOAuth}
+
+	resetAt := time.Now().Add(90 * time.Minute).Unix()
+	shouldDisable := svc.HandleUpstreamError(
+		context.Background(),
+		account,
+		http.StatusTooManyRequests,
+		anthropicPerClassNoOverallExceededHeaders(resetAt),
+		[]byte(`{"error":{"type":"rate_limit_error","message":"per-class limit reached"}}`),
+		"claude-opus-4-8",
+	)
+
+	require.False(t, shouldDisable)
+	// model-class cooldown for opus written exactly once
+	require.Len(t, repo.modelRateLimitCalls, 1)
+	call := repo.modelRateLimitCalls[0]
+	require.Equal(t, int64(921), call.accountID)
+	require.Equal(t, tkModelClassScope("opus"), call.scope)
+	require.Equal(t, tkAnthropicModelCooldownReason, call.reason)
+	// NO account-level rate limit (siblings keep their genuine capacity)
+	require.Equal(t, 0, repo.setRateLimitedCalls,
+		"per-class sub-bucket limit must NOT cool the whole account")
+	// per-class path must NOT force the account-global 5h session window rejected
+	require.Equal(t, 0, repo.updateSessionWindowCalls,
+		"per-class cooldown must not corrupt the account-global 5h session window")
+}
+
 func TestG4_OpusCooled_SonnetHaikuStillSchedulable(t *testing.T) {
-	// Simulate the post-write account state: opus class cooled until reset.
+	// Reader-side: represents a genuine per-class cooldown (only opus class
+	// cooled). Simulate the post-write account state: opus class cooled until reset.
 	resetAt := time.Now().Add(90 * time.Minute)
 	account := &Account{
 		ID:          902,

--- a/scripts/sentinels/gateway-tk.json
+++ b/scripts/sentinels/gateway-tk.json
@@ -1822,10 +1822,11 @@
         "func tkAnthropicModelClass(model string) string",
         "anthropicModelClassRateLimitPrefix = \"anthropic:class:\"",
         "func (s *RateLimitService) tkTryAnthropicModelScopedCooldown(",
+        "if result.window == anthropicUnifiedWindow5h || result.window == anthropicUnifiedWindow7d {",
         "SetModelRateLimit(ctx, account.ID, scopeKey, resetAt, tkAnthropicModelCooldownReason)",
         "func (a *Account) tkAnthropicModelClassRateLimitActive(requestedModel string) bool"
       ],
-      "rationale": "G4 model-dimension cooldown companion. Anthropic OAuth accounts share a unified 5h/7d window across model classes; when opus exhausts it, upstream returns a unified-window 429 and the LEGACY behaviour cooled the WHOLE account (SetRateLimited), taking healthy sonnet/haiku offline (prod edge us6, account edge-ls-oh-3-d). This file scopes that cooldown to (account x model class) via the existing model_rate_limits store with an 'anthropic:class:<opus|sonnet|haiku>' scope key (mirrors the antigravity 'antigravity:gemini' family-key precedent). Losing tkTryAnthropicModelScopedCooldown / tkAnthropicModelClass on an upstream merge would silently re-introduce the account-level amplification; this sentinel catches that."
+      "rationale": "G4 model-dimension cooldown companion. Anthropic OAuth accounts share a unified 5h/7d window across model classes. The model-scoped cooldown is ONLY correct for a genuine per-class sub-bucket limit; an account-wide unified window (anthropic-ratelimit-unified-{5h,7d}-* with NO class suffix) is shared and blocks every class even when that class's own sub-bucket is allowed (direct upstream probe edge-us3 account a1, 2026-06-06: unified-7d-status=rejected returned 429 to a sonnet request while unified-7d_sonnet-status=allowed). The 'if result.window == anthropicUnifiedWindow5h || ...7d' guard makes tkTryAnthropicModelScopedCooldown DECLINE (return false -> caller does account-level SetRateLimited) for account-wide windows, so all classes are cooled; model-scoping survives only for window=='' (per-class sub-bucket). Losing that guard re-introduces the bug where a 7d-exhausted account leaves haiku falsely schedulable and unmarked. Losing tkTryAnthropicModelScopedCooldown / tkAnthropicModelClass on an upstream merge would silently re-introduce the original account-level amplification; this sentinel catches both."
     },
     {
       "path": "backend/internal/service/ratelimit_service.go",


### PR DESCRIPTION
## Problem

G4 (#600, [account/model-scoped cooldown]) model-scoped **every** Anthropic unified-window 429 to the requested model's class, on the premise that sibling classes (sonnet/haiku) stay healthy when one class burns the shared window.

**That premise is false — proven by a direct upstream probe** (edge-us3 account a1, 2026-06-06). A `sonnet` request to the account returned `HTTP 429 rate_limit_error` while the response headers showed:

```
anthropic-ratelimit-unified-status: rejected
anthropic-ratelimit-unified-7d-status: rejected            (utilization 1.0, surpassed-threshold 1.0)
anthropic-ratelimit-unified-7d_sonnet-status: allowed      (utilization 0.0)   ← sonnet sub-bucket has room
anthropic-ratelimit-unified-5h-status: allowed             (utilization 0.0)
anthropic-ratelimit-unified-representative-claim: seven_day
```

i.e. the account-wide `seven_day` window being `rejected` 429s **every** class even when that class's own sub-bucket is `allowed`. The `anthropic-ratelimit-unified-{5h,7d}-*` windows (no class suffix) are **account-wide shared windows**; per-class buckets only appear as `…-7d_<class>-*` and are NOT what the 429 reset headers key off.

### Observed impact (edge-us3)
Single-account edge whose only account hit its 7d window: kept returning `no available accounts` 429 for opus, left **haiku falsely "schedulable"**, and **never marked the account rate-limited** (`temp_unschedulable_until` / `rate_limit_reset_at` unset). The account sat stuck until the 7d reset, masked from prod by failover — a silently-dead edge.

## Fix

`tkTryAnthropicModelScopedCooldown` now **declines** (returns false → caller falls through to account-level `SetRateLimited`) when the surpassed window is an account-wide unified window (`anthropic429Result.window == "5h"/"7d"`). Model-scoping is **preserved only** for a genuine per-class sub-bucket limit (`window == ""`, neither overall window surpassed), where siblings truly have capacity. Also stop force-writing the account-global 5h session window `"rejected"` in the now per-class-only path (it would corrupt the Setup-Token usage gauge).

**Not a full revert of #600**: the model-scoped path is retained exactly where it is correct (per-class) and corrected where its premise was false (account-wide). Hard account failures (401/403/credit/529/no-reset) keep their existing account-level behaviour.

All changes are in the TK companion file `*_tk_model_cooldown.go` + its `_test.go` — no upstream-shaped file touched; the caller at `ratelimit_service.go` needs no change.

## Tests
- Invert `TestG4_OpusUnifiedWindow429_*` → `TestG4_OverallWindow429_CoolsAccountNotModelClass` (account-wide 5h exhaustion → account-level `SetRateLimited`, no model-scoped write).
- Add `TestG4_PerClassSubBucket429_ModelScopedSiblingsSchedulable` (neither overall window surpassed → model-scoped, account-global window untouched).
- Existing account-level / reader / boundary tests unchanged.

## Verification
- `go build ./...` ✓
- `go test -tags=unit ./...` (full backend) ✓
- `golangci-lint run ./internal/service/...` → 0 issues ✓
- `bash scripts/preflight.sh` → PASS ✓ (upstream-override-marker exempt: changes are `*_tk_*.go` + `*_test.go`)

## Out of scope (separate follow-up)
- a1's current line state (`model_rate_limits.sonnet` mis-cooled, account-level unmarked) self-corrects on the next 429 after this ships.
- edge-us3 zero-redundancy capacity (single account exhausted until the 7d reset) needs an operational fix (add a healthy account / route away) — orthogonal to this bug.

🤖 Generated with [Claude Code](https://claude.com/claude-code)