### PR TITLE
fix(ops): min-sample floor for rate P0 alert rules (kill low-traffic false positives)

### DIFF
--- a/backend/internal/service/ops_alert_evaluator_service.go
+++ b/backend/internal/service/ops_alert_evaluator_service.go
@@ -243,7 +243,7 @@ func (s *OpsAlertEvaluatorService) evaluateOnce(interval time.Duration) {
 		windowStart := safeEnd.Add(-time.Duration(windowMinutes) * time.Minute)
 		windowEnd := safeEnd
 
-		metricValue, ok := s.computeRuleMetric(ctx, rule, systemMetrics, windowStart, windowEnd, scopePlatform, scopeGroupID)
+		metricValue, ok := s.computeRuleMetric(ctx, rule, systemMetrics, windowStart, windowEnd, scopePlatform, scopeGroupID, runtimeCfg.RateRuleMinSamples)
 		if !ok {
 			s.resetRuleState(rule.ID, now)
 			continue
@@ -461,9 +461,19 @@ func (s *OpsAlertEvaluatorService) computeRuleMetric(
 	end time.Time,
 	platform string,
 	groupID *int64,
+	rateRuleMinSamples int,
 ) (float64, bool) {
 	if rule == nil {
 		return 0, false
+	}
+	// Sample floor for ratio metrics: a window with fewer than this many
+	// SLA-counted requests is too sparse to yield a trustworthy rate, so the
+	// rule is skipped (ok=false) instead of firing on a misleading 100% (false
+	// P0 on low-traffic edges, 2026-06-06 us2/us5). Always at least 1 so the
+	// >0 denominator guard still holds when the floor is unset.
+	rateSampleFloor := int64(rateRuleMinSamples)
+	if rateSampleFloor < 1 {
+		rateSampleFloor = 1
 	}
 	switch strings.TrimSpace(rule.MetricType) {
 	case "cpu_usage_percent":
@@ -614,17 +624,17 @@ func (s *OpsAlertEvaluatorService) computeRuleMetric(
 
 	switch strings.TrimSpace(rule.MetricType) {
 	case "success_rate":
-		if overview.RequestCountSLA <= 0 {
+		if overview.RequestCountSLA < rateSampleFloor {
 			return 0, false
 		}
 		return overview.SLA * 100, true
 	case "error_rate":
-		if overview.RequestCountSLA <= 0 {
+		if overview.RequestCountSLA < rateSampleFloor {
 			return 0, false
 		}
 		return overview.ErrorRate * 100, true
 	case "upstream_error_rate":
-		if overview.RequestCountSLA <= 0 {
+		if overview.RequestCountSLA < rateSampleFloor {
 			return 0, false
 		}
 		return overview.UpstreamErrorRate * 100, true

--- a/backend/internal/service/ops_alert_evaluator_service_test.go
+++ b/backend/internal/service/ops_alert_evaluator_service_test.go
@@ -201,7 +201,57 @@ func TestComputeRuleMetricNewIndicators(t *testing.T) {
 			rule := &OpsAlertRule{
 				MetricType: tt.metricType,
 			}
-			gotValue, gotOK := svc.computeRuleMetric(ctx, rule, nil, start, end, platform, tt.groupID)
+			gotValue, gotOK := svc.computeRuleMetric(ctx, rule, nil, start, end, platform, tt.groupID, 0)
+			require.Equal(t, tt.wantOK, gotOK)
+			if !tt.wantOK {
+				return
+			}
+			require.InDelta(t, tt.wantValue, gotValue, 0.0001)
+		})
+	}
+}
+
+// TestComputeRuleMetricRateSampleFloor pins the false-P0 guard: a ratio metric
+// (upstream_error_rate) over a window holding fewer SLA-counted requests than
+// the configured floor must return ok=false so the rule is skipped, instead of
+// reporting a misleading 100% on near-empty low-traffic windows (2026-06-06
+// us2/us5 incident: 19 / 1 requests in ~25min yet upstream_error_rate=100%).
+func TestComputeRuleMetricRateSampleFloor(t *testing.T) {
+	t.Parallel()
+
+	start := time.Now().UTC().Add(-5 * time.Minute)
+	end := time.Now().UTC()
+	ctx := context.Background()
+
+	tests := []struct {
+		name       string
+		requestSLA int64
+		minSamples int
+		wantOK     bool
+		wantValue  float64
+	}{
+		{name: "below floor is skipped (us2: 19 reqs, floor 20)", requestSLA: 19, minSamples: 20, wantOK: false},
+		{name: "single request is skipped (us5: 1 req, floor 20)", requestSLA: 1, minSamples: 20, wantOK: false},
+		{name: "at floor is evaluated", requestSLA: 20, minSamples: 20, wantOK: true, wantValue: 100},
+		{name: "above floor is evaluated", requestSLA: 200, minSamples: 20, wantOK: true, wantValue: 100},
+		{name: "floor unset (0) falls back to legacy >0 guard, evaluates 1 req", requestSLA: 1, minSamples: 0, wantOK: true, wantValue: 100},
+		{name: "floor unset (0) still skips empty window", requestSLA: 0, minSamples: 0, wantOK: false},
+	}
+
+	for _, tt := range tests {
+		tt := tt
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+
+			svc := &OpsAlertEvaluatorService{
+				opsRepo: &stubOpsRepo{overview: &OpsDashboardOverview{
+					RequestCountSLA:   tt.requestSLA,
+					UpstreamErrorRate: 1.0, // 100% of the (few) requests failed upstream
+				}},
+			}
+			rule := &OpsAlertRule{MetricType: "upstream_error_rate"}
+
+			gotValue, gotOK := svc.computeRuleMetric(ctx, rule, nil, start, end, "", nil, tt.minSamples)
 			require.Equal(t, tt.wantOK, gotOK)
 			if !tt.wantOK {
 				return

--- a/backend/internal/service/ops_settings.go
+++ b/backend/internal/service/ops_settings.go
@@ -13,6 +13,11 @@ import (
 const (
 	opsAlertEvaluatorLeaderLockKeyDefault = "ops:alert:evaluator:leader"
 	opsAlertEvaluatorLeaderLockTTLDefault = 30 * time.Second
+	// opsAlertRateRuleMinSamplesDefault is the default minimum SLA-counted
+	// request count in a rule window below which ratio metrics (success_rate /
+	// error_rate / upstream_error_rate) are not evaluated. See
+	// OpsAlertRuntimeSettings.RateRuleMinSamples.
+	opsAlertRateRuleMinSamplesDefault     = 20
 	opsFeishuAlertRateLimitPerHourDefault = 3
 	opsFeishuAlertCooldownSecondsDefault  = 3600
 	// 账号失效事件「临时冷却」聚合摘要的默认 flush 间隔（秒）。
@@ -298,6 +303,7 @@ func (c *OpsEmailNotificationConfig) ForResponse() *OpsEmailNotificationConfig {
 func defaultOpsAlertRuntimeSettings() *OpsAlertRuntimeSettings {
 	return &OpsAlertRuntimeSettings{
 		EvaluationIntervalSeconds: 60,
+		RateRuleMinSamples:        opsAlertRateRuleMinSamplesDefault,
 		DistributedLock: OpsDistributedLockSettings{
 			Enabled:    true,
 			Key:        opsAlertEvaluatorLeaderLockKeyDefault,
@@ -403,6 +409,11 @@ func (s *OpsService) GetOpsAlertRuntimeSettings(ctx context.Context) (*OpsAlertR
 	if cfg.EvaluationIntervalSeconds <= 0 {
 		cfg.EvaluationIntervalSeconds = defaultCfg.EvaluationIntervalSeconds
 	}
+	// 0 / missing on a legacy settings row → fill the default floor so the
+	// false-P0 guard applies without requiring operators to re-save settings.
+	if cfg.RateRuleMinSamples <= 0 {
+		cfg.RateRuleMinSamples = defaultCfg.RateRuleMinSamples
+	}
 	normalizeOpsDistributedLockSettings(&cfg.DistributedLock, opsAlertEvaluatorLeaderLockKeyDefault, defaultCfg.DistributedLock.TTLSeconds)
 	normalizeOpsAlertSilencingSettings(&cfg.Silencing)
 
@@ -423,6 +434,9 @@ func (s *OpsService) UpdateOpsAlertRuntimeSettings(ctx context.Context, cfg *Ops
 	if cfg.EvaluationIntervalSeconds < 1 || cfg.EvaluationIntervalSeconds > int((24*time.Hour).Seconds()) {
 		return nil, errors.New("evaluation_interval_seconds must be between 1 and 86400")
 	}
+	if cfg.RateRuleMinSamples < 0 || cfg.RateRuleMinSamples > 1_000_000 {
+		return nil, errors.New("rate_rule_min_samples must be between 0 and 1000000")
+	}
 	if cfg.DistributedLock.Enabled {
 		if err := validateOpsDistributedLockSettings(cfg.DistributedLock); err != nil {
 			return nil, err
@@ -435,6 +449,9 @@ func (s *OpsService) UpdateOpsAlertRuntimeSettings(ctx context.Context, cfg *Ops
 	}
 
 	defaultCfg := defaultOpsAlertRuntimeSettings()
+	if cfg.RateRuleMinSamples <= 0 {
+		cfg.RateRuleMinSamples = defaultCfg.RateRuleMinSamples
+	}
 	normalizeOpsDistributedLockSettings(&cfg.DistributedLock, opsAlertEvaluatorLeaderLockKeyDefault, defaultCfg.DistributedLock.TTLSeconds)
 	normalizeOpsAlertSilencingSettings(&cfg.Silencing)
 

--- a/backend/internal/service/ops_settings_models.go
+++ b/backend/internal/service/ops_settings_models.go
@@ -100,6 +100,17 @@ type OpsRuntimeLogConfig struct {
 type OpsAlertRuntimeSettings struct {
 	EvaluationIntervalSeconds int `json:"evaluation_interval_seconds"`
 
+	// RateRuleMinSamples is the minimum number of SLA-counted requests that must
+	// exist in a rule window before a ratio metric (success_rate / error_rate /
+	// upstream_error_rate) is evaluated. Below this floor the metric returns
+	// ok=false and the rule is skipped, so a near-empty low-traffic window cannot
+	// produce a misleading 100% rate and page a false P0 (2026-06-06 us2/us5: a
+	// ~25min window held only 19 / 1 requests, yet a couple of transient upstream
+	// blips pushed upstream_error_rate to 100%). 0 (or missing on legacy
+	// settings rows) is filled to the default; set 1 to restore the legacy
+	// behavior where only the >0 denominator guard applies.
+	RateRuleMinSamples int `json:"rate_rule_min_samples"`
+
 	DistributedLock OpsDistributedLockSettings `json:"distributed_lock"`
 	Silencing       OpsAlertSilencingSettings  `json:"silencing"`
 	Thresholds      OpsMetricThresholds        `json:"thresholds"` // 指标阈值配置

--- a/backend/internal/service/ratelimit_service_anthropic_consolidation_test.go
+++ b/backend/internal/service/ratelimit_service_anthropic_consolidation_test.go
@@ -483,6 +483,7 @@ func TestOpsAlertEvaluator_AnthropicCooldownTierEscalationCount_ReflectsLadderWr
 		time.Now().UTC(),
 		"",
 		nil,
+		0,
 	)
 	require.True(t, ok, "metric must be reportable when the cache is wired")
 	require.InDelta(t, 2.0, value, 0.0001,

--- a/scripts/sentinels/gateway-tk.json
+++ b/scripts/sentinels/gateway-tk.json
@@ -84,9 +84,10 @@
         "\"anthropic_cooldown_tier_escalation_count\"",
         "SetAnthropicUpstreamErrorCounterCache",
         "GetAnthropicCooldownTierEscalations",
-        "AnthropicCooldownTierEscalationsKey"
+        "AnthropicCooldownTierEscalationsKey",
+        "rateSampleFloor"
       ],
-      "rationale": "Ops alert evaluator must call the TK companion notification fanout and report Feishu sends in the heartbeat. If an upstream merge restores the old email-only call, P0 Feishu delivery silently stops while alert event creation still works. The anthropic_cooldown_tier_escalation_count metric case is the PR #337 follow-up that turns persistent ladder escalation into Feishu/email alerts; dropping the case (or the cache injection seam / shared canonical key) silently disables the alert while the writer side keeps incrementing the counter."
+      "rationale": "Ops alert evaluator must call the TK companion notification fanout and report Feishu sends in the heartbeat. If an upstream merge restores the old email-only call, P0 Feishu delivery silently stops while alert event creation still works. The anthropic_cooldown_tier_escalation_count metric case is the PR #337 follow-up that turns persistent ladder escalation into Feishu/email alerts; dropping the case (or the cache injection seam / shared canonical key) silently disables the alert while the writer side keeps incrementing the counter. `rateSampleFloor` is the min-sample guard for ratio metrics (success_rate / error_rate / upstream_error_rate): below RateRuleMinSamples SLA-counted requests the metric returns ok=false so a near-empty low-traffic window can't page a false 100% P0 (2026-06-06 us2/us5). If an upstream merge restores the bare `RequestCountSLA <= 0` guard, low-traffic edges silently regress to firing P0 on a 1-request window."
     },
     {
       "path": "backend/internal/service/ops_alert_notifications_tk_feishu.go",
@@ -116,9 +117,10 @@
       "must_contain": [
         "OpsFeishuAlertConfig",
         "WebhookURLConfigured",
-        "SigningSecretConfigured"
+        "SigningSecretConfigured",
+        "RateRuleMinSamples"
       ],
-      "rationale": "Ops email notification config JSON must preserve the Feishu write-only webhook/secret state without a DB migration. If this model shape is overwritten, frontend saves can drop Feishu config or leak secret fields."
+      "rationale": "Ops email notification config JSON must preserve the Feishu write-only webhook/secret state without a DB migration. If this model shape is overwritten, frontend saves can drop Feishu config or leak secret fields. RateRuleMinSamples is the runtime-tunable min-sample floor for ratio-metric P0 rules (default 20, 0/missing filled on read so legacy settings rows get the guard without a migration); if an upstream merge drops the field the false-P0 low-traffic guard silently disappears."
     },
     {
       "path": "backend/internal/service/openai_messages_compaction_tk.go",


### PR DESCRIPTION
## 背景 / 根因

2026-06-06 us2、us5 各收到一条 P0 `upstream_error_rate=100% overall`。排障结论（只读取证，未动线上）：**假 P0**，分两层：

1. **指标污染** = 升级前的 context-canceled 尾流。两 edge 当日 ~09:02/09:06Z 升级到 1.7.79（含 #628），污染 `upstream_error_rate` 的 `phase=upstream` 记录全部产生于重启**之前**；重启后同样的 `context canceled` 已被 #628 正确归到 `phase=request/owner=client` 并掉出指标。
2. **晚触发（数小时后）= 低分母伪影**。告警实际在 16:06Z（us2，晚 7h）、22:57Z（us5，晚 13h）才响。核查告警时间窗：us2 25 分钟内仅 **19** 个 `/v1/messages`、us5 仅 **1** 个。`upstream_error_rate>20%` P0 规则**没有最小样本下限**，夜间稀疏流量下，1~数次真上游瞬时抖动（EOF/temp-502/overloaded）打在接近零的分母上即算出 100%。**非容量问题**。

这是相对 #628 的**新增缺口**：#628 修了分类，但比率规则在低分母窗口仍会误触发。

## 改动

给三个比率指标（`success_rate` / `error_rate` / `upstream_error_rate`）的零分母守卫加**最小样本下限**：

- 新增 `OpsAlertRuntimeSettings.RateRuleMinSamples`（默认 **20**，与 `EvaluationIntervalSeconds` 同款全局运行时设置，admin 可调）。
- 窗口内 SLA 计数请求数 `< floor` → 指标返回 `ok=false`，规则跳过，不再在稀疏窗口误报。
- **0/缺失**（老 settings 行）在读取时自动回填默认 → 现网 prod/edge **零迁移、零重存**即生效；设为 **1** 可回退旧 `>0` 行为。
- 计数/仪表类指标（`group_available_*` / `account_*` / `*_count` / cpu/memory）**不受影响**。

## 验证

- 新单测 `TestComputeRuleMetricRateSampleFloor` 钉住：us2(19)/us5(1) 低于下限 → 跳过；=20 / >20 → 触发；floor=0 回退为 `>0` 旧行为且仍跳过空窗。
- `go build ./...`、`go test -tags=unit ./...` 全绿。
- `scripts/preflight.sh`（含全部 sub2api sentinel 检查）PASS。
- sentinel 注册表 `gateway-tk.json` 同步补 `rateSampleFloor` + `RateRuleMinSamples` 锚点，防上游 merge 静默还原裸 `>0` 守卫。

## Notes

- 纯后端（`no-web-impact`）。设置已可经现有 admin runtime-settings API PUT；UI 暴露该旋钮可作快速跟进。
- 触及上游所有的 `internal/service/ops_*`（`upstream-touch-guarded`，已补 sentinel 锚点）。

🤖 Generated with [Claude Code](https://claude.com/claude-code)