### PR TITLE
chore(cc-fingerprint): align UA to cc 2.1.168 (pure version bump)

### DIFF
--- a/backend/internal/baseline/anthropic-http-mimicry-baselines.json
+++ b/backend/internal/baseline/anthropic-http-mimicry-baselines.json
@@ -1,6 +1,6 @@
 {
   "schema_version": 1,
-  "cc_version": "2.1.167",
+  "cc_version": "2.1.168",
   "description": "Canonical OAuth HTTP mimicry betas for Claude Code CLI. Live wire values are driven at runtime by settings.claude_code_http_mimicry_manifest (sync-runtime / plan-http-mimicry-sync). Compile-time defaults in backend/internal/pkg/claude/constants.go catch up on the release train.",
   "sonnet_opus": [
     "claude-code-20250219",

--- a/backend/internal/pkg/claude/constants.go
+++ b/backend/internal/pkg/claude/constants.go
@@ -81,7 +81,7 @@ const DefaultCacheControlTTL = "5m"
 // CLICurrentVersion 是 sub2api 当前对外伪装的 Claude Code CLI 版本号（三段 semver）。
 // 用于 billing attribution block 中的 cc_version=X.Y.Z.{fp} 前缀以及 fingerprint 计算。
 // 必须与 DefaultHeaders["User-Agent"] 中的版本号严格一致；不一致会被 Anthropic 判第三方。
-const CLICurrentVersion = "2.1.167"
+const CLICurrentVersion = "2.1.168"
 
 // JoinBetaHeader joins beta tokens into the wire anthropic-beta header value.
 func JoinBetaHeader(betas []string) string {
@@ -137,7 +137,7 @@ func FullClaudeCodeHaikuMimicryBetas() []string {
 // 包依赖方向为 service → claude，claude 无法反向 import service，故这里以同步字面量
 // 承载，由守卫测试强制对齐。
 var DefaultHeaders = map[string]string{
-	"User-Agent":                                "claude-cli/2.1.167 (external, sdk-cli)",
+	"User-Agent":                                "claude-cli/2.1.168 (external, sdk-cli)",
 	"X-Stainless-Lang":                          "js",
 	"X-Stainless-Package-Version":               "0.94.0",
 	"X-Stainless-OS":                            "MacOS",

--- a/backend/internal/service/identity_service.go
+++ b/backend/internal/service/identity_service.go
@@ -38,7 +38,7 @@ var (
 // / `StainlessPackageVersion:` 字面量做指纹基线巡检，computed 值会让它失明。
 // 字面量与 canonical 的一致性改由 identity_canonical_consistency_test.go 机械锁死。
 var defaultFingerprint = Fingerprint{
-	UserAgent:               "claude-cli/2.1.167 (external, sdk-cli)",
+	UserAgent:               "claude-cli/2.1.168 (external, sdk-cli)",
 	StainlessLang:           "js",
 	StainlessPackageVersion: "0.94.0",
 	StainlessOS:             "MacOS",

--- a/backend/internal/service/identity_service_tk_canonical_http.go
+++ b/backend/internal/service/identity_service_tk_canonical_http.go
@@ -56,7 +56,7 @@ const (
 	// neither env nor runtime resolver provides a value. Keep in sync with
 	// the most recent cc CLI release this build was validated against; the
 	// admin UI / runtime resolver is the normal update path going forward.
-	DefaultClaudeCodeUserAgentVersion = "2.1.167"
+	DefaultClaudeCodeUserAgentVersion = "2.1.168"
 
 	// canonicalUAPrefix / canonicalUASuffix wrap the version-only field.
 	// Matches the wire shape Anthropic observes from a real Claude Code CLI

--- a/deploy/aws/stage0/anthropic-http-mimicry-baselines.json
+++ b/deploy/aws/stage0/anthropic-http-mimicry-baselines.json
@@ -1,6 +1,6 @@
 {
   "schema_version": 1,
-  "cc_version": "2.1.167",
+  "cc_version": "2.1.168",
   "description": "Canonical OAuth HTTP mimicry betas for Claude Code CLI. Live wire values are driven at runtime by settings.claude_code_http_mimicry_manifest (sync-runtime / plan-http-mimicry-sync). Compile-time defaults in backend/internal/pkg/claude/constants.go catch up on the release train.",
   "sonnet_opus": [
     "claude-code-20250219",

--- a/deploy/aws/stage0/tk_canonical_cc_oauth.json
+++ b/deploy/aws/stage0/tk_canonical_cc_oauth.json
@@ -71,7 +71,7 @@
   ],
   "observed": {
     "model": "claude-haiku-4-5-20251001",
-    "user_agent": "claude-cli/2.1.167 (external, sdk-cli)",
+    "user_agent": "claude-cli/2.1.168 (external, sdk-cli)",
     "stainless_os": "MacOS",
     "stainless_arch": "arm64",
     "stainless_runtime": "node",

--- a/docs/cc-fingerprint-changelog.md
+++ b/docs/cc-fingerprint-changelog.md
@@ -37,3 +37,4 @@ re-document it per patch — note "A/B unchanged" in the row instead.
 | 2.1.165 | 2026-06-05 | pure UA | 2.1.163 → 2.1.165. TLS/beta unchanged. |
 | 2.1.166 | 2026-06-06 | pure UA | 2.1.165 → 2.1.166. TLS/beta unchanged. |
 | 2.1.167 | 2026-06-06 | pure UA | 2.1.166 → 2.1.167. TLS/beta unchanged; Haiku A/B 8/11 vs 3/11 (per #429). Capture egress 16.147.170.3. |
+| 2.1.168 | 2026-06-07 | pure UA | 2.1.167 → 2.1.168. TLS ja3 unchanged; sonnet beta unchanged; Haiku A/B bimodal 2/3 vs 1/3, baseline matches a variant (per #429). Capture egress 52.15.35.197. |

--- a/ops/stage0/smoke_lib.sh
+++ b/ops/stage0/smoke_lib.sh
@@ -49,7 +49,7 @@ if [[ -z "${_TK_SMOKE_LIB_LOADED:-}" ]]; then
   }
 
   smoke_default_claude_user_agent() {
-    printf '%s' "${TK_SMOKE_CLAUDE_USER_AGENT:-claude-cli/2.1.167 (external, sdk-cli)}"
+    printf '%s' "${TK_SMOKE_CLAUDE_USER_AGENT:-claude-cli/2.1.168 (external, sdk-cli)}"
   }
 
   # soft_degrade_or_exit — see post_deploy_smoke.sh header for contract.


### PR DESCRIPTION
## Summary

Pure UA / version bump **2.1.167 → 2.1.168** (skill `/tokenkey-cc-fingerprint-alignment` §4.1). Captured real cc 2.1.168 via cc0 mitm — TLS and beta unchanged, only the version string drifted.

## Capture / diff (ground truth, cc 2.1.168)

| field | result |
|---|---|
| `tls.ja3_hash` / `ja3_raw` | ✅ **OK — ClientHello unchanged** (no TLS profile change needed) |
| `canonical.user_agent_version` / `mimic.cli_version` | ❌ 2.1.167 → **2.1.168** |
| `canonical`/`mimic.stainless_package_version` | ✅ OK |
| `betas.sonnet_mimicry` | ✅ OK |
| `betas.haiku_mimicry` | 🔍 **INVESTIGATE** — bimodal A/B (2/3 vs 1/3), baseline matches a variant → known [#429](https://github.com/youxuanxue/sub2api/issues/429) gray release, **not actionable** |

Capture bundle: `.tls_list/20260606T234415Z-cc-capture.bundle.json`. Egress 52.15.35.197.

## Change (single source → 7 copies)

Edited only `deploy/aws/stage0/anthropic-http-mimicry-baselines.json` `cc_version`, then `scripts/sentinels/check-cc-version-sync.py --write` propagated to all 7 copies (constants.go `CLICurrentVersion` + UA headers, identity_service*.go, tk_canonical_cc_oauth.json `observed.user_agent`, smoke_lib.sh, embedded baseline). All diffs are pure version-string `2.1.167 → 2.1.168`. One changelog row added; **no spec-delta** (no behavior change), **no beta change**, **no TLS change**.

## Test

- `check-cc-version-sync.py --selftest` + `--check` → cc_version=2.1.168 consistent across 7 copies
- `go test -tags=unit ./internal/pkg/claude/... -run TestFullClaudeCode` → ok
- `test_capture_cc_fingerprint.py` → 13 tests ok
- `scripts/preflight.sh` → PASS

## After merge

Run `bash ops/anthropic/cc_fingerprint_apply_http_runtime.sh` (or `manage-anthropic-config.py sync-runtime --target all-deployable-and-prod`) to push live UA → 2.1.168 (no release needed; compile default catches up on next release). Fleet binaries are ≥1.7.78 so the mimicry self-heal ratchet is present — sync-runtime will stick.

🤖 Generated with [Claude Code](https://claude.com/claude-code)