### PR TITLE
fix(ops): exclude relayed edge "no available accounts" from upstream_error_rate (Fix A)

### DIFF
--- a/backend/internal/handler/ops_error_logger.go
+++ b/backend/internal/handler/ops_error_logger.go
@@ -1300,9 +1300,19 @@ func classifyOpsSeverity(errType string, status int) string {
 
 func classifyOpsErrorLog(c *gin.Context, errType, message, code string, status int) (phase string, isBusinessLimited bool, errorOwner string, errorSource string) {
 	phase = classifyOpsPhase(errType, message, code)
-	routingCapacityLimited := isOpsRoutingCapacityLimited(c)
-	clientBusinessLimited := service.HasOpsClientBusinessLimited(c)
 	upstreamError := hasOpsUpstreamErrorContext(c)
+	// TK (mirror-edge metric pollution, 2026-06-06 yace load test): a relayed
+	// downstream-capacity verdict — an upstream (a TokenKey edge reached via a
+	// cc-<edge> apikey mirror account) answered 429/5xx with a "no available
+	// accounts" / "all available accounts exhausted" body — is OUR fleet capacity,
+	// not provider health. Fold it into routingCapacityLimited so it is owned as
+	// routing (out of upstream_error_rate) exactly like a LOCAL empty pool, mirroring
+	// the cooldown-ladder skip in ratelimit_service_tk_downstream_no_available.go.
+	// Boundary (anthropic_amplifier_exemption_boundary): only TokenKey phrases match;
+	// a real provider 429 (rate_limit_error) / raw 5xx still counts. See
+	// tkUpstreamDownstreamCapacity.
+	routingCapacityLimited := isOpsRoutingCapacityLimited(c) || (upstreamError && tkUpstreamDownstreamCapacity(c))
+	clientBusinessLimited := service.HasOpsClientBusinessLimited(c)
 	// TK: an upstream client-induced request rejection (invalid_request_error /
 	// request_too_large / 413 / unsupported-model-for-account) is caller-fault, not
 	// provider health. Own it to the client (request phase) instead of relabeling

--- a/backend/internal/handler/ops_error_logger_test.go
+++ b/backend/internal/handler/ops_error_logger_test.go
@@ -969,13 +969,31 @@ func TestClassifyOpsUpstreamAuthTextStillCountsForSLA(t *testing.T) {
 	}
 }
 
-func TestClassifyOpsUpstreamNoAvailableTextStillCountsForSLA(t *testing.T) {
+// POLICY CHANGE (2026-06-06, mirror-edge metric pollution): an upstream verdict
+// carrying a TokenKey "No available accounts" envelope is now owned as routing (out
+// of upstream_error_rate), NOT counted as provider health. This intentionally
+// reverses the original assertion from the 2026-05-18 "SLA 排除逻辑" commit
+// (ae6ee23e), which predates the mirror-edge topology understanding.
+//
+// Why the reversal: prod relays to Edge stacks via cc-<edge> apikey mirror accounts;
+// an empty edge pool returns 429/503 "No available accounts" (tkNoAvailableAccounts,
+// PR #575). The old asymmetry — local empty pool excluded (routingCapacityLimited)
+// but a RELAYED "no available" counted — treated OUR own fleet capacity as Anthropic
+// health. During the yace load test that made upstream_error_rate read ~1300 on a
+// dead single-account edge AND a healthy 3-account edge alike (16x client-cancel +
+// failover smear), so the metric could not tell a dead edge from a healthy one. Edge
+// health now has a dedicated truthful signal (ops/observability/scan-edge-health.sh,
+// #640); upstream_error_rate is reserved for genuine provider health. A real provider
+// 429 (rate_limit_error) / raw 5xx carries no TokenKey phrase and still counts — see
+// TestClassifyOpsGenuineUpstreamStaysProviderDespiteCapacityHelper.
+// tkUpstreamDownstreamCapacity is the predicate; it folds into routingCapacityLimited.
+func TestClassifyOpsUpstreamNoAvailableTextExcludedFromSLA(t *testing.T) {
 	gin.SetMode(gin.TestMode)
 	rec := httptest.NewRecorder()
 	c, _ := gin.CreateTestContext(rec)
 	service.SetOpsUpstreamError(c, http.StatusServiceUnavailable, "No available accounts", "")
 
-	phase, isBusinessLimited, errorOwner, errorSource := classifyOpsErrorLog(
+	phase, isBusinessLimited, errorOwner, _ := classifyOpsErrorLog(
 		c,
 		"api_error",
 		"No available accounts",
@@ -983,10 +1001,9 @@ func TestClassifyOpsUpstreamNoAvailableTextStillCountsForSLA(t *testing.T) {
 		http.StatusServiceUnavailable,
 	)
 
-	require.Equal(t, "upstream", phase)
-	require.False(t, isBusinessLimited)
-	require.Equal(t, "provider", errorOwner)
-	require.Equal(t, "upstream_http", errorSource)
+	require.Equal(t, "routing", phase, "relayed downstream-capacity verdict is routing, not provider health")
+	require.True(t, isBusinessLimited, "TK fleet capacity is a business/capacity limit, like a local empty pool")
+	require.Equal(t, "platform", errorOwner, "must NOT be provider — otherwise it feeds upstream_error_rate")
 }
 
 func TestParseOpsErrorResponsePreservesNestedStringCode(t *testing.T) {

--- a/backend/internal/handler/ops_error_logger_tk_downstream_capacity.go
+++ b/backend/internal/handler/ops_error_logger_tk_downstream_capacity.go
@@ -1,0 +1,61 @@
+package handler
+
+import (
+	"strings"
+
+	"github.com/gin-gonic/gin"
+)
+
+// opsDownstreamFailoverExhaustedPhrase is the TokenKey-generated envelope emitted
+// when a downstream failover loop runs dry. It mirrors the service-layer constant
+// in ratelimit_service_tk_downstream_no_available.go (kept as a local copy so the
+// handler layer does not import a service internal); matched case-insensitively.
+const opsDownstreamFailoverExhaustedPhrase = "all available accounts exhausted"
+
+// tkUpstreamDownstreamCapacity reports whether the captured upstream verdict is a
+// TokenKey *downstream-capacity* signal rather than provider health: an upstream
+// (typically a TokenKey edge reached via a cc-<edge> apikey mirror account) answered
+// 429/503/5xx with a body whose text is one of TokenKey's own pool-empty envelopes
+// ("no available accounts" / "all available accounts exhausted").
+//
+// WHY (mirror-edge metric pollution, 2026-06-06 yace load test): prod relays to the
+// edge via apikey mirror accounts (credentials.base_url=api-<edge>.tokenkey.dev);
+// when the edge pool is empty it returns 429 with a "No available accounts" body
+// (helper tkNoAvailableAccounts, PR #575). That 429 is OUR fleet capacity, not
+// Anthropic rate-limiting — but because it carries a definitive upstream status,
+// tkUpstreamClientCanceled deliberately skips it and classifyOpsErrorLog counted it
+// as phase=upstream, so a dead single-account edge (us3: served_200=0,
+// no_available_429=33748) and a healthy edge (us5: 2251x200, 77x429) both read
+// ~1300 upstream-429 on prod. Folding this into routingCapacityLimited owns it as
+// routing (out of upstream_error_rate) exactly like a LOCAL empty pool, and mirrors
+// the cooldown-ladder skip already done in
+// ratelimit_service_tk_downstream_no_available.go (slog
+// anthropic_downstream_no_available_accounts_skip_penalty /
+// anthropic_downstream_failover_exhausted_skip_penalty).
+//
+// Boundary (anthropic_amplifier_exemption_boundary): ONLY the TokenKey-generated
+// phrases match. A real Anthropic 429 (rate_limit_error) or a raw edge-infra 5xx
+// carries no such phrase and stays provider-owned, so genuine upstream health still
+// counts toward upstream_error_rate.
+func tkUpstreamDownstreamCapacity(c *gin.Context) bool {
+	if c == nil {
+		return false
+	}
+	// Only a relayed verdict carries a definitive upstream status. 429 is the
+	// pool-empty fast-fail (PR #575); 5xx covers the legacy 503 and
+	// failover-exhausted envelopes. A status of 0 (pure transport error) is owned by
+	// tkUpstreamClientCanceled, not here.
+	status := tkOpsUpstreamStatusCode(c)
+	if status != 429 && status < 500 {
+		return false
+	}
+	body, msg := tkOpsUpstreamErrorText(c)
+	combined := strings.ToLower(strings.TrimSpace(msg + "\n" + body))
+	if combined == "" {
+		return false
+	}
+	// isOpsNoAvailableAccountMessage already lowercases; the second check is the
+	// failover-exhausted envelope. Both are TokenKey-generated, never provider text.
+	return isOpsNoAvailableAccountMessage(combined) ||
+		strings.Contains(combined, opsDownstreamFailoverExhaustedPhrase)
+}

--- a/backend/internal/handler/ops_error_logger_tk_downstream_capacity_test.go
+++ b/backend/internal/handler/ops_error_logger_tk_downstream_capacity_test.go
@@ -1,0 +1,157 @@
+package handler
+
+import (
+	"net/http"
+	"net/http/httptest"
+	"testing"
+
+	"github.com/gin-gonic/gin"
+	"github.com/stretchr/testify/require"
+
+	"github.com/Wei-Shaw/sub2api/internal/service"
+)
+
+// Mirror-edge metric pollution (2026-06-06 yace load test): prod relays to the edge
+// via cc-<edge> apikey mirror accounts; when the edge pool is empty it returns 429
+// with a "No available accounts" body (tkNoAvailableAccounts, PR #575). That 429 is
+// TokenKey fleet capacity, not Anthropic health, but because it carries a definitive
+// upstream status the classifier counted it phase=upstream / error_owner=provider —
+// so a dead single-account edge (us3: served_200=0, no_available_429=33748) and a
+// healthy edge (us5: 2251x200, 77x429) BOTH read ~1300 upstream-429 on prod, making
+// upstream_error_rate useless for telling a dead edge from a healthy one.
+//
+// These tests pin the corrected classification: a relayed downstream-capacity
+// verdict ("no available accounts" / "all available accounts exhausted") is owned as
+// routing (phase=routing, error_owner=platform, businessLimited) so it drops out of
+// upstream_error_rate, while a genuine provider 429 (rate_limit_error) and raw 5xx
+// keep counting. Setups mirror the relay forward site, which records an
+// appendOpsUpstreamError event carrying UpstreamStatusCode + UpstreamResponseBody.
+func TestClassifyOpsDownstreamCapacityOwnedAsRouting(t *testing.T) {
+	gin.SetMode(gin.TestMode)
+
+	cases := []struct {
+		name   string
+		event  *service.OpsUpstreamErrorEvent
+		errMsg string
+	}{
+		{
+			name: "edge no-available 429 body",
+			event: &service.OpsUpstreamErrorEvent{
+				UpstreamStatusCode:   429,
+				Kind:                 "http_error",
+				UpstreamResponseBody: `{"error":{"message":"No available accounts: no available accounts","type":"api_error"},"type":"error"}`,
+			},
+			errMsg: "No available accounts: no available accounts",
+		},
+		{
+			name: "edge no-available 429 then client cancel (the polluting shape)",
+			event: &service.OpsUpstreamErrorEvent{
+				UpstreamStatusCode:   429,
+				Kind:                 "request_error",
+				Message:              `Post "https://api-us3.tokenkey.dev/v1/messages": context canceled`,
+				UpstreamResponseBody: `{"error":{"message":"No available accounts: no available accounts","type":"api_error"}}`,
+			},
+			errMsg: "Upstream request failed",
+		},
+		{
+			name: "downstream failover exhausted 503",
+			event: &service.OpsUpstreamErrorEvent{
+				UpstreamStatusCode:   503,
+				Kind:                 "http_error",
+				UpstreamResponseBody: `{"error":{"message":"All available accounts exhausted","type":"api_error"}}`,
+			},
+			errMsg: "All available accounts exhausted",
+		},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			rec := httptest.NewRecorder()
+			c, _ := gin.CreateTestContext(rec)
+			c.Set(service.OpsUpstreamErrorsKey, []*service.OpsUpstreamErrorEvent{tc.event})
+
+			phase, isBusinessLimited, errorOwner, _ := classifyOpsErrorLog(
+				c, "api_error", tc.errMsg, "", http.StatusTooManyRequests)
+
+			require.Equal(t, "routing", phase, "downstream-capacity verdict must be routing, not upstream")
+			require.Equal(t, "platform", errorOwner, "must NOT be provider — otherwise it feeds upstream_error_rate")
+			require.True(t, isBusinessLimited, "downstream capacity is a TK business/capacity limit, like a local empty pool")
+		})
+	}
+}
+
+// Boundary: a genuine provider verdict carries no TokenKey envelope phrase and MUST
+// keep counting toward upstream_error_rate (error_owner=provider). This is the
+// anthropic_amplifier_exemption_boundary — over-broadening here would blind the
+// provider-health P0.
+func TestClassifyOpsGenuineUpstreamStaysProviderDespiteCapacityHelper(t *testing.T) {
+	gin.SetMode(gin.TestMode)
+
+	cases := []struct {
+		name   string
+		event  *service.OpsUpstreamErrorEvent
+		errMsg string
+		status int
+	}{
+		{
+			name: "real Anthropic 429 rate_limit_error",
+			event: &service.OpsUpstreamErrorEvent{
+				UpstreamStatusCode:   429,
+				Kind:                 "http_error",
+				UpstreamResponseBody: `{"type":"error","error":{"type":"rate_limit_error","message":"This request would exceed your account's rate limit."}}`,
+			},
+			errMsg: "Upstream rate limit exceeded, please retry later",
+			status: http.StatusTooManyRequests,
+		},
+		{
+			name: "raw upstream 500 with no TokenKey phrase",
+			event: &service.OpsUpstreamErrorEvent{
+				UpstreamStatusCode:   500,
+				Kind:                 "http_error",
+				UpstreamResponseBody: `{"error":{"message":"internal server error","type":"server_error"}}`,
+			},
+			errMsg: "Upstream request failed",
+			status: http.StatusBadGateway,
+		},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			rec := httptest.NewRecorder()
+			c, _ := gin.CreateTestContext(rec)
+			c.Set(service.OpsUpstreamErrorsKey, []*service.OpsUpstreamErrorEvent{tc.event})
+
+			phase, _, errorOwner, _ := classifyOpsErrorLog(c, "upstream_error", tc.errMsg, "", tc.status)
+
+			require.Equal(t, "upstream", phase, "genuine provider error must stay upstream")
+			require.Equal(t, "provider", errorOwner, "must keep counting toward upstream_error_rate")
+		})
+	}
+}
+
+// Unit-level guard on the predicate itself: the status gate (0 => owned by
+// client-cancel, not here) and the phrase boundary.
+func TestTkUpstreamDownstreamCapacityPredicate(t *testing.T) {
+	gin.SetMode(gin.TestMode)
+
+	mk := func(status int, body, msg string) *gin.Context {
+		rec := httptest.NewRecorder()
+		c, _ := gin.CreateTestContext(rec)
+		c.Set(service.OpsUpstreamErrorsKey, []*service.OpsUpstreamErrorEvent{{
+			UpstreamStatusCode:   status,
+			UpstreamResponseBody: body,
+			Message:              msg,
+		}})
+		return c
+	}
+
+	require.True(t, tkUpstreamDownstreamCapacity(mk(429, "No available accounts", "")))
+	require.True(t, tkUpstreamDownstreamCapacity(mk(503, "all available accounts exhausted", "")))
+	require.True(t, tkUpstreamDownstreamCapacity(mk(502, "", "No available accounts: no available accounts")))
+	// status 0 (pure transport) is owned by tkUpstreamClientCanceled, not here.
+	require.False(t, tkUpstreamDownstreamCapacity(mk(0, "No available accounts", "context canceled")))
+	// real provider 429 — no TokenKey phrase.
+	require.False(t, tkUpstreamDownstreamCapacity(mk(429, `{"type":"rate_limit_error"}`, "")))
+	// nil context.
+	require.False(t, tkUpstreamDownstreamCapacity(nil))
+}

--- a/scripts/sentinels/gateway-tk.json
+++ b/scripts/sentinels/gateway-tk.json
@@ -1863,12 +1863,13 @@
     {
       "path": "backend/internal/handler/ops_error_logger.go",
       "must_contain": [
+        "routingCapacityLimited := isOpsRoutingCapacityLimited(c) || (upstreamError && tkUpstreamDownstreamCapacity(c))",
         "clientInducedUpstream := upstreamError && tkUpstreamClientInducedRejection(c)",
         "clientCanceledUpstream := upstreamError && tkUpstreamClientCanceled(c)",
         "if upstreamError && !routingCapacityLimited && !clientInducedUpstream && !clientCanceledUpstream {",
         "if (clientInducedUpstream || clientCanceledUpstream) && !routingCapacityLimited {"
       ],
-      "rationale": "Injection point in classifyOpsErrorLog: an upstream client-induced 4xx (tkUpstreamClientInducedRejection) AND a client/caller disconnect with no upstream status (tkUpstreamClientCanceled, issue #625) must NOT take the upstream/provider phase override (which feeds error_owner=provider -> upstream_error_rate), and must instead be owned to the client (phase=request). routingCapacityLimited still wins last so 'no available accounts' SLA-exclusion is preserved. An upstream merge that rewrites this classifier and copies back the unconditional 'if upstreamError { phase = upstream }' shape silently restores the prod P0 false page (and the quad-edge context-canceled false P0); this sentinel anchors the guard plus both the client-induced and client-canceled branches."
+      "rationale": "Injection point in classifyOpsErrorLog: an upstream client-induced 4xx (tkUpstreamClientInducedRejection) AND a client/caller disconnect with no upstream status (tkUpstreamClientCanceled, issue #625) must NOT take the upstream/provider phase override (which feeds error_owner=provider -> upstream_error_rate), and must instead be owned to the client (phase=request). routingCapacityLimited still wins last so 'no available accounts' SLA-exclusion is preserved. The routingCapacityLimited assignment ALSO folds in tkUpstreamDownstreamCapacity (mirror-edge metric pollution, 2026-06-06): a RELAYED downstream-capacity verdict — an edge answered 429/5xx with a TokenKey 'no available accounts' / 'all available accounts exhausted' body — is OUR fleet capacity, not provider health, so it is owned as routing (out of upstream_error_rate) exactly like a LOCAL empty pool; this corrects the old asymmetry where a relayed no-available counted for SLA while a local one did not (which made upstream_error_rate read ~1300 on both a dead and a healthy edge). Boundary: only TokenKey phrases match; real provider 429/5xx still counts. An upstream merge that rewrites this classifier and copies back the unconditional 'if upstreamError { phase = upstream }' shape, or drops the tkUpstreamDownstreamCapacity fold, silently restores the prod P0 false page (and the quad-edge context-canceled false P0 / the mirror-edge upstream-429 pollution); this sentinel anchors the guard plus the routing-capacity fold and both the client-induced and client-canceled branches."
     },
     {
       "path": "backend/internal/handler/ops_error_logger_tk_client_induced_upstream_test.go",
@@ -1950,6 +1951,25 @@
         "tkObserveCancelStorm(c, ops)"
       ],
       "rationale": "Per-API-key cancel-storm detector chokepoint hook (PR #635, Phase 1 detect-only). OpsErrorLoggerMiddleware is the single terminal-outcome observation point on /v1; this one line right after c.Next() feeds every request (success + >=400, independent of the ops-monitoring master switch) into OpsService.ObserveCancelStorm so a borrowed key issuing a context-canceled flood (the non-human-harness shape that got a subscription-OAuth account org-disabled) raises a real-time Feishu alert. The hook is small and compile-clean if dropped, so an upstream merge could silently revert it and re-blind the fleet to cancel storms. This sentinel pins the literal call; the detector itself (window counting + threshold + alert) lives in ops_cancel_storm_tk.go, which a missing hook would leave dead."
+    },
+    {
+      "path": "backend/internal/handler/ops_error_logger_tk_downstream_capacity.go",
+      "must_contain": [
+        "func tkUpstreamDownstreamCapacity(c *gin.Context) bool",
+        "if status != 429 && status < 500 {",
+        "isOpsNoAvailableAccountMessage(combined)",
+        "opsDownstreamFailoverExhaustedPhrase"
+      ],
+      "rationale": "Mirror-edge metric pollution (2026-06-06 yace load test): prod relays to Edge stacks via cc-<edge> apikey mirror accounts; an empty edge pool returns 429/503 with a TokenKey 'No available accounts' body (tkNoAvailableAccounts, PR #575). Because that 429 carries a definitive upstream status, tkUpstreamClientCanceled (status-0 gate) deliberately skips it and classifyOpsErrorLog counted it as phase=upstream/provider — so a dead single-account edge (us3: served_200=0, no_available_429=33748) and a healthy 3-account edge (us5: 2251x200, 77x429) both read ~1300 upstream-429 on prod, making the provider-health metric unable to tell a dead edge from a healthy one. This predicate detects a relayed TokenKey downstream-capacity verdict (status 429 or >=500 AND body text 'no available accounts' / 'all available accounts exhausted') so classifyOpsErrorLog can fold it into routingCapacityLimited and own it as routing (out of upstream_error_rate), exactly like a LOCAL empty pool and mirroring the cooldown-ladder skip in ratelimit_service_tk_downstream_no_available.go. Boundary (anthropic_amplifier_exemption_boundary): the status gate keeps status-0 transport errors with tkUpstreamClientCanceled, and ONLY the TokenKey-generated phrases match — a real Anthropic 429 (rate_limit_error) or raw 5xx carries no such phrase and stays provider-owned. Dropping the predicate (or broadening it past the TK phrases) re-arms the mirror-edge false P0 / blinds provider health."
+    },
+    {
+      "path": "backend/internal/handler/ops_error_logger_tk_downstream_capacity_test.go",
+      "must_contain": [
+        "TestClassifyOpsDownstreamCapacityOwnedAsRouting",
+        "TestClassifyOpsGenuineUpstreamStaysProviderDespiteCapacityHelper",
+        "TestTkUpstreamDownstreamCapacityPredicate"
+      ],
+      "rationale": "Focused regressions proving the mirror-edge boundary: (1) a relayed edge 'no available accounts' 429 (with and without a trailing client-cancel) and an 'all available accounts exhausted' 503 classify as phase=routing / error_owner=platform / businessLimited (out of upstream_error_rate); (2) a genuine provider 429 (rate_limit_error) and a raw 5xx with no TokenKey phrase stay phase=upstream / error_owner=provider so they keep counting; (3) the predicate status gate (status 0 owned by client-cancel) and phrase boundary hold. Dropping these lets an upstream merge silently revert the mirror-edge upstream-429 exclusion through the classifier."
     }
   ]
 }


### PR DESCRIPTION
## Why (Fix A from the mirror-edge metric decision)

prod relays to Edge stacks via `cc-<edge>` apikey mirror accounts (`credentials.base_url=api-<edge>.tokenkey.dev`). An empty edge pool returns **429/503 with a TokenKey "No available accounts" body** (`tkNoAvailableAccounts`, PR #575). Because that verdict carries a *definitive upstream status*, `tkUpstreamClientCanceled` (status-0 gate) deliberately skipped it and `classifyOpsErrorLog` counted it as `phase=upstream` / `error_owner=provider`.

During the 2026-06-06 yace load test this made `upstream_error_rate` read **~1300 across all six mirror edges** — a **dead** single-account edge and a **healthy** 3-account edge alike:

| edge | true state | served_200 | no_available_429 | prod upstream-429 |
|---|---|---|---|---|
| us5 | healthy (3 accts) | 2251 | 77 | ~1272 |
| us3 | DEAD 3.5h (1 acct) | 0 | 33748 | ~1801 |

(edge-us5 emitted **77** real 429 but prod recorded **1266** — 16× pollution from client-cancel tagging + failover smear). The provider-health metric could not tell a dead edge from a healthy one.

## What

Fold a new predicate `tkUpstreamDownstreamCapacity` into `routingCapacityLimited` in `classifyOpsErrorLog`: a **relayed** 429/5xx whose body is a TokenKey `"no available accounts"` / `"all available accounts exhausted"` envelope is owned as **routing** (out of `upstream_error_rate`), exactly like a LOCAL empty pool — mirroring the cooldown-ladder skip already in `ratelimit_service_tk_downstream_no_available.go`.

**Boundary (`anthropic_amplifier_exemption_boundary`):** only TokenKey-generated phrases match. A real Anthropic 429 (`rate_limit_error`) or raw 5xx carries no such phrase and **still counts** toward provider health.

- New TK predicate file `ops_error_logger_tk_downstream_capacity.go` (+ status-0 gate keeps transport cancels with `tkUpstreamClientCanceled`).
- One folded line in `classifyOpsErrorLog` (upstream-owned hotspot) — anchored lines unchanged.
- New focused tests (six real-edge shapes + provider-stays-counting boundary + predicate unit).
- **Intentional SLA-semantics reversal:** `TestClassifyOps...StillCountsForSLA` → `...ExcludedFromSLA` (the 2026-05-18 commit ae6ee23e predated the mirror topology). Edge health now has a dedicated truthful signal (`scan-edge-health.sh`, #640), so `upstream_error_rate` is reserved for genuine provider health.
- Sentinel `gateway-tk.json` updated (predicate + test + the classifier fold).

## Verification

- `go test -tags=unit ./internal/...` — **0 FAIL**; `go build ./...` ok.
- Full `scripts/preflight.sh` (incl. all sub2api checks) **PASS**; gateway-TK sentinel 203/203.

## Scope

Fix **A only**. **Fix C** (stop prod retry-storming dead single-account edges) is **deliberately deferred** to its own PR: it conflicts with the intentional no-cooldown design in `tkSkipDownstreamNoAvailableAccountsPenalty` (so a transiently-empty edge recovers fast) and needs a transient-vs-persistent threshold + a canary.

🤖 Generated with [Claude Code](https://claude.com/claude-code)