### PR TITLE
chore(edge): retire us1 EC2 — deployable=false (unlock decommission)

### DIFF
--- a/deploy/aws/stage0/edge-targets.json
+++ b/deploy/aws/stage0/edge-targets.json
@@ -4,7 +4,7 @@
   "max_monthly_budget_usd": 16,
   "targets": {
     "us1": {
-      "deployable": true,
+      "deployable": false,
       "profile": "edge-minimal",
       "region": "us-west-2",
       "domain": "api-us1.tokenkey.dev",

--- a/scripts/test_resolve_edge_deploy_route.py
+++ b/scripts/test_resolve_edge_deploy_route.py
@@ -30,12 +30,11 @@ class ResolveEdgeDeployRouteTest(unittest.TestCase):
         self.assertEqual(route["confirm_flag"], "confirm_instance")
         self.assertTrue(route["confirm_value"].endswith("-ls"))
 
-    def test_us1_routes_to_ec2(self) -> None:
-        route = self._route("us1")
-        self.assertEqual(route["platform"], "ec2")
-        self.assertEqual(route["workflow_file"], "deploy-edge-stage0.yml")
-        self.assertEqual(route["confirm_flag"], "confirm_stack")
-        self.assertIn("tokenkey-edge-us1", route["confirm_value"])
+    # NOTE: us1 was the last EC2 edge; it is being retired (deployable=false →
+    # decommission, replaced by the us6 Lightsail edge). With no deployable EC2 edge
+    # left in the matrix there is no live fixture for the EC2 routing branch, so the
+    # former `test_us1_routes_to_ec2` happy-path test is dropped. The rejection path
+    # below still exercises non-deployable resolution.
 
     def test_non_deployable_edge_fails(self) -> None:
         proc = subprocess.run(


### PR DESCRIPTION
## What
Set `us1` `deployable=false` in the EC2 edge matrix to unlock `deploy-edge-stage0.yml operation=decommission` (its guard requires deployable=false).

## Why
us1 was the **last deployable EC2 edge**. Its accounts have been migrated to the **us6 Lightsail** edge:
- gemini-imagen-veo-paid / gemini-nano-banana-free / kiro → copied byte-faithfully (credential md5 identical us1↔us6), wired into new `google`/`kiro-us6` groups, snapshot rebuilt.
- anthropic OAuth accounts were already soft-deleted days ago.
us1 now holds only the local admin account.

After this merges, the decommission workflow takes a 30-day EBS snapshot and deletes `tokenkey-edge-us1-stage0`.

## Architectural note
With us1 retired, **no deployable EC2 edge remains** — TokenKey edges become all-Lightsail. The EC2 deploy path (resolve-edge-deploy-route EC2 branch, deploy-edge-stage0.yml, cicd-oidc EC2 role) goes dormant. The `test_us1_routes_to_ec2` happy-path fixture is dropped (no EC2 edge to exercise it); the `fra1` non-deployable rejection test still covers that path.

## Follow-up (PR-B, after decommission)
Remove the us1 matrix row + cicd-oidc EC2 role/TargetInstanceId + ops-stage0-pg-dump-refresh edge-us1 job + sentinel/smoke refs; record the retired EIP in edge-polluted-ips.json. Porkbun A-record deletion for api-us1 is manual.

## Validation
- `scripts/preflight.sh` PASS (incl. edge platform exclusivity, scripts unittest 55 ok)

no-upstream-touch

🤖 Generated with [Claude Code](https://claude.com/claude-code)