### PR TITLE
feat(tier): raise L5 max_sessions baseline 120 -> 150

### DIFF
--- a/backend/internal/baseline/anthropic-oauth-stability-baselines-tiered.json
+++ b/backend/internal/baseline/anthropic-oauth-stability-baselines-tiered.json
@@ -204,7 +204,7 @@
         "extra": {
           "base_rpm": 84,
           "rpm_sticky_buffer": 30,
-          "max_sessions": 120,
+          "max_sessions": 150,
           "session_idle_timeout_minutes": 8,
           "window_cost_limit": 800,
           "window_cost_sticky_reserve": 0

--- a/deploy/aws/stage0/anthropic-oauth-stability-baselines-tiered.json
+++ b/deploy/aws/stage0/anthropic-oauth-stability-baselines-tiered.json
@@ -204,7 +204,7 @@
         "extra": {
           "base_rpm": 84,
           "rpm_sticky_buffer": 30,
-          "max_sessions": 120,
+          "max_sessions": 150,
           "session_idle_timeout_minutes": 8,
           "window_cost_limit": 800,
           "window_cost_sticky_reserve": 0


### PR DESCRIPTION
## What

把 anthropic-oauth stability tier **L5** 的最大并发会话上限 `max_sessions` 从 **120 提到 150**（+25%），运营调整。

## Why

- tier 数值单一真值源是 git baseline JSON；运行时各节点 `tiers` 表 overlay 到账号，账号 extra 为 null 是正确态（#472）。
- `tk_012` frozen seed 的 L5 行 max_sessions 本来就是 150，本次把 JSON 恢复到与原始 seed 一致。

## Changes

- `deploy/aws/stage0/anthropic-oauth-stability-baselines-tiered.json` — `tiers.l5.baseline.extra.max_sessions` 120 → 150
- `backend/internal/baseline/anthropic-oauth-stability-baselines-tiered.json` — 同字段同改（go:embed 副本，sentinel 钉死两份相等）
- **不改** `tk_012`：已应用迁移不可变，其 frozen seed L5 已是 150，sentinel 第三断言钉死原值。

## Impact

- 影响 4 个 L5 账号（us5×2 / us6 / us7）会话上限 120 → 150；其余 tier / 其余 cap 不变。
- 纯后端/配置改动，无前端影响。
- 合并后将 `apply-tiers-live` 实时下发到全 fleet（不等发版）。

## Verification

- `scripts/sentinels/check-tier-baseline-embed.py` GREEN（两份 JSON 相等 + tk_012 frozen 未变）
- `go test -tags=unit ./...` 全绿（baseline / service / openai_ws_v2）
- `scripts/preflight.sh` PASS