### PR TITLE
chore(edge): us1 zero-compat after EC2 decommission

### DIFF
--- a/deploy/aws/stage0/edge-polluted-ips.json
+++ b/deploy/aws/stage0/edge-polluted-ips.json
@@ -43,6 +43,13 @@
       "platform": "ec2",
       "edge_id": "fra1",
       "notes": "EC2 fra1 EIP released 2026-06-01 on EC2 decommission (fra1 goes Lightsail-only; not upstream pollution; exclude from re-allocation)"
+    },
+    {
+      "ip": "16.147.170.3",
+      "region": "us-west-2",
+      "platform": "ec2",
+      "edge_id": "us1",
+      "notes": "EC2 us1 EIP released 2026-06-07 on edge retirement (accounts migrated to us6 Lightsail; cc/codex fingerprint egress migrated to 52.15.35.197; not upstream pollution; exclude from re-allocation)"
     }
   ]
 }

--- a/deploy/aws/stage0/edge-targets.json
+++ b/deploy/aws/stage0/edge-targets.json
@@ -16,7 +16,7 @@
       "snapshot_schedule": "none",
       "monthly_budget_usd": 16,
       "ssm_prefix": "/tokenkey/edge/us1",
-      "purpose": "clean-us-egress-planned"
+      "purpose": "RETIRED 2026-06-07: EC2 stack decommissioned (instance terminated, EIP 16.147.170.3 released, EBS snap-09294f99e52c67dba kept 30d). Accounts migrated to us6 Lightsail; cc/codex fingerprint egress migrated to 52.15.35.197. Tombstone kept (deployable=false) because us1 is the last EC2 edge; full EC2-path removal (workflow options/role-maps, cicd-oidc EdgeUs1*, resolver branch) is a separate decision."
     }
   }
 }

--- a/docs/deploy/tokenkey-edge-ip-history.md
+++ b/docs/deploy/tokenkey-edge-ip-history.md
@@ -19,4 +19,5 @@ Active edge EIP rotation runbook: [`.cursor/skills/tokenkey-stage0-edge-ip-rotat
 | `18.135.59.111` | eu-west-2 | Lightsail edge-uk1 tokenkey-edge-uk1-ls-ip superseded 2026-05-26; released after matrix correction to 13.134.80.182 |
 | `100.48.129.133` | us-east-1 | Lightsail edge-us2 StaticIp-2 upstream API risk-block (2026-05-29) |
 | `52.47.52.132` | eu-west-3 | EC2 fra1 EIP released 2026-06-01 on EC2 decommission (fra1 goes Lightsail-only; not upstream pollution; exclude from re-allocation) |
+| `16.147.170.3` | us-west-2 | EC2 us1 EIP released 2026-06-07 on edge retirement (accounts migrated to us6 Lightsail; cc/codex fingerprint egress migrated to 52.15.35.197; not upstream pollution; exclude from re-allocation) |
 <!-- END edge-ip-status:polluted -->

--- a/ops/anthropic/capture_cc_fingerprint.py
+++ b/ops/anthropic/capture_cc_fingerprint.py
@@ -689,7 +689,8 @@ def run_check_env(
     gost_port = int(os.environ.get("CC0_GOST_HTTP_PORT", "11800"))
     # Fallback only — the operator's ~/.config/cc0/env CC0_EXPECT_EGRESS_IP wins.
     # Current canonical cc0 SOCKS-chain egress (see docs/spec-delta-cc-2.1.16x.md).
-    expect_ip = os.environ.get("CC0_EXPECT_EGRESS_IP", "16.147.170.3")
+    # 16.147.170.3 (retired EC2 us1 EIP) was decommissioned 2026-06-07; egress moved here.
+    expect_ip = os.environ.get("CC0_EXPECT_EGRESS_IP", "52.15.35.197")
     try:
         socks_host, socks_port = _parse_host_port(socks, default_host="127.0.0.1")
     except ValueError as exc:


### PR DESCRIPTION
## Context
us1 EC2 was **decommissioned 2026-06-07** (operator-creds CFN delete — the deploy-edge-stage0 `operation=decommission` workflow is IAM-blocked: its OIDC role `tokenkey-gha-*-error-clustering` lacks `cloudformation:DeleteStack`). Stack `tokenkey-edge-us1-stage0` deleted, instance terminated, EIP `16.147.170.3` released; EBS `snap-09294f99e52c67dba` kept 30 days for rollback. Accounts were migrated to the us6 Lightsail edge earlier.

## Changes (safe, non-breaking)
- **edge-polluted-ips.json + edge-ip-history.md**: record released EIP `16.147.170.3` (us-west-2) so clean-egress allocation excludes it. (edge-ip-status --check in sync.)
- **capture_cc_fingerprint.py**: fallback `CC0_EXPECT_EGRESS_IP` default `16.147.170.3` → `52.15.35.197`. The cc/codex fingerprint egress was migrated off the retired us1 IP; the live operator env already points to 52.15.35.197 and today's cc 2.1.168 capture used it. This only fixes the no-env fallback so it no longer targets the dead IP.
- **edge-targets.json**: us1 left as a `deployable=false` **tombstone** with a retirement note.

## Deliberately NOT bundled (separate decision)
us1 is the **last EC2 edge** — fully removing it cascades into the EC2 deploy path (deploy-edge-stage0.yml dispatch options would go empty, role-maps, cicd-oidc `EdgeUs1*` role + TargetInstanceId, resolve-edge-target.py EC2 branch). That is the question "does TokenKey keep any EC2 edge capability", which should be decided on its own, not smuggled into a cleanup PR. The orphaned cicd-oidc EdgeUs1 IAM role is harmless (unused).

## Still manual
- Porkbun: delete the `api-us1.tokenkey.dev` A record (no DNS automation in repo).
- prod mirror accounts `cc-us1`(id42) / `kiro-us1`(id49) still point at `api-us1` — left as-is per operator decision (steps 1/2 skipped).

## Validation
`scripts/preflight.sh` PASS (edge-ip-status in sync, scripts unittest 55 ok, exclusivity ok).

no-upstream-touch

🤖 Generated with [Claude Code](https://claude.com/claude-code)