### PR TITLE
feat(tier): add Anthropic stability tier L6 (concurrency=25, else == L5)

### DIFF
--- a/backend/internal/baseline/anthropic-oauth-stability-baselines-tiered.json
+++ b/backend/internal/baseline/anthropic-oauth-stability-baselines-tiered.json
@@ -5,7 +5,7 @@
     "single_account_scope": true,
     "rate_multiplier_fixed": 1.0,
     "usage_model": "Claude Code human-paced work: usage budget and session length are constrained separately; lower tiers are scheduled first but reach their local limits earlier.",
-    "tier_order": ["l1", "l2", "l3", "l4", "l5"],
+    "tier_order": ["l1", "l2", "l3", "l4", "l5", "l6"],
     "escalation_model": "code-owned",
     "cooldown_ladder_seconds": [30, 120, 600],
     "cooldown_tier_ttl_minutes": 30,
@@ -198,6 +198,23 @@
       "baseline": {
         "account": {
           "concurrency": 20,
+          "priority": 1,
+          "rate_multiplier": 1.0
+        },
+        "extra": {
+          "base_rpm": 84,
+          "rpm_sticky_buffer": 30,
+          "max_sessions": 150,
+          "session_idle_timeout_minutes": 8,
+          "window_cost_limit": 800,
+          "window_cost_sticky_reserve": 0
+        }
+      }
+    },
+    "l6": {
+      "baseline": {
+        "account": {
+          "concurrency": 25,
           "priority": 1,
           "rate_multiplier": 1.0
         },

--- a/backend/internal/baseline/tier_test.go
+++ b/backend/internal/baseline/tier_test.go
@@ -9,13 +9,13 @@ func TestLoadTierBaselineDoc(t *testing.T) {
 	if err != nil {
 		t.Fatalf("LoadTierBaselineDoc: %v", err)
 	}
-	if got := len(doc.Tiers); got != 5 {
-		t.Fatalf("expected 5 tiers, got %d", got)
+	if got := len(doc.Tiers); got != 6 {
+		t.Fatalf("expected 6 tiers, got %d", got)
 	}
 	if doc.SharedBaseline.TLSProfile.Name != "tk_canonical_cc_oauth" {
 		t.Fatalf("unexpected canonical tls profile name %q", doc.SharedBaseline.TLSProfile.Name)
 	}
-	wantOrder := []string{"l1", "l2", "l3", "l4", "l5"}
+	wantOrder := []string{"l1", "l2", "l3", "l4", "l5", "l6"}
 	if len(doc.Policy.TierOrder) != len(wantOrder) {
 		t.Fatalf("tier_order = %v", doc.Policy.TierOrder)
 	}

--- a/backend/internal/web/dist/frontend-source.json
+++ b/backend/internal/web/dist/frontend-source.json
@@ -1,7 +1,7 @@
 {
   "algorithm": "sha256(git-ls-files:path,size,content)",
   "file_count": 456,
-  "hash": "40f0644337cdc0014dc6490f50cbff588a44106b712460bc1349960122c4923f",
+  "hash": "cc386710e7252e7f754ffd09329d08773cdea18c04f7b0ed053933ba057c9932",
   "schema": 1,
   "source": "frontend/"
 }

--- a/deploy/aws/stage0/anthropic-oauth-stability-baselines-tiered.json
+++ b/deploy/aws/stage0/anthropic-oauth-stability-baselines-tiered.json
@@ -5,7 +5,7 @@
     "single_account_scope": true,
     "rate_multiplier_fixed": 1.0,
     "usage_model": "Claude Code human-paced work: usage budget and session length are constrained separately; lower tiers are scheduled first but reach their local limits earlier.",
-    "tier_order": ["l1", "l2", "l3", "l4", "l5"],
+    "tier_order": ["l1", "l2", "l3", "l4", "l5", "l6"],
     "escalation_model": "code-owned",
     "cooldown_ladder_seconds": [30, 120, 600],
     "cooldown_tier_ttl_minutes": 30,
@@ -198,6 +198,23 @@
       "baseline": {
         "account": {
           "concurrency": 20,
+          "priority": 1,
+          "rate_multiplier": 1.0
+        },
+        "extra": {
+          "base_rpm": 84,
+          "rpm_sticky_buffer": 30,
+          "max_sessions": 150,
+          "session_idle_timeout_minutes": 8,
+          "window_cost_limit": 800,
+          "window_cost_sticky_reserve": 0
+        }
+      }
+    },
+    "l6": {
+      "baseline": {
+        "account": {
+          "concurrency": 25,
           "priority": 1,
           "rate_multiplier": 1.0
         },

--- a/frontend/src/constants/accountTierOptions.tk.ts
+++ b/frontend/src/constants/accountTierOptions.tk.ts
@@ -4,7 +4,7 @@
  *
  * The backend tiers table (projection of the git baseline,
  * backend/internal/baseline/anthropic-oauth-stability-baselines-tiered.json,
- * tier_order l1..l5) is the SINGLE SOURCE OF TRUTH for per-tier VALUES. The
+ * tier_order l1..l6) is the SINGLE SOURCE OF TRUTH for per-tier VALUES. The
  * picker (useTkAccountTier) fetches them live from GET /admin/tiers and renders
  * the numeric hints from that response. This constant is ONLY a label fallback
  * if that fetch fails — so it deliberately carries no numeric config (hardcoding
@@ -24,4 +24,5 @@ export const ACCOUNT_TIER_OPTIONS: AccountTierOption[] = [
   { value: 'l3', label: 'L3', hint: '' },
   { value: 'l4', label: 'L4', hint: '' },
   { value: 'l5', label: 'L5', hint: '' },
+  { value: 'l6', label: 'L6', hint: '' },
 ]

--- a/ops/anthropic/manage-anthropic-config.py
+++ b/ops/anthropic/manage-anthropic-config.py
@@ -4189,7 +4189,7 @@ def main() -> int:
                         help="declare an edge OAuth tier change; emit plan JSON")
     sp.add_argument("--edge-id", "--edge", dest="edge_id", required=True)
     sp.add_argument("--account-name", "--account", dest="account_name", required=True)
-    sp.add_argument("--tier", required=True, help="l1 / l2 / l3 / l4 / l5")
+    sp.add_argument("--tier", required=True, help="l1 / l2 / l3 / l4 / l5 / l6")
     sp.add_argument("--snapshot", required=True)
     sp.add_argument("--out", help="write plan JSON (otherwise stdout)")
     sp.add_argument(
@@ -4207,7 +4207,7 @@ def main() -> int:
     sp = sub.add_parser(
         "plan-tier-bump",
         help="re-apply a tier's baseline to every account on that tier (one multi-action plan)")
-    sp.add_argument("--tier", required=True, help="l1 / l2 / l3 / l4 / l5")
+    sp.add_argument("--tier", required=True, help="l1 / l2 / l3 / l4 / l5 / l6")
     sp.add_argument("--snapshot", required=True)
     sp.add_argument("--out", help="write plan JSON (otherwise stdout)")
     sp.add_argument(

--- a/scripts/sentinels/frontend-tk.json
+++ b/scripts/sentinels/frontend-tk.json
@@ -332,7 +332,7 @@
       "must_contain": [
         "ACCOUNT_TIER_OPTIONS"
       ],
-      "rationale": "TK-only tier dropdown options (l1..l5) for the admin 'Set Tier' action. Display labels only — the backend embedded baseline owns the numeric tier values. Guards the constant against silent upstream-merge deletion that would break the tier modal import."
+      "rationale": "TK-only tier dropdown options (l1..l6) for the admin 'Set Tier' action. Display labels only — the backend embedded baseline owns the numeric tier values. Guards the constant against silent upstream-merge deletion that would break the tier modal import."
     },
     {
       "path": "frontend/src/composables/useTkAccountTier.ts",


### PR DESCRIPTION
## What

新增稳定性 tier **L6**:`concurrency=25`,其余字段全部与 L5 一致
(`priority=1`, `base_rpm=84`, `max_sessions=150`, `rpm_sticky_buffer=30`,
`window_cost_limit=800`, `session_idle_timeout_minutes=8`, cache_ttl 1h,
TLS profile `tk_canonical_cc_oauth` — 均继承 `shared_baseline`)。

## Why

为高稳定性账号提供一档更高并发(20→25)的运营档位(目标:us5 `edge-or2-ls-b`)。
tier 数值单一真值源是 git baseline JSON;运行时各节点 `tiers` 表由
`ensureSeededFromBaseline` 在启动 UPSERT(账号 `extra` 为 null,#472)。新增 tier =
在两份 baseline JSON 加 `l6`,**不碰**已应用的 `tk_012`(frozen seed 由 sentinel 钉死,
仍 l1..l5)。

## Changes

- `deploy/aws/stage0/` + `backend/internal/baseline/` 两份 tiered baseline JSON:
  `policy.tier_order` 追加 `"l6"` + 新增 `tiers.l6` 块(sentinel 钉死两份相等)
- `backend/internal/baseline/tier_test.go`:tier 数量 5→6 + `wantOrder` 追加 l6
- `frontend/src/constants/accountTierOptions.tk.ts`:下拉 fallback 追加 L6
  + 重建 `backend/internal/web/dist/frontend-source.json` 指纹
- `scripts/sentinels/frontend-tk.json`:rationale (l1..l5)→(l1..l6)
- `ops/anthropic/manage-anthropic-config.py`:两处 `--tier` help 文案补 l6

## Impact

- 纯新增 tier;**无账号默认落到 L6**,现有 tier/cap 不变。
- L6 在**下次发版/重启**时由 `ensureSeededFromBaseline` INSERT 进各节点 `tiers` 表;
  之后 admin 用 ApplyTier 把账号设为 L6(`apply-tiers-live` 是 UPDATE-only,不会 INSERT 新 tier 行)。
- 触及前端(下拉 fallback),有 web 影响,**不**声明 `no-web-impact`。

## Verification

- `scripts/sentinels/check-tier-baseline-embed.py` GREEN(两份 JSON 相等 + tk_012 frozen 未变)
- `go test -tags=unit ./...` 全绿(baseline tier 数量/顺序/ladder 不变量)
- frontend `pnpm lint:check`(0 error)+ `typecheck` 通过
- `_load_expected_tiers()['l6']` = concurrency 25 / max_sessions 150 / base_rpm 84
- `scripts/preflight.sh` PASS

🤖 Generated with [Claude Code](https://claude.com/claude-code)