### PR TITLE
fix(edge-lightsail): correct us6/us7 static-IP truth (DNS pointed at dangling/dead IPs)

### DIFF
--- a/deploy/aws/lightsail/edge-targets-lightsail.json
+++ b/deploy/aws/lightsail/edge-targets-lightsail.json
@@ -150,14 +150,14 @@
       "ec2_equivalent_region": "us-east-2",
       "availability_zone": "us-east-2a",
       "domain": "api-us6.tokenkey.dev",
-      "porkbun_a_ipv4": "52.15.35.197",
+      "porkbun_a_ipv4": "3.148.79.145",
       "instance_name": "edge-ls-us-oh-3",
       "static_ip_name": "StaticIp-oh-3",
       "bundle_id": "micro_3_0",
       "blueprint_id": "amazon_linux_2023",
       "monthly_budget_usd": 12,
       "ssm_prefix": "/tokenkey/lightsail/us6",
-      "purpose": "us-east-2-ohio-egress (rehomed 2026-06-05 from retired us-east-1 edge-ls-us-va-1/3.212.130.21 to adopted console-created edge-ls-us-oh-3 / StaticIp-oh-3)"
+      "purpose": "us-east-2-ohio-egress (rehomed 2026-06-05 to adopted console-created edge-ls-us-oh-3 / StaticIp-oh-3; corrected 2026-06-08: A record was stale at ephemeral 52.15.35.197 which AWS re-adopted to *.coverahealth.com — StaticIp-oh-3 truth is 3.148.79.145)"
     },
     "us7": {
       "deployable": true,
@@ -167,14 +167,14 @@
       "ec2_equivalent_region": "us-east-2",
       "availability_zone": "us-east-2a",
       "domain": "api-us7.tokenkey.dev",
-      "porkbun_a_ipv4": "3.139.183.116",
+      "porkbun_a_ipv4": "18.188.207.95",
       "instance_name": "edge-ls-us-oh-4",
-      "static_ip_name": "StaticIp-oh-4",
+      "static_ip_name": "StaticIp-oh-4-b",
       "bundle_id": "micro_3_0",
       "blueprint_id": "amazon_linux_2023",
       "monthly_budget_usd": 12,
       "ssm_prefix": "/tokenkey/lightsail/us7",
-      "purpose": "us-east-2-ohio-egress (rehomed 2026-06-05 from retired us-east-1 edge-ls-us-va-2/44.216.223.210 to adopted console-created edge-ls-us-oh-4 / StaticIp-oh-4)"
+      "purpose": "us-east-2-ohio-egress (rehomed 2026-06-05 to adopted console-created edge-ls-us-oh-4; corrected 2026-06-08: live static IP is StaticIp-oh-4-b/18.188.207.95 not StaticIp-oh-4/3.139.183.116 — A record was stale at the dead 3.139.183.116)"
     },
     "uk2": {
       "deployable": true,


### PR DESCRIPTION
## 问题

prod 的 `cc-us6` / `cc-us7` mirror 账号无法到达对应 edge —— 但根因不是 edge 死了。

排查发现 **两个 edge 本身都完全健康**(Caddy 在跑、LE 证书有效 `CN=api-us6/us7.tokenkey.dev` 到期 2026-09-02、`/health` 与 `/healthz` 在真静态 IP 上返回 200、HTTP/2 正常),故障 100% 在 **DNS / registry / SSM 落后于真实静态 IP**:

| edge | A 记录/registry 旧值 | 旧值现状 | 真实静态 IP (get-static-ip) |
|---|---|---|---|
| us6 | `52.15.35.197` | 实例挂静态 IP 前的临时公网 IP,已被 AWS 回收并 re-adopt 给 `*.coverahealth.com`(别人的服务器) | `StaticIp-oh-3` = **3.148.79.145** |
| us7 | `3.139.183.116` + `static_ip_name=StaticIp-oh-4` | IP 已死;静态 IP 名也写错 | `StaticIp-oh-4-b` = **18.188.207.95** |

**不需要 IP 轮换 / 重 provision** —— 纯真值订正。

## 改动

- `edge-targets-lightsail.json`:us6/us7 `porkbun_a_ipv4` 订正到真实静态 IP;us7 `static_ip_name` `StaticIp-oh-4` → `StaticIp-oh-4-b`;purpose 注释记录订正缘由。

## 已在仓库外完成

- SSM `/tokenkey/lightsail/{us6,us7}/public_ip` 已 `put-parameter` 对齐真值(version 2)。

## 仍需运营手动(无 Porkbun API)

- Porkbun A 记录:`api-us6.tokenkey.dev` → `3.148.79.145`;`api-us7.tokenkey.dev` → `18.188.207.95`。改完 `dig +short @1.1.1.1` 验证后,prod anthropic 池 `cc-us6`/`cc-us7` 即恢复。

## 验证

- `aws lightsail get-static-ips --region us-east-2`:StaticIp-oh-3=3.148.79.145(挂 edge-ls-us-oh-3,running)、StaticIp-oh-4-b=18.188.207.95(挂 edge-ls-us-oh-4,running)
- `curl --noproxy '*' --resolve api-us6:443:3.148.79.145 .../health` → 200;us7 同理 → 200
- 旧 52.15.35.197 出证 `CN=*.coverahealth.com`(确认 dangling/误 adopt)
- 真 IP 不在 `edge-polluted-ips.json`
- `scripts/preflight.sh`(含 sub2api 全检)PASS

🤖 Generated with [Claude Code](https://claude.com/claude-code)
