### PR TITLE
fix(gateway): SSE keepalive during upstream header-wait on streaming /v1/messages

### DIFF
--- a/backend/internal/service/gateway_service.go
+++ b/backend/internal/service/gateway_service.go
@@ -4856,8 +4856,14 @@ func (s *GatewayService) Forward(ctx context.Context, c *gin.Context, account *A
 		// 记录本次实际发送的 wire body；只有请求成功后才写回 ParsedRequest，避免 400 retry 基于已签名 CCH 再改写。
 		lastWireBody = wireBody
 
-		// 发送请求
+		// 发送请求。流式请求在等待上游响应头期间发送 SSE keepalive，防止空闲敏感的
+		// 中间层（Cloudflare Tunnel / Caddy / 客户端 SDK）在上游排队/首字节前断开连接
+		// （Wei-Shaw/sub2api#2121）。首个 ping 延迟一个 keepalive 间隔，故快速 failover
+		// 错误（429/503/5xx）在写出任何字节前已返回，handler 的 c.Writer.Written()
+		// failover 门禁得以保留。详见 gateway_service_tk_header_wait_keepalive.go。
+		hwka := s.beginHeaderWaitKeepalive(c, reqStream)
 		resp, err = s.httpUpstream.DoWithTLS(upstreamReq, proxyURL, account.ID, account.Concurrency, tlsProfile)
+		hwka.stop()
 		if err != nil {
 			if resp != nil && resp.Body != nil {
 				_ = resp.Body.Close()

--- a/backend/internal/service/gateway_service_tk_header_wait_keepalive.go
+++ b/backend/internal/service/gateway_service_tk_header_wait_keepalive.go
@@ -1,0 +1,134 @@
+package service
+
+import (
+	"fmt"
+	"net/http"
+	"sync"
+	"time"
+
+	"github.com/gin-gonic/gin"
+)
+
+// anthropicSSEPingFrame is the Anthropic-shaped SSE keepalive frame. It is byte
+// identical to the in-stream keepalive emitted by handleStreamingResponse* so a
+// downstream client sees exactly one ping event type whether the heartbeat was
+// produced before or after the upstream started streaming.
+const anthropicSSEPingFrame = "event: ping\ndata: {\"type\": \"ping\"}\n\n"
+
+// headerWaitKeepalive emits SSE ping frames to the downstream client while the
+// upstream is still being dialed / has not yet returned its response headers.
+// See beginHeaderWaitKeepalive for the failover-safety rationale.
+type headerWaitKeepalive struct {
+	stopCh chan struct{}
+	doneCh chan struct{}
+	once   sync.Once
+}
+
+// stop terminates the keepalive goroutine and blocks until it has fully
+// returned, guaranteeing that no ping can race a subsequent write to the same
+// gin.ResponseWriter. It is safe to call on a nil receiver (the no-op case
+// returned by beginHeaderWaitKeepalive when keepalive is disabled).
+func (k *headerWaitKeepalive) stop() {
+	if k == nil {
+		return
+	}
+	k.once.Do(func() { close(k.stopCh) })
+	<-k.doneCh
+}
+
+// beginHeaderWaitKeepalive starts a background SSE ping emitter for streaming
+// Anthropic requests. It is a no-op (returns nil) for non-streaming requests or
+// when keepalive is disabled (gateway.stream_keepalive_interval <= 0). The
+// returned handle MUST be stopped (k.stop()) the instant the upstream call
+// returns, before any other code writes to c.Writer.
+//
+// Why this exists (Wei-Shaw/sub2api#2121): the existing in-stream keepalive only
+// fires AFTER the upstream has produced its first SSE byte. While Forward blocks
+// in DoWithTLS waiting for the upstream response headers — which can take a long
+// time when the upstream is queueing under load or "thinking" before the first
+// token — the downstream connection is completely idle. Idle-sensitive
+// intermediaries (Cloudflare Tunnel, Caddy, client SDKs) then drop the
+// connection and a request that would have succeeded is lost. This is amplified
+// on the prod->edge mirror-relay topology, where the same header-wait window is
+// traversed on two hops.
+//
+// Failover safety: the FIRST ping is delayed by one full keepalive interval, so
+// any failover-eligible upstream outcome (429/503/5xx, empty-pool fast-fail,
+// fast network refusal) — all of which return within ~1-2s — is decided before
+// a single byte is written. The handler's c.Writer.Written() failover gate is
+// therefore preserved for the overwhelming majority of requests. Only an
+// upstream that stays silent past one full interval and THEN fails loses
+// transparent failover; that request is already pathologically slow, and the
+// pre-existing ensureForwardErrorResponse path still delivers a protocol-
+// compliant SSE terminal event to the downstream client.
+func (s *GatewayService) beginHeaderWaitKeepalive(c *gin.Context, reqStream bool) *headerWaitKeepalive {
+	if !reqStream {
+		return nil
+	}
+	if s == nil || s.cfg == nil || s.cfg.Gateway.StreamKeepaliveInterval <= 0 {
+		return nil
+	}
+	interval := time.Duration(s.cfg.Gateway.StreamKeepaliveInterval) * time.Second
+	return startHeaderWaitKeepalive(c, interval)
+}
+
+// startHeaderWaitKeepalive is the interval-driven core of beginHeaderWaitKeepalive,
+// split out so tests can drive it with a sub-second interval. interval <= 0,
+// a nil context/writer, or a writer that cannot flush all yield a nil no-op.
+func startHeaderWaitKeepalive(c *gin.Context, interval time.Duration) *headerWaitKeepalive {
+	if interval <= 0 || c == nil || c.Writer == nil || c.Request == nil {
+		return nil
+	}
+	flusher, ok := c.Writer.(http.Flusher)
+	if !ok {
+		return nil
+	}
+
+	k := &headerWaitKeepalive{
+		stopCh: make(chan struct{}),
+		doneCh: make(chan struct{}),
+	}
+	go func() {
+		defer close(k.doneCh)
+		ticker := time.NewTicker(interval)
+		defer ticker.Stop()
+		ctxDone := c.Request.Context().Done()
+		headersSent := false
+		for {
+			select {
+			case <-k.stopCh:
+				return
+			case <-ctxDone:
+				return
+			case <-ticker.C:
+				if !headersSent {
+					// Commit SSE response headers exactly once, before the first
+					// ping forces WriteHeader(200). Mirrors the header set in
+					// handleStreamingResponseAnthropicAPIKeyPassthrough so the
+					// real stream handler's later c.Header() calls are harmless
+					// no-ops on the already-sent header block.
+					h := c.Writer.Header()
+					if h.Get("Content-Type") == "" {
+						h.Set("Content-Type", "text/event-stream")
+					}
+					if h.Get("Cache-Control") == "" {
+						h.Set("Cache-Control", "no-cache")
+					}
+					if h.Get("Connection") == "" {
+						h.Set("Connection", "keep-alive")
+					}
+					h.Set("X-Accel-Buffering", "no")
+					headersSent = true
+				}
+				if _, err := fmt.Fprint(c.Writer, anthropicSSEPingFrame); err != nil {
+					// Client is gone; stop emitting. The upstream read path will
+					// observe the disconnect via context cancellation or its own
+					// write failure once it takes over.
+					return
+				}
+				flusher.Flush()
+			}
+		}
+	}()
+	return k
+}

--- a/backend/internal/service/gateway_service_tk_header_wait_keepalive_test.go
+++ b/backend/internal/service/gateway_service_tk_header_wait_keepalive_test.go
@@ -1,0 +1,91 @@
+package service
+
+import (
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/gin-gonic/gin"
+)
+
+func newKeepaliveTestContext(t *testing.T) (*gin.Context, *httptest.ResponseRecorder) {
+	t.Helper()
+	gin.SetMode(gin.TestMode)
+	rec := httptest.NewRecorder()
+	c, _ := gin.CreateTestContext(rec)
+	c.Request = httptest.NewRequest(http.MethodPost, "/v1/messages", nil)
+	return c, rec
+}
+
+// A slow upstream (one that has not returned headers within a keepalive
+// interval) must produce SSE ping frames and the SSE response headers, so an
+// idle-sensitive intermediary does not drop the connection (Wei-Shaw#2121).
+func TestStartHeaderWaitKeepalive_EmitsPingsAfterInterval(t *testing.T) {
+	c, rec := newKeepaliveTestContext(t)
+
+	k := startHeaderWaitKeepalive(c, 20*time.Millisecond)
+	if k == nil {
+		t.Fatal("expected non-nil keepalive handle for positive interval")
+	}
+	// Simulate an upstream that blocks past several intervals before stop().
+	time.Sleep(90 * time.Millisecond)
+	k.stop()
+
+	body := rec.Body.String()
+	if got := strings.Count(body, "event: ping"); got < 1 {
+		t.Fatalf("expected at least one ping frame, got %d (body=%q)", got, body)
+	}
+	if ct := rec.Header().Get("Content-Type"); ct != "text/event-stream" {
+		t.Fatalf("expected SSE content-type committed before first ping, got %q", ct)
+	}
+	if rec.Header().Get("X-Accel-Buffering") != "no" {
+		t.Fatalf("expected X-Accel-Buffering=no, got %q", rec.Header().Get("X-Accel-Buffering"))
+	}
+	if !c.Writer.Written() {
+		t.Fatal("expected writer marked written after pings")
+	}
+}
+
+// The failover-safety contract: if the upstream returns BEFORE one keepalive
+// interval elapses (the path that every fast 429/503/5xx failover takes), NOT a
+// single byte may be written — otherwise the handler's c.Writer.Written()
+// failover gate would be tripped and transparent failover lost.
+func TestStartHeaderWaitKeepalive_NoWriteBeforeInterval(t *testing.T) {
+	c, rec := newKeepaliveTestContext(t)
+
+	k := startHeaderWaitKeepalive(c, 500*time.Millisecond)
+	if k == nil {
+		t.Fatal("expected non-nil keepalive handle")
+	}
+	// Upstream "returned" almost immediately, well within the interval.
+	time.Sleep(5 * time.Millisecond)
+	k.stop()
+
+	if rec.Body.Len() != 0 {
+		t.Fatalf("expected no body written before interval, got %q", rec.Body.String())
+	}
+	if c.Writer.Written() {
+		t.Fatal("writer must not be marked written before any ping (failover gate)")
+	}
+}
+
+func TestStartHeaderWaitKeepalive_DisabledReturnsNil(t *testing.T) {
+	c, _ := newKeepaliveTestContext(t)
+	if k := startHeaderWaitKeepalive(c, 0); k != nil {
+		t.Fatal("expected nil handle when interval <= 0")
+	}
+	// stop() on a nil handle must be a safe no-op.
+	var nilHandle *headerWaitKeepalive
+	nilHandle.stop()
+}
+
+func TestBeginHeaderWaitKeepalive_NonStreamReturnsNil(t *testing.T) {
+	c, _ := newKeepaliveTestContext(t)
+	// reqStream=false short-circuits before any config lookup, so a zero-value
+	// service is sufficient.
+	if k := (&GatewayService{}).beginHeaderWaitKeepalive(c, false); k != nil {
+		t.Fatal("expected nil handle for non-streaming request")
+	}
+}

--- a/scripts/sentinels/gateway-tk.json
+++ b/scripts/sentinels/gateway-tk.json
@@ -1970,6 +1970,33 @@
         "TestTkUpstreamDownstreamCapacityPredicate"
       ],
       "rationale": "Focused regressions proving the mirror-edge boundary: (1) a relayed edge 'no available accounts' 429 (with and without a trailing client-cancel) and an 'all available accounts exhausted' 503 classify as phase=routing / error_owner=platform / businessLimited (out of upstream_error_rate); (2) a genuine provider 429 (rate_limit_error) and a raw 5xx with no TokenKey phrase stay phase=upstream / error_owner=provider so they keep counting; (3) the predicate status gate (status 0 owned by client-cancel) and phrase boundary hold. Dropping these lets an upstream merge silently revert the mirror-edge upstream-429 exclusion through the classifier."
+    },
+    {
+      "path": "backend/internal/service/gateway_service_tk_header_wait_keepalive.go",
+      "must_contain": [
+        "func (s *GatewayService) beginHeaderWaitKeepalive(c *gin.Context, reqStream bool) *headerWaitKeepalive",
+        "func startHeaderWaitKeepalive(c *gin.Context, interval time.Duration) *headerWaitKeepalive",
+        "func (k *headerWaitKeepalive) stop()",
+        "anthropicSSEPingFrame"
+      ],
+      "rationale": "Header-wait SSE keepalive (Wei-Shaw/sub2api#2121): emits Anthropic-shaped ping frames to the downstream client while Forward blocks in DoWithTLS waiting for upstream response headers, so idle-sensitive intermediaries (Cloudflare Tunnel / Caddy / client SDKs) do not drop a slow request before the first upstream byte. This closes the gap left by the in-stream keepalive (which only fires AFTER the first SSE byte) and is amplified on the prod->edge mirror relay. The first ping is delayed one keepalive interval so fast failover-eligible errors return before any byte is written, preserving the handler's c.Writer.Written() failover gate. An upstream merge that overwrites this companion would silently re-open the slow-header connection-drop on the busiest path."
+    },
+    {
+      "path": "backend/internal/service/gateway_service.go",
+      "must_contain": [
+        "hwka := s.beginHeaderWaitKeepalive(c, reqStream)",
+        "hwka.stop()"
+      ],
+      "rationale": "Thin injection point of the header-wait SSE keepalive around the primary streaming DoWithTLS call in Forward. Begin returns a no-op for non-streaming/disabled requests; stop() must run the instant DoWithTLS returns and before any other write to c.Writer so a ping cannot race the stream handler. Catches an upstream merge that copies the old DoWithTLS shape back over the injection."
+    },
+    {
+      "path": "backend/internal/service/gateway_service_tk_header_wait_keepalive_test.go",
+      "must_contain": [
+        "TestStartHeaderWaitKeepalive_EmitsPingsAfterInterval",
+        "TestStartHeaderWaitKeepalive_NoWriteBeforeInterval",
+        "TestBeginHeaderWaitKeepalive_NonStreamReturnsNil"
+      ],
+      "rationale": "Focused regressions for the header-wait keepalive: (1) ping frames + SSE headers are emitted once one interval elapses on a slow upstream; (2) NOT a single byte is written before the interval, which is the failover-gate contract (a fast 429/503/5xx must still be able to failover via c.Writer.Written()==false); (3) non-streaming requests get a nil no-op. Dropping these lets an upstream merge silently revert the failover-safe delayed-ping behavior."
     }
   ]
 }


### PR DESCRIPTION
## Problem (Wei-Shaw/sub2api#2121)

On streaming Anthropic `/v1/messages`, `Forward` blocks in `DoWithTLS` waiting for the upstream **response headers**. While the upstream queues under load / "thinks" before the first token, the **downstream connection is completely idle** — nothing is on the wire. Idle-sensitive intermediaries (Cloudflare Tunnel, Caddy, client SDKs) then drop the connection and a request that would have succeeded is lost.

The existing in-stream keepalive only fires **after** the first upstream SSE byte, so the entire header-wait window (up to the 300s response-header-timeout) is dead air. This is **amplified on the prod→edge mirror-relay topology**, where the same header-wait window is traversed on two hops.

## Fix

Emit Anthropic-shaped SSE ping frames to the client during the header-wait, via a thin begin/stop wrapper around the primary streaming `DoWithTLS` call. All logic lives in the new `gateway_service_tk_header_wait_keepalive.go` companion; the upstream-shaped `gateway_service.go` gets only an 8-line injection.

### Failover-safe by construction
The **first ping is delayed one full keepalive interval** (`gateway.stream_keepalive_interval`, default 10s). Fast failover-eligible outcomes (429/503/5xx, empty-pool fast-fail, fast network refusal) all return within ~1–2s — i.e. **before any byte is written** — so the handler's `c.Writer.Written()` failover gate is preserved for the overwhelming majority of requests. For the pathological case (upstream silent past one interval, then errors), the pre-existing `ensureForwardErrorResponse` path already degrades a post-ping error into a protocol-compliant SSE terminal event. Reuses the existing config knob (set to `0` to disable both keepalives) — no new config surface.

## Tests
`go test -tags=unit ./...` green. New focused regressions:
- pings + SSE headers emitted once one interval elapses on a slow upstream;
- **zero bytes written before the interval** — the failover-gate contract;
- non-streaming / disabled → nil no-op.

## Scope / discipline
- Backend-only (`no-web-impact`); guarded upstream-file touch (`upstream-touch-guarded`).
- 3 sentinel anchors added (companion, injection point, failover-gate tests) to block silent upstream-merge reverts.
- `Refs Wei-Shaw/sub2api#2121` (enhancement, not a fix-ledger bug — no trailer).
- **Out-of-order vs upstream:** TK is 14 commits behind `upstream/main` (pre-existing). This change is scoped entirely to a TK-owned streaming path and does not depend on any of those upstream commits; landing the periodic upstream merge is a separate workflow and is not blocked by this PR.

## Checklist
- [x] `go test -tags=unit ./...`
- [x] `golangci-lint run ./internal/service/` — 0 issues
- [x] `go build ./...`
- [x] `scripts/preflight.sh` PASS (full sub2api suite)
- [x] No frontend impact; no schema/ent changes; no upstream symbol deletions

🤖 Generated with [Claude Code](https://claude.com/claude-code)