### PR TITLE
fix(gateway): SSE keepalive during upstream header-wait on OpenAI/Codex streaming

### DIFF
--- a/backend/internal/service/gateway_service_tk_header_wait_keepalive.go
+++ b/backend/internal/service/gateway_service_tk_header_wait_keepalive.go
@@ -15,6 +15,14 @@ import (
 // produced before or after the upstream started streaming.
 const anthropicSSEPingFrame = "event: ping\ndata: {\"type\": \"ping\"}\n\n"
 
+// openaiSSECommentFrame is the OpenAI/Codex-shaped SSE keepalive frame. The
+// OpenAI passthrough in-stream keepalive uses a bare SSE comment line (":\n\n"),
+// which every SSE client ignores — unlike the Anthropic path it must NOT emit a
+// typed event, because the strict Codex/Responses SDK rejects unknown event
+// frames. Kept byte identical to that in-stream frame for the same reason as
+// anthropicSSEPingFrame.
+const openaiSSECommentFrame = ":\n\n"
+
 // headerWaitKeepalive emits SSE ping frames to the downstream client while the
 // upstream is still being dialed / has not yet returned its response headers.
 // See beginHeaderWaitKeepalive for the failover-safety rationale.
@@ -69,13 +77,34 @@ func (s *GatewayService) beginHeaderWaitKeepalive(c *gin.Context, reqStream bool
 		return nil
 	}
 	interval := time.Duration(s.cfg.Gateway.StreamKeepaliveInterval) * time.Second
-	return startHeaderWaitKeepalive(c, interval)
+	return startHeaderWaitKeepalive(c, interval, anthropicSSEPingFrame)
+}
+
+// beginHeaderWaitKeepalive (OpenAI) is the OpenAI/Codex passthrough analogue of
+// the Anthropic header-wait keepalive above. The OpenAI passthrough streaming
+// forward (forwardOpenAIPassthrough) blocks in s.httpUpstream.Do(...) waiting for
+// the upstream response headers exactly like the Anthropic Forward path, with the
+// same idle-drop exposure and the same failover gate (the handler compares
+// c.Writer.Size() before/after forward). Reuses the same config knob and the same
+// failover-safe delayed-first-ping construction; it differs only in the emitted
+// frame — a bare SSE comment that the strict Codex/Responses SDK tolerates. A
+// no-op for non-streaming/disabled requests.
+func (s *OpenAIGatewayService) beginHeaderWaitKeepalive(c *gin.Context, reqStream bool) *headerWaitKeepalive {
+	if !reqStream {
+		return nil
+	}
+	if s == nil || s.cfg == nil || s.cfg.Gateway.StreamKeepaliveInterval <= 0 {
+		return nil
+	}
+	interval := time.Duration(s.cfg.Gateway.StreamKeepaliveInterval) * time.Second
+	return startHeaderWaitKeepalive(c, interval, openaiSSECommentFrame)
 }
 
 // startHeaderWaitKeepalive is the interval-driven core of beginHeaderWaitKeepalive,
-// split out so tests can drive it with a sub-second interval. interval <= 0,
-// a nil context/writer, or a writer that cannot flush all yield a nil no-op.
-func startHeaderWaitKeepalive(c *gin.Context, interval time.Duration) *headerWaitKeepalive {
+// split out so tests can drive it with a sub-second interval. frame is the SSE
+// bytes emitted each tick (platform specific). interval <= 0, a nil
+// context/writer, or a writer that cannot flush all yield a nil no-op.
+func startHeaderWaitKeepalive(c *gin.Context, interval time.Duration, frame string) *headerWaitKeepalive {
 	if interval <= 0 || c == nil || c.Writer == nil || c.Request == nil {
 		return nil
 	}
@@ -120,7 +149,7 @@ func startHeaderWaitKeepalive(c *gin.Context, interval time.Duration) *headerWai
 					h.Set("X-Accel-Buffering", "no")
 					headersSent = true
 				}
-				if _, err := fmt.Fprint(c.Writer, anthropicSSEPingFrame); err != nil {
+				if _, err := fmt.Fprint(c.Writer, frame); err != nil {
 					// Client is gone; stop emitting. The upstream read path will
 					// observe the disconnect via context cancellation or its own
 					// write failure once it takes over.

--- a/backend/internal/service/gateway_service_tk_header_wait_keepalive_test.go
+++ b/backend/internal/service/gateway_service_tk_header_wait_keepalive_test.go
@@ -25,7 +25,7 @@ func newKeepaliveTestContext(t *testing.T) (*gin.Context, *httptest.ResponseReco
 func TestStartHeaderWaitKeepalive_EmitsPingsAfterInterval(t *testing.T) {
 	c, rec := newKeepaliveTestContext(t)
 
-	k := startHeaderWaitKeepalive(c, 20*time.Millisecond)
+	k := startHeaderWaitKeepalive(c, 20*time.Millisecond, anthropicSSEPingFrame)
 	if k == nil {
 		t.Fatal("expected non-nil keepalive handle for positive interval")
 	}
@@ -55,7 +55,7 @@ func TestStartHeaderWaitKeepalive_EmitsPingsAfterInterval(t *testing.T) {
 func TestStartHeaderWaitKeepalive_NoWriteBeforeInterval(t *testing.T) {
 	c, rec := newKeepaliveTestContext(t)
 
-	k := startHeaderWaitKeepalive(c, 500*time.Millisecond)
+	k := startHeaderWaitKeepalive(c, 500*time.Millisecond, anthropicSSEPingFrame)
 	if k == nil {
 		t.Fatal("expected non-nil keepalive handle")
 	}
@@ -73,7 +73,7 @@ func TestStartHeaderWaitKeepalive_NoWriteBeforeInterval(t *testing.T) {
 
 func TestStartHeaderWaitKeepalive_DisabledReturnsNil(t *testing.T) {
 	c, _ := newKeepaliveTestContext(t)
-	if k := startHeaderWaitKeepalive(c, 0); k != nil {
+	if k := startHeaderWaitKeepalive(c, 0, anthropicSSEPingFrame); k != nil {
 		t.Fatal("expected nil handle when interval <= 0")
 	}
 	// stop() on a nil handle must be a safe no-op.
@@ -87,5 +87,35 @@ func TestBeginHeaderWaitKeepalive_NonStreamReturnsNil(t *testing.T) {
 	// service is sufficient.
 	if k := (&GatewayService{}).beginHeaderWaitKeepalive(c, false); k != nil {
 		t.Fatal("expected nil handle for non-streaming request")
+	}
+	// Same contract for the OpenAI passthrough analogue.
+	if k := (&OpenAIGatewayService{}).beginHeaderWaitKeepalive(c, false); k != nil {
+		t.Fatal("expected nil handle for non-streaming OpenAI request")
+	}
+}
+
+// The OpenAI/Codex passthrough heartbeat must be a bare SSE comment (":\n\n"),
+// never a typed event frame — the strict Codex/Responses SDK rejects unknown
+// events. This pins the frame and the same pre-headers behavior.
+func TestStartHeaderWaitKeepalive_OpenAICommentFrame(t *testing.T) {
+	c, rec := newKeepaliveTestContext(t)
+	c.Request = httptest.NewRequest(http.MethodPost, "/v1/responses", nil)
+
+	k := startHeaderWaitKeepalive(c, 20*time.Millisecond, openaiSSECommentFrame)
+	if k == nil {
+		t.Fatal("expected non-nil keepalive handle for positive interval")
+	}
+	time.Sleep(90 * time.Millisecond)
+	k.stop()
+
+	body := rec.Body.String()
+	if !strings.Contains(body, ":\n\n") {
+		t.Fatalf("expected SSE comment keepalive, got %q", body)
+	}
+	if strings.Contains(body, "event:") {
+		t.Fatalf("OpenAI keepalive must not emit a typed event frame, got %q", body)
+	}
+	if ct := rec.Header().Get("Content-Type"); ct != "text/event-stream" {
+		t.Fatalf("expected SSE content-type committed before first comment, got %q", ct)
 	}
 }

--- a/backend/internal/service/openai_gateway_service.go
+++ b/backend/internal/service/openai_gateway_service.go
@@ -3444,8 +3444,15 @@ func (s *OpenAIGatewayService) forwardOpenAIPassthrough(
 		c.Set("openai_passthrough", true)
 	}
 
+	// 流式请求在等待上游响应头期间发送 SSE keepalive（comment 帧），防止空闲敏感的
+	// 中间层（Cloudflare Tunnel / Caddy / 客户端 SDK）在上游排队/首字节前断开连接
+	// （Wei-Shaw/sub2api#2121）。首个 ping 延迟一个 keepalive 间隔，故快速 failover
+	// 错误在写出任何字节前已返回，handler 的 c.Writer.Size() failover 门禁得以保留。
+	// 详见 gateway_service_tk_header_wait_keepalive.go。
+	hwka := s.beginHeaderWaitKeepalive(c, reqStream)
 	upstreamStart := time.Now()
 	resp, err := s.httpUpstream.Do(upstreamReq, proxyURL, account.ID, account.Concurrency)
+	hwka.stop()
 	SetOpsLatencyMs(c, OpsUpstreamLatencyMsKey, time.Since(upstreamStart).Milliseconds())
 	if err != nil {
 		safeErr := sanitizeUpstreamErrorMessage(err.Error())

--- a/scripts/sentinels/gateway-tk.json
+++ b/scripts/sentinels/gateway-tk.json
@@ -1980,11 +1980,13 @@
       "path": "backend/internal/service/gateway_service_tk_header_wait_keepalive.go",
       "must_contain": [
         "func (s *GatewayService) beginHeaderWaitKeepalive(c *gin.Context, reqStream bool) *headerWaitKeepalive",
-        "func startHeaderWaitKeepalive(c *gin.Context, interval time.Duration) *headerWaitKeepalive",
+        "func startHeaderWaitKeepalive(c *gin.Context, interval time.Duration, frame string) *headerWaitKeepalive",
         "func (k *headerWaitKeepalive) stop()",
-        "anthropicSSEPingFrame"
+        "anthropicSSEPingFrame",
+        "func (s *OpenAIGatewayService) beginHeaderWaitKeepalive(c *gin.Context, reqStream bool) *headerWaitKeepalive",
+        "openaiSSECommentFrame"
       ],
-      "rationale": "Header-wait SSE keepalive (Wei-Shaw/sub2api#2121): emits Anthropic-shaped ping frames to the downstream client while Forward blocks in DoWithTLS waiting for upstream response headers, so idle-sensitive intermediaries (Cloudflare Tunnel / Caddy / client SDKs) do not drop a slow request before the first upstream byte. This closes the gap left by the in-stream keepalive (which only fires AFTER the first SSE byte) and is amplified on the prod->edge mirror relay. The first ping is delayed one keepalive interval so fast failover-eligible errors return before any byte is written, preserving the handler's c.Writer.Written() failover gate. An upstream merge that overwrites this companion would silently re-open the slow-header connection-drop on the busiest path."
+      "rationale": "Header-wait SSE keepalive (Wei-Shaw/sub2api#2121): emits Anthropic-shaped ping frames to the downstream client while Forward blocks in DoWithTLS waiting for upstream response headers, so idle-sensitive intermediaries (Cloudflare Tunnel / Caddy / client SDKs) do not drop a slow request before the first upstream byte. This closes the gap left by the in-stream keepalive (which only fires AFTER the first SSE byte) and is amplified on the prod->edge mirror relay. The first ping is delayed one keepalive interval so fast failover-eligible errors return before any byte is written, preserving the handler's c.Writer.Written() failover gate. An upstream merge that overwrites this companion would silently re-open the slow-header connection-drop on the busiest path. Now parameterized by frame and used by BOTH the Anthropic Forward path (event:ping frame) and the OpenAI/Codex passthrough path (bare SSE comment frame) — one keepalive implementation, two platforms."
     },
     {
       "path": "backend/internal/service/gateway_service.go",
@@ -2002,6 +2004,14 @@
         "TestBeginHeaderWaitKeepalive_NonStreamReturnsNil"
       ],
       "rationale": "Focused regressions for the header-wait keepalive: (1) ping frames + SSE headers are emitted once one interval elapses on a slow upstream; (2) NOT a single byte is written before the interval, which is the failover-gate contract (a fast 429/503/5xx must still be able to failover via c.Writer.Written()==false); (3) non-streaming requests get a nil no-op. Dropping these lets an upstream merge silently revert the failover-safe delayed-ping behavior."
+    },
+    {
+      "path": "backend/internal/service/openai_gateway_service.go",
+      "must_contain": [
+        "hwka := s.beginHeaderWaitKeepalive(c, reqStream)",
+        "hwka.stop()"
+      ],
+      "rationale": "Header-wait SSE keepalive injection on the OpenAI/Codex passthrough streaming forward (forwardOpenAIPassthrough, around s.httpUpstream.Do). Same Wei-Shaw/sub2api#2121 idle-drop fix as the Anthropic Forward path, same failover-safe delayed-first-ping (the handler's failover gate compares c.Writer.Size() before/after forward). stop() must run the instant Do() returns. Catches an upstream merge that copies the old Do() shape back over the injection."
     }
   ]
 }


### PR DESCRIPTION
## Problem (Wei-Shaw/sub2api#2121, OpenAI/Codex half)

PR #656 added a header-wait SSE keepalive for the **Anthropic** streaming path. The **OpenAI/Codex passthrough** path has the *identical* gap: `forwardOpenAIPassthrough` blocks in `s.httpUpstream.Do(...)` waiting for the upstream response headers, and while the upstream queues / "thinks" before the first byte the downstream connection is idle. Idle-sensitive intermediaries (Cloudflare Tunnel, Caddy, client SDKs) then drop the connection. The existing OpenAI **in-stream** keepalive only fires *after* the first upstream byte — the header-wait window was uncovered.

## Fix — one implementation, two platforms

The existing `startHeaderWaitKeepalive` core is now **parameterized by the emitted frame** (no second implementation):
- Anthropic keeps `event: ping\ndata: {"type":"ping"}\n\n`.
- OpenAI/Codex uses a **bare SSE comment** `:\n\n` — byte-identical to OpenAI's in-stream keepalive. This matters: the strict Codex/Responses SDK rejects unknown typed event frames, so a comment is the only safe heartbeat.

`(s *OpenAIGatewayService) beginHeaderWaitKeepalive` passes the comment frame; the injection is a thin begin/stop around the `Do()` call.

### Failover-safe by the same construction
First ping is delayed one full keepalive interval (`gateway.stream_keepalive_interval`, default 10s). The OpenAI handler's failover gate compares `c.Writer.Size()` before/after forward, so a fast failover-eligible error (429/503/5xx) returns **before any byte is written** → transparent failover preserved. Reuses the existing config knob (`0` disables).

## Tests
`go test -tags=unit ./...` green. New regression pins the OpenAI comment frame and asserts **no typed event is ever emitted**; existing anthropic regressions updated for the new signature; both `beginHeaderWaitKeepalive` non-stream no-ops covered.

## Scope / discipline
- Backend-only (`no-web-impact`); guarded upstream-file touch (`upstream-touch-guarded`).
- Sentinels: updated `startHeaderWaitKeepalive` signature anchor; added the OpenAI begin func + comment-frame const + the OpenAI injection point.
- `Refs Wei-Shaw/sub2api#2121` (enhancement, no fix-ledger trailer).
- Bridge path (newapi adaptor) intentionally **not** touched — `adaptor.DoResponse` is upstream new-api territory.

## Checklist
- [x] `go test -tags=unit ./...`
- [x] `golangci-lint run ./internal/service/` — 0 issues
- [x] `go build ./...`
- [x] `scripts/preflight.sh` PASS (full sub2api suite)
- [x] No frontend/schema/ent changes; no upstream symbol deletions

🤖 Generated with [Claude Code](https://claude.com/claude-code)