### PR TITLE
feat(ops): edge-health-watch — Feishu alert when an edge dies

### DIFF
--- a/.github/workflows/edge-health-watch.yml
+++ b/.github/workflows/edge-health-watch.yml
@@ -94,7 +94,7 @@ jobs:
           set -uo pipefail
           mkdir -p .edge-health-state
           bash ops/observability/scan-edge-health.sh --with-prod --since "$SINCE" \
-            --timeout-seconds "$SCAN_PROBE_TIMEOUT" --json > verdicts.jsonl 2> scan.stderr || true
+            --timeout-seconds "$SCAN_PROBE_TIMEOUT" --json > verdicts.jsonl 2> scan.stderr || true  # preflight-allow: swallow — exit code ignored on purpose; the verdict-file emptiness check below is the gate
           echo "---- verdicts ----"; cat verdicts.jsonl || true  # preflight-allow: swallow — diagnostic echo
           echo "---- scan stderr (tail) ----"; tail -20 scan.stderr || true  # preflight-allow: swallow — diagnostic echo
           # Single decision: a non-empty verdict file is the only thing that lets us

--- a/.github/workflows/edge-health-watch.yml
+++ b/.github/workflows/edge-health-watch.yml
@@ -45,12 +45,16 @@ concurrency:
 jobs:
   watch:
     runs-on: ubuntu-latest
-    timeout-minutes: 12
+    # >= worst-case scan (10 targets x SCAN_PROBE_TIMEOUT) + setup. The scan caps each
+    # probe at SCAN_PROBE_TIMEOUT below so a fully-degraded SSM cycle cannot run past
+    # this and get the job killed mid-scan (which would drop the alert + state save).
+    timeout-minutes: 15
     env:
       OIDC_ROLE_ARN: ${{ vars.AWS_OIDC_ROLE_ARN }}
       AWS_REGION: ${{ vars.AWS_REGION || 'us-east-1' }}
       SINCE: ${{ inputs.since || '2h' }}
       DRY_RUN: ${{ inputs.dry_run || 'false' }}
+      SCAN_PROBE_TIMEOUT: "60" # per-edge SSM timeout; 10 targets x 60s = 600s < job timeout
       FEISHU_WEBHOOK_URL: ${{ secrets.TK_FEISHU_WEBHOOK_URL }}
       FEISHU_SIGNING_SECRET: ${{ secrets.TK_FEISHU_SIGNING_SECRET }}
     steps:
@@ -76,10 +80,6 @@ jobs:
           restore-keys: |
             edge-health-watch-state-
 
-      - name: Install boto3 (run-probe SSM resolution)
-        if: steps.precheck.outputs.skip == 'false'
-        run: pip install --quiet boto3
-
       - name: Configure AWS credentials via OIDC
         if: steps.precheck.outputs.skip == 'false'
         uses: aws-actions/configure-aws-credentials@v6
@@ -93,17 +93,16 @@ jobs:
         run: |
           set -uo pipefail
           mkdir -p .edge-health-state
-          if bash ops/observability/scan-edge-health.sh --with-prod --since "$SINCE" --json \
-               > verdicts.jsonl 2> scan.stderr; then
-            echo "scan_ok=true" >> "$GITHUB_OUTPUT"
-          else
-            echo "scan_ok=false" >> "$GITHUB_OUTPUT"
-          fi
+          bash ops/observability/scan-edge-health.sh --with-prod --since "$SINCE" \
+            --timeout-seconds "$SCAN_PROBE_TIMEOUT" --json > verdicts.jsonl 2> scan.stderr || true
           echo "---- verdicts ----"; cat verdicts.jsonl || true
           echo "---- scan stderr (tail) ----"; tail -20 scan.stderr || true
-          # A totally empty scan (all targets unreachable / scan crashed) must NOT be
-          # read as "fleet healthy" — guard against a false all-clear.
-          if [ ! -s verdicts.jsonl ]; then
+          # Single decision: a non-empty verdict file is the only thing that lets us
+          # judge + alert. An empty file (scan crashed / all targets unreachable) must
+          # NOT be read as "fleet healthy" — guard against a false all-clear.
+          if [ -s verdicts.jsonl ]; then
+            echo "scan_ok=true" >> "$GITHUB_OUTPUT"
+          else
             echo "::warning::scan produced no verdicts — skipping alert decision this cycle."
             echo "scan_ok=false" >> "$GITHUB_OUTPUT"
           fi

--- a/.github/workflows/edge-health-watch.yml
+++ b/.github/workflows/edge-health-watch.yml
@@ -1,0 +1,163 @@
+name: Edge Health Watch
+
+# Frequent, read-only fleet edge-health watch that turns scan-edge-health.sh (#640)
+# from "someone has to remember to run it" into "Feishu shouts the moment an edge
+# dies". Born from the 2026-06-07 incident: 4 edges went to 0 schedulable accounts
+# and the one healthy multi-account edge buckled under concentrated failover load;
+# ~3445 clients ate 429s across two spikes — with ZERO alerts, because the only
+# truth signal was a manual scan.
+#
+# Read-only: GHA -> AWS STS (OIDC) -> SSM `docker logs` + `psql SELECT` via
+# scan-edge-health.sh. Never deploys, writes config, edits secrets, or mutates AWS.
+# The ONLY outbound side effect is a Feishu text post, and only when the actionable
+# (down/degraded/unreachable) edge set CHANGES vs the previous run (state-diff dedup
+# via the Actions cache) — so a multi-hour incident does not re-spam, and a recovery
+# posts a green all-clear.
+#
+# Cadence caveat: GitHub scheduled workflows are best-effort and can run late or skip
+# under load — this is detection-latency insurance, not a hard SLA. If a tighter SLA
+# is needed later, move the loop to the in-cluster reconciler.
+
+on:
+  schedule:
+    - cron: "7,22,37,52 * * * *" # ~every 15 min, off the :00 mark (GHA best-effort)
+  workflow_dispatch:
+    inputs:
+      dry_run:
+        description: "Compute + print the alert but do NOT post to Feishu"
+        required: false
+        default: "false"
+        type: choice
+        options: ["false", "true"]
+      since:
+        description: "Traffic window for the scan (docker logs --since)"
+        required: false
+        default: "2h"
+
+permissions:
+  contents: read
+  id-token: write
+
+concurrency:
+  group: edge-health-watch
+  cancel-in-progress: false
+
+jobs:
+  watch:
+    runs-on: ubuntu-latest
+    timeout-minutes: 12
+    env:
+      OIDC_ROLE_ARN: ${{ vars.AWS_OIDC_ROLE_ARN }}
+      AWS_REGION: ${{ vars.AWS_REGION || 'us-east-1' }}
+      SINCE: ${{ inputs.since || '2h' }}
+      DRY_RUN: ${{ inputs.dry_run || 'false' }}
+      FEISHU_WEBHOOK_URL: ${{ secrets.TK_FEISHU_WEBHOOK_URL }}
+      FEISHU_SIGNING_SECRET: ${{ secrets.TK_FEISHU_SIGNING_SECRET }}
+    steps:
+      - uses: actions/checkout@v6
+
+      - name: Precheck OIDC role
+        id: precheck
+        run: |
+          set -euo pipefail
+          if [ -z "${OIDC_ROLE_ARN:-}" ]; then
+            echo "::warning::AWS_OIDC_ROLE_ARN repo variable is empty — edge-health-watch cannot reach SSM; skipping."
+            echo "skip=true" >> "$GITHUB_OUTPUT"
+          else
+            echo "skip=false" >> "$GITHUB_OUTPUT"
+          fi
+
+      - name: Restore previous state key
+        if: steps.precheck.outputs.skip == 'false'
+        uses: actions/cache/restore@v4
+        with:
+          path: .edge-health-state
+          key: edge-health-watch-state-${{ github.run_id }}
+          restore-keys: |
+            edge-health-watch-state-
+
+      - name: Install boto3 (run-probe SSM resolution)
+        if: steps.precheck.outputs.skip == 'false'
+        run: pip install --quiet boto3
+
+      - name: Configure AWS credentials via OIDC
+        if: steps.precheck.outputs.skip == 'false'
+        uses: aws-actions/configure-aws-credentials@v6
+        with:
+          role-to-assume: ${{ env.OIDC_ROLE_ARN }}
+          aws-region: ${{ env.AWS_REGION }}
+
+      - name: Scan fleet edge health (read-only SSM)
+        if: steps.precheck.outputs.skip == 'false'
+        id: scan
+        run: |
+          set -uo pipefail
+          mkdir -p .edge-health-state
+          if bash ops/observability/scan-edge-health.sh --with-prod --since "$SINCE" --json \
+               > verdicts.jsonl 2> scan.stderr; then
+            echo "scan_ok=true" >> "$GITHUB_OUTPUT"
+          else
+            echo "scan_ok=false" >> "$GITHUB_OUTPUT"
+          fi
+          echo "---- verdicts ----"; cat verdicts.jsonl || true
+          echo "---- scan stderr (tail) ----"; tail -20 scan.stderr || true
+          # A totally empty scan (all targets unreachable / scan crashed) must NOT be
+          # read as "fleet healthy" — guard against a false all-clear.
+          if [ ! -s verdicts.jsonl ]; then
+            echo "::warning::scan produced no verdicts — skipping alert decision this cycle."
+            echo "scan_ok=false" >> "$GITHUB_OUTPUT"
+          fi
+
+      - name: Decide + post alert
+        if: steps.precheck.outputs.skip == 'false' && steps.scan.outputs.scan_ok == 'true'
+        run: |
+          set -euo pipefail
+          KEYFILE=.edge-health-state/key
+          python3 ops/observability/edge-health-alert.py --window "$SINCE" \
+            --prev-key-file "$KEYFILE" < verdicts.jsonl > decision.json
+          cat decision.json
+          # Persist the new key for the next run's state-diff (saved by the cache step).
+          python3 -c "import json;open('.edge-health-state/key','w').write(json.load(open('decision.json'))['key'])"
+
+          SHOULD=$(python3 -c "import json;print(json.load(open('decision.json'))['should_alert'])")
+          if [ "$SHOULD" != "True" ]; then
+            echo "no actionable-set change since last run — not posting."
+            exit 0
+          fi
+          if [ "$DRY_RUN" = "true" ]; then
+            echo "DRY_RUN=true — would post the following to Feishu:"
+            python3 -c "import json;print(json.load(open('decision.json'))['message'])"
+            exit 0
+          fi
+          if [ -z "${FEISHU_WEBHOOK_URL:-}" ] || [ -z "${FEISHU_SIGNING_SECRET:-}" ]; then
+            echo "::warning::TK_FEISHU_WEBHOOK_URL / TK_FEISHU_SIGNING_SECRET not set — alert computed but not posted."
+            python3 -c "import json;print(json.load(open('decision.json'))['message'])"
+            exit 0
+          fi
+          python3 - <<'PY'
+          import base64, hashlib, hmac, json, os, time, urllib.request
+          d = json.load(open("decision.json"))
+          ts = str(int(time.time()))
+          secret = os.environ["FEISHU_SIGNING_SECRET"]
+          string_to_sign = f"{ts}\n{secret}"
+          sign = base64.b64encode(
+              hmac.new(string_to_sign.encode("utf-8"), digestmod=hashlib.sha256).digest()
+          ).decode("utf-8")
+          body = json.dumps({
+              "timestamp": ts, "sign": sign,
+              "msg_type": "text", "content": {"text": d["message"]},
+          }).encode("utf-8")
+          req = urllib.request.Request(
+              os.environ["FEISHU_WEBHOOK_URL"], data=body,
+              headers={"Content-Type": "application/json"},
+          )
+          with urllib.request.urlopen(req, timeout=15) as resp:
+              print("feishu status", resp.status, resp.read().decode("utf-8")[:300])
+          PY
+
+      - name: Save state key
+        if: steps.precheck.outputs.skip == 'false' && steps.scan.outputs.scan_ok == 'true'
+        uses: actions/cache/save@v4
+        with:
+          path: .edge-health-state
+          key: edge-health-watch-state-${{ github.run_id }}

--- a/.github/workflows/edge-health-watch.yml
+++ b/.github/workflows/edge-health-watch.yml
@@ -95,8 +95,8 @@ jobs:
           mkdir -p .edge-health-state
           bash ops/observability/scan-edge-health.sh --with-prod --since "$SINCE" \
             --timeout-seconds "$SCAN_PROBE_TIMEOUT" --json > verdicts.jsonl 2> scan.stderr || true
-          echo "---- verdicts ----"; cat verdicts.jsonl || true
-          echo "---- scan stderr (tail) ----"; tail -20 scan.stderr || true
+          echo "---- verdicts ----"; cat verdicts.jsonl || true  # preflight-allow: swallow — diagnostic echo
+          echo "---- scan stderr (tail) ----"; tail -20 scan.stderr || true  # preflight-allow: swallow — diagnostic echo
           # Single decision: a non-empty verdict file is the only thing that lets us
           # judge + alert. An empty file (scan crashed / all targets unreachable) must
           # NOT be read as "fleet healthy" — guard against a false all-clear.

--- a/ops/observability/edge-health-alert.py
+++ b/ops/observability/edge-health-alert.py
@@ -1,0 +1,274 @@
+#!/usr/bin/env python3
+"""edge-health-alert.py — turn scan-edge-health.sh --json output into an alert
+decision + a Feishu message, with cross-run dedup via a state key.
+
+This is the *decision* half of the edge-health-watch loop; the *transport* halves
+are scan-edge-health.sh --json (read-only SSM fleet sweep) and the
+.github/workflows/edge-health-watch.yml step that signs + POSTs to Feishu. Keeping
+the decision here (pure Python, no HTTP/AWS) makes it unit-testable with fixtures
+(--selftest) and registerable in preflight, mirroring data_layer_capacity_verdict.py
+and edge_health_verdict.py.
+
+WHY (2026-06-07 incident): 4 edges went to 0 schedulable accounts and the one healthy
+multi-account edge (us5) buckled under concentrated failover load; ~3445 clients ate
+429s across two spikes — and ZERO alerts fired, because the truth tool
+(scan-edge-health.sh, #640) only runs when a human remembers to run it. This turns
+"someone has to go look" into "Feishu shouts the moment an edge dies".
+
+Trigger model: the ACTIONABLE set is the edges whose verdict is down / degraded /
+unreachable / parse-error (a `thin` single-account edge is shown for context but is
+chronic for most of the fleet, so it does NOT trigger on its own). The state key is a
+stable digest of that set; the workflow alerts ONLY when the key changes vs the
+previous run — new breakage, escalation, OR full recovery — so a multi-hour incident
+does not re-spam every cycle, and a recovery posts a green all-clear.
+
+Input (stdin): one verdict JSON object per line (scan-edge-health.sh --json).
+Args:
+  --prev-key-file <path>   file holding the previous run's state key (may be missing/empty)
+  --window <str>           traffic window label to show in the message (default "2h")
+  --selftest               run fixtures (exit 1 on failure)
+
+Output (stdout): one JSON object:
+  {"key","actionable_count","changed","should_alert","severity","message"}
+The workflow writes `key` back to the cache, and POSTs `message` to Feishu iff
+`should_alert` is true.
+"""
+from __future__ import annotations
+
+import argparse
+import json
+import sys
+
+ACTIONABLE = ("down", "degraded", "unreachable", "parse-error")
+_SEV_ORDER = {"down": 0, "unreachable": 0, "parse-error": 0, "degraded": 1}
+
+
+def _num(v, default=0):
+    try:
+        return int(v)
+    except (TypeError, ValueError):
+        return default
+
+
+def build_decision(rows: list, prev_key: str, window: str) -> dict:
+    """Pure: verdict rows + previous state key -> alert decision + message."""
+    by_verdict: dict = {}
+    for r in rows:
+        by_verdict.setdefault(r.get("verdict"), []).append(r)
+
+    actionable = [r for r in rows if r.get("verdict") in ACTIONABLE]
+    # Stable key: sorted "verdict:edge" of the actionable set. Same incident => same
+    # key => no re-alert; any change (new edge, recovery) flips it.
+    key_parts = sorted(f"{r.get('verdict')}:{r.get('edge')}" for r in actionable)
+    key = "|".join(key_parts)  # "" when the fleet is clean
+
+    changed = key != (prev_key or "")
+    should_alert = changed  # breakage, escalation, AND recovery all flip the key
+
+    thin = sorted(r.get("edge") for r in by_verdict.get("thin", []))
+    healthy = sorted(
+        r.get("edge") for r in rows if r.get("verdict") in ("healthy", "idle")
+    )
+
+    if not actionable:
+        severity = "recovery" if (prev_key or "") else "ok"
+    elif any(r.get("verdict") in ("down", "unreachable", "parse-error") for r in actionable):
+        severity = "critical"
+    else:
+        severity = "warning"
+
+    message = _format_message(actionable, thin, healthy, window, severity)
+    return {
+        "key": key,
+        "actionable_count": len(actionable),
+        "changed": changed,
+        "should_alert": should_alert,
+        "severity": severity,
+        "message": message,
+    }
+
+
+def _format_message(actionable: list, thin: list, healthy: list, window: str, severity: str) -> str:
+    if not actionable:
+        head = "✅ TokenKey Edge Health — all edges recovered (no down/degraded)"
+    else:
+        head = f"🔴 TokenKey Edge Health — {len(actionable)} edge(s) need action"
+    lines = [head, ""]
+
+    grouped: dict = {}
+    for r in sorted(actionable, key=lambda r: (_SEV_ORDER.get(r.get("verdict"), 9), r.get("edge") or "")):
+        grouped.setdefault(r.get("verdict"), []).append(r)
+
+    for verdict in ("down", "unreachable", "parse-error", "degraded"):
+        rs = grouped.get(verdict)
+        if not rs:
+            continue
+        lines.append(f"{verdict.upper()}:")
+        for r in rs:
+            if verdict in ("unreachable", "parse-error"):
+                lines.append(f"  • {r.get('edge')}")
+            else:
+                sched = _num(r.get("schedulable_accounts"))
+                served = _num(r.get("served_200"))
+                noavail = _num(r.get("no_available_429"))
+                ratio = r.get("served_ratio")
+                wait = _num(r.get("wait_timeout"))
+                tail = f"sched={sched} served200={served} noavail429={noavail}"
+                if ratio is not None:
+                    tail += f" ratio={ratio}"
+                if wait:
+                    tail += f" wait_to={wait}"
+                lines.append(f"  • {r.get('edge')}  {tail}")
+
+    if thin:
+        lines.append("")
+        lines.append(f"thin/SPOF (single account): {', '.join(thin)}")
+    if healthy:
+        lines.append(f"healthy: {', '.join(healthy)}")
+    lines.append("")
+    lines.append(f"window={window} • detail: ops/observability/scan-edge-health.sh --with-prod")
+    return "\n".join(lines)
+
+
+# --- selftest fixtures: the 2026-06-07 incident shapes + dedup behavior ----------
+def _rows(*specs):
+    out = []
+    for s in specs:
+        out.append(s)
+    return out
+
+
+_SELFTEST = []
+
+
+def _case(name, rows, prev_key, expect):
+    _SELFTEST.append((name, rows, prev_key, expect))
+
+
+_case(
+    "incident: 3 down + 1 degraded => critical, alert from clean",
+    [
+        {"edge": "uk2", "verdict": "down", "schedulable_accounts": 0, "served_200": 712, "no_available_429": 0},
+        {"edge": "uk3", "verdict": "down", "schedulable_accounts": 0, "served_200": 882, "no_available_429": 0},
+        {"edge": "us3", "verdict": "down", "schedulable_accounts": 0, "served_200": 170, "no_available_429": 0},
+        {"edge": "us5", "verdict": "degraded", "schedulable_accounts": 3, "served_200": 11102, "no_available_429": 4841, "served_ratio": 0.696, "wait_timeout": 5656},
+        {"edge": "us2", "verdict": "thin", "schedulable_accounts": 1},
+        {"edge": "prod", "verdict": "healthy", "schedulable_accounts": 14},
+    ],
+    "",
+    {"should_alert": True, "severity": "critical", "actionable_count": 4},
+)
+_case(
+    "same incident set unchanged => NO re-alert",
+    [
+        {"edge": "uk2", "verdict": "down"},
+        {"edge": "uk3", "verdict": "down"},
+        {"edge": "us3", "verdict": "down"},
+        {"edge": "us5", "verdict": "degraded"},
+    ],
+    "degraded:us5|down:uk2|down:uk3|down:us3",
+    {"should_alert": False, "severity": "critical"},
+)
+_case(
+    "escalation: a new edge goes down => alert (key changed)",
+    [
+        {"edge": "uk2", "verdict": "down"},
+        {"edge": "uk3", "verdict": "down"},
+        {"edge": "us3", "verdict": "down"},
+        {"edge": "us6", "verdict": "down"},
+        {"edge": "us5", "verdict": "degraded"},
+    ],
+    "degraded:us5|down:uk2|down:uk3|down:us3",
+    {"should_alert": True, "severity": "critical"},
+)
+_case(
+    "full recovery => green all-clear alert",
+    [
+        {"edge": "uk2", "verdict": "healthy", "schedulable_accounts": 2},
+        {"edge": "us5", "verdict": "healthy", "schedulable_accounts": 3},
+    ],
+    "degraded:us5|down:uk2|down:uk3|down:us3",
+    {"should_alert": True, "severity": "recovery", "actionable_count": 0},
+)
+_case(
+    "steady healthy => no alert, no key",
+    [
+        {"edge": "uk2", "verdict": "healthy"},
+        {"edge": "us5", "verdict": "healthy"},
+    ],
+    "",
+    {"should_alert": False, "severity": "ok", "actionable_count": 0},
+)
+_case(
+    "chronic thin alone does NOT trigger",
+    [
+        {"edge": "uk1", "verdict": "thin", "schedulable_accounts": 1},
+        {"edge": "us2", "verdict": "thin", "schedulable_accounts": 1},
+        {"edge": "prod", "verdict": "healthy"},
+    ],
+    "",
+    {"should_alert": False, "actionable_count": 0},
+)
+_case(
+    "unreachable edge => critical actionable",
+    [
+        {"edge": "fra1", "verdict": "unreachable"},
+        {"edge": "prod", "verdict": "healthy"},
+    ],
+    "",
+    {"should_alert": True, "severity": "critical", "actionable_count": 1},
+)
+
+
+def _run_selftest() -> int:
+    failures = 0
+    for name, rows, prev_key, expect in _SELFTEST:
+        got = build_decision(rows, prev_key, "2h")
+        for k, v in expect.items():
+            if got.get(k) != v:
+                failures += 1
+                print(f"  [FAIL] {name}: {k} expected={v} got={got.get(k)}", file=sys.stderr)
+                break
+        else:
+            print(f"  [ok] {name}", file=sys.stderr)
+    if failures:
+        print(f"edge-health-alert selftest: {failures} FAILED", file=sys.stderr)
+        return 1
+    print(f"edge-health-alert selftest: all {len(_SELFTEST)} cases passed", file=sys.stderr)
+    return 0
+
+
+def main() -> int:
+    ap = argparse.ArgumentParser(description="Edge-health alert decision from scan-edge-health.sh --json.")
+    ap.add_argument("--prev-key-file", default=None)
+    ap.add_argument("--window", default="2h")
+    ap.add_argument("--selftest", action="store_true")
+    args = ap.parse_args()
+
+    if args.selftest:
+        return _run_selftest()
+
+    prev_key = ""
+    if args.prev_key_file:
+        try:
+            with open(args.prev_key_file, encoding="utf-8") as fh:
+                prev_key = fh.read().strip()
+        except FileNotFoundError:
+            prev_key = ""
+
+    rows = []
+    for line in sys.stdin:
+        line = line.strip()
+        if not line:
+            continue
+        try:
+            rows.append(json.loads(line))
+        except json.JSONDecodeError:
+            continue
+
+    print(json.dumps(build_decision(rows, prev_key, args.window), ensure_ascii=False))
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/ops/observability/edge-health-alert.py
+++ b/ops/observability/edge-health-alert.py
@@ -52,10 +52,6 @@ def _num(v, default=0):
 
 def build_decision(rows: list, prev_key: str, window: str) -> dict:
     """Pure: verdict rows + previous state key -> alert decision + message."""
-    by_verdict: dict = {}
-    for r in rows:
-        by_verdict.setdefault(r.get("verdict"), []).append(r)
-
     actionable = [r for r in rows if r.get("verdict") in ACTIONABLE]
     # Stable key: sorted "verdict:edge" of the actionable set. Same incident => same
     # key => no re-alert; any change (new edge, recovery) flips it.
@@ -65,7 +61,9 @@ def build_decision(rows: list, prev_key: str, window: str) -> dict:
     changed = key != (prev_key or "")
     should_alert = changed  # breakage, escalation, AND recovery all flip the key
 
-    thin = sorted(r.get("edge") for r in by_verdict.get("thin", []))
+    # `idle-thin` (a single-account edge with no traffic) is a SPOF too — surface it
+    # in the thin context line, not silently dropped.
+    thin = sorted(r.get("edge") for r in rows if r.get("verdict") in ("thin", "idle-thin"))
     healthy = sorted(
         r.get("edge") for r in rows if r.get("verdict") in ("healthy", "idle")
     )
@@ -131,13 +129,6 @@ def _format_message(actionable: list, thin: list, healthy: list, window: str, se
 
 
 # --- selftest fixtures: the 2026-06-07 incident shapes + dedup behavior ----------
-def _rows(*specs):
-    out = []
-    for s in specs:
-        out.append(s)
-    return out
-
-
 _SELFTEST = []
 
 

--- a/ops/observability/scan-edge-health.sh
+++ b/ops/observability/scan-edge-health.sh
@@ -35,12 +35,14 @@ SINCE="2h"
 WITH_PROD=0
 EDGES_CSV=""
 JSON=0
+PROBE_TIMEOUT=150 # per-edge SSM timeout (s); the watch lowers it to bound total wall-clock
 while [ $# -gt 0 ]; do
   case "$1" in
     --since) SINCE="$2"; shift 2 ;;
     --with-prod) WITH_PROD=1; shift ;;
     --edges) EDGES_CSV="$2"; shift 2 ;;
     --json) JSON=1; shift ;;
+    --timeout-seconds) PROBE_TIMEOUT="$2"; shift 2 ;;
     -h|--help) sed -n '2,30p' "$0" | sed 's/^# \{0,1\}//'; exit 0 ;;
     *) echo "scan-edge-health: unknown arg '$1'" >&2; exit 1 ;;
   esac
@@ -83,7 +85,7 @@ for tgt in "${TARGETS[@]}"; do
   echo "  probing $tgt ..." >&2
   if out="$(bash "$RUN_PROBE" --target "$tgt" --script "$PROBE" \
               --env "PLATFORM=anthropic" --env "SINCE=$SINCE" \
-              --timeout-seconds 150 2>/dev/null)"; then
+              --timeout-seconds "$PROBE_TIMEOUT" 2>/dev/null)"; then
     verdict_json="$(printf '%s\n' "$out" | python3 "$VERDICT" --label "$label" 2>/dev/null)"
     if [ -n "$verdict_json" ]; then
       printf '%s\n' "$verdict_json" >> "$RESULTS"

--- a/ops/observability/scan-edge-health.sh
+++ b/ops/observability/scan-edge-health.sh
@@ -46,17 +46,30 @@ done
 
 # Resolve the target list. Default = the deployable-edge matrix (EC2 ∪ Lightsail,
 # same source the deploy workflows use). Subset via --edges.
+EDGES=()
 if [ -n "$EDGES_CSV" ]; then
   IFS=',' read -r -a EDGES <<< "$EDGES_CSV"
 else
-  mapfile -t EDGES < <(python3 "$RESOLVE" --list-deployable)
+  # macOS default bash is 3.2 and has no `mapfile`; read line-by-line so the
+  # default (no --edges) invocation works for operators on a Mac, not just the
+  # --edges path.
+  while IFS= read -r _edge; do
+    [ -n "$_edge" ] && EDGES+=("$_edge")
+  done < <(python3 "$RESOLVE" --list-deployable)
 fi
 
 TARGETS=()
-for e in "${EDGES[@]}"; do
+# "${EDGES[@]+...}" guards expanding an empty array under `set -u` on bash 3.2
+# (newer bash treats empty-array expansion as unset; the +-form is portable).
+for e in "${EDGES[@]+"${EDGES[@]}"}"; do
   [ -n "$e" ] && TARGETS+=("edge:$e")
 done
 [ "$WITH_PROD" = "1" ] && TARGETS+=("prod")
+
+if [ "${#TARGETS[@]}" -eq 0 ]; then
+  echo "scan-edge-health: no targets resolved (check --edges / resolve-edge-target.py --list-deployable)" >&2
+  exit 1
+fi
 
 echo "scan-edge-health: ${#TARGETS[@]} targets, traffic window since=$SINCE" >&2
 

--- a/ops/observability/scan-edge-health.sh
+++ b/ops/observability/scan-edge-health.sh
@@ -34,11 +34,13 @@ RESOLVE="$REPO_ROOT/deploy/aws/stage0/resolve-edge-target.py"
 SINCE="2h"
 WITH_PROD=0
 EDGES_CSV=""
+JSON=0
 while [ $# -gt 0 ]; do
   case "$1" in
     --since) SINCE="$2"; shift 2 ;;
     --with-prod) WITH_PROD=1; shift ;;
     --edges) EDGES_CSV="$2"; shift 2 ;;
+    --json) JSON=1; shift ;;
     -h|--help) sed -n '2,30p' "$0" | sed 's/^# \{0,1\}//'; exit 0 ;;
     *) echo "scan-edge-health: unknown arg '$1'" >&2; exit 1 ;;
   esac
@@ -92,6 +94,13 @@ for tgt in "${TARGETS[@]}"; do
     printf '{"edge":"%s","verdict":"unreachable"}\n' "$label" >> "$RESULTS"
   fi
 done
+
+# --json: emit the per-edge verdict JSON lines verbatim (machine-readable, for the
+# edge-health-watch workflow / edge-health-alert.py) and skip the human table.
+if [ "$JSON" = "1" ]; then
+  cat "$RESULTS"
+  exit 0
+fi
 
 echo
 echo "=== edge health (truth from each edge's own access log, NOT prod upstream-429) ==="

--- a/scripts/preflight.sh
+++ b/scripts/preflight.sh
@@ -823,6 +823,26 @@ else
     echo "  ok: edge-health verdict healthy/thin/degraded/down fixtures pass"
 fi
 
+# ---- sub2api: edge-health alert decision selftest --------------------------
+# The edge-health-watch alert logic (actionable-set + state-diff dedup + Feishu
+# message) lives in edge-health-alert.py and is the decision half of
+# .github/workflows/edge-health-watch.yml. Its fixtures pin the 2026-06-07 incident
+# shapes + the dedup behavior (no re-spam on a steady incident, alert on escalation /
+# recovery, chronic thin does not trigger), so a logic regression fails preflight
+# instead of silently re-spamming or going silent. Read-only, no AWS / no HTTP.
+echo ""
+echo "=== sub2api: edge-health alert decision selftest ==="
+if ! command -v python3 >/dev/null 2>&1; then
+    echo "  FAIL: python3 not on PATH (required for edge-health alert selftest)"
+    errors=$((errors + 1))
+elif ! python3 ./ops/observability/edge-health-alert.py --selftest >/dev/null 2>&1; then
+    echo "  FAIL: edge-health alert decision selftest"
+    echo "        — run: python3 ops/observability/edge-health-alert.py --selftest"
+    errors=$((errors + 1))
+else
+    echo "  ok: edge-health alert decision/dedup fixtures pass"
+fi
+
 # ---- sub2api: pgdump timer cadence parity ----------------------------------
 # The tokenkey-pgdump systemd timer is defined in TWO places that must stay in
 # sync: the first-boot copy in stage0-ec2-bootstrap.sh and the live-host refresh


### PR DESCRIPTION
## Why

The **2026-06-07 incident**: 4 edges went to 0 schedulable accounts and the one healthy multi-account edge (us5) buckled under concentrated failover load; **~3445 clients ate 429s** across two spikes (09:53–10:22, 14:53–15:10 UTC) — with **ZERO alerts**. We only knew because someone ran the scan tool by hand. This is the "make the truth tool actually shout" half of the edge-health work (#640 gave the truth; this makes it proactive).

## What (two items the operator asked for)

**1. Fix scan-edge-health bash 3.2 crash** — the default (no `--edges`) path used `mapfile`, which doesn't exist on the macOS default shell, so `scan-edge-health.sh` crashed exactly when an operator reaches for it. Replaced with a portable `while read` loop + empty-array guards. (The earlier live test only hit the `--edges` path — verify-the-executed-artifact.)

**2. Wire scan → Feishu alert** (three thin, testable parts):
- `scan-edge-health.sh --json` — emit per-edge verdict JSON instead of the table.
- `edge-health-alert.py` — **pure decision**: actionable set (down/degraded/unreachable; chronic `thin` is context, not a trigger) + stable state key + **state-diff dedup** + the Feishu message. `--selftest` pins the incident shapes and dedup behavior (no re-spam on a steady incident, alert on escalation **and** on recovery). Registered in preflight.
- `.github/workflows/edge-health-watch.yml` — read-only OIDC→SSM fleet scan ~every 15 min (+ `workflow_dispatch` with `dry_run`); posts to Feishu (`TK_FEISHU_*`, HMAC sign) **only when the actionable set changes** vs the previous run (Actions-cache state diff). Guards a false all-clear if the scan returns no verdicts.

## Verification

- `edge-health-alert.py --selftest` → **7/7**; `edge_health_verdict.py --selftest` still 12/12.
- Live `scan-edge-health.sh --with-prod --json | edge-health-alert.py` against the fleet → correct `severity=critical`, 3 edges down (uk2/uk3/us3), accurate message.
- `scan-edge-health.sh --with-prod` now prints the full table on macOS default bash.
- Full `scripts/preflight.sh` (incl. all sub2api checks) **PASS**; `check_workflow_yaml` clean (15 workflows).
- I will dispatch the workflow with `dry_run=true` on this branch to validate the OIDC→SSM→scan path in real CI without posting.

## Scope / safety

Read-only throughout (docker logs + psql SELECT); the **only** outbound side effect is a Feishu text post on state change. GHA cron is best-effort — detection-latency insurance, not a hard SLA (a tighter SLA would move the loop into the in-cluster reconciler; noted for later).

This does **not** cure the disease (account supply erosion) — it compresses *detection* from "hours / by luck" to "~1 cycle", shrinking the blast radius of every future account death.

🤖 Generated with [Claude Code](https://claude.com/claude-code)