### PR TITLE
fix(ops): edge-health-watch dry-run must not advance dedup state

### DIFF
--- a/.github/workflows/edge-health-watch.yml
+++ b/.github/workflows/edge-health-watch.yml
@@ -115,8 +115,14 @@ jobs:
           python3 ops/observability/edge-health-alert.py --window "$SINCE" \
             --prev-key-file "$KEYFILE" < verdicts.jsonl > decision.json
           cat decision.json
-          # Persist the new key for the next run's state-diff (saved by the cache step).
-          python3 -c "import json;open('.edge-health-state/key','w').write(json.load(open('decision.json'))['key'])"
+          # Persist the new key for the next run's state-diff — but only on a real run.
+          # A dry-run must be side-effect-free: it must NOT advance the dedup state, or
+          # testing on a live incident would pre-ack the current bad set and suppress the
+          # next real alert. The cache "Save state key" step is also gated on !dry_run; the
+          # local write here is belt-and-suspenders (the file is discarded with the runner).
+          if [ "$DRY_RUN" != "true" ]; then
+            python3 -c "import json;open('.edge-health-state/key','w').write(json.load(open('decision.json'))['key'])"
+          fi
 
           SHOULD=$(python3 -c "import json;print(json.load(open('decision.json'))['should_alert'])")
           if [ "$SHOULD" != "True" ]; then
@@ -155,7 +161,8 @@ jobs:
           PY
 
       - name: Save state key
-        if: steps.precheck.outputs.skip == 'false' && steps.scan.outputs.scan_ok == 'true'
+        # Not on dry-run: a dry-run must not advance the dedup state (see Decide step).
+        if: steps.precheck.outputs.skip == 'false' && steps.scan.outputs.scan_ok == 'true' && inputs.dry_run != 'true'
         uses: actions/cache/save@v4
         with:
           path: .edge-health-state


### PR DESCRIPTION
## Why

Follow-up to #660, caught during the post-merge `dry_run=true` validation. A dry-run is meant to be **side-effect-free**, but it persisted the actionable-set state key (the Decide step wrote it + the cache Save step stored it unconditionally). So running a dry-run on a live incident **pre-acked the current bad set** and would suppress the next *real* alert for it.

Concretely: the 2026-06-08 dry-run seeded `down:uk2|down:uk3|down:us3` into the cache, so the next live cron would see "no change" and stay silent on a fleet that is currently down.

## What

Gate both writes on `dry_run != true`:
- Decide step: only write `.edge-health-state/key` on a real run.
- Save step `if:` adds `&& inputs.dry_run != 'true'` so the cache is not advanced on a dry-run.

A real run still advances state **every** cycle (including steady / no-alert cycles), so dedup is unchanged for production; only dry-runs are now read-only against the dedup state.

## Verification

- Full `scripts/preflight.sh` (incl. all sub2api checks) **PASS**; `check_workflow_yaml` clean; job-level-if env check OK (the new condition is step-level `inputs.dry_run`).
- The post-merge dry-run of #660 already proved the end-to-end path works (OIDC → SSM scan → decision → `DRY_RUN=true` printed the critical message, no Feishu post).

## Note

The already-seeded dry-run cache from #660's validation still exists. To get the first live Feishu post to fire on the current down set (uk2/uk3/us3), that one cache entry can be deleted — but that triggers a real team-facing Feishu alert, so leaving it for the operator to decide / for the next natural state-change to flush it.

🤖 Generated with [Claude Code](https://claude.com/claude-code)