### PR TITLE
feat(openai): read-first privacy ensure to dodge CF-only-blocks-writes deadlock

### DIFF
--- a/backend/internal/service/openai_privacy_retry_test.go
+++ b/backend/internal/service/openai_privacy_retry_test.go
@@ -43,7 +43,9 @@ func TestAdminService_EnsureOpenAIPrivacy_RetriesNonSuccessModes(t *testing.T) {
 			got := svc.EnsureOpenAIPrivacy(context.Background(), account)
 
 			require.Equal(t, PrivacyModeFailed, got)
-			require.Equal(t, 1, privacyCalls)
+			// read-first calls the factory once (the GET) then disableOpenAITraining
+			// calls it again (the PATCH); both fail here, so the factory is hit twice.
+			require.Equal(t, 2, privacyCalls)
 		})
 	}
 }
@@ -83,7 +85,9 @@ func TestTokenRefreshService_ensureOpenAIPrivacy_RetriesNonSuccessModes(t *testi
 
 			service.ensureOpenAIPrivacy(context.Background(), account)
 
-			require.Equal(t, 1, privacyCalls)
+			// read-first calls the factory once (the GET) then disableOpenAITraining
+			// calls it again (the PATCH); both fail here, so the factory is hit twice.
+			require.Equal(t, 2, privacyCalls)
 		})
 	}
 }

--- a/backend/internal/service/openai_privacy_service.go
+++ b/backend/internal/service/openai_privacy_service.go
@@ -42,6 +42,17 @@ func disableOpenAITraining(ctx context.Context, clientFactory PrivacyClientFacto
 		return ""
 	}
 
+	// TK: read-first. The settings PATCH below is Cloudflare-challenged from a datacenter
+	// egress (-> training_set_cf_blocked) even when training is already disabled. A GET of
+	// the same settings resource is not challenged, so if upstream training_allowed is
+	// already false we record training_off without issuing the (blocked) PATCH. An
+	// inconclusive read (error / non-2xx / unparseable) falls through to the PATCH path
+	// unchanged. Read+parse live in openai_privacy_tk_read.go to keep this a thin call site.
+	if disabled, ok := readOpenAITrainingDisabled(ctx, clientFactory, accessToken, proxyURL); ok && disabled {
+		slog.Info("openai_privacy_read_already_disabled")
+		return PrivacyModeTrainingOff
+	}
+
 	ctx, cancel := context.WithTimeout(ctx, 15*time.Second)
 	defer cancel()
 

--- a/backend/internal/service/openai_privacy_service.go
+++ b/backend/internal/service/openai_privacy_service.go
@@ -14,9 +14,11 @@ import (
 // Injected from repository layer to avoid import cycles.
 type PrivacyClientFactory func(proxyURL string) (*req.Client, error)
 
-const (
-	openAISettingsURL = "https://chatgpt.com/backend-api/settings/account_user_setting"
+// openAISettingsURL is the training-toggle PATCH endpoint. var (not const) only so
+// tests can point it at an httptest server, mirroring openAISettingsUserURL (the read side).
+var openAISettingsURL = "https://chatgpt.com/backend-api/settings/account_user_setting"
 
+const (
 	PrivacyModeTrainingOff = "training_off"
 	PrivacyModeFailed      = "training_set_failed"
 	PrivacyModeCFBlocked   = "training_set_cf_blocked"

--- a/backend/internal/service/openai_privacy_tk_read.go
+++ b/backend/internal/service/openai_privacy_tk_read.go
@@ -11,7 +11,8 @@ import (
 // PATCH endpoint (openAISettingsURL), a GET here is NOT Cloudflare-challenged from a
 // datacenter egress, so it can confirm the current training_allowed state even when the
 // PATCH would be blocked. See disableOpenAITraining for how the two combine.
-const openAISettingsUserURL = "https://chatgpt.com/backend-api/settings/user"
+// var (not const) only so tests can point it at an httptest server.
+var openAISettingsUserURL = "https://chatgpt.com/backend-api/settings/user"
 
 // openAIUserSettings is the subset of GET /backend-api/settings/user we depend on.
 // TrainingAllowed is a pointer so an absent field is distinguishable from an explicit false.

--- a/backend/internal/service/openai_privacy_tk_read.go
+++ b/backend/internal/service/openai_privacy_tk_read.go
@@ -1,0 +1,83 @@
+package service
+
+import (
+	"context"
+	"encoding/json"
+	"log/slog"
+	"time"
+)
+
+// openAISettingsUserURL is the read side of the ChatGPT settings resource. Unlike the
+// PATCH endpoint (openAISettingsURL), a GET here is NOT Cloudflare-challenged from a
+// datacenter egress, so it can confirm the current training_allowed state even when the
+// PATCH would be blocked. See disableOpenAITraining for how the two combine.
+const openAISettingsUserURL = "https://chatgpt.com/backend-api/settings/user"
+
+// openAIUserSettings is the subset of GET /backend-api/settings/user we depend on.
+// TrainingAllowed is a pointer so an absent field is distinguishable from an explicit false.
+type openAIUserSettings struct {
+	TrainingAllowed *bool `json:"training_allowed"`
+}
+
+// readOpenAITrainingDisabled GETs the ChatGPT user settings and reports whether the
+// "Improve the model for everyone" toggle (training_allowed) is already off.
+//
+//	disabled=true,  ok=true  -> upstream confirms training_allowed == false
+//	disabled=false, ok=true  -> upstream confirms training_allowed == true
+//	ok=false                 -> inconclusive (no token/factory, transport error, non-2xx,
+//	                            unparseable body, or field absent); the caller must fall
+//	                            back to the PATCH path.
+//
+// TK: the read path exists because the settings PATCH is Cloudflare-challenged from a
+// datacenter egress (privacy_mode=training_set_cf_blocked) even when training is already
+// disabled, while this GET is not. Matching the PATCH, "off" is decided on training_allowed
+// alone (the only field the PATCH sets), so the read and write stay symmetric.
+func readOpenAITrainingDisabled(ctx context.Context, clientFactory PrivacyClientFactory, accessToken, proxyURL string) (disabled bool, ok bool) {
+	if accessToken == "" || clientFactory == nil {
+		return false, false
+	}
+
+	ctx, cancel := context.WithTimeout(ctx, 15*time.Second)
+	defer cancel()
+
+	client, err := clientFactory(proxyURL)
+	if err != nil {
+		slog.Warn("openai_privacy_read_client_error", "error", err.Error())
+		return false, false
+	}
+
+	resp, err := client.R().
+		SetContext(ctx).
+		SetHeader("Authorization", "Bearer "+accessToken).
+		SetHeader("Origin", "https://chatgpt.com").
+		SetHeader("Referer", "https://chatgpt.com/").
+		SetHeader("Accept", "application/json").
+		SetHeader("sec-fetch-mode", "cors").
+		SetHeader("sec-fetch-site", "same-origin").
+		SetHeader("sec-fetch-dest", "empty").
+		Get(openAISettingsUserURL)
+	if err != nil {
+		slog.Warn("openai_privacy_read_request_error", "error", err.Error())
+		return false, false
+	}
+	if resp.StatusCode < 200 || resp.StatusCode >= 300 {
+		slog.Warn("openai_privacy_read_non_2xx", "status", resp.StatusCode, "content_type", resp.GetContentType())
+		return false, false
+	}
+
+	return parseOpenAITrainingDisabled([]byte(resp.String()))
+}
+
+// parseOpenAITrainingDisabled is the pure, testable decision: training is "off" only when
+// the body parses and training_allowed is present and false. A missing field yields
+// ok=false so the caller does not record training_off on an ambiguous read.
+func parseOpenAITrainingDisabled(body []byte) (disabled bool, ok bool) {
+	var s openAIUserSettings
+	if err := json.Unmarshal(body, &s); err != nil {
+		return false, false
+	}
+	if s.TrainingAllowed == nil {
+		return false, false
+	}
+	return !*s.TrainingAllowed, true
+}

--- a/backend/internal/service/openai_privacy_tk_read_test.go
+++ b/backend/internal/service/openai_privacy_tk_read_test.go
@@ -1,0 +1,47 @@
+//go:build unit
+
+package service
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/require"
+)
+
+func TestParseOpenAITrainingDisabled(t *testing.T) {
+	t.Parallel()
+
+	cases := []struct {
+		name         string
+		body         string
+		wantDisabled bool
+		wantOK       bool
+	}{
+		{name: "training_allowed false -> disabled", body: `{"training_allowed":false}`, wantDisabled: true, wantOK: true},
+		{name: "training_allowed true -> not disabled", body: `{"training_allowed":true}`, wantDisabled: false, wantOK: true},
+		{
+			name:   "field absent (other training flags only) -> inconclusive",
+			body:   `{"codex_training_allowed":false,"video_training_allowed":false}`,
+			wantOK: false,
+		},
+		{name: "empty object -> inconclusive", body: `{}`, wantOK: false},
+		{name: "not json -> inconclusive", body: `<!doctype html><html>just a moment</html>`, wantOK: false},
+		{name: "empty body -> inconclusive", body: ``, wantOK: false},
+		{
+			name:         "full settings payload, training off",
+			body:         `{"training_allowed":false,"codex_training_allowed":false,"precise_location_allowed":true}`,
+			wantDisabled: true,
+			wantOK:       true,
+		},
+	}
+
+	for _, tc := range cases {
+		tc := tc
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+			disabled, ok := parseOpenAITrainingDisabled([]byte(tc.body))
+			require.Equal(t, tc.wantOK, ok)
+			require.Equal(t, tc.wantDisabled, disabled)
+		})
+	}
+}

--- a/backend/internal/service/openai_privacy_tk_read_test.go
+++ b/backend/internal/service/openai_privacy_tk_read_test.go
@@ -3,8 +3,13 @@
 package service
 
 import (
+	"context"
+	"io"
+	"net/http"
+	"net/http/httptest"
 	"testing"
 
+	"github.com/imroc/req/v3"
 	"github.com/stretchr/testify/require"
 )
 
@@ -44,4 +49,70 @@ func TestParseOpenAITrainingDisabled(t *testing.T) {
 			require.Equal(t, tc.wantDisabled, disabled)
 		})
 	}
+}
+
+// TestReadOpenAITrainingDisabled exercises the HTTP read path end to end against an
+// httptest server: status handling, body extraction, header wiring, and the parse
+// integration. It swaps the package-level openAISettingsUserURL, so it must run
+// sequentially (no t.Parallel) — the package's privacy retry tests share the var.
+func TestReadOpenAITrainingDisabled(t *testing.T) {
+	cases := []struct {
+		name         string
+		status       int
+		contentType  string
+		body         string
+		wantDisabled bool
+		wantOK       bool
+	}{
+		{name: "200 training off -> disabled", status: 200, contentType: "application/json", body: `{"training_allowed":false}`, wantDisabled: true, wantOK: true},
+		{name: "200 training on -> not disabled", status: 200, contentType: "application/json", body: `{"training_allowed":true}`, wantDisabled: false, wantOK: true},
+		{name: "200 field absent -> inconclusive", status: 200, contentType: "application/json", body: `{"codex_training_allowed":false}`, wantOK: false},
+		{name: "403 cf challenge html -> inconclusive", status: 403, contentType: "text/html", body: `<!doctype html><html>just a moment</html>`, wantOK: false},
+		{name: "200 non-json body -> inconclusive", status: 200, contentType: "text/html", body: `<html>nope</html>`, wantOK: false},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			var gotAuth, gotPath string
+			srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+				gotAuth = r.Header.Get("Authorization")
+				gotPath = r.URL.Path
+				w.Header().Set("Content-Type", tc.contentType)
+				w.WriteHeader(tc.status)
+				_, _ = io.WriteString(w, tc.body)
+			}))
+			defer srv.Close()
+
+			orig := openAISettingsUserURL
+			openAISettingsUserURL = srv.URL + "/backend-api/settings/user"
+			defer func() { openAISettingsUserURL = orig }()
+
+			factory := func(proxyURL string) (*req.Client, error) { return req.C(), nil }
+			disabled, ok := readOpenAITrainingDisabled(context.Background(), factory, "tok-xyz", "")
+
+			require.Equal(t, tc.wantOK, ok)
+			require.Equal(t, tc.wantDisabled, disabled)
+			require.Equal(t, "Bearer tok-xyz", gotAuth, "access token must be sent as Bearer")
+			require.Equal(t, "/backend-api/settings/user", gotPath)
+		})
+	}
+}
+
+// TestReadOpenAITrainingDisabled_Guards covers the early-return guards that never issue
+// a request (missing token or factory) and a transport failure (factory error).
+func TestReadOpenAITrainingDisabled_Guards(t *testing.T) {
+	okFactory := func(string) (*req.Client, error) { return req.C(), nil }
+
+	disabled, ok := readOpenAITrainingDisabled(context.Background(), okFactory, "", "")
+	require.False(t, ok)
+	require.False(t, disabled)
+
+	disabled, ok = readOpenAITrainingDisabled(context.Background(), nil, "tok", "")
+	require.False(t, ok)
+	require.False(t, disabled)
+
+	errFactory := func(string) (*req.Client, error) { return nil, io.ErrUnexpectedEOF }
+	disabled, ok = readOpenAITrainingDisabled(context.Background(), errFactory, "tok", "")
+	require.False(t, ok)
+	require.False(t, disabled)
 }

--- a/backend/internal/service/openai_privacy_tk_read_test.go
+++ b/backend/internal/service/openai_privacy_tk_read_test.go
@@ -7,6 +7,7 @@ import (
 	"io"
 	"net/http"
 	"net/http/httptest"
+	"strings"
 	"testing"
 
 	"github.com/imroc/req/v3"
@@ -115,4 +116,52 @@ func TestReadOpenAITrainingDisabled_Guards(t *testing.T) {
 	disabled, ok = readOpenAITrainingDisabled(context.Background(), errFactory, "tok", "")
 	require.False(t, ok)
 	require.False(t, disabled)
+}
+
+// TestDisableOpenAITraining_ReadFirstShortCircuit is the end-to-end assertion of the
+// PR's headline behavior: when the upstream read says training is already off,
+// disableOpenAITraining returns training_off WITHOUT issuing the (Cloudflare-blocked)
+// PATCH; when the read says training is on, it falls through and DOES issue the PATCH.
+// A single httptest server serves both the read GET and the write PATCH so the test is
+// hermetic. Runs sequentially (it swaps package-level URL vars).
+func TestDisableOpenAITraining_ReadFirstShortCircuit(t *testing.T) {
+	for _, tc := range []struct {
+		name         string
+		readBody     string
+		wantPatchHit bool
+	}{
+		{name: "read says training off -> skip PATCH", readBody: `{"training_allowed":false}`, wantPatchHit: false},
+		{name: "read says training on -> do PATCH", readBody: `{"training_allowed":true}`, wantPatchHit: true},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			var patchHit bool
+			srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+				switch {
+				case r.Method == http.MethodGet && strings.HasSuffix(r.URL.Path, "/settings/user"):
+					w.Header().Set("Content-Type", "application/json")
+					_, _ = io.WriteString(w, tc.readBody)
+				case r.Method == http.MethodPatch && strings.HasSuffix(r.URL.Path, "/account_user_setting"):
+					patchHit = true
+					w.WriteHeader(http.StatusOK)
+					_, _ = io.WriteString(w, `{"ok":true}`)
+				default:
+					w.WriteHeader(http.StatusNotFound)
+				}
+			}))
+			defer srv.Close()
+
+			origRead, origPatch := openAISettingsUserURL, openAISettingsURL
+			openAISettingsUserURL = srv.URL + "/backend-api/settings/user"
+			openAISettingsURL = srv.URL + "/backend-api/settings/account_user_setting"
+			defer func() { openAISettingsUserURL = origRead; openAISettingsURL = origPatch }()
+
+			factory := func(proxyURL string) (*req.Client, error) { return req.C(), nil }
+			got := disableOpenAITraining(context.Background(), factory, "tok-xyz", "")
+
+			// Both branches end at training_off (read short-circuit, or PATCH 200 -> classify),
+			// so the PATCH-hit flag is what proves the short-circuit actually skipped the write.
+			require.Equal(t, PrivacyModeTrainingOff, got)
+			require.Equal(t, tc.wantPatchHit, patchHit)
+		})
+	}
 }

--- a/scripts/sentinels/gateway-tk.json
+++ b/scripts/sentinels/gateway-tk.json
@@ -1651,9 +1651,18 @@
     {
       "path": "backend/internal/service/openai_privacy_service.go",
       "must_contain": [
-        "classifyOpenAIPrivacyResponse(resp.StatusCode, resp.GetContentType(), resp.String())"
+        "classifyOpenAIPrivacyResponse(resp.StatusCode, resp.GetContentType(), resp.String())",
+        "readOpenAITrainingDisabled(ctx, clientFactory, accessToken, proxyURL)"
       ],
-      "rationale": "The OpenAI 'disable training data sharing' PATCH to chatgpt.com/backend-api gets served an OpenAI-branded Cloudflare anti-bot interstitial (gray logo SVG + <meta http-equiv=refresh>, status 403) from a datacenter egress IP. That page contains NONE of the legacy cloudflare/cf-/Just-a-moment markers, so the original inline detection mis-recorded it as training_set_failed (red 'Fail') instead of training_set_cf_blocked (yellow 'CF' — blocked, retryable, not an account fault). disableOpenAITraining now delegates classification to classifyOpenAIPrivacyResponse in openai_privacy_tk_classify.go (broadened HTML / <html> / cf / meta-refresh detection). An upstream merge that restores the old inline 3-marker block here compiles clean but silently reverts the fix and leaves the companion file as dead code — this sentinel catches that revert."
+      "rationale": "The OpenAI 'disable training data sharing' PATCH to chatgpt.com/backend-api gets served an OpenAI-branded Cloudflare anti-bot interstitial (gray logo SVG + <meta http-equiv=refresh>, status 403) from a datacenter egress IP. That page contains NONE of the legacy cloudflare/cf-/Just-a-moment markers, so the original inline detection mis-recorded it as training_set_failed (red 'Fail') instead of training_set_cf_blocked (yellow 'CF' — blocked, retryable, not an account fault). disableOpenAITraining now delegates classification to classifyOpenAIPrivacyResponse in openai_privacy_tk_classify.go (broadened HTML / <html> / cf / meta-refresh detection), and READS training state first via readOpenAITrainingDisabled (openai_privacy_tk_read.go): because Cloudflare challenges only the PATCH (write) and not the settings GET (read), an account whose training_allowed is already false is recorded training_off without ever issuing the blocked PATCH. An upstream merge that restores the old inline 3-marker block OR drops the read-first hook compiles clean but silently reverts the fix and leaves the companion files as dead code — this sentinel catches that revert."
+    },
+    {
+      "path": "backend/internal/service/openai_privacy_tk_read.go",
+      "must_contain": [
+        "https://chatgpt.com/backend-api/settings/user",
+        "func parseOpenAITrainingDisabled(body []byte) (disabled bool, ok bool)"
+      ],
+      "rationale": "Read side of the OpenAI privacy fix. The settings PATCH (openAISettingsURL) is Cloudflare-challenged from a datacenter egress, pinning privacy_mode at training_set_cf_blocked even when training is already off; the settings GET (openAISettingsUserURL = /backend-api/settings/user) is NOT challenged. readOpenAITrainingDisabled reads training_allowed and, when already false, lets disableOpenAITraining record training_off without the blocked PATCH; parseOpenAITrainingDisabled is the pure, table-tested decision (mirrors the write side: training_allowed alone). If this file or its GET URL is deleted by an upstream merge/refactor, the read-first hook in openai_privacy_service.go would fail to compile or silently lose its only non-CF path back to training_off — this sentinel guards both anchors."
     },
     {
       "path": "backend/internal/service/account_usage_service.go",


### PR DESCRIPTION
## 问题

TokenKey 给 OpenAI OAuth 账号"退出训练"靠对 `chatgpt.com/backend-api/settings/account_user_setting` 发 **PATCH**（`feature=training_allowed&value=false`），成功记 `privacy_mode=training_off`。

实测（prod 真实 access_token）：**这条 PATCH 在数据中心 egress 被 Cloudflare 持续挑战**（403/503 HTML 挑战页），于是 `disableOpenAITraining` 一直记成 `training_set_cf_blocked`，`IsPrivacySet()` 永为 false。token 刷新/OAuth 虽自动重试（`ensureOpenAIPrivacy`）但每次都被 CF 拦、不自愈。prod `GPT-pro1(id=9)` / `GPT-pro2(id=48)` 即此状态。

关键：**CF 只挑战 PATCH(写)，不挑战 GET(读)**。`GET /backend-api/settings/user` 从 prod egress 干净 200，含 `"training_allowed": false`——这俩账号上游训练其实早已关闭，只是 TK 因写被拦误记。

## 改动

在 `disableOpenAITraining` 内部加 **read-first**（单一注入点，4 个 ensure 调用方自动受益）：先 `GET settings/user` 读 `training_allowed`，已 false 就直接返回 `training_off`、不发那条注定被拦的 PATCH；读不确定（错误/非2xx/解析失败）原样回退到现有 PATCH 路径。判定**只看 `training_allowed`**，与写入端语义对称、无 churn。

- `openai_privacy_tk_read.go`（新）— `readOpenAITrainingDisabled` + 纯函数 `parseOpenAITrainingDisabled`（table 测）。
- `openai_privacy_service.go`（upstream-shaped 薄壳）— 仅加 ~10 行 guarded hook。
- `openai_privacy_tk_read_test.go`（新）— parse 单测。
- `openai_privacy_retry_test.go` — 工厂调用计数 1→2（read 试 + write 试）。
- `scripts/sentinels/gateway-tk.json` — 新 read-first 锚点 + 守护新读文件，防上游 merge 静默回退。

## 不在范围
不扩展 PATCH 去关 `codex_training_allowed*`；不碰 `IsPrivacySet()`/`require_privacy_set` 门禁与调度。发版后对 9/48 触发一次 ensure 即会把它们纠正为 `training_off`。

## 验证
- [x] `go test -tags=unit ./internal/service/` 全绿（新 parse 测 + 改后 retry 测）
- [x] `golangci-lint run ./internal/service/` 0 issues
- [x] `bash scripts/preflight.sh`（含 sub2api 全部 sentinel/marker 门禁）PASS
- [x] commit 带 `no-web-impact` + `upstream-touch-guarded`
- 发版后端到端：对 9/48 触发 admin set-privacy（或等 token-refresh），复核 DB `extra->>'privacy_mode'`=`training_off`

合并方式按 §5.y：**Squash and merge**（TK feature PR）。

🤖 Generated with [Claude Code](https://claude.com/claude-code)