### PR TITLE
fix(gateway): escalate valid-but-revoked OAuth 401 flap to permanent disable + P0 alert

### DIFF
--- a/backend/internal/config/config.go
+++ b/backend/internal/config/config.go
@@ -1369,6 +1369,18 @@ type RateLimitConfig struct {
 	// 60 分钟）。跨窗口的 401 会重新种 baseline 而非升级，防止几小时前的良性瞬时 401
 	// 与今天一次新瞬时 401 凑成误升级。零值或负值回退到默认 60。
 	OAuth401AfterRefreshWindowMinutes int `mapstructure:"oauth_401_after_refresh_window_minutes"`
+
+	// OAuth401SameVersionDisableThreshold 控制「token 仍有效却在同一版本上持续 401」
+	// 升级为 error 永久停调度的阈值——补 OAuth401AfterRefreshDisableThreshold 的结构性
+	// 盲区。后者要求 token 版本递增（=其间发生过 refresh）才计数；但 grant 被上游吊销
+	// 而 access_token 仍在有效期内时，NeedsRefresh=false → 永不刷新 → 版本冻结 → 那个
+	// 闸门永不前进，账号在 active⇄临时不可调度 之间无限 flap、永不升级、永不告警。
+	// 本阈值用「同一版本跨多个冷却周期 401」（带去抖折叠并发突发）作第二触发：默认 1，
+	// 即第一次 401 种 baseline、跨一个冷却周期后的同版本 401 即判定吊销并升级。
+	// 注意权衡：调低告警更快但若 Anthropic 侧对有效 token 发生短暂全网 401 抖动，会更易
+	// 把整池账号一起误升级为永久失效（需人工重授权）；reset-on-success 兜底（任一成功清零）。
+	// 零值或负值回退到默认 1。
+	OAuth401SameVersionDisableThreshold int `mapstructure:"oauth_401_same_version_disable_threshold"`
 }
 
 // APIKeyAuthCacheConfig API Key 认证缓存配置
@@ -1876,6 +1888,7 @@ func setDefaults() {
 	// RateLimit
 	viper.SetDefault("rate_limit.overload_cooldown_minutes", 10)
 	viper.SetDefault("rate_limit.oauth_401_cooldown_minutes", 10)
+	viper.SetDefault("rate_limit.oauth_401_same_version_disable_threshold", 1)
 	viper.SetDefault("rate_limit.anthropic_error_threshold", 3)
 	viper.SetDefault("rate_limit.anthropic_error_window_minutes", 1)
 

--- a/backend/internal/repository/oauth_401_after_refresh_counter_cache.go
+++ b/backend/internal/repository/oauth_401_after_refresh_counter_cache.go
@@ -10,35 +10,52 @@ import (
 
 const oauth401AfterRefreshCounterPrefix = "oauth_401_after_refresh:account:"
 
-// oauth401AfterRefreshIncrScript 原子地用 token 版本戳做闸门计数：
-//   - Hash 字段 ver = 上一次 401 记录的 token 版本；count = 「换新 token 仍 401」累计次数。
-//   - 无 baseline（key 不存在或已过 TTL）→ 种下 ver、count=0、设 TTL，返回 0。
-//   - ver 递增（其间发生过成功 refresh）→ count+1、更新 ver、刷新 TTL，返回新 count。
-//   - ver 相等（同 token / 并发突发）→ 仅刷新 TTL，返回当前 count。
-//   - ver 变小（请求快照过旧）→ 不动，返回当前 count。
+// oauth401AfterRefreshIncrScript 原子地用 token 版本戳做闸门，维护两个互补计数维度，
+// 返回 {count, sameCount}：
+//   - Hash 字段 ver = 上次 401 记录的 token 版本；count = 「换新 token 仍 401」累计；
+//     same = 「同一有效 token 跨冷却周期持续 401」累计；same_at = 上次 same 计数的服务端秒戳。
+//   - 无 baseline（key 不存在或已过 TTL）→ 种下 ver/count=0/same=0/same_at=now、设 TTL，返回 {0,0}。
+//   - ver 递增（其间发生过成功 refresh，新 token 仍 401）→ count+1、更新 ver、把 same 维度
+//     重置到新版本 baseline（same=0、same_at=now）、刷新 TTL，返回 {count,0}。
+//   - ver 相等（同 token，未刷新）→ 仅当 now-same_at >= debounce 才 same+1 并更新 same_at
+//     （把一个冷却周期内的并发突发折叠成 1），否则只刷 TTL；返回 {count,same}。
+//   - ver 变小（请求快照过旧）→ 不动，返回 {count,same}。
+//
+// 用服务端 redis.call('TIME') 取时间（同 concurrency_cache.go 房式），跨网关实例确定、
+// 无客户端时钟漂移；TIME 需 effects replication，故首行 replicate_commands()（Redis 5+ 为 no-op）。
 var oauth401AfterRefreshIncrScript = redis.NewScript(`
+	redis.replicate_commands()
 	local key = KEYS[1]
 	local ver = tonumber(ARGV[1])
 	local ttl = tonumber(ARGV[2])
+	local debounce = tonumber(ARGV[3])
+	local now = tonumber(redis.call('TIME')[1])
 
 	local stored = redis.call('HGET', key, 'ver')
 	if stored == false then
-		redis.call('HSET', key, 'ver', ver, 'count', 0)
+		redis.call('HSET', key, 'ver', ver, 'count', 0, 'same', 0, 'same_at', now)
 		redis.call('EXPIRE', key, ttl)
-		return 0
+		return {0, 0}
 	end
 
 	stored = tonumber(stored)
 	local count = tonumber(redis.call('HGET', key, 'count') or '0')
+	local same = tonumber(redis.call('HGET', key, 'same') or '0')
 	if ver > stored then
 		count = count + 1
-		redis.call('HSET', key, 'ver', ver, 'count', count)
+		same = 0
+		redis.call('HSET', key, 'ver', ver, 'count', count, 'same', 0, 'same_at', now)
 		redis.call('EXPIRE', key, ttl)
 	elseif ver == stored then
+		local sameAt = tonumber(redis.call('HGET', key, 'same_at') or '0')
+		if (now - sameAt) >= debounce then
+			same = same + 1
+			redis.call('HSET', key, 'same', same, 'same_at', now)
+		end
 		redis.call('EXPIRE', key, ttl)
 	end
 
-	return count
+	return {count, same}
 `)
 
 type oauth401AfterRefreshCounterCache struct {
@@ -50,19 +67,30 @@ func NewOAuth401AfterRefreshCounterCache(rdb *redis.Client) service.OAuth401Afte
 	return &oauth401AfterRefreshCounterCache{rdb: rdb}
 }
 
-func (c *oauth401AfterRefreshCounterCache) RecordOAuth401AfterRefresh(ctx context.Context, accountID int64, tokenVersion int64, windowMinutes int) (int64, error) {
+func (c *oauth401AfterRefreshCounterCache) RecordOAuth401AfterRefresh(ctx context.Context, accountID int64, tokenVersion int64, windowMinutes, debounceSeconds int) (int64, int64, error) {
 	key := fmt.Sprintf("%s%d", oauth401AfterRefreshCounterPrefix, accountID)
 
 	ttlSeconds := windowMinutes * 60
 	if ttlSeconds < 60 {
 		ttlSeconds = 60
 	}
-
-	result, err := oauth401AfterRefreshIncrScript.Run(ctx, c.rdb, []string{key}, tokenVersion, ttlSeconds).Int64()
-	if err != nil {
-		return 0, fmt.Errorf("record oauth 401 after refresh: %w", err)
+	if debounceSeconds < 0 {
+		debounceSeconds = 0
 	}
-	return result, nil
+
+	result, err := oauth401AfterRefreshIncrScript.Run(ctx, c.rdb, []string{key}, tokenVersion, ttlSeconds, debounceSeconds).Int64Slice()
+	if err != nil {
+		return 0, 0, fmt.Errorf("record oauth 401 after refresh: %w", err)
+	}
+	// 脚本恒返回 {count, same}；防御性兜底，长度不足按 0 处理。
+	var count, same int64
+	if len(result) > 0 {
+		count = result[0]
+	}
+	if len(result) > 1 {
+		same = result[1]
+	}
+	return count, same, nil
 }
 
 func (c *oauth401AfterRefreshCounterCache) ResetOAuth401AfterRefresh(ctx context.Context, accountID int64) error {

--- a/backend/internal/repository/oauth_401_after_refresh_counter_integration_test.go
+++ b/backend/internal/repository/oauth_401_after_refresh_counter_integration_test.go
@@ -1,0 +1,153 @@
+//go:build integration
+
+package repository
+
+import (
+	"fmt"
+	"testing"
+
+	"github.com/Wei-Shaw/sub2api/internal/service"
+	"github.com/stretchr/testify/require"
+	"github.com/stretchr/testify/suite"
+)
+
+// OAuth401AfterRefreshCounterSuite 用真实 Redis 验证版本闸门 Lua 脚本的两维度计数语义：
+// version-bump（换新 token 仍 401）与 same-version（同一有效 token 跨冷却周期持续 401）。
+type OAuth401AfterRefreshCounterSuite struct {
+	IntegrationRedisSuite
+	cache service.OAuth401AfterRefreshCounterCache
+}
+
+func TestOAuth401AfterRefreshCounterSuite(t *testing.T) {
+	suite.Run(t, new(OAuth401AfterRefreshCounterSuite))
+}
+
+func (s *OAuth401AfterRefreshCounterSuite) SetupTest() {
+	s.IntegrationRedisSuite.SetupTest()
+	s.cache = NewOAuth401AfterRefreshCounterCache(s.rdb)
+}
+
+func (s *OAuth401AfterRefreshCounterSuite) key(accountID int64) string {
+	return fmt.Sprintf("%s%d", oauth401AfterRefreshCounterPrefix, accountID)
+}
+
+// forceSameElapsed 把 same_at 置 0，模拟「距上次同版本计数已远超 debounce」，
+// 使下一次同版本调用确定性地 +1（无需 sleep 等真实时钟）。
+func (s *OAuth401AfterRefreshCounterSuite) forceSameElapsed(accountID int64) {
+	require.NoError(s.T(), s.rdb.HSet(s.ctx, s.key(accountID), "same_at", 0).Err())
+}
+
+func (s *OAuth401AfterRefreshCounterSuite) hgetInt(accountID int64, field string) int64 {
+	v, err := s.rdb.HGet(s.ctx, s.key(accountID), field).Int64()
+	require.NoError(s.T(), err, "HGET %s", field)
+	return v
+}
+
+// 首次（无 baseline）→ 种 baseline，返回 (0,0)，hash 落 ver/count=0/same=0/same_at>0。
+func (s *OAuth401AfterRefreshCounterSuite) TestSeedReturnsZeroZero() {
+	const id = int64(10)
+	count, same, err := s.cache.RecordOAuth401AfterRefresh(s.ctx, id, 1000, 60, 300)
+	require.NoError(s.T(), err)
+	require.Equal(s.T(), int64(0), count)
+	require.Equal(s.T(), int64(0), same)
+	require.Equal(s.T(), int64(1000), s.hgetInt(id, "ver"))
+	require.Equal(s.T(), int64(0), s.hgetInt(id, "count"))
+	require.Equal(s.T(), int64(0), s.hgetInt(id, "same"))
+	require.Positive(s.T(), s.hgetInt(id, "same_at"), "same_at must be stamped to server time")
+}
+
+// 版本递增（其间换过新 token 仍 401）→ count+1，且 same 维度重置到新版本 baseline。
+func (s *OAuth401AfterRefreshCounterSuite) TestVersionBumpIncrementsAndResetsSame() {
+	const id = int64(11)
+	_, _, err := s.cache.RecordOAuth401AfterRefresh(s.ctx, id, 1000, 60, 100)
+	require.NoError(s.T(), err)
+	// 先攒一个 same 计数。
+	s.forceSameElapsed(id)
+	_, same, err := s.cache.RecordOAuth401AfterRefresh(s.ctx, id, 1000, 60, 100)
+	require.NoError(s.T(), err)
+	require.Equal(s.T(), int64(1), same)
+
+	// 版本递增 → count=1，same 归零。
+	count, same, err := s.cache.RecordOAuth401AfterRefresh(s.ctx, id, 2000, 60, 100)
+	require.NoError(s.T(), err)
+	require.Equal(s.T(), int64(1), count)
+	require.Equal(s.T(), int64(0), same)
+	require.Equal(s.T(), int64(2000), s.hgetInt(id, "ver"))
+	require.Equal(s.T(), int64(0), s.hgetInt(id, "same"))
+}
+
+// 同版本：debounce 窗口内的并发突发折叠为 0 增量；跨 debounce 才 +1。
+func (s *OAuth401AfterRefreshCounterSuite) TestSameVersionDebounceGatesIncrements() {
+	const id = int64(12)
+	const debounce = 100
+
+	_, same, err := s.cache.RecordOAuth401AfterRefresh(s.ctx, id, 1000, 60, debounce) // seed
+	require.NoError(s.T(), err)
+	require.Equal(s.T(), int64(0), same)
+
+	// 紧接着同版本（同 debounce 窗口内）→ 不增量（折叠突发）。
+	_, same, err = s.cache.RecordOAuth401AfterRefresh(s.ctx, id, 1000, 60, debounce)
+	require.NoError(s.T(), err)
+	require.Equal(s.T(), int64(0), same, "burst within debounce must not increment")
+
+	// 模拟跨过一个冷却周期 → +1。
+	s.forceSameElapsed(id)
+	_, same, err = s.cache.RecordOAuth401AfterRefresh(s.ctx, id, 1000, 60, debounce)
+	require.NoError(s.T(), err)
+	require.Equal(s.T(), int64(1), same)
+
+	// 再紧接着同窗口 → 仍不增量。
+	_, same, err = s.cache.RecordOAuth401AfterRefresh(s.ctx, id, 1000, 60, debounce)
+	require.NoError(s.T(), err)
+	require.Equal(s.T(), int64(1), same, "burst after increment must not double-count")
+
+	// 再跨一个周期 → +1 = 2。
+	s.forceSameElapsed(id)
+	_, same, err = s.cache.RecordOAuth401AfterRefresh(s.ctx, id, 1000, 60, debounce)
+	require.NoError(s.T(), err)
+	require.Equal(s.T(), int64(2), same)
+}
+
+// 版本变小（请求快照过旧）→ 两维度都不动。
+func (s *OAuth401AfterRefreshCounterSuite) TestStaleVersionIsNoOp() {
+	const id = int64(13)
+	_, _, err := s.cache.RecordOAuth401AfterRefresh(s.ctx, id, 2000, 60, 100)
+	require.NoError(s.T(), err)
+	s.forceSameElapsed(id)
+	_, same, err := s.cache.RecordOAuth401AfterRefresh(s.ctx, id, 2000, 60, 100)
+	require.NoError(s.T(), err)
+	require.Equal(s.T(), int64(1), same)
+
+	// 过旧版本 → 返回当前 (count=0, same=1)，hash 不变。
+	count, same, err := s.cache.RecordOAuth401AfterRefresh(s.ctx, id, 500, 60, 100)
+	require.NoError(s.T(), err)
+	require.Equal(s.T(), int64(0), count)
+	require.Equal(s.T(), int64(1), same)
+	require.Equal(s.T(), int64(2000), s.hgetInt(id, "ver"))
+}
+
+// Reset 清整 key；其后调用重新种 baseline。
+func (s *OAuth401AfterRefreshCounterSuite) TestResetClearsAll() {
+	const id = int64(14)
+	s.forceSameElapsedSeed(id)
+
+	require.NoError(s.T(), s.cache.ResetOAuth401AfterRefresh(s.ctx, id))
+	exists, err := s.rdb.Exists(s.ctx, s.key(id)).Result()
+	require.NoError(s.T(), err)
+	require.Equal(s.T(), int64(0), exists, "reset must DEL the whole key")
+
+	count, same, err := s.cache.RecordOAuth401AfterRefresh(s.ctx, id, 1000, 60, 100)
+	require.NoError(s.T(), err)
+	require.Equal(s.T(), int64(0), count)
+	require.Equal(s.T(), int64(0), same)
+}
+
+// forceSameElapsedSeed seeds and bumps same to 1 (helper for ResetClearsAll).
+func (s *OAuth401AfterRefreshCounterSuite) forceSameElapsedSeed(id int64) {
+	_, _, err := s.cache.RecordOAuth401AfterRefresh(s.ctx, id, 1000, 60, 100)
+	require.NoError(s.T(), err)
+	s.forceSameElapsed(id)
+	_, same, err := s.cache.RecordOAuth401AfterRefresh(s.ctx, id, 1000, 60, 100)
+	require.NoError(s.T(), err)
+	require.Equal(s.T(), int64(1), same)
+}

--- a/backend/internal/service/oauth_401_after_refresh_counter.go
+++ b/backend/internal/service/oauth_401_after_refresh_counter.go
@@ -2,22 +2,31 @@ package service
 
 import "context"
 
-// OAuth401AfterRefreshCounterCache 追踪 OAuth 账号「token 被成功刷新过、却仍持续 401」的次数。
+// OAuth401AfterRefreshCounterCache 追踪 OAuth 账号在「grant 被上游吊销」两种特征下的 401 累计。
 //
-// 与单纯的 401 计数不同：这里用 token 版本戳（credentials["_token_version"]，每次成功
-// refresh 盖一个 UnixMilli）做闸门——只有「本次 401 所用 token 的版本 > 上一次 401 记录的
-// 版本」才计数，即两次 401 之间确实发生过一次成功 refresh，换了新 token 却仍 401。这精确
-// 对应「refresh 端点成功但 grant 实质已被上游吊销」的 flap 盲区，把它和「token 只是过期
-// 待刷新 / 并发同 token 突发 / 首次 401」区分开，避免把可恢复账号误判为永久禁用。
+// 用 token 版本戳（credentials["_token_version"]，每次成功 refresh 盖一个 UnixMilli）做闸门，
+// 同时维护两个互补的计数维度：
+//
+//   - versionBumpCount（refresh 成功却仍 401）：只有「本次 401 所用 token 的版本 > 上一次
+//     401 记录的版本」才计数，即两次 401 之间确实换过新 token 却仍 401。对应「refresh 端点
+//     成功但 grant 实质已被吊销」的 flap，把它和「过期待刷新 / 并发同 token 突发 / 首次 401」
+//     区分开。
+//   - sameVersionCount（token 仍有效却持续 401）：版本相等（其间没换 token）且距上次同版本
+//     计数 ≥ debounce 秒时 +1。补前者的结构性盲区——grant 被吊销而 access_token 仍在有效期
+//     内时 NeedsRefresh=false → 永不刷新 → 版本冻结 → versionBumpCount 永不前进。debounce
+//     把一个冷却周期内的并发突发折叠成 1，使每个冷却周期至多 +1。
+//
+// 两维度同窗口 TTL（windowMinutes）：跨窗口的 401 重新种 baseline 而非升级，防止久远的良性
+// 瞬时 401 与今天一次新瞬时 401 凑成误升级。调用方对两个计数各自配阈值，任一达阈值即升级。
 type OAuth401AfterRefreshCounterCache interface {
-	// RecordOAuth401AfterRefresh 原子记录一次 401：
-	//   - 首次（窗口内无 baseline 版本）→ 仅种下 baseline 版本，返回 0（不计数）。
-	//   - tokenVersion > 已存版本（其间发生过成功 refresh）→ INCR 并返回当前计数。
-	//   - tokenVersion == 已存版本（同 token / 并发突发）→ 仅刷新窗口，返回当前计数（不变）。
-	//   - tokenVersion < 已存版本（请求快照过旧）→ 忽略，返回当前计数（不变）。
-	// baseline 版本带 windowMinutes TTL：跨窗口的 401 会重新种 baseline 而非升级，
-	// 防止几小时前的良性瞬时 401 和今天一次新瞬时 401 凑成误升级。
-	RecordOAuth401AfterRefresh(ctx context.Context, accountID int64, tokenVersion int64, windowMinutes int) (int64, error)
-	// ResetOAuth401AfterRefresh 在账号成功响应 / 恢复后清零计数与 baseline 版本。
+	// RecordOAuth401AfterRefresh 原子记录一次 401，返回 (versionBumpCount, sameVersionCount)：
+	//   - 首次（窗口内无 baseline）→ 种下 baseline 版本与时间戳，返回 (0, 0)。
+	//   - tokenVersion > 已存版本（其间换过新 token）→ versionBumpCount+1，并把 sameVersion
+	//     维度重置到新版本 baseline；返回更新后的 (versionBumpCount, 0)。
+	//   - tokenVersion == 已存版本（同 token）→ 距上次同版本计数 ≥ debounceSeconds 才
+	//     sameVersionCount+1，否则只刷新窗口（折叠并发突发）；返回当前 (versionBumpCount, sameVersionCount)。
+	//   - tokenVersion < 已存版本（请求快照过旧）→ 忽略，返回当前 (versionBumpCount, sameVersionCount)。
+	RecordOAuth401AfterRefresh(ctx context.Context, accountID int64, tokenVersion int64, windowMinutes, debounceSeconds int) (versionBumpCount int64, sameVersionCount int64, err error)
+	// ResetOAuth401AfterRefresh 在账号成功响应 / 恢复后清零两维度计数与 baseline 版本。
 	ResetOAuth401AfterRefresh(ctx context.Context, accountID int64) error
 }

--- a/backend/internal/service/ratelimit_service_tk_oauth401.go
+++ b/backend/internal/service/ratelimit_service_tk_oauth401.go
@@ -25,6 +25,14 @@ const (
 	// 401 重新种 baseline 而非升级，防止几小时前的良性瞬时 401 与今天一次新瞬时 401
 	// 凑成误升级。
 	oauth401AfterRefreshWindowMinutesDefault = 60
+	// oauth401SameVersionDisableThresholdDefault：「token 仍有效却在同一版本上跨冷却周期
+	// 持续 401」的升级阈值。补 version-bump 闸门盲区（grant 被吊销但 access_token 仍有效
+	// → 不触发刷新 → 版本冻结 → version-bump 永不前进）。默认 1：第一次 401 种 baseline、
+	// 跨一个冷却周期后的同版本 401 即判吊销并升级。零/负回退默认 1。
+	oauth401SameVersionDisableThresholdDefault = 1
+	// oauth401SameVersionDebounceFloorSeconds：same-version 计数去抖的下限秒数，防止极小
+	// cooldown 误配导致一个冷却周期内多次计数。实际 debounce 取 max(floor, cooldown/2)。
+	oauth401SameVersionDebounceFloorSeconds = 60
 )
 
 // SetOAuth401AfterRefreshCounter 设置「refresh 后仍 401」计数器（可选依赖；未注入时
@@ -49,6 +57,32 @@ func (s *RateLimitService) getOAuth401AfterRefreshWindowMinutes() int {
 	return oauth401AfterRefreshWindowMinutesDefault
 }
 
+// getOAuth401SameVersionThreshold 返回 same-version 升级阈值，未设 / 零 / 负回退默认 1。
+func (s *RateLimitService) getOAuth401SameVersionThreshold() int64 {
+	if s != nil && s.cfg != nil && s.cfg.RateLimit.OAuth401SameVersionDisableThreshold > 0 {
+		return int64(s.cfg.RateLimit.OAuth401SameVersionDisableThreshold)
+	}
+	return oauth401SameVersionDisableThresholdDefault
+}
+
+// getOAuth401SameVersionDebounceSeconds 派生 same-version 计数去抖窗口：max(floor, cooldown/2)。
+// 同版本 401 因 temp_unschedulable 天然间隔 ~cooldown 秒；debounce 取 cooldown 的一半，远高于
+// 亚秒并发突发（折叠成 1）、又低于真实周期间隔（每周期必计一次）。floor 防极小 cooldown 误配。
+func (s *RateLimitService) getOAuth401SameVersionDebounceSeconds() int {
+	cooldownMinutes := 0
+	if s != nil && s.cfg != nil {
+		cooldownMinutes = s.cfg.RateLimit.OAuth401CooldownMinutes
+	}
+	if cooldownMinutes <= 0 {
+		cooldownMinutes = 10
+	}
+	debounce := cooldownMinutes * 60 / 2
+	if debounce < oauth401SameVersionDebounceFloorSeconds {
+		debounce = oauth401SameVersionDebounceFloorSeconds
+	}
+	return debounce
+}
+
 // ResetOAuth401AfterRefreshCounter 在账号成功响应 / 恢复后清零计数与 baseline 版本，
 // 避免一次良性瞬时 401 的 baseline 长期残留累积。计数器未注入时为 no-op。
 func (s *RateLimitService) ResetOAuth401AfterRefreshCounter(ctx context.Context, accountID int64) {
@@ -60,12 +94,16 @@ func (s *RateLimitService) ResetOAuth401AfterRefreshCounter(ctx context.Context,
 	}
 }
 
-// tkTryEscalateRevokedOAuth401 判定本次 OAuth 401 是否属于「token 已被成功刷新过却仍
-// 401」（grant 实质吊销）的 flap，并在达阈值时升级为 error 永久停调度 + 告警。
-// 返回 true 表示已升级（调用方应 break，不再走 temp_unschedulable 冷却）。
+// tkTryEscalateRevokedOAuth401 判定本次 OAuth 401 是否属于 grant 实质吊销的 flap，并在
+// 任一触发达阈值时升级为 error 永久停调度 + 告警。返回 true 表示已升级（调用方应 break，
+// 不再走 temp_unschedulable 冷却）。
 //
-// 闸门：用账号请求快照里 credentials["_token_version"]（每次成功 refresh 盖一个
-// UnixMilli 戳）比对上一次 401 记录的版本——只有版本递增（其间确实换了新 token）才计数。
+// 两条互补触发，都用账号请求快照里 credentials["_token_version"]（每次成功 refresh 盖一个
+// UnixMilli 戳）做闸门：
+//   - version-bump：版本递增（两次 401 之间换过新 token 却仍 401）→「refresh 成功但 grant
+//     已被吊销」。
+//   - same-version：版本冻结却跨多个冷却周期持续 401 →「grant 被吊销而 access_token 仍在
+//     有效期内」（NeedsRefresh=false 永不刷新，version-bump 看不到）。补前者的结构性盲区。
 //
 // 任一前置不满足（计数器未注入 / _token_version 缺失 / 计数器返回错误）时返回 false，
 // 回退到既有 temp_unschedulable 冷却。这是 fail-open：绝不因计数器缺失或故障把账号误判
@@ -80,34 +118,58 @@ func (s *RateLimitService) tkTryEscalateRevokedOAuth401(ctx context.Context, acc
 		return false
 	}
 
-	count, err := s.oauth401AfterRefreshCounter.RecordOAuth401AfterRefresh(
-		ctx, account.ID, tokenVersion, s.getOAuth401AfterRefreshWindowMinutes(),
+	versionBumpCount, sameVersionCount, err := s.oauth401AfterRefreshCounter.RecordOAuth401AfterRefresh(
+		ctx, account.ID, tokenVersion,
+		s.getOAuth401AfterRefreshWindowMinutes(),
+		s.getOAuth401SameVersionDebounceSeconds(),
 	)
 	if err != nil {
 		slog.Warn("oauth_401_after_refresh_record_failed", "account_id", account.ID, "error", err)
 		return false
 	}
 
-	threshold := s.getOAuth401AfterRefreshThreshold()
-	if count < threshold {
+	// 两条互补触发，任一达阈值即升级为 error 永久停调度 + 告警（handleAuthError 内 notify + SetError）。
+	// version-bump 优先（信号更强：换过新 token 仍 401）；same-version 补其盲区。
+	switch {
+	case versionBumpCount >= s.getOAuth401AfterRefreshThreshold():
+		msg := fmt.Sprintf(
+			"OAuth 401 persists after %d successful token refresh(es) — refresh_token likely revoked, manual re-authorization required (re-login via account management)",
+			versionBumpCount,
+		)
+		if strings.TrimSpace(upstreamMsg) != "" {
+			msg = msg + ": " + upstreamMsg
+		}
+		// greppable marker（§8.5 排障约定）。
+		slog.Warn("oauth_401_after_refresh_revoked",
+			"account_id", account.ID,
+			"platform", account.Platform,
+			"count", versionBumpCount,
+			"threshold", s.getOAuth401AfterRefreshThreshold(),
+			"token_version", tokenVersion,
+		)
+		s.handleAuthError(ctx, account, msg)
+		return true
+	case sameVersionCount >= s.getOAuth401SameVersionThreshold():
+		// token 仍有效却跨冷却周期持续 401：access_token 未到期 → 不触发刷新 → 版本冻结，
+		// 而上游持续拒——grant 在有效期内被吊销。这是 version-bump 闸门看不到的盲区。
+		msg := fmt.Sprintf(
+			"OAuth 401 persists at a still-valid token across %d cooldown cycle(s) — grant likely revoked upstream, manual re-authorization required (re-login via account management)",
+			sameVersionCount,
+		)
+		if strings.TrimSpace(upstreamMsg) != "" {
+			msg = msg + ": " + upstreamMsg
+		}
+		// greppable marker（§8.5 排障约定），区别于 version-bump 触发。
+		slog.Warn("oauth_401_same_version_persists_revoked",
+			"account_id", account.ID,
+			"platform", account.Platform,
+			"same_version_count", sameVersionCount,
+			"threshold", s.getOAuth401SameVersionThreshold(),
+			"token_version", tokenVersion,
+		)
+		s.handleAuthError(ctx, account, msg)
+		return true
+	default:
 		return false
 	}
-
-	msg := fmt.Sprintf(
-		"OAuth 401 persists after %d successful token refresh(es) — refresh_token likely revoked, manual re-authorization required (re-login via account management)",
-		count,
-	)
-	if strings.TrimSpace(upstreamMsg) != "" {
-		msg = msg + ": " + upstreamMsg
-	}
-	// greppable marker（§8.5 排障约定）。handleAuthError 内部已 notify 告警 + SetError。
-	slog.Warn("oauth_401_after_refresh_revoked",
-		"account_id", account.ID,
-		"platform", account.Platform,
-		"count", count,
-		"threshold", threshold,
-		"token_version", tokenVersion,
-	)
-	s.handleAuthError(ctx, account, msg)
-	return true
 }

--- a/backend/internal/service/ratelimit_service_tk_oauth401.go
+++ b/backend/internal/service/ratelimit_service_tk_oauth401.go
@@ -130,8 +130,10 @@ func (s *RateLimitService) tkTryEscalateRevokedOAuth401(ctx context.Context, acc
 
 	// 两条互补触发，任一达阈值即升级为 error 永久停调度 + 告警（handleAuthError 内 notify + SetError）。
 	// version-bump 优先（信号更强：换过新 token 仍 401）；same-version 补其盲区。
+	versionThreshold := s.getOAuth401AfterRefreshThreshold()
+	sameThreshold := s.getOAuth401SameVersionThreshold()
 	switch {
-	case versionBumpCount >= s.getOAuth401AfterRefreshThreshold():
+	case versionBumpCount >= versionThreshold:
 		msg := fmt.Sprintf(
 			"OAuth 401 persists after %d successful token refresh(es) — refresh_token likely revoked, manual re-authorization required (re-login via account management)",
 			versionBumpCount,
@@ -144,12 +146,12 @@ func (s *RateLimitService) tkTryEscalateRevokedOAuth401(ctx context.Context, acc
 			"account_id", account.ID,
 			"platform", account.Platform,
 			"count", versionBumpCount,
-			"threshold", s.getOAuth401AfterRefreshThreshold(),
+			"threshold", versionThreshold,
 			"token_version", tokenVersion,
 		)
 		s.handleAuthError(ctx, account, msg)
 		return true
-	case sameVersionCount >= s.getOAuth401SameVersionThreshold():
+	case sameVersionCount >= sameThreshold:
 		// token 仍有效却跨冷却周期持续 401：access_token 未到期 → 不触发刷新 → 版本冻结，
 		// 而上游持续拒——grant 在有效期内被吊销。这是 version-bump 闸门看不到的盲区。
 		msg := fmt.Sprintf(
@@ -164,7 +166,7 @@ func (s *RateLimitService) tkTryEscalateRevokedOAuth401(ctx context.Context, acc
 			"account_id", account.ID,
 			"platform", account.Platform,
 			"same_version_count", sameVersionCount,
-			"threshold", s.getOAuth401SameVersionThreshold(),
+			"threshold", sameThreshold,
 			"token_version", tokenVersion,
 		)
 		s.handleAuthError(ctx, account, msg)

--- a/backend/internal/service/ratelimit_service_tk_oauth401_test.go
+++ b/backend/internal/service/ratelimit_service_tk_oauth401_test.go
@@ -13,29 +13,37 @@ import (
 )
 
 // oauth401AfterRefreshCounterStub 是 OAuth401AfterRefreshCounterCache 的可控 fake：
-// counts 按调用顺序弹出返回值（空则返回 0，对应「种 baseline / 不计数」）；err 注入故障。
+// counts / sameCounts 按调用顺序弹出 version-bump / same-version 返回值（空则返回 0，
+// 对应「种 baseline / 不计数」）；err 注入故障。
 type oauth401AfterRefreshCounterStub struct {
-	counts         []int64
-	recordIDs      []int64
-	recordVersions []int64
-	recordWindows  []int
-	resetCalls     []int64
-	err            error
+	counts          []int64
+	sameCounts      []int64
+	recordIDs       []int64
+	recordVersions  []int64
+	recordWindows   []int
+	recordDebounces []int
+	resetCalls      []int64
+	err             error
 }
 
-func (s *oauth401AfterRefreshCounterStub) RecordOAuth401AfterRefresh(_ context.Context, accountID int64, tokenVersion int64, windowMinutes int) (int64, error) {
+func (s *oauth401AfterRefreshCounterStub) RecordOAuth401AfterRefresh(_ context.Context, accountID int64, tokenVersion int64, windowMinutes, debounceSeconds int) (int64, int64, error) {
 	s.recordIDs = append(s.recordIDs, accountID)
 	s.recordVersions = append(s.recordVersions, tokenVersion)
 	s.recordWindows = append(s.recordWindows, windowMinutes)
+	s.recordDebounces = append(s.recordDebounces, debounceSeconds)
 	if s.err != nil {
-		return 0, s.err
+		return 0, 0, s.err
 	}
-	if len(s.counts) == 0 {
-		return 0, nil
+	var count, same int64
+	if len(s.counts) > 0 {
+		count = s.counts[0]
+		s.counts = s.counts[1:]
 	}
-	count := s.counts[0]
-	s.counts = s.counts[1:]
-	return count, nil
+	if len(s.sameCounts) > 0 {
+		same = s.sameCounts[0]
+		s.sameCounts = s.sameCounts[1:]
+	}
+	return count, same, nil
 }
 
 func (s *oauth401AfterRefreshCounterStub) ResetOAuth401AfterRefresh(_ context.Context, accountID int64) error {
@@ -181,4 +189,63 @@ func TestRateLimitService_OAuth401AfterRefresh_ClearRateLimitResets(t *testing.T
 
 	require.NoError(t, service.ClearRateLimit(context.Background(), 707))
 	require.Equal(t, []int64{707}, counter.resetCalls)
+}
+
+// same-version 达阈值（默认 1）：token 仍有效却跨冷却周期持续 401（版本未递增），
+// 升级为 SetError + 告警，文案区别于 version-bump（提示 grant 在有效期内被吊销）。
+func TestRateLimitService_OAuth401SameVersion_EscalatesAtThreshold(t *testing.T) {
+	repo := &rateLimitAccountRepoStub{}
+	// version-bump 维度恒 0（无刷新），same-version 维度返回 1。
+	counter := &oauth401AfterRefreshCounterStub{sameCounts: []int64{1}}
+	blocker := &runtimeBlockRecorder{}
+	service := NewRateLimitService(repo, nil, &config.Config{}, nil, nil)
+	service.SetOAuth401AfterRefreshCounter(counter)
+	service.SetAccountRuntimeBlocker(blocker)
+	account := newOAuth401AnthropicAccount(801, 1737654321000)
+
+	shouldDisable := service.HandleUpstreamError(context.Background(), account, 401, http.Header{}, []byte("unauthorized"))
+
+	require.True(t, shouldDisable)
+	require.Equal(t, 1, repo.setErrorCalls, "same-version at threshold must SetError (permanent)")
+	require.Equal(t, 0, repo.tempCalls, "must NOT fall through to temp_unschedulable cooldown")
+	require.Contains(t, repo.lastErrorMsg, "still-valid token")
+	require.Contains(t, repo.lastErrorMsg, "grant likely revoked upstream")
+	require.Contains(t, repo.lastErrorMsg, "manual re-authorization")
+	require.Len(t, blocker.accounts, 1, "escalation must notify scheduling-blocked for alerting")
+	require.Equal(t, "auth_error", blocker.reasons[0])
+	// 默认 cooldown 10min → 派生 debounce = 10*60/2 = 300s，透传给计数器。
+	require.Equal(t, []int{300}, counter.recordDebounces)
+}
+
+// same-version 低于阈值（配置=3，count=2）：不升级，回退 temp_unschedulable 冷却。
+func TestRateLimitService_OAuth401SameVersion_BelowThresholdFallsThroughToCooldown(t *testing.T) {
+	repo := &rateLimitAccountRepoStub{}
+	counter := &oauth401AfterRefreshCounterStub{sameCounts: []int64{2}}
+	cfg := &config.Config{}
+	cfg.RateLimit.OAuth401SameVersionDisableThreshold = 3
+	service := NewRateLimitService(repo, nil, cfg, nil, nil)
+	service.SetOAuth401AfterRefreshCounter(counter)
+	account := newOAuth401AnthropicAccount(802, 1737654321000)
+
+	shouldDisable := service.HandleUpstreamError(context.Background(), account, 401, http.Header{}, []byte("unauthorized"))
+
+	require.True(t, shouldDisable)
+	require.Equal(t, 0, repo.setErrorCalls, "same-version below threshold must not escalate")
+	require.Equal(t, 1, repo.tempCalls, "falls through to temp_unschedulable cooldown")
+}
+
+// version-bump 与 same-version 同时达阈值时，version-bump 优先（信号更强，文案不同）。
+func TestRateLimitService_OAuth401_VersionBumpTakesPriorityOverSameVersion(t *testing.T) {
+	repo := &rateLimitAccountRepoStub{}
+	counter := &oauth401AfterRefreshCounterStub{counts: []int64{1}, sameCounts: []int64{5}}
+	service := NewRateLimitService(repo, nil, &config.Config{}, nil, nil)
+	service.SetOAuth401AfterRefreshCounter(counter)
+	account := newOAuth401AnthropicAccount(803, 1737654321000)
+
+	shouldDisable := service.HandleUpstreamError(context.Background(), account, 401, http.Header{}, []byte("unauthorized"))
+
+	require.True(t, shouldDisable)
+	require.Equal(t, 1, repo.setErrorCalls)
+	require.Contains(t, repo.lastErrorMsg, "refresh_token likely revoked", "version-bump branch wins")
+	require.NotContains(t, repo.lastErrorMsg, "still-valid token")
 }

--- a/backend/internal/service/ratelimit_service_tk_oauth401_test.go
+++ b/backend/internal/service/ratelimit_service_tk_oauth401_test.go
@@ -217,10 +217,10 @@ func TestRateLimitService_OAuth401SameVersion_EscalatesAtThreshold(t *testing.T)
 	require.Equal(t, []int{300}, counter.recordDebounces)
 }
 
-// same-version 低于阈值（配置=3，count=2）：不升级，回退 temp_unschedulable 冷却。
-func TestRateLimitService_OAuth401SameVersion_BelowThresholdFallsThroughToCooldown(t *testing.T) {
+// same-version 阈值可配（=3）：count=2 仍冷却，count=3 才升级。
+func TestRateLimitService_OAuth401SameVersion_ThresholdConfigurable(t *testing.T) {
 	repo := &rateLimitAccountRepoStub{}
-	counter := &oauth401AfterRefreshCounterStub{sameCounts: []int64{2}}
+	counter := &oauth401AfterRefreshCounterStub{sameCounts: []int64{2, 3}}
 	cfg := &config.Config{}
 	cfg.RateLimit.OAuth401SameVersionDisableThreshold = 3
 	service := NewRateLimitService(repo, nil, cfg, nil, nil)
@@ -228,10 +228,15 @@ func TestRateLimitService_OAuth401SameVersion_BelowThresholdFallsThroughToCooldo
 	account := newOAuth401AnthropicAccount(802, 1737654321000)
 
 	shouldDisable := service.HandleUpstreamError(context.Background(), account, 401, http.Header{}, []byte("unauthorized"))
-
 	require.True(t, shouldDisable)
-	require.Equal(t, 0, repo.setErrorCalls, "same-version below threshold must not escalate")
+	require.Equal(t, 0, repo.setErrorCalls, "same-version below threshold 3 must not escalate")
 	require.Equal(t, 1, repo.tempCalls, "falls through to temp_unschedulable cooldown")
+
+	shouldDisable = service.HandleUpstreamError(context.Background(), account, 401, http.Header{}, []byte("unauthorized"))
+	require.True(t, shouldDisable)
+	require.Equal(t, 1, repo.setErrorCalls, "same-version at configured threshold 3 must escalate")
+	require.Equal(t, 1, repo.tempCalls, "no extra cooldown on escalation")
+	require.Contains(t, repo.lastErrorMsg, "still-valid token")
 }
 
 // version-bump 与 same-version 同时达阈值时，version-bump 优先（信号更强，文案不同）。

--- a/scripts/sentinels/gateway-tk.json
+++ b/scripts/sentinels/gateway-tk.json
@@ -337,14 +337,18 @@
         "account.GetCredentialAsInt64(\"_token_version\")",
         "s.oauth401AfterRefreshCounter.RecordOAuth401AfterRefresh(",
         "oauth_401_after_refresh_revoked",
+        "oauth_401_same_version_persists_revoked",
+        "func (s *RateLimitService) getOAuth401SameVersionThreshold()",
+        "func (s *RateLimitService) getOAuth401SameVersionDebounceSeconds()",
         "manual re-authorization required",
         "s.handleAuthError(ctx, account, msg)",
         "oauth401AfterRefreshDisableThresholdDefault",
         "oauth401AfterRefreshWindowMinutesDefault",
+        "oauth401SameVersionDisableThresholdDefault",
         "func (s *RateLimitService) SetOAuth401AfterRefreshCounter(",
         "func (s *RateLimitService) ResetOAuth401AfterRefreshCounter("
       ],
-      "rationale": "TK companion holding the OAuth 'refresh endpoint succeeds but the freshly minted token still 401s' escalation (effective grant revocation). The flap it fixes is silent: the gateway 401 handler only writes temp_unschedulable while the background refresh treats a successful refresh as healthy (only invalid_grant hits SetError), so a revoked grant whose refresh still 200s bounces active<->temp_unschedulable forever with status=active, no error and no alert (observed draining single-account edge-uk1 into intermittent 503). The escalation is load-bearing and MUST survive upstream merges: (1) the _token_version gate (GetCredentialAsInt64) distinguishes 'a NEW token still 401s' from benign expiry/concurrent bursts — without it the counter would permanently disable accounts on ordinary transient 401s; (2) RecordOAuth401AfterRefresh feeds the windowed version-gated counter; (3) at threshold it calls handleAuthError (SetError + scheduling-blocked alert) with a message prompting manual re-authorization; (4) the oauth_401_after_refresh_revoked slog marker is the ops observability anchor. Dropping any anchor silently restores the infinite-flap blind spot, which compiles clean and passes the pre-existing 401 cooldown tests."
+      "rationale": "TK companion holding the OAuth grant-revocation escalation, with TWO complementary triggers that MUST both survive upstream merges. (A) version-bump ('refresh endpoint succeeds but the freshly minted token still 401s'): the _token_version gate (GetCredentialAsInt64) distinguishes 'a NEW token still 401s' from benign expiry/concurrent bursts; oauth_401_after_refresh_revoked is its slog marker. (B) same-version ('grant revoked while access_token is still valid'): when the token is NOT near expiry NeedsRefresh=false → no refresh ever fires → _token_version is frozen → trigger A's version gate can never advance, so the account flaps active<->temp_unschedulable forever (observed on edge-uk1 account#2 2026-06-08: Redis counter {ver,count=0} stuck, 8+ clean 10-min 401 cycles, status=active, no alert). Trigger B counts same-version 401s across cooldown cycles (debounced to collapse concurrent bursts) via getOAuth401SameVersionThreshold (default 1) and escalates with the oauth_401_same_version_persists_revoked marker. Both triggers funnel to handleAuthError (SetError + scheduling-blocked auth_error alert) prompting manual re-authorization. The flap is silent: the gateway 401 handler only writes temp_unschedulable while background refresh treats a successful/absent refresh as healthy (only invalid_grant hits SetError). Dropping any anchor silently restores the infinite-flap blind spot, which compiles clean and passes the pre-existing 401 cooldown tests. NB force-refresh-on-401 was deliberately NOT used (5b37e9ae→6aec5050 reverted it: writing the request-start credential snapshot resurrects a rotated refresh_token and falsely disables accounts)."
     },
     {
       "path": "backend/internal/service/oauth_401_after_refresh_counter.go",
@@ -361,10 +365,11 @@
         "oauth_401_after_refresh:account:",
         "NewOAuth401AfterRefreshCounterCache",
         "if ver > stored then",
+        "if (now - sameAt) >= debounce then",
         "RecordOAuth401AfterRefresh",
         "ResetOAuth401AfterRefresh"
       ],
-      "rationale": "Redis-backed atomic counter using a Hash {ver,count} + Lua script. The `if ver > stored then` branch is the load-bearing version gate: it only increments when the token used by this 401 is newer than the one recorded at the previous 401 (a successful refresh happened in between yet it still 401'd). The oauth_401_after_refresh:account: key prefix must stay stable so all app replicas share the same baseline/count. A refactor that drops the version comparison would turn the counter into a naive 401 counter and start permanently disabling accounts on ordinary transient/expiry 401s."
+      "rationale": "Redis-backed atomic counter using a Hash {ver,count,same,same_at} + Lua script returning {count, same} — two load-bearing version-gated dimensions. (1) The `if ver > stored then` branch is the version gate: increments `count` only when this 401's token is newer than the previously recorded one (a refresh happened yet it still 401'd). (2) The `if (now - sameAt) >= debounce then` branch is the same-version gate: when the version is FROZEN (grant revoked but access_token still valid → never refreshed) it increments `same` at most once per cooldown cycle (debounce collapses concurrent bursts; uses server-side redis.call('TIME') so multiple app replicas agree). The oauth_401_after_refresh:account: key prefix must stay stable so all replicas share one baseline. Dropping the version comparison turns it into a naive 401 counter (permanently disables accounts on transient/expiry 401s); dropping the same-version gate (or its debounce) re-opens the valid-but-revoked-token infinite-flap blind spot that trigger A is structurally blind to."
     },
     {
       "path": "backend/internal/service/ratelimit_service_tk_oauth401_test.go",


### PR DESCRIPTION
## Problem

A revoked Anthropic OAuth grant whose `access_token` is **still within its validity window** 401s forever in a 10-min `temp_unschedulable` flap and **never escalates** to a permanent error / Feishu **P0** alert.

The #493 escalation gate (`tkTryEscalateRevokedOAuth401`) only counts when `_token_version` **increases** — i.e. a refresh happened between two 401s and the new token still 401'd. But a still-valid token is never refreshed (`NeedsRefresh=false`), so the version is **frozen** and the gate can never advance. This is a structural blind spot of the version gate.

### Live evidence (edge-uk1 `edge-ls-uk-1-b` id=2, 2026-06-08)
- Grant revoked upstream at **11:26** (token refreshed 09:18, valid until 17:18 — ~6h of validity left).
- Redis counter `oauth_401_after_refresh:account:2` stuck at `{ver=1780910331086, count=0}`; DB `_token_version` identical.
- 8+ consecutive 401s at a clean ~10-min cadence (`11:26 → 11:36 → … → 12:40`), `status=active`, `error_message=''`, **never escalated**.
- During each cooldown the single-account edge served nothing (`select_account_no_available`) → prod relay failed over to other edges. feishu **was enabled** on the edge, so this is **not** a config issue — only the permanent P0 never fired.

## Fix

Add a **complementary same-version trigger** to the existing version-gated counter (the natural complement to #493's version-bump trigger):

- Lua script now maintains `{ver, count, same, same_at}` and returns `{count, same}`. The `same` dimension increments at most **once per cooldown cycle** (debounced via server-side `redis.call('TIME')` so concurrent bursts collapse and all app replicas agree).
- Escalate when `versionBumpCount ≥ threshold` **OR** `sameVersionCount ≥ OAuth401SameVersionDisableThreshold` (default **1**, configurable). Both funnel through `handleAuthError` → `SetError` + `auth_error` scheduling-blocked alert prompting manual re-auth. Version-bump keeps priority; a distinct slog marker `oauth_401_same_version_persists_revoked` separates the two.

**Invariants preserved:** every fail-open guard (nil counter / record error / missing `_token_version` → temp cooldown, never a false permanent disable) and all five reset-on-recovery sites.

**Deliberately NOT force-refresh-on-401:** `5b37e9ae → 6aec5050` reverted that approach — writing the request-start credential snapshot resurrects a rotated `refresh_token` and falsely disables accounts. This fix touches no token hotpath and writes no credentials.

This also matches open-source community best practice for shared Claude pools (Linux.do / claude-code #48079/#54443/#61912 / new-api·CRS): rolling revocation is frequent; on persistent 401 **disable + require manual re-auth**, never auto-retry the same token.

## Effect

`edge-ls-uk-1-b` (and any valid-but-revoked grant) now escalates on the 2nd same-version 401 (~10 min) to a red **P0 "立即重新 OAuth 授权"** instead of flapping silently forever. (Clearing the 401 still needs a human to re-authorize the account — code only converts the silent flap into an actionable alert.)

⚠️ **Behavior change:** this will permanently disable accounts that previously flapped — which is correct (stops one wasted upstream request per 10 min + prod failover pollution, and surfaces the P0). The threshold is configurable: if Anthropic ever returns 401 for valid tokens fleet-wide (transient), raise `OAuth401SameVersionDisableThreshold`; `reset-on-success` already clears the counter on any successful request.

## Verification
- `go build ./...` ✓
- `go test -tags=unit ./...` ✓ (full suite, 0 fail)
- `go test -tags=integration ./internal/repository/` ✓ (5 Lua two-dimension cases, real Redis)
- `golangci-lint run` ✓ 0 issues · `gofmt` ✓
- `scripts/preflight.sh` ✓ PASS (incl. sub2api sentinel layer)

Sentinels (`scripts/sentinels/gateway-tk.json`) updated with anchors for the new same-version mechanism so an upstream merge can't silently drop it.

## Merge
TK-originated fix → **Squash and merge** (per CLAUDE.md §5.y). Pure backend (`no-web-impact`), `config.go` touch guarded via sentinel update + `upstream-touch-guarded`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
