### PR TITLE
ci: roll Go build/test cache per-job so CI stops cold-rebuilding every run

### DIFF
--- a/.github/actions/go-rolling-cache/action.yml
+++ b/.github/actions/go-rolling-cache/action.yml
@@ -1,0 +1,45 @@
+# Single source for the Go cache strategy shared by the heavy Go CI jobs
+# (test-unit / test-integration / golangci-lint). Replaces setup-go's built-in
+# cache, which is keyed only on hash(go.sum), IMMUTABLE (saved once on first
+# miss), and was shared across these jobs even though they build different
+# objects (-tags=unit vs =integration vs none) — whichever job won the post-job
+# save race poisoned the others, so the test-result cache effectively never
+# restored and every run cold-compiled + re-ran all packages.
+#
+# Two caches, deliberately split:
+#   - module cache: identical across all jobs, only changes with go.sum, so one
+#     shared immutable entry is correct and avoids triplicating ~1GB of
+#     GOMODCACHE against the 10GB/repo budget.
+#   - build/test cache: per-job (prefix) + run_id-unique save key so it ROLLS
+#     forward every run; restore-keys seeds from the previous run (incremental,
+#     not cold). Go's cache is content-addressed, so a stale entry is unused,
+#     never wrong.
+#
+# Set `cache: false` on the calling job's actions/setup-go step and call this
+# AFTER it (mirrors warm-release-cache in backend-ci.yml).
+name: Go rolling build/test cache
+description: Shared module cache + per-job rolling Go build/test cache (replaces setup-go's immutable shared cache).
+
+inputs:
+  prefix:
+    description: Per-job cache namespace (e.g. unit / integration / lint) — keeps build objects from colliding across build tags.
+    required: true
+
+runs:
+  using: composite
+  steps:
+    - name: Go module cache
+      uses: actions/cache@v4
+      with:
+        path: ~/go/pkg/mod
+        key: ${{ runner.os }}-gomod-${{ hashFiles('backend/go.sum') }}
+        restore-keys: ${{ runner.os }}-gomod-
+
+    - name: Go build/test cache (rolling, ${{ inputs.prefix }})
+      uses: actions/cache@v4
+      with:
+        path: ~/.cache/go-build
+        key: ${{ runner.os }}-gobuild-${{ inputs.prefix }}-${{ hashFiles('backend/go.sum') }}-${{ github.run_id }}
+        restore-keys: |
+          ${{ runner.os }}-gobuild-${{ inputs.prefix }}-${{ hashFiles('backend/go.sum') }}-
+          ${{ runner.os }}-gobuild-${{ inputs.prefix }}-

--- a/.github/workflows/backend-ci.yml
+++ b/.github/workflows/backend-ci.yml
@@ -57,40 +57,18 @@ jobs:
     steps:
       - uses: actions/checkout@v6
       - uses: ./.github/actions/cache-and-checkout-new-api
-      # cache:false — setup-go's go.sum-keyed cache is IMMUTABLE (saved once on
-      # first miss, never refreshed) AND shared across test-unit/test-integration/
-      # golangci-lint, which build different objects (-tags=unit vs =integration
-      # vs none). Whichever job won the save race poisoned the others, so the unit
-      # test-result cache was effectively NEVER restored — every CI run cold-compiled
-      # AND re-ran all 52 packages (~262s). We own caching explicitly below instead.
+      # cache:false + ./.github/actions/go-rolling-cache — setup-go's built-in
+      # cache is immutable and was shared across the three Go jobs despite their
+      # differing build tags, so the test-result cache never persisted (every run
+      # cold-compiled + re-ran all packages). See that composite for the full why.
       - uses: actions/setup-go@v6
         with:
           go-version-file: backend/go.mod
           check-latest: false
           cache: false
-      # Shared, immutable module cache — modules only change with go.sum, so a
-      # single entry keyed on go.sum is correct and avoids triplicating ~1GB of
-      # GOMODCACHE across the three rolling build caches (10GB/repo budget).
-      - name: Go module cache
-        uses: actions/cache@v4
+      - uses: ./.github/actions/go-rolling-cache
         with:
-          path: ~/go/pkg/mod
-          key: ${{ runner.os }}-gomod-${{ hashFiles('backend/go.sum') }}
-          restore-keys: ${{ runner.os }}-gomod-
-      # Rolling per-job build+test cache (mirrors warm-release-cache below): a
-      # run_id-unique SAVE key always re-saves at post-job so the cache rolls
-      # forward every run; restore-keys seeds from the previous run (incremental,
-      # not cold). Distinct `unit` prefix keeps it from colliding with the
-      # integration/lint build objects. Go's cache is content-addressed, so a
-      # stale entry is unused, never wrong.
-      - name: Go build/test cache (rolling, unit)
-        uses: actions/cache@v4
-        with:
-          path: ~/.cache/go-build
-          key: ${{ runner.os }}-gobuild-unit-${{ hashFiles('backend/go.sum') }}-${{ github.run_id }}
-          restore-keys: |
-            ${{ runner.os }}-gobuild-unit-${{ hashFiles('backend/go.sum') }}-
-            ${{ runner.os }}-gobuild-unit-
+          prefix: unit
       - name: Verify Go version
         run: |
           go version | grep -q 'go1.26.4'
@@ -104,26 +82,15 @@ jobs:
     steps:
       - uses: actions/checkout@v6
       - uses: ./.github/actions/cache-and-checkout-new-api
-      # cache:false + explicit rolling cache — see test-unit rationale above.
+      # cache:false + ./.github/actions/go-rolling-cache — see test-unit above.
       - uses: actions/setup-go@v6
         with:
           go-version-file: backend/go.mod
           check-latest: false
           cache: false
-      - name: Go module cache
-        uses: actions/cache@v4
+      - uses: ./.github/actions/go-rolling-cache
         with:
-          path: ~/go/pkg/mod
-          key: ${{ runner.os }}-gomod-${{ hashFiles('backend/go.sum') }}
-          restore-keys: ${{ runner.os }}-gomod-
-      - name: Go build/test cache (rolling, integration)
-        uses: actions/cache@v4
-        with:
-          path: ~/.cache/go-build
-          key: ${{ runner.os }}-gobuild-integration-${{ hashFiles('backend/go.sum') }}-${{ github.run_id }}
-          restore-keys: |
-            ${{ runner.os }}-gobuild-integration-${{ hashFiles('backend/go.sum') }}-
-            ${{ runner.os }}-gobuild-integration-
+          prefix: integration
       - name: Verify Go version
         run: |
           go version | grep -q 'go1.26.4'
@@ -161,28 +128,17 @@ jobs:
     steps:
       - uses: actions/checkout@v6
       - uses: ./.github/actions/cache-and-checkout-new-api
-      # cache:false + explicit rolling cache — see test-unit rationale above.
+      # cache:false + ./.github/actions/go-rolling-cache — see test-unit above.
       # golangci-lint-action manages its own analysis cache (~/.cache/golangci-lint)
-      # on top of the GOCACHE we roll here; the two are independent.
+      # on top of the GOCACHE this rolls; the two are independent.
       - uses: actions/setup-go@v6
         with:
           go-version-file: backend/go.mod
           check-latest: false
           cache: false
-      - name: Go module cache
-        uses: actions/cache@v4
+      - uses: ./.github/actions/go-rolling-cache
         with:
-          path: ~/go/pkg/mod
-          key: ${{ runner.os }}-gomod-${{ hashFiles('backend/go.sum') }}
-          restore-keys: ${{ runner.os }}-gomod-
-      - name: Go build cache (rolling, lint)
-        uses: actions/cache@v4
-        with:
-          path: ~/.cache/go-build
-          key: ${{ runner.os }}-gobuild-lint-${{ hashFiles('backend/go.sum') }}-${{ github.run_id }}
-          restore-keys: |
-            ${{ runner.os }}-gobuild-lint-${{ hashFiles('backend/go.sum') }}-
-            ${{ runner.os }}-gobuild-lint-
+          prefix: lint
       - name: Verify Go version
         run: |
           go version | grep -q 'go1.26.4'

--- a/.github/workflows/backend-ci.yml
+++ b/.github/workflows/backend-ci.yml
@@ -57,12 +57,40 @@ jobs:
     steps:
       - uses: actions/checkout@v6
       - uses: ./.github/actions/cache-and-checkout-new-api
+      # cache:false — setup-go's go.sum-keyed cache is IMMUTABLE (saved once on
+      # first miss, never refreshed) AND shared across test-unit/test-integration/
+      # golangci-lint, which build different objects (-tags=unit vs =integration
+      # vs none). Whichever job won the save race poisoned the others, so the unit
+      # test-result cache was effectively NEVER restored — every CI run cold-compiled
+      # AND re-ran all 52 packages (~262s). We own caching explicitly below instead.
       - uses: actions/setup-go@v6
         with:
           go-version-file: backend/go.mod
           check-latest: false
-          cache: true
-          cache-dependency-path: backend/go.sum
+          cache: false
+      # Shared, immutable module cache — modules only change with go.sum, so a
+      # single entry keyed on go.sum is correct and avoids triplicating ~1GB of
+      # GOMODCACHE across the three rolling build caches (10GB/repo budget).
+      - name: Go module cache
+        uses: actions/cache@v4
+        with:
+          path: ~/go/pkg/mod
+          key: ${{ runner.os }}-gomod-${{ hashFiles('backend/go.sum') }}
+          restore-keys: ${{ runner.os }}-gomod-
+      # Rolling per-job build+test cache (mirrors warm-release-cache below): a
+      # run_id-unique SAVE key always re-saves at post-job so the cache rolls
+      # forward every run; restore-keys seeds from the previous run (incremental,
+      # not cold). Distinct `unit` prefix keeps it from colliding with the
+      # integration/lint build objects. Go's cache is content-addressed, so a
+      # stale entry is unused, never wrong.
+      - name: Go build/test cache (rolling, unit)
+        uses: actions/cache@v4
+        with:
+          path: ~/.cache/go-build
+          key: ${{ runner.os }}-gobuild-unit-${{ hashFiles('backend/go.sum') }}-${{ github.run_id }}
+          restore-keys: |
+            ${{ runner.os }}-gobuild-unit-${{ hashFiles('backend/go.sum') }}-
+            ${{ runner.os }}-gobuild-unit-
       - name: Verify Go version
         run: |
           go version | grep -q 'go1.26.4'
@@ -76,12 +104,26 @@ jobs:
     steps:
       - uses: actions/checkout@v6
       - uses: ./.github/actions/cache-and-checkout-new-api
+      # cache:false + explicit rolling cache — see test-unit rationale above.
       - uses: actions/setup-go@v6
         with:
           go-version-file: backend/go.mod
           check-latest: false
-          cache: true
-          cache-dependency-path: backend/go.sum
+          cache: false
+      - name: Go module cache
+        uses: actions/cache@v4
+        with:
+          path: ~/go/pkg/mod
+          key: ${{ runner.os }}-gomod-${{ hashFiles('backend/go.sum') }}
+          restore-keys: ${{ runner.os }}-gomod-
+      - name: Go build/test cache (rolling, integration)
+        uses: actions/cache@v4
+        with:
+          path: ~/.cache/go-build
+          key: ${{ runner.os }}-gobuild-integration-${{ hashFiles('backend/go.sum') }}-${{ github.run_id }}
+          restore-keys: |
+            ${{ runner.os }}-gobuild-integration-${{ hashFiles('backend/go.sum') }}-
+            ${{ runner.os }}-gobuild-integration-
       - name: Verify Go version
         run: |
           go version | grep -q 'go1.26.4'
@@ -119,12 +161,28 @@ jobs:
     steps:
       - uses: actions/checkout@v6
       - uses: ./.github/actions/cache-and-checkout-new-api
+      # cache:false + explicit rolling cache — see test-unit rationale above.
+      # golangci-lint-action manages its own analysis cache (~/.cache/golangci-lint)
+      # on top of the GOCACHE we roll here; the two are independent.
       - uses: actions/setup-go@v6
         with:
           go-version-file: backend/go.mod
           check-latest: false
-          cache: true
-          cache-dependency-path: backend/go.sum
+          cache: false
+      - name: Go module cache
+        uses: actions/cache@v4
+        with:
+          path: ~/go/pkg/mod
+          key: ${{ runner.os }}-gomod-${{ hashFiles('backend/go.sum') }}
+          restore-keys: ${{ runner.os }}-gomod-
+      - name: Go build cache (rolling, lint)
+        uses: actions/cache@v4
+        with:
+          path: ~/.cache/go-build
+          key: ${{ runner.os }}-gobuild-lint-${{ hashFiles('backend/go.sum') }}-${{ github.run_id }}
+          restore-keys: |
+            ${{ runner.os }}-gobuild-lint-${{ hashFiles('backend/go.sum') }}-
+            ${{ runner.os }}-gobuild-lint-
       - name: Verify Go version
         run: |
           go version | grep -q 'go1.26.4'


### PR DESCRIPTION
## 问题（核查实证）

CI 主工作流 `CI`（`backend-ci.yml`）关键路径 = `test-unit` ~283s（Unit tests 步骤 262s），各 job 并行所以总时长 ≈ 最慢 job。

抓真实 main CI 日志：`test-unit` **52 个包全部新鲜执行、0 个 `(cached)`**（`internal/handler 29.719s`、`ent/schema 2.748s`…），首个测试输出前 ~128s 纯编译空窗。

本地受控实验证明缓存机制完好：GOCACHE 持久 + 输入不变时 `go test -tags=unit ./...` 是 **52/52 `(cached)`、~1s**。所以 CI 慢纯粹是**缓存跨 run 不持久化**。

**根因**：`setup-go` 缓存 key 仅按 `hash(go.sum)`、命中后不再保存（不可变），且 `test-unit`/`test-integration`/`golangci-lint` 三 job 共用同一 key，但 unit/integration 用不同 build tag 产物不同 → post-job 保存 race 互相污染，unit 的 test-result 缓存几乎从不被保存。每次 CI 全量重编 + 全量重跑。该缓存自 #102（4/29）起就结构性失效，测试套件持续增长（`internal/service` 单包 4050 测试 / 串行 ~110s）而无缓存吸收 → "又变慢"的锯齿。

## 改动（仅 `backend-ci.yml`，复用同文件已验证的 `warm-release-cache` 范式）

对 `test-unit` / `test-integration` / `golangci-lint`：
- `setup-go` 改 `cache: false`，停止依赖那个不可变、跨 job 互污的共享缓存。
- 新增**共享不可变 module 缓存**（`~/go/pkg/mod`，按 go.sum，单份省存储）。
- 新增 **per-job 滚动 build+test 缓存**（`~/.cache/go-build`，`run_id` 唯一 save key + `restore-keys` 前缀 `unit`/`integration`/`lint`），每 run 滚动前进、增量恢复。

## 预期

常见路径（PR 只改少量包）下 `test-unit` 从 ~262s 降到数十秒级——仅变更包重编重跑，其余 `(cached)`。内容寻址缓存，陈旧条目被忽略、永不会错。

## 非目标

`internal/service` 长杆（4050 测试 / 串行 ~110s）被改动时仍需重跑；彻底解决需 `t.Parallel()` 或 matrix 分片，改动面大，留后续。

## 验证

- 本地 `scripts/preflight.sh` 全 PASS（含 `release/warm Go cache key parity`）。
- YAML 合法（`yaml.safe_load`）。
- CI 上验证：本 PR 第二次小 commit（只改单包）时 `test-unit` 日志除被改包外应全部 `(cached)`，Unit tests 步骤大幅缩短。

🤖 Generated with [Claude Code](https://claude.com/claude-code)