### PR TITLE
fix(dashboard): make rolling presets use absolute time so two machines agree

### DIFF
--- a/backend/internal/handler/admin/dashboard_handler.go
+++ b/backend/internal/handler/admin/dashboard_handler.go
@@ -34,6 +34,13 @@ func NewDashboardHandler(dashboardService *service.DashboardService, aggregation
 // parseTimeRange parses start_date, end_date query parameters
 // Uses user's timezone if provided, otherwise falls back to server timezone
 func parseTimeRange(c *gin.Context) (time.Time, time.Time) {
+	// TK: rolling/duration presets send precise epoch-ms instants so the window
+	// is timezone-independent and identical across viewers. See
+	// dashboard_handler_tk_window.go for the rationale.
+	if s, e, ok := parseAbsoluteRange(c); ok {
+		return s, e
+	}
+
 	userTZ := c.Query("timezone") // Get user's timezone from request
 	now := timezone.NowInUserLocation(userTZ)
 	startDate := c.Query("start_date")

--- a/backend/internal/handler/admin/dashboard_handler_tk_window.go
+++ b/backend/internal/handler/admin/dashboard_handler_tk_window.go
@@ -1,0 +1,71 @@
+package admin
+
+import (
+	"strconv"
+	"strings"
+	"time"
+
+	"github.com/gin-gonic/gin"
+)
+
+// TK: absolute-time window channel for the admin dashboard.
+//
+// The default `start_date`/`end_date` channel is date-granular and re-expanded
+// by parseTimeRange into the *user's timezone* day boundaries. That makes a
+// rolling preset like "近24小时" resolve to a different absolute window per
+// viewer timezone — two admins (e.g. one browser reporting Asia/Shanghai, one
+// reporting a US zone) then see materially different numbers for the same
+// selection. Rolling/duration presets are an absolute concept ("the last N
+// hours" is the same window everywhere on Earth), so the frontend sends precise
+// epoch-millisecond instants for them and we honor those verbatim, bypassing
+// the timezone-dependent date expansion entirely.
+//
+// Calendar presets (today / this month / custom date pick) keep using the
+// date-string + timezone path, where per-viewer local-calendar boundaries are
+// the intended behavior.
+
+// absoluteRangeFloor guards against absurd / malicious timestamps. Any data
+// predates this; anything before it is treated as "not an absolute range".
+var absoluteRangeFloor = time.Date(2020, 1, 1, 0, 0, 0, 0, time.UTC)
+
+// parseAbsoluteRange reads start_ts / end_ts (epoch milliseconds) from the
+// request. It returns ok=true only when BOTH are present, parse cleanly, sit
+// after absoluteRangeFloor, are not unreasonably far in the future, and form a
+// non-empty window (end > start). When ok=false the caller falls back to the
+// legacy date-string + timezone path, so the absence or malformation of these
+// params never changes existing behavior.
+func parseAbsoluteRange(c *gin.Context) (start time.Time, end time.Time, ok bool) {
+	startMs, ok1 := parseEpochMillis(c.Query("start_ts"))
+	endMs, ok2 := parseEpochMillis(c.Query("end_ts"))
+	if !ok1 || !ok2 {
+		return time.Time{}, time.Time{}, false
+	}
+
+	start = time.UnixMilli(startMs).UTC()
+	end = time.UnixMilli(endMs).UTC()
+
+	if !end.After(start) {
+		return time.Time{}, time.Time{}, false
+	}
+	if start.Before(absoluteRangeFloor) {
+		return time.Time{}, time.Time{}, false
+	}
+	// Allow a little clock skew but reject windows that run far into the future.
+	if end.After(time.Now().UTC().Add(2 * time.Hour)) {
+		return time.Time{}, time.Time{}, false
+	}
+
+	return start, end, true
+}
+
+func parseEpochMillis(raw string) (int64, bool) {
+	raw = strings.TrimSpace(raw)
+	if raw == "" {
+		return 0, false
+	}
+	v, err := strconv.ParseInt(raw, 10, 64)
+	if err != nil || v <= 0 {
+		return 0, false
+	}
+	return v, true
+}

--- a/backend/internal/handler/admin/dashboard_handler_tk_window_test.go
+++ b/backend/internal/handler/admin/dashboard_handler_tk_window_test.go
@@ -1,0 +1,78 @@
+package admin
+
+import (
+	"fmt"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+	"time"
+
+	"github.com/gin-gonic/gin"
+	"github.com/stretchr/testify/require"
+)
+
+func ctxWithURL(rawURL string) *gin.Context {
+	w := httptest.NewRecorder()
+	c, _ := gin.CreateTestContext(w)
+	c.Request = httptest.NewRequest(http.MethodGet, rawURL, nil)
+	return c
+}
+
+// TestParseAbsoluteRange_TimezoneIndependent is the regression guard for the
+// "two machines see different dashboard data" bug: given precise start_ts/end_ts,
+// the resolved window must be identical regardless of the timezone query param.
+func TestParseAbsoluteRange_TimezoneIndependent(t *testing.T) {
+	gin.SetMode(gin.TestMode)
+
+	endMs := time.Date(2026, 6, 8, 15, 8, 0, 0, time.UTC).UnixMilli()
+	startMs := endMs - 24*60*60*1000
+
+	shanghai := ctxWithURL(fmt.Sprintf("/?start_ts=%d&end_ts=%d&timezone=Asia/Shanghai", startMs, endMs))
+	la := ctxWithURL(fmt.Sprintf("/?start_ts=%d&end_ts=%d&timezone=America/Los_Angeles", startMs, endMs))
+
+	s1, e1 := parseTimeRange(shanghai)
+	s2, e2 := parseTimeRange(la)
+
+	require.Equal(t, s1, s2, "start must not depend on timezone when absolute ts given")
+	require.Equal(t, e1, e2, "end must not depend on timezone when absolute ts given")
+	require.Equal(t, time.UnixMilli(startMs).UTC(), s1)
+	require.Equal(t, time.UnixMilli(endMs).UTC(), e1)
+	require.Equal(t, 24*time.Hour, e1.Sub(s1))
+}
+
+func TestParseAbsoluteRange_RejectsAndFallsBack(t *testing.T) {
+	gin.SetMode(gin.TestMode)
+	now := time.Now().UTC().UnixMilli()
+
+	cases := []struct {
+		name string
+		url  string
+	}{
+		{"missing end_ts", fmt.Sprintf("/?start_ts=%d", now)},
+		{"missing start_ts", fmt.Sprintf("/?end_ts=%d", now)},
+		{"empty", "/"},
+		{"non-numeric", "/?start_ts=abc&end_ts=def"},
+		{"end before start", fmt.Sprintf("/?start_ts=%d&end_ts=%d", now, now-1000)},
+		{"end equals start", fmt.Sprintf("/?start_ts=%d&end_ts=%d", now, now)},
+		{"before floor", fmt.Sprintf("/?start_ts=%d&end_ts=%d", int64(1000), now)},
+		{"far future", fmt.Sprintf("/?start_ts=%d&end_ts=%d", now, now+24*60*60*1000)},
+		{"negative", "/?start_ts=-5&end_ts=-1"},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			_, _, ok := parseAbsoluteRange(ctxWithURL(tc.url))
+			require.False(t, ok, "expected absolute-range parse to reject %q", tc.url)
+		})
+	}
+}
+
+// TestParseTimeRange_FallbackUnchanged ensures the legacy date-string + timezone
+// path is untouched when no absolute ts is supplied.
+func TestParseTimeRange_FallbackUnchanged(t *testing.T) {
+	gin.SetMode(gin.TestMode)
+	c := ctxWithURL("/?start_date=2024-01-01&end_date=2024-01-02&timezone=UTC")
+	start, end := parseTimeRange(c)
+	require.Equal(t, time.Date(2024, 1, 1, 0, 0, 0, 0, time.UTC), start)
+	require.Equal(t, time.Date(2024, 1, 3, 0, 0, 0, 0, time.UTC), end)
+}

--- a/backend/internal/web/dist/frontend-source.json
+++ b/backend/internal/web/dist/frontend-source.json
@@ -1,7 +1,7 @@
 {
   "algorithm": "sha256(git-ls-files:path,size,content)",
-  "file_count": 459,
-  "hash": "a2d090824d68cc0c97fa3df629159e7d45833862c969704e4a74a88e10232f45",
+  "file_count": 460,
+  "hash": "327ec596a6ebcd17ed23a8aaa9d6c2e0923b72d6e55e7e4117047efab39e693d",
   "schema": 1,
   "source": "frontend/"
 }

--- a/frontend/src/api/admin/dashboard.ts
+++ b/frontend/src/api/admin/dashboard.ts
@@ -47,6 +47,11 @@ export async function getRealtimeMetrics(): Promise<{
 export interface TrendParams {
   start_date?: string
   end_date?: string
+  // TK: absolute epoch-ms window for rolling presets (timezone-independent).
+  // When present, the backend uses these verbatim and ignores the timezone-
+  // derived date expansion. See utils/dashboardWindow.tk.ts.
+  start_ts?: number
+  end_ts?: number
   granularity?: 'day' | 'hour'
   user_id?: number
   api_key_id?: number
@@ -236,7 +241,7 @@ export interface UserTrendResponse {
 }
 
 export interface UserSpendingRankingParams
-  extends Pick<TrendParams, 'start_date' | 'end_date'> {
+  extends Pick<TrendParams, 'start_date' | 'end_date' | 'start_ts' | 'end_ts'> {
   limit?: number
 }
 

--- a/frontend/src/utils/dashboardWindow.tk.ts
+++ b/frontend/src/utils/dashboardWindow.tk.ts
@@ -1,0 +1,56 @@
+/**
+ * TK: absolute-time windows for rolling dashboard presets.
+ *
+ * Rolling/duration presets ("近24小时 / 近7天 / …") are an absolute concept —
+ * "the last N hours" is the same window everywhere on Earth. The legacy path
+ * sends them as `YYYY-MM-DD` date strings, which the backend re-expands into the
+ * *viewer's timezone* day boundaries. Two admins whose browsers report different
+ * timezones (e.g. a fingerprint browser spoofing a US zone vs. Asia/Shanghai)
+ * then see the SAME selection resolve to different absolute windows and thus
+ * different numbers. To make the window timezone-independent, we send precise
+ * epoch-millisecond instants (`start_ts`/`end_ts`) computed from `Date.now()`.
+ *
+ * Calendar presets (today / yesterday / this month / last month / custom date
+ * pick) intentionally keep the date-string + timezone path: a "today" report is
+ * a local-calendar concept and should follow the viewer's timezone.
+ */
+
+const HOUR_MS = 60 * 60 * 1000
+const DAY_MS = 24 * HOUR_MS
+
+/**
+ * Maps a DateRangePicker preset value to its rolling duration in milliseconds.
+ * Only presets listed here are treated as absolute rolling windows; any other
+ * preset (or a manual custom selection, where preset is null) falls back to the
+ * date-string + timezone path.
+ */
+export const ROLLING_PRESET_MS: Record<string, number> = {
+  last24Hours: 24 * HOUR_MS,
+  '7days': 7 * DAY_MS,
+  '14days': 14 * DAY_MS,
+  '30days': 30 * DAY_MS
+}
+
+/** Floor a timestamp to the start of its wall-clock minute. */
+const floorToMinute = (ms: number): number => ms - (ms % (60 * 1000))
+
+/**
+ * For a rolling preset, returns the absolute window as epoch-ms params suitable
+ * for spreading into a dashboard request. Returns null for calendar presets /
+ * custom selections so the caller keeps sending only start_date/end_date.
+ *
+ * The end is floored to the current minute so near-simultaneous loads (and
+ * multiple machines) produce an identical window — identical cache key, byte-
+ * identical numbers. Refreshing a minute later simply advances by one minute of
+ * fresh data, which is the intuitive behavior.
+ */
+export function rollingWindowTs(
+  preset: string | null | undefined
+): { start_ts: number; end_ts: number } | null {
+  if (!preset) return null
+  const duration = ROLLING_PRESET_MS[preset]
+  if (!duration) return null
+
+  const end = floorToMinute(Date.now())
+  return { start_ts: end - duration, end_ts: end }
+}

--- a/frontend/src/views/admin/DashboardView.vue
+++ b/frontend/src/views/admin/DashboardView.vue
@@ -373,6 +373,7 @@ import DateRangePicker from '@/components/common/DateRangePicker.vue'
 import Select from '@/components/common/Select.vue'
 import ModelDistributionChart from '@/components/charts/ModelDistributionChart.vue'
 import TokenUsageTrend from '@/components/charts/TokenUsageTrend.vue'
+import { rollingWindowTs } from '@/utils/dashboardWindow.tk'
 
 import {
   Chart as ChartJS,
@@ -438,6 +439,10 @@ const granularity = ref<'day' | 'hour'>('hour')
 const defaultRange = getLast24HoursRangeDates()
 const startDate = ref(defaultRange.start)
 const endDate = ref(defaultRange.end)
+// TK: tracks the active DateRangePicker preset so rolling presets can be sent
+// as an absolute (timezone-independent) epoch-ms window. Defaults to
+// 'last24Hours' to match the default range above. See utils/dashboardWindow.tk.ts.
+const activePreset = ref<string | null>('last24Hours')
 
 // Granularity options for Select component
 const granularityOptions = computed(() => [
@@ -668,6 +673,8 @@ const onDateRangeChange = (range: {
   endDate: string
   preset: string | null
 }) => {
+  // TK: remember the preset so rolling windows go out as absolute epoch-ms.
+  activePreset.value = range.preset
   // Auto-select granularity based on date range
   const start = new Date(range.startDate)
   const end = new Date(range.endDate)
@@ -694,6 +701,7 @@ const loadDashboardSnapshot = async (includeStats: boolean) => {
     const response = await adminAPI.dashboard.getSnapshotV2({
       start_date: startDate.value,
       end_date: endDate.value,
+      ...rollingWindowTs(activePreset.value),
       granularity: granularity.value,
       include_stats: includeStats,
       include_trend: true,
@@ -726,6 +734,7 @@ const loadUsersTrend = async () => {
     const response = await adminAPI.dashboard.getUserUsageTrend({
       start_date: startDate.value,
       end_date: endDate.value,
+      ...rollingWindowTs(activePreset.value),
       granularity: granularity.value,
       limit: 12
     })
@@ -750,6 +759,7 @@ const loadUserSpendingRanking = async () => {
     const response = await adminAPI.dashboard.getUserSpendingRanking({
       start_date: startDate.value,
       end_date: endDate.value,
+      ...rollingWindowTs(activePreset.value),
       limit: rankingLimit
     })
     if (currentSeq !== rankingLoadSeq) return

--- a/scripts/sentinels/gateway-tk.json
+++ b/scripts/sentinels/gateway-tk.json
@@ -2026,6 +2026,13 @@
         "hwka.stop()"
       ],
       "rationale": "Header-wait SSE keepalive injection on the OpenAI/Codex passthrough streaming forward (forwardOpenAIPassthrough, around s.httpUpstream.Do). Same Wei-Shaw/sub2api#2121 idle-drop fix as the Anthropic Forward path, same failover-safe delayed-first-ping (the handler's failover gate compares c.Writer.Size() before/after forward). stop() must run the instant Do() returns. Catches an upstream merge that copies the old Do() shape back over the injection."
+    },
+    {
+      "path": "backend/internal/handler/admin/dashboard_handler.go",
+      "must_contain": [
+        "if s, e, ok := parseAbsoluteRange(c); ok {"
+      ],
+      "rationale": "Thin TK injection at the top of the upstream-owned parseTimeRange (the single chokepoint for all 7 dashboard time-window endpoints). Rolling presets (近24小时/7/14/30天) send absolute epoch-ms start_ts/end_ts so the window is timezone-independent; without this hook the window falls back to the viewer's browser-reported timezone and two admin sessions on different timezones (e.g. a fingerprint browser spoofing a US zone vs Asia/Shanghai) again see materially different dashboard numbers for the same selection. The implementation lives in the dashboard_handler_tk_window.go companion; this sentinel anchors the one-line call site that an upstream merge copying the old parseTimeRange shape back would silently drop."
     }
   ]
 }


### PR DESCRIPTION
## 问题

同一 admin 账号在两台机器（左 SunBrowser 指纹浏览器、右 Chrome）打开 `/admin/dashboard`，同一个「近24小时」看到不同的「今日请求 / Token / 用户消费榜」；而流量全在重叠区的用户两边一致。

## 根因

仪表盘统计时间窗**依赖浏览器自报的时区**（`Intl.DateTimeFormat`）。「近24小时」被降精度成 `YYYY-MM-DD` 日期串发出，后端 `parseTimeRange` 再按**用户时区**展开成当地自然日边界（且实际是 ~48h 日对齐窗）。两台浏览器上报时区不同（指纹浏览器伪装美国时区 vs `Asia/Shanghai`），同一选项被解析成相差约 15h 的两个绝对窗，聚合出不同数据。prod 单实例，排除缓存副本漂移——差异只能来自时区。算账与截图完全吻合。

## 修复（方向 A：滚动窗用绝对时间）

- 滚动/时长预设（近24小时/7/14/30天）改发绝对 epoch-ms `start_ts`/`end_ts`（`end` floor 到整分钟 → 跨机一致），后端原样按精确窗聚合，绕过时区日期展开。
- 自然日历预设（今天/本月/自定义）保持原 tz-local 路径。
- 顺带修掉「近24小时实为 ~48h」的标注 bug。
- `parseTimeRange` 是 7 个时间窗端点的唯一收口，改一处全覆盖。

## 改动（TK §5 最小侵入）

| 文件 | 作用 |
|---|---|
| `backend/.../dashboard_handler_tk_window.go`（新） | `parseAbsoluteRange`（含边界校验） |
| `backend/.../dashboard_handler.go` | `parseTimeRange` 顶部 3 行 hook（无 ts 时行为不变） |
| `frontend/src/utils/dashboardWindow.tk.ts`（新） | `rollingWindowTs` |
| `frontend/src/api/admin/dashboard.ts` | 可选 `start_ts`/`end_ts` |
| `frontend/src/views/admin/DashboardView.vue` | `activePreset` + 三处 spread |
| `scripts/sentinels/gateway-tk.json` | 锚定注入点，防 upstream merge 静默丢失 |
| `backend/.../dashboard_handler_tk_window_test.go`（新） | 时区无关性 + 非法回退回归测试 |

## 取舍

`7/14/30天` 由「日历末端=today 的日对齐区间」变为「滚动 N×24h」，`按天` 粒度下首/尾日可能是部分桶（更诚实）。`today/yesterday/thisMonth/lastMonth` 保持 tz-local。

## 验证

- `go build ./...` ✅ · `go test -tags=unit ./...` 全过（含新测试）✅
- `pnpm typecheck` ✅ · `pnpm lint:check` ✅ · `pnpm build`（重建嵌入 dist + manifest）✅
- `scripts/preflight.sh` **PASS** ✅
- 手验：本地 Stage0 起栈，用两个不同时区的浏览器看「近24小时」应一致（仅差刷新时刻 ~1 分钟数据）。

> 备注：本修复让「近X」在任何浏览器一致；但用伪装时区的指纹浏览器看「今天/本月」这类日历预设仍按伪装时区显示——预期行为。

## 合并

TK 自源 fix PR → **Squash and merge**。

🤖 Generated with [Claude Code](https://claude.com/claude-code)