### PR TITLE
feat(deploy): prod rollout 上线后自动推飞书发版同步卡片

### DIFF
--- a/.github/workflows/deploy-stage0.yml
+++ b/.github/workflows/deploy-stage0.yml
@@ -179,6 +179,20 @@ jobs:
           # already-deployed image.
           bash ops/stage0/post_deploy_smoke.sh
 
+      - name: Notify Feishu (release rollout)
+        # Best-effort 发版公告。默认 step gating 保证它只在 prod 换镜像 +
+        # External health + smoke 全绿后才跑 —— 卡片 == "该版本已上线且烟测通过"。
+        # continue-on-error 让 webhook 抽风不把成功的 prod deploy 标红(对齐
+        # release.yml 的 Telegram 步)。脚本本身也始终 exit 0(双保险),失败时
+        # 打 ::warning::,绝不打印 webhook/secret。
+        continue-on-error: true
+        env:
+          TK_FEISHU_WEBHOOK_URL: ${{ secrets.TK_FEISHU_WEBHOOK_URL }}
+          TK_FEISHU_SIGNING_SECRET: ${{ secrets.TK_FEISHU_SIGNING_SECRET }}
+          API_URL: ${{ steps.instance.outputs.api_url }}
+          RUN_URL: ${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}
+        run: bash ops/stage0/notify-feishu-release.sh "$INPUT_TAG" "$API_URL" --run-url "$RUN_URL"
+
       - name: Job summary
         if: always()
         env:

--- a/.github/workflows/deploy-stage0.yml
+++ b/.github/workflows/deploy-stage0.yml
@@ -182,16 +182,25 @@ jobs:
       - name: Notify Feishu (release rollout)
         # Best-effort 发版公告。默认 step gating 保证它只在 prod 换镜像 +
         # External health + smoke 全绿后才跑 —— 卡片 == "该版本已上线且烟测通过"。
-        # continue-on-error 让 webhook 抽风不把成功的 prod deploy 标红(对齐
+        # 标 continue-on-error 让 webhook 抽风不把成功的 prod deploy 标红(对齐
         # release.yml 的 Telegram 步)。脚本本身也始终 exit 0(双保险),失败时
         # 打 ::warning::,绝不打印 webhook/secret。
-        continue-on-error: true
+        continue-on-error: true  # preflight-allow: swallow
         env:
           TK_FEISHU_WEBHOOK_URL: ${{ secrets.TK_FEISHU_WEBHOOK_URL }}
           TK_FEISHU_SIGNING_SECRET: ${{ secrets.TK_FEISHU_SIGNING_SECRET }}
           API_URL: ${{ steps.instance.outputs.api_url }}
           RUN_URL: ${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}
-        run: bash ops/stage0/notify-feishu-release.sh "$INPUT_TAG" "$API_URL" --run-url "$RUN_URL"
+          GH_TOKEN: ${{ github.token }}
+        run: |
+          set -uo pipefail
+          # 取本次 Release 的 changelog(goreleaser 自动生成,内含自上次 tag 以来
+          # 的提交)内联到卡片;Release 尚未建/手动重放旧 tag 取不到时退回空,
+          # 卡片降级为只留 Release 链接。无 set -e,gh 失败只让 NOTES 为空,
+          # 不影响通知本身(best-effort)。
+          NOTES="$(gh release view "v$INPUT_TAG" --json body --jq '.body' 2>/dev/null)"
+          bash ops/stage0/notify-feishu-release.sh "$INPUT_TAG" "$API_URL" \
+            --run-url "$RUN_URL" --notes "$NOTES"
 
       - name: Job summary
         if: always()

--- a/ops/stage0/notify-feishu-release.sh
+++ b/ops/stage0/notify-feishu-release.sh
@@ -1,0 +1,211 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+# Post a best-effort "release rolled out" card to the shared TokenKey ops Feishu
+# webhook after a successful prod Stage0 deploy. Wired as the final step of
+# .github/workflows/deploy-stage0.yml, AFTER external-health + post-deploy smoke,
+# so the card means exactly: "this version is now LIVE on prod and smoke-green".
+#
+# Why this exists:
+#   release.yml already pings Telegram at IMAGE-BUILD time, but nothing announced
+#   the moment a version actually rolled out to prod. Operators asked for a Feishu
+#   sync on every prod rollout; this script is the deterministic, code-ified
+#   version of that ("自动化优先、一切代码化") instead of a remembered manual curl.
+#
+# Design:
+#   - Best-effort. ANY send failure prints a ::warning:: and exits 0, so a flaky
+#     webhook never reddens an already-successful prod deploy. The workflow step
+#     ALSO sets continue-on-error: true (belt and suspenders).
+#   - Card shape + HMAC signature mirror the backend canonical sender
+#     backend/internal/service/ops_feishu_notifier_tk.go (feishuCardPayload /
+#     signFeishuWebhook): sign = base64(hmac_sha256(key = ts+"\n"+secret, msg="")).
+#     So this rollout card looks and signs identically to prod alert cards.
+#   - NEVER prints the webhook URL, the signing secret, or the computed sign.
+#
+# Usage:
+#   TK_FEISHU_WEBHOOK_URL=... [TK_FEISHU_SIGNING_SECRET=...] \
+#     bash ops/stage0/notify-feishu-release.sh <tag> <api_url> [--run-url URL] [--dry-run]
+#
+#   <tag>      released image tag WITHOUT leading v (e.g. 1.7.83). A leading v is
+#              tolerated and stripped.
+#   <api_url>  prod gateway URL (e.g. https://api.tokenkey.dev).
+#   --run-url  link to the deploy workflow run (optional).
+#   --dry-run  build + sign the card, print a SANITIZED payload, do NOT POST.
+#
+# Requires: python3, curl. GITHUB_REPOSITORY (auto-set in Actions) enriches the
+# card with a GitHub Release link; absent → that link is simply omitted.
+
+usage() {
+  cat <<'EOF'
+Usage:
+  TK_FEISHU_WEBHOOK_URL=... [TK_FEISHU_SIGNING_SECRET=...] \
+    bash ops/stage0/notify-feishu-release.sh <tag> <api_url> [--run-url URL] [--dry-run]
+EOF
+}
+
+TAG=""
+API_URL=""
+RUN_URL=""
+DRY_RUN=0
+
+while [ $# -gt 0 ]; do
+  case "$1" in
+    --run-url) RUN_URL="${2:-}"; shift 2 ;;
+    --run-url=*) RUN_URL="${1#*=}"; shift ;;
+    --dry-run) DRY_RUN=1; shift ;;
+    -h | --help) usage; exit 0 ;;
+    --*) echo "[error] unknown flag: $1" >&2; usage; exit 2 ;;
+    *)
+      if [ -z "$TAG" ]; then
+        TAG="$1"
+      elif [ -z "$API_URL" ]; then
+        API_URL="$1"
+      else
+        echo "[error] unexpected arg: $1" >&2; usage; exit 2
+      fi
+      shift ;;
+  esac
+done
+
+if [ -z "$TAG" ] || [ -z "$API_URL" ]; then
+  echo "[error] <tag> and <api_url> are required" >&2
+  usage
+  exit 2
+fi
+
+# deploy-stage0 passes a bare tag, but tolerate a leading v just in case.
+TAG="${TAG#v}"
+
+WEBHOOK="${TK_FEISHU_WEBHOOK_URL:-}"
+SECRET="${TK_FEISHU_SIGNING_SECRET:-}"
+
+if [ "$DRY_RUN" -ne 1 ] && [ -z "$WEBHOOK" ]; then
+  # best-effort: a missing webhook is surfaced but never fails the deploy.
+  echo "::warning::TK_FEISHU_WEBHOOK_URL empty; skipping release Feishu notification"
+  exit 0
+fi
+
+# Build (and sign) the interactive-card payload in python3 so JSON escaping and
+# the HMAC are byte-correct vs the Go canonical sender. python prints the JSON
+# payload to stdout (sanitized when NF_DRY_RUN=1).
+PAYLOAD_JSON="$(
+  NF_TAG="$TAG" \
+  NF_API_URL="$API_URL" \
+  NF_RUN_URL="$RUN_URL" \
+  NF_SECRET="$SECRET" \
+  NF_DRY_RUN="$DRY_RUN" \
+  python3 <<'PY'
+import base64
+import datetime
+import hashlib
+import hmac
+import json
+import os
+import time
+
+tag = os.environ["NF_TAG"]
+api_url = os.environ["NF_API_URL"]
+run_url = os.environ.get("NF_RUN_URL", "").strip()
+secret = os.environ.get("NF_SECRET", "").strip()
+repo = os.environ.get("GITHUB_REPOSITORY", "").strip()
+dry = os.environ.get("NF_DRY_RUN") == "1"
+
+ts = int(time.time())
+utc = datetime.datetime.fromtimestamp(ts, datetime.timezone.utc)
+cst = utc + datetime.timedelta(hours=8)
+when = f"{utc:%Y-%m-%d %H:%M} UTC · {cst:%Y-%m-%d %H:%M} CST"
+
+lines = [
+    f"**版本**  v{tag}",
+    "**环境**  prod",
+    f"**API**  {api_url}",
+    f"**上线时间**  {when}",
+    "**烟测**  ✅ 通过",
+]
+links = []
+if repo:
+    links.append(f"[GitHub Release](https://github.com/{repo}/releases/tag/v{tag})")
+if run_url:
+    links.append(f"[发版流水线]({run_url})")
+if links:
+    lines.append("  ·  ".join(links))
+body = "\n".join(lines)
+
+payload = {
+    "msg_type": "interactive",
+    "card": {
+        "header": {
+            "template": "green",
+            "title": {"tag": "plain_text", "content": f"🚀 TokenKey 发版上线 v{tag}"},
+        },
+        "elements": [
+            {"tag": "div", "text": {"tag": "lark_md", "content": body}},
+        ],
+    },
+}
+
+# Mirror backend signFeishuWebhook: key = timestamp+"\n"+secret over empty msg.
+if secret:
+    string_to_sign = f"{ts}\n{secret}"
+    sign = base64.b64encode(
+        hmac.new(string_to_sign.encode("utf-8"), b"", hashlib.sha256).digest()
+    ).decode("utf-8")
+    payload["timestamp"] = str(ts)
+    payload["sign"] = sign
+
+if dry:
+    safe = json.loads(json.dumps(payload))
+    if "sign" in safe:
+        safe["sign"] = "<redacted-sign>"
+    print(json.dumps(safe, ensure_ascii=False, indent=2))
+else:
+    print(json.dumps(payload, ensure_ascii=False))
+PY
+)"
+
+if [ "$DRY_RUN" -eq 1 ]; then
+  echo "[dry-run] feishu release card payload (sanitized; sign + webhook withheld):"
+  echo "$PAYLOAD_JSON"
+  exit 0
+fi
+
+BODY_FILE="$(mktemp)"
+trap 'rm -f "$BODY_FILE"' EXIT
+
+HTTP_CODE="$(
+  curl -sS -o "$BODY_FILE" -w '%{http_code}' \
+    -X POST "$WEBHOOK" \
+    -H 'Content-Type: application/json' \
+    --max-time 10 \
+    -d "$PAYLOAD_JSON" 2>/dev/null || echo "000"
+)"
+
+# Feishu returns HTTP 200 + JSON {"code":0,...} on success; a non-zero code is a
+# logical failure (bad sign, bad webhook) even with HTTP 200.
+CODE_FIELD="$(
+  python3 -c 'import sys,json
+try:
+    print(json.load(open(sys.argv[1])).get("code", 0))
+except Exception:
+    print(0)' "$BODY_FILE" 2>/dev/null || echo 0
+)"
+
+case "$HTTP_CODE" in
+  2??)
+    if [ "$CODE_FIELD" = "0" ]; then
+      echo "[ok] feishu release card posted (v$TAG, http=$HTTP_CODE)"
+      exit 0
+    fi
+    ;;
+esac
+
+SAFE_HOOK="$(
+  printf '%s' "$WEBHOOK" | python3 -c 'import sys,urllib.parse as u
+try:
+    p=u.urlparse(sys.stdin.read().strip())
+    print(f"{p.scheme}://{p.netloc}/<redacted>" if p.scheme and p.netloc else "<redacted-feishu-webhook>")
+except Exception:
+    print("<redacted-feishu-webhook>")' 2>/dev/null || echo "<redacted-feishu-webhook>"
+)"
+echo "::warning::feishu release notification failed (http=$HTTP_CODE code=$CODE_FIELD endpoint=$SAFE_HOOK)"
+exit 0

--- a/ops/stage0/notify-feishu-release.sh
+++ b/ops/stage0/notify-feishu-release.sh
@@ -15,7 +15,7 @@ set -euo pipefail
 # Design:
 #   - Best-effort. ANY send failure prints a ::warning:: and exits 0, so a flaky
 #     webhook never reddens an already-successful prod deploy. The workflow step
-#     ALSO sets continue-on-error: true (belt and suspenders).
+#     itself is ALSO marked continue-on-error (belt and suspenders).
 #   - Card shape + HMAC signature mirror the backend canonical sender
 #     backend/internal/service/ops_feishu_notifier_tk.go (feishuCardPayload /
 #     signFeishuWebhook): sign = base64(hmac_sha256(key = ts+"\n"+secret, msg="")).
@@ -24,12 +24,16 @@ set -euo pipefail
 #
 # Usage:
 #   TK_FEISHU_WEBHOOK_URL=... [TK_FEISHU_SIGNING_SECRET=...] \
-#     bash ops/stage0/notify-feishu-release.sh <tag> <api_url> [--run-url URL] [--dry-run]
+#     bash ops/stage0/notify-feishu-release.sh <tag> <api_url> \
+#       [--run-url URL] [--notes TEXT] [--dry-run]
 #
 #   <tag>      released image tag WITHOUT leading v (e.g. 1.7.83). A leading v is
 #              tolerated and stripped.
 #   <api_url>  prod gateway URL (e.g. https://api.tokenkey.dev).
 #   --run-url  link to the deploy workflow run (optional).
+#   --notes    release changelog (e.g. `gh release view` body) to inline under a
+#              "本次更新" section; truncated for card readability. Empty/absent →
+#              section omitted, card degrades to version + links (optional).
 #   --dry-run  build + sign the card, print a SANITIZED payload, do NOT POST.
 #
 # Requires: python3, curl. GITHUB_REPOSITORY (auto-set in Actions) enriches the
@@ -39,19 +43,27 @@ usage() {
   cat <<'EOF'
 Usage:
   TK_FEISHU_WEBHOOK_URL=... [TK_FEISHU_SIGNING_SECRET=...] \
-    bash ops/stage0/notify-feishu-release.sh <tag> <api_url> [--run-url URL] [--dry-run]
+    bash ops/stage0/notify-feishu-release.sh <tag> <api_url> \
+      [--run-url URL] [--notes TEXT] [--dry-run]
 EOF
 }
 
 TAG=""
 API_URL=""
 RUN_URL=""
+NOTES=""
 DRY_RUN=0
+
+# Flags that take a value: require the value to be present so a trailing
+# `--run-url` (no arg) fails loudly instead of `shift 2` erroring under set -e.
+need_val() { [ "$2" -ge 2 ] || { echo "[error] $1 needs a value" >&2; usage; exit 2; }; }
 
 while [ $# -gt 0 ]; do
   case "$1" in
-    --run-url) RUN_URL="${2:-}"; shift 2 ;;
+    --run-url) need_val "$1" "$#"; RUN_URL="$2"; shift 2 ;;
     --run-url=*) RUN_URL="${1#*=}"; shift ;;
+    --notes) need_val "$1" "$#"; NOTES="$2"; shift 2 ;;
+    --notes=*) NOTES="${1#*=}"; shift ;;
     --dry-run) DRY_RUN=1; shift ;;
     -h | --help) usage; exit 0 ;;
     --*) echo "[error] unknown flag: $1" >&2; usage; exit 2 ;;
@@ -92,6 +104,7 @@ PAYLOAD_JSON="$(
   NF_TAG="$TAG" \
   NF_API_URL="$API_URL" \
   NF_RUN_URL="$RUN_URL" \
+  NF_NOTES="$NOTES" \
   NF_SECRET="$SECRET" \
   NF_DRY_RUN="$DRY_RUN" \
   python3 <<'PY'
@@ -106,6 +119,7 @@ import time
 tag = os.environ["NF_TAG"]
 api_url = os.environ["NF_API_URL"]
 run_url = os.environ.get("NF_RUN_URL", "").strip()
+notes = os.environ.get("NF_NOTES", "").strip()
 secret = os.environ.get("NF_SECRET", "").strip()
 repo = os.environ.get("GITHUB_REPOSITORY", "").strip()
 dry = os.environ.get("NF_DRY_RUN") == "1"
@@ -131,6 +145,19 @@ if links:
     lines.append("  ·  ".join(links))
 body = "\n".join(lines)
 
+elements = [{"tag": "div", "text": {"tag": "lark_md", "content": body}}]
+
+# Inline the changelog ("自上次版本以来的变更") under its own section when
+# provided. Truncate for card readability — the full list always lives behind
+# the GitHub Release link above.
+if notes:
+    cap = 1200
+    shown = notes if len(notes) <= cap else notes[:cap].rstrip() + "\n\n…(更多见 GitHub Release)"
+    elements.append({"tag": "hr"})
+    elements.append(
+        {"tag": "div", "text": {"tag": "lark_md", "content": "**本次更新**\n" + shown}}
+    )
+
 payload = {
     "msg_type": "interactive",
     "card": {
@@ -138,9 +165,7 @@ payload = {
             "template": "green",
             "title": {"tag": "plain_text", "content": f"🚀 TokenKey 发版上线 v{tag}"},
         },
-        "elements": [
-            {"tag": "div", "text": {"tag": "lark_md", "content": body}},
-        ],
+        "elements": elements,
     },
 }
 


### PR DESCRIPTION
## 背景

每次 **prod rollout 发版上线**后,需要往 TK ops 共享飞书群同步本次发版情况。此前 `release.yml` 只在**镜像构建完成时**发 Telegram,**没有任何在「真正上线 prod 那一刻」的飞书通知**——靠人记着手动 curl。本 PR 把它固化成 `deploy-stage0.yml` 的自动步骤("自动化优先、一切代码化")。

## 改动

**`ops/stage0/notify-feishu-release.sh`**(新,TK-only)
- 复用 `TK_FEISHU_WEBHOOK_URL` / `TK_FEISHU_SIGNING_SECRET`(已在本 workflow 接入)。
- 推绿色 `interactive` 卡片;卡片结构 + HMAC 签名**字节级对齐后端 canonical sender**(`backend/internal/service/ops_feishu_notifier_tk.go` 的 `feishuCardPayload` / `signFeishuWebhook`),与告警卡片同形同签。
- 内容:`🚀 TokenKey 发版上线 v<版本>` + 环境 prod / API / 上线时间(UTC·CST)/ 烟测✅ / GitHub Release + 发版流水线链接。
- Best-effort:始终 `exit 0`,失败打 `::warning::`;**绝不打印 webhook/secret/sign**;`--dry-run` 本地/CI 自测。

**`.github/workflows/deploy-stage0.yml`**
- 新增 `Notify Feishu (release rollout)` 步,位于 `Post-deploy gateway smoke` 之后、`Job summary` 之前,`continue-on-error: true`。
- 落点在 smoke 之后:smoke 失败工作流即中止 → **永不公告未通过烟测的发版**;webhook 抽风也不会把已成功的 prod deploy 标红(对齐 release.yml 的 Telegram 步)。

## 触发链
\`tag push → release.yml 构建 + Telegram → 自动 queue prod deploy → deploy-stage0 换镜像/健康/烟测全绿 → **新增飞书卡片**\`。飞书在「真正上线 prod 那一刻」推,与既有 Telegram 是两个时刻、互不冲突。

## 验证
- 签名 python vs openssl vs **Go 后端** 三方字节一致 ✅
- dry-run 签名/未签名 payload 结构正确、脱敏 ✅
- 边界:空 webhook→warning+exit0;缺参→exit2 ✅
- `bash -n` + yaml parse + `shellcheck`(0.11.0) clean ✅
- `scripts/preflight.sh` **PASS**(新脚本被 ops orphan-check 识别为已 wired)✅

## 规则
- 纯 TK-only `ops/` + `.github/` 文件,非 upstream-shaped 路径、无 backend/frontend 改动 → 无需 upstream-override / no-web-impact marker(preflight 已确认)。
- secret 仍只在 GH secrets,不入库(§7)。
- 合并请用 **Squash and merge**(§5.y,TK-originated PR)。

🤖 Generated with [Claude Code](https://claude.com/claude-code)