### PR TITLE
feat(ops): advisory post-deploy check for exclusive-group orphan keys

### DIFF
--- a/.github/workflows/deploy-stage0.yml
+++ b/.github/workflows/deploy-stage0.yml
@@ -151,6 +151,18 @@ jobs:
           API_URL: ${{ steps.instance.outputs.api_url }}
         run: bash ops/stage0/external_health.sh "$API_URL"
 
+      - name: Post-deploy data invariant check (exclusive-group orphans)
+        # ADVISORY ONLY — never blocks the deploy. Reads (read-only) whether any
+        # API key is bound to an exclusive standard group whose user is NOT in
+        # user_allowed_groups (would 403 under #669). The sanctioned admin-UI
+        # path can't produce this; only manual DB edits / legacy rows can — so
+        # this surfaces drift right after deploy (often follows DB surgery).
+        # continue-on-error + the script's always-0 exit are belt-and-suspenders.
+        continue-on-error: true
+        env:
+          INSTANCE_ID: ${{ steps.instance.outputs.id }}
+        run: bash ops/stage0/check_exclusive_group_orphans_via_ssm.sh "$INSTANCE_ID" "deploy-stage0 orphan check env=prod"
+
       - name: Sync Feishu alert config
         # Inject the shared Feishu webhook/secret into prod's
         # ops_email_notification_config and enable alerting (idempotent). The

--- a/deploy/aws/README.md
+++ b/deploy/aws/README.md
@@ -315,6 +315,7 @@ aws cloudformation describe-stacks --region "$REGION" --stack-name "$OIDC_STACK"
 - **R4: 回滚能力依赖快照与冷备**：迁移窗口前必须完成 root EBS snapshot 和 tar 冷备，不满足则不应执行 deploy。
 - **R5: 实例替换会按陈旧 CFN `ImageTag` 静默降级**：日常 SSM 热更不回写 CFN，CFN `ImageTag` 是很旧的 init 值；任何 replace（resize/AMI/UserData 变更）都会让新机按它 bootstrap → 线上退版。**对策**：替换类操作必须 `--parameter-overrides ImageTag=<运行态 tag>`（见 §实例规格升级 step 0）。
 - **R6: 实例替换会锁死 CI 部署**：新实例 ID 变化后，`cicd-oidc` 的 `TargetInstanceId` 仍指旧机 → `deploy-stage0.yml`（含 release 自动触发）全部 `AccessDeniedException: ssm:SendCommand`。**对策**：替换后立即把 OIDC 栈 `TargetInstanceId` 重指新机（见 §实例规格升级 step 4）。
+- **R7: 专属分组发卡只能走 admin UI，禁手改 `api_keys.group_id`**：#669 起，key 绑的专属标准组要求用户在 `user_allowed_groups` 白名单，否则请求 403 `GROUP_NOT_ALLOWED`。admin 后台「绑定/迁移分组」会原子写白名单，自助建卡会 gate——所以正规路径不会产生孤儿。**只有直接 SQL 改 `api_keys.group_id` 会**。手术后请跑 `ops/stage0/check_exclusive_group_orphans_via_ssm.sh <instance-id>`（发版时该步自动跑，仅告警不阻断）；发现孤儿用脚本头部的 backfill SQL 补授权（确认用户确应有权后）。
 
 > **事故记录 2026-06-05（resize 三连副作用）**：prod 按本 SOP 早期版本做 `t4g.small → t4g.large` resize，CFN `UPDATE_COMPLETE`、规格与数据(`DataVolume` Retain)均正确，但触发**三个**实例替换副作用：①(已在 #582 修)`build-cfn.sh` 把注释 marker 写进 UserData 致 `#!/bin/bash` 非首行 → cloud-init 不跑 bootstrap，新机空跑、靠手动 SSM 救活；②救活/bootstrap 用的是陈旧 CFN `ImageTag=1.7.11`，线上从 1.7.70 退版（本 PR step 0 修）；③OIDC `TargetInstanceId` 仍指旧机，`deploy-stage0.yml` 部署 1.7.70 时 `ssm:SendCommand` AccessDenied（本 PR step 4 修）。恢复：用管理员本地凭证跑 `ops/stage0/deploy_via_ssm.sh 1.7.70 <new-id>`（绕过坏 OIDC）热换回 1.7.70 + 重指 OIDC。**根因共性：任何实例替换都要同步 ImageTag 与 OIDC TargetInstanceId**。
 

--- a/ops/stage0/check_exclusive_group_orphans_via_ssm.sh
+++ b/ops/stage0/check_exclusive_group_orphans_via_ssm.sh
@@ -66,9 +66,11 @@ ssm_region_args=()
 _region="${AWS_REGION:-${AWS_DEFAULT_REGION:-}}"
 [[ -n "${_region}" ]] && ssm_region_args=(--region "${_region}")
 
-# Read-only orphan COUNT + detail (same predicate as the backfill remedy above).
-# Single-statement-per-line; piped in as base64 so no shell/JSON quoting of the
-# SQL string literals ('subscription', 'orphans=', …) is needed.
+# Read-only orphan COUNT + detail. The orphan predicate (same as the backfill
+# remedy above) is repeated in both queries on purpose: a psql CTE scopes only to
+# the single statement it prefixes, so the count and detail must each carry it.
+# The two WHEREs sit adjacent here — keep them in sync. Piped in as base64 so no
+# shell/JSON quoting of the SQL literals ('subscription', 'orphans=', …) is needed.
 read -r -d '' ORPHAN_SQL <<'SQL' || true
 \pset pager off
 \set ON_ERROR_STOP on
@@ -149,7 +151,9 @@ if [[ "${orphans}" -eq 0 ]]; then
 fi
 
 echo "::warning::exclusive-group orphan check: ${orphans} api key(s) bound to an exclusive standard group whose user is NOT in user_allowed_groups — they will 403 GROUP_NOT_ALLOWED. Confirm intended-revocation vs backfill the grant (remedy SQL in script header). Affected:"
-grep -E '^orphan_detail\|' "${stdout_file}" | while IFS='|' read -r _tag key_id user_id email group_id group_name; do
+# `|| true` guard: under `set -e`+`pipefail` a no-match grep (exit 1) would abort
+# the script before the final `exit 0`, breaking the "ALWAYS exit 0" contract.
+{ grep -E '^orphan_detail\|' "${stdout_file}" || true; } | while IFS='|' read -r _tag key_id user_id email group_id group_name; do
   echo "::warning::  api_key=${key_id} user=${user_id} <${email}> group=${group_id} (${group_name})"
 done
 exit 0

--- a/ops/stage0/check_exclusive_group_orphans_via_ssm.sh
+++ b/ops/stage0/check_exclusive_group_orphans_via_ssm.sh
@@ -1,0 +1,155 @@
+#!/usr/bin/env bash
+#
+# Stage0 prod-only post-deploy DATA-INVARIANT check: exclusive-group orphan keys.
+#
+# Why this exists:
+#   #669 made `user_allowed_groups` load-bearing at request time — an API key
+#   bound to an EXCLUSIVE, non-subscription ("standard") group whose user is NOT
+#   in that group's allowed-list now gets 403 GROUP_NOT_ALLOWED. The sanctioned
+#   admin-UI provisioning path (AdminUpdateAPIKeyGroupID / migrate-group) grants
+#   `user_allowed_groups` atomically when it binds, and self-service key creation
+#   gates on it — so NO code path can produce such an "orphan". The only way one
+#   appears is a human hand-editing `api_keys.group_id` in the DB (bypassing the
+#   UI), or legacy rows from before grant-on-bind existed.
+#
+#   Rather than run a standing reconciler to watch for a state the sanctioned
+#   workflow already makes unreachable, this is a CHEAP, READ-ONLY check run at
+#   the one moment the risk is real: a deploy (which often follows DB surgery).
+#   It is ADVISORY ONLY — it NEVER fails the deploy. orphans>0 emits a
+#   ::warning:: listing (key,user,group) so an operator can decide: backfill the
+#   grant (legacy/provisioning slip) or confirm it's an intended revocation.
+#
+#   Remedy when it fires (idempotent, safe to re-run):
+#     INSERT INTO user_allowed_groups (user_id, group_id, created_at)
+#     SELECT DISTINCT k.user_id, k.group_id, now() FROM api_keys k
+#       JOIN groups g ON g.id=k.group_id AND g.deleted_at IS NULL
+#       JOIN users  u ON u.id=k.user_id  AND u.deleted_at IS NULL
+#      WHERE k.deleted_at IS NULL AND k.group_id IS NOT NULL AND g.is_exclusive
+#        AND g.subscription_type IS DISTINCT FROM 'subscription'
+#        AND NOT EXISTS (SELECT 1 FROM user_allowed_groups a
+#                        WHERE a.user_id=k.user_id AND a.group_id=k.group_id)
+#     ON CONFLICT (user_id, group_id) DO NOTHING;
+#   (only after confirming the affected users SHOULD retain access.)
+#
+# Prod-only: api_keys/users/groups live on the prod control-plane DB. Edge
+# Stage0 stacks are anthropic-OAuth relays with no such tables, so this is NOT
+# wired into the edge deploy workflow.
+#
+# Usage:
+#   ops/stage0/check_exclusive_group_orphans_via_ssm.sh <instance_id> [comment]
+# Env:
+#   AWS_REGION / AWS_DEFAULT_REGION  region (else AWS default chain)
+#   PG_CONTAINER  postgres container name (default tokenkey-postgres)
+#   PG_USER       psql user (default tokenkey)
+#   PG_DB         psql db   (default tokenkey)
+#   SSM_TIMEOUT_SECONDS  invocation wait budget (default 120)
+#
+# Exit status: ALWAYS 0 except on usage error (missing instance_id). The data
+# finding is surfaced via ::warning:: lines, never via a non-zero exit — the
+# deploy must not be blocked by a data-layer observation.
+
+set -euo pipefail
+
+INSTANCE_ID="${1:-${INSTANCE_ID:-}}"
+COMMENT="${2:-stage0 exclusive-group orphan check}"
+PG_CONTAINER="${PG_CONTAINER:-tokenkey-postgres}"
+PG_USER="${PG_USER:-tokenkey}"
+PG_DB="${PG_DB:-tokenkey}"
+SSM_TIMEOUT_SECONDS="${SSM_TIMEOUT_SECONDS:-120}"
+
+if [[ -z "${INSTANCE_ID}" ]]; then
+  echo "usage: $0 <instance_id> [comment]" >&2
+  exit 2
+fi
+
+ssm_region_args=()
+_region="${AWS_REGION:-${AWS_DEFAULT_REGION:-}}"
+[[ -n "${_region}" ]] && ssm_region_args=(--region "${_region}")
+
+# Read-only orphan COUNT + detail (same predicate as the backfill remedy above).
+# Single-statement-per-line; piped in as base64 so no shell/JSON quoting of the
+# SQL string literals ('subscription', 'orphans=', …) is needed.
+read -r -d '' ORPHAN_SQL <<'SQL' || true
+\pset pager off
+\set ON_ERROR_STOP on
+SELECT 'orphans=' || count(*)
+FROM api_keys k
+JOIN groups g ON g.id = k.group_id AND g.deleted_at IS NULL
+JOIN users  u ON u.id = k.user_id  AND u.deleted_at IS NULL
+WHERE k.deleted_at IS NULL AND k.group_id IS NOT NULL AND g.is_exclusive = true
+  AND g.subscription_type IS DISTINCT FROM 'subscription'
+  AND NOT EXISTS (SELECT 1 FROM user_allowed_groups a
+                  WHERE a.user_id = k.user_id AND a.group_id = k.group_id);
+SELECT 'orphan_detail|' || k.id || '|' || k.user_id || '|' || coalesce(u.email,'') || '|' || k.group_id || '|' || g.name
+FROM api_keys k
+JOIN groups g ON g.id = k.group_id AND g.deleted_at IS NULL
+JOIN users  u ON u.id = k.user_id  AND u.deleted_at IS NULL
+WHERE k.deleted_at IS NULL AND k.group_id IS NOT NULL AND g.is_exclusive = true
+  AND g.subscription_type IS DISTINCT FROM 'subscription'
+  AND NOT EXISTS (SELECT 1 FROM user_allowed_groups a
+                  WHERE a.user_id = k.user_id AND a.group_id = k.group_id)
+ORDER BY k.user_id, k.id LIMIT 50;
+SQL
+
+B64="$(printf '%s' "${ORPHAN_SQL}" | base64 | tr -d '\n')"
+
+# One SSM command element → no unconditional-execution trap (a multi-element
+# AWS-RunShellScript array runs every element without `set -e`; a single `&&`-
+# chained element fails as a unit). The base64 → psql pipe is the whole job.
+REMOTE_CMD="set -euo pipefail && printf %s '${B64}' | base64 -d | docker exec -i ${PG_CONTAINER} psql -U ${PG_USER} -d ${PG_DB} -At -F '|'"
+
+params_file="$(mktemp)"
+stdout_file="$(mktemp)"
+trap 'rm -f "${params_file}" "${stdout_file}"' EXIT
+jq -n --arg cmd "${REMOTE_CMD}" '{commands: [$cmd]}' > "${params_file}"
+
+cmd_id="$(aws "${ssm_region_args[@]}" ssm send-command \
+  --instance-ids "${INSTANCE_ID}" \
+  --document-name AWS-RunShellScript \
+  --comment "${COMMENT}" \
+  --parameters "file://${params_file}" \
+  --query 'Command.CommandId' --output text 2>/dev/null || echo "")"
+
+if [[ -z "${cmd_id}" || "${cmd_id}" == "None" ]]; then
+  echo "::warning::exclusive-group orphan check: SSM send-command failed (instance=${INSTANCE_ID}); skipped — NOT a deploy blocker."
+  exit 0
+fi
+echo "exclusive-group orphan check: ssm command-id=${cmd_id}"
+
+deadline=$(( $(date +%s) + SSM_TIMEOUT_SECONDS ))
+status="InProgress"
+while true; do
+  status="$(aws "${ssm_region_args[@]}" ssm get-command-invocation \
+    --command-id "${cmd_id}" --instance-id "${INSTANCE_ID}" \
+    --query 'Status' --output text 2>/dev/null || echo InProgress)"
+  case "${status}" in Success|Failed|TimedOut|Cancelled) break ;; esac
+  if [[ $(date +%s) -ge ${deadline} ]]; then status="TimedOut"; break; fi
+  sleep 4
+done
+
+aws "${ssm_region_args[@]}" ssm get-command-invocation \
+  --command-id "${cmd_id}" --instance-id "${INSTANCE_ID}" \
+  --query 'StandardOutputContent' --output text > "${stdout_file}" 2>/dev/null || true
+
+if [[ "${status}" != "Success" ]]; then
+  echo "::warning::exclusive-group orphan check: SSM status=${status}; skipped — NOT a deploy blocker."
+  exit 0
+fi
+
+count_line="$(grep -E '^orphans=' "${stdout_file}" | head -1 || true)"
+orphans="${count_line#orphans=}"
+if [[ -z "${orphans}" || ! "${orphans}" =~ ^[0-9]+$ ]]; then
+  echo "::warning::exclusive-group orphan check: could not parse orphan count from psql output; skipped — NOT a deploy blocker."
+  exit 0
+fi
+
+if [[ "${orphans}" -eq 0 ]]; then
+  echo "exclusive-group orphan check: ok (orphans=0)"
+  exit 0
+fi
+
+echo "::warning::exclusive-group orphan check: ${orphans} api key(s) bound to an exclusive standard group whose user is NOT in user_allowed_groups — they will 403 GROUP_NOT_ALLOWED. Confirm intended-revocation vs backfill the grant (remedy SQL in script header). Affected:"
+grep -E '^orphan_detail\|' "${stdout_file}" | while IFS='|' read -r _tag key_id user_id email group_id group_name; do
+  echo "::warning::  api_key=${key_id} user=${user_id} <${email}> group=${group_id} (${group_name})"
+done
+exit 0


### PR DESCRIPTION
## Summary

Follow-up to #669 (exclusive-group API-key auth). After backfilling the 5 legacy orphan keys in prod (would_403: 5→0), this adds the third-layer治本 — deliberately **NOT** a standing reconciler.

### Why not a reconciler
Audit confirmed **no code path can create an exclusive-standard orphan**:
- `AddGroupToAllowedGroups` is called in exactly 2 places — admin bind + migrate — both grant atomically.
- Self-service key creation **gates** via `canUserBindGroup` (can't create an orphan).
- redeem/subscription only touch **subscription-type** groups, **exempt** from the 403.

The orphan state is unreachable via the sanctioned admin-UI path; the only sources are legacy rows (pre grant-on-bind — already backfilled) and **manual DB edits**. A standing daemon watching a state the workflow already makes impossible is net-complexity for a non-recurring, self-inflicted event (TK §5 hardens *after* recurrence).

### What this adds (minimal, advisory)
- `ops/stage0/check_exclusive_group_orphans_via_ssm.sh` — read-only SSM `docker exec psql` orphan COUNT (prod-only; edges have no such tables). `orphans>0` → `::warning::` listing (key,user,group); **always exits 0**, never blocks a deploy. Header carries the idempotent backfill remedy SQL.
- `deploy-stage0.yml` — non-fatal `continue-on-error` step after External health (a deploy often follows DB surgery — the moment the risk is real).
- `README R7` — provision exclusive groups only via admin UI; never hand-edit `api_keys.group_id`.

### Validation
- Ran live against prod: `orphans=0` (backfill confirmed closed).
- `bash scripts/preflight.sh` PASS (ops-tool-orphan wired, SSM/smoke parse, workflow yaml).
- ops/workflow/docs only — no backend/frontend source, no upstream-shaped paths.

🤖 Generated with [Claude Code](https://claude.com/claude-code)