### PR TITLE
feat(admin): edit newapi+service_account (Vertex) credentials in EditAccountModal

### DIFF
--- a/backend/internal/web/dist/frontend-source.json
+++ b/backend/internal/web/dist/frontend-source.json
@@ -1,7 +1,7 @@
 {
   "algorithm": "sha256(git-ls-files:path,size,content)",
   "file_count": 461,
-  "hash": "d1e67175b740fc5015c393876401ffa4a4a1af29380bba67242577edfd140f98",
+  "hash": "4a00a9e121b4942fee89dca4c33eefc3cb7b932002ebca6483e692022e7249b8",
   "schema": 1,
   "source": "frontend/"
 }

--- a/backend/internal/web/dist/frontend-source.json
+++ b/backend/internal/web/dist/frontend-source.json
@@ -1,7 +1,7 @@
 {
   "algorithm": "sha256(git-ls-files:path,size,content)",
   "file_count": 461,
-  "hash": "3c3bb911e2f45bff0159620aa989d98f4b35b419203c11ce6a53cbf29b55e84b",
+  "hash": "d1e67175b740fc5015c393876401ffa4a4a1af29380bba67242577edfd140f98",
   "schema": 1,
   "source": "frontend/"
 }

--- a/frontend/src/components/account/EditAccountModal.vue
+++ b/frontend/src/components/account/EditAccountModal.vue
@@ -4035,24 +4035,68 @@ const handleSubmit = async () => {
 
       updatePayload.credentials = newCredentials
     } else if (props.account.platform === 'newapi' && props.account.type === 'service_account') {
-      // 第五平台 newapi + Vertex service_account: channel_type + base_url +
-      // model_mapping 走 newapi composable.buildSubmitBundle（与 apikey 路径同一
-      // 套结构化 selector），Vertex SA 专属字段（service_account_json 写一次 /
-      // location / tier_id）在此叠加。SA JSON 留空 = 保留现有密钥（与 api_key 同
-      // 语义），永不回吐脱敏后的存储值。
+      // 第五平台 newapi + Vertex service_account: 复用 newapi 结构化 selector
+      // 的 channel_type + model_mapping（与 apikey 路径同一套控件），但 **不** 走
+      // buildSubmitBundle —— 后者强制 base_url + api_key，二者对 Vertex 都不适用
+      // （ChannelBaseURLs[41]=VertexAI 上游为空串；鉴权走 SA JSON 而非 api_key）。
+      // 这里直接读 composable 暴露的 ref 拼装，叠加 Vertex 专属字段
+      // （service_account_json 写一次 / location / tier_id）。SA JSON 留空 = 保留
+      // 现有密钥（与 api_key 同语义），永不回吐脱敏后的存储值。
       const currentCredentials = (props.account.credentials as Record<string, unknown>) || {}
-      const bundle = newapiBuildSubmitBundle('edit')
-      if (!bundle) return
-      const newCredentials: Record<string, unknown> = { ...currentCredentials, ...bundle.credentials }
+      const newCredentials: Record<string, unknown> = { ...currentCredentials }
 
-      // newapi bundle 不带 api_key（Vertex 鉴权走 SA JSON），从 base credentials
-      // 移除残留 api_key 避免误用。
+      if (!newapiChannelType.value || newapiChannelType.value <= 0) {
+        appStore.showError(t('admin.accounts.newApiPlatform.pleaseSelectChannelType'))
+        return
+      }
+      updatePayload.channel_type = newapiChannelType.value
+
+      // Vertex 鉴权不依赖 api_key / base_url：移除残留 api_key 避免误用，base_url
+      // 仅在账号原本携带时透传（不强制、不注入空串）。
       delete newCredentials.api_key
-      // composable 没填的字段意味着「清空」——edit 路径需主动 delete。
-      if (!bundle.credentials.model_mapping) delete newCredentials.model_mapping
-      if (!bundle.credentials.status_code_mapping) delete newCredentials.status_code_mapping
-      if (!bundle.credentials.openai_organization) delete newCredentials.openai_organization
-      updatePayload.channel_type = bundle.channelType
+
+      const saModelMapping = buildModelMappingObject(
+        newapiRestrictionMode.value,
+        newapiAllowedModels.value,
+        newapiModelMappings.value
+      )
+      if (saModelMapping) {
+        newCredentials.model_mapping = saModelMapping
+      } else {
+        delete newCredentials.model_mapping
+      }
+      if (Object.keys(newapiUpstreamModelPricingStatus.value).length > 0) {
+        newCredentials.model_pricing_status = { ...newapiUpstreamModelPricingStatus.value }
+      } else {
+        delete newCredentials.model_pricing_status
+      }
+
+      const saStatusCodeMapping = newapiStatusCodeMapping.value.trim()
+      if (saStatusCodeMapping) {
+        // Same validation the apikey path gets via buildSubmitBundle: a non-empty
+        // status_code_mapping must be a JSON object, else block (don't persist
+        // malformed transit config).
+        let saStatusCodeValid = false
+        try {
+          const parsed = JSON.parse(saStatusCodeMapping)
+          saStatusCodeValid = parsed !== null && typeof parsed === 'object' && !Array.isArray(parsed)
+        } catch {
+          saStatusCodeValid = false
+        }
+        if (!saStatusCodeValid) {
+          appStore.showError(t('admin.accounts.newApiPlatform.jsonObjectRequired'))
+          return
+        }
+        newCredentials.status_code_mapping = saStatusCodeMapping
+      } else {
+        delete newCredentials.status_code_mapping
+      }
+      const saOpenaiOrganization = newapiOpenAIOrganization.value.trim()
+      if (saOpenaiOrganization) {
+        newCredentials.openai_organization = saOpenaiOrganization
+      } else {
+        delete newCredentials.openai_organization
+      }
 
       if (!editVertexLocation.value.trim()) {
         appStore.showError(t('admin.accounts.vertexLocationRequired'))

--- a/frontend/src/components/account/EditAccountModal.vue
+++ b/frontend/src/components/account/EditAccountModal.vue
@@ -839,6 +839,93 @@
         </div>
       </div>
 
+      <!--
+        newapi (5th platform) + Vertex service_account (channel_type=41 …).
+        These accounts (e.g. gemini-imagen-veo-paid) fell through BOTH the
+        apikey block (gated on type==='apikey') and the gemini|anthropic Vertex
+        block (gated on platform), leaving them with no editable credential
+        fields. Compose the existing pieces here: AccountNewApiPlatformFields
+        (channel_type + base_url + structured model_mapping selector) for the
+        newapi shape, plus a write-once SA JSON textarea + location for Vertex.
+      -->
+      <div
+        v-if="account.platform === 'newapi' && account.type === 'service_account'"
+        class="space-y-4"
+      >
+        <AccountNewApiPlatformFields
+          v-model:channelType="newapiChannelType"
+          v-model:baseUrl="newapiBaseUrl"
+          v-model:apiKey="newapiApiKey"
+          v-model:modelMapping="newapiModelMapping"
+          v-model:statusCodeMapping="newapiStatusCodeMapping"
+          v-model:openaiOrganization="newapiOpenAIOrganization"
+          v-model:allowedModels="newapiAllowedModels"
+          v-model:pricingStatusByModel="newapiUpstreamModelPricingStatus"
+          v-model:modelMappings="newapiModelMappings"
+          v-model:restrictionMode="newapiRestrictionMode"
+          :channel-type-options="newapiChannelTypeOptions"
+          :channel-types-loading="newapiChannelTypesLoading"
+          :channel-types-error="newapiChannelTypesError"
+          :selected-channel-type-base-url="newapiSelectedBaseUrl"
+          :fetch-models-enabled="newapiFetchModelsEnabled"
+          :fetch-models-disabled="newapiFetchModelsDisabled"
+          :fetch-models-loading="newapiFetchModelsLoading"
+          variant="edit"
+          @fetch-models="newapiHandleFetchUpstreamModels"
+        />
+
+        <!-- Vertex Service Account credentials (SA JSON write-once + location) -->
+        <div class="border-t border-gray-200 pt-4 dark:border-dark-600">
+          <div>
+            <label class="input-label">Service Account JSON</label>
+            <textarea
+              v-model="editVertexServiceAccountJson"
+              rows="4"
+              spellcheck="false"
+              autocomplete="off"
+              class="input font-mono text-xs"
+              :placeholder="t('admin.accounts.vertexSaJsonNewapiEditPlaceholder')"
+            ></textarea>
+            <p class="input-hint">{{ t('admin.accounts.vertexSaJsonNewapiEditHint') }}</p>
+          </div>
+          <div class="mt-4 grid grid-cols-1 gap-4 sm:grid-cols-2">
+            <div>
+              <label class="input-label">Project ID</label>
+              <input
+                v-model="editVertexProjectId"
+                type="text"
+                class="input font-mono"
+                readonly
+                :placeholder="t('admin.accounts.vertexProjectIdPlaceholder')"
+              />
+            </div>
+            <div>
+              <label class="input-label">Location</label>
+              <select
+                v-model="editVertexLocation"
+                required
+                class="input font-mono"
+              >
+                <optgroup
+                  v-for="group in VERTEX_LOCATION_OPTIONS"
+                  :key="group.label"
+                  :label="group.label"
+                >
+                  <option
+                    v-for="option in group.options"
+                    :key="option.value"
+                    :value="option.value"
+                  >
+                    {{ option.label }}
+                  </option>
+                </optgroup>
+              </select>
+              <p class="input-hint">{{ t('admin.accounts.vertexLocationHint') }}</p>
+            </div>
+          </div>
+        </div>
+      </div>
+
       <!-- Bedrock fields (for bedrock type, both SigV4 and API Key modes) -->
       <div v-if="account.type === 'bedrock'" class="space-y-4">
         <!-- SigV4 fields -->
@@ -2537,6 +2624,11 @@ const editBedrockApiKeyValue = ref('')
 const editVertexProjectId = ref('')
 const editVertexClientEmail = ref('')
 const editVertexLocation = ref('us-central1')
+// Write-once SA JSON for newapi (5th-platform) Vertex accounts: leave empty to
+// keep the stored secret; paste a fresh SA JSON to re-derive project_id /
+// client_email and rotate the key. Mirrors the api_key "leave empty to keep"
+// pattern; the stored secret is never echoed back into the DOM.
+const editVertexServiceAccountJson = ref('')
 const isBedrockAPIKeyMode = computed(() =>
   props.account?.type === 'bedrock' &&
   (props.account?.credentials as Record<string, unknown>)?.auth_mode === 'apikey'
@@ -2965,6 +3057,33 @@ const loadModelRestrictionFromMapping = (rawMapping?: Record<string, unknown>) =
 const buildModelRestrictionMapping = () =>
   buildModelMappingObject('combined', allowedModels.value, modelMappings.value)
 
+/**
+ * Parse a freshly pasted Vertex Service Account JSON, normalize it, and
+ * re-derive project_id / client_email into the edit refs. Mirrors
+ * CreateAccountModal.applyVertexServiceAccountJson but writes the normalized
+ * JSON back into editVertexServiceAccountJson so the submit path forwards a
+ * compact, validated blob. Returns false (with a toast) on invalid input.
+ */
+const applyEditVertexServiceAccountJson = (raw: string): boolean => {
+  try {
+    const parsed = JSON.parse(raw) as Record<string, unknown>
+    const projectId = (parsed.project_id as string) || ''
+    const clientEmail = (parsed.client_email as string) || ''
+    const privateKey = (parsed.private_key as string) || ''
+    if (!projectId || !clientEmail || !privateKey) {
+      appStore.showError(t('admin.accounts.vertexSaJsonMissingFields'))
+      return false
+    }
+    editVertexProjectId.value = projectId
+    editVertexClientEmail.value = clientEmail
+    editVertexServiceAccountJson.value = JSON.stringify(parsed)
+    return true
+  } catch {
+    appStore.showError(t('admin.accounts.vertexSaJsonInvalid'))
+    return false
+  }
+}
+
 const syncFormFromAccount = (newAccount: Account | null) => {
   if (!newAccount) {
     return
@@ -2994,6 +3113,7 @@ const syncFormFromAccount = (newAccount: Account | null) => {
   editVertexProjectId.value = ''
   editVertexClientEmail.value = ''
   editVertexLocation.value = 'us-central1'
+  editVertexServiceAccountJson.value = ''
 
   // Load mixed scheduling setting (only for antigravity accounts)
   mixedScheduling.value = false
@@ -3228,6 +3348,25 @@ const syncFormFromAccount = (newAccount: Account | null) => {
   } else if (newAccount.type === 'upstream' && newAccount.credentials) {
     const credentials = newAccount.credentials as Record<string, unknown>
     editBaseUrl.value = (credentials.base_url as string) || ''
+  } else if (newAccount.platform === 'newapi' && newAccount.type === 'service_account' && newAccount.credentials) {
+    // 第五平台 newapi + Vertex service_account (channel_type=41 …): channel_type
+    // + base_url + model_mapping selector 走 newapi composable（与 apikey 路径
+    // 同一套结构化 selector），Vertex SA 专属字段（service_account_json 写一次 /
+    // location）走下方 editVertex* refs。CREATE 经 channel_type=41 落地，EDIT 在
+    // 此对齐其能力，避免被迫改 SQL。
+    const credentials = newAccount.credentials as Record<string, unknown>
+    newapiPopulateFromAccount({
+      channel_type: newAccount.channel_type,
+      credentials,
+    })
+    newapiBootstrap()
+    if (!credentials.model_pricing_status) {
+      void newapiRefreshStoredPricingStatus()
+    }
+    editVertexProjectId.value = (credentials.project_id as string) || ''
+    editVertexClientEmail.value = (credentials.client_email as string) || ''
+    editVertexLocation.value = (credentials.location as string) || (credentials.vertex_location as string) || 'us-central1'
+    editVertexServiceAccountJson.value = ''
   } else if ((newAccount.platform === 'gemini' || newAccount.platform === 'anthropic') && newAccount.type === 'service_account' && newAccount.credentials) {
     const credentials = newAccount.credentials as Record<string, unknown>
     editVertexProjectId.value = (credentials.project_id as string) || ''
@@ -3890,6 +4029,64 @@ const handleSubmit = async () => {
       // Add intercept warmup requests setting
       applyInterceptWarmup(newCredentials, interceptWarmupRequests.value, 'edit')
 
+      if (!applyTempUnschedConfig(newCredentials)) {
+        return
+      }
+
+      updatePayload.credentials = newCredentials
+    } else if (props.account.platform === 'newapi' && props.account.type === 'service_account') {
+      // 第五平台 newapi + Vertex service_account: channel_type + base_url +
+      // model_mapping 走 newapi composable.buildSubmitBundle（与 apikey 路径同一
+      // 套结构化 selector），Vertex SA 专属字段（service_account_json 写一次 /
+      // location / tier_id）在此叠加。SA JSON 留空 = 保留现有密钥（与 api_key 同
+      // 语义），永不回吐脱敏后的存储值。
+      const currentCredentials = (props.account.credentials as Record<string, unknown>) || {}
+      const bundle = newapiBuildSubmitBundle('edit')
+      if (!bundle) return
+      const newCredentials: Record<string, unknown> = { ...currentCredentials, ...bundle.credentials }
+
+      // newapi bundle 不带 api_key（Vertex 鉴权走 SA JSON），从 base credentials
+      // 移除残留 api_key 避免误用。
+      delete newCredentials.api_key
+      // composable 没填的字段意味着「清空」——edit 路径需主动 delete。
+      if (!bundle.credentials.model_mapping) delete newCredentials.model_mapping
+      if (!bundle.credentials.status_code_mapping) delete newCredentials.status_code_mapping
+      if (!bundle.credentials.openai_organization) delete newCredentials.openai_organization
+      updatePayload.channel_type = bundle.channelType
+
+      if (!editVertexLocation.value.trim()) {
+        appStore.showError(t('admin.accounts.vertexLocationRequired'))
+        return
+      }
+
+      // SA JSON write-once: 用户粘贴了新 JSON → 解析 + 重导出 project_id /
+      // client_email + 轮换密钥；留空 → 保留现有（脱敏后存在性优先读
+      // credentials_status）。
+      const saJsonInput = editVertexServiceAccountJson.value.trim()
+      if (saJsonInput) {
+        if (!applyEditVertexServiceAccountJson(saJsonInput)) return
+        newCredentials.service_account_json = editVertexServiceAccountJson.value.trim()
+        newCredentials.project_id = editVertexProjectId.value.trim()
+        newCredentials.client_email = editVertexClientEmail.value.trim()
+      } else {
+        const credentialsStatus = props.account.credentials_status
+        const hasExistingServiceAccountJson = credentialsStatus
+          ? Boolean(
+              credentialsStatus.has_service_account_json || credentialsStatus.has_service_account
+            )
+          : Boolean(currentCredentials.service_account_json || currentCredentials.service_account)
+        if (!hasExistingServiceAccountJson) {
+          appStore.showError(t('admin.accounts.vertexSaJsonRequired'))
+          return
+        }
+        // 保留现有 project_id / client_email（populate 时已从 credentials 灌入）。
+        if (editVertexProjectId.value.trim()) newCredentials.project_id = editVertexProjectId.value.trim()
+        if (editVertexClientEmail.value.trim()) newCredentials.client_email = editVertexClientEmail.value.trim()
+      }
+      newCredentials.location = editVertexLocation.value.trim()
+      newCredentials.tier_id = 'vertex'
+
+      applyInterceptWarmup(newCredentials, interceptWarmupRequests.value, 'edit')
       if (!applyTempUnschedConfig(newCredentials)) {
         return
       }

--- a/frontend/src/i18n/locales/en.ts
+++ b/frontend/src/i18n/locales/en.ts
@@ -3532,6 +3532,8 @@ export default {
       vertexSaJsonSelectBtn: 'Select JSON',
       vertexSaJsonUploadHint: 'After uploading or dropping a JSON file, the project_id will be auto-extracted. Key content is only used for account creation.',
       vertexSaJsonEditHint: 'Service Account JSON is not shown on the edit page; to change the JSON, delete the account and recreate it.',
+      vertexSaJsonNewapiEditHint: 'Leave empty to keep the current Service Account JSON. Paste a new JSON to rotate the key — the project_id will be re-extracted automatically.',
+      vertexSaJsonNewapiEditPlaceholder: 'Leave empty to keep current — or paste a new Service Account JSON to replace it',
       vertexProjectIdPlaceholder: 'Auto-extracted from JSON',
       vertexLocationHint: 'Available locations vary by Vertex model. Select the default endpoint location for this account.',
       vertexLocationRequired: 'Please enter a Vertex location',

--- a/frontend/src/i18n/locales/zh.ts
+++ b/frontend/src/i18n/locales/zh.ts
@@ -3678,6 +3678,8 @@ export default {
       vertexSaJsonSelectBtn: '选择 JSON',
       vertexSaJsonUploadHint: '上传或拖入 JSON 后会自动读取 project_id，密钥内容仅用于创建账号提交。',
       vertexSaJsonEditHint: 'Service Account JSON 不在编辑页显示；需要更换 JSON 时请删除账号后重新创建。',
+      vertexSaJsonNewapiEditHint: '留空则保留当前 Service Account JSON；粘贴新的 JSON 可轮换密钥，project_id 会自动重新解析。',
+      vertexSaJsonNewapiEditPlaceholder: '留空保留当前；或粘贴新的 Service Account JSON 以替换',
       vertexProjectIdPlaceholder: '从 JSON 自动读取',
       vertexLocationHint: '不同 Vertex 模型可用 location 可能不同，这里选择账号默认 endpoint location。',
       vertexLocationRequired: '请填写 Vertex location',

--- a/scripts/sentinels/frontend-tk.json
+++ b/scripts/sentinels/frontend-tk.json
@@ -328,6 +328,15 @@
       "rationale": "Post-2026-05-29 upstream merge: EditAccountModal was 3-way re-merged after the original merge took upstream wholesale and dropped TK customizations. This guards the upstream features TK adopted in that re-merge — per-account 5h/7d quota auto-pause threshold persistence (auto_pause_5h/7d_threshold, paired with the backend shouldAutoPauseOpenAIAccountByQuota gate) and the OpenAI endpoint-capability selection (openAIEndpointCapabilities). A future merge that re-overwrites this modal must keep them or the admin loses the auto-pause / capability controls. The TK compaction/pricing literals are guarded by the existing frontend-tk + newapi sentinels."
     },
     {
+      "path": "frontend/src/components/account/EditAccountModal.vue",
+      "must_contain": [
+        "account.platform === 'newapi' && account.type === 'service_account'",
+        "applyEditVertexServiceAccountJson",
+        "newCredentials.service_account_json = editVertexServiceAccountJson.value.trim()"
+      ],
+      "rationale": "Fifth-platform newapi + Vertex service_account (channel_type=41, e.g. gemini-imagen-veo-paid) accounts fall through BOTH upstream credential blocks (apikey block is type==='apikey', Vertex block is platform gemini|anthropic), so without this dedicated branch the Edit modal renders NO credential fields and operators must edit channel_type / model_mapping / vertex_location / SA JSON via raw SQL. The first literal pins the template v-if that surfaces AccountNewApiPlatformFields (channel_type + structured model_mapping selector) for this account shape; the second pins the write-once SA JSON parse helper (paste re-derives project_id/client_email, leave empty keeps the redacted secret); the third pins the submit-path persist of a rotated service_account_json. Compile still passes if a future upstream merge silently drops any one of these — the branch would just stop rendering or stop persisting — so all three are anchored to keep the load/edit/persist chain intact."
+    },
+    {
       "path": "frontend/src/constants/accountTierOptions.tk.ts",
       "must_contain": [
         "ACCOUNT_TIER_OPTIONS"


### PR DESCRIPTION
## Design rationale (Jobs lens)

- **Reuse, don't duplicate.** The edit surface composes the two pieces that already exist — `AccountNewApiPlatformFields` (channel_type + base_url + the structured model_mapping whitelist/mapping selector, driven by the already-wired `useTkAccountNewApiPlatform` composable) and the Vertex SA fields — instead of authoring a third parallel credential form.
- **One coherent journey with create.** A `platform=newapi + type=service_account` account (channel_type=41 Vertex, e.g. `gemini-imagen-veo-paid`) lands via the newapi channel-type=41 path; EDIT now matches that capability so the two surfaces feel like one product, not two.
- **Secrets stay write-once.** The Service Account JSON is a textarea with a "leave empty to keep current" hint, mirroring the `api_key` edit pattern. The stored (redacted) secret is never echoed into the DOM; pasting a fresh JSON re-derives `project_id` / `client_email` and rotates the key.
- **What I deliberately did NOT add.** No `base_url`-for-Vertex duplication beyond what `AccountNewApiPlatformFields` already gives, no new feature flags, no drag-and-drop uploader (the create modal has it; edit keeps a single paste textarea to stay minimal and obvious). No backend change — `UpdateAccount` already accepts `credentials` + top-level `channel_type`.
- **Merge-safe by construction.** Adds a `frontend-tk` sentinel entry pinning the new load/edit/persist chain (template v-if, SA-JSON parse helper, persist line) so a future upstream merge that re-overwrites this modal cannot silently drop it — compile would still pass, the control would just vanish, which is exactly the failure mode sentinels guard.

## The bug

`EditAccountModal.vue` had TWO credential-editing blocks and a newapi+service_account account fell through BOTH:
1. The apikey block is gated on `account.type === 'apikey'` → excludes `service_account`.
2. The Vertex SA block is gated on `platform === 'gemini' || 'anthropic'` → excludes `newapi`.

Result: the account rendered only name/notes/proxy/concurrency/groups — no way to edit channel_type, model_mapping, vertex_location, or the SA JSON without raw SQL. This removes that whole class of operational pain.

## What's in the diff

- `frontend/src/components/account/EditAccountModal.vue`: new template block + populate branch + submit branch for `newapi + service_account`; new `editVertexServiceAccountJson` ref + `applyEditVertexServiceAccountJson` parse helper.
- `frontend/src/i18n/locales/{en,zh}.ts`: two new keys (`vertexSaJsonNewapiEditHint`, `vertexSaJsonNewapiEditPlaceholder`) with en/zh parity; reuses existing keys (`vertexProjectIdPlaceholder`, `vertexLocationHint`, `vertexSaJsonMissingFields`, `vertexSaJsonInvalid`, `vertexSaJsonRequired`, `vertexLocationRequired`) everywhere else.
- `scripts/sentinels/frontend-tk.json`: sentinel entry for the new chain.
- `backend/internal/web/dist/frontend-source.json`: regenerated embedded dist (from `pnpm build`).

## Verification

- `cd frontend && pnpm lint:check` — passes (1 pre-existing warning in an unrelated playground spec).
- `pnpm typecheck` — passes.
- `pnpm build` — passes; embedded dist regenerated.
- `pnpm test:run` — the 9 failing tests (incl. 2 in EditAccountModal.spec) are **pre-existing on the base commit** (verified via `git stash`); my change keeps the same pass/fail count.
- `bash scripts/preflight.sh` — **PASS** including the full sub2api sentinel/web-surface-alignment/embedded-dist-freshness suite.

🤖 Generated with [Claude Code](https://claude.com/claude-code)