### PR TITLE
fix(accounts): honor force refresh for anthropic OAuth usage query

### DIFF
--- a/backend/internal/service/account_usage_service.go
+++ b/backend/internal/service/account_usage_service.go
@@ -337,10 +337,14 @@ func (s *AccountUsageService) GetUsage(ctx context.Context, accountID int64, for
 			if cache, ok := cached.(*apiUsageCache); ok {
 				age := time.Since(cache.timestamp)
 				if cache.err != nil && age < apiErrorCacheTTL {
-					// 负缓存命中：返回缓存的错误，避免重试风暴
+					// 负缓存命中：返回缓存的错误，避免重试风暴。
+					// force 也尊重负缓存：上游 usage 端点刚 429 时，手动「查询」
+					// 不应在 1 分钟内反复打它。
 					return nil, cache.err
 				}
-				if cache.response != nil && age < apiCacheTTL {
+				// force（手动「查询」）跳过正缓存命中以强制刷新，对齐 41e7ae53
+				// 对 OpenAI manual refresh 的修复；singleflight + jitter + 负缓存仍生效。
+				if !forceProbe && cache.response != nil && age < apiCacheTTL {
 					apiResp = cache.response
 				}
 			}
@@ -366,7 +370,7 @@ func (s *AccountUsageService) GetUsage(ctx context.Context, accountID int64, for
 						if cache.err != nil && age < apiErrorCacheTTL {
 							return nil, cache.err
 						}
-						if cache.response != nil && age < apiCacheTTL {
+						if !forceProbe && cache.response != nil && age < apiCacheTTL {
 							return cache.response, nil
 						}
 					}

--- a/backend/internal/service/account_usage_service_force_refresh_test.go
+++ b/backend/internal/service/account_usage_service_force_refresh_test.go
@@ -1,0 +1,95 @@
+package service
+
+import (
+	"context"
+	"testing"
+	"time"
+)
+
+// countingUsageFetcher 记录上游 usage 抓取次数，用于断言「手动查询是否真打上游」。
+type countingUsageFetcher struct {
+	calls int
+	resp  *ClaudeUsageResponse
+}
+
+func (f *countingUsageFetcher) FetchUsage(context.Context, string, string) (*ClaudeUsageResponse, error) {
+	f.calls++
+	return f.resp, nil
+}
+
+func (f *countingUsageFetcher) FetchUsageWithOptions(context.Context, *ClaudeUsageFetchOptions) (*ClaudeUsageResponse, error) {
+	f.calls++
+	return f.resp, nil
+}
+
+// forceRefreshRepo 在 stubOpenAIAccountRepo（按 accounts slice 提供 GetByID）之上补齐
+// GetUsage anthropic 路径会触达的写回方法，避免 nil-interface panic。
+type forceRefreshRepo struct {
+	stubOpenAIAccountRepo
+}
+
+func (forceRefreshRepo) UpdateExtra(context.Context, int64, map[string]any) error       { return nil }
+func (forceRefreshRepo) UpdateSessionWindowEnd(context.Context, int64, time.Time) error { return nil }
+
+// TestAccountUsageService_GetUsage_AnthropicForceBypassesCache 钉死 anthropic OAuth 账号
+// 的「查询」按钮（force=true）必须绕过 3min 正缓存强制刷新——这是 41e7ae53 修了 OpenAI
+// 却漏给 anthropic 的同一个 bug。force=false 仍读缓存（保护上游 usage 端点）。
+func TestAccountUsageService_GetUsage_AnthropicForceBypassesCache(t *testing.T) {
+	account := Account{
+		ID:       7777,
+		Platform: PlatformAnthropic,
+		Type:     AccountTypeOAuth,
+		Status:   StatusActive,
+		Credentials: map[string]any{
+			"access_token": "tkn-abc",
+		},
+	}
+
+	fresh := &ClaudeUsageResponse{}
+	fresh.FiveHour.Utilization = 42 // 上游「新」值
+
+	fetcher := &countingUsageFetcher{resp: fresh}
+	cache := NewUsageCache()
+
+	// 预置一条「新鲜」正缓存（3min 内），内容是旧值；force 必须绕过它。
+	stale := &ClaudeUsageResponse{}
+	stale.FiveHour.Utilization = 99 // 缓存里的「旧」值
+	cache.apiCache.Store(account.ID, &apiUsageCache{response: stale, timestamp: time.Now()})
+	// 预置窗口统计缓存，使 addWindowStats 不触达 usageLogRepo（保持 nil）。
+	cache.windowStatsCache.Store(account.ID, &windowStatsCache{stats: &WindowStats{}, timestamp: time.Now()})
+
+	svc := &AccountUsageService{
+		accountRepo:  &forceRefreshRepo{stubOpenAIAccountRepo{accounts: []Account{account}}},
+		usageFetcher: fetcher,
+		cache:        cache,
+		// tlsFPProfileService / identityCache / usageLogRepo 保持 nil：
+		// 账号无 Extra → IsTLSFingerprintEnabled=false → ResolveTLSProfile 不解引用 nil；
+		// identityCache 有 nil 守卫；windowStatsCache 预置使 usageLogRepo 不被触达。
+	}
+
+	ctx := context.Background()
+
+	// force=false：命中正缓存，返回旧值，不打上游。
+	u1, err := svc.GetUsage(ctx, account.ID, false)
+	if err != nil {
+		t.Fatalf("GetUsage(force=false) error = %v", err)
+	}
+	if fetcher.calls != 0 {
+		t.Fatalf("force=false 不应打上游，实际 calls=%d", fetcher.calls)
+	}
+	if u1.FiveHour == nil || u1.FiveHour.Utilization != 99 {
+		t.Fatalf("force=false 应返回缓存旧值 99，实际 %#v", u1.FiveHour)
+	}
+
+	// force=true：绕过正缓存，强制打上游一次，返回新值。
+	u2, err := svc.GetUsage(ctx, account.ID, true)
+	if err != nil {
+		t.Fatalf("GetUsage(force=true) error = %v", err)
+	}
+	if fetcher.calls != 1 {
+		t.Fatalf("force=true 应绕缓存打上游恰好 1 次，实际 calls=%d", fetcher.calls)
+	}
+	if u2.FiveHour == nil || u2.FiveHour.Utilization != 42 {
+		t.Fatalf("force=true 应返回上游新值 42，实际 %#v", u2.FiveHour)
+	}
+}


### PR DESCRIPTION
## 问题

账号卡片「用量窗口」的 **「查询」按钮**(主动查询)会发 `force=true`,但 `AccountUsageService.GetUsage` 只把 `forceProbe` 接到了 **OpenAI 分支**(commit `41e7ae53 fix: OpenAI OAuth usage quota never refreshing on manual refresh`)。**anthropic 的 `CanGetUsage()` 分支无条件读 3min 正缓存(`apiCache`)**,所以 3min 内点「查询」拿到的是缓存、而非真打 `https://api.anthropic.com/api/oauth/usage` 的新值——正是 `41e7ae53` 给 OpenAI 修过、却**漏给 anthropic** 的同一个「手动刷新不刷新」bug。

线上佐证:edge 容器 access-log 里同一秒内 `/admin/accounts/:id/usage` 出现 1037ms(真打上游)与 7ms(命中 3min 缓存)两种延迟,后者就是 force 被无视读缓存。

## 改动

`account_usage_service.go` 的 anthropic 分支,两处**正缓存命中**(外层赋值 + singleflight 内 return)各加 `!forceProbe` 守卫:`force=true` 跳过 3min 正缓存、强制一次上游抓取。**保留** singleflight + jitter + 1min **负缓存**——手动刷新仍不能在上游 usage 端点刚 429 时反复打它(这正是缓存存在的意义)。

## 测试

新增单测 `TestAccountUsageService_GetUsage_AnthropicForceBypassesCache`:
- `force=false` → 命中缓存返回旧值、**不打上游**;
- `force=true` → 绕缓存、**恰好打上游 1 次**、返回新值。

已验证:**移除 fix 后该测试 FAIL**(`force=true calls=0`),加 fix 后 PASS——确证测试真守住行为。`go test -tags=unit ./...` 全绿、`golangci-lint` 0 issues。

## 范围与纪律

- **纯后端**,无 web 影响(`no-web-impact`)。
- 触及 upstream-shaped 文件 `internal/service/account_usage_service.go`,故带 `upstream-touch-guarded`;sentinel 锚点(`parseExtraSampledAt` / `SessionWindowStart` staleness guard)**未触碰**,故 `sentinel-registry-reviewed`。
- 这是 upstream(Wei-Shaw/sub2api)`41e7ae53` 的不完整修复,**建议后续也回报 upstream**。
- 合并方式:**Squash and merge**(TK-originated)。

## ⚠️ 不在本 PR 范围

本 PR **不**修复「7d 显示陈旧」的那个现象——经查那是 **Anthropic usage 端点自身的滚动窗回落滞后**(点查询时上游真返回 100%),非缓存/代码问题。另有两个独立 UX 改进(前端静默吞错、卡片显示采样年龄)留作后续单独 PR。

🤖 Generated with [Claude Code](https://claude.com/claude-code)