### PR TITLE
fix(admin): edit form supports concurrency=0 (unlimited); web-search-emulation returns default when unset

### DIFF
--- a/backend/internal/service/websearch_config.go
+++ b/backend/internal/service/websearch_config.go
@@ -3,6 +3,7 @@ package service
 import (
 	"context"
 	"encoding/json"
+	"errors"
 	"fmt"
 	"log/slog"
 	"sync/atomic"
@@ -106,11 +107,20 @@ func (s *SettingService) loadWebSearchConfigFromDB() (*WebSearchEmulationConfig,
 
 	raw, err := s.settingRepo.GetValue(dbCtx, SettingKeyWebSearchEmulationConfig)
 	if err != nil {
-		webSearchEmulationCache.Store(&cachedWebSearchEmulationConfig{
-			config:    &WebSearchEmulationConfig{},
-			expiresAt: time.Now().Add(webSearchEmulationErrorTTL).UnixNano(),
-		})
-		return &WebSearchEmulationConfig{}, err
+		// Unset key = feature never configured = empty (disabled) config, not an
+		// error. Without this, a fresh deployment returns 404 on every account
+		// create/edit modal and the channels/settings pages that fetch this
+		// config (the GET handler maps the error straight to 404). Mirrors the
+		// "未配置返回零值 + nil" pattern used elsewhere in SettingService.
+		if errors.Is(err, ErrSettingNotFound) {
+			raw = ""
+		} else {
+			webSearchEmulationCache.Store(&cachedWebSearchEmulationConfig{
+				config:    &WebSearchEmulationConfig{},
+				expiresAt: time.Now().Add(webSearchEmulationErrorTTL).UnixNano(),
+			})
+			return &WebSearchEmulationConfig{}, err
+		}
 	}
 	cfg := parseWebSearchConfigJSON(raw)
 	webSearchEmulationCache.Store(&cachedWebSearchEmulationConfig{

--- a/backend/internal/service/websearch_config_unset_test.go
+++ b/backend/internal/service/websearch_config_unset_test.go
@@ -1,0 +1,78 @@
+//go:build unit
+
+package service
+
+import (
+	"context"
+	"errors"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+)
+
+// websearchUnsetSettingRepo implements SettingRepository and always reports the
+// websearch key as unset (ErrSettingNotFound) — the fresh-deployment state.
+type websearchUnsetSettingRepo struct{}
+
+func (websearchUnsetSettingRepo) Get(context.Context, string) (*Setting, error) {
+	return nil, ErrSettingNotFound
+}
+func (websearchUnsetSettingRepo) GetValue(context.Context, string) (string, error) {
+	return "", ErrSettingNotFound
+}
+func (websearchUnsetSettingRepo) Set(context.Context, string, string) error { return nil }
+func (websearchUnsetSettingRepo) GetMultiple(context.Context, []string) (map[string]string, error) {
+	return map[string]string{}, nil
+}
+func (websearchUnsetSettingRepo) SetMultiple(context.Context, map[string]string) error { return nil }
+func (websearchUnsetSettingRepo) GetAll(context.Context) (map[string]string, error) {
+	return map[string]string{}, nil
+}
+func (websearchUnsetSettingRepo) Delete(context.Context, string) error { return nil }
+
+// An unset websearch-emulation setting must read as an empty (disabled) config
+// with NO error — otherwise the GET handler maps the error to 404 and every
+// account create/edit modal + channels/settings page 404s on a fresh deploy.
+func TestGetWebSearchEmulationConfig_UnsetReturnsEmptyNoError(t *testing.T) {
+	// Defensively expire any process cache a prior test may have populated.
+	webSearchEmulationCache.Store(&cachedWebSearchEmulationConfig{
+		config:    &WebSearchEmulationConfig{},
+		expiresAt: 0,
+	})
+
+	svc := &SettingService{settingRepo: websearchUnsetSettingRepo{}}
+	cfg, err := svc.GetWebSearchEmulationConfig(context.Background())
+
+	require.NoError(t, err, "unset setting must not surface as an error (would become a 404)")
+	require.NotNil(t, cfg)
+	require.False(t, cfg.Enabled, "unset config is disabled")
+	require.Empty(t, cfg.Providers, "unset config has no providers")
+}
+
+// A real DB error (not ErrSettingNotFound) must still propagate.
+func TestGetWebSearchEmulationConfig_RealErrorPropagates(t *testing.T) {
+	webSearchEmulationCache.Store(&cachedWebSearchEmulationConfig{
+		config:    &WebSearchEmulationConfig{},
+		expiresAt: 0,
+	})
+
+	svc := &SettingService{settingRepo: websearchErrSettingRepo{err: errors.New("redis down")}}
+	_, err := svc.GetWebSearchEmulationConfig(context.Background())
+	require.Error(t, err, "non-not-found errors must still propagate")
+}
+
+type websearchErrSettingRepo struct{ err error }
+
+func (r websearchErrSettingRepo) Get(context.Context, string) (*Setting, error) { return nil, r.err }
+func (r websearchErrSettingRepo) GetValue(context.Context, string) (string, error) {
+	return "", r.err
+}
+func (websearchErrSettingRepo) Set(context.Context, string, string) error { return nil }
+func (websearchErrSettingRepo) GetMultiple(context.Context, []string) (map[string]string, error) {
+	return map[string]string{}, nil
+}
+func (websearchErrSettingRepo) SetMultiple(context.Context, map[string]string) error { return nil }
+func (websearchErrSettingRepo) GetAll(context.Context) (map[string]string, error) {
+	return map[string]string{}, nil
+}
+func (websearchErrSettingRepo) Delete(context.Context, string) error { return nil }

--- a/backend/internal/web/dist/frontend-source.json
+++ b/backend/internal/web/dist/frontend-source.json
@@ -1,7 +1,7 @@
 {
   "algorithm": "sha256(git-ls-files:path,size,content)",
   "file_count": 461,
-  "hash": "d6aa872d8b2887246523410cc47c010270d450e60d16bb76bfc064b6b39d13b6",
+  "hash": "26821aea8a4a270172d8245ff14d61af361dea5f86f2e963b39c582d34ebba4b",
   "schema": 1,
   "source": "frontend/"
 }

--- a/backend/internal/web/dist/frontend-source.json
+++ b/backend/internal/web/dist/frontend-source.json
@@ -1,7 +1,7 @@
 {
   "algorithm": "sha256(git-ls-files:path,size,content)",
   "file_count": 461,
-  "hash": "26821aea8a4a270172d8245ff14d61af361dea5f86f2e963b39c582d34ebba4b",
+  "hash": "a2ccd4ef4f4ba02a518ef082a33833ed75b89fe7789cf87dcc1d38df16cb1ac6",
   "schema": 1,
   "source": "frontend/"
 }

--- a/frontend/src/components/account/BulkEditAccountModal.vue
+++ b/frontend/src/components/account/BulkEditAccountModal.vue
@@ -536,13 +536,14 @@
             v-model.number="concurrency"
             id="bulk-edit-concurrency"
             type="number"
-            min="1"
+            min="0"
             :disabled="!enableConcurrency"
             class="input"
             :class="!enableConcurrency && 'cursor-not-allowed opacity-50'"
             aria-labelledby="bulk-edit-concurrency-label"
-            @input="concurrency = Math.max(1, concurrency || 1)"
+            @input="concurrency = Math.max(0, concurrency || 0)"
           />
+          <p v-if="enableConcurrency" class="input-hint">{{ t('admin.accounts.concurrencyZeroHint') }}</p>
         </div>
         <div>
           <div class="mb-3 flex items-center justify-between">
@@ -595,7 +596,7 @@
             v-model.number="priority"
             id="bulk-edit-priority"
             type="number"
-            min="1"
+            min="0"
             :disabled="!enablePriority"
             class="input"
             :class="!enablePriority && 'cursor-not-allowed opacity-50'"

--- a/frontend/src/components/account/CreateAccountModal.vue
+++ b/frontend/src/components/account/CreateAccountModal.vue
@@ -2568,8 +2568,9 @@
       <div class="grid grid-cols-2 gap-4 lg:grid-cols-4">
         <div>
           <label class="input-label">{{ t('admin.accounts.concurrency') }}</label>
-          <input v-model.number="form.concurrency" type="number" min="1" class="input"
-            @input="form.concurrency = Math.max(1, form.concurrency || 1)" />
+          <input v-model.number="form.concurrency" type="number" min="0" class="input"
+            @input="form.concurrency = Math.max(0, form.concurrency || 0)" />
+          <p class="input-hint">{{ t('admin.accounts.concurrencyZeroHint') }}</p>
         </div>
         <div>
           <label class="input-label">{{ t('admin.accounts.loadFactor') }}</label>
@@ -2583,7 +2584,7 @@
           <input
             v-model.number="form.priority"
             type="number"
-            min="1"
+            min="0"
             class="input"
             data-tour="account-form-priority"
           />

--- a/frontend/src/components/account/EditAccountModal.vue
+++ b/frontend/src/components/account/EditAccountModal.vue
@@ -1424,8 +1424,9 @@
       <div class="grid grid-cols-2 gap-4 lg:grid-cols-4">
         <div>
           <label class="input-label">{{ t('admin.accounts.concurrency') }}</label>
-          <input v-model.number="form.concurrency" type="number" min="1" class="input"
-            @input="form.concurrency = Math.max(1, form.concurrency || 1)" />
+          <input v-model.number="form.concurrency" type="number" min="0" class="input"
+            @input="form.concurrency = Math.max(0, form.concurrency || 0)" />
+          <p class="input-hint">{{ t('admin.accounts.concurrencyZeroHint') }}</p>
         </div>
         <div>
           <label class="input-label">{{ t('admin.accounts.loadFactor') }}</label>
@@ -1439,7 +1440,7 @@
           <input
             v-model.number="form.priority"
             type="number"
-            min="1"
+            min="0"
             class="input"
             data-tour="account-form-priority"
           />

--- a/frontend/src/i18n/locales/en.ts
+++ b/frontend/src/i18n/locales/en.ts
@@ -3812,6 +3812,7 @@ export default {
       proxy: 'Proxy',
       noProxy: 'No Proxy',
       concurrency: 'Concurrency',
+      concurrencyZeroHint: '0 = unlimited (no concurrency limit)',
       loadFactor: 'Load Factor',
       loadFactorHint: 'Higher load factor increases scheduling frequency',
       priority: 'Priority',

--- a/frontend/src/i18n/locales/zh.ts
+++ b/frontend/src/i18n/locales/zh.ts
@@ -3948,6 +3948,7 @@ export default {
       proxy: '代理',
       noProxy: '无代理',
       concurrency: '并发数',
+      concurrencyZeroHint: '0 = 不限制（无并发上限）',
       loadFactor: '负载因子',
       loadFactorHint: '提高负载因子可以提高对账号的调度频率',
       priority: '优先级',


### PR DESCRIPTION
Two bugs surfaced by the local Playwright **e2e acceptance** of the #676 newapi+service_account (Vertex) edit feature. Independent of #677.

## 1. Edit/Create form could not represent or save `concurrency=0` (= unlimited)

The gateway treats `concurrency <= 0` as **unlimited** (`concurrency_service.go:166`, covered by `TestAcquireAccountSlot_UnlimitedConcurrency`). But the account form pinned the input to `min="1"` plus an `@input` `Math.max(1,…)` clamp, so it could neither **set** "unlimited" nor even **open + save** an account that already had `concurrency=0` (e.g. API/SQL-seeded accounts like the prod `gemini-imagen-veo-paid` Vertex accounts). Native HTML5 validation **silently blocked submit** — no PUT fired, no toast, modal stayed open. `priority` had the same `min="1"` block for stored `0` values.

**Fix:** allow `0` on the `concurrency` and `priority` inputs in `EditAccountModal` + `CreateAccountModal`, clamp to `>= 0`, and add a `concurrencyZeroHint` ("0 = unlimited") so the meaning is explicit.

## 2. `GET /admin/settings/web-search-emulation` returned 404 when unset

On a fresh deployment the setting key doesn't exist, so `loadWebSearchConfigFromDB` propagated the settings-repo not-found error straight to the handler → **404** on every account create/edit modal and the channels/settings pages that fetch it. The service already intended "unset = empty config" (it returns `&WebSearchEmulationConfig{}` alongside the error).

**Fix:** treat `ErrSettingNotFound` as "unset = empty/disabled config" and return it with `nil` error — mirroring the established `errors.Is(err, ErrSettingNotFound)` pattern used elsewhere in `SettingService` (e.g. `content_moderation.go`). Real DB errors still propagate.

## Verification (local Stage0, real UI + API)

Built an image from this branch, deployed the Stage0 stack, and proved both fixes end-to-end:

- **#2** — `GET /api/v1/admin/settings/web-search-emulation` → **200** `{"enabled":false,"providers":[]}` (was 404).
- **#3** — reset the fixture account to `concurrency=0, priority=0`, then via **real browser UI (Playwright)** opened its edit modal and clicked Save without touching anything → **PUT 200**, modal closed, `concurrency=0` preserved on the round-trip. (Before the fix the same flow was silently blocked.)

Gates: `go build ./...` ✓; new backend unit tests `TestGetWebSearchEmulationConfig_UnsetReturnsEmptyNoError` + `_RealErrorPropagates` ✓; frontend `lint:check` (1 pre-existing unrelated warning) + `typecheck` + `build` ✓; embedded dist regenerated; `bash scripts/preflight.sh` PASS.

🤖 Generated with [Claude Code](https://claude.com/claude-code)