### PR TITLE
fix(release): make tag annotation body the single source of changelog

### DIFF
--- a/.github/workflows/deploy-stage0.yml
+++ b/.github/workflows/deploy-stage0.yml
@@ -206,11 +206,14 @@ jobs:
           GH_TOKEN: ${{ github.token }}
         run: |
           set -uo pipefail
-          # 取本次 Release 的 changelog(goreleaser 自动生成,内含自上次 tag 以来
-          # 的提交)内联到卡片;Release 尚未建/手动重放旧 tag 取不到时退回空,
-          # 卡片降级为只留 Release 链接。无 set -e,gh 失败只让 NOTES 为空,
-          # 不影响通知本身(best-effort)。
-          NOTES="$(gh release view "v$INPUT_TAG" --json body --jq '.body' 2>/dev/null)"
+          # changelog 的唯一源是 tag 注解正文(release-tag.sh 自动生成,release.yml
+          # 也读它喂给 GitHub Release header)。直接读 tag body 而非渲染后的
+          # `gh release view` —— 后者还含 goreleaser 的 README 标语 header + 安装
+          # footer,会被 clean_changelog 倒进「其他」桶污染卡片。runner 默认浅克隆
+          # 无 tag,先 fetch。取不到 → NOTES 空 → 卡片降级为只留链接(best-effort,
+          # 无 set -e,失败不影响通知本身)。
+          git fetch origin "refs/tags/v${INPUT_TAG}:refs/tags/v${INPUT_TAG}" --force 2>/dev/null || true
+          NOTES="$(git tag -l --format='%(contents:body)' "v$INPUT_TAG" 2>/dev/null)"
           bash ops/stage0/notify-feishu-release.sh "$INPUT_TAG" "$API_URL" \
             --run-url "$RUN_URL" --notes "$NOTES"
 

--- a/scripts/release-tag.sh
+++ b/scripts/release-tag.sh
@@ -13,14 +13,25 @@
 #   4. Tag does not already exist locally or on origin.
 #   5. We're on `main` and up to date with `origin/main`.
 #
+# Changelog: when --message is NOT given, the annotated tag BODY is filled
+# deterministically with the conventional-commit subjects since the previous
+# release tag (first-parent = squash-merged PR titles). That body is the single
+# source the whole release-notes pipeline reads:
+#   release.yml  -> git tag '%(contents:body)' -> goreleaser header -> GitHub Release
+#   deploy-stage0 -> same tag body -> Feishu rollout card
+# An empty changelog (nothing but a VERSION bump in range) is REFUSED unless
+# --allow-empty-changelog is passed, so a version can never ship with blank notes.
+#
 # Usage:
 #   bash scripts/release-tag.sh v1.3.0
 #   bash scripts/release-tag.sh v1.3.0 --message "Custom annotated tag message"
-#   bash scripts/release-tag.sh v1.3.0 --no-push      # create tag locally only
+#   bash scripts/release-tag.sh v1.3.0 --no-push                 # create tag locally only
+#   bash scripts/release-tag.sh v1.3.0 --dry-run                 # print the tag message, do NOT tag/push
+#   bash scripts/release-tag.sh v1.3.0 --allow-empty-changelog   # permit a no-changelog release
 #
 # Exit codes:
 #   0 — tag created (and pushed unless --no-push); release.yml will fire
-#   1 — validation failure (commit / VERSION / tag conflict)
+#   1 — validation failure (commit / VERSION / tag conflict / empty changelog)
 #   2 — git/network failure
 
 set -euo pipefail
@@ -33,11 +44,15 @@ fi
 TAG=""
 MESSAGE=""
 PUSH=1
+DRY_RUN=0
+ALLOW_EMPTY=0
 while [ "$#" -gt 0 ]; do
   case "$1" in
     --message) MESSAGE="$2"; shift 2 ;;
     --no-push) PUSH=0; shift ;;
-    -h|--help) sed -n '2,28p' "$0" | sed 's/^# \{0,1\}//'; exit 0 ;;
+    --dry-run) DRY_RUN=1; shift ;;
+    --allow-empty-changelog) ALLOW_EMPTY=1; shift ;;
+    -h|--help) sed -n '2,40p' "$0" | sed 's/^# \{0,1\}//'; exit 0 ;;
     v*) TAG="$1"; shift ;;
     *) echo "ERROR: unknown arg or invalid tag (must start with v): $1" >&2; exit 1 ;;
   esac
@@ -55,6 +70,57 @@ if ! [[ "$TAG" =~ ^v[0-9]+\.[0-9]+\.[0-9]+(-rc\.[0-9]+|-beta\.[0-9]+)?$ ]]; then
 fi
 
 VERSION_NUM="${TAG#v}"
+
+# gen_changelog — deterministic changelog body for the annotated tag.
+# Emits one `- <subject>` line per first-parent commit since the previous
+# release tag (squash-merged PRs carry `type(scope): … (#NNN)` subjects, the
+# universal interchange shape: GitHub auto-links #NNN, the Feishu card buckets
+# by `type`). VERSION-bump and sync-version-file writebacks are dropped as noise.
+gen_changelog() {
+  local prev range
+  prev=$(git describe --tags --abbrev=0 HEAD 2>/dev/null || true)
+  # If HEAD is already tagged (re-run, or --dry-run on a released commit), the
+  # describe above returns that same tag; step back one commit for the real prev.
+  if [ -n "$prev" ] && [ "$(git rev-parse "${prev}^{commit}")" = "$(git rev-parse HEAD)" ]; then
+    prev=$(git describe --tags --abbrev=0 HEAD^ 2>/dev/null || true)
+  fi
+  if [ -n "$prev" ]; then
+    range="${prev}..HEAD"
+  else
+    range="HEAD"  # first release ever: take the whole history
+  fi
+  git log --first-parent --pretty=format:'- %s' "$range" \
+    | grep -viE 'bump VERSION|sync.version.file' || true
+}
+
+# build_message — populate MESSAGE when the caller did not pass --message.
+# Subject line + blank + changelog body so `git tag '%(contents:body)'` returns
+# exactly the changelog. Refuses an empty changelog unless --allow-empty-changelog.
+build_message() {
+  [ -n "$MESSAGE" ] && return 0
+  local body
+  body=$(gen_changelog)
+  if [ -z "$body" ] && [ "$ALLOW_EMPTY" -ne 1 ]; then
+    echo "ERROR: no changelog entries since the previous release tag." >&2
+    echo "       The annotated tag body would be empty, so the GitHub Release" >&2
+    echo "       page and the Feishu rollout card would show no real changes." >&2
+    echo "" >&2
+    echo "  - If this release genuinely has no user-facing changes, re-run with" >&2
+    echo "      --allow-empty-changelog" >&2
+    echo "  - Otherwise pass an explicit body with --message \"…\"." >&2
+    exit 1
+  fi
+  MESSAGE="$(printf 'Release %s\n\n%s\n' "$TAG" "$body")"
+}
+
+# --dry-run: print the tag message that WOULD be written, then stop. Skips the
+# must-not-exist / branch-sync / network checks so it works on any historical
+# commit (also used to regenerate backfill text — same code path = single source).
+if [ "$DRY_RUN" -eq 1 ]; then
+  build_message
+  printf '%s\n' "$MESSAGE"
+  exit 0
+fi
 
 # 2. [skip ci] check — the v1.3.0 incident
 HEAD_MSG=$(git log -1 --format='%B')
@@ -120,10 +186,8 @@ if [ "$LOCAL" != "$REMOTE" ]; then
   exit 1
 fi
 
-# All checks passed. Create the tag.
-if [ -z "$MESSAGE" ]; then
-  MESSAGE="Release $TAG"
-fi
+# All checks passed. Build the message (auto-changelog unless --message given).
+build_message
 
 echo "Creating annotated tag $TAG -> $LOCAL"
 git tag -a "$TAG" -m "$MESSAGE"

--- a/scripts/release-tag.sh
+++ b/scripts/release-tag.sh
@@ -36,8 +36,12 @@
 
 set -euo pipefail
 
+# print_usage — render the comment banner (lines 2-35) as help text. Single
+# source for both the no-args error and -h/--help so the line range never drifts.
+print_usage() { sed -n '2,35p' "$0" | sed 's/^# \{0,1\}//'; }
+
 if [ "$#" -lt 1 ]; then
-  sed -n '2,28p' "$0" | sed 's/^# \{0,1\}//'
+  print_usage
   exit 1
 fi
 
@@ -52,7 +56,7 @@ while [ "$#" -gt 0 ]; do
     --no-push) PUSH=0; shift ;;
     --dry-run) DRY_RUN=1; shift ;;
     --allow-empty-changelog) ALLOW_EMPTY=1; shift ;;
-    -h|--help) sed -n '2,40p' "$0" | sed 's/^# \{0,1\}//'; exit 0 ;;
+    -h|--help) print_usage; exit 0 ;;
     v*) TAG="$1"; shift ;;
     *) echo "ERROR: unknown arg or invalid tag (must start with v): $1" >&2; exit 1 ;;
   esac


### PR DESCRIPTION
## 问题

v1.7.85 的飞书发版卡片「本次更新 · 🔧 其他」全是 README 标语 + 安装步骤,本次真实变更(#681 / #679 / #675 / #678 / #676 / #674)一条没出现;GitHub Release 页同样没有 changelog。

根因是**两个缺陷叠加**,都收敛到同一件事:**git tag 注解正文本应是 changelog 唯一源,却被允许为空 / 没被当作源读取**。

- **D1(根因)**:`scripts/release-tag.sh` 未传 `--message` 时默认 `MESSAGE="Release $TAG"`(仅 subject、正文 body 为空)。`release.yml` 用 `git tag '%(contents:body)'` 只取正文注入 goreleaser header(`changelog: disable: true`)。body 空 → Release 页只剩 README 标语 + 安装 footer。
- **D2(口径)**:`deploy-stage0.yml` 把 `gh release view --json body`(**整个渲染后的 body**,含标语 header + 安装 footer)塞给 `notify-feishu-release.sh --notes`;即便 D1 修好,`clean_changelog` 仍会把标语/安装/文档链接倒进「其他」桶。

## 改动(收敛到唯一源 = tag 注解正文)

- **`scripts/release-tag.sh`**:未传 `--message` 时,确定性地从「上一个 release tag..HEAD」的 first-parent 提交(squash-merge 的 PR 标题,天然带 `type(scope): … (#NNN)`)生成 changelog 正文,`bump VERSION` / `sync-version-file` 噪声过滤;**空 changelog 拒绝打 tag**(`--allow-empty-changelog` 可覆盖),与已有 `skip-ci`/VERSION 门同列;新增 `--dry-run` 预览。`--message` 仍可显式覆盖。
- **`.github/workflows/deploy-stage0.yml`**:飞书 notes 源从 `gh release view` 渲染后 body 改为直接读 tag 正文(先 fetch tag),与 `release.yml` 同源、纯 changelog,无 header/footer 泄漏。`notify-feishu-release.sh` 不动。

**不加 deploy 侧另算一份 changelog 的兜底**——双源会漂移、会掩盖空 tag。源头一对,下游自洽。

## v1.7.85 回填

tag 不重打(§5.y 历史不可变 + 会重触发 release.yml)。已用同款生成逻辑 `gh release edit v1.7.85` 回填 Release 页(标语 + 6 条真实 changelog + 原安装 footer)。飞书卡片不补发(rollout 已结束,重发反而困惑)。

## 验证

- `release-tag.sh v1.7.86 --dry-run` → 正确输出自 v1.7.84 起 6 条 PR(VERSION bump 已滤)
- 空 changelog 范围 → exit 1 拒绝;`--allow-empty-changelog` → exit 0
- 端到端:把 tag 正文喂 `notify-feishu-release.sh --dry-run` → 卡片只含 ✨新功能×3 / 🐛修复×3,**无**安装样板
- `gh release view v1.7.85` → changelog 段已出现,安装 footer 仍在
- `scripts/preflight.sh` 全绿;shellcheck 干净

🤖 Generated with [Claude Code](https://claude.com/claude-code)
