### PR TITLE
feat(fable): support Claude Fable 5 (claude-fable-5)

### DIFF
--- a/backend/internal/pkg/claude/constants.go
+++ b/backend/internal/pkg/claude/constants.go
@@ -161,6 +161,12 @@ type Model struct {
 // DefaultModels Claude Code 客户端支持的默认模型列表
 var DefaultModels = []Model{
 	{
+		ID:          "claude-fable-5",
+		Type:        "model",
+		DisplayName: "Claude Fable 5",
+		CreatedAt:   "2026-06-09T00:00:00Z",
+	},
+	{
 		ID:          "claude-opus-4-5-20251101",
 		Type:        "model",
 		DisplayName: "Claude Opus 4.5",

--- a/backend/internal/service/bedrock_request.go
+++ b/backend/internal/service/bedrock_request.go
@@ -674,10 +674,19 @@ func sanitizeBedrockThinking(body []byte, modelID string) []byte {
 		return body
 	}
 
-	if isBedrockOpus47OrNewer(modelID) {
-		if thinkingType == "enabled" {
+	if isBedrockOpus47OrNewer(modelID) || isFableModel(modelID) {
+		switch thinkingType {
+		case "enabled":
 			body, _ = sjson.SetBytes(body, "thinking.type", "adaptive")
 			body, _ = sjson.DeleteBytes(body, "thinking.budget_tokens")
+		case "disabled":
+			// Fable rejects an explicit thinking.type "disabled" with a 400 (Opus
+			// 4.7+ still accepts it); omitting the field is the documented
+			// equivalent. Proactive strip here since the bedrock path runs before
+			// the first send. See docs/spec-delta-cc-fable-5.md.
+			if isFableModel(modelID) {
+				body, _ = sjson.DeleteBytes(body, "thinking")
+			}
 		}
 		return body
 	}

--- a/backend/internal/service/bedrock_request_test.go
+++ b/backend/internal/service/bedrock_request_test.go
@@ -789,6 +789,25 @@ func TestSanitizeBedrockThinking(t *testing.T) {
 		assert.Equal(t, "enabled", gjson.GetBytes(result, "thinking.type").String())
 		assert.Equal(t, int64(defaultThinkingBudgetTokens), gjson.GetBytes(result, "thinking.budget_tokens").Int())
 	})
+
+	t.Run("fable converts enabled to adaptive (adaptive-only, like opus 4.7+)", func(t *testing.T) {
+		input := `{"thinking":{"type":"enabled","budget_tokens":10000},"messages":[]}`
+		result := sanitizeBedrockThinking([]byte(input), "anthropic.claude-fable-5")
+		assert.Equal(t, "adaptive", gjson.GetBytes(result, "thinking.type").String())
+		assert.False(t, gjson.GetBytes(result, "thinking.budget_tokens").Exists())
+	})
+
+	t.Run("fable strips explicit disabled (fable 400s on disabled; opus 4.7+ accepts)", func(t *testing.T) {
+		input := `{"thinking":{"type":"disabled"},"messages":[]}`
+		result := sanitizeBedrockThinking([]byte(input), "anthropic.claude-fable-5")
+		assert.False(t, gjson.GetBytes(result, "thinking").Exists(), "thinking field must be omitted for fable disabled")
+	})
+
+	t.Run("opus 4.7 keeps explicit disabled unchanged (only fable strips it)", func(t *testing.T) {
+		input := `{"thinking":{"type":"disabled"},"messages":[]}`
+		result := sanitizeBedrockThinking([]byte(input), "us.anthropic.claude-opus-4-7-v1")
+		assert.Equal(t, "disabled", gjson.GetBytes(result, "thinking.type").String())
+	})
 }
 
 func TestSanitizeBedrockToolUseIDs(t *testing.T) {

--- a/backend/internal/service/billing_service.go
+++ b/backend/internal/service/billing_service.go
@@ -245,6 +245,16 @@ func (s *BillingService) initFallbackPricing() {
 	// Claude 4.7 Opus (暂与4.6同价，待官方定价更新)
 	s.fallbackPrices["claude-opus-4.7"] = s.fallbackPrices["claude-opus-4.6"]
 
+	// Claude Fable 5 (Opus 之上的新档；官方 $10/$50 per MTok)。
+	// cache 写 = 1.25× 输入 ($12.5)，cache 读 = 0.1× 输入 ($1.0)，与其它 claude 档一致。
+	s.fallbackPrices["claude-fable-5"] = &ModelPricing{
+		InputPricePerToken:         10e-6,   // $10 per MTok
+		OutputPricePerToken:        50e-6,   // $50 per MTok
+		CacheCreationPricePerToken: 12.5e-6, // $12.50 per MTok
+		CacheReadPricePerToken:     1.0e-6,  // $1.00 per MTok
+		SupportsCacheBreakdown:     false,
+	}
+
 	// Gemini 3.1 Pro
 	s.fallbackPrices["gemini-3.1-pro"] = &ModelPricing{
 		InputPricePerToken:         2e-6,   // $2 per MTok
@@ -335,6 +345,11 @@ func (s *BillingService) getFallbackPricing(model string) *ModelPricing {
 			return s.fallbackPrices["claude-3-5-haiku"]
 		}
 		return s.fallbackPrices["claude-3-haiku"]
+	}
+	// Claude Fable 5（Opus 之上的新档）必须先于下面的 claude 兜底命中，
+	// 否则会被误判为 sonnet（$3/$15）严重少收费。
+	if strings.Contains(modelLower, "fable") {
+		return s.fallbackPrices["claude-fable-5"]
 	}
 	// Claude 未知型号统一回退到 Sonnet，避免计费中断。
 	if strings.Contains(modelLower, "claude") {

--- a/backend/internal/service/billing_service_test.go
+++ b/backend/internal/service/billing_service_test.go
@@ -84,6 +84,10 @@ func TestGetModelPricing_FallbackMatchesByFamily(t *testing.T) {
 		{"claude-3-5-sonnet-20241022", 3e-6},
 		{"claude-3-5-haiku-20241022", 1e-6},
 		{"claude-3-haiku-20240307", 0.25e-6},
+		// Fable 5 is the tier above Opus ($10/MTok); must NOT fall through to the
+		// generic claude→sonnet ($3) catch-all (would underbill ~3.3x).
+		{"claude-fable-5", 10e-6},
+		{"claude-fable-5[1m]", 10e-6},
 	}
 
 	for _, tt := range tests {
@@ -342,6 +346,8 @@ func TestGetFallbackPricing_FamilyMatching(t *testing.T) {
 		{name: "claude opus 4.6", model: "claude-opus-4.6-20260201", expectedInput: 5e-6},
 		{name: "claude opus 4.5 alt separator", model: "claude-opus-4-5-20260101", expectedInput: 5e-6},
 		{name: "claude generic model fallback sonnet", model: "claude-foo-bar", expectedInput: 3e-6},
+		{name: "claude fable 5 (above opus, $10)", model: "claude-fable-5", expectedInput: 10e-6},
+		{name: "claude fable 5 1m alias", model: "claude-fable-5[1m]", expectedInput: 10e-6},
 		{name: "gemini explicit fallback", model: "gemini-3-1-pro", expectedInput: 2e-6},
 		// upstream Wei-Shaw/sub2api#2486: unknown gemini-* must NOT bill $0; falls back to gemini-3.1-pro pricing.
 		{name: "gemini unknown falls back to 3.1-pro", model: "gemini-2.0-pro", expectedInput: 2e-6},

--- a/backend/internal/service/gateway_request.go
+++ b/backend/internal/service/gateway_request.go
@@ -1346,8 +1346,8 @@ func RectifyThinkingBudget(body []byte, modelID string) ([]byte, bool) {
 		return body, false
 	}
 
-	// Opus 4.7+ only accepts adaptive: never force "enabled"/budget_tokens for these models.
-	if isOpus47OrNewer(modelID) {
+	// Opus 4.7+ and Fable only accept adaptive: never force "enabled"/budget_tokens for these models.
+	if requiresAdaptiveOnlyThinking(modelID) {
 		modified, changed := RectifyThinkingTypeAdaptive(body)
 		// Still honor a sane max_tokens floor so a tiny client max_tokens doesn't choke thinking.
 		if maxTokens := gjson.GetBytes(modified, "max_tokens").Int(); maxTokens > 0 && maxTokens < int64(BudgetRectifyMinMaxTokens) {

--- a/backend/internal/service/gateway_request_thinking_adaptive_test.go
+++ b/backend/internal/service/gateway_request_thinking_adaptive_test.go
@@ -44,6 +44,60 @@ func TestIsOpus47OrNewer(t *testing.T) {
 	}
 }
 
+func TestIsFableModel(t *testing.T) {
+	cases := []struct {
+		model string
+		want  bool
+	}{
+		{"claude-fable-5", true},
+		{"claude-fable-5[1m]", true},
+		{"claude-fable-5-20260609", true},
+		{"anthropic.claude-fable-5", true}, // bedrock form
+		{"Claude-Fable-5", true},           // case-insensitive
+		{"claude-opus-4-8", false},
+		{"claude-sonnet-4-6", false},
+		{"", false},
+	}
+	for _, tc := range cases {
+		t.Run(tc.model, func(t *testing.T) {
+			require.Equal(t, tc.want, isFableModel(tc.model))
+		})
+	}
+}
+
+func TestRequiresAdaptiveOnlyThinking(t *testing.T) {
+	// True for opus-4.7+ AND fable; false for sonnet / opus-4.6 / haiku.
+	cases := []struct {
+		model string
+		want  bool
+	}{
+		{"claude-fable-5", true},
+		{"claude-fable-5[1m]", true},
+		{"claude-opus-4-7", true},
+		{"claude-opus-4-8", true},
+		{"claude-opus-4-6", false},
+		{"claude-sonnet-4-6", false},
+		{"claude-haiku-4-5-20251001", false},
+		{"", false},
+	}
+	for _, tc := range cases {
+		t.Run(tc.model, func(t *testing.T) {
+			require.Equal(t, tc.want, requiresAdaptiveOnlyThinking(tc.model))
+		})
+	}
+}
+
+func TestRectifyThinkingBudget_FableIsAdaptive(t *testing.T) {
+	// Fable shares opus-4.7+'s adaptive-only surface: a budget-constraint repair
+	// must produce adaptive (no budget_tokens), never enabled+32000 (fable 400s).
+	body := []byte(`{"model":"claude-fable-5","max_tokens":1024,"thinking":{"type":"enabled","budget_tokens":100}}`)
+	out, changed := RectifyThinkingBudget(body, "claude-fable-5")
+	require.True(t, changed)
+	require.Equal(t, "adaptive", gjson.GetBytes(out, "thinking.type").String())
+	require.False(t, gjson.GetBytes(out, "thinking.budget_tokens").Exists())
+	require.GreaterOrEqual(t, gjson.GetBytes(out, "max_tokens").Int(), int64(BudgetRectifyMinMaxTokens))
+}
+
 func TestIsThinkingTypeAdaptiveRequiredError(t *testing.T) {
 	// The exact production 400 message (CC issue #61348).
 	realMsg := `"thinking.type.enabled" is not supported for this model. Use "thinking.type.adaptive" and "output_config.effort" to control thinking behavior.`

--- a/backend/internal/service/gateway_request_tk_fable.go
+++ b/backend/internal/service/gateway_request_tk_fable.go
@@ -1,0 +1,34 @@
+package service
+
+import "strings"
+
+// TokenKey: Fable-tier model predicates for thinking-shape rectification.
+//
+// Fable 5 (`claude-fable-5`) is the new tier above Opus. Captured real Claude
+// Code 2.1.170 traffic (egress 3.148.79.145, 2026-06-09; see
+// docs/spec-delta-cc-fable-5.md) shows Fable shares Opus 4.7+'s request surface:
+// manual thinking (`thinking:{type:"enabled",budget_tokens:N}`) is rejected with
+// the same adaptive-required 400, and only `{type:"adaptive"}` is accepted.
+//
+// The existing budget/adaptive rectifiers hard-gate on isOpus47OrNewer, whose
+// name (and the shared claudeVersionRe regex) only matches opus/sonnet/haiku
+// version strings — `claude-fable-5` matches neither, so without this widening
+// Fable's adaptive-required 400 would be gated OUT of the reactive repair and
+// surfaced raw to the client. requiresAdaptiveOnlyThinking is the broadened gate
+// used at those call sites; isOpus47OrNewer stays honest to its name.
+
+// isFableModel reports whether modelID is a Claude Fable-tier model. Matches the
+// bare id, dated snapshots, the [1m] context-window alias, and the bedrock
+// `anthropic.claude-fable-5` form via a single substring test.
+func isFableModel(modelID string) bool {
+	return strings.Contains(strings.ToLower(modelID), "fable")
+}
+
+// requiresAdaptiveOnlyThinking reports whether the model rejects manual thinking
+// (`thinking:{type:"enabled",budget_tokens:N}` → 400) and accepts only
+// `{type:"adaptive"}`. True for Opus 4.7+ and all Fable-tier models. This is the
+// platform-neutral gate; the bedrock path mirrors it via isBedrockOpus47OrNewer
+// || isFableModel in sanitizeBedrockThinking.
+func requiresAdaptiveOnlyThinking(modelID string) bool {
+	return isOpus47OrNewer(modelID) || isFableModel(modelID)
+}

--- a/backend/internal/service/gateway_service.go
+++ b/backend/internal/service/gateway_service.go
@@ -5157,8 +5157,9 @@ func (s *GatewayService) Forward(ctx context.Context, c *gin.Context, account *A
 				// Claude for Mac、第三方 SDK）仍发老格式 → 上游 400 挂会话。反应式自愈：只在上游
 				// 真的回该 400 时把 enabled→adaptive 重试一次，happy path 一字节不碰。复用 budget
 				// 整流总开关（thinking-type 与 thinking-budget 同属思考整流，共用 kill-switch，
-				// 不新增配置面），并硬门控 isOpus47OrNewer(reqModel) 防误伤 sonnet / opus-4.6。
-				if isThinkingTypeAdaptiveRequiredError(errMsg) && isOpus47OrNewer(reqModel) && s.settingService.IsBudgetRectifierEnabled(ctx) {
+				// 不新增配置面），并硬门控 requiresAdaptiveOnlyThinking(reqModel)（opus-4.7+ / fable）
+				// 防误伤 sonnet / opus-4.6。
+				if isThinkingTypeAdaptiveRequiredError(errMsg) && requiresAdaptiveOnlyThinking(reqModel) && s.settingService.IsBudgetRectifierEnabled(ctx) {
 					appendOpsUpstreamError(c, OpsUpstreamErrorEvent{
 						Platform:           account.Platform,
 						AccountID:          account.ID,
@@ -5667,10 +5668,10 @@ func (s *GatewayService) forwardAnthropicAPIKeyPassthroughWithInput(
 					}
 				}
 
-				// Opus 4.7+ reject thinking.type=enabled (only adaptive). Reactive repair
-				// mirrors the main path's 4th priority; hard-gated by isOpus47OrNewer.
+				// Opus 4.7+ and Fable reject thinking.type=enabled (only adaptive). Reactive
+				// repair mirrors the main path's 4th priority; hard-gated by requiresAdaptiveOnlyThinking.
 				if !adaptiveRetryAttempted && attempt < maxRetryAttempts && time.Since(retryStart) < maxRetryElapsed &&
-					isThinkingTypeAdaptiveRequiredError(errMsg) && isOpus47OrNewer(modelForRepair) && s.settingService.IsBudgetRectifierEnabled(ctx) {
+					isThinkingTypeAdaptiveRequiredError(errMsg) && requiresAdaptiveOnlyThinking(modelForRepair) && s.settingService.IsBudgetRectifierEnabled(ctx) {
 					if rectified, applied := RectifyThinkingTypeAdaptive(input.Body); applied {
 						appendOpsUpstreamError(c, OpsUpstreamErrorEvent{
 							Platform:           account.Platform,

--- a/backend/internal/service/ops_cancel_storm_tk.go
+++ b/backend/internal/service/ops_cancel_storm_tk.go
@@ -200,7 +200,10 @@ func (d *cancelStormDetector) observe(apiKeyID int64, apiKeyName, model string, 
 	if cfg.Mode != cancelStormModeDetectOnly {
 		return
 	}
-	if cfg.OpusOnly && !isOpusModel(model) {
+	// OpusOnly watches the expensive tier for client-cancel abuse. Fable is the
+	// tier above Opus (priciest of all), so it belongs in scope too — otherwise
+	// the costliest model would silently escape the costly-model watch.
+	if cfg.OpusOnly && !isOpusModel(model) && !isFableModel(model) {
 		return
 	}
 

--- a/backend/internal/service/ops_cancel_storm_tk_test.go
+++ b/backend/internal/service/ops_cancel_storm_tk_test.go
@@ -146,6 +146,19 @@ func TestCancelStormOpusOnlyGatesNonOpus(t *testing.T) {
 	require.Empty(t, d.states)
 }
 
+func TestCancelStormOpusOnlyIncludesFable(t *testing.T) {
+	// Fable is the tier above Opus (priciest), so opus_only must still watch it —
+	// otherwise the costliest model escapes the costly-model cancel-storm watch.
+	now := time.Unix(1700000000, 0)
+	doer := &blockingFeishuDoer{done: make(chan struct{}, 8)}
+	d := newTestCancelStormDetector(&CancelStormConfig{Mode: cancelStormModeDetectOnly, WindowSeconds: 600, MinSampleCount: 2, CancelRateThreshold: 0.5, AlertCooldownSeconds: 600, OpusOnly: true}, doer, now)
+	for i := 0; i < 10; i++ {
+		d.observe(7, "k", "claude-fable-5", true)
+	}
+	waitForFeishuCalls(t, doer, 1)
+	require.Equal(t, 1, doer.callCount(), "opus_only must still watch fable (priciest tier)")
+}
+
 func TestCancelStormWindowTumblingResets(t *testing.T) {
 	now := time.Unix(1700000000, 0)
 	cur := now

--- a/backend/internal/service/pricing_catalog_supported_models_tk.go
+++ b/backend/internal/service/pricing_catalog_supported_models_tk.go
@@ -54,6 +54,7 @@ package service
 // supportedAnthropicCatalogModels — claude IDs confirmed servable.
 var supportedAnthropicCatalogModels = map[string]struct{}{
 	// servable-allowlist:begin anthropic
+	"claude-fable-5":    {},
 	"claude-haiku-4-5":  {},
 	"claude-opus-4-1":   {},
 	"claude-opus-4-5":   {},

--- a/backend/internal/service/tk_pricing_overlay.json
+++ b/backend/internal/service/tk_pricing_overlay.json
@@ -4,6 +4,25 @@
     "provenance": "media: BerriAI/litellm model_prices_and_context_window.json, captured 2026-06-01; deepseek-v4-*: https://api-docs.deepseek.com/quick_start/pricing, captured 2026-06-04 (cache-hit input = cache_read; cache writes billed as normal input, no separate write fee)",
     "regen": "manual curation; no auto-sync (entries are few + slow-moving). If they proliferate, add provider-aware sync."
   },
+  "claude-fable-5": {
+    "litellm_provider": "anthropic",
+    "mode": "chat",
+    "input_cost_per_token": 0.00001,
+    "output_cost_per_token": 0.00005,
+    "cache_creation_input_token_cost": 0.0000125,
+    "cache_creation_input_token_cost_above_1hr": 0.00002,
+    "cache_read_input_token_cost": 0.000001,
+    "max_input_tokens": 1000000,
+    "max_output_tokens": 128000,
+    "max_tokens": 128000,
+    "supports_prompt_caching": true,
+    "supports_function_calling": true,
+    "supports_tool_choice": true,
+    "supports_vision": true,
+    "supports_pdf_input": true,
+    "supports_reasoning": true,
+    "source": "Anthropic official Fable 5 list price (2026-06: in $10/M, out $50/M, 1M ctx, 128K out); litellm mirror lags new model"
+  },
   "deepseek-v4-flash": {
     "litellm_provider": "deepseek",
     "mode": "chat",

--- a/backend/internal/web/dist/frontend-source.json
+++ b/backend/internal/web/dist/frontend-source.json
@@ -1,7 +1,7 @@
 {
   "algorithm": "sha256(git-ls-files:path,size,content)",
   "file_count": 461,
-  "hash": "f21d8bb78b7fc75a9dcadfc341325964bb5099efff043956eb2d052c925813f8",
+  "hash": "3fa3e76c2ba788df7720a751331c620dd625c06799d57564b2dc62bf4c729114",
   "schema": 1,
   "source": "frontend/"
 }

--- a/docs/spec-delta-cc-fable-5.md
+++ b/docs/spec-delta-cc-fable-5.md
@@ -1,0 +1,104 @@
+# spec-delta: Fable 5 (`claude-fable-5`) support
+
+TokenKey support for Anthropic's new top-tier model **Fable 5** (`claude-fable-5`,
+the tier above Opus; $10/$50 per MTok, 1M context, 128K output). Grounded in real
+Claude Code 2.1.170 traffic captured via the cc-fingerprint pipeline.
+
+## Capture (ground truth)
+
+- Tooling: `/tokenkey-cc-fingerprint-alignment` + cc0-here (cc0 → gost → SOCKS).
+- Client: cc 2.1.170; capture egress **3.148.79.145**; 2026-06-09 (captured + re-verified).
+- Driven by overriding `TOKENKEY_CC_CAPTURE_MODEL` through the mitm chain across
+  haiku-4-5 / sonnet-4-6 / opus-4-8 / fable-5; a direct
+  `cc0-here --model claude-fable-5` returned a real `PONG` (200), confirming the
+  OAuth account can serve Fable today (free for Pro/Max/Team until 2026-06-22,
+  then credits).
+
+### Per-model `anthropic-beta` (real cc 2.1.170 `/v1/messages`)
+
+| Model | beta set (relative to committed `sonnet_opus` baseline) |
+|---|---|
+| haiku-4-5 | distinct (`structured-outputs-2025-12-15`, no `claude-code`/`effort`); A/B bimodal per #429 |
+| sonnet-4-6 | baseline **+ `effort-2025-11-24`** |
+| opus-4-8 | baseline + `effort-2025-11-24` **+ `mid-conversation-system-2026-04-07`** |
+| **fable-5** | **opus-4-8 + `server-side-fallback-2026-06-01` + `fallback-credit-2026-06-01`** (`opus-4-8 − fable-5 = ∅`) |
+
+Fable is a **strict superset of Opus 4.8** — exactly the two fallback/credit betas
+extra. TLS ja3 / UA (`claude-cli/2.1.170 (external, sdk-cli)`) /
+X-Stainless-Package-Version (`0.94.0`) are identical across all four models.
+
+### Findings
+
+| Dimension | Fable 5 | vs Opus 4.8 | Action |
+|---|---|---|---|
+| TLS ja3 | matches baseline | ClientHello is model-independent | none |
+| User-Agent | `claude-cli/2.1.170 (external, sdk-cli)` | identical | none |
+| X-Stainless-Package-Version | `0.94.0` | identical | none |
+| mimicry family | selector is `Contains(model,"haiku")` → else sonnet_opus; fable is non-haiku | auto-classified into sonnet_opus | none (already correct) |
+| `anthropic-beta` (main `/v1/messages`) | Opus 4.8 set **+ `server-side-fallback-2026-06-01` + `fallback-credit-2026-06-01`** | only +2 fallback/credit betas | see Decision 3 |
+
+Real captured Fable 5 beta set:
+
+```
+claude-code-20250219,oauth-2025-04-20,interleaved-thinking-2025-05-14,
+thinking-token-count-2026-05-13,context-management-2025-06-27,
+prompt-caching-scope-2026-01-05,mid-conversation-system-2026-04-07,
+advisor-tool-2026-03-01,advanced-tool-use-2025-11-20,effort-2025-11-24,
+server-side-fallback-2026-06-01,fallback-credit-2026-06-01,
+extended-cache-ttl-2025-04-11,cache-diagnosis-2026-04-07
+```
+
+## Decisions
+
+1. **Pricing (止血).** Fable was un-priced everywhere; `getFallbackPricing` matched
+   the generic `claude→sonnet` catch-all → ~3.3x **underbill**. Added
+   `claude-fable-5` = $10/$50 (cache write $12.50, cache read $1.00) to both
+   `tk_pricing_overlay.json` (primary, litellm mirror lags) and
+   `billing_service.go` `fallbackPrices` (safety net), plus an explicit `fable`
+   branch in `getFallbackPricing` ahead of the claude catch-all.
+
+2. **Thinking integrity.** Fable shares Opus 4.7+'s adaptive-only surface
+   (`thinking:{type:"enabled",budget_tokens:N}` → 400, only `adaptive` accepted),
+   but the reactive repair was hard-gated on `isOpus47OrNewer`, whose name/regex
+   only match opus/sonnet/haiku — so Fable's adaptive-required 400 was gated OUT
+   and surfaced raw. Added `isFableModel` + `requiresAdaptiveOnlyThinking`
+   (`gateway_request_tk_fable.go`) and swapped the gate at the 3 call sites
+   (`RectifyThinkingBudget` + the two reactive `RectifyThinkingTypeAdaptive`
+   sites). Bedrock CC-compat path (`sanitizeBedrockThinking`, proactive) extended
+   to treat Fable as adaptive-only **and** strip an explicit
+   `thinking.type:"disabled"` — Fable's one breaking change beyond Opus 4.7+ (it
+   400s on `disabled`; omitting the field is the documented equivalent).
+
+   **Known gap (deferred):** the *direct* Anthropic path has no proactive thinking
+   sanitizer (it is reactive-on-400 only), and the exact upstream 400 message for
+   Fable `disabled` was not captured (cc never emits `disabled` for Fable). So a
+   third-party client sending `thinking:{type:"disabled"}` for Fable on the direct
+   path gets an honest passthrough 400 rather than an auto-repair. Add a reactive
+   matcher once the real message is captured.
+
+3. **Mimicry betas — intentionally NOT changed.** Fable already auto-classifies
+   into the sonnet_opus mimicry family, so it inherits that beta set. The two
+   Fable-only betas (`server-side-fallback-2026-06-01`, `fallback-credit-2026-06-01`)
+   are first-party credit/fallback-billing signals; injecting them on relayed
+   accounts is meaningless-to-harmful, so they are recorded here but not added to
+   the mimicry constants.
+
+   Separately, re-verification shows the committed `sonnet_opus` baseline lacks
+   `effort-2025-11-24` (sonnet-4-6 **and** opus-4-8) and
+   `mid-conversation-system-2026-04-07` (opus-4-8) that live cc 2.1.170 sends — a
+   **general 2.1.170 beta drift**, independent of Fable, and likely
+   request-conditional (those betas only appear when effort / mid-conversation
+   system features are exercised, so a flat hard-align risks over-fitting one
+   sample — cf. #429). To be handled by the normal cc-fingerprint-alignment flow
+   (§4.2) with multi-request characterization, not this PR.
+
+4. **Visibility (all three).** Added `claude-fable-5` to
+   `claude.DefaultModels` (advertised `/v1/models` + admin pickers),
+   `supportedAnthropicCatalogModels` (public `/pricing` + Your-Menu; justified by
+   the live 200 probe — the next `refresh-servable-allowlist.py` run reconciles
+   it), and the frontend `claudeModels` + label/color map (`useModelWhitelist.ts`).
+
+## Out of scope
+
+General cc 2.1.170 `sonnet_opus` beta drift (Decision 3) and any direct-path
+`disabled` reactive repair (Decision 2).

--- a/frontend/src/composables/useModelWhitelist.ts
+++ b/frontend/src/composables/useModelWhitelist.ts
@@ -41,6 +41,7 @@ const newapiModels = [
 
 // Anthropic Claude
 export const claudeModels = [
+  'claude-fable-5',
   'claude-opus-4-1-20250805',
   'claude-sonnet-4-5-20250929', 'claude-haiku-4-5-20251001',
   'claude-opus-4-5-20251101',
@@ -257,6 +258,7 @@ const anthropicPresetMappings = [
   { label: 'Opus 4.6', from: 'claude-opus-4-6', to: 'claude-opus-4-6', color: 'bg-purple-100 text-purple-700 hover:bg-purple-200 dark:bg-purple-900/30 dark:text-purple-400' },
   { label: 'Opus 4.7', from: 'claude-opus-4-7', to: 'claude-opus-4-7', color: 'bg-purple-100 text-purple-700 hover:bg-purple-200 dark:bg-purple-900/30 dark:text-purple-400' },
   { label: 'Opus 4.8', from: 'claude-opus-4-8', to: 'claude-opus-4-8', color: 'bg-purple-100 text-purple-700 hover:bg-purple-200 dark:bg-purple-900/30 dark:text-purple-400' },
+  { label: 'Fable 5', from: 'claude-fable-5', to: 'claude-fable-5', color: 'bg-rose-100 text-rose-700 hover:bg-rose-200 dark:bg-rose-900/30 dark:text-rose-400' },
   { label: 'Haiku 4.5', from: 'claude-haiku-4-5-20251001', to: 'claude-haiku-4-5-20251001', color: 'bg-emerald-100 text-emerald-700 hover:bg-emerald-200 dark:bg-emerald-900/30 dark:text-emerald-400' },
   { label: 'Opus->Sonnet', from: 'claude-opus-4-6', to: 'claude-sonnet-4-5-20250929', color: 'bg-amber-100 text-amber-700 hover:bg-amber-200 dark:bg-amber-900/30 dark:text-amber-400' }
 ]


### PR DESCRIPTION
## What

First-class TokenKey support for Anthropic's new top-tier model **Fable 5** (`claude-fable-5`) — the tier above Opus ($10/$50 per MTok, 1M context, 128K output).

Grounded in **real Claude Code 2.1.170 capture** (`/tokenkey-cc-fingerprint-alignment` + cc0-here, cc0 → gost → SOCKS, egress 3.148.79.145). Full capture record: `docs/spec-delta-cc-fable-5.md`.

### Fingerprint findings (re-verified, 4-model)

| Model | `anthropic-beta` vs committed `sonnet_opus` baseline |
|---|---|
| sonnet-4-6 | baseline + `effort-2025-11-24` |
| opus-4-8 | baseline + `effort` + `mid-conversation-system-2026-04-07` |
| **fable-5** | **= opus-4-8 + `server-side-fallback-2026-06-01` + `fallback-credit-2026-06-01`** (strict superset) |

- TLS ja3 / UA (`claude-cli/2.1.170`) / X-Stainless (`0.94.0`) identical across all four → **zero fingerprint-layer change** for Fable.
- Fable already auto-buckets into the `sonnet_opus` mimicry family (selector is `Contains(model,"haiku")`).

## Changes

**Billing (止血)** — Fable was un-priced everywhere and `getFallbackPricing` mis-matched the generic `claude→sonnet` catch-all (~3.3× underbill):
- `billing_service.go`: `claude-fable-5` = $10/$50 (cache write $12.50, read $1.00) fallback + explicit `fable` branch ahead of the claude catch-all.
- `tk_pricing_overlay.json`: Fable litellm-shape entry (primary path; mirror lags).

**Thinking integrity** — Fable shares Opus 4.7+'s adaptive-only surface (manual `enabled+budget_tokens` → 400):
- `gateway_request_tk_fable.go` (new): `isFableModel` + `requiresAdaptiveOnlyThinking`.
- `gateway_request.go` / `gateway_service.go` (×2): swap the 3 adaptive-required repair gates `isOpus47OrNewer` → `requiresAdaptiveOnlyThinking` (Fable's adaptive-required 400 was gated out → surfaced raw).
- `bedrock_request.go`: treat Fable as adaptive-only + strip explicit `thinking.type:"disabled"` (Fable's one breaking change beyond Opus 4.7+).

**Visibility (all three)** — `claude.DefaultModels`, `supportedAnthropicCatalogModels` (justified by live 200 probe), frontend `useModelWhitelist.ts` (`claudeModels` + label/color).

## Deliberately out of scope (see spec-delta)

- The 2 Fable-only `server-side-fallback`/`fallback-credit` betas are **not** injected into mimicry (first-party credit-billing signals, meaningless/harmful on relayed accounts).
- Direct-path `disabled`→400 reactive repair (no captured 400 message; cc never emits `disabled` for Fable).
- General cc 2.1.170 `sonnet_opus` beta drift (`effort` / `mid-conversation-system`, likely request-conditional) → normal fingerprint-alignment flow.

## Checklist
- [x] `go test -tags=unit ./...` passes (+ new tests: `isFableModel` / `requiresAdaptiveOnlyThinking` / fable budget→adaptive / bedrock disabled-strip / fable billing fallback)
- [x] `golangci-lint run ./...` — 0 issues
- [x] `go build -tags=integration ./...` succeeds
- [x] frontend `pnpm typecheck` passes; embedded dist rebuilt + fresh
- [x] `scripts/preflight.sh` PASS
- [x] No upstream symbol deleted/renamed (additive only) — `upstream-touch-guarded`; hotspots reviewed — `sentinel-registry-reviewed`
- [x] TK-originated PR → **Squash and merge** per §5.y

🤖 Generated with [Claude Code](https://claude.com/claude-code)
