### PR TITLE
feat(pricing): 缺价模型飞书聚合告警 + 定价热更新 runbook（#675 遗留项）

### DIFF
--- a/.cursor/skills/tokenkey-servable-model-refresh/SKILL.md
+++ b/.cursor/skills/tokenkey-servable-model-refresh/SKILL.md
@@ -109,3 +109,19 @@ probe key 取自**绑定 `google` 组的 api_key**（`api_keys.group_id→groups
 - **改了 allowlist 后**：公开目录 + 我的菜单两面同源（见
   `supportedCatalogModelIDsForPlatform` / `FilterPublicCatalogToServable`），上线需**发版**才生效。
 - **合并永远等人授权**；本 skill 的 `--open-pr` 只开 PR，不合并。
+
+## 姊妹 runbook：缺价模型定价热更新
+
+收到飞书「**模型缺价（已记零成本）**」卡片（PricingMissingNotifier：缺价模型**照常服务**、
+按零成本记账，不拒绝客户）时，处置走 `ops/pricing/apply-pricing-hotfix.py`：
+
+```bash
+python3 ops/pricing/apply-pricing-hotfix.py lookup --model <模型名>   # litellm 全量源取价（含被裁剪镜像丢掉的带前缀键）
+export TOKENKEY_ADMIN_API_KEY=...                                     # settings.admin_api_key
+python3 ops/pricing/apply-pricing-hotfix.py channels                  # 选 --channel-id
+python3 ops/pricing/apply-pricing-hotfix.py apply --model <模型名> --channel-id N --platform <平台> --from-litellm --yes   # 热更：渠道定价凌驾一切，立即生效无需发版
+python3 ops/pricing/apply-pricing-hotfix.py stage-overlay --model <模型名> --from-litellm   # 固化：fill-only 进 tk_pricing_overlay.json，提 PR
+```
+
+细则（per-channel 语义、litellm 没收录时的 `--entry-json` 路径、镜像价格错误时只能用渠道定价修）
+见 `ops/pricing/README.md` §"Pricing-missing hotfix"。

--- a/backend/cmd/server/wire.go
+++ b/backend/cmd/server/wire.go
@@ -112,6 +112,10 @@ func provideCleanup(
 	// Stopped at shutdown, and so wire forces evaluation of
 	// ProvideTKAccountIncidentNotifier (which attaches it onto RateLimitService).
 	accountIncidentNotifier *service.TKAccountIncidentNotifier,
+	// TokenKey: pricing-missing Feishu notifier. Passed so its digest ticker is
+	// Stopped at shutdown, and so wire forces evaluation of
+	// ProvideTKPricingMissingNotifier (which attaches it onto both gateways).
+	pricingMissingNotifier *service.TKPricingMissingNotifier,
 	// TokenKey: forces wire to evaluate ProvideTKAuthServiceColdStart so the
 	// trial-key issuer gets wired onto AuthService at startup. The value is
 	// unused — only the dependency edge matters. See US-029 / US-030.
@@ -306,6 +310,12 @@ func provideCleanup(
 			{"AccountIncidentNotifier", func() error {
 				if accountIncidentNotifier != nil {
 					accountIncidentNotifier.Stop()
+				}
+				return nil
+			}},
+			{"PricingMissingNotifier", func() error {
+				if pricingMissingNotifier != nil {
+					pricingMissingNotifier.Stop()
 				}
 				return nil
 			}},

--- a/backend/cmd/server/wire_gen.go
+++ b/backend/cmd/server/wire_gen.go
@@ -305,13 +305,14 @@ func initializeApplication(buildInfo handler.BuildInfo) (*Application, error) {
 	paymentOrderExpiryService := service.ProvidePaymentOrderExpiryService(paymentService, leaderLockCache, db)
 	channelMonitorRunner := service.ProvideChannelMonitorRunner(channelMonitorService, settingService)
 	tkAccountIncidentNotifier := service.ProvideTKAccountIncidentNotifier(rateLimitService, opsService, configConfig)
+	tkPricingMissingNotifier := service.ProvideTKPricingMissingNotifier(gatewayService, openAIGatewayService, opsService, configConfig)
 	tkAuthServiceColdStartReady := service.ProvideTKAuthServiceColdStart(authService, apiKeyService, settingService)
 	tkGatewayPricingAvailabilityReady := service.ProvideTKGatewayPricingAvailability(gatewayService, pricingAvailabilityService)
 	anthropicSignaturePreemptCache := repository.NewAnthropicSignaturePreemptCache(redisClient)
 	tkGatewayAnthropicSigPreemptReady := service.ProvideTKGatewayAnthropicSigPreempt(gatewayService, anthropicSignaturePreemptCache)
 	modelListFilter := service.NewModelListFilter(pricingCatalogService, pricingAvailabilityService)
 	tkGatewayHandlerModelListReady := handler.ProvideTKGatewayHandlerModelList(gatewayHandler, modelListFilter)
-	v := provideCleanup(client, redisClient, opsMetricsCollector, opsAggregationService, opsAlertEvaluatorService, opsCleanupService, opsScheduledReportService, opsSystemLogSink, schedulerSnapshotService, schedulerRateLimitReaper, anthropicConfigReconciler, tokenRefreshService, accountExpiryService, proxyExpiryService, subscriptionExpiryService, usageCleanupService, idempotencyCleanupService, pricingService, emailQueueService, billingCacheService, usageRecordWorkerPool, qaService, subscriptionService, oAuthService, openAIOAuthService, geminiOAuthService, antigravityOAuthService, openAIGatewayService, scheduledTestRunnerService, backupService, paymentOrderExpiryService, channelMonitorRunner, tkAccountIncidentNotifier, tkAuthServiceColdStartReady, tkGatewayPricingAvailabilityReady, tkGatewayAnthropicSigPreemptReady, tkGatewayHandlerModelListReady)
+	v := provideCleanup(client, redisClient, opsMetricsCollector, opsAggregationService, opsAlertEvaluatorService, opsCleanupService, opsScheduledReportService, opsSystemLogSink, schedulerSnapshotService, schedulerRateLimitReaper, anthropicConfigReconciler, tokenRefreshService, accountExpiryService, proxyExpiryService, subscriptionExpiryService, usageCleanupService, idempotencyCleanupService, pricingService, emailQueueService, billingCacheService, usageRecordWorkerPool, qaService, subscriptionService, oAuthService, openAIOAuthService, geminiOAuthService, antigravityOAuthService, openAIGatewayService, scheduledTestRunnerService, backupService, paymentOrderExpiryService, channelMonitorRunner, tkAccountIncidentNotifier, tkPricingMissingNotifier, tkAuthServiceColdStartReady, tkGatewayPricingAvailabilityReady, tkGatewayAnthropicSigPreemptReady, tkGatewayHandlerModelListReady)
 	application := &Application{
 		Server:  httpServer,
 		Cleanup: v,
@@ -374,6 +375,8 @@ func provideCleanup(
 	channelMonitorRunner *service.ChannelMonitorRunner,
 
 	accountIncidentNotifier *service.TKAccountIncidentNotifier,
+
+	pricingMissingNotifier *service.TKPricingMissingNotifier,
 
 	_ service.TKAuthServiceColdStartReady,
 
@@ -555,6 +558,12 @@ func provideCleanup(
 			{"AccountIncidentNotifier", func() error {
 				if accountIncidentNotifier != nil {
 					accountIncidentNotifier.Stop()
+				}
+				return nil
+			}},
+			{"PricingMissingNotifier", func() error {
+				if pricingMissingNotifier != nil {
+					pricingMissingNotifier.Stop()
 				}
 				return nil
 			}},

--- a/backend/cmd/server/wire_gen_test.go
+++ b/backend/cmd/server/wire_gen_test.go
@@ -87,6 +87,7 @@ func TestProvideCleanup_WithMinimalDependencies_NoPanic(t *testing.T) {
 		nil,                                   // paymentOrderExpiry
 		nil,                                   // channelMonitorRunner
 		nil,                                   // accountIncidentNotifier
+		nil,                                   // pricingMissingNotifier
 		service.TKAuthServiceColdStartReady{}, // TK: forces SetTrialKeyIssuer wiring
 		service.TKGatewayPricingAvailabilityReady{}, // TK: forces SetPricingAvailabilityService wiring
 		service.TKGatewayAnthropicSigPreemptReady{}, // TK: forces SetAnthropicSigPreemptCache wiring

--- a/backend/internal/service/gateway_service.go
+++ b/backend/internal/service/gateway_service.go
@@ -646,6 +646,9 @@ type GatewayService struct {
 	// TK: per-account thinking-block signature_error preempt cache. Injected via
 	// SetAnthropicSigPreemptCache (TK companion). nil = feature disabled.
 	tkAnthropicSigPreemptCache AnthropicSignaturePreemptCache
+	// TK: pricing-missing → Feishu notifier. Injected via
+	// SetPricingMissingNotifier (TK companion). nil = feature disabled.
+	tkPricingMissingNotifier PricingMissingNotifier
 	// TK: Kiro (sixth platform) forwarder. Routes IsKiro() accounts to the
 	// vendored CodeWhisperer EventStream protocol layer.
 	kiroGateway *KiroGatewayService
@@ -9633,8 +9636,8 @@ func (s *GatewayService) calculateTokenCost(
 		// TK (upstream Wei-Shaw/sub2api#1833 / #1544): surface pricing-missing as a
 		// structured, observable zero-cost record instead of a silent ActualCost:0
 		// leak — at parity with the OpenAI record-usage path. See
-		// logTokenCostPricingMissing.
-		logTokenCostPricingMissing(billingModel, apiKey, result, err)
+		// recordTokenCostPricingMissing (log + Feishu pricing-missing notifier).
+		s.recordTokenCostPricingMissing(billingModel, apiKey, result, tokens, err)
 		if isUsagePricingUnavailableError(err) {
 			return &CostBreakdown{BillingMode: string(BillingModeToken)}
 		}

--- a/backend/internal/service/gateway_service_tk_billing_pricing_missing.go
+++ b/backend/internal/service/gateway_service_tk_billing_pricing_missing.go
@@ -47,3 +47,43 @@ func logTokenCostPricingMissing(billingModel string, apiKey *APIKey, result *For
 	}
 	logger.L().With(fields...).Warn("gateway_usage.cost_calculation_failed_record_zero_cost")
 }
+
+// SetPricingMissingNotifier wires the pricing-missing Feishu notifier
+// post-construction (TK companion setter — same shape as
+// SetPricingAvailabilityService) so the upstream constructor signature stays
+// unchanged. nil = feature disabled.
+func (s *GatewayService) SetPricingMissingNotifier(n PricingMissingNotifier) {
+	if s == nil {
+		return
+	}
+	s.tkPricingMissingNotifier = n
+}
+
+// recordTokenCostPricingMissing is the single funnel entry called from
+// calculateRecordUsageCost: it keeps the structured zero-cost log (grepped by
+// ops tooling and the #675 probe cross-check) and additionally feeds the
+// pricing-missing Feishu notifier so operators get told to configure pricing
+// instead of discovering revenue leaks in logs. Service is NOT refused.
+func (s *GatewayService) recordTokenCostPricingMissing(billingModel string, apiKey *APIKey, result *ForwardResult, tokens UsageTokens, err error) {
+	logTokenCostPricingMissing(billingModel, apiKey, result, err)
+	if s == nil || s.tkPricingMissingNotifier == nil || !isUsagePricingUnavailableError(err) {
+		return
+	}
+	ev := PricingMissingEvent{
+		BillingModel: billingModel,
+		Tokens:       totalUsageTokensForPricingMissing(tokens),
+	}
+	if result != nil {
+		ev.RequestedModel = result.Model
+		ev.UpstreamModel = result.UpstreamModel
+	}
+	if apiKey != nil {
+		ev.APIKeyID = apiKey.ID
+		if apiKey.Group != nil {
+			ev.GroupID = apiKey.Group.ID
+			ev.GroupName = apiKey.Group.Name
+			ev.Platform = apiKey.Group.Platform
+		}
+	}
+	s.tkPricingMissingNotifier.NotifyPricingMissing(ev)
+}

--- a/backend/internal/service/openai_gateway_service.go
+++ b/backend/internal/service/openai_gateway_service.go
@@ -401,6 +401,9 @@ type OpenAIGatewayService struct {
 	codexSnapshotThrottle               *accountWriteThrottle
 	openaiCompatSessionResponses        sync.Map
 	openaiCompatAnthropicDigestSessions sync.Map
+	// TK: pricing-missing → Feishu notifier. Injected via
+	// SetPricingMissingNotifier (TK companion). nil = feature disabled.
+	tkPricingMissingNotifier PricingMissingNotifier
 }
 
 // NewOpenAIGatewayService creates a new OpenAIGatewayService
@@ -6108,6 +6111,9 @@ func (s *OpenAIGatewayService) RecordUsage(ctx context.Context, input *OpenAIRec
 			zap.Int64("api_key_id", apiKey.ID),
 			zap.Int64("account_id", account.ID),
 		).Warn("openai_usage.pricing_missing_record_zero_cost", zap.Error(err))
+		// TK: feed the pricing-missing Feishu notifier (see
+		// openai_gateway_service_tk_pricing_missing.go). Service is NOT refused.
+		s.notifyOpenAIPricingMissing(input, result, apiKey, billingModels, tokens)
 		cost = &CostBreakdown{BillingMode: string(BillingModeToken)}
 	}
 

--- a/backend/internal/service/openai_gateway_service_tk_pricing_missing.go
+++ b/backend/internal/service/openai_gateway_service_tk_pricing_missing.go
@@ -1,0 +1,53 @@
+package service
+
+// TK: OpenAI-compat record-usage funnel → pricing-missing Feishu notifier hook.
+// Companion to the one-line injection in OpenAIGatewayService.RecordUsage's
+// "openai_usage.pricing_missing_record_zero_cost" branch (which is upstream-owned
+// observability and stays untouched). Service is NOT refused — see
+// pricing_missing_notifier_tk.go for the design rationale.
+
+// SetPricingMissingNotifier wires the pricing-missing Feishu notifier
+// post-construction so the upstream constructor signature stays unchanged.
+// nil = feature disabled.
+func (s *OpenAIGatewayService) SetPricingMissingNotifier(n PricingMissingNotifier) {
+	if s == nil {
+		return
+	}
+	s.tkPricingMissingNotifier = n
+}
+
+// notifyOpenAIPricingMissing builds a PricingMissingEvent from the record-usage
+// context and feeds the notifier. nil-safe on every input.
+func (s *OpenAIGatewayService) notifyOpenAIPricingMissing(
+	input *OpenAIRecordUsageInput,
+	result *OpenAIForwardResult,
+	apiKey *APIKey,
+	billingModels []string,
+	tokens UsageTokens,
+) {
+	if s == nil || s.tkPricingMissingNotifier == nil {
+		return
+	}
+	ev := PricingMissingEvent{
+		BillingModel: firstUsageBillingModel(billingModels),
+		Tokens:       totalUsageTokensForPricingMissing(tokens),
+	}
+	if input != nil {
+		ev.RequestedModel = input.OriginalModel
+	}
+	if result != nil {
+		ev.UpstreamModel = result.UpstreamModel
+		if ev.RequestedModel == "" {
+			ev.RequestedModel = result.Model
+		}
+	}
+	if apiKey != nil {
+		ev.APIKeyID = apiKey.ID
+		if apiKey.Group != nil {
+			ev.GroupID = apiKey.Group.ID
+			ev.GroupName = apiKey.Group.Name
+			ev.Platform = apiKey.Group.Platform
+		}
+	}
+	s.tkPricingMissingNotifier.NotifyPricingMissing(ev)
+}

--- a/backend/internal/service/ops_settings.go
+++ b/backend/internal/service/ops_settings.go
@@ -22,6 +22,9 @@ const (
 	opsFeishuAlertCooldownSecondsDefault  = 3600
 	// 账号失效事件「临时冷却」聚合摘要的默认 flush 间隔（秒）。
 	opsFeishuAccountIncidentDigestSecondsDefault = 600
+	// 缺价模型零成本流量聚合摘要的默认 flush 间隔（秒）。运营配置动作级别，
+	// 不是 P0 故障流，默认半小时。
+	opsFeishuPricingMissingDigestSecondsDefault = 1800
 )
 
 // =========================
@@ -219,6 +222,7 @@ func defaultOpsFeishuAlertConfig() OpsFeishuAlertConfig {
 		RateLimitPerHour:             opsFeishuAlertRateLimitPerHourDefault,
 		CooldownSeconds:              opsFeishuAlertCooldownSecondsDefault,
 		AccountIncidentDigestSeconds: opsFeishuAccountIncidentDigestSecondsDefault,
+		PricingMissingDigestSeconds:  opsFeishuPricingMissingDigestSecondsDefault,
 	}
 }
 
@@ -236,6 +240,7 @@ func updateOpsFeishuAlertConfig(dst *OpsFeishuAlertConfig, req *OpsFeishuAlertCo
 	dst.RateLimitPerHour = req.RateLimitPerHour
 	dst.CooldownSeconds = req.CooldownSeconds
 	dst.AccountIncidentDigestSeconds = req.AccountIncidentDigestSeconds
+	dst.PricingMissingDigestSeconds = req.PricingMissingDigestSeconds
 }
 
 func normalizeOpsFeishuAlertConfig(cfg *OpsFeishuAlertConfig) {
@@ -255,6 +260,9 @@ func normalizeOpsFeishuAlertConfig(cfg *OpsFeishuAlertConfig) {
 	if cfg.AccountIncidentDigestSeconds == 0 {
 		cfg.AccountIncidentDigestSeconds = opsFeishuAccountIncidentDigestSecondsDefault
 	}
+	if cfg.PricingMissingDigestSeconds == 0 {
+		cfg.PricingMissingDigestSeconds = opsFeishuPricingMissingDigestSecondsDefault
+	}
 }
 
 func validateOpsFeishuAlertConfig(cfg OpsFeishuAlertConfig) error {
@@ -272,6 +280,9 @@ func validateOpsFeishuAlertConfig(cfg OpsFeishuAlertConfig) error {
 	}
 	if cfg.AccountIncidentDigestSeconds < 30 || cfg.AccountIncidentDigestSeconds > 86400 {
 		return errors.New("feishu.account_incident_digest_seconds must be between 30 and 86400")
+	}
+	if cfg.PricingMissingDigestSeconds < 30 || cfg.PricingMissingDigestSeconds > 86400 {
+		return errors.New("feishu.pricing_missing_digest_seconds must be between 30 and 86400")
 	}
 	return nil
 }

--- a/backend/internal/service/ops_settings.go
+++ b/backend/internal/service/ops_settings.go
@@ -239,8 +239,16 @@ func updateOpsFeishuAlertConfig(dst *OpsFeishuAlertConfig, req *OpsFeishuAlertCo
 	}
 	dst.RateLimitPerHour = req.RateLimitPerHour
 	dst.CooldownSeconds = req.CooldownSeconds
-	dst.AccountIncidentDigestSeconds = req.AccountIncidentDigestSeconds
-	dst.PricingMissingDigestSeconds = req.PricingMissingDigestSeconds
+	// 两个 digest-seconds 字段晚于原始契约加入：早于它们的客户端发的"完整"
+	// feishu payload 不含这些键（解码为 0），而 validate 先于 normalize 执行——
+	// 无条件拷贝会让 0 覆盖存量值并使整个更新 400。0 对这两个字段本就非法
+	// （下限 30），故按"0=未提供"保留存量值，不破坏既有客户端。
+	if req.AccountIncidentDigestSeconds != 0 {
+		dst.AccountIncidentDigestSeconds = req.AccountIncidentDigestSeconds
+	}
+	if req.PricingMissingDigestSeconds != 0 {
+		dst.PricingMissingDigestSeconds = req.PricingMissingDigestSeconds
+	}
 }
 
 func normalizeOpsFeishuAlertConfig(cfg *OpsFeishuAlertConfig) {

--- a/backend/internal/service/ops_settings_feishu_compat_test.go
+++ b/backend/internal/service/ops_settings_feishu_compat_test.go
@@ -1,0 +1,62 @@
+package service
+
+import (
+	"context"
+	"testing"
+)
+
+// 两个 digest-seconds 字段晚于原始 feishu 契约加入。早于它们的 API 客户端
+// （运维脚本 / 旧前端 bundle）发的"完整" feishu payload 不含这些键（解码为 0），
+// 而 update 路径 validate 先于 normalize 执行——若无条件拷贝，0 会覆盖存量值并让
+// 整个设置更新 400。本测试钉住"0=未提供，保留存量值"的兼容语义。
+func TestUpdateEmailNotificationConfig_LegacyFeishuPayloadKeepsDigestSeconds(t *testing.T) {
+	repo := newRuntimeSettingRepoStub()
+	svc := &OpsService{settingRepo: repo}
+	ctx := context.Background()
+
+	seed := defaultOpsFeishuAlertConfig()
+	seed.Enabled = true
+	seed.WebhookURL = "https://open.feishu.cn/open-apis/bot/v2/hook/test"
+	seed.AccountIncidentDigestSeconds = 900
+	seed.PricingMissingDigestSeconds = 3600
+	if _, err := svc.UpdateEmailNotificationConfig(ctx,
+		&OpsEmailNotificationConfigUpdateRequest{Feishu: &seed}); err != nil {
+		t.Fatalf("seed update error = %v", err)
+	}
+
+	// 旧客户端形态：完整 feishu 对象但不含两个 digest 字段（零值）。
+	legacy := defaultOpsFeishuAlertConfig()
+	legacy.Enabled = true
+	legacy.WebhookURL = "https://open.feishu.cn/open-apis/bot/v2/hook/test"
+	legacy.AccountIncidentDigestSeconds = 0
+	legacy.PricingMissingDigestSeconds = 0
+	updated, err := svc.UpdateEmailNotificationConfig(ctx,
+		&OpsEmailNotificationConfigUpdateRequest{Feishu: &legacy})
+	if err != nil {
+		t.Fatalf("legacy-shaped update must not fail validation, got %v", err)
+	}
+	if updated.Feishu.AccountIncidentDigestSeconds != 900 {
+		t.Fatalf("AccountIncidentDigestSeconds = %d, want stored 900 preserved",
+			updated.Feishu.AccountIncidentDigestSeconds)
+	}
+	if updated.Feishu.PricingMissingDigestSeconds != 3600 {
+		t.Fatalf("PricingMissingDigestSeconds = %d, want stored 3600 preserved",
+			updated.Feishu.PricingMissingDigestSeconds)
+	}
+
+	// 显式值仍可更新。
+	explicit := defaultOpsFeishuAlertConfig()
+	explicit.Enabled = true
+	explicit.WebhookURL = "https://open.feishu.cn/open-apis/bot/v2/hook/test"
+	explicit.AccountIncidentDigestSeconds = 120
+	explicit.PricingMissingDigestSeconds = 240
+	updated, err = svc.UpdateEmailNotificationConfig(ctx,
+		&OpsEmailNotificationConfigUpdateRequest{Feishu: &explicit})
+	if err != nil {
+		t.Fatalf("explicit update error = %v", err)
+	}
+	if updated.Feishu.AccountIncidentDigestSeconds != 120 || updated.Feishu.PricingMissingDigestSeconds != 240 {
+		t.Fatalf("explicit values not applied: got (%d, %d), want (120, 240)",
+			updated.Feishu.AccountIncidentDigestSeconds, updated.Feishu.PricingMissingDigestSeconds)
+	}
+}

--- a/backend/internal/service/ops_settings_models.go
+++ b/backend/internal/service/ops_settings_models.go
@@ -43,6 +43,9 @@ type OpsFeishuAlertConfig struct {
 	// AccountIncidentDigestSeconds 控制账号失效事件中「临时冷却」类（429/529/temp）
 	// 聚合摘要的 flush 间隔（秒）。永久失效类即时单发，不受此值影响。默认 600。
 	AccountIncidentDigestSeconds int `json:"account_incident_digest_seconds"`
+	// PricingMissingDigestSeconds 控制缺价模型零成本流量聚合摘要的 flush 间隔
+	// （秒）。首见模型的即时卡不受此值影响。默认 1800。
+	PricingMissingDigestSeconds int `json:"pricing_missing_digest_seconds"`
 }
 
 // OpsEmailNotificationConfigUpdateRequest allows partial updates, while the

--- a/backend/internal/service/pricing_missing_notifier_tk.go
+++ b/backend/internal/service/pricing_missing_notifier_tk.go
@@ -1,0 +1,393 @@
+package service
+
+// TK: 缺价计费（pricing_missing_record_zero_cost）→ 飞书聚合告警。
+//
+// 背景（PR #675 遗留项）：catch-all 账号会把任意模型名转发到上游；若该模型没有
+// 定价条目，两条计费 funnel（GatewayService.calculateRecordUsageCost 与
+// OpenAIGatewayService.RecordUsage）会记一条零成本 usage log 并继续服务——即
+// 免费用量 = 收入流失，此前只有结构化日志可见，无人主动通知。
+//
+// 设计决策：**不拒绝服务**。计费模型在请求前不可知（候选链含上游响应字段），
+// 入口硬护栏 by-construction 不准；定价 ≠ 可服务（litellm 镜像滞后会把数据缺口
+// 放大成客户侧故障）；servable 探测流水线也依赖真实请求穿过 catch-all。本通知器
+// 只补"运营可见性"：缺价流量照常服务、照常记零成本日志，另路飞书告警提醒运营
+// 热更定价（渠道定价 admin API，立即生效）并固化进 tk_pricing_overlay.json。
+//
+// 形态仿 account_incident_notifier_tk.go（#516），信噪比第一：
+//   - 首见 (platform, model) → 即时一张橙头卡（24h 去重 + 每小时滑窗限量），
+//     运营第一时间知道有新缺价模型在跑零成本流量。
+//   - 全量事件进聚合 buffer，由后台 ticker 按
+//     feishu.pricing_missing_digest_seconds（默认 1800s）flush 一条摘要——
+//     这是"运营配置动作"级别的提醒，不是 P0 故障流。
+//   - 运营补价后 ErrModelPricingUnavailable 不再触发，告警自然停止，无需手动清除。
+//
+// 唯一挂钩点是两条计费 funnel 的 pricing-missing 分支（见
+// gateway_service_tk_billing_pricing_missing.go 与
+// openai_gateway_service_tk_pricing_missing.go）；既有日志行保持不动——#675 的
+// 探测交叉核验与 ops 工具仍 grep 它。单副本 Stage0、无 leader，挂钩点直接发
+// 不会跨节点重复。
+
+import (
+	"context"
+	"fmt"
+	"net/http"
+	"sort"
+	"strings"
+	"sync"
+	"time"
+
+	"github.com/Wei-Shaw/sub2api/internal/pkg/logger"
+)
+
+const (
+	// 首见即时卡同 (site, platform, model) 的去重窗口。
+	pricingMissingFirstSeenDedupeWindow = 24 * time.Hour
+	// 首见即时卡每小时最多条数（滑动窗口防爆量——catch-all 被异常客户端
+	// 喷洒大量不同模型名时退化为只看摘要）。
+	pricingMissingFirstSeenRatePerHour = 10
+	// 聚合摘要 flush 间隔兜底值（配置缺失时）。运营配置动作级别，半小时足够。
+	pricingMissingDigestSecondsFallback = 1800
+	// 摘要里每个 (platform, model) 展示的组名样例上限。
+	pricingMissingDigestMaxGroupSamples = 8
+)
+
+// PricingMissingEvent 是单次"缺价记零成本"事件的最小快照。
+type PricingMissingEvent struct {
+	Platform       string // group 平台（anthropic/openai/gemini/newapi/...）
+	BillingModel   string // 计费解析最终落到的模型名（聚合键）
+	RequestedModel string // 客户端请求的模型名（样例展示）
+	UpstreamModel  string // 上游实际服务的模型名（样例展示）
+	GroupID        int64
+	GroupName      string
+	APIKeyID       int64
+	Tokens         int64 // 本次未计费 token 估算（input+output+cache）
+}
+
+// PricingMissingNotifier 是计费 funnel 注入的最小通知面（仿 AccountIncidentNotifier）。
+type PricingMissingNotifier interface {
+	NotifyPricingMissing(ev PricingMissingEvent)
+}
+
+// pricingMissingDigestEntry 是聚合 buffer 的单个 (platform, model) 条目。
+type pricingMissingDigestEntry struct {
+	platform       string
+	billingModel   string
+	requestedModel string // 首个样例
+	upstreamModel  string // 首个样例
+	count          int
+	tokens         int64
+	groupIDs       map[int64]struct{}
+	groupSamples   []string
+	apiKeyIDs      map[int64]struct{}
+	firstAt        time.Time
+	lastAt         time.Time
+}
+
+type TKPricingMissingNotifier struct {
+	cfgProvider opsFeishuConfigProvider
+	httpClient  opsFeishuHTTPDoer
+	siteID      string
+	now         func() time.Time
+
+	mu           sync.Mutex
+	firstSentAt  map[string]time.Time // 首见即时卡去重: site|platform|model -> 上次发送
+	firstLimiter *slidingWindowLimiter
+	digest       map[string]*pricingMissingDigestEntry
+
+	stopCh   chan struct{}
+	stopOnce sync.Once
+}
+
+func newTKPricingMissingNotifier(cfgProvider opsFeishuConfigProvider, siteID string) *TKPricingMissingNotifier {
+	n := &TKPricingMissingNotifier{
+		cfgProvider:  cfgProvider,
+		httpClient:   &http.Client{Timeout: opsFeishuWebhookTimeout},
+		siteID:       strings.TrimSpace(siteID),
+		now:          time.Now,
+		firstSentAt:  map[string]time.Time{},
+		firstLimiter: newSlidingWindowLimiter(pricingMissingFirstSeenRatePerHour, time.Hour),
+		digest:       map[string]*pricingMissingDigestEntry{},
+		stopCh:       make(chan struct{}),
+	}
+	if n.siteID == "" {
+		n.siteID = "unknown"
+	}
+	return n
+}
+
+// Start 启动后台聚合 flush ticker。必须配对 Stop()。
+func (n *TKPricingMissingNotifier) Start() {
+	if n == nil {
+		return
+	}
+	go n.digestLoop()
+}
+
+// Stop 优雅停 ticker，供 wire cleanup 调用。幂等。
+func (n *TKPricingMissingNotifier) Stop() {
+	if n == nil {
+		return
+	}
+	n.stopOnce.Do(func() {
+		close(n.stopCh)
+	})
+}
+
+// NotifyPricingMissing 登记一次缺价事件：写聚合 buffer；首见 (platform, model)
+// 额外发一张即时卡。同步路径只做内存操作，发送全部异步，绝不阻塞计费 funnel。
+func (n *TKPricingMissingNotifier) NotifyPricingMissing(ev PricingMissingEvent) {
+	if n == nil {
+		return
+	}
+	platform := strings.TrimSpace(strings.ToLower(ev.Platform))
+	model := strings.TrimSpace(ev.BillingModel)
+	if model == "" {
+		model = strings.TrimSpace(ev.RequestedModel)
+	}
+	if model == "" {
+		return
+	}
+	if platform == "" {
+		platform = "unknown"
+	}
+	now := n.currentTime()
+	key := platform + "\x1f" + strings.ToLower(model)
+
+	n.mu.Lock()
+	entry := n.digest[key]
+	if entry == nil {
+		entry = &pricingMissingDigestEntry{
+			platform:       platform,
+			billingModel:   model,
+			requestedModel: strings.TrimSpace(ev.RequestedModel),
+			upstreamModel:  strings.TrimSpace(ev.UpstreamModel),
+			groupIDs:       map[int64]struct{}{},
+			apiKeyIDs:      map[int64]struct{}{},
+			firstAt:        now,
+		}
+		n.digest[key] = entry
+	}
+	entry.count++
+	entry.tokens += ev.Tokens
+	entry.lastAt = now
+	if ev.GroupID > 0 {
+		if _, ok := entry.groupIDs[ev.GroupID]; !ok {
+			entry.groupIDs[ev.GroupID] = struct{}{}
+			if len(entry.groupSamples) < pricingMissingDigestMaxGroupSamples {
+				entry.groupSamples = append(entry.groupSamples, pricingMissingGroupLabel(ev.GroupID, ev.GroupName))
+			}
+		}
+	}
+	if ev.APIKeyID > 0 {
+		entry.apiKeyIDs[ev.APIKeyID] = struct{}{}
+	}
+
+	// 首见即时卡判定（持锁只做去重 + 限量记账）。
+	dedupeKey := n.siteID + "|" + key
+	if last, seen := n.firstSentAt[dedupeKey]; seen && now.Sub(last) < pricingMissingFirstSeenDedupeWindow {
+		n.mu.Unlock()
+		return
+	}
+	if n.firstLimiter != nil && !n.firstLimiter.Allow(now) {
+		n.mu.Unlock()
+		return
+	}
+	n.firstSentAt[dedupeKey] = now
+	n.mu.Unlock()
+
+	title := fmt.Sprintf("TokenKey 模型缺价（已记零成本）[%s]", n.siteID)
+	body := buildPricingMissingFirstSeenText(n.siteID, ev, platform, model, now)
+	n.send(title, "orange", body, fmt.Sprintf("platform=%s model=%s", platform, model))
+}
+
+func (n *TKPricingMissingNotifier) digestLoop() {
+	defer func() {
+		if r := recover(); r != nil {
+			logger.LegacyPrintf("service.pricing_missing", "[PricingMissing] digest loop panic recovered: %v", r)
+		}
+	}()
+	for {
+		timer := time.NewTimer(n.digestInterval())
+		select {
+		case <-n.stopCh:
+			timer.Stop()
+			return
+		case <-timer.C:
+			n.flushDigest()
+			n.pruneFirstSeen()
+		}
+	}
+}
+
+// digestInterval 从配置读 flush 间隔（秒），下限 30s，缺失则兜底 1800s。
+func (n *TKPricingMissingNotifier) digestInterval() time.Duration {
+	secs := pricingMissingDigestSecondsFallback
+	if n.cfgProvider != nil {
+		if cfg, err := n.cfgProvider.GetEmailNotificationConfig(context.Background()); err == nil && cfg != nil && cfg.Feishu.PricingMissingDigestSeconds > 0 {
+			secs = cfg.Feishu.PricingMissingDigestSeconds
+		}
+	}
+	if secs < 30 {
+		secs = 30
+	}
+	return time.Duration(secs) * time.Second
+}
+
+// flushDigest 取出并清空 buffer，有内容则异步发一条摘要；空则跳过。
+// panic 就地兜住，不传播到 digestLoop（同 account incident 的理由）。
+func (n *TKPricingMissingNotifier) flushDigest() {
+	defer func() {
+		if r := recover(); r != nil {
+			logger.LegacyPrintf("service.pricing_missing", "[PricingMissing] flushDigest panic recovered: %v", r)
+		}
+	}()
+	n.mu.Lock()
+	if len(n.digest) == 0 {
+		n.mu.Unlock()
+		return
+	}
+	entries := make([]*pricingMissingDigestEntry, 0, len(n.digest))
+	for _, e := range n.digest {
+		entries = append(entries, e)
+	}
+	n.digest = map[string]*pricingMissingDigestEntry{}
+	n.mu.Unlock()
+
+	sort.Slice(entries, func(i, j int) bool {
+		if entries[i].platform != entries[j].platform {
+			return entries[i].platform < entries[j].platform
+		}
+		return entries[i].billingModel < entries[j].billingModel
+	})
+	now := n.currentTime()
+	title := fmt.Sprintf("TokenKey 缺价模型零成本摘要 [%s]", n.siteID)
+	body := buildPricingMissingDigestText(n.siteID, entries, now)
+	n.send(title, "orange", body, "digest")
+}
+
+// pruneFirstSeen 修剪过期的首见去重台账（超出去重窗口的条目）。
+func (n *TKPricingMissingNotifier) pruneFirstSeen() {
+	now := n.currentTime()
+	n.mu.Lock()
+	defer n.mu.Unlock()
+	for k, t := range n.firstSentAt {
+		if now.Sub(t) >= pricingMissingFirstSeenDedupeWindow {
+			delete(n.firstSentAt, k)
+		}
+	}
+}
+
+// send 异步发送（绝不阻塞计费 funnel / flush goroutine）。
+func (n *TKPricingMissingNotifier) send(title, headerTemplate, body, logCtx string) {
+	go n.sendNow(title, headerTemplate, body, logCtx)
+}
+
+// sendNow 同步发送一条飞书卡片。独立 5s ctx，不继承请求 ctx；panic recover。
+func (n *TKPricingMissingNotifier) sendNow(title, headerTemplate, body, logCtx string) {
+	defer func() {
+		if r := recover(); r != nil {
+			logger.LegacyPrintf("service.pricing_missing", "[PricingMissing] send panic recovered (%s): %v", logCtx, r)
+		}
+	}()
+	if n == nil || n.cfgProvider == nil {
+		return
+	}
+	cfg, err := n.cfgProvider.GetEmailNotificationConfig(context.Background())
+	if err != nil || cfg == nil || !cfg.Feishu.Enabled || strings.TrimSpace(cfg.Feishu.WebhookURL) == "" {
+		return
+	}
+	ctx, cancel := context.WithTimeout(context.Background(), opsFeishuWebhookTimeout)
+	defer cancel()
+	payload := feishuCardPayload(cfg.Feishu, n.now, headerTemplate, title, body)
+	if err := sendFeishuPayload(ctx, n.httpClient, cfg.Feishu, payload); err != nil {
+		logger.LegacyPrintf("service.pricing_missing", "[PricingMissing] feishu send failed (%s): %s", logCtx, err.Error())
+	}
+}
+
+func (n *TKPricingMissingNotifier) currentTime() time.Time {
+	if n != nil && n.now != nil {
+		return n.now()
+	}
+	return time.Now()
+}
+
+// pricingMissingAdviceText 是两种卡片共用的运营动作脚注。
+const pricingMissingAdviceText = "说明：该流量**已照常服务、按零成本记录**（未拒绝客户）。运营动作：\n" +
+	"1. 热更止血：`python3 ops/pricing/apply-pricing-hotfix.py lookup --model <模型名>` 取价，再 `apply` 经 admin API 写入渠道定价（立即生效，无需发版）；\n" +
+	"2. 固化：`stage-overlay` 把 fill-only 条目写入 `tk_pricing_overlay.json` 提 PR（litellm 镜像补上后自动让位）。"
+
+func buildPricingMissingFirstSeenText(site string, ev PricingMissingEvent, platform, model string, now time.Time) string {
+	requested := strings.TrimSpace(ev.RequestedModel)
+	if requested == "" {
+		requested = "-"
+	}
+	upstream := strings.TrimSpace(ev.UpstreamModel)
+	if upstream == "" {
+		upstream = "-"
+	}
+	group := "-"
+	if ev.GroupID > 0 {
+		group = pricingMissingGroupLabel(ev.GroupID, ev.GroupName)
+	}
+	return fmt.Sprintf("**节点**：%s\n**平台**：%s\n**计费模型**：%s\n**请求模型**：%s\n**上游模型**：%s\n**组**：%s\n**api_key**：#%d\n**时间**：%s\n\n首次发现该模型缺价（24h 内同模型不再即时提醒，后续进周期摘要）。\n\n%s",
+		escapeFeishuText(site),
+		escapeFeishuText(platform),
+		escapeFeishuText(model),
+		escapeFeishuText(requested),
+		escapeFeishuText(upstream),
+		escapeFeishuText(group),
+		ev.APIKeyID,
+		escapeFeishuText(formatAlertTime(now)),
+		pricingMissingAdviceText,
+	)
+}
+
+func buildPricingMissingDigestText(site string, entries []*pricingMissingDigestEntry, now time.Time) string {
+	lines := make([]string, 0, len(entries)+2)
+	lines = append(lines, fmt.Sprintf("**节点**：%s\n**时间**：%s\n\n缺价模型零成本流量摘要：",
+		escapeFeishuText(site), escapeFeishuText(formatAlertTime(now))))
+	for _, e := range entries {
+		samples := strings.Join(e.groupSamples, ", ")
+		if len(e.groupIDs) > len(e.groupSamples) {
+			samples += fmt.Sprintf(" 等共%d个", len(e.groupIDs))
+		}
+		if samples == "" {
+			samples = "-"
+		}
+		lines = append(lines, fmt.Sprintf("- **%s / %s**：%d 次 / 约 %s tokens 未计费 / %d 个 key / 组：%s",
+			escapeFeishuText(e.platform),
+			escapeFeishuText(e.billingModel),
+			e.count,
+			formatPricingMissingTokens(e.tokens),
+			len(e.apiKeyIDs),
+			escapeFeishuText(samples)))
+	}
+	lines = append(lines, "\n"+pricingMissingAdviceText)
+	return strings.Join(lines, "\n")
+}
+
+func pricingMissingGroupLabel(id int64, name string) string {
+	name = strings.TrimSpace(name)
+	if name == "" {
+		return fmt.Sprintf("#%d", id)
+	}
+	return fmt.Sprintf("%s(#%d)", name, id)
+}
+
+// formatPricingMissingTokens 把 token 数格式化成人类可读量级（1.2k / 3.4M）。
+func formatPricingMissingTokens(t int64) string {
+	switch {
+	case t >= 1_000_000:
+		return fmt.Sprintf("%.1fM", float64(t)/1_000_000)
+	case t >= 1_000:
+		return fmt.Sprintf("%.1fk", float64(t)/1_000)
+	default:
+		return fmt.Sprintf("%d", t)
+	}
+}
+
+// totalUsageTokensForPricingMissing 估算一次请求未计费的 token 总量。
+func totalUsageTokensForPricingMissing(tokens UsageTokens) int64 {
+	return int64(tokens.InputTokens) + int64(tokens.OutputTokens) +
+		int64(tokens.CacheCreationTokens) + int64(tokens.CacheReadTokens)
+}

--- a/backend/internal/service/pricing_missing_notifier_tk.go
+++ b/backend/internal/service/pricing_missing_notifier_tk.go
@@ -387,7 +387,10 @@ func formatPricingMissingTokens(t int64) string {
 }
 
 // totalUsageTokensForPricingMissing 估算一次请求未计费的 token 总量。
+// CacheCreation5m/1h 是 CacheCreationTokens 的细分桶，不重复累加；
+// ImageOutputTokens 独立计入（图像缺价流量否则在摘要里显示 0 tokens）。
 func totalUsageTokensForPricingMissing(tokens UsageTokens) int64 {
 	return int64(tokens.InputTokens) + int64(tokens.OutputTokens) +
-		int64(tokens.CacheCreationTokens) + int64(tokens.CacheReadTokens)
+		int64(tokens.CacheCreationTokens) + int64(tokens.CacheReadTokens) +
+		int64(tokens.ImageOutputTokens)
 }

--- a/backend/internal/service/pricing_missing_notifier_tk_test.go
+++ b/backend/internal/service/pricing_missing_notifier_tk_test.go
@@ -1,0 +1,228 @@
+//go:build unit
+
+package service
+
+import (
+	"errors"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/require"
+)
+
+// Reuses fakeIncidentConfigProvider / enabledFeishuConfig / blockingFeishuDoer
+// from account_incident_notifier_tk_test.go (same package, same unit tag).
+
+func newTestPricingMissingNotifier(provider opsFeishuConfigProvider, doer opsFeishuHTTPDoer, fixedNow time.Time) *TKPricingMissingNotifier {
+	n := newTKPricingMissingNotifier(provider, "edge-test")
+	n.httpClient = doer
+	n.now = func() time.Time { return fixedNow }
+	return n
+}
+
+func waitFeishuCalls(t *testing.T, done chan struct{}, want int) {
+	t.Helper()
+	for i := 0; i < want; i++ {
+		select {
+		case <-done:
+		case <-time.After(2 * time.Second):
+			t.Fatalf("timed out waiting for feishu send %d/%d", i+1, want)
+		}
+	}
+}
+
+func samplePricingMissingEvent() PricingMissingEvent {
+	return PricingMissingEvent{
+		Platform:       "newapi",
+		BillingModel:   "doubao-seedream-9",
+		RequestedModel: "doubao-seedream-9",
+		UpstreamModel:  "doubao-seedream-9-250901",
+		GroupID:        3,
+		GroupName:      "vertex-pool",
+		APIKeyID:       42,
+		Tokens:         1500,
+	}
+}
+
+func TestPricingMissingNotifier_FirstSeenSendsOnce_ThenAggregates(t *testing.T) {
+	doer := &blockingFeishuDoer{done: make(chan struct{}, 8)}
+	now := time.Date(2026, 6, 10, 8, 0, 0, 0, time.UTC)
+	n := newTestPricingMissingNotifier(&fakeIncidentConfigProvider{cfg: enabledFeishuConfig()}, doer, now)
+
+	ev := samplePricingMissingEvent()
+	n.NotifyPricingMissing(ev)
+	waitFeishuCalls(t, doer.done, 1)
+	body := doer.lastBody()
+	require.Contains(t, body, "doubao-seedream-9", "first-seen card must name the model")
+	require.Contains(t, body, "newapi", "first-seen card must name the platform")
+	require.Contains(t, body, "已照常服务", "card must state service was NOT refused")
+	require.Contains(t, body, "apply-pricing-hotfix.py", "card must point at the hot-update runbook")
+
+	// 同 (platform, model) 第二次:不再发即时卡,只进聚合。
+	n.NotifyPricingMissing(ev)
+	require.Equal(t, 1, doer.callCount(), "second event within dedupe window must not send another immediate card")
+
+	n.mu.Lock()
+	require.Len(t, n.digest, 1)
+	for _, e := range n.digest {
+		require.Equal(t, 2, e.count)
+		require.Equal(t, int64(3000), e.tokens)
+		require.Len(t, e.groupIDs, 1)
+		require.Len(t, e.apiKeyIDs, 1)
+	}
+	n.mu.Unlock()
+}
+
+func TestPricingMissingNotifier_FlushDigest_SendsAndClears(t *testing.T) {
+	doer := &blockingFeishuDoer{done: make(chan struct{}, 8)}
+	now := time.Date(2026, 6, 10, 8, 0, 0, 0, time.UTC)
+	n := newTestPricingMissingNotifier(&fakeIncidentConfigProvider{cfg: enabledFeishuConfig()}, doer, now)
+
+	ev := samplePricingMissingEvent()
+	n.NotifyPricingMissing(ev) // 1 immediate card
+	n.NotifyPricingMissing(ev)
+	other := samplePricingMissingEvent()
+	other.Platform = "gemini"
+	other.BillingModel = "imagen-9.0-generate-001"
+	n.NotifyPricingMissing(other) // 1 more immediate card (different model)
+	waitFeishuCalls(t, doer.done, 2)
+
+	n.flushDigest()
+	waitFeishuCalls(t, doer.done, 1)
+	body := doer.lastBody()
+	require.Contains(t, body, "doubao-seedream-9")
+	require.Contains(t, body, "imagen-9.0-generate-001")
+	require.Contains(t, body, "3.0k", "digest must surface the unbilled token volume")
+
+	n.mu.Lock()
+	require.Empty(t, n.digest, "flush must clear the buffer")
+	n.mu.Unlock()
+
+	// 空 buffer 再 flush:不发。
+	before := doer.callCount()
+	n.flushDigest()
+	time.Sleep(50 * time.Millisecond)
+	require.Equal(t, before, doer.callCount(), "empty digest must not send")
+}
+
+func TestPricingMissingNotifier_DisabledFeishu_NoSend(t *testing.T) {
+	cfg := enabledFeishuConfig()
+	cfg.Feishu.Enabled = false
+	doer := &blockingFeishuDoer{}
+	n := newTestPricingMissingNotifier(&fakeIncidentConfigProvider{cfg: cfg}, doer, time.Now())
+
+	n.NotifyPricingMissing(samplePricingMissingEvent())
+	n.flushDigest()
+	time.Sleep(50 * time.Millisecond)
+	require.Equal(t, 0, doer.callCount())
+}
+
+func TestPricingMissingNotifier_EmptyModel_Ignored(t *testing.T) {
+	doer := &blockingFeishuDoer{}
+	n := newTestPricingMissingNotifier(&fakeIncidentConfigProvider{cfg: enabledFeishuConfig()}, doer, time.Now())
+
+	n.NotifyPricingMissing(PricingMissingEvent{Platform: "openai"})
+	n.mu.Lock()
+	require.Empty(t, n.digest)
+	n.mu.Unlock()
+	require.Equal(t, 0, doer.callCount())
+}
+
+func TestPricingMissingNotifier_PruneFirstSeen(t *testing.T) {
+	doer := &blockingFeishuDoer{done: make(chan struct{}, 8)}
+	base := time.Date(2026, 6, 10, 8, 0, 0, 0, time.UTC)
+	n := newTestPricingMissingNotifier(&fakeIncidentConfigProvider{cfg: enabledFeishuConfig()}, doer, base)
+
+	n.NotifyPricingMissing(samplePricingMissingEvent())
+	waitFeishuCalls(t, doer.done, 1)
+
+	// 超过去重窗口后修剪,首见卡可再次发送。
+	n.now = func() time.Time { return base.Add(pricingMissingFirstSeenDedupeWindow + time.Minute) }
+	n.pruneFirstSeen()
+	n.NotifyPricingMissing(samplePricingMissingEvent())
+	waitFeishuCalls(t, doer.done, 1)
+	require.Equal(t, 2, doer.callCount())
+}
+
+func TestPricingMissingNotifier_DigestIntervalFromConfig(t *testing.T) {
+	cfg := enabledFeishuConfig()
+	cfg.Feishu.PricingMissingDigestSeconds = 120
+	n := newTestPricingMissingNotifier(&fakeIncidentConfigProvider{cfg: cfg}, &blockingFeishuDoer{}, time.Now())
+	require.Equal(t, 2*time.Minute, n.digestInterval())
+
+	// 配置缺失 → 兜底 1800s。
+	n2 := newTestPricingMissingNotifier(&fakeIncidentConfigProvider{cfg: enabledFeishuConfig()}, &blockingFeishuDoer{}, time.Now())
+	require.Equal(t, time.Duration(pricingMissingDigestSecondsFallback)*time.Second, n2.digestInterval())
+}
+
+// --- funnel hook tests ----------------------------------------------------
+
+type recordingPricingMissingNotifier struct {
+	events []PricingMissingEvent
+}
+
+func (r *recordingPricingMissingNotifier) NotifyPricingMissing(ev PricingMissingEvent) {
+	r.events = append(r.events, ev)
+}
+
+func TestGatewayRecordTokenCostPricingMissing_FeedsNotifier(t *testing.T) {
+	rec := &recordingPricingMissingNotifier{}
+	svc := &GatewayService{tkPricingMissingNotifier: rec}
+
+	result := &ForwardResult{Model: "glm-5", UpstreamModel: "glm-5-air"}
+	apiKey := &APIKey{ID: 7, Group: &Group{ID: 3, Name: "g3", Platform: PlatformAnthropic}}
+	tokens := UsageTokens{InputTokens: 100, OutputTokens: 50, CacheReadTokens: 10}
+
+	svc.recordTokenCostPricingMissing("glm-5", apiKey, result, tokens, ErrModelPricingUnavailable)
+	require.Len(t, rec.events, 1)
+	ev := rec.events[0]
+	require.Equal(t, "glm-5", ev.BillingModel)
+	require.Equal(t, "glm-5-air", ev.UpstreamModel)
+	require.Equal(t, PlatformAnthropic, ev.Platform)
+	require.Equal(t, int64(3), ev.GroupID)
+	require.Equal(t, int64(7), ev.APIKeyID)
+	require.Equal(t, int64(160), ev.Tokens)
+
+	// 非缺价类计费错误:只记日志,不喂通知器。
+	svc.recordTokenCostPricingMissing("glm-5", apiKey, result, tokens, errors.New("unexpected cost-calc failure"))
+	require.Len(t, rec.events, 1)
+}
+
+func TestGatewayRecordTokenCostPricingMissing_NilNotifierSafe(t *testing.T) {
+	svc := &GatewayService{}
+	require.NotPanics(t, func() {
+		svc.recordTokenCostPricingMissing("glm-5", nil, nil, UsageTokens{}, ErrModelPricingUnavailable)
+	})
+}
+
+func TestOpenAINotifyPricingMissing_FeedsNotifier(t *testing.T) {
+	rec := &recordingPricingMissingNotifier{}
+	svc := &OpenAIGatewayService{tkPricingMissingNotifier: rec}
+
+	input := &OpenAIRecordUsageInput{}
+	input.OriginalModel = "doubao-seedream-9"
+	result := &OpenAIForwardResult{UpstreamModel: "doubao-seedream-9-250901"}
+	apiKey := &APIKey{ID: 9, Group: &Group{ID: 5, Name: "np", Platform: PlatformNewAPI}}
+
+	svc.notifyOpenAIPricingMissing(input, result, apiKey,
+		[]string{"doubao-seedream-9"}, UsageTokens{InputTokens: 20, OutputTokens: 5})
+	require.Len(t, rec.events, 1)
+	ev := rec.events[0]
+	require.Equal(t, "doubao-seedream-9", ev.BillingModel)
+	require.Equal(t, "doubao-seedream-9", ev.RequestedModel)
+	require.Equal(t, "doubao-seedream-9-250901", ev.UpstreamModel)
+	require.Equal(t, PlatformNewAPI, ev.Platform)
+	require.Equal(t, int64(25), ev.Tokens)
+
+	// nil notifier 安全。
+	bare := &OpenAIGatewayService{}
+	require.NotPanics(t, func() {
+		bare.notifyOpenAIPricingMissing(nil, nil, nil, nil, UsageTokens{})
+	})
+}
+
+func TestPricingMissingAdviceText_MentionsBothRemediationPaths(t *testing.T) {
+	require.True(t, strings.Contains(pricingMissingAdviceText, "apply-pricing-hotfix.py"))
+	require.True(t, strings.Contains(pricingMissingAdviceText, "tk_pricing_overlay.json"))
+}

--- a/backend/internal/service/wire.go
+++ b/backend/internal/service/wire.go
@@ -652,6 +652,11 @@ var ProviderSet = wire.NewSet(
 	// Returns the instance so provideCleanup (cmd/server/wire.go) can Stop() the
 	// ticker at shutdown — same lifecycle shape as ChannelMonitorRunner.
 	ProvideTKAccountIncidentNotifier,
+	// TokenKey: pricing-missing → Feishu notifier. Builds the notifier, starts
+	// its digest ticker, and wires it onto GatewayService + OpenAIGatewayService
+	// post-construction. Returns the instance so provideCleanup
+	// (cmd/server/wire.go) can Stop() the ticker at shutdown.
+	ProvideTKPricingMissingNotifier,
 )
 
 // TKAuthServiceColdStartReady is a wire sentinel: holding it proves that
@@ -810,6 +815,38 @@ func ProvideTKAccountIncidentNotifier(
 	n.Start()
 	if rl != nil {
 		rl.SetAccountIncidentNotifier(n)
+	}
+	return n
+}
+
+// ProvideTKPricingMissingNotifier builds the pricing-missing Feishu notifier,
+// starts its background digest ticker, and wires it onto both billing funnels
+// (GatewayService + OpenAIGatewayService) post-construction. Same lifecycle
+// shape as ProvideTKAccountIncidentNotifier: returns the concrete instance so
+// provideCleanup can Stop() the ticker at shutdown. Setters are nil-safe.
+func ProvideTKPricingMissingNotifier(
+	gw *GatewayService,
+	openaiGw *OpenAIGatewayService,
+	ops *OpsService,
+	cfg *config.Config,
+) *TKPricingMissingNotifier {
+	site := "unknown"
+	if cfg != nil {
+		site = siteFromFrontendURL(cfg.Server.FrontendURL)
+	}
+	// Pass a nil interface (not a typed-nil *OpsService) when ops is absent so the
+	// notifier's `cfgProvider != nil` guards short-circuit cleanly.
+	var provider opsFeishuConfigProvider
+	if ops != nil {
+		provider = ops
+	}
+	n := newTKPricingMissingNotifier(provider, site)
+	n.Start()
+	if gw != nil {
+		gw.SetPricingMissingNotifier(n)
+	}
+	if openaiGw != nil {
+		openaiGw.SetPricingMissingNotifier(n)
 	}
 	return n
 }

--- a/ops/pricing/README.md
+++ b/ops/pricing/README.md
@@ -14,6 +14,7 @@ live in
 | --- | --- |
 | `probe-servable-models.sh` | Runs ON the prod host (via `ops/observability/run-probe.sh`). Pulls the edge-us7 relay key + the GPT-line key from the DB (never printed), sends one minimal real request per candidate model, emits `platform⇥model⇥http⇥verdict` TSV. A model is **servable** iff it returns a real `200`. |
 | `refresh-servable-allowlist.py` | Orchestrator: derives candidates from the litellm catalog, runs the probe, keeps `verdict==servable`, de-duplicates dated snapshots, and splices the two Go maps. `selftest` covers all deterministic glue (no prod). |
+| `apply-pricing-hotfix.py` | Companion runbook for the **"模型缺价（已记零成本）" Feishu alert** (PricingMissingNotifier). Hot-applies channel pricing via the prod admin API (immediate, no release) and stages the durable fill-only entry into `tk_pricing_overlay.json`. `selftest` covers all pure logic (no network). See "Pricing-missing hotfix" below. |
 
 ## Re-run (operator, needs AWS creds for prod SSM)
 
@@ -35,6 +36,43 @@ Split the steps when you want to inspect the raw verdicts first:
 python3 ops/pricing/refresh-servable-allowlist.py probe | tee /tmp/servable.tsv
 python3 ops/pricing/refresh-servable-allowlist.py apply --results /tmp/servable.tsv
 ```
+
+## Pricing-missing hotfix (Feishu「模型缺价」告警的处置 runbook)
+
+Unpriced models are **served and recorded at zero cost** (never refused —
+pricing data lag must not become a customer-facing outage); the
+`PricingMissingNotifier` Feishu card tells you which `(platform, model)` is
+leaking. Remediation is two-step, mirroring the TLS-fingerprint / tiers
+"repo baseline + live push" hot-update shape:
+
+```bash
+# 0. what does litellm (FULL source, incl. provider-prefixed keys the trimmed
+#    mirror drops) say this model costs?
+python3 ops/pricing/apply-pricing-hotfix.py lookup --model doubao-seedream-9
+
+# 1. HOT (immediate, no release): upsert channel pricing via prod admin API.
+#    Channel pricing (DB) overrides every other pricing source; the channel
+#    cache invalidates on write. Dry-run by default; --yes to commit.
+export TOKENKEY_ADMIN_API_KEY=...   # settings.admin_api_key
+python3 ops/pricing/apply-pricing-hotfix.py channels   # pick --channel-id
+python3 ops/pricing/apply-pricing-hotfix.py apply \
+  --model doubao-seedream-9 --channel-id 4 --platform newapi --from-litellm --yes
+
+# 2. DURABLE (next release): append the fill-only entry to
+#    backend/internal/service/tk_pricing_overlay.json and open a PR.
+#    Self-deprecating: the day the trimmed mirror carries the bare key, the
+#    source value wins. For models litellm lacks entirely, use
+#    --entry-json with the provider's official list price.
+python3 ops/pricing/apply-pricing-hotfix.py stage-overlay \
+  --model doubao-seedream-9 --from-litellm
+python3 scripts/checks/pricing-overlay.py && bash scripts/preflight.sh
+```
+
+Caveats: channel pricing is per-channel — if the leaking traffic spans several
+channels, repeat `apply` per channel. `--from-litellm` cannot fix WRONG mirror
+prices for already-priced models (fill-only never overrides); channel pricing
+is exactly the tool for that. Alert digest cadence is
+`feishu.pricing_missing_digest_seconds` (default 1800s).
 
 ## Classification & de-dup rules
 

--- a/ops/pricing/apply-pricing-hotfix.py
+++ b/ops/pricing/apply-pricing-hotfix.py
@@ -86,6 +86,31 @@ def litellm_candidates(pricing: dict, model: str) -> dict:
     return out
 
 
+def pick_litellm_candidate(found: dict, model: str, explicit_key: str | None = None):
+    """从多候选里确定性选一个条目。
+
+    apply --yes 直接写计费配置，不允许猜：裸名精确键优先（litellm 的规范键）；
+    只剩一个候选时取它；多个 provider 前缀键并存（价格可能不同）则拒绝，
+    要求 --litellm-key 显式指定。返回 (key, entry)。
+    """
+    if explicit_key:
+        if explicit_key not in found:
+            raise SystemExit(f"--litellm-key {explicit_key!r} not among matches: "
+                             f"{', '.join(sorted(found))}")
+        return explicit_key, found[explicit_key]
+    lower = model.strip().lower()
+    for key in found:
+        if key.lower() == lower:
+            return key, found[key]
+    if len(found) == 1:
+        key = next(iter(found))
+        return key, found[key]
+    raise SystemExit(
+        f"ambiguous: {len(found)} litellm keys match {model!r} with no bare-name key: "
+        f"{', '.join(sorted(found))} — prices may differ per provider; "
+        "pass --litellm-key to choose explicitly")
+
+
 def synthesize_overlay_entry(litellm_entry: dict, source_note: str) -> dict:
     """从 litellm 条目裁出 overlay 条目（只保留 overlay 解析面认识的字段）。"""
     out = {}
@@ -271,9 +296,10 @@ def cmd_lookup(args) -> int:
     for key, entry in found.items():
         print(f"\n=== litellm key: {key}")
         print(json.dumps(entry, indent=2, ensure_ascii=False))
-    pick = next(iter(found.values()))
-    note = f"litellm {next(iter(found.keys()))} (captured via apply-pricing-hotfix.py lookup)"
-    print("\n=== suggested overlay entry (stage-overlay --from-litellm uses this):")
+    picked_key, pick = pick_litellm_candidate(found, args.model, args.litellm_key)
+    note = f"litellm {picked_key} (captured via apply-pricing-hotfix.py lookup)"
+    print(f"\n=== suggested overlay entry (from {picked_key}; "
+          "stage-overlay --from-litellm uses this):")
     print(render_overlay_block(args.model, synthesize_overlay_entry(pick, note)))
     print("\n=== suggested channel pricing payload element (apply --from-litellm uses this):")
     print(json.dumps(synthesize_channel_pricing(args.model, args.platform, pick),
@@ -303,8 +329,8 @@ def cmd_apply(args) -> int:
         if not found:
             raise SystemExit(f"--from-litellm: no litellm entry for {args.model!r}; "
                              "pass explicit --input-price/--output-price instead")
-        new_entry = synthesize_channel_pricing(args.model, args.platform,
-                                               next(iter(found.values())))
+        _, picked = pick_litellm_candidate(found, args.model, args.litellm_key)
+        new_entry = synthesize_channel_pricing(args.model, args.platform, picked)
     else:
         new_entry = {"platform": args.platform, "models": [args.model]}
         if args.per_request_price is not None:
@@ -356,9 +382,10 @@ def cmd_stage_overlay(args) -> int:
         if not found:
             raise SystemExit(f"no litellm entry for {args.model!r}; "
                              "provide --entry-json with provider official prices")
-        note = args.source or (f"litellm {next(iter(found.keys()))} "
+        picked_key, picked = pick_litellm_candidate(found, args.model, args.litellm_key)
+        note = args.source or (f"litellm {picked_key} "
                                "(captured via apply-pricing-hotfix.py)")
-        entry = synthesize_overlay_entry(next(iter(found.values())), note)
+        entry = synthesize_overlay_entry(picked, note)
 
     text = OVERLAY_PATH.read_text()
     new_text = insert_overlay_entry(text, args.model, entry)
@@ -395,6 +422,29 @@ def cmd_selftest(_args) -> int:
         ["vertex_ai/imagen-9.0-generate-001"]
     assert list(litellm_candidates(fixture, "DeepSeek-V9")) == ["deepseek/deepseek-v9"]
     assert litellm_candidates(fixture, "nope") == {}
+
+    # pick_litellm_candidate: 裸名优先；单候选直取；多前缀键无裸名 → 拒绝（防止
+    # 不同 provider 价格不同时静默取错）；--litellm-key 显式指定必须存在于候选。
+    multi = {
+        "openrouter/foo-1": {"input_cost_per_token": 9e-06},
+        "vertex_ai/foo-1": {"input_cost_per_token": 1e-06},
+    }
+    k, _ = pick_litellm_candidate(dict(multi, **{"foo-1": {"input_cost_per_token": 2e-06}}), "foo-1")
+    assert k == "foo-1"  # 裸名优先
+    k, _ = pick_litellm_candidate({"vertex_ai/foo-1": multi["vertex_ai/foo-1"]}, "foo-1")
+    assert k == "vertex_ai/foo-1"  # 单候选直取
+    try:
+        pick_litellm_candidate(multi, "foo-1")
+        raise AssertionError("multi-candidate without bare key must be rejected")
+    except SystemExit:
+        pass
+    k, _ = pick_litellm_candidate(multi, "foo-1", "vertex_ai/foo-1")
+    assert k == "vertex_ai/foo-1"  # 显式指定
+    try:
+        pick_litellm_candidate(multi, "foo-1", "nope/foo-1")
+        raise AssertionError("unknown --litellm-key must be rejected")
+    except SystemExit:
+        pass
 
     # synthesize_overlay_entry: 只保留白名单字段 + source。
     ov = synthesize_overlay_entry(fixture["deepseek/deepseek-v9"], "note")
@@ -474,6 +524,7 @@ def main() -> int:
     p.add_argument("--platform", default="anthropic",
                    help="platform used in the suggested channel payload (default anthropic)")
     p.add_argument("--litellm-url", default=LITELLM_URL_DEFAULT)
+    p.add_argument("--litellm-key", help="exact litellm key to use when several match")
     p.set_defaults(fn=cmd_lookup)
 
     p = sub.add_parser("channels", help="list channels to pick --channel-id")
@@ -487,6 +538,7 @@ def main() -> int:
                    help="group platform the pricing entry binds to (anthropic/openai/gemini/newapi/...)")
     p.add_argument("--from-litellm", action="store_true")
     p.add_argument("--litellm-url", default=LITELLM_URL_DEFAULT)
+    p.add_argument("--litellm-key", help="exact litellm key to use when several match")
     p.add_argument("--input-price", type=float, help="USD per input token")
     p.add_argument("--output-price", type=float, help="USD per output token")
     p.add_argument("--cache-read-price", type=float)
@@ -500,6 +552,7 @@ def main() -> int:
     p.add_argument("--model", required=True)
     p.add_argument("--from-litellm", action="store_true")
     p.add_argument("--litellm-url", default=LITELLM_URL_DEFAULT)
+    p.add_argument("--litellm-key", help="exact litellm key to use when several match")
     p.add_argument("--entry-json", help="path to a JSON object (or '-' for stdin) "
                                         "with overlay fields, for models litellm lacks")
     p.add_argument("--source", help="provenance note stored in the entry's source field")

--- a/ops/pricing/apply-pricing-hotfix.py
+++ b/ops/pricing/apply-pricing-hotfix.py
@@ -1,0 +1,517 @@
+#!/usr/bin/env python3
+"""apply-pricing-hotfix.py — 缺价模型定价热更新（飞书「模型缺价」告警的配套 runbook 脚本）。
+
+背景：catch-all 账号会把任意模型名转发到上游；缺价模型按零成本记账（不拒绝服务），
+由 PricingMissingNotifier 发飞书提醒运营。本脚本把既有的人肉止血路径机械化
+（deepseek-v4 先例：手工配渠道定价止血 → tk_pricing_overlay.json 固化）：
+
+  热更（立即生效，无需发版）：渠道定价 DB 凌驾一切定价来源，经 prod admin API
+  （x-api-key，参考 settings.admin_api_key）upsert —— 与 TLS 指纹/tiers 的
+  「repo 基线 + 脚本推运行时」热更新模式同构。
+  固化（随下次发版生效）：fill-only 条目写入 backend/internal/service/
+  tk_pricing_overlay.json（litellm 镜像补上后自动让位），提 PR。
+
+子命令：
+  lookup        从 litellm 上游全量源（含被裁剪镜像丢掉的带前缀键）查某模型价格，
+                输出建议的 overlay 条目 + 渠道定价 payload。
+  channels      列出渠道（id / 名称 / 各定价条目的平台与模型数），帮运营选 --channel-id。
+  apply         GET 渠道 → upsert 该模型的定价条目 → PUT 回写（默认 dry-run，--yes 才真写）。
+  stage-overlay 把条目以文本追加方式写入 tk_pricing_overlay.json（保持既有格式零搅动）。
+  selftest      离线自检（纯函数全覆盖，无网络）。
+
+环境变量：TOKENKEY_BASE_URL（默认 https://api.tokenkey.dev）、TOKENKEY_ADMIN_API_KEY。
+"""
+
+from __future__ import annotations
+
+import argparse
+import json
+import os
+import sys
+import urllib.error
+import urllib.request
+from decimal import Decimal
+from pathlib import Path
+
+LITELLM_URL_DEFAULT = (
+    "https://raw.githubusercontent.com/BerriAI/litellm/main/"
+    "model_prices_and_context_window.json"
+)
+BASE_URL_DEFAULT = os.environ.get("TOKENKEY_BASE_URL", "https://api.tokenkey.dev")
+REPO_ROOT = Path(__file__).resolve().parents[2]
+OVERLAY_PATH = REPO_ROOT / "backend" / "internal" / "service" / "tk_pricing_overlay.json"
+
+# overlay 允许携带的 litellm 字段（与 pricing_service_tk_overlay.go 的解析面对齐）。
+OVERLAY_FIELDS = (
+    "litellm_provider",
+    "mode",
+    "input_cost_per_token",
+    "output_cost_per_token",
+    "cache_creation_input_token_cost",
+    "cache_creation_input_token_cost_above_1hr",
+    "cache_read_input_token_cost",
+    "output_cost_per_image",
+    "output_cost_per_image_token",
+    "output_cost_per_video_per_second",
+    "max_input_tokens",
+    "max_output_tokens",
+    "max_tokens",
+    "supports_prompt_caching",
+    "supports_function_calling",
+    "supports_tool_choice",
+    "supports_vision",
+    "supports_pdf_input",
+    "supports_reasoning",
+)
+
+
+# ---------------------------------------------------------------------------
+# 纯函数（selftest 全覆盖）
+# ---------------------------------------------------------------------------
+
+def litellm_candidates(pricing: dict, model: str) -> dict:
+    """返回 litellm 全量源里匹配 model 的条目：裸名精确匹配 + 任意 provider 前缀键。
+
+    被裁剪镜像丢掉的就是带前缀键（如 vertex_ai/imagen-4.0-generate-001），
+    这里必须把它们找回来。
+    """
+    out = {}
+    lower = model.strip().lower()
+    for key, entry in pricing.items():
+        if not isinstance(entry, dict):
+            continue
+        k = key.lower()
+        if k == lower or k.endswith("/" + lower):
+            out[key] = entry
+    return out
+
+
+def synthesize_overlay_entry(litellm_entry: dict, source_note: str) -> dict:
+    """从 litellm 条目裁出 overlay 条目（只保留 overlay 解析面认识的字段）。"""
+    out = {}
+    for field in OVERLAY_FIELDS:
+        if field in litellm_entry and litellm_entry[field] is not None:
+            out[field] = litellm_entry[field]
+    if source_note:
+        out["source"] = source_note
+    return out
+
+
+def synthesize_channel_pricing(model: str, platform: str, entry: dict) -> dict:
+    """从 litellm 条目合成渠道定价 request 条目（admin PUT /channels/:id 的
+    model_pricing 元素，字段名对齐 channelModelPricingRequest）。"""
+    out = {"platform": platform, "models": [model]}
+    mode = (entry.get("mode") or "chat").lower()
+    if entry.get("output_cost_per_image") is not None:
+        out["billing_mode"] = "per_request"
+        out["per_request_price"] = entry["output_cost_per_image"]
+        return out
+    if mode in ("image_generation", "image"):
+        out["billing_mode"] = "per_request"
+        if entry.get("output_cost_per_image") is not None:
+            out["per_request_price"] = entry["output_cost_per_image"]
+        return out
+    out["billing_mode"] = "token"
+    mapping = (
+        ("input_cost_per_token", "input_price"),
+        ("output_cost_per_token", "output_price"),
+        ("cache_creation_input_token_cost", "cache_write_price"),
+        ("cache_read_input_token_cost", "cache_read_price"),
+    )
+    for src, dst in mapping:
+        if entry.get(src) is not None:
+            out[dst] = entry[src]
+    return out
+
+
+def strip_pricing_response_fields(pricing_list: list) -> list:
+    """把 GET 响应里的 model_pricing 还原成 PUT request 形态（剥掉 id 等响应字段）。"""
+    cleaned = []
+    for p in pricing_list or []:
+        q = {k: v for k, v in p.items() if k not in ("id",) and v is not None}
+        intervals = []
+        for itv in q.get("intervals") or []:
+            intervals.append({k: v for k, v in itv.items()
+                              if k not in ("id", "pricing_id") and v is not None})
+        if intervals:
+            q["intervals"] = intervals
+        else:
+            q.pop("intervals", None)
+        cleaned.append(q)
+    return cleaned
+
+
+def upsert_model_pricing(existing: list, new_entry: dict) -> list:
+    """把 new_entry（单模型条目）upsert 进渠道定价列表。
+
+    确定性规则：先把该模型从所有既有条目的 models 里摘除（同平台才摘；条目因此
+    变空则整条删除），再把 new_entry 追加到尾部。多模型共享条目不被整条覆盖。
+    """
+    model = new_entry["models"][0].strip().lower()
+    platform = (new_entry.get("platform") or "").strip().lower()
+    out = []
+    for p in existing or []:
+        p_platform = (p.get("platform") or "").strip().lower()
+        if p_platform != platform:
+            out.append(p)
+            continue
+        models = [m for m in (p.get("models") or []) if m.strip().lower() != model]
+        if not models:
+            continue  # 条目只剩该模型 → 整条让位给 new_entry
+        if len(models) != len(p.get("models") or []):
+            p = dict(p)
+            p["models"] = models
+        out.append(p)
+    out.append(new_entry)
+    return out
+
+
+def format_number(v) -> str:
+    """价格以普通十进制输出（不出现 1e-05 这类科学计数法），与 overlay 文件既有风格一致。"""
+    if isinstance(v, bool):
+        return "true" if v else "false"
+    if isinstance(v, int):
+        return str(v)
+    d = v if isinstance(v, Decimal) else Decimal(str(v))
+    s = format(d, "f")
+    if "." in s:
+        s = s.rstrip("0").rstrip(".")
+    return s or "0"
+
+
+def render_overlay_block(model: str, entry: dict) -> str:
+    """手工序列化 overlay 条目（2 空格缩进、价格普通十进制），供文本追加。"""
+    lines = [f'  {json.dumps(model, ensure_ascii=False)}: {{']
+    items = list(entry.items())
+    for i, (k, v) in enumerate(items):
+        comma = "," if i < len(items) - 1 else ""
+        if isinstance(v, str):
+            rendered = json.dumps(v, ensure_ascii=False)
+        else:
+            rendered = format_number(v)
+        lines.append(f'    {json.dumps(k, ensure_ascii=False)}: {rendered}{comma}')
+    lines.append("  }")
+    return "\n".join(lines)
+
+
+def insert_overlay_entry(text: str, model: str, entry: dict) -> str:
+    """把条目以文本方式追加到 overlay JSON 末尾（既有内容一个字节不动）。"""
+    data = json.loads(text)
+    if model in data:
+        raise ValueError(
+            f"model {model!r} already present in overlay — edit it by hand "
+            "(textual append cannot replace in place)")
+    trimmed = text.rstrip("\n")
+    if not trimmed.endswith("}"):
+        raise ValueError("overlay file does not end with '}'")
+    body = trimmed[:-1].rstrip()
+    if not body.endswith("}"):
+        raise ValueError("overlay file has no trailing entry to append after")
+    new_text = body + ",\n" + render_overlay_block(model, entry) + "\n}\n"
+    parsed = json.loads(new_text)  # 追加后必须仍是合法 JSON
+    if model not in parsed:
+        raise ValueError("post-insert validation failed")
+    return new_text
+
+
+# ---------------------------------------------------------------------------
+# 网络面（admin API / litellm 源）
+# ---------------------------------------------------------------------------
+
+def http_json(url: str, method: str = "GET", payload: dict | None = None,
+              api_key: str | None = None, timeout: int = 30) -> dict:
+    headers = {"Accept": "application/json"}
+    body = None
+    if payload is not None:
+        headers["Content-Type"] = "application/json"
+        body = json.dumps(payload).encode()
+    if api_key:
+        headers["x-api-key"] = api_key
+    req = urllib.request.Request(url, data=body, headers=headers, method=method)
+    try:
+        with urllib.request.urlopen(req, timeout=timeout) as resp:
+            return json.loads(resp.read().decode())
+    except urllib.error.HTTPError as e:
+        detail = e.read().decode(errors="replace")[:500]
+        raise SystemExit(f"HTTP {e.code} {method} {url}: {detail}") from e
+
+
+def admin_api_key() -> str:
+    key = os.environ.get("TOKENKEY_ADMIN_API_KEY", "").strip()
+    if not key:
+        raise SystemExit(
+            "TOKENKEY_ADMIN_API_KEY not set (settings.admin_api_key; "
+            "see memory/runbook: prod admin API via caddy x-api-key)")
+    return key
+
+
+def fetch_litellm(url: str) -> dict:
+    print(f"fetching litellm source: {url}", file=sys.stderr)
+    return http_json(url)
+
+
+def unwrap_data(resp: dict):
+    if isinstance(resp, dict) and "data" in resp:
+        return resp["data"]
+    return resp
+
+
+# ---------------------------------------------------------------------------
+# 子命令
+# ---------------------------------------------------------------------------
+
+def cmd_lookup(args) -> int:
+    pricing = fetch_litellm(args.litellm_url)
+    found = litellm_candidates(pricing, args.model)
+    if not found:
+        print(f"no litellm entry for {args.model!r} (bare or provider-prefixed). "
+              "Price it from the provider's official list, then use "
+              "`apply --input-price/--output-price` and `stage-overlay --entry-json`.")
+        return 1
+    for key, entry in found.items():
+        print(f"\n=== litellm key: {key}")
+        print(json.dumps(entry, indent=2, ensure_ascii=False))
+    pick = next(iter(found.values()))
+    note = f"litellm {next(iter(found.keys()))} (captured via apply-pricing-hotfix.py lookup)"
+    print("\n=== suggested overlay entry (stage-overlay --from-litellm uses this):")
+    print(render_overlay_block(args.model, synthesize_overlay_entry(pick, note)))
+    print("\n=== suggested channel pricing payload element (apply --from-litellm uses this):")
+    print(json.dumps(synthesize_channel_pricing(args.model, args.platform, pick),
+                     indent=2, ensure_ascii=False))
+    return 0
+
+
+def cmd_channels(args) -> int:
+    resp = http_json(f"{args.base_url}/api/v1/admin/channels", api_key=admin_api_key())
+    data = unwrap_data(resp)
+    items = data.get("items") if isinstance(data, dict) else data
+    if items is None:
+        items = data if isinstance(data, list) else []
+    for ch in items:
+        pricing = ch.get("model_pricing") or []
+        plats = sorted({(p.get("platform") or "?") for p in pricing})
+        nmodels = sum(len(p.get("models") or []) for p in pricing)
+        print(f"#{ch.get('id')}\t{ch.get('name')}\tstatus={ch.get('status')}\t"
+              f"pricing: {nmodels} models on {','.join(plats) or '-'}")
+    return 0
+
+
+def cmd_apply(args) -> int:
+    if args.from_litellm:
+        pricing = fetch_litellm(args.litellm_url)
+        found = litellm_candidates(pricing, args.model)
+        if not found:
+            raise SystemExit(f"--from-litellm: no litellm entry for {args.model!r}; "
+                             "pass explicit --input-price/--output-price instead")
+        new_entry = synthesize_channel_pricing(args.model, args.platform,
+                                               next(iter(found.values())))
+    else:
+        new_entry = {"platform": args.platform, "models": [args.model]}
+        if args.per_request_price is not None:
+            new_entry["billing_mode"] = "per_request"
+            new_entry["per_request_price"] = args.per_request_price
+        else:
+            if args.input_price is None or args.output_price is None:
+                raise SystemExit("apply needs --from-litellm, or --per-request-price, "
+                                 "or both --input-price and --output-price")
+            new_entry["billing_mode"] = "token"
+            new_entry["input_price"] = args.input_price
+            new_entry["output_price"] = args.output_price
+            if args.cache_read_price is not None:
+                new_entry["cache_read_price"] = args.cache_read_price
+            if args.cache_write_price is not None:
+                new_entry["cache_write_price"] = args.cache_write_price
+
+    key = admin_api_key()
+    url = f"{args.base_url}/api/v1/admin/channels/{args.channel_id}"
+    channel = unwrap_data(http_json(url, api_key=key))
+    existing = strip_pricing_response_fields(channel.get("model_pricing") or [])
+    merged = upsert_model_pricing(existing, new_entry)
+    payload = {"model_pricing": merged}
+
+    print(f"channel #{args.channel_id} ({channel.get('name')}): "
+          f"{len(existing)} pricing entries -> {len(merged)}")
+    print("new/updated entry:")
+    print(json.dumps(new_entry, indent=2, ensure_ascii=False))
+    if not args.yes:
+        print("\nDRY-RUN（未写入）。确认无误后追加 --yes 真正 PUT。")
+        return 0
+    http_json(url, method="PUT", payload=payload, api_key=key)
+    print("PUT ok — 渠道定价缓存即时失效，下一请求生效。")
+    print("别忘了固化：stage-overlay（或确认 litellm 镜像已收录该裸名键）。")
+    return 0
+
+
+def cmd_stage_overlay(args) -> int:
+    if args.entry_json:
+        raw = sys.stdin.read() if args.entry_json == "-" else Path(args.entry_json).read_text()
+        entry = json.loads(raw)
+        if not isinstance(entry, dict) or not entry:
+            raise SystemExit("--entry-json must be a non-empty JSON object")
+        if args.source:
+            entry["source"] = args.source
+    else:
+        pricing = fetch_litellm(args.litellm_url)
+        found = litellm_candidates(pricing, args.model)
+        if not found:
+            raise SystemExit(f"no litellm entry for {args.model!r}; "
+                             "provide --entry-json with provider official prices")
+        note = args.source or (f"litellm {next(iter(found.keys()))} "
+                               "(captured via apply-pricing-hotfix.py)")
+        entry = synthesize_overlay_entry(next(iter(found.values())), note)
+
+    text = OVERLAY_PATH.read_text()
+    new_text = insert_overlay_entry(text, args.model, entry)
+    if args.dry_run:
+        print(render_overlay_block(args.model, entry))
+        print(f"\nDRY-RUN（未写入 {OVERLAY_PATH}）。")
+        return 0
+    OVERLAY_PATH.write_text(new_text)
+    print(f"appended {args.model!r} to {OVERLAY_PATH}")
+    print("next: scripts/checks/pricing-overlay.py + scripts/preflight.sh, 然后提 PR 固化。")
+    return 0
+
+
+# ---------------------------------------------------------------------------
+# selftest（离线）
+# ---------------------------------------------------------------------------
+
+def cmd_selftest(_args) -> int:
+    fixture = {
+        "sample_spec": "doc",
+        "gpt-x": {"mode": "chat", "input_cost_per_token": 1e-06, "output_cost_per_token": 2e-06},
+        "vertex_ai/imagen-9.0-generate-001": {
+            "mode": "image_generation", "litellm_provider": "vertex_ai-image-models",
+            "output_cost_per_image": 0.04},
+        "deepseek/deepseek-v9": {
+            "mode": "chat", "litellm_provider": "deepseek",
+            "input_cost_per_token": 1.4e-07, "output_cost_per_token": 2.8e-07,
+            "cache_read_input_token_cost": 2.8e-09, "supports_prompt_caching": True},
+    }
+
+    # litellm_candidates: 裸名 + 带前缀键都要命中；大小写不敏感。
+    assert list(litellm_candidates(fixture, "gpt-x")) == ["gpt-x"]
+    assert list(litellm_candidates(fixture, "imagen-9.0-generate-001")) == \
+        ["vertex_ai/imagen-9.0-generate-001"]
+    assert list(litellm_candidates(fixture, "DeepSeek-V9")) == ["deepseek/deepseek-v9"]
+    assert litellm_candidates(fixture, "nope") == {}
+
+    # synthesize_overlay_entry: 只保留白名单字段 + source。
+    ov = synthesize_overlay_entry(fixture["deepseek/deepseek-v9"], "note")
+    assert ov["litellm_provider"] == "deepseek" and ov["source"] == "note"
+    assert "mode" in ov and ov["supports_prompt_caching"] is True
+
+    # synthesize_channel_pricing: chat → token 模式；image → per_request。
+    cp = synthesize_channel_pricing("deepseek-v9", "anthropic", fixture["deepseek/deepseek-v9"])
+    assert cp["billing_mode"] == "token" and cp["input_price"] == 1.4e-07
+    assert cp["cache_read_price"] == 2.8e-09 and cp["models"] == ["deepseek-v9"]
+    ci = synthesize_channel_pricing("imagen-9.0-generate-001", "gemini",
+                                    fixture["vertex_ai/imagen-9.0-generate-001"])
+    assert ci["billing_mode"] == "per_request" and ci["per_request_price"] == 0.04
+
+    # upsert: 新模型追加；同平台同模型替换；多模型共享条目只摘除该模型；跨平台不动。
+    existing = [
+        {"platform": "anthropic", "models": ["glm-5", "qwen-9"], "billing_mode": "token",
+         "input_price": 1e-06, "output_price": 2e-06},
+        {"platform": "gemini", "models": ["deepseek-v9"], "billing_mode": "token"},
+    ]
+    new = {"platform": "anthropic", "models": ["deepseek-v9"], "billing_mode": "token",
+           "input_price": 1.4e-07, "output_price": 2.8e-07}
+    merged = upsert_model_pricing(existing, new)
+    assert merged[-1] == new and len(merged) == 3  # gemini 条目不受影响
+    replaced = upsert_model_pricing(merged, dict(new, input_price=9e-07))
+    assert len(replaced) == 3 and replaced[-1]["input_price"] == 9e-07
+    shared = upsert_model_pricing(
+        [{"platform": "anthropic", "models": ["a", "b"], "billing_mode": "token"}],
+        {"platform": "anthropic", "models": ["a"], "billing_mode": "token"})
+    assert shared[0]["models"] == ["b"] and shared[1]["models"] == ["a"]
+
+    # format_number: 永不输出科学计数法。
+    assert format_number(1e-05) == "0.00001"
+    assert format_number(0.04) == "0.04"
+    assert format_number(True) == "true" and format_number(7) == "7"
+
+    # insert_overlay_entry: 既有文本零搅动 + 追加后合法；重复键拒绝。
+    base = '{\n  "_meta": {\n    "note": "x"\n  },\n  "m1": {\n    "mode": "chat"\n  }\n}\n'
+    inserted = insert_overlay_entry(base, "m2", {"mode": "chat", "input_cost_per_token": 1e-05})
+    assert inserted.startswith(base[:-3])  # 原文本（除收尾）原样保留
+    parsed = json.loads(inserted)
+    assert parsed["m2"]["input_cost_per_token"] == 1e-05
+    assert "1e-05" not in inserted  # 普通十进制
+    try:
+        insert_overlay_entry(base, "m1", {"mode": "chat"})
+        raise AssertionError("duplicate key must be rejected")
+    except ValueError:
+        pass
+
+    # 真实 overlay 文件:只读校验可被追加(不落盘)。
+    real = OVERLAY_PATH.read_text()
+    out = insert_overlay_entry(real, "tk-selftest-sentinel-model", {"mode": "chat"})
+    assert json.loads(out)["tk-selftest-sentinel-model"]["mode"] == "chat"
+
+    # strip_pricing_response_fields: 剥 id / 空值 / interval 内嵌 id。
+    stripped = strip_pricing_response_fields([
+        {"id": 3, "platform": "anthropic", "models": ["x"], "input_price": None,
+         "billing_mode": "token", "output_price": 1e-06,
+         "intervals": [{"id": 9, "pricing_id": 3, "min_tokens": 0, "input_price": 1e-06}]},
+    ])
+    assert "id" not in stripped[0] and "input_price" not in stripped[0]
+    assert stripped[0]["intervals"] == [{"min_tokens": 0, "input_price": 1e-06}]
+
+    print("selftest: OK")
+    return 0
+
+
+# ---------------------------------------------------------------------------
+
+def main() -> int:
+    ap = argparse.ArgumentParser(description=__doc__,
+                                 formatter_class=argparse.RawDescriptionHelpFormatter)
+    sub = ap.add_subparsers(dest="cmd", required=True)
+
+    p = sub.add_parser("lookup", help="query litellm full source for a model's price")
+    p.add_argument("--model", required=True)
+    p.add_argument("--platform", default="anthropic",
+                   help="platform used in the suggested channel payload (default anthropic)")
+    p.add_argument("--litellm-url", default=LITELLM_URL_DEFAULT)
+    p.set_defaults(fn=cmd_lookup)
+
+    p = sub.add_parser("channels", help="list channels to pick --channel-id")
+    p.add_argument("--base-url", default=BASE_URL_DEFAULT)
+    p.set_defaults(fn=cmd_channels)
+
+    p = sub.add_parser("apply", help="hot-apply channel pricing via admin API (dry-run by default)")
+    p.add_argument("--model", required=True)
+    p.add_argument("--channel-id", type=int, required=True)
+    p.add_argument("--platform", required=True,
+                   help="group platform the pricing entry binds to (anthropic/openai/gemini/newapi/...)")
+    p.add_argument("--from-litellm", action="store_true")
+    p.add_argument("--litellm-url", default=LITELLM_URL_DEFAULT)
+    p.add_argument("--input-price", type=float, help="USD per input token")
+    p.add_argument("--output-price", type=float, help="USD per output token")
+    p.add_argument("--cache-read-price", type=float)
+    p.add_argument("--cache-write-price", type=float)
+    p.add_argument("--per-request-price", type=float, help="USD per request (image etc.)")
+    p.add_argument("--base-url", default=BASE_URL_DEFAULT)
+    p.add_argument("--yes", action="store_true", help="actually PUT (default is dry-run)")
+    p.set_defaults(fn=cmd_apply)
+
+    p = sub.add_parser("stage-overlay", help="append a fill-only entry to tk_pricing_overlay.json")
+    p.add_argument("--model", required=True)
+    p.add_argument("--from-litellm", action="store_true")
+    p.add_argument("--litellm-url", default=LITELLM_URL_DEFAULT)
+    p.add_argument("--entry-json", help="path to a JSON object (or '-' for stdin) "
+                                        "with overlay fields, for models litellm lacks")
+    p.add_argument("--source", help="provenance note stored in the entry's source field")
+    p.add_argument("--dry-run", action="store_true")
+    p.set_defaults(fn=cmd_stage_overlay)
+
+    p = sub.add_parser("selftest", help="offline self-checks")
+    p.set_defaults(fn=cmd_selftest)
+
+    args = ap.parse_args()
+    return args.fn(args)
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/scripts/preflight.sh
+++ b/scripts/preflight.sh
@@ -428,6 +428,25 @@ else
     echo "  ok: pricing overlay valid (anchors present, no \$0)"
 fi
 
+# ---- sub2api: pricing-hotfix runbook selftest -------------------------------
+# ops/pricing/apply-pricing-hotfix.py is the runbook the PricingMissingNotifier
+# Feishu card points operators at (lookup / apply channel pricing / stage
+# overlay). Its selftest is offline and covers all pure logic — run it so a
+# refactor of the overlay file format or upsert rules fails preflight instead
+# of failing the operator mid-incident.
+echo ""
+echo "=== sub2api: pricing-hotfix runbook selftest ==="
+if ! command -v python3 >/dev/null 2>&1; then
+    echo "  FAIL: python3 not on PATH (required for pricing-hotfix selftest)"
+    errors=$((errors + 1))
+elif ! python3 ./ops/pricing/apply-pricing-hotfix.py selftest >/dev/null 2>&1; then
+    echo "  FAIL: pricing-hotfix runbook selftest"
+    echo "        — run: python3 ops/pricing/apply-pricing-hotfix.py selftest"
+    errors=$((errors + 1))
+else
+    echo "  ok: pricing-hotfix runbook selftest"
+fi
+
 # ---- sub2api: frontend TK sentinel registry ---------------------------------
 # Source of truth: scripts/sentinels/frontend-tk.json. Verifies that load-bearing
 # TokenKey-only frontend surfaces (sidebar geometry, fluid table mode, sticky

--- a/scripts/sentinels/gateway-tk.json
+++ b/scripts/sentinels/gateway-tk.json
@@ -1323,9 +1323,9 @@
       "path": "backend/internal/service/gateway_service.go",
       "must_contain": [
         "topLevelCacheControl := gjson.GetBytes(out, \"cache_control\").Exists()",
-        "logTokenCostPricingMissing(billingModel, apiKey, result, err)"
+        "s.recordTokenCostPricingMissing(billingModel, apiKey, result, tokens, err)"
       ],
-      "rationale": "TK#2013: enforceCacheControlLimit must count a non-standard top-level cache_control toward the 4-block limit (else Anthropic 400 'Found 5'). TK#1833/#1544: calculateTokenCost must surface pricing-missing as an observable marked zero-cost record instead of a silent ActualCost:0 revenue leak."
+      "rationale": "TK#2013: enforceCacheControlLimit must count a non-standard top-level cache_control toward the 4-block limit (else Anthropic 400 'Found 5'). TK#1833/#1544: calculateTokenCost must surface pricing-missing as an observable marked zero-cost record instead of a silent ActualCost:0 revenue leak (call renamed to recordTokenCostPricingMissing when the Feishu pricing-missing notifier was layered on top — it still emits the same structured log)."
     },
     {
       "path": "backend/internal/service/gateway_service_tk_billing_pricing_missing.go",
@@ -2033,6 +2033,22 @@
         "if s, e, ok := parseAbsoluteRange(c); ok {"
       ],
       "rationale": "Thin TK injection at the top of the upstream-owned parseTimeRange (the single chokepoint for all 7 dashboard time-window endpoints). Rolling presets (近24小时/7/14/30天) send absolute epoch-ms start_ts/end_ts so the window is timezone-independent; without this hook the window falls back to the viewer's browser-reported timezone and two admin sessions on different timezones (e.g. a fingerprint browser spoofing a US zone vs Asia/Shanghai) again see materially different dashboard numbers for the same selection. The implementation lives in the dashboard_handler_tk_window.go companion; this sentinel anchors the one-line call site that an upstream merge copying the old parseTimeRange shape back would silently drop."
+    },
+    {
+      "path": "backend/internal/service/gateway_service.go",
+      "must_contain": [
+        "s.recordTokenCostPricingMissing(billingModel, apiKey, result, tokens, err)",
+        "tkPricingMissingNotifier PricingMissingNotifier"
+      ],
+      "rationale": "Pricing-missing -> Feishu notifier hook on the Anthropic/generic billing funnel (PR #675 follow-up). Unpriced models are served and recorded at zero cost by design (never refused); this one-line call + struct field are the only bridge from calculateRecordUsageCost into PricingMissingNotifier. Both compile-clean if an upstream merge reverts the call back to the bare logTokenCostPricingMissing shape, which would silently turn revenue-leak alerting back into log-only observability."
+    },
+    {
+      "path": "backend/internal/service/openai_gateway_service.go",
+      "must_contain": [
+        "s.notifyOpenAIPricingMissing(input, result, apiKey, billingModels, tokens)",
+        "tkPricingMissingNotifier PricingMissingNotifier"
+      ],
+      "rationale": "Pricing-missing -> Feishu notifier hook on the OpenAI-compat record-usage funnel (covers newapi fifth platform + image/video relays). The upstream-owned openai_usage.pricing_missing_record_zero_cost log line stays untouched; this adjacent one-line call is the only feed into PricingMissingNotifier on this path and is compile-clean if dropped by an upstream merge."
     }
   ]
 }


### PR DESCRIPTION
## 背景（#675 遗留项的处置结论）

#675 留了「拒绝服务未定价模型」硬护栏评估。结论是**不拒绝服务**，理由：

1. 计费模型在请求前不可知（候选链含上游响应字段 `result.BillingModel`），入口预检 by-construction 误杀；
2. 定价 ≠ 可服务（既有边界，#605 踩过）：litellm 镜像滞后会把数据缺口放大成客户侧 4xx 故障；
3. 硬拒绝会废掉 #605/#608/#675 的 servable 探测流水线（探测依赖真实请求穿过 catch-all）；
4. 裸名/不可服务模型已有 #617 的 400 护栏，剩下的真实缺口只是「已服务但零成本」的运营可见性。

本 PR 把缺口补成「**照常服务 + 飞书告警提醒运营配置定价 + 机械化热更**」。

## 改动

- **`PricingMissingNotifier`**（`pricing_missing_notifier_tk.go`，仿 #516 账号失效通知器）：首见 `(platform, model)` 即时橙卡（24h 去重 + 每小时滑窗限量 10）；全量事件进聚合 buffer，按 `feishu.pricing_missing_digest_seconds`（默认 1800s，校验 30..86400）flush 摘要（次数 / 未计费 tokens 量级 / 涉及组与 key）。补价后告警自然停止。
- **两条计费 funnel 挂钩**（既有 `pricing_missing_record_zero_cost` 日志行不动，#675 交叉核验与 ops 工具仍 grep 它）：
  - anthropic/通用：`calculateRecordUsageCost` 的调用换成 companion `recordTokenCostPricingMissing`（内部仍发同一结构化日志；gateway-tk sentinel 锚点同 commit 更新）；
  - openai-compat（含 newapi 第五平台、图/视频）：upstream-owned Warn 后追加一行 `s.notifyOpenAIPricingMissing(...)`。
  - 两处注入均为 compile-clean-if-dropped，已加 **gateway-tk.json sentinel** 防 upstream merge 静默吞掉。
- **Wire**：`ProvideTKPricingMissingNotifier`（与账号失效通知器同生命周期形态，`provideCleanup` Stop；`wire_gen` 重新生成）。
- **`ops/pricing/apply-pricing-hotfix.py`**（飞书卡片指向的 runbook，机械化 deepseek-v4 先例的人肉路径，与 TLS 指纹/tiers「repo 基线 + 脚本推运行时」同构）：
  - `lookup`：litellm **全量源**取价（含被裁剪镜像丢掉的带前缀键）；
  - `apply`：经 prod admin API（x-api-key）upsert 渠道定价——**立即生效，无需发版**（渠道定价凌驾一切来源，写入即失效缓存）；默认 dry-run，`--yes` 才写；
  - `stage-overlay`：fill-only 条目**文本追加**进 `tk_pricing_overlay.json`（既有字节零搅动），提 PR 固化；
  - `selftest` 离线全覆盖，已挂进 `scripts/preflight.sh`。
- `ops/pricing/README.md` runbook 章节 + `tokenkey-servable-model-refresh` SKILL 姊妹指引。

前端整对象 round-trip（深拷贝 GET 响应再 PUT），新设置字段经 UI 保存不会被打回默认，无需前端改动。

## 验证

- `go test -tags=unit ./...` ✅（含 notifier 聚合/去重/flush/disabled-no-op、两 funnel 挂钩、nil-safe 单测）
- `go test -tags=integration ./...` ✅
- `golangci-lint run ./internal/service/... ./cmd/server/...` ✅ 0 issues
- `python3 ops/pricing/apply-pricing-hotfix.py selftest` ✅
- `scripts/preflight.sh` **PASS**（含新挂的 hotfix selftest、gateway-tk sentinel、upstream-override 门禁）

## Out-of-order 说明

`check-drift.sh`：TK behind upstream/main 16 commits（2026-06-09 合并后新到）。本 PR 为 TK-only 功能（新增 companion 文件 + 两处一行注入），与该 16 个上游 commit 无重叠面；每日 upstream-merge agent 将按既定通道处理合并。

no-web-impact

🤖 Generated with [Claude Code](https://claude.com/claude-code)