### PR TITLE
fix(fable): proactively strip explicit thinking.type=disabled for fable models

### DIFF
--- a/backend/internal/service/gateway_request_tk_fable.go
+++ b/backend/internal/service/gateway_request_tk_fable.go
@@ -1,6 +1,13 @@
 package service
 
-import "strings"
+import (
+	"strings"
+
+	"github.com/tidwall/gjson"
+	"github.com/tidwall/sjson"
+
+	"github.com/Wei-Shaw/sub2api/internal/pkg/logger"
+)
 
 // TokenKey: Fable-tier model predicates for thinking-shape rectification.
 //
@@ -16,6 +23,14 @@ import "strings"
 // Fable's adaptive-required 400 would be gated OUT of the reactive repair and
 // surfaced raw to the client. requiresAdaptiveOnlyThinking is the broadened gate
 // used at those call sites; isOpus47OrNewer stays honest to its name.
+//
+// Disabled semantics (prod 2026-06-10, user 16): Fable also rejects an explicit
+// `thinking:{"type":"disabled"}` with a 400 ("thinking.type.disabled" is not
+// supported for this model …), while Opus 4.7+ still ACCEPTS explicit disabled —
+// so the proactive strip below gates on isFableModel, NOT on
+// requiresAdaptiveOnlyThinking. Omitting the field is the documented equivalent.
+// Precedent: the bedrock path already does exactly this (bedrock_request.go:683,
+// sanitizeBedrockThinking "disabled" case); see docs/spec-delta-cc-fable-5.md.
 
 // isFableModel reports whether modelID is a Claude Fable-tier model. Matches the
 // bare id, dated snapshots, the [1m] context-window alias, and the bedrock
@@ -31,4 +46,28 @@ func isFableModel(modelID string) bool {
 // || isFableModel in sanitizeBedrockThinking.
 func requiresAdaptiveOnlyThinking(modelID string) bool {
 	return isOpus47OrNewer(modelID) || isFableModel(modelID)
+}
+
+// tkStripFableDisabledThinking proactively drops an explicit
+// `thinking:{"type":"disabled"}` before the outbound send when the body targets
+// a Fable-tier model (upstream rejects explicit disabled with a 400; omitting
+// the field is equivalent — see the file-header note and bedrock_request.go:683
+// for the same rule on the bedrock path). Any other shape — non-fable model,
+// adaptive/enabled thinking, or no thinking at all — returns the input bytes
+// unchanged (no reformat). Surgical delete via sjson keeps every other byte
+// intact. The reactive 400 detector stays anchored on "enabled" only: once this
+// proactive strip runs, the disabled shape never reaches upstream.
+func tkStripFableDisabledThinking(body []byte) []byte {
+	model := gjson.GetBytes(body, "model").String()
+	if !isFableModel(model) || gjson.GetBytes(body, "thinking.type").String() != "disabled" {
+		return body
+	}
+	stripped, err := sjson.DeleteBytes(body, "thinking")
+	if err != nil {
+		return body
+	}
+	logger.LegacyPrintf("service.gateway",
+		"[Forward] stripped explicit thinking.type=disabled for fable model before upstream forward (fable returns 400 on explicit disabled; omitted field is equivalent): model=%s original_bytes=%d stripped_bytes=%d",
+		model, len(body), len(stripped))
+	return stripped
 }

--- a/backend/internal/service/gateway_request_tk_fable_test.go
+++ b/backend/internal/service/gateway_request_tk_fable_test.go
@@ -1,0 +1,98 @@
+//go:build unit
+
+package service
+
+// Unit tests for tkStripFableDisabledThinking — the proactive pre-send strip of
+// an explicit `thinking:{"type":"disabled"}` for Fable-tier models.
+//
+// Evidence (prod, 2026-06-10, user 16, claude-fable-5): upstream rejected the
+// explicit disabled shape with a 400 whose message begins:
+//
+//	"thinking.type.disabled" is not supported for this model. Thinking
+//	defaults to adaptive mode and "output_config.effort" to control thinking
+//	behavior.
+//
+// Same-window fable requests with adaptive thinking or no thinking field all
+// succeeded. Opus 4.7+ still accepts explicit disabled, hence the gate is
+// isFableModel, not requiresAdaptiveOnlyThinking. The bedrock path already
+// strips this shape (bedrock_request.go sanitizeBedrockThinking "disabled"
+// case); these tests lock the same semantics on the direct Anthropic path.
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/require"
+	"github.com/tidwall/gjson"
+	"github.com/tidwall/sjson"
+)
+
+// TestTkStripFableDisabledThinking_StripIsSurgical asserts that for
+// fable+disabled the thinking member disappears and every other byte of the
+// body is preserved verbatim (sjson surgical delete, no reformat).
+func TestTkStripFableDisabledThinking_StripIsSurgical(t *testing.T) {
+	input := []byte(`{"model":"claude-fable-5","max_tokens":32000,"thinking":{"type":"disabled"},"metadata":{"user_id":"u-16"},"messages":[{"role":"user","content":"hi  é"}],"stream":true}`)
+	want := []byte(`{"model":"claude-fable-5","max_tokens":32000,"metadata":{"user_id":"u-16"},"messages":[{"role":"user","content":"hi  é"}],"stream":true}`)
+
+	got := tkStripFableDisabledThinking(input)
+	require.False(t, gjson.GetBytes(got, "thinking").Exists())
+	require.Equal(t, string(want), string(got))
+}
+
+// TestTkStripFableDisabledThinking_NoTouch asserts the function returns the
+// input bytes unchanged for every shape that must NOT be stripped.
+func TestTkStripFableDisabledThinking_NoTouch(t *testing.T) {
+	cases := []struct {
+		name string
+		body string
+	}{
+		{"fable adaptive", `{"model":"claude-fable-5","thinking":{"type":"adaptive"},"max_tokens":100}`},
+		{"fable enabled", `{"model":"claude-fable-5","thinking":{"type":"enabled","budget_tokens":1024},"max_tokens":100}`},
+		{"fable no thinking", `{"model":"claude-fable-5","max_tokens":100}`},
+		{"opus 4.7 disabled (still accepted upstream)", `{"model":"claude-opus-4-7","thinking":{"type":"disabled"},"max_tokens":100}`},
+		{"sonnet 4.6 disabled", `{"model":"claude-sonnet-4-6","thinking":{"type":"disabled"},"max_tokens":100}`},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			input := []byte(tc.body)
+			got := tkStripFableDisabledThinking(input)
+			require.Equal(t, tc.body, string(got))
+		})
+	}
+}
+
+// TestTkStripFableDisabledThinking_ModelVariants asserts every fable model-id
+// variant observed in the wild hits the strip.
+func TestTkStripFableDisabledThinking_ModelVariants(t *testing.T) {
+	variants := []string{
+		"claude-fable-5",
+		"claude-fable-5-20260601",  // dated snapshot
+		"claude-fable-5[1m]",       // context-window alias
+		"anthropic.claude-fable-5", // bedrock form
+	}
+	for _, model := range variants {
+		t.Run(model, func(t *testing.T) {
+			body, err := sjson.Set(`{"model":"","thinking":{"type":"disabled"},"max_tokens":100}`, "model", model)
+			require.NoError(t, err)
+			got := tkStripFableDisabledThinking([]byte(body))
+			require.False(t, gjson.GetBytes(got, "thinking").Exists(), "thinking must be stripped for %s", model)
+			require.Equal(t, model, gjson.GetBytes(got, "model").String())
+		})
+	}
+}
+
+// TestTkStripFableDisabledThinking_SanitizeChainShape mirrors the exact
+// composition used at all three gateway_service.go pre-send sites:
+//
+//	tkStripFableDisabledThinking(StripEmptyTextBlocks(TkSanitizeRequestBody(body, account)))
+//
+// and proves the composed outbound body carries no thinking member.
+func TestTkStripFableDisabledThinking_SanitizeChainShape(t *testing.T) {
+	account := &Account{ID: 1, Name: "fable-test", Platform: PlatformAnthropic}
+	body := []byte(`{"model":"claude-fable-5","thinking":{"type":"disabled"},"messages":[{"role":"user","content":[{"type":"text","text":"hello"},{"type":"text","text":""}]}],"max_tokens":100}`)
+
+	out := tkStripFableDisabledThinking(StripEmptyTextBlocks(TkSanitizeRequestBody(body, account)))
+
+	require.False(t, gjson.GetBytes(out, "thinking").Exists())
+	require.Equal(t, "claude-fable-5", gjson.GetBytes(out, "model").String())
+	require.True(t, gjson.ValidBytes(out))
+}

--- a/backend/internal/service/gateway_service.go
+++ b/backend/internal/service/gateway_service.go
@@ -4829,7 +4829,9 @@ func (s *GatewayService) Forward(ctx context.Context, c *gin.Context, account *A
 	// #63885 / #64777), THEN strip empty text blocks (including nested in
 	// tool_result). Sanitize runs first because StripEmptyTextBlocks parses the
 	// body as JSON; both prevent an upstream 400 before the first call.
-	if err := replaceBody(StripEmptyTextBlocks(TkSanitizeRequestBody(body, account))); err != nil {
+	// tkStripFableDisabledThinking: fable rejects explicit thinking.type=disabled
+	// with a 400 (gateway_request_tk_fable.go).
+	if err := replaceBody(tkStripFableDisabledThinking(StripEmptyTextBlocks(TkSanitizeRequestBody(body, account)))); err != nil {
 		return nil, err
 	}
 
@@ -5519,7 +5521,9 @@ func (s *GatewayService) forwardAnthropicAPIKeyPassthroughWithInput(
 	// #60168 / #63885 / #64777), THEN strip empty text blocks (including nested
 	// in tool_result). Sanitize runs first because StripEmptyTextBlocks parses
 	// the body as JSON; both prevent an upstream 400.
-	input.Body = StripEmptyTextBlocks(TkSanitizeRequestBody(input.Body, account))
+	// tkStripFableDisabledThinking: fable rejects explicit thinking.type=disabled
+	// with a 400 (gateway_request_tk_fable.go).
+	input.Body = tkStripFableDisabledThinking(StripEmptyTextBlocks(TkSanitizeRequestBody(input.Body, account)))
 	if input.Parsed != nil {
 		// 透传分支也会改写实际 wire body，成功 usage hash 依赖这里同步当前 body。
 		if err := input.Parsed.ReplaceBody(input.Body); err != nil {
@@ -9913,7 +9917,9 @@ func (s *GatewayService) ForwardCountTokens(ctx context.Context, c *gin.Context,
 	// #60168 / #63885 / #64777), THEN strip empty text blocks. Sanitize runs
 	// first because StripEmptyTextBlocks parses the body as JSON; both prevent
 	// an upstream 400 (here also guarding the per-account upstream-error breaker).
-	if err := replaceBody(StripEmptyTextBlocks(TkSanitizeRequestBody(body, account))); err != nil {
+	// tkStripFableDisabledThinking: fable rejects explicit thinking.type=disabled
+	// with a 400 (gateway_request_tk_fable.go).
+	if err := replaceBody(tkStripFableDisabledThinking(StripEmptyTextBlocks(TkSanitizeRequestBody(body, account)))); err != nil {
 		return err
 	}
 

--- a/scripts/sentinels/gateway-tk.json
+++ b/scripts/sentinels/gateway-tk.json
@@ -2049,6 +2049,22 @@
         "tkPricingMissingNotifier PricingMissingNotifier"
       ],
       "rationale": "Pricing-missing -> Feishu notifier hook on the OpenAI-compat record-usage funnel (covers newapi fifth platform + image/video relays). The upstream-owned openai_usage.pricing_missing_record_zero_cost log line stays untouched; this adjacent one-line call is the only feed into PricingMissingNotifier on this path and is compile-clean if dropped by an upstream merge."
+    },
+    {
+      "path": "backend/internal/service/gateway_request_tk_fable.go",
+      "must_contain": [
+        "func tkStripFableDisabledThinking(body []byte) []byte",
+        "sjson.DeleteBytes(body, \"thinking\")"
+      ],
+      "rationale": "Proactive pre-send strip of explicit thinking:{type:\"disabled\"} for Fable-tier models. Upstream rejects the explicit disabled shape on fable with a 400 ('\"thinking.type.disabled\" is not supported for this model …', prod 2026-06-10 user 16) while Opus 4.7+ still accepts it — so the gate is isFableModel, NOT requiresAdaptiveOnlyThinking, and omitting the field is the documented equivalent (same rule the bedrock path already applies in sanitizeBedrockThinking's disabled case). If this function is silently dropped, fable clients sending thinking.type=disabled regress to raw upstream 400s on the direct Anthropic path."
+    },
+    {
+      "path": "backend/internal/service/gateway_service.go",
+      "must_contain": [
+        "replaceBody(tkStripFableDisabledThinking(StripEmptyTextBlocks(TkSanitizeRequestBody(body, account))))",
+        "input.Body = tkStripFableDisabledThinking(StripEmptyTextBlocks(TkSanitizeRequestBody(input.Body, account)))"
+      ],
+      "rationale": "The three pre-send sanitize chains (main Forward ~4834, API-Key passthrough ~5526, count_tokens ~9922) must wrap the StripEmptyTextBlocks(TkSanitizeRequestBody(...)) combo with tkStripFableDisabledThinking so an explicit thinking.type=disabled never reaches upstream for fable models. An upstream merge that restores the bare two-function chain silently reverts the fix and fable+disabled requests 400 again. The replaceBody form covers both Forward and count_tokens; the input.Body form covers the passthrough path."
     }
   ]
 }


### PR DESCRIPTION
## 问题（prod 实测，2026-06-10）

user 16 客户端以 `thinking:{"type":"disabled"}` 调 `claude-fable-5`，上游返 400：`"thinking.type.disabled" is not supported for this model. Thinking defaults to adaptive mode…`，TokenKey 原样透传给客户端，03:22–03:27 UTC 持续发生（8+ 次/窗口，客户端在重试循环）。同窗口 fable + adaptive / 无 thinking 流量全部成功——仅显式 disabled 这一种形状受阻。

根因：反应式修复检测器 `isThinkingTypeAdaptiveRequiredError` 只锚 `thinking.type.enabled`，disabled 形状不进修复-重试链。Bedrock 路径早已正确处理（`bedrock_request.go:683`，fable+disabled → 省略 thinking 字段；**Opus 4.7+ 仍接受 explicit disabled**）。

## 修法（乔布斯决策：proactive-only）

- `gateway_request_tk_fable.go` 新增 `tkStripFableDisabledThinking`：`isFableModel && thinking.type=="disabled"` → `sjson.DeleteBytes(body,"thinking")`（省略 = 让上游用默认 adaptive，与 Bedrock 同语义；**不**改写成 adaptive）；其余形状原字节返回。
- `gateway_service.go` 三处 pre-send sanitize 链各一行包裹（主 Forward / API-Key passthrough / count_tokens），净增 6 行、零重排。
- 检测器与修复-重试链**不动**（proactive 之后该形状永不到上游，reactive 是死代码）；gate 收口 `isFableModel`，不扩 opus-4.7（对 opus 剥 disabled 是有害语义改变）；无 `IsBudgetRectifierEnabled` 门控（形状修正非策略整流，Bedrock 同款无门控）。
- `scripts/sentinels/gateway-tk.json` +2 锚点钉新函数与包裹链（registry-update-gate 强制；防 upstream merge 静默还原注入点）。

## 三层 e2e

1. **单测**（13 子用例全绿）：手术性逐字节断言（剥离后其余字节不变）、防误伤五组（fable+adaptive/enabled/无 thinking、opus-4-7+disabled、sonnet+disabled 均原字节返回）、4 个模型 id 变体（bare/dated/[1m]/bedrock 形）、按 gateway_service.go 实际组合顺序的链测试。
2. **本地验证**：`go test -tags=unit ./...` 全量绿；`golangci-lint run ./...` 0 issue；`bash scripts/preflight.sh` 绿；`go build ./...` 过。
3. **上线后 prod 实测 checklist**：
   - [x] 用 user 16 同形状（fable + explicit disabled）打 prod，期待 200
   - [x] `ops_error_logs` 按 `thinking.type.disabled` 指纹过滤，确认不再增长
   - [x] fable + adaptive / enabled 流量成功率不变

## 出 order 说明

TK 当前落后 upstream/main 18 commits；本 PR 为用户正在受影响的止血修复，先行合入，upstream 合流由每日 upstream-merge agent 处理。

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
**上线后 prod 实测（v1.7.88，2026-06-10 05:55 UTC，全部通过）**：fable + explicit `thinking:{type:"disabled"}` 经 CC 客户端形状实测返 **200**（响应正常，`msg_01AQ9D4T…`）；网关日志出现剥离行（`original_bytes=520 stripped_bytes=476`）；`ops_error_logs` 中该 400 指纹最后出现于 04:45 UTC（部署前），部署后零新增；fable adaptive/无 thinking 流量持续 200（40 分钟内 258 条成功）。
