### PR TITLE
fix(pricing): copy cache_creation_input_token_cost_above_1hr in TK overlay loader

### DIFF
--- a/backend/internal/service/pricing_service_tk_overlay.go
+++ b/backend/internal/service/pricing_service_tk_overlay.go
@@ -90,6 +90,9 @@ func loadTKPricingOverlay() map[string]*LiteLLMModelPricing {
 			if e.CacheCreationInputTokenCost != nil {
 				p.CacheCreationInputTokenCost = *e.CacheCreationInputTokenCost
 			}
+			if e.CacheCreationInputTokenCostAbove1hr != nil {
+				p.CacheCreationInputTokenCostAbove1hr = *e.CacheCreationInputTokenCostAbove1hr
+			}
 			if e.CacheReadInputTokenCost != nil {
 				p.CacheReadInputTokenCost = *e.CacheReadInputTokenCost
 			}

--- a/backend/internal/service/pricing_service_tk_overlay_test.go
+++ b/backend/internal/service/pricing_service_tk_overlay_test.go
@@ -4,6 +4,8 @@ import (
 	"testing"
 
 	"github.com/stretchr/testify/require"
+
+	"github.com/Wei-Shaw/sub2api/internal/config"
 )
 
 // TestTKPricingOverlay_FillsDeepseekV4 verifies the overlay supplies pricing for
@@ -80,4 +82,98 @@ func TestTKPricingOverlay_MediaEntriesStillPresent(t *testing.T) {
 	veo := data["veo-3.0-generate-001"]
 	require.NotNil(t, veo, "media overlay entry veo-3.0-generate-001 must survive the rename")
 	require.InDelta(t, 0.4, veo.OutputCostPerSecond, 1e-12)
+}
+
+// TestTKPricingOverlay_CopiesCacheCreation1hPrice guards the overlay loader's
+// field copy of cache_creation_input_token_cost_above_1hr. The loader used to
+// drop it (only the main parsePricingData entry path copied it), so any overlay
+// model with a 1h cache-write tier — claude-fable-5 — silently billed 1h cache
+// creation at the 5m rate ($12.50/MTok instead of $20/MTok).
+func TestTKPricingOverlay_CopiesCacheCreation1hPrice(t *testing.T) {
+	overlay := loadTKPricingOverlay()
+	fable := overlay["claude-fable-5"]
+	require.NotNil(t, fable, "overlay must carry claude-fable-5")
+	require.InDelta(t, 1.25e-5, fable.CacheCreationInputTokenCost, 1e-15)
+	require.InDelta(t, 2e-5, fable.CacheCreationInputTokenCostAbove1hr, 1e-15,
+		"overlay loader must copy the 1h cache-write price")
+}
+
+// TestBilling_FableOverlayEnablesCacheBreakdown verifies end-to-end that a
+// claude-fable-5 pricing resolved via the TK overlay (the model is absent from
+// the trimmed runtime source) enables 5m/1h cache breakdown billing:
+// price1h (2e-5) > price5m (1.25e-5) > 0.
+func TestBilling_FableOverlayEnablesCacheBreakdown(t *testing.T) {
+	svc := &PricingService{}
+	data, err := svc.parsePricingData([]byte(`{
+		"gpt-5.4": {"input_cost_per_token": 0.0000025, "output_cost_per_token": 0.000015, "litellm_provider": "openai", "mode": "chat"}
+	}`))
+	require.NoError(t, err)
+	require.NotNil(t, data["claude-fable-5"], "fable must be injected by the overlay (absent from source body)")
+
+	billing := NewBillingService(&config.Config{}, &PricingService{pricingData: data})
+	pricing, err := billing.GetModelPricing("claude-fable-5")
+	require.NoError(t, err)
+	require.True(t, pricing.SupportsCacheBreakdown, "1h > 5m price must enable breakdown")
+	require.InDelta(t, 1.25e-5, pricing.CacheCreation5mPrice, 1e-15)
+	require.InDelta(t, 2e-5, pricing.CacheCreation1hPrice, 1e-15)
+}
+
+// TestBilling_Fable1hCacheCreationCost_ProdShape is the regression reproduction
+// with the exact prod token shape that exposed the bug (usage_logs, 2026-06):
+// cache_creation_5m_tokens=0, cache_creation_1h_tokens=684124. Correct cost is
+// 684124 * 2e-5 = $13.68248; before the fix the overlay dropped the 1h price,
+// breakdown stayed off, and the same shape billed flat 5m rate:
+// 684124 * 1.25e-5 = $8.55155.
+func TestBilling_Fable1hCacheCreationCost_ProdShape(t *testing.T) {
+	svc := &PricingService{}
+	data, err := svc.parsePricingData([]byte(`{
+		"gpt-5.4": {"input_cost_per_token": 0.0000025, "output_cost_per_token": 0.000015, "litellm_provider": "openai", "mode": "chat"}
+	}`))
+	require.NoError(t, err)
+
+	billing := NewBillingService(&config.Config{}, &PricingService{pricingData: data})
+	tokens := UsageTokens{
+		CacheCreationTokens:   684124,
+		CacheCreation5mTokens: 0,
+		CacheCreation1hTokens: 684124,
+	}
+	breakdown, err := billing.CalculateCost("claude-fable-5", tokens, 1.0)
+	require.NoError(t, err)
+	require.InDelta(t, 13.68248, breakdown.CacheCreationCost, 1e-6)
+}
+
+// TestBilling_SourceCarried1hPriceUnaffected is the no-regression control: a
+// model whose 1h cache-write price comes from the runtime source (main
+// parsePricingData path, which always copied the field) must bill exactly as
+// before the overlay-loader fix.
+func TestBilling_SourceCarried1hPriceUnaffected(t *testing.T) {
+	svc := &PricingService{}
+	data, err := svc.parsePricingData([]byte(`{
+		"claude-opus-4-6": {
+			"input_cost_per_token": 5e-06,
+			"output_cost_per_token": 2.5e-05,
+			"cache_creation_input_token_cost": 6.25e-06,
+			"cache_creation_input_token_cost_above_1hr": 1e-05,
+			"cache_read_input_token_cost": 5e-07,
+			"litellm_provider": "anthropic",
+			"mode": "chat"
+		}
+	}`))
+	require.NoError(t, err)
+
+	billing := NewBillingService(&config.Config{}, &PricingService{pricingData: data})
+	pricing, err := billing.GetModelPricing("claude-opus-4-6")
+	require.NoError(t, err)
+	require.True(t, pricing.SupportsCacheBreakdown)
+	require.InDelta(t, 6.25e-6, pricing.CacheCreation5mPrice, 1e-15)
+	require.InDelta(t, 1e-5, pricing.CacheCreation1hPrice, 1e-15)
+
+	breakdown, err := billing.CalculateCost("claude-opus-4-6", UsageTokens{
+		CacheCreationTokens:   1000000,
+		CacheCreation5mTokens: 400000,
+		CacheCreation1hTokens: 600000,
+	}, 1.0)
+	require.NoError(t, err)
+	// 400000*6.25e-6 + 600000*1e-5 = 2.5 + 6.0
+	require.InDelta(t, 8.5, breakdown.CacheCreationCost, 1e-9)
 }

--- a/scripts/sentinels/newapi.json
+++ b/scripts/sentinels/newapi.json
@@ -299,6 +299,20 @@
         "applyTKPricingOverlay(result)"
       ],
       "rationale": "TK pricing overlay injection point inside parsePricingData — the single choke-point both the remote (Wei-Shaw) and disk-fallback load paths funnel through. The production price source is a TRIMMED litellm mirror that drops provider-prefixed keys and token-less media entries (and litellm itself lags new provider models like deepseek-v4-*), so those models resolve to nothing there; this fill-only overlay (companion pricing_service_tk_overlay.go, embedded tk_pricing_overlay.json) supplies the bare-name entries so per-image / per-second / per-token billing applies. If an upstream merge restructures parsePricingData and drops this one-line call, imagen silently reverts to the $0.134 default, veo to $0, and deepseek-v4-* to $0 (pricing_missing_record_zero_cost). The companion file's go:embed also makes the overlay JSON's presence build-enforced."
+    },
+    {
+      "path": "backend/internal/service/pricing_service_tk_overlay.go",
+      "must_contain": [
+        "p.CacheCreationInputTokenCostAbove1hr = *e.CacheCreationInputTokenCostAbove1hr"
+      ],
+      "rationale": "The overlay loader manually copies LiteLLMRawEntry fields into LiteLLMModelPricing; a missing copy is invisible at compile time and silently zeroes that price for every overlay-only model. This exact field was dropped once in prod: claude-fable-5 (absent from the trimmed runtime source, priced only by the overlay) billed all 1h cache-creation tokens at the 5m rate ($12.50/MTok instead of the official $20/MTok) because billing_service.go's breakdown predicate price1h>price5m saw price1h=0. Pinning the copy line keeps the 1h cache-write tier alive for any overlay entry carrying cache_creation_input_token_cost_above_1hr."
+    },
+    {
+      "path": "backend/internal/service/pricing_service_tk_overlay_test.go",
+      "must_contain": [
+        "TestBilling_Fable1hCacheCreationCost_ProdShape"
+      ],
+      "rationale": "Regression reproduction with the prod token shape (cache_creation_5m=0, cache_creation_1h=684124) asserting the corrected $13.68 cache-creation cost end-to-end through GetModelPricing + CalculateCost. Dropping this test re-opens the silent 5m-rate undercharge path for overlay-priced models with a 1h cache tier."
     }
   ]
 }


### PR DESCRIPTION
## 问题（prod 实测，2026-06-10）

`claude-fable-5` 成功请求的 cache_creation tokens 全部为 1h TTL（prod 实测一组：`cache_creation_5m_tokens=0, cache_creation_1h_tokens=684124`），但 `cache_creation_cost` 隐含单价 $12.50/MTok（5m 档），按官方牌价应为 $20/MTok（1h 档）——少计 ~37.5%（该组实例：计 $8.55，应 $13.68）。

根因：`loadTKPricingOverlay` 把 `LiteLLMRawEntry` 转 `LiteLLMModelPricing` 时漏拷 `CacheCreationInputTokenCostAbove1hr`（主解析路径 `pricing_service.go` 有拷，overlay 路径没拷）→ overlay-only 模型 price1h=0 → `billing_service.go` 的 breakdown 判定 `price1h>0 && price1h>price5m` 恒 false → `computeCacheCreationCost` 走 5m 平价。fable 不在 runtime 价格源（litellm 镜像滞后新模型），价格只能来自 overlay，路径无歧义。

## 修法（乔布斯决策：修唯一坏掉的管道）

- `pricing_service_tk_overlay.go` 补拷 3 行（nil-guard 与紧邻字段块逐字同形）。同时治好未来任何带 above_1hr 的 overlay 条目。
- **不动** billing_service.go / pricing_service.go / tk_pricing_overlay.json / fallback 价格表（fallback 全表统一 `SupportsCacheBreakdown:false` 是既有契约，live path 走 overlay）。
- opus 无此缺口（runtime 源自带 above_1hr、走主解析路径），不在范围。
- 涨价方向（对齐官方牌价 5m=$12.5 / 1h=$20），**不回溯**存量 usage_logs。
- `scripts/sentinels/newapi.json` +2 条目钉拷贝行与回归测试（registry-update-gate 强制）。

## 三层 e2e

1. **单测**（4 个新增全绿，红绿验证通过——stash 修复后测试确实变红）：overlay 字段断言（fable 1h 价 == 2e-5）、`GetModelPricing("claude-fable-5")` breakdown 生效（5m=1.25e-5 / 1h=2e-5）、prod 形状复现（5m=0、1h=684124 → $13.68248，修复前 $8.55155）、runtime 源 opus 对照不回归。
2. **本地验证**：`go test -tags=unit ./...` 全量绿；`golangci-lint run ./...` 0 issue；`bash scripts/preflight.sh` 绿。
3. **上线后 prod 实测 checklist**：
   - [x] 新 fable 流量在 `usage_logs` 验 1h 缓存写有效单价 ≈2e-5/token（`cache_creation_cost / cache_creation_1h_tokens`）
   - [x] 抽同期 opus-4-x 记录对照计费不回归
   - [x] 无新增 pricing 缺失/零成本记录

## 出 order 说明

TK 当前落后 upstream/main 18 commits；本 PR 为计费正确性止血，先行合入，upstream 合流由每日 upstream-merge agent 处理。

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
**上线后 prod 实测（v1.7.88，全部通过）**：部署后 fable 全部带 1h 缓存写的 usage_logs 行隐含单价精确 **$20.00/MTok**（抽样 12 行逐行验证，修复前为 $12.50）；opus 对照组（4-6/4-7/4-8 共 155 行）1h 单价 $10.00/MTok 与修复前一致，无回归。
