### PR TITLE
feat(ops/pricing): ARK_* direct-dataplane probe families for volcengine activation truth

### DIFF
--- a/.cursor/skills/tokenkey-servable-model-refresh/SKILL.md
+++ b/.cursor/skills/tokenkey-servable-model-refresh/SKILL.md
@@ -96,6 +96,29 @@ probe key 取自**绑定 `google` 组的 api_key**（`api_keys.group_id→groups
 4. 发版 → soak 回读确认零 $0 → **此时才**永久清空 `model_mapping` + `schedulable=true`
    （裸 SQL 后刷 `scheduler_outbox`，见 memory `gemini_media`）。
 
+## Volcengine / ark 三族（直连数据面，开通真值，免调度窗口）
+
+volcengine（newapi `channel_type=45`）模型的「有权限访问」检查**不走 TK 网关**，三族直打 ark 数据面：
+`ARK_CHAT_MODELS`→`/api/v3/chat/completions`、`ARK_IMAGE_MODELS`→`/api/v3/images/generations`、
+`ARK_VIDEO_MODELS`→`/api/v3/contents/generations/tasks`。凭据取自 `accounts.id=ARK_ACCOUNT_ID`
+（默认 7）的 `credentials.api_key/base_url`，**账号保持 `schedulable=false` 也能探**——零 prod
+配置改动、零客户暴露面。
+
+```bash
+bash ops/observability/run-probe.sh --target prod --script ops/pricing/probe-servable-models.sh \
+  --env "ARK_CHAT_MODELS=doubao-seed-1-6-250615 kimi-k2-250711" --timeout-seconds 300
+```
+
+- **为什么直连**（2026-06-10 实证）：ark 的 `GET /api/v3/models` 是**平台目录非开通清单**（kimi/qwen
+  在列但调用全拒）；经 TK 网关探测时 ark 的 404 被 bridge 包成不透明 502 读不出语义。直连后判别确定：
+  **200=已开通；404 `InvalidEndpointOrModel.NotFound`=未开通/已下线（落 unsupported）；429/5xx=transient**。
+- **费用**：未开通模型的 404 免费；已开通模型 chat 仅 16 token、image 计 ~1 张、**video 会创建真实
+  付费任务**——video 族只对真要上架的模型探，别全量扫。
+- **结果不进 Go allowlist**：`refresh-servable-allowlist.py parse_results` 只认 anthropic/openai/gemini，
+  `volcengine` 行天然忽略（该 vendor 在公开目录是 passthrough）。本族是运营对账工具：输出与账号
+  `model_mapping` 做差集 → 未开通的从 mapping 清掉，已开通∩未定价的先补价再放行（对照 deepseek-v4
+  渠道定价样板，见 memory `volc_video_submit_200_and_ark_pricing_path`）。
+
 ## 判断要点 / 坑
 
 - **verdict 语义**：200=servable（留）；400/404+retired/not-found/"not supported when using

--- a/ops/pricing/probe-servable-models.sh
+++ b/ops/pricing/probe-servable-models.sh
@@ -154,7 +154,7 @@ body_video() { printf '{"model":"%s","prompt":"a small red ball rolling on a tab
 body_ark_video() { printf '{"model":"%s","content":[{"type":"text","text":"a small red ball rolling on a table --resolution 480p --duration 5"}]}' "$1"; }
 
 main() {
-	local akey okey gkey
+	local akey okey gkey arkacct arkkey arkbase
 	if [ -n "${ANTHROPIC_MODELS:-}" ]; then
 		akey="$($PSQL -c "SELECT credentials->>'api_key' FROM accounts WHERE id=$AACCT AND deleted_at IS NULL" | tr -d '[:space:]')"
 		if [ -z "$akey" ]; then
@@ -181,6 +181,9 @@ main() {
 		arkkey="$($PSQL -c "SELECT credentials->>'api_key' FROM accounts WHERE id=$arkacct AND deleted_at IS NULL" | tr -d '[:space:]')"
 		arkbase="$($PSQL -c "SELECT credentials->>'base_url' FROM accounts WHERE id=$arkacct AND deleted_at IS NULL" | tr -d '[:space:]')"
 		arkbase="${arkbase%/}"
+		# Mirror NormalizeArkChannelBaseURL (integration/newapi): operators commonly
+		# paste .../api/v3 into base_url; the data plane wants the host root.
+		arkbase="${arkbase%/api/v3}"
 		if [ -z "$arkkey" ] || [ -z "$arkbase" ]; then
 			emit volcengine "*" 000 "auth_error"
 		else

--- a/ops/pricing/probe-servable-models.sh
+++ b/ops/pricing/probe-servable-models.sh
@@ -14,7 +14,21 @@
 #   GEMINI_VIDEO_MODELS      -> POST app:8080/v1/video/generations (async submit; 200-on-submit=servable, best-effort)
 #     NB gemini families run ON the edge host and hit the app container directly
 #     (the edge Caddy 403s host-local /v1/* — it only allows the prod gateway CIDR).
+#   ARK_CHAT_MODELS          -> POST <ark>/api/v3/chat/completions  (DIRECT ark data plane)
+#   ARK_IMAGE_MODELS         -> POST <ark>/api/v3/images/generations (direct; a servable model bills ~1 image)
+#   ARK_VIDEO_MODELS         -> POST <ark>/api/v3/contents/generations/tasks (direct; a servable model creates a REAL paid video task — probe sparingly)
+#     NB ark families bypass the TK gateway entirely: credentials come from the
+#     accounts row id=ARK_ACCOUNT_ID, so NO schedulable window is needed and the
+#     account may stay disabled. This is the ACTIVATION-truth probe: ark's GET
+#     /api/v3/models is the platform CATALOG, not the activation list — a model
+#     can be listed there yet reject every call. Per-model classification
+#     (verified 2026-06-10 against prod account 7): 200 = activated; 404
+#     InvalidEndpointOrModel.NotFound "does not exist or you do not have access"
+#     = not activated / retired (-> unsupported via the does-not-exist match);
+#     429/5xx = transient (-> inconclusive). The TK-gateway probe path wraps that
+#     404 into an opaque 502, which is why these families talk to ark directly.
 # Optional env:
+#   ARK_ACCOUNT_ID           default 7   (accounts row holding the ark api_key + base_url)
 #   ANTHROPIC_EDGE_BASE      default https://api-us7.tokenkey.dev
 #   ANTHROPIC_KEY_ACCOUNT_ID default 54  (its credentials.api_key relays to the edge)
 #   PROD_BASE                default https://api.tokenkey.dev
@@ -135,6 +149,9 @@ body_chat() { printf '{"model":"%s","max_tokens":16,"messages":[{"role":"user","
 body_resp() { printf '{"model":"%s","instructions":"You are a helpful assistant.","input":[{"type":"message","role":"user","content":[{"type":"input_text","text":"Say OK"}]}],"stream":false}' "$1"; }
 body_img() { printf '{"model":"%s","prompt":"a small red circle on white","n":1,"size":"1024x1024"}' "$1"; }
 body_video() { printf '{"model":"%s","prompt":"a small red ball rolling on a table","seconds":"4"}' "$1"; }
+# ark create-task shape (seedance text commands ride inside the prompt text);
+# smallest billable settings so an activated model costs as little as possible.
+body_ark_video() { printf '{"model":"%s","content":[{"type":"text","text":"a small red ball rolling on a table --resolution 480p --duration 5"}]}' "$1"; }
 
 main() {
 	local akey okey gkey
@@ -154,6 +171,22 @@ main() {
 			[ -n "${OPENAI_CHAT_MODELS:-}" ] && probe_openai_endpoint "$okey" /v1/chat/completions "$OPENAI_CHAT_MODELS" body_chat
 			[ -n "${OPENAI_RESPONSES_MODELS:-}" ] && probe_openai_endpoint "$okey" /v1/responses "$OPENAI_RESPONSES_MODELS" body_resp
 			[ -n "${OPENAI_IMAGE_MODELS:-}" ] && probe_openai_endpoint "$okey" /v1/images/generations "$OPENAI_IMAGE_MODELS" body_img
+		fi
+	fi
+	# Ark families: DIRECT volcengine data-plane probe (activation truth). Bypasses
+	# the TK gateway — no schedulable window, the account row may stay disabled.
+	# 404 InvalidEndpointOrModel.NotFound = not activated (verdict: unsupported).
+	if [ -n "${ARK_CHAT_MODELS:-}${ARK_IMAGE_MODELS:-}${ARK_VIDEO_MODELS:-}" ]; then
+		arkacct="${ARK_ACCOUNT_ID:-7}"
+		arkkey="$($PSQL -c "SELECT credentials->>'api_key' FROM accounts WHERE id=$arkacct AND deleted_at IS NULL" | tr -d '[:space:]')"
+		arkbase="$($PSQL -c "SELECT credentials->>'base_url' FROM accounts WHERE id=$arkacct AND deleted_at IS NULL" | tr -d '[:space:]')"
+		arkbase="${arkbase%/}"
+		if [ -z "$arkkey" ] || [ -z "$arkbase" ]; then
+			emit volcengine "*" 000 "auth_error"
+		else
+			[ -n "${ARK_CHAT_MODELS:-}" ] && probe_compat_endpoint volcengine "$arkbase" "$arkkey" /api/v3/chat/completions "$ARK_CHAT_MODELS" body_chat
+			[ -n "${ARK_IMAGE_MODELS:-}" ] && probe_compat_endpoint volcengine "$arkbase" "$arkkey" /api/v3/images/generations "$ARK_IMAGE_MODELS" body_img
+			[ -n "${ARK_VIDEO_MODELS:-}" ] && probe_compat_endpoint volcengine "$arkbase" "$arkkey" /api/v3/contents/generations/tasks "$ARK_VIDEO_MODELS" body_ark_video
 		fi
 	fi
 	# Gemini family: newapi/Vertex models served through the google group on GEMINI_BASE.


### PR DESCRIPTION
## What

Adds three direct-ark probe families to `ops/pricing/probe-servable-models.sh`:

| env | endpoint |
|---|---|
| `ARK_CHAT_MODELS` | `POST <ark>/api/v3/chat/completions` |
| `ARK_IMAGE_MODELS` | `POST <ark>/api/v3/images/generations` |
| `ARK_VIDEO_MODELS` | `POST <ark>/api/v3/contents/generations/tasks` |

Credentials come from `accounts.id=ARK_ACCOUNT_ID` (default 7); the probe bypasses the TK gateway entirely, so **no schedulable window is needed** — the account stays disabled, zero prod config changes, zero customer exposure. Skill doc (`tokenkey-servable-model-refresh`) updated alongside.

## Why direct (verified 2026-06-10 against prod account 7)

- ark `GET /api/v3/models` is the platform **catalog**, not the activation list — kimi/qwen/wan2 are listed yet every invocation is rejected.
- Through the TK gateway, ark's `404 InvalidEndpointOrModel.NotFound` gets wrapped into an opaque 502, losing the activation signal (that's why the 2026-06-10 volcengine sweep read 69 inconclusive 502s).
- Direct classification is deterministic: **200 = activated (servable); 404 NotFound = not activated/retired (unsupported via the existing does-not-exist verdict match); 429/5xx = inconclusive**.

## Scope / non-goals

- `volcengine` TSV rows are ignored by `refresh-servable-allowlist.py parse_results` by design (the vendor is catalog-passthrough in the public catalog) — this is an **ops reconciliation family** (diff against account `model_mapping`, gate pricing before enablement), not allowlist input.
- Cost note documented in the script header: 404s are free; an activated chat probe costs 16 tokens, image ~1 image, **video creates a real paid task** — probe video sparingly.

## Validation

End-to-end on prod via `run-probe.sh` with mixed expectations, all verdicts exact:

```
volcengine  doubao-seed-1-6-250615          200  servable
volcengine  kimi-k2-250711                  404  unsupported
volcengine  doubao-seedream-3-0-t2i-250415  404  unsupported
volcengine  wan2-1-14b-t2v-250225           404  unsupported
```

`bash -n` clean; `refresh-servable-allowlist.py selftest` PASS; local preflight PASS.

no-web-impact

🤖 Generated with [Claude Code](https://claude.com/claude-code)