### PR TITLE
feat(rates): 非 admin 用户页面不再下发专属倍率值

### DIFF
--- a/backend/internal/handler/api_key_handler.go
+++ b/backend/internal/handler/api_key_handler.go
@@ -301,6 +301,12 @@ func (h *APIKeyHandler) GetUserGroupRates(c *gin.Context) {
 		return
 	}
 
+	// TK: 非 admin 用户不下发专属倍率值（见 api_key_handler_tk_rate_visibility.go）
+	if tkHideUserRateValues(c) {
+		response.Success(c, map[int64]float64{})
+		return
+	}
+
 	rates, err := h.apiKeyService.GetUserGroupRates(c.Request.Context(), subject.UserID)
 	if err != nil {
 		response.ErrorFrom(c, err)

--- a/backend/internal/handler/api_key_handler_tk_rate_visibility.go
+++ b/backend/internal/handler/api_key_handler_tk_rate_visibility.go
@@ -1,0 +1,29 @@
+package handler
+
+// TK: 专属倍率值仅对 admin 可见。
+//
+// 运营场景：管理员给客户配置了 per-user 专属倍率（折扣/加价），但不希望
+// 客户在自己的页面（API 密钥徽章、分组选择器、可用渠道、模型价格提示）
+// 看到倍率数值。计费路径不受影响——gateway 计费仍按真实生效倍率执行，
+// 这里只收敛"展示端点"的下发内容。
+//
+// 注入点（均为 thin hook）：
+//   - GetUserGroupRates (api_key_handler.go)：非 admin 返回空 map。
+//   - MePricingCatalogHandler.Get (me_pricing_catalog_handler_tk.go)：
+//     置 opts.HideUserRateOverrides，catalog 的倍率提示回落到分组默认值。
+
+import (
+	"github.com/Wei-Shaw/sub2api/internal/domain"
+	middleware2 "github.com/Wei-Shaw/sub2api/internal/server/middleware"
+
+	"github.com/gin-gonic/gin"
+)
+
+// tkHideUserRateValues reports whether per-user rate override values must be
+// hidden from the current requester. Hidden for everyone except admin; a
+// missing role in context (should not happen on authenticated routes) also
+// hides, failing closed.
+func tkHideUserRateValues(c *gin.Context) bool {
+	role, ok := middleware2.GetUserRoleFromContext(c)
+	return !ok || role != domain.RoleAdmin
+}

--- a/backend/internal/handler/api_key_handler_tk_rate_visibility_test.go
+++ b/backend/internal/handler/api_key_handler_tk_rate_visibility_test.go
@@ -1,0 +1,80 @@
+//go:build unit
+
+package handler
+
+import (
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+
+	"github.com/Wei-Shaw/sub2api/internal/server/middleware"
+	"github.com/Wei-Shaw/sub2api/internal/service"
+
+	"github.com/gin-gonic/gin"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func newGroupRatesRouter(t *testing.T, svc *service.APIKeyService, role string) *gin.Engine {
+	t.Helper()
+	gin.SetMode(gin.TestMode)
+	h := NewAPIKeyHandler(svc)
+	r := gin.New()
+	r.GET("/api/v1/groups/rates", func(c *gin.Context) {
+		c.Set(string(middleware.ContextKeyUser), middleware.AuthSubject{UserID: 42})
+		if role != "" {
+			c.Set(string(middleware.ContextKeyUserRole), role)
+		}
+		h.GetUserGroupRates(c)
+	})
+	return r
+}
+
+// 非 admin（含 role 缺失）必须拿到空 map，且不触达 service —— 传入 nil
+// service 仍 200 即证明短路生效。
+func TestGetUserGroupRates_HiddenForNonAdmin(t *testing.T) {
+	for _, role := range []string{"user", ""} {
+		r := newGroupRatesRouter(t, nil, role)
+		req := httptest.NewRequest(http.MethodGet, "/api/v1/groups/rates", nil)
+		w := httptest.NewRecorder()
+		r.ServeHTTP(w, req)
+		require.Equal(t, http.StatusOK, w.Code, "role=%q", role)
+
+		var resp struct {
+			Data map[int64]float64 `json:"data"`
+		}
+		require.NoError(t, json.Unmarshal(w.Body.Bytes(), &resp))
+		assert.Empty(t, resp.Data, "role=%q", role)
+	}
+}
+
+// admin 走原路径（零值 service 的 userGroupRateRepo 为 nil → data 为 null），
+// 关键断言是没有被非 admin 短路成空 map 之外的行为且不 panic。
+func TestGetUserGroupRates_AdminReachesService(t *testing.T) {
+	r := newGroupRatesRouter(t, &service.APIKeyService{}, "admin")
+	req := httptest.NewRequest(http.MethodGet, "/api/v1/groups/rates", nil)
+	w := httptest.NewRecorder()
+	r.ServeHTTP(w, req)
+	require.Equal(t, http.StatusOK, w.Code)
+}
+
+func TestTkHideUserRateValues(t *testing.T) {
+	gin.SetMode(gin.TestMode)
+	cases := []struct {
+		role string
+		set  bool
+		hide bool
+	}{
+		{role: "admin", set: true, hide: false},
+		{role: "user", set: true, hide: true},
+		{set: false, hide: true},
+	}
+	for _, tc := range cases {
+		c, _ := gin.CreateTestContext(httptest.NewRecorder())
+		if tc.set {
+			c.Set(string(middleware.ContextKeyUserRole), tc.role)
+		}
+		assert.Equal(t, tc.hide, tkHideUserRateValues(c), "role=%q set=%v", tc.role, tc.set)
+	}
+}

--- a/backend/internal/handler/me_pricing_catalog_handler_tk.go
+++ b/backend/internal/handler/me_pricing_catalog_handler_tk.go
@@ -69,6 +69,8 @@ func (h *MePricingCatalogHandler) Get(c *gin.Context) {
 	if !ok {
 		return
 	}
+	// TK: 非 admin 用户不下发专属倍率值（见 api_key_handler_tk_rate_visibility.go）
+	opts.HideUserRateOverrides = tkHideUserRateValues(c)
 
 	if h == nil || h.svc == nil {
 		response.InternalError(c, "pricing service unavailable")

--- a/backend/internal/handler/me_pricing_catalog_handler_tk_test.go
+++ b/backend/internal/handler/me_pricing_catalog_handler_tk_test.go
@@ -172,3 +172,36 @@ func TestMePricingHandler_GenericErrorIs500(t *testing.T) {
 	r.ServeHTTP(w, req)
 	assert.Equal(t, http.StatusInternalServerError, w.Code)
 }
+
+// TK: 非 admin（含 role 缺失）请求必须置位 HideUserRateOverrides；admin 不置位。
+func TestMePricingHandler_HideUserRateOverridesByRole(t *testing.T) {
+	cases := []struct {
+		name string
+		role string
+		hide bool
+	}{
+		{name: "admin sees overrides", role: "admin", hide: false},
+		{name: "user hidden", role: "user", hide: true},
+		{name: "missing role hidden", role: "", hide: true},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			svc := &fakeMePricingSvc{resp: &service.MePricingCatalogResponse{}}
+			gin.SetMode(gin.TestMode)
+			h := &MePricingCatalogHandler{svc: svc}
+			r := gin.New()
+			r.GET("/api/v1/me/pricing-catalog", func(c *gin.Context) {
+				c.Set(string(middleware.ContextKeyUser), middleware.AuthSubject{UserID: 42})
+				if tc.role != "" {
+					c.Set(string(middleware.ContextKeyUserRole), tc.role)
+				}
+				h.Get(c)
+			})
+			req := httptest.NewRequest(http.MethodGet, "/api/v1/me/pricing-catalog", nil)
+			w := httptest.NewRecorder()
+			r.ServeHTTP(w, req)
+			require.Equal(t, http.StatusOK, w.Code)
+			assert.Equal(t, tc.hide, svc.seenOpt.HideUserRateOverrides)
+		})
+	}
+}

--- a/backend/internal/service/me_pricing_catalog_tk.go
+++ b/backend/internal/service/me_pricing_catalog_tk.go
@@ -123,6 +123,11 @@ func NewMePricingCatalogService(
 type MePricingCatalogOptions struct {
 	APIKeyID *int64
 	GroupID  *int64
+	// HideUserRateOverrides 隐藏 per-user 专属倍率的"数值痕迹"：倍率提示
+	// 字段（rate_multiplier / has_override / accessible_groups 的倍率）回落
+	// 到分组默认值，但 models 的 your_price 仍按真实生效倍率计算——价格
+	// 必须与实际计费一致。非 admin 请求由 handler 置位。
+	HideUserRateOverrides bool
 }
 
 // MePricingCatalogResponse is the top-level DTO returned to the user UI.
@@ -297,12 +302,21 @@ func (s *MePricingCatalogService) BuildForUser(
 
 	models := s.buildModelsForGroup(ctx, targetGroup, effective)
 
+	// HideUserRateOverrides：倍率提示字段回落到分组默认值（your_price 已按
+	// 真实 effective 计算完毕，不回滚——价格必须与实际计费一致）。
+	shownRate := effective
+	shownOverride := hasOverride
+	if opts.HideUserRateOverrides {
+		shownRate = listMult
+		shownOverride = false
+	}
+
 	// Build picker DTO for accessible_groups with effective rate per group.
 	groupRefs := make([]MePricingGroupRef, 0, len(accessibleGroups))
 	for i := range accessibleGroups {
 		g := accessibleGroups[i]
 		rate := g.RateMultiplier
-		if r, ok := userRates[g.ID]; ok {
+		if r, ok := userRates[g.ID]; ok && !opts.HideUserRateOverrides {
 			rate = r
 		}
 		groupRefs = append(groupRefs, MePricingGroupRef{
@@ -321,9 +335,9 @@ func (s *MePricingCatalogService) BuildForUser(
 			ID:               targetGroup.ID,
 			Name:             targetGroup.Name,
 			Platform:         targetGroup.Platform,
-			RateMultiplier:   effective,
+			RateMultiplier:   shownRate,
 			ListMultiplier:   listMult,
-			HasOverride:      hasOverride,
+			HasOverride:      shownOverride,
 			IsExclusive:      targetGroup.IsExclusive,
 			SubscriptionType: targetGroup.SubscriptionType,
 		},

--- a/scripts/sentinels/gateway-tk.json
+++ b/scripts/sentinels/gateway-tk.json
@@ -2065,6 +2065,13 @@
         "input.Body = tkStripFableDisabledThinking(StripEmptyTextBlocks(TkSanitizeRequestBody(input.Body, account)))"
       ],
       "rationale": "The three pre-send sanitize chains (main Forward ~4834, API-Key passthrough ~5526, count_tokens ~9922) must wrap the StripEmptyTextBlocks(TkSanitizeRequestBody(...)) combo with tkStripFableDisabledThinking so an explicit thinking.type=disabled never reaches upstream for fable models. An upstream merge that restores the bare two-function chain silently reverts the fix and fable+disabled requests 400 again. The replaceBody form covers both Forward and count_tokens; the input.Body form covers the passthrough path."
+    },
+    {
+      "path": "backend/internal/handler/api_key_handler.go",
+      "must_contain": [
+        "if tkHideUserRateValues(c) {"
+      ],
+      "rationale": "GetUserGroupRates (GET /groups/rates) must short-circuit to an empty map for non-admin requesters so per-user rate-override values never reach customer-facing pages (API key badges / group selector / available channels). The helper lives in api_key_handler_tk_rate_visibility.go (TK-owned); an upstream merge that restores the bare handler silently re-exposes every customer's negotiated multiplier."
     }
   ]
 }


### PR DESCRIPTION
## 背景

运营给客户配置 per-user 专属倍率（折扣/协议价）后，不希望客户在自己的页面上看到倍率数值。此前客户端三个表面都会显示：API 密钥徽章 / 分组选择器（删除线 + 专属倍率）、可用渠道页、模型价格页的「×N (个人覆写)」提示。

## 改动

**计费路径完全不动**——gateway 计费仍按真实生效倍率执行，只收敛展示端点的下发内容。

- `GET /groups/rates`：非 admin 请求短路返回空 map。注入点 4 行（upstream 文件 `api_key_handler.go`），helper 收敛在 TK companion `api_key_handler_tk_rate_visibility.go`，并新增 **gateway-tk sentinel** 锚定注入点，防 upstream merge 静默回退。
- `GET /me/pricing-catalog`（TK 自有）：非 admin 时 `rate_multiplier` / `has_override` / `accessible_groups` 倍率回落到分组默认值；`models[].your_price` 仍按真实生效倍率计算，与实际计费、使用记录一致。
- role 缺失按非 admin 处理（fail closed）。
- admin 自己的页面行为不变（仍可见专属倍率，便于自查）。

**前端零改动**：空 map / 默认倍率下，GroupBadge 与 PricingView 既有渲染逻辑自然隐藏专属倍率痕迹。

## 测试

- `go test -tags=unit ./...` 全绿
- 新增：`GET /groups/rates` 非 admin 空 map（nil service 仍 200 证明短路）/ admin 走原路径；me-pricing handler 按 role 置位 `HideUserRateOverrides`；`tkHideUserRateValues` 三态用例
- `golangci-lint run` 0 issues；`scripts/preflight.sh` PASS（含 gateway-tk sentinel 214/214）

🤖 Generated with [Claude Code](https://claude.com/claude-code)