### PR TITLE
feat(pricing): VolcEngine 渠道刷新 20 个实测可服务模型 + 官方定价 + ARK 直连探测族(含 #692)

### DIFF
--- a/.cursor/skills/tokenkey-servable-model-refresh/SKILL.md
+++ b/.cursor/skills/tokenkey-servable-model-refresh/SKILL.md
@@ -96,6 +96,29 @@ probe key 取自**绑定 `google` 组的 api_key**（`api_keys.group_id→groups
 4. 发版 → soak 回读确认零 $0 → **此时才**永久清空 `model_mapping` + `schedulable=true`
    （裸 SQL 后刷 `scheduler_outbox`，见 memory `gemini_media`）。
 
+## Volcengine / ark 三族（直连数据面，开通真值，免调度窗口）
+
+volcengine（newapi `channel_type=45`）模型的「有权限访问」检查**不走 TK 网关**，三族直打 ark 数据面：
+`ARK_CHAT_MODELS`→`/api/v3/chat/completions`、`ARK_IMAGE_MODELS`→`/api/v3/images/generations`、
+`ARK_VIDEO_MODELS`→`/api/v3/contents/generations/tasks`。凭据取自 `accounts.id=ARK_ACCOUNT_ID`
+（默认 7）的 `credentials.api_key/base_url`，**账号保持 `schedulable=false` 也能探**——零 prod
+配置改动、零客户暴露面。
+
+```bash
+bash ops/observability/run-probe.sh --target prod --script ops/pricing/probe-servable-models.sh \
+  --env "ARK_CHAT_MODELS=doubao-seed-1-6-250615 kimi-k2-250711" --timeout-seconds 300
+```
+
+- **为什么直连**（2026-06-10 实证）：ark 的 `GET /api/v3/models` 是**平台目录非开通清单**（kimi/qwen
+  在列但调用全拒）；经 TK 网关探测时 ark 的 404 被 bridge 包成不透明 502 读不出语义。直连后判别确定：
+  **200=已开通；404 `InvalidEndpointOrModel.NotFound`=未开通/已下线（落 unsupported）；429/5xx=transient**。
+- **费用**：未开通模型的 404 免费；已开通模型 chat 仅 16 token、image 计 ~1 张、**video 会创建真实
+  付费任务**——video 族只对真要上架的模型探，别全量扫。
+- **结果不进 Go allowlist**：`refresh-servable-allowlist.py parse_results` 只认 anthropic/openai/gemini，
+  `volcengine` 行天然忽略（该 vendor 在公开目录是 passthrough）。本族是运营对账工具：输出与账号
+  `model_mapping` 做差集 → 未开通的从 mapping 清掉，已开通∩未定价的先补价再放行（对照 deepseek-v4
+  渠道定价样板，见 memory `volc_video_submit_200_and_ark_pricing_path`）。
+
 ## 判断要点 / 坑
 
 - **verdict 语义**：200=servable（留）；400/404+retired/not-found/"not supported when using

--- a/backend/internal/service/tk_pricing_overlay.json
+++ b/backend/internal/service/tk_pricing_overlay.json
@@ -1,17 +1,17 @@
 {
   "_meta": {
     "note": "TK-owned pricing overlay for models the runtime price source lacks. fill-only: merged into PricingService AFTER any source load (Wei-Shaw remote OR disk fallback), and ONLY for keys the source does not already carry. The Wei-Shaw runtime mirror is a TRIMMED litellm mirror that drops provider-prefixed keys and token-less media entries, so imagen-*/veo-* resolve to nothing there; litellm itself also lags new provider models (deepseek-v4-*), which then bill $0. Media price = vertex_ai provider (TK media flow routes through Vertex ch41); falls back to gemini only when no vertex variant exists. Text price = provider official list price. Self-deprecating: the day the source carries a bare key natively, the source value wins and the entry below is ignored. fill-only cannot CORRECT wrong source prices (deepseek-chat/reasoner still carry the pre-V4 rate in the mirror) — use channel pricing (DB) for that.",
-    "provenance": "media: BerriAI/litellm model_prices_and_context_window.json, captured 2026-06-01; deepseek-v4-*: https://api-docs.deepseek.com/quick_start/pricing, captured 2026-06-04 (cache-hit input = cache_read; cache writes billed as normal input, no separate write fee)",
+    "provenance": "media: BerriAI/litellm model_prices_and_context_window.json, captured 2026-06-01; deepseek-v4-*: https://api-docs.deepseek.com/quick_start/pricing, captured 2026-06-04 (cache-hit input = cache_read; cache writes billed as normal input, no separate write fee); volcengine doubao-*/glm-4-7-251222: VolcEngine Ark official model-pricing page, captured 2026-06-10 (≤32K input tier, CNY/USD=7.3); glm-4.7 matches Zhipu official",
     "regen": "manual curation; no auto-sync (entries are few + slow-moving). If they proliferate, add provider-aware sync."
   },
   "claude-fable-5": {
     "litellm_provider": "anthropic",
     "mode": "chat",
-    "input_cost_per_token": 0.00001,
-    "output_cost_per_token": 0.00005,
-    "cache_creation_input_token_cost": 0.0000125,
-    "cache_creation_input_token_cost_above_1hr": 0.00002,
-    "cache_read_input_token_cost": 0.000001,
+    "input_cost_per_token": 1e-05,
+    "output_cost_per_token": 5e-05,
+    "cache_creation_input_token_cost": 1.25e-05,
+    "cache_creation_input_token_cost_above_1hr": 2e-05,
+    "cache_read_input_token_cost": 1e-06,
     "max_input_tokens": 1000000,
     "max_output_tokens": 128000,
     "max_tokens": 128000,
@@ -26,18 +26,18 @@
   "deepseek-v4-flash": {
     "litellm_provider": "deepseek",
     "mode": "chat",
-    "input_cost_per_token": 0.00000014,
-    "output_cost_per_token": 0.00000028,
-    "cache_read_input_token_cost": 0.0000000028,
+    "input_cost_per_token": 1.4e-07,
+    "output_cost_per_token": 2.8e-07,
+    "cache_read_input_token_cost": 2.8e-09,
     "supports_prompt_caching": true,
     "source": "https://api-docs.deepseek.com/quick_start/pricing (2026-06-04: in $0.14/M cache-miss, $0.0028/M cache-hit, out $0.28/M)"
   },
   "deepseek-v4-pro": {
     "litellm_provider": "deepseek",
     "mode": "chat",
-    "input_cost_per_token": 0.000000435,
-    "output_cost_per_token": 0.00000087,
-    "cache_read_input_token_cost": 0.000000003625,
+    "input_cost_per_token": 4.35e-07,
+    "output_cost_per_token": 8.7e-07,
+    "cache_read_input_token_cost": 3.625e-09,
     "supports_prompt_caching": true,
     "source": "https://api-docs.deepseek.com/quick_start/pricing (2026-06-04: in $0.435/M cache-miss, $0.003625/M cache-hit, out $0.87/M)"
   },
@@ -130,5 +130,181 @@
     "mode": "video_generation",
     "output_cost_per_second": 0.05,
     "source": "litellm:gemini/veo-3.1-lite-generate-preview"
+  },
+  "doubao-seed-2-0-pro-260215": {
+    "litellm_provider": "volcengine",
+    "mode": "chat",
+    "input_cost_per_token": 4.38356164384e-07,
+    "output_cost_per_token": 2.19178082192e-06,
+    "cache_read_input_token_cost": 8.76712328767e-08,
+    "supports_prompt_caching": true,
+    "source": "VolcEngine Ark official (2026-06-10, ≤32K input tier): in ¥3.2/M, out ¥16/M, cache-hit ¥0.64/M; CNY/USD=7.3"
+  },
+  "doubao-seed-2-0-code-preview-260215": {
+    "litellm_provider": "volcengine",
+    "mode": "chat",
+    "input_cost_per_token": 4.38356164384e-07,
+    "output_cost_per_token": 2.19178082192e-06,
+    "cache_read_input_token_cost": 8.76712328767e-08,
+    "supports_prompt_caching": true,
+    "source": "VolcEngine Ark official (2026-06-10, ≤32K input tier): in ¥3.2/M, out ¥16/M, cache-hit ¥0.64/M; CNY/USD=7.3"
+  },
+  "doubao-seed-2-0-lite-260215": {
+    "litellm_provider": "volcengine",
+    "mode": "chat",
+    "input_cost_per_token": 8.21917808219e-08,
+    "output_cost_per_token": 4.93150684932e-07,
+    "cache_read_input_token_cost": 1.64383561644e-08,
+    "supports_prompt_caching": true,
+    "source": "VolcEngine Ark official (2026-06-10, ≤32K input tier): in ¥0.6/M, out ¥3.6/M, cache-hit ¥0.12/M; CNY/USD=7.3"
+  },
+  "doubao-seed-2-0-lite-260428": {
+    "litellm_provider": "volcengine",
+    "mode": "chat",
+    "input_cost_per_token": 8.21917808219e-08,
+    "output_cost_per_token": 4.93150684932e-07,
+    "cache_read_input_token_cost": 1.64383561644e-08,
+    "supports_prompt_caching": true,
+    "source": "VolcEngine Ark official (2026-06-10, ≤32K input tier): in ¥0.6/M, out ¥3.6/M, cache-hit ¥0.12/M; CNY/USD=7.3"
+  },
+  "doubao-seed-2-0-mini-260215": {
+    "litellm_provider": "volcengine",
+    "mode": "chat",
+    "input_cost_per_token": 2.7397260274e-08,
+    "output_cost_per_token": 2.7397260274e-07,
+    "cache_read_input_token_cost": 5.47945205479e-09,
+    "supports_prompt_caching": true,
+    "source": "VolcEngine Ark official (2026-06-10, ≤32K input tier): in ¥0.2/M, out ¥2/M, cache-hit ¥0.04/M; CNY/USD=7.3"
+  },
+  "doubao-seed-2-0-mini-260428": {
+    "litellm_provider": "volcengine",
+    "mode": "chat",
+    "input_cost_per_token": 2.7397260274e-08,
+    "output_cost_per_token": 2.7397260274e-07,
+    "cache_read_input_token_cost": 5.47945205479e-09,
+    "supports_prompt_caching": true,
+    "source": "VolcEngine Ark official (2026-06-10, ≤32K input tier): in ¥0.2/M, out ¥2/M, cache-hit ¥0.04/M; CNY/USD=7.3"
+  },
+  "doubao-seed-1-8-251228": {
+    "litellm_provider": "volcengine",
+    "mode": "chat",
+    "input_cost_per_token": 1.09589041096e-07,
+    "output_cost_per_token": 1.09589041096e-06,
+    "cache_read_input_token_cost": 2.19178082192e-08,
+    "supports_prompt_caching": true,
+    "source": "VolcEngine Ark official (2026-06-10, ≤32K input tier): in ¥0.8/M, out ¥8/M, cache-hit ¥0.16/M; CNY/USD=7.3"
+  },
+  "doubao-seed-1-6-250615": {
+    "litellm_provider": "volcengine",
+    "mode": "chat",
+    "input_cost_per_token": 1.09589041096e-07,
+    "output_cost_per_token": 1.09589041096e-06,
+    "cache_read_input_token_cost": 2.19178082192e-08,
+    "supports_prompt_caching": true,
+    "source": "VolcEngine Ark official (2026-06-10, ≤32K input tier): in ¥0.8/M, out ¥8/M, cache-hit ¥0.16/M; CNY/USD=7.3"
+  },
+  "doubao-seed-1-6-251015": {
+    "litellm_provider": "volcengine",
+    "mode": "chat",
+    "input_cost_per_token": 1.09589041096e-07,
+    "output_cost_per_token": 1.09589041096e-06,
+    "cache_read_input_token_cost": 2.19178082192e-08,
+    "supports_prompt_caching": true,
+    "source": "VolcEngine Ark official (2026-06-10, ≤32K input tier): in ¥0.8/M, out ¥8/M, cache-hit ¥0.16/M; CNY/USD=7.3"
+  },
+  "doubao-seed-1-6-flash-250615": {
+    "litellm_provider": "volcengine",
+    "mode": "chat",
+    "input_cost_per_token": 2.05479452055e-08,
+    "output_cost_per_token": 2.05479452055e-07,
+    "cache_read_input_token_cost": 4.1095890411e-09,
+    "supports_prompt_caching": true,
+    "source": "VolcEngine Ark official (2026-06-10, ≤32K input tier): in ¥0.15/M, out ¥1.5/M, cache-hit ¥0.03/M; CNY/USD=7.3"
+  },
+  "doubao-seed-1-6-flash-250828": {
+    "litellm_provider": "volcengine",
+    "mode": "chat",
+    "input_cost_per_token": 2.05479452055e-08,
+    "output_cost_per_token": 2.05479452055e-07,
+    "cache_read_input_token_cost": 4.1095890411e-09,
+    "supports_prompt_caching": true,
+    "source": "VolcEngine Ark official (2026-06-10, ≤32K input tier): in ¥0.15/M, out ¥1.5/M, cache-hit ¥0.03/M; CNY/USD=7.3"
+  },
+  "doubao-seed-1-6-vision-250815": {
+    "litellm_provider": "volcengine",
+    "mode": "chat",
+    "input_cost_per_token": 1.09589041096e-07,
+    "output_cost_per_token": 1.09589041096e-06,
+    "cache_read_input_token_cost": 2.19178082192e-08,
+    "supports_prompt_caching": true,
+    "source": "VolcEngine Ark official (2026-06-10, ≤32K input tier): in ¥0.8/M, out ¥8/M, cache-hit ¥0.16/M; CNY/USD=7.3"
+  },
+  "doubao-seed-character-251128": {
+    "litellm_provider": "volcengine",
+    "mode": "chat",
+    "input_cost_per_token": 1.09589041096e-07,
+    "output_cost_per_token": 2.7397260274e-07,
+    "cache_read_input_token_cost": 2.19178082192e-08,
+    "supports_prompt_caching": true,
+    "source": "VolcEngine Ark official (2026-06-10, ≤32K input tier): in ¥0.8/M, out ¥2/M, cache-hit ¥0.16/M; CNY/USD=7.3"
+  },
+  "doubao-seed-code-preview-251028": {
+    "litellm_provider": "volcengine",
+    "mode": "chat",
+    "input_cost_per_token": 1.64383561644e-07,
+    "output_cost_per_token": 1.09589041096e-06,
+    "cache_read_input_token_cost": 3.28767123288e-08,
+    "supports_prompt_caching": true,
+    "source": "VolcEngine Ark official (2026-06-10, ≤32K input tier): in ¥1.2/M, out ¥8/M, cache-hit ¥0.24/M; CNY/USD=7.3"
+  },
+  "doubao-1-5-pro-32k-250115": {
+    "litellm_provider": "volcengine",
+    "mode": "chat",
+    "input_cost_per_token": 1.09589041096e-07,
+    "output_cost_per_token": 2.7397260274e-07,
+    "cache_read_input_token_cost": 2.19178082192e-08,
+    "supports_prompt_caching": true,
+    "source": "VolcEngine Ark official (2026-06-10, ≤32K input tier): in ¥0.8/M, out ¥2/M, cache-hit ¥0.16/M; CNY/USD=7.3"
+  },
+  "doubao-1-5-pro-32k-character-250715": {
+    "litellm_provider": "volcengine",
+    "mode": "chat",
+    "input_cost_per_token": 1.09589041096e-07,
+    "output_cost_per_token": 2.7397260274e-07,
+    "cache_read_input_token_cost": 2.19178082192e-08,
+    "supports_prompt_caching": true,
+    "source": "VolcEngine Ark official (2026-06-10, ≤32K input tier): in ¥0.8/M, out ¥2/M, cache-hit ¥0.16/M; CNY/USD=7.3"
+  },
+  "doubao-1-5-lite-32k-250115": {
+    "litellm_provider": "volcengine",
+    "mode": "chat",
+    "input_cost_per_token": 4.1095890411e-08,
+    "output_cost_per_token": 8.21917808219e-08,
+    "cache_read_input_token_cost": 8.21917808219e-09,
+    "supports_prompt_caching": true,
+    "source": "VolcEngine Ark official (2026-06-10, ≤32K input tier): in ¥0.3/M, out ¥0.6/M, cache-hit ¥0.06/M; CNY/USD=7.3"
+  },
+  "doubao-1-5-vision-pro-32k-250115": {
+    "litellm_provider": "volcengine",
+    "mode": "chat",
+    "input_cost_per_token": 4.1095890411e-07,
+    "output_cost_per_token": 1.23287671233e-06,
+    "source": "VolcEngine Ark official (2026-06-10, ≤32K input tier): in ¥3/M, out ¥9/M; CNY/USD=7.3"
+  },
+  "doubao-seed-translation-250915": {
+    "litellm_provider": "volcengine",
+    "mode": "chat",
+    "input_cost_per_token": 1.64383561644e-07,
+    "output_cost_per_token": 4.93150684932e-07,
+    "source": "VolcEngine Ark official (2026-06-10, ≤32K input tier): in ¥1.2/M, out ¥3.6/M; CNY/USD=7.3"
+  },
+  "glm-4-7-251222": {
+    "litellm_provider": "volcengine",
+    "mode": "chat",
+    "input_cost_per_token": 4.1095890411e-07,
+    "output_cost_per_token": 1.91780821918e-06,
+    "cache_read_input_token_cost": 8.21917808219e-08,
+    "supports_prompt_caching": true,
+    "source": "VolcEngine Ark official (2026-06-10, ≤32K input tier): in ¥3/M, out ¥14/M, cache-hit ¥0.6/M; CNY/USD=7.3"
   }
 }

--- a/backend/migrations/tk_020_volcengine_servable_refresh.sql
+++ b/backend/migrations/tk_020_volcengine_servable_refresh.sql
@@ -1,0 +1,90 @@
+-- Migration: tk_020_volcengine_servable_refresh
+--
+-- Refresh the VolcEngine newapi channel (account id=7, platform=newapi,
+-- channel_type=45) advertised model set, and re-enable it.
+--
+-- Background / incident:
+--   account 7 "volcengine" advertised ~70 stale model IDs in
+--   credentials.model_mapping. Almost all were either never 开通 (activated) on
+--   the underlying VolcEngine Ark account or already 下线 (retired), so every
+--   client request returned ark `404 InvalidEndpointOrModel.NotFound`. The
+--   newapi bridge swallows that upstream status code and wraps it as a bare
+--   502 (ops_error_logs: error_phase=upstream, upstream_status_code=null),
+--   which spiked prod upstream_error_rate to ~30% and fired a P0 (2026-06-10).
+--   The account was manually set schedulable=false to stop the bleeding.
+--
+-- What was done:
+--   Probed VolcEngine Ark directly (DB base_url+api_key, bypassing the TK
+--   scheduling pool) for every model in ark /api/v3/models. 36 returned
+--   200/400 (servable), 83 returned a stable 404 (not 开通 / 下线). Re-tested
+--   for stability (zero transient).
+--
+-- Scope of THIS migration (batch 1 = 20 chat/text models, all priced):
+--   The 20 IDs below are the empirically-servable chat/text doubao + glm models,
+--   each given an official VolcEngine Ark price in tk_pricing_overlay.json
+--   (≤32K input tier, CNY/USD=7.3) so they bill non-zero (no #688
+--   pricing_missing). model_mapping is an identity whitelist (key===value); the
+--   keys are what this newapi channel advertises into the gateway and "My Menu".
+--
+-- Deliberately EXCLUDED (handled elsewhere / later):
+--   - deepseek-v4-flash/pro, deepseek-v3-2: served via the official DeepSeek
+--     direct channel (group 11, api.deepseek.com) at official rates. VolcEngine's
+--     own deepseek-v4-pro list price (¥12/¥24) is ~4x official, so serving it via
+--     this VolcEngine channel and billing at official rates would lose money.
+--   - embedding (doubao-embedding-vision) + media (seedream image, seedance
+--     video, 3D) — batch 2: embedding has dual text/image input pricing and media
+--     bills via RunImageRelay (per-image) / CalculateVideoCost (per-second), which
+--     need separate overlay fields + per-second rates.
+--
+-- Re-enable: this migration flips schedulable back to true. Prices ship in the
+-- same release (tk_pricing_overlay.json is a compile-time embed), so the 20
+-- models are priced the moment they become schedulable.
+--
+-- Raw-SQL account mutations bypass the Ent hooks that enqueue a scheduler
+-- snapshot refresh, so enqueue one scheduler_outbox `account_changed` event
+-- (same shape as tk_015) — otherwise running replicas keep the stale model_mapping
+-- until their next full snapshot reload.
+--
+-- Idempotent: re-running overwrites model_mapping with the same map, sets
+-- schedulable=true (already true), and enqueues one more refresh event.
+
+SET LOCAL lock_timeout = '5s';
+SET LOCAL statement_timeout = '10min';
+
+WITH upd AS (
+    UPDATE accounts
+    SET credentials = jsonb_set(
+            credentials,
+            '{model_mapping}',
+            '{
+                "doubao-seed-2-0-pro-260215": "doubao-seed-2-0-pro-260215",
+                "doubao-seed-2-0-code-preview-260215": "doubao-seed-2-0-code-preview-260215",
+                "doubao-seed-2-0-lite-260215": "doubao-seed-2-0-lite-260215",
+                "doubao-seed-2-0-lite-260428": "doubao-seed-2-0-lite-260428",
+                "doubao-seed-2-0-mini-260215": "doubao-seed-2-0-mini-260215",
+                "doubao-seed-2-0-mini-260428": "doubao-seed-2-0-mini-260428",
+                "doubao-seed-1-8-251228": "doubao-seed-1-8-251228",
+                "doubao-seed-1-6-250615": "doubao-seed-1-6-250615",
+                "doubao-seed-1-6-251015": "doubao-seed-1-6-251015",
+                "doubao-seed-1-6-flash-250615": "doubao-seed-1-6-flash-250615",
+                "doubao-seed-1-6-flash-250828": "doubao-seed-1-6-flash-250828",
+                "doubao-seed-1-6-vision-250815": "doubao-seed-1-6-vision-250815",
+                "doubao-seed-character-251128": "doubao-seed-character-251128",
+                "doubao-seed-code-preview-251028": "doubao-seed-code-preview-251028",
+                "doubao-1-5-pro-32k-250115": "doubao-1-5-pro-32k-250115",
+                "doubao-1-5-pro-32k-character-250715": "doubao-1-5-pro-32k-character-250715",
+                "doubao-1-5-lite-32k-250115": "doubao-1-5-lite-32k-250115",
+                "doubao-1-5-vision-pro-32k-250115": "doubao-1-5-vision-pro-32k-250115",
+                "doubao-seed-translation-250915": "doubao-seed-translation-250915",
+                "glm-4-7-251222": "glm-4-7-251222"
+            }'::jsonb
+        ),
+        schedulable = true,
+        updated_at = NOW()
+    WHERE id = 7
+      AND platform = 'newapi'
+      AND deleted_at IS NULL
+    RETURNING id
+)
+INSERT INTO scheduler_outbox (event_type, account_id, group_id, payload)
+SELECT 'account_changed', id, NULL, NULL FROM upd;

--- a/backend/migrations/tk_020_volcengine_servable_refresh.sql
+++ b/backend/migrations/tk_020_volcengine_servable_refresh.sql
@@ -81,8 +81,13 @@ WITH upd AS (
         ),
         schedulable = true,
         updated_at = NOW()
+    -- channel_type=45 guards cross-deployment blast radius: these migrations run
+    -- on every TK stack (prod, edges, local stage0), and a bare id can collide
+    -- with an unrelated account in another DB. Only the VolcEngine Ark adaptor
+    -- channel may match.
     WHERE id = 7
       AND platform = 'newapi'
+      AND channel_type = 45
       AND deleted_at IS NULL
     RETURNING id
 )

--- a/ops/pricing/probe-servable-models.sh
+++ b/ops/pricing/probe-servable-models.sh
@@ -154,7 +154,7 @@ body_video() { printf '{"model":"%s","prompt":"a small red ball rolling on a tab
 body_ark_video() { printf '{"model":"%s","content":[{"type":"text","text":"a small red ball rolling on a table --resolution 480p --duration 5"}]}' "$1"; }
 
 main() {
-	local akey okey gkey
+	local akey okey gkey arkacct arkkey arkbase
 	if [ -n "${ANTHROPIC_MODELS:-}" ]; then
 		akey="$($PSQL -c "SELECT credentials->>'api_key' FROM accounts WHERE id=$AACCT AND deleted_at IS NULL" | tr -d '[:space:]')"
 		if [ -z "$akey" ]; then
@@ -181,6 +181,9 @@ main() {
 		arkkey="$($PSQL -c "SELECT credentials->>'api_key' FROM accounts WHERE id=$arkacct AND deleted_at IS NULL" | tr -d '[:space:]')"
 		arkbase="$($PSQL -c "SELECT credentials->>'base_url' FROM accounts WHERE id=$arkacct AND deleted_at IS NULL" | tr -d '[:space:]')"
 		arkbase="${arkbase%/}"
+		# Mirror NormalizeArkChannelBaseURL (integration/newapi): operators commonly
+		# paste .../api/v3 into base_url; the data plane wants the host root.
+		arkbase="${arkbase%/api/v3}"
 		if [ -z "$arkkey" ] || [ -z "$arkbase" ]; then
 			emit volcengine "*" 000 "auth_error"
 		else

--- a/ops/pricing/probe-servable-models.sh
+++ b/ops/pricing/probe-servable-models.sh
@@ -14,7 +14,21 @@
 #   GEMINI_VIDEO_MODELS      -> POST app:8080/v1/video/generations (async submit; 200-on-submit=servable, best-effort)
 #     NB gemini families run ON the edge host and hit the app container directly
 #     (the edge Caddy 403s host-local /v1/* — it only allows the prod gateway CIDR).
+#   ARK_CHAT_MODELS          -> POST <ark>/api/v3/chat/completions  (DIRECT ark data plane)
+#   ARK_IMAGE_MODELS         -> POST <ark>/api/v3/images/generations (direct; a servable model bills ~1 image)
+#   ARK_VIDEO_MODELS         -> POST <ark>/api/v3/contents/generations/tasks (direct; a servable model creates a REAL paid video task — probe sparingly)
+#     NB ark families bypass the TK gateway entirely: credentials come from the
+#     accounts row id=ARK_ACCOUNT_ID, so NO schedulable window is needed and the
+#     account may stay disabled. This is the ACTIVATION-truth probe: ark's GET
+#     /api/v3/models is the platform CATALOG, not the activation list — a model
+#     can be listed there yet reject every call. Per-model classification
+#     (verified 2026-06-10 against prod account 7): 200 = activated; 404
+#     InvalidEndpointOrModel.NotFound "does not exist or you do not have access"
+#     = not activated / retired (-> unsupported via the does-not-exist match);
+#     429/5xx = transient (-> inconclusive). The TK-gateway probe path wraps that
+#     404 into an opaque 502, which is why these families talk to ark directly.
 # Optional env:
+#   ARK_ACCOUNT_ID           default 7   (accounts row holding the ark api_key + base_url)
 #   ANTHROPIC_EDGE_BASE      default https://api-us7.tokenkey.dev
 #   ANTHROPIC_KEY_ACCOUNT_ID default 54  (its credentials.api_key relays to the edge)
 #   PROD_BASE                default https://api.tokenkey.dev
@@ -135,6 +149,9 @@ body_chat() { printf '{"model":"%s","max_tokens":16,"messages":[{"role":"user","
 body_resp() { printf '{"model":"%s","instructions":"You are a helpful assistant.","input":[{"type":"message","role":"user","content":[{"type":"input_text","text":"Say OK"}]}],"stream":false}' "$1"; }
 body_img() { printf '{"model":"%s","prompt":"a small red circle on white","n":1,"size":"1024x1024"}' "$1"; }
 body_video() { printf '{"model":"%s","prompt":"a small red ball rolling on a table","seconds":"4"}' "$1"; }
+# ark create-task shape (seedance text commands ride inside the prompt text);
+# smallest billable settings so an activated model costs as little as possible.
+body_ark_video() { printf '{"model":"%s","content":[{"type":"text","text":"a small red ball rolling on a table --resolution 480p --duration 5"}]}' "$1"; }
 
 main() {
 	local akey okey gkey
@@ -154,6 +171,22 @@ main() {
 			[ -n "${OPENAI_CHAT_MODELS:-}" ] && probe_openai_endpoint "$okey" /v1/chat/completions "$OPENAI_CHAT_MODELS" body_chat
 			[ -n "${OPENAI_RESPONSES_MODELS:-}" ] && probe_openai_endpoint "$okey" /v1/responses "$OPENAI_RESPONSES_MODELS" body_resp
 			[ -n "${OPENAI_IMAGE_MODELS:-}" ] && probe_openai_endpoint "$okey" /v1/images/generations "$OPENAI_IMAGE_MODELS" body_img
+		fi
+	fi
+	# Ark families: DIRECT volcengine data-plane probe (activation truth). Bypasses
+	# the TK gateway — no schedulable window, the account row may stay disabled.
+	# 404 InvalidEndpointOrModel.NotFound = not activated (verdict: unsupported).
+	if [ -n "${ARK_CHAT_MODELS:-}${ARK_IMAGE_MODELS:-}${ARK_VIDEO_MODELS:-}" ]; then
+		arkacct="${ARK_ACCOUNT_ID:-7}"
+		arkkey="$($PSQL -c "SELECT credentials->>'api_key' FROM accounts WHERE id=$arkacct AND deleted_at IS NULL" | tr -d '[:space:]')"
+		arkbase="$($PSQL -c "SELECT credentials->>'base_url' FROM accounts WHERE id=$arkacct AND deleted_at IS NULL" | tr -d '[:space:]')"
+		arkbase="${arkbase%/}"
+		if [ -z "$arkkey" ] || [ -z "$arkbase" ]; then
+			emit volcengine "*" 000 "auth_error"
+		else
+			[ -n "${ARK_CHAT_MODELS:-}" ] && probe_compat_endpoint volcengine "$arkbase" "$arkkey" /api/v3/chat/completions "$ARK_CHAT_MODELS" body_chat
+			[ -n "${ARK_IMAGE_MODELS:-}" ] && probe_compat_endpoint volcengine "$arkbase" "$arkkey" /api/v3/images/generations "$ARK_IMAGE_MODELS" body_img
+			[ -n "${ARK_VIDEO_MODELS:-}" ] && probe_compat_endpoint volcengine "$arkbase" "$arkkey" /api/v3/contents/generations/tasks "$ARK_VIDEO_MODELS" body_ark_video
 		fi
 	fi
 	# Gemini family: newapi/Vertex models served through the google group on GEMINI_BASE.


### PR DESCRIPTION
> 本 PR 已合并 #692（ARK 直连探测族）；#692 已关闭，此处为唯一载体。

## 背景 / 事故

prod P0 告警 `upstream_error_rate 30.53% overall`(2026-06-10 03:27Z)。根因:账号 7「volcengine」(platform=newapi, channel_type=45)对外宣告 ~70 个**旧/已下线**模型 ID,客户请求打上去 ark 返 `404 InvalidEndpointOrModel.NotFound`,被 newapi bridge **吞掉错误码**包成裸 502(`ops_error_logs.error_phase=upstream, upstream_status_code=null`)→ 拉爆 upstream_error_rate。**非传输宕机、非 Anthropic/edge、非容量**。账号当时被手动 `schedulable=false` 止血。

## 实测

直连 ark(从 DB 读 base_url+api_key,**绕开 TK 调度池**)逐个探 `/api/v3/models` 全量:**36 可服务(200/400)/ 83 稳定 404(未开通/已下线)**,重测零 transient。

## Part 1: 数据修复(第一批 = 20 个 chat/text,价全锁)

- **`tk_020_volcengine_servable_refresh.sql`**:账号 7 `model_mapping` 刷成 20 个恒等白名单 + `schedulable=true` 重新启用 + `scheduler_outbox('account_changed')`(范式同 058/tk_015,raw-SQL 须刷 outbox 才 materialize)。
- **`tk_pricing_overlay.json`**:新增 20 条 VolcEngine Ark 官方价(≤32K input 档,CNY/USD=7.3,含缓存命中价),走公共目录 base 价路径,与 anthropic OAuth 模型同;避免零计费 / #688 缺价告警。

**20 个**:doubao-seed-2.0(pro/code/lite×2/mini×2)、seed-1.8、seed-1.6(×2/flash×2/vision)、seed-character、seed-code、doubao-1.5(pro/pro-character/lite/vision)、seed-translation、glm-4.7。

### 排除(归他处 / 第二批)

- **deepseek-v4-flash/pro、deepseek-v3-2**:由 group 11(`api.deepseek.com` 官方直连)按官方价服务。火山自家 deepseek-v4-pro 价 ¥12/¥24 ≈ 官方 4x,经火山服务再按官方计费会亏。
- **embedding**(doubao-embedding-vision,文本¥0.7/图片¥1.8 双输入)+ **图像**(seedream,`RunImageRelay` per-image)+ **视频**(seedance,`CalculateVideoCost` per-second)+ **3D** → 第二批(需 per-image/per-second 价 + 专门字段)。

## Part 2: ARK_* 直连探测族(原 #692)

为 `ops/pricing/probe-servable-models.sh` 新增三个直连 ark 探测族:

| env | endpoint |
|---|---|
| `ARK_CHAT_MODELS` | `POST <ark>/api/v3/chat/completions` |
| `ARK_IMAGE_MODELS` | `POST <ark>/api/v3/images/generations` |
| `ARK_VIDEO_MODELS` | `POST <ark>/api/v3/contents/generations/tasks` |

凭据来自 `accounts.id=ARK_ACCOUNT_ID`(默认 7),完全绕开 TK 网关——**无需可调度窗口**,账号保持 disabled,零 prod 配置变更,零客户暴露。skill 文档(`tokenkey-servable-model-refresh`)同步更新。

### 为什么直连(2026-06-10 prod 账号 7 实证)

- ark `GET /api/v3/models` 是平台**目录**而非开通清单——kimi/qwen/wan2 在目录里但每次调用都被拒。
- 经 TK 网关时 ark 的 `404 InvalidEndpointOrModel.NotFound` 被包成不透明 502,丢失开通信号(2026-06-10 火山扫描 69 个 inconclusive 502 即此因)。
- 直连分类确定性:**200 = 已开通(servable);404 NotFound = 未开通/已下线(unsupported);429/5xx = inconclusive**。

### Scope / non-goals

- `volcengine` TSV 行被 `refresh-servable-allowlist.py parse_results` 按设计忽略(该 vendor 在公共目录是 catalog-passthrough)——这是 **ops 对账族**(diff 账号 `model_mapping`、启用前 gate 定价),不是 allowlist 输入。
- 成本注记在脚本头:404 免费;开通的 chat 探测 16 tokens,image ~1 张,**video 会创建真实付费任务**——谨慎探测 video。

## 验证

- `go build ./...`(跨仓库)OK
- `go test -tags=unit ./internal/service/... ./internal/server/...` 全绿
- `scripts/preflight.sh` PASS(迁移不可变 + sentinel + no-web-impact + no-upstream-touch marker)
- overlay JSON 校验通过,既有条目值不变
- 探测脚本:`bash -n` clean;`refresh-servable-allowlist.py selftest` PASS;prod 端到端混合预期全部 verdict 精确(200 servable / 404 unsupported)

## 上线后复验(待 deploy)

- 重跑直连-ark 分桶,20 个应 servable
- gateway 日志无 `gateway_usage.pricing_missing_record_zero_cost` marker 对这 20 个触发
- usage_logs 计费金额非 0;upstream_error_rate 回落

## Checklist

- [x] `go test -tags=unit ./...`(service/server)通过
- [x] `go build ./...` 通过(跨仓库依赖编译)
- [x] 无 schema 变更(纯迁移 + overlay JSON + ops 脚本)
- [x] 纯后端:commit 含 `no-web-impact`
- [x] 未碰上游符号:commit 含 `no-upstream-touch`(tk_ 迁移 + tk_ overlay + ops 脚本,TK-only)
- [x] 迁移用新编号 tk_020,不改已应用迁移

🤖 Generated with [Claude Code](https://claude.com/claude-code)
