### PR TITLE
feat(admin): 账号列表与 Edge 账号列表展示 account ID 便于排查

### DIFF
--- a/backend/internal/web/dist/frontend-source.json
+++ b/backend/internal/web/dist/frontend-source.json
@@ -1,7 +1,7 @@
 {
   "algorithm": "sha256(git-ls-files:path,size,content)",
   "file_count": 462,
-  "hash": "76bb0c8686f6f93482d50c229a6e08c425c4191b8e8d9c6391cd9afc591727ed",
+  "hash": "997aee9eedb747d0315cc980289eff14350ff122b2fa019e75584f140fc3f125",
   "schema": 1,
   "source": "frontend/"
 }

--- a/frontend/src/i18n/locales/en.ts
+++ b/frontend/src/i18n/locales/en.ts
@@ -3160,6 +3160,7 @@ export default {
       stubPausedHint:
         'The prod-side stub for this edge is paused (关调度) — prod no longer routes traffic here, though the edge itself stays reachable.',
       cooldownRecovered: 'Recovered',
+      accountIdHint: "Account ID on this edge (edge-local database primary key), used to pinpoint it when troubleshooting",
       columns: {
         name: 'Name',
         platformType: 'Platform / Type',
@@ -3263,6 +3264,7 @@ export default {
       schedulableHint: 'Enable to include this account in API request scheduling',
       schedulableEnabled: 'Scheduling enabled',
       schedulableDisabled: 'Scheduling disabled',
+      accountIdHint: 'Account ID (database primary key), used to pinpoint this account when troubleshooting',
       failedToToggleSchedulable: 'Failed to toggle scheduling status',
       groupCountTotal: '{count} groups total',
       platforms: {

--- a/frontend/src/i18n/locales/zh.ts
+++ b/frontend/src/i18n/locales/zh.ts
@@ -3234,6 +3234,7 @@ export default {
       stubPaused: '调度已关闭',
       stubPausedHint: '该 edge 在 prod 侧的 stub 已关调度——prod 不再向其调度流量，但该 edge 本身仍可达。',
       cooldownRecovered: '已恢复',
+      accountIdHint: '该 edge 上账号的 ID（edge 本地数据库主键），排查问题时用于精确定位',
       columns: {
         name: '名称',
         platformType: '平台 / 类型',
@@ -3338,6 +3339,7 @@ export default {
       schedulableHint: '开启后账号参与API请求调度',
       schedulableEnabled: '调度已开启',
       schedulableDisabled: '调度已关闭',
+      accountIdHint: '账号 ID（数据库主键），排查问题时用于精确定位该账号',
       failedToToggleSchedulable: '切换调度状态失败',
       groupCountTotal: '共 {count} 个分组',
       columns: {

--- a/frontend/src/views/admin/AccountsView.vue
+++ b/frontend/src/views/admin/AccountsView.vue
@@ -194,6 +194,7 @@
           <template #cell-name="{ row, value }">
             <div class="flex flex-col">
               <span class="font-medium text-gray-900 dark:text-white">{{ value }}</span>
+              <span class="font-mono text-xs text-gray-400 dark:text-gray-500" :title="t('admin.accounts.accountIdHint')">ID: {{ row.id }}</span>
               <span
                 v-if="row.extra?.email_address || row.extra?.email || row.credentials?.email"
                 class="text-xs text-gray-500 dark:text-gray-400 truncate max-w-[200px]"

--- a/frontend/src/views/admin/EdgeAccountsView.vue
+++ b/frontend/src/views/admin/EdgeAccountsView.vue
@@ -208,6 +208,7 @@
                 <tr v-for="acct in edge.accounts" :key="acct.id" class="hover:bg-gray-50 dark:hover:bg-dark-700/40">
                   <td class="px-4 py-2 align-top">
                     <div class="font-medium text-gray-900 dark:text-white">{{ acct.name }}</div>
+                    <div class="font-mono text-xs text-gray-400 dark:text-gray-500" :title="t('admin.edgeAccounts.accountIdHint')">ID: {{ acct.id }}</div>
                     <div v-if="acct.error_message" class="mt-0.5 max-w-xs truncate text-xs text-red-500" :title="acct.error_message">
                       {{ acct.error_message }}
                     </div>

--- a/scripts/sentinels/frontend-tk.json
+++ b/scripts/sentinels/frontend-tk.json
@@ -554,6 +554,36 @@
         "concurrency = Math.max(0, concurrency || 0)"
       ],
       "rationale": "Same 0=unlimited concurrency guard as EditAccountModal, for the bulk-edit path (the third account-form surface). Anchors min=\"0\" + Math.max(0,…); without it a bulk update reverted by an upstream merge could neither set unlimited nor preserve a 0 and would clamp it back to 1. Keeps the 0=unlimited behavior consistent across single-edit / create / bulk-edit for every platform."
+    },
+    {
+      "path": "frontend/src/views/admin/AccountsView.vue",
+      "must_contain": [
+        ":title=\"t('admin.accounts.accountIdHint')\">ID: {{ row.id }}"
+      ],
+      "rationale": "PR #697: the account ID (database primary key) line under the name in the #cell-name template, used by operators to pinpoint an account when troubleshooting (cooldown attribution, SQL lookups, scheduler logs all key on id). A single one-line span on a large upstream-shaped view is exactly the kind of change an upstream merge silently drops while keeping the build green — without it operators are back to extra DB queries to map name→id. The literal pins both the i18n hint hook and the rendered row.id in one anchor."
+    },
+    {
+      "path": "frontend/src/views/admin/EdgeAccountsView.vue",
+      "must_contain": [
+        ":title=\"t('admin.edgeAccounts.accountIdHint')\">ID: {{ acct.id }}"
+      ],
+      "rationale": "PR #697: the edge-local account ID line under the name in the Edge Accounts overview table. The ID shown is the EDGE's own database primary key (data comes from each edge's /admin/accounts), NOT the prod account id — the i18n hint exists precisely to prevent that confusion during troubleshooting, so the anchor pins the hint hook together with the rendered acct.id. Same silent-drop risk as the AccountsView entry above; both surfaces must move in lockstep."
+    },
+    {
+      "path": "frontend/src/i18n/locales/en.ts",
+      "must_contain": [
+        "accountIdHint: 'Account ID (database primary key)",
+        "accountIdHint: \"Account ID on this edge (edge-local database primary key)"
+      ],
+      "rationale": "PR #697: English hover hints for the account ID line on /admin/accounts (admin.accounts.accountIdHint) and /admin/edge-accounts (admin.edgeAccounts.accountIdHint). The edge variant's 'edge-local database primary key' wording is load-bearing — it is the only place warning operators that edge account IDs are a different keyspace from prod's. Anchored as key + distinctive prefix (not full text) so copy edits stay cheap; locked in lockstep with the zh.ts counterpart below so an upstream locale merge cannot drop one language and leave a raw i18n path in the title attribute."
+    },
+    {
+      "path": "frontend/src/i18n/locales/zh.ts",
+      "must_contain": [
+        "accountIdHint: '账号 ID（数据库主键）",
+        "accountIdHint: '该 edge 上账号的 ID（edge 本地数据库主键）"
+      ],
+      "rationale": "PR #697: Chinese counterparts of the en.ts accountIdHint anchors above (admin.accounts.accountIdHint + admin.edgeAccounts.accountIdHint, the latter carrying the edge-local-keyspace warning). Moves in lockstep with en.ts so neither language silently regresses during an i18n upstream merge."
     }
   ]
 }


### PR DESCRIPTION
## 背景

排查问题时需按 account ID(数据库主键)精确定位账号,但 `/admin/accounts` 与 `/admin/edge-accounts` 列表此前只展示名称,需额外查询才能拿到 ID。

## 改动

两个页面「名称」单元格下方各新增一行 account ID:

- **`/admin/accounts`**(`AccountsView.vue`)— name 列下 `ID: {row.id}`
- **`/admin/edge-accounts`**(`EdgeAccountsView.vue`)— name 列下 `ID: {acct.id}`

样式 `font-mono text-xs text-gray-400`,不抢视觉、可直接复制;配 `accountIdHint` 悬浮提示(中英双语)。

> Edge 账号 ID 是**该 edge 本地库的主键**(数据来自各 edge 自己的 `/admin/accounts`),与 prod 库的账号 id 不是一套——提示文案已注明,避免排查时混淆。

纯前端展示改动,无接口 / 调度 / 计费变更。

## 验证

- `pnpm typecheck` ✅
- `pnpm lint:check` ✅(仅一个与本改动无关的既有 warning)
- `pnpm --dir frontend run build` 已重建嵌入 dist(`frontend-source.json`)
- `scripts/preflight.sh` ✅ PASS

## Upstream merge 覆写防护

`scripts/sentinels/frontend-tk.json` 新增 4 条 sentinel,把本 PR 的 4 处新增面全部锚定:

- `AccountsView.vue` — `:title="t('admin.accounts.accountIdHint')">ID: {{ row.id }}`(一条 literal 同时钉住 i18n hook 与 row.id 渲染)
- `EdgeAccountsView.vue` — 同上,edge-local 变体
- `en.ts` / `zh.ts` — 两个 `accountIdHint` 定义(key + 区分性前缀锚定,edge 变体的「edge 本地数据库主键」措辞是 load-bearing 警示),en/zh lockstep

未来 upstream merge 若静默吞掉任一行,本地 preflight 与 `upstream-merge-pr-shape` 门禁会直接 fail。

另含一个空的 `sentinel-registry-reviewed` marker 提交(破解首提交看不到自身 marker 的死锁)。

🤖 Generated with [Claude Code](https://claude.com/claude-code)
