### PR TITLE
fix(release): --quiet flag order in release-bump-and-tag.sh (broke first live release)

### DIFF
--- a/scripts/release-bump-and-tag.sh
+++ b/scripts/release-bump-and-tag.sh
@@ -100,9 +100,12 @@ trap cleanup EXIT
 
 echo "[release-bump-and-tag] creating ephemeral worktree: $WT_DIR (detached at origin/main)"
 git -C "$REPO_ROOT" fetch origin main --tags --quiet || { echo "[release-bump-and-tag] ERROR: fetch failed" >&2; exit 2; }
-git -C "$REPO_ROOT" worktree add --detach "$WT_DIR" origin/main --quiet
+# Options MUST precede positional args: git rejects a trailing `--quiet` after
+# the commit-ish / pathspec as an unknown pathspec (git 2.52: "pathspec
+# '--quiet' did not match any file"), which aborted the first live release run.
+git -C "$REPO_ROOT" worktree add --quiet --detach "$WT_DIR" origin/main
 # preflight (pre-commit hook) delegates generic checks to the dev-rules submodule.
-git -C "$WT_DIR" submodule update --init dev-rules --quiet
+git -C "$WT_DIR" submodule update --quiet --init dev-rules
 
 if [ "$ACTION" = "bump-and-tag" ]; then
   # Monotonic belt: the bump commit is pushed to origin/main BEFORE the tag


### PR DESCRIPTION
## What

`scripts/release-bump-and-tag.sh` placed `--quiet` **after** the positional args on two git invocations:

- `git worktree add --detach "$WT_DIR" origin/main --quiet` (line 103)
- `git submodule update --init dev-rules --quiet` (line 105)

git 2.52 parses the trailing `--quiet` as a pathspec and aborts: `pathspec '--quiet' did not match any file`. Options must precede positional args. Reordered both.

## Why it matters

This was the **first live use** of the script (added in #695) during the v1.7.89 release. Both lines failed in sequence, aborting the worktree-isolated bump before any VERSION write. The release was completed by hand-finishing the bump inside the ephemeral worktree (origin/main stayed clean throughout; `release-tag.sh` still gated the tag). Without this fix, every future release via the canonical path breaks.

## Scope

One file, options-before-positionals reorder + an explanatory comment. No behavior change beyond making the script run. Local preflight green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)