### PR TITLE
feat(ci): 确认型 marker 迁可变 PR 表面 + 本地 advisory + 收窄触发面

### DIFF
--- a/.github/workflows/marker-acknowledgement-pr.yml
+++ b/.github/workflows/marker-acknowledgement-pr.yml
@@ -1,0 +1,84 @@
+name: Marker Acknowledgement (PR surface)
+
+# Hard gate for the "acknowledgement marker" family on EVERY PR to main.
+#
+# Why this workflow exists (CLAUDE.md §5.y.1 evolution):
+#   The upstream-touch-* and sentinel-registry-reviewed markers used to be
+#   checked only in local pre-commit/preflight, against the *committed*
+#   range origin/main..HEAD. But pre-commit runs BEFORE the commit exists,
+#   so the marker can never be in range yet — a structural false deadlock
+#   that forced stash / empty-commit / force-push gymnastics on every benign
+#   PR that touched an upstream-shaped file (the #697 account-id display PR
+#   paid this tax twice).
+#
+#   Fix: the marker is acknowledgement, not a mechanical fact, so it belongs
+#   on the MUTABLE PR surface — the PR description — checked in CI. A failing
+#   check means "edit the PR body, re-run" (this workflow re-runs on `edited`),
+#   never "rewrite git history". Locally the same scripts run in advisory mode
+#   (MARKER_GATE_ADVISORY=1 in scripts/preflight.sh) so they inform without
+#   blocking. The mechanical sentinel ANCHOR verifiers (must_contain literals)
+#   are unchanged and still hard — this only moves the acknowledgement step.
+#
+#   Trigger narrowing also lives in the scripts: pure-insertion diffs
+#   (no deleted lines — cannot drop an upstream symbol) and i18n locale
+#   dictionaries are auto-accepted, so most benign PRs never need a marker.
+#
+# Marker tokens (put ONE in the PR description when the gate asks):
+#   upstream-touch-guarded / upstream-touch-trivial / upstream-merge /
+#   no-upstream-touch        — for the upstream-override gate
+#   sentinel-registry-reviewed                       — for the sentinel gate
+
+on:
+  pull_request:
+    # `edited` is essential: editing the PR body to add a marker must re-run
+    # this gate without a new push.
+    types: [opened, synchronize, reopened, edited]
+    branches: [main]
+
+permissions:
+  contents: read
+  pull-requests: read
+
+jobs:
+  validate:
+    runs-on: ubuntu-latest
+    steps:
+      # fetch-depth: 0 so PR base..head plumbing resolves. submodules are NOT
+      # needed: both scripts live in this repo (scripts/checks, scripts/sentinels).
+      - uses: actions/checkout@v6
+        with:
+          fetch-depth: 0
+          ref: ${{ github.event.pull_request.head.sha }}
+
+      - name: upstream-override marker (PR body)
+        env:
+          PR_BODY: ${{ github.event.pull_request.body }}
+        run: |
+          BASE_SHA='${{ github.event.pull_request.base.sha }}'
+          if [ ! -f ./scripts/checks/upstream-override-marker.py ]; then
+            echo "::error::scripts/checks/upstream-override-marker.py missing."
+            exit 1
+          fi
+          # HARD mode (no MARKER_GATE_ADVISORY). The checked-out HEAD is the PR
+          # head.sha, so the script's base...HEAD diff is the PR diff.
+          if ! python3 ./scripts/checks/upstream-override-marker.py --base "$BASE_SHA" --pr-body "$PR_BODY"; then
+            echo "::error::Upstream-override acknowledgement missing."
+            echo "::error::Add one of upstream-touch-guarded / upstream-touch-trivial / upstream-merge / no-upstream-touch to the PR description, then re-run (this gate re-runs on PR edit)."
+            exit 1
+          fi
+
+      - name: sentinel registry update gate (PR body)
+        env:
+          PR_BODY: ${{ github.event.pull_request.body }}
+        run: |
+          BASE_SHA='${{ github.event.pull_request.base.sha }}'
+          HEAD_SHA='${{ github.event.pull_request.head.sha }}'
+          if [ ! -f ./scripts/sentinels/check-registry-update-gate.py ]; then
+            echo "::error::scripts/sentinels/check-registry-update-gate.py missing."
+            exit 1
+          fi
+          if ! python3 ./scripts/sentinels/check-registry-update-gate.py --base "$BASE_SHA" --head "$HEAD_SHA" --pr-body "$PR_BODY"; then
+            echo "::error::Sentinel registry update gate failed."
+            echo "::error::Either update scripts/sentinels/*.json, or add sentinel-registry-reviewed to the PR description, then re-run."
+            exit 1
+          fi

--- a/.github/workflows/upstream-merge-pr-shape.yml
+++ b/.github/workflows/upstream-merge-pr-shape.yml
@@ -400,16 +400,20 @@ jobs:
           fi
 
       - name: Check 12 — sentinel registry update gate (PR diff ↔ registries coupled)
+        env:
+          PR_BODY: ${{ github.event.pull_request.body }}
         run: |
           # Preflight parity: scripts/sentinels/check-registry-update-gate.py — forces any
           # change to sentinel-covered or hotspot-listed sources to accompany a registry edit.
+          # --pr-body lets the review marker live on the mutable PR description (edit + re-run,
+          # no commit rewrite); same acceptance logic preflight runs in advisory mode locally.
           if [ ! -f ./scripts/sentinels/check-registry-update-gate.py ]; then
             echo "::error::scripts/sentinels/check-registry-update-gate.py missing."
             exit 1
           fi
           BASE_SHA='${{ github.event.pull_request.base.sha }}'
           HEAD_SHA='${{ github.event.pull_request.head.sha }}'
-          if ! python3 ./scripts/sentinels/check-registry-update-gate.py --base "$BASE_SHA" --head "$HEAD_SHA"; then
+          if ! python3 ./scripts/sentinels/check-registry-update-gate.py --base "$BASE_SHA" --head "$HEAD_SHA" --pr-body "$PR_BODY"; then
             echo "::error::Sentinel registry update gate failed."
             echo "::error::Changing load-bearing hotspots requires updating scripts/sentinels/*.json in the same PR."
             exit 1

--- a/scripts/checks/upstream-override-marker.py
+++ b/scripts/checks/upstream-override-marker.py
@@ -98,6 +98,11 @@ UPSTREAM_SHAPED_EXCLUDE = [
     re.compile(r"^frontend/src/constants/.*\.tk\.ts$"),
     re.compile(r"^frontend/src/api/admin/tk/"),
     re.compile(r"^frontend/src/__tests__/"),
+    # i18n locale dictionaries are append-heavy by nature: TK adds keys on
+    # nearly every feature PR, so requiring a marker on every touch is pure
+    # ceremony. Upstream-merge conflicts there are surfaced by the 3-way
+    # merge itself, not by this acknowledgement gate. Excluded outright.
+    re.compile(r"^frontend/src/i18n/locales/.*\.ts$"),
 ]
 
 MARKERS = [
@@ -136,12 +141,145 @@ def is_upstream_shaped(path: str) -> bool:
     return False
 
 
+def is_pure_insertion(base: str, files: list[str]) -> bool:
+    """True when EVERY given file's diff against base adds lines but deletes
+    none (`git diff --numstat` deleted-count == 0). A pure-insertion diff
+    cannot delete or rewrite an upstream symbol, so it carries no
+    upstream-merge revert risk and is treated as an implicit
+    `upstream-touch-trivial`.
+
+    Conservative: any file that is binary (`-` numstat), renamed (path not
+    matched verbatim), or missing from the numstat output fails the test and
+    falls through to the marker requirement.
+    """
+    if not files:
+        return False
+    out = subprocess.check_output(
+        ["git", "diff", "--numstat", f"{base}...HEAD", "--", *files],
+        text=True,
+    )
+    stat: dict[str, tuple[str, str]] = {}
+    for line in out.splitlines():
+        parts = line.split("\t")
+        if len(parts) != 3:
+            continue
+        added, deleted, path = parts
+        stat[path] = (added, deleted)
+    for f in files:
+        if f not in stat:
+            return False  # renamed / not found — be conservative
+        added, deleted = stat[f]
+        if added == "-" or deleted == "-":
+            return False  # binary — can't tell
+        if int(deleted) != 0:
+            return False
+    return True
+
+
+def decide(
+    upstream_files: list[str],
+    sentinel_touched: list[str],
+    pure_insertion: bool,
+    marker_text: str,
+) -> tuple[bool, str]:
+    """Pure verdict function (no git / IO) so the acceptance logic is unit
+    testable. Returns (ok, reason). Acceptance order:
+      1. no upstream-shaped paths touched
+      2. a sentinel registry was updated in the same PR
+      3. the diff is pure-insertion (implicit upstream-touch-trivial)
+      4. an explicit marker token appears in commit messages OR the PR body
+    """
+    if not upstream_files:
+        return True, "no upstream-shaped paths changed"
+    if sentinel_touched:
+        return True, "sentinel registry updated: " + ", ".join(sorted(sentinel_touched))
+    if pure_insertion:
+        return True, "pure-insertion diff (no deletions) — implicit upstream-touch-trivial"
+    for marker in MARKERS:
+        if marker in marker_text:
+            return True, f"marker '{marker}' present"
+    return False, "upstream-shaped paths changed without sentinel / marker / pure-insertion"
+
+
+def _print_failure(upstream_files: list[str], stream) -> None:
+    print("Upstream-shaped files in this PR:", file=stream)
+    for f in upstream_files[:30]:
+        print(f"  {f}", file=stream)
+    if len(upstream_files) > 30:
+        print(f"  ... and {len(upstream_files) - 30} more", file=stream)
+    print("", file=stream)
+    print("Fix (any one):", file=stream)
+    print("  (a) make the change pure-insertion (no deleted lines), OR", file=stream)
+    print("  (b) add one of these tokens to the PR description (mutable — no commit rewrite): "
+          + ", ".join(MARKERS) + ", OR", file=stream)
+    print("  (c) update one of scripts/sentinels/*.json with anchor(s) for the change.", file=stream)
+    print("", file=stream)
+    print("Marker semantics:", file=stream)
+    print("  upstream-touch-guarded — anchors are pinned in a sentinel registry", file=stream)
+    print("  upstream-touch-trivial — change has no upstream-merge revert risk", file=stream)
+    print("  upstream-merge         — this is the upstream-merge PR itself", file=stream)
+    print("  no-upstream-touch      — paths were misclassified; assert no upstream surface", file=stream)
+
+
+def run_selftest() -> int:
+    cases = [
+        # (upstream_files, sentinel_touched, pure_insertion, marker_text, expect_ok)
+        ([], [], False, "", True),                                   # nothing upstream
+        (["backend/internal/handler/x.go"], ["scripts/sentinels/newapi.json"], False, "", True),  # sentinel
+        (["frontend/src/views/admin/AccountsView.vue"], [], True, "", True),  # pure insertion
+        (["backend/internal/service/x.go"], [], False, "feat: ... upstream-touch-guarded ...", True),  # commit marker
+        (["backend/internal/service/x.go"], [], False, "no-upstream-touch in PR body", True),  # pr-body marker (same text channel)
+        (["backend/internal/service/x.go"], [], False, "", False),   # nothing → fail
+        (["backend/internal/service/x.go"], [], False, "guarded but not the token", False),  # near-miss
+    ]
+    failed = 0
+    for i, (uf, st, pure, txt, expect) in enumerate(cases):
+        ok, _ = decide(uf, st, pure, txt)
+        status = "PASS" if ok == expect else "FAIL"
+        if ok != expect:
+            failed += 1
+        print(f"  {status} case {i}: expect_ok={expect} got_ok={ok}")
+    # path classification: i18n excluded, view included, _tk_ excluded
+    cls = [
+        ("frontend/src/i18n/locales/en.ts", False),
+        ("frontend/src/views/admin/AccountsView.vue", True),
+        ("frontend/src/views/admin/EdgeAccountsView.vue", True),
+        ("backend/internal/service/foo_tk_bar.go", False),
+        ("backend/internal/service/foo.go", True),
+    ]
+    for path, expect in cls:
+        got = is_upstream_shaped(path)
+        status = "PASS" if got == expect else "FAIL"
+        if got != expect:
+            failed += 1
+        print(f"  {status} classify {path}: expect={expect} got={got}")
+    if failed:
+        print(f"upstream-override-marker selftest: {failed} case(s) FAILED", file=sys.stderr)
+        return 1
+    print("ok: upstream-override-marker selftest passed")
+    return 0
+
+
 def main() -> int:
     ap = argparse.ArgumentParser(description=__doc__)
     ap.add_argument("--base", default=os.environ.get("PREFLIGHT_BASE", "origin/main"))
     ap.add_argument("--quiet", action="store_true",
                     help="suppress success output (used by preflight wrapper)")
+    ap.add_argument("--pr-body", default="",
+                    help="PR description text; marker tokens here satisfy the gate "
+                         "(mutable surface — CI passes ${{ github.event.pull_request.body }})")
+    ap.add_argument("--selftest", action="store_true",
+                    help="run the pure-logic self-test and exit")
     args = ap.parse_args()
+
+    if args.selftest:
+        return run_selftest()
+
+    # Advisory mode: local pre-commit/pre-push cannot see the in-flight commit
+    # message or the PR body, so a hard block there is a structural false
+    # deadlock. Preflight sets MARKER_GATE_ADVISORY=1 → we compute and print
+    # guidance but never block. The hard gate runs in CI against the PR body.
+    advisory = bool(os.environ.get("MARKER_GATE_ADVISORY"))
 
     try:
         paths = changed_paths(args.base)
@@ -150,54 +288,36 @@ def main() -> int:
         return 2
 
     upstream_files = [p for p in paths if is_upstream_shaped(p)]
-    if not upstream_files:
-        if not args.quiet:
-            print("[check_upstream_override_marker] no upstream-shaped paths changed")
-        return 0
-
     sentinel_touched = [p for p in paths if SENTINEL_REGISTRY_RE.match(p)]
-    if sentinel_touched:
+
+    pure_insertion = False
+    if upstream_files and not sentinel_touched:
+        try:
+            pure_insertion = is_pure_insertion(args.base, upstream_files)
+        except subprocess.CalledProcessError as e:
+            print(f"FAIL: git diff --numstat failed: {e}", file=sys.stderr)
+            return 2
+
+    marker_text = args.pr_body or ""
+    if upstream_files and not sentinel_touched and not pure_insertion:
+        try:
+            marker_text += "\n" + commit_messages(args.base)
+        except subprocess.CalledProcessError as e:
+            print(f"FAIL: git log failed: {e}", file=sys.stderr)
+            return 2
+
+    ok, reason = decide(upstream_files, sentinel_touched, pure_insertion, marker_text)
+    if ok:
         if not args.quiet:
-            print(
-                "[check_upstream_override_marker] sentinel registry updated: "
-                + ", ".join(sorted(sentinel_touched))
-            )
+            print(f"[check_upstream_override_marker] {reason}")
         return 0
 
-    try:
-        msg = commit_messages(args.base)
-    except subprocess.CalledProcessError as e:
-        print(f"FAIL: git log failed: {e}", file=sys.stderr)
-        return 2
-
-    for marker in MARKERS:
-        if marker in msg:
-            if not args.quiet:
-                print(f"[check_upstream_override_marker] marker '{marker}' present in commit message")
-            return 0
-
-    # Fail
-    print(
-        "[check_upstream_override_marker] FAIL: upstream-shaped paths changed "
-        "without a sentinel-registry update and without an explicit marker.",
-        file=sys.stderr,
-    )
-    print("Upstream-shaped files in this PR:", file=sys.stderr)
-    for f in upstream_files[:30]:
-        print(f"  {f}", file=sys.stderr)
-    if len(upstream_files) > 30:
-        print(f"  ... and {len(upstream_files) - 30} more", file=sys.stderr)
-    print("", file=sys.stderr)
-    print("Fix: either", file=sys.stderr)
-    print("  (a) update one of scripts/sentinels/*.json with anchor(s) for the change, OR", file=sys.stderr)
-    print(f"  (b) include one of these tokens in any commit message: {', '.join(MARKERS)}", file=sys.stderr)
-    print("", file=sys.stderr)
-    print("Marker semantics:", file=sys.stderr)
-    print("  upstream-touch-guarded — anchors are pinned in a sentinel registry", file=sys.stderr)
-    print("  upstream-touch-trivial — change is pure delete/rename/comment-only, no revert risk", file=sys.stderr)
-    print("  upstream-merge         — this is the upstream-merge PR itself", file=sys.stderr)
-    print("  no-upstream-touch      — paths were misclassified; assert no upstream surface", file=sys.stderr)
-    return 1
+    stream = sys.stdout if advisory else sys.stderr
+    prefix = "advisory (not blocking — CI enforces on PR body)" if advisory else "FAIL"
+    print(f"[check_upstream_override_marker] {prefix}: upstream-shaped paths "
+          "changed without sentinel / marker / pure-insertion.", file=stream)
+    _print_failure(upstream_files, stream)
+    return 0 if advisory else 1
 
 
 if __name__ == "__main__":

--- a/scripts/preflight.sh
+++ b/scripts/preflight.sh
@@ -639,15 +639,22 @@ fi
 # turning the recurring review ask "补充必要的 upstream merge 覆写防护门禁" into
 # a hard preflight failure instead of human memory.
 echo ""
-echo "=== sub2api: sentinel registry update gate ==="
+echo "=== sub2api: sentinel registry update gate (advisory locally) ==="
+# MARKER_GATE_ADVISORY=1: pre-commit/pre-push structurally cannot see the
+# in-flight commit message or the PR body, so a hard block here is a false
+# deadlock (benign pure-insertion / i18n PRs paid stash+force-push tax). The
+# script prints guidance but exits 0; the HARD gate runs in CI against the PR
+# body (.github/workflows/marker-acknowledgement-pr.yml + upstream-merge-pr-shape
+# Check 12). Pure-insertion / i18n changes are auto-accepted by the script.
 if ! command -v python3 >/dev/null 2>&1; then
     echo "  FAIL: python3 not on PATH (required for sentinel registry update gate)"
     errors=$((errors + 1))
-elif ! python3 ./scripts/sentinels/check-registry-update-gate.py --quiet; then
-    # check-sentinel-registry-update-gate.py already printed the actionable failure.
+elif ! MARKER_GATE_ADVISORY=1 python3 ./scripts/sentinels/check-registry-update-gate.py --quiet; then
+    # advisory mode never returns non-zero; this branch only fires on a hard
+    # script error (exit 2 — malformed registry / unresolved base).
     errors=$((errors + 1))
 else
-    echo "  ok: guarded hotspot changes update their sentinel registries"
+    echo "  ok: sentinel update gate evaluated (advisory; CI enforces on PR body)"
 fi
 
 # ---- sub2api: script ref existence ------------------------------------------
@@ -695,15 +702,19 @@ fi
 # acknowledgement that this PR's diff against an upstream merge has been
 # considered.
 echo ""
-echo "=== sub2api: upstream override marker ==="
+echo "=== sub2api: upstream override marker (advisory locally) ==="
+# MARKER_GATE_ADVISORY=1 — advisory locally (cannot see in-flight commit /
+# PR body); HARD gate is .github/workflows/marker-acknowledgement-pr.yml which
+# reads the PR body. Pure-insertion / i18n diffs are auto-accepted.
 if ! command -v python3 >/dev/null 2>&1; then
     echo "  FAIL: python3 not on PATH (required for upstream override marker check)"
     errors=$((errors + 1))
-elif ! python3 ./scripts/checks/upstream-override-marker.py --quiet; then
-    # check-upstream-override-marker.py already printed the actionable failure.
+elif ! MARKER_GATE_ADVISORY=1 python3 ./scripts/checks/upstream-override-marker.py --quiet; then
+    # advisory mode never returns non-zero; this branch only fires on a hard
+    # script error (exit 2 — git failure).
     errors=$((errors + 1))
 else
-    echo "  ok: upstream-shaped paths protected (sentinel update or marker present)"
+    echo "  ok: upstream override marker evaluated (advisory; CI enforces on PR body)"
 fi
 
 # ---- sub2api: redaction version contract ------------------------------------

--- a/scripts/sentinels/check-registry-update-gate.py
+++ b/scripts/sentinels/check-registry-update-gate.py
@@ -19,6 +19,7 @@ import argparse
 import fnmatch
 import json
 import os
+import re
 import subprocess
 import sys
 from pathlib import Path
@@ -27,6 +28,12 @@ from typing import Iterable
 REPO_ROOT = Path(__file__).resolve().parent.parent.parent
 REGISTRY_GLOB = "scripts/sentinels/*.json"
 DEFAULT_BASE = "origin/main"
+
+# i18n locale dictionaries are append-heavy (TK adds keys on nearly every
+# feature PR). Requiring a registry update / review marker on every touch is
+# pure ceremony; the independent sentinel anchor verifiers still prove any
+# anchored literal survives. Excluded from THIS update-gate outright.
+I18N_LOCALE_RE = re.compile(r"^frontend/src/i18n/locales/.*\.ts$")
 
 # Commit-message markers that count as explicit author assertions that the
 # author reviewed the touched hotspot files against their guarding sentinel
@@ -133,14 +140,44 @@ def commit_messages(base: str, head: str) -> str:
     return proc.stdout
 
 
-def has_review_marker(base: str, head: str) -> tuple[bool, str | None]:
+def has_review_marker(base: str, head: str, pr_body: str = "") -> tuple[bool, str | None]:
     """Return (matched, marker) — True when any SENTINEL_GATE_MARKERS appears
-    verbatim in a commit message between base and head."""
-    msg = commit_messages(base, head)
+    verbatim in a commit message between base and head, OR in the PR body
+    (the mutable surface CI passes via --pr-body)."""
+    text = (pr_body or "") + "\n" + commit_messages(base, head)
     for marker in SENTINEL_GATE_MARKERS:
-        if marker in msg:
+        if marker in text:
             return True, marker
     return False, None
+
+
+def deletion_counts(base: str, head: str) -> dict[str, int]:
+    """Aggregate per-path deleted-line counts across the committed range AND
+    the working tree / index (the same three sources the gate reads for
+    changed files). A path with zero deletions everywhere is a pure-insertion
+    change that cannot remove a load-bearing symbol, so it carries no
+    upstream-merge revert risk. Binary (`-`) is treated as a deletion (can't
+    tell) to stay conservative."""
+    counts: dict[str, int] = {}
+    sources = (
+        ["diff", "--numstat", f"{base}...{head}"],
+        ["diff", "--numstat"],
+        ["diff", "--cached", "--numstat"],
+    )
+    for args in sources:
+        proc = run_git(args, check=False)
+        if proc.returncode != 0:
+            continue
+        for line in proc.stdout.splitlines():
+            parts = line.split("\t")
+            if len(parts) != 3:
+                continue
+            added, deleted, path = parts
+            if added == "-" or deleted == "-":
+                counts[path] = counts.get(path, 0) + 1  # binary → conservative
+                continue
+            counts[path] = counts.get(path, 0) + int(deleted)
+    return counts
 
 
 def registry_paths() -> list[Path]:
@@ -190,7 +227,16 @@ def main() -> int:
     parser.add_argument("--base", help="git ref to compare against (default: GITHUB_BASE_REF or origin/main)")
     parser.add_argument("--head", default="HEAD", help="git ref to compare as the change head (default: HEAD)")
     parser.add_argument("--quiet", action="store_true", help="only print failures")
+    parser.add_argument("--pr-body", default="",
+                        help="PR description text; a review marker here satisfies the gate "
+                             "(mutable surface — CI passes the PR body)")
     args = parser.parse_args()
+
+    # Advisory mode: local pre-commit/pre-push cannot see the in-flight commit
+    # message or the PR body, so a hard block there is a structural false
+    # deadlock. Preflight sets MARKER_GATE_ADVISORY=1 → compute + print but
+    # never block. The hard gate runs in CI against the PR body.
+    advisory = bool(os.environ.get("MARKER_GATE_ADVISORY"))
 
     base = resolve_base(args.base)
     if base is None:
@@ -213,11 +259,18 @@ def main() -> int:
 
     coverage = covered_paths_by_registry()
     changed_registries = {p for p in changed if fnmatch.fnmatch(p, REGISTRY_GLOB)}
+    # Pure-insertion paths (no deletions anywhere) cannot remove a load-bearing
+    # symbol → no anchor can have been dropped → safe to auto-accept.
+    deletions = deletion_counts(base, args.head)
     violations: list[tuple[str, set[str], set[str]]] = []
 
     for path in sorted(changed):
         if fnmatch.fnmatch(path, REGISTRY_GLOB):
             continue
+        if I18N_LOCALE_RE.match(path):
+            continue  # i18n locale dictionaries excluded outright
+        if deletions.get(path, 0) == 0:
+            continue  # pure-insertion — implicit sentinel-registry-reviewed
         related = {registry for registry, paths in coverage.items() if path in paths}
         related.update(matching_hotspot_registries(path))
         if not related:
@@ -238,33 +291,36 @@ def main() -> int:
     # literal needs to change. This is the documented escape hatch for the
     # "touched a hotspot but the existing sentinels still hold" case — the
     # alternative is rationale-text vandalism every PR.
-    matched, marker = has_review_marker(base, args.head)
+    matched, marker = has_review_marker(base, args.head, args.pr_body)
     if matched:
         if not args.quiet:
             print(
                 "sentinel registry update gate: ok "
-                f"(commit marker '{marker}' present; hotspot review acknowledged)"
+                f"(review marker '{marker}' present; hotspot review acknowledged)"
             )
         return 0
 
-    print("sentinel registry update gate: FAIL", file=sys.stderr)
+    stream = sys.stdout if advisory else sys.stderr
+    prefix = "advisory (not blocking — CI enforces on PR body)" if advisory else "FAIL"
+    print(f"sentinel registry update gate: {prefix}", file=stream)
     print(
-        "  Load-bearing TK/NewAPI surfaces changed without updating the matching sentinel registry.",
-        file=sys.stderr,
+        "  Load-bearing TK/NewAPI surfaces changed (with deletions) without updating the matching sentinel registry.",
+        file=stream,
     )
     for path, related, seen in violations:
-        print(f"  - {path}", file=sys.stderr)
-        print(f"      update one of: {compact(related)}", file=sys.stderr)
-        print(f"      changed registries in this diff: {compact(seen)}", file=sys.stderr)
+        print(f"  - {path}", file=stream)
+        print(f"      update one of: {compact(related)}", file=stream)
+        print(f"      changed registries in this diff: {compact(seen)}", file=stream)
     print(
         "  Fix (any one): "
-        "(a) add/adjust the relevant sentinel literal in the same PR; "
-        "(b) put one of these markers in a commit message in this PR's range: "
+        "(a) make the change pure-insertion (no deleted lines); "
+        "(b) add/adjust the relevant sentinel literal in the same PR; "
+        "(c) put one of these markers in the PR description: "
         + ", ".join(SENTINEL_GATE_MARKERS)
         + " — use marker only when you reviewed the hotspots and confirmed no anchor change is required.",
-        file=sys.stderr,
+        file=stream,
     )
-    return 1
+    return 0 if advisory else 1
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
## 背景

#697(加一行 account ID 展示)~70% 时间耗在**确认型 marker 门禁的首提交死锁**上:`upstream-touch-*` / `sentinel-registry-reviewed` 是纯"作者确认令牌",却放在 **pre-commit** 阶段、按已提交范围 `origin/main..HEAD` 校验——而 commit 还没创建,marker 必然不在范围里,benign 改动每次都要 stash/空提交/`--force` 杂耍。即使移到 pre-push 也治不了根:**确认信息存活在不可变的 commit message 里**,失败就得重写历史。

## 改动(只迁"确认",不动"机械")

把**只逼人打字的确认令牌**从不可变 commit 挪到**可变的 PR 表面**;**会校验事实的机械门禁(sentinel 锚点 must_contain)保持不动**。

1. **收窄触发面**(`upstream-override-marker.py` + `check-registry-update-gate.py`):
   - 排除 `frontend/src/i18n/locales/*.ts`(append-heavy,纯仪式)。
   - **纯插入 diff**(numstat deletions=0)自动视为 trivial——不可能删 upstream 符号 / sentinel 锚点,无 revert 风险。
2. **`--pr-body` 作为 marker 接受源**:可变 PR 描述里写 token 即可,CI 传 `github.event.pull_request.body`。
3. **本地 advisory**:`scripts/preflight.sh` 两个检查前置 `MARKER_GATE_ADVISORY=1` → 只打印指引、`exit 0` 不 block,**首提交死锁消失**。
4. **CI 硬拦下沉到 PR 表面**:新增 `marker-acknowledgement-pr.yml`(所有 PR,含 `edited` 类型→改 PR body 后自动重跑)读 PR body HARD 跑两检查;`upstream-merge-pr-shape.yml` Check 12 同步加 `--pr-body`。

失败闭环从"重写 git 历史"塌成"改一行 PR 描述 + re-run"。

## 不变量
- 机械型 sentinel 锚点校验(`check-newapi.py` 等)不动、仍硬拦。
- fix-ledger trailer(`Upstream-Fixes:`)是机械型,不在本次范围。
- 纯插入 / i18n 自动放行,但任何**带删除**的 upstream 改动仍需 marker(锚点保护不削弱)。

## 验证
- 两脚本 `--selftest` / decide() 纯函数全过。
- 真实 git 端到端:纯插入→放行;带删除无 marker→FAIL(1);+`--pr-body` marker→放行;`MARKER_GATE_ADVISORY=1`→exit 0 advisory。i18n→不触发。
- `scripts/preflight.sh` 全量 PASS(本地 advisory)。
- 本 PR 自身只碰 scripts+workflows(无 upstream-shaped 运行时文件),新 gate 自我放行。

🤖 Generated with [Claude Code](https://claude.com/claude-code)