### PR TITLE
fix(pricing): 公开目录/我的菜单展示套用 TK overlay 价(deepseek-v4-pro + 火山全系不再空价)

### DIFF
--- a/backend/internal/service/pricing_catalog_tk.go
+++ b/backend/internal/service/pricing_catalog_tk.go
@@ -181,6 +181,12 @@ func (s *PricingCatalogService) BuildPublicCatalog(ctx context.Context) *PublicC
 	}
 
 	resp := buildCatalogFromBytes(data, modTime)
+	// Enrich only a healthy (non-degraded) catalog: a garbage/empty source yields
+	// an empty list and must STAY empty (AC-005 degraded→empty / 200-not-500
+	// contract) rather than surfacing a partial overlay-only catalog.
+	if len(resp.Data) > 0 {
+		applyCatalogOverlayPricing(resp)
+	}
 
 	s.mu.Lock()
 	s.cached = resp
@@ -238,6 +244,74 @@ func buildCatalogFromBytes(data []byte, modTime time.Time) *PublicCatalogRespons
 		Object:    "list",
 		Data:      models,
 		UpdatedAt: updatedAt,
+	}
+}
+
+// applyCatalogOverlayPricing fill-only-merges TK-overlay-priced models the file
+// source lacks into the public catalog, so overlay-only models (deepseek-v4-pro,
+// doubao-*, glm-4-7-251222, …) surface with their prices in the public catalog
+// AND Your-Menu (me_pricing_catalog reads BuildPublicCatalog as metaByID).
+//
+// The runtime price file is a TRIMMED litellm mirror; models litellm lacks are
+// priced ONLY in tk_pricing_overlay.json, which until now fed billing
+// (GetModelPricing applies it) but NOT this display path — hence empty/missing
+// price rows for the entire VolcEngine fifth-platform batch + deepseek-v4-pro.
+//
+// Fill-only mirrors the billing priority (model_pricing_resolver: channel DB >
+// litellm mirror > TK overlay): a name already present from the file source is
+// left untouched, so a model the mirror prices natively keeps the mirror value.
+// Channel pricing stays a strictly higher tier handled upstream (me menu Stage 1
+// / billing resolver), so the overlay only ever fills the litellm tier.
+//
+// Only token-priced entries merge. Per-image / per-second media overlay entries
+// (imagen-*/veo-*/seedream/seedance) carry no token price and are skipped, which
+// matches buildCatalogFromBytes' own nil-token-price skip — media catalog display
+// is a separate (batch 2) concern.
+func applyCatalogOverlayPricing(resp *PublicCatalogResponse) {
+	if resp == nil {
+		return
+	}
+	overlay := loadTKPricingOverlay()
+	if len(overlay) == 0 {
+		return
+	}
+	seen := make(map[string]struct{}, len(resp.Data))
+	for i := range resp.Data {
+		seen[resp.Data[i].ModelID] = struct{}{}
+	}
+	names := make([]string, 0, len(overlay))
+	for name := range overlay {
+		names = append(names, name)
+	}
+	sort.Strings(names)
+
+	appended := false
+	for _, name := range names {
+		if _, ok := seen[name]; ok {
+			continue
+		}
+		p := overlay[name]
+		if p == nil || (p.InputCostPerToken == 0 && p.OutputCostPerToken == 0) {
+			continue
+		}
+		in, out := p.InputCostPerToken, p.OutputCostPerToken
+		cacheRead, cacheWrite := p.CacheReadInputTokenCost, p.CacheCreationInputTokenCost
+		e := catalogRichEntry{
+			InputCostPerToken:           &in,
+			OutputCostPerToken:          &out,
+			CacheReadInputTokenCost:     &cacheRead,
+			CacheCreationInputTokenCost: &cacheWrite,
+			LiteLLMProvider:             p.LiteLLMProvider,
+			Mode:                        p.Mode,
+			SupportsPromptCaching:       p.SupportsPromptCaching,
+		}
+		resp.Data = append(resp.Data, catalogModelFromEntry(name, &e))
+		appended = true
+	}
+	if appended {
+		sort.Slice(resp.Data, func(i, j int) bool {
+			return resp.Data[i].ModelID < resp.Data[j].ModelID
+		})
 	}
 }
 

--- a/backend/internal/service/pricing_catalog_tk_test.go
+++ b/backend/internal/service/pricing_catalog_tk_test.go
@@ -48,13 +48,12 @@ const litellmFixtureJSON = `{
 }`
 
 func TestPricingCatalogService_ParsesLiteLLMShape(t *testing.T) {
-	s := &PricingCatalogService{}
 	ts := time.Date(2026, 4, 22, 10, 0, 0, 0, time.UTC)
-	s.SetSourceForTesting(func() ([]byte, time.Time, bool) {
-		return []byte(litellmFixtureJSON), ts, true
-	})
-
-	resp := s.BuildPublicCatalog(context.Background())
+	// Test the pure parser directly: BuildPublicCatalog additionally fill-merges
+	// the always-on TK pricing overlay (applyCatalogOverlayPricing), which would
+	// add ~24 unrelated overlay models here. buildCatalogFromBytes is exactly the
+	// parse-mechanics seam these assertions target.
+	resp := buildCatalogFromBytes([]byte(litellmFixtureJSON), ts)
 	require.NotNil(t, resp)
 	assert.Equal(t, "list", resp.Object)
 	assert.Equal(t, ts, resp.UpdatedAt, "updated_at must reflect source mtime")
@@ -82,6 +81,48 @@ func TestPricingCatalogService_ParsesLiteLLMShape(t *testing.T) {
 	// supports_function_calling alone also yields tool_use.
 	assert.Contains(t, gpt.Capabilities, "tool_use")
 	assert.Contains(t, gpt.Capabilities, "vision")
+}
+
+// TestPricingCatalogService_AppliesTKOverlayPricing pins the display-side overlay
+// merge: models priced ONLY in tk_pricing_overlay.json (deepseek-v4-pro, doubao-*,
+// glm-4-7-251222 — the VolcEngine fifth-platform batch + deepseek) must surface in
+// the public catalog / Your-Menu with their prices, matching the billing path that
+// already applies the overlay. The merge is fill-only: a model the file source
+// prices natively keeps the source value (overlay never overrides).
+func TestPricingCatalogService_AppliesTKOverlayPricing(t *testing.T) {
+	// Healthy source: one base model + deepseek-v4-flash at a deliberately absurd
+	// price so the fill-only assertion can prove the source wins over the overlay.
+	const fixture = `{
+	  "gpt-5.4": {"input_cost_per_token":0.0000005,"output_cost_per_token":0.000002,"litellm_provider":"openai"},
+	  "deepseek-v4-flash": {"input_cost_per_token":0.999,"output_cost_per_token":0.999,"litellm_provider":"deepseek"}
+	}`
+	s := &PricingCatalogService{}
+	s.SetSourceForTesting(func() ([]byte, time.Time, bool) {
+		return []byte(fixture), time.Date(2026, 6, 10, 0, 0, 0, 0, time.UTC), true
+	})
+
+	resp := s.BuildPublicCatalog(context.Background())
+	require.NotNil(t, resp)
+	byID := make(map[string]PublicCatalogModel, len(resp.Data))
+	for _, m := range resp.Data {
+		byID[m.ModelID] = m
+	}
+
+	// overlay-only models surface with their overlay price (per-token ×1000 = per-1K).
+	pro, ok := byID["deepseek-v4-pro"]
+	require.True(t, ok, "overlay-only deepseek-v4-pro must surface in catalog")
+	assert.InDelta(t, 0.000435, pro.Pricing.InputPer1KTokens, 1e-9, "deepseek-v4-pro input = overlay $0.435/M")
+	assert.InDelta(t, 0.00087, pro.Pricing.OutputPer1KTokens, 1e-9, "deepseek-v4-pro output = overlay $0.87/M")
+	_, ok = byID["doubao-seed-2-0-pro-260215"]
+	assert.True(t, ok, "doubao overlay model must surface")
+	_, ok = byID["glm-4-7-251222"]
+	assert.True(t, ok, "glm-4-7 overlay model must surface")
+
+	// fill-only: a model present in BOTH source and overlay keeps the SOURCE price.
+	flash, ok := byID["deepseek-v4-flash"]
+	require.True(t, ok)
+	assert.InDelta(t, 999.0, flash.Pricing.InputPer1KTokens, 1e-6,
+		"source price wins over overlay (fill-only); overlay must NOT override")
 }
 
 // TestPublicCatalog_FiltersUnservableClaudeAndGpt covers the support filter

--- a/scripts/sentinels/pricing-availability.json
+++ b/scripts/sentinels/pricing-availability.json
@@ -4,48 +4,94 @@
   "sentinels": [
     {
       "path": "backend/internal/handler/gateway_handler.go",
-      "must_contain": ["TkRecordFailureFromErr", "tkFilterModelIDs", "tkAntigravityDefaultModels", "TkEvalBodyGuard(", "TkEnrichForbiddenMessage("],
+      "must_contain": [
+        "TkRecordFailureFromErr",
+        "tkFilterModelIDs",
+        "tkAntigravityDefaultModels",
+        "TkEvalBodyGuard(",
+        "TkEnrichForbiddenMessage("
+      ],
       "rationale": "gateway_handler.go has TK injection points across multiple flows: (1) failure taps at the Anthropic /v1/messages + Gemini /v1/messages error paths (TkRecordFailureFromErr), (2) the priced-and-available filter on the model-list whitelist path (tkFilterModelIDs), (3) the shape-preserving antigravity model filter (tkAntigravityDefaultModels), (4) the pre-flight body-size guard on Messages + CountTokens entries (TkEvalBodyGuard) that fail-fast oversize requests before forward — see edge:us1 production data where opus-4-7 upstream rejects body >= ~940 KB with raw 403; and (5) the actionable-message enrichment for upstream 403 in handleFailoverExhausted + handleFailoverExhaustedSimple (TkEnrichForbiddenMessage). An upstream merge touching the forward-failed error handlers, the Models/AntigravityModels methods, or the entry hooks could silently drop any of these. If TkRecordFailureFromErr is lost, model_not_found failures from Anthropic and Gemini platforms stop being classified; if TkEvalBodyGuard is lost, claude-cli clients lose the pre-flight rejection and again hit upstream 403; if TkEnrichForbiddenMessage is lost, the 403 response collapses back to 'Upstream access forbidden, please contact administrator' without body-size hint."
     },
     {
       "path": "backend/internal/handler/gateway_handler_chat_completions.go",
-      "must_contain": ["TkRecordFailureFromErr"],
+      "must_contain": [
+        "TkRecordFailureFromErr"
+      ],
       "rationale": "The OpenAI chat completions forward-failure path (line ~247) records upstream 404/model_not_found errors. Without this tap, model_not_found failures from OpenAI-compat and newapi platform accounts are never classified, and those models stay 'untested' or 'stale' in the availability table instead of flipping to 'unreachable'. The test TestTkRecordFailureFromErr_ExtractsAndClassifies verifies the logic works but does NOT verify the tap call-site still exists in this handler. This PR also touches the OpenAI-compat sticky-session preparation hook in this upstream-shaped file; keeping this entry in the diff records that the availability tap was explicitly re-checked while routing code moved into the TK companion helper."
     },
     {
       "path": "backend/internal/handler/gateway_handler_responses.go",
-      "must_contain": ["TkRecordFailureFromErr", "TkEvalBodyGuard("],
+      "must_contain": [
+        "TkRecordFailureFromErr",
+        "TkEvalBodyGuard("
+      ],
       "rationale": "The Responses API forward-failure path records upstream errors for the /v1/responses endpoint. Without this tap, model failures on the Responses pathway are invisible to the availability system. Same regression risk as chat_completions: upstream could refactor the error path and silently drop the TK line. This entry also locks the TkEvalBodyGuard pre-flight hook so upstream churn on the /v1/responses entry cannot quietly remove body-size protection for OpenAI compat clients."
     },
     {
       "path": "backend/internal/handler/gemini_v1beta_handler.go",
-      "must_contain": ["TkRecordFailureFromErr", "tkGeminiFallbackModelsList", "TkEvalBodyGuard(", "TkEnrichForbiddenMessage("],
+      "must_contain": [
+        "TkRecordFailureFromErr",
+        "tkGeminiFallbackModelsList",
+        "TkEvalBodyGuard(",
+        "TkEnrichForbiddenMessage("
+      ],
       "rationale": "gemini_v1beta_handler.go has multiple TK injection points: (1) the failure tap on the /v1beta forward path that detects Google's 'Requested entity was not found' responses (TkRecordFailureFromErr), (2) the filtered Gemini fallback model list for the two static-fallback response paths (tkGeminiFallbackModelsList), (3) the pre-flight body-size guard before SelectAccount (TkEvalBodyGuard) — same data-driven motivation as anthropic opus-4-7 oversize rejection, and (4) the actionable-message enrichment for upstream 403 in mapGeminiUpstreamError's caller (TkEnrichForbiddenMessage). The Gemini handler is large and frequently touched by upstream; each TK injection is a 1-line addition easy to lose in merge conflict resolution."
     },
     {
       "path": "backend/internal/service/gateway_service.go",
-      "must_contain": ["tkPricingAvailability", "RecordOutcome", "TkEnrichForbiddenMessage("],
+      "must_contain": [
+        "tkPricingAvailability",
+        "RecordOutcome",
+        "TkEnrichForbiddenMessage("
+      ],
       "rationale": "gateway_service.go carries the success-path availability tap inside recordUsageCore (the 100%-hit path for all platform forwards) plus the TK 403 error-message enrichment in handleErrorResponse. Three sentinels: tkPricingAvailability (field declaration), RecordOutcome (success tap), and TkEnrichForbiddenMessage (403 client-message enrichment, replaces the default 'Upstream access forbidden, please contact administrator' with body-size hint). An upstream merge restructuring recordUsageCore or handleErrorResponse could silently remove any of these, collapsing the availability signal or regressing the 403 UX to the unhelpful default."
     },
     {
       "path": "backend/internal/handler/gateway_handler_tk_forward_error.go",
-      "must_contain": ["TkRecordFailureFromErr", "UpstreamFailoverError"],
+      "must_contain": [
+        "TkRecordFailureFromErr",
+        "UpstreamFailoverError"
+      ],
       "rationale": "This TK companion file is the single implementation of TkRecordFailureFromErr — the helper that extracts upstream HTTP status from UpstreamFailoverError and forwards it to the availability classifier. If this file is lost (e.g. an upstream merge that removes all untracked files), all 5 tap call sites compile against a missing function and the build fails. The file also contains the UpstreamFailoverError unwrap logic that makes model_not_found classification work correctly (R-004 fix from review-20260506)."
     },
     {
       "path": "backend/internal/handler/pricing_catalog_handler_tk.go",
-      "must_contain": ["service.FilterPublicCatalogToServable("],
+      "must_contain": [
+        "service.FilterPublicCatalogToServable("
+      ],
       "rationale": "The public /pricing endpoint prunes retired/unservable claude + gpt rows so customers only see models TokenKey can actually serve (empirical 2026-06-05 probe). The filter is PRESENTATION-ONLY — applied in GetPublicCatalog after BuildPublicCatalog, deliberately NOT in the shared parse (which also backs IsModelPriced billing/gateway filtering). An upstream merge that rewrites GetPublicCatalog could silently drop the call and restore the full unservable list (customers again pick claude-3-*/gpt-4o and hit 400/404). Pins the call site."
     },
     {
       "path": "backend/internal/service/pricing_catalog_supported_models_tk.go",
-      "must_contain": ["func isPublicCatalogModelSupported(", "func FilterPublicCatalogToServable(", "func supportedCatalogModelIDsForPlatform(", "supportedAnthropicCatalogModels", "supportedOpenAICatalogModels", "supportedGeminiCatalogModels", "servable-allowlist:begin anthropic", "servable-allowlist:begin openai", "servable-allowlist:begin gemini"],
+      "must_contain": [
+        "func isPublicCatalogModelSupported(",
+        "func FilterPublicCatalogToServable(",
+        "func supportedCatalogModelIDsForPlatform(",
+        "supportedAnthropicCatalogModels",
+        "supportedOpenAICatalogModels",
+        "supportedGeminiCatalogModels",
+        "servable-allowlist:begin anthropic",
+        "servable-allowlist:begin openai",
+        "servable-allowlist:begin gemini"
+      ],
       "rationale": "Single source for the empirically-servable claude + gpt sets, shared by the public /pricing presentation filter (FilterPublicCatalogToServable) and the Your-Menu unrestricted-account fallback (supportedCatalogModelIDsForPlatform). Losing the allowlist vars would silently widen both surfaces back to the full unservable set; losing the funcs breaks both call sites. The `servable-allowlist:begin/end` splice markers are load-bearing for ops/pricing/refresh-servable-allowlist.py (it rewrites the maps between them); an upstream merge that drops the markers would break the re-runnable refresh. Other vendors (gemini, deepseek, …) intentionally pass through — only the claude + gpt families are curated."
     },
     {
       "path": "backend/internal/service/pricing_catalog_tk_test.go",
-      "must_contain": ["TestPublicCatalog_FiltersUnservableClaudeAndGpt", "TestIsPublicCatalogModelSupported"],
+      "must_contain": [
+        "TestPublicCatalog_FiltersUnservableClaudeAndGpt",
+        "TestIsPublicCatalogModelSupported"
+      ],
       "rationale": "Regression coverage for the public-catalog support filter: asserts retired/unservable claude+gpt rows are pruned, servable ones kept, and non-curated vendors pass through. Pinned so an upstream merge that rewrites the catalog test file cannot silently drop the filter's regression guard. (This file also matches the *_tk_*.go hotspot via its _tk_test.go suffix, so the registry-update gate requires it to be tracked in a sentinel registry; pricing-availability is its correct domain.)"
+    },
+    {
+      "path": "backend/internal/service/pricing_catalog_tk.go",
+      "must_contain": [
+        "func applyCatalogOverlayPricing",
+        "applyCatalogOverlayPricing(resp)"
+      ],
+      "rationale": "Display-side TK pricing-overlay merge. BuildPublicCatalog reads the trimmed litellm price file (model_pricing.json) and, unlike the billing path (GetModelPricing → applyTKPricingOverlay), did NOT apply the overlay — so every model priced ONLY in tk_pricing_overlay.json (the entire VolcEngine fifth-platform batch: doubao-*/glm-4-7-251222, plus deepseek-v4-pro) showed empty/missing prices in the public /pricing catalog AND Your-Menu (me_pricing_catalog reads BuildPublicCatalog as metaByID), even though billing was correct. applyCatalogOverlayPricing fill-only-merges the overlay's token-priced models into the catalog so display matches billing. It is fill-only (file source wins; channel pricing stays a strictly higher tier upstream) and is gated behind a non-degraded catalog (len(resp.Data)>0) to preserve the AC-005 degraded→empty contract. An upstream merge refactoring BuildPublicCatalog could silently drop the applyCatalogOverlayPricing(resp) call, regressing every overlay-only model back to an empty price row."
     }
   ]
 }


### PR DESCRIPTION
## 问题

「我的菜单」里 **deepseek-v4-pro 报价是空的**(flash 正常)。排查发现影响面更大:**公开目录 + 我的菜单对所有"只在 TK overlay 里定价"的模型都缺价/空价**——deepseek-v4-flash/pro、刚上的 20 个 doubao、glm-4.7,公开目录里全 MISSING。

## 根因

`BuildPublicCatalog`(`buildCatalogFromBytes`)直接解析裁剪版 litellm 价文件 `model_pricing.json`,**不调 `applyTKPricingOverlay`**。而 doubao/deepseek-v4/glm-4.7 的价 litellm 上游没有、**只配在 `tk_pricing_overlay.json`**。结果:
- **计费正确**(走 `GetModelPricing` → 含 overlay,prod 实测 deepseek-v4-pro 那笔 $0.00003 就是 overlay 价正确扣的)。
- **展示坏**:公开目录不含这些模型;我的菜单里它们空价(flash 因额外有一行 channel 渠道价才显示)。

## 修复

`applyCatalogOverlayPricing` 在 `BuildPublicCatalog` 里 **fill-only** 合并 overlay 的 token-价模型,让展示与计费一致:
- **fill-only**:文件源已有的不覆盖(channel 渠道价仍是严格更高层,在 me-menu Stage 1 / 计费 resolver 处理)——与计费优先级 `channel DB > litellm > overlay` 一致。
- **仅 token-价条目**:媒体类(per-image / per-second:imagen/veo/seedream/seedance)无 token 价、自动跳过,留第二批。
- **`len>0` 守卫**:降级/空/garbage 源不合 overlay,保 AC-005「降级=空、200-not-500」契约。
- **新增 sentinel**(`pricing-availability.json`):保护该合并不被未来 `git merge upstream/main` 悄悄删掉。

纯展示改动,**零计费风险**(计费路径不碰)。

## 验证

- `go build ./...` + `go test -tags=unit ./internal/service/... ./internal/handler/... ./internal/server/...` 全绿
- 新增 `TestPricingCatalogService_AppliesTKOverlayPricing`:overlay-only 模型(deepseek-v4-pro/doubao/glm-4.7)出现且带价 + fill-only 源价优先
- `ParsesLiteLLMShape` 改用纯函数 `buildCatalogFromBytes`(parser 机制不受 overlay 影响)
- `scripts/preflight.sh` PASS(sentinel gate 由本 PR 内 sentinel 更新满足)

## Checklist
- [x] 单测/构建/preflight 全绿
- [x] 纯后端:commit 含 `no-web-impact`
- [x] 触碰 sentinel-guarded 面:同 PR 更新 `scripts/sentinels/pricing-availability.json`
- [x] 无 schema 变更、无迁移

## 上线后复验
合并发版后:公开目录 + 我的菜单应能看到 deepseek-v4-flash/pro + 20 个 doubao + glm-4.7 的价(非空)。

🤖 Generated with [Claude Code](https://claude.com/claude-code)