### PR TITLE
fix(codex): drop stale gpt-5.3-codex→codex-mini-latest ChatGPT OAuth rewrite (upstream contract reversed 2026-05-29)

### DIFF
--- a/backend/internal/service/openai_codex_transform.go
+++ b/backend/internal/service/openai_codex_transform.go
@@ -842,12 +842,30 @@ func normalizeOpenAIResponsesImageOnlyModel(reqBody map[string]any) bool {
 }
 
 // chatGPTOAuthUpstreamModelNames maps internal canonical model names to the
-// identifiers accepted by the ChatGPT OAuth backend (chatgpt.com).
-// The ChatGPT internal Codex API requires "codex-mini-latest" and rejects
-// "gpt-5.3-codex" with 400 "not supported when using Codex with a ChatGPT account".
-var chatGPTOAuthUpstreamModelNames = map[string]string{
-	"gpt-5.3-codex": "codex-mini-latest",
-}
+// identifiers accepted by the ChatGPT OAuth backend (chatgpt.com). The map is
+// deliberately EMPTY — it is NOT dead code: the lookup in
+// normalizeOpenAIModelForUpstream is the zero-cost seam for the next time the
+// ChatGPT OAuth backend flips its model-name contract (it already did once).
+//
+// Contract timeline:
+//   - Until 2026-05-28 the backend rejected bare "gpt-5.3-codex" and required
+//     "codex-mini-latest" — hence the former gpt-5.3-codex → codex-mini-latest
+//     entry here.
+//   - Since 2026-05-29 the contract REVERSED: the backend now rejects the
+//     rewrite target with the prod 400 literal (keep verbatim, grep anchor):
+//     The 'codex-mini-latest' model is not supported when using Codex with a ChatGPT account
+//   - 2026-06-10 prod probe (read-only, exact gateway header shape, OAuth
+//     accounts 9/GPT-pro1 + 48/GPT-pro2): both "gpt-5.3-codex" AND
+//     "codex-mini-latest" return that 400 on both accounts, while control
+//     "gpt-5.3-codex-spark" streams 200 — the OAuth backend currently serves
+//     a narrower model set than the platform API (not enumerated here).
+//
+// Even though bare "gpt-5.3-codex" is also rejected today, dropping the stale
+// rewrite still matters: clients now receive the upstream's real, actionable
+// 400 (passed through by the caller-fault 400 catch-all in
+// openai_gateway_service.go) instead of an error about a model name they
+// never sent because of a silent rewrite.
+var chatGPTOAuthUpstreamModelNames = map[string]string{}
 
 func normalizeOpenAIModelForUpstream(account *Account, model string) string {
 	if account == nil || account.Type == AccountTypeOAuth {

--- a/backend/internal/service/openai_model_mapping_test.go
+++ b/backend/internal/service/openai_model_mapping_test.go
@@ -268,22 +268,22 @@ func TestNormalizeOpenAIModelForUpstream(t *testing.T) {
 			want:    "codex-auto-review",
 		},
 		{
-			name:    "oauth maps gpt-5.3-codex to codex-mini-latest for ChatGPT backend",
+			name:    "oauth keeps canonical gpt-5.3-codex unrewritten (ChatGPT backend contract reversed 2026-05-29)",
 			account: &Account{Type: AccountTypeOAuth},
 			model:   "gpt-5.3-codex",
-			want:    "codex-mini-latest",
+			want:    "gpt-5.3-codex",
 		},
 		{
-			name:    "oauth maps gpt-5.3 alias to codex-mini-latest for ChatGPT backend",
+			name:    "oauth normalizes gpt-5.3 alias to gpt-5.3-codex via codexModelMap",
 			account: &Account{Type: AccountTypeOAuth},
 			model:   "gpt-5.3",
-			want:    "codex-mini-latest",
+			want:    "gpt-5.3-codex",
 		},
 		{
-			name:    "oauth maps codex-mini-latest alias to codex-mini-latest for ChatGPT backend",
+			name:    "oauth normalizes codex-mini-latest alias to gpt-5.3-codex via codexModelMap",
 			account: &Account{Type: AccountTypeOAuth},
 			model:   "codex-mini-latest",
-			want:    "codex-mini-latest",
+			want:    "gpt-5.3-codex",
 		},
 		{
 			name:    "oauth spark model not remapped",
@@ -311,6 +311,15 @@ func TestNormalizeOpenAIModelForUpstream(t *testing.T) {
 				t.Fatalf("normalizeOpenAIModelForUpstream(...) = %q, want %q", got, tt.want)
 			}
 		})
+	}
+}
+
+// The ChatGPT OAuth rewrite table must stay empty until the upstream contract
+// flips again (2026-06-10 prod probe): canonical names go upstream as-is so
+// clients see the real upstream 400 instead of a silently rewritten model.
+func TestChatGPTOAuthUpstreamModelNamesIsEmpty(t *testing.T) {
+	if len(chatGPTOAuthUpstreamModelNames) != 0 {
+		t.Fatalf("chatGPTOAuthUpstreamModelNames = %#v, want empty map (see contract timeline in openai_codex_transform.go)", chatGPTOAuthUpstreamModelNames)
 	}
 }
 

--- a/scripts/sentinels/gateway-tk.json
+++ b/scripts/sentinels/gateway-tk.json
@@ -559,9 +559,10 @@
       "path": "backend/internal/service/openai_codex_transform.go",
       "must_contain": [
         "chatGPTOAuthUpstreamModelNames",
-        "codex-mini-latest"
+        "codex-mini-latest",
+        "var chatGPTOAuthUpstreamModelNames = map[string]string{}"
       ],
-      "rationale": "ChatGPT OAuth backend rejects gpt-5.3-codex with 400 'not supported when using Codex with a ChatGPT account'; the accepted wire name is codex-mini-latest. This reverse-mapping table in normalizeOpenAIModelForUpstream is the only gate preventing the internal canonical name from leaking to the upstream API."
+      "rationale": "ChatGPT OAuth model-name contract REVERSED on 2026-05-29 (2026-06-10 prod probe, OAuth accounts 9+48): the backend now 400-rejects codex-mini-latest, so the former gpt-5.3-codex -> codex-mini-latest rewrite must stay removed and the table must stay EMPTY until the contract flips again. The lookup seam in normalizeOpenAIModelForUpstream plus the contract-timeline comment (with the verbatim codex-mini-latest 400 literal as grep anchor) must survive upstream merges; losing them either re-introduces the stale rewrite (silent 400 on every OAuth codex request) or erases the documented seam for the next reversal."
     },
     {
       "path": "backend/internal/service/openai_gateway_service.go",


### PR DESCRIPTION
## 问题

`chatGPTOAuthUpstreamModelNames` 把规范名 `gpt-5.3-codex` 出站改写成 `codex-mini-latest`（写入时上游确实要求如此）。**上游契约自 2026-05-29 反转**：ChatGPT OAuth 后端开始 400 拒绝 `codex-mini-latest`，导致所有经 OAuth 账号的 gpt-5.3-codex 请求必败（prod 数据：05-28 最后成功，05-29 起持续 400），并曾连带打断 GPT专线 分组的 claude 派发链 12 天（派发配置已另行 admin 止血）。

## 实测（2026-06-10，read-only probe，出站形状逐字照抄网关常量，脱敏=状态码+≤512B body+token前8）

| 账号 | gpt-5.3-codex（裸） | codex-mini-latest | gpt-5.3-codex-spark（阳性对照） |
|---|---|---|---|
| 9 / GPT-pro1 | 400 not-supported | 400 not-supported | 200 SSE 正常 |
| 48 / GPT-pro2 | 400 not-supported | 400 not-supported | 200 SSE 正常 |

**分支 B 结论**：契约确认反转，且裸名当前也不被 ChatGPT OAuth 后端接受（只收 spark 等窄集）。probe 按协议迭代三版修通 spark 对照（input 列表化 + instructions）；两轮迭代中 not-supported 400 始终稳定 = 模型名门拒绝早于 body 校验，结论可信。

## 修法（乔布斯决策：A/B 分支 diff 相同）

- `chatGPTOAuthUpstreamModelNames` 清成**空 map**；`normalizeOpenAIModelForUpstream` 函数与查表结构保留——空表是下次契约反转的零成本接缝（14 个月内契约已反转两次），非死代码。
- **为何删映射而非改派 spark**：spark 是不同模型，静默改派违反最小惊讶；删映射让客户端拿到上游真实 actionable 400（既有 caller-fault 透传 catch-all 接住，`invalid_request_error` 不计账号 pause 阈值、不冷却共享 OAuth 账号）。
- 注释翻新：完整时间线 + 逐字保留 prod 400 字面量作未来 grep 锚点 + 分支 B 语义说明。
- 测试：三个编码旧契约的用例翻转（rename 含 contract reversed 2026-05-29）+ 新增空表断言用例；spark/apikey/TestNormalizeCodexModel_* 保持绿未动。
- sentinel：`gateway-tk.json` sentinels[48] rationale 由旧契约翻新为新契约 + 新增空表字面量锚点（double-trigger by design：upstream merge 静默还原旧映射会撞红；未来合法反转加 entry 也会撞红强制同步审视注释与 rationale）。
- 禁改清单零触碰：codexModelMap 主表、openai_gateway_service.go、ratelimit_service_tk_client_induced_400.go。

## 验证

- `go build ./...` / `go test -tags=unit ./...` 全量 / `golangci-lint run ./...` 0 issues / `bash scripts/preflight.sh` PASS（sentinel 214/214）
- 上线后 prod 验证 checklist：
  - [ ] 直调裸 `gpt-5.3-codex`（OAuth 账号）期待**真实 400** + 上游 message（非 502 掩码）
  - [ ] 账号 9/48 不因此进 cooldown（`temp_unschedulable_reason` 无新增）
  - [ ] codex not-supported 400 指纹趋势随客户端纠正下降
  - [ ] `gpt-5.3-codex-spark` 流量不回归（持续 200）

## 出 order 说明

TK 当前落后 upstream/main 20 commits；本 PR 为单文件止血修复先行落地，upstream 合流由每日 agent 正常推进，改动区为 TK-shaped、无冲突面交集。审计：`git log --oneline upstream/main..HEAD | wc -l` = 757。

🤖 Generated with [Claude Code](https://claude.com/claude-code)