### PR TITLE
feat: worktree new-api bootstrap-hook + no-web-impact CI 硬拦 + dev-rules bump(承接 #74)

### DIFF
--- a/.github/workflows/marker-acknowledgement-pr.yml
+++ b/.github/workflows/marker-acknowledgement-pr.yml
@@ -43,12 +43,14 @@ jobs:
   validate:
     runs-on: ubuntu-latest
     steps:
-      # fetch-depth: 0 so PR base..head plumbing resolves. submodules are NOT
-      # needed: both scripts live in this repo (scripts/checks, scripts/sentinels).
+      # fetch-depth: 0 so PR base..head plumbing resolves. submodules: recursive
+      # because the no-web-impact gate lives in the dev-rules submodule
+      # (dev-rules/scripts/check_web_surface_alignment.py).
       - uses: actions/checkout@v6
         with:
           fetch-depth: 0
           ref: ${{ github.event.pull_request.head.sha }}
+          submodules: recursive
 
       - name: upstream-override marker (PR body)
         env:
@@ -80,5 +82,26 @@ jobs:
           if ! python3 ./scripts/sentinels/check-registry-update-gate.py --base "$BASE_SHA" --head "$HEAD_SHA" --pr-body "$PR_BODY"; then
             echo "::error::Sentinel registry update gate failed."
             echo "::error::Either update scripts/sentinels/*.json, or add sentinel-registry-reviewed to the PR description, then re-run."
+            exit 1
+          fi
+
+      - name: no-web-impact gate (PR body)
+        env:
+          PR_BODY: ${{ github.event.pull_request.body }}
+        run: |
+          # The dev-rules no-web-impact check is advisory in local preflight
+          # (cannot see the PR body); this is its HARD gate, reading the mutable
+          # PR description. A backend/business-logic change must ship Web/config/
+          # contract alignment evidence OR carry a 'no-web-impact' token in the
+          # PR description. The script lives in the dev-rules submodule.
+          BASE_SHA='${{ github.event.pull_request.base.sha }}'
+          GATE=dev-rules/scripts/check_web_surface_alignment.py
+          if [ ! -f "$GATE" ]; then
+            echo "::error::$GATE missing (dev-rules submodule not checked out?)."
+            exit 1
+          fi
+          if ! python3 "$GATE" --base "$BASE_SHA" --pr-body "$PR_BODY"; then
+            echo "::error::no-web-impact gate failed."
+            echo "::error::Add Web/config/contract alignment evidence, or put 'no-web-impact' in the PR description, then re-run."
             exit 1
           fi

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -148,6 +148,14 @@ bash scripts/upstream/sync-new-api.sh --bump <sha>   # update .new-api-ref + syn
 - When upstream changes break compilation, fix the bridge — do NOT modify New API from this repo.
 - New-api packages may register top-level `flag.Bool` (e.g. `-version`) in their `init()`; check `flag.Lookup` before defining your own to avoid `flag redefined` panics at startup. See `backend/cmd/server/main.go`.
 
+**Worktrees + the `../../new-api` sibling (turnkey bootstrap):**
+
+Default to an **isolated git worktree** for any commit-bearing task — sharing the primary checkout's single mutable HEAD/index with a parallel agent (e.g. a twin worker) lets one `git checkout` land your commits on the wrong branch. A worktree created at a deep path (`EnterWorktree` → `.claude/worktrees/<name>/`) breaks the `replace … => ../../new-api` resolution, which is exactly the friction that makes people skip worktrees. Make it free instead of skipping it:
+
+- Run `bash dev-rules/templates/worktree-bootstrap.sh <worktree_dir>` after creating a worktree. It inits the `dev-rules` submodule and runs this repo's `scripts/worktree-bootstrap-hook.sh`, which symlinks the deep-path-resolved `new-api` location to the real sibling clone so `go build` / preflight work.
+- Sibling-placed worktrees (e.g. twin's `<parent>/<repo>-twin-*`) resolve `../../new-api` natively — the hook is a no-op there.
+- The real sibling clone is still located/synced by `scripts/upstream/sync-new-api.sh` (`.new-api-ref`); the hook only fixes path resolution, never the pin.
+
 ### 5. Upstream Isolation
 
 This repo is a fork of `Wei-Shaw/sub2api`, tracked via the `upstream` remote (`upstream/main`). Minimize diff against upstream:

--- a/scripts/worktree-bootstrap-hook.sh
+++ b/scripts/worktree-bootstrap-hook.sh
@@ -1,0 +1,52 @@
+#!/usr/bin/env bash
+# worktree-bootstrap-hook.sh — sub2api project hook for the generic
+# dev-rules/templates/worktree-bootstrap.sh.
+#
+# sub2api's backend/go.mod pins the cross-repo dependency with
+#   replace github.com/QuantumNous/new-api => ../../new-api
+# resolved relative to backend/, i.e. it expects a sibling `new-api` clone next
+# to the repo root. A worktree created at a DEEP path (Claude Code
+# EnterWorktree puts them under `.claude/worktrees/<name>/`) makes
+# `../../new-api` resolve to `<repo>/.claude/worktrees/new-api` instead of the
+# real sibling clone — so `go build` / preflight fail with a missing module.
+#
+# This hook creates a symlink at that resolved location pointing at the real
+# sibling `new-api`, making deep-path worktrees turnkey. Sibling-placed
+# worktrees (e.g. twin's `<parent>/<repo>-twin-*`) already resolve natively, so
+# the hook is a no-op there. Idempotent. Receives the worktree dir as $1.
+set -euo pipefail
+
+WT="${1:?usage: worktree-bootstrap-hook.sh <worktree_dir>}"
+WT="$(cd "$WT" && pwd)"
+
+# Where go.mod's `../../new-api` (relative to <WT>/backend) resolves:
+#   <WT>/backend/../../new-api == $(dirname "$WT")/new-api
+NEEDED="$(dirname "$WT")/new-api"
+
+# Already a usable clone at that path (sibling worktree, or symlink already
+# made)? Nothing to do.
+if [ -e "$NEEDED/go.mod" ]; then
+  echo "[worktree-bootstrap-hook] new-api already resolves at $NEEDED"
+  exit 0
+fi
+
+# Locate the real sibling new-api via the MAIN repo root (a worktree's
+# --show-toplevel is the worktree itself; --git-common-dir points at the main
+# .git regardless of which worktree we are in).
+GIT_COMMON="$(cd "$WT" && git rev-parse --git-common-dir)"
+case "$GIT_COMMON" in
+  /*) ;;
+  *) GIT_COMMON="$WT/$GIT_COMMON" ;;
+esac
+GIT_COMMON="$(cd "$GIT_COMMON" && pwd)"
+MAIN_ROOT="$(dirname "$GIT_COMMON")"           # <main>/.git -> <main>
+REAL="$(dirname "$MAIN_ROOT")/new-api"         # sibling of the main repo root
+
+if [ ! -d "$REAL" ]; then
+  echo "[worktree-bootstrap-hook] WARN: real new-api not found at $REAL" >&2
+  echo "[worktree-bootstrap-hook]       run scripts/upstream/sync-new-api.sh first." >&2
+  exit 0
+fi
+
+ln -sfn "$REAL" "$NEEDED"
+echo "[worktree-bootstrap-hook] linked $NEEDED -> $REAL"


### PR DESCRIPTION
## 背景

承接已合并的 dev-rules **#74**(twin 默认 worktree 隔离 + turnkey bootstrap + no-web-impact 迁 PR 表面)的 **sub2api 跨仓尾巴**,单 PR 收口。

## 改动

1. **dev-rules 指针 bump**(`a5566e0 → 0abbeda`):消费 #74。
2. **`scripts/worktree-bootstrap-hook.sh`**:深路径 worktree(`EnterWorktree` → `.claude/worktrees/<n>/`)会让 `go.mod replace => ../../new-api` 解析错位;hook 在错位点建 symlink 指向真实 sibling `new-api`,让深路径 worktree 开箱即用。sibling worktree(twin)天然解析→自动 no-op;幂等。由 dev-rules `templates/worktree-bootstrap.sh` 自动调用。
3. **`marker-acknowledgement-pr.yml`**:加 **no-web-impact PR-body 硬拦 job** + checkout `submodules: recursive`(脚本在 dev-rules 子模块)。**补缺口**:no-web-impact 本地转 advisory 后,若 CI 无硬门禁就从"local-only 门"变成"完全没门"。
4. **CLAUDE.md §4**:记录"会 commit 的活默认隔离 worktree" + bootstrap 用法。

## 验证

- `scripts/worktree-bootstrap-hook.sh` 端到端实测:深 worktree fresh run → 正确 symlink → `go list new-api/dto` 成功 → 幂等 re-run no-op。
- `marker-acknowledgement-pr.yml` YAML 解析通过;**本 PR 即 live dogfood**(#700 已让该 workflow 在 main 生效,本 PR 新增的 no-web-impact job 也会在此 PR 上跑)。
- `scripts/preflight.sh` 全量 PASS:dev-rules sync 无漂移、AGENTS.md 受管块同步、submodule 指针在 origin/main 可达。
- 本 PR 无 upstream-shaped 运行时文件改动,marker gate 自我放行。

## 至此两条根因修复闭环
- **marker 死锁**:#700(sub2api)+ #74(no-web-impact 部分)→ 确认型 marker 全部迁可变 PR 表面 + 本地 advisory + 收窄触发面。
- **worktree 污染**:#74(twin 默认隔离 + turnkey bootstrap)+ 本 PR(new-api hook 让深路径 worktree turnkey + 默认纪律)。

🤖 Generated with [Claude Code](https://claude.com/claude-code)