### PR TITLE
fix(ops): newapi 上游 404 模型不可用归客户端错误,移出 upstream_error_rate(防假 P0 复发)

### DIFF
--- a/backend/internal/handler/ops_error_logger_tk_client_induced_upstream.go
+++ b/backend/internal/handler/ops_error_logger_tk_client_induced_upstream.go
@@ -56,10 +56,15 @@ func tkUpstreamClientInducedRejection(c *gin.Context) bool {
 		if combined == "" || tkOpsIsAccountLevel4xx(combined) {
 			return false
 		}
-		// Reuse the SAME predicate the gateway response path uses (B-2,
-		// service.handleErrorResponse) so this metric classification can never
-		// drift from the client-facing 400 "Unsupported model" decision.
-		return service.IsAnthropicModelNotFound404([]byte(body), msg)
+		// Reuse the SAME predicates the gateway uses so this metric classification
+		// can never drift from the client-facing decision: anthropic 404 (B-2,
+		// service.handleErrorResponse "Unsupported model"); newapi/openai-compat 404
+		// model-not-found (VolcEngine InvalidEndpointOrModel.NotFound — an
+		// un-activated / retired model on a fifth-platform channel; 2026-06-10 false
+		// P0). The newapi upstream status now reaches here via the bridge's
+		// service.TkRecordBridgeUpstreamError (text/embedding/image/responses relays).
+		return service.IsAnthropicModelNotFound404([]byte(body), msg) ||
+			service.IsOpenAICompatModelNotFound404([]byte(body), msg)
 	}
 	// Only request-validation 4xx are caller-fault. 401/403 and any 5xx stay
 	// provider-owned (account auth / availability / genuine upstream failure); 404

--- a/backend/internal/handler/ops_error_logger_tk_client_induced_upstream_test.go
+++ b/backend/internal/handler/ops_error_logger_tk_client_induced_upstream_test.go
@@ -55,6 +55,35 @@ func TestClassifyOpsUpstreamClientInducedRejectionOwnedByClient(t *testing.T) {
 		require.Equal(t, "client", errorOwner)
 	})
 
+	t.Run("newapi/volcengine upstream 404 model-not-found (InvalidEndpointOrModel.NotFound) owned by client", func(t *testing.T) {
+		// 2026-06-10 false P0: account 7 (volcengine) advertised an un-activated model;
+		// every request 404'd on ark and — swallowed into a generic 502 — counted toward
+		// upstream_error_rate. The bridge dispatch now records the real upstream 404 via
+		// TkRecordBridgeUpstreamError (code prefixed into the message, since the ops
+		// classifier reads only the single-field message key), so this must be client-owned.
+		rec := httptest.NewRecorder()
+		c, _ := gin.CreateTestContext(rec)
+		service.SetOpsUpstreamError(c, http.StatusNotFound,
+			"InvalidEndpointOrModel.NotFound: The model `doubao-lite-32k-240828` does not exist or you do not have access to it.",
+			"InvalidEndpointOrModel.NotFound")
+
+		phase, _, errorOwner, _ := classifyOpsErrorLog(c, "upstream_error", "Upstream request failed", "", http.StatusBadGateway)
+
+		require.Equal(t, "request", phase, "newapi 404 model-not-found must be client-owned, out of upstream_error_rate")
+		require.Equal(t, "client", errorOwner)
+	})
+
+	t.Run("genuine newapi upstream 503 stays provider-owned (must keep counting)", func(t *testing.T) {
+		rec := httptest.NewRecorder()
+		c, _ := gin.CreateTestContext(rec)
+		service.SetOpsUpstreamError(c, http.StatusServiceUnavailable, "upstream service temporarily unavailable", "")
+
+		phase, _, errorOwner, _ := classifyOpsErrorLog(c, "upstream_error", "Upstream request failed", "", http.StatusBadGateway)
+
+		require.Equal(t, "upstream", phase, "a real 5xx must stay provider-owned")
+		require.Equal(t, "provider", errorOwner)
+	})
+
 	t.Run("upstream 413 request_too_large is always client-induced", func(t *testing.T) {
 		rec := httptest.NewRecorder()
 		c, _ := gin.CreateTestContext(rec)

--- a/backend/internal/service/gateway_bridge_dispatch.go
+++ b/backend/internal/service/gateway_bridge_dispatch.go
@@ -109,7 +109,7 @@ func (s *GatewayService) ForwardAsChatCompletionsDispatched(
 			zap.String("bridge_path", "newapi_adaptor_error"),
 			zap.Int64("account_id", account.ID),
 		)
-		return nil, &NewAPIRelayError{Err: apiErr}
+		return nil, tkWrapBridgeRelayError(c, apiErr)
 	}
 	logger.L().Info("gateway.newapi_bridge_dispatch",
 		zap.String("endpoint", BridgeEndpointChatCompletions),
@@ -160,7 +160,7 @@ func (s *GatewayService) ForwardAsResponsesDispatched(
 			zap.String("bridge_path", "newapi_adaptor_error"),
 			zap.Int64("account_id", account.ID),
 		)
-		return nil, &NewAPIRelayError{Err: apiErr}
+		return nil, tkWrapBridgeRelayError(c, apiErr)
 	}
 	logger.L().Info("gateway.newapi_bridge_dispatch",
 		zap.String("endpoint", BridgeEndpointResponses),

--- a/backend/internal/service/newapi_model_not_found_tk.go
+++ b/backend/internal/service/newapi_model_not_found_tk.go
@@ -1,0 +1,81 @@
+package service
+
+import (
+	"strings"
+
+	newapitypes "github.com/QuantumNous/new-api/types"
+	"github.com/gin-gonic/gin"
+	"github.com/tidwall/gjson"
+)
+
+// IsOpenAICompatModelNotFound404 reports whether an OpenAI-compatible / newapi
+// upstream 404 is a CALLER-fault "the requested model does not exist / is not
+// accessible on this channel" rather than a provider-health failure. The newapi
+// fifth-platform sibling of IsAnthropicModelNotFound404 — VolcEngine Ark returns
+//
+//	{"error":{"code":"InvalidEndpointOrModel.NotFound",
+//	          "message":"The model `X` does not exist or you do not have access to it."}}
+//
+// for a model that is not 开通 (activated) or already 下线 (retired) on the channel.
+//
+// classifyOpsErrorLog uses this (via tkUpstreamClientInducedRejection) to own the
+// error to the client (phase=request → error_owner=client), keeping it OUT of
+// upstream_error_rate. Without it a single channel that advertises an un-activated
+// model lets every client request inflate the provider-health P0 capacity alert —
+// the 2026-06-10 false P0 (account 7 volcengine, ~130×502 in 12 min).
+func IsOpenAICompatModelNotFound404(responseBody []byte, upstreamMsg string) bool {
+	combined := strings.ToLower(strings.TrimSpace(upstreamMsg + "\n" + string(responseBody)))
+	if combined == "" {
+		return false
+	}
+	if strings.Contains(combined, "invalidendpointormodel.notfound") ||
+		strings.Contains(combined, "does not exist or you do not have access") {
+		return true
+	}
+	if code := strings.ToLower(strings.TrimSpace(gjson.GetBytes(responseBody, "error.code").String())); code == "invalidendpointormodel.notfound" {
+		return true
+	}
+	return false
+}
+
+// TkRecordBridgeUpstreamError records the REAL upstream HTTP status + error
+// message/code from a New API bridge relay error into the ops context, so ops
+// error classification (classifyOpsErrorLog) sees the true upstream verdict.
+//
+// Why: newapi bridge forward failures frequently fall through to the generic
+// "Upstream request failed" fallback (ensureForwardErrorResponse), which never
+// calls SetOpsUpstreamError. ops_error_logs then records upstream_status_code=null
+// and — because error_type=upstream_error alone classifies as phase=upstream —
+// a caller-fault upstream 404 model-not-found is mis-owned as provider health and
+// pollutes upstream_error_rate (the 2026-06-10 false P0). Recording the real 404
+// at the bridge (the one layer where the upstream status is guaranteed available)
+// lets tkUpstreamClientInducedRejection reclassify it phase=request, independent
+// of which downstream response path runs.
+//
+// The error CODE is prefixed into the recorded message because the ops classifier
+// reads only the single-field message key (tkOpsUpstreamErrorText), not the detail
+// key, so the InvalidEndpointOrModel.NotFound signal must travel in the message.
+func TkRecordBridgeUpstreamError(c *gin.Context, upstreamStatusCode int, err *newapitypes.NewAPIError) {
+	if c == nil || err == nil {
+		return
+	}
+	code := strings.TrimSpace(string(err.GetErrorCode()))
+	msg := strings.TrimSpace(err.Error())
+	if code != "" {
+		msg = code + ": " + msg
+	}
+	SetOpsUpstreamError(c, upstreamStatusCode, msg, code)
+}
+
+// tkWrapBridgeRelayError records the real upstream status of a New API bridge
+// dispatch error (see TkRecordBridgeUpstreamError) and wraps it as a
+// *NewAPIRelayError. Use at every dispatch site that wraps a real bridge upstream
+// error (NOT the synthetic missing-credential / unsupported-channel errors, which
+// carry no upstream verdict). This is the TokenKey-service chokepoint between the
+// bridge (which cannot call up into internal/service) and the handler.
+func tkWrapBridgeRelayError(c *gin.Context, apiErr *newapitypes.NewAPIError) *NewAPIRelayError {
+	if apiErr != nil {
+		TkRecordBridgeUpstreamError(c, apiErr.StatusCode, apiErr)
+	}
+	return &NewAPIRelayError{Err: apiErr}
+}

--- a/backend/internal/service/newapi_model_not_found_tk_test.go
+++ b/backend/internal/service/newapi_model_not_found_tk_test.go
@@ -1,0 +1,65 @@
+//go:build unit
+
+package service
+
+import (
+	"errors"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+
+	newapitypes "github.com/QuantumNous/new-api/types"
+	"github.com/gin-gonic/gin"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestIsOpenAICompatModelNotFound404(t *testing.T) {
+	cases := []struct {
+		name string
+		body string
+		msg  string
+		want bool
+	}{
+		{"volcengine error.code in JSON body", `{"error":{"code":"InvalidEndpointOrModel.NotFound","message":"The model ` + "`x`" + ` does not exist or you do not have access to it."}}`, "", true},
+		{"volcengine message substring", "", "The model `doubao-lite-32k-240828` does not exist or you do not have access to it.", true},
+		{"code-prefixed message (as recorded by the bridge dispatch)", "", "InvalidEndpointOrModel.NotFound: The model `x` does not exist or you do not have access to it.", true},
+		{"genuine 5xx is NOT model-not-found", `{"error":{"message":"upstream service temporarily unavailable"}}`, "Upstream request failed", false},
+		{"rate limit is NOT model-not-found", "", "Upstream rate limit exceeded, please retry later", false},
+		{"empty", "", "", false},
+	}
+	for _, tc := range cases {
+		assert.Equalf(t, tc.want, IsOpenAICompatModelNotFound404([]byte(tc.body), tc.msg), "case %q", tc.name)
+	}
+}
+
+func TestTkRecordBridgeUpstreamError_RecordsRealUpstream404(t *testing.T) {
+	gin.SetMode(gin.TestMode)
+
+	// nil-safe.
+	TkRecordBridgeUpstreamError(nil, http.StatusNotFound, nil)
+
+	rec := httptest.NewRecorder()
+	c, _ := gin.CreateTestContext(rec)
+	TkRecordBridgeUpstreamError(c, http.StatusNotFound, nil) // nil err is a no-op
+	_, ok := c.Get(OpsUpstreamStatusCodeKey)
+	require.False(t, ok, "nil err must not touch the ops context")
+
+	apiErr := newapitypes.NewErrorWithStatusCode(
+		errors.New("The model `doubao-lite-32k-240828` does not exist or you do not have access to it."),
+		newapitypes.ErrorCode("InvalidEndpointOrModel.NotFound"),
+		http.StatusNotFound,
+	)
+	TkRecordBridgeUpstreamError(c, apiErr.StatusCode, apiErr)
+
+	status, ok := c.Get(OpsUpstreamStatusCodeKey)
+	require.True(t, ok)
+	require.Equal(t, http.StatusNotFound, status)
+
+	msg, ok := c.Get(OpsUpstreamErrorMessageKey)
+	require.True(t, ok)
+	// The code is prefixed into the message so the ops classifier (which reads only
+	// the single-field message key) can see the InvalidEndpointOrModel.NotFound signal.
+	require.True(t, IsOpenAICompatModelNotFound404(nil, msg.(string)),
+		"recorded message must be recognized as a model-not-found")
+}

--- a/backend/internal/service/openai_gateway_bridge_dispatch.go
+++ b/backend/internal/service/openai_gateway_bridge_dispatch.go
@@ -51,7 +51,7 @@ func (s *OpenAIGatewayService) ForwardAsChatCompletionsDispatched(
 			zap.String("bridge_path", "newapi_adaptor_error"),
 			zap.Int64("account_id", account.ID),
 		)
-		return nil, &NewAPIRelayError{Err: apiErr}
+		return nil, tkWrapBridgeRelayError(c, apiErr)
 	}
 	logger.L().Info("openai_gateway.newapi_bridge_dispatch",
 		zap.String("endpoint", BridgeEndpointChatCompletions),
@@ -123,7 +123,7 @@ func (s *OpenAIGatewayService) ForwardAsResponsesDispatched(
 			zap.String("bridge_path", "newapi_adaptor_error"),
 			zap.Int64("account_id", account.ID),
 		)
-		return nil, &NewAPIRelayError{Err: apiErr}
+		return nil, tkWrapBridgeRelayError(c, apiErr)
 	}
 	logger.L().Info("openai_gateway.newapi_bridge_dispatch",
 		zap.String("endpoint", BridgeEndpointResponses),
@@ -174,7 +174,7 @@ func (s *OpenAIGatewayService) ForwardAsEmbeddingsDispatched(
 			zap.String("bridge_path", "newapi_adaptor_error"),
 			zap.Int64("account_id", account.ID),
 		)
-		return nil, &NewAPIRelayError{Err: apiErr}
+		return nil, tkWrapBridgeRelayError(c, apiErr)
 	}
 	logger.L().Info("openai_gateway.newapi_bridge_dispatch",
 		zap.String("endpoint", BridgeEndpointEmbeddings),
@@ -225,7 +225,7 @@ func (s *OpenAIGatewayService) ForwardAsImageGenerationsDispatched(
 			zap.String("bridge_path", "newapi_adaptor_error"),
 			zap.Int64("account_id", account.ID),
 		)
-		return nil, &NewAPIRelayError{Err: apiErr}
+		return nil, tkWrapBridgeRelayError(c, apiErr)
 	}
 	logger.L().Info("openai_gateway.newapi_bridge_dispatch",
 		zap.String("endpoint", BridgeEndpointImages),

--- a/backend/internal/service/openai_gateway_bridge_dispatch_tk_anthropic.go
+++ b/backend/internal/service/openai_gateway_bridge_dispatch_tk_anthropic.go
@@ -125,7 +125,7 @@ func (s *OpenAIGatewayService) ForwardAsAnthropicDispatched(
 			message = "Bridge dispatch failed"
 		}
 		writeAnthropicError(c, statusCode, errType, message)
-		return nil, &NewAPIRelayError{Err: apiErr}
+		return nil, tkWrapBridgeRelayError(c, apiErr)
 	}
 
 	logger.L().Info("openai_gateway.newapi_bridge_anthropic_dispatch",

--- a/backend/internal/service/openai_gateway_bridge_dispatch_tk_video.go
+++ b/backend/internal/service/openai_gateway_bridge_dispatch_tk_video.go
@@ -78,7 +78,7 @@ func (s *OpenAIGatewayService) ForwardAsVideoSubmitDispatched(
 			zap.String("bridge_path", "newapi_adaptor_error"),
 			zap.Int64("account_id", account.ID),
 		)
-		return nil, &NewAPIRelayError{Err: apiErr}
+		return nil, tkWrapBridgeRelayError(c, apiErr)
 	}
 	logger.L().Info("openai_gateway.newapi_bridge_dispatch",
 		zap.String("endpoint", BridgeEndpointVideoSubmit),
@@ -113,7 +113,7 @@ func (s *OpenAIGatewayService) ForwardAsVideoFetchDispatched(
 			zap.String("bridge_path", "newapi_adaptor_error"),
 			zap.String("upstream_task_id", in.UpstreamTaskID),
 		)
-		return nil, &NewAPIRelayError{Err: apiErr}
+		return nil, tkWrapBridgeRelayError(c, apiErr)
 	}
 	logger.L().Info("openai_gateway.newapi_bridge_dispatch",
 		zap.String("endpoint", BridgeEndpointVideoFetch),


### PR DESCRIPTION
## 背景(③ 系统性修复)

2026-06-10 prod P0(`upstream_error_rate 30%`)的**放大机制**:newapi 渠道(火山)对外宣告了上游**未开通/已下线**的模型,客户请求 → ark 返 `404 InvalidEndpointOrModel.NotFound` → newapi bridge **吞码**包成裸 `502` → `error_type=upstream_error` → `phase=upstream / owner=provider` → 计入 `upstream_error_rate`。**一个渠道配置漂移被放大成「上游全站故障」假 P0**,还带偏排查方向。这是一整类风险:任何 newapi 渠道将来再宣告不可用模型都会复发。

Anthropic 侧早有对称处置(#617 上游 404→客户端 400;#602/#628 caller-fault 上游错误归 `phase=request` 移出指标),**但 newapi/openai-compat 平台没覆盖**。

## 根因(已 trace 坐实)

- 事故 502 行:`error_type=upstream_error`、`upstream_status_code=null`、`error_message="Upstream request failed"`(通用兜底体)。
- newapi bridge 失败常落到 `ensureForwardErrorResponse` 通用兜底,**从不调 `SetOpsUpstreamError`** → `upstream_status_code=null`,ops 分类器看不到真实 404,既有谓词 `tkUpstreamClientInducedRejection`(要求 `upstreamError=true`)**根本不触发**。
- 注:bridge 包(`internal/relay/bridge`)的 `service.` 是 **new-api 的 service**;TokenKey `internal/service` → bridge 是单向依赖,bridge 反向调不了 TokenKey service。所以注入点必须在 **TokenKey service 的 dispatch 层**。

## 修复(Part A · 指标修复 = 防复发)

- **`IsOpenAICompatModelNotFound404`**(新 helper,镜像 `IsAnthropicModelNotFound404`):认火山 `InvalidEndpointOrModel.NotFound` / "does not exist or you do not have access"。
- **`tkWrapBridgeRelayError`**:在 dispatch 层(bridge→handler chokepoint,能调 `SetOpsUpstreamError`)记录真实上游 `status` + `code`,覆盖 **chat / responses / embeddings / images / video** 全 newapi 面。code 前缀拼进 message(ops 分类器只读单字段 message 键)。
- 扩 `tkUpstreamClientInducedRejection` 404 分支 `|| IsOpenAICompatModelNotFound404(...)`。

→ newapi 404 model-not-found → `phase=request / owner=client`,**移出 upstream_error_rate**;真 5xx/429 不受影响(谓词不命中,仍 provider-owned)。**顺带修了 `upstream_status_code=null` 数据质量 bug**(newapi bridge HTTP 错误现都带真实 status)。

## 不在本 PR(Part B)

客户端响应仍为 502/上游码。「502→400 客户端响应」的响应路径 murky(经某 early-write/streaming 交互落到通用兜底),需 **live 抓一个真实 newapi-404** 才能放准注入点,另做。本 PR 只关掉假 P0(核心)。

## 验证

- `go build ./...` + `go test -tags=unit ./internal/service/... ./internal/handler/... ./internal/relay/bridge/... ./internal/server/...` 全绿。
- 新增:`IsOpenAICompatModelNotFound404` 真值表(火山 404 命中、真 5xx/429 不命中)、`TkRecordBridgeUpstreamError` context 断言、handler 分类用例(**newapi 404→client / 真 503→provider 对照** + 既有 anthropic 404 回归)。
- `scripts/preflight.sh` PASS。

## Checklist
- [x] 单测/构建/preflight 全绿
- [x] 纯后端:`no-web-impact`;TK-owned newapi bridge/ops 代码、未删上游符号:`no-upstream-touch`
- [x] 无 schema 变更、无迁移
- [x] 不碰计费/调度/响应体(纯 ops 分类 + 上游 status 传播)

## 上线后复验(可选)
下次有 un-开通 newapi 模型时:`ops_error_logs` 该 404 行应 `error_phase=request / error_owner=client / upstream_status_code=404`,`upstream_error_rate` 不受其影响。

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
sentinel-registry-reviewed: 审过被触动的 sentinel 热点 `ops_error_logger_tk_client_induced_upstream.go`——改动是在既有 404 分支追加 `|| service.IsOpenAICompatModelNotFound404(...)`,所有 anchor(`if status == 404 {`、`service.IsAnthropicModelNotFound404([]byte(body), msg)`)均完好,无 anchor 变更。dispatch 文件的改动是把 `&NewAPIRelayError{Err: apiErr}` 等价替换为 `tkWrapBridgeRelayError(c, apiErr)`(仍构造同一 NewAPIRelayError),guarded anchor(ImageCount / ForwardAsVideo* / BridgeEndpoint*)均完好。