### PR TITLE
feat(pricing): 用户级页面隐藏倍率 + pricing 页统一官方定价 + 目录重命名（接续 #693）

### DIFF
--- a/backend/internal/service/me_pricing_catalog_tk.go
+++ b/backend/internal/service/me_pricing_catalog_tk.go
@@ -1,6 +1,6 @@
 package service
 
-// TokenKey: per-user pricing catalog ("Your Menu").
+// TokenKey: per-user pricing catalog ("Group Catalog" / "分组目录").
 //
 // Unlike service.PricingCatalogService.BuildPublicCatalog (a platform-wide
 // flat list of LiteLLM list prices), MePricingCatalogService builds a view
@@ -509,7 +509,7 @@ func (s *MePricingCatalogService) buildModelsForGroup(
 //     allowed, the native OAuth case) — emit the platform's canonical
 //     model list (claude/openai/gemini/antigravity default models, the
 //     same source gateway `/v1/models` uses). This is what fixes the
-//     empty "Your Menu" for Anthropic OAuth groups: those accounts are
+//     empty "Group Catalog" for Anthropic OAuth groups: those accounts are
 //     not channels and carry no whitelist, so before this branch both
 //     the channel stage and the whitelist stage produced nothing.
 //
@@ -585,7 +585,7 @@ func addFallbackModel(
 }
 
 // platformDefaultModelIDs returns the model-ID list an unrestricted native
-// account contributes to Your Menu.
+// account contributes to the Group Catalog.
 //
 // Anthropic / OpenAI use the empirically-servable allowlist
 // (supportedCatalogModelIDsForPlatform) — the SAME source the public /pricing

--- a/backend/internal/service/me_pricing_catalog_tk.go
+++ b/backend/internal/service/me_pricing_catalog_tk.go
@@ -5,10 +5,15 @@ package service
 // Unlike service.PricingCatalogService.BuildPublicCatalog (a platform-wide
 // flat list of LiteLLM list prices), MePricingCatalogService builds a view
 // scoped to ONE group — the group of the user's selected API key, or any
-// other group the user can access ("explore other group" mode). Prices
-// are the prices the user is actually charged: channel-configured rates
-// multiplied by `group.rate_multiplier`, with `user_group_rate` override
-// layered on top.
+// other group the user can access ("explore other group" mode).
+//
+// TK pricing-display policy (运营要求，展示端与倍率彻底脱钩): the prices
+// emitted here are the OFFICIAL list prices (multiplier 1.0) — they do NOT
+// apply `group.rate_multiplier` nor the `user_group_rate` override. The
+// pricing page ("分组目录"/"所有目录") is a catalog of official prices; a
+// customer's real cost depends on their (hidden) rate. The billing path is
+// unaffected: the gateway still charges the true effective rate. `your_price`
+// keeps its field name for DTO stability but now carries the official price.
 //
 // Why a separate service / why not extend ChannelService.ListAvailable:
 //   - This is a TK-only surface; ChannelService is upstream-shaped and we
@@ -20,17 +25,14 @@ package service
 //   - LiteLLM metadata (context_window, capabilities) is joined post-hoc
 //     from PricingCatalogService — the channel layer doesn't carry those.
 //
-// Pricing precedence (matches gateway billing path):
-//   effective_rate = user_group_rate[group_id]  if present
-//                  else group.rate_multiplier
-//   A user_group_rate of 0 is the legitimate "free subscription" value
-//   and is NOT short-circuited — we emit zeros.
+// Effective rate (user_group_rate override else group.rate_multiplier) is
+// still computed for the target_group rate hint fields (see #693's
+// HideUserRateOverrides), but it is NO LONGER applied to model prices.
 //
 // Multi-channel dedupe rule: when the same model_id appears on multiple
 // active channels mapped to the target group, we keep the row with the
-// LOWEST combined input+output price. This matches the implicit promise
-// of "your menu" — the headline price equals the cheapest path the user
-// can actually be billed under.
+// LOWEST combined input+output (official) price — the headline price equals
+// the cheapest catalog path for that model.
 
 import (
 	"context"
@@ -233,7 +235,8 @@ const keyListPageSize = 200
 //  4. Walk channels, filter to active + mapped to target group, filter
 //     SupportedModels.Platform == targetGroup.Platform (cross-platform leak guard).
 //  5. Dedupe by model_id, keep the cheapest (input + output sum) row.
-//  6. Multiply every price by effectiveRate.
+//  6. Emit OFFICIAL prices (multiplier 1.0) — effectiveRate is computed but
+//     NOT applied to model prices (TK pricing-display policy; see file header).
 //  7. Join LiteLLM metadata for capabilities / context_window / max_output.
 //  8. Sort alpha by model_id.
 func (s *MePricingCatalogService) BuildForUser(
@@ -300,10 +303,13 @@ func (s *MePricingCatalogService) BuildForUser(
 		hasOverride = r != listMult
 	}
 
-	models := s.buildModelsForGroup(ctx, targetGroup, effective)
+	// TK: 模型价格一律按官方基础价（倍率 1.0）计算，不乘 effective/override。
+	// pricing 页是官方定价目录；真实计费在网关按 effective 倍率执行，不受此影响。
+	const officialRate = 1.0
+	models := s.buildModelsForGroup(ctx, targetGroup, officialRate)
 
-	// HideUserRateOverrides：倍率提示字段回落到分组默认值（your_price 已按
-	// 真实 effective 计算完毕，不回滚——价格必须与实际计费一致）。
+	// HideUserRateOverrides：倍率提示字段回落到分组默认值（前端已不再渲染这些
+	// 字段——pricing 页与倍率彻底脱钩——但保留 #693 的口径以稳住 DTO 与测试）。
 	shownRate := effective
 	shownOverride := hasOverride
 	if opts.HideUserRateOverrides {

--- a/backend/internal/service/me_pricing_catalog_tk_test.go
+++ b/backend/internal/service/me_pricing_catalog_tk_test.go
@@ -184,7 +184,9 @@ func mkPublicCatalogModel(modelID, vendor string, in, out, cacheR float64) Publi
 
 // ----- tests -----
 
-func TestMePricingCatalog_DefaultToFirstKeyGroup_AppliesGroupMultiplier(t *testing.T) {
+// TK: 价格一律官方基价（倍率 1.0），TargetGroup 的 RateMultiplier 字段仍反映
+// 真实生效倍率（1.5），但不再作用于 YourPrice。
+func TestMePricingCatalog_DefaultToFirstKeyGroup_OfficialPrice(t *testing.T) {
 	gPro := mkGroupForMe(10, "Pro", "newapi", 1.5)
 	gMax := mkGroupForMe(20, "Max", "newapi", 0.8)
 	k1 := mkKeyForMe(1, 7, "default", ptrI(10))
@@ -210,9 +212,9 @@ func TestMePricingCatalog_DefaultToFirstKeyGroup_AppliesGroupMultiplier(t *testi
 	assert.Equal(t, 1.5, resp.TargetGroup.ListMultiplier)
 	assert.False(t, resp.TargetGroup.HasOverride)
 	require.Len(t, resp.Models, 1)
-	// 0.000003 * 1000 * 1.5 = 0.0045
-	assert.InDelta(t, 0.0045, *resp.Models[0].YourPrice.InputPer1K, 1e-9)
-	assert.InDelta(t, 0.0225, *resp.Models[0].YourPrice.OutputPer1K, 1e-9)
+	// 官方基价：0.000003 * 1000 = 0.003（不乘 1.5 倍率）
+	assert.InDelta(t, 0.003, *resp.Models[0].YourPrice.InputPer1K, 1e-9)
+	assert.InDelta(t, 0.015, *resp.Models[0].YourPrice.OutputPer1K, 1e-9)
 	// my_keys + accessible_groups populated
 	require.Len(t, resp.MyKeys, 1)
 	assert.Equal(t, int64(1), resp.MyKeys[0].ID)
@@ -249,15 +251,18 @@ func TestMePricingCatalog_UserOverrideTakesPrecedence(t *testing.T) {
 	)
 	resp, err := svc.BuildForUser(context.Background(), 7, MePricingCatalogOptions{})
 	require.NoError(t, err)
+	// 覆写仍体现在 RateMultiplier 字段（生效 0.5），但价格按官方基价展示。
 	assert.Equal(t, 0.5, resp.TargetGroup.RateMultiplier)
 	assert.Equal(t, 1.0, resp.TargetGroup.ListMultiplier)
 	assert.True(t, resp.TargetGroup.HasOverride)
-	// 0.000010 * 1000 * 0.5 = 0.005
-	assert.InDelta(t, 0.005, *resp.Models[0].YourPrice.InputPer1K, 1e-9)
-	assert.InDelta(t, 0.010, *resp.Models[0].YourPrice.OutputPer1K, 1e-9)
+	// 官方基价：0.000010 * 1000 = 0.01（不乘 0.5 覆写）
+	assert.InDelta(t, 0.01, *resp.Models[0].YourPrice.InputPer1K, 1e-9)
+	assert.InDelta(t, 0.02, *resp.Models[0].YourPrice.OutputPer1K, 1e-9)
 }
 
-func TestMePricingCatalog_ZeroRateIsLegitFree(t *testing.T) {
+// TK: rate 0（免费订阅）仍体现在 RateMultiplier 字段，但 pricing 页与倍率
+// 脱钩——展示官方基价而非 0。真实计费在网关按 0 倍率执行。
+func TestMePricingCatalog_ZeroRateShownAsOfficialPrice(t *testing.T) {
 	gPro := mkGroupForMe(10, "Pro", "newapi", 1.0)
 	k1 := mkKeyForMe(1, 7, "default", ptrI(10))
 
@@ -281,8 +286,9 @@ func TestMePricingCatalog_ZeroRateIsLegitFree(t *testing.T) {
 	require.NoError(t, err)
 	assert.Equal(t, 0.0, resp.TargetGroup.RateMultiplier)
 	assert.True(t, resp.TargetGroup.HasOverride)
-	assert.Equal(t, 0.0, *resp.Models[0].YourPrice.InputPer1K)
-	assert.Equal(t, 0.0, *resp.Models[0].YourPrice.OutputPer1K)
+	// 官方基价（不因 rate 0 归零）：0.000010 * 1000 = 0.01
+	assert.InDelta(t, 0.01, *resp.Models[0].YourPrice.InputPer1K, 1e-9)
+	assert.InDelta(t, 0.02, *resp.Models[0].YourPrice.OutputPer1K, 1e-9)
 }
 
 func TestMePricingCatalog_ExploreOtherGroup(t *testing.T) {
@@ -567,7 +573,8 @@ func TestMePricingCatalog_PerRequestBillingPreservesPrice(t *testing.T) {
 	require.Len(t, resp.Models, 1)
 	assert.Equal(t, string(BillingModePerRequest), resp.Models[0].BillingMode)
 	require.NotNil(t, resp.Models[0].YourPrice.PerRequest)
-	assert.InDelta(t, 0.04, *resp.Models[0].YourPrice.PerRequest, 1e-9)
+	// 官方基价：per-request 0.02（不乘 2.0 倍率）
+	assert.InDelta(t, 0.02, *resp.Models[0].YourPrice.PerRequest, 1e-9)
 	assert.Nil(t, resp.Models[0].YourPrice.InputPer1K)
 }
 
@@ -576,8 +583,8 @@ func TestMePricingCatalog_PerRequestBillingPreservesPrice(t *testing.T) {
 // TestBuildForUser_AccountWhitelistOnly_NoChannels mirrors the production
 // incident that motivated the bridge: operator created an account, ticked
 // the model-whitelist boxes in admin, never configured any channels. The
-// menu should reflect the whitelist with LiteLLM-derived default prices
-// × group rate, not be empty.
+// menu should reflect the whitelist with LiteLLM-derived OFFICIAL prices
+// (decoupled from group rate), not be empty.
 func TestBuildForUser_AccountWhitelistOnly_NoChannels(t *testing.T) {
 	gOpenAI := mkGroupForMe(30, "GPT", "openai", 2.0)
 	k1 := mkKeyForMe(1, 7, "gpt-key", ptrI(30))
@@ -603,11 +610,11 @@ func TestBuildForUser_AccountWhitelistOnly_NoChannels(t *testing.T) {
 	}
 	require.Contains(t, byID, "gpt-5.2")
 	require.NotNil(t, byID["gpt-5.2"].YourPrice.InputPer1K)
-	assert.InDelta(t, 0.010, *byID["gpt-5.2"].YourPrice.InputPer1K, 1e-9, "0.005 catalog × 2.0 effective rate")
+	assert.InDelta(t, 0.005, *byID["gpt-5.2"].YourPrice.InputPer1K, 1e-9, "0.005 catalog 官方价（不乘 2.0 倍率）")
 	require.NotNil(t, byID["gpt-5.2"].YourPrice.OutputPer1K)
-	assert.InDelta(t, 0.040, *byID["gpt-5.2"].YourPrice.OutputPer1K, 1e-9, "0.020 catalog × 2.0 effective rate")
+	assert.InDelta(t, 0.020, *byID["gpt-5.2"].YourPrice.OutputPer1K, 1e-9, "0.020 catalog 官方价（不乘 2.0 倍率）")
 	require.NotNil(t, byID["gpt-4o"].YourPrice.InputPer1K)
-	assert.InDelta(t, 0.005, *byID["gpt-4o"].YourPrice.InputPer1K, 1e-9)
+	assert.InDelta(t, 0.0025, *byID["gpt-4o"].YourPrice.InputPer1K, 1e-9, "0.0025 catalog 官方价")
 }
 
 // TestBuildForUser_ChannelAndAccount_ChannelWins guards the "channel

--- a/backend/internal/web/dist/frontend-source.json
+++ b/backend/internal/web/dist/frontend-source.json
@@ -1,7 +1,7 @@
 {
   "algorithm": "sha256(git-ls-files:path,size,content)",
   "file_count": 462,
-  "hash": "4972b2b67330c9fa5e0c46fae00920c036858ce1327518480a5e38432e7efc3d",
+  "hash": "4540f37e17a949907e96b57d1269f8c546c562c8ad8faa9f6f525ebc0de223b2",
   "schema": 1,
   "source": "frontend/"
 }

--- a/backend/internal/web/dist/frontend-source.json
+++ b/backend/internal/web/dist/frontend-source.json
@@ -1,7 +1,7 @@
 {
   "algorithm": "sha256(git-ls-files:path,size,content)",
   "file_count": 462,
-  "hash": "997aee9eedb747d0315cc980289eff14350ff122b2fa019e75584f140fc3f125",
+  "hash": "4972b2b67330c9fa5e0c46fae00920c036858ce1327518480a5e38432e7efc3d",
   "schema": 1,
   "source": "frontend/"
 }

--- a/frontend/src/api/me-pricing.ts
+++ b/frontend/src/api/me-pricing.ts
@@ -3,10 +3,10 @@
  *
  * Backed by GET /api/v1/me/pricing-catalog
  * (handler/me_pricing_catalog_handler_tk.go). Returns the model menu for
- * the group of the user's selected API key, with prices already multiplied
- * by the user's effective rate (group.rate_multiplier × per-user override).
- * The same endpoint serves the "explore other group" comparison view when
- * `group_id` is supplied.
+ * the group of the user's selected API key, at OFFICIAL list prices —
+ * decoupled from the group/override rate (TK pricing-display policy; see
+ * me_pricing_catalog_tk.go header). The same endpoint serves the "explore
+ * other group" comparison view when `group_id` is supplied.
  *
  * Response shape uses the standard `{code,message,data}` envelope, which
  * the axios response interceptor unwraps — callers receive the `data`
@@ -19,10 +19,11 @@ import { apiClient } from './client'
 export type MePricingBillingMode = 'token' | 'per_request' | 'image' | string
 
 /**
- * "Your price" — already multiplied by effective rate (group default ×
- * per-user override). Per-1k for token modes; per-call for per_request.
- * Nil-valued fields mean "no data" (the field is omitted from the JSON
- * payload entirely thanks to backend `omitempty`).
+ * Official list price (field name kept as `your_price` for DTO stability,
+ * but no longer multiplied by the group/override rate). Per-1k for token
+ * modes; per-call for per_request. Nil-valued fields mean "no data" (the
+ * field is omitted from the JSON payload entirely thanks to backend
+ * `omitempty`).
  */
 export interface MePricingPrice {
   currency: string

--- a/frontend/src/components/channels/AvailableChannelsTable.vue
+++ b/frontend/src/components/channels/AvailableChannelsTable.vue
@@ -94,6 +94,7 @@
                   :rate-multiplier="g.rate_multiplier"
                   :user-rate-multiplier="userGroupRates[g.id] ?? null"
                   always-show-rate
+                  hide-rate-value
                 />
               </div>
               <div
@@ -116,6 +117,7 @@
                   :rate-multiplier="g.rate_multiplier"
                   :user-rate-multiplier="userGroupRates[g.id] ?? null"
                   always-show-rate
+                  hide-rate-value
                 />
               </div>
               <span v-if="section.groups.length === 0" class="text-xs text-gray-400">-</span>

--- a/frontend/src/components/common/GroupBadge.vue
+++ b/frontend/src/components/common/GroupBadge.vue
@@ -43,6 +43,12 @@ interface Props {
    * 只关心费率、不关心有效期的场景）。
    */
   alwaysShowRate?: boolean
+  /**
+   * TK: 用户级页面隐藏倍率数值。开启后不展示标准倍率标签 `{rate}x` 与删除线
+   * 专属倍率（订阅「订阅/剩余天数」标签仍保留——那不是倍率）。运营要求倍率仅
+   * 在管理页可见、用户页一律不可见；调用方在用户视图传入 true。
+   */
+  hideRateValue?: boolean
 }
 
 const props = withDefaults(defineProps<Props>(), {
@@ -50,15 +56,22 @@ const props = withDefaults(defineProps<Props>(), {
   showRate: true,
   daysRemaining: null,
   userRateMultiplier: null,
-  alwaysShowRate: false
+  alwaysShowRate: false,
+  hideRateValue: false
 })
 
 const { t } = useI18n()
 
 const isSubscription = computed(() => props.subscriptionType === 'subscription')
 
-// 是否有专属倍率（且与默认倍率不同）
+// TK: hideRateValue 时把 always-show-rate 视为关闭，使订阅组回落到「订阅/天数」
+// 标签而非倍率。
+const effectiveAlwaysShowRate = computed(() => props.alwaysShowRate && !props.hideRateValue)
+
+// 是否有专属倍率（且与默认倍率不同）。hideRateValue 时一律视为无，绝不展示
+// 删除线专属倍率。
 const hasCustomRate = computed(() => {
+  if (props.hideRateValue) return false
   return (
     props.userRateMultiplier !== null &&
     props.userRateMultiplier !== undefined &&
@@ -70,16 +83,17 @@ const hasCustomRate = computed(() => {
 // 是否显示右侧标签
 const showLabel = computed(() => {
   if (!props.showRate) return false
-  // 订阅类型：显示天数或"订阅"
+  // 订阅类型：显示天数或"订阅"（非倍率，hideRateValue 不影响）
   if (isSubscription.value) return true
-  // 标准类型：显示倍率（包括专属倍率）
+  // 标准类型：显示倍率（包括专属倍率）—— hideRateValue 时整体隐藏
+  if (props.hideRateValue) return false
   return props.rateMultiplier !== undefined || hasCustomRate.value
 })
 
 // Label text
 const labelText = computed(() => {
   const rateLabel = props.rateMultiplier !== undefined ? `${props.rateMultiplier}x` : ''
-  if (isSubscription.value && !props.alwaysShowRate) {
+  if (isSubscription.value && !effectiveAlwaysShowRate.value) {
     // 如果有剩余天数，显示天数
     if (props.daysRemaining !== null && props.daysRemaining !== undefined) {
       if (props.daysRemaining <= 0) {

--- a/frontend/src/components/common/GroupOptionItem.vue
+++ b/frontend/src/components/common/GroupOptionItem.vue
@@ -25,7 +25,7 @@
     <!-- Right: rate pill + checkmark (vertically centered to first row) -->
     <div class="flex shrink-0 items-center gap-2 pt-0.5">
       <!-- Rate pill (platform color) -->
-      <span v-if="rateMultiplier !== undefined" :class="['inline-flex items-center whitespace-nowrap rounded-full px-3 py-1 text-xs font-semibold', ratePillClass]">
+      <span v-if="rateMultiplier !== undefined && !hideRateValue" :class="['inline-flex items-center whitespace-nowrap rounded-full px-3 py-1 text-xs font-semibold', ratePillClass]">
         <template v-if="hasCustomRate">
           <span class="mr-1 line-through opacity-50">{{ rateMultiplier }}x</span>
           <span class="font-bold">{{ userRateMultiplier }}x</span>
@@ -63,13 +63,19 @@ interface Props {
   description?: string | null
   selected?: boolean
   showCheckmark?: boolean
+  /**
+   * TK: 用户级页面隐藏倍率数值。开启后右侧倍率 pill 整体不渲染。运营要求倍率
+   * 仅在管理页可见、用户页一律不可见；调用方在用户视图传入 true。
+   */
+  hideRateValue?: boolean
 }
 
 const props = withDefaults(defineProps<Props>(), {
   subscriptionType: 'standard',
   selected: false,
   showCheckmark: true,
-  userRateMultiplier: null
+  userRateMultiplier: null,
+  hideRateValue: false
 })
 
 // Whether user has a custom rate different from default

--- a/frontend/src/components/common/__tests__/GroupBadge.spec.ts
+++ b/frontend/src/components/common/__tests__/GroupBadge.spec.ts
@@ -52,3 +52,50 @@ describe('GroupBadge (newapi visual parity)', () => {
     expect(html).not.toContain('bg-violet-100')
   })
 })
+
+// TK: 用户级页面隐藏倍率（hideRateValue）。倍率数值一律不展示，但订阅
+// 「订阅/天数」标签保留（那不是倍率）。
+describe('GroupBadge (hideRateValue — user-facing pages)', () => {
+  it('hides the standard rate label when hideRateValue', () => {
+    const wrapper = mountBadge({ rateMultiplier: 1.5, hideRateValue: true })
+    expect(wrapper.text()).not.toContain('1.5x')
+  })
+
+  it('hides the 1x default rate too', () => {
+    const wrapper = mountBadge({ rateMultiplier: 1, hideRateValue: true })
+    expect(wrapper.text()).not.toContain('1x')
+  })
+
+  it('hides the struck-through per-user override when hideRateValue', () => {
+    const wrapper = mountBadge({
+      rateMultiplier: 2,
+      userRateMultiplier: 0.5,
+      hideRateValue: true,
+    })
+    const text = wrapper.text()
+    expect(text).not.toContain('2x')
+    expect(text).not.toContain('0.5x')
+  })
+
+  it('still shows the standard rate when hideRateValue is not set', () => {
+    const wrapper = mountBadge({ rateMultiplier: 1.5 })
+    expect(wrapper.text()).toContain('1.5x')
+  })
+
+  it('keeps the subscription days label even when hideRateValue (not a rate)', () => {
+    // alwaysShowRate would normally force the rate; hideRateValue must fall the
+    // subscription badge back to its days label and drop the rate value.
+    // (i18n interpolation is disabled in this test build, so the days label
+    // renders as the raw key — we assert the rate is gone + the label exists.)
+    const wrapper = mountBadge({
+      subscriptionType: 'subscription',
+      daysRemaining: 15,
+      alwaysShowRate: true,
+      rateMultiplier: 3,
+      hideRateValue: true,
+    })
+    const text = wrapper.text()
+    expect(text).not.toContain('3x')
+    expect(text).toContain('daysRemaining')
+  })
+})

--- a/frontend/src/i18n/locales/en.ts
+++ b/frontend/src/i18n/locales/en.ts
@@ -50,24 +50,24 @@ export default {
     ctaBonus: 'Register — get {amount} trial credit',
     ctaBonusHint: 'Shown when signup bonus is enabled for this site.',
     perRequest: '/ request',
-    // TK: authenticated "Your Menu" view (GET /api/v1/me/pricing-catalog).
+    // TK: authenticated "Group Catalog" view (GET /api/v1/me/pricing-catalog).
+    // Prices always show official list pricing, decoupled from group/override
+    // multipliers.
     my: {
-      tabMy: 'Your Menu',
-      tabPublic: 'Public Catalog',
-      title: 'Your Model Menu',
-      subtitle: 'Models available to the group of your selected API key, at your effective price',
+      tabMy: 'Group Catalog',
+      tabPublic: 'All Catalog',
+      title: 'Group Model Catalog',
+      subtitle: 'Models available to the group of your selected API key, at official pricing',
       description:
-        'Prices are already multiplied by your effective rate (group default × your override), per 1,000 tokens. Switch keys to see another group, or compare other accessible groups to decide whether to upgrade.',
+        'Shows the models available to the selected group and their official pricing, per 1,000 tokens. Switch keys to see another group, or compare other accessible groups.',
       pickerKey: 'Current key:',
       pickerCompare: 'Compare group:',
       compareDefault: 'Keep current',
       noKeyHint: 'You have no active API keys yet — create one in the console first.',
       columns: {
-        input: 'Input (your price)',
-        output: 'Output (your price)'
+        input: 'Input (official price)',
+        output: 'Output (official price)'
       },
-      rateHint: 'Multiplier {multiplier} applied',
-      rateOverride: 'includes personal override',
       empty: {
         noAccess: {
           title: 'No accessible group',
@@ -79,7 +79,7 @@ export default {
         }
       },
       exploreBanner: {
-        message: 'Viewing {group} catalog · multiplier ×{multiplier}',
+        message: 'Viewing {group} catalog',
         cta: 'Create key in {group}'
       },
       billingMode: {

--- a/frontend/src/i18n/locales/zh.ts
+++ b/frontend/src/i18n/locales/zh.ts
@@ -49,24 +49,23 @@ export default {
     ctaBonus: '立即注册 · 获赠 {amount} 试用额度',
     ctaBonusHint: '当本站开启注册赠额时显示此提示。',
     perRequest: '/ 次',
-    // TK: 登录态「我的菜单」视图（GET /api/v1/me/pricing-catalog）
+    // TK: 登录态「分组目录」视图（GET /api/v1/me/pricing-catalog）。价格一律
+    // 展示官方定价，与分组倍率/个人覆写脱钩。
     my: {
-      tabMy: '我的菜单',
-      tabPublic: '公开目录',
-      title: '我的模型菜单',
-      subtitle: '当前 API Key 所属分组可调用的模型与你的实际单价',
+      tabMy: '分组目录',
+      tabPublic: '所有目录',
+      title: '分组模型目录',
+      subtitle: '当前 API Key 所属分组可调用的模型与官方定价',
       description:
-        '价格已按你的有效倍率（分组默认 × 个人覆写）计算，单位为每 1,000 tokens。切换 API Key 查看不同 group，或对比其他可用 group 决定是否升级。',
+        '展示所选分组可调用的模型及其官方定价，单位为每 1,000 tokens。切换 API Key 查看不同 group，或对比其他可用 group。',
       pickerKey: '当前 Key：',
       pickerCompare: '对比其他 group：',
       compareDefault: '保持当前',
       noKeyHint: '你还没有可用的 API Key，先去控制台创建一个。',
       columns: {
-        input: '输入（你的单价）',
-        output: '输出（你的单价）'
+        input: '输入（官方单价）',
+        output: '输出（官方单价）'
       },
-      rateHint: '已应用 {multiplier} 倍率',
-      rateOverride: '含个人覆写',
       empty: {
         noAccess: {
           title: '暂无可用分组',
@@ -78,7 +77,7 @@ export default {
         }
       },
       exploreBanner: {
-        message: '正在查看 {group} 的目录 · 倍率 ×{multiplier}',
+        message: '正在查看 {group} 的目录',
         cta: '在 {group} 创建 Key'
       },
       billingMode: {

--- a/frontend/src/views/PricingView.vue
+++ b/frontend/src/views/PricingView.vue
@@ -133,7 +133,7 @@
                   :key="g.id"
                   :value="g.id"
                 >
-                  {{ g.name }}{{ formatGroupRateBadge(g) }}
+                  {{ g.name }}
                 </option>
               </select>
             </label>
@@ -432,9 +432,6 @@
                 <template v-else>
                   {{ t('pricing.footer.total', { count: rowTotal }) }}
                 </template>
-                <span v-if="rateHint" class="ml-2 text-gray-600 dark:text-dark-300">
-                  · {{ rateHint }}
-                </span>
               </p>
               <p class="text-left sm:text-right">
                 {{ t('pricing.updatedAt', { time: formattedUpdatedAt }) }}
@@ -679,29 +676,15 @@ const formattedUpdatedAt = computed(() => {
   }
 })
 
-// ============================== rate-hint ==============================
-
-const rateHint = computed(() => {
-  if (viewMode.value !== 'my' || !myCatalog.value) return ''
-  const tg = myCatalog.value.target_group
-  const rate = tg.rate_multiplier
-  if (rate === 1 && !tg.has_override) return ''
-  const fmt = rate === 0 ? '×0' : `×${rate}`
-  const suffix = tg.has_override ? ` (${t('pricing.my.rateOverride')})` : ''
-  return t('pricing.my.rateHint', { multiplier: fmt }) + suffix
-})
-
 // ============================== group switcher ==============================
+//
+// TK: pricing 页（分组目录/所有目录）一律展示官方定价，与分组倍率/个人覆写
+// 彻底脱钩——故不再有倍率提示（原 rateHint）、对比下拉不再拼 ×N 倍率角标。
 
 const groupsForComparison = computed<MePricingGroupRef[]>(() => {
   if (!myCatalog.value) return []
   return myCatalog.value.accessible_groups
 })
-
-function formatGroupRateBadge(g: MePricingGroupRef): string {
-  if (g.rate_multiplier === 1) return ''
-  return ` · ×${g.rate_multiplier}`
-}
 
 interface ExploreBanner {
   message: string
@@ -717,8 +700,7 @@ const exploreBanner = computed<ExploreBanner | null>(() => {
   // User is viewing a group they don't hold a key in → upgrade-CTA banner.
   return {
     message: t('pricing.my.exploreBanner.message', {
-      group: tg.name,
-      multiplier: tg.rate_multiplier
+      group: tg.name
     }),
     ctaLabel: t('pricing.my.exploreBanner.cta', { group: tg.name }),
     ctaTo: { path: '/dashboard/keys', query: { group_id: String(tg.id) } }

--- a/frontend/src/views/PricingView.vue
+++ b/frontend/src/views/PricingView.vue
@@ -57,7 +57,7 @@
             <p class="text-xs text-gray-600 dark:text-dark-400">{{ t('pricing.ctaBonusHint') }}</p>
           </div>
 
-          <!-- Segmented view switch: 我的菜单 / 公开目录. Only shown when logged in. -->
+          <!-- Segmented view switch: 分组目录 / 所有目录. Only shown when logged in. -->
           <div v-if="canShowMyView" class="mt-6 flex justify-center">
             <div
               role="tablist"
@@ -85,7 +85,7 @@
       </div>
 
       <div class="mx-auto flex min-h-0 w-full max-w-[90rem] flex-1 flex-col">
-        <!-- "我的菜单" toolbar: key picker + group switcher + banner -->
+        <!-- "分组目录" toolbar: key picker + group switcher + banner -->
         <div
           v-if="viewMode === 'my' && !loading && !errorMessage && myCatalog"
           class="mb-4 flex flex-col gap-3"
@@ -452,11 +452,11 @@
  *  - Public view (unauthenticated default): GET /api/v1/public/pricing returns
  *    the platform-wide LiteLLM list-price catalog. Behaves per US-028 AC-005
  *    (empty when source unavailable; 404 when admin disabled public catalog).
- *  - "我的菜单" view (authenticated default when accessible groups exist):
+ *  - "分组目录" view (authenticated default when accessible groups exist):
  *    GET /api/v1/me/pricing-catalog returns models scoped to the user's
- *    selected key's group, with prices already multiplied by their effective
- *    rate (group default × per-user override). The user can switch keys or
- *    explore other accessible groups for upgrade comparison.
+ *    selected key's group, at OFFICIAL list prices (decoupled from the
+ *    group/override rate — see me_pricing_catalog_tk.go header). The user can
+ *    switch keys or explore other accessible groups.
  *
  * Both feed a single normalized row shape so the table markup stays identical
  * between modes — this is by design; the v1 trade-off accepted in

--- a/frontend/src/views/__tests__/PricingView.spec.ts
+++ b/frontend/src/views/__tests__/PricingView.spec.ts
@@ -66,23 +66,21 @@ vi.mock('vue-i18n', async () => {
     'pricing.tableHint': '',
     'pricing.search.noMatches': '',
     'common.loading': 'Loading',
-    'pricing.my.tabMy': 'Your Menu',
-    'pricing.my.tabPublic': 'Public Catalog',
-    'pricing.my.title': 'Your Model Menu',
+    'pricing.my.tabMy': 'Group Catalog',
+    'pricing.my.tabPublic': 'All Catalog',
+    'pricing.my.title': 'Group Model Catalog',
     'pricing.my.subtitle': '',
     'pricing.my.description': '',
     'pricing.my.pickerKey': 'Current key:',
     'pricing.my.pickerCompare': 'Compare group:',
     'pricing.my.compareDefault': 'Keep current',
-    'pricing.my.columns.input': 'Input (your price)',
-    'pricing.my.columns.output': 'Output (your price)',
-    'pricing.my.rateHint': 'Multiplier {multiplier} applied',
-    'pricing.my.rateOverride': 'includes personal override',
+    'pricing.my.columns.input': 'Input (official price)',
+    'pricing.my.columns.output': 'Output (official price)',
     'pricing.my.empty.noModels.title': 'This group has no models yet',
     'pricing.my.empty.noModels.hint': '',
     'pricing.my.empty.noAccess.title': 'No accessible group',
     'pricing.my.empty.noAccess.hint': '',
-    'pricing.my.exploreBanner.message': 'Viewing {group} catalog · ×{multiplier}',
+    'pricing.my.exploreBanner.message': 'Viewing {group} catalog',
     'pricing.my.exploreBanner.cta': 'Create key in {group}',
     'pricing.my.noKeyHint': '',
     'pricing.perRequest': '/ request'
@@ -180,7 +178,7 @@ describe('PricingView', () => {
     expect(wrapper.html()).toContain('max-w-[90rem]')
   })
 
-  it('authenticated user defaults to "Your Menu" view with your_price applied', async () => {
+  it('authenticated user defaults to "Group Catalog" view showing official catalog prices', async () => {
     authState.isAuthenticated = true
     const me: MePricingCatalogResponse = {
       target_group: {
@@ -237,11 +235,11 @@ describe('PricingView', () => {
 
     expect(getMePricingCatalog).toHaveBeenCalled()
     expect(getPublicPricing).not.toHaveBeenCalled()
-    // Hero swaps to "Your Model Menu" copy.
-    expect(wrapper.text()).toContain('Your Model Menu')
-    // your_price applied — input 0.0045 → "$0.0045"
+    // Hero swaps to "Group Model Catalog" copy.
+    expect(wrapper.text()).toContain('Group Model Catalog')
+    // Catalog price rendered from your_price (now the official price) — 0.0045 → "$0.0045"
     expect(wrapper.text()).toContain('$0.0045')
-    // Rate hint shown when multiplier != 1.
-    expect(wrapper.text()).toContain('Multiplier ×1.5 applied')
+    // TK: pricing 页与倍率脱钩——不再展示倍率提示。
+    expect(wrapper.text()).not.toContain('Multiplier')
   })
 })

--- a/frontend/src/views/user/KeysView.vue
+++ b/frontend/src/views/user/KeysView.vue
@@ -112,6 +112,7 @@
                   :subscription-type="row.group.subscription_type"
                   :rate-multiplier="row.group.rate_multiplier"
                   :user-rate-multiplier="userGroupRates[row.group.id]"
+                  hide-rate-value
                 />
                 <span v-else class="text-sm text-gray-400 dark:text-dark-500">{{
                   t('keys.noGroup')
@@ -422,6 +423,7 @@
                 :subscription-type="(option as unknown as GroupOption).subscriptionType"
                 :rate-multiplier="(option as unknown as GroupOption).rate"
                 :user-rate-multiplier="(option as unknown as GroupOption).userRate"
+                hide-rate-value
               />
               <span v-else class="text-gray-400">{{ t('keys.selectGroup') }}</span>
             </template>
@@ -434,6 +436,7 @@
                 :user-rate-multiplier="(option as unknown as GroupOption).userRate"
                 :description="(option as unknown as GroupOption).description"
                 :selected="selected"
+                hide-rate-value
               />
             </template>
           </Select>
@@ -1028,6 +1031,7 @@
               :rate-multiplier="option.rate"
               :user-rate-multiplier="option.userRate"
               :description="option.description"
+              hide-rate-value
               :selected="
                 selectedKeyForGroup?.group_id === option.value ||
                 (!selectedKeyForGroup?.group_id && option.value === null)

--- a/scripts/sentinels/frontend-tk.json
+++ b/scripts/sentinels/frontend-tk.json
@@ -203,18 +203,18 @@
         "anthropicCacheTTL1hInjection: 'Anthropic Cache TTL 1h Injection'",
         "providerAirwallex: 'Airwallex'",
         "airwallex: 'Airwallex'",
-        "tabMy: 'Your Menu'",
+        "tabMy: 'Group Catalog'",
         "exploreBanner: {"
       ],
-      "rationale": "English admin settings labels must stay in sync with the global sticky and Anthropic Cache TTL 1h controls so upstream locale merges cannot silently regress one language while the template still compiles. The Airwallex provider/method labels are likewise load-bearing for admin payment setup and frontend method rendering. The pricing 'Your Menu' i18n keys (tabMy, exploreBanner) anchor the per-key pricing catalog feature so an upstream locale merge cannot silently strip them and degrade the segmented control + upgrade-banner UI to raw keys."
+      "rationale": "English admin settings labels must stay in sync with the global sticky and Anthropic Cache TTL 1h controls so upstream locale merges cannot silently regress one language while the template still compiles. The Airwallex provider/method labels are likewise load-bearing for admin payment setup and frontend method rendering. The pricing catalog i18n keys (tabMy='Group Catalog', exploreBanner) anchor the per-group pricing catalog feature so an upstream locale merge cannot silently strip them and degrade the segmented control + upgrade-banner UI to raw keys."
     },
     {
       "path": "frontend/src/i18n/locales/zh.ts",
       "must_contain": [
-        "tabMy: '我的菜单'",
+        "tabMy: '分组目录'",
         "exploreBanner: {"
       ],
-      "rationale": "Chinese pricing 'Your Menu' i18n keys (tabMy, exploreBanner) must move in lockstep with the English copies above. An upstream merge that drops only one language leaves operators staring at raw `pricing.my.*` paths in either zh or en — a regression that compiles but visibly breaks the page."
+      "rationale": "Chinese pricing catalog i18n keys (tabMy='分组目录', exploreBanner) must move in lockstep with the English copies above. An upstream merge that drops only one language leaves operators staring at raw `pricing.my.*` paths in either zh or en — a regression that compiles but visibly breaks the page."
     },
     {
       "path": "frontend/src/views/admin/SettingsView.vue",


### PR DESCRIPTION
接续 #693。把展示端**彻底与倍率脱钩**：用户级页面看不到任何倍率，pricing 页统一显示官方价。计费路径不受影响——网关仍按真实生效倍率扣费。

## 改动

### A. 用户级页面隐藏倍率徽章（KeysView + 可用渠道，含 admin）
- `GroupBadge` / `GroupOptionItem` 新增 `hideRateValue` prop（默认 `false`）。用户视图传 `true` → 隐藏标准 `{rate}x`、删除线专属倍率（订阅「订阅/天数」标签保留）；admin 管理页不传该 prop → 照常显示倍率（管理页只有 admin 可见，语义自洽）。
- 按页面区分（用户级不可见 / 管理页可见），不按角色分支。

### B. Pricing 页统一官方定价（全员生效，含 admin）
- 后端 `me_pricing_catalog_tk.go`：`models` 按官方基价（倍率 1.0）计算，不乘分组默认倍率 / 个人覆写。`your_price` 字段名保留以稳住 DTO，但语义改为官方价（注释已更新）。
- 前端 `PricingView.vue`：移除页脚 rateHint、对比下拉 `×N` 角标、explore banner 倍率。
- 「所有目录」走 `/public/pricing`，本就是官方 list 价，数据无需改。

### C. 重命名 + 文案（zh + en）
- 我的菜单 → **分组目录**（Group Catalog）；公开目录 → **所有目录**（All Catalog）。
- 标题 / 副标题 / 列名改为官方价语义。

### 按要求保留（不改）
- **UsageView** 用量明细 Rate 列 + CSV「Rate Multiplier」：真实生效倍率的计费事实记录。
- **支付/订阅套餐卡片** `×N` 倍率：营销 / 选购决策信息。

## 测试 & 门禁
- 后端 `go test -tags=unit ./...` 全绿；`me_pricing_catalog_tk_test.go` 价格断言改为官方基价。
- 前端 GroupBadge / PricingView spec 全绿，新增 `hideRateValue` 用例。
- typecheck / lint 干净；`scripts/preflight.sh` PASS。
- 已更新 `scripts/sentinels/frontend-tk.json` 锚点（tabMy 新名）+ 重建 embedded `backend/internal/web/dist` 源哈希。
- commit 带 `upstream-touch-guarded`（触及 upstream-shaped 前端文件）。本改动有 web 影响。

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
门禁 marker：
- `upstream-touch-guarded` — 触及 upstream-shaped 前端文件，TK 行为已守护。
- `sentinel-registry-reviewed` — me_pricing_catalog_tk.go(+test) 映射 gateway-tk/newapi registry：已复核改动仅为注释更新 + buildModelsForGroup 倍率 effective→officialRate(1.0)，未触及任何 pinned anchor（check-newapi 36/36、check-gateway-tk 215/215 全 PASS），无需调整其锚点。