### PR TITLE
feat(qwen): 开服 Qwen(账号60/组18)——qwen3.7-max 官方价 + 修 claude-code 派发 + 启用

### DIFF
--- a/backend/internal/service/tk_pricing_overlay.json
+++ b/backend/internal/service/tk_pricing_overlay.json
@@ -306,5 +306,40 @@
     "cache_read_input_token_cost": 8.21917808219e-08,
     "supports_prompt_caching": true,
     "source": "VolcEngine Ark official (2026-06-10, ≤32K input tier): in ¥3/M, out ¥14/M, cache-hit ¥0.6/M; CNY/USD=7.3"
-  }
+  },
+    "qwen3.7-max": {
+      "litellm_provider": "dashscope",
+      "mode": "chat",
+      "input_cost_per_token": 1.64383561644e-06,
+      "output_cost_per_token": 4.93150684932e-06,
+      "source": "Alibaba DashScope 通义千问 qwen3.7-max 官方标准按量价 (2026-06: in ¥12/M, out ¥36/M; help.aliyun.com/zh/model-studio/model-pricing, captured 2026-06-10); CNY/USD=7.3; list price (限时5折 promo NOT applied — bill at list to avoid undercharge on promo end)"
+    },
+    "qwen3.7-max-preview": {
+      "litellm_provider": "dashscope",
+      "mode": "chat",
+      "input_cost_per_token": 1.64383561644e-06,
+      "output_cost_per_token": 4.93150684932e-06,
+      "source": "Alibaba DashScope 通义千问 qwen3.7-max 官方标准按量价 (2026-06: in ¥12/M, out ¥36/M; help.aliyun.com/zh/model-studio/model-pricing, captured 2026-06-10); CNY/USD=7.3; list price (限时5折 promo NOT applied — bill at list to avoid undercharge on promo end)"
+    },
+    "qwen3.7-max-2026-05-17": {
+      "litellm_provider": "dashscope",
+      "mode": "chat",
+      "input_cost_per_token": 1.64383561644e-06,
+      "output_cost_per_token": 4.93150684932e-06,
+      "source": "Alibaba DashScope 通义千问 qwen3.7-max 官方标准按量价 (2026-06: in ¥12/M, out ¥36/M; help.aliyun.com/zh/model-studio/model-pricing, captured 2026-06-10); CNY/USD=7.3; list price (限时5折 promo NOT applied — bill at list to avoid undercharge on promo end)"
+    },
+    "qwen3.7-max-2026-05-20": {
+      "litellm_provider": "dashscope",
+      "mode": "chat",
+      "input_cost_per_token": 1.64383561644e-06,
+      "output_cost_per_token": 4.93150684932e-06,
+      "source": "Alibaba DashScope 通义千问 qwen3.7-max 官方标准按量价 (2026-06: in ¥12/M, out ¥36/M; help.aliyun.com/zh/model-studio/model-pricing, captured 2026-06-10); CNY/USD=7.3; list price (限时5折 promo NOT applied — bill at list to avoid undercharge on promo end)"
+    },
+    "qwen3.7-max-2026-06-08": {
+      "litellm_provider": "dashscope",
+      "mode": "chat",
+      "input_cost_per_token": 1.64383561644e-06,
+      "output_cost_per_token": 4.93150684932e-06,
+      "source": "Alibaba DashScope 通义千问 qwen3.7-max 官方标准按量价 (2026-06: in ¥12/M, out ¥36/M; help.aliyun.com/zh/model-studio/model-pricing, captured 2026-06-10); CNY/USD=7.3; list price (限时5折 promo NOT applied — bill at list to avoid undercharge on promo end)"
+    }
 }

--- a/backend/migrations/tk_021_qwen_enable_and_claude_code_dispatch.sql
+++ b/backend/migrations/tk_021_qwen_enable_and_claude_code_dispatch.sql
@@ -1,0 +1,55 @@
+-- Migration: tk_021_qwen_enable_and_claude_code_dispatch
+--
+-- Wire up the Qwen account (id=60 "Qwen", platform=openai, base_url=
+-- https://dashscope.aliyuncs.com/compatible-mode/v1; group id=18 "Qwen") so it can
+-- actually serve, with correct Claude-Code dispatch + non-zero billing.
+--
+-- Audit (2026-06-10, read-only probe):
+--   - account 60 advertises only the qwen3.7-max family (qwen3.7-max + preview + 3
+--     dated snapshots), all 200/servable on DashScope. It is currently
+--     schedulable=false (offline).
+--   - group 18 messages_dispatch_model_config was COPY-PASTED from a GPT group:
+--     opus→gpt-5.5 / sonnet→gpt-5.3-codex / haiku→gpt-5.4-mini. A Claude Code client
+--     (/v1/messages) on the Qwen group would be dispatched to GPT models the Qwen
+--     account does NOT serve → wrong route / failure.
+--   - qwen3.7-max has NO pricing (no channel pricing, not in litellm, not in overlay)
+--     → would bill $0 (revenue leak + pricing_missing #688) once it serves.
+--
+-- This migration fixes (2) and (3); pricing (1) ships in the SAME release via
+-- backend/internal/service/tk_pricing_overlay.json (qwen3.7-max* at the DashScope
+-- official list price ¥12/¥36 per M, CNY/USD=7.3).
+
+SET LOCAL lock_timeout = '5s';
+SET LOCAL statement_timeout = '10min';
+
+-- (2) Fix the Claude-Code dispatch mapping: map all three Claude tiers to the only
+--     model the Qwen account advertises (qwen3.7-max). claude_code_only stays false
+--     (the group already allows non-Claude-Code OpenAI clients too).
+UPDATE groups
+SET messages_dispatch_model_config = '{
+        "opus_mapped_model": "qwen3.7-max",
+        "sonnet_mapped_model": "qwen3.7-max",
+        "haiku_mapped_model": "qwen3.7-max"
+    }'::jsonb,
+    updated_at = NOW()
+WHERE id = 18
+  AND name = 'Qwen'
+  AND platform = 'openai';
+
+-- (3) Enable the Qwen account now that pricing + dispatch are in place. Raw-SQL
+--     account mutation bypasses the Ent hooks that enqueue a scheduler snapshot
+--     refresh, so enqueue a scheduler_outbox account_changed event (pattern:
+--     tk_015 / tk_020) — otherwise running replicas keep the stale schedulable=false
+--     until their next full snapshot reload.
+WITH upd AS (
+    UPDATE accounts
+    SET schedulable = true,
+        updated_at = NOW()
+    WHERE id = 60
+      AND name = 'Qwen'
+      AND platform = 'openai'
+      AND deleted_at IS NULL
+    RETURNING id
+)
+INSERT INTO scheduler_outbox (event_type, account_id, group_id, payload)
+SELECT 'account_changed', id, NULL, NULL FROM upd;


### PR DESCRIPTION
## 背景(/tokenkey-servable-model-refresh 体检 Qwen 账号)

prod 体检发现 **Qwen 账号(id=60「Qwen」, platform=openai, base_url=DashScope compatible-mode; group id=18「Qwen」)** 三处未就绪:

1. **可服务**:账号 60 只宣告 `qwen3.7-max` 系(5 个:max + preview + 3 个 dated),直连 DashScope 实测**全部 200 可服务** ✓;但账号 `schedulable=false`(未开服)。
2. **claude-code 派发映射配错**:组 18 `messages_dispatch_model_config` 是从某 GPT 组**复制粘贴**的(opus→gpt-5.5 / sonnet→gpt-5.3-codex / haiku→gpt-5.4-mini)→ Claude Code 客户端(/v1/messages)打组 18 会被派发到 **GPT 模型(账号 60 不服务)** → 错路由/失败。
3. **定价缺**:qwen3.7-max 无任何价(组渠道价空 / litellm 0 / overlay 0)→ 一旦开服**零计费 + #688 缺价告警**。

## 修复(三处一并上线)

- **① 定价** `tk_pricing_overlay.json`:qwen3.7-max* 5 个加 **DashScope 官方标准按量价 ¥12/¥36 每 M**(÷7.3 = in **$1.644**/M, out **$4.932**/M)。取 list 价、**不取限时 5 折**(避免优惠到期少收);`_meta` 带 provenance + 汇率。走公共目录 base 价路径(同 deepseek-v4/doubao)。
- **② 派发映射** `tk_021` 迁移:组 18 `messages_dispatch_model_config` 改 **opus/sonnet/haiku → qwen3.7-max**(账号唯一宣告的模型),`claude_code_only` 维持 false。
- **③ 开服** `tk_021` 迁移:账号 60 `schedulable=true` + `scheduler_outbox('account_changed')`。

> 净效果:Claude Code / OpenAI 客户端经 Qwen 组都能真用上 qwen3.7-max、非零计费;`/v1/messages`(claude-code)三档都正确派发到 qwen3.7-max。

## 验证
- `go build ./internal/service/` + 定价单测全绿;迁移两段 JSON 合法;`scripts/preflight.sh` PASS。
- 直连 DashScope 实测 qwen3.7-max* 全 200。

## Checklist
- [x] 单测/构建/preflight 全绿
- [x] 纯后端:no-web-impact;TK overlay + tk_ 迁移、未碰上游符号:no-upstream-touch
- [x] 迁移用新编号 tk_021;raw-SQL 账号变更配 scheduler_outbox
- [x] 计价取官方 list 价(禁臆造),¥12/¥36 经用户确认

## 上线后复验
发版后:账号 60 schedulable=true materialize;经 Qwen 组发 qwen3.7-max 请求 200 + usage_logs 计费非 0;claude-code 客户端 opus/sonnet/haiku 都路由到 qwen3.7-max;「我的菜单/公开目录」显示 qwen3.7-max 价。

no-web-impact
no-upstream-touch

🤖 Generated with [Claude Code](https://claude.com/claude-code)