### PR TITLE
feat(newapi): migrate Qwen + DeepSeek to extension engine (newapi bridge)

### DIFF
--- a/backend/internal/handler/ops_error_logger_tk_client_induced_upstream_test.go
+++ b/backend/internal/handler/ops_error_logger_tk_client_induced_upstream_test.go
@@ -73,6 +73,41 @@ func TestClassifyOpsUpstreamClientInducedRejectionOwnedByClient(t *testing.T) {
 		require.Equal(t, "client", errorOwner)
 	})
 
+	t.Run("newapi/dashscope upstream 404 model_not_found (Qwen ct=17) owned by client", func(t *testing.T) {
+		// Direct probe 2026-06-10: DashScope (Qwen extension-engine channel) returns the
+		// OpenAI-standard 404 model_not_found envelope for a retired/unknown model. The
+		// bridge records it code-prefixed; it must be client-owned so a future Qwen model
+		// drift cannot re-fire the upstream_error_rate P0 (same class as the volcengine case).
+		rec := httptest.NewRecorder()
+		c, _ := gin.CreateTestContext(rec)
+		service.SetOpsUpstreamError(c, http.StatusNotFound,
+			"model_not_found: The model `qwen3.7-max-retired` does not exist or you do not have access to it.",
+			"model_not_found")
+
+		phase, _, errorOwner, _ := classifyOpsErrorLog(c, "upstream_error", "Upstream request failed", "", http.StatusBadGateway)
+
+		require.Equal(t, "request", phase, "dashscope 404 model_not_found must be client-owned")
+		require.Equal(t, "client", errorOwner)
+	})
+
+	t.Run("newapi/deepseek upstream 400 invalid_request_error (DeepSeek ct=43) owned by client", func(t *testing.T) {
+		// Direct probe 2026-06-10: DeepSeek (extension-engine channel) returns HTTP 400
+		// invalid_request_error for an unknown model ("The supported API model names are
+		// deepseek-v4-pro or deepseek-v4-flash, but you passed X."). It rides the existing
+		// 400 invalid_request_error branch (not the 404 helper), so model drift on the
+		// DeepSeek channel is likewise out of upstream_error_rate.
+		rec := httptest.NewRecorder()
+		c, _ := gin.CreateTestContext(rec)
+		service.SetOpsUpstreamError(c, http.StatusBadRequest,
+			"invalid_request_error: The supported API model names are deepseek-v4-pro or deepseek-v4-flash, but you passed deepseek-v4-retired.",
+			"invalid_request_error")
+
+		phase, _, errorOwner, _ := classifyOpsErrorLog(c, "upstream_error", "Upstream request failed", "", http.StatusBadGateway)
+
+		require.Equal(t, "request", phase, "deepseek 400 invalid_request_error must be client-owned")
+		require.Equal(t, "client", errorOwner)
+	})
+
 	t.Run("genuine newapi upstream 503 stays provider-owned (must keep counting)", func(t *testing.T) {
 		rec := httptest.NewRecorder()
 		c, _ := gin.CreateTestContext(rec)

--- a/backend/internal/service/newapi_model_not_found_tk.go
+++ b/backend/internal/service/newapi_model_not_found_tk.go
@@ -11,12 +11,26 @@ import (
 // IsOpenAICompatModelNotFound404 reports whether an OpenAI-compatible / newapi
 // upstream 404 is a CALLER-fault "the requested model does not exist / is not
 // accessible on this channel" rather than a provider-health failure. The newapi
-// fifth-platform sibling of IsAnthropicModelNotFound404 — VolcEngine Ark returns
+// fifth-platform sibling of IsAnthropicModelNotFound404. Two real upstream shapes
+// (both captured by direct probe, 2026-06-10):
 //
-//	{"error":{"code":"InvalidEndpointOrModel.NotFound",
-//	          "message":"The model `X` does not exist or you do not have access to it."}}
+//	VolcEngine Ark (channel_type=45): un-activated / retired model →
+//	  {"error":{"code":"InvalidEndpointOrModel.NotFound",
+//	            "message":"The model `X` does not exist or you do not have access to it."}}
 //
-// for a model that is not 开通 (activated) or already 下线 (retired) on the channel.
+//	DashScope / Qwen (channel_type=17, OpenAI-compatible mode): unknown / retired
+//	  model → HTTP 404 with the OpenAI-standard envelope
+//	  {"error":{"code":"model_not_found",
+//	            "message":"The model `X` does not exist or you do not have access to it."}}
+//
+// (DeepSeek, channel_type=43, instead returns HTTP 400 invalid_request_error for an
+// unknown model — "The supported API model names are ...". That is already owned to
+// the client by the 400 invalid_request_error branch in tkUpstreamClientInducedRejection,
+// so it never reaches this 404 helper.)
+//
+// Both the prose phrase ("does not exist or you do not have access") and the
+// structured code ("model_not_found" / "InvalidEndpointOrModel.NotFound") are
+// matched, so the classification survives a vendor changing one without the other.
 //
 // classifyOpsErrorLog uses this (via tkUpstreamClientInducedRejection) to own the
 // error to the client (phase=request → error_owner=client), keeping it OUT of
@@ -29,10 +43,11 @@ func IsOpenAICompatModelNotFound404(responseBody []byte, upstreamMsg string) boo
 		return false
 	}
 	if strings.Contains(combined, "invalidendpointormodel.notfound") ||
+		strings.Contains(combined, "model_not_found") ||
 		strings.Contains(combined, "does not exist or you do not have access") {
 		return true
 	}
-	if code := strings.ToLower(strings.TrimSpace(gjson.GetBytes(responseBody, "error.code").String())); code == "invalidendpointormodel.notfound" {
+	if code := strings.ToLower(strings.TrimSpace(gjson.GetBytes(responseBody, "error.code").String())); code == "invalidendpointormodel.notfound" || code == "model_not_found" {
 		return true
 	}
 	return false

--- a/backend/internal/service/newapi_model_not_found_tk_test.go
+++ b/backend/internal/service/newapi_model_not_found_tk_test.go
@@ -24,6 +24,12 @@ func TestIsOpenAICompatModelNotFound404(t *testing.T) {
 		{"volcengine error.code in JSON body", `{"error":{"code":"InvalidEndpointOrModel.NotFound","message":"The model ` + "`x`" + ` does not exist or you do not have access to it."}}`, "", true},
 		{"volcengine message substring", "", "The model `doubao-lite-32k-240828` does not exist or you do not have access to it.", true},
 		{"code-prefixed message (as recorded by the bridge dispatch)", "", "InvalidEndpointOrModel.NotFound: The model `x` does not exist or you do not have access to it.", true},
+		// DashScope / Qwen (channel_type=17) real 404 (direct probe 2026-06-10): the
+		// OpenAI-standard model_not_found envelope. Matched by BOTH the prose phrase
+		// and the structured code, so a vendor reword of either still classifies.
+		{"dashscope model_not_found JSON body", `{"error":{"message":"The model ` + "`qwen-x`" + ` does not exist or you do not have access to it.","type":"invalid_request_error","code":"model_not_found"}}`, "", true},
+		{"dashscope code-prefixed message (bridge path)", "", "model_not_found: The model `qwen-x` does not exist or you do not have access to it.", true},
+		{"model_not_found structured code alone (prose reworded)", `{"error":{"code":"model_not_found","message":"whatever wording the vendor uses"}}`, "", true},
 		{"genuine 5xx is NOT model-not-found", `{"error":{"message":"upstream service temporarily unavailable"}}`, "Upstream request failed", false},
 		{"rate limit is NOT model-not-found", "", "Upstream rate limit exceeded, please retry later", false},
 		{"empty", "", "", false},

--- a/backend/migrations/tk_022_qwen_deepseek_to_extension_engine.sql
+++ b/backend/migrations/tk_022_qwen_deepseek_to_extension_engine.sql
@@ -1,0 +1,133 @@
+-- Migration: tk_022_qwen_deepseek_to_extension_engine
+--
+-- Migrate the Qwen (account id=60 / group id=18) and DeepSeek (account id=39 /
+-- group id=11) channels from the openai-native passthrough path
+-- (platform=openai, channel_type=0, raw forward to credentials.base_url) to the
+-- New API "extension engine" bridge — i.e. the fifth-platform adaptor path,
+-- same shape as the VolcEngine account 7 (platform=newapi, channel_type>0):
+--   - DeepSeek  -> channel_type=43 (ChannelTypeDeepSeek, relay/channel/deepseek)
+--   - Qwen/Ali  -> channel_type=17 (ChannelTypeAli,      relay/channel/ali)
+--
+-- Why bridge over passthrough:
+--   The new-api Ali/DeepSeek adaptors do provider-specific shaping the raw
+--   passthrough does not (Ali clamps top_p to (0,1) + sets DashScope SSE header;
+--   DeepSeek handles reasoning / FIM /beta / thinking-suffix). Routing both
+--   through the bridge also unifies them with the existing fifth-platform
+--   account (VolcEngine) under one identity (platform=newapi) so admin UI,
+--   affinity, and the newapi sentinel/registry all treat them consistently.
+--
+-- Audit (2026-06-10, read-only prod probe). Both groups are DEDICATED
+-- single-account pools (group 11 = only account 39; group 18 = only account 60),
+-- so flipping group.platform to newapi orphans no sibling account:
+--   - account 39 "ds-官": platform=openai, channel_type=0, schedulable=true,
+--     credentials.base_url=https://api.deepseek.com (bare host — the DeepSeek
+--     adaptor appends /v1/chat/completions itself, so this base_url is already
+--     adaptor-compatible and is NOT changed here),
+--     model_mapping={deepseek-v4-pro, deepseek-v4-flash} (identity whitelist).
+--   - account 60 "Qwen": platform=openai, channel_type=0, schedulable=false
+--     (tk_021 enables it on the openai path first; this migration then moves it
+--     to the bridge), credentials.base_url=
+--     https://dashscope.aliyuncs.com/compatible-mode/v1 (HAS the /compatible-mode/v1
+--     suffix). The Ali adaptor builds {base_url}/compatible-mode/v1/chat/completions
+--     itself, so the stored suffix would DOUBLE-append -> 404. This migration
+--     rewrites base_url to the bare host https://dashscope.aliyuncs.com.
+--     model_mapping={qwen3.7-max + 4 dated/preview variants} (identity whitelist).
+--
+-- Not changed (verified, no code/pricing change needed):
+--   - Model names pass through unrewritten: ParseDeepSeekV4ThinkingSuffix only
+--     trims {"-none","-max"}; deepseek-v4-pro/-flash match neither.
+--   - Pricing: bridge accounts bill via the same BillingModel resolver; overlay
+--     already prices deepseek-v4-pro/-flash + qwen3.7-max* (#696/#701/#706).
+--   - claude-code: messages_dispatch_model_config is preserved for newapi groups
+--     (tkGroupKeepsDispatchConfig includes newapi). group 11 keeps its
+--     opus->deepseek-v4-pro / sonnet,haiku->deepseek-v4-flash dispatch; group 18's
+--     dispatch is (re)set to qwen3.7-max here so it is correct even if tk_021 has
+--     not run on this stack yet.
+--
+-- Atomicity: the migration runner wraps each .sql file in one transaction
+-- (migrations_runner.go BeginTx/Commit), so the account-platform flip and the
+-- group-platform flip commit together. A live scheduler replica (separate MVCC
+-- connection) sees the old consistent state until COMMIT, then refreshes both via
+-- the trailing scheduler_outbox events (account_changed + group_changed) — never
+-- a torn state where account.platform != group.platform (which IsOpenAICompatPoolMember
+-- would read as "not a pool member" and silently de-schedule the account).
+--
+-- Raw-SQL account/group mutations bypass the Ent hooks that enqueue a scheduler
+-- snapshot refresh, so each guarded UPDATE enqueues its own outbox event
+-- (account_changed / group_changed) only when it actually matched a row.
+--
+-- Idempotent + cross-deployment safe: every UPDATE is guarded by
+-- (id, name, platform='openai') so re-running is a no-op once migrated, and a
+-- bare id colliding with an unrelated account/group in another DB (these
+-- migrations run on every TK stack) cannot match.
+
+SET LOCAL lock_timeout = '5s';
+SET LOCAL statement_timeout = '10min';
+
+-- 1) DeepSeek account 39 -> newapi / channel_type=43 (DeepSeek adaptor).
+--    base_url unchanged (bare host already adaptor-compatible).
+WITH upd_acct AS (
+    UPDATE accounts
+    SET platform = 'newapi',
+        channel_type = 43,
+        schedulable = true,
+        updated_at = NOW()
+    WHERE id = 39
+      AND name = 'ds-官'
+      AND platform = 'openai'
+      AND channel_type = 0
+      AND deleted_at IS NULL
+    RETURNING id
+)
+INSERT INTO scheduler_outbox (event_type, account_id, group_id, payload)
+SELECT 'account_changed', id, NULL, NULL FROM upd_acct;
+
+-- 2) Qwen account 60 -> newapi / channel_type=17 (Ali adaptor).
+--    Strip the /compatible-mode/v1 suffix from base_url (the adaptor appends it).
+WITH upd_acct AS (
+    UPDATE accounts
+    SET platform = 'newapi',
+        channel_type = 17,
+        schedulable = true,
+        credentials = jsonb_set(credentials, '{base_url}', '"https://dashscope.aliyuncs.com"'),
+        updated_at = NOW()
+    WHERE id = 60
+      AND name = 'Qwen'
+      AND platform = 'openai'
+      AND deleted_at IS NULL
+    RETURNING id
+)
+INSERT INTO scheduler_outbox (event_type, account_id, group_id, payload)
+SELECT 'account_changed', id, NULL, NULL FROM upd_acct;
+
+-- 3) DeepSeek group 11 -> newapi (dispatch config preserved for newapi groups).
+WITH upd_grp AS (
+    UPDATE groups
+    SET platform = 'newapi',
+        updated_at = NOW()
+    WHERE id = 11
+      AND name = 'deepseek'
+      AND platform = 'openai'
+    RETURNING id
+)
+INSERT INTO scheduler_outbox (event_type, account_id, group_id, payload)
+SELECT 'group_changed', NULL, id, NULL FROM upd_grp;
+
+-- 4) Qwen group 18 -> newapi, and (re)set Claude-Code dispatch to the only model
+--    the Qwen account advertises (qwen3.7-max), self-contained vs tk_021 ordering.
+WITH upd_grp AS (
+    UPDATE groups
+    SET platform = 'newapi',
+        messages_dispatch_model_config = '{
+            "opus_mapped_model": "qwen3.7-max",
+            "sonnet_mapped_model": "qwen3.7-max",
+            "haiku_mapped_model": "qwen3.7-max"
+        }'::jsonb,
+        updated_at = NOW()
+    WHERE id = 18
+      AND name = 'Qwen'
+      AND platform = 'openai'
+    RETURNING id
+)
+INSERT INTO scheduler_outbox (event_type, account_id, group_id, payload)
+SELECT 'group_changed', NULL, id, NULL FROM upd_grp;


### PR DESCRIPTION
## 目的

把 prod 的 **Qwen**（账号 60 / group 18）和 **DeepSeek**（账号 39 / group 11）从 **openai 透传**（`platform=openai, channel_type=0`）迁到 **Extension Engine = New API 第五平台 bridge adaptor**，与 VolcEngine 账号 7 同形态：DeepSeek `channel_type=43`、Qwen/Ali `channel_type=17`。

## 为什么这样改（关键事实，已查证）

- **bridge 门禁**（`engine.BuildDispatchPlan`）只要 `channel_type>0 && platform∈{openai,newapi}`；**调度池铁律**（`IsOpenAICompatPoolMember`）要求 `account.platform==group.platform`。两组都是**专属单账号池**（group 11=仅39；group 18=仅60），故翻 `group.platform→newapi` **零孤儿风险**，采规范第五平台形态。
- **base_url 坑**：Ali adaptor 自拼 `{base_url}/compatible-mode/v1/chat/completions`，账号 60 现有 `…/compatible-mode/v1` 后缀会双重拼接→404，本迁移改成裸 host。DeepSeek 的 `https://api.deepseek.com` 裸 host 已兼容，不改。
- **模型名不被改写**：`ParseDeepSeekV4ThinkingSuffix` 只认 `{-none,-max}`，`deepseek-v4-pro/-flash` 原样透传。
- **计价/claude-code 不变**：同一 BillingModel 解析（overlay 已含价）；`messages_dispatch_model_config` 对 newapi 组保留，group 18 dispatch 重置 qwen3.7-max。
- **原子无撕裂**：单事务迁移 + `account_changed`(39,60)+`group_changed`(11,18) outbox 刷新。守卫 `(id,name,platform='openai')` → 幂等 + 跨部署安全。

## ③ 防复发伞收敛进本 PR（直连两家实测 404/400 形态）

直连探测（2026-06-10）两家上游对未知模型的真实返回：
- **DashScope/Qwen (ct=17)**：HTTP **404** `{code:"model_not_found", message:"...does not exist or you do not have access to it."}` — 已被 `IsOpenAICompatModelNotFound404` 的 OpenAI 标准短语命中。
- **DeepSeek (ct=43)**：HTTP **400** `invalid_request_error`（"The supported API model names are deepseek-v4-pro or deepseek-v4-flash, ..."）— 已被 400 `invalid_request_error` 分支判为 client-owned，根本不走 404 helper。

两者**今天就已**在 ③ 伞下（一个借 VolcEngine 同款短语、一个走 400 路径）。本 PR 把它**固化**：helper 加结构化 `model_not_found` code（比 prose 更稳），并用**两家真实响应体**加回归测，让未来 Qwen/DeepSeek 模型漂移仍稳在 `upstream_error_rate` 外——与 VolcEngine 同等防复发保证。Sentinel 文件改动为纯插入（`TestClassifyOps...` 三锚点不变）。

## 验证

- 全迁移链对真实 Postgres 幂等应用通过（`TestMigrationsRunner_IsIdempotent_AndSchemaIsUpToDate`，跑两遍）。
- `go build ./...` + service/handler unit（含 DashScope/DeepSeek 真体回归测）绿；`scripts/preflight.sh` 全绿。
- `tk_*.sql` 不属 upstream-override-marker 覆盖面；`_tk_.go`/`_test.go` 同样豁免；纯后端 `no-web-impact`。

## 风险 / 收尾

- 客户 user_id=16 在用这两组 → **发版后**按 1) DB 核 platform/ct/base_url 2) 真发 `deepseek-v4-pro`/`qwen3.7-max` 期望 200+非零计费 3) claude-code `/v1/messages` 4) ops_error_logs 平稳 验收；异常即 admin 关停止血。

sentinel-registry-reviewed

🤖 Generated with [Claude Code](https://claude.com/claude-code)