### PR TITLE
fix(ops): upstream_error_rate 分子排除已恢复(final<400)行——防 signature_preempt 恢复-200 假 P0

### DIFF
--- a/backend/internal/repository/ops_repo_dashboard.go
+++ b/backend/internal/repository/ops_repo_dashboard.go
@@ -883,7 +883,9 @@ SELECT
   COALESCE(COUNT(*) FILTER (WHERE COALESCE(status_code, 0) >= 400), 0) AS error_total,
   COALESCE(COUNT(*) FILTER (WHERE COALESCE(status_code, 0) >= 400 AND is_business_limited), 0) AS business_limited,
   COALESCE(COUNT(*) FILTER (WHERE COALESCE(status_code, 0) >= 400 AND NOT is_business_limited), 0) AS error_sla,
-  COALESCE(COUNT(*) FILTER (WHERE error_owner = 'provider' AND NOT is_business_limited AND COALESCE(upstream_status_code, status_code, 0) NOT IN (429, 529)), 0) AS upstream_excl,
+  -- TK: upstream_excl requires a final failure (status >= 400) — provider errors recovered
+  -- to 200 (signature_preempt / failover retries) must not drive upstream_error_rate P0s.
+  COALESCE(COUNT(*) FILTER (WHERE COALESCE(status_code, 0) >= 400 AND error_owner = 'provider' AND NOT is_business_limited AND COALESCE(upstream_status_code, status_code, 0) NOT IN (429, 529)), 0) AS upstream_excl,
   COALESCE(COUNT(*) FILTER (WHERE error_owner = 'provider' AND NOT is_business_limited AND COALESCE(upstream_status_code, status_code, 0) = 429), 0) AS upstream_429,
   COALESCE(COUNT(*) FILTER (WHERE error_owner = 'provider' AND NOT is_business_limited AND COALESCE(upstream_status_code, status_code, 0) = 529), 0) AS upstream_529
 FROM ops_error_logs

--- a/backend/internal/repository/ops_repo_preagg.go
+++ b/backend/internal/repository/ops_repo_preagg.go
@@ -93,7 +93,9 @@ error_agg AS (
     COUNT(*) FILTER (WHERE COALESCE(client_status_code, 0) >= 400) AS error_count_total,
     COUNT(*) FILTER (WHERE COALESCE(client_status_code, 0) >= 400 AND is_business_limited) AS business_limited_count,
     COUNT(*) FILTER (WHERE COALESCE(client_status_code, 0) >= 400 AND NOT is_business_limited) AS error_count_sla,
-    COUNT(*) FILTER (WHERE error_owner = 'provider' AND NOT is_business_limited AND COALESCE(effective_status_code, 0) NOT IN (429, 529)) AS upstream_error_count_excl_429_529,
+    -- TK: same final-failure (client_status >= 400) gate as dashboard upstream_excl —
+    -- recovered-to-200 provider retries must not count as upstream errors.
+    COUNT(*) FILTER (WHERE COALESCE(client_status_code, 0) >= 400 AND error_owner = 'provider' AND NOT is_business_limited AND COALESCE(effective_status_code, 0) NOT IN (429, 529)) AS upstream_error_count_excl_429_529,
     COUNT(*) FILTER (WHERE error_owner = 'provider' AND NOT is_business_limited AND COALESCE(effective_status_code, 0) = 429) AS upstream_429_count,
     COUNT(*) FILTER (WHERE error_owner = 'provider' AND NOT is_business_limited AND COALESCE(effective_status_code, 0) = 529) AS upstream_529_count
   FROM error_base

--- a/backend/internal/repository/ops_repo_tk_upstream_excl_recovered_integration_test.go
+++ b/backend/internal/repository/ops_repo_tk_upstream_excl_recovered_integration_test.go
@@ -1,0 +1,96 @@
+//go:build integration
+
+package repository
+
+import (
+	"context"
+	"testing"
+	"time"
+
+	"github.com/Wei-Shaw/sub2api/internal/service"
+	"github.com/stretchr/testify/require"
+)
+
+// TestUpstreamExclExcludesRecoveredRows 验证 upstream_excl(=upstream_error_rate 分子)
+// 只统计最终失败(status_code>=400)的 provider 行:
+//
+// us7 P0 2026-06-10T13:40Z 教训——thinking-block 签名 400 经 signature_preempt 剥离重试
+// 恢复成 final 200 的行(owner=provider, status_code=200)曾被计入分子,5 分钟窗 60/218≈27.5%
+// 触发假 P0。修复后这类已恢复行不再驱动 upstream_error_rate,但 429/529 观测计数器保持原语义。
+//
+// 同一过滤表达式存在于 raw dashboard / trends / preagg(hourly) / metrics collector 四处;
+// 本测试覆盖 repository 三处(collector 在 service 包,表达式相同)。
+func TestUpstreamExclExcludesRecoveredRows(t *testing.T) {
+	ctx := context.Background()
+	_, _ = integrationDB.ExecContext(ctx, "TRUNCATE ops_error_logs RESTART IDENTITY CASCADE")
+	_, _ = integrationDB.ExecContext(ctx, "TRUNCATE ops_metrics_hourly")
+
+	repo := NewOpsRepository(integrationDB).(*opsRepository)
+
+	windowStart := time.Now().UTC().Add(-2 * time.Hour).Truncate(time.Hour)
+	windowEnd := windowStart.Add(time.Hour)
+	at := windowStart.Add(5 * time.Minute)
+
+	insert := func(statusCode int, owner string, upstreamStatus *int) {
+		_, err := integrationDB.ExecContext(ctx, `
+			INSERT INTO ops_error_logs (
+				error_phase, error_type, severity, status_code,
+				error_owner, upstream_status_code, created_at
+			) VALUES ('upstream', 'upstream_error', 'error', $1, $2, $3, $4)`,
+			statusCode, owner, upstreamStatus, at,
+		)
+		require.NoError(t, err)
+	}
+	intPtr := func(v int) *int { return &v }
+
+	// 1) us7 P0 驱动行:provider 错误已恢复成 final 200(upstream_status_code 为 NULL,
+	//    如 thinking_blocks_stripped)——不得计入 upstream_excl。
+	insert(200, "provider", nil)
+	// 2) 恢复行变体:上游 400 被重试恢复成 final 200——同样不得计入。
+	insert(200, "provider", intPtr(400))
+	// 3) 最终失败的 provider 502——唯一应计入 upstream_excl 的行。
+	insert(502, "provider", nil)
+	// 4) 客户端归属的 502(context canceled)——owner 过滤排除(#628 语义)。
+	insert(502, "client", nil)
+	// 5) 最终失败的 provider 429——进 upstream_429 桶,不进 excl。
+	insert(429, "provider", intPtr(429))
+
+	filter := &service.OpsDashboardFilter{
+		StartTime: windowStart,
+		EndTime:   windowEnd,
+		QueryMode: service.OpsQueryModeRaw,
+	}
+
+	// ── raw dashboard(告警评估器走的路径)─────────────────────────────────
+	overview, err := repo.GetDashboardOverview(ctx, filter)
+	require.NoError(t, err)
+	require.NotNil(t, overview)
+	require.EqualValues(t, 1, overview.UpstreamErrorCountExcl429529,
+		"recovered-to-200 provider rows must not count toward upstream_excl")
+	require.EqualValues(t, 1, overview.Upstream429Count)
+	require.EqualValues(t, 3, overview.ErrorCountSLA, "final >=400 rows: provider 502 + client 502 + provider 429")
+
+	// ── trends ───────────────────────────────────────────────────────────
+	trend, err := repo.GetErrorTrend(ctx, filter, 3600)
+	require.NoError(t, err)
+	var trendExcl, trend429 int64
+	for _, p := range trend.Points {
+		trendExcl += p.UpstreamErrorCountExcl429529
+		trend429 += p.Upstream429Count
+	}
+	require.EqualValues(t, 1, trendExcl)
+	require.EqualValues(t, 1, trend429)
+
+	// ── preagg hourly(dashboard preagg 模式的数据源)──────────────────────
+	require.NoError(t, repo.UpsertHourlyMetrics(ctx, windowStart, windowEnd))
+	var preaggExcl, preagg429 int64
+	err = integrationDB.QueryRowContext(ctx, `
+		SELECT upstream_error_count_excl_429_529, upstream_429_count
+		FROM ops_metrics_hourly
+		WHERE bucket_start = $1 AND platform IS NULL AND group_id IS NULL`,
+		windowStart,
+	).Scan(&preaggExcl, &preagg429)
+	require.NoError(t, err)
+	require.EqualValues(t, 1, preaggExcl)
+	require.EqualValues(t, 1, preagg429)
+}

--- a/backend/internal/repository/ops_repo_trends.go
+++ b/backend/internal/repository/ops_repo_trends.go
@@ -454,7 +454,9 @@ SELECT
   COUNT(*) FILTER (WHERE COALESCE(status_code, 0) >= 400) AS error_total,
   COUNT(*) FILTER (WHERE COALESCE(status_code, 0) >= 400 AND is_business_limited) AS business_limited,
   COUNT(*) FILTER (WHERE COALESCE(status_code, 0) >= 400 AND NOT is_business_limited) AS error_sla,
-  COUNT(*) FILTER (WHERE error_owner = 'provider' AND NOT is_business_limited AND COALESCE(upstream_status_code, status_code, 0) NOT IN (429, 529)) AS upstream_excl,
+  -- TK: same final-failure (status >= 400) gate as dashboard upstream_excl — recovered-to-200
+  -- provider retries must not count as upstream errors.
+  COUNT(*) FILTER (WHERE COALESCE(status_code, 0) >= 400 AND error_owner = 'provider' AND NOT is_business_limited AND COALESCE(upstream_status_code, status_code, 0) NOT IN (429, 529)) AS upstream_excl,
   COUNT(*) FILTER (WHERE error_owner = 'provider' AND NOT is_business_limited AND COALESCE(upstream_status_code, status_code, 0) = 429) AS upstream_429,
   COUNT(*) FILTER (WHERE error_owner = 'provider' AND NOT is_business_limited AND COALESCE(upstream_status_code, status_code, 0) = 529) AS upstream_529
 FROM ops_error_logs

--- a/backend/internal/service/ops_metrics_collector.go
+++ b/backend/internal/service/ops_metrics_collector.go
@@ -534,7 +534,9 @@ SELECT
   COALESCE(COUNT(*) FILTER (WHERE COALESCE(status_code, 0) >= 400), 0) AS error_total,
   COALESCE(COUNT(*) FILTER (WHERE COALESCE(status_code, 0) >= 400 AND is_business_limited), 0) AS business_limited,
   COALESCE(COUNT(*) FILTER (WHERE COALESCE(status_code, 0) >= 400 AND NOT is_business_limited), 0) AS error_sla,
-  COALESCE(COUNT(*) FILTER (WHERE error_owner = 'provider' AND NOT is_business_limited AND COALESCE(upstream_status_code, status_code, 0) NOT IN (429, 529)), 0) AS upstream_excl,
+  -- TK: same final-failure (status >= 400) gate as dashboard upstream_excl — recovered-to-200
+  -- provider retries must not count as upstream errors.
+  COALESCE(COUNT(*) FILTER (WHERE COALESCE(status_code, 0) >= 400 AND error_owner = 'provider' AND NOT is_business_limited AND COALESCE(upstream_status_code, status_code, 0) NOT IN (429, 529)), 0) AS upstream_excl,
   COALESCE(COUNT(*) FILTER (WHERE error_owner = 'provider' AND NOT is_business_limited AND COALESCE(upstream_status_code, status_code, 0) = 429), 0) AS upstream_429,
   COALESCE(COUNT(*) FILTER (WHERE error_owner = 'provider' AND NOT is_business_limited AND COALESCE(upstream_status_code, status_code, 0) = 529), 0) AS upstream_529
 FROM ops_error_logs

--- a/scripts/sentinels/gateway-tk.json
+++ b/scripts/sentinels/gateway-tk.json
@@ -2098,6 +2098,34 @@
         "setOpsUpstreamRequestBody(c, retryWireBody2)"
       ],
       "rationale": "The native anthropic Forward path must stash the final (post-rewrite) upstream request body before the retry loop AND re-stash after a successful filtered-thinking / tool-downgrade retry. Two consumers depend on it: ops_error_logs per-attempt body context, and the traj v2 upstream-request divergence capture (qa reads the same gin key for opt-in records; see scripts/sentinels/trajectory.json required_file_hooks). An upstream merge dropping any of these calls silently corrupts exported training pairs instead of failing loudly."
+    },
+    {
+      "path": "backend/internal/repository/ops_repo_dashboard.go",
+      "must_contain": [
+        "COALESCE(status_code, 0) >= 400 AND error_owner = 'provider'"
+      ],
+      "rationale": "upstream_error_rate numerator (upstream_excl) requires a final failure (status >= 400): provider errors recovered to 200 (signature_preempt thinking_blocks_stripped retries, failover) must not drive the P0 capacity alert — us7 false P0 2026-06-10 was 60 recovered-200 rows / 5min window reading 27.5%. The filter is an in-place edit inside upstream-shaped SQL hotspots, compile-clean if dropped, so an upstream merge resolving these SELECT blocks can silently revert it and the false P0 recurs. Same gate must stay in all four sites: dashboard queryErrorCounts (alert evaluator raw path), trends, preagg hourly, 1m metrics collector."
+    },
+    {
+      "path": "backend/internal/repository/ops_repo_trends.go",
+      "must_contain": [
+        "COALESCE(status_code, 0) >= 400 AND error_owner = 'provider'"
+      ],
+      "rationale": "upstream_error_rate numerator (upstream_excl) requires a final failure (status >= 400): provider errors recovered to 200 (signature_preempt thinking_blocks_stripped retries, failover) must not drive the P0 capacity alert — us7 false P0 2026-06-10 was 60 recovered-200 rows / 5min window reading 27.5%. The filter is an in-place edit inside upstream-shaped SQL hotspots, compile-clean if dropped, so an upstream merge resolving these SELECT blocks can silently revert it and the false P0 recurs. Same gate must stay in all four sites: dashboard queryErrorCounts (alert evaluator raw path), trends, preagg hourly, 1m metrics collector."
+    },
+    {
+      "path": "backend/internal/repository/ops_repo_preagg.go",
+      "must_contain": [
+        "COALESCE(client_status_code, 0) >= 400 AND error_owner = 'provider'"
+      ],
+      "rationale": "upstream_error_rate numerator (upstream_excl) requires a final failure (status >= 400): provider errors recovered to 200 (signature_preempt thinking_blocks_stripped retries, failover) must not drive the P0 capacity alert — us7 false P0 2026-06-10 was 60 recovered-200 rows / 5min window reading 27.5%. The filter is an in-place edit inside upstream-shaped SQL hotspots, compile-clean if dropped, so an upstream merge resolving these SELECT blocks can silently revert it and the false P0 recurs. Same gate must stay in all four sites: dashboard queryErrorCounts (alert evaluator raw path), trends, preagg hourly, 1m metrics collector."
+    },
+    {
+      "path": "backend/internal/service/ops_metrics_collector.go",
+      "must_contain": [
+        "COALESCE(status_code, 0) >= 400 AND error_owner = 'provider'"
+      ],
+      "rationale": "upstream_error_rate numerator (upstream_excl) requires a final failure (status >= 400): provider errors recovered to 200 (signature_preempt thinking_blocks_stripped retries, failover) must not drive the P0 capacity alert — us7 false P0 2026-06-10 was 60 recovered-200 rows / 5min window reading 27.5%. The filter is an in-place edit inside upstream-shaped SQL hotspots, compile-clean if dropped, so an upstream merge resolving these SELECT blocks can silently revert it and the false P0 recurs. Same gate must stay in all four sites: dashboard queryErrorCounts (alert evaluator raw path), trends, preagg hourly, 1m metrics collector."
     }
   ]
 }


### PR DESCRIPTION
## 背景：us7 假 P0（2026-06-10T13:40:24Z）

P0 告警「上游错误率极高」（rule#8，`upstream_error_rate > 20`，5min 窗）在 us7 触发，值 29.76%。排障坐实为**指标口径放大**，第四种 upstream_error_rate 假 P0 变体：

- us7 自身完全健康：3h served_200=2572、no_available_429=0、ratio=1.000
- 告警窗内分子 60 行 **全部是 final_status=200 的已恢复行**（`Recovered upstream error: thinking_blocks_stripped`——thinking-block 签名 400 经 signature_preempt 剥离重试成功）
- 精确复算：60 / (213 成功 + 5 error_sla) = **27.52%**，与告警值同量级
- 镜像拓扑下 prod failover 把会话换 edge 后，旧 thinking 签名跨账号必失效，一个长会话连打就是一波——机制按设计工作，用户侧零失败

## 根因

`upstream_excl`（upstream_error_rate 分子）的过滤条件只有 `error_owner='provider' AND NOT is_business_limited AND 非429/529`，**缺 final-status 门**——恢复成 200 的 provider 行照样计入分子，而分母是请求数。

## 修复

同一过滤表达式四处一致加 `COALESCE(status_code,0) >= 400`（与同查询里 error_sla 的既有口径对齐）：

| 位置 | 路径 |
|---|---|
| `ops_repo_dashboard.go` queryErrorCounts | **告警评估器（QueryModeRaw）+ dashboard raw/head/tail**，合并即生效 |
| `ops_repo_trends.go` GetErrorTrend | 错误趋势图 |
| `ops_repo_preagg.go` UpsertHourlyMetrics | preagg 小时表（历史行保留旧口径，不回填） |
| `ops_metrics_collector.go` | 1m 系统指标快照 |

**不改**：`upstream_429` / `upstream_529` 观测桶（非告警分子；保留恢复事件可见性）；恢复行的写入路径（ops_error_logs 里仍可见，供 triage）。

## 测试

- 新增集成测试 `ops_repo_tk_upstream_excl_recovered_integration_test.go`：5 类行（恢复-200 无 upstream 码 / 恢复-200 上游400 / final 502 provider / final 502 client / final 429 provider）断言 raw dashboard、trends、preagg 三路径 excl=1、429桶=1、error_sla=3
- `go test -tags=unit ./...` 53 包全绿；`go test -tags=integration ./internal/repository/ -run TestUpstreamExclExcludesRecoveredRows` PASS
- `golangci-lint run` 0 issues；`scripts/preflight.sh` PASS（pre-commit 全量跑过）

纯后端指标口径修复，无 web 影响（no-web-impact）。upstream-shaped 文件均为最小注入（每处一个过滤条件 + 两行注释），commit 带 upstream-touch-guarded。

🤖 Generated with [Claude Code](https://claude.com/claude-code)