### PR TITLE
fix(qwen): enable claude-code /v1/messages dispatch for the Qwen group

### DIFF
--- a/backend/migrations/tk_023_qwen_enable_messages_dispatch.sql
+++ b/backend/migrations/tk_023_qwen_enable_messages_dispatch.sql
@@ -1,0 +1,38 @@
+-- Migration: tk_023_qwen_enable_messages_dispatch
+--
+-- Enable Claude-Code (/v1/messages) dispatch for the Qwen group (id=18).
+--
+-- Gap (found during v1.7.91 post-deploy verification): tk_021 set group 18's
+-- messages_dispatch_model_config to {opus,sonnet,haiku -> qwen3.7-max} but left
+-- allow_messages_dispatch=false. The /v1/messages handler gates on that flag
+-- (backend/internal/handler/openai_gateway_handler.go: "if apiKey.Group != nil &&
+-- !apiKey.Group.AllowMessagesDispatch -> 403 'This group does not allow
+-- /v1/messages dispatch'"), so a Claude-Code client on the Qwen group was rejected
+-- 403 and the opus/sonnet/haiku -> qwen3.7-max mapping never ran — the dispatch
+-- config was inert. The DeepSeek group (id=11) already has the flag true, which is
+-- why its Claude-Code path worked. This flips Qwen to match, completing the
+-- Claude-Code support tk_021 intended.
+--
+-- Raw-SQL group mutation bypasses the Ent hooks that enqueue a scheduler snapshot
+-- refresh, so enqueue a scheduler_outbox group_changed event (same pattern as
+-- tk_022) — otherwise running replicas keep the stale flag until a full reload.
+--
+-- Idempotent + cross-deployment safe: guarded by (id, name, platform='newapi',
+-- allow_messages_dispatch=false) so re-running is a no-op once enabled, and a bare
+-- id colliding with an unrelated group in another DB cannot match.
+
+SET LOCAL lock_timeout = '5s';
+SET LOCAL statement_timeout = '10min';
+
+WITH upd AS (
+    UPDATE groups
+    SET allow_messages_dispatch = true,
+        updated_at = NOW()
+    WHERE id = 18
+      AND name = 'Qwen'
+      AND platform = 'newapi'
+      AND allow_messages_dispatch = false
+    RETURNING id
+)
+INSERT INTO scheduler_outbox (event_type, account_id, group_id, payload)
+SELECT 'group_changed', NULL, id, NULL FROM upd;


### PR DESCRIPTION
## 目的

补 #710 发版后验收发现的缺口:**Qwen 组(18)的 claude-code 派发实际是关着的**。

tk_021 给组18 设了 `messages_dispatch_model_config = {opus/sonnet/haiku → qwen3.7-max}`,但 `allow_messages_dispatch` 留成 `false`。`/v1/messages` handler 在 `openai_gateway_handler.go` 上硬 gate 这个标志——为 false 时直接返 **403 "This group does not allow /v1/messages dispatch"**,opus→qwen3.7-max 映射根本没机会跑。DeepSeek 组(11)该标志是 `true`(所以它的 claude-code 一直正常)。

tk_023 把组18 翻成 `true`,对齐 deepseek,补齐 tk_021 本意的 claude-code 支持。单条 guarded UPDATE + `scheduler_outbox group_changed` 刷新;`allow_messages_dispatch=false` 守卫 → 幂等。

## 验证(prod v1.7.91,已直接应用 SQL+outbox 并在此固化)

- 全迁移链含 tk_023 对真实 PG 幂等应用通过(`TestMigrationsRunner_IsIdempotent_AndSchemaIsUpToDate`)。
- **claude-code `/v1/messages` opus-tier → HTTP 200**,真回包;usage_log `total_cost=0.0004783562`(12in/93out)= **qwen3.7-max 价**($1.64/$4.93 per M),证明 opus→qwen3.7-max 映射 + 计费正确。
- 测试用临时 key/allowed-user 已清理(`keys=0 uag=0`),永久标志保留(`flag=true`)。
- `tk_*.sql` 不属 upstream-override-marker 覆盖面;纯后端 `no-web-impact`。

## 说明

- prod 已直接应用(止血+即时可用),tk_023 用于**可复现性**(其它环境 / 重建按迁移链自动获得);下次部署幂等 no-op。
- `/v1/messages` 派发路径 usage_log 记 *requested* claude 名、但按 *mapped* 模型(qwen3.7-max)计价——与 deepseek 同行为,既有设计。

🤖 Generated with [Claude Code](https://claude.com/claude-code)