### PR TITLE
fix(ops): 修复 probe-429-classify 第三段 5min 桶 SQL 的 AT TIME ZONE 优先级错误

### DIFF
--- a/ops/observability/probe-429-classify.sh
+++ b/ops/observability/probe-429-classify.sh
@@ -43,7 +43,7 @@ echo "=== window_minutes (status>=429 per 5min) ==="
 $PSQL -c "
 WITH b AS (SELECT now()-interval '${WINDOW_HOURS} hour' AS s, now() AS u)
 SELECT row_to_json(t) FROM (
-  SELECT to_char(date_trunc('hour',created_at)+date_part('minute',created_at)::int/5*interval '5 min' AT TIME ZONE 'UTC','YYYY-MM-DD\"T\"HH24:MI\"Z\"') AS slot5,
+  SELECT to_char(date_bin('5 min', created_at, timestamptz 'epoch') AT TIME ZONE 'UTC','YYYY-MM-DD\"T\"HH24:MI\"Z\"') AS slot5,
          status_code, COUNT(*) AS n
   FROM ops_error_logs l, b
   WHERE l.created_at>=b.s AND l.created_at<b.u AND status_code>=429


### PR DESCRIPTION
## 问题

`ops/observability/probe-429-classify.sh` 第三段「=== window_minutes (status>=429 per 5min) ===」的 SQL 在 prod（postgres:18-alpine）报错，导致整个探针 exit 3（2026-06-11 prod 实测复现）：

```
ERROR:  function pg_catalog.timezone(unknown, interval) does not exist
LINE 4: ...part('minute',created_at)::int/5*interval '5 min' AT TIME ZO...
HINT:  No function matches the given name and argument types.
```

根因：`AT TIME ZONE` 运算优先级高于 `+`，原式 `date_trunc('hour',created_at) + date_part(...)::int/5*interval '5 min' AT TIME ZONE 'UTC'` 把时区转换应用到了 `interval '5 min'` 上，而非求和后的时间戳。前两段（429_by_type、err_by_group_model）不受影响。

## 修复

改用 `date_bin('5 min', created_at, timestamptz 'epoch') AT TIME ZONE 'UTC'`（PG14+ 内置，prod 为 PG18）：`AT TIME ZONE` 作用于 date_bin 返回的 timestamptz，timestamptz→timestamp 顺序与同目录 `ops-error-triage.sh` 中正常工作的时间桶写法（`date_trunc('minute', created_at) AT TIME ZONE 'UTC'`）一致。输出仍为 row_to_json，字段名 `slot5` 与格式 `YYYY-MM-DDTHH:MIZ` 不变。

## 同类反模式扫描

`grep -rn "AT TIME ZONE" ops/` 复查全部 17 处用法：其余均直接作用于 timestamptz 列（`created_at`、`session_window_end`、`now()`）或 `date_trunc`/`MIN`/`MAX` 的 timestamptz 结果，无 interval 优先级问题，不需要改动。

## prod 实跑验证（只读 SELECT，经 run-probe.sh SSM 通道）

```
bash ops/observability/run-probe.sh --target prod --script ops/observability/probe-429-classify.sh --env WINDOW_HOURS=3 --timeout-seconds 120
```

结果：**exit 0**，SSM status=Success duration=7s，三段全部有输出、0 条 ERROR。第三段输出示例：

```
=== window_minutes (status>=429 per 5min) ===
{"slot5":"2026-06-11T06:25Z","status_code":502,"n":981}
{"slot5":"2026-06-11T06:45Z","status_code":429,"n":51}
{"slot5":"2026-06-11T08:30Z","status_code":503,"n":480}
```

改动范围：仅 `ops/observability/probe-429-classify.sh` 一行（TK-only 目录，no-web-impact / no-upstream-touch）。

🤖 Generated with [Claude Code](https://claude.com/claude-code)