### PR TITLE
fix(openai): 空池快速失败 429 对齐 #575（openai/newapi compat 路径）

### DIFF
--- a/backend/internal/handler/gateway_handler_tk_count_tokens_failover.go
+++ b/backend/internal/handler/gateway_handler_tk_count_tokens_failover.go
@@ -57,14 +57,16 @@ func (h *GatewayHandler) forwardCountTokensWithFailover(
 		)
 		if err != nil {
 			// 选号落空。若此前已发生过 failover 错误，按最后一次上游错误回客户端，
-			// 保留真实状态码（429/529/...）；否则按容量不可用回 503。
+			// 保留真实状态码（429/529/...）；否则空池快速失败 429（#575 语义），
+			// 其余调度错误（DB 故障等）保持 503。
 			if fs.LastFailoverErr != nil {
 				h.gatewayService.WriteCountTokensFailoverError(c, fs.LastFailoverErr)
 				return
 			}
 			reqLog.Warn("gateway.count_tokens_select_account_failed", zap.Error(err))
 			markOpsRoutingCapacityLimitedIfNoAvailable(c, err)
-			h.errorResponse(c, http.StatusServiceUnavailable, "api_error", "Service temporarily unavailable")
+			tkStatus, tkMsg := tkSelectFailureStatusMessage(c, err)
+			h.errorResponse(c, tkStatus, "api_error", tkMsg)
 			return
 		}
 		setOpsSelectedAccount(c, account.ID, account.Platform)

--- a/backend/internal/handler/no_available_accounts_tk.go
+++ b/backend/internal/handler/no_available_accounts_tk.go
@@ -38,3 +38,25 @@ func tkNoAvailableAccounts(c *gin.Context) int {
 	c.Header("Retry-After", tkNoAvailableAccountsRetryAfterSeconds)
 	return http.StatusTooManyRequests
 }
+
+// tkSelectFailureStatusMessage maps a FIRST-attempt account-selection error
+// (len(failedAccountIDs)==0, no upstream attempt was made yet) to the
+// client-facing (status, message) pair.
+//
+// Empty pool — the "no available accounts" error family, classified by
+// isOpsNoAvailableAccountError, the exact predicate ops logging already uses in
+// markOpsRoutingCapacityLimitedIfNoAvailable — gets the #575 fast-fail
+// semantics: 429 + Retry-After via tkNoAvailableAccounts (see that helper's
+// comment for why 503 melts the node behind Caddy passive health). Any other
+// scheduler failure (DB outage, context errors, ...) keeps 503: those are real
+// service faults, not capacity backoff hints.
+//
+// This converged the openai/newapi compat handlers with the anthropic path,
+// which adopted the 429 semantics in #575; before this helper the two branches
+// of the same handler disagreed (selection==nil → 429, select error → 503).
+func tkSelectFailureStatusMessage(c *gin.Context, err error) (int, string) {
+	if isOpsNoAvailableAccountError(err) {
+		return tkNoAvailableAccounts(c), "No available accounts: " + err.Error()
+	}
+	return http.StatusServiceUnavailable, "Service temporarily unavailable"
+}

--- a/backend/internal/handler/no_available_accounts_tk_test.go
+++ b/backend/internal/handler/no_available_accounts_tk_test.go
@@ -1,0 +1,74 @@
+package handler
+
+import (
+	"errors"
+	"fmt"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+
+	"github.com/Wei-Shaw/sub2api/internal/service"
+	"github.com/gin-gonic/gin"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// TestTkSelectFailureStatusMessage verifies the empty-pool fast-fail mapping
+// shared by the openai/newapi compat handlers (#575 parity with the anthropic
+// path): the no-available-accounts error family becomes 429 + Retry-After,
+// everything else (DB outage, ...) stays 503.
+func TestTkSelectFailureStatusMessage(t *testing.T) {
+	gin.SetMode(gin.TestMode)
+
+	newCtx := func(t *testing.T) (*gin.Context, *httptest.ResponseRecorder) {
+		t.Helper()
+		w := httptest.NewRecorder()
+		c, _ := gin.CreateTestContext(w)
+		c.Request = httptest.NewRequest(http.MethodPost, "/v1/chat/completions", nil)
+		return c, w
+	}
+
+	t.Run("no_available_accounts_sentinel_returns_429_with_retry_after", func(t *testing.T) {
+		c, w := newCtx(t)
+		status, msg := tkSelectFailureStatusMessage(c, service.ErrNoAvailableAccounts)
+
+		require.Equal(t, http.StatusTooManyRequests, status)
+		assert.Equal(t, tkNoAvailableAccountsRetryAfterSeconds, w.Header().Get("Retry-After"))
+		assert.Contains(t, msg, "No available accounts")
+	})
+
+	t.Run("wrapped_no_available_accounts_returns_429", func(t *testing.T) {
+		c, w := newCtx(t)
+		wrapped := fmt.Errorf("%w supporting model: gpt-5.2 (channel pricing restriction)", service.ErrNoAvailableAccounts)
+		status, msg := tkSelectFailureStatusMessage(c, wrapped)
+
+		require.Equal(t, http.StatusTooManyRequests, status)
+		assert.Equal(t, tkNoAvailableAccountsRetryAfterSeconds, w.Header().Get("Retry-After"))
+		assert.Contains(t, msg, "gpt-5.2")
+	})
+
+	t.Run("no_available_compact_accounts_returns_429", func(t *testing.T) {
+		c, _ := newCtx(t)
+		status, _ := tkSelectFailureStatusMessage(c, service.ErrNoAvailableCompactAccounts)
+
+		require.Equal(t, http.StatusTooManyRequests, status)
+	})
+
+	t.Run("message_match_without_sentinel_returns_429", func(t *testing.T) {
+		// Relay-hop case: the upstream TokenKey edge serialized the sentinel into a
+		// plain message; the substring classifier must still catch it.
+		c, _ := newCtx(t)
+		status, _ := tkSelectFailureStatusMessage(c, errors.New("scheduler: no available openai accounts in group 7"))
+
+		require.Equal(t, http.StatusTooManyRequests, status)
+	})
+
+	t.Run("other_scheduler_errors_stay_503_without_retry_after", func(t *testing.T) {
+		c, w := newCtx(t)
+		status, msg := tkSelectFailureStatusMessage(c, errors.New("pq: connection refused"))
+
+		require.Equal(t, http.StatusServiceUnavailable, status)
+		assert.Empty(t, w.Header().Get("Retry-After"))
+		assert.Equal(t, "Service temporarily unavailable", msg)
+	})
+}

--- a/backend/internal/handler/openai_chat_completions.go
+++ b/backend/internal/handler/openai_chat_completions.go
@@ -156,7 +156,9 @@ func (h *OpenAIGatewayHandler) ChatCompletions(c *gin.Context) {
 			)
 			if len(failedAccountIDs) == 0 {
 				markOpsRoutingCapacityLimitedIfNoAvailable(c, err)
-				h.handleStreamingAwareError(c, http.StatusServiceUnavailable, "api_error", "Service temporarily unavailable", streamStarted)
+				// TK: empty pool fast-fails 429 (#575 parity); other scheduler errors stay 503.
+				tkStatus, tkMsg := tkSelectFailureStatusMessage(c, err)
+				h.handleStreamingAwareError(c, tkStatus, "api_error", tkMsg, streamStarted)
 				return
 			} else {
 				if lastFailoverErr != nil {

--- a/backend/internal/handler/openai_gateway_embeddings_images.go
+++ b/backend/internal/handler/openai_gateway_embeddings_images.go
@@ -160,7 +160,10 @@ func (h *OpenAIGatewayHandler) Embeddings(c *gin.Context) {
 					}
 				}
 				if err != nil {
-					h.handleStreamingAwareError(c, http.StatusServiceUnavailable, "api_error", "Service temporarily unavailable", streamStarted)
+					markOpsRoutingCapacityLimitedIfNoAvailable(c, err)
+					// TK: empty pool fast-fails 429 (#575 parity); other scheduler errors stay 503.
+					tkStatus, tkMsg := tkSelectFailureStatusMessage(c, err)
+					h.handleStreamingAwareError(c, tkStatus, "api_error", tkMsg, streamStarted)
 					return
 				}
 			} else {
@@ -458,7 +461,10 @@ func (h *OpenAIGatewayHandler) ImageGenerations(c *gin.Context) {
 					}
 				}
 				if err != nil {
-					h.handleStreamingAwareError(c, http.StatusServiceUnavailable, "api_error", "Service temporarily unavailable", streamStarted)
+					markOpsRoutingCapacityLimitedIfNoAvailable(c, err)
+					// TK: empty pool fast-fails 429 (#575 parity); other scheduler errors stay 503.
+					tkStatus, tkMsg := tkSelectFailureStatusMessage(c, err)
+					h.handleStreamingAwareError(c, tkStatus, "api_error", tkMsg, streamStarted)
 					return
 				}
 			} else {

--- a/backend/internal/handler/openai_gateway_handler.go
+++ b/backend/internal/handler/openai_gateway_handler.go
@@ -306,10 +306,13 @@ func (h *OpenAIGatewayHandler) Responses(c *gin.Context) {
 			if len(failedAccountIDs) == 0 {
 				markOpsRoutingCapacityLimitedIfNoAvailable(c, err)
 				if errors.Is(err, service.ErrNoAvailableCompactAccounts) {
-					h.handleStreamingAwareError(c, http.StatusServiceUnavailable, "compact_not_supported", "No available OpenAI accounts support /responses/compact", streamStarted)
+					// TK: empty compact pool is the same no-available family → 429 (#575 parity).
+					h.handleStreamingAwareError(c, tkNoAvailableAccounts(c), "compact_not_supported", "No available OpenAI accounts support /responses/compact", streamStarted)
 					return
 				}
-				h.handleStreamingAwareError(c, http.StatusServiceUnavailable, "api_error", "Service temporarily unavailable", streamStarted)
+				// TK: empty pool fast-fails 429 (#575 parity); other scheduler errors stay 503.
+				tkStatus, tkMsg := tkSelectFailureStatusMessage(c, err)
+				h.handleStreamingAwareError(c, tkStatus, "api_error", tkMsg, streamStarted)
 				return
 			}
 			if lastFailoverErr != nil {
@@ -746,7 +749,9 @@ func (h *OpenAIGatewayHandler) Messages(c *gin.Context) {
 			if len(failedAccountIDs) == 0 {
 				if err != nil {
 					markOpsRoutingCapacityLimitedIfNoAvailable(c, err)
-					h.anthropicStreamingAwareError(c, http.StatusServiceUnavailable, "api_error", "Service temporarily unavailable", streamStarted)
+					// TK: empty pool fast-fails 429 (#575 parity); other scheduler errors stay 503.
+					tkStatus, tkMsg := tkSelectFailureStatusMessage(c, err)
+					h.anthropicStreamingAwareError(c, tkStatus, "api_error", tkMsg, streamStarted)
 					return
 				}
 			} else {

--- a/backend/internal/handler/openai_gateway_tk_video.go
+++ b/backend/internal/handler/openai_gateway_tk_video.go
@@ -128,7 +128,16 @@ func (h *OpenAIGatewayHandler) VideoSubmit(c *gin.Context) {
 	)
 	if err != nil || selection == nil || selection.Account == nil {
 		reqLog.Warn("openai_video_submit.account_select_failed", zap.Error(err))
-		h.errorResponse(c, http.StatusServiceUnavailable, "api_error", "Service temporarily unavailable")
+		if err == nil {
+			// Scheduler returned no usable selection without an error → empty pool.
+			markOpsRoutingCapacityLimited(c)
+			h.errorResponse(c, tkNoAvailableAccounts(c), "api_error", "No available accounts")
+			return
+		}
+		markOpsRoutingCapacityLimitedIfNoAvailable(c, err)
+		// Empty pool fast-fails 429 (#575 parity); other scheduler errors stay 503.
+		tkStatus, tkMsg := tkSelectFailureStatusMessage(c, err)
+		h.errorResponse(c, tkStatus, "api_error", tkMsg)
 		return
 	}
 	account := selection.Account

--- a/backend/internal/handler/openai_images.go
+++ b/backend/internal/handler/openai_images.go
@@ -158,7 +158,9 @@ func (h *OpenAIGatewayHandler) Images(c *gin.Context) {
 			)
 			if len(failedAccountIDs) == 0 {
 				markOpsRoutingCapacityLimitedIfNoAvailable(c, err)
-				h.handleStreamingAwareError(c, http.StatusServiceUnavailable, "api_error", "No available compatible accounts", streamStarted)
+				// TK: empty pool fast-fails 429 (#575 parity); other scheduler errors stay 503.
+				tkStatus, tkMsg := tkSelectFailureStatusMessage(c, err)
+				h.handleStreamingAwareError(c, tkStatus, "api_error", tkMsg, streamStarted)
 				return
 			}
 			if lastFailoverErr != nil {
@@ -170,7 +172,8 @@ func (h *OpenAIGatewayHandler) Images(c *gin.Context) {
 		}
 		if selection == nil || selection.Account == nil {
 			markOpsRoutingCapacityLimited(c)
-			h.handleStreamingAwareError(c, http.StatusServiceUnavailable, "api_error", "No available compatible accounts", streamStarted)
+			// TK: empty pool fast-fails 429 (#575 parity with the other selection==nil branches).
+			h.handleStreamingAwareError(c, tkNoAvailableAccounts(c), "api_error", "No available compatible accounts", streamStarted)
 			return
 		}
 

--- a/scripts/sentinels/gateway-tk.json
+++ b/scripts/sentinels/gateway-tk.json
@@ -1851,10 +1851,36 @@
       "path": "backend/internal/handler/no_available_accounts_tk.go",
       "must_contain": [
         "func tkNoAvailableAccounts",
+        "func tkSelectFailureStatusMessage",
+        "isOpsNoAvailableAccountError(err)",
         "http.StatusTooManyRequests",
         "Retry-After"
       ],
-      "rationale": "Empty-pool fast-fail returns 429+Retry-After (not 503) so Caddy passive-health on the single Stage0 upstream does not conflate an empty scheduling pool with a backend outage and stall all traffic incl. the dashboard. An upstream merge re-introducing 503 at the account-select call sites regresses the prod flood-containment fix (PR #572 / IP 58.213.121.60 1540 RPM incident)."
+      "rationale": "Empty-pool fast-fail returns 429+Retry-After (not 503) so Caddy passive-health on the single Stage0 upstream does not conflate an empty scheduling pool with a backend outage and stall all traffic incl. the dashboard. An upstream merge re-introducing 503 at the account-select call sites regresses the prod flood-containment fix (PR #572 / IP 58.213.121.60 1540 RPM incident). tkSelectFailureStatusMessage (PR #723) extends the same semantics to the openai/newapi compat first-selection failure branches: the no-available error family (classified by isOpsNoAvailableAccountError, the same predicate ops capacity-limited marking uses) maps to 429, while genuine scheduler faults (DB outage, context errors) keep 503."
+    },
+    {
+      "path": "backend/internal/handler/openai_chat_completions.go",
+      "must_contain": [
+        "tkStatus, tkMsg := tkSelectFailureStatusMessage(c, err)"
+      ],
+      "rationale": "/v1/chat/completions first-selection failure (len(failedAccountIDs)==0) must route through tkSelectFailureStatusMessage so an empty openai/newapi pool fast-fails 429 instead of 503 (PR #723, #575 parity; prod 2026-06-11: 480 empty-pool 503s in 2min when both GPT accounts hit upstream 429). Reverting this one-line hook to the upstream 503 literal compiles clean but re-exposes the Caddy passive-health melt + SDK retry storm the no_available_accounts_tk.go sentinel documents."
+    },
+    {
+      "path": "backend/internal/handler/openai_gateway_handler.go",
+      "must_contain": [
+        "h.handleStreamingAwareError(c, tkNoAvailableAccounts(c), \"compact_not_supported\"",
+        "h.handleStreamingAwareError(c, tkStatus, \"api_error\", tkMsg, streamStarted)",
+        "h.anthropicStreamingAwareError(c, tkStatus, \"api_error\", tkMsg, streamStarted)"
+      ],
+      "rationale": "Responses + openai_messages first-selection failure branches must route through tkSelectFailureStatusMessage (429 on empty pool, 503 on real scheduler faults), and the empty compact pool (ErrNoAvailableCompactAccounts) keeps its compact_not_supported code but joins the 429 no-available family (PR #723, #575 parity). The two helper-call sites have identical assignment lines, so the anchors pin the two distinct error-writer lines (handleStreamingAwareError for Responses, anthropicStreamingAwareError for Messages) — losing either on an upstream merge silently reverts that endpoint to empty-pool 503."
+    },
+    {
+      "path": "backend/internal/handler/openai_images.go",
+      "must_contain": [
+        "tkStatus, tkMsg := tkSelectFailureStatusMessage(c, err)",
+        "h.handleStreamingAwareError(c, tkNoAvailableAccounts(c), \"api_error\", \"No available compatible accounts\", streamStarted)"
+      ],
+      "rationale": "Images first-selection failure must route through tkSelectFailureStatusMessage, and the selection==nil branch returns 429 via tkNoAvailableAccounts — previously the only selection==nil branch still answering 503, inconsistent with its sibling handlers (PR #723, #575 parity). An upstream merge restoring either 503 literal compiles clean but regresses the image surface back to the Caddy passive-health failure mode."
     },
     {
       "path": "backend/internal/service/ratelimit_service_tk_model_cooldown.go",


### PR DESCRIPTION
## 背景（线上证据）

2026-06-11 诊断 prod 过去 24h：**503×529，其中 480 条集中在 08:31–08:32 UTC** —— GPT-pro1/pro2 两个 openai 账号同时被上游 429 限流后池空，`openai_chat_completions.go` 的「首次选号即失败（`len(failedAccountIDs)==0`）」分支走 `markOpsRoutingCapacityLimitedIfNoAvailable(c, err)` + 503 `Service temporarily unavailable`。

而 anthropic 路径在 #575 已改为**空池快速失败 429**，rationale 同样适用于 openai/newapi compat 路径：

- Stage0 单 app upstream 挂在 Caddy 后，Caddy 被动健康检查把 503 列入 `unhealthy_status`（`max_fails=1`）——一条空池 503 就把唯一 upstream 标记为 down，后续所有请求（含 dashboard）卡在 `lb_try_duration`，空池 503 洪峰会合成一次假后端宕机；429 不在 `unhealthy_status` 里，不会触发误判。
- 503 让 SDK 客户端激进重试（retry storm）；429 + `Retry-After` 让它们退避。

更直接的矛盾：同一个 handler 里 `selection==nil` 分支早已用 `tkNoAvailableAccounts(c)`（429），而选号 error 分支却回 503——同一语义两种状态码。

## 改动

**判别器（薄注入 + companion 收敛，§5 纪律）：** `no_available_accounts_tk.go` 新增 `tkSelectFailureStatusMessage(c, err)`，复用 ops 既有判别器 `isOpsNoAvailableAccountError`（`errors.Is(ErrNoAvailableAccounts / ErrNoAvailableCompactAccounts)` + relay-hop message 匹配）：

- no-available 错误族 → `tkNoAvailableAccounts(c)`（429 + `Retry-After: 5`）+ `No available accounts: <err>`
- 其余调度错误（DB 故障、context 错误等）→ 保持 503 `Service temporarily unavailable`

**接入位点（只动空池/首次选号失败分支）：**

| 位点 | 原行为 | 现行为 |
|---|---|---|
| `openai_chat_completions.go` 首选失败 | 503 | 判别器 |
| `openai_gateway_handler.go` Responses 首选失败 | 503 | 判别器 |
| `openai_gateway_handler.go` Responses compact 池空（`ErrNoAvailableCompactAccounts`） | 503 | 429（同属 no-available 族，保留 `compact_not_supported` code） |
| `openai_gateway_handler.go` openai_messages 首选失败 | 503 | 判别器 |
| `openai_gateway_embeddings_images.go` embeddings + images 别名首选失败（×2） | 503（且原本漏标 ops capacity-limited） | 判别器 + 补 `markOpsRoutingCapacityLimitedIfNoAvailable` |
| `openai_images.go` 首选失败 | 503 | 判别器 |
| `openai_images.go` `selection==nil` | 503（与其他文件同分支的 429 不一致） | 429 |
| `openai_gateway_tk_video.go` submit 选号失败 | 503（err/nil-selection 合并一个 503） | 拆分：空池/nil-selection → 429，其余 → 判别器 |
| `gateway_handler_tk_count_tokens_failover.go:67` 选号落空且无前置 failover 错误 | 503 | 判别器（count_tokens 同经 Caddy，503 同样触发被动健康误判） |

**核实后不改的位点：**

- `gateway_handler_tk_count_tokens_failover.go:48`——body 还原失败是内部错误（500），不是空池，保持原状。
- 各 handler 的 failover-exhausted / 502 掩码路径（`handleFailoverExhausted*`）——已有上游错误语义，且另有并行 PR 在改该路径，本 PR hunks 不重叠。
- 已是 429 的 `selection==nil` 分支（chat_completions / responses / messages / embeddings / images 别名）——不动。

## 测试

- 新增 `no_available_accounts_tk_test.go`：判别映射 5 个用例（sentinel / wrapped supporting-model / compact / relay-hop message-match / 非空池 503 + 无 Retry-After）。
- 现有断言 503 的测试核实均为依赖缺失（`ensureResponsesDependencies`）/ nil registry 路径，与空池无关，无需改动。
- `(cd backend && go test -tags=unit ./...)` 全包全绿；`golangci-lint run` 0 issues；`scripts/preflight.sh` PASS。

no-web-impact（纯后端状态码语义，无前端改动）；upstream-touch-guarded（openai handlers 为 upstream-shaped，改动为薄注入 + `*_tk_*.go` companion）。

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---

sentinel-registry-reviewed：已逐个核对本 PR 触碰的热点文件（`openai_chat_completions.go` / `openai_gateway_handler.go` / `openai_gateway_tk_video.go` / `gateway_handler_tk_count_tokens_failover.go`），既有锚点全 intact——删除的行均为被替换的 503 字面量调用行，不是任何 sentinel 锚点。**Review 修复（bcd7e41e，xj-review R-001）：新注入位点本身是新增 load-bearing 注入面，已补入 `scripts/sentinels/gateway-tk.json`**——三个 upstream-owned 文件（`openai_chat_completions.go` / `openai_gateway_handler.go` / `openai_images.go`）的 `tkSelectFailureStatusMessage` 调用、compact 429 分支、images `selection==nil` 429 分支逐一加锚，并在 `no_available_accounts_tk.go` 条目补 helper 符号 + 判别谓词锚（226→229 intact）。此后上游 merge 把任一注入行回退成 503 会被本地 preflight 与 upstream-merge PR shape 双双拦下。
