### PR TITLE
fix(newapi): bridge 错误路径接入账号惩罚 + 透传真实上游状态码 + 补 402 飞书告警盲区

### DIFF
--- a/backend/internal/handler/openai_chat_completions.go
+++ b/backend/internal/handler/openai_chat_completions.go
@@ -269,6 +269,22 @@ func (h *OpenAIGatewayHandler) ChatCompletions(c *gin.Context) {
 					)
 					continue
 				}
+				// Preserve upstream NewAPIRelayError detail for newapi accounts (mirrors
+				// the /v1/responses handler): without this branch the fallback below
+				// masks the adaptor's structured error (402 insufficient balance,
+				// 429 rate limit, …) as a generic 502 "Upstream request failed" —
+				// the 2026-06-11 DeepSeek prod incident shape. The sibling block
+				// further down (after the else) is only reachable on the
+				// image-partial-result path and never fires for plain chat errors.
+				if TkTryWriteNewAPIRelayErrorJSON(c, err, streamStarted, writerSizeBeforeForward) {
+					h.gatewayService.ReportOpenAIAccountScheduleResult(account.ID, false, nil)
+					reqLog.Warn("openai_chat_completions.forward_failed",
+						zap.Int64("account_id", account.ID),
+						zap.Bool("fallback_error_response_written", false),
+						zap.Error(err),
+					)
+					return
+				}
 				h.gatewayService.ReportOpenAIAccountScheduleResult(account.ID, false, nil)
 				upstreamErrorAlreadyCommunicated := openAIForwardErrorAlreadyCommunicated(c, writerSizeBeforeForward, err)
 				wroteFallback := false

--- a/backend/internal/service/account_incident_notifier_tk.go
+++ b/backend/internal/service/account_incident_notifier_tk.go
@@ -214,14 +214,16 @@ func (n *TKAccountIncidentNotifier) NotifyAccountIncident(account *Account, unti
 		return
 	}
 	n.trackActive(account, cls, until)
-	if cls.kind == IncidentKindPermanentDisable {
-		// 永久失效是整账号下线,无上游维度细分语义 → 忽略 detail。
-		n.handlePermanent(account, reason, cls)
-		return
-	}
 	d := ""
 	if len(detail) > 0 {
 		d = strings.TrimSpace(detail[0])
+	}
+	if cls.kind == IncidentKindPermanentDisable {
+		// 永久失效卡片把 detail 渲染为「详情」行（携带真实上游 status + message,
+		// 如 "Payment required (402): Insufficient Balance"）,运营无需再查 DB
+		// error_message 才能定位是余额耗尽还是凭证吊销。
+		n.handlePermanent(account, reason, cls, d)
+		return
 	}
 	n.recordTemporary(account, cls, d)
 }
@@ -284,7 +286,8 @@ func (n *TKAccountIncidentNotifier) NotifyAccountRecovered(accountID int64) {
 }
 
 // handlePermanent: 同步只做内存去重判定,命中后异步发即时单条 P0 卡片。
-func (n *TKAccountIncidentNotifier) handlePermanent(account *Account, reason string, cls incidentClass) {
+// detail（可为空）是上游真实错误摘要,渲染为卡片「详情」行。
+func (n *TKAccountIncidentNotifier) handlePermanent(account *Account, reason string, cls incidentClass, detail string) {
 	now := n.currentTime()
 	key := accountIncidentDedupeKey(n.siteID, account.ID, cls.reasonClass)
 	n.mu.Lock()
@@ -300,7 +303,7 @@ func (n *TKAccountIncidentNotifier) handlePermanent(account *Account, reason str
 	n.mu.Unlock()
 
 	title := fmt.Sprintf("TokenKey 账号永久失效 [%s]", n.siteID)
-	body := buildAccountIncidentPermanentText(n.siteID, account, reason, cls, now)
+	body := buildAccountIncidentPermanentText(n.siteID, account, reason, cls, now, detail)
 	n.send(title, "red", body, fmt.Sprintf("account_id=%d reason=%s", account.ID, reason))
 }
 
@@ -459,14 +462,20 @@ func (n *TKAccountIncidentNotifier) currentTime() time.Time {
 	return time.Now()
 }
 
-func buildAccountIncidentPermanentText(site string, account *Account, reason string, cls incidentClass, now time.Time) string {
-	return fmt.Sprintf("**节点**：%s\n**账号**：%s\n**平台**：%s\n**组**：%s\n**事件**：%s\n**reason**：%s\n**时间**：%s\n\n**建议**：%s",
+func buildAccountIncidentPermanentText(site string, account *Account, reason string, cls incidentClass, now time.Time, detail string) string {
+	detailLine := ""
+	if d := strings.TrimSpace(detail); d != "" {
+		// 上游真实错误摘要（含 upstream status,如 "Payment required (402): …"）。
+		detailLine = "\n**详情**：" + escapeFeishuText(d)
+	}
+	return fmt.Sprintf("**节点**：%s\n**账号**：%s\n**平台**：%s\n**组**：%s\n**事件**：%s\n**reason**：%s%s\n**时间**：%s\n\n**建议**：%s",
 		escapeFeishuText(site),
 		escapeFeishuText(accountIncidentLabel(account)),
 		escapeFeishuText(strings.TrimSpace(account.Platform)),
 		escapeFeishuText(accountGroupNames(account)),
 		escapeFeishuText(cls.kindZh),
 		escapeFeishuText(strings.TrimSpace(reason)),
+		detailLine,
 		escapeFeishuText(formatAlertTime(now)),
 		escapeFeishuText(cls.advice),
 	)

--- a/backend/internal/service/gateway_bridge_dispatch.go
+++ b/backend/internal/service/gateway_bridge_dispatch.go
@@ -109,7 +109,7 @@ func (s *GatewayService) ForwardAsChatCompletionsDispatched(
 			zap.String("bridge_path", "newapi_adaptor_error"),
 			zap.Int64("account_id", account.ID),
 		)
-		return nil, tkWrapBridgeRelayError(c, apiErr)
+		return nil, s.tkWrapBridgeRelayErrorWithPenalty(ctx, c, account, apiErr)
 	}
 	logger.L().Info("gateway.newapi_bridge_dispatch",
 		zap.String("endpoint", BridgeEndpointChatCompletions),
@@ -160,7 +160,7 @@ func (s *GatewayService) ForwardAsResponsesDispatched(
 			zap.String("bridge_path", "newapi_adaptor_error"),
 			zap.Int64("account_id", account.ID),
 		)
-		return nil, tkWrapBridgeRelayError(c, apiErr)
+		return nil, s.tkWrapBridgeRelayErrorWithPenalty(ctx, c, account, apiErr)
 	}
 	logger.L().Info("gateway.newapi_bridge_dispatch",
 		zap.String("endpoint", BridgeEndpointResponses),

--- a/backend/internal/service/newapi_bridge_penalty_tk.go
+++ b/backend/internal/service/newapi_bridge_penalty_tk.go
@@ -1,0 +1,117 @@
+package service
+
+import (
+	"context"
+	"encoding/json"
+	"log/slog"
+	"net/http"
+
+	newapitypes "github.com/QuantumNous/new-api/types"
+	"github.com/gin-gonic/gin"
+)
+
+// TK: newapi fifth-platform bridge → account penalty wiring.
+//
+// Why this file exists (prod 2026-06-11, account 39 "ds-官" / DeepSeek):
+// every bridge.Dispatch* error path used to call only tkWrapBridgeRelayError,
+// which records the upstream verdict for OPS LOGGING and wraps the error —
+// it never reaches RateLimitService.HandleUpstreamError. So an upstream 402
+// "Insufficient Balance" left the account schedulable=true with no cooldown,
+// no disable and no Feishu alert; the gateway hammered the exhausted upstream
+// ~6946 times in 2h. The pre-existing "case 402 → handleAuthError +
+// shouldDisable" in ratelimit_service.go was simply unreachable for newapi
+// accounts because nothing on the bridge path called into it.
+//
+// tkHandleBridgeUpstreamPenalty closes that gap. Design constraints:
+//
+//   - Status allowlist {401, 402, 429} ONLY. 400 and 404 are deliberately
+//     excluded: they are client-induced (bad request / unknown model name) and
+//     penalizing them lets any caller drain the pool (the #617 lesson where
+//     client 400s were mistaken for upstream faults and cooled healthy
+//     accounts). The allowlist also automatically excludes the synthetic
+//     bridge errors (errBridgeMissingCredential / errBridgeVideoUnsupportedChannel
+//     are 400) — and as a second layer, the wrapper below is only invoked at
+//     sites wrapping a REAL bridge.Dispatch* upstream error, never for the
+//     synthetic early-returns.
+//   - headers are not available from *newapitypes.NewAPIError, so we pass nil.
+//     That is safe: http.Header.Get on a nil map returns "" (no reset-time
+//     headers found), and for PlatformNewAPI handle429 then falls back to the
+//     body parser and finally apply429FallbackRateLimit (default short
+//     cooldown) — exactly the conservative behaviour we want.
+//   - The account-state write must survive client cancellation: we reuse
+//     openAIAccountStateContext (context.WithoutCancel + short timeout), the
+//     same pattern as handleOpenAIAccountUpstreamError. A canceled request
+//     must not abort the SetError/SetRateLimited write (the #628 class).
+func tkHandleBridgeUpstreamPenalty(ctx context.Context, rls *RateLimitService, account *Account, apiErr *newapitypes.NewAPIError) {
+	if rls == nil || account == nil || apiErr == nil {
+		return
+	}
+	if !tkBridgePenaltyStatusEligible(apiErr.StatusCode) {
+		return
+	}
+	stateCtx, cancel := openAIAccountStateContext(ctx)
+	defer cancel()
+	shouldDisable := rls.HandleUpstreamError(stateCtx, account, apiErr.StatusCode, nil, tkBridgeUpstreamErrorBody(apiErr))
+	slog.Warn("newapi_bridge_upstream_penalty",
+		"account_id", account.ID,
+		"platform", account.Platform,
+		"channel_type", account.ChannelType,
+		"status_code", apiErr.StatusCode,
+		"should_disable", shouldDisable,
+	)
+}
+
+// tkBridgePenaltyStatusEligible is the explicit allowlist of upstream statuses
+// that may penalize the account from the bridge path. Keep this narrow: adding
+// 403/5xx here means a transient upstream WAF blip or provider outage could
+// permanently disable accounts via handle403/custom-code paths — widen only
+// with production evidence.
+func tkBridgePenaltyStatusEligible(statusCode int) bool {
+	switch statusCode {
+	case http.StatusUnauthorized, http.StatusPaymentRequired, http.StatusTooManyRequests:
+		return true
+	}
+	return false
+}
+
+// tkBridgeUpstreamErrorBody synthesizes an OpenAI-style error envelope from the
+// bridge relay error so RateLimitService body parsers (extractUpstreamErrorMessage,
+// parseOpenAIRateLimitResetTime, …) see the upstream message/code. NewAPIError
+// does not retain the raw upstream response body; ToOpenAIError() is the closest
+// faithful projection (it preserves the upstream message and structured code).
+func tkBridgeUpstreamErrorBody(apiErr *newapitypes.NewAPIError) []byte {
+	if apiErr == nil {
+		return nil
+	}
+	body, err := json.Marshal(map[string]any{"error": apiErr.ToOpenAIError()})
+	if err != nil {
+		return nil
+	}
+	return body
+}
+
+// tkWrapBridgeRelayErrorWithPenalty is the OpenAIGatewayService dispatch-site
+// chokepoint: apply the account penalty for real upstream bridge errors, then
+// record + wrap exactly like tkWrapBridgeRelayError. Use at every dispatch site
+// that wraps a REAL bridge upstream error and has the selected account in hand
+// (NOT for synthetic missing-credential / unsupported-channel errors, and NOT
+// for the account-agnostic video fetch path).
+func (s *OpenAIGatewayService) tkWrapBridgeRelayErrorWithPenalty(ctx context.Context, c *gin.Context, account *Account, apiErr *newapitypes.NewAPIError) *NewAPIRelayError {
+	var rls *RateLimitService
+	if s != nil {
+		rls = s.rateLimitService
+	}
+	tkHandleBridgeUpstreamPenalty(ctx, rls, account, apiErr)
+	return tkWrapBridgeRelayError(c, apiErr)
+}
+
+// tkWrapBridgeRelayErrorWithPenalty is the GatewayService sibling (the Anthropic
+// gateway's chat-completions/responses bridge boundary in gateway_bridge_dispatch.go).
+func (s *GatewayService) tkWrapBridgeRelayErrorWithPenalty(ctx context.Context, c *gin.Context, account *Account, apiErr *newapitypes.NewAPIError) *NewAPIRelayError {
+	var rls *RateLimitService
+	if s != nil {
+		rls = s.rateLimitService
+	}
+	tkHandleBridgeUpstreamPenalty(ctx, rls, account, apiErr)
+	return tkWrapBridgeRelayError(c, apiErr)
+}

--- a/backend/internal/service/newapi_bridge_penalty_tk_test.go
+++ b/backend/internal/service/newapi_bridge_penalty_tk_test.go
@@ -1,0 +1,193 @@
+//go:build unit
+
+package service
+
+import (
+	"context"
+	"errors"
+	"strings"
+	"testing"
+	"time"
+
+	newapitypes "github.com/QuantumNous/new-api/types"
+	"github.com/Wei-Shaw/sub2api/internal/config"
+	"github.com/stretchr/testify/require"
+)
+
+// tkBridgePenaltyIncidentRecorder records NotifyAccountIncident calls so tests
+// can assert the Feishu funnel fires with the upstream detail attached.
+type tkBridgePenaltyIncidentRecorder struct {
+	reasons   []string
+	details   []string
+	recovered []int64
+}
+
+func (r *tkBridgePenaltyIncidentRecorder) NotifyAccountIncident(account *Account, until time.Time, reason string, kind AccountIncidentKind, detail ...string) {
+	r.reasons = append(r.reasons, reason)
+	d := ""
+	if len(detail) > 0 {
+		d = detail[0]
+	}
+	r.details = append(r.details, d)
+}
+
+func (r *tkBridgePenaltyIncidentRecorder) NotifyAccountRecovered(accountID int64) {
+	r.recovered = append(r.recovered, accountID)
+}
+
+func newBridgePenaltyTestService() (*RateLimitService, *rateLimitAccountRepoStub, *runtimeBlockRecorder, *tkBridgePenaltyIncidentRecorder) {
+	repo := &rateLimitAccountRepoStub{}
+	blocker := &runtimeBlockRecorder{}
+	incidents := &tkBridgePenaltyIncidentRecorder{}
+	svc := NewRateLimitService(repo, nil, &config.Config{}, nil, nil)
+	svc.SetAccountRuntimeBlocker(blocker)
+	svc.SetAccountIncidentNotifier(incidents)
+	return svc, repo, blocker, incidents
+}
+
+func newNewAPIBridgeAccount() *Account {
+	// Mirrors prod account 39 "ds-官": fifth-platform newapi apikey account
+	// with a DeepSeek channel type, no pool mode, no custom error codes.
+	return &Account{
+		ID:          39,
+		Name:        "ds-官",
+		Platform:    PlatformNewAPI,
+		Type:        AccountTypeAPIKey,
+		ChannelType: 43,
+	}
+}
+
+func upstreamBridgeError(statusCode int, msg string) *newapitypes.NewAPIError {
+	return newapitypes.NewErrorWithStatusCode(
+		errors.New(msg),
+		newapitypes.ErrorCodeBadResponseStatusCode,
+		statusCode,
+	)
+}
+
+// 402 insufficient balance MUST disable the account (handleAuthError path) and
+// surface the upstream verdict in the incident detail — the 2026-06-11 prod
+// gap where 6946×402 left the account schedulable with no alert.
+func TestTkHandleBridgeUpstreamPenalty_402DisablesAccountAndAlerts(t *testing.T) {
+	svc, repo, blocker, incidents := newBridgePenaltyTestService()
+	account := newNewAPIBridgeAccount()
+
+	tkHandleBridgeUpstreamPenalty(context.Background(), svc, account, upstreamBridgeError(402, "Insufficient Balance"))
+
+	require.Equal(t, 1, repo.setErrorCalls, "402 must SetError (stop scheduling)")
+	require.Contains(t, repo.lastErrorMsg, "Payment required (402)")
+	require.Contains(t, repo.lastErrorMsg, "Insufficient Balance")
+
+	require.Equal(t, []string{"auth_error"}, blocker.reasons)
+	require.Equal(t, []string{"auth_error"}, incidents.reasons)
+	require.Len(t, incidents.details, 1)
+	require.Contains(t, incidents.details[0], "402", "Feishu detail must carry the upstream status")
+	require.Contains(t, incidents.details[0], "Insufficient Balance")
+}
+
+// 429 must put the account into a rate-limit cooldown via the fallback path
+// (no reset headers available on the bridge path → apply429FallbackRateLimit).
+func TestTkHandleBridgeUpstreamPenalty_429SetsRateLimitCooldown(t *testing.T) {
+	svc, repo, _, _ := newBridgePenaltyTestService()
+	account := newNewAPIBridgeAccount()
+
+	tkHandleBridgeUpstreamPenalty(context.Background(), svc, account, upstreamBridgeError(429, "Requests rate limit exceeded"))
+
+	require.Equal(t, 1, repo.setRateLimitedCalls, "429 must SetRateLimited (fallback cooldown)")
+	require.True(t, repo.lastRateLimitedResetAt.After(time.Now()), "cooldown reset must be in the future")
+	require.Zero(t, repo.setErrorCalls, "429 must not permanently disable")
+}
+
+// 401 on an apikey account must disable (invalid credentials).
+func TestTkHandleBridgeUpstreamPenalty_401DisablesAccount(t *testing.T) {
+	svc, repo, _, _ := newBridgePenaltyTestService()
+	account := newNewAPIBridgeAccount()
+
+	tkHandleBridgeUpstreamPenalty(context.Background(), svc, account, upstreamBridgeError(401, "Authentication Fails"))
+
+	require.Equal(t, 1, repo.setErrorCalls)
+	require.Contains(t, repo.lastErrorMsg, "Authentication failed (401)")
+}
+
+// Client-induced statuses must NEVER penalize the account (the #617 lesson:
+// cooling accounts on client 400s drains the pool). 404 model-not-found and
+// the synthetic 400 bridge errors are all out of the allowlist.
+func TestTkHandleBridgeUpstreamPenalty_ClientInducedStatusesAreIgnored(t *testing.T) {
+	for _, tc := range []struct {
+		name   string
+		apiErr *newapitypes.NewAPIError
+	}{
+		{"client 400", upstreamBridgeError(400, "The supported API model names are ...")},
+		{"model not found 404", upstreamBridgeError(404, "model_not_found")},
+		{"synthetic missing credential", errBridgeMissingCredential("api_key")},
+		{"synthetic unsupported video channel", errBridgeVideoUnsupportedChannel(1)},
+		{"server 500", upstreamBridgeError(500, "internal error")},
+		{"server 502", upstreamBridgeError(502, "bad gateway")},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			svc, repo, blocker, incidents := newBridgePenaltyTestService()
+			account := newNewAPIBridgeAccount()
+
+			tkHandleBridgeUpstreamPenalty(context.Background(), svc, account, tc.apiErr)
+
+			require.Zero(t, repo.setErrorCalls)
+			require.Zero(t, repo.setRateLimitedCalls)
+			require.Zero(t, repo.tempCalls)
+			require.Empty(t, blocker.reasons)
+			require.Empty(t, incidents.reasons)
+		})
+	}
+}
+
+// nil inputs must be no-ops (defensive: penalty is best-effort glue, never a
+// crash source on the error path).
+func TestTkHandleBridgeUpstreamPenalty_NilSafety(t *testing.T) {
+	svc, repo, _, _ := newBridgePenaltyTestService()
+	account := newNewAPIBridgeAccount()
+
+	tkHandleBridgeUpstreamPenalty(context.Background(), nil, account, upstreamBridgeError(402, "x"))
+	tkHandleBridgeUpstreamPenalty(context.Background(), svc, nil, upstreamBridgeError(402, "x"))
+	tkHandleBridgeUpstreamPenalty(context.Background(), svc, account, nil)
+
+	require.Zero(t, repo.setErrorCalls)
+	require.Zero(t, repo.setRateLimitedCalls)
+}
+
+// The penalty write must survive client cancellation: a canceled request
+// context must not abort the SetError write (context.WithoutCancel inside
+// openAIAccountStateContext).
+func TestTkHandleBridgeUpstreamPenalty_SurvivesCanceledRequestContext(t *testing.T) {
+	svc, repo, _, _ := newBridgePenaltyTestService()
+	account := newNewAPIBridgeAccount()
+
+	ctx, cancel := context.WithCancel(context.Background())
+	cancel()
+	tkHandleBridgeUpstreamPenalty(ctx, svc, account, upstreamBridgeError(402, "Insufficient Balance"))
+
+	require.Equal(t, 1, repo.setErrorCalls)
+}
+
+func TestTkBridgeUpstreamErrorBody_OpenAIEnvelope(t *testing.T) {
+	body := tkBridgeUpstreamErrorBody(upstreamBridgeError(402, "Insufficient Balance"))
+	require.NotEmpty(t, body)
+	require.Contains(t, string(body), `"error"`)
+	require.Contains(t, string(body), "Insufficient Balance")
+	require.Nil(t, tkBridgeUpstreamErrorBody(nil))
+}
+
+// The permanent Feishu card must render the upstream detail line when present
+// and keep the legacy shape when absent.
+func TestBuildAccountIncidentPermanentText_RendersUpstreamDetail(t *testing.T) {
+	account := newNewAPIBridgeAccount()
+	cls := classifyIncident("auth_error", time.Time{}, IncidentKindUnknown)
+	now := time.Now()
+
+	withDetail := buildAccountIncidentPermanentText("prod", account, "auth_error", cls, now, "Payment required (402): Insufficient Balance")
+	require.Contains(t, withDetail, "**详情**：")
+	require.Contains(t, withDetail, "Payment required (402)")
+	require.Contains(t, withDetail, "ds-官")
+	require.Contains(t, withDetail, PlatformNewAPI)
+
+	withoutDetail := buildAccountIncidentPermanentText("prod", account, "auth_error", cls, now, "")
+	require.False(t, strings.Contains(withoutDetail, "**详情**"), "no detail line when detail is empty")
+}

--- a/backend/internal/service/openai_gateway_bridge_dispatch.go
+++ b/backend/internal/service/openai_gateway_bridge_dispatch.go
@@ -51,7 +51,7 @@ func (s *OpenAIGatewayService) ForwardAsChatCompletionsDispatched(
 			zap.String("bridge_path", "newapi_adaptor_error"),
 			zap.Int64("account_id", account.ID),
 		)
-		return nil, tkWrapBridgeRelayError(c, apiErr)
+		return nil, s.tkWrapBridgeRelayErrorWithPenalty(ctx, c, account, apiErr)
 	}
 	logger.L().Info("openai_gateway.newapi_bridge_dispatch",
 		zap.String("endpoint", BridgeEndpointChatCompletions),
@@ -123,7 +123,7 @@ func (s *OpenAIGatewayService) ForwardAsResponsesDispatched(
 			zap.String("bridge_path", "newapi_adaptor_error"),
 			zap.Int64("account_id", account.ID),
 		)
-		return nil, tkWrapBridgeRelayError(c, apiErr)
+		return nil, s.tkWrapBridgeRelayErrorWithPenalty(ctx, c, account, apiErr)
 	}
 	logger.L().Info("openai_gateway.newapi_bridge_dispatch",
 		zap.String("endpoint", BridgeEndpointResponses),
@@ -174,7 +174,7 @@ func (s *OpenAIGatewayService) ForwardAsEmbeddingsDispatched(
 			zap.String("bridge_path", "newapi_adaptor_error"),
 			zap.Int64("account_id", account.ID),
 		)
-		return nil, tkWrapBridgeRelayError(c, apiErr)
+		return nil, s.tkWrapBridgeRelayErrorWithPenalty(ctx, c, account, apiErr)
 	}
 	logger.L().Info("openai_gateway.newapi_bridge_dispatch",
 		zap.String("endpoint", BridgeEndpointEmbeddings),
@@ -225,7 +225,7 @@ func (s *OpenAIGatewayService) ForwardAsImageGenerationsDispatched(
 			zap.String("bridge_path", "newapi_adaptor_error"),
 			zap.Int64("account_id", account.ID),
 		)
-		return nil, tkWrapBridgeRelayError(c, apiErr)
+		return nil, s.tkWrapBridgeRelayErrorWithPenalty(ctx, c, account, apiErr)
 	}
 	logger.L().Info("openai_gateway.newapi_bridge_dispatch",
 		zap.String("endpoint", BridgeEndpointImages),

--- a/backend/internal/service/openai_gateway_bridge_dispatch_tk_anthropic.go
+++ b/backend/internal/service/openai_gateway_bridge_dispatch_tk_anthropic.go
@@ -125,7 +125,7 @@ func (s *OpenAIGatewayService) ForwardAsAnthropicDispatched(
 			message = "Bridge dispatch failed"
 		}
 		writeAnthropicError(c, statusCode, errType, message)
-		return nil, tkWrapBridgeRelayError(c, apiErr)
+		return nil, s.tkWrapBridgeRelayErrorWithPenalty(ctx, c, account, apiErr)
 	}
 
 	logger.L().Info("openai_gateway.newapi_bridge_anthropic_dispatch",

--- a/backend/internal/service/openai_gateway_bridge_dispatch_tk_video.go
+++ b/backend/internal/service/openai_gateway_bridge_dispatch_tk_video.go
@@ -78,7 +78,7 @@ func (s *OpenAIGatewayService) ForwardAsVideoSubmitDispatched(
 			zap.String("bridge_path", "newapi_adaptor_error"),
 			zap.Int64("account_id", account.ID),
 		)
-		return nil, tkWrapBridgeRelayError(c, apiErr)
+		return nil, s.tkWrapBridgeRelayErrorWithPenalty(ctx, c, account, apiErr)
 	}
 	logger.L().Info("openai_gateway.newapi_bridge_dispatch",
 		zap.String("endpoint", BridgeEndpointVideoSubmit),
@@ -113,6 +113,10 @@ func (s *OpenAIGatewayService) ForwardAsVideoFetchDispatched(
 			zap.String("bridge_path", "newapi_adaptor_error"),
 			zap.String("upstream_task_id", in.UpstreamTaskID),
 		)
+		// No account penalty here: the fetch path is account-agnostic (routing
+		// comes from the VideoTaskCache registry snapshot, the *Account is not
+		// in hand), and a poll failure long after submit must not punish
+		// whichever account currently maps to the channel.
 		return nil, tkWrapBridgeRelayError(c, apiErr)
 	}
 	logger.L().Info("openai_gateway.newapi_bridge_dispatch",

--- a/backend/internal/service/ratelimit_service.go
+++ b/backend/internal/service/ratelimit_service.go
@@ -930,7 +930,11 @@ func (s *RateLimitService) GeminiCooldown(ctx context.Context, account *Account)
 
 // handleAuthError 处理认证类错误(401/403)，停止账号调度
 func (s *RateLimitService) handleAuthError(ctx context.Context, account *Account, errorMsg string) {
-	s.notifyAccountSchedulingBlocked(account, time.Time{}, "auth_error")
+	// TK: forward errorMsg as detail so the Feishu permanent-disable card shows
+	// the real upstream verdict (e.g. "Payment required (402): Insufficient
+	// Balance"), not just the opaque reason "auth_error". The 2026-06-11 newapi
+	// 402 incident had account name/platform on the card but no upstream status.
+	s.notifyAccountSchedulingBlocked(account, time.Time{}, "auth_error", errorMsg)
 	if err := s.accountRepo.SetError(ctx, account.ID, errorMsg); err != nil {
 		slog.Warn("account_set_error_failed", "account_id", account.ID, "error", err)
 		return

--- a/scripts/sentinels/check-newapi.py
+++ b/scripts/sentinels/check-newapi.py
@@ -8,6 +8,7 @@ entry verifies:
 
   1. The file at `path` exists.
   2. Every literal string in `must_contain` appears at least once in the file.
+  3. Every literal string in `must_not_contain` is absent from the file.
 
 Exit codes:
   0  — all sentinels intact.
@@ -69,7 +70,8 @@ def check_sentinel(entry: dict) -> tuple[bool, list[str]]:
     if not file_path.is_file():
         return False, [f"file missing: {path_str}"]
     must_contain = entry.get("must_contain") or []
-    if not must_contain:
+    must_not_contain = entry.get("must_not_contain") or []
+    if not must_contain and not must_not_contain:
         return True, []
     try:
         content = file_path.read_text(encoding="utf-8", errors="replace")
@@ -79,6 +81,9 @@ def check_sentinel(entry: dict) -> tuple[bool, list[str]]:
     for needle in must_contain:
         if needle not in content:
             failures.append(f"missing literal `{needle}` in {path_str}")
+    for needle in must_not_contain:
+        if needle in content:
+            failures.append(f"forbidden literal `{needle}` still present in {path_str}")
     return (len(failures) == 0), failures
 
 

--- a/scripts/sentinels/newapi.json
+++ b/scripts/sentinels/newapi.json
@@ -327,16 +327,51 @@
     {
       "path": "backend/internal/service/openai_gateway_bridge_dispatch.go",
       "must_contain": [
-        "tkWrapBridgeRelayErrorWithPenalty"
+        "s.tkWrapBridgeRelayErrorWithPenalty(ctx, c, account, apiErr)"
       ],
-      "rationale": "Every real-upstream-error dispatch site in the OpenAI-gateway bridge boundary must call the penalty-wrapping chokepoint (not the penalty-less tkWrapBridgeRelayError). An upstream merge that restructures these dispatch functions and reverts to the plain wrapper silently disconnects the newapi account-penalty path again with no compile error."
+      "must_not_contain": [
+        "tkWrapBridgeRelayError(c, apiErr)"
+      ],
+      "rationale": "Every real-upstream-error dispatch site in the OpenAI-gateway bridge boundary (chat/responses/embeddings/images, 4 sites) must call the penalty-wrapping chokepoint. The 4 call lines are textually identical, so must_contain alone cannot catch a partial revert — must_not_contain asserts ZERO penalty-less tkWrapBridgeRelayError(c, apiErr) calls remain in this file, which catches any single site regressing. A refactor that reverts to the plain wrapper silently disconnects the newapi account-penalty path with no compile error."
+    },
+    {
+      "path": "backend/internal/service/gateway_bridge_dispatch.go",
+      "must_contain": [
+        "s.tkWrapBridgeRelayErrorWithPenalty(ctx, c, account, apiErr)"
+      ],
+      "must_not_contain": [
+        "tkWrapBridgeRelayError(c, apiErr)"
+      ],
+      "rationale": "The Anthropic-gateway bridge boundary (GatewayService ForwardAsChatCompletionsDispatched / ForwardAsResponsesDispatched, 2 sites) is the same penalty chokepoint class as openai_gateway_bridge_dispatch.go and must stay wired identically: zero penalty-less tkWrapBridgeRelayError(c, apiErr) calls. Without this entry only the OpenAI-gateway file was anchored and a refactor here would silently drop the account penalty for messages-dispatch newapi traffic."
+    },
+    {
+      "path": "backend/internal/service/openai_gateway_bridge_dispatch_tk_anthropic.go",
+      "must_contain": [
+        "s.tkWrapBridgeRelayErrorWithPenalty(ctx, c, account, apiErr)"
+      ],
+      "rationale": "ForwardAsAnthropicDispatched is the 7th penalty wiring site (anthropic-shaped requests routed over the newapi bridge). Same risk class as the other dispatch boundaries: reverting to the plain wrapper compiles clean and silently disconnects the account penalty."
+    },
+    {
+      "path": "backend/internal/service/openai_gateway_bridge_dispatch_tk_video.go",
+      "must_contain": [
+        "s.tkWrapBridgeRelayErrorWithPenalty(ctx, c, account, apiErr)",
+        "No account penalty here"
+      ],
+      "rationale": "Video SUBMIT must penalize (the selected account is in hand); video FETCH must NOT (account-agnostic VideoTaskCache registry routing — a poll failure long after submit must not punish whichever account currently maps to the channel). Anchors the submit-site penalty call plus the fetch-path exemption comment so neither side of the asymmetry is silently flattened: no must_not_contain here because the fetch path legitimately keeps the plain tkWrapBridgeRelayError."
     },
     {
       "path": "backend/internal/handler/openai_chat_completions.go",
       "must_contain": [
-        "TkTryWriteNewAPIRelayErrorJSON(c, err, streamStarted, writerSizeBeforeForward)"
+        "// image-partial-result path and never fires for plain chat errors.\n\t\t\t\tif TkTryWriteNewAPIRelayErrorJSON(c, err, streamStarted, writerSizeBeforeForward) {"
       ],
-      "rationale": "Chat-completions handler must preserve the NewAPIRelayError's real upstream status (402/429/...) to the client instead of masking it as 502 'Upstream request failed'. The reachable call lives INSIDE the non-failover error branch (mirroring the /v1/responses handler); a merge that drops it reverts every newapi bridge error to an opaque 502 (the 2026-06-11 DeepSeek incident shape, 6946 masked 402s)."
+      "rationale": "Chat-completions handler must preserve the NewAPIRelayError's real upstream status (402/429/...) to the client instead of masking it as 502 'Upstream request failed'. The load-bearing call lives INSIDE the non-failover error branch (mirroring the /v1/responses handler); the file contains a SECOND textually-identical call further down that is only reachable on the image-partial-result path, so a bare single-line needle would still pass after a merge dropped the reachable branch. The needle therefore pins the comment tail + if-line contiguous to the in-branch site; a merge that drops it reverts every newapi chat bridge error to an opaque 502 (the 2026-06-11 DeepSeek incident shape, 6946 masked 402s)."
+    },
+    {
+      "path": "backend/internal/service/ratelimit_service.go",
+      "must_contain": [
+        "s.notifyAccountSchedulingBlocked(account, time.Time{}, \"auth_error\", errorMsg)"
+      ],
+      "rationale": "handleAuthError must forward the upstream error message as the Feishu permanent-disable card detail (e.g. 'Payment required (402): Insufficient Balance'). notifyAccountSchedulingBlocked's detail parameter is variadic, so an upstream merge reverting this call to the bare 3-arg form compiles clean and silently strips the upstream status/message from the P0 card — losing the alert-content half of the 2026-06-11 incident fix while the alert itself still fires."
     }
   ]
 }

--- a/scripts/sentinels/newapi.json
+++ b/scripts/sentinels/newapi.json
@@ -314,6 +314,29 @@
         "TestBilling_Fable1hCacheCreationCost_ProdShape"
       ],
       "rationale": "Regression reproduction with the prod token shape (cache_creation_5m=0, cache_creation_1h=684124) asserting the corrected $13.68 cache-creation cost end-to-end through GetModelPricing + CalculateCost. Dropping this test re-opens the silent 5m-rate undercharge path for overlay-priced models with a 1h cache tier."
+    },
+    {
+      "path": "backend/internal/service/newapi_bridge_penalty_tk.go",
+      "must_contain": [
+        "tkHandleBridgeUpstreamPenalty",
+        "tkWrapBridgeRelayErrorWithPenalty",
+        "tkBridgePenaltyStatusEligible"
+      ],
+      "rationale": "TK companion that routes real bridge.Dispatch* upstream errors (401/402/429 allowlist) into RateLimitService.HandleUpstreamError so newapi accounts get disabled/cooled and the Feishu account-incident alert fires. Without it the fifth platform regresses to the 2026-06-11 prod incident: a 402 'Insufficient Balance' DeepSeek account stayed schedulable=true while the gateway hammered the exhausted upstream 6946 times in 2h with zero alerts. The narrow status allowlist is itself load-bearing: it is what keeps client-induced 400/404 (and the synthetic missing-credential/unsupported-channel 400s) from draining the pool (the #617 class)."
+    },
+    {
+      "path": "backend/internal/service/openai_gateway_bridge_dispatch.go",
+      "must_contain": [
+        "tkWrapBridgeRelayErrorWithPenalty"
+      ],
+      "rationale": "Every real-upstream-error dispatch site in the OpenAI-gateway bridge boundary must call the penalty-wrapping chokepoint (not the penalty-less tkWrapBridgeRelayError). An upstream merge that restructures these dispatch functions and reverts to the plain wrapper silently disconnects the newapi account-penalty path again with no compile error."
+    },
+    {
+      "path": "backend/internal/handler/openai_chat_completions.go",
+      "must_contain": [
+        "TkTryWriteNewAPIRelayErrorJSON(c, err, streamStarted, writerSizeBeforeForward)"
+      ],
+      "rationale": "Chat-completions handler must preserve the NewAPIRelayError's real upstream status (402/429/...) to the client instead of masking it as 502 'Upstream request failed'. The reachable call lives INSIDE the non-failover error branch (mirroring the /v1/responses handler); a merge that drops it reverts every newapi bridge error to an opaque 502 (the 2026-06-11 DeepSeek incident shape, 6946 masked 402s)."
     }
   ]
 }


### PR DESCRIPTION
## 背景（线上证据，2026-06-11 诊断）

prod account 39「ds-官」（platform=newapi，DeepSeek 官方，channel_type=43）余额耗尽，上游返 **402 \"Insufficient Balance\"**：

- ~2h 内 prod 记录 **6946 条 402**，全被掩成最终 **502 `{"message":"Upstream request failed"}`** 返回客户端；
- 另有 **~160 条上游 429**（DeepSeek 并发上限）同样被掩成 502；
- 账号全程 `schedulable=true`、无冷却、无禁用、**无任何告警**，网关持续锤已耗尽的上游。

**根因**：`internal/service/openai_gateway_bridge_dispatch.go` 等各 `bridge.Dispatch*` 错误路径只调 `tkWrapBridgeRelayError`（`newapi_model_not_found_tk.go`，仅记 ops 上游错误日志）→ 从不调 `RateLimitService.HandleUpstreamError`，因此 `ratelimit_service.go` 既有的「case 402 → handleAuthError + shouldDisable」对 newapi 账号**不可达**。

## 改动（三件事）

### 1. bridge dispatch 错误路径接入账号惩罚

新增 TK companion `backend/internal/service/newapi_bridge_penalty_tk.go`：

- `tkHandleBridgeUpstreamPenalty`：以 **{401, 402, 429} 显式 allowlist** 把真实上游 bridge 错误委托给 `RateLimitService.HandleUpstreamError`；
- `tkWrapBridgeRelayErrorWithPenalty`（`OpenAIGatewayService` / `GatewayService` 双形态）：dispatch 错误位点一行调用，penalty + 原 `tkWrapBridgeRelayError`（ops 记录 + wrap）原子完成；
- 接线位点（7 处，均为一行替换）：`openai_gateway_bridge_dispatch.go`（chat/responses/embeddings/images ×4）、`gateway_bridge_dispatch.go`（chat/responses ×2）、`openai_gateway_bridge_dispatch_tk_anthropic.go`（×1）、`openai_gateway_bridge_dispatch_tk_video.go`（submit ×1；fetch 为 account-agnostic 注册表路由，不惩罚，已留注释）。

**关键设计取舍**：
- **headers 缺失**：`NewAPIError` 不携带上游响应头，`HandleUpstreamError` 的 headers 实参传 `nil`——`http.Header.Get` 对 nil map 安全返回空；newapi 429 因此命中 `apply429FallbackRateLimit`（默认短冷却），正是保守期望行为。响应体用 `ToOpenAIError()` 合成 OpenAI 风格 envelope，让 `extractUpstreamErrorMessage` 等 body 解析器拿到真实 message/code。
- **绝不惩罚 400/404**（#617 教训：客户端诱发错误若计入惩罚，任意调用方可抽干池子）。allowlist 同时天然排除 synthetic `errBridgeMissingCredential` / `errBridgeVideoUnsupportedChannel`（均为 400）；且 wrapper 只挂在真实上游错误位点，synthetic 早退路径不经过它（双保险）。403/5xx 也暂不纳入（403 → handle403 会永久禁用，对瞬时 WAF 误伤风险大；扩面需生产证据）。
- **防 client-cancel 吞写**：惩罚写入用 `openAIAccountStateContext`（`context.WithoutCancel` + 短超时，与 `handleOpenAIAccountUpstreamError` 同模式），客户端断流不影响 SetError/SetRateLimited 落库。
- admin 账号测试探针 `dispatchNewAPIAccountTestChatCompletions` 保持不惩罚（管理员手动测号不应改账号调度状态）。

**结果映射**：402 → `handleAuthError`（SetError 永久停调度）；429 → fallback 限流冷却（不永久禁用）；401（apikey）→ SetError。

### 2. 最终响应透传真实上游状态码

`openai_chat_completions.go`：原 `TkTryWriteNewAPIRelayErrorJSON` 分支位于 else 块**之外**，只在 image-partial-result 路径可达——普通 chat bridge 错误先命中 else 内的 `ensureForwardErrorResponse` 兜底（502 \"Upstream request failed\"）后 return，TK 分支是死代码。本 PR 把该调用接入 else 内非-failover 错误分支（镜像 `/v1/responses` handler 的既有正确形态），402/429 等真实状态码与结构化错误体直达客户端。`/v1/responses`、embeddings、images 路径本就正确，未动。（未触碰 152-168 行「首次选号失败→503」分支，与并行 PR 无 hunk 重叠。）

### 3. 飞书 402 余额耗尽告警

复用 #516 账号失效告警体系：402 经 `handleAuthError` → `notifyAccountSchedulingBlocked(reason="auth_error")` → 永久失效 P0 红卡**自动触发**（本 PR 之前该路径对 newapi 不可达，故无告警）。增强卡片内容：

- `handleAuthError` 把 errorMsg 作为 detail 传入汇聚点（薄注入，一行）；
- 永久失效卡片新增「**详情**」行，运营直接看到真实 upstream status + message（如 `Payment required (402): Insufficient Balance`），卡片原有 账号名/平台/组 字段不变——满足「账号名/平台/upstream status」三要素。

### 哨兵 & 门禁

`scripts/sentinels/newapi.json` 共 7 条 entry 覆盖本 PR 全部注入面（xj-review R-001..R-004 修复后，aa8cc202）：惩罚 chokepoint 符号、**两个** dispatch 边界文件（openai + anthropic gateway）、tk_anthropic 第 7 接线位点、tk_video submit/fetch 不对称性、chat-completions 状态透传（多行 needle 钉死 in-branch 可达位点，区别于同文的 image-partial 旧位点）、ratelimit_service.go 的 handleAuthError detail 四参调用（variadic 退参 revert 编译静默）。`check-newapi.py` 增加 `must_not_contain` 支持（对齐 check-gateway-tk.py）——两个 dispatch 文件断言**零裸 `tkWrapBridgeRelayError(c, apiErr)` 调用**，单位点 partial revert 也会被咬住；并顺手修两个 checker 的 only-must_not_contain 早退缺口。43/43 PASS + 三组负向自测（单位点 revert / 新分支删除 / detail 退参均触发 FAIL）。sentinel-registry-reviewed。

## 测试

- 新增 `newapi_bridge_penalty_tk_test.go`（unit）：402→SetError+告警 detail 含 402、429→SetRateLimited 冷却且不禁用、401→SetError、400/404/synthetic/5xx 全不惩罚、nil 安全、canceled ctx 仍落写、飞书永久卡 detail 渲染/缺省不渲染。
- `go test -tags=unit ./...` 全绿；`golangci-lint run ./...` 0 issues；`go vet -tags=integration` 编译通过；`scripts/preflight.sh` PASS（含 newapi sentinel registry）。

🤖 Generated with [Claude Code](https://claude.com/claude-code)
