### PR TITLE
fix(anthropic): request-owned 429 短路 + 同文案 failover 熔断 + 池级全不可调度 P0 告警

### DIFF
--- a/backend/internal/service/account_incident_notifier_tk.go
+++ b/backend/internal/service/account_incident_notifier_tk.go
@@ -44,6 +44,10 @@ type AccountIncidentNotifier interface {
 	// admin 重测恢复)时调用,对此前告警过的账号发一条即时恢复绿卡。事件驱动:纯定时器
 	// 到期自愈不经此路径,也不播报(原冷却卡已写明 until)。未告警账号调用为 no-op。
 	NotifyAccountRecovered(accountID int64)
+	// NotifyPlatformPoolExhausted 在某平台可调度账号数降为 0 时发即时 P0 卡片
+	// （事件驱动,由账号冷却汇聚点触发的池级检查上报;trigger 是压垮池的最后一个
+	// 账号）。实现侧按 platform 去重防 flap 刷屏。见 account_incident_notifier_tk_pool.go。
+	NotifyPlatformPoolExhausted(platform string, trigger *Account, until time.Time, reason string)
 }
 
 const (
@@ -157,12 +161,13 @@ type TKAccountIncidentNotifier struct {
 	siteID      string
 	now         func() time.Time
 
-	mu             sync.Mutex
-	permSentAt     map[string]time.Time                   // 永久失效去重: key -> 上次发送
-	permLimiter    *slidingWindowLimiter                  // 永久失效防爆量
-	digest         map[string]*accountIncidentDigestEntry // reasonClass -> 聚合条目
-	active         map[int64]map[string]*activeIncident   // accountID -> reasonClass -> 活跃事件(恢复台账)
-	recoverySentAt map[int64]time.Time                    // 恢复绿卡去重: accountID -> 上次发送
+	mu                sync.Mutex
+	permSentAt        map[string]time.Time                   // 永久失效去重: key -> 上次发送
+	permLimiter       *slidingWindowLimiter                  // 永久失效防爆量
+	digest            map[string]*accountIncidentDigestEntry // reasonClass -> 聚合条目
+	active            map[int64]map[string]*activeIncident   // accountID -> reasonClass -> 活跃事件(恢复台账)
+	recoverySentAt    map[int64]time.Time                    // 恢复绿卡去重: accountID -> 上次发送
+	poolExhaustSentAt map[string]time.Time                   // 平台池全不可调度 P0 去重: platform -> 上次发送
 
 	stopCh   chan struct{}
 	stopOnce sync.Once
@@ -170,16 +175,17 @@ type TKAccountIncidentNotifier struct {
 
 func newTKAccountIncidentNotifier(cfgProvider opsFeishuConfigProvider, siteID string) *TKAccountIncidentNotifier {
 	n := &TKAccountIncidentNotifier{
-		cfgProvider:    cfgProvider,
-		httpClient:     &http.Client{Timeout: opsFeishuWebhookTimeout},
-		siteID:         strings.TrimSpace(siteID),
-		now:            time.Now,
-		permSentAt:     map[string]time.Time{},
-		permLimiter:    newSlidingWindowLimiter(accountIncidentPermanentRatePerHour, time.Hour),
-		digest:         map[string]*accountIncidentDigestEntry{},
-		active:         map[int64]map[string]*activeIncident{},
-		recoverySentAt: map[int64]time.Time{},
-		stopCh:         make(chan struct{}),
+		cfgProvider:       cfgProvider,
+		httpClient:        &http.Client{Timeout: opsFeishuWebhookTimeout},
+		siteID:            strings.TrimSpace(siteID),
+		now:               time.Now,
+		permSentAt:        map[string]time.Time{},
+		permLimiter:       newSlidingWindowLimiter(accountIncidentPermanentRatePerHour, time.Hour),
+		digest:            map[string]*accountIncidentDigestEntry{},
+		active:            map[int64]map[string]*activeIncident{},
+		recoverySentAt:    map[int64]time.Time{},
+		poolExhaustSentAt: map[string]time.Time{},
+		stopCh:            make(chan struct{}),
 	}
 	if n.siteID == "" {
 		n.siteID = "unknown"

--- a/backend/internal/service/account_incident_notifier_tk_pool.go
+++ b/backend/internal/service/account_incident_notifier_tk_pool.go
@@ -1,0 +1,59 @@
+package service
+
+import (
+	"fmt"
+	"strings"
+	"time"
+)
+
+// 平台池全不可调度 → 即时 P0 飞书卡片。
+//
+// 事件背景（prod 2026-06-11）：7 个 anthropic 镜像账号在一分钟内被同一个"毒请求"
+// 的 failover 扇出连锁封进 10 分钟冷却,06:49 起全池空转、用户侧 429,而既有
+// #516 体系只看单账号事件、anthropic_cooldown_tier_escalation_count 评估器
+// 也抓不到"全池同时倒"这个形态——冷却自愈(06:58)比任何人发现都早。
+// 本卡片在"最后一个可调度账号被封"的那一刻即时发出（事件驱动,非轮询）,
+// 把发现时间从 ~10 分钟压到秒级。
+const accountIncidentPoolExhaustedDedupeWindow = 10 * time.Minute
+
+// NotifyPlatformPoolExhausted 发送平台池全不可调度 P0 卡片。按 platform 去重
+// （冷却风暴里每个后续账号封锁都会再触发一次池级检查,只发第一张）。
+func (n *TKAccountIncidentNotifier) NotifyPlatformPoolExhausted(platform string, trigger *Account, until time.Time, reason string) {
+	if n == nil || strings.TrimSpace(platform) == "" {
+		return
+	}
+	now := n.currentTime()
+	n.mu.Lock()
+	if n.poolExhaustSentAt == nil {
+		n.poolExhaustSentAt = map[string]time.Time{}
+	}
+	if last, seen := n.poolExhaustSentAt[platform]; seen && now.Sub(last) < accountIncidentPoolExhaustedDedupeWindow {
+		n.mu.Unlock()
+		return
+	}
+	n.poolExhaustSentAt[platform] = now
+	n.mu.Unlock()
+
+	title := fmt.Sprintf("TokenKey 平台池全不可调度 [%s]", n.siteID)
+	body := buildPoolExhaustedText(n.siteID, platform, trigger, until, reason, now)
+	n.send(title, "red", body, fmt.Sprintf("platform=%s reason=%s", platform, reason))
+}
+
+func buildPoolExhaustedText(site, platform string, trigger *Account, until time.Time, reason string, now time.Time) string {
+	triggerLabel := "-"
+	if trigger != nil {
+		triggerLabel = accountIncidentLabel(trigger)
+	}
+	untilText := "未知"
+	if !until.IsZero() {
+		untilText = formatAlertTime(until)
+	}
+	return fmt.Sprintf("**节点**：%s\n**平台**：%s\n**事件**：该平台可调度账号数已降为 0,所有流量将快速失败(429)\n**压垮池的最后账号**：%s\n**该账号 reason**：%s\n**该账号冷却至**：%s\n**时间**：%s\n\n**建议**：先跑 ops/observability/scan-edge-health.sh 看各 edge 自身健康;若 reason 是 anthropic_upstream_error 且各账号几乎同秒进入冷却,优先怀疑单请求确定性 429(如长上下文 usage-credits 策略拒绝)被 failover 扇出,而非账号/edge 真实故障。",
+		escapeFeishuText(site),
+		escapeFeishuText(strings.TrimSpace(platform)),
+		escapeFeishuText(triggerLabel),
+		escapeFeishuText(strings.TrimSpace(reason)),
+		escapeFeishuText(untilText),
+		escapeFeishuText(formatAlertTime(now)),
+	)
+}

--- a/backend/internal/service/account_incident_notifier_tk_pool_test.go
+++ b/backend/internal/service/account_incident_notifier_tk_pool_test.go
@@ -1,0 +1,47 @@
+//go:build unit
+
+package service
+
+import (
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/require"
+)
+
+func TestNotifyPlatformPoolExhausted_SendsP0AndDedupes(t *testing.T) {
+	provider := &fakeIncidentConfigProvider{cfg: enabledFeishuConfig()}
+	doer := &blockingFeishuDoer{done: make(chan struct{}, 4)}
+	fixedNow := time.Date(2026, 6, 11, 6, 49, 0, 0, time.UTC)
+	n := newTestNotifier(provider, doer, fixedNow)
+
+	trigger := &Account{ID: 7, Name: "cc-us7", Platform: PlatformAnthropic, Type: AccountTypeAPIKey}
+	until := fixedNow.Add(10 * time.Minute)
+
+	n.NotifyPlatformPoolExhausted(PlatformAnthropic, trigger, until, "temp_unschedulable")
+	select {
+	case <-doer.done:
+	case <-time.After(2 * time.Second):
+		t.Fatal("pool-exhausted P0 card was not sent")
+	}
+	require.Equal(t, 1, doer.callCount())
+	body := doer.lastBody()
+	require.Contains(t, body, "平台池全不可调度")
+	require.Contains(t, body, PlatformAnthropic)
+	require.Contains(t, body, "cc-us7")
+
+	// Cooldown-storm shape: every subsequent account block re-triggers the
+	// pool check; only the first card within the dedupe window goes out.
+	n.NotifyPlatformPoolExhausted(PlatformAnthropic, trigger, until, "temp_unschedulable")
+	time.Sleep(100 * time.Millisecond)
+	require.Equal(t, 1, doer.callCount(), "duplicate pool-exhausted within dedupe window must be suppressed")
+
+	// A different platform has its own dedupe key.
+	n.NotifyPlatformPoolExhausted(PlatformOpenAI, trigger, until, "429")
+	select {
+	case <-doer.done:
+	case <-time.After(2 * time.Second):
+		t.Fatal("second-platform pool-exhausted card was not sent")
+	}
+	require.Equal(t, 2, doer.callCount())
+}

--- a/backend/internal/service/gateway_service.go
+++ b/backend/internal/service/gateway_service.go
@@ -5309,6 +5309,13 @@ func (s *GatewayService) Forward(ctx context.Context, c *gin.Context, account *A
 			_ = resp.Body.Close()
 			resp.Body = io.NopCloser(bytes.NewReader(respBody))
 
+			// TK: request-owned 429 (policy phrase / same-text breaker) — pass the
+			// upstream body through, skip penalty + failover. See
+			// gateway_service_tk_request_owned_429.go.
+			if tkResult, tkErr, handled := s.tkHandleAnthropicRequestOwned429(c, account, resp, respBody); handled {
+				return tkResult, tkErr
+			}
+
 			// 调试日志：打印重试耗尽后的错误响应
 			logger.LegacyPrintf("service.gateway", "[Forward] Upstream error (retry exhausted, failover): Account=%d(%s) Status=%d RequestID=%s Body=%s",
 				account.ID, account.Name, resp.StatusCode, resp.Header.Get("x-request-id"), truncateString(string(respBody), 1000))
@@ -5343,6 +5350,12 @@ func (s *GatewayService) Forward(ctx context.Context, c *gin.Context, account *A
 		respBody, _ := s.readUpstreamErrorBody(resp)
 		_ = resp.Body.Close()
 		resp.Body = io.NopCloser(bytes.NewReader(respBody))
+
+		// TK: request-owned 429 — same short-circuit as the retry-exhausted
+		// branch above. See gateway_service_tk_request_owned_429.go.
+		if tkResult, tkErr, handled := s.tkHandleAnthropicRequestOwned429(c, account, resp, respBody); handled {
+			return tkResult, tkErr
+		}
 
 		// 调试日志：打印上游错误响应
 		logger.LegacyPrintf("service.gateway", "[Forward] Upstream error (failover): Account=%d(%s) Status=%d RequestID=%s Body=%s",
@@ -5793,6 +5806,12 @@ func (s *GatewayService) forwardAnthropicAPIKeyPassthroughWithInput(
 			_ = resp.Body.Close()
 			resp.Body = io.NopCloser(bytes.NewReader(respBody))
 
+			// TK: request-owned 429 — the prod mirror hop sees the edge's relayed
+			// policy 429 here. See gateway_service_tk_request_owned_429.go.
+			if tkResult, tkErr, handled := s.tkHandleAnthropicRequestOwned429(c, account, resp, respBody); handled {
+				return tkResult, tkErr
+			}
+
 			logger.LegacyPrintf("service.gateway", "[Anthropic Passthrough] Upstream error (retry exhausted, failover): Account=%d(%s) Status=%d RequestID=%s Body=%s",
 				account.ID, account.Name, resp.StatusCode, resp.Header.Get("x-request-id"), truncateString(string(respBody), 1000))
 
@@ -5826,6 +5845,12 @@ func (s *GatewayService) forwardAnthropicAPIKeyPassthroughWithInput(
 		respBody, _ := s.readUpstreamErrorBody(resp)
 		_ = resp.Body.Close()
 		resp.Body = io.NopCloser(bytes.NewReader(respBody))
+
+		// TK: request-owned 429 — same short-circuit as the retry-exhausted
+		// branch above. See gateway_service_tk_request_owned_429.go.
+		if tkResult, tkErr, handled := s.tkHandleAnthropicRequestOwned429(c, account, resp, respBody); handled {
+			return tkResult, tkErr
+		}
 
 		logger.LegacyPrintf("service.gateway", "[Anthropic Passthrough] Upstream error (failover): Account=%d(%s) Status=%d RequestID=%s Body=%s",
 			account.ID, account.Name, resp.StatusCode, resp.Header.Get("x-request-id"), truncateString(string(respBody), 1000))

--- a/backend/internal/service/gateway_service_tk_request_owned_429.go
+++ b/backend/internal/service/gateway_service_tk_request_owned_429.go
@@ -1,0 +1,158 @@
+package service
+
+import (
+	"fmt"
+	"net/http"
+	"strings"
+
+	"github.com/gin-gonic/gin"
+
+	"github.com/Wei-Shaw/sub2api/internal/pkg/logger"
+)
+
+// Request-owned Anthropic 429 classification + same-text failover circuit
+// breaker.
+//
+// Incident (prod 2026-06-11 06:44–06:59 UTC): a single >200k long-context
+// request on a no-credits subscription account drew a DETERMINISTIC policy 429
+// from Anthropic — "Usage credits are required for long context requests." —
+// which is a property of the REQUEST, not of any account. Failover fanned the
+// same request across all 7 cc-<edge> mirror accounts, every hop fed the
+// anthropic 3/3 error ladder, and within 4 minutes the whole mirror pool was
+// locked in tier-2 10-minute cooldowns while the edges themselves were already
+// healthy again. Two layers of defense, both implemented here:
+//
+//  1. Known-phrase classifier (tkIsAnthropicRequestOwned429Message): a policy
+//     429 is short-circuited on the FIRST hop — the original upstream body is
+//     passed through to the caller (so a prod mirror hop can re-classify the
+//     same phrase), no account penalty, no failover.
+//  2. Same-text circuit breaker (tkAnthropic429SameTextThreshold): for future
+//     deterministic 429 variants we cannot enumerate, identical 429 message
+//     text from N distinct accounts within ONE request is judged
+//     request-owned — stop the fan-out, skip side effects from that hop on.
+//     Legitimate per-account rate limits rarely repeat the exact same body
+//     text N times in a single failover chain; genuine multi-account burn is
+//     surfaced to the client as the 429 it is (with the real upstream text)
+//     instead of poisoning the remaining pool.
+//
+// Body passthrough is load-bearing: the prod ↔ edge mirror topology relays the
+// edge's response body to prod, so preserving the original phrase is what lets
+// the SAME classifier fire again on the prod hop (the edge→prod boundary used
+// to rewrite 429s to a generic text the exemption predicates cannot see).
+var tkAnthropicRequestOwned429Markers = []string{
+	"usage credits are required",
+}
+
+// tkAnthropic429SameTextThreshold is the number of occurrences of an
+// IDENTICAL upstream 429 message text, within one request's failover chain,
+// at which the 429 is judged deterministic/request-owned. The first
+// (threshold-1) hops keep normal semantics (penalty + failover) so genuine
+// single-account rate limits are unaffected.
+const tkAnthropic429SameTextThreshold = 3
+
+// tkAnthropic429TextSeenContextKey holds the per-request map of normalized
+// 429 message text → occurrence count, written only by the sequential
+// failover chain of a single request.
+const tkAnthropic429TextSeenContextKey = "tk_anthropic_429_text_seen"
+
+// tkIsAnthropicRequestOwned429Message reports whether an upstream 429 message
+// identifies a deterministic, request-owned policy rejection. Markers are
+// matched case-insensitively and kept tight to avoid matching genuine
+// account-level rate-limit texts.
+func tkIsAnthropicRequestOwned429Message(upstreamMsg string, responseBody []byte) bool {
+	hay := strings.ToLower(upstreamMsg)
+	if len(responseBody) > 0 {
+		hay += " " + strings.ToLower(string(responseBody))
+	}
+	for _, m := range tkAnthropicRequestOwned429Markers {
+		if strings.Contains(hay, m) {
+			return true
+		}
+	}
+	return false
+}
+
+// tkNoteAnthropic429Text records one occurrence of the normalized 429 text for
+// this request and returns the total occurrence count including this one.
+func tkNoteAnthropic429Text(c *gin.Context, normalizedMsg string) int {
+	if c == nil || normalizedMsg == "" {
+		return 0
+	}
+	var seen map[string]int
+	if v, ok := c.Get(tkAnthropic429TextSeenContextKey); ok {
+		seen, _ = v.(map[string]int)
+	}
+	if seen == nil {
+		seen = make(map[string]int, 2)
+	}
+	seen[normalizedMsg]++
+	c.Set(tkAnthropic429TextSeenContextKey, seen)
+	return seen[normalizedMsg]
+}
+
+// tkHandleAnthropicRequestOwned429 short-circuits a request-owned anthropic
+// 429: it writes the ORIGINAL upstream status + body through to the client
+// (preserving the policy phrase for the next mirror hop), records ops
+// telemetry, and returns handled=true so the caller skips account side
+// effects and failover. Returns handled=false for everything else.
+//
+// Call sites are the anthropic failover branches of Forward /
+// forwardAnthropicAPIKeyPassthroughWithInput, after the error body has been
+// read and BEFORE handleFailoverSideEffects / handleRetryExhaustedSideEffects.
+func (s *GatewayService) tkHandleAnthropicRequestOwned429(c *gin.Context, account *Account, resp *http.Response, respBody []byte) (*ForwardResult, error, bool) {
+	if c == nil || account == nil || resp == nil {
+		return nil, nil, false
+	}
+	if resp.StatusCode != http.StatusTooManyRequests || account.Platform != PlatformAnthropic {
+		return nil, nil, false
+	}
+	upstreamMsg := strings.TrimSpace(extractUpstreamErrorMessage(respBody))
+	upstreamMsg = sanitizeUpstreamErrorMessage(upstreamMsg)
+	normalized := strings.ToLower(upstreamMsg)
+
+	known := tkIsAnthropicRequestOwned429Message(upstreamMsg, respBody)
+	occurrences := tkNoteAnthropic429Text(c, normalized)
+	if !known && occurrences < tkAnthropic429SameTextThreshold {
+		return nil, nil, false
+	}
+
+	reason := "known_policy_phrase"
+	if !known {
+		reason = fmt.Sprintf("same_text_x%d", occurrences)
+	}
+	logger.LegacyPrintf("service.gateway",
+		"[RequestOwned429] short-circuit (reason=%s): Account=%d(%s) RequestID=%s Msg=%s",
+		reason, account.ID, account.Name, resp.Header.Get("x-request-id"), truncateString(upstreamMsg, 300))
+
+	setOpsUpstreamError(c, resp.StatusCode, upstreamMsg, "")
+	appendOpsUpstreamError(c, OpsUpstreamErrorEvent{
+		Platform:           account.Platform,
+		AccountID:          account.ID,
+		AccountName:        account.Name,
+		UpstreamStatusCode: resp.StatusCode,
+		UpstreamRequestID:  resp.Header.Get("x-request-id"),
+		Kind:               "request_owned_429",
+		Message:            upstreamMsg,
+	})
+
+	MarkResponseCommitted(c)
+	if ra := strings.TrimSpace(resp.Header.Get("Retry-After")); ra != "" {
+		c.Header("Retry-After", ra)
+	}
+	if len(respBody) > 0 {
+		c.Data(http.StatusTooManyRequests, "application/json", respBody)
+	} else {
+		c.JSON(http.StatusTooManyRequests, gin.H{
+			"type": "error",
+			"error": gin.H{
+				"type":    "rate_limit_error",
+				"message": "Upstream rate limit exceeded, please retry later",
+			},
+		})
+	}
+
+	if upstreamMsg == "" {
+		return nil, fmt.Errorf("upstream error: 429 request-owned (%s)", reason), true
+	}
+	return nil, fmt.Errorf("upstream error: 429 request-owned (%s) message=%s", reason, upstreamMsg), true
+}

--- a/backend/internal/service/gateway_service_tk_request_owned_429.go
+++ b/backend/internal/service/gateway_service_tk_request_owned_429.go
@@ -111,6 +111,21 @@ func (s *GatewayService) tkHandleAnthropicRequestOwned429(c *gin.Context, accoun
 	normalized := strings.ToLower(upstreamMsg)
 
 	known := tkIsAnthropicRequestOwned429Message(upstreamMsg, respBody)
+	if !known {
+		// TK capacity envelopes are exempt from the same-text breaker: a prod
+		// mirror hop receiving "No available accounts" (#575 fast-fail) or the
+		// failover-exhausted rewrite "Upstream rate limit exceeded, please
+		// retry later" from several edges is seeing EDGE-scoped capacity
+		// signals — cross-edge failover is the designed remedy there, and the
+		// texts are identical by construction, not because the request is
+		// poisoned. The breaker stays focused on provider-originated
+		// deterministic texts.
+		if tkSkipDownstreamNoAvailableAccountsPenalty(resp.StatusCode, upstreamMsg, respBody) ||
+			tkSkipDownstreamFailoverExhaustedPenalty(resp.StatusCode, upstreamMsg, respBody) ||
+			strings.Contains(normalized, "upstream rate limit exceeded") {
+			return nil, nil, false
+		}
+	}
 	occurrences := tkNoteAnthropic429Text(c, normalized)
 	if !known && occurrences < tkAnthropic429SameTextThreshold {
 		return nil, nil, false

--- a/backend/internal/service/gateway_service_tk_request_owned_429_test.go
+++ b/backend/internal/service/gateway_service_tk_request_owned_429_test.go
@@ -101,6 +101,25 @@ func TestTkHandleAnthropicRequestOwned429_DistinctTextsNeverTrip(t *testing.T) {
 	}
 }
 
+// TK capacity envelopes (#575 empty-pool fast-fail, failover-exhausted rewrite)
+// are EDGE-scoped signals where cross-edge failover is the designed remedy —
+// identical text from many edges must never trip the breaker.
+func TestTkHandleAnthropicRequestOwned429_CapacityEnvelopesExempt(t *testing.T) {
+	envelopes := []string{
+		`{"type":"error","error":{"type":"api_error","message":"No available accounts: no available accounts"}}`,
+		`{"type":"error","error":{"type":"rate_limit_error","message":"Upstream rate limit exceeded, please retry later"}}`,
+	}
+	for _, body := range envelopes {
+		c, _ := newRequestOwned429TestContext(t)
+		svc := &GatewayService{}
+		for i := 1; i <= tkAnthropic429SameTextThreshold+2; i++ {
+			account := &Account{ID: int64(i), Platform: PlatformAnthropic, Type: AccountTypeAPIKey}
+			_, _, handled := svc.tkHandleAnthropicRequestOwned429(c, account, anthropic429Response(body), []byte(body))
+			require.False(t, handled, "capacity envelope must never trip the breaker (occurrence %d, body=%s)", i, body)
+		}
+	}
+}
+
 func TestTkHandleAnthropicRequestOwned429_ScopeGuards(t *testing.T) {
 	c, _ := newRequestOwned429TestContext(t)
 	svc := &GatewayService{}

--- a/backend/internal/service/gateway_service_tk_request_owned_429_test.go
+++ b/backend/internal/service/gateway_service_tk_request_owned_429_test.go
@@ -1,0 +1,123 @@
+//go:build unit
+
+package service
+
+import (
+	"errors"
+	"io"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"testing"
+
+	"github.com/gin-gonic/gin"
+	"github.com/stretchr/testify/require"
+)
+
+const tkUsageCredits429Body = `{"type":"error","error":{"type":"rate_limit_error","message":"Usage credits are required for long context requests."}}`
+
+func TestTkIsAnthropicRequestOwned429Message(t *testing.T) {
+	// Marker in the parsed message.
+	require.True(t, tkIsAnthropicRequestOwned429Message("Usage credits are required for long context requests.", nil))
+	// Case-insensitive.
+	require.True(t, tkIsAnthropicRequestOwned429Message("USAGE CREDITS ARE REQUIRED for long context requests.", nil))
+	// Marker only in the raw body.
+	require.True(t, tkIsAnthropicRequestOwned429Message("", []byte(tkUsageCredits429Body)))
+	// Genuine account-level rate limits must NOT match.
+	require.False(t, tkIsAnthropicRequestOwned429Message("Number of request tokens has exceeded your per-minute rate limit", nil))
+	require.False(t, tkIsAnthropicRequestOwned429Message("", []byte(`{"type":"error","error":{"type":"rate_limit_error","message":"Rate limited"}}`)))
+	require.False(t, tkIsAnthropicRequestOwned429Message("", nil))
+}
+
+func newRequestOwned429TestContext(t *testing.T) (*gin.Context, *httptest.ResponseRecorder) {
+	t.Helper()
+	gin.SetMode(gin.TestMode)
+	rec := httptest.NewRecorder()
+	c, _ := gin.CreateTestContext(rec)
+	c.Request = httptest.NewRequest(http.MethodPost, "/v1/messages", strings.NewReader("{}"))
+	return c, rec
+}
+
+func anthropic429Response(body string) *http.Response {
+	return &http.Response{
+		StatusCode: http.StatusTooManyRequests,
+		Header:     http.Header{},
+		Body:       io.NopCloser(strings.NewReader(body)),
+	}
+}
+
+// Incident 2026-06-11: the deterministic policy 429 must be short-circuited on
+// the FIRST hop — original status + body passed through (so the prod mirror hop
+// can re-classify the same phrase), and the returned error must NOT be a
+// failover error.
+func TestTkHandleAnthropicRequestOwned429_KnownPhraseShortCircuitsFirstHop(t *testing.T) {
+	c, rec := newRequestOwned429TestContext(t)
+	svc := &GatewayService{}
+	account := &Account{ID: 1, Name: "cc-us3", Platform: PlatformAnthropic, Type: AccountTypeAPIKey}
+
+	result, err, handled := svc.tkHandleAnthropicRequestOwned429(c, account, anthropic429Response(tkUsageCredits429Body), []byte(tkUsageCredits429Body))
+	require.True(t, handled)
+	require.Nil(t, result)
+	require.Error(t, err)
+	var failoverErr *UpstreamFailoverError
+	require.False(t, errors.As(err, &failoverErr), "request-owned 429 must not fan out")
+
+	require.Equal(t, http.StatusTooManyRequests, rec.Code)
+	require.Contains(t, rec.Body.String(), "Usage credits are required", "original policy phrase must survive the mirror boundary")
+}
+
+// Unknown deterministic 429s: identical message text from N accounts within one
+// request trips the breaker at the Nth occurrence; the first N-1 hops keep
+// normal failover semantics.
+func TestTkHandleAnthropicRequestOwned429_SameTextBreaker(t *testing.T) {
+	c, rec := newRequestOwned429TestContext(t)
+	svc := &GatewayService{}
+	body := `{"type":"error","error":{"type":"rate_limit_error","message":"Some future deterministic rejection"}}`
+
+	for i := 1; i < tkAnthropic429SameTextThreshold; i++ {
+		account := &Account{ID: int64(i), Platform: PlatformAnthropic, Type: AccountTypeAPIKey}
+		_, _, handled := svc.tkHandleAnthropicRequestOwned429(c, account, anthropic429Response(body), []byte(body))
+		require.False(t, handled, "occurrence %d must keep normal failover semantics", i)
+	}
+
+	last := &Account{ID: 99, Platform: PlatformAnthropic, Type: AccountTypeAPIKey}
+	_, err, handled := svc.tkHandleAnthropicRequestOwned429(c, last, anthropic429Response(body), []byte(body))
+	require.True(t, handled, "occurrence %d (identical text) must trip the breaker", tkAnthropic429SameTextThreshold)
+	require.Error(t, err)
+	require.Equal(t, http.StatusTooManyRequests, rec.Code)
+	require.Contains(t, rec.Body.String(), "Some future deterministic rejection")
+}
+
+// Distinct texts (genuine per-account rate limits) must never trip the breaker.
+func TestTkHandleAnthropicRequestOwned429_DistinctTextsNeverTrip(t *testing.T) {
+	c, _ := newRequestOwned429TestContext(t)
+	svc := &GatewayService{}
+	texts := []string{"limit A", "limit B", "limit C", "limit D"}
+	for i, msg := range texts {
+		body := `{"type":"error","error":{"type":"rate_limit_error","message":"` + msg + `"}}`
+		account := &Account{ID: int64(i + 1), Platform: PlatformAnthropic, Type: AccountTypeAPIKey}
+		_, _, handled := svc.tkHandleAnthropicRequestOwned429(c, account, anthropic429Response(body), []byte(body))
+		require.False(t, handled, "distinct text %q must not trip the breaker", msg)
+	}
+}
+
+func TestTkHandleAnthropicRequestOwned429_ScopeGuards(t *testing.T) {
+	c, _ := newRequestOwned429TestContext(t)
+	svc := &GatewayService{}
+
+	// Non-anthropic platform is out of scope even with the policy phrase.
+	openaiAccount := &Account{ID: 7, Platform: PlatformOpenAI, Type: AccountTypeAPIKey}
+	_, _, handled := svc.tkHandleAnthropicRequestOwned429(c, openaiAccount, anthropic429Response(tkUsageCredits429Body), []byte(tkUsageCredits429Body))
+	require.False(t, handled)
+
+	// Non-429 statuses are out of scope.
+	anthropicAccount := &Account{ID: 8, Platform: PlatformAnthropic, Type: AccountTypeAPIKey}
+	resp503 := anthropic429Response(tkUsageCredits429Body)
+	resp503.StatusCode = http.StatusServiceUnavailable
+	_, _, handled = svc.tkHandleAnthropicRequestOwned429(c, anthropicAccount, resp503, []byte(tkUsageCredits429Body))
+	require.False(t, handled)
+
+	// Nil gin context (no request scope to track) must be a no-op.
+	_, _, handled = svc.tkHandleAnthropicRequestOwned429(nil, anthropicAccount, anthropic429Response(tkUsageCredits429Body), []byte(tkUsageCredits429Body))
+	require.False(t, handled)
+}

--- a/backend/internal/service/newapi_bridge_penalty_tk_test.go
+++ b/backend/internal/service/newapi_bridge_penalty_tk_test.go
@@ -35,6 +35,9 @@ func (r *tkBridgePenaltyIncidentRecorder) NotifyAccountRecovered(accountID int64
 	r.recovered = append(r.recovered, accountID)
 }
 
+func (r *tkBridgePenaltyIncidentRecorder) NotifyPlatformPoolExhausted(platform string, trigger *Account, until time.Time, reason string) {
+}
+
 func newBridgePenaltyTestService() (*RateLimitService, *rateLimitAccountRepoStub, *runtimeBlockRecorder, *tkBridgePenaltyIncidentRecorder) {
 	repo := &rateLimitAccountRepoStub{}
 	blocker := &runtimeBlockRecorder{}

--- a/backend/internal/service/ratelimit_service.go
+++ b/backend/internal/service/ratelimit_service.go
@@ -248,6 +248,9 @@ func (s *RateLimitService) notifyAccountSchedulingBlocked(account *Account, unti
 	s.runtimeBlocker.BlockAccountScheduling(account, until, reason)
 	// TK: 同一汇聚点上报账号失效事件给飞书（kind 由 reason 在 classifyIncident 内精确派生）。
 	s.notifyAccountIncident(account, until, reason, IncidentKindUnknown, detail...)
+	// TK: 池级检查——若这是该平台最后一个可调度账号,即时发全池不可调度 P0。
+	// 见 ratelimit_service_tk_pool_exhausted.go。
+	s.tkCheckPlatformPoolExhausted(account, until, reason)
 }
 
 func (s *RateLimitService) notifyAccountSchedulingBlockCleared(accountID int64) {
@@ -497,6 +500,19 @@ func (s *RateLimitService) HandleUpstreamError(ctx context.Context, account *Acc
 				"status_code", statusCode)
 		}
 	case 429:
+		// TK (prod 2026-06-11 incident): a deterministic policy 429 — e.g.
+		// "Usage credits are required for long context requests." — is a
+		// property of the REQUEST, not of account health. The gateway short-
+		// circuits it before side effects (gateway_service_tk_request_owned_429.go);
+		// this is the defense-in-depth for every other HandleUpstreamError
+		// caller: skip the ladder/cooldown so one poisoned request can never
+		// cool a healthy account, let alone lock the whole mirror pool.
+		if account.Platform == PlatformAnthropic && tkIsAnthropicRequestOwned429Message(upstreamMsg, responseBody) {
+			slog.Info("anthropic_request_owned_429_skip_penalty",
+				"account_id", account.ID,
+				"status_code", statusCode)
+			return true
+		}
 		// TK (prod 2026-06): edges empty-pool fast-fail is 429+Retry-After, not
 		// 503. Same downstream-exhaustion semantics as handleAnthropicUpstreamError
 		// skip path — do not classify as upstream rate-limit cooldown / Feishu 429.

--- a/backend/internal/service/ratelimit_service_tk_pool_exhausted.go
+++ b/backend/internal/service/ratelimit_service_tk_pool_exhausted.go
@@ -1,0 +1,61 @@
+package service
+
+import (
+	"context"
+	"log/slog"
+	"time"
+)
+
+// 池级全不可调度检查（事件驱动,挂在 notifyAccountSchedulingBlocked 汇聚点）。
+//
+// 单账号冷却走 #516 的单卡/摘要;但"最后一个可调度账号被封"是质变——整个平台
+// 的流量从这一刻起全部快速失败,必须即时 P0(prod 2026-06-11 全池冷却事件中,
+// 该信号本可比冷却自愈早 ~9 分钟暴露问题)。检查异步执行,不阻塞请求路径;
+// 延迟一拍是为了等触发本次通知的 SetTempUnschedulable 写入提交,避免查到
+// 账号自身仍可调度的假阴性。当前只对 anthropic 启用(镜像池形态最受 failover
+// 扇出连锁影响);其他平台如需纳入,把 platform 判断改成集合即可。
+const (
+	tkPoolExhaustedCheckDelay   = 2 * time.Second
+	tkPoolExhaustedCheckTimeout = 5 * time.Second
+)
+
+func (s *RateLimitService) tkCheckPlatformPoolExhausted(account *Account, until time.Time, reason string) {
+	if s == nil || account == nil || s.incidentNotifier == nil || s.accountRepo == nil {
+		return
+	}
+	if account.Platform != PlatformAnthropic {
+		return
+	}
+	platform := account.Platform
+	go func() {
+		defer func() {
+			if r := recover(); r != nil {
+				slog.Warn("pool_exhausted_check_panic_recovered", "platform", platform, "panic", r)
+			}
+		}()
+		time.Sleep(tkPoolExhaustedCheckDelay)
+		ctx, cancel := context.WithTimeout(context.Background(), tkPoolExhaustedCheckTimeout)
+		defer cancel()
+		s.tkPlatformPoolExhaustedCheck(ctx, platform, account, until, reason)
+	}()
+}
+
+// tkPlatformPoolExhaustedCheck 是可同步调用的检查本体（拆出便于单测）。
+func (s *RateLimitService) tkPlatformPoolExhaustedCheck(ctx context.Context, platform string, trigger *Account, until time.Time, reason string) {
+	if s == nil || s.incidentNotifier == nil || s.accountRepo == nil {
+		return
+	}
+	accounts, err := s.accountRepo.ListSchedulableByPlatform(ctx, platform)
+	if err != nil {
+		slog.Warn("pool_exhausted_check_query_failed", "platform", platform, "error", err)
+		return
+	}
+	if len(accounts) > 0 {
+		return
+	}
+	slog.Error("platform_pool_exhausted",
+		"platform", platform,
+		"trigger_account_id", trigger.ID,
+		"trigger_reason", reason)
+	s.incidentNotifier.NotifyPlatformPoolExhausted(platform, trigger, until, reason)
+}

--- a/backend/internal/service/ratelimit_service_tk_pool_exhausted.go
+++ b/backend/internal/service/ratelimit_service_tk_pool_exhausted.go
@@ -42,7 +42,7 @@ func (s *RateLimitService) tkCheckPlatformPoolExhausted(account *Account, until 
 
 // tkPlatformPoolExhaustedCheck 是可同步调用的检查本体（拆出便于单测）。
 func (s *RateLimitService) tkPlatformPoolExhaustedCheck(ctx context.Context, platform string, trigger *Account, until time.Time, reason string) {
-	if s == nil || s.incidentNotifier == nil || s.accountRepo == nil {
+	if s == nil || s.incidentNotifier == nil || s.accountRepo == nil || trigger == nil {
 		return
 	}
 	accounts, err := s.accountRepo.ListSchedulableByPlatform(ctx, platform)

--- a/backend/internal/service/ratelimit_service_tk_pool_exhausted_test.go
+++ b/backend/internal/service/ratelimit_service_tk_pool_exhausted_test.go
@@ -1,0 +1,95 @@
+//go:build unit
+
+package service
+
+import (
+	"context"
+	"testing"
+	"time"
+
+	"github.com/Wei-Shaw/sub2api/internal/config"
+	"github.com/stretchr/testify/require"
+)
+
+type poolExhaustedRepoStub struct {
+	mockAccountRepoForGemini
+	schedulable []Account
+	queryErr    error
+	calls       int
+}
+
+func (r *poolExhaustedRepoStub) ListSchedulableByPlatform(ctx context.Context, platform string) ([]Account, error) {
+	r.calls++
+	return r.schedulable, r.queryErr
+}
+
+type poolExhaustedNotifierStub struct {
+	incidents int
+	pools     []string
+}
+
+func (n *poolExhaustedNotifierStub) NotifyAccountIncident(account *Account, until time.Time, reason string, kind AccountIncidentKind, detail ...string) {
+	n.incidents++
+}
+func (n *poolExhaustedNotifierStub) NotifyAccountRecovered(accountID int64) {}
+func (n *poolExhaustedNotifierStub) NotifyPlatformPoolExhausted(platform string, trigger *Account, until time.Time, reason string) {
+	n.pools = append(n.pools, platform)
+}
+
+// Incident 2026-06-11: the moment the LAST schedulable anthropic account got
+// cooled, the pool went dark for ~10 minutes with no alert — the P0 card must
+// fire exactly on the 0-schedulable transition.
+func TestTkPlatformPoolExhaustedCheck_FiresOnEmptyPool(t *testing.T) {
+	repo := &poolExhaustedRepoStub{schedulable: nil}
+	notifier := &poolExhaustedNotifierStub{}
+	service := NewRateLimitService(repo, nil, &config.Config{}, nil, nil)
+	service.SetAccountIncidentNotifier(notifier)
+	trigger := &Account{ID: 7, Name: "cc-us7", Platform: PlatformAnthropic, Type: AccountTypeAPIKey}
+
+	service.tkPlatformPoolExhaustedCheck(context.Background(), PlatformAnthropic, trigger, time.Now().Add(10*time.Minute), "temp_unschedulable")
+
+	require.Equal(t, []string{PlatformAnthropic}, notifier.pools)
+}
+
+func TestTkPlatformPoolExhaustedCheck_QuietWhenPoolHasCapacity(t *testing.T) {
+	repo := &poolExhaustedRepoStub{schedulable: []Account{{ID: 1, Platform: PlatformAnthropic}}}
+	notifier := &poolExhaustedNotifierStub{}
+	service := NewRateLimitService(repo, nil, &config.Config{}, nil, nil)
+	service.SetAccountIncidentNotifier(notifier)
+	trigger := &Account{ID: 7, Platform: PlatformAnthropic, Type: AccountTypeAPIKey}
+
+	service.tkPlatformPoolExhaustedCheck(context.Background(), PlatformAnthropic, trigger, time.Now(), "429")
+
+	require.Empty(t, notifier.pools, "pool with schedulable accounts must not alert")
+}
+
+func TestTkPlatformPoolExhaustedCheck_QuietOnQueryError(t *testing.T) {
+	repo := &poolExhaustedRepoStub{queryErr: context.DeadlineExceeded}
+	notifier := &poolExhaustedNotifierStub{}
+	service := NewRateLimitService(repo, nil, &config.Config{}, nil, nil)
+	service.SetAccountIncidentNotifier(notifier)
+	trigger := &Account{ID: 7, Platform: PlatformAnthropic, Type: AccountTypeAPIKey}
+
+	service.tkPlatformPoolExhaustedCheck(context.Background(), PlatformAnthropic, trigger, time.Now(), "429")
+
+	require.Empty(t, notifier.pools, "query failure must fail quiet, not page")
+}
+
+// The async wrapper only arms for anthropic; other platforms must not even
+// query (mirror-pool fan-out is the failure shape this watches).
+func TestTkCheckPlatformPoolExhausted_NonAnthropicIsNoop(t *testing.T) {
+	repo := &poolExhaustedRepoStub{}
+	notifier := &poolExhaustedNotifierStub{}
+	service := NewRateLimitService(repo, nil, &config.Config{}, nil, nil)
+	service.SetAccountIncidentNotifier(notifier)
+
+	service.tkCheckPlatformPoolExhausted(&Account{ID: 1, Platform: PlatformOpenAI}, time.Now(), "429")
+	service.tkCheckPlatformPoolExhausted(nil, time.Now(), "429")
+
+	// The anthropic path is async (delay + goroutine), so a non-anthropic
+	// no-op is observable as: no goroutine ever queries the repo. Give any
+	// stray goroutine a beat to surface before asserting.
+	time.Sleep(50 * time.Millisecond)
+	require.Zero(t, repo.calls)
+	require.Empty(t, notifier.pools)
+}

--- a/backend/internal/service/ratelimit_service_tk_request_owned_429_test.go
+++ b/backend/internal/service/ratelimit_service_tk_request_owned_429_test.go
@@ -1,0 +1,51 @@
+//go:build unit
+
+package service
+
+import (
+	"context"
+	"net/http"
+	"testing"
+
+	"github.com/Wei-Shaw/sub2api/internal/config"
+	"github.com/stretchr/testify/require"
+)
+
+// Incident 2026-06-11: a deterministic policy 429 ("Usage credits are required
+// for long context requests.") fanned out by failover must never advance the
+// anthropic 3/3 ladder or write any cooldown — repeated arrivals poisoned all 7
+// mirror accounts into tier-2 10-minute cooldowns. Defense-in-depth mirror of
+// the gateway-level short circuit, for every other HandleUpstreamError caller.
+func TestRateLimitService_HandleUpstreamError_RequestOwned429_DoesNotPenalize(t *testing.T) {
+	repo := &rateLimitAccountRepoStub{}
+	counter := &anthropicUpstreamErrorCounterCacheStub{counts: []int64{1, 2, 3, 4, 5}}
+	service := NewRateLimitService(repo, nil, &config.Config{}, nil, nil)
+	service.SetAnthropicUpstreamErrorCounterCache(counter)
+	account := &Account{ID: 4043, Platform: PlatformAnthropic, Type: AccountTypeAPIKey}
+
+	body := []byte(`{"type":"error","error":{"type":"rate_limit_error","message":"Usage credits are required for long context requests."}}`)
+	for i := 0; i < 5; i++ {
+		shouldDisable := service.HandleUpstreamError(context.Background(), account, http.StatusTooManyRequests, http.Header{}, body)
+		require.True(t, shouldDisable, "iteration %d: request-owned 429 must fail this request away from the account", i)
+	}
+
+	require.Equal(t, 0, repo.setRateLimitedCalls, "request-owned 429 must not write SetRateLimited")
+	require.Equal(t, 0, repo.tempCalls, "request-owned 429 must never write temp_unschedulable")
+	require.Equal(t, 0, repo.setErrorCalls)
+	require.Empty(t, counter.incrementIDs, "request-owned 429 must NOT advance the 3/3 ladder counter")
+}
+
+// A genuine anthropic rate-limit 429 must keep the pre-existing penalty path
+// (regression guard for the new skip being too broad).
+func TestRateLimitService_HandleUpstreamError_Genuine429_StillPenalizes(t *testing.T) {
+	repo := &rateLimitAccountRepoStub{}
+	counter := &anthropicUpstreamErrorCounterCacheStub{counts: []int64{1}}
+	service := NewRateLimitService(repo, nil, &config.Config{}, nil, nil)
+	service.SetAnthropicUpstreamErrorCounterCache(counter)
+	account := &Account{ID: 4044, Platform: PlatformAnthropic, Type: AccountTypeAPIKey}
+
+	body := []byte(`{"type":"error","error":{"type":"rate_limit_error","message":"Number of request tokens has exceeded your per-minute rate limit"}}`)
+	service.HandleUpstreamError(context.Background(), account, http.StatusTooManyRequests, http.Header{}, body)
+
+	require.NotEmpty(t, counter.incrementIDs, "genuine 429 must still advance the ladder counter")
+}

--- a/scripts/sentinels/gateway-tk.json
+++ b/scripts/sentinels/gateway-tk.json
@@ -2223,9 +2223,10 @@
       "must_contain": [
         "usage credits are required",
         "tkAnthropic429SameTextThreshold",
-        "MarkResponseCommitted"
+        "MarkResponseCommitted",
+        "tkSkipDownstreamNoAvailableAccountsPenalty"
       ],
-      "rationale": "Companion owning the request-owned 429 classifier (known policy phrase) + same-text failover circuit breaker + ORIGINAL-body passthrough. Body passthrough is load-bearing for the prod<->edge mirror topology: preserving the upstream phrase is what lets the prod hop re-classify the relayed 429 instead of seeing a rewritten generic text the exemption predicates cannot match."
+      "rationale": "Companion owning the request-owned 429 classifier (known policy phrase) + same-text failover circuit breaker + ORIGINAL-body passthrough. Body passthrough is load-bearing for the prod<->edge mirror topology: preserving the upstream phrase is what lets the prod hop re-classify the relayed 429 instead of seeing a rewritten generic text the exemption predicates cannot match. The capacity-envelope exemption (tkSkipDownstreamNoAvailableAccountsPenalty / failover-exhausted / generic rewrite text) must stay wired into the breaker path: without it, identical empty-pool 429s from several edges would trip the breaker and prematurely stop legitimate cross-edge failover."
     },
     {
       "path": "backend/internal/service/ratelimit_service.go",

--- a/scripts/sentinels/gateway-tk.json
+++ b/scripts/sentinels/gateway-tk.json
@@ -2210,6 +2210,38 @@
         "middleware.TkAdminComplianceGuardIfEnabled(settingService)"
       ],
       "rationale": "Third registration site of the upstream admin compliance guard (admin payment group). Same silent-revert mode as page_handler.go — bare AdminComplianceGuard here 423-locks /api/v1/admin/payment/* for fleet automation."
+    },
+    {
+      "path": "backend/internal/service/gateway_service.go",
+      "must_contain": [
+        "tkHandleAnthropicRequestOwned429"
+      ],
+      "rationale": "Incident 2026-06-11 (anthropic mirror-pool 10-min full-cooldown): the request-owned-429 short circuit must stay wired into BOTH failover branches of Forward AND forwardAnthropicAPIKeyPassthroughWithInput. If an upstream merge drops these calls, a single deterministic policy 429 (e.g. 'Usage credits are required for long context requests.') again fans out across every cc-<edge> mirror account and locks the whole pool via the 3/3 ladder."
+    },
+    {
+      "path": "backend/internal/service/gateway_service_tk_request_owned_429.go",
+      "must_contain": [
+        "usage credits are required",
+        "tkAnthropic429SameTextThreshold",
+        "MarkResponseCommitted"
+      ],
+      "rationale": "Companion owning the request-owned 429 classifier (known policy phrase) + same-text failover circuit breaker + ORIGINAL-body passthrough. Body passthrough is load-bearing for the prod<->edge mirror topology: preserving the upstream phrase is what lets the prod hop re-classify the relayed 429 instead of seeing a rewritten generic text the exemption predicates cannot match."
+    },
+    {
+      "path": "backend/internal/service/ratelimit_service.go",
+      "must_contain": [
+        "anthropic_request_owned_429_skip_penalty",
+        "tkCheckPlatformPoolExhausted"
+      ],
+      "rationale": "Two incident-2026-06-11 guards inside upstream-owned ratelimit_service.go: (a) defense-in-depth skip in case 429 so a request-owned policy 429 never advances the anthropic ladder regardless of which caller reached HandleUpstreamError; (b) the pool-exhausted check hook on the notifyAccountSchedulingBlocked funnel — the only place that can observe the 'last schedulable account just got cooled' transition for the platform-pool P0 Feishu card."
+    },
+    {
+      "path": "backend/internal/service/account_incident_notifier_tk_pool.go",
+      "must_contain": [
+        "NotifyPlatformPoolExhausted",
+        "accountIncidentPoolExhaustedDedupeWindow"
+      ],
+      "rationale": "Platform-pool-exhausted P0 Feishu card (closes the #516 blind spot where 7 simultaneous per-account cooldowns produced no pool-level signal and the 06:49-06:58 outage went unalerted). Dedupe-per-platform is required: every subsequent account block during a cooldown storm re-triggers the pool check."
     }
   ]
 }


### PR DESCRIPTION
## 背景（prod 2026-06-11 06:44–06:59 UTC 全池冷却事件）

单用户 >200k 长上下文请求在无 usage credits 的订阅账号上拿到**确定性策略 429**：

> Usage credits are required for long context requests.

该错误是请求属性而非账号健康问题——池内任何订阅账号都必然复现，failover 无解。实际发生的连锁：failover 把同一请求扇出到全部 7 个 `cc-<edge>` 镜像账号（prod `upstream_events` 7 个账号 first_at 同为 06:44:41）→ 每跳推进 anthropic 3/3 阈梯 → 30s/2m/10m 三档 4 分钟走完 → 06:48–06:49 全池 tier-2 十分钟封锁 → 06:49–06:57 用户侧 128 条无辜 429（峰值 28/分钟），而 edge 侧 06:48 即已恢复正常。期间无任何飞书告警（#516 只看单账号事件）。

## 改动（三层，全部 companion 收敛 + 薄注入，§5 纪律）

**1. 根治：已知策略短语 429 第一跳短路**（`gateway_service_tk_request_owned_429.go`）

- 分类器命中 `usage credits are required` → 原状态码 + **原 body 透传**给调用方，不计账号惩罚、不 failover。
- body 透传是 load-bearing：prod↔edge 镜像拓扑里，保留原短语才能让 prod 跳用同一分类器再次命中（事件中 edge→prod 边界把 429 改写成通用文案，prod 豁免谓词无法识别，正是放大器成立的缺口）。
- 注入 `Forward` 与 `forwardAnthropicAPIKeyPassthroughWithInput` 的全部 4 个 failover 分支（每处 +4 行调用）。

**2. 结构免疫：同文案确定性 429 熔断**（同 companion）

- 同一请求内**同文案** 429 出现第 3 次 → 判 request-owned，熔断扇出、该跳起不再推进任何账号计数器——对未来无法枚举的确定性 429 变体免疫。
- 前 2 跳保持原 failover 语义：单账号真实限流（文案各异或只出现一次）完全不受影响。
- `HandleUpstreamError` case 429 另加 defense-in-depth skip（先例：`tkSkipDownstreamNoAvailableAccountsPenalty` / 413 G1），覆盖 gateway 短路之外的所有调用方。

**3. 告警：平台池全不可调度 P0**（`account_incident_notifier_tk_pool.go` + `ratelimit_service_tk_pool_exhausted.go`）

- `notifyAccountSchedulingBlocked` 汇聚点挂池级检查（异步、延迟 2s 等冷却写入提交）：anthropic 可调度账号数降为 0 → 即时飞书红卡（按 platform 10 分钟去重防冷却风暴刷屏）。
- 补 #516 体系"全池同时倒"盲区；本事件该卡片 06:49 即发出，比冷却自愈早 ~9 分钟。
- `AccountIncidentNotifier` 接口新增 `NotifyPlatformPoolExhausted`（仓库内唯一实现 + 测试 stub 已同步）。

## 测试

- 12 个新单测：分类器正负向（含 body-only 匹配、真实限流文案不误伤）、熔断阈值边界（前 N-1 跳不动 / 第 N 跳熔断 / 不同文案永不熔断）、透传 body 保留短语、429 阈梯计数器不推进 + 真实 429 回归守卫、池空/池有容量/查询失败、P0 发送与去重。
- `go test -tags=unit ./...` 全包全绿；`golangci-lint run` 0 issues；`scripts/preflight.sh` PASS（gateway TK sentinels 234/234）。

## 防回归

- `scripts/sentinels/gateway-tk.json` 新增 4 条守卫：4 个注入点调用、companion 锚点（短语/阈值/透传）、ratelimit skip + 池级 hook、P0 去重窗口。仅新增条目，未改既有 sentinel。sentinel-registry-reviewed：新增 4 条均为本 PR 引入的锚点，既有 230 条未触碰。

no-web-impact（纯后端）；upstream-touch-guarded（`gateway_service.go` / `ratelimit_service.go` / `account_incident_notifier_tk.go` 为薄注入：4×4 行调用 + case 429 一段 skip + 汇聚点 1 行 + struct 1 字段，逻辑全部在 `*_tk_*.go` companion）。

🤖 Generated with [Claude Code](https://claude.com/claude-code)
