### PR TITLE
chore(sentinels): gateway-tk 注册表去冗余 + 条目内卫生 lint 硬化

### DIFF
--- a/scripts/sentinels/check-gateway-tk.py
+++ b/scripts/sentinels/check-gateway-tk.py
@@ -8,9 +8,22 @@ Reads `scripts/sentinels/gateway-tk.json` and for each entry verifies:
   2. Every literal string in `must_contain` appears at least once in the file.
   3. Every literal string in `must_not_contain` is absent from the file.
 
+It also lints registry hygiene WITHIN each entry (anti-bloat guard):
+
+  - duplicate `must_contain` needles in the same entry are noise;
+  - a needle that is a substring of another needle in the same entry is
+    vacuous (the longer literal present always implies the shorter one) —
+    either drop it or strengthen it (e.g. `Name` → `Name(` / `func Name(` /
+    `type Name struct`) so it pins a distinct symbol occurrence.
+
+  Cross-entry overlap is intentionally NOT linted: two entries may share an
+  anchor under different rationales, and a long needle in one entry must not
+  excuse a short needle in another (entries evolve independently).
+
 Exit codes:
   0  — all sentinels intact.
-  1  — at least one sentinel missing or has lost a required symbol.
+  1  — at least one sentinel missing, lost a required symbol, or failed
+       registry hygiene.
   2  — registry file missing or malformed.
 """
 from __future__ import annotations
@@ -43,6 +56,38 @@ def load_registry() -> dict:
     return data
 
 
+_CONTENT_CACHE: dict[str, str] = {}
+
+
+def read_file_cached(path_str: str) -> str:
+    """Read a sentinel target file once even when many entries share the path
+    (gateway_service.go alone is anchored by 15+ entries)."""
+    if path_str not in _CONTENT_CACHE:
+        _CONTENT_CACHE[path_str] = (REPO_ROOT / path_str).read_text(
+            encoding="utf-8", errors="replace"
+        )
+    return _CONTENT_CACHE[path_str]
+
+
+def lint_entry_hygiene(entry: dict) -> list[str]:
+    """Within-entry anti-bloat lint; see module docstring."""
+    needles = entry.get("must_contain") or []
+    problems: list[str] = []
+    seen: set[str] = set()
+    for n in needles:
+        if n in seen:
+            problems.append(f"duplicate needle in same entry: `{n}`")
+        seen.add(n)
+    for a in seen:
+        for b in seen:
+            if a != b and a in b:
+                problems.append(
+                    f"vacuous needle `{a}` is a substring of sibling needle `{b}` "
+                    "— drop it or strengthen it to pin a distinct symbol"
+                )
+    return problems
+
+
 def check_sentinel(entry: dict) -> tuple[bool, list[str]]:
     path_str = entry.get("path")
     if not path_str:
@@ -50,14 +95,14 @@ def check_sentinel(entry: dict) -> tuple[bool, list[str]]:
     file_path = REPO_ROOT / path_str
     if not file_path.is_file():
         return False, [f"file missing: {path_str}"]
+    failures: list[str] = lint_entry_hygiene(entry)
     must_contain = entry.get("must_contain") or []
-    if not must_contain:
+    if not must_contain and not failures:
         return True, []
     try:
-        content = file_path.read_text(encoding="utf-8", errors="replace")
+        content = read_file_cached(path_str)
     except OSError as exc:
         return False, [f"cannot read {path_str}: {exc}"]
-    failures: list[str] = []
     for needle in must_contain:
         if needle not in content:
             failures.append(f"missing literal `{needle}` in {path_str}")

--- a/scripts/sentinels/check-gateway-tk.py
+++ b/scripts/sentinels/check-gateway-tk.py
@@ -78,8 +78,8 @@ def lint_entry_hygiene(entry: dict) -> list[str]:
         if n in seen:
             problems.append(f"duplicate needle in same entry: `{n}`")
         seen.add(n)
-    for a in seen:
-        for b in seen:
+    for a in sorted(seen):
+        for b in sorted(seen):
             if a != b and a in b:
                 problems.append(
                     f"vacuous needle `{a}` is a substring of sibling needle `{b}` "
@@ -97,8 +97,9 @@ def check_sentinel(entry: dict) -> tuple[bool, list[str]]:
         return False, [f"file missing: {path_str}"]
     failures: list[str] = lint_entry_hygiene(entry)
     must_contain = entry.get("must_contain") or []
-    if not must_contain and not failures:
-        return True, []
+    must_not_contain = entry.get("must_not_contain") or []
+    if not must_contain and not must_not_contain:
+        return (len(failures) == 0), failures
     try:
         content = read_file_cached(path_str)
     except OSError as exc:
@@ -106,7 +107,7 @@ def check_sentinel(entry: dict) -> tuple[bool, list[str]]:
     for needle in must_contain:
         if needle not in content:
             failures.append(f"missing literal `{needle}` in {path_str}")
-    for needle in entry.get("must_not_contain") or []:
+    for needle in must_not_contain:
         if needle in content:
             failures.append(f"forbidden literal `{needle}` still present in {path_str}")
     return (len(failures) == 0), failures

--- a/scripts/sentinels/gateway-tk.json
+++ b/scripts/sentinels/gateway-tk.json
@@ -104,7 +104,7 @@
     {
       "path": "backend/internal/service/ops_feishu_notifier_tk.go",
       "must_contain": [
-        "sanitizeFeishuWebhook",
+        "func sanitizeFeishuWebhook(",
         "sanitizeFeishuWebhookError",
         "signFeishuWebhook",
         "SigningSecret",
@@ -165,17 +165,17 @@
         "openai_403_cf_challenge_skip_cooldown",
         "openAIIsHTMLBody",
         "openai_403_html_body_skip_cooldown",
-        "handleAnthropicUpstreamError",
+        "handleAnthropicUpstreamError(",
         "handleAnthropicUpstreamErrorWithOptions",
         "IncrementAnthropicUpstreamErrorCount",
-        "IncrementAnthropicCooldownTier",
+        "IncrementAnthropicCooldownTier(",
         "IncrementAnthropicCooldownTierEscalations",
         "anthropic_cooldown_tier_escalation",
         "anthropic_upstream_error_cooldown_write_skipped",
         "anthropic_tls_fingerprint_failure_suspected",
         "403_escalated_to_error",
         "SetTempUnschedulable(ctx, account.ID, until, reason)",
-        "ResetAnthropicUpstreamErrorCounter",
+        ") ResetAnthropicUpstreamErrorCounter(",
         "ResetAnthropicCooldownTier",
         "if account.IsPoolMode() && !customErrorCodesEnabled && account.Platform != PlatformAnthropic {",
         "if !account.ShouldHandleErrorCode(statusCode) && account.Platform != PlatformAnthropic {",
@@ -199,7 +199,7 @@
         "type AnthropicUpstreamErrorCounterCache interface",
         "IncrementAnthropicUpstreamErrorCount",
         "ResetAnthropicUpstreamErrorCount",
-        "IncrementAnthropicCooldownTier",
+        "IncrementAnthropicCooldownTier(",
         "ResetAnthropicCooldownTier",
         "IncrementAnthropicCooldownTierEscalations",
         "GetAnthropicCooldownTierEscalations",
@@ -220,7 +220,7 @@
         "NewAnthropicUpstreamErrorCounterCache",
         "IncrementAnthropicUpstreamErrorCount",
         "ResetAnthropicUpstreamErrorCount",
-        "IncrementAnthropicCooldownTier",
+        "IncrementAnthropicCooldownTier(",
         "ResetAnthropicCooldownTier",
         "IncrementAnthropicCooldownTierEscalations",
         "GetAnthropicCooldownTierEscalations",
@@ -268,7 +268,7 @@
         "invalid_request_error",
         "request_too_large"
       ],
-      "rationale": "G1 client-induced exemption predicate. An Anthropic invalid_request_error (#2608) OR request_too_large is a caller-side fault, not account health, and must be skipped from the 3/3 ladder (via case 400 catch-all and case 413 in ratelimit_service.go). Dropping the request_too_large arm re-arms the oversized-body amplifier on the 400-shape; dropping invalid_request_error restores the original #2608 amplifier where any caller can pause a shared OAuth account with malformed requests."
+      "rationale": "G1 client-induced exemption predicate. An Anthropic invalid_request_error (#2608) OR request_too_large is a caller-side fault, not account health, and must be skipped from the 3/3 ladder (via case 400 catch-all and case 413 in ratelimit_service.go). Dropping the request_too_large arm re-arms the oversized-body amplifier on the 400-shape; dropping invalid_request_error restores the original #2608 amplifier where any caller can pause a shared OAuth account with malformed requests. Removing the predicate reopens the external account-disable abuse vector (TK#2608)."
     },
     {
       "path": "backend/internal/service/ratelimit_service_tk_downstream_no_available.go",
@@ -280,7 +280,7 @@
         "all available accounts exhausted",
         "ErrNoAvailableAccounts.Error()"
       ],
-      "rationale": "Downstream capacity-signal skips for prod→edge mirror stubs. 'no available accounts' (429/503, empty downstream pool) and 'all available accounts exhausted' (G2 narrow, 429/5xx, downstream failover loop ran dry) are both TokenKey-generated downstream-capacity strings the real provider APIs never emit; a healthy forwarding stub must fail over without advancing the 3/3 ladder. Both skips match ONLY these TokenKey phrases, so raw edge-infra 5xx and genuine provider errors still count and keep the PR #333 route-away cooldown. Dropping any function silently re-arms the corresponding downstream-error amplifier; widening the match beyond the TokenKey phrases would break route-away on genuinely-broken edges."
+      "rationale": "Downstream capacity-signal skips for prod→edge mirror stubs. 'no available accounts' (429/503, empty downstream pool) and 'all available accounts exhausted' (G2 narrow, 429/5xx, downstream failover loop ran dry) are both TokenKey-generated downstream-capacity strings the real provider APIs never emit; a healthy forwarding stub must fail over without advancing the 3/3 ladder. Both skips match ONLY these TokenKey phrases, so raw edge-infra 5xx and genuine provider errors still count and keep the PR #333 route-away cooldown. Dropping any function silently re-arms the corresponding downstream-error amplifier; widening the match beyond the TokenKey phrases would break route-away on genuinely-broken edges. Prod incidents 2026-05-31 / 2026-06 were both this misattribution: empty-pool downstream 503/429 punished as account health."
     },
     {
       "path": "backend/internal/service/ratelimit_service_tk_request_too_large_test.go",
@@ -441,7 +441,7 @@
     {
       "path": "backend/internal/service/sticky_session_injector.go",
       "must_contain": [
-        "StickyKeySourceClientClaudeCodeSessionID",
+        "StickyKeySourceClientClaudeCodeSessionID = \"client_claude_code_session_id\"",
         "headers.Get(\"X-Claude-Code-Session-Id\")",
         "req.IsClaudeCodeUA || key.Source == StickyKeySourceClientClaudeCodeSessionID",
         "//  1. headers[\"session_id\"] / headers[\"conversation_id\"] / headers[\"X-Claude-Code-Session-Id\"] / headers[\"X-Session-Id\"]"
@@ -465,7 +465,7 @@
         "logger.WriteSinkEvent(\"info\", \"http.access.sticky\", \"sticky.hash_source\"",
         "\"session_hash_short\": shortSessionHash(sessionHash)",
         "resolveOpsTLSFingerprintProfile(c, s.tlsFPProfileService, account)",
-        "tlsFingerprintProfileNameForAccount(account)",
+        "GetOrCreateFingerprint(ctx, account.ID, c.Request.Header, s.tlsFingerprintProfileNameForAccount(account))",
         "GetOrCreateFingerprint(ctx, account.ID, clientHeaders, s.tlsFingerprintProfileNameForAccount(account))",
         "s.isCanonicalAnthropicOAuth(account)",
         "checkCanonicalIngressUA(c.Request.Header)",
@@ -481,7 +481,7 @@
         "Passthrough:        true,",
         "Wei-Shaw/sub2api#2506",
         "!strings.Contains(strings.ToLower(modelID), \"haiku\")",
-        "StripCountTokensUnsupportedFields(body)",
+        "if next, stripped := StripCountTokensUnsupportedFields(body); len(stripped) > 0 {",
         "count_tokens.stripped_unsupported_fields",
         "tkCountTokensSkipBreaker(resp.StatusCode)",
         "body, _ = StripCountTokensUnsupportedFields(body)",
@@ -562,7 +562,6 @@
     {
       "path": "backend/internal/service/openai_codex_transform.go",
       "must_contain": [
-        "chatGPTOAuthUpstreamModelNames",
         "codex-mini-latest",
         "var chatGPTOAuthUpstreamModelNames = map[string]string{}"
       ],
@@ -571,7 +570,7 @@
     {
       "path": "backend/internal/service/openai_gateway_service.go",
       "must_contain": [
-        "openAICompatSSEFrame",
+        "type openAICompatSSEFrame struct",
         "openAICompatSSEFrameParser",
         "openAICompatPayloadWithEventType",
         "extractOpenAISSEEventLine",
@@ -687,7 +686,6 @@
     {
       "path": "backend/internal/repository/account_repo.go",
       "must_contain": [
-        "SumConcurrencyAnthropic",
         "func (r *accountRepository) SumConcurrencyAnthropic",
         "WHERE platform = $1 AND schedulable = true AND deleted_at IS NULL",
         "dbproxy.StatusEQ(service.StatusActive)",
@@ -1363,23 +1361,6 @@
         "anthropic_downstream_no_available_accounts_skip_penalty"
       ],
       "rationale": "TK#2608: client-induced Anthropic 400 invalid_request_error must not advance the per-account cooldown counter (else an external caller can pause a shared OAuth subscription account). TK#1981: opt-in clamp of long OpenAI 429 resets so released accounts are re-probed by traffic instead of idling. Prod incident 2026-05-31 / 2026-06: a downstream 503 or 429 whose body is our own 'no available accounts' pool-exhaustion signal (edge empty pool or thin-pool burst, surfaced through a prod per-edge mirror stub) must fail over to the next stub WITHOUT handle429 cooldown, anthropic_upstream_error counter advance, or Feishu digest '限流冷却（429）' — else intentional edge shutdown or a brief edge burst cools the whole stub and collapses the prod pool."
-    },
-    {
-      "path": "backend/internal/service/ratelimit_service_tk_client_induced_400.go",
-      "must_contain": [
-        "func tkIsAnthropicClientInducedBadRequest",
-        "invalid_request_error"
-      ],
-      "rationale": "TK#2608: the predicate distinguishing client-induced 400s from account-level punishment. Removing it reopens the external account-disable abuse vector."
-    },
-    {
-      "path": "backend/internal/service/ratelimit_service_tk_downstream_no_available.go",
-      "must_contain": [
-        "func tkIsDownstreamNoAvailableAccounts",
-        "func tkSkipDownstreamNoAvailableAccountsPenalty",
-        "ErrNoAvailableAccounts.Error()"
-      ],
-      "rationale": "Prod incident 2026-05-31 / 2026-06: predicates distinguishing a downstream gateway's own 'no available accounts' pool-exhaustion 503/429 (transient edge capacity blip or intentional edge shutdown on a forwarded-to pool) from a genuine account-health upstream rate limit. Removing them lets empty-pool 429 hit handle429 + Feishu '限流冷却' noise and reintroduces the self-inflicted stub-cooldown amplifier."
     },
     {
       "path": "backend/internal/service/openai_gateway_service_tk_implicit_throttle.go",


### PR DESCRIPTION
## 背景

`scripts/sentinels/gateway-tk.json` 已增长到 ~2200 行 / 214KB（233 条 entry、813 个 needle，106 次提交触达）。本 PR 是对「是否需要精简」的量化评估 + 无信息损失的优化落地。

## 评估结论（先说不做什么）

- **rationale 文本占文件 63% 字节，有意保留**：它是 sentinel 失败时打印的现场上下文与机构记忆，运行时零成本，不是可精简对象。
- **跨 entry 共享锚点（如 `anthropic_model_not_found_skip_penalty` 同时在 entry 14/200）保留**：不同 rationale 合法共存，失败时两条关注点同时浮出是特性不是冗余。
- 运行时开销可忽略，真正的优化对象是**条目内的真冗余/弱锚点**与**后续增长的机械防线**。

## 改动

### 注册表（233 → 231 条，813 → 809 needle）

1. **强化 10 个被同条目更长 needle 蕴含的弱锚点**（长串在文件中出现必然蕴含短串，短串作为检查是空集）：`Name` → `Name(` / `func Name(` / `type Name struct` / 常量声明形态，使其真正锚定独立符号。其中 entry 39 顺带新锚定了此前未覆盖的 `c.Request.Header` 变体 `GetOrCreateFingerprint` 调用点与 count_tokens strip 分支（净增防护）。
2. **删除 2 个纯冗余前缀 needle**（`chatGPTOAuthUpstreamModelNames` / `SumConcurrencyAnthropic`，各自的声明形态 needle 已锚定同一符号）。
3. **合并 2 对同关注点重复条目**（客户端 400 豁免谓词、下游 no-available-accounts 豁免），旧条目 rationale 的增量信息（abuse vector、incident 日期）并入保留条目，不丢信息。

### check-gateway-tk.py（升级原则 §5：软约束硬化）

- 新增**条目内卫生 lint**：同条目重复 needle / 被蕴含 needle 直接 FAIL（带可操作的修复提示），防止注册表再积累空集锚点。跨条目重叠明确不 lint（见脚本 docstring）。已做注入式负向测试验证。
- **文件内容缓存**：同一 path 多条目只读一次（`gateway_service.go` 此前被读 15+ 次）。

## 验证

- `python3 scripts/sentinels/check-gateway-tk.py` PASS (231/231)
- 负向测试：注入重复/被蕴含 needle → exit 1 + 可操作报错 → 还原 PASS
- `scripts/preflight.sh` 全量 PASS（含 gateway TK sentinel registry、merge-gate parity）

sentinel-registry-reviewed
no-web-impact

🤖 Generated with [Claude Code](https://claude.com/claude-code)