### PR TITLE
fix(compliance): default-off TK gate must also suppress the admin compliance dialog

### DIFF
--- a/backend/internal/server/middleware/admin_compliance_test.go
+++ b/backend/internal/server/middleware/admin_compliance_test.go
@@ -45,7 +45,14 @@ func (r *complianceGuardRepoStub) Delete(ctx context.Context, key string) error 
 
 func TestAdminComplianceGuardBlocksAdminRouteWhenMissing(t *testing.T) {
 	gin.SetMode(gin.TestMode)
-	svc := service.NewSettingService(&complianceGuardRepoStub{}, &config.Config{})
+	// TK: the ack requirement is now a single gate-aware decision in
+	// GetAdminComplianceStatus (default-off override, see
+	// service/admin_compliance_tk_gate.go). The upstream guard only blocks once
+	// the gate is enabled — in production it is always wrapped by
+	// TkAdminComplianceGuardIfEnabled, which skips the guard entirely when off.
+	svc := service.NewSettingService(&complianceGuardRepoStub{
+		values: map[string]string{service.SettingKeyTkAdminComplianceGateEnabled: "true"},
+	}, &config.Config{})
 	router := gin.New()
 	router.Use(func(c *gin.Context) {
 		c.Set(string(ContextKeyUser), AuthSubject{UserID: 1})

--- a/backend/internal/service/admin_compliance.go
+++ b/backend/internal/service/admin_compliance.go
@@ -104,6 +104,20 @@ func (s *SettingService) GetAdminComplianceStatus(ctx context.Context, adminUser
 		return status, nil
 	}
 
+	// TK: the admin compliance acknowledgement is setting-gated and default-off
+	// (see admin_compliance_tk_gate.go). The frontend dialog is driven solely by
+	// status.Required, and this status endpoint is intentionally NOT wrapped by
+	// TkAdminComplianceGuardIfEnabled (it must stay reachable so the dialog can
+	// load). Without this check the dialog would block the admin console even on
+	// fleet nodes where the gate is disabled — exactly the regression that shipped
+	// when the upstream feature first merged. When the gate is off the
+	// acknowledgement is simply not required; the upstream ack flow below runs
+	// only once an operator opts the node in.
+	if !s.IsTkAdminComplianceGateEnabled(ctx) {
+		status.Required = false
+		return status, nil
+	}
+
 	raw, err := s.settingRepo.GetValue(ctx, adminComplianceAcknowledgementKey(adminUserID))
 	if err != nil {
 		if errors.Is(err, ErrSettingNotFound) {

--- a/backend/internal/service/admin_compliance_test.go
+++ b/backend/internal/service/admin_compliance_test.go
@@ -55,7 +55,13 @@ func (r *adminComplianceRepoStub) Delete(ctx context.Context, key string) error 
 }
 
 func TestAdminComplianceStatusRequiresAckWhenMissing(t *testing.T) {
-	svc := NewSettingService(&adminComplianceRepoStub{}, &config.Config{})
+	// TK: the upstream always-required semantics only apply once an operator
+	// opts the node in via tk_admin_compliance_gate_enabled=true (default-off
+	// override, see admin_compliance_tk_gate.go). Gate-off behavior is covered
+	// in admin_compliance_tk_gate_test.go.
+	svc := NewSettingService(&adminComplianceRepoStub{
+		values: map[string]string{SettingKeyTkAdminComplianceGateEnabled: "true"},
+	}, &config.Config{})
 
 	status, err := svc.GetAdminComplianceStatus(context.Background(), 1)
 	require.NoError(t, err)
@@ -78,7 +84,11 @@ func TestAcceptAdminComplianceRejectsWrongPhrase(t *testing.T) {
 }
 
 func TestAcceptAdminCompliancePersistsCurrentVersion(t *testing.T) {
-	repo := &adminComplianceRepoStub{}
+	// TK: gate enabled so the post-accept GetAdminComplianceStatus reads back the
+	// persisted acknowledgement instead of short-circuiting on the default-off gate.
+	repo := &adminComplianceRepoStub{
+		values: map[string]string{SettingKeyTkAdminComplianceGateEnabled: "true"},
+	}
 	svc := NewSettingService(repo, &config.Config{})
 
 	status, err := svc.AcceptAdminCompliance(context.Background(), AdminComplianceAcceptInput{
@@ -104,7 +114,10 @@ func TestAdminComplianceStatusRequiresAckOnOldVersion(t *testing.T) {
 	old, err := json.Marshal(AdminComplianceAcknowledgement{Version: "v2026.01.01"})
 	require.NoError(t, err)
 	svc := NewSettingService(&adminComplianceRepoStub{
-		values: map[string]string{adminComplianceAcknowledgementKey(1): string(old)},
+		values: map[string]string{
+			SettingKeyTkAdminComplianceGateEnabled: "true",
+			adminComplianceAcknowledgementKey(1):   string(old),
+		},
 	}, &config.Config{})
 
 	status, err := svc.GetAdminComplianceStatus(context.Background(), 1)
@@ -120,7 +133,10 @@ func TestAdminComplianceStatusIsPerAdminUser(t *testing.T) {
 	})
 	require.NoError(t, err)
 	svc := NewSettingService(&adminComplianceRepoStub{
-		values: map[string]string{adminComplianceAcknowledgementKey(1): string(current)},
+		values: map[string]string{
+			SettingKeyTkAdminComplianceGateEnabled: "true",
+			adminComplianceAcknowledgementKey(1):   string(current),
+		},
 	}, &config.Config{})
 
 	statusForUserOne, err := svc.GetAdminComplianceStatus(context.Background(), 1)

--- a/backend/internal/service/admin_compliance_tk_gate_test.go
+++ b/backend/internal/service/admin_compliance_tk_gate_test.go
@@ -1,0 +1,78 @@
+package service
+
+import (
+	"context"
+	"encoding/json"
+	"testing"
+
+	"github.com/Wei-Shaw/sub2api/internal/config"
+	"github.com/stretchr/testify/require"
+)
+
+// These cover the TokenKey default-off override of the upstream admin
+// compliance gate (see admin_compliance_tk_gate.go). The regression they guard:
+// the frontend dialog is driven solely by GetAdminComplianceStatus().Required,
+// and that status endpoint is NOT wrapped by the middleware gate, so without the
+// gate check in GetAdminComplianceStatus the dialog blocks the console even when
+// the gate is disabled.
+
+func TestAdminComplianceStatusNotRequiredWhenGateDisabledByDefault(t *testing.T) {
+	// No tk_admin_compliance_gate_enabled setting and no acknowledgement: the
+	// default-off gate must report the ack as not required so the dialog stays hidden.
+	svc := NewSettingService(&adminComplianceRepoStub{}, &config.Config{})
+
+	status, err := svc.GetAdminComplianceStatus(context.Background(), 1)
+	require.NoError(t, err)
+	require.False(t, status.Required)
+	require.Nil(t, status.Acknowledgement)
+}
+
+func TestAdminComplianceStatusNotRequiredWhenGateExplicitlyFalse(t *testing.T) {
+	svc := NewSettingService(&adminComplianceRepoStub{
+		values: map[string]string{SettingKeyTkAdminComplianceGateEnabled: "false"},
+	}, &config.Config{})
+
+	status, err := svc.GetAdminComplianceStatus(context.Background(), 1)
+	require.NoError(t, err)
+	require.False(t, status.Required)
+}
+
+func TestAdminComplianceStatusRequiredWhenGateEnabledWithoutAck(t *testing.T) {
+	svc := NewSettingService(&adminComplianceRepoStub{
+		values: map[string]string{SettingKeyTkAdminComplianceGateEnabled: "true"},
+	}, &config.Config{})
+
+	status, err := svc.GetAdminComplianceStatus(context.Background(), 1)
+	require.NoError(t, err)
+	require.True(t, status.Required)
+}
+
+func TestAdminComplianceStatusRespectsAckWhenGateEnabled(t *testing.T) {
+	current, err := json.Marshal(AdminComplianceAcknowledgement{
+		Version:     AdminComplianceVersion,
+		AdminUserID: 1,
+	})
+	require.NoError(t, err)
+	svc := NewSettingService(&adminComplianceRepoStub{
+		values: map[string]string{
+			SettingKeyTkAdminComplianceGateEnabled: "true",
+			adminComplianceAcknowledgementKey(1):   string(current),
+		},
+	}, &config.Config{})
+
+	status, err := svc.GetAdminComplianceStatus(context.Background(), 1)
+	require.NoError(t, err)
+	require.False(t, status.Required)
+	require.NotNil(t, status.Acknowledgement)
+}
+
+func TestIsAdminComplianceAcknowledgedTrueWhenGateDisabled(t *testing.T) {
+	// Defense in depth: even though the middleware guard is skipped entirely when
+	// the gate is off, the acknowledgement predicate must not report a missing ack
+	// as un-acknowledged for a disabled gate.
+	svc := NewSettingService(&adminComplianceRepoStub{}, &config.Config{})
+
+	ok, err := svc.IsAdminComplianceAcknowledged(context.Background(), 1)
+	require.NoError(t, err)
+	require.True(t, ok)
+}


### PR DESCRIPTION
## 问题

prod（`api.tokenkey.dev/admin/*`，1.7.93）任何管理员登录后被「部署与运营合规确认」弹窗（协议版本 v2026.06.10）强制盖死整个控制台，硬刷新也甩不掉。

## 根因

upstream 的 admin compliance gate（随 #721 合入）有**两条独立路径**：

1. **后端 423 拦截** — middleware `AdminComplianceGuard`，TokenKey 已用 `TkAdminComplianceGuardIfEnabled` 包成 default-off（`tk_admin_compliance_gate_enabled`）。
2. **前端弹窗显示** — 由 `GET /api/v1/admin/compliance` 返回的 `required` 字段驱动；该 status endpoint **故意不被 gate 包**（必须可达才能加载弹窗）。

TK 的 default-off override 只覆盖了路径 1，`GetAdminComplianceStatus` **完全不查 gate**，无 ack 时永远返回 `required=true`。于是 prod（gate 关闭、零 ack）后端拦截是 no-op，但前端弹窗照弹。`cmd+shift+r` 无效，因为 `required` 来自 API 而非浏览器缓存。

**prod 只读实测佐证**：`tk_admin_compliance_gate_enabled` 缺省（default-off）、`admin_compliance_acknowledgement*` 零条记录、镜像 `1.7.93` 含 #721 override —— 三者自洽，弹窗仍出现，确认是 override 不完整。

## 修复

`GetAdminComplianceStatus` 现在咨询 `IsTkAdminComplianceGateEnabled`：gate 关闭时直接返回 `required=false`。前端弹窗与后端拦截共用**同一个 gate-aware 判定**。Defense in depth：upstream guard 用的 `IsAdminComplianceAcknowledged` 谓词也随之 gate-aware，避免将来有人直接挂 `AdminComplianceGuard` 漏掉 TK 包装时复活封锁。

行为矩阵：

| gate | ack | required（修复后） |
|---|---|---|
| off（默认） | — | **false**（弹窗不显示） |
| on | 无 | true |
| on | 当前版本 | false |
| on | 旧版本 | true |

## 测试

- `backend/internal/service/admin_compliance_tk_gate_test.go`（新增）：覆盖 gate 缺省 / 显式 false / 开启无 ack / 开启有 ack，以及 `IsAdminComplianceAcknowledged` 在 gate-off 时为 true。
- 适配 4 个 upstream service 测试 + 1 个 upstream middleware 测试：always-required 语义现在显式开 gate 验证（不是删测试，是反映 TK override 后的默认变化）。
- `go test -tags=unit ./...` 全绿；`golangci-lint run` 改动包 0 issues；preflight PASS。

## 合规

- 改了 upstream-shaped 文件 `admin_compliance.go`（thin injection：一个 gate-aware early-return + 注释），commit 带 `upstream-touch-guarded`。
- 纯 backend 改动（前端代码未动，前端行为由 API 自动恢复），commit 带 `no-web-impact`。
- 无 upstream symbol 删除（§5.x 不适用）。

合并方式：**Squash and merge**（TK-originated fix，§5.y）。
