### PR TITLE
fix(anthropic): 529 扇出收敛(同文案熔断扩529 + handle529接tier阶梯) + 自愈类临时冷却摘要默认关

### DIFF
--- a/backend/internal/service/account_incident_notifier_tk.go
+++ b/backend/internal/service/account_incident_notifier_tk.go
@@ -219,6 +219,13 @@ func (n *TKAccountIncidentNotifier) NotifyAccountIncident(account *Account, unti
 	if !cls.alert {
 		return
 	}
+	if cls.kind == IncidentKindTemporaryCooldown && !n.temporaryDigestEnabled() {
+		// 自愈类临时冷却摘要默认关（opt-in）：不记恢复台账、不入 digest buffer、不发摘要。
+		// 临时冷却卡片本身已写明 until，自愈静默即可。池级全不可调度 P0
+		// （NotifyPlatformPoolExhausted）、永久失效 P0（handlePermanent）、永久恢复绿卡
+		// 走不同路径，恒发不受影响。设 feishu.account_incident_digest_seconds 为正数即恢复。
+		return
+	}
 	n.trackActive(account, cls, until)
 	d := ""
 	if len(detail) > 0 {
@@ -384,6 +391,21 @@ func (n *TKAccountIncidentNotifier) pruneStaleActive() {
 			delete(n.recoverySentAt, id)
 		}
 	}
+}
+
+// temporaryDigestEnabled 报告自愈类临时冷却摘要是否开启。opt-in 语义：仅当
+// feishu.account_incident_digest_seconds 被显式设为 > 0 才开启；默认（未配 / <=0）
+// 关闭——运营判定 529/429/temp 这类自愈橙头摘要在 provider 抖动时是噪音。池级 P0
+// 与永久失效 P0/恢复绿卡在另一条路径，恒发。设正数间隔即重新开启。
+func (n *TKAccountIncidentNotifier) temporaryDigestEnabled() bool {
+	if n == nil || n.cfgProvider == nil {
+		return false
+	}
+	cfg, err := n.cfgProvider.GetEmailNotificationConfig(context.Background())
+	if err != nil || cfg == nil {
+		return false
+	}
+	return cfg.Feishu.AccountIncidentDigestSeconds > 0
 }
 
 // digestInterval 从配置读 flush 间隔（秒）,下限 30s,缺失则兜底 600s。

--- a/backend/internal/service/account_incident_notifier_tk_test.go
+++ b/backend/internal/service/account_incident_notifier_tk_test.go
@@ -35,6 +35,14 @@ func enabledFeishuConfig() *OpsEmailNotificationConfig {
 	}
 }
 
+// disabledDigestFeishuConfig keeps Feishu on but turns the self-healing
+// temporary-cooldown digest OFF (opt-in): account_incident_digest_seconds<=0.
+func disabledDigestFeishuConfig() *OpsEmailNotificationConfig {
+	cfg := enabledFeishuConfig()
+	cfg.Feishu.AccountIncidentDigestSeconds = 0
+	return cfg
+}
+
 type blockingFeishuDoer struct {
 	mu     sync.Mutex
 	calls  int
@@ -198,6 +206,45 @@ func TestNotifyTemporaryBuffersUntilFlush(t *testing.T) {
 	n.mu.Lock()
 	require.Empty(t, n.digest)
 	n.mu.Unlock()
+}
+
+// Self-healing temporary-cooldown digest is opt-in (default off). When
+// account_incident_digest_seconds<=0, a 429/529 temp cooldown must NOT buffer,
+// NOT register an active-recovery ledger entry, and NOT send — while the
+// pool-level全不可调度 P0 and permanent-failure P0 stay on their always-fire paths.
+func TestTemporaryDigestDisabled_SilencesSelfHealingButKeepsP0(t *testing.T) {
+	doer := &blockingFeishuDoer{done: make(chan struct{}, 4)}
+	fixedNow := time.Date(2026, 6, 11, 16, 50, 0, 0, time.UTC)
+	n := newTestNotifier(&fakeIncidentConfigProvider{cfg: disabledDigestFeishuConfig()}, doer, fixedNow)
+
+	// Temporary cooldown (529) is fully silenced.
+	n.NotifyAccountIncident(testAccount(1, "cc-us3", "anthropic"), fixedNow.Add(30*time.Second), "529", IncidentKindUnknown)
+	n.mu.Lock()
+	require.Empty(t, n.digest, "disabled digest must not buffer temporary cooldowns")
+	require.Empty(t, n.active, "disabled digest must not track temporary cooldowns for recovery")
+	n.mu.Unlock()
+	n.flushDigest()
+	time.Sleep(50 * time.Millisecond)
+	require.Equal(t, 0, doer.callCount(), "no temporary digest send when disabled")
+
+	// Pool-level P0 still fires.
+	n.NotifyPlatformPoolExhausted(PlatformAnthropic, testAccount(1, "cc-us3", "anthropic"), fixedNow.Add(30*time.Second), "529")
+	select {
+	case <-doer.done:
+	case <-time.After(2 * time.Second):
+		t.Fatal("pool-exhausted P0 must still fire when digest disabled")
+	}
+	require.Equal(t, 1, doer.callCount())
+	require.Contains(t, doer.lastBody(), "平台池全不可调度")
+
+	// Permanent failure P0 still fires immediately.
+	n.NotifyAccountIncident(testAccount(2, "cc-us6", "anthropic"), time.Time{}, "auth_error", IncidentKindUnknown)
+	select {
+	case <-doer.done:
+	case <-time.After(2 * time.Second):
+		t.Fatal("permanent P0 must still fire when digest disabled")
+	}
+	require.Equal(t, 2, doer.callCount())
 }
 
 func TestModelClassCooldownDetailSubdividesDigest(t *testing.T) {

--- a/backend/internal/service/gateway_service_tk_request_owned_429.go
+++ b/backend/internal/service/gateway_service_tk_request_owned_429.go
@@ -26,14 +26,17 @@ import (
 //     429 is short-circuited on the FIRST hop — the original upstream body is
 //     passed through to the caller (so a prod mirror hop can re-classify the
 //     same phrase), no account penalty, no failover.
-//  2. Same-text circuit breaker (tkAnthropic429SameTextThreshold): for future
-//     deterministic 429 variants we cannot enumerate, identical 429 message
-//     text from N distinct accounts within ONE request is judged
+//  2. Same-text circuit breaker (tkAnthropic429SameTextThreshold): for
+//     deterministic error variants we cannot enumerate, identical upstream
+//     message text from N distinct accounts within ONE request is judged
 //     request-owned — stop the fan-out, skip side effects from that hop on.
 //     Legitimate per-account rate limits rarely repeat the exact same body
 //     text N times in a single failover chain; genuine multi-account burn is
-//     surfaced to the client as the 429 it is (with the real upstream text)
-//     instead of poisoning the remaining pool.
+//     surfaced to the client as the error it is (with the real upstream text)
+//     instead of poisoning the remaining pool. The breaker is status-
+//     generalized to 429 AND 529 (see tkHandleAnthropicRequestOwned429): the
+//     06:44 UTC 429 incident recurred on 529 during the 16:42–17:03 UTC
+//     Anthropic-wide overload event because this breaker was 429-only.
 //
 // Body passthrough is load-bearing: the prod ↔ edge mirror topology relays the
 // edge's response body to prod, so preserving the original phrase is what lets
@@ -91,10 +94,18 @@ func tkNoteAnthropic429Text(c *gin.Context, normalizedMsg string) int {
 }
 
 // tkHandleAnthropicRequestOwned429 short-circuits a request-owned anthropic
-// 429: it writes the ORIGINAL upstream status + body through to the client
-// (preserving the policy phrase for the next mirror hop), records ops
-// telemetry, and returns handled=true so the caller skips account side
-// effects and failover. Returns handled=false for everything else.
+// 429 OR a same-text-fanned 529: it writes the ORIGINAL upstream status + body
+// through to the client (preserving the policy phrase for the next mirror hop),
+// records ops telemetry, and returns handled=true so the caller skips account
+// side effects and failover. Returns handled=false for everything else.
+//
+// 529 coverage (prod 2026-06-11 16:42–17:03 UTC Anthropic-wide overload event):
+// the same-text breaker is status-generalized so an identical 529 "overloaded"
+// text fanned across one request's failover chain stops poisoning the rest of a
+// multi-account pool — failing over more during a provider-wide overload is
+// pointless and cools every account. There is no request-owned PHRASE for 529
+// (overload is provider state, not a request property), so 529 only ever takes
+// the same-text path, never the known-phrase first-hop short-circuit.
 //
 // Call sites are the anthropic failover branches of Forward /
 // forwardAnthropicAPIKeyPassthroughWithInput, after the error body has been
@@ -103,7 +114,10 @@ func (s *GatewayService) tkHandleAnthropicRequestOwned429(c *gin.Context, accoun
 	if c == nil || account == nil || resp == nil {
 		return nil, nil, false
 	}
-	if resp.StatusCode != http.StatusTooManyRequests || account.Platform != PlatformAnthropic {
+	// 529 (overloaded) joins 429 here; both are in shouldFailoverUpstreamError so
+	// both reach these call sites. http has no 529 constant — match the literal
+	// the rest of the codebase uses.
+	if (resp.StatusCode != http.StatusTooManyRequests && resp.StatusCode != 529) || account.Platform != PlatformAnthropic {
 		return nil, nil, false
 	}
 	upstreamMsg := strings.TrimSpace(extractUpstreamErrorMessage(respBody))
@@ -136,9 +150,13 @@ func (s *GatewayService) tkHandleAnthropicRequestOwned429(c *gin.Context, accoun
 		reason = fmt.Sprintf("same_text_x%d", occurrences)
 	}
 	logger.LegacyPrintf("service.gateway",
-		"[RequestOwned429] short-circuit (reason=%s): Account=%d(%s) RequestID=%s Msg=%s",
-		reason, account.ID, account.Name, resp.Header.Get("x-request-id"), truncateString(upstreamMsg, 300))
+		"[RequestOwned429] short-circuit (status=%d reason=%s): Account=%d(%s) RequestID=%s Msg=%s",
+		resp.StatusCode, reason, account.ID, account.Name, resp.Header.Get("x-request-id"), truncateString(upstreamMsg, 300))
 
+	kind := "request_owned_429"
+	if resp.StatusCode == 529 {
+		kind = "request_owned_529"
+	}
 	setOpsUpstreamError(c, resp.StatusCode, upstreamMsg, "")
 	appendOpsUpstreamError(c, OpsUpstreamErrorEvent{
 		Platform:           account.Platform,
@@ -146,7 +164,7 @@ func (s *GatewayService) tkHandleAnthropicRequestOwned429(c *gin.Context, accoun
 		AccountName:        account.Name,
 		UpstreamStatusCode: resp.StatusCode,
 		UpstreamRequestID:  resp.Header.Get("x-request-id"),
-		Kind:               "request_owned_429",
+		Kind:               kind,
 		Message:            upstreamMsg,
 	})
 
@@ -154,8 +172,19 @@ func (s *GatewayService) tkHandleAnthropicRequestOwned429(c *gin.Context, accoun
 	if ra := strings.TrimSpace(resp.Header.Get("Retry-After")); ra != "" {
 		c.Header("Retry-After", ra)
 	}
+	// Pass the ORIGINAL upstream status through (was hardcoded 429): a 529 must
+	// reach the client as 529 so the prod mirror hop re-classifies it as overload,
+	// not rate-limit. Empty-body fallback is keyed by status.
 	if len(respBody) > 0 {
-		c.Data(http.StatusTooManyRequests, "application/json", respBody)
+		c.Data(resp.StatusCode, "application/json", respBody)
+	} else if resp.StatusCode == 529 {
+		c.JSON(529, gin.H{
+			"type": "error",
+			"error": gin.H{
+				"type":    "overloaded_error",
+				"message": "Upstream service overloaded, please retry later",
+			},
+		})
 	} else {
 		c.JSON(http.StatusTooManyRequests, gin.H{
 			"type": "error",
@@ -167,7 +196,7 @@ func (s *GatewayService) tkHandleAnthropicRequestOwned429(c *gin.Context, accoun
 	}
 
 	if upstreamMsg == "" {
-		return nil, fmt.Errorf("upstream error: 429 request-owned (%s)", reason), true
+		return nil, fmt.Errorf("upstream error: %d request-owned (%s)", resp.StatusCode, reason), true
 	}
-	return nil, fmt.Errorf("upstream error: 429 request-owned (%s) message=%s", reason, upstreamMsg), true
+	return nil, fmt.Errorf("upstream error: %d request-owned (%s) message=%s", resp.StatusCode, reason, upstreamMsg), true
 }

--- a/backend/internal/service/gateway_service_tk_request_owned_429_test.go
+++ b/backend/internal/service/gateway_service_tk_request_owned_429_test.go
@@ -120,6 +120,40 @@ func TestTkHandleAnthropicRequestOwned429_CapacityEnvelopesExempt(t *testing.T) 
 	}
 }
 
+func anthropicStatusResponse(status int, body string) *http.Response {
+	return &http.Response{
+		StatusCode: status,
+		Header:     http.Header{},
+		Body:       io.NopCloser(strings.NewReader(body)),
+	}
+}
+
+// Incident 2026-06-11 16:42–17:03 UTC (Anthropic-wide overload event): the
+// same-text breaker is status-generalized to 529. An identical "overloaded"
+// 529 text fanned across one request's failover chain must trip the breaker at
+// the Nth occurrence AND be written back to the client AS 529 — not rewritten
+// to 429 — so the prod mirror hop re-classifies it as overload, not rate-limit.
+func TestTkHandleAnthropicRequestOwned429_Overloaded529SameTextBreaker(t *testing.T) {
+	c, rec := newRequestOwned429TestContext(t)
+	svc := &GatewayService{}
+	body := `{"type":"error","error":{"type":"overloaded_error","message":"Overloaded"}}`
+
+	for i := 1; i < tkAnthropic429SameTextThreshold; i++ {
+		account := &Account{ID: int64(i), Platform: PlatformAnthropic, Type: AccountTypeAPIKey}
+		_, _, handled := svc.tkHandleAnthropicRequestOwned429(c, account, anthropicStatusResponse(529, body), []byte(body))
+		require.False(t, handled, "529 occurrence %d must keep normal failover semantics", i)
+	}
+
+	last := &Account{ID: 99, Platform: PlatformAnthropic, Type: AccountTypeAPIKey}
+	_, err, handled := svc.tkHandleAnthropicRequestOwned429(c, last, anthropicStatusResponse(529, body), []byte(body))
+	require.True(t, handled, "identical 529 text at threshold must trip the breaker")
+	require.Error(t, err)
+	var failoverErr *UpstreamFailoverError
+	require.False(t, errors.As(err, &failoverErr), "tripped 529 must not fan out further")
+	require.Equal(t, 529, rec.Code, "529 must pass through as 529, not be rewritten to 429")
+	require.Contains(t, rec.Body.String(), "Overloaded")
+}
+
 func TestTkHandleAnthropicRequestOwned429_ScopeGuards(t *testing.T) {
 	c, _ := newRequestOwned429TestContext(t)
 	svc := &GatewayService{}

--- a/backend/internal/service/openai_oauth_passthrough_test.go
+++ b/backend/internal/service/openai_oauth_passthrough_test.go
@@ -851,7 +851,9 @@ func TestOpenAIGatewayService_OpenAIPassthrough_429And529TriggerFailover(t *test
 			assertRepo: func(t *testing.T, repo *openAIPassthroughFailoverRepo, start time.Time) {
 				require.Empty(t, repo.rateLimitCalls)
 				require.Len(t, repo.overloadCalls, 1)
-				require.WithinDuration(t, start.Add(10*time.Minute), repo.overloadCalls[0], 5*time.Second)
+				// 529 without Retry-After now gets the 30s tier-0 floor, not flat 10min
+				// (amplifier removal, 2026-06-11). Sustained 529 escalates via the 3/3 ladder.
+				require.WithinDuration(t, start.Add(anthropicCooldownTierLadder[0]), repo.overloadCalls[0], 5*time.Second)
 			},
 		},
 		{
@@ -876,7 +878,9 @@ func TestOpenAIGatewayService_OpenAIPassthrough_429And529TriggerFailover(t *test
 			assertRepo: func(t *testing.T, repo *openAIPassthroughFailoverRepo, start time.Time) {
 				require.Empty(t, repo.rateLimitCalls)
 				require.Len(t, repo.overloadCalls, 1)
-				require.WithinDuration(t, start.Add(10*time.Minute), repo.overloadCalls[0], 5*time.Second)
+				// 529 without Retry-After now gets the 30s tier-0 floor, not flat 10min
+				// (amplifier removal, 2026-06-11). Sustained 529 escalates via the 3/3 ladder.
+				require.WithinDuration(t, start.Add(anthropicCooldownTierLadder[0]), repo.overloadCalls[0], 5*time.Second)
 			},
 		},
 	}

--- a/backend/internal/service/overload_cooldown_test.go
+++ b/backend/internal/service/overload_cooldown_test.go
@@ -5,6 +5,7 @@ package service
 import (
 	"context"
 	"encoding/json"
+	"net/http"
 	"testing"
 	"time"
 
@@ -186,11 +187,21 @@ func TestSetOverloadCooldownSettings_AcceptsBoundaries(t *testing.T) {
 
 // ===========================================================================
 // RateLimitService: handle529 behaviour
+//
+// Incident 2026-06-11 16:50 UTC: a single provider-wide 529 used to flat-lock
+// the (often single-account) edge pool for OverloadCooldownMinutes (default 10).
+// New semantics — single/transient 529 gets only the 30s tier-0 floor and the
+// CooldownMinutes duration role is superseded by the tier ladder; the upstream
+// Retry-After is honored when present (clamped to the ladder max). The Enabled
+// toggle is preserved. Sustained 529 escalation (30s→2m→10m) lives in
+// handleAnthropicUpstreamErrorWithOptions, exercised by the 3/3-ladder tests.
 // ===========================================================================
 
-func TestHandle529_EnabledFromDB_PausesAccount(t *testing.T) {
+func TestHandle529_NoRetryAfter_ShortFloorNotFlatTenMin(t *testing.T) {
 	accountRepo := &overloadAccountRepoStub{}
 	settingRepo := newMockSettingRepo()
+	// Even an explicit 15-min setting no longer drives a single-529 cooldown:
+	// the duration is ladder-driven. This is the amplifier removal.
 	data, _ := json.Marshal(OverloadCooldownSettings{Enabled: true, CooldownMinutes: 15})
 	settingRepo.data[SettingKeyOverloadCooldownSettings] = string(data)
 
@@ -200,11 +211,12 @@ func TestHandle529_EnabledFromDB_PausesAccount(t *testing.T) {
 
 	account := &Account{ID: 42, Platform: PlatformAnthropic, Type: AccountTypeOAuth}
 	before := time.Now()
-	svc.handle529(context.Background(), account)
+	owned := svc.handle529(context.Background(), account, http.Header{})
 
+	require.False(t, owned, "no Retry-After → not authoritative → ladder must NOT be suppressed")
 	require.Equal(t, 1, accountRepo.overloadCalls)
 	require.Equal(t, int64(42), accountRepo.lastOverloadID)
-	require.WithinDuration(t, before.Add(15*time.Minute), accountRepo.lastOverloadEnd, 2*time.Second)
+	require.WithinDuration(t, before.Add(anthropicCooldownTierLadder[0]), accountRepo.lastOverloadEnd, 2*time.Second)
 }
 
 func TestHandle529_DisabledFromDB_SkipsAccount(t *testing.T) {
@@ -218,55 +230,56 @@ func TestHandle529_DisabledFromDB_SkipsAccount(t *testing.T) {
 	svc.SetSettingService(settingSvc)
 
 	account := &Account{ID: 42, Platform: PlatformAnthropic, Type: AccountTypeOAuth}
-	svc.handle529(context.Background(), account)
+	owned := svc.handle529(context.Background(), account, http.Header{})
 
+	require.False(t, owned)
 	require.Equal(t, 0, accountRepo.overloadCalls, "should NOT pause when disabled")
 }
 
-func TestHandle529_NilSettingService_FallsBackToConfig(t *testing.T) {
-	accountRepo := &overloadAccountRepoStub{}
-	cfg := &config.Config{}
-	cfg.RateLimit.OverloadCooldownMinutes = 20
-	svc := NewRateLimitService(accountRepo, nil, cfg, nil, nil)
-	// NOT calling SetSettingService — remains nil
-
-	account := &Account{ID: 77, Platform: PlatformAnthropic, Type: AccountTypeOAuth}
-	before := time.Now()
-	svc.handle529(context.Background(), account)
-
-	require.Equal(t, 1, accountRepo.overloadCalls)
-	require.WithinDuration(t, before.Add(20*time.Minute), accountRepo.lastOverloadEnd, 2*time.Second)
-}
-
-func TestHandle529_NilSettingService_ZeroConfig_DefaultsTen(t *testing.T) {
+func TestHandle529_HonorsUpstreamRetryAfter(t *testing.T) {
 	accountRepo := &overloadAccountRepoStub{}
 	svc := NewRateLimitService(accountRepo, nil, &config.Config{}, nil, nil)
 
-	account := &Account{ID: 88, Platform: PlatformAnthropic, Type: AccountTypeOAuth}
+	account := &Account{ID: 77, Platform: PlatformAnthropic, Type: AccountTypeOAuth}
+	headers := http.Header{}
+	headers.Set("Retry-After", "120")
 	before := time.Now()
-	svc.handle529(context.Background(), account)
+	owned := svc.handle529(context.Background(), account, headers)
 
+	require.True(t, owned, "a precise Retry-After is authoritative → suppress the ladder")
 	require.Equal(t, 1, accountRepo.overloadCalls)
-	require.WithinDuration(t, before.Add(10*time.Minute), accountRepo.lastOverloadEnd, 2*time.Second)
+	require.WithinDuration(t, before.Add(120*time.Second), accountRepo.lastOverloadEnd, 2*time.Second)
 }
 
-func TestHandle529_DBReadError_FallsBackToConfig(t *testing.T) {
+func TestHandle529_ClampsExcessiveRetryAfter(t *testing.T) {
 	accountRepo := &overloadAccountRepoStub{}
-	errRepo := &errSettingRepo{readErr: context.DeadlineExceeded}
-	errRepo.data = make(map[string]string)
+	svc := NewRateLimitService(accountRepo, nil, &config.Config{}, nil, nil)
 
-	cfg := &config.Config{}
-	cfg.RateLimit.OverloadCooldownMinutes = 7
-	settingSvc := NewSettingService(errRepo, cfg)
-	svc := NewRateLimitService(accountRepo, nil, cfg, nil, nil)
-	svc.SetSettingService(settingSvc)
-
-	account := &Account{ID: 99, Platform: PlatformAnthropic, Type: AccountTypeOAuth}
+	account := &Account{ID: 78, Platform: PlatformAnthropic, Type: AccountTypeOAuth}
+	headers := http.Header{}
+	headers.Set("Retry-After", "3600") // 1h — must clamp to the ladder max (10min)
 	before := time.Now()
-	svc.handle529(context.Background(), account)
+	owned := svc.handle529(context.Background(), account, headers)
 
+	require.True(t, owned)
+	maxCooldown := anthropicCooldownTierLadder[len(anthropicCooldownTierLadder)-1]
+	require.WithinDuration(t, before.Add(maxCooldown), accountRepo.lastOverloadEnd, 2*time.Second)
+}
+
+func TestHandle529_NilSettingService_StillShortFloor(t *testing.T) {
+	accountRepo := &overloadAccountRepoStub{}
+	cfg := &config.Config{}
+	cfg.RateLimit.OverloadCooldownMinutes = 20 // legacy flat config no longer drives duration
+	svc := NewRateLimitService(accountRepo, nil, cfg, nil, nil)
+	// NOT calling SetSettingService — remains nil; fallback keeps Enabled=true.
+
+	account := &Account{ID: 88, Platform: PlatformAnthropic, Type: AccountTypeOAuth}
+	before := time.Now()
+	owned := svc.handle529(context.Background(), account, http.Header{})
+
+	require.False(t, owned)
 	require.Equal(t, 1, accountRepo.overloadCalls)
-	require.WithinDuration(t, before.Add(7*time.Minute), accountRepo.lastOverloadEnd, 2*time.Second)
+	require.WithinDuration(t, before.Add(anthropicCooldownTierLadder[0]), accountRepo.lastOverloadEnd, 2*time.Second)
 }
 
 // ===========================================================================

--- a/backend/internal/service/ratelimit_service.go
+++ b/backend/internal/service/ratelimit_service.go
@@ -545,12 +545,19 @@ func (s *RateLimitService) HandleUpstreamError(ctx context.Context, account *Acc
 			shouldDisable = false
 		}
 	case 529:
-		// Same rationale as 429: when handle529 successfully wrote
-		// SetOverloaded with the configured cooldown, suppress the
-		// ladder's redundant SetTempUnschedulable write.
-		overloadSet := s.handle529(ctx, account)
+		// 529 overload: handle529 writes a SHORT transient cooldown — the upstream
+		// Retry-After when present, else a 30s floor (tier-0). It returns true ONLY
+		// when it honored a precise Retry-After, in which case we suppress the
+		// ladder so that authoritative reset is not raced. The common no-Retry-
+		// After 529 returns false, so a SUSTAINED 529 storm still escalates via the
+		// existing 3/3 ladder (30s→2m→10m, slot-gated, capped at 10min) below —
+		// while single transient 529s never reach the ladder threshold and cost
+		// only the 30s floor. This replaces the legacy flat 10-min SetOverloaded
+		// that turned a single provider-wide 529 blip into a 10-min full-pool lock
+		// on single-account edges (2026-06-11 16:50 UTC全edge全宕).
+		retryAfterOwned := s.handle529(ctx, account, headers)
 		if account.Platform == PlatformAnthropic {
-			shouldDisable = s.handleAnthropicUpstreamErrorWithOptions(ctx, account, statusCode, upstreamMsg, responseBody, overloadSet)
+			shouldDisable = s.handleAnthropicUpstreamErrorWithOptions(ctx, account, statusCode, upstreamMsg, responseBody, retryAfterOwned)
 		} else {
 			shouldDisable = false
 		}
@@ -1983,17 +1990,24 @@ func persistOpenAI429PlanType(ctx context.Context, repo AccountRepository, accou
 	slog.Info("openai_429_plan_type_synced", "account_id", account.ID, "previous_plan_type", current, "plan_type", planType)
 }
 
-// handle529 处理529过载错误
-// 根据配置决定是否暂停账号调度及冷却时长
-// handle529 marks the account overloaded for the configured cooldown and
-// returns true when an exact SetOverloaded write succeeded. The return is
-// consumed by the case 529 dispatch so handleAnthropicUpstreamError can
-// skip writing a parallel SetTempUnschedulable cooldown that would only
-// race the just-written overload_until (last-write-wins) — the per-account
-// counter and tier counter still advance so a repeat 529 storm still
-// escalates the ladder. A false return means the caller should fall back
-// to the ladder write (settings disabled or Redis/DB failure).
-func (s *RateLimitService) handle529(ctx context.Context, account *Account) bool {
+// handle529 处理529过载错误：写一个【短】的瞬时过载冷却，而非旧的固定 10 分钟。
+//
+// 529 是 provider 级瞬时过载（不是某账号的健康问题）。旧实现对单次 529 直接
+// SetOverloaded(now + 10min)，把一次上游抖动放大成（常为单账号的）edge 池 10
+// 分钟全锁——这正是 tier 阶梯（30s→2m→10m，anthropicCooldownTierLadder）当年要
+// 取代的 flat 行为，而 529 是唯一还在走 flat 老路的状态码（2026-06-11 16:50 UTC
+// 七 edge 全宕）。新语义：
+//   - 上游带 Retry-After      → 采纳之（authoritative，clamp ≤ 阶梯末级 10min），
+//     返回 true 让调用方抑制阶梯写以免覆盖该精确值；
+//   - 否则（常见 529）        → 30s 地板（tier-0），返回 false —— 持续 529 风暴仍由
+//     case 529 里的 3/3 阶梯（slot 门控、capped 10min）
+//     升级；单次/少量瞬时 529 到不了阈值，只付 30s。
+//
+// 返回值语义随之从“是否写了 overload”改为“是否写了精确 Retry-After（调用方据此
+// 决定是否抑制阶梯）”。settings.Enabled 仍是 529 是否进入即时过载冷却的总开关；
+// CooldownMinutes 的定长角色被阶梯取代（沿用 2026-05-21 阶梯替换 flat 的同一杠杆），
+// 仅在 operator 显式设更大值时作为 30s 地板的上调下限保留其“想要更长 529 冷却”意图。
+func (s *RateLimitService) handle529(ctx context.Context, account *Account, headers http.Header) bool {
 	var settings *OverloadCooldownSettings
 	if s.settingService != nil {
 		var err error
@@ -2003,13 +2017,9 @@ func (s *RateLimitService) handle529(ctx context.Context, account *Account) bool
 			settings = nil
 		}
 	}
-	// 回退到配置文件
 	if settings == nil {
-		cooldown := s.cfg.RateLimit.OverloadCooldownMinutes
-		if cooldown <= 0 {
-			cooldown = 10
-		}
-		settings = &OverloadCooldownSettings{Enabled: true, CooldownMinutes: cooldown}
+		// 回退到配置文件：仅取 Enabled 语义，时长走阶梯（不再用 flat 分钟数）。
+		settings = &OverloadCooldownSettings{Enabled: true, CooldownMinutes: s.cfg.RateLimit.OverloadCooldownMinutes}
 	}
 
 	if !settings.Enabled {
@@ -2017,20 +2027,37 @@ func (s *RateLimitService) handle529(ctx context.Context, account *Account) bool
 		return false
 	}
 
-	cooldownMinutes := settings.CooldownMinutes
-	if cooldownMinutes <= 0 {
-		cooldownMinutes = 10
+	now := time.Now()
+	maxCooldown := anthropicCooldownTierLadder[len(anthropicCooldownTierLadder)-1]
+
+	var cooldown time.Duration
+	retryAfterOwned := false
+	if resetAt := parseRetryAfterResetTime(headers, now); resetAt != nil && resetAt.After(now) {
+		cooldown = resetAt.Sub(now)
+		if cooldown > maxCooldown {
+			cooldown = maxCooldown
+		}
+		retryAfterOwned = true
+	} else {
+		// 30s 瞬时地板（tier-0）。CooldownMinutes 的定长角色被阶梯彻底取代——不能拿它
+		// 当地板，否则默认值 10（DefaultOverloadCooldownSettings）会把单次 529 又锁回
+		// 10min，正是本次要消除的放大器。持续 529 由 case 529 的 3/3 阶梯升级到 10min。
+		cooldown = anthropicCooldownTierLadder[0]
 	}
 
-	until := time.Now().Add(time.Duration(cooldownMinutes) * time.Minute)
+	until := now.Add(cooldown)
 	s.notifyAccountSchedulingBlocked(account, until, "529")
 	if err := s.accountRepo.SetOverloaded(ctx, account.ID, until); err != nil {
 		slog.Warn("overload_set_failed", "account_id", account.ID, "error", err)
 		return false
 	}
 
-	slog.Info("account_overloaded", "account_id", account.ID, "until", until)
-	return true
+	slog.Info("account_overloaded",
+		"account_id", account.ID,
+		"until", until,
+		"cooldown_seconds", int(cooldown.Seconds()),
+		"retry_after_owned", retryAfterOwned)
+	return retryAfterOwned
 }
 
 // UpdateSessionWindow 从成功响应更新5h窗口状态

--- a/backend/internal/service/ratelimit_service.go
+++ b/backend/internal/service/ratelimit_service.go
@@ -2004,9 +2004,12 @@ func persistOpenAI429PlanType(ctx context.Context, repo AccountRepository, accou
 //     升级；单次/少量瞬时 529 到不了阈值，只付 30s。
 //
 // 返回值语义随之从“是否写了 overload”改为“是否写了精确 Retry-After（调用方据此
-// 决定是否抑制阶梯）”。settings.Enabled 仍是 529 是否进入即时过载冷却的总开关；
-// CooldownMinutes 的定长角色被阶梯取代（沿用 2026-05-21 阶梯替换 flat 的同一杠杆），
-// 仅在 operator 显式设更大值时作为 30s 地板的上调下限保留其“想要更长 529 冷却”意图。
+// 决定是否抑制阶梯）”。settings.Enabled 仍是 529 是否进入即时过载冷却的总开关。
+// settings.CooldownMinutes 的定长角色被 tier 阶梯【彻底】取代——本函数不再读取它
+// 来定时长（沿用 2026-05-21 阶梯替换 flat 的同一杠杆）。因此 admin 的 cooldown_minutes
+// 设置目前对【冷却时长】已失效（Enabled 开关仍生效）；若 operator 需要收紧 529 冷却
+// 上限，后续应把它接成阶梯末级 cap，而非在此当地板（默认 10 会把单次 529 又锁回
+// 10min，正是本次要消除的放大器）。
 func (s *RateLimitService) handle529(ctx context.Context, account *Account, headers http.Header) bool {
 	var settings *OverloadCooldownSettings
 	if s.settingService != nil {
@@ -2018,8 +2021,9 @@ func (s *RateLimitService) handle529(ctx context.Context, account *Account, head
 		}
 	}
 	if settings == nil {
-		// 回退到配置文件：仅取 Enabled 语义，时长走阶梯（不再用 flat 分钟数）。
-		settings = &OverloadCooldownSettings{Enabled: true, CooldownMinutes: s.cfg.RateLimit.OverloadCooldownMinutes}
+		// 回退：仅需 Enabled 语义,时长走阶梯,不再读 cfg.RateLimit.OverloadCooldownMinutes
+		// 这条 flat 分钟数（CooldownMinutes 留零值,本函数也不读它定时长）。
+		settings = &OverloadCooldownSettings{Enabled: true}
 	}
 
 	if !settings.Enabled {

--- a/backend/internal/service/ratelimit_service_anthropic_consolidation_test.go
+++ b/backend/internal/service/ratelimit_service_anthropic_consolidation_test.go
@@ -22,8 +22,10 @@ import (
 //     SetTempUnschedulable so last-write-wins doesn't replace the upstream-
 //     authoritative reset time with a less-precise local cooldown. The
 //     counters still advance.
-// P3: 529 with a successful SetOverloaded write must likewise suppress the
-//     ladder cooldown write.
+// P3: 529 WITHOUT Retry-After writes only the 30s tier-0 floor and does NOT
+//     suppress the ladder, so a sustained 529 storm escalates via the ladder
+//     (amplifier removal 2026-06-11). A precise Retry-After is still authoritative
+//     and suppresses the ladder, same as 429-reset.
 // P4: A second 403 hit whose prior reason was also a 403 temp-unschedulable
 //     must escalate (tryTempUnschedulable returns false) so handle403's
 //     downstream Anthropic path runs without writing yet another 6h cooldown.
@@ -119,9 +121,15 @@ func TestRateLimitService_HandleUpstreamError_Anthropic429NoResetHeaderStillLadd
 		"third 429 without reset header MUST land the ladder cooldown — that's the only signal of a failing account")
 }
 
-// --- P3: 529 successful overload suppresses ladder cooldown -------------------
-
-func TestRateLimitService_HandleUpstreamError_Anthropic529SetOverloadedSuppressesLadder(t *testing.T) {
+// --- P3: 529 short floor, then ladder escalates on sustained ------------------
+//
+// 2026-06-11 16:50 UTC amplifier removal: a 529 WITHOUT Retry-After is no longer
+// "authoritative" — handle529 writes only the 30s tier-0 floor and does NOT
+// suppress the ladder. So a SUSTAINED 529 storm (3/3 threshold) escalates via the
+// existing ladder (SetTempUnschedulable, 30s→2m→10m), instead of being flat-
+// locked for 10 min on the first hit. (A precise Retry-After is still honored and
+// suppresses the ladder — see the 429-reset test above and the handle529 tests.)
+func TestRateLimitService_HandleUpstreamError_Anthropic529FloorThenLadderEscalates(t *testing.T) {
 	repo := &rateLimitAccountRepoStub{}
 	counter := &anthropicUpstreamErrorCounterCacheStub{
 		counts:     []int64{1, 2, 3},
@@ -145,14 +153,16 @@ func TestRateLimitService_HandleUpstreamError_Anthropic529SetOverloadedSuppresse
 			context.Background(),
 			account,
 			529,
-			http.Header{},
+			http.Header{}, // no Retry-After → 30s floor, ladder NOT suppressed
 			[]byte(`{"error":{"type":"overloaded_error","message":"upstream overloaded"}}`),
 		)
 	}
 
-	require.Equal(t, 3, repo.setOverloadedCalls, "every 529 wrote SetOverloaded")
-	require.Equal(t, 0, repo.tempCalls,
-		"ladder must NOT write SetTempUnschedulable when SetOverloaded landed")
+	require.Equal(t, 3, repo.setOverloadedCalls, "every 529 still writes the SetOverloaded floor")
+	require.Equal(t, 1, repo.tempCalls,
+		"the 3rd (threshold) 529 must escalate via the ladder — no longer suppressed when no Retry-After landed")
+	require.Equal(t, []int64{703, 703, 703}, counter.incrementIDs,
+		"3/3 short-window counter advanced on every 529")
 }
 
 // --- P4: 403 second hit escalates ---------------------------------------------

--- a/scripts/sentinels/gateway-tk.json
+++ b/scripts/sentinels/gateway-tk.json
@@ -1694,9 +1694,11 @@
         "func (n *TKAccountIncidentNotifier) trackActive(",
         "func (n *TKAccountIncidentNotifier) pruneStaleActive(",
         "TokenKey 账号恢复",
-        "n.send(title, \"green\", body,"
+        "n.send(title, \"green\", body,",
+        "func (n *TKAccountIncidentNotifier) temporaryDigestEnabled() bool",
+        "cls.kind == IncidentKindTemporaryCooldown && !n.temporaryDigestEnabled()"
       ],
-      "rationale": "账号失效 → 飞书告警的核心实现（TK-only，无上游对应）。NotifyAccountIncident 按 classifyIncident 的派生形态分流：永久失效（status=error 终态）即时单条 P0；临时冷却（429/529/...自愈）写聚合 buffer 由后台 ticker flush 成低频摘要，保住信噪比不刷屏。classifyIncident 把底层 reason 字符串映射成 (形态, 去重类, 中文文案, 运营建议)。`case \"429_model_class\"` 是 G4(#600)模型维度 cooldown 的专属分类——缺它会落兜底\"账号临时冷却\"，把 opus-only 冷却误报成整账号下线。**恢复通知（事件驱动）**：trackActive 登记活跃事件台账；NotifyAccountRecovered 在真实清除事件(ClearRateLimit/RecoverAccountState)时对此前告警过的账号发即时绿卡（`green` header），永久+临时两类都发；pruneStaleActive 静默修剪纯定时器到期(无 clear 事件)的陈旧条目、**不发卡**(按设计:定时器到期不播报)。删掉任一 anchor 会让恢复链路断裂或模型类告警回到误报兜底。整文件易在大重构/上游合并中被整体误删——删掉等于告警链路断裂。"
+      "rationale": "账号失效 → 飞书告警的核心实现（TK-only，无上游对应）。NotifyAccountIncident 按 classifyIncident 的派生形态分流：永久失效（status=error 终态）即时单条 P0；临时冷却（429/529/...自愈）写聚合 buffer 由后台 ticker flush 成低频摘要，保住信噪比不刷屏。classifyIncident 把底层 reason 字符串映射成 (形态, 去重类, 中文文案, 运营建议)。`case \"429_model_class\"` 是 G4(#600)模型维度 cooldown 的专属分类——缺它会落兜底\"账号临时冷却\"，把 opus-only 冷却误报成整账号下线。**恢复通知（事件驱动）**：trackActive 登记活跃事件台账；NotifyAccountRecovered 在真实清除事件(ClearRateLimit/RecoverAccountState)时对此前告警过的账号发即时绿卡（`green` header），永久+临时两类都发；pruneStaleActive 静默修剪纯定时器到期(无 clear 事件)的陈旧条目、**不发卡**(按设计:定时器到期不播报)。删掉任一 anchor 会让恢复链路断裂或模型类告警回到误报兜底。整文件易在大重构/上游合并中被整体误删——删掉等于告警链路断裂。**自愈摘要 opt-in 默认关（PR#730）**：temporaryDigestEnabled + NotifyAccountIncident 里 `cls.kind == IncidentKindTemporaryCooldown && !n.temporaryDigestEnabled()` 的早返门把 529/429/temp 自愈类摘要改成默认静默(feishu.account_incident_digest_seconds>0 才发)；上游合并/重构若删掉该门会让自愈类摘要回到默认刷屏，淹没真故障 P0。"
     },
     {
       "path": "backend/internal/service/ratelimit_service_tk_incident.go",
@@ -2224,17 +2226,22 @@
         "usage credits are required",
         "tkAnthropic429SameTextThreshold",
         "MarkResponseCommitted",
-        "tkSkipDownstreamNoAvailableAccountsPenalty"
+        "tkSkipDownstreamNoAvailableAccountsPenalty",
+        "resp.StatusCode != 529",
+        "c.Data(resp.StatusCode, \"application/json\", respBody)"
       ],
-      "rationale": "Companion owning the request-owned 429 classifier (known policy phrase) + same-text failover circuit breaker + ORIGINAL-body passthrough. Body passthrough is load-bearing for the prod<->edge mirror topology: preserving the upstream phrase is what lets the prod hop re-classify the relayed 429 instead of seeing a rewritten generic text the exemption predicates cannot match. The capacity-envelope exemption (tkSkipDownstreamNoAvailableAccountsPenalty / failover-exhausted / generic rewrite text) must stay wired into the breaker path: without it, identical empty-pool 429s from several edges would trip the breaker and prematurely stop legitimate cross-edge failover."
+      "rationale": "Companion owning the request-owned 429 classifier (known policy phrase) + same-text failover circuit breaker + ORIGINAL-body passthrough. Body passthrough is load-bearing for the prod<->edge mirror topology: preserving the upstream phrase is what lets the prod hop re-classify the relayed 429 instead of seeing a rewritten generic text the exemption predicates cannot match. The capacity-envelope exemption (tkSkipDownstreamNoAvailableAccountsPenalty / failover-exhausted / generic rewrite text) must stay wired into the breaker path: without it, identical empty-pool 429s from several edges would trip the breaker and prematurely stop legitimate cross-edge failover. 529 generalization (prod 2026-06-11 16:42-17:03 UTC Anthropic-wide overload): the breaker gate must keep 529 in scope ('resp.StatusCode != 529') and pass the ORIGINAL status through ('c.Data(resp.StatusCode, ...)') instead of the old hardcoded 429 — a future upstream merge reverting either anchor re-opens the 529 fan-out that PR#730 closed (a single deterministic 529 poisoning a whole multi-account pool, and the client seeing 429 instead of 529)."
     },
     {
       "path": "backend/internal/service/ratelimit_service.go",
       "must_contain": [
         "anthropic_request_owned_429_skip_penalty",
-        "tkCheckPlatformPoolExhausted"
+        "tkCheckPlatformPoolExhausted",
+        "func (s *RateLimitService) handle529(ctx context.Context, account *Account, headers http.Header) bool",
+        "cooldown = anthropicCooldownTierLadder[0]",
+        "retryAfterOwned := s.handle529(ctx, account, headers)"
       ],
-      "rationale": "Two incident-2026-06-11 guards inside upstream-owned ratelimit_service.go: (a) defense-in-depth skip in case 429 so a request-owned policy 429 never advances the anthropic ladder regardless of which caller reached HandleUpstreamError; (b) the pool-exhausted check hook on the notifyAccountSchedulingBlocked funnel — the only place that can observe the 'last schedulable account just got cooled' transition for the platform-pool P0 Feishu card."
+      "rationale": "Three incident-2026-06-11 guards inside upstream-owned ratelimit_service.go: (a) defense-in-depth skip in case 429 so a request-owned policy 429 never advances the anthropic ladder regardless of which caller reached HandleUpstreamError; (b) the pool-exhausted check hook on the notifyAccountSchedulingBlocked funnel — the only place that can observe the 'last schedulable account just got cooled' transition for the platform-pool P0 Feishu card; (c) handle529 amplifier removal (16:50 UTC全edge全宕): handle529 takes 'headers' to honor upstream Retry-After and writes only the 30s tier-0 floor ('cooldown = anthropicCooldownTierLadder[0]') instead of the legacy flat 10-min SetOverloaded, and case 529 feeds its return as skipCooldownWrite ('retryAfterOwned := s.handle529(...)') so a no-Retry-After 529 does NOT suppress the 3/3 ladder — sustained 529 still escalates while a single provider-wide blip costs only 30s. A future upstream merge reverting any anchor (dropping headers, reinstating a flat-minutes cooldown, or suppressing the ladder unconditionally) re-arms the single-account-edge 10-min lockout PR#730 fixed."
     },
     {
       "path": "backend/internal/service/account_incident_notifier_tk_pool.go",


### PR DESCRIPTION
## 背景

prod/edge **2026-06-11 16:50 UTC** 七个 edge 的 anthropic 池在 ~30s 内顺序全宕(reason=529,各薄池单账号),全冷却到 ~17:00 自愈,触发 7 条「全池不可调度」P0 + 自愈类摘要刷屏。

复盘已坐实(代码 + status.claude.com):**触发是真上游** —— Anthropic 全局 "Elevated errors across models" 事件(16:42–17:03 UTC),非单请求毒。但 TK 三处叠加把一次 20min 上游抖动放大成全 edge 10min 硬锁:

1. `handle529` 对单次 529 直接 `SetOverloaded(now + OverloadCooldownMinutes)`,**默认 flat 10min** → 单账号 edge 池一击清空(实证「过载冷却(529):1 次/1 账号」)。
2. `shouldFailoverUpstreamError` 含 529 → 沿 `cc-<edge>` 镜像链 failover 涂抹(30s 顺序倒)。
3. #725 的 request-owned 同文案熔断被钉死 **429-only**,529 完全不覆盖——那个本为"无法枚举的确定性变体"设计的结构免疫对 529 失效。

## 改动

### Layer 1 — 同文案熔断扩到 529(与 #725 同形)
`gateway_service_tk_request_owned_429.go`:状态门放开到 **429|529**,短路写回**透传原始状态码**(529 → `overloaded_error`,不再硬写 429),堵单个确定性 529 请求把多账号池扇出打满。529 无 request-owned 短语,只走同文案路径。

### Layer 2 — handle529 接入 tier 阶梯(本次单账号 edge 症状真修)
`ratelimit_service.go` `handle529` + case 529:529 不再 flat 10min。honor 上游 `Retry-After`(clamp ≤ 阶梯末级 10min);否则 **30s tier-0 地板**。持续 529 经既有 3/3 阶梯升级 `30s→2m→10m`(仅在无 Retry-After 时不抑制阶梯写,避免覆盖精确 reset)。`CooldownMinutes` 定长角色被阶梯取代(沿用 2026-05-21 阶梯替换 flat 的同一杠杆),`Enabled` 总开关保留。单账号 edge 在上游恢复后秒级回填,不再卡 10min。

### Part 2 — 自愈类临时冷却摘要默认关
`account_incident_notifier_tk.go`:`IncidentKindTemporaryCooldown` 自愈摘要(529/429/oauth401-temp/403temp/temp)改 **opt-in 默认关**(`feishu.account_incident_digest_seconds > 0` 才发)。**池级全不可调度 P0(#725)、永久失效 P0、永久恢复绿卡走不同路径,恒发不受影响。** 设正数间隔即恢复。

### Upstream-merge 覆写防护门禁(sentinel)
`scripts/sentinels/gateway-tk.json`:给上面三处新增的 load-bearing 529/自愈面补 sentinel 锚点,未来上游合并/重构若静默回退即被 `check-gateway-tk.py` 拦截(preflight + `upstream-merge-pr-shape` workflow 双触发):
- 熔断 `resp.StatusCode != 529` + `c.Data(resp.StatusCode, ...)` 透传原码;
- handle529 的 `headers` 入参签名 + `anthropicCooldownTierLadder[0]` 30s 地板 + `retryAfterOwned := s.handle529(...)`;
- `temporaryDigestEnabled` + 自愈类早返门。

## 自审 (xj-review) 修复
- **R-001 (medium, 已修)**:handle529 注释原称 `CooldownMinutes` 作 30s 地板上调下限,但代码已彻底不读它定时长(文档与代码各讲一遍 + 死赋值)→ 注释诚实化、去死赋值。
- **R-002 (low, 已知限制 / 建议独立 PR)**:本 PR 使 admin `cooldown_minutes` 旋钮对**时长**失效(`Enabled` 仍生效)。未半接(只 cap Retry-After 不 cap 阶梯会更糟)。已在码内 + sentinel rationale 文档化;后续应把它接成阶梯末级 cap 或从 admin UI 退役。

## 测试
- `gateway_service_tk_request_owned_429_test.go`:529 同文案第 3 次熔断、写回 **529**(非 429)、不 fan out。
- `overload_cooldown_test.go`:无 Retry-After→30s 地板(非 10min)、Retry-After 采纳+clamp、`Enabled=false` 仍忽略、返回值语义。
- `ratelimit_service_anthropic_consolidation_test.go`:持续 529 经 3/3 阶梯升级(不再被抑制)。
- `account_incident_notifier_tk_test.go`:digest 禁用下 temp 不入 buffer/不记台账/不发,池级 P0 + 永久 P0 仍发。
- 更新旧 flat-10min 断言的 4 个 handle529 + 2 个 passthrough 529 单测。
- `go test -tags=unit ./...` 全绿,`golangci-lint` 0 issues,`go build ./...` 通过,gateway-tk 235 entries sentinel intact,`preflight` PASS。

## 合并
TK fix PR → **Squash and merge**(§5.y)。

no-web-impact
upstream-touch-guarded
