### PR TITLE
fix(newapi): upstream 欠费(Arrearage) 400 → 账号级冷却 + 即时飞书告警

### DIFF
--- a/backend/internal/service/account_incident_notifier_tk.go
+++ b/backend/internal/service/account_incident_notifier_tk.go
@@ -104,6 +104,16 @@ func classifyIncident(reason string, until time.Time, kind AccountIncidentKind) 
 		return incidentClass{true, IncidentKindTemporaryCooldown, "403", "OpenAI 403 临时冷却", "检查 IP/账号风控状态"}
 	case "temp_unschedulable", "stream_timeout_temp_unschedulable":
 		return incidentClass{true, IncidentKindTemporaryCooldown, "temp", "临时不可调度", "观察是否自愈"}
+	case "newapi_arrears":
+		// TK (prod 2026-06-12, account 60 "Qwen" / DashScope arrears): an upstream
+		// account-standing / 欠费 failure that arrives as a 400 ("Arrearage"). The
+		// account is COOLED (not hard-disabled) so a recharge auto-recovers, but
+		// the ALERT must be IMMEDIATE + actionable — arrears is persistent until a
+		// human recharges, so it must NOT fold into the #730 default-OFF temporary
+		// digest. Route it through the permanent (immediate P0 card) path with the
+		// 1h per-account dedupe so a persistently-arrears account fires at most
+		// once per window instead of one card per request.
+		return incidentClass{true, IncidentKindPermanentDisable, "newapi_arrears", "上游账号欠费", "DashScope 等上游账号欠费(Arrearage),需在对应控制台(如阿里云百炼)充值/还款;账号已临时摘出轮换,充值后冷却到期自动恢复"}
 	case "429_model_class":
 		// G4(#600)模型维度 cooldown：单模型类(如 opus)打穿 5h/7d 用量窗口,只冷却该模型类,
 		// 账号其它模型仍可调度。不能复用兜底的"账号临时冷却"——那会误报成整账号下线。

--- a/backend/internal/service/newapi_bridge_arrears_tk.go
+++ b/backend/internal/service/newapi_bridge_arrears_tk.go
@@ -1,0 +1,183 @@
+package service
+
+import (
+	"context"
+	"log/slog"
+	"strings"
+	"time"
+
+	newapitypes "github.com/QuantumNous/new-api/types"
+	"github.com/tidwall/gjson"
+)
+
+// TK: newapi fifth-platform bridge → upstream account-standing / arrears (欠费)
+// classifier + account-level penalty + immediate Feishu alert.
+//
+// Why this file exists (prod 2026-06-12, account 60 "Qwen" / Alibaba DashScope,
+// channel_type=17, base_url https://dashscope.aliyuncs.com):
+// when the upstream Alibaba account is in arrears, DashScope returns HTTP 400
+// with body
+//
+//	{"error":{"message":"Access denied, please make sure your account is in
+//	good standing. ...","type":"Arrearage","code":"Arrearage"}}
+//
+// TokenKey classifies a bridge 400 as CLIENT-induced (see
+// tkBridgePenaltyStatusEligible — 400 is excluded from the penalty allowlist
+// precisely so a malformed caller request can never cool a shared account, the
+// #617 lesson). That is correct for validation / bad-param / oversized-body
+// 400s, but an arrears 400 is an ACCOUNT-standing failure that is persistent
+// until a human recharges the upstream console. Left as a pass-through 400 the
+// dead account stays active + schedulable, every request fails identically with
+// a confusing "400 bad request", AND operators get NO alert that the Alibaba
+// account needs a recharge.
+//
+// This file closes that gap WITHOUT widening the 400 allowlist (which would
+// re-open the #617 pool-drain). It is a separate, deliberately narrow exception:
+//
+//   - Part A (penalty): the arrears signal is matched conservatively (upstream
+//     provider error code/type == "Arrearage" case-insensitive, OR message
+//     containing "account is in good standing" / "overdue" / "arrear"). On a
+//     match the account is COOLED (SetTempUnschedulable, a few minutes) — not
+//     hard-disabled — so a recharge lets it auto-recover after the cooldown
+//     expires and the account is re-probed. Cooling (not pass-through) takes the
+//     dead account out of rotation, enabling failover or a clean "no available
+//     accounts" response instead of a wall of identical 400s.
+//   - Part B (alert): the same path routes the incident through the IMMEDIATE
+//     P0 Feishu card (classifyIncident "newapi_arrears" → IncidentKindPermanent
+//     Disable), NOT the self-healing temporary-cooldown digest that #730 made
+//     default-OFF. Arrears does not self-heal — it needs a human — so it must be
+//     a visible, actionable card. Per-account dedupe (the 1h permanent-dedupe
+//     window inside handlePermanent) keeps a persistently-arrears account from
+//     spamming one card per request.
+//
+// Narrowness is the whole point: a false positive cools + alerts on a healthy
+// account, so the matcher must NEVER fire on a generic / legitimate client 400.
+
+// tkBridgeArrearsCooldownDuration is the account-level cooldown applied on an
+// upstream arrears 400. A few minutes: long enough to take the dead account out
+// of rotation and stop the identical-400 wall, short enough that a fresh
+// recharge auto-recovers on the next re-probe without admin intervention. The
+// immediate Feishu card is what actually prompts the human recharge; the
+// cooldown is just the stop-the-bleeding rotation removal.
+const tkBridgeArrearsCooldownDuration = 5 * time.Minute
+
+// tkBridgeArrearsIncidentReason is the stable reason string classifyIncident
+// maps to the immediate "上游账号欠费" P0 card (NOT the temporary digest).
+const tkBridgeArrearsIncidentReason = "newapi_arrears"
+
+// tkIsBridgeUpstreamArrears reports whether a bridge upstream error is an
+// account-standing / arrears (欠费) signal that warrants an account-level
+// penalty + immediate alert. It inspects the synthesized OpenAI-style envelope
+// (tkBridgeUpstreamErrorBody) because RelayErrorHandler stores the DashScope
+// error.message / error.type / error.code inside NewAPIError.RelayError, which
+// only ToOpenAIError() faithfully projects (NewAPIError.Error() returns the bare
+// error code when the underlying Err is nil).
+//
+// Match ONLY the account-standing signal — provider error code/type ==
+// "arrearage" (case-insensitive), OR message containing one of the
+// account-standing phrases. Generic invalid_request_error / bad-param / oversize
+// 400s carry none of these and must fall through to the client unchanged.
+func tkIsBridgeUpstreamArrears(apiErr *newapitypes.NewAPIError) bool {
+	if apiErr == nil {
+		return false
+	}
+	// Conservative status gate: arrears is the 400 (and occasionally 403) shape
+	// for the DashScope/百炼 "account in arrears" verdict. Never let a 5xx
+	// upstream outage or a 429 rate-limit reach this account-standing matcher.
+	switch apiErr.StatusCode {
+	case 400, 403:
+	default:
+		return false
+	}
+	body := tkBridgeUpstreamErrorBody(apiErr)
+	if len(body) == 0 {
+		return false
+	}
+	code := strings.ToLower(strings.TrimSpace(gjson.GetBytes(body, "error.code").String()))
+	typ := strings.ToLower(strings.TrimSpace(gjson.GetBytes(body, "error.type").String()))
+	if code == "arrearage" || typ == "arrearage" {
+		return true
+	}
+	msg := strings.ToLower(gjson.GetBytes(body, "error.message").String())
+	if msg == "" {
+		return false
+	}
+	for _, marker := range []string{
+		"account is in good standing", // DashScope arrears verbatim phrase
+		"overdue",                     // overdue-payment
+		"arrear",                      // arrears / arrearage (substring)
+	} {
+		if strings.Contains(msg, marker) {
+			return true
+		}
+	}
+	return false
+}
+
+// tkBridgeArrearsDetail synthesizes the Feishu card 详情 line: the upstream code
+// ("Arrearage") plus the truncated upstream message, so operators see WHICH
+// upstream account-standing verdict fired without querying the DB.
+func tkBridgeArrearsDetail(apiErr *newapitypes.NewAPIError) string {
+	if apiErr == nil {
+		return ""
+	}
+	body := tkBridgeUpstreamErrorBody(apiErr)
+	code := strings.TrimSpace(gjson.GetBytes(body, "error.code").String())
+	if code == "" {
+		code = strings.TrimSpace(gjson.GetBytes(body, "error.type").String())
+	}
+	msg := strings.TrimSpace(gjson.GetBytes(body, "error.message").String())
+	if code == "" && msg == "" {
+		return ""
+	}
+	head := "Arrearage"
+	if code != "" {
+		head = "Arrearage (upstream code=" + code + ")"
+	}
+	if msg == "" {
+		return head
+	}
+	return head + ": " + truncateForLog([]byte(msg), 256)
+}
+
+// tkHandleBridgeArrearsPenalty applies the account-level penalty for an upstream
+// arrears 400 and emits the immediate P0 Feishu alert. Returns true when it
+// handled the error (caller must NOT then run the generic status-allowlist
+// penalty). The account-state write survives client cancellation via
+// openAIAccountStateContext (context.WithoutCancel), like the sibling penalty.
+func tkHandleBridgeArrearsPenalty(ctx context.Context, rls *RateLimitService, account *Account, apiErr *newapitypes.NewAPIError) bool {
+	if rls == nil || account == nil || apiErr == nil {
+		return false
+	}
+	if !tkIsBridgeUpstreamArrears(apiErr) {
+		return false
+	}
+	until := time.Now().Add(tkBridgeArrearsCooldownDuration)
+	detail := tkBridgeArrearsDetail(apiErr)
+
+	stateCtx, cancel := openAIAccountStateContext(ctx)
+	defer cancel()
+
+	// Account-level cooldown (rotation removal), NOT hard-disable: a recharge
+	// auto-recovers after expiry + re-probe.
+	reasonMsg := "Upstream account arrears (" + tkBridgeArrearsIncidentReason + ")"
+	if detail != "" {
+		reasonMsg = reasonMsg + ": " + detail
+	}
+	if err := rls.accountRepo.SetTempUnschedulable(stateCtx, account.ID, until, reasonMsg); err != nil {
+		slog.Warn("newapi_bridge_arrears_set_temp_unschedulable_failed",
+			"account_id", account.ID, "error", err)
+	}
+	// Funnel: runtime-block + immediate P0 Feishu card (classifyIncident maps
+	// "newapi_arrears" → IncidentKindPermanentDisable) + pool-exhaustion check.
+	rls.notifyAccountSchedulingBlocked(account, until, tkBridgeArrearsIncidentReason, detail)
+
+	slog.Warn("newapi_bridge_upstream_arrears_penalty",
+		"account_id", account.ID,
+		"platform", account.Platform,
+		"channel_type", account.ChannelType,
+		"status_code", apiErr.StatusCode,
+		"cooldown_until", until.Format(time.RFC3339),
+	)
+	return true
+}

--- a/backend/internal/service/newapi_bridge_arrears_tk_test.go
+++ b/backend/internal/service/newapi_bridge_arrears_tk_test.go
@@ -1,0 +1,231 @@
+//go:build unit
+
+package service
+
+import (
+	"context"
+	"testing"
+	"time"
+
+	newapitypes "github.com/QuantumNous/new-api/types"
+	"github.com/stretchr/testify/require"
+)
+
+// arrearsBridgeError mirrors the real RelayErrorHandler output for a DashScope
+// arrears 400: the upstream {"error":{"message":...,"type":"Arrearage",
+// "code":"Arrearage"}} envelope is stored as a NewAPIError of errorType
+// OpenAIError with RelayError = OpenAIError{...} (via types.WithOpenAIError).
+func arrearsBridgeError(statusCode int, msg, typ, code string) *newapitypes.NewAPIError {
+	return newapitypes.WithOpenAIError(newapitypes.OpenAIError{
+		Message: msg,
+		Type:    typ,
+		Code:    code,
+	}, statusCode)
+}
+
+const dashscopeArrearsMessage = "Access denied, please make sure your account is in good standing. For details, see: https://help.aliyun.com/zh/model-studio/error-code#overdue-payment"
+
+func newQwenArrearsAccount() *Account {
+	// Mirrors prod account 60 "Qwen": fifth-platform newapi apikey account on
+	// DashScope (channel_type=17), no pool mode, no custom error codes.
+	return &Account{
+		ID:          60,
+		Name:        "Qwen",
+		Platform:    PlatformNewAPI,
+		Type:        AccountTypeAPIKey,
+		ChannelType: 17,
+	}
+}
+
+// Part A POSITIVE: the canonical DashScope Arrearage 400 (code/type == Arrearage)
+// must be classified as arrears.
+func TestTkIsBridgeUpstreamArrears_DashScopeArrearageCode(t *testing.T) {
+	err := arrearsBridgeError(400, dashscopeArrearsMessage, "Arrearage", "Arrearage")
+	require.True(t, tkIsBridgeUpstreamArrears(err))
+}
+
+// Part A POSITIVE: case-insensitive code/type, and the message-only variants
+// ("account is in good standing" / "overdue" / "arrear") all match even when the
+// provider does not surface a structured Arrearage code.
+func TestTkIsBridgeUpstreamArrears_MessageAndCaseVariants(t *testing.T) {
+	for _, tc := range []struct {
+		name string
+		err  *newapitypes.NewAPIError
+	}{
+		{"lowercase code", arrearsBridgeError(400, "x", "", "arrearage")},
+		{"lowercase type", arrearsBridgeError(400, "x", "arrearage", "")},
+		{"good standing phrase", arrearsBridgeError(400, dashscopeArrearsMessage, "invalid_request_error", "invalid")},
+		{"overdue phrase", arrearsBridgeError(400, "Your payment is overdue, please recharge.", "billing_error", "billing")},
+		{"arrear phrase", arrearsBridgeError(400, "Account in arrears.", "", "")},
+		{"403 arrears", arrearsBridgeError(403, "x", "Arrearage", "Arrearage")},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			require.True(t, tkIsBridgeUpstreamArrears(tc.err))
+		})
+	}
+}
+
+// Part A NEGATIVE: genuine client / validation / oversize 400s, model-not-found
+// 404s, rate-limit 429s and 5xx outages must NEVER be classified as arrears —
+// they carry no account-standing signal and penalizing them re-opens the #617
+// pool-drain.
+func TestTkIsBridgeUpstreamArrears_NonArrearsNeverMatch(t *testing.T) {
+	for _, tc := range []struct {
+		name string
+		err  *newapitypes.NewAPIError
+	}{
+		{"client invalid_request", arrearsBridgeError(400, "Invalid value for parameter 'temperature'", "invalid_request_error", "invalid_value")},
+		{"oversize body", arrearsBridgeError(400, "request body too large", "invalid_request_error", "request_too_large")},
+		{"bad model name", arrearsBridgeError(400, "The supported API model names are ...", "invalid_request_error", "model_not_found")},
+		{"model not found 404", arrearsBridgeError(404, "model_not_found", "not_found", "model_not_found")},
+		{"rate limit 429", arrearsBridgeError(429, "Requests rate limit exceeded", "rate_limit_error", "rate_limit")},
+		{"server 500", arrearsBridgeError(500, "internal error", "server_error", "server_error")},
+		{"nil", nil},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			require.False(t, tkIsBridgeUpstreamArrears(tc.err))
+		})
+	}
+}
+
+// Part A: an arrears 400 must COOL the account (SetTempUnschedulable, NOT
+// SetError/hard-disable) and route the incident with reason "newapi_arrears" to
+// the notifier so it fails over / surfaces "no available accounts" instead of a
+// pass-through 400.
+func TestTkHandleBridgeArrearsPenalty_CoolsAccountAndAlerts(t *testing.T) {
+	svc, repo, blocker, incidents := newBridgePenaltyTestService()
+	account := newQwenArrearsAccount()
+
+	handled := tkHandleBridgeArrearsPenalty(context.Background(), svc,
+		account, arrearsBridgeError(400, dashscopeArrearsMessage, "Arrearage", "Arrearage"))
+
+	require.True(t, handled, "arrears must be handled (not passed through)")
+	require.Equal(t, 1, repo.tempCalls, "arrears must COOL via SetTempUnschedulable")
+	require.Zero(t, repo.setErrorCalls, "arrears must NOT hard-disable (recharge auto-recovers)")
+	require.Contains(t, repo.lastTempReason, tkBridgeArrearsIncidentReason)
+
+	require.Equal(t, []string{tkBridgeArrearsIncidentReason}, blocker.reasons)
+	require.Equal(t, []string{tkBridgeArrearsIncidentReason}, incidents.reasons)
+	require.Len(t, incidents.details, 1)
+	require.Contains(t, incidents.details[0], "Arrearage", "Feishu detail must carry the upstream verdict")
+}
+
+// Part A NEGATIVE: a genuine client 400 must NOT be handled by the arrears path
+// (returns false → no cooldown, no alert).
+func TestTkHandleBridgeArrearsPenalty_ClientBadRequestNotHandled(t *testing.T) {
+	svc, repo, blocker, incidents := newBridgePenaltyTestService()
+	account := newQwenArrearsAccount()
+
+	handled := tkHandleBridgeArrearsPenalty(context.Background(), svc,
+		account, arrearsBridgeError(400, "Invalid value for parameter 'temperature'", "invalid_request_error", "invalid_value"))
+
+	require.False(t, handled)
+	require.Zero(t, repo.tempCalls)
+	require.Zero(t, repo.setErrorCalls)
+	require.Empty(t, blocker.reasons)
+	require.Empty(t, incidents.reasons)
+}
+
+// Part A integration: the bridge penalty entrypoint must route an arrears 400
+// through the arrears path (cool + alert) even though 400 is excluded from the
+// generic tkBridgePenaltyStatusEligible allowlist — i.e. the arrears exception
+// runs BEFORE the allowlist skip.
+func TestTkHandleBridgeUpstreamPenalty_ArrearsExceptionBeforeAllowlist(t *testing.T) {
+	require.False(t, tkBridgePenaltyStatusEligible(400),
+		"precondition: 400 is excluded from the generic penalty allowlist")
+
+	svc, repo, _, incidents := newBridgePenaltyTestService()
+	account := newQwenArrearsAccount()
+
+	tkHandleBridgeUpstreamPenalty(context.Background(), svc, account,
+		arrearsBridgeError(400, dashscopeArrearsMessage, "Arrearage", "Arrearage"))
+
+	require.Equal(t, 1, repo.tempCalls, "arrears 400 must cool via the exception path")
+	require.Equal(t, []string{tkBridgeArrearsIncidentReason}, incidents.reasons)
+}
+
+// Part A: the bridge penalty entrypoint must still skip a generic client 400
+// (no arrears markers) — the arrears exception must not widen the 400 allowlist.
+func TestTkHandleBridgeUpstreamPenalty_GenericClient400StillSkipped(t *testing.T) {
+	svc, repo, blocker, incidents := newBridgePenaltyTestService()
+	account := newQwenArrearsAccount()
+
+	tkHandleBridgeUpstreamPenalty(context.Background(), svc, account,
+		arrearsBridgeError(400, "Invalid value for parameter 'temperature'", "invalid_request_error", "invalid_value"))
+
+	require.Zero(t, repo.tempCalls)
+	require.Zero(t, repo.setErrorCalls)
+	require.Empty(t, blocker.reasons)
+	require.Empty(t, incidents.reasons)
+}
+
+// The penalty write must survive client cancellation (context.WithoutCancel).
+func TestTkHandleBridgeArrearsPenalty_SurvivesCanceledContext(t *testing.T) {
+	svc, repo, _, _ := newBridgePenaltyTestService()
+	account := newQwenArrearsAccount()
+
+	ctx, cancel := context.WithCancel(context.Background())
+	cancel()
+	handled := tkHandleBridgeArrearsPenalty(ctx, svc, account,
+		arrearsBridgeError(400, dashscopeArrearsMessage, "Arrearage", "Arrearage"))
+
+	require.True(t, handled)
+	require.Equal(t, 1, repo.tempCalls)
+}
+
+// nil safety: best-effort glue on the error path must never panic.
+func TestTkHandleBridgeArrearsPenalty_NilSafety(t *testing.T) {
+	svc, _, _, _ := newBridgePenaltyTestService()
+	account := newQwenArrearsAccount()
+	require.False(t, tkHandleBridgeArrearsPenalty(context.Background(), nil, account, arrearsBridgeError(400, "x", "Arrearage", "Arrearage")))
+	require.False(t, tkHandleBridgeArrearsPenalty(context.Background(), svc, nil, arrearsBridgeError(400, "x", "Arrearage", "Arrearage")))
+	require.False(t, tkHandleBridgeArrearsPenalty(context.Background(), svc, account, nil))
+}
+
+// Part B: classifyIncident must route "newapi_arrears" to the IMMEDIATE P0 card
+// (IncidentKindPermanentDisable), NOT the #730 default-OFF temporary digest, and
+// carry the actionable recharge advice + the "上游账号欠费" label.
+func TestClassifyIncident_NewAPIArrearsIsImmediateNotDigest(t *testing.T) {
+	// until is non-zero (the account is cooled, not permanently disabled), but
+	// the reason exact-match forces the immediate kind regardless of until — the
+	// alert must not self-heal-silently like a temporary cooldown.
+	cls := classifyIncident(tkBridgeArrearsIncidentReason, time.Now().Add(5*time.Minute), IncidentKindUnknown)
+	require.True(t, cls.alert)
+	require.Equal(t, IncidentKindPermanentDisable, cls.kind,
+		"arrears must use the immediate P0 path, NOT the temporary digest")
+	require.Equal(t, "上游账号欠费", cls.kindZh)
+	require.Contains(t, cls.advice, "充值")
+}
+
+// Part B: the immediate (permanent) path is per-account deduped to once-per-hour
+// window — a persistently-arrears account hitting every request must fire at
+// most one card per window. Drive handlePermanent directly (the notifier-level
+// dedupe), then assert a second hit inside the window is suppressed.
+func TestHandlePermanent_NewAPIArrearsDedupedPerAccountWindow(t *testing.T) {
+	notifier := newTKAccountIncidentNotifier(nil, "prod")
+	account := newQwenArrearsAccount()
+	cls := classifyIncident(tkBridgeArrearsIncidentReason, time.Now().Add(5*time.Minute), IncidentKindUnknown)
+
+	base := time.Now()
+	notifier.now = func() time.Time { return base }
+	notifier.handlePermanent(account, tkBridgeArrearsIncidentReason, cls, "Arrearage")
+	_, seen := notifier.permSentAt[accountIncidentDedupeKey("prod", account.ID, cls.reasonClass)]
+	require.True(t, seen, "first arrears alert must register the dedupe key")
+
+	// A second hit one minute later (inside the 1h permanent-dedupe window) must
+	// NOT update the timestamp (suppressed).
+	firstAt := notifier.permSentAt[accountIncidentDedupeKey("prod", account.ID, cls.reasonClass)]
+	notifier.now = func() time.Time { return base.Add(time.Minute) }
+	notifier.handlePermanent(account, tkBridgeArrearsIncidentReason, cls, "Arrearage")
+	require.Equal(t, firstAt, notifier.permSentAt[accountIncidentDedupeKey("prod", account.ID, cls.reasonClass)],
+		"second arrears hit inside the dedupe window must be suppressed (one card per account per window)")
+}
+
+// The arrears detail line carries the upstream Arrearage code + message for the
+// Feishu card.
+func TestTkBridgeArrearsDetail_CarriesCodeAndMessage(t *testing.T) {
+	detail := tkBridgeArrearsDetail(arrearsBridgeError(400, dashscopeArrearsMessage, "Arrearage", "Arrearage"))
+	require.Contains(t, detail, "Arrearage")
+	require.Contains(t, detail, "upstream code=Arrearage")
+	require.Empty(t, tkBridgeArrearsDetail(nil))
+}

--- a/backend/internal/service/newapi_bridge_penalty_tk.go
+++ b/backend/internal/service/newapi_bridge_penalty_tk.go
@@ -46,6 +46,15 @@ func tkHandleBridgeUpstreamPenalty(ctx context.Context, rls *RateLimitService, a
 	if rls == nil || account == nil || apiErr == nil {
 		return
 	}
+	// TK (prod 2026-06-12, account 60 "Qwen" / DashScope arrears): an upstream
+	// account-standing / arrears 400 ("Arrearage") is an ACCOUNT-level failure
+	// disguised as a client 400. It must be caught BEFORE the status allowlist
+	// below (which deliberately excludes 400 to avoid the #617 client-400
+	// pool-drain). This narrow exception cools the account + fires an immediate
+	// P0 Feishu card. See newapi_bridge_arrears_tk.go.
+	if tkHandleBridgeArrearsPenalty(ctx, rls, account, apiErr) {
+		return
+	}
 	if !tkBridgePenaltyStatusEligible(apiErr.StatusCode) {
 		return
 	}

--- a/scripts/sentinels/newapi.json
+++ b/scripts/sentinels/newapi.json
@@ -320,9 +320,28 @@
       "must_contain": [
         "tkHandleBridgeUpstreamPenalty",
         "tkWrapBridgeRelayErrorWithPenalty",
-        "tkBridgePenaltyStatusEligible"
+        "tkBridgePenaltyStatusEligible",
+        "tkHandleBridgeArrearsPenalty(ctx, rls, account, apiErr)"
       ],
-      "rationale": "TK companion that routes real bridge.Dispatch* upstream errors (401/402/429 allowlist) into RateLimitService.HandleUpstreamError so newapi accounts get disabled/cooled and the Feishu account-incident alert fires. Without it the fifth platform regresses to the 2026-06-11 prod incident: a 402 'Insufficient Balance' DeepSeek account stayed schedulable=true while the gateway hammered the exhausted upstream 6946 times in 2h with zero alerts. The narrow status allowlist is itself load-bearing: it is what keeps client-induced 400/404 (and the synthetic missing-credential/unsupported-channel 400s) from draining the pool (the #617 class)."
+      "rationale": "TK companion that routes real bridge.Dispatch* upstream errors (401/402/429 allowlist) into RateLimitService.HandleUpstreamError so newapi accounts get disabled/cooled and the Feishu account-incident alert fires. Without it the fifth platform regresses to the 2026-06-11 prod incident: a 402 'Insufficient Balance' DeepSeek account stayed schedulable=true while the gateway hammered the exhausted upstream 6946 times in 2h with zero alerts. The narrow status allowlist is itself load-bearing: it is what keeps client-induced 400/404 (and the synthetic missing-credential/unsupported-channel 400s) from draining the pool (the #617 class). The tkHandleBridgeArrearsPenalty call MUST run BEFORE the tkBridgePenaltyStatusEligible allowlist (which excludes 400): an upstream DashScope arrears 400 ('Arrearage') is an account-standing failure disguised as a client 400 and must cool+alert, not pass through. Reordering it after the allowlist (or dropping it) silently re-opens the 2026-06-12 prod incident where account 60 'Qwen' stayed schedulable with confusing 400s and no recharge alert."
+    },
+    {
+      "path": "backend/internal/service/newapi_bridge_arrears_tk.go",
+      "must_contain": [
+        "tkIsBridgeUpstreamArrears",
+        "tkHandleBridgeArrearsPenalty",
+        "tkBridgeArrearsIncidentReason",
+        "arrearage"
+      ],
+      "rationale": "TK companion implementing the narrow upstream account-standing / arrears (欠费) classifier + account-level penalty + immediate Feishu alert for the fifth platform. tkIsBridgeUpstreamArrears matches ONLY the DashScope/百炼 arrears verdict (provider code/type == 'Arrearage' case-insensitive, OR message containing 'account is in good standing' / 'overdue' / 'arrear') — never a generic client 400, which would re-open the #617 pool-drain. tkHandleBridgeArrearsPenalty cools the account (SetTempUnschedulable, NOT hard-disable, so a recharge auto-recovers) and funnels the incident through notifyAccountSchedulingBlocked with reason 'newapi_arrears'. Dropping any symbol or weakening the matcher regresses the 2026-06-12 prod incident (account 60 'Qwen' arrears → confusing pass-through 400 + no alert) or, if widened, drains the pool on legitimate client 400s."
+    },
+    {
+      "path": "backend/internal/service/account_incident_notifier_tk.go",
+      "must_contain": [
+        "case \"newapi_arrears\":",
+        "IncidentKindPermanentDisable, \"newapi_arrears\", \"上游账号欠费\""
+      ],
+      "rationale": "classifyIncident MUST map reason 'newapi_arrears' to the IMMEDIATE P0 card path (IncidentKindPermanentDisable), NOT the temporary-cooldown digest that PR #730 made default-OFF. Upstream arrears is persistent until a human recharges — it will not self-heal — so folding it into the silenced self-healing digest would mean operators never learn the upstream account needs a recharge. Re-mapping it to IncidentKindTemporaryCooldown silently regresses the 2026-06-12 alerting gap."
     },
     {
       "path": "backend/internal/service/openai_gateway_bridge_dispatch.go",


### PR DESCRIPTION
## 根因

第五平台 `newapi` 经 account 60 \"Qwen\"(`platform=newapi`, `channel_type=17`, `base_url https://dashscope.aliyuncs.com`，阿里云 DashScope/百炼)服务 Qwen。当上游阿里云账号欠费时，DashScope 返回 **HTTP 400**，body：

```json
{"error":{"message":"Access denied, please make sure your account is in good standing. For details, see: https://help.aliyun.com/zh/model-studio/error-code#overdue-payment","type":"Arrearage","code":"Arrearage"}}
```

TokenKey 把 bridge 400 一律当**客户端诱发**(跳过账号惩罚、原样透传 400，#617 防池干)。这对校验/参数/超大 body 的 400 正确，但欠费 400 是**账号级**故障：欠费/账号已死的上游仍 `active`+可调度，每个请求都报同样令人困惑的 400，运营也收不到任何\"该充值\"的告警。

## Part A — 窄账号级惩罚(newapi bridge)

新增窄分类器 `tkIsBridgeUpstreamArrears`（`backend/internal/service/newapi_bridge_arrears_tk.go`），**仅**匹配账号欠费信号：上游 `code`/`type` == `Arrearage`(不区分大小写)，或 message 含 `account is in good standing` / `overdue` / `arrear`。**绝不**命中普通客户端 400(校验/参数/超大 body)——否则重开 #617 池干。

命中后**冷却**账号(`SetTempUnschedulable` 5min，**非**硬禁用——充值后冷却到期自动恢复+再探活)，把死账号摘出轮换，让请求 failover 或干净返回 `no available accounts` 而非 400 墙。注入点在 `tkHandleBridgeUpstreamPenalty` 的 status allowlist 跳过**之前**(allowlist 故意排除 400)。

## Part B — 即时飞书告警(去重，明确不进 #730 静默摘要)

`classifyIncident` 把 reason `newapi_arrears` 映射到**即时 P0 卡片**路径(`IncidentKindPermanentDisable`)，而**非** PR #730 默认关的自愈类临时冷却摘要——欠费在人工充值前**持续存在不会自愈**，必须即时可见可执行。标签\"上游账号欠费\"，建议\"DashScope 等上游账号欠费(Arrearage)，需在对应控制台(如阿里云百炼)充值/还款；账号已临时摘出轮换\"。复用 `handlePermanent` 的每账号 1h 去重窗口，持续欠费账号每窗口至多一张卡。卡片详情携带 account id/name + platform + 上游 code `Arrearage`。

## 测试

- **Part A 正例**：`Arrearage` code/type + 大小写变体 + message 三变体(good standing / overdue / arrear) → 冷却(`tempCalls`)，**非**硬禁用(`setErrorCalls=0`)，incident reason `newapi_arrears`。
- **Part A 反例**：普通客户端 400(`invalid_request_error` / 超大 body / bad model) / 404 / 429 / 5xx → 不冷却不告警；入口 `tkHandleBridgeUpstreamPenalty` 对普通 400 仍跳过(allowlist 未被拓宽)。
- **Part B**：`classifyIncident` 即时(`IncidentKindPermanentDisable`)非摘要 + 每账号 1h 去重 + 详情携带 `Arrearage`。
- nil 安全 + 取消上下文存活(`context.WithoutCancel`)。

## markers / 隔离

全部 TK companion(`*_tk_*.go` + sentinel + test)，**未触碰任何 upstream-shaped 文件**。commit 携带 `no-web-impact` + `sentinel-registry-reviewed`。新增/扩展 3 条 `scripts/sentinels/newapi.json` 条目(arrears 文件 + penalty 注入顺序 + classifyIncident 映射)。

🤖 Generated with [Claude Code](https://claude.com/claude-code)