### PR TITLE
fix(pricing): 补 qwen2.5-coder 价 + 已服务零计费 P0 统一探针（漏算止血 + 根因②）

### DIFF
--- a/backend/internal/service/gateway_service.go
+++ b/backend/internal/service/gateway_service.go
@@ -9505,6 +9505,10 @@ func (s *GatewayService) recordUsageCore(ctx context.Context, input *recordUsage
 
 	// 创建使用日志
 	accountRateMultiplier := account.BillingRateMultiplier()
+
+	// TK 根因②：已服务但零计费统一探针（cost 已知后判定，命中发 P0 告警）。
+	s.tkNotifyServedZeroCost(cost, result, apiKey, billingModel, requestedModel, multiplier, accountRateMultiplier)
+
 	usageLog := s.buildRecordUsageLog(ctx, input, result, apiKey, user, account, subscription,
 		requestedModel, multiplier, imageMultiplier, accountRateMultiplier, billingType, cacheTTLOverridden, cost, opts)
 
@@ -9700,10 +9704,13 @@ func (s *GatewayService) calculateTokenCost(
 	}
 	if err != nil {
 		// TK (upstream Wei-Shaw/sub2api#1833 / #1544): surface pricing-missing as a
-		// structured, observable zero-cost record instead of a silent ActualCost:0
-		// leak — at parity with the OpenAI record-usage path. See
-		// recordTokenCostPricingMissing (log + Feishu pricing-missing notifier).
-		s.recordTokenCostPricingMissing(billingModel, apiKey, result, tokens, err)
+		// structured, observable zero-cost log instead of a silent ActualCost:0
+		// leak — at parity with the OpenAI record-usage path. The P0 Feishu alert
+		// is no longer fired here: it is consolidated into the result-side
+		// "served but zero cost" probe (tkNotifyServedZeroCost) at the record-usage
+		// site, which catches this error-path zero-cost AND the silent $0 paths
+		// that never error. This call keeps only the grep-able structured log.
+		logTokenCostPricingMissing(billingModel, apiKey, result, err)
 		if isUsagePricingUnavailableError(err) {
 			return &CostBreakdown{BillingMode: string(BillingModeToken)}
 		}

--- a/backend/internal/service/gateway_service_tk_billing_pricing_missing.go
+++ b/backend/internal/service/gateway_service_tk_billing_pricing_missing.go
@@ -59,31 +59,10 @@ func (s *GatewayService) SetPricingMissingNotifier(n PricingMissingNotifier) {
 	s.tkPricingMissingNotifier = n
 }
 
-// recordTokenCostPricingMissing is the single funnel entry called from
-// calculateRecordUsageCost: it keeps the structured zero-cost log (grepped by
-// ops tooling and the #675 probe cross-check) and additionally feeds the
-// pricing-missing Feishu notifier so operators get told to configure pricing
-// instead of discovering revenue leaks in logs. Service is NOT refused.
-func (s *GatewayService) recordTokenCostPricingMissing(billingModel string, apiKey *APIKey, result *ForwardResult, tokens UsageTokens, err error) {
-	logTokenCostPricingMissing(billingModel, apiKey, result, err)
-	if s == nil || s.tkPricingMissingNotifier == nil || !isUsagePricingUnavailableError(err) {
-		return
-	}
-	ev := PricingMissingEvent{
-		BillingModel: billingModel,
-		Tokens:       totalUsageTokensForPricingMissing(tokens),
-	}
-	if result != nil {
-		ev.RequestedModel = result.Model
-		ev.UpstreamModel = result.UpstreamModel
-	}
-	if apiKey != nil {
-		ev.APIKeyID = apiKey.ID
-		if apiKey.Group != nil {
-			ev.GroupID = apiKey.Group.ID
-			ev.GroupName = apiKey.Group.Name
-			ev.Platform = apiKey.Group.Platform
-		}
-	}
-	s.tkPricingMissingNotifier.NotifyPricingMissing(ev)
-}
+// Note: the former recordTokenCostPricingMissing (error-side log + Feishu notify)
+// has been consolidated. The structured log is now emitted directly via
+// logTokenCostPricingMissing at the calculateTokenCost error branch, and the
+// Feishu P0 alert moved to the result-side "served but zero cost" probe
+// (tkNotifyServedZeroCost / tkServedZeroCostReason in
+// gateway_service_tk_served_zero_cost.go), which also catches the silent $0
+// paths that never return an error.

--- a/backend/internal/service/gateway_service_tk_served_zero_cost.go
+++ b/backend/internal/service/gateway_service_tk_served_zero_cost.go
@@ -1,0 +1,107 @@
+package service
+
+import (
+	"github.com/Wei-Shaw/sub2api/internal/pkg/logger"
+	"go.uber.org/zap"
+)
+
+// TK 根因②：「已服务但零计费」统一探针。
+//
+// 背景：计价不确定时系统选择"免费放行"（unpriced never blocks），漏血默认无声。
+// 除无价模型（ErrModelPricingUnavailable，已有错误侧观测）外，还有多类静默 $0：
+// 非缺价 cost-calc 错误吞 $0、渠道/视频/per_request 无价、负倍率归零。本探针在两条
+// 计费 funnel 的记账点（cost 已知后）统一按**结果**判定（TotalCost/ActualCost），
+// 一张网罩住所有静默路径，命中即经 PricingMissingNotifier 发 P0 告警 + 结构化日志。
+// 不拒绝服务、不改金额，纯可观测性。判据见 tkServedZeroCostReason。
+
+// tkServedZeroCostReason 判定一次已记账请求是否构成"计费漏算"并给出原因。
+// billableUnits<=0（失败/空请求/count_tokens 不记账）→ 不报。
+//   - TotalCost==0（倍率前价格本身为零）→ "unpriced"：无价模型 / 渠道 $0 /
+//     视频·per_request 无价 / cost-calc 错误返回的零 CostBreakdown。
+//   - TotalCost>0 但 ActualCost==0 且倍率<0 → "negative_multiplier"：价格有效却被
+//     负倍率归零。倍率恰为 0 是合法免费分组，**不报**。
+func tkServedZeroCostReason(cost *CostBreakdown, billableUnits int64, multiplier, accountRateMultiplier float64) (string, bool) {
+	if cost == nil || billableUnits <= 0 {
+		return "", false
+	}
+	if cost.TotalCost == 0 {
+		return "unpriced", true
+	}
+	if cost.ActualCost == 0 && (multiplier < 0 || accountRateMultiplier < 0) {
+		return "negative_multiplier", true
+	}
+	return "", false
+}
+
+// tkClaudeUsageBillableUnits 估算计费单元：token 总量优先，回退图片张数。
+func tkClaudeUsageBillableUnits(u ClaudeUsage, imageCount int) int64 {
+	t := int64(u.InputTokens) + int64(u.OutputTokens) +
+		int64(u.CacheCreationInputTokens) + int64(u.CacheReadInputTokens) +
+		int64(u.ImageOutputTokens)
+	if t > 0 {
+		return t
+	}
+	if imageCount > 0 {
+		return int64(imageCount)
+	}
+	return 0
+}
+
+// tkNotifyServedZeroCost 是 anthropic 计费 funnel（recordUsageCore）的薄注入：
+// cost 已知后判定，命中即发 P0 告警 + 结构化日志。nil-safe，发送异步，绝不阻塞
+// funnel。注：Feishu 关闭时 notifier 自然 no-op，但日志始终在（ops 可 grep）。
+func (s *GatewayService) tkNotifyServedZeroCost(
+	cost *CostBreakdown, result *ForwardResult, apiKey *APIKey,
+	billingModel, requestedModel string, multiplier, accountRateMultiplier float64,
+) {
+	if s == nil || cost == nil || result == nil {
+		return
+	}
+	units := tkClaudeUsageBillableUnits(result.Usage, result.ImageCount)
+	reason, ok := tkServedZeroCostReason(cost, units, multiplier, accountRateMultiplier)
+	if !ok {
+		return
+	}
+
+	fields := []zap.Field{
+		zap.String("component", "service.gateway"),
+		zap.String("reason", reason),
+		zap.String("billing_model", billingModel),
+		zap.String("requested_model", requestedModel),
+		zap.String("upstream_model", result.UpstreamModel),
+		zap.Int64("billable_units", units),
+		zap.Float64("total_cost", cost.TotalCost),
+		zap.Float64("rate_multiplier", multiplier),
+		zap.Float64("account_rate_multiplier", accountRateMultiplier),
+	}
+	if apiKey != nil {
+		fields = append(fields, zap.Int64("api_key_id", apiKey.ID))
+		if apiKey.Group != nil {
+			fields = append(fields,
+				zap.Int64("group_id", apiKey.Group.ID),
+				zap.String("group_platform", apiKey.Group.Platform),
+			)
+		}
+	}
+	logger.L().With(fields...).Warn("gateway_usage.served_zero_cost")
+
+	if s.tkPricingMissingNotifier == nil {
+		return
+	}
+	ev := PricingMissingEvent{
+		Reason:         reason,
+		BillingModel:   billingModel,
+		RequestedModel: requestedModel,
+		UpstreamModel:  result.UpstreamModel,
+		Tokens:         units,
+	}
+	if apiKey != nil {
+		ev.APIKeyID = apiKey.ID
+		if apiKey.Group != nil {
+			ev.GroupID = apiKey.Group.ID
+			ev.GroupName = apiKey.Group.Name
+			ev.Platform = apiKey.Group.Platform
+		}
+	}
+	s.tkPricingMissingNotifier.NotifyPricingMissing(ev)
+}

--- a/backend/internal/service/openai_gateway_service.go
+++ b/backend/internal/service/openai_gateway_service.go
@@ -6120,9 +6120,8 @@ func (s *OpenAIGatewayService) RecordUsage(ctx context.Context, input *OpenAIRec
 			zap.Int64("api_key_id", apiKey.ID),
 			zap.Int64("account_id", account.ID),
 		).Warn("openai_usage.pricing_missing_record_zero_cost", zap.Error(err))
-		// TK: feed the pricing-missing Feishu notifier (see
-		// openai_gateway_service_tk_pricing_missing.go). Service is NOT refused.
-		s.notifyOpenAIPricingMissing(input, result, apiKey, billingModels, tokens)
+		// TK 根因②：错误侧不再单独 notify——已收敛到记账点的"已服务但零计费"
+		// 统一探针（tkNotifyServedZeroCost，下方），避免一次事件两张卡。日志保留。
 		cost = &CostBreakdown{BillingMode: string(BillingModeToken)}
 	}
 
@@ -6136,6 +6135,10 @@ func (s *OpenAIGatewayService) RecordUsage(ctx context.Context, input *OpenAIRec
 	// Create usage log
 	durationMs := int(result.Duration.Milliseconds())
 	accountRateMultiplier := account.BillingRateMultiplier()
+
+	// TK 根因②：已服务但零计费统一探针（cost 已知后判定，命中发 P0 告警）。
+	s.tkNotifyServedZeroCost(cost, result, apiKey, input, billingModels, actualInputTokens, multiplier, accountRateMultiplier)
+
 	requestID := resolveUsageBillingRequestID(ctx, result.RequestID)
 	if result.OpenAIWSMode {
 		if upstreamRequestID := strings.TrimSpace(result.RequestID); upstreamRequestID != "" {

--- a/backend/internal/service/openai_gateway_service_tk_pricing_missing.go
+++ b/backend/internal/service/openai_gateway_service_tk_pricing_missing.go
@@ -6,48 +6,15 @@ package service
 // observability and stays untouched). Service is NOT refused — see
 // pricing_missing_notifier_tk.go for the design rationale.
 
-// SetPricingMissingNotifier wires the pricing-missing Feishu notifier
-// post-construction so the upstream constructor signature stays unchanged.
-// nil = feature disabled.
+// SetPricingMissingNotifier wires the pricing-missing / served-zero-cost Feishu
+// notifier post-construction so the upstream constructor signature stays
+// unchanged. nil = feature disabled. The actual notify trigger lives in the
+// result-side probe (tkNotifyServedZeroCost in
+// openai_gateway_service_tk_served_zero_cost.go); the former error-side
+// notifyOpenAIPricingMissing was consolidated into it.
 func (s *OpenAIGatewayService) SetPricingMissingNotifier(n PricingMissingNotifier) {
 	if s == nil {
 		return
 	}
 	s.tkPricingMissingNotifier = n
-}
-
-// notifyOpenAIPricingMissing builds a PricingMissingEvent from the record-usage
-// context and feeds the notifier. nil-safe on every input.
-func (s *OpenAIGatewayService) notifyOpenAIPricingMissing(
-	input *OpenAIRecordUsageInput,
-	result *OpenAIForwardResult,
-	apiKey *APIKey,
-	billingModels []string,
-	tokens UsageTokens,
-) {
-	if s == nil || s.tkPricingMissingNotifier == nil {
-		return
-	}
-	ev := PricingMissingEvent{
-		BillingModel: firstUsageBillingModel(billingModels),
-		Tokens:       totalUsageTokensForPricingMissing(tokens),
-	}
-	if input != nil {
-		ev.RequestedModel = input.OriginalModel
-	}
-	if result != nil {
-		ev.UpstreamModel = result.UpstreamModel
-		if ev.RequestedModel == "" {
-			ev.RequestedModel = result.Model
-		}
-	}
-	if apiKey != nil {
-		ev.APIKeyID = apiKey.ID
-		if apiKey.Group != nil {
-			ev.GroupID = apiKey.Group.ID
-			ev.GroupName = apiKey.Group.Name
-			ev.Platform = apiKey.Group.Platform
-		}
-	}
-	s.tkPricingMissingNotifier.NotifyPricingMissing(ev)
 }

--- a/backend/internal/service/openai_gateway_service_tk_served_zero_cost.go
+++ b/backend/internal/service/openai_gateway_service_tk_served_zero_cost.go
@@ -1,0 +1,80 @@
+package service
+
+import (
+	"github.com/Wei-Shaw/sub2api/internal/pkg/logger"
+	"go.uber.org/zap"
+)
+
+// TK 根因②：openai 计费 funnel（OpenAIGatewayService.RecordUsage）的「已服务但
+// 零计费」薄注入。判据与告警同 anthropic 侧（gateway_service_tk_served_zero_cost.go
+// 的 tkServedZeroCostReason）。actualInputTokens 由调用点传入（openai 路径的输入
+// token 已剔除 cache_read，见 RecordUsage）。
+func (s *OpenAIGatewayService) tkNotifyServedZeroCost(
+	cost *CostBreakdown, result *OpenAIForwardResult, apiKey *APIKey,
+	input *OpenAIRecordUsageInput, billingModels []string,
+	actualInputTokens int, multiplier, accountRateMultiplier float64,
+) {
+	if s == nil || cost == nil || result == nil {
+		return
+	}
+	units := int64(actualInputTokens) +
+		int64(result.Usage.OutputTokens) +
+		int64(result.Usage.CacheCreationInputTokens) +
+		int64(result.Usage.CacheReadInputTokens) +
+		int64(result.Usage.ImageOutputTokens)
+	if units <= 0 && result.ImageCount > 0 {
+		units = int64(result.ImageCount)
+	}
+	reason, ok := tkServedZeroCostReason(cost, units, multiplier, accountRateMultiplier)
+	if !ok {
+		return
+	}
+
+	requested := result.Model
+	if input != nil && input.OriginalModel != "" {
+		requested = input.OriginalModel
+	}
+	billingModel := firstUsageBillingModel(billingModels)
+
+	fields := []zap.Field{
+		zap.String("component", "service.openai_gateway"),
+		zap.String("reason", reason),
+		zap.String("billing_model", billingModel),
+		zap.String("requested_model", requested),
+		zap.String("upstream_model", result.UpstreamModel),
+		zap.Int64("billable_units", units),
+		zap.Float64("total_cost", cost.TotalCost),
+		zap.Float64("rate_multiplier", multiplier),
+		zap.Float64("account_rate_multiplier", accountRateMultiplier),
+	}
+	if apiKey != nil {
+		fields = append(fields, zap.Int64("api_key_id", apiKey.ID))
+		if apiKey.Group != nil {
+			fields = append(fields,
+				zap.Int64("group_id", apiKey.Group.ID),
+				zap.String("group_platform", apiKey.Group.Platform),
+			)
+		}
+	}
+	logger.L().With(fields...).Warn("openai_usage.served_zero_cost")
+
+	if s.tkPricingMissingNotifier == nil {
+		return
+	}
+	ev := PricingMissingEvent{
+		Reason:         reason,
+		BillingModel:   billingModel,
+		RequestedModel: requested,
+		UpstreamModel:  result.UpstreamModel,
+		Tokens:         units,
+	}
+	if apiKey != nil {
+		ev.APIKeyID = apiKey.ID
+		if apiKey.Group != nil {
+			ev.GroupID = apiKey.Group.ID
+			ev.GroupName = apiKey.Group.Name
+			ev.Platform = apiKey.Group.Platform
+		}
+	}
+	s.tkPricingMissingNotifier.NotifyPricingMissing(ev)
+}

--- a/backend/internal/service/pricing_missing_notifier_tk.go
+++ b/backend/internal/service/pricing_missing_notifier_tk.go
@@ -51,8 +51,14 @@ const (
 	pricingMissingDigestMaxGroupSamples = 8
 )
 
-// PricingMissingEvent 是单次"缺价记零成本"事件的最小快照。
+// PricingMissingEvent 是单次"已服务但零计费"事件的最小快照。
 type PricingMissingEvent struct {
+	// Reason 是漏算原因，驱动卡片文案：
+	//   "unpriced"            — 倍率前 TotalCost==0，价格本身为零（无价模型/渠道$0/
+	//                           视频·per_request 无价/cost-calc 错误吞 $0）。
+	//   "negative_multiplier" — 价格有效但被负倍率归零。
+	// 空字符串向后兼容，按 "unpriced" 处理。
+	Reason         string
 	Platform       string // group 平台（anthropic/openai/gemini/newapi/...）
 	BillingModel   string // 计费解析最终落到的模型名（聚合键）
 	RequestedModel string // 客户端请求的模型名（样例展示）
@@ -60,7 +66,17 @@ type PricingMissingEvent struct {
 	GroupID        int64
 	GroupName      string
 	APIKeyID       int64
-	Tokens         int64 // 本次未计费 token 估算（input+output+cache）
+	Tokens         int64 // 本次未计费计费单元估算（token 总量或图片张数）
+}
+
+// pricingMissingReasonLabel 把 Reason 码翻成中文卡片文案；空/未知按无价处理。
+func pricingMissingReasonLabel(reason string) string {
+	switch reason {
+	case "negative_multiplier":
+		return "负倍率归零（价格有效但被负费率倍率清零）"
+	default:
+		return "模型无价（倍率前成本为零）"
+	}
 }
 
 // PricingMissingNotifier 是计费 funnel 注入的最小通知面（仿 AccountIncidentNotifier）。
@@ -195,9 +211,9 @@ func (n *TKPricingMissingNotifier) NotifyPricingMissing(ev PricingMissingEvent) 
 	n.firstSentAt[dedupeKey] = now
 	n.mu.Unlock()
 
-	title := fmt.Sprintf("TokenKey 模型缺价（已记零成本）[%s]", n.siteID)
+	title := fmt.Sprintf("TokenKey P0 计费漏算：已服务但零计费 [%s]", n.siteID)
 	body := buildPricingMissingFirstSeenText(n.siteID, ev, platform, model, now)
-	n.send(title, "orange", body, fmt.Sprintf("platform=%s model=%s", platform, model))
+	n.send(title, "red", body, fmt.Sprintf("reason=%s platform=%s model=%s", ev.Reason, platform, model))
 }
 
 func (n *TKPricingMissingNotifier) digestLoop() {
@@ -260,7 +276,7 @@ func (n *TKPricingMissingNotifier) flushDigest() {
 		return entries[i].billingModel < entries[j].billingModel
 	})
 	now := n.currentTime()
-	title := fmt.Sprintf("TokenKey 缺价模型零成本摘要 [%s]", n.siteID)
+	title := fmt.Sprintf("TokenKey 已服务零计费摘要 [%s]", n.siteID)
 	body := buildPricingMissingDigestText(n.siteID, entries, now)
 	n.send(title, "orange", body, "digest")
 }
@@ -329,14 +345,16 @@ func buildPricingMissingFirstSeenText(site string, ev PricingMissingEvent, platf
 	if ev.GroupID > 0 {
 		group = pricingMissingGroupLabel(ev.GroupID, ev.GroupName)
 	}
-	return fmt.Sprintf("**节点**：%s\n**平台**：%s\n**计费模型**：%s\n**请求模型**：%s\n**上游模型**：%s\n**组**：%s\n**api_key**：#%d\n**时间**：%s\n\n首次发现该模型缺价（24h 内同模型不再即时提醒，后续进周期摘要）。\n\n%s",
+	return fmt.Sprintf("**节点**：%s\n**原因**：%s\n**平台**：%s\n**计费模型**：%s\n**请求模型**：%s\n**上游模型**：%s\n**组**：%s\n**api_key**：#%d\n**本次计费单元**：%d\n**时间**：%s\n\n首次发现该（platform, model）已服务却零计费（24h 内同模型不再即时提醒，后续进周期摘要）。\n\n%s",
 		escapeFeishuText(site),
+		escapeFeishuText(pricingMissingReasonLabel(ev.Reason)),
 		escapeFeishuText(platform),
 		escapeFeishuText(model),
 		escapeFeishuText(requested),
 		escapeFeishuText(upstream),
 		escapeFeishuText(group),
 		ev.APIKeyID,
+		ev.Tokens,
 		escapeFeishuText(formatAlertTime(now)),
 		pricingMissingAdviceText,
 	)
@@ -384,13 +402,4 @@ func formatPricingMissingTokens(t int64) string {
 	default:
 		return fmt.Sprintf("%d", t)
 	}
-}
-
-// totalUsageTokensForPricingMissing 估算一次请求未计费的 token 总量。
-// CacheCreation5m/1h 是 CacheCreationTokens 的细分桶，不重复累加；
-// ImageOutputTokens 独立计入（图像缺价流量否则在摘要里显示 0 tokens）。
-func totalUsageTokensForPricingMissing(tokens UsageTokens) int64 {
-	return int64(tokens.InputTokens) + int64(tokens.OutputTokens) +
-		int64(tokens.CacheCreationTokens) + int64(tokens.CacheReadTokens) +
-		int64(tokens.ImageOutputTokens)
 }

--- a/backend/internal/service/pricing_missing_notifier_tk_test.go
+++ b/backend/internal/service/pricing_missing_notifier_tk_test.go
@@ -3,7 +3,6 @@
 package service
 
 import (
-	"errors"
 	"strings"
 	"testing"
 	"time"
@@ -156,7 +155,7 @@ func TestPricingMissingNotifier_DigestIntervalFromConfig(t *testing.T) {
 	require.Equal(t, time.Duration(pricingMissingDigestSecondsFallback)*time.Second, n2.digestInterval())
 }
 
-// --- funnel hook tests ----------------------------------------------------
+// --- served-but-zero-cost probe tests (root-cause ②) -----------------------
 
 type recordingPricingMissingNotifier struct {
 	events []PricingMissingEvent
@@ -166,17 +165,49 @@ func (r *recordingPricingMissingNotifier) NotifyPricingMissing(ev PricingMissing
 	r.events = append(r.events, ev)
 }
 
-func TestGatewayRecordTokenCostPricingMissing_FeedsNotifier(t *testing.T) {
+func TestServedZeroCostReason_TruthTable(t *testing.T) {
+	// 倍率前 TotalCost==0 且有计费单元 → unpriced（无价模型/渠道$0/视频·per_request
+	// 无价/cost-calc 错误吞 $0 都落这里）。
+	reason, ok := tkServedZeroCostReason(&CostBreakdown{TotalCost: 0, ActualCost: 0}, 160, 1.0, 1.0)
+	require.True(t, ok)
+	require.Equal(t, "unpriced", reason)
+
+	// 价格有效但负倍率归零 → negative_multiplier（group 倍率 / account 倍率任一为负）。
+	reason, ok = tkServedZeroCostReason(&CostBreakdown{TotalCost: 10, ActualCost: 0}, 160, -1.0, 1.0)
+	require.True(t, ok)
+	require.Equal(t, "negative_multiplier", reason)
+	_, ok = tkServedZeroCostReason(&CostBreakdown{TotalCost: 10, ActualCost: 0}, 160, 1.0, -2.0)
+	require.True(t, ok)
+
+	// 合法免费分组（倍率恰为 0、价格有效）→ 不报。
+	_, ok = tkServedZeroCostReason(&CostBreakdown{TotalCost: 10, ActualCost: 0}, 160, 0.0, 1.0)
+	require.False(t, ok, "multiplier==0 is a legitimate free tier, must NOT alert")
+
+	// 无计费单元（失败/空请求/count_tokens）→ 不报。
+	_, ok = tkServedZeroCostReason(&CostBreakdown{TotalCost: 0}, 0, 1.0, 1.0)
+	require.False(t, ok)
+
+	// nil cost → 不报。
+	_, ok = tkServedZeroCostReason(nil, 100, 1.0, 1.0)
+	require.False(t, ok)
+}
+
+func TestGatewayTkNotifyServedZeroCost_FeedsNotifier(t *testing.T) {
 	rec := &recordingPricingMissingNotifier{}
 	svc := &GatewayService{tkPricingMissingNotifier: rec}
 
-	result := &ForwardResult{Model: "glm-5", UpstreamModel: "glm-5-air"}
+	result := &ForwardResult{
+		Model:         "glm-5",
+		UpstreamModel: "glm-5-air",
+		Usage:         ClaudeUsage{InputTokens: 100, OutputTokens: 50, CacheReadInputTokens: 10},
+	}
 	apiKey := &APIKey{ID: 7, Group: &Group{ID: 3, Name: "g3", Platform: PlatformAnthropic}}
-	tokens := UsageTokens{InputTokens: 100, OutputTokens: 50, CacheReadTokens: 10}
 
-	svc.recordTokenCostPricingMissing("glm-5", apiKey, result, tokens, ErrModelPricingUnavailable)
+	// unpriced：TotalCost==0 且已服务 → 喂通知器。
+	svc.tkNotifyServedZeroCost(&CostBreakdown{TotalCost: 0}, result, apiKey, "glm-5", "glm-5", 1.0, 1.0)
 	require.Len(t, rec.events, 1)
 	ev := rec.events[0]
+	require.Equal(t, "unpriced", ev.Reason)
 	require.Equal(t, "glm-5", ev.BillingModel)
 	require.Equal(t, "glm-5-air", ev.UpstreamModel)
 	require.Equal(t, PlatformAnthropic, ev.Platform)
@@ -184,41 +215,51 @@ func TestGatewayRecordTokenCostPricingMissing_FeedsNotifier(t *testing.T) {
 	require.Equal(t, int64(7), ev.APIKeyID)
 	require.Equal(t, int64(160), ev.Tokens)
 
-	// 非缺价类计费错误:只记日志,不喂通知器。
-	svc.recordTokenCostPricingMissing("glm-5", apiKey, result, tokens, errors.New("unexpected cost-calc failure"))
+	// 合法免费（倍率=0、价格有效）→ 不喂。
+	svc.tkNotifyServedZeroCost(&CostBreakdown{TotalCost: 10, ActualCost: 0}, result, apiKey, "glm-5", "glm-5", 0.0, 1.0)
 	require.Len(t, rec.events, 1)
+
+	// 负倍率 → 喂（negative_multiplier）。
+	svc.tkNotifyServedZeroCost(&CostBreakdown{TotalCost: 10, ActualCost: 0}, result, apiKey, "glm-5", "glm-5", -1.0, 1.0)
+	require.Len(t, rec.events, 2)
+	require.Equal(t, "negative_multiplier", rec.events[1].Reason)
 }
 
-func TestGatewayRecordTokenCostPricingMissing_NilNotifierSafe(t *testing.T) {
+func TestGatewayTkNotifyServedZeroCost_NilSafe(t *testing.T) {
 	svc := &GatewayService{}
 	require.NotPanics(t, func() {
-		svc.recordTokenCostPricingMissing("glm-5", nil, nil, UsageTokens{}, ErrModelPricingUnavailable)
+		svc.tkNotifyServedZeroCost(&CostBreakdown{TotalCost: 0}, &ForwardResult{Usage: ClaudeUsage{InputTokens: 1}}, nil, "m", "m", 1.0, 1.0)
 	})
 }
 
-func TestOpenAINotifyPricingMissing_FeedsNotifier(t *testing.T) {
+func TestOpenAITkNotifyServedZeroCost_FeedsNotifier(t *testing.T) {
 	rec := &recordingPricingMissingNotifier{}
 	svc := &OpenAIGatewayService{tkPricingMissingNotifier: rec}
 
 	input := &OpenAIRecordUsageInput{}
 	input.OriginalModel = "doubao-seedream-9"
-	result := &OpenAIForwardResult{UpstreamModel: "doubao-seedream-9-250901"}
+	result := &OpenAIForwardResult{
+		Model:         "doubao-seedream-9",
+		UpstreamModel: "doubao-seedream-9-250901",
+		Usage:         OpenAIUsage{OutputTokens: 5},
+	}
 	apiKey := &APIKey{ID: 9, Group: &Group{ID: 5, Name: "np", Platform: PlatformNewAPI}}
 
-	svc.notifyOpenAIPricingMissing(input, result, apiKey,
-		[]string{"doubao-seedream-9"}, UsageTokens{InputTokens: 20, OutputTokens: 5})
+	// unpriced：actualInputTokens=20 + output 5 = 25 计费单元。
+	svc.tkNotifyServedZeroCost(&CostBreakdown{TotalCost: 0}, result, apiKey, input, []string{"doubao-seedream-9"}, 20, 1.0, 1.0)
 	require.Len(t, rec.events, 1)
 	ev := rec.events[0]
+	require.Equal(t, "unpriced", ev.Reason)
 	require.Equal(t, "doubao-seedream-9", ev.BillingModel)
 	require.Equal(t, "doubao-seedream-9", ev.RequestedModel)
 	require.Equal(t, "doubao-seedream-9-250901", ev.UpstreamModel)
 	require.Equal(t, PlatformNewAPI, ev.Platform)
 	require.Equal(t, int64(25), ev.Tokens)
 
-	// nil notifier 安全。
+	// nil 输入安全。
 	bare := &OpenAIGatewayService{}
 	require.NotPanics(t, func() {
-		bare.notifyOpenAIPricingMissing(nil, nil, nil, nil, UsageTokens{})
+		bare.tkNotifyServedZeroCost(nil, nil, nil, nil, nil, 0, 1.0, 1.0)
 	})
 }
 

--- a/backend/internal/service/pricing_service_tk_overlay_test.go
+++ b/backend/internal/service/pricing_service_tk_overlay_test.go
@@ -241,3 +241,51 @@ func TestBilling_SourceCarried1hPriceUnaffected(t *testing.T) {
 	// 400000*6.25e-6 + 600000*1e-5 = 2.5 + 6.0
 	require.InDelta(t, 8.5, breakdown.CacheCreationCost, 1e-9)
 }
+
+// TestTKPricingOverlay_FillsRetiredQwen25Coder verifies the overlay supplies
+// pricing for qwen2.5-coder-32b / qwen2.5-coder-7b — retired models absent from
+// both the runtime price source AND Alibaba's current price list, proxy-filled
+// from lineage successors qwen3-coder-plus / qwen3-coder-flash (Beijing RMB list
+// ÷ 6.7). Before this fill they billed $0: in 2026-04/05 a trajectory harness
+// served 66,556 requests (mapped to gpt-5.4) at $0 because the unpriced requested
+// name was the billing key. The fill makes both names carry a non-zero,
+// input-tiered price so they no longer silently leak via pricing-missing $0.
+func TestTKPricingOverlay_FillsRetiredQwen25Coder(t *testing.T) {
+	svc := &PricingService{}
+	// Source deliberately carries neither qwen2.5-coder key (mirrors prod, where
+	// the trimmed source lacks them), so the overlay fill must apply.
+	body := []byte(`{
+		"gpt-5.4": {
+			"input_cost_per_token": 0.0000025,
+			"output_cost_per_token": 0.000015,
+			"litellm_provider": "openai",
+			"mode": "chat"
+		}
+	}`)
+
+	data, err := svc.parsePricingData(body)
+	require.NoError(t, err)
+
+	c32 := data["qwen2.5-coder-32b"]
+	require.NotNil(t, c32, "overlay must inject qwen2.5-coder-32b")
+	require.InDelta(t, 5.970149e-07, c32.InputCostPerToken, 1e-13)
+	require.InDelta(t, 2.38806e-06, c32.OutputCostPerToken, 1e-13)
+	require.InDelta(t, 5.970149e-07, c32.CacheReadInputTokenCost, 1e-13)
+	require.Len(t, c32.Intervals, 4, "32b must carry the 4 input-token tiers")
+	top32 := c32.Intervals[len(c32.Intervals)-1]
+	require.Nil(t, top32.MaxTokens, "last 32b tier is unbounded (>256K)")
+	require.NotNil(t, top32.InputPrice)
+	require.NotNil(t, top32.OutputPrice)
+	require.InDelta(t, 2.985075e-06, *top32.InputPrice, 1e-13)
+	require.InDelta(t, 2.985075e-05, *top32.OutputPrice, 1e-13)
+
+	c7 := data["qwen2.5-coder-7b"]
+	require.NotNil(t, c7, "overlay must inject qwen2.5-coder-7b")
+	require.InDelta(t, 1.492537e-07, c7.InputCostPerToken, 1e-13)
+	require.InDelta(t, 5.970149e-07, c7.OutputCostPerToken, 1e-13)
+	require.InDelta(t, 1.492537e-07, c7.CacheReadInputTokenCost, 1e-13)
+	require.Len(t, c7.Intervals, 4, "7b must carry the 4 input-token tiers")
+	base7 := c7.Intervals[0]
+	require.NotNil(t, base7.InputPrice)
+	require.InDelta(t, 1.492537e-07, *base7.InputPrice, 1e-13)
+}

--- a/backend/internal/service/tk_pricing_overlay.json
+++ b/backend/internal/service/tk_pricing_overlay.json
@@ -1,7 +1,7 @@
 {
   "_meta": {
     "note": "TK-owned pricing overlay for models the runtime price source lacks. Merged into PricingService AFTER any source load (Wei-Shaw remote OR disk fallback); an entry below applies when the source key is ABSENT or the source entry is EFFECTIVELY UNPRICED (every cost field 0.0 — litellm's 'unknown', not 'free'; see tkIsEffectivelyUnpriced). The Wei-Shaw runtime mirror is a TRIMMED litellm mirror that drops provider-prefixed keys and token-less media entries, so imagen-*/veo-* resolve to nothing there; litellm itself also lags new provider models (deepseek-v4-*) or carries them as zero placeholders (deepseek-v3-2-251201), which then bill $0. Media price = vertex_ai provider (TK media flow routes through Vertex ch41); falls back to gemini only when no vertex variant exists. Text price = provider official list price. Self-deprecating: the day the source carries a real (non-zero) price under the bare key, the source value wins and the entry below is ignored. The overlay cannot CORRECT wrong NON-ZERO source prices (deepseek-chat/reasoner still carry the pre-V4 rate in the mirror) — use channel pricing (DB) for that.",
-    "provenance": "media: BerriAI/litellm model_prices_and_context_window.json, captured 2026-06-01; deepseek-v4-*: https://api-docs.deepseek.com/quick_start/pricing, captured 2026-06-04 (cache-hit input = cache_read; cache writes billed as normal input, no separate write fee); volcengine doubao-*/glm-4-7-251222/deepseek-v3-2-251201: VolcEngine Ark official model-pricing page, captured 2026-06-10 (≤32K input tier, CNY/USD=6.7); glm-4.7 matches Zhipu official; qwen3.7-max*: Alibaba DashScope official list price, captured 2026-06-10 (per-entry source)",
+    "provenance": "media: BerriAI/litellm model_prices_and_context_window.json, captured 2026-06-01; deepseek-v4-*: https://api-docs.deepseek.com/quick_start/pricing, captured 2026-06-04 (cache-hit input = cache_read; cache writes billed as normal input, no separate write fee); volcengine doubao-*/glm-4-7-251222/deepseek-v3-2-251201: VolcEngine Ark official model-pricing page, captured 2026-06-10 (≤32K input tier, CNY/USD=6.7); glm-4.7 matches Zhipu official; qwen3.7-max*: Alibaba DashScope official list price, captured 2026-06-10 (per-entry source); qwen2.5-coder-32b/7b: retired & absent from current Alibaba list — proxy-filled from lineage successors qwen3-coder-plus / qwen3-coder-flash, Beijing RMB list ÷ 6.7, docs/accounts/aliyun_pricing_20260612.md captured 2026-06-12 (per-entry source)",
     "regen": "manual curation; no auto-sync (entries are few + slow-moving). If they proliferate, add provider-aware sync."
   },
   "claude-fable-5": {
@@ -771,5 +771,81 @@
       }
     ],
     "source": "Alibaba DashScope qwen3-coder-plus official USD list (China-mainland; tiered by input tokens: 0<=32K in $0.574/$2.294 per M, 32K<=128K $0.861/$3.441, 128K<=256K $1.434/$5.735, 256K<=1M $2.868/$28.671; help.aliyun.com/zh/model-studio/model-pricing captured 2026-06-11). List price only — context-cache discount not modeled. Whole-request input-tier via overlay intervals."
+  },
+  "qwen2.5-coder-32b": {
+    "litellm_provider": "dashscope",
+    "mode": "chat",
+    "input_cost_per_token": 5.970149e-07,
+    "output_cost_per_token": 2.38806e-06,
+    "cache_read_input_token_cost": 5.970149e-07,
+    "intervals": [
+      {
+        "min_tokens": 0,
+        "max_tokens": 32000,
+        "input_cost_per_token": 5.970149e-07,
+        "output_cost_per_token": 2.38806e-06,
+        "cache_read_input_token_cost": 5.970149e-07
+      },
+      {
+        "min_tokens": 32000,
+        "max_tokens": 128000,
+        "input_cost_per_token": 8.955224e-07,
+        "output_cost_per_token": 3.58209e-06,
+        "cache_read_input_token_cost": 8.955224e-07
+      },
+      {
+        "min_tokens": 128000,
+        "max_tokens": 256000,
+        "input_cost_per_token": 1.492537e-06,
+        "output_cost_per_token": 5.970149e-06,
+        "cache_read_input_token_cost": 1.492537e-06
+      },
+      {
+        "min_tokens": 256000,
+        "max_tokens": null,
+        "input_cost_per_token": 2.985075e-06,
+        "output_cost_per_token": 2.985075e-05,
+        "cache_read_input_token_cost": 2.985075e-06
+      }
+    ],
+    "source": "TK proxy fill — qwen2.5-coder-32b is retired/absent from the runtime price source AND from Alibaba's current price list; priced via its lineage successor qwen3-coder-plus. Alibaba DashScope qwen3-coder-plus China-mainland (Beijing) RMB list ÷ 6.7 (0<=32K ¥4/¥16, 32K<=128K ¥6/¥24, 128K<=256K ¥10/¥40, 256K<=1M ¥20/¥200 per M); docs/accounts/aliyun_pricing_20260612.md captured 2026-06-12. List price only — batch/context-cache discounts not modeled. Whole-request input-tier via overlay intervals."
+  },
+  "qwen2.5-coder-7b": {
+    "litellm_provider": "dashscope",
+    "mode": "chat",
+    "input_cost_per_token": 1.492537e-07,
+    "output_cost_per_token": 5.970149e-07,
+    "cache_read_input_token_cost": 1.492537e-07,
+    "intervals": [
+      {
+        "min_tokens": 0,
+        "max_tokens": 32000,
+        "input_cost_per_token": 1.492537e-07,
+        "output_cost_per_token": 5.970149e-07,
+        "cache_read_input_token_cost": 1.492537e-07
+      },
+      {
+        "min_tokens": 32000,
+        "max_tokens": 128000,
+        "input_cost_per_token": 2.238806e-07,
+        "output_cost_per_token": 8.955224e-07,
+        "cache_read_input_token_cost": 2.238806e-07
+      },
+      {
+        "min_tokens": 128000,
+        "max_tokens": 256000,
+        "input_cost_per_token": 3.731343e-07,
+        "output_cost_per_token": 1.492537e-06,
+        "cache_read_input_token_cost": 3.731343e-07
+      },
+      {
+        "min_tokens": 256000,
+        "max_tokens": null,
+        "input_cost_per_token": 7.462687e-07,
+        "output_cost_per_token": 3.731343e-06,
+        "cache_read_input_token_cost": 7.462687e-07
+      }
+    ],
+    "source": "TK proxy fill — qwen2.5-coder-7b is retired/absent from the runtime price source AND from Alibaba's current price list; priced via its lineage successor qwen3-coder-flash. Alibaba DashScope qwen3-coder-flash China-mainland (Beijing) RMB list ÷ 6.7 (0<=32K ¥1/¥4, 32K<=128K ¥1.5/¥6, 128K<=256K ¥2.5/¥10, 256K<=1M ¥5/¥25 per M); docs/accounts/aliyun_pricing_20260612.md captured 2026-06-12. List price only — batch/context-cache discounts not modeled. Whole-request input-tier via overlay intervals."
   }
 }

--- a/scripts/sentinels/gateway-tk.json
+++ b/scripts/sentinels/gateway-tk.json
@@ -1340,9 +1340,9 @@
       "path": "backend/internal/service/gateway_service.go",
       "must_contain": [
         "topLevelCacheControl := gjson.GetBytes(out, \"cache_control\").Exists()",
-        "s.recordTokenCostPricingMissing(billingModel, apiKey, result, tokens, err)"
+        "logTokenCostPricingMissing(billingModel, apiKey, result, err)"
       ],
-      "rationale": "TK#2013: enforceCacheControlLimit must count a non-standard top-level cache_control toward the 4-block limit (else Anthropic 400 'Found 5'). TK#1833/#1544: calculateTokenCost must surface pricing-missing as an observable marked zero-cost record instead of a silent ActualCost:0 revenue leak (call renamed to recordTokenCostPricingMissing when the Feishu pricing-missing notifier was layered on top — it still emits the same structured log)."
+      "rationale": "TK#2013: enforceCacheControlLimit must count a non-standard top-level cache_control toward the 4-block limit (else Anthropic 400 'Found 5'). TK#1833/#1544: calculateTokenCost must surface pricing-missing as an observable structured log instead of a silent ActualCost:0 revenue leak. The Feishu P0 alert was consolidated into the result-side served-but-zero-cost probe (tkNotifyServedZeroCost); this call now keeps only the grep-able structured log."
     },
     {
       "path": "backend/internal/service/gateway_service_tk_billing_pricing_missing.go",
@@ -2065,18 +2065,18 @@
     {
       "path": "backend/internal/service/gateway_service.go",
       "must_contain": [
-        "s.recordTokenCostPricingMissing(billingModel, apiKey, result, tokens, err)",
+        "s.tkNotifyServedZeroCost(cost, result, apiKey, billingModel, requestedModel, multiplier, accountRateMultiplier)",
         "tkPricingMissingNotifier PricingMissingNotifier"
       ],
-      "rationale": "Pricing-missing -> Feishu notifier hook on the Anthropic/generic billing funnel (PR #675 follow-up). Unpriced models are served and recorded at zero cost by design (never refused); this one-line call + struct field are the only bridge from calculateRecordUsageCost into PricingMissingNotifier. Both compile-clean if an upstream merge reverts the call back to the bare logTokenCostPricingMissing shape, which would silently turn revenue-leak alerting back into log-only observability."
+      "rationale": "Served-but-zero-cost -> Feishu P0 hook on the Anthropic/generic billing funnel (root-cause ②). After cost is resolved in recordUsageCore, this result-side probe (tkServedZeroCostReason: pre-multiplier TotalCost==0, or valid price zeroed by a negative multiplier) is the only bridge into PricingMissingNotifier — covering unpriced models AND the silent $0 paths (channel/video/per_request/cost-calc-error) that never return an error. Compile-clean if an upstream merge drops the call, which would silently turn revenue-leak P0 alerting back into log-only observability."
     },
     {
       "path": "backend/internal/service/openai_gateway_service.go",
       "must_contain": [
-        "s.notifyOpenAIPricingMissing(input, result, apiKey, billingModels, tokens)",
+        "s.tkNotifyServedZeroCost(cost, result, apiKey, input, billingModels, actualInputTokens, multiplier, accountRateMultiplier)",
         "tkPricingMissingNotifier PricingMissingNotifier"
       ],
-      "rationale": "Pricing-missing -> Feishu notifier hook on the OpenAI-compat record-usage funnel (covers newapi fifth platform + image/video relays). The upstream-owned openai_usage.pricing_missing_record_zero_cost log line stays untouched; this adjacent one-line call is the only feed into PricingMissingNotifier on this path and is compile-clean if dropped by an upstream merge."
+      "rationale": "Served-but-zero-cost -> Feishu P0 hook on the OpenAI-compat record-usage funnel (covers newapi fifth platform + image/video relays). The upstream-owned openai_usage.pricing_missing_record_zero_cost log line stays untouched; this adjacent result-side probe is the only feed into PricingMissingNotifier on this path (root-cause ②) and is compile-clean if dropped by an upstream merge."
     },
     {
       "path": "backend/internal/service/gateway_request_tk_fable.go",


### PR DESCRIPTION
## 背景

排查发现内部 traj 评测 harness 用无价的 `qwen2.5-coder-32b/7b`（被 model-mapping 改写成有价 `gpt-5.4` 真实服务）**66,556 笔成功请求按 $0 入账，漏算约 $269**。根因是**计价不确定时系统"免费放行"且漏血无声**——全局通查发现多类静默 $0 口子。

本 PR 两步：**止血**（补价）+ **根因②**（统一探针 + P0）。

## 第一步：止血 — 补 qwen2.5-coder overlay 价

两模型已从阿里现行价目下线，按血缘后继代填（DashScope 北京列价 ÷ 6.7，四档分层）：
| 模型 | 代填源 | 0-32K (in/out $/M) | >256K |
|---|---|---|---|
| `qwen2.5-coder-32b` | qwen3-coder-plus | 0.597 / 2.388 | 2.985 / 29.851 |
| `qwen2.5-coder-7b` | qwen3-coder-flash | 0.149 / 0.597 | 0.746 / 3.731 |

非公开 servable allowlist，不改公开 /pricing。

## 第二步：根因② — 「已服务但零计费」统一探针 + P0 告警

把告警从"无价模型"放宽到**结果侧 `TotalCost==0`（倍率前）统一探针并升级 P0**，一张网罩住此前**静默 $0** 的口子：无价模型 / 渠道 $0 / 视频·per_request 无价 / 非缺价 cost-calc 错误吞 $0 / 负倍率归零。

- **判据**：`TotalCost==0`（倍率前）天然排除合法免费分组（倍率=0 → ActualCost=0 但 TotalCost>0）；负倍率（价格有效被负倍率归零）单独条件。
- **两条 funnel 薄注入**：`recordUsageCore`（anthropic）+ `RecordUsage`（openai），cost 已知后各一行。
- **收敛**：错误侧 notify 删除（`recordTokenCostPricingMissing` / `notifyOpenAIPricingMissing` / `totalUsageTokensForPricingMissing`），保留 grep-able 结构化日志，避免一次事件两张卡。
- **notifier**：`PricingMissingEvent`+`Reason`；首见卡 orange→**red P0**。
- 不改计费金额，纯可观测性；Feishu 关闭时 no-op，日志始终在。

## 变更
- `tk_pricing_overlay.json` +2 条目 + `_meta`
- `gateway_service_tk_served_zero_cost.go` / `openai_gateway_service_tk_served_zero_cost.go`（新）：判据 + 注入助手
- `gateway_service.go` / `openai_gateway_service.go`：各一行注入 + 收敛错误侧 notify（保留日志）
- `pricing_missing_notifier_tk.go`：Reason + P0 红卡
- `scripts/sentinels/gateway-tk.json`：3 锚点更新到新注入点
- 单测：overlay 非零 + 区间；探针真值表 + 双 funnel（合法免费/零单元/负倍率边界）

## 验证
- `go test -tags=unit ./internal/service/` 全过；`golangci-lint` 0 issues
- `scripts/preflight.sh` 全绿（含 `pricing overlay valid, no $0` + `gateway TK sentinels intact` + `silent-error-swallow`）
- CI 全绿（test-unit / test-integration / preflight / golangci-lint / backend-security / frontend / validate）

## 审查（xj-review，严格 merge-ready）
- **decision: merge-ready**（risk: normal，零 critical/high/medium finding）
- low 透明取舍（不阻塞）：① notifier 类型仍名 `PricingMissing*`（最小侵入未重命名，加 `Reason`+doc 澄清）；② 经 newapi bridge 的视频异步计费在 bridge 内记账、不过这两条 funnel（v1 已知边界，注释标注）；③ `negative_multiplier` 按 (platform,model) 去重（与 unpriced 互斥，实践无影响）。
- 分支基底早于 #733（仅删无关 `.claude/` TLS hook），GitHub merge-base diff 干净、`mergeable: CLEAN`，无冲突。

## marker / 合并
- `no-web-impact`（纯后端可观测性）；`upstream-touch-guarded`（gateway 上游文件薄注入，由 gateway-tk sentinel 守护）；`sentinel-registry-reviewed`（更新了既有 gateway-tk.json 锚点）
- TK-originated → **Squash and merge**

## 不在本次范围
- 计费按 `upstream_model` 取价（"改金额"，与本次"加信号"正交）
- 历史 ~$269 漏算追溯/补收

🤖 Generated with [Claude Code](https://claude.com/claude-code)