### PR TITLE
feat(newapi): 上游账号低余额主动哨兵（DeepSeek 提前飞书预警）

### DIFF
--- a/backend/.golangci.yml
+++ b/backend/.golangci.yml
@@ -41,6 +41,9 @@ linters:
             # TK: per-node anthropic config reconciler needs redis for its
             # leader lock (SetNX + Lua release), same as the ops services above.
             - "!**/internal/service/anthropic_config_reconciler.go"
+            # TK: per-node upstream low-balance sentinel uses the same redis
+            # leader-lock pattern as the reconciler above.
+            - "!**/internal/service/upstream_balance_sentinel_tk.go"
             - "!**/internal/service/wire.go"
           deny:
             - pkg: github.com/Wei-Shaw/sub2api/internal/repository

--- a/backend/cmd/server/wire.go
+++ b/backend/cmd/server/wire.go
@@ -87,6 +87,7 @@ func provideCleanup(
 	// TK: per-node anthropic config self-healer — see
 	// internal/service/anthropic_config_reconciler.go.
 	anthropicConfigReconciler *service.AnthropicConfigReconciler,
+	upstreamBalanceSentinel *service.UpstreamBalanceSentinel,
 	tokenRefresh *service.TokenRefreshService,
 	accountExpiry *service.AccountExpiryService,
 	proxyExpiry *service.ProxyExpiryService,
@@ -200,6 +201,12 @@ func provideCleanup(
 			{"AnthropicConfigReconciler", func() error {
 				if anthropicConfigReconciler != nil {
 					anthropicConfigReconciler.Stop()
+				}
+				return nil
+			}},
+			{"UpstreamBalanceSentinel", func() error {
+				if upstreamBalanceSentinel != nil {
+					upstreamBalanceSentinel.Stop()
 				}
 				return nil
 			}},

--- a/backend/cmd/server/wire_gen.go
+++ b/backend/cmd/server/wire_gen.go
@@ -298,6 +298,8 @@ func initializeApplication(buildInfo handler.BuildInfo) (*Application, error) {
 	rateLimitExpiryRepository := repository.NewRateLimitExpiryRepository(db)
 	schedulerRateLimitReaper := service.ProvideSchedulerRateLimitReaper(rateLimitExpiryRepository, configConfig)
 	anthropicConfigReconciler := service.ProvideAnthropicConfigReconciler(accountRepository, userRepository, adminService, tierService, accountTierService, tlsFingerprintProfileService, settingService, configConfig, redisClient)
+	tkAccountIncidentNotifier := service.ProvideTKAccountIncidentNotifier(rateLimitService, opsService, configConfig)
+	upstreamBalanceSentinel := service.ProvideUpstreamBalanceSentinel(accountRepository, httpUpstream, tkAccountIncidentNotifier, opsService, settingRepository, opsRepository, redisClient)
 	tokenRefreshService := service.ProvideTokenRefreshService(accountRepository, oAuthService, openAIOAuthService, geminiOAuthService, antigravityOAuthService, compositeTokenCacheInvalidator, schedulerCache, configConfig, tempUnschedCache, privacyClientFactory, proxyRepository, oAuthRefreshAPI, openAIGatewayService)
 	accountExpiryService := service.ProvideAccountExpiryService(accountRepository)
 	proxyExpiryService := service.ProvideProxyExpiryService(proxyRepository)
@@ -305,7 +307,6 @@ func initializeApplication(buildInfo handler.BuildInfo) (*Application, error) {
 	scheduledTestRunnerService := service.ProvideScheduledTestRunnerService(scheduledTestPlanRepository, scheduledTestService, accountTestService, rateLimitService, configConfig)
 	paymentOrderExpiryService := service.ProvidePaymentOrderExpiryService(paymentService, leaderLockCache, db)
 	channelMonitorRunner := service.ProvideChannelMonitorRunner(channelMonitorService, settingService)
-	tkAccountIncidentNotifier := service.ProvideTKAccountIncidentNotifier(rateLimitService, opsService, configConfig)
 	tkPricingMissingNotifier := service.ProvideTKPricingMissingNotifier(gatewayService, openAIGatewayService, opsService, configConfig)
 	tkAuthServiceColdStartReady := service.ProvideTKAuthServiceColdStart(authService, apiKeyService, settingService)
 	tkGatewayPricingAvailabilityReady := service.ProvideTKGatewayPricingAvailability(gatewayService, pricingAvailabilityService)
@@ -313,7 +314,7 @@ func initializeApplication(buildInfo handler.BuildInfo) (*Application, error) {
 	tkGatewayAnthropicSigPreemptReady := service.ProvideTKGatewayAnthropicSigPreempt(gatewayService, anthropicSignaturePreemptCache)
 	modelListFilter := service.NewModelListFilter(pricingCatalogService, pricingAvailabilityService)
 	tkGatewayHandlerModelListReady := handler.ProvideTKGatewayHandlerModelList(gatewayHandler, modelListFilter)
-	v := provideCleanup(client, redisClient, opsMetricsCollector, opsAggregationService, opsAlertEvaluatorService, opsCleanupService, opsScheduledReportService, opsSystemLogSink, schedulerSnapshotService, schedulerRateLimitReaper, anthropicConfigReconciler, tokenRefreshService, accountExpiryService, proxyExpiryService, subscriptionExpiryService, usageCleanupService, idempotencyCleanupService, pricingService, emailQueueService, billingCacheService, usageRecordWorkerPool, qaService, subscriptionService, oAuthService, openAIOAuthService, geminiOAuthService, antigravityOAuthService, openAIGatewayService, scheduledTestRunnerService, backupService, paymentOrderExpiryService, channelMonitorRunner, tkAccountIncidentNotifier, tkPricingMissingNotifier, tkAuthServiceColdStartReady, tkGatewayPricingAvailabilityReady, tkGatewayAnthropicSigPreemptReady, tkGatewayHandlerModelListReady)
+	v := provideCleanup(client, redisClient, opsMetricsCollector, opsAggregationService, opsAlertEvaluatorService, opsCleanupService, opsScheduledReportService, opsSystemLogSink, schedulerSnapshotService, schedulerRateLimitReaper, anthropicConfigReconciler, upstreamBalanceSentinel, tokenRefreshService, accountExpiryService, proxyExpiryService, subscriptionExpiryService, usageCleanupService, idempotencyCleanupService, pricingService, emailQueueService, billingCacheService, usageRecordWorkerPool, qaService, subscriptionService, oAuthService, openAIOAuthService, geminiOAuthService, antigravityOAuthService, openAIGatewayService, scheduledTestRunnerService, backupService, paymentOrderExpiryService, channelMonitorRunner, tkAccountIncidentNotifier, tkPricingMissingNotifier, tkAuthServiceColdStartReady, tkGatewayPricingAvailabilityReady, tkGatewayAnthropicSigPreemptReady, tkGatewayHandlerModelListReady)
 	application := &Application{
 		Server:  httpServer,
 		Cleanup: v,
@@ -353,6 +354,7 @@ func provideCleanup(
 	schedulerRateLimitReaper *service.SchedulerRateLimitReaper,
 
 	anthropicConfigReconciler *service.AnthropicConfigReconciler,
+	upstreamBalanceSentinel *service.UpstreamBalanceSentinel,
 	tokenRefresh *service.TokenRefreshService,
 	accountExpiry *service.AccountExpiryService,
 	proxyExpiry *service.ProxyExpiryService,
@@ -449,6 +451,12 @@ func provideCleanup(
 			{"AnthropicConfigReconciler", func() error {
 				if anthropicConfigReconciler != nil {
 					anthropicConfigReconciler.Stop()
+				}
+				return nil
+			}},
+			{"UpstreamBalanceSentinel", func() error {
+				if upstreamBalanceSentinel != nil {
+					upstreamBalanceSentinel.Stop()
 				}
 				return nil
 			}},

--- a/backend/cmd/server/wire_gen_test.go
+++ b/backend/cmd/server/wire_gen_test.go
@@ -65,6 +65,7 @@ func TestProvideCleanup_WithMinimalDependencies_NoPanic(t *testing.T) {
 		schedulerSnapshotSvc,
 		schedulerRateLimitReaperSvc,
 		nil, // anthropicConfigReconciler
+		nil, // upstreamBalanceSentinel
 		tokenRefreshSvc,
 		accountExpirySvc,
 		proxyExpirySvc,

--- a/backend/internal/integration/newapi/balance_probe_tk.go
+++ b/backend/internal/integration/newapi/balance_probe_tk.go
@@ -1,0 +1,139 @@
+package newapi
+
+// TK: 上游渠道账号「余额探测」——给后台 upstream_balance_sentinel 哨兵复用。
+//
+// 背景：newapi 第五平台的上游渠道账号余额耗尽时，bridge 把 402/429 吞码掩成 502
+// 无限锤上游（见 2026-06-11 DeepSeek 余额归零事故）。被动 402 告警只能事后报，要
+// 提前预防只能主动拉余额。不是每个渠道都有公开余额 API——只有 DeepSeek 提供
+// GET /user/balance，故这里按 channel_type 派发，v1 仅注册 DeepSeek(43)。加新渠道 =
+// 注册一个探测函数，哨兵主循环零改动。
+//
+// 本包（integration/newapi）位于 service 之下，禁止 import service（会成环）。因此
+// HTTP 出站走一个本地最小 doer 接口，service.HTTPUpstream 结构上即满足它。
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"io"
+	"net/http"
+	"strconv"
+	"strings"
+
+	newapiconstant "github.com/QuantumNous/new-api/constant"
+)
+
+// HTTPDoer 是余额探测所需的最小上游 HTTP 出站面。签名与 service.HTTPUpstream.Do
+// 对齐，故注入 service.HTTPUpstream 即满足（无需本包 import service）。
+type HTTPDoer interface {
+	Do(req *http.Request, proxyURL string, accountID int64, accountConcurrency int) (*http.Response, error)
+}
+
+// BalanceResult 是一次余额探测的归一化结果。AvailableCNY 是可用余额（人民币）；
+// IsAvailable 是上游自报的「账号当前是否可用」硬信号（DeepSeek 余额归零时为 false）。
+type BalanceResult struct {
+	AvailableCNY float64
+	IsAvailable  bool
+}
+
+// BalanceProbeFn 探测单个上游渠道账号的余额。
+type BalanceProbeFn func(ctx context.Context, doer HTTPDoer, baseURL, apiKey, proxyURL string, accountID int64, accountConcurrency int) (BalanceResult, error)
+
+// balanceProbeRegistry 是 channel_type → 探测函数的派发表。
+//
+// 只收「有 per-api-key 余额端点」的渠道——这是准入硬条件，不是当前实现的偷懒：
+//   - DeepSeek：`GET /user/balance`（Bearer api_key），可直接用账号已存的 key 探。✅
+//   - 火山方舟 (45) / 通义千问·Ali (17)：余额是**云账号级**，只能走各自的 Billing/BSS
+//     OpenAPI（火山 V4 签名 / 阿里 RPC 签名），凭证是 AK/SK 而非渠道 api_key，且粒度对
+//     不到单渠道账号——结构上无法低成本复用本探测面。它们的余额耗尽继续靠反应式 #724
+//     402 透传 + 账号惩罚兜底；真要主动监控得另起「云账号级余额」ops job，别塞进这里。
+var balanceProbeRegistry = map[int]BalanceProbeFn{
+	newapiconstant.ChannelTypeDeepSeek: ProbeDeepSeekBalance,
+}
+
+// BalanceProbeFor 返回某 channel_type 的余额探测函数（若该渠道支持公开余额查询）。
+func BalanceProbeFor(channelType int) (BalanceProbeFn, bool) {
+	fn, ok := balanceProbeRegistry[channelType]
+	return fn, ok
+}
+
+const deepSeekDefaultBaseURL = "https://api.deepseek.com"
+
+// deepSeekBalanceResponse 映射 GET /user/balance 的响应：
+//
+//	{"is_available":true,"balance_infos":[{"currency":"CNY","total_balance":"298.02",...}]}
+//
+// total_balance 是字符串数值，需 ParseFloat。
+type deepSeekBalanceResponse struct {
+	IsAvailable  bool `json:"is_available"`
+	BalanceInfos []struct {
+		Currency     string `json:"currency"`
+		TotalBalance string `json:"total_balance"`
+	} `json:"balance_infos"`
+}
+
+// ProbeDeepSeekBalance 拉 DeepSeek 账号的 CNY 可用余额。
+func ProbeDeepSeekBalance(ctx context.Context, doer HTTPDoer, baseURL, apiKey, proxyURL string, accountID int64, accountConcurrency int) (BalanceResult, error) {
+	if doer == nil {
+		return BalanceResult{}, fmt.Errorf("deepseek balance: nil http doer")
+	}
+	if strings.TrimSpace(apiKey) == "" {
+		return BalanceResult{}, fmt.Errorf("deepseek balance: empty api_key")
+	}
+	base := strings.TrimRight(strings.TrimSpace(baseURL), "/")
+	if base == "" {
+		base = deepSeekDefaultBaseURL
+	}
+	req, err := http.NewRequestWithContext(ctx, http.MethodGet, base+"/user/balance", nil)
+	if err != nil {
+		return BalanceResult{}, fmt.Errorf("deepseek balance: build request: %w", err)
+	}
+	req.Header.Set("Authorization", "Bearer "+strings.TrimSpace(apiKey))
+	req.Header.Set("Accept", "application/json")
+
+	resp, err := doer.Do(req, proxyURL, accountID, accountConcurrency)
+	if err != nil {
+		return BalanceResult{}, fmt.Errorf("deepseek balance: request: %w", err)
+	}
+	defer func() { _ = resp.Body.Close() }()
+
+	body, err := io.ReadAll(io.LimitReader(resp.Body, 64*1024))
+	if err != nil {
+		return BalanceResult{}, fmt.Errorf("deepseek balance: read body: %w", err)
+	}
+	if resp.StatusCode != http.StatusOK {
+		// 401/403 = 凭证失效；其它非 200 = 上游抖动。两者都不是「低余额」，交由
+		// 哨兵记心跳错误、不发预警（避免误报）。
+		return BalanceResult{}, fmt.Errorf("deepseek balance: upstream status %d: %s", resp.StatusCode, truncateForErr(body))
+	}
+
+	return parseDeepSeekBalance(body)
+}
+
+// parseDeepSeekBalance 独立出来便于单测（确定性、无网络）。
+func parseDeepSeekBalance(body []byte) (BalanceResult, error) {
+	var parsed deepSeekBalanceResponse
+	if err := json.Unmarshal(body, &parsed); err != nil {
+		return BalanceResult{}, fmt.Errorf("deepseek balance: decode: %w", err)
+	}
+	for _, info := range parsed.BalanceInfos {
+		if !strings.EqualFold(strings.TrimSpace(info.Currency), "CNY") {
+			continue
+		}
+		val, err := strconv.ParseFloat(strings.TrimSpace(info.TotalBalance), 64)
+		if err != nil {
+			return BalanceResult{}, fmt.Errorf("deepseek balance: parse total_balance %q: %w", info.TotalBalance, err)
+		}
+		return BalanceResult{AvailableCNY: val, IsAvailable: parsed.IsAvailable}, nil
+	}
+	// 没有 CNY 条目：DeepSeek 正常恒有 CNY，缺失视为异常响应，不当作 0 余额误报。
+	return BalanceResult{}, fmt.Errorf("deepseek balance: no CNY balance_info in response")
+}
+
+func truncateForErr(b []byte) string {
+	s := strings.TrimSpace(string(b))
+	if len(s) > 200 {
+		return s[:200]
+	}
+	return s
+}

--- a/backend/internal/integration/newapi/balance_probe_tk_test.go
+++ b/backend/internal/integration/newapi/balance_probe_tk_test.go
@@ -1,0 +1,83 @@
+//go:build unit
+
+package newapi
+
+import (
+	"testing"
+
+	newapiconstant "github.com/QuantumNous/new-api/constant"
+)
+
+func TestParseDeepSeekBalance(t *testing.T) {
+	cases := []struct {
+		name      string
+		body      string
+		wantCNY   float64
+		wantAvail bool
+		wantErr   bool
+	}{
+		{
+			name:      "healthy topped up",
+			body:      `{"is_available":true,"balance_infos":[{"currency":"CNY","total_balance":"298.02","granted_balance":"0.00","topped_up_balance":"298.02"}]}`,
+			wantCNY:   298.02,
+			wantAvail: true,
+		},
+		{
+			name:      "exhausted is_available false",
+			body:      `{"is_available":false,"balance_infos":[{"currency":"CNY","total_balance":"0.00"}]}`,
+			wantCNY:   0,
+			wantAvail: false,
+		},
+		{
+			name:      "picks CNY among multiple currencies",
+			body:      `{"is_available":true,"balance_infos":[{"currency":"USD","total_balance":"5.00"},{"currency":"CNY","total_balance":"42.50"}]}`,
+			wantCNY:   42.50,
+			wantAvail: true,
+		},
+		{
+			name:    "no CNY entry is an error not zero",
+			body:    `{"is_available":true,"balance_infos":[{"currency":"USD","total_balance":"5.00"}]}`,
+			wantErr: true,
+		},
+		{
+			name:    "bad json",
+			body:    `{not json`,
+			wantErr: true,
+		},
+		{
+			name:    "non-numeric total_balance",
+			body:    `{"is_available":true,"balance_infos":[{"currency":"CNY","total_balance":"abc"}]}`,
+			wantErr: true,
+		},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			got, err := parseDeepSeekBalance([]byte(tc.body))
+			if tc.wantErr {
+				if err == nil {
+					t.Fatalf("expected error, got result %+v", got)
+				}
+				return
+			}
+			if err != nil {
+				t.Fatalf("unexpected error: %v", err)
+			}
+			if got.AvailableCNY != tc.wantCNY {
+				t.Errorf("AvailableCNY = %v, want %v", got.AvailableCNY, tc.wantCNY)
+			}
+			if got.IsAvailable != tc.wantAvail {
+				t.Errorf("IsAvailable = %v, want %v", got.IsAvailable, tc.wantAvail)
+			}
+		})
+	}
+}
+
+func TestBalanceProbeFor(t *testing.T) {
+	if _, ok := BalanceProbeFor(newapiconstant.ChannelTypeDeepSeek); !ok {
+		t.Errorf("expected DeepSeek (%d) to be registered", newapiconstant.ChannelTypeDeepSeek)
+	}
+	// An unrelated channel type must not resolve a probe — the sentinel skips it.
+	if _, ok := BalanceProbeFor(0); ok {
+		t.Errorf("channel_type 0 should not have a balance probe")
+	}
+}

--- a/backend/internal/service/account_incident_notifier_tk_balance.go
+++ b/backend/internal/service/account_incident_notifier_tk_balance.go
@@ -1,0 +1,52 @@
+package service
+
+// TK: 上游账号「低余额」主动预警飞书卡片。
+//
+// 与本文件的兄弟告警（永久失效红卡 / 临时冷却橙摘要 / 池级 P0）不同，这是一条**预防性**
+// 预警——账号尚能服务，只是余额逼近阈值，提前提醒运营充值，避免归零后触发全量 402 断供
+// （2026-06-11 DeepSeek 余额归零事故）。故用橙头（警告，非红头 P0）。
+//
+// 触发判定 + re-arm 去重在 upstream_balance_sentinel_tk.go 的哨兵里（它握有余额数值）；
+// 本方法是无状态的「立即渲染并发一条卡」，与 buildAccountIncident*Text 同性质。方法挂在
+// 具体类型 *TKAccountIncidentNotifier 上、不进 AccountIncidentNotifier 接口，故不波及接口
+// 的若干测试 stub。
+
+import (
+	"fmt"
+	"strings"
+	"time"
+)
+
+// NotifyUpstreamBalanceLow 发一条上游账号低余额橙头预警卡。哨兵已完成「首次跨入低于阈值」
+// 的去重，这里每调用一次即发一条。
+func (n *TKAccountIncidentNotifier) NotifyUpstreamBalanceLow(account *Account, balanceCNY float64, isAvailable bool, threshold float64, rechargeURL string) {
+	if n == nil || account == nil {
+		return
+	}
+	title := fmt.Sprintf("TokenKey 上游账号低余额预警 [%s]", n.siteID)
+	body := buildUpstreamBalanceLowText(n.siteID, account, balanceCNY, isAvailable, threshold, rechargeURL, n.currentTime())
+	n.send(title, "orange", body, "upstream_balance_low")
+}
+
+func buildUpstreamBalanceLowText(site string, account *Account, balanceCNY float64, isAvailable bool, threshold float64, rechargeURL string, now time.Time) string {
+	rechargeLine := ""
+	if r := strings.TrimSpace(rechargeURL); r != "" {
+		rechargeLine = "\n**充值**：" + escapeFeishuText(r)
+	}
+	// 上游自报不可用（DeepSeek is_available=false）= 余额可能已归零，措辞更紧急。
+	availabilityNote := ""
+	if !isAvailable {
+		availabilityNote = "\n**上游状态**：已报账号不可用（余额可能已归零，正在或即将全量 402 断供）"
+	}
+	return fmt.Sprintf("**节点**：%s\n**账号**：%s\n**平台**：%s\n**组**：%s\n**当前余额**：%.2f 元\n**告警阈值**：%.2f 元%s%s\n**时间**：%s\n\n**建议**：尽快为该上游渠道账号充值；余额归零会把整条线并发压到下限并最终触发全量 402 断供。",
+		escapeFeishuText(site),
+		escapeFeishuText(accountIncidentLabel(account)),
+		escapeFeishuText(strings.TrimSpace(account.Platform)),
+		escapeFeishuText(accountGroupNames(account)),
+		balanceCNY,
+		threshold,
+		availabilityNote,
+		rechargeLine,
+		escapeFeishuText(formatAlertTime(now)),
+	)
+}

--- a/backend/internal/service/ops_settings.go
+++ b/backend/internal/service/ops_settings.go
@@ -25,6 +25,9 @@ const (
 	// 缺价模型零成本流量聚合摘要的默认 flush 间隔（秒）。运营配置动作级别，
 	// 不是 P0 故障流，默认半小时。
 	opsFeishuPricingMissingDigestSecondsDefault = 1800
+	// 上游账号低余额主动告警的默认触发阈值（人民币）。开箱即可工作；运营可在
+	// ops 通知设置里上调。
+	opsFeishuUpstreamBalanceLowThresholdCNYDefault = 50.0
 )
 
 // =========================
@@ -218,11 +221,12 @@ func validateOpsEmailNotificationConfig(cfg *OpsEmailNotificationConfig) error {
 
 func defaultOpsFeishuAlertConfig() OpsFeishuAlertConfig {
 	return OpsFeishuAlertConfig{
-		Enabled:                      false,
-		RateLimitPerHour:             opsFeishuAlertRateLimitPerHourDefault,
-		CooldownSeconds:              opsFeishuAlertCooldownSecondsDefault,
-		AccountIncidentDigestSeconds: opsFeishuAccountIncidentDigestSecondsDefault,
-		PricingMissingDigestSeconds:  opsFeishuPricingMissingDigestSecondsDefault,
+		Enabled:                        false,
+		RateLimitPerHour:               opsFeishuAlertRateLimitPerHourDefault,
+		CooldownSeconds:                opsFeishuAlertCooldownSecondsDefault,
+		AccountIncidentDigestSeconds:   opsFeishuAccountIncidentDigestSecondsDefault,
+		PricingMissingDigestSeconds:    opsFeishuPricingMissingDigestSecondsDefault,
+		UpstreamBalanceLowThresholdCNY: opsFeishuUpstreamBalanceLowThresholdCNYDefault,
 	}
 }
 
@@ -249,6 +253,11 @@ func updateOpsFeishuAlertConfig(dst *OpsFeishuAlertConfig, req *OpsFeishuAlertCo
 	if req.PricingMissingDigestSeconds != 0 {
 		dst.PricingMissingDigestSeconds = req.PricingMissingDigestSeconds
 	}
+	// 同上「0=未提供」语义：阈值 0 既是早于本字段的客户端的缺省解码值，也不是合法
+	// 触发级别（normalize 会回填默认 50），故保留存量值，不被旧 payload 抹零。
+	if req.UpstreamBalanceLowThresholdCNY != 0 {
+		dst.UpstreamBalanceLowThresholdCNY = req.UpstreamBalanceLowThresholdCNY
+	}
 }
 
 func normalizeOpsFeishuAlertConfig(cfg *OpsFeishuAlertConfig) {
@@ -271,6 +280,9 @@ func normalizeOpsFeishuAlertConfig(cfg *OpsFeishuAlertConfig) {
 	if cfg.PricingMissingDigestSeconds == 0 {
 		cfg.PricingMissingDigestSeconds = opsFeishuPricingMissingDigestSecondsDefault
 	}
+	if cfg.UpstreamBalanceLowThresholdCNY == 0 {
+		cfg.UpstreamBalanceLowThresholdCNY = opsFeishuUpstreamBalanceLowThresholdCNYDefault
+	}
 }
 
 func validateOpsFeishuAlertConfig(cfg OpsFeishuAlertConfig) error {
@@ -291,6 +303,11 @@ func validateOpsFeishuAlertConfig(cfg OpsFeishuAlertConfig) error {
 	}
 	if cfg.PricingMissingDigestSeconds < 30 || cfg.PricingMissingDigestSeconds > 86400 {
 		return errors.New("feishu.pricing_missing_digest_seconds must be between 30 and 86400")
+	}
+	// 阈值是正向触发级别（人民币）；normalize 已把 0 回填为默认，故此处不接受非正值。
+	// 上限给一个宽松的现实护栏，挡住明显误填。
+	if cfg.UpstreamBalanceLowThresholdCNY < 1 || cfg.UpstreamBalanceLowThresholdCNY > 1000000 {
+		return errors.New("feishu.upstream_balance_low_threshold_cny must be between 1 and 1000000")
 	}
 	return nil
 }

--- a/backend/internal/service/ops_settings_models.go
+++ b/backend/internal/service/ops_settings_models.go
@@ -46,6 +46,11 @@ type OpsFeishuAlertConfig struct {
 	// PricingMissingDigestSeconds 控制缺价模型零成本流量聚合摘要的 flush 间隔
 	// （秒）。首见模型的即时卡不受此值影响。默认 1800。
 	PricingMissingDigestSeconds int `json:"pricing_missing_digest_seconds"`
+	// UpstreamBalanceLowThresholdCNY 是「上游账号低余额」主动告警的触发阈值（人民币）。
+	// 后台 upstream_balance_sentinel 哨兵定时拉有公开余额 API 的上游渠道账号（当前仅
+	// DeepSeek channel_type=43）的余额，低于此值时提前发一条橙头飞书预警，让运营在归零
+	// 触发全量 402 断供前充值。正向触发级别（非开关）——总开关沿用 Feishu.Enabled。默认 50。
+	UpstreamBalanceLowThresholdCNY float64 `json:"upstream_balance_low_threshold_cny"`
 }
 
 // OpsEmailNotificationConfigUpdateRequest allows partial updates, while the

--- a/backend/internal/service/upstream_balance_sentinel_tk.go
+++ b/backend/internal/service/upstream_balance_sentinel_tk.go
@@ -1,0 +1,298 @@
+package service
+
+// TK: 上游账号低余额主动哨兵。
+//
+// 背景 / 动机见 docs / plan「上游账号低余额主动告警」。一句话：newapi 第五平台上游渠道
+// 账号余额耗尽时，bridge 把 402/429 吞码掩成 502 无限锤上游（2026-06-11 DeepSeek 余额归零
+// 事故）。被动 402 告警只能事后报；本哨兵定时**主动**拉有公开余额 API 的渠道账号余额，低于
+// 阈值就提前发一条橙头飞书预警，让运营在归零前充值。
+//
+// 设计对齐 anthropic_config_reconciler：单 ticker + Redis leader-lock（无 redis 降级 lockless）+
+// 心跳写 ops_job_heartbeats。只读上游 + 只发告警，不写账号状态、不改任何配置。
+// 当前只接 DeepSeek（唯一有公开 /user/balance 的渠道，见 newapi.BalanceProbeFor）。
+
+import (
+	"context"
+	"fmt"
+	"log/slog"
+	"strings"
+	"sync"
+	"time"
+
+	"github.com/Wei-Shaw/sub2api/internal/integration/newapi"
+
+	"github.com/google/uuid"
+	"github.com/redis/go-redis/v9"
+)
+
+const (
+	upstreamBalanceSentinelJobName = "upstream_balance_sentinel"
+	upstreamBalanceSentinelLockKey = "upstream:balance:sentinel:leader"
+	upstreamBalanceSentinelLockTTL = 4 * time.Minute
+	upstreamBalanceSentinelRunTO   = 60 * time.Second
+	upstreamBalanceCheckInterval   = 5 * time.Minute
+	upstreamBalanceHeartbeatTO     = 5 * time.Second
+)
+
+// balanceSentinelAccountStore is the narrow account dependency (the live
+// *accountRepository satisfies it). A small interface keeps runOnce unit-testable
+// without a full repository stub.
+type balanceSentinelAccountStore interface {
+	ListByPlatform(ctx context.Context, platform string) ([]Account, error)
+}
+
+// balanceSentinelHeartbeat is the narrow heartbeat dependency (*OpsService's repo
+// path satisfies it via OpsService). nil → heartbeat is skipped.
+type balanceSentinelHeartbeat interface {
+	UpsertJobHeartbeat(ctx context.Context, in *OpsUpsertJobHeartbeatInput) error
+}
+
+// UpstreamBalanceSentinel polls upstream channel-account balances and fires a
+// pre-emptive low-balance Feishu warning before the account hits zero.
+type UpstreamBalanceSentinel struct {
+	accounts   balanceSentinelAccountStore
+	http       newapi.HTTPDoer
+	notifier   *TKAccountIncidentNotifier
+	cfg        opsFeishuConfigProvider // reads Feishu.Enabled + threshold
+	recharge   rechargeURLResolver     // reuses the existing balance_low_notify_recharge_url setting
+	heartbeat  balanceSentinelHeartbeat
+	redis      *redis.Client
+	instanceID string
+
+	// armed tracks the per-account re-arm dedup: true once we've alerted on a
+	// crossing into low, cleared when the account recovers to >= threshold. Avoids
+	// re-alerting every tick while still low, and re-arms after a top-up.
+	armed map[int64]bool
+
+	stopCh   chan struct{}
+	stopOnce sync.Once
+	startOne sync.Once
+	wg       sync.WaitGroup
+
+	warnNoRedisOnce sync.Once
+}
+
+// rechargeURLResolver reads the operator-facing recharge link surfaced in the
+// alert card. *SettingService satisfies it; nil → no link in the card.
+type rechargeURLResolver interface {
+	GetValue(ctx context.Context, key string) (string, error)
+}
+
+// NewUpstreamBalanceSentinel constructs the sentinel. A nil accounts store or nil
+// notifier makes Start a no-op (keeps wire wiring safe for minimal deps).
+func NewUpstreamBalanceSentinel(
+	accounts balanceSentinelAccountStore,
+	httpUpstream newapi.HTTPDoer,
+	notifier *TKAccountIncidentNotifier,
+	cfg opsFeishuConfigProvider,
+	recharge rechargeURLResolver,
+	heartbeat balanceSentinelHeartbeat,
+	redisClient *redis.Client,
+) *UpstreamBalanceSentinel {
+	return &UpstreamBalanceSentinel{
+		accounts:   accounts,
+		http:       httpUpstream,
+		notifier:   notifier,
+		cfg:        cfg,
+		recharge:   recharge,
+		heartbeat:  heartbeat,
+		redis:      redisClient,
+		instanceID: uuid.NewString(),
+		armed:      map[int64]bool{},
+		stopCh:     make(chan struct{}),
+	}
+}
+
+// Start launches the sentinel goroutine. Safe to call once; nil deps no-op.
+func (s *UpstreamBalanceSentinel) Start() {
+	if s == nil || s.accounts == nil || s.notifier == nil || s.http == nil {
+		return
+	}
+	s.startOne.Do(func() {
+		s.wg.Add(1)
+		go func() {
+			defer s.wg.Done()
+			ticker := time.NewTicker(upstreamBalanceCheckInterval)
+			defer ticker.Stop()
+			for {
+				select {
+				case <-ticker.C:
+					s.runOnceLocked()
+				case <-s.stopCh:
+					return
+				}
+			}
+		}()
+	})
+}
+
+// Stop signals the goroutine to exit and waits. Safe to call once.
+func (s *UpstreamBalanceSentinel) Stop() {
+	if s == nil {
+		return
+	}
+	s.stopOnce.Do(func() {
+		close(s.stopCh)
+	})
+	s.wg.Wait()
+}
+
+// runOnceLocked acquires the redis leader lock (best-effort; lockless on no redis)
+// and runs one pass. Multiple replicas thus alert at most once per tick fleet-wide.
+func (s *UpstreamBalanceSentinel) runOnceLocked() {
+	release, ok := s.tryAcquireLock()
+	if !ok {
+		return
+	}
+	if release != nil {
+		defer release()
+	}
+	ctx, cancel := context.WithTimeout(context.Background(), upstreamBalanceSentinelRunTO)
+	defer cancel()
+	s.runOnce(ctx)
+}
+
+func (s *UpstreamBalanceSentinel) tryAcquireLock() (func(), bool) {
+	if s.redis == nil {
+		s.warnNoRedisOnce.Do(func() {
+			slog.Warn("upstream balance sentinel running without distributed lock (no redis)")
+		})
+		return nil, true
+	}
+	ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
+	defer cancel()
+	acquired, err := s.redis.SetNX(ctx, upstreamBalanceSentinelLockKey, s.instanceID, upstreamBalanceSentinelLockTTL).Result()
+	if err != nil {
+		slog.Warn("upstream balance sentinel leader lock SetNX failed; skipping cycle", "err", err)
+		return nil, false
+	}
+	if !acquired {
+		return nil, false
+	}
+	return func() {
+		releaseCtx, releaseCancel := context.WithTimeout(context.Background(), 5*time.Second)
+		defer releaseCancel()
+		// Best-effort release; TTL backstops a missed delete.
+		_, _ = s.redis.Del(releaseCtx, upstreamBalanceSentinelLockKey).Result()
+	}, true
+}
+
+// runOnce performs a single balance-poll pass. Tests call it directly to drive
+// the threshold-crossing + re-arm invariants without the ticker / lock.
+func (s *UpstreamBalanceSentinel) runOnce(ctx context.Context) {
+	startedAt := time.Now()
+	threshold, enabled := s.thresholdConfig(ctx)
+	if !enabled || threshold <= 0 {
+		// Feature off (Feishu disabled or no threshold). Skip silently — no upstream
+		// HTTP, no heartbeat noise.
+		return
+	}
+
+	accounts, err := s.accounts.ListByPlatform(ctx, PlatformNewAPI)
+	if err != nil {
+		s.recordHeartbeatError(startedAt, fmt.Errorf("list newapi accounts: %w", err))
+		return
+	}
+
+	rechargeURL := s.rechargeURL(ctx)
+
+	checked, low, probeErrs := 0, 0, 0
+	for i := range accounts {
+		acc := &accounts[i]
+		probe, ok := newapi.BalanceProbeFor(acc.ChannelType)
+		if !ok || !acc.IsActive() {
+			continue
+		}
+		checked++
+		apiKey := strings.TrimSpace(acc.GetCredential("api_key"))
+		baseURL := strings.TrimSpace(acc.GetCredential("base_url"))
+		proxyURL := ""
+		if acc.ProxyID != nil && acc.Proxy != nil {
+			proxyURL = acc.Proxy.URL()
+		}
+		res, perr := probe(ctx, s.http, baseURL, apiKey, proxyURL, acc.ID, acc.Concurrency)
+		if perr != nil {
+			// Upstream blip / bad credential — NOT a low-balance signal. Count it for
+			// the heartbeat but never alert (avoid false positives on transient errors).
+			probeErrs++
+			slog.Warn("upstream balance probe failed", "account_id", acc.ID, "name", acc.Name, "err", perr)
+			continue
+		}
+		isLow := !res.IsAvailable || res.AvailableCNY < threshold
+		if isLow {
+			low++
+			if !s.armed[acc.ID] {
+				s.armed[acc.ID] = true
+				s.notifier.NotifyUpstreamBalanceLow(acc, res.AvailableCNY, res.IsAvailable, threshold, rechargeURL)
+			}
+		} else {
+			// Recovered above threshold → re-arm so a future dip alerts again.
+			delete(s.armed, acc.ID)
+		}
+	}
+
+	s.recordHeartbeatSuccess(startedAt, checked, low, probeErrs)
+}
+
+// thresholdConfig reads the low-balance threshold and whether Feishu alerting is
+// enabled. Returns (threshold, enabled).
+func (s *UpstreamBalanceSentinel) thresholdConfig(ctx context.Context) (float64, bool) {
+	if s.cfg == nil {
+		return 0, false
+	}
+	cfg, err := s.cfg.GetEmailNotificationConfig(ctx)
+	if err != nil || cfg == nil {
+		return 0, false
+	}
+	return cfg.Feishu.UpstreamBalanceLowThresholdCNY, cfg.Feishu.Enabled
+}
+
+func (s *UpstreamBalanceSentinel) rechargeURL(ctx context.Context) string {
+	if s.recharge == nil {
+		return ""
+	}
+	v, err := s.recharge.GetValue(ctx, SettingKeyBalanceLowNotifyRechargeURL)
+	if err != nil {
+		return ""
+	}
+	return strings.TrimSpace(v)
+}
+
+func (s *UpstreamBalanceSentinel) recordHeartbeatSuccess(runAt time.Time, checked, low, probeErrs int) {
+	if s == nil || s.heartbeat == nil {
+		return
+	}
+	now := time.Now().UTC()
+	durMs := time.Since(runAt).Milliseconds()
+	result := fmt.Sprintf("checked=%d low=%d probe_errors=%d", checked, low, probeErrs)
+	ctx, cancel := context.WithTimeout(context.Background(), upstreamBalanceHeartbeatTO)
+	defer cancel()
+	_ = s.heartbeat.UpsertJobHeartbeat(ctx, &OpsUpsertJobHeartbeatInput{
+		JobName:        upstreamBalanceSentinelJobName,
+		LastRunAt:      &runAt,
+		LastSuccessAt:  &now,
+		LastDurationMs: &durMs,
+		LastResult:     &result,
+	})
+}
+
+func (s *UpstreamBalanceSentinel) recordHeartbeatError(runAt time.Time, err error) {
+	if s == nil || s.heartbeat == nil || err == nil {
+		return
+	}
+	now := time.Now().UTC()
+	durMs := time.Since(runAt).Milliseconds()
+	msg := err.Error()
+	if len(msg) > 2048 {
+		msg = msg[:2048]
+	}
+	ctx, cancel := context.WithTimeout(context.Background(), upstreamBalanceHeartbeatTO)
+	defer cancel()
+	_ = s.heartbeat.UpsertJobHeartbeat(ctx, &OpsUpsertJobHeartbeatInput{
+		JobName:        upstreamBalanceSentinelJobName,
+		LastRunAt:      &runAt,
+		LastErrorAt:    &now,
+		LastError:      &msg,
+		LastDurationMs: &durMs,
+	})
+}

--- a/backend/internal/service/upstream_balance_sentinel_tk_test.go
+++ b/backend/internal/service/upstream_balance_sentinel_tk_test.go
@@ -1,0 +1,201 @@
+//go:build unit
+
+package service
+
+import (
+	"context"
+	"io"
+	"net/http"
+	"strings"
+	"sync"
+	"testing"
+	"time"
+
+	newapiconstant "github.com/QuantumNous/new-api/constant"
+)
+
+// fakeBalanceDoer returns a canned DeepSeek /user/balance body per call, driven by
+// a script so each runOnce pass can present a different balance.
+type fakeBalanceDoer struct {
+	mu     sync.Mutex
+	bodies []string // consumed FIFO; last one repeats
+	calls  int
+}
+
+func (d *fakeBalanceDoer) Do(req *http.Request, proxyURL string, accountID int64, accountConcurrency int) (*http.Response, error) {
+	d.mu.Lock()
+	defer d.mu.Unlock()
+	idx := d.calls
+	if idx >= len(d.bodies) {
+		idx = len(d.bodies) - 1
+	}
+	body := d.bodies[idx]
+	d.calls++
+	return &http.Response{
+		StatusCode: http.StatusOK,
+		Body:       io.NopCloser(strings.NewReader(body)),
+		Header:     http.Header{},
+	}, nil
+}
+
+// fakeFeishuCfg yields a config with Feishu enabled (so runOnce proceeds) but no
+// webhook URL — so the notifier's async send is a safe no-op (no network).
+type fakeFeishuCfg struct {
+	threshold float64
+	enabled   bool
+}
+
+func (c fakeFeishuCfg) GetEmailNotificationConfig(_ context.Context) (*OpsEmailNotificationConfig, error) {
+	return &OpsEmailNotificationConfig{
+		Feishu: OpsFeishuAlertConfig{
+			Enabled:                        c.enabled,
+			UpstreamBalanceLowThresholdCNY: c.threshold,
+		},
+	}, nil
+}
+
+type fakeAccountStore struct{ accounts []Account }
+
+func (s fakeAccountStore) ListByPlatform(_ context.Context, _ string) ([]Account, error) {
+	return s.accounts, nil
+}
+
+// The low-balance alert method is on the concrete *TKAccountIncidentNotifier, so
+// these tests assert the deterministic re-arm invariant on the sentinel's `armed`
+// map (the alert is fired iff armed flips false→true), and separately unit-test
+// the card text. The notifier itself sends nothing because its config carries no
+// webhook URL (send() short-circuits), so there is no network in these tests.
+
+func timeFixed() time.Time { return time.Date(2026, 6, 12, 8, 0, 0, 0, time.UTC) }
+
+func dsBody(balance string, available bool) string {
+	avail := "true"
+	if !available {
+		avail = "false"
+	}
+	return `{"is_available":` + avail + `,"balance_infos":[{"currency":"CNY","total_balance":"` + balance + `"}]}`
+}
+
+func newTestSentinel(doer *fakeBalanceDoer, store fakeAccountStore, threshold float64) *UpstreamBalanceSentinel {
+	notifier := newTKAccountIncidentNotifier(fakeFeishuCfg{threshold: threshold, enabled: true}, "test")
+	return NewUpstreamBalanceSentinel(
+		store,
+		doer,
+		notifier,
+		fakeFeishuCfg{threshold: threshold, enabled: true},
+		nil, // recharge resolver: nil → no link
+		nil, // heartbeat: nil → skipped
+		nil, // redis: nil → lockless
+	)
+}
+
+func dsAccount(id int64) Account {
+	return Account{
+		ID:          id,
+		Name:        "ds-test",
+		Platform:    PlatformNewAPI,
+		Status:      StatusActive,
+		ChannelType: newapiconstant.ChannelTypeDeepSeek,
+		Credentials: map[string]any{"api_key": "sk-test", "base_url": "https://api.deepseek.com"},
+	}
+}
+
+// TestSentinelReArmDedup drives the core invariant: alert on first crossing into
+// low (armed=true), stay armed while still low, re-arm (armed cleared) on recovery,
+// and re-arm again on the next dip.
+func TestSentinelReArmDedup(t *testing.T) {
+	const threshold = 50.0
+	acc := dsAccount(39)
+	// Script: low(10) → low(5) → recovered(298) → low(8)
+	doer := &fakeBalanceDoer{bodies: []string{
+		dsBody("10.00", true),  // pass 1: low → arm
+		dsBody("5.00", true),   // pass 2: still low → stays armed, no re-alert
+		dsBody("298.00", true), // pass 3: recovered → disarm
+		dsBody("8.00", true),   // pass 4: low again → re-arm
+	}}
+	s := newTestSentinel(doer, fakeAccountStore{accounts: []Account{acc}}, threshold)
+	ctx := context.Background()
+
+	s.runOnce(ctx)
+	if !s.armed[39] {
+		t.Fatalf("pass1: expected account armed after first low crossing")
+	}
+	s.runOnce(ctx)
+	if !s.armed[39] {
+		t.Fatalf("pass2: expected account to stay armed while still low")
+	}
+	s.runOnce(ctx)
+	if s.armed[39] {
+		t.Fatalf("pass3: expected account disarmed after recovery above threshold")
+	}
+	s.runOnce(ctx)
+	if !s.armed[39] {
+		t.Fatalf("pass4: expected account re-armed on the next dip below threshold")
+	}
+	if doer.calls != 4 {
+		t.Errorf("expected 4 probe calls, got %d", doer.calls)
+	}
+}
+
+// TestSentinelIsAvailableFalseArms verifies the upstream "is_available=false" hard
+// signal alone arms the account even if the parsed balance is above threshold.
+func TestSentinelIsAvailableFalseArms(t *testing.T) {
+	const threshold = 50.0
+	acc := dsAccount(39)
+	// balance string above threshold, but is_available=false → still low.
+	doer := &fakeBalanceDoer{bodies: []string{dsBody("999.00", false)}}
+	s := newTestSentinel(doer, fakeAccountStore{accounts: []Account{acc}}, threshold)
+	s.runOnce(context.Background())
+	if !s.armed[39] {
+		t.Fatalf("expected account armed when upstream reports is_available=false")
+	}
+}
+
+// TestSentinelFeatureOffSkips verifies that with Feishu disabled, runOnce makes no
+// upstream probe call at all.
+func TestSentinelFeatureOffSkips(t *testing.T) {
+	doer := &fakeBalanceDoer{bodies: []string{dsBody("1.00", true)}}
+	notifier := newTKAccountIncidentNotifier(fakeFeishuCfg{threshold: 50, enabled: false}, "test")
+	s := NewUpstreamBalanceSentinel(
+		fakeAccountStore{accounts: []Account{dsAccount(39)}},
+		doer, notifier,
+		fakeFeishuCfg{threshold: 50, enabled: false},
+		nil, nil, nil,
+	)
+	s.runOnce(context.Background())
+	if doer.calls != 0 {
+		t.Errorf("expected 0 probe calls when feature off, got %d", doer.calls)
+	}
+	if s.armed[39] {
+		t.Errorf("expected no arming when feature off")
+	}
+}
+
+// TestSentinelNonDeepSeekSkipped verifies a non-probeable channel type is skipped.
+func TestSentinelNonDeepSeekSkipped(t *testing.T) {
+	acc := dsAccount(39)
+	acc.ChannelType = 0 // not registered
+	doer := &fakeBalanceDoer{bodies: []string{dsBody("1.00", true)}}
+	s := newTestSentinel(doer, fakeAccountStore{accounts: []Account{acc}}, 50)
+	s.runOnce(context.Background())
+	if doer.calls != 0 {
+		t.Errorf("expected 0 probe calls for non-DeepSeek channel, got %d", doer.calls)
+	}
+}
+
+// TestBuildUpstreamBalanceLowText sanity-checks the card body renders the key
+// fields without panicking on a minimal account.
+func TestBuildUpstreamBalanceLowText(t *testing.T) {
+	acc := dsAccount(39)
+	body := buildUpstreamBalanceLowText("prod", &acc, 12.34, true, 50, "https://recharge.example", timeFixed())
+	for _, want := range []string{"12.34", "50.00", "recharge.example", "ds-test", "newapi"} {
+		if !strings.Contains(body, want) {
+			t.Errorf("card body missing %q\n%s", want, body)
+		}
+	}
+	// is_available=false adds the urgent line.
+	body2 := buildUpstreamBalanceLowText("prod", &acc, 0, false, 50, "", timeFixed())
+	if !strings.Contains(body2, "余额可能已归零") {
+		t.Errorf("expected urgent availability note when is_available=false\n%s", body2)
+	}
+}

--- a/backend/internal/service/wire.go
+++ b/backend/internal/service/wire.go
@@ -270,6 +270,34 @@ func ProvideAnthropicConfigReconciler(
 	return rec
 }
 
+// ProvideUpstreamBalanceSentinel creates and starts the TK per-node upstream
+// low-balance sentinel. It polls newapi channel accounts that expose a public
+// balance API (currently DeepSeek) and fires a pre-emptive Feishu warning before
+// an account's balance hits zero. accountRepo/opsRepo satisfy the narrow
+// dependencies; ops provides the threshold + Feishu-enabled read; settingSvc
+// supplies the recharge link. Read-only against upstream; never writes accounts.
+func ProvideUpstreamBalanceSentinel(
+	accountRepo AccountRepository,
+	httpUpstream HTTPUpstream,
+	notifier *TKAccountIncidentNotifier,
+	ops *OpsService,
+	settingRepo SettingRepository,
+	opsRepo OpsRepository,
+	redisClient *redis.Client,
+) *UpstreamBalanceSentinel {
+	var cfgProvider opsFeishuConfigProvider
+	if ops != nil {
+		cfgProvider = ops
+	}
+	var recharge rechargeURLResolver
+	if settingRepo != nil {
+		recharge = settingRepo
+	}
+	s := NewUpstreamBalanceSentinel(accountRepo, httpUpstream, notifier, cfgProvider, recharge, opsRepo, redisClient)
+	s.Start()
+	return s
+}
+
 // ProvideEdgeAccountsAggregator creates the prod-side cross-edge read-only
 // account aggregator. It owns its own short-timeout HTTP client (constructed
 // here rather than wired) to avoid colliding with other *http.Client providers
@@ -588,6 +616,7 @@ var ProviderSet = wire.NewSet(
 	// scheduler_rate_limit_reaper.go.
 	ProvideSchedulerRateLimitReaper,
 	ProvideAnthropicConfigReconciler,
+	ProvideUpstreamBalanceSentinel,
 	// TK: prod-side cross-edge read-only account overview — see edge_accounts_aggregator_tk.go.
 	ProvideEdgeAccountsAggregator,
 	NewIdentityService,

--- a/backend/internal/web/dist/frontend-source.json
+++ b/backend/internal/web/dist/frontend-source.json
@@ -1,7 +1,7 @@
 {
   "algorithm": "sha256(git-ls-files:path,size,content)",
   "file_count": 467,
-  "hash": "488b8f09205528d779cb58809e9e64866cb7cafb59fe09a6fba7df0093085d9b",
+  "hash": "4081ec821498b606267ea5c4f37c9c97af4d77b085c68797b23d6f38d6518f01",
   "schema": 1,
   "source": "frontend/"
 }

--- a/frontend/src/api/admin/ops.ts
+++ b/frontend/src/api/admin/ops.ts
@@ -762,6 +762,7 @@ export interface EmailNotificationConfig {
     signing_secret_configured: boolean
     rate_limit_per_hour: number
     cooldown_seconds: number
+    upstream_balance_low_threshold_cny: number
   }
 }
 

--- a/frontend/src/i18n/locales/en.ts
+++ b/frontend/src/i18n/locales/en.ts
@@ -5551,6 +5551,8 @@ export default {
         feishuSecretKeepPlaceholder: 'Configured, leave empty to keep',
         feishuSecretConfiguredHint: 'Configured, leave empty to keep; enter a new value to replace it.',
         feishuCooldownSeconds: 'Cooldown seconds',
+        feishuUpstreamBalanceLowThreshold: 'Upstream balance alert threshold (CNY)',
+        feishuUpstreamBalanceLowThresholdHint: 'A background sentinel polls upstream channel accounts that expose a public balance API (currently DeepSeek) and sends a pre-emptive Feishu warning when balance drops below this value, before it hits zero. Requires Feishu alerts enabled above.',
         configured: 'Configured',
         notConfigured: 'Not configured',
         dailySummary: 'Daily summary',
@@ -5576,7 +5578,8 @@ export default {
           feishuWebhookRequired: 'Feishu P0 alerts require a configured webhook when enabled',
           feishuWebhookHttps: 'Feishu webhook must be an HTTPS URL',
           feishuRateLimitRange: 'Feishu rate limit per hour must be between 1 and 24',
-          feishuCooldownRange: 'Feishu cooldown must be between 60 and 86400 seconds'
+          feishuCooldownRange: 'Feishu cooldown must be between 60 and 86400 seconds',
+          feishuUpstreamBalanceLowThresholdRange: 'Upstream balance alert threshold must be between 1 and 1000000'
         }
       },
       settings: {

--- a/frontend/src/i18n/locales/zh.ts
+++ b/frontend/src/i18n/locales/zh.ts
@@ -5707,6 +5707,8 @@ export default {
         feishuSecretKeepPlaceholder: '已配置，留空保留',
         feishuSecretConfiguredHint: '已配置，留空保留；输入新值会覆盖。',
         feishuCooldownSeconds: '冷却时间（秒）',
+        feishuUpstreamBalanceLowThreshold: '上游余额告警阈值（元）',
+        feishuUpstreamBalanceLowThresholdHint: '后台定时拉有公开余额接口的上游渠道账号（当前 DeepSeek）余额，低于此值提前发飞书预警，避免归零断供。需启用上方飞书告警。',
         configured: '已配置',
         notConfigured: '未配置',
         dailySummary: '每日摘要',
@@ -5732,7 +5734,8 @@ export default {
           feishuWebhookRequired: '启用飞书 P0 告警时必须配置 Webhook',
           feishuWebhookHttps: '飞书 Webhook 必须是 HTTPS URL',
           feishuRateLimitRange: '飞书每小时限额必须在 1 到 24 之间',
-          feishuCooldownRange: '飞书冷却时间必须在 60 到 86400 秒之间'
+          feishuCooldownRange: '飞书冷却时间必须在 60 到 86400 秒之间',
+          feishuUpstreamBalanceLowThresholdRange: '上游余额告警阈值必须在 1 到 1000000 之间'
         }
       },
       settings: {

--- a/frontend/src/views/admin/ops/components/OpsEmailNotificationCard.vue
+++ b/frontend/src/views/admin/ops/components/OpsEmailNotificationCard.vue
@@ -166,6 +166,9 @@ const editorValidation = computed(() => {
   if (!(typeof draft.value.feishu.cooldown_seconds === 'number' && Number.isFinite(draft.value.feishu.cooldown_seconds) && draft.value.feishu.cooldown_seconds >= 60 && draft.value.feishu.cooldown_seconds <= 86400)) {
     errors.push(t('admin.ops.email.validation.feishuCooldownRange'))
   }
+  if (!(typeof draft.value.feishu.upstream_balance_low_threshold_cny === 'number' && Number.isFinite(draft.value.feishu.upstream_balance_low_threshold_cny) && draft.value.feishu.upstream_balance_low_threshold_cny >= 1 && draft.value.feishu.upstream_balance_low_threshold_cny <= 1000000)) {
+    errors.push(t('admin.ops.email.validation.feishuUpstreamBalanceLowThresholdRange'))
+  }
 
   return { valid: errors.length === 0, errors }
 })
@@ -282,6 +285,10 @@ onMounted(() => {
           <div class="text-xs text-gray-600 dark:text-gray-300">
             {{ t('admin.ops.email.feishuCooldownSeconds') }}:
             <span class="ml-1 font-medium text-gray-900 dark:text-white">{{ config.feishu.cooldown_seconds }}</span>
+          </div>
+          <div class="text-xs text-gray-600 dark:text-gray-300">
+            {{ t('admin.ops.email.feishuUpstreamBalanceLowThreshold') }}:
+            <span class="ml-1 font-medium text-gray-900 dark:text-white">{{ config.feishu.upstream_balance_low_threshold_cny }}</span>
           </div>
         </div>
       </div>
@@ -431,6 +438,11 @@ onMounted(() => {
           <div>
             <div class="mb-1 text-xs font-medium text-gray-600 dark:text-gray-300">{{ t('admin.ops.email.feishuCooldownSeconds') }}</div>
             <input v-model.number="draft.feishu.cooldown_seconds" data-testid="ops-feishu-cooldown-input" type="number" min="60" max="86400" class="input" />
+          </div>
+          <div>
+            <div class="mb-1 text-xs font-medium text-gray-600 dark:text-gray-300">{{ t('admin.ops.email.feishuUpstreamBalanceLowThreshold') }}</div>
+            <input v-model.number="draft.feishu.upstream_balance_low_threshold_cny" data-testid="ops-feishu-upstream-balance-threshold-input" type="number" min="1" max="1000000" class="input" />
+            <p class="mt-1 text-xs text-gray-500 dark:text-gray-400">{{ t('admin.ops.email.feishuUpstreamBalanceLowThresholdHint') }}</p>
           </div>
         </div>
       </div>

--- a/frontend/src/views/admin/ops/components/__tests__/OpsEmailNotificationCard.spec.ts
+++ b/frontend/src/views/admin/ops/components/__tests__/OpsEmailNotificationCard.spec.ts
@@ -97,6 +97,7 @@ function sampleConfig(overrides: Partial<EmailNotificationConfig> = {}): EmailNo
       signing_secret_configured: false,
       rate_limit_per_hour: 3,
       cooldown_seconds: 3600,
+      upstream_balance_low_threshold_cny: 50,
     },
     ...overrides,
   }
@@ -131,6 +132,7 @@ describe('OpsEmailNotificationCard', () => {
         signing_secret_configured: true,
         rate_limit_per_hour: 3,
         cooldown_seconds: 3600,
+        upstream_balance_low_threshold_cny: 50,
       },
     }))
 

--- a/scripts/sentinels/newapi.json
+++ b/scripts/sentinels/newapi.json
@@ -391,6 +391,30 @@
         "s.notifyAccountSchedulingBlocked(account, time.Time{}, \"auth_error\", errorMsg)"
       ],
       "rationale": "handleAuthError must forward the upstream error message as the Feishu permanent-disable card detail (e.g. 'Payment required (402): Insufficient Balance'). notifyAccountSchedulingBlocked's detail parameter is variadic, so an upstream merge reverting this call to the bare 3-arg form compiles clean and silently strips the upstream status/message from the P0 card — losing the alert-content half of the 2026-06-11 incident fix while the alert itself still fires."
+    },
+    {
+      "path": "backend/internal/integration/newapi/balance_probe_tk.go",
+      "must_contain": [
+        "func BalanceProbeFor",
+        "newapiconstant.ChannelTypeDeepSeek: ProbeDeepSeekBalance"
+      ],
+      "rationale": "Per-channel upstream balance-probe dispatch for the fifth platform. The DeepSeek registry binding is the only thing wiring channel_type=43 to a real /user/balance probe; dropping it (or BalanceProbeFor) compiles clean and silently turns the upstream low-balance sentinel into a no-op (it lists accounts, finds no probe, alerts nothing) — re-opening the 2026-06-11 DeepSeek balance-zero blind spot the sentinel exists to pre-empt. Only channels with a per-api-key balance endpoint belong here (火山/千问 balances are cloud-account-level AK/SK billing APIs, intentionally absent)."
+    },
+    {
+      "path": "backend/internal/service/upstream_balance_sentinel_tk.go",
+      "must_contain": [
+        "newapi.BalanceProbeFor(acc.ChannelType)",
+        "s.notifier.NotifyUpstreamBalanceLow",
+        "ListByPlatform(ctx, PlatformNewAPI)"
+      ],
+      "rationale": "The poll->detect->alert chain of the upstream low-balance sentinel: list newapi accounts, probe those exposing a per-key balance API, fire a pre-emptive Feishu warning below threshold. An upstream merge that drops any link (the PlatformNewAPI listing, the BalanceProbeFor lookup, or the NotifyUpstreamBalanceLow call) compiles clean but silently disables proactive low-balance alerting, leaving only the reactive #724 402 path that fires after the account is already balance-exhausted and permanently disabled."
+    },
+    {
+      "path": "backend/internal/service/wire.go",
+      "must_contain": [
+        "ProvideUpstreamBalanceSentinel,"
+      ],
+      "rationale": "ProviderSet member that constructs AND Start()s the upstream low-balance sentinel. The sentinel is a side-effect service consumed only by provideCleanup, so if an upstream merge drops this wire.NewSet entry together with the provideCleanup wiring, Wire regenerates clean with no sentinel and the background poller silently never starts. The trailing comma pins the set member specifically (dropping the provider func instead fails compile, so only the registration needs guarding)."
     }
   ]
 }


### PR DESCRIPTION
## 背景

2026-06-11 中午 prod 上 deepseek-v4-pro 大面积不稳定。排查坐实根因：唯一的 DeepSeek 上游渠道账号 `ds-官`（account 39，platform=newapi、channel_type=43、直连 api.deepseek.com）**余额归零**——6946 条上游 402 `Insufficient Balance` + 160 条"并发被余额压到 50"的 429，全被 newapi bridge 吞码掩成 **502 无限锤上游**（峰值 ~500 次/分钟）。对客户表现为"并发开小也容易 retry / 中午一段时间连不上 ds"。

现状缺口：仓库里**没有任何主动低余额告警**。唯一相关的是 #724 的**被动 402 告警**——必须等请求真撞上余额归零才触发，已经在断供中，无法提前预防。`balance_low_notify_*` 那套是给**终端客户**自己余额用的，与我们对接上游的钱包是两根轴。

## 方案

新增 per-node 后台哨兵 `upstream_balance_sentinel`：每 5min（Redis leader-lock + `ops_job_heartbeats` 心跳）**主动**拉有 per-api-key 余额端点的渠道账号余额，低于阈值发橙头飞书**预警**，让运营在归零断供前充值。只读上游、只发告警、**不写账号状态、不改任何配置**。

设计原则（乔布斯把关，刻意从简）：
- **聚焦**：只接 DeepSeek（唯一有 `GET /user/balance` per-key 余额端点的渠道）。火山方舟(45)/通义千问·Ali(17) 的余额是**云账号级 AK/SK 计费 OpenAPI**，凭证与粒度都对不上，结构上无法低成本复用——继续靠 #724 反应式 402 兜底。`BalanceProbeFor` 派发表把这条准入写进注释。
- **简洁**：不新建表/不新建 Redis 缓存/不改接口（告警走具体类型 `*TKAccountIncidentNotifier` 新方法，省去 3 个 stub）。阈值复用现成 ops 飞书设置 JSON（默认 50 CNY），充值链接复用 `balance_low_notify_recharge_url`，总开关沿用 `Feishu.Enabled`。
- **re-arm 去重**：首次跨入低于阈值告警一次，仍低则静默，回升到 ≥阈值清位，再次下探重新告警。

## 改动

**新增**
- `integration/newapi/balance_probe_tk.go` (+test) — DeepSeek `/user/balance` 探测 + `BalanceProbeFor(channelType)` 派发表
- `service/upstream_balance_sentinel_tk.go` (+test) — 哨兵（仿 `anthropic_config_reconciler`：ticker + leader-lock + 心跳 + re-arm）
- `service/account_incident_notifier_tk_balance.go` — 复用现成飞书通道的橙头预警卡

**追加（不重写上游）**
- `ops_settings_models.go` / `ops_settings.go` — `UpstreamBalanceLowThresholdCNY`（default/merge/normalize/validate 四段）
- `wire.go` / `cmd/server/wire.go` / `wire_gen.go` — Provider + cleanup + 重生成
- 前端 `OpsEmailNotificationCard.vue` + `ops.ts` + en/zh i18n — 阈值输入（与 cooldown 同款）
- `.golangci.yml` — 哨兵文件加入 redis depguard 白名单（与 reconciler 同理）

## 验证

- `go build ./...` + `go build -tags=integration ./...` ✅
- `go test -tags=unit ./...` 全过（新增 8 个测试：解析/派发/re-arm 去重/`is_available` 硬信号/功能关跳过/卡片渲染）
- `golangci-lint run ./...` 0 issues
- 前端 typecheck + lint:check + card spec ✅
- `scripts/preflight.sh` PASS（含全部 sub2api sentinels + 前端 dist 重建 + ancestry anchor）

## Checklist

- [x] 纯追加，无 upstream 符号删除；commit 带 `upstream-touch-guarded`
- [x] 有前端改动，**未**带 `no-web-impact`
- [x] 已 rebase 到 `origin/main`（ancestry guard 满足）
- [x] TK feature → reviewer 用 **Squash and merge**

🤖 Generated with [Claude Code](https://claude.com/claude-code)