### PR TITLE
fix(ops): cancel-storm 告警按平台定制风险文案，去除非-anthropic key 的 Anthropic 误导

### DIFF
--- a/backend/internal/handler/ops_error_logger_tk_cancel_storm.go
+++ b/backend/internal/handler/ops_error_logger_tk_cancel_storm.go
@@ -29,5 +29,13 @@ func tkObserveCancelStorm(c *gin.Context, ops *service.OpsService) {
 			model = s
 		}
 	}
-	ops.ObserveCancelStorm(apiKey.ID, apiKey.Name, model, tkUpstreamClientCanceled(c))
+	// Authoritative group platform (anthropic/openai/gemini/antigravity/newapi) so
+	// the alert names the actual upstream at risk instead of always blaming
+	// Anthropic. Only the real group platform is trusted; an empty fallback (no path
+	// guess) keeps this off the per-request hot path with zero allocation and avoids
+	// a fresh misattribution — guessPlatformFromPath maps /v1/messages to openai,
+	// which would mislabel an anthropic key whose Group is not loaded. Unknown
+	// platform → cancelStormAdvice emits the neutral, un-named wording.
+	platform := resolveOpsPlatform(apiKey, "")
+	ops.ObserveCancelStorm(apiKey.ID, apiKey.Name, model, platform, tkUpstreamClientCanceled(c))
 }

--- a/backend/internal/service/ops_cancel_storm_tk.go
+++ b/backend/internal/service/ops_cancel_storm_tk.go
@@ -191,8 +191,10 @@ func (d *cancelStormDetector) loadConfig() *CancelStormConfig {
 
 // observe feeds one terminal request outcome into the per-key window and fires an
 // alert when the cancel rate crosses the configured threshold. No-op unless mode
-// is "detect_only".
-func (d *cancelStormDetector) observe(apiKeyID int64, apiKeyName, model string, canceled bool) {
+// is "detect_only". platform is the request's resolved group platform; it only
+// shapes the alert's risk wording (anthropic OAuth org-disable vs. generic
+// upstream-spend on the other platforms), never the detection.
+func (d *cancelStormDetector) observe(apiKeyID int64, apiKeyName, model, platform string, canceled bool) {
 	if d == nil || apiKeyID <= 0 {
 		return
 	}
@@ -246,7 +248,7 @@ func (d *cancelStormDetector) observe(apiKeyID int64, apiKeyName, model string, 
 	d.mu.Unlock()
 
 	if shouldAlert {
-		go d.sendAlert(apiKeyID, apiKeyName, model, rate, total, cancels, cfg)
+		go d.sendAlert(apiKeyID, apiKeyName, model, platform, rate, total, cancels, cfg)
 	}
 }
 
@@ -270,7 +272,7 @@ func (d *cancelStormDetector) sweepLocked(now time.Time, window time.Duration) {
 	}
 }
 
-func (d *cancelStormDetector) sendAlert(apiKeyID int64, apiKeyName, model string, rate float64, total, canceled int, cfg *CancelStormConfig) {
+func (d *cancelStormDetector) sendAlert(apiKeyID int64, apiKeyName, model, platform string, rate float64, total, canceled int, cfg *CancelStormConfig) {
 	defer func() {
 		if r := recover(); r != nil {
 			logger.LegacyPrintf("service.cancel_storm", "[CancelStorm] alert panic recovered: %v", r)
@@ -290,14 +292,14 @@ func (d *cancelStormDetector) sendAlert(apiKeyID int64, apiKeyName, model string
 	if d.siteID != "" && d.siteID != "unknown" {
 		title = title + " · " + d.siteID
 	}
-	body := buildCancelStormText(d.siteID, apiKeyID, apiKeyName, model, rate, total, canceled, cfg, d.currentTime())
+	body := buildCancelStormText(d.siteID, apiKeyID, apiKeyName, model, platform, rate, total, canceled, cfg, d.currentTime())
 	payload := feishuCardPayload(fcfg.Feishu, d.now, "orange", title, body)
 	if sErr := sendFeishuPayload(ctx, d.httpClient, fcfg.Feishu, payload); sErr != nil {
 		logger.LegacyPrintf("service.cancel_storm", "[CancelStorm] feishu send failed: %s", sErr.Error())
 	}
 }
 
-func buildCancelStormText(site string, apiKeyID int64, apiKeyName, model string, rate float64, total, canceled int, cfg *CancelStormConfig, now time.Time) string {
+func buildCancelStormText(site string, apiKeyID int64, apiKeyName, model, platform string, rate float64, total, canceled int, cfg *CancelStormConfig, now time.Time) string {
 	keyLabel := fmt.Sprintf("#%d", apiKeyID)
 	if name := strings.TrimSpace(apiKeyName); name != "" {
 		keyLabel = fmt.Sprintf("%s (#%d)", name, apiKeyID)
@@ -306,7 +308,6 @@ func buildCancelStormText(site string, apiKeyID int64, apiKeyName, model string,
 	if modelLabel == "" {
 		modelLabel = "-"
 	}
-	advice := "疑似外部客户端以短超时/程序化方式滥用该 key,持续高取消率会触发上游(Anthropic)滥用风控并可能封禁承载账号。建议核查该 key 来源,必要时降并发/限流或暂停该 key。"
 	return fmt.Sprintf("**节点**：%s\n**API Key**：%s\n**模型**：%s\n**取消率**：%.0f%%（%d/%d，窗口 %ds）\n**模式**：%s\n**时间**：%s\n\n**建议**：%s",
 		escapeFeishuText(site),
 		escapeFeishuText(keyLabel),
@@ -314,8 +315,32 @@ func buildCancelStormText(site string, apiKeyID int64, apiKeyName, model string,
 		rate*100, canceled, total, cfg.WindowSeconds,
 		escapeFeishuText(cfg.Mode),
 		escapeFeishuText(formatAlertTime(now)),
-		advice,
+		cancelStormAdvice(platform),
 	)
+}
+
+// cancelStormAdvice tailors the alert's risk wording to the account-carrying
+// platform. The detector was born from an Anthropic subscription-OAuth account
+// getting org-disabled by a client-cancel flood — that catastrophic, hard-to-
+// recover failure mode is unique to anthropic and must keep its sharp warning.
+// For every other platform the same hardcoded "Anthropic 封禁承载账号" string is a
+// misattribution (a newapi/openai/gemini key never routes to an anthropic OAuth
+// account), so it would point oncall at an account that is not in the path. There
+// the real cost is wasted upstream spend + that provider's own abuse/rate
+// controls, so we name the actual platform instead of Anthropic.
+func cancelStormAdvice(platform string) string {
+	const prefix = "疑似外部客户端以短超时/程序化方式滥用该 key。"
+	const suffix = "建议核查该 key 来源，必要时降并发/限流或暂停该 key。"
+	var risk string
+	switch strings.ToLower(strings.TrimSpace(platform)) {
+	case PlatformAnthropic:
+		risk = "持续高取消率会触发上游 Anthropic 滥用风控，可能导致订阅 OAuth 承载账号被封禁（org-disable，难以恢复）。"
+	case "":
+		risk = "持续高取消率会无谓消耗上游算力与额度，并可能触发上游服务商的滥用/限流风控。"
+	default:
+		risk = fmt.Sprintf("持续高取消率会无谓消耗上游（%s）算力与额度，并可能触发该上游服务商的滥用/限流风控。", platform)
+	}
+	return prefix + risk + suffix
 }
 
 func isOpusModel(model string) bool {
@@ -323,11 +348,13 @@ func isOpusModel(model string) bool {
 }
 
 // ObserveCancelStorm feeds one terminal request outcome (api key id + name, model,
-// whether the client canceled) into the per-key cancel-storm detector. No-op
-// unless cancel_storm_config mode is "detect_only". Safe on nil receiver / detector.
-func (s *OpsService) ObserveCancelStorm(apiKeyID int64, apiKeyName, model string, canceled bool) {
+// resolved group platform, whether the client canceled) into the per-key
+// cancel-storm detector. No-op unless cancel_storm_config mode is "detect_only".
+// Safe on nil receiver / detector. platform only shapes the alert's risk wording,
+// never the detection.
+func (s *OpsService) ObserveCancelStorm(apiKeyID int64, apiKeyName, model, platform string, canceled bool) {
 	if s == nil || s.cancelStorm == nil {
 		return
 	}
-	s.cancelStorm.observe(apiKeyID, apiKeyName, model, canceled)
+	s.cancelStorm.observe(apiKeyID, apiKeyName, model, platform, canceled)
 }

--- a/backend/internal/service/ops_cancel_storm_tk_test.go
+++ b/backend/internal/service/ops_cancel_storm_tk_test.go
@@ -88,7 +88,7 @@ func TestCancelStormModeOffNoAlert(t *testing.T) {
 	doer := &blockingFeishuDoer{}
 	d := newTestCancelStormDetector(&CancelStormConfig{Mode: cancelStormModeOff, WindowSeconds: 60, MinSampleCount: 2}, doer, now)
 	for i := 0; i < 10; i++ {
-		d.observe(7, "borrowed-key", "claude-opus-4-8", true)
+		d.observe(7, "borrowed-key", "claude-opus-4-8", "anthropic", true)
 	}
 	time.Sleep(30 * time.Millisecond)
 	require.Equal(t, 0, doer.callCount(), "mode=off must never alert")
@@ -101,7 +101,7 @@ func TestCancelStormBelowMinSampleNoAlert(t *testing.T) {
 	d := newTestCancelStormDetector(&CancelStormConfig{Mode: cancelStormModeDetectOnly, WindowSeconds: 60, MinSampleCount: 5, CancelRateThreshold: 0.5}, doer, now)
 	// 4 requests all canceled: rate 1.0 but below the 5-sample floor.
 	for i := 0; i < 4; i++ {
-		d.observe(7, "k", "claude-opus-4-8", true)
+		d.observe(7, "k", "claude-opus-4-8", "anthropic", true)
 	}
 	time.Sleep(30 * time.Millisecond)
 	require.Equal(t, 0, doer.callCount())
@@ -114,12 +114,33 @@ func TestCancelStormCrossThresholdAlerts(t *testing.T) {
 	// 5 requests, 3 canceled -> rate 0.6 >= 0.5 and total 5 >= 5 -> alert.
 	pattern := []bool{true, true, true, false, false}
 	for _, c := range pattern {
-		d.observe(7, "borrowed-key", "claude-opus-4-8", c)
+		d.observe(7, "borrowed-key", "claude-opus-4-8", "anthropic", c)
 	}
 	waitForFeishuCalls(t, doer, 1)
 	body := doer.lastBody()
 	require.Contains(t, body, "borrowed-key (#7)")
 	require.Contains(t, body, "60%")
+	// anthropic key keeps the sharp catastrophic warning (org-disable risk).
+	require.Contains(t, body, "Anthropic")
+	require.Contains(t, body, "org-disable")
+}
+
+// A non-anthropic platform (e.g. newapi/deepseek) must NOT inherit the hardcoded
+// "Anthropic 封禁承载账号" warning — that account is not in its path. The alert
+// names the real upstream platform instead. Guards the newapi/deepseek misattribution.
+func TestCancelStormNonAnthropicAdviceNamesRealPlatform(t *testing.T) {
+	now := time.Unix(1700000000, 0)
+	doer := &blockingFeishuDoer{done: make(chan struct{}, 4)}
+	d := newTestCancelStormDetector(&CancelStormConfig{Mode: cancelStormModeDetectOnly, WindowSeconds: 60, MinSampleCount: 5, CancelRateThreshold: 0.5, AlertCooldownSeconds: 600}, doer, now)
+	pattern := []bool{true, true, true, false, false}
+	for _, c := range pattern {
+		d.observe(9, "eval-deepseek-key", "deepseek-v4-pro", "newapi", c)
+	}
+	waitForFeishuCalls(t, doer, 1)
+	body := doer.lastBody()
+	require.Contains(t, body, "newapi", "advice must name the real upstream platform")
+	require.NotContains(t, body, "Anthropic", "non-anthropic key must not blame Anthropic")
+	require.NotContains(t, body, "org-disable", "org-disable risk is anthropic-only")
 }
 
 func TestCancelStormDedupWithinCooldown(t *testing.T) {
@@ -127,7 +148,7 @@ func TestCancelStormDedupWithinCooldown(t *testing.T) {
 	doer := &blockingFeishuDoer{done: make(chan struct{}, 8)}
 	d := newTestCancelStormDetector(&CancelStormConfig{Mode: cancelStormModeDetectOnly, WindowSeconds: 600, MinSampleCount: 2, CancelRateThreshold: 0.5, AlertCooldownSeconds: 600}, doer, now)
 	for i := 0; i < 10; i++ {
-		d.observe(7, "k", "claude-opus-4-8", true)
+		d.observe(7, "k", "claude-opus-4-8", "anthropic", true)
 	}
 	waitForFeishuCalls(t, doer, 1)
 	time.Sleep(40 * time.Millisecond)
@@ -139,7 +160,7 @@ func TestCancelStormOpusOnlyGatesNonOpus(t *testing.T) {
 	doer := &blockingFeishuDoer{}
 	d := newTestCancelStormDetector(&CancelStormConfig{Mode: cancelStormModeDetectOnly, WindowSeconds: 60, MinSampleCount: 2, CancelRateThreshold: 0.5, OpusOnly: true}, doer, now)
 	for i := 0; i < 10; i++ {
-		d.observe(7, "k", "claude-sonnet-4-6", true)
+		d.observe(7, "k", "claude-sonnet-4-6", "anthropic", true)
 	}
 	time.Sleep(30 * time.Millisecond)
 	require.Equal(t, 0, doer.callCount(), "opus_only must skip non-opus models")
@@ -153,7 +174,7 @@ func TestCancelStormOpusOnlyIncludesFable(t *testing.T) {
 	doer := &blockingFeishuDoer{done: make(chan struct{}, 8)}
 	d := newTestCancelStormDetector(&CancelStormConfig{Mode: cancelStormModeDetectOnly, WindowSeconds: 600, MinSampleCount: 2, CancelRateThreshold: 0.5, AlertCooldownSeconds: 600, OpusOnly: true}, doer, now)
 	for i := 0; i < 10; i++ {
-		d.observe(7, "k", "claude-fable-5", true)
+		d.observe(7, "k", "claude-fable-5", "anthropic", true)
 	}
 	waitForFeishuCalls(t, doer, 1)
 	require.Equal(t, 1, doer.callCount(), "opus_only must still watch fable (priciest tier)")
@@ -172,7 +193,7 @@ func TestCancelStormWindowTumblingResets(t *testing.T) {
 
 	// Fill the first window with cancels (min_sample high so no alert).
 	for i := 0; i < 3; i++ {
-		d.observe(7, "k", "claude-opus-4-8", true)
+		d.observe(7, "k", "claude-opus-4-8", "anthropic", true)
 	}
 	d.mu.Lock()
 	require.Equal(t, 3, d.states[7].total)
@@ -181,7 +202,7 @@ func TestCancelStormWindowTumblingResets(t *testing.T) {
 
 	// Advance past the window; the next observe must reset, not accumulate.
 	cur = now.Add(61 * time.Second)
-	d.observe(7, "k", "claude-opus-4-8", false)
+	d.observe(7, "k", "claude-opus-4-8", "anthropic", false)
 	d.mu.Lock()
 	require.Equal(t, 1, d.states[7].total, "window must tumble-reset total")
 	require.Equal(t, 0, d.states[7].canceled, "old-window cancels must not carry over")


### PR DESCRIPTION
## 背景

prod 取消风暴告警（某 newapi/deepseek 训练评测 key，模型 `deepseek-v4-pro`，取消率 75%）排查发现：该 key `group.platform=newapi`，承载账号是 DeepSeek 官方付费 API，**链路里没有任何 Anthropic OAuth 账号**。但告警建议文案把"触发上游(Anthropic)滥用风控并封禁承载账号"**硬编码、不区分平台**，会把 oncall 引向一个根本不存在的 Anthropic 承载账号。

检测器（`detect_only`，仅统计+飞书告警、无强制动作）原为 Opus 中继事故（订阅 OAuth 账号被 org-disable）而生，后 `opus_only=false` 扩到全模型，但 `buildCancelStormText` 的 advice 文案未跟着泛化。

## 改动

把请求的**真实 group platform** 透传到告警文案（`tkObserveCancelStorm` → `ObserveCancelStorm` → `observe` → `sendAlert` → `buildCancelStormText`），新增 `cancelStormAdvice(platform)`：

- **anthropic**：保留 org-disable 灾难性警告（本就为它而设）。
- **其余平台**（newapi/openai/gemini/antigravity）：改为"无谓消耗上游(`<platform>`)算力与额度 + 可能触发该上游服务商的滥用/限流风控"，并**点名真实平台**。
- **空/未知平台**：不点名的中性文案。

`platform` **只影响告警文案，不改检测逻辑与阈值**。shim 用 `resolveOpsPlatform(apiKey, "")` 只认权威 `group.platform`、不走 path-guess（热路径零分配 + 避免 `/v1/messages`→openai 对未加载 Group 的 anthropic key 二次误配）。

## 范围与纪律

- 只动 `*_tk_*.go` + 其单测（`ops_cancel_storm_tk.go` / `ops_error_logger_tk_cancel_storm.go` / `ops_cancel_storm_tk_test.go`），upstream 文件零改动。
- 纯后端：`no-web-impact`。
- 新增 `TestCancelStormNonAnthropicAdviceNamesRealPlatform` 锁定 newapi/deepseek 误配（newapi key 文案含 `newapi`、不含 `Anthropic`/`org-disable`）；既有 anthropic 用例加断言保留 org-disable 警告。

## 验证

- `go build ./...` ✓
- `go test -tags=unit ./...` ✓（含新增用例）
- `golangci-lint run ./internal/service/... ./internal/handler/...` ✓ 0 issues
- `scripts/preflight.sh` ✓ PASS

---

**sentinel-registry-reviewed**: 已核对 cancel-storm sentinel（`scripts/sentinels/gateway-tk.json` 的 `tkObserveCancelStorm(c, ops)` anchor 在 `ops_error_logger.go`，本 PR 未触及）；本 PR 仅做函数签名透传 platform + 告警文案改写，未删除任何 load-bearing 符号/路由/注册或 sentinel anchor，无需改注册表。

🤖 Generated with [Claude Code](https://claude.com/claude-code)
