### PR TITLE
fix(pricing): seedream/seedance 官方价固化进 TK overlay（按张/按秒）

### DIFF
--- a/backend/internal/service/pricing_service_tk_overlay_test.go
+++ b/backend/internal/service/pricing_service_tk_overlay_test.go
@@ -148,6 +148,37 @@ func TestTKPricingOverlay_MediaEntriesStillPresent(t *testing.T) {
 	require.InDelta(t, 0.4, veo.OutputCostPerSecond, 1e-12)
 }
 
+// TestTKPricingOverlay_SeedMediaEntries guards the VolcEngine seedream (per-image)
+// and seedance (per-second) overlay prices: the runtime mirror is a trimmed litellm
+// that has no media entries for these IDs, so without the overlay every seedream
+// image bills $0 and every seedance second bills $0.
+func TestTKPricingOverlay_SeedMediaEntries(t *testing.T) {
+	svc := &PricingService{}
+	data, err := svc.parsePricingData([]byte(`{
+		"gpt-5.4": {"input_cost_per_token": 0.0000025, "output_cost_per_token": 0.000015, "litellm_provider": "openai", "mode": "chat"}
+	}`))
+	require.NoError(t, err)
+	for model, wantPerImage := range map[string]float64{
+		"doubao-seedream-4-0-250828": 0.029850746268656716,
+		"seedream-4-0-250828":        0.029850746268656716,
+	} {
+		entry := data[model]
+		require.NotNil(t, entry, "overlay must carry %s", model)
+		require.InDelta(t, wantPerImage, entry.OutputCostPerImage, 1e-12, model)
+	}
+	for model, wantPerSecond := range map[string]float64{
+		"doubao-seedance-1-0-pro-250528":  0.10880597014925374,
+		"seedance-1-0-pro-250528":         0.10880597014925374,
+		"doubao-seedance-1-5-pro-251215":  0.11611940298507463,
+		"doubao-seedance-2-0-260128":      0.36985074626865673,
+		"doubao-seedance-2-0-fast-260128": 0.11940298507462686,
+	} {
+		entry := data[model]
+		require.NotNil(t, entry, "overlay must carry %s", model)
+		require.InDelta(t, wantPerSecond, entry.OutputCostPerSecond, 1e-12, model)
+	}
+}
+
 // TestTKPricingOverlay_CopiesCacheCreation1hPrice guards the overlay loader's
 // field copy of cache_creation_input_token_cost_above_1hr. The loader used to
 // drop it (only the main parsePricingData entry path copied it), so any overlay

--- a/backend/internal/service/tk_pricing_overlay.json
+++ b/backend/internal/service/tk_pricing_overlay.json
@@ -1,7 +1,7 @@
 {
   "_meta": {
     "note": "TK-owned pricing overlay for models the runtime price source lacks. Merged into PricingService AFTER any source load (Wei-Shaw remote OR disk fallback); an entry below applies when the source key is ABSENT or the source entry is EFFECTIVELY UNPRICED (every cost field 0.0 — litellm's 'unknown', not 'free'; see tkIsEffectivelyUnpriced). The Wei-Shaw runtime mirror is a TRIMMED litellm mirror that drops provider-prefixed keys and token-less media entries, so imagen-*/veo-* resolve to nothing there; litellm itself also lags new provider models (deepseek-v4-*) or carries them as zero placeholders (deepseek-v3-2-251201), which then bill $0. Media price = vertex_ai provider (TK media flow routes through Vertex ch41); falls back to gemini only when no vertex variant exists. Text price = provider official list price. Self-deprecating: the day the source carries a real (non-zero) price under the bare key, the source value wins and the entry below is ignored. The overlay cannot CORRECT wrong NON-ZERO source prices (deepseek-chat/reasoner still carry the pre-V4 rate in the mirror) — use channel pricing (DB) for that.",
-    "provenance": "media: BerriAI/litellm model_prices_and_context_window.json, captured 2026-06-01; deepseek-v4-*: https://api-docs.deepseek.com/quick_start/pricing, captured 2026-06-04 (cache-hit input = cache_read; cache writes billed as normal input, no separate write fee); volcengine doubao-*/glm-4-7-251222/deepseek-v3-2-251201: VolcEngine Ark official model-pricing page, captured 2026-06-10 (≤32K input tier, CNY/USD=6.7); glm-4.7 matches Zhipu official; qwen3.7-max*: Alibaba DashScope official list price, captured 2026-06-10 (per-entry source); qwen2.5-coder-32b/7b: retired & absent from current Alibaba list — proxy-filled from lineage successors qwen3-coder-plus / qwen3-coder-flash, Beijing RMB list ÷ 6.7, docs/accounts/aliyun_pricing_20260612.md captured 2026-06-12 (per-entry source)",
+    "provenance": "media: BerriAI/litellm model_prices_and_context_window.json, captured 2026-06-01; deepseek-v4-*: https://api-docs.deepseek.com/quick_start/pricing, captured 2026-06-04 (cache-hit input = cache_read; cache writes billed as normal input, no separate write fee); volcengine doubao-*/glm-4-7-251222/deepseek-v3-2-251201: VolcEngine Ark official model-pricing page, captured 2026-06-10 (≤32K input tier, CNY/USD=6.7); glm-4.7 matches Zhipu official; qwen3.7-max*: Alibaba DashScope official list price, captured 2026-06-10 (per-entry source); qwen2.5-coder-32b/7b: retired & absent from current Alibaba list — proxy-filled from lineage successors qwen3-coder-plus / qwen3-coder-flash, Beijing RMB list ÷ 6.7, docs/accounts/aliyun_pricing_20260612.md captured 2026-06-12 (per-entry source); seedream/seedance media: VolcEngine Ark official model-pricing page (https://www.volcengine.com/docs/82379/1099320), captured 2026-06-12, CNY/USD=6.7 — per-image flat price; per-second video price derived at each model's max supported tier (1080p@24fps; 2.0-fast 720p), online standard rate, derivation formula in per-entry source; only IDs present in new-api ch45/54 model lists are included — seedream-4.5/5.0(-lite) & seedance-1.0-pro-fast are priced upstream but absent from new-api constants, seedance-1.0-lite is listed but retired/unpriced, all deliberately NOT included (served_zero_cost P0 probe covers the gap; a wrong price has no probe)",
     "regen": "manual curation; no auto-sync (entries are few + slow-moving). If they proliferate, add provider-aware sync."
   },
   "claude-fable-5": {
@@ -154,6 +154,48 @@
     "mode": "video_generation",
     "output_cost_per_second": 0.05,
     "source": "litellm:gemini/veo-3.1-lite-generate-preview"
+  },
+  "doubao-seedream-4-0-250828": {
+    "litellm_provider": "volcengine",
+    "mode": "image_generation",
+    "output_cost_per_image": 0.029850746268656716,
+    "source": "VolcEngine Ark official model-pricing page https://www.volcengine.com/docs/82379/1099320, captured 2026-06-12: doubao-seedream-4.0 = 0.2 CNY/image (billed per successfully generated image; single flat price, no resolution tiers) ÷ 6.7 = 0.0298507 USD/image."
+  },
+  "seedream-4-0-250828": {
+    "litellm_provider": "volcengine",
+    "mode": "image_generation",
+    "output_cost_per_image": 0.029850746268656716,
+    "source": "No-prefix alias of doubao-seedream-4-0-250828 (new-api relay/channel/volcengine ModelList carries both names; billing key = requested_model so the alias must price identically). Same VolcEngine Ark official 0.2 CNY/image ÷ 6.7, captured 2026-06-12."
+  },
+  "doubao-seedance-1-0-pro-250528": {
+    "litellm_provider": "volcengine",
+    "mode": "video_generation",
+    "output_cost_per_second": 0.10880597014925374,
+    "source": "VolcEngine Ark official https://www.volcengine.com/docs/82379/1099320, captured 2026-06-12: doubao-seedance-1.0-pro online = 15 CNY/M tokens; video tokens = duration*W*H*fps/1024. Priced at the model's MAX tier 1080p(1920x1080)@24fps so lower-resolution requests over- not under-charge: 1920*1080*24/1024 = 48600 tokens/s -> 48600*15/1e6 = 0.729 CNY/s ÷ 6.7 = 0.1088060 USD/s (matches official 1080p 5s example ~3.645 CNY). 720p actual cost is 4/9 of this."
+  },
+  "seedance-1-0-pro-250528": {
+    "litellm_provider": "volcengine",
+    "mode": "video_generation",
+    "output_cost_per_second": 0.10880597014925374,
+    "source": "No-prefix alias of doubao-seedance-1-0-pro-250528 (new-api volcengine ModelList carries both; billing key = requested_model). Same derivation: 1080p@24fps max tier, 48600 tokens/s * 15 CNY/M = 0.729 CNY/s ÷ 6.7. Captured 2026-06-12."
+  },
+  "doubao-seedance-1-5-pro-251215": {
+    "litellm_provider": "volcengine",
+    "mode": "video_generation",
+    "output_cost_per_second": 0.11611940298507463,
+    "source": "VolcEngine Ark official https://www.volcengine.com/docs/82379/1099320, captured 2026-06-12: doubao-seedance-1.5-pro, MAX tier = 1080p WITH audio (16 CNY/M tokens). Official example table 1080p 16:9 5s with-audio = 3.89 CNY -> 0.778 CNY/s ÷ 6.7 = 0.1161194 USD/s; token-formula cross-check 48600*16/1e6 = 0.7776 CNY/s (<0.1% off). Silent 1080p is half; 480p/720p cheaper — single per-second price never under-charges those."
+  },
+  "doubao-seedance-2-0-260128": {
+    "litellm_provider": "volcengine",
+    "mode": "video_generation",
+    "output_cost_per_second": 0.36985074626865673,
+    "source": "VolcEngine Ark official https://www.volcengine.com/docs/82379/1099320, captured 2026-06-12: doubao-seedance-2.0, MAX output tier 1080p, input-without-video (text/image-to-video, 51 CNY/M tokens). Official example 1080p 5s = 12.39 CNY -> 2.478 CNY/s ÷ 6.7 = 0.3698507 USD/s; cross-check 48600*51/1e6 = 2.4786 CNY/s. CAVEAT: video-input continuation bills (input+output) duration upstream and can exceed this single per-second rate up to ~2.4x — restrict or re-price before enabling video input on TK."
+  },
+  "doubao-seedance-2-0-fast-260128": {
+    "litellm_provider": "volcengine",
+    "mode": "video_generation",
+    "output_cost_per_second": 0.11940298507462686,
+    "source": "VolcEngine Ark official https://www.volcengine.com/docs/82379/1099320, captured 2026-06-12: doubao-seedance-2.0-fast, MAX supported output is 720p (no 1080p), input-without-video (37 CNY/M tokens). Official example 720p 5s = 4.00 CNY -> 0.8 CNY/s ÷ 6.7 = 0.1194030 USD/s; cross-check 1280*720*24/1024 = 21600 tokens/s * 37/1e6 = 0.7992 CNY/s. Same video-input caveat as seedance-2.0."
   },
   "doubao-seed-2-0-pro-260215": {
     "litellm_provider": "volcengine",

--- a/scripts/checks/pricing-overlay.py
+++ b/scripts/checks/pricing-overlay.py
@@ -13,9 +13,11 @@ This check hardens that against silent regression (CLAUDE.md §5 "upgrade princi
 a soft rule that bit us once becomes a mechanical gate). It asserts:
   1. The overlay parses and is non-empty.
   2. Anchor models are present with a non-zero price in the right field:
-       imagen-4.0-generate-001 -> output_cost_per_image > 0
-       veo-3.1-generate-001    -> output_cost_per_second > 0
-       deepseek-v4-flash       -> input_cost_per_token > 0
+       imagen-4.0-generate-001        -> output_cost_per_image > 0
+       veo-3.1-generate-001           -> output_cost_per_second > 0
+       deepseek-v4-flash              -> input_cost_per_token > 0
+       doubao-seedream-4-0-250828     -> output_cost_per_image > 0
+       doubao-seedance-1-0-pro-250528 -> output_cost_per_second > 0
   3. EVERY entry has a recognized mode and a > 0 price in the matching field(s)
      (no silently-shipped $0 entry, which would deduct nothing):
        image_generation -> output_cost_per_image
@@ -46,6 +48,8 @@ ANCHORS = {
     "imagen-4.0-generate-001": "output_cost_per_image",
     "veo-3.1-generate-001": "output_cost_per_second",
     "deepseek-v4-flash": "input_cost_per_token",
+    "doubao-seedream-4-0-250828": "output_cost_per_image",
+    "doubao-seedance-1-0-pro-250528": "output_cost_per_second",
 }
 
 


### PR DESCRIPTION
## 背景

火山媒体模型（Doubao Seedream 图片 / Seedance 视频）此前在仓内 `tk_pricing_overlay.json` 没有条目——线上若服务这两族只能靠 prod DB 渠道价，换库/新环境即回到 $0 + served_zero_cost P0 告警轰炸。本 PR 按既定路径（火山官方价目页取证 → overlay PR 固化）补齐，与 imagen/veo 同等待遇。

## 收录条目（7 条，CNY÷6.7）

| 模型 | 模式 | USD 单价 |
|---|---|---|
| doubao-seedream-4-0-250828（+无前缀别名） | 按张 | $0.02985/图（官方 0.2 元/张） |
| doubao-seedance-1-0-pro-250528（+无前缀别名） | 按秒 | $0.10881/秒 |
| doubao-seedance-1-5-pro-251215 | 按秒 | $0.11612/秒（有声档） |
| doubao-seedance-2-0-260128 | 按秒 | $0.36985/秒 |
| doubao-seedance-2-0-fast-260128 | 按秒 | $0.11940/秒 |

- 按秒价取各模型最高支持档（1080p@24fps；2.0-fast 上限 720p）+ 在线标准价，宁可不少收；与官方"元/个"示例表交叉验证误差 <0.1%，推导公式逐条写进 per-entry source。
- 无前缀别名按同价收录：计费键是 requested_model，new-api volcengine ModelList 同时带两个名字。
- **刻意不收**：seedream-4.5/5.0(-lite)、seedance-1.0-pro-fast 不在 new-api ch45/54 模型常量表；seedance-1.0-lite 已下架无现价——缺价有 P0 探针兜底、错价没有兜底。
- 运营警示（写在 per-entry source）：seedance-2.0/2.0-fast 的"输入含视频"场景按(输入+输出)时长计 token，单维度按秒价会少收 1.6~2.4 倍——TokenKey 开放视频输入前须另行加价或限制。

## 守卫与测试

- `scripts/checks/pricing-overlay.py` ANCHORS 增加 seedream/seedance 各一锚（mutation 验证：改坏价格即红）。
- `pricing_service_tk_overlay_test.go` 新增 `TestTKPricingOverlay_SeedMediaEntries` 非零断言。
- `go test -tags=unit ./...` 全绿；`bash scripts/preflight.sh` PASS；fill-only 语义不变（既有 `FillOnlySourceWins` 背书）。

合并方式：Squash and merge（TK-originated）。

🤖 Generated with [Claude Code](https://claude.com/claude-code)