### PR TITLE
feat(newapi): 哨兵心跳 last_result 带上探测账号当前余额

### DIFF
--- a/backend/internal/service/upstream_balance_sentinel_tk.go
+++ b/backend/internal/service/upstream_balance_sentinel_tk.go
@@ -197,6 +197,11 @@ func (s *UpstreamBalanceSentinel) runOnce(ctx context.Context) {
 	rechargeURL := s.rechargeURL(ctx)
 
 	checked, low, probeErrs := 0, 0, 0
+	// balances carries each probed account's current balance into the heartbeat
+	// last_result so operators reading ops_job_heartbeats see the ACTUAL remaining
+	// balance + its trend across ticks — not just the low=0/1 binary. (low=0 only
+	// proves "≥ threshold"; 60 vs 3262 撑得久天差地别。)
+	balances := make([]string, 0, len(accounts))
 	for i := range accounts {
 		acc := &accounts[i]
 		probe, ok := newapi.BalanceProbeFor(acc.ChannelType)
@@ -218,6 +223,7 @@ func (s *UpstreamBalanceSentinel) runOnce(ctx context.Context) {
 			slog.Warn("upstream balance probe failed", "account_id", acc.ID, "name", acc.Name, "err", perr)
 			continue
 		}
+		balances = append(balances, fmt.Sprintf("%s:%.2f", sanitizeBalanceSampleName(acc.Name), res.AvailableCNY))
 		isLow := !res.IsAvailable || res.AvailableCNY < threshold
 		if isLow {
 			low++
@@ -231,7 +237,7 @@ func (s *UpstreamBalanceSentinel) runOnce(ctx context.Context) {
 		}
 	}
 
-	s.recordHeartbeatSuccess(startedAt, checked, low, probeErrs)
+	s.recordHeartbeatSuccess(startedAt, checked, low, probeErrs, balances)
 }
 
 // thresholdConfig reads the low-balance threshold and whether Feishu alerting is
@@ -258,13 +264,13 @@ func (s *UpstreamBalanceSentinel) rechargeURL(ctx context.Context) string {
 	return strings.TrimSpace(v)
 }
 
-func (s *UpstreamBalanceSentinel) recordHeartbeatSuccess(runAt time.Time, checked, low, probeErrs int) {
+func (s *UpstreamBalanceSentinel) recordHeartbeatSuccess(runAt time.Time, checked, low, probeErrs int, balances []string) {
 	if s == nil || s.heartbeat == nil {
 		return
 	}
 	now := time.Now().UTC()
 	durMs := time.Since(runAt).Milliseconds()
-	result := fmt.Sprintf("checked=%d low=%d probe_errors=%d", checked, low, probeErrs)
+	result := formatSentinelHeartbeatResult(checked, low, probeErrs, balances)
 	ctx, cancel := context.WithTimeout(context.Background(), upstreamBalanceHeartbeatTO)
 	defer cancel()
 	_ = s.heartbeat.UpsertJobHeartbeat(ctx, &OpsUpsertJobHeartbeatInput{
@@ -274,6 +280,31 @@ func (s *UpstreamBalanceSentinel) recordHeartbeatSuccess(runAt time.Time, checke
 		LastDurationMs: &durMs,
 		LastResult:     &result,
 	})
+}
+
+// formatSentinelHeartbeatResult renders the heartbeat last_result string, e.g.
+// "checked=1 low=0 probe_errors=0 balances=[ds-官:3262.07]". Pure + 2048-clamped
+// (ops_job_heartbeats.last_result column bound) so it's deterministically testable.
+func formatSentinelHeartbeatResult(checked, low, probeErrs int, balances []string) string {
+	result := fmt.Sprintf("checked=%d low=%d probe_errors=%d", checked, low, probeErrs)
+	if len(balances) > 0 {
+		result += " balances=[" + strings.Join(balances, ",") + "]"
+	}
+	if len(result) > 2048 {
+		result = result[:2048]
+	}
+	return result
+}
+
+// sanitizeBalanceSampleName keeps the heartbeat balances=[...] list parseable by
+// stripping the delimiter chars an account name could otherwise inject (`,` `:`
+// `[` `]`). Balance is operational data (not a secret), so the name is kept legible.
+func sanitizeBalanceSampleName(name string) string {
+	name = strings.TrimSpace(name)
+	if name == "" {
+		return "?"
+	}
+	return strings.NewReplacer(",", "_", ":", "_", "[", "_", "]", "_").Replace(name)
 }
 
 func (s *UpstreamBalanceSentinel) recordHeartbeatError(runAt time.Time, err error) {

--- a/backend/internal/service/upstream_balance_sentinel_tk_test.go
+++ b/backend/internal/service/upstream_balance_sentinel_tk_test.go
@@ -199,3 +199,64 @@ func TestBuildUpstreamBalanceLowText(t *testing.T) {
 		t.Errorf("expected urgent availability note when is_available=false\n%s", body2)
 	}
 }
+
+type fakeHeartbeat struct{ last *OpsUpsertJobHeartbeatInput }
+
+func (h *fakeHeartbeat) UpsertJobHeartbeat(_ context.Context, in *OpsUpsertJobHeartbeatInput) error {
+	h.last = in
+	return nil
+}
+
+// TestSentinelHeartbeatCarriesBalance drives runOnce end-to-end and asserts the
+// probed account's actual balance lands in the heartbeat last_result.
+func TestSentinelHeartbeatCarriesBalance(t *testing.T) {
+	hb := &fakeHeartbeat{}
+	doer := &fakeBalanceDoer{bodies: []string{dsBody("3262.07", true)}}
+	notifier := newTKAccountIncidentNotifier(fakeFeishuCfg{threshold: 50, enabled: true}, "test")
+	s := NewUpstreamBalanceSentinel(
+		fakeAccountStore{accounts: []Account{dsAccount(39)}},
+		doer, notifier,
+		fakeFeishuCfg{threshold: 50, enabled: true},
+		nil, hb, nil,
+	)
+	s.runOnce(context.Background())
+	if hb.last == nil || hb.last.LastResult == nil {
+		t.Fatalf("expected a success heartbeat with last_result")
+	}
+	got := *hb.last.LastResult
+	for _, want := range []string{"checked=1", "low=0", "probe_errors=0", "balances=[ds-test:3262.07]"} {
+		if !strings.Contains(got, want) {
+			t.Errorf("last_result missing %q: %s", want, got)
+		}
+	}
+}
+
+func TestFormatSentinelHeartbeatResult(t *testing.T) {
+	if got := formatSentinelHeartbeatResult(0, 0, 0, nil); got != "checked=0 low=0 probe_errors=0" {
+		t.Errorf("no-balance form wrong: %q", got)
+	}
+	if got := formatSentinelHeartbeatResult(2, 1, 0, []string{"ds-x:42.50", "y:100.00"}); got != "checked=2 low=1 probe_errors=0 balances=[ds-x:42.50,y:100.00]" {
+		t.Errorf("balance form wrong: %q", got)
+	}
+	big := make([]string, 0, 500)
+	for i := 0; i < 500; i++ {
+		big = append(big, "acctname:1234.56")
+	}
+	if got := formatSentinelHeartbeatResult(500, 0, 0, big); len(got) > 2048 {
+		t.Errorf("expected clamp to 2048, got %d", len(got))
+	}
+}
+
+func TestSanitizeBalanceSampleName(t *testing.T) {
+	cases := map[string]string{
+		"ds-官":       "ds-官",
+		"a,b:c[d]e":  "a_b_c_d_e",
+		"  spaced  ": "spaced",
+		"":           "?",
+	}
+	for in, want := range cases {
+		if got := sanitizeBalanceSampleName(in); got != want {
+			t.Errorf("sanitize(%q)=%q want %q", in, got, want)
+		}
+	}
+}


### PR DESCRIPTION
## 背景

`upstream_balance_sentinel`（#734，已在 prod 运行）写心跳 `ops_job_heartbeats.last_result` 原来只有计数：`checked=1 low=0 probe_errors=0`。运维看心跳只能推断「余额 ≥ 阈值」，但**不知道实际还剩多少**（60 vs 3262 撑得久天差地别），也看不到逐 tick 的消耗趋势 / 告警前「温水区」的下滑。本次发版排查时就因此被迫另查 balance API，还摆了个拿过时快照（298）的乌龙——正是这个盲点。

## 改动

把每个探测账号的当前余额拼进 last_result：

```
checked=1 low=0 probe_errors=0 balances=[ds-官:3262.07]
```

- `runOnce` 收集每个成功探测账号的余额样本
- `formatSentinelHeartbeatResult` 纯函数拼接 + 2048 截断（`last_result` 列上界）→ 确定性可测
- `sanitizeBalanceSampleName` 去掉账号名里的 `, : [ ]` 防破坏 `balances=[...]` 可解析性
- 余额是运营数据非密钥，写运维心跳表 OK

不改 schema / 告警逻辑 / 接口 / sentinel 锚。

## 验证

- 新增 3 个单测（端到端心跳带余额 + 纯函数格式/截断 + 名字清洗）；`go test -tags=unit` 绿
- `go build ./...` + `golangci-lint` 0 issues
- `scripts/preflight.sh` PASS

## sentinel-registry-reviewed

本 PR 改动了带 newapi sentinel 锚的 `upstream_balance_sentinel_tk.go`（含删除行：`recordHeartbeatSuccess` 签名变更）。已复核三个锚 **均未改动**：`newapi.BalanceProbeFor(acc.ChannelType)` / `s.notifier.NotifyUpstreamBalanceLow` / `ListByPlatform(ctx, PlatformNewAPI)`；`check-newapi.py` 48/48 intact。无需调整注册表。

## Checklist
- [x] 纯后端、commit 带 `no-web-impact`
- [x] sentinel 锚未动，PR body 带 `sentinel-registry-reviewed`
- [x] 已 rebase origin/main（ancestry ✓）；TK feat → Squash and merge

🤖 Generated with [Claude Code](https://claude.com/claude-code)