### PR TITLE
fix(gateway): CC-only 分组非-CC OpenAI-compat 流量按 fallback_group_id 回退而非 403

### DIFF
--- a/backend/internal/handler/gateway_handler_chat_completions.go
+++ b/backend/internal/handler/gateway_handler_chat_completions.go
@@ -88,11 +88,24 @@ func (h *GatewayHandler) ChatCompletions(c *gin.Context) {
 	// 解析渠道级模型映射
 	channelMapping, _ := h.gatewayService.ResolveChannelMappingAndRestrict(c.Request.Context(), apiKey.GroupID, reqModel)
 
-	// Claude Code only restriction
+	// Claude Code only restriction.
+	// TK: when a CC-only group declares a valid fallback_group_id, route non-CC
+	// OpenAI-compat traffic to that fallback group instead of hard-403'ing (see
+	// gateway_handler_tk_cc_only_fallback.go). No/invalid fallback keeps the 403.
 	if apiKey.Group != nil && apiKey.Group.ClaudeCodeOnly {
-		h.chatCompletionsErrorResponse(c, http.StatusForbidden, "permission_error",
-			"This group is restricted to Claude Code clients (/v1/messages only)")
-		return
+		writeForbidden := func() {
+			h.chatCompletionsErrorResponse(c, http.StatusForbidden, "permission_error", tkCCOnlyForbiddenMessage)
+		}
+		writeBillingError := func(status int, code, message string) {
+			h.chatCompletionsErrorResponse(c, status, code, message)
+		}
+		fallbackAPIKey, handled := h.tkResolveCCOnlyFallback(c, apiKey, reqLog, writeForbidden, writeBillingError)
+		if handled {
+			return
+		}
+		apiKey = fallbackAPIKey
+		// Re-resolve channel-level model mapping against the fallback group.
+		channelMapping, _ = h.gatewayService.ResolveChannelMappingAndRestrict(c.Request.Context(), apiKey.GroupID, reqModel)
 	}
 
 	if decision := h.checkContentModeration(c, reqLog, apiKey, subject, service.ContentModerationProtocolOpenAIChat, reqModel, body); decision != nil && decision.Blocked {

--- a/backend/internal/handler/gateway_handler_responses.go
+++ b/backend/internal/handler/gateway_handler_responses.go
@@ -106,14 +106,23 @@ func (h *GatewayHandler) Responses(c *gin.Context) {
 
 	// Claude Code only restriction:
 	// /v1/responses is never a Claude Code endpoint.
-	// When claude_code_only is enabled, this endpoint is rejected.
-	// The existing service-layer checkClaudeCodeRestriction handles degradation
-	// to fallback groups when the Forward path calls SelectAccountForModelWithExclusions.
-	// Here we just reject at handler level since /v1/responses clients can't be Claude Code.
+	// TK: when a CC-only group declares a valid fallback_group_id, route non-CC
+	// OpenAI-compat traffic to that fallback group instead of hard-403'ing (see
+	// gateway_handler_tk_cc_only_fallback.go). No/invalid fallback keeps the 403.
 	if apiKey.Group != nil && apiKey.Group.ClaudeCodeOnly {
-		h.responsesErrorResponse(c, http.StatusForbidden, "permission_error",
-			"This group is restricted to Claude Code clients (/v1/messages only)")
-		return
+		writeForbidden := func() {
+			h.responsesErrorResponse(c, http.StatusForbidden, "permission_error", tkCCOnlyForbiddenMessage)
+		}
+		writeBillingError := func(status int, code, message string) {
+			h.responsesErrorResponse(c, status, code, message)
+		}
+		fallbackAPIKey, handled := h.tkResolveCCOnlyFallback(c, apiKey, reqLog, writeForbidden, writeBillingError)
+		if handled {
+			return
+		}
+		apiKey = fallbackAPIKey
+		// Re-resolve channel-level model mapping against the fallback group.
+		channelMapping, _ = h.gatewayService.ResolveChannelMappingAndRestrict(requestCtx, apiKey.GroupID, reqModel)
 	}
 
 	if decision := h.checkContentModeration(c, reqLog, apiKey, subject, service.ContentModerationProtocolOpenAIResponses, reqModel, body); decision != nil && decision.Blocked {

--- a/backend/internal/handler/gateway_handler_tk_cc_only_fallback.go
+++ b/backend/internal/handler/gateway_handler_tk_cc_only_fallback.go
@@ -1,0 +1,131 @@
+package handler
+
+import (
+	"strconv"
+
+	"github.com/Wei-Shaw/sub2api/internal/service"
+	"github.com/gin-gonic/gin"
+	"go.uber.org/zap"
+)
+
+// TK: Claude-Code-only group fallback routing for the OpenAI-compatible paths
+// (/v1/chat/completions, /v1/responses).
+//
+// Background: a group can be claude_code_only=true (CC-only): it only serves
+// Claude Code clients via /v1/messages. A NON-CC request hitting a CC-only
+// group on an OpenAI-compat path is otherwise hard-403'd. Operators configure
+// a fallback_group_id on the CC-only group expecting non-CC traffic to fall
+// back to that group instead of being rejected — this helper implements that
+// intent. The companion upstream-shaped handlers keep a thin injection (see
+// gateway_handler_chat_completions.go / gateway_handler_responses.go).
+//
+// Guards (all must hold to route to the fallback; otherwise the original 403
+// stands — never silently route to a bad group):
+//   - the CC-only group must declare a fallback_group_id (else keep the 403);
+//   - the fallback group must resolve, be active, NOT be claude_code_only
+//     (loop guard — re-entering the same 403), and be on the anthropic platform
+//     (these OpenAI-compat paths only forward to the Anthropic upstream);
+//   - billing eligibility for the fallback-bound key must pass.
+//
+// Single-hop only: the fallback is resolved exactly once, never chained.
+
+// tkCCOnlyFallbackGroupValid is the pure validation predicate for a candidate
+// CC-only fallback group. It is dependency-free so it can be unit-tested in
+// isolation. nil is invalid.
+func tkCCOnlyFallbackGroupValid(fallback *service.Group) bool {
+	if fallback == nil {
+		return false
+	}
+	// Loop guard: a CC-only fallback would re-trigger the same 403.
+	if fallback.ClaudeCodeOnly {
+		return false
+	}
+	// These OpenAI-compat paths only forward to the Anthropic upstream, so the
+	// fallback must be servable there.
+	if fallback.Platform != service.PlatformAnthropic {
+		return false
+	}
+	return fallback.IsActive()
+}
+
+// tkResolveCCOnlyFallback is invoked at the CC-only guard of an OpenAI-compat
+// handler when apiKey.Group.ClaudeCodeOnly is true. It returns:
+//
+//   - (fallbackAPIKey, false): a valid fallback was found and billing passed;
+//     the caller must continue the request bound to fallbackAPIKey (the request
+//     is served by the fallback group's accounts).
+//   - (nil, true): the caller must return immediately — either the original 403
+//     was written (no/invalid fallback), or a billing error was surfaced. The
+//     helper has already written the response via writeForbidden / the billing
+//     error writer.
+//
+// errWriter writes the canonical 403 for the calling endpoint (chat-completions
+// vs responses error shapes differ). billingErrWriter writes a billing error
+// (status/code/message) for the calling endpoint.
+func (h *GatewayHandler) tkResolveCCOnlyFallback(
+	c *gin.Context,
+	apiKey *service.APIKey,
+	reqLog *zap.Logger,
+	writeForbidden func(),
+	writeBillingError func(status int, code, message string),
+) (fallbackAPIKey *service.APIKey, handled bool) {
+	const ccOnlyForbiddenLog = "gateway.cc_only_fallback"
+
+	if apiKey == nil || apiKey.Group == nil || apiKey.Group.FallbackGroupID == nil || *apiKey.Group.FallbackGroupID <= 0 {
+		// No fallback configured — keep the existing 403.
+		writeForbidden()
+		return nil, true
+	}
+
+	fallbackGroupID := *apiKey.Group.FallbackGroupID
+	fallbackGroup, err := h.gatewayService.ResolveGroupByID(c.Request.Context(), fallbackGroupID)
+	if err != nil || fallbackGroup == nil {
+		reqLog.Warn(ccOnlyForbiddenLog+".resolve_failed",
+			zap.Int64("fallback_group_id", fallbackGroupID), zap.Error(err))
+		writeForbidden()
+		return nil, true
+	}
+
+	if !tkCCOnlyFallbackGroupValid(fallbackGroup) {
+		reqLog.Warn(ccOnlyForbiddenLog+".invalid",
+			zap.Int64("fallback_group_id", fallbackGroup.ID),
+			zap.String("fallback_platform", fallbackGroup.Platform),
+			zap.Bool("fallback_claude_code_only", fallbackGroup.ClaudeCodeOnly),
+			zap.String("fallback_status", fallbackGroup.Status),
+		)
+		writeForbidden()
+		return nil, true
+	}
+
+	clonedAPIKey := cloneAPIKeyWithGroup(apiKey, fallbackGroup)
+	// Billing eligibility for the fallback-bound key. Subscription is nil here —
+	// the fallback is a different group, so the original group's subscription
+	// context does not apply (mirrors the PromptTooLongError fallback path).
+	if err := h.billingCacheService.CheckBillingEligibility(
+		c.Request.Context(),
+		clonedAPIKey.User,
+		clonedAPIKey,
+		fallbackGroup,
+		nil,
+		service.PlatformFromAPIKey(clonedAPIKey),
+	); err != nil {
+		reqLog.Info(ccOnlyForbiddenLog+".billing_check_failed",
+			zap.Int64("fallback_group_id", fallbackGroup.ID), zap.Error(err))
+		status, code, message, retryAfter := billingErrorDetails(err)
+		if retryAfter > 0 {
+			c.Header("Retry-After", strconv.Itoa(retryAfter))
+		}
+		writeBillingError(status, code, message)
+		return nil, true
+	}
+
+	reqLog.Info(ccOnlyForbiddenLog+".routed",
+		zap.Any("from_group_id", apiKey.GroupID),
+		zap.Int64("fallback_group_id", fallbackGroup.ID),
+	)
+	return clonedAPIKey, false
+}
+
+// tkCCOnlyForbiddenMessage is the canonical CC-only rejection message, shared by
+// both OpenAI-compat handlers so the 403 text stays identical to upstream.
+const tkCCOnlyForbiddenMessage = "This group is restricted to Claude Code clients (/v1/messages only)"

--- a/backend/internal/handler/gateway_handler_tk_cc_only_fallback_unit_test.go
+++ b/backend/internal/handler/gateway_handler_tk_cc_only_fallback_unit_test.go
@@ -1,0 +1,244 @@
+//go:build unit
+
+package handler
+
+import (
+	"context"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"testing"
+
+	"github.com/Wei-Shaw/sub2api/internal/config"
+	middleware2 "github.com/Wei-Shaw/sub2api/internal/server/middleware"
+	"github.com/Wei-Shaw/sub2api/internal/service"
+	"github.com/gin-gonic/gin"
+	"github.com/stretchr/testify/require"
+	"go.uber.org/zap"
+)
+
+func i64ptr(v int64) *int64 { return &v }
+
+func TestTkCCOnlyFallbackGroupValid(t *testing.T) {
+	tests := []struct {
+		name  string
+		group *service.Group
+		want  bool
+	}{
+		{name: "nil", group: nil, want: false},
+		{
+			name:  "valid_active_anthropic_non_cc",
+			group: &service.Group{ID: 20, Platform: service.PlatformAnthropic, Status: service.StatusActive},
+			want:  true,
+		},
+		{
+			name:  "loop_guard_cc_only",
+			group: &service.Group{ID: 20, Platform: service.PlatformAnthropic, Status: service.StatusActive, ClaudeCodeOnly: true},
+			want:  false,
+		},
+		{
+			name:  "inactive",
+			group: &service.Group{ID: 20, Platform: service.PlatformAnthropic, Status: "disabled"},
+			want:  false,
+		},
+		{
+			name:  "wrong_platform",
+			group: &service.Group{ID: 20, Platform: service.PlatformOpenAI, Status: service.StatusActive},
+			want:  false,
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			require.Equal(t, tt.want, tkCCOnlyFallbackGroupValid(tt.group))
+		})
+	}
+}
+
+// newCCOnlyFallbackContext builds a gin context with a request whose context
+// optionally carries a hydrated group (so ResolveGroupByID resolves repo-free
+// or via the fake repo).
+func newCCOnlyFallbackContext() (*gin.Context, *httptest.ResponseRecorder) {
+	rec := httptest.NewRecorder()
+	c, _ := gin.CreateTestContext(rec)
+	c.Request = httptest.NewRequest(http.MethodPost, "/v1/chat/completions", strings.NewReader("{}"))
+	c.Request = c.Request.WithContext(context.Background())
+	return c, rec
+}
+
+func newCCOnlyFallbackHandler(t *testing.T, fallbackGroup *service.Group) (*GatewayHandler, func()) {
+	t.Helper()
+	gwSvc := service.NewGatewayService(
+		nil,
+		&fakeGroupRepo{group: fallbackGroup},
+		nil, nil, nil, nil, nil, nil, nil, nil, nil, nil, nil, nil, nil, nil, nil, nil, nil, nil, nil, nil, nil, nil, nil, nil, nil, nil,
+	)
+	cfg := &config.Config{RunMode: config.RunModeSimple}
+	billingCacheSvc := service.NewBillingCacheService(nil, nil, nil, nil, nil, nil, cfg, nil)
+	h := &GatewayHandler{
+		gatewayService:      gwSvc,
+		billingCacheService: billingCacheSvc,
+		cfg:                 cfg,
+	}
+	return h, func() { billingCacheSvc.Stop() }
+}
+
+// ccOnlyAPIKey returns an apiKey bound to a CC-only group with the given
+// fallback_group_id (nil = none).
+func ccOnlyAPIKey(fallbackGroupID *int64) *service.APIKey {
+	groupID := int64(1)
+	return &service.APIKey{
+		ID:      11,
+		GroupID: &groupID,
+		User:    &service.User{ID: 13},
+		Group: &service.Group{
+			ID:              1,
+			Platform:        service.PlatformAnthropic,
+			Status:          service.StatusActive,
+			ClaudeCodeOnly:  true,
+			FallbackGroupID: fallbackGroupID,
+		},
+	}
+}
+
+func TestTkResolveCCOnlyFallback_NoFallbackKeeps403(t *testing.T) {
+	h, cleanup := newCCOnlyFallbackHandler(t, nil)
+	defer cleanup()
+	c, rec := newCCOnlyFallbackContext()
+
+	forbiddenCalled := false
+	fallback, handled := h.tkResolveCCOnlyFallback(c, ccOnlyAPIKey(nil), zap.NewNop(),
+		func() { forbiddenCalled = true; rec.WriteHeader(http.StatusForbidden) },
+		func(status int, code, message string) {
+			t.Fatalf("unexpected billing error %d %s %s", status, code, message)
+		},
+	)
+
+	require.True(t, handled)
+	require.Nil(t, fallback)
+	require.True(t, forbiddenCalled)
+	require.Equal(t, http.StatusForbidden, rec.Code)
+}
+
+func TestTkResolveCCOnlyFallback_CCOnlyFallbackKeeps403(t *testing.T) {
+	// Fallback group is itself CC-only → loop guard → keep 403.
+	fallbackGroup := &service.Group{
+		ID:             20,
+		Platform:       service.PlatformAnthropic,
+		Status:         service.StatusActive,
+		ClaudeCodeOnly: true,
+	}
+	h, cleanup := newCCOnlyFallbackHandler(t, fallbackGroup)
+	defer cleanup()
+	c, rec := newCCOnlyFallbackContext()
+
+	forbiddenCalled := false
+	fallback, handled := h.tkResolveCCOnlyFallback(c, ccOnlyAPIKey(i64ptr(20)), zap.NewNop(),
+		func() { forbiddenCalled = true; rec.WriteHeader(http.StatusForbidden) },
+		func(status int, code, message string) {
+			t.Fatalf("unexpected billing error %d %s %s", status, code, message)
+		},
+	)
+
+	require.True(t, handled)
+	require.Nil(t, fallback)
+	require.True(t, forbiddenCalled)
+}
+
+func TestTkResolveCCOnlyFallback_InactiveFallbackKeeps403(t *testing.T) {
+	fallbackGroup := &service.Group{
+		ID:       20,
+		Platform: service.PlatformAnthropic,
+		Status:   "disabled",
+	}
+	h, cleanup := newCCOnlyFallbackHandler(t, fallbackGroup)
+	defer cleanup()
+	c, rec := newCCOnlyFallbackContext()
+
+	forbiddenCalled := false
+	fallback, handled := h.tkResolveCCOnlyFallback(c, ccOnlyAPIKey(i64ptr(20)), zap.NewNop(),
+		func() { forbiddenCalled = true; rec.WriteHeader(http.StatusForbidden) },
+		func(status int, code, message string) {
+			t.Fatalf("unexpected billing error %d %s %s", status, code, message)
+		},
+	)
+
+	require.True(t, handled)
+	require.Nil(t, fallback)
+	require.True(t, forbiddenCalled)
+}
+
+func TestTkResolveCCOnlyFallback_ValidFallbackRoutes(t *testing.T) {
+	fallbackGroup := &service.Group{
+		ID:       20,
+		Name:     "default-fallback",
+		Platform: service.PlatformAnthropic,
+		Status:   service.StatusActive,
+	}
+	h, cleanup := newCCOnlyFallbackHandler(t, fallbackGroup)
+	defer cleanup()
+	c, _ := newCCOnlyFallbackContext()
+
+	origKey := ccOnlyAPIKey(i64ptr(20))
+	fallback, handled := h.tkResolveCCOnlyFallback(c, origKey, zap.NewNop(),
+		func() { t.Fatal("unexpected 403 for valid fallback") },
+		func(status int, code, message string) {
+			t.Fatalf("unexpected billing error %d %s %s", status, code, message)
+		},
+	)
+
+	require.False(t, handled)
+	require.NotNil(t, fallback)
+	// The returned key must be re-bound to the fallback group (group 20), and the
+	// original key must be untouched (still bound to the CC-only group 1).
+	require.NotNil(t, fallback.GroupID)
+	require.Equal(t, int64(20), *fallback.GroupID)
+	require.Equal(t, int64(20), fallback.Group.ID)
+	require.False(t, fallback.Group.ClaudeCodeOnly)
+	require.Equal(t, int64(1), *origKey.GroupID, "original apiKey must not be mutated")
+}
+
+// TestChatCompletions_CCOnlyValidFallback_NotForbidden drives the full
+// ChatCompletions handler entry point: a CC-only group with a valid non-CC
+// fallback must NOT return the CC-only 403. The request proceeds past the guard
+// and (with no schedulable accounts) fails later with a non-403 status — proving
+// the 403 was bypassed and the request was routed through the fallback group.
+func TestChatCompletions_CCOnlyValidFallback_NotForbidden(t *testing.T) {
+	gin.SetMode(gin.TestMode)
+
+	fallbackGroup := &service.Group{
+		ID:       20,
+		Name:     "default-fallback",
+		Platform: service.PlatformAnthropic,
+		Status:   service.StatusActive,
+		Hydrated: true,
+	}
+	h, cleanup := newTestGatewayHandler(t, fallbackGroup, nil)
+	defer cleanup()
+
+	rec := httptest.NewRecorder()
+	c, _ := gin.CreateTestContext(rec)
+	body := `{"model":"claude-3-5-sonnet","stream":false,"messages":[{"role":"user","content":"hi"}]}`
+	c.Request = httptest.NewRequest(http.MethodPost, "/v1/chat/completions", strings.NewReader(body))
+	c.Request.Header.Set("Content-Type", "application/json")
+
+	groupID := int64(1)
+	c.Set(string(middleware2.ContextKeyAPIKey), &service.APIKey{
+		ID:      11,
+		GroupID: &groupID,
+		User:    &service.User{ID: 13},
+		Group: &service.Group{
+			ID:              1,
+			Platform:        service.PlatformAnthropic,
+			Status:          service.StatusActive,
+			ClaudeCodeOnly:  true,
+			FallbackGroupID: i64ptr(20),
+		},
+	})
+	c.Set(string(middleware2.ContextKeyUser), middleware2.AuthSubject{UserID: 13, Concurrency: 1})
+
+	h.ChatCompletions(c)
+
+	require.NotEqual(t, http.StatusForbidden, rec.Code,
+		"valid fallback must bypass the CC-only 403; got body %s", rec.Body.String())
+	require.NotContains(t, rec.Body.String(), "restricted to Claude Code clients")
+}

--- a/scripts/sentinels/gateway-tk.json
+++ b/scripts/sentinels/gateway-tk.json
@@ -2250,6 +2250,32 @@
         "accountIncidentPoolExhaustedDedupeWindow"
       ],
       "rationale": "Platform-pool-exhausted P0 Feishu card (closes the #516 blind spot where 7 simultaneous per-account cooldowns produced no pool-level signal and the 06:49-06:58 outage went unalerted). Dedupe-per-platform is required: every subsequent account block during a cooldown storm re-triggers the pool check."
+    },
+    {
+      "path": "backend/internal/handler/gateway_handler_tk_cc_only_fallback.go",
+      "must_contain": [
+        "func tkCCOnlyFallbackGroupValid(fallback *service.Group) bool",
+        "func (h *GatewayHandler) tkResolveCCOnlyFallback(",
+        "if fallback.ClaudeCodeOnly {",
+        "if fallback.Platform != service.PlatformAnthropic {",
+        "cloneAPIKeyWithGroup(apiKey, fallbackGroup)",
+        "h.billingCacheService.CheckBillingEligibility("
+      ],
+      "rationale": "TK companion implementing CC-only-group fallback routing on the OpenAI-compat paths (/v1/chat/completions, /v1/responses). A group with claude_code_only=true hard-403s non-CC traffic; operators set fallback_group_id expecting that traffic to fall back instead. This helper resolves+validates the fallback group and re-binds the apiKey so the request is served by the fallback group's accounts instead of being rejected. The validation guards are load-bearing: ClaudeCodeOnly reject is the no-loop guard (a CC-only fallback would re-fire the same 403), Platform==anthropic keeps the fallback servable on these anthropic-only OpenAI-compat paths, and billing eligibility must pass before routing. Dropping any guard either re-opens the 403 loop or silently routes to an unservable/unbilled group."
+    },
+    {
+      "path": "backend/internal/handler/gateway_handler_chat_completions.go",
+      "must_contain": [
+        "h.tkResolveCCOnlyFallback(c, apiKey, reqLog, writeForbidden, writeBillingError)"
+      ],
+      "rationale": "Thin injection point for CC-only fallback routing in the upstream-shaped /v1/chat/completions handler. The bare CC-only 403 was replaced by a call into the TK companion (gateway_handler_tk_cc_only_fallback.go) that, on a valid fallback_group_id, re-binds apiKey to the fallback group and continues the request. An upstream merge that copies the old bare-403 shape back over this hook silently reverts the fallback feature."
+    },
+    {
+      "path": "backend/internal/handler/gateway_handler_responses.go",
+      "must_contain": [
+        "h.tkResolveCCOnlyFallback(c, apiKey, reqLog, writeForbidden, writeBillingError)"
+      ],
+      "rationale": "Thin injection point for CC-only fallback routing in the upstream-shaped /v1/responses handler. Mirrors the /v1/chat/completions hook: the bare CC-only 403 delegates to the TK companion so a valid fallback_group_id routes non-CC traffic to the fallback group instead of rejecting it. Anchors the hook against an upstream merge silently restoring the bare 403."
     }
   ]
 }


### PR DESCRIPTION
## 问题

`claude_code_only=true` 的 CC-only 分组只服务 Claude Code 客户端（`/v1/messages`）。当非-CC 请求打到 CC-only 分组的 OpenAI-compat 路径（`/v1/chat/completions`、`/v1/responses`）时，handler 在主转发流程之前就硬返回 **403 "This group is restricted to Claude Code clients (/v1/messages only)"**。

运维在 CC-only 分组上配置 `fallback_group_id`（如 prod 分组 1 "default" CC-only → `fallback_group_id=20` "default-fallback"，一个非-CC anthropic 分组），**期望非-CC 流量回退到该分组而不是被 403**。但这个意图从未实现：CC-only 的 403 是一个早退硬返回，从不查 `fallback_group_id`；现有唯一的 `fallback_group_id` 触发点只覆盖 antigravity 的 `PromptTooLongError` 路径，与 CC-only 客户端类型拒绝无关。

## 修复

在 CC-only 守卫处，若分组声明了**有效**的 `fallback_group_id`，把请求重新绑定到 fallback 分组并由其账号服务，而不是返回 403。无 fallback 或 fallback 无效则保持原 403 不变（无回归）。

逻辑收敛进 TK companion `backend/internal/handler/gateway_handler_tk_cc_only_fallback.go`；两个 upstream-shaped handler 只做薄注入（几行替换裸 403）。复用既有 `PromptTooLongError` fallback 的 helper：`ResolveGroupByID` / `cloneAPIKeyWithGroup` / `CheckBillingEligibility` / `billingErrorDetails`。重绑后两个 handler 各自按 fallback 分组 ID 重解析 channel 模型映射。

### 守卫（任一不满足都保持 403，绝不静默路由到坏分组）

- **无 fallback**：`FallbackGroupID == nil` → 保持 403。
- **无循环（核心）**：fallback 分组本身若 `ClaudeCodeOnly=true` → 拒绝（否则会再次触发同一 403 / 死循环）。
- **非-CC fallback only / 平台一致**：fallback 必须是 anthropic 平台（这两条 OpenAI-compat 路径只转发到 Anthropic 上游）。
- **存在且 active**：fallback 必须解析成功且 `IsActive()`。
- **计费校验**：fallback 绑定的 key 必须通过 `CheckBillingEligibility`；不通过则透出 billing 错误（而非泛化 403）。
- **单跳**：fallback 只解析一次，不链式 fallback-of-fallback。

保守性：只改 CC-only 拒绝这一条路径，正常请求不受影响。

## 测试

`backend/internal/handler/gateway_handler_tk_cc_only_fallback_unit_test.go`（`//go:build unit`）：

- 纯校验谓词 `tkCCOnlyFallbackGroupValid`：nil / active-anthropic-非CC（valid）/ CC-only（loop guard）/ inactive / 错误平台。
- helper `tkResolveCCOnlyFallback`：无 fallback → 403；fallback 自身 CC-only → 403；fallback inactive → 403；有效 fallback → 返回重绑到 group 20 的 apiKey（且原 apiKey 不被改动）。
- 全 handler 入口 `ChatCompletions`：CC-only + 有效 fallback → **非 403**（日志确认调度走 `group_id=20`），证明 403 被绕过、请求真正路由到 fallback 分组。

既有 CC-only 403 测试（`openai_stream_validation_test.go`）继续通过（无/无效 fallback 行为不变）。

## Sentinel

`scripts/sentinels/gateway-tk.json` 新增 3 条：新 companion + 两个注入锚点（chat_completions / responses），防止 upstream merge 静默还原裸 403。`python3 scripts/sentinels/check-gateway-tk.py` 通过（238/238 intact）。

## Markers

`no-web-impact`（纯后端）、`upstream-touch-guarded`（薄注入触碰 upstream-shaped handler，sentinel 注册已更新）。
