### PR TITLE
feat(pricing): 媒体路径缺价=400 拒绝 + 视频价签强制声明失败计费语义

### DIFF
--- a/backend/internal/handler/openai_gateway_embeddings_images.go
+++ b/backend/internal/handler/openai_gateway_embeddings_images.go
@@ -384,6 +384,12 @@ func (h *OpenAIGatewayHandler) ImageGenerations(c *gin.Context) {
 		return
 	}
 
+	// TK: unpriced media is not served — see openai_gateway_service_tk_media_unpriced_guard.go.
+	if h.gatewayService.TkImageModelUnpriced(reqModel, apiKey.Group) {
+		h.errorResponse(c, http.StatusBadRequest, "invalid_request_error", service.TkUnpricedMediaModelMessage(reqModel, "image"))
+		return
+	}
+
 	channelMapping, _ := h.gatewayService.ResolveChannelMappingAndRestrict(c.Request.Context(), apiKey.GroupID, reqModel)
 
 	if h.errorPassthroughService != nil {

--- a/backend/internal/handler/openai_gateway_tk_video.go
+++ b/backend/internal/handler/openai_gateway_tk_video.go
@@ -102,6 +102,14 @@ func (h *OpenAIGatewayHandler) VideoSubmit(c *gin.Context) {
 			"Video input (video_url content) is not supported: video-input generation is not yet priced on this gateway. Remove the video_url content part; first-frame image input (image_url) is supported.")
 		return
 	}
+	// Unpriced media is not served (pre-spend 400 instead of post-spend $0 +
+	// P0 alert — one video task is real upstream money); see
+	// openai_gateway_service_tk_media_unpriced_guard.go for the policy.
+	if h.gatewayService.TkVideoModelUnpriced(reqModel) {
+		h.errorResponse(c, http.StatusBadRequest, "invalid_request_error",
+			service.TkUnpricedMediaModelMessage(reqModel, "video"))
+		return
+	}
 	reqLog = reqLog.With(zap.String("model", reqModel))
 
 	setOpsRequestModelAndBody(c, reqModel, false, body)

--- a/backend/internal/handler/openai_images.go
+++ b/backend/internal/handler/openai_images.go
@@ -86,6 +86,11 @@ func (h *OpenAIGatewayHandler) Images(c *gin.Context) {
 		h.errorResponse(c, http.StatusForbidden, "permission_error", service.ImageGenerationPermissionMessage())
 		return
 	}
+	// TK: unpriced media is not served — see openai_gateway_service_tk_media_unpriced_guard.go.
+	if h.gatewayService.TkImageModelUnpriced(requestModel, apiKey.Group) {
+		h.errorResponse(c, http.StatusBadRequest, "invalid_request_error", service.TkUnpricedMediaModelMessage(requestModel, "image"))
+		return
+	}
 	if decision := h.checkContentModeration(c, reqLog, apiKey, subject, service.ContentModerationProtocolOpenAIImages, requestModel, parsed.ModerationBody()); decision != nil && decision.Blocked {
 		h.errorResponse(c, contentModerationStatus(decision), contentModerationErrorCode(decision), decision.Message)
 		return

--- a/backend/internal/service/billing_service.go
+++ b/backend/internal/service/billing_service.go
@@ -951,8 +951,10 @@ func (s *BillingService) getImageUnitPrice(model string, imageSize string, group
 // where the per-second rate comes from the LiteLLM table (e.g. veo `output_cost_per_second`,
 // resolved via the provider-prefix fallback in GetModelPricing). Callers pass the requested
 // duration (handlers default to a conservative 8s when the request omits it). When no
-// per-second price exists the cost is zero — an unpriced model must never block the request,
-// and the real spend ceiling is the upstream provider budget, not this internal estimate.
+// per-second price exists the cost is zero — this function stays non-blocking, but the
+// submit handler rejects unpriced models BEFORE dispatch via TkVideoModelUnpriced
+// (openai_gateway_service_tk_media_unpriced_guard.go), so a zero here should only be
+// reachable when pricing was removed between admission and billing.
 func (s *BillingService) CalculateVideoCost(model string, seconds int64, rateMultiplier float64) *CostBreakdown {
 	if seconds <= 0 {
 		seconds = 1

--- a/backend/internal/service/openai_gateway_service_tk_media_unpriced_guard.go
+++ b/backend/internal/service/openai_gateway_service_tk_media_unpriced_guard.go
@@ -1,0 +1,81 @@
+package service
+
+import "fmt"
+
+// TK: media unpriced = reject (操作员拍板 2026-06-12，反转媒体路径的
+// "先服务后补价"默认).
+//
+// Chat keeps serve-and-alert (a chat request is cents and availability wins;
+// the served_zero_cost P0 probe surfaces the gap). Media is the opposite
+// regime: one video task is up to ~$22 of upstream spend and images burn
+// hard per-project provider quota — serving them unpriced (video bills $0,
+// image falls back to a blind hardcoded $0.134) converts a pricing gap into
+// real money loss before any operator can react to the P0. So the image and
+// video gateway surfaces refuse to serve a model with no usable price: the
+// pre-spend 400 below replaces the post-spend alert.
+//
+// This is also what makes new upstream channels safe to auto-enable: their
+// models arrive unpriced → rejected → the human pricing act (overlay entry
+// with per-entry source + failure_billing declaration, see
+// scripts/checks/pricing-overlay.py) is the approval gate.
+//
+// Both predicates key off the REQUESTED model — the billing key — via the
+// same PricingService.GetModelPricing the billing path resolves through, so
+// guard and bill cannot drift. They fail OPEN on missing wiring (nil
+// services: can't tell → don't block) and CLOSED on missing price.
+
+// TkVideoModelUnpriced reports whether the requested model has no per-second
+// video price. Video billing uses OutputCostPerSecond exclusively
+// (CalculateVideoCost), so any model without it would bill $0 per second —
+// including text models pointed at the video endpoint.
+func (s *BillingService) TkVideoModelUnpriced(model string) bool {
+	if s == nil || s.pricingService == nil {
+		return false
+	}
+	pricing := s.pricingService.GetModelPricing(model)
+	return pricing == nil || pricing.OutputCostPerSecond <= 0
+}
+
+// TkImageModelUnpriced reports whether the requested model has no usable
+// image price from ANY static source: group-level size prices, a per-image
+// price, or token prices (gpt-image-style models bill by image tokens).
+// Only the truly priceless are rejected — tkIsEffectivelyUnpriced treats
+// litellm's all-zero placeholder rows as unpriced too. Channel-level DB
+// pricing is deliberately not consulted (unknown before scheduling; per
+// operating discipline it only holds non-zero corrections of models that
+// already carry a static price, so it cannot be a model's sole price).
+func (s *BillingService) TkImageModelUnpriced(model string, group *Group) bool {
+	if group != nil && (group.ImagePrice1K != nil || group.ImagePrice2K != nil || group.ImagePrice4K != nil) {
+		return false
+	}
+	if s == nil || s.pricingService == nil {
+		return false
+	}
+	pricing := s.pricingService.GetModelPricing(model)
+	return pricing == nil || tkIsEffectivelyUnpriced(pricing)
+}
+
+// TkVideoModelUnpriced / TkImageModelUnpriced — handler-facing wrappers so the
+// gateway handlers depend on OpenAIGatewayService only.
+func (s *OpenAIGatewayService) TkVideoModelUnpriced(model string) bool {
+	if s == nil {
+		return false
+	}
+	return s.billingService.TkVideoModelUnpriced(model)
+}
+
+func (s *OpenAIGatewayService) TkImageModelUnpriced(model string, group *Group) bool {
+	if s == nil {
+		return false
+	}
+	return s.billingService.TkImageModelUnpriced(model, group)
+}
+
+// TkUnpricedMediaModelMessage is the client-facing 400 body for both media
+// surfaces — explicit about WHY (no silent wrong charge) and about the way
+// out (operator adds pricing).
+func TkUnpricedMediaModelMessage(model, kind string) string {
+	return fmt.Sprintf(
+		"Model %q has no %s generation price configured on this gateway; unpriced media is not served (a silent zero or fallback charge is worse than a clear error). Ask the operator to add pricing for it first.",
+		model, kind)
+}

--- a/backend/internal/service/openai_gateway_service_tk_media_unpriced_guard.go
+++ b/backend/internal/service/openai_gateway_service_tk_media_unpriced_guard.go
@@ -1,6 +1,9 @@
 package service
 
-import "fmt"
+import (
+	"fmt"
+	"strings"
+)
 
 // TK: media unpriced = reject (操作员拍板 2026-06-12，反转媒体路径的
 // "先服务后补价"默认).
@@ -45,6 +48,12 @@ func (s *BillingService) TkVideoModelUnpriced(model string) bool {
 // operating discipline it only holds non-zero corrections of models that
 // already carry a static price, so it cannot be a model's sole price).
 func (s *BillingService) TkImageModelUnpriced(model string, group *Group) bool {
+	if strings.TrimSpace(model) == "" {
+		// Model-less image requests are legal on the OAuth path (the forward
+		// layer defaults them, e.g. to gpt-image-2) — defaulting and model
+		// validation belong to that layer, so an empty name fails OPEN here.
+		return false
+	}
 	if group != nil && (group.ImagePrice1K != nil || group.ImagePrice2K != nil || group.ImagePrice4K != nil) {
 		return false
 	}

--- a/backend/internal/service/openai_gateway_service_tk_media_unpriced_guard_contract_test.go
+++ b/backend/internal/service/openai_gateway_service_tk_media_unpriced_guard_contract_test.go
@@ -1,0 +1,79 @@
+//go:build unit
+
+package service
+
+import (
+	"os"
+	"regexp"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+)
+
+// Overwrite-protection gates for the media unpriced-reject guard. Both
+// premises below can drift SILENTLY (zero compile errors) under future
+// refactors or upstream merges; these tests turn the drift into a red
+// test-unit job.
+
+// TestMediaUnpricedGuard_ParityWithVideoBilling locks the guard's core
+// premise: video billing reads OutputCostPerSecond and nothing else, so
+// "guard rejects" must equal "billing would charge $0". If CalculateVideoCost
+// ever starts consulting other fields (tiers, token prices, channel data),
+// some row below breaks the equality and forces the guard to be updated in
+// the same change — instead of silently rejecting now-billable models or
+// admitting now-free ones.
+func TestMediaUnpricedGuard_ParityWithVideoBilling(t *testing.T) {
+	svc := &BillingService{
+		pricingService: &PricingService{
+			pricingData: map[string]*LiteLLMModelPricing{
+				"per-second-priced": {OutputCostPerSecond: 0.40, Mode: "video_generation"},
+				"token-only-priced": {InputCostPerToken: 1e-6, OutputCostPerToken: 4e-5, Mode: "chat"},
+				"per-image-only":    {OutputCostPerImage: 0.04, Mode: "image_generation"},
+				"zero-placeholder":  {Mode: "video_generation"},
+			},
+		},
+	}
+	for _, model := range []string{
+		"per-second-priced",
+		"token-only-priced",
+		"per-image-only",
+		"zero-placeholder",
+		"absent-model",
+	} {
+		guardRejects := svc.TkVideoModelUnpriced(model)
+		billsZero := svc.CalculateVideoCost(model, 8, 1.0).TotalCost <= 0
+		require.Equal(t, billsZero, guardRejects,
+			"guard/billing parity broken for %q: guard rejects=%v but bills zero=%v — "+
+				"video billing semantics changed; update TkVideoModelUnpriced in the same change",
+			model, guardRejects, billsZero)
+	}
+}
+
+// TestMediaUnpricedGuard_EmptyModelDefaultIsPriced locks the fail-open
+// premise for model-less image requests: the guard lets them through because
+// the OAuth forward layer defaults the model — which is only safe while that
+// DEFAULT is itself a priced model. The default name is extracted from the
+// live source (same package), so an upstream merge that changes it to an
+// unpriced model turns this red instead of silently re-opening the
+// unpriced-media hole; the shipped fallback pricing + overlay is the same
+// chain the runtime resolves through.
+func TestMediaUnpricedGuard_EmptyModelDefaultIsPriced(t *testing.T) {
+	src, err := os.ReadFile("openai_images_responses.go")
+	require.NoError(t, err)
+	m := regexp.MustCompile(`requestModel = "([^"]+)"`).FindSubmatch(src)
+	require.NotNil(t, m,
+		"model-less image defaulting (requestModel = \"...\") not found in openai_images_responses.go — "+
+			"if defaulting moved or was removed, re-evaluate the empty-model fail-open in TkImageModelUnpriced")
+	defaultModel := string(m[1])
+
+	fallback, err := os.ReadFile("../../resources/model-pricing/model_prices_and_context_window.json")
+	require.NoError(t, err)
+	data, err := (&PricingService{}).parsePricingData(fallback)
+	require.NoError(t, err)
+	svc := &BillingService{pricingService: &PricingService{pricingData: data}}
+
+	require.False(t, svc.TkImageModelUnpriced(defaultModel, nil),
+		"the model-less image default %q must be priced in the shipped pricing chain — "+
+			"an unpriced default makes the guard's empty-model fail-open a billing hole",
+		defaultModel)
+}

--- a/backend/internal/service/openai_gateway_service_tk_media_unpriced_guard_test.go
+++ b/backend/internal/service/openai_gateway_service_tk_media_unpriced_guard_test.go
@@ -60,6 +60,10 @@ func TestTkImageModelUnpriced(t *testing.T) {
 	group := &Group{ImagePrice2K: &price}
 	require.False(t, svc.TkImageModelUnpriced("never-priced-image-model", group))
 
+	// Model-less requests (OAuth path defaults the model downstream) fail OPEN.
+	require.False(t, svc.TkImageModelUnpriced("", nil))
+	require.False(t, svc.TkImageModelUnpriced("   ", nil))
+
 	// Fail OPEN on missing wiring.
 	require.False(t, (&BillingService{}).TkImageModelUnpriced("anything", nil))
 }

--- a/backend/internal/service/openai_gateway_service_tk_media_unpriced_guard_test.go
+++ b/backend/internal/service/openai_gateway_service_tk_media_unpriced_guard_test.go
@@ -1,0 +1,72 @@
+//go:build unit
+
+package service
+
+import (
+	"strings"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+)
+
+func tkMediaGuardBillingService() *BillingService {
+	return &BillingService{
+		pricingService: &PricingService{
+			pricingData: map[string]*LiteLLMModelPricing{
+				"veo-3.1-generate-001":           {OutputCostPerSecond: 0.40, Mode: "video_generation"},
+				"imagen-4.0-generate-001":        {OutputCostPerImage: 0.04, Mode: "image_generation"},
+				"gpt-image-token-billed":         {InputCostPerToken: 1e-6, OutputCostPerToken: 4e-5, Mode: "chat"},
+				"zero-placeholder-media":         {Mode: "image_generation"}, // litellm all-zero placeholder
+				"doubao-seedance-1-0-pro-250528": {OutputCostPerSecond: 0.10880597014925374, Mode: "video_generation"},
+			},
+		},
+	}
+}
+
+func TestTkVideoModelUnpriced(t *testing.T) {
+	svc := tkMediaGuardBillingService()
+
+	require.False(t, svc.TkVideoModelUnpriced("veo-3.1-generate-001"))
+	require.False(t, svc.TkVideoModelUnpriced("doubao-seedance-1-0-pro-250528"))
+
+	// Unknown model: would bill $0/s → must be rejected pre-dispatch.
+	require.True(t, svc.TkVideoModelUnpriced("brand-new-video-model"))
+	// Token-priced model pointed at the VIDEO endpoint: video billing only
+	// reads OutputCostPerSecond, so this would also bill $0 → unpriced here.
+	require.True(t, svc.TkVideoModelUnpriced("gpt-image-token-billed"))
+	// Zero placeholder row → unpriced.
+	require.True(t, svc.TkVideoModelUnpriced("zero-placeholder-media"))
+
+	// Fail OPEN on missing wiring: a nil pricing service must not block.
+	require.False(t, (&BillingService{}).TkVideoModelUnpriced("anything"))
+	var nilSvc *BillingService
+	require.False(t, nilSvc.TkVideoModelUnpriced("anything"))
+}
+
+func TestTkImageModelUnpriced(t *testing.T) {
+	svc := tkMediaGuardBillingService()
+
+	require.False(t, svc.TkImageModelUnpriced("imagen-4.0-generate-001", nil))
+	// gpt-image-style models bill by tokens — token prices count as priced.
+	require.False(t, svc.TkImageModelUnpriced("gpt-image-token-billed", nil))
+
+	// Truly priceless / zero placeholder → rejected (this replaces the blind
+	// $0.134 hardcoded fallback for models nobody priced).
+	require.True(t, svc.TkImageModelUnpriced("never-priced-image-model", nil))
+	require.True(t, svc.TkImageModelUnpriced("zero-placeholder-media", nil))
+
+	// Group-level size prices are a legitimate sole price source.
+	price := 0.05
+	group := &Group{ImagePrice2K: &price}
+	require.False(t, svc.TkImageModelUnpriced("never-priced-image-model", group))
+
+	// Fail OPEN on missing wiring.
+	require.False(t, (&BillingService{}).TkImageModelUnpriced("anything", nil))
+}
+
+func TestTkUnpricedMediaModelMessage(t *testing.T) {
+	msg := TkUnpricedMediaModelMessage("some-model", "video")
+	require.True(t, strings.Contains(msg, `"some-model"`))
+	require.True(t, strings.Contains(msg, "video generation price"))
+	require.True(t, strings.Contains(msg, "operator"))
+}

--- a/backend/internal/service/tk_pricing_overlay.json
+++ b/backend/internal/service/tk_pricing_overlay.json
@@ -1,6 +1,6 @@
 {
   "_meta": {
-    "note": "TK-owned pricing overlay for models the runtime price source lacks. Merged into PricingService AFTER any source load (Wei-Shaw remote OR disk fallback); an entry below applies when the source key is ABSENT or the source entry is EFFECTIVELY UNPRICED (every cost field 0.0 — litellm's 'unknown', not 'free'; see tkIsEffectivelyUnpriced). The Wei-Shaw runtime mirror is a TRIMMED litellm mirror that drops provider-prefixed keys and token-less media entries, so imagen-*/veo-* resolve to nothing there; litellm itself also lags new provider models (deepseek-v4-*) or carries them as zero placeholders (deepseek-v3-2-251201), which then bill $0. Media price = vertex_ai provider (TK media flow routes through Vertex ch41); falls back to gemini only when no vertex variant exists. Text price = provider official list price. Self-deprecating: the day the source carries a real (non-zero) price under the bare key, the source value wins and the entry below is ignored. The overlay cannot CORRECT wrong NON-ZERO source prices (deepseek-chat/reasoner still carry the pre-V4 rate in the mirror) — use channel pricing (DB) for that.",
+    "note": "TK-owned pricing overlay for models the runtime price source lacks. Merged into PricingService AFTER any source load (Wei-Shaw remote OR disk fallback); an entry below applies when the source key is ABSENT or the source entry is EFFECTIVELY UNPRICED (every cost field 0.0 — litellm's 'unknown', not 'free'; see tkIsEffectivelyUnpriced). The Wei-Shaw runtime mirror is a TRIMMED litellm mirror that drops provider-prefixed keys and token-less media entries, so imagen-*/veo-* resolve to nothing there; litellm itself also lags new provider models (deepseek-v4-*) or carries them as zero placeholders (deepseek-v3-2-251201), which then bill $0. Media price = vertex_ai provider (TK media flow routes through Vertex ch41); falls back to gemini only when no vertex variant exists. Text price = provider official list price. Self-deprecating: the day the source carries a real (non-zero) price under the bare key, the source value wins and the entry below is ignored. The overlay cannot CORRECT wrong NON-ZERO source prices (deepseek-chat/reasoner still carry the pre-V4 rate in the mirror) — use channel pricing (DB) for that. Video entries MUST declare failure_billing (currently only 'success_only' is legal): TokenKey refunds the user in full when a video task ends failed, which is only loss-free if the provider does not charge for failed tasks — the person pricing a new video model verifies that on the official page and declares it here; scripts/checks/pricing-overlay.py enforces the field, and any other value must first change the refund design.",
     "provenance": "media: BerriAI/litellm model_prices_and_context_window.json, captured 2026-06-01; deepseek-v4-*: https://api-docs.deepseek.com/quick_start/pricing, captured 2026-06-04 (cache-hit input = cache_read; cache writes billed as normal input, no separate write fee); volcengine doubao-*/glm-4-7-251222/deepseek-v3-2-251201: VolcEngine Ark official model-pricing page, captured 2026-06-10 (≤32K input tier, CNY/USD=6.7); glm-4.7 matches Zhipu official; qwen3.7-max*: Alibaba DashScope official list price, captured 2026-06-10 (per-entry source); qwen2.5-coder-32b/7b: retired & absent from current Alibaba list — proxy-filled from lineage successors qwen3-coder-plus / qwen3-coder-flash, Beijing RMB list ÷ 6.7, docs/accounts/aliyun_pricing_20260612.md captured 2026-06-12 (per-entry source); seedream/seedance media: VolcEngine Ark official model-pricing page (https://www.volcengine.com/docs/82379/1099320), captured 2026-06-12, CNY/USD=6.7 — per-image flat price; per-second video price derived at each model's max supported tier (1080p@24fps; 2.0-fast 720p), online standard rate, derivation formula in per-entry source; only IDs present in new-api ch45/54 model lists are included — seedream-4.5/5.0(-lite) & seedance-1.0-pro-fast are priced upstream but absent from new-api constants, seedance-1.0-lite is listed but retired/unpriced, all deliberately NOT included (served_zero_cost P0 probe covers the gap; a wrong price has no probe)",
     "regen": "manual curation; no auto-sync (entries are few + slow-moving). If they proliferate, add provider-aware sync."
   },
@@ -111,49 +111,57 @@
     "litellm_provider": "vertex_ai",
     "mode": "video_generation",
     "output_cost_per_second": 0.35,
-    "source": "litellm:vertex_ai/veo-2.0-generate-001"
+    "source": "litellm:vertex_ai/veo-2.0-generate-001",
+    "failure_billing": "success_only"
   },
   "veo-3.0-fast-generate-001": {
     "litellm_provider": "vertex_ai",
     "mode": "video_generation",
     "output_cost_per_second": 0.15,
-    "source": "litellm:vertex_ai/veo-3.0-fast-generate-001"
+    "source": "litellm:vertex_ai/veo-3.0-fast-generate-001",
+    "failure_billing": "success_only"
   },
   "veo-3.0-generate-001": {
     "litellm_provider": "vertex_ai",
     "mode": "video_generation",
     "output_cost_per_second": 0.4,
-    "source": "litellm:vertex_ai/veo-3.0-generate-001"
+    "source": "litellm:vertex_ai/veo-3.0-generate-001",
+    "failure_billing": "success_only"
   },
   "veo-3.1-fast-generate-001": {
     "litellm_provider": "vertex_ai",
     "mode": "video_generation",
     "output_cost_per_second": 0.15,
-    "source": "litellm:vertex_ai/veo-3.1-fast-generate-001"
+    "source": "litellm:vertex_ai/veo-3.1-fast-generate-001",
+    "failure_billing": "success_only"
   },
   "veo-3.1-fast-generate-preview": {
     "litellm_provider": "vertex_ai",
     "mode": "video_generation",
     "output_cost_per_second": 0.15,
-    "source": "litellm:vertex_ai/veo-3.1-fast-generate-preview"
+    "source": "litellm:vertex_ai/veo-3.1-fast-generate-preview",
+    "failure_billing": "success_only"
   },
   "veo-3.1-generate-001": {
     "litellm_provider": "vertex_ai",
     "mode": "video_generation",
     "output_cost_per_second": 0.4,
-    "source": "litellm:vertex_ai/veo-3.1-generate-001"
+    "source": "litellm:vertex_ai/veo-3.1-generate-001",
+    "failure_billing": "success_only"
   },
   "veo-3.1-generate-preview": {
     "litellm_provider": "vertex_ai",
     "mode": "video_generation",
     "output_cost_per_second": 0.4,
-    "source": "litellm:vertex_ai/veo-3.1-generate-preview"
+    "source": "litellm:vertex_ai/veo-3.1-generate-preview",
+    "failure_billing": "success_only"
   },
   "veo-3.1-lite-generate-preview": {
     "litellm_provider": "gemini",
     "mode": "video_generation",
     "output_cost_per_second": 0.05,
-    "source": "litellm:gemini/veo-3.1-lite-generate-preview"
+    "source": "litellm:gemini/veo-3.1-lite-generate-preview",
+    "failure_billing": "success_only"
   },
   "doubao-seedream-4-0-250828": {
     "litellm_provider": "volcengine",
@@ -171,31 +179,36 @@
     "litellm_provider": "volcengine",
     "mode": "video_generation",
     "output_cost_per_second": 0.10880597014925374,
-    "source": "VolcEngine Ark official https://www.volcengine.com/docs/82379/1099320, captured 2026-06-12: doubao-seedance-1.0-pro online = 15 CNY/M tokens; video tokens = duration*W*H*fps/1024. Priced at the model's MAX tier 1080p(1920x1080)@24fps so lower-resolution requests over- not under-charge: 1920*1080*24/1024 = 48600 tokens/s -> 48600*15/1e6 = 0.729 CNY/s ÷ 6.7 = 0.1088060 USD/s (matches official 1080p 5s example ~3.645 CNY). 720p actual cost is 4/9 of this."
+    "source": "VolcEngine Ark official https://www.volcengine.com/docs/82379/1099320, captured 2026-06-12: doubao-seedance-1.0-pro online = 15 CNY/M tokens; video tokens = duration*W*H*fps/1024. Priced at the model's MAX tier 1080p(1920x1080)@24fps so lower-resolution requests over- not under-charge: 1920*1080*24/1024 = 48600 tokens/s -> 48600*15/1e6 = 0.729 CNY/s ÷ 6.7 = 0.1088060 USD/s (matches official 1080p 5s example ~3.645 CNY). 720p actual cost is 4/9 of this.",
+    "failure_billing": "success_only"
   },
   "seedance-1-0-pro-250528": {
     "litellm_provider": "volcengine",
     "mode": "video_generation",
     "output_cost_per_second": 0.10880597014925374,
-    "source": "No-prefix alias of doubao-seedance-1-0-pro-250528 (new-api volcengine ModelList carries both; billing key = requested_model). Same derivation: 1080p@24fps max tier, 48600 tokens/s * 15 CNY/M = 0.729 CNY/s ÷ 6.7. Captured 2026-06-12."
+    "source": "No-prefix alias of doubao-seedance-1-0-pro-250528 (new-api volcengine ModelList carries both; billing key = requested_model). Same derivation: 1080p@24fps max tier, 48600 tokens/s * 15 CNY/M = 0.729 CNY/s ÷ 6.7. Captured 2026-06-12.",
+    "failure_billing": "success_only"
   },
   "doubao-seedance-1-5-pro-251215": {
     "litellm_provider": "volcengine",
     "mode": "video_generation",
     "output_cost_per_second": 0.11611940298507463,
-    "source": "VolcEngine Ark official https://www.volcengine.com/docs/82379/1099320, captured 2026-06-12: doubao-seedance-1.5-pro, MAX tier = 1080p WITH audio (16 CNY/M tokens). Official example table 1080p 16:9 5s with-audio = 3.89 CNY -> 0.778 CNY/s ÷ 6.7 = 0.1161194 USD/s; token-formula cross-check 48600*16/1e6 = 0.7776 CNY/s (<0.1% off). Silent 1080p is half; 480p/720p cheaper — single per-second price never under-charges those."
+    "source": "VolcEngine Ark official https://www.volcengine.com/docs/82379/1099320, captured 2026-06-12: doubao-seedance-1.5-pro, MAX tier = 1080p WITH audio (16 CNY/M tokens). Official example table 1080p 16:9 5s with-audio = 3.89 CNY -> 0.778 CNY/s ÷ 6.7 = 0.1161194 USD/s; token-formula cross-check 48600*16/1e6 = 0.7776 CNY/s (<0.1% off). Silent 1080p is half; 480p/720p cheaper — single per-second price never under-charges those.",
+    "failure_billing": "success_only"
   },
   "doubao-seedance-2-0-260128": {
     "litellm_provider": "volcengine",
     "mode": "video_generation",
-    "output_cost_per_second": 0.36985074626865673,
-    "source": "VolcEngine Ark official https://www.volcengine.com/docs/82379/1099320, captured 2026-06-12: doubao-seedance-2.0, MAX output tier 1080p, input-without-video (text/image-to-video, 51 CNY/M tokens). Official example 1080p 5s = 12.39 CNY -> 2.478 CNY/s ÷ 6.7 = 0.3698507 USD/s; cross-check 48600*51/1e6 = 2.4786 CNY/s. CAVEAT: video-input continuation bills (input+output) duration upstream and can exceed this single per-second rate up to ~2.4x — restrict or re-price before enabling video input on TK."
+    "output_cost_per_second": 0.3698507462686567,
+    "source": "VolcEngine Ark official https://www.volcengine.com/docs/82379/1099320, captured 2026-06-12: doubao-seedance-2.0, MAX output tier 1080p, input-without-video (text/image-to-video, 51 CNY/M tokens). Official example 1080p 5s = 12.39 CNY -> 2.478 CNY/s ÷ 6.7 = 0.3698507 USD/s; cross-check 48600*51/1e6 = 2.4786 CNY/s. CAVEAT: video-input continuation bills (input+output) duration upstream and can exceed this single per-second rate up to ~2.4x — restrict or re-price before enabling video input on TK.",
+    "failure_billing": "success_only"
   },
   "doubao-seedance-2-0-fast-260128": {
     "litellm_provider": "volcengine",
     "mode": "video_generation",
     "output_cost_per_second": 0.11940298507462686,
-    "source": "VolcEngine Ark official https://www.volcengine.com/docs/82379/1099320, captured 2026-06-12: doubao-seedance-2.0-fast, MAX supported output is 720p (no 1080p), input-without-video (37 CNY/M tokens). Official example 720p 5s = 4.00 CNY -> 0.8 CNY/s ÷ 6.7 = 0.1194030 USD/s; cross-check 1280*720*24/1024 = 21600 tokens/s * 37/1e6 = 0.7992 CNY/s. Same video-input caveat as seedance-2.0."
+    "source": "VolcEngine Ark official https://www.volcengine.com/docs/82379/1099320, captured 2026-06-12: doubao-seedance-2.0-fast, MAX supported output is 720p (no 1080p), input-without-video (37 CNY/M tokens). Official example 720p 5s = 4.00 CNY -> 0.8 CNY/s ÷ 6.7 = 0.1194030 USD/s; cross-check 1280*720*24/1024 = 21600 tokens/s * 37/1e6 = 0.7992 CNY/s. Same video-input caveat as seedance-2.0.",
+    "failure_billing": "success_only"
   },
   "doubao-seed-2-0-pro-260215": {
     "litellm_provider": "volcengine",

--- a/scripts/checks/pricing-overlay.py
+++ b/scripts/checks/pricing-overlay.py
@@ -86,6 +86,20 @@ def main() -> int:
             price = pricing.get(field)
             if not isinstance(price, (int, float)) or price <= 0:
                 errors.append(f"{model}: mode={mode} requires {field} > 0, got {price!r}")
+        if mode == "video_generation":
+            # TokenKey refunds the user in full when a video task ends failed —
+            # loss-free ONLY if the provider does not charge for failed tasks.
+            # Whoever prices a video model verifies that on the official pricing
+            # page and declares it here; a provider that charges on failure must
+            # not be priced (= not served) until the refund design handles it.
+            failure_billing = pricing.get("failure_billing")
+            if failure_billing != "success_only":
+                errors.append(
+                    f"{model}: video entries must declare failure_billing='success_only' "
+                    f"(got {failure_billing!r}); a provider that charges for failed tasks "
+                    f"breaks the terminal-failure refund — change the refund design before "
+                    f"pricing it"
+                )
 
     for model, field in ANCHORS.items():
         pricing = entries.get(model)

--- a/scripts/sentinels/gateway-tk.json
+++ b/scripts/sentinels/gateway-tk.json
@@ -1652,7 +1652,8 @@
         "VideoDurationSeconds",
         "RefundVideoUsageOnFailure",
         "videoSubmitHasVideoInput",
-        "videoTerminalOutcome"
+        "videoTerminalOutcome",
+        "TkVideoModelUnpriced"
       ],
       "rationale": "Per-second video (veo) billing: VideoSubmit records usage with the requested duration (default 8s via videoRequestedSeconds) so the cost path bills duration x per-second rate. Without this anchor veo silently bills $0 (no tokens, no per-second branch). RefundVideoUsageOnFailure anchors the terminal-failed refund trigger (user paid at submit for a video that never materialized); videoSubmitHasVideoInput anchors the video-INPUT reject guard (upstream bills input+output duration for video-in, so the per-output-second price would under-charge 1.6-2.4x — lifting the guard requires re-pricing in the same PR)."
     },
@@ -2279,6 +2280,22 @@
         "h.tkResolveCCOnlyFallback(c, apiKey, reqLog, writeForbidden, writeBillingError)"
       ],
       "rationale": "Thin injection point for CC-only fallback routing in the upstream-shaped /v1/responses handler. Mirrors the /v1/chat/completions hook: the bare CC-only 403 delegates to the TK companion so a valid fallback_group_id routes non-CC traffic to the fallback group instead of rejecting it. Anchors the hook against an upstream merge silently restoring the bare 403."
+    },
+    {
+      "path": "backend/internal/service/openai_gateway_service_tk_media_unpriced_guard.go",
+      "must_contain": [
+        "TkVideoModelUnpriced",
+        "TkImageModelUnpriced",
+        "TkUnpricedMediaModelMessage"
+      ],
+      "rationale": "Media unpriced-reject policy (operator decision 2026-06-12): image/video gateway surfaces refuse to serve models with no usable price — the pre-spend 400 replaces the post-spend served_zero_cost P0 for media, where one task is real upstream money (video up to ~$22) and image otherwise falls back to a blind hardcoded $0.134. Also the safety premise that lets new upstream channels auto-enable: their models arrive unpriced and are rejected until the human pricing act. Removing this file silently reverts media to serve-unpriced."
+    },
+    {
+      "path": "backend/internal/handler/openai_gateway_embeddings_images.go",
+      "must_contain": [
+        "TkImageModelUnpriced"
+      ],
+      "rationale": "Second TK hook for the media unpriced-reject policy: ImageGenerations() is the OpenAI-compat pool entry for POST /images/generations (newapi groups route here, NOT through openai_images.go Images()). The first guard rollout missed this entry and unpriced image requests sailed to the upstream — caught by local e2e. Dropping this call silently re-opens that exact hole."
     }
   ]
 }

--- a/scripts/sentinels/pricing-availability.json
+++ b/scripts/sentinels/pricing-availability.json
@@ -100,6 +100,21 @@
         "litellmPricing.Intervals"
       ],
       "rationale": "BillingService.GetModelPricing carries a 1-line TK hook: a litellm entry whose every cost field is zero (litellm's 'cost unknown' placeholder — e.g. deepseek-v3-2-251201 under volcengine) is treated as pricing-missing instead of a successful $0 lookup, falling through to fallback / ErrModelPricingUnavailable so the existing zero-cost record + Feishu pricing-missing funnel fires. Without this hook, zero-placeholder models silently bill $0 with no alert (683 prod requests leaked through 2026-06-10 before it existed). An upstream merge restructuring GetModelPricing could drop the `&& !tkIsEffectivelyUnpriced(...)` guard without any compile error. The predicate itself lives in pricing_service_tk_overlay.go (shared with the overlay absent-or-zero fill). SECOND hook on the same constructor: GetModelPricing MUST copy `Intervals: litellmPricing.Intervals` onto ModelPricing so overlay interval (tiered) pricing is carried into billing (consumed downstream via ResolvedPricing.Intervals -> GetIntervalPricing); dropping the copy silently flattens every overlay-tiered model to its base-tier price with no compile error."
+    },
+    {
+      "path": "scripts/checks/pricing-overlay.py",
+      "must_contain": [
+        "failure_billing"
+      ],
+      "rationale": "The failure_billing declaration check is the human-judgment anchor of the video pricing workflow: TokenKey refunds users in full on terminal-failed video tasks, which is only loss-free when the provider does not charge for failures — whoever prices a video model must verify and declare that. Dropping this block from the check silently removes the forced verification while overlay entries keep parsing fine."
+    },
+    {
+      "path": "backend/internal/service/openai_gateway_service_tk_media_unpriced_guard_contract_test.go",
+      "must_contain": [
+        "TestMediaUnpricedGuard_ParityWithVideoBilling",
+        "TestMediaUnpricedGuard_EmptyModelDefaultIsPriced"
+      ],
+      "rationale": "Overwrite-protection gates for the media unpriced-reject guard: lock guard<->video-billing parity (billing semantics change must update the guard in the same change) and the empty-model fail-open premise (the OAuth default image model must stay priced in the shipped chain). Deleting these tests re-opens the silent-drift channels they close."
     }
   ]
 }


### PR DESCRIPTION
## 背景（操作员拍板 2026-06-12）

媒体路径反转「先服务后补价」。聊天保持 serve + served_zero_cost P0（几分钱、可用性优先）；媒体相反——视频单任务最高 ~$22 上游真实开销，图片缺价此前**盲兜底 $0.134 硬编码**——缺价照服务等于把价签缺口直接变成钱的损失。改为**售前 400 取代售后告警**。

这同时是「新渠道自动进门」的安全前提：新上游渠道的模型天然缺价 → 天然被拒 → 补价动作（overlay 条目 + per-entry source + failure_billing 声明）就是人工审批门，不再需要独立的签字注册表。

## 改动

1. **双谓词守卫**（`openai_gateway_service_tk_media_unpriced_guard.go`）：
   - 视频：requested model 无 `output_cost_per_second` 即拒（视频计费唯一价源；文本模型指到视频端点同样拒）。
   - 图片：组级尺寸价 / 每张价 / token 价（gpt-image 族按 token 计）**全缺才拒**（复用 `tkIsEffectivelyUnpriced`，litellm 零占位行同拒）——只拒真正无价者，不误伤任何既有价源。
   - 与计费同源取价（`GetModelPricing`），守卫与计费不漂移；服务未接线 fail-open、缺价 fail-closed。
2. **三处注入**：视频 handler + 图片双入口（`Images()` 与 compat 池真实入口 `ImageGenerations()`——首轮端到端实测抓到后者被漏、缺价请求直达上游，已补并双双锚进 sentinel 防回退）。
3. **价签长出失败计费声明**：13 条视频 overlay 条目加 `failure_billing="success_only"`；`pricing-overlay.py` 强制视频条目必须声明且当前仅此值合法——TK 终态 failed 全额退用户，仅当供应商对失败不收费才无损；**对失败收费的供应商必须先改退费设计才允许定价**（mutation 实测：删字段即红）。
4. `CalculateVideoCost` 注释纠偏（"unpriced 不阻断"已被 handler 售前拒取代）。

## 测试与端到端验收

- 单测：谓词 3 组（含 fail-open/零占位/组价/token 价边界）+ 全量 `go test -tags=unit ./...` 绿（既有图片测试零误伤）。
- 守卫脚本 mutation 验证：删任一 failure_billing 字段 preflight 即红。
- **本机端到端**（二进制 + docker PG/Redis + ark stub 全真栈）：缺价视频/图片均 400 明确文案、零计费零落库；有价模型（seedance/seedream）正常放行到上游 ✅

## Sentinel 说明

`billing_service.go` 的 diff 为**纯注释重写**（更新过时的 "unpriced 不阻断" 注释），pricing-availability 热点锚（`tkIsEffectivelyUnpriced` / `litellmPricing.Intervals`）实测完好，无需锚点变更。

sentinel-registry-reviewed

合并方式：Squash and merge（TK-originated）。

🤖 Generated with [Claude Code](https://claude.com/claude-code)

### 追加：upstream merge 覆盖写防护门禁（commit 3）

sentinel 锚只防 hook/文件被删，语义漂移另用 contract test 锁死（标准 test-unit job，任何 PR / upstream merge 改前提即红）：

- `TestMediaUnpricedGuard_ParityWithVideoBilling`：守卫拒绝 ⟺ 视频计费为零，逐行平价断言——计费改读其他字段时强制同改守卫。
- `TestMediaUnpricedGuard_EmptyModelDefaultIsPriced`：正则从同包源码自取 OAuth 默认模型名（自动跟随上游改名），对随仓 fallback+overlay 同链断言默认名必须有价——默认换成无价模型即红。
- 门禁自保：pricing-overlay.py 的 failure_billing 检查块 + contract test 文件锚进 pricing-availability.json。