### PR TITLE
fix(anthropic): prod 调度对持续饱和镜像 stub 施加 bounded 去优先级偏好

### DIFF
--- a/backend/cmd/server/wire.go
+++ b/backend/cmd/server/wire.go
@@ -132,6 +132,10 @@ func provideCleanup(
 	// this dependency edge wire would dead-code the post-construction setter
 	// because no other production component references the sentinel.
 	_ service.TKGatewayAnthropicSigPreemptReady,
+	// TokenKey: forces wire to evaluate ProvideTKAnthropicSaturation so the
+	// saturation counter is wired onto GatewayService + RateLimitService at
+	// startup (otherwise wire dead-codes the post-construction setters).
+	_ service.TKAnthropicSaturationReady,
 	// TokenKey: forces wire to evaluate ProvideTKGatewayHandlerModelList so
 	// GatewayHandler.SetModelListFilter is called at startup. See R-003 /
 	// Goal 2 of docs/approved/pricing-availability-source-of-truth.md.

--- a/backend/cmd/server/wire_gen.go
+++ b/backend/cmd/server/wire_gen.go
@@ -312,9 +312,11 @@ func initializeApplication(buildInfo handler.BuildInfo) (*Application, error) {
 	tkGatewayPricingAvailabilityReady := service.ProvideTKGatewayPricingAvailability(gatewayService, pricingAvailabilityService)
 	anthropicSignaturePreemptCache := repository.NewAnthropicSignaturePreemptCache(redisClient)
 	tkGatewayAnthropicSigPreemptReady := service.ProvideTKGatewayAnthropicSigPreempt(gatewayService, anthropicSignaturePreemptCache)
+	anthropicSaturationCounterCache := repository.NewAnthropicSaturationCounterCache(redisClient)
+	tkAnthropicSaturationReady := service.ProvideTKAnthropicSaturation(gatewayService, rateLimitService, anthropicSaturationCounterCache)
 	modelListFilter := service.NewModelListFilter(pricingCatalogService, pricingAvailabilityService)
 	tkGatewayHandlerModelListReady := handler.ProvideTKGatewayHandlerModelList(gatewayHandler, modelListFilter)
-	v := provideCleanup(client, redisClient, opsMetricsCollector, opsAggregationService, opsAlertEvaluatorService, opsCleanupService, opsScheduledReportService, opsSystemLogSink, schedulerSnapshotService, schedulerRateLimitReaper, anthropicConfigReconciler, upstreamBalanceSentinel, tokenRefreshService, accountExpiryService, proxyExpiryService, subscriptionExpiryService, usageCleanupService, idempotencyCleanupService, pricingService, emailQueueService, billingCacheService, usageRecordWorkerPool, qaService, subscriptionService, oAuthService, openAIOAuthService, geminiOAuthService, antigravityOAuthService, openAIGatewayService, scheduledTestRunnerService, backupService, paymentOrderExpiryService, channelMonitorRunner, tkAccountIncidentNotifier, tkPricingMissingNotifier, tkAuthServiceColdStartReady, tkGatewayPricingAvailabilityReady, tkGatewayAnthropicSigPreemptReady, tkGatewayHandlerModelListReady)
+	v := provideCleanup(client, redisClient, opsMetricsCollector, opsAggregationService, opsAlertEvaluatorService, opsCleanupService, opsScheduledReportService, opsSystemLogSink, schedulerSnapshotService, schedulerRateLimitReaper, anthropicConfigReconciler, upstreamBalanceSentinel, tokenRefreshService, accountExpiryService, proxyExpiryService, subscriptionExpiryService, usageCleanupService, idempotencyCleanupService, pricingService, emailQueueService, billingCacheService, usageRecordWorkerPool, qaService, subscriptionService, oAuthService, openAIOAuthService, geminiOAuthService, antigravityOAuthService, openAIGatewayService, scheduledTestRunnerService, backupService, paymentOrderExpiryService, channelMonitorRunner, tkAccountIncidentNotifier, tkPricingMissingNotifier, tkAuthServiceColdStartReady, tkGatewayPricingAvailabilityReady, tkGatewayAnthropicSigPreemptReady, tkAnthropicSaturationReady, tkGatewayHandlerModelListReady)
 	application := &Application{
 		Server:  httpServer,
 		Cleanup: v,
@@ -386,6 +388,8 @@ func provideCleanup(
 	_ service.TKGatewayPricingAvailabilityReady,
 
 	_ service.TKGatewayAnthropicSigPreemptReady,
+
+	_ service.TKAnthropicSaturationReady,
 
 	_ handler.TKGatewayHandlerModelListReady,
 ) func() {

--- a/backend/cmd/server/wire_gen_test.go
+++ b/backend/cmd/server/wire_gen_test.go
@@ -92,6 +92,7 @@ func TestProvideCleanup_WithMinimalDependencies_NoPanic(t *testing.T) {
 		service.TKAuthServiceColdStartReady{}, // TK: forces SetTrialKeyIssuer wiring
 		service.TKGatewayPricingAvailabilityReady{}, // TK: forces SetPricingAvailabilityService wiring
 		service.TKGatewayAnthropicSigPreemptReady{}, // TK: forces SetAnthropicSigPreemptCache wiring
+		service.TKAnthropicSaturationReady{},        // TK: forces SetAnthropicSaturationCounter wiring
 		handler.TKGatewayHandlerModelListReady{},    // TK: forces SetModelListFilter wiring
 	)
 

--- a/backend/internal/repository/anthropic_saturation_counter_cache.go
+++ b/backend/internal/repository/anthropic_saturation_counter_cache.go
@@ -56,22 +56,6 @@ func (c *anthropicSaturationCounterCache) IncrementSaturation(ctx context.Contex
 	return count, nil
 }
 
-func (c *anthropicSaturationCounterCache) GetSaturation(ctx context.Context, accountID int64) (int64, error) {
-	key := anthropicSaturationKey(accountID)
-	raw, err := c.rdb.Get(ctx, key).Result()
-	if err == redis.Nil {
-		return 0, nil
-	}
-	if err != nil {
-		return 0, fmt.Errorf("get anthropic saturation: %w", err)
-	}
-	n, convErr := strconv.ParseInt(raw, 10, 64)
-	if convErr != nil {
-		return 0, fmt.Errorf("parse anthropic saturation %q: %w", raw, convErr)
-	}
-	return n, nil
-}
-
 func (c *anthropicSaturationCounterCache) GetSaturationBatch(ctx context.Context, accountIDs []int64) (map[int64]int64, error) {
 	out := make(map[int64]int64, len(accountIDs))
 	if len(accountIDs) == 0 {

--- a/backend/internal/repository/anthropic_saturation_counter_cache.go
+++ b/backend/internal/repository/anthropic_saturation_counter_cache.go
@@ -1,0 +1,105 @@
+package repository
+
+import (
+	"context"
+	"fmt"
+	"strconv"
+
+	"github.com/Wei-Shaw/sub2api/internal/service"
+	"github.com/redis/go-redis/v9"
+)
+
+const anthropicSaturationCountPrefix = "anthropic_saturation_count:account:"
+
+// anthropicSaturationIncrScript atomically INCRs the per-account saturation
+// counter; if it just became 1 (the key was absent/expired) it EXPIREs the key
+// to windowSec. A sustained burst therefore keeps the ORIGINAL fixed window
+// instead of sliding it forward on every hit — once the edge recovers and the
+// hits stop, the key expires and the count (and the scheduler's penalty) clears
+// on its own.
+//
+// KEYS[1] = count key, ARGV[1] = windowSec. Returns: count.
+var anthropicSaturationIncrScript = redis.NewScript(`
+	local key = KEYS[1]
+	local window = tonumber(ARGV[1])
+
+	local count = redis.call('INCR', key)
+	if count == 1 then
+		redis.call('EXPIRE', key, window)
+	end
+
+	return count
+`)
+
+type anthropicSaturationCounterCache struct {
+	rdb *redis.Client
+}
+
+// NewAnthropicSaturationCounterCache builds the Redis-backed saturation counter.
+func NewAnthropicSaturationCounterCache(rdb *redis.Client) service.AnthropicSaturationCounterCache {
+	return &anthropicSaturationCounterCache{rdb: rdb}
+}
+
+func anthropicSaturationKey(accountID int64) string {
+	return fmt.Sprintf("%s%d", anthropicSaturationCountPrefix, accountID)
+}
+
+func (c *anthropicSaturationCounterCache) IncrementSaturation(ctx context.Context, accountID int64, windowSeconds int) (int64, error) {
+	if windowSeconds <= 0 {
+		return 0, fmt.Errorf("invalid window: %d", windowSeconds)
+	}
+	key := anthropicSaturationKey(accountID)
+	count, err := anthropicSaturationIncrScript.Run(ctx, c.rdb, []string{key}, windowSeconds).Int64()
+	if err != nil {
+		return 0, fmt.Errorf("increment anthropic saturation: %w", err)
+	}
+	return count, nil
+}
+
+func (c *anthropicSaturationCounterCache) GetSaturation(ctx context.Context, accountID int64) (int64, error) {
+	key := anthropicSaturationKey(accountID)
+	raw, err := c.rdb.Get(ctx, key).Result()
+	if err == redis.Nil {
+		return 0, nil
+	}
+	if err != nil {
+		return 0, fmt.Errorf("get anthropic saturation: %w", err)
+	}
+	n, convErr := strconv.ParseInt(raw, 10, 64)
+	if convErr != nil {
+		return 0, fmt.Errorf("parse anthropic saturation %q: %w", raw, convErr)
+	}
+	return n, nil
+}
+
+func (c *anthropicSaturationCounterCache) GetSaturationBatch(ctx context.Context, accountIDs []int64) (map[int64]int64, error) {
+	out := make(map[int64]int64, len(accountIDs))
+	if len(accountIDs) == 0 {
+		return out, nil
+	}
+	keys := make([]string, len(accountIDs))
+	for i, id := range accountIDs {
+		keys[i] = anthropicSaturationKey(id)
+	}
+	vals, err := c.rdb.MGet(ctx, keys...).Result()
+	if err != nil {
+		return nil, fmt.Errorf("mget anthropic saturation: %w", err)
+	}
+	for i, v := range vals {
+		if v == nil {
+			continue
+		}
+		s, ok := v.(string)
+		if !ok {
+			continue
+		}
+		n, convErr := strconv.ParseInt(s, 10, 64)
+		if convErr != nil {
+			continue
+		}
+		if n != 0 {
+			out[accountIDs[i]] = n
+		}
+	}
+	return out, nil
+}

--- a/backend/internal/repository/anthropic_saturation_counter_cache_test.go
+++ b/backend/internal/repository/anthropic_saturation_counter_cache_test.go
@@ -1,0 +1,102 @@
+//go:build unit
+
+package repository
+
+import (
+	"context"
+	"testing"
+	"time"
+
+	"github.com/alicebob/miniredis/v2"
+	"github.com/redis/go-redis/v9"
+	"github.com/stretchr/testify/require"
+)
+
+func newSaturationTestCache(t *testing.T) (*anthropicSaturationCounterCache, *miniredis.Miniredis) {
+	t.Helper()
+	mr := miniredis.RunT(t)
+	rdb := redis.NewClient(&redis.Options{Addr: mr.Addr()})
+	t.Cleanup(func() { _ = rdb.Close() })
+	return &anthropicSaturationCounterCache{rdb: rdb}, mr
+}
+
+func TestAnthropicSaturationCounter_IncrementAndGet(t *testing.T) {
+	cache, _ := newSaturationTestCache(t)
+	ctx := context.Background()
+
+	// Empty key reads 0.
+	n, err := cache.GetSaturation(ctx, 7)
+	require.NoError(t, err)
+	require.Equal(t, int64(0), n)
+
+	// Three increments => count 3, Get reflects it without mutating.
+	for i := 1; i <= 3; i++ {
+		c, incErr := cache.IncrementSaturation(ctx, 7, 90)
+		require.NoError(t, incErr)
+		require.Equal(t, int64(i), c)
+	}
+	got, err := cache.GetSaturation(ctx, 7)
+	require.NoError(t, err)
+	require.Equal(t, int64(3), got)
+
+	// A different account is independent.
+	other, err := cache.GetSaturation(ctx, 8)
+	require.NoError(t, err)
+	require.Equal(t, int64(0), other)
+}
+
+func TestAnthropicSaturationCounter_FixedWindowTTLSelfClears(t *testing.T) {
+	cache, mr := newSaturationTestCache(t)
+	ctx := context.Background()
+
+	_, err := cache.IncrementSaturation(ctx, 42, 90)
+	require.NoError(t, err)
+	// TTL is set on the first INCR (key was absent).
+	ttl := mr.TTL(anthropicSaturationKey(42))
+	require.InDelta(t, float64(90*time.Second), float64(ttl), float64(2*time.Second))
+
+	// Subsequent increments within the window keep the ORIGINAL window (TTL is
+	// only (re)set when the key was absent), so the window does not slide forever.
+	mr.FastForward(30 * time.Second)
+	_, err = cache.IncrementSaturation(ctx, 42, 90)
+	require.NoError(t, err)
+	ttlAfter := mr.TTL(anthropicSaturationKey(42))
+	require.LessOrEqual(t, ttlAfter, 60*time.Second, "window must not slide forward on later hits")
+
+	// After the window fully elapses, the counter self-clears back to 0.
+	mr.FastForward(90 * time.Second)
+	got, err := cache.GetSaturation(ctx, 42)
+	require.NoError(t, err)
+	require.Equal(t, int64(0), got, "counter must self-clear on TTL expiry")
+}
+
+func TestAnthropicSaturationCounter_GetBatch(t *testing.T) {
+	cache, _ := newSaturationTestCache(t)
+	ctx := context.Background()
+
+	for i := 0; i < 5; i++ {
+		_, err := cache.IncrementSaturation(ctx, 1, 90)
+		require.NoError(t, err)
+	}
+	_, err := cache.IncrementSaturation(ctx, 2, 90)
+	require.NoError(t, err)
+
+	// id 3 never incremented => absent.
+	out, err := cache.GetSaturationBatch(ctx, []int64{1, 2, 3})
+	require.NoError(t, err)
+	require.Equal(t, int64(5), out[1])
+	require.Equal(t, int64(1), out[2])
+	_, present := out[3]
+	require.False(t, present, "absent keys must not appear in the batch result")
+
+	// Empty input => empty map, no error.
+	empty, err := cache.GetSaturationBatch(ctx, nil)
+	require.NoError(t, err)
+	require.Empty(t, empty)
+}
+
+func TestAnthropicSaturationCounter_InvalidWindow(t *testing.T) {
+	cache, _ := newSaturationTestCache(t)
+	_, err := cache.IncrementSaturation(context.Background(), 1, 0)
+	require.Error(t, err)
+}

--- a/backend/internal/repository/anthropic_saturation_counter_cache_test.go
+++ b/backend/internal/repository/anthropic_saturation_counter_cache_test.go
@@ -24,25 +24,22 @@ func TestAnthropicSaturationCounter_IncrementAndGet(t *testing.T) {
 	cache, _ := newSaturationTestCache(t)
 	ctx := context.Background()
 
-	// Empty key reads 0.
-	n, err := cache.GetSaturation(ctx, 7)
+	// Empty key reads 0 via the batch read.
+	zero, err := cache.GetSaturationBatch(ctx, []int64{7})
 	require.NoError(t, err)
-	require.Equal(t, int64(0), n)
+	require.Empty(t, zero, "absent key must not appear")
 
-	// Three increments => count 3, Get reflects it without mutating.
+	// Three increments => count 3, batch read reflects it without mutating.
 	for i := 1; i <= 3; i++ {
 		c, incErr := cache.IncrementSaturation(ctx, 7, 90)
 		require.NoError(t, incErr)
 		require.Equal(t, int64(i), c)
 	}
-	got, err := cache.GetSaturation(ctx, 7)
+	got, err := cache.GetSaturationBatch(ctx, []int64{7, 8})
 	require.NoError(t, err)
-	require.Equal(t, int64(3), got)
-
-	// A different account is independent.
-	other, err := cache.GetSaturation(ctx, 8)
-	require.NoError(t, err)
-	require.Equal(t, int64(0), other)
+	require.Equal(t, int64(3), got[7])
+	_, has8 := got[8] // a different account is independent
+	require.False(t, has8)
 }
 
 func TestAnthropicSaturationCounter_FixedWindowTTLSelfClears(t *testing.T) {
@@ -65,9 +62,9 @@ func TestAnthropicSaturationCounter_FixedWindowTTLSelfClears(t *testing.T) {
 
 	// After the window fully elapses, the counter self-clears back to 0.
 	mr.FastForward(90 * time.Second)
-	got, err := cache.GetSaturation(ctx, 42)
+	got, err := cache.GetSaturationBatch(ctx, []int64{42})
 	require.NoError(t, err)
-	require.Equal(t, int64(0), got, "counter must self-clear on TTL expiry")
+	require.Empty(t, got, "counter must self-clear on TTL expiry")
 }
 
 func TestAnthropicSaturationCounter_GetBatch(t *testing.T) {

--- a/backend/internal/repository/wire.go
+++ b/backend/internal/repository/wire.go
@@ -110,6 +110,7 @@ var ProviderSet = wire.NewSet(
 	NewAnthropicUpstreamErrorCounterCache,
 	NewOAuth401AfterRefreshCounterCache,
 	NewAnthropicSignaturePreemptCache,
+	NewAnthropicSaturationCounterCache,
 	NewInternal500CounterCache,
 	ProvideConcurrencyCache,
 	ProvideSessionLimitCache,

--- a/backend/internal/service/anthropic_saturation_counter.go
+++ b/backend/internal/service/anthropic_saturation_counter.go
@@ -23,11 +23,6 @@ type AnthropicSaturationCounterCache interface {
 	// window rather than sliding it forward indefinitely). Returns the new count.
 	IncrementSaturation(ctx context.Context, accountID int64, windowSeconds int) (count int64, err error)
 
-	// GetSaturation returns the current in-window count for accountID without
-	// mutating it (0 when the key is absent/expired). Used by the scheduler to
-	// compute the de-prioritization penalty per selection.
-	GetSaturation(ctx context.Context, accountID int64) (count int64, err error)
-
 	// GetSaturationBatch returns the current in-window counts for accountIDs in a
 	// single round trip (MGET). Missing/expired keys map to 0. The scheduler
 	// scores a whole candidate set per selection, so a batch read avoids N

--- a/backend/internal/service/anthropic_saturation_counter.go
+++ b/backend/internal/service/anthropic_saturation_counter.go
@@ -1,0 +1,36 @@
+package service
+
+import "context"
+
+// AnthropicSaturationCounterCache tracks, per anthropic mirror-stub account, a
+// short-window count of recent *downstream-capacity* hits — i.e. responses where
+// tkSkipDownstreamNoAvailableAccountsPenalty / tkSkipDownstreamFailoverExhaustedPenalty
+// fired (the forwarded-to edge pool was empty or its failover loop ran dry). The
+// stub itself is healthy; this counter is NOT a cooldown and NEVER advances the
+// 3/3 ladder or SetTempUnschedulable. It is read by the load-aware account
+// scheduler to apply a BOUNDED de-prioritization preference so prod stops
+// selecting a saturated edge stub first and wasting a failover hop on every
+// request for the whole ~47-min upstream-limit window.
+//
+// Self-clearing by construction: the counter is a fixed window with a short TTL,
+// and the scheduler reads it live on every selection. When the edge recovers,
+// the no-available hits stop, the counter expires, and the preference evaporates
+// with no separate clear-on-200 hook, marker, or cooldown state.
+type AnthropicSaturationCounterCache interface {
+	// IncrementSaturation records one downstream-capacity hit for accountID. The
+	// counter is a fixed window with TTL=windowSeconds (the TTL is set only when
+	// an empty key is first INCR'd, so a sustained burst keeps the original
+	// window rather than sliding it forward indefinitely). Returns the new count.
+	IncrementSaturation(ctx context.Context, accountID int64, windowSeconds int) (count int64, err error)
+
+	// GetSaturation returns the current in-window count for accountID without
+	// mutating it (0 when the key is absent/expired). Used by the scheduler to
+	// compute the de-prioritization penalty per selection.
+	GetSaturation(ctx context.Context, accountID int64) (count int64, err error)
+
+	// GetSaturationBatch returns the current in-window counts for accountIDs in a
+	// single round trip (MGET). Missing/expired keys map to 0. The scheduler
+	// scores a whole candidate set per selection, so a batch read avoids N
+	// sequential Redis calls on the hot path.
+	GetSaturationBatch(ctx context.Context, accountIDs []int64) (map[int64]int64, error)
+}

--- a/backend/internal/service/domain_constants.go
+++ b/backend/internal/service/domain_constants.go
@@ -509,6 +509,13 @@ const (
 	// 全池再排队（upstream #2859，默认 true）。为 false 时退回今日行为：槽满即在
 	// 原 sticky 账号上排队。详见 docs/approved/sticky-routing.md §11.5。
 	SettingKeyStickySlotFullEscapeEnabled = "gateway.sticky_routing.slot_full_escape_enabled"
+	// SettingKeyAnthropicSaturatedStubDeprioritizeEnabled (TK) 控制是否对持续返回
+	// 下游容量信号（"No available accounts" / "all available accounts exhausted"）
+	// 的 anthropic 镜像 stub 账号施加 BOUNDED 调度去优先级偏好（默认 true）。这是
+	// 一个调度偏好而非冷却：饱和 stub 仍是候选、仍可作为最后兜底被选中；偏好随
+	// Redis 短窗计数 TTL 自行消散。为 false 时退回纯优先级/负载选择（无 saturation 项）。
+	// 详见 backend/internal/service/gateway_service_tk_saturation_penalty.go。
+	SettingKeyAnthropicSaturatedStubDeprioritizeEnabled = "gateway.anthropic_saturated_stub_deprioritize.enabled"
 	// SettingKeyEnableAnthropicCacheTTL1hInjection 是否对 Anthropic OAuth/SetupToken 请求体注入 1h cache_control ttl（默认 false）
 	SettingKeyEnableAnthropicCacheTTL1hInjection = "enable_anthropic_cache_ttl_1h_injection"
 	// SettingKeyRewriteMessageCacheControl 是否改写 messages[*].content[*].cache_control（默认 false）

--- a/backend/internal/service/gateway_service.go
+++ b/backend/internal/service/gateway_service.go
@@ -94,6 +94,11 @@ type forceCacheBillingKeyType struct{}
 type accountWithLoad struct {
 	account  *Account
 	loadInfo *AccountLoadInfo
+	// saturationPenalty (TK) 是加到 account.Priority 上的 BOUNDED 去优先级偏好，仅
+	// 对持续返回下游容量信号的 anthropic 镜像 stub 非零。filterByMinPriority 按
+	// effectivePriority()（Priority+saturationPenalty）排序。详见
+	// gateway_service_tk_saturation_penalty.go。
+	saturationPenalty int
 }
 
 var ForceCacheBillingContextKey = forceCacheBillingKeyType{}
@@ -646,6 +651,10 @@ type GatewayService struct {
 	// TK: per-account thinking-block signature_error preempt cache. Injected via
 	// SetAnthropicSigPreemptCache (TK companion). nil = feature disabled.
 	tkAnthropicSigPreemptCache AnthropicSignaturePreemptCache
+	// TK: per-stub anthropic downstream-capacity saturation counter. Injected via
+	// SetAnthropicSaturationCounter (TK companion). nil = feature disabled. Read
+	// to apply a bounded de-prioritization preference in load-aware selection.
+	tkAnthropicSaturationCounter AnthropicSaturationCounterCache
 	// TK: pricing-missing → Feishu notifier. Injected via
 	// SetPricingMissingNotifier (TK companion). nil = feature disabled.
 	tkPricingMissingNotifier PricingMissingNotifier
@@ -2183,6 +2192,11 @@ func (s *GatewayService) SelectAccountWithLoadAwareness(ctx context.Context, gro
 			}
 		}
 
+		// TK: 为持续饱和的 anthropic 镜像 stub 计算 bounded 去优先级偏好，折入
+		// effectivePriority()，使其在下面的分层过滤中排到非饱和 stub 之后但不被
+		// 排除。详见 gateway_service_tk_saturation_penalty.go。
+		s.computeAnthropicSaturationPenalties(ctx, available)
+
 		// 分层过滤选择：优先级 → 负载率 → LRU
 		for len(available) > 0 {
 			// 1. 取优先级最小的集合
@@ -2908,20 +2922,23 @@ func (s *GatewayService) newSelectionResult(ctx context.Context, account *Accoun
 	}, nil
 }
 
-// filterByMinPriority 过滤出优先级最小的账号集合
+// filterByMinPriority 过滤出（有效）优先级最小的账号集合。
+// 有效优先级 = account.Priority + saturationPenalty（TK），后者默认 0，仅对持续
+// 饱和的 anthropic 镜像 stub 为正的 BOUNDED 常量，使其排在所有非饱和 stub 之后，
+// 但仍保留在候选集中（不排除）。详见 gateway_service_tk_saturation_penalty.go。
 func filterByMinPriority(accounts []accountWithLoad) []accountWithLoad {
 	if len(accounts) == 0 {
 		return accounts
 	}
-	minPriority := accounts[0].account.Priority
+	minPriority := accounts[0].effectivePriority()
 	for _, acc := range accounts[1:] {
-		if acc.account.Priority < minPriority {
-			minPriority = acc.account.Priority
+		if acc.effectivePriority() < minPriority {
+			minPriority = acc.effectivePriority()
 		}
 	}
 	result := make([]accountWithLoad, 0, len(accounts))
 	for _, acc := range accounts {
-		if acc.account.Priority == minPriority {
+		if acc.effectivePriority() == minPriority {
 			result = append(result, acc)
 		}
 	}

--- a/backend/internal/service/gateway_service_tk_saturation_penalty.go
+++ b/backend/internal/service/gateway_service_tk_saturation_penalty.go
@@ -1,0 +1,124 @@
+package service
+
+import (
+	"context"
+	"log/slog"
+)
+
+// TK — anthropic saturated mirror-stub de-prioritization (score side).
+//
+// See ratelimit_service_tk_saturation.go for the increment side and the prod
+// problem statement. This file is the READ side: a BOUNDED preference term added
+// to the existing load-aware candidate ranking so prod's account selection
+// routes AWAY from an anthropic stub that is emitting SUSTAINED downstream-
+// capacity 429/502 ("No available accounts" / "all available accounts
+// exhausted"). It is a routing PREFERENCE, NOT a cooldown:
+//
+//   - de-prioritize  — a saturated stub's effective priority is bumped into a
+//     worse bucket (filterByMinPriority picks the smallest), so it sorts AFTER
+//     any non-saturated stub.
+//   - last-resort / never-unschedulable — the penalty is a bounded additive
+//     constant; the stub stays in the candidate set (and the Layer-3 fallback
+//     queue), so if it is the only/highest candidate it is still selected. The
+//     feature NEVER calls SetTempUnschedulable / SetRateLimited / advances the
+//     3/3 ladder.
+//   - self-clearing — the penalty is recomputed per selection from the LIVE
+//     Redis count, which has a short TTL; when the edge recovers, the count
+//     expires and the preference evaporates with no clear-on-200 hook.
+//   - all-saturated safety — if every candidate is saturated, all get the SAME
+//     additive penalty, so their RELATIVE order is preserved and selection still
+//     returns a stub. Safe by construction: the penalty is a bounded ADD, never
+//     a sentinel/exclusion value.
+
+// anthropicSaturationPriorityPenalty is the bounded additive delta applied to a
+// saturated stub's effective priority for ranking. Account priorities are small
+// operator-assigned ints (typically 0..~100). A large constant (1000) guarantees
+// any saturated stub sorts strictly after every non-saturated one regardless of
+// their base priorities, while staying a finite, bounded value — it can never
+// push a candidate out of the set (filterByMinPriority compares values, it does
+// not exclude). When ALL candidates are saturated they all gain the same +1000,
+// so the base-priority/load/LRU ordering among them is preserved unchanged.
+const anthropicSaturationPriorityPenalty = 1000
+
+// SetAnthropicSaturationCounter wires the Redis-backed saturation counter into
+// GatewayService post-construction (mirrors SetAnthropicSigPreemptCache). Nil-
+// safe: when unset, computeAnthropicSaturationPenalties is a no-op and selection
+// is identical to pre-feature behaviour.
+func (s *GatewayService) SetAnthropicSaturationCounter(cache AnthropicSaturationCounterCache) {
+	if s != nil {
+		s.tkAnthropicSaturationCounter = cache
+	}
+}
+
+// HasAnthropicSaturationCounter reports whether the saturation counter is wired
+// (used by DI smoke tests to prove the post-construction setter ran).
+func (s *GatewayService) HasAnthropicSaturationCounter() bool {
+	return s != nil && s.tkAnthropicSaturationCounter != nil
+}
+
+// computeAnthropicSaturationPenalties fills accountWithLoad.saturationPenalty for
+// each candidate when the feature is enabled. The penalty is non-zero ONLY for
+// anthropic accounts whose live in-window saturation count is at/above
+// anthropicSaturationThreshold (transient blips below threshold are untouched, so
+// current behaviour is preserved). Best-effort: nil receiver/cache, disabled
+// kill-switch, or any Redis error leaves all penalties at 0 (pre-feature
+// scoring). Logs at most once per selection (the set of newly-penalized IDs).
+func (s *GatewayService) computeAnthropicSaturationPenalties(ctx context.Context, candidates []accountWithLoad) {
+	if s == nil || s.tkAnthropicSaturationCounter == nil || len(candidates) == 0 {
+		return
+	}
+	if s.settingService != nil && !s.settingService.IsAnthropicSaturatedStubDeprioritizeEnabled(ctx) {
+		return
+	}
+
+	ids := make([]int64, 0, len(candidates))
+	for i := range candidates {
+		acc := candidates[i].account
+		if acc != nil && acc.Platform == PlatformAnthropic {
+			ids = append(ids, acc.ID)
+		}
+	}
+	if len(ids) == 0 {
+		return
+	}
+
+	counts, err := s.tkAnthropicSaturationCounter.GetSaturationBatch(ctx, ids)
+	if err != nil {
+		slog.Warn("anthropic_saturation_penalty_read_failed", "error", err)
+		return
+	}
+	if len(counts) == 0 {
+		return
+	}
+
+	var penalized []int64
+	for i := range candidates {
+		acc := candidates[i].account
+		if acc == nil || acc.Platform != PlatformAnthropic {
+			continue
+		}
+		if counts[acc.ID] >= anthropicSaturationThreshold {
+			candidates[i].saturationPenalty = anthropicSaturationPriorityPenalty
+			penalized = append(penalized, acc.ID)
+		}
+	}
+	if len(penalized) > 0 {
+		slog.Debug("anthropic_saturation_penalty_applied",
+			"account_ids", penalized,
+			"penalty", anthropicSaturationPriorityPenalty,
+			"candidate_count", len(candidates))
+	}
+}
+
+// effectivePriority is the ranking key used by filterByMinPriority: the base
+// account priority plus the bounded saturation penalty (0 when the feature is
+// off / the stub is not saturated). Keeping this as a tiny helper means
+// filterByMinPriority reads as "min effective priority" with the TK term folded
+// in, rather than scattering the penalty arithmetic across the comparison.
+func (a accountWithLoad) effectivePriority() int {
+	p := 0
+	if a.account != nil {
+		p = a.account.Priority
+	}
+	return p + a.saturationPenalty
+}

--- a/backend/internal/service/gateway_service_tk_saturation_penalty.go
+++ b/backend/internal/service/gateway_service_tk_saturation_penalty.go
@@ -32,12 +32,17 @@ import (
 
 // anthropicSaturationPriorityPenalty is the bounded additive delta applied to a
 // saturated stub's effective priority for ranking. Account priorities are small
-// operator-assigned ints (typically 0..~100). A large constant (1000) guarantees
-// any saturated stub sorts strictly after every non-saturated one regardless of
-// their base priorities, while staying a finite, bounded value — it can never
-// push a candidate out of the set (filterByMinPriority compares values, it does
-// not exclude). When ALL candidates are saturated they all gain the same +1000,
-// so the base-priority/load/LRU ordering among them is preserved unchanged.
+// operator-assigned ints (the cc-<edge> mirror stubs sit at 0..~100). The
+// constant (1000) is chosen ≫ the realistic priority SPREAD across the anthropic
+// pool, so a saturated stub sorts strictly after every non-saturated one as long
+// as that spread stays < 1000 — the de-prioritization is a best-effort
+// PREFERENCE, not a hard guarantee, and degrades gracefully if an operator ever
+// configures a >1000 priority gap (the saturated stub may then still be picked,
+// which is acceptable: it is only ever a routing hint). It stays a finite,
+// bounded value — it can NEVER push a candidate out of the set (filterByMinPriority
+// compares values, it does not exclude), which is the load-bearing amplifier-safety
+// property. When ALL candidates are saturated they all gain the same +1000, so
+// the base-priority/load/LRU ordering among them is preserved exactly.
 const anthropicSaturationPriorityPenalty = 1000
 
 // SetAnthropicSaturationCounter wires the Redis-backed saturation counter into

--- a/backend/internal/service/gateway_service_tk_saturation_penalty_test.go
+++ b/backend/internal/service/gateway_service_tk_saturation_penalty_test.go
@@ -1,0 +1,225 @@
+//go:build unit
+
+package service
+
+import (
+	"context"
+	"testing"
+	"time"
+
+	"github.com/Wei-Shaw/sub2api/internal/config"
+	"github.com/stretchr/testify/require"
+)
+
+// --- stubs ---
+
+// fakeSaturationCache implements AnthropicSaturationCounterCache from a static
+// per-account count map, so score-side tests run without Redis.
+type fakeSaturationCache struct {
+	counts map[int64]int64
+	getErr error
+}
+
+func (f *fakeSaturationCache) IncrementSaturation(_ context.Context, accountID int64, _ int) (int64, error) {
+	if f.counts == nil {
+		f.counts = map[int64]int64{}
+	}
+	f.counts[accountID]++
+	return f.counts[accountID], nil
+}
+
+func (f *fakeSaturationCache) GetSaturation(_ context.Context, accountID int64) (int64, error) {
+	if f.getErr != nil {
+		return 0, f.getErr
+	}
+	return f.counts[accountID], nil
+}
+
+func (f *fakeSaturationCache) GetSaturationBatch(_ context.Context, ids []int64) (map[int64]int64, error) {
+	if f.getErr != nil {
+		return nil, f.getErr
+	}
+	out := map[int64]int64{}
+	for _, id := range ids {
+		if n := f.counts[id]; n != 0 {
+			out[id] = n
+		}
+	}
+	return out, nil
+}
+
+// satSettingRepoStub feeds SettingService.GetValue for the kill-switch tests.
+type satSettingRepoStub struct{ values map[string]string }
+
+func (r *satSettingRepoStub) Get(_ context.Context, key string) (*Setting, error) {
+	if v, ok := r.values[key]; ok {
+		return &Setting{Key: key, Value: v}, nil
+	}
+	return nil, ErrSettingNotFound
+}
+func (r *satSettingRepoStub) GetValue(_ context.Context, key string) (string, error) {
+	s, err := r.Get(context.Background(), key)
+	if err != nil {
+		return "", err
+	}
+	return s.Value, nil
+}
+func (r *satSettingRepoStub) Set(_ context.Context, _, _ string) error { return nil }
+func (r *satSettingRepoStub) GetMultiple(_ context.Context, _ []string) (map[string]string, error) {
+	return map[string]string{}, nil
+}
+func (r *satSettingRepoStub) SetMultiple(_ context.Context, _ map[string]string) error { return nil }
+func (r *satSettingRepoStub) GetAll(_ context.Context) (map[string]string, error) {
+	return map[string]string{}, nil
+}
+func (r *satSettingRepoStub) Delete(_ context.Context, _ string) error { return nil }
+
+func anthropicAccWithLoad(id int64, priority int, loadRate int, lastUsed *time.Time) accountWithLoad {
+	return accountWithLoad{
+		account: &Account{
+			ID:         id,
+			Priority:   priority,
+			Platform:   PlatformAnthropic,
+			Type:       AccountTypeAPIKey,
+			LastUsedAt: lastUsed,
+		},
+		loadInfo: &AccountLoadInfo{AccountID: id, LoadRate: loadRate},
+	}
+}
+
+// resetSatCache clears the process-level kill-switch cache between subtests so a
+// prior subtest's cached decision does not leak.
+func resetSatCache() { satDeprioritizeCache.Store((*satDeprioritizeCacheEntry)(nil)) }
+
+// --- effectivePriority / filterByMinPriority ---
+
+func TestEffectivePriority_FoldsPenalty(t *testing.T) {
+	a := anthropicAccWithLoad(1, 5, 0, nil)
+	require.Equal(t, 5, a.effectivePriority(), "no penalty => base priority")
+	a.saturationPenalty = anthropicSaturationPriorityPenalty
+	require.Equal(t, 5+anthropicSaturationPriorityPenalty, a.effectivePriority())
+}
+
+func TestFilterByMinPriority_SaturatedSortsAfterFresh(t *testing.T) {
+	// Two equal-base-priority stubs; one carries the saturation penalty.
+	fresh := anthropicAccWithLoad(1, 0, 50, nil)
+	saturated := anthropicAccWithLoad(2, 0, 0, nil) // lower load, but saturated
+	saturated.saturationPenalty = anthropicSaturationPriorityPenalty
+
+	result := filterByMinPriority([]accountWithLoad{saturated, fresh})
+	require.Len(t, result, 1, "penalty must break the priority tie")
+	require.Equal(t, int64(1), result[0].account.ID, "fresh stub wins despite higher load")
+}
+
+func TestFilterByMinPriority_AllSaturatedPreservesOrder(t *testing.T) {
+	// Every candidate saturated => same additive penalty => base ordering intact,
+	// and the set is NON-EMPTY (bounded penalty never excludes — amplifier-safe).
+	a := anthropicAccWithLoad(1, 1, 0, nil)
+	b := anthropicAccWithLoad(2, 2, 0, nil)
+	c := anthropicAccWithLoad(3, 1, 0, nil)
+	for _, p := range []*accountWithLoad{&a, &b, &c} {
+		p.saturationPenalty = anthropicSaturationPriorityPenalty
+	}
+	result := filterByMinPriority([]accountWithLoad{a, b, c})
+	// Base min priority is 1 (ids 1,3); id 2 (priority 2) sorts after. Both
+	// priority-1 entries survive because relative order is preserved.
+	require.Len(t, result, 2)
+	ids := map[int64]bool{result[0].account.ID: true, result[1].account.ID: true}
+	require.True(t, ids[1] && ids[3], "all-saturated still returns the min-base-priority bucket")
+}
+
+// --- computeAnthropicSaturationPenalties ---
+
+func TestComputePenalties_BelowThresholdNoPenalty(t *testing.T) {
+	resetSatCache()
+	gw := &GatewayService{}
+	gw.SetAnthropicSaturationCounter(&fakeSaturationCache{counts: map[int64]int64{
+		1: anthropicSaturationThreshold - 1, // just below
+	}})
+	cands := []accountWithLoad{anthropicAccWithLoad(1, 0, 0, nil)}
+	gw.computeAnthropicSaturationPenalties(context.Background(), cands)
+	require.Equal(t, 0, cands[0].saturationPenalty, "below threshold => no penalty (current behaviour preserved)")
+}
+
+func TestComputePenalties_AtThresholdPenalized(t *testing.T) {
+	resetSatCache()
+	gw := &GatewayService{}
+	gw.SetAnthropicSaturationCounter(&fakeSaturationCache{counts: map[int64]int64{
+		1: anthropicSaturationThreshold,     // at threshold => penalized
+		2: anthropicSaturationThreshold + 5, // above => penalized
+		3: 0,                                // fresh => untouched
+	}})
+	cands := []accountWithLoad{
+		anthropicAccWithLoad(1, 0, 0, nil),
+		anthropicAccWithLoad(2, 0, 0, nil),
+		anthropicAccWithLoad(3, 0, 0, nil),
+	}
+	gw.computeAnthropicSaturationPenalties(context.Background(), cands)
+	require.Equal(t, anthropicSaturationPriorityPenalty, cands[0].saturationPenalty)
+	require.Equal(t, anthropicSaturationPriorityPenalty, cands[1].saturationPenalty)
+	require.Equal(t, 0, cands[2].saturationPenalty)
+}
+
+func TestComputePenalties_NonAnthropicIgnored(t *testing.T) {
+	resetSatCache()
+	gw := &GatewayService{}
+	gw.SetAnthropicSaturationCounter(&fakeSaturationCache{counts: map[int64]int64{9: 100}})
+	cands := []accountWithLoad{{
+		account:  &Account{ID: 9, Platform: PlatformOpenAI, Priority: 0},
+		loadInfo: &AccountLoadInfo{AccountID: 9},
+	}}
+	gw.computeAnthropicSaturationPenalties(context.Background(), cands)
+	require.Equal(t, 0, cands[0].saturationPenalty, "non-anthropic platform must never be penalized by this feature")
+}
+
+func TestComputePenalties_ReadErrorIsBestEffort(t *testing.T) {
+	resetSatCache()
+	gw := &GatewayService{}
+	gw.SetAnthropicSaturationCounter(&fakeSaturationCache{getErr: context.DeadlineExceeded})
+	cands := []accountWithLoad{anthropicAccWithLoad(1, 0, 0, nil)}
+	gw.computeAnthropicSaturationPenalties(context.Background(), cands)
+	require.Equal(t, 0, cands[0].saturationPenalty, "redis error => no penalty (selection must not fail)")
+}
+
+func TestComputePenalties_NilCacheIsNoop(t *testing.T) {
+	resetSatCache()
+	gw := &GatewayService{} // no cache wired => feature disabled
+	cands := []accountWithLoad{anthropicAccWithLoad(1, 0, 0, nil)}
+	gw.computeAnthropicSaturationPenalties(context.Background(), cands)
+	require.Equal(t, 0, cands[0].saturationPenalty)
+}
+
+func TestComputePenalties_KillSwitchOff(t *testing.T) {
+	resetSatCache()
+	gw := &GatewayService{}
+	gw.SetAnthropicSaturationCounter(&fakeSaturationCache{counts: map[int64]int64{1: 100}})
+	gw.settingService = NewSettingService(
+		&satSettingRepoStub{values: map[string]string{
+			SettingKeyAnthropicSaturatedStubDeprioritizeEnabled: "false",
+		}},
+		&config.Config{},
+	)
+	cands := []accountWithLoad{anthropicAccWithLoad(1, 0, 0, nil)}
+	gw.computeAnthropicSaturationPenalties(context.Background(), cands)
+	require.Equal(t, 0, cands[0].saturationPenalty, "kill-switch off => exact pre-feature scoring (no penalty)")
+	resetSatCache()
+}
+
+func TestComputePenalties_KillSwitchDefaultOn(t *testing.T) {
+	resetSatCache()
+	gw := &GatewayService{}
+	gw.SetAnthropicSaturationCounter(&fakeSaturationCache{counts: map[int64]int64{1: 100}})
+	// Empty setting => default ON.
+	gw.settingService = NewSettingService(&satSettingRepoStub{values: map[string]string{}}, &config.Config{})
+	cands := []accountWithLoad{anthropicAccWithLoad(1, 0, 0, nil)}
+	gw.computeAnthropicSaturationPenalties(context.Background(), cands)
+	require.Equal(t, anthropicSaturationPriorityPenalty, cands[0].saturationPenalty, "default ON => penalty applied")
+	resetSatCache()
+}
+
+func TestHasAnthropicSaturationCounter(t *testing.T) {
+	gw := &GatewayService{}
+	require.False(t, gw.HasAnthropicSaturationCounter())
+	gw.SetAnthropicSaturationCounter(&fakeSaturationCache{})
+	require.True(t, gw.HasAnthropicSaturationCounter())
+}

--- a/backend/internal/service/gateway_service_tk_saturation_penalty_test.go
+++ b/backend/internal/service/gateway_service_tk_saturation_penalty_test.go
@@ -28,13 +28,6 @@ func (f *fakeSaturationCache) IncrementSaturation(_ context.Context, accountID i
 	return f.counts[accountID], nil
 }
 
-func (f *fakeSaturationCache) GetSaturation(_ context.Context, accountID int64) (int64, error) {
-	if f.getErr != nil {
-		return 0, f.getErr
-	}
-	return f.counts[accountID], nil
-}
-
 func (f *fakeSaturationCache) GetSaturationBatch(_ context.Context, ids []int64) (map[int64]int64, error) {
 	if f.getErr != nil {
 		return nil, f.getErr

--- a/backend/internal/service/ratelimit_service.go
+++ b/backend/internal/service/ratelimit_service.go
@@ -37,8 +37,12 @@ type RateLimitService struct {
 	// TK: 账号失效事件 → 飞书即时告警。挂钩在 notifyAccountSchedulingBlocked,
 	// 实现在 account_incident_notifier_tk.go / ratelimit_service_tk_incident.go。
 	incidentNotifier AccountIncidentNotifier
-	usageCacheMu     sync.RWMutex
-	usageCache       map[int64]*geminiUsageCacheEntry
+	// TK: anthropic 镜像 stub 「下游容量饱和」短窗计数器（可选依赖）。在 skip-penalty
+	// 路径上递增；由调度器读取施加 bounded 去优先级偏好。逻辑在
+	// ratelimit_service_tk_saturation.go。
+	anthropicSaturationCounter AnthropicSaturationCounterCache
+	usageCacheMu               sync.RWMutex
+	usageCache                 map[int64]*geminiUsageCacheEntry
 }
 
 type AccountRuntimeBlocker interface {
@@ -520,6 +524,10 @@ func (s *RateLimitService) HandleUpstreamError(ctx context.Context, account *Acc
 			slog.Info("anthropic_downstream_no_available_accounts_skip_penalty",
 				"account_id", account.ID,
 				"status_code", statusCode)
+			// TK: feed the bounded saturation de-prioritization preference (not a
+			// cooldown; ladder/cooldown stay untouched). See
+			// ratelimit_service_tk_saturation.go.
+			s.recordAnthropicStubSaturation(ctx, account.ID, statusCode, "no_available_accounts")
 			return true
 		}
 		// TK (G2, narrow): the sibling downstream capacity signal — a forwarded
@@ -530,6 +538,8 @@ func (s *RateLimitService) HandleUpstreamError(ctx context.Context, account *Acc
 			slog.Info("anthropic_downstream_failover_exhausted_skip_penalty",
 				"account_id", account.ID,
 				"status_code", statusCode)
+			// TK: feed the bounded saturation de-prioritization preference.
+			s.recordAnthropicStubSaturation(ctx, account.ID, statusCode, "all_available_accounts_exhausted")
 			return true
 		}
 		// handle429 returns true when SetRateLimited landed on an upstream-
@@ -1104,6 +1114,9 @@ func (s *RateLimitService) handleAnthropicUpstreamError(ctx context.Context, acc
 		slog.Info("anthropic_downstream_no_available_accounts_skip_penalty",
 			"account_id", account.ID,
 			"status_code", statusCode)
+		// TK: feed the bounded saturation de-prioritization preference (legacy 503
+		// path). Not a cooldown — ladder/SetTempUnschedulable stay untouched.
+		s.recordAnthropicStubSaturation(ctx, account.ID, statusCode, "no_available_accounts")
 		return true
 	}
 
@@ -1118,6 +1131,8 @@ func (s *RateLimitService) handleAnthropicUpstreamError(ctx context.Context, acc
 		slog.Info("anthropic_downstream_failover_exhausted_skip_penalty",
 			"account_id", account.ID,
 			"status_code", statusCode)
+		// TK: feed the bounded saturation de-prioritization preference.
+		s.recordAnthropicStubSaturation(ctx, account.ID, statusCode, "all_available_accounts_exhausted")
 		return true
 	}
 

--- a/backend/internal/service/ratelimit_service_tk_downstream_no_available_test.go
+++ b/backend/internal/service/ratelimit_service_tk_downstream_no_available_test.go
@@ -77,6 +77,63 @@ func TestRateLimitService_HandleUpstreamError_DownstreamNoAvailable429_DoesNotPe
 	require.Empty(t, counter.incrementIDs, "downstream no-available 429 must NOT advance the cooldown counter")
 }
 
+// fakeSaturationCounterRL records IncrementSaturation calls for the increment-
+// side test (read methods are unused on the rate-limit side).
+type fakeSaturationCounterRL struct{ incrementIDs []int64 }
+
+func (f *fakeSaturationCounterRL) IncrementSaturation(_ context.Context, accountID int64, _ int) (int64, error) {
+	f.incrementIDs = append(f.incrementIDs, accountID)
+	return int64(len(f.incrementIDs)), nil
+}
+func (f *fakeSaturationCounterRL) GetSaturation(_ context.Context, _ int64) (int64, error) {
+	return 0, nil
+}
+func (f *fakeSaturationCounterRL) GetSaturationBatch(_ context.Context, _ []int64) (map[int64]int64, error) {
+	return map[int64]int64{}, nil
+}
+
+// The saturation feature MUST feed the de-prioritization counter on the skip
+// path while NEVER advancing the 3/3 ladder or writing temp_unschedulable /
+// SetRateLimited. This is the load-bearing invariant: penalty, not cooldown.
+func TestRateLimitService_DownstreamNoAvailable_FeedsSaturationButNotLadder(t *testing.T) {
+	repo := &rateLimitAccountRepoStub{}
+	ladder := &anthropicUpstreamErrorCounterCacheStub{counts: []int64{1, 2, 3, 4, 5, 6}}
+	sat := &fakeSaturationCounterRL{}
+	service := NewRateLimitService(repo, nil, &config.Config{}, nil, nil)
+	service.SetAnthropicUpstreamErrorCounterCache(ladder)
+	service.SetAnthropicSaturationCounter(sat)
+	account := &Account{ID: 4044, Platform: PlatformAnthropic, Type: AccountTypeAPIKey}
+
+	// 429 empty-pool fast-fail.
+	noAvail := []byte(`{"type":"error","error":{"type":"api_error","message":"No available accounts: no available accounts"}}`)
+	for i := 0; i < 3; i++ {
+		require.True(t, service.HandleUpstreamError(context.Background(), account, http.StatusTooManyRequests, http.Header{}, noAvail))
+	}
+	// 502 failover-exhausted (sibling capacity signal).
+	exhausted := []byte(`{"type":"error","error":{"type":"server_error","message":"all available accounts exhausted"}}`)
+	for i := 0; i < 2; i++ {
+		require.True(t, service.HandleUpstreamError(context.Background(), account, http.StatusBadGateway, http.Header{}, exhausted))
+	}
+
+	require.Equal(t, []int64{4044, 4044, 4044, 4044, 4044}, sat.incrementIDs,
+		"every downstream-capacity hit must feed the saturation preference counter")
+	require.Empty(t, ladder.incrementIDs, "saturation feature must NOT advance the 3/3 ladder")
+	require.Equal(t, 0, repo.tempCalls, "saturation feature must NOT write temp_unschedulable")
+	require.Equal(t, 0, repo.setRateLimitedCalls, "saturation feature must NOT write SetRateLimited")
+	require.Equal(t, 0, repo.setErrorCalls)
+}
+
+// When the saturation counter is unwired (nil), the skip path behaves exactly as
+// before — proving the increment is an optional, inert-by-default dependency.
+func TestRateLimitService_DownstreamNoAvailable_NilSaturationCounterIsInert(t *testing.T) {
+	repo := &rateLimitAccountRepoStub{}
+	service := NewRateLimitService(repo, nil, &config.Config{}, nil, nil)
+	account := &Account{ID: 4045, Platform: PlatformAnthropic, Type: AccountTypeAPIKey}
+	noAvail := []byte(`{"type":"error","error":{"type":"api_error","message":"No available accounts: no available accounts"}}`)
+	require.True(t, service.HandleUpstreamError(context.Background(), account, http.StatusTooManyRequests, http.Header{}, noAvail))
+	require.Equal(t, 0, repo.tempCalls)
+}
+
 // Regression: a genuine Anthropic upstream 503 (no "no available accounts" body)
 // still flows through the threshold path so persistent real upstream failure
 // continues to escalate and eventually cools the account.

--- a/backend/internal/service/ratelimit_service_tk_downstream_no_available_test.go
+++ b/backend/internal/service/ratelimit_service_tk_downstream_no_available_test.go
@@ -85,9 +85,6 @@ func (f *fakeSaturationCounterRL) IncrementSaturation(_ context.Context, account
 	f.incrementIDs = append(f.incrementIDs, accountID)
 	return int64(len(f.incrementIDs)), nil
 }
-func (f *fakeSaturationCounterRL) GetSaturation(_ context.Context, _ int64) (int64, error) {
-	return 0, nil
-}
 func (f *fakeSaturationCounterRL) GetSaturationBatch(_ context.Context, _ []int64) (map[int64]int64, error) {
 	return map[int64]int64{}, nil
 }

--- a/backend/internal/service/ratelimit_service_tk_saturation.go
+++ b/backend/internal/service/ratelimit_service_tk_saturation.go
@@ -1,0 +1,79 @@
+package service
+
+import (
+	"context"
+	"log/slog"
+)
+
+// TK — anthropic saturated mirror-stub de-prioritization (increment side).
+//
+// Problem (prod): prod reaches Anthropic ONLY through per-edge api-key mirror
+// "stub" accounts (cc-us2 / cc-uk1 / …) that forward to the matching Edge
+// gateway, where a SINGLE OAuth account is common (SPOF). When that edge's one
+// account is upstream-rate-limited (~47-min window), the edge returns TokenKey's
+// own "No available accounts" 429 (or "all available accounts exhausted" 502).
+// tkSkipDownstreamNoAvailableAccountsPenalty / ...FailoverExhaustedPenalty
+// correctly SKIP penalty + fail over (so users see no failures) but DELIBERATELY
+// keep the stub fully schedulable — counting these toward the 3/3 ladder once
+// caused the 2026-05-31 "503 amplifier" that collapsed the whole prod pool.
+//
+// Consequence: prod keeps selecting the dead stub FIRST and paying a wasted
+// failover hop on EVERY request for the whole window. This counter feeds a
+// BOUNDED scheduler preference (gateway_service_tk_saturation_penalty.go) that
+// routes AWAY from a SUSTAINEDLY saturated stub — a preference, NOT a cooldown:
+// it never SetTempUnschedulable / advances the ladder / SetRateLimited.
+
+const (
+	// anthropicSaturationWindowSeconds is the fixed-window TTL of the per-stub
+	// saturation counter. ~90s: long enough that a real ~47-min upstream-limit
+	// window keeps the count continuously above threshold (each forwarded request
+	// re-increments), short enough that a recovered edge clears the preference
+	// within ~1.5 min of its last no-available hit (self-clearing, no 200-hook).
+	anthropicSaturationWindowSeconds = 90
+
+	// anthropicSaturationThreshold is the in-window hit count at/above which a
+	// stub is treated as "saturated" and de-prioritized. A small threshold (not
+	// 1) preserves current behaviour for transient blips — a couple of stray
+	// no-available hits (e.g. one momentary edge burst) never trip it; only a
+	// SUSTAINED pattern does.
+	anthropicSaturationThreshold int64 = 4
+)
+
+// SetAnthropicSaturationCounter wires the Redis-backed saturation counter into
+// RateLimitService (optional dependency). Nil-safe: when unset, the increment
+// helper is a no-op and the feature is inert.
+func (s *RateLimitService) SetAnthropicSaturationCounter(cache AnthropicSaturationCounterCache) {
+	s.anthropicSaturationCounter = cache
+}
+
+// recordAnthropicStubSaturation increments the per-stub saturation counter for a
+// downstream-capacity hit. Called only from the two skip-penalty branches in
+// HandleUpstreamError (anthropic stub received our own "no available accounts" /
+// "all available accounts exhausted" envelope). Best-effort: Redis errors are
+// logged and swallowed — selection must never fail because the preference
+// counter is unavailable. Logs at threshold crossing only (low-volume), so ops
+// can see a stub entering the de-prioritized state.
+func (s *RateLimitService) recordAnthropicStubSaturation(ctx context.Context, accountID int64, statusCode int, reason string) {
+	if s == nil || s.anthropicSaturationCounter == nil {
+		return
+	}
+	count, err := s.anthropicSaturationCounter.IncrementSaturation(ctx, accountID, anthropicSaturationWindowSeconds)
+	if err != nil {
+		slog.Warn("anthropic_stub_saturation_increment_failed",
+			"account_id", accountID,
+			"reason", reason,
+			"error", err)
+		return
+	}
+	// Log exactly on the threshold-crossing increment (count == threshold), not
+	// per hit — one line marks the transition into the de-prioritized state.
+	if count == anthropicSaturationThreshold {
+		slog.Info("anthropic_stub_saturated_deprioritized",
+			"account_id", accountID,
+			"recent_count", count,
+			"threshold", anthropicSaturationThreshold,
+			"window_seconds", anthropicSaturationWindowSeconds,
+			"status_code", statusCode,
+			"reason", reason)
+	}
+}

--- a/backend/internal/service/setting_service_tk_saturation.go
+++ b/backend/internal/service/setting_service_tk_saturation.go
@@ -1,0 +1,72 @@
+package service
+
+import (
+	"context"
+	"log/slog"
+	"strings"
+	"sync/atomic"
+	"time"
+
+	"golang.org/x/sync/singleflight"
+)
+
+// TK: kill-switch accessor for the anthropic saturated-stub de-prioritization
+// preference (SettingKeyAnthropicSaturatedStubDeprioritizeEnabled). Mirrors
+// IsStickyRoutingEnabled exactly in shape: process-level atomic cache (60s TTL),
+// singleflight to collapse concurrent DB reads, fail-OPEN to true on missing
+// key / DB error / unwired service. Default ON — an operator can disable the
+// feature (settings → false) to fall back to pure priority/load selection.
+
+type satDeprioritizeCacheEntry struct {
+	enabled   bool
+	expiresAt int64 // UnixNano
+}
+
+var satDeprioritizeCache atomic.Value // *satDeprioritizeCacheEntry
+var satDeprioritizeSF singleflight.Group
+
+const satDeprioritizeCacheTTL = 60 * time.Second
+const satDeprioritizeErrorTTL = 5 * time.Second
+const satDeprioritizeDBTimeout = 5 * time.Second
+
+// IsAnthropicSaturatedStubDeprioritizeEnabled reports whether the bounded
+// saturation de-prioritization preference is active. Defaults to true.
+func (s *SettingService) IsAnthropicSaturatedStubDeprioritizeEnabled(ctx context.Context) bool {
+	if s == nil || s.settingRepo == nil {
+		return true
+	}
+	if cached, ok := satDeprioritizeCache.Load().(*satDeprioritizeCacheEntry); ok && cached != nil {
+		if time.Now().UnixNano() < cached.expiresAt {
+			return cached.enabled
+		}
+	}
+	val, _, _ := satDeprioritizeSF.Do(SettingKeyAnthropicSaturatedStubDeprioritizeEnabled, func() (any, error) {
+		if cached, ok := satDeprioritizeCache.Load().(*satDeprioritizeCacheEntry); ok && cached != nil {
+			if time.Now().UnixNano() < cached.expiresAt {
+				return cached.enabled, nil
+			}
+		}
+		dbCtx, cancel := context.WithTimeout(context.WithoutCancel(ctx), satDeprioritizeDBTimeout)
+		defer cancel()
+		raw, err := s.settingRepo.GetValue(dbCtx, SettingKeyAnthropicSaturatedStubDeprioritizeEnabled)
+		if err != nil {
+			slog.Warn("failed to get anthropic saturated-stub deprioritize setting", "error", err)
+			satDeprioritizeCache.Store(&satDeprioritizeCacheEntry{
+				enabled:   true,
+				expiresAt: time.Now().Add(satDeprioritizeErrorTTL).UnixNano(),
+			})
+			return true, nil
+		}
+		// Empty string => never set => default true (opt-out, not opt-in).
+		enabled := strings.TrimSpace(raw) != "false"
+		satDeprioritizeCache.Store(&satDeprioritizeCacheEntry{
+			enabled:   enabled,
+			expiresAt: time.Now().Add(satDeprioritizeCacheTTL).UnixNano(),
+		})
+		return enabled, nil
+	})
+	if b, ok := val.(bool); ok {
+		return b
+	}
+	return true
+}

--- a/backend/internal/service/wire.go
+++ b/backend/internal/service/wire.go
@@ -676,6 +676,11 @@ var ProviderSet = wire.NewSet(
 	// Same shape as ProvideTKGatewayPricingAvailability; consumed by
 	// provideCleanup in cmd/server/wire.go so wire forces evaluation.
 	ProvideTKGatewayAnthropicSigPreempt,
+	// TokenKey: anthropic saturated mirror-stub de-prioritization — wires the
+	// Redis saturation counter onto GatewayService (scheduler read) and
+	// RateLimitService (skip-penalty write). Consumed by provideCleanup so wire
+	// forces evaluation.
+	ProvideTKAnthropicSaturation,
 	// TokenKey: account-incident → Feishu notifier. Builds the notifier, starts
 	// its digest ticker, and wires it onto RateLimitService post-construction.
 	// Returns the instance so provideCleanup (cmd/server/wire.go) can Stop() the
@@ -813,6 +818,32 @@ func ProvideTKGatewayAnthropicSigPreempt(
 		gw.SetAnthropicSigPreemptCache(cache)
 	}
 	return TKGatewayAnthropicSigPreemptReady{}
+}
+
+// TKAnthropicSaturationReady is a wire sentinel proving that the anthropic
+// saturation counter has been wired onto BOTH GatewayService (read side, the
+// scheduler penalty) and RateLimitService (write side, the skip-penalty
+// increments). provideCleanup (cmd/server/wire.go) consumes it as an unused
+// parameter so wire forces evaluation of the side-effect.
+type TKAnthropicSaturationReady struct{}
+
+// ProvideTKAnthropicSaturation wires the Redis-backed anthropic saturation
+// counter into the gateway scheduler (read) and the rate-limit skip-penalty
+// path (write). One provider, two setters — both nil-safe; if cache is nil the
+// feature is inert (no penalty, no increments). See
+// gateway_service_tk_saturation_penalty.go / ratelimit_service_tk_saturation.go.
+func ProvideTKAnthropicSaturation(
+	gw *GatewayService,
+	rl *RateLimitService,
+	cache AnthropicSaturationCounterCache,
+) TKAnthropicSaturationReady {
+	if gw != nil {
+		gw.SetAnthropicSaturationCounter(cache)
+	}
+	if rl != nil {
+		rl.SetAnthropicSaturationCounter(cache)
+	}
+	return TKAnthropicSaturationReady{}
 }
 
 // ProvideTKAccountIncidentNotifier builds the account-incident Feishu notifier,

--- a/scripts/sentinels/gateway-tk.json
+++ b/scripts/sentinels/gateway-tk.json
@@ -2296,6 +2296,69 @@
         "TkImageModelUnpriced"
       ],
       "rationale": "Second TK hook for the media unpriced-reject policy: ImageGenerations() is the OpenAI-compat pool entry for POST /images/generations (newapi groups route here, NOT through openai_images.go Images()). The first guard rollout missed this entry and unpriced image requests sailed to the upstream — caught by local e2e. Dropping this call silently re-opens that exact hole."
+    },
+    {
+      "path": "backend/internal/service/gateway_service_tk_saturation_penalty.go",
+      "must_contain": [
+        "func (s *GatewayService) computeAnthropicSaturationPenalties(",
+        "func (a accountWithLoad) effectivePriority() int",
+        "anthropicSaturationPriorityPenalty = 1000",
+        "IsAnthropicSaturatedStubDeprioritizeEnabled"
+      ],
+      "rationale": "Read side of the anthropic saturated mirror-stub de-prioritization (prod 2026-06-12): a BOUNDED additive priority penalty folded into the load-aware candidate ranking so prod routes AWAY from an edge stub emitting SUSTAINED downstream-capacity 429/502 instead of selecting it first and wasting a failover hop every request for the whole ~47-min upstream-limit window. It is a PREFERENCE not a cooldown — the penalty is a finite ADD (1000) that can never exclude a stub from the candidate set (filterByMinPriority compares values, all-saturated keeps relative order), so amplifier-safety (2026-05-31 503 amplifier) is preserved by construction. Dropping this file silently reverts prod to selecting the dead stub first. The kill-switch read (IsAnthropicSaturatedStubDeprioritizeEnabled) keeps it operator-disableable."
+    },
+    {
+      "path": "backend/internal/service/gateway_service.go",
+      "must_contain": [
+        "s.computeAnthropicSaturationPenalties(ctx, available)",
+        "minPriority := accounts[0].effectivePriority()"
+      ],
+      "rationale": "Thin injection of the saturation de-prioritization into the upstream-shaped load-aware scheduler: the penalty is computed once on the Layer-2 'available' set, and filterByMinPriority ranks on effectivePriority() (Priority+saturationPenalty) instead of bare Priority. Removing the compute call leaves penalties at 0 (feature inert); reverting filterByMinPriority to bare account.Priority drops the fold-in even if penalties are set. Either silently disables the preference, so both anchors are pinned."
+    },
+    {
+      "path": "backend/internal/service/ratelimit_service_tk_saturation.go",
+      "must_contain": [
+        "func (s *RateLimitService) recordAnthropicStubSaturation(",
+        "anthropicSaturationThreshold int64 = 4",
+        "anthropicSaturationWindowSeconds = 90",
+        "anthropic_stub_saturated_deprioritized"
+      ],
+      "rationale": "Write side of the saturation de-prioritization: increments the per-stub short-window counter ONLY on the downstream-capacity skip-penalty path (no-available / failover-exhausted). The fixed window (90s) self-clears so the preference evaporates ~1.5min after an edge recovers; the small threshold (4) preserves current behaviour for transient blips. Crucially this NEVER advances the 3/3 ladder / SetTempUnschedulable — it is a preference feed, not a cooldown. The threshold-crossing slog line (anthropic_stub_saturated_deprioritized) is the ops visibility for a stub entering the de-prioritized state. Dropping this file stops feeding the counter and the scheduler preference becomes inert."
+    },
+    {
+      "path": "backend/internal/service/ratelimit_service.go",
+      "must_contain": [
+        "s.recordAnthropicStubSaturation(ctx, account.ID, statusCode, \"no_available_accounts\")",
+        "s.recordAnthropicStubSaturation(ctx, account.ID, statusCode, \"all_available_accounts_exhausted\")"
+      ],
+      "rationale": "Thin injection of the saturation counter increments at the two HandleUpstreamError skip-penalty branches (429 empty-pool + legacy 503 no-available, and the failover-exhausted 502 sibling). These sit AFTER the skip decision (the function still returns true to fail over) so they never change the cooldown/ladder behaviour — they only feed the de-prioritization preference. An upstream merge that rewrites the skip branches would silently drop the feed; these literal call anchors catch it."
+    },
+    {
+      "path": "backend/internal/repository/anthropic_saturation_counter_cache.go",
+      "must_contain": [
+        "func NewAnthropicSaturationCounterCache(",
+        "anthropic_saturation_count:account:",
+        "anthropicSaturationIncrScript",
+        "func (c *anthropicSaturationCounterCache) GetSaturationBatch("
+      ],
+      "rationale": "Redis-backed fixed-window counter for the saturation de-prioritization. The INCR+EXPIRE-on-first-hit Lua keeps the ORIGINAL window (no sliding) so the count tracks a sustained burst and self-clears on TTL; GetSaturationBatch (MGET) is the scheduler's per-selection hot-path read. Deleting this repo file breaks the wire provider and disables the feature."
+    },
+    {
+      "path": "backend/internal/service/setting_service_tk_saturation.go",
+      "must_contain": [
+        "func (s *SettingService) IsAnthropicSaturatedStubDeprioritizeEnabled(",
+        "SettingKeyAnthropicSaturatedStubDeprioritizeEnabled"
+      ],
+      "rationale": "Kill-switch accessor (default ON, fail-open) for the saturation de-prioritization. Mirrors IsStickyRoutingEnabled: process-level cache + singleflight + default-true on missing/error. Removing it forces the read site to a compile error (or, if also reverted, removes the operator's ability to disable the preference) — pinned so the kill-switch survives merges."
+    },
+    {
+      "path": "backend/internal/service/wire.go",
+      "must_contain": [
+        "func ProvideTKAnthropicSaturation(",
+        "gw.SetAnthropicSaturationCounter(cache)",
+        "rl.SetAnthropicSaturationCounter(cache)"
+      ],
+      "rationale": "Wire glue that attaches the saturation counter onto BOTH GatewayService (read) and RateLimitService (write) post-construction, keeping the upstream NewGatewayService/NewRateLimitService signatures stable. One provider, two setters — if either setter call is dropped, one half of the feature goes inert (scheduler can't read, or skip path can't write). The TKAnthropicSaturationReady sentinel forces wire to evaluate it; these anchors pin the dual-setter wiring."
     }
   ]
 }


### PR DESCRIPTION
## 问题

prod 经 per-edge api-key 镜像 stub（cc-us2 / cc-uk1 / …，`platform=anthropic, type=apikey`）转发到对应 Edge 网关，edge 常运行单 OAuth 账号（SPOF）。当该 edge 的唯一账号被上游限流（~47min 窗口）时，edge 返回 TokenKey 自己的「No available accounts」429（或「all available accounts exhausted」502）envelope。

prod 的 `tkSkipDownstreamNoAvailableAccountsPenalty` / `tkSkipDownstreamFailoverExhaustedPenalty` 正确地 **skip penalty + failover**（用户无感），但为避免 2026-05-31 的「503 amplifier」（把 no-available 计入 3/3 ladder 曾冷却 prod stub 导致全池崩塌），**刻意保持这个 cc-stub 完全可调度**。后果：prod 整窗口里每个请求都**先选中这个已死 stub 再 failover**——浪费一跳，并把负载砸向健康 edge。

## 方案（已 Jobs review，最小形）

account 调度本就是排序式的。本 PR 在**既有 load-aware 候选排序**里加**一个 bounded saturation 偏好项**，由**一个 per-stub 短窗 Redis 计数**喂入。这是一个**路由偏好，不是冷却**，也**不是平行的 marker/deprioritize 子系统**——score 引擎免费给到 deprioritize / last-resort / self-clear / all-saturated 安全：

- **deprioritize** = 饱和 stub 的 `effectivePriority` = `Priority + bounded 惩罚(1000)`，`filterByMinPriority` 据此排序，排到所有非饱和 stub 之后；
- **last-resort / never-unschedulable** = 惩罚是有界的**加法常量**，stub 仍留在候选集（及 Layer-3 兜底队列）。本特性**绝不** `SetTempUnschedulable` / 推进 3/3 ladder / `SetRateLimited`；
- **self-clear** = 计数短 TTL（90s 固定窗，不滑动）+ 每次选择实时读 → edge 恢复后 ~1.5min 偏好自动消散，**无** clear-on-200 hook / 单独 marker / 冷却状态；
- **all-saturated amplifier-safety** = 若全部候选饱和，所有候选同加 1000，**相对序不变** → 仍能选出 stub。**by construction** 安全（惩罚是有界 ADD，永不推到 sentinel/排除值）。

### anthropic 选择路径（CRITICAL FIRST STEP 结论）

cc-stub 是 `platform=anthropic`。load-balance（非粘性）选择走 `GatewayService.SelectAccountWithLoadAwareness` Layer-2：`filterByMinPriority → filterByMinLoadRate → selectByLRU`（`gateway_service.go`）。`Priority` 是主排序键——**这是一个确定性多键排序**，可在主键上加 bounded 项。粘性（Layer 1/1.5）固定单账号、无多候选可排序；粘性 miss 后回落到 Layer-2，正是目标要消除的 failover 重选点。故 Layer-2 是正确且充分的注入点。

### 实现面（刻意很小）

| 面 | 文件 |
|---|---|
| Redis 短窗计数（INCR+首次 EXPIRE，MGET 批读） | `repository/anthropic_saturation_counter_cache.go` |
| 写入：两个 skip-penalty 分支递增计数 | `ratelimit_service.go`（薄注入）+ `ratelimit_service_tk_saturation.go` |
| 读取/打分：`effectivePriority()` 折入惩罚 | `gateway_service.go`（薄注入）+ `gateway_service_tk_saturation_penalty.go` |
| kill-switch（默认 ON，fail-open） | `setting_service_tk_saturation.go` |
| Wire（一个 provider，两个 setter，不改 upstream 构造签名） | `wire.go` |

阈值 4 / 窗 90s / 惩罚 1000 的取值理由见各文件注释。

## 为什么优于两个替代方案

- **优于「每 edge ≥2 账号」**：那是运维约束，靠人持续维护、有成本、无法防新单账号 edge；本方案是**自愈的软件不变量**，对任何 SPOF edge 自动生效，零运维。
- **优于 marker 子系统**：不引入平行状态机/marker/TTL/clear-hook。复用既有排序引擎的一个加法项 + 一个短窗计数，deprioritize/last-resort/self-clear/all-saturated 全部免费且 by-construction 正确，merge 面最小。

## 测试（build-tag unit）

- 低于阈值 → 不罚（保留现行行为）；达到/超过 → 排到 fresh stub 之后；
- 选择：一饱和 + 一 fresh → 选 fresh（即便 fresh 负载更高）；
- **全饱和 → 仍返回 stub**（有界惩罚、相对序不变，amplifier-safe）；
- self-clear：计数 TTL 过期 → 计数归零（miniredis FastForward）；窗口不滑动；
- **kill-switch off → 精确 pre-feature 打分**（无惩罚）；默认 ON → 施加惩罚；
- **feature 路径喂计数但绝不调用 ladder / SetTempUnschedulable / SetRateLimited**（增量断言双向：saturation 计数递增、ladder 计数为空、temp/rate-limited 调用为 0）；
- nil cache → 完全 inert；redis 读错误 → best-effort 不罚（选择绝不因此失败）。

## TK 隔离 / sentinel

TK 逻辑在 `*_tk_*.go` companion；upstream-shaped 文件仅薄注入（一个计数递增 + 一个打分项 + 一个 setting 读 + `filterByMinPriority` 改读 `effectivePriority()`）。`scripts/sentinels/gateway-tk.json` 新增 7 条 companion + 注入点 anchor，`python3 scripts/sentinels/check-gateway-tk.py` PASS（247/247）。

## 不变量（non-negotiable）

- 本特性永不 `SetTempUnschedulable` / 推进 3/3 ladder / `SetRateLimited` —— 仅偏好；
- 惩罚有界，全饱和池仍能选出（不排除、不会因本特性造成「no schedulable accounts」）；
- 阈值以下的瞬时几次 hit 不罚（保留现行行为）。

🤖 Generated with [Claude Code](https://claude.com/claude-code)