### PR TITLE
fix(smoke): soft-skip CC-only fallback pool-exhaustion ("All available accounts exhausted")

### DIFF
--- a/ops/stage0/smoke_lib.sh
+++ b/ops/stage0/smoke_lib.sh
@@ -72,8 +72,24 @@ if [[ -z "${_TK_SMOKE_LIB_LOADED:-}" ]]; then
         ;;
       *)
         case "${err_msg}" in
-          *"no available accounts"*)
-            echo "::warning::tk_post_deploy_smoke: ${label} returned HTTP ${http} with 'no available accounts' — pool exhausted, not a control-plane regression." >&2
+          # Pool exhaustion is a runtime resource state, not a control-plane
+          # regression. Two distinct gateway phrasings reach here:
+          #   "no available accounts"        — empty/throttled pool on the
+          #                                    directly-bound group.
+          #   "All available accounts exhausted" — the CC-only fallback path
+          #                                    (PR #740): a claude_code_only key
+          #                                    routes /v1/chat|/v1/responses to
+          #                                    its fallback_group_id, and that
+          #                                    fallback pool was exhausted. Before
+          #                                    #740 this same key returned the
+          #                                    "restricted to Claude Code clients"
+          #                                    rejection below (already soft-skipped),
+          #                                    so matching only the first phrase
+          #                                    turned an unchanged pool state into
+          #                                    a hard smoke failure. /v1/messages
+          #                                    stays the canonical signal for this key.
+          *"no available accounts"*|*"available accounts exhausted"*)
+            echo "::warning::tk_post_deploy_smoke: ${label} returned HTTP ${http} with a pool-exhaustion message ('no available accounts' / 'All available accounts exhausted') — pool exhausted, not a control-plane regression." >&2
             jq . "${resp_file}" >&2 2>/dev/null || cat "${resp_file}" >&2
             echo "tk_post_deploy_smoke: ${label} section soft-skipped (pool exhausted)"
             return 1


### PR DESCRIPTION
## 背景

v1.7.97 发版（prod 全 fleet 已上线、实测 `/v1/messages` 200 健康）时，prod `deploy-stage0` 的 post-deploy gateway smoke 在 `/v1/chat/completions` 探针硬失败：HTTP 403 `"All available accounts exhausted"`。**这不是线上回归**——SSM 实测 prod 镜像 1.7.97 正常服务真实流量（200 主导，0 panic / 0 error-level）。

## 根因

PR #740（CC-only 组把非-CC OpenAI-compat 流量路由到 `fallback_group_id` 而非直接 403）改变了 smoke key（组 `cc-edges`，`claude_code_only`）的 chat 报文：

| 版本 | chat 403 报文 | `soft_degrade_or_exit` 处理 |
|---|---|---|
| ≤1.7.96 | `restricted to Claude Code clients` | 命中 cc-only 软跳过 → pass |
| 1.7.97 (#740) | `All available accounts exhausted`（fallback 池耗尽） | 池耗尽模式只匹配 `no available accounts` → 未命中 → **hard fail** |

`ops/stage0/smoke_lib.sh` 的池耗尽软跳过只匹配 `"no available accounts"`，匹配不到 #740 fallback 路径的 `"All available accounts exhausted"`，于是把一个**未变化的池状态**变成了 prod smoke 红灯。chat 在这个 CC-only key 上本来就不工作（#740 前是 cc-only 拒），`/v1/messages` 才是这个 key 的 canonical 信号。

## 改动

`ops/stage0/smoke_lib.sh`：把池耗尽软跳过模式从仅 `*"no available accounts"*` 扩到 `*"no available accounts"*|*"available accounts exhausted"*`，并加注释说明 #740 出处。

验证（pattern 测试）：
- `All available accounts exhausted` → soft-skip(pool) ✓
- `no available accounts for group` → soft-skip(pool) ✓（不回归）
- `restricted to Claude Code clients` → soft-skip(cc-only) ✓（不回归）
- 其他 403 → **hard-fail** ✓（不过度放宽）

## 影响面 / 验证

- 纯 ops 烟测脚本，无后端/前端/数据层改动（`no-web-impact`）。
- `bash -n` 语法 OK；本地 `scripts/preflight.sh` PASS（含 smoke suite 契约测试 + smoke 脚本语法门禁）。
- 合并后下次发版（v1.7.98）prod smoke 在同样的 fallback-池-耗尽场景会正确软跳过、由 `/v1/messages` 兜底。

## 合并方式

TK-originated fix → **Squash and merge**（rule §5.y）。