### PR TITLE
fix(billing): 余额并发透支修复——预扣 HOLD（原子预留 + 请求结束释放 + 对账兜底）

### DIFF
--- a/backend/cmd/server/wire.go
+++ b/backend/cmd/server/wire.go
@@ -94,6 +94,10 @@ func provideCleanup(
 	subscriptionExpiry *service.SubscriptionExpiryService,
 	usageCleanup *service.UsageCleanupService,
 	idempotencyCleanup *service.IdempotencyCleanupService,
+	// TokenKey: pre-flight balance-hold reconciler — passed so its sweep ticker
+	// is Stopped at shutdown and so wire forces evaluation of
+	// ProvideHoldReconcilerService (which starts the ticker at construction).
+	holdReconciler *service.HoldReconcilerService,
 	pricing *service.PricingService,
 	emailQueue *service.EmailQueueService,
 	billingCache *service.BillingCacheService,
@@ -223,6 +227,12 @@ func provideCleanup(
 			{"IdempotencyCleanupService", func() error {
 				if idempotencyCleanup != nil {
 					idempotencyCleanup.Stop()
+				}
+				return nil
+			}},
+			{"HoldReconcilerService", func() error {
+				if holdReconciler != nil {
+					holdReconciler.Stop()
 				}
 				return nil
 			}},

--- a/backend/cmd/server/wire_gen.go
+++ b/backend/cmd/server/wire_gen.go
@@ -304,6 +304,7 @@ func initializeApplication(buildInfo handler.BuildInfo) (*Application, error) {
 	accountExpiryService := service.ProvideAccountExpiryService(accountRepository)
 	proxyExpiryService := service.ProvideProxyExpiryService(proxyRepository)
 	subscriptionExpiryService := service.ProvideSubscriptionExpiryService(userSubscriptionRepository, settingRepository, notificationEmailService, leaderLockCache, db)
+	holdReconcilerService := service.ProvideHoldReconcilerService(usageBillingRepository)
 	scheduledTestRunnerService := service.ProvideScheduledTestRunnerService(scheduledTestPlanRepository, scheduledTestService, accountTestService, rateLimitService, configConfig)
 	paymentOrderExpiryService := service.ProvidePaymentOrderExpiryService(paymentService, leaderLockCache, db)
 	channelMonitorRunner := service.ProvideChannelMonitorRunner(channelMonitorService, settingService)
@@ -316,7 +317,7 @@ func initializeApplication(buildInfo handler.BuildInfo) (*Application, error) {
 	tkAnthropicSaturationReady := service.ProvideTKAnthropicSaturation(gatewayService, rateLimitService, anthropicSaturationCounterCache)
 	modelListFilter := service.NewModelListFilter(pricingCatalogService, pricingAvailabilityService)
 	tkGatewayHandlerModelListReady := handler.ProvideTKGatewayHandlerModelList(gatewayHandler, modelListFilter)
-	v := provideCleanup(client, redisClient, opsMetricsCollector, opsAggregationService, opsAlertEvaluatorService, opsCleanupService, opsScheduledReportService, opsSystemLogSink, schedulerSnapshotService, schedulerRateLimitReaper, anthropicConfigReconciler, upstreamBalanceSentinel, tokenRefreshService, accountExpiryService, proxyExpiryService, subscriptionExpiryService, usageCleanupService, idempotencyCleanupService, pricingService, emailQueueService, billingCacheService, usageRecordWorkerPool, qaService, subscriptionService, oAuthService, openAIOAuthService, geminiOAuthService, antigravityOAuthService, openAIGatewayService, scheduledTestRunnerService, backupService, paymentOrderExpiryService, channelMonitorRunner, tkAccountIncidentNotifier, tkPricingMissingNotifier, tkAuthServiceColdStartReady, tkGatewayPricingAvailabilityReady, tkGatewayAnthropicSigPreemptReady, tkAnthropicSaturationReady, tkGatewayHandlerModelListReady)
+	v := provideCleanup(client, redisClient, opsMetricsCollector, opsAggregationService, opsAlertEvaluatorService, opsCleanupService, opsScheduledReportService, opsSystemLogSink, schedulerSnapshotService, schedulerRateLimitReaper, anthropicConfigReconciler, upstreamBalanceSentinel, tokenRefreshService, accountExpiryService, proxyExpiryService, subscriptionExpiryService, usageCleanupService, idempotencyCleanupService, holdReconcilerService, pricingService, emailQueueService, billingCacheService, usageRecordWorkerPool, qaService, subscriptionService, oAuthService, openAIOAuthService, geminiOAuthService, antigravityOAuthService, openAIGatewayService, scheduledTestRunnerService, backupService, paymentOrderExpiryService, channelMonitorRunner, tkAccountIncidentNotifier, tkPricingMissingNotifier, tkAuthServiceColdStartReady, tkGatewayPricingAvailabilityReady, tkGatewayAnthropicSigPreemptReady, tkAnthropicSaturationReady, tkGatewayHandlerModelListReady)
 	application := &Application{
 		Server:  httpServer,
 		Cleanup: v,
@@ -363,6 +364,8 @@ func provideCleanup(
 	subscriptionExpiry *service.SubscriptionExpiryService,
 	usageCleanup *service.UsageCleanupService,
 	idempotencyCleanup *service.IdempotencyCleanupService,
+
+	holdReconciler *service.HoldReconcilerService,
 	pricing *service.PricingService,
 	emailQueue *service.EmailQueueService,
 	billingCache *service.BillingCacheService,
@@ -473,6 +476,12 @@ func provideCleanup(
 			{"IdempotencyCleanupService", func() error {
 				if idempotencyCleanup != nil {
 					idempotencyCleanup.Stop()
+				}
+				return nil
+			}},
+			{"HoldReconcilerService", func() error {
+				if holdReconciler != nil {
+					holdReconciler.Stop()
 				}
 				return nil
 			}},

--- a/backend/cmd/server/wire_gen_test.go
+++ b/backend/cmd/server/wire_gen_test.go
@@ -72,6 +72,7 @@ func TestProvideCleanup_WithMinimalDependencies_NoPanic(t *testing.T) {
 		subscriptionExpirySvc,
 		&service.UsageCleanupService{},
 		idempotencyCleanupSvc,
+		nil, // holdReconciler
 		pricingSvc,
 		emailQueueSvc,
 		billingCacheSvc,

--- a/backend/internal/handler/openai_chat_completions.go
+++ b/backend/internal/handler/openai_chat_completions.go
@@ -106,6 +106,16 @@ func (h *OpenAIGatewayHandler) ChatCompletions(c *gin.Context) {
 
 	subscription, _ := middleware2.GetSubscriptionFromContext(c)
 
+	// TK: pre-flight balance hold (concurrent-overdraft fix; see
+	// openai_gateway_handler_tk_hold.go). Reserve before forwarding, release at
+	// request end; balance users only.
+	if release, reject := h.tkApplyBalanceHold(c, apiKey, reqModel, body); reject {
+		h.errorResponse(c, http.StatusForbidden, "insufficient_balance", tkInsufficientBalanceForHoldMsg)
+		return
+	} else if release != nil {
+		defer release()
+	}
+
 	service.SetOpsLatencyMs(c, service.OpsAuthLatencyMsKey, time.Since(requestStart).Milliseconds())
 	routingStart := time.Now()
 

--- a/backend/internal/handler/openai_chat_completions.go
+++ b/backend/internal/handler/openai_chat_completions.go
@@ -107,14 +107,15 @@ func (h *OpenAIGatewayHandler) ChatCompletions(c *gin.Context) {
 	subscription, _ := middleware2.GetSubscriptionFromContext(c)
 
 	// TK: pre-flight balance hold (concurrent-overdraft fix; see
-	// openai_gateway_handler_tk_hold.go). Reserve before forwarding, release at
-	// request end; balance users only.
-	if release, reject := h.tkApplyBalanceHold(c, apiKey, reqModel, body); reject {
+	// openai_gateway_handler_tk_hold.go). Reserve before forwarding; refund
+	// ownership is handed to the usage-record task at submit time, the deferred
+	// release only covers never-billed paths. Balance users only.
+	hold, holdReject := h.tkApplyBalanceHold(c, apiKey, reqModel, body)
+	if holdReject {
 		h.errorResponse(c, http.StatusForbidden, "insufficient_balance", tkInsufficientBalanceForHoldMsg)
 		return
-	} else if release != nil {
-		defer release()
 	}
+	defer hold.ReleaseUnlessSettling()
 
 	service.SetOpsLatencyMs(c, service.OpsAuthLatencyMsKey, time.Since(requestStart).Milliseconds())
 	routingStart := time.Now()
@@ -344,6 +345,7 @@ func (h *OpenAIGatewayHandler) ChatCompletions(c *gin.Context) {
 		inboundEndpoint := GetInboundEndpoint(c)
 		upstreamEndpoint := resolveRawCCUpstreamEndpoint(c, account)
 
+		tkHoldRequestID := hold.HandOffToSettlement()
 		h.submitOpenAIUsageRecordTask(c.Request.Context(), result, func(ctx context.Context) {
 			if err := h.gatewayService.RecordUsage(ctx, &service.OpenAIRecordUsageInput{
 				Result:             result,
@@ -356,6 +358,7 @@ func (h *OpenAIGatewayHandler) ChatCompletions(c *gin.Context) {
 				UserAgent:          userAgent,
 				IPAddress:          clientIP,
 				APIKeyService:      h.apiKeyService,
+				TkHoldRequestID:    tkHoldRequestID,
 				ChannelUsageFields: channelMapping.ToUsageFields(reqModel, result.UpstreamModel),
 			}); err != nil {
 				logger.L().With(

--- a/backend/internal/handler/openai_gateway_embeddings_images.go
+++ b/backend/internal/handler/openai_gateway_embeddings_images.go
@@ -91,6 +91,16 @@ func (h *OpenAIGatewayHandler) Embeddings(c *gin.Context) {
 
 	subscription, _ := middleware2.GetSubscriptionFromContext(c)
 
+	// TK: pre-flight balance hold (concurrent-overdraft fix; see
+	// openai_gateway_handler_tk_hold.go). Embeddings produce no output tokens,
+	// so the no-output estimate is used; balance users only.
+	if release, reject := h.tkApplyBalanceHoldNoOutput(c, apiKey, reqModel, body); reject {
+		h.errorResponse(c, http.StatusForbidden, "insufficient_balance", tkInsufficientBalanceForHoldMsg)
+		return
+	} else if release != nil {
+		defer release()
+	}
+
 	service.SetOpsLatencyMs(c, service.OpsAuthLatencyMsKey, time.Since(requestStart).Milliseconds())
 	routingStart := time.Now()
 
@@ -397,6 +407,16 @@ func (h *OpenAIGatewayHandler) ImageGenerations(c *gin.Context) {
 	}
 
 	subscription, _ := middleware2.GetSubscriptionFromContext(c)
+
+	// TK: pre-flight balance hold (concurrent-overdraft fix; see
+	// openai_gateway_handler_tk_hold.go). Image holds reserve the requested
+	// image count at the tier-max price; balance users only.
+	if release, reject := h.tkApplyImageHold(c, apiKey, reqModel, int(gjson.GetBytes(body, "n").Int())); reject {
+		h.errorResponse(c, http.StatusForbidden, "insufficient_balance", tkInsufficientBalanceForHoldMsg)
+		return
+	} else if release != nil {
+		defer release()
+	}
 
 	service.SetOpsLatencyMs(c, service.OpsAuthLatencyMsKey, time.Since(requestStart).Milliseconds())
 	routingStart := time.Now()

--- a/backend/internal/handler/openai_gateway_embeddings_images.go
+++ b/backend/internal/handler/openai_gateway_embeddings_images.go
@@ -93,13 +93,14 @@ func (h *OpenAIGatewayHandler) Embeddings(c *gin.Context) {
 
 	// TK: pre-flight balance hold (concurrent-overdraft fix; see
 	// openai_gateway_handler_tk_hold.go). Embeddings produce no output tokens,
-	// so the no-output estimate is used; balance users only.
-	if release, reject := h.tkApplyBalanceHoldNoOutput(c, apiKey, reqModel, body); reject {
+	// so the no-output estimate is used; refund ownership is handed to the
+	// usage-record task at submit time. Balance users only.
+	hold, holdReject := h.tkApplyBalanceHoldNoOutput(c, apiKey, reqModel, body)
+	if holdReject {
 		h.errorResponse(c, http.StatusForbidden, "insufficient_balance", tkInsufficientBalanceForHoldMsg)
 		return
-	} else if release != nil {
-		defer release()
 	}
+	defer hold.ReleaseUnlessSettling()
 
 	service.SetOpsLatencyMs(c, service.OpsAuthLatencyMsKey, time.Since(requestStart).Milliseconds())
 	routingStart := time.Now()
@@ -292,6 +293,7 @@ func (h *OpenAIGatewayHandler) Embeddings(c *gin.Context) {
 		userAgent := c.GetHeader("User-Agent")
 		clientIP := ip.GetClientIP(c)
 
+		tkHoldRequestID := hold.HandOffToSettlement()
 		h.submitUsageRecordTask(c.Request.Context(), func(ctx context.Context) {
 			upstreamModelForUsage := ""
 			if result != nil {
@@ -308,6 +310,7 @@ func (h *OpenAIGatewayHandler) Embeddings(c *gin.Context) {
 				UserAgent:          userAgent,
 				IPAddress:          clientIP,
 				APIKeyService:      h.apiKeyService,
+				TkHoldRequestID:    tkHoldRequestID,
 				ChannelUsageFields: channelMapping.ToUsageFields(reqModel, upstreamModelForUsage),
 			}); err != nil {
 				logger.L().With(
@@ -410,13 +413,14 @@ func (h *OpenAIGatewayHandler) ImageGenerations(c *gin.Context) {
 
 	// TK: pre-flight balance hold (concurrent-overdraft fix; see
 	// openai_gateway_handler_tk_hold.go). Image holds reserve the requested
-	// image count at the tier-max price; balance users only.
-	if release, reject := h.tkApplyImageHold(c, apiKey, reqModel, int(gjson.GetBytes(body, "n").Int())); reject {
+	// image count at the tier-max price; refund ownership is handed to the
+	// usage-record task at submit time. Balance users only.
+	hold, holdReject := h.tkApplyImageHold(c, apiKey, reqModel, int(gjson.GetBytes(body, "n").Int()))
+	if holdReject {
 		h.errorResponse(c, http.StatusForbidden, "insufficient_balance", tkInsufficientBalanceForHoldMsg)
 		return
-	} else if release != nil {
-		defer release()
 	}
+	defer hold.ReleaseUnlessSettling()
 
 	service.SetOpsLatencyMs(c, service.OpsAuthLatencyMsKey, time.Since(requestStart).Milliseconds())
 	routingStart := time.Now()
@@ -609,6 +613,7 @@ func (h *OpenAIGatewayHandler) ImageGenerations(c *gin.Context) {
 		userAgent := c.GetHeader("User-Agent")
 		clientIP := ip.GetClientIP(c)
 
+		tkHoldRequestID := hold.HandOffToSettlement()
 		h.submitUsageRecordTask(c.Request.Context(), func(ctx context.Context) {
 			upstreamModelForUsage := ""
 			if result != nil {
@@ -625,6 +630,7 @@ func (h *OpenAIGatewayHandler) ImageGenerations(c *gin.Context) {
 				UserAgent:          userAgent,
 				IPAddress:          clientIP,
 				APIKeyService:      h.apiKeyService,
+				TkHoldRequestID:    tkHoldRequestID,
 				ChannelUsageFields: channelMapping.ToUsageFields(reqModel, upstreamModelForUsage),
 			}); err != nil {
 				logger.L().With(

--- a/backend/internal/handler/openai_gateway_handler.go
+++ b/backend/internal/handler/openai_gateway_handler.go
@@ -276,6 +276,16 @@ func (h *OpenAIGatewayHandler) Responses(c *gin.Context) {
 	// Get subscription info (may be nil)
 	subscription, _ := middleware2.GetSubscriptionFromContext(c)
 
+	// TK: pre-flight balance hold (concurrent-overdraft fix; see
+	// openai_gateway_handler_tk_hold.go). Reserve before forwarding, release at
+	// request end; balance users only.
+	if release, reject := h.tkApplyBalanceHold(c, apiKey, reqModel, body); reject {
+		h.errorResponse(c, http.StatusForbidden, "insufficient_balance", tkInsufficientBalanceForHoldMsg)
+		return
+	} else if release != nil {
+		defer release()
+	}
+
 	service.SetOpsLatencyMs(c, service.OpsAuthLatencyMsKey, time.Since(requestStart).Milliseconds())
 	routingStart := time.Now()
 
@@ -714,6 +724,16 @@ func (h *OpenAIGatewayHandler) Messages(c *gin.Context) {
 	}
 
 	subscription, _ := middleware2.GetSubscriptionFromContext(c)
+
+	// TK: pre-flight balance hold (concurrent-overdraft fix; see
+	// openai_gateway_handler_tk_hold.go). Reserve before forwarding, release at
+	// request end; balance users only. Anthropic-shaped error surface.
+	if release, reject := h.tkApplyBalanceHold(c, apiKey, reqModel, body); reject {
+		h.anthropicErrorResponse(c, http.StatusForbidden, "insufficient_balance", tkInsufficientBalanceForHoldMsg)
+		return
+	} else if release != nil {
+		defer release()
+	}
 
 	service.SetOpsLatencyMs(c, service.OpsAuthLatencyMsKey, time.Since(requestStart).Milliseconds())
 	routingStart := time.Now()

--- a/backend/internal/handler/openai_gateway_handler.go
+++ b/backend/internal/handler/openai_gateway_handler.go
@@ -277,14 +277,15 @@ func (h *OpenAIGatewayHandler) Responses(c *gin.Context) {
 	subscription, _ := middleware2.GetSubscriptionFromContext(c)
 
 	// TK: pre-flight balance hold (concurrent-overdraft fix; see
-	// openai_gateway_handler_tk_hold.go). Reserve before forwarding, release at
-	// request end; balance users only.
-	if release, reject := h.tkApplyBalanceHold(c, apiKey, reqModel, body); reject {
+	// openai_gateway_handler_tk_hold.go). Reserve before forwarding; refund
+	// ownership is handed to the usage-record task at submit time, the deferred
+	// release only covers never-billed paths. Balance users only.
+	hold, holdReject := h.tkApplyBalanceHold(c, apiKey, reqModel, body)
+	if holdReject {
 		h.errorResponse(c, http.StatusForbidden, "insufficient_balance", tkInsufficientBalanceForHoldMsg)
 		return
-	} else if release != nil {
-		defer release()
 	}
+	defer hold.ReleaseUnlessSettling()
 
 	service.SetOpsLatencyMs(c, service.OpsAuthLatencyMsKey, time.Since(requestStart).Milliseconds())
 	routingStart := time.Now()
@@ -529,6 +530,7 @@ func (h *OpenAIGatewayHandler) Responses(c *gin.Context) {
 		upstreamEndpoint := GetUpstreamEndpoint(c, account.Platform)
 
 		// 使用量记录通过有界 worker 池提交，避免请求热路径创建无界 goroutine。
+		tkHoldRequestID := hold.HandOffToSettlement()
 		h.submitOpenAIUsageRecordTask(c.Request.Context(), result, func(ctx context.Context) {
 			if err := h.gatewayService.RecordUsage(ctx, &service.OpenAIRecordUsageInput{
 				Result:             result,
@@ -542,6 +544,7 @@ func (h *OpenAIGatewayHandler) Responses(c *gin.Context) {
 				IPAddress:          clientIP,
 				RequestPayloadHash: requestPayloadHash,
 				APIKeyService:      h.apiKeyService,
+				TkHoldRequestID:    tkHoldRequestID,
 				ChannelUsageFields: channelMapping.ToUsageFields(reqModel, result.UpstreamModel),
 			}); err != nil {
 				logger.L().With(
@@ -726,14 +729,16 @@ func (h *OpenAIGatewayHandler) Messages(c *gin.Context) {
 	subscription, _ := middleware2.GetSubscriptionFromContext(c)
 
 	// TK: pre-flight balance hold (concurrent-overdraft fix; see
-	// openai_gateway_handler_tk_hold.go). Reserve before forwarding, release at
-	// request end; balance users only. Anthropic-shaped error surface.
-	if release, reject := h.tkApplyBalanceHold(c, apiKey, reqModel, body); reject {
+	// openai_gateway_handler_tk_hold.go). Reserve before forwarding; refund
+	// ownership is handed to the usage-record task at submit time, the deferred
+	// release only covers never-billed paths. Balance users only;
+	// Anthropic-shaped error surface.
+	hold, holdReject := h.tkApplyBalanceHold(c, apiKey, reqModel, body)
+	if holdReject {
 		h.anthropicErrorResponse(c, http.StatusForbidden, "insufficient_balance", tkInsufficientBalanceForHoldMsg)
 		return
-	} else if release != nil {
-		defer release()
 	}
+	defer hold.ReleaseUnlessSettling()
 
 	service.SetOpsLatencyMs(c, service.OpsAuthLatencyMsKey, time.Since(requestStart).Milliseconds())
 	routingStart := time.Now()
@@ -933,6 +938,7 @@ func (h *OpenAIGatewayHandler) Messages(c *gin.Context) {
 		inboundEndpoint := GetInboundEndpoint(c)
 		upstreamEndpoint := GetUpstreamEndpoint(c, account.Platform)
 
+		tkHoldRequestID := hold.HandOffToSettlement()
 		h.submitOpenAIUsageRecordTask(c.Request.Context(), result, func(ctx context.Context) {
 			if err := h.gatewayService.RecordUsage(ctx, &service.OpenAIRecordUsageInput{
 				Result:             result,
@@ -946,6 +952,7 @@ func (h *OpenAIGatewayHandler) Messages(c *gin.Context) {
 				IPAddress:          clientIP,
 				RequestPayloadHash: requestPayloadHash,
 				APIKeyService:      h.apiKeyService,
+				TkHoldRequestID:    tkHoldRequestID,
 				ChannelUsageFields: channelMappingMsg.ToUsageFields(reqModel, result.UpstreamModel),
 			}); err != nil {
 				logger.L().With(
@@ -1378,6 +1385,28 @@ func (h *OpenAIGatewayHandler) ResponsesWebSocket(c *gin.Context) {
 		return
 	}
 
+	// TK: pre-flight balance holds, one per billed turn (concurrent-overdraft
+	// fix; see openai_gateway_handler_tk_hold.go). Turn 1 reserves here from
+	// the validated first message; later turns reserve in BeforeRequest. Each
+	// turn's refund ownership is handed to its usage-record task in AfterTurn;
+	// the deferred release covers a turn that never reaches billing.
+	var wsTurnHold *tkHoldHandle
+	defer func() { wsTurnHold.ReleaseUnlessSettling() }()
+	wsHoldSeq := 0
+	wsReserveTurnHold := func(model string, payload []byte) error {
+		wsHoldSeq++
+		turnHold, holdReject := h.tkApplyWSTurnHold(c, apiKey, model, payload, wsHoldSeq)
+		if holdReject {
+			return service.NewOpenAIWSClientCloseError(coderws.StatusPolicyViolation, tkInsufficientBalanceForHoldMsg, nil)
+		}
+		wsTurnHold = turnHold
+		return nil
+	}
+	if err := wsReserveTurnHold(reqModel, firstMessage); err != nil {
+		closeOpenAIClientWS(wsConn, coderws.StatusPolicyViolation, tkInsufficientBalanceForHoldMsg)
+		return
+	}
+
 	sessionHash := h.gatewayService.GenerateSessionHashWithFallback(
 		c,
 		firstMessage,
@@ -1489,6 +1518,13 @@ func (h *OpenAIGatewayHandler) ResponsesWebSocket(c *gin.Context) {
 					writeContentModerationWSError(ctx, wsConn, decision)
 					return service.NewOpenAIWSClientCloseError(coderws.StatusPolicyViolation, decision.Message, nil)
 				}
+				// TK: reserve this turn's balance hold (turn 1 reserved pre-loop;
+				// non-nil also covers a failover retry of an unbilled turn).
+				if wsTurnHold == nil {
+					if err := wsReserveTurnHold(model, payload); err != nil {
+						return err
+					}
+				}
 				return nil
 			},
 			BeforeTurn: func(turn int) error {
@@ -1523,6 +1559,12 @@ func (h *OpenAIGatewayHandler) ResponsesWebSocket(c *gin.Context) {
 				return nil
 			},
 			AfterTurn: func(turn int, result *service.OpenAIForwardResult, turnErr error) {
+				// TK: this turn's hold leaves the loop here — either handed to
+				// the usage-record task below or released by the defer (turn
+				// never billed).
+				turnHold := wsTurnHold
+				wsTurnHold = nil
+				defer turnHold.ReleaseUnlessSettling()
 				releaseTurnSlots()
 				if turnErr != nil {
 					if result == nil || result.ImageCount <= 0 {
@@ -1545,6 +1587,7 @@ func (h *OpenAIGatewayHandler) ResponsesWebSocket(c *gin.Context) {
 				h.gatewayService.ReportOpenAIAccountScheduleResult(account.ID, true, result.FirstTokenMs)
 				inboundEndpoint := GetInboundEndpoint(c)
 				upstreamEndpoint := GetUpstreamEndpoint(c, account.Platform)
+				tkHoldRequestID := turnHold.HandOffToSettlement()
 				h.submitOpenAIUsageRecordTask(ctx, result, func(taskCtx context.Context) {
 					if err := h.gatewayService.RecordUsage(taskCtx, &service.OpenAIRecordUsageInput{
 						Result:             result,
@@ -1558,6 +1601,7 @@ func (h *OpenAIGatewayHandler) ResponsesWebSocket(c *gin.Context) {
 						IPAddress:          clientIP,
 						RequestPayloadHash: requestPayloadHash,
 						APIKeyService:      h.apiKeyService,
+						TkHoldRequestID:    tkHoldRequestID,
 						ChannelUsageFields: channelMappingWS.ToUsageFields(reqModel, result.UpstreamModel),
 					}); err != nil {
 						reqLog.Error("openai.websocket_record_usage_failed",

--- a/backend/internal/handler/openai_gateway_handler_tk_hold.go
+++ b/backend/internal/handler/openai_gateway_handler_tk_hold.go
@@ -1,0 +1,119 @@
+package handler
+
+import (
+	middleware2 "github.com/Wei-Shaw/sub2api/internal/server/middleware"
+	"github.com/Wei-Shaw/sub2api/internal/service"
+	"github.com/gin-gonic/gin"
+	"github.com/tidwall/gjson"
+)
+
+// TK: pre-flight balance HOLD injection for OpenAI-compatible routes.
+//
+// Reserves an upper-bound cost on the user balance BEFORE forwarding so that
+// concurrent requests cannot overdraw it (the post-hoc deduct has no floor —
+// see service/usage_billing_hold_tk.go for the invariant). Balance users only:
+// subscription requests have no balance to overdraw and are skipped. The hold
+// is released at request end via the returned closure (deferred by the caller).
+//
+// tkInsufficientBalanceForHoldMsg is the client-facing reason when the balance
+// cannot cover the reservation.
+const tkInsufficientBalanceForHoldMsg = "Insufficient account balance to reserve this request"
+
+// tkHoldFallbackMaxOutputTokens is the conservative output-token upper bound
+// used when a request omits max_tokens / max_completion_tokens /
+// max_output_tokens. The hold must be an upper bound on actual cost; without a
+// client-declared ceiling we assume a large output so the reservation cannot
+// under-cover. (PR-follow-up: derive the exact per-model max-output from
+// pricing metadata to tighten this.)
+const tkHoldFallbackMaxOutputTokens = 200000
+
+// tkParseMaxOutputTokens extracts the output-token ceiling from the request,
+// falling back to a conservative bound when the client omits it. Field names
+// per surface: max_tokens (chat, anthropic messages), max_completion_tokens
+// (chat), max_output_tokens (responses) — max() of whatever is present.
+func tkParseMaxOutputTokens(body []byte) int {
+	m := int(gjson.GetBytes(body, "max_tokens").Int())
+	if mc := int(gjson.GetBytes(body, "max_completion_tokens").Int()); mc > m {
+		m = mc
+	}
+	if mo := int(gjson.GetBytes(body, "max_output_tokens").Int()); mo > m {
+		m = mo
+	}
+	if m <= 0 {
+		m = tkHoldFallbackMaxOutputTokens
+	}
+	return m
+}
+
+// tkApplyHold is the shared reserve-or-skip shell: skips subscription requests
+// (no balance to overdraw), resolves the usage-billing request id, runs the
+// route-specific reserve, and wraps the release closure. Returns:
+//   - release != nil → a hold is held; caller MUST defer release().
+//   - reject == true  → balance insufficient; caller returns its 403 and stops.
+//   - both zero       → not gated (subscription / no hold capability / unpriced).
+func (h *OpenAIGatewayHandler) tkApplyHold(c *gin.Context, apiKey *service.APIKey, reserve func(requestID string) (held bool, reject bool)) (release func(), reject bool) {
+	if h == nil || h.gatewayService == nil || apiKey == nil || apiKey.User == nil {
+		return nil, false
+	}
+	if subscription, _ := middleware2.GetSubscriptionFromContext(c); subscription != nil {
+		return nil, false
+	}
+	requestID := service.TkResolveUsageBillingRequestID(c.Request.Context())
+	held, rej := reserve(requestID)
+	if rej {
+		return nil, true
+	}
+	if held {
+		ctx := c.Request.Context()
+		return func() { h.gatewayService.TkReleaseHold(ctx, requestID) }, false
+	}
+	return nil, false
+}
+
+// tkApplyBalanceHold reserves a pre-flight token hold for the output-bearing
+// token routes (chat / responses / messages).
+//
+// promptTokens upper bound = len(body): a BPE token spans ≥ 1 body byte, so the
+// byte count is a safe (loose) upper bound on input tokens without a tokenizer.
+func (h *OpenAIGatewayHandler) tkApplyBalanceHold(c *gin.Context, apiKey *service.APIKey, reqModel string, body []byte) (release func(), reject bool) {
+	return h.tkApplyTokenHold(c, apiKey, reqModel, body, tkParseMaxOutputTokens(body))
+}
+
+// tkApplyBalanceHoldNoOutput is tkApplyBalanceHold for routes that produce no
+// output tokens (embeddings): the output side of the estimate is zero instead
+// of the fallback ceiling, so an embeddings call is not blocked by a hold three
+// orders of magnitude above its real cost.
+func (h *OpenAIGatewayHandler) tkApplyBalanceHoldNoOutput(c *gin.Context, apiKey *service.APIKey, reqModel string, body []byte) (release func(), reject bool) {
+	return h.tkApplyTokenHold(c, apiKey, reqModel, body, 0)
+}
+
+func (h *OpenAIGatewayHandler) tkApplyTokenHold(c *gin.Context, apiKey *service.APIKey, reqModel string, body []byte, maxOutputTokens int) (release func(), reject bool) {
+	return h.tkApplyHold(c, apiKey, func(requestID string) (bool, bool) {
+		return h.gatewayService.TkReserveTokenHold(
+			c.Request.Context(),
+			requestID,
+			reqModel,
+			gjson.GetBytes(body, "service_tier").String(),
+			apiKey.User,
+			apiKey,
+			len(body),
+			maxOutputTokens,
+		)
+	})
+}
+
+// tkApplyImageHold reserves a pre-flight hold for an image-generation request
+// (n = requested image count; actual delivers ≤ n).
+func (h *OpenAIGatewayHandler) tkApplyImageHold(c *gin.Context, apiKey *service.APIKey, reqModel string, n int) (release func(), reject bool) {
+	return h.tkApplyHold(c, apiKey, func(requestID string) (bool, bool) {
+		return h.gatewayService.TkReserveImageHold(c.Request.Context(), requestID, reqModel, apiKey.User, apiKey, n)
+	})
+}
+
+// tkApplyVideoHold reserves a pre-flight hold for an async video submit
+// (seconds = the same request-derived duration the submit path bills).
+func (h *OpenAIGatewayHandler) tkApplyVideoHold(c *gin.Context, apiKey *service.APIKey, reqModel string, seconds int64) (release func(), reject bool) {
+	return h.tkApplyHold(c, apiKey, func(requestID string) (bool, bool) {
+		return h.gatewayService.TkReserveVideoHold(c.Request.Context(), requestID, reqModel, apiKey.User, apiKey, seconds)
+	})
+}

--- a/backend/internal/handler/openai_gateway_handler_tk_hold.go
+++ b/backend/internal/handler/openai_gateway_handler_tk_hold.go
@@ -1,6 +1,9 @@
 package handler
 
 import (
+	"context"
+	"strconv"
+
 	middleware2 "github.com/Wei-Shaw/sub2api/internal/server/middleware"
 	"github.com/Wei-Shaw/sub2api/internal/service"
 	"github.com/gin-gonic/gin"
@@ -12,11 +15,20 @@ import (
 // Reserves an upper-bound cost on the user balance BEFORE forwarding so that
 // concurrent requests cannot overdraw it (the post-hoc deduct has no floor —
 // see service/usage_billing_hold_tk.go for the invariant). Balance users only:
-// subscription requests have no balance to overdraw and are skipped. The hold
-// is released at request end via the returned closure (deferred by the caller).
+// subscription requests have no balance to overdraw and are skipped.
+//
+// Hold lifecycle (the release-before-settle rule): the reservation must outlive
+// the handler whenever a usage-record task was submitted, because the actual
+// balance deduction runs in that async task — refunding at handler return would
+// re-expose the funds to concurrent admission until the bill lands. So the
+// handler defers ReleaseUnlessSettling() and, at each usage-task submit site,
+// synchronously calls HandOffToSettlement(); settlement then consumes the hold
+// in the same transaction as the deduction (usage_billing_repo_tk_hold.go).
+// Crash after hand-off is repaid by the hold reconciler.
 //
 // tkInsufficientBalanceForHoldMsg is the client-facing reason when the balance
-// cannot cover the reservation.
+// cannot cover the reservation (rejected 403, matching billingErrorDetails'
+// insufficient-balance mapping).
 const tkInsufficientBalanceForHoldMsg = "Insufficient account balance to reserve this request"
 
 // tkHoldFallbackMaxOutputTokens is the conservative output-token upper bound
@@ -45,13 +57,48 @@ func tkParseMaxOutputTokens(body []byte) int {
 	return m
 }
 
+// tkHoldHandle owns one reservation's release. Nil-safe: a nil handle (request
+// not gated) makes every method a no-op, so call sites need no nil checks. Not
+// goroutine-safe — HandOffToSettlement must be called from the handler
+// goroutine BEFORE the deferred ReleaseUnlessSettling can run (i.e. before the
+// handler returns), which every submit site satisfies by construction.
+type tkHoldHandle struct {
+	h         *OpenAIGatewayHandler
+	ctx       context.Context
+	requestID string
+	settling  bool
+}
+
+// ReleaseUnlessSettling refunds the hold at handler return — the error-path
+// cleanup. Once handed off to settlement it is a no-op: the settlement
+// transaction (or, after a crash, the reconciler) owns the refund.
+func (hh *tkHoldHandle) ReleaseUnlessSettling() {
+	if hh == nil || hh.settling {
+		return
+	}
+	hh.h.gatewayService.TkReleaseHold(hh.ctx, hh.requestID)
+}
+
+// HandOffToSettlement transfers refund ownership to the usage-record task and
+// returns the hold key to stamp into OpenAIRecordUsageInput.TkHoldRequestID.
+// MUST be called synchronously at the submit site (not inside the async task
+// closure), or the deferred release races the hand-off.
+func (hh *tkHoldHandle) HandOffToSettlement() string {
+	if hh == nil {
+		return ""
+	}
+	hh.settling = true
+	return hh.requestID
+}
+
 // tkApplyHold is the shared reserve-or-skip shell: skips subscription requests
-// (no balance to overdraw), resolves the usage-billing request id, runs the
-// route-specific reserve, and wraps the release closure. Returns:
-//   - release != nil → a hold is held; caller MUST defer release().
-//   - reject == true  → balance insufficient; caller returns its 403 and stops.
-//   - both zero       → not gated (subscription / no hold capability / unpriced).
-func (h *OpenAIGatewayHandler) tkApplyHold(c *gin.Context, apiKey *service.APIKey, reserve func(requestID string) (held bool, reject bool)) (release func(), reject bool) {
+// (no balance to overdraw), resolves the usage-billing request id (plus an
+// optional suffix for sub-request holds, e.g. WS turns), runs the
+// route-specific reserve, and wraps the handle. Returns:
+//   - hold != nil → reserved; caller MUST defer hold.ReleaseUnlessSettling().
+//   - reject == true → balance insufficient; caller returns its 403 and stops.
+//   - both zero → not gated (subscription / no hold capability / unpriced).
+func (h *OpenAIGatewayHandler) tkApplyHold(c *gin.Context, apiKey *service.APIKey, requestIDSuffix string, reserve func(requestID string) (held bool, reject bool)) (hold *tkHoldHandle, reject bool) {
 	if h == nil || h.gatewayService == nil || apiKey == nil || apiKey.User == nil {
 		return nil, false
 	}
@@ -59,13 +106,16 @@ func (h *OpenAIGatewayHandler) tkApplyHold(c *gin.Context, apiKey *service.APIKe
 		return nil, false
 	}
 	requestID := service.TkResolveUsageBillingRequestID(c.Request.Context())
+	if requestID == "" {
+		return nil, false
+	}
+	requestID += requestIDSuffix
 	held, rej := reserve(requestID)
 	if rej {
 		return nil, true
 	}
 	if held {
-		ctx := c.Request.Context()
-		return func() { h.gatewayService.TkReleaseHold(ctx, requestID) }, false
+		return &tkHoldHandle{h: h, ctx: c.Request.Context(), requestID: requestID}, false
 	}
 	return nil, false
 }
@@ -75,20 +125,28 @@ func (h *OpenAIGatewayHandler) tkApplyHold(c *gin.Context, apiKey *service.APIKe
 //
 // promptTokens upper bound = len(body): a BPE token spans ≥ 1 body byte, so the
 // byte count is a safe (loose) upper bound on input tokens without a tokenizer.
-func (h *OpenAIGatewayHandler) tkApplyBalanceHold(c *gin.Context, apiKey *service.APIKey, reqModel string, body []byte) (release func(), reject bool) {
-	return h.tkApplyTokenHold(c, apiKey, reqModel, body, tkParseMaxOutputTokens(body))
+func (h *OpenAIGatewayHandler) tkApplyBalanceHold(c *gin.Context, apiKey *service.APIKey, reqModel string, body []byte) (hold *tkHoldHandle, reject bool) {
+	return h.tkApplyTokenHold(c, apiKey, reqModel, body, tkParseMaxOutputTokens(body), "")
 }
 
 // tkApplyBalanceHoldNoOutput is tkApplyBalanceHold for routes that produce no
 // output tokens (embeddings): the output side of the estimate is zero instead
 // of the fallback ceiling, so an embeddings call is not blocked by a hold three
 // orders of magnitude above its real cost.
-func (h *OpenAIGatewayHandler) tkApplyBalanceHoldNoOutput(c *gin.Context, apiKey *service.APIKey, reqModel string, body []byte) (release func(), reject bool) {
-	return h.tkApplyTokenHold(c, apiKey, reqModel, body, 0)
+func (h *OpenAIGatewayHandler) tkApplyBalanceHoldNoOutput(c *gin.Context, apiKey *service.APIKey, reqModel string, body []byte) (hold *tkHoldHandle, reject bool) {
+	return h.tkApplyTokenHold(c, apiKey, reqModel, body, 0, "")
 }
 
-func (h *OpenAIGatewayHandler) tkApplyTokenHold(c *gin.Context, apiKey *service.APIKey, reqModel string, body []byte, maxOutputTokens int) (release func(), reject bool) {
-	return h.tkApplyHold(c, apiKey, func(requestID string) (bool, bool) {
+// tkApplyWSTurnHold reserves a per-turn token hold on the Responses WebSocket
+// ingress. Each turn is billed separately (per-turn RecordUsage with an
+// upstream-derived request id), so each turn gets its own hold, keyed by the
+// connection's billing request id + the turn ordinal.
+func (h *OpenAIGatewayHandler) tkApplyWSTurnHold(c *gin.Context, apiKey *service.APIKey, reqModel string, payload []byte, turn int) (hold *tkHoldHandle, reject bool) {
+	return h.tkApplyTokenHold(c, apiKey, reqModel, payload, tkParseMaxOutputTokens(payload), ":wsturn:"+strconv.Itoa(turn))
+}
+
+func (h *OpenAIGatewayHandler) tkApplyTokenHold(c *gin.Context, apiKey *service.APIKey, reqModel string, body []byte, maxOutputTokens int, requestIDSuffix string) (hold *tkHoldHandle, reject bool) {
+	return h.tkApplyHold(c, apiKey, requestIDSuffix, func(requestID string) (bool, bool) {
 		return h.gatewayService.TkReserveTokenHold(
 			c.Request.Context(),
 			requestID,
@@ -104,16 +162,16 @@ func (h *OpenAIGatewayHandler) tkApplyTokenHold(c *gin.Context, apiKey *service.
 
 // tkApplyImageHold reserves a pre-flight hold for an image-generation request
 // (n = requested image count; actual delivers ≤ n).
-func (h *OpenAIGatewayHandler) tkApplyImageHold(c *gin.Context, apiKey *service.APIKey, reqModel string, n int) (release func(), reject bool) {
-	return h.tkApplyHold(c, apiKey, func(requestID string) (bool, bool) {
+func (h *OpenAIGatewayHandler) tkApplyImageHold(c *gin.Context, apiKey *service.APIKey, reqModel string, n int) (hold *tkHoldHandle, reject bool) {
+	return h.tkApplyHold(c, apiKey, "", func(requestID string) (bool, bool) {
 		return h.gatewayService.TkReserveImageHold(c.Request.Context(), requestID, reqModel, apiKey.User, apiKey, n)
 	})
 }
 
 // tkApplyVideoHold reserves a pre-flight hold for an async video submit
 // (seconds = the same request-derived duration the submit path bills).
-func (h *OpenAIGatewayHandler) tkApplyVideoHold(c *gin.Context, apiKey *service.APIKey, reqModel string, seconds int64) (release func(), reject bool) {
-	return h.tkApplyHold(c, apiKey, func(requestID string) (bool, bool) {
+func (h *OpenAIGatewayHandler) tkApplyVideoHold(c *gin.Context, apiKey *service.APIKey, reqModel string, seconds int64) (hold *tkHoldHandle, reject bool) {
+	return h.tkApplyHold(c, apiKey, "", func(requestID string) (bool, bool) {
 		return h.gatewayService.TkReserveVideoHold(c.Request.Context(), requestID, reqModel, apiKey.User, apiKey, seconds)
 	})
 }

--- a/backend/internal/handler/openai_gateway_handler_tk_hold_test.go
+++ b/backend/internal/handler/openai_gateway_handler_tk_hold_test.go
@@ -1,6 +1,11 @@
 package handler
 
-import "testing"
+import (
+	"context"
+	"testing"
+
+	"github.com/Wei-Shaw/sub2api/internal/service"
+)
 
 // The output-token ceiling feeds the hold's upper bound, so missing a surface's
 // field name silently under-caps nothing (fallback is huge) but over-caps cost:
@@ -24,5 +29,34 @@ func TestTkParseMaxOutputTokens(t *testing.T) {
 		if got := tkParseMaxOutputTokens([]byte(tc.body)); got != tc.want {
 			t.Errorf("%s: tkParseMaxOutputTokens(%s) = %d, want %d", tc.name, tc.body, got, tc.want)
 		}
+	}
+}
+
+// The hand-off protocol is the release-ordering half of the overdraft
+// invariant: once a usage-record task owns the refund, the handler's deferred
+// release must become a no-op — otherwise the hold is refunded while the bill
+// is still queued and the funds are re-exposed to concurrent admission.
+func TestTkHoldHandle_HandOffDisablesDeferredRelease(t *testing.T) {
+	h := &OpenAIGatewayHandler{gatewayService: &service.OpenAIGatewayService{}}
+	hh := &tkHoldHandle{h: h, ctx: context.Background(), requestID: "local:req-1"}
+
+	if got := hh.HandOffToSettlement(); got != "local:req-1" {
+		t.Fatalf("HandOffToSettlement() = %q, want the hold request id", got)
+	}
+	if !hh.settling {
+		t.Fatal("hand-off must mark the handle as settling")
+	}
+	// Must be a no-op (and must not panic on the zero gateway service): the
+	// settlement transaction owns the refund now.
+	hh.ReleaseUnlessSettling()
+}
+
+// A nil handle (request not gated: subscription / unpriced / no capability)
+// must make both lifecycle calls safe no-ops so call sites need no nil checks.
+func TestTkHoldHandle_NilSafe(t *testing.T) {
+	var hh *tkHoldHandle
+	hh.ReleaseUnlessSettling()
+	if got := hh.HandOffToSettlement(); got != "" {
+		t.Fatalf("nil handle HandOffToSettlement() = %q, want empty", got)
 	}
 }

--- a/backend/internal/handler/openai_gateway_handler_tk_hold_test.go
+++ b/backend/internal/handler/openai_gateway_handler_tk_hold_test.go
@@ -1,0 +1,28 @@
+package handler
+
+import "testing"
+
+// The output-token ceiling feeds the hold's upper bound, so missing a surface's
+// field name silently under-caps nothing (fallback is huge) but over-caps cost:
+// every supported field spelling must be honoured, and absence must fall back
+// to the conservative ceiling.
+func TestTkParseMaxOutputTokens(t *testing.T) {
+	cases := []struct {
+		name string
+		body string
+		want int
+	}{
+		{"chat max_tokens", `{"max_tokens":1024}`, 1024},
+		{"chat max_completion_tokens", `{"max_completion_tokens":2048}`, 2048},
+		{"responses max_output_tokens", `{"max_output_tokens":4096}`, 4096},
+		{"max of multiple fields", `{"max_tokens":100,"max_output_tokens":300,"max_completion_tokens":200}`, 300},
+		{"absent falls back", `{}`, tkHoldFallbackMaxOutputTokens},
+		{"zero falls back", `{"max_tokens":0}`, tkHoldFallbackMaxOutputTokens},
+		{"negative falls back", `{"max_tokens":-5}`, tkHoldFallbackMaxOutputTokens},
+	}
+	for _, tc := range cases {
+		if got := tkParseMaxOutputTokens([]byte(tc.body)); got != tc.want {
+			t.Errorf("%s: tkParseMaxOutputTokens(%s) = %d, want %d", tc.name, tc.body, got, tc.want)
+		}
+	}
+}

--- a/backend/internal/handler/openai_gateway_tk_video.go
+++ b/backend/internal/handler/openai_gateway_tk_video.go
@@ -120,6 +120,17 @@ func (h *OpenAIGatewayHandler) VideoSubmit(c *gin.Context) {
 	}
 	subscription, _ := middleware2.GetSubscriptionFromContext(c)
 
+	// TK: pre-flight balance hold (concurrent-overdraft fix; see
+	// openai_gateway_handler_tk_hold.go). Video reserves the exact submit-time
+	// cost (same request-derived seconds the billing path uses); balance users
+	// only. Released at handler end — the async RecordUsage settles the bill.
+	if release, reject := h.tkApplyVideoHold(c, apiKey, reqModel, videoRequestedSeconds(body)); reject {
+		h.errorResponse(c, http.StatusForbidden, "insufficient_balance", tkInsufficientBalanceForHoldMsg)
+		return
+	} else if release != nil {
+		defer release()
+	}
+
 	service.SetOpsLatencyMs(c, service.OpsAuthLatencyMsKey, time.Since(requestStart).Milliseconds())
 	routingStart := time.Now()
 

--- a/backend/internal/handler/openai_gateway_tk_video.go
+++ b/backend/internal/handler/openai_gateway_tk_video.go
@@ -122,14 +122,15 @@ func (h *OpenAIGatewayHandler) VideoSubmit(c *gin.Context) {
 
 	// TK: pre-flight balance hold (concurrent-overdraft fix; see
 	// openai_gateway_handler_tk_hold.go). Video reserves the exact submit-time
-	// cost (same request-derived seconds the billing path uses); balance users
-	// only. Released at handler end — the async RecordUsage settles the bill.
-	if release, reject := h.tkApplyVideoHold(c, apiKey, reqModel, videoRequestedSeconds(body)); reject {
+	// cost (same request-derived seconds the billing path uses); refund
+	// ownership is handed to the usage-record task at submit time. Balance
+	// users only.
+	hold, holdReject := h.tkApplyVideoHold(c, apiKey, reqModel, videoRequestedSeconds(body))
+	if holdReject {
 		h.errorResponse(c, http.StatusForbidden, "insufficient_balance", tkInsufficientBalanceForHoldMsg)
 		return
-	} else if release != nil {
-		defer release()
 	}
+	defer hold.ReleaseUnlessSettling()
 
 	service.SetOpsLatencyMs(c, service.OpsAuthLatencyMsKey, time.Since(requestStart).Milliseconds())
 	routingStart := time.Now()
@@ -261,6 +262,7 @@ func (h *OpenAIGatewayHandler) VideoSubmit(c *gin.Context) {
 	// full billing context (apiKey/user/account/subscription), and 8s is veo's
 	// conservative max so we never under-charge when the field is omitted.
 	videoSeconds := videoRequestedSeconds(body)
+	tkHoldRequestID := hold.HandOffToSettlement()
 	h.submitUsageRecordTask(c.Request.Context(), func(ctx context.Context) {
 		if err := h.gatewayService.RecordUsage(ctx, &service.OpenAIRecordUsageInput{
 			Result: &service.OpenAIForwardResult{
@@ -280,6 +282,7 @@ func (h *OpenAIGatewayHandler) VideoSubmit(c *gin.Context) {
 			UserAgent:        userAgent,
 			IPAddress:        clientIP,
 			APIKeyService:    h.apiKeyService,
+			TkHoldRequestID:  tkHoldRequestID,
 		}); err != nil {
 			logger.L().With(
 				zap.String("component", "handler.openai_gateway.video_submit"),

--- a/backend/internal/handler/openai_images.go
+++ b/backend/internal/handler/openai_images.go
@@ -118,13 +118,14 @@ func (h *OpenAIGatewayHandler) Images(c *gin.Context) {
 
 	// TK: pre-flight balance hold (concurrent-overdraft fix; see
 	// openai_gateway_handler_tk_hold.go). Image holds reserve the requested
-	// image count at the tier-max price; balance users only.
-	if release, reject := h.tkApplyImageHold(c, apiKey, requestModel, parsed.N); reject {
+	// image count at the tier-max price; refund ownership is handed to the
+	// usage-record task at submit time. Balance users only.
+	hold, holdReject := h.tkApplyImageHold(c, apiKey, requestModel, parsed.N)
+	if holdReject {
 		h.errorResponse(c, http.StatusForbidden, "insufficient_balance", tkInsufficientBalanceForHoldMsg)
 		return
-	} else if release != nil {
-		defer release()
 	}
+	defer hold.ReleaseUnlessSettling()
 
 	service.SetOpsLatencyMs(c, service.OpsAuthLatencyMsKey, time.Since(requestStart).Milliseconds())
 	routingStart := time.Now()
@@ -335,6 +336,7 @@ func (h *OpenAIGatewayHandler) Images(c *gin.Context) {
 		if result != nil {
 			upstreamModel = result.UpstreamModel
 		}
+		tkHoldRequestID := hold.HandOffToSettlement()
 		h.submitMandatoryUsageRecordTask(c.Request.Context(), func(ctx context.Context) {
 			if err := h.gatewayService.RecordUsage(ctx, &service.OpenAIRecordUsageInput{
 				Result:             result,
@@ -348,6 +350,7 @@ func (h *OpenAIGatewayHandler) Images(c *gin.Context) {
 				IPAddress:          clientIP,
 				RequestPayloadHash: requestPayloadHash,
 				APIKeyService:      h.apiKeyService,
+				TkHoldRequestID:    tkHoldRequestID,
 				ChannelUsageFields: channelMapping.ToUsageFields(requestModel, upstreamModel),
 			}); err != nil {
 				logger.L().With(

--- a/backend/internal/handler/openai_images.go
+++ b/backend/internal/handler/openai_images.go
@@ -116,6 +116,16 @@ func (h *OpenAIGatewayHandler) Images(c *gin.Context) {
 
 	subscription, _ := middleware2.GetSubscriptionFromContext(c)
 
+	// TK: pre-flight balance hold (concurrent-overdraft fix; see
+	// openai_gateway_handler_tk_hold.go). Image holds reserve the requested
+	// image count at the tier-max price; balance users only.
+	if release, reject := h.tkApplyImageHold(c, apiKey, requestModel, parsed.N); reject {
+		h.errorResponse(c, http.StatusForbidden, "insufficient_balance", tkInsufficientBalanceForHoldMsg)
+		return
+	} else if release != nil {
+		defer release()
+	}
+
 	service.SetOpsLatencyMs(c, service.OpsAuthLatencyMsKey, time.Since(requestStart).Milliseconds())
 	routingStart := time.Now()
 

--- a/backend/internal/repository/usage_billing_repo.go
+++ b/backend/internal/repository/usage_billing_repo.go
@@ -106,6 +106,12 @@ func (r *usageBillingRepository) claimUsageBillingKey(ctx context.Context, tx *s
 }
 
 func (r *usageBillingRepository) applyUsageBillingEffects(ctx context.Context, tx *sql.Tx, cmd *service.UsageBillingCommand, result *service.UsageBillingApplyResult) error {
+	// TK: consume the pre-flight balance hold in the SAME transaction as the
+	// deduction below (see usage_billing_repo_tk_hold.go).
+	if err := tkConsumeBalanceHoldInTx(ctx, tx, cmd.TkHoldRequestID); err != nil {
+		return err
+	}
+
 	if cmd.SubscriptionCost > 0 && cmd.SubscriptionID != nil {
 		if err := incrementUsageBillingSubscription(ctx, tx, *cmd.SubscriptionID, cmd.SubscriptionCost); err != nil {
 			return err

--- a/backend/internal/repository/usage_billing_repo_tk_hold.go
+++ b/backend/internal/repository/usage_billing_repo_tk_hold.go
@@ -1,0 +1,194 @@
+package repository
+
+import (
+	"context"
+	"database/sql"
+	"errors"
+	"time"
+
+	"github.com/Wei-Shaw/sub2api/internal/service"
+)
+
+// TK: pre-flight balance HOLD repository methods — money movement, atomic.
+// Implements service.UsageBillingHoldApplier (consumed via type assertion; the
+// wide UsageBillingRepository interface stays Apply-only). See tk_026 and
+// service/usage_billing_hold_tk.go for the why and the invariant.
+
+// ReserveBalanceHold atomically records a usage_holds row AND deducts the
+// reserved amount from the user balance, guarded by `balance >= amount`.
+//
+// Both effects share one transaction, so the outcome is all-or-nothing:
+//   - hold row inserted + balance deducted  → reserved (true)
+//   - balance insufficient (deduct matches 0 rows) → both rolled back (false)
+//   - hold row already exists for this request_id  → idempotent no-op (true);
+//     never double-deducts (a retried reserve for the same request must not
+//     charge twice).
+func (r *usageBillingRepository) ReserveBalanceHold(ctx context.Context, cmd *service.HoldCommand) (bool, error) {
+	if cmd == nil || cmd.Amount <= 0 {
+		return false, nil
+	}
+	if r == nil || r.db == nil {
+		return false, errors.New("usage billing repository db is nil")
+	}
+	if cmd.RequestID == "" {
+		return false, service.ErrUsageBillingRequestIDRequired
+	}
+
+	tx, err := r.db.BeginTx(ctx, nil)
+	if err != nil {
+		return false, err
+	}
+	defer func() {
+		if tx != nil {
+			_ = tx.Rollback()
+		}
+	}()
+
+	// Claim the hold row first. ON CONFLICT DO NOTHING makes a retried reserve
+	// for the same request_id idempotent: no new row → already reserved → do
+	// NOT deduct again.
+	var insertedID string
+	err = tx.QueryRowContext(ctx, `
+		INSERT INTO usage_holds (request_id, user_id, api_key_id, amount)
+		VALUES ($1, $2, $3, $4)
+		ON CONFLICT (request_id) DO NOTHING
+		RETURNING request_id
+	`, cmd.RequestID, cmd.UserID, cmd.APIKeyID, cmd.Amount).Scan(&insertedID)
+	if errors.Is(err, sql.ErrNoRows) {
+		// Hold already exists for this request — reservation stands, money was
+		// already moved by the first reserve. Commit (no-op) and report held.
+		if err := tx.Commit(); err != nil {
+			return false, err
+		}
+		tx = nil
+		return true, nil
+	}
+	if err != nil {
+		return false, err
+	}
+
+	// Atomic floor-guarded deduction. 0 rows ⇒ balance < amount ⇒ reject; the
+	// hold INSERT rolls back with it, so no orphan hold is left behind.
+	var newBalance float64
+	err = tx.QueryRowContext(ctx, `
+		UPDATE users
+		SET balance = balance - $1,
+			updated_at = NOW()
+		WHERE id = $2 AND deleted_at IS NULL AND balance >= $1
+		RETURNING balance
+	`, cmd.Amount, cmd.UserID).Scan(&newBalance)
+	if errors.Is(err, sql.ErrNoRows) {
+		// Insufficient balance (or user missing): roll back the hold INSERT.
+		return false, nil
+	}
+	if err != nil {
+		return false, err
+	}
+
+	if err := tx.Commit(); err != nil {
+		return false, err
+	}
+	tx = nil
+	return true, nil
+}
+
+// ReleaseBalanceHold refunds the reserved amount and removes the hold row, in
+// one transaction. Idempotent: a missing row (already released, or refunded by
+// the reconciler) returns (false, nil) and moves no money.
+func (r *usageBillingRepository) ReleaseBalanceHold(ctx context.Context, requestID string) (bool, error) {
+	if r == nil || r.db == nil {
+		return false, errors.New("usage billing repository db is nil")
+	}
+	if requestID == "" {
+		return false, nil
+	}
+
+	tx, err := r.db.BeginTx(ctx, nil)
+	if err != nil {
+		return false, err
+	}
+	defer func() {
+		if tx != nil {
+			_ = tx.Rollback()
+		}
+	}()
+
+	var userID int64
+	var amount float64
+	err = tx.QueryRowContext(ctx, `
+		DELETE FROM usage_holds
+		WHERE request_id = $1
+		RETURNING user_id, amount
+	`, requestID).Scan(&userID, &amount)
+	if errors.Is(err, sql.ErrNoRows) {
+		// Nothing held for this request — already released or never reserved.
+		return false, nil
+	}
+	if err != nil {
+		return false, err
+	}
+
+	if _, err := tx.ExecContext(ctx, `
+		UPDATE users
+		SET balance = balance + $1,
+			updated_at = NOW()
+		WHERE id = $2 AND deleted_at IS NULL
+	`, amount, userID); err != nil {
+		return false, err
+	}
+
+	if err := tx.Commit(); err != nil {
+		return false, err
+	}
+	tx = nil
+	return true, nil
+}
+
+// ReleaseExpiredBalanceHolds refunds holds older than olderThan (up to batch
+// rows) in a single transaction — the crash-recovery sweep for reserve/release
+// pairs whose request-end release never ran. FOR UPDATE SKIP LOCKED keeps it
+// from fighting concurrent normal releases; the per-user SUM folds multiple
+// leaked holds for one user into one balance update.
+func (r *usageBillingRepository) ReleaseExpiredBalanceHolds(ctx context.Context, olderThan time.Time, batch int) (int, error) {
+	if r == nil || r.db == nil {
+		return 0, errors.New("usage billing repository db is nil")
+	}
+	if batch <= 0 {
+		batch = 500
+	}
+
+	var refunded int
+	err := r.db.QueryRowContext(ctx, `
+		WITH picked AS (
+			SELECT request_id
+			FROM usage_holds
+			WHERE created_at < $1
+			ORDER BY created_at
+			LIMIT $2
+			FOR UPDATE SKIP LOCKED
+		),
+		deleted AS (
+			DELETE FROM usage_holds
+			WHERE request_id IN (SELECT request_id FROM picked)
+			RETURNING user_id, amount
+		),
+		agg AS (
+			SELECT user_id, SUM(amount) AS total
+			FROM deleted
+			GROUP BY user_id
+		),
+		upd AS (
+			UPDATE users u
+			SET balance = balance + agg.total,
+				updated_at = NOW()
+			FROM agg
+			WHERE u.id = agg.user_id AND u.deleted_at IS NULL
+			RETURNING 1
+		)
+		SELECT COUNT(*) FROM deleted
+	`, olderThan, batch).Scan(&refunded)
+	if err != nil {
+		return 0, err
+	}
+	return refunded, nil
+}

--- a/backend/internal/repository/usage_billing_repo_tk_hold.go
+++ b/backend/internal/repository/usage_billing_repo_tk_hold.go
@@ -144,6 +144,40 @@ func (r *usageBillingRepository) ReleaseBalanceHold(ctx context.Context, request
 	return true, nil
 }
 
+// tkConsumeBalanceHoldInTx refunds a handed-off pre-flight hold INSIDE the
+// settlement transaction (applyUsageBillingEffects), so the balance leaves the
+// tx as B + hold − actual in one atomic step. This closes the only timing gap
+// of the overdraft fix: if the hold were refunded at handler end while the
+// settlement was still queued, a concurrent request could be admitted against
+// the not-yet-debited balance. Idempotent: a missing row (hold already
+// consumed by an earlier settle of the same request, or refunded by the
+// reconciler after a crash) moves no money.
+func tkConsumeBalanceHoldInTx(ctx context.Context, tx *sql.Tx, holdRequestID string) error {
+	if holdRequestID == "" {
+		return nil
+	}
+	var userID int64
+	var amount float64
+	err := tx.QueryRowContext(ctx, `
+		DELETE FROM usage_holds
+		WHERE request_id = $1
+		RETURNING user_id, amount
+	`, holdRequestID).Scan(&userID, &amount)
+	if errors.Is(err, sql.ErrNoRows) {
+		return nil
+	}
+	if err != nil {
+		return err
+	}
+	_, err = tx.ExecContext(ctx, `
+		UPDATE users
+		SET balance = balance + $1,
+			updated_at = NOW()
+		WHERE id = $2 AND deleted_at IS NULL
+	`, amount, userID)
+	return err
+}
+
 // ReleaseExpiredBalanceHolds refunds holds older than olderThan (up to batch
 // rows) in a single transaction — the crash-recovery sweep for reserve/release
 // pairs whose request-end release never ran. FOR UPDATE SKIP LOCKED keeps it

--- a/backend/internal/repository/usage_billing_repo_tk_hold_integration_test.go
+++ b/backend/internal/repository/usage_billing_repo_tk_hold_integration_test.go
@@ -1,0 +1,137 @@
+//go:build integration
+
+package repository
+
+import (
+	"context"
+	"fmt"
+	"sync"
+	"sync/atomic"
+	"testing"
+	"time"
+
+	"github.com/google/uuid"
+	"github.com/stretchr/testify/require"
+
+	"github.com/Wei-Shaw/sub2api/internal/service"
+)
+
+func newHoldApplier(t *testing.T) (service.UsageBillingHoldApplier, *service.User, *service.APIKey) {
+	t.Helper()
+	client := testEntClient(t)
+	repo := NewUsageBillingRepository(client, integrationDB)
+	applier, ok := repo.(service.UsageBillingHoldApplier)
+	require.True(t, ok, "usage billing repository must implement UsageBillingHoldApplier")
+
+	user := mustCreateUser(t, client, &service.User{
+		Email:        fmt.Sprintf("hold-user-%s@example.com", uuid.NewString()),
+		PasswordHash: "hash",
+		Balance:      10,
+	})
+	apiKey := mustCreateApiKey(t, client, &service.APIKey{
+		UserID: user.ID,
+		Key:    "sk-hold-" + uuid.NewString(),
+		Name:   "hold",
+		Quota:  1,
+	})
+	return applier, user, apiKey
+}
+
+func holdBalance(t *testing.T, userID int64) float64 {
+	t.Helper()
+	var b float64
+	require.NoError(t, integrationDB.QueryRowContext(context.Background(),
+		"SELECT balance FROM users WHERE id = $1", userID).Scan(&b))
+	return b
+}
+
+func TestReserveBalanceHold_FloorIdempotentAndRelease(t *testing.T) {
+	ctx := context.Background()
+	applier, user, apiKey := newHoldApplier(t)
+
+	reqA := uuid.NewString()
+	ok, err := applier.ReserveBalanceHold(ctx, &service.HoldCommand{RequestID: reqA, UserID: user.ID, APIKeyID: apiKey.ID, Amount: 5})
+	require.NoError(t, err)
+	require.True(t, ok, "5 of 10 must reserve")
+	require.InDelta(t, 5, holdBalance(t, user.ID), 1e-9)
+
+	// Floor: 6 of remaining 5 must be refused, balance untouched, no orphan hold.
+	reqB := uuid.NewString()
+	ok, err = applier.ReserveBalanceHold(ctx, &service.HoldCommand{RequestID: reqB, UserID: user.ID, APIKeyID: apiKey.ID, Amount: 6})
+	require.NoError(t, err)
+	require.False(t, ok, "6 of 5 remaining must be refused")
+	require.InDelta(t, 5, holdBalance(t, user.ID), 1e-9)
+
+	// Idempotent: re-reserving the same request must not double-deduct.
+	ok, err = applier.ReserveBalanceHold(ctx, &service.HoldCommand{RequestID: reqA, UserID: user.ID, APIKeyID: apiKey.ID, Amount: 5})
+	require.NoError(t, err)
+	require.True(t, ok)
+	require.InDelta(t, 5, holdBalance(t, user.ID), 1e-9)
+
+	// Release refunds exactly once.
+	released, err := applier.ReleaseBalanceHold(ctx, reqA)
+	require.NoError(t, err)
+	require.True(t, released)
+	require.InDelta(t, 10, holdBalance(t, user.ID), 1e-9)
+
+	released, err = applier.ReleaseBalanceHold(ctx, reqA)
+	require.NoError(t, err)
+	require.False(t, released, "double release must be a no-op")
+	require.InDelta(t, 10, holdBalance(t, user.ID), 1e-9)
+}
+
+// The headline guarantee: concurrent reservations against a thin balance can
+// never drive it negative — exactly the affordable number succeed.
+func TestReserveBalanceHold_ConcurrentNeverNegative(t *testing.T) {
+	ctx := context.Background()
+	applier, user, apiKey := newHoldApplier(t) // balance 10
+
+	const goroutines = 50
+	var success int64
+	var wg sync.WaitGroup
+	wg.Add(goroutines)
+	for i := 0; i < goroutines; i++ {
+		go func() {
+			defer wg.Done()
+			ok, err := applier.ReserveBalanceHold(ctx, &service.HoldCommand{
+				RequestID: uuid.NewString(), UserID: user.ID, APIKeyID: apiKey.ID, Amount: 1,
+			})
+			if err == nil && ok {
+				atomic.AddInt64(&success, 1)
+			}
+		}()
+	}
+	wg.Wait()
+
+	bal := holdBalance(t, user.ID)
+	require.GreaterOrEqual(t, bal, 0.0, "balance must NEVER go negative")
+	require.LessOrEqual(t, success, int64(10), "at most 10 of $1 holds can fit in $10")
+	require.InDelta(t, 10-float64(success), bal, 1e-9, "balance must equal 10 minus successful holds")
+}
+
+func TestReleaseExpiredBalanceHolds_RefundsLeaks(t *testing.T) {
+	ctx := context.Background()
+	applier, user, apiKey := newHoldApplier(t)
+
+	reqX := uuid.NewString()
+	ok, err := applier.ReserveBalanceHold(ctx, &service.HoldCommand{RequestID: reqX, UserID: user.ID, APIKeyID: apiKey.ID, Amount: 3})
+	require.NoError(t, err)
+	require.True(t, ok)
+	require.InDelta(t, 7, holdBalance(t, user.ID), 1e-9)
+
+	// Simulate a leaked hold (request crashed before release): age it past TTL.
+	_, err = integrationDB.ExecContext(ctx,
+		"UPDATE usage_holds SET created_at = NOW() - INTERVAL '1 hour' WHERE request_id = $1", reqX)
+	require.NoError(t, err)
+
+	refunded, err := applier.ReleaseExpiredBalanceHolds(ctx, time.Now().Add(-30*time.Minute), 100)
+	require.NoError(t, err)
+	require.Equal(t, 1, refunded)
+	require.InDelta(t, 10, holdBalance(t, user.ID), 1e-9, "reconciler must refund the leaked hold")
+
+	// Row is gone; a late release is a harmless no-op.
+	var n int
+	require.NoError(t, integrationDB.QueryRowContext(ctx,
+		"SELECT COUNT(*) FROM usage_holds WHERE request_id = $1", reqX).Scan(&n))
+	require.Equal(t, 0, n)
+}

--- a/backend/internal/repository/usage_billing_repo_tk_hold_integration_test.go
+++ b/backend/internal/repository/usage_billing_repo_tk_hold_integration_test.go
@@ -109,6 +109,65 @@ func TestReserveBalanceHold_ConcurrentNeverNegative(t *testing.T) {
 	require.InDelta(t, 10-float64(success), bal, 1e-9, "balance must equal 10 minus successful holds")
 }
 
+// The release-before-settle closure: a hold handed off to settlement must be
+// consumed (refunded) in the SAME billing transaction as the deduction, so the
+// balance moves B → B + hold − actual in one atomic step and is never exposed
+// at B + hold with the bill still pending.
+func TestApply_ConsumesHandedOffHoldAtomically(t *testing.T) {
+	ctx := context.Background()
+	client := testEntClient(t)
+	repo := NewUsageBillingRepository(client, integrationDB)
+	applier, ok := repo.(service.UsageBillingHoldApplier)
+	require.True(t, ok)
+
+	user := mustCreateUser(t, client, &service.User{
+		Email:        fmt.Sprintf("hold-settle-%s@example.com", uuid.NewString()),
+		PasswordHash: "hash",
+		Balance:      10,
+	})
+	apiKey := mustCreateApiKey(t, client, &service.APIKey{
+		UserID: user.ID,
+		Key:    "sk-hold-settle-" + uuid.NewString(),
+		Name:   "hold-settle",
+		Quota:  1,
+	})
+
+	holdID := "local:" + uuid.NewString()
+	reserved, err := applier.ReserveBalanceHold(ctx, &service.HoldCommand{
+		RequestID: holdID, UserID: user.ID, APIKeyID: apiKey.ID, Amount: 5,
+	})
+	require.NoError(t, err)
+	require.True(t, reserved)
+	require.InDelta(t, 5, holdBalance(t, user.ID), 1e-9)
+
+	cmd := &service.UsageBillingCommand{
+		RequestID:       uuid.NewString(), // billing id may differ from the hold id (WS turns)
+		APIKeyID:        apiKey.ID,
+		UserID:          user.ID,
+		AccountID:       1,
+		AccountType:     service.AccountTypeAPIKey,
+		Model:           "test-model",
+		BalanceCost:     3,
+		TkHoldRequestID: holdID,
+	}
+	cmd.Normalize()
+	result, err := repo.Apply(ctx, cmd)
+	require.NoError(t, err)
+	require.True(t, result.Applied)
+	require.InDelta(t, 7, holdBalance(t, user.ID), 1e-9, "settle must net hold refund (+5) and actual (−3)")
+
+	var n int
+	require.NoError(t, integrationDB.QueryRowContext(ctx,
+		"SELECT COUNT(*) FROM usage_holds WHERE request_id = $1", holdID).Scan(&n))
+	require.Equal(t, 0, n, "consumed hold row must be gone")
+
+	// A late handler-end release must find nothing to refund.
+	released, err := applier.ReleaseBalanceHold(ctx, holdID)
+	require.NoError(t, err)
+	require.False(t, released)
+	require.InDelta(t, 7, holdBalance(t, user.ID), 1e-9)
+}
+
 func TestReleaseExpiredBalanceHolds_RefundsLeaks(t *testing.T) {
 	ctx := context.Background()
 	applier, user, apiKey := newHoldApplier(t)

--- a/backend/internal/service/billing_service_tk_hold.go
+++ b/backend/internal/service/billing_service_tk_hold.go
@@ -1,0 +1,112 @@
+package service
+
+import "strings"
+
+// TK: pre-flight HOLD estimates — the LOAD-BEARING property is hold >= actual.
+// If any estimate can fall below the eventual billed cost, the overdraft
+// invariant (see usage_billing_hold_tk.go) is void. So every estimate is a
+// deliberate UPPER BOUND on what computeTokenBreakdown / CalculateImageCost /
+// CalculateVideoCost will later bill; the cost is some over-reservation, which
+// only briefly shrinks AVAILABLE balance and is corrected by exact settlement.
+
+// EstimateTokenHold returns an upper bound on the actual cost of a token-billed
+// request (chat / responses / messages; embeddings pass maxOutputTokens=0).
+//
+// Upper-bound construction vs. computeTokenBreakdown's actual formula:
+//   - input side: every prompt token is priced at the MAX of all input-side
+//     unit prices (input / cache-creation 5m / 1h / priority). At billing time
+//     each token is one of input | cache_read | cache_creation; cache_read is
+//     the cheapest and cache_creation the dearest, so max() dominates any split.
+//   - output side: max_tokens (the hard ceiling the model cannot exceed) at the
+//     MAX of output / priority-output / image-output unit price.
+//   - long-context: applied whenever promptTokens COULD cross the model
+//     threshold (actual triggers on input+cache_read ≤ promptTokens, so this is
+//     a safe over-approximation).
+//   - service tier: serviceTierCostMultiplier covers the non-priority-unit
+//     branch (priority→2.0); combined with the priority unit price in max()
+//     above it over-covers the priority branch (computeTokenBreakdown picks
+//     ONE of the two), never under.
+func (s *BillingService) EstimateTokenHold(model, serviceTier string, promptTokens, maxOutputTokens int, rateMultiplier float64) (float64, error) {
+	pricing, err := s.GetModelPricing(model) // already carries long-context policy
+	if err != nil {
+		return 0, err
+	}
+	if promptTokens < 0 {
+		promptTokens = 0
+	}
+	if maxOutputTokens < 0 {
+		maxOutputTokens = 0
+	}
+
+	unitIn := maxFloat(
+		pricing.InputPricePerToken,
+		pricing.InputPricePerTokenPriority,
+		pricing.CacheCreationPricePerToken,
+		pricing.CacheCreation5mPrice,
+		pricing.CacheCreation1hPrice,
+	)
+	unitOut := maxFloat(
+		pricing.OutputPricePerToken,
+		pricing.OutputPricePerTokenPriority,
+		pricing.ImageOutputPricePerToken,
+	)
+
+	lcIn, lcOut := 1.0, 1.0
+	if pricing.LongContextInputThreshold > 0 && promptTokens > pricing.LongContextInputThreshold {
+		if pricing.LongContextInputMultiplier > 1 {
+			lcIn = pricing.LongContextInputMultiplier
+		}
+		if pricing.LongContextOutputMultiplier > 1 {
+			lcOut = pricing.LongContextOutputMultiplier
+		}
+	}
+
+	tier := serviceTierCostMultiplier(serviceTier)
+	if rateMultiplier < 0 {
+		rateMultiplier = 0
+	}
+
+	total := float64(promptTokens)*unitIn*lcIn + float64(maxOutputTokens)*unitOut*lcOut
+	return total * tier * rateMultiplier, nil
+}
+
+// EstimateImageHold returns an upper bound on an image-generation request:
+// CalculateImageCost over the REQUESTED image count (actual delivers ≤ n) at
+// the requested size tier. An empty/unknown size tier is priced as 4K (the
+// dearest tier, 2× base) so a request that omits size cannot under-reserve.
+func (s *BillingService) EstimateImageHold(model, sizeTier string, n int, groupConfig *ImagePriceConfig, rateMultiplier float64) float64 {
+	if n <= 0 {
+		n = 1
+	}
+	if strings.TrimSpace(sizeTier) == "" {
+		sizeTier = "4K"
+	}
+	bd := s.CalculateImageCost(model, sizeTier, n, groupConfig, rateMultiplier)
+	if bd == nil {
+		return 0
+	}
+	return bd.ActualCost
+}
+
+// EstimateVideoHold returns an upper bound on an async video submit:
+// CalculateVideoCost over the requested duration (the same seconds actual bills,
+// so this is exact). Callers pass the request-clamped seconds (handlers clamp
+// to [1,60]).
+func (s *BillingService) EstimateVideoHold(model string, seconds int64, rateMultiplier float64) float64 {
+	bd := s.CalculateVideoCost(model, seconds, rateMultiplier)
+	if bd == nil {
+		return 0
+	}
+	return bd.ActualCost
+}
+
+// maxFloat returns the largest of the given values (0 for an empty list).
+func maxFloat(vs ...float64) float64 {
+	m := 0.0
+	for _, v := range vs {
+		if v > m {
+			m = v
+		}
+	}
+	return m
+}

--- a/backend/internal/service/billing_service_tk_hold_test.go
+++ b/backend/internal/service/billing_service_tk_hold_test.go
@@ -1,0 +1,118 @@
+//go:build unit
+
+package service
+
+import (
+	"testing"
+
+	"github.com/Wei-Shaw/sub2api/internal/config"
+)
+
+// The load-bearing property of the overdraft fix: the hold estimate must be an
+// UPPER BOUND on whatever the request can actually be billed. If any reachable
+// token distribution (input ≤ prompt, output ≤ max_tokens) costs more than the
+// hold, the "balance never goes negative" guarantee is void. These tests pin
+// that property across token splits and service tiers.
+
+func TestEstimateTokenHold_IsUpperBoundOverDistributions(t *testing.T) {
+	s := NewBillingService(&config.Config{}, nil) // fallback pricing, no pricingService
+	const (
+		model   = "claude-sonnet-4"
+		prompt  = 1000 // upper bound on input tokens
+		maxOut  = 500  // hard output ceiling
+		mult    = 1.0
+		epsilon = 1e-9
+	)
+
+	for _, tier := range []string{"", "priority", "flex"} {
+		hold, err := s.EstimateTokenHold(model, tier, prompt, maxOut, mult)
+		if err != nil {
+			t.Fatalf("EstimateTokenHold(tier=%q): %v", tier, err)
+		}
+
+		// Every distribution the request could actually resolve to: input is
+		// split across input / cache-creation / cache-read (cache-creation is
+		// the dearest, cache-read the cheapest), output up to maxOut.
+		dists := []UsageTokens{
+			{InputTokens: prompt, OutputTokens: maxOut},
+			{CacheCreationTokens: prompt, OutputTokens: maxOut}, // most expensive input
+			{InputTokens: prompt / 2, CacheCreationTokens: prompt / 2, OutputTokens: maxOut},
+			{CacheReadTokens: prompt, OutputTokens: maxOut}, // cheapest input
+			{InputTokens: prompt, OutputTokens: 0},
+		}
+		for _, d := range dists {
+			bd, err := s.CalculateCostWithServiceTier(model, d, mult, tier)
+			if err != nil {
+				t.Fatalf("CalculateCostWithServiceTier(tier=%q, %+v): %v", tier, d, err)
+			}
+			if bd.ActualCost > hold+epsilon {
+				t.Errorf("hold is NOT an upper bound: tier=%q dist=%+v actual=%.12f > hold=%.12f",
+					tier, d, bd.ActualCost, hold)
+			}
+		}
+	}
+}
+
+func TestEstimateTokenHold_ScalesWithRateMultiplier(t *testing.T) {
+	s := NewBillingService(&config.Config{}, nil)
+	h1, err := s.EstimateTokenHold("claude-sonnet-4", "", 1000, 500, 1.0)
+	if err != nil {
+		t.Fatal(err)
+	}
+	h2, err := s.EstimateTokenHold("claude-sonnet-4", "", 1000, 500, 2.0)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if h2 <= h1 {
+		t.Errorf("hold should scale with rate multiplier: mult=1 → %.10f, mult=2 → %.10f", h1, h2)
+	}
+}
+
+func TestEstimateTokenHold_UnpricedModelErrors(t *testing.T) {
+	s := NewBillingService(&config.Config{}, nil)
+	if _, err := s.EstimateTokenHold("definitely-not-a-real-model-xyz", "", 100, 100, 1.0); err == nil {
+		t.Error("expected an error for an unpriced model so the caller can fail-open (chat serves $0)")
+	}
+}
+
+func TestEstimateImageHold_CoversFewerDeliveredImages(t *testing.T) {
+	s := NewBillingService(&config.Config{}, nil)
+	// Reserve for the requested count; actual delivers ≤ n, so hold ≥ actual.
+	hold := s.EstimateImageHold("some-image-model", "2K", 4, nil, 1.0)
+	actual := s.CalculateImageCost("some-image-model", "2K", 2, nil, 1.0).ActualCost
+	if actual > hold {
+		t.Errorf("image hold (n=4) must cover actual fewer images (n=2): hold=%.6f actual=%.6f", hold, actual)
+	}
+	// An omitted size tier must be priced as the dearest tier (4K), never under.
+	holdEmpty := s.EstimateImageHold("some-image-model", "", 1, nil, 1.0)
+	hold4K := s.EstimateImageHold("some-image-model", "4K", 1, nil, 1.0)
+	if holdEmpty < hold4K {
+		t.Errorf("empty size tier must reserve as 4K: empty=%.6f 4K=%.6f", holdEmpty, hold4K)
+	}
+}
+
+func TestEstimateVideoHold_MatchesBilledDuration(t *testing.T) {
+	s := NewBillingService(&config.Config{}, nil)
+	hold := s.EstimateVideoHold("some-video-model", 8, 1.0)
+	actual := s.CalculateVideoCost("some-video-model", 8, 1.0).ActualCost
+	if hold < actual {
+		t.Errorf("video hold must be ≥ billed cost for the same duration: hold=%.6f actual=%.6f", hold, actual)
+	}
+}
+
+func TestMaxFloat(t *testing.T) {
+	cases := []struct {
+		in   []float64
+		want float64
+	}{
+		{nil, 0},
+		{[]float64{1, 2, 3}, 3},
+		{[]float64{-1, -2}, 0}, // never below zero
+		{[]float64{0.3e-6, 3.75e-6, 3e-6}, 3.75e-6},
+	}
+	for _, c := range cases {
+		if got := maxFloat(c.in...); got != c.want {
+			t.Errorf("maxFloat(%v) = %v, want %v", c.in, got, c.want)
+		}
+	}
+}

--- a/backend/internal/service/gateway_service.go
+++ b/backend/internal/service/gateway_service.go
@@ -8947,6 +8947,9 @@ type postUsageBillingParams struct {
 	AccountRateMultiplier float64
 	APIKeyService         APIKeyQuotaUpdater
 	Platform              string // 来自 APIKey 关联 Group 的平台标识
+	// TK: pre-flight balance-hold key handed off by the handler; consumed in the
+	// settlement transaction (see UsageBillingCommand.TkHoldRequestID).
+	TkHoldRequestID string
 }
 
 // PlatformFromAPIKey 从 APIKey 关联的 Group 推导 platform 名称。
@@ -9092,6 +9095,7 @@ func buildUsageBillingCommand(requestID string, usageLog *UsageLog, p *postUsage
 		AccountID:          p.Account.ID,
 		AccountType:        p.Account.Type,
 		RequestPayloadHash: strings.TrimSpace(p.RequestPayloadHash),
+		TkHoldRequestID:    strings.TrimSpace(p.TkHoldRequestID),
 	}
 	if usageLog != nil {
 		cmd.Model = usageLog.Model

--- a/backend/internal/service/hold_reconciler_service.go
+++ b/backend/internal/service/hold_reconciler_service.go
@@ -1,0 +1,101 @@
+package service
+
+import (
+	"context"
+	"sync"
+	"time"
+
+	"github.com/Wei-Shaw/sub2api/internal/pkg/logger"
+)
+
+// HoldReconcilerService refunds leaked pre-flight balance holds — the
+// crash-recovery backstop for the overdraft fix (see usage_billing_hold_tk.go).
+//
+// A hold is reserved before forward and released at request end. The normal
+// release runs in the request goroutine, so a process crash (or a panic past
+// the defer) mid-request can leave a usage_holds row with the balance still
+// reduced and no matching bill. This ticker sweeps holds older than the TTL and
+// refunds them.
+//
+// TTL must exceed the longest legitimate request duration, or a still-running
+// long stream would have its hold refunded early (losing overdraft protection
+// for that one request until it ends). 30m comfortably covers streaming; the
+// only cost of a generous TTL is that a genuinely leaked hold is refunded a bit
+// later. The refund is conservative either way — a leaked hold over-charges the
+// user (their balance is held for unrendered service), never the operator.
+type HoldReconcilerService struct {
+	applier  UsageBillingHoldApplier
+	interval time.Duration
+	ttl      time.Duration
+	batch    int
+
+	startOnce sync.Once
+	stopOnce  sync.Once
+	stopCh    chan struct{}
+}
+
+// NewHoldReconcilerService builds the reconciler. If the repository does not
+// implement the hold capability (UsageBillingHoldApplier), Start is a no-op.
+func NewHoldReconcilerService(repo UsageBillingRepository) *HoldReconcilerService {
+	applier, _ := repo.(UsageBillingHoldApplier)
+	return &HoldReconcilerService{
+		applier:  applier,
+		interval: 60 * time.Second,
+		ttl:      30 * time.Minute,
+		batch:    500,
+		stopCh:   make(chan struct{}),
+	}
+}
+
+func (s *HoldReconcilerService) Start() {
+	if s == nil || s.applier == nil {
+		return
+	}
+	s.startOnce.Do(func() {
+		logger.LegacyPrintf("service.hold_reconciler", "[HoldReconciler] started interval=%s ttl=%s batch=%d", s.interval, s.ttl, s.batch)
+		go s.runLoop()
+	})
+}
+
+func (s *HoldReconcilerService) Stop() {
+	if s == nil {
+		return
+	}
+	s.stopOnce.Do(func() {
+		close(s.stopCh)
+		logger.LegacyPrintf("service.hold_reconciler", "[HoldReconciler] stopped")
+	})
+}
+
+func (s *HoldReconcilerService) runLoop() {
+	ticker := time.NewTicker(s.interval)
+	defer ticker.Stop()
+
+	// Sweep once on start to drain anything leaked across a restart.
+	s.reconcileOnce()
+
+	for {
+		select {
+		case <-ticker.C:
+			s.reconcileOnce()
+		case <-s.stopCh:
+			return
+		}
+	}
+}
+
+func (s *HoldReconcilerService) reconcileOnce() {
+	ctx, cancel := context.WithTimeout(context.Background(), 10*time.Second)
+	defer cancel()
+
+	olderThan := time.Now().Add(-s.ttl)
+	refunded, err := s.applier.ReleaseExpiredBalanceHolds(ctx, olderThan, s.batch)
+	if err != nil {
+		logger.LegacyPrintf("service.hold_reconciler", "[HoldReconciler] sweep failed err=%v", err)
+		return
+	}
+	if refunded > 0 {
+		// Non-zero means real crash leaks were refunded — surface for ops.
+		logger.LegacyPrintf("service.hold_reconciler", "[HoldReconciler] refunded leaked holds count=%d older_than=%s", refunded, olderThan.Format(time.RFC3339))
+	}
+}

--- a/backend/internal/service/openai_gateway_service.go
+++ b/backend/internal/service/openai_gateway_service.go
@@ -6028,6 +6028,10 @@ type OpenAIRecordUsageInput struct {
 	IPAddress          string // 请求的客户端 IP 地址
 	RequestPayloadHash string
 	APIKeyService      APIKeyQuotaUpdater
+	// TkHoldRequestID is the pre-flight balance-hold key handed off by the
+	// handler at usage-task submit time; settlement consumes (refunds) it in the
+	// same transaction as the balance deduction (see usage_billing_hold_tk.go).
+	TkHoldRequestID string
 	ChannelUsageFields
 }
 
@@ -6256,6 +6260,7 @@ func (s *OpenAIGatewayService) RecordUsage(ctx context.Context, input *OpenAIRec
 			AccountRateMultiplier: accountRateMultiplier,
 			APIKeyService:         input.APIKeyService,
 			Platform:              PlatformFromAPIKey(apiKey),
+			TkHoldRequestID:       input.TkHoldRequestID,
 		}, s.billingDeps(), s.usageBillingRepo)
 		return err
 	}()

--- a/backend/internal/service/openai_gateway_service_tk_hold.go
+++ b/backend/internal/service/openai_gateway_service_tk_hold.go
@@ -1,0 +1,212 @@
+package service
+
+import (
+	"context"
+	"time"
+
+	"github.com/Wei-Shaw/sub2api/internal/pkg/logger"
+	"go.uber.org/zap"
+)
+
+// TK: pre-flight balance HOLD wiring for the OpenAI-compatible gateway (chat /
+// responses / messages / embeddings / images / video — the balance-billed
+// overdraft surface; Anthropic-native traffic is predominantly subscription,
+// which does not touch balance). Estimates an upper bound, reserves it
+// atomically before forward, and releases at request end. See
+// usage_billing_hold_tk.go for the invariant and billing_service_tk_hold.go
+// for the upper-bound formulas.
+
+// tkReserveBalanceHold reserves an upper-bound hold via the repository's narrow
+// hold capability. Returns:
+//   - held=true            → balance reserved; caller MUST release at request end.
+//   - held=false, reject=true  → insufficient balance; caller rejects with 402.
+//   - held=false, reject=false → not gated (no hold capability, or amount ≤ 0 —
+//     e.g. an unpriced chat model that bills $0 by design); let post-hoc billing
+//     proceed unchanged.
+func tkReserveBalanceHold(ctx context.Context, repo UsageBillingRepository, requestID string, userID, apiKeyID int64, amount float64) (held bool, reject bool, err error) {
+	applier, ok := repo.(UsageBillingHoldApplier)
+	if !ok {
+		return false, false, nil
+	}
+	if amount <= 0 || requestID == "" {
+		return false, false, nil
+	}
+	reserved, err := applier.ReserveBalanceHold(ctx, &HoldCommand{
+		RequestID: requestID,
+		UserID:    userID,
+		APIKeyID:  apiKeyID,
+		Amount:    amount,
+	})
+	if err != nil {
+		return false, false, err
+	}
+	if !reserved {
+		return false, true, nil
+	}
+	return true, false, nil
+}
+
+// tkReleaseBalanceHold refunds a reservation; idempotent and best-effort (the
+// hold reconciler is the backstop for any release that does not run).
+func tkReleaseBalanceHold(ctx context.Context, repo UsageBillingRepository, requestID string) {
+	applier, ok := repo.(UsageBillingHoldApplier)
+	if !ok || requestID == "" {
+		return
+	}
+	_, _ = applier.ReleaseBalanceHold(ctx, requestID)
+}
+
+// tkHoldRateMultiplier resolves the SAME user×group rate multiplier the billing
+// path applies to the balance, so the hold cannot under-estimate via a smaller
+// multiplier. Mirrors the resolution in RecordUsage (openai_gateway_service.go).
+func (s *OpenAIGatewayService) tkHoldRateMultiplier(ctx context.Context, user *User, apiKey *APIKey) float64 {
+	multiplier := 1.0
+	if s.cfg != nil && s.cfg.Default.RateMultiplier > 0 {
+		multiplier = s.cfg.Default.RateMultiplier
+	}
+	if user != nil && apiKey != nil && apiKey.GroupID != nil && s.userGroupRateResolver != nil {
+		groupDefault := 1.0
+		if apiKey.Group != nil {
+			groupDefault = apiKey.Group.RateMultiplier
+		}
+		multiplier = s.userGroupRateResolver.Resolve(ctx, user.ID, *apiKey.GroupID, groupDefault)
+	}
+	return multiplier
+}
+
+// TkReserveTokenHold estimates an upper-bound token cost and reserves it.
+// requestID must be the usage-billing request id (TkResolveUsageBillingRequestID)
+// so release/reconcile key off the same value the billed row carries. promptTokens
+// must be an UPPER BOUND on the request's input tokens (callers over-estimate);
+// embeddings pass maxOutputTokens=0.
+//
+// Returns held (caller must release at request end) and reject (caller returns
+// 402). A pricing/DB failure is fail-open (held=false, reject=false) + an ALERT
+// log: a reservation outage must not deny service (availability wins, same
+// regime as unpriced-chat serve-and-alert), it only narrows the guarantee until
+// resolved.
+func (s *OpenAIGatewayService) TkReserveTokenHold(ctx context.Context, requestID, model, serviceTier string, user *User, apiKey *APIKey, promptTokens, maxOutputTokens int) (held bool, reject bool) {
+	if s == nil || user == nil || apiKey == nil || requestID == "" {
+		return false, false
+	}
+	multiplier := s.tkHoldRateMultiplier(ctx, user, apiKey)
+	amount, err := s.billingService.EstimateTokenHold(model, serviceTier, promptTokens, maxOutputTokens, multiplier)
+	if err != nil {
+		// Unpriced model: chat bills $0 by design and serves — do not gate.
+		return false, false
+	}
+	held, reject, err = tkReserveBalanceHold(ctx, s.usageBillingRepo, requestID, user.ID, apiKey.ID, amount)
+	if err != nil {
+		logger.L().Error("openai_gateway.hold_reserve_failed",
+			zap.String("request_id", requestID),
+			zap.Int64("user_id", user.ID),
+			zap.Float64("amount", amount),
+			zap.Error(err),
+		)
+		return false, false
+	}
+	return held, reject
+}
+
+// TkReserveImageHold estimates an upper-bound image-generation cost and
+// reserves it. n is the REQUESTED image count (actual delivers ≤ n). Same
+// fail-open posture as TkReserveTokenHold.
+//
+// Upper-bound construction: billing resolves the size tier from the upstream
+// OUTPUT size (which may exceed the requested size), so the estimate takes the
+// MAX over all billing tiers (1K/2K/4K) of the same cost calculation billing
+// will run — the channel per-request/image price when channel-priced, the
+// group/litellm image price otherwise. Known gap, deliberately accepted: a
+// channel priced in TOKEN mode bills an image request by its (unboundable)
+// image-output tokens; the tier-max image estimate still collapses the
+// concurrent-overdraft amplification there, but is not a proven bound.
+func (s *OpenAIGatewayService) TkReserveImageHold(ctx context.Context, requestID, model string, user *User, apiKey *APIKey, n int) (held bool, reject bool) {
+	if s == nil || user == nil || apiKey == nil || requestID == "" {
+		return false, false
+	}
+	multiplier := resolveImageRateMultiplier(apiKey, s.tkHoldRateMultiplier(ctx, user, apiKey))
+	amount := s.tkEstimateImageHoldAmount(ctx, model, apiKey, n, multiplier)
+	held, reject, err := tkReserveBalanceHold(ctx, s.usageBillingRepo, requestID, user.ID, apiKey.ID, amount)
+	if err != nil {
+		logger.L().Error("openai_gateway.hold_reserve_failed",
+			zap.String("request_id", requestID),
+			zap.Int64("user_id", user.ID),
+			zap.Float64("amount", amount),
+			zap.Error(err),
+		)
+		return false, false
+	}
+	return held, reject
+}
+
+// tkEstimateImageHoldAmount mirrors calculateOpenAIImageCost with at-submit
+// upper-bound inputs: requested count, MAX over billing tiers.
+func (s *OpenAIGatewayService) tkEstimateImageHoldAmount(ctx context.Context, model string, apiKey *APIKey, n int, multiplier float64) float64 {
+	if n <= 0 {
+		n = 1
+	}
+	var groupConfig *ImagePriceConfig
+	if apiKey != nil && apiKey.Group != nil {
+		groupConfig = &ImagePriceConfig{
+			Price1K: apiKey.Group.ImagePrice1K,
+			Price2K: apiKey.Group.ImagePrice2K,
+			Price4K: apiKey.Group.ImagePrice4K,
+		}
+	}
+	resolved := s.resolveOpenAIChannelPricing(ctx, model, apiKey)
+	amount := 0.0
+	for _, tier := range []string{ImageBillingSize1K, ImageBillingSize2K, ImageBillingSize4K} {
+		if resolved != nil && (resolved.Mode == BillingModePerRequest || resolved.Mode == BillingModeImage) && apiKey.Group != nil {
+			gid := apiKey.Group.ID
+			cost, err := s.billingService.CalculateCostUnified(CostInput{
+				Ctx:            ctx,
+				Model:          model,
+				GroupID:        &gid,
+				RequestCount:   n,
+				SizeTier:       tier,
+				RateMultiplier: multiplier,
+				Resolver:       s.resolver,
+				Resolved:       resolved,
+			})
+			if err == nil && cost != nil {
+				amount = maxFloat(amount, cost.ActualCost)
+				continue
+			}
+		}
+		amount = maxFloat(amount, s.billingService.EstimateImageHold(model, tier, n, groupConfig, multiplier))
+	}
+	return amount
+}
+
+// TkReserveVideoHold reserves the exact cost the video submit path will bill:
+// CalculateVideoCost over the same request-derived seconds, same multiplier.
+// Same fail-open posture as TkReserveTokenHold.
+func (s *OpenAIGatewayService) TkReserveVideoHold(ctx context.Context, requestID, model string, user *User, apiKey *APIKey, seconds int64) (held bool, reject bool) {
+	if s == nil || user == nil || apiKey == nil || requestID == "" {
+		return false, false
+	}
+	multiplier := s.tkHoldRateMultiplier(ctx, user, apiKey)
+	amount := s.billingService.EstimateVideoHold(model, seconds, multiplier)
+	held, reject, err := tkReserveBalanceHold(ctx, s.usageBillingRepo, requestID, user.ID, apiKey.ID, amount)
+	if err != nil {
+		logger.L().Error("openai_gateway.hold_reserve_failed",
+			zap.String("request_id", requestID),
+			zap.Int64("user_id", user.ID),
+			zap.Float64("amount", amount),
+			zap.Error(err),
+		)
+		return false, false
+	}
+	return held, reject
+}
+
+// TkReleaseHold refunds a reservation at request end. Detaches from the
+// request context (which may already be cancelled) so the refund still runs.
+func (s *OpenAIGatewayService) TkReleaseHold(ctx context.Context, requestID string) {
+	if s == nil || requestID == "" {
+		return
+	}
+	relCtx, cancel := context.WithTimeout(context.WithoutCancel(ctx), 5*time.Second)
+	defer cancel()
+	tkReleaseBalanceHold(relCtx, s.usageBillingRepo, requestID)
+}

--- a/backend/internal/service/openai_gateway_service_tk_hold.go
+++ b/backend/internal/service/openai_gateway_service_tk_hold.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"time"
 
+	"github.com/Wei-Shaw/sub2api/internal/config"
 	"github.com/Wei-Shaw/sub2api/internal/pkg/logger"
 	"go.uber.org/zap"
 )
@@ -18,8 +19,9 @@ import (
 
 // tkReserveBalanceHold reserves an upper-bound hold via the repository's narrow
 // hold capability. Returns:
-//   - held=true            → balance reserved; caller MUST release at request end.
-//   - held=false, reject=true  → insufficient balance; caller rejects with 402.
+//   - held=true            → balance reserved; the caller owns the release
+//     (request-end refund, or hand-off to settlement).
+//   - held=false, reject=true  → insufficient balance; caller rejects with 403.
 //   - held=false, reject=false → not gated (no hold capability, or amount ≤ 0 —
 //     e.g. an unpriced chat model that bills $0 by design); let post-hoc billing
 //     proceed unchanged.
@@ -74,19 +76,25 @@ func (s *OpenAIGatewayService) tkHoldRateMultiplier(ctx context.Context, user *U
 	return multiplier
 }
 
+// tkHoldGatingDisabled reports whether hold gating is off for this deployment:
+// simple mode records usage but never bills, so a reservation would only pin
+// user money until the reconciler refunds it.
+func (s *OpenAIGatewayService) tkHoldGatingDisabled() bool {
+	return s.cfg != nil && s.cfg.RunMode == config.RunModeSimple
+}
+
 // TkReserveTokenHold estimates an upper-bound token cost and reserves it.
-// requestID must be the usage-billing request id (TkResolveUsageBillingRequestID)
-// so release/reconcile key off the same value the billed row carries. promptTokens
-// must be an UPPER BOUND on the request's input tokens (callers over-estimate);
-// embeddings pass maxOutputTokens=0.
+// requestID must be derived from the usage-billing request id
+// (TkResolveUsageBillingRequestID) so reconciliation can anchor a hold to its
+// request. promptTokens must be an UPPER BOUND on the request's input tokens
+// (callers over-estimate); embeddings pass maxOutputTokens=0.
 //
-// Returns held (caller must release at request end) and reject (caller returns
-// 402). A pricing/DB failure is fail-open (held=false, reject=false) + an ALERT
-// log: a reservation outage must not deny service (availability wins, same
-// regime as unpriced-chat serve-and-alert), it only narrows the guarantee until
-// resolved.
+// Returns held (caller owns the release) and reject (caller returns 403). A
+// pricing/DB failure is fail-open (held=false, reject=false) + an ALERT log: a
+// reservation outage must not deny service (availability wins, same regime as
+// unpriced-chat serve-and-alert), it only narrows the guarantee until resolved.
 func (s *OpenAIGatewayService) TkReserveTokenHold(ctx context.Context, requestID, model, serviceTier string, user *User, apiKey *APIKey, promptTokens, maxOutputTokens int) (held bool, reject bool) {
-	if s == nil || user == nil || apiKey == nil || requestID == "" {
+	if s == nil || user == nil || apiKey == nil || requestID == "" || s.tkHoldGatingDisabled() {
 		return false, false
 	}
 	multiplier := s.tkHoldRateMultiplier(ctx, user, apiKey)
@@ -121,7 +129,7 @@ func (s *OpenAIGatewayService) TkReserveTokenHold(ctx context.Context, requestID
 // image-output tokens; the tier-max image estimate still collapses the
 // concurrent-overdraft amplification there, but is not a proven bound.
 func (s *OpenAIGatewayService) TkReserveImageHold(ctx context.Context, requestID, model string, user *User, apiKey *APIKey, n int) (held bool, reject bool) {
-	if s == nil || user == nil || apiKey == nil || requestID == "" {
+	if s == nil || user == nil || apiKey == nil || requestID == "" || s.tkHoldGatingDisabled() {
 		return false, false
 	}
 	multiplier := resolveImageRateMultiplier(apiKey, s.tkHoldRateMultiplier(ctx, user, apiKey))
@@ -182,7 +190,7 @@ func (s *OpenAIGatewayService) tkEstimateImageHoldAmount(ctx context.Context, mo
 // CalculateVideoCost over the same request-derived seconds, same multiplier.
 // Same fail-open posture as TkReserveTokenHold.
 func (s *OpenAIGatewayService) TkReserveVideoHold(ctx context.Context, requestID, model string, user *User, apiKey *APIKey, seconds int64) (held bool, reject bool) {
-	if s == nil || user == nil || apiKey == nil || requestID == "" {
+	if s == nil || user == nil || apiKey == nil || requestID == "" || s.tkHoldGatingDisabled() {
 		return false, false
 	}
 	multiplier := s.tkHoldRateMultiplier(ctx, user, apiKey)

--- a/backend/internal/service/usage_billing.go
+++ b/backend/internal/service/usage_billing.go
@@ -39,6 +39,13 @@ type UsageBillingCommand struct {
 	APIKeyQuotaCost     float64
 	APIKeyRateLimitCost float64
 	AccountQuotaCost    float64
+
+	// TkHoldRequestID, when non-empty, is the pre-flight balance-hold ledger key
+	// this settlement must consume (refund) in the SAME transaction as the
+	// balance deduction — closing the release-before-settle gap of the overdraft
+	// fix (see usage_billing_hold_tk.go). Deliberately excluded from the billing
+	// fingerprint: a retried apply must dedup identically with or without it.
+	TkHoldRequestID string
 }
 
 func (c *UsageBillingCommand) Normalize() {

--- a/backend/internal/service/usage_billing_hold_tk.go
+++ b/backend/internal/service/usage_billing_hold_tk.go
@@ -17,12 +17,19 @@ import (
 //
 // Invariant: reserve is atomic `UPDATE users SET balance = balance - hold
 // WHERE balance >= hold`. Row-lock serialization ⇒ after admitting k concurrent
-// requests balance = B - Σholdᵢ ≥ 0, so Σholdᵢ ≤ B. At request end each releases
-// its hold; the async path bills actualᵢ. If hold is a true upper bound
-// (actualᵢ ≤ holdᵢ — guaranteed by the EstimateHold* formulas in
+// requests balance = B - Σholdᵢ ≥ 0, so Σholdᵢ ≤ B. If hold is a true upper
+// bound (actualᵢ ≤ holdᵢ — guaranteed by the EstimateHold* formulas in
 // billing_service_tk_hold.go), then final balance = B - Σactualᵢ ≥ B - Σholdᵢ ≥ 0.
 // Provably never negative. The hold's deliberate over-estimate only briefly
 // shrinks AVAILABLE balance; settlement still bills exact actual.
+//
+// Release ordering is part of the invariant: billing settles asynchronously,
+// so a hold refunded at handler return while its bill is still queued would
+// re-expose the funds to concurrent admission. Hence the hand-off protocol —
+// when a usage-record task is submitted, the handler hands refund ownership to
+// settlement (UsageBillingCommand.TkHoldRequestID) and the hold is consumed in
+// the SAME transaction as the balance deduction; only never-billed paths
+// refund at handler return, and crashes are repaid by the hold reconciler.
 //
 // Capability is consumed by type assertion (same pattern as
 // UsageBillingVideoRefundApplier) so the wide UsageBillingRepository interface
@@ -44,7 +51,7 @@ type UsageBillingHoldApplier interface {
 	// guarded by `balance >= amount` and records a usage_holds row, in one
 	// transaction. Returns (true, nil) when reserved (or a hold for this
 	// request_id already exists — idempotent), (false, nil) when the balance is
-	// insufficient (caller rejects with 402), (false, err) on a DB error.
+	// insufficient (caller rejects with 403), (false, err) on a DB error.
 	ReserveBalanceHold(ctx context.Context, cmd *HoldCommand) (reserved bool, err error)
 
 	// ReleaseBalanceHold refunds the reserved amount and deletes the hold row,

--- a/backend/internal/service/usage_billing_hold_tk.go
+++ b/backend/internal/service/usage_billing_hold_tk.go
@@ -1,0 +1,59 @@
+package service
+
+import (
+	"context"
+	"time"
+)
+
+// TK: pre-flight balance HOLD — the concurrent-overdraft fix (see tk_026).
+//
+// Balance is deducted AFTER the upstream serves a request (post-hoc) with no
+// `balance >= amount` floor, so N concurrent requests from a barely-positive
+// balance all pass admission, all get served, then all deduct — driving the
+// balance arbitrarily negative. Post-hoc anything cannot un-serve an
+// already-served request; the only fix is to RESERVE an upper-bound estimate
+// of the cost BEFORE forwarding and RELEASE it when the request ends. Actual
+// billing stays untouched on the async path.
+//
+// Invariant: reserve is atomic `UPDATE users SET balance = balance - hold
+// WHERE balance >= hold`. Row-lock serialization ⇒ after admitting k concurrent
+// requests balance = B - Σholdᵢ ≥ 0, so Σholdᵢ ≤ B. At request end each releases
+// its hold; the async path bills actualᵢ. If hold is a true upper bound
+// (actualᵢ ≤ holdᵢ — guaranteed by the EstimateHold* formulas in
+// billing_service_tk_hold.go), then final balance = B - Σactualᵢ ≥ B - Σholdᵢ ≥ 0.
+// Provably never negative. The hold's deliberate over-estimate only briefly
+// shrinks AVAILABLE balance; settlement still bills exact actual.
+//
+// Capability is consumed by type assertion (same pattern as
+// UsageBillingVideoRefundApplier) so the wide UsageBillingRepository interface
+// and its test stubs stay untouched.
+
+// HoldCommand is the money-movement half of a pre-flight reservation, applied
+// at-most-once per request_id by UsageBillingHoldApplier.
+type HoldCommand struct {
+	RequestID string  // usage-billing request id — reserve/release idempotency key
+	UserID    int64   // balance owner (subscription users do not reserve — see hold injection)
+	APIKeyID  int64   // recorded for audit/reconciliation only
+	Amount    float64 // USD reserved (> 0); released verbatim at request end
+}
+
+// UsageBillingHoldApplier is the optional narrow capability the hold path needs
+// from the usage-billing repository.
+type UsageBillingHoldApplier interface {
+	// ReserveBalanceHold atomically deducts cmd.Amount from the user balance
+	// guarded by `balance >= amount` and records a usage_holds row, in one
+	// transaction. Returns (true, nil) when reserved (or a hold for this
+	// request_id already exists — idempotent), (false, nil) when the balance is
+	// insufficient (caller rejects with 402), (false, err) on a DB error.
+	ReserveBalanceHold(ctx context.Context, cmd *HoldCommand) (reserved bool, err error)
+
+	// ReleaseBalanceHold refunds the reserved amount and deletes the hold row,
+	// in one transaction. Idempotent: a missing row returns (false, nil).
+	ReleaseBalanceHold(ctx context.Context, requestID string) (released bool, err error)
+
+	// ReleaseExpiredBalanceHolds refunds holds older than olderThan (up to batch
+	// rows) — the crash-recovery sweep for reserve/release pairs whose
+	// request-end release never ran (process crash mid-request). Returns the
+	// number of holds refunded.
+	ReleaseExpiredBalanceHolds(ctx context.Context, olderThan time.Time, batch int) (refunded int, err error)
+}

--- a/backend/internal/service/wire.go
+++ b/backend/internal/service/wire.go
@@ -448,6 +448,16 @@ func ProvideIdempotencyCleanupService(repo IdempotencyRepository, cfg *config.Co
 	return svc
 }
 
+// ProvideHoldReconcilerService builds and starts the pre-flight balance-hold
+// reconciler (crash-recovery for the overdraft fix; see
+// hold_reconciler_service.go). No-op when the repository lacks the hold
+// capability.
+func ProvideHoldReconcilerService(repo UsageBillingRepository) *HoldReconcilerService {
+	svc := NewHoldReconcilerService(repo)
+	svc.Start()
+	return svc
+}
+
 // ProvideScheduledTestService creates ScheduledTestService.
 func ProvideScheduledTestService(
 	planRepo ScheduledTestPlanRepository,
@@ -644,6 +654,7 @@ var ProviderSet = wire.NewSet(
 	ProvideIdempotencyCoordinator,
 	ProvideSystemOperationLockService,
 	ProvideIdempotencyCleanupService,
+	ProvideHoldReconcilerService,
 	ProvideScheduledTestService,
 	ProvideScheduledTestRunnerService,
 	NewGroupCapacityService,

--- a/backend/migrations/tk_026_usage_holds.sql
+++ b/backend/migrations/tk_026_usage_holds.sql
@@ -1,0 +1,36 @@
+-- TK: pre-flight balance HOLD ledger for the concurrent-overdraft fix.
+--
+-- Why: balance is deducted AFTER the upstream serves the request (post-hoc),
+-- and the deduct SQL has no `balance >= amount` floor. N concurrent requests
+-- from a barely-positive balance all pass admission, all get served, then all
+-- deduct — driving the balance arbitrarily negative. There is no way to
+-- "un-serve" an already-served request, so the only fix is to RESERVE an
+-- upper-bound estimate of the cost BEFORE forwarding (atomic `balance >= hold`
+-- guard) and RELEASE it when the request ends. Actual post-hoc billing is
+-- unchanged. Invariant: with hold >= actual, Σholds <= balance at admission,
+-- so final balance = B - Σactual >= 0 — provably never negative.
+--
+-- This table is the durable hold ledger so a reserve/release pair survives a
+-- crash and a reconciler can refund leaked holds (a process crash between
+-- reserve and the request-end release would otherwise leave balance reduced
+-- with no matching bill).
+--
+--   request_id  the usage-billing request id (same value RecordUsage persists
+--               as usage_logs.request_id) — the reserve/release idempotency key
+--               and the reconciler's cross-check anchor against the billed row.
+--   amount      USD reserved (> 0); released verbatim at request end.
+--   created_at  set at reserve; the reconciler refunds rows older than its TTL.
+CREATE TABLE IF NOT EXISTS usage_holds (
+    request_id  TEXT PRIMARY KEY,
+    user_id     BIGINT      NOT NULL,
+    api_key_id  BIGINT      NOT NULL,
+    amount      NUMERIC     NOT NULL,
+    created_at  TIMESTAMPTZ NOT NULL DEFAULT NOW()
+);
+
+-- The reconciler scans by age (oldest leaked holds first); a plain btree on
+-- created_at keeps that sweep index-only on the hot path.
+CREATE INDEX IF NOT EXISTS idx_usage_holds_created_at ON usage_holds (created_at);
+
+COMMENT ON TABLE usage_holds IS
+    'Pre-flight balance reservations (TK overdraft fix): a row exists only while a request is in flight; released (deleted) at request end or refunded by the hold reconciler after TTL. See tk_026.';

--- a/scripts/sentinels/gateway-tk.json
+++ b/scripts/sentinels/gateway-tk.json
@@ -2359,6 +2359,99 @@
         "rl.SetAnthropicSaturationCounter(cache)"
       ],
       "rationale": "Wire glue that attaches the saturation counter onto BOTH GatewayService (read) and RateLimitService (write) post-construction, keeping the upstream NewGatewayService/NewRateLimitService signatures stable. One provider, two setters — if either setter call is dropped, one half of the feature goes inert (scheduler can't read, or skip path can't write). The TKAnthropicSaturationReady sentinel forces wire to evaluate it; these anchors pin the dual-setter wiring."
+    },
+    {
+      "path": "backend/internal/handler/openai_chat_completions.go",
+      "must_contain": [
+        "hold, holdReject := h.tkApplyBalanceHold(c, apiKey, reqModel, body)",
+        "tkHoldRequestID := hold.HandOffToSettlement()",
+        "TkHoldRequestID:    tkHoldRequestID,"
+      ],
+      "rationale": "Pre-flight balance HOLD on /v1/chat/completions (PR #746 concurrent-overdraft fix): reserve before forward + hand refund ownership to the usage-record task. Dropping the reserve reopens unbounded concurrent overdraft on the busiest balance route; dropping the hand-off reopens the release-before-settle window (hold refunded while the bill is still queued). Logic lives in openai_gateway_handler_tk_hold.go; these are the thin hooks an upstream merge can silently revert."
+    },
+    {
+      "path": "backend/internal/handler/openai_gateway_handler.go",
+      "must_contain": [
+        "hold, holdReject := h.tkApplyBalanceHold(c, apiKey, reqModel, body)",
+        "h.errorResponse(c, http.StatusForbidden, \"insufficient_balance\", tkInsufficientBalanceForHoldMsg)",
+        "h.anthropicErrorResponse(c, http.StatusForbidden, \"insufficient_balance\", tkInsufficientBalanceForHoldMsg)",
+        "TkHoldRequestID:    tkHoldRequestID,"
+      ],
+      "rationale": "Pre-flight balance HOLD on /v1/responses (errorResponse-form rejection) and /v1/messages dispatch (anthropicErrorResponse-form rejection) — PR #746 overdraft fix. The two routes share the apply literal, so the per-route rejection lines are the anchors proving EACH injection survived an upstream merge, not just one of them."
+    },
+    {
+      "path": "backend/internal/handler/openai_gateway_handler.go",
+      "must_contain": [
+        "wsReserveTurnHold := func(model string, payload []byte) error {",
+        "if err := wsReserveTurnHold(reqModel, firstMessage); err != nil {",
+        "if err := wsReserveTurnHold(model, payload); err != nil {",
+        "tkHoldRequestID := turnHold.HandOffToSettlement()"
+      ],
+      "rationale": "Per-turn balance HOLD on the Responses WebSocket ingress (PR #746 review R-002): turn 1 reserves pre-loop from firstMessage, later turns reserve in BeforeRequest, AfterTurn hands each turn's refund to its usage-record task. WS bills per turn on balance, so losing any of these silently reopens the overdraft bypass through the WS surface."
+    },
+    {
+      "path": "backend/internal/handler/openai_gateway_embeddings_images.go",
+      "must_contain": [
+        "hold, holdReject := h.tkApplyBalanceHoldNoOutput(c, apiKey, reqModel, body)",
+        "hold, holdReject := h.tkApplyImageHold(c, apiKey, reqModel, int(gjson.GetBytes(body, \"n\").Int()))",
+        "tkHoldRequestID := hold.HandOffToSettlement()"
+      ],
+      "rationale": "Pre-flight balance HOLD on /v1/embeddings (no-output estimate — embeddings have no max_tokens, the 200k output fallback would over-reserve 1000x) and /v1/images/generations compat route (requested count at tier-max price). PR #746 overdraft fix; thin hooks into upstream-shaped handlers."
+    },
+    {
+      "path": "backend/internal/handler/openai_images.go",
+      "must_contain": [
+        "hold, holdReject := h.tkApplyImageHold(c, apiKey, requestModel, parsed.N)",
+        "tkHoldRequestID := hold.HandOffToSettlement()",
+        "TkHoldRequestID:    tkHoldRequestID,"
+      ],
+      "rationale": "Pre-flight balance HOLD on the OpenAI Images API route (JSON + multipart): reserve parsed.N images at tier-max price before forward, hand refund to the mandatory usage-record task. PR #746 overdraft fix."
+    },
+    {
+      "path": "backend/internal/repository/usage_billing_repo.go",
+      "must_contain": [
+        "tkConsumeBalanceHoldInTx(ctx, tx, cmd.TkHoldRequestID)"
+      ],
+      "rationale": "Settlement-side hold consumption INSIDE the billing transaction (PR #746 review R-001): balance leaves applyUsageBillingEffects as B + hold − actual in one atomic step. Removing this single call silently reverts the overdraft fix to the broken release-before-settle shape — every handed-off hold would leak to the 30m reconciler and the funds-re-exposure window would return. The helper lives in usage_billing_repo_tk_hold.go; this is the one-line hook."
+    },
+    {
+      "path": "backend/internal/service/openai_gateway_service.go",
+      "must_contain": [
+        "TkHoldRequestID string",
+        "TkHoldRequestID:       input.TkHoldRequestID,"
+      ],
+      "rationale": "Hold hand-off threading (PR #746): OpenAIRecordUsageInput.TkHoldRequestID carries the handler's hold key into RecordUsage and onto postUsageBillingParams. If an upstream merge drops the field or the assignment, holds are never consumed at settle — compile may still pass if both vanish together, so the literals are pinned."
+    },
+    {
+      "path": "backend/internal/service/gateway_service.go",
+      "must_contain": [
+        "TkHoldRequestID string",
+        "TkHoldRequestID:    strings.TrimSpace(p.TkHoldRequestID),"
+      ],
+      "rationale": "Hold hand-off threading (PR #746): postUsageBillingParams.TkHoldRequestID → UsageBillingCommand inside buildUsageBillingCommand. Same silent-revert risk as the openai_gateway_service.go entry — both sides of the thread are pinned."
+    },
+    {
+      "path": "backend/internal/service/usage_billing.go",
+      "must_contain": [
+        "TkHoldRequestID string"
+      ],
+      "rationale": "UsageBillingCommand.TkHoldRequestID is the contract the repository's settlement transaction consumes the hold by (PR #746). Deliberately excluded from the billing fingerprint; losing the field severs handler→settlement hand-off."
+    },
+    {
+      "path": "backend/internal/service/wire.go",
+      "must_contain": [
+        "func ProvideHoldReconcilerService(repo UsageBillingRepository) *HoldReconcilerService {",
+        "ProvideHoldReconcilerService,"
+      ],
+      "rationale": "Hold reconciler DI registration (PR #746): the crash-recovery sweep that refunds leaked holds. If the provider drops out of ProviderSet together with its cleanup parameter, the build still compiles — and every crash-leaked hold pins user balance forever. Sentinel makes the silent-consistent deletion loud."
+    },
+    {
+      "path": "backend/cmd/server/wire.go",
+      "must_contain": [
+        "holdReconciler *service.HoldReconcilerService,",
+        "{\"HoldReconcilerService\", func() error {"
+      ],
+      "rationale": "Hold reconciler shutdown hook in provideCleanup (PR #746): forces wire to construct (and therefore start) the reconciler and stops its ticker at shutdown. Same silent-consistent-deletion risk as the service/wire.go entry."
     }
   ]
 }


### PR DESCRIPTION
## 问题

余额扣费是**后置**的（上游服务完后才 `RecordUsage` 扣费），且扣费 SQL 没有 `balance >= amount` 下限。N 个并发请求从一个余额勉强为正的账户出发：全部通过准入 → 全部被上游服务 → 全部扣费，余额被打到**任意负值**。已被服务的请求无法"反服务"，后置路径上无解。

## 方案：转发前预扣 HOLD + 结算事务内消费

转发前以原子 `UPDATE users SET balance = balance - hold WHERE balance >= hold` 预留费用**上界**；实际计费照旧走异步路径精确结算。

**不变量**：行锁串行化保证并发准入后 `Σholdᵢ ≤ B`；只要 hold ≥ actual（估价公式逐项构造为上界），最终余额 `B - Σactualᵢ ≥ 0`，可证不为负。过度预留只短暂收窄可用余额，结算始终按实际成本。

**释放时序是不变量的一部分**（review R-001）：计费异步结算，若 handler 结束即退还 hold，账单还在队列里时资金会重新暴露给并发准入。因此采用**交棒协议**——handler 提交 usage-record task 时把退款所有权交给结算（`OpenAIRecordUsageInput.TkHoldRequestID` → `UsageBillingCommand`），hold 在与余额扣费**同一事务**内被消费（`balance = B + hold − actual` 原子完成）；只有未计费路径由 defer 释放；crash 由对账器兜底（TTL 30m，方向只多还用户）。

## 实现（§5 收敛模式：逻辑全在 companion 文件，上游文件只留薄注入点）

| 层 | 文件 | 内容 |
|---|---|---|
| 迁移 | `tk_026_usage_holds.sql` | 持久 hold 台账（request_id 主键） |
| 仓储 | `usage_billing_repo_tk_hold.go` | Reserve/Release/ReleaseExpired + `tkConsumeBalanceHoldInTx`（结算事务内消费），单事务原子、幂等、`SKIP LOCKED` 扫表 |
| 估价 | `billing_service_tk_hold.go` | token：输入按最贵单价 × prompt 上界、输出按 max_tokens 上限、长上下文/service-tier 超覆盖；image：请求张数 × tier-max 价；video：按提交秒数精确 |
| 服务 | `openai_gateway_service_tk_hold.go` | 预留/释放 + 与计费同源的 rate multiplier；simple 模式（不计费）跳过；能力经类型断言消费，宽接口与测试桩零改动 |
| 接线 | `openai_gateway_handler_tk_hold.go` | `tkHoldHandle` 交棒句柄 + chat / responses / messages / embeddings / images(JSON+multipart) / video submit / **Responses WebSocket（每 turn）** 七个余额计费入口；订阅请求跳过 |
| 兜底 | `hold_reconciler_service.go` | 周期回灌 crash 泄漏的 hold |

**Fail-open 姿态**：估价失败（未定价 chat 模型本就 \$0 计费）或 DB 故障时不拦截、只告警——预留通道故障不应变成拒绝服务，与现有 unpriced-chat serve-and-alert 同一姿态。

**已知缺口（代码注释中显式声明）**：
- channel 以 TOKEN 模式计价的 image 请求按 image-output tokens 计费、无法预先界定上界，hold 用 tier-max 图价近似——仍消解并发放大，但非可证上界。
- **残留面（建议 follow-up PR）**：anthropic / gemini / antigravity 原生网关的余额计费入口暂未接 hold（Anthropic-native 流量以订阅为主，订阅不走余额）；本 PR 覆盖 OpenAI-compat 网关全部余额入口。

## 测试

- 单测：估价上界性质（token 分布扫描 / tier / multiplier / image 少交付 / video 同秒）、`tkParseMaxOutputTokens` 三种字段拼写、交棒后 defer 失效 + nil 安全
- 集成（testcontainers PG）：floor 拒绝 + 幂等 + 释放、**并发预留余额永不为负**、**结算事务原子消费 hold**、过期 hold 回灌
- `go test -tags=unit ./...`、`-tags=integration ./...`、`golangci-lint`、`scripts/preflight.sh` 全绿

markers: no-web-impact / upstream-touch-guarded（见 commit message）

🤖 Generated with [Claude Code](https://claude.com/claude-code)