### PR TITLE
feat(sentinels): 新增 TK 承重面强制覆写防护——pure-insertion 不再豁免新文件

### DIFF
--- a/.github/workflows/marker-acknowledgement-pr.yml
+++ b/.github/workflows/marker-acknowledgement-pr.yml
@@ -22,6 +22,10 @@ name: Marker Acknowledgement (PR surface)
 #   Trigger narrowing also lives in the scripts: pure-insertion diffs
 #   (no deleted lines — cannot drop an upstream symbol) and i18n locale
 #   dictionaries are auto-accepted, so most benign PRs never need a marker.
+#   Exception: a newly ADDED hotspot file (new *_tk_*.go companion, bridge
+#   file, TK frontend module) is pure-insertion by definition but is a brand
+#   new load-bearing surface with zero sentinel coverage — the registry gate
+#   requires sentinel anchors or sentinel-registry-reviewed for it.
 #
 # Marker tokens (put ONE in the PR description when the gate asks):
 #   upstream-touch-guarded / upstream-touch-trivial / upstream-merge /

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -314,6 +314,12 @@ section only records sub2api-specific choices.
     surface for newapi MUST add a sentinel entry in the same commit. See
     `docs/approved/newapi-as-fifth-platform.md` § 12 for the registry
     doctrine (categories, double-trigger, evolution discipline).
+    Mechanized for ALL platforms by
+    `scripts/sentinels/check-registry-update-gate.py`: a newly ADDED
+    hotspot file (new `*_tk_*.go` companion, bridge file, TK frontend
+    module) fails the marker-acknowledgement CI gate unless the PR adds
+    sentinel anchor(s) for it or carries `sentinel-registry-reviewed`
+    in the PR description — pure-insertion no longer exempts new files.
   When adding a new sub2api-only check, append it to `scripts/preflight.sh`
   (NEVER edit the dev-rules template — it is shared across all consumer
   projects). If the check turns out to be useful for more than just

--- a/scripts/preflight.sh
+++ b/scripts/preflight.sh
@@ -645,9 +645,15 @@ echo "=== sub2api: sentinel registry update gate (advisory locally) ==="
 # deadlock (benign pure-insertion / i18n PRs paid stash+force-push tax). The
 # script prints guidance but exits 0; the HARD gate runs in CI against the PR
 # body (.github/workflows/marker-acknowledgement-pr.yml + upstream-merge-pr-shape
-# Check 12). Pure-insertion / i18n changes are auto-accepted by the script.
+# Check 12). Pure-insertion edits of EXISTING files / i18n changes are
+# auto-accepted by the script; newly ADDED hotspot files (new TK companions /
+# bridge files / TK frontend modules) are NOT — a new load-bearing surface
+# must gain sentinel anchors or carry sentinel-registry-reviewed in the PR body.
 if ! command -v python3 >/dev/null 2>&1; then
     echo "  FAIL: python3 not on PATH (required for sentinel registry update gate)"
+    errors=$((errors + 1))
+elif ! python3 ./scripts/sentinels/check-registry-update-gate.py --selftest >/dev/null; then
+    echo "  FAIL: check-registry-update-gate.py self-test failed"
     errors=$((errors + 1))
 elif ! MARKER_GATE_ADVISORY=1 python3 ./scripts/sentinels/check-registry-update-gate.py --quiet; then
     # advisory mode never returns non-zero; this branch only fires on a hard

--- a/scripts/sentinels/check-registry-update-gate.py
+++ b/scripts/sentinels/check-registry-update-gate.py
@@ -8,6 +8,22 @@ merge 覆写防护门禁". Existing sentinel checkers prove that current literal
 still present; this checker proves that PRs changing known hotspot files also
 update the relevant registry in the same branch.
 
+Two trigger shapes:
+
+  1. EDIT with deletions — a hotspot/sentinel-covered file changed and at
+     least one line was deleted (an anchored literal may have been dropped).
+     Pure-insertion edits of EXISTING files stay exempt: they cannot remove
+     an anchor.
+  2. NEW load-bearing surface — a newly ADDED file matches a hotspot pattern
+     (new `*_tk_*.go` companion, new bridge file, new TK composable /
+     constants module). New files are pure-insertion by definition, so
+     without this trigger they sail through every marker gate with zero
+     sentinel coverage — exactly the recurring post-review ask "增加 upstream
+     merge 覆写防护门禁". The author must either pin anchors for the new
+     surface (and ideally its injection point in the upstream file) in a
+     sentinel registry, or acknowledge with the `sentinel-registry-reviewed`
+     marker in the PR description.
+
 Exit codes:
   0 — no hotspot/sentinel-covered source changed, or matching registry changed.
   1 — source changed without a matching sentinel registry update.
@@ -79,6 +95,15 @@ HOTSPOT_PATTERNS: dict[str, list[str]] = {
     "backend/internal/integration/newapi/**/*.go": ["scripts/sentinels/newapi.json"],
     "backend/internal/**/*_tk_*.go": ["scripts/sentinels/newapi.json", "scripts/sentinels/gateway-tk.json"],
     "backend/internal/relay/bridge/*.go": ["scripts/sentinels/newapi.json"],
+    # Generic TK-only frontend conventions (mirror of the override-marker
+    # EXCLUDE list): these files are invisible to the upstream-override gate
+    # by design, so THIS gate is the only thing forcing sentinel coverage for
+    # a brand-new TK frontend surface. fnmatch `*` crosses `/`, so the
+    # admin/tk pattern covers nested files too.
+    "frontend/src/composables/useTk*.ts": ["scripts/sentinels/frontend-tk.json"],
+    "frontend/src/constants/*.tk.ts": ["scripts/sentinels/frontend-tk.json"],
+    "frontend/src/components/admin/tk/*.vue": ["scripts/sentinels/frontend-tk.json"],
+    "frontend/src/api/admin/tk/*.ts": ["scripts/sentinels/frontend-tk.json"],
 }
 
 
@@ -131,6 +156,23 @@ def working_tree_changed_files() -> set[str]:
         proc = run_git(args)
         changed.update(line.strip() for line in proc.stdout.splitlines() if line.strip())
     return changed
+
+
+def added_files(base: str, head: str) -> set[str]:
+    """Newly ADDED paths across the same three sources `changed_files` /
+    `deletion_counts` read (committed range, working tree, index)."""
+    added: set[str] = set()
+    sources = (
+        ["diff", "--name-only", "--diff-filter=A", f"{base}...{head}"],
+        ["diff", "--name-only", "--diff-filter=A"],
+        ["diff", "--cached", "--name-only", "--diff-filter=A"],
+    )
+    for args in sources:
+        proc = run_git(args, check=False)
+        if proc.returncode != 0:
+            continue
+        added.update(line.strip() for line in proc.stdout.splitlines() if line.strip())
+    return added
 
 
 def commit_messages(base: str, head: str) -> str:
@@ -217,9 +259,67 @@ def matching_hotspot_registries(path: str) -> set[str]:
     return registries
 
 
+def required_registries(path: str, deleted: int, is_added: bool, covered: set[str]) -> set[str]:
+    """Pure per-path verdict (no git / IO, unit-tested by --selftest).
+    Returns the registries this path obliges the PR to update (empty set =
+    no obligation). Obligation triggers:
+      - covered/hotspot file changed WITH deletions (an anchor may be gone), or
+      - hotspot-matching file is NEWLY ADDED (a brand-new load-bearing TK
+        surface with zero sentinel coverage — pure-insertion must NOT exempt
+        it, that is the exact shape that previously sailed through).
+    """
+    if I18N_LOCALE_RE.match(path):
+        return set()
+    hotspot = matching_hotspot_registries(path)
+    related = covered | hotspot
+    if not related:
+        return set()
+    if deleted == 0 and not (is_added and hotspot):
+        return set()  # pure-insertion edit of an existing file — cannot drop an anchor
+    return related
+
+
 def compact(items: Iterable[str]) -> str:
     values = sorted(set(items))
     return ", ".join(values) if values else "(none)"
+
+
+def run_selftest() -> int:
+    nj = "scripts/sentinels/newapi.json"
+    gj = "scripts/sentinels/gateway-tk.json"
+    fj = "scripts/sentinels/frontend-tk.json"
+    cases = [
+        # (path, deleted, is_added, covered, expected_required)
+        # EDIT with deletions on a hotspot → obligation
+        ("backend/internal/service/foo_tk_bar.go", 3, False, set(), {nj, gj}),
+        # pure-insertion EDIT of an existing hotspot → exempt (unchanged behavior)
+        ("backend/internal/service/foo_tk_bar.go", 0, False, set(), set()),
+        # NEW hotspot file, pure-insertion → obligation (the new trigger)
+        ("backend/internal/service/foo_tk_bar.go", 0, True, set(), {nj, gj}),
+        ("backend/internal/relay/bridge/new_relay.go", 0, True, set(), {nj}),
+        ("frontend/src/composables/useTkNewThing.ts", 0, True, set(), {fj}),
+        ("frontend/src/constants/newThing.tk.ts", 0, True, set(), {fj}),
+        ("frontend/src/components/admin/tk/NewPanel.vue", 0, True, set(), {fj}),
+        # NEW file that matches no hotspot → exempt (override gate's domain)
+        ("backend/internal/handler/plain.go", 0, True, set(), set()),
+        # sentinel-covered (non-hotspot) path: deletions oblige, insertion doesn't
+        ("backend/internal/server/routes/gateway.go", 2, False, {gj}, {gj}),
+        ("backend/internal/server/routes/gateway.go", 0, False, {gj}, set()),
+        # i18n always exempt
+        ("frontend/src/i18n/locales/en.ts", 9, False, set(), set()),
+    ]
+    failed = 0
+    for i, (path, deleted, is_added, covered, expect) in enumerate(cases):
+        got = required_registries(path, deleted, is_added, covered)
+        status = "PASS" if got == expect else "FAIL"
+        if got != expect:
+            failed += 1
+        print(f"  {status} case {i}: {path} deleted={deleted} added={is_added} → {sorted(got)}")
+    if failed:
+        print(f"registry-update-gate selftest: {failed} case(s) FAILED", file=sys.stderr)
+        return 1
+    print("ok: registry-update-gate selftest passed")
+    return 0
 
 
 def main() -> int:
@@ -230,7 +330,12 @@ def main() -> int:
     parser.add_argument("--pr-body", default="",
                         help="PR description text; a review marker here satisfies the gate "
                              "(mutable surface — CI passes the PR body)")
+    parser.add_argument("--selftest", action="store_true",
+                        help="run the pure-logic self-test and exit")
     args = parser.parse_args()
+
+    if args.selftest:
+        return run_selftest()
 
     # Advisory mode: local pre-commit/pre-push cannot see the in-flight commit
     # message or the PR body, so a hard block there is a structural false
@@ -260,23 +365,22 @@ def main() -> int:
     coverage = covered_paths_by_registry()
     changed_registries = {p for p in changed if fnmatch.fnmatch(p, REGISTRY_GLOB)}
     # Pure-insertion paths (no deletions anywhere) cannot remove a load-bearing
-    # symbol → no anchor can have been dropped → safe to auto-accept.
+    # symbol → no anchor can have been dropped → safe to auto-accept, EXCEPT
+    # newly ADDED hotspot files: a brand-new load-bearing TK surface has zero
+    # sentinel coverage, and "pure insertion" is its normal shape.
     deletions = deletion_counts(base, args.head)
-    violations: list[tuple[str, set[str], set[str]]] = []
+    added = added_files(base, args.head)
+    violations: list[tuple[str, set[str], set[str], bool]] = []
 
     for path in sorted(changed):
         if fnmatch.fnmatch(path, REGISTRY_GLOB):
             continue
-        if I18N_LOCALE_RE.match(path):
-            continue  # i18n locale dictionaries excluded outright
-        if deletions.get(path, 0) == 0:
-            continue  # pure-insertion — implicit sentinel-registry-reviewed
-        related = {registry for registry, paths in coverage.items() if path in paths}
-        related.update(matching_hotspot_registries(path))
+        covered = {registry for registry, paths in coverage.items() if path in paths}
+        related = required_registries(path, deletions.get(path, 0), path in added, covered)
         if not related:
             continue
         if changed_registries.isdisjoint(related):
-            violations.append((path, related, changed_registries))
+            violations.append((path, related, changed_registries, path in added))
 
     if not violations:
         if not args.quiet:
@@ -304,20 +408,24 @@ def main() -> int:
     prefix = "advisory (not blocking — CI enforces on PR body)" if advisory else "FAIL"
     print(f"sentinel registry update gate: {prefix}", file=stream)
     print(
-        "  Load-bearing TK/NewAPI surfaces changed (with deletions) without updating the matching sentinel registry.",
+        "  Load-bearing TK/NewAPI surfaces changed (with deletions, or newly added) "
+        "without updating the matching sentinel registry.",
         file=stream,
     )
-    for path, related, seen in violations:
-        print(f"  - {path}", file=stream)
+    for path, related, seen, is_new in violations:
+        tag = " [NEW load-bearing surface]" if is_new else ""
+        print(f"  - {path}{tag}", file=stream)
         print(f"      update one of: {compact(related)}", file=stream)
         print(f"      changed registries in this diff: {compact(seen)}", file=stream)
     print(
         "  Fix (any one): "
-        "(a) make the change pure-insertion (no deleted lines); "
-        "(b) add/adjust the relevant sentinel literal in the same PR; "
+        "(a) for EDITED files: make the change pure-insertion (no deleted lines); "
+        "(b) add sentinel anchor(s) for the surface in the same PR — for a NEW "
+        "TK companion, anchor BOTH the new file and its injection line in the "
+        "upstream file; "
         "(c) put one of these markers in the PR description: "
         + ", ".join(SENTINEL_GATE_MARKERS)
-        + " — use marker only when you reviewed the hotspots and confirmed no anchor change is required.",
+        + " — use marker only when you reviewed the surface and confirmed no anchor is required.",
         file=stream,
     )
     return 0 if advisory else 1


### PR DESCRIPTION
## 背景

「增加 upstream merge 覆写防护门禁」此前每次都要在 PR review 之后人工提出。根因：`check-registry-update-gate.py` 对 pure-insertion（零删除行）无条件放行，而**新增的 TK 承重面（新 `*_tk_*.go` companion、bridge 文件、TK 前端模块）天然就是 pure-insertion**——门禁永远不开火，判断责任落回人工。

## 改动

- **新触发形态**：新增(A)且匹配 hotspot pattern 的文件，即使零删除也要求二选一——①同 PR 在 `scripts/sentinels/*.json` 加锚点（建议同时钉住 companion 文件与其在 upstream 文件里的注入行）；②PR body 携带 `sentinel-registry-reviewed`。CI 硬门禁复用既有 `marker-acknowledgement-pr.yml`，零新基础设施。
- **既有行为不变**：存量文件的 pure-insertion 编辑、i18n 词典仍然豁免（#697 收窄不回退）。
- 补 frontend TK 通用约定 hotspot pattern（`useTk*.ts` / `*.tk.ts` / `components/admin/tk` / `api/admin/tk`）——这些路径被 override-marker 门禁设计性排除，本门禁是它们唯一的覆盖防护入口。
- 新增 `required_registries()` 纯判定函数 + `--selftest`（11 case），接入 preflight（与 `upstream-override-marker.py --selftest` 同构）。
- 同步 preflight / workflow 注释与 CLAUDE.md §10 说明。

## 验证

- `--selftest` 11/11 PASS
- 端到端模拟：staged 新增 `backend/internal/service/zz_tk_probe.go` → 门禁 FAIL 并标注 `[NEW load-bearing surface]`；PR body 加 marker → PASS
- `scripts/preflight.sh` 全绿（含本门禁 advisory 自跑）

## 覆写防护门禁自检（本 PR）

本 PR 仅触及 `scripts/`、`.github/workflows/`、`CLAUDE.md`，无 upstream-shaped 路径、无新增承重面、无 hotspot 删改——两道 marker 门禁均不开火，无需 sentinel 锚点。merge-gate-parity 脚本清单未变化，parity 检查通过。

no-web-impact

🤖 Generated with [Claude Code](https://claude.com/claude-code)