### PR TITLE
fix(ops): edge-health 告警态势分层——0账号边降为 no-accounts posture，SPOF 集变化进状态键

### DIFF
--- a/.cursor/skills/tokenkey-online-log-troubleshooting/SKILL.md
+++ b/.cursor/skills/tokenkey-online-log-troubleshooting/SKILL.md
@@ -334,7 +334,7 @@ bash ops/observability/scan-edge-health.sh --with-prod --since 15h  # 含 prod +
 bash ops/observability/scan-edge-health.sh --edges us3,us6          # 子集
 ```
 
-输出一张按严重度排序的表：每 edge `schedulable_accounts / served_200 / no_available_429 / ratio / wait_timeout / SPOF / verdict(healthy|thin|degraded|down|idle)`，并附 ACTION（down/degraded/unreachable）与 RISK（单账号 SPOF）摘要。**判定来自 edge 自身 access-log，不受 §0 trap 9 的 prod upstream-429 污染。** verdict 逻辑在纯函数 `edge_health_verdict.py`（`--selftest` fixtures 钉死六个真 edge + 边界，已进 preflight），阈值 + rationale 在 `edge-health-thresholds.json`。
+输出一张按严重度排序的表：每 edge `schedulable_accounts / served_200 / no_available_429 / ratio / wait_timeout / SPOF / verdict(healthy|thin|idle-thin|degraded|down|idle|no-accounts)`，并附 ACTION（down/degraded/unreachable）、RISK（单账号 SPOF）与 PLAN（no-accounts：0 账号且无被拒流量，补号或下线的态势待办，不算事故）摘要。**判定来自 edge 自身 access-log，不受 §0 trap 9 的 prod upstream-429 污染。** verdict 逻辑在纯函数 `edge_health_verdict.py`（`--selftest` fixtures 钉死六个真 edge + 边界，已进 preflight），阈值 + rationale 在 `edge-health-thresholds.json`。
 
 `group.rpm_limit` 与 `user_group_rate_multipliers` 由 admin UI 维护，不由本 skill 派生（按 memory「group.rpm_limit 与 account 字段独立」）；如需读 group 状态请直接看 admin UI，不要在 SKILL 里写漂移容易的 SELECT。
 

--- a/.github/workflows/edge-health-watch.yml
+++ b/.github/workflows/edge-health-watch.yml
@@ -10,9 +10,10 @@ name: Edge Health Watch
 # Read-only: GHA -> AWS STS (OIDC) -> SSM `docker logs` + `psql SELECT` via
 # scan-edge-health.sh. Never deploys, writes config, edits secrets, or mutates AWS.
 # The ONLY outbound side effect is a Feishu text post, and only when the actionable
-# (down/degraded/unreachable) edge set CHANGES vs the previous run (state-diff dedup
-# via the Actions cache) — so a multi-hour incident does not re-spam, and a recovery
-# posts a green all-clear.
+# (down/degraded/unreachable) OR posture (thin/idle-thin/no-accounts) edge set CHANGES
+# vs the previous run (state-diff dedup via the Actions cache) — so a multi-hour
+# incident or a chronically thin fleet does not re-spam, posture drift posts one 🟡
+# notice, and a recovery posts a green all-clear.
 #
 # Cadence caveat: GitHub scheduled workflows are best-effort and can run late or skip
 # under load — this is detection-latency insurance, not a hard SLA. If a tighter SLA
@@ -126,7 +127,7 @@ jobs:
 
           SHOULD=$(python3 -c "import json;print(json.load(open('decision.json'))['should_alert'])")
           if [ "$SHOULD" != "True" ]; then
-            echo "no actionable-set change since last run — not posting."
+            echo "no actionable/posture set change since last run — not posting."
             exit 0
           fi
           if [ "$DRY_RUN" = "true" ]; then

--- a/ops/observability/edge-health-alert.py
+++ b/ops/observability/edge-health-alert.py
@@ -15,12 +15,19 @@ multi-account edge (us5) buckled under concentrated failover load; ~3445 clients
 (scan-edge-health.sh, #640) only runs when a human remembers to run it. This turns
 "someone has to go look" into "Feishu shouts the moment an edge dies".
 
-Trigger model: the ACTIONABLE set is the edges whose verdict is down / degraded /
-unreachable / parse-error (a `thin` single-account edge is shown for context but is
-chronic for most of the fleet, so it does NOT trigger on its own). The state key is a
-stable digest of that set; the workflow alerts ONLY when the key changes vs the
-previous run — new breakage, escalation, OR full recovery — so a multi-hour incident
-does not re-spam every cycle, and a recovery posts a green all-clear.
+Trigger model — two tiers, both deduped by one state key:
+  ACTIONABLE (incident): verdict down / degraded / unreachable / parse-error.
+    Present => 🔴 critical/warning.
+  POSTURE (provisioning risk): verdict thin / idle-thin (single-account SPOF) and
+    no-accounts (zero accounts provisioned, no rejected demand — e.g. uk2/uk3 awaiting
+    the add-accounts vs decommission decision). Chronic states that must not pin the
+    fleet to critical, but whose SET CHANGES are exactly the early warnings the
+    2026-06-07 incident lacked (an edge slipping 2→1 accounts is the step BEFORE
+    down). Posture-only changes => 🟡 notice.
+The state key digests BOTH sets (`a:` / `p:` prefixed); the workflow alerts ONLY when
+the key changes vs the previous run — new breakage, escalation, posture drift, OR
+recovery — so a multi-hour incident (or a chronically thin fleet) does not re-spam
+every cycle, and a recovery posts a green all-clear.
 
 Input (stdin): one verdict JSON object per line (scan-edge-health.sh --json).
 Args:
@@ -40,6 +47,7 @@ import json
 import sys
 
 ACTIONABLE = ("down", "degraded", "unreachable", "parse-error")
+POSTURE = ("thin", "idle-thin", "no-accounts")
 _SEV_ORDER = {"down": 0, "unreachable": 0, "parse-error": 0, "degraded": 1}
 
 
@@ -53,29 +61,44 @@ def _num(v, default=0):
 def build_decision(rows: list, prev_key: str, window: str) -> dict:
     """Pure: verdict rows + previous state key -> alert decision + message."""
     actionable = [r for r in rows if r.get("verdict") in ACTIONABLE]
-    # Stable key: sorted "verdict:edge" of the actionable set. Same incident => same
-    # key => no re-alert; any change (new edge, recovery) flips it.
-    key_parts = sorted(f"{r.get('verdict')}:{r.get('edge')}" for r in actionable)
-    key = "|".join(key_parts)  # "" when the fleet is clean
+    posture = [r for r in rows if r.get("verdict") in POSTURE]
+    # Stable key: sorted "a:verdict:edge" (incident) + "p:verdict:edge" (posture).
+    # Same incident AND same posture => same key => no re-alert; any change (new edge
+    # down, an edge slipping to single-account, posture resolved, recovery) flips it.
+    key_parts = sorted(f"a:{r.get('verdict')}:{r.get('edge')}" for r in actionable) + \
+        sorted(f"p:{r.get('verdict')}:{r.get('edge')}" for r in posture)
+    key = "|".join(key_parts)  # "" when the fleet is fully clean
 
     changed = key != (prev_key or "")
-    should_alert = changed  # breakage, escalation, AND recovery all flip the key
+    should_alert = changed  # breakage, escalation, posture drift, recovery all flip the key
 
     # `idle-thin` (a single-account edge with no traffic) is a SPOF too — surface it
     # in the thin context line, not silently dropped.
     thin = sorted(r.get("edge") for r in rows if r.get("verdict") in ("thin", "idle-thin"))
+    no_accounts = sorted(r.get("edge") for r in rows if r.get("verdict") == "no-accounts")
     healthy = sorted(
         r.get("edge") for r in rows if r.get("verdict") in ("healthy", "idle")
     )
 
+    # Legacy keys (pre-posture) carried unprefixed actionable entries — treat any
+    # non-`p:` part as actionable so the first run after the format change still
+    # reads "there WAS an incident" for recovery semantics.
+    prev_had_actionable = any(
+        part and not part.startswith("p:") for part in (prev_key or "").split("|")
+    )
     if not actionable:
-        severity = "recovery" if (prev_key or "") else "ok"
+        if posture:
+            # Incident over but provisioning risk remains => green recovery head if an
+            # incident just cleared, otherwise a posture-drift notice.
+            severity = "recovery" if prev_had_actionable else "notice"
+        else:
+            severity = "recovery" if (prev_key or "") else "ok"
     elif any(r.get("verdict") in ("down", "unreachable", "parse-error") for r in actionable):
         severity = "critical"
     else:
         severity = "warning"
 
-    message = _format_message(actionable, thin, healthy, window)
+    message = _format_message(actionable, thin, no_accounts, healthy, window, severity)
     return {
         "key": key,
         "actionable_count": len(actionable),
@@ -107,7 +130,9 @@ def _classify(r: dict) -> tuple:
     noavail = _num(r.get("no_available_429"))
     if verdict == "down":
         if sched == 0 and total == 0:
-            return ("未配置账号", "该 edge 没有任何账号——需新增账号，或确认是否应下线该 edge")
+            # The quiet (no-demand) zero-account state is verdict no-accounts (posture)
+            # and never reaches here; down+total=0 means clients ARE eating 429s.
+            return ("未配置账号·流量被拒", "该 edge 没有任何账号且仍有请求打到这——紧急补号，或把 prod 镜像/DNS 流量从该 edge 摘除")
         if sched == 0 and noavail == 0:
             return ("池刚空·尚未拒单(领先告警)",
                     "账号已全部不可调度但还没开始 429——下一批请求即将掉单，按下方排查三连逐账号定位")
@@ -138,11 +163,14 @@ def _needs_triage_runbook(actionable: list) -> bool:
 _VERDICT_ZH = {"down": "宕机", "unreachable": "不可达", "parse-error": "解析失败", "degraded": "降级"}
 
 
-def _format_message(actionable: list, thin: list, healthy: list, window: str) -> str:
-    if not actionable:
-        head = "✅ TokenKey 边缘健康 — 全部恢复（无 宕机/降级）"
-    else:
+def _format_message(actionable: list, thin: list, no_accounts: list, healthy: list,
+                    window: str, severity: str) -> str:
+    if actionable:
         head = f"🔴 TokenKey 边缘健康 — {len(actionable)} 个 edge 需要处理"
+    elif severity == "notice":
+        head = "🟡 TokenKey 边缘健康 — 账号配备风险变化（无宕机/降级）"
+    else:
+        head = "✅ TokenKey 边缘健康 — 全部恢复（无 宕机/降级）"
     lines = [head, ""]
 
     grouped: dict = {}
@@ -183,9 +211,12 @@ def _format_message(actionable: list, thin: list, healthy: list, window: str) ->
         lines.append("  2. schedulable=false 被钉死: OAuth 健康+无冷却却调度关闭 → admin UI 手动启用（无自愈）")
         lines.append("  3. OAuth 吊销: refresh 报成功仍 401 → 重新授权/换号，重刷无效")
 
-    if thin:
+    if (thin or no_accounts) and lines[-1] != "":
         lines.append("")
+    if thin:
         lines.append(f"薄边/SPOF（单账号，应补到 ≥2）: {', '.join(thin)}")
+    if no_accounts:
+        lines.append(f"未配置账号（0 账号、无被拒流量——补号或下线，决策前不按宕机告警）: {', '.join(no_accounts)}")
     if healthy:
         lines.append(f"健康: {', '.join(healthy)}")
     lines.append("")
@@ -222,7 +253,7 @@ _case(
         {"edge": "us3", "verdict": "down"},
         {"edge": "us5", "verdict": "degraded"},
     ],
-    "degraded:us5|down:uk2|down:uk3|down:us3",
+    "a:degraded:us5|a:down:uk2|a:down:uk3|a:down:us3",
     {"should_alert": False, "severity": "critical"},
 )
 _case(
@@ -234,7 +265,7 @@ _case(
         {"edge": "us6", "verdict": "down"},
         {"edge": "us5", "verdict": "degraded"},
     ],
-    "degraded:us5|down:uk2|down:uk3|down:us3",
+    "a:degraded:us5|a:down:uk2|a:down:uk3|a:down:us3",
     {"should_alert": True, "severity": "critical"},
 )
 _case(
@@ -243,7 +274,25 @@ _case(
         {"edge": "uk2", "verdict": "healthy", "schedulable_accounts": 2},
         {"edge": "us5", "verdict": "healthy", "schedulable_accounts": 3},
     ],
-    "degraded:us5|down:uk2|down:uk3|down:us3",
+    "a:degraded:us5|a:down:uk2|a:down:uk3|a:down:us3",
+    {"should_alert": True, "severity": "recovery", "actionable_count": 0},
+)
+_case(
+    "legacy unprefixed prev key (pre-posture format) still reads as incident => recovery",
+    [
+        {"edge": "uk2", "verdict": "healthy", "schedulable_accounts": 2},
+        {"edge": "us5", "verdict": "healthy", "schedulable_accounts": 3},
+    ],
+    "degraded:us5|down:uk2",
+    {"should_alert": True, "severity": "recovery", "actionable_count": 0},
+)
+_case(
+    "incident recovers but SPOF posture remains => green recovery head, key keeps posture",
+    [
+        {"edge": "uk2", "verdict": "healthy", "schedulable_accounts": 2},
+        {"edge": "us2", "verdict": "thin", "schedulable_accounts": 1},
+    ],
+    "a:down:uk2|p:thin:us2",
     {"should_alert": True, "severity": "recovery", "actionable_count": 0},
 )
 _case(
@@ -256,14 +305,43 @@ _case(
     {"should_alert": False, "severity": "ok", "actionable_count": 0},
 )
 _case(
-    "chronic thin alone does NOT trigger",
+    "posture drift: thin set first seen => ONE notice alert",
     [
         {"edge": "uk1", "verdict": "thin", "schedulable_accounts": 1},
         {"edge": "us2", "verdict": "thin", "schedulable_accounts": 1},
         {"edge": "prod", "verdict": "healthy"},
     ],
     "",
-    {"should_alert": False, "actionable_count": 0},
+    {"should_alert": True, "severity": "notice", "actionable_count": 0},
+)
+_case(
+    "chronic thin unchanged => silence (deduped via p: key)",
+    [
+        {"edge": "uk1", "verdict": "thin", "schedulable_accounts": 1},
+        {"edge": "us2", "verdict": "thin", "schedulable_accounts": 1},
+        {"edge": "prod", "verdict": "healthy"},
+    ],
+    "p:thin:uk1|p:thin:us2",
+    {"should_alert": False, "severity": "notice", "actionable_count": 0},
+)
+_case(
+    "uk2/uk3 zero-account posture unchanged => silence, NOT chronic critical",
+    [
+        {"edge": "uk2", "verdict": "no-accounts", "schedulable_accounts": 0, "total_accounts": 0},
+        {"edge": "uk3", "verdict": "no-accounts", "schedulable_accounts": 0, "total_accounts": 0},
+        {"edge": "prod", "verdict": "healthy"},
+    ],
+    "p:no-accounts:uk2|p:no-accounts:uk3",
+    {"should_alert": False, "severity": "notice", "actionable_count": 0},
+)
+_case(
+    "posture resolved (account added, SPOF gone) => notice alert announces the change",
+    [
+        {"edge": "uk1", "verdict": "healthy", "schedulable_accounts": 2},
+        {"edge": "us2", "verdict": "thin", "schedulable_accounts": 1},
+    ],
+    "p:thin:uk1|p:thin:us2",
+    {"should_alert": True, "severity": "notice", "actionable_count": 0},
 )
 _case(
     "unreachable edge => critical actionable",
@@ -281,8 +359,8 @@ _case(
 _MESSAGE_CASES = []
 
 
-def _msg_case(name, rows, must_contain, must_not_contain=()):
-    _MESSAGE_CASES.append((name, rows, must_contain, must_not_contain))
+def _msg_case(name, rows, must_contain, must_not_contain=(), prev_key=""):
+    _MESSAGE_CASES.append((name, rows, must_contain, must_not_contain, prev_key))
 
 
 _msg_case(
@@ -302,11 +380,31 @@ _msg_case(
     ["池刚空·尚未拒单"],
 )
 _msg_case(
-    "no-accounts down (total=0) => 未配置账号, NO 排查三连 runbook",
+    "down with total=0 AND rejected demand => 未配置账号·流量被拒, NO 排查三连 runbook",
     [{"edge": "fra1", "verdict": "down", "schedulable_accounts": 0, "total_accounts": 0,
-      "served_200": 0, "no_available_429": 0}],
-    ["未配置账号"],
+      "served_200": 0, "no_available_429": 412}],
+    ["未配置账号·流量被拒", "紧急补号"],
     ["排查三连"],
+)
+_msg_case(
+    "posture-only (thin + no-accounts) => 🟡 notice head with both posture lines",
+    [
+        {"edge": "uk1", "verdict": "thin", "schedulable_accounts": 1},
+        {"edge": "uk2", "verdict": "no-accounts", "schedulable_accounts": 0, "total_accounts": 0},
+        {"edge": "prod", "verdict": "healthy", "schedulable_accounts": 14},
+    ],
+    ["🟡", "账号配备风险变化", "薄边/SPOF（单账号，应补到 ≥2）: uk1", "未配置账号（0 账号", "uk2"],
+    ["🔴", "全部恢复", "宕机（down）"],
+)
+_msg_case(
+    "incident cleared with posture residue => ✅ recovery head + posture lines",
+    [
+        {"edge": "uk2", "verdict": "healthy", "schedulable_accounts": 2},
+        {"edge": "us2", "verdict": "thin", "schedulable_accounts": 1},
+    ],
+    ["✅", "全部恢复", "薄边/SPOF（单账号，应补到 ≥2）: us2"],
+    ["🔴", "🟡"],
+    prev_key="a:down:uk2|p:thin:us2",
 )
 _msg_case(
     "unreachable => 探测不可达 action, no runbook",
@@ -333,8 +431,8 @@ def _run_selftest() -> int:
                 break
         else:
             print(f"  [ok] {name}", file=sys.stderr)
-    for name, rows, must_contain, must_not_contain in _MESSAGE_CASES:
-        msg = build_decision(rows, "", "2h")["message"]
+    for name, rows, must_contain, must_not_contain, prev_key in _MESSAGE_CASES:
+        msg = build_decision(rows, prev_key, "2h")["message"]
         missing = [s for s in must_contain if s not in msg]
         present = [s for s in must_not_contain if s in msg]
         if missing or present:

--- a/ops/observability/edge_health_verdict.py
+++ b/ops/observability/edge_health_verdict.py
@@ -1,6 +1,6 @@
 #!/usr/bin/env python3
 """edge_health_verdict.py — turn the read-only edge probe output into a deterministic
-edge-health verdict (healthy | thin | degraded | down | idle | no-accounts).
+edge-health verdict (healthy | thin | idle-thin | degraded | down | idle | no-accounts).
 
 This is the *logic* half; the *transport* half is the read-only bash probe
 `probe-edge-health.sh` (delivered to each edge host via run-probe.sh), and the

--- a/ops/observability/edge_health_verdict.py
+++ b/ops/observability/edge_health_verdict.py
@@ -1,6 +1,6 @@
 #!/usr/bin/env python3
 """edge_health_verdict.py — turn the read-only edge probe output into a deterministic
-edge-health verdict (healthy | thin | degraded | down | idle).
+edge-health verdict (healthy | thin | degraded | down | idle | no-accounts).
 
 This is the *logic* half; the *transport* half is the read-only bash probe
 `probe-edge-health.sh` (delivered to each edge host via run-probe.sh), and the
@@ -75,7 +75,16 @@ def compute_verdict(accounts: list, traffic: dict, thresholds: dict) -> dict:
 
     # Verdict precedence — most-severe wins. Each branch carries a `reason` so the
     # table is self-explaining and the selftest pins the exact boundary that fired.
-    if n_sched == 0:
+    #
+    # total==0 is PROVISIONING POSTURE, not an incident — as long as nothing is being
+    # rejected. uk2/uk3 (2026-06: registered Stage0 stacks awaiting the add-accounts vs
+    # decommission decision) sat at total=0 with served_200≈720/2h — exactly the 10s
+    # health-check cadence, zero real demand — yet read `down` and pinned every alert
+    # cycle to critical. The moment demand DOES hit an unprovisioned edge
+    # (no_available_429 > 0), it falls through to `down`: clients are eating 429s.
+    if n_total == 0 and no_avail == 0:
+        verdict, reason = "no-accounts", "no accounts provisioned and no rejected demand (posture: add accounts or decommission)"
+    elif n_sched == 0:
         verdict, reason = "down", "no schedulable accounts (empty pool by construction)"
     elif denom == 0:
         # No served traffic AND no empty-pool signal in the window => nothing to judge
@@ -181,6 +190,24 @@ _SELFTEST_CASES = [
         "no schedulable accounts => down",
         [{"schedulable": False, "name": "a1"}, {"schedulable": False, "name": "a2"}],
         {"served_200": 0, "no_available_429": 0, "total_completed": 0},
+        "down",
+    ),
+    (
+        "uk2 shape: zero accounts, health-check 200s only, no rejected demand => no-accounts",
+        [],
+        {"served_200": 719, "no_available_429": 0, "total_completed": 719, "since": "2h"},
+        "no-accounts",
+    ),
+    (
+        "zero accounts, fully idle => no-accounts",
+        [],
+        {"served_200": 0, "no_available_429": 0, "total_completed": 0, "since": "2h"},
+        "no-accounts",
+    ),
+    (
+        "zero accounts BUT demand being rejected => still down (clients eating 429)",
+        [],
+        {"served_200": 0, "no_available_429": 412, "total_completed": 412, "since": "2h"},
         "down",
     ),
     (

--- a/ops/observability/scan-edge-health.sh
+++ b/ops/observability/scan-edge-health.sh
@@ -117,11 +117,11 @@ for line in open(sys.argv[1], encoding="utf-8"):
 
 # sort: most severe first
 order = {"down": 0, "unreachable": 0, "parse-error": 0, "degraded": 1,
-         "thin": 2, "idle-thin": 3, "idle": 4, "healthy": 5}
+         "thin": 2, "no-accounts": 3, "idle-thin": 4, "idle": 5, "healthy": 6}
 rows.sort(key=lambda r: (order.get(r.get("verdict"), 9), r.get("edge") or ""))
 
 hdr = ("EDGE", "VERDICT", "SCHED", "SERVED_200", "NO_AVAIL_429", "RATIO", "WAIT_TO", "SPOF")
-w = (6, 10, 6, 11, 13, 7, 8, 5)
+w = (6, 11, 6, 11, 13, 7, 8, 5)
 def fmt(vals): return "  ".join(str(v).ljust(width) for v, width in zip(vals, w))
 print(fmt(hdr))
 for r in rows:
@@ -139,11 +139,14 @@ for r in rows:
 print()
 # loud summary of the edges that need action
 bad = [r for r in rows if r.get("verdict") in ("down", "degraded", "unreachable")]
-spof = [r for r in rows if r.get("single_account_risk") and r.get("verdict") not in ("down","unreachable")]
+spof = [r for r in rows if r.get("single_account_risk") and r.get("verdict") not in ("down","unreachable","no-accounts")]
+noacct = [r for r in rows if r.get("verdict") == "no-accounts"]
 if bad:
     print("ACTION — down/degraded/unreachable:", ", ".join(r.get("edge","?") for r in bad))
 if spof:
     print("RISK   — single-account (SPOF):    ", ", ".join(r.get("edge","?") for r in spof))
-if not bad and not spof:
+if noacct:
+    print("PLAN   — no accounts provisioned:  ", ", ".join(r.get("edge","?") for r in noacct), "(add accounts or decommission)")
+if not bad and not spof and not noacct:
     print("all edges healthy with >=2 schedulable accounts")
 PY


### PR DESCRIPTION
## 问题（本次 Feishu 告警暴露的两个对偶缺口）

今晨告警把 uk2/uk3 列为 🔴 宕机「未配置账号——需新增账号或下线」。但 `served200=719/720 per 2h` 恰好是每 10 秒一次的健康检查探活，`noavail429=0` 说明**没有任何请求在被拒**——这是「补号 vs 下线」的配备态势待办，不是事故。现状下它们：

1. **永久占据 actionable 集** → 告警永远 critical，且其它任何边抖动（状态键变化）都连带重播 uk2/uk3「宕机」。
2. 反向缺口：真正的配备风险 **SPOF 薄边集合变化**（2→1 新增单点、补号脱险）从不进状态键，完全无感知——而「边滑向单账号」正是 2026-06-07 事故（4 边归零、us5 被集中 failover 压垮）之前缺失的领先信号。

## 方案：态势（posture）与事故（incident）分层，共用一把去重状态键

| 层 | verdict | 触发 | 头 |
|---|---|---|---|
| 事故 | down / degraded / unreachable / parse-error | 集合变化即告警 | 🔴 critical/warning |
| 态势 | thin / idle-thin / **no-accounts**（新） | 集合变化发一次 | 🟡 notice |

- `edge_health_verdict.py`：`total_accounts==0 && noavail429==0` → 新态势 verdict `no-accounts`；**护栏**：`total==0` 但仍有流量被拒（noavail>0）→ 维持 `down`（客户端正在吃 429，文案升级为「未配置账号·流量被拒——紧急补号或摘流」）。
- `edge-health-alert.py`：状态键改为 `a:…|p:…` 两段；legacy 无前缀键按事故解读，保证升级后第一拍的恢复语义正确（实测：旧键 `down:uk2|down:uk3` → 一次 ✅ recovery + posture 风险清单，之后静默）；事故清除但残留 posture 保持 ✅ recovery 头 + 风险行，posture-only 变化为 🟡 notice。
- `scan-edge-health.sh`：人读表格/汇总加 `no-accounts`（`PLAN —` 行），`RISK — SPOF` 行不再混入零账号边。

## 验证

- `edge_health_verdict.py --selftest`：15 例全绿（新增 uk2 健康检查形态、纯 idle 零账号、被拒流量护栏 3 例）。
- `edge-health-alert.py --selftest`：19 例全绿（新增 legacy 键迁移、posture 首见/去重/脱险、recovery 残留 posture 等 7 例；原「chronic thin 不触发」语义按设计翻转为「首见 notice 一次 + 之后去重静默」）。
- 端到端复演本次告警的真实 fleet 形态（uk2/uk3 0 账号 + 4 thin + 4 healthy）：第一拍 ✅ recovery 一次，第二拍 should_alert=false。
- `scripts/preflight.sh` PASS。

仅动 `ops/observability/` 三件套 + selftest，无 Go/前端改动（no-web-impact）。workflow 只消费 `should_alert/key/message`，新增 severity `notice` 无消费侧改动。

no-upstream-touch

🤖 Generated with [Claude Code](https://claude.com/claude-code)