### PR TITLE
fix(gateway): drop default body-size guard; rely on upstream reject codes (403/413) for alerting

### DIFF
--- a/backend/internal/config/config.go
+++ b/backend/internal/config/config.go
@@ -708,10 +708,11 @@ const (
 
 // UpstreamBodyGuardConfig TK: 上游大请求体软门禁规则（按 platform + model_prefix 匹配）。
 //
-// 背景：实测发现 anthropic claude-opus-4-7 上游对 body ≥ ~940KB 的请求直接 403（无 anthropic JSON），
-// 同账号同模型同窗口下 ≤ 400KB 的请求 200 成功。默认对该模型预填 warn=600KB / reject=900KB，
-// 让大请求在 forward 之前 fail-fast，避免 (a) 消耗 OAuth 配额，(b) 污染 ops 错误统计，
-// (c) 让客户端拿到可操作的 hint（/compact 或新会话）。
+// 背景：按客户端字节预拦是错误的代理指标。2026-06-13 复验 opus-4-7 与 opus-4-8 均能正常服务 >1MB 请求
+// （实测至 1.03MB / ~317K input tokens、HTTP 200），原 ~940KB 的 403 拐点（PR #322 / 2026-05-20 edge:us1
+// 单点观测）不再复现；Anthropic 侧超限是 413@32MB、403 属 permission/WAF 类，故旧 403 是 WAF/数据中心 IP
+// 的边缘条件而非稳定尺寸上限。**默认不再预填任何规则**（default off），改为依赖上游真实拒绝码（403/413）的
+// 反应式告警。本机制保留供运维按需配置（opt-in）：在 gateway.upstream_body_guards 显式配规则才生效。
 //
 // 匹配规则：
 //   - Platform 必须等于 account.Platform（如 "anthropic" / "openai" / "gemini"）。
@@ -1597,19 +1598,12 @@ func load(allowMissingJWTSecret bool) (*Config, error) {
 		cfg.Gateway.OpenAIWS.StickyResponseIDTTLSeconds = cfg.Gateway.OpenAIWS.StickyPreviousResponseTTLSeconds
 	}
 
-	// TK: upstream body guards 默认值。
-	// 未配置时填充 anthropic claude-opus-4-7 默认规则，基于 edge:us1 实测数据：
-	// body ≤ ~400KB 成功，≥ ~940KB 上游 403。要禁用默认规则，请显式在 yaml 中配 1 条 reject_bytes=0 / warn_bytes=0 的同 platform/model_prefix 规则。
-	if len(cfg.Gateway.UpstreamBodyGuards) == 0 {
-		cfg.Gateway.UpstreamBodyGuards = []UpstreamBodyGuardConfig{
-			{
-				Platform:    "anthropic",
-				ModelPrefix: "claude-opus-4-7",
-				WarnBytes:   600000,
-				RejectBytes: 900000,
-			},
-		}
-	}
+	// TK: upstream body guards 默认 OFF——不再预填任何规则。
+	// 按客户端字节预拦是错误的代理指标：2026-06-13 复验 opus-4-7 与 opus-4-8 均能正常服务 >1MB 请求
+	// （实测至 1.03MB / ~317K input tokens、HTTP 200），原 ~940KB 的 403 拐点（PR #322 / 2026-05-20
+	// edge:us1 单点观测）不再复现；Anthropic 侧超限是 413@32MB、403 属 permission/WAF 类，故旧 403 是
+	// WAF/数据中心 IP 的边缘条件而非稳定尺寸上限。默认不再预拦，改为依赖上游真实拒绝码（403/413）的反应式
+	// 告警（见 ops_error_logs / edge-health）。机制保留供运维按需在 gateway.upstream_body_guards 配置。
 	for i := range cfg.Gateway.UpstreamBodyGuards {
 		cfg.Gateway.UpstreamBodyGuards[i].Platform = strings.TrimSpace(cfg.Gateway.UpstreamBodyGuards[i].Platform)
 		cfg.Gateway.UpstreamBodyGuards[i].ModelPrefix = strings.TrimSpace(cfg.Gateway.UpstreamBodyGuards[i].ModelPrefix)

--- a/backend/internal/config/config_test.go
+++ b/backend/internal/config/config_test.go
@@ -89,21 +89,14 @@ func TestLoadDefaultUpstreamBodyGuards(t *testing.T) {
 		t.Fatalf("Load() error: %v", err)
 	}
 
-	if len(cfg.Gateway.UpstreamBodyGuards) != 1 {
-		t.Fatalf("UpstreamBodyGuards len = %d, want 1", len(cfg.Gateway.UpstreamBodyGuards))
-	}
-	g := cfg.Gateway.UpstreamBodyGuards[0]
-	if g.Platform != "anthropic" {
-		t.Fatalf("default guard Platform = %q, want anthropic", g.Platform)
-	}
-	if g.ModelPrefix != "claude-opus-4-7" {
-		t.Fatalf("default guard ModelPrefix = %q, want claude-opus-4-7", g.ModelPrefix)
-	}
-	if g.WarnBytes != 600000 {
-		t.Fatalf("default guard WarnBytes = %d, want 600000", g.WarnBytes)
-	}
-	if g.RejectBytes != 900000 {
-		t.Fatalf("default guard RejectBytes = %d, want 900000", g.RejectBytes)
+	// Default OFF: TK no longer pre-injects an opus-4-7 body guard. Pre-flighting
+	// on client byte count is the wrong proxy (2026-06-13 re-validation: opus-4-7
+	// and opus-4-8 both serve >1 MB with HTTP 200); a returning size cliff is
+	// caught reactively via upstream 403/413 in ops_error_logs. The mechanism is
+	// opt-in — operators add rules via gateway.upstream_body_guards in yaml.
+	if len(cfg.Gateway.UpstreamBodyGuards) != 0 {
+		t.Fatalf("default UpstreamBodyGuards len = %d, want 0 (default off after 2026-06-13 re-validation): %+v",
+			len(cfg.Gateway.UpstreamBodyGuards), cfg.Gateway.UpstreamBodyGuards)
 	}
 }
 

--- a/backend/internal/handler/gateway_handler_tk_body_guard.go
+++ b/backend/internal/handler/gateway_handler_tk_body_guard.go
@@ -11,13 +11,19 @@ package handler
 // logic lives in this file so the upstream-shaped entry files stay 1-line
 // hooks.
 //
-// Why this exists: edge:us1 observed claude-opus-4-7 upstream 403s
-// concentrated entirely on body >= ~940 KB requests (same OAuth account,
-// same model, same window). claude-cli/2.1.144 then retries the same body
-// 3x before giving up, wasting OAuth quota and polluting ops_error_logs.
-// Defaults (loaded by config.load() when gateway.upstream_body_guards is
-// absent) warn at 600 KB and reject at 900 KB for anthropic claude-opus-4-7;
-// operators can override per-(platform, model_prefix) via yaml.
+// Why this exists (and why it ships DEFAULT OFF): pre-flighting on client byte
+// count is the wrong proxy metric. The original 900 KB reject came from a
+// single 2026-05-20 edge:us1 observation (PR #322) of claude-opus-4-7 upstream
+// 403s on bodies >= ~940 KB. Re-validated 2026-06-13: opus-4-7 AND opus-4-8
+// both serve >1 MB requests (tested up to 1.03 MB / ~317K input tokens) with
+// HTTP 200 on the current fleet — the ~940 KB 403 cliff no longer reproduces.
+// Per Anthropic, oversize is 413 @ 32 MB and 403 is permission/WAF-class, so
+// the old 403 was a WAF/datacenter-IP edge condition, not a stable size limit.
+// So TK injects NO default guard; a returning size cliff is caught reactively
+// via the upstream's real reject codes (403/413) surfaced in ops_error_logs /
+// edge-health. This mechanism is retained as an OPT-IN operator tool: it is a
+// pure no-op until an operator configures gateway.upstream_body_guards
+// per-(platform, model_prefix) in yaml.
 //
 // Contract:
 //   - Function does NOT write a response — each platform uses its own error


### PR DESCRIPTION
## What & why

Pre-flighting upstream requests on **client byte count** is the wrong proxy metric. The original opus-4-7 body guard (PR #322, default `warn=600KB / reject=900KB`) was built on a **single 2026-05-20 edge:us1 observation** of upstream 403s on bodies ≥ ~940 KB. That cliff no longer reproduces, so this PR **drops the default guard entirely** and relies on the upstream's real reject codes (403/413) for alerting.

### Empirical re-validation (2026-06-13)

- **opus-4-8 (no guard)** — 1 MB text (~280K input tokens) + 1 MB image → **HTTP 200**.
- **opus-4-7 (guard temporarily disabled on idle edge us3, restored after)** — 900 KB / 980 KB / 1.03 MB → **HTTP 200**, `input_tokens` up to **317,802**.
- **Infra audit** — edge Caddy `request_body max_size=100MB`; Go `MaxBytesReader=256MB`; edges are **not** behind Cloudflare → there is **no TK ~1 MB proxy cap**. Anthropic side: oversize is **413 @ 32 MB**; a **403 is permission/WAF-class**, not a stable size limit.

Conclusion: the old ~940 KB 403 was a WAF / datacenter-IP edge condition, not an Anthropic size ceiling. Byte-threshold pre-flight is the wrong tool.

## Part A — drop the default guard (default OFF)

- Removed the `config.load()` default-injection block that pre-filled the anthropic/`claude-opus-4-7` guard when `gateway.upstream_body_guards` was empty. TK now ships with **no** body guard → no pre-flight byte block by default.
- **Kept the mechanism** as an opt-in operator tool: `TkEvalBodyGuard`, `UpstreamBodyGuardConfig`, the `gateway.upstream_body_guards` config field, and all 7 call sites. They early-return as a no-op when `len(guards)==0`. This is "default off", **not** a feature deletion (§5.x satisfied; it is TK-authored anyway).
- Updated the WHY comments (`config.go` struct doc + removed injection site; `gateway_handler_tk_body_guard.go` header) and the default-config test to assert the default `UpstreamBodyGuards` is **empty**. Handler-level tests that build their own guard structs are unchanged.

## Part B — alerting on upstream reject codes (already covered, no code change)

Investigated `ops_error_logger_tk_client_induced_upstream.go` + `classifyOpsErrorLog` + `ops-error-triage.sh`. **Removing the guard is safe — a returning size cliff is already visible to alerting:**

1. **Faithful recording (independent of classification):** when upstream returns 403/413, `ops_error_logger.go` populates `entry.UpstreamStatusCode` and `entry.UpstreamErrors[]` **unconditionally** from `OpsUpstreamStatusCodeKey` / `OpsUpstreamErrorsKey` (lines ~818, ~969-1005). The caller-fault classification only flips `phase`/`error_owner` — it never suppresses the recorded `upstream_status_code`.
2. **403 → auto-alerting:** a genuine Anthropic 403 (oversize / permission / WAF) does **not** match `service.IsCanonicalIngressUARejectMessage`, so `tkUpstreamClientInducedRejection` returns `false` → stays `phase=upstream`, `error_owner=provider` → **counts toward `upstream_error_rate`** and fires the existing provider-health P0 alert.
3. **413 → recorded + visible in triage:** 413 `request_too_large` is deliberately classified caller-fault (kept out of `upstream_error_rate` so one client looping oversized bodies can't page on-call — its original #602-boundary purpose). It is **not** dropped: `ops/observability/ops-error-triage.sh` `by_status` and especially `upstream_events` (which reads `upstream_status_code` straight from the `upstream_errors` JSONB, lines 133-154) surface any cluster of upstream 413 regardless of classification.

So a returning size cliff surfaces either as an `upstream_error_rate`-counted **403** (automatic alert) or as a **413** cluster in `ops-error-triage.sh`. No new code was needed.

## Verification

- `cd backend && go build ./...` — pass
- `cd backend && go test -tags=unit ./...` — full suite pass
- `golangci-lint run` on `internal/config/...` + `internal/handler/...` — 0 issues
- `bash scripts/preflight.sh` — PASS (commit carries `no-web-impact` + `no-upstream-touch`)

## Notes for reviewer

- **Merge mode: Squash and merge** (§5.y, TK-originated fix).
- `sentinel-registry-reviewed`: the sentinel update gate flagged `gateway_handler_tk_body_guard.go` as an edited TK hotspot with deletions; the deletions are **comment-only** (WHY block) — no anchor line or functional symbol removed — so no sentinel anchor change is required.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
