### PR TITLE
fix(gateway): newapi/openai 不服务模型名→400(非空池429) + 补 qwen-max/plus 定价

### DIFF
--- a/backend/internal/handler/gateway_handler_tk_count_tokens_failover.go
+++ b/backend/internal/handler/gateway_handler_tk_count_tokens_failover.go
@@ -65,8 +65,8 @@ func (h *GatewayHandler) forwardCountTokensWithFailover(
 			}
 			reqLog.Warn("gateway.count_tokens_select_account_failed", zap.Error(err))
 			markOpsRoutingCapacityLimitedIfNoAvailable(c, err)
-			tkStatus, tkMsg := tkSelectFailureStatusMessage(c, err)
-			h.errorResponse(c, tkStatus, "api_error", tkMsg)
+			tkStatus, tkType, tkMsg := tkSelectFailureStatusMessage(c, err, parsedReq.Model)
+			h.errorResponse(c, tkStatus, tkType, tkMsg)
 			return
 		}
 		setOpsSelectedAccount(c, account.ID, account.Platform)

--- a/backend/internal/handler/no_available_accounts_tk.go
+++ b/backend/internal/handler/no_available_accounts_tk.go
@@ -1,8 +1,10 @@
 package handler
 
 import (
+	"errors"
 	"net/http"
 
+	"github.com/Wei-Shaw/sub2api/internal/service"
 	"github.com/gin-gonic/gin"
 )
 
@@ -41,7 +43,21 @@ func tkNoAvailableAccounts(c *gin.Context) int {
 
 // tkSelectFailureStatusMessage maps a FIRST-attempt account-selection error
 // (len(failedAccountIDs)==0, no upstream attempt was made yet) to the
-// client-facing (status, message) pair.
+// client-facing (status, errType, message) triple. errType is the JSON error
+// envelope "type" the caller should write (OpenAI-compat: "invalid_request_error"
+// for 4xx client faults, "api_error" otherwise).
+//
+// Unsupported model — service.ErrUnsupportedModel: the scheduler determined NO
+// account in the pool serves this model NAME (e.g. a legacy/typo'd id like
+// "deepseek-chat" or "qwen-max" when the matched newapi pool only maps
+// "deepseek-v4-pro" / "qwen3.7-*"). That is a CLIENT error, not capacity, so it
+// gets 400 invalid_request_error (parity with the anthropic path's
+// tkWriteUnsupportedModelIfApplicable). Surfacing it as 400 keeps it client-owned
+// (phase=request, out of upstream_error_rate) instead of an empty-pool 429 that
+// reads as a capacity signal and fires ops alerts (prod 2026-06-13: a client
+// hammering unservable deepseek/qwen names produced 8× empty-pool 429). Checked
+// FIRST: ErrUnsupportedModel's message deliberately omits "no available accounts"
+// so isOpsNoAvailableAccountError does not also match it.
 //
 // Empty pool — the "no available accounts" error family, classified by
 // isOpsNoAvailableAccountError, the exact predicate ops logging already uses in
@@ -54,9 +70,12 @@ func tkNoAvailableAccounts(c *gin.Context) int {
 // This converged the openai/newapi compat handlers with the anthropic path,
 // which adopted the 429 semantics in #575; before this helper the two branches
 // of the same handler disagreed (selection==nil → 429, select error → 503).
-func tkSelectFailureStatusMessage(c *gin.Context, err error) (int, string) {
-	if isOpsNoAvailableAccountError(err) {
-		return tkNoAvailableAccounts(c), "No available accounts: " + err.Error()
+func tkSelectFailureStatusMessage(c *gin.Context, err error, reqModel string) (int, string, string) {
+	if errors.Is(err, service.ErrUnsupportedModel) {
+		return http.StatusBadRequest, service.TkUnsupportedModelErrType, service.TkUnsupportedModelMessage(reqModel)
 	}
-	return http.StatusServiceUnavailable, "Service temporarily unavailable"
+	if isOpsNoAvailableAccountError(err) {
+		return tkNoAvailableAccounts(c), "api_error", "No available accounts: " + err.Error()
+	}
+	return http.StatusServiceUnavailable, "api_error", "Service temporarily unavailable"
 }

--- a/backend/internal/handler/no_available_accounts_tk_test.go
+++ b/backend/internal/handler/no_available_accounts_tk_test.go
@@ -30,9 +30,10 @@ func TestTkSelectFailureStatusMessage(t *testing.T) {
 
 	t.Run("no_available_accounts_sentinel_returns_429_with_retry_after", func(t *testing.T) {
 		c, w := newCtx(t)
-		status, msg := tkSelectFailureStatusMessage(c, service.ErrNoAvailableAccounts)
+		status, errType, msg := tkSelectFailureStatusMessage(c, service.ErrNoAvailableAccounts, "gpt-5.2")
 
 		require.Equal(t, http.StatusTooManyRequests, status)
+		assert.Equal(t, "api_error", errType)
 		assert.Equal(t, tkNoAvailableAccountsRetryAfterSeconds, w.Header().Get("Retry-After"))
 		assert.Contains(t, msg, "No available accounts")
 	})
@@ -40,16 +41,33 @@ func TestTkSelectFailureStatusMessage(t *testing.T) {
 	t.Run("wrapped_no_available_accounts_returns_429", func(t *testing.T) {
 		c, w := newCtx(t)
 		wrapped := fmt.Errorf("%w supporting model: gpt-5.2 (channel pricing restriction)", service.ErrNoAvailableAccounts)
-		status, msg := tkSelectFailureStatusMessage(c, wrapped)
+		status, errType, msg := tkSelectFailureStatusMessage(c, wrapped, "gpt-5.2")
 
 		require.Equal(t, http.StatusTooManyRequests, status)
+		assert.Equal(t, "api_error", errType)
 		assert.Equal(t, tkNoAvailableAccountsRetryAfterSeconds, w.Header().Get("Retry-After"))
 		assert.Contains(t, msg, "gpt-5.2")
 	})
 
+	t.Run("unsupported_model_returns_400_invalid_request", func(t *testing.T) {
+		// The scheduler determined no account in the pool serves this model NAME
+		// (e.g. a client sending "deepseek-chat" to a pool mapping only
+		// "deepseek-v4-*"). That is a client error → 400 invalid_request_error, NOT
+		// an empty-pool 429, so it never reads as a capacity signal / fires alerts.
+		c, w := newCtx(t)
+		wrapped := fmt.Errorf("%w: deepseek-chat (total=1 eligible=0 ...)", service.ErrUnsupportedModel)
+		status, errType, msg := tkSelectFailureStatusMessage(c, wrapped, "deepseek-chat")
+
+		require.Equal(t, http.StatusBadRequest, status)
+		assert.Equal(t, service.TkUnsupportedModelErrType, errType)
+		assert.Equal(t, service.TkUnsupportedModelMessage("deepseek-chat"), msg)
+		// Must NOT carry the 429 capacity backoff hint.
+		assert.Empty(t, w.Header().Get("Retry-After"))
+	})
+
 	t.Run("no_available_compact_accounts_returns_429", func(t *testing.T) {
 		c, _ := newCtx(t)
-		status, _ := tkSelectFailureStatusMessage(c, service.ErrNoAvailableCompactAccounts)
+		status, _, _ := tkSelectFailureStatusMessage(c, service.ErrNoAvailableCompactAccounts, "gpt-5.2")
 
 		require.Equal(t, http.StatusTooManyRequests, status)
 	})
@@ -58,16 +76,17 @@ func TestTkSelectFailureStatusMessage(t *testing.T) {
 		// Relay-hop case: the upstream TokenKey edge serialized the sentinel into a
 		// plain message; the substring classifier must still catch it.
 		c, _ := newCtx(t)
-		status, _ := tkSelectFailureStatusMessage(c, errors.New("scheduler: no available openai accounts in group 7"))
+		status, _, _ := tkSelectFailureStatusMessage(c, errors.New("scheduler: no available openai accounts in group 7"), "gpt-5.2")
 
 		require.Equal(t, http.StatusTooManyRequests, status)
 	})
 
 	t.Run("other_scheduler_errors_stay_503_without_retry_after", func(t *testing.T) {
 		c, w := newCtx(t)
-		status, msg := tkSelectFailureStatusMessage(c, errors.New("pq: connection refused"))
+		status, errType, msg := tkSelectFailureStatusMessage(c, errors.New("pq: connection refused"), "gpt-5.2")
 
 		require.Equal(t, http.StatusServiceUnavailable, status)
+		assert.Equal(t, "api_error", errType)
 		assert.Empty(t, w.Header().Get("Retry-After"))
 		assert.Equal(t, "Service temporarily unavailable", msg)
 	})

--- a/backend/internal/handler/openai_chat_completions.go
+++ b/backend/internal/handler/openai_chat_completions.go
@@ -168,8 +168,8 @@ func (h *OpenAIGatewayHandler) ChatCompletions(c *gin.Context) {
 			if len(failedAccountIDs) == 0 {
 				markOpsRoutingCapacityLimitedIfNoAvailable(c, err)
 				// TK: empty pool fast-fails 429 (#575 parity); other scheduler errors stay 503.
-				tkStatus, tkMsg := tkSelectFailureStatusMessage(c, err)
-				h.handleStreamingAwareError(c, tkStatus, "api_error", tkMsg, streamStarted)
+				tkStatus, tkType, tkMsg := tkSelectFailureStatusMessage(c, err, reqModel)
+				h.handleStreamingAwareError(c, tkStatus, tkType, tkMsg, streamStarted)
 				return
 			} else {
 				if lastFailoverErr != nil {

--- a/backend/internal/handler/openai_gateway_embeddings_images.go
+++ b/backend/internal/handler/openai_gateway_embeddings_images.go
@@ -173,8 +173,8 @@ func (h *OpenAIGatewayHandler) Embeddings(c *gin.Context) {
 				if err != nil {
 					markOpsRoutingCapacityLimitedIfNoAvailable(c, err)
 					// TK: empty pool fast-fails 429 (#575 parity); other scheduler errors stay 503.
-					tkStatus, tkMsg := tkSelectFailureStatusMessage(c, err)
-					h.handleStreamingAwareError(c, tkStatus, "api_error", tkMsg, streamStarted)
+					tkStatus, tkType, tkMsg := tkSelectFailureStatusMessage(c, err, defaultModel)
+					h.handleStreamingAwareError(c, tkStatus, tkType, tkMsg, streamStarted)
 					return
 				}
 			} else {
@@ -493,8 +493,8 @@ func (h *OpenAIGatewayHandler) ImageGenerations(c *gin.Context) {
 				if err != nil {
 					markOpsRoutingCapacityLimitedIfNoAvailable(c, err)
 					// TK: empty pool fast-fails 429 (#575 parity); other scheduler errors stay 503.
-					tkStatus, tkMsg := tkSelectFailureStatusMessage(c, err)
-					h.handleStreamingAwareError(c, tkStatus, "api_error", tkMsg, streamStarted)
+					tkStatus, tkType, tkMsg := tkSelectFailureStatusMessage(c, err, defaultModel)
+					h.handleStreamingAwareError(c, tkStatus, tkType, tkMsg, streamStarted)
 					return
 				}
 			} else {

--- a/backend/internal/handler/openai_gateway_handler.go
+++ b/backend/internal/handler/openai_gateway_handler.go
@@ -347,8 +347,8 @@ func (h *OpenAIGatewayHandler) Responses(c *gin.Context) {
 					return
 				}
 				// TK: empty pool fast-fails 429 (#575 parity); other scheduler errors stay 503.
-				tkStatus, tkMsg := tkSelectFailureStatusMessage(c, err)
-				h.handleStreamingAwareError(c, tkStatus, "api_error", tkMsg, streamStarted)
+				tkStatus, tkType, tkMsg := tkSelectFailureStatusMessage(c, err, reqModel)
+				h.handleStreamingAwareError(c, tkStatus, tkType, tkMsg, streamStarted)
 				return
 			}
 			if lastFailoverErr != nil {
@@ -798,8 +798,8 @@ func (h *OpenAIGatewayHandler) Messages(c *gin.Context) {
 				if err != nil {
 					markOpsRoutingCapacityLimitedIfNoAvailable(c, err)
 					// TK: empty pool fast-fails 429 (#575 parity); other scheduler errors stay 503.
-					tkStatus, tkMsg := tkSelectFailureStatusMessage(c, err)
-					h.anthropicStreamingAwareError(c, tkStatus, "api_error", tkMsg, streamStarted)
+					tkStatus, tkType, tkMsg := tkSelectFailureStatusMessage(c, err, currentRoutingModel)
+					h.anthropicStreamingAwareError(c, tkStatus, tkType, tkMsg, streamStarted)
 					return
 				}
 			} else {

--- a/backend/internal/handler/openai_gateway_tk_video.go
+++ b/backend/internal/handler/openai_gateway_tk_video.go
@@ -166,8 +166,8 @@ func (h *OpenAIGatewayHandler) VideoSubmit(c *gin.Context) {
 		}
 		markOpsRoutingCapacityLimitedIfNoAvailable(c, err)
 		// Empty pool fast-fails 429 (#575 parity); other scheduler errors stay 503.
-		tkStatus, tkMsg := tkSelectFailureStatusMessage(c, err)
-		h.errorResponse(c, tkStatus, "api_error", tkMsg)
+		tkStatus, tkType, tkMsg := tkSelectFailureStatusMessage(c, err, reqModel)
+		h.errorResponse(c, tkStatus, tkType, tkMsg)
 		return
 	}
 	account := selection.Account

--- a/backend/internal/handler/openai_images.go
+++ b/backend/internal/handler/openai_images.go
@@ -175,8 +175,8 @@ func (h *OpenAIGatewayHandler) Images(c *gin.Context) {
 			if len(failedAccountIDs) == 0 {
 				markOpsRoutingCapacityLimitedIfNoAvailable(c, err)
 				// TK: empty pool fast-fails 429 (#575 parity); other scheduler errors stay 503.
-				tkStatus, tkMsg := tkSelectFailureStatusMessage(c, err)
-				h.handleStreamingAwareError(c, tkStatus, "api_error", tkMsg, streamStarted)
+				tkStatus, tkType, tkMsg := tkSelectFailureStatusMessage(c, err, requestModel)
+				h.handleStreamingAwareError(c, tkStatus, tkType, tkMsg, streamStarted)
 				return
 			}
 			if lastFailoverErr != nil {

--- a/backend/internal/service/model_pricing_resolver_tk_overlay_intervals_test.go
+++ b/backend/internal/service/model_pricing_resolver_tk_overlay_intervals_test.go
@@ -36,13 +36,13 @@ func TestOverlayLoader_ParsesIntervals(t *testing.T) {
 	require.NotNil(t, coder.Intervals[0].MaxTokens)
 	require.Equal(t, 32000, *coder.Intervals[0].MaxTokens)
 	require.NotNil(t, coder.Intervals[0].InputPrice)
-	require.InDelta(t, 5.74e-07, *coder.Intervals[0].InputPrice, 1e-15)
+	require.InDelta(t, 4/6.7e6, *coder.Intervals[0].InputPrice, 1e-15)
 	require.Nil(t, coder.Intervals[3].MaxTokens, "top tier must be unbounded (>256K)")
 	require.NotNil(t, coder.Intervals[3].OutputPrice)
-	require.InDelta(t, 2.8671e-05, *coder.Intervals[3].OutputPrice, 1e-15)
+	require.InDelta(t, 200/6.7e6, *coder.Intervals[3].OutputPrice, 1e-15)
 
 	// flat base is the out-of-range fallback = tier 1.
-	require.InDelta(t, 5.74e-07, coder.InputCostPerToken, 1e-15)
+	require.InDelta(t, 4/6.7e6, coder.InputCostPerToken, 1e-15)
 	require.False(t, tkIsEffectivelyUnpriced(coder))
 
 	// VolcEngine doubao-seed-2.0-pro: 3 input tiers with per-tier cache-hit price
@@ -72,11 +72,11 @@ func TestOverlayIntervalPricing_CoderPlusWholeRequestTier(t *testing.T) {
 		ctxTokens int
 		in, out   float64
 	}{
-		{10_000, 5.74e-07, 2.294e-06},   // tier1 (0,32K]
-		{32_000, 5.74e-07, 2.294e-06},   // 32K boundary stays tier1 (max inclusive)
-		{32_001, 8.61e-07, 3.441e-06},   // tier2 (32K,128K]
-		{200_000, 1.434e-06, 5.735e-06}, // tier3 (128K,256K]
-		{500_000, 2.868e-06, 2.8671e-05}, // tier4 (256K,inf)
+		{10_000, 4 / 6.7e6, 16 / 6.7e6},   // tier1 (0,32K] ¥4/¥16
+		{32_000, 4 / 6.7e6, 16 / 6.7e6},   // 32K boundary stays tier1 (max inclusive)
+		{32_001, 6 / 6.7e6, 24 / 6.7e6},   // tier2 (32K,128K] ¥6/¥24
+		{200_000, 10 / 6.7e6, 40 / 6.7e6}, // tier3 (128K,256K] ¥10/¥40
+		{500_000, 20 / 6.7e6, 200 / 6.7e6}, // tier4 (256K,inf) ¥20/¥200
 	}
 	for _, c := range cases {
 		p := r.GetIntervalPricing(resolved, c.ctxTokens)
@@ -97,14 +97,14 @@ func TestOverlayIntervalPricing_PlusFlashTwoTier(t *testing.T) {
 
 	plus := r.Resolve(context.Background(), PricingInput{Model: "qwen3.7-plus"})
 	require.Len(t, plus.Intervals, 2)
-	require.InDelta(t, 2.76e-07, r.GetIntervalPricing(plus, 100_000).InputPricePerToken, 1e-15)
-	require.InDelta(t, 8.26e-07, r.GetIntervalPricing(plus, 300_000).InputPricePerToken, 1e-15)
-	require.InDelta(t, 3.301e-06, r.GetIntervalPricing(plus, 300_000).OutputPricePerToken, 1e-15)
+	require.InDelta(t, 2/6.7e6, r.GetIntervalPricing(plus, 100_000).InputPricePerToken, 1e-15)   // tier1 ¥2
+	require.InDelta(t, 6/6.7e6, r.GetIntervalPricing(plus, 300_000).InputPricePerToken, 1e-15)   // tier2 ¥6
+	require.InDelta(t, 24/6.7e6, r.GetIntervalPricing(plus, 300_000).OutputPricePerToken, 1e-15) // tier2 ¥24
 
 	flash := r.Resolve(context.Background(), PricingInput{Model: "qwen3.6-flash"})
 	require.Len(t, flash.Intervals, 2)
-	require.InDelta(t, 1.65e-07, r.GetIntervalPricing(flash, 100_000).InputPricePerToken, 1e-15)
-	require.InDelta(t, 3.961e-06, r.GetIntervalPricing(flash, 300_000).OutputPricePerToken, 1e-15)
+	require.InDelta(t, 1.2/6.7e6, r.GetIntervalPricing(flash, 100_000).InputPricePerToken, 1e-15)  // tier1 ¥1.2
+	require.InDelta(t, 28.8/6.7e6, r.GetIntervalPricing(flash, 300_000).OutputPricePerToken, 1e-15) // tier2 ¥28.8
 }
 
 // TestOverlayIntervals_FlatModelUnaffected guards the orthogonality: a flat overlay
@@ -114,7 +114,7 @@ func TestOverlayIntervals_FlatModelUnaffected(t *testing.T) {
 	resolved := r.Resolve(context.Background(), PricingInput{Model: "qwen3.7-max"})
 	require.Empty(t, resolved.Intervals, "flat overlay model must not gain intervals")
 	require.NotNil(t, resolved.BasePricing)
-	require.InDelta(t, 1.65e-06, resolved.BasePricing.InputPricePerToken, 1e-15)
+	require.InDelta(t, 12/6.7e6, resolved.BasePricing.InputPricePerToken, 1e-15)
 	// cache-read billed at full input rate ("用原价"), not $0.
-	require.InDelta(t, 1.65e-06, resolved.BasePricing.CacheReadPricePerToken, 1e-15)
+	require.InDelta(t, 12/6.7e6, resolved.BasePricing.CacheReadPricePerToken, 1e-15)
 }

--- a/backend/internal/service/openai_account_scheduler.go
+++ b/backend/internal/service/openai_account_scheduler.go
@@ -1029,8 +1029,8 @@ func (s *defaultOpenAIAccountScheduler) selectByLoadBalance(
 	if len(filtered) == 0 {
 		// TK: when the schedulable pool was emptied PURELY because no account serves
 		// the requested model name, surface ErrUnsupportedModel (→ HTTP 400) instead
-		// of an empty-pool 429. See openAICompatNoCandidateErr (TK companion).
-		return nil, 0, 0, 0, s.openAICompatNoCandidateErr(req, accounts)
+		// of an empty-pool 429. See openAICompatNoCandidateError (TK companion).
+		return nil, 0, 0, 0, openAICompatNoCandidateError(req.RequestedModel, req.GroupPlatform, false, accounts, req.ExcludedIDs)
 	}
 
 	loadMap := map[int64]*AccountLoadInfo{}

--- a/backend/internal/service/openai_account_scheduler.go
+++ b/backend/internal/service/openai_account_scheduler.go
@@ -1027,10 +1027,10 @@ func (s *defaultOpenAIAccountScheduler) selectByLoadBalance(
 		})
 	}
 	if len(filtered) == 0 {
-		if req.GroupPlatform != "" && req.GroupPlatform != PlatformOpenAI {
-			return nil, 0, 0, 0, fmt.Errorf("no available accounts for platform %q", openAICompatErrorPlatformLabel(req.GroupPlatform))
-		}
-		return nil, 0, 0, 0, noAvailableOpenAISelectionError(req.RequestedModel, false, req.GroupPlatform)
+		// TK: when the schedulable pool was emptied PURELY because no account serves
+		// the requested model name, surface ErrUnsupportedModel (→ HTTP 400) instead
+		// of an empty-pool 429. See openAICompatNoCandidateErr (TK companion).
+		return nil, 0, 0, 0, s.openAICompatNoCandidateErr(req, accounts)
 	}
 
 	loadMap := map[int64]*AccountLoadInfo{}

--- a/backend/internal/service/openai_account_scheduler_tk_errors.go
+++ b/backend/internal/service/openai_account_scheduler_tk_errors.go
@@ -24,35 +24,39 @@ func openAICompatErrorPlatformLabel(groupPlatform string) string {
 	return groupPlatform
 }
 
-// openAICompatNoCandidateErr is the single exit for the OpenAI-compat scheduler's
-// "candidate filter emptied the schedulable pool" branch (selectByLoadBalance,
-// len(filtered)==0). It mirrors the anthropic path's tkWrapSelectionFailure
-// (gateway_service_tk_unsupported_model.go): when EVERY schedulable account in
-// the matched pool was rejected purely because it does not serve the requested
-// model NAME, the failure is a CLIENT error (wrong/legacy model id), not capacity
-// — return service.ErrUnsupportedModel so the handler maps it to HTTP 400
+// openAICompatNoCandidateError is the SINGLE exit for BOTH OpenAI-compat selection
+// paths whose schedulable pool was emptied by the candidate filter:
+//   - the load-balance scheduler (defaultOpenAIAccountScheduler.selectByLoadBalance,
+//     len(filtered)==0); and
+//   - the priority/LRU path (OpenAIGatewayService.selectAccountForModelWithExclusions,
+//     selectBestAccount → nil), which count_tokens and the sticky/legacy callers use.
+//
+// It mirrors the anthropic path's tkWrapSelectionFailure
+// (gateway_service_tk_unsupported_model.go): when EVERY schedulable account in the
+// matched pool was rejected purely because it does not serve the requested model
+// NAME, the failure is a CLIENT error (wrong/legacy model id), not capacity —
+// return service.ErrUnsupportedModel so the handler maps it to HTTP 400
 // invalid_request_error (kept out of upstream_error_rate). Otherwise the original
 // empty-pool errors are preserved verbatim (429 fast-fail / platform label).
 //
 // Prod 2026-06-13: a client requesting unservable newapi names (deepseek-chat,
 // qwen-max — the matched pools only mapped deepseek-v4-* / qwen3.7-*) produced
 // empty-pool 429s (account_id=null) that read as a capacity signal and fired ops
-// alerts. This converges the openai/newapi pools with the anthropic 400 behavior.
-//
-// Only the len(filtered)==0 branch routes here. The len(accounts)==0 branch (no
-// schedulable account seen at all → no model evidence) and the post-load-balance
+// alerts. Routing both pool-emptied points through this one function converges the
+// openai/newapi pools with the anthropic 400 behavior. The len(accounts)==0 branch
+// (no schedulable account seen at all → no model evidence) and the post-load-balance
 // "couldn't acquire a slot" branches stay 429: those are genuine capacity gaps.
-func (s *defaultOpenAIAccountScheduler) openAICompatNoCandidateErr(req OpenAIAccountScheduleRequest, accounts []Account) error {
-	if req.RequestedModel != "" {
-		stats := collectOpenAICompatSelectionFailureStats(accounts, req)
+func openAICompatNoCandidateError(requestedModel, groupPlatform string, compactBlocked bool, accounts []Account, excludedIDs map[int64]struct{}) error {
+	if requestedModel != "" {
+		stats := collectOpenAICompatSelectionFailureStats(accounts, requestedModel, excludedIDs)
 		if tkSelectionFailedDueToUnsupportedModel(stats) {
-			return fmt.Errorf("%w: %s (%s)", ErrUnsupportedModel, req.RequestedModel, summarizeSelectionFailureStats(stats))
+			return fmt.Errorf("%w: %s (%s)", ErrUnsupportedModel, requestedModel, summarizeSelectionFailureStats(stats))
 		}
 	}
-	if req.GroupPlatform != "" && req.GroupPlatform != PlatformOpenAI {
-		return fmt.Errorf("no available accounts for platform %q", openAICompatErrorPlatformLabel(req.GroupPlatform))
+	if groupPlatform != "" && groupPlatform != PlatformOpenAI {
+		return fmt.Errorf("no available accounts for platform %q", openAICompatErrorPlatformLabel(groupPlatform))
 	}
-	return noAvailableOpenAISelectionError(req.RequestedModel, false, req.GroupPlatform)
+	return noAvailableOpenAISelectionError(requestedModel, compactBlocked, groupPlatform)
 }
 
 // collectOpenAICompatSelectionFailureStats categorizes each schedulable account
@@ -74,19 +78,19 @@ func (s *defaultOpenAIAccountScheduler) openAICompatNoCandidateErr(req OpenAIAcc
 // limits are filtered out of the schedulable list upstream). The net predicate
 // therefore fires only when at least one account is model-unsupported AND none
 // supports the model.
-func collectOpenAICompatSelectionFailureStats(accounts []Account, req OpenAIAccountScheduleRequest) selectionFailureStats {
+func collectOpenAICompatSelectionFailureStats(accounts []Account, requestedModel string, excludedIDs map[int64]struct{}) selectionFailureStats {
 	stats := selectionFailureStats{Total: len(accounts)}
 	for i := range accounts {
 		acc := &accounts[i]
-		if req.ExcludedIDs != nil {
-			if _, excluded := req.ExcludedIDs[acc.ID]; excluded {
+		if excludedIDs != nil {
+			if _, excluded := excludedIDs[acc.ID]; excluded {
 				// A previously-attempted account may well serve the model; never
 				// let an excluded account contribute "unsupported" evidence.
 				stats.Unschedulable++
 				continue
 			}
 		}
-		if req.RequestedModel != "" && !acc.IsModelSupported(req.RequestedModel) {
+		if requestedModel != "" && !acc.IsModelSupported(requestedModel) {
 			stats.ModelUnsupported++
 			stats.SampleMappingIDs = appendSelectionFailureSampleID(stats.SampleMappingIDs, acc.ID)
 			continue

--- a/backend/internal/service/openai_account_scheduler_tk_errors.go
+++ b/backend/internal/service/openai_account_scheduler_tk_errors.go
@@ -1,5 +1,7 @@
 package service
 
+import "fmt"
+
 // openAICompatErrorPlatformLabel returns the platform identifier to embed in
 // "no available accounts" error messages produced by the OpenAI-compat
 // scheduler.
@@ -20,4 +22,76 @@ func openAICompatErrorPlatformLabel(groupPlatform string) string {
 		return PlatformOpenAI
 	}
 	return groupPlatform
+}
+
+// openAICompatNoCandidateErr is the single exit for the OpenAI-compat scheduler's
+// "candidate filter emptied the schedulable pool" branch (selectByLoadBalance,
+// len(filtered)==0). It mirrors the anthropic path's tkWrapSelectionFailure
+// (gateway_service_tk_unsupported_model.go): when EVERY schedulable account in
+// the matched pool was rejected purely because it does not serve the requested
+// model NAME, the failure is a CLIENT error (wrong/legacy model id), not capacity
+// — return service.ErrUnsupportedModel so the handler maps it to HTTP 400
+// invalid_request_error (kept out of upstream_error_rate). Otherwise the original
+// empty-pool errors are preserved verbatim (429 fast-fail / platform label).
+//
+// Prod 2026-06-13: a client requesting unservable newapi names (deepseek-chat,
+// qwen-max — the matched pools only mapped deepseek-v4-* / qwen3.7-*) produced
+// empty-pool 429s (account_id=null) that read as a capacity signal and fired ops
+// alerts. This converges the openai/newapi pools with the anthropic 400 behavior.
+//
+// Only the len(filtered)==0 branch routes here. The len(accounts)==0 branch (no
+// schedulable account seen at all → no model evidence) and the post-load-balance
+// "couldn't acquire a slot" branches stay 429: those are genuine capacity gaps.
+func (s *defaultOpenAIAccountScheduler) openAICompatNoCandidateErr(req OpenAIAccountScheduleRequest, accounts []Account) error {
+	if req.RequestedModel != "" {
+		stats := collectOpenAICompatSelectionFailureStats(accounts, req)
+		if tkSelectionFailedDueToUnsupportedModel(stats) {
+			return fmt.Errorf("%w: %s (%s)", ErrUnsupportedModel, req.RequestedModel, summarizeSelectionFailureStats(stats))
+		}
+	}
+	if req.GroupPlatform != "" && req.GroupPlatform != PlatformOpenAI {
+		return fmt.Errorf("no available accounts for platform %q", openAICompatErrorPlatformLabel(req.GroupPlatform))
+	}
+	return noAvailableOpenAISelectionError(req.RequestedModel, false, req.GroupPlatform)
+}
+
+// collectOpenAICompatSelectionFailureStats categorizes each schedulable account
+// that survived to the candidate filter into the shared selectionFailureStats so
+// tkSelectionFailedDueToUnsupportedModel can decide "purely unsupported model" vs
+// "transient capacity". It deliberately only distinguishes the model-support axis
+// (Account.IsModelSupported — the same check isAccountRequestCompatible applies):
+//
+//   - account does NOT support the model name  → ModelUnsupported (evidence the
+//     name is unserved);
+//   - account supports the model but was excluded or filtered for any other
+//     reason (runtime block, capability, transport, upstream restriction) →
+//     Unschedulable, which SUPPRESSES the 400: the model IS served, just not
+//     selectable right now, so the client should get the 429 capacity hint, not a
+//     misleading "Unsupported model".
+//
+// Eligible is 0 by construction here (any fully-eligible account would be in
+// `filtered`); ModelRateLimited is not tracked on this path (account-level rate
+// limits are filtered out of the schedulable list upstream). The net predicate
+// therefore fires only when at least one account is model-unsupported AND none
+// supports the model.
+func collectOpenAICompatSelectionFailureStats(accounts []Account, req OpenAIAccountScheduleRequest) selectionFailureStats {
+	stats := selectionFailureStats{Total: len(accounts)}
+	for i := range accounts {
+		acc := &accounts[i]
+		if req.ExcludedIDs != nil {
+			if _, excluded := req.ExcludedIDs[acc.ID]; excluded {
+				// A previously-attempted account may well serve the model; never
+				// let an excluded account contribute "unsupported" evidence.
+				stats.Unschedulable++
+				continue
+			}
+		}
+		if req.RequestedModel != "" && !acc.IsModelSupported(req.RequestedModel) {
+			stats.ModelUnsupported++
+			stats.SampleMappingIDs = appendSelectionFailureSampleID(stats.SampleMappingIDs, acc.ID)
+			continue
+		}
+		stats.Unschedulable++
+	}
+	return stats
 }

--- a/backend/internal/service/openai_account_scheduler_tk_errors_test.go
+++ b/backend/internal/service/openai_account_scheduler_tk_errors_test.go
@@ -25,22 +25,20 @@ func newapiAcctWithMapping(id int64, served ...string) Account {
 	}
 }
 
-// TestOpenAICompatNoCandidateErr_UnsupportedModel is the core of the 2026-06-13
-// fix: when the schedulable pool was emptied PURELY because no account serves the
-// requested model NAME, the OpenAI-compat scheduler must surface
-// ErrUnsupportedModel (→ HTTP 400), not an empty-pool 429.
-func TestOpenAICompatNoCandidateErr_UnsupportedModel(t *testing.T) {
-	s := &defaultOpenAIAccountScheduler{}
-
+// TestOpenAICompatNoCandidateError is the core of the 2026-06-13 fix: when the
+// schedulable pool was emptied PURELY because no account serves the requested
+// model NAME, the OpenAI-compat selection paths must surface ErrUnsupportedModel
+// (→ HTTP 400), not an empty-pool 429. The same function backs both the
+// load-balance scheduler and the selectBestAccount (count_tokens/sticky) path.
+func TestOpenAICompatNoCandidateError(t *testing.T) {
 	t.Run("all_accounts_lack_model_mapping_entry_returns_unsupported", func(t *testing.T) {
 		// Prod shape: group 11 "deepseek" maps only deepseek-v4-*, client asks for
 		// the legacy "deepseek-chat".
 		accounts := []Account{
 			newapiAcctWithMapping(39, "deepseek-v4-pro", "deepseek-v4-flash"),
 		}
-		req := OpenAIAccountScheduleRequest{RequestedModel: "deepseek-chat", GroupPlatform: PlatformNewAPI}
 
-		err := s.openAICompatNoCandidateErr(req, accounts)
+		err := openAICompatNoCandidateError("deepseek-chat", PlatformNewAPI, false, accounts, nil)
 
 		require.Error(t, err)
 		assert.True(t, errors.Is(err, ErrUnsupportedModel), "expected ErrUnsupportedModel, got %v", err)
@@ -57,9 +55,8 @@ func TestOpenAICompatNoCandidateErr_UnsupportedModel(t *testing.T) {
 			newapiAcctWithMapping(39, "deepseek-v4-pro"),
 			newapiAcctWithMapping(40, "deepseek-chat"),
 		}
-		req := OpenAIAccountScheduleRequest{RequestedModel: "deepseek-chat", GroupPlatform: PlatformNewAPI}
 
-		err := s.openAICompatNoCandidateErr(req, accounts)
+		err := openAICompatNoCandidateError("deepseek-chat", PlatformNewAPI, false, accounts, nil)
 
 		require.Error(t, err)
 		assert.False(t, errors.Is(err, ErrUnsupportedModel))
@@ -73,13 +70,8 @@ func TestOpenAICompatNoCandidateErr_UnsupportedModel(t *testing.T) {
 		accounts := []Account{
 			newapiAcctWithMapping(39, "deepseek-chat"),
 		}
-		req := OpenAIAccountScheduleRequest{
-			RequestedModel: "deepseek-chat",
-			GroupPlatform:  PlatformNewAPI,
-			ExcludedIDs:    map[int64]struct{}{39: {}},
-		}
 
-		err := s.openAICompatNoCandidateErr(req, accounts)
+		err := openAICompatNoCandidateError("deepseek-chat", PlatformNewAPI, false, accounts, map[int64]struct{}{39: {}})
 
 		require.Error(t, err)
 		assert.False(t, errors.Is(err, ErrUnsupportedModel))
@@ -87,9 +79,8 @@ func TestOpenAICompatNoCandidateErr_UnsupportedModel(t *testing.T) {
 
 	t.Run("empty_model_never_unsupported", func(t *testing.T) {
 		accounts := []Account{newapiAcctWithMapping(39, "deepseek-v4-pro")}
-		req := OpenAIAccountScheduleRequest{RequestedModel: "", GroupPlatform: PlatformNewAPI}
 
-		err := s.openAICompatNoCandidateErr(req, accounts)
+		err := openAICompatNoCandidateError("", PlatformNewAPI, false, accounts, nil)
 
 		require.Error(t, err)
 		assert.False(t, errors.Is(err, ErrUnsupportedModel))
@@ -100,9 +91,8 @@ func TestOpenAICompatNoCandidateErr_UnsupportedModel(t *testing.T) {
 		// never unsupported; the model is forwarded and any upstream 404 is handled
 		// by the response-path unsupported-model classifier (path B).
 		accounts := []Account{{ID: 9, Platform: PlatformOpenAI}}
-		req := OpenAIAccountScheduleRequest{RequestedModel: "gpt-9-turbo"}
 
-		err := s.openAICompatNoCandidateErr(req, accounts)
+		err := openAICompatNoCandidateError("gpt-9-turbo", "", false, accounts, nil)
 
 		require.Error(t, err)
 		assert.False(t, errors.Is(err, ErrUnsupportedModel))
@@ -112,12 +102,10 @@ func TestOpenAICompatNoCandidateErr_UnsupportedModel(t *testing.T) {
 // TestCollectOpenAICompatSelectionFailureStats pins the categorization the
 // unsupported-model predicate depends on.
 func TestCollectOpenAICompatSelectionFailureStats(t *testing.T) {
-	req := OpenAIAccountScheduleRequest{RequestedModel: "deepseek-chat"}
-
 	t.Run("all_unsupported", func(t *testing.T) {
 		stats := collectOpenAICompatSelectionFailureStats(
 			[]Account{newapiAcctWithMapping(1, "deepseek-v4-pro"), newapiAcctWithMapping(2, "deepseek-v4-flash")},
-			req,
+			"deepseek-chat", nil,
 		)
 		assert.Equal(t, 2, stats.ModelUnsupported)
 		assert.Equal(t, 0, stats.Unschedulable)
@@ -127,7 +115,7 @@ func TestCollectOpenAICompatSelectionFailureStats(t *testing.T) {
 	t.Run("mixed_supporting_suppresses", func(t *testing.T) {
 		stats := collectOpenAICompatSelectionFailureStats(
 			[]Account{newapiAcctWithMapping(1, "deepseek-v4-pro"), newapiAcctWithMapping(2, "deepseek-chat")},
-			req,
+			"deepseek-chat", nil,
 		)
 		assert.Equal(t, 1, stats.ModelUnsupported)
 		assert.Equal(t, 1, stats.Unschedulable)

--- a/backend/internal/service/openai_account_scheduler_tk_errors_test.go
+++ b/backend/internal/service/openai_account_scheduler_tk_errors_test.go
@@ -1,0 +1,136 @@
+//go:build unit
+
+package service
+
+import (
+	"errors"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// newapiAcctWithMapping builds a minimal newapi Account whose model_mapping
+// allowlist contains exactly the given served model names (value == key, the
+// identity mapping prod uses for deepseek-v4-* / qwen3.7-*).
+func newapiAcctWithMapping(id int64, served ...string) Account {
+	mapping := make(map[string]any, len(served))
+	for _, m := range served {
+		mapping[m] = m
+	}
+	return Account{
+		ID:          id,
+		Platform:    PlatformNewAPI,
+		Credentials: map[string]any{"model_mapping": mapping},
+	}
+}
+
+// TestOpenAICompatNoCandidateErr_UnsupportedModel is the core of the 2026-06-13
+// fix: when the schedulable pool was emptied PURELY because no account serves the
+// requested model NAME, the OpenAI-compat scheduler must surface
+// ErrUnsupportedModel (→ HTTP 400), not an empty-pool 429.
+func TestOpenAICompatNoCandidateErr_UnsupportedModel(t *testing.T) {
+	s := &defaultOpenAIAccountScheduler{}
+
+	t.Run("all_accounts_lack_model_mapping_entry_returns_unsupported", func(t *testing.T) {
+		// Prod shape: group 11 "deepseek" maps only deepseek-v4-*, client asks for
+		// the legacy "deepseek-chat".
+		accounts := []Account{
+			newapiAcctWithMapping(39, "deepseek-v4-pro", "deepseek-v4-flash"),
+		}
+		req := OpenAIAccountScheduleRequest{RequestedModel: "deepseek-chat", GroupPlatform: PlatformNewAPI}
+
+		err := s.openAICompatNoCandidateErr(req, accounts)
+
+		require.Error(t, err)
+		assert.True(t, errors.Is(err, ErrUnsupportedModel), "expected ErrUnsupportedModel, got %v", err)
+		assert.False(t, errors.Is(err, ErrNoAvailableAccounts))
+		// Must NOT carry the phrase isOpsNoAvailableAccountError matches, or ops
+		// would relabel it as routing-capacity instead of a client request error.
+		assert.NotContains(t, err.Error(), "no available accounts")
+	})
+
+	t.Run("a_supporting_account_present_stays_no_available_accounts", func(t *testing.T) {
+		// One account DOES serve the model (it just got filtered downstream, e.g.
+		// cooldown/capability) → this is a transient capacity gap, keep 429 family.
+		accounts := []Account{
+			newapiAcctWithMapping(39, "deepseek-v4-pro"),
+			newapiAcctWithMapping(40, "deepseek-chat"),
+		}
+		req := OpenAIAccountScheduleRequest{RequestedModel: "deepseek-chat", GroupPlatform: PlatformNewAPI}
+
+		err := s.openAICompatNoCandidateErr(req, accounts)
+
+		require.Error(t, err)
+		assert.False(t, errors.Is(err, ErrUnsupportedModel))
+		// newapi platform label preserved for operator clarity.
+		assert.Contains(t, err.Error(), "newapi")
+	})
+
+	t.Run("excluded_supporting_account_does_not_trigger_unsupported", func(t *testing.T) {
+		// The only account serves the model but was excluded (failover retry). We
+		// must NOT claim "unsupported" — fall back to the 429 family.
+		accounts := []Account{
+			newapiAcctWithMapping(39, "deepseek-chat"),
+		}
+		req := OpenAIAccountScheduleRequest{
+			RequestedModel: "deepseek-chat",
+			GroupPlatform:  PlatformNewAPI,
+			ExcludedIDs:    map[int64]struct{}{39: {}},
+		}
+
+		err := s.openAICompatNoCandidateErr(req, accounts)
+
+		require.Error(t, err)
+		assert.False(t, errors.Is(err, ErrUnsupportedModel))
+	})
+
+	t.Run("empty_model_never_unsupported", func(t *testing.T) {
+		accounts := []Account{newapiAcctWithMapping(39, "deepseek-v4-pro")}
+		req := OpenAIAccountScheduleRequest{RequestedModel: "", GroupPlatform: PlatformNewAPI}
+
+		err := s.openAICompatNoCandidateErr(req, accounts)
+
+		require.Error(t, err)
+		assert.False(t, errors.Is(err, ErrUnsupportedModel))
+	})
+
+	t.Run("openai_platform_passthrough_account_supports_all_models", func(t *testing.T) {
+		// An account with no model_mapping (passthrough) serves every name →
+		// never unsupported; the model is forwarded and any upstream 404 is handled
+		// by the response-path unsupported-model classifier (path B).
+		accounts := []Account{{ID: 9, Platform: PlatformOpenAI}}
+		req := OpenAIAccountScheduleRequest{RequestedModel: "gpt-9-turbo"}
+
+		err := s.openAICompatNoCandidateErr(req, accounts)
+
+		require.Error(t, err)
+		assert.False(t, errors.Is(err, ErrUnsupportedModel))
+	})
+}
+
+// TestCollectOpenAICompatSelectionFailureStats pins the categorization the
+// unsupported-model predicate depends on.
+func TestCollectOpenAICompatSelectionFailureStats(t *testing.T) {
+	req := OpenAIAccountScheduleRequest{RequestedModel: "deepseek-chat"}
+
+	t.Run("all_unsupported", func(t *testing.T) {
+		stats := collectOpenAICompatSelectionFailureStats(
+			[]Account{newapiAcctWithMapping(1, "deepseek-v4-pro"), newapiAcctWithMapping(2, "deepseek-v4-flash")},
+			req,
+		)
+		assert.Equal(t, 2, stats.ModelUnsupported)
+		assert.Equal(t, 0, stats.Unschedulable)
+		assert.True(t, tkSelectionFailedDueToUnsupportedModel(stats))
+	})
+
+	t.Run("mixed_supporting_suppresses", func(t *testing.T) {
+		stats := collectOpenAICompatSelectionFailureStats(
+			[]Account{newapiAcctWithMapping(1, "deepseek-v4-pro"), newapiAcctWithMapping(2, "deepseek-chat")},
+			req,
+		)
+		assert.Equal(t, 1, stats.ModelUnsupported)
+		assert.Equal(t, 1, stats.Unschedulable)
+		assert.False(t, tkSelectionFailedDueToUnsupportedModel(stats))
+	})
+}

--- a/backend/internal/service/openai_gateway_service.go
+++ b/backend/internal/service/openai_gateway_service.go
@@ -1737,7 +1737,11 @@ func (s *OpenAIGatewayService) selectAccountForModelWithExclusions(ctx context.C
 	selected, compactBlocked := s.selectBestAccount(ctx, groupID, accounts, requestedModel, excludedIDs, groupPlatform, requireCompact)
 
 	if selected == nil {
-		return nil, noAvailableOpenAISelectionError(requestedModel, compactBlocked, groupPlatform)
+		// TK: route through the shared no-candidate classifier so a pool emptied
+		// PURELY by unservable model name surfaces ErrUnsupportedModel (→ HTTP 400),
+		// not an empty-pool 429 — parity with the selectByLoadBalance path so
+		// count_tokens / sticky callers do not misclassify (prod 2026-06-13).
+		return nil, openAICompatNoCandidateError(requestedModel, groupPlatform, compactBlocked, accounts, excludedIDs)
 	}
 
 	hydrated, err := s.hydrateSelectedAccount(ctx, selected)

--- a/backend/internal/service/openai_gateway_service_test.go
+++ b/backend/internal/service/openai_gateway_service_test.go
@@ -767,8 +767,13 @@ func TestOpenAISelectAccountForModelWithExclusions_NoModelSupport(t *testing.T) 
 	if acc != nil {
 		t.Fatalf("expected nil account for unsupported model")
 	}
-	if !strings.Contains(err.Error(), "supporting model") {
-		t.Fatalf("unexpected error: %v", err)
+	// TK 2026-06-13: a model name that NO account in the pool serves is now a
+	// CLIENT error (ErrUnsupportedModel → HTTP 400 invalid_request_error), not the
+	// generic no-available "supporting model" 429 family — so this exact path
+	// (selectBestAccount → nil) stops misclassifying an unservable model id as a
+	// capacity signal. See openAICompatNoCandidateError.
+	if !errors.Is(err, ErrUnsupportedModel) {
+		t.Fatalf("expected ErrUnsupportedModel for unservable model name, got: %v", err)
 	}
 }
 

--- a/backend/internal/service/tk_pricing_overlay.json
+++ b/backend/internal/service/tk_pricing_overlay.json
@@ -765,6 +765,45 @@
     ],
     "source": "Alibaba DashScope qwen3.7-plus official USD list (China-mainland; tiered by input tokens: 0<Token<=256K in $0.276/M out $1.101/M, 256K<Token<=1M in $0.826/M out $3.301/M; non-thinking == thinking output; help.aliyun.com/zh/model-studio/model-pricing captured 2026-06-11). List price only — Batch/context-cache discounts not modeled. Whole-request input-tier via overlay intervals."
   },
+  "qwen-max": {
+    "litellm_provider": "dashscope",
+    "mode": "chat",
+    "input_cost_per_token": 3.582089552238806e-07,
+    "output_cost_per_token": 1.432835820895522e-06,
+    "cache_read_input_token_cost": 3.582089552238806e-07,
+    "source": "Alibaba DashScope qwen-max (legacy stable alias, 当前能力等同 qwen-max snapshot) official China-mainland (Beijing) RMB list ÷ 6.7 (无阶梯计价 in ¥2.4/M out ¥9.6/M); docs/accounts/aliyun_pricing_20260612.md captured 2026-06-12. Added 2026-06-13: client-facing legacy alias served via account 60 (dashscope.aliyuncs.com) that the qwen3.7-* mapping did not cover (empty-pool 429 incident). List price only — Batch (half-price)/context-cache discounts not modeled (bill at list). International deployment is ~5x higher (¥11.743/¥46.971) and intentionally NOT modeled; the prod account uses the China-mainland endpoint."
+  },
+  "qwen-plus": {
+    "litellm_provider": "dashscope",
+    "mode": "chat",
+    "input_cost_per_token": 1.194029850746269e-07,
+    "output_cost_per_token": 2.985074626865672e-07,
+    "cache_read_input_token_cost": 1.194029850746269e-07,
+    "intervals": [
+      {
+        "min_tokens": 0,
+        "max_tokens": 128000,
+        "input_cost_per_token": 1.194029850746269e-07,
+        "output_cost_per_token": 2.985074626865672e-07,
+        "cache_read_input_token_cost": 1.194029850746269e-07
+      },
+      {
+        "min_tokens": 128000,
+        "max_tokens": 256000,
+        "input_cost_per_token": 3.582089552238806e-07,
+        "output_cost_per_token": 2.985074626865672e-06,
+        "cache_read_input_token_cost": 3.582089552238806e-07
+      },
+      {
+        "min_tokens": 256000,
+        "max_tokens": null,
+        "input_cost_per_token": 7.164179104477612e-07,
+        "output_cost_per_token": 7.164179104477612e-06,
+        "cache_read_input_token_cost": 7.164179104477612e-07
+      }
+    ],
+    "source": "Alibaba DashScope qwen-plus (legacy stable alias, 当前能力等同 qwen-plus-2025-12-01) official China-mainland (Beijing) RMB list ÷ 6.7, tiered by input tokens (0<=128K in ¥0.8 out ¥2; 128K<=256K in ¥2.4 out ¥20; 256K<=1M in ¥4.8 out ¥48 per M); docs/accounts/aliyun_pricing_20260612.md captured 2026-06-12. Added 2026-06-13: client-facing legacy alias served via account 60 (dashscope.aliyuncs.com) that the qwen3.7-* mapping did not cover. Output priced at NON-thinking list; thinking-mode output is higher (¥8/¥24/¥64 per tier) and intentionally NOT modeled (bill at non-thinking list). Batch (half-price)/context-cache discounts not modeled. Whole-request input-tier via overlay intervals."
+  },
   "qwen3.6-flash": {
     "litellm_provider": "dashscope",
     "mode": "chat",

--- a/backend/internal/service/tk_pricing_overlay.json
+++ b/backend/internal/service/tk_pricing_overlay.json
@@ -1,7 +1,7 @@
 {
   "_meta": {
     "note": "TK-owned pricing overlay for models the runtime price source lacks. Merged into PricingService AFTER any source load (Wei-Shaw remote OR disk fallback); an entry below applies when the source key is ABSENT or the source entry is EFFECTIVELY UNPRICED (every cost field 0.0 — litellm's 'unknown', not 'free'; see tkIsEffectivelyUnpriced). The Wei-Shaw runtime mirror is a TRIMMED litellm mirror that drops provider-prefixed keys and token-less media entries, so imagen-*/veo-* resolve to nothing there; litellm itself also lags new provider models (deepseek-v4-*) or carries them as zero placeholders (deepseek-v3-2-251201), which then bill $0. Media price = vertex_ai provider (TK media flow routes through Vertex ch41); falls back to gemini only when no vertex variant exists. Text price = provider official list price. Self-deprecating: the day the source carries a real (non-zero) price under the bare key, the source value wins and the entry below is ignored. The overlay cannot CORRECT wrong NON-ZERO source prices (deepseek-chat/reasoner still carry the pre-V4 rate in the mirror) — use channel pricing (DB) for that. Video entries MUST declare failure_billing (currently only 'success_only' is legal): TokenKey refunds the user in full when a video task ends failed, which is only loss-free if the provider does not charge for failed tasks — the person pricing a new video model verifies that on the official page and declares it here; scripts/checks/pricing-overlay.py enforces the field, and any other value must first change the refund design.",
-    "provenance": "media: BerriAI/litellm model_prices_and_context_window.json, captured 2026-06-01; deepseek-v4-*: https://api-docs.deepseek.com/quick_start/pricing, captured 2026-06-04 (cache-hit input = cache_read; cache writes billed as normal input, no separate write fee); volcengine doubao-*/glm-4-7-251222/deepseek-v3-2-251201: VolcEngine Ark official model-pricing page, captured 2026-06-10 (≤32K input tier, CNY/USD=6.7); glm-4.7 matches Zhipu official; qwen3.7-max*: Alibaba DashScope official list price, captured 2026-06-10 (per-entry source); qwen2.5-coder-32b/7b: retired & absent from current Alibaba list — proxy-filled from lineage successors qwen3-coder-plus / qwen3-coder-flash, Beijing RMB list ÷ 6.7, docs/accounts/aliyun_pricing_20260612.md captured 2026-06-12 (per-entry source); seedream/seedance media: VolcEngine Ark official model-pricing page (https://www.volcengine.com/docs/82379/1099320), captured 2026-06-12, CNY/USD=6.7 — per-image flat price; per-second video price derived at each model's max supported tier (1080p@24fps; 2.0-fast 720p), online standard rate, derivation formula in per-entry source; only IDs present in new-api ch45/54 model lists are included — seedream-4.5/5.0(-lite) & seedance-1.0-pro-fast are priced upstream but absent from new-api constants, seedance-1.0-lite is listed but retired/unpriced, all deliberately NOT included (served_zero_cost P0 probe covers the gap; a wrong price has no probe); video failure_billing evidence: seedance entries carry the verified official Ark wording (success-only, captured 2026-06-12); veo entries are metric-inferred (billed per generated output second) with the official Google sentence still pending capture",
+    "provenance": "media: BerriAI/litellm model_prices_and_context_window.json, captured 2026-06-01; deepseek-v4-*: https://api-docs.deepseek.com/quick_start/pricing, captured 2026-06-04 (cache-hit input = cache_read; cache writes billed as normal input, no separate write fee); volcengine doubao-*/glm-4-7-251222/deepseek-v3-2-251201: VolcEngine Ark official model-pricing page, captured 2026-06-10 (≤32K input tier, CNY/USD=6.7); glm-4.7 matches Zhipu official; qwen3.7-max* / qwen3.7-plus / qwen3.6-flash / qwen3-coder-plus / qwen-max / qwen-plus: Alibaba DashScope China-mainland (Beijing) RMB list ÷ 6.7, docs/accounts/aliyun_pricing_20260612.md captured 2026-06-12 (per-entry source; the qwen3.7-* / qwen3.6-flash / qwen3-coder-plus values were corrected 2026-06-13 from a prior USD-list basis ≈÷7.27 to the table's canonical CNY/USD=6.7); qwen2.5-coder-32b/7b: retired & absent from current Alibaba list — proxy-filled from lineage successors qwen3-coder-plus / qwen3-coder-flash, Beijing RMB list ÷ 6.7, docs/accounts/aliyun_pricing_20260612.md captured 2026-06-12 (per-entry source); seedream/seedance media: VolcEngine Ark official model-pricing page (https://www.volcengine.com/docs/82379/1099320), captured 2026-06-12, CNY/USD=6.7 — per-image flat price; per-second video price derived at each model's max supported tier (1080p@24fps; 2.0-fast 720p), online standard rate, derivation formula in per-entry source; only IDs present in new-api ch45/54 model lists are included — seedream-4.5/5.0(-lite) & seedance-1.0-pro-fast are priced upstream but absent from new-api constants, seedance-1.0-lite is listed but retired/unpriced, all deliberately NOT included (served_zero_cost P0 probe covers the gap; a wrong price has no probe); video failure_billing evidence: seedance entries carry the verified official Ark wording (success-only, captured 2026-06-12); veo entries are metric-inferred (billed per generated output second) with the official Google sentence still pending capture",
     "regen": "manual curation; no auto-sync (entries are few + slow-moving). If they proliferate, add provider-aware sync."
   },
   "claude-fable-5": {
@@ -704,66 +704,66 @@
   "qwen3.7-max": {
     "litellm_provider": "dashscope",
     "mode": "chat",
-    "input_cost_per_token": 1.65e-06,
-    "output_cost_per_token": 4.951e-06,
-    "cache_read_input_token_cost": 1.65e-06,
-    "source": "Alibaba DashScope qwen3.7-max official USD list price (in $1.65/M, out $4.951/M; China-mainland deployment, 0<token<=1M tier, non-thinking & thinking; help.aliyun.com/zh/model-studio/model-pricing, captured 2026-06-11). List price only — Batch (half-price) and context-cache discounts intentionally NOT modeled (bill at list)."
+    "input_cost_per_token": 1.7910447761194032e-06,
+    "output_cost_per_token": 5.373134328358209e-06,
+    "cache_read_input_token_cost": 1.7910447761194032e-06,
+    "source": "Alibaba DashScope qwen3.7-max official China-mainland (Beijing) RMB list ÷ 6.7 (0<Token≤1M in ¥12/M out ¥36/M; thinking & non-thinking share one price; qwen3.7-max-preview / -2026-05-17 are thinking-only at the same rate). docs/accounts/aliyun_pricing_20260612.md captured 2026-06-12. Corrected 2026-06-13 from a prior USD-list basis (≈÷7.27) to the table's canonical CNY/USD=6.7. List price only — Batch (half-price)/context-cache discounts not modeled."
   },
   "qwen3.7-max-preview": {
     "litellm_provider": "dashscope",
     "mode": "chat",
-    "input_cost_per_token": 1.65e-06,
-    "output_cost_per_token": 4.951e-06,
-    "cache_read_input_token_cost": 1.65e-06,
-    "source": "Alibaba DashScope qwen3.7-max official USD list price (in $1.65/M, out $4.951/M; China-mainland deployment, 0<token<=1M tier, non-thinking & thinking; help.aliyun.com/zh/model-studio/model-pricing, captured 2026-06-11). List price only — Batch (half-price) and context-cache discounts intentionally NOT modeled (bill at list)."
+    "input_cost_per_token": 1.7910447761194032e-06,
+    "output_cost_per_token": 5.373134328358209e-06,
+    "cache_read_input_token_cost": 1.7910447761194032e-06,
+    "source": "Alibaba DashScope qwen3.7-max official China-mainland (Beijing) RMB list ÷ 6.7 (0<Token≤1M in ¥12/M out ¥36/M; thinking & non-thinking share one price; qwen3.7-max-preview / -2026-05-17 are thinking-only at the same rate). docs/accounts/aliyun_pricing_20260612.md captured 2026-06-12. Corrected 2026-06-13 from a prior USD-list basis (≈÷7.27) to the table's canonical CNY/USD=6.7. List price only — Batch (half-price)/context-cache discounts not modeled."
   },
   "qwen3.7-max-2026-05-17": {
     "litellm_provider": "dashscope",
     "mode": "chat",
-    "input_cost_per_token": 1.65e-06,
-    "output_cost_per_token": 4.951e-06,
-    "cache_read_input_token_cost": 1.65e-06,
-    "source": "Alibaba DashScope qwen3.7-max official USD list price (in $1.65/M, out $4.951/M; China-mainland deployment, 0<token<=1M tier, non-thinking & thinking; help.aliyun.com/zh/model-studio/model-pricing, captured 2026-06-11). List price only — Batch (half-price) and context-cache discounts intentionally NOT modeled (bill at list)."
+    "input_cost_per_token": 1.7910447761194032e-06,
+    "output_cost_per_token": 5.373134328358209e-06,
+    "cache_read_input_token_cost": 1.7910447761194032e-06,
+    "source": "Alibaba DashScope qwen3.7-max official China-mainland (Beijing) RMB list ÷ 6.7 (0<Token≤1M in ¥12/M out ¥36/M; thinking & non-thinking share one price; qwen3.7-max-preview / -2026-05-17 are thinking-only at the same rate). docs/accounts/aliyun_pricing_20260612.md captured 2026-06-12. Corrected 2026-06-13 from a prior USD-list basis (≈÷7.27) to the table's canonical CNY/USD=6.7. List price only — Batch (half-price)/context-cache discounts not modeled."
   },
   "qwen3.7-max-2026-05-20": {
     "litellm_provider": "dashscope",
     "mode": "chat",
-    "input_cost_per_token": 1.65e-06,
-    "output_cost_per_token": 4.951e-06,
-    "cache_read_input_token_cost": 1.65e-06,
-    "source": "Alibaba DashScope qwen3.7-max official USD list price (in $1.65/M, out $4.951/M; China-mainland deployment, 0<token<=1M tier, non-thinking & thinking; help.aliyun.com/zh/model-studio/model-pricing, captured 2026-06-11). List price only — Batch (half-price) and context-cache discounts intentionally NOT modeled (bill at list)."
+    "input_cost_per_token": 1.7910447761194032e-06,
+    "output_cost_per_token": 5.373134328358209e-06,
+    "cache_read_input_token_cost": 1.7910447761194032e-06,
+    "source": "Alibaba DashScope qwen3.7-max official China-mainland (Beijing) RMB list ÷ 6.7 (0<Token≤1M in ¥12/M out ¥36/M; thinking & non-thinking share one price; qwen3.7-max-preview / -2026-05-17 are thinking-only at the same rate). docs/accounts/aliyun_pricing_20260612.md captured 2026-06-12. Corrected 2026-06-13 from a prior USD-list basis (≈÷7.27) to the table's canonical CNY/USD=6.7. List price only — Batch (half-price)/context-cache discounts not modeled."
   },
   "qwen3.7-max-2026-06-08": {
     "litellm_provider": "dashscope",
     "mode": "chat",
-    "input_cost_per_token": 1.65e-06,
-    "output_cost_per_token": 4.951e-06,
-    "cache_read_input_token_cost": 1.65e-06,
-    "source": "Alibaba DashScope qwen3.7-max official USD list price (in $1.65/M, out $4.951/M; China-mainland deployment, 0<token<=1M tier, non-thinking & thinking; help.aliyun.com/zh/model-studio/model-pricing, captured 2026-06-11). List price only — Batch (half-price) and context-cache discounts intentionally NOT modeled (bill at list)."
+    "input_cost_per_token": 1.7910447761194032e-06,
+    "output_cost_per_token": 5.373134328358209e-06,
+    "cache_read_input_token_cost": 1.7910447761194032e-06,
+    "source": "Alibaba DashScope qwen3.7-max official China-mainland (Beijing) RMB list ÷ 6.7 (0<Token≤1M in ¥12/M out ¥36/M; thinking & non-thinking share one price; qwen3.7-max-preview / -2026-05-17 are thinking-only at the same rate). docs/accounts/aliyun_pricing_20260612.md captured 2026-06-12. Corrected 2026-06-13 from a prior USD-list basis (≈÷7.27) to the table's canonical CNY/USD=6.7. List price only — Batch (half-price)/context-cache discounts not modeled."
   },
   "qwen3.7-plus": {
     "litellm_provider": "dashscope",
     "mode": "chat",
-    "input_cost_per_token": 2.76e-07,
-    "output_cost_per_token": 1.101e-06,
-    "cache_read_input_token_cost": 2.76e-07,
+    "input_cost_per_token": 2.9850746268656716e-07,
+    "output_cost_per_token": 1.1940298507462686e-06,
+    "cache_read_input_token_cost": 2.9850746268656716e-07,
     "intervals": [
       {
         "min_tokens": 0,
         "max_tokens": 256000,
-        "input_cost_per_token": 2.76e-07,
-        "output_cost_per_token": 1.101e-06,
-        "cache_read_input_token_cost": 2.76e-07
+        "input_cost_per_token": 2.9850746268656716e-07,
+        "output_cost_per_token": 1.1940298507462686e-06,
+        "cache_read_input_token_cost": 2.9850746268656716e-07
       },
       {
         "min_tokens": 256000,
         "max_tokens": null,
-        "input_cost_per_token": 8.26e-07,
-        "output_cost_per_token": 3.301e-06,
-        "cache_read_input_token_cost": 8.26e-07
+        "input_cost_per_token": 8.955223880597016e-07,
+        "output_cost_per_token": 3.5820895522388063e-06,
+        "cache_read_input_token_cost": 8.955223880597016e-07
       }
     ],
-    "source": "Alibaba DashScope qwen3.7-plus official USD list (China-mainland; tiered by input tokens: 0<Token<=256K in $0.276/M out $1.101/M, 256K<Token<=1M in $0.826/M out $3.301/M; non-thinking == thinking output; help.aliyun.com/zh/model-studio/model-pricing captured 2026-06-11). List price only — Batch/context-cache discounts not modeled. Whole-request input-tier via overlay intervals."
+    "source": "Alibaba DashScope qwen3.7-plus official China-mainland RMB list ÷ 6.7, tiered by input tokens (0<256K in ¥2/M out ¥8/M; 256K<1M in ¥6/M out ¥24/M; non-thinking == thinking output); docs/accounts/aliyun_pricing_20260612.md captured 2026-06-12. Corrected 2026-06-13 to canonical CNY/USD=6.7. List price only — Batch/context-cache discounts not modeled. Whole-request input-tier via overlay intervals."
   },
   "qwen-max": {
     "litellm_provider": "dashscope",
@@ -807,64 +807,64 @@
   "qwen3.6-flash": {
     "litellm_provider": "dashscope",
     "mode": "chat",
-    "input_cost_per_token": 1.65e-07,
-    "output_cost_per_token": 9.9e-07,
-    "cache_read_input_token_cost": 1.65e-07,
+    "input_cost_per_token": 1.791044776119403e-07,
+    "output_cost_per_token": 1.0746268656716418e-06,
+    "cache_read_input_token_cost": 1.791044776119403e-07,
     "intervals": [
       {
         "min_tokens": 0,
         "max_tokens": 256000,
-        "input_cost_per_token": 1.65e-07,
-        "output_cost_per_token": 9.9e-07,
-        "cache_read_input_token_cost": 1.65e-07
+        "input_cost_per_token": 1.791044776119403e-07,
+        "output_cost_per_token": 1.0746268656716418e-06,
+        "cache_read_input_token_cost": 1.791044776119403e-07
       },
       {
         "min_tokens": 256000,
         "max_tokens": null,
-        "input_cost_per_token": 6.6e-07,
-        "output_cost_per_token": 3.961e-06,
-        "cache_read_input_token_cost": 6.6e-07
+        "input_cost_per_token": 7.164179104477612e-07,
+        "output_cost_per_token": 4.298507462686567e-06,
+        "cache_read_input_token_cost": 7.164179104477612e-07
       }
     ],
-    "source": "Alibaba DashScope qwen3.6-flash official USD list (China-mainland; tiered by input tokens: 0<Token<=256K in $0.165/M out $0.99/M, 256K<Token<=1M in $0.66/M out $3.961/M; help.aliyun.com/zh/model-studio/model-pricing captured 2026-06-11). List price only — Batch (half-price)/context-cache discounts not modeled. Whole-request input-tier via overlay intervals."
+    "source": "Alibaba DashScope qwen3.6-flash official China-mainland RMB list ÷ 6.7, tiered by input tokens (0<256K in ¥1.2/M out ¥7.2/M; 256K<1M in ¥4.8/M out ¥28.8/M; 非思考和思考同价); docs/accounts/aliyun_pricing_20260612.md captured 2026-06-12. Corrected 2026-06-13 to canonical CNY/USD=6.7. List price only — Batch (half-price)/context-cache discounts not modeled. Whole-request input-tier via overlay intervals."
   },
   "qwen3-coder-plus": {
     "litellm_provider": "dashscope",
     "mode": "chat",
-    "input_cost_per_token": 5.74e-07,
-    "output_cost_per_token": 2.294e-06,
-    "cache_read_input_token_cost": 5.74e-07,
+    "input_cost_per_token": 5.970149253731343e-07,
+    "output_cost_per_token": 2.3880597014925373e-06,
+    "cache_read_input_token_cost": 5.970149253731343e-07,
     "intervals": [
       {
         "min_tokens": 0,
         "max_tokens": 32000,
-        "input_cost_per_token": 5.74e-07,
-        "output_cost_per_token": 2.294e-06,
-        "cache_read_input_token_cost": 5.74e-07
+        "input_cost_per_token": 5.970149253731343e-07,
+        "output_cost_per_token": 2.3880597014925373e-06,
+        "cache_read_input_token_cost": 5.970149253731343e-07
       },
       {
         "min_tokens": 32000,
         "max_tokens": 128000,
-        "input_cost_per_token": 8.61e-07,
-        "output_cost_per_token": 3.441e-06,
-        "cache_read_input_token_cost": 8.61e-07
+        "input_cost_per_token": 8.955223880597016e-07,
+        "output_cost_per_token": 3.5820895522388063e-06,
+        "cache_read_input_token_cost": 8.955223880597016e-07
       },
       {
         "min_tokens": 128000,
         "max_tokens": 256000,
-        "input_cost_per_token": 1.434e-06,
-        "output_cost_per_token": 5.735e-06,
-        "cache_read_input_token_cost": 1.434e-06
+        "input_cost_per_token": 1.4925373134328358e-06,
+        "output_cost_per_token": 5.970149253731343e-06,
+        "cache_read_input_token_cost": 1.4925373134328358e-06
       },
       {
         "min_tokens": 256000,
         "max_tokens": null,
-        "input_cost_per_token": 2.868e-06,
-        "output_cost_per_token": 2.8671e-05,
-        "cache_read_input_token_cost": 2.868e-06
+        "input_cost_per_token": 2.9850746268656716e-06,
+        "output_cost_per_token": 2.9850746268656717e-05,
+        "cache_read_input_token_cost": 2.9850746268656716e-06
       }
     ],
-    "source": "Alibaba DashScope qwen3-coder-plus official USD list (China-mainland; tiered by input tokens: 0<=32K in $0.574/$2.294 per M, 32K<=128K $0.861/$3.441, 128K<=256K $1.434/$5.735, 256K<=1M $2.868/$28.671; help.aliyun.com/zh/model-studio/model-pricing captured 2026-06-11). List price only — context-cache discount not modeled. Whole-request input-tier via overlay intervals."
+    "source": "Alibaba DashScope qwen3-coder-plus official China-mainland RMB list ÷ 6.7, tiered by input tokens (0<=32K ¥4/¥16; 32K<=128K ¥6/¥24; 128K<=256K ¥10/¥40; 256K<=1M ¥20/¥200 per M); docs/accounts/aliyun_pricing_20260612.md captured 2026-06-12. Corrected 2026-06-13 to canonical CNY/USD=6.7. List price only — context-cache discount not modeled. Whole-request input-tier via overlay intervals."
   },
   "qwen2.5-coder-32b": {
     "litellm_provider": "dashscope",

--- a/scripts/sentinels/gateway-tk.json
+++ b/scripts/sentinels/gateway-tk.json
@@ -1841,14 +1841,16 @@
         "func tkSelectFailureStatusMessage",
         "isOpsNoAvailableAccountError(err)",
         "http.StatusTooManyRequests",
-        "Retry-After"
+        "Retry-After",
+        "errors.Is(err, service.ErrUnsupportedModel)",
+        "http.StatusBadRequest"
       ],
-      "rationale": "Empty-pool fast-fail returns 429+Retry-After (not 503) so Caddy passive-health on the single Stage0 upstream does not conflate an empty scheduling pool with a backend outage and stall all traffic incl. the dashboard. An upstream merge re-introducing 503 at the account-select call sites regresses the prod flood-containment fix (PR #572 / IP 58.213.121.60 1540 RPM incident). tkSelectFailureStatusMessage (PR #723) extends the same semantics to the openai/newapi compat first-selection failure branches: the no-available error family (classified by isOpsNoAvailableAccountError, the same predicate ops capacity-limited marking uses) maps to 429, while genuine scheduler faults (DB outage, context errors) keep 503."
+      "rationale": "Empty-pool fast-fail returns 429+Retry-After (not 503) so Caddy passive-health on the single Stage0 upstream does not conflate an empty scheduling pool with a backend outage and stall all traffic incl. the dashboard. An upstream merge re-introducing 503 at the account-select call sites regresses the prod flood-containment fix (PR #572 / IP 58.213.121.60 1540 RPM incident). tkSelectFailureStatusMessage (PR #723) extends the same semantics to the openai/newapi compat first-selection failure branches: the no-available error family (classified by isOpsNoAvailableAccountError, the same predicate ops capacity-limited marking uses) maps to 429, while genuine scheduler faults (DB outage, context errors) keep 503. The ErrUnsupportedModel→400 (StatusBadRequest) branch (prod 2026-06-13) splits 'no account serves this model NAME' out of the 429 capacity family into a client invalid_request_error, so an unservable model id (e.g. deepseek-chat/qwen-max against a pool mapping only deepseek-v4-*/qwen3.7-*) stops masquerading as a capacity signal that fires ops alerts; it is checked FIRST because ErrUnsupportedModel's message omits 'no available accounts'."
     },
     {
       "path": "backend/internal/handler/openai_chat_completions.go",
       "must_contain": [
-        "tkStatus, tkMsg := tkSelectFailureStatusMessage(c, err)"
+        "tkStatus, tkType, tkMsg := tkSelectFailureStatusMessage(c, err, reqModel)"
       ],
       "rationale": "/v1/chat/completions first-selection failure (len(failedAccountIDs)==0) must route through tkSelectFailureStatusMessage so an empty openai/newapi pool fast-fails 429 instead of 503 (PR #723, #575 parity; prod 2026-06-11: 480 empty-pool 503s in 2min when both GPT accounts hit upstream 429). Reverting this one-line hook to the upstream 503 literal compiles clean but re-exposes the Caddy passive-health melt + SDK retry storm the no_available_accounts_tk.go sentinel documents."
     },
@@ -1856,18 +1858,35 @@
       "path": "backend/internal/handler/openai_gateway_handler.go",
       "must_contain": [
         "h.handleStreamingAwareError(c, tkNoAvailableAccounts(c), \"compact_not_supported\"",
-        "h.handleStreamingAwareError(c, tkStatus, \"api_error\", tkMsg, streamStarted)",
-        "h.anthropicStreamingAwareError(c, tkStatus, \"api_error\", tkMsg, streamStarted)"
+        "h.handleStreamingAwareError(c, tkStatus, tkType, tkMsg, streamStarted)",
+        "h.anthropicStreamingAwareError(c, tkStatus, tkType, tkMsg, streamStarted)"
       ],
       "rationale": "Responses + openai_messages first-selection failure branches must route through tkSelectFailureStatusMessage (429 on empty pool, 503 on real scheduler faults), and the empty compact pool (ErrNoAvailableCompactAccounts) keeps its compact_not_supported code but joins the 429 no-available family (PR #723, #575 parity). The two helper-call sites have identical assignment lines, so the anchors pin the two distinct error-writer lines (handleStreamingAwareError for Responses, anthropicStreamingAwareError for Messages) — losing either on an upstream merge silently reverts that endpoint to empty-pool 503."
     },
     {
       "path": "backend/internal/handler/openai_images.go",
       "must_contain": [
-        "tkStatus, tkMsg := tkSelectFailureStatusMessage(c, err)",
+        "tkStatus, tkType, tkMsg := tkSelectFailureStatusMessage(c, err, requestModel)",
         "h.handleStreamingAwareError(c, tkNoAvailableAccounts(c), \"api_error\", \"No available compatible accounts\", streamStarted)"
       ],
       "rationale": "Images first-selection failure must route through tkSelectFailureStatusMessage, and the selection==nil branch returns 429 via tkNoAvailableAccounts — previously the only selection==nil branch still answering 503, inconsistent with its sibling handlers (PR #723, #575 parity). An upstream merge restoring either 503 literal compiles clean but regresses the image surface back to the Caddy passive-health failure mode."
+    },
+    {
+      "path": "backend/internal/service/openai_account_scheduler_tk_errors.go",
+      "must_contain": [
+        "func (s *defaultOpenAIAccountScheduler) openAICompatNoCandidateErr",
+        "tkSelectionFailedDueToUnsupportedModel(stats)",
+        "ErrUnsupportedModel",
+        "func collectOpenAICompatSelectionFailureStats"
+      ],
+      "rationale": "openAICompatNoCandidateErr is the OpenAI-compat scheduler's single exit for the len(filtered)==0 branch (prod 2026-06-13): when EVERY schedulable account was rejected purely because it does not serve the requested model NAME, it returns service.ErrUnsupportedModel (→ HTTP 400 invalid_request_error via tkSelectFailureStatusMessage) instead of an empty-pool 429 that reads as a capacity signal and fires ops alerts. collectOpenAICompatSelectionFailureStats counts a model-supporting-but-filtered account as Unschedulable so it SUPPRESSES the 400 (the model is served, just not selectable now → keep 429), mirroring the anthropic tkWrapSelectionFailure predicate. Losing this companion on an upstream merge silently reverts unservable-model requests to the misleading empty-pool 429."
+    },
+    {
+      "path": "backend/internal/service/openai_account_scheduler.go",
+      "must_contain": [
+        "s.openAICompatNoCandidateErr(req, accounts)"
+      ],
+      "rationale": "The candidate-filter-empty branch (len(filtered)==0) in selectByLoadBalance must route through openAICompatNoCandidateErr (TK companion) so a pool emptied purely by unservable model NAME surfaces ErrUnsupportedModel→400, not empty-pool 429 (prod 2026-06-13). Reverting this one-line hook to the inline noAvailableOpenAISelectionError/platform-label returns compiles clean but re-buries 'client asked for a model nobody serves' inside the 429 capacity family, re-triggering false ops alerts. Only this branch routes here — the len(accounts)==0 and post-load-balance slot-acquire branches stay 429 (genuine capacity)."
     },
     {
       "path": "backend/internal/service/ratelimit_service_tk_model_cooldown.go",

--- a/scripts/sentinels/gateway-tk.json
+++ b/scripts/sentinels/gateway-tk.json
@@ -1874,19 +1874,26 @@
     {
       "path": "backend/internal/service/openai_account_scheduler_tk_errors.go",
       "must_contain": [
-        "func (s *defaultOpenAIAccountScheduler) openAICompatNoCandidateErr",
+        "func openAICompatNoCandidateError",
         "tkSelectionFailedDueToUnsupportedModel(stats)",
         "ErrUnsupportedModel",
         "func collectOpenAICompatSelectionFailureStats"
       ],
-      "rationale": "openAICompatNoCandidateErr is the OpenAI-compat scheduler's single exit for the len(filtered)==0 branch (prod 2026-06-13): when EVERY schedulable account was rejected purely because it does not serve the requested model NAME, it returns service.ErrUnsupportedModel (→ HTTP 400 invalid_request_error via tkSelectFailureStatusMessage) instead of an empty-pool 429 that reads as a capacity signal and fires ops alerts. collectOpenAICompatSelectionFailureStats counts a model-supporting-but-filtered account as Unschedulable so it SUPPRESSES the 400 (the model is served, just not selectable now → keep 429), mirroring the anthropic tkWrapSelectionFailure predicate. Losing this companion on an upstream merge silently reverts unservable-model requests to the misleading empty-pool 429."
+      "rationale": "openAICompatNoCandidateError is the SHARED single exit for BOTH OpenAI-compat pool-emptied points (prod 2026-06-13): selectByLoadBalance len(filtered)==0 AND selectAccountForModelWithExclusions selectBestAccount→nil. When EVERY schedulable account was rejected purely because it does not serve the requested model NAME, it returns service.ErrUnsupportedModel (→ HTTP 400 invalid_request_error via tkSelectFailureStatusMessage) instead of an empty-pool 429 that reads as a capacity signal and fires ops alerts. collectOpenAICompatSelectionFailureStats counts a model-supporting-but-filtered account as Unschedulable so it SUPPRESSES the 400 (the model is served, just not selectable now → keep 429), mirroring the anthropic tkWrapSelectionFailure predicate. Losing this companion on an upstream merge silently reverts unservable-model requests to the misleading empty-pool 429."
     },
     {
       "path": "backend/internal/service/openai_account_scheduler.go",
       "must_contain": [
-        "s.openAICompatNoCandidateErr(req, accounts)"
+        "openAICompatNoCandidateError(req.RequestedModel, req.GroupPlatform, false, accounts, req.ExcludedIDs)"
       ],
-      "rationale": "The candidate-filter-empty branch (len(filtered)==0) in selectByLoadBalance must route through openAICompatNoCandidateErr (TK companion) so a pool emptied purely by unservable model NAME surfaces ErrUnsupportedModel→400, not empty-pool 429 (prod 2026-06-13). Reverting this one-line hook to the inline noAvailableOpenAISelectionError/platform-label returns compiles clean but re-buries 'client asked for a model nobody serves' inside the 429 capacity family, re-triggering false ops alerts. Only this branch routes here — the len(accounts)==0 and post-load-balance slot-acquire branches stay 429 (genuine capacity)."
+      "rationale": "The candidate-filter-empty branch (len(filtered)==0) in selectByLoadBalance must route through openAICompatNoCandidateError (TK companion) so a pool emptied purely by unservable model NAME surfaces ErrUnsupportedModel→400, not empty-pool 429 (prod 2026-06-13). Reverting this one-line hook to the inline noAvailableOpenAISelectionError/platform-label returns compiles clean but re-buries 'client asked for a model nobody serves' inside the 429 capacity family, re-triggering false ops alerts. Only this branch routes here — the len(accounts)==0 and post-load-balance slot-acquire branches stay 429 (genuine capacity)."
+    },
+    {
+      "path": "backend/internal/service/openai_gateway_service.go",
+      "must_contain": [
+        "openAICompatNoCandidateError(requestedModel, groupPlatform, compactBlocked, accounts, excludedIDs)"
+      ],
+      "rationale": "selectAccountForModelWithExclusions (the priority/LRU path used by count_tokens + sticky/legacy callers) must route its selected==nil exit through the SAME openAICompatNoCandidateError as the load-balance scheduler, so an unservable model NAME surfaces ErrUnsupportedModel→400 on every OpenAI-compat surface, not just /v1/chat/completions (prod 2026-06-13 parity). Reverting to the bare noAvailableOpenAISelectionError compiles clean but re-buries unservable-model as empty-pool 429 on these surfaces and makes the handler's ErrUnsupportedModel→400 mapping dead code there."
     },
     {
       "path": "backend/internal/service/ratelimit_service_tk_model_cooldown.go",


### PR DESCRIPTION
## 背景 / 根因

prod 2026-06-13 05:44:27–05:45:43 出现 8× 空池快失败 `429 No available accounts`（`account_id=null`），模型 `deepseek-chat` `deepseek-reasoner` `qwen-max` `qwen-plus`，而同平台 `deepseek-v4-pro/flash` 正常跑量。

只读诊断（prod，7 天窗口）坐实：**这 4 个名字 7 天内零成功请求**——是客户端用的上游通用/旧名，TK 的 newapi 池只映服务新版：

- group 11 `deepseek` → 账号 39（`api.deepseek.com`）`model_mapping` 仅 `deepseek-v4-pro/flash`
- group 18 `Qwen` → 账号 60（`dashscope.aliyuncs.com`）`model_mapping` 仅 `qwen3.7-*`

名字不在任一账号 mapping → 调度器过滤殆尽 → 空池 429，被误当容量信号触发告警。

## 改动（3 个 commit，一个 PR）

### commit 1 — Item 2（不服务模型名 → 400 而非空池 429）+ Item 1b（qwen-max/plus 定价）
**Item 2**：镜像已存在的 anthropic `ErrUnsupportedModel`→400 模式到 openai/newapi 调度器：

- `openai_account_scheduler_tk_errors.go`：`openAICompatNoCandidateError` + `collectOpenAICompatSelectionFailureStats`。当池内每个可调度账号都仅因不服务该模型名被拒（无任一账号支持该名）→ 返回 `service.ErrUnsupportedModel`；否则保持原空池 429/平台标签。支持该模型但因冷却/能力/上游限制被过滤的账号计为 `Unschedulable`，**抑制** 400（仍 429），无回归。
- `no_available_accounts_tk.go`：`tkSelectFailureStatusMessage` 扩为 `(status, errType, msg)` + `reqModel`，对 `ErrUnsupportedModel` 返回 **400 `invalid_request_error`**（client-owned，phase=request，不计入 `upstream_error_rate`；经 `classifyOpsErrorLog` 400→client 确认）。8 个 openai/newapi 调用点同步传 `reqModel` + `errType`。

**Item 1b**：`tk_pricing_overlay.json` 新增 `qwen-max`（无阶梯 ¥2.4/¥9.6 ÷6.7）、`qwen-plus`（分段，**非思考**输出价；qwen-plus 系列默认 `enable_thinking=false`，非思考即默认模式价，已核 Alibaba 文档）。两者在 litellm 镜像缺失，不补会零计费泄漏。

### commit 2 — Item 2 R-001：覆盖 selectBestAccount 路径
self-review 发现首版只覆盖 `selectByLoadBalance`，而 count_tokens/sticky 走 `selectAccountForModelWithExclusions → selectBestAccount` 第二出口仍返回 429。重构为共享 `openAICompatNoCandidateError`，两个 pool-emptied 出口统一经它；既有测试 `_NoModelSupport` 翻成断言 400。

### commit 3 — 汇率口径修正：qwen3.x 全部统一到 CNY/USD=6.7
核实 qwen3.7-max 计费时发现全表 CNY→USD 口径漂移：`qwen3.7-max/plus`、`qwen3.6-flash` 隐含除数 **7.27**、`qwen3-coder-plus` **6.97**，而 overlay 注释 56 处统一声明 **÷6.7**（唯一口径源，代码无汇率常量）。账号 60 走 dashscope 中国内地端按人民币计费，应 ÷6.7。

按 `docs/accounts/aliyun_pricing_20260612.md` 中国内地人民币 ÷6.7 重算这 4 个模型共 8 条（qwen3.7-max 含 4 快照），价格上调 ~8.5%（coder-plus ~4%）。例：qwen3.7-max ¥12/¥36 → $1.791/$5.373。修复后全部 CNY 计价条目反推除数均 = 6.700。
- **qwen3.7-max 思考/非思考无价差**：文档「非思考和思考模式」共用一档，原「同价」处理正确，本次仅修汇率口径。
- 未动：deepseek-v3-2、qwen2.5-coder-*（经核已 6.7）、deepseek-v4-*（DeepSeek 美元原生价）、我新加的 qwen-max/plus（本就 6.7）。

### sentinel
`gateway-tk.json` 更新 `tkSelectFailureStatusMessage` 签名锚点 + 新增 `openAICompatNoCandidateError` / 两个注入点锚点 + `no_available_accounts_tk.go` 的 `ErrUnsupportedModel`→400 锚点。

## 不在本 PR 内
**Item 1a（让 4 个模型真正可服务）= prod `model_mapping` 写**：给账号 39 加 `deepseek-chat/reasoner`、账号 60 加 `qwen-max/plus` 映射 + 失效调度缓存。独立 prod 运维动作，经确认的 admin-API/SSM remediation 单独执行。本 PR 让「客户端用错名字」从容量告警里摘出（即便不补服务也立即止血噪声）。

## 测试
- 调度器单测：unsupported→`ErrUnsupportedModel` / 有账号支持→429 / excluded 抑制 / 空模型 / passthrough；handler 单测：`ErrUnsupportedModel`→400。
- 区间定价测试期望值改为 `¥/6.7e6` 自证形式。
- `go test -tags=unit ./...` 全绿；`scripts/preflight.sh` 绿；`scripts/checks/pricing-overlay.py` 绿。

## markers
upstream-touch-guarded
no-web-impact
sentinel-registry-reviewed

🤖 Generated with [Claude Code](https://claude.com/claude-code)
