### PR TITLE
fix(gateway): 退役-opus 重映去掉 claude-opus-4-6（仍服务且回明文 thinking）

### DIFF
--- a/backend/internal/service/gateway_service_tk_canonical_oauth_guard.go
+++ b/backend/internal/service/gateway_service_tk_canonical_oauth_guard.go
@@ -14,8 +14,10 @@ import (
 // 2026-05-25 Anthropic hold on edge-uk1 account EN-LD-EC2-16-3:
 //   1. third-party SDK UAs (OpenAI/Python, httpx, requests, ...) silently
 //      draining a personal Claude Code subscription
-//   2. retired models (claude-opus-4-6 / claude-opus-4-5*) routed alongside the
+//   2. retired models (claude-opus-4-5* and older) routed alongside the
 //      current 4-7 default — a mix-pattern real cc clients no longer produce.
+//      (claude-opus-4-6 is deliberately excluded — see canonicalDeprecatedOpusPrefixes:
+//      it still serves upstream WITH plaintext thinking, so remapping it away is harmful.)
 //
 // Both gates are scoped to OAuth + canonical TLS only; API-key channels and
 // non-canonical OAuth accounts keep upstream-default behavior.
@@ -156,12 +158,20 @@ func shouldRewriteSystemForNonCCMimicry(reqModel string, canonicalStrict bool) b
 // opus model ids are remapped to this on the canonical OAuth path.
 const canonicalDefaultOpus = "claude-opus-4-7"
 
-// canonicalDeprecatedOpusPrefixes lists the opus model ids that the 2.1.150
-// Claude Code CLI no longer emits by default; routing them alongside 4-7
-// produces a mix-pattern that current real clients do not. Each entry is the
-// model-id prefix (so dated variants like claude-opus-4-6-20250930 are caught).
+// canonicalDeprecatedOpusPrefixes lists opus model ids to remap to the current
+// default. Each entry is a model-id prefix (so dated variants like
+// claude-opus-4-5-20250520 are caught too).
+//
+// NOTE: claude-opus-4-6 is intentionally NOT in this list. It is still served
+// upstream and — unlike opus >= 4-7 — still returns PLAINTEXT extended thinking
+// (verified 2026-06-13: opus-4-6 -> HTTP 200 with ~1800-3800 chars of thinking,
+// while opus-4-7/4-8 return an empty thinking block + signature only). Remapping
+// 4-6 -> 4-7 silently destroyed that thinking (and silently substituted the
+// model the caller asked for / its billing key). The remap's original rationale
+// ("retired opus no longer emits thinking") proved false for 4-6, so it passes
+// through. opus-4-5 stays remapped only because it rejects the thinking shape we
+// send (`adaptive`); 4-4 and older are genuinely 404 upstream.
 var canonicalDeprecatedOpusPrefixes = []string{
-	"claude-opus-4-6",
 	"claude-opus-4-5",
 	"claude-opus-4-4",
 	"claude-opus-4-3",

--- a/backend/internal/service/gateway_service_tk_canonical_oauth_guard_test.go
+++ b/backend/internal/service/gateway_service_tk_canonical_oauth_guard_test.go
@@ -235,7 +235,8 @@ func TestShouldRewriteSystemForNonCCMimicry(t *testing.T) {
 func TestRemapDeprecatedOpusOnCanonical_RetiredOpusToCurrentDefault(t *testing.T) {
 	cases := map[string]string{
 		// NOTE: claude-opus-4-6 is intentionally NOT here — it still serves upstream
-		// with plaintext thinking and must pass through (see *_Opus46PassesThrough).
+		// with plaintext thinking and must pass through (asserted in
+		// TestRemapDeprecatedOpusOnCanonical_CurrentAndNonOpusUnchanged).
 		"claude-opus-4-5":          canonicalDefaultOpus,
 		"claude-opus-4-5-20250520": canonicalDefaultOpus,
 		"claude-opus-4-4":          canonicalDefaultOpus,
@@ -284,12 +285,13 @@ func TestRemapDeprecatedOpusOnCanonical_CurrentAndNonOpusUnchanged(t *testing.T)
 }
 
 // TestRemapDeprecatedOpusOnCanonical_OpusPrefixIsolation verifies that the
-// prefix check requires either an exact match or a "-" separator so
-// "claude-opus-4-60" (hypothetical) is NOT treated as opus-4-6.
+// prefix check requires either an exact match or a "-" separator, so a longer
+// id that merely shares a listed prefix's digits (e.g. "claude-opus-4-50" vs the
+// listed "claude-opus-4-5") is NOT remapped.
 func TestRemapDeprecatedOpusOnCanonical_OpusPrefixIsolation(t *testing.T) {
 	cases := []string{
-		"claude-opus-4-60",
-		"claude-opus-4-65",
+		"claude-opus-4-50", // shares "claude-opus-4-5" digits but no "-" boundary
+		"claude-opus-4-55",
 		"claude-opus-4-7x",
 	}
 	for _, in := range cases {

--- a/backend/internal/service/gateway_service_tk_canonical_oauth_guard_test.go
+++ b/backend/internal/service/gateway_service_tk_canonical_oauth_guard_test.go
@@ -234,15 +234,15 @@ func TestShouldRewriteSystemForNonCCMimicry(t *testing.T) {
 
 func TestRemapDeprecatedOpusOnCanonical_RetiredOpusToCurrentDefault(t *testing.T) {
 	cases := map[string]string{
-		"claude-opus-4-6":          canonicalDefaultOpus,
-		"claude-opus-4-6-20250930": canonicalDefaultOpus,
+		// NOTE: claude-opus-4-6 is intentionally NOT here — it still serves upstream
+		// with plaintext thinking and must pass through (see *_Opus46PassesThrough).
 		"claude-opus-4-5":          canonicalDefaultOpus,
 		"claude-opus-4-5-20250520": canonicalDefaultOpus,
 		"claude-opus-4-4":          canonicalDefaultOpus,
 		"claude-opus-4-1":          canonicalDefaultOpus,
 		"claude-opus-4-0":          canonicalDefaultOpus,
 		// case-insensitive
-		"Claude-Opus-4-6": canonicalDefaultOpus,
+		"Claude-Opus-4-5": canonicalDefaultOpus,
 	}
 	for in, want := range cases {
 		got, remapped := remapDeprecatedOpusOnCanonical(in)
@@ -260,6 +260,12 @@ func TestRemapDeprecatedOpusOnCanonical_CurrentAndNonOpusUnchanged(t *testing.T)
 	cases := []string{
 		"claude-opus-4-7",
 		"claude-opus-4-7-20260301",
+		// opus-4-6 still serves upstream with plaintext thinking — must pass through
+		// unchanged (remapping it to 4-7 would silently drop the thinking + swap the
+		// billing key). See gateway_service_tk_canonical_oauth_guard.go NOTE.
+		"claude-opus-4-6",
+		"claude-opus-4-6-20250930",
+		"Claude-Opus-4-6",
 		"claude-sonnet-4-6",
 		"claude-sonnet-4-5",
 		"claude-haiku-4-5-20251001",


### PR DESCRIPTION
## 背景

PR #750 主张「退役 opus（4-6/4-5）上游已不再回 extended thinking」，并据此把 `remapDeprecatedOpusOnCanonical`（opus-4-6→4-7）**扩到全 anthropic OAuth**。**该前提对 opus-4-6 是错的。**

## 实测（2026-06-13，三路径互证）

| 路径 | 模型 | thinking 文本 |
|---|---|---|
| first-party cc0（真 Claude Code，自有订阅，不经 TK） | claude-opus-4-6 | **3789 字明文** ✓ |
| 直连 edge OAuth（自有账号，绕过 TK 网关） | claude-opus-4-6 | **3363 / 1834 字明文** ✓ |
| 任意路径 | claude-opus-4-7 / 4-8 | **0**（空块+签名，上游模型级扣留） |
| 直连 | claude-opus-4-5 | HTTP 400「adaptive thinking not supported」(模型在，仅拒形状) |
| 直连 | claude-opus-4-4 | HTTP 404（真退役） |

→ 扣留只针对 **opus≥4-7**，**不含 4-6**。把 opus-4-6 重映到 4-7 反而：①销毁了 4-6 本可返回的明文 thinking；②把请求静默升级成被扣留的 4-7；③把计费 key 换成 4-7。

## 改动

- `gateway_service_tk_canonical_oauth_guard.go`：从 `canonicalDeprecatedOpusPrefixes` 删掉 `claude-opus-4-6`（保留 4-5/4-4/…，理由见注释）。
- 测试：4-6 从「被重映」用例移到「passthrough 不重映」用例。
- `go build ./...` ✅；`go test -tags=unit ./internal/service/` 全绿。

## 与 #750 的关系

方向相反：#750 把有害重映**扩大**，本 PR 把 4-6 **移出**重映。本 PR 取代 #750，建议 #750 关闭。

no-web-impact

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
sentinel-registry-reviewed — 改动仅从一个 Go 字符串切片删一个 model id 并改注释/测试；该文件(gateway_service_tk_canonical_oauth_guard.go)非 sentinel 注册面，无需新增/更新 anchor。
