### PR TITLE
fix(gateway): capability-scope 401 no longer cools the whole account

### DIFF
--- a/backend/internal/service/openai_gateway_service.go
+++ b/backend/internal/service/openai_gateway_service.go
@@ -2458,6 +2458,15 @@ func (s *OpenAIGatewayService) shouldFailoverUpstreamError(statusCode int) bool 
 }
 
 func (s *OpenAIGatewayService) shouldFailoverOpenAIUpstreamResponse(statusCode int, upstreamMsg string, upstreamBody []byte) bool {
+	// TK (prod P0 2026-06-13, GPT专线): a capability/scope-level 401 must NOT
+	// failover. Every account in the pool shares the same missing capability scope,
+	// so failing over just poisons each account in turn (and, with the no-cooldown
+	// guard in HandleUpstreamError, would otherwise loop the whole pool before the
+	// empty-pool 429). Route it straight to the non-failover error handler, which
+	// maps it to a client 400. See ratelimit_service_tk_capability_scope_401.go.
+	if tkIsCapabilityScope401(statusCode, upstreamBody) {
+		return false
+	}
 	if s.shouldFailoverUpstreamError(statusCode) {
 		return true
 	}
@@ -4629,6 +4638,17 @@ func (s *OpenAIGatewayService) handleErrorResponse(
 
 	switch resp.StatusCode {
 	case 401:
+		// TK (prod P0 2026-06-13, GPT专线): a capability/scope-level 401 is a
+		// per-request capability gap (token missing the scope for this operation,
+		// e.g. image generation), not an account-side auth failure — surface it as a
+		// 400 invalid_request so the caller knows the model/capability is not
+		// available on the serving account. See ratelimit_service_tk_capability_scope_401.go.
+		if tkIsCapabilityScope401(resp.StatusCode, body) {
+			statusCode = http.StatusBadRequest
+			errType = "invalid_request_error"
+			errMsg = tkCapabilityScope401ClientMessage(upstreamMsg)
+			break
+		}
 		statusCode = http.StatusBadGateway
 		errType = "upstream_error"
 		errMsg = "Upstream authentication failed, please contact administrator"
@@ -4786,6 +4806,15 @@ func (s *OpenAIGatewayService) handleCompatErrorResponse(
 	}
 
 	MarkResponseCommitted(c)
+
+	// TK (prod P0 2026-06-13, GPT专线): a capability/scope-level 401 is a
+	// per-request capability gap, not an account-side auth failure — surface it as a
+	// 400 invalid_request (the account stays schedulable for every other model).
+	// See ratelimit_service_tk_capability_scope_401.go.
+	if tkIsCapabilityScope401(resp.StatusCode, body) {
+		writeError(c, http.StatusBadRequest, "invalid_request_error", tkCapabilityScope401ClientMessage(upstreamMsg))
+		return nil, fmt.Errorf("upstream error: %d (capability scope 401) %s", resp.StatusCode, upstreamMsg)
+	}
 
 	// Map status code to error type and write response
 	errType := "api_error"

--- a/backend/internal/service/openai_images_responses.go
+++ b/backend/internal/service/openai_images_responses.go
@@ -743,6 +743,23 @@ func (s *OpenAIGatewayService) handleOpenAIImagesErrorResponse(
 		}
 	}
 
+	// TK (prod P0 2026-06-13, GPT专线): a capability/scope-level 401 (the serving
+	// OAuth token is missing the image-generation scope, e.g. Missing scopes:
+	// api.model.images.request) is a per-request capability gap, not an account-side
+	// auth failure — surface it as a 400 invalid_request. The no-cooldown guard in
+	// HandleUpstreamError already kept the account schedulable for every other model.
+	// See ratelimit_service_tk_capability_scope_401.go.
+	if tkIsCapabilityScope401(resp.StatusCode, body) {
+		upErr := &OpenAIImagesUpstreamError{
+			StatusCode:        http.StatusBadRequest,
+			ErrorType:         "invalid_request_error",
+			Message:           tkCapabilityScope401ClientMessage(upstreamMsg),
+			UpstreamRequestID: strings.TrimSpace(resp.Header.Get("x-request-id")),
+		}
+		writeOpenAIImagesUpstreamErrorResponse(c, upErr)
+		return nil, upErr
+	}
+
 	// Surface the real upstream error to the client.
 	upErr := openAIImagesUpstreamErrorFromHTTP(resp.StatusCode, resp.Header, body)
 	writeOpenAIImagesUpstreamErrorResponse(c, upErr)

--- a/backend/internal/service/ratelimit_service.go
+++ b/backend/internal/service/ratelimit_service.go
@@ -376,6 +376,17 @@ func (s *RateLimitService) HandleUpstreamError(ctx context.Context, account *Acc
 		}
 		// 其他 400 错误（如参数问题）不处理，不禁用账号
 	case 401:
+		// TK (prod P0 2026-06-13, GPT专线): a capability/scope-level 401 (the
+		// upstream rejects a specific capability — e.g. image generation — because
+		// the serving OAuth token lacks that capability's scope) must NOT cool or
+		// disable the account. The account can still serve every other model; the
+		// caller's gateway error mapping surfaces this as a 400 capability-unservable
+		// error for THIS request only. See ratelimit_service_tk_capability_scope_401.go.
+		if tkIsCapabilityScope401(statusCode, responseBody) {
+			slog.Info("capability_scope_401_skip_penalty",
+				"account_id", account.ID, "platform", account.Platform, "message", upstreamMsg)
+			return false
+		}
 		// OpenAI: token_invalidated / token_revoked 表示 token 被永久作废（非过期），直接标记 error
 		openai401Code := extractUpstreamErrorCode(responseBody)
 		if account.Platform == PlatformOpenAI && (openai401Code == "token_invalidated" || openai401Code == "token_revoked") {

--- a/backend/internal/service/ratelimit_service_tk_capability_scope_401.go
+++ b/backend/internal/service/ratelimit_service_tk_capability_scope_401.go
@@ -1,0 +1,109 @@
+package service
+
+import (
+	"strings"
+
+	"github.com/tidwall/gjson"
+)
+
+// TK (prod P0 2026-06-13, GPT专线 group_id=2): a capability/scope-level upstream
+// 401 — the upstream rejects a SPECIFIC capability (e.g. image generation)
+// because the serving OAuth token is missing that capability's scope — must NOT
+// be treated as an account-level auth failure.
+//
+// Incident: the GPT专线 group had only 2 healthy OpenAI OAuth accounts (ids 9
+// "GPT-pro1", 48 "GPT-pro2"). Both lacked the image-generation scope. A
+// `gpt-image-1` request (POST /v1/images/generations) made OpenAI return:
+//
+//	OAuth 401: You have insufficient permissions for this operation. Missing
+//	scopes: api.model.images.request. Check that you have the correct role in
+//	your organization (Reader, Writer, Owner) and project (Member, Owner) ...
+//
+// The generic 401 handling cooled the WHOLE account for ~10 minutes
+// (SetTempUnschedulable / runtime block), which drained BOTH healthy accounts
+// out of the pool for ALL models (claude-opus-4-7, gpt-5.5, opus-4-8, gpt-image-*).
+// The entire group then served 429 "No available accounts" for the cooldown
+// window — a classic thin-pool 503/429 amplifier (cf. #725): one poison
+// capability gets fanned out into a pool-wide outage.
+//
+// The account is perfectly capable of serving chat/completions — only the IMAGE
+// capability is unauthorized. So this sub-class of 401 must:
+//  1. NOT cool / disable the account (HandleUpstreamError returns shouldDisable=false),
+//  2. NOT trigger account failover (shouldFailoverOpenAIUpstreamResponse=false) —
+//     every account in the pool shares the same missing scope, so failing over
+//     just poisons each account in turn,
+//  3. surface a clear client-facing 400 for THAT request only, analogous to how
+//     TK returns 400 for retired/unservable model names.
+//
+// A GENUINE account-level 401 (invalid/revoked credentials, expired token,
+// {"detail":"Unauthorized"}, token_invalidated/token_revoked) keeps the existing
+// cooldown/disable behavior — the whole point is to DISTINGUISH the two, never to
+// weaken real auth-failure handling.
+//
+// Kept in a TK-only companion file so future upstream merges of
+// ratelimit_service.go / openai_gateway_service.go do not collide on this branch.
+
+// tkCapabilityScope401Marker is the OpenAI substring that unambiguously marks a
+// capability/scope rejection (case-insensitive). "missing scopes" is the
+// load-bearing signal: OpenAI emits it only when a token lacks a scope for a
+// specific capability (e.g. api.model.images.request), never for a generic
+// expired/invalid credential. "insufficient permissions for this operation"
+// accompanies it and is required as a second anchor so a server-side message that
+// merely happens to contain "scope" cannot trip this path.
+const (
+	tkCapabilityScope401MissingScopes  = "missing scopes"
+	tkCapabilityScope401InsufficientOp = "insufficient permissions for this operation"
+)
+
+// tkIsCapabilityScope401 reports whether a 401 upstream response is a
+// capability/scope rejection (token missing a capability scope) rather than an
+// account-level auth failure. Matches the OpenAI missing-scope signature
+// precisely — both anchor phrases must be present — to avoid mis-classifying a
+// generic 401 as a recoverable capability gap.
+func tkIsCapabilityScope401(statusCode int, body []byte) bool {
+	if statusCode != 401 {
+		return false
+	}
+	hay := tkCapabilityScope401Haystack(body)
+	if hay == "" {
+		return false
+	}
+	return strings.Contains(hay, tkCapabilityScope401MissingScopes) &&
+		strings.Contains(hay, tkCapabilityScope401InsufficientOp)
+}
+
+// tkCapabilityScope401Haystack assembles the lower-cased text to scan: the
+// extracted/structured error message plus the common OpenAI envelope fields. We
+// scan structured fields (not the raw body verbatim) so a scope literal that only
+// appears inside an unrelated field cannot match, while still covering both the
+// {"error":{"message":...}} and {"detail":...} shapes OpenAI uses for 401.
+func tkCapabilityScope401Haystack(body []byte) string {
+	if len(body) == 0 {
+		return ""
+	}
+	parts := make([]string, 0, 3)
+	if msg := strings.TrimSpace(extractUpstreamErrorMessage(body)); msg != "" {
+		parts = append(parts, msg)
+	}
+	if errMsg := strings.TrimSpace(gjson.GetBytes(body, "error.message").String()); errMsg != "" {
+		parts = append(parts, errMsg)
+	}
+	if detail := strings.TrimSpace(gjson.GetBytes(body, "detail").String()); detail != "" {
+		parts = append(parts, detail)
+	}
+	return strings.ToLower(strings.Join(parts, "\n"))
+}
+
+// tkCapabilityScope401ClientMessage is the client-facing message for a
+// capability-scope 401. It states the capability is not available on the serving
+// account WITHOUT leaking which account, mirroring the actionable-but-non-leaky
+// shape of TK's retired-model 400 messages.
+func tkCapabilityScope401ClientMessage(upstreamMsg string) string {
+	base := "The requested capability is not available on the serving account " +
+		"(the upstream account's credentials are missing the required scope for this operation)."
+	upstreamMsg = strings.TrimSpace(upstreamMsg)
+	if upstreamMsg == "" {
+		return base
+	}
+	return base + " Upstream detail: " + upstreamMsg
+}

--- a/backend/internal/service/ratelimit_service_tk_capability_scope_401_test.go
+++ b/backend/internal/service/ratelimit_service_tk_capability_scope_401_test.go
@@ -1,0 +1,128 @@
+//go:build unit
+
+package service
+
+import (
+	"context"
+	"net/http"
+	"testing"
+
+	"github.com/Wei-Shaw/sub2api/internal/config"
+	"github.com/stretchr/testify/require"
+)
+
+// The exact OpenAI OAuth 401 body from the GPT专线 incident (2026-06-13): a
+// gpt-image-1 request hit an OAuth account whose token lacks the image scope.
+const tkCapabilityScope401IncidentBody = `{"error":{"message":"You have insufficient permissions for this operation. Missing scopes: api.model.images.request. Check that you have the correct role in your organization (Reader, Writer, Owner) and project (Member, Owner), and if you're using a restricted API key, that it has the necessary scopes.","type":"invalid_request_error","code":"insufficient_scope"}}`
+
+func TestTkIsCapabilityScope401(t *testing.T) {
+	// The incident body — both anchors present → capability-scope 401.
+	require.True(t, tkIsCapabilityScope401(401, []byte(tkCapabilityScope401IncidentBody)))
+
+	// Same signature carried in the {"detail":...} envelope shape.
+	require.True(t, tkIsCapabilityScope401(401,
+		[]byte(`{"detail":"You have insufficient permissions for this operation. Missing scopes: api.model.images.request."}`)))
+
+	// Generic invalid-credentials 401 → NOT capability-scope (must keep cooldown).
+	require.False(t, tkIsCapabilityScope401(401,
+		[]byte(`{"error":{"message":"invalid or expired credentials","type":"invalid_request_error"}}`)))
+	require.False(t, tkIsCapabilityScope401(401, []byte(`{"detail":"Unauthorized"}`)))
+
+	// Only one anchor present → NOT a match (precise, not a generic "scope" grep).
+	require.False(t, tkIsCapabilityScope401(401,
+		[]byte(`{"error":{"message":"Missing scopes: api.model.foo"}}`)))
+	require.False(t, tkIsCapabilityScope401(401,
+		[]byte(`{"error":{"message":"insufficient permissions for this operation"}}`)))
+
+	// Non-401 status with the signature → NOT a match (this gate is 401-only).
+	require.False(t, tkIsCapabilityScope401(403, []byte(tkCapabilityScope401IncidentBody)))
+	require.False(t, tkIsCapabilityScope401(401, nil))
+}
+
+func TestTkCapabilityScope401ClientMessage(t *testing.T) {
+	base := tkCapabilityScope401ClientMessage("")
+	require.Contains(t, base, "not available on the serving account")
+	require.Contains(t, base, "missing the required scope")
+
+	withDetail := tkCapabilityScope401ClientMessage("Missing scopes: api.model.images.request")
+	require.Contains(t, withDetail, "Upstream detail: Missing scopes: api.model.images.request")
+}
+
+// Branch (a): a capability-scope 401 must NOT cool/disable the account.
+// HandleUpstreamError returns shouldDisable=false and writes NEITHER
+// temp_unschedulable NOR error — the account stays schedulable for every other
+// model (claude-opus-4-7, gpt-5.5, ...).
+func TestRateLimitService_HandleUpstreamError_CapabilityScope401_DoesNotCoolAccount(t *testing.T) {
+	repo := &rateLimitAccountRepoStub{}
+	service := NewRateLimitService(repo, nil, &config.Config{}, nil, nil)
+	// The incident account shape: OpenAI OAuth (id 9 "GPT-pro1" / id 48 "GPT-pro2").
+	account := &Account{
+		ID:       9,
+		Platform: PlatformOpenAI,
+		Type:     AccountTypeOAuth,
+		Credentials: map[string]any{
+			"refresh_token": "rt",
+		},
+	}
+
+	body := []byte(tkCapabilityScope401IncidentBody)
+	// Even when hit repeatedly (a heavy image client), the account is never cooled.
+	for i := 0; i < 5; i++ {
+		shouldDisable := service.HandleUpstreamError(context.Background(), account, 401, http.Header{}, body)
+		require.False(t, shouldDisable, "iteration %d: capability-scope 401 must not disable the account", i)
+	}
+
+	require.Equal(t, 0, repo.tempCalls, "capability-scope 401 must never write temp_unschedulable")
+	require.Equal(t, 0, repo.setErrorCalls, "capability-scope 401 must never SetError")
+}
+
+// Branch (b): a GENUINE account-level 401 (invalid/expired credentials, no
+// capability-scope signature) must keep the EXISTING cooldown behavior. For an
+// OAuth account this is a temp_unschedulable cooldown (give the refresh window).
+func TestRateLimitService_HandleUpstreamError_GenericOAuth401_StillCoolsAccount(t *testing.T) {
+	repo := &rateLimitAccountRepoStub{}
+	service := NewRateLimitService(repo, nil, &config.Config{}, nil, nil)
+	account := &Account{
+		ID:       9,
+		Platform: PlatformOpenAI,
+		Type:     AccountTypeOAuth,
+		Credentials: map[string]any{
+			"refresh_token": "rt",
+		},
+	}
+
+	body := []byte(`{"error":{"message":"invalid or expired credentials","type":"invalid_request_error"}}`)
+	shouldDisable := service.HandleUpstreamError(context.Background(), account, 401, http.Header{}, body)
+
+	require.True(t, shouldDisable, "generic 401 must still trigger failover/cooldown")
+	require.Equal(t, 1, repo.tempCalls, "generic OAuth 401 must temp_unschedulable as before")
+	require.Equal(t, 0, repo.setErrorCalls)
+}
+
+// A capability-scope 401 must NOT trigger account failover (every account in the
+// pool shares the same missing scope), but a generic 401 still must.
+func TestOpenAIGatewayService_ShouldFailover_CapabilityScope401Suppressed(t *testing.T) {
+	svc := &OpenAIGatewayService{}
+	capBody := []byte(tkCapabilityScope401IncidentBody)
+	require.False(t, svc.shouldFailoverOpenAIUpstreamResponse(401, "", capBody),
+		"capability-scope 401 must not failover")
+
+	genericBody := []byte(`{"error":{"message":"invalid or expired credentials"}}`)
+	require.True(t, svc.shouldFailoverOpenAIUpstreamResponse(401, "invalid or expired credentials", genericBody),
+		"generic 401 must still failover")
+}
+
+// Branch (b'): a genuine permanent-auth 401 ({"detail":"Unauthorized"}) on an
+// OpenAI account must still SetError (permanent disable), unchanged.
+func TestRateLimitService_HandleUpstreamError_OpenAIUnauthorized401_StillSetsError(t *testing.T) {
+	repo := &rateLimitAccountRepoStub{}
+	service := NewRateLimitService(repo, nil, &config.Config{}, nil, nil)
+	account := &Account{ID: 48, Platform: PlatformOpenAI, Type: AccountTypeOAuth}
+
+	body := []byte(`{"detail":"Unauthorized"}`)
+	shouldDisable := service.HandleUpstreamError(context.Background(), account, 401, http.Header{}, body)
+
+	require.True(t, shouldDisable)
+	require.Equal(t, 1, repo.setErrorCalls, "permanent-auth 401 must SetError unchanged")
+	require.Equal(t, 0, repo.tempCalls)
+}

--- a/scripts/sentinels/gateway-tk.json
+++ b/scripts/sentinels/gateway-tk.json
@@ -2479,6 +2479,40 @@
         "{\"HoldReconcilerService\", func() error {"
       ],
       "rationale": "Hold reconciler shutdown hook in provideCleanup (PR #746): forces wire to construct (and therefore start) the reconciler and stops its ticker at shutdown. Same silent-consistent-deletion risk as the service/wire.go entry."
+    },
+    {
+      "path": "backend/internal/service/ratelimit_service_tk_capability_scope_401.go",
+      "must_contain": [
+        "func tkIsCapabilityScope401(statusCode int, body []byte) bool",
+        "tkCapabilityScope401MissingScopes  = \"missing scopes\"",
+        "tkCapabilityScope401InsufficientOp = \"insufficient permissions for this operation\"",
+        "func tkCapabilityScope401ClientMessage(upstreamMsg string) string"
+      ],
+      "rationale": "TK fix (prod P0 2026-06-13, GPT专线 group_id=2): a capability/scope-level upstream 401 (token missing a capability scope, e.g. images Missing scopes: api.model.images.request) must NOT cool the whole account — that drained a thin OpenAI OAuth pool to zero and 429'd ALL models for ~10min (503/429 amplifier, cf. #725). The detector keys on BOTH 'missing scopes' AND 'insufficient permissions for this operation' to distinguish capability-401 from a genuine account-level 401. If an upstream merge drops this file the no-cooldown / no-failover / client-400 guards below silently revert to cooling the account again."
+    },
+    {
+      "path": "backend/internal/service/ratelimit_service.go",
+      "must_contain": [
+        "tkIsCapabilityScope401(statusCode, responseBody)",
+        "capability_scope_401_skip_penalty"
+      ],
+      "rationale": "Injection point: HandleUpstreamError case 401 short-circuits a capability-scope 401 to shouldDisable=false BEFORE any temp_unschedulable / SetError path, so the account stays schedulable for every other model. Anchors the no-cooldown guard against silent upstream-merge reversion (paired with ratelimit_service_tk_capability_scope_401.go)."
+    },
+    {
+      "path": "backend/internal/service/openai_gateway_service.go",
+      "must_contain": [
+        "if tkIsCapabilityScope401(statusCode, upstreamBody) {",
+        "if tkIsCapabilityScope401(resp.StatusCode, body) {"
+      ],
+      "rationale": "Injection points: shouldFailoverOpenAIUpstreamResponse suppresses failover for a capability-scope 401 (every pool account shares the missing scope), and the non-failover handleErrorResponse/handleCompatErrorResponse 401 sites map it to a client 400 invalid_request_error. Anchors the no-failover + client-400 guards against silent upstream-merge reversion."
+    },
+    {
+      "path": "backend/internal/service/openai_images_responses.go",
+      "must_contain": [
+        "if tkIsCapabilityScope401(resp.StatusCode, body) {",
+        "tkCapabilityScope401ClientMessage(upstreamMsg)"
+      ],
+      "rationale": "Injection point: handleOpenAIImagesErrorResponse (the actual incident path for POST /v1/images/generations) maps a capability-scope 401 to a client 400 invalid_request_error instead of surfacing the upstream 401 / triggering cooldown. Anchors the image-path client-400 guard against silent upstream-merge reversion."
     }
   ]
 }


### PR DESCRIPTION
## Root cause (prod P0, GPT专线 group_id=2)

The `GPT专线` group (platform=openai) dropped to **zero schedulable accounts** for ~10 minutes, returning a storm of `429 "No available accounts"` for **all** models in the group (claude-opus-4-7, gpt-5.5, opus-4-8, gpt-image-*), affecting heavy traffic (user_id=16 "计算所").

The group had only 2 healthy accounts — ids **9 "GPT-pro1"** and **48 "GPT-pro2"** (the other 4 are status=error/admin-disabled). Both are OpenAI OAuth accounts whose tokens **lack the image-generation scope**. When a `gpt-image-1` request (`POST /v1/images/generations`) hit them, OpenAI returned an upstream **401**:

> OAuth 401: You have insufficient permissions for this operation. **Missing scopes: api.model.images.request**. Check that you have the correct role in your organization (Reader, Writer, Owner) and project (Member, Owner), and if you're using a restricted API key, that it has the necessary scopes.

TK treated this as an account-level auth failure → **full-account temp cooldown (~10min)**. That removed **both** healthy accounts from the pool for **all** models, not just images. This is the same class as the historical "503/429 amplifier + thin-pool" issue (#725): one poison capability fans out into a pool-wide outage. The account is perfectly capable of serving chat/completions — only the IMAGE capability is unauthorized.

## The distinction: capability-401 vs account-401

| | capability-scope 401 | genuine account 401 |
|---|---|---|
| Signature | body contains **both** `missing scopes` **and** `insufficient permissions for this operation` | invalid/expired creds, `{"detail":"Unauthorized"}`, `token_invalidated`/`token_revoked`, missing refresh_token |
| Cooldown | **none** — account stays schedulable for every other model | unchanged (temp_unschedulable / SetError) |
| Failover | **suppressed** — every pool account shares the missing scope | unchanged |
| Client response | **400** `invalid_request_error` ("capability not available on the serving account") | unchanged (502 / cooldown) |

The detector requires **both** anchor phrases (case-insensitive, scanning structured `error.message` / `detail`) so a generic 401 is never misclassified as a recoverable capability gap.

## Changes

New TK companion `ratelimit_service_tk_capability_scope_401.go` (detector + client message). Three upstream-shaped files get only thin guard-call injections:

- `ratelimit_service.go` — `HandleUpstreamError` case 401 returns `shouldDisable=false` before any cooldown/disable path.
- `openai_gateway_service.go` — `shouldFailoverOpenAIUpstreamResponse` suppresses failover for capability-401 (covers the "don't re-select the scope-incapable account" goal at the **pool** level — the request fails fast with a 400, never poisoning each account in turn); `handleErrorResponse` + `handleCompatErrorResponse` map it to a client 400.
- `openai_images_responses.go` — `handleOpenAIImagesErrorResponse` (the actual incident path) maps it to a client 400.

## Test coverage (`-tags=unit`)

- `TestTkIsCapabilityScope401` — incident body + `{"detail":...}` shape match; generic-creds / `Unauthorized` / single-anchor / non-401 / nil all reject.
- `TestTkCapabilityScope401ClientMessage`.
- `TestRateLimitService_HandleUpstreamError_CapabilityScope401_DoesNotCoolAccount` — branch (a): 5× hits, `tempCalls==0`, `setErrorCalls==0`.
- `TestRateLimitService_HandleUpstreamError_GenericOAuth401_StillCoolsAccount` — branch (b): `tempCalls==1`.
- `TestRateLimitService_HandleUpstreamError_OpenAIUnauthorized401_StillSetsError` — branch (b'): `setErrorCalls==1`.
- `TestOpenAIGatewayService_ShouldFailover_CapabilityScope401Suppressed`.

## Markers / gates

- Backend-only change → `no-web-impact` (in commit).
- Touches upstream-shaped files → `upstream-touch-guarded` (in commit).
- New TK companion is a load-bearing surface → **added 4 sentinel anchors** to `scripts/sentinels/gateway-tk.json` (new file + each injection line), so the registry-update gate is satisfied by anchors, not a bare marker. All 262 gateway-TK sentinels intact.

## Validation
- `go build ./...` ✅
- `go test -tags=unit ./...` ✅
- `golangci-lint run ./internal/service/...` → 0 issues ✅
- `bash scripts/preflight.sh` → PASS ✅
