### PR TITLE
feat(stage0): warm-image pre-pull workflow + SSM primitive (take the ~150s deploy pull off the critical path)

### DIFF
--- a/.github/workflows/warm-image-stage0.yml
+++ b/.github/workflows/warm-image-stage0.yml
@@ -1,0 +1,122 @@
+name: Stage0 Warm Image
+
+# Pre-pulls a released image tag onto the prod Stage0 host BEFORE a deploy, so
+# that deploy-stage0.yml's in-band `docker compose pull` collapses to a ~3s
+# manifest no-op instead of paying the full cold pull (~150s measured on the
+# prod t4g.small, 2026-06-13) on its critical path.
+#
+# Read-only: it runs ops/stage0/warm_pull_via_ssm.sh, which only `docker pull`s
+# the new tag — it never edits .env, restarts, drains, or swaps the running
+# container. Safe to dispatch at any time against live prod.
+#
+# Driven by the tokenkey-stage0-release-rollout skill: dispatched (and its prod
+# Environment approval auto-approved via gh, since the warm is read-only) right
+# before the prod deploy so the layers are on disk by deploy time. Mirrors
+# deploy-stage0.yml's prod resolve path (CFN InstanceId + the shared
+# validate-deploy-tag / verify_ghcr_manifest gates) so the two never diverge.
+
+on:
+  workflow_dispatch:
+    inputs:
+      tag:
+        description: "Released image tag without leading v (e.g. 1.8.0). Must already exist on GHCR."
+        required: true
+        type: string
+      simple_release_override:
+        description: "Pass-through to the GHCR multi-arch manifest gate. Default false; matches deploy-stage0.yml."
+        required: false
+        type: boolean
+        default: false
+
+permissions:
+  contents: read
+  id-token: write
+  packages: read
+
+# Warm is idempotent and read-only, but serialize per host so two concurrent
+# warms don't fight over the docker pull lock. Separate group from the deploy
+# lock so a warm never blocks (or is blocked by) an in-flight deploy.
+concurrency:
+  group: warm-image-stage0-prod
+  cancel-in-progress: false
+
+jobs:
+  warm:
+    runs-on: ubuntu-latest
+    # Bound to a cold image pull on a slow link; far below the 6h default so a
+    # hung describe-stacks / SSM poll can't hold the concurrency lock for hours.
+    timeout-minutes: 15
+    # Same prod Environment binding as deploy-stage0.yml: required for the
+    # OIDC sub claim (IAM trust in cicd-oidc.yaml). The rollout skill
+    # auto-approves the pending deployment via gh because the warm is read-only.
+    environment: prod
+    env:
+      AWS_REGION: ${{ vars.AWS_REGION || 'us-east-1' }}
+      OIDC_ROLE_ARN: ${{ vars.AWS_OIDC_ROLE_ARN }}
+      INPUT_TAG: ${{ inputs.tag }}
+      INPUT_OVERRIDE: ${{ inputs.simple_release_override }}
+    steps:
+      - uses: actions/checkout@v6
+        with:
+          submodules: recursive
+
+      - name: Validate tag + resolve stack name
+        id: stack
+        run: |
+          set -euo pipefail
+          # Tag-format gate: single source of truth shared with the deploy
+          # workflows (prevents regex/message drift).
+          bash ops/stage0/validate-deploy-tag.sh "$INPUT_TAG"
+          if [ -z "${OIDC_ROLE_ARN:-}" ]; then
+            echo "::error::AWS_OIDC_ROLE_ARN repo variable not set; configure per docs/approved/deploy-stage0-workflow.md §5"
+            exit 1
+          fi
+          NAME="${{ vars.PROD_STACK_NAME || 'tokenkey-prod-stage0' }}"
+          echo "name=$NAME" >> "$GITHUB_OUTPUT"
+
+      - name: Verify GHCR multi-arch manifest
+        # Shared gate with deploy-stage0.yml: never warm a tag the deploy would
+        # refuse (e.g. a single-arch manifest that crashes on the arm64 host).
+        env:
+          GH_TOKEN: ${{ github.token }}
+        run: bash ops/stage0/verify_ghcr_manifest.sh "$INPUT_TAG" "$INPUT_OVERRIDE"
+
+      - name: Configure AWS credentials via OIDC
+        uses: aws-actions/configure-aws-credentials@v6
+        with:
+          role-to-assume: ${{ env.OIDC_ROLE_ARN }}
+          aws-region: ${{ env.AWS_REGION }}
+
+      - name: Resolve target instance
+        id: instance
+        env:
+          STACK_NAME: ${{ steps.stack.outputs.name }}
+        run: |
+          set -euo pipefail
+          ID=$(aws cloudformation describe-stacks --stack-name "$STACK_NAME" \
+            --query 'Stacks[0].Outputs[?OutputKey==`InstanceId`].OutputValue' --output text)
+          if [ -z "$ID" ] || [ "$ID" = "None" ]; then
+            echo "::error::could not resolve InstanceId from stack $STACK_NAME"
+            exit 1
+          fi
+          echo "id=$ID" >> "$GITHUB_OUTPUT"
+          echo "warming ${INPUT_TAG} on instance=$ID (env=prod stack=$STACK_NAME)"
+
+      - name: Warm image via SSM Run-Command
+        env:
+          INSTANCE_ID: ${{ steps.instance.outputs.id }}
+          STAGE0_SSM_OUTPUT_DIR: .
+        run: bash ops/stage0/warm_pull_via_ssm.sh "$INPUT_TAG" "$INSTANCE_ID" "warm-image env=prod"
+
+      - name: Job summary
+        if: always()
+        env:
+          STACK_NAME: ${{ steps.stack.outputs.name }}
+        run: |
+          {
+            echo "### Stage0 Warm Image"
+            echo "- tag: \`$INPUT_TAG\`"
+            echo "- stack: \`$STACK_NAME\`"
+            echo "- effect: image layers pre-pulled on the prod host (read-only; no deploy)"
+            echo "- next: run Stage0 Deploy for the same tag — its in-band pull is now a no-op"
+          } >> "$GITHUB_STEP_SUMMARY"

--- a/ops/stage0/warm_pull_via_ssm.sh
+++ b/ops/stage0/warm_pull_via_ssm.sh
@@ -1,0 +1,128 @@
+#!/usr/bin/env bash
+#
+# Stage0 SSM image-prewarm primitive.
+#
+# Scope: pull a tag's image onto a Stage0 host AHEAD of the actual deploy, so
+# that when `deploy_via_ssm.sh` later runs `docker compose pull tokenkey` the
+# layers are already on disk and the in-band pull collapses to a ~3s manifest
+# no-op. The image pull is the single largest variable in the deploy SSM step
+# (a cold pull of the multi-arch Go image measured ~150s on a prod t4g.small,
+# 2026-06-13); moving it into a separate earlier round-trip takes it off the
+# deploy-stage0 critical path.
+#
+# What this script does (and ONLY this — it is deliberately read-only):
+#   1. Read /var/lib/tokenkey/.env to learn the EXACT image repo the host runs
+#      (TOKENKEY_IMAGE=<registry>/<owner>/sub2api:<oldtag>). Deriving the repo
+#      from the host — instead of hard-coding ghcr.io — means we warm whatever
+#      registry the host actually pulls from (ghcr / dockerhub / mirror), so the
+#      warmed layers are the same blobs the deploy will reuse.
+#   2. `docker pull <repo>:<TAG>` for the new tag.
+#
+# What it INTENTIONALLY DOES NOT do — the entire point is that it is safe to run
+# at any time against a live host with zero client impact:
+#   - It does NOT edit /var/lib/tokenkey/.env (the live container keeps pointing
+#     at its current image; only the on-disk layer cache grows).
+#   - It does NOT stop / recreate / restart the tokenkey container.
+#   - It does NOT drain, swap, or health-check. There is nothing to roll back,
+#     so there is no rollback trap.
+# A failed warm is non-fatal to the deploy: the later in-band `compose pull`
+# simply pays the full pull as it does today.
+#
+# Targeting mirrors deploy_via_ssm.sh's prod path: a single EC2 instance-id
+# (i-*). Edge (Lightsail mi-*) prewarm is a deliberate follow-up — not wired
+# here so this script carries no unused targeting branch.
+
+set -euo pipefail
+
+TAG="${1:-${INPUT_TAG:-}}"
+INSTANCE_ID="${2:-${INSTANCE_ID:-}}"
+COMMENT="${3:-${SSM_COMMENT:-warm-image}}"
+# Bound to image pull + extract on a slow link/disk; well under the deploy
+# timeout since there is no drain/health window here.
+TIMEOUT_SECONDS="${STAGE0_WARM_SSM_TIMEOUT_SECONDS:-300}"
+OUTPUT_DIR="${STAGE0_SSM_OUTPUT_DIR:-.}"
+
+if [[ -z "${TAG}" ]]; then
+  echo "stage0_warm_pull_via_ssm: tag is required" >&2
+  exit 1
+fi
+if [[ -z "${INSTANCE_ID}" ]]; then
+  echo "stage0_warm_pull_via_ssm: instance id is required" >&2
+  exit 1
+fi
+
+ssm_region_args=()
+if [[ -n "${AWS_REGION:-${AWS_DEFAULT_REGION:-}}" ]]; then
+  ssm_region_args=(--region "${AWS_REGION:-${AWS_DEFAULT_REGION}}")
+fi
+
+mkdir -p "${OUTPUT_DIR}"
+params_file="${OUTPUT_DIR}/warm-ssm-params.json"
+stdout_file="${OUTPUT_DIR}/warm-stdout.txt"
+stderr_file="${OUTPUT_DIR}/warm-stderr.txt"
+
+jq -n --arg tag "${TAG}" '{
+  commands: [
+    "set -euo pipefail",
+    ("echo \"=== warm image for tag=" + $tag + " (read-only pull; no .env edit, no container restart) ===\""),
+    "CUR=$(sed -n '\''s/^TOKENKEY_IMAGE=//p'\'' /var/lib/tokenkey/.env | head -1)",
+    "if [ -z \"$CUR\" ]; then echo \"::error::TOKENKEY_IMAGE not found in /var/lib/tokenkey/.env\"; exit 1; fi",
+    "REPO=\"${CUR%:*}\"",
+    "if [ -z \"$REPO\" ] || [ \"$REPO\" = \"$CUR\" ]; then echo \"::error::could not parse repo from TOKENKEY_IMAGE=$CUR\"; exit 1; fi",
+    ("IMG=\"${REPO}:" + $tag + "\""),
+    "echo \"warming $IMG (host currently runs $CUR)\"",
+    "sudo docker pull \"$IMG\"",
+    "echo \"=== warm complete: $IMG on disk ===\""
+  ]
+}' > "${params_file}"
+
+cmd_id="$(aws "${ssm_region_args[@]}" ssm send-command \
+  --instance-ids "${INSTANCE_ID}" \
+  --document-name AWS-RunShellScript \
+  --comment "${COMMENT} tag=${TAG}" \
+  --parameters "file://${params_file}" \
+  --query 'Command.CommandId' --output text)"
+
+echo "ssm warm command-id=${cmd_id}"
+if [[ -n "${GITHUB_OUTPUT:-}" ]]; then
+  echo "command_id=${cmd_id}" >> "${GITHUB_OUTPUT}"
+fi
+
+deadline=$(( $(date +%s) + TIMEOUT_SECONDS ))
+status="InProgress"
+while true; do
+  status="$(aws "${ssm_region_args[@]}" ssm get-command-invocation \
+    --command-id "${cmd_id}" --instance-id "${INSTANCE_ID}" \
+    --query 'Status' --output text 2>/dev/null || echo InProgress)"
+  case "${status}" in
+    Success|Failed|TimedOut|Cancelled) break ;;
+  esac
+  if [[ $(date +%s) -ge ${deadline} ]]; then
+    echo "::warning::ssm warm timeout (non-fatal — deploy will pay the in-band pull)" >&2
+    status="TimedOut"
+    break
+  fi
+  sleep 5
+done
+
+aws "${ssm_region_args[@]}" ssm get-command-invocation \
+  --command-id "${cmd_id}" --instance-id "${INSTANCE_ID}" \
+  --query 'StandardOutputContent' --output text > "${stdout_file}" 2>/dev/null || true
+aws "${ssm_region_args[@]}" ssm get-command-invocation \
+  --command-id "${cmd_id}" --instance-id "${INSTANCE_ID}" \
+  --query 'StandardErrorContent' --output text > "${stderr_file}" 2>/dev/null || true
+
+echo '--- ssm warm stdout (last 4KB) ---'
+tail -c 4096 "${stdout_file}" 2>/dev/null || true
+echo
+echo '--- ssm warm stderr (last 4KB) ---'
+tail -c 4096 "${stderr_file}" 2>/dev/null || true
+echo
+
+# A warm failure is non-fatal: the deploy still works, it just pays the pull.
+# Exit 0 on TimedOut (already warned); only a hard SSM Failed is worth a
+# non-zero so the caller can surface it, but even then the deploy is safe.
+if [[ "${status}" == "Failed" ]]; then
+  echo "::warning::ssm warm status=Failed (non-fatal — deploy will pay the in-band pull)" >&2
+fi
+exit 0

--- a/ops/stage0/warm_pull_via_ssm.sh
+++ b/ops/stage0/warm_pull_via_ssm.sh
@@ -107,16 +107,16 @@ done
 
 aws "${ssm_region_args[@]}" ssm get-command-invocation \
   --command-id "${cmd_id}" --instance-id "${INSTANCE_ID}" \
-  --query 'StandardOutputContent' --output text > "${stdout_file}" 2>/dev/null || true
+  --query 'StandardOutputContent' --output text > "${stdout_file}" 2>/dev/null || true  # preflight-allow: swallow (diagnostic fetch; warm is non-fatal)
 aws "${ssm_region_args[@]}" ssm get-command-invocation \
   --command-id "${cmd_id}" --instance-id "${INSTANCE_ID}" \
-  --query 'StandardErrorContent' --output text > "${stderr_file}" 2>/dev/null || true
+  --query 'StandardErrorContent' --output text > "${stderr_file}" 2>/dev/null || true  # preflight-allow: swallow (diagnostic fetch; warm is non-fatal)
 
 echo '--- ssm warm stdout (last 4KB) ---'
-tail -c 4096 "${stdout_file}" 2>/dev/null || true
+tail -c 4096 "${stdout_file}" 2>/dev/null || true  # preflight-allow: swallow (display only)
 echo
 echo '--- ssm warm stderr (last 4KB) ---'
-tail -c 4096 "${stderr_file}" 2>/dev/null || true
+tail -c 4096 "${stderr_file}" 2>/dev/null || true  # preflight-allow: swallow (display only)
 echo
 
 # A warm failure is non-fatal: the deploy still works, it just pays the pull.

--- a/scripts/checks/check-stage0-ssm-host-parse.sh
+++ b/scripts/checks/check-stage0-ssm-host-parse.sh
@@ -17,7 +17,8 @@
 # its params file WITHOUT touching AWS, then `bash -n` the joined commands.
 #
 # Scope (explicit, not silent): covers the prod/edge MUTATION primitives
-# (deploy image, sync Caddyfile, sync docs, sync Feishu config).
+# (deploy image, sync Caddyfile, sync docs, sync Feishu config) plus the
+# read-only warm-image primitive (same jq-host-command shape, same blind spot).
 # edge_post_deploy_smoke.sh also builds an SSM `commands` array, but is left out
 # on purpose — its array is assembled inside functions behind many runtime env
 # vars (no clean "args -> params file" entrypoint to stub), and an unparseable
@@ -58,7 +59,11 @@ check_one() {
   # The missing-file case is handled explicitly below.
   PATH="${stub}:${PATH}" STAGE0_SSM_OUTPUT_DIR="${tmp}/${out}" AWS_REGION=us-east-1 \
     "$@" >/dev/null 2>"${tmp}/${out}/err" || true  # preflight-allow: swallow
-  local pf="${tmp}/${out}/ssm-params.json"
+  # Primitives name their params file differently (deploy: ssm-params.json,
+  # warm: warm-ssm-params.json) — match any *ssm-params.json so the parse gate
+  # stays agnostic to the exact filename.
+  local pf
+  pf="$(ls "${tmp}/${out}/"*ssm-params.json 2>/dev/null | head -1)"
   if [[ ! -f "${pf}" ]]; then
     echo "  FAIL: ${label} — no ssm-params.json emitted (stub run aborted before params generation)" >&2
     tail -3 "${tmp}/${out}/err" 2>/dev/null | sed 's/^/      /' >&2 || true  # preflight-allow: swallow (diagnostic only)
@@ -75,6 +80,7 @@ check_one() {
 }
 
 check_one "deploy_via_ssm.sh"               deploy    bash "${OPS}/deploy_via_ssm.sh" 1.0.0 i-0stub probe
+check_one "warm_pull_via_ssm.sh"            warm      bash "${OPS}/warm_pull_via_ssm.sh" 1.0.0 i-0stub probe
 check_one "sync_caddyfile_via_ssm.sh prod"  sync-prod bash "${OPS}/sync_caddyfile_via_ssm.sh" prod i-0stub probe
 check_one "sync_caddyfile_via_ssm.sh edge"  sync-edge bash "${OPS}/sync_caddyfile_via_ssm.sh" edge i-0stub probe
 check_one "sync_docs_pages.sh"              sync-docs bash "${OPS}/sync_docs_pages.sh" i-0stub


### PR DESCRIPTION
## What

Adds a **read-only image pre-warm** so the deploy-stage0 SSM step stops paying the cold `docker compose pull` on its critical path.

- `ops/stage0/warm_pull_via_ssm.sh` — SSM primitive: derives the host's exact image repo from `/var/lib/tokenkey/.env` (`TOKENKEY_IMAGE`) and `docker pull`s the new tag. **Never** edits `.env`, restarts, drains, or swaps the container — nothing to roll back, so no rollback trap. A failed/timed-out warm is **non-fatal** (exit 0): the deploy just pays the in-band pull as today.
- `.github/workflows/warm-image-stage0.yml` — `workflow_dispatch`, prod-only, mirrors deploy-stage0.yml's resolve path (shared `validate-deploy-tag` + `verify_ghcr_manifest` gates, CFN `InstanceId`). `environment: prod` for the OIDC sub claim, same as the deploy workflow.

## Why (evidence)

prod 1.7.100 redeploy (2026-06-13, SSM cmd `53fd79df`): the `Deploy via SSM` step was 4m6s host-time, of which `docker compose pull` was **~150s (~84%)** — a cold pull of the multi-arch Go image (two ~35MB layers re-fetched + extracted). The pull already overlaps client serving (old container stays up), but it sits on the deploy job's critical path. Pre-warming collapses deploy-stage0's in-band pull to a ~3s manifest no-op.

## Scope

**Additive** — no change to any existing deploy/rollout flow. Usable today: dispatch this workflow for a tag (approve the prod Environment), then run Stage0 Deploy — its pull is now a no-op.

Follow-ups (separate PRs):
- Auto-drive from the `tokenkey-stage0-release-rollout` skill: dispatch warm + `gh` auto-approve (warm is read-only) right before the prod deploy.
- Edge (Lightsail) prewarm — not wired here so the primitive carries no unused targeting branch.

Pairs with #762 (drain cap+plateau, ~46s). Together: deploy-stage0 SSM step ~4m → under ~1m.

## Test

- `bash -n` on script + outer; jq-built SSM params parse; joined host command bash-valid with **zero destructive ops**; fake-`.env` simulation derives `ghcr.io/<owner>/sub2api` repo and targets the new tag.
- `scripts/preflight.sh` PASS — workflow yaml clean (17), Stage0 job timeouts, ops-tool orphan wiring (80, 0 orphans), env-context gate all green.

`no-web-impact`

🤖 Generated with [Claude Code](https://claude.com/claude-code)