### PR TITLE
perf(stage0): speed up prod deploy — drain cap+plateau, read-only image prewarm, rollout-skill wiring

### DIFF
--- a/.cursor/skills/tokenkey-stage0-release-rollout/SKILL.md
+++ b/.cursor/skills/tokenkey-stage0-release-rollout/SKILL.md
@@ -161,8 +161,10 @@ bash scripts/release-bump-and-tag.sh --dry-run  # 只看决策与计划，不写
 ```bash
 # 1) dispatch 只读预热（与 deploy 同 prod Environment）
 gh workflow run warm-image-stage0.yml -f tag="$TARGET_TAG"
-# 取刚触发的 warm run（按 workflow_dispatch + 最新；必要时 sleep 几秒等 run 出现）
-WARM_RUN_ID=$(gh run list --workflow=warm-image-stage0.yml --event=workflow_dispatch --limit 1 --json databaseId --jq '.[0].databaseId')
+# 取刚触发的 warm run：选最近一个**未完成**的（卡在 waiting/in_progress 的就是它），
+# 避免 --limit 1 抓到上一次已 completed 的旧 run。必要时 sleep 几秒等 run 出现。
+WARM_RUN_ID=$(gh run list --workflow=warm-image-stage0.yml --event=workflow_dispatch --limit 5 \
+  --json databaseId,status --jq '[.[]|select(.status!="completed")][0].databaseId')
 # 2) 自批 prod Environment（warm 只读，自批安全；与 deploy 同一 --input JSON 形状，
 #    -f/-F 在数组字段上类型推断不可靠）。run 卡在 waiting 后才有 pending_deployment，
 #    必要时轮询到 .[0] 出现再批。

--- a/.cursor/skills/tokenkey-stage0-release-rollout/SKILL.md
+++ b/.cursor/skills/tokenkey-stage0-release-rollout/SKILL.md
@@ -34,6 +34,7 @@ description: >-
 | Edge upgrade/smoke/rollback dispatch | 机械 | `bash scripts/stage0/dispatch-edge-deploy.sh --edge-id … --operation …` |
 | **其余 Edge 顺序 rollout（fail-stop + smoke 标记验收）** | 机械 | `bash scripts/stage0/rollout-edges.sh --tag X.Y.Z --skip <canary>` |
 | dispatch release.yml / deploy-stage0.yml + watch | 机械 | `gh workflow run` + `gh run watch --exit-status` |
+| prod 镜像预热（deploy 前，把 ~150s pull 移出关键路径） | 机械 | `gh workflow run warm-image-stage0.yml` + 自批 + watch（只读、非致命；命令形状见 §「部署目标矩阵 → prod」） |
 | prod Environment approval（canary 绿后） | 机械 | `gh api -X POST …/pending_deployments`（命令形状见 §「部署目标矩阵 → prod」；批不批、何时批是判断） |
 | prod 完整 smoke（CI 唯一验收源） | 机械 | `deploy-stage0.yml` job log 内 `tk_post_deploy_smoke: OK`（`GATEWAY_SMOKE_SUITE=full`） |
 | Edge smoke 分阶段（infra / main-via-edge / full） | 机械 | `ops/stage0/edge_post_deploy_smoke.sh` + workflow `smoke_phase`；main-via-edge 用 `GATEWAY_SMOKE_SUITE=main-via-edge`（/v1/messages + Claude UA，不走 chat） |
@@ -153,7 +154,27 @@ bash scripts/release-bump-and-tag.sh --dry-run  # 只看决策与计划，不写
 
 ### prod：主网关
 
-`release.yml` **不再自动 queue prod**（原 `queue-prod-deploy` job 已移除）——release 只 build 镜像，部署由本 skill 在 build 成功后**显式 dispatch**（顺序与 rollout 意图由 skill 持有；裸 tag-push 不会自动部署 prod，发版务必走 skill）。先确认没有遗留的同 tag run，再 dispatch（tag 不带 `v`）：
+`release.yml` **不再自动 queue prod**（原 `queue-prod-deploy` job 已移除）——release 只 build 镜像，部署由本 skill 在 build 成功后**显式 dispatch**（顺序与 rollout 意图由 skill 持有；裸 tag-push 不会自动部署 prod，发版务必走 skill）。
+
+**先预热镜像（把 deploy 的 ~150s 镜像 pull 移出关键路径）**：`deploy-stage0` 的 in-band `docker compose pull` 是其 SSM 步骤最大耗时（prod 实测 ~150s，占 ~84%）。`warm-image-stage0.yml` 在 prod 主机上**只读** `docker pull` 新 tag（不改 `.env`、不重启容器），warm 完成后 deploy 的 pull 退化成 ~3s no-op。warm 是只读的，所以**自批它的 `prod` Environment 门禁是安全的**（门禁是为「改变在跑服务的 deploy」设的）。warm **失败/超时非致命**——deploy 仍会自己 pull，绝不阻断发版。dispatch deploy 前先 warm：
+
+```bash
+# 1) dispatch 只读预热（与 deploy 同 prod Environment）
+gh workflow run warm-image-stage0.yml -f tag="$TARGET_TAG"
+# 取刚触发的 warm run（按 workflow_dispatch + 最新；必要时 sleep 几秒等 run 出现）
+WARM_RUN_ID=$(gh run list --workflow=warm-image-stage0.yml --event=workflow_dispatch --limit 1 --json databaseId --jq '.[0].databaseId')
+# 2) 自批 prod Environment（warm 只读，自批安全；与 deploy 同一 --input JSON 形状，
+#    -f/-F 在数组字段上类型推断不可靠）。run 卡在 waiting 后才有 pending_deployment，
+#    必要时轮询到 .[0] 出现再批。
+WARM_ENV_ID=$(gh api "repos/{owner}/{repo}/actions/runs/$WARM_RUN_ID/pending_deployments" --jq '.[0].environment.id')
+gh api -X POST "repos/{owner}/{repo}/actions/runs/$WARM_RUN_ID/pending_deployments" --input - <<EOF
+{"environment_ids":[$WARM_ENV_ID],"state":"approved","comment":"read-only image prewarm for $TARGET_TAG"}
+EOF
+# 3) watch 到完成；非致命——失败也继续 deploy（deploy 自己付 pull）
+gh run watch "$WARM_RUN_ID" --exit-status || echo "warm non-fatal failure — proceeding to deploy (it will pay the in-band pull)"
+```
+
+先确认没有遗留的同 tag deploy run，再 dispatch（tag 不带 `v`）：
 
 ```bash
 gh run list --workflow=deploy-stage0.yml --limit 3 --json databaseId,event,createdAt,status,displayTitle
@@ -174,7 +195,7 @@ gh run view "$RUN_ID" --json status --jq .status   # 期望 in_progress
 
 若 API 返回 403（执行账号非 reviewer），则回落人工批准，不要换号绕过。
 
-**target=all 注意**：prod 不再被 release 自动 queue，所以**先不要 dispatch prod**——等第一个 deployable Edge canary infra smoke 绿后，再 `gh workflow run deploy-stage0.yml -f tag=$TARGET_TAG`，然后按上面的 approval 命令自批。canary-first 顺序由"先不 dispatch"自然保证，不再依赖"先不批准"的提前 waiting run。
+**target=all 注意**：prod 不再被 release 自动 queue，所以**先不要 dispatch prod deploy**——等第一个 deployable Edge canary infra smoke 绿后，再 `gh workflow run deploy-stage0.yml -f tag=$TARGET_TAG`，然后按上面的 approval 命令自批。canary-first 顺序由"先不 dispatch deploy"自然保证，不再依赖"先不批准"的提前 waiting run。**prod 的 warm（上面的预热块）是例外**：它只读、与 canary 无依赖，应在 canary infra smoke **跑的同时**就提前 dispatch+自批，让镜像 pull 与 canary 并行——这样 canary 绿后 dispatch prod deploy 时层已在盘上，净省一次 pull 的墙钟。
 
 ### edge-<edge_id>：Edge 资源节点（Lightsail，单一 dispatch 入口）
 

--- a/.github/workflows/warm-image-stage0.yml
+++ b/.github/workflows/warm-image-stage0.yml
@@ -1,0 +1,122 @@
+name: Stage0 Warm Image
+
+# Pre-pulls a released image tag onto the prod Stage0 host BEFORE a deploy, so
+# that deploy-stage0.yml's in-band `docker compose pull` collapses to a ~3s
+# manifest no-op instead of paying the full cold pull (~150s measured on the
+# prod t4g.small, 2026-06-13) on its critical path.
+#
+# Read-only: it runs ops/stage0/warm_pull_via_ssm.sh, which only `docker pull`s
+# the new tag — it never edits .env, restarts, drains, or swaps the running
+# container. Safe to dispatch at any time against live prod.
+#
+# Driven by the tokenkey-stage0-release-rollout skill: dispatched (and its prod
+# Environment approval auto-approved via gh, since the warm is read-only) right
+# before the prod deploy so the layers are on disk by deploy time. Mirrors
+# deploy-stage0.yml's prod resolve path (CFN InstanceId + the shared
+# validate-deploy-tag / verify_ghcr_manifest gates) so the two never diverge.
+
+on:
+  workflow_dispatch:
+    inputs:
+      tag:
+        description: "Released image tag without leading v (e.g. 1.8.0). Must already exist on GHCR."
+        required: true
+        type: string
+      simple_release_override:
+        description: "Pass-through to the GHCR multi-arch manifest gate. Default false; matches deploy-stage0.yml."
+        required: false
+        type: boolean
+        default: false
+
+permissions:
+  contents: read
+  id-token: write
+  packages: read
+
+# Warm is idempotent and read-only, but serialize per host so two concurrent
+# warms don't fight over the docker pull lock. Separate group from the deploy
+# lock so a warm never blocks (or is blocked by) an in-flight deploy.
+concurrency:
+  group: warm-image-stage0-prod
+  cancel-in-progress: false
+
+jobs:
+  warm:
+    runs-on: ubuntu-latest
+    # Bound to a cold image pull on a slow link; far below the 6h default so a
+    # hung describe-stacks / SSM poll can't hold the concurrency lock for hours.
+    timeout-minutes: 15
+    # Same prod Environment binding as deploy-stage0.yml: required for the
+    # OIDC sub claim (IAM trust in cicd-oidc.yaml). The rollout skill
+    # auto-approves the pending deployment via gh because the warm is read-only.
+    environment: prod
+    env:
+      AWS_REGION: ${{ vars.AWS_REGION || 'us-east-1' }}
+      OIDC_ROLE_ARN: ${{ vars.AWS_OIDC_ROLE_ARN }}
+      INPUT_TAG: ${{ inputs.tag }}
+      INPUT_OVERRIDE: ${{ inputs.simple_release_override }}
+    steps:
+      - uses: actions/checkout@v6
+        with:
+          submodules: recursive
+
+      - name: Validate tag + resolve stack name
+        id: stack
+        run: |
+          set -euo pipefail
+          # Tag-format gate: single source of truth shared with the deploy
+          # workflows (prevents regex/message drift).
+          bash ops/stage0/validate-deploy-tag.sh "$INPUT_TAG"
+          if [ -z "${OIDC_ROLE_ARN:-}" ]; then
+            echo "::error::AWS_OIDC_ROLE_ARN repo variable not set; configure per docs/approved/deploy-stage0-workflow.md §5"
+            exit 1
+          fi
+          NAME="${{ vars.PROD_STACK_NAME || 'tokenkey-prod-stage0' }}"
+          echo "name=$NAME" >> "$GITHUB_OUTPUT"
+
+      - name: Verify GHCR multi-arch manifest
+        # Shared gate with deploy-stage0.yml: never warm a tag the deploy would
+        # refuse (e.g. a single-arch manifest that crashes on the arm64 host).
+        env:
+          GH_TOKEN: ${{ github.token }}
+        run: bash ops/stage0/verify_ghcr_manifest.sh "$INPUT_TAG" "$INPUT_OVERRIDE"
+
+      - name: Configure AWS credentials via OIDC
+        uses: aws-actions/configure-aws-credentials@v6
+        with:
+          role-to-assume: ${{ env.OIDC_ROLE_ARN }}
+          aws-region: ${{ env.AWS_REGION }}
+
+      - name: Resolve target instance
+        id: instance
+        env:
+          STACK_NAME: ${{ steps.stack.outputs.name }}
+        run: |
+          set -euo pipefail
+          ID=$(aws cloudformation describe-stacks --stack-name "$STACK_NAME" \
+            --query 'Stacks[0].Outputs[?OutputKey==`InstanceId`].OutputValue' --output text)
+          if [ -z "$ID" ] || [ "$ID" = "None" ]; then
+            echo "::error::could not resolve InstanceId from stack $STACK_NAME"
+            exit 1
+          fi
+          echo "id=$ID" >> "$GITHUB_OUTPUT"
+          echo "warming ${INPUT_TAG} on instance=$ID (env=prod stack=$STACK_NAME)"
+
+      - name: Warm image via SSM Run-Command
+        env:
+          INSTANCE_ID: ${{ steps.instance.outputs.id }}
+          STAGE0_SSM_OUTPUT_DIR: .
+        run: bash ops/stage0/warm_pull_via_ssm.sh "$INPUT_TAG" "$INSTANCE_ID" "warm-image env=prod"
+
+      - name: Job summary
+        if: always()
+        env:
+          STACK_NAME: ${{ steps.stack.outputs.name }}
+        run: |
+          {
+            echo "### Stage0 Warm Image"
+            echo "- tag: \`$INPUT_TAG\`"
+            echo "- stack: \`$STACK_NAME\`"
+            echo "- effect: image layers pre-pulled on the prod host (read-only; no deploy)"
+            echo "- next: run Stage0 Deploy for the same tag — its in-band pull is now a no-op"
+          } >> "$GITHUB_STEP_SUMMARY"

--- a/ops/stage0/deploy_via_ssm.sh
+++ b/ops/stage0/deploy_via_ssm.sh
@@ -16,10 +16,20 @@
 #   3. Send SIGUSR1 to tokenkey → wait for /health/inflight to report
 #      draining=true && in_flight=0 (pre-drain so live SSE finishes). Only now
 #      does Caddy active health (health_uri /health) remove the old upstream.
+#      Bounded by TWO early-exits so a node carrying long-lived SSE never burns
+#      the full budget for a drain that will not complete: (a) a hard cap of 15
+#      tries × 2s = 30s, and (b) a plateau break — if in_flight stops decreasing
+#      for 3 consecutive polls, stop waiting (the remaining streams are
+#      long-lived and the swap will sever them regardless). Measured on the prod
+#      1.7.100 redeploy (2026-06-13): under sustained streaming the old 38-try
+#      (76s) loop NEVER reached in_flight=0 — it drifted 18→8 and plateaued at 8
+#      from try ~31, so it paid the full 76s AND still severed 8 streams at swap.
+#      The cap+plateau cut that wasted wait to ≤30s (≈10s once plateaued) for the
+#      same client outcome.
 #      SKIPPED when the outgoing container is not `healthy`: a crash-looping /
 #      unhealthy container has no in-flight to drain (Caddy already flipped it
 #      out at /health!=200), and SIGUSR1 + the inflight-wait would block the
-#      full ~76s on a container whose `docker exec wget` never answers —
+#      full ~30s on a container whose `docker exec wget` never answers —
 #      starving the new container's health window and tripping the rollback
 #      trap, which then restores the (broken) previous image. That exact loop
 #      kept uk1 pinned to a crash-looping image on 2026-06-03; gating the drain
@@ -69,7 +79,7 @@ source "$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)/ssm_resolve_invocation_mi.
 TAG="${1:-${INPUT_TAG:-}}"
 INSTANCE_ID="${2:-${INSTANCE_ID:-}}"
 COMMENT="${3:-${SSM_COMMENT:-deploy-stage0}}"
-# Default bumped 300 -> 480 to cover pre-drain (≤ ~76s) + image pull + container
+# Default bumped 300 -> 480 to cover pre-drain (≤ ~30s) + image pull + container
 # start + healthcheck (≤ start_period 60s) + headroom on a slow link.
 TIMEOUT_SECONDS="${STAGE0_SSM_TIMEOUT_SECONDS:-480}"
 OUTPUT_DIR="${STAGE0_SSM_OUTPUT_DIR:-.}"
@@ -108,7 +118,7 @@ jq -n --arg tag "${TAG}" '{
     "cd /var/lib/tokenkey && sudo docker compose --env-file .env pull tokenkey",
     "echo \"=== pre-drain: SIGUSR1 + wait in_flight=0 (only when outgoing container healthy) ===\"",
     "OLD_HEALTH=$(sudo docker inspect tokenkey --format '\''{{if .State.Health}}{{.State.Health.Status}}{{else}}none{{end}}'\'' 2>/dev/null || echo missing); echo \"pre-drain: outgoing container health=$OLD_HEALTH\"",
-    "if [ \"$OLD_HEALTH\" = healthy ]; then sudo docker kill -s USR1 tokenkey 2>/dev/null || true; for i in $(seq 1 38); do body=$(sudo docker exec tokenkey wget -q -T 3 -O - http://localhost:8080/health/inflight 2>/dev/null); n=$(printf '\''%s'\'' \"$body\" | sed -n '\''s/.*\"in_flight\":\\([0-9]*\\).*/\\1/p'\''); if printf '\''%s'\'' \"$body\" | grep -q '\''\"draining\":true'\''; then d=true; else d=false; fi; echo \"pre-drain: draining=$d in_flight=${n:-?} try=$i/38\"; [ \"$d\" = true ] && [ \"${n:-1}\" = 0 ] && break; sleep 2; done; else echo \"pre-drain SKIPPED: outgoing container not healthy (health=$OLD_HEALTH) — Caddy already flipped it out, nothing to drain; straight to recreate (avoids burning the ~76s drain budget on a crash-looping container, which previously starved the new container health window and tripped the rollback trap — uk1 2026-06-03)\"; fi",
+    "if [ \"$OLD_HEALTH\" = healthy ]; then sudo docker kill -s USR1 tokenkey 2>/dev/null || true; prev=-1; stall=0; for i in $(seq 1 15); do body=$(sudo docker exec tokenkey wget -q -T 3 -O - http://localhost:8080/health/inflight 2>/dev/null); n=$(printf '\''%s'\'' \"$body\" | sed -n '\''s/.*\"in_flight\":\\([0-9]*\\).*/\\1/p'\''); if printf '\''%s'\'' \"$body\" | grep -q '\''\"draining\":true'\''; then d=true; else d=false; fi; echo \"pre-drain: draining=$d in_flight=${n:-?} try=$i/15\"; [ \"$d\" = true ] && [ \"${n:-1}\" = 0 ] && break; cur=${n:-0}; if [ \"$prev\" -ge 0 ] && [ \"$cur\" -ge \"$prev\" ]; then stall=$((stall+1)); else stall=0; fi; prev=$cur; [ \"$stall\" -ge 3 ] && { echo \"pre-drain: in_flight plateaued at $cur for 3 tries (long-lived streams will not finish in the drain budget); stop waiting — swap will sever them\"; break; }; sleep 2; done; else echo \"pre-drain SKIPPED: outgoing container not healthy (health=$OLD_HEALTH) — Caddy already flipped it out, nothing to drain; straight to recreate (avoids burning the ~30s drain budget on a crash-looping container, which previously starved the new container health window and tripped the rollback trap — uk1 2026-06-03)\"; fi",
     "echo \"=== swap: stop-old + start-new (image already on disk from pull above) ===\"",
     "cd /var/lib/tokenkey && sudo docker compose --env-file .env up -d --no-deps --force-recreate tokenkey",
     "for i in 1 2 3 4 5 6 7 8 9 10 11 12; do s=$(sudo docker inspect tokenkey --format '\''{{.State.Health.Status}}'\'' 2>/dev/null || echo missing); echo \"try $i: $s\"; [ \"$s\" = healthy ] && break; sleep 5; done",

--- a/ops/stage0/deploy_via_ssm.sh
+++ b/ops/stage0/deploy_via_ssm.sh
@@ -19,8 +19,11 @@
 #      Bounded by TWO early-exits so a node carrying long-lived SSE never burns
 #      the full budget for a drain that will not complete: (a) a hard cap of 15
 #      tries × 2s = 30s, and (b) a plateau break — if in_flight stops decreasing
-#      for 3 consecutive polls, stop waiting (the remaining streams are
-#      long-lived and the swap will sever them regardless). Measured on the prod
+#      for 3 consecutive VALID readings, stop waiting (the remaining streams are
+#      long-lived and the swap will sever them regardless). A failed/empty poll
+#      is treated as no-information: it does not advance the plateau counter (and
+#      the in_flight=0 break already reads an empty poll as not-drained), so a
+#      transient wget blip cannot end the drain early. Measured on the prod
 #      1.7.100 redeploy (2026-06-13): under sustained streaming the old 38-try
 #      (76s) loop NEVER reached in_flight=0 — it drifted 18→8 and plateaued at 8
 #      from try ~31, so it paid the full 76s AND still severed 8 streams at swap.
@@ -118,7 +121,7 @@ jq -n --arg tag "${TAG}" '{
     "cd /var/lib/tokenkey && sudo docker compose --env-file .env pull tokenkey",
     "echo \"=== pre-drain: SIGUSR1 + wait in_flight=0 (only when outgoing container healthy) ===\"",
     "OLD_HEALTH=$(sudo docker inspect tokenkey --format '\''{{if .State.Health}}{{.State.Health.Status}}{{else}}none{{end}}'\'' 2>/dev/null || echo missing); echo \"pre-drain: outgoing container health=$OLD_HEALTH\"",
-    "if [ \"$OLD_HEALTH\" = healthy ]; then sudo docker kill -s USR1 tokenkey 2>/dev/null || true; prev=-1; stall=0; for i in $(seq 1 15); do body=$(sudo docker exec tokenkey wget -q -T 3 -O - http://localhost:8080/health/inflight 2>/dev/null); n=$(printf '\''%s'\'' \"$body\" | sed -n '\''s/.*\"in_flight\":\\([0-9]*\\).*/\\1/p'\''); if printf '\''%s'\'' \"$body\" | grep -q '\''\"draining\":true'\''; then d=true; else d=false; fi; echo \"pre-drain: draining=$d in_flight=${n:-?} try=$i/15\"; [ \"$d\" = true ] && [ \"${n:-1}\" = 0 ] && break; cur=${n:-0}; if [ \"$prev\" -ge 0 ] && [ \"$cur\" -ge \"$prev\" ]; then stall=$((stall+1)); else stall=0; fi; prev=$cur; [ \"$stall\" -ge 3 ] && { echo \"pre-drain: in_flight plateaued at $cur for 3 tries (long-lived streams will not finish in the drain budget); stop waiting — swap will sever them\"; break; }; sleep 2; done; else echo \"pre-drain SKIPPED: outgoing container not healthy (health=$OLD_HEALTH) — Caddy already flipped it out, nothing to drain; straight to recreate (avoids burning the ~30s drain budget on a crash-looping container, which previously starved the new container health window and tripped the rollback trap — uk1 2026-06-03)\"; fi",
+    "if [ \"$OLD_HEALTH\" = healthy ]; then sudo docker kill -s USR1 tokenkey 2>/dev/null || true; prev=-1; stall=0; for i in $(seq 1 15); do body=$(sudo docker exec tokenkey wget -q -T 3 -O - http://localhost:8080/health/inflight 2>/dev/null); n=$(printf '\''%s'\'' \"$body\" | sed -n '\''s/.*\"in_flight\":\\([0-9]*\\).*/\\1/p'\''); if printf '\''%s'\'' \"$body\" | grep -q '\''\"draining\":true'\''; then d=true; else d=false; fi; echo \"pre-drain: draining=$d in_flight=${n:-?} try=$i/15\"; [ \"$d\" = true ] && [ \"${n:-1}\" = 0 ] && break; if [ -n \"$n\" ]; then if [ \"$prev\" -ge 0 ] && [ \"$n\" -ge \"$prev\" ]; then stall=$((stall+1)); else stall=0; fi; prev=$n; [ \"$stall\" -ge 3 ] && { echo \"pre-drain: in_flight plateaued at $n for 3 tries (long-lived streams will not finish in the drain budget); stop waiting — swap will sever them\"; break; }; fi; sleep 2; done; else echo \"pre-drain SKIPPED: outgoing container not healthy (health=$OLD_HEALTH) — Caddy already flipped it out, nothing to drain; straight to recreate (avoids burning the ~30s drain budget on a crash-looping container, which previously starved the new container health window and tripped the rollback trap — uk1 2026-06-03)\"; fi",
     "echo \"=== swap: stop-old + start-new (image already on disk from pull above) ===\"",
     "cd /var/lib/tokenkey && sudo docker compose --env-file .env up -d --no-deps --force-recreate tokenkey",
     "for i in 1 2 3 4 5 6 7 8 9 10 11 12; do s=$(sudo docker inspect tokenkey --format '\''{{.State.Health.Status}}'\'' 2>/dev/null || echo missing); echo \"try $i: $s\"; [ \"$s\" = healthy ] && break; sleep 5; done",

--- a/ops/stage0/warm_pull_via_ssm.sh
+++ b/ops/stage0/warm_pull_via_ssm.sh
@@ -1,0 +1,128 @@
+#!/usr/bin/env bash
+#
+# Stage0 SSM image-prewarm primitive.
+#
+# Scope: pull a tag's image onto a Stage0 host AHEAD of the actual deploy, so
+# that when `deploy_via_ssm.sh` later runs `docker compose pull tokenkey` the
+# layers are already on disk and the in-band pull collapses to a ~3s manifest
+# no-op. The image pull is the single largest variable in the deploy SSM step
+# (a cold pull of the multi-arch Go image measured ~150s on a prod t4g.small,
+# 2026-06-13); moving it into a separate earlier round-trip takes it off the
+# deploy-stage0 critical path.
+#
+# What this script does (and ONLY this — it is deliberately read-only):
+#   1. Read /var/lib/tokenkey/.env to learn the EXACT image repo the host runs
+#      (TOKENKEY_IMAGE=<registry>/<owner>/sub2api:<oldtag>). Deriving the repo
+#      from the host — instead of hard-coding ghcr.io — means we warm whatever
+#      registry the host actually pulls from (ghcr / dockerhub / mirror), so the
+#      warmed layers are the same blobs the deploy will reuse.
+#   2. `docker pull <repo>:<TAG>` for the new tag.
+#
+# What it INTENTIONALLY DOES NOT do — the entire point is that it is safe to run
+# at any time against a live host with zero client impact:
+#   - It does NOT edit /var/lib/tokenkey/.env (the live container keeps pointing
+#     at its current image; only the on-disk layer cache grows).
+#   - It does NOT stop / recreate / restart the tokenkey container.
+#   - It does NOT drain, swap, or health-check. There is nothing to roll back,
+#     so there is no rollback trap.
+# A failed warm is non-fatal to the deploy: the later in-band `compose pull`
+# simply pays the full pull as it does today.
+#
+# Targeting mirrors deploy_via_ssm.sh's prod path: a single EC2 instance-id
+# (i-*). Edge (Lightsail mi-*) prewarm is a deliberate follow-up — not wired
+# here so this script carries no unused targeting branch.
+
+set -euo pipefail
+
+TAG="${1:-${INPUT_TAG:-}}"
+INSTANCE_ID="${2:-${INSTANCE_ID:-}}"
+COMMENT="${3:-${SSM_COMMENT:-warm-image}}"
+# Bound to image pull + extract on a slow link/disk; well under the deploy
+# timeout since there is no drain/health window here.
+TIMEOUT_SECONDS="${STAGE0_WARM_SSM_TIMEOUT_SECONDS:-300}"
+OUTPUT_DIR="${STAGE0_SSM_OUTPUT_DIR:-.}"
+
+if [[ -z "${TAG}" ]]; then
+  echo "stage0_warm_pull_via_ssm: tag is required" >&2
+  exit 1
+fi
+if [[ -z "${INSTANCE_ID}" ]]; then
+  echo "stage0_warm_pull_via_ssm: instance id is required" >&2
+  exit 1
+fi
+
+ssm_region_args=()
+if [[ -n "${AWS_REGION:-${AWS_DEFAULT_REGION:-}}" ]]; then
+  ssm_region_args=(--region "${AWS_REGION:-${AWS_DEFAULT_REGION}}")
+fi
+
+mkdir -p "${OUTPUT_DIR}"
+params_file="${OUTPUT_DIR}/warm-ssm-params.json"
+stdout_file="${OUTPUT_DIR}/warm-stdout.txt"
+stderr_file="${OUTPUT_DIR}/warm-stderr.txt"
+
+jq -n --arg tag "${TAG}" '{
+  commands: [
+    "set -euo pipefail",
+    ("echo \"=== warm image for tag=" + $tag + " (read-only pull; no .env edit, no container restart) ===\""),
+    "CUR=$(sed -n '\''s/^TOKENKEY_IMAGE=//p'\'' /var/lib/tokenkey/.env | head -1)",
+    "if [ -z \"$CUR\" ]; then echo \"::error::TOKENKEY_IMAGE not found in /var/lib/tokenkey/.env\"; exit 1; fi",
+    "REPO=\"${CUR%:*}\"",
+    "if [ -z \"$REPO\" ] || [ \"$REPO\" = \"$CUR\" ]; then echo \"::error::could not parse repo from TOKENKEY_IMAGE=$CUR\"; exit 1; fi",
+    ("IMG=\"${REPO}:" + $tag + "\""),
+    "echo \"warming $IMG (host currently runs $CUR)\"",
+    "sudo docker pull \"$IMG\"",
+    "echo \"=== warm complete: $IMG on disk ===\""
+  ]
+}' > "${params_file}"
+
+cmd_id="$(aws "${ssm_region_args[@]}" ssm send-command \
+  --instance-ids "${INSTANCE_ID}" \
+  --document-name AWS-RunShellScript \
+  --comment "${COMMENT} tag=${TAG}" \
+  --parameters "file://${params_file}" \
+  --query 'Command.CommandId' --output text)"
+
+echo "ssm warm command-id=${cmd_id}"
+if [[ -n "${GITHUB_OUTPUT:-}" ]]; then
+  echo "command_id=${cmd_id}" >> "${GITHUB_OUTPUT}"
+fi
+
+deadline=$(( $(date +%s) + TIMEOUT_SECONDS ))
+status="InProgress"
+while true; do
+  status="$(aws "${ssm_region_args[@]}" ssm get-command-invocation \
+    --command-id "${cmd_id}" --instance-id "${INSTANCE_ID}" \
+    --query 'Status' --output text 2>/dev/null || echo InProgress)"
+  case "${status}" in
+    Success|Failed|TimedOut|Cancelled) break ;;
+  esac
+  if [[ $(date +%s) -ge ${deadline} ]]; then
+    echo "::warning::ssm warm timeout (non-fatal — deploy will pay the in-band pull)" >&2
+    status="TimedOut"
+    break
+  fi
+  sleep 5
+done
+
+aws "${ssm_region_args[@]}" ssm get-command-invocation \
+  --command-id "${cmd_id}" --instance-id "${INSTANCE_ID}" \
+  --query 'StandardOutputContent' --output text > "${stdout_file}" 2>/dev/null || true
+aws "${ssm_region_args[@]}" ssm get-command-invocation \
+  --command-id "${cmd_id}" --instance-id "${INSTANCE_ID}" \
+  --query 'StandardErrorContent' --output text > "${stderr_file}" 2>/dev/null || true
+
+echo '--- ssm warm stdout (last 4KB) ---'
+tail -c 4096 "${stdout_file}" 2>/dev/null || true
+echo
+echo '--- ssm warm stderr (last 4KB) ---'
+tail -c 4096 "${stderr_file}" 2>/dev/null || true
+echo
+
+# A warm failure is non-fatal: the deploy still works, it just pays the pull.
+# Exit 0 on TimedOut (already warned); only a hard SSM Failed is worth a
+# non-zero so the caller can surface it, but even then the deploy is safe.
+if [[ "${status}" == "Failed" ]]; then
+  echo "::warning::ssm warm status=Failed (non-fatal — deploy will pay the in-band pull)" >&2
+fi
+exit 0

--- a/ops/stage0/warm_pull_via_ssm.sh
+++ b/ops/stage0/warm_pull_via_ssm.sh
@@ -107,16 +107,16 @@ done
 
 aws "${ssm_region_args[@]}" ssm get-command-invocation \
   --command-id "${cmd_id}" --instance-id "${INSTANCE_ID}" \
-  --query 'StandardOutputContent' --output text > "${stdout_file}" 2>/dev/null || true
+  --query 'StandardOutputContent' --output text > "${stdout_file}" 2>/dev/null || true  # preflight-allow: swallow (diagnostic fetch; warm is non-fatal)
 aws "${ssm_region_args[@]}" ssm get-command-invocation \
   --command-id "${cmd_id}" --instance-id "${INSTANCE_ID}" \
-  --query 'StandardErrorContent' --output text > "${stderr_file}" 2>/dev/null || true
+  --query 'StandardErrorContent' --output text > "${stderr_file}" 2>/dev/null || true  # preflight-allow: swallow (diagnostic fetch; warm is non-fatal)
 
 echo '--- ssm warm stdout (last 4KB) ---'
-tail -c 4096 "${stdout_file}" 2>/dev/null || true
+tail -c 4096 "${stdout_file}" 2>/dev/null || true  # preflight-allow: swallow (display only)
 echo
 echo '--- ssm warm stderr (last 4KB) ---'
-tail -c 4096 "${stderr_file}" 2>/dev/null || true
+tail -c 4096 "${stderr_file}" 2>/dev/null || true  # preflight-allow: swallow (display only)
 echo
 
 # A warm failure is non-fatal: the deploy still works, it just pays the pull.

--- a/scripts/checks/check-stage0-ssm-host-parse.sh
+++ b/scripts/checks/check-stage0-ssm-host-parse.sh
@@ -17,7 +17,8 @@
 # its params file WITHOUT touching AWS, then `bash -n` the joined commands.
 #
 # Scope (explicit, not silent): covers the prod/edge MUTATION primitives
-# (deploy image, sync Caddyfile, sync docs, sync Feishu config).
+# (deploy image, sync Caddyfile, sync docs, sync Feishu config) plus the
+# read-only warm-image primitive (same jq-host-command shape, same blind spot).
 # edge_post_deploy_smoke.sh also builds an SSM `commands` array, but is left out
 # on purpose — its array is assembled inside functions behind many runtime env
 # vars (no clean "args -> params file" entrypoint to stub), and an unparseable
@@ -58,7 +59,11 @@ check_one() {
   # The missing-file case is handled explicitly below.
   PATH="${stub}:${PATH}" STAGE0_SSM_OUTPUT_DIR="${tmp}/${out}" AWS_REGION=us-east-1 \
     "$@" >/dev/null 2>"${tmp}/${out}/err" || true  # preflight-allow: swallow
-  local pf="${tmp}/${out}/ssm-params.json"
+  # Primitives name their params file differently (deploy: ssm-params.json,
+  # warm: warm-ssm-params.json) — match any *ssm-params.json so the parse gate
+  # stays agnostic to the exact filename.
+  local pf
+  pf="$(ls "${tmp}/${out}/"*ssm-params.json 2>/dev/null | head -1)"
   if [[ ! -f "${pf}" ]]; then
     echo "  FAIL: ${label} — no ssm-params.json emitted (stub run aborted before params generation)" >&2
     tail -3 "${tmp}/${out}/err" 2>/dev/null | sed 's/^/      /' >&2 || true  # preflight-allow: swallow (diagnostic only)
@@ -75,6 +80,7 @@ check_one() {
 }
 
 check_one "deploy_via_ssm.sh"               deploy    bash "${OPS}/deploy_via_ssm.sh" 1.0.0 i-0stub probe
+check_one "warm_pull_via_ssm.sh"            warm      bash "${OPS}/warm_pull_via_ssm.sh" 1.0.0 i-0stub probe
 check_one "sync_caddyfile_via_ssm.sh prod"  sync-prod bash "${OPS}/sync_caddyfile_via_ssm.sh" prod i-0stub probe
 check_one "sync_caddyfile_via_ssm.sh edge"  sync-edge bash "${OPS}/sync_caddyfile_via_ssm.sh" edge i-0stub probe
 check_one "sync_docs_pages.sh"              sync-docs bash "${OPS}/sync_docs_pages.sh" i-0stub


### PR DESCRIPTION
Consolidates the two deploy-speedup changes (#762 drain, #763 warm) **plus** the rollout-skill wiring (PR-B) into one PR, per request. Supersedes #762 and #763.

## Why

prod 1.7.100 redeploy (2026-06-13, SSM cmd `53fd79df`): the `Deploy via SSM` step ran 4m6s host-time. Exact breakdown from the SSM stdout:

| phase | measured | evidence |
|---|---|---|
| `docker compose pull` | **~150s (~84%)** | residual after the timed phases below |
| pre-drain | **76s (38/38, never reached in_flight=0)** | drifted 18→8, plateaued at 8 from try ~31 |
| swap + health | ~17s | 3 health tries |

Two independent levers, both addressed here.

## What

**1. Pre-drain cap + plateau break** (`ops/stage0/deploy_via_ssm.sh`)
- cap 38→15 tries (76s→30s); plateau break when `in_flight` stops decreasing for 3 consecutive **valid** readings (a failed/empty poll is no-information — does not advance the counter, mirroring the conservative `${n:-1}` used for the real drain-complete check). The `in_flight=0` break is unchanged and still fires first on nodes whose streams finish. ~46s off a busy node, same client outcome (the 8 plateaued streams are severed at swap either way).

**2. Read-only image prewarm** (`ops/stage0/warm_pull_via_ssm.sh` + `.github/workflows/warm-image-stage0.yml`)
- SSM primitive derives the host's exact image repo from `/var/lib/tokenkey/.env` (`TOKENKEY_IMAGE`) and `docker pull`s the new tag. **Never** edits `.env`, restarts, drains, or swaps — nothing to roll back. Failed/timed-out warm is **non-fatal** (exit 0). Pulling ahead of deploy collapses deploy-stage0's in-band pull to a ~3s manifest no-op.
- Workflow: `workflow_dispatch`, prod-only, mirrors deploy-stage0's resolve path (shared `validate-deploy-tag` + `verify_ghcr_manifest` gates, CFN `InstanceId`), `environment: prod` for the OIDC sub claim.
- The new SSM-host-command script is added to the `check-stage0-ssm-host-parse.sh` gate (the class whose unquoted-parens-in-echo bug #512 a canary caught — and which I hit during this script's own dev).

**3. Rollout-skill wiring** (`tokenkey-stage0-release-rollout` SKILL.md)
- Dispatches the warm workflow **before** the prod deploy and auto-approves its prod Environment gate via the same `gh api .../pending_deployments` pattern the deploy step already uses. Auto-approving is safe because the warm is read-only (the gate guards service-changing deploys, which warm is not).
- `target=all`: warm is the one prod step dispatched **early** (overlapping canary infra smoke) since it is read-only and canary-independent — that overlap is where net wall-clock is saved.

Combined effect: deploy-stage0 SSM step ~4m → under ~1m.

## Scope / safety

- Drain change: pure bounding of an existing wait; correctness on nodes whose streams finish is unchanged.
- Warm + skill: additive — no change to existing deploy behavior; the deploy still works (and pays the pull) if warm is skipped or fails.
- Edge (Lightsail) prewarm: deliberate follow-up — not wired here, so the primitive carries no unused targeting branch.

## Test

- `bash -n` on both SSM scripts + outer; jq-built params parse; joined host commands bash-valid; warm has **zero destructive ops** (fake-`.env` sim derives `ghcr.io/<owner>/sub2api` and targets the new tag); drain behavioral sim confirms 4 consecutive empty polls do **not** plateau-break.
- `scripts/preflight.sh` PASS on the combined branch — SSM-parse gate now lists `warm_pull_via_ssm.sh`, workflow yaml clean (17), Stage0 job timeouts, ops-tool orphan wiring (80, 0 orphans), agent-contract + codex AGENTS/skill-length all green.

`no-web-impact`

🤖 Generated with [Claude Code](https://claude.com/claude-code)