### PR TITLE
fix(smoke+models): pin main-via-edge smoke model + drop access-gated claude-fable-5 from anthropic /v1/models

### DIFF
--- a/backend/internal/pkg/claude/constants.go
+++ b/backend/internal/pkg/claude/constants.go
@@ -159,13 +159,19 @@ type Model struct {
 }
 
 // DefaultModels Claude Code 客户端支持的默认模型列表
+//
+// claude-fable-5 removed 2026-06-13 (us7 P0): Anthropic now access-gates Fable 5
+// on the OAuth path and answers 404 "Claude Fable 5 is not available, use Opus
+// 4.8". It must not be advertised by the anthropic gateway /v1/models (this list
+// is the candidate source for GatewayHandler.tkClaudeDefaultModelIDs), or
+// clients pick it and hit a 400 unservable-model error (the deploy smoke's
+// /claude/i auto-pick even selected it as the first entry — see the #761
+// main-via-edge follow-up). Mirrors the same removal already applied to the
+// servable allowlist (pricing_catalog_supported_models_tk.go). Antigravity keeps
+// its OWN fable-5 entry (internal/pkg/antigravity/claude_types.go) — fable stays
+// servable there, so per-platform truth is preserved. Do NOT re-add here on an
+// upstream merge.
 var DefaultModels = []Model{
-	{
-		ID:          "claude-fable-5",
-		Type:        "model",
-		DisplayName: "Claude Fable 5",
-		CreatedAt:   "2026-06-09T00:00:00Z",
-	},
 	{
 		ID:          "claude-opus-4-5-20251101",
 		Type:        "model",

--- a/ops/stage0/post_deploy_smoke.sh
+++ b/ops/stage0/post_deploy_smoke.sh
@@ -154,7 +154,18 @@ fi
 
 echo "tk_post_deploy_smoke: /v1/models shape object=${models_object} count=${models_count}"
 
-model="$(smoke_pick_model_from_list "$tmpdir/models.json" "${TK_SMOKE_PROD_ANTHROPIC_MODEL:-}")" || exit 1
+# Anthropic model override: prod full suite sets TK_SMOKE_PROD_ANTHROPIC_MODEL
+# (a prod Environment var). The main-via-edge canary runs in an edge Environment
+# that has NO such var, so without a fallback smoke_pick_model_from_list auto-picks
+# the first /claude/i id from /v1/models — which can be an access-gated model
+# (e.g. claude-fable-5: 404/400 on the OAuth path) and fails the smoke spuriously.
+# Fall back to TK_SMOKE_EDGE_LOCAL_CHAT_MODEL (default claude-sonnet-4-6) so the
+# canary always probes a servable model instead of whatever sorts first.
+anthropic_model_override="${TK_SMOKE_PROD_ANTHROPIC_MODEL:-}"
+if [[ -z "${anthropic_model_override}" && "${GATEWAY_SMOKE_SUITE:-}" == "main-via-edge" ]]; then
+  anthropic_model_override="${TK_SMOKE_EDGE_LOCAL_CHAT_MODEL:-}"
+fi
+model="$(smoke_pick_model_from_list "$tmpdir/models.json" "${anthropic_model_override}")" || exit 1
 echo "tk_post_deploy_smoke: using model=${model}"
 
 # --- 4) OpenAI-compat chat ---


### PR DESCRIPTION
Follow-ups from the **v1.8.0** `target=all` rollout, where the **uk1 canary main-via-edge smoke went RED** on a 400 — diagnosed as a smoke-config + advertised-model issue, **not** a 1.8.0 regression (prod full smoke passed). Both fixes in one PR.

## #1 — main-via-edge smoke auto-picked an access-gated model
The canary `main-via-edge` smoke runs in an **edge Environment** that has no `TK_SMOKE_PROD_ANTHROPIC_MODEL` (that var lives in the `prod` Environment). So `smoke_pick_model_from_list` (smoke_lib.sh) fell back to auto-pick: the first `/claude/i` id from prod `/v1/models` — which was `claude-fable-5` → access-gated on the OAuth path → **400**, looking like a deploy failure.

**Fix:** `ops/stage0/post_deploy_smoke.sh` — for the `main-via-edge` suite, fall back to the already-defined `TK_SMOKE_EDGE_LOCAL_CHAT_MODEL` (default `claude-sonnet-4-6`) when `TK_SMOKE_PROD_ANTHROPIC_MODEL` is unset. No new GitHub Environment var needed.

## #2 — anthropic `/v1/models` still advertised access-gated `claude-fable-5`
`/v1/models` (anthropic) is built from `claude.DefaultModels` filtered by `ModelListFilter.FilterClientFacing` (**priced AND not availability-unreachable**). `claude-fable-5` is priced and was never probe-marked unreachable, so it leaked through as the **first** entry — even though the servable allowlist (`pricing_catalog_supported_models_tk.go`) already dropped it on 2026-06-13 (us7 P0).

**Fix:** remove the **TK-added** (#687) `claude-fable-5` entry from `claude.DefaultModels`. Antigravity keeps its **own** fable-5 entry (`internal/pkg/antigravity/claude_types.go`), so **per-platform truth is preserved** — fable stays servable on antigravity, gone on anthropic. Fable request-handling code (thinking-sanitize) is untouched; only advertisement changes.

## Why one entry, not the full refresh / a filter change
- The servable allowlist already excludes fable-5; the leak was specifically via the gateway's `claude.DefaultModels` candidate source.
- Removing from the **shared** list is safe because antigravity has its own copy — verified.
- Avoided coupling `/v1/models` to allowlist-intersection in `FilterClientFacing` (larger blast radius); the surgical removal matches the existing 2026-06-13 decision.

## Validation
- `go build ./...` OK (cross-repo new-api resolves)
- `go test -tags=unit ./internal/pkg/claude/... ./internal/handler/... ./internal/service/...` — all pass
- `bash -n post_deploy_smoke.sh` OK
- `scripts/preflight.sh` PASS
- No test asserted fable-5 presence/count; no sentinel pins fable-5 in `claude/constants.go` (anchors are beta-registry + mimicry UA)

Upstream isolation: `post_deploy_smoke.sh` is ops; `constants.go` edit removes a TK-added entry (not upstream-owned) → `upstream-touch-trivial`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
sentinel-registry-reviewed: the only sentinel surface in this diff is `backend/internal/pkg/claude/constants.go`, whose anchors (gateway-tk.json) pin the OAuth Claude Code mimicry **beta registry** + **DefaultHeaders mimicry UA** — none pin the `DefaultModels` entries. Removing the `claude-fable-5` model entry leaves every anchored symbol intact (verified: anchors are BetaAdvisorTool/…/FullClaudeCodeMimicryBetas/JoinBetaHeader and '(external, sdk-cli)'/'v24.3.0'). No new anchor is required for dropping an advertised model id.