### PR TITLE
fix(billing): Vertex Veo official-price alignment + image/video watch probes

### DIFF
--- a/.cursor/skills/tokenkey-online-log-troubleshooting/SKILL.md
+++ b/.cursor/skills/tokenkey-online-log-troubleshooting/SKILL.md
@@ -27,6 +27,7 @@ description: >-
 | Docker access log 解析（status/model/minute/latency 直方图 + marker 计数） | 机械 | `ops/observability/parse-access-log.py --stdin\|--file\|--docker` |
 | Gateway "http request completed" 最近 N 行 tail（脱敏 → JSON array，轻量原始日志） | 机械 | `ops/observability/probe-tail-gateway-logs.sh`（经 run-probe 投递；`LIMIT` 默认 50、`SINCE` 默认 24h、`CONTAINER` 默认 tokenkey） |
 | Dashboard 预聚合覆盖度诊断（"使用趋势只显示 2 天"：usage_dashboard_daily/hourly vs raw usage_logs + aggregation watermark） | 机械 | `ops/observability/probe-dashboard-aggregate-coverage.sh`（经 run-probe 投递；只读 `row_to_json`） |
+| 图片/视频盯盘（成功计量计费 + 错误分面 + 计费异常 + last-seen；区分 image vs video、空池 429 vs 真上游错误 vs 缺权限 401） | 机械 | `ops/observability/probe-image-video-billing.sh`（窗口盯盘，`WINDOW_MIN`/`CTX_HOURS`）+ `ops/observability/probe-image-video-deepctx.sh`（openai 账号池/报错归属/流量出处一次性深挖），均经 run-probe 投递；只读 `row_to_json` |
 | Gateway UA/TLS / usage_logs / ops / docker 指纹交叉对比（窄时间窗） | 机械 | `ops/observability/probe-gateway-ua-tls-compare.sh`（通过 run-probe.sh 投递；`WINDOW_MINUTES` 收窄 DB 窗） |
 | `SUB2API_DEBUG_GATEWAY_BODY` 日志拉回本机（SSM gzip → S3 presigned PUT → 本地 gunzip） | 机械 | `ops/observability/fetch-gateway-debug-log.sh --target prod\|edge:<id>`（**本地** orchestrator，不走 run-probe） |
 | anthropic capacity / cap 与 schedulable 证据 | 机械 | `ops/observability/probe-caps.sh`（已有，通过 run-probe.sh 投递）/ `ops/anthropic/manage-anthropic-config.py snapshot` |

--- a/backend/internal/service/tk_pricing_overlay.json
+++ b/backend/internal/service/tk_pricing_overlay.json
@@ -110,57 +110,57 @@
   "veo-2.0-generate-001": {
     "litellm_provider": "vertex_ai",
     "mode": "video_generation",
-    "output_cost_per_second": 0.35,
-    "source": "litellm:vertex_ai/veo-2.0-generate-001 failure_billing evidence (METRIC-INFERRED, official sentence pending): Google bills Veo per second of GENERATED output video (Vertex pricing unit), so a failed generation produces zero billable seconds; the explicit failure-billing sentence could not be captured on 2026-06-12 (Google docs unreachable from the capture network) — replace this note with the official quote when reachable.",
+    "output_cost_per_second": 0.5,
+    "source": "Official Vertex AI pricing (cloud.google.com/vertex-ai/generative-ai/pricing, verified 2026-06-13): Veo 2 video = $0.50/second (720p). TK bills a single flat per-second rate per model (no resolution/audio granularity), so this is set to the model's MAX official tier to never under-charge. Google bills Veo per second of GENERATED output video, so a failed generation produces zero billable seconds (failure_billing=success_only).",
     "failure_billing": "success_only"
   },
   "veo-3.0-fast-generate-001": {
     "litellm_provider": "vertex_ai",
     "mode": "video_generation",
     "output_cost_per_second": 0.15,
-    "source": "litellm:vertex_ai/veo-3.0-fast-generate-001 failure_billing evidence (METRIC-INFERRED, official sentence pending): Google bills Veo per second of GENERATED output video (Vertex pricing unit), so a failed generation produces zero billable seconds; the explicit failure-billing sentence could not be captured on 2026-06-12 (Google docs unreachable from the capture network) — replace this note with the official quote when reachable.",
+    "source": "Official Vertex AI pricing (cloud.google.com/vertex-ai/generative-ai/pricing, verified 2026-06-13): Veo 3 Fast MAX tier = $0.12/second (1080p + audio); no 4k tier. TK's flat $0.15 already exceeds the official max across all reachable resolution/audio combos — retained (not lowered) to avoid reducing existing revenue. Google bills Veo per second of GENERATED output video, so a failed generation produces zero billable seconds (failure_billing=success_only).",
     "failure_billing": "success_only"
   },
   "veo-3.0-generate-001": {
     "litellm_provider": "vertex_ai",
     "mode": "video_generation",
     "output_cost_per_second": 0.4,
-    "source": "litellm:vertex_ai/veo-3.0-generate-001 failure_billing evidence (METRIC-INFERRED, official sentence pending): Google bills Veo per second of GENERATED output video (Vertex pricing unit), so a failed generation produces zero billable seconds; the explicit failure-billing sentence could not be captured on 2026-06-12 (Google docs unreachable from the capture network) — replace this note with the official quote when reachable.",
+    "source": "Official Vertex AI pricing (cloud.google.com/vertex-ai/generative-ai/pricing, verified 2026-06-13): Veo 3 MAX tier = $0.40/second (720p/1080p + audio); no 4k tier. TK's flat $0.40 matches the official max — covers all reachable resolution/audio combos. Google bills Veo per second of GENERATED output video, so a failed generation produces zero billable seconds (failure_billing=success_only).",
     "failure_billing": "success_only"
   },
   "veo-3.1-fast-generate-001": {
     "litellm_provider": "vertex_ai",
     "mode": "video_generation",
-    "output_cost_per_second": 0.15,
-    "source": "litellm:vertex_ai/veo-3.1-fast-generate-001 failure_billing evidence (METRIC-INFERRED, official sentence pending): Google bills Veo per second of GENERATED output video (Vertex pricing unit), so a failed generation produces zero billable seconds; the explicit failure-billing sentence could not be captured on 2026-06-12 (Google docs unreachable from the capture network) — replace this note with the official quote when reachable.",
+    "output_cost_per_second": 0.3,
+    "source": "Official Vertex AI pricing (cloud.google.com/vertex-ai/generative-ai/pricing, verified 2026-06-13): Veo 3.1 Fast MAX tier = $0.30/second (4k + audio); lower tiers 720p $0.10, 1080p $0.12, video-only 4k $0.25. TK bills a single flat per-second rate per model (no resolution/audio granularity), so this is set to the model's MAX official tier to never under-charge. Google bills Veo per second of GENERATED output video, so a failed generation produces zero billable seconds (failure_billing=success_only).",
     "failure_billing": "success_only"
   },
   "veo-3.1-fast-generate-preview": {
     "litellm_provider": "vertex_ai",
     "mode": "video_generation",
-    "output_cost_per_second": 0.15,
-    "source": "litellm:vertex_ai/veo-3.1-fast-generate-preview failure_billing evidence (METRIC-INFERRED, official sentence pending): Google bills Veo per second of GENERATED output video (Vertex pricing unit), so a failed generation produces zero billable seconds; the explicit failure-billing sentence could not be captured on 2026-06-12 (Google docs unreachable from the capture network) — replace this note with the official quote when reachable.",
+    "output_cost_per_second": 0.3,
+    "source": "Official Vertex AI pricing (cloud.google.com/vertex-ai/generative-ai/pricing, verified 2026-06-13): Veo 3.1 Fast MAX tier = $0.30/second (4k + audio); lower tiers 720p $0.10, 1080p $0.12, video-only 4k $0.25. TK bills a single flat per-second rate per model (no resolution/audio granularity), so this is set to the model's MAX official tier to never under-charge. Google bills Veo per second of GENERATED output video, so a failed generation produces zero billable seconds (failure_billing=success_only).",
     "failure_billing": "success_only"
   },
   "veo-3.1-generate-001": {
     "litellm_provider": "vertex_ai",
     "mode": "video_generation",
-    "output_cost_per_second": 0.4,
-    "source": "litellm:vertex_ai/veo-3.1-generate-001 failure_billing evidence (METRIC-INFERRED, official sentence pending): Google bills Veo per second of GENERATED output video (Vertex pricing unit), so a failed generation produces zero billable seconds; the explicit failure-billing sentence could not be captured on 2026-06-12 (Google docs unreachable from the capture network) — replace this note with the official quote when reachable.",
+    "output_cost_per_second": 0.6,
+    "source": "Official Vertex AI pricing (cloud.google.com/vertex-ai/generative-ai/pricing, verified 2026-06-13): Veo 3.1 MAX tier = $0.60/second (4k + audio); lower tiers 720p/1080p + audio $0.40, video-only 4k $0.40, video-only 720p/1080p $0.20. TK bills a single flat per-second rate per model (no resolution/audio granularity), so this is set to the model's MAX official tier to never under-charge. Google bills Veo per second of GENERATED output video, so a failed generation produces zero billable seconds (failure_billing=success_only).",
     "failure_billing": "success_only"
   },
   "veo-3.1-generate-preview": {
     "litellm_provider": "vertex_ai",
     "mode": "video_generation",
-    "output_cost_per_second": 0.4,
-    "source": "litellm:vertex_ai/veo-3.1-generate-preview failure_billing evidence (METRIC-INFERRED, official sentence pending): Google bills Veo per second of GENERATED output video (Vertex pricing unit), so a failed generation produces zero billable seconds; the explicit failure-billing sentence could not be captured on 2026-06-12 (Google docs unreachable from the capture network) — replace this note with the official quote when reachable.",
+    "output_cost_per_second": 0.6,
+    "source": "Official Vertex AI pricing (cloud.google.com/vertex-ai/generative-ai/pricing, verified 2026-06-13): Veo 3.1 MAX tier = $0.60/second (4k + audio); lower tiers 720p/1080p + audio $0.40, video-only 4k $0.40, video-only 720p/1080p $0.20. TK bills a single flat per-second rate per model (no resolution/audio granularity), so this is set to the model's MAX official tier to never under-charge. Google bills Veo per second of GENERATED output video, so a failed generation produces zero billable seconds (failure_billing=success_only).",
     "failure_billing": "success_only"
   },
   "veo-3.1-lite-generate-preview": {
     "litellm_provider": "gemini",
     "mode": "video_generation",
-    "output_cost_per_second": 0.05,
-    "source": "litellm:gemini/veo-3.1-lite-generate-preview failure_billing evidence (METRIC-INFERRED, official sentence pending): Google bills Veo per second of GENERATED output video (Vertex pricing unit), so a failed generation produces zero billable seconds; the explicit failure-billing sentence could not be captured on 2026-06-12 (Google docs unreachable from the capture network) — replace this note with the official quote when reachable.",
+    "output_cost_per_second": 0.08,
+    "source": "Official Vertex AI pricing (cloud.google.com/vertex-ai/generative-ai/pricing, verified 2026-06-13): Veo 3.1 Lite MAX tier = $0.08/second (1080p + audio); lower tiers 720p + audio $0.05, video-only 720p $0.03 / 1080p $0.05; no 4k tier. TK bills a single flat per-second rate per model (no resolution/audio granularity), so this is set to the model's MAX official tier to never under-charge. Google bills Veo per second of GENERATED output video, so a failed generation produces zero billable seconds (failure_billing=success_only).",
     "failure_billing": "success_only"
   },
   "doubao-seedream-4-0-250828": {

--- a/ops/observability/probe-image-video-billing.sh
+++ b/ops/observability/probe-image-video-billing.sh
@@ -21,14 +21,21 @@ set -u
 
 WINDOW_MIN="${WINDOW_MIN:-30}"
 CTX_HOURS="${CTX_HOURS:-6}"
+# Integer-validate before interpolating into SQL interval literals (matches
+# probe-429-classify.sh's WINDOW_HOURS guard; closes the injection vector).
+case "$WINDOW_MIN" in ''|*[!0-9]*) echo "bad WINDOW_MIN (want integer minutes)" >&2; exit 2;; esac
+case "$CTX_HOURS"  in ''|*[!0-9]*) echo "bad CTX_HOURS (want integer hours)"   >&2; exit 2;; esac
 PSQL='docker exec tokenkey-postgres psql -U tokenkey -d tokenkey -X -A -t'
 
 W="interval '${WINDOW_MIN} minutes'"
 C="interval '${CTX_HOURS} hours'"
 
-# usage_logs predicates
+# usage_logs predicates — keep image/video symmetric: billing_mode is the
+# precise tag, the others are belt-and-suspenders. video submit rows can have
+# NULL video_duration_seconds, so billing_mode='video' is load-bearing here
+# (without it those zero-cost submit rows — exactly what we watch for — slip).
 IMG_U="(billing_mode = 'image' OR COALESCE(image_count,0) > 0 OR inbound_endpoint ILIKE '%image%')"
-VID_U="(video_duration_seconds IS NOT NULL OR inbound_endpoint ILIKE '%video%')"
+VID_U="(billing_mode = 'video' OR video_duration_seconds IS NOT NULL OR inbound_endpoint ILIKE '%video%')"
 # ops_error_logs predicates
 IMG_E="(request_path ILIKE '%/images%' OR inbound_endpoint ILIKE '%image%')"
 VID_E="(request_path ILIKE '%/video%' OR inbound_endpoint ILIKE '%video%')"

--- a/ops/observability/probe-image-video-billing.sh
+++ b/ops/observability/probe-image-video-billing.sh
@@ -1,0 +1,158 @@
+#!/usr/bin/env bash
+# probe-image-video-billing.sh — read-only prod盯盘 for image/video generation
+# traffic: volume, errors, and metering/billing. Runs INSIDE the TokenKey host
+# (prod or edge) via run-probe.sh. Output is row_to_json so parsing is
+# field-named, not column-index.
+#
+#   bash ops/observability/run-probe.sh --target prod \
+#     --script ops/observability/probe-image-video-billing.sh \
+#     [--env WINDOW_MIN=30] [--env CTX_HOURS=6]
+#
+# WINDOW_MIN — detailed recent window in minutes (default 30; overlaps the
+#              5-min report cadence so nothing slips between reports).
+# CTX_HOURS  — broader context window in hours (default 6).
+#
+# Discriminators (image vs video) — derived from usage_logs / ops_error_logs:
+#   image: billing_mode='image' OR image_count>0 OR inbound_endpoint ILIKE '%image%'
+#          (errors: request_path/inbound_endpoint ILIKE '%/images%')
+#   video: video_duration_seconds IS NOT NULL OR inbound_endpoint ILIKE '%video%'
+#          (errors: request_path/inbound_endpoint ILIKE '%/video%'  — also matches /videos)
+set -u
+
+WINDOW_MIN="${WINDOW_MIN:-30}"
+CTX_HOURS="${CTX_HOURS:-6}"
+PSQL='docker exec tokenkey-postgres psql -U tokenkey -d tokenkey -X -A -t'
+
+W="interval '${WINDOW_MIN} minutes'"
+C="interval '${CTX_HOURS} hours'"
+
+# usage_logs predicates
+IMG_U="(billing_mode = 'image' OR COALESCE(image_count,0) > 0 OR inbound_endpoint ILIKE '%image%')"
+VID_U="(video_duration_seconds IS NOT NULL OR inbound_endpoint ILIKE '%video%')"
+# ops_error_logs predicates
+IMG_E="(request_path ILIKE '%/images%' OR inbound_endpoint ILIKE '%image%')"
+VID_E="(request_path ILIKE '%/video%' OR inbound_endpoint ILIKE '%video%')"
+
+echo "=== meta ==="
+$PSQL -c "SELECT row_to_json(t) FROM (SELECT
+  now() AT TIME ZONE 'UTC'                         AS now_utc,
+  now() AT TIME ZONE 'Asia/Shanghai'              AS now_cst,
+  ${WINDOW_MIN}::int                               AS window_min,
+  ${CTX_HOURS}::int                                AS ctx_hours) t;" 2>&1
+
+# ---------------------------------------------------------------------------
+# IMAGE — billing/volume from usage_logs (successful, billed requests)
+# ---------------------------------------------------------------------------
+echo
+echo "=== image: usage_logs totals (window vs ctx) ==="
+$PSQL -c "SELECT row_to_json(t) FROM (SELECT
+  count(*) FILTER (WHERE created_at >= now() - ${W})                       AS req_window,
+  count(*) FILTER (WHERE created_at >= now() - ${C})                       AS req_ctx,
+  COALESCE(sum(image_count) FILTER (WHERE created_at >= now() - ${C}),0)   AS images_ctx,
+  ROUND(COALESCE(sum(total_cost)  FILTER (WHERE created_at >= now() - ${C}),0)::numeric,6) AS total_cost_ctx,
+  ROUND(COALESCE(sum(actual_cost) FILTER (WHERE created_at >= now() - ${C}),0)::numeric,6) AS actual_cost_ctx,
+  count(*) FILTER (WHERE created_at >= now() - ${C} AND COALESCE(total_cost,0)=0) AS zero_cost_ctx
+  FROM usage_logs WHERE ${IMG_U} AND created_at >= now() - ${C}) t;" 2>&1
+
+echo
+echo "=== image: by model (ctx) — vol, images, cost, zero-cost rows ==="
+$PSQL -c "SELECT row_to_json(t) FROM (SELECT
+  COALESCE(requested_model,model)                                AS req_model,
+  upstream_model,
+  count(*)                                                       AS reqs,
+  COALESCE(sum(image_count),0)                                   AS images,
+  ROUND(COALESCE(sum(total_cost),0)::numeric,6)                  AS total_cost,
+  count(*) FILTER (WHERE COALESCE(total_cost,0)=0)               AS zero_cost_rows
+  FROM usage_logs WHERE ${IMG_U} AND created_at >= now() - ${C}
+  GROUP BY 1,2 ORDER BY reqs DESC LIMIT 30) t;" 2>&1
+
+echo
+echo "=== image: last 5 billed rows (sample) ==="
+$PSQL -c "SELECT row_to_json(t) FROM (SELECT
+  created_at AT TIME ZONE 'UTC' AS ts_utc,
+  COALESCE(requested_model,model) AS req_model, upstream_model,
+  image_count, image_size, billing_mode,
+  ROUND(COALESCE(total_cost,0)::numeric,6) AS total_cost
+  FROM usage_logs WHERE ${IMG_U} ORDER BY created_at DESC LIMIT 5) t;" 2>&1
+
+# ---------------------------------------------------------------------------
+# VIDEO — billing/volume from usage_logs
+# ---------------------------------------------------------------------------
+echo
+echo "=== video: usage_logs totals (window vs ctx) ==="
+$PSQL -c "SELECT row_to_json(t) FROM (SELECT
+  count(*) FILTER (WHERE created_at >= now() - ${W})                            AS req_window,
+  count(*) FILTER (WHERE created_at >= now() - ${C})                            AS req_ctx,
+  COALESCE(sum(video_duration_seconds) FILTER (WHERE created_at >= now() - ${C}),0) AS video_secs_ctx,
+  ROUND(COALESCE(sum(total_cost)  FILTER (WHERE created_at >= now() - ${C}),0)::numeric,6) AS total_cost_ctx,
+  ROUND(COALESCE(sum(actual_cost) FILTER (WHERE created_at >= now() - ${C}),0)::numeric,6) AS actual_cost_ctx,
+  count(*) FILTER (WHERE created_at >= now() - ${C} AND COALESCE(total_cost,0)=0) AS zero_cost_ctx
+  FROM usage_logs WHERE ${VID_U} AND created_at >= now() - ${C}) t;" 2>&1
+
+echo
+echo "=== video: by model (ctx) — vol, secs, cost, zero-cost rows ==="
+$PSQL -c "SELECT row_to_json(t) FROM (SELECT
+  COALESCE(requested_model,model)                                AS req_model,
+  upstream_model,
+  count(*)                                                       AS reqs,
+  COALESCE(sum(video_duration_seconds),0)                        AS video_secs,
+  ROUND(COALESCE(sum(total_cost),0)::numeric,6)                  AS total_cost,
+  count(*) FILTER (WHERE COALESCE(total_cost,0)=0)               AS zero_cost_rows
+  FROM usage_logs WHERE ${VID_U} AND created_at >= now() - ${C}
+  GROUP BY 1,2 ORDER BY reqs DESC LIMIT 30) t;" 2>&1
+
+echo
+echo "=== video: last 5 billed rows (sample) ==="
+$PSQL -c "SELECT row_to_json(t) FROM (SELECT
+  created_at AT TIME ZONE 'UTC' AS ts_utc,
+  COALESCE(requested_model,model) AS req_model, upstream_model,
+  video_duration_seconds, billing_mode,
+  ROUND(COALESCE(total_cost,0)::numeric,6) AS total_cost
+  FROM usage_logs WHERE ${VID_U} ORDER BY created_at DESC LIMIT 5) t;" 2>&1
+
+# ---------------------------------------------------------------------------
+# ERRORS — ops_error_logs filtered to image/video surfaces
+# ---------------------------------------------------------------------------
+echo
+echo "=== errors: image+video counts (window vs ctx) ==="
+$PSQL -c "SELECT row_to_json(t) FROM (SELECT
+  count(*) FILTER (WHERE ${IMG_E} AND created_at >= now() - ${W}) AS img_err_window,
+  count(*) FILTER (WHERE ${IMG_E} AND created_at >= now() - ${C}) AS img_err_ctx,
+  count(*) FILTER (WHERE ${VID_E} AND created_at >= now() - ${W}) AS vid_err_window,
+  count(*) FILTER (WHERE ${VID_E} AND created_at >= now() - ${C}) AS vid_err_ctx
+  FROM ops_error_logs WHERE (${IMG_E} OR ${VID_E}) AND created_at >= now() - ${C}) t;" 2>&1
+
+echo
+echo "=== errors: breakdown by surface/status/type (ctx) ==="
+$PSQL -c "SELECT row_to_json(t) FROM (SELECT
+  CASE WHEN ${VID_E} THEN 'video' WHEN ${IMG_E} THEN 'image' ELSE 'other' END AS surface,
+  COALESCE(platform,'?')        AS platform,
+  COALESCE(model,'?')           AS model,
+  error_phase, error_type,
+  status_code, upstream_status_code,
+  is_business_limited,
+  count(*)                      AS n
+  FROM ops_error_logs WHERE (${IMG_E} OR ${VID_E}) AND created_at >= now() - ${C}
+  GROUP BY 1,2,3,4,5,6,7,8 ORDER BY n DESC LIMIT 40) t;" 2>&1
+
+echo
+echo "=== errors: last 8 (sample, desensitized) ==="
+$PSQL -c "SELECT row_to_json(t) FROM (SELECT
+  created_at AT TIME ZONE 'UTC' AS ts_utc,
+  CASE WHEN ${VID_E} THEN 'video' WHEN ${IMG_E} THEN 'image' ELSE 'other' END AS surface,
+  platform, model, request_path,
+  error_phase, error_type, status_code, upstream_status_code,
+  left(COALESCE(upstream_error_message, error_message,''),200) AS msg
+  FROM ops_error_logs WHERE (${IMG_E} OR ${VID_E})
+  ORDER BY created_at DESC LIMIT 8) t;" 2>&1
+
+# ---------------------------------------------------------------------------
+# LAST-SEEN — so empty windows are still informative
+# ---------------------------------------------------------------------------
+echo
+echo "=== last-seen (even if windows empty) ==="
+$PSQL -c "SELECT row_to_json(t) FROM (SELECT
+  (SELECT max(created_at) AT TIME ZONE 'UTC' FROM usage_logs WHERE ${IMG_U})        AS last_image_ok,
+  (SELECT max(created_at) AT TIME ZONE 'UTC' FROM usage_logs WHERE ${VID_U})        AS last_video_ok,
+  (SELECT max(created_at) AT TIME ZONE 'UTC' FROM ops_error_logs WHERE ${IMG_E})    AS last_image_err,
+  (SELECT max(created_at) AT TIME ZONE 'UTC' FROM ops_error_logs WHERE ${VID_E})    AS last_video_err) t;" 2>&1

--- a/ops/observability/probe-image-video-deepctx.sh
+++ b/ops/observability/probe-image-video-deepctx.sh
@@ -1,0 +1,88 @@
+#!/usr/bin/env bash
+# probe-image-video-deepctx.sh — read-only one-shot deep context for the
+# image/video failure baseline: WHY image gen returns errors (openai pool
+# state, offending account_ids, missing-scope vs empty-pool), and traffic
+# provenance (test sweep vs organic users). Runs INSIDE the host via run-probe.
+set -u
+PSQL='docker exec tokenkey-postgres psql -U tokenkey -d tokenkey -X -A -t'
+
+echo "=== openai account pool (not soft-deleted) ==="
+$PSQL -c "SELECT row_to_json(t) FROM (SELECT
+  status,
+  schedulable,
+  (temp_unschedulable_until IS NOT NULL AND temp_unschedulable_until > now()) AS in_cooldown,
+  channel_type,
+  count(*) AS n
+  FROM accounts
+  WHERE platform='openai' AND deleted_at IS NULL
+  GROUP BY 1,2,3,4 ORDER BY n DESC) t;" 2>&1
+
+echo
+echo "=== openai accounts schedulable RIGHT NOW (detail) ==="
+$PSQL -c "SELECT row_to_json(t) FROM (SELECT
+  id, name, status, schedulable, priority, channel_type,
+  temp_unschedulable_until AT TIME ZONE 'UTC' AS cooldown_until_utc,
+  left(COALESCE(temp_unschedulable_reason,''),120) AS reason
+  FROM accounts
+  WHERE platform='openai' AND deleted_at IS NULL
+  ORDER BY schedulable DESC, priority ASC LIMIT 20) t;" 2>&1
+
+echo
+echo "=== image errors by account_id (24h) — who is failing ==="
+$PSQL -c "SELECT row_to_json(t) FROM (SELECT
+  account_id, platform, model,
+  status_code, upstream_status_code, error_type, error_phase,
+  count(*) AS n,
+  max(created_at AT TIME ZONE 'UTC') AS last_utc
+  FROM ops_error_logs
+  WHERE (request_path ILIKE '%/images%' OR inbound_endpoint ILIKE '%image%')
+    AND created_at >= now() - interval '24 hours'
+  GROUP BY 1,2,3,4,5,6,7 ORDER BY n DESC LIMIT 30) t;" 2>&1
+
+echo
+echo "=== image traffic provenance: distinct users/api_keys (7d, ok+err) ==="
+$PSQL -c "SELECT row_to_json(t) FROM (SELECT
+  'usage_ok' AS src, count(*) AS rows,
+  count(DISTINCT user_id) AS users, count(DISTINCT api_key_id) AS keys,
+  min(created_at AT TIME ZONE 'UTC') AS first_utc, max(created_at AT TIME ZONE 'UTC') AS last_utc
+  FROM usage_logs
+  WHERE (billing_mode='image' OR COALESCE(image_count,0)>0 OR inbound_endpoint ILIKE '%image%')
+    AND created_at >= now() - interval '7 days'
+  UNION ALL
+  SELECT 'err', count(*),
+  count(DISTINCT user_id), count(DISTINCT api_key_id),
+  min(created_at AT TIME ZONE 'UTC'), max(created_at AT TIME ZONE 'UTC')
+  FROM ops_error_logs
+  WHERE (request_path ILIKE '%/images%' OR inbound_endpoint ILIKE '%image%')
+    AND created_at >= now() - interval '7 days') t;" 2>&1
+
+echo
+echo "=== video traffic provenance: distinct users/api_keys (7d, ok+err) ==="
+$PSQL -c "SELECT row_to_json(t) FROM (SELECT
+  'usage_ok' AS src, count(*) AS rows,
+  count(DISTINCT user_id) AS users, count(DISTINCT api_key_id) AS keys,
+  min(created_at AT TIME ZONE 'UTC') AS first_utc, max(created_at AT TIME ZONE 'UTC') AS last_utc
+  FROM usage_logs
+  WHERE (video_duration_seconds IS NOT NULL OR billing_mode='video' OR inbound_endpoint ILIKE '%video%')
+    AND created_at >= now() - interval '7 days'
+  UNION ALL
+  SELECT 'err', count(*),
+  count(DISTINCT user_id), count(DISTINCT api_key_id),
+  min(created_at AT TIME ZONE 'UTC'), max(created_at AT TIME ZONE 'UTC')
+  FROM ops_error_logs
+  WHERE (request_path ILIKE '%/video%' OR inbound_endpoint ILIKE '%video%')
+    AND created_at >= now() - interval '7 days') t;" 2>&1
+
+echo
+echo "=== video usage rows detail (7d) — submit vs billed (cost/secs) ==="
+$PSQL -c "SELECT row_to_json(t) FROM (SELECT
+  COALESCE(requested_model,model) AS req_model,
+  billing_mode,
+  count(*) AS rows,
+  count(*) FILTER (WHERE COALESCE(total_cost,0)=0) AS zero_cost,
+  count(*) FILTER (WHERE video_duration_seconds IS NOT NULL) AS has_secs,
+  ROUND(COALESCE(sum(total_cost),0)::numeric,6) AS total_cost
+  FROM usage_logs
+  WHERE (video_duration_seconds IS NOT NULL OR billing_mode='video' OR inbound_endpoint ILIKE '%video%')
+    AND created_at >= now() - interval '7 days'
+  GROUP BY 1,2 ORDER BY rows DESC LIMIT 30) t;" 2>&1


### PR DESCRIPTION
This PR carries two related image/video billing changes on one branch (squash-merged into one commit per CLAUDE.md §5.y):

1. **Billing fix** — align Vertex **Veo** per-second prices to the official **max** tier so TK never under-charges (`6dcfc758`).
2. **Observability** — read-only image/video traffic + billing **watch probes** (original scope, `0edaf45e`/`aedc7058`).

---

## 1. Billing fix: Vertex Veo official-price alignment

### What

TK bills video as a **single flat `output_cost_per_second` per model name** (no resolution/audio granularity — see `CalculateVideoCost`). So each rate must equal the model's **MAX official tier** or TK under-charges 4k/with-audio requests. Verified TK's overlay against the **official** Vertex AI pricing page (`cloud.google.com/vertex-ai/generative-ai/pricing`, raw-HTML capture 2026-06-13) and raised the under-charging entries:

| Model | Before | After | Official max tier |
|---|---|---|---|
| `veo-2.0-generate-001` | $0.35 | **$0.50** | 720p |
| `veo-3.1-generate-001` / `-preview` | $0.40 | **$0.60** | 4k + audio |
| `veo-3.1-fast-generate-001` / `-preview` | $0.15 | **$0.30** | 4k + audio |
| `veo-3.1-lite-generate-preview` | $0.05 | **$0.08** | 1080p + audio |

**Unchanged (already ≥ official max):** `veo-3.0` $0.40 (= 720p/1080p + audio; the $0.50 video-only / $0.75 with-audio figures were Google's **launch** prices, since cut — confirmed on the live official page), `veo-3.0-fast` $0.15 (> official $0.12). **Imagen** entries already match official ($0.06/$0.04/$0.02), untouched.

Each entry's prose `source` note was refreshed from the stale `"official sentence pending / docs unreachable"` placeholder to the verified per-tier breakdown.

### Why

Direct money correctness: the prior `veo-2.0 / veo-3.1*` rates were below the current official Vertex price, so every such request under-charged vs what Google bills us. Conservative max-tier flat rate matches the existing billing philosophy (`videoRequestedSeconds` already defaults to veo's conservative 8s max + round-up).

### Verification

- `go test -tags=unit ./internal/service/ -run 'Pricing|Overlay|Video|Media'` — **PASS** (overlay test only pins `veo-3.0`=0.4, unchanged).
- `scripts/preflight.sh` pricing-overlay gate (anchors present, no $0) — **PASS**.
- TK-only file (`tk_pricing_overlay.json`); no upstream-shaped path touched (`no-web-impact`).

---

## 2. Observability probes

## What

Two read-only prod probes for monitoring the **image/video generation surfaces** (volume, errors, metering/billing). Both are delivered via `ops/observability/run-probe.sh --target prod|edge:<id>` and query `usage_logs` + `ops_error_logs` with `row_to_json` output (field-named, not column-index).

- **`probe-image-video-billing.sh`** — windowed watch (`WINDOW_MIN`/`CTX_HOURS` env):
  - per-surface (image vs video) success/billing totals (window vs context)
  - by-model volume + cost + zero-cost-row anomaly counts
  - `ops_error_logs` breakdown distinguishing **empty-pool 429** (`No available accounts`) vs **true upstream error** vs **missing-scope 401**
  - `last-seen` timestamps so empty windows stay informative
- **`probe-image-video-deepctx.sh`** — one-shot deep context:
  - openai account pool schedulability + `temp_unschedulable_reason`
  - image errors grouped by `account_id` (who is failing)
  - traffic provenance (test sweep vs organic distinct users/keys)

Discriminators (image vs video) derive from `billing_mode` / `image_count` / `video_duration_seconds` / `inbound_endpoint` (usage_logs) and `request_path` / `inbound_endpoint` (ops_error_logs) — documented in each script header.

## Why

Existing observability tooling is anthropic/edge-focused; there was no mechanized probe for the fifth-platform image/video surfaces. These were authored to drive a live monitoring session and validated end-to-end against prod (`status=Success`).

## Notes

- **Read-only** (psql `SELECT` only, no writes), consistent with the run-probe convention.
- Wired into the `tokenkey-online-log-troubleshooting` skill determinism table — required for the `ops-tool-orphan` preflight gate to recognize them (0 orphans).
- No upstream-shaped paths touched; no backend/business-logic changed (`no-web-impact`).
- `scripts/preflight.sh`: **PASS**.

Merge mode: **Squash and merge** (TK-originated, per CLAUDE.md §5.y).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
