### PR TITLE
fix(gateway): Responses stream truncation emits response.incomplete, not a fake completed

### DIFF
--- a/.cache/upstream/fact-checks.json
+++ b/.cache/upstream/fact-checks.json
@@ -567,6 +567,23 @@
         "backend/internal/service/openai_gateway_service.go:Do NOT reintroduce a 100-raw inversion",
         "backend/internal/service/openai_gateway_service_codex_snapshot_test.go:TestNormalize_ProdLayoutUsedPercentPassthrough"
       ]
+    },
+    {
+      "upstream": "Wei-Shaw/sub2api#2245",
+      "severity": "high",
+      "summary": "OpenAI Responses streaming: when the upstream SSE stream ends without a terminal event (Anthropic message_stop), the /responses conversion finalizes the turn as a spec-valid response.incomplete (status=incomplete, incomplete_details.reason=interrupted) instead of a fake response.completed. The streaming terminal event type is now derived from response.status, so strict Responses clients (Codex CLI / OpenAI SDK) receive a correct terminal event and a truncated turn is not reported (to client or billing) as a clean success.",
+      "fixed_by": [
+        "backend/internal/pkg/apicompat/anthropic_to_responses_response.go",
+        "backend/internal/pkg/apicompat/anthropic_to_responses_truncation_test.go",
+        "backend/internal/service/gateway_forward_as_responses.go",
+        "backend/internal/service/gateway_forward_as_responses_test.go"
+      ],
+      "fixed_if_all_present": [
+        "backend/internal/pkg/apicompat/anthropic_to_responses_response.go:responsesTerminalEventTypeForStatus",
+        "backend/internal/pkg/apicompat/anthropic_to_responses_response.go:responsesIncompleteReasonInterrupted",
+        "backend/internal/pkg/apicompat/anthropic_to_responses_truncation_test.go:TestFinalizeAnthropicResponsesStream_TruncationEmitsIncomplete",
+        "backend/internal/service/gateway_forward_as_responses_test.go:TestHandleResponsesStreamingResponse_TruncatedUpstreamEmitsIncomplete"
+      ]
     }
   ]
 }

--- a/.cache/upstream/fixes.json
+++ b/.cache/upstream/fixes.json
@@ -341,6 +341,17 @@
       "summary": "OpenAI scheduling now queries account_groups for the requested group, so grouped balance traffic should not select ungrouped accounts."
     },
     {
+      "upstream": "Wei-Shaw/sub2api#2245",
+      "status": "fixed_in_tokenkey",
+      "fixed_by": [
+        "backend/internal/pkg/apicompat/anthropic_to_responses_response.go",
+        "backend/internal/pkg/apicompat/anthropic_to_responses_truncation_test.go",
+        "backend/internal/service/gateway_forward_as_responses.go",
+        "backend/internal/service/gateway_forward_as_responses_test.go"
+      ],
+      "summary": "OpenAI Responses streaming: when the upstream SSE stream ends without a terminal event (Anthropic message_stop), the /responses conversion finalizes the turn as a spec-valid response.incomplete (status=incomplete, incomplete_details.reason=interrupted) instead of a fake response.completed. The streaming terminal event type is now derived from response.status, so strict Responses clients (Codex CLI / OpenAI SDK) receive a correct terminal event and a truncated turn is not reported (to client or billing) as a clean success."
+    },
+    {
       "upstream": "Wei-Shaw/sub2api#2258",
       "tokenkey_pr": "youxuanxue/sub2api#232",
       "status": "fixed_in_tokenkey",

--- a/.cache/upstream/triage.json
+++ b/.cache/upstream/triage.json
@@ -5,8 +5,8 @@
   "rationale": "TokenKey-local triage cache for upstream open issues. Use this file before re-triaging upstream issues; update entries when TokenKey fixes, dismisses, or reclassifies an issue.",
   "counts": {
     "needs_review": 409,
-    "fixed": 38,
-    "needs_prod_validation": 2,
+    "needs_prod_validation": 1,
+    "fixed": 39,
     "medium": 123,
     "not_applicable": 1,
     "low": 110,
@@ -5115,24 +5115,6 @@
       "updated_at": "2026-05-11T07:02:08Z"
     },
     {
-      "upstream": "Wei-Shaw/sub2api#2245",
-      "url": "https://github.com/Wei-Shaw/sub2api/issues/2245",
-      "title": "OpenAI Responses SSE 流未完成时被转发为 HTTP 200 导致 stream closed before response.completed 问题",
-      "impact": "needs_prod_validation",
-      "categories": [
-        "rate_limit_cooldown",
-        "billing_usage",
-        "account_pool_health",
-        "ops_observability",
-        "compatibility",
-        "enhancement",
-        "docs"
-      ],
-      "tokenkey_status": "known_protocol_limitation",
-      "rationale": "Responses stream terminal-event detection exists, but downstream may already have received HTTP 200 before an incomplete SSE is detected.",
-      "updated_at": "2026-05-07T06:36:20Z"
-    },
-    {
       "upstream": "Wei-Shaw/sub2api#1048",
       "url": "https://github.com/Wei-Shaw/sub2api/issues/1048",
       "title": "功能建议：建议新增gemini的openai兼容协议。openclaw中gemini的原生v1beta协议无法使用",
@@ -6894,6 +6876,24 @@
       "tokenkey_status": "fixed_in_tokenkey",
       "rationale": "Account scheduling now queries the account_groups join table for the requested group; balance-group requests should not schedule ungrouped accounts.",
       "updated_at": "2026-05-05T18:45:31Z"
+    },
+    {
+      "upstream": "Wei-Shaw/sub2api#2245",
+      "url": "https://github.com/Wei-Shaw/sub2api/issues/2245",
+      "title": "OpenAI Responses SSE 流未完成时被转发为 HTTP 200 导致 stream closed before response.completed 问题",
+      "impact": "fixed",
+      "categories": [
+        "rate_limit_cooldown",
+        "billing_usage",
+        "account_pool_health",
+        "ops_observability",
+        "compatibility",
+        "enhancement",
+        "docs"
+      ],
+      "tokenkey_status": "fixed_in_tokenkey",
+      "rationale": "OpenAI Responses streaming: when the upstream SSE stream ends without a terminal event (Anthropic message_stop), the /responses conversion finalizes the turn as a spec-valid response.incomplete (status=incomplete, incomplete_details.reason=interrupted) instead of a fake response.completed. The streaming terminal event type is now derived from response.status, so strict Responses clients (Codex CLI / OpenAI SDK) receive a correct terminal event and a truncated turn is not reported (to client or billing) as a clean success.",
+      "updated_at": "2026-05-07T06:36:20Z"
     },
     {
       "upstream": "Wei-Shaw/sub2api#2258",

--- a/backend/internal/pkg/apicompat/anthropic_to_responses_response.go
+++ b/backend/internal/pkg/apicompat/anthropic_to_responses_response.go
@@ -196,8 +196,14 @@ func AnthropicEventToResponsesEvents(
 	}
 }
 
-// FinalizeAnthropicResponsesStream emits synthetic termination events if the
-// stream ended without a proper message_stop.
+// FinalizeAnthropicResponsesStream emits a synthetic terminal event when the
+// upstream stream ended without a message_stop — i.e. the connection dropped
+// before the turn finished. The response is genuinely truncated, so it emits a
+// spec-valid response.incomplete (status="incomplete") rather than a fake
+// response.completed: a strict Responses client (Codex CLI / OpenAI SDK)
+// otherwise either errors with "stream closed before response.completed" (when
+// no terminal arrives at all) or, worse, is told a cut-off turn succeeded and
+// consumes the partial output as if it were complete. See Wei-Shaw/sub2api#2245.
 func FinalizeAnthropicResponsesStream(state *AnthropicEventToResponsesState) []ResponsesStreamEvent {
 	if !state.CreatedSent || state.CompletedSent {
 		return nil
@@ -208,8 +214,11 @@ func FinalizeAnthropicResponsesStream(state *AnthropicEventToResponsesState) []R
 	// Close any open item
 	events = append(events, closeCurrentResponsesItem(state)...)
 
-	// Emit response.completed
-	events = append(events, makeResponsesCompletedEvent(state, "completed", nil))
+	// Reaching here means the upstream never sent message_stop; surface the turn
+	// as incomplete instead of synthesizing a successful completion.
+	events = append(events, makeResponsesCompletedEvent(state, responsesStatusIncomplete, &ResponsesIncompleteDetails{
+		Reason: responsesIncompleteReasonInterrupted,
+	}))
 	state.CompletedSent = true
 	return events
 }
@@ -485,6 +494,41 @@ func makeResponsesCreatedEvent(state *AnthropicEventToResponsesState) ResponsesS
 	}
 }
 
+// Responses terminal-event status values. The streaming terminal event type
+// must agree with response.status — real OpenAI emits response.incomplete /
+// response.failed (not response.completed carrying a non-"completed" status),
+// and strict SDKs (Codex CLI / OpenAI SDK) validate the Responses stream
+// lifecycle against that.
+const (
+	responsesStatusIncomplete = "incomplete"
+	responsesStatusFailed     = "failed"
+
+	// responsesIncompleteReasonInterrupted marks a turn whose upstream stream
+	// ended before any terminal event (connection dropped mid-response). It is
+	// deliberately not one of OpenAI's model-driven reasons (max_output_tokens /
+	// content_filter): the cause is a transport-level truncation.
+	responsesIncompleteReasonInterrupted = "interrupted"
+)
+
+// responsesTerminalEventTypeForStatus maps a response.status to its matching
+// streaming terminal event type so the two never disagree.
+func responsesTerminalEventTypeForStatus(status string) string {
+	switch status {
+	case responsesStatusIncomplete:
+		return "response.incomplete"
+	case responsesStatusFailed:
+		return "response.failed"
+	case "cancelled", "canceled":
+		return "response.cancelled"
+	default:
+		return "response.completed"
+	}
+}
+
+// makeResponsesCompletedEvent builds a Responses terminal stream event. The
+// event type is derived from status (see responsesTerminalEventTypeForStatus),
+// so a status="incomplete"/"failed" turn emits response.incomplete/response.failed
+// rather than a mislabelled response.completed.
 func makeResponsesCompletedEvent(
 	state *AnthropicEventToResponsesState,
 	status string,
@@ -508,7 +552,7 @@ func makeResponsesCompletedEvent(
 	}
 
 	return ResponsesStreamEvent{
-		Type:           "response.completed",
+		Type:           responsesTerminalEventTypeForStatus(status),
 		SequenceNumber: seq,
 		Response: &ResponsesResponse{
 			ID:                state.ResponseID,

--- a/backend/internal/pkg/apicompat/anthropic_to_responses_truncation_test.go
+++ b/backend/internal/pkg/apicompat/anthropic_to_responses_truncation_test.go
@@ -1,0 +1,123 @@
+package apicompat
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// terminalEvent returns the single terminal stream event in events (the one
+// whose type is in the response.* terminal set), or nil if none is present.
+func terminalEvent(events []ResponsesStreamEvent) *ResponsesStreamEvent {
+	for i := range events {
+		switch events[i].Type {
+		case "response.completed", "response.incomplete", "response.failed", "response.cancelled":
+			return &events[i]
+		}
+	}
+	return nil
+}
+
+// driveAnthropicResponsesStream feeds a sequence of Anthropic SSE events through
+// the forward converter and returns the accumulated Responses events.
+func driveAnthropicResponsesStream(state *AnthropicEventToResponsesState, evts ...*AnthropicStreamEvent) []ResponsesStreamEvent {
+	var out []ResponsesStreamEvent
+	for _, e := range evts {
+		out = append(out, AnthropicEventToResponsesEvents(e, state)...)
+	}
+	return out
+}
+
+// TestFinalizeAnthropicResponsesStream_TruncationEmitsIncomplete is the
+// regression guard for Wei-Shaw/sub2api#2245: an upstream stream that ends
+// without message_stop must be finalized as response.incomplete (status
+// "incomplete"), not a fake response.completed that tells a strict Responses
+// client the truncated turn succeeded.
+func TestFinalizeAnthropicResponsesStream_TruncationEmitsIncomplete(t *testing.T) {
+	state := NewAnthropicEventToResponsesState()
+
+	// message_start + some partial content, then the upstream drops (no message_stop).
+	driveAnthropicResponsesStream(state,
+		&AnthropicStreamEvent{
+			Type: "message_start",
+			Message: &AnthropicResponse{
+				ID:    "msg_truncated",
+				Model: "claude-sonnet-4-5-20250929",
+				Usage: AnthropicUsage{InputTokens: 12},
+			},
+		},
+		&AnthropicStreamEvent{Type: "content_block_start", ContentBlock: &AnthropicContentBlock{Type: "text"}},
+		&AnthropicStreamEvent{Type: "content_block_delta", Delta: &AnthropicDelta{Type: "text_delta", Text: "partial"}},
+	)
+	require.True(t, state.CreatedSent, "response.created must have been emitted")
+	require.False(t, state.CompletedSent, "no terminal event before finalize")
+
+	final := FinalizeAnthropicResponsesStream(state)
+	require.NotEmpty(t, final, "finalize must synthesize a terminal event on truncation")
+
+	term := terminalEvent(final)
+	require.NotNil(t, term, "a terminal response.* event must be emitted")
+	assert.Equal(t, "response.incomplete", term.Type, "truncated stream must emit response.incomplete, not response.completed")
+	require.NotNil(t, term.Response)
+	assert.Equal(t, "incomplete", term.Response.Status)
+	require.NotNil(t, term.Response.IncompleteDetails)
+	assert.Equal(t, "interrupted", term.Response.IncompleteDetails.Reason)
+	assert.True(t, state.CompletedSent, "finalize must mark the terminal as sent")
+}
+
+// TestFinalizeAnthropicResponsesStream_NoTerminalBeforeCreated guards that a
+// stream which never started (no response.created) is a no-op on finalize.
+func TestFinalizeAnthropicResponsesStream_NoTerminalBeforeCreated(t *testing.T) {
+	state := NewAnthropicEventToResponsesState()
+	assert.Nil(t, FinalizeAnthropicResponsesStream(state))
+}
+
+// TestFinalizeAnthropicResponsesStream_NoOpAfterMessageStop guards that a
+// cleanly completed stream (message_stop seen) does NOT get a second synthetic
+// terminal from finalize.
+func TestFinalizeAnthropicResponsesStream_NoOpAfterMessageStop(t *testing.T) {
+	state := NewAnthropicEventToResponsesState()
+
+	events := driveAnthropicResponsesStream(state,
+		&AnthropicStreamEvent{
+			Type: "message_start",
+			Message: &AnthropicResponse{
+				ID:    "msg_complete",
+				Model: "claude-sonnet-4-5-20250929",
+				Usage: AnthropicUsage{InputTokens: 12},
+			},
+		},
+		&AnthropicStreamEvent{Type: "content_block_start", ContentBlock: &AnthropicContentBlock{Type: "text"}},
+		&AnthropicStreamEvent{Type: "content_block_delta", Delta: &AnthropicDelta{Type: "text_delta", Text: "done"}},
+		&AnthropicStreamEvent{Type: "message_stop"},
+	)
+
+	// The clean completion must surface as response.completed.
+	term := terminalEvent(events)
+	require.NotNil(t, term, "message_stop must produce a terminal event")
+	assert.Equal(t, "response.completed", term.Type)
+	require.NotNil(t, term.Response)
+	assert.Equal(t, "completed", term.Response.Status)
+
+	// Finalize after a clean completion is a no-op (no duplicate terminal).
+	assert.Nil(t, FinalizeAnthropicResponsesStream(state),
+		"finalize must not emit a second terminal after message_stop")
+}
+
+// TestResponsesTerminalEventTypeForStatus pins the status→event-type mapping so
+// the streaming terminal event type can never disagree with response.status.
+func TestResponsesTerminalEventTypeForStatus(t *testing.T) {
+	cases := map[string]string{
+		"completed":  "response.completed",
+		"incomplete": "response.incomplete",
+		"failed":     "response.failed",
+		"cancelled":  "response.cancelled",
+		"canceled":   "response.cancelled",
+		"":           "response.completed", // unknown/empty defaults to completed
+	}
+	for status, wantType := range cases {
+		assert.Equalf(t, wantType, responsesTerminalEventTypeForStatus(status),
+			"status %q should map to %q", status, wantType)
+	}
+}

--- a/backend/internal/service/gateway_forward_as_responses.go
+++ b/backend/internal/service/gateway_forward_as_responses.go
@@ -452,6 +452,13 @@ func (s *GatewayService) handleResponsesStreamingResponse(
 
 	finalizeStream := func() (*ForwardResult, error) {
 		if finalEvents := apicompat.FinalizeAnthropicResponsesStream(state); len(finalEvents) > 0 {
+			// Non-empty finalize events mean the upstream stream ended without a
+			// terminal message_stop; FinalizeAnthropicResponsesStream synthesizes a
+			// response.incomplete terminal so the strict client is not left hanging.
+			// Surface it for ops: the turn is truncated, not a clean completion.
+			logger.L().Info("forward_as_responses stream: upstream ended without terminal event; emitted response.incomplete",
+				zap.String("request_id", requestID),
+			)
 			for _, evt := range finalEvents {
 				sse, err := apicompat.ResponsesEventToSSE(evt)
 				if err != nil {

--- a/backend/internal/service/gateway_forward_as_responses_test.go
+++ b/backend/internal/service/gateway_forward_as_responses_test.go
@@ -92,3 +92,42 @@ func TestHandleResponsesStreamingResponse_PreservesMessageStartCacheUsage(t *tes
 	require.Equal(t, 4, result.Usage.CacheCreationInputTokens)
 	require.Contains(t, rec.Body.String(), `response.completed`)
 }
+
+// TestHandleResponsesStreamingResponse_TruncatedUpstreamEmitsIncomplete is the
+// end-to-end guard for Wei-Shaw/sub2api#2245: when the upstream SSE stream ends
+// without message_stop, the client must receive a response.incomplete terminal
+// event (a spec-valid terminal in the strict Responses lifecycle) rather than a
+// fake response.completed or no terminal event at all.
+func TestHandleResponsesStreamingResponse_TruncatedUpstreamEmitsIncomplete(t *testing.T) {
+	t.Parallel()
+	gin.SetMode(gin.TestMode)
+
+	rec := httptest.NewRecorder()
+	c, _ := gin.CreateTestContext(rec)
+
+	// message_start + partial content, then the upstream drops (no message_stop).
+	resp := &http.Response{
+		Header: http.Header{"x-request-id": []string{"rid_truncated"}},
+		Body: io.NopCloser(strings.NewReader(strings.Join([]string{
+			`event: message_start`,
+			`data: {"type":"message_start","message":{"id":"msg_3","type":"message","role":"assistant","content":[],"model":"claude-sonnet-4.5","stop_reason":"","usage":{"input_tokens":15}}}`,
+			``,
+			`event: content_block_start`,
+			`data: {"type":"content_block_start","index":0,"content_block":{"type":"text","text":""}}`,
+			``,
+			`event: content_block_delta`,
+			`data: {"type":"content_block_delta","index":0,"delta":{"type":"text_delta","text":"partial"}}`,
+			``,
+		}, "\n"))),
+	}
+
+	svc := &GatewayService{}
+	result, err := svc.handleResponsesStreamingResponse(resp, c, "claude-sonnet-4.5", "claude-sonnet-4.5", nil, time.Now())
+	require.NoError(t, err)
+	require.NotNil(t, result)
+
+	body := rec.Body.String()
+	require.Contains(t, body, "response.incomplete", "truncated upstream must surface response.incomplete to the client")
+	require.Contains(t, body, `"status":"incomplete"`)
+	require.NotContains(t, body, "response.completed", "a truncated turn must not be reported as completed")
+}


### PR DESCRIPTION
## What & why

Fixes the highest-value issue surfaced by the daily upstream watchdog (PR #595's `triage.json`), where it was flagged `needs_prod_validation` / `known_protocol_limitation`:

**Wei-Shaw/sub2api#2245 — OpenAI Responses SSE forwarded as HTTP 200 even when the stream ends before a terminal event.**

When an upstream SSE stream feeding `/v1/responses` ends **without** a terminal event (Anthropic `message_stop`) — i.e. the connection drops mid-turn — the Anthropic→Responses converter synthesized a `response.completed` event with `status="completed"`. That falsely reports a **truncated** turn as a clean success, to both:

- the **client** — strict Responses SDKs (Codex CLI / OpenAI SDK) that validate the stream lifecycle, and
- TokenKey's own **usage recording**.

## Fix

In the TK-owned `internal/pkg/apicompat` conversion layer:

1. **Derive the streaming terminal event *type* from `response.status`** (`responsesTerminalEventTypeForStatus`), so the event type can never disagree with the status (real OpenAI emits `response.incomplete` / `response.failed`, not `response.completed` carrying a non-`completed` status). This is a zero-impact generalization for existing callers, which all pass `status="completed"`.
2. **`FinalizeAnthropicResponsesStream` now finalizes a stream that never saw `message_stop` as `response.incomplete`** (`status="incomplete"`, `incomplete_details.reason="interrupted"`) — a spec-valid terminal event that tells the client the turn was cut off instead of lying that it completed.
3. A log line in the `/responses` caller surfaces the truncation for ops attribution.

### Blast radius (all 3 callers of `FinalizeAnthropicResponsesStream` verified)
- **`/v1/responses`** (`gateway_forward_as_responses.go`): the fix — strict clients get a correct terminal.
- **Anthropic→chat-completions**: `ResponsesEventToChatChunks` already routes `response.incomplete` through the same terminal handler as `response.completed` — no behavior change.
- **Gemini compat**: emits `message_stop` before finalize, so `Finalize` is a no-op there — unaffected.

### Out of scope (documented, not silently dropped)
The OpenAI chat→Responses fallback finalizer (`FinalizeChatCompletionsResponsesStream`) has the same shape but its truncation signal needs the caller's done-sentinel state threaded through — a separate change. Tracked as a follow-up.

## Tests
- `apicompat` unit: truncation → `response.incomplete` (type + status + reason); normal completion stays `response.completed`; `status`→event-type mapping; no double-terminal after `message_stop`.
- service unit (end-to-end through `handleResponsesStreamingResponse`): a truncated upstream surfaces `response.incomplete` to the client and never `response.completed`.
- Full backend unit suite green (53 packages); `golangci-lint` clean on changed packages.

## Fix ledger
- `Upstream-Fixes: Wei-Shaw/sub2api#2245` declared in the commit trailer.
- `.cache/upstream/fact-checks.json` entry added + propagated via `apply-fix-ledger.py --apply` (preflight `sub2api: fix-ledger consistency` → ok).

## Notes for reviewer
- TK-originated fix → **Squash and merge** (rule §5.y).
- `no-web-impact` — backend-only, no frontend surface.
- `upstream-touch-trivial` — the only upstream-shaped file touched (`gateway_forward_as_responses.go`) is an insertion-only log line; the substantive change is in the TK-only `internal/pkg/apicompat` package.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
