### PR TITLE
fix(antigravity): converge model_mapping to empirically-servable wire ids

### DIFF
--- a/backend/internal/domain/constants.go
+++ b/backend/internal/domain/constants.go
@@ -97,24 +97,30 @@ var DefaultAntigravityModelMapping = map[string]string{
 	"claude-haiku-4-5":          "claude-sonnet-4-6",
 	"claude-haiku-4-5-20251001": "claude-sonnet-4-6",
 	// Gemini 2.5 白名单
-	"gemini-2.5-flash":               "gemini-2.5-flash",
-	"gemini-2.5-flash-image":         "gemini-2.5-flash-image",
-	"gemini-2.5-flash-image-preview": "gemini-2.5-flash-image",
-	"gemini-2.5-flash-lite":          "gemini-2.5-flash-lite",
+	"gemini-2.5-flash":      "gemini-2.5-flash",
+	"gemini-2.5-flash-lite": "gemini-2.5-flash-lite",
+	// 2.5-flash-image 上游对该账号返回 502（2026-06-15 prod 中继实测）→ 重指可服务的
+	// 3.1-flash-image（保留别名兼容，客户端无需改名）。
+	"gemini-2.5-flash-image":         "gemini-3.1-flash-image",
+	"gemini-2.5-flash-image-preview": "gemini-3.1-flash-image",
 	"gemini-2.5-flash-thinking":      "gemini-2.5-flash-thinking",
 	"gemini-2.5-pro":                 "gemini-2.5-pro",
-	// Gemini 3 白名单
+	// Gemini 3 白名单。gemini-3-pro-* 上游目录已无（仅剩 gemini-3-flash 与 gemini-3.1-pro-*）
+	// → 2026-06-15 prod 中继实测 gemini-3-pro-high/low 返回 200 但 0/0（静默空响应）。
+	// 重指到等价可服务 wire id：high→gemini-pro-agent（上游显示名同为 "Gemini 3.1 Pro (High)"）、
+	// low→gemini-3.1-pro-low。
 	"gemini-3-flash":    "gemini-3-flash",
-	"gemini-3-pro-high": "gemini-3-pro-high",
-	"gemini-3-pro-low":  "gemini-3-pro-low",
+	"gemini-3-pro-high": "gemini-pro-agent",
+	"gemini-3-pro-low":  "gemini-3.1-pro-low",
 	// Gemini 3 preview 映射
 	"gemini-3-flash-preview": "gemini-3-flash",
-	"gemini-3-pro-preview":   "gemini-3-pro-high",
-	// Gemini 3.1 白名单
-	"gemini-3.1-pro-high": "gemini-3.1-pro-high",
+	"gemini-3-pro-preview":   "gemini-pro-agent",
+	// Gemini 3.1 白名单。gemini-3.1-pro-high 在上游 deprecatedModelIds 中，直接请求返回 400
+	// （2026-06-15 实测）→ 重指 gemini-pro-agent（非弃用、同为 3.1 Pro High）。
+	"gemini-3.1-pro-high": "gemini-pro-agent",
 	"gemini-3.1-pro-low":  "gemini-3.1-pro-low",
 	// Gemini 3.1 preview 映射
-	"gemini-3.1-pro-preview": "gemini-3.1-pro-high",
+	"gemini-3.1-pro-preview": "gemini-pro-agent",
 	// Gemini 3.1 image 白名单
 	"gemini-3.1-flash-image": "gemini-3.1-flash-image",
 	// Gemini 3.1 image preview 映射

--- a/backend/internal/domain/constants_test.go
+++ b/backend/internal/domain/constants_test.go
@@ -9,8 +9,10 @@ func TestDefaultAntigravityModelMapping_ImageCompatibilityAliases(t *testing.T) 
 	t.Parallel()
 
 	cases := map[string]string{
-		"gemini-2.5-flash-image":         "gemini-2.5-flash-image",
-		"gemini-2.5-flash-image-preview": "gemini-2.5-flash-image",
+		// 2.5-flash-image 上游返回 502（2026-06-15 prod 中继实测）→ 全部图片别名收敛到
+		// 可服务的 3.1-flash-image。
+		"gemini-2.5-flash-image":         "gemini-3.1-flash-image",
+		"gemini-2.5-flash-image-preview": "gemini-3.1-flash-image",
 		"gemini-3.1-flash-image":         "gemini-3.1-flash-image",
 		"gemini-3.1-flash-image-preview": "gemini-3.1-flash-image",
 		"gemini-3-pro-image":             "gemini-3.1-flash-image",
@@ -24,6 +26,35 @@ func TestDefaultAntigravityModelMapping_ImageCompatibilityAliases(t *testing.T) 
 		}
 		if got != want {
 			t.Fatalf("unexpected mapping for %q: got %q want %q", from, got, want)
+		}
+	}
+}
+
+// TestDefaultAntigravityModelMapping_DeprecatedProRemap 守护 2026-06-15 prod 中继实测
+// 暴露的「假成功 / 弃用」Pro 档收敛：gemini-3-pro-* 上游目录已无（返回 200 但 0/0），
+// gemini-3.1-pro-high 在上游 deprecatedModelIds（返回 400）。两者及其 preview 别名都必须
+// 重指到等价可服务 wire id，不得回退到不可服务的裸名。
+func TestDefaultAntigravityModelMapping_DeprecatedProRemap(t *testing.T) {
+	t.Parallel()
+
+	cases := map[string]string{
+		"gemini-3-pro-high":      "gemini-pro-agent",
+		"gemini-3-pro-low":       "gemini-3.1-pro-low",
+		"gemini-3-pro-preview":   "gemini-pro-agent",
+		"gemini-3.1-pro-high":    "gemini-pro-agent",
+		"gemini-3.1-pro-preview": "gemini-pro-agent",
+	}
+	for from, want := range cases {
+		got, ok := DefaultAntigravityModelMapping[from]
+		if !ok {
+			t.Fatalf("expected mapping for %q to exist", from)
+		}
+		if got != want {
+			t.Fatalf("unexpected mapping for %q: got %q want %q", from, got, want)
+		}
+		// 重指目标本身必须是映射内的可服务 wire id（防再次指向不可服务裸名）。
+		if _, ok := DefaultAntigravityModelMapping[want]; !ok {
+			t.Fatalf("remap target %q for %q is not itself a known servable wire id", want, from)
 		}
 	}
 }

--- a/backend/internal/service/account.go
+++ b/backend/internal/service/account.go
@@ -520,7 +520,9 @@ func (a *Account) resolveModelMapping(rawMapping map[string]any) map[string]stri
 		if a.Platform == domain.PlatformAntigravity {
 			ensureAntigravityDefaultPassthroughs(result, []string{
 				"gemini-3-flash",
-				"gemini-3.1-pro-high",
+				// gemini-3.1-pro-high 上游已 deprecated（直接请求 400，2026-06-15 prod 中继实测）；
+				// safety-net 只能补 identity 透传（→ 400），故不再补全——等价的非弃用档
+				// 走下方 gemini-pro-agent（上游显示名同为 "Gemini 3.1 Pro (High)"）。
 				"gemini-3.1-pro-low",
 				// 2026-06 实测新增 user-facing wire id（三档 thinking budget
 				// low/extra-low/high=agent 全部可服务，须对称补全；友好别名

--- a/backend/internal/service/account_wildcard_test.go
+++ b/backend/internal/service/account_wildcard_test.go
@@ -424,8 +424,10 @@ func TestAccountGetModelMapping_AntigravityEnsuresGeminiDefaultPassthroughs(t *t
 	if mapping["gemini-3-flash"] != "gemini-3-flash" {
 		t.Fatalf("expected gemini-3-flash passthrough to be auto-filled, got: %q", mapping["gemini-3-flash"])
 	}
-	if mapping["gemini-3.1-pro-high"] != "gemini-3.1-pro-high" {
-		t.Fatalf("expected gemini-3.1-pro-high passthrough to be auto-filled, got: %q", mapping["gemini-3.1-pro-high"])
+	// gemini-3.1-pro-high 上游已 deprecated（identity 透传会 400），已从 safety-net 移除：
+	// 自定义映射未显式声明时不再被补全（客户端改用 gemini-pro-agent）。
+	if _, exists := mapping["gemini-3.1-pro-high"]; exists {
+		t.Fatalf("did not expect deprecated gemini-3.1-pro-high to be auto-filled, got: %q", mapping["gemini-3.1-pro-high"])
 	}
 	if mapping["gemini-3.1-pro-low"] != "gemini-3.1-pro-low" {
 		t.Fatalf("expected gemini-3.1-pro-low passthrough to be auto-filled, got: %q", mapping["gemini-3.1-pro-low"])

--- a/backend/internal/service/model_rate_limit_test.go
+++ b/backend/internal/service/model_rate_limit_test.go
@@ -108,12 +108,14 @@ func TestIsModelRateLimited(t *testing.T) {
 			expected:       true,
 		},
 		{
-			name: "antigravity platform - gemini-3-pro-preview mapped to gemini-3-pro-high",
+			name: "antigravity platform - gemini-3-pro-preview mapped to gemini-pro-agent",
 			account: &Account{
 				Platform: PlatformAntigravity,
 				Extra: map[string]any{
 					modelRateLimitsKey: map[string]any{
-						"gemini-3-pro-high": map[string]any{
+						// 2026-06-15 起 gemini-3-pro-preview → gemini-pro-agent
+						// （gemini-3-pro-high 上游目录已无）。
+						"gemini-pro-agent": map[string]any{
 							"rate_limit_reset_at": future,
 						},
 					},

--- a/scripts/sentinels/gateway-tk.json
+++ b/scripts/sentinels/gateway-tk.json
@@ -1608,6 +1608,24 @@
       "rationale": "GeminiOnlyAntigravityModelMapping — the canonical map the AntigravityConfigReconciler writes onto every antigravity account — is derived once at package init from DefaultAntigravityModelMapping by dropping claude-* / gpt-oss-* keys. A silent upstream-merge change to (or removal of) the builder's prefix filter would let claude/gpt-oss back into the map the reconciler writes, i.e. silently serve claude on antigravity — the exact backward-drift this guards. Locked by TestGeminiOnlyAntigravityModelMapping too; this sentinel additionally catches a source revert that lands without the test running."
     },
     {
+      "path": "backend/internal/domain/constants.go",
+      "must_contain": [
+        "\"gemini-3-pro-high\": \"gemini-pro-agent\"",
+        "\"gemini-3.1-pro-high\": \"gemini-pro-agent\"",
+        "\"gemini-2.5-flash-image-preview\": \"gemini-3.1-flash-image\""
+      ],
+      "rationale": "DefaultAntigravityModelMapping 收敛锚点（2026-06-15 prod 中继实测，PR #774）。三类坏映射必须保持重指到等价可服务 wire id，不得回退到不可服务裸名 identity：(1) gemini-3-pro-*（high/low/preview）上游目录已无 gemini-3-pro-*，identity 请求返回 200 但 0/0（静默空响应）→ high/preview→gemini-pro-agent、low→gemini-3.1-pro-low；(2) gemini-3.1-pro-high（及 -pro-preview）在上游 deprecatedModelIds，identity 请求返回 400 → gemini-pro-agent（非弃用、上游显示名同为 'Gemini 3.1 Pro (High)'）；(3) gemini-2.5-flash-image（及 -preview）上游返回 502 → gemini-3.1-flash-image。上游 merge 若把这些 target 改回 identity 即重新静默服务坏模型；与 TestDefaultAntigravityModelMapping_DeprecatedProRemap / _ImageCompatibilityAliases 双重守护，sentinel 额外兜住源码 revert 未跑测试的情况。"
+    },
+    {
+      "path": "backend/internal/service/account.go",
+      "must_contain": [
+        "ensureAntigravityDefaultPassthroughs(result, []string{",
+        "\"gemini-3-flash-agent\",",
+        "\"gemini-pro-agent\","
+      ],
+      "rationale": "Antigravity 自定义-映射账号的 safety-net 透传列表（GetModelMapping 内）。这是 antigravity gemini-only 服务面的「五面」之一：公共目录 / UseKeyModal 宣告可服务的 wire id，若自定义 model_mapping 账号未显式声明，必须由此列表补 identity 透传，否则静默 404（xj-review R / memory antigravity_claude_exclude_per_account_not_global_default）。2026-06-15（PR #774）起该列表已移除上游 deprecated 的 gemini-3.1-pro-high（identity 透传 → 400），等价档走 gemini-pro-agent。上游 merge 若删除 ensureAntigravityDefaultPassthroughs 调用或丢失 gemini-pro-agent / gemini-3-flash-agent 成员，自定义账号会静默拒绝可服务模型——本 sentinel 守护该调用与收敛后的成员。"
+    },
+    {
       "path": "backend/internal/service/wire.go",
       "must_contain": [
         "func ProvideAntigravityConfigReconciler(",


### PR DESCRIPTION
## 背景

2026-06-15 用 prod stub key (`TK_SMOKE_PROD_ANTIGRAVITY_KEY`) 经**完整中继链路**实测 antigravity 全量服务面:

```
prod 网关 (api.tokenkey.dev/antigravity/v1/messages)
  → 镜像账号 id=61 (type=apikey, base_url=api-us3)
  → edge-us3 网关 → OAuth 账号 id=3 → 上游 cloudcode-pa
```

链路本身 ✅ 打通(多模型 200 + 真实 token)。但暴露 `DefaultAntigravityModelMapping` 三类坏映射(经 `/v1internal:fetchAvailableModels` 上游目录交叉确认):

| 模型(及 preview 别名) | 现象 | 上游真因 | 本 PR 重指 |
|---|---|---|---|
| `gemini-3-pro-high` / `gemini-3-pro-low` / `gemini-3-pro-preview` | **200 但 0/0(静默空响应)** | 上游目录已无 `gemini-3-pro-*` | → `gemini-pro-agent` / `gemini-3.1-pro-low` |
| `gemini-3.1-pro-high` / `gemini-3.1-pro-preview` | **400 invalid_request** | 在上游 `deprecatedModelIds` | → `gemini-pro-agent`(非弃用、同为 "Gemini 3.1 Pro (High)") |
| `gemini-2.5-flash-image` / `-preview` | **502 upstream_error** | 2.5 图模型上游对该账号不可用 | → `gemini-3.1-flash-image` |

均为**别名重指**(保留 key,客户端无需改名)。

## 改动

- `domain/constants.go` `DefaultAntigravityModelMapping`:重指上述 7 条。`GeminiOnlyAntigravityModelMapping` 由此派生(单一真值源),`AntigravityConfigReconciler` 自动下发新账号。
- `service/account.go` `ensureAntigravityDefaultPassthroughs`:移除 `gemini-3.1-pro-high`(safety-net 只能补 identity 透传 → 400;等价档走已在列表的 `gemini-pro-agent`)。
- 测试:`constants_test`(图片别名收敛 + 新增 `TestDefaultAntigravityModelMapping_DeprecatedProRemap`)、`account_wildcard_test`(safety-net 不再补 3.1-pro-high)、`model_rate_limit_test`(preview → pro-agent)。

**不增补新模型**:`fetchAvailableModels` 可用 gemini 已全覆盖;`gemini-3.1-flash-lite` 与 `gemini-2.5-flash-lite` 上游同后端(冗余),压测期账号 429 未取到干净基线,留待后续。

## 现网

prod 镜像 id=61 / edge-us3 id=3 已先行 SQL 热修(止血),本 PR 落地后与常量一致(reconciler 因账号纯 gemini 不回写,持久)。

## 校验

- `go test -tags=unit ./...` ✓ · `golangci-lint run ./internal/...` 0 issues ✓ · `go build ./...` ✓
- `scripts/preflight.sh` ✓(pricing overlay 无 $0 / 全 sentinel intact / ancestry anchor)

## Markers

upstream-touch-guarded
no-web-impact
sentinel-registry-reviewed

Reviewer:**Squash and merge**(TK 自有 fix PR)。

## upstream-merge 覆盖写防护(本 PR 内补)

往 `scripts/sentinels/gateway-tk.json` 增两条 backward-drift 锚点(§5.x):
- **constants.go 收敛 target**:`gemini-3-pro-high` / `gemini-3.1-pro-high` → `gemini-pro-agent`、`gemini-2.5-flash-image-preview` → `gemini-3.1-flash-image`。上游 merge 若改回不可服务 identity(静默空 / 400 / 502)即翻红。
- **account.go safety-net**:`ensureAntigravityDefaultPassthroughs` 调用 + 收敛成员(`gemini-pro-agent` / `gemini-3-flash-agent`),防上游删调用致自定义账号静默 404。

`check-gateway-tk.py` 271/271 intact;`check-registry-update-gate.py` ok。
