### PR TITLE
feat(edge): open Lightsail edge public port 8443 (never force-closed)

### DIFF
--- a/deploy/aws/README.md
+++ b/deploy/aws/README.md
@@ -178,12 +178,12 @@ ops/stage0/sync-feishu-config.sh
 
 IP 被上游污染需轮换 Static IP：[`.cursor/skills/tokenkey-stage0-edge-lightsail-ip-rotation/SKILL.md`](../../.cursor/skills/tokenkey-stage0-edge-lightsail-ip-rotation/SKILL.md) + `ops/lightsail/rotate-static-ip.sh`。
 
-## 公网端口收窄（443-only）
+## 公网端口收窄（prod 443-only；edge 443 + 8443）
 
-prod (EC2) 与 edge (Lightsail) 的公网暴露收窄到**只剩 TCP 443**：
+公网暴露收窄到 TCP 443（**prod 仅 443**；**edge 为 443 + 8443**，8443 为备用连接口、按设计保持开放）：
 
-- **80 关闭**：证书改用 **TLS-ALPN-01**（走 443，Caddyfile `disable_http_challenge`），不再需要 HTTP-01 / `:80` 跳转。
-- **22 关闭**：运维全走 SSM Session Manager（prod）/ Lightsail 控制台 browser SSH（edge），均不依赖公网 22。prod 由 `AdminCidr` 默认 `127.0.0.1/32` 收口；edge 由 `put-instance-public-ports` 声明完整端口集 = 仅 443（覆盖掉 Lightsail 默认的 22）。
+- **80 关闭**：证书改用 **TLS-ALPN-01**（走 443，Caddyfile `disable_http_challenge`），不再需要 HTTP-01 / `:80` 跳转；edge 的 8443 不参与续签，TLS-ALPN-01 仍只在 443 上完成。
+- **22 关闭**：运维全走 SSM Session Manager（prod）/ Lightsail 控制台 browser SSH（edge），均不依赖公网 22。prod 由 `AdminCidr` 默认 `127.0.0.1/32` 收口；edge 由 `put-instance-public-ports` 声明完整端口集 = 443 + 8443（覆盖掉 Lightsail 默认的 22）。
 
 唯一实质风险是证书续签——靠「**先切 ALPN 配置 → 验证可签 → 再关 80**」的顺序消除。**rollout 必须按此序，PR 合并本身零 live 影响（现网证书 ~30d 内仍有效）：**
 

--- a/deploy/aws/lightsail/README.md
+++ b/deploy/aws/lightsail/README.md
@@ -79,14 +79,14 @@ gh workflow run deploy-edge-lightsail-stage0.yml \
 
 ### 冒烟 / 本机 curl 对域名长期 `HTTP 000` 或 TCP 超时
 
-Lightsail **实例控制台「Networking」防火墙**的硬化基线是**仅放行 TCP 443**（HTTPS + ACME TLS-ALPN-01）；
-**80 与 22 关闭**（证书走 TLS-ALPN-01 无需 80；SSH 走 SSM / 控制台 browser SSH，不依赖公网 22）。仅靠正确 DNS（A → Static IP）不够；若 443 没开，`curl https://api-…/health` 会与 GitHub runner 一致：约 130s 级连接超时。
+Lightsail **实例控制台「Networking」防火墙**的硬化基线是**放行 TCP 443 + 8443**（443 = HTTPS 业务 + ACME TLS-ALPN-01；
+8443 = 备用连接口，按设计保持开放、不强制关掉）；**80 与 22 关闭**（证书走 TLS-ALPN-01 无需 80，续签仍只走 443；SSH 走 SSM / 控制台 browser SSH，不依赖公网 22）。仅靠正确 DNS（A → Static IP）不够；若 443 没开，`curl https://api-…/health` 会与 GitHub runner 一致：约 130s 级连接超时。
 
-- 自检：`aws lightsail get-instance-port-states --region <region> --instance-name <instance_name>`（期望仅 443 open）
+- 自检：`aws lightsail get-instance-port-states --region <region> --instance-name <instance_name>`（期望 443 + 8443 open，80/22 closed）
 - 一次性修复 / 收口到基线（与 provision 脚本行为一致，原子覆盖整张防火墙表）：  
   `bash ops/stage0/verify-edge-lightsail-network.sh <edge_id> --enforce-ports`  
-  其内部即 `aws lightsail put-instance-public-ports --region <region> --instance-name <instance_name> --port-infos fromPort=443,toPort=443,protocol=tcp,cidrs=0.0.0.0/0`（put = 替换语义，顺带关掉默认 22 与历史 80）。
-- IaC：`provision-edge.sh` 会在 attach Static IP 后用 `put-instance-public-ports` 设为 **仅 443**；CI OIDC role 需在
+  其内部即 `aws lightsail put-instance-public-ports --region <region> --instance-name <instance_name> --port-infos fromPort=443,toPort=443,protocol=tcp,cidrs=0.0.0.0/0 fromPort=8443,toPort=8443,protocol=tcp,cidrs=0.0.0.0/0`（put = 替换语义，顺带关掉默认 22 与历史 80，同时保留 8443）。
+- IaC：`provision-edge.sh` 会在 attach Static IP 后用 `put-instance-public-ports` 设为 **443 + 8443**；CI OIDC role 需在
   `cicd-oidc-lightsail-addon.yaml` 中包含 `lightsail:PutInstancePublicPorts`（及 `GetInstancePortStates`）。
 
 ### Admin 登录 / 忘记密码

--- a/deploy/aws/lightsail/provision-edge.sh
+++ b/deploy/aws/lightsail/provision-edge.sh
@@ -153,15 +153,19 @@ aws lightsail attach-static-ip \
 # We declare the COMPLETE desired port set with put-instance-public-ports (replace
 # semantics), not open-instance-public-ports (add-only). This atomically:
 #   - opens 443 (business + ACME TLS-ALPN-01),
+#   - opens 8443 (alternate connection port — kept open by design; NOT force-closed),
 #   - drops the Lightsail-default public SSH (22) — operate via SSM / console SSH,
 #   - keeps public 80 closed — certs use TLS-ALPN-01 on 443, so HTTP-01 is unneeded.
+# Cert renewal still rides 443 only (TLS-ALPN-01); 8443 is a spare ingress port.
 # Operate existing edges to this same set via ops/stage0/verify-edge-lightsail-network.sh --enforce-ports.
-echo "setting Lightsail public ports to 443-only (IPv4) on ${INSTANCE_NAME}"
+echo "setting Lightsail public ports to 443 + 8443 (IPv4) on ${INSTANCE_NAME}"
 if aws lightsail put-instance-public-ports \
   --region "$LIGHTSAIL_REGION" \
   --instance-name "$INSTANCE_NAME" \
-  --port-infos "fromPort=443,toPort=443,protocol=tcp,cidrs=0.0.0.0/0" >/dev/null; then
-  echo "lightsail firewall: public ports set to TCP 443 only (22/80 closed)"
+  --port-infos \
+    "fromPort=443,toPort=443,protocol=tcp,cidrs=0.0.0.0/0" \
+    "fromPort=8443,toPort=8443,protocol=tcp,cidrs=0.0.0.0/0" >/dev/null; then
+  echo "lightsail firewall: public ports set to TCP 443 + 8443 (22/80 closed)"
 else
   echo "::notice::put-instance-public-ports failed — check:" >&2
   echo "       aws lightsail get-instance-port-states --region ${LIGHTSAIL_REGION} --instance-name ${INSTANCE_NAME}" >&2

--- a/ops/stage0/verify-edge-lightsail-network.sh
+++ b/ops/stage0/verify-edge-lightsail-network.sh
@@ -1,14 +1,15 @@
 #!/usr/bin/env bash
 # verify-edge-lightsail-network.sh — Post-provision / post-DNS checks for Lightsail edges.
 #
-# Hardened public-port baseline (since the 443-only narrowing): TCP 443 OPEN,
-# TCP 80 and 22 CLOSED. Certs use TLS-ALPN-01 on 443 (Caddyfile.edge
-# disable_http_challenge), so HTTP-01 / public 80 is unneeded; SSH (22) is
-# operated via SSM / Lightsail console, never the public port.
+# Hardened public-port baseline: TCP 443 + 8443 OPEN, TCP 80 and 22 CLOSED.
+# 443 carries business + ACME TLS-ALPN-01 (Caddyfile.edge disable_http_challenge),
+# so HTTP-01 / public 80 is unneeded; 8443 is an alternate connection port kept
+# open by design (NOT force-closed); SSH (22) is operated via SSM / Lightsail
+# console, never the public port. Cert renewal still rides 443 only.
 #
 # Confirms the firewall matches that baseline and (optionally) public HTTPS
-# /health succeeds. --enforce-ports rewrites the firewall to 443-only (closes
-# 22/80); --renew-cert restarts Caddy when DNS was late (ACME NXDOMAIN).
+# /health succeeds. --enforce-ports rewrites the firewall to 443 + 8443 (closes
+# 22/80, keeps 8443); --renew-cert restarts Caddy when DNS was late (ACME NXDOMAIN).
 #
 # Usage:
 #   bash ops/stage0/verify-edge-lightsail-network.sh <edge_id> [--enforce-ports] [--renew-cert]
@@ -34,15 +35,16 @@ usage() {
 Usage:
   bash ops/stage0/verify-edge-lightsail-network.sh <edge_id> [--enforce-ports] [--renew-cert]
 
-Hardened baseline: TCP 443 open; TCP 80 and 22 closed.
+Hardened baseline: TCP 443 + 8443 open; TCP 80 and 22 closed.
 
 Checks:
   - Lightsail public port 443 is open (80/22 expected closed; drift warned)
+  - Lightsail public port 8443 is open (alternate connection port; warn if missing)
   - dig @1.1.1.1 A record matches static IP (when DNS exists)
   - curl https://api-<edge_id>.tokenkey.dev/health (best effort)
 
 Options:
-  --enforce-ports  put-instance-public-ports to 443-only (closes public 22 and 80)
+  --enforce-ports  put-instance-public-ports to 443 + 8443 (closes public 22 and 80)
   --renew-cert     restart tokenkey-caddy via SSM (after DNS cutover / ACME retry)
 EOF
 }
@@ -126,15 +128,17 @@ port_open() {
 echo "[verify-edge-lightsail-network] edge_id=${EDGE_ID} region=${REGION} instance=${INSTANCE}"
 echo "[verify-edge-lightsail-network] domain=${DOMAIN} static_ip=${STATIC_IP}"
 
-# Hardened baseline = 443 open, 80/22 closed. --enforce-ports rewrites the whole
-# firewall to exactly that (put = replace semantics, so it also drops the
-# Lightsail-default public SSH 22 and any historical 80).
+# Hardened baseline = 443 + 8443 open, 80/22 closed. --enforce-ports rewrites the
+# whole firewall to exactly that (put = replace semantics, so it also drops the
+# Lightsail-default public SSH 22 and any historical 80, while KEEPING 8443).
 if $ENFORCE_PORTS; then
-  echo "[verify-edge-lightsail-network] enforcing public ports = 443-only (closes 22 and 80)..."
+  echo "[verify-edge-lightsail-network] enforcing public ports = 443 + 8443 (closes 22 and 80, keeps 8443)..."
   aws lightsail put-instance-public-ports \
     --region "$REGION" \
     --instance-name "$INSTANCE" \
-    --port-infos "fromPort=443,toPort=443,protocol=tcp,cidrs=0.0.0.0/0" >/dev/null \
+    --port-infos \
+      "fromPort=443,toPort=443,protocol=tcp,cidrs=0.0.0.0/0" \
+      "fromPort=8443,toPort=8443,protocol=tcp,cidrs=0.0.0.0/0" >/dev/null \
     || { echo "[verify-edge-lightsail-network] FAIL: put-instance-public-ports failed" >&2; exit 3; }
 fi
 
@@ -144,12 +148,20 @@ if ! port_open 443; then
 fi
 echo "[verify-edge-lightsail-network] ok: firewall TCP 443 open"
 
+# 8443 is part of the hardened baseline (alternate connection port). Open is
+# expected; warn (not fail) if missing so an operator can rerun --enforce-ports.
+if port_open 8443; then
+  echo "[verify-edge-lightsail-network] ok: firewall TCP 8443 open"
+else
+  echo "[verify-edge-lightsail-network] WARN: public TCP 8443 not open (baseline is 443 + 8443) — run with --enforce-ports to open" >&2
+fi
+
 # Drift from the hardened baseline: 80 / 22 should be closed.
 drift_ports=()
 port_open 80 && drift_ports+=("80")
 port_open 22 && drift_ports+=("22")
 if [[ ${#drift_ports[@]} -gt 0 ]]; then
-  echo "[verify-edge-lightsail-network] WARN: public TCP ${drift_ports[*]} still open (baseline is 443-only) — run with --enforce-ports to close" >&2
+  echo "[verify-edge-lightsail-network] WARN: public TCP ${drift_ports[*]} still open (baseline is 443 + 8443) — run with --enforce-ports to close" >&2
 fi
 
 if $RENEW_CERT; then

--- a/scripts/checks/lightsail-oidc-perm-coverage.py
+++ b/scripts/checks/lightsail-oidc-perm-coverage.py
@@ -80,9 +80,9 @@ EXPECTED_ACTIONS: list[tuple[str, str]] = [
     ("lightsail:AttachStaticIp", "bind IP to instance"),
     ("lightsail:DetachStaticIp", "recreate=true path"),
     ("lightsail:ReleaseStaticIp", "recreate=true path + ip rotation"),
-    # --- Lightsail instance firewall (443-only hardened baseline) -------
+    # --- Lightsail instance firewall (443 + 8443 hardened baseline) -----
     ("lightsail:GetInstancePortStates", "read-back firewall state in provision + verify-edge"),
-    ("lightsail:PutInstancePublicPorts", "provision + verify-edge --enforce-ports set 443-only (closes 22/80)"),
+    ("lightsail:PutInstancePublicPorts", "provision + verify-edge --enforce-ports set 443 + 8443 (closes 22/80)"),
     # --- SSM managed-instance ops after registration -------------------
     ("ssm:DescribeInstanceInformation", "poll for mi-* registration"),
     ("ssm:SendCommand", "upgrade / smoke / log fetch via Hybrid managed instance"),


### PR DESCRIPTION
## What

Edge (Lightsail) firewall baseline goes from **443-only** to **443 + 8443**. 8443 is an alternate connection port kept open **by design** — both convergence paths now declare the full desired set `[443, 8443]` via `put-instance-public-ports` (replace semantics), so neither a re-provision nor `--enforce-ports` will force-close it.

## Why

The 443-only hardening (#720) closes everything except 443 on each `put`. Operators need a spare ingress port (8443) that survives the convergence instead of being silently re-closed on the next deploy / `--enforce-ports` run.

## Scope (intentionally minimal)

- **Firewall port only** — Caddy does **not** listen on 8443, no `docker-compose` change, no container recreate → **zero blip on 443**. The port is open but unserved by design.
- **prod (EC2) stays 443-only** — this touches only the edge (Lightsail) path. No CFN / security-group change.
- **No new IAM** — same `lightsail:PutInstancePublicPorts` call.

## Changes

| File | Change |
|---|---|
| `deploy/aws/lightsail/provision-edge.sh` | declare `443 + 8443` on provision |
| `ops/stage0/verify-edge-lightsail-network.sh` | `--enforce-ports` declares `443 + 8443`; new 8443 open self-check (WARN if missing); drift detection still only flags 80/22 |
| `deploy/aws/README.md`, `deploy/aws/lightsail/README.md` | baseline doc updated; **prod 443-only vs edge 443+8443** made explicit |
| `scripts/checks/lightsail-oidc-perm-coverage.py` | IAM perm description string |

## Rollout status

The live edge fleet (9 deployable edges) has **already** been set to `443 + 8443` out-of-band; 443 health verified `{"status":"ok"}`. This PR makes the code match that state so the convergence paths stop fighting it.

## Test

- `bash scripts/preflight.sh` — PASS
- `bash -n` both shell scripts; `--help` text reflects the new baseline
- Per-edge `get-instance-port-states` shows `443 + 8443` open, `80/22` closed

## Notes for reviewer

- Merge mode: **Squash and merge** (TK-originated).
- `no-upstream-touch`: all paths are TK-only ops/docs (no upstream-shaped files).

🤖 Generated with [Claude Code](https://claude.com/claude-code)