### PR TITLE
feat(antigravity): enforce supported_model_scopes on /models + API-key usage guide

### DIFF
--- a/backend/internal/handler/gateway_handler.go
+++ b/backend/internal/handler/gateway_handler.go
@@ -1191,9 +1191,16 @@ func (h *GatewayHandler) AntigravityModels(c *gin.Context) {
 	// availability. Candidate set is always the antigravity-specific list (not the
 	// full cross-platform catalog). Response shape is always []antigravity.ClaudeModel.
 	// Goal 2 / R-003; shape/scope regression fix from review-20260507 R-001/R-002.
+	models := h.tkAntigravityDefaultModels(c.Request.Context())
+	// TK: enforce the group's supported_model_scopes on the advertised list, so a
+	// gemini-only antigravity group ([gemini_text, gemini_image]) hides claude here —
+	// matching the per-account gemini-only model_mapping. Empty scopes = unrestricted.
+	if apiKey, ok := middleware2.GetAPIKeyFromContext(c); ok && apiKey != nil && apiKey.Group != nil {
+		models = tkAntigravityFilterModelsByGroupScopes(apiKey.Group.SupportedModelScopes, models)
+	}
 	c.JSON(http.StatusOK, gin.H{
 		"object": "list",
-		"data":   h.tkAntigravityDefaultModels(c.Request.Context()),
+		"data":   models,
 	})
 }
 

--- a/backend/internal/handler/gateway_handler_tk_model_list.go
+++ b/backend/internal/handler/gateway_handler_tk_model_list.go
@@ -137,3 +137,46 @@ func (h *GatewayHandler) tkGeminiFallbackModelsList(ctx context.Context) gemini.
 	}
 	return gemini.ModelsListResponse{Models: out}
 }
+
+// antigravityModelScope classifies an antigravity model id into the group
+// supported_model_scopes vocabulary ("claude" / "gemini_text" / "gemini_image").
+// gpt-oss gets its own bucket so a gemini-only group filters it out too (it is
+// neither a gemini text nor image scope). Mirrors the frontend SubscriptionPlanCard
+// / UseKeyModal classification so /antigravity/v1/models and the usage guide agree.
+func antigravityModelScope(id string) string {
+	l := strings.ToLower(strings.TrimSpace(id))
+	switch {
+	case strings.HasPrefix(l, "claude-"):
+		return "claude"
+	case strings.HasPrefix(l, "gpt-oss"):
+		return "gpt_oss"
+	case strings.Contains(l, "image"):
+		return "gemini_image"
+	default:
+		return "gemini_text"
+	}
+}
+
+// tkAntigravityFilterModelsByGroupScopes keeps only models whose scope is in the
+// group's supported_model_scopes. Empty scopes = no restriction (back-compat for
+// pre-#774 groups). This is the FIRST request-path enforcement of
+// supported_model_scopes: the operator policy "antigravity serves gemini only"
+// (group scopes [gemini_text, gemini_image]) now actually hides claude from
+// /antigravity/v1/models, matching the per-account gemini-only model_mapping
+// (see domain.GeminiOnlyAntigravityModelMapping + AntigravityConfigReconciler).
+func tkAntigravityFilterModelsByGroupScopes(scopes []string, models []antigravity.ClaudeModel) []antigravity.ClaudeModel {
+	if len(scopes) == 0 {
+		return models
+	}
+	allow := make(map[string]bool, len(scopes))
+	for _, s := range scopes {
+		allow[strings.TrimSpace(s)] = true
+	}
+	out := make([]antigravity.ClaudeModel, 0, len(models))
+	for _, m := range models {
+		if allow[antigravityModelScope(m.ID)] {
+			out = append(out, m)
+		}
+	}
+	return out
+}

--- a/backend/internal/handler/gateway_handler_tk_model_list.go
+++ b/backend/internal/handler/gateway_handler_tk_model_list.go
@@ -141,8 +141,11 @@ func (h *GatewayHandler) tkGeminiFallbackModelsList(ctx context.Context) gemini.
 // antigravityModelScope classifies an antigravity model id into the group
 // supported_model_scopes vocabulary ("claude" / "gemini_text" / "gemini_image").
 // gpt-oss gets its own bucket so a gemini-only group filters it out too (it is
-// neither a gemini text nor image scope). Mirrors the frontend SubscriptionPlanCard
-// / UseKeyModal classification so /antigravity/v1/models and the usage guide agree.
+// neither a gemini text nor image scope). Same bucketing as the frontend
+// SubscriptionPlanCard badge labels (claude / gemini_text→Gemini / gemini_image→
+// Imagen). Note the UseKeyModal usage guide does NOT classify per-model — it only
+// gates the claude *flavor* on scopes.includes('claude'); the gemini_text vs
+// gemini_image split is enforced here on /antigravity/v1/models only.
 func antigravityModelScope(id string) string {
 	l := strings.ToLower(strings.TrimSpace(id))
 	switch {

--- a/backend/internal/handler/gateway_handler_tk_model_list_test.go
+++ b/backend/internal/handler/gateway_handler_tk_model_list_test.go
@@ -213,3 +213,67 @@ func (r *capturedRepo2) Get(_ context.Context, p, m string) (service.Availabilit
 	defer r.mu.Unlock()
 	return r.rows[r.key(p, m)], nil
 }
+
+func TestAntigravityModelScope(t *testing.T) {
+	cases := map[string]string{
+		"claude-sonnet-4-6":      "claude",
+		"claude-opus-4-8":        "claude",
+		"gpt-oss-120b-medium":    "gpt_oss",
+		"gemini-3.1-flash-image": "gemini_image",
+		"gemini-2.5-flash-image": "gemini_image",
+		"gemini-3-pro-image":     "gemini_image",
+		"gemini-3-flash":         "gemini_text",
+		"gemini-pro-agent":       "gemini_text",
+		"gemini-2.5-pro":         "gemini_text",
+		"tab_flash_lite_preview": "gemini_text",
+	}
+	for id, want := range cases {
+		if got := antigravityModelScope(id); got != want {
+			t.Fatalf("antigravityModelScope(%q)=%q want %q", id, got, want)
+		}
+	}
+}
+
+func TestTkAntigravityFilterModelsByGroupScopes(t *testing.T) {
+	models := []antigravity.ClaudeModel{
+		{ID: "claude-sonnet-4-6"},
+		{ID: "claude-opus-4-8"},
+		{ID: "gpt-oss-120b-medium"},
+		{ID: "gemini-3-flash"},
+		{ID: "gemini-pro-agent"},
+		{ID: "gemini-3.1-flash-image"},
+	}
+	ids := func(ms []antigravity.ClaudeModel) []string {
+		out := make([]string, len(ms))
+		for i, m := range ms {
+			out[i] = m.ID
+		}
+		return out
+	}
+
+	// gemini-only group (operator policy): claude + gpt-oss dropped.
+	got := tkAntigravityFilterModelsByGroupScopes([]string{"gemini_text", "gemini_image"}, models)
+	want := []string{"gemini-3-flash", "gemini-pro-agent", "gemini-3.1-flash-image"}
+	if strings.Join(ids(got), ",") != strings.Join(want, ",") {
+		t.Fatalf("gemini-only scope filter = %v, want %v", ids(got), want)
+	}
+
+	// gemini_text only: image dropped too.
+	got = tkAntigravityFilterModelsByGroupScopes([]string{"gemini_text"}, models)
+	want = []string{"gemini-3-flash", "gemini-pro-agent"}
+	if strings.Join(ids(got), ",") != strings.Join(want, ",") {
+		t.Fatalf("gemini_text scope filter = %v, want %v", ids(got), want)
+	}
+
+	// claude included: claude kept (but gpt-oss still dropped — not a scope value).
+	got = tkAntigravityFilterModelsByGroupScopes([]string{"claude", "gemini_text", "gemini_image"}, models)
+	if strings.Join(ids(got), ",") != "claude-sonnet-4-6,claude-opus-4-8,gemini-3-flash,gemini-pro-agent,gemini-3.1-flash-image" {
+		t.Fatalf("claude+gemini scope filter unexpected: %v", ids(got))
+	}
+
+	// empty scopes = no restriction (back-compat).
+	got = tkAntigravityFilterModelsByGroupScopes(nil, models)
+	if len(got) != len(models) {
+		t.Fatalf("empty scopes should be unrestricted, got %d of %d", len(got), len(models))
+	}
+}

--- a/backend/internal/web/dist/frontend-source.json
+++ b/backend/internal/web/dist/frontend-source.json
@@ -1,7 +1,7 @@
 {
   "algorithm": "sha256(git-ls-files:path,size,content)",
   "file_count": 477,
-  "hash": "d56394502cb46f4b8cbff3992c0f182ff063075a7efb912a79f84338bdf613dd",
+  "hash": "449bbbcff5e6ab2f2cc9ea5e5595b035f0a140c690ba87accce00e2c902a2ea7",
   "schema": 1,
   "source": "frontend/"
 }

--- a/backend/internal/web/dist/frontend-source.json
+++ b/backend/internal/web/dist/frontend-source.json
@@ -1,7 +1,7 @@
 {
   "algorithm": "sha256(git-ls-files:path,size,content)",
   "file_count": 477,
-  "hash": "449bbbcff5e6ab2f2cc9ea5e5595b035f0a140c690ba87accce00e2c902a2ea7",
+  "hash": "cf9cebda4734758fae037613a2300b67d0d1d9692409cc35d3e2eda17de33778",
   "schema": 1,
   "source": "frontend/"
 }

--- a/frontend/src/components/keys/UseKeyModal.vue
+++ b/frontend/src/components/keys/UseKeyModal.vue
@@ -149,7 +149,9 @@ interface Props {
   allowMessagesDispatch?: boolean
   // 分组的「支持的模型系列」(claude / gemini_text / gemini_image)。仅 antigravity 用：
   // 不含 'claude' 时隐藏 Claude flavor（Claude Code tab + OpenCode antigravity-claude
-  // provider），与 /antigravity/v1/models 的 scope 过滤同口径。空/未传 = 不限制。
+  // provider）。本指南只按 claude flavor 做粗粒度 gate；gemini_text 与 gemini_image 的
+  // 细分仅后端 /antigravity/v1/models 生效（运营策略下两者总是成对 = gemini-only）。
+  // 空/未传 = 不限制。
   supportedModelScopes?: string[]
 }
 
@@ -186,8 +188,9 @@ const activeClientTab = ref<string>('claude')
 // ChatGPT WebSocket auth, so codex (HTTP) is the right default — same as
 // `openai` minus codex-ws.
 // antigravity 的 Claude flavor 是否对当前分组开放：分组 supported_model_scopes 含
-// 'claude' 才显示（与后端 /antigravity/v1/models 的 scope 过滤同口径）。空/未传 =
-// 不限制（向后兼容旧分组）。非 antigravity 平台不受影响。
+// 'claude' 才显示。这是 claude 维度上与后端 /antigravity/v1/models scope 过滤的一致点；
+// 本指南不做 gemini_text/gemini_image 的逐模型细分（那只在后端 /models 生效）。
+// 空/未传 = 不限制（向后兼容旧分组）。非 antigravity 平台不受影响。
 const antigravityClaudeAllowed = computed(() => {
   if (props.platform !== 'antigravity') return true
   const scopes = props.supportedModelScopes

--- a/frontend/src/components/keys/UseKeyModal.vue
+++ b/frontend/src/components/keys/UseKeyModal.vue
@@ -147,6 +147,10 @@ interface Props {
   baseUrl: string
   platform: GroupPlatform | null
   allowMessagesDispatch?: boolean
+  // 分组的「支持的模型系列」(claude / gemini_text / gemini_image)。仅 antigravity 用：
+  // 不含 'claude' 时隐藏 Claude flavor（Claude Code tab + OpenCode antigravity-claude
+  // provider），与 /antigravity/v1/models 的 scope 过滤同口径。空/未传 = 不限制。
+  supportedModelScopes?: string[]
 }
 
 interface Emits {
@@ -181,6 +185,16 @@ const activeClientTab = ref<string>('claude')
 // upstream speaks OpenAI's /v1/chat/completions shape but does not expose
 // ChatGPT WebSocket auth, so codex (HTTP) is the right default — same as
 // `openai` minus codex-ws.
+// antigravity 的 Claude flavor 是否对当前分组开放：分组 supported_model_scopes 含
+// 'claude' 才显示（与后端 /antigravity/v1/models 的 scope 过滤同口径）。空/未传 =
+// 不限制（向后兼容旧分组）。非 antigravity 平台不受影响。
+const antigravityClaudeAllowed = computed(() => {
+  if (props.platform !== 'antigravity') return true
+  const scopes = props.supportedModelScopes
+  if (!scopes || scopes.length === 0) return true
+  return scopes.includes('claude')
+})
+
 const defaultClientTab = computed(() => {
   switch (props.platform) {
     case 'openai':
@@ -190,7 +204,7 @@ const defaultClientTab = computed(() => {
     case 'gemini':
       return 'gemini'
     case 'antigravity':
-      return 'claude'
+      return antigravityClaudeAllowed.value ? 'claude' : 'gemini'
     default:
       return 'claude'
   }
@@ -288,12 +302,16 @@ const clientTabs = computed((): TabConfig[] => {
         { id: 'gemini', label: t('keys.useKeyModal.cliTabs.geminiCli'), icon: SparkleIcon },
         { id: 'opencode', label: t('keys.useKeyModal.cliTabs.opencode'), icon: TerminalIcon }
       ]
-    case 'antigravity':
-      return [
-        { id: 'claude', label: t('keys.useKeyModal.cliTabs.claudeCode'), icon: TerminalIcon },
-        { id: 'gemini', label: t('keys.useKeyModal.cliTabs.geminiCli'), icon: SparkleIcon },
-        { id: 'opencode', label: t('keys.useKeyModal.cliTabs.opencode'), icon: TerminalIcon }
-      ]
+    case 'antigravity': {
+      const tabs: TabConfig[] = []
+      // gemini-only 分组（supported_model_scopes 不含 claude）隐藏 Claude Code tab。
+      if (antigravityClaudeAllowed.value) {
+        tabs.push({ id: 'claude', label: t('keys.useKeyModal.cliTabs.claudeCode'), icon: TerminalIcon })
+      }
+      tabs.push({ id: 'gemini', label: t('keys.useKeyModal.cliTabs.geminiCli'), icon: SparkleIcon })
+      tabs.push({ id: 'opencode', label: t('keys.useKeyModal.cliTabs.opencode'), icon: TerminalIcon })
+      return tabs
+    }
     case 'newapi': {
       // OpenAI-compat HTTP only; no codex-ws. Optionally claude tab when the
       // group enables messages dispatch (mirrors the openai branch).
@@ -434,11 +452,15 @@ const currentFiles = computed((): FileConfig[] => {
         return [generateOpenCodeConfig('openai', apiBase, apiKey)]
       case 'gemini':
         return [generateOpenCodeConfig('gemini', geminiBase, apiKey)]
-      case 'antigravity':
-        return [
-          generateOpenCodeConfig('antigravity-claude', antigravityBase, apiKey, 'opencode.json (Claude)'),
-          generateOpenCodeConfig('antigravity-gemini', antigravityGeminiBase, apiKey, 'opencode.json (Gemini)')
-        ]
+      case 'antigravity': {
+        const configs: FileConfig[] = []
+        // gemini-only 分组隐藏 antigravity-claude provider，只给 gemini 配置。
+        if (antigravityClaudeAllowed.value) {
+          configs.push(generateOpenCodeConfig('antigravity-claude', antigravityBase, apiKey, 'opencode.json (Claude)'))
+        }
+        configs.push(generateOpenCodeConfig('antigravity-gemini', antigravityGeminiBase, apiKey, 'opencode.json (Gemini)'))
+        return configs
+      }
       default:
         return [generateOpenCodeConfig('openai', apiBase, apiKey)]
     }

--- a/frontend/src/components/keys/__tests__/UseKeyModal.spec.ts
+++ b/frontend/src/components/keys/__tests__/UseKeyModal.spec.ts
@@ -249,4 +249,64 @@ describe('UseKeyModal', () => {
     expect(activeBlocks).toHaveLength(0)
     expect(joined).toMatch(/#\s*export CLAUDE_CODE_DISABLE_NONESSENTIAL_TRAFFIC=1/)
   })
+  it('hides Claude flavor for a gemini-only antigravity group (scope gate)', async () => {
+    const wrapper = mount(UseKeyModal, {
+      props: {
+        show: true,
+        apiKey: 'sk-test',
+        baseUrl: 'https://example.com/v1',
+        platform: 'antigravity',
+        supportedModelScopes: ['gemini_text', 'gemini_image']
+      },
+      global: {
+        stubs: {
+          BaseDialog: { template: '<div><slot /><slot name="footer" /></div>' },
+          Icon: { template: '<span />' }
+        }
+      }
+    })
+    await nextTick()
+
+    // Claude Code tab is hidden when the group scopes exclude claude.
+    const claudeTab = wrapper.findAll('button').find((b) =>
+      b.text().includes('keys.useKeyModal.cliTabs.claudeCode')
+    )
+    expect(claudeTab).toBeUndefined()
+
+    // OpenCode tab yields only the gemini provider, never antigravity-claude.
+    const opencodeTab = wrapper.findAll('button').find((b) =>
+      b.text().includes('keys.useKeyModal.cliTabs.opencode')
+    )
+    expect(opencodeTab).toBeDefined()
+    await opencodeTab!.trigger('click')
+    await nextTick()
+
+    const blocks = wrapper.findAll('pre code').map((c) => c.text())
+    expect(blocks.some((c) => c.includes('"antigravity-claude"'))).toBe(false)
+    expect(blocks.some((c) => c.includes('"antigravity-gemini"'))).toBe(true)
+  })
+
+  it('keeps Claude flavor for antigravity when scopes include claude or are absent', async () => {
+    const wrapper = mount(UseKeyModal, {
+      props: {
+        show: true,
+        apiKey: 'sk-test',
+        baseUrl: 'https://example.com/v1',
+        platform: 'antigravity',
+        supportedModelScopes: ['claude', 'gemini_text', 'gemini_image']
+      },
+      global: {
+        stubs: {
+          BaseDialog: { template: '<div><slot /><slot name="footer" /></div>' },
+          Icon: { template: '<span />' }
+        }
+      }
+    })
+    await nextTick()
+    const claudeTab = wrapper.findAll('button').find((b) =>
+      b.text().includes('keys.useKeyModal.cliTabs.claudeCode')
+    )
+    expect(claudeTab).toBeDefined()
+  })
+
 })

--- a/frontend/src/types/index.ts
+++ b/frontend/src/types/index.ts
@@ -531,6 +531,9 @@ export interface Group {
   fallback_group_id_on_invalid_request: number | null
   // OpenAI Messages 调度开关（用户侧需要此字段判断是否展示 Claude Code 教程）
   allow_messages_dispatch?: boolean
+  // 支持的模型系列（仅 antigravity 平台使用；用户侧 UseKeyModal 据此决定是否展示
+  // Claude flavor）。后端 keys DTO 会返回此字段。
+  supported_model_scopes?: string[]
   default_mapped_model?: string
   messages_dispatch_model_config?: OpenAIMessagesDispatchModelConfig
   messages_compaction_enabled?: boolean | null
@@ -552,8 +555,7 @@ export interface AdminGroup extends Group {
   // MCP XML 协议注入（仅 antigravity 平台使用）
   mcp_xml_inject: boolean
 
-  // 支持的模型系列（仅 antigravity 平台使用）
-  supported_model_scopes?: string[]
+  // supported_model_scopes 已上移到基础 Group（用户侧 keys DTO 也返回）。
 
   // 分组下账号数量（仅管理员可见）
   account_count?: number

--- a/frontend/src/views/user/KeysView.vue
+++ b/frontend/src/views/user/KeysView.vue
@@ -930,6 +930,7 @@
       :base-url="publicSettings?.api_base_url || ''"
       :platform="selectedKey?.group?.platform || null"
       :allow-messages-dispatch="selectedKey?.group?.allow_messages_dispatch || false"
+      :supported-model-scopes="selectedKey?.group?.supported_model_scopes"
       @close="closeUseKeyModal"
     />
 

--- a/scripts/sentinels/frontend-tk.json
+++ b/scripts/sentinels/frontend-tk.json
@@ -561,6 +561,14 @@
       "rationale": "The 'Use API Key' modal recommends ANTHROPIC_MODEL for Claude Code. The base id MUST be an empirically-servable Anthropic model (backend supportedAnthropicCatalogModels, regenerated from a live prod probe — PR #608), NOT a bare alias. The gateway strips the trailing [1m] context-window suffix (gateway_anthropic_context_window_alias_tk.go), so a bare 'opus[1m]' collapses to 'opus' and is rejected as a non-servable model name → 400 invalid_request (PR #617), while the user silently never gets 1M context. Pinning the servable id catches a regression back to the bare alias on upstream merge or careless edit. Advance this needle (and the modal's export/settings strings) together when the servable opus generation moves past claude-opus-4-8."
     },
     {
+      "path": "frontend/src/components/keys/UseKeyModal.vue",
+      "must_contain": [
+        "const antigravityClaudeAllowed = computed(",
+        "supportedModelScopes"
+      ],
+      "rationale": "antigravity 使用指南的 gemini-only gate（与后端 /antigravity/v1/models 的 supported_model_scopes 过滤同口径）。antigravityClaudeAllowed 据分组 supportedModelScopes 是否含 'claude' 决定是否展示 Claude flavor（Claude Code tab、OpenCode antigravity-claude provider）；gemini-only 分组([gemini_text, gemini_image])隐藏 claude，避免使用指南教用户配 claude on antigravity 却 403。上游 merge 若删除该 computed 或 supportedModelScopes prop，指南会静默回退到展示 claude——本 sentinel 守护。与后端 gateway_handler_tk_model_list.go 的 tkAntigravityFilterModelsByGroupScopes 锚点配对。"
+    },
+    {
       "path": "frontend/src/views/HomeView.vue",
       "must_contain": [
         "HomeTkLanding"

--- a/scripts/sentinels/gateway-tk.json
+++ b/scripts/sentinels/gateway-tk.json
@@ -1626,6 +1626,14 @@
       "rationale": "Antigravity 自定义-映射账号的 safety-net 透传列表（GetModelMapping 内）。这是 antigravity gemini-only 服务面的「五面」之一：公共目录 / UseKeyModal 宣告可服务的 wire id，若自定义 model_mapping 账号未显式声明，必须由此列表补 identity 透传，否则静默 404（xj-review R / memory antigravity_claude_exclude_per_account_not_global_default）。2026-06-15（PR #774）起该列表已移除上游 deprecated 的 gemini-3.1-pro-high（identity 透传 → 400），等价档走 gemini-pro-agent。上游 merge 若删除 ensureAntigravityDefaultPassthroughs 调用或丢失 gemini-pro-agent / gemini-3-flash-agent 成员，自定义账号会静默拒绝可服务模型——本 sentinel 守护该调用与收敛后的成员。"
     },
     {
+      "path": "backend/internal/handler/gateway_handler_tk_model_list.go",
+      "must_contain": [
+        "func tkAntigravityFilterModelsByGroupScopes(",
+        "func antigravityModelScope("
+      ],
+      "rationale": "supported_model_scopes 的请求路径 enforcement（首次落地，PR 后续）：/antigravity/v1/models 经 AntigravityModels handler 调用 tkAntigravityFilterModelsByGroupScopes 按分组 supported_model_scopes（claude / gemini_text / gemini_image）过滤已宣告模型，使 gemini-only 分组（[gemini_text, gemini_image]）从 /models 隐藏 claude，与 per-account gemini-only model_mapping + 前端 UseKeyModal 的 claude-flavor gate 同口径。antigravityModelScope 是 model→scope 归类器（claude-/gpt-oss-/含 image/其余=gemini_text），与前端分类镜像。上游 merge 若删除这两个函数或 AntigravityModels 里的过滤调用，/models 会静默回退到含 claude 的全目录——本 sentinel 守护。"
+    },
+    {
       "path": "backend/internal/service/wire.go",
       "must_contain": [
         "func ProvideAntigravityConfigReconciler(",


### PR DESCRIPTION
## 背景

发版后 `/antigravity/v1/models` 与 API key 使用指南仍展示 claude(`AntigravityModels` handler 走 `tkAntigravityDefaultModels`,**不读** group `models_list_config`;UseKeyModal 的 OpenCode 给 `antigravity-claude` provider)。而 antigravity 运营策略是 **gemini-only**(claude 路由到 anthropic,已在账号 `model_mapping` 层强制)。本 PR 让这两条「广告面」与策略一致。

`supported_model_scopes` 此前是**纯展示字段**(无任何 enforcement)——本 PR 给它首次请求路径 enforcement。

## 改动

**后端**(收敛到 TK companion):
- `gateway_handler_tk_model_list.go`:`antigravityModelScope`(model→scope:`claude-`/`gpt-oss-`/含 `image`=gemini_image/其余=gemini_text)+ `tkAntigravityFilterModelsByGroupScopes`。
- `AntigravityModels` handler 薄接入:按 `apiKey.Group.SupportedModelScopes` 过滤已宣告模型。**空 scopes = 不限制**(向后兼容)。gemini-only 分组从 `/antigravity/v1/models` 隐藏 claude。

**前端**(UseKeyModal,数据驱动同口径):
- 新增 `supportedModelScopes` prop + `antigravityClaudeAllowed` computed:分组 scopes 不含 `claude` 时隐藏 Claude flavor(Claude Code tab、OpenCode `antigravity-claude` provider),默认 tab 落到 gemini。
- `KeysView` 透传 `selectedKey.group.supported_model_scopes`;`Group` 类型补 `supported_model_scopes`(后端 keys DTO 已返回,从 `AdminGroup` 上移到基础 `Group`)。

## 覆盖写防护(§5.x)

- `gateway-tk.json`:锚 `tkAntigravityFilterModelsByGroupScopes` + `antigravityModelScope`。
- `frontend-tk.json`:锚 `antigravityClaudeAllowed` + `supportedModelScopes`。
- 上游 merge 若删任一,`/models` / 使用指南会静默回退到含 claude——sentinel 翻红。

## 校验

- `go test -tags=unit ./internal/handler/` ✓(新增 `TestAntigravityModelScope` / `TestTkAntigravityFilterModelsByGroupScopes`)· `golangci-lint` 0 issues ✓ · `go build ./...` ✓
- 前端 `typecheck` / `lint:check` ✓ · `vitest` UseKeyModal 8 测试 ✓(含 gemini-only gate + claude-included 两条新增)
- `frontend-source.json` 已刷新 · `scripts/preflight.sh` 全绿(gateway-tk 272/272、frontend-tk 86/86、registry-update ok、pricing overlay 无 $0)

注:现网 prod g21 / edge g2 已先把 `models_list_config` 设 gemini-only enabled(止血,影响通用 `/v1/models`);本 PR 是 `/antigravity/v1/models` 与使用指南的根因修复(代码级、数据驱动 scope)。

## Markers

upstream-touch-guarded

Reviewer:**Squash and merge**(TK 自有 feature PR)。
