### PR TITLE
ops(edge): record us3/us5 Static IP rotation — new IPs + polluted old IPs

### DIFF
--- a/deploy/aws/lightsail/edge-targets-lightsail.json
+++ b/deploy/aws/lightsail/edge-targets-lightsail.json
@@ -99,14 +99,14 @@
       "ec2_equivalent_region": "us-east-2",
       "availability_zone": "us-east-2a",
       "domain": "api-us3.tokenkey.dev",
-      "porkbun_a_ipv4": "3.128.102.134",
+      "porkbun_a_ipv4": "18.220.195.44",
       "instance_name": "tokenkey-edge-us-oh1-ls",
-      "static_ip_name": "Static-oh-1",
+      "static_ip_name": "vless-oh-fresh-1",
       "bundle_id": "micro_3_0",
       "blueprint_id": "amazon_linux_2023",
       "monthly_budget_usd": 12,
       "ssm_prefix": "/tokenkey/lightsail/us3",
-      "purpose": "us-east-2-ohio-egress (pre-provisioned Static-oh-1 / tokenkey-edge-us-oh1-ls)"
+      "purpose": "us-east-2-ohio-egress (rotated 2026-06-16: swapped to vless-oh-fresh-1 / 18.220.195.44 after Static-oh-1 / 3.128.102.134 upstream API risk-block; old Static-oh-1 detached, recorded in edge-polluted-ips.json)"
     },
     "us4": {
       "deployable": true,
@@ -133,14 +133,14 @@
       "ec2_equivalent_region": "us-west-2",
       "availability_zone": "us-west-2a",
       "domain": "api-us5.tokenkey.dev",
-      "porkbun_a_ipv4": "44.224.133.40",
+      "porkbun_a_ipv4": "32.185.163.163",
       "instance_name": "tokenkey-edge-us-or2-ls",
-      "static_ip_name": "StaticIp-or-2",
+      "static_ip_name": "vless-or-fresh-1",
       "bundle_id": "micro_3_0",
       "blueprint_id": "amazon_linux_2023",
       "monthly_budget_usd": 12,
       "ssm_prefix": "/tokenkey/lightsail/us5",
-      "purpose": "us-west-2-oregon-egress-2 (pre-provisioned StaticIp-or-2 / tokenkey-edge-us-or2-ls)"
+      "purpose": "us-west-2-oregon-egress-2 (rotated 2026-06-16: swapped to vless-or-fresh-1 / 32.185.163.163 after StaticIp-or-2 / 44.224.133.40 upstream API risk-block; old StaticIp-or-2 detached, recorded in edge-polluted-ips.json)"
     },
     "us6": {
       "deployable": true,

--- a/deploy/aws/stage0/edge-polluted-ips.json
+++ b/deploy/aws/stage0/edge-polluted-ips.json
@@ -50,6 +50,20 @@
       "platform": "ec2",
       "edge_id": "us1",
       "notes": "EC2 us1 EIP released 2026-06-07 on edge retirement (accounts migrated to us6 Lightsail; cc/codex fingerprint egress migrated to 52.15.35.197; not upstream pollution; exclude from re-allocation)"
+    },
+    {
+      "ip": "3.128.102.134",
+      "region": "us-east-2",
+      "platform": "lightsail",
+      "edge_id": "us3",
+      "notes": "Lightsail edge-us3 Static-oh-1 upstream API risk-block (2026-06-16); swapped to vless-oh-fresh-1 / 18.220.195.44; old Static-oh-1 detached, exclude from re-allocation"
+    },
+    {
+      "ip": "44.224.133.40",
+      "region": "us-west-2",
+      "platform": "lightsail",
+      "edge_id": "us5",
+      "notes": "Lightsail edge-us5 StaticIp-or-2 upstream API risk-block (2026-06-16); swapped to vless-or-fresh-1 / 32.185.163.163; old StaticIp-or-2 detached, exclude from re-allocation"
     }
   ]
 }

--- a/docs/deploy/tokenkey-edge-ip-history.md
+++ b/docs/deploy/tokenkey-edge-ip-history.md
@@ -20,4 +20,6 @@ Active edge EIP rotation runbook: [`.cursor/skills/tokenkey-stage0-edge-ip-rotat
 | `100.48.129.133` | us-east-1 | Lightsail edge-us2 StaticIp-2 upstream API risk-block (2026-05-29) |
 | `52.47.52.132` | eu-west-3 | EC2 fra1 EIP released 2026-06-01 on EC2 decommission (fra1 goes Lightsail-only; not upstream pollution; exclude from re-allocation) |
 | `16.147.170.3` | us-west-2 | EC2 us1 EIP released 2026-06-07 on edge retirement (accounts migrated to us6 Lightsail; cc/codex fingerprint egress migrated to 52.15.35.197; not upstream pollution; exclude from re-allocation) |
+| `3.128.102.134` | us-east-2 | Lightsail edge-us3 Static-oh-1 upstream API risk-block (2026-06-16); swapped to vless-oh-fresh-1 / 18.220.195.44; old Static-oh-1 detached, exclude from re-allocation |
+| `44.224.133.40` | us-west-2 | Lightsail edge-us5 StaticIp-or-2 upstream API risk-block (2026-06-16); swapped to vless-or-fresh-1 / 32.185.163.163; old StaticIp-or-2 detached, exclude from re-allocation |
 <!-- END edge-ip-status:polluted -->


### PR DESCRIPTION
## What

us3 / us5 edge egress Static IPs were risk-blocked upstream and swapped at the AWS Lightsail layer to fresh adopted Static IPs. This records the rotation in the repo source-of-truth files.

| edge | instance / region | old (polluted) | new (live) |
|---|---|---|---|
| us3 | tokenkey-edge-us-oh1-ls / us-east-2 | Static-oh-1 `3.128.102.134` | vless-oh-fresh-1 `18.220.195.44` |
| us5 | tokenkey-edge-us-or2-ls / us-west-2 | StaticIp-or-2 `44.224.133.40` | vless-or-fresh-1 `32.185.163.163` |

## Changes

- `deploy/aws/lightsail/edge-targets-lightsail.json` — us3/us5 `porkbun_a_ipv4` (manual-DNS single source of truth) + `static_ip_name` → live attached Static IPs; `purpose` notes the rotation.
- `deploy/aws/stage0/edge-polluted-ips.json` — appended the two detached old IPs so `rotate-static-ip.sh` refuses to re-allocate them.
- `docs/deploy/tokenkey-edge-ip-history.md` — synced polluted table (`edge-ip-status --check` green).

## Verification (already live)

- AWS Lightsail: new Static IPs attached, instances `running`, ports 443/8443 open.
- DNS: A records re-pointed via Porkbun API. The Cloudflare-backed zone would not republish in-place edits (stored value correct but authoritative NS served the stale snapshot + returned `BAD (HORIZONTAL) REFERRAL`); **delete + recreate** of the records forced a clean publish. Authoritative NS + public resolvers now serve the new IPs.
- Edge smoke: `api-us3` / `api-us5` `/health` → HTTP 200, `tk_edge_post_deploy_smoke: OK phase=infra` (runs 27561346916 / 27561350137).

## Notes

- Old detached Static IPs (`Static-oh-1`, `StaticIp-or-2`) are recorded as polluted; whether to AWS-`release` them (irreversible; stops the detached-IP charge) is a separate operator decision, not done here.
- Pure ops/data change — `no-web-impact`, `no-upstream-touch`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)