### PR TITLE
feat(antigravity): self-heal group supported_model_scopes to gemini-only + check assertion

### DIFF
--- a/backend/cmd/server/wire_gen.go
+++ b/backend/cmd/server/wire_gen.go
@@ -298,7 +298,7 @@ func initializeApplication(buildInfo handler.BuildInfo) (*Application, error) {
 	rateLimitExpiryRepository := repository.NewRateLimitExpiryRepository(db)
 	schedulerRateLimitReaper := service.ProvideSchedulerRateLimitReaper(rateLimitExpiryRepository, configConfig)
 	anthropicConfigReconciler := service.ProvideAnthropicConfigReconciler(accountRepository, userRepository, adminService, tierService, accountTierService, tlsFingerprintProfileService, settingService, configConfig, redisClient)
-	antigravityConfigReconciler := service.ProvideAntigravityConfigReconciler(accountRepository, configConfig, redisClient)
+	antigravityConfigReconciler := service.ProvideAntigravityConfigReconciler(accountRepository, groupRepository, configConfig, redisClient)
 	tkAccountIncidentNotifier := service.ProvideTKAccountIncidentNotifier(rateLimitService, opsService, configConfig)
 	upstreamBalanceSentinel := service.ProvideUpstreamBalanceSentinel(accountRepository, httpUpstream, tkAccountIncidentNotifier, opsService, settingRepository, opsRepository, redisClient)
 	tokenRefreshService := service.ProvideTokenRefreshService(accountRepository, oAuthService, openAIOAuthService, geminiOAuthService, antigravityOAuthService, compositeTokenCacheInvalidator, schedulerCache, configConfig, tempUnschedCache, privacyClientFactory, proxyRepository, oAuthRefreshAPI, openAIGatewayService)

--- a/backend/internal/domain/constants.go
+++ b/backend/internal/domain/constants.go
@@ -162,6 +162,14 @@ func buildGeminiOnlyAntigravityModelMapping() map[string]string {
 	return out
 }
 
+// GeminiOnlyAntigravityModelScopes 是 gemini-only 运营策略下 antigravity 分组的规范
+// supported_model_scopes：只 gemini 文本 + gemini 图片，不含 claude（claude 路由到
+// anthropic）。AntigravityConfigReconciler 把每个 antigravity 分组的 scopes 自愈为此值，
+// 与「每个 antigravity 账号 model_mapping 收成 GeminiOnlyAntigravityModelMapping」对称——
+// 使 /antigravity/v1/models 与 API key 使用指南对新建/漂移分组都自动隐藏 claude。
+// scope 词表为 claude / gemini_text / gemini_image（migration 046b），故 gemini-only 即此两项。
+var GeminiOnlyAntigravityModelScopes = []string{"gemini_text", "gemini_image"}
+
 // DefaultBedrockModelMapping 是 AWS Bedrock 平台的默认模型映射
 // 将 Anthropic 标准模型名映射到 Bedrock 模型 ID
 // 注意：此处的 "us." 前缀仅为默认值，ResolveBedrockModelID 会根据账号配置的

--- a/backend/internal/service/antigravity_config_reconciler.go
+++ b/backend/internal/service/antigravity_config_reconciler.go
@@ -69,12 +69,26 @@ type antigravityReconcilerAccountStore interface {
 	BulkUpdate(ctx context.Context, ids []int64, updates AccountBulkUpdate) (int64, error)
 }
 
+// antigravityReconcilerGroupStore is the narrow group dependency. GroupRepository
+// satisfies it (both methods already exist on that interface), so no new repo
+// surface / stub churn is needed. Group scopes have no token-like sibling field,
+// so the reconciler reuses the existing full Update (read-modify-write) rather
+// than a partial column write — and only fires on drift (idempotent), so the
+// clobber window is a freshly-created / just-edited group, negligible in practice.
+type antigravityReconcilerGroupStore interface {
+	ListActiveByPlatform(ctx context.Context, platform string) ([]Group, error)
+	Update(ctx context.Context, group *Group) error
+}
+
 // AntigravityConfigReconciler runs a single ticker that, each tick (and once
 // immediately on start), acquires a redis leader lock (best-effort; degrades to
-// lockless on no redis) and enforces gemini-only model_mapping on the local DB's
-// antigravity accounts.
+// lockless on no redis) and enforces the gemini-only operator policy on the local
+// DB: gemini-only model_mapping on antigravity accounts AND gemini-only
+// supported_model_scopes on antigravity groups (so /antigravity/v1/models + the
+// API key usage guide hide claude for new / drifted groups too).
 type AntigravityConfigReconciler struct {
 	accounts   antigravityReconcilerAccountStore
+	groups     antigravityReconcilerGroupStore
 	cfg        *config.Config
 	redis      *redis.Client
 	instanceID string
@@ -87,15 +101,17 @@ type AntigravityConfigReconciler struct {
 	warnNoRedisOnce sync.Once
 }
 
-// NewAntigravityConfigReconciler constructs the reconciler. A nil accounts store
-// produces a no-op on Start, keeping wire wiring safe for minimal test deps.
+// NewAntigravityConfigReconciler constructs the reconciler. A nil accounts/groups
+// store no-ops that half, keeping wire wiring safe for minimal test deps.
 func NewAntigravityConfigReconciler(
 	accounts antigravityReconcilerAccountStore,
+	groups antigravityReconcilerGroupStore,
 	cfg *config.Config,
 	redisClient *redis.Client,
 ) *AntigravityConfigReconciler {
 	return &AntigravityConfigReconciler{
 		accounts:   accounts,
+		groups:     groups,
 		cfg:        cfg,
 		redis:      redisClient,
 		instanceID: uuid.NewString(),
@@ -227,6 +243,15 @@ func antigravityCanServeExcluded(a *Account) bool {
 // sub-object — dropping claude/gpt-oss keys — and enqueues a scheduler_outbox
 // event so the change takes effect). Tests call it directly.
 func (r *AntigravityConfigReconciler) runOnce(ctx context.Context) {
+	if r == nil {
+		return
+	}
+	r.reconcileAccounts(ctx)
+	r.reconcileGroups(ctx)
+}
+
+// reconcileAccounts enforces gemini-only model_mapping on every antigravity account.
+func (r *AntigravityConfigReconciler) reconcileAccounts(ctx context.Context) {
 	if r == nil || r.accounts == nil {
 		return
 	}
@@ -256,4 +281,58 @@ func (r *AntigravityConfigReconciler) runOnce(ctx context.Context) {
 		return
 	}
 	slog.Info("antigravity config reconciler: enforced gemini-only model_mapping", "accounts", len(drifted))
+}
+
+// reconcileGroups enforces gemini-only supported_model_scopes on every antigravity
+// group, so /antigravity/v1/models and the API key usage guide hide claude for
+// newly-created or operator-drifted groups too — symmetric with the per-account
+// model_mapping enforcement, and the request-path consumer of supported_model_scopes
+// (gateway_handler AntigravityModels filter + UseKeyModal claude-flavor gate).
+func (r *AntigravityConfigReconciler) reconcileGroups(ctx context.Context) {
+	if r == nil || r.groups == nil {
+		return
+	}
+	groups, err := r.groups.ListActiveByPlatform(ctx, PlatformAntigravity)
+	if err != nil {
+		slog.Warn("antigravity config reconciler: list groups failed", "err", err)
+		return
+	}
+	enforced := 0
+	for i := range groups {
+		g := &groups[i]
+		if !antigravityGroupScopesNeedGeminiOnly(g.SupportedModelScopes) {
+			continue
+		}
+		g.SupportedModelScopes = append([]string(nil), domain.GeminiOnlyAntigravityModelScopes...)
+		if err := r.groups.Update(ctx, g); err != nil {
+			slog.Warn("antigravity config reconciler: update group scopes failed", "err", err, "group", g.ID)
+			continue
+		}
+		enforced++
+	}
+	if enforced > 0 {
+		slog.Info("antigravity config reconciler: enforced gemini-only group scopes", "groups", enforced)
+	}
+}
+
+// antigravityGroupScopesNeedGeminiOnly reports whether a group's
+// supported_model_scopes diverges from the canonical gemini-only set
+// (domain.GeminiOnlyAntigravityModelScopes). Empty/nil (= unrestricted → advertises
+// claude), claude present, or any non-canonical set (extra/missing/duplicate) all
+// count as drift. Order-independent.
+func antigravityGroupScopesNeedGeminiOnly(scopes []string) bool {
+	want := domain.GeminiOnlyAntigravityModelScopes
+	if len(scopes) != len(want) {
+		return true
+	}
+	got := make(map[string]bool, len(scopes))
+	for _, s := range scopes {
+		got[strings.TrimSpace(s)] = true
+	}
+	for _, w := range want {
+		if !got[w] {
+			return true
+		}
+	}
+	return false
 }

--- a/backend/internal/service/antigravity_config_reconciler_test.go
+++ b/backend/internal/service/antigravity_config_reconciler_test.go
@@ -23,7 +23,7 @@ func TestAntigravityReconciler_EmptyMapAccount_ReconciledToGeminiOnly(t *testing
 			},
 		},
 	}
-	r := NewAntigravityConfigReconciler(acc, nil, nil)
+	r := NewAntigravityConfigReconciler(acc, nil, nil, nil)
 	r.runOnce(context.Background())
 
 	require.Len(t, acc.bulkCalls, 1, "expected one BulkUpdate for the claude-serving account")
@@ -60,7 +60,7 @@ func TestAntigravityReconciler_AlreadyGeminiOnly_Skip(t *testing.T) {
 			},
 		},
 	}
-	r := NewAntigravityConfigReconciler(acc, nil, nil)
+	r := NewAntigravityConfigReconciler(acc, nil, nil, nil)
 	r.runOnce(context.Background())
 
 	require.Empty(t, acc.bulkCalls, "already-gemini-only account must not be rewritten")
@@ -83,7 +83,7 @@ func TestAntigravityReconciler_OnlyDriftedAccountsRewritten(t *testing.T) {
 			},
 		},
 	}
-	r := NewAntigravityConfigReconciler(acc, nil, nil)
+	r := NewAntigravityConfigReconciler(acc, nil, nil, nil)
 	r.runOnce(context.Background())
 
 	require.Len(t, acc.bulkCalls, 1)
@@ -112,7 +112,7 @@ func TestAntigravityReconciler_NonProbeClaudeId_StillReconciled(t *testing.T) {
 			},
 		},
 	}
-	r := NewAntigravityConfigReconciler(acc, nil, nil)
+	r := NewAntigravityConfigReconciler(acc, nil, nil, nil)
 	r.runOnce(context.Background())
 
 	require.Len(t, acc.bulkCalls, 1, "custom map with claude-opus must be reconciled")
@@ -126,6 +126,75 @@ func TestAntigravityReconciler_NilSafe(t *testing.T) {
 	var nilRec *AntigravityConfigReconciler
 	require.NotPanics(t, func() { nilRec.runOnce(context.Background()); nilRec.Start(); nilRec.Stop() })
 
-	rec := NewAntigravityConfigReconciler(nil, nil, nil)
+	rec := NewAntigravityConfigReconciler(nil, nil, nil, nil)
 	require.NotPanics(t, func() { rec.runOnce(context.Background()); rec.Start(); rec.Stop() })
+}
+
+// --- group scope reconciliation ---
+
+type reconcilerGroupStub struct {
+	byPlatform  map[string][]Group
+	updateCalls []Group
+	listErr     error
+}
+
+func (s *reconcilerGroupStub) ListActiveByPlatform(_ context.Context, platform string) ([]Group, error) {
+	if s.listErr != nil {
+		return nil, s.listErr
+	}
+	return s.byPlatform[platform], nil
+}
+
+func (s *reconcilerGroupStub) Update(_ context.Context, g *Group) error {
+	s.updateCalls = append(s.updateCalls, *g)
+	return nil
+}
+
+func TestAntigravityGroupScopesNeedGeminiOnly(t *testing.T) {
+	cases := []struct {
+		scopes []string
+		drift  bool
+	}{
+		{nil, true},        // empty = unrestricted → advertises claude
+		{[]string{}, true}, // empty
+		{[]string{"claude", "gemini_text", "gemini_image"}, true}, // default (includes claude)
+		{[]string{"gemini_text"}, true},                           // missing image
+		{[]string{"gemini_text", "gemini_text"}, true},            // duplicate, missing image
+		{[]string{"gemini_text", "gemini_image"}, false},          // canonical
+		{[]string{"gemini_image", "gemini_text"}, false},          // canonical, order-independent
+	}
+	for _, c := range cases {
+		if got := antigravityGroupScopesNeedGeminiOnly(c.scopes); got != c.drift {
+			t.Fatalf("antigravityGroupScopesNeedGeminiOnly(%v)=%v want %v", c.scopes, got, c.drift)
+		}
+	}
+}
+
+func TestAntigravityReconciler_GroupScopes_HealsDriftedToGeminiOnly(t *testing.T) {
+	grp := &reconcilerGroupStub{
+		byPlatform: map[string][]Group{
+			PlatformAntigravity: {
+				{ID: 1, Platform: PlatformAntigravity, SupportedModelScopes: []string{"claude", "gemini_text", "gemini_image"}}, // drift
+				{ID: 2, Platform: PlatformAntigravity, SupportedModelScopes: []string{"gemini_text", "gemini_image"}},           // aligned → skip
+				{ID: 3, Platform: PlatformAntigravity, SupportedModelScopes: nil},                                               // empty → drift
+			},
+		},
+	}
+	r := NewAntigravityConfigReconciler(nil, grp, nil, nil)
+	r.runOnce(context.Background())
+
+	require.Len(t, grp.updateCalls, 2, "only the two drifted groups should be updated")
+	ids := []int64{grp.updateCalls[0].ID, grp.updateCalls[1].ID}
+	require.ElementsMatch(t, []int64{1, 3}, ids)
+	for _, g := range grp.updateCalls {
+		require.Equal(t, domain.GeminiOnlyAntigravityModelScopes, g.SupportedModelScopes,
+			"healed group %d must carry canonical gemini-only scopes", g.ID)
+	}
+}
+
+func TestAntigravityReconciler_GroupScopes_NilStoreSafe(t *testing.T) {
+	// accounts present, groups nil → group reconcile no-ops, no panic.
+	acc := &reconcilerAccountStub{byPlatform: map[string][]Account{}}
+	r := NewAntigravityConfigReconciler(acc, nil, nil, nil)
+	require.NotPanics(t, func() { r.runOnce(context.Background()) })
 }

--- a/backend/internal/service/wire.go
+++ b/backend/internal/service/wire.go
@@ -277,10 +277,11 @@ func ProvideAnthropicConfigReconciler(
 // Start()s the ticker. See antigravity_config_reconciler.go for the doctrine.
 func ProvideAntigravityConfigReconciler(
 	accountRepo AccountRepository,
+	groupRepo GroupRepository,
 	cfg *config.Config,
 	redisClient *redis.Client,
 ) *AntigravityConfigReconciler {
-	rec := NewAntigravityConfigReconciler(accountRepo, cfg, redisClient)
+	rec := NewAntigravityConfigReconciler(accountRepo, groupRepo, cfg, redisClient)
 	rec.Start()
 	return rec
 }

--- a/ops/anthropic/test_ops_sql_execute.py
+++ b/ops/anthropic/test_ops_sql_execute.py
@@ -41,7 +41,7 @@ CREATE TABLE accounts(id bigint, name text, platform text, type text, status tex
   session_window_end timestamptz, credentials jsonb DEFAULT '{}', extra jsonb DEFAULT '{}',
   created_at timestamptz, updated_at timestamptz, deleted_at timestamptz);
 CREATE TABLE groups(id bigint, name text, platform text, status text, claude_code_only boolean,
-  fallback_group_id bigint, created_at timestamptz, updated_at timestamptz, deleted_at timestamptz);
+  supported_model_scopes jsonb, fallback_group_id bigint, created_at timestamptz, updated_at timestamptz, deleted_at timestamptz);
 CREATE TABLE account_groups(account_id bigint, group_id bigint);
 CREATE TABLE users(id bigint, balance numeric, concurrency int,
   created_at timestamptz, updated_at timestamptz, deleted_at timestamptz);

--- a/ops/antigravity/check-antigravity-account-config.py
+++ b/ops/antigravity/check-antigravity-account-config.py
@@ -1,19 +1,24 @@
 #!/usr/bin/env python3
-"""TokenKey post-rollout antigravity account config check (read-only).
+"""TokenKey post-rollout antigravity config check (read-only).
 
-Verifies every ``platform=antigravity`` account across all deployable edges + prod
-carries a **gemini-only** ``credentials.model_mapping`` — i.e. ``claude-*`` and
-``gpt-oss-*`` are NOT reachable. Operator policy: antigravity serves gemini only
-(claude routed to anthropic, gpt-oss off antigravity).
+Verifies the gemini-only operator policy (antigravity serves gemini only; claude
+routed to anthropic, gpt-oss off antigravity) across all deployable edges + prod,
+on BOTH surfaces the backend ``AntigravityConfigReconciler`` self-heals:
 
-The backend ``AntigravityConfigReconciler`` self-heals this on every node (writes
-the gemini-only map to any drifted account on boot + on its tick). This tool is
-the post-rollout *verification* that the self-heal converged fleet-wide.
+  1. **accounts** — every ``platform=antigravity`` account carries a gemini-only
+     ``credentials.model_mapping`` (no ``claude-*`` / ``gpt-oss-*`` keys).
+  2. **groups** — every active ``platform=antigravity`` group carries gemini-only
+     ``supported_model_scopes`` (exactly ``[gemini_text, gemini_image]``), so
+     ``/antigravity/v1/models`` + the API key usage guide hide claude.
+
+The reconciler self-heals both on every node (boot + tick). This tool is the
+post-rollout *verification* that the self-heal converged fleet-wide.
 
 A **violation** is any antigravity account whose ``model_mapping`` is null/empty
 (an empty map falls back to ``DefaultAntigravityModelMapping``, which still
-includes claude + gpt-oss) or contains any key with prefix ``claude-`` /
-``gpt-oss-``.
+includes claude + gpt-oss) or contains any ``claude-`` / ``gpt-oss-`` key; OR any
+active antigravity group whose ``supported_model_scopes`` is empty (unrestricted →
+advertises claude) or not exactly the gemini-only set.
 
 Exit codes (mirrors the anthropic post-release check): ``0`` = all gemini-only
 (green); ``1`` = violations found (yellow, non-blocking at rollout); ``2`` = could
@@ -44,6 +49,19 @@ ANTIGRAVITY_ACCOUNTS_SQL = (
     "FROM accounts WHERE platform = 'antigravity' AND deleted_at IS NULL;"
 )
 
+# Active antigravity groups + their supported_model_scopes. status='active' mirrors
+# the reconciler's ListActiveByPlatform (same口径: only groups the reconciler heals
+# are asserted). `deleted_at IS NULL` mandatory (soft-delete gate).
+ANTIGRAVITY_GROUPS_SQL = (
+    "SELECT COALESCE(json_agg(json_build_object("
+    "'id', id, 'name', name, 'scopes', supported_model_scopes))::text, '[]') "
+    "FROM groups WHERE platform = 'antigravity' AND status = 'active' AND deleted_at IS NULL;"
+)
+
+# Canonical gemini-only group scopes — mirrors domain.GeminiOnlyAntigravityModelScopes
+# and the reconciler's antigravityGroupScopesNeedGeminiOnly predicate.
+GEMINI_ONLY_SCOPES = {"gemini_text", "gemini_image"}
+
 # ops-sql-coverage gate: ssm_run_sql ships SQL over SSM, it does not build it.
 SELF_CHECK_EXEMPT: dict[str, str] = {
     "ssm_run_sql": "executes SQL over SSM, does not build it",
@@ -52,7 +70,10 @@ SELF_CHECK_EXEMPT: dict[str, str] = {
 
 def iter_self_check_sql() -> list[tuple[str, str]]:
     """(label, rendered_sql) for the ops-sql-coverage real-Postgres self-check."""
-    return [("ANTIGRAVITY_ACCOUNTS_SQL", ANTIGRAVITY_ACCOUNTS_SQL)]
+    return [
+        ("ANTIGRAVITY_ACCOUNTS_SQL", ANTIGRAVITY_ACCOUNTS_SQL),
+        ("ANTIGRAVITY_GROUPS_SQL", ANTIGRAVITY_GROUPS_SQL),
+    ]
 
 
 def fail(msg: str) -> None:
@@ -127,17 +148,44 @@ def _account_violation(row: dict) -> str | None:
     return None
 
 
-def _check_target(label: str, region: str, instance_id: str) -> list[dict]:
-    out = ssm_run_sql(region, instance_id, ANTIGRAVITY_ACCOUNTS_SQL, f"antigravity-config-check {label}")
+def _group_violation(row: dict) -> str | None:
+    """Return a human reason if the group scopes are NOT gemini-only, else None."""
+    scopes = row.get("scopes")
+    if not scopes or not isinstance(scopes, list):
+        return "empty/missing supported_model_scopes (unrestricted → advertises claude on /models + usage guide)"
+    got = {str(s).strip() for s in scopes}
+    if got == GEMINI_ONLY_SCOPES:
+        return None
+    parts = []
+    extra = sorted(got - GEMINI_ONLY_SCOPES)
+    missing = sorted(GEMINI_ONLY_SCOPES - got)
+    if extra:
+        parts.append("unexpected: " + ", ".join(extra))
+    if missing:
+        parts.append("missing: " + ", ".join(missing))
+    return "scopes not gemini-only (" + "; ".join(parts) + ")"
+
+
+def _parse_rows(label: str, out: str) -> list:
     try:
-        rows = json.loads(out or "[]")
+        return json.loads(out or "[]")
     except json.JSONDecodeError:
         fail(f"{label}: could not parse antigravity snapshot JSON: {out[:300]!r}")
+        return []  # unreachable (fail raises)
+
+
+def _check_target(label: str, region: str, instance_id: str) -> list[dict]:
     bad: list[dict] = []
-    for r in rows:
+    acc_out = ssm_run_sql(region, instance_id, ANTIGRAVITY_ACCOUNTS_SQL, f"antigravity-account-check {label}")
+    for r in _parse_rows(label, acc_out):
         reason = _account_violation(r)
         if reason:
-            bad.append({"target": label, "id": r.get("id"), "name": r.get("name"), "reason": reason})
+            bad.append({"target": label, "kind": "account", "id": r.get("id"), "name": r.get("name"), "reason": reason})
+    grp_out = ssm_run_sql(region, instance_id, ANTIGRAVITY_GROUPS_SQL, f"antigravity-group-check {label}")
+    for r in _parse_rows(label, grp_out):
+        reason = _group_violation(r)
+        if reason:
+            bad.append({"target": label, "kind": "group", "id": r.get("id"), "name": r.get("name"), "reason": reason})
     return bad
 
 
@@ -169,18 +217,21 @@ def main() -> int:
         for fut in as_completed(futs):
             violations.extend(fut.result())
 
+    def _sort_key(v: dict):
+        return (str(v["target"]), v.get("kind", ""), v.get("id") or 0)
+
     if args.json:
         print(json.dumps({
             "targets": [t[0] for t in targets],
             "violation_count": len(violations),
-            "violations": sorted(violations, key=lambda v: (str(v["target"]), v.get("id") or 0)),
+            "violations": sorted(violations, key=_sort_key),
         }, indent=2, ensure_ascii=False))
     elif violations:
-        print(f"FAIL: {len(violations)} antigravity account(s) not gemini-only across {len(targets)} target(s):")
-        for v in sorted(violations, key=lambda v: (str(v["target"]), v.get("id") or 0)):
-            print(f"  [{v['target']}] account {v['id']} ({v['name']}): {v['reason']}")
+        print(f"FAIL: {len(violations)} antigravity config violation(s) not gemini-only across {len(targets)} target(s):")
+        for v in sorted(violations, key=_sort_key):
+            print(f"  [{v['target']}] {v.get('kind', 'account')} {v['id']} ({v['name']}): {v['reason']}")
     else:
-        print(f"OK: all antigravity accounts gemini-only across {len(targets)} target(s)")
+        print(f"OK: all antigravity accounts + groups gemini-only across {len(targets)} target(s)")
 
     return 1 if violations else 0
 

--- a/ops/antigravity/test_check_antigravity_account_config.py
+++ b/ops/antigravity/test_check_antigravity_account_config.py
@@ -1,0 +1,82 @@
+#!/usr/bin/env python3
+"""Offline unit tests for the antigravity post-rollout config check's violation
+classification logic — the load-bearing predicates that decide whether an account
+/ group is flagged. The real-Postgres SQL self-check (ops/anthropic/
+test_ops_sql_execute.py) proves the SQL *executes*; this proves the verdicts are
+correct, so a careless edit to _account_violation / _group_violation is caught.
+
+stdlib-only. The module filename is hyphenated, so it is loaded via importlib.
+"""
+from __future__ import annotations
+
+import importlib.util
+import pathlib
+import unittest
+
+_HERE = pathlib.Path(__file__).resolve().parent
+_MOD_PATH = _HERE / "check-antigravity-account-config.py"
+
+
+def _load_module():
+    spec = importlib.util.spec_from_file_location("check_antigravity_account_config", _MOD_PATH)
+    assert spec is not None and spec.loader is not None
+    mod = importlib.util.module_from_spec(spec)
+    spec.loader.exec_module(mod)  # type: ignore[union-attr]
+    return mod
+
+
+CHK = _load_module()
+
+
+class AccountViolationTest(unittest.TestCase):
+    def test_gemini_only_account_clean(self):
+        self.assertIsNone(CHK._account_violation({"model_mapping": {"gemini-3-flash": "gemini-3-flash"}}))
+
+    def test_empty_mapping_is_violation(self):
+        self.assertIsNotNone(CHK._account_violation({"model_mapping": None}))
+        self.assertIsNotNone(CHK._account_violation({"model_mapping": {}}))
+        self.assertIsNotNone(CHK._account_violation({}))
+
+    def test_claude_or_gptoss_key_is_violation(self):
+        r = CHK._account_violation({"model_mapping": {"claude-opus-4-8": "x", "gemini-3-flash": "y"}})
+        self.assertIsNotNone(r)
+        self.assertIn("claude-opus-4-8", r)
+        self.assertIsNotNone(CHK._account_violation({"model_mapping": {"gpt-oss-120b-medium": "x"}}))
+
+
+class GroupViolationTest(unittest.TestCase):
+    def test_canonical_gemini_only_clean(self):
+        self.assertIsNone(CHK._group_violation({"scopes": ["gemini_text", "gemini_image"]}))
+
+    def test_order_independent(self):
+        self.assertIsNone(CHK._group_violation({"scopes": ["gemini_image", "gemini_text"]}))
+
+    def test_empty_or_missing_is_violation(self):
+        self.assertIsNotNone(CHK._group_violation({"scopes": None}))
+        self.assertIsNotNone(CHK._group_violation({"scopes": []}))
+        self.assertIsNotNone(CHK._group_violation({}))
+
+    def test_claude_present_is_violation(self):
+        r = CHK._group_violation({"scopes": ["claude", "gemini_text", "gemini_image"]})
+        self.assertIsNotNone(r)
+        self.assertIn("unexpected: claude", r)
+
+    def test_missing_image_is_violation(self):
+        r = CHK._group_violation({"scopes": ["gemini_text"]})
+        self.assertIsNotNone(r)
+        self.assertIn("missing: gemini_image", r)
+
+    def test_canonical_set_matches_constant(self):
+        # The check's gemini-only set must equal the canonical scopes (mirrors the
+        # Go domain.GeminiOnlyAntigravityModelScopes + reconciler predicate).
+        self.assertEqual(CHK.GEMINI_ONLY_SCOPES, {"gemini_text", "gemini_image"})
+
+
+class SelfCheckSqlEnumerationTest(unittest.TestCase):
+    def test_both_sql_enumerated(self):
+        labels = [label for label, _ in CHK.iter_self_check_sql()]
+        self.assertEqual(labels, ["ANTIGRAVITY_ACCOUNTS_SQL", "ANTIGRAVITY_GROUPS_SQL"])
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/scripts/sentinels/gateway-tk.json
+++ b/scripts/sentinels/gateway-tk.json
@@ -1595,9 +1595,12 @@
       "must_contain": [
         "func (r *AntigravityConfigReconciler) runOnce(",
         "func antigravityCanServeExcluded(",
-        "domain.GeminiOnlyAntigravityModelMapping"
+        "domain.GeminiOnlyAntigravityModelMapping",
+        "func (r *AntigravityConfigReconciler) reconcileGroups(",
+        "func antigravityGroupScopesNeedGeminiOnly(",
+        "domain.GeminiOnlyAntigravityModelScopes"
       ],
-      "rationale": "Per-node in-process self-healer that enforces the operator policy 'Antigravity serves gemini only' by rewriting every antigravity account's credentials.model_mapping to domain.GeminiOnlyAntigravityModelMapping (claude routed to anthropic, gpt-oss off antigravity). It is a plain-named (non-_tk_) service file that is compile-clean if dropped, so an upstream merge or refactor could silently delete it and the gemini-only auto-sync would stop with no test failure. antigravityCanServeExcluded is the load-bearing drift predicate (scan claude-*/gpt-oss-* keys + catch-all-wildcard probe) that must stay aligned with the post-rollout check ops/antigravity/check-antigravity-account-config.py; weakening it back to a two-id probe re-opens the claude-leak the reconciler exists to close (xj-review R-001)."
+      "rationale": "Per-node in-process self-healer that enforces the operator policy 'Antigravity serves gemini only' on TWO surfaces: (1) accounts — rewrites every antigravity account's credentials.model_mapping to domain.GeminiOnlyAntigravityModelMapping (antigravityCanServeExcluded drift predicate); (2) groups — rewrites every active antigravity group's supported_model_scopes to domain.GeminiOnlyAntigravityModelScopes (antigravityGroupScopesNeedGeminiOnly drift predicate, reconcileGroups), so /antigravity/v1/models + the API key usage guide hide claude for newly-created / drifted groups too. It is a plain-named (non-_tk_) service file that is compile-clean if dropped, so an upstream merge or refactor could silently delete either half and the gemini-only auto-sync would stop with no test failure. Both drift predicates must stay aligned with the post-rollout check ops/antigravity/check-antigravity-account-config.py (accounts + groups same口径); weakening antigravityCanServeExcluded back to a two-id probe re-opens the claude-leak the reconciler exists to close (xj-review R-001); dropping reconcileGroups re-opens claude in /models + usage guide for new groups."
     },
     {
       "path": "backend/internal/domain/constants.go",


### PR DESCRIPTION
## 背景

#776 让 `/antigravity/v1/models` + API key 使用指南按分组 `supported_model_scopes` 隐藏 claude,但**没人把分组 scopes 收成 gemini-only**:新建 antigravity 分组默认 `["claude","gemini_text","gemini_image"]`(migration 046b 列默认含 claude),且 `AntigravityConfigReconciler` 此前只自愈**账号** model_mapping、不碰**分组** scopes,check 脚本也只查账号。所以新建分组仍会展示 claude——账号维全自动、分组维(#776)纯手工无自愈无验证。本 PR 对称补齐。

## 改动

**reconciler(自愈)**
- 新增 `domain.GeminiOnlyAntigravityModelScopes = [gemini_text, gemini_image]`(单一真值源)。
- `runOnce` 拆 `reconcileAccounts` + `reconcileGroups`;后者把每个 **active** antigravity 分组 scopes≠canonical 的自愈为 gemini-only(`antigravityGroupScopesNeedGeminiOnly` 判据:空/含 claude/非规范集都算漂移,顺序无关)。
- 窄 group store **复用** `GroupRepository` 已有的 `ListActiveByPlatform` + `Update`——**不加接口方法、不动 7 个 stub**;group 无 token 类敏感兄弟字段,full-update 可接受,且只在 drift 时写、幂等(对账号必须 partial 是为防清 token,分组没有该约束)。
- 启动即跑 + 周期,与账号同一 ticker / leader-lock / `antigravity_config_reconciler_interval_seconds`(`<=0` 关)。

**check(发版后验证,只读)**
- `ops/antigravity/check-antigravity-account-config.py` 加 `ANTIGRAVITY_GROUPS_SQL` + `_group_violation`:断言每个 active antigravity 分组 scopes 恰为 gemini-only;与 reconciler predicate **同口径**。新 SQL 进 `iter_self_check_sql` → ops-sql 真 PG 自检自动覆盖。已接进 `tokenkey-stage0-release-rollout` skill 的发版后段(无需改 skill,脚本同一入口)。

**覆盖写防护**
- `gateway-tk.json` sentinel 扩锚 `reconcileGroups` / `antigravityGroupScopesNeedGeminiOnly` / `domain.GeminiOnlyAntigravityModelScopes`。

## 效果

新建 antigravity **账号**(model_mapping)**和分组**(scopes)现都自动收敛 gemini-only,发版后同口径验证两者。

## 校验

- `go build ./...` ✓ · `go generate ./cmd/server`(wire 注入 groupRepository)✓ · `golangci-lint` 0 ✓
- service+domain unit ✓(新增 group drift 判据 / 自愈 / nil-safe;5 处 New 调用补 groups 参数)
- `ops/anthropic` 122 tests ✓(test schema 补 `groups.supported_model_scopes` 列;新 SQL 真 PG 执行)
- check `_group_violation` / `_account_violation` 离线断言 ✓
- `scripts/preflight.sh` 全绿(gateway-tk 271/271、ops-sql-coverage、ops-tool-orphan、soft-delete)

## Markers
upstream-touch-guarded
no-web-impact

Reviewer:**Squash and merge**。
