### PR TITLE
fix(usage): persist 7d-Sonnet passively + stop 5h roll wiping 7d window

### DIFF
--- a/backend/internal/service/account_usage_service.go
+++ b/backend/internal/service/account_usage_service.go
@@ -423,6 +423,32 @@ func (s *AccountUsageService) GetUsage(ctx context.Context, accountID int64, for
 	return nil, fmt.Errorf("account type %s does not support usage query", account.Type)
 }
 
+// buildPassiveWindow 从 Extra 的被动采样键重建一个用量窗口（7d / 7d-Sonnet 同构）。
+// utilKey 存 0-1 小数利用率，resetKey 存 Unix 秒重置时间。两者都缺（≤0）时返回 nil，
+// 让调用方把对应窗口留空而不是渲染一个 0% 空窗。
+func buildPassiveWindow(extra map[string]any, utilKey, resetKey string) *UsageProgress {
+	util := parseExtraFloat64(extra[utilKey])
+	resetRaw := parseExtraFloat64(extra[resetKey])
+	if util <= 0 && resetRaw <= 0 {
+		return nil
+	}
+	var resetAt *time.Time
+	var remaining int
+	if resetRaw > 0 {
+		t := time.Unix(int64(resetRaw), 0)
+		resetAt = &t
+		remaining = int(time.Until(t).Seconds())
+		if remaining < 0 {
+			remaining = 0
+		}
+	}
+	return &UsageProgress{
+		Utilization:      util * 100,
+		ResetsAt:         resetAt,
+		RemainingSeconds: remaining,
+	}
+}
+
 // GetPassiveUsage 从 Account.Extra 中的被动采样数据构建 UsageInfo，不调用外部 API。
 // 仅适用于 Anthropic OAuth / SetupToken 账号。
 func (s *AccountUsageService) GetPassiveUsage(ctx context.Context, accountID int64) (*UsageInfo, error) {
@@ -442,47 +468,10 @@ func (s *AccountUsageService) GetPassiveUsage(ctx context.Context, accountID int
 	// 设置采样时间
 	info.UpdatedAt = parseExtraSampledAt(account.Extra["passive_usage_sampled_at"])
 
-	// 构建 7d 窗口（从被动采样数据）
-	util7d := parseExtraFloat64(account.Extra["passive_usage_7d_utilization"])
-	reset7dRaw := parseExtraFloat64(account.Extra["passive_usage_7d_reset"])
-	if util7d > 0 || reset7dRaw > 0 {
-		var resetAt *time.Time
-		var remaining int
-		if reset7dRaw > 0 {
-			t := time.Unix(int64(reset7dRaw), 0)
-			resetAt = &t
-			remaining = int(time.Until(t).Seconds())
-			if remaining < 0 {
-				remaining = 0
-			}
-		}
-		info.SevenDay = &UsageProgress{
-			Utilization:      util7d * 100,
-			ResetsAt:         resetAt,
-			RemainingSeconds: remaining,
-		}
-	}
-
-	// 构建 7d Sonnet 子窗口（从被动采样数据；仅由 active 查询回写，见 syncActiveToPassive）
-	util7dSonnet := parseExtraFloat64(account.Extra["passive_usage_7d_sonnet_utilization"])
-	reset7dSonnetRaw := parseExtraFloat64(account.Extra["passive_usage_7d_sonnet_reset"])
-	if util7dSonnet > 0 || reset7dSonnetRaw > 0 {
-		var resetAt *time.Time
-		var remaining int
-		if reset7dSonnetRaw > 0 {
-			t := time.Unix(int64(reset7dSonnetRaw), 0)
-			resetAt = &t
-			remaining = int(time.Until(t).Seconds())
-			if remaining < 0 {
-				remaining = 0
-			}
-		}
-		info.SevenDaySonnet = &UsageProgress{
-			Utilization:      util7dSonnet * 100,
-			ResetsAt:         resetAt,
-			RemainingSeconds: remaining,
-		}
-	}
+	// 构建 7d 窗口 + 7d Sonnet 子窗口（均从被动采样数据；7d-S 仅由 active 查询回写，
+	// 见 syncActiveToPassive——限流响应头里没有 sonnet 子窗）。
+	info.SevenDay = buildPassiveWindow(account.Extra, "passive_usage_7d_utilization", "passive_usage_7d_reset")
+	info.SevenDaySonnet = buildPassiveWindow(account.Extra, "passive_usage_7d_sonnet_utilization", "passive_usage_7d_sonnet_reset")
 
 	// 添加窗口统计
 	s.addWindowStats(ctx, account, info)

--- a/backend/internal/service/account_usage_service.go
+++ b/backend/internal/service/account_usage_service.go
@@ -463,6 +463,27 @@ func (s *AccountUsageService) GetPassiveUsage(ctx context.Context, accountID int
 		}
 	}
 
+	// 构建 7d Sonnet 子窗口（从被动采样数据；仅由 active 查询回写，见 syncActiveToPassive）
+	util7dSonnet := parseExtraFloat64(account.Extra["passive_usage_7d_sonnet_utilization"])
+	reset7dSonnetRaw := parseExtraFloat64(account.Extra["passive_usage_7d_sonnet_reset"])
+	if util7dSonnet > 0 || reset7dSonnetRaw > 0 {
+		var resetAt *time.Time
+		var remaining int
+		if reset7dSonnetRaw > 0 {
+			t := time.Unix(int64(reset7dSonnetRaw), 0)
+			resetAt = &t
+			remaining = int(time.Until(t).Seconds())
+			if remaining < 0 {
+				remaining = 0
+			}
+		}
+		info.SevenDaySonnet = &UsageProgress{
+			Utilization:      util7dSonnet * 100,
+			ResetsAt:         resetAt,
+			RemainingSeconds: remaining,
+		}
+	}
+
 	// 添加窗口统计
 	s.addWindowStats(ctx, account, info)
 
@@ -472,7 +493,7 @@ func (s *AccountUsageService) GetPassiveUsage(ctx context.Context, accountID int
 // syncActiveToPassive 将主动查询的最新数据回写到 Extra 被动缓存，
 // 这样下次被动加载时能看到最新值。
 func (s *AccountUsageService) syncActiveToPassive(ctx context.Context, accountID int64, usage *UsageInfo) {
-	extraUpdates := make(map[string]any, 4)
+	extraUpdates := make(map[string]any, 6)
 
 	if usage.FiveHour != nil {
 		extraUpdates["session_window_utilization"] = usage.FiveHour.Utilization / 100
@@ -481,6 +502,14 @@ func (s *AccountUsageService) syncActiveToPassive(ctx context.Context, accountID
 		extraUpdates["passive_usage_7d_utilization"] = usage.SevenDay.Utilization / 100
 		if usage.SevenDay.ResetsAt != nil {
 			extraUpdates["passive_usage_7d_reset"] = usage.SevenDay.ResetsAt.Unix()
+		}
+	}
+	// 7d Sonnet 子窗口只来自 active /api/oauth/usage（限流响应头没有 sonnet 子窗），
+	// 必须显式回写，否则点击「查询」拿到的 7d-S 在下次 passive 加载时丢失。
+	if usage.SevenDaySonnet != nil {
+		extraUpdates["passive_usage_7d_sonnet_utilization"] = usage.SevenDaySonnet.Utilization / 100
+		if usage.SevenDaySonnet.ResetsAt != nil {
+			extraUpdates["passive_usage_7d_sonnet_reset"] = usage.SevenDaySonnet.ResetsAt.Unix()
 		}
 	}
 

--- a/backend/internal/service/account_usage_session_window_test.go
+++ b/backend/internal/service/account_usage_session_window_test.go
@@ -2,6 +2,7 @@ package service
 
 import (
 	"context"
+	"math"
 	"sync"
 	"testing"
 	"time"
@@ -131,5 +132,79 @@ func TestSyncActiveToPassive_SkipsSessionWindowEndWhenResetMissing(t *testing.T)
 	defer repo.mu.Unlock()
 	if len(repo.sessionWindowEnds) != 0 {
 		t.Fatalf("expected no UpdateSessionWindowEnd calls when ResetsAt is nil, got %d", len(repo.sessionWindowEnds))
+	}
+}
+
+// TestSyncActiveToPassive_PersistsSevenDaySonnet pins that a manual「查询」(active)
+// result's 7d-Sonnet sub-window is written back to Extra. Without this the only
+// source of 7d-S (the active /api/oauth/usage endpoint) is lost on the next passive
+// load, so the admin "用量窗口" column can never show 7d-S after a refresh.
+func TestSyncActiveToPassive_PersistsSevenDaySonnet(t *testing.T) {
+	t.Parallel()
+
+	repo := &sessionWindowSyncRepo{}
+	svc := &AccountUsageService{accountRepo: repo}
+	sonnetReset := time.Now().Add(5 * 24 * time.Hour).UTC().Truncate(time.Second)
+	svc.syncActiveToPassive(context.Background(), 7, &UsageInfo{
+		FiveHour:       &UsageProgress{Utilization: 17},
+		SevenDay:       &UsageProgress{Utilization: 4},
+		SevenDaySonnet: &UsageProgress{Utilization: 6, ResetsAt: &sonnetReset},
+	})
+
+	repo.mu.Lock()
+	defer repo.mu.Unlock()
+	if len(repo.extraUpdates) != 1 {
+		t.Fatalf("expected 1 UpdateExtra call, got %d", len(repo.extraUpdates))
+	}
+	u := repo.extraUpdates[0]
+	if v, ok := u["passive_usage_7d_sonnet_utilization"].(float64); !ok || math.Abs(v-6.0/100) > 1e-9 {
+		t.Fatalf("expected passive_usage_7d_sonnet_utilization=%v, got %v", 6.0/100, u["passive_usage_7d_sonnet_utilization"])
+	}
+	if v, ok := u["passive_usage_7d_sonnet_reset"].(int64); !ok || v != sonnetReset.Unix() {
+		t.Fatalf("expected passive_usage_7d_sonnet_reset=%d, got %v", sonnetReset.Unix(), u["passive_usage_7d_sonnet_reset"])
+	}
+}
+
+// TestGetPassiveUsage_RebuildsSevenDaySonnet pins the read side: once 7d-S has been
+// persisted (by a prior active query), a passive load rebuilds it so it survives
+// page refresh / 自动刷新.
+func TestGetPassiveUsage_RebuildsSevenDaySonnet(t *testing.T) {
+	t.Parallel()
+
+	sonnetReset := time.Now().Add(5 * 24 * time.Hour).Truncate(time.Second)
+	acct := Account{
+		ID:       8,
+		Platform: PlatformAnthropic,
+		Type:     AccountTypeOAuth,
+		Extra: map[string]any{
+			"passive_usage_7d_utilization":        0.04,
+			"passive_usage_7d_reset":              float64(time.Now().Add(5 * 24 * time.Hour).Unix()),
+			"passive_usage_7d_sonnet_utilization": 0.06,
+			"passive_usage_7d_sonnet_reset":       float64(sonnetReset.Unix()),
+		},
+	}
+	cache := NewUsageCache()
+	// Preseed window-stats cache so addWindowStats never touches a nil usageLogRepo.
+	cache.windowStatsCache.Store(acct.ID, &windowStatsCache{stats: &WindowStats{}, timestamp: time.Now()})
+	svc := &AccountUsageService{
+		accountRepo: stubOpenAIAccountRepo{accounts: []Account{acct}},
+		cache:       cache,
+	}
+
+	info, err := svc.GetPassiveUsage(context.Background(), acct.ID)
+	if err != nil {
+		t.Fatalf("GetPassiveUsage error: %v", err)
+	}
+	if info.SevenDay == nil {
+		t.Fatal("expected SevenDay (overall 7d) to rebuild")
+	}
+	if info.SevenDaySonnet == nil {
+		t.Fatal("expected SevenDaySonnet to be rebuilt from passive extra, got nil")
+	}
+	if math.Abs(info.SevenDaySonnet.Utilization-6) > 1e-9 {
+		t.Fatalf("expected SevenDaySonnet.Utilization=6, got %v", info.SevenDaySonnet.Utilization)
+	}
+	if info.SevenDaySonnet.ResetsAt == nil || info.SevenDaySonnet.ResetsAt.Unix() != sonnetReset.Unix() {
+		t.Fatalf("expected SevenDaySonnet.ResetsAt unix=%d, got %v", sonnetReset.Unix(), info.SevenDaySonnet.ResetsAt)
 	}
 }

--- a/backend/internal/service/ratelimit_service.go
+++ b/backend/internal/service/ratelimit_service.go
@@ -2156,13 +2156,13 @@ func (s *RateLimitService) UpdateSessionWindow(ctx context.Context, account *Acc
 		slog.Info("account_session_window_initialized", "account_id", account.ID, "window_start", start, "window_end", end, "status", status)
 	}
 
-	// 窗口重置时清除旧的 utilization 和被动采样数据，避免残留上个窗口的数据
+	// 5h 窗口重置时只清除 5h 自己的陈旧 utilization，避免新窗口残留上个窗口的高利用率。
+	// 7d 家族（passive_usage_7d_* / passive_usage_7d_sonnet_*）属于独立的 7 天窗口，
+	// 绝不能被 5h 滚动连带清空——否则每天 4-5 次 5h 滚动都会把仍然有效的 7d / 7d-S 抹掉，
+	// UI 出现频繁空窗。7d 的新鲜度由其自身 reset 时间戳治理，并由下次真实流量或主动「查询」覆盖。
 	if windowEnd != nil && needInitWindow {
 		_ = s.accountRepo.UpdateExtra(ctx, account.ID, map[string]any{
-			"session_window_utilization":   nil,
-			"passive_usage_7d_utilization": nil,
-			"passive_usage_7d_reset":       nil,
-			"passive_usage_sampled_at":     nil,
+			"session_window_utilization": nil,
 		})
 	}
 

--- a/backend/internal/service/ratelimit_session_window_test.go
+++ b/backend/internal/service/ratelimit_session_window_test.go
@@ -334,6 +334,21 @@ func TestUpdateSessionWindow_ClearsUtilizationOnWindowReset(t *testing.T) {
 		t.Errorf("expected utilization cleared to nil, got %v", clearCall.Updates["session_window_utilization"])
 	}
 
+	// The 5h roll MUST NOT touch the independent 7d window family — clearing it on
+	// every 5h reset is what made 7d / 7d-S blank ~4-5x/day in the admin UI.
+	if _, ok := clearCall.Updates["passive_usage_7d_utilization"]; ok {
+		t.Errorf("5h roll must not clear passive_usage_7d_utilization")
+	}
+	if _, ok := clearCall.Updates["passive_usage_7d_reset"]; ok {
+		t.Errorf("5h roll must not clear passive_usage_7d_reset")
+	}
+	if _, ok := clearCall.Updates["passive_usage_7d_sonnet_utilization"]; ok {
+		t.Errorf("5h roll must not clear passive_usage_7d_sonnet_utilization")
+	}
+	if len(clearCall.Updates) != 1 {
+		t.Errorf("expected clear call to touch only session_window_utilization, got %v", clearCall.Updates)
+	}
+
 	// Second call: store new utilization
 	storeCall := repo.updateExtraCalls[1]
 	if val, ok := storeCall.Updates["session_window_utilization"].(float64); !ok || val != 0.15 {

--- a/scripts/sentinels/gateway-tk.json
+++ b/scripts/sentinels/gateway-tk.json
@@ -2579,6 +2579,25 @@
         "tkCapabilityScope401ClientMessage(upstreamMsg)"
       ],
       "rationale": "Injection point: handleOpenAIImagesErrorResponse (the actual incident path for POST /v1/images/generations) maps a capability-scope 401 to a client 400 invalid_request_error instead of surfacing the upstream 401 / triggering cooldown. Anchors the image-path client-400 guard against silent upstream-merge reversion."
+    },
+    {
+      "path": "backend/internal/service/account_usage_service.go",
+      "must_contain": [
+        "func buildPassiveWindow(extra map[string]any, utilKey, resetKey string) *UsageProgress {",
+        "info.SevenDaySonnet = buildPassiveWindow(account.Extra, \"passive_usage_7d_sonnet_utilization\", \"passive_usage_7d_sonnet_reset\")",
+        "extraUpdates[\"passive_usage_7d_sonnet_utilization\"] = usage.SevenDaySonnet.Utilization / 100"
+      ],
+      "rationale": "TK 7d-Sonnet passive round-trip (PR #782): seven_day_sonnet has NO anthropic-ratelimit-unified-* header source, so it only comes from the active /api/oauth/usage endpoint. syncActiveToPassive persists it to passive_usage_7d_sonnet_* and GetPassiveUsage rebuilds it via buildPassiveWindow, so the admin 用量窗口 column's 7d-S survives a passive refresh. These touches are compile-clean if dropped; an upstream merge that reverts GetPassiveUsage / syncActiveToPassive would silently make 7d-S vanish on refresh again. Anchors all three legs (helper + rebuild + persist)."
+    },
+    {
+      "path": "backend/internal/service/ratelimit_service.go",
+      "must_contain": [
+        "5h 窗口重置时只清除 5h 自己的陈旧 utilization"
+      ],
+      "must_not_contain": [
+        "\"passive_usage_7d_utilization\": nil"
+      ],
+      "rationale": "TK fix (PR #782): on a 5h session-window roll (needInitWindow) UpdateSessionWindow must clear ONLY session_window_utilization, never the independent 7d family (passive_usage_7d_* / passive_usage_7d_sonnet_*). The pre-fix code cleared the 7d keys as nil on every 5h roll (4-5x/day), blanking the admin 7d / 7d-S windows until new traffic re-sampled the header. must_contain pins the fixed comment; must_not_contain catches an upstream merge that re-introduces the 7d nil-clear — the bare key still legitimately appears in the header-sampling block as an index assignment (extraUpdates[...] = ts), so the map-literal `: nil` form is the revert-specific signal."
     }
   ]
 }


### PR DESCRIPTION
## 问题

Anthropic OAuth 账号在 `/admin/accounts` 的「用量窗口」列,刷新后只剩 5h,**7 天剩余量 + 7 天 s 剩余量看不到**(截图复现)。

## 线上真值定位(uk1 edge)

- 上游 `GET /api/oauth/usage` 返回 200,三窗口齐全:`five_hour` / `seven_day` / `seven_day_sonnet`(均带 `resets_at`)→ **active「查询」路径本身是好的**。
- 限流响应头只有 `anthropic-ratelimit-unified-5h-*` 和 `-7d-*`,**没有 sonnet 子窗头** → 7d-S 只能来自 active `/usage`。
- DB Extra 里 `passive_usage_7d_*` 存在但 5h 显示 0%(窗口刚过期)→ 暴露了 5h 滚动清空 7d 的 bug。

## 两个后端根因 + 修复

1. **7d-S 从不被 passive 持久化** — `syncActiveToPassive` 不回写 `SevenDaySonnet`、`GetPassiveUsage` 不重建它,所以点「查询」拿到的 7d-S 在下次 passive 加载即丢失。
   → 新增 `passive_usage_7d_sonnet_utilization/_reset` 回写 + 重建。
2. **5h 滚动连带清空独立的 7d 窗口** — `UpdateSessionWindow` 在 `needInitWindow` 时把 `passive_usage_7d_*` 一起清 nil;5h 每天滚 4-5 次,每次抹掉仍有效的 7d/7d-S,直到下次流量重采头。
   → 滚动时只清 `session_window_utilization`,保留 7d 家族。

## 行为

点一次每行「查询」(真实打上游)→ 5h/7d/7d-S 全显示且落库 → 之后页面刷新 / 自动刷新(passive)继续显示,不再被 5h 滚动抹掉。**不引入后台定期轮询。**

边界:7d-S 因上游无 sonnet 头,只能靠点一次「查询」首次填充,填充后持久;5h/7d 仍由真实流量被动采样 + 「查询」双路保鲜。前端 `AccountUsageCell.vue` 已有 `7d` / `7d S` 渲染分支,无需改前端。

## 测试 / 门禁

- 新增 `TestSyncActiveToPassive_PersistsSevenDaySonnet`、`TestGetPassiveUsage_RebuildsSevenDaySonnet`;强化 `TestUpdateSessionWindow_ClearsUtilizationOnWindowReset` 钉死「5h 滚动不得触碰 7d 家族」。
- `go test -tags=unit ./internal/service/ ./internal/repository/` 全绿;`golangci-lint` 0 issues;`go build ./...` OK;`scripts/preflight.sh` PASS。
- commit 携带 `upstream-touch-guarded`(动到 upstream-shaped 的 `ratelimit_service.go` / `account_usage_service.go`)+ `no-web-impact`。

合并方式:§5.y TK PR → **Squash and merge**。

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---

---

### 上游 merge 覆盖写防护(sentinel 锚点)

本 PR 在 upstream-shaped 文件里新增的 TK 行,已在 `scripts/sentinels/gateway-tk.json` 加 sentinel 锚点(替代上一轮的 `sentinel-registry-reviewed` 人工确认,升级为机械防护):

- `account_usage_service.go`:`buildPassiveWindow` helper + 7d-S 重建行 + 7d-S 回写行(must_contain 三腿)。
- `ratelimit_service.go`:5h 滚动只清 5h utilization 的修复 —— must_contain 钉死修复注释,**must_not_contain `"passive_usage_7d_utilization": nil`** 直接拦截「上游 merge 把 7d nil-clear 写回来」。

`check-gateway-tk.py` 跑在 preflight(每个 PR + 本地 pre-commit)与 `upstream-merge-pr-shape.yml`,故将来 upstream merge 覆盖/还原这些 TK 行会被 FAIL 拦住。当前 274/274 intact。

