### PR TITLE
feat(antigravity): post-rollout check asserts account↔group binding

### DIFF
--- a/ops/antigravity/check-antigravity-account-config.py
+++ b/ops/antigravity/check-antigravity-account-config.py
@@ -6,19 +6,23 @@ routed to anthropic, gpt-oss off antigravity) across all deployable edges + prod
 on BOTH surfaces the backend ``AntigravityConfigReconciler`` self-heals:
 
   1. **accounts** — every ``platform=antigravity`` account carries a gemini-only
-     ``credentials.model_mapping`` (no ``claude-*`` / ``gpt-oss-*`` keys).
+     ``credentials.model_mapping`` (no ``claude-*`` / ``gpt-oss-*`` keys), AND any
+     active+schedulable account is bound to an antigravity group (account_groups).
   2. **groups** — every active ``platform=antigravity`` group carries gemini-only
      ``supported_model_scopes`` (exactly ``[gemini_text, gemini_image]``), so
      ``/antigravity/v1/models`` + the API key usage guide hide claude.
 
-The reconciler self-heals both on every node (boot + tick). This tool is the
-post-rollout *verification* that the self-heal converged fleet-wide.
+The reconciler self-heals the gemini-only config on every node (boot + tick); the
+group binding is a one-time provisioning step the reconciler does NOT heal, so this
+tool is the only safety net for it. This tool is the post-rollout *verification*.
 
 A **violation** is any antigravity account whose ``model_mapping`` is null/empty
 (an empty map falls back to ``DefaultAntigravityModelMapping``, which still
-includes claude + gpt-oss) or contains any ``claude-`` / ``gpt-oss-`` key; OR any
-active antigravity group whose ``supported_model_scopes`` is empty (unrestricted →
-advertises claude) or not exactly the gemini-only set.
+includes claude + gpt-oss) or contains any ``claude-`` / ``gpt-oss-`` key, OR an
+active+schedulable account with no antigravity-group binding (account_groups missing
+→ scheduler "No available accounts" 429: looks ready but silently never serves); OR
+any active antigravity group whose ``supported_model_scopes`` is empty (unrestricted
+→ advertises claude) or not exactly the gemini-only set.
 
 Exit codes (mirrors the anthropic post-release check): ``0`` = all gemini-only
 (green); ``1`` = violations found (yellow, non-blocking at rollout); ``2`` = could
@@ -45,8 +49,12 @@ PROD_TARGET = {"region": "us-east-1", "stack": "tokenkey-prod-stage0", "label": 
 # + correctness: soft-deleted rows are not served).
 ANTIGRAVITY_ACCOUNTS_SQL = (
     "SELECT COALESCE(json_agg(json_build_object("
-    "'id', id, 'name', name, 'model_mapping', credentials->'model_mapping'))::text, '[]') "
-    "FROM accounts WHERE platform = 'antigravity' AND deleted_at IS NULL;"
+    "'id', a.id, 'name', a.name, 'model_mapping', a.credentials->'model_mapping', "
+    "'status', a.status, 'schedulable', a.schedulable, "
+    "'bound', EXISTS(SELECT 1 FROM account_groups ag JOIN groups g ON g.id = ag.group_id "
+    "WHERE ag.account_id = a.id AND g.platform = 'antigravity' AND g.deleted_at IS NULL)"
+    "))::text, '[]') "
+    "FROM accounts a WHERE a.platform = 'antigravity' AND a.deleted_at IS NULL;"
 )
 
 # Active antigravity groups + their supported_model_scopes. status='active' mirrors
@@ -138,14 +146,32 @@ def ssm_run_sql(region: str, instance_id: str, sql: str, comment: str) -> str:
 
 
 def _account_violation(row: dict) -> str | None:
-    """Return a human reason if the account is NOT gemini-only, else None."""
+    """Return a human reason if the account is misconfigured, else None.
+
+    Two independent checks (both reported if both fail):
+      1. gemini-only model_mapping (no claude-* / gpt-oss-* keys, non-empty).
+      2. group binding — an active+schedulable account MUST be bound to an
+         antigravity group via account_groups, else the scheduler finds no
+         account for that group and fast-fails every request with
+         "No available accounts" 429 (the account looks ready but silently
+         never serves). This binding is a provisioning step the reconciler does
+         NOT self-heal, so the post-rollout check is the only safety net.
+    """
+    reasons: list[str] = []
+
     mm = row.get("model_mapping")
     if not mm or not isinstance(mm, dict):
-        return "empty/missing model_mapping (falls back to default → serves claude/gpt-oss)"
-    leaked = sorted(k for k in mm if k.startswith("claude-") or k.startswith("gpt-oss-"))
-    if leaked:
-        return "serves excluded models: " + ", ".join(leaked)
-    return None
+        reasons.append("empty/missing model_mapping (falls back to default → serves claude/gpt-oss)")
+    else:
+        leaked = sorted(k for k in mm if k.startswith("claude-") or k.startswith("gpt-oss-"))
+        if leaked:
+            reasons.append("serves excluded models: " + ", ".join(leaked))
+
+    if row.get("status") == "active" and row.get("schedulable") and not row.get("bound"):
+        reasons.append("active+schedulable but NOT bound to any antigravity group "
+                       "(account_groups missing → scheduler 'No available accounts' 429)")
+
+    return "; ".join(reasons) if reasons else None
 
 
 def _group_violation(row: dict) -> str | None:

--- a/ops/antigravity/test_check_antigravity_account_config.py
+++ b/ops/antigravity/test_check_antigravity_account_config.py
@@ -43,6 +43,46 @@ class AccountViolationTest(unittest.TestCase):
         self.assertIn("claude-opus-4-8", r)
         self.assertIsNotNone(CHK._account_violation({"model_mapping": {"gpt-oss-120b-medium": "x"}}))
 
+    def _gemini_only_mm(self):
+        return {"gemini-3-flash": "gemini-3-flash"}
+
+    def test_active_schedulable_unbound_is_violation(self):
+        # the us4 gap: healthy gemini-only account but no account_groups binding.
+        r = CHK._account_violation({
+            "model_mapping": self._gemini_only_mm(),
+            "status": "active", "schedulable": True, "bound": False,
+        })
+        self.assertIsNotNone(r)
+        self.assertIn("not bound", r.lower())
+
+    def test_active_schedulable_bound_is_clean(self):
+        self.assertIsNone(CHK._account_violation({
+            "model_mapping": self._gemini_only_mm(),
+            "status": "active", "schedulable": True, "bound": True,
+        }))
+
+    def test_parked_account_unbound_is_not_flagged(self):
+        # schedulable=false (intentionally parked) → binding not required, no false flag.
+        self.assertIsNone(CHK._account_violation({
+            "model_mapping": self._gemini_only_mm(),
+            "status": "active", "schedulable": False, "bound": False,
+        }))
+
+    def test_inactive_unbound_is_not_flagged(self):
+        self.assertIsNone(CHK._account_violation({
+            "model_mapping": self._gemini_only_mm(),
+            "status": "inactive", "schedulable": True, "bound": False,
+        }))
+
+    def test_bad_mapping_and_unbound_reports_both(self):
+        r = CHK._account_violation({
+            "model_mapping": {"claude-opus-4-8": "x"},
+            "status": "active", "schedulable": True, "bound": False,
+        })
+        self.assertIsNotNone(r)
+        self.assertIn("claude-opus-4-8", r)
+        self.assertIn("not bound", r.lower())
+
 
 class GroupViolationTest(unittest.TestCase):
     def test_canonical_gemini_only_clean(self):


### PR DESCRIPTION
## 背景

实测 us4 新中继链路时暴露的真实缺口:新建 antigravity OAuth 账号(id=5,健康/gemini-only/schedulable/token 齐),但 operator 漏了把账号绑定到 antigravity 分组(`account_groups` junction 行缺失)。后果——分组调度找不到任何账号,**每个请求 `No available accounts` 429,账号看着 ready 却静默永不服务**(`/models` 能通因为它不走账号调度,极具迷惑性)。

这是一次性 **provisioning** 步骤(应走 admin UI 的 BindAccountsToGroup),`AntigravityConfigReconciler` **不自愈**(它只管 model_mapping + 分组 scopes 的 gemini-only)。所以发版后 check 是这条的**唯一安全网**。

## 改动(`ops/antigravity/check-antigravity-account-config.py`)

- `ANTIGRAVITY_ACCOUNTS_SQL` 增 `status` / `schedulable` / `bound`(`EXISTS(account_groups JOIN groups WHERE platform='antigravity')`)。
- `_account_violation` 加第二项检查(两项独立、都报):**active+schedulable 账号无 antigravity-group 绑定 = 违规**。`schedulable=false`(有意 park)与 `inactive` 不误报。
- docstring 同步。

## 校验

- 离线单测 +5 例(`ops/antigravity/test_check_antigravity_account_config.py`,共 15):unbound 违规 / bound 干净 / parked 不报 / inactive 不报 / 坏映射+unbound 双报 ✓
- ops-sql 真 PG 自检覆盖新 SQL(`account_groups` JOIN;test schema 已有该表 + `schedulable` 列)✓
- `scripts/preflight.sh` 全绿(ops-sql-coverage / ops-tool-orphan / no existence-only)

## Markers
no-web-impact

Reviewer:**Squash and merge**。
