### PR TITLE
fix(antigravity): surface supported_model_scopes on user keys DTO so usage guide hides Claude for gemini-only groups

### DIFF
--- a/backend/internal/handler/dto/group_mapper_scopes_test.go
+++ b/backend/internal/handler/dto/group_mapper_scopes_test.go
@@ -1,0 +1,72 @@
+package dto
+
+import (
+	"encoding/json"
+	"testing"
+
+	"github.com/Wei-Shaw/sub2api/internal/service"
+	"github.com/stretchr/testify/require"
+)
+
+// TestGroupFromService_UserPathCarriesSupportedModelScopes locks the fix for the
+// antigravity usage-guide gap: the user-facing keys DTO (GroupFromService /
+// APIKeyFromService.Group) MUST surface supported_model_scopes so UseKeyModal can
+// hide the Claude flavor for gemini-only antigravity groups. The field used to live
+// only on AdminGroup, so the user path returned it as undefined and the guide always
+// showed Claude.
+func TestGroupFromService_UserPathCarriesSupportedModelScopes(t *testing.T) {
+	src := &service.Group{
+		ID:                   7,
+		Name:                 "antigravity-gemini-only",
+		Platform:             "antigravity",
+		SupportedModelScopes: []string{"gemini_text", "gemini_image"},
+	}
+
+	// Direct user-path group mapper.
+	g := GroupFromService(src)
+	require.NotNil(t, g)
+	require.Equal(t, []string{"gemini_text", "gemini_image"}, g.SupportedModelScopes)
+
+	// Nested under a user API key (the shape KeysView actually consumes).
+	key := APIKeyFromService(&service.APIKey{ID: 1, UserID: 2, Key: "sk-scopes", Group: src})
+	require.NotNil(t, key.Group)
+	require.Equal(t, []string{"gemini_text", "gemini_image"}, key.Group.SupportedModelScopes)
+
+	// JSON must include the snake_case field so the frontend prop is populated.
+	b, err := json.Marshal(key.Group)
+	require.NoError(t, err)
+	require.Contains(t, string(b), `"supported_model_scopes":["gemini_text","gemini_image"]`)
+}
+
+// TestGroupFromServiceAdmin_StillCarriesSupportedModelScopes guards that moving the
+// field down to the embedded base Group did not drop it from the admin DTO (admin
+// inherits it via embedding rather than an explicit field).
+func TestGroupFromServiceAdmin_StillCarriesSupportedModelScopes(t *testing.T) {
+	src := &service.Group{
+		ID:                   8,
+		Name:                 "antigravity-admin",
+		Platform:             "antigravity",
+		SupportedModelScopes: []string{"gemini_text", "gemini_image"},
+	}
+
+	ag := GroupFromServiceAdmin(src)
+	require.NotNil(t, ag)
+	require.Equal(t, []string{"gemini_text", "gemini_image"}, ag.SupportedModelScopes)
+
+	b, err := json.Marshal(ag)
+	require.NoError(t, err)
+	require.Contains(t, string(b), `"supported_model_scopes":["gemini_text","gemini_image"]`)
+}
+
+// TestGroupFromService_EmptyScopesOmitted verifies the back-compat shape: a group
+// with no scopes (unrestricted) omits the field, so the frontend gate treats it as
+// "show all flavors" exactly as before #776.
+func TestGroupFromService_EmptyScopesOmitted(t *testing.T) {
+	g := GroupFromService(&service.Group{ID: 9, Name: "unrestricted", Platform: "antigravity"})
+	require.NotNil(t, g)
+	require.Empty(t, g.SupportedModelScopes)
+
+	b, err := json.Marshal(g)
+	require.NoError(t, err)
+	require.NotContains(t, string(b), "supported_model_scopes")
+}

--- a/backend/internal/handler/dto/mappers.go
+++ b/backend/internal/handler/dto/mappers.go
@@ -150,12 +150,12 @@ func GroupFromServiceAdmin(g *service.Group) *AdminGroup {
 		DefaultMappedModel:          g.DefaultMappedModel,
 		MessagesDispatchModelConfig: g.MessagesDispatchModelConfig,
 		ModelsListConfig:            g.ModelsListConfig,
-		SupportedModelScopes:        g.SupportedModelScopes,
-		AccountCount:                g.AccountCount,
-		ActiveAccountCount:          g.ActiveAccountCount,
-		RateLimitedAccountCount:     g.RateLimitedAccountCount,
-		SortOrder:                   g.SortOrder,
-		StickyRoutingMode:           g.StickyRoutingMode,
+		// SupportedModelScopes 现由内嵌 Group（groupFromServiceBase）填充。
+		AccountCount:            g.AccountCount,
+		ActiveAccountCount:      g.ActiveAccountCount,
+		RateLimitedAccountCount: g.RateLimitedAccountCount,
+		SortOrder:               g.SortOrder,
+		StickyRoutingMode:       g.StickyRoutingMode,
 	}
 	if len(g.AccountGroups) > 0 {
 		out.AccountGroups = make([]AccountGroup, 0, len(g.AccountGroups))
@@ -195,6 +195,7 @@ func groupFromServiceBase(g *service.Group) Group {
 		RPMLimit:                               g.RPMLimit,
 		MessagesCompactionEnabled:              g.MessagesCompactionEnabled,
 		MessagesCompactionInputTokensThreshold: g.MessagesCompactionInputTokensThreshold,
+		SupportedModelScopes:                   g.SupportedModelScopes,
 		CreatedAt:                              g.CreatedAt,
 		UpdatedAt:                              g.UpdatedAt,
 	}

--- a/backend/internal/handler/dto/types.go
+++ b/backend/internal/handler/dto/types.go
@@ -125,6 +125,11 @@ type Group struct {
 	MessagesCompactionEnabled              *bool `json:"messages_compaction_enabled"`
 	MessagesCompactionInputTokensThreshold *int  `json:"messages_compaction_input_tokens_threshold"`
 
+	// 支持的模型系列（仅 antigravity 平台使用）。用户侧 keys 接口也需返回，供
+	// UseKeyModal 使用指南据此隐藏 gemini-only 分组的 Claude flavor（与后端
+	// /antigravity/v1/models 的 scope 过滤同源）。空 = 不限制。
+	SupportedModelScopes []string `json:"supported_model_scopes,omitempty"`
+
 	CreatedAt time.Time `json:"created_at"`
 	UpdatedAt time.Time `json:"updated_at"`
 }
@@ -146,8 +151,8 @@ type AdminGroup struct {
 	MessagesDispatchModelConfig domain.OpenAIMessagesDispatchModelConfig `json:"messages_dispatch_model_config"`
 	ModelsListConfig            domain.GroupModelsListConfig             `json:"models_list_config"`
 
-	// 支持的模型系列（仅 antigravity 平台使用）
-	SupportedModelScopes    []string       `json:"supported_model_scopes"`
+	// 注：SupportedModelScopes 已上移到基础 Group（用户侧 keys DTO 也返回），
+	// AdminGroup 经内嵌 Group 继承，无需在此重复声明。
 	AccountGroups           []AccountGroup `json:"account_groups,omitempty"`
 	AccountCount            int64          `json:"account_count,omitempty"`
 	ActiveAccountCount      int64          `json:"active_account_count,omitempty"`

--- a/scripts/sentinels/gateway-tk.json
+++ b/scripts/sentinels/gateway-tk.json
@@ -1637,6 +1637,21 @@
       "rationale": "supported_model_scopes 的请求路径 enforcement（首次落地，PR 后续）：/antigravity/v1/models 经 AntigravityModels handler 调用 tkAntigravityFilterModelsByGroupScopes 按分组 supported_model_scopes（claude / gemini_text / gemini_image）过滤已宣告模型，使 gemini-only 分组（[gemini_text, gemini_image]）从 /models 隐藏 claude，与 per-account gemini-only model_mapping + 前端 UseKeyModal 的 claude-flavor gate 同口径。antigravityModelScope 是 model→scope 归类器（claude-/gpt-oss-/含 image/其余=gemini_text），与前端分类镜像。上游 merge 若删除这两个函数或 AntigravityModels 里的过滤调用，/models 会静默回退到含 claude 的全目录——本 sentinel 守护。"
     },
     {
+      "path": "backend/internal/handler/dto/types.go",
+      "must_contain": [
+        "json:\"supported_model_scopes,omitempty\""
+      ],
+      "rationale": "supported_model_scopes 的用户侧呈现路径（PR #784）—— 字段必须挂在基础 Group DTO（带 omitempty），而非仅 AdminGroup：用户 keys 接口经 APIKeyFromService → GroupFromServiceShallow → groupFromServiceBase 序列化基础 Group，只有该字段在基础 Group 上，前端 KeysView/UseKeyModal 才拿得到 supported_model_scopes，进而对 gemini-only antigravity 分组隐藏 Claude flavor（与 gateway-tk 的 tkAntigravityFilterModelsByGroupScopes /models 过滤、reconcileGroups 自愈、per-account gemini-only model_mapping 同口径）。dto/types.go 是 upstream-shaped（Wei-Shaw/sub2api 原版仅在 AdminGroup 上有该字段、且无 omitempty），一次 git merge upstream/main 可能把该字段从基础 Group 移回 AdminGroup 或整体覆盖，使用户路径静默回退到 undefined → 前端 gate 默认放行 → 使用指南重新出现 antigravity-claude tab，且 admin 路径仍正常、无测试失败（正是本 sentinel 守护的 backward-drift）。锚 `json:\"supported_model_scopes,omitempty\"` 唯一标识基础 Group 上的该字段形态（AdminGroup 旧版用无 omitempty 的 tag）。配套 mappers.go 的 groupFromServiceBase 填充锚。"
+    },
+    {
+      "path": "backend/internal/handler/dto/mappers.go",
+      "must_contain": [
+        "func groupFromServiceBase(",
+        "SupportedModelScopes:"
+      ],
+      "rationale": "承接 dto/types.go 的 supported_model_scopes 用户侧呈现锚（PR #784）：基础 Group struct 有字段还不够，groupFromServiceBase 必须把 service.Group.SupportedModelScopes 填进基础 Group DTO，用户 keys 路径才会真正返回它（否则 omitempty 恒省略 → 前端 gate 失效、指南重新显示 antigravity-claude）。SupportedModelScopes 赋值现仅存在于 groupFromServiceBase（已从 GroupFromServiceAdmin 移除，admin 经内嵌 Group 继承）。dto/mappers.go 是 upstream-shaped、且上游从无此字段，一次 git merge upstream/main 整体覆盖该文件会让 `SupportedModelScopes:` 赋值消失而编译照常通过、admin 路径不受影响、无测试失败 —— 本 sentinel 守护该 backward-drift。"
+    },
+    {
       "path": "backend/internal/service/wire.go",
       "must_contain": [
         "func ProvideAntigravityConfigReconciler(",


### PR DESCRIPTION
## Problem

去掉 antigravity 分组的 claude(把 group `supported_model_scopes` 设为 gemini-only)后,**使用指南(UseKeyModal)里仍然显示 antigravity-claude 的 Claude Code tab + OpenCode `antigravity-claude` provider**。

根因是 display 路径 vs guard 路径不对称:
- 前端 gate `antigravityClaudeAllowed`(`UseKeyModal.vue`)按 `group.supported_model_scopes` 是否含 `claude` 来隐藏 Claude flavor;
- 但**用户侧 keys DTO 从不序列化该字段** —— 它只在 `AdminGroup` 上,基础 `dto.Group` / `groupFromServiceBase`(用户 keys 走 `APIKeyFromService → GroupFromServiceShallow → groupFromServiceBase`)没有;
- 于是用户路径拿到的 `supported_model_scopes` 恒为 `undefined` → gate 默认「不限制」→ 即便 gemini-only 分组,指南照样显示 Claude。

这与后端 `/antigravity/v1/models` 的 scope 过滤、以及逐账号 gemini-only `model_mapping` 都矛盾(那两条路径本就正确隐藏 claude,只有指南这条「读」路径漏了)。纯 UX 不一致,无安全/计费影响。

## Fix

- 把 `SupportedModelScopes` 从 `AdminGroup` **下移到内嵌的基础 `Group`**(与 #776 的前端 `types/index.ts` 形状对齐);`AdminGroup` 经内嵌继承,admin DTO/JSON 不变。
- `groupFromServiceBase` 填充该字段,用户侧 keys 接口从此返回 `supported_model_scopes`,前端 gate 生效。
- 加回归测试:用户路径携带、admin 路径仍携带、空 scopes 走 omitempty 向后兼容三态。

## Validation

- `go build ./...`(跨 new-api)OK
- `go test -tags=unit ./internal/handler/... ./internal/service/... ./internal/server/...` 全过(含新增 dto 回归测试)
- `golangci-lint run ./internal/handler/dto/...` 0 issues
- `scripts/preflight.sh` PASS

## Markers

upstream-touch-guarded — 改动 `dto/types.go` + `dto/mappers.go`(upstream-shaped),为字段下移 + 映射,行为对 admin 路径无变更,对用户路径补齐缺失字段。
no-upstream-deletion — 无 upstream 符号删除(字段下移 + 内嵌继承)。
no-web-impact — 未改前端源码(#776 已落前端消费侧),无需 rebuild 嵌入 dist。

## Rollout note

需发一版才能让线上指南正确隐藏(本仓库当前 prod/edge 已在 v1.8.4;此 fix 进下一版)。

🤖 Generated with [Claude Code](https://claude.com/claude-code)