### PR TITLE
fix(studio): modality-aware key picker so Studio lands on an image/video-serving group

### DIFF
--- a/backend/internal/web/dist/frontend-source.json
+++ b/backend/internal/web/dist/frontend-source.json
@@ -1,7 +1,7 @@
 {
   "algorithm": "sha256(git-ls-files:path,size,content)",
   "file_count": 477,
-  "hash": "7ea34a79ec937e48262a06f6fe1ceb514eaac36ccf2a55507676ec080d671b34",
+  "hash": "9c3f81e968df06dcdf9e778ee9ae32ecd10cd0b8b6021cb732e4edcdc67f65d9",
   "schema": 1,
   "source": "frontend/"
 }

--- a/backend/internal/web/dist/frontend-source.json
+++ b/backend/internal/web/dist/frontend-source.json
@@ -1,7 +1,7 @@
 {
   "algorithm": "sha256(git-ls-files:path,size,content)",
-  "file_count": 482,
-  "hash": "856da3f1e7089341faa749aa05d1c28fc8e09ad44284baa54f76969328b18fdc",
+  "file_count": 483,
+  "hash": "b04a6266f03dbbc25f9c424570ee1c0e518fb758021762e4d482e5e81e12c886",
   "schema": 1,
   "source": "frontend/"
 }

--- a/backend/internal/web/dist/frontend-source.json
+++ b/backend/internal/web/dist/frontend-source.json
@@ -1,7 +1,7 @@
 {
   "algorithm": "sha256(git-ls-files:path,size,content)",
-  "file_count": 477,
-  "hash": "9c3f81e968df06dcdf9e778ee9ae32ecd10cd0b8b6021cb732e4edcdc67f65d9",
+  "file_count": 482,
+  "hash": "856da3f1e7089341faa749aa05d1c28fc8e09ad44284baa54f76969328b18fdc",
   "schema": 1,
   "source": "frontend/"
 }

--- a/backend/internal/web/dist/frontend-source.json
+++ b/backend/internal/web/dist/frontend-source.json
@@ -1,7 +1,7 @@
 {
   "algorithm": "sha256(git-ls-files:path,size,content)",
-  "file_count": 482,
-  "hash": "d1a6355b5a3ce3898d096db723bfe19e8eeecfe441f78dfc5f51efb9544cdbcc",
+  "file_count": 477,
+  "hash": "7ea34a79ec937e48262a06f6fe1ceb514eaac36ccf2a55507676ec080d671b34",
   "schema": 1,
   "source": "frontend/"
 }

--- a/frontend/src/constants/__tests__/mediaTiers.tk.spec.ts
+++ b/frontend/src/constants/__tests__/mediaTiers.tk.spec.ts
@@ -1,0 +1,74 @@
+import { describe, it, expect } from 'vitest'
+import {
+  modalityHasTiers,
+  pickModalityKey,
+  resolveAvailableTiers,
+  type ModalityKeyOption,
+} from '@/constants/mediaTiers.tk'
+
+// A Vertex group serves the imagen image tiers + the veo cinematic video tier.
+const IMAGEN = new Set(['imagen-4.0-fast-generate-001', 'imagen-4.0-generate-001'])
+const VEO = new Set(['veo-3.1-generate-001'])
+// An antigravity/gemini-text group serves none of the studio media tiers.
+const ANTIGRAVITY = new Set(['claude-sonnet-4-5', 'gemini-3-flash'])
+
+describe('modalityHasTiers', () => {
+  it('is true when the pool backs at least one tier', () => {
+    expect(modalityHasTiers('image', IMAGEN)).toBe(true)
+    expect(modalityHasTiers('video', VEO)).toBe(true)
+  })
+
+  it('is false for a pool with no backing model', () => {
+    expect(modalityHasTiers('image', ANTIGRAVITY)).toBe(false)
+    expect(modalityHasTiers('video', ANTIGRAVITY)).toBe(false)
+    expect(modalityHasTiers('image', VEO)).toBe(false) // veo backs video only
+    expect(modalityHasTiers('video', IMAGEN)).toBe(false)
+    expect(modalityHasTiers('image', new Set())).toBe(false)
+  })
+
+  it('agrees with resolveAvailableTiers', () => {
+    expect(modalityHasTiers('image', IMAGEN)).toBe(resolveAvailableTiers('image', IMAGEN).length > 0)
+  })
+})
+
+function opt(id: number, isTrial: boolean, availableIds: Set<string>): ModalityKeyOption {
+  return { id, isTrial, availableIds }
+}
+
+describe('pickModalityKey', () => {
+  it('returns currentId unchanged when no options', () => {
+    expect(pickModalityKey([], 'image', 7)).toBe(7)
+    expect(pickModalityKey([], 'image', null)).toBe(null)
+  })
+
+  it('keeps the current key when it already serves the modality', () => {
+    const opts = [opt(1, false, ANTIGRAVITY), opt(2, false, IMAGEN)]
+    expect(pickModalityKey(opts, 'image', 2)).toBe(2)
+  })
+
+  it('moves off a non-serving current key to a serving one', () => {
+    // The prod regression: bootstrap seeded the antigravity key (1); image needs
+    // the imagen group (2).
+    const opts = [opt(1, true, ANTIGRAVITY), opt(2, false, IMAGEN)]
+    expect(pickModalityKey(opts, 'image', 1)).toBe(2)
+  })
+
+  it('prefers a trial-named serving key over the first serving key', () => {
+    const opts = [opt(1, false, IMAGEN), opt(2, true, IMAGEN)]
+    expect(pickModalityKey(opts, 'image', null)).toBe(2)
+  })
+
+  it('re-targets per modality (image vs video live on different groups)', () => {
+    const opts = [opt(1, false, IMAGEN), opt(2, false, VEO)]
+    expect(pickModalityKey(opts, 'image', null)).toBe(1)
+    expect(pickModalityKey(opts, 'video', null)).toBe(2)
+  })
+
+  it('falls back to the seed/global default when nothing serves the modality', () => {
+    const opts = [opt(1, false, ANTIGRAVITY), opt(2, true, ANTIGRAVITY)]
+    // current seed kept so the UI still shows an honest empty state
+    expect(pickModalityKey(opts, 'image', 1)).toBe(1)
+    // no seed → trial-named key, else first
+    expect(pickModalityKey(opts, 'image', null)).toBe(2)
+  })
+})

--- a/frontend/src/constants/mediaTiers.tk.ts
+++ b/frontend/src/constants/mediaTiers.tk.ts
@@ -151,6 +151,57 @@ export function resolveAvailableTiers(
 }
 
 /**
+ * True when this model pool backs at least one tier of the modality — i.e. the
+ * Studio tab is actually usable for a key whose group exposes `availableIds`.
+ */
+export function modalityHasTiers(
+  modality: StudioModality,
+  availableIds: ReadonlySet<string>
+): boolean {
+  return resolveAvailableTiers(modality, availableIds).length > 0
+}
+
+/** One selectable key, reduced to what the modality-aware picker needs. */
+export interface ModalityKeyOption {
+  id: number
+  /** A key literally named "trial" is the historical default landing key. */
+  isTrial: boolean
+  /** Model ids exposed by this key's group (its GET /v1/models pool). */
+  availableIds: ReadonlySet<string>
+}
+
+/**
+ * Pick the key the Studio should land on for `modality`.
+ *
+ * The Studio tab is dead unless the selected key's GROUP serves the modality —
+ * image (Vertex/gemini), seedream-image (VolcEngine/newapi) and the video tiers
+ * each live on a different platform group, so a single key rarely serves all
+ * three. The historical bootstrap grabbed `trial`/`keys[0]` blind to modality,
+ * which on prod routinely landed on an antigravity key with no image models
+ * (the "当前分组暂无可用的图片模型" dead-end). This makes the choice modality-aware:
+ *
+ *  1. keep `currentId` when it already serves the modality (respect the user's
+ *     explicit selection, and keep the e2e's imagen-serving default stable);
+ *  2. else prefer a serving key — `trial` first, then the first serving key;
+ *  3. else fall back to `currentId`, then the global `trial`/first key, so the
+ *     UI still has a selection and shows the honest empty state.
+ */
+export function pickModalityKey(
+  options: readonly ModalityKeyOption[],
+  modality: StudioModality,
+  currentId: number | null
+): number | null {
+  if (options.length === 0) return currentId
+  const serving = options.filter((o) => modalityHasTiers(modality, o.availableIds))
+  if (currentId != null && serving.some((o) => o.id === currentId)) return currentId
+  const pickServing = serving.find((o) => o.isTrial) ?? serving[0]
+  if (pickServing) return pickServing.id
+  if (currentId != null) return currentId
+  const fallback = options.find((o) => o.isTrial) ?? options[0]
+  return fallback ? fallback.id : null
+}
+
+/**
  * Image aspect/size presets. We send only sizes the current gateway path is
  * proven to accept (the existing playground set), and surface each preset's
  * CLASSIFIED billing tier + multiplier (mirrored client-side) so pricing stays

--- a/frontend/src/i18n/locales/en.ts
+++ b/frontend/src/i18n/locales/en.ts
@@ -171,7 +171,6 @@ export default {
     apiKey: 'API Key',
     pickKeyPlaceholder: 'Select an API key…',
     loadingModels: 'Loading models…',
-    noModels: 'No models returned for your key. Check group routing or try another key.',
     loadFailed: 'Could not load Studio.',
     noApiKey: 'No active API key found. Create one under API Keys.',
     manageKeys: 'Manage API keys',

--- a/frontend/src/i18n/locales/en.ts
+++ b/frontend/src/i18n/locales/en.ts
@@ -183,6 +183,7 @@ export default {
     topUp: 'Top up',
     viewPricing: 'See pricing',
     via: 'via {vendor}',
+    keyNoModality: 'no models for this mode',
     bakeoff: {
       hint: 'One prompt, several models side by side — each with its real price and speed.',
       needTwo: 'Need at least two priced models in this group to compare.',

--- a/frontend/src/i18n/locales/en.ts
+++ b/frontend/src/i18n/locales/en.ts
@@ -248,6 +248,7 @@ export default {
       notifyMe: 'Notify me when done',
       usuallyTakes: 'Usually 30–90s',
       noUrlHint: 'Task succeeded but no video URL could be parsed.',
+      download: 'Download',
       open: 'Open ↗',
       failedRefunded: 'Generation failed — {cost} refunded. Try a shorter clip or another tier.',
       techDetails: 'Technical details',

--- a/frontend/src/i18n/locales/zh.ts
+++ b/frontend/src/i18n/locales/zh.ts
@@ -246,6 +246,7 @@ export default {
       notifyMe: '完成通知我',
       usuallyTakes: '通常 30–90 秒',
       noUrlHint: '任务成功，但未能解析出视频地址。',
+      download: '下载',
       open: '打开 ↗',
       failedRefunded: '生成失败 — 已退你 {cost}。试试更短的片子或别的档位。',
       techDetails: '技术详情',

--- a/frontend/src/i18n/locales/zh.ts
+++ b/frontend/src/i18n/locales/zh.ts
@@ -181,6 +181,7 @@ export default {
     topUp: '去充值',
     viewPricing: '查看价格',
     via: '经 {vendor}',
+    keyNoModality: '此模式无可用模型',
     bakeoff: {
       hint: '一条 prompt，多个模型并排出片——各自带真实价格和速度。',
       needTwo: '该分组至少需要两个已定价模型才能对比。',

--- a/frontend/src/i18n/locales/zh.ts
+++ b/frontend/src/i18n/locales/zh.ts
@@ -169,7 +169,6 @@ export default {
     apiKey: 'API 密钥',
     pickKeyPlaceholder: '选择一个 API 密钥…',
     loadingModels: '正在加载模型…',
-    noModels: '该密钥未返回任何模型，请检查分组路由或换一个密钥。',
     loadFailed: '工作室加载失败。',
     noApiKey: '没有可用的 API 密钥，请先在「API 密钥」里创建一个。',
     manageKeys: '管理 API 密钥',

--- a/frontend/src/utils/__tests__/studioDownload.tk.spec.ts
+++ b/frontend/src/utils/__tests__/studioDownload.tk.spec.ts
@@ -1,0 +1,51 @@
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest'
+import { downloadMedia } from '@/utils/studioDownload.tk'
+
+describe('downloadMedia', () => {
+  let clickSpy: ReturnType<typeof vi.fn>
+  let lastAnchor: HTMLAnchorElement | null
+
+  beforeEach(() => {
+    lastAnchor = null
+    clickSpy = vi.fn()
+    const realCreate = document.createElement.bind(document)
+    vi.spyOn(document, 'createElement').mockImplementation((tag: string) => {
+      const el = realCreate(tag) as HTMLElement
+      if (tag === 'a') {
+        lastAnchor = el as HTMLAnchorElement
+        ;(el as HTMLAnchorElement).click = clickSpy
+      }
+      return el
+    })
+  })
+  afterEach(() => vi.restoreAllMocks())
+
+  it('no-ops on empty url', () => {
+    downloadMedia('', 'x.png')
+    expect(clickSpy).not.toHaveBeenCalled()
+  })
+
+  it('downloads a data: URL with the filename and no new tab', () => {
+    downloadMedia('data:image/png;base64,AAAA', 'tokenkey-1.png')
+    expect(clickSpy).toHaveBeenCalledOnce()
+    expect(lastAnchor?.getAttribute('download')).toBe('tokenkey-1.png')
+    expect(lastAnchor?.target).toBe('')
+  })
+
+  it('opens a remote URL in a new tab (download attr is cross-origin-ignored)', () => {
+    downloadMedia('https://cdn.example.com/v.mp4', 'tokenkey-vt_1.mp4')
+    expect(clickSpy).toHaveBeenCalledOnce()
+    expect(lastAnchor?.getAttribute('download')).toBe('tokenkey-vt_1.mp4')
+    expect(lastAnchor?.target).toBe('_blank')
+    expect(lastAnchor?.rel).toBe('noopener')
+  })
+
+  it('falls back to window.open when anchor click throws', () => {
+    const openSpy = vi.spyOn(window, 'open').mockImplementation(() => null)
+    clickSpy.mockImplementation(() => {
+      throw new Error('blocked')
+    })
+    downloadMedia('https://cdn.example.com/v.mp4', 'x.mp4')
+    expect(openSpy).toHaveBeenCalledWith('https://cdn.example.com/v.mp4', '_blank')
+  })
+})

--- a/frontend/src/utils/studioDownload.tk.ts
+++ b/frontend/src/utils/studioDownload.tk.ts
@@ -1,0 +1,28 @@
+/**
+ * TokenKey-only: trigger a browser download of a Studio-generated media URL.
+ *
+ * `data:` URLs (e.g. base64 images from Vertex) download directly with the given
+ * filename. Remote (cross-origin) URLs can't honor the `download` attribute, so
+ * we open them in a new tab as a best-effort save target — the user saves from
+ * there. Shared by ImageStudio (images) and VideoStudio (videos) so both
+ * surfaces behave identically.
+ */
+export function downloadMedia(url: string, filename: string): void {
+  if (!url) return
+  try {
+    const a = document.createElement('a')
+    a.href = url
+    a.download = filename
+    // The download attribute is ignored cross-origin, so for remote URLs fall
+    // back to opening in a new tab rather than a same-tab navigation.
+    if (!url.startsWith('data:')) {
+      a.target = '_blank'
+      a.rel = 'noopener'
+    }
+    document.body.appendChild(a)
+    a.click()
+    a.remove()
+  } catch {
+    window.open(url, '_blank')
+  }
+}

--- a/frontend/src/views/user/studio/ImageStudio.vue
+++ b/frontend/src/views/user/studio/ImageStudio.vue
@@ -106,8 +106,9 @@
       </div>
     </div>
 
-    <!-- RIGHT: cost panel + button (the spine) -->
-    <div class="space-y-4">
+    <!-- RIGHT: cost panel + button (the spine). Hidden when the group serves no
+         image tier — no point showing a $0 panel and a dead Generate button. -->
+    <div v-if="tiers.length" class="space-y-4">
       <div class="rounded-xl border border-primary-200 bg-primary-50/40 p-4 shadow-sm dark:border-primary-900/40 dark:bg-primary-950/30">
         <div class="text-xs font-semibold uppercase tracking-wide text-primary-700 dark:text-primary-300">{{ t('studio.cost.thisGeneration') }}</div>
         <div class="mt-2 font-mono text-[12px] text-gray-600 dark:text-dark-300">{{ formula }}</div>
@@ -126,11 +127,11 @@
         @click="generate"
       >
         <template v-if="sending">{{ t('studio.image.generating') }}</template>
-        <template v-else-if="!canAfford && tiers.length">{{ t('studio.image.generateTopUp', { cost: formatUsd(estimate) }) }}</template>
+        <template v-else-if="!canAfford">{{ t('studio.image.generateTopUp', { cost: formatUsd(estimate) }) }}</template>
         <template v-else>{{ t('studio.image.generate', { cost: formatUsd(estimate) }) }}</template>
       </button>
       <router-link
-        v-if="!canAfford && tiers.length"
+        v-if="!canAfford"
         to="/purchase"
         class="block text-center text-xs font-medium text-primary-600 underline dark:text-primary-400"
       >
@@ -168,6 +169,7 @@ import {
   IMAGE_SIZE_MULTIPLIER,
 } from '@/utils/mediaCostEstimate.tk'
 import { classifyGatewayError, studioErrorI18nKey, type StudioErrorCode } from '@/utils/studioGatewayError.tk'
+import { downloadMedia } from '@/utils/studioDownload.tk'
 import { useMediaLibrary, type ImageHistoryItem } from '@/composables/useMediaLibrary'
 
 const props = defineProps<{
@@ -260,20 +262,7 @@ function reuse(img: ImageHistoryItem): void {
 }
 
 function download(img: ImageHistoryItem): void {
-  try {
-    const a = document.createElement('a')
-    a.href = img.src
-    a.download = `tokenkey-${img.id}.png`
-    if (!img.src.startsWith('data:')) {
-      a.target = '_blank'
-      a.rel = 'noopener'
-    }
-    document.body.appendChild(a)
-    a.click()
-    a.remove()
-  } catch {
-    window.open(img.src, '_blank')
-  }
+  downloadMedia(img.src, `tokenkey-${img.id}.png`)
 }
 
 async function generate(): Promise<void> {

--- a/frontend/src/views/user/studio/MediaStudioView.vue
+++ b/frontend/src/views/user/studio/MediaStudioView.vue
@@ -85,7 +85,7 @@
       </div>
 
       <ImageStudio
-        v-if="userReady && !loadError && view === 'image'"
+        v-if="userReady && !loadError && probed && view === 'image'"
         :api-key="apiKey"
         :gateway-base="gatewayBase"
         :available-ids="availableIds"
@@ -95,7 +95,7 @@
         @spent="refreshBalance"
       />
       <VideoStudio
-        v-else-if="userReady && !loadError && view === 'video'"
+        v-else-if="userReady && !loadError && probed && view === 'video'"
         :api-key="apiKey"
         :gateway-base="gatewayBase"
         :available-ids="availableIds"
@@ -107,7 +107,7 @@
         @spent="refreshBalance"
       />
       <BakeOff
-        v-else-if="userReady && !loadError && view === 'bakeoff'"
+        v-else-if="userReady && !loadError && probed && view === 'bakeoff'"
         :api-key="apiKey"
         :gateway-base="gatewayBase"
         :available-ids="availableIds"
@@ -131,6 +131,12 @@ import BakeOff from '@/views/user/studio/BakeOff.vue'
 import { keysAPI } from '@/api/keys'
 import { gatewayListModels, resolveGatewayBaseUrl } from '@/api/playground'
 import { formatUsd } from '@/utils/mediaCostEstimate.tk'
+import {
+  modalityHasTiers,
+  pickModalityKey,
+  type ModalityKeyOption,
+  type StudioModality,
+} from '@/constants/mediaTiers.tk'
 import { useAppStore } from '@/stores/app'
 import { useAuthStore } from '@/stores/auth'
 import type { ApiKey } from '@/types'
@@ -143,8 +149,12 @@ const view = ref<'image' | 'video' | 'bakeoff'>('image')
 const keys = ref<ApiKey[]>([])
 const selectedKeyId = ref<number | null>(null)
 const gatewayBase = ref('')
-const availableIds = ref<Set<string>>(new Set())
+// Per-group model pools, keyed by groupKeyOf(). Probed once for every distinct
+// group up front so the picker (and the dropdown annotations) can reason about
+// EVERY key's modality, not just the one currently selected.
+const groupModelSets = ref<Map<string, Set<string>>>(new Map())
 const modelsLoading = ref(false)
+const probed = ref(false)
 const loadError = ref('')
 
 const selectedKey = computed(() => keys.value.find((k) => k.id === selectedKeyId.value))
@@ -156,33 +166,42 @@ const balance = computed(() => authStore.user?.balance ?? 0)
 const userReady = computed(() => authStore.user?.id != null)
 const userId = computed(() => authStore.user?.id ?? 'anon')
 
-function keyLabel(k: ApiKey): string {
-  const group = k.group?.name || t('studio.defaultGroup')
-  return `${k.name || k.id} · ${group}`
+// Keys in the same group share one /v1/models pool — dedup the probe by group,
+// falling back to the key id for the (rare) ungrouped key.
+function groupKeyOf(k: ApiKey): string {
+  return k.group?.id != null ? `g${k.group.id}` : `k${k.id}`
+}
+function availableIdsOf(k: ApiKey): Set<string> {
+  return groupModelSets.value.get(groupKeyOf(k)) ?? new Set<string>()
 }
 
-let modelsAbort: AbortController | null = null
+// Model pool of the currently selected key — what the child studios resolve
+// tiers against.
+const availableIds = computed<Set<string>>(() =>
+  selectedKey.value ? availableIdsOf(selectedKey.value) : new Set<string>()
+)
 
-async function loadModelsForKey(key: string): Promise<void> {
-  modelsAbort?.abort()
-  const ctrl = new AbortController()
-  modelsAbort = ctrl
-  loadError.value = ''
-  availableIds.value = new Set()
-  modelsLoading.value = true
-  try {
-    const list = await gatewayListModels(key, gatewayBase.value, ctrl.signal)
-    if (ctrl.signal.aborted) return
-    availableIds.value = new Set((list.data || []).map((m) => m.id))
-    if (availableIds.value.size === 0) {
-      loadError.value = t('studio.noModels')
-    }
-  } catch (e) {
-    if (ctrl.signal.aborted) return
-    loadError.value = e instanceof Error ? e.message : t('studio.loadFailed')
-  } finally {
-    if (modelsAbort === ctrl) modelsLoading.value = false
+// Modality the picker cares about: bake-off compares image models, so it shares
+// the image pool requirement.
+const pickerModality = computed<StudioModality>(() => (view.value === 'video' ? 'video' : 'image'))
+
+function modalityOptions(): ModalityKeyOption[] {
+  return keys.value.map((k) => ({
+    id: k.id,
+    isTrial: k.name?.toLowerCase() === 'trial',
+    availableIds: availableIdsOf(k),
+  }))
+}
+
+function keyLabel(k: ApiKey): string {
+  const group = k.group?.name || t('studio.defaultGroup')
+  const base = `${k.name || k.id} · ${group}`
+  // Once probed, flag keys whose group can't serve the active modality so the
+  // user isn't left guessing which key to pick.
+  if (probed.value && !modalityHasTiers(pickerModality.value, availableIdsOf(k))) {
+    return `${base} · ${t('studio.keyNoModality')}`
   }
+  return base
 }
 
 async function refreshBalance(): Promise<void> {
@@ -193,8 +212,46 @@ async function refreshBalance(): Promise<void> {
   }
 }
 
-watch(selectedKeyId, () => {
-  if (apiKey.value) void loadModelsForKey(apiKey.value)
+// Probe /v1/models for every distinct group, in parallel. A failed probe maps to
+// an empty pool (so that group's tiers stay hidden); only an all-failed result
+// is surfaced as a hard load error.
+async function probeAllGroups(): Promise<void> {
+  const reps = new Map<string, ApiKey>()
+  for (const k of keys.value) {
+    const gk = groupKeyOf(k)
+    if (!reps.has(gk)) reps.set(gk, k)
+  }
+  const entries = [...reps.entries()]
+  if (entries.length === 0) return
+  modelsLoading.value = true
+  try {
+    const results = await Promise.allSettled(
+      entries.map(([, k]) => gatewayListModels(k.key, gatewayBase.value))
+    )
+    const next = new Map<string, Set<string>>()
+    let anyOk = false
+    results.forEach((r, i) => {
+      const gk = entries[i][0]
+      if (r.status === 'fulfilled') {
+        anyOk = true
+        next.set(gk, new Set((r.value.data || []).map((m) => m.id)))
+      } else {
+        next.set(gk, new Set())
+      }
+    })
+    groupModelSets.value = next
+    if (!anyOk) loadError.value = t('studio.loadFailed')
+  } finally {
+    modelsLoading.value = false
+  }
+}
+
+// Re-pick when the modality tab changes: if the current key already serves the
+// new modality it is kept, otherwise we move to one that does (the dropdown
+// still lets the user override).
+watch(view, () => {
+  if (!probed.value) return
+  selectedKeyId.value = pickModalityKey(modalityOptions(), pickerModality.value, selectedKeyId.value)
 })
 
 async function bootstrap(): Promise<void> {
@@ -205,12 +262,17 @@ async function bootstrap(): Promise<void> {
     const page = await keysAPI.list(1, 50, { status: 'active' })
     keys.value = (page.items || []).filter((k) => !!k.key)
     const trial = keys.value.find((k) => k.name?.toLowerCase() === 'trial')
-    const pick = trial || keys.value[0]
-    if (!pick) {
+    const seed = (trial || keys.value[0])?.id ?? null
+    if (seed == null) {
       loadError.value = t('studio.noApiKey')
       return
     }
-    selectedKeyId.value = pick.id
+    await probeAllGroups()
+    if (loadError.value) return
+    // Seed with the historical default, then let the picker move to a key whose
+    // group actually serves the landing modality.
+    selectedKeyId.value = pickModalityKey(modalityOptions(), pickerModality.value, seed)
+    probed.value = true
   } catch (e) {
     loadError.value = e instanceof Error ? e.message : t('studio.loadFailed')
   }

--- a/frontend/src/views/user/studio/MediaStudioView.vue
+++ b/frontend/src/views/user/studio/MediaStudioView.vue
@@ -181,9 +181,12 @@ const availableIds = computed<Set<string>>(() =>
   selectedKey.value ? availableIdsOf(selectedKey.value) : new Set<string>()
 )
 
-// Modality the picker cares about: bake-off compares image models, so it shares
-// the image pool requirement.
-const pickerModality = computed<StudioModality>(() => (view.value === 'video' ? 'video' : 'image'))
+// The single modality the picker can optimize a key for. Bake-off has its OWN
+// internal image/video toggle, so no single key serves both of its sub-modes —
+// we leave its key selection to the user there (null = don't auto-pick / annotate).
+const pickerModality = computed<StudioModality | null>(() =>
+  view.value === 'image' ? 'image' : view.value === 'video' ? 'video' : null
+)
 
 function modalityOptions(): ModalityKeyOption[] {
   return keys.value.map((k) => ({
@@ -197,8 +200,9 @@ function keyLabel(k: ApiKey): string {
   const group = k.group?.name || t('studio.defaultGroup')
   const base = `${k.name || k.id} · ${group}`
   // Once probed, flag keys whose group can't serve the active modality so the
-  // user isn't left guessing which key to pick.
-  if (probed.value && !modalityHasTiers(pickerModality.value, availableIdsOf(k))) {
+  // user isn't left guessing which key to pick. Skipped on bake-off (dual modality).
+  const m = pickerModality.value
+  if (probed.value && m && !modalityHasTiers(m, availableIdsOf(k))) {
     return `${base} · ${t('studio.keyNoModality')}`
   }
   return base
@@ -248,10 +252,12 @@ async function probeAllGroups(): Promise<void> {
 
 // Re-pick when the modality tab changes: if the current key already serves the
 // new modality it is kept, otherwise we move to one that does (the dropdown
-// still lets the user override).
+// still lets the user override). Bake-off (null modality) keeps the current key.
 watch(view, () => {
   if (!probed.value) return
-  selectedKeyId.value = pickModalityKey(modalityOptions(), pickerModality.value, selectedKeyId.value)
+  const m = pickerModality.value
+  if (!m) return
+  selectedKeyId.value = pickModalityKey(modalityOptions(), m, selectedKeyId.value)
 })
 
 async function bootstrap(): Promise<void> {
@@ -270,8 +276,8 @@ async function bootstrap(): Promise<void> {
     await probeAllGroups()
     if (loadError.value) return
     // Seed with the historical default, then let the picker move to a key whose
-    // group actually serves the landing modality.
-    selectedKeyId.value = pickModalityKey(modalityOptions(), pickerModality.value, seed)
+    // group actually serves the landing modality (view is 'image' at mount).
+    selectedKeyId.value = pickModalityKey(modalityOptions(), pickerModality.value ?? 'image', seed)
     probed.value = true
   } catch (e) {
     loadError.value = e instanceof Error ? e.message : t('studio.loadFailed')

--- a/frontend/src/views/user/studio/VideoStudio.vue
+++ b/frontend/src/views/user/studio/VideoStudio.vue
@@ -144,6 +144,7 @@
             <span class="shrink-0 rounded bg-primary-50 px-1.5 py-0.5 font-semibold text-primary-700 dark:bg-primary-950/50 dark:text-primary-300">{{ formatUsd(task.estCost) }}</span>
           </div>
           <div class="flex gap-3 text-[11px] font-medium text-gray-500 dark:text-dark-400">
+            <button v-if="task.url" type="button" class="text-primary-600 dark:text-primary-300" @click="downloadMedia(task.url, `tokenkey-${task.id}.mp4`)">{{ t('studio.video.download') }}</button>
             <a v-if="task.url" :href="task.url" target="_blank" rel="noopener" class="text-primary-600 dark:text-primary-300">{{ t('studio.video.open') }}</a>
             <button type="button" @click="reuse(task)">{{ t('studio.image.usePrompt') }}</button>
             <button type="button" @click="removeTask(task.id)">{{ t('studio.clear') }}</button>
@@ -162,8 +163,9 @@
       </div>
     </div>
 
-    <!-- RIGHT: cost panel + button -->
-    <div class="space-y-4">
+    <!-- RIGHT: cost panel + button. Hidden when the group serves no video tier —
+         no point showing a $0 panel and a dead Generate button. -->
+    <div v-if="tiers.length" class="space-y-4">
       <div class="rounded-xl border border-primary-200 bg-primary-50/40 p-4 shadow-sm dark:border-primary-900/40 dark:bg-primary-950/30">
         <div class="text-xs font-semibold uppercase tracking-wide text-primary-700 dark:text-primary-300">{{ t('studio.cost.thisVideo') }}</div>
         <div class="mt-2 font-mono text-[12px] text-gray-600 dark:text-dark-300">{{ formula }}</div>
@@ -184,11 +186,11 @@
         @click="generate"
       >
         <template v-if="sending">{{ t('studio.video.submitting') }}</template>
-        <template v-else-if="!canAfford && tiers.length">{{ t('studio.video.generateTopUp', { cost: formatUsd(estimate) }) }}</template>
+        <template v-else-if="!canAfford">{{ t('studio.video.generateTopUp', { cost: formatUsd(estimate) }) }}</template>
         <template v-else>{{ t('studio.video.generate', { cost: formatUsd(estimate) }) }}</template>
       </button>
       <router-link
-        v-if="!canAfford && tiers.length"
+        v-if="!canAfford"
         to="/purchase"
         class="block text-center text-xs font-medium text-primary-600 underline dark:text-primary-400"
       >
@@ -220,6 +222,7 @@ import {
   resolveAvailableTiers,
 } from '@/constants/mediaTiers.tk'
 import { estimateVideoCost, formatUsd } from '@/utils/mediaCostEstimate.tk'
+import { downloadMedia } from '@/utils/studioDownload.tk'
 import { classifyGatewayError, studioErrorI18nKey, type StudioErrorCode } from '@/utils/studioGatewayError.tk'
 import { useMediaLibrary, type VideoTaskItem } from '@/composables/useMediaLibrary'
 import { useVideoTaskPoll, requestVideoNotifyPermission, maybeNotify } from '@/composables/useVideoTaskPoll'


### PR DESCRIPTION
## Problem

The Media Studio (`/studio`) dead-ends on **"当前分组暂无可用的图片模型"** whenever the selected API key's group can't serve the active modality. The bootstrap picked `trial`/`keys[0]` blind to modality and only probed `GET /v1/models` for that one key. On prod, admin's first key is the **antigravity smoke key**, whose group serves no imagen/seedream/veo models — so the image tab looked broken even though the Vertex/gemini key would resolve every image tier.

Root cause: image (Vertex/gemini), seedream-image (VolcEngine/newapi) and the video tiers each live on a **different platform group**, so a single key rarely serves all three. The studio treated key and modality as independent — the missing coupling is the bug.

## Fix (frontend, TK-owned)

- **Probe every distinct group up front** (deduped by group id, parallel `allSettled`; a failed probe → empty pool, all-failed → hard error) so the picker can reason about *every* key's modality, not just the selected one.
- **`pickModalityKey()` + `modalityHasTiers()`** (pure, in `mediaTiers.tk.ts`): keep the current key if it serves the modality, else prefer a serving key (trial-first), else fall back to the seed/global default so the honest empty state still shows. Re-runs on bootstrap **and** on modality-tab change.
- **Annotate non-serving keys** in the dropdown ("此模式无可用模型" / "no models for this mode") so a manual pick is legible.
- **Gate child studios on `probed`** to avoid an empty-state flash during the probe.
- **Unit test** for the picker (`constants/__tests__/mediaTiers.tk.spec.ts`, 9 cases).

The historical `trial`/`keys[0]` default is preserved as the *seed*, so the e2e's imagen-serving default stays stable.

## Validation

- `pnpm vitest run` new spec: 9/9 pass; `vue-tsc --noEmit`: clean; `eslint` changed files: clean.
- Full vitest suite: only 6 pre-existing failures (router guards / account modals / email-verify / page-size) — confirmed identical on `origin/main` with my changes stashed; none import the changed modules.
- `scripts/preflight.sh`: PASS (incl. rebuilt embedded dist source hash).

## Scope / markers

All changes are TK-owned: studio views, `*.tk.ts`, i18n locales — **no upstream-shaped paths touched**. The frontend-TK sentinels stayed intact; the registry update-gate fires only because `MediaStudioView.vue` was edited with deletions, and the surface was reviewed (no new anchor required).

no-upstream-touch
sentinel-registry-reviewed