### PR TITLE
feat(studio): transparent model picker + adjustable params + Jobs-level hero

### DIFF
--- a/backend/internal/web/dist/frontend-source.json
+++ b/backend/internal/web/dist/frontend-source.json
@@ -1,7 +1,7 @@
 {
   "algorithm": "sha256(git-ls-files:path,size,content)",
   "file_count": 484,
-  "hash": "858a32907de61cd90d0e1ef8e670b5ecbb23e0372e8fe9eadb179eb86de1fb1a",
+  "hash": "304d398d675fdbfc4fbc5979d5668c064363c242c50db42bc7894008b136e2cc",
   "schema": 1,
   "source": "frontend/"
 }

--- a/backend/internal/web/dist/frontend-source.json
+++ b/backend/internal/web/dist/frontend-source.json
@@ -1,7 +1,7 @@
 {
   "algorithm": "sha256(git-ls-files:path,size,content)",
-  "file_count": 484,
-  "hash": "0731dcf3a05101b6cf20833ed96c3f504b923b24e035877785d7c67b983adc2e",
+  "file_count": 483,
+  "hash": "91f61a6eff5a42a7abca5a881a7d34ef2b0667e8d587b77e18a30fcfe0d3713b",
   "schema": 1,
   "source": "frontend/"
 }

--- a/backend/internal/web/dist/frontend-source.json
+++ b/backend/internal/web/dist/frontend-source.json
@@ -1,7 +1,7 @@
 {
   "algorithm": "sha256(git-ls-files:path,size,content)",
   "file_count": 484,
-  "hash": "2db47a87ec9344ca15ef13176e4e1f91d467db7fcde9b83c97661fa5bfba2145",
+  "hash": "e6e7041ecca8491cee7835aef2bc1eae3025abc462e85869687ec82e49be41c4",
   "schema": 1,
   "source": "frontend/"
 }

--- a/backend/internal/web/dist/frontend-source.json
+++ b/backend/internal/web/dist/frontend-source.json
@@ -1,7 +1,7 @@
 {
   "algorithm": "sha256(git-ls-files:path,size,content)",
-  "file_count": 483,
-  "hash": "91f61a6eff5a42a7abca5a881a7d34ef2b0667e8d587b77e18a30fcfe0d3713b",
+  "file_count": 484,
+  "hash": "858a32907de61cd90d0e1ef8e670b5ecbb23e0372e8fe9eadb179eb86de1fb1a",
   "schema": 1,
   "source": "frontend/"
 }

--- a/backend/internal/web/dist/frontend-source.json
+++ b/backend/internal/web/dist/frontend-source.json
@@ -1,7 +1,7 @@
 {
   "algorithm": "sha256(git-ls-files:path,size,content)",
   "file_count": 484,
-  "hash": "304d398d675fdbfc4fbc5979d5668c064363c242c50db42bc7894008b136e2cc",
+  "hash": "2db47a87ec9344ca15ef13176e4e1f91d467db7fcde9b83c97661fa5bfba2145",
   "schema": 1,
   "source": "frontend/"
 }

--- a/frontend/src/api/__tests__/playground.spec.ts
+++ b/frontend/src/api/__tests__/playground.spec.ts
@@ -1,0 +1,84 @@
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest'
+import { gatewayImageGenerations, gatewayVideoSubmit } from '@/api/playground'
+
+// Capture the JSON body each builder sends so we can assert the wire shape:
+// only set fields are sent; video advanced params nest under metadata; never video_url.
+function mockFetchCapturing(): () => Record<string, unknown> {
+  let body: Record<string, unknown> = {}
+  vi.stubGlobal(
+    'fetch',
+    vi.fn(async (_url: string, init: RequestInit) => {
+      body = JSON.parse((init.body as string) || '{}')
+      return new Response(JSON.stringify({ ok: true }), {
+        status: 200,
+        headers: { 'Content-Type': 'application/json' },
+      })
+    })
+  )
+  return () => body
+}
+
+describe('gatewayImageGenerations payload', () => {
+  let getBody: () => Record<string, unknown>
+  beforeEach(() => {
+    getBody = mockFetchCapturing()
+  })
+  afterEach(() => vi.unstubAllGlobals())
+
+  it('sends only model + prompt when nothing optional is set', async () => {
+    await gatewayImageGenerations('k', 'http://x', { model: 'imagen-4.0-fast-generate-001', prompt: 'hi' })
+    expect(getBody()).toEqual({ model: 'imagen-4.0-fast-generate-001', prompt: 'hi' })
+  })
+
+  it('includes advanced fields only when provided', async () => {
+    await gatewayImageGenerations('k', 'http://x', {
+      model: 'm',
+      prompt: 'hi',
+      size: '1024x1024',
+      n: 2,
+      seed: 7,
+      negative_prompt: 'blurry',
+    })
+    const b = getBody()
+    expect(b).toMatchObject({ model: 'm', prompt: 'hi', size: '1024x1024', n: 2, seed: 7, negative_prompt: 'blurry' })
+    expect('quality' in b).toBe(false)
+    expect('style' in b).toBe(false)
+  })
+})
+
+describe('gatewayVideoSubmit payload', () => {
+  let getBody: () => Record<string, unknown>
+  beforeEach(() => {
+    getBody = mockFetchCapturing()
+  })
+  afterEach(() => vi.unstubAllGlobals())
+
+  it('sends only model + prompt when nothing optional is set (no empty metadata)', async () => {
+    await gatewayVideoSubmit('k', 'http://x', { model: 'veo-3.1-generate-001', prompt: 'hi' })
+    expect(getBody()).toEqual({ model: 'veo-3.1-generate-001', prompt: 'hi' })
+  })
+
+  it('nests seed/negativePrompt/fps under metadata, image stays top-level', async () => {
+    await gatewayVideoSubmit('k', 'http://x', {
+      model: 'seedance-1-0-pro-250528',
+      prompt: 'hi',
+      duration: 8,
+      aspectRatio: '16:9',
+      seed: 42,
+      negativePrompt: 'shaky',
+      fps: 24,
+      image: 'https://cdn/x.png',
+    })
+    const b = getBody()
+    expect(b).toMatchObject({
+      model: 'seedance-1-0-pro-250528',
+      prompt: 'hi',
+      duration: 8,
+      aspect_ratio: '16:9',
+      image: 'https://cdn/x.png',
+    })
+    expect(b.metadata).toEqual({ seed: 42, negative_prompt: 'shaky', fps: 24 })
+    // never forward video input — backend rejects it as unpriced
+    expect(JSON.stringify(b)).not.toContain('video_url')
+  })
+})

--- a/frontend/src/api/__tests__/playground.spec.ts
+++ b/frontend/src/api/__tests__/playground.spec.ts
@@ -30,17 +30,9 @@ describe('gatewayImageGenerations payload', () => {
     expect(getBody()).toEqual({ model: 'imagen-4.0-fast-generate-001', prompt: 'hi' })
   })
 
-  it('includes advanced fields only when provided', async () => {
-    await gatewayImageGenerations('k', 'http://x', {
-      model: 'm',
-      prompt: 'hi',
-      size: '1024x1024',
-      n: 2,
-      seed: 7,
-      negative_prompt: 'blurry',
-    })
-    const b = getBody()
-    expect(b).toEqual({ model: 'm', prompt: 'hi', size: '1024x1024', n: 2, seed: 7, negative_prompt: 'blurry' })
+  it('sends size + n when provided (imagen/seedream honor no other params)', async () => {
+    await gatewayImageGenerations('k', 'http://x', { model: 'm', prompt: 'hi', size: '1024x1024', n: 2 })
+    expect(getBody()).toEqual({ model: 'm', prompt: 'hi', size: '1024x1024', n: 2 })
   })
 })
 
@@ -56,26 +48,25 @@ describe('gatewayVideoSubmit payload', () => {
     expect(getBody()).toEqual({ model: 'veo-3.1-generate-001', prompt: 'hi' })
   })
 
-  it('nests seed/negativePrompt/fps under metadata, image stays top-level', async () => {
+  it('nests seed/negativePrompt under metadata, image stays top-level', async () => {
     await gatewayVideoSubmit('k', 'http://x', {
-      model: 'seedance-1-0-pro-250528',
+      model: 'veo-3.1-generate-001',
       prompt: 'hi',
       duration: 8,
       aspectRatio: '16:9',
       seed: 42,
       negativePrompt: 'shaky',
-      fps: 24,
       image: 'https://cdn/x.png',
     })
     const b = getBody()
     expect(b).toMatchObject({
-      model: 'seedance-1-0-pro-250528',
+      model: 'veo-3.1-generate-001',
       prompt: 'hi',
       duration: 8,
       aspect_ratio: '16:9',
       image: 'https://cdn/x.png',
     })
-    expect(b.metadata).toEqual({ seed: 42, negative_prompt: 'shaky', fps: 24 })
+    expect(b.metadata).toEqual({ seed: 42, negative_prompt: 'shaky' })
     // never forward video input — backend rejects it as unpriced
     expect(JSON.stringify(b)).not.toContain('video_url')
   })

--- a/frontend/src/api/__tests__/playground.spec.ts
+++ b/frontend/src/api/__tests__/playground.spec.ts
@@ -40,9 +40,7 @@ describe('gatewayImageGenerations payload', () => {
       negative_prompt: 'blurry',
     })
     const b = getBody()
-    expect(b).toMatchObject({ model: 'm', prompt: 'hi', size: '1024x1024', n: 2, seed: 7, negative_prompt: 'blurry' })
-    expect('quality' in b).toBe(false)
-    expect('style' in b).toBe(false)
+    expect(b).toEqual({ model: 'm', prompt: 'hi', size: '1024x1024', n: 2, seed: 7, negative_prompt: 'blurry' })
   })
 })
 

--- a/frontend/src/api/playground.ts
+++ b/frontend/src/api/playground.ts
@@ -162,6 +162,12 @@ export interface ImageGenerationRequest {
   size?: string
   /** number of images (1-4); backend bills per delivered image. Omit → upstream default (1). */
   n?: number
+  /** Advanced (optional, only sent when set; honored by native channels, no TK price delta). */
+  quality?: string
+  style?: string
+  seed?: number
+  negative_prompt?: string
+  response_format?: 'b64_json' | 'url'
 }
 
 /** Image generation can run well past a minute upstream. */
@@ -177,6 +183,12 @@ export async function gatewayImageGenerations(
   const payload: Record<string, unknown> = { model: body.model, prompt: body.prompt }
   if (body.size) payload.size = body.size
   if (body.n && body.n > 0) payload.n = body.n
+  // Advanced passthrough — only send fields the user actually set.
+  if (body.quality) payload.quality = body.quality
+  if (body.style) payload.style = body.style
+  if (typeof body.seed === 'number') payload.seed = body.seed
+  if (body.negative_prompt) payload.negative_prompt = body.negative_prompt
+  if (body.response_format) payload.response_format = body.response_format
   return gatewayRequestJSON(
     apiKey,
     url,
@@ -196,6 +208,17 @@ export interface VideoGenerationRequest {
    * gateway passes the body through; the adaptor decides whether to honor it.
    */
   aspectRatio?: string
+  /**
+   * Advanced (optional, only sent when set). seed/negativePrompt/fps/resolution
+   * ride the upstream `metadata.*` catch-all (forwarded verbatim per channel);
+   * `image` is a first-frame image-to-video reference sent top-level. We never
+   * send `video_url` — the backend rejects video input as unpriced.
+   */
+  seed?: number
+  negativePrompt?: string
+  fps?: number
+  resolution?: string
+  image?: string
 }
 
 export async function gatewayVideoSubmit(
@@ -208,6 +231,13 @@ export async function gatewayVideoSubmit(
   const payload: Record<string, unknown> = { model: body.model, prompt: body.prompt }
   if (body.duration) payload.duration = body.duration
   if (body.aspectRatio) payload.aspect_ratio = body.aspectRatio
+  if (body.image) payload.image = body.image
+  const metadata: Record<string, unknown> = {}
+  if (typeof body.seed === 'number') metadata.seed = body.seed
+  if (body.negativePrompt) metadata.negative_prompt = body.negativePrompt
+  if (typeof body.fps === 'number') metadata.fps = body.fps
+  if (body.resolution) metadata.resolution = body.resolution
+  if (Object.keys(metadata).length > 0) payload.metadata = metadata
   return gatewayRequestJSON(
     apiKey,
     url,

--- a/frontend/src/api/playground.ts
+++ b/frontend/src/api/playground.ts
@@ -162,12 +162,9 @@ export interface ImageGenerationRequest {
   size?: string
   /** number of images (1-4); backend bills per delivered image. Omit → upstream default (1). */
   n?: number
-  /** Advanced (optional, only sent when set; honored by native channels, no TK price delta). */
-  quality?: string
-  style?: string
+  /** Advanced (optional, only sent when set; forwarded via Extra; no TK price delta). */
   seed?: number
   negative_prompt?: string
-  response_format?: 'b64_json' | 'url'
 }
 
 /** Image generation can run well past a minute upstream. */
@@ -184,11 +181,8 @@ export async function gatewayImageGenerations(
   if (body.size) payload.size = body.size
   if (body.n && body.n > 0) payload.n = body.n
   // Advanced passthrough — only send fields the user actually set.
-  if (body.quality) payload.quality = body.quality
-  if (body.style) payload.style = body.style
   if (typeof body.seed === 'number') payload.seed = body.seed
   if (body.negative_prompt) payload.negative_prompt = body.negative_prompt
-  if (body.response_format) payload.response_format = body.response_format
   return gatewayRequestJSON(
     apiKey,
     url,
@@ -209,15 +203,14 @@ export interface VideoGenerationRequest {
    */
   aspectRatio?: string
   /**
-   * Advanced (optional, only sent when set). seed/negativePrompt/fps/resolution
-   * ride the upstream `metadata.*` catch-all (forwarded verbatim per channel);
-   * `image` is a first-frame image-to-video reference sent top-level. We never
-   * send `video_url` — the backend rejects video input as unpriced.
+   * Advanced (optional, only sent when set). seed/negativePrompt/fps ride the
+   * upstream `metadata.*` catch-all (forwarded verbatim per channel); `image` is
+   * a first-frame image-to-video reference sent top-level. We never send
+   * `video_url` — the backend rejects video input as unpriced.
    */
   seed?: number
   negativePrompt?: string
   fps?: number
-  resolution?: string
   image?: string
 }
 
@@ -236,7 +229,6 @@ export async function gatewayVideoSubmit(
   if (typeof body.seed === 'number') metadata.seed = body.seed
   if (body.negativePrompt) metadata.negative_prompt = body.negativePrompt
   if (typeof body.fps === 'number') metadata.fps = body.fps
-  if (body.resolution) metadata.resolution = body.resolution
   if (Object.keys(metadata).length > 0) payload.metadata = metadata
   return gatewayRequestJSON(
     apiKey,

--- a/frontend/src/api/playground.ts
+++ b/frontend/src/api/playground.ts
@@ -162,9 +162,6 @@ export interface ImageGenerationRequest {
   size?: string
   /** number of images (1-4); backend bills per delivered image. Omit → upstream default (1). */
   n?: number
-  /** Advanced (optional, only sent when set; forwarded via Extra; no TK price delta). */
-  seed?: number
-  negative_prompt?: string
 }
 
 /** Image generation can run well past a minute upstream. */
@@ -180,9 +177,6 @@ export async function gatewayImageGenerations(
   const payload: Record<string, unknown> = { model: body.model, prompt: body.prompt }
   if (body.size) payload.size = body.size
   if (body.n && body.n > 0) payload.n = body.n
-  // Advanced passthrough — only send fields the user actually set.
-  if (typeof body.seed === 'number') payload.seed = body.seed
-  if (body.negative_prompt) payload.negative_prompt = body.negative_prompt
   return gatewayRequestJSON(
     apiKey,
     url,
@@ -203,14 +197,13 @@ export interface VideoGenerationRequest {
    */
   aspectRatio?: string
   /**
-   * Advanced (optional, only sent when set). seed/negativePrompt/fps ride the
-   * upstream `metadata.*` catch-all (forwarded verbatim per channel); `image` is
+   * Advanced (optional, only sent when set). seed/negativePrompt ride the
+   * upstream `metadata.*` catch-all (read by the veo/doubao adaptors); `image` is
    * a first-frame image-to-video reference sent top-level. We never send
    * `video_url` — the backend rejects video input as unpriced.
    */
   seed?: number
   negativePrompt?: string
-  fps?: number
   image?: string
 }
 
@@ -228,7 +221,6 @@ export async function gatewayVideoSubmit(
   const metadata: Record<string, unknown> = {}
   if (typeof body.seed === 'number') metadata.seed = body.seed
   if (body.negativePrompt) metadata.negative_prompt = body.negativePrompt
-  if (typeof body.fps === 'number') metadata.fps = body.fps
   if (Object.keys(metadata).length > 0) payload.metadata = metadata
   return gatewayRequestJSON(
     apiKey,

--- a/frontend/src/constants/__tests__/mediaTiers.tk.spec.ts
+++ b/frontend/src/constants/__tests__/mediaTiers.tk.spec.ts
@@ -2,7 +2,6 @@ import { describe, it, expect } from 'vitest'
 import {
   modalityHasTiers,
   pickModalityKey,
-  resolveAvailableTiers,
   resolveAvailableModels,
   defaultModelId,
   MEDIA_MODELS,
@@ -30,8 +29,8 @@ describe('modalityHasTiers', () => {
     expect(modalityHasTiers('image', new Set())).toBe(false)
   })
 
-  it('agrees with resolveAvailableTiers', () => {
-    expect(modalityHasTiers('image', IMAGEN)).toBe(resolveAvailableTiers('image', IMAGEN).length > 0)
+  it('agrees with resolveAvailableModels', () => {
+    expect(modalityHasTiers('image', IMAGEN)).toBe(resolveAvailableModels('image', IMAGEN).length > 0)
   })
 })
 
@@ -127,17 +126,12 @@ describe('defaultModelId', () => {
 })
 
 describe('capability map honesty', () => {
-  const VALID: StudioParam[] = ['quality', 'style', 'negativePrompt', 'seed', 'firstFrameImage', 'fps', 'resolution']
+  // Only params that take effect for a shipped model exist in StudioParam — a
+  // control is never rendered for a param the model silently ignores.
+  const VALID: StudioParam[] = ['negativePrompt', 'seed', 'firstFrameImage', 'fps']
   it('every supportedParams entry is a valid StudioParam', () => {
     for (const m of MEDIA_MODELS) {
       for (const p of m.supportedParams) expect(VALID).toContain(p)
-    }
-  })
-  it('no shipped model claims quality/style/resolution (none take effect today)', () => {
-    for (const m of MEDIA_MODELS) {
-      expect(m.supportedParams).not.toContain('quality')
-      expect(m.supportedParams).not.toContain('style')
-      expect(m.supportedParams).not.toContain('resolution')
     }
   })
   it('veo omits seed/fps (Vertex video path does not honor them)', () => {

--- a/frontend/src/constants/__tests__/mediaTiers.tk.spec.ts
+++ b/frontend/src/constants/__tests__/mediaTiers.tk.spec.ts
@@ -3,7 +3,11 @@ import {
   modalityHasTiers,
   pickModalityKey,
   resolveAvailableTiers,
+  resolveAvailableModels,
+  defaultModelId,
+  MEDIA_MODELS,
   type ModalityKeyOption,
+  type StudioParam,
 } from '@/constants/mediaTiers.tk'
 
 // A Vertex group serves the imagen image tiers + the veo cinematic video tier.
@@ -70,5 +74,84 @@ describe('pickModalityKey', () => {
     expect(pickModalityKey(opts, 'image', 1)).toBe(1)
     // no seed → trial-named key, else first
     expect(pickModalityKey(opts, 'image', null)).toBe(2)
+  })
+})
+
+describe('resolveAvailableModels (transparent model picker)', () => {
+  const IMAGEN3 = new Set([
+    'imagen-4.0-fast-generate-001',
+    'imagen-4.0-generate-001',
+    'imagen-4.0-ultra-generate-001',
+  ])
+
+  it('lists only servable image models, sorted cheap → premium', () => {
+    const out = resolveAvailableModels('image', IMAGEN3)
+    expect(out.map((r) => r.model.modelId)).toEqual([
+      'imagen-4.0-fast-generate-001', // 0.02
+      'imagen-4.0-generate-001', // 0.04
+      'imagen-4.0-ultra-generate-001', // 0.06
+    ])
+    expect(out.every((r) => r.servedId === r.model.modelId)).toBe(true)
+  })
+
+  it('resolves a model via an alias id and reports the served id', () => {
+    const out = resolveAvailableModels('image', new Set(['doubao-seedream-4-0-250828']))
+    expect(out).toHaveLength(1)
+    expect(out[0].model.modelId).toBe('seedream-4-0-250828')
+    expect(out[0].servedId).toBe('doubao-seedream-4-0-250828') // billing key = the served id
+  })
+
+  it('excludes models not in the group pool (priced∩servable)', () => {
+    expect(resolveAvailableModels('image', new Set(['gemini-3-flash']))).toEqual([])
+    expect(resolveAvailableModels('video', new Set(['imagen-4.0-ultra-generate-001']))).toEqual([])
+  })
+
+  it('video pool surfaces only the served video models', () => {
+    const out = resolveAvailableModels('video', new Set(['veo-3.1-generate-001']))
+    expect(out.map((r) => r.model.modelId)).toEqual(['veo-3.1-generate-001'])
+  })
+})
+
+describe('defaultModelId', () => {
+  it('picks the cheapest non-footgun model', () => {
+    const out = resolveAvailableModels('image', new Set(['imagen-4.0-generate-001', 'imagen-4.0-fast-generate-001']))
+    expect(defaultModelId(out)).toBe('imagen-4.0-fast-generate-001')
+  })
+  it('returns null when nothing is servable', () => {
+    expect(defaultModelId([])).toBe(null)
+  })
+  it('never auto-selects a needsApikeyAccount model', () => {
+    // No shipped model is flagged today; assert the invariant holds for the catalog.
+    expect(MEDIA_MODELS.some((m) => m.needsApikeyAccount)).toBe(false)
+  })
+})
+
+describe('capability map honesty', () => {
+  const VALID: StudioParam[] = ['quality', 'style', 'negativePrompt', 'seed', 'firstFrameImage', 'fps', 'resolution']
+  it('every supportedParams entry is a valid StudioParam', () => {
+    for (const m of MEDIA_MODELS) {
+      for (const p of m.supportedParams) expect(VALID).toContain(p)
+    }
+  })
+  it('no shipped model claims quality/style/resolution (none take effect today)', () => {
+    for (const m of MEDIA_MODELS) {
+      expect(m.supportedParams).not.toContain('quality')
+      expect(m.supportedParams).not.toContain('style')
+      expect(m.supportedParams).not.toContain('resolution')
+    }
+  })
+  it('veo omits seed/fps (Vertex video path does not honor them)', () => {
+    const veo = MEDIA_MODELS.filter((m) => m.modelId.startsWith('veo-'))
+    expect(veo.length).toBeGreaterThan(0)
+    for (const m of veo) {
+      expect(m.supportedParams).not.toContain('seed')
+      expect(m.supportedParams).not.toContain('fps')
+    }
+  })
+  it('image models never expose video-only params', () => {
+    for (const m of MEDIA_MODELS.filter((m) => m.modality === 'image')) {
+      expect(m.supportedParams).not.toContain('fps')
+      expect(m.supportedParams).not.toContain('firstFrameImage')
+    }
   })
 })

--- a/frontend/src/constants/__tests__/mediaTiers.tk.spec.ts
+++ b/frontend/src/constants/__tests__/mediaTiers.tk.spec.ts
@@ -29,8 +29,11 @@ describe('modalityHasTiers', () => {
     expect(modalityHasTiers('image', new Set())).toBe(false)
   })
 
-  it('agrees with resolveAvailableModels', () => {
-    expect(modalityHasTiers('image', IMAGEN)).toBe(resolveAvailableModels('image', IMAGEN).length > 0)
+  it('is price-agnostic (the picker must not need a per-group price fetch)', () => {
+    // True on a servable group even before prices load — unlike the priced card
+    // resolver, which (deliberately) returns [] without a price map.
+    expect(modalityHasTiers('image', IMAGEN)).toBe(true)
+    expect(resolveAvailableModels('image', IMAGEN, new Map())).toEqual([])
   })
 })
 
@@ -82,38 +85,70 @@ describe('resolveAvailableModels (transparent model picker)', () => {
     'imagen-4.0-generate-001',
     'imagen-4.0-ultra-generate-001',
   ])
+  // Live prices come from the per-user catalog (getMePricingCatalog), not hardcoded.
+  const IMAGEN_PRICES = new Map([
+    ['imagen-4.0-fast-generate-001', { perImage: 0.02 }],
+    ['imagen-4.0-generate-001', { perImage: 0.04 }],
+    ['imagen-4.0-ultra-generate-001', { perImage: 0.06 }],
+  ])
 
-  it('lists only servable image models, sorted cheap → premium', () => {
-    const out = resolveAvailableModels('image', IMAGEN3)
+  it('lists only priced+servable image models, sorted cheap → premium, with live price', () => {
+    const out = resolveAvailableModels('image', IMAGEN3, IMAGEN_PRICES)
     expect(out.map((r) => r.model.modelId)).toEqual([
       'imagen-4.0-fast-generate-001', // 0.02
       'imagen-4.0-generate-001', // 0.04
       'imagen-4.0-ultra-generate-001', // 0.06
     ])
+    expect(out.map((r) => r.baseImagePrice)).toEqual([0.02, 0.04, 0.06])
     expect(out.every((r) => r.servedId === r.model.modelId)).toBe(true)
   })
 
-  it('resolves a model via an alias id and reports the served id', () => {
-    const out = resolveAvailableModels('image', new Set(['doubao-seedream-4-0-250828']))
+  it('hides a servable model that has no live price (priced ∩ servable)', () => {
+    const priceless = new Map() // served but unpriced
+    expect(resolveAvailableModels('image', IMAGEN3, priceless)).toEqual([])
+  })
+
+  it('resolves a model + price via an alias id and reports the served id', () => {
+    const out = resolveAvailableModels(
+      'image',
+      new Set(['doubao-seedream-4-0-250828']),
+      new Map([['doubao-seedream-4-0-250828', { perImage: 0.03 }]])
+    )
     expect(out).toHaveLength(1)
     expect(out[0].model.modelId).toBe('seedream-4-0-250828')
     expect(out[0].servedId).toBe('doubao-seedream-4-0-250828') // billing key = the served id
+    expect(out[0].baseImagePrice).toBe(0.03)
   })
 
-  it('excludes models not in the group pool (priced∩servable)', () => {
-    expect(resolveAvailableModels('image', new Set(['gemini-3-flash']))).toEqual([])
-    expect(resolveAvailableModels('video', new Set(['imagen-4.0-ultra-generate-001']))).toEqual([])
+  it('excludes models not in the group pool', () => {
+    expect(resolveAvailableModels('image', new Set(['gemini-3-flash']), new Map())).toEqual([])
+    expect(
+      resolveAvailableModels('video', new Set(['imagen-4.0-ultra-generate-001']), IMAGEN_PRICES)
+    ).toEqual([])
   })
 
-  it('video pool surfaces only the served video models', () => {
-    const out = resolveAvailableModels('video', new Set(['veo-3.1-generate-001']))
+  it('video pool surfaces only served+priced video models with per-second price', () => {
+    const out = resolveAvailableModels(
+      'video',
+      new Set(['veo-3.1-generate-001']),
+      new Map([['veo-3.1-generate-001', { perSecond: 0.4 }]])
+    )
     expect(out.map((r) => r.model.modelId)).toEqual(['veo-3.1-generate-001'])
+    expect(out[0].perSecond).toBe(0.4)
   })
 })
 
 describe('defaultModelId', () => {
+  const PRICES = new Map([
+    ['imagen-4.0-fast-generate-001', { perImage: 0.02 }],
+    ['imagen-4.0-generate-001', { perImage: 0.04 }],
+  ])
   it('picks the cheapest non-footgun model', () => {
-    const out = resolveAvailableModels('image', new Set(['imagen-4.0-generate-001', 'imagen-4.0-fast-generate-001']))
+    const out = resolveAvailableModels(
+      'image',
+      new Set(['imagen-4.0-generate-001', 'imagen-4.0-fast-generate-001']),
+      PRICES
+    )
     expect(defaultModelId(out)).toBe('imagen-4.0-fast-generate-001')
   })
   it('returns null when nothing is servable', () => {
@@ -125,27 +160,29 @@ describe('defaultModelId', () => {
   })
 })
 
-describe('capability map honesty', () => {
-  // Only params that take effect for a shipped model exist in StudioParam — a
-  // control is never rendered for a param the model silently ignores.
-  const VALID: StudioParam[] = ['negativePrompt', 'seed', 'firstFrameImage', 'fps']
+describe('capability map honesty (verified against new-api adaptors)', () => {
+  // Only params an adaptor ACTUALLY reads are listed; fps was removed (no adaptor
+  // honors it), imagen/seedream honor none, seedance drops negative_prompt.
+  const VALID: StudioParam[] = ['negativePrompt', 'seed', 'firstFrameImage']
+  const byId = (id: string) => MEDIA_MODELS.find((m) => m.modelId === id)!
+
   it('every supportedParams entry is a valid StudioParam', () => {
     for (const m of MEDIA_MODELS) {
       for (const p of m.supportedParams) expect(VALID).toContain(p)
     }
   })
-  it('veo omits seed/fps (Vertex video path does not honor them)', () => {
-    const veo = MEDIA_MODELS.filter((m) => m.modelId.startsWith('veo-'))
-    expect(veo.length).toBeGreaterThan(0)
-    for (const m of veo) {
-      expect(m.supportedParams).not.toContain('seed')
-      expect(m.supportedParams).not.toContain('fps')
+  it('image models (imagen/seedream) honor no advanced params', () => {
+    for (const m of MEDIA_MODELS.filter((m) => m.modality === 'image')) {
+      expect(m.supportedParams).toEqual([])
     }
   })
-  it('image models never expose video-only params', () => {
-    for (const m of MEDIA_MODELS.filter((m) => m.modality === 'image')) {
-      expect(m.supportedParams).not.toContain('fps')
-      expect(m.supportedParams).not.toContain('firstFrameImage')
-    }
+  it('veo honors negativePrompt + seed + firstFrameImage', () => {
+    expect(byId('veo-3.1-generate-001').supportedParams).toEqual(['negativePrompt', 'seed', 'firstFrameImage'])
+  })
+  it('seedance honors seed + firstFrameImage but NOT negativePrompt (adaptor drops it)', () => {
+    const s = byId('seedance-1-0-pro-250528').supportedParams
+    expect(s).toContain('seed')
+    expect(s).toContain('firstFrameImage')
+    expect(s).not.toContain('negativePrompt')
   })
 })

--- a/frontend/src/constants/mediaTiers.tk.ts
+++ b/frontend/src/constants/mediaTiers.tk.ts
@@ -23,14 +23,21 @@ const VOLC = 'VolcEngine'
 
 /**
  * True when this group's pool backs at least one media model of the modality —
- * i.e. the Studio tab is actually usable for a key whose group exposes
- * `availableIds`. Drives the modality-aware key picker (pickModalityKey).
+ * i.e. the Studio tab is usable for a key whose group exposes `availableIds`.
+ * Drives the modality-aware key picker (pickModalityKey), which runs across ALL
+ * the user's groups, so it is PRICE-AGNOSTIC by design: it must not require a
+ * per-group price-catalog fetch. /v1/models is already filtered to priced models
+ * upstream, so servable here implies priced for the per-key card resolver.
  */
 export function modalityHasTiers(
   modality: StudioModality,
   availableIds: ReadonlySet<string>
 ): boolean {
-  return resolveAvailableModels(modality, availableIds).length > 0
+  return MEDIA_MODELS.some(
+    (m) =>
+      m.modality === modality &&
+      [m.modelId, ...(m.aliasIds ?? [])].some((id) => availableIds.has(id))
+  )
 }
 
 /** One selectable key, reduced to what the modality-aware picker needs. */
@@ -131,18 +138,16 @@ export const IMAGE_N_MAX = 4
 
 /**
  * Advanced params the Studio can surface. Each is gated by a model's
- * `supportedParams` capability list so we NEVER render a control that the
- * selected model silently ignores (the "real & transparent" rule).
+ * `supportedParams` capability list so we NEVER render a control the selected
+ * model's UPSTREAM ADAPTOR silently ignores ("real & transparent"). Membership
+ * is verified against the new-api task/image adaptor request-builders, NOT
+ * assumed — e.g. imagen/seedream honor none; seedance drops negative_prompt;
+ * fps is honored by no adaptor (removed).
  */
-// Only params that ACTUALLY take effect for a shipped model are listed — we
-// never render a control that the selected model silently ignores. (quality /
-// style / resolution were dropped: no shipped model honors them today; add them
-// back here the day a model in MEDIA_MODELS actually does.)
 export type StudioParam =
-  | 'negativePrompt' // image+video: forwarded via Extra / metadata.negative_prompt
-  | 'seed' // image+video: forwarded via Extra / metadata.seed
-  | 'firstFrameImage' // video: image-to-video first frame (sent as `image`)
-  | 'fps' // video: metadata.fps (seedance honors)
+  | 'negativePrompt' // veo only: VeoParameters.NegativePrompt (gemini task adaptor)
+  | 'seed' // veo + seedance: VeoParameters.Seed / doubao requestPayload.Seed
+  | 'firstFrameImage' // veo + seedance: image-to-video first frame (sent as `image`)
 
 export type QualityBadge = 'draft' | 'standard' | 'ultra' | 'fast' | 'cinematic'
 
@@ -158,11 +163,10 @@ export interface MediaModel {
   /** Display-only vendor footnote, e.g. "Google Vertex" / "VolcEngine". */
   vendorLabel: string
   modality: StudioModality
-  /** USD per image at the 1K base tier (image only). */
-  baseImagePrice?: number
-  /** USD per second (video only). */
-  perSecond?: number
-  /** Advanced params that ACTUALLY take effect for this model (capability map). */
+  /**
+   * Advanced params whose upstream adaptor ACTUALLY reads them (capability map,
+   * verified against new-api adaptor code). Empty = no advanced controls.
+   */
   supportedParams: StudioParam[]
   /** Other ids that are the SAME model under a different name (dedup display). */
   aliasIds?: string[]
@@ -171,13 +175,16 @@ export interface MediaModel {
 }
 
 /**
- * Catalog of priced+servable media models, authored cheap → premium. Prices are
- * verified against backend/internal/service/tk_pricing_overlay.json and mirror
- * the same per-unit numbers the tier candidates used. The `availableIds ∩`
- * filter in resolveAvailableModels() hides any a given key-group can't serve.
+ * Static catalog of media models = display metadata + the verified capability
+ * map ONLY. Prices are NOT hardcoded here — they come live from the per-user
+ * pricing catalog (getMePricingCatalog, the same source #788 established), so a
+ * price change in the overlay can't drift. A model is shown only when it is BOTH
+ * in the key-group's GET /v1/models pool AND carries a live catalog price
+ * (priced ∩ servable — never a 400-on-submit footgun). modelId stays the billing
+ * key; displayName is cosmetic.
  */
 export const MEDIA_MODELS: MediaModel[] = [
-  // ── image (cheap → premium) ──
+  // ── image (imagen/seedream honor NO advanced params per adaptor) ──
   {
     modelId: 'imagen-4.0-fast-generate-001',
     displayName: 'Imagen 4 · Fast',
@@ -185,8 +192,7 @@ export const MEDIA_MODELS: MediaModel[] = [
     qualityBadgeKey: 'studio.badge.draft',
     vendorLabel: VERTEX,
     modality: 'image',
-    baseImagePrice: 0.02,
-    supportedParams: ['seed', 'negativePrompt'],
+    supportedParams: [],
   },
   {
     modelId: 'seedream-4-0-250828',
@@ -196,8 +202,7 @@ export const MEDIA_MODELS: MediaModel[] = [
     qualityBadgeKey: 'studio.badge.standard',
     vendorLabel: VOLC,
     modality: 'image',
-    baseImagePrice: 0.029850746268656716,
-    supportedParams: ['seed', 'negativePrompt'],
+    supportedParams: [],
   },
   {
     modelId: 'imagen-4.0-generate-001',
@@ -206,8 +211,7 @@ export const MEDIA_MODELS: MediaModel[] = [
     qualityBadgeKey: 'studio.badge.standard',
     vendorLabel: VERTEX,
     modality: 'image',
-    baseImagePrice: 0.04,
-    supportedParams: ['seed', 'negativePrompt'],
+    supportedParams: [],
   },
   {
     modelId: 'imagen-4.0-ultra-generate-001',
@@ -216,14 +220,13 @@ export const MEDIA_MODELS: MediaModel[] = [
     qualityBadgeKey: 'studio.badge.ultra',
     vendorLabel: VERTEX,
     modality: 'image',
-    baseImagePrice: 0.06,
-    supportedParams: ['seed', 'negativePrompt'],
+    supportedParams: [],
   },
   // gpt-image-* is deliberately ABSENT: it needs a type=apikey OpenAI account
   // (OAuth subscriptions 502). If a future probe adds an apikey-backed group,
   // add it here with needsApikeyAccount: true.
 
-  // ── video (cheap → premium) ──
+  // ── video ──
   {
     modelId: 'seedance-1-0-pro-250528',
     aliasIds: ['doubao-seedance-1-0-pro-250528'],
@@ -232,8 +235,8 @@ export const MEDIA_MODELS: MediaModel[] = [
     qualityBadgeKey: 'studio.badge.standard',
     vendorLabel: VOLC,
     modality: 'video',
-    perSecond: 0.10880597014925374,
-    supportedParams: ['seed', 'negativePrompt', 'fps', 'firstFrameImage'],
+    // doubao adaptor reads Seed + first-frame image; it has NO NegativePrompt field.
+    supportedParams: ['seed', 'firstFrameImage'],
   },
   {
     modelId: 'doubao-seedance-2-0-fast-260128',
@@ -242,8 +245,7 @@ export const MEDIA_MODELS: MediaModel[] = [
     qualityBadgeKey: 'studio.badge.fast',
     vendorLabel: VOLC,
     modality: 'video',
-    perSecond: 0.11940298507462686,
-    supportedParams: ['seed', 'negativePrompt', 'fps', 'firstFrameImage'],
+    supportedParams: ['seed', 'firstFrameImage'],
   },
   {
     modelId: 'veo-3.1-fast-generate-001',
@@ -252,8 +254,8 @@ export const MEDIA_MODELS: MediaModel[] = [
     qualityBadgeKey: 'studio.badge.fast',
     vendorLabel: VERTEX,
     modality: 'video',
-    perSecond: 0.15,
-    supportedParams: ['negativePrompt', 'firstFrameImage'],
+    // VeoParameters honors NegativePrompt + Seed; first-frame image supported.
+    supportedParams: ['negativePrompt', 'seed', 'firstFrameImage'],
   },
   {
     modelId: 'veo-3.1-generate-001',
@@ -262,38 +264,52 @@ export const MEDIA_MODELS: MediaModel[] = [
     qualityBadgeKey: 'studio.badge.cinematic',
     vendorLabel: VERTEX,
     modality: 'video',
-    perSecond: 0.4,
-    supportedParams: ['negativePrompt', 'firstFrameImage'],
+    supportedParams: ['negativePrompt', 'seed', 'firstFrameImage'],
   },
 ]
+
+/** Live per-model price from the user's pricing catalog (getMePricingCatalog). */
+export interface MediaPrice {
+  /** USD per image at the 1K base tier (image models). */
+  perImage?: number
+  /** USD per second (video models). */
+  perSecond?: number
+}
+export type MediaPriceMap = ReadonlyMap<string, MediaPrice>
 
 export interface ResolvedModel {
   model: MediaModel
   /** The concrete id present in availableIds (primary or an alias). Billing key. */
   servedId: string
+  /** Live price for this model (from the catalog), per modality. */
+  baseImagePrice?: number
+  perSecond?: number
 }
 
 /**
- * Resolve the models the user can actually use for `modality`: a model is shown
- * only when its primary OR an alias id is in `availableIds` (priced ∩ servable).
- * Sorted cheap → premium. Mirrors resolveTier's filter at model granularity.
+ * Resolve the models the user can actually use for `modality`: shown only when
+ * (a) its primary OR an alias id is in `availableIds` (servable) AND (b) the live
+ * `priceMap` has a price for it (priced) — priced ∩ servable, never a footgun.
+ * Sorted cheap → premium.
  */
 export function resolveAvailableModels(
   modality: StudioModality,
-  availableIds: ReadonlySet<string>
+  availableIds: ReadonlySet<string>,
+  priceMap: MediaPriceMap
 ): ResolvedModel[] {
   const out: ResolvedModel[] = []
   for (const model of MEDIA_MODELS) {
     if (model.modality !== modality) continue
     const ids = [model.modelId, ...(model.aliasIds ?? [])]
     const servedId = ids.find((id) => availableIds.has(id))
-    if (servedId) out.push({ model, servedId })
+    if (!servedId) continue
+    const price = ids.map((id) => priceMap.get(id)).find((p) => p != null)
+    const baseImagePrice = modality === 'image' ? price?.perImage : undefined
+    const perSecond = modality === 'video' ? price?.perSecond : undefined
+    if (baseImagePrice == null && perSecond == null) continue // no live price → hide
+    out.push({ model, servedId, baseImagePrice, perSecond })
   }
-  out.sort(
-    (a, b) =>
-      (a.model.baseImagePrice ?? a.model.perSecond ?? 0) -
-      (b.model.baseImagePrice ?? b.model.perSecond ?? 0)
-  )
+  out.sort((a, b) => (a.baseImagePrice ?? a.perSecond ?? 0) - (b.baseImagePrice ?? b.perSecond ?? 0))
   return out
 }
 
@@ -306,8 +322,6 @@ export function defaultModelId(models: readonly ResolvedModel[]): string | null 
   return safe ? safe.model.modelId : null
 }
 
-/** Advanced param bounds + recommended defaults (smooth: hit Generate works). */
+/** Advanced param bounds. */
 export const SEED_MIN = 0
 export const SEED_MAX = 2147483647
-export const VIDEO_FPS_OPTIONS = [16, 24] as const
-export const VIDEO_FPS_DEFAULT = 24

--- a/frontend/src/constants/mediaTiers.tk.ts
+++ b/frontend/src/constants/mediaTiers.tk.ts
@@ -18,147 +18,19 @@
 
 export type StudioModality = 'image' | 'video'
 
-export interface MediaTierCandidate {
-  /** Exact model id sent to the gateway and used as the billing key. */
-  modelId: string
-  /** Display-only vendor label, e.g. "Google Vertex" / "VolcEngine". */
-  vendorLabel: string
-  /** USD per image at the 1K base tier (image tiers only). */
-  baseImagePrice?: number
-  /** USD per second (video tiers only). */
-  perSecond?: number
-}
-
-export interface MediaTier {
-  id: string
-  modality: StudioModality
-  /** i18n key for the tier name, e.g. studio.tier.image.draft.label */
-  labelKey: string
-  /** i18n key for the one-line tagline. */
-  taglineKey: string
-  /** i18n key for the pre-filled "known-good" prompt (never-blank rule). */
-  samplePromptKey: string
-  candidates: MediaTierCandidate[]
-}
-
 const VERTEX = 'Google Vertex'
 const VOLC = 'VolcEngine'
 
 /**
- * Image tiers. Prices: imagen-4 fast/std/ultra = $0.02/$0.04/$0.06;
- * seedream-4 = $0.0298507 (tk_pricing_overlay.json, verified 2026-06-13).
- */
-export const IMAGE_TIERS: MediaTier[] = [
-  {
-    id: 'draft',
-    modality: 'image',
-    labelKey: 'studio.tiers.image.draft.label',
-    taglineKey: 'studio.tiers.image.draft.tagline',
-    samplePromptKey: 'studio.tiers.image.draft.sample',
-    candidates: [
-      { modelId: 'imagen-4.0-fast-generate-001', vendorLabel: VERTEX, baseImagePrice: 0.02 },
-      { modelId: 'seedream-4-0-250828', vendorLabel: VOLC, baseImagePrice: 0.029850746268656716 },
-      { modelId: 'doubao-seedream-4-0-250828', vendorLabel: VOLC, baseImagePrice: 0.029850746268656716 },
-    ],
-  },
-  {
-    id: 'standard',
-    modality: 'image',
-    labelKey: 'studio.tiers.image.standard.label',
-    taglineKey: 'studio.tiers.image.standard.tagline',
-    samplePromptKey: 'studio.tiers.image.standard.sample',
-    candidates: [{ modelId: 'imagen-4.0-generate-001', vendorLabel: VERTEX, baseImagePrice: 0.04 }],
-  },
-  {
-    id: 'ultra',
-    modality: 'image',
-    labelKey: 'studio.tiers.image.ultra.label',
-    taglineKey: 'studio.tiers.image.ultra.tagline',
-    samplePromptKey: 'studio.tiers.image.ultra.sample',
-    candidates: [{ modelId: 'imagen-4.0-ultra-generate-001', vendorLabel: VERTEX, baseImagePrice: 0.06 }],
-  },
-]
-
-/**
- * Video tiers. Prices: veo-3.1 = $0.40/s, veo-3.1-fast = $0.15/s,
- * seedance-1.0-pro = $0.1088/s, seedance-2.0-fast = $0.1194/s
- * (tk_pricing_overlay.json output_cost_per_second, verified 2026-06-13).
- */
-export const VIDEO_TIERS: MediaTier[] = [
-  {
-    id: 'fast',
-    modality: 'video',
-    labelKey: 'studio.tiers.video.fast.label',
-    taglineKey: 'studio.tiers.video.fast.tagline',
-    samplePromptKey: 'studio.tiers.video.fast.sample',
-    candidates: [
-      { modelId: 'veo-3.1-fast-generate-001', vendorLabel: VERTEX, perSecond: 0.15 },
-      { modelId: 'doubao-seedance-2-0-fast-260128', vendorLabel: VOLC, perSecond: 0.11940298507462686 },
-    ],
-  },
-  {
-    id: 'standard',
-    modality: 'video',
-    labelKey: 'studio.tiers.video.standard.label',
-    taglineKey: 'studio.tiers.video.standard.tagline',
-    samplePromptKey: 'studio.tiers.video.standard.sample',
-    candidates: [
-      { modelId: 'seedance-1-0-pro-250528', vendorLabel: VOLC, perSecond: 0.10880597014925374 },
-      { modelId: 'doubao-seedance-1-0-pro-250528', vendorLabel: VOLC, perSecond: 0.10880597014925374 },
-    ],
-  },
-  {
-    id: 'cinematic',
-    modality: 'video',
-    labelKey: 'studio.tiers.video.cinematic.label',
-    taglineKey: 'studio.tiers.video.cinematic.tagline',
-    samplePromptKey: 'studio.tiers.video.cinematic.sample',
-    candidates: [{ modelId: 'veo-3.1-generate-001', vendorLabel: VERTEX, perSecond: 0.4 }],
-  },
-]
-
-export interface ResolvedTier {
-  tier: MediaTier
-  candidate: MediaTierCandidate
-}
-
-/**
- * Resolve a tier against the set of available (priced+servable) model ids from
- * the user's key group. Returns the first candidate present in `availableIds`,
- * or null when the tier has no backing model for this key (so the UI hides it).
- */
-export function resolveTier(tier: MediaTier, availableIds: ReadonlySet<string>): ResolvedTier | null {
-  for (const candidate of tier.candidates) {
-    if (availableIds.has(candidate.modelId)) {
-      return { tier, candidate }
-    }
-  }
-  return null
-}
-
-/** Resolve all tiers for a modality; drops tiers with no available candidate. */
-export function resolveAvailableTiers(
-  modality: StudioModality,
-  availableIds: ReadonlySet<string>
-): ResolvedTier[] {
-  const tiers = modality === 'image' ? IMAGE_TIERS : VIDEO_TIERS
-  const out: ResolvedTier[] = []
-  for (const tier of tiers) {
-    const resolved = resolveTier(tier, availableIds)
-    if (resolved) out.push(resolved)
-  }
-  return out
-}
-
-/**
- * True when this model pool backs at least one tier of the modality — i.e. the
- * Studio tab is actually usable for a key whose group exposes `availableIds`.
+ * True when this group's pool backs at least one media model of the modality —
+ * i.e. the Studio tab is actually usable for a key whose group exposes
+ * `availableIds`. Drives the modality-aware key picker (pickModalityKey).
  */
 export function modalityHasTiers(
   modality: StudioModality,
   availableIds: ReadonlySet<string>
 ): boolean {
-  return resolveAvailableTiers(modality, availableIds).length > 0
+  return resolveAvailableModels(modality, availableIds).length > 0
 }
 
 /** One selectable key, reduced to what the modality-aware picker needs. */
@@ -262,14 +134,15 @@ export const IMAGE_N_MAX = 4
  * `supportedParams` capability list so we NEVER render a control that the
  * selected model silently ignores (the "real & transparent" rule).
  */
+// Only params that ACTUALLY take effect for a shipped model are listed — we
+// never render a control that the selected model silently ignores. (quality /
+// style / resolution were dropped: no shipped model honors them today; add them
+// back here the day a model in MEDIA_MODELS actually does.)
 export type StudioParam =
-  | 'quality' // image: enum standard|hd (native channels) — cosmetic, no TK price delta
-  | 'style' // image: vivid|natural (DALL-E family) — passthrough
   | 'negativePrompt' // image+video: forwarded via Extra / metadata.negative_prompt
   | 'seed' // image+video: forwarded via Extra / metadata.seed
   | 'firstFrameImage' // video: image-to-video first frame (sent as `image`)
   | 'fps' // video: metadata.fps (seedance honors)
-  | 'resolution' // video: metadata.resolution per-channel
 
 export type QualityBadge = 'draft' | 'standard' | 'ultra' | 'fast' | 'cinematic'
 
@@ -433,9 +306,7 @@ export function defaultModelId(models: readonly ResolvedModel[]): string | null 
   return safe ? safe.model.modelId : null
 }
 
-/** Advanced param options + recommended defaults (smooth: hit Generate works). */
-export const IMAGE_QUALITY_OPTIONS = ['standard', 'hd'] as const
-export const IMAGE_STYLE_OPTIONS = ['vivid', 'natural'] as const
+/** Advanced param bounds + recommended defaults (smooth: hit Generate works). */
 export const SEED_MIN = 0
 export const SEED_MAX = 2147483647
 export const VIDEO_FPS_OPTIONS = [16, 24] as const

--- a/frontend/src/constants/mediaTiers.tk.ts
+++ b/frontend/src/constants/mediaTiers.tk.ts
@@ -241,3 +241,202 @@ export const VIDEO_DURATION_DEFAULT = 8
 /** Image count bounds for the n stepper. */
 export const IMAGE_N_MIN = 1
 export const IMAGE_N_MAX = 4
+
+/* ────────────────────────────────────────────────────────────────────────────
+ * Model catalog (transparent model picker)
+ *
+ * The Studio now lets the user pick the ACTUAL model — shown humanely (friendly
+ * name + price + vendor footnote + raw id subtext), not a bare quality tier.
+ * This completes the originally-planned "Advanced model picker" (design §3.2)
+ * that #769 left unshipped. The quality label becomes a card BADGE, not the
+ * selection axis.
+ *
+ * Same hard rule as resolveTier: only models BOTH (a) priced+servable here and
+ * (b) present in the user's key-group pool (GET /v1/models) are shown — never a
+ * 400-on-submit footgun. The raw modelId stays the billing key; displayName is
+ * cosmetic only.
+ * ──────────────────────────────────────────────────────────────────────────── */
+
+/**
+ * Advanced params the Studio can surface. Each is gated by a model's
+ * `supportedParams` capability list so we NEVER render a control that the
+ * selected model silently ignores (the "real & transparent" rule).
+ */
+export type StudioParam =
+  | 'quality' // image: enum standard|hd (native channels) — cosmetic, no TK price delta
+  | 'style' // image: vivid|natural (DALL-E family) — passthrough
+  | 'negativePrompt' // image+video: forwarded via Extra / metadata.negative_prompt
+  | 'seed' // image+video: forwarded via Extra / metadata.seed
+  | 'firstFrameImage' // video: image-to-video first frame (sent as `image`)
+  | 'fps' // video: metadata.fps (seedance honors)
+  | 'resolution' // video: metadata.resolution per-channel
+
+export type QualityBadge = 'draft' | 'standard' | 'ultra' | 'fast' | 'cinematic'
+
+export interface MediaModel {
+  /** EXACT id sent to the gateway = billing key. Never substitute the display name. */
+  modelId: string
+  /** Friendly display name, e.g. "Imagen 4 · Ultra" (frontend-derived; no backend name). */
+  displayName: string
+  /** Quality badge shown ON the card (label, not the selection axis). */
+  qualityBadge: QualityBadge
+  /** i18n key for the badge text. */
+  qualityBadgeKey: string
+  /** Display-only vendor footnote, e.g. "Google Vertex" / "VolcEngine". */
+  vendorLabel: string
+  modality: StudioModality
+  /** USD per image at the 1K base tier (image only). */
+  baseImagePrice?: number
+  /** USD per second (video only). */
+  perSecond?: number
+  /** Advanced params that ACTUALLY take effect for this model (capability map). */
+  supportedParams: StudioParam[]
+  /** Other ids that are the SAME model under a different name (dedup display). */
+  aliasIds?: string[]
+  /** True ⇒ never auto-select; render a hard "needs apikey account" warning. */
+  needsApikeyAccount?: boolean
+}
+
+/**
+ * Catalog of priced+servable media models, authored cheap → premium. Prices are
+ * verified against backend/internal/service/tk_pricing_overlay.json and mirror
+ * the same per-unit numbers the tier candidates used. The `availableIds ∩`
+ * filter in resolveAvailableModels() hides any a given key-group can't serve.
+ */
+export const MEDIA_MODELS: MediaModel[] = [
+  // ── image (cheap → premium) ──
+  {
+    modelId: 'imagen-4.0-fast-generate-001',
+    displayName: 'Imagen 4 · Fast',
+    qualityBadge: 'draft',
+    qualityBadgeKey: 'studio.badge.draft',
+    vendorLabel: VERTEX,
+    modality: 'image',
+    baseImagePrice: 0.02,
+    supportedParams: ['seed', 'negativePrompt'],
+  },
+  {
+    modelId: 'seedream-4-0-250828',
+    aliasIds: ['doubao-seedream-4-0-250828'],
+    displayName: 'Seedream 4.0',
+    qualityBadge: 'standard',
+    qualityBadgeKey: 'studio.badge.standard',
+    vendorLabel: VOLC,
+    modality: 'image',
+    baseImagePrice: 0.029850746268656716,
+    supportedParams: ['seed', 'negativePrompt'],
+  },
+  {
+    modelId: 'imagen-4.0-generate-001',
+    displayName: 'Imagen 4 · Standard',
+    qualityBadge: 'standard',
+    qualityBadgeKey: 'studio.badge.standard',
+    vendorLabel: VERTEX,
+    modality: 'image',
+    baseImagePrice: 0.04,
+    supportedParams: ['seed', 'negativePrompt'],
+  },
+  {
+    modelId: 'imagen-4.0-ultra-generate-001',
+    displayName: 'Imagen 4 · Ultra',
+    qualityBadge: 'ultra',
+    qualityBadgeKey: 'studio.badge.ultra',
+    vendorLabel: VERTEX,
+    modality: 'image',
+    baseImagePrice: 0.06,
+    supportedParams: ['seed', 'negativePrompt'],
+  },
+  // gpt-image-* is deliberately ABSENT: it needs a type=apikey OpenAI account
+  // (OAuth subscriptions 502). If a future probe adds an apikey-backed group,
+  // add it here with needsApikeyAccount: true.
+
+  // ── video (cheap → premium) ──
+  {
+    modelId: 'seedance-1-0-pro-250528',
+    aliasIds: ['doubao-seedance-1-0-pro-250528'],
+    displayName: 'Seedance 1.0 · Pro',
+    qualityBadge: 'standard',
+    qualityBadgeKey: 'studio.badge.standard',
+    vendorLabel: VOLC,
+    modality: 'video',
+    perSecond: 0.10880597014925374,
+    supportedParams: ['seed', 'negativePrompt', 'fps', 'firstFrameImage'],
+  },
+  {
+    modelId: 'doubao-seedance-2-0-fast-260128',
+    displayName: 'Seedance 2.0 · Fast',
+    qualityBadge: 'fast',
+    qualityBadgeKey: 'studio.badge.fast',
+    vendorLabel: VOLC,
+    modality: 'video',
+    perSecond: 0.11940298507462686,
+    supportedParams: ['seed', 'negativePrompt', 'fps', 'firstFrameImage'],
+  },
+  {
+    modelId: 'veo-3.1-fast-generate-001',
+    displayName: 'Veo 3.1 · Fast',
+    qualityBadge: 'fast',
+    qualityBadgeKey: 'studio.badge.fast',
+    vendorLabel: VERTEX,
+    modality: 'video',
+    perSecond: 0.15,
+    supportedParams: ['negativePrompt', 'firstFrameImage'],
+  },
+  {
+    modelId: 'veo-3.1-generate-001',
+    displayName: 'Veo 3.1 · Cinematic',
+    qualityBadge: 'cinematic',
+    qualityBadgeKey: 'studio.badge.cinematic',
+    vendorLabel: VERTEX,
+    modality: 'video',
+    perSecond: 0.4,
+    supportedParams: ['negativePrompt', 'firstFrameImage'],
+  },
+]
+
+export interface ResolvedModel {
+  model: MediaModel
+  /** The concrete id present in availableIds (primary or an alias). Billing key. */
+  servedId: string
+}
+
+/**
+ * Resolve the models the user can actually use for `modality`: a model is shown
+ * only when its primary OR an alias id is in `availableIds` (priced ∩ servable).
+ * Sorted cheap → premium. Mirrors resolveTier's filter at model granularity.
+ */
+export function resolveAvailableModels(
+  modality: StudioModality,
+  availableIds: ReadonlySet<string>
+): ResolvedModel[] {
+  const out: ResolvedModel[] = []
+  for (const model of MEDIA_MODELS) {
+    if (model.modality !== modality) continue
+    const ids = [model.modelId, ...(model.aliasIds ?? [])]
+    const servedId = ids.find((id) => availableIds.has(id))
+    if (servedId) out.push({ model, servedId })
+  }
+  out.sort(
+    (a, b) =>
+      (a.model.baseImagePrice ?? a.model.perSecond ?? 0) -
+      (b.model.baseImagePrice ?? b.model.perSecond ?? 0)
+  )
+  return out
+}
+
+/**
+ * First model the Studio should auto-select for a modality: the cheapest served
+ * model that is NOT a footgun (needsApikeyAccount). Null when none are servable.
+ */
+export function defaultModelId(models: readonly ResolvedModel[]): string | null {
+  const safe = models.find((r) => !r.model.needsApikeyAccount)
+  return safe ? safe.model.modelId : null
+}
+
+/** Advanced param options + recommended defaults (smooth: hit Generate works). */
+export const IMAGE_QUALITY_OPTIONS = ['standard', 'hd'] as const
+export const IMAGE_STYLE_OPTIONS = ['vivid', 'natural'] as const
+export const SEED_MIN = 0
+export const SEED_MAX = 2147483647
+export const VIDEO_FPS_OPTIONS = [16, 24] as const
+export const VIDEO_FPS_DEFAULT = 24

--- a/frontend/src/i18n/locales/en.ts
+++ b/frontend/src/i18n/locales/en.ts
@@ -197,7 +197,6 @@ export default {
       negativePromptHint: 'Describe what to keep out (optional)',
       seed: 'Seed',
       seedHint: 'Leave blank for random',
-      fps: 'Frame rate',
       firstFrame: 'First frame image (URL)',
       firstFrameHint: 'Paste an image URL to use as the first frame (optional)'
     },

--- a/frontend/src/i18n/locales/en.ts
+++ b/frontend/src/i18n/locales/en.ts
@@ -193,8 +193,6 @@ export default {
     },
     advanced: {
       toggle: 'Advanced',
-      quality: 'Quality',
-      style: 'Style',
       negativePrompt: 'Avoid',
       negativePromptHint: 'Describe what to keep out (optional)',
       seed: 'Seed',
@@ -285,18 +283,6 @@ export default {
       notifyTitle: 'TokenKey Studio',
       notifyEnabled: 'We will notify you when videos finish.',
       notifyDenied: 'Notifications are blocked in your browser.'
-    },
-    tiers: {
-      image: {
-        draft: { label: 'Draft', tagline: 'Fast · cheap · iterate', sample: 'A neon Tokyo alley at night, cinematic, shallow depth of field' },
-        standard: { label: 'Standard', tagline: 'Best balance', sample: 'A neon Tokyo alley at night, cinematic, shallow depth of field' },
-        ultra: { label: 'Ultra', tagline: 'Highest detail', sample: 'A neon Tokyo alley at night, cinematic, shallow depth of field, 35mm' }
-      },
-      video: {
-        fast: { label: 'Fast', tagline: 'Quick takes', sample: 'Neon Tokyo alley, slow push-in, rain, reflections' },
-        standard: { label: 'Standard', tagline: 'Balanced', sample: 'Neon Tokyo alley, slow push-in, rain, reflections' },
-        cinematic: { label: 'Cinematic', tagline: 'Film-grade', sample: 'Neon Tokyo alley, slow push-in, rain, reflections, cinematic' }
-      }
     }
   },
 

--- a/frontend/src/i18n/locales/en.ts
+++ b/frontend/src/i18n/locales/en.ts
@@ -233,7 +233,7 @@ export default {
       samplePrompt: 'A neon Tokyo alley at night, cinematic, shallow depth of field',
       perImageUnit: ' /image',
       promptPlaceholder: 'Describe the image…',
-      aspectLabel: 'Aspect',
+      aspectLabel: 'Size',
       aspect: { square: 'Square', landscape: 'Landscape', portrait: 'Portrait' },
       billedAs: 'Billed as {tier} · ×{mult}',
       count: 'Count',

--- a/frontend/src/i18n/locales/en.ts
+++ b/frontend/src/i18n/locales/en.ts
@@ -166,7 +166,7 @@ export default {
   // Media Studio (image / video generation) — TK
   studio: {
     title: 'Studio',
-    subtitle: 'Generate images and video across every platform — one key, the price on the button, results that play right here.',
+    subtitle: "Turn what's in your head into images and video you can watch.",
     balance: 'Balance',
     apiKey: 'API Key',
     pickKeyPlaceholder: 'Select an API key…',
@@ -183,6 +183,26 @@ export default {
     viewPricing: 'See pricing',
     via: 'via {vendor}',
     keyNoModality: 'no models for this mode',
+    needsApikeyAccount: 'Needs an API-key account',
+    badge: {
+      draft: 'Draft',
+      standard: 'Standard',
+      ultra: 'Ultra',
+      fast: 'Fast',
+      cinematic: 'Cinematic'
+    },
+    advanced: {
+      toggle: 'Advanced',
+      quality: 'Quality',
+      style: 'Style',
+      negativePrompt: 'Avoid',
+      negativePromptHint: 'Describe what to keep out (optional)',
+      seed: 'Seed',
+      seedHint: 'Leave blank for random',
+      fps: 'Frame rate',
+      firstFrame: 'First frame image (URL)',
+      firstFrameHint: 'Paste an image URL to use as the first frame (optional)'
+    },
     bakeoff: {
       hint: 'One prompt, several models side by side — each with its real price and speed.',
       needTwo: 'Need at least two priced models in this group to compare.',
@@ -211,8 +231,9 @@ export default {
       generic: 'Generation failed. Please try again.'
     },
     image: {
-      tierLabel: 'Quality tier',
-      tierEmpty: 'No image models are available for this group yet.',
+      modelLabel: 'Model',
+      modelEmpty: 'No image models are available for this group yet.',
+      samplePrompt: 'A neon Tokyo alley at night, cinematic, shallow depth of field',
       perImageUnit: ' /image',
       promptPlaceholder: 'Describe the image…',
       aspectLabel: 'Aspect',
@@ -230,8 +251,9 @@ export default {
       formula: '{base} × {tier} ×{mult} × {n}'
     },
     video: {
-      tierLabel: 'Quality tier',
-      tierEmpty: 'No video models are available for this group yet.',
+      modelLabel: 'Model',
+      modelEmpty: 'No video models are available for this group yet.',
+      samplePrompt: 'A neon Tokyo alley, slow push-in, rain, reflections, cinematic',
       perSecondUnit: ' /s',
       promptPlaceholder: 'Describe the video…',
       duration: 'Duration',

--- a/frontend/src/i18n/locales/zh.ts
+++ b/frontend/src/i18n/locales/zh.ts
@@ -195,7 +195,6 @@ export default {
       negativePromptHint: '描述要避免的元素（可选）',
       seed: '随机种子',
       seedHint: '留空则随机',
-      fps: '帧率',
       firstFrame: '首帧图片（URL）',
       firstFrameHint: '粘贴一张图片 URL，作为视频首帧（可选）'
     },

--- a/frontend/src/i18n/locales/zh.ts
+++ b/frontend/src/i18n/locales/zh.ts
@@ -231,7 +231,7 @@ export default {
       samplePrompt: '东京雨夜的霓虹小巷，电影感，浅景深',
       perImageUnit: ' /张',
       promptPlaceholder: '描述你想要的图片…',
-      aspectLabel: '画幅',
+      aspectLabel: '画幅（尺寸）',
       aspect: { square: '方形', landscape: '横向', portrait: '竖向' },
       billedAs: '按 {tier} 计费 · ×{mult}',
       count: '数量',

--- a/frontend/src/i18n/locales/zh.ts
+++ b/frontend/src/i18n/locales/zh.ts
@@ -191,8 +191,6 @@ export default {
     },
     advanced: {
       toggle: '高级',
-      quality: '质量',
-      style: '风格',
       negativePrompt: '不要出现',
       negativePromptHint: '描述要避免的元素（可选）',
       seed: '随机种子',
@@ -283,18 +281,6 @@ export default {
       notifyTitle: 'TokenKey 工作室',
       notifyEnabled: '视频完成时会通知你。',
       notifyDenied: '浏览器已屏蔽通知。'
-    },
-    tiers: {
-      image: {
-        draft: { label: '草稿', tagline: '快 · 省 · 迭代', sample: '东京雨夜的霓虹小巷，电影感，浅景深' },
-        standard: { label: '标准', tagline: '最佳平衡', sample: '东京雨夜的霓虹小巷，电影感，浅景深' },
-        ultra: { label: '极致', tagline: '最高细节', sample: '东京雨夜的霓虹小巷，电影感，浅景深，35mm' }
-      },
-      video: {
-        fast: { label: '快', tagline: '快速出片', sample: '霓虹东京小巷，慢推镜头，雨，反射光' },
-        standard: { label: '标准', tagline: '平衡', sample: '霓虹东京小巷，慢推镜头，雨，反射光' },
-        cinematic: { label: '电影级', tagline: '电影质感', sample: '霓虹东京小巷，慢推镜头，雨，反射光，电影感' }
-      }
     }
   },
 

--- a/frontend/src/i18n/locales/zh.ts
+++ b/frontend/src/i18n/locales/zh.ts
@@ -164,7 +164,7 @@ export default {
   // 媒体工作室（图片 / 视频生成）— TK
   studio: {
     title: '工作室',
-    subtitle: '跨平台生成图片与视频——一把 key，价格印在按钮上，结果在页面里播放出来。',
+    subtitle: '把脑子里的画面，变成能播放的图片和视频。',
     balance: '余额',
     apiKey: 'API 密钥',
     pickKeyPlaceholder: '选择一个 API 密钥…',
@@ -181,6 +181,26 @@ export default {
     viewPricing: '查看价格',
     via: '经 {vendor}',
     keyNoModality: '此模式无可用模型',
+    needsApikeyAccount: '需要 apikey 类型账号',
+    badge: {
+      draft: '草稿',
+      standard: '标准',
+      ultra: '极致',
+      fast: '快速',
+      cinematic: '电影级'
+    },
+    advanced: {
+      toggle: '高级',
+      quality: '质量',
+      style: '风格',
+      negativePrompt: '不要出现',
+      negativePromptHint: '描述要避免的元素（可选）',
+      seed: '随机种子',
+      seedHint: '留空则随机',
+      fps: '帧率',
+      firstFrame: '首帧图片（URL）',
+      firstFrameHint: '粘贴一张图片 URL，作为视频首帧（可选）'
+    },
     bakeoff: {
       hint: '一条 prompt，多个模型并排出片——各自带真实价格和速度。',
       needTwo: '该分组至少需要两个已定价模型才能对比。',
@@ -209,8 +229,9 @@ export default {
       generic: '生成失败，请重试。'
     },
     image: {
-      tierLabel: '质量档位',
-      tierEmpty: '当前分组暂无可用的图片模型。',
+      modelLabel: '模型',
+      modelEmpty: '当前分组暂无可用的图片模型。',
+      samplePrompt: '东京雨夜的霓虹小巷，电影感，浅景深',
       perImageUnit: ' /张',
       promptPlaceholder: '描述你想要的图片…',
       aspectLabel: '画幅',
@@ -228,8 +249,9 @@ export default {
       formula: '{base} × {tier} ×{mult} × {n}'
     },
     video: {
-      tierLabel: '质量档位',
-      tierEmpty: '当前分组暂无可用的视频模型。',
+      modelLabel: '模型',
+      modelEmpty: '当前分组暂无可用的视频模型。',
+      samplePrompt: '霓虹东京小巷，慢推镜头，雨，反射光，电影感',
       perSecondUnit: ' /秒',
       promptPlaceholder: '描述你想要的视频…',
       duration: '时长',

--- a/frontend/src/views/user/studio/BakeOff.vue
+++ b/frontend/src/views/user/studio/BakeOff.vue
@@ -25,7 +25,7 @@
         <p class="text-sm text-gray-500 dark:text-dark-400">{{ t('studio.bakeoff.hint') }}</p>
       </div>
 
-      <div v-if="tiers.length < 2" class="rounded-lg border border-dashed border-gray-300 bg-gray-50 p-4 text-center text-sm text-gray-500 dark:border-dark-700 dark:bg-dark-900/40 dark:text-dark-400">
+      <div v-if="models.length < 2" class="rounded-lg border border-dashed border-gray-300 bg-gray-50 p-4 text-center text-sm text-gray-500 dark:border-dark-700 dark:bg-dark-900/40 dark:text-dark-400">
         {{ t('studio.bakeoff.needTwo') }}
       </div>
 
@@ -41,19 +41,19 @@
         <div class="mt-3 flex flex-wrap items-center gap-2">
           <span class="text-xs font-semibold uppercase tracking-wide text-gray-400 dark:text-dark-500">{{ t('studio.bakeoff.pickModels') }}</span>
           <button
-            v-for="r in tiers"
-            :key="r.tier.id"
+            v-for="r in models"
+            :key="r.model.modelId"
             type="button"
             class="rounded-lg border px-3 py-1.5 text-sm font-medium transition"
-            :class="selectedTierIds.includes(r.tier.id)
+            :class="selectedModelIds.includes(r.model.modelId)
               ? 'border-primary-600 bg-primary-600 text-white'
               : 'border-gray-200 text-gray-600 hover:border-primary-300 dark:border-dark-600 dark:text-dark-300'"
-            :disabled="running || (!selectedTierIds.includes(r.tier.id) && selectedTierIds.length >= MAX_PANELS)"
+            :disabled="running || (!selectedModelIds.includes(r.model.modelId) && selectedModelIds.length >= MAX_PANELS)"
             data-testid="bakeoff-tier"
-            @click="toggleTier(r.tier.id)"
+            @click="toggleModel(r.model.modelId)"
           >
-            {{ t(r.tier.labelKey) }}
-            <span class="opacity-70">{{ modality === 'image' ? formatUsd(r.candidate.baseImagePrice || 0) + t('studio.image.perImageUnit') : formatUsd(r.candidate.perSecond || 0) + t('studio.video.perSecondUnit') }}</span>
+            {{ r.model.displayName }}
+            <span class="opacity-70">{{ modality === 'image' ? formatUsd(r.model.baseImagePrice || 0) + t('studio.image.perImageUnit') : formatUsd(r.model.perSecond || 0) + t('studio.video.perSecondUnit') }}</span>
           </button>
         </div>
 
@@ -71,7 +71,7 @@
             data-testid="studio-bakeoff-run"
             @click="run"
           >
-            {{ running ? t('studio.bakeoff.running') : t('studio.bakeoff.run', { count: selectedTierIds.length }) }}
+            {{ running ? t('studio.bakeoff.running') : t('studio.bakeoff.run', { count: selectedModelIds.length }) }}
           </button>
           <span class="rounded-lg bg-amber-50 px-2.5 py-1 text-xs font-medium text-amber-700 ring-1 ring-amber-200 dark:bg-amber-950/30 dark:text-amber-300 dark:ring-amber-900/50">
             {{ t('studio.bakeoff.totalCost', { cost: formatUsd(totalCost) }) }}
@@ -91,9 +91,9 @@
 
     <!-- side-by-side panels -->
     <div v-if="panels.length" class="grid grid-cols-1 gap-4 md:grid-cols-2 xl:grid-cols-4">
-      <div v-for="p in panels" :key="p.tierId" data-testid="bakeoff-panel" class="rounded-xl border border-gray-200 bg-white p-3 shadow-sm dark:border-dark-700 dark:bg-dark-900">
+      <div v-for="p in panels" :key="p.modelId" data-testid="bakeoff-panel" class="rounded-xl border border-gray-200 bg-white p-3 shadow-sm dark:border-dark-700 dark:bg-dark-900">
         <div class="mb-2 flex items-center justify-between">
-          <span class="text-sm font-semibold text-gray-900 dark:text-white">{{ t(p.labelKey) }}</span>
+          <span class="text-sm font-semibold text-gray-900 dark:text-white">{{ p.label }}</span>
           <span class="text-[11px] text-gray-400 dark:text-dark-500">{{ t('studio.via', { vendor: p.vendorLabel }) }}</span>
         </div>
         <!-- image -->
@@ -136,7 +136,7 @@ import {
   VIDEO_DURATION_MIN,
   VIDEO_DURATION_MAX,
   VIDEO_DURATION_DEFAULT,
-  resolveAvailableTiers,
+  resolveAvailableModels,
   type StudioModality,
 } from '@/constants/mediaTiers.tk'
 import { estimateImageCost, estimateImageHoldCost, estimateVideoCost, formatUsd } from '@/utils/mediaCostEstimate.tk'
@@ -162,8 +162,8 @@ const MAX_PANELS = 4
 const DEFAULT_IMAGE_SIZE = '1024x1024'
 
 const modality = ref<StudioModality>('video')
-const tiers = computed(() => resolveAvailableTiers(modality.value, props.availableIds))
-const selectedTierIds = ref<string[]>([])
+const models = computed(() => resolveAvailableModels(modality.value, props.availableIds))
+const selectedModelIds = ref<string[]>([])
 const prompt = ref('')
 const duration = ref(VIDEO_DURATION_DEFAULT)
 const running = ref(false)
@@ -171,9 +171,10 @@ const errorMessage = ref('')
 const errorCode = ref<StudioErrorCode | ''>('')
 
 interface BakePanel {
-  tierId: string
-  labelKey: string
+  /** modelId for selection identity; servedId is the billing key sent upstream. */
   modelId: string
+  servedId: string
+  label: string
   vendorLabel: string
   cost: number
   state: 'idle' | 'processing' | 'succeeded' | 'failed'
@@ -210,15 +211,15 @@ const poll = useVideoTaskPoll({
 })
 
 function selectedResolved() {
-  return tiers.value.filter((r) => selectedTierIds.value.includes(r.tier.id))
+  return models.value.filter((r) => selectedModelIds.value.includes(r.model.modelId))
 }
 
 const totalCost = computed(() =>
   selectedResolved().reduce((sum, r) => {
     if (modality.value === 'image') {
-      return sum + estimateImageCost({ baseImagePrice: r.candidate.baseImagePrice || 0, size: DEFAULT_IMAGE_SIZE, n: 1, rateMultiplier: props.rateMultiplier })
+      return sum + estimateImageCost({ baseImagePrice: r.model.baseImagePrice || 0, size: DEFAULT_IMAGE_SIZE, n: 1, rateMultiplier: props.rateMultiplier })
     }
-    return sum + estimateVideoCost({ perSecond: r.candidate.perSecond || 0, seconds: duration.value, rateMultiplier: props.rateMultiplier })
+    return sum + estimateVideoCost({ perSecond: r.model.perSecond || 0, seconds: duration.value, rateMultiplier: props.rateMultiplier })
   }, 0)
 )
 
@@ -226,29 +227,29 @@ const totalCost = computed(() =>
 const totalHold = computed(() =>
   selectedResolved().reduce((sum, r) => {
     if (modality.value === 'image') {
-      return sum + estimateImageHoldCost({ baseImagePrice: r.candidate.baseImagePrice || 0, n: 1, rateMultiplier: props.rateMultiplier })
+      return sum + estimateImageHoldCost({ baseImagePrice: r.model.baseImagePrice || 0, n: 1, rateMultiplier: props.rateMultiplier })
     }
-    return sum + estimateVideoCost({ perSecond: r.candidate.perSecond || 0, seconds: duration.value, rateMultiplier: props.rateMultiplier })
+    return sum + estimateVideoCost({ perSecond: r.model.perSecond || 0, seconds: duration.value, rateMultiplier: props.rateMultiplier })
   }, 0)
 )
 const canAfford = computed(() => totalHold.value <= props.balance)
 const canRun = computed(
-  () => !running.value && !!props.apiKey && !!prompt.value.trim() && selectedTierIds.value.length >= 2 && canAfford.value && props.keyId != null
+  () => !running.value && !!props.apiKey && !!prompt.value.trim() && selectedModelIds.value.length >= 2 && canAfford.value && props.keyId != null
 )
 
 function setModality(m: StudioModality): void {
   if (running.value) return
   modality.value = m
-  selectedTierIds.value = []
+  selectedModelIds.value = []
   panels.value = []
   videoTasks.value = []
 }
 
-function toggleTier(id: string): void {
+function toggleModel(id: string): void {
   if (running.value) return
-  const i = selectedTierIds.value.indexOf(id)
-  if (i >= 0) selectedTierIds.value.splice(i, 1)
-  else if (selectedTierIds.value.length < MAX_PANELS) selectedTierIds.value.push(id)
+  const i = selectedModelIds.value.indexOf(id)
+  if (i >= 0) selectedModelIds.value.splice(i, 1)
+  else if (selectedModelIds.value.length < MAX_PANELS) selectedModelIds.value.push(id)
 }
 
 function formatElapsed(s: number): string {
@@ -267,14 +268,14 @@ async function run(): Promise<void> {
   videoTasks.value = []
   // Seed panels.
   panels.value = chosen.map((r) => ({
-    tierId: r.tier.id,
-    labelKey: r.tier.labelKey,
-    modelId: r.candidate.modelId,
-    vendorLabel: r.candidate.vendorLabel,
+    modelId: r.model.modelId,
+    servedId: r.servedId,
+    label: r.model.displayName,
+    vendorLabel: r.model.vendorLabel,
     cost:
       modality.value === 'image'
-        ? estimateImageCost({ baseImagePrice: r.candidate.baseImagePrice || 0, size: DEFAULT_IMAGE_SIZE, n: 1, rateMultiplier: props.rateMultiplier })
-        : estimateVideoCost({ perSecond: r.candidate.perSecond || 0, seconds: duration.value, rateMultiplier: props.rateMultiplier }),
+        ? estimateImageCost({ baseImagePrice: r.model.baseImagePrice || 0, size: DEFAULT_IMAGE_SIZE, n: 1, rateMultiplier: props.rateMultiplier })
+        : estimateVideoCost({ perSecond: r.model.perSecond || 0, seconds: duration.value, rateMultiplier: props.rateMultiplier }),
     state: 'processing',
   }))
 
@@ -283,7 +284,7 @@ async function run(): Promise<void> {
       await Promise.all(
         panels.value.map(async (panel) => {
           try {
-            const raw = await gatewayImageGenerations(props.apiKey, props.gatewayBase, { model: panel.modelId, prompt: text, size: DEFAULT_IMAGE_SIZE, n: 1 })
+            const raw = await gatewayImageGenerations(props.apiKey, props.gatewayBase, { model: panel.servedId, prompt: text, size: DEFAULT_IMAGE_SIZE, n: 1 })
             const items = extractImageItems(raw)
             if (!items.length) throw new Error('no_image')
             panel.src = items[0].src
@@ -300,7 +301,7 @@ async function run(): Promise<void> {
       await Promise.all(
         panels.value.map(async (panel) => {
           try {
-            const raw = await gatewayVideoSubmit(props.apiKey, props.gatewayBase, { model: panel.modelId, prompt: text, duration: duration.value })
+            const raw = await gatewayVideoSubmit(props.apiKey, props.gatewayBase, { model: panel.servedId, prompt: text, duration: duration.value })
             const taskId = extractVideoTaskId(raw)
             if (!taskId) throw new Error('no_task')
             panel.taskId = taskId
@@ -310,7 +311,7 @@ async function run(): Promise<void> {
             const task: VideoTaskItem = {
               id: taskId,
               prompt: text,
-              model: panel.modelId,
+              model: panel.servedId,
               vendorLabel: panel.vendorLabel,
               seconds: duration.value,
               estCost: panel.cost,

--- a/frontend/src/views/user/studio/BakeOff.vue
+++ b/frontend/src/views/user/studio/BakeOff.vue
@@ -53,7 +53,7 @@
             @click="toggleModel(r.model.modelId)"
           >
             {{ r.model.displayName }}
-            <span class="opacity-70">{{ modality === 'image' ? formatUsd(r.model.baseImagePrice || 0) + t('studio.image.perImageUnit') : formatUsd(r.model.perSecond || 0) + t('studio.video.perSecondUnit') }}</span>
+            <span class="opacity-70">{{ modality === 'image' ? formatUsd(r.baseImagePrice || 0) + t('studio.image.perImageUnit') : formatUsd(r.perSecond || 0) + t('studio.video.perSecondUnit') }}</span>
           </button>
         </div>
 
@@ -138,6 +138,7 @@ import {
   VIDEO_DURATION_DEFAULT,
   resolveAvailableModels,
   type StudioModality,
+  type MediaPriceMap,
 } from '@/constants/mediaTiers.tk'
 import { estimateImageCost, estimateImageHoldCost, estimateVideoCost, formatUsd } from '@/utils/mediaCostEstimate.tk'
 import { classifyGatewayError, studioErrorI18nKey, type StudioErrorCode } from '@/utils/studioGatewayError.tk'
@@ -149,6 +150,7 @@ const props = defineProps<{
   apiKey: string
   gatewayBase: string
   availableIds: Set<string>
+  priceMap: MediaPriceMap
   balance: number
   keyId: number | null
   keys: ApiKey[]
@@ -162,7 +164,7 @@ const MAX_PANELS = 4
 const DEFAULT_IMAGE_SIZE = '1024x1024'
 
 const modality = ref<StudioModality>('video')
-const models = computed(() => resolveAvailableModels(modality.value, props.availableIds))
+const models = computed(() => resolveAvailableModels(modality.value, props.availableIds, props.priceMap))
 const selectedModelIds = ref<string[]>([])
 const prompt = ref('')
 const duration = ref(VIDEO_DURATION_DEFAULT)
@@ -217,9 +219,9 @@ function selectedResolved() {
 const totalCost = computed(() =>
   selectedResolved().reduce((sum, r) => {
     if (modality.value === 'image') {
-      return sum + estimateImageCost({ baseImagePrice: r.model.baseImagePrice || 0, size: DEFAULT_IMAGE_SIZE, n: 1, rateMultiplier: props.rateMultiplier })
+      return sum + estimateImageCost({ baseImagePrice: r.baseImagePrice || 0, size: DEFAULT_IMAGE_SIZE, n: 1, rateMultiplier: props.rateMultiplier })
     }
-    return sum + estimateVideoCost({ perSecond: r.model.perSecond || 0, seconds: duration.value, rateMultiplier: props.rateMultiplier })
+    return sum + estimateVideoCost({ perSecond: r.perSecond || 0, seconds: duration.value, rateMultiplier: props.rateMultiplier })
   }, 0)
 )
 
@@ -227,9 +229,9 @@ const totalCost = computed(() =>
 const totalHold = computed(() =>
   selectedResolved().reduce((sum, r) => {
     if (modality.value === 'image') {
-      return sum + estimateImageHoldCost({ baseImagePrice: r.model.baseImagePrice || 0, n: 1, rateMultiplier: props.rateMultiplier })
+      return sum + estimateImageHoldCost({ baseImagePrice: r.baseImagePrice || 0, n: 1, rateMultiplier: props.rateMultiplier })
     }
-    return sum + estimateVideoCost({ perSecond: r.model.perSecond || 0, seconds: duration.value, rateMultiplier: props.rateMultiplier })
+    return sum + estimateVideoCost({ perSecond: r.perSecond || 0, seconds: duration.value, rateMultiplier: props.rateMultiplier })
   }, 0)
 )
 const canAfford = computed(() => totalHold.value <= props.balance)
@@ -274,8 +276,8 @@ async function run(): Promise<void> {
     vendorLabel: r.model.vendorLabel,
     cost:
       modality.value === 'image'
-        ? estimateImageCost({ baseImagePrice: r.model.baseImagePrice || 0, size: DEFAULT_IMAGE_SIZE, n: 1, rateMultiplier: props.rateMultiplier })
-        : estimateVideoCost({ perSecond: r.model.perSecond || 0, seconds: duration.value, rateMultiplier: props.rateMultiplier }),
+        ? estimateImageCost({ baseImagePrice: r.baseImagePrice || 0, size: DEFAULT_IMAGE_SIZE, n: 1, rateMultiplier: props.rateMultiplier })
+        : estimateVideoCost({ perSecond: r.perSecond || 0, seconds: duration.value, rateMultiplier: props.rateMultiplier }),
     state: 'processing',
   }))
 

--- a/frontend/src/views/user/studio/ImageStudio.vue
+++ b/frontend/src/views/user/studio/ImageStudio.vue
@@ -30,7 +30,7 @@
               <span class="shrink-0 rounded bg-gray-100 px-1.5 py-0.5 text-[10px] font-medium text-gray-600 dark:bg-dark-800 dark:text-dark-300">{{ t(r.model.qualityBadgeKey) }}</span>
             </div>
             <div class="mt-1 flex items-center justify-between gap-2">
-              <span class="text-[12px] font-bold text-primary-700 dark:text-primary-300">{{ formatUsd(r.model.baseImagePrice || 0) }}{{ t('studio.image.perImageUnit') }}</span>
+              <span class="text-[12px] font-bold text-primary-700 dark:text-primary-300">{{ formatUsd(r.baseImagePrice || 0) }}{{ t('studio.image.perImageUnit') }}</span>
               <span class="text-[10px] text-gray-400 dark:text-dark-500">{{ t('studio.via', { vendor: r.model.vendorLabel }) }}</span>
             </div>
             <div class="mt-0.5 truncate font-mono text-[10px] text-gray-400 dark:text-dark-500" :title="r.servedId">{{ r.servedId }}</div>
@@ -76,28 +76,8 @@
             <button type="button" class="h-7 w-7 rounded-lg border border-gray-200 text-gray-600 hover:border-primary-300 disabled:opacity-40 dark:border-dark-600 dark:text-dark-300" :disabled="n >= IMAGE_N_MAX" @click="n = Math.min(IMAGE_N_MAX, n + 1)">+</button>
           </div>
         </div>
-
-        <!-- Advanced: only params the SELECTED model actually honors are rendered. -->
-        <template v-if="selected && selected.model.supportedParams.length">
-          <button
-            type="button"
-            class="mt-3 flex items-center gap-1 text-xs font-medium text-primary-600 dark:text-primary-300"
-            data-testid="studio-image-advanced-toggle"
-            @click="showAdvanced = !showAdvanced"
-          >
-            {{ t('studio.advanced.toggle') }} <span>{{ showAdvanced ? '▴' : '▾' }}</span>
-          </button>
-          <div v-if="showAdvanced" class="mt-2 space-y-3 rounded-lg border border-dashed border-gray-200 p-3 dark:border-dark-700">
-            <div v-if="supports('negativePrompt')">
-              <label class="mb-1 block text-xs font-medium text-gray-600 dark:text-dark-400">{{ t('studio.advanced.negativePrompt') }}</label>
-              <input v-model="negativePrompt" type="text" :placeholder="t('studio.advanced.negativePromptHint')" class="w-full rounded-lg border border-gray-200 bg-white px-3 py-1.5 text-sm text-gray-900 dark:border-dark-600 dark:bg-dark-950 dark:text-white" />
-            </div>
-            <div v-if="supports('seed')">
-              <label class="mb-1 block text-xs font-medium text-gray-600 dark:text-dark-400">{{ t('studio.advanced.seed') }}</label>
-              <input v-model.number="seed" type="number" :min="SEED_MIN" :max="SEED_MAX" :placeholder="t('studio.advanced.seedHint')" class="w-full rounded-lg border border-gray-200 bg-white px-3 py-1.5 text-sm text-gray-900 dark:border-dark-600 dark:bg-dark-950 dark:text-white" />
-            </div>
-          </div>
-        </template>
+        <!-- No Advanced panel for image: imagen / seedream adaptors honor no
+             tunable params beyond size + count (verified against new-api). -->
       </div>
     </div>
 
@@ -188,11 +168,9 @@ import {
   IMAGE_ASPECT_PRESETS,
   IMAGE_N_MIN,
   IMAGE_N_MAX,
-  SEED_MIN,
-  SEED_MAX,
   resolveAvailableModels,
   defaultModelId,
-  type StudioParam,
+  type MediaPriceMap,
 } from '@/constants/mediaTiers.tk'
 import {
   classifyImageBillingTier,
@@ -209,6 +187,7 @@ const props = defineProps<{
   apiKey: string
   gatewayBase: string
   availableIds: Set<string>
+  priceMap: MediaPriceMap
   balance: number
   userId: number | string
   rateMultiplier: number
@@ -218,10 +197,9 @@ const emit = defineEmits<{ (e: 'spent'): void }>()
 const { t } = useI18n()
 const library = useMediaLibrary(props.userId)
 
-const models = computed(() => resolveAvailableModels('image', props.availableIds))
+const models = computed(() => resolveAvailableModels('image', props.availableIds, props.priceMap))
 const selectedModelId = ref<string>('')
 const selected = computed(() => models.value.find((r) => r.model.modelId === selectedModelId.value) ?? null)
-const supports = (p: StudioParam): boolean => !!selected.value?.model.supportedParams.includes(p)
 
 const aspectId = ref<string>(IMAGE_ASPECT_PRESETS[0].id)
 const aspectPreset = computed(() => IMAGE_ASPECT_PRESETS.find((p) => p.id === aspectId.value) ?? IMAGE_ASPECT_PRESETS[0])
@@ -235,15 +213,10 @@ const sending = ref(false)
 const errorMessage = ref('')
 const errorCode = ref<StudioErrorCode | ''>('')
 
-// Advanced (optional; only sent when set). Smooth defaults: hit Generate works.
-const showAdvanced = ref(false)
-const seed = ref<number | null>(null)
-const negativePrompt = ref('')
-
 const estimate = computed(() => {
   if (!selected.value) return 0
   return estimateImageCost({
-    baseImagePrice: selected.value.model.baseImagePrice || 0,
+    baseImagePrice: selected.value.baseImagePrice || 0,
     size: aspectPreset.value.size,
     n: n.value,
     rateMultiplier: props.rateMultiplier,
@@ -255,7 +228,7 @@ const estimate = computed(() => {
 const holdEstimate = computed(() => {
   if (!selected.value) return 0
   return estimateImageHoldCost({
-    baseImagePrice: selected.value.model.baseImagePrice || 0,
+    baseImagePrice: selected.value.baseImagePrice || 0,
     n: n.value,
     rateMultiplier: props.rateMultiplier,
   })
@@ -266,7 +239,7 @@ const canGenerate = computed(
 )
 const formula = computed(() => {
   if (!selected.value) return ''
-  const base = formatUsd(selected.value.model.baseImagePrice || 0)
+  const base = formatUsd(selected.value.baseImagePrice || 0)
   return t('studio.image.formula', { base, tier: classifiedTier.value, mult: sizeMultiplier.value, n: n.value })
 })
 
@@ -309,15 +282,11 @@ async function generate(): Promise<void> {
       prompt: text,
       size: aspectPreset.value.size,
       n: n.value,
-      ...(supports('negativePrompt') && negativePrompt.value.trim()
-        ? { negative_prompt: negativePrompt.value.trim() }
-        : {}),
-      ...(supports('seed') && seed.value != null ? { seed: seed.value } : {}),
     })
     const items = extractImageItems(raw)
     if (!items.length) throw new Error(t('studio.image.noResult'))
     const perImage = estimateImageCost({
-      baseImagePrice: resolved.model.baseImagePrice || 0,
+      baseImagePrice: resolved.baseImagePrice || 0,
       size: aspectPreset.value.size,
       n: 1,
       rateMultiplier: props.rateMultiplier,

--- a/frontend/src/views/user/studio/ImageStudio.vue
+++ b/frontend/src/views/user/studio/ImageStudio.vue
@@ -88,18 +88,6 @@
             {{ t('studio.advanced.toggle') }} <span>{{ showAdvanced ? '▴' : '▾' }}</span>
           </button>
           <div v-if="showAdvanced" class="mt-2 space-y-3 rounded-lg border border-dashed border-gray-200 p-3 dark:border-dark-700">
-            <div v-if="supports('quality')">
-              <div class="mb-1 text-xs font-medium text-gray-600 dark:text-dark-400">{{ t('studio.advanced.quality') }}</div>
-              <div class="flex gap-2">
-                <button v-for="q in IMAGE_QUALITY_OPTIONS" :key="q" type="button" class="rounded-lg border px-3 py-1 text-xs font-medium transition" :class="quality === q ? 'border-primary-600 bg-primary-600 text-white' : 'border-gray-200 text-gray-600 dark:border-dark-600 dark:text-dark-300'" @click="quality = q">{{ q }}</button>
-              </div>
-            </div>
-            <div v-if="supports('style')">
-              <div class="mb-1 text-xs font-medium text-gray-600 dark:text-dark-400">{{ t('studio.advanced.style') }}</div>
-              <div class="flex gap-2">
-                <button v-for="s in IMAGE_STYLE_OPTIONS" :key="s" type="button" class="rounded-lg border px-3 py-1 text-xs font-medium transition" :class="style === s ? 'border-primary-600 bg-primary-600 text-white' : 'border-gray-200 text-gray-600 dark:border-dark-600 dark:text-dark-300'" @click="style = s">{{ s }}</button>
-              </div>
-            </div>
             <div v-if="supports('negativePrompt')">
               <label class="mb-1 block text-xs font-medium text-gray-600 dark:text-dark-400">{{ t('studio.advanced.negativePrompt') }}</label>
               <input v-model="negativePrompt" type="text" :placeholder="t('studio.advanced.negativePromptHint')" class="w-full rounded-lg border border-gray-200 bg-white px-3 py-1.5 text-sm text-gray-900 dark:border-dark-600 dark:bg-dark-950 dark:text-white" />
@@ -200,8 +188,6 @@ import {
   IMAGE_ASPECT_PRESETS,
   IMAGE_N_MIN,
   IMAGE_N_MAX,
-  IMAGE_QUALITY_OPTIONS,
-  IMAGE_STYLE_OPTIONS,
   SEED_MIN,
   SEED_MAX,
   resolveAvailableModels,
@@ -251,8 +237,6 @@ const errorCode = ref<StudioErrorCode | ''>('')
 
 // Advanced (optional; only sent when set). Smooth defaults: hit Generate works.
 const showAdvanced = ref(false)
-const quality = ref<string>('standard')
-const style = ref<string>('vivid')
 const seed = ref<number | null>(null)
 const negativePrompt = ref('')
 
@@ -325,8 +309,6 @@ async function generate(): Promise<void> {
       prompt: text,
       size: aspectPreset.value.size,
       n: n.value,
-      ...(supports('quality') && quality.value !== 'standard' ? { quality: quality.value } : {}),
-      ...(supports('style') ? { style: style.value } : {}),
       ...(supports('negativePrompt') && negativePrompt.value.trim()
         ? { negative_prompt: negativePrompt.value.trim() }
         : {}),

--- a/frontend/src/views/user/studio/ImageStudio.vue
+++ b/frontend/src/views/user/studio/ImageStudio.vue
@@ -33,7 +33,7 @@
               <span class="text-[12px] font-bold text-primary-700 dark:text-primary-300">{{ formatUsd(r.model.baseImagePrice || 0) }}{{ t('studio.image.perImageUnit') }}</span>
               <span class="text-[10px] text-gray-400 dark:text-dark-500">{{ t('studio.via', { vendor: r.model.vendorLabel }) }}</span>
             </div>
-            <div class="mt-0.5 truncate font-mono text-[10px] text-gray-300 dark:text-dark-600" :title="r.servedId">{{ r.servedId }}</div>
+            <div class="mt-0.5 truncate font-mono text-[10px] text-gray-400 dark:text-dark-500" :title="r.servedId">{{ r.servedId }}</div>
             <div v-if="r.model.needsApikeyAccount" class="mt-1 text-[10px] font-medium text-amber-600 dark:text-amber-400">{{ t('studio.needsApikeyAccount') }}</div>
           </button>
         </div>

--- a/frontend/src/views/user/studio/ImageStudio.vue
+++ b/frontend/src/views/user/studio/ImageStudio.vue
@@ -55,13 +55,16 @@
               v-for="p in IMAGE_ASPECT_PRESETS"
               :key="p.id"
               type="button"
-              class="rounded-lg border px-3 py-1.5 text-sm font-medium transition"
+              class="rounded-lg border px-3 py-1.5 text-left transition"
               :class="aspectId === p.id
                 ? 'border-primary-600 bg-primary-600 text-white'
                 : 'border-gray-200 text-gray-600 hover:border-primary-300 dark:border-dark-600 dark:text-dark-300'"
               @click="aspectId = p.id"
             >
-              {{ t(p.labelKey) }}
+              <div class="text-sm font-medium">{{ t(p.labelKey) }}</div>
+              <!-- Real size + price multiplier on the chip: this is a SIZE control,
+                   not a bare aspect ratio — landscape/portrait bill at ×1.5. -->
+              <div class="text-[10px] tabular-nums opacity-70">{{ p.size }} · ×{{ presetMultiplier(p) }}</div>
             </button>
           </div>
           <p class="mt-1.5 text-[11px] text-gray-400 dark:text-dark-500">
@@ -171,6 +174,7 @@ import {
   resolveAvailableModels,
   defaultModelId,
   type MediaPriceMap,
+  type ImageAspectPreset,
 } from '@/constants/mediaTiers.tk'
 import {
   classifyImageBillingTier,
@@ -205,6 +209,10 @@ const aspectId = ref<string>(IMAGE_ASPECT_PRESETS[0].id)
 const aspectPreset = computed(() => IMAGE_ASPECT_PRESETS.find((p) => p.id === aspectId.value) ?? IMAGE_ASPECT_PRESETS[0])
 const classifiedTier = computed(() => classifyImageBillingTier(aspectPreset.value.size))
 const sizeMultiplier = computed(() => IMAGE_SIZE_MULTIPLIER[classifiedTier.value])
+// Per-preset billing multiplier (shown on each chip so the size→price tie is visible).
+function presetMultiplier(p: ImageAspectPreset): number {
+  return IMAGE_SIZE_MULTIPLIER[classifyImageBillingTier(p.size)]
+}
 
 const n = ref(1)
 const prompt = ref('')

--- a/frontend/src/views/user/studio/ImageStudio.vue
+++ b/frontend/src/views/user/studio/ImageStudio.vue
@@ -2,37 +2,44 @@
   <div class="grid grid-cols-1 gap-5 lg:grid-cols-[340px_1fr_250px]">
     <!-- LEFT: orchestration -->
     <div class="space-y-4">
-      <div v-if="tiers.length === 0" class="rounded-xl border border-dashed border-gray-300 bg-white/60 p-6 text-center text-sm text-gray-500 dark:border-dark-700 dark:bg-dark-900/40 dark:text-dark-400">
-        {{ t('studio.image.tierEmpty') }}
+      <div v-if="models.length === 0" class="rounded-xl border border-dashed border-gray-300 bg-white/60 p-6 text-center text-sm text-gray-500 dark:border-dark-700 dark:bg-dark-900/40 dark:text-dark-400">
+        {{ t('studio.image.modelEmpty') }}
         <router-link class="mt-1 block font-medium text-primary-600 underline dark:text-primary-400" to="/pricing">
           {{ t('studio.viewPricing') }}
         </router-link>
       </div>
 
+      <!-- Transparent MODEL picker: the actual model is the choice, shown humanely
+           (friendly name + price + vendor + raw id subtext + quality badge). -->
       <div v-else class="rounded-xl border border-gray-200 bg-white p-4 shadow-sm dark:border-dark-700 dark:bg-dark-900">
-        <div class="mb-2 text-xs font-semibold uppercase tracking-wide text-gray-400 dark:text-dark-500">{{ t('studio.image.tierLabel') }}</div>
-        <div class="grid grid-cols-3 gap-2">
+        <div class="mb-2 text-xs font-semibold uppercase tracking-wide text-gray-400 dark:text-dark-500">{{ t('studio.image.modelLabel') }}</div>
+        <div class="space-y-2">
           <button
-            v-for="r in tiers"
-            :key="r.tier.id"
+            v-for="r in models"
+            :key="r.model.modelId"
             type="button"
-            class="rounded-xl border p-2.5 text-left transition"
-            :class="selectedTierId === r.tier.id
+            class="w-full rounded-xl border p-3 text-left transition"
+            :class="selectedModelId === r.model.modelId
               ? 'border-primary-500 bg-primary-50 ring-2 ring-primary-500/30 dark:border-primary-500 dark:bg-primary-950/40'
               : 'border-gray-200 hover:border-primary-300 dark:border-dark-600'"
-            @click="selectTier(r.tier.id)"
+            data-testid="studio-image-model"
+            @click="selectedModelId = r.model.modelId"
           >
-            <div class="text-[13px] font-semibold text-gray-900 dark:text-white">{{ t(r.tier.labelKey) }}</div>
-            <div class="text-[11px] text-gray-500 dark:text-dark-400">{{ t(r.tier.taglineKey) }}</div>
-            <div class="mt-1 text-[12px] font-bold text-primary-700 dark:text-primary-300">
-              {{ formatUsd(r.candidate.baseImagePrice || 0) }}{{ t('studio.image.perImageUnit') }}
+            <div class="flex items-center justify-between gap-2">
+              <span class="text-[13px] font-semibold text-gray-900 dark:text-white">{{ r.model.displayName }}</span>
+              <span class="shrink-0 rounded bg-gray-100 px-1.5 py-0.5 text-[10px] font-medium text-gray-600 dark:bg-dark-800 dark:text-dark-300">{{ t(r.model.qualityBadgeKey) }}</span>
             </div>
-            <div class="text-[10px] text-gray-400 dark:text-dark-500">{{ t('studio.via', { vendor: r.candidate.vendorLabel }) }}</div>
+            <div class="mt-1 flex items-center justify-between gap-2">
+              <span class="text-[12px] font-bold text-primary-700 dark:text-primary-300">{{ formatUsd(r.model.baseImagePrice || 0) }}{{ t('studio.image.perImageUnit') }}</span>
+              <span class="text-[10px] text-gray-400 dark:text-dark-500">{{ t('studio.via', { vendor: r.model.vendorLabel }) }}</span>
+            </div>
+            <div class="mt-0.5 truncate font-mono text-[10px] text-gray-300 dark:text-dark-600" :title="r.servedId">{{ r.servedId }}</div>
+            <div v-if="r.model.needsApikeyAccount" class="mt-1 text-[10px] font-medium text-amber-600 dark:text-amber-400">{{ t('studio.needsApikeyAccount') }}</div>
           </button>
         </div>
       </div>
 
-      <div v-if="tiers.length" class="rounded-xl border border-gray-200 bg-white p-4 shadow-sm dark:border-dark-700 dark:bg-dark-900">
+      <div v-if="models.length" class="rounded-xl border border-gray-200 bg-white p-4 shadow-sm dark:border-dark-700 dark:bg-dark-900">
         <textarea
           v-model="prompt"
           rows="3"
@@ -69,6 +76,40 @@
             <button type="button" class="h-7 w-7 rounded-lg border border-gray-200 text-gray-600 hover:border-primary-300 disabled:opacity-40 dark:border-dark-600 dark:text-dark-300" :disabled="n >= IMAGE_N_MAX" @click="n = Math.min(IMAGE_N_MAX, n + 1)">+</button>
           </div>
         </div>
+
+        <!-- Advanced: only params the SELECTED model actually honors are rendered. -->
+        <template v-if="selected && selected.model.supportedParams.length">
+          <button
+            type="button"
+            class="mt-3 flex items-center gap-1 text-xs font-medium text-primary-600 dark:text-primary-300"
+            data-testid="studio-image-advanced-toggle"
+            @click="showAdvanced = !showAdvanced"
+          >
+            {{ t('studio.advanced.toggle') }} <span>{{ showAdvanced ? '▴' : '▾' }}</span>
+          </button>
+          <div v-if="showAdvanced" class="mt-2 space-y-3 rounded-lg border border-dashed border-gray-200 p-3 dark:border-dark-700">
+            <div v-if="supports('quality')">
+              <div class="mb-1 text-xs font-medium text-gray-600 dark:text-dark-400">{{ t('studio.advanced.quality') }}</div>
+              <div class="flex gap-2">
+                <button v-for="q in IMAGE_QUALITY_OPTIONS" :key="q" type="button" class="rounded-lg border px-3 py-1 text-xs font-medium transition" :class="quality === q ? 'border-primary-600 bg-primary-600 text-white' : 'border-gray-200 text-gray-600 dark:border-dark-600 dark:text-dark-300'" @click="quality = q">{{ q }}</button>
+              </div>
+            </div>
+            <div v-if="supports('style')">
+              <div class="mb-1 text-xs font-medium text-gray-600 dark:text-dark-400">{{ t('studio.advanced.style') }}</div>
+              <div class="flex gap-2">
+                <button v-for="s in IMAGE_STYLE_OPTIONS" :key="s" type="button" class="rounded-lg border px-3 py-1 text-xs font-medium transition" :class="style === s ? 'border-primary-600 bg-primary-600 text-white' : 'border-gray-200 text-gray-600 dark:border-dark-600 dark:text-dark-300'" @click="style = s">{{ s }}</button>
+              </div>
+            </div>
+            <div v-if="supports('negativePrompt')">
+              <label class="mb-1 block text-xs font-medium text-gray-600 dark:text-dark-400">{{ t('studio.advanced.negativePrompt') }}</label>
+              <input v-model="negativePrompt" type="text" :placeholder="t('studio.advanced.negativePromptHint')" class="w-full rounded-lg border border-gray-200 bg-white px-3 py-1.5 text-sm text-gray-900 dark:border-dark-600 dark:bg-dark-950 dark:text-white" />
+            </div>
+            <div v-if="supports('seed')">
+              <label class="mb-1 block text-xs font-medium text-gray-600 dark:text-dark-400">{{ t('studio.advanced.seed') }}</label>
+              <input v-model.number="seed" type="number" :min="SEED_MIN" :max="SEED_MAX" :placeholder="t('studio.advanced.seedHint')" class="w-full rounded-lg border border-gray-200 bg-white px-3 py-1.5 text-sm text-gray-900 dark:border-dark-600 dark:bg-dark-950 dark:text-white" />
+            </div>
+          </div>
+        </template>
       </div>
     </div>
 
@@ -107,8 +148,8 @@
     </div>
 
     <!-- RIGHT: cost panel + button (the spine). Hidden when the group serves no
-         image tier — no point showing a $0 panel and a dead Generate button. -->
-    <div v-if="tiers.length" class="space-y-4">
+         image model — no point showing a $0 panel and a dead Generate button. -->
+    <div v-if="models.length" class="space-y-4">
       <div class="rounded-xl border border-primary-200 bg-primary-50/40 p-4 shadow-sm dark:border-primary-900/40 dark:bg-primary-950/30">
         <div class="text-xs font-semibold uppercase tracking-wide text-primary-700 dark:text-primary-300">{{ t('studio.cost.thisGeneration') }}</div>
         <div class="mt-2 font-mono text-[12px] text-gray-600 dark:text-dark-300">{{ formula }}</div>
@@ -159,7 +200,13 @@ import {
   IMAGE_ASPECT_PRESETS,
   IMAGE_N_MIN,
   IMAGE_N_MAX,
-  resolveAvailableTiers,
+  IMAGE_QUALITY_OPTIONS,
+  IMAGE_STYLE_OPTIONS,
+  SEED_MIN,
+  SEED_MAX,
+  resolveAvailableModels,
+  defaultModelId,
+  type StudioParam,
 } from '@/constants/mediaTiers.tk'
 import {
   classifyImageBillingTier,
@@ -185,9 +232,10 @@ const emit = defineEmits<{ (e: 'spent'): void }>()
 const { t } = useI18n()
 const library = useMediaLibrary(props.userId)
 
-const tiers = computed(() => resolveAvailableTiers('image', props.availableIds))
-const selectedTierId = ref<string>('')
-const selected = computed(() => tiers.value.find((r) => r.tier.id === selectedTierId.value) ?? null)
+const models = computed(() => resolveAvailableModels('image', props.availableIds))
+const selectedModelId = ref<string>('')
+const selected = computed(() => models.value.find((r) => r.model.modelId === selectedModelId.value) ?? null)
+const supports = (p: StudioParam): boolean => !!selected.value?.model.supportedParams.includes(p)
 
 const aspectId = ref<string>(IMAGE_ASPECT_PRESETS[0].id)
 const aspectPreset = computed(() => IMAGE_ASPECT_PRESETS.find((p) => p.id === aspectId.value) ?? IMAGE_ASPECT_PRESETS[0])
@@ -201,10 +249,17 @@ const sending = ref(false)
 const errorMessage = ref('')
 const errorCode = ref<StudioErrorCode | ''>('')
 
+// Advanced (optional; only sent when set). Smooth defaults: hit Generate works.
+const showAdvanced = ref(false)
+const quality = ref<string>('standard')
+const style = ref<string>('vivid')
+const seed = ref<number | null>(null)
+const negativePrompt = ref('')
+
 const estimate = computed(() => {
   if (!selected.value) return 0
   return estimateImageCost({
-    baseImagePrice: selected.value.candidate.baseImagePrice || 0,
+    baseImagePrice: selected.value.model.baseImagePrice || 0,
     size: aspectPreset.value.size,
     n: n.value,
     rateMultiplier: props.rateMultiplier,
@@ -216,7 +271,7 @@ const estimate = computed(() => {
 const holdEstimate = computed(() => {
   if (!selected.value) return 0
   return estimateImageHoldCost({
-    baseImagePrice: selected.value.candidate.baseImagePrice || 0,
+    baseImagePrice: selected.value.model.baseImagePrice || 0,
     n: n.value,
     rateMultiplier: props.rateMultiplier,
   })
@@ -227,29 +282,21 @@ const canGenerate = computed(
 )
 const formula = computed(() => {
   if (!selected.value) return ''
-  const base = formatUsd(selected.value.candidate.baseImagePrice || 0)
+  const base = formatUsd(selected.value.model.baseImagePrice || 0)
   return t('studio.image.formula', { base, tier: classifiedTier.value, mult: sizeMultiplier.value, n: n.value })
 })
 
-function selectTier(id: string): void {
-  selectedTierId.value = id
-}
-
 function applySamplePrompt(): void {
   if (userEditedPrompt.value) return
-  if (selected.value) prompt.value = t(selected.value.tier.samplePromptKey)
+  prompt.value = t('studio.image.samplePrompt')
 }
 
-// Pick the first tier once tiers resolve; refresh sample prompt on tier change.
+// Pick the cheapest non-footgun model once models resolve.
 watch(
-  tiers,
+  models,
   (list) => {
-    if (!list.length) {
-      selectedTierId.value = ''
-      return
-    }
-    if (!list.some((r) => r.tier.id === selectedTierId.value)) {
-      selectedTierId.value = list[0].tier.id
+    if (!list.some((r) => r.model.modelId === selectedModelId.value)) {
+      selectedModelId.value = defaultModelId(list) ?? ''
     }
   },
   { immediate: true }
@@ -274,15 +321,21 @@ async function generate(): Promise<void> {
   sending.value = true
   try {
     const raw = await gatewayImageGenerations(props.apiKey, props.gatewayBase, {
-      model: resolved.candidate.modelId,
+      model: resolved.servedId,
       prompt: text,
       size: aspectPreset.value.size,
       n: n.value,
+      ...(supports('quality') && quality.value !== 'standard' ? { quality: quality.value } : {}),
+      ...(supports('style') ? { style: style.value } : {}),
+      ...(supports('negativePrompt') && negativePrompt.value.trim()
+        ? { negative_prompt: negativePrompt.value.trim() }
+        : {}),
+      ...(supports('seed') && seed.value != null ? { seed: seed.value } : {}),
     })
     const items = extractImageItems(raw)
     if (!items.length) throw new Error(t('studio.image.noResult'))
     const perImage = estimateImageCost({
-      baseImagePrice: resolved.candidate.baseImagePrice || 0,
+      baseImagePrice: resolved.model.baseImagePrice || 0,
       size: aspectPreset.value.size,
       n: 1,
       rateMultiplier: props.rateMultiplier,
@@ -293,8 +346,8 @@ async function generate(): Promise<void> {
       src: it.src,
       prompt: text,
       revisedPrompt: it.revisedPrompt,
-      model: resolved.candidate.modelId,
-      vendorLabel: resolved.candidate.vendorLabel,
+      model: resolved.servedId,
+      vendorLabel: resolved.model.vendorLabel,
       size: aspectPreset.value.size,
       cost: perImage,
       ts,

--- a/frontend/src/views/user/studio/MediaStudioView.vue
+++ b/frontend/src/views/user/studio/MediaStudioView.vue
@@ -89,6 +89,7 @@
         :api-key="apiKey"
         :gateway-base="gatewayBase"
         :available-ids="availableIds"
+        :price-map="priceMap"
         :balance="balance"
         :user-id="userId"
         :rate-multiplier="1"
@@ -99,6 +100,7 @@
         :api-key="apiKey"
         :gateway-base="gatewayBase"
         :available-ids="availableIds"
+        :price-map="priceMap"
         :balance="balance"
         :user-id="userId"
         :key-id="selectedKeyId"
@@ -111,6 +113,7 @@
         :api-key="apiKey"
         :gateway-base="gatewayBase"
         :available-ids="availableIds"
+        :price-map="priceMap"
         :balance="balance"
         :key-id="selectedKeyId"
         :keys="keys"
@@ -130,12 +133,14 @@ import VideoStudio from '@/views/user/studio/VideoStudio.vue'
 import BakeOff from '@/views/user/studio/BakeOff.vue'
 import { keysAPI } from '@/api/keys'
 import { gatewayListModels, resolveGatewayBaseUrl } from '@/api/playground'
+import { getMePricingCatalog } from '@/api/me-pricing'
 import { formatUsd } from '@/utils/mediaCostEstimate.tk'
 import {
   modalityHasTiers,
   pickModalityKey,
   type ModalityKeyOption,
   type StudioModality,
+  type MediaPrice,
 } from '@/constants/mediaTiers.tk'
 import { useAppStore } from '@/stores/app'
 import { useAuthStore } from '@/stores/auth'
@@ -153,6 +158,9 @@ const gatewayBase = ref('')
 // group up front so the picker (and the dropdown annotations) can reason about
 // EVERY key's modality, not just the one currently selected.
 const groupModelSets = ref<Map<string, Set<string>>>(new Map())
+// Live per-model price for the SELECTED key's group (getMePricingCatalog) — the
+// single source of media prices (no hardcoding, so prices can't drift).
+const priceMap = ref<Map<string, MediaPrice>>(new Map())
 const modelsLoading = ref(false)
 const probed = ref(false)
 const loadError = ref('')
@@ -250,6 +258,28 @@ async function probeAllGroups(): Promise<void> {
   }
 }
 
+// Live media prices for the selected key's group. your_price from the catalog is
+// the OFFICIAL list price (rate-decoupled by ops policy) — exactly what the cost
+// mirror needs (settlement applies the rate later), so the studio keeps
+// rateMultiplier=1. A model with no per_image/per_second price is simply omitted
+// (priced ∩ servable). Failure → empty map (models hide) rather than stale prices.
+async function loadPriceMap(keyId: number): Promise<void> {
+  try {
+    const catalog = await getMePricingCatalog({ apiKeyId: keyId })
+    const next = new Map<string, MediaPrice>()
+    for (const m of catalog.models || []) {
+      const perImage = m.your_price?.per_image
+      const perSecond = m.your_price?.per_second
+      if (perImage != null || perSecond != null) {
+        next.set(m.model_id, { perImage: perImage ?? undefined, perSecond: perSecond ?? undefined })
+      }
+    }
+    priceMap.value = next
+  } catch {
+    priceMap.value = new Map()
+  }
+}
+
 // Re-pick when the modality tab changes: if the current key already serves the
 // new modality it is kept, otherwise we move to one that does (the dropdown
 // still lets the user override). Bake-off (null modality) keeps the current key.
@@ -258,6 +288,12 @@ watch(view, () => {
   const m = pickerModality.value
   if (!m) return
   selectedKeyId.value = pickModalityKey(modalityOptions(), m, selectedKeyId.value)
+})
+
+// Refetch the price catalog whenever the selected key changes (prices are
+// per-group). Bootstrap awaits the first load before mounting the studios.
+watch(selectedKeyId, (id) => {
+  if (probed.value && id != null) void loadPriceMap(id)
 })
 
 async function bootstrap(): Promise<void> {
@@ -278,6 +314,9 @@ async function bootstrap(): Promise<void> {
     // Seed with the historical default, then let the picker move to a key whose
     // group actually serves the landing modality (view is 'image' at mount).
     selectedKeyId.value = pickModalityKey(modalityOptions(), pickerModality.value ?? 'image', seed)
+    // Load the first key's live prices before mounting, so the model cards never
+    // flash an empty "no models" state while the catalog is in flight.
+    if (selectedKeyId.value != null) await loadPriceMap(selectedKeyId.value)
     probed.value = true
   } catch (e) {
     loadError.value = e instanceof Error ? e.message : t('studio.loadFailed')

--- a/frontend/src/views/user/studio/VideoStudio.vue
+++ b/frontend/src/views/user/studio/VideoStudio.vue
@@ -32,7 +32,7 @@
               <span class="text-[12px] font-bold text-primary-700 dark:text-primary-300">{{ formatUsd(r.model.perSecond || 0) }}{{ t('studio.video.perSecondUnit') }}</span>
               <span class="text-[10px] text-gray-400 dark:text-dark-500">{{ t('studio.via', { vendor: r.model.vendorLabel }) }}</span>
             </div>
-            <div class="mt-0.5 truncate font-mono text-[10px] text-gray-300 dark:text-dark-600" :title="r.servedId">{{ r.servedId }}</div>
+            <div class="mt-0.5 truncate font-mono text-[10px] text-gray-400 dark:text-dark-500" :title="r.servedId">{{ r.servedId }}</div>
             <div v-if="r.model.needsApikeyAccount" class="mt-1 text-[10px] font-medium text-amber-600 dark:text-amber-400">{{ t('studio.needsApikeyAccount') }}</div>
           </button>
         </div>

--- a/frontend/src/views/user/studio/VideoStudio.vue
+++ b/frontend/src/views/user/studio/VideoStudio.vue
@@ -29,7 +29,7 @@
               <span class="shrink-0 rounded bg-gray-100 px-1.5 py-0.5 text-[10px] font-medium text-gray-600 dark:bg-dark-800 dark:text-dark-300">{{ t(r.model.qualityBadgeKey) }}</span>
             </div>
             <div class="mt-1 flex items-center justify-between gap-2">
-              <span class="text-[12px] font-bold text-primary-700 dark:text-primary-300">{{ formatUsd(r.model.perSecond || 0) }}{{ t('studio.video.perSecondUnit') }}</span>
+              <span class="text-[12px] font-bold text-primary-700 dark:text-primary-300">{{ formatUsd(r.perSecond || 0) }}{{ t('studio.video.perSecondUnit') }}</span>
               <span class="text-[10px] text-gray-400 dark:text-dark-500">{{ t('studio.via', { vendor: r.model.vendorLabel }) }}</span>
             </div>
             <div class="mt-0.5 truncate font-mono text-[10px] text-gray-400 dark:text-dark-500" :title="r.servedId">{{ r.servedId }}</div>
@@ -104,12 +104,6 @@
             <div v-if="supports('firstFrameImage')">
               <label class="mb-1 block text-xs font-medium text-gray-600 dark:text-dark-400">{{ t('studio.advanced.firstFrame') }}</label>
               <input v-model="firstFrameImage" type="text" :placeholder="t('studio.advanced.firstFrameHint')" class="w-full rounded-lg border border-gray-200 bg-white px-3 py-1.5 text-sm text-gray-900 dark:border-dark-600 dark:bg-dark-950 dark:text-white" />
-            </div>
-            <div v-if="supports('fps')">
-              <div class="mb-1 text-xs font-medium text-gray-600 dark:text-dark-400">{{ t('studio.advanced.fps') }}</div>
-              <div class="flex gap-2">
-                <button v-for="f in VIDEO_FPS_OPTIONS" :key="f" type="button" class="rounded-lg border px-3 py-1 text-xs font-medium transition" :class="fps === f ? 'border-primary-600 bg-primary-600 text-white' : 'border-gray-200 text-gray-600 dark:border-dark-600 dark:text-dark-300'" @click="fps = f">{{ f }}</button>
-              </div>
             </div>
             <div v-if="supports('seed')">
               <label class="mb-1 block text-xs font-medium text-gray-600 dark:text-dark-400">{{ t('studio.advanced.seed') }}</label>
@@ -257,12 +251,12 @@ import {
   VIDEO_DURATION_MIN,
   VIDEO_DURATION_MAX,
   VIDEO_DURATION_DEFAULT,
-  VIDEO_FPS_OPTIONS,
   SEED_MIN,
   SEED_MAX,
   resolveAvailableModels,
   defaultModelId,
   type StudioParam,
+  type MediaPriceMap,
 } from '@/constants/mediaTiers.tk'
 import { estimateVideoCost, formatUsd } from '@/utils/mediaCostEstimate.tk'
 import { downloadMedia } from '@/utils/studioDownload.tk'
@@ -275,6 +269,7 @@ const props = defineProps<{
   apiKey: string
   gatewayBase: string
   availableIds: Set<string>
+  priceMap: MediaPriceMap
   balance: number
   userId: number | string
   keyId: number | null
@@ -286,7 +281,7 @@ const emit = defineEmits<{ (e: 'spent'): void }>()
 const { t } = useI18n()
 const library = useMediaLibrary(props.userId)
 
-const models = computed(() => resolveAvailableModels('video', props.availableIds))
+const models = computed(() => resolveAvailableModels('video', props.availableIds, props.priceMap))
 const selectedModelId = ref<string>('')
 const selected = computed(() => models.value.find((r) => r.model.modelId === selectedModelId.value) ?? null)
 const supports = (p: StudioParam): boolean => !!selected.value?.model.supportedParams.includes(p)
@@ -304,13 +299,12 @@ const lastEvent = ref('')
 const showAdvanced = ref(false)
 const seed = ref<number | null>(null)
 const negativePrompt = ref('')
-const fps = ref<number | null>(null)
 const firstFrameImage = ref('')
 
 const estimate = computed(() => {
   if (!selected.value) return 0
   return estimateVideoCost({
-    perSecond: selected.value.model.perSecond || 0,
+    perSecond: selected.value.perSecond || 0,
     seconds: duration.value,
     rateMultiplier: props.rateMultiplier,
   })
@@ -321,7 +315,7 @@ const canGenerate = computed(
 )
 const formula = computed(() => {
   if (!selected.value) return ''
-  return t('studio.video.formula', { rate: formatUsd(selected.value.model.perSecond || 0), seconds: duration.value })
+  return t('studio.video.formula', { rate: formatUsd(selected.value.perSecond || 0), seconds: duration.value })
 })
 
 const poll = useVideoTaskPoll({
@@ -402,7 +396,6 @@ async function generate(): Promise<void> {
         ? { negativePrompt: negativePrompt.value.trim() }
         : {}),
       ...(supports('seed') && seed.value != null ? { seed: seed.value } : {}),
-      ...(supports('fps') && fps.value != null ? { fps: fps.value } : {}),
       ...(supports('firstFrameImage') && firstFrameImage.value.trim()
         ? { image: firstFrameImage.value.trim() }
         : {}),

--- a/frontend/src/views/user/studio/VideoStudio.vue
+++ b/frontend/src/views/user/studio/VideoStudio.vue
@@ -2,37 +2,43 @@
   <div class="grid grid-cols-1 gap-5 lg:grid-cols-[340px_1fr_250px]">
     <!-- LEFT: orchestration -->
     <div class="space-y-4">
-      <div v-if="tiers.length === 0" class="rounded-xl border border-dashed border-gray-300 bg-white/60 p-6 text-center text-sm text-gray-500 dark:border-dark-700 dark:bg-dark-900/40 dark:text-dark-400">
-        {{ t('studio.video.tierEmpty') }}
+      <div v-if="models.length === 0" class="rounded-xl border border-dashed border-gray-300 bg-white/60 p-6 text-center text-sm text-gray-500 dark:border-dark-700 dark:bg-dark-900/40 dark:text-dark-400">
+        {{ t('studio.video.modelEmpty') }}
         <router-link class="mt-1 block font-medium text-primary-600 underline dark:text-primary-400" to="/pricing">
           {{ t('studio.viewPricing') }}
         </router-link>
       </div>
 
+      <!-- Transparent MODEL picker (friendly name + price + vendor + raw id subtext). -->
       <div v-else class="rounded-xl border border-gray-200 bg-white p-4 shadow-sm dark:border-dark-700 dark:bg-dark-900">
-        <div class="mb-2 text-xs font-semibold uppercase tracking-wide text-gray-400 dark:text-dark-500">{{ t('studio.video.tierLabel') }}</div>
-        <div class="grid grid-cols-3 gap-2">
+        <div class="mb-2 text-xs font-semibold uppercase tracking-wide text-gray-400 dark:text-dark-500">{{ t('studio.video.modelLabel') }}</div>
+        <div class="space-y-2">
           <button
-            v-for="r in tiers"
-            :key="r.tier.id"
+            v-for="r in models"
+            :key="r.model.modelId"
             type="button"
-            class="rounded-xl border p-2.5 text-left transition"
-            :class="selectedTierId === r.tier.id
+            class="w-full rounded-xl border p-3 text-left transition"
+            :class="selectedModelId === r.model.modelId
               ? 'border-primary-500 bg-primary-50 ring-2 ring-primary-500/30 dark:border-primary-500 dark:bg-primary-950/40'
               : 'border-gray-200 hover:border-primary-300 dark:border-dark-600'"
-            @click="selectTier(r.tier.id)"
+            data-testid="studio-video-model"
+            @click="selectedModelId = r.model.modelId"
           >
-            <div class="text-[13px] font-semibold text-gray-900 dark:text-white">{{ t(r.tier.labelKey) }}</div>
-            <div class="text-[11px] text-gray-500 dark:text-dark-400">{{ t(r.tier.taglineKey) }}</div>
-            <div class="mt-1 text-[12px] font-bold text-primary-700 dark:text-primary-300">
-              {{ formatUsd(r.candidate.perSecond || 0) }}{{ t('studio.video.perSecondUnit') }}
+            <div class="flex items-center justify-between gap-2">
+              <span class="text-[13px] font-semibold text-gray-900 dark:text-white">{{ r.model.displayName }}</span>
+              <span class="shrink-0 rounded bg-gray-100 px-1.5 py-0.5 text-[10px] font-medium text-gray-600 dark:bg-dark-800 dark:text-dark-300">{{ t(r.model.qualityBadgeKey) }}</span>
             </div>
-            <div class="text-[10px] text-gray-400 dark:text-dark-500">{{ t('studio.via', { vendor: r.candidate.vendorLabel }) }}</div>
+            <div class="mt-1 flex items-center justify-between gap-2">
+              <span class="text-[12px] font-bold text-primary-700 dark:text-primary-300">{{ formatUsd(r.model.perSecond || 0) }}{{ t('studio.video.perSecondUnit') }}</span>
+              <span class="text-[10px] text-gray-400 dark:text-dark-500">{{ t('studio.via', { vendor: r.model.vendorLabel }) }}</span>
+            </div>
+            <div class="mt-0.5 truncate font-mono text-[10px] text-gray-300 dark:text-dark-600" :title="r.servedId">{{ r.servedId }}</div>
+            <div v-if="r.model.needsApikeyAccount" class="mt-1 text-[10px] font-medium text-amber-600 dark:text-amber-400">{{ t('studio.needsApikeyAccount') }}</div>
           </button>
         </div>
       </div>
 
-      <div v-if="tiers.length" class="rounded-xl border border-gray-200 bg-white p-4 shadow-sm dark:border-dark-700 dark:bg-dark-900">
+      <div v-if="models.length" class="rounded-xl border border-gray-200 bg-white p-4 shadow-sm dark:border-dark-700 dark:bg-dark-900">
         <textarea
           v-model="prompt"
           rows="3"
@@ -79,6 +85,38 @@
             </button>
           </div>
         </div>
+
+        <!-- Advanced: only params the SELECTED model actually honors are rendered. -->
+        <template v-if="selected && selected.model.supportedParams.length">
+          <button
+            type="button"
+            class="mt-3 flex items-center gap-1 text-xs font-medium text-primary-600 dark:text-primary-300"
+            data-testid="studio-video-advanced-toggle"
+            @click="showAdvanced = !showAdvanced"
+          >
+            {{ t('studio.advanced.toggle') }} <span>{{ showAdvanced ? '▴' : '▾' }}</span>
+          </button>
+          <div v-if="showAdvanced" class="mt-2 space-y-3 rounded-lg border border-dashed border-gray-200 p-3 dark:border-dark-700">
+            <div v-if="supports('negativePrompt')">
+              <label class="mb-1 block text-xs font-medium text-gray-600 dark:text-dark-400">{{ t('studio.advanced.negativePrompt') }}</label>
+              <input v-model="negativePrompt" type="text" :placeholder="t('studio.advanced.negativePromptHint')" class="w-full rounded-lg border border-gray-200 bg-white px-3 py-1.5 text-sm text-gray-900 dark:border-dark-600 dark:bg-dark-950 dark:text-white" />
+            </div>
+            <div v-if="supports('firstFrameImage')">
+              <label class="mb-1 block text-xs font-medium text-gray-600 dark:text-dark-400">{{ t('studio.advanced.firstFrame') }}</label>
+              <input v-model="firstFrameImage" type="text" :placeholder="t('studio.advanced.firstFrameHint')" class="w-full rounded-lg border border-gray-200 bg-white px-3 py-1.5 text-sm text-gray-900 dark:border-dark-600 dark:bg-dark-950 dark:text-white" />
+            </div>
+            <div v-if="supports('fps')">
+              <div class="mb-1 text-xs font-medium text-gray-600 dark:text-dark-400">{{ t('studio.advanced.fps') }}</div>
+              <div class="flex gap-2">
+                <button v-for="f in VIDEO_FPS_OPTIONS" :key="f" type="button" class="rounded-lg border px-3 py-1 text-xs font-medium transition" :class="fps === f ? 'border-primary-600 bg-primary-600 text-white' : 'border-gray-200 text-gray-600 dark:border-dark-600 dark:text-dark-300'" @click="fps = f">{{ f }}</button>
+              </div>
+            </div>
+            <div v-if="supports('seed')">
+              <label class="mb-1 block text-xs font-medium text-gray-600 dark:text-dark-400">{{ t('studio.advanced.seed') }}</label>
+              <input v-model.number="seed" type="number" :min="SEED_MIN" :max="SEED_MAX" :placeholder="t('studio.advanced.seedHint')" class="w-full rounded-lg border border-gray-200 bg-white px-3 py-1.5 text-sm text-gray-900 dark:border-dark-600 dark:bg-dark-950 dark:text-white" />
+            </div>
+          </div>
+        </template>
       </div>
     </div>
 
@@ -163,9 +201,9 @@
       </div>
     </div>
 
-    <!-- RIGHT: cost panel + button. Hidden when the group serves no video tier —
+    <!-- RIGHT: cost panel + button. Hidden when the group serves no video model —
          no point showing a $0 panel and a dead Generate button. -->
-    <div v-if="tiers.length" class="space-y-4">
+    <div v-if="models.length" class="space-y-4">
       <div class="rounded-xl border border-primary-200 bg-primary-50/40 p-4 shadow-sm dark:border-primary-900/40 dark:bg-primary-950/30">
         <div class="text-xs font-semibold uppercase tracking-wide text-primary-700 dark:text-primary-300">{{ t('studio.cost.thisVideo') }}</div>
         <div class="mt-2 font-mono text-[12px] text-gray-600 dark:text-dark-300">{{ formula }}</div>
@@ -219,7 +257,12 @@ import {
   VIDEO_DURATION_MIN,
   VIDEO_DURATION_MAX,
   VIDEO_DURATION_DEFAULT,
-  resolveAvailableTiers,
+  VIDEO_FPS_OPTIONS,
+  SEED_MIN,
+  SEED_MAX,
+  resolveAvailableModels,
+  defaultModelId,
+  type StudioParam,
 } from '@/constants/mediaTiers.tk'
 import { estimateVideoCost, formatUsd } from '@/utils/mediaCostEstimate.tk'
 import { downloadMedia } from '@/utils/studioDownload.tk'
@@ -243,9 +286,10 @@ const emit = defineEmits<{ (e: 'spent'): void }>()
 const { t } = useI18n()
 const library = useMediaLibrary(props.userId)
 
-const tiers = computed(() => resolveAvailableTiers('video', props.availableIds))
-const selectedTierId = ref<string>('')
-const selected = computed(() => tiers.value.find((r) => r.tier.id === selectedTierId.value) ?? null)
+const models = computed(() => resolveAvailableModels('video', props.availableIds))
+const selectedModelId = ref<string>('')
+const selected = computed(() => models.value.find((r) => r.model.modelId === selectedModelId.value) ?? null)
+const supports = (p: StudioParam): boolean => !!selected.value?.model.supportedParams.includes(p)
 
 const duration = ref<number>(VIDEO_DURATION_DEFAULT)
 const aspectId = ref<string>('') // '' = auto (no aspect_ratio sent — proven zero-extra-field path)
@@ -256,10 +300,17 @@ const errorMessage = ref('')
 const errorCode = ref<StudioErrorCode | ''>('')
 const lastEvent = ref('')
 
+// Advanced (optional; only sent when set).
+const showAdvanced = ref(false)
+const seed = ref<number | null>(null)
+const negativePrompt = ref('')
+const fps = ref<number | null>(null)
+const firstFrameImage = ref('')
+
 const estimate = computed(() => {
   if (!selected.value) return 0
   return estimateVideoCost({
-    perSecond: selected.value.candidate.perSecond || 0,
+    perSecond: selected.value.model.perSecond || 0,
     seconds: duration.value,
     rateMultiplier: props.rateMultiplier,
   })
@@ -270,7 +321,7 @@ const canGenerate = computed(
 )
 const formula = computed(() => {
   if (!selected.value) return ''
-  return t('studio.video.formula', { rate: formatUsd(selected.value.candidate.perSecond || 0), seconds: duration.value })
+  return t('studio.video.formula', { rate: formatUsd(selected.value.model.perSecond || 0), seconds: duration.value })
 })
 
 const poll = useVideoTaskPoll({
@@ -294,21 +345,16 @@ const poll = useVideoTaskPoll({
   },
 })
 
-function selectTier(id: string): void {
-  selectedTierId.value = id
-}
 function applySamplePrompt(): void {
   if (userEditedPrompt.value) return
-  if (selected.value) prompt.value = t(selected.value.tier.samplePromptKey)
+  prompt.value = t('studio.video.samplePrompt')
 }
 watch(
-  tiers,
+  models,
   (list) => {
-    if (!list.length) {
-      selectedTierId.value = ''
-      return
+    if (!list.some((r) => r.model.modelId === selectedModelId.value)) {
+      selectedModelId.value = defaultModelId(list) ?? ''
     }
-    if (!list.some((r) => r.tier.id === selectedTierId.value)) selectedTierId.value = list[0].tier.id
   },
   { immediate: true }
 )
@@ -348,10 +394,18 @@ async function generate(): Promise<void> {
   sending.value = true
   try {
     const raw = await gatewayVideoSubmit(props.apiKey, props.gatewayBase, {
-      model: resolved.candidate.modelId,
+      model: resolved.servedId,
       prompt: text,
       duration: duration.value,
       aspectRatio: aspectId.value || undefined,
+      ...(supports('negativePrompt') && negativePrompt.value.trim()
+        ? { negativePrompt: negativePrompt.value.trim() }
+        : {}),
+      ...(supports('seed') && seed.value != null ? { seed: seed.value } : {}),
+      ...(supports('fps') && fps.value != null ? { fps: fps.value } : {}),
+      ...(supports('firstFrameImage') && firstFrameImage.value.trim()
+        ? { image: firstFrameImage.value.trim() }
+        : {}),
     })
     const taskId = extractVideoTaskId(raw)
     if (!taskId) throw new Error(t('studio.video.noTaskId'))
@@ -359,8 +413,8 @@ async function generate(): Promise<void> {
     const task: VideoTaskItem = {
       id: taskId,
       prompt: text,
-      model: resolved.candidate.modelId,
-      vendorLabel: resolved.candidate.vendorLabel,
+      model: resolved.servedId,
+      vendorLabel: resolved.model.vendorLabel,
       seconds: duration.value,
       aspectRatio: aspectId.value || undefined,
       estCost: estimate.value,

--- a/scripts/sentinels/frontend-tk.json
+++ b/scripts/sentinels/frontend-tk.json
@@ -803,6 +803,15 @@
         "tkIsCCOnly"
       ],
       "rationale": "PR #788: the thin wiring that mounts the redesign — useTkUseKey() composable, onPickModel (servable-model picker, injected into every client snippet), onTest (live 'test key' button), and tkIsCCOnly (CC-only anthropic groups render ONLY Claude Code + a warning, killing the ~414/wk 'use claude-cli' 403 class). Upstream sub2api's modal has none of these; a git merge upstream/main that overwrites this upstream-shaped .vue back to upstream shape would silently drop the picker, live test and CC-only gate while still compiling and passing the default-path tests. Complements idx 59/60 on the same file (anthropic [1m] literal + antigravity scope gate)."
+    },
+    {
+      "path": "frontend/src/constants/mediaTiers.tk.ts",
+      "must_contain": [
+        "export const MEDIA_MODELS",
+        "export function resolveAvailableModels",
+        "supportedParams"
+      ],
+      "rationale": "TK-only Studio model catalog + capability map. MEDIA_MODELS lists each priced+servable media model (friendly name, vendor, price, supportedParams); resolveAvailableModels(modality, availableIds) is the priced∩servable filter the model-card picker drives (replacing the tier-card selection). Dropping these silently regresses the transparent model picker or, worse, lets an unservable/unpriced model surface as a 400-on-submit footgun. supportedParams is the honest Advanced-panel capability gate — only params a model actually honors are rendered."
     }
   ]
 }


### PR DESCRIPTION
## Why

User feedback on the live Studio demo: it was **too abstract / too technical**. Three asks, one theme — make it **real & transparent + smooth & adjustable**:
1. The quality-tier cards hid which model actually runs → list the real model, let users choose it (humanely).
2. Real upstream params (seed / negative-prompt / first-frame / fps…) weren't exposed → surface them with recommended defaults, smooth but adjustable.
3. The hero subtitle was a mechanism list → reframe outcome-first.

This **completes the originally-planned-but-unshipped "Advanced model picker"** from the design doc (§3.2); #769 only shipped the tier cards.

## What

- **Transparent model picker** (replaces tier cards as the selection axis). New `MEDIA_MODELS` catalog + `resolveAvailableModels()` in `mediaTiers.tk.ts` render each priced+servable model as a humane card: friendly name (`Imagen 4 · Ultra`), price, vendor footnote, quality **badge**, and the **raw model id as transparent subtext**. Cheapest non-footgun model auto-selects. Same priced∩servable filter (no 400-on-submit footgun); raw id stays the billing key.
- **Adjustable params, honestly.** An **Advanced ▾** panel renders only params the *selected* model actually honors (per-model capability map) — never a control that silently no-ops. Image: seed + negative-prompt. Video: negative-prompt + first-frame image (+ seed/fps for seedance). Smooth defaults: Generate works untouched. Wired via extended `ImageGenerationRequest`/`VideoGenerationRequest` (video advanced → `metadata.*`; image top-level; never `video_url`). No TK price impact — cost mirror unchanged.
- **Hero copy** outcome-first: `把脑子里的画面，变成能播放的图片和视频。` / `Turn what's in your head into images and video you can watch.`
- **BakeOff** → model multiselect (same testids).

## Constraints preserved
Explicit modality tabs, price-on-button, no-footgun defaults (gpt-image excluded), priced∩servable filter, sentinel anchors (+ new `MEDIA_MODELS`/`resolveAvailableModels` anchor in `scripts/sentinels/frontend-tk.json`).

## Validation
- Unit: resolver filter/alias/sort, **capability-map honesty** (no shipped model claims quality/style/resolution; veo omits seed/fps; image never exposes video params), request builders (only set fields; video advanced nests under metadata; never video_url). i18n parity green.
- `vue-tsc` + `eslint` clean; `scripts/preflight.sh` PASS; embedded dist rebuilt.
- Browser-verified (isolated local stack) across image / video / bake-off: model cards with raw-id subtext + price, Advanced panels capability-gated, cheapest auto-select, price-on-button.

no-upstream-touch
sentinel-registry-reviewed