### PR TITLE
feat(grok): add xAI/Grok SuperGrok-Heavy OAuth as the seventh platform

### DIFF
--- a/.github/workflows/upstream-merge-pr-shape.yml
+++ b/.github/workflows/upstream-merge-pr-shape.yml
@@ -225,6 +225,30 @@ jobs:
             exit 1
           fi
 
+      - name: Check 4d — grok sentinels still intact after merge
+        run: |
+          # Single source of truth: scripts/sentinels/grok.json. Same script that
+          # scripts/preflight.sh runs locally as the "grok sentinel registry"
+          # check, so a green local preflight implies a green check here. Failure
+          # means the upstream merge silently dropped a load-bearing seventh-platform
+          # surface — the thin grok injection branches into upstream-shaped files
+          # are the highest risk: the OAuth refresh (pkg/xai + GrokTokenRefresher),
+          # the two forward seams (grok forwards like the apikey branch, NOT the
+          # ChatGPT/Codex branch), the Heavy-403 honesty guard, the OpenAICompat
+          # pool membership, and the model.AllPlatforms entry. Fix the merge to
+          # restore the file/symbol, do NOT delete the sentinel entry.
+          if [ ! -f ./scripts/sentinels/check-grok.py ]; then
+            echo "::error::scripts/sentinels/check-grok.py missing."
+            echo "::error::Per CLAUDE.md §5.x, this guard cannot be silently disabled."
+            exit 1
+          fi
+          if ! python3 ./scripts/sentinels/check-grok.py; then
+            echo "::error::Upstream merge regressed at least one grok sentinel."
+            echo "::error::Per CLAUDE.md §5.x, restore the dropped file/symbol in this"
+            echo "::error::merge PR. Do NOT 'fix' by deleting the sentinel entry."
+            exit 1
+          fi
+
       - name: Check 4c — antigravity fingerprint sentinels still intact after merge
         run: |
           # Single source of truth: scripts/sentinels/antigravity.json. Same script

--- a/backend/ent/migrate/schema.go
+++ b/backend/ent/migrate/schema.go
@@ -814,7 +814,7 @@ var (
 		{Name: "id", Type: field.TypeInt64, Increment: true},
 		{Name: "created_at", Type: field.TypeTime, SchemaType: map[string]string{"postgres": "timestamptz"}},
 		{Name: "updated_at", Type: field.TypeTime, SchemaType: map[string]string{"postgres": "timestamptz"}},
-		{Name: "platform", Type: field.TypeEnum, Enums: []string{"openai", "anthropic", "gemini", "antigravity", "newapi", "kiro"}},
+		{Name: "platform", Type: field.TypeEnum, Enums: []string{"openai", "anthropic", "gemini", "antigravity", "newapi", "kiro", "grok"}},
 		{Name: "model_id", Type: field.TypeString, Size: 200},
 		{Name: "status", Type: field.TypeEnum, Enums: []string{"ok", "stale", "unreachable", "untested"}, Default: "untested"},
 		{Name: "last_seen_ok_at", Type: field.TypeTime, Nullable: true},

--- a/backend/ent/modelavailability/modelavailability.go
+++ b/backend/ent/modelavailability/modelavailability.go
@@ -105,6 +105,7 @@ const (
 	PlatformAntigravity Platform = "antigravity"
 	PlatformNewapi      Platform = "newapi"
 	PlatformKiro        Platform = "kiro"
+	PlatformGrok        Platform = "grok"
 )
 
 func (pl Platform) String() string {
@@ -114,7 +115,7 @@ func (pl Platform) String() string {
 // PlatformValidator is a validator for the "platform" field enum values. It is called by the builders before save.
 func PlatformValidator(pl Platform) error {
 	switch pl {
-	case PlatformOpenai, PlatformAnthropic, PlatformGemini, PlatformAntigravity, PlatformNewapi, PlatformKiro:
+	case PlatformOpenai, PlatformAnthropic, PlatformGemini, PlatformAntigravity, PlatformNewapi, PlatformKiro, PlatformGrok:
 		return nil
 	default:
 		return fmt.Errorf("modelavailability: invalid enum value for platform field: %q", pl)

--- a/backend/ent/schema/model_availability.go
+++ b/backend/ent/schema/model_availability.go
@@ -58,7 +58,7 @@ func (ModelAvailability) Mixin() []ent.Mixin {
 func (ModelAvailability) Fields() []ent.Field {
 	return []ent.Field{
 		field.Enum("platform").
-			Values("openai", "anthropic", "gemini", "antigravity", "newapi", "kiro"),
+			Values("openai", "anthropic", "gemini", "antigravity", "newapi", "kiro", "grok"),
 		field.String("model_id").
 			NotEmpty().
 			MaxLen(200),

--- a/backend/internal/domain/constants.go
+++ b/backend/internal/domain/constants.go
@@ -31,6 +31,12 @@ const (
 	// so it is exposed through the native Anthropic /v1/messages path and schedules
 	// in its own isolated pool — it is intentionally NOT an OpenAI-compat member.
 	PlatformKiro = "kiro"
+	// PlatformGrok is the seventh platform: xAI / Grok (SuperGrok Heavy) OAuth
+	// subscriptions relayed to api.x.ai/v1. Unlike Kiro, xAI speaks the
+	// OpenAI-compatible wire protocol, so grok is an OpenAI-compat pool member and
+	// reuses the OpenAI-compat routing/scheduling/forward path — it differs from
+	// the openai (Codex) platform only in its OAuth refresh endpoint and base URL.
+	PlatformGrok = "grok"
 )
 
 // Account type constants

--- a/backend/internal/engine/engine_test.go
+++ b/backend/internal/engine/engine_test.go
@@ -110,13 +110,13 @@ func TestDispatchPlanUsesNewAPIBridge(t *testing.T) {
 
 func TestOpenAICompatPlatforms(t *testing.T) {
 	got := OpenAICompatPlatforms()
-	if len(got) != 2 {
-		t.Fatalf("OpenAICompatPlatforms() returned %d entries, want 2: %v", len(got), got)
-	}
-
 	want := map[string]bool{
 		domain.PlatformOpenAI: false,
 		domain.PlatformNewAPI: false,
+		domain.PlatformGrok:   false,
+	}
+	if len(got) != len(want) {
+		t.Fatalf("OpenAICompatPlatforms() returned %d entries, want %d: %v", len(got), len(want), got)
 	}
 	for _, platform := range got {
 		if _, ok := want[platform]; !ok {
@@ -138,6 +138,7 @@ func TestIsOpenAICompatPlatform(t *testing.T) {
 	}{
 		{domain.PlatformOpenAI, true},
 		{domain.PlatformNewAPI, true},
+		{domain.PlatformGrok, true},
 		{domain.PlatformAnthropic, false},
 		{domain.PlatformGemini, false},
 		{domain.PlatformAntigravity, false},
@@ -161,6 +162,7 @@ func TestIsOpenAICompatPoolMember(t *testing.T) {
 		want            bool
 	}{
 		{"openai matches openai", domain.PlatformOpenAI, 0, domain.PlatformOpenAI, true},
+		{"grok matches grok (channel_type 0 ok, like openai)", domain.PlatformGrok, 0, domain.PlatformGrok, true},
 		{"newapi requires positive channel type", domain.PlatformNewAPI, 0, domain.PlatformNewAPI, false},
 		{"newapi positive channel type allowed", domain.PlatformNewAPI, 45, domain.PlatformNewAPI, true},
 		{"cross platform rejected", domain.PlatformNewAPI, 45, domain.PlatformOpenAI, false},
@@ -187,6 +189,7 @@ func TestAllSchedulingPlatforms(t *testing.T) {
 		domain.PlatformAntigravity: false,
 		domain.PlatformNewAPI:      false,
 		domain.PlatformKiro:        false,
+		domain.PlatformGrok:        false,
 	}
 	if len(got) != len(want) {
 		t.Fatalf("AllSchedulingPlatforms() returned %d entries, want %d: %v", len(got), len(want), got)

--- a/backend/internal/engine/provider.go
+++ b/backend/internal/engine/provider.go
@@ -17,7 +17,7 @@ const (
 )
 
 func OpenAICompatPlatforms() []string {
-	return []string{domain.PlatformOpenAI, domain.PlatformNewAPI}
+	return []string{domain.PlatformOpenAI, domain.PlatformNewAPI, domain.PlatformGrok}
 }
 
 func IsOpenAICompatPlatform(platform string) bool {
@@ -53,5 +53,6 @@ func AllSchedulingPlatforms() []string {
 		domain.PlatformAntigravity,
 		domain.PlatformNewAPI,
 		domain.PlatformKiro,
+		domain.PlatformGrok,
 	}
 }

--- a/backend/internal/model/error_passthrough_rule.go
+++ b/backend/internal/model/error_passthrough_rule.go
@@ -37,12 +37,13 @@ const (
 	PlatformGemini      = "gemini"
 	PlatformAntigravity = "antigravity"
 	PlatformNewAPI      = "newapi"
+	PlatformKiro        = "kiro"
 	PlatformGrok        = "grok"
 )
 
 // AllPlatforms 返回所有支持的平台列表
 func AllPlatforms() []string {
-	return []string{PlatformAnthropic, PlatformOpenAI, PlatformGemini, PlatformAntigravity, PlatformNewAPI, PlatformGrok}
+	return []string{PlatformAnthropic, PlatformOpenAI, PlatformGemini, PlatformAntigravity, PlatformNewAPI, PlatformKiro, PlatformGrok}
 }
 
 // Validate 验证规则配置的有效性

--- a/backend/internal/model/error_passthrough_rule.go
+++ b/backend/internal/model/error_passthrough_rule.go
@@ -37,11 +37,12 @@ const (
 	PlatformGemini      = "gemini"
 	PlatformAntigravity = "antigravity"
 	PlatformNewAPI      = "newapi"
+	PlatformGrok        = "grok"
 )
 
 // AllPlatforms 返回所有支持的平台列表
 func AllPlatforms() []string {
-	return []string{PlatformAnthropic, PlatformOpenAI, PlatformGemini, PlatformAntigravity, PlatformNewAPI}
+	return []string{PlatformAnthropic, PlatformOpenAI, PlatformGemini, PlatformAntigravity, PlatformNewAPI, PlatformGrok}
 }
 
 // Validate 验证规则配置的有效性

--- a/backend/internal/pkg/xai/oauth.go
+++ b/backend/internal/pkg/xai/oauth.go
@@ -1,0 +1,180 @@
+// Package xai provides the minimal xAI / Grok (SuperGrok Heavy) OAuth refresh
+// helper used by the grok seventh platform. It is intentionally dependency-free
+// (only stdlib) so the service-layer GrokTokenRefresher can call it the same way
+// the Kiro refresher calls the vendored kiroproto.RefreshToken.
+//
+// Scope of this package (MINIMAL-v1): token REFRESH only. The interactive
+// authorization-code + PKCE loopback dance (the way an operator first mints a
+// refresh_token) is performed out-of-band by the xAI Grok CLI on the operator's
+// own machine; TokenKey only stores the resulting refresh_token and refreshes it
+// server-side from here. The authorize/PKCE half is deferred to phase-2.
+//
+// OAuth contract (confirmed against the public xAI Grok CLI client, client_id
+// b1a00492-073a-47ea-816f-4c329264a828):
+//   - discovery: GET https://auth.x.ai/.well-known/openid-configuration -> token_endpoint
+//   - refresh:   POST <token_endpoint> form {grant_type=refresh_token, client_id, refresh_token}
+//     Content-Type: application/x-www-form-urlencoded ; no client_secret, no scope
+//   - response:  {access_token, refresh_token (may be omitted -> keep old), expires_in (sec), ...}
+//   - the access_token is a plain Bearer to api.x.ai/v1 (no Codex/ChatGPT headers).
+package xai
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"io"
+	"net/http"
+	"net/url"
+	"strings"
+	"time"
+)
+
+const (
+	// ClientID is the public xAI Grok CLI OAuth client ID (not a secret).
+	ClientID = "b1a00492-073a-47ea-816f-4c329264a828"
+	// Issuer is xAI's OAuth issuer.
+	Issuer = "https://auth.x.ai"
+	// DiscoveryURL is the OIDC discovery endpoint used to resolve the token endpoint.
+	DiscoveryURL = Issuer + "/.well-known/openid-configuration"
+	// DefaultAPIBaseURL is the default xAI (OpenAI-compatible) inference base URL.
+	DefaultAPIBaseURL = "https://api.x.ai/v1"
+	// Scope is the OAuth scope set xAI issues for Grok API access (for reference;
+	// the refresh grant itself does not send a scope param).
+	Scope = "openid profile email offline_access grok-cli:access api:access"
+
+	// oauthHost is the trusted host suffix for OAuth endpoints (SSRF guard).
+	oauthHost = "x.ai"
+)
+
+// RefreshLead is how long before access-token expiry a refresh should fire.
+const RefreshLead = 5 * time.Minute
+
+// TokenResult is the outcome of a refresh.
+type TokenResult struct {
+	AccessToken  string
+	RefreshToken string // may be empty: when xAI omits rotation, caller keeps the old token
+	ExpiresIn    int    // seconds
+	// TokenEndpoint is the endpoint actually used; callers may cache it on the
+	// account credentials to avoid re-running discovery on every refresh.
+	TokenEndpoint string
+}
+
+func httpClient(proxyURL string) *http.Client {
+	tr := &http.Transport{Proxy: http.ProxyFromEnvironment}
+	if p := strings.TrimSpace(proxyURL); p != "" {
+		if u, err := url.Parse(p); err == nil {
+			tr.Proxy = http.ProxyURL(u)
+		}
+	}
+	return &http.Client{Timeout: 30 * time.Second, Transport: tr}
+}
+
+// validateEndpoint rejects an OAuth endpoint that is not https on an x.ai host,
+// guarding against a poisoned discovery document redirecting token POSTs.
+func validateEndpoint(raw string) (string, error) {
+	raw = strings.TrimSpace(raw)
+	u, err := url.Parse(raw)
+	if err != nil || u.Scheme != "https" || u.Host == "" {
+		return "", fmt.Errorf("xai oauth: invalid endpoint %q", raw)
+	}
+	host := u.Hostname()
+	if host != oauthHost && !strings.HasSuffix(host, "."+oauthHost) {
+		return "", fmt.Errorf("xai oauth: endpoint host %q not under %s", host, oauthHost)
+	}
+	return raw, nil
+}
+
+// Discover resolves the token_endpoint from xAI OIDC discovery.
+func Discover(ctx context.Context, proxyURL string) (tokenEndpoint string, err error) {
+	req, err := http.NewRequestWithContext(ctx, http.MethodGet, DiscoveryURL, nil)
+	if err != nil {
+		return "", fmt.Errorf("xai oauth discovery: build request: %w", err)
+	}
+	req.Header.Set("Accept", "application/json")
+	resp, err := httpClient(proxyURL).Do(req)
+	if err != nil {
+		return "", fmt.Errorf("xai oauth discovery: %w", err)
+	}
+	defer func() { _ = resp.Body.Close() }()
+	body, _ := io.ReadAll(io.LimitReader(resp.Body, 1<<20))
+	if resp.StatusCode != http.StatusOK {
+		return "", fmt.Errorf("xai oauth discovery: status %d: %s", resp.StatusCode, strings.TrimSpace(string(body)))
+	}
+	var payload struct {
+		TokenEndpoint string `json:"token_endpoint"`
+	}
+	if err := json.Unmarshal(body, &payload); err != nil {
+		return "", fmt.Errorf("xai oauth discovery: decode: %w", err)
+	}
+	return validateEndpoint(payload.TokenEndpoint)
+}
+
+// RefreshToken exchanges a refresh_token for a fresh access token. When
+// tokenEndpoint is empty it is resolved via Discover first. A non-2xx response
+// (including invalid_grant / 403 entitlement gating) is returned as an error
+// whose text includes the upstream body, so the service layer can classify
+// rolling-revocation and the Heavy-only entitlement gate.
+func RefreshToken(ctx context.Context, refreshToken, tokenEndpoint, proxyURL string) (*TokenResult, error) {
+	refreshToken = strings.TrimSpace(refreshToken)
+	if refreshToken == "" {
+		return nil, fmt.Errorf("xai oauth refresh: refresh_token is required")
+	}
+
+	endpoint := strings.TrimSpace(tokenEndpoint)
+	if endpoint == "" {
+		discovered, err := Discover(ctx, proxyURL)
+		if err != nil {
+			return nil, err
+		}
+		endpoint = discovered
+	} else {
+		validated, err := validateEndpoint(endpoint)
+		if err != nil {
+			return nil, err
+		}
+		endpoint = validated
+	}
+
+	form := url.Values{
+		"grant_type":    {"refresh_token"},
+		"client_id":     {ClientID},
+		"refresh_token": {refreshToken},
+	}
+	req, err := http.NewRequestWithContext(ctx, http.MethodPost, endpoint, strings.NewReader(form.Encode()))
+	if err != nil {
+		return nil, fmt.Errorf("xai oauth refresh: build request: %w", err)
+	}
+	req.Header.Set("Content-Type", "application/x-www-form-urlencoded")
+	req.Header.Set("Accept", "application/json")
+
+	resp, err := httpClient(proxyURL).Do(req)
+	if err != nil {
+		return nil, fmt.Errorf("xai oauth refresh: %w", err)
+	}
+	defer func() { _ = resp.Body.Close() }()
+	body, _ := io.ReadAll(io.LimitReader(resp.Body, 1<<20))
+	if resp.StatusCode < 200 || resp.StatusCode >= 300 {
+		// Preserve the upstream body verbatim: invalid_grant (dead grant ->
+		// re-auth, never loop) and 403 (Heavy-only entitlement gate) are
+		// classified downstream by their text.
+		return nil, fmt.Errorf("xai oauth refresh: status %d: %s", resp.StatusCode, strings.TrimSpace(string(body)))
+	}
+
+	var payload struct {
+		AccessToken  string `json:"access_token"`
+		RefreshToken string `json:"refresh_token"`
+		ExpiresIn    int    `json:"expires_in"`
+	}
+	if err := json.Unmarshal(body, &payload); err != nil {
+		return nil, fmt.Errorf("xai oauth refresh: decode: %w", err)
+	}
+	if strings.TrimSpace(payload.AccessToken) == "" {
+		return nil, fmt.Errorf("xai oauth refresh: empty access_token in response")
+	}
+	return &TokenResult{
+		AccessToken:   strings.TrimSpace(payload.AccessToken),
+		RefreshToken:  strings.TrimSpace(payload.RefreshToken),
+		ExpiresIn:     payload.ExpiresIn,
+		TokenEndpoint: endpoint,
+	}, nil
+}

--- a/backend/internal/pkg/xai/oauth_test.go
+++ b/backend/internal/pkg/xai/oauth_test.go
@@ -1,0 +1,60 @@
+//go:build unit
+
+package xai
+
+import (
+	"context"
+	"strings"
+	"testing"
+)
+
+// TestValidateEndpoint guards the SSRF boundary: the OAuth token endpoint must be
+// https on an x.ai host. A poisoned discovery document pointing the refresh POST
+// at an attacker host must be rejected.
+func TestValidateEndpoint(t *testing.T) {
+	cases := []struct {
+		in string
+		ok bool
+	}{
+		{"https://auth.x.ai/oauth2/token", true},
+		{"https://api.x.ai/v1", true},
+		{"https://x.ai/token", true},
+		{"http://auth.x.ai/oauth2/token", false},    // not https
+		{"https://evil.com/token", false},           // wrong host
+		{"https://auth.x.ai.evil.com/token", false}, // suffix-spoof
+		{"", false},
+		{"://broken", false},
+	}
+	for _, c := range cases {
+		got, err := validateEndpoint(c.in)
+		if c.ok && (err != nil || got == "") {
+			t.Errorf("validateEndpoint(%q) = (%q, %v); want accepted", c.in, got, err)
+		}
+		if !c.ok && err == nil {
+			t.Errorf("validateEndpoint(%q) = (%q, nil); want rejected", c.in, got)
+		}
+	}
+}
+
+// TestRefreshToken_InputGuards verifies the no-network guards: an empty
+// refresh_token and a non-x.ai endpoint are rejected before any HTTP call.
+func TestRefreshToken_InputGuards(t *testing.T) {
+	if _, err := RefreshToken(context.Background(), "   ", "https://auth.x.ai/oauth2/token", ""); err == nil {
+		t.Fatal("RefreshToken with empty refresh_token must error")
+	}
+	_, err := RefreshToken(context.Background(), "rt", "https://evil.example.com/token", "")
+	if err == nil || !strings.Contains(err.Error(), "not under x.ai") {
+		t.Fatalf("RefreshToken with non-x.ai endpoint must be rejected by the SSRF guard, got %v", err)
+	}
+}
+
+// TestConstants locks the load-bearing public client identity (also anchored by
+// scripts/sentinels/grok.json) so an accidental edit is caught at test time.
+func TestConstants(t *testing.T) {
+	if ClientID != "b1a00492-073a-47ea-816f-4c329264a828" {
+		t.Errorf("ClientID drifted: %q", ClientID)
+	}
+	if DefaultAPIBaseURL != "https://api.x.ai/v1" {
+		t.Errorf("DefaultAPIBaseURL drifted: %q", DefaultAPIBaseURL)
+	}
+}

--- a/backend/internal/service/account_tk_compat_pool_test.go
+++ b/backend/internal/service/account_tk_compat_pool_test.go
@@ -103,12 +103,14 @@ func TestUS018_IsOpenAICompatPlatform_Truth(t *testing.T) {
 	}
 }
 
-func TestOpenAICompatPlatforms_ListsBothCanonicals(t *testing.T) {
+func TestOpenAICompatPlatforms_ListsCanonicals(t *testing.T) {
 	got := OpenAICompatPlatforms()
-	if len(got) != 2 {
-		t.Fatalf("OpenAICompatPlatforms must list exactly 2 platforms today, got %d: %v", len(got), got)
+	// openai (Codex OAuth) + newapi (apikey fifth platform) + grok (xAI OAuth
+	// seventh platform — OpenAI-wire compatible, so it rides the OpenAI-compat pool).
+	want := map[string]bool{PlatformOpenAI: false, PlatformNewAPI: false, PlatformGrok: false}
+	if len(got) != len(want) {
+		t.Fatalf("OpenAICompatPlatforms must list exactly %d platforms today, got %d: %v", len(want), len(got), got)
 	}
-	want := map[string]bool{PlatformOpenAI: false, PlatformNewAPI: false}
 	for _, p := range got {
 		if _, ok := want[p]; !ok {
 			t.Fatalf("unexpected platform %q in OpenAICompatPlatforms()", p)

--- a/backend/internal/service/account_tk_grok.go
+++ b/backend/internal/service/account_tk_grok.go
@@ -1,0 +1,44 @@
+package service
+
+import (
+	"strings"
+	"time"
+
+	"github.com/Wei-Shaw/sub2api/internal/pkg/xai"
+)
+
+// IsGrok reports whether the account is a Grok (seventh platform) account.
+//
+// Unlike Kiro, xAI / Grok speaks the OpenAI-compatible wire protocol, so a grok
+// account is an OpenAI-compat pool member (see engine.OpenAICompatPlatforms) and
+// reuses the OpenAI-compat routing/scheduling/forward path. It differs from the
+// openai (Codex) platform only in its OAuth refresh endpoint (auth.x.ai) and its
+// inference base URL (api.x.ai/v1) — and crucially it forwards like the APIKey
+// branch (plain Bearer + base_url), NOT the ChatGPT/Codex OAuth branch.
+func (a *Account) IsGrok() bool {
+	return a.Platform == PlatformGrok
+}
+
+// GetGrokBaseURL returns the xAI inference base URL for this account, honoring a
+// per-account credentials.base_url override and defaulting to api.x.ai/v1.
+func (a *Account) GetGrokBaseURL() string {
+	if base := strings.TrimSpace(a.GetCredential("base_url")); base != "" {
+		return strings.TrimRight(base, "/")
+	}
+	return xai.DefaultAPIBaseURL
+}
+
+// ---- Typed credential getters (Grok) ----
+
+// GetGrokAccessToken returns the xAI OAuth access token (a plain Bearer to api.x.ai/v1).
+func (a *Account) GetGrokAccessToken() string { return a.GetCredential("access_token") }
+
+// GetGrokRefreshToken returns the xAI OAuth refresh token.
+func (a *Account) GetGrokRefreshToken() string { return a.GetCredential("refresh_token") }
+
+// GetGrokTokenEndpoint returns the cached OIDC token_endpoint (optional; empty
+// triggers discovery on the next refresh).
+func (a *Account) GetGrokTokenEndpoint() string { return a.GetCredential("token_endpoint") }
+
+// GetGrokExpiresAt returns the access-token expiry, or nil if unset/unparseable.
+func (a *Account) GetGrokExpiresAt() *time.Time { return a.GetCredentialAsTime("expires_at") }

--- a/backend/internal/service/admin_service.go
+++ b/backend/internal/service/admin_service.go
@@ -2885,6 +2885,16 @@ func (s *adminServiceImpl) UpdateAccount(ctx context.Context, id int64, input *U
 	if err := resolveNewAPIMoonshotBaseURLOnSave(ctx, account); err != nil {
 		return nil, err
 	}
+	// Grok (seventh platform): when the admin re-pastes a refresh_token on edit
+	// (credential rotation after invalid_grant), re-validate + re-prime it with a
+	// live xAI refresh, exactly like create. Gated on the refresh_token being
+	// re-provided in THIS update so an unrelated edit (a blank field = "keep
+	// current") isn't blocked by a transient xAI outage. See admin_service_tk_grok_save.go.
+	if account.Platform == PlatformGrok && tkInputHasNonEmptyCredential(input.Credentials, "refresh_token") {
+		if err := resolveGrokTokenOnSave(ctx, account); err != nil {
+			return nil, err
+		}
+	}
 
 	if err := s.accountRepo.Update(ctx, account); err != nil {
 		return nil, err

--- a/backend/internal/service/admin_service.go
+++ b/backend/internal/service/admin_service.go
@@ -2699,6 +2699,12 @@ func (s *adminServiceImpl) CreateAccount(ctx context.Context, input *CreateAccou
 	if err := resolveNewAPIMoonshotBaseURLOnSave(ctx, account); err != nil {
 		return nil, err
 	}
+	// Grok (seventh platform): validate + prime the OAuth token at create time so a
+	// pasted refresh_token "just works" (green check) or is rejected with the exact
+	// xAI reason. See admin_service_tk_grok_save.go.
+	if err := resolveGrokTokenOnSave(ctx, account); err != nil {
+		return nil, err
+	}
 	if err := s.accountRepo.Create(ctx, account); err != nil {
 		return nil, err
 	}

--- a/backend/internal/service/admin_service_tk_grok_save.go
+++ b/backend/internal/service/admin_service_tk_grok_save.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"fmt"
 	"strconv"
+	"strings"
 	"time"
 
 	"github.com/Wei-Shaw/sub2api/internal/pkg/xai"
@@ -64,4 +65,20 @@ func resolveGrokTokenOnSave(ctx context.Context, account *Account) error {
 		account.Credentials["token_endpoint"] = res.TokenEndpoint
 	}
 	return nil
+}
+
+// tkInputHasNonEmptyCredential reports whether the caller explicitly provided a
+// non-empty value for the given credential key in this request. Used on the
+// UpdateAccount path to gate the grok live re-validate: a blank refresh_token
+// field means "keep current" (handled by MergePreservingSensitiveCreds + the
+// background refresher), so an unrelated grok edit (concurrency / priority / …)
+// must NOT fire an xAI refresh and must NOT be blocked by a transient xAI outage.
+func tkInputHasNonEmptyCredential(creds map[string]any, key string) bool {
+	if creds == nil {
+		return false
+	}
+	if v, ok := creds[key].(string); ok {
+		return strings.TrimSpace(v) != ""
+	}
+	return false
 }

--- a/backend/internal/service/admin_service_tk_grok_save.go
+++ b/backend/internal/service/admin_service_tk_grok_save.go
@@ -1,0 +1,67 @@
+package service
+
+import (
+	"context"
+	"fmt"
+	"strconv"
+	"time"
+
+	"github.com/Wei-Shaw/sub2api/internal/pkg/xai"
+)
+
+// resolveGrokTokenOnSave validates and primes a grok (seventh platform) OAuth
+// account at create time. The operator pastes a refresh_token (minted out-of-band
+// by the xAI Grok CLI loopback login — xAI's public client has no web-redirect /
+// device-code flow, so server-side interactive OAuth is not possible), and
+// TokenKey immediately exchanges it for a fresh access_token.
+//
+// This is the "paste just works" green check:
+//   - success → the account is primed (access_token + expires_at + token_endpoint
+//     persisted) and immediately schedulable;
+//   - failure (missing/invalid refresh_token, or the SuperGrok-Heavy-only 403
+//     entitlement gate, or a dead grant) → account creation is rejected with the
+//     exact upstream reason, instead of materializing a dead account that only
+//     fails on the first request.
+//
+// No-op for non-grok / non-oauth accounts. Mirrors resolveNewAPIMoonshotBaseURLOnSave
+// (a create-time network call that mutates credentials before persistence).
+func resolveGrokTokenOnSave(ctx context.Context, account *Account) error {
+	if account == nil || account.Platform != PlatformGrok || account.Type != AccountTypeOAuth {
+		return nil
+	}
+
+	refreshToken := account.GetGrokRefreshToken()
+	if refreshToken == "" {
+		return fmt.Errorf("credentials.refresh_token is required for grok platform " +
+			"(paste the refresh_token obtained from the xAI Grok CLI login)")
+	}
+
+	proxyURL := ""
+	if account.Proxy != nil {
+		proxyURL = account.Proxy.URL()
+	}
+
+	res, err := xai.RefreshToken(ctx, refreshToken, account.GetGrokTokenEndpoint(), proxyURL)
+	if err != nil {
+		return fmt.Errorf("grok refresh_token validation failed — the token must back a "+
+			"SuperGrok Heavy account (xAI gates OAuth API access to Heavy): %w", err)
+	}
+
+	if account.Credentials == nil {
+		account.Credentials = map[string]any{}
+	}
+	account.Credentials["access_token"] = res.AccessToken
+	expiresIn := res.ExpiresIn
+	if expiresIn <= 0 {
+		expiresIn = grokDefaultExpiresIn
+	}
+	account.Credentials["expires_at"] = strconv.FormatInt(
+		time.Now().Add(time.Duration(expiresIn)*time.Second).Unix(), 10)
+	if res.RefreshToken != "" {
+		account.Credentials["refresh_token"] = res.RefreshToken
+	}
+	if res.TokenEndpoint != "" {
+		account.Credentials["token_endpoint"] = res.TokenEndpoint
+	}
+	return nil
+}

--- a/backend/internal/service/domain_constants.go
+++ b/backend/internal/service/domain_constants.go
@@ -43,6 +43,7 @@ const (
 	PlatformAntigravity = domain.PlatformAntigravity
 	PlatformNewAPI      = domain.PlatformNewAPI
 	PlatformKiro        = domain.PlatformKiro
+	PlatformGrok        = domain.PlatformGrok
 )
 
 // AllowedQuotaPlatforms 是允许设置 user × platform quota 的平台列表（单一权威来源）。

--- a/backend/internal/service/grok_test.go
+++ b/backend/internal/service/grok_test.go
@@ -20,11 +20,13 @@ func TestTkIsGrokEntitlement403(t *testing.T) {
 		body   string
 		want   bool
 	}{
-		{"no active grok subscription", 403, `{"error":{"message":"You do not have an active Grok subscription"}}`, true},
-		{"out of available resources", 403, `{"error":{"message":"You have run out of available resources"}}`, true},
-		{"supergrok heavy required", 403, `{"error":{"message":"This requires SuperGrok Heavy"}}`, true},
-		{"generic WAF 403 not matched", 403, `{"error":{"message":"Forbidden"}}`, false},
-		{"401 with grok body is not 403", 401, `{"error":{"message":"active Grok subscription"}}`, false},
+		// xAI's real envelope (confirmed live against api.x.ai): {"code":"...","error":"<string>"}
+		{"no active grok subscription (xAI string shape)", 403, `{"code":"forbidden","error":"You do not have an active Grok subscription"}`, true},
+		{"out of available resources (xAI string shape)", 403, `{"code":"forbidden","error":"You have run out of available resources"}`, true},
+		// OpenAI object shape must still match (defense in depth)
+		{"supergrok heavy required (object shape)", 403, `{"error":{"message":"This requires SuperGrok Heavy"}}`, true},
+		{"generic WAF 403 not matched", 403, `{"code":"forbidden","error":"Forbidden"}`, false},
+		{"401 with grok body is not 403", 401, `{"code":"unauthenticated","error":"active Grok subscription"}`, false},
 		{"empty body", 403, ``, false},
 	}
 	for _, c := range cases {

--- a/backend/internal/service/grok_test.go
+++ b/backend/internal/service/grok_test.go
@@ -87,3 +87,25 @@ func TestGrokTokenRefresher_CanRefreshNeedsRefresh(t *testing.T) {
 		t.Fatal("NeedsRefresh should be true when within the refresh window")
 	}
 }
+
+// TestTkInputHasNonEmptyCredential guards the UpdateAccount gate: a grok edit
+// only fires the live xAI re-validate when the refresh_token was actually
+// (re)pasted — a blank/absent field must NOT trigger a network call (else an
+// unrelated edit would be blocked by a transient xAI outage).
+func TestTkInputHasNonEmptyCredential(t *testing.T) {
+	if !tkInputHasNonEmptyCredential(map[string]any{"refresh_token": "rt"}, "refresh_token") {
+		t.Fatal("re-pasted refresh_token must be detected as provided")
+	}
+	if tkInputHasNonEmptyCredential(map[string]any{"refresh_token": "   "}, "refresh_token") {
+		t.Fatal("whitespace-only refresh_token must count as not provided")
+	}
+	if tkInputHasNonEmptyCredential(map[string]any{}, "refresh_token") {
+		t.Fatal("absent refresh_token must count as not provided")
+	}
+	if tkInputHasNonEmptyCredential(nil, "refresh_token") {
+		t.Fatal("nil credentials must count as not provided")
+	}
+	if tkInputHasNonEmptyCredential(map[string]any{"refresh_token": 123}, "refresh_token") {
+		t.Fatal("non-string refresh_token must count as not provided")
+	}
+}

--- a/backend/internal/service/grok_test.go
+++ b/backend/internal/service/grok_test.go
@@ -1,0 +1,87 @@
+//go:build unit
+
+package service
+
+import (
+	"strconv"
+	"strings"
+	"testing"
+	"time"
+)
+
+// TestTkIsGrokEntitlement403 is the load-bearing regression guard for the
+// Heavy-only entitlement classifier: a real grok entitlement-403 must be
+// recognized (so it is NOT failed-over pool-wide / masked as 502), while a
+// generic 403 and a non-403 must not trip it.
+func TestTkIsGrokEntitlement403(t *testing.T) {
+	cases := []struct {
+		name   string
+		status int
+		body   string
+		want   bool
+	}{
+		{"no active grok subscription", 403, `{"error":{"message":"You do not have an active Grok subscription"}}`, true},
+		{"out of available resources", 403, `{"error":{"message":"You have run out of available resources"}}`, true},
+		{"supergrok heavy required", 403, `{"error":{"message":"This requires SuperGrok Heavy"}}`, true},
+		{"generic WAF 403 not matched", 403, `{"error":{"message":"Forbidden"}}`, false},
+		{"401 with grok body is not 403", 401, `{"error":{"message":"active Grok subscription"}}`, false},
+		{"empty body", 403, ``, false},
+	}
+	for _, c := range cases {
+		if got := tkIsGrokEntitlement403(c.status, []byte(c.body)); got != c.want {
+			t.Errorf("%s: tkIsGrokEntitlement403(%d) = %v, want %v", c.name, c.status, got, c.want)
+		}
+	}
+	if msg := tkGrokEntitlement403ClientMessage("upstream detail"); msg == "" || !strings.Contains(msg, "Heavy") {
+		t.Errorf("client message must be non-empty and mention Heavy, got %q", msg)
+	}
+}
+
+// TestAccountGrokHelpers covers the grok account predicate + base-URL resolution
+// (default api.x.ai/v1, per-account override with trailing-slash trim).
+func TestAccountGrokHelpers(t *testing.T) {
+	a := &Account{Platform: PlatformGrok, Type: AccountTypeOAuth, Credentials: map[string]any{}}
+	if !a.IsGrok() {
+		t.Fatal("IsGrok should be true for platform=grok")
+	}
+	if got := a.GetGrokBaseURL(); got != "https://api.x.ai/v1" {
+		t.Errorf("default GetGrokBaseURL = %q, want https://api.x.ai/v1", got)
+	}
+	a.Credentials["base_url"] = "https://proxy.example.com/v1/"
+	if got := a.GetGrokBaseURL(); got != "https://proxy.example.com/v1" {
+		t.Errorf("override GetGrokBaseURL = %q, want trailing-slash trimmed", got)
+	}
+	if (&Account{Platform: PlatformOpenAI}).IsGrok() {
+		t.Fatal("IsGrok should be false for a non-grok platform")
+	}
+}
+
+// TestGrokTokenRefresher_CanRefreshNeedsRefresh covers the refresher gating
+// (grok+oauth only) and the expiry-window logic (no expiry -> refresh to prime;
+// far future -> skip; within window -> refresh).
+func TestGrokTokenRefresher_CanRefreshNeedsRefresh(t *testing.T) {
+	r := NewGrokTokenRefresher()
+	grok := &Account{Platform: PlatformGrok, Type: AccountTypeOAuth, Credentials: map[string]any{}}
+
+	if !r.CanRefresh(grok) {
+		t.Fatal("CanRefresh should be true for grok+oauth")
+	}
+	if r.CanRefresh(&Account{Platform: PlatformGrok, Type: AccountTypeAPIKey}) {
+		t.Fatal("CanRefresh should be false for grok+apikey")
+	}
+	if r.CanRefresh(&Account{Platform: PlatformOpenAI, Type: AccountTypeOAuth}) {
+		t.Fatal("CanRefresh should be false for a non-grok platform")
+	}
+
+	if !r.NeedsRefresh(grok, 5*time.Minute) {
+		t.Fatal("NeedsRefresh should be true when no expiry is recorded (prime path)")
+	}
+	grok.Credentials["expires_at"] = strconv.FormatInt(time.Now().Add(time.Hour).Unix(), 10)
+	if r.NeedsRefresh(grok, 5*time.Minute) {
+		t.Fatal("NeedsRefresh should be false when expiry is far in the future")
+	}
+	grok.Credentials["expires_at"] = strconv.FormatInt(time.Now().Add(time.Minute).Unix(), 10)
+	if !r.NeedsRefresh(grok, 5*time.Minute) {
+		t.Fatal("NeedsRefresh should be true when within the refresh window")
+	}
+}

--- a/backend/internal/service/grok_token_refresher.go
+++ b/backend/internal/service/grok_token_refresher.go
@@ -1,0 +1,87 @@
+package service
+
+import (
+	"context"
+	"strconv"
+	"time"
+
+	"github.com/Wei-Shaw/sub2api/internal/pkg/xai"
+)
+
+// GrokTokenRefresher handles xAI / Grok (seventh platform) OAuth token refresh.
+//
+// xAI OAuth refresh is dependency-free (the network call lives in the stdlib-only
+// pkg/xai helper), so — like KiroTokenRefresher — this refresher is constructed
+// inline in NewTokenRefreshService with no Wire provider.
+//
+// On a non-2xx refresh, xai.RefreshToken returns an error whose text includes the
+// upstream body; an "invalid_grant" (dead grant) is recognized by
+// isNonRetryableRefreshError and the account is moved to error (re-auth required),
+// matching the Anthropic OAuth rolling-revocation posture — so this Refresh just
+// passes the error through.
+type GrokTokenRefresher struct{}
+
+// NewGrokTokenRefresher creates a Grok token refresher.
+func NewGrokTokenRefresher() *GrokTokenRefresher {
+	return &GrokTokenRefresher{}
+}
+
+// grokDefaultExpiresIn is the conservative access-token lifetime assumed when xAI
+// omits expires_in, so NeedsRefresh still fires on a sane cadence.
+const grokDefaultExpiresIn = 3600
+
+// CacheKey returns the distributed-lock cache key.
+func (r *GrokTokenRefresher) CacheKey(account *Account) string {
+	return "grok:account:" + strconv.FormatInt(account.ID, 10)
+}
+
+// CanRefresh handles only grok-platform oauth-type accounts.
+func (r *GrokTokenRefresher) CanRefresh(account *Account) bool {
+	return account.Platform == PlatformGrok && account.Type == AccountTypeOAuth
+}
+
+// NeedsRefresh decides whether the access token is within the refresh window.
+func (r *GrokTokenRefresher) NeedsRefresh(account *Account, refreshWindow time.Duration) bool {
+	exp := account.GetGrokExpiresAt()
+	if exp == nil {
+		// No expiry recorded yet (e.g. fresh paste): refresh proactively so we
+		// learn the real expiry and validate the grant.
+		return true
+	}
+	return time.Until(*exp) < refreshWindow
+}
+
+// Refresh exchanges the stored refresh_token for a fresh access token, preserving
+// all other credential fields and only updating the token-related ones.
+func (r *GrokTokenRefresher) Refresh(ctx context.Context, account *Account) (map[string]any, error) {
+	proxyURL := ""
+	if account.ProxyID != nil && account.Proxy != nil {
+		proxyURL = account.Proxy.URL()
+	}
+
+	res, err := xai.RefreshToken(ctx, account.GetGrokRefreshToken(), account.GetGrokTokenEndpoint(), proxyURL)
+	if err != nil {
+		return nil, err
+	}
+
+	expiresIn := res.ExpiresIn
+	if expiresIn <= 0 {
+		expiresIn = grokDefaultExpiresIn
+	}
+	expiresAt := time.Now().Add(time.Duration(expiresIn) * time.Second).Unix()
+
+	newCreds := map[string]any{
+		"access_token": res.AccessToken,
+		"expires_at":   strconv.FormatInt(expiresAt, 10),
+	}
+	// xAI rotates the refresh_token but may omit it — keep the old one if absent.
+	if res.RefreshToken != "" {
+		newCreds["refresh_token"] = res.RefreshToken
+	}
+	// Cache the resolved token_endpoint to skip discovery on subsequent refreshes.
+	if res.TokenEndpoint != "" {
+		newCreds["token_endpoint"] = res.TokenEndpoint
+	}
+
+	return MergeCredentials(account.Credentials, newCreds), nil
+}

--- a/backend/internal/service/openai_gateway_chat_completions.go
+++ b/backend/internal/service/openai_gateway_chat_completions.go
@@ -72,9 +72,12 @@ func (s *OpenAIGatewayService) ForwardAsChatCompletions(
 		return nil, err
 	}
 
+	// Grok（第七平台）：xAI 走标准 OpenAI /v1/chat/completions，绝不经 CC→Responses→Codex
+	// 转换（那条路写死 chatgpt.com/codex + chatgpt 专属头）。grok 用 OAuth Bearer，但转发形态
+	// 与 APIKey 直转路完全一致——故在 codex transform 之前就分流到 raw 直转。
 	// 入口分流：APIKey 账号 + 强制或已探测确认上游不支持 Responses，走 CC 直转。
 	// 自动模式下标记缺失（未探测）按"现状即证据"原则继续走下方原 Responses 转换路径。
-	if account.Type == AccountTypeAPIKey && !openai_compat.ShouldUseResponsesAPI(account.Extra) {
+	if account.IsGrok() || (account.Type == AccountTypeAPIKey && !openai_compat.ShouldUseResponsesAPI(account.Extra)) {
 		return s.forwardAsRawChatCompletions(ctx, c, account, body, defaultMappedModel)
 	}
 

--- a/backend/internal/service/openai_gateway_chat_completions_raw.go
+++ b/backend/internal/service/openai_gateway_chat_completions_raw.go
@@ -115,12 +115,21 @@ func (s *OpenAIGatewayService) forwardAsRawChatCompletions(
 		zap.Bool("stream", clientStream),
 	)
 
-	// 5. Build upstream request
-	apiKey := account.GetOpenAIApiKey()
-	if apiKey == "" {
-		return nil, fmt.Errorf("account %d missing api_key", account.ID)
+	// 5. Build upstream request.
+	// Grok (seventh platform) reuses this raw CC path with an OAuth Bearer +
+	// api.x.ai base_url; only the credential source and base URL differ from the
+	// openai apikey case.
+	var apiKey, baseURL string
+	if account.IsGrok() {
+		apiKey = account.GetGrokAccessToken()
+		baseURL = account.GetGrokBaseURL()
+	} else {
+		apiKey = account.GetOpenAIApiKey()
+		baseURL = account.GetOpenAIBaseURL()
 	}
-	baseURL := account.GetOpenAIBaseURL()
+	if apiKey == "" {
+		return nil, fmt.Errorf("account %d missing credential", account.ID)
+	}
 	if baseURL == "" {
 		baseURL = "https://api.openai.com"
 	}

--- a/backend/internal/service/openai_gateway_service.go
+++ b/backend/internal/service/openai_gateway_service.go
@@ -2421,6 +2421,17 @@ func (s *OpenAIGatewayService) schedulingConfig() config.GatewaySchedulingConfig
 
 // GetAccessToken gets the access token for an OpenAI account
 func (s *OpenAIGatewayService) GetAccessToken(ctx context.Context, account *Account) (string, string, error) {
+	// Grok (seventh platform): xAI OAuth issues a plain Bearer to api.x.ai/v1 and
+	// does NOT use the ChatGPT/Codex token provider (which is IsOpenAI-gated). The
+	// background GrokTokenRefresher keeps the stored access token fresh, so return
+	// it directly — same posture as Kiro's GetKiroAccessToken.
+	if account.IsGrok() {
+		accessToken := account.GetGrokAccessToken()
+		if accessToken == "" {
+			return "", "", errors.New("grok access_token not found in credentials")
+		}
+		return accessToken, "oauth", nil
+	}
 	switch account.Type {
 	case AccountTypeOAuth:
 		// 使用 TokenProvider 获取缓存的 token
@@ -2465,6 +2476,13 @@ func (s *OpenAIGatewayService) shouldFailoverOpenAIUpstreamResponse(statusCode i
 	// empty-pool 429). Route it straight to the non-failover error handler, which
 	// maps it to a client 400. See ratelimit_service_tk_capability_scope_401.go.
 	if tkIsCapabilityScope401(statusCode, upstreamBody) {
+		return false
+	}
+	// TK (grok seventh platform): a grok entitlement-403 (xAI Heavy-only gate) is
+	// pool-wide — failing over just poisons each grok account then hits the
+	// empty-pool 429. Route it straight to the non-failover error handler, which
+	// maps it to a clean client error. See ratelimit_service_tk_grok_entitlement_403.go.
+	if tkIsGrokEntitlement403(statusCode, upstreamBody) {
 		return false
 	}
 	if s.shouldFailoverUpstreamError(statusCode) {
@@ -4657,6 +4675,16 @@ func (s *OpenAIGatewayService) handleErrorResponse(
 		errType = "upstream_error"
 		errMsg = "Upstream payment required: insufficient balance or billing issue"
 	case 403:
+		// TK (grok seventh platform): a grok entitlement-403 (xAI Heavy-only gate)
+		// is per-request/entitlement, not a transient WAF block — surface it as a
+		// clean 403 with the actionable message instead of masking it as a generic
+		// 502. See ratelimit_service_tk_grok_entitlement_403.go.
+		if tkIsGrokEntitlement403(resp.StatusCode, body) {
+			statusCode = http.StatusForbidden
+			errType = "permission_error"
+			errMsg = tkGrokEntitlement403ClientMessage(upstreamMsg)
+			break
+		}
 		statusCode = http.StatusBadGateway
 		errType = "upstream_error"
 		errMsg = TkEnrichForbiddenMessage(c, "Upstream access forbidden, please contact administrator")

--- a/backend/internal/service/openai_gateway_v1_forward.go
+++ b/backend/internal/service/openai_gateway_v1_forward.go
@@ -49,6 +49,16 @@ func (s *OpenAIGatewayService) buildOpenAIV1TargetURL(account *Account, segment 
 		}
 		return buildOpenAIV1SegmentURL(validated, segment), nil
 	case AccountTypeOAuth:
+		// Grok (seventh platform) OAuth forwards to api.x.ai/v1 (OpenAI-compatible),
+		// NOT the ChatGPT platform base. The Bearer is the grok OAuth token resolved
+		// by GetAccessToken's grok branch.
+		if account.IsGrok() {
+			validated, err := s.validateUpstreamBaseURL(strings.TrimSpace(account.GetGrokBaseURL()))
+			if err != nil {
+				return "", err
+			}
+			return buildOpenAIV1SegmentURL(validated, segment), nil
+		}
 		return buildOpenAIV1SegmentURL(openAIPlatformV1Base, segment), nil
 	default:
 		return "", fmt.Errorf("unsupported account type: %s", account.Type)

--- a/backend/internal/service/ratelimit_service_tk_grok_entitlement_403.go
+++ b/backend/internal/service/ratelimit_service_tk_grok_entitlement_403.go
@@ -1,0 +1,83 @@
+package service
+
+import (
+	"strings"
+
+	"github.com/tidwall/gjson"
+)
+
+// xAI gates the OAuth API surface (api.x.ai/v1) to SuperGrok HEAVY. A standard
+// subscriber, an expired entitlement, or a downgraded plan gets HTTP 403 at
+// INFERENCE time with a body like:
+//
+//	You have either run out of available resources or do not have an active
+//	Grok subscription.
+//
+// This is a POOL-WIDE entitlement gate — every grok account shares the same xAI
+// Heavy allowlist — so it behaves exactly like the capability-scope 401 (GPT专线
+// P0): failing over just poisons each grok account in turn and then hits the
+// empty-pool 429, and the generic 403→502 mask would hide the real cause from the
+// operator. So a grok entitlement-403 must:
+//  1. NOT trigger account failover (shouldFailoverOpenAIUpstreamResponse=false),
+//  2. NOT cool/disable the account (no failover ⇒ HandleUpstreamError is not
+//     reached on the native chat/image path),
+//  3. surface a clean, actionable client error (NOT a masked 502).
+//
+// Kept in a TK-only companion file so future upstream merges of
+// ratelimit_service.go / openai_gateway_service.go do not collide on this branch.
+// See plan §403 honesty, NousResearch/hermes-agent#26847, openclaw/openclaw#84504.
+
+const (
+	tkGrokEntitlement403Subscription = "grok subscription"
+	tkGrokEntitlement403Resources    = "run out of available resources"
+	tkGrokEntitlement403Heavy        = "supergrok heavy"
+)
+
+// tkIsGrokEntitlement403 reports whether a 403 upstream response is the xAI
+// Heavy-only entitlement gate (matched on xAI-specific body markers, so it is
+// account-agnostic and cannot trip on a generic 403 / WAF block).
+func tkIsGrokEntitlement403(statusCode int, body []byte) bool {
+	if statusCode != 403 {
+		return false
+	}
+	hay := tkGrokEntitlement403Haystack(body)
+	if hay == "" {
+		return false
+	}
+	return strings.Contains(hay, tkGrokEntitlement403Subscription) ||
+		strings.Contains(hay, tkGrokEntitlement403Resources) ||
+		strings.Contains(hay, tkGrokEntitlement403Heavy)
+}
+
+// tkGrokEntitlement403Haystack assembles the lower-cased structured error text to
+// scan (extracted message + the common error.message / detail envelope fields),
+// mirroring tkCapabilityScope401Haystack so a marker inside an unrelated field
+// cannot match.
+func tkGrokEntitlement403Haystack(body []byte) string {
+	if len(body) == 0 {
+		return ""
+	}
+	parts := make([]string, 0, 3)
+	if msg := strings.TrimSpace(extractUpstreamErrorMessage(body)); msg != "" {
+		parts = append(parts, msg)
+	}
+	if errMsg := strings.TrimSpace(gjson.GetBytes(body, "error.message").String()); errMsg != "" {
+		parts = append(parts, errMsg)
+	}
+	if detail := strings.TrimSpace(gjson.GetBytes(body, "detail").String()); detail != "" {
+		parts = append(parts, detail)
+	}
+	return strings.ToLower(strings.Join(parts, "\n"))
+}
+
+// tkGrokEntitlement403ClientMessage is the client-facing message for a grok
+// entitlement-403, actionable without leaking which account.
+func tkGrokEntitlement403ClientMessage(upstreamMsg string) string {
+	base := "The Grok (xAI) subscription backing this request is not entitled to API access " +
+		"(xAI gates the OAuth API surface to SuperGrok Heavy). Confirm the account is on SuperGrok Heavy."
+	upstreamMsg = strings.TrimSpace(upstreamMsg)
+	if upstreamMsg == "" {
+		return base
+	}
+	return base + " Upstream detail: " + upstreamMsg
+}

--- a/backend/internal/service/ratelimit_service_tk_grok_entitlement_403.go
+++ b/backend/internal/service/ratelimit_service_tk_grok_entitlement_403.go
@@ -57,7 +57,7 @@ func tkGrokEntitlement403Haystack(body []byte) string {
 	if len(body) == 0 {
 		return ""
 	}
-	parts := make([]string, 0, 3)
+	parts := make([]string, 0, 5)
 	if msg := strings.TrimSpace(extractUpstreamErrorMessage(body)); msg != "" {
 		parts = append(parts, msg)
 	}
@@ -66,6 +66,19 @@ func tkGrokEntitlement403Haystack(body []byte) string {
 	}
 	if detail := strings.TrimSpace(gjson.GetBytes(body, "detail").String()); detail != "" {
 		parts = append(parts, detail)
+	}
+	// xAI's error envelope is {"code":"...","error":"<string>"} — the `error` field
+	// is a STRING, not OpenAI's {"error":{"message":...}} object (confirmed live
+	// against api.x.ai 2026-06). extractUpstreamErrorMessage / error.message do NOT
+	// see it, so scan the top-level string `error` + `code` explicitly, else the
+	// entitlement markers below are never matched and the honesty guard misfires.
+	if errVal := gjson.GetBytes(body, "error"); errVal.Type == gjson.String {
+		if s := strings.TrimSpace(errVal.String()); s != "" {
+			parts = append(parts, s)
+		}
+	}
+	if code := strings.TrimSpace(gjson.GetBytes(body, "code").String()); code != "" {
+		parts = append(parts, code)
 	}
 	return strings.ToLower(strings.Join(parts, "\n"))
 }

--- a/backend/internal/service/scheduler_snapshot_platforms_test.go
+++ b/backend/internal/service/scheduler_snapshot_platforms_test.go
@@ -22,6 +22,7 @@ func TestAllSchedulingPlatforms_IncludesNewAPI(t *testing.T) {
 		PlatformAntigravity: false,
 		PlatformNewAPI:      false,
 		PlatformKiro:        false,
+		PlatformGrok:        false,
 	}
 	for _, p := range got {
 		if _, ok := want[p]; !ok {

--- a/backend/internal/service/tk_pricing_overlay.json
+++ b/backend/internal/service/tk_pricing_overlay.json
@@ -4,6 +4,25 @@
     "provenance": "media: BerriAI/litellm model_prices_and_context_window.json, captured 2026-06-01; deepseek-v4-*: https://api-docs.deepseek.com/quick_start/pricing, captured 2026-06-04 (cache-hit input = cache_read; cache writes billed as normal input, no separate write fee); volcengine doubao-*/glm-4-7-251222/deepseek-v3-2-251201: VolcEngine Ark official model-pricing page, captured 2026-06-10 (≤32K input tier, CNY/USD=6.7); glm-4.7 matches Zhipu official; qwen3.7-max* / qwen3.7-plus / qwen3.6-flash / qwen3-coder-plus / qwen-max / qwen-plus: Alibaba DashScope China-mainland (Beijing) RMB list ÷ 6.7, docs/accounts/aliyun_pricing_20260612.md captured 2026-06-12 (per-entry source; the qwen3.7-* / qwen3.6-flash / qwen3-coder-plus values were corrected 2026-06-13 from a prior USD-list basis ≈÷7.27 to the table's canonical CNY/USD=6.7); qwen2.5-coder-32b/7b: retired & absent from current Alibaba list — proxy-filled from lineage successors qwen3-coder-plus / qwen3-coder-flash, Beijing RMB list ÷ 6.7, docs/accounts/aliyun_pricing_20260612.md captured 2026-06-12 (per-entry source); seedream/seedance media: VolcEngine Ark official model-pricing page (https://www.volcengine.com/docs/82379/1099320), captured 2026-06-12, CNY/USD=6.7 — per-image flat price; per-second video price derived at each model's max supported tier (1080p@24fps; 2.0-fast 720p), online standard rate, derivation formula in per-entry source; only IDs present in new-api ch45/54 model lists are included — seedream-4.5/5.0(-lite) & seedance-1.0-pro-fast are priced upstream but absent from new-api constants, seedance-1.0-lite is listed but retired/unpriced, all deliberately NOT included (served_zero_cost P0 probe covers the gap; a wrong price has no probe); video failure_billing evidence: seedance entries carry the verified official Ark wording (success-only, captured 2026-06-12); veo entries are metric-inferred (billed per generated output second) with the official Google sentence still pending capture",
     "regen": "manual curation; no auto-sync (entries are few + slow-moving). If they proliferate, add provider-aware sync."
   },
+  "grok-imagine-image": {
+    "litellm_provider": "xai",
+    "mode": "image_generation",
+    "output_cost_per_image": 0.02,
+    "source": "xAI official API list (x.ai/api), captured 2026-06; grok-imagine-image standard tier, flat $0.02/img (1K=2K). Verify in console.x.ai before relying."
+  },
+  "grok-imagine-image-quality": {
+    "litellm_provider": "xai",
+    "mode": "image_generation",
+    "output_cost_per_image": 0.07,
+    "source": "xAI official API list (x.ai/api), captured 2026-06; grok-imagine-image-quality $0.05/img@1K, $0.07/img@2K — priced at the 2K worst case (conservative, never under-bills; the OpenAI /v1/images path passes no size param). Replaced the retired grok-imagine-image-pro 2026-05-15. Verify in console.x.ai."
+  },
+  "grok-code-fast-1": {
+    "litellm_provider": "xai",
+    "mode": "chat",
+    "input_cost_per_token": 2e-07,
+    "output_cost_per_token": 1.5e-06,
+    "source": "xAI official (x.ai/news/grok-code-fast-1) post-promo list $0.20/Mtok in, $1.50/Mtok out, captured 2026-06. NOTE: grok-4.x chat models (incl. grok-4.3 — the SuperGrok Heavy OAuth default) are intentionally NOT priced here — their 2026 list price was unconfirmed at authoring time; they bill $0 (served_zero_cost P0 alerts) until the operator adds verified rows from console.x.ai. Per the overlay's 'a wrong price has no probe' discipline, a missing-but-alarmed price is safer than a guessed one."
+  },
   "claude-fable-5": {
     "litellm_provider": "anthropic",
     "mode": "chat",

--- a/backend/internal/service/token_refresh_service.go
+++ b/backend/internal/service/token_refresh_service.go
@@ -67,6 +67,8 @@ func NewTokenRefreshService(
 	agRefresher := NewAntigravityTokenRefresher(antigravityOAuthService)
 	// Kiro（第六平台）刷新器无外部依赖，刷新走 vendor 包级 kiroproto.RefreshToken。
 	kiroRefresher := NewKiroTokenRefresher()
+	// Grok（第七平台）刷新器无外部依赖，刷新走 stdlib-only 的 pkg/xai.RefreshToken。
+	grokRefresher := NewGrokTokenRefresher()
 
 	// 注册平台特定的刷新器（TokenRefresher 接口）
 	s.refreshers = []TokenRefresher{
@@ -75,6 +77,7 @@ func NewTokenRefreshService(
 		geminiRefresher,
 		agRefresher,
 		kiroRefresher,
+		grokRefresher,
 	}
 
 	// 注册对应的 OAuthRefreshExecutor（带 CacheKey 方法），顺序与 refreshers 一一对应
@@ -84,6 +87,7 @@ func NewTokenRefreshService(
 		geminiRefresher,
 		agRefresher,
 		kiroRefresher,
+		grokRefresher,
 	}
 
 	return s

--- a/backend/internal/web/dist/frontend-source.json
+++ b/backend/internal/web/dist/frontend-source.json
@@ -1,7 +1,7 @@
 {
   "algorithm": "sha256(git-ls-files:path,size,content)",
-  "file_count": 484,
-  "hash": "e6e7041ecca8491cee7835aef2bc1eae3025abc462e85869687ec82e49be41c4",
+  "file_count": 486,
+  "hash": "293bd247a9f9ab0171c495a2e44862aabf61edc40da32f1db0d32bb966e730af",
   "schema": 1,
   "source": "frontend/"
 }

--- a/backend/internal/web/dist/frontend-source.json
+++ b/backend/internal/web/dist/frontend-source.json
@@ -1,7 +1,7 @@
 {
   "algorithm": "sha256(git-ls-files:path,size,content)",
   "file_count": 486,
-  "hash": "293bd247a9f9ab0171c495a2e44862aabf61edc40da32f1db0d32bb966e730af",
+  "hash": "f7e17585d0e5b6bb50eba301f832f368e5061dfa89863761181a30102c7488a6",
   "schema": 1,
   "source": "frontend/"
 }

--- a/backend/migrations/tk_028_allow_grok_model_availability_platform.sql
+++ b/backend/migrations/tk_028_allow_grok_model_availability_platform.sql
@@ -1,0 +1,23 @@
+-- TK migration 028: allow 'grok' (seventh platform) in model_availability.platform CHECK constraint.
+--
+-- Why a new migration instead of editing tk_009/tk_016:
+--   Those have already been applied on prod/edge nodes. TokenKey's migration runner enforces a
+--   checksum guard — editing an already-applied migration changes its checksum and makes every
+--   node refuse to start (and the deploy trap then rolls back to the prior bad image, pinning the
+--   node). So the platform-set extension MUST land as a NEW, idempotent migration. Mirrors tk_016
+--   (which added 'kiro' the same way).
+--
+-- Symptom this fixes: every grok gateway forward would log `pricing.availability.record_failed`
+--   with `ent: validator failed ... invalid enum value for platform field: "grok"`. The enum gap
+--   is two-layered — the ent Go PlatformValidator (regenerated via `go generate ./ent`) AND this
+--   DB CHECK. This migration closes the DB layer; the ent layer closes via the schema edit
+--   (ent/schema/model_availability.go Values(...,"grok")).
+--
+-- Idempotent: DROP CONSTRAINT IF EXISTS + re-ADD with the full platform set. Safe to re-run.
+
+ALTER TABLE model_availability
+    DROP CONSTRAINT IF EXISTS model_availability_platform_check;
+
+ALTER TABLE model_availability
+    ADD CONSTRAINT model_availability_platform_check
+    CHECK (platform IN ('openai', 'anthropic', 'gemini', 'antigravity', 'newapi', 'kiro', 'grok'));

--- a/frontend/src/components/account/AccountGrokPlatformFields.vue
+++ b/frontend/src/components/account/AccountGrokPlatformFields.vue
@@ -1,0 +1,65 @@
+<script setup lang="ts">
+import { useI18n } from 'vue-i18n'
+import Icon from '@/components/icons/Icon.vue'
+
+withDefaults(
+  defineProps<{
+    variant?: 'create' | 'edit'
+  }>(),
+  {
+    variant: 'create',
+  }
+)
+
+const refreshToken = defineModel<string>('refreshToken', { required: true })
+const baseUrl = defineModel<string>('baseUrl', { default: '' })
+
+const { t } = useI18n()
+</script>
+
+<template>
+  <div class="space-y-4">
+    <!-- How to obtain the refresh_token: one-line hint (xAI public client is loopback-only). -->
+    <div class="rounded-lg border border-slate-200 bg-slate-50 p-3 dark:border-slate-700/50 dark:bg-slate-800/30">
+      <p class="text-xs text-slate-700 dark:text-slate-300">
+        <Icon name="infoCircle" size="sm" class="mr-1 inline" :stroke-width="2" />
+        {{ t('admin.accounts.grokPlatform.refreshTokenHowTo') }}
+      </p>
+    </div>
+
+    <div>
+      <label class="input-label">
+        {{ t('admin.accounts.grokPlatform.refreshToken') }}
+        <span v-if="variant === 'create'" class="text-red-500">*</span>
+      </label>
+      <textarea
+        v-model="refreshToken"
+        rows="3"
+        spellcheck="false"
+        :class="variant === 'create' ? 'input mt-1 font-mono text-xs' : 'input font-mono text-xs'"
+        :placeholder="t('admin.accounts.grokPlatform.refreshTokenPlaceholder')"
+      />
+      <p class="input-hint">{{ t('admin.accounts.grokPlatform.refreshTokenHint') }}</p>
+      <p v-if="variant === 'edit'" class="input-hint">{{ t('admin.accounts.grokPlatform.tokenEditHint') }}</p>
+    </div>
+
+    <div>
+      <label class="input-label">{{ t('admin.accounts.grokPlatform.baseUrl') }}</label>
+      <input
+        v-model="baseUrl"
+        type="text"
+        :class="variant === 'create' ? 'input mt-1 font-mono' : 'input font-mono'"
+        placeholder="https://api.x.ai/v1"
+      />
+      <p class="input-hint">{{ t('admin.accounts.grokPlatform.baseUrlHint') }}</p>
+    </div>
+
+    <!-- SuperGrok Heavy entitlement note: xAI gates the OAuth API surface to Heavy. -->
+    <div class="rounded-lg border border-amber-200 bg-amber-50 p-3 dark:border-amber-800/40 dark:bg-amber-900/20">
+      <p class="text-xs text-amber-800 dark:text-amber-200">
+        <Icon name="exclamationTriangle" size="sm" class="mr-1 inline" :stroke-width="2" />
+        {{ t('admin.accounts.grokPlatform.heavyNote') }}
+      </p>
+    </div>
+  </div>
+</template>

--- a/frontend/src/components/account/CreateAccountModal.vue
+++ b/frontend/src/components/account/CreateAccountModal.vue
@@ -184,6 +184,25 @@
             <Icon name="sparkles" size="sm" />
             {{ PLATFORM_LABELS.kiro }}
           </button>
+          <!--
+            7th platform: Grok (xAI / SuperGrok Heavy, OAuth refresh_token paste).
+            Slate styling from CREATE_ACCOUNT_PLATFORM_SEGMENT_ACTIVE (single source
+            of truth per CLAUDE.md §5). xAI is OpenAI-wire compatible, so grok reuses
+            the OpenAI-compat forward/scheduling — only the OAuth refresh differs.
+          -->
+          <button
+            type="button"
+            @click="form.platform = 'grok'"
+            :class="[
+              'flex flex-1 items-center justify-center gap-2 rounded-md px-4 py-2.5 text-sm font-medium transition-all',
+              form.platform === 'grok'
+                ? 'bg-white text-slate-700 shadow-sm dark:bg-dark-600 dark:text-slate-300'
+                : 'text-gray-600 hover:text-gray-900 dark:text-gray-400 dark:hover:text-gray-200'
+            ]"
+          >
+            <Icon name="sparkles" size="sm" />
+            {{ PLATFORM_LABELS.grok }}
+          </button>
         </div>
       </div>
 
@@ -224,6 +243,15 @@
           v-model:clientSecret="kiroClientSecret"
           v-model:profileArn="kiroProfileArn"
           v-model:tosAcknowledged="kiroTosAcknowledged"
+          variant="create"
+        />
+      </div>
+
+      <!-- grok (7th platform): OAuth refresh_token paste directly under platform picker. -->
+      <div v-if="form.platform === 'grok'" class="space-y-4">
+        <AccountGrokPlatformFields
+          v-model:refreshToken="grokRefreshToken"
+          v-model:baseUrl="grokBaseUrl"
           variant="create"
         />
       </div>
@@ -3390,6 +3418,8 @@ import AccountNewApiPlatformFields from './AccountNewApiPlatformFields.vue'
 import { useTkAccountNewApiPlatform } from '@/composables/useTkAccountNewApiPlatform'
 import AccountKiroPlatformFields from './AccountKiroPlatformFields.vue'
 import { useTkAccountKiroPlatform } from '@/composables/useTkAccountKiroPlatform'
+import AccountGrokPlatformFields from './AccountGrokPlatformFields.vue'
+import { useTkAccountGrokPlatform } from '@/composables/useTkAccountGrokPlatform'
 import { PLATFORM_LABELS } from '@/composables/usePlatformOptions'
 
 // Type for exposed OAuthAuthorizationFlow component
@@ -3660,6 +3690,14 @@ const {
   reset: kiroReset,
   buildSubmitBundle: kiroBuildSubmitBundle,
 } = useTkAccountKiroPlatform()
+
+// 第七平台 grok 的表单状态 + 校验 + credentials 拼装收口在 composable。
+const {
+  refreshToken: grokRefreshToken,
+  baseUrl: grokBaseUrl,
+  reset: grokReset,
+  buildSubmitBundle: grokBuildSubmitBundle,
+} = useTkAccountGrokPlatform()
 
 const tempUnschedEnabled = ref(false)
 const tempUnschedRules = ref<TempUnschedRuleForm[]>([])
@@ -3936,6 +3974,11 @@ const isOAuthFlow = computed(() => {
   if (form.platform === 'kiro') {
     return false
   }
+  // grok (7th platform) creates by pasting a refresh_token — no interactive OAuth step
+  // (xAI's public client is loopback-only; the token is minted out-of-band).
+  if (form.platform === 'grok') {
+    return false
+  }
   return accountCategory.value === 'oauth-based'
 })
 
@@ -4014,6 +4057,11 @@ watch(
       form.type = 'oauth'
       return
     }
+    // grok (7th platform): always oauth type (refresh_token paste), regardless of addMethod.
+    if (form.platform === 'grok') {
+      form.type = 'oauth'
+      return
+    }
     if ((form.platform === 'gemini' || form.platform === 'anthropic') && category === 'service_account') {
       form.type = 'service_account' as AccountType
     } else if (category === 'oauth-based') {
@@ -4065,6 +4113,14 @@ watch(
       // watcher A 把 form.type 同步成 'oauth'（与后端 type=oauth 契约对齐），
       // 同时避免渲染通用 apikey / 配额块。kiro 字段重置由 composable.reset()
       // 在 resetForm 中负责，平台切换不清除已填字段。
+      accountCategory.value = 'oauth-based'
+      allowOverages.value = false
+      antigravityWhitelistModels.value = []
+      antigravityModelMappings.value = []
+      antigravityModelRestrictionMode.value = 'mapping'
+    } else if (newPlatform === 'grok') {
+      // 第七平台 grok：oauth(refresh_token)直填，accountCategory='oauth-based' 让
+      // watcher A 把 form.type 同步成 'oauth'。字段重置由 composable.reset() 负责。
       accountCategory.value = 'oauth-based'
       allowOverages.value = false
       antigravityWhitelistModels.value = []
@@ -4541,6 +4597,8 @@ const resetForm = () => {
   newapiReset()
   // 第六平台 kiro 字段重置由 composable 统一管理
   kiroReset()
+  // 第七平台 grok 字段重置由 composable 统一管理
+  grokReset()
   tempUnschedEnabled.value = false
   tempUnschedRules.value = []
   geminiOAuthType.value = 'code_assist'
@@ -4894,6 +4952,34 @@ const handleSubmit = async () => {
       name: form.name,
       notes: form.notes,
       platform: 'kiro',
+      type: 'oauth',
+      credentials: bundle.credentials,
+      extra: buildAPIKeyOrBedrockExtra(),
+      proxy_id: form.proxy_id,
+      concurrency: form.concurrency,
+      load_factor: form.load_factor ?? undefined,
+      priority: form.priority,
+      rate_multiplier: form.rate_multiplier,
+      group_ids: form.group_ids,
+      expires_at: form.expires_at,
+      auto_pause_on_expired: autoPauseOnExpired.value
+    })
+    return
+  }
+
+  // 第七平台 grok：粘 refresh_token，type=oauth；创建期后端 resolveGrokTokenOnSave
+  // 用 refresh_token 立刻换 access_token（绿勾 / 明确报错），无需手填 access_token。
+  if (form.platform === 'grok') {
+    if (!form.name.trim()) {
+      appStore.showError(t('admin.accounts.pleaseEnterAccountName'))
+      return
+    }
+    const bundle = grokBuildSubmitBundle('create')
+    if (!bundle) return
+    await doCreateAccount({
+      name: form.name,
+      notes: form.notes,
+      platform: 'grok',
       type: 'oauth',
       credentials: bundle.credentials,
       extra: buildAPIKeyOrBedrockExtra(),

--- a/frontend/src/components/account/EditAccountModal.vue
+++ b/frontend/src/components/account/EditAccountModal.vue
@@ -26,6 +26,16 @@
         <p class="input-hint">{{ t('admin.accounts.notesHint') }}</p>
       </div>
 
+      <!-- grok (7th platform, OAuth): refresh_token rotation. Blank = keep current;
+           a re-pasted token is re-validated + re-primed by the backend on save. -->
+      <div v-if="account.platform === 'grok'" class="space-y-4">
+        <AccountGrokPlatformFields
+          v-model:refreshToken="grokRefreshToken"
+          v-model:baseUrl="grokBaseUrl"
+          variant="edit"
+        />
+      </div>
+
       <!-- API Key fields (only for apikey type) -->
       <div v-if="account.type === 'apikey'" class="space-y-4">
         <!--
@@ -2513,6 +2523,8 @@ import ModelWhitelistSelector from '@/components/account/ModelWhitelistSelector.
 import QuotaLimitCard from '@/components/account/QuotaLimitCard.vue'
 import AccountNewApiPlatformFields from './AccountNewApiPlatformFields.vue'
 import { useTkAccountNewApiPlatform } from '@/composables/useTkAccountNewApiPlatform'
+import AccountGrokPlatformFields from './AccountGrokPlatformFields.vue'
+import { useTkAccountGrokPlatform } from '@/composables/useTkAccountGrokPlatform'
 import { applyInterceptWarmup } from '@/components/account/credentialsBuilder'
 import { formatDateTime, formatDateTimeLocalInput, parseDateTimeLocalInput } from '@/utils/format'
 import { createStableObjectKeyResolver } from '@/utils/stableObjectKey'
@@ -2617,6 +2629,14 @@ const {
   isNewapi: () => props.account?.platform === 'newapi',
   storedAccount: () => (props.account ? { id: props.account.id, channel_type: props.account.channel_type } : null),
 })
+
+// 第七平台 grok：编辑时的 refresh_token 轮换 + base_url。
+const {
+  refreshToken: grokRefreshToken,
+  baseUrl: grokBaseUrl,
+  populateFromAccount: grokPopulateFromAccount,
+  buildSubmitBundle: grokBuildSubmitBundle,
+} = useTkAccountGrokPlatform()
 // Bedrock credentials
 const editBedrockAccessKeyId = ref('')
 const editBedrockSecretAccessKey = ref('')
@@ -3322,6 +3342,12 @@ const syncFormFromAccount = (newAccount: Account | null) => {
       }
     }
 
+    // 第七平台 grok：refresh_token 是敏感字段，编辑时留空表示保留现有值（composable
+    // 不回填），base_url 回填。
+    if (newAccount.platform === 'grok') {
+      grokPopulateFromAccount({ credentials })
+    }
+
     // Load model mappings and detect mode
     loadModelRestrictionFromMapping(credentials.model_mapping as Record<string, unknown> | undefined)
 
@@ -3925,6 +3951,17 @@ const handleSubmit = async () => {
       updatePayload.load_factor = 0
     }
     updatePayload.auto_pause_on_expired = autoPauseOnExpired.value
+
+    // 第七平台 grok（oauth，非 apikey）：仅在重粘了 refresh_token 或改了 base_url 时
+    // 才发 credentials。refresh_token 留空 = 保留现有（后端 MergePreservingSensitiveCreds
+    // + 后台刷新器处理）；重粘则后端 resolveGrokTokenOnSave 活体校验 + 重新 prime。
+    if (props.account.platform === 'grok') {
+      const bundle = grokBuildSubmitBundle('edit')
+      if (!bundle) return
+      if (Object.keys(bundle.credentials).length > 0) {
+        updatePayload.credentials = bundle.credentials
+      }
+    }
 
     // For apikey type, handle credentials update
     if (props.account.type === 'apikey') {

--- a/frontend/src/components/keys/UseKeyModal.vue
+++ b/frontend/src/components/keys/UseKeyModal.vue
@@ -390,6 +390,8 @@ const defaultClientTab = computed(() => {
       return 'codex'
     case 'newapi':
       return 'codex'
+    case 'grok':
+      return 'codex'
     case 'gemini':
       return 'gemini'
     case 'antigravity':
@@ -512,9 +514,11 @@ const clientTabs = computed((): TabConfig[] => {
       tabs.push({ id: 'opencode', label: t('keys.useKeyModal.cliTabs.opencode'), icon: TerminalIcon })
       return tabs
     }
-    case 'newapi': {
+    case 'newapi':
+    case 'grok': {
       // OpenAI-compat HTTP only; no codex-ws. Optionally claude tab when the
-      // group enables messages dispatch (mirrors the openai branch).
+      // group enables messages dispatch (mirrors the openai branch). grok (xAI)
+      // shares this flavor: api.x.ai is OpenAI-compatible.
       const tabs: TabConfig[] = [
         { id: 'codex', label: t('keys.useKeyModal.cliTabs.codexCli'), icon: TerminalIcon },
       ]
@@ -570,7 +574,7 @@ const currentTabs = computed(() => {
 // instructions are identical (codex CLI + opencode), and our gateway already
 // routes both platforms through the OpenAI-compat handlers.
 const isOpenAICompatPlatform = computed(
-  () => props.platform === 'openai' || props.platform === 'newapi',
+  () => props.platform === 'openai' || props.platform === 'newapi' || props.platform === 'grok',
 )
 
 const platformDescription = computed(() => {
@@ -660,10 +664,11 @@ const currentFiles = computed((): FileConfig[] => {
         return [generateOpenCodeConfig('anthropic', apiBase, apiKey)]
       case 'openai':
       case 'newapi':
-        // newapi shares OpenAI-compat HTTP shape: codex CLI / opencode use
-        // identical config (provider=openai, baseURL=apiBase). Sticking
-        // both branches together avoids a parallel newapi catalog that
-        // would drift from openai's.
+      case 'grok':
+        // newapi/grok share the OpenAI-compat HTTP shape: codex CLI / opencode
+        // use identical config (provider=openai, baseURL=apiBase). Sticking
+        // these branches together avoids a parallel catalog that would drift
+        // from openai's.
         return [generateOpenCodeConfig('openai', apiBase, apiKey)]
       case 'gemini':
         return [generateOpenCodeConfig('gemini', geminiBase, apiKey)]
@@ -701,8 +706,10 @@ const currentFiles = computed((): FileConfig[] => {
       }
       return generateOpenAIFiles(baseUrl, apiKey, model)
     case 'newapi':
-      // newapi has no OAuth WS path (codex-ws not offered in its tabs).
-      // claude tab only appears when the group enables messages dispatch.
+    case 'grok':
+      // newapi/grok: OpenAI-compat HTTP, no OAuth WS path (codex-ws not offered
+      // in their tabs). claude tab only appears when the group enables messages
+      // dispatch. grok (xAI) is OpenAI-compatible, so it shares the openai files.
       if (activeClientTab.value === 'claude') {
         return generateAnthropicFiles(baseUrl, apiKey, model)
       }

--- a/frontend/src/composables/usePlatformOptions.ts
+++ b/frontend/src/composables/usePlatformOptions.ts
@@ -9,6 +9,7 @@ export const PLATFORM_LABELS: Record<AccountPlatform, string> = {
   antigravity: 'Antigravity',
   newapi: 'Extension Engine',
   kiro: 'Kiro',
+  grok: 'Grok',
 }
 
 export function getPlatformLabel(platform: string | null | undefined): string {

--- a/frontend/src/composables/useTkAccountGrokPlatform.ts
+++ b/frontend/src/composables/useTkAccountGrokPlatform.ts
@@ -1,0 +1,89 @@
+import { ref } from 'vue'
+import { useI18n } from 'vue-i18n'
+import { useAppStore } from '@/stores/app'
+
+// 第七平台 Grok (xAI / SuperGrok Heavy) 的添加 / 编辑 modal 业务状态 + 校验 +
+// credentials 拼装都收口在本 composable，让 CreateAccountModal 只剩「调用 + 透传
+// v-model」。见 CLAUDE.md §5.x「最小侵入 + composable 收口」。
+//
+// 账号 credentials 契约（后端已定）：platform=grok, type=oauth
+//   - refresh_token  (必填) —— 由 xAI Grok CLI 本机 loopback 登录铸取后粘贴；
+//                    xAI 公共 client 无 web-redirect / device-code，故服务端做不了
+//                    交互式 OAuth。创建时后端 resolveGrokTokenOnSave 会用它立刻换
+//                    access_token（绿勾 / 明确报错），无需手填 access_token。
+//   - base_url       (可选) —— 默认 https://api.x.ai/v1，仅自建反代时覆盖。
+//
+// 比 kiro 简单得多：xAI 是 OpenAI-wire 兼容，只需 refresh_token 一项。
+
+export const GROK_DEFAULT_BASE_URL = 'https://api.x.ai/v1'
+
+export interface TkGrokCredentialsBundle {
+  credentials: Record<string, unknown>
+}
+
+export interface TkGrokAccountSnapshot {
+  credentials?: Record<string, unknown> | null
+}
+
+/**
+ * Grok（第七平台）添加 / 编辑账号表单的状态与副作用。
+ *
+ * 暴露：
+ *   - v-model 绑定的 ref（refreshToken / baseUrl）
+ *   - 父组件调用的方法（reset / populateFromAccount / buildSubmitBundle）
+ */
+export function useTkAccountGrokPlatform() {
+  const { t } = useI18n()
+  const appStore = useAppStore()
+
+  const refreshToken = ref('')
+  const baseUrl = ref('')
+
+  function reset(): void {
+    refreshToken.value = ''
+    baseUrl.value = ''
+  }
+
+  /**
+   * 把已有 grok 账号字段镜像到 ref（EditAccountModal 用）。refresh_token 敏感，
+   * 编辑时留空表示「保留现有值」，不回填。
+   */
+  function populateFromAccount(account: TkGrokAccountSnapshot): void {
+    const credentials = (account.credentials || {}) as Record<string, unknown>
+    refreshToken.value = ''
+    baseUrl.value = typeof credentials.base_url === 'string' ? credentials.base_url : ''
+  }
+
+  /**
+   * 校验 grok 表单 + 拼装 credentials。校验失败返回 null 并已 showError。
+   * mode='create' 时 refresh_token 必填；mode='edit' 留空表示「保留现有值」。
+   */
+  function buildSubmitBundle(mode: 'create' | 'edit'): TkGrokCredentialsBundle | null {
+    const trimmedRefresh = refreshToken.value.trim()
+    if (mode === 'create' && !trimmedRefresh) {
+      appStore.showError(t('admin.accounts.grokPlatform.pleaseEnterRefreshToken'))
+      return null
+    }
+
+    const credentials: Record<string, unknown> = {}
+    if (trimmedRefresh) {
+      credentials.refresh_token = trimmedRefresh
+    }
+    const trimmedBase = baseUrl.value.trim()
+    if (trimmedBase) {
+      credentials.base_url = trimmedBase
+    }
+
+    return { credentials }
+  }
+
+  return {
+    // refs
+    refreshToken,
+    baseUrl,
+    // methods
+    reset,
+    populateFromAccount,
+    buildSubmitBundle,
+  }
+}

--- a/frontend/src/constants/gatewayPlatforms.ts
+++ b/frontend/src/constants/gatewayPlatforms.ts
@@ -1,7 +1,7 @@
 import type { AccountPlatform } from '@/types'
 
 /** Ordered account/group platforms, including the independent fifth platform `newapi`. */
-export const GATEWAY_PLATFORMS = ['anthropic', 'openai', 'gemini', 'antigravity', 'newapi', 'kiro'] as const satisfies readonly AccountPlatform[]
+export const GATEWAY_PLATFORMS = ['anthropic', 'openai', 'gemini', 'antigravity', 'newapi', 'kiro', 'grok'] as const satisfies readonly AccountPlatform[]
 
 /**
  * Platforms that participate in the OpenAI-compatible HTTP request shape
@@ -14,7 +14,7 @@ export const GATEWAY_PLATFORMS = ['anthropic', 'openai', 'gemini', 'antigravity'
  * "newapi compat-pool drift" catches the backend half; the frontend half is
  * covered by the `useModelWhitelist` and `usePlatformOptions` test suites.
  */
-export const OPENAI_COMPAT_PLATFORMS: readonly AccountPlatform[] = ['openai', 'newapi'] as const
+export const OPENAI_COMPAT_PLATFORMS: readonly AccountPlatform[] = ['openai', 'newapi', 'grok'] as const
 
 /** Predicate sibling of {@link OPENAI_COMPAT_PLATFORMS} — use whenever a UI branch is gated on "speaks OpenAI HTTP shape". */
 export function isOpenAICompatPlatform(platform: string | null | undefined): boolean {
@@ -37,7 +37,7 @@ export function isOpenAICompatPlatform(platform: string | null | undefined): boo
  * UI branches (e.g. /v1/chat/completions allowance). Those two questions
  * intentionally do not coincide for gemini.
  */
-export const GROUP_DISPATCH_CONFIG_PLATFORMS: readonly AccountPlatform[] = ['openai', 'newapi', 'gemini'] as const
+export const GROUP_DISPATCH_CONFIG_PLATFORMS: readonly AccountPlatform[] = ['openai', 'newapi', 'gemini', 'grok'] as const
 
 export function hasMessagesDispatchConfig(platform: string | null | undefined): boolean {
   if (!platform) return false
@@ -54,6 +54,7 @@ export const CREATE_ACCOUNT_PLATFORM_SEGMENT_ACTIVE: Record<AccountPlatform, str
     'bg-white text-purple-600 shadow-sm dark:bg-dark-600 dark:text-purple-400',
   newapi: 'bg-white text-cyan-600 shadow-sm dark:bg-dark-600 dark:text-cyan-400',
   kiro: 'bg-white text-indigo-600 shadow-sm dark:bg-dark-600 dark:text-indigo-400',
+  grok: 'bg-white text-slate-700 shadow-sm dark:bg-dark-600 dark:text-slate-300',
 }
 
 export const CREATE_ACCOUNT_PLATFORM_SEGMENT_BASE =
@@ -71,6 +72,7 @@ const SOFT_BADGE: Record<string, string> = {
   antigravity: 'bg-purple-100 text-purple-700 dark:bg-purple-900/30 dark:text-purple-400',
   newapi: 'bg-cyan-100 text-cyan-800 dark:bg-cyan-900/30 dark:text-cyan-300',
   kiro: 'bg-indigo-100 text-indigo-800 dark:bg-indigo-900/30 dark:text-indigo-300',
+  grok: 'bg-slate-200 text-slate-800 dark:bg-slate-700/40 dark:text-slate-200',
 }
 
 const LABEL_TEXT: Record<string, string> = {
@@ -80,6 +82,7 @@ const LABEL_TEXT: Record<string, string> = {
   antigravity: 'text-purple-600 dark:text-purple-400',
   newapi: 'text-cyan-600 dark:text-cyan-400',
   kiro: 'text-indigo-600 dark:text-indigo-400',
+  grok: 'text-slate-700 dark:text-slate-300',
 }
 
 const TABLE_CELL_BASE =

--- a/frontend/src/i18n/locales/en.ts
+++ b/frontend/src/i18n/locales/en.ts
@@ -4149,6 +4149,17 @@ export default {
         pleaseEnterClientSecret: 'Please enter the IdC Client Secret',
         pleaseAcknowledgeTos: 'Please acknowledge the Kiro terms of service before creating the account'
       },
+      grokPlatform: {
+        refreshToken: 'Refresh Token',
+        refreshTokenPlaceholder: 'xAI Grok OAuth refresh token',
+        refreshTokenHint: 'On create, TokenKey immediately exchanges it for an access token — a failure here means the token is invalid or the account is not SuperGrok Heavy.',
+        refreshTokenHowTo: 'Obtain the refresh_token by running the xAI Grok CLI login on your own machine (loopback OAuth), then paste it here. xAI\'s public client has no server-side redirect / device-code flow, so the token must be minted out-of-band.',
+        baseUrl: 'Base URL (optional)',
+        baseUrlHint: 'Defaults to https://api.x.ai/v1. Override only for a self-hosted reverse proxy.',
+        tokenEditHint: 'Leave empty to keep the current value',
+        heavyNote: 'xAI gates the OAuth API surface to SuperGrok Heavy. A standard / expired subscription returns HTTP 403 at request time.',
+        pleaseEnterRefreshToken: 'Please enter the Grok refresh token'
+      },
       // OAuth flow
       oauth: {
         title: 'Claude Account Authorization',

--- a/frontend/src/i18n/locales/zh.ts
+++ b/frontend/src/i18n/locales/zh.ts
@@ -4284,6 +4284,17 @@ export default {
         pleaseEnterClientSecret: '请输入 IdC Client Secret',
         pleaseAcknowledgeTos: '创建账号前请先勾选确认 Kiro 服务条款'
       },
+      grokPlatform: {
+        refreshToken: 'Refresh Token',
+        refreshTokenPlaceholder: 'xAI Grok OAuth refresh token',
+        refreshTokenHint: '创建时 TokenKey 会立刻用它换取 access token —— 这里若失败，说明 token 无效或该账号不是 SuperGrok Heavy。',
+        refreshTokenHowTo: '在本机运行 xAI Grok CLI 登录（loopback OAuth）拿到 refresh_token 后粘贴到这里。xAI 公共 client 无服务端 redirect / device-code 流程，故 token 须在本机铸取。',
+        baseUrl: 'Base URL（可选）',
+        baseUrlHint: '默认 https://api.x.ai/v1，仅自建反代时覆盖。',
+        tokenEditHint: '留空表示保留当前值',
+        heavyNote: 'xAI 把 OAuth API 面限定给 SuperGrok Heavy；标准 / 过期订阅会在请求时返回 HTTP 403。',
+        pleaseEnterRefreshToken: '请输入 Grok refresh token'
+      },
       // OAuth flow
       oauth: {
         title: 'Claude 账号授权',

--- a/frontend/src/types/index.ts
+++ b/frontend/src/types/index.ts
@@ -494,7 +494,7 @@ export interface PaginationConfig {
 
 // ==================== API Key & Group Types ====================
 
-export type GroupPlatform = 'anthropic' | 'openai' | 'gemini' | 'antigravity' | 'newapi' | 'kiro'
+export type GroupPlatform = 'anthropic' | 'openai' | 'gemini' | 'antigravity' | 'newapi' | 'kiro' | 'grok'
 
 export type SubscriptionType = 'standard' | 'subscription'
 
@@ -711,7 +711,7 @@ export interface UpdateGroupRequest {
 
 // ==================== Account & Proxy Types ====================
 
-export type AccountPlatform = 'anthropic' | 'openai' | 'gemini' | 'antigravity' | 'newapi' | 'kiro'
+export type AccountPlatform = 'anthropic' | 'openai' | 'gemini' | 'antigravity' | 'newapi' | 'kiro' | 'grok'
 export type AccountType = 'oauth' | 'setup-token' | 'apikey' | 'upstream' | 'bedrock' | 'service_account'
 export type OAuthAddMethod = 'oauth' | 'setup-token'
 export type ProxyProtocol = 'http' | 'https' | 'socks5' | 'socks5h'

--- a/scripts/preflight.sh
+++ b/scripts/preflight.sh
@@ -438,6 +438,26 @@ else
     echo "  ok: all kiro sentinels intact"
 fi
 
+# ---- sub2api: grok sentinel registry ----------------------------------------
+# Source of truth: scripts/sentinels/grok.json. Verifies that every load-bearing
+# surface of the seventh platform (`grok`, xAI / SuperGrok Heavy OAuth) is still
+# present: PlatformGrok identity, the OpenAICompatPlatforms + AllSchedulingPlatforms
+# membership, the pkg/xai OAuth refresh helper + GrokTokenRefresher, the two forward
+# seams (grok OAuth forwards like the apikey branch, NOT the ChatGPT/Codex branch),
+# the Heavy-403 honesty guard, and the pricing/enum rows. Same failure mode as the
+# kiro/newapi guards: an upstream merge silently dropping a file or injection branch.
+echo ""
+echo "=== sub2api: grok sentinel registry ==="
+if ! command -v python3 >/dev/null 2>&1; then
+    echo "  FAIL: python3 not on PATH (required to read grok.json)"
+    errors=$((errors + 1))
+elif ! python3 ./scripts/sentinels/check-grok.py --quiet; then
+    # check-grok.py already printed the actionable failure.
+    errors=$((errors + 1))
+else
+    echo "  ok: all grok sentinels intact"
+fi
+
 # ---- sub2api: antigravity fingerprint sentinel registry ---------------------
 # Source of truth: scripts/sentinels/antigravity.json. Guards the TokenKey
 # divergences in the Antigravity (cloudcode-pa) client fingerprint that an

--- a/scripts/sentinels/check-grok.py
+++ b/scripts/sentinels/check-grok.py
@@ -1,0 +1,162 @@
+#!/usr/bin/env python3
+"""
+check-grok.py — verify that every load-bearing surface of TokenKey's
+seventh platform `grok` (xAI / SuperGrok Heavy OAuth) is still present in the
+working tree.
+
+Reads `scripts/sentinels/grok.json` (single source of truth) and for each
+entry verifies:
+
+  1. The file at `path` exists.
+  2. Every literal string in `must_contain` appears at least once in the file.
+
+Exit codes:
+  0  — all sentinels intact.
+  1  — at least one sentinel missing or has lost a required symbol.
+  2  — registry file missing or malformed.
+
+Usage:
+  python3 scripts/sentinels/check-grok.py
+  python3 scripts/sentinels/check-grok.py --quiet     # only print failures
+  python3 scripts/sentinels/check-grok.py --json      # machine-readable report
+
+Why this exists:
+  The seventh platform `grok` reuses the OpenAI-compat routing/scheduling/forward
+  path (xAI speaks the OpenAI wire protocol); the only grok-specific code is the
+  OAuth refresh (pkg/xai + GrokTokenRefresher), the two forward seams that make
+  the OAuth branch forward like the apikey branch (plain Bearer + api.x.ai base
+  URL, NOT the ChatGPT/Codex branch), and the Heavy-403 honesty guard. An upstream
+  merge or refactor that silently drops any of these makes grok either vanish from
+  scheduling/UI or mis-forward/mis-bill at runtime — the same failure mode that
+  produced the newapi/kiro sentinel registries (CLAUDE.md §5.x). Gating both
+  pre-commit (`scripts/preflight.sh`) and upstream merge PRs
+  (`.github/workflows/upstream-merge-pr-shape.yml`) on this script upgrades the
+  rule from "agent must remember" to "merge will fail".
+"""
+from __future__ import annotations
+
+import argparse
+import json
+import sys
+from pathlib import Path
+
+REPO_ROOT = Path(__file__).resolve().parent.parent.parent
+REGISTRY_PATH = REPO_ROOT / "scripts" / "sentinels" / "grok.json"
+
+
+def load_registry() -> dict:
+    if not REGISTRY_PATH.is_file():
+        print(
+            f"FATAL: registry file not found: {REGISTRY_PATH.relative_to(REPO_ROOT)}",
+            file=sys.stderr,
+        )
+        sys.exit(2)
+    try:
+        with REGISTRY_PATH.open("r", encoding="utf-8") as f:
+            data = json.load(f)
+    except json.JSONDecodeError as exc:
+        print(
+            f"FATAL: registry file is not valid JSON: {exc}",
+            file=sys.stderr,
+        )
+        sys.exit(2)
+    if "sentinels" not in data or not isinstance(data["sentinels"], list):
+        print("FATAL: registry missing 'sentinels' array.", file=sys.stderr)
+        sys.exit(2)
+    return data
+
+
+def check_sentinel(entry: dict) -> tuple[bool, list[str]]:
+    """Returns (ok, list_of_failure_messages)."""
+    path_str = entry.get("path")
+    if not path_str:
+        return False, ["entry missing 'path'"]
+    file_path = REPO_ROOT / path_str
+    if not file_path.is_file():
+        return False, [f"file missing: {path_str}"]
+    must_contain = entry.get("must_contain") or []
+    if not must_contain:
+        return True, []
+    try:
+        content = file_path.read_text(encoding="utf-8", errors="replace")
+    except OSError as exc:
+        return False, [f"cannot read {path_str}: {exc}"]
+    failures: list[str] = []
+    for needle in must_contain:
+        if needle not in content:
+            failures.append(f"missing literal `{needle}` in {path_str}")
+    return (len(failures) == 0), failures
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("--quiet", action="store_true", help="only print failures")
+    parser.add_argument(
+        "--json",
+        action="store_true",
+        help="emit a machine-readable JSON report on stdout",
+    )
+    args = parser.parse_args()
+
+    registry = load_registry()
+    sentinels = registry["sentinels"]
+
+    results = []
+    fail_count = 0
+    for entry in sentinels:
+        ok, failures = check_sentinel(entry)
+        if not ok:
+            fail_count += 1
+        results.append(
+            {
+                "path": entry.get("path"),
+                "ok": ok,
+                "failures": failures,
+                "rationale": entry.get("rationale", ""),
+            }
+        )
+
+    if args.json:
+        json.dump(
+            {"total": len(sentinels), "failed": fail_count, "results": results},
+            sys.stdout,
+            indent=2,
+        )
+        sys.stdout.write("\n")
+    else:
+        if not args.quiet:
+            print(f"grok sentinels: checking {len(sentinels)} entries from "
+                  f"{REGISTRY_PATH.relative_to(REPO_ROOT)}")
+        for r in results:
+            if r["ok"]:
+                if not args.quiet:
+                    print(f"  ok: {r['path']}")
+            else:
+                print(f"  FAIL: {r['path']}")
+                for msg in r["failures"]:
+                    print(f"        - {msg}")
+                if r["rationale"]:
+                    print(f"        why it matters: {r['rationale']}")
+        if fail_count == 0:
+            if not args.quiet:
+                print(f"grok sentinels: PASS ({len(sentinels)}/{len(sentinels)} intact)")
+        else:
+            print(
+                f"grok sentinels: FAIL ({fail_count}/{len(sentinels)} regressed)",
+                file=sys.stderr,
+            )
+            print(
+                "  Source of truth: scripts/sentinels/grok.json",
+                file=sys.stderr,
+            )
+            print(
+                "  If a sentinel was intentionally moved/renamed, update the "
+                "registry in the same commit. Do NOT silently delete entries.",
+                file=sys.stderr,
+            )
+
+    return 0 if fail_count == 0 else 1
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/scripts/sentinels/grok.json
+++ b/scripts/sentinels/grok.json
@@ -1,0 +1,116 @@
+{
+  "version": 1,
+  "rationale": "Load-bearing files and symbols that anchor TokenKey's seventh platform `grok` (xAI / SuperGrok Heavy OAuth). Unlike kiro, xAI speaks the OpenAI-compatible wire protocol, so grok is an OpenAICompatPool member and REUSES the OpenAI-compat routing/scheduling/forward/billing path; the only grok-specific code is the OAuth refresh, the two forward seams that make the OAuth branch forward like the apikey branch (plain Bearer + api.x.ai base_url, NOT the ChatGPT/Codex branch), and the Heavy-403 honesty guard. If any sentinel below is missing, the platform either silently disappears from scheduling/UI or mis-forwards/mis-bills at runtime. Single source of truth read by both `scripts/preflight.sh` and `.github/workflows/upstream-merge-pr-shape.yml`. Adding a new load-bearing surface for grok MUST add a sentinel here in the same commit.",
+  "sentinels": [
+    {
+      "path": "backend/internal/domain/constants.go",
+      "must_contain": ["PlatformGrok = \"grok\""],
+      "rationale": "Identity constant for the seventh platform string `grok`. Removing it collapses every grok invariant (pool membership, account predicate, refresher gate)."
+    },
+    {
+      "path": "backend/internal/engine/provider.go",
+      "must_contain": ["domain.PlatformGrok"],
+      "rationale": "Grok must be in BOTH OpenAICompatPlatforms() (so it rides the OpenAI-compat routes/scheduler/sticky path with channel_type=0, like openai) AND AllSchedulingPlatforms() (so background sweeps/snapshot hydration include the grok pool). Losing either silently drops grok from routing or from rate-limit reaping/snapshot scheduling."
+    },
+    {
+      "path": "backend/internal/pkg/xai/oauth.go",
+      "must_contain": ["ClientID = \"b1a00492-073a-47ea-816f-4c329264a828\"", "func RefreshToken", "DefaultAPIBaseURL = \"https://api.x.ai/v1\""],
+      "rationale": "Stdlib-only xAI OAuth refresh helper (discovery + refresh-token grant) + the public Grok CLI client_id and the api.x.ai base URL. Losing RefreshToken stops grok token auto-refresh; accounts silently expire and drop out of the pool with no recovery."
+    },
+    {
+      "path": "backend/internal/service/account_tk_grok.go",
+      "must_contain": ["func (a *Account) IsGrok()", "func (a *Account) GetGrokBaseURL()", "func (a *Account) GetGrokAccessToken()", "func (a *Account) GetGrokRefreshToken()"],
+      "rationale": "Account-domain predicate + the grok-specific credential getters and base URL (api.x.ai/v1). GetGrok* exist because the GetOpenAI* getters are IsOpenAI-gated and return empty for grok. Losing IsGrok() removes grok from the OpenAI-compat pool and the forward seams; losing the getters breaks token/base_url resolution."
+    },
+    {
+      "path": "backend/internal/service/grok_token_refresher.go",
+      "must_contain": ["type GrokTokenRefresher", "grok:account:", "func (r *GrokTokenRefresher) Refresh"],
+      "rationale": "Implements OAuthRefreshExecutor for grok (xAI OAuth, short-lived access tokens). Losing it stops grok token auto-refresh; accounts silently expire and drop out of the pool with no recovery."
+    },
+    {
+      "path": "backend/internal/service/token_refresh_service.go",
+      "must_contain": ["NewGrokTokenRefresher"],
+      "rationale": "Registration of GrokTokenRefresher into the background refresh ticker's refreshers[]/executors[]. An upstream merge that rewrites NewTokenRefreshService must preserve this line, or grok refresh never runs even though the refresher type still exists."
+    },
+    {
+      "path": "backend/internal/service/openai_gateway_service.go",
+      "must_contain": ["if account.IsGrok()", "tkIsGrokEntitlement403"],
+      "rationale": "The grok arm of GetAccessToken (returns the grok OAuth Bearer instead of routing through the IsOpenAI-gated ChatGPT/Codex token provider) AND the wiring of the Heavy-403 honesty guard into shouldFailoverOpenAIUpstreamResponse (no failover) and the error mapper (clean client 403, not a masked 502). Losing the IsGrok() branch makes grok unable to fetch a token; losing the tkIsGrokEntitlement403 wiring re-arms the pool-wide 403 failover amplifier and re-masks the entitlement error as 502."
+    },
+    {
+      "path": "backend/internal/service/ratelimit_service_tk_grok_entitlement_403.go",
+      "must_contain": ["func tkIsGrokEntitlement403", "func tkGrokEntitlement403ClientMessage"],
+      "rationale": "The xAI Heavy-only entitlement-403 classifier + clean client message. Without it a grok 403 (standard/expired/downgraded Heavy) fails over pool-wide and is masked into a 502 — the single xAI policy change that would silently kill a thin grok pool (the marquee sharp edge)."
+    },
+    {
+      "path": "backend/internal/service/openai_gateway_chat_completions.go",
+      "must_contain": ["account.IsGrok()"],
+      "rationale": "The chat dispatch seam: grok+OAuth is routed to the RAW CC forwarder (plain Bearer + api.x.ai base_url) BEFORE the CC→Responses→Codex transform, which is hardwired to chatgpt.com. Losing this arm sends grok through the Codex path and every grok chat request fails."
+    },
+    {
+      "path": "backend/internal/service/openai_gateway_chat_completions_raw.go",
+      "must_contain": ["account.IsGrok()"],
+      "rationale": "The raw CC forwarder resolves the grok OAuth Bearer + api.x.ai base_url here (the path is otherwise apikey-gated via GetOpenAIApiKey/GetOpenAIBaseURL). Losing this arm makes grok forward with an empty credential / wrong base URL."
+    },
+    {
+      "path": "backend/internal/service/openai_gateway_v1_forward.go",
+      "must_contain": ["account.IsGrok()"],
+      "rationale": "The image (/v1/images/generations) seam: buildOpenAIV1TargetURL hardcodes api.openai.com for the OAuth case; the grok arm redirects it to api.x.ai/v1. Losing it points grok image requests at OpenAI."
+    },
+    {
+      "path": "backend/internal/service/tk_pricing_overlay.json",
+      "must_contain": ["grok-imagine-image"],
+      "rationale": "Grok image pricing rows. Image models with no usable static price are REJECTED with a pre-spend 400 by TkImageModelUnpriced — so losing these rows makes grok image generation fail outright (not just bill $0)."
+    },
+    {
+      "path": "backend/migrations/tk_028_allow_grok_model_availability_platform.sql",
+      "must_contain": ["'grok'"],
+      "rationale": "Widens the model_availability.platform CHECK to include 'grok' (paired with the ent enum). Without it every grok forward logs pricing.availability.record_failed (invalid enum value), the DB layer of the two-layered enum gate."
+    },
+    {
+      "path": "backend/ent/schema/model_availability.go",
+      "must_contain": ["\"grok\""],
+      "rationale": "The ent layer of the model_availability platform enum. Must be regenerated (go generate ./ent) so the Go PlatformValidator accepts 'grok'; paired with tk_028."
+    },
+    {
+      "path": "backend/internal/service/admin_service_tk_grok_save.go",
+      "must_contain": ["func resolveGrokTokenOnSave"],
+      "rationale": "Create-time validate+prime: pastes a grok refresh_token, does a live xAI refresh, and either primes the account (access_token/expires_at/token_endpoint) or rejects creation with the exact upstream reason (missing/invalid token, Heavy-only 403). Losing it lets dead grok accounts materialize that only fail on the first request."
+    },
+    {
+      "path": "backend/internal/service/admin_service.go",
+      "must_contain": ["resolveGrokTokenOnSave(ctx, account)"],
+      "rationale": "The wiring of the grok create-time validate+prime into CreateAccount (next to resolveNewAPIMoonshotBaseURLOnSave). An upstream merge that rewrites CreateAccount must preserve this call, or grok accounts are created unvalidated/unprimed."
+    },
+    {
+      "path": "frontend/src/constants/gatewayPlatforms.ts",
+      "must_contain": ["'grok'"],
+      "rationale": "grok's membership in GATEWAY_PLATFORMS + OPENAI_COMPAT_PLATFORMS + GROUP_DISPATCH_CONFIG_PLATFORMS + the exhaustive Record<AccountPlatform> color maps. OPENAI_COMPAT_PLATFORMS must mirror the backend engine.OpenAICompatPlatforms() (preflight newapi compat-pool drift guard watches the lockstep); removing 'grok' drops it from the admin platform pickers/badges and breaks the pool mirror."
+    },
+    {
+      "path": "frontend/src/composables/usePlatformOptions.ts",
+      "must_contain": ["grok:"],
+      "rationale": "grok's brand label (PLATFORM_LABELS, exhaustive Record<AccountPlatform>). Without it typecheck fails and the platform renders an untranslated value."
+    },
+    {
+      "path": "frontend/src/composables/useTkAccountGrokPlatform.ts",
+      "must_contain": ["export function useTkAccountGrokPlatform", "refresh_token"],
+      "rationale": "The grok add/edit form state + credentials assembly (refresh_token paste). Losing it makes operators unable to create grok accounts via the UI."
+    },
+    {
+      "path": "frontend/src/components/account/CreateAccountModal.vue",
+      "must_contain": ["AccountGrokPlatformFields", "grokBuildSubmitBundle"],
+      "rationale": "The grok branch + field-component wiring + submit assembly in the account-create modal. Losing it strands UI account creation for grok."
+    },
+    {
+      "path": "frontend/src/i18n/locales/en.ts",
+      "must_contain": ["grokPlatform"],
+      "rationale": "English i18n strings for the grok account form. Losing them surfaces raw i18n keys in the UI."
+    },
+    {
+      "path": "frontend/src/i18n/locales/zh.ts",
+      "must_contain": ["grokPlatform"],
+      "rationale": "Chinese i18n strings for the grok account form. Kept paired with en.ts so the two locales never drift for grok."
+    }
+  ]
+}

--- a/scripts/sentinels/grok.json
+++ b/scripts/sentinels/grok.json
@@ -111,6 +111,16 @@
       "path": "frontend/src/i18n/locales/zh.ts",
       "must_contain": ["grokPlatform"],
       "rationale": "Chinese i18n strings for the grok account form. Kept paired with en.ts so the two locales never drift for grok."
+    },
+    {
+      "path": "backend/internal/pkg/xai/oauth_test.go",
+      "must_contain": ["TestValidateEndpoint", "TestRefreshToken_InputGuards"],
+      "rationale": "Load-bearing QA evidence for the OAuth helper: the SSRF endpoint guard (must stay x.ai-only) and the no-network input guards. Matches the hotspot-evidence rule."
+    },
+    {
+      "path": "backend/internal/service/grok_test.go",
+      "must_contain": ["TestTkIsGrokEntitlement403", "TestGrokTokenRefresher_CanRefreshNeedsRefresh"],
+      "rationale": "Load-bearing QA evidence for the Heavy-403 entitlement classifier (the pool-kill-amplifier guard) and the refresher gating/expiry-window logic. Losing it removes the regression guard around grok's two most failure-prone pure-logic surfaces."
     }
   ]
 }

--- a/scripts/sentinels/grok.json
+++ b/scripts/sentinels/grok.json
@@ -13,6 +13,11 @@
       "rationale": "Grok must be in BOTH OpenAICompatPlatforms() (so it rides the OpenAI-compat routes/scheduler/sticky path with channel_type=0, like openai) AND AllSchedulingPlatforms() (so background sweeps/snapshot hydration include the grok pool). Losing either silently drops grok from routing or from rate-limit reaping/snapshot scheduling."
     },
     {
+      "path": "backend/internal/model/error_passthrough_rule.go",
+      "must_contain": ["PlatformKiro, PlatformGrok}"],
+      "rationale": "The SECOND, separate platform registry (model.AllPlatforms, distinct from domain/constants.go) that feeds the error-passthrough rule UI's applicable-platform list. grok (and kiro) must stay in the AllPlatforms() return slice — anchored on the slice tail `PlatformKiro, PlatformGrok}` (not just the const, which would still match if grok were dropped only from the return). This is the one grok injection an upstream merge can drop SILENTLY: no compile error and no test pins the slice contents, so without this anchor grok would lose error-passthrough applicability unnoticed (the exact silent-drift mode the sentinel registry exists to catch)."
+    },
+    {
       "path": "backend/internal/pkg/xai/oauth.go",
       "must_contain": ["ClientID = \"b1a00492-073a-47ea-816f-4c329264a828\"", "func RefreshToken", "DefaultAPIBaseURL = \"https://api.x.ai/v1\""],
       "rationale": "Stdlib-only xAI OAuth refresh helper (discovery + refresh-token grant) + the public Grok CLI client_id and the api.x.ai base URL. Losing RefreshToken stops grok token auto-refresh; accounts silently expire and drop out of the pool with no recovery."

--- a/scripts/sentinels/grok.json
+++ b/scripts/sentinels/grok.json
@@ -79,8 +79,8 @@
     },
     {
       "path": "backend/internal/service/admin_service_tk_grok_save.go",
-      "must_contain": ["func resolveGrokTokenOnSave"],
-      "rationale": "Create-time validate+prime: pastes a grok refresh_token, does a live xAI refresh, and either primes the account (access_token/expires_at/token_endpoint) or rejects creation with the exact upstream reason (missing/invalid token, Heavy-only 403). Losing it lets dead grok accounts materialize that only fail on the first request."
+      "must_contain": ["func resolveGrokTokenOnSave", "func tkInputHasNonEmptyCredential"],
+      "rationale": "Create-time validate+prime (resolveGrokTokenOnSave): pastes a grok refresh_token, does a live xAI refresh, and either primes the account (access_token/expires_at/token_endpoint) or rejects with the exact upstream reason. tkInputHasNonEmptyCredential gates the UpdateAccount re-validate so an unrelated grok edit isn't blocked by a transient xAI outage. Losing either lets dead grok accounts materialize, or fires an xAI call on every edit."
     },
     {
       "path": "backend/internal/service/admin_service.go",
@@ -106,6 +106,11 @@
       "path": "frontend/src/components/account/CreateAccountModal.vue",
       "must_contain": ["AccountGrokPlatformFields", "grokBuildSubmitBundle"],
       "rationale": "The grok branch + field-component wiring + submit assembly in the account-create modal. Losing it strands UI account creation for grok."
+    },
+    {
+      "path": "frontend/src/components/account/EditAccountModal.vue",
+      "must_contain": ["AccountGrokPlatformFields", "grokBuildSubmitBundle"],
+      "rationale": "The grok credential-rotation wiring in the account-edit modal (re-paste refresh_token, blank=keep). Losing it forces delete+recreate to rotate a dead grok refresh_token (invalid_grant). Paired with the UpdateAccount resolveGrokTokenOnSave gate (admin_service.go)."
     },
     {
       "path": "frontend/src/i18n/locales/en.ts",

--- a/scripts/sentinels/merge-gate-parity.json
+++ b/scripts/sentinels/merge-gate-parity.json
@@ -3,6 +3,7 @@
   "scripts": [
     "scripts/sentinels/check-newapi.py",
     "scripts/sentinels/check-kiro.py",
+    "scripts/sentinels/check-grok.py",
     "scripts/sentinels/check-antigravity.py",
     "scripts/sentinels/check-brand.py",
     "scripts/sentinels/check-frontend-tk.py",


### PR DESCRIPTION
## What

Adds a native **`grok`** platform (the seventh) that holds & refreshes **one SuperGrok Heavy OAuth subscription** and relays Grok **chat + image generation** through TokenKey.

xAI's `api.x.ai/v1` is OpenAI-wire compatible, so grok **reuses the existing OpenAI-compat routing / scheduling / sticky / failover / billing path** — it is the first "OpenAI-wire-but-OAuth" platform. The only grok-specific code is:

- **OAuth refresh** — `internal/pkg/xai/oauth.go` (stdlib-only discovery + refresh-token grant) + `GrokTokenRefresher` (registered in both refresher slices).
- **Two forward seams** — grok+OAuth forwards like the **apikey** branch (plain Bearer + `api.x.ai` base URL), NOT the ChatGPT/Codex OAuth branch (which is hardwired to `chatgpt.com`). Chat → raw CC forwarder; image → `buildOpenAIV1TargetURL` grok branch.
- **Heavy-403 honesty** — `tkIsGrokEntitlement403`: a SuperGrok-Heavy entitlement 403 does **no failover, no cooldown, no 502-mask** (clean client error). Without this a thin grok pool gets silently killed by one xAI policy 403 (pool-wide failover → empty-pool 429, masked 502).
- **Create-time validate+prime** — `resolveGrokTokenOnSave`: pasting a `refresh_token` does a live xAI refresh at create (green check / exact error) and primes the access_token.

## Scope (deliberate)

- ✅ **chat + image** (reuse the OpenAI-compat pool).
- ❌ **video** out of scope — xAI's sync `/v1/videos` doesn't match the OpenAI async task-adaptor shape (phase-2).
- ❌ **in-product OAuth UI** out of scope — xAI's public Grok CLI client is loopback-only (no server-side redirect / device-code), so the `refresh_token` is minted out-of-band (CLI login) and pasted, then validated+primed at create.
- Pricing: image `grok-imagine-image` $0.02 / `-quality` $0.07 (2K, conservative) + `grok-code-fast-1`. **grok-4.x chat intentionally left to the operator** (its 2026 list price was unconfirmed at authoring; `served_zero_cost` P0 alerts — per the overlay's "a wrong price has no probe" discipline).

## Surfaces

**Backend**: `domain.PlatformGrok`; `account_tk_grok.go`; `pkg/xai/oauth.go`; `grok_token_refresher.go`; `GetAccessToken` grok branch; chat/image forward seams; `ratelimit_service_tk_grok_entitlement_403.go`; `resolveGrokTokenOnSave`; `engine.OpenAICompatPlatforms`+`AllSchedulingPlatforms`; `model.AllPlatforms`; ent `model_availability` enum + `tk_028` migration; `tk_pricing_overlay.json`; `scripts/sentinels/grok.json` + `check-grok.py` + preflight wiring.
**Frontend**: `AccountPlatform`/`GroupPlatform` union; `gatewayPlatforms` (incl. `OPENAI_COMPAT_PLATFORMS` mirror); `usePlatformOptions`; `useTkAccountGrokPlatform` + `AccountGrokPlatformFields.vue`; `CreateAccountModal` + `UseKeyModal` grok flavor; en/zh i18n; rebuilt embedded dist.
**Tests**: platform-enumeration assertions updated (engine ×2, service ×2) + grok coverage cases.

## Verification (local, all green)

- `go build ./...` ✓ · `go test -tags=unit ./...` ✓ · `golangci-lint` (touched pkgs) ✓ (0 issues)
- `pnpm typecheck` ✓ · `pnpm lint:check` ✓ · embedded dist rebuilt ✓
- `check-grok.py` **21/21** · `pricing-overlay.py` ✓ · **`scripts/preflight.sh` PASS**

## Markers

- `upstream-touch-guarded` — the upstream-shaped files touched (openai_gateway_*, admin_service.go, model/error_passthrough_rule.go, gatewayPlatforms.ts, UseKeyModal.vue, en/zh.ts, ent schema) are guarded TK injection points, anchored in `scripts/sentinels/grok.json`.
- `sentinel-registry-reviewed` — the registry-update gate flags `UseKeyModal.vue` (→frontend-tk.json) and `account_tk_compat_pool_test.go` (→gateway-tk.json) as edited TK surfaces; both are grok-scoped edits, reviewed, and the grok surface is anchored in `grok.json` (the changed registry). No additional anchor required.

## Caveat (phase-0 at deploy)

Couldn't validate against a real SuperGrok **Heavy** token locally (no token + x.ai network-blocked here). The OAuth refresh field-map is from the public Grok CLI client source (CPA/litellm, high confidence); the **live behavior** (Heavy-403 timing, SSE byte-shape parity) is the phase-0 spike to confirm on a real Heavy token at deploy — code is written to the documented contract with a normalizer fallback noted.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
