### PR TITLE
feat(keys): export a key's conversation records (traj), admin-gated per user (#685)

### DIFF
--- a/backend/ent/migrate/schema.go
+++ b/backend/ent/migrate/schema.go
@@ -1650,6 +1650,7 @@ var (
 		{Name: "total_recharged", Type: field.TypeFloat64, Default: 0, SchemaType: map[string]string{"postgres": "decimal(20,8)"}},
 		{Name: "onboarding_tour_seen_at", Type: field.TypeTime, Nullable: true},
 		{Name: "rpm_limit", Type: field.TypeInt, Default: 0},
+		{Name: "traj_export_enabled", Type: field.TypeBool, Default: false},
 	}
 	// UsersTable holds the schema information for the "users" table.
 	UsersTable = &schema.Table{

--- a/backend/ent/mutation.go
+++ b/backend/ent/mutation.go
@@ -45152,6 +45152,7 @@ type UserMutation struct {
 	onboarding_tour_seen_at       *time.Time
 	rpm_limit                     *int
 	addrpm_limit                  *int
+	traj_export_enabled           *bool
 	clearedFields                 map[string]struct{}
 	api_keys                      map[int64]struct{}
 	removedapi_keys               map[int64]struct{}
@@ -46351,6 +46352,42 @@ func (m *UserMutation) ResetRpmLimit() {
 	m.addrpm_limit = nil
 }
 
+// SetTrajExportEnabled sets the "traj_export_enabled" field.
+func (m *UserMutation) SetTrajExportEnabled(b bool) {
+	m.traj_export_enabled = &b
+}
+
+// TrajExportEnabled returns the value of the "traj_export_enabled" field in the mutation.
+func (m *UserMutation) TrajExportEnabled() (r bool, exists bool) {
+	v := m.traj_export_enabled
+	if v == nil {
+		return
+	}
+	return *v, true
+}
+
+// OldTrajExportEnabled returns the old "traj_export_enabled" field's value of the User entity.
+// If the User object wasn't provided to the builder, the object is fetched from the database.
+// An error is returned if the mutation operation is not UpdateOne, or the database query fails.
+func (m *UserMutation) OldTrajExportEnabled(ctx context.Context) (v bool, err error) {
+	if !m.op.Is(OpUpdateOne) {
+		return v, errors.New("OldTrajExportEnabled is only allowed on UpdateOne operations")
+	}
+	if m.id == nil || m.oldValue == nil {
+		return v, errors.New("OldTrajExportEnabled requires an ID field in the mutation")
+	}
+	oldValue, err := m.oldValue(ctx)
+	if err != nil {
+		return v, fmt.Errorf("querying old value for OldTrajExportEnabled: %w", err)
+	}
+	return oldValue.TrajExportEnabled, nil
+}
+
+// ResetTrajExportEnabled resets all changes to the "traj_export_enabled" field.
+func (m *UserMutation) ResetTrajExportEnabled() {
+	m.traj_export_enabled = nil
+}
+
 // AddAPIKeyIDs adds the "api_keys" edge to the APIKey entity by ids.
 func (m *UserMutation) AddAPIKeyIDs(ids ...int64) {
 	if m.api_keys == nil {
@@ -47087,7 +47124,7 @@ func (m *UserMutation) Type() string {
 // order to get all numeric fields that were incremented/decremented, call
 // AddedFields().
 func (m *UserMutation) Fields() []string {
-	fields := make([]string, 0, 24)
+	fields := make([]string, 0, 25)
 	if m.created_at != nil {
 		fields = append(fields, user.FieldCreatedAt)
 	}
@@ -47160,6 +47197,9 @@ func (m *UserMutation) Fields() []string {
 	if m.rpm_limit != nil {
 		fields = append(fields, user.FieldRpmLimit)
 	}
+	if m.traj_export_enabled != nil {
+		fields = append(fields, user.FieldTrajExportEnabled)
+	}
 	return fields
 }
 
@@ -47216,6 +47256,8 @@ func (m *UserMutation) Field(name string) (ent.Value, bool) {
 		return m.OnboardingTourSeenAt()
 	case user.FieldRpmLimit:
 		return m.RpmLimit()
+	case user.FieldTrajExportEnabled:
+		return m.TrajExportEnabled()
 	}
 	return nil, false
 }
@@ -47273,6 +47315,8 @@ func (m *UserMutation) OldField(ctx context.Context, name string) (ent.Value, er
 		return m.OldOnboardingTourSeenAt(ctx)
 	case user.FieldRpmLimit:
 		return m.OldRpmLimit(ctx)
+	case user.FieldTrajExportEnabled:
+		return m.OldTrajExportEnabled(ctx)
 	}
 	return nil, fmt.Errorf("unknown User field %s", name)
 }
@@ -47449,6 +47493,13 @@ func (m *UserMutation) SetField(name string, value ent.Value) error {
 			return fmt.Errorf("unexpected type %T for field %s", value, name)
 		}
 		m.SetRpmLimit(v)
+		return nil
+	case user.FieldTrajExportEnabled:
+		v, ok := value.(bool)
+		if !ok {
+			return fmt.Errorf("unexpected type %T for field %s", value, name)
+		}
+		m.SetTrajExportEnabled(v)
 		return nil
 	}
 	return fmt.Errorf("unknown User field %s", name)
@@ -47678,6 +47729,9 @@ func (m *UserMutation) ResetField(name string) error {
 		return nil
 	case user.FieldRpmLimit:
 		m.ResetRpmLimit()
+		return nil
+	case user.FieldTrajExportEnabled:
+		m.ResetTrajExportEnabled()
 		return nil
 	}
 	return fmt.Errorf("unknown User field %s", name)

--- a/backend/ent/runtime/runtime.go
+++ b/backend/ent/runtime/runtime.go
@@ -2107,6 +2107,10 @@ func init() {
 	userDescRpmLimit := userFields[20].Descriptor()
 	// user.DefaultRpmLimit holds the default value on creation for the rpm_limit field.
 	user.DefaultRpmLimit = userDescRpmLimit.Default.(int)
+	// userDescTrajExportEnabled is the schema descriptor for traj_export_enabled field.
+	userDescTrajExportEnabled := userFields[21].Descriptor()
+	// user.DefaultTrajExportEnabled holds the default value on creation for the traj_export_enabled field.
+	user.DefaultTrajExportEnabled = userDescTrajExportEnabled.Default.(bool)
 	userallowedgroupFields := schema.UserAllowedGroup{}.Fields()
 	_ = userallowedgroupFields
 	// userallowedgroupDescCreatedAt is the schema descriptor for created_at field.

--- a/backend/ent/schema/user.go
+++ b/backend/ent/schema/user.go
@@ -118,6 +118,11 @@ func (User) Fields() []ent.Field {
 		// 用户级每分钟请求数上限（0 = 不限制）。仅当所在分组未设置 rpm_limit 时作为兜底生效。
 		field.Int("rpm_limit").
 			Default(0),
+
+		// TK: 管理员授予的「可导出对话记录(traj)」开关。默认关闭。
+		// 开启后该用户每个 API Key 行出现导出入口，可独立导出其捕获的对话轨迹。
+		field.Bool("traj_export_enabled").
+			Default(false),
 	}
 }
 

--- a/backend/ent/user.go
+++ b/backend/ent/user.go
@@ -65,6 +65,8 @@ type User struct {
 	OnboardingTourSeenAt *time.Time `json:"onboarding_tour_seen_at,omitempty"`
 	// RpmLimit holds the value of the "rpm_limit" field.
 	RpmLimit int `json:"rpm_limit,omitempty"`
+	// TrajExportEnabled holds the value of the "traj_export_enabled" field.
+	TrajExportEnabled bool `json:"traj_export_enabled,omitempty"`
 	// Edges holds the relations/edges for other nodes in the graph.
 	// The values are being populated by the UserQuery when eager-loading is set.
 	Edges        UserEdges `json:"edges"`
@@ -237,7 +239,7 @@ func (*User) scanValues(columns []string) ([]any, error) {
 	values := make([]any, len(columns))
 	for i := range columns {
 		switch columns[i] {
-		case user.FieldTotpEnabled, user.FieldBalanceNotifyEnabled:
+		case user.FieldTotpEnabled, user.FieldBalanceNotifyEnabled, user.FieldTrajExportEnabled:
 			values[i] = new(sql.NullBool)
 		case user.FieldBalance, user.FieldBalanceNotifyThreshold, user.FieldTotalRecharged:
 			values[i] = new(sql.NullFloat64)
@@ -418,6 +420,12 @@ func (_m *User) assignValues(columns []string, values []any) error {
 				return fmt.Errorf("unexpected type %T for field rpm_limit", values[i])
 			} else if value.Valid {
 				_m.RpmLimit = int(value.Int64)
+			}
+		case user.FieldTrajExportEnabled:
+			if value, ok := values[i].(*sql.NullBool); !ok {
+				return fmt.Errorf("unexpected type %T for field traj_export_enabled", values[i])
+			} else if value.Valid {
+				_m.TrajExportEnabled = value.Bool
 			}
 		default:
 			_m.selectValues.Set(columns[i], values[i])
@@ -610,6 +618,9 @@ func (_m *User) String() string {
 	builder.WriteString(", ")
 	builder.WriteString("rpm_limit=")
 	builder.WriteString(fmt.Sprintf("%v", _m.RpmLimit))
+	builder.WriteString(", ")
+	builder.WriteString("traj_export_enabled=")
+	builder.WriteString(fmt.Sprintf("%v", _m.TrajExportEnabled))
 	builder.WriteByte(')')
 	return builder.String()
 }

--- a/backend/ent/user/user.go
+++ b/backend/ent/user/user.go
@@ -63,6 +63,8 @@ const (
 	FieldOnboardingTourSeenAt = "onboarding_tour_seen_at"
 	// FieldRpmLimit holds the string denoting the rpm_limit field in the database.
 	FieldRpmLimit = "rpm_limit"
+	// FieldTrajExportEnabled holds the string denoting the traj_export_enabled field in the database.
+	FieldTrajExportEnabled = "traj_export_enabled"
 	// EdgeAPIKeys holds the string denoting the api_keys edge name in mutations.
 	EdgeAPIKeys = "api_keys"
 	// EdgeRedeemCodes holds the string denoting the redeem_codes edge name in mutations.
@@ -218,6 +220,7 @@ var Columns = []string{
 	FieldTotalRecharged,
 	FieldOnboardingTourSeenAt,
 	FieldRpmLimit,
+	FieldTrajExportEnabled,
 }
 
 var (
@@ -288,6 +291,8 @@ var (
 	DefaultTotalRecharged float64
 	// DefaultRpmLimit holds the default value on creation for the "rpm_limit" field.
 	DefaultRpmLimit int
+	// DefaultTrajExportEnabled holds the default value on creation for the "traj_export_enabled" field.
+	DefaultTrajExportEnabled bool
 )
 
 // OrderOption defines the ordering options for the User queries.
@@ -416,6 +421,11 @@ func ByOnboardingTourSeenAt(opts ...sql.OrderTermOption) OrderOption {
 // ByRpmLimit orders the results by the rpm_limit field.
 func ByRpmLimit(opts ...sql.OrderTermOption) OrderOption {
 	return sql.OrderByField(FieldRpmLimit, opts...).ToFunc()
+}
+
+// ByTrajExportEnabled orders the results by the traj_export_enabled field.
+func ByTrajExportEnabled(opts ...sql.OrderTermOption) OrderOption {
+	return sql.OrderByField(FieldTrajExportEnabled, opts...).ToFunc()
 }
 
 // ByAPIKeysCount orders the results by api_keys count.

--- a/backend/ent/user/where.go
+++ b/backend/ent/user/where.go
@@ -175,6 +175,11 @@ func RpmLimit(v int) predicate.User {
 	return predicate.User(sql.FieldEQ(FieldRpmLimit, v))
 }
 
+// TrajExportEnabled applies equality check predicate on the "traj_export_enabled" field. It's identical to TrajExportEnabledEQ.
+func TrajExportEnabled(v bool) predicate.User {
+	return predicate.User(sql.FieldEQ(FieldTrajExportEnabled, v))
+}
+
 // CreatedAtEQ applies the EQ predicate on the "created_at" field.
 func CreatedAtEQ(v time.Time) predicate.User {
 	return predicate.User(sql.FieldEQ(FieldCreatedAt, v))
@@ -1393,6 +1398,16 @@ func RpmLimitLT(v int) predicate.User {
 // RpmLimitLTE applies the LTE predicate on the "rpm_limit" field.
 func RpmLimitLTE(v int) predicate.User {
 	return predicate.User(sql.FieldLTE(FieldRpmLimit, v))
+}
+
+// TrajExportEnabledEQ applies the EQ predicate on the "traj_export_enabled" field.
+func TrajExportEnabledEQ(v bool) predicate.User {
+	return predicate.User(sql.FieldEQ(FieldTrajExportEnabled, v))
+}
+
+// TrajExportEnabledNEQ applies the NEQ predicate on the "traj_export_enabled" field.
+func TrajExportEnabledNEQ(v bool) predicate.User {
+	return predicate.User(sql.FieldNEQ(FieldTrajExportEnabled, v))
 }
 
 // HasAPIKeys applies the HasEdge predicate on the "api_keys" edge.

--- a/backend/ent/user_create.go
+++ b/backend/ent/user_create.go
@@ -354,6 +354,20 @@ func (_c *UserCreate) SetNillableRpmLimit(v *int) *UserCreate {
 	return _c
 }
 
+// SetTrajExportEnabled sets the "traj_export_enabled" field.
+func (_c *UserCreate) SetTrajExportEnabled(v bool) *UserCreate {
+	_c.mutation.SetTrajExportEnabled(v)
+	return _c
+}
+
+// SetNillableTrajExportEnabled sets the "traj_export_enabled" field if the given value is not nil.
+func (_c *UserCreate) SetNillableTrajExportEnabled(v *bool) *UserCreate {
+	if v != nil {
+		_c.SetTrajExportEnabled(*v)
+	}
+	return _c
+}
+
 // AddAPIKeyIDs adds the "api_keys" edge to the APIKey entity by IDs.
 func (_c *UserCreate) AddAPIKeyIDs(ids ...int64) *UserCreate {
 	_c.mutation.AddAPIKeyIDs(ids...)
@@ -652,6 +666,10 @@ func (_c *UserCreate) defaults() error {
 		v := user.DefaultRpmLimit
 		_c.mutation.SetRpmLimit(v)
 	}
+	if _, ok := _c.mutation.TrajExportEnabled(); !ok {
+		v := user.DefaultTrajExportEnabled
+		_c.mutation.SetTrajExportEnabled(v)
+	}
 	return nil
 }
 
@@ -737,6 +755,9 @@ func (_c *UserCreate) check() error {
 	}
 	if _, ok := _c.mutation.RpmLimit(); !ok {
 		return &ValidationError{Name: "rpm_limit", err: errors.New(`ent: missing required field "User.rpm_limit"`)}
+	}
+	if _, ok := _c.mutation.TrajExportEnabled(); !ok {
+		return &ValidationError{Name: "traj_export_enabled", err: errors.New(`ent: missing required field "User.traj_export_enabled"`)}
 	}
 	return nil
 }
@@ -860,6 +881,10 @@ func (_c *UserCreate) createSpec() (*User, *sqlgraph.CreateSpec) {
 	if value, ok := _c.mutation.RpmLimit(); ok {
 		_spec.SetField(user.FieldRpmLimit, field.TypeInt, value)
 		_node.RpmLimit = value
+	}
+	if value, ok := _c.mutation.TrajExportEnabled(); ok {
+		_spec.SetField(user.FieldTrajExportEnabled, field.TypeBool, value)
+		_node.TrajExportEnabled = value
 	}
 	if nodes := _c.mutation.APIKeysIDs(); len(nodes) > 0 {
 		edge := &sqlgraph.EdgeSpec{
@@ -1473,6 +1498,18 @@ func (u *UserUpsert) AddRpmLimit(v int) *UserUpsert {
 	return u
 }
 
+// SetTrajExportEnabled sets the "traj_export_enabled" field.
+func (u *UserUpsert) SetTrajExportEnabled(v bool) *UserUpsert {
+	u.Set(user.FieldTrajExportEnabled, v)
+	return u
+}
+
+// UpdateTrajExportEnabled sets the "traj_export_enabled" field to the value that was provided on create.
+func (u *UserUpsert) UpdateTrajExportEnabled() *UserUpsert {
+	u.SetExcluded(user.FieldTrajExportEnabled)
+	return u
+}
+
 // UpdateNewValues updates the mutable fields using the new values that were set on create.
 // Using this option is equivalent to using:
 //
@@ -1921,6 +1958,20 @@ func (u *UserUpsertOne) AddRpmLimit(v int) *UserUpsertOne {
 func (u *UserUpsertOne) UpdateRpmLimit() *UserUpsertOne {
 	return u.Update(func(s *UserUpsert) {
 		s.UpdateRpmLimit()
+	})
+}
+
+// SetTrajExportEnabled sets the "traj_export_enabled" field.
+func (u *UserUpsertOne) SetTrajExportEnabled(v bool) *UserUpsertOne {
+	return u.Update(func(s *UserUpsert) {
+		s.SetTrajExportEnabled(v)
+	})
+}
+
+// UpdateTrajExportEnabled sets the "traj_export_enabled" field to the value that was provided on create.
+func (u *UserUpsertOne) UpdateTrajExportEnabled() *UserUpsertOne {
+	return u.Update(func(s *UserUpsert) {
+		s.UpdateTrajExportEnabled()
 	})
 }
 
@@ -2538,6 +2589,20 @@ func (u *UserUpsertBulk) AddRpmLimit(v int) *UserUpsertBulk {
 func (u *UserUpsertBulk) UpdateRpmLimit() *UserUpsertBulk {
 	return u.Update(func(s *UserUpsert) {
 		s.UpdateRpmLimit()
+	})
+}
+
+// SetTrajExportEnabled sets the "traj_export_enabled" field.
+func (u *UserUpsertBulk) SetTrajExportEnabled(v bool) *UserUpsertBulk {
+	return u.Update(func(s *UserUpsert) {
+		s.SetTrajExportEnabled(v)
+	})
+}
+
+// UpdateTrajExportEnabled sets the "traj_export_enabled" field to the value that was provided on create.
+func (u *UserUpsertBulk) UpdateTrajExportEnabled() *UserUpsertBulk {
+	return u.Update(func(s *UserUpsert) {
+		s.UpdateTrajExportEnabled()
 	})
 }
 

--- a/backend/ent/user_update.go
+++ b/backend/ent/user_update.go
@@ -431,6 +431,20 @@ func (_u *UserUpdate) AddRpmLimit(v int) *UserUpdate {
 	return _u
 }
 
+// SetTrajExportEnabled sets the "traj_export_enabled" field.
+func (_u *UserUpdate) SetTrajExportEnabled(v bool) *UserUpdate {
+	_u.mutation.SetTrajExportEnabled(v)
+	return _u
+}
+
+// SetNillableTrajExportEnabled sets the "traj_export_enabled" field if the given value is not nil.
+func (_u *UserUpdate) SetNillableTrajExportEnabled(v *bool) *UserUpdate {
+	if v != nil {
+		_u.SetTrajExportEnabled(*v)
+	}
+	return _u
+}
+
 // AddAPIKeyIDs adds the "api_keys" edge to the APIKey entity by IDs.
 func (_u *UserUpdate) AddAPIKeyIDs(ids ...int64) *UserUpdate {
 	_u.mutation.AddAPIKeyIDs(ids...)
@@ -1097,6 +1111,9 @@ func (_u *UserUpdate) sqlSave(ctx context.Context) (_node int, err error) {
 	}
 	if value, ok := _u.mutation.AddedRpmLimit(); ok {
 		_spec.AddField(user.FieldRpmLimit, field.TypeInt, value)
+	}
+	if value, ok := _u.mutation.TrajExportEnabled(); ok {
+		_spec.SetField(user.FieldTrajExportEnabled, field.TypeBool, value)
 	}
 	if _u.mutation.APIKeysCleared() {
 		edge := &sqlgraph.EdgeSpec{
@@ -2106,6 +2123,20 @@ func (_u *UserUpdateOne) AddRpmLimit(v int) *UserUpdateOne {
 	return _u
 }
 
+// SetTrajExportEnabled sets the "traj_export_enabled" field.
+func (_u *UserUpdateOne) SetTrajExportEnabled(v bool) *UserUpdateOne {
+	_u.mutation.SetTrajExportEnabled(v)
+	return _u
+}
+
+// SetNillableTrajExportEnabled sets the "traj_export_enabled" field if the given value is not nil.
+func (_u *UserUpdateOne) SetNillableTrajExportEnabled(v *bool) *UserUpdateOne {
+	if v != nil {
+		_u.SetTrajExportEnabled(*v)
+	}
+	return _u
+}
+
 // AddAPIKeyIDs adds the "api_keys" edge to the APIKey entity by IDs.
 func (_u *UserUpdateOne) AddAPIKeyIDs(ids ...int64) *UserUpdateOne {
 	_u.mutation.AddAPIKeyIDs(ids...)
@@ -2802,6 +2833,9 @@ func (_u *UserUpdateOne) sqlSave(ctx context.Context) (_node *User, err error) {
 	}
 	if value, ok := _u.mutation.AddedRpmLimit(); ok {
 		_spec.AddField(user.FieldRpmLimit, field.TypeInt, value)
+	}
+	if value, ok := _u.mutation.TrajExportEnabled(); ok {
+		_spec.SetField(user.FieldTrajExportEnabled, field.TypeBool, value)
 	}
 	if _u.mutation.APIKeysCleared() {
 		edge := &sqlgraph.EdgeSpec{

--- a/backend/internal/handler/admin/user_handler.go
+++ b/backend/internal/handler/admin/user_handler.go
@@ -70,6 +70,8 @@ type UpdateUserRequest struct {
 	RPMLimit      *int     `json:"rpm_limit"`
 	Status        string   `json:"status" binding:"omitempty,oneof=active disabled"`
 	AllowedGroups *[]int64 `json:"allowed_groups"`
+	// TrajExportEnabled 管理员授予的「可导出对话记录(traj)」开关；nil 表示不改动。
+	TrajExportEnabled *bool `json:"traj_export_enabled"`
 	// GroupRates 用户专属分组倍率配置
 	// map[groupID]*rate，nil 表示删除该分组的专属倍率
 	GroupRates map[int64]*float64 `json:"group_rates"`
@@ -298,16 +300,17 @@ func (h *UserHandler) Update(c *gin.Context) {
 
 	// 使用指针类型直接传递，nil 表示未提供该字段
 	user, err := h.adminService.UpdateUser(c.Request.Context(), userID, &service.UpdateUserInput{
-		Email:         req.Email,
-		Password:      req.Password,
-		Username:      req.Username,
-		Notes:         req.Notes,
-		Balance:       req.Balance,
-		Concurrency:   req.Concurrency,
-		RPMLimit:      req.RPMLimit,
-		Status:        req.Status,
-		AllowedGroups: req.AllowedGroups,
-		GroupRates:    req.GroupRates,
+		Email:             req.Email,
+		Password:          req.Password,
+		Username:          req.Username,
+		Notes:             req.Notes,
+		Balance:           req.Balance,
+		Concurrency:       req.Concurrency,
+		RPMLimit:          req.RPMLimit,
+		Status:            req.Status,
+		AllowedGroups:     req.AllowedGroups,
+		TrajExportEnabled: req.TrajExportEnabled,
+		GroupRates:        req.GroupRates,
 	})
 	if err != nil {
 		response.ErrorFrom(c, err)

--- a/backend/internal/handler/dto/mappers.go
+++ b/backend/internal/handler/dto/mappers.go
@@ -31,6 +31,7 @@ func UserFromServiceShallow(u *service.User) *User {
 		TotalRecharged:             u.TotalRecharged,
 		OnboardingTourSeenAt:       u.OnboardingTourSeenAt,
 		RPMLimit:                   u.RPMLimit,
+		TrajExportEnabled:          u.TrajExportEnabled,
 		DeletedAt:                  u.DeletedAt,
 	}
 }

--- a/backend/internal/handler/dto/types.go
+++ b/backend/internal/handler/dto/types.go
@@ -33,6 +33,9 @@ type User struct {
 	OnboardingTourSeenAt *time.Time `json:"onboarding_tour_seen_at"`
 	// RPMLimit 用户级每分钟请求数上限（0 = 不限制），仅在所用分组未设置 rpm_limit 时作为兜底生效。
 	RPMLimit int `json:"rpm_limit"`
+	// TrajExportEnabled 管理员授予的「可导出对话记录(traj)」开关。
+	// 前端据此在每个 API Key 行渲染导出入口；后端导出端点亦据此 403 兜底。
+	TrajExportEnabled bool `json:"traj_export_enabled"`
 
 	APIKeys       []APIKey           `json:"api_keys,omitempty"`
 	Subscriptions []UserSubscription `json:"subscriptions,omitempty"`

--- a/backend/internal/handler/qa_handler.go
+++ b/backend/internal/handler/qa_handler.go
@@ -51,6 +51,11 @@ func NewQAHandler(service *qa.Service) *QAHandler {
 type ExportSelfRequest struct {
 	SynthSessionID string `json:"synth_session_id"`
 	SynthRole      string `json:"synth_role"`
+	// APIKeyID, when non-nil, scopes the traj export to a single API key
+	// (TK per-key "导出对话记录"). When set and no synth_session_id is given,
+	// the trailing-24h default window is dropped so the export returns the
+	// key's full retained trajectory (bounded only by qa_capture.retention_days).
+	APIKeyID *int64 `json:"api_key_id"`
 	// Format: "" / "v1" = legacy ExportRow; "v2" = traj v2 session/turns
 	// (.examples-aligned, carries thinking/signature/usage/stop_reason).
 	Format string `json:"format"`

--- a/backend/internal/handler/qa_handler_test.go
+++ b/backend/internal/handler/qa_handler_test.go
@@ -45,7 +45,6 @@ import (
 	"github.com/stretchr/testify/require"
 )
 
-
 type qaMemBlobStore struct{ objects map[string][]byte }
 
 func (m *qaMemBlobStore) Put(_ context.Context, key string, body []byte, _ string) (string, error) {
@@ -119,6 +118,20 @@ func newQAHandlerRouterWithStore(
 	r.POST("/api/v1/users/me/qa/traj/export", h.ExportSelfTrajectory)
 	r.GET("/api/v1/users/me/qa/traj/exports/*key", h.DownloadSelfTrajectoryExport)
 	return r, h
+}
+
+// seedTrajExportUser inserts a user with the given traj_export_enabled flag and
+// returns its (auto-assigned) ID — the trajectory export endpoint now gates on
+// this admin-granted switch, so success-path tests must seed an authorized user.
+func seedTrajExportUser(t *testing.T, ctx context.Context, client *dbent.Client, enabled bool) int64 {
+	t.Helper()
+	u, err := client.User.Create().
+		SetEmail("traj-export@test.local").
+		SetPasswordHash("x").
+		SetTrajExportEnabled(enabled).
+		Save(ctx)
+	require.NoError(t, err)
+	return u.ID
 }
 
 func TestUS059_ExportSelf_Unauthenticated_401(t *testing.T) {
@@ -356,6 +369,7 @@ func TestUS077_ExportSelfTrajectory_BySynthSessionID_200(t *testing.T) {
 	r, client, _ := newQAHandlerTestEnv(t, true, 7)
 	ctx := context.Background()
 	now := time.Now().UTC()
+	uid := seedTrajExportUser(t, ctx, client, true)
 
 	store := &qaMemBlobStore{objects: map[string][]byte{}}
 	blob := bytes.Buffer{}
@@ -368,7 +382,7 @@ func TestUS077_ExportSelfTrajectory_BySynthSessionID_200(t *testing.T) {
 
 	_, err = client.QARecord.Create().
 		SetRequestID("traj-handler").
-		SetUserID(7).
+		SetUserID(uid).
 		SetAPIKeyID(1).
 		SetPlatform("anthropic").
 		SetSynthSessionID("m0-TRAJ-H").
@@ -380,7 +394,7 @@ func TestUS077_ExportSelfTrajectory_BySynthSessionID_200(t *testing.T) {
 		Save(ctx)
 	require.NoError(t, err)
 
-	r, _ = newQAHandlerRouterWithStore(7, true, client, store)
+	r, _ = newQAHandlerRouterWithStore(uid, true, client, store)
 	body := bytes.NewBufferString(`{"synth_session_id":"m0-TRAJ-H"}`)
 	req := httptest.NewRequest(http.MethodPost, "/api/v1/users/me/qa/traj/export", body)
 	req.Header.Set("Content-Type", "application/json")
@@ -409,6 +423,7 @@ func TestUS077_ExportSelfTrajectory_LocalFSDownloadURLIsHTTPReachable(t *testing
 
 	ctx := context.Background()
 	now := time.Now().UTC()
+	uid := seedTrajExportUser(t, ctx, client, true)
 	blob := bytes.Buffer{}
 	enc, err := zstd.NewWriter(&blob)
 	require.NoError(t, err)
@@ -418,7 +433,7 @@ func TestUS077_ExportSelfTrajectory_LocalFSDownloadURLIsHTTPReachable(t *testing
 
 	_, err = client.QARecord.Create().
 		SetRequestID("traj-localfs").
-		SetUserID(7).
+		SetUserID(uid).
 		SetAPIKeyID(1).
 		SetPlatform("anthropic").
 		SetSynthSessionID("m0-TRAJ-HTTP").
@@ -431,7 +446,7 @@ func TestUS077_ExportSelfTrajectory_LocalFSDownloadURLIsHTTPReachable(t *testing
 	require.NoError(t, err)
 
 	store := &qaLocalFSLikeBlobStore{qaMemBlobStore{objects: map[string][]byte{"evidence/traj-localfs.zst": blob.Bytes()}}}
-	r, _ := newQAHandlerRouterWithStore(7, true, client, store)
+	r, _ := newQAHandlerRouterWithStore(uid, true, client, store)
 
 	body := bytes.NewBufferString(`{"synth_session_id":"m0-TRAJ-HTTP"}`)
 	req := httptest.NewRequest(http.MethodPost, "/api/v1/users/me/qa/traj/export", body)
@@ -460,6 +475,23 @@ func TestUS077_ExportSelfTrajectory_LocalFSDownloadURLIsHTTPReachable(t *testing
 	require.NoError(t, err)
 	require.Len(t, zr.File, 1)
 	require.Equal(t, "trajectory.jsonl", zr.File[0].Name)
+}
+
+// Per-user authorization backstop: a user whose traj_export_enabled switch is
+// off (the default) gets 403 even with a valid auth subject and captured data.
+func TestExportSelfTrajectory_Forbidden_WhenSwitchOff(t *testing.T) {
+	r, client, _ := newQAHandlerTestEnv(t, true, 7)
+	ctx := context.Background()
+	uid := seedTrajExportUser(t, ctx, client, false) // admin switch OFF
+	r, _ = newQAHandlerRouterWithStore(uid, true, client, &qaMemBlobStore{objects: map[string][]byte{}})
+
+	body := bytes.NewBufferString(`{"format":"v2"}`)
+	req := httptest.NewRequest(http.MethodPost, "/api/v1/users/me/qa/traj/export", body)
+	req.Header.Set("Content-Type", "application/json")
+	w := httptest.NewRecorder()
+	r.ServeHTTP(w, req)
+
+	require.Equal(t, http.StatusForbidden, w.Code, "body=%s", w.Body.String())
 }
 
 func TestUS033_DownloadSelfExport_RejectsCrossUserAndTraversalKeys(t *testing.T) {

--- a/backend/internal/handler/qa_handler_traj.go
+++ b/backend/internal/handler/qa_handler_traj.go
@@ -9,6 +9,7 @@ import (
 	"strings"
 	"time"
 
+	"github.com/Wei-Shaw/sub2api/internal/domain"
 	"github.com/Wei-Shaw/sub2api/internal/observability/qa"
 	"github.com/Wei-Shaw/sub2api/internal/pkg/response"
 	middleware2 "github.com/Wei-Shaw/sub2api/internal/server/middleware"
@@ -53,7 +54,12 @@ func (h *QAHandler) ExportSelfTrajectory(c *gin.Context) {
 		SynthSessionID: strings.TrimSpace(req.SynthSessionID),
 		SynthRole:      strings.TrimSpace(req.SynthRole),
 		APIKeyID:       req.APIKeyID,
-		Format:         strings.TrimSpace(req.Format),
+		// The traj v2 projector only faithfully reconstructs Anthropic
+		// /v1/messages trajectories; openai/gemini blobs project to empty or
+		// garbage turns. Pin the export to anthropic so a non-anthropic key
+		// (UI already hides the entry) can't yield a misleading non-empty zip.
+		Platform: domain.PlatformAnthropic,
+		Format:   strings.TrimSpace(req.Format),
 	}
 	// Per-key export ("导出该 Key 的对话记录") drops the trailing-24h default
 	// window and returns the key's full retained trajectory; the data set is

--- a/backend/internal/handler/qa_handler_traj.go
+++ b/backend/internal/handler/qa_handler_traj.go
@@ -28,6 +28,19 @@ func (h *QAHandler) ExportSelfTrajectory(c *gin.Context) {
 		return
 	}
 
+	// Per-user authorization backstop behind the UI visibility gate: the
+	// export entry is hidden unless the admin set users.traj_export_enabled,
+	// but never trust the client — re-check before doing any work.
+	authorized, err := h.service.UserTrajExportEnabled(c.Request.Context(), subject.UserID)
+	if err != nil {
+		response.ErrorFrom(c, err)
+		return
+	}
+	if !authorized {
+		response.Forbidden(c, "Conversation export is not enabled for this account")
+		return
+	}
+
 	req := ExportSelfRequest{}
 	if c.Request != nil && c.Request.ContentLength != 0 {
 		if err := c.ShouldBindJSON(&req); err != nil {
@@ -39,9 +52,14 @@ func (h *QAHandler) ExportSelfTrajectory(c *gin.Context) {
 	filter := qa.ExportFilter{
 		SynthSessionID: strings.TrimSpace(req.SynthSessionID),
 		SynthRole:      strings.TrimSpace(req.SynthRole),
+		APIKeyID:       req.APIKeyID,
 		Format:         strings.TrimSpace(req.Format),
 	}
-	if filter.SynthSessionID == "" {
+	// Per-key export ("导出该 Key 的对话记录") drops the trailing-24h default
+	// window and returns the key's full retained trajectory; the data set is
+	// already bounded by qa_capture.retention_days. The default 24h window
+	// only guards the unscoped "export my recent traffic" path.
+	if filter.SynthSessionID == "" && filter.APIKeyID == nil {
 		filter.Until = time.Now().UTC()
 		filter.Since = filter.Until.Add(-defaultQAExportWindow)
 	}

--- a/backend/internal/observability/qa/service_export_test.go
+++ b/backend/internal/observability/qa/service_export_test.go
@@ -510,6 +510,43 @@ func mustInsertQARecordWithBlob(t *testing.T, ctx context.Context, client *dbent
 	require.NoError(t, err)
 }
 
+// Per-key export ("导出该 Key 的对话记录") must restrict the record set to a
+// single API key while keeping the user_id scope as the outer AND — so a
+// foreign user id with the same key id yields zero rows.
+func TestExportUserTrajectoryData_ScopedByAPIKey(t *testing.T) {
+	svc, client, store := newQAExportTestService(t)
+	ctx := context.Background()
+	now := time.Now().UTC()
+
+	simpleBlob := map[string]any{
+		"request":  map[string]any{"path": "/v1/messages", "body": map[string]any{"messages": []any{map[string]any{"role": "user", "content": "hi"}}}},
+		"response": map[string]any{"status_code": 200, "headers": map[string]any{}, "body": map[string]any{"content": []any{map[string]any{"type": "text", "text": "ok"}}}},
+		"stream":   map[string]any{"chunks": []any{}},
+	}
+	// Same user (7), two different API keys: two records under key 1, one under key 2.
+	mustInsertQARecordWithBlob(t, ctx, client, store, qaRecordBuilder{requestID: "key1-a", userID: 7, apiKeyID: 1, createdAt: now.Add(-2 * time.Hour)}, simpleBlob)
+	mustInsertQARecordWithBlob(t, ctx, client, store, qaRecordBuilder{requestID: "key1-b", userID: 7, apiKeyID: 1, createdAt: now.Add(-1 * time.Hour)}, simpleBlob)
+	mustInsertQARecordWithBlob(t, ctx, client, store, qaRecordBuilder{requestID: "key2-a", userID: 7, apiKeyID: 2, createdAt: now.Add(-30 * time.Minute)}, simpleBlob)
+
+	key1 := int64(1)
+	recs, err := svc.queryExportRecords(ctx, 7, ExportFilter{APIKeyID: &key1})
+	require.NoError(t, err)
+	require.Len(t, recs, 2, "only key 1's two records, key 2 excluded")
+	for _, r := range recs {
+		require.Equal(t, int64(1), r.APIKeyID)
+	}
+
+	// Foreign user id with the same key id → zero rows (user scope ANDs first).
+	foreign, err := svc.queryExportRecords(ctx, 8, ExportFilter{APIKeyID: &key1})
+	require.NoError(t, err)
+	require.Empty(t, foreign)
+
+	// End-to-end export scoped by key 1 builds a non-empty trajectory.
+	res, err := svc.ExportUserTrajectoryData(ctx, 7, ExportFilter{APIKeyID: &key1})
+	require.NoError(t, err)
+	require.Positive(t, res.RecordCount)
+}
+
 func TestUS077_ExportUserTrajectoryData_ProjectsSessionTurnAndTools(t *testing.T) {
 	svc, client, store := newQAExportTestService(t)
 	ctx := context.Background()

--- a/backend/internal/observability/qa/service_export_test.go
+++ b/backend/internal/observability/qa/service_export_test.go
@@ -510,6 +510,37 @@ func mustInsertQARecordWithBlob(t *testing.T, ctx context.Context, client *dbent
 	require.NoError(t, err)
 }
 
+// The traj v2 projector is Anthropic-shaped, so the traj export pins
+// Platform="anthropic"; records from other platforms (openai/gemini) must be
+// excluded even when they share the same user and API key.
+func TestExportUserTrajectoryData_PlatformFilterExcludesNonAnthropic(t *testing.T) {
+	svc, client, _ := newQAExportTestService(t)
+	ctx := context.Background()
+	now := time.Now().UTC()
+
+	mk := func(reqID, platform string) {
+		_, err := client.QARecord.Create().
+			SetRequestID(reqID).
+			SetUserID(7).
+			SetAPIKeyID(1).
+			SetPlatform(platform).
+			SetCreatedAt(now).
+			SetRetentionUntil(now.Add(7 * 24 * time.Hour)).
+			Save(ctx)
+		require.NoError(t, err)
+	}
+	mk("anthropic-1", "anthropic")
+	mk("openai-1", "openai")
+	mk("gemini-1", "gemini")
+
+	key1 := int64(1)
+	recs, err := svc.queryExportRecords(ctx, 7, ExportFilter{APIKeyID: &key1, Platform: "anthropic"})
+	require.NoError(t, err)
+	require.Len(t, recs, 1)
+	require.Equal(t, "anthropic", recs[0].Platform)
+	require.Equal(t, "anthropic-1", recs[0].RequestID)
+}
+
 // Per-key export ("导出该 Key 的对话记录") must restrict the record set to a
 // single API key while keeping the user_id scope as the outer AND — so a
 // foreign user id with the same key id yields zero rows.

--- a/backend/internal/observability/qa/service_traj_export.go
+++ b/backend/internal/observability/qa/service_traj_export.go
@@ -150,6 +150,9 @@ func (s *Service) queryExportRecords(ctx context.Context, userID int64, filter E
 	if filter.APIKeyID != nil {
 		predicates = append(predicates, qarecord.APIKeyIDEQ(*filter.APIKeyID))
 	}
+	if p := strings.TrimSpace(filter.Platform); p != "" {
+		predicates = append(predicates, qarecord.PlatformEQ(p))
+	}
 	if synthSession := strings.TrimSpace(filter.SynthSessionID); synthSession != "" {
 		predicates = append(predicates, qarecord.SynthSessionIDEQ(synthSession))
 	} else {

--- a/backend/internal/observability/qa/service_traj_export.go
+++ b/backend/internal/observability/qa/service_traj_export.go
@@ -130,8 +130,26 @@ func (s *Service) DownloadUserTrajectoryExport(ctx context.Context, userID int64
 	return body, err
 }
 
+// UserTrajExportEnabled reports whether the admin has granted this user the
+// traj_export_enabled switch. It is the handler-layer authorization backstop
+// behind the UI visibility gate — a hand-crafted POST cannot bypass it. A
+// missing user resolves to false (denied) rather than an error.
+func (s *Service) UserTrajExportEnabled(ctx context.Context, userID int64) (bool, error) {
+	u, err := s.client.User.Get(ctx, userID)
+	if err != nil {
+		if ent.IsNotFound(err) {
+			return false, nil
+		}
+		return false, err
+	}
+	return u.TrajExportEnabled, nil
+}
+
 func (s *Service) queryExportRecords(ctx context.Context, userID int64, filter ExportFilter) ([]*ent.QARecord, error) {
 	predicates := []predicate.QARecord{qarecord.UserIDEQ(userID)}
+	if filter.APIKeyID != nil {
+		predicates = append(predicates, qarecord.APIKeyIDEQ(*filter.APIKeyID))
+	}
 	if synthSession := strings.TrimSpace(filter.SynthSessionID); synthSession != "" {
 		predicates = append(predicates, qarecord.SynthSessionIDEQ(synthSession))
 	} else {

--- a/backend/internal/observability/qa/types.go
+++ b/backend/internal/observability/qa/types.go
@@ -75,6 +75,10 @@ type ExportFilter struct {
 	Until          time.Time
 	SynthSessionID string
 	SynthRole      string
+	// APIKeyID, when non-nil, restricts the export to records produced by a
+	// single API key (TK per-key "导出对话记录"). Combined as AND with the
+	// user_id scope, so a foreign key id simply yields zero rows.
+	APIKeyID *int64
 	// Format selects the export shape: "" / "v1" = legacy per-message
 	// ExportRow JSONL; "v2" = richer session/turns (traj v2, .examples-aligned,
 	// one TrajSessionV2 object per line, carries thinking/signature/usage).

--- a/backend/internal/observability/qa/types.go
+++ b/backend/internal/observability/qa/types.go
@@ -79,6 +79,11 @@ type ExportFilter struct {
 	// single API key (TK per-key "导出对话记录"). Combined as AND with the
 	// user_id scope, so a foreign key id simply yields zero rows.
 	APIKeyID *int64
+	// Platform, when non-empty, restricts the export to one platform. The traj
+	// v2 projector only faithfully reconstructs Anthropic /v1/messages shapes,
+	// so the traj export pins this to "anthropic"; non-anthropic records (whose
+	// blobs would project to empty/garbage turns) are excluded.
+	Platform string
 	// Format selects the export shape: "" / "v1" = legacy per-message
 	// ExportRow JSONL; "v2" = richer session/turns (traj v2, .examples-aligned,
 	// one TrajSessionV2 object per line, carries thinking/signature/usage).

--- a/backend/internal/repository/api_key_repo.go
+++ b/backend/internal/repository/api_key_repo.go
@@ -767,6 +767,7 @@ func userEntityToService(u *dbent.User) *service.User {
 		TotalRecharged:             u.TotalRecharged,
 		OnboardingTourSeenAt:       u.OnboardingTourSeenAt,
 		RPMLimit:                   u.RpmLimit,
+		TrajExportEnabled:          u.TrajExportEnabled,
 		CreatedAt:                  u.CreatedAt,
 		UpdatedAt:                  u.UpdatedAt,
 		DeletedAt:                  u.DeletedAt,

--- a/backend/internal/repository/user_repo.go
+++ b/backend/internal/repository/user_repo.go
@@ -95,6 +95,7 @@ func (r *userRepository) Create(ctx context.Context, userIn *service.User) error
 		SetNillableLastLoginAt(userIn.LastLoginAt).
 		SetNillableLastActiveAt(userIn.LastActiveAt).
 		SetRpmLimit(userIn.RPMLimit).
+		SetTrajExportEnabled(userIn.TrajExportEnabled).
 		Save(txCtx)
 	if err != nil {
 		return translatePersistenceError(err, nil, service.ErrEmailExists)
@@ -239,7 +240,8 @@ func (r *userRepository) Update(ctx context.Context, userIn *service.User) error
 		SetNillableBalanceNotifyThreshold(userIn.BalanceNotifyThreshold).
 		SetBalanceNotifyExtraEmails(marshalExtraEmails(userIn.BalanceNotifyExtraEmails)).
 		SetTotalRecharged(userIn.TotalRecharged).
-		SetRpmLimit(userIn.RPMLimit)
+		SetRpmLimit(userIn.RPMLimit).
+		SetTrajExportEnabled(userIn.TrajExportEnabled)
 	if userIn.SignupSource != "" {
 		updateOp = updateOp.SetSignupSource(userIn.SignupSource)
 	}

--- a/backend/internal/server/api_contract_test.go
+++ b/backend/internal/server/api_contract_test.go
@@ -56,6 +56,7 @@ func TestAPIContracts(t *testing.T) {
 					"balance": 12.5,
 					"concurrency": 5,
 					"rpm_limit": 0,
+					"traj_export_enabled": false,
 					"status": "active",
 					"allowed_groups": null,
 					"created_at": "2025-01-02T03:04:05Z",

--- a/backend/internal/service/admin_service.go
+++ b/backend/internal/service/admin_service.go
@@ -151,6 +151,9 @@ type UpdateUserInput struct {
 	RPMLimit      *int     // 使用指针区分"未提供"和"设置为0"
 	Status        string
 	AllowedGroups *[]int64 // 使用指针区分"未提供"和"设置为空数组"
+	// TrajExportEnabled 管理员授予的「可导出对话记录(traj)」开关。
+	// 指针区分"未提供"（不改动）与显式 true/false。
+	TrajExportEnabled *bool
 	// GroupRates 用户专属分组倍率配置
 	// map[groupID]*rate，nil 表示删除该分组的专属倍率
 	GroupRates map[int64]*float64
@@ -827,6 +830,10 @@ func (s *adminServiceImpl) UpdateUser(ctx context.Context, id int64, input *Upda
 
 	if input.RPMLimit != nil {
 		user.RPMLimit = *input.RPMLimit
+	}
+
+	if input.TrajExportEnabled != nil {
+		user.TrajExportEnabled = *input.TrajExportEnabled
 	}
 
 	if input.AllowedGroups != nil {

--- a/backend/internal/service/user.go
+++ b/backend/internal/service/user.go
@@ -63,6 +63,10 @@ type User struct {
 	// 避免每请求查 DB。字段不持久化到数据库。
 	UserGroupRPMOverride *int
 
+	// TrajExportEnabled 管理员授予的「可导出对话记录(traj)」开关。默认 false。
+	// 开启后该用户每个 API Key 可独立导出其捕获的对话轨迹。
+	TrajExportEnabled bool
+
 	APIKeys       []APIKey
 	Subscriptions []UserSubscription
 }

--- a/backend/internal/web/dist/frontend-source.json
+++ b/backend/internal/web/dist/frontend-source.json
@@ -1,7 +1,7 @@
 {
   "algorithm": "sha256(git-ls-files:path,size,content)",
-  "file_count": 486,
-  "hash": "f7e17585d0e5b6bb50eba301f832f368e5061dfa89863761181a30102c7488a6",
+  "file_count": 487,
+  "hash": "f29a933582559404d65ec1dfbb1933b6fef8d5e28f16ab7b37a295a24997d287",
   "schema": 1,
   "source": "frontend/"
 }

--- a/backend/internal/web/dist/frontend-source.json
+++ b/backend/internal/web/dist/frontend-source.json
@@ -1,7 +1,7 @@
 {
   "algorithm": "sha256(git-ls-files:path,size,content)",
   "file_count": 487,
-  "hash": "f29a933582559404d65ec1dfbb1933b6fef8d5e28f16ab7b37a295a24997d287",
+  "hash": "c71db7d2fce5574a80986b40f54bd4dd988cfe156bf5ff3cc370d13188c756da",
   "schema": 1,
   "source": "frontend/"
 }

--- a/backend/migrations/tk_028_add_user_traj_export_enabled.sql
+++ b/backend/migrations/tk_028_add_user_traj_export_enabled.sql
@@ -1,0 +1,10 @@
+-- TK: per-user "可导出对话记录(traj)" 授权开关。默认 false（关闭）。
+-- 管理员在用户编辑面板为某用户开启后，该用户每个 API Key 行出现导出入口，
+-- 可独立导出其经网关捕获的对话轨迹（qa traj v2 导出器，见 #685）。
+-- 后端导出端点 POST /api/v1/users/me/qa/traj/export 亦据此字段做 403 兜底，
+-- 防止绕过前端可见性闸。纯能力授权，不影响计费/转发/捕获本身。
+ALTER TABLE users
+    ADD COLUMN IF NOT EXISTS traj_export_enabled BOOLEAN NOT NULL DEFAULT false;
+
+COMMENT ON COLUMN users.traj_export_enabled IS
+    'Admin-granted switch allowing the user to export each API key''s captured conversation trajectory (qa traj v2). Default false. Gates both the UI export entry and the self-export endpoint.';

--- a/frontend/src/api/__tests__/qaTraj.spec.ts
+++ b/frontend/src/api/__tests__/qaTraj.spec.ts
@@ -1,0 +1,47 @@
+import { describe, expect, it, vi, beforeEach, afterEach } from 'vitest'
+import type { AxiosInstance, AxiosRequestConfig } from 'axios'
+
+vi.mock('@/i18n', () => ({
+  getLocale: () => 'zh-CN'
+}))
+
+describe('qaTraj API', () => {
+  let apiClient: AxiosInstance
+  let qaTraj: typeof import('@/api/qaTraj')
+
+  beforeEach(async () => {
+    vi.resetModules()
+    const clientMod = await import('@/api/client')
+    apiClient = clientMod.apiClient
+    qaTraj = await import('@/api/qaTraj')
+  })
+
+  afterEach(() => {
+    vi.restoreAllMocks()
+  })
+
+  it('exportKey posts the per-key v2 payload and unwraps the envelope', async () => {
+    let captured: AxiosRequestConfig | undefined
+    apiClient.defaults.adapter = vi.fn().mockImplementation((config: AxiosRequestConfig) => {
+      captured = config
+      return Promise.resolve({
+        status: 200,
+        statusText: 'OK',
+        headers: {},
+        config,
+        data: {
+          code: 0,
+          data: { download_url: '/api/v1/users/me/qa/traj/exports/k.zip', expires_at: 't', record_count: 3 }
+        }
+      })
+    })
+
+    const result = await qaTraj.qaTrajAPI.exportKey(42)
+
+    expect(captured?.url).toBe('/users/me/qa/traj/export')
+    expect(captured?.method?.toLowerCase()).toBe('post')
+    expect(JSON.parse(captured?.data as string)).toEqual({ api_key_id: 42, format: 'v2' })
+    expect(result.record_count).toBe(3)
+    expect(result.download_url).toBe('/api/v1/users/me/qa/traj/exports/k.zip')
+  })
+})

--- a/frontend/src/api/index.ts
+++ b/frontend/src/api/index.ts
@@ -13,6 +13,7 @@ export { authAPI, isTotp2FARequired, type LoginResponse } from './auth'
 
 // User APIs
 export { keysAPI } from './keys'
+export { qaTrajAPI, type TrajExportResult } from './qaTraj'
 export { usageAPI } from './usage'
 export { userAPI } from './user'
 export { redeemAPI, type RedeemHistoryItem } from './redeem'

--- a/frontend/src/api/qaTraj.ts
+++ b/frontend/src/api/qaTraj.ts
@@ -1,0 +1,67 @@
+/**
+ * TokenKey: per-API-key conversation-record (traj) export.
+ *
+ * Surfaces the already-shipped self-export endpoints (qa traj v2, issue #685)
+ * scoped to a single API key. Gated end-to-end by the admin-granted
+ * `traj_export_enabled` user switch — the UI only renders the entry when the
+ * switch is on, and the backend returns 403 otherwise.
+ */
+
+import { apiClient } from './client'
+
+export interface TrajExportResult {
+  download_url: string
+  expires_at: string
+  record_count: number
+}
+
+/**
+ * Build a trajectory export for a single API key. Returns the download URL plus
+ * record_count so the caller can distinguish "captured but empty" (0) from a
+ * real export. Format is always v2 (.examples-aligned, training-ready).
+ */
+async function exportKey(apiKeyId: number): Promise<TrajExportResult> {
+  const { data } = await apiClient.post<TrajExportResult>('/users/me/qa/traj/export', {
+    api_key_id: apiKeyId,
+    format: 'v2'
+  })
+  return data
+}
+
+function triggerBlobDownload(blob: Blob, filename: string): void {
+  const url = window.URL.createObjectURL(blob)
+  const a = document.createElement('a')
+  a.href = url
+  a.download = filename
+  document.body.appendChild(a)
+  a.click()
+  a.remove()
+  window.URL.revokeObjectURL(url)
+}
+
+/**
+ * Download the export zip and save it as `filename`. Same-origin URLs (the
+ * localfs-backed authenticated download path) go through apiClient so the JWT
+ * is attached; an off-origin presigned URL (S3) is opened directly — it carries
+ * its own signature and must not receive an Authorization header.
+ */
+async function download(downloadUrl: string, filename: string): Promise<void> {
+  const sameOrigin = downloadUrl.startsWith('/') || downloadUrl.startsWith(window.location.origin)
+  if (sameOrigin) {
+    const resp = await apiClient.get(downloadUrl, { responseType: 'blob' })
+    triggerBlobDownload(resp.data as Blob, filename)
+    return
+  }
+  const a = document.createElement('a')
+  a.href = downloadUrl
+  a.download = filename
+  a.rel = 'noopener'
+  document.body.appendChild(a)
+  a.click()
+  a.remove()
+}
+
+export const qaTrajAPI = {
+  exportKey,
+  download
+}

--- a/frontend/src/components/admin/user/UserEditModal.vue
+++ b/frontend/src/components/admin/user/UserEditModal.vue
@@ -49,6 +49,13 @@
         />
         <p class="input-hint">{{ t('admin.users.form.rpmLimitHint') }}</p>
       </div>
+      <div>
+        <label class="flex cursor-pointer items-center gap-2">
+          <input v-model="form.traj_export_enabled" type="checkbox" class="h-4 w-4 rounded border-gray-300 text-primary-600 focus:ring-primary-500" />
+          <span class="input-label !mb-0">{{ t('admin.users.form.trajExport') }}</span>
+        </label>
+        <p class="input-hint">{{ t('admin.users.form.trajExportHint') }}</p>
+      </div>
       <UserAttributeForm v-model="form.customAttributes" :user-id="user?.id" />
     </form>
     <template #footer>
@@ -78,11 +85,11 @@ const emit = defineEmits(['close', 'success'])
 const { t } = useI18n(); const appStore = useAppStore(); const { copyToClipboard } = useClipboard()
 
 const submitting = ref(false); const passwordCopied = ref(false)
-const form = reactive({ email: '', password: '', username: '', notes: '', concurrency: 1, rpm_limit: 0, customAttributes: {} as UserAttributeValuesMap })
+const form = reactive({ email: '', password: '', username: '', notes: '', concurrency: 1, rpm_limit: 0, traj_export_enabled: false, customAttributes: {} as UserAttributeValuesMap })
 
 watch(() => props.user, (u) => {
   if (u) {
-    Object.assign(form, { email: u.email, password: '', username: u.username || '', notes: u.notes || '', concurrency: u.concurrency, rpm_limit: u.rpm_limit ?? 0, customAttributes: {} })
+    Object.assign(form, { email: u.email, password: '', username: u.username || '', notes: u.notes || '', concurrency: u.concurrency, rpm_limit: u.rpm_limit ?? 0, traj_export_enabled: u.traj_export_enabled ?? false, customAttributes: {} })
     passwordCopied.value = false
   }
 }, { immediate: true })
@@ -109,7 +116,7 @@ const handleUpdateUser = async () => {
   }
   submitting.value = true
   try {
-    const data: any = { email: form.email, username: form.username, notes: form.notes, concurrency: form.concurrency, rpm_limit: form.rpm_limit }
+    const data: any = { email: form.email, username: form.username, notes: form.notes, concurrency: form.concurrency, rpm_limit: form.rpm_limit, traj_export_enabled: form.traj_export_enabled }
     if (form.password.trim()) data.password = form.password.trim()
     await adminAPI.users.update(props.user.id, data)
     if (Object.keys(form.customAttributes).length > 0) await adminAPI.userAttributes.updateUserAttributeValues(props.user.id, form.customAttributes)

--- a/frontend/src/i18n/locales/en.ts
+++ b/frontend/src/i18n/locales/en.ts
@@ -1018,6 +1018,12 @@ export default {
     copyToClipboard: 'Copy to clipboard',
     copied: 'Copied!',
     importToCcSwitch: 'Import to CCS',
+    export: 'Export',
+    exporting: 'Exporting…',
+    exportTooltip: "Export this key's conversation records (training-ready JSONL)",
+    exportSuccess: 'Exported {count} conversation records',
+    exportEmpty: 'No conversation records captured for this key yet',
+    exportFailed: 'Export failed, please try again',
     enable: 'Enable',
     disable: 'Disable',
     nameLabel: 'Name',
@@ -2169,7 +2175,9 @@ export default {
       form: {
         rpmLimit: 'Requests Per Minute (RPM)',
         rpmLimitPlaceholder: '0 = unlimited',
-        rpmLimitHint: 'Max requests per minute for this user; 0 = unlimited. Acts as a fallback only when the group has no rpm_limit set.'
+        rpmLimitHint: 'Max requests per minute for this user; 0 = unlimited. Acts as a fallback only when the group has no rpm_limit set.',
+        trajExport: 'Allow conversation export',
+        trajExportHint: "When on, the user can export each API key's captured conversation records individually."
       },
       columns: {
         user: 'User',

--- a/frontend/src/i18n/locales/zh.ts
+++ b/frontend/src/i18n/locales/zh.ts
@@ -1015,6 +1015,12 @@ export default {
     copyToClipboard: '复制到剪贴板',
     copied: '已复制！',
     importToCcSwitch: '导入到 CCS',
+    export: '导出',
+    exporting: '导出中…',
+    exportTooltip: '导出该 Key 的对话记录（训练就绪 JSONL）',
+    exportSuccess: '已导出 {count} 条对话记录',
+    exportEmpty: '该 Key 暂无可导出的对话记录',
+    exportFailed: '导出失败，请重试',
     enable: '启用',
     disable: '禁用',
     nameLabel: '名称',
@@ -2273,7 +2279,9 @@ export default {
         selectStatus: '选择状态',
         rpmLimit: '每分钟请求数 (RPM)',
         rpmLimitPlaceholder: '0 表示不限制',
-        rpmLimitHint: '该用户每分钟最大请求数，0 = 不限制；仅在所用分组未设置 rpm_limit 时作为兜底生效'
+        rpmLimitHint: '该用户每分钟最大请求数，0 = 不限制；仅在所用分组未设置 rpm_limit 时作为兜底生效',
+        trajExport: '允许导出对话记录',
+        trajExportHint: '开启后，该用户每个 API Key 可单独导出其捕获的对话记录'
       },
       adjustBalance: '调整余额',
       adjustConcurrency: '调整并发数',

--- a/frontend/src/types/index.ts
+++ b/frontend/src/types/index.ts
@@ -88,6 +88,7 @@ export interface User {
   balance: number // User balance for API usage
   concurrency: number // Allowed concurrent requests
   rpm_limit?: number // User-level RPM cap (0 = unlimited); effective as fallback when group has no rpm_limit
+  traj_export_enabled?: boolean // Admin-granted: allow exporting each API key's captured conversation records
   status: 'active' | 'disabled' // Account status
   allowed_groups: number[] | null // Allowed group IDs (null = all non-exclusive groups)
   balance_notify_enabled: boolean

--- a/frontend/src/views/user/KeysView.vue
+++ b/frontend/src/views/user/KeysView.vue
@@ -343,9 +343,9 @@
                 <Icon v-else name="checkCircle" size="sm" />
                 <span class="text-xs">{{ row.status === 'active' ? t('keys.disable') : t('keys.enable') }}</span>
               </button>
-              <!-- Export Conversations Button (admin-granted per-user switch) -->
+              <!-- Export Conversations Button (admin-granted per-user switch; anthropic keys only — the traj projector is Anthropic-shaped) -->
               <button
-                v-if="canExportTraj"
+                v-if="canExportTraj && row.group?.platform === 'anthropic'"
                 @click="exportKeyTraj(row)"
                 :disabled="exportingKeyId !== null"
                 :title="t('keys.exportTooltip')"

--- a/frontend/src/views/user/KeysView.vue
+++ b/frontend/src/views/user/KeysView.vue
@@ -343,6 +343,17 @@
                 <Icon v-else name="checkCircle" size="sm" />
                 <span class="text-xs">{{ row.status === 'active' ? t('keys.disable') : t('keys.enable') }}</span>
               </button>
+              <!-- Export Conversations Button (admin-granted per-user switch) -->
+              <button
+                v-if="canExportTraj"
+                @click="exportKeyTraj(row)"
+                :disabled="exportingKeyId !== null"
+                :title="t('keys.exportTooltip')"
+                class="flex flex-col items-center gap-0.5 rounded-lg p-1.5 text-gray-500 transition-colors hover:bg-indigo-50 hover:text-indigo-600 disabled:cursor-not-allowed disabled:opacity-50 dark:hover:bg-indigo-900/20 dark:hover:text-indigo-400"
+              >
+                <Icon :name="exportingKeyId === row.id ? 'refresh' : 'download'" size="sm" :class="{ 'animate-spin': exportingKeyId === row.id }" />
+                <span class="text-xs">{{ exportingKeyId === row.id ? t('keys.exporting') : t('keys.export') }}</span>
+              </button>
               <!-- Edit Button -->
               <button
                 @click="editKey(row)"
@@ -1060,7 +1071,8 @@
 import { getPersistedPageSize } from '@/composables/usePersistedPageSize'
 
 const { t } = useI18n()
-import { keysAPI, authAPI, usageAPI, userGroupsAPI } from '@/api'
+import { keysAPI, authAPI, usageAPI, userGroupsAPI, qaTrajAPI } from '@/api'
+import { useAuthStore } from '@/stores/auth'
 import AppLayout from '@/components/layout/AppLayout.vue'
 import TablePageLayout from '@/components/layout/TablePageLayout.vue'
 	import DataTable from '@/components/common/DataTable.vue'
@@ -1103,8 +1115,13 @@ interface GroupOption {
 }
 
 const appStore = useAppStore()
+const authStore = useAuthStore()
 const onboardingStore = useOnboardingStore()
 const { copyToClipboard: clipboardCopy } = useClipboard()
+
+// Admin-granted per-user switch: only then does each key row expose the
+// conversation-record export entry (backend also enforces 403).
+const canExportTraj = computed(() => authStore.user?.traj_export_enabled === true)
 
 const columns = computed<Column[]>(() => [
   { key: 'name', label: t('common.name'), sortable: true },
@@ -1154,6 +1171,7 @@ const showCcsClientSelect = ref(false)
 const pendingCcsRow = ref<ApiKey | null>(null)
 const selectedKey = ref<ApiKey | null>(null)
 const copiedKeyId = ref<number | null>(null)
+const exportingKeyId = ref<number | null>(null)
 const groupSelectorKeyId = ref<number | null>(null)
 const publicSettings = ref<PublicSettings | null>(null)
 const dropdownRef = ref<HTMLElement | null>(null)
@@ -1762,6 +1780,28 @@ const handleCcsClientSelect = (clientType: CcSwitchClientType) => {
   }
   showCcsClientSelect.value = false
   pendingCcsRow.value = null
+}
+
+// Export this key's captured conversation records (qa traj v2). One click:
+// build the export → download the zip. Empty capture → friendly toast, no file.
+const exportKeyTraj = async (row: ApiKey) => {
+  if (exportingKeyId.value !== null) return
+  exportingKeyId.value = row.id
+  try {
+    const result = await qaTrajAPI.exportKey(row.id)
+    if (!result.record_count) {
+      appStore.showInfo(t('keys.exportEmpty'))
+      return
+    }
+    const stamp = new Date().toISOString().slice(0, 10)
+    const safeName = (row.name || `key-${row.id}`).replace(/[^\w.-]+/g, '_')
+    await qaTrajAPI.download(result.download_url, `conversations-${safeName}-${stamp}.zip`)
+    appStore.showSuccess(t('keys.exportSuccess', { count: result.record_count }))
+  } catch (error) {
+    appStore.showError(t('keys.exportFailed'))
+  } finally {
+    exportingKeyId.value = null
+  }
 }
 
 const closeCcsClientSelect = () => {

--- a/scripts/sentinels/frontend-tk.json
+++ b/scripts/sentinels/frontend-tk.json
@@ -812,6 +812,22 @@
         "supportedParams"
       ],
       "rationale": "TK-only Studio model catalog + capability map. MEDIA_MODELS lists each priced+servable media model (friendly name, vendor, price, supportedParams); resolveAvailableModels(modality, availableIds) is the priced∩servable filter the model-card picker drives (replacing the tier-card selection). Dropping these silently regresses the transparent model picker or, worse, lets an unservable/unpriced model surface as a 400-on-submit footgun. supportedParams is the honest Advanced-panel capability gate — only params a model actually honors are rendered."
+    },
+    {
+      "path": "frontend/src/views/user/KeysView.vue",
+      "must_contain": [
+        "canExportTraj && row.group?.platform === 'anthropic'"
+      ],
+      "rationale": "PR #792: the per-key conversation-record (traj) Export chip is gated by BOTH the admin-granted per-user switch (canExportTraj) AND anthropic-only (row.group.platform === 'anthropic'), because the traj v2 projector only reconstructs Anthropic /v1/messages. KeysView.vue is upstream-shaped; a git merge upstream/main that overwrites it back to upstream shape would silently drop the chip or its dual gate, exposing the export entry to every platform/user while still compiling."
+    },
+    {
+      "path": "frontend/src/api/qaTraj.ts",
+      "must_contain": [
+        "qaTrajAPI",
+        "format: 'v2'",
+        "api_key_id"
+      ],
+      "rationale": "PR #792: the TK-only conversation-export API client. qaTrajAPI.exportKey posts {api_key_id, format:'v2'} to the per-key self-export endpoint; an upstream merge replacing the api/ layer or dropping this module would silently sever the export wiring (KeysView import breaks loud, but a merge that rewrites both would not)."
     }
   ]
 }

--- a/scripts/sentinels/trajectory.json
+++ b/scripts/sentinels/trajectory.json
@@ -44,6 +44,23 @@
         "setOpsUpstreamRequestBody(c, body)"
       ],
       "rationale": "pre-flight stash of the final upstream request body on the native anthropic path; an upstream merge dropping this call disables both ops_error_logs body context and traj divergence capture"
+    },
+    {
+      "source": "backend/internal/handler/qa_handler_traj.go",
+      "must_contain": [
+        "UserTrajExportEnabled",
+        "domain.PlatformAnthropic"
+      ],
+      "rationale": "Per-key conversation-record (traj) export must keep BOTH gates: the admin-granted per-user switch (UserTrajExportEnabled -> 403) and the anthropic-only pin (Platform: domain.PlatformAnthropic). The traj v2 projector only faithfully reconstructs Anthropic /v1/messages; an upstream merge or refactor dropping the gate silently re-opens export to unauthorized users, and dropping the platform pin silently hands non-anthropic keys misleading non-empty garbage zips."
+    },
+    {
+      "source": "backend/internal/observability/qa/service_traj_export.go",
+      "must_contain": [
+        "func (s *Service) UserTrajExportEnabled",
+        "qarecord.APIKeyIDEQ",
+        "qarecord.PlatformEQ"
+      ],
+      "rationale": "The export authorization helper plus the per-key (APIKeyIDEQ) and platform (PlatformEQ) scoping predicates. Losing the helper drops the 403 backstop; losing either predicate silently widens a self-export across keys or platforms beyond what the UI gate allows."
     }
   ],
   "semantic_route_contracts": [


### PR DESCRIPTION
## What

Adds a per-API-key **conversation-record (traj) export** to `/keys`, gated by a new admin-granted per-user switch — the消费侧 (Phase 2) for the already-merged traj v2 capture/export in #685.

- **Admin grants per user**: new `users.traj_export_enabled` (default off), cloned end-to-end from the `rpm_limit` plumbing (ent → `service.User`/repo → admin `UpdateUser` → `dto.User` → `GET /auth/me`). Toggle lives in the admin user-edit modal ("Allow conversation export").
- **When on**: every **anthropic** API Key row grows one `Export` chip; one click builds that key's full retained trajectory (`api_key_id`-scoped, v2 format, no 24h window cap) and downloads `conversations-<key>-<date>.zip`. Empty capture → toast, no empty file.
- **When off**: chip hidden, and the endpoint returns **403** (defense-in-depth behind the UI gate); existing `503` when capture is disabled deployment-wide is preserved.
- **Anthropic-only**: the traj v2 projector only faithfully reconstructs Anthropic `/v1/messages`; openai/gemini blobs project to empty/garbage turns. The chip renders only for `platform === 'anthropic'` keys and the backend pins `ExportFilter.Platform = anthropic`.

## Design notes (Jobs review)

One switch only (per-user, also the data-governance boundary). The gate doubles as anti-clutter (chip renders only for authorized + anthropic keys). Surface language is human ("conversation records"); the implementation keeps the precise `traj_export_enabled` naming.

## Tests

- Backend: per-key scoping (foreign user id → 0 rows), platform filter (excludes openai/gemini), 403 when switch off; `/auth/me` contract golden updated.
- Frontend: `qaTraj` posts `{api_key_id, format:'v2'}`; UsersView + i18n specs green.
- `go test -tags=unit ./...`, `golangci-lint run ./...`, `pnpm typecheck && pnpm lint:check`, `scripts/preflight.sh` all pass locally.

## Upstream-merge overwrite protection (sentinels)

The load-bearing TK surfaces this PR adds are **registered in the sentinel registries** so a future upstream merge or refactor that silently overwrites/drops them fails `check-trajectory-hooks` / `check-frontend-tk` (run by both `preflight.sh` and `upstream-merge-pr-shape.yml`):

- `scripts/sentinels/trajectory.json`: `qa_handler_traj.go` (`UserTrajExportEnabled` + `domain.PlatformAnthropic`), `service_traj_export.go` (`UserTrajExportEnabled` + `qarecord.APIKeyIDEQ` + `qarecord.PlatformEQ`).
- `scripts/sentinels/frontend-tk.json`: `KeysView.vue` chip dual gate, `qaTraj.ts` client.

Reverse-tested: removing either gate flips the checker to exit 1. (This replaces the earlier `sentinel-registry-reviewed` PR-body bypass with real anchors.)

## Markers / boundary

- `upstream-touch-guarded` — additive field plumbing through upstream-shaped handlers/services/repos/dto/views, all gated behind the per-user switch; ent schema + `tk_028` migration follow schema-first.

Merge mode: **Squash and merge** (TK-originated feature).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
