### PR TITLE
fix(stage0): edge disk hygiene — prune images on deploy + port #778 disk alert & QA cleanup to edges

### DIFF
--- a/.github/workflows/deploy-edge-lightsail-stage0.yml
+++ b/.github/workflows/deploy-edge-lightsail-stage0.yml
@@ -249,6 +249,26 @@ jobs:
           TK_FEISHU_SIGNING_SECRET: ${{ secrets.TK_FEISHU_SIGNING_SECRET }}
         run: bash ops/stage0/sync-feishu-config.sh --platform lightsail "${{ steps.edge.outputs.edge_id }}"
 
+      - name: Sync edge host units (disk-full alert + QA stale cleanup)
+        # prod (deploy/aws/stage0/stage0-ec2-bootstrap.sh) installs AND enables
+        # tokenkey-disk-metrics.timer (#778 on-box disk alert) and
+        # tokenkey-qa-stale-cleanup.timer; the Lightsail user-data 14 KB cap means
+        # render-bootstrap can only ship the scripts, not wire the units, and
+        # deploy_via_ssm.sh never re-runs bootstrap. So existing edges silently
+        # lacked the disk alert (filled-disk crash with no notice) and QA cleanup
+        # (qa_records/qa_blobs grew unbounded). This SSM push reaches existing edges
+        # and new ones (after provision). Runs AFTER the Feishu step so the disk
+        # alert finds TOKENKEY_FEISHU_WEBHOOK_URL/_SECRET in .env on its first fire.
+        if: inputs.operation == 'provision' || inputs.operation == 'upgrade' || inputs.operation == 'rollback' || inputs.operation == 'smoke'
+        env:
+          INSTANCE_ID: ${{ steps.instance.outputs.managed_instance_id }}
+          AWS_REGION: ${{ steps.edge.outputs.lightsail_region }}
+          # 1.5 days = prod parity (CFN QaStaleRetentionDays default); edges are
+          # pure relays so QA there is low-value — keep retention short.
+          TK_QA_STALE_RETENTION_DAYS: "1.5"
+          STAGE0_SSM_OUTPUT_DIR: .
+        run: bash ops/stage0/sync-edge-host-units-via-ssm.sh "$INSTANCE_ID" "edge-host-units edge=${{ steps.edge.outputs.edge_id }}"
+
       - name: Edge smoke
         if: inputs.operation == 'smoke' || inputs.operation == 'upgrade' || inputs.operation == 'rollback'
         env:

--- a/deploy/aws/lightsail/tokenkey-disk-metrics-edge.sh
+++ b/deploy/aws/lightsail/tokenkey-disk-metrics-edge.sh
@@ -1,0 +1,58 @@
+#!/bin/bash
+# TokenKey Stage0 EDGE — on-box disk-full Feishu alert (Lightsail variant of the
+# prod #778 alert in deploy/aws/stage0/stage0-ec2-bootstrap.sh).
+#
+# Single source of record: consumed both by
+#   - deploy/aws/lightsail/render-bootstrap.sh (bakes it into new-edge user-data), and
+#   - ops/stage0/sync-edge-host-units-via-ssm.sh (pushes it onto running edges via SSM).
+# Keep those two in sync by editing ONLY this file.
+#
+# Differences vs the prod EC2 alert (intentional, per "乔布斯审核" — cut to essentials):
+#   - df target is /  (edge has NO separate /var/lib/tokenkey data volume; it is
+#     a directory on the single root volume).
+#   - NO CloudWatch put-metric. Edges have no DataVolumeDiskAlarm and may lack the
+#     cloudwatch:PutMetricData IAM, so a metric publish here is a perpetually-failing
+#     aws call every 5min — pure noise. The Feishu post is the whole point.
+#   - Node label from API_DOMAIN (.env), not IMDS instance-id (Lightsail metadata differs).
+#
+# A full root volume crashes Postgres AND degrades the app, so this alert MUST run
+# independent of Docker/Postgres — the timer fires it every 5min on-box. Webhook +
+# secret are injected via /var/lib/tokenkey/.env; absent webhook => silent no-op.
+set -euo pipefail
+
+USED="$(df -P / 2>/dev/null | awk 'NR==2 {gsub(/%/,"",$5); print $5}')"
+[ -z "${USED}" ] && exit 0
+
+THRESHOLD="${TOKENKEY_DISK_ALERT_THRESHOLD:-85}"
+COOLDOWN="${TOKENKEY_DISK_ALERT_COOLDOWN_SEC:-1800}"
+STAMP=/run/tokenkey-disk-alert.stamp
+WEBHOOK=""; SECRET=""; NODE="$(hostname)"
+if [ -r /var/lib/tokenkey/.env ]; then
+  WEBHOOK="$(sed -n 's/^TOKENKEY_FEISHU_WEBHOOK_URL=//p' /var/lib/tokenkey/.env | head -1)"
+  SECRET="$(sed -n 's/^TOKENKEY_FEISHU_WEBHOOK_SECRET=//p' /var/lib/tokenkey/.env | head -1)"
+  DOM="$(sed -n 's/^API_DOMAIN=//p' /var/lib/tokenkey/.env | head -1)"
+  [ -n "${DOM}" ] && NODE="${DOM}"
+fi
+
+if [ "${USED}" -ge "${THRESHOLD}" ] && [ -n "${WEBHOOK}" ]; then
+  NOW="$(date +%s)"
+  LAST=0; [ -r "${STAMP}" ] && LAST="$(cat "${STAMP}" 2>/dev/null || echo 0)"
+  if [ "$((NOW - LAST))" -ge "${COOLDOWN}" ]; then
+    TEXT="🔴 P0 磁盘将满 ${NODE} — 数据盘 / 使用率 ${USED}% (阈值 ${THRESHOLD}%)。Postgres 满盘会崩溃→网关全挂。立即清 docker 镜像/日志或扩容。node=${NODE}"
+    # Feishu custom-bot signed message: sign = base64(HMAC-SHA256(key=ts\nsecret, "")).
+    if [ -n "${SECRET}" ]; then
+      SIGN="$(printf '' | openssl dgst -sha256 -hmac "${NOW}"$'\n'"${SECRET}" -binary 2>/dev/null | base64)"
+      PAYLOAD="$(printf '{"timestamp":"%s","sign":"%s","msg_type":"text","content":{"text":"%s"}}' "${NOW}" "${SIGN}" "${TEXT}")"
+    else
+      PAYLOAD="$(printf '{"msg_type":"text","content":{"text":"%s"}}' "${TEXT}")"
+    fi
+    # Feishu returns HTTP 200 even when it REJECTS (bad signature / missing keyword);
+    # the real status is the body's "code" field (0 = delivered). Stamp the cooldown
+    # only on code:0, so a misconfigured webhook keeps retrying every tick instead of
+    # silently dropping every alert while the stamp suppresses retries for COOLDOWN.
+    RESP="$(curl -sS -m 10 -X POST "${WEBHOOK}" -H 'Content-Type: application/json' -d "${PAYLOAD}" 2>/dev/null || true)"  # preflight-allow: swallow — curl failure ⇒ empty RESP ⇒ no stamp ⇒ retry next tick
+    case "${RESP}" in
+      *'"code":0'*) echo "${NOW}" > "${STAMP}" || true ;;  # preflight-allow: swallow — best-effort cooldown stamp; alert delivered
+    esac
+  fi
+fi

--- a/ops/stage0/deploy_via_ssm.sh
+++ b/ops/stage0/deploy_via_ssm.sh
@@ -116,6 +116,7 @@ jq -n --arg tag "${TAG}" '{
     "trap rollback ERR",
     ("sudo sed -i '\''s|sub2api:[^[:space:]]*|sub2api:" + $tag + "|'\'' /var/lib/tokenkey/.env"),
     "if ! grep -q '\''^SERVER_FRONTEND_URL='\'' /var/lib/tokenkey/.env; then d=$(sed -n '\''s/^API_DOMAIN=//p'\'' /var/lib/tokenkey/.env | head -1); if [ -n \"$d\" ]; then echo \"SERVER_FRONTEND_URL=https://$d\" | sudo tee -a /var/lib/tokenkey/.env >/dev/null; echo \"ensured SERVER_FRONTEND_URL=https://$d\"; else echo \"API_DOMAIN empty; skip SERVER_FRONTEND_URL backfill\"; fi; else echo \"SERVER_FRONTEND_URL already present\"; fi",
+    "if ! grep -q '\''^TOKENKEY_GHCR_KEEP_TAGS='\'' /var/lib/tokenkey/.env; then echo '\''TOKENKEY_GHCR_KEEP_TAGS=3'\'' | sudo tee -a /var/lib/tokenkey/.env >/dev/null; echo '\''ensured TOKENKEY_GHCR_KEEP_TAGS=3'\''; else echo '\''TOKENKEY_GHCR_KEEP_TAGS already present'\''; fi",
     ("if [ -f /var/lib/tokenkey/docker-compose.yml ] && ! grep -q '\''SERVER_FRONTEND_URL'\'' /var/lib/tokenkey/docker-compose.yml; then sudo cp -a /var/lib/tokenkey/docker-compose.yml /var/lib/tokenkey/docker-compose.yml.compose-before-" + $tag + "; sudo sed -i '\''/^      - TZ=/a\\      - SERVER_FRONTEND_URL=${SERVER_FRONTEND_URL:-}'\'' /var/lib/tokenkey/docker-compose.yml; if grep -q '\''SERVER_FRONTEND_URL'\'' /var/lib/tokenkey/docker-compose.yml; then echo ensured-compose-SERVER_FRONTEND_URL-mapping; else echo '\''::warning::failed to insert compose SERVER_FRONTEND_URL mapping'\''; fi; else echo compose-SERVER_FRONTEND_URL-mapping-present-or-no-compose; fi"),
     "echo \"=== pull new image BEFORE drain (old container keeps serving 100% traffic) ===\"",
     "cd /var/lib/tokenkey && sudo docker compose --env-file .env pull tokenkey",
@@ -128,6 +129,7 @@ jq -n --arg tag "${TAG}" '{
     "FINAL=$(sudo docker inspect tokenkey --format '\''{{.State.Health.Status}}'\'' 2>/dev/null || echo missing)",
     "if [ \"$FINAL\" != \"healthy\" ]; then echo \"::error::container did not reach healthy state (final=$FINAL)\"; sudo docker logs tokenkey --since 2m 2>&1 | tail -50; exit 1; fi",
     "trap - ERR",
+    "echo \"=== prune stale ghcr image tags (keep newest 3 + in-use) — runs on every deploy; the tokenkey.service ExecStartPost hook only fires on full restart, so deploys never pruned and tags piled to 50+/14G per node before this ===\"; PRUNE=/usr/local/bin/tokenkey-prune-ghcr-app-tags-core.sh; [ -x \"$PRUNE\" ] || PRUNE=/usr/local/bin/tokenkey-prune-ghcr-app-tags.sh; if [ -x \"$PRUNE\" ]; then sudo env TOKENKEY_GHCR_KEEP_TAGS=3 \"$PRUNE\" || echo '\''::warning::ghcr prune failed (non-fatal)'\''; else echo '\''no ghcr prune script on box; skipping'\''; fi; sudo docker image prune -f >/dev/null 2>&1 || true",
     "cd /var/lib/tokenkey && sudo docker compose ps",
     "sudo docker logs tokenkey --since 2m 2>&1 | tail -20"
   ]

--- a/ops/stage0/sync-edge-host-units-via-ssm.sh
+++ b/ops/stage0/sync-edge-host-units-via-ssm.sh
@@ -1,0 +1,216 @@
+#!/usr/bin/env bash
+# Bring a running Lightsail EDGE's host-level systemd units up to prod parity via
+# SSM Run-Command. Mirrors ops/stage0/pg_dump_refresh_via_ssm.sh.
+#
+# Why this exists: prod (deploy/aws/stage0/stage0-ec2-bootstrap.sh) installs AND
+# enables two host units that the edge bootstrap (deploy/aws/lightsail/render-bootstrap.sh)
+# does NOT wire — render-bootstrap is capped at 14336 bytes of Lightsail user-data
+# and only `chmod +x`'s the scripts. So existing + new edges silently lacked:
+#   1. on-box disk-full Feishu alert (tokenkey-disk-metrics.sh + .timer) — #778 was
+#      prod-only; an edge that fills its root volume crashed Postgres with NO alert.
+#   2. QA stale cleanup (tokenkey-qa-stale-cleanup.sh + .timer + retention env) — the
+#      script shipped but never ran on edges, so qa_records/qa_blobs grew unbounded
+#      (13+ days / multi-GB) while prod stayed pruned at 1.5 days.
+# render-bootstrap can't grow (user-data cap), and deploy_via_ssm.sh does not re-run
+# bootstrap, so this SSM push is the path that reaches existing edges (the same
+# situation #778 solved for prod with pg_dump_refresh_via_ssm.sh). The edge deploy
+# workflow calls this after provision/upgrade; run it standalone to backfill a node.
+#
+# Single source of record for the unit payloads:
+#   - deploy/aws/lightsail/tokenkey-disk-metrics-edge.sh  (disk alert; feishu-only, df /)
+#   - deploy/aws/stage0/tokenkey-qa-stale-cleanup.sh      (QA prune; shared with prod)
+# Edit only those files; this script base64-pushes them verbatim.
+#
+# Prereq for the disk alert to actually post: TOKENKEY_FEISHU_WEBHOOK_URL/_SECRET must
+# be present in /var/lib/tokenkey/.env (the alert no-ops silently otherwise). The edge
+# deploy workflow's sync-feishu-config step mirrors them there.
+#
+# Usage:
+#   bash ops/stage0/sync-edge-host-units-via-ssm.sh <instance-id|mi-...> [comment]
+#   AWS_REGION=us-east-2 TK_QA_STALE_RETENTION_DAYS=1.5 \
+#     bash ops/stage0/sync-edge-host-units-via-ssm.sh mi-...
+
+set -euo pipefail
+
+INSTANCE_ID="${1:-${INSTANCE_ID:-}}"
+COMMENT="${2:-${SSM_COMMENT:-ops-edge-host-units-sync}}"
+TIMEOUT_SECONDS="${STAGE0_SSM_TIMEOUT_SECONDS:-300}"
+OUTPUT_DIR="${STAGE0_SSM_OUTPUT_DIR:-.}"
+# Edge QA retention in days (fractional OK). Default 1.5 = prod parity (the CFN
+# QaStaleRetentionDays default). edges are pure relays so QA there is low-value;
+# keep it short.
+QA_RETENTION_DAYS="${TK_QA_STALE_RETENTION_DAYS:-1.5}"
+
+if [ -z "${INSTANCE_ID}" ]; then
+  echo "stage0_sync_edge_host_units_via_ssm: instance id is required" >&2
+  exit 1
+fi
+if ! printf '%s' "${QA_RETENTION_DAYS}" | grep -Eq '^(0|[1-9][0-9]*)(\.[0-9]+)?$'; then
+  echo "stage0_sync_edge_host_units_via_ssm: invalid TK_QA_STALE_RETENTION_DAYS=${QA_RETENTION_DAYS}" >&2
+  exit 1
+fi
+
+ssm_region_args=()
+if [ -n "${AWS_REGION:-${AWS_DEFAULT_REGION:-}}" ]; then
+  ssm_region_args=(--region "${AWS_REGION:-${AWS_DEFAULT_REGION}}")
+fi
+
+mkdir -p "${OUTPUT_DIR}"
+params_file="${OUTPUT_DIR}/ssm-params.json"
+stdout_file="${OUTPUT_DIR}/stdout.txt"
+stderr_file="${OUTPUT_DIR}/stderr.txt"
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+DM_SRC="${SCRIPT_DIR}/../../deploy/aws/lightsail/tokenkey-disk-metrics-edge.sh"
+QA_SRC="${SCRIPT_DIR}/../../deploy/aws/stage0/tokenkey-qa-stale-cleanup.sh"
+[[ -f "${DM_SRC}" ]] || { echo "missing ${DM_SRC}" >&2; exit 1; }
+[[ -f "${QA_SRC}" ]] || { echo "missing ${QA_SRC}" >&2; exit 1; }
+
+# Encode each payload to single-line base64 so embedding into the JSON command
+# array is shell-quoting-safe. tr -d strips both GNU and BSD base64 wrapping.
+DM_SH_B64="$(base64 <"${DM_SRC}" | tr -d '\n')"
+QA_SH_B64="$(base64 <"${QA_SRC}" | tr -d '\n')"
+
+DM_SERVICE_B64="$(cat <<'DMSEOF' | base64 | tr -d '\n'
+[Unit]
+Description=tokenkey EDGE on-box disk-full Feishu alert
+After=network-online.target tokenkey.service
+Wants=network-online.target
+
+[Service]
+Type=oneshot
+EnvironmentFile=-/var/lib/tokenkey/.env
+ExecStart=/usr/local/bin/tokenkey-disk-metrics.sh
+DMSEOF
+)"
+
+DM_TIMER_B64="$(cat <<'DMTEOF' | base64 | tr -d '\n'
+[Unit]
+Description=Fire tokenkey EDGE disk-full alert every 5 minutes
+
+[Timer]
+OnBootSec=3min
+OnUnitActiveSec=5min
+RandomizedDelaySec=30
+Persistent=true
+
+[Install]
+WantedBy=timers.target
+DMTEOF
+)"
+
+QA_SERVICE_B64="$(cat <<'QASEOF' | base64 | tr -d '\n'
+[Unit]
+Description=Prune QA records and blob trees older than retention
+After=network-online.target tokenkey.service
+Wants=network-online.target
+Requires=tokenkey.service
+
+[Service]
+Type=oneshot
+EnvironmentFile=-/etc/tokenkey/qa-stale-retention.env
+ExecStart=/usr/local/bin/tokenkey-qa-stale-cleanup.sh
+QASEOF
+)"
+
+QA_TIMER_B64="$(cat <<'QATEOF' | base64 | tr -d '\n'
+[Unit]
+Description=Daily QA stale cleanup (low-traffic window)
+
+[Timer]
+OnCalendar=*-*-* 04:15:00
+RandomizedDelaySec=30min
+Persistent=true
+
+[Install]
+WantedBy=timers.target
+QATEOF
+)"
+
+# In-place sync trace: which commit the live units are now aligned to.
+TEMPLATE_SHA="${GITHUB_SHA:-local}"
+
+jq -n \
+  --arg dmsh "${DM_SH_B64}" \
+  --arg dmsvc "${DM_SERVICE_B64}" \
+  --arg dmtmr "${DM_TIMER_B64}" \
+  --arg qash "${QA_SH_B64}" \
+  --arg qasvc "${QA_SERVICE_B64}" \
+  --arg qatmr "${QA_TIMER_B64}" \
+  --arg qadays "${QA_RETENTION_DAYS}" \
+  --arg sha "${TEMPLATE_SHA}" \
+  '{
+    commands: [
+      "set -euo pipefail",
+      "echo === edge host-units sync: disk-full alert + QA stale cleanup ===",
+      "sudo install -d -m 0755 /etc/tokenkey",
+      ("echo " + $dmsh + " | base64 -d | sudo tee /usr/local/bin/tokenkey-disk-metrics.sh > /dev/null"),
+      "sudo chmod +x /usr/local/bin/tokenkey-disk-metrics.sh",
+      ("echo " + $dmsvc + " | base64 -d | sudo tee /etc/systemd/system/tokenkey-disk-metrics.service > /dev/null"),
+      ("echo " + $dmtmr + " | base64 -d | sudo tee /etc/systemd/system/tokenkey-disk-metrics.timer > /dev/null"),
+      ("echo " + $qash + " | base64 -d | sudo tee /usr/local/bin/tokenkey-qa-stale-cleanup.sh > /dev/null"),
+      "sudo chmod +x /usr/local/bin/tokenkey-qa-stale-cleanup.sh",
+      ("echo " + $qasvc + " | base64 -d | sudo tee /etc/systemd/system/tokenkey-qa-stale-cleanup.service > /dev/null"),
+      ("echo " + $qatmr + " | base64 -d | sudo tee /etc/systemd/system/tokenkey-qa-stale-cleanup.timer > /dev/null"),
+      ("printf '\''TOKENKEY_QA_STALE_RETENTION_DAYS=%s\\n'\'' " + $qadays + " | sudo tee /etc/tokenkey/qa-stale-retention.env > /dev/null"),
+      "sudo systemctl daemon-reload",
+      "sudo systemctl enable --now tokenkey-disk-metrics.timer",
+      "sudo systemctl enable --now tokenkey-qa-stale-cleanup.timer",
+      "sudo systemctl restart tokenkey-disk-metrics.timer tokenkey-qa-stale-cleanup.timer",
+      "echo --- timers ---",
+      "sudo systemctl list-timers tokenkey-disk-metrics.timer tokenkey-qa-stale-cleanup.timer --no-pager || true",
+      "echo --- retention env ---",
+      "cat /etc/tokenkey/qa-stale-retention.env || true",
+      "echo --- feishu webhook present in .env -- disk alert no-ops without it --",
+      "grep -cE '\''^TOKENKEY_FEISHU_WEBHOOK_URL='\'' /var/lib/tokenkey/.env || true",
+      ("echo Live edge host units now match deploy/aws@" + $sha + " on $(hostname)")
+    ]
+  }' > "${params_file}"
+
+cmd_id="$(aws "${ssm_region_args[@]}" ssm send-command \
+  --instance-ids "${INSTANCE_ID}" \
+  --document-name AWS-RunShellScript \
+  --comment "${COMMENT}" \
+  --parameters "file://${params_file}" \
+  --query 'Command.CommandId' --output text)"
+
+echo "ssm command-id=${cmd_id}"
+if [ -n "${GITHUB_OUTPUT:-}" ]; then
+  echo "command_id=${cmd_id}" >> "${GITHUB_OUTPUT}"
+fi
+
+deadline=$(( $(date +%s) + TIMEOUT_SECONDS ))
+status="InProgress"
+while true; do
+  status="$(aws "${ssm_region_args[@]}" ssm get-command-invocation \
+    --command-id "${cmd_id}" --instance-id "${INSTANCE_ID}" \
+    --query 'Status' --output text 2>/dev/null || echo InProgress)"
+  case "${status}" in
+    Success|Failed|TimedOut|Cancelled) break ;;
+  esac
+  if [ "$(date +%s)" -ge "${deadline}" ]; then
+    echo "::error::ssm timeout" >&2
+    status="TimedOut"
+    break
+  fi
+  sleep 5
+done
+
+aws "${ssm_region_args[@]}" ssm get-command-invocation \
+  --command-id "${cmd_id}" --instance-id "${INSTANCE_ID}" \
+  --query 'StandardOutputContent' --output text > "${stdout_file}"
+aws "${ssm_region_args[@]}" ssm get-command-invocation \
+  --command-id "${cmd_id}" --instance-id "${INSTANCE_ID}" \
+  --query 'StandardErrorContent' --output text > "${stderr_file}"
+
+echo '--- ssm stdout (last 8KB) ---'
+tail -c 8192 "${stdout_file}"
+echo
+echo '--- ssm stderr (last 8KB) ---'
+tail -c 8192 "${stderr_file}"
+echo
+
+if [ "${status}" != "Success" ]; then
+  echo "::error::ssm command status=${status}" >&2
+  exit 1
+fi

--- a/ops/stage0/sync-feishu-config.sh
+++ b/ops/stage0/sync-feishu-config.sh
@@ -191,6 +191,17 @@ commands = [
     "echo \"FEISHU_ENABLED=${FEISHU_ENABLED} FEISHU_WEBHOOK_PRESENT=${FEISHU_WEBHOOK_PRESENT} FEISHU_SECRET_PRESENT=${FEISHU_SECRET_PRESENT}\"",
     "if [ \"${FEISHU_ENABLED}\" != \"true\" ] || [ \"${FEISHU_WEBHOOK_PRESENT}\" != \"t\" ] || [ \"${FEISHU_SECRET_PRESENT}\" != \"t\" ]; then echo '[error] feishu config not fully applied' >&2; exit 1; fi",
     "echo FEISHU_SYNC_OK=1",
+    # Mirror webhook/secret into /var/lib/tokenkey/.env so the on-box disk-full
+    # Feishu alert (tokenkey-disk-metrics.sh) can read them when the app/DB is
+    # DOWN — which is exactly when a full disk strikes. The DB copy above feeds
+    # the in-app alert path; this .env copy feeds the independent on-box timer.
+    # Quoted heredoc => values pass through literally, never echoed.
+    "sudo sed -i '/^TOKENKEY_FEISHU_WEBHOOK_URL=/d;/^TOKENKEY_FEISHU_WEBHOOK_SECRET=/d' /var/lib/tokenkey/.env",
+    "sudo tee -a /var/lib/tokenkey/.env >/dev/null <<'EOENV'",
+    "TOKENKEY_FEISHU_WEBHOOK_URL=" + webhook,
+    "TOKENKEY_FEISHU_WEBHOOK_SECRET=" + secret,
+    "EOENV",
+    "echo ENV_FEISHU_SYNC_OK=1",
 ]
 print(json.dumps(commands))
 PY

--- a/scripts/checks/check-stage0-ssm-host-parse.sh
+++ b/scripts/checks/check-stage0-ssm-host-parse.sh
@@ -17,8 +17,9 @@
 # its params file WITHOUT touching AWS, then `bash -n` the joined commands.
 #
 # Scope (explicit, not silent): covers the prod/edge MUTATION primitives
-# (deploy image, sync Caddyfile, sync docs, sync Feishu config) plus the
-# read-only warm-image primitive (same jq-host-command shape, same blind spot).
+# (deploy image, sync Caddyfile, sync docs, sync Feishu config, sync edge host
+# units) plus the read-only warm-image primitive (same jq-host-command shape,
+# same blind spot).
 # edge_post_deploy_smoke.sh also builds an SSM `commands` array, but is left out
 # on purpose — its array is assembled inside functions behind many runtime env
 # vars (no clean "args -> params file" entrypoint to stub), and an unparseable
@@ -90,5 +91,7 @@ check_one "sync_docs_pages.sh"              sync-docs bash "${OPS}/sync_docs_pag
 check_one "sync-feishu-config.sh"           sync-feishu \
   env TK_FEISHU_WEBHOOK_URL=https://example.test/hook TK_FEISHU_SIGNING_SECRET=dummy \
   bash "${OPS}/sync-feishu-config.sh" prod
+check_one "sync-edge-host-units-via-ssm.sh" sync-host-units \
+  bash "${OPS}/sync-edge-host-units-via-ssm.sh" mi-0stub
 
 exit "${rc}"

--- a/scripts/preflight.sh
+++ b/scripts/preflight.sh
@@ -903,6 +903,30 @@ if [[ "${_smoke_syntax_ok}" == "true" ]]; then
   echo "  ok: stage0 smoke scripts parse"
 fi
 
+# ---- sub2api: standalone host script syntax (tokenkey-*.sh) ------------------
+# The tokenkey-*.sh host scripts (pgdump, qa-stale-cleanup, prune, disk-metrics)
+# ship to prod/edge boxes either embedded in the CFN/Lightsail bootstrap or
+# base64-pushed by the *_via_ssm.sh refresh primitives. In the base64 path the
+# SSM host-parse guard below only sees the OPAQUE base64 blob, so a syntax error
+# in the decoded script would slip every local gate and only surface at runtime
+# on the box — and for the disk-full alert that means a SILENTLY broken safety
+# net (the exact #778 failure mode). bash -n them as standalone files here.
+# Glob (not an enumerated list) so a new tokenkey-*.sh is covered on day one.
+echo ""
+echo "=== sub2api: standalone host script syntax (tokenkey-*.sh) ==="
+_host_syntax_ok=true
+for _host_script in ./deploy/aws/stage0/tokenkey-*.sh ./deploy/aws/lightsail/tokenkey-*.sh; do
+  [ -e "${_host_script}" ] || continue
+  if ! bash -n "${_host_script}"; then
+    echo "  FAIL: ${_host_script} has bash syntax errors"
+    errors=$((errors + 1))
+    _host_syntax_ok=false
+  fi
+done
+if [[ "${_host_syntax_ok}" == "true" ]]; then
+  echo "  ok: standalone tokenkey-*.sh host scripts parse"
+fi
+
 # ---- sub2api: SSM host command script parses (deploy/sync primitives) --------
 # The jq `commands` array these scripts send to AWS-RunShellScript is joined and
 # run on the host; "JSON valid" locally does NOT catch host-shell syntax errors


### PR DESCRIPTION
## 背景 / 全舰队磁盘排查

排查 prod 满盘事故(#778)的对等性时,发现 edge(Lightsail)有三处系统性缺口,把 oh1/oh2/or1/or2 顶到 **76–79%** 且**毫无满盘告警**——正是 #778 的失败模式,只是 edge 上一直没修。

| edge | 排查时 | 主因 |
|---|---|---|
| oh1/or1 | 79%/78% | 旧 ghcr 镜像 54 个(14G,95% 可回收)+ qa_blobs 3.3G |
| oh2/or2 | 77%/76% | 同上 |

**backlog 已带外止血**(运行态,不在本 PR):全 10 节点清到 keep-3(oh1 79%→47%,uk1 60%→24%,prod 36%→28%)。

## 三个根因,都是「prod 有、edge 没有 / 从不运行」

1. **镜像 prune 从不在发版时跑。** `tokenkey-prune-ghcr-app-tags.sh` 挂在 `tokenkey.service` 的 `ExecStartPost`,但真实部署路径 `deploy_via_ssm.sh` 走裸 `compose up --force-recreate`、从不重启该 unit → tag 无限堆积。现在 `deploy_via_ssm.sh` 在健康检查后调用既有 prune(保留最新 3 + 在用),并把 `TOKENKEY_GHCR_KEEP_TAGS=3` 回填进 `.env`。**一处共享路径,prod + 全 edge 每次发版自清。**

2. **#778 on-box 满盘飞书告警是 prod 专属**(`stage0-ec2-bootstrap.sh`)。新增 edge 版 `tokenkey-disk-metrics-edge.sh`(仅飞书、df `/`、去掉 CloudWatch),经新 `sync-edge-host-units-via-ssm.sh` 推送。

3. **QA 过期清理在 edge 上从没接线。** `tokenkey-qa-stale-cleanup.sh`(删 `qa_records` 行 + 删 blob 文件)被 render-bootstrap 装了脚本但**没建 .service/.timer/retention env、没 enable** → QA 无限增长(edge qa_records 跨 13 天,prod 仅 1.5 天)。同一 sync 脚本安装并 enable 它,**保留 1.5 天(prod 对齐)**。

> 注:用户原以为 QA 是「60 天」,但那是 Go 配置 `qa_capture.retention_days`(只写 `retention_until` 列、**无执行器读它**,vestigial)。真实有效的保留由上面这个 host 脚本控制。故本 PR **不动任何 Go**,只把 edge 接上既有机制。

## 为何走 SSM 推送而非 render-bootstrap

`render-bootstrap.sh` 渲染的 Lightsail user-data 有 **14336 字节硬上限**(当前 14290,仅剩 46 字节),塞不下这些 unit;且 `deploy_via_ssm.sh` 不重跑 bootstrap。所以经 SSM 推送是**触达现存 edge** 的唯一路径(完全镜像 #778 的 `pg_dump_refresh_via_ssm.sh`)。edge 部署 workflow 在 provision/upgrade 后调用它;`sync-feishu-config.sh` 现在也把 webhook/secret 镜像进 `.env`,让独立于 app/DB 的 on-box 告警在满盘(app/DB 已挂)时仍能投递。

## 改动

| 文件 | 改动 |
|---|---|
| `ops/stage0/deploy_via_ssm.sh` | 健康后调既有 prune(keep=3)+ `.env` 回填 `TOKENKEY_GHCR_KEEP_TAGS=3` |
| `deploy/aws/lightsail/tokenkey-disk-metrics-edge.sh`(新) | edge 版满盘飞书告警单一源(仅飞书/df `/`/无 CloudWatch) |
| `ops/stage0/sync-edge-host-units-via-ssm.sh`(新) | 经 SSM 安装 disk-metrics + qa-cleanup 两组 unit、retention=1.5 |
| `ops/stage0/sync-feishu-config.sh` | DB 之外,同时把 webhook/secret 镜像进 `.env`(给 on-box 告警) |
| `.github/workflows/deploy-edge-lightsail-stage0.yml` | provision/upgrade 后调 sync-edge-host-units |
| `scripts/checks/check-stage0-ssm-host-parse.sh` | 新 SSM primitive 纳入 host-parse 守卫 |

## 验证
- `scripts/preflight.sh` PASS(含 SSM host-parse 守卫——它**抓到并让我修了**一处裸括号 echo 的 host-shell 语法错误)。
- 全部改动脚本 `bash -n` OK;workflow YAML 解析 OK。
- sync 脚本 jq 产出合法 JSON;嵌入的 disk-metrics 脚本 base64 round-trip **字节一致**。
- 无 Go / 前端改动。

## 合并后激活(需 SSM,不进 git)
对 9 台现存 edge 各跑一次(workflow 下次发版会自动带上):
\`\`\`
AWS_REGION=<region> bash ops/stage0/sync-edge-host-units-via-ssm.sh <mi-id>
\`\`\`
\+ 经 workflow 的 sync-feishu 步骤注入 `.env` webhook(或重新 deploy edge)。

## 合并方式
TK fix PR → **Squash and merge**(rule §5.y)。

no-web-impact / no-upstream-touch(纯 infra/deploy 脚本,无 Go/前端)。