### PR TITLE
fix(edge-accounts): render real backend error instead of [object Object]

### DIFF
--- a/backend/internal/web/dist/frontend-source.json
+++ b/backend/internal/web/dist/frontend-source.json
@@ -1,7 +1,7 @@
 {
   "algorithm": "sha256(git-ls-files:path,size,content)",
   "file_count": 486,
-  "hash": "cdb2a3467f09f2aa40713d03876bda1ebfda7c50bb2d388dd3b4703f1051fd0a",
+  "hash": "2a38bf64726b1d155ac5cd41f45c1260f78876a2c4f5a4e45b4c02adecf729b9",
   "schema": 1,
   "source": "frontend/"
 }

--- a/backend/internal/web/dist/frontend-source.json
+++ b/backend/internal/web/dist/frontend-source.json
@@ -1,7 +1,7 @@
 {
   "algorithm": "sha256(git-ls-files:path,size,content)",
   "file_count": 486,
-  "hash": "4869fefd5da70f220adca53f3bd5a0e43250380d9f10c5590c34b11d3a65a2f5",
+  "hash": "cdb2a3467f09f2aa40713d03876bda1ebfda7c50bb2d388dd3b4703f1051fd0a",
   "schema": 1,
   "source": "frontend/"
 }

--- a/backend/internal/web/dist/frontend-source.json
+++ b/backend/internal/web/dist/frontend-source.json
@@ -1,7 +1,7 @@
 {
   "algorithm": "sha256(git-ls-files:path,size,content)",
   "file_count": 486,
-  "hash": "03cfa9766acf20407349a18aa47ee48b9cb756b9c157d8283a82085721bbb4ef",
+  "hash": "4869fefd5da70f220adca53f3bd5a0e43250380d9f10c5590c34b11d3a65a2f5",
   "schema": 1,
   "source": "frontend/"
 }

--- a/frontend/src/api/__tests__/client.spec.ts
+++ b/frontend/src/api/__tests__/client.spec.ts
@@ -144,6 +144,25 @@ describe('API Client', () => {
       )
     })
 
+    it('拒绝值是 Error 实例（根除全站 [object Object] 渲染）', async () => {
+      // The interceptor must reject with a real Error (ApiError), not a plain object —
+      // otherwise every `e instanceof Error ? e.message : String(e)` call site renders
+      // "[object Object]" (the bug this fixes at the source). One representative path
+      // (HTTP error response) is enough; all reject points share createApiError.
+      const adapter = vi.fn().mockRejectedValue({
+        response: { status: 500, data: { code: 'INTERNAL', message: 'edge fan-out failed' } },
+        config: { url: '/test' },
+        code: 'ERR_BAD_REQUEST',
+      })
+      apiClient.defaults.adapter = adapter
+
+      await expect(apiClient.get('/test')).rejects.toBeInstanceOf(Error)
+      const err = await apiClient.get('/test').catch((e) => e)
+      expect(err).toBeInstanceOf(Error)
+      expect(err.message).toBe('edge fan-out failed')
+      expect(String(err)).not.toBe('[object Object]')
+    })
+
     it('部署与运营合规未确认时广播事件且保留登录态', async () => {
       localStorage.setItem('auth_token', 'admin-token')
       const listener = vi.fn()

--- a/frontend/src/api/__tests__/clientTk.spec.ts
+++ b/frontend/src/api/__tests__/clientTk.spec.ts
@@ -1,0 +1,49 @@
+import { describe, it, expect } from 'vitest'
+import { ApiError, createApiError, createNetworkError, isNetworkError } from '@/api/client.tk'
+
+describe('ApiError', () => {
+  // The root-cause fix for the app-wide "[object Object]" bug: the axios interceptor
+  // now rejects with this Error subclass, so `e instanceof Error` holds everywhere.
+  it('is a real Error instance carrying the flattened backend fields', () => {
+    const e = createApiError({ status: 500, code: 'INTERNAL', message: 'boom', reason: 'X', error: 'detail' })
+    expect(e).toBeInstanceOf(Error)
+    expect(e).toBeInstanceOf(ApiError)
+    expect(e.name).toBe('ApiError')
+    expect(e.message).toBe('boom')
+    expect(e.status).toBe(500)
+    expect(e.code).toBe('INTERNAL')
+    expect(e.reason).toBe('X')
+    expect(e.error).toBe('detail')
+  })
+
+  it('renders its message (never "[object Object]") through String() and the Error contract', () => {
+    const e = createApiError({ status: 502, code: 'BAD_GATEWAY', message: 'edge fan-out failed' })
+    // The exact failure mode that produced the bug: String(e) on the old plain object.
+    expect(String(e)).not.toBe('[object Object]')
+    expect(String(e)).toContain('edge fan-out failed')
+    expect((e as Error).message).toBe('edge fan-out failed')
+  })
+
+  it('keeps fields enumerable so spread / JSON.stringify retain them (incl. message)', () => {
+    const e = createApiError({ status: 404, code: 'NOT_FOUND', message: 'missing', metadata: { id: 7 } })
+    const spread = { ...e }
+    expect(spread).toMatchObject({ status: 404, code: 'NOT_FOUND', message: 'missing', metadata: { id: 7 } })
+    const json = JSON.parse(JSON.stringify(e))
+    expect(json.message).toBe('missing')
+    expect(json.status).toBe(404)
+  })
+
+  it('falls back to a default message when none is supplied', () => {
+    const e = createApiError({ status: 500, code: 'INTERNAL' })
+    expect(e.message).toBe('API error')
+  })
+
+  it('createNetworkError returns an ApiError that the isNetworkError duck-type guard still matches', () => {
+    const e = createNetworkError('/test')
+    expect(e).toBeInstanceOf(Error)
+    expect(e.status).toBe(0)
+    expect(e.code).toBe('NETWORK_ERROR')
+    expect(e.url).toBe('/test')
+    expect(isNetworkError(e)).toBe(true)
+  })
+})

--- a/frontend/src/api/client.tk.ts
+++ b/frontend/src/api/client.tk.ts
@@ -1,5 +1,57 @@
 import type { AxiosError } from 'axios'
 
+// The axios response interceptor (client.ts) used to reject with a *plain object*
+// { status, code, message, ... }. Because a plain object is not an Error, every
+// `e instanceof Error ? e.message : String(e)` call site across the app fell through
+// to String(e) === "[object Object]" — the bug fixed at the source here. ApiError is
+// a real Error subclass carrying the same flattened fields, so `instanceof Error`
+// holds everywhere and `.message` surfaces the backend message without per-call-site
+// helpers. Object.assign makes every custom field an *enumerable own* property; the
+// constructor additionally redefines `message` as enumerable (Error's constructor sets
+// it non-enumerable), so spreads / JSON.stringify retain the full shape too — strictly
+// more robust than the old plain object. Direct field access (e.message / e.status /
+// e.reason) is unaffected by enumerability, so existing consumers (utils/apiError.ts,
+// utils/authError.ts, the 409 mixed_channel checks) keep working unchanged.
+export interface ApiErrorFields {
+  status?: number
+  code?: number | string
+  message?: string
+  reason?: string
+  error?: string
+  metadata?: Record<string, unknown>
+  offline?: boolean
+  url?: string
+}
+
+export class ApiError extends Error {
+  status?: number
+  code?: number | string
+  reason?: string
+  error?: string
+  metadata?: Record<string, unknown>
+  offline?: boolean
+  url?: string
+
+  constructor(fields: ApiErrorFields) {
+    super(fields.message ?? 'API error')
+    this.name = 'ApiError'
+    Object.assign(this, fields)
+    // Error's constructor installs `message` as a non-enumerable own property, which
+    // assignment via Object.assign preserves. Redefine it enumerable so a spread or
+    // JSON.stringify of this error retains `message` alongside the other fields.
+    Object.defineProperty(this, 'message', {
+      value: this.message,
+      enumerable: true,
+      writable: true,
+      configurable: true,
+    })
+  }
+}
+
+export function createApiError(fields: ApiErrorFields): ApiError {
+  return new ApiError(fields)
+}
+
 const NETWORK_ERROR_MESSAGE = 'Network error. Please check your connection.'
 const NETWORK_ERROR_CODES = new Set([
   'ERR_NETWORK',
@@ -37,16 +89,19 @@ export function requestUrlFromError(error: unknown): string | undefined {
   return typeof config?.url === 'string' ? config.url : undefined
 }
 
-export function createNetworkError(url?: string): ApiNetworkError {
-  return {
+// Returns an ApiError instance (not a plain object) so a network failure is also a
+// real Error — same rationale as ApiError above. The status:0 / code:'NETWORK_ERROR'
+// fields are preserved, so the isNetworkError duck-type guard still matches it.
+export function createNetworkError(url?: string): ApiError {
+  return new ApiError({
     status: 0,
     code: 'NETWORK_ERROR',
     message: NETWORK_ERROR_MESSAGE,
     offline: isBrowserOffline(),
     ...(url ? { url } : {})
-  }
+  })
 }
 
-export function networkErrorFromAxios(error: AxiosError): ApiNetworkError {
+export function networkErrorFromAxios(error: AxiosError): ApiError {
   return createNetworkError(error.config?.url)
 }

--- a/frontend/src/api/client.ts
+++ b/frontend/src/api/client.ts
@@ -6,7 +6,7 @@
 import axios, { AxiosInstance, AxiosError, InternalAxiosRequestConfig, AxiosResponse } from 'axios'
 import type { ApiResponse } from '@/types'
 import { getLocale } from '@/i18n'
-import { createNetworkError, isNetworkError, networkErrorFromAxios, requestUrlFromError } from './client.tk'
+import { createApiError, createNetworkError, isNetworkError, networkErrorFromAxios, requestUrlFromError } from './client.tk'
 
 // ==================== Axios Instance Configuration ====================
 
@@ -95,13 +95,13 @@ apiClient.interceptors.response.use(
       } else {
         // API error
         const resp = apiResponse as unknown as Record<string, unknown>
-        return Promise.reject({
+        return Promise.reject(createApiError({
           status: response.status,
           code: apiResponse.code,
           message: apiResponse.message || 'Unknown error',
-          reason: resp.reason,
-          metadata: resp.metadata,
-        })
+          reason: resp.reason as string | undefined,
+          metadata: resp.metadata as Record<string, unknown> | undefined,
+        }))
       }
     }
     return response
@@ -141,12 +141,12 @@ apiClient.interceptors.response.use(
           window.location.href = '/admin/settings'
         }
 
-        return Promise.reject({
+        return Promise.reject(createApiError({
           status,
           code: 'OPS_DISABLED',
           message: apiData.message || error.message,
           url
-        })
+        }))
       }
 
       if (status === 423 && apiData.code === 'ADMIN_COMPLIANCE_ACK_REQUIRED') {
@@ -158,12 +158,12 @@ apiClient.interceptors.response.use(
           // ignore event failures
         }
 
-        return Promise.reject({
+        return Promise.reject(createApiError({
           status,
           code: apiData.code,
           message: apiData.message || error.message,
           metadata: apiData.metadata,
-        })
+        }))
       }
 
       // 401: Try to refresh the token if we have a refresh token
@@ -190,11 +190,11 @@ apiClient.interceptors.response.use(
                   resolve(apiClient(originalRequest))
                 } else {
                   // Refresh failed, reject with original error
-                  reject({
+                  reject(createApiError({
                     status,
                     code: apiData.code,
                     message: apiData.message || apiData.detail || error.message
-                  })
+                  }))
                 }
               })
             })
@@ -262,11 +262,11 @@ apiClient.interceptors.response.use(
               window.location.href = '/login'
             }
 
-            return Promise.reject({
+            return Promise.reject(createApiError({
               status: 401,
               code: 'TOKEN_REFRESH_FAILED',
               message: 'Session expired. Please log in again.'
-            })
+            }))
           }
         }
 
@@ -295,14 +295,14 @@ apiClient.interceptors.response.use(
       }
 
       // Return structured error
-      return Promise.reject({
+      return Promise.reject(createApiError({
         status,
         code: apiData.code,
         reason: apiData.reason,
         error: apiData.error,
         message: apiData.message || apiData.detail || error.message,
         metadata: apiData.metadata,
-      })
+      }))
     }
 
     // Network error

--- a/frontend/src/components/admin/user/InviteTrialModal.vue
+++ b/frontend/src/components/admin/user/InviteTrialModal.vue
@@ -112,6 +112,7 @@ import { computed, ref, watch } from 'vue'
 import { useI18n } from 'vue-i18n'
 import { useAppStore } from '@/stores/app'
 import { useTkInviteTrial } from '@/composables/useTkInviteTrial'
+import { unknownToErrorMessage } from '@/utils/authError'
 import BaseDialog from '@/components/common/BaseDialog.vue'
 import TrialResultCards from './TrialResultCards.vue'
 
@@ -184,7 +185,10 @@ const onSubmit = async () => {
     await submit()
     emit('success') // refresh the user list behind the modal
   } catch (e) {
-    errorText.value = e instanceof Error ? e.message : String(e)
+    // The axios interceptor (api/client.ts) rejects with a flattened plain object
+    // { status, code, message, ... }, not an Error — so String(e) rendered
+    // "[object Object]" in the modal. Pull the backend message via the helper.
+    errorText.value = unknownToErrorMessage(e, t('admin.users.inviteTrial.submitFailed'))
   }
 }
 
@@ -196,7 +200,7 @@ const onSavePreset = async () => {
     appStore.showSuccess(t('admin.users.inviteTrial.presetSaved'))
     form.presetName = name
   } catch (e) {
-    errorText.value = e instanceof Error ? e.message : String(e)
+    errorText.value = unknownToErrorMessage(e, t('admin.users.inviteTrial.savePresetFailed'))
   }
 }
 

--- a/frontend/src/composables/__tests__/useServableModels.spec.ts
+++ b/frontend/src/composables/__tests__/useServableModels.spec.ts
@@ -46,6 +46,19 @@ describe('useServableModels', () => {
     expect(error.value).toContain('boom')
   })
 
+  it('surfaces the message from the interceptor-flattened error object (not [object Object])', async () => {
+    // api/client.ts rejects with a plain object { status, code, message }, not an
+    // Error — String(e) used to store "[object Object]" here.
+    mockGet.mockRejectedValueOnce({ status: 500, code: 'INTERNAL', message: 'candidate fetch failed' })
+    const { ensureLoaded, error } = useServableModels()
+
+    await ensureLoaded('gemini')
+
+    expect(servableModelsFor('gemini')).toEqual([])
+    expect(error.value).toBe('candidate fetch failed')
+    expect(error.value).not.toBe('[object Object]')
+  })
+
   it('non-API platform is a no-op (no fetch, undefined list → caller uses its static fallback)', async () => {
     const { ensureLoaded } = useServableModels()
     await ensureLoaded('zhipu')

--- a/frontend/src/composables/useServableModels.ts
+++ b/frontend/src/composables/useServableModels.ts
@@ -1,5 +1,6 @@
 import { reactive, ref } from 'vue'
 import { getModelsListCandidates } from '@/api/admin/groups'
+import { unknownToErrorMessage } from '@/utils/authError'
 import type { GroupPlatform } from '@/types'
 
 // TK (R-003, follow-up to PR #752): the self-healing servable model lists for the
@@ -57,7 +58,10 @@ export function useServableModels() {
     try {
       cache[backend] = await getModelsListCandidates(0, backend)
     } catch (e) {
-      error.value = e instanceof Error ? e.message : String(e)
+      // The axios interceptor (api/client.ts) rejects with a flattened plain
+      // object { status, code, message, ... }, not an Error — so String(e) would
+      // store "[object Object]". Pull the backend message via the shared helper.
+      error.value = unknownToErrorMessage(e, 'Failed to load servable models')
       cache[backend] = [] // loaded-empty; the selector's custom input stays the escape hatch
     } finally {
       inflight.delete(backend)

--- a/frontend/src/composables/useTkEdgeAccounts.ts
+++ b/frontend/src/composables/useTkEdgeAccounts.ts
@@ -14,8 +14,10 @@
  */
 
 import { ref, computed, onMounted, onBeforeUnmount } from 'vue'
+import { useI18n } from 'vue-i18n'
 import { useIntervalFn } from '@vueuse/core'
 import { adminAPI } from '@/api/admin'
+import { unknownToErrorMessage } from '@/utils/authError'
 import type { EdgeAccountsResult } from '@/api/admin/edgeAccounts'
 
 // Selectable auto-refresh cadences (seconds), matching the admin accounts page. The
@@ -80,6 +82,7 @@ export function mergeEdges(current: EdgeAccountsResult[], next: EdgeAccountsResu
 // platform). The page defaults to it so the overview is complete; the filter
 // narrows to a single platform.
 export function useTkEdgeAccounts(initialPlatform = 'all') {
+  const { t } = useI18n()
   const platform = ref(initialPlatform)
   const edges = ref<EdgeAccountsResult[]>([])
   const loading = ref(false)
@@ -178,7 +181,12 @@ export function useTkEdgeAccounts(initialPlatform = 'all') {
       etag.value = res.etag
       lastFetchedAt.value = new Date()
     } catch (e: unknown) {
-      error.value = e instanceof Error ? e.message : String(e)
+      // The axios response interceptor (api/client.ts) rejects with a *flattened
+      // plain object* { status, code, message, ... }, NOT an Error instance — so
+      // `String(e)` here rendered "[object Object]" in the error banner. Pull the
+      // backend message off that shape via the shared helper, like the other TK
+      // composables (useNewApiChannelTypes.ts) do.
+      error.value = unknownToErrorMessage(e, t('admin.edgeAccounts.loadFailed'))
       edges.value = []
       etag.value = null
     } finally {

--- a/frontend/src/i18n/locales/en.ts
+++ b/frontend/src/i18n/locales/en.ts
@@ -3322,6 +3322,7 @@ export default {
       allPlatforms: 'All platforms',
       manageAccounts: 'Manage accounts',
       manageFailed: 'Failed to open this edge for management',
+      loadFailed: 'Failed to load edge accounts',
       handoff: {
         signingIn: 'Signing in to this edge…',
         failed: 'Sign-in failed or the link expired.',

--- a/frontend/src/i18n/locales/zh.ts
+++ b/frontend/src/i18n/locales/zh.ts
@@ -3396,6 +3396,7 @@ export default {
       allPlatforms: '全部平台',
       manageAccounts: '管理账号',
       manageFailed: '打开该 edge 管理页失败',
+      loadFailed: '加载 edge 账号失败',
       handoff: {
         signingIn: '正在登录该 edge…',
         failed: '登录失败或链接已过期。',

--- a/frontend/src/i18n/tk/inviteTrial.tk.ts
+++ b/frontend/src/i18n/tk/inviteTrial.tk.ts
@@ -49,7 +49,9 @@ const en: InviteTrialOverlay = {
         apiKey: 'API key',
         expiresAt: 'Expires',
         createMore: 'Create more',
-        presetSaved: 'Preset saved'
+        presetSaved: 'Preset saved',
+        submitFailed: 'Failed to create trial credentials',
+        savePresetFailed: 'Failed to save preset'
       }
     }
   }
@@ -96,7 +98,9 @@ const zh: InviteTrialOverlay = {
         apiKey: 'API Key',
         expiresAt: '到期',
         createMore: '继续创建',
-        presetSaved: '方案已保存'
+        presetSaved: '方案已保存',
+        submitFailed: '创建试用凭证失败',
+        savePresetFailed: '保存方案失败'
       }
     }
   }

--- a/frontend/src/utils/__tests__/authError.spec.ts
+++ b/frontend/src/utils/__tests__/authError.spec.ts
@@ -1,5 +1,5 @@
 import { describe, expect, it } from 'vitest'
-import { buildAuthErrorMessage } from '@/utils/authError'
+import { buildAuthErrorMessage, unknownToErrorMessage } from '@/utils/authError'
 
 describe('buildAuthErrorMessage', () => {
   it('prefers response detail message when available', () => {
@@ -86,5 +86,20 @@ describe('buildAuthErrorMessage', () => {
       }
     )
     expect(message).toBe('refresh hint')
+  })
+})
+
+describe('unknownToErrorMessage', () => {
+  // Regression: the axios response interceptor (api/client.ts) rejects with a
+  // *flattened plain object* { status, code, message } — NOT an Error instance.
+  // Callers that did `String(e)` rendered "[object Object]" (Edge Accounts banner).
+  it('extracts message from the interceptor-flattened error object', () => {
+    const flattened = { status: 500, code: 'INTERNAL', message: 'edge fan-out failed' }
+    expect(unknownToErrorMessage(flattened, 'fallback')).toBe('edge fan-out failed')
+    expect(unknownToErrorMessage(flattened, 'fallback')).not.toBe('[object Object]')
+  })
+
+  it('uses fallback when the object carries no message', () => {
+    expect(unknownToErrorMessage({ status: 500, code: 'INTERNAL' }, 'fallback')).toBe('fallback')
   })
 })

--- a/scripts/sentinels/frontend-tk.json
+++ b/scripts/sentinels/frontend-tk.json
@@ -832,6 +832,21 @@
         "api_key_id"
       ],
       "rationale": "PR #792: the TK-only conversation-export API client. qaTrajAPI.exportKey posts {api_key_id, format:'v2'} to the per-key self-export endpoint; an upstream merge replacing the api/ layer or dropping this module would silently sever the export wiring (KeysView import breaks loud, but a merge that rewrites both would not)."
+    },
+    {
+      "path": "frontend/src/api/client.tk.ts",
+      "must_contain": [
+        "class ApiError extends Error",
+        "export function createApiError"
+      ],
+      "rationale": "PR #803: ApiError is the TK-only Error subclass the axios response interceptor rejects with, so `e instanceof Error` holds across the whole app and no call site renders \"[object Object]\". It carries the flattened backend fields (status/code/message/reason/error/metadata) as enumerable own properties. If an upstream merge replaced client.tk.ts or dropped this class, client.ts's createApiError import would break loud — but a merge rewriting both would silently revert every error banner to the [object Object] bug. createNetworkError also returns an ApiError instance; the isNetworkError duck-type guard (status===0) still matches it."
+    },
+    {
+      "path": "frontend/src/api/client.ts",
+      "must_contain": [
+        "createApiError("
+      ],
+      "rationale": "PR #803: the upstream-shaped axios response interceptor must reject with createApiError(...) (a real Error), NOT a plain object. This is the load-bearing injection point — an upstream merge that restores the original `Promise.reject({ status, code, message })` plain-object shape would compile fine and silently reintroduce the app-wide [object Object] rendering bug at every `e instanceof Error ? e.message : String(e)` call site. Anchoring the createApiError( call makes that revert fail the merge gate instead of shipping silently."
     }
   ]
 }


### PR DESCRIPTION
## 问题

`/admin/edge-accounts` 等页面在请求失败时把错误条渲染成 `[object Object]`(见截图),吞掉了后端真实报错。

## 根因(单一)

`frontend/src/api/client.ts` 的 axios 响应拦截器出错时 `Promise.reject({ status, code, message, ... })` 抛的是**纯对象**而非 `Error` 实例。于是全站任何 `e instanceof Error ? e.message : String(e)` 都走 `String(e)` → `"[object Object]"`。

## 修法:在源头修对(而非每个调用点贴创可贴)

最初的提交先用 `unknownToErrorMessage` helper 修了 3 处调用点——但那是退化版。本 PR 进一步在**拦截器源头**修:让 reject 抛一个真正的 `Error` 子类,使 `e instanceof Error` 全站成立,所有调用点(含未改的、将来新增的)一次免疫,删掉「每个开发者记得用 helper」这条靠自觉的纪律(设计即工作方式)。

- **`client.tk.ts`(TK-only)**:新增 `ApiError extends Error` + `createApiError` 工厂,携带后端展平字段(status/code/message/reason/error/metadata)为**可枚举 own 属性**(message 显式 redefine 为可枚举,使 spread/JSON.stringify 也保留——严格 ⊇ 旧纯对象)。`createNetworkError` 也改返回 ApiError,`isNetworkError` 鸭子检查(status===0)仍匹配。
- **`client.ts`(upstream,薄注入)**:6 处 `Promise.reject({…})` → `Promise.reject(createApiError({…}))`,一个 import + 每处包一层,无逻辑搬动。
- **`scripts/sentinels/frontend-tk.json`**:锚定 `class ApiError extends Error` / `createApiError`(client.tk.ts)与 `createApiError(`(client.ts),使未来 upstream merge 若把 reject 退回纯对象会**门禁失败**而非静默退回 bug。

### consumer 零改动(已审计)

`utils/apiError.ts` 的 object 分支在 instanceof 分支之前、且走直接字段访问(与可枚举无关);`authError.ts`、2 处 `error.status===409 && error.error==='mixed_channel_warning'` 同为直接字段访问 → 全部兼容。全仓**无** `JSON.stringify(err)` / `{...err}` / `Object.keys(err)` 依赖(Explore 全仓扫确认)。所有 16 个 api/ consumer 测试 + 受影响 spec 全绿。

### 已知行为变化(正向后果,非回归)

全站 ~13 处原本对 API 错误显示 `[object Object]` 或 i18n 通用文案处,现在显示**后端真实 message**(后端 message 走 `Accept-Language` 已本地化)。3 处 `unknownToErrorMessage` 采纳保留(仍正确,额外处理 reason→i18n / cancel error)。

## 验证

- `pnpm vitest run`(新增 `clientTk.spec.ts` ApiError 单测 + `client.spec.ts` 拦截器级「reject 是 Error 实例」守卫 + authError/useServableModels/inviteTrialLocales/useTkEdgeAccounts 回归)全绿。
- `vue-tsc --noEmit` + `eslint` clean。
- `pnpm build` 重生成 embedded dist + `frontend-source.json`。
- `PREFLIGHT_BASE=origin/main scripts/preflight.sh` PASS(含 sentinel / upstream-override / registry-update / dist-freshness)。

## 覆写门禁

本 PR 在 `scripts/sentinels/frontend-tk.json` **真实添加了 sentinel 锚点**(option (a) — 真覆盖保护),pin 住 client.ts / client.tk.ts 的根修注入点。upstream-override 与 registry-update 两道门禁均经此机械满足,**不依赖任何 marker 旁路**。

🤖 Generated with [Claude Code](https://claude.com/claude-code)
