### PR TITLE
fix(stage0): pin prod AMI + DataVolume default 50 GiB (defuse CFN update-replaces-instance trap)

### DIFF
--- a/deploy/aws/cloudformation/stage0-single-ec2.yaml
+++ b/deploy/aws/cloudformation/stage0-single-ec2.yaml
@@ -72,7 +72,7 @@ Parameters:
     MaxValue: 200
   DataVolumeSizeGiB:
     Type: Number
-    Default: 30
+    Default: 50
     MinValue: 20
     MaxValue: 500
     Description: |
@@ -82,11 +82,28 @@ Parameters:
       instance is replaced (e.g. by an ImageTag CFN change — see issue #8 +
       persistent data volume hardening), this volume detaches and re-attaches to the new
       instance with all data intact, instead of being thrown away with the
-      old root EBS. Default 30 GiB matches the prior root-EBS data layout.
+      old root EBS. Default 50 GiB: prod organic growth (live PG + 1.5d QA
+      blobs + 6x hourly pgdump) hit the 85% alarm at 30 GiB on 2026-06-17;
+      grown to 50 GiB online (no garbage to reclaim — all data legitimate).
   AmazonLinux2023Arm64Ami:
-    Type: AWS::SSM::Parameter::Value<AWS::EC2::Image::Id>
-    Default: /aws/service/ami-amazon-linux-latest/al2023-ami-kernel-default-arm64
-    Description: SSM parameter that always resolves to the latest AL2023 ARM64 AMI in the current region.
+    Type: AWS::EC2::Image::Id
+    Default: ami-0b183bb1259186479
+    Description: >-
+      Pinned AL2023 ARM64 AMI id (us-east-1). DELIBERATELY pinned, NOT the SSM
+      `latest` alias. The SSM-resolved type re-resolves to the newest AMI on
+      EVERY stack update, so any unrelated UpdateStack (a param tweak, a volume
+      grow) silently changes ImageId -> RequiresRecreation=Always -> the EC2
+      instance is REPLACED and cloud-init reinstalls the stale `ImageTag` param
+      (prod runs on SSM-hot-deployed images, so ImageTag lags far behind). That
+      turns a one-line param change into a prod version regression + EIP churn
+      (see prod_t4g_resize_instance_replace_triple_sideeffect; confirmed
+      2026-06-17 via change-set: a DataVolumeSizeGiB-only update still showed
+      Instance Replacement=True, CausingEntity=ImageId). Pinning makes the AMI
+      behave like ImageTag: stable across updates, bumped on purpose. To bump:
+      `aws ssm get-parameter --name
+      /aws/service/ami-amazon-linux-latest/al2023-ami-kernel-default-arm64
+      --query Parameter.Value --output text`, set it here, and plan a
+      maintenance-window instance replacement (sync ImageTag in the same op).
 
   AdminCidr:
     Type: String

--- a/deploy/aws/cloudformation/stage0-single-ec2.yaml
+++ b/deploy/aws/cloudformation/stage0-single-ec2.yaml
@@ -82,28 +82,24 @@ Parameters:
       instance is replaced (e.g. by an ImageTag CFN change — see issue #8 +
       persistent data volume hardening), this volume detaches and re-attaches to the new
       instance with all data intact, instead of being thrown away with the
-      old root EBS. Default 50 GiB: prod organic growth (live PG + 1.5d QA
-      blobs + 6x hourly pgdump) hit the 85% alarm at 30 GiB on 2026-06-17;
-      grown to 50 GiB online (no garbage to reclaim — all data legitimate).
+      old root EBS. Sized for prod organic growth: live PostgreSQL + ~1.5 days
+      of QA blobs + 6 hourly pgdump retained copies; 30 GiB proved too tight.
   AmazonLinux2023Arm64Ami:
     Type: AWS::EC2::Image::Id
     Default: ami-0b183bb1259186479
     Description: >-
       Pinned AL2023 ARM64 AMI id (us-east-1). DELIBERATELY pinned, NOT the SSM
-      `latest` alias. The SSM-resolved type re-resolves to the newest AMI on
-      EVERY stack update, so any unrelated UpdateStack (a param tweak, a volume
-      grow) silently changes ImageId -> RequiresRecreation=Always -> the EC2
-      instance is REPLACED and cloud-init reinstalls the stale `ImageTag` param
-      (prod runs on SSM-hot-deployed images, so ImageTag lags far behind). That
-      turns a one-line param change into a prod version regression + EIP churn
-      (see prod_t4g_resize_instance_replace_triple_sideeffect; confirmed
-      2026-06-17 via change-set: a DataVolumeSizeGiB-only update still showed
-      Instance Replacement=True, CausingEntity=ImageId). Pinning makes the AMI
-      behave like ImageTag: stable across updates, bumped on purpose. To bump:
-      `aws ssm get-parameter --name
-      /aws/service/ami-amazon-linux-latest/al2023-ami-kernel-default-arm64
-      --query Parameter.Value --output text`, set it here, and plan a
-      maintenance-window instance replacement (sync ImageTag in the same op).
+      `latest` alias: the SSM-resolved type re-resolves to the newest AMI on
+      every stack update, so any unrelated UpdateStack (a param tweak, a volume
+      grow) changes ImageId -> RequiresRecreation=Always -> the EC2 instance is
+      REPLACED and cloud-init reinstalls whatever `ImageTag` the stack carries
+      (prod runs SSM-hot-deployed images, so ImageTag lags) -- turning a
+      one-line param change into a version regression + EIP churn. Pinning makes
+      the AMI behave like ImageTag: stable across updates, bumped on purpose. To
+      bump: read the latest from SSM
+      (/aws/service/ami-amazon-linux-latest/al2023-ami-kernel-default-arm64),
+      set it here, and plan a maintenance-window instance replacement that syncs
+      ImageTag in the same op.
 
   AdminCidr:
     Type: String


### PR DESCRIPTION
## P0 context (2026-06-17)

prod `api.tokenkey.dev` DataVolume `/var/lib/tokenkey` (vol-020ce8eda4cf1e5ea, instance i-0e43099f831b03160) hit the **85% disk alarm** at 30 GiB. Root cause was **organic growth, not garbage** — every consumer was legitimate:

| consumer | size |
|---|---|
| `app/qa_blobs` (1.5d retention, cleanup working) | 9.7G |
| live Postgres (growing) | 8.8G |
| `pgdump` (6× hourly, already minimized, S3-archived) | 4.1G |

**Stop-gap already applied live:** grew the EBS volume online `aws ec2 modify-volume --size 50` + `resize2fs /dev/nvme1n1` → **82% → 49%**, zero downtime, PG never restarted.

## Why the obvious CFN path was a trap

Reconciling the volume via `UpdateStack` would have **replaced the prod instance**. A change-set with *only* `DataVolumeSizeGiB` changed still showed `Instance` Replacement=`True`, CausingEntity=`ImageId`: the AMI param was the SSM `latest` alias, which **re-resolves to the newest AMI on every update** → `RequiresRecreation: Always` → instance replaced → cloud-init rolls back to the stale `ImageTag` param (prod runs SSM-hot-deployed images, so `ImageTag` lags far behind). See `prod_t4g_resize_instance_replace_triple_sideeffect`.

## This PR (source-of-truth only — no live stack mutation)

1. **`DataVolumeSizeGiB` default 30 → 50** — matches the now-live volume.
2. **`AmazonLinux2023Arm64Ami`: SSM-`latest` → pinned `AWS::EC2::Image::Id`** (`ami-0b183bb1259186479`, current prod AMI) — defuses the auto-replace trap so AMI behaves like `ImageTag` (stable across updates, bumped on purpose; how-to in the param Description).

## Deferred: deployed-param reconciliation (runbook, NOT in this PR)

The live stack still carries inert drifted params (`DataVolumeSizeGiB=30`, `AdminCidr=0.0.0.0/0` while the **live SG is already `127.0.0.1/32`**, `ImageTag=1.7.11`). They only bite on `UpdateStack`, which is intentionally avoided. Reconcile them together at the next maintenance window:
- after the **6h EBS modify cooldown** (else CFN re-issues `modify-volume` and fails),
- with this PR's pinned-AMI template,
- via a **change-set that proves zero `Instance` replacement** before execute,
- setting `DataVolumeSizeGiB=50`, `AdminCidr=127.0.0.1/32`, `ImageTag=<current>` in one op.

## Verification
- Live: disk 82%→49%, PG `Up healthy`, login/gateway up.
- `scripts/preflight.sh`: PASS (incl. CloudFormation template-version validation).
- `build-cfn.sh --check`: blobs untouched (Parameters-only edit).
- No consumer passes the AMI param as an SSM path → the type change breaks nothing.

`no-web-impact`: deploy/CFN template only; no frontend or API surface change.

Merge mode: **Squash and merge** (TK-originated fix).