### PR TITLE
feat(ops): extend pool-exhausted P0 alert from anthropic-only to gpt/google

### DIFF
--- a/backend/internal/service/account_incident_notifier_tk_pool.go
+++ b/backend/internal/service/account_incident_notifier_tk_pool.go
@@ -48,12 +48,26 @@ func buildPoolExhaustedText(site, platform string, trigger *Account, until time.
 	if !until.IsZero() {
 		untilText = formatAlertTime(until)
 	}
-	return fmt.Sprintf("**节点**：%s\n**平台**：%s\n**事件**：该平台可调度账号数已降为 0,所有流量将快速失败(429)\n**压垮池的最后账号**：%s\n**该账号 reason**：%s\n**该账号冷却至**：%s\n**时间**：%s\n\n**建议**：先跑 ops/observability/scan-edge-health.sh 看各 edge 自身健康;若 reason 是 anthropic_upstream_error 且各账号几乎同秒进入冷却,优先怀疑单请求确定性 429(如长上下文 usage-credits 策略拒绝)被 failover 扇出,而非账号/edge 真实故障。",
+	return fmt.Sprintf("**节点**：%s\n**平台**：%s\n**事件**：该平台可调度账号数已降为 0,所有流量将快速失败(429)\n**压垮池的最后账号**：%s\n**该账号 reason**：%s\n**该账号冷却至**：%s\n**时间**：%s\n\n**建议**：%s",
 		escapeFeishuText(site),
 		escapeFeishuText(strings.TrimSpace(platform)),
 		escapeFeishuText(triggerLabel),
 		escapeFeishuText(strings.TrimSpace(reason)),
 		escapeFeishuText(untilText),
 		escapeFeishuText(formatAlertTime(now)),
+		// 建议文本与既有非转义字面量同形(含 / 路径),不过 escapeFeishuText。
+		poolExhaustedAdvice(platform),
 	)
+}
+
+// poolExhaustedAdvice 按平台给出"池全空"时的处置建议。anthropic 是 prod→edge
+// 镜像中继形态,排障先看各 edge 自身健康 + failover 扇出连锁(2026-06-11);而
+// openai(gpt)/gemini(google) 等是本地账号池,没有 edge 拓扑,scan-edge-health.sh
+// 对它们无意义——处置就是直接为该平台补充账号(线上 2026-06-17 反馈"我就开始配号"),
+// 或核对席位是否被打满。给错平台的 CTA 会在事故里把运维带偏,故按平台分流。
+func poolExhaustedAdvice(platform string) string {
+	if strings.TrimSpace(platform) == PlatformAnthropic {
+		return "先跑 ops/observability/scan-edge-health.sh 看各 edge 自身健康;若 reason 是 anthropic_upstream_error 且各账号几乎同秒进入冷却,优先怀疑单请求确定性 429(如长上下文 usage-credits 策略拒绝)被 failover 扇出,而非账号/edge 真实故障。"
+	}
+	return "该平台号池已空,需立即为该平台补充可调度账号;若现有账号均健康却仍不可调度,多为并发/会话席位被打满或集中冷却,核对各账号 concurrency/max_sessions 余量与冷却状态。"
 }

--- a/backend/internal/service/account_incident_notifier_tk_pool_test.go
+++ b/backend/internal/service/account_incident_notifier_tk_pool_test.go
@@ -29,6 +29,8 @@ func TestNotifyPlatformPoolExhausted_SendsP0AndDedupes(t *testing.T) {
 	require.Contains(t, body, "平台池全不可调度")
 	require.Contains(t, body, PlatformAnthropic)
 	require.Contains(t, body, "cc-us7")
+	// anthropic CTA keeps the prod→edge relay remediation.
+	require.Contains(t, body, "scan-edge-health.sh")
 
 	// Cooldown-storm shape: every subsequent account block re-triggers the
 	// pool check; only the first card within the dedupe window goes out.
@@ -44,4 +46,11 @@ func TestNotifyPlatformPoolExhausted_SendsP0AndDedupes(t *testing.T) {
 		t.Fatal("second-platform pool-exhausted card was not sent")
 	}
 	require.Equal(t, 2, doer.callCount())
+	// openai(gpt) has no edge topology: the CTA must point at adding accounts /
+	// checking seats, NOT the anthropic-only edge-health script (would misdirect
+	// ops during a gpt incident — 2026-06-17).
+	openaiBody := doer.lastBody()
+	require.Contains(t, openaiBody, PlatformOpenAI)
+	require.Contains(t, openaiBody, "补充可调度账号")
+	require.NotContains(t, openaiBody, "scan-edge-health.sh")
 }

--- a/backend/internal/service/ratelimit_service_tk_pool_exhausted.go
+++ b/backend/internal/service/ratelimit_service_tk_pool_exhausted.go
@@ -12,18 +12,35 @@ import (
 // 的流量从这一刻起全部快速失败,必须即时 P0(prod 2026-06-11 全池冷却事件中,
 // 该信号本可比冷却自愈早 ~9 分钟暴露问题)。检查异步执行,不阻塞请求路径;
 // 延迟一拍是为了等触发本次通知的 SetTempUnschedulable 写入提交,避免查到
-// 账号自身仍可调度的假阴性。当前只对 anthropic 启用(镜像池形态最受 failover
-// 扇出连锁影响);其他平台如需纳入,把 platform 判断改成集合即可。
+// 账号自身仍可调度的假阴性。
 const (
 	tkPoolExhaustedCheckDelay   = 2 * time.Second
 	tkPoolExhaustedCheckTimeout = 5 * time.Second
 )
 
+// tkPoolExhaustedPlatforms 是启用"平台池全不可调度"即时 P0 检查的平台集合。
+// anthropic 是镜像池形态、最受 failover 扇出连锁影响(prod 2026-06-11);
+// openai(gpt)/gemini(google) 同为有专属账号池的平台——号池被打满同样让该平台
+// 流量从那一刻起全部快速失败(429,见线上 2026-06-17 反馈"gpt 号池满了"),
+// 纳入同一即时 P0 通道。其他平台(newapi/kiro/grok/antigravity)如需纳入,
+// 加进本集合即可。
+var tkPoolExhaustedPlatforms = map[string]struct{}{
+	PlatformAnthropic: {},
+	PlatformOpenAI:    {},
+	PlatformGemini:    {},
+}
+
+// tkPoolExhaustedEnabled 报告某平台是否启用池级全不可调度即时 P0 检查。
+func tkPoolExhaustedEnabled(platform string) bool {
+	_, ok := tkPoolExhaustedPlatforms[platform]
+	return ok
+}
+
 func (s *RateLimitService) tkCheckPlatformPoolExhausted(account *Account, until time.Time, reason string) {
 	if s == nil || account == nil || s.incidentNotifier == nil || s.accountRepo == nil {
 		return
 	}
-	if account.Platform != PlatformAnthropic {
+	if !tkPoolExhaustedEnabled(account.Platform) {
 		return
 	}
 	platform := account.Platform

--- a/backend/internal/service/ratelimit_service_tk_pool_exhausted_test.go
+++ b/backend/internal/service/ratelimit_service_tk_pool_exhausted_test.go
@@ -75,21 +75,49 @@ func TestTkPlatformPoolExhaustedCheck_QuietOnQueryError(t *testing.T) {
 	require.Empty(t, notifier.pools, "query failure must fail quiet, not page")
 }
 
-// The async wrapper only arms for anthropic; other platforms must not even
-// query (mirror-pool fan-out is the failure shape this watches).
-func TestTkCheckPlatformPoolExhausted_NonAnthropicIsNoop(t *testing.T) {
+// The pool-exhausted check is enabled per-platform; platforms outside the set
+// (kiro/newapi/grok/antigravity) must not even query the repo.
+func TestTkCheckPlatformPoolExhausted_DisabledPlatformIsNoop(t *testing.T) {
 	repo := &poolExhaustedRepoStub{}
 	notifier := &poolExhaustedNotifierStub{}
 	service := NewRateLimitService(repo, nil, &config.Config{}, nil, nil)
 	service.SetAccountIncidentNotifier(notifier)
 
-	service.tkCheckPlatformPoolExhausted(&Account{ID: 1, Platform: PlatformOpenAI}, time.Now(), "429")
+	service.tkCheckPlatformPoolExhausted(&Account{ID: 1, Platform: PlatformKiro}, time.Now(), "429")
 	service.tkCheckPlatformPoolExhausted(nil, time.Now(), "429")
 
-	// The anthropic path is async (delay + goroutine), so a non-anthropic
+	// The armed path is async (delay + goroutine), so a disabled-platform
 	// no-op is observable as: no goroutine ever queries the repo. Give any
 	// stray goroutine a beat to surface before asserting.
 	time.Sleep(50 * time.Millisecond)
 	require.Zero(t, repo.calls)
 	require.Empty(t, notifier.pools)
+}
+
+// The 95%-pool incident (2026-06-17) extended the immediate P0 from
+// anthropic-only to the gpt/google pools: openai + gemini must now be armed,
+// while non-pool platforms stay out.
+func TestTkPoolExhaustedEnabled_PlatformSet(t *testing.T) {
+	for _, p := range []string{PlatformAnthropic, PlatformOpenAI, PlatformGemini} {
+		require.Truef(t, tkPoolExhaustedEnabled(p), "platform %q must be armed for pool-exhausted P0", p)
+	}
+	for _, p := range []string{PlatformKiro, PlatformNewAPI, PlatformGrok, PlatformAntigravity, ""} {
+		require.Falsef(t, tkPoolExhaustedEnabled(p), "platform %q must not be armed", p)
+	}
+}
+
+// The sync check body is platform-agnostic (gating lives in the async wrapper),
+// so an empty openai/gemini pool fires the P0 just like anthropic does.
+func TestTkPlatformPoolExhaustedCheck_FiresForOpenAIAndGemini(t *testing.T) {
+	for _, platform := range []string{PlatformOpenAI, PlatformGemini} {
+		repo := &poolExhaustedRepoStub{schedulable: nil}
+		notifier := &poolExhaustedNotifierStub{}
+		service := NewRateLimitService(repo, nil, &config.Config{}, nil, nil)
+		service.SetAccountIncidentNotifier(notifier)
+		trigger := &Account{ID: 16, Platform: platform, Type: AccountTypeAPIKey}
+
+		service.tkPlatformPoolExhaustedCheck(context.Background(), platform, trigger, time.Now().Add(10*time.Minute), "429")
+
+		require.Equalf(t, []string{platform}, notifier.pools, "empty %s pool must page P0", platform)
+	}
 }

--- a/scripts/sentinels/gateway-tk.json
+++ b/scripts/sentinels/gateway-tk.json
@@ -2628,6 +2628,18 @@
         "len(account.GetModelMapping()) == 0 && !tkIsForwardableAnthropicModelName(requestedModel)"
       ],
       "rationale": "TK fix (PR #806): the injection point in isModelSupportedByAccount that routes a cross-vendor model name on a passthrough (empty model_mapping) anthropic direct account to the local Path A 400 instead of forwarding it to api.anthropic.com. Pinning the full guard expression also anchors the passthrough-only scope (len(GetModelMapping())==0) so a refactor cannot silently widen it to over-block mapped accounts or narrow it to re-open the leak. Pairs with the predicate sentinel on gateway_service_tk_unsupported_model.go."
+    },
+    {
+      "path": "backend/internal/service/ratelimit_service_tk_pool_exhausted.go",
+      "must_contain": [
+        "var tkPoolExhaustedPlatforms = map[string]struct{}{",
+        "PlatformOpenAI",
+        "PlatformGemini",
+        "func tkPoolExhaustedEnabled(platform string) bool {",
+        "if !tkPoolExhaustedEnabled(account.Platform) {",
+        "s.incidentNotifier.NotifyPlatformPoolExhausted(platform, trigger, until, reason)"
+      ],
+      "rationale": "Platform-pool-exhausted P0 enablement set (2026-06-17 'gpt 号池满了' incident). The immediate P0 card was anthropic-only until this; tkPoolExhaustedPlatforms now also holds PlatformOpenAI + PlatformGemini so an emptied gpt/google pool's fast-fail-to-429 transition pages ops at once. PlatformOpenAI/PlatformGemini appear nowhere else in this file, so the sentinel mechanically protects pool coverage: an upstream merge or 'simplify' refactor that drops either key (reverting to anthropic-only and re-blinding gpt/google) makes the substring vanish and fails the gate. The tkPoolExhaustedEnabled predicate + the guard call site + the NotifyPlatformPoolExhausted dispatch are anchored too so the membership check can't be bypassed by removing the guard. Pairs with the existing ratelimit_service.go (tkCheckPlatformPoolExhausted hook) and account_incident_notifier_tk_pool.go (card) sentinels."
     }
   ]
 }


### PR DESCRIPTION
## 背景

线上 2026-06-17 反馈 **"gpt 号池满了"** → 一堆客户端 429。复盘发现：「平台池全不可调度」即时 P0 飞书卡（`NotifyPlatformPoolExhausted`，2026-06-11 anthropic 全池冷却事故时建的）**只对 anthropic 武装**——openai(gpt)/gemini(google) 号池被打满走的是同一个失败形态（最后一个可调度账号被封的那一刻，该平台流量全部快速失败 429），却没有任何池级告警。

这是运维要的"预警"的**第一半**：池满那一刻的即时 P0。第二半（95% headroom 提前预警）是独立 follow-up，不在本 PR。

## 改动

- `tkCheckPlatformPoolExhausted` 的单平台 guard（`account.Platform != PlatformAnthropic`）换成可扩展集合 `tkPoolExhaustedPlatforms = {anthropic, openai, gemini}` + `tkPoolExhaustedEnabled()` 谓词。
- 异步 wrapper 是唯一的 gate；同步检查本体 `tkPlatformPoolExhaustedCheck` 与按平台去重的飞书卡片**本就平台无关**，所以这是唯一的行为改动。
- 池满 P0 卡片的处置话术按平台分流（`poolExhaustedAdvice`）：anthropic 保留 prod→edge relay 排障（`scan-edge-health.sh` + failover 扇出），openai/gemini 等本地账号池给"补充该平台账号 / 核对并发·会话席位余量"——避免给错平台的 CTA 在事故里把运维带偏。
- newapi/kiro/grok/antigravity 留在集合外（加进 map 即可纳入）。

## 测试

- 更新 `TestTkCheckPlatformPoolExhausted_*`：原断言 openai 是 no-op（已反转），改用 kiro（仍在集合外）验 no-op。
- 新增 `TestTkPoolExhaustedEnabled_PlatformSet`（集合成员）+ `TestTkPlatformPoolExhaustedCheck_FiresForOpenAIAndGemini`（空 gpt/google 池触发 P0）。
- 强化 `TestNotifyPlatformPoolExhausted_*`：锁定 CTA 双分支（anthropic body 含 `scan-edge-health.sh`；openai body 含"补充可调度账号"且**不**含 `scan-edge-health.sh`）。
- `go build ./...`、`go test -tags=unit ./internal/service/`、`golangci-lint` 全绿；`scripts/preflight.sh` PASS。

## 门禁

- **no-web-impact**：纯后端，无前端改动（已在 commit message 声明）。
- **sentinel registry**：本 PR 触及 load-bearing TK 面 `ratelimit_service_tk_pool_exhausted.go`，已在同一提交为它加 `scripts/sentinels/gateway-tk.json` 锚点——锚住 `PlatformOpenAI`/`PlatformGemini` 成员（二者在该文件中仅出现于该 map），未来上游 merge 若把它退回 anthropic-only 会让锚点消失并 fail gate。registry-update gate 已 ok。
- **upstream-override**：仅触及 `*_tk_*.go` / `*_test.go` / sentinel 注册表，不触上游形状路径，无需 marker。

## 合并方式

TK feature PR → **Squash and merge**。