### PR TITLE
fix(gateway): block cross-vendor model names from reaching api.anthropic.com on anthropic passthrough accounts

### DIFF
--- a/backend/internal/service/gateway_service.go
+++ b/backend/internal/service/gateway_service.go
@@ -3938,6 +3938,15 @@ func (s *GatewayService) isModelSupportedByAccount(account *Account, requestedMo
 			requestedModel = claude.NormalizeModelID(requestedModel)
 		}
 	}
+	// TK 跨厂商脏模型前置拦截：anthropic 直连账号（OAuth/SetupToken/APIKey，上游确为
+	// api.anthropic.com）的 passthrough（空 model_mapping）会把客户端原样模型名转发上游，而上游只服务
+	// claude-*。非 claude-* 名（deepseek-/gpt-/gemini- …）转发必 404，且是滥用风控的指纹异常。此处判
+	// false → 选择失败 → ErrUnsupportedModel → Path A 本地 400，永不离开网关。ServiceAccount(Vertex)
+	// 上游不是 anthropic、模型名形态不同，已在上方排除；Bedrock 在函数顶部已 early-return。
+	if account.Platform == PlatformAnthropic && account.Type != AccountTypeServiceAccount &&
+		!tkIsForwardableAnthropicModelName(requestedModel) {
+		return false
+	}
 	// 其他平台使用账户的模型支持检查
 	return account.IsModelSupported(requestedModel)
 }

--- a/backend/internal/service/gateway_service.go
+++ b/backend/internal/service/gateway_service.go
@@ -3939,12 +3939,16 @@ func (s *GatewayService) isModelSupportedByAccount(account *Account, requestedMo
 		}
 	}
 	// TK 跨厂商脏模型前置拦截：anthropic 直连账号（OAuth/SetupToken/APIKey，上游确为
-	// api.anthropic.com）的 passthrough（空 model_mapping）会把客户端原样模型名转发上游，而上游只服务
-	// claude-*。非 claude-* 名（deepseek-/gpt-/gemini- …）转发必 404，且是滥用风控的指纹异常。此处判
-	// false → 选择失败 → ErrUnsupportedModel → Path A 本地 400，永不离开网关。ServiceAccount(Vertex)
-	// 上游不是 anthropic、模型名形态不同，已在上方排除；Bedrock 在函数顶部已 early-return。
+	// api.anthropic.com）的 **passthrough（空 model_mapping）** 会把客户端原样模型名转发上游，而上游只
+	// 服务 claude-*。非 claude-* 名（deepseek-/gpt-/gemini- …）转发必 404，且是滥用风控的指纹异常。此处
+	// 判 false → 选择失败 → ErrUnsupportedModel → Path A 本地 400，永不离开网关。
+	//
+	// 只约束 passthrough：带显式 model_mapping 的账号转发的是 **mapped 后的** 模型名（见
+	// account.GetMappedModel 的转发用法），例如 {gpt-4o→claude-sonnet} 实际发的是 claude-sonnet、不泄漏，
+	// 故交回下方 IsModelSupported 按账号映射裁决，不被本守卫误拦。ServiceAccount(Vertex) 上游不是
+	// anthropic、模型名形态不同，在本条件内用 Type 排除；Bedrock 在函数顶部已 early-return。
 	if account.Platform == PlatformAnthropic && account.Type != AccountTypeServiceAccount &&
-		!tkIsForwardableAnthropicModelName(requestedModel) {
+		len(account.GetModelMapping()) == 0 && !tkIsForwardableAnthropicModelName(requestedModel) {
 		return false
 	}
 	// 其他平台使用账户的模型支持检查

--- a/backend/internal/service/gateway_service_tk_unsupported_model.go
+++ b/backend/internal/service/gateway_service_tk_unsupported_model.go
@@ -88,3 +88,32 @@ func tkWrapSelectionFailure(requestedModel string, stats selectionFailureStats) 
 	}
 	return fmt.Errorf("%w supporting model: %s (%s)", ErrNoAvailableAccounts, requestedModel, summarizeSelectionFailureStats(stats))
 }
+
+// tkIsForwardableAnthropicModelName reports whether a (normalized) model name is
+// structurally inside the Anthropic namespace, i.e. safe to forward to
+// api.anthropic.com on a direct-Anthropic account.
+//
+// Why this exists (prod 2026-06-16, edge us3 account oh1-ls-b ID 4): a
+// passthrough (empty model_mapping) anthropic OAuth account forwards the client's
+// raw model name verbatim, but the upstream only serves claude-*. Cross-vendor
+// names (deepseek-/gpt-/gemini-/qwen- …) forwarded there always 404 AND are an
+// abuse-detection fingerprint anomaly — a real Claude Code client never asks
+// api.anthropic.com for "deepseek-v4-flash". The revoked account had sent
+// deepseek-v4-flash; the same-edge survivor account (oh1-ls-a) never sent a
+// cross-vendor name, so cross-vendor is the differentiated signal. A false
+// verdict here routes the request to the existing Path A local 400
+// (ErrUnsupportedModel) so the dirty name never leaves the gateway.
+//
+// Deliberately a namespace-prefix check, NOT a servable-catalog membership check:
+// any future claude-* model forwards with zero code edits (forward-compat), with
+// no stale-allowlist availability risk on a new-model launch day. Same-family
+// stale/typo names (claude-haiku-4-6) are intentionally allowed through — the
+// survivor sent claude-haiku-4-6 16× over 12 days and was NOT revoked, so the
+// upstream tolerates them; they are not worth the staleness cost to block.
+func tkIsForwardableAnthropicModelName(model string) bool {
+	m := strings.ToLower(strings.TrimSpace(model))
+	if m == "" {
+		return true // empty model name is out of this guard's scope (handled elsewhere)
+	}
+	return strings.HasPrefix(m, "claude-")
+}

--- a/backend/internal/service/gateway_service_tk_unsupported_model_test.go
+++ b/backend/internal/service/gateway_service_tk_unsupported_model_test.go
@@ -171,8 +171,8 @@ func TestIsModelSupportedByAccount_TkDirtyModelGuard(t *testing.T) {
 
 func TestIsModelSupportedByAccount_TkGuardWithExplicitMapping(t *testing.T) {
 	svc := &GatewayService{}
-	// An anthropic account WITH an explicit model_mapping (Path A) is constrained by
-	// the mapping; the namespace guard neither loosens nor changes it.
+	// An anthropic account WITH an explicit model_mapping is constrained by the
+	// mapping; the namespace guard (passthrough-only) does not run for it.
 	mapped := &Account{
 		ID:       9,
 		Platform: PlatformAnthropic,
@@ -186,5 +186,27 @@ func TestIsModelSupportedByAccount_TkGuardWithExplicitMapping(t *testing.T) {
 	}
 	if svc.isModelSupportedByAccount(mapped, "deepseek-v4-flash") {
 		t.Error("mapped anthropic account should not support an unmapped cross-vendor model")
+	}
+
+	// Guard must NOT run for a mapped account: a non-claude REQUEST name that the
+	// account explicitly maps to a claude model is served — the forwarded model is
+	// the mapped claude name (no leak), so the passthrough-only guard does not block
+	// it. (Regression for the over-block where the guard short-circuited before the
+	// mapping was consulted.)
+	foreignToClaude := &Account{
+		ID:       10,
+		Platform: PlatformAnthropic,
+		Type:     AccountTypeOAuth,
+		Credentials: map[string]any{
+			"model_mapping": map[string]any{"gpt-4o": "claude-sonnet-4-5"},
+		},
+	}
+	if !svc.isModelSupportedByAccount(foreignToClaude, "gpt-4o") {
+		t.Error("anthropic account mapping gpt-4o->claude-sonnet-4-5 should support gpt-4o (forwarded model is claude, no leak)")
+	}
+	// A different non-claude name not in the mapping is still unsupported (mapping is
+	// the allowlist) — unchanged behavior.
+	if svc.isModelSupportedByAccount(foreignToClaude, "deepseek-v4-flash") {
+		t.Error("mapped account should not support a cross-vendor model absent from its mapping")
 	}
 }

--- a/backend/internal/service/gateway_service_tk_unsupported_model_test.go
+++ b/backend/internal/service/gateway_service_tk_unsupported_model_test.go
@@ -93,3 +93,98 @@ func TestTkWrapSelectionFailure(t *testing.T) {
 		}
 	})
 }
+
+// Tk cross-vendor dirty-model guard (prod 2026-06-16, edge us3 oh1-ls-b ID 4):
+// a passthrough anthropic OAuth account forwarded non-claude names
+// (deepseek-v4-flash) to api.anthropic.com → 404 + abuse fingerprint. The guard
+// converts those to a local Path A 400 (selection miss) while leaving same-family
+// names (claude-haiku-4-6, tolerated upstream) and all non-anthropic platforms
+// untouched.
+func TestTkIsForwardableAnthropicModelName(t *testing.T) {
+	forwardable := []string{
+		"claude-opus-4-8",
+		"claude-haiku-4-6",            // same-family stale/typo: intentionally allowed (upstream tolerates)
+		"claude-sonnet-4-5-20250929", // dated snapshot
+		"Claude-Opus-4-8",            // case-insensitive
+		" claude-opus-4-8 ",          // trimmed
+		"",                           // empty out of scope → allowed
+	}
+	for _, m := range forwardable {
+		if !tkIsForwardableAnthropicModelName(m) {
+			t.Errorf("tkIsForwardableAnthropicModelName(%q) = false, want true", m)
+		}
+	}
+
+	blocked := []string{
+		"deepseek-v4-flash", // the revoked account's cross-vendor leak
+		"gpt-4o",
+		"gemini-2.5-pro",
+		"qwen-max",
+		"opus", // bare family (aliased upstream at handler throat; here it is not claude-*)
+	}
+	for _, m := range blocked {
+		if tkIsForwardableAnthropicModelName(m) {
+			t.Errorf("tkIsForwardableAnthropicModelName(%q) = true, want false", m)
+		}
+	}
+}
+
+func TestIsModelSupportedByAccount_TkDirtyModelGuard(t *testing.T) {
+	svc := &GatewayService{}
+
+	// anthropic OAuth passthrough (empty model_mapping): cross-vendor blocked,
+	// real claude served, same-family stale name still forwards (Path B, tolerated).
+	anthropicOAuth := &Account{ID: 4, Platform: PlatformAnthropic, Type: AccountTypeOAuth}
+	if svc.isModelSupportedByAccount(anthropicOAuth, "deepseek-v4-flash") {
+		t.Error("anthropic OAuth passthrough should NOT support deepseek-v4-flash (cross-vendor leak)")
+	}
+	if !svc.isModelSupportedByAccount(anthropicOAuth, "claude-opus-4-8") {
+		t.Error("anthropic OAuth passthrough should support claude-opus-4-8")
+	}
+	if !svc.isModelSupportedByAccount(anthropicOAuth, "claude-haiku-4-6") {
+		t.Error("anthropic OAuth passthrough should still allow claude-haiku-4-6 (same-family, tolerated)")
+	}
+
+	// anthropic APIKey passthrough also forwards to api.anthropic.com → same guard.
+	anthropicAPIKey := &Account{ID: 5, Platform: PlatformAnthropic, Type: AccountTypeAPIKey}
+	if svc.isModelSupportedByAccount(anthropicAPIKey, "deepseek-v4-flash") {
+		t.Error("anthropic APIKey passthrough should NOT support deepseek-v4-flash")
+	}
+
+	// anthropic ServiceAccount (Vertex): upstream is NOT api.anthropic.com; guard
+	// must NOT apply — a claude name stays supported.
+	anthropicVertex := &Account{ID: 6, Platform: PlatformAnthropic, Type: AccountTypeServiceAccount}
+	if !svc.isModelSupportedByAccount(anthropicVertex, "claude-sonnet-4-5") {
+		t.Error("anthropic ServiceAccount (Vertex) should still support claude-sonnet-4-5")
+	}
+
+	// Non-anthropic platforms untouched: passthrough openai / newapi keep multi-vendor.
+	openai := &Account{ID: 7, Platform: PlatformOpenAI, Type: AccountTypeAPIKey}
+	if !svc.isModelSupportedByAccount(openai, "deepseek-v4-flash") {
+		t.Error("openai passthrough must still support arbitrary models (not anthropic-scoped)")
+	}
+	newapi := &Account{ID: 8, Platform: PlatformNewAPI, Type: AccountTypeAPIKey}
+	if !svc.isModelSupportedByAccount(newapi, "deepseek-v4-flash") {
+		t.Error("newapi (fifth platform, multi-vendor) must still support deepseek-v4-flash")
+	}
+}
+
+func TestIsModelSupportedByAccount_TkGuardWithExplicitMapping(t *testing.T) {
+	svc := &GatewayService{}
+	// An anthropic account WITH an explicit model_mapping (Path A) is constrained by
+	// the mapping; the namespace guard neither loosens nor changes it.
+	mapped := &Account{
+		ID:       9,
+		Platform: PlatformAnthropic,
+		Type:     AccountTypeOAuth,
+		Credentials: map[string]any{
+			"model_mapping": map[string]any{"claude-opus-4-8": "claude-opus-4-8"},
+		},
+	}
+	if !svc.isModelSupportedByAccount(mapped, "claude-opus-4-8") {
+		t.Error("mapped anthropic account should support its mapped claude model")
+	}
+	if svc.isModelSupportedByAccount(mapped, "deepseek-v4-flash") {
+		t.Error("mapped anthropic account should not support an unmapped cross-vendor model")
+	}
+}

--- a/scripts/sentinels/gateway-tk.json
+++ b/scripts/sentinels/gateway-tk.json
@@ -2613,6 +2613,21 @@
         "\"passive_usage_7d_utilization\": nil"
       ],
       "rationale": "TK fix (PR #782): on a 5h session-window roll (needInitWindow) UpdateSessionWindow must clear ONLY session_window_utilization, never the independent 7d family (passive_usage_7d_* / passive_usage_7d_sonnet_*). The pre-fix code cleared the 7d keys as nil on every 5h roll (4-5x/day), blanking the admin 7d / 7d-S windows until new traffic re-sampled the header. must_contain pins the fixed comment; must_not_contain catches an upstream merge that re-introduces the 7d nil-clear — the bare key still legitimately appears in the header-sampling block as an index assignment (extraUpdates[...] = ts), so the map-literal `: nil` form is the revert-specific signal."
+    },
+    {
+      "path": "backend/internal/service/gateway_service_tk_unsupported_model.go",
+      "must_contain": [
+        "func tkIsForwardableAnthropicModelName(model string) bool {",
+        "return strings.HasPrefix(m, \"claude-\")"
+      ],
+      "rationale": "TK fix (PR #806): tkIsForwardableAnthropicModelName is the namespace-prefix predicate that keeps cross-vendor model names (deepseek-/gpt-/gemini- …) from being forwarded to api.anthropic.com on a passthrough anthropic account — they 404 upstream AND are an abuse-detection fingerprint anomaly (prod 2026-06-16 edge us3 oh1-ls-b ID 4 was OAuth-revoked; it had sent deepseek-v4-flash). must_contain pins both the function and the claude- prefix rule so an upstream merge or refactor that deletes the predicate (re-opening the leak) fails the sentinel check."
+    },
+    {
+      "path": "backend/internal/service/gateway_service.go",
+      "must_contain": [
+        "len(account.GetModelMapping()) == 0 && !tkIsForwardableAnthropicModelName(requestedModel)"
+      ],
+      "rationale": "TK fix (PR #806): the injection point in isModelSupportedByAccount that routes a cross-vendor model name on a passthrough (empty model_mapping) anthropic direct account to the local Path A 400 instead of forwarding it to api.anthropic.com. Pinning the full guard expression also anchors the passthrough-only scope (len(GetModelMapping())==0) so a refactor cannot silently widen it to over-block mapped accounts or narrow it to re-open the leak. Pairs with the predicate sentinel on gateway_service_tk_unsupported_model.go."
     }
   ]
 }


### PR DESCRIPTION
## 问题（线上根因）

调查 edge `us3`（oh1）账号 `oh1-ls-b` (ID 4) 的 OAuth 401 吊销时发现：一个 **passthrough（空 `model_mapping`）的 anthropic OAuth 账号会把客户端原样模型名转发到 `api.anthropic.com`**。`Account.IsModelSupported`（`account.go:639`）对空映射账号**对任何模型名返回 `true`**，所以跨厂商名（如 `deepseek-v4-flash`）被判"支持" → anthropic 账号被选中 → 转发上游 → 404。

非 `claude-*` 名转发到 Anthropic 不仅必 404，更是**滥用风控的指纹异常**——真 Claude Code 客户端永不向 `api.anthropic.com` 索要 `deepseek-v4-flash`。

**差异化证据**（2026-06-16，edge us3）：被吊销号 acct 4 发过 `deepseek-v4-flash`；同 edge 同 IP 的**幸存号 acct 1（2.3B tokens / 12 天 / 0×401）一次跨厂商名都没发**，只发过同族错版 `claude-haiku-4-6`（16 次仍活）。→ **跨厂商名是差异化信号；同族错版被上游容忍。**

## 改动

守卫 `isModelSupportedByAccount`（`gateway_service.go`）——它是 **13 个选择点（sticky / load-balance / failover）背后的唯一模型支持谓词**，故一处守卫覆盖全部转发路径：

- 新增 `tkIsForwardableAnthropicModelName`（TK companion `gateway_service_tk_unsupported_model.go`）：anthropic 直连账号的模型名须 `HasPrefix("claude-")`，否则谓词 false → 选择失败 → 既有 **Path A 本地 400**（`ErrUnsupportedModel`），**永不转发 `api.anthropic.com`**。
- **命名空间前缀判别，不做 servable 目录成员校验**：未来任何 `claude-*` 新模型零代码自动透传（forward-compat），不引入陈旧 allowlist 的发版日可用性风险。
- **同族错版**（`claude-haiku-4-6`）有意放行——证据显示上游容忍 + 保 forward-compat。
- 作用域严格限 anthropic 直连（OAuth/SetupToken/APIKey）：**ServiceAccount(Vertex) / Bedrock 排除**（上游非 anthropic），**newapi 第五平台 / openai 多厂商池不受影响**。

## 验证

- `go test -tags=unit ./...` — 全绿（新增 3 个测试：谓词 / 各账号类型 / 非 anthropic 不误伤 / Path A 不变）
- `go build ./...` / `golangci-lint ./internal/service/...` — 0 issues
- `scripts/preflight.sh` — PASS（含全部 sub2api sentinel / upstream-override marker 门禁）
- 发版后行为核验：edge `ops_error_logs` 中跨厂商名应以 `error_phase=request` 本地 400 出现、`upstream_status_code` 不再是 404。

## 影响面

纯后端，无 schema / 前端 / VERSION bump。upstream 文件（`gateway_service.go`）为**纯插入** 9 行 + TK companion 追加。

🤖 Generated with [Claude Code](https://claude.com/claude-code)