### PR TITLE
feat(studio): gemini-native image generation in the image tab

### DIFF
--- a/backend/internal/web/dist/frontend-source.json
+++ b/backend/internal/web/dist/frontend-source.json
@@ -1,7 +1,7 @@
 {
   "algorithm": "sha256(git-ls-files:path,size,content)",
   "file_count": 486,
-  "hash": "d9ea0d36ea49612c2373f2dd8ff7d553a85741395a29d9365241d0ae9d32ce01",
+  "hash": "7514e7aa3f9224a072ef81e763a7ca6168ee5f31c8e4c0a566770032d9663396",
   "schema": 1,
   "source": "frontend/"
 }

--- a/backend/internal/web/dist/frontend-source.json
+++ b/backend/internal/web/dist/frontend-source.json
@@ -1,7 +1,7 @@
 {
   "algorithm": "sha256(git-ls-files:path,size,content)",
   "file_count": 486,
-  "hash": "7514e7aa3f9224a072ef81e763a7ca6168ee5f31c8e4c0a566770032d9663396",
+  "hash": "03cfa9766acf20407349a18aa47ee48b9cb756b9c157d8283a82085721bbb4ef",
   "schema": 1,
   "source": "frontend/"
 }

--- a/frontend/src/api/playground.ts
+++ b/frontend/src/api/playground.ts
@@ -185,6 +185,48 @@ export async function gatewayImageGenerations(
   )
 }
 
+export interface GeminiImageViaChatRequest {
+  model: string
+  prompt: string
+  /**
+   * Aspect-ratio code (e.g. "16:9") → extra_body.google.image_config.aspect_ratio.
+   * Degrades gracefully (model's default ratio) if an upstream strips it.
+   */
+  aspectRatio?: string
+}
+
+/**
+ * Gemini-native image generation rides /v1/chat/completions (NOT /v1/images/
+ * generations, NOT the /v1beta native route — that one is gemini-platform-group only
+ * and 400s for antigravity/newapi groups). Verified against prod: the response is a
+ * regular OpenAI chat completion whose choices[].message.content carries the image as
+ * `![image](data:image/…;base64,…)` markdown (new-api / antigravity both convert the
+ * gemini inline image to this shape). Parse with extractChatImageItems. This is the
+ * universal, platform-adaptive path. Uses the image timeout (gen can exceed a minute).
+ */
+export async function gatewayGeminiImageViaChat(
+  apiKey: string,
+  gatewayBaseUrl: string,
+  body: GeminiImageViaChatRequest,
+  signal?: AbortSignal
+): Promise<unknown> {
+  const url = `${stripTrailingSlashes(gatewayBaseUrl)}/v1/chat/completions`
+  const payload: Record<string, unknown> = {
+    model: body.model,
+    messages: [{ role: 'user', content: body.prompt }],
+    stream: false
+  }
+  if (body.aspectRatio) {
+    payload.extra_body = { google: { image_config: { aspect_ratio: body.aspectRatio } } }
+  }
+  return gatewayRequestJSON(
+    apiKey,
+    url,
+    { method: 'POST', body: payload, timeoutMs: PLAYGROUND_IMAGE_TIMEOUT_MS },
+    signal
+  )
+}
+
 export interface VideoGenerationRequest {
   model: string
   prompt: string

--- a/frontend/src/constants/__tests__/mediaTiers.tk.spec.ts
+++ b/frontend/src/constants/__tests__/mediaTiers.tk.spec.ts
@@ -8,6 +8,7 @@ import {
   MEDIA_MODELS,
   IMAGEN_IMAGE_SIZES,
   SEEDREAM_IMAGE_SIZES,
+  GEMINI_IMAGE_SIZES,
   type ModalityKeyOption,
   type StudioParam,
 } from '@/constants/mediaTiers.tk'
@@ -235,8 +236,13 @@ describe('image aspect options (per-model, upstream-valid wire values)', () => {
     }
   })
 
-  it('no image model offers an Imagen-invalid ratio (regression: 3:2 / 2:3)', () => {
-    for (const m of MEDIA_MODELS.filter((m) => m.modality === 'image')) {
+  it('IMAGEN models never offer an Imagen-invalid ratio (regression: 3:2 / 2:3)', () => {
+    // The 3:2/2:3 rule is IMAGEN-specific: those map to a hard-400 on Vertex.
+    // Gemini legitimately supports 3:2/2:3/21:9 (different upstream), so the guard
+    // is scoped to imagen models (the ones whose imageSizes is IMAGEN_IMAGE_SIZES).
+    const imagenModels = MEDIA_MODELS.filter((m) => m.imageSizes === IMAGEN_IMAGE_SIZES)
+    expect(imagenModels.length).toBeGreaterThan(0)
+    for (const m of imagenModels) {
       for (const opt of m.imageSizes ?? []) {
         expect(opt.ratio).not.toBe('3:2')
         expect(opt.ratio).not.toBe('2:3')
@@ -251,6 +257,27 @@ describe('image aspect options (per-model, upstream-valid wire values)', () => {
       expect(IMAGEN_VALID.has(opt.value)).toBe(true)
     }
     expect(new Set(IMAGEN_IMAGE_SIZES.map((o) => o.ratio))).toEqual(IMAGEN_VALID)
+  })
+
+  it('Gemini sends ratio codes verbatim, from its broader documented set', () => {
+    // Nano Banana / Gemini 3 image: 10 ratios (superset of Imagen's 5).
+    const GEMINI_VALID = new Set(['1:1', '2:3', '3:2', '3:4', '4:3', '4:5', '5:4', '9:16', '16:9', '21:9'])
+    for (const opt of GEMINI_IMAGE_SIZES) {
+      expect(opt.value).toBe(opt.ratio) // ratio code on the wire (→ image_config.aspect_ratio)
+      expect(GEMINI_VALID.has(opt.ratio)).toBe(true)
+    }
+    expect(new Set(GEMINI_IMAGE_SIZES.map((o) => o.ratio))).toEqual(GEMINI_VALID)
+  })
+
+  it('gemini image models are flatImageBilling; imagen/seedream are not', () => {
+    for (const m of MEDIA_MODELS.filter((m) => m.imageSizes === GEMINI_IMAGE_SIZES)) {
+      expect(m.flatImageBilling).toBe(true)
+    }
+    for (const m of MEDIA_MODELS.filter(
+      (m) => m.imageSizes === IMAGEN_IMAGE_SIZES || m.imageSizes === SEEDREAM_IMAGE_SIZES
+    )) {
+      expect(m.flatImageBilling).toBeFalsy()
+    }
   })
 
   it('Seedream sends pixel WxH within ARK range [1024², 4096²], ratio range [1/16,16]', () => {

--- a/frontend/src/constants/__tests__/mediaTiers.tk.spec.ts
+++ b/frontend/src/constants/__tests__/mediaTiers.tk.spec.ts
@@ -8,7 +8,6 @@ import {
   MEDIA_MODELS,
   IMAGEN_IMAGE_SIZES,
   SEEDREAM_IMAGE_SIZES,
-  GEMINI_IMAGE_SIZES,
   type ModalityKeyOption,
   type StudioParam,
 } from '@/constants/mediaTiers.tk'
@@ -227,9 +226,14 @@ describe('image aspect options (per-model, upstream-valid wire values)', () => {
   // and Imagen must send the ratio code verbatim.
   const IMAGEN_VALID = new Set(['1:1', '3:4', '4:3', '9:16', '16:9'])
 
-  it('every image model carries a non-empty imageSizes; video models carry none', () => {
-    for (const m of MEDIA_MODELS.filter((m) => m.modality === 'image')) {
+  it('imagen/seedream image models carry imageSizes; gemini (flat) and video carry none', () => {
+    // Gemini-native image has NO aspect picker (the ratio control is not honored on its
+    // serving path — #807 R-001), so its entries carry no imageSizes.
+    for (const m of MEDIA_MODELS.filter((m) => m.modality === 'image' && !m.flatImageBilling)) {
       expect(m.imageSizes && m.imageSizes.length).toBeTruthy()
+    }
+    for (const m of MEDIA_MODELS.filter((m) => m.modality === 'image' && m.flatImageBilling)) {
+      expect(m.imageSizes).toBeUndefined()
     }
     for (const m of MEDIA_MODELS.filter((m) => m.modality === 'video')) {
       expect(m.imageSizes).toBeUndefined()
@@ -259,19 +263,11 @@ describe('image aspect options (per-model, upstream-valid wire values)', () => {
     expect(new Set(IMAGEN_IMAGE_SIZES.map((o) => o.ratio))).toEqual(IMAGEN_VALID)
   })
 
-  it('Gemini sends ratio codes verbatim, from its broader documented set', () => {
-    // Nano Banana / Gemini 3 image: 10 ratios (superset of Imagen's 5).
-    const GEMINI_VALID = new Set(['1:1', '2:3', '3:2', '3:4', '4:3', '4:5', '5:4', '9:16', '16:9', '21:9'])
-    for (const opt of GEMINI_IMAGE_SIZES) {
-      expect(opt.value).toBe(opt.ratio) // ratio code on the wire (→ image_config.aspect_ratio)
-      expect(GEMINI_VALID.has(opt.ratio)).toBe(true)
-    }
-    expect(new Set(GEMINI_IMAGE_SIZES.map((o) => o.ratio))).toEqual(GEMINI_VALID)
-  })
-
-  it('gemini image models are flatImageBilling; imagen/seedream are not', () => {
-    for (const m of MEDIA_MODELS.filter((m) => m.imageSizes === GEMINI_IMAGE_SIZES)) {
-      expect(m.flatImageBilling).toBe(true)
+  it('gemini image models are flatImageBilling with no aspect picker; imagen/seedream are tiered', () => {
+    const gemini = MEDIA_MODELS.filter((m) => m.modality === 'image' && m.flatImageBilling)
+    expect(gemini.length).toBeGreaterThan(0)
+    for (const m of gemini) {
+      expect(m.imageSizes).toBeUndefined() // ratio control not honored on the serving path (#807 R-001)
     }
     for (const m of MEDIA_MODELS.filter(
       (m) => m.imageSizes === IMAGEN_IMAGE_SIZES || m.imageSizes === SEEDREAM_IMAGE_SIZES

--- a/frontend/src/constants/__tests__/playgroundMedia.tk.spec.ts
+++ b/frontend/src/constants/__tests__/playgroundMedia.tk.spec.ts
@@ -1,8 +1,10 @@
 import { describe, expect, it } from 'vitest'
 import {
+  extractChatImageItems,
   extractImageItems,
   extractVideoTaskId,
   extractVideoUrl,
+  isGeminiNativeImageModel,
   modalityForModel,
   videoStateFromFetch
 } from '@/constants/playgroundMedia.tk'
@@ -12,6 +14,27 @@ describe('modalityForModel', () => {
     for (const id of ['gpt-image-1', 'gpt-image-2-2026-04-21', 'imagen-4.0-generate-001', 'doubao-seedream-4-0-250828']) {
       expect(modalityForModel(id)).toBe('image')
     }
+  })
+
+  it('classifies gemini-native image models as image (served via chat)', () => {
+    for (const id of [
+      'gemini-3.1-flash-image',
+      'gemini-3.1-flash-image-preview',
+      'gemini-2.5-flash-image',
+      'gemini-3-pro-image-preview',
+      'nano-banana-pro-preview'
+    ]) {
+      expect(modalityForModel(id)).toBe('image')
+    }
+  })
+
+  it('does NOT misclassify plain gemini chat models as image', () => {
+    for (const id of ['gemini-2.5-pro', 'gemini-2.5-flash', 'gemini-3-flash-agent', 'gemini-3.5-flash-extra-low']) {
+      expect(modalityForModel(id)).toBe('chat')
+      expect(isGeminiNativeImageModel(id)).toBe(false)
+    }
+    expect(isGeminiNativeImageModel('gemini-3.1-flash-image')).toBe(true)
+    expect(isGeminiNativeImageModel('models/gemini-2.5-flash-image')).toBe(true)
   })
 
   it('classifies the served video families', () => {
@@ -55,6 +78,45 @@ describe('extractImageItems', () => {
     expect(extractImageItems({ data: [{ url: 'javascript:alert(1)' }] })).toEqual([])
     expect(extractImageItems({ data: [{ url: 'data:text/html;base64,PGI+' }] })).toEqual([])
     expect(extractImageItems({ data: [{ url: 'HTTPS://cdn.example/x.png' }] })).toHaveLength(1)
+  })
+})
+
+describe('extractChatImageItems (gemini image via /v1/chat/completions)', () => {
+  const chat = (content: unknown): unknown => ({ choices: [{ message: { content } }] })
+
+  it('pulls the markdown data-image URI out of message content (verified prod shape)', () => {
+    // Real prod response: content = "![image](data:image/jpeg;base64,…)".
+    const items = extractChatImageItems(chat('![image](data:image/jpeg;base64,aGVsbG8=)'))
+    expect(items).toEqual([{ src: 'data:image/jpeg;base64,aGVsbG8=' }])
+  })
+
+  it('handles multiple images and a leading caption', () => {
+    const items = extractChatImageItems(
+      chat('here:\n![a](data:image/png;base64,QQ==) and ![b](data:image/jpeg;base64,Qg==)')
+    )
+    expect(items.map((i) => i.src)).toEqual(['data:image/png;base64,QQ==', 'data:image/jpeg;base64,Qg=='])
+  })
+
+  it('handles structured content parts (image_url / inline_data)', () => {
+    expect(
+      extractChatImageItems(chat([{ type: 'image_url', image_url: { url: 'https://cdn.example/x.png' } }]))
+    ).toEqual([{ src: 'https://cdn.example/x.png' }])
+    expect(extractChatImageItems(chat([{ inline_data: { mime_type: 'image/webp', data: 'd2VicA==' } }]))).toEqual([
+      { src: 'data:image/webp;base64,d2VicA==' }
+    ])
+  })
+
+  it('returns empty for text-only / malformed responses', () => {
+    expect(extractChatImageItems(chat('just text, no image'))).toEqual([])
+    expect(extractChatImageItems(null)).toEqual([])
+    expect(extractChatImageItems({ choices: 'oops' })).toEqual([])
+    expect(extractChatImageItems({ choices: [{}] })).toEqual([])
+  })
+
+  it('drops non-image / oversized data URIs (same guard as extractImageItems)', () => {
+    expect(extractChatImageItems(chat('![x](data:text/html;base64,PGI+)'))).toEqual([])
+    const huge = 'A'.repeat(64 * 1024 * 1024 + 1)
+    expect(extractChatImageItems(chat(`![x](data:image/png;base64,${huge})`))).toEqual([])
   })
 })
 

--- a/frontend/src/constants/mediaTiers.tk.ts
+++ b/frontend/src/constants/mediaTiers.tk.ts
@@ -160,25 +160,13 @@ export const SEEDREAM_IMAGE_SIZES: ImageSizeOption[] = [
   { ratio: '16:9', value: '2048x1152' },
 ]
 
-/**
- * Gemini-native image (Nano Banana / Gemini 3 image): served via /v1/chat/completions
- * with `extra_body.google.image_config.aspect_ratio` = the ratio code (sent verbatim,
- * value === ratio). Gemini supports a BROADER set than Imagen — its 10 documented
- * ratios (ref: Google Nano Banana / Gemini 3 Pro Image docs). Per the #801 per-model
- * design, each model lists its OWN supported ratios; this is gemini's full set.
- */
-export const GEMINI_IMAGE_SIZES: ImageSizeOption[] = [
-  { ratio: '1:1', value: '1:1' },
-  { ratio: '2:3', value: '2:3' },
-  { ratio: '3:2', value: '3:2' },
-  { ratio: '3:4', value: '3:4' },
-  { ratio: '4:3', value: '4:3' },
-  { ratio: '4:5', value: '4:5' },
-  { ratio: '5:4', value: '5:4' },
-  { ratio: '9:16', value: '9:16' },
-  { ratio: '16:9', value: '16:9' },
-  { ratio: '21:9', value: '21:9' },
-]
+// NB: gemini-native image has NO aspect-ratio picker. The control was verified
+// non-functional on the antigravity serving path (prod: 1:1 / 9:16 / 16:9 all return
+// 1408x768 — extra_body.google.image_config.aspect_ratio is dropped before the
+// upstream). Rather than ship a cosmetic control we omit it; gemini image generates at
+// the model's default ratio. Forwarding the ratio is a separate backend effort (it must
+// thread aspect_ratio through the OpenAI→Claude→Gemini transform) gated on a prod canary
+// that confirms cloudcode-pa actually honors it. See PR #807 review R-001.
 
 /** Video aspect ratios — passthrough hint to the task adaptor (TK does not interpret). */
 export interface VideoAspectPreset {
@@ -329,7 +317,6 @@ export const MEDIA_MODELS: MediaModel[] = [
     vendorLabel: GEMINI,
     modality: 'image',
     supportedParams: [],
-    imageSizes: GEMINI_IMAGE_SIZES,
     flatImageBilling: true,
   },
   {
@@ -341,7 +328,6 @@ export const MEDIA_MODELS: MediaModel[] = [
     vendorLabel: GEMINI,
     modality: 'image',
     supportedParams: [],
-    imageSizes: GEMINI_IMAGE_SIZES,
     flatImageBilling: true,
   },
   {
@@ -353,7 +339,6 @@ export const MEDIA_MODELS: MediaModel[] = [
     vendorLabel: GEMINI,
     modality: 'image',
     supportedParams: [],
-    imageSizes: GEMINI_IMAGE_SIZES,
     flatImageBilling: true,
   },
   // gpt-image-* is deliberately ABSENT: it needs a type=apikey OpenAI account

--- a/frontend/src/constants/mediaTiers.tk.ts
+++ b/frontend/src/constants/mediaTiers.tk.ts
@@ -31,6 +31,7 @@ export type PickerModality = StudioModality | 'chat'
 
 const VERTEX = 'Google Vertex'
 const VOLC = 'VolcEngine'
+const GEMINI = 'Google Gemini'
 
 /**
  * True when this group's pool backs at least one media model of the modality —
@@ -159,6 +160,26 @@ export const SEEDREAM_IMAGE_SIZES: ImageSizeOption[] = [
   { ratio: '16:9', value: '2048x1152' },
 ]
 
+/**
+ * Gemini-native image (Nano Banana / Gemini 3 image): served via /v1/chat/completions
+ * with `extra_body.google.image_config.aspect_ratio` = the ratio code (sent verbatim,
+ * value === ratio). Gemini supports a BROADER set than Imagen — its 10 documented
+ * ratios (ref: Google Nano Banana / Gemini 3 Pro Image docs). Per the #801 per-model
+ * design, each model lists its OWN supported ratios; this is gemini's full set.
+ */
+export const GEMINI_IMAGE_SIZES: ImageSizeOption[] = [
+  { ratio: '1:1', value: '1:1' },
+  { ratio: '2:3', value: '2:3' },
+  { ratio: '3:2', value: '3:2' },
+  { ratio: '3:4', value: '3:4' },
+  { ratio: '4:3', value: '4:3' },
+  { ratio: '4:5', value: '4:5' },
+  { ratio: '5:4', value: '5:4' },
+  { ratio: '9:16', value: '9:16' },
+  { ratio: '16:9', value: '16:9' },
+  { ratio: '21:9', value: '21:9' },
+]
+
 /** Video aspect ratios — passthrough hint to the task adaptor (TK does not interpret). */
 export interface VideoAspectPreset {
   id: string
@@ -234,9 +255,15 @@ export interface MediaModel {
   /**
    * Image modality only: the aspect-ratio options this model's UPSTREAM accepts,
    * each carrying the exact `size` string to send. Imagen ⇒ ratio codes, Seedream
-   * ⇒ pixel WxH (see ImageSizeOption). Absent for video models.
+   * ⇒ pixel WxH, Gemini-native ⇒ ratio codes (see ImageSizeOption). Absent for video.
    */
   imageSizes?: ImageSizeOption[]
+  /**
+   * True ⇒ this model is served via /v1/chat/completions (gemini-native image), not
+   * /v1/images/generations, and bills a FLAT output_cost_per_image (no 1K/2K/4K size
+   * tier). The Studio routes it through chat and skips the size-tier cost multiplier.
+   */
+  flatImageBilling?: boolean
 }
 
 /**
@@ -290,6 +317,44 @@ export const MEDIA_MODELS: MediaModel[] = [
     modality: 'image',
     supportedParams: [],
     imageSizes: IMAGEN_IMAGE_SIZES,
+  },
+  // ── gemini-native image (Nano Banana family) — served via /v1/chat/completions
+  //    (responseModalities IMAGE), NOT /v1/images/generations. Flat per-image billing.
+  {
+    modelId: 'gemini-3.1-flash-image',
+    aliasIds: ['gemini-3.1-flash-image-preview'],
+    displayName: 'Gemini 3.1 Flash Image',
+    qualityBadge: 'fast',
+    qualityBadgeKey: 'studio.badge.fast',
+    vendorLabel: GEMINI,
+    modality: 'image',
+    supportedParams: [],
+    imageSizes: GEMINI_IMAGE_SIZES,
+    flatImageBilling: true,
+  },
+  {
+    modelId: 'gemini-2.5-flash-image',
+    aliasIds: ['gemini-2.5-flash-image-preview'],
+    displayName: 'Gemini 2.5 Flash Image',
+    qualityBadge: 'standard',
+    qualityBadgeKey: 'studio.badge.standard',
+    vendorLabel: GEMINI,
+    modality: 'image',
+    supportedParams: [],
+    imageSizes: GEMINI_IMAGE_SIZES,
+    flatImageBilling: true,
+  },
+  {
+    modelId: 'gemini-3-pro-image-preview',
+    aliasIds: ['gemini-3-pro-image', 'nano-banana-pro-preview'],
+    displayName: 'Nano Banana Pro (Gemini 3 Pro Image)',
+    qualityBadge: 'ultra',
+    qualityBadgeKey: 'studio.badge.ultra',
+    vendorLabel: GEMINI,
+    modality: 'image',
+    supportedParams: [],
+    imageSizes: GEMINI_IMAGE_SIZES,
+    flatImageBilling: true,
   },
   // gpt-image-* is deliberately ABSENT: it needs a type=apikey OpenAI account
   // (OAuth subscriptions 502). If a future probe adds an apikey-backed group,

--- a/frontend/src/constants/playgroundMedia.tk.ts
+++ b/frontend/src/constants/playgroundMedia.tk.ts
@@ -11,16 +11,39 @@
 //              priced in tk_pricing_overlay.json.
 //   - video  — veo-* (Vertex) and *seedance* (Doubao Seedance) are the families
 //              served via /v1/video/generations (task adaptor channel types 45/54).
+//   - image (gemini-native) — gemini-*-image / nano-banana ("Nano Banana") models
+//              output images, but via /v1/chat/completions (responseModalities
+//              IMAGE), NOT /v1/images/generations. The predicate mirrors the
+//              backend isImageGenerationModel() family (antigravity_gateway_service.go).
 // Unknown ids stay 'chat' — wrong-modality submits get a clear gateway error,
 // never a silent misroute.
 
 export type PlaygroundModality = 'chat' | 'image' | 'video'
 
+/**
+ * Gemini-native image-generation ids: `gemini…-image`, `gemini…-image-preview`,
+ * `gemini…-image-<variant>`, and the `nano-banana` family. Must NOT match plain
+ * gemini chat ids (e.g. gemini-2.5-flash, gemini-3-flash-agent) — only ids whose
+ * name carries an `-image` segment. Mirrors backend isImageGenerationModel().
+ */
+const GEMINI_NATIVE_IMAGE_RE = /(?:^|\/)gemini[-\w.]*-image(?:-[-\w.]*)?$/
+
+export function isGeminiNativeImageModel(modelId: string): boolean {
+  const id = (modelId || '').trim().toLowerCase()
+  return GEMINI_NATIVE_IMAGE_RE.test(id) || id.includes('nano-banana')
+}
+
 export function modalityForModel(modelId: string): PlaygroundModality {
   const id = (modelId || '').trim().toLowerCase()
   if (!id) return 'chat'
   if (id.includes('seedance') || id.startsWith('veo-')) return 'video'
-  if (id.startsWith('gpt-image-') || id.startsWith('imagen-') || id.includes('seedream')) return 'image'
+  if (
+    id.startsWith('gpt-image-') ||
+    id.startsWith('imagen-') ||
+    id.includes('seedream') ||
+    isGeminiNativeImageModel(id)
+  )
+    return 'image'
   return 'chat'
 }
 
@@ -70,6 +93,64 @@ export function extractImageItems(resp: unknown): PlaygroundImageItem[] {
       items.push({ src: rec.url, revisedPrompt: revised })
     } else if (typeof rec.b64_json === 'string' && withinInlineB64Cap(rec.b64_json)) {
       items.push({ src: `data:image/png;base64,${rec.b64_json}`, revisedPrompt: revised })
+    }
+  }
+  return items
+}
+
+/**
+ * Extract image(s) from a CHAT COMPLETION response — gemini-native image models
+ * (Nano Banana family) are served via /v1/chat/completions (verified against prod:
+ * antigravity + newapi groups both return the image, NOT the /v1beta native route
+ * which is gemini-platform-group only). The image arrives as markdown in
+ * choices[].message.content: `![image](data:image/jpeg;base64,…)`. Some upstreams
+ * may instead return structured content parts (image_url / inline_data); handle both.
+ * Reuses extractImageItems' scheme guard + decoded-size cap so a hostile relay can't
+ * smuggle a javascript: scheme or a tab-freezing multi-hundred-MB b64.
+ */
+export function extractChatImageItems(resp: unknown): PlaygroundImageItem[] {
+  const root = asRecord(resp)
+  const choices = root?.choices
+  if (!Array.isArray(choices)) return []
+  const items: PlaygroundImageItem[] = []
+  const pushDataUri = (uri: string): void => {
+    const m = /^data:image\/[\w.+-]+;base64,([A-Za-z0-9+/=]+)$/i.exec(uri)
+    if (m && withinInlineB64Cap(m[1])) items.push({ src: uri })
+  }
+  const pushUrl = (url: string): void => {
+    if (/^https?:\/\//i.test(url)) items.push({ src: url })
+    else pushDataUri(url)
+  }
+  for (const choice of choices) {
+    const message = asRecord(asRecord(choice)?.message)
+    if (!message) continue
+    const content = message.content
+    if (typeof content === 'string') {
+      // markdown ![…](data:image/…;base64,…) — pull every data: image URI out.
+      const re = /\(\s*(data:image\/[\w.+-]+;base64,[A-Za-z0-9+/=]+)\s*\)/gi
+      let mm: RegExpExecArray | null
+      while ((mm = re.exec(content)) !== null) pushDataUri(mm[1])
+    } else if (Array.isArray(content)) {
+      // structured parts: {type:'image_url', image_url:{url}} or {inline_data:{data,mime_type}}.
+      for (const part of content) {
+        const p = asRecord(part)
+        if (!p) continue
+        const imageUrl = asRecord(p.image_url)
+        if (typeof imageUrl?.url === 'string') pushUrl(imageUrl.url)
+        else if (typeof p.image_url === 'string') pushUrl(p.image_url)
+        const inline = asRecord(p.inline_data) ?? asRecord(p.inlineData)
+        if (inline && typeof inline.data === 'string') {
+          const mime =
+            typeof inline.mime_type === 'string'
+              ? inline.mime_type
+              : typeof inline.mimeType === 'string'
+                ? inline.mimeType
+                : 'image/png'
+          if (mime.startsWith('image') && withinInlineB64Cap(inline.data)) {
+            items.push({ src: `data:${mime};base64,${inline.data}` })
+          }
+        }
+      }
     }
   }
   return items

--- a/frontend/src/i18n/locales/en.ts
+++ b/frontend/src/i18n/locales/en.ts
@@ -171,6 +171,7 @@ export default {
       promptPlaceholder: 'Describe the image…',
       aspectLabel: 'Aspect ratio',
       billedAs: 'Billed as {tier} · ×{mult}',
+      billedFlat: 'Flat per-image price (one image per run)',
       count: 'Count',
       resultsTitle: 'Results',
       emptyHint: 'Pick a tier and generate — results appear here and persist across reloads.',
@@ -180,7 +181,8 @@ export default {
       generateTopUp: 'Generate · {cost} — top up',
       generating: 'Generating…',
       noResult: 'The gateway returned no image data.',
-      formula: '{base} × {tier} ×{mult} × {n}'
+      formula: '{base} × {tier} ×{mult} × {n}',
+      formulaFlat: '{base} × {n}'
     },
     video: {
       modelLabel: 'Model',

--- a/frontend/src/i18n/locales/zh.ts
+++ b/frontend/src/i18n/locales/zh.ts
@@ -169,6 +169,7 @@ export default {
       promptPlaceholder: '描述你想要的图片…',
       aspectLabel: '比例',
       billedAs: '按 {tier} 计费 · ×{mult}',
+      billedFlat: '按张计费（固定单价，每次一张）',
       count: '数量',
       resultsTitle: '结果',
       emptyHint: '选个档位并生成——结果会显示在这里，刷新也不丢。',
@@ -178,7 +179,8 @@ export default {
       generateTopUp: '生成 · {cost} — 去充值',
       generating: '生成中…',
       noResult: '网关未返回图片数据。',
-      formula: '{base} × {tier} ×{mult} × {n}'
+      formula: '{base} × {tier} ×{mult} × {n}',
+      formulaFlat: '{base} × {n}'
     },
     video: {
       modelLabel: '模型',

--- a/frontend/src/views/user/studio/ImageStudio.vue
+++ b/frontend/src/views/user/studio/ImageStudio.vue
@@ -49,26 +49,29 @@
           @input="userEditedPrompt = true"
         />
         <div class="mt-3">
-          <div class="mb-1.5 text-xs font-semibold uppercase tracking-wide text-gray-400 dark:text-dark-500">{{ t('studio.image.aspectLabel') }}</div>
-          <!-- Ratios are the SELECTED MODEL's actual supported set, shown raw (the
-               exact value goes on the wire). Imagen ⇒ ratio code; Seedream ⇒ the
-               literal pixel size is shown as a subtext. -->
-          <div class="flex flex-wrap gap-2">
-            <button
-              v-for="opt in sizeOptions"
-              :key="opt.ratio"
-              type="button"
-              class="rounded-lg border px-3 py-1.5 text-left transition"
-              :class="selectedRatio === opt.ratio
-                ? 'border-primary-600 bg-primary-600 text-white'
-                : 'border-gray-200 text-gray-600 hover:border-primary-300 dark:border-dark-600 dark:text-dark-300'"
-              data-testid="studio-image-aspect"
-              @click="selectedRatio = opt.ratio"
-            >
-              <div class="text-sm font-medium tabular-nums">{{ opt.ratio }}</div>
-              <div v-if="sizeSubtext(opt.value, opt.ratio)" class="text-[10px] tabular-nums opacity-70">{{ sizeSubtext(opt.value, opt.ratio) }}</div>
-            </button>
-          </div>
+          <!-- Aspect picker is shown only when the selected model has supported ratios
+               (Imagen ratio codes / Seedream pixel sizes). Gemini-native image has no
+               picker: the ratio control is not honored on its serving path (see #807
+               R-001), so we omit it rather than ship a cosmetic control. -->
+          <template v-if="sizeOptions.length">
+            <div class="mb-1.5 text-xs font-semibold uppercase tracking-wide text-gray-400 dark:text-dark-500">{{ t('studio.image.aspectLabel') }}</div>
+            <div class="flex flex-wrap gap-2">
+              <button
+                v-for="opt in sizeOptions"
+                :key="opt.ratio"
+                type="button"
+                class="rounded-lg border px-3 py-1.5 text-left transition"
+                :class="selectedRatio === opt.ratio
+                  ? 'border-primary-600 bg-primary-600 text-white'
+                  : 'border-gray-200 text-gray-600 hover:border-primary-300 dark:border-dark-600 dark:text-dark-300'"
+                data-testid="studio-image-aspect"
+                @click="selectedRatio = opt.ratio"
+              >
+                <div class="text-sm font-medium tabular-nums">{{ opt.ratio }}</div>
+                <div v-if="sizeSubtext(opt.value, opt.ratio)" class="text-[10px] tabular-nums opacity-70">{{ sizeSubtext(opt.value, opt.ratio) }}</div>
+              </button>
+            </div>
+          </template>
           <p class="mt-1.5 text-[11px] text-gray-400 dark:text-dark-500">
             <template v-if="isFlatImage">{{ t('studio.image.billedFlat') }}</template>
             <template v-else>{{ t('studio.image.billedAs', { tier: classifiedTier, mult: sizeMultiplier }) }}</template>

--- a/frontend/src/views/user/studio/ImageStudio.vue
+++ b/frontend/src/views/user/studio/ImageStudio.vue
@@ -70,10 +70,12 @@
             </button>
           </div>
           <p class="mt-1.5 text-[11px] text-gray-400 dark:text-dark-500">
-            {{ t('studio.image.billedAs', { tier: classifiedTier, mult: sizeMultiplier }) }}
+            <template v-if="isFlatImage">{{ t('studio.image.billedFlat') }}</template>
+            <template v-else>{{ t('studio.image.billedAs', { tier: classifiedTier, mult: sizeMultiplier }) }}</template>
           </p>
         </div>
-        <div class="mt-3 flex items-center justify-between">
+        <!-- Count stepper hidden for gemini-native image: the chat surface returns one image per request. -->
+        <div v-if="!isFlatImage" class="mt-3 flex items-center justify-between">
           <span class="text-sm font-medium text-gray-700 dark:text-dark-200">{{ t('studio.image.count') }}</span>
           <div class="flex items-center gap-2">
             <button type="button" class="h-7 w-7 rounded-lg border border-gray-200 text-gray-600 hover:border-primary-300 disabled:opacity-40 dark:border-dark-600 dark:text-dark-300" :disabled="n <= IMAGE_N_MIN" @click="n = Math.max(IMAGE_N_MIN, n - 1)">−</button>
@@ -167,8 +169,8 @@
 <script setup lang="ts">
 import { computed, ref, watch } from 'vue'
 import { useI18n } from 'vue-i18n'
-import { gatewayImageGenerations } from '@/api/playground'
-import { extractImageItems } from '@/constants/playgroundMedia.tk'
+import { gatewayImageGenerations, gatewayGeminiImageViaChat } from '@/api/playground'
+import { extractImageItems, extractChatImageItems } from '@/constants/playgroundMedia.tk'
 import {
   IMAGE_N_MIN,
   IMAGE_N_MAX,
@@ -218,6 +220,11 @@ const selectedSize = computed(
 const sentSize = computed(() => selectedSize.value?.value ?? '')
 const classifiedTier = computed(() => classifyImageBillingTier(sentSize.value))
 const sizeMultiplier = computed(() => IMAGE_SIZE_MULTIPLIER[classifiedTier.value])
+// Gemini-native image is served via /v1/chat/completions and bills a FLAT
+// output_cost_per_image (no 1K/2K/4K size tier, one image per request). Skip the
+// size-tier multiplier and the count stepper for these models.
+const isFlatImage = computed(() => !!selected.value?.model.flatImageBilling)
+const effectiveN = computed(() => (isFlatImage.value ? 1 : n.value))
 // Show the literal pixel size as a subtext when it differs from the ratio label
 // (Seedream); for Imagen the value IS the ratio, so no redundant subtext.
 function sizeSubtext(value: string, ratio: string): string {
@@ -235,16 +242,25 @@ const estimate = computed(() => {
   if (!selected.value) return 0
   return estimateImageCost({
     baseImagePrice: selected.value.baseImagePrice || 0,
-    size: sentSize.value,
-    n: n.value,
+    size: isFlatImage.value ? '1K' : sentSize.value, // flat ⇒ ×1, no size tier
+    n: effectiveN.value,
     rateMultiplier: props.rateMultiplier,
   })
 })
-// Affordability is gated on the backend HOLD upper bound (4K tier-max), NOT the
-// per-size estimate — otherwise a balance between the headline price and the
-// hold would enable a request the gateway then 403s (insufficient_balance).
+// Affordability is gated on the backend HOLD upper bound. For imagen/seedream that
+// is the 4K tier-max (settlement bills the real size), so the UI can't enable a
+// request the gateway then 403s. Gemini bills flat per-image (no tier), so its hold
+// IS the flat estimate.
 const holdEstimate = computed(() => {
   if (!selected.value) return 0
+  if (isFlatImage.value) {
+    return estimateImageCost({
+      baseImagePrice: selected.value.baseImagePrice || 0,
+      size: '1K',
+      n: 1,
+      rateMultiplier: props.rateMultiplier,
+    })
+  }
   return estimateImageHoldCost({
     baseImagePrice: selected.value.baseImagePrice || 0,
     n: n.value,
@@ -258,6 +274,9 @@ const canGenerate = computed(
 const formula = computed(() => {
   if (!selected.value) return ''
   const base = formatUsd(selected.value.baseImagePrice || 0)
+  if (isFlatImage.value) {
+    return t('studio.image.formulaFlat', { base, n: effectiveN.value })
+  }
   return t('studio.image.formula', { base, tier: classifiedTier.value, mult: sizeMultiplier.value, n: n.value })
 })
 
@@ -306,17 +325,30 @@ async function generate(): Promise<void> {
   errorCode.value = ''
   sending.value = true
   try {
-    const raw = await gatewayImageGenerations(props.apiKey, props.gatewayBase, {
-      model: resolved.servedId,
-      prompt: text,
-      size: sentSize.value,
-      n: n.value,
-    })
-    const items = extractImageItems(raw)
+    // Gemini-native image rides /v1/chat/completions (image returned as markdown in
+    // the chat response — the universal path that works for antigravity + newapi
+    // groups); imagen/seedream ride /v1/images/generations. Route by the model.
+    let items
+    if (isFlatImage.value) {
+      const raw = await gatewayGeminiImageViaChat(props.apiKey, props.gatewayBase, {
+        model: resolved.servedId,
+        prompt: text,
+        aspectRatio: sentSize.value // ratio code → extra_body.google.image_config.aspect_ratio
+      })
+      items = extractChatImageItems(raw)
+    } else {
+      const raw = await gatewayImageGenerations(props.apiKey, props.gatewayBase, {
+        model: resolved.servedId,
+        prompt: text,
+        size: sentSize.value,
+        n: n.value,
+      })
+      items = extractImageItems(raw)
+    }
     if (!items.length) throw new Error(t('studio.image.noResult'))
     const perImage = estimateImageCost({
       baseImagePrice: resolved.baseImagePrice || 0,
-      size: sentSize.value,
+      size: isFlatImage.value ? '1K' : sentSize.value,
       n: 1,
       rateMultiplier: props.rateMultiplier,
     })

--- a/scripts/sentinels/frontend-tk.json
+++ b/scripts/sentinels/frontend-tk.json
@@ -685,9 +685,11 @@
         "modalityForModel",
         "id.startsWith('gpt-image-')",
         "id.includes('seedance') || id.startsWith('veo-')",
-        "videoStateFromFetch"
+        "videoStateFromFetch",
+        "isGeminiNativeImageModel",
+        "extractChatImageItems"
       ],
-      "rationale": "Playground media modality table + tolerant response parsing. /v1/models returns bare ids and the public catalog has no image/video capability tag, so this frontend table is the only thing routing gpt-image-*/imagen-*/seedream prompts to /v1/images/generations and veo-*/seedance prompts to the vt_ video task flow. The gpt-image- prefix mirrors the backend's own intent predicate (openai_images.go isOpenAIImageGenerationModel) — if either side changes family patterns the other must follow."
+      "rationale": "Playground media modality table + tolerant response parsing. /v1/models returns bare ids and the public catalog has no image/video capability tag, so this frontend table is the only thing routing gpt-image-*/imagen-*/seedream prompts to /v1/images/generations and veo-*/seedance prompts to the vt_ video task flow. The gpt-image- prefix mirrors the backend's own intent predicate (openai_images.go isOpenAIImageGenerationModel) — if either side changes family patterns the other must follow. isGeminiNativeImageModel classifies gemini-*-image / nano-banana ids as 'image' (mirrors backend isImageGenerationModel) — they are served via /v1/chat/completions (verified prod: the image returns as ![image](data:…) markdown for antigravity + newapi groups), so extractChatImageItems is the ONLY parser pulling that inline image out of the chat response; dropping either silently regresses gemini-native image in the Studio."
     },
     {
       "path": "frontend/src/views/user/studio/ChatStudio.vue",
@@ -811,7 +813,8 @@
         "export function resolveAvailableModels",
         "supportedParams",
         "export const IMAGEN_IMAGE_SIZES",
-        "export const SEEDREAM_IMAGE_SIZES"
+        "export const SEEDREAM_IMAGE_SIZES",
+        "export const GEMINI_IMAGE_SIZES"
       ],
       "rationale": "TK-only Studio model catalog + capability map. MEDIA_MODELS lists each priced+servable media model (friendly name, vendor, price, supportedParams); resolveAvailableModels(modality, availableIds) is the priced∩servable filter the model-card picker drives (replacing the tier-card selection). Dropping these silently regresses the transparent model picker or, worse, lets an unservable/unpriced model surface as a 400-on-submit footgun. supportedParams is the honest Advanced-panel capability gate — only params a model actually honors are rendered. IMAGEN_IMAGE_SIZES / SEEDREAM_IMAGE_SIZES are the per-model aspect-ratio option sets: Imagen MUST send ratio codes {1:1,3:4,4:3,9:16,16:9} verbatim and Seedream MUST send pixel WxH — losing them reverts to the fixed-pixel preset that made the gemini/vertex adaptor emit 3:2/2:3, which Imagen hard-400s ('Invalid aspect ratio, 3:2')."
     },

--- a/scripts/sentinels/frontend-tk.json
+++ b/scripts/sentinels/frontend-tk.json
@@ -813,8 +813,7 @@
         "export function resolveAvailableModels",
         "supportedParams",
         "export const IMAGEN_IMAGE_SIZES",
-        "export const SEEDREAM_IMAGE_SIZES",
-        "export const GEMINI_IMAGE_SIZES"
+        "export const SEEDREAM_IMAGE_SIZES"
       ],
       "rationale": "TK-only Studio model catalog + capability map. MEDIA_MODELS lists each priced+servable media model (friendly name, vendor, price, supportedParams); resolveAvailableModels(modality, availableIds) is the priced∩servable filter the model-card picker drives (replacing the tier-card selection). Dropping these silently regresses the transparent model picker or, worse, lets an unservable/unpriced model surface as a 400-on-submit footgun. supportedParams is the honest Advanced-panel capability gate — only params a model actually honors are rendered. IMAGEN_IMAGE_SIZES / SEEDREAM_IMAGE_SIZES are the per-model aspect-ratio option sets: Imagen MUST send ratio codes {1:1,3:4,4:3,9:16,16:9} verbatim and Seedream MUST send pixel WxH — losing them reverts to the fixed-pixel preset that made the gemini/vertex adaptor emit 3:2/2:3, which Imagen hard-400s ('Invalid aspect ratio, 3:2')."
     },


### PR DESCRIPTION
## Problem

A user's `Google-Gemini` key serves gemini-native image models (`gemini-3.1-flash-image`, "按图" in /pricing) but the Studio **图片** tab showed "此模式无可用模型". Root cause: gemini-native image is a **fourth image surface** the Studio never wired up. Unlike Imagen/Seedream (`/v1/images/generations`), gemini-native image is served via **`/v1/chat/completions`**, returning the image as `![image](data:image/jpeg;base64,…)` markdown in `choices[].message.content`.

## Verified against today's prod (read-only SSM probes)

| Group | Image | Video |
|---|---|---|
| **21 antigravity** (the user's key) | `gemini-3.1-flash-image` → `/v1/chat/completions` → **HTTP 200, inline image markdown** ✓ (this PR) | no video model in pool — N/A |
| **16 newapi** | `imagen-4.0-*` → `/v1/images/generations` → **200, b64_json** ✓ (already worked) | `veo-3.1` → `/v1/video/generations` → **200, `vt_…queued`** ✓ (already worked) |

The `/v1beta` native gemini route is **not** usable here: its `requireGroupGoogle` middleware 400s for non-gemini-platform groups (antigravity/newapi). The OpenAI chat path is the **universal, platform-adaptive** one. This PR is purely additive — imagen/seedream/veo paths are untouched.

## Change (frontend only — backend already counts `imageCount=1` for these)

- `modalityForModel()`: classify `gemini-*-image` / `nano-banana` ids as `image` via a precise predicate mirroring backend `isImageGenerationModel()` (does **not** catch plain gemini chat models).
- `MEDIA_MODELS`: gemini image entries (3.1 Flash Image, 2.5 Flash Image, Nano Banana Pro) with `flatImageBilling`.
- `ImageStudio.generate()`: route gemini models through `gatewayGeminiImageViaChat` (`/v1/chat/completions`); parse the inline image with `extractChatImageItems`. imagen/seedream keep the images endpoint.
- Cost mirror: gemini bills **flat** `output_cost_per_image` (no 1K/2K/4K tier, one image per run) — skip the size multiplier + count stepper; honest "按张计费".
- **No aspect-ratio picker for gemini image** (review R-001, below).

## How it stays adaptive

"What a group serves" comes from the gateway (`GET /v1/models`); "how a model is called" comes from the static `MEDIA_MODELS` catalog (endpoint family + billing). The Studio shows `servable ∩ priced`, then routes by the selected model's family. No per-group branching.

## Review R-001 (resolved in this PR)

An earlier cut shipped a 10-ratio aspect picker for gemini. Prod verification (neutral prompt) showed `aspect_ratio` 1:1 / 9:16 / 16:9 **all return 1408×768** on the antigravity path — `extra_body.google.image_config.aspect_ratio` is dropped before the upstream. Rather than ship a cosmetic control, the picker is **removed**; gemini image generates at the model's default ratio. Forwarding the ratio (thread it through the antigravity OpenAI→Claude→Gemini transform) is a **separate backend PR gated on a prod canary** that first confirms cloudcode-pa honors `aspectRatio`.

## Tests / gates

- `modalityForModel` gemini pos/neg; `extractChatImageItems` (verified prod markdown shape + guards); gemini catalog flat-billing + no-imageSizes invariant; #801 regression test scoped to imagen.
- Sentinels: `isGeminiNativeImageModel`, `extractChatImageItems` + the `ImageStudio.vue` surface.
- `typecheck` / `lint` / specs / `preflight` green. Upstream-override + registry-update gates auto-pass via sentinel coverage (no markers).

Reviewer: per §5.y this is a TK feature → **Squash and merge**.

🤖 Generated with [Claude Code](https://claude.com/claude-code)