### PR TITLE
fix(gateway): apply messages-dispatch model mapping on /v1/responses inbound

### DIFF
--- a/backend/internal/handler/openai_gateway_handler.go
+++ b/backend/internal/handler/openai_gateway_handler.go
@@ -325,6 +325,12 @@ func (h *OpenAIGatewayHandler) Responses(c *gin.Context) {
 	sameAccountRetryCount := make(map[int64]int)
 	var lastFailoverErr *service.UpstreamFailoverError
 
+	// TK: route account selection on the same dispatch-mapped model that the forward
+	// body carries (claude 家族名 → 配置 gpt 模型），与 /v1/messages 对齐，避免
+	// scheduler 的渠道计价/模型限制与粘性按一个永不真打到上游的 claude 名判定。
+	// 见 openai_gateway_handler_tk_responses_dispatch.go。
+	selectionModel := tkResolveResponsesSelectionModel(apiKey, reqModel)
+
 	for {
 		// Select account supporting the requested model
 		reqLog.Debug("openai.account_selecting", zap.Int("excluded_account_count", len(failedAccountIDs)))
@@ -333,7 +339,7 @@ func (h *OpenAIGatewayHandler) Responses(c *gin.Context) {
 			apiKey.GroupID,
 			previousResponseID,
 			sessionHash,
-			reqModel,
+			selectionModel,
 			failedAccountIDs,
 			service.OpenAIUpstreamTransportAny,
 			service.OpenAIEndpointCapabilityChatCompletions,

--- a/backend/internal/handler/openai_gateway_handler.go
+++ b/backend/internal/handler/openai_gateway_handler.go
@@ -262,6 +262,11 @@ func (h *OpenAIGatewayHandler) Responses(c *gin.Context) {
 	// 解析渠道级模型映射
 	channelMapping, _ := h.gatewayService.ResolveChannelMappingAndRestrict(c.Request.Context(), apiKey.GroupID, reqModel)
 	forwardBody := openAIModelMappedBody(body, channelMapping.Mapped, channelMapping.MappedModel, h.gatewayService.ReplaceModelInBody)
+	// TK: /v1/responses 入口补套 group messages-dispatch 模型映射（claude 家族名 →
+	// 配置的 gpt 模型），与 /v1/messages、/v1/chat/completions 同源。否则裸 claude 名
+	// 透传 Codex/ChatGPT 后端会被上游拒为 400 "model not supported"。
+	// 见 openai_gateway_handler_tk_responses_dispatch.go。
+	forwardBody = tkApplyResponsesDispatchModelMapping(apiKey, forwardBody, h.gatewayService.ReplaceModelInBody)
 
 	// 提前校验 function_call_output 是否具备可关联上下文，避免上游 400。
 	if !h.validateFunctionCallOutputRequest(c, body, reqLog) {

--- a/backend/internal/handler/openai_gateway_handler_tk_responses_dispatch.go
+++ b/backend/internal/handler/openai_gateway_handler_tk_responses_dispatch.go
@@ -42,3 +42,18 @@ func tkApplyResponsesDispatchModelMapping(
 	}
 	return replace(forwardBody, mapped)
 }
+
+// tkResolveResponsesSelectionModel returns the model name the /v1/responses
+// account-selection step should route on. When the requested model is a claude
+// family name it returns the group dispatch-mapped gpt model (parity with
+// /v1/messages, which selects on its preferredMappedModel), so the scheduler's
+// channel-pricing / model-restriction filtering and load/sticky decisions see the
+// real upstream-bound model rather than a claude name that never reaches the
+// upstream. Non-claude models (mapping returns "") and nil apiKey fall through to
+// the original requested model unchanged.
+func tkResolveResponsesSelectionModel(apiKey *service.APIKey, requestedModel string) string {
+	if mapped := resolveOpenAIMessagesDispatchMappedModel(apiKey, requestedModel); mapped != "" {
+		return mapped
+	}
+	return requestedModel
+}

--- a/backend/internal/handler/openai_gateway_handler_tk_responses_dispatch.go
+++ b/backend/internal/handler/openai_gateway_handler_tk_responses_dispatch.go
@@ -1,0 +1,44 @@
+package handler
+
+import (
+	"github.com/Wei-Shaw/sub2api/internal/service"
+	"github.com/tidwall/gjson"
+)
+
+// tkApplyResponsesDispatchModelMapping applies the group-level messages-dispatch
+// model mapping (opus_mapped_model 等) to a /v1/responses forward body, mirroring
+// what the /v1/messages and /v1/chat/completions handlers already do via
+// resolveOpenAIMessagesDispatchMappedModel.
+//
+// 背景：/v1/responses 入口此前不套用 group.MessagesDispatchModelConfig。带 claude
+// 模型名（如 claude-opus-4-7）的请求会把裸 claude 名透传到 Codex/ChatGPT 后端，
+// 返回上游 400 "The 'claude-opus-4-7' model is not supported when using Codex with
+// a ChatGPT account."。/v1/messages（openai_gateway_handler.go:712）与
+// /v1/chat/completions（openai_chat_completions.go:216）都在转发前把 claude 家族
+// 名映射成配置的 gpt 模型，唯独 responses 入口漏接——这与 edge 中转无关，是入口层
+// 缺一段映射（OAuth 直连账号同样命中）。
+//
+// 此 helper 在 handler 层、转发之前补上同一映射，覆盖 native responses 与
+// raw-chat-fallback 两条转发路径（service.Forward 的 model 解析走 account 级
+// GetMappedModel + codex 归一化，永不查 group dispatch 配置，故必须在 handler 改写
+// body）。计费语义不变：handler 仍以原始 reqModel 记 requested_model，
+// result.UpstreamModel 记实际上游模型，与 /v1/messages 路径一致。
+//
+// 映射基于「当前（已套用渠道映射后的）body model」判定：仅当其为 claude 家族名时
+// 才改写，从而让渠道映射优先、dispatch 仅作 claude→gpt 兜底，优先级与 messages
+// 路径相同。非 claude 模型（gpt-5.5 等）返回空映射，函数原样返回 body。
+func tkApplyResponsesDispatchModelMapping(
+	apiKey *service.APIKey,
+	forwardBody []byte,
+	replace openAIModelBodyReplaceFunc,
+) []byte {
+	if apiKey == nil || replace == nil {
+		return forwardBody
+	}
+	currentModel := gjson.GetBytes(forwardBody, "model").String()
+	mapped := resolveOpenAIMessagesDispatchMappedModel(apiKey, currentModel)
+	if mapped == "" || mapped == currentModel {
+		return forwardBody
+	}
+	return replace(forwardBody, mapped)
+}

--- a/backend/internal/handler/openai_gateway_handler_tk_responses_dispatch_test.go
+++ b/backend/internal/handler/openai_gateway_handler_tk_responses_dispatch_test.go
@@ -85,3 +85,31 @@ func Test_tkApplyResponsesDispatchModelMapping(t *testing.T) {
 		}
 	})
 }
+
+// Test_tkResolveResponsesSelectionModel pins that account selection routes on the
+// dispatch-mapped gpt model for claude family names (parity with /v1/messages) and
+// leaves non-claude names / nil apiKey unchanged.
+func Test_tkResolveResponsesSelectionModel(t *testing.T) {
+	keyWith := func(cfg service.OpenAIMessagesDispatchModelConfig) *service.APIKey {
+		return &service.APIKey{Group: &service.Group{ID: 2, Platform: service.PlatformOpenAI, MessagesDispatchModelConfig: cfg}}
+	}
+
+	cases := []struct {
+		name      string
+		apiKey    *service.APIKey
+		requested string
+		want      string
+	}{
+		{"claude opus routes on configured gpt", keyWith(service.OpenAIMessagesDispatchModelConfig{OpusMappedModel: "gpt-5.5"}), "claude-opus-4-7", "gpt-5.5"},
+		{"claude opus routes on default gpt when unset", keyWith(service.OpenAIMessagesDispatchModelConfig{}), "claude-opus-4-7", "gpt-5.5"},
+		{"non-claude model routes unchanged", keyWith(service.OpenAIMessagesDispatchModelConfig{OpusMappedModel: "gpt-5.5"}), "gpt-5.5", "gpt-5.5"},
+		{"nil apiKey routes unchanged", nil, "claude-opus-4-7", "claude-opus-4-7"},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			if got := tkResolveResponsesSelectionModel(tc.apiKey, tc.requested); got != tc.want {
+				t.Fatalf("selection model = %q, want %q", got, tc.want)
+			}
+		})
+	}
+}

--- a/backend/internal/handler/openai_gateway_handler_tk_responses_dispatch_test.go
+++ b/backend/internal/handler/openai_gateway_handler_tk_responses_dispatch_test.go
@@ -1,0 +1,87 @@
+//go:build unit
+
+package handler
+
+import (
+	"testing"
+
+	"github.com/Wei-Shaw/sub2api/internal/service"
+	"github.com/tidwall/gjson"
+)
+
+// Test_tkApplyResponsesDispatchModelMapping pins the /v1/responses inbound model
+// mapping that mirrors /v1/messages + /v1/chat/completions: a claude family model
+// name must be rewritten to the group's configured gpt model before forwarding,
+// so the Codex/ChatGPT backend does not reject the raw claude name with a 400.
+func Test_tkApplyResponsesDispatchModelMapping(t *testing.T) {
+	replace := func(body []byte, newModel string) []byte {
+		return service.ReplaceModelInBody(body, newModel)
+	}
+	keyWith := func(cfg service.OpenAIMessagesDispatchModelConfig) *service.APIKey {
+		return &service.APIKey{Group: &service.Group{
+			ID:                          2,
+			Platform:                    service.PlatformOpenAI,
+			MessagesDispatchModelConfig: cfg,
+		}}
+	}
+	bodyWithModel := func(model string) []byte {
+		return []byte(`{"model":"` + model + `","input":[]}`)
+	}
+
+	cases := []struct {
+		name      string
+		apiKey    *service.APIKey
+		body      []byte
+		wantModel string
+	}{
+		{
+			name:      "claude opus mapped to configured gpt model",
+			apiKey:    keyWith(service.OpenAIMessagesDispatchModelConfig{OpusMappedModel: "gpt-5.5"}),
+			body:      bodyWithModel("claude-opus-4-7"),
+			wantModel: "gpt-5.5",
+		},
+		{
+			name:      "claude opus uses default mapping when group config empty",
+			apiKey:    keyWith(service.OpenAIMessagesDispatchModelConfig{}),
+			body:      bodyWithModel("claude-opus-4-7"),
+			wantModel: "gpt-5.5", // defaultOpenAIMessagesDispatchOpusMappedModel
+		},
+		{
+			name:      "claude sonnet honours configured sonnet mapping",
+			apiKey:    keyWith(service.OpenAIMessagesDispatchModelConfig{SonnetMappedModel: "gpt-5.5"}),
+			body:      bodyWithModel("claude-sonnet-4-6"),
+			wantModel: "gpt-5.5",
+		},
+		{
+			name:      "non-claude model is left untouched",
+			apiKey:    keyWith(service.OpenAIMessagesDispatchModelConfig{OpusMappedModel: "gpt-5.5"}),
+			body:      bodyWithModel("gpt-5.5"),
+			wantModel: "gpt-5.5",
+		},
+		{
+			name:      "nil apiKey is a no-op",
+			apiKey:    nil,
+			body:      bodyWithModel("claude-opus-4-7"),
+			wantModel: "claude-opus-4-7",
+		},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			out := tkApplyResponsesDispatchModelMapping(tc.apiKey, tc.body, replace)
+			got := gjson.GetBytes(out, "model").String()
+			if got != tc.wantModel {
+				t.Fatalf("model = %q, want %q", got, tc.wantModel)
+			}
+		})
+	}
+
+	// nil replace must never panic and must return the body verbatim.
+	t.Run("nil replace is a no-op", func(t *testing.T) {
+		body := bodyWithModel("claude-opus-4-7")
+		out := tkApplyResponsesDispatchModelMapping(keyWith(service.OpenAIMessagesDispatchModelConfig{OpusMappedModel: "gpt-5.5"}), body, nil)
+		if got := gjson.GetBytes(out, "model").String(); got != "claude-opus-4-7" {
+			t.Fatalf("model = %q, want claude-opus-4-7", got)
+		}
+	})
+}

--- a/scripts/sentinels/gateway-tk.json
+++ b/scripts/sentinels/gateway-tk.json
@@ -2662,6 +2662,22 @@
         "if s.tkTryDisableAnthropicOrgBan403(ctx, account, upstreamMsg, responseBody) {"
       ],
       "rationale": "Injection point that wires the Anthropic 403 org-ban permanent-disable (ratelimit_service_tk_anthropic_org_ban_403.go) into handle403, BEFORE the TLS-fingerprint cooldown and the handleAnthropicUpstreamError 3/3 ladder. handle403 is an upstream-shaped file whose 403 branch attracts upstream merges; without this anchor, a merge that rewrites the anthropic 403 branch could drop the one-line call and silently restore the eternal-flap behaviour (the companion file would still compile, so the gateway-tk.json file sentinel alone would not catch a dead call site). Pairs with the ratelimit_service_tk_anthropic_org_ban_403.go function/keyword sentinel."
+    },
+    {
+      "path": "backend/internal/handler/openai_gateway_handler.go",
+      "must_contain": [
+        "forwardBody = tkApplyResponsesDispatchModelMapping(apiKey, forwardBody, h.gatewayService.ReplaceModelInBody)",
+        "selectionModel := tkResolveResponsesSelectionModel(apiKey, reqModel)"
+      ],
+      "rationale": "TK fix (PR #809): the two thin injection points that make the /v1/responses inbound handler apply the group messages_dispatch_model_config mapping (claude family name -> configured gpt model), at parity with /v1/messages and /v1/chat/completions. (1) tkApplyResponsesDispatchModelMapping rewrites the forward-body model before dispatch so a claude model name (e.g. claude-opus-4-7) is not sent raw to the Codex/ChatGPT backend, which rejects it with upstream 400 'model not supported when using Codex with a ChatGPT account'. (2) tkResolveResponsesSelectionModel routes account selection on the same mapped model so the scheduler's channel-pricing / model-restriction filtering and load/sticky decisions see the real upstream-bound model instead of a claude name that never reaches the upstream. service.Forward resolves the upstream model via account-level GetMappedModel + codex normalization and never consults the group dispatch config, so the body must be rewritten here. An upstream merge that rewrites the Responses handler forward-body construction or the account-selection loop would silently drop either hook and regress the fix. Pairs with the openai_gateway_handler_tk_responses_dispatch.go sentinel."
+    },
+    {
+      "path": "backend/internal/handler/openai_gateway_handler_tk_responses_dispatch.go",
+      "must_contain": [
+        "func tkApplyResponsesDispatchModelMapping(",
+        "func tkResolveResponsesSelectionModel("
+      ],
+      "rationale": "TK companion (PR #809) holding the /v1/responses dispatch model-mapping helpers: forward-body rewrite (tkApplyResponsesDispatchModelMapping) and account-selection model (tkResolveResponsesSelectionModel). Load-bearing: deleting the file silently regresses /v1/responses for claude model names (upstream 400) and the responses<->messages selection parity. Anchored so an upstream merge or refactor cannot remove the companion without tripping the sentinel; pairs with the openai_gateway_handler.go injection-site sentinel above."
     }
   ]
 }


### PR DESCRIPTION
## Problem (reproduced live on prod)

Customer (user 16, GPT专线 / group 2) on Claude Code CLI hit `429 No available accounts`,
then a `/v1/responses` failure diagnosed as "claude responses protocol not supported through
the edge relay". A read-only investigation + controlled live reproduction showed the real
mechanism is **not** relay/protocol-related:

- `/v1/messages` + `claude-opus-4-7` (the real claude-code path) → **200**, mapped to `gpt-5.5`.
- `/v1/responses` + `claude-opus-4-7` → **400** `"The 'claude-opus-4-7' model is not supported
  when using Codex with a ChatGPT account"`.

Root cause: the `/v1/responses` inbound handler never applied the group
`messages_dispatch_model_config` mapping (`opus_mapped_model` → `gpt-5.5`) that `/v1/messages`
(`openai_gateway_handler.go:712`) and `/v1/chat/completions` (`openai_chat_completions.go:216`)
both apply. The raw claude model name reached the Codex/ChatGPT backend and was rejected. This is
**account-agnostic** (OAuth direct accounts and edge-relay stubs alike) — not a relay/protocol
limitation, and explains why "use /v1/chat/completions or /v1/messages" worked.

## Change (2 commits)

1. **Forward-body mapping** — `tkApplyResponsesDispatchModelMapping` (new TK companion) maps a
   claude-family body model to the group's configured gpt model before dispatch, covering both the
   native responses forward and the raw-chat-fallback path (`service.Forward` resolves the upstream
   model via account-level `GetMappedModel` + codex normalization and never consults the group
   dispatch config, so the body is rewritten at the handler). Channel mapping keeps precedence.
2. **Account-selection alignment** — `tkResolveResponsesSelectionModel` routes account selection on
   the same dispatch-mapped model, matching `/v1/messages` (which selects on its mapped model).
   Without this, an openai group carrying a channel-pricing / model restriction that allows the
   mapped gpt model but not the claude name would serve on `/v1/messages` yet empty-pool (429) on
   `/v1/responses` for the same request. Non-claude models / nil apiKey unchanged.

Billing semantics unchanged: `requested_model` stays the original claude name, `upstream_model`
reflects the mapped gpt model — identical to the `/v1/messages` path.

## Test

- `go test -tags=unit ./...` — pass (full suite). Unit tests cover both helpers (opus/sonnet
  mapping, default mapping, non-claude no-op, nil apiKey, nil replace; selection-model parity).
- `golangci-lint run ./internal/handler/` — clean. `scripts/preflight.sh` (PREFLIGHT_BASE=origin/main) — PASS.
- Live: `/v1/messages` claude-opus-4-7 → 200; `/v1/responses` claude-opus-4-7 → 400 (pre-fix).

## Notes

- Backend-only (`no-web-impact`).
- The new `*_tk_*.go` companion + the upstream injection call-sites are pinned with real
  sentinel anchors in `scripts/sentinels/gateway-tk.json` (commit 3), so a future upstream
  merge that clobbers the Responses handler trips the gate — no reliance on the
  `sentinel-registry-reviewed` escape marker.
- Upstream-shaped `openai_gateway_handler.go` touched minimally: +7/−1 (one comment block + one
  helper call + a single arg swap `reqModel`→`selectionModel`); no upstream symbol/route deletion.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

