### PR TITLE
fix(gateway): permanently disable Anthropic accounts on 403 org-ban instead of flapping the transient cooldown

### DIFF
--- a/backend/internal/service/ratelimit_service.go
+++ b/backend/internal/service/ratelimit_service.go
@@ -1050,6 +1050,14 @@ func (s *RateLimitService) handle403(ctx context.Context, account *Account, upst
 				"account_id", account.ID)
 			return true
 		}
+		// TK (handle403 gap, 2026-06-16 edge us6 incident): a 403 permission_error
+		// signalling a PERMANENT organization-level OAuth ban must permanently
+		// disable + alert, not flap forever on the transient 3/3 ladder (whose
+		// 10-min cooldown auto-recovers and re-offers a banned account every
+		// cycle). See ratelimit_service_tk_anthropic_org_ban_403.go.
+		if s.tkTryDisableAnthropicOrgBan403(ctx, account, upstreamMsg, responseBody) {
+			return true
+		}
 		// TLS / bot-detection 失效专项：上游用 403 拒绝是因为 Cloudflare / WAF
 		// 识别到 JA3/JA4 不像真实 Claude Code CLI（指纹库失效或 CLI 版本升级）。
 		// 这种情况下账号本身没问题，是基础设施层面的问题，需要 ops 立即介入

--- a/backend/internal/service/ratelimit_service_tk_anthropic_org_ban_403.go
+++ b/backend/internal/service/ratelimit_service_tk_anthropic_org_ban_403.go
@@ -1,0 +1,77 @@
+package service
+
+import (
+	"context"
+	"log/slog"
+	"strings"
+)
+
+// tkAnthropicOrgBan403Keywords matches Anthropic 403 permission_error bodies that
+// signal a PERMANENT organization-level block on this account's credentials —
+// not transient upstream jitter. The canonical incident (2026-06-16, edge us6
+// account edge-ls-oh-3-d) is the OAuth subscription relay ban:
+//
+//	{"type":"error","error":{"type":"permission_error",
+//	  "message":"OAuth authentication is currently not allowed for this organization."}}
+//
+// Anthropic's sibling org-disabled verdict is permanently disabled when it
+// arrives as a 400 ("organization has been disabled" → case 400 in
+// HandleUpstreamErrorRaw) but can also arrive as a 403; catch that shape here
+// too so the HTTP status code never decides recoverability for an
+// account-fatal condition. Matching is case-insensitive substring
+// (matchTempUnschedKeyword).
+var tkAnthropicOrgBan403Keywords = []string{
+	"not allowed for this organization",
+	"organization has been disabled",
+}
+
+// tkTryDisableAnthropicOrgBan403 reports whether an Anthropic upstream 403 is a
+// permanent organization-level ban and, when so, permanently disables the
+// account (SetError, no auto-recovery) and fires the Feishu permanent-disable
+// card — then returns true so the caller skips the transient cooldown ladder.
+//
+// WHY (handle403 gap, 2026-06-16 edge us6 incident): without this, an org-ban
+// 403 falls through to handleAnthropicUpstreamError — the generic 3/3
+// short-window ladder whose cooldown caps at 10 min and AUTO-RECOVERS. The
+// account then flaps forever: cool 10m → re-enter pool → 403 → re-cool, burning
+// one failover per cycle and polluting upstream-error attribution, until an
+// operator manually sets schedulable=false. A genuine org ban is irrecoverable
+// for THIS account/org (token refresh keeps succeeding — the grant lives, the
+// org is policy-blocked at request time), so the correct action is permanent
+// disable + alert to prompt manual account replacement, mirroring the 400
+// "organization has been disabled" handling and the 401 grant-revocation
+// escalation (tkTryEscalateRevokedOAuth401).
+//
+// Returns false (→ falls through to the existing tiered cooldown unchanged) when
+// nothing matches, so any non-org-ban 403 behaves exactly as before. Fail-safe:
+// a missing match never escalates.
+func (s *RateLimitService) tkTryDisableAnthropicOrgBan403(ctx context.Context, account *Account, upstreamMsg string, responseBody []byte) bool {
+	if s == nil || account == nil {
+		return false
+	}
+	haystack := strings.ToLower(strings.TrimSpace(upstreamMsg) + " " + string(responseBody))
+	matched := matchTempUnschedKeyword(haystack, tkAnthropicOrgBan403Keywords)
+	if matched == "" {
+		return false
+	}
+
+	msg := buildForbiddenErrorMessage(
+		"Organization OAuth ban (403):",
+		upstreamMsg,
+		responseBody,
+		"OAuth authentication is currently not allowed for this organization",
+	)
+
+	// greppable marker (§8.5 troubleshooting convention) — distinct from the
+	// transient anthropic_upstream_error ladder and the TLS-fingerprint signal,
+	// so ops alerting can route this to "replace the account", not "wait it out".
+	slog.Warn("anthropic_org_ban_403_permanent_disable",
+		"account_id", account.ID,
+		"platform", account.Platform,
+		"matched_keyword", matched,
+		"action", "ops_should_replace_with_unbanned_account",
+		"upstream_msg", upstreamMsg,
+	)
+	s.handleAuthError(ctx, account, msg)
+	return true
+}

--- a/backend/internal/service/ratelimit_service_tk_anthropic_org_ban_403.go
+++ b/backend/internal/service/ratelimit_service_tk_anthropic_org_ban_403.go
@@ -20,8 +20,20 @@ import (
 // too so the HTTP status code never decides recoverability for an
 // account-fatal condition. Matching is case-insensitive substring
 // (matchTempUnschedKeyword).
+//
+// Precision bar (permanent disable is irreversible — no auto-recovery, needs an
+// operator): match ONLY phrases that are unambiguously account/auth-level. The
+// incident phrase keeps the "authentication is currently not allowed" qualifier
+// rather than the bare "not allowed for this organization" tail — the bare tail
+// would also match a MODEL/feature-level denial (e.g. "Model X is not allowed
+// for this organization"), and a client requesting a model the org lacks could
+// then permanently disable a perfectly healthy account (the poison-request
+// fan-out the 413/429/400 client-induced skips exist to prevent). Biasing tight
+// is safe here: a missed/reworded ban merely falls back to the pre-existing
+// transient-flap behaviour (recoverable by ops), whereas a false match is a
+// self-inflicted outage.
 var tkAnthropicOrgBan403Keywords = []string{
-	"not allowed for this organization",
+	"authentication is currently not allowed for this organization",
 	"organization has been disabled",
 }
 

--- a/backend/internal/service/ratelimit_service_tk_anthropic_org_ban_403_test.go
+++ b/backend/internal/service/ratelimit_service_tk_anthropic_org_ban_403_test.go
@@ -1,0 +1,106 @@
+//go:build unit
+
+package service
+
+import (
+	"context"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/require"
+)
+
+// orgBan403AccountRepoStub captures SetError / SetTempUnschedulable so a test can
+// assert which disable path handle403 took. Embedding the interface makes any
+// unexpected method call panic.
+type orgBan403AccountRepoStub struct {
+	AccountRepository
+	setErrorCalls    []setErrorCall
+	tempUnschedCalls []tempUnschedCall
+}
+
+func (r *orgBan403AccountRepoStub) SetError(_ context.Context, id int64, errorMsg string) error {
+	r.setErrorCalls = append(r.setErrorCalls, setErrorCall{accountID: id, reason: errorMsg})
+	return nil
+}
+
+func (r *orgBan403AccountRepoStub) SetTempUnschedulable(_ context.Context, id int64, until time.Time, reason string) error {
+	r.tempUnschedCalls = append(r.tempUnschedCalls, tempUnschedCall{accountID: id, until: until, reason: reason})
+	return nil
+}
+
+// The canonical incident body (2026-06-16, edge us6 account edge-ls-oh-3-d).
+const tkOrgBan403IncidentBody = `{"type":"error","error":{"type":"permission_error","message":"OAuth authentication is currently not allowed for this organization."}}`
+
+func TestTryDisableAnthropicOrgBan403_MatchesOrgBan(t *testing.T) {
+	cases := []struct {
+		name string
+		msg  string
+		body string
+	}{
+		{"oauth org ban via body", "", tkOrgBan403IncidentBody},
+		{"oauth org ban via upstreamMsg", "OAuth authentication is currently not allowed for this organization.", ""},
+		{"org disabled as 403 via body", "", `{"type":"error","error":{"type":"permission_error","message":"This organization has been disabled."}}`},
+		{"mixed case", "", `{"error":{"message":"OAuth authentication is currently NOT ALLOWED FOR THIS ORGANIZATION."}}`},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			repo := &orgBan403AccountRepoStub{}
+			svc := &RateLimitService{accountRepo: repo}
+			account := &Account{ID: 1, Name: "edge-ls-oh-3-d", Platform: PlatformAnthropic, Type: "oauth"}
+
+			matched := svc.tkTryDisableAnthropicOrgBan403(context.Background(), account, tc.msg, []byte(tc.body))
+
+			require.True(t, matched, "org-ban 403 must be recognized and escalated")
+			require.Len(t, repo.setErrorCalls, 1, "must permanently disable via SetError")
+			require.Empty(t, repo.tempUnschedCalls, "must NOT take the transient cooldown path")
+			require.Equal(t, int64(1), repo.setErrorCalls[0].accountID)
+			require.Contains(t, repo.setErrorCalls[0].reason, "Organization OAuth ban (403)")
+		})
+	}
+}
+
+func TestTryDisableAnthropicOrgBan403_IgnoresNonOrgBan403(t *testing.T) {
+	cases := []struct {
+		name string
+		msg  string
+		body string
+	}{
+		{"generic permission error", "", `{"type":"error","error":{"type":"permission_error","message":"You do not have access to this model."}}`},
+		{"tls/bot challenge", "", `<html>Just a moment... cloudflare challenge</html>`},
+		{"empty body and msg", "", ""},
+		{"unrelated organization word", "", `{"error":{"message":"Rate limit reached in organization org on tokens per min."}}`},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			repo := &orgBan403AccountRepoStub{}
+			svc := &RateLimitService{accountRepo: repo}
+			account := &Account{ID: 2, Name: "acc-2", Platform: PlatformAnthropic}
+
+			matched := svc.tkTryDisableAnthropicOrgBan403(context.Background(), account, tc.msg, []byte(tc.body))
+
+			require.False(t, matched, "non-org-ban 403 must fall through to the existing cooldown path")
+			require.Empty(t, repo.setErrorCalls)
+			require.Empty(t, repo.tempUnschedCalls)
+		})
+	}
+}
+
+// handle403 end-to-end: the incident body must reach permanent disable (SetError)
+// and report shouldDisable=true, NOT advance the transient 3/3 ladder.
+func TestHandle403_AnthropicOrgBan_PermanentlyDisables(t *testing.T) {
+	repo := &orgBan403AccountRepoStub{}
+	svc := &RateLimitService{accountRepo: repo}
+	account := &Account{ID: 1, Name: "edge-ls-oh-3-d", Platform: PlatformAnthropic, Type: "oauth"}
+
+	shouldDisable := svc.handle403(
+		context.Background(),
+		account,
+		"OAuth authentication is currently not allowed for this organization.",
+		[]byte(tkOrgBan403IncidentBody),
+	)
+
+	require.True(t, shouldDisable, "org-ban 403 must report shouldDisable=true")
+	require.Len(t, repo.setErrorCalls, 1, "must SetError (permanent disable, no auto-recovery)")
+	require.Empty(t, repo.tempUnschedCalls, "must NOT cool down (which would auto-recover and re-offer the banned account)")
+}

--- a/backend/internal/service/ratelimit_service_tk_anthropic_org_ban_403_test.go
+++ b/backend/internal/service/ratelimit_service_tk_anthropic_org_ban_403_test.go
@@ -67,6 +67,12 @@ func TestTryDisableAnthropicOrgBan403_IgnoresNonOrgBan403(t *testing.T) {
 		body string
 	}{
 		{"generic permission error", "", `{"type":"error","error":{"type":"permission_error","message":"You do not have access to this model."}}`},
+		// Boundary: a MODEL/feature-level "not allowed for this organization" denial
+		// must NOT permanently disable a healthy account — only the account/auth-level
+		// "authentication is currently not allowed for this organization" does. A
+		// client requesting a model the org lacks must never poison the account.
+		{"model-level not-allowed (must not disable)", "", `{"type":"error","error":{"type":"permission_error","message":"Model claude-opus-4 is not allowed for this organization."}}`},
+		{"oauth token lacks scopes", "", `{"type":"error","error":{"type":"permission_error","message":"OAuth token lacks required scopes"}}`},
 		{"tls/bot challenge", "", `<html>Just a moment... cloudflare challenge</html>`},
 		{"empty body and msg", "", ""},
 		{"unrelated organization word", "", `{"error":{"message":"Rate limit reached in organization org on tokens per min."}}`},

--- a/backend/internal/service/ratelimit_service_tk_canonical_ingress_reject.go
+++ b/backend/internal/service/ratelimit_service_tk_canonical_ingress_reject.go
@@ -25,10 +25,12 @@ import "net/http"
 // non-strict edge will serve it during canary) and leave stub health untouched.
 //
 // Boundary discipline (mirrors tkSkipDownstreamNoAvailableAccountsPenalty):
-// match ONLY TokenKey's own rejection phrase. A genuine Anthropic 403
-// (organization disabled, TLS/bot challenge, permission revocation) carries no
-// such phrase and still flows through the TLS-keyword check and the tiered
-// cooldown.
+// match ONLY TokenKey's own rejection phrase. A genuine Anthropic 403 carries no
+// such phrase and falls through to the rest of handle403: an account-fatal
+// org-level ban ("not allowed for this organization" / "organization has been
+// disabled") is permanently disabled by tkTryDisableAnthropicOrgBan403, a
+// TLS/bot challenge takes the short TLS-fingerprint cooldown, and any other 403
+// flows through the tiered upstream-error cooldown.
 func tkSkipRelayedCanonicalIngressRejectPenalty(statusCode int, upstreamMsg string, responseBody []byte) bool {
 	if statusCode != http.StatusForbidden {
 		return false

--- a/scripts/sentinels/gateway-tk.json
+++ b/scripts/sentinels/gateway-tk.json
@@ -2649,7 +2649,7 @@
       "path": "backend/internal/service/ratelimit_service_tk_anthropic_org_ban_403.go",
       "must_contain": [
         "var tkAnthropicOrgBan403Keywords = []string{",
-        "\"not allowed for this organization\"",
+        "\"authentication is currently not allowed for this organization\"",
         "\"organization has been disabled\"",
         "func (s *RateLimitService) tkTryDisableAnthropicOrgBan403(",
         "s.handleAuthError(ctx, account, msg)"

--- a/scripts/sentinels/gateway-tk.json
+++ b/scripts/sentinels/gateway-tk.json
@@ -2644,6 +2644,24 @@
         "s.incidentNotifier.NotifyPlatformPoolExhausted(platform, trigger, until, reason)"
       ],
       "rationale": "Platform-pool-exhausted P0 enablement set (2026-06-17 'gpt 号池满了' incident). The immediate P0 card was anthropic-only until this; tkPoolExhaustedPlatforms now also holds PlatformOpenAI + PlatformGemini so an emptied gpt/google pool's fast-fail-to-429 transition pages ops at once. PlatformOpenAI/PlatformGemini appear nowhere else in this file, so the sentinel mechanically protects pool coverage: an upstream merge or 'simplify' refactor that drops either key (reverting to anthropic-only and re-blinding gpt/google) makes the substring vanish and fails the gate. The tkPoolExhaustedEnabled predicate + the guard call site + the NotifyPlatformPoolExhausted dispatch are anchored too so the membership check can't be bypassed by removing the guard. Pairs with the existing ratelimit_service.go (tkCheckPlatformPoolExhausted hook) and account_incident_notifier_tk_pool.go (card) sentinels."
+    },
+    {
+      "path": "backend/internal/service/ratelimit_service_tk_anthropic_org_ban_403.go",
+      "must_contain": [
+        "var tkAnthropicOrgBan403Keywords = []string{",
+        "\"not allowed for this organization\"",
+        "\"organization has been disabled\"",
+        "func (s *RateLimitService) tkTryDisableAnthropicOrgBan403(",
+        "s.handleAuthError(ctx, account, msg)"
+      ],
+      "rationale": "Anthropic 403 org-ban permanent-disable (2026-06-16 edge us6 account edge-ls-oh-3-d incident). A 403 permission_error 'OAuth authentication is currently not allowed for this organization' is an irrecoverable org-level ban (token refresh keeps succeeding — grant alive, org policy-blocked at request time), but handle403 previously routed it into handleAnthropicUpstreamError's generic 3/3 ladder whose 10-min cooldown AUTO-RECOVERS, so a banned account flapped forever (cool 10m -> re-enter pool -> 403 -> re-cool). The keyword list + the tkTryDisableAnthropicOrgBan403 function + its handleAuthError (SetError, no auto-recovery) call are the whole fix: if an upstream merge or refactor deletes any of them, the org-ban 403 silently falls back to the eternal-flap ladder and the regression is invisible until an operator notices the wasted failover + attribution noise. Pairs with the ratelimit_service.go injection-point sentinel."
+    },
+    {
+      "path": "backend/internal/service/ratelimit_service.go",
+      "must_contain": [
+        "if s.tkTryDisableAnthropicOrgBan403(ctx, account, upstreamMsg, responseBody) {"
+      ],
+      "rationale": "Injection point that wires the Anthropic 403 org-ban permanent-disable (ratelimit_service_tk_anthropic_org_ban_403.go) into handle403, BEFORE the TLS-fingerprint cooldown and the handleAnthropicUpstreamError 3/3 ladder. handle403 is an upstream-shaped file whose 403 branch attracts upstream merges; without this anchor, a merge that rewrites the anthropic 403 branch could drop the one-line call and silently restore the eternal-flap behaviour (the companion file would still compile, so the gateway-tk.json file sentinel alone would not catch a dead call site). Pairs with the ratelimit_service_tk_anthropic_org_ban_403.go function/keyword sentinel."
     }
   ]
 }


### PR DESCRIPTION
## Problem

A 403 `permission_error` **\"OAuth authentication is currently not allowed for this organization.\"** is an **irrecoverable org-level OAuth ban** — but `handle403` routed it into `handleAnthropicUpstreamError`'s generic 3/3 ladder, whose 10-min cooldown **auto-recovers**. A banned account therefore flapped forever:

```
cool 10m → re-enter pool → 403 → 3/3 → re-cool → …  (until an operator manually sets schedulable=false)
```

burning one failover per cycle and polluting upstream-error attribution.

### Why it's irrecoverable (not transient)
Token **refresh keeps succeeding** (the grant lives) — the org is policy-blocked **at request time**. So waiting out the cooldown, re-refreshing, or re-authorizing the *same* org all fail. Distinct from 401 grant-revocation and from 429 rate-limit.

### Field evidence — edge us6, account `edge-ls-oh-3-d` (`usaiberlini@gmail.com`)
- Healthy & serving 200 for ~12 days (created 06-05).
- **Hard cut to 403 at 2026-06-16T23:18:59 UTC.**
- **93 / 93** post-ban routings → 403 (per-hour routing:403 = `23h 4:4 / 01h 1:1 / 02h 3:3 / 04h 31:31 / 05h 50:50 / 06h 4:4`).
- `token_refresh.account_refreshed` succeeded before *and* after the ban (22:26, 05:56).
- Edge stayed healthy because 2 sibling accounts (different orgs) absorbed the traffic — so the only symptom was wasted failover + attribution noise, no client impact.

## Fix

`tkTryDisableAnthropicOrgBan403` (new `*_tk_*.go` companion): detect the org-ban phrases (`not allowed for this organization` / `organization has been disabled`) in the 403 body/message and **permanently disable** (`SetError`, no auto-recovery) + fire the Feishu permanent-disable card. Wired into `handle403` as a one-line call **before** the TLS-fingerprint cooldown and the 3/3 ladder.

This mirrors the existing **400 \"organization has been disabled\"** handling and the **401 grant-revocation** escalation (`tkTryEscalateRevokedOAuth401`) — i.e. it decouples recoverability from the HTTP status code for an account-fatal condition. Non-org-ban 403s fall through to the existing tiered cooldown **unchanged** (fail-safe).

## Tests
- `TestTryDisableAnthropicOrgBan403_MatchesOrgBan` — incident body, upstreamMsg-only, org-disabled-as-403, mixed case → permanent disable, no cooldown.
- `TestTryDisableAnthropicOrgBan403_IgnoresNonOrgBan403` — generic permission error / TLS challenge / empty / unrelated \"organization\" word → falls through.
- `TestHandle403_AnthropicOrgBan_PermanentlyDisables` — end-to-end via `handle403`: `SetError` called, `SetTempUnschedulable` not.

## Checklist
- `go build ./...` ✅ · `go test -tags=unit ./internal/service/` ✅ · `golangci-lint run ./internal/service/...` 0 issues ✅
- `no-web-impact` (backend-only error classification) ✅
- Sentinel anchors added in the same PR (`scripts/sentinels/gateway-tk.json`): the new companion's keyword list + function + `handleAuthError` call, and the `handle403` injection line — registry-update gate green ✅
- Net-adds an upstream symbol only; `ratelimit_service.go` edit is pure-insertion (upstream-override gate auto-pass) ✅

🤖 Generated with [Claude Code](https://claude.com/claude-code)