### PR TITLE
feat(studio): forward gemini-native image aspect ratio (restore 10-ratio picker)

### DIFF
--- a/backend/internal/pkg/antigravity/claude_types.go
+++ b/backend/internal/pkg/antigravity/claude_types.go
@@ -17,6 +17,18 @@ type ClaudeRequest struct {
 	Tools       []ClaudeTool    `json:"tools,omitempty"`
 	Thinking    *ThinkingConfig `json:"thinking,omitempty"`
 	Metadata    *ClaudeMetadata `json:"metadata,omitempty"`
+	// ImageConfig is the TK gemini-native image aspect-ratio carrier. The OpenAI-compat
+	// inbound (extra_body.google.image_config.aspect_ratio) threads it onto the Anthropic
+	// /v1/messages body across the prod→edge relay; buildGenerationConfig reads it and emits
+	// generationConfig.imageConfig.aspectRatio to cloudcode-pa. Upstream honors all 10
+	// documented ratios (prod canary 2026-06-17); not a Claude-spec field.
+	ImageConfig *ClaudeImageConfig `json:"image_config,omitempty"`
+}
+
+// ClaudeImageConfig carries the gemini-native image aspect ratio from the OpenAI-compat
+// inbound to the Gemini image transform. AspectRatio is a code like "1:1" / "16:9".
+type ClaudeImageConfig struct {
+	AspectRatio string `json:"aspect_ratio,omitempty"`
 }
 
 // ClaudeMessage Claude 消息

--- a/backend/internal/pkg/antigravity/request_transformer.go
+++ b/backend/internal/pkg/antigravity/request_transformer.go
@@ -654,7 +654,32 @@ func buildGenerationConfig(req *ClaudeRequest) *GeminiGenerationConfig {
 		config.TopK = req.TopK
 	}
 
+	// TK: gemini-native image aspect-ratio passthrough. Only image models, and only
+	// when the inbound carried a ratio (extra_body.google.image_config.aspect_ratio →
+	// ClaudeRequest.ImageConfig). Emitted as generationConfig.imageConfig.aspectRatio;
+	// cloudcode-pa honors all 10 documented ratios (prod canary 2026-06-17). The wire
+	// struct (GeminiImageConfig) already existed but was never populated.
+	if req.ImageConfig != nil && IsImageModel(req.Model) {
+		if ar := strings.TrimSpace(req.ImageConfig.AspectRatio); ar != "" {
+			config.ImageConfig = &GeminiImageConfig{AspectRatio: ar}
+		}
+	}
+
 	return config
+}
+
+// IsImageModel reports whether an antigravity (Gemini) model id is a native image
+// generation model — ids carrying an "-image" segment (gemini-3.1-flash-image,
+// …-image-preview, …-image-<variant>) or the nano-banana family. Mirrors the service
+// isImageGenerationModel allowlist and the frontend GEMINI_NATIVE_IMAGE_RE; deliberately
+// does NOT match plain gemini chat ids. Used to gate aspectRatio injection.
+func IsImageModel(model string) bool {
+	m := strings.ToLower(strings.TrimSpace(model))
+	m = strings.TrimPrefix(m, "models/")
+	if strings.Contains(m, "nano-banana") {
+		return true
+	}
+	return strings.HasPrefix(m, "gemini-") && (strings.HasSuffix(m, "-image") || strings.Contains(m, "-image-"))
 }
 
 func hasWebSearchTool(tools []ClaudeTool) bool {

--- a/backend/internal/pkg/antigravity/request_transformer_tk_image_test.go
+++ b/backend/internal/pkg/antigravity/request_transformer_tk_image_test.go
@@ -1,0 +1,85 @@
+package antigravity
+
+import (
+	"encoding/json"
+	"testing"
+
+	"github.com/tidwall/gjson"
+)
+
+// gemini-native image aspect-ratio passthrough: a ClaudeRequest.ImageConfig on an image
+// model must surface as generationConfig.imageConfig.aspectRatio on the wire to cloudcode-pa.
+// The contract (which ratios upstream honors) is proven by the prod canary 2026-06-17; this
+// guards that TK actually emits the field it dropped before.
+func transformAspectRatio(t *testing.T, model string, cfg *ClaudeImageConfig) gjson.Result {
+	t.Helper()
+	req := &ClaudeRequest{
+		Model:     model,
+		MaxTokens: 1024,
+		Messages: []ClaudeMessage{
+			{Role: "user", Content: json.RawMessage(`"a red apple on a table"`)},
+		},
+		ImageConfig: cfg,
+	}
+	body, err := TransformClaudeToGeminiWithOptions(req, "project-1", model, DefaultTransformOptions())
+	if err != nil {
+		t.Fatalf("transform: %v", err)
+	}
+	// TransformClaudeToGeminiWithOptions returns the full v1internal envelope
+	// ({project,…,request:{…,generationConfig}}), so the ratio lives under request.*.
+	return gjson.GetBytes(body, "request.generationConfig.imageConfig.aspectRatio")
+}
+
+func TestAspectRatioPassthrough_ImageModel_Emitted(t *testing.T) {
+	for _, model := range []string{
+		"gemini-3.1-flash-image",
+		"gemini-3.1-flash-image-preview",
+		"gemini-2.5-flash-image",
+		"gemini-3-pro-image",
+	} {
+		for _, ratio := range []string{"1:1", "16:9", "9:16", "21:9", "4:3"} {
+			got := transformAspectRatio(t, model, &ClaudeImageConfig{AspectRatio: ratio})
+			if got.String() != ratio {
+				t.Errorf("model=%s ratio=%s: got imageConfig.aspectRatio=%q, want %q", model, ratio, got.String(), ratio)
+			}
+		}
+	}
+}
+
+func TestAspectRatioPassthrough_NonImageModel_NotEmitted(t *testing.T) {
+	// A chat model must never get an imageConfig even if a ratio leaks through.
+	got := transformAspectRatio(t, "gemini-2.5-flash", &ClaudeImageConfig{AspectRatio: "16:9"})
+	if got.Exists() {
+		t.Errorf("chat model emitted imageConfig.aspectRatio=%q, want absent", got.String())
+	}
+}
+
+func TestAspectRatioPassthrough_NoConfig_NotEmitted(t *testing.T) {
+	// Image model without a ratio (the default-dimensions path) must not emit imageConfig.
+	if got := transformAspectRatio(t, "gemini-3.1-flash-image", nil); got.Exists() {
+		t.Errorf("nil ImageConfig emitted imageConfig.aspectRatio=%q, want absent", got.String())
+	}
+	if got := transformAspectRatio(t, "gemini-3.1-flash-image", &ClaudeImageConfig{AspectRatio: ""}); got.Exists() {
+		t.Errorf("empty AspectRatio emitted imageConfig.aspectRatio=%q, want absent", got.String())
+	}
+}
+
+func TestIsImageModel(t *testing.T) {
+	cases := map[string]bool{
+		"gemini-3.1-flash-image":         true,
+		"gemini-3.1-flash-image-preview": true,
+		"gemini-2.5-flash-image":         true,
+		"gemini-3-pro-image":             true,
+		"models/gemini-3.1-flash-image":  true,
+		"nano-banana-pro":                true,
+		"gemini-2.5-flash":               false,
+		"gemini-3-flash-agent":           false,
+		"claude-opus-4-8":                false,
+		"":                               false,
+	}
+	for model, want := range cases {
+		if got := IsImageModel(model); got != want {
+			t.Errorf("IsImageModel(%q)=%v, want %v", model, got, want)
+		}
+	}
+}

--- a/backend/internal/service/gateway_forward_as_chat_completions.go
+++ b/backend/internal/service/gateway_forward_as_chat_completions.go
@@ -105,6 +105,11 @@ func (s *GatewayService) ForwardAsChatCompletions(
 	// 7. Enforce cache_control block limit
 	anthropicBody = enforceCacheControlLimit(anthropicBody)
 
+	// TK: thread gemini-native image aspect ratio (extra_body.google.image_config.
+	// aspect_ratio) from the raw CC body onto the relayed Anthropic body; the antigravity
+	// Gemini transform consumes it downstream. No-op for non-image / ratio-less requests.
+	anthropicBody = tkInjectGeminiImageAspectRatio(body, anthropicBody)
+
 	// 8. Get access token
 	token, tokenType, err := s.GetAccessToken(ctx, account)
 	if err != nil {

--- a/backend/internal/service/gateway_forward_as_chat_completions_tk_image.go
+++ b/backend/internal/service/gateway_forward_as_chat_completions_tk_image.go
@@ -1,0 +1,36 @@
+package service
+
+import (
+	"strings"
+
+	"github.com/tidwall/gjson"
+	"github.com/tidwall/sjson"
+)
+
+// tkInjectGeminiImageAspectRatio threads a gemini-native image aspect ratio from an
+// OpenAI Chat Completions inbound onto the Anthropic /v1/messages body that the
+// OpenAI-compat path (GatewayService.ForwardAsChatCompletions) relays upstream.
+//
+// The inbound carries the ratio at extra_body.google.image_config.aspect_ratio — a field
+// apicompat.ChatCompletionsRequest does not model, so it is invisible to the CC→Responses→
+// Anthropic struct chain (same situation as reasoning_effort, which the call site already
+// re-reads from the raw body via gjson). We therefore lift it straight off the raw CC body
+// and stamp it onto the relayed Anthropic body as image_config.aspect_ratio. Downstream the
+// antigravity transform (internal/pkg/antigravity) reads ClaudeRequest.ImageConfig and emits
+// generationConfig.imageConfig.aspectRatio to cloudcode-pa, which honors all 10 documented
+// ratios (prod canary 2026-06-17).
+//
+// No-op unless the inbound carried a non-empty aspect_ratio, so non-image / ratio-less
+// traffic is untouched. Pure over bytes to keep the ForwardAsChatCompletions call site to a
+// single line and the behavior unit-testable.
+func tkInjectGeminiImageAspectRatio(ccBody, anthropicBody []byte) []byte {
+	ar := strings.TrimSpace(gjson.GetBytes(ccBody, "extra_body.google.image_config.aspect_ratio").String())
+	if ar == "" {
+		return anthropicBody
+	}
+	out, err := sjson.SetBytes(anthropicBody, "image_config.aspect_ratio", ar)
+	if err != nil {
+		return anthropicBody
+	}
+	return out
+}

--- a/backend/internal/service/gateway_forward_as_chat_completions_tk_image_test.go
+++ b/backend/internal/service/gateway_forward_as_chat_completions_tk_image_test.go
@@ -3,8 +3,10 @@
 package service
 
 import (
+	"encoding/json"
 	"testing"
 
+	"github.com/Wei-Shaw/sub2api/internal/pkg/antigravity"
 	"github.com/tidwall/gjson"
 )
 
@@ -42,4 +44,38 @@ func TestTkInjectGeminiImageAspectRatio(t *testing.T) {
 			t.Errorf("image_config injected for empty ratio: %s", out)
 		}
 	})
+}
+
+// End-to-end wire contract: the whole feature hinges on the prod-side injection key
+// (image_config.aspect_ratio) matching the edge-side antigravity.ClaudeRequest json tags.
+// The two halves are otherwise tested in isolation (the transform test sets ImageConfig via
+// the Go field, bypassing JSON), so a rename of either json tag would silently break the
+// passthrough with every other test still green. This crosses the real boundary: inject onto
+// an Anthropic body, unmarshal it into ClaudeRequest exactly as Forward does, run the
+// transform, and assert the ratio reaches generationConfig.imageConfig.aspectRatio.
+func TestGeminiAspectRatio_ProdToEdgeWireContract(t *testing.T) {
+	const ratio = "16:9"
+	const model = "gemini-3.1-flash-image"
+	cc := []byte(`{"model":"` + model + `","messages":[],"extra_body":{"google":{"image_config":{"aspect_ratio":"` + ratio + `"}}}}`)
+	anthropic := []byte(`{"model":"` + model + `","messages":[{"role":"user","content":"a red apple"}],"max_tokens":1024}`)
+
+	relayed := tkInjectGeminiImageAspectRatio(cc, anthropic)
+
+	// Edge: Forward unmarshals the relayed body into a ClaudeRequest.
+	var claudeReq antigravity.ClaudeRequest
+	if err := json.Unmarshal(relayed, &claudeReq); err != nil {
+		t.Fatalf("unmarshal relayed body into ClaudeRequest: %v", err)
+	}
+	if claudeReq.ImageConfig == nil || claudeReq.ImageConfig.AspectRatio != ratio {
+		t.Fatalf("ClaudeRequest.ImageConfig did not carry the ratio: %+v (json key drift between inject and ClaudeRequest tags?)", claudeReq.ImageConfig)
+	}
+
+	// Edge: transform emits it onto the cloudcode-pa wire.
+	body, err := antigravity.TransformClaudeToGeminiWithOptions(&claudeReq, "p", model, antigravity.DefaultTransformOptions())
+	if err != nil {
+		t.Fatalf("transform: %v", err)
+	}
+	if got := gjson.GetBytes(body, "request.generationConfig.imageConfig.aspectRatio").String(); got != ratio {
+		t.Fatalf("upstream wire aspectRatio=%q, want %q", got, ratio)
+	}
 }

--- a/backend/internal/service/gateway_forward_as_chat_completions_tk_image_test.go
+++ b/backend/internal/service/gateway_forward_as_chat_completions_tk_image_test.go
@@ -1,0 +1,45 @@
+//go:build unit
+
+package service
+
+import (
+	"testing"
+
+	"github.com/tidwall/gjson"
+)
+
+// The OpenAI-compat path must lift extra_body.google.image_config.aspect_ratio off the raw
+// CC body and stamp it onto the relayed Anthropic body as image_config.aspect_ratio (which
+// apicompat.ChatCompletionsRequest does not model). The antigravity transform reads it
+// downstream. No-op for ratio-less inbounds.
+func TestTkInjectGeminiImageAspectRatio(t *testing.T) {
+	anthropic := []byte(`{"model":"gemini-3.1-flash-image","messages":[{"role":"user","content":"hi"}]}`)
+
+	t.Run("injects when present", func(t *testing.T) {
+		cc := []byte(`{"model":"gemini-3.1-flash-image","messages":[],"extra_body":{"google":{"image_config":{"aspect_ratio":"16:9"}}}}`)
+		out := tkInjectGeminiImageAspectRatio(cc, anthropic)
+		if got := gjson.GetBytes(out, "image_config.aspect_ratio").String(); got != "16:9" {
+			t.Errorf("image_config.aspect_ratio=%q, want 16:9", got)
+		}
+		// Original anthropic fields preserved.
+		if got := gjson.GetBytes(out, "model").String(); got != "gemini-3.1-flash-image" {
+			t.Errorf("model clobbered: %q", got)
+		}
+	})
+
+	t.Run("no-op when absent", func(t *testing.T) {
+		cc := []byte(`{"model":"gemini-3.1-flash-image","messages":[]}`)
+		out := tkInjectGeminiImageAspectRatio(cc, anthropic)
+		if gjson.GetBytes(out, "image_config").Exists() {
+			t.Errorf("image_config injected for ratio-less inbound: %s", out)
+		}
+	})
+
+	t.Run("no-op when empty string", func(t *testing.T) {
+		cc := []byte(`{"extra_body":{"google":{"image_config":{"aspect_ratio":""}}}}`)
+		out := tkInjectGeminiImageAspectRatio(cc, anthropic)
+		if gjson.GetBytes(out, "image_config").Exists() {
+			t.Errorf("image_config injected for empty ratio: %s", out)
+		}
+	})
+}

--- a/backend/internal/web/dist/frontend-source.json
+++ b/backend/internal/web/dist/frontend-source.json
@@ -1,7 +1,7 @@
 {
   "algorithm": "sha256(git-ls-files:path,size,content)",
   "file_count": 486,
-  "hash": "8e7b9e1820f035f4c2a1bec8941e355f89eec326a49fbbdced3e28c06e183826",
+  "hash": "8e08cfbe94a018d9e76068dc8d2ad548e936295bdde32efa4723c21de1848334",
   "schema": 1,
   "source": "frontend/"
 }

--- a/frontend/src/constants/__tests__/mediaTiers.tk.spec.ts
+++ b/frontend/src/constants/__tests__/mediaTiers.tk.spec.ts
@@ -8,6 +8,7 @@ import {
   MEDIA_MODELS,
   IMAGEN_IMAGE_SIZES,
   SEEDREAM_IMAGE_SIZES,
+  GEMINI_IMAGE_SIZES,
   type ModalityKeyOption,
   type StudioParam,
 } from '@/constants/mediaTiers.tk'
@@ -226,14 +227,13 @@ describe('image aspect options (per-model, upstream-valid wire values)', () => {
   // and Imagen must send the ratio code verbatim.
   const IMAGEN_VALID = new Set(['1:1', '3:4', '4:3', '9:16', '16:9'])
 
-  it('imagen/seedream image models carry imageSizes; gemini (flat) and video carry none', () => {
-    // Gemini-native image has NO aspect picker (the ratio control is not honored on its
-    // serving path — #807 R-001), so its entries carry no imageSizes.
-    for (const m of MEDIA_MODELS.filter((m) => m.modality === 'image' && !m.flatImageBilling)) {
+  it('all image models carry imageSizes (gemini too, post-canary); video carry none', () => {
+    // Gemini-native image regained its aspect picker: a prod canary (2026-06-17) confirmed
+    // cloudcode-pa honors imageConfig.aspectRatio for all 10 documented ratios, lifting the
+    // #807 R-001 "no picker" deferral. So every image model now carries imageSizes; only
+    // video models (passthrough hint, separate VIDEO_ASPECT_PRESETS) carry none.
+    for (const m of MEDIA_MODELS.filter((m) => m.modality === 'image')) {
       expect(m.imageSizes && m.imageSizes.length).toBeTruthy()
-    }
-    for (const m of MEDIA_MODELS.filter((m) => m.modality === 'image' && m.flatImageBilling)) {
-      expect(m.imageSizes).toBeUndefined()
     }
     for (const m of MEDIA_MODELS.filter((m) => m.modality === 'video')) {
       expect(m.imageSizes).toBeUndefined()
@@ -263,17 +263,29 @@ describe('image aspect options (per-model, upstream-valid wire values)', () => {
     expect(new Set(IMAGEN_IMAGE_SIZES.map((o) => o.ratio))).toEqual(IMAGEN_VALID)
   })
 
-  it('gemini image models are flatImageBilling with no aspect picker; imagen/seedream are tiered', () => {
+  it('gemini image models are flatImageBilling AND carry the 10-ratio picker; imagen/seedream are tiered', () => {
     const gemini = MEDIA_MODELS.filter((m) => m.modality === 'image' && m.flatImageBilling)
     expect(gemini.length).toBeGreaterThan(0)
     for (const m of gemini) {
-      expect(m.imageSizes).toBeUndefined() // ratio control not honored on the serving path (#807 R-001)
+      // flat billing (no 1K/2K/4K size tier) is orthogonal to aspect ratio: the picker
+      // now drives aspect_ratio only, billing stays flat per image.
+      expect(m.imageSizes).toBe(GEMINI_IMAGE_SIZES)
     }
     for (const m of MEDIA_MODELS.filter(
       (m) => m.imageSizes === IMAGEN_IMAGE_SIZES || m.imageSizes === SEEDREAM_IMAGE_SIZES
     )) {
       expect(m.flatImageBilling).toBeFalsy()
     }
+  })
+
+  it('GEMINI_IMAGE_SIZES sends the ratio code verbatim and is exactly the 10 prod-verified ratios', () => {
+    // Mirrors the prod canary (2026-06-17): each of these returned dims matching the
+    // requested ratio. value === ratio because gemini bills flat (no pixel size).
+    const PROD_VERIFIED = new Set(['1:1', '2:3', '3:2', '3:4', '4:3', '4:5', '5:4', '9:16', '16:9', '21:9'])
+    for (const opt of GEMINI_IMAGE_SIZES) {
+      expect(opt.value).toBe(opt.ratio)
+    }
+    expect(new Set(GEMINI_IMAGE_SIZES.map((o) => o.ratio))).toEqual(PROD_VERIFIED)
   })
 
   it('Seedream sends pixel WxH within ARK range [1024², 4096²], ratio range [1/16,16]', () => {

--- a/frontend/src/constants/mediaTiers.tk.ts
+++ b/frontend/src/constants/mediaTiers.tk.ts
@@ -160,13 +160,27 @@ export const SEEDREAM_IMAGE_SIZES: ImageSizeOption[] = [
   { ratio: '16:9', value: '2048x1152' },
 ]
 
-// NB: gemini-native image has NO aspect-ratio picker. The control was verified
-// non-functional on the antigravity serving path (prod: 1:1 / 9:16 / 16:9 all return
-// 1408x768 — extra_body.google.image_config.aspect_ratio is dropped before the
-// upstream). Rather than ship a cosmetic control we omit it; gemini image generates at
-// the model's default ratio. Forwarding the ratio is a separate backend effort (it must
-// thread aspect_ratio through the OpenAI→Claude→Gemini transform) gated on a prod canary
-// that confirms cloudcode-pa actually honors it. See PR #807 review R-001.
+/**
+ * Gemini-native image: send the ratio code verbatim — it rides extra_body.google.
+ * image_config.aspect_ratio and the antigravity transform emits it as generationConfig.
+ * imageConfig.aspectRatio to cloudcode-pa. A prod canary (2026-06-17) confirmed upstream
+ * honors all 10 documented ratios (returned dims match each requested ratio within ~1%),
+ * which is why R-001's "no picker" deferral is now lifted. Value === ratio (no pixel size:
+ * gemini bills flat per image, so sentSize feeds aspect_ratio only). (ref: Google Gemini-3
+ * image docs — supported aspectRatio set.)
+ */
+export const GEMINI_IMAGE_SIZES: ImageSizeOption[] = [
+  { ratio: '1:1', value: '1:1' },
+  { ratio: '2:3', value: '2:3' },
+  { ratio: '3:2', value: '3:2' },
+  { ratio: '3:4', value: '3:4' },
+  { ratio: '4:3', value: '4:3' },
+  { ratio: '4:5', value: '4:5' },
+  { ratio: '5:4', value: '5:4' },
+  { ratio: '9:16', value: '9:16' },
+  { ratio: '16:9', value: '16:9' },
+  { ratio: '21:9', value: '21:9' },
+]
 
 /** Video aspect ratios — passthrough hint to the task adaptor (TK does not interpret). */
 export interface VideoAspectPreset {
@@ -318,6 +332,7 @@ export const MEDIA_MODELS: MediaModel[] = [
     modality: 'image',
     supportedParams: [],
     flatImageBilling: true,
+    imageSizes: GEMINI_IMAGE_SIZES,
   },
   {
     modelId: 'gemini-2.5-flash-image',
@@ -329,6 +344,7 @@ export const MEDIA_MODELS: MediaModel[] = [
     modality: 'image',
     supportedParams: [],
     flatImageBilling: true,
+    imageSizes: GEMINI_IMAGE_SIZES,
   },
   {
     modelId: 'gemini-3-pro-image-preview',
@@ -340,6 +356,7 @@ export const MEDIA_MODELS: MediaModel[] = [
     modality: 'image',
     supportedParams: [],
     flatImageBilling: true,
+    imageSizes: GEMINI_IMAGE_SIZES,
   },
   // gpt-image-* is deliberately ABSENT: it needs a type=apikey OpenAI account
   // (OAuth subscriptions 502). If a future probe adds an apikey-backed group,

--- a/scripts/sentinels/antigravity.json
+++ b/scripts/sentinels/antigravity.json
@@ -15,6 +15,14 @@
         "Header.Set(\"X-Goog-Api-Client\""
       ],
       "rationale": "On-wire-confirmed: the real IDE sends NO X-Goog-Api-Client(gl-node) header on setUserSettings/fetchUserInfo. TK removed the pinned `gl-node/22.21.1`. An upstream merge re-adding it re-introduces a header the real client never sends (fingerprint noise). Locked by client_test.go TestPrivacyCalls_无GlNode且UA带hub too — this sentinel additionally catches an upstream merge that reverts the source without the test running."
+    },
+    {
+      "path": "backend/internal/pkg/antigravity/request_transformer.go",
+      "must_contain": [
+        "func IsImageModel(model string) bool {",
+        "config.ImageConfig = &GeminiImageConfig{AspectRatio: ar}"
+      ],
+      "rationale": "Gemini-native image aspect-ratio passthrough, edge transform side. buildGenerationConfig emits generationConfig.imageConfig.aspectRatio (the GeminiImageConfig wire struct existed but was never populated until 2026-06-17) from ClaudeRequest.ImageConfig, gated on IsImageModel so chat models never get an imageConfig. A prod canary confirmed cloudcode-pa honors all 10 documented ratios; if an upstream merge or refactor drops the emit or the gate, the ratio silently reverts to the model default (1408x768) — invisible because the request still 200s. Pairs with the prod-side gateway_forward_as_chat_completions.go injection sentinel (gateway-tk.json)."
     }
   ]
 }

--- a/scripts/sentinels/frontend-tk.json
+++ b/scripts/sentinels/frontend-tk.json
@@ -813,9 +813,10 @@
         "export function resolveAvailableModels",
         "supportedParams",
         "export const IMAGEN_IMAGE_SIZES",
-        "export const SEEDREAM_IMAGE_SIZES"
+        "export const SEEDREAM_IMAGE_SIZES",
+        "export const GEMINI_IMAGE_SIZES"
       ],
-      "rationale": "TK-only Studio model catalog + capability map. MEDIA_MODELS lists each priced+servable media model (friendly name, vendor, price, supportedParams); resolveAvailableModels(modality, availableIds) is the priced∩servable filter the model-card picker drives (replacing the tier-card selection). Dropping these silently regresses the transparent model picker or, worse, lets an unservable/unpriced model surface as a 400-on-submit footgun. supportedParams is the honest Advanced-panel capability gate — only params a model actually honors are rendered. IMAGEN_IMAGE_SIZES / SEEDREAM_IMAGE_SIZES are the per-model aspect-ratio option sets: Imagen MUST send ratio codes {1:1,3:4,4:3,9:16,16:9} verbatim and Seedream MUST send pixel WxH — losing them reverts to the fixed-pixel preset that made the gemini/vertex adaptor emit 3:2/2:3, which Imagen hard-400s ('Invalid aspect ratio, 3:2')."
+      "rationale": "TK-only Studio model catalog + capability map. MEDIA_MODELS lists each priced+servable media model (friendly name, vendor, price, supportedParams); resolveAvailableModels(modality, availableIds) is the priced∩servable filter the model-card picker drives (replacing the tier-card selection). Dropping these silently regresses the transparent model picker or, worse, lets an unservable/unpriced model surface as a 400-on-submit footgun. supportedParams is the honest Advanced-panel capability gate — only params a model actually honors are rendered. IMAGEN_IMAGE_SIZES / SEEDREAM_IMAGE_SIZES / GEMINI_IMAGE_SIZES are the per-model aspect-ratio option sets: Imagen MUST send ratio codes {1:1,3:4,4:3,9:16,16:9} verbatim, Seedream MUST send pixel WxH, and GEMINI_IMAGE_SIZES carries the 10 prod-canary-verified (2026-06-17) gemini-native ratios that ride extra_body.google.image_config.aspect_ratio. Losing the imagen set reverts to the fixed-pixel preset that made the gemini/vertex adaptor emit 3:2/2:3, which Imagen hard-400s ('Invalid aspect ratio, 3:2'); losing the gemini set silently drops the restored aspect picker back to R-001's no-control state."
     },
     {
       "path": "frontend/src/views/user/KeysView.vue",

--- a/scripts/sentinels/gateway-tk.json
+++ b/scripts/sentinels/gateway-tk.json
@@ -635,9 +635,10 @@
       "path": "backend/internal/service/gateway_forward_as_chat_completions.go",
       "must_contain": [
         "Wei-Shaw/sub2api#1311",
-        "c.Writer.Header().Set(\"Content-Type\", \"application/json; charset=utf-8\")"
+        "c.Writer.Header().Set(\"Content-Type\", \"application/json; charset=utf-8\")",
+        "anthropicBody = tkInjectGeminiImageAspectRatio(body, anthropicBody)"
       ],
-      "rationale": "Gateway Anthropic-backed /v1/chat/completions non-stream path (handleCCBufferedFromAnthropic) shares the upstream #1311 Content-Type leak root cause and must explicitly override Content-Type after WriteFilteredHeaders so the converted chat.completion JSON body is not labeled text/event-stream."
+      "rationale": "Gateway Anthropic-backed /v1/chat/completions non-stream path (handleCCBufferedFromAnthropic) shares the upstream #1311 Content-Type leak root cause and must explicitly override Content-Type after WriteFilteredHeaders so the converted chat.completion JSON body is not labeled text/event-stream. Also the call site wiring the gemini-native image aspect-ratio injection (tkInjectGeminiImageAspectRatio, gateway_forward_as_chat_completions_tk_image.go) into the OpenAI-compat → Anthropic forward, after enforceCacheControlLimit and before buildUpstreamRequest — the companion compiling alone would not catch a dropped call site, so the one-line hook is anchored here separately."
     },
     {
       "path": "backend/internal/service/gateway_forward_as_responses_tk_content_type_test.go",
@@ -2678,6 +2679,15 @@
         "func tkResolveResponsesSelectionModel("
       ],
       "rationale": "TK companion (PR #809) holding the /v1/responses dispatch model-mapping helpers: forward-body rewrite (tkApplyResponsesDispatchModelMapping) and account-selection model (tkResolveResponsesSelectionModel). Load-bearing: deleting the file silently regresses /v1/responses for claude model names (upstream 400) and the responses<->messages selection parity. Anchored so an upstream merge or refactor cannot remove the companion without tripping the sentinel; pairs with the openai_gateway_handler.go injection-site sentinel above."
+    },
+    {
+      "path": "backend/internal/service/gateway_forward_as_chat_completions_tk_image.go",
+      "must_contain": [
+        "func tkInjectGeminiImageAspectRatio(",
+        "extra_body.google.image_config.aspect_ratio",
+        "sjson.SetBytes(anthropicBody, \"image_config.aspect_ratio\", ar)"
+      ],
+      "rationale": "Gemini-native image aspect-ratio passthrough, prod side. The Studio rides extra_body.google.image_config.aspect_ratio on /v1/chat/completions; apicompat.ChatCompletionsRequest does not model extra_body, so the OpenAI-compat path (ForwardAsChatCompletions) would silently drop it (exactly how it was lost pre-fix — PR #807 R-001). This helper re-reads the ratio off the raw CC body (parity with extractCCReasoningEffortFromBody) and stamps it onto the relayed Anthropic /v1/messages body as image_config.aspect_ratio, where the edge antigravity transform turns it into generationConfig.imageConfig.aspectRatio. A prod canary (2026-06-17) confirmed cloudcode-pa honors all 10 ratios. The call site lives in gateway_forward_as_chat_completions.go (anchored there); the antigravity request_transformer.go emit is anchored in antigravity.json. If any is dropped by an upstream merge the ratio silently reverts to upstream default and the regression is invisible."
     }
   ]
 }


### PR DESCRIPTION
## Problem

Gemini-native image (`gemini-3.x-flash-image` / nano-banana) ignored the Studio aspect picker. The ratio rides `extra_body.google.image_config.aspect_ratio` on `/v1/chat/completions`, but `apicompat.ChatCompletionsRequest` never modeled `extra_body`, and on the Gemini transform `buildGenerationConfig` never populated the (already-wired) `GeminiImageConfig`. So #807 R-001 shipped without the picker, deferring it to a prod canary that confirms cloudcode-pa actually honors `aspectRatio`.

## Prod canary (2026-06-17) — upstream honors it, all 10 ratios

Ran on the us3 edge (`antigravity-oh1-ls-b` → `cloudcode-pa`), **real OAuth token, prod egress, TK's exact `v1internal` envelope**, varying only `generationConfig.imageConfig.aspectRatio`:

| ratio | dims | ratio | dims | ratio | dims |
|---|---|---|---|---|---|
| *(none)* | 1408×768 | 3:4 | 896×1200 | 9:16 | 768×1376 |
| 1:1 | 1024×1024 | 4:3 | 1200×896 | 16:9 | 1376×768 |
| 2:3 | 848×1264 | 4:5 | 928×1152 | 21:9 | 1584×672 |
| 3:2 | 1264×848 | 5:4 | 1152×928 | | |

All HTTP 200; returned dims match each requested ratio within ~1%. R-001's *"1:1/9:16/16:9 all → 1408×768"* was reading the **default** (no `imageConfig`, = the *none* row) — TK's own drop, **not** an upstream limit.

## Change — 2-point passthrough across the prod→edge mirror relay

The wire struct (`GeminiGenerationConfig.ImageConfig → aspectRatio`) already existed and serializes correctly; it was just never populated. The flow is **prod (CC→Anthropic relay) → edge `/v1/messages` (antigravity→Gemini transform)**, so the ratio is threaded at 2 points:

- **prod OpenAI-compat path** (`ForwardAsChatCompletions`): `tkInjectGeminiImageAspectRatio` lifts the ratio off the raw CC body (parity with the existing `extractCCReasoningEffortFromBody`) and stamps `image_config.aspect_ratio` onto the relayed Anthropic `/v1/messages` body. `ChatCompletionsRequest` has no `extra_body` field, so the struct chain can't carry it.
- **edge antigravity transform**: `ClaudeRequest.ImageConfig` → `buildGenerationConfig` sets `GeminiImageConfig.AspectRatio`, gated on `IsImageModel` (chat models never get an `imageConfig`).
- **Studio**: restore the gemini ratio picker via `GEMINI_IMAGE_SIZES` (the 10 verified ratios). The picker UI + `extra_body` forwarding already existed; R-001 had only emptied gemini's `imageSizes`.

Purely additive — imagen/seedream/veo paths untouched.

## Tests / gates

- antigravity transform pos/neg (4 image models × 5 ratios emit `imageConfig.aspectRatio`; chat model + nil config emit nothing) + `IsImageModel`.
- prod-side `tkInjectGeminiImageAspectRatio` (injects / no-op absent / no-op empty).
- frontend 10-ratio catalog invariant (replaces the #807 no-`imageSizes` assertion) + `value === ratio` + the prod-verified set.
- Sentinels added: prod injection (`gateway-tk.json`), edge emit (`antigravity.json`), frontend ratio set (`frontend-tk.json`).
- `preflight` / `golangci-lint` / `typecheck` / `lint` / `vitest` green. Upstream-override auto-passes (pure insertion + sentinel coverage); registry-update gate satisfied via the new sentinel anchor.

Reviewer: per §5.y this is a TK feature → **Squash and merge**.

🤖 Generated with [Claude Code](https://claude.com/claude-code)