### PR TITLE
chore(billing): consolidate gemini image-model predicate to one source (#814 R-002)

### DIFF
--- a/backend/internal/service/antigravity_gateway_service.go
+++ b/backend/internal/service/antigravity_gateway_service.go
@@ -4141,23 +4141,16 @@ func (s *AntigravityGatewayService) extractImageInputSize(body []byte) string {
 	return ""
 }
 
-// isImageGenerationModel 判断模型是否为图片生成模型
-// 支持的模型：gemini-3.1-flash-image, gemini-3-pro-image, gemini-2.5-flash-image 等
+// isImageGenerationModel 判断模型是否为图片生成模型（gemini-3.1-flash-image,
+// gemini-3-pro-image, gemini-2.5-flash-image, nano-banana 等）。
+//
+// 委托给 antigravity.IsImageModel（单一真值源），消除此前 service 硬编码白名单与
+// antigravity 包谓词的重复维护（xj-review #814 R-002）。两者对所有已有/已测模型结果
+// 一致；canonical 版本以 `gemini-*-image` 子串 + nano-banana 识别，故未来新增的 gemini
+// 图片模型会被自动识别，不再需要手工追加白名单（旧白名单遗漏即静默漏计费）。前端
+// GEMINI_NATIVE_IMAGE_RE 因语言隔离仍为镜像（无法共享 Go 代码）。
 func isImageGenerationModel(model string) bool {
-	modelLower := strings.ToLower(model)
-	// 移除 models/ 前缀
-	modelLower = strings.TrimPrefix(modelLower, "models/")
-
-	// 精确匹配或前缀匹配
-	return modelLower == "gemini-3.1-flash-image" ||
-		modelLower == "gemini-3.1-flash-image-preview" ||
-		strings.HasPrefix(modelLower, "gemini-3.1-flash-image-") ||
-		modelLower == "gemini-3-pro-image" ||
-		modelLower == "gemini-3-pro-image-preview" ||
-		strings.HasPrefix(modelLower, "gemini-3-pro-image-") ||
-		modelLower == "gemini-2.5-flash-image" ||
-		modelLower == "gemini-2.5-flash-image-preview" ||
-		strings.HasPrefix(modelLower, "gemini-2.5-flash-image-")
+	return antigravity.IsImageModel(model)
 }
 
 // cleanGeminiRequest 清理 Gemini 请求体中的 Schema

--- a/backend/internal/service/antigravity_image_test.go
+++ b/backend/internal/service/antigravity_image_test.go
@@ -40,6 +40,18 @@ func TestIsImageGenerationModel_CaseInsensitive(t *testing.T) {
 	require.True(t, isImageGenerationModel("GEMINI-2.5-FLASH-IMAGE"))
 }
 
+// TestIsImageGenerationModel_DelegatesToCanonical locks the R-002 consolidation
+// (#814): isImageGenerationModel delegates to antigravity.IsImageModel, so a FUTURE
+// gemini image model is recognized without touching a hardcoded allowlist (the old
+// allowlist would have silently failed to bill it). Reverting to a narrow allowlist
+// fails here. nano-banana (an alias family) is likewise recognized.
+func TestIsImageGenerationModel_DelegatesToCanonical(t *testing.T) {
+	require.True(t, isImageGenerationModel("gemini-4-flash-image"))       // future family, not in old allowlist
+	require.True(t, isImageGenerationModel("gemini-5-pro-image-preview")) // future family + variant
+	require.True(t, isImageGenerationModel("nano-banana-pro"))            // alias family
+	require.False(t, isImageGenerationModel("gemini-4-flash"))            // future chat model, no -image
+}
+
 // TestExtractImageSize_ValidSizes 测试有效尺寸解析
 func TestExtractImageSize_ValidSizes(t *testing.T) {
 	svc := &AntigravityGatewayService{}

--- a/scripts/sentinels/gateway-tk.json
+++ b/scripts/sentinels/gateway-tk.json
@@ -2688,6 +2688,13 @@
         "sjson.SetBytes(anthropicBody, \"image_config.aspect_ratio\", ar)"
       ],
       "rationale": "Gemini-native image aspect-ratio passthrough, prod side. The Studio rides extra_body.google.image_config.aspect_ratio on /v1/chat/completions; apicompat.ChatCompletionsRequest does not model extra_body, so the OpenAI-compat path (ForwardAsChatCompletions) would silently drop it (exactly how it was lost pre-fix — PR #807 R-001). This helper re-reads the ratio off the raw CC body (parity with extractCCReasoningEffortFromBody) and stamps it onto the relayed Anthropic /v1/messages body as image_config.aspect_ratio, where the edge antigravity transform turns it into generationConfig.imageConfig.aspectRatio. A prod canary (2026-06-17) confirmed cloudcode-pa honors all 10 ratios. The call site lives in gateway_forward_as_chat_completions.go (anchored there); the antigravity request_transformer.go emit is anchored in antigravity.json. If any is dropped by an upstream merge the ratio silently reverts to upstream default and the regression is invisible."
+    },
+    {
+      "path": "backend/internal/service/antigravity_gateway_service.go",
+      "must_contain": [
+        "return antigravity.IsImageModel(model)"
+      ],
+      "rationale": "isImageGenerationModel delegates to the canonical antigravity.IsImageModel (single source of truth for gemini-native image detection; #814 R-002 consolidation). antigravity_gateway_service.go is a large gateway file that attracts upstream merges; one that rewrites this helper could silently restore the old hardcoded gemini-image allowlist body, re-forking the predicate into 3 divergent copies and silently failing to bill future gemini image models (imageCount never fires). Pinning the one-line delegation keeps the dedup mechanical. Pairs with the antigravity.IsImageModel definition sentinel (antigravity.json) and the TestIsImageGenerationModel_DelegatesToCanonical behavioral guard."
     }
   ]
 }


### PR DESCRIPTION
Follow-up to #814 (xj-review finding **R-002**).

## Problem

"Is this a gemini image model?" had **three** deciders with divergent logic:

- `service.isImageGenerationModel` — hardcoded allowlist (gemini-3.1-flash-image / gemini-3-pro-image / gemini-2.5-flash-image + variants), drives billing `imageCount`.
- `antigravity.IsImageModel` — `gemini-*-image` substring + nano-banana (added in #814).
- frontend `GEMINI_NATIVE_IMAGE_RE` — equivalent regex.

No current model triggers a disagreement (all 3 shipped families are in the allowlist), but a future `gemini-4-flash-image` would be recognized by the antigravity transform **and** the frontend, yet silently **not billed as a flat image** by the service allowlist — a latent revenue bug that only surfaces when someone adds a model and forgets the allowlist.

## Change

`service.isImageGenerationModel` now delegates to `antigravity.IsImageModel` (single source of truth). Behavior is **byte-identical for every existing/tested model** — the unchanged `TestIsImageGenerationModel_*` cases (including the tricky false cases like `my-gemini-3-pro-image-test` and the uppercase trues) all still pass — and future gemini image families are auto-recognized instead of needing a manual allowlist bump. The service's 5 callers (billing, account-test probe, two gemini-compat paths) all benefit.

The frontend regex stays a **documented mirror** — Go↔TS can't share code, so 3→2 is the floor here; the remaining split is unavoidable.

## Tests / gates

- `TestIsImageGenerationModel_DelegatesToCanonical` locks the future-model recognition (`gemini-4-flash-image`, `gemini-5-pro-image-preview`, `nano-banana-pro` → true; `gemini-4-flash` → false), so a revert to a narrow allowlist fails CI.
- All existing `isImageGenerationModel` tests unchanged and green.
- `preflight` / `golangci` / `go test -tags=unit` green. **Backend-only, no web impact.** Override gate reports no upstream-shaped path touched (antigravity is a TK platform file).

Reviewer: per §5.y this is a TK chore → **Squash and merge**.

🤖 Generated with [Claude Code](https://claude.com/claude-code)