### PR TITLE
fix(gateway): advertise qwen3-8b/14b/32b on Qwen account 60 (tk_029)

### DIFF
--- a/backend/migrations/tk_029_qwen3_dense_8b_14b_32b_model_mapping.sql
+++ b/backend/migrations/tk_029_qwen3_dense_8b_14b_32b_model_mapping.sql
@@ -1,0 +1,57 @@
+-- Migration: tk_029_qwen3_dense_8b_14b_32b_model_mapping
+--
+-- Advertise the three open-source DENSE Qwen3 models on the Qwen account (id=60),
+-- so the Qwen group can serve them:
+--   - account 60 "Qwen" (Ali, channel_type=17): qwen3-8b, qwen3-14b, qwen3-32b
+--
+-- Why (prod 2026-06-17, per customer request): clients sent these dense Qwen3
+-- names but account 60's credentials.model_mapping is an identity WHITELIST that
+-- only listed the qwen3.7-max family + qwen-max/qwen-plus + qwen3.7-plus /
+-- qwen3.6-flash / qwen3-coder-plus (tk_024) and the legacy aliases (tk_027). The
+-- scheduler found no account advertising the dense names for the group -> empty
+-- pool -> fast-fail 429. DashScope serves these names directly with account 60's
+-- key (China-mainland/Beijing endpoint), so merging them into the whitelist makes
+-- the bridge advertise + route them.
+--
+-- Pricing already shipped in #812 (added 2026-06-17) via
+-- backend/internal/service/tk_pricing_overlay.json (qwen3-8b: in ¥0.5/M, out
+-- 非思考 ¥2/M / 思考 ¥5/M; qwen3-14b: in ¥1/M, out ¥4/M / ¥10/M; qwen3-32b: in ¥2/M,
+-- out ¥8/M / ¥20/M; all ÷6.7; thinking-rate default because open-source dense
+-- Qwen3 defaults enable_thinking=true). The overlay is compile-embedded, so the
+-- whitelist add lands on an image that already prices these names -- no $0 window.
+--
+-- Merge (jsonb ||) preserves the existing identity-whitelist entries; only the
+-- three new identity keys are added. Raw-SQL account mutation bypasses the Ent
+-- snapshot-refresh hooks, so enqueue a scheduler_outbox account_changed event
+-- (pattern: tk_022 / tk_024 / tk_027) so the running scheduler sees the change
+-- without a restart.
+--
+-- Idempotent + cross-deployment safe: guarded by (id, name, platform='newapi',
+-- channel_type=17) so re-running merges the same keys (no-op) and a bare id
+-- colliding with an unrelated account in another DB cannot match.
+
+SET LOCAL lock_timeout = '5s';
+SET LOCAL statement_timeout = '10min';
+
+-- Qwen account 60: add qwen3-8b, qwen3-14b, qwen3-32b (dense, open-source).
+WITH upd_qwen AS (
+    UPDATE accounts
+    SET credentials = jsonb_set(
+            credentials,
+            '{model_mapping}',
+            COALESCE(credentials -> 'model_mapping', '{}'::jsonb) || '{
+                "qwen3-8b": "qwen3-8b",
+                "qwen3-14b": "qwen3-14b",
+                "qwen3-32b": "qwen3-32b"
+            }'::jsonb
+        ),
+        updated_at = NOW()
+    WHERE id = 60
+      AND name = 'Qwen'
+      AND platform = 'newapi'
+      AND channel_type = 17
+      AND deleted_at IS NULL
+    RETURNING id
+)
+INSERT INTO scheduler_outbox (event_type, account_id, group_id, payload)
+SELECT 'account_changed', id, NULL, NULL FROM upd_qwen;


### PR DESCRIPTION
## 🔴 Hotfix: qwen3-8b/14b/32b empty-pool 429/503 on account 60

qwen3-8b/14b/32b were priced in #812 (`tk_pricing_overlay.json`) but never mapped onto account 60's `credentials.model_mapping` identity whitelist (highest mapping migration was `tk_027`; `tk_028` is unrelated). The Qwen group's scheduling pool is empty for those names → fast-fail `429/503 "No available accounts"`.

`tk_029` merges the three identity keys via jsonb `||` (preserving existing mappings, guarded by `id+name+platform+channel_type+deleted_at`) and enqueues a `scheduler_outbox` `account_changed` event in the same transaction so the running scheduler picks them up without a restart. Pricing already shipped in #812 → no $0 window.

- Takes effect on next deploy (no prod hotwire requested).
- Idempotent + cross-deployment safe.

**Checklist:** pure-insertion migration (no upstream symbol deleted) · `no-web-impact` · full `scripts/preflight.sh` green.

Reviewer: **Squash and merge** (TK fix PR, §5.y).

🤖 Generated with [Claude Code](https://claude.com/claude-code)