### PR TITLE
feat(pricing): served-models manifest as single source of truth + drift guard

### DIFF
--- a/.github/workflows/upstream-merge-pr-shape.yml
+++ b/.github/workflows/upstream-merge-pr-shape.yml
@@ -485,7 +485,31 @@ jobs:
             exit 1
           fi
 
+      - name: Check 14 — served-models manifest agrees with price/display/migration
+        run: |
+          # Preflight parity: scripts/checks/catalog-serving-drift.py — guards the
+          # #812-class regression where a model is priced + advertised-as-intended in
+          # backend/internal/service/tk_served_models.json but never wired onto the
+          # serving account's credentials.model_mapping (=> empty pool 429/503). The
+          # same script scripts/preflight.sh runs locally, so a green local preflight
+          # implies a green check here. Selftest first (offline fixtures), then the
+          # real run against the manifest + tk_pricing_overlay.json + the Go
+          # servable-allowlist maps + tk_*.sql model_mapping migrations.
+          if [ ! -f ./scripts/checks/catalog-serving-drift.py ]; then
+            echo "::error::scripts/checks/catalog-serving-drift.py missing."
+            exit 1
+          fi
+          if ! python3 ./scripts/checks/catalog-serving-drift.py --selftest; then
+            echo "::error::catalog-serving-drift.py selftest failed (guard logic broke)."
+            exit 1
+          fi
+          if ! python3 ./scripts/checks/catalog-serving-drift.py; then
+            echo "::error::served-models manifest drift: a manifest entry disagrees with its price, display allowlist, or model_mapping migration."
+            echo "::error::Land the missing tk_NNN_*_model_mapping migration (or add the 'served-via-admin-ui' notes opt-out), or remove the row — do NOT delete the guard."
+            exit 1
+          fi
+
       - name: Summary
         run: |
-          echo "All thirteen §5.y / §5.x checks passed for merge/upstream-* PR."
+          echo "All fourteen §5.y / §5.x checks passed for merge/upstream-* PR."
           echo "Reviewer reminder: pick GitHub 'Create a merge commit' (not Squash)."

--- a/backend/internal/service/tk_served_models.json
+++ b/backend/internal/service/tk_served_models.json
@@ -1,0 +1,175 @@
+{
+  "_doc": "TokenKey served-models MANIFEST — the single declarative source of intent for 'TK serves model M on platform P via an account credentials.model_mapping whitelist, at price π, display=yes/no'. This is a THIN INTENT layer ABOVE the two existing mechanisms it must agree with: (1) per-account credentials.model_mapping (the runtime servable WHITELIST, set by tk_NNN_*_model_mapping*.sql migrations and admin-UI edits), and (2) tk_pricing_overlay.json + the runtime litellm mirror (the PRICE). It is NOT a replacement for either — its projections must AGREE with them, and scripts/checks/catalog-serving-drift.py asserts that agreement (drift guard). SCOPE: ONLY the TK-curated, account-model_mapping-served newapi long-tail (qwen/deepseek families on the two dedicated single-account groups). NOT the litellm catalog, NOT the four native-platform first-class catalogs (anthropic/openai/gemini/antigravity — those have Go servable-allowlist maps in pricing_catalog_supported_models_tk.go), NOT grok (native seventh platform served by platform routing + ch48, not by a 39/60 model_mapping). Consumers: drift guard (now), tokenkey-onboard-model skill (now), future newapi reconciler (//go:embed of THIS file). Co-located with tk_pricing_overlay.json so the same Go package can embed both and the same preflight can parse both.",
+  "_schema": {
+    "version": 1,
+    "entry_key": "<platform>/<model_id>",
+    "fields": {
+      "platform": "account/group platform string; for this manifest always 'newapi' (the fifth platform). MUST equal the served account's accounts.platform.",
+      "model_id": "the client-facing model id that must appear as a KEY in the served account's credentials.model_mapping whitelist (identity-mapped: key==value for these accounts).",
+      "served_on": "string list of accounts.id (as strings) whose credentials.model_mapping MUST advertise model_id. For the seed every entry is a single dedicated account. This is the #812-catching anchor: the guard scans tk_*_model_mapping*.sql for model_id under each listed account.",
+      "channel_type": "the newapi channel_type of the serving account (17=Ali/DashScope, 43=DeepSeek). Documents the upstream adaptor; not asserted against DB (admin-UI editable) but recorded for the reconciler.",
+      "price_source": "one of 'overlay' (priced in tk_pricing_overlay.json), 'mirror' (priced by the runtime litellm/Wei-Shaw mirror under the bare key — overlay deliberately absent because the mirror already carries a non-zero price), 'channel' (priced via channel_model_pricing DB rows). The guard resolves price differently per source.",
+      "price_key": "the key under which the price resolves in the named source (overlay JSON key, or mirror/litellm key, or channel pricing model id). Usually == model_id.",
+      "display": "bool. true => model_id MUST be present in the platform's Go servable-allowlist map (pricing_catalog_supported_models_tk.go). newapi has NO such map, so every seed entry is false (catalog renders these via price-presence passthrough, not via a map). Reserved true for a future curated newapi map.",
+      "notes": "free-form provenance / known-gap marker."
+    }
+  },
+  "entries": {
+    "newapi/deepseek-v4-pro": {
+      "platform": "newapi",
+      "model_id": "deepseek-v4-pro",
+      "served_on": [
+        "39"
+      ],
+      "channel_type": 43,
+      "price_source": "overlay",
+      "price_key": "deepseek-v4-pro",
+      "display": false,
+      "notes": "ds-官 account 39. Mapped by tk_022 (identity whitelist). Priced in overlay (litellm lags V4). served-via-admin-ui (model_mapping predates the tk_*.sql era / set out-of-band; A3 downgraded to WARN)."
+    },
+    "newapi/deepseek-v4-flash": {
+      "platform": "newapi",
+      "model_id": "deepseek-v4-flash",
+      "served_on": [
+        "39"
+      ],
+      "channel_type": 43,
+      "price_source": "overlay",
+      "price_key": "deepseek-v4-flash",
+      "display": false,
+      "notes": "ds-官 account 39. Mapped by tk_022. Priced in overlay; pricing-overlay.py anchor. served-via-admin-ui (model_mapping predates the tk_*.sql era / set out-of-band; A3 downgraded to WARN)."
+    },
+    "newapi/deepseek-chat": {
+      "platform": "newapi",
+      "model_id": "deepseek-chat",
+      "served_on": [
+        "39"
+      ],
+      "channel_type": 43,
+      "price_source": "mirror",
+      "price_key": "deepseek-chat",
+      "display": false,
+      "notes": "ds-官 account 39. Legacy/canonical alias mapped by tk_027. NOT in overlay on purpose: the runtime litellm mirror carries a non-zero (pre-V4) deepseek-chat price, and the overlay is fill-only and cannot correct a wrong-but-non-zero source price (see overlay header). price_source=mirror => guard does NOT require an overlay key, only that no overlay key with value 0 shadows it."
+    },
+    "newapi/deepseek-reasoner": {
+      "platform": "newapi",
+      "model_id": "deepseek-reasoner",
+      "served_on": [
+        "39"
+      ],
+      "channel_type": 43,
+      "price_source": "mirror",
+      "price_key": "deepseek-reasoner",
+      "display": false,
+      "notes": "ds-官 account 39. Legacy/canonical alias mapped by tk_027. Same mirror-priced rationale as deepseek-chat."
+    },
+    "newapi/qwen3.7-max": {
+      "platform": "newapi",
+      "model_id": "qwen3.7-max",
+      "served_on": [
+        "60"
+      ],
+      "channel_type": 17,
+      "price_source": "overlay",
+      "price_key": "qwen3.7-max",
+      "display": false,
+      "notes": "Qwen account 60. Mapped by tk_021/tk_022 (also the Claude-Code dispatch target for group 18). Priced in overlay. Dated/preview snapshots (qwen3.7-max-preview/-2026-*) are priced in overlay but intentionally NOT manifest entries — they are not separately model_mapped and the manifest curates client-facing names, not every dated variant."
+    },
+    "newapi/qwen3.7-plus": {
+      "platform": "newapi",
+      "model_id": "qwen3.7-plus",
+      "served_on": [
+        "60"
+      ],
+      "channel_type": 17,
+      "price_source": "overlay",
+      "price_key": "qwen3.7-plus",
+      "display": false,
+      "notes": "Qwen account 60. Mapped by tk_024. Tiered (overlay intervals)."
+    },
+    "newapi/qwen3.6-flash": {
+      "platform": "newapi",
+      "model_id": "qwen3.6-flash",
+      "served_on": [
+        "60"
+      ],
+      "channel_type": 17,
+      "price_source": "overlay",
+      "price_key": "qwen3.6-flash",
+      "display": false,
+      "notes": "Qwen account 60. Mapped by tk_024. Tiered (overlay intervals)."
+    },
+    "newapi/qwen3-coder-plus": {
+      "platform": "newapi",
+      "model_id": "qwen3-coder-plus",
+      "served_on": [
+        "60"
+      ],
+      "channel_type": 17,
+      "price_source": "overlay",
+      "price_key": "qwen3-coder-plus",
+      "display": false,
+      "notes": "Qwen account 60. Mapped by tk_024. Tiered (overlay intervals)."
+    },
+    "newapi/qwen-max": {
+      "platform": "newapi",
+      "model_id": "qwen-max",
+      "served_on": [
+        "60"
+      ],
+      "channel_type": 17,
+      "price_source": "overlay",
+      "price_key": "qwen-max",
+      "display": false,
+      "notes": "Qwen account 60. Legacy stable alias mapped by tk_027. Flat-priced in overlay."
+    },
+    "newapi/qwen-plus": {
+      "platform": "newapi",
+      "model_id": "qwen-plus",
+      "served_on": [
+        "60"
+      ],
+      "channel_type": 17,
+      "price_source": "overlay",
+      "price_key": "qwen-plus",
+      "display": false,
+      "notes": "Qwen account 60. Legacy stable alias mapped by tk_027. Tiered (overlay intervals), non-thinking list."
+    },
+    "newapi/qwen3-8b": {
+      "platform": "newapi",
+      "model_id": "qwen3-8b",
+      "served_on": [
+        "60"
+      ],
+      "channel_type": 17,
+      "price_source": "overlay",
+      "price_key": "qwen3-8b",
+      "display": false,
+      "notes": "KNOWN GAP (#812-class): priced in overlay (added 2026-06-17 per customer request) but NO migration maps it onto account 60's credentials.model_mapping (highest model_mapping migration is tk_027; tk_028 is unrelated). Until tk_029 advertises it on account 60, the runtime pool is empty for qwen3-8b => 429/503. SEEDED ON PURPOSE so the served_on=>migration drift guard HARD-FAILS this row, surfacing the gap in CI."
+    },
+    "newapi/qwen3-14b": {
+      "platform": "newapi",
+      "model_id": "qwen3-14b",
+      "served_on": [
+        "60"
+      ],
+      "channel_type": 17,
+      "price_source": "overlay",
+      "price_key": "qwen3-14b",
+      "display": false,
+      "notes": "KNOWN GAP (#812-class): priced in overlay, NOT model_mapped on account 60. Same as qwen3-8b — needs tk_029. Drift guard HARD-FAILS until then."
+    },
+    "newapi/qwen3-32b": {
+      "platform": "newapi",
+      "model_id": "qwen3-32b",
+      "served_on": [
+        "60"
+      ],
+      "channel_type": 17,
+      "price_source": "overlay",
+      "price_key": "qwen3-32b",
+      "display": false,
+      "notes": "KNOWN GAP (#812-class): priced in overlay, NOT model_mapped on account 60. Same as qwen3-8b — needs tk_029. Drift guard HARD-FAILS until then."
+    }
+  }
+}

--- a/backend/internal/service/tk_served_models.json
+++ b/backend/internal/service/tk_served_models.json
@@ -145,7 +145,7 @@
       "price_source": "overlay",
       "price_key": "qwen3-8b",
       "display": false,
-      "notes": "KNOWN GAP (#812-class): priced in overlay (added 2026-06-17 per customer request) but NO migration maps it onto account 60's credentials.model_mapping (highest model_mapping migration is tk_027; tk_028 is unrelated). Until tk_029 advertises it on account 60, the runtime pool is empty for qwen3-8b => 429/503. SEEDED ON PURPOSE so the served_on=>migration drift guard HARD-FAILS this row, surfacing the gap in CI."
+      "notes": "Qwen account 60. Mapped by tk_029 (dense open-source identity whitelist). Priced in overlay (#812, added 2026-06-17 per customer request; thinking-rate default because open-source dense Qwen3 defaults enable_thinking=true). This row was seeded in PR #819 while still gapped (priced but not yet mapped) to prove the served_on=>migration drift guard hard-fails the #812 shape; #818/tk_029 closed the gap, so A3 now passes."
     },
     "newapi/qwen3-14b": {
       "platform": "newapi",
@@ -157,7 +157,7 @@
       "price_source": "overlay",
       "price_key": "qwen3-14b",
       "display": false,
-      "notes": "KNOWN GAP (#812-class): priced in overlay, NOT model_mapped on account 60. Same as qwen3-8b — needs tk_029. Drift guard HARD-FAILS until then."
+      "notes": "Qwen account 60. Mapped by tk_029 (dense open-source identity whitelist). Priced in overlay (#812). Same provenance as qwen3-8b; #818/tk_029 closed the original #812 gap."
     },
     "newapi/qwen3-32b": {
       "platform": "newapi",
@@ -169,7 +169,7 @@
       "price_source": "overlay",
       "price_key": "qwen3-32b",
       "display": false,
-      "notes": "KNOWN GAP (#812-class): priced in overlay, NOT model_mapped on account 60. Same as qwen3-8b — needs tk_029. Drift guard HARD-FAILS until then."
+      "notes": "Qwen account 60. Mapped by tk_029 (dense open-source identity whitelist). Priced in overlay (#812). Same provenance as qwen3-8b; #818/tk_029 closed the original #812 gap."
     }
   }
 }

--- a/docs/approved/newapi-served-models-reconciler.md
+++ b/docs/approved/newapi-served-models-reconciler.md
@@ -1,0 +1,309 @@
+---
+title: newapi Served-Models Reconciler + Runtime-Config Decision (Phase 3, design only)
+status: approved
+approved_by: xuejiao (design directive, this session)
+approved_at: 2026-06-17
+authors: [agent]
+created: 2026-06-17
+related_prs: []
+related_commits: []
+related_stories: []
+related_design: docs/approved/newapi-as-fifth-platform.md
+supersedes: none
+---
+
+# newapi Served-Models Reconciler + Runtime-Config Decision (Phase 3, design only)
+
+> Status: **APPROVED DESIGN, DEFERRED IMPLEMENTATION.** This is a decision record, not
+> a shipped feature. It depends on the keystone artifact
+> `backend/internal/service/tk_served_models.json` (the served-models MANIFEST) and its
+> drift guard `scripts/checks/catalog-serving-drift.py` (the "Foundation PR"). Build the
+> reconciler described in §1 only when the trigger in §2 fires; until then the
+> `tokenkey-onboard-model` skill + the static drift guard are the operating mechanism.
+
+## 0. Context and the problem this solves
+
+TokenKey serves a TK-curated long-tail of `newapi` (fifth-platform) models — Qwen and
+DeepSeek families — on **two dedicated single-account groups**:
+
+| account | name | platform | channel_type | group |
+| --- | --- | --- | --- | --- |
+| 60 | Qwen | `newapi` | 17 (Ali/DashScope) | 18 |
+| 39 | ds-官 DeepSeek | `newapi` | 43 (DeepSeek) | 11 |
+
+A model is "served" on one of these accounts only when its client-facing id appears as a
+key in that account's `credentials.model_mapping` (an identity WHITELIST: `key == value`).
+Today that whitelist is set by numbered `tk_NNN_*_model_mapping*.sql` migrations
+(`tk_021`, `tk_022`, `tk_024`, `tk_027`) and by ad-hoc admin-UI edits. **Adding a model
+therefore requires a new migration** — a release — even though the price can be hot-added
+via channel pricing or the overlay.
+
+This is the exact failure mode behind the **#812-class regression**: `qwen3-8b`,
+`qwen3-14b`, `qwen3-32b` are priced in `tk_pricing_overlay.json` (added 2026-06-17) but
+**no migration maps them onto account 60** — the highest mapping migration is `tk_027`
+(`tk_028` only touches the `model_availability` platform CHECK for grok). The pool is
+empty for those three ids → `429`/`503` in prod, with the price present making it look
+served. `ls backend/migrations/tk_029*` returns nothing as of this writing — the gap is
+real and is what the static drift guard hard-fails on.
+
+Two questions follow, and this record answers both:
+
+1. **Can we make "add a model" need no per-account migration?** → Yes, via a
+   reconciler that converges accounts 39/60 toward a canonical whitelist derived from the
+   manifest. **Recommended (§1).**
+2. **Can we make pricing truly runtime (no release at all)?** → Not yet. The refund-safety
+   validation that gates video pricing is preflight-time; moving pricing to runtime means
+   moving that validation to write-time and accepting `channel_model_pricing`'s
+   silent-shadow precedence. **Explicit blocker, DEFERRED with a measurable trigger (§2).**
+
+---
+
+## 1. Decision: a newapi whitelist reconciler, canonical = manifest-DERIVED domain constant
+
+### 1.1 What it does
+
+A per-node `NewAPIServedModelsReconciler` modeled **byte-for-byte** on
+`backend/internal/service/antigravity_config_reconciler.go`. Each tick (and once
+immediately on boot), under a Redis leader-lock, it:
+
+1. `accounts.ListByPlatform(ctx, PlatformNewAPI)` — list this deployment's newapi accounts.
+2. For each account whose id is a manifest `served_on` target (39, 60), compute the
+   **desired** `credentials.model_mapping` = the canonical identity whitelist for that
+   account derived from the manifest.
+3. Skip-if-aligned: only accounts whose current whitelist is **missing** a desired key are
+   rewritten (drift probe; idempotent, no write thrash — same posture as
+   `antigravityCanServeExcluded` at `antigravity_config_reconciler.go:229`).
+4. `accounts.BulkUpdate(ctx, drifted, AccountBulkUpdate{Credentials: {"model_mapping": ...}})`
+   — the JSONB shallow-merge replaces the whole `model_mapping` sub-object and enqueues a
+   `scheduler_outbox` event so the change takes effect without a restart
+   (`antigravity_config_reconciler.go:277-282`).
+
+The whole point: **adding `qwen3-8b` becomes one manifest row + (its derived constant
+flowing through automatically), not a `tk_029` migration.** The reconciler closes the
+#812 gap structurally instead of per-incident.
+
+### 1.2 Canonical source: manifest-DERIVED domain constant (recommended) vs DB-backed config
+
+This is the load-bearing choice. Two candidates:
+
+**Option A — domain constant DERIVED from the embedded manifest (RECOMMENDED).**
+Mirror the proven antigravity single-source pattern exactly. There,
+`GeminiOnlyAntigravityModelMapping` is **not** a hand-maintained second list — it is
+`buildGeminiOnlyAntigravityModelMapping()` filtering `DefaultAntigravityModelMapping`
+(`constants.go:158-169`), so "adding a gemini wire id above flows into the gemini-only set
+for free." The newapi analogue:
+
+- The manifest `tk_served_models.json` is already `//go:embed`-able from
+  `backend/internal/service/` (it sits beside `tk_pricing_overlay.json`, which
+  `pricing_service_tk_overlay.go:49` already embeds with `//go:embed`).
+- A new derivation function — call it `NewAPIServedWhitelistFor(accountID int64)` —
+  parses the embedded manifest once and returns the identity whitelist
+  `{model_id: model_id}` for every entry whose `served_on` contains that account id.
+- That function IS the single source. The manifest is the only place a human edits; the
+  Go canonical whitelist is *derived*, never hand-kept. This is the same
+  "net-zero second list" discipline as the antigravity reconciler.
+
+**Option B — read a DB-backed config table at runtime (REJECTED for now).**
+Truly runtime (edit a row, no rebuild). Rejected because: (i) it duplicates intent that
+already lives in the manifest, creating a two-writer drift surface the manifest guard
+cannot see; (ii) the reconciler would then trust un-reviewed DB rows to rewrite
+`credentials.model_mapping` — a self-modifying config loop with no code-review gate; (iii)
+it buys true-runtime *whitelisting* but the **pricing** half is still release-bound (§2),
+so it solves half a problem while adding a new failure mode. Option A keeps the
+review gate (manifest PR) and the single source, at the cost of a rebuild to add a model —
+which is acceptable until the §2 trigger says otherwise.
+
+**Decision: Option A.** The manifest-derived constant is the canonical source; the
+reconciler converges DB toward it.
+
+### 1.3 §5.x framing: this is a NET-ADD reconciler, it MUST NOT delete
+
+Per CLAUDE.md §5.x (default = keep upstream capability, override; never silent-delete),
+the newapi reconciler's converge step is **add-only on the whitelist**:
+
+- It **adds** missing desired keys to `credentials.model_mapping`. It does **not** remove
+  keys the manifest omits. An operator who hand-added a model via admin-UI keeps it; the
+  reconciler never "cleans up" a key just because it is not in the manifest.
+  - This is a deliberate divergence from the antigravity reconciler, which *replaces* the
+    whole `model_mapping` (dropping claude/gpt-oss). That replace is correct there because
+    the policy is exclusionary ("gemini-only"). The newapi policy is **inclusionary**
+    ("at least serve the curated long-tail") — so it unions, never subtracts.
+  - Mechanically: read current `model_mapping`, union with the derived desired set, write
+    back only if the union differs (still idempotent / skip-if-aligned).
+- It touches **per-account DB rows only**, never a global default constant and never an
+  upstream-owned symbol. The manifest itself is TK-scoped (`SCOPE` = only the 39/60
+  long-tail; NOT the litellm catalog, NOT the four native platforms' Go allowlist maps,
+  NOT grok — grok is served by platform routing + ch48, not by a 39/60 whitelist).
+- Consequence: an upstream merge cannot regress this into a deletion, and the reconciler
+  can never empty a pool. The worst case is a no-op (manifest empty / accounts absent),
+  which is the safe direction.
+
+### 1.4 Interaction with the static drift guard
+
+The Foundation PR's `catalog-serving-drift.py` already hard-fails when a `served_on`
+entry has no migration (the #812 catcher). Once this reconciler ships, the guard's A3
+(served_on ⇒ migration) assertion **changes meaning**: a manifest row no longer needs a
+migration — it needs to be reconciled. The guard's A3 should then accept *either* a
+matching `tk_*model_mapping*.sql` **or** the row being within the reconciler's derived set
+(i.e. the reconciler is the migration). Until the reconciler ships, A3 stays migration-only
+and `qwen3-8b/14b/32b` hard-fail — which is exactly why the hotfix `tk_029` (the
+"Hotfix PR") lands first and independently of this design. **The reconciler is the
+structural fix; `tk_029` is the point fix that unblocks CI now.**
+
+---
+
+## 2. The true-runtime (no-release) question: explicit blocker, DEFERRED
+
+The reconciler in §1 removes the **migration** for whitelisting, but a new model still
+needs a **rebuild** because (a) the manifest is `//go:embed`-ed and (b) its price comes
+from the `//go:embed`-ed `tk_pricing_overlay.json` or the runtime mirror. "True runtime"
+= add a model with neither a migration nor a release. That requires moving **pricing** to
+runtime, and that is blocked by a refund-safety invariant.
+
+### 2.1 The blocker: refund-safety validation is preflight-time, not write-time
+
+Video pricing carries a money-loss invariant enforced today in
+`scripts/checks/pricing-overlay.py:112-119`:
+
+```py
+if mode == "video_generation":
+    failure_billing = pricing.get("failure_billing")
+    if failure_billing != "success_only":
+        errors.append(... "a provider that charges for failed tasks breaks the
+                          terminal-failure refund — change the refund design before
+                          pricing it")
+```
+
+TokenKey refunds the user in full when a video task ends `failed`; that is loss-free
+**only if** the provider does not bill failed tasks. This is a **preflight-time** gate: a
+human prices a video model in the overlay JSON, declares `failure_billing='success_only'`,
+and CI proves it before the price can ship. It is the same class as the chat-mode
+`input/output_cost_per_token > 0` and the `thinking_output_cost_per_token > 0` anchors —
+all of which assume a human-reviewed, CI-gated edit.
+
+**Moving pricing to runtime deletes that gate.** A runtime admin-API price write does not
+pass through `scripts/preflight.sh`. To keep refund-safety, every check
+`pricing-overlay.py` runs at preflight (recognized mode, non-zero in the mode's fields,
+`failure_billing='success_only'` for video, positive thinking rate) would have to be
+**re-implemented as a WRITE-TIME validator in the admin pricing API** — reject the write
+at the handler before it reaches `channel_model_pricing`. That is a non-trivial,
+high-blast-radius piece of new code (a refund-correctness gate on the money path), not a
+config flip.
+
+### 2.2 The second cost: accepting channel_model_pricing's silent-shadow precedence
+
+Runtime pricing in this codebase means `channel_model_pricing` DB rows (raw-SQL, the
+resolver in `model_pricing_resolver.go`), which **override everything** — including the
+overlay (`pricing_service_tk_overlay.go` header: "The DB-backed ModelPricing override
+... still sits above everything"). So a runtime price is a **silent shadow over the
+overlay**: the overlay's CI-proven value can be masked by a DB row no guard ever saw. For
+refund-safety that is the dangerous direction — a runtime row could price a
+charges-on-failure video model and the preflight guard would never fire because the
+overlay still says `success_only` while the live price comes from the shadowing DB row.
+Accepting runtime pricing means **accepting that precedence and rebuilding the guard at
+the write boundary** so the shadow itself is validated.
+
+### 2.3 Decision: DEFER, with a measurable trigger
+
+**Defer true-runtime pricing.** The cost is a new refund-correctness validator on the
+money path plus owning the silent-shadow precedence — both justified only by sustained
+add-model churn. The static guard + reconciler (§1) + the `tokenkey-onboard-model` skill
+cover the current cadence with full CI safety.
+
+**Trigger condition (build the write-time validator + runtime pricing when ALL hold):**
+
+- Models are added to the manifest at a rate of **≥ 1/week sustained over a rolling
+  month** (4+ adds in 30 days). Measure from `git log` on `tk_served_models.json` +
+  `tk_pricing_overlay.json`.
+- AND at least one of those adds was a **video model** (the refund-safety arm is the
+  expensive part; if all adds are chat/overlay-priced the skill suffices indefinitely).
+- AND a release-cadence pain signal exists: an add was blocked or delayed waiting on a
+  release window (recorded in the onboarding skill's run log).
+
+Until then, "add a model" = manifest PR + overlay/channel price + (`tk_029`-style migration
+OR the reconciler once it ships) — a normal reviewed release. **The skill suffices.**
+
+---
+
+## 3. Mechanical add-a-reconciler checklist (8 steps)
+
+The exact steps to land `NewAPIServedModelsReconciler`, each anchored to where the
+antigravity reconciler does the same thing. This is the future implementer's recipe.
+
+1. **Reconciler file** — new `backend/internal/service/newapi_served_models_reconciler.go`,
+   structured as a copy of `antigravity_config_reconciler.go`: Redis leader-lock
+   (`newapi:served:reconciler:leader`, compare-and-delete release script,
+   `antigravity_config_reconciler.go:57-62`), ticker + **immediate boot pass**
+   (`Start()` runs `runOnceLocked()` before the loop, `:145-164`), `Stop()` via
+   `stopOnce`/`wg` (`:168-176`). Narrow store interface
+   `{ ListByPlatform; BulkUpdate }` (`:67-70`) so `runOnce` is unit-testable without a
+   full repo stub. Converge logic is **union, not replace** (§1.3).
+
+2. **Canonical derivation** — add `NewAPIServedWhitelistFor(accountID int64) map[string]string`
+   to a domain/service file that `//go:embed`s `tk_served_models.json`. It parses the
+   manifest once (skip `_`-prefixed metadata keys, same as
+   `pricing_service_tk_overlay.go:70`) and returns the identity whitelist for that account.
+   This is the **single source** — no hand-kept second list (the `constants.go:160`
+   `buildGeminiOnly...` discipline).
+
+3. **Config field + default** — add
+   `gateway.scheduling.newapi_served_models_reconciler_interval_seconds` to the config
+   struct (beside `AntigravityConfigReconcilerIntervalSeconds`, `config.go:1181`) and
+   register `viper.SetDefault("gateway.scheduling.newapi_served_models_reconciler_interval_seconds", 300)`
+   (beside `config.go:2091`). `<=0` disables the goroutine (`tickInterval()` at
+   `:124-133`).
+
+4. **Provider** — add `ProvideNewAPIServedModelsReconciler(accountRepo AccountRepository,
+   cfg *config.Config, redisClient *redis.Client) *NewAPIServedModelsReconciler` to
+   `service/wire.go`, modeled on `ProvideAntigravityConfigReconciler` (`wire.go:278-287`):
+   construct, `rec.Start()`, return.
+
+5. **ProviderSet registration** — add `ProvideNewAPIServedModelsReconciler,` to
+   `service.ProviderSet` (the `wire.NewSet(...)` block, beside
+   `ProvideAntigravityConfigReconciler,` at `wire.go:645`).
+
+6. **Cleanup edge** — add a `*service.NewAPIServedModelsReconciler` parameter to
+   `provideCleanup` in `cmd/server/wire.go` (beside `antigravityConfigReconciler` at
+   `cmd/server/wire.go:92`) AND a parallel `cleanupStep` that calls `.Stop()` (beside the
+   `AntigravityConfigReconciler` step at `cmd/server/wire.go:218-223`). This is what forces
+   wire to evaluate the side-effect provider; without the cleanup edge wire dead-codes a
+   side-effect-only service.
+
+7. **Regenerate + sentinel** — run `go generate ./cmd/server` (regenerate `wire_gen.go`;
+   committing generated churn is expected per CLAUDE.md §2/§5). Then **add a sentinel
+   entry** to `scripts/sentinels/newapi.json` pinning the new reconciler file and its
+   load-bearing symbols (`ListByPlatform(ctx, PlatformNewAPI)`,
+   `NewAPIServedWhitelistFor`, the union-not-replace marker) AND a `service/wire.go`
+   `must_contain` of `ProvideNewAPIServedModelsReconciler,` (mirroring the existing
+   `ProvideUpstreamBalanceSentinel,` sentinel at `newapi.json` lines 418-423 — guards the
+   side-effect ProviderSet member that fails silently if an upstream merge drops it). The
+   registry-update gate (`check-registry-update-gate.py`) requires this in the same PR.
+
+8. **Unit test via narrow-interface fakes** — `newapi_served_models_reconciler_test.go`
+   calling `runOnce(ctx)` directly with a fake store satisfying
+   `{ ListByPlatform; BulkUpdate }`. Cases: (a) account missing a desired key ⇒ BulkUpdate
+   called with the union; (b) account already a superset ⇒ no BulkUpdate (skip-if-aligned);
+   (c) operator-added extra key is preserved (union, not replace — the §1.3 invariant);
+   (d) non-39/60 newapi account untouched; (e) empty manifest ⇒ no-op. Run with
+   `go test -tags=unit ./internal/service/ -run Reconciler`. Then `scripts/preflight.sh`
+   for the sentinel + registry-update gates, and a full `go test -tags=unit ./...`
+   (per the local-scope discipline: never just the service package).
+
+---
+
+## 4. Out of scope (recorded so the boundary is explicit)
+
+- **The four native platforms** (anthropic/openai/gemini/antigravity) — they have Go
+  servable-allowlist maps in `pricing_catalog_supported_models_tk.go` and the
+  `tokenkey-servable-model-refresh` flow; the manifest's `display` field is reserved for a
+  future curated newapi map but is `false` for every seed entry (newapi has no map; the
+  public catalog renders these via price-presence passthrough).
+- **grok** — native seventh platform (#791), served by platform routing + ch48 API-key
+  relay, not by a 39/60 `model_mapping`. `grok-*` overlay rows are out of this manifest's
+  mechanism by construction.
+- **The runtime ops scan** (live `accounts.credentials.model_mapping` on prod 39/60 vs
+  manifest) — that is a read-only observability check
+  (`SELECT id, credentials->'model_mapping' FROM accounts WHERE id IN (39,60) AND
+  deleted_at IS NULL`, note the soft-delete filter), never a PR gate. The static guard
+  proves intent↔price↔(migration|reconciler) agree in the repo; the ops scan proves the
+  repo agrees with live prod. Design-only here.

--- a/scripts/checks/catalog-serving-drift.py
+++ b/scripts/checks/catalog-serving-drift.py
@@ -1,0 +1,495 @@
+#!/usr/bin/env python3
+"""Validate the TK served-models MANIFEST against the mechanisms it must agree with.
+
+Source of truth: backend/internal/service/tk_served_models.json — a THIN declarative
+intent layer ("TK serves model M on platform P via an account credentials.model_mapping
+whitelist, at price π, display=yes/no") that sits ABOVE three already-existing
+mechanisms and must AGREE with each:
+
+  (1) per-account credentials.model_mapping — the runtime servable WHITELIST, written
+      by tk_NNN_*.sql migrations (and admin-UI edits). The DECLARED-served signal.
+  (2) tk_pricing_overlay.json + the runtime litellm mirror — the PRICE.
+  (3) the Go servable-allowlist maps in pricing_catalog_supported_models_tk.go — the
+      curated DISPLAY allowlist (only anthropic/openai/gemini/antigravity have one).
+
+This guard hardens the #812-class regression (a model priced + advertised-as-intended
+but never actually wired onto the serving account's model_mapping => empty pool =>
+429/503 in prod) into a mechanical CI gate (CLAUDE.md §「升级原则」). It asserts:
+
+  A0 PARSE        manifest + overlay parse; every entry has the required fields/types.
+  A1 PRICE        every entry resolves to a non-zero price in its declared price_source
+                  (overlay key > 0 for the mode; mirror => overlay does not zero it;
+                  channel => notes documents the channel source).            HARD-FAIL
+  A2 DISPLAY      display==true => model_id present in the platform's Go allowlist map.
+                  newapi has NO map, so every newapi entry MUST be display=false.  HARD
+  A3 SERVED_ON    every served_on account => some tk_*.sql model_mapping migration maps
+                  model_id onto that account (quoted id co-occurring with `id = <A>`).
+                  This is the #812-catching direction.                        HARD-FAIL
+                  Escape hatch: an entry whose notes contain the literal
+                  `served-via-admin-ui` is downgraded to WARN (model_mapping applied
+                  out-of-band of any migration — a reviewable, greppable opt-out).
+  A4 ENUMERATION  (advisory WARN) every dashscope/deepseek chat overlay key SHOULD be a
+                  manifest entry (catch a priced+served-but-forgotten model).
+
+Usage: python3 scripts/checks/catalog-serving-drift.py [--quiet] [--selftest]
+Exit 0 ok, 1 drift, 2 missing dep / file / unparseable.
+"""
+
+from __future__ import annotations
+
+import json
+import pathlib
+import re
+import sys
+
+REPO_ROOT = pathlib.Path(__file__).resolve().parent.parent.parent
+SERVICE_DIR = REPO_ROOT / "backend" / "internal" / "service"
+MANIFEST = SERVICE_DIR / "tk_served_models.json"
+OVERLAY = SERVICE_DIR / "tk_pricing_overlay.json"
+ALLOWLIST_GO = SERVICE_DIR / "pricing_catalog_supported_models_tk.go"
+MIGRATIONS_DIR = REPO_ROOT / "backend" / "migrations"
+# Broad on purpose: model_mapping JSON lives in several tk_*.sql files whose NAME does
+# not contain "model_mapping" (tk_020/tk_021/tk_022 set mappings too). A3 still scopes
+# by the quoted model_id co-occurring with the account guard, so widening the glob only
+# adds files that cannot false-match (they lack the quoted id).
+MIGRATION_GLOB = "tk_*.sql"
+
+# Price mode -> the field(s) that MUST be > 0 for that mode (mirrors pricing-overlay.py
+# MODE_FIELDS so the overlay arm of A1 is byte-identical to a check already green).
+MODE_FIELDS = {
+    "image_generation": ("output_cost_per_image",),
+    "video_generation": ("output_cost_per_second",),
+    "chat": ("input_cost_per_token", "output_cost_per_token"),
+}
+
+# Platforms that actually have a Go servable-allowlist map (A2 only meaningful here).
+ALLOWLIST_PLATFORMS = ("anthropic", "openai", "gemini", "antigravity")
+
+# A4 advisory: overlay vendors whose chat models are the manifest's curated long-tail.
+ENUMERATION_PROVIDERS = {"dashscope", "deepseek"}
+
+# Recognized literal escape hatch in an entry's notes (A3 migration-scan opt-out).
+ADMIN_UI_OPT_OUT = "served-via-admin-ui"
+
+REQUIRED_FIELDS = {
+    "platform": str,
+    "model_id": str,
+    "served_on": list,
+    "channel_type": int,
+    "price_source": str,
+    "price_key": str,
+    "display": bool,
+}
+VALID_PRICE_SOURCES = {"overlay", "mirror", "channel"}
+
+
+# --------------------------------------------------------------------------- helpers
+
+
+def _is_pos_number(v) -> bool:
+    return isinstance(v, (int, float)) and not isinstance(v, bool) and v > 0
+
+
+def parse_allowlist_maps(go_text: str) -> dict[str, set[str]]:
+    """Extract {platform: {quoted keys}} from the marker-delimited Go map literals.
+
+    Mirrors ops/pricing/refresh-servable-allowlist.py's splice anchors:
+    `// servable-allowlist:begin <platform>` ... `// servable-allowlist:end <platform>`.
+    Keys are pulled with the `"<id>":` map-key regex (comment lines have no `":`).
+    """
+    out: dict[str, set[str]] = {}
+    for platform in ALLOWLIST_PLATFORMS:
+        begin = re.search(
+            r"//\s*servable-allowlist:begin\s+" + re.escape(platform) + r"\b", go_text
+        )
+        end = re.search(
+            r"//\s*servable-allowlist:end\s+" + re.escape(platform) + r"\b", go_text
+        )
+        if not begin or not end or end.start() <= begin.end():
+            # Missing/corrupted marker block: leave platform absent so A2 can flag it
+            # only if some entry claims display=true on it (vacuous for the newapi seed).
+            continue
+        block = go_text[begin.end() : end.start()]
+        out[platform] = set(re.findall(r'"([^"]+)"\s*:', block))
+    return out
+
+
+def migration_maps_model(files: dict[str, str], account: str, model_id: str) -> bool:
+    """True iff some migration file contains BOTH the account guard `id = <account>`
+    and the QUOTED model id `"<model_id>"` (file-level co-occurrence).
+
+    Quoting defeats the prefix false-match (`"qwen3.7-max"` does NOT match inside
+    `"qwen3.7-max-preview"` because of the trailing quote). The seed shares no model_id
+    across accounts 39/60, so file-level (vs per-statement) scoping cannot bleed; a
+    future migration that maps the same name onto two accounts in one file would need
+    per-`id`-statement scoping — documented in the guardFalsePositiveAnalysis.
+    """
+    guard = re.compile(r"\bid\s*=\s*" + re.escape(account) + r"\b")
+    quoted = '"' + model_id + '"'
+    for text in files.values():
+        if quoted in text and guard.search(text):
+            return True
+    return False
+
+
+# --------------------------------------------------------------------------- core
+
+
+def evaluate(
+    manifest: dict,
+    overlay: dict,
+    allowlist: dict[str, set[str]],
+    migration_files: dict[str, str],
+) -> tuple[list[str], list[str]]:
+    """Return (hard_errors, warnings). Pure — no I/O — so --selftest can drive it."""
+    errors: list[str] = []
+    warnings: list[str] = []
+
+    entries = manifest.get("entries")
+    if not isinstance(entries, dict):
+        return (["manifest has no top-level `entries` object"], warnings)
+
+    overlay_entries = {k: v for k, v in overlay.items() if not k.startswith("_")}
+    manifest_model_ids: set[str] = set()
+
+    for key, entry in entries.items():
+        if key.startswith("_"):
+            continue
+        # ---- A0 structural ------------------------------------------------------
+        if not isinstance(entry, dict):
+            errors.append(f"{key}: entry is not an object")
+            continue
+        bad_field = False
+        for field, typ in REQUIRED_FIELDS.items():
+            if field not in entry:
+                errors.append(f"{key}: missing required field {field!r}")
+                bad_field = True
+                continue
+            val = entry[field]
+            # bool is a subclass of int — guard channel_type explicitly.
+            if typ is int and isinstance(val, bool):
+                errors.append(f"{key}: field {field!r} must be int, got bool")
+                bad_field = True
+            elif not isinstance(val, typ):
+                errors.append(
+                    f"{key}: field {field!r} must be {typ.__name__}, got {type(val).__name__}"
+                )
+                bad_field = True
+        if bad_field:
+            continue
+        if any(not isinstance(a, str) for a in entry["served_on"]):
+            errors.append(f"{key}: served_on must be a list of account-id strings")
+            continue
+        if entry["price_source"] not in VALID_PRICE_SOURCES:
+            errors.append(
+                f"{key}: price_source {entry['price_source']!r} not in {sorted(VALID_PRICE_SOURCES)}"
+            )
+            continue
+
+        platform = entry["platform"]
+        model_id = entry["model_id"]
+        price_source = entry["price_source"]
+        price_key = entry["price_key"]
+        notes = entry.get("notes", "") or ""
+        manifest_model_ids.add(model_id)
+
+        # ---- A1 price-resolvable -----------------------------------------------
+        if price_source == "overlay":
+            po = overlay_entries.get(price_key)
+            if not isinstance(po, dict):
+                errors.append(
+                    f"{key}: price_source=overlay but price_key {price_key!r} absent from "
+                    f"tk_pricing_overlay.json"
+                )
+            else:
+                mode = po.get("mode")
+                fields = MODE_FIELDS.get(mode)
+                if fields is None:
+                    errors.append(
+                        f"{key}: overlay entry {price_key!r} has unrecognized mode {mode!r}"
+                    )
+                else:
+                    for f in fields:
+                        if not _is_pos_number(po.get(f)):
+                            errors.append(
+                                f"{key}: overlay {price_key!r} (mode={mode}) requires {f} > 0, "
+                                f"got {po.get(f)!r}"
+                            )
+        elif price_source == "mirror":
+            # Static guard cannot read the live mirror; only prove the overlay does NOT
+            # zero it out (a $0 overlay row would shadow the mirror price). Deliberately
+            # weak arm (deepseek-chat/reasoner): can false-NEGATIVE, never false-POSITIVE.
+            po = overlay_entries.get(price_key)
+            if isinstance(po, dict):
+                mode = po.get("mode")
+                fields = MODE_FIELDS.get(mode, ())
+                if fields and all(not _is_pos_number(po.get(f)) for f in fields):
+                    errors.append(
+                        f"{key}: price_source=mirror but a $0 overlay row for {price_key!r} "
+                        f"shadows the mirror price (remove the zero overlay row or correct it)"
+                    )
+        elif price_source == "channel":
+            if "channel" not in notes.lower():
+                errors.append(
+                    f"{key}: price_source=channel requires a notes substring documenting "
+                    f"the channel_model_pricing source (static guard cannot read the DB)"
+                )
+
+        # ---- A2 display => allowlist -------------------------------------------
+        if entry["display"]:
+            if platform not in ALLOWLIST_PLATFORMS:
+                errors.append(
+                    f"{key}: display=true on platform {platform!r} which has NO Go "
+                    f"servable-allowlist map — display must be false (false promise guard)"
+                )
+            elif model_id not in allowlist.get(platform, set()):
+                errors.append(
+                    f"{key}: display=true but {model_id!r} absent from the {platform} "
+                    f"servable-allowlist map in pricing_catalog_supported_models_tk.go"
+                )
+
+        # ---- A3 served_on => migration -----------------------------------------
+        admin_ui = ADMIN_UI_OPT_OUT in notes
+        for account in entry["served_on"]:
+            if migration_maps_model(migration_files, account, model_id):
+                continue
+            msg = (
+                f"{key}: served_on lists account {account} but NO tk_*.sql migration maps "
+                f'"{model_id}" onto it (`id = {account}` + quoted id). #812-class gap: the '
+                f"runtime pool is empty for this model => 429/503. Land a tk_NNN_*_model_mapping "
+                f"migration advertising it on account {account}, or remove this row."
+            )
+            if admin_ui:
+                warnings.append(
+                    msg + f"  [downgraded to WARN: notes carries '{ADMIN_UI_OPT_OUT}']"
+                )
+            else:
+                errors.append(msg)
+
+    # ---- A4 enumeration completeness (advisory) --------------------------------
+    for k, v in overlay_entries.items():
+        if not isinstance(v, dict):
+            continue
+        if v.get("litellm_provider") in ENUMERATION_PROVIDERS and v.get("mode") == "chat":
+            if k not in manifest_model_ids:
+                warnings.append(
+                    f"overlay chat model {k!r} (provider={v.get('litellm_provider')}) is not a "
+                    f"manifest entry — confirm it is intentionally not account-mapping-served, "
+                    f"or add it (advisory)."
+                )
+
+    return (errors, warnings)
+
+
+# --------------------------------------------------------------------------- selftest
+
+
+def _selftest() -> int:
+    """Synthetic pass+fail fixtures, no repo I/O — proves each assertion fires."""
+    overlay = {
+        "_meta": {"note": "x"},
+        "good-chat": {
+            "litellm_provider": "dashscope",
+            "mode": "chat",
+            "input_cost_per_token": 1e-7,
+            "output_cost_per_token": 2e-7,
+        },
+        "zero-chat": {
+            "litellm_provider": "deepseek",
+            "mode": "chat",
+            "input_cost_per_token": 0,
+            "output_cost_per_token": 0,
+        },
+        "forgotten-chat": {
+            "litellm_provider": "dashscope",
+            "mode": "chat",
+            "input_cost_per_token": 1e-7,
+            "output_cost_per_token": 2e-7,
+        },
+    }
+    allowlist = {"anthropic": {"claude-opus-4-8"}, "openai": set(), "gemini": set(),
+                 "antigravity": set()}
+    migrations = {
+        "tk_900_x.sql": 'UPDATE accounts ... WHERE id = 60 ... "good-chat": "good-chat"',
+        # account 60 also gets the mirror + admin-ui entries below
+        "tk_901_y.sql": 'WHERE id = 60 ... "mirror-chat" "adminui-chat"',
+    }
+
+    def run(entries):
+        return evaluate({"entries": entries}, overlay, allowlist, migrations)
+
+    failures: list[str] = []
+
+    # --- PASS fixture: every assertion satisfied -------------------------------
+    pass_entries = {
+        "newapi/good-chat": {
+            "platform": "newapi", "model_id": "good-chat", "served_on": ["60"],
+            "channel_type": 17, "price_source": "overlay", "price_key": "good-chat",
+            "display": False, "notes": "ok",
+        },
+        "newapi/mirror-chat": {
+            "platform": "newapi", "model_id": "mirror-chat", "served_on": ["60"],
+            "channel_type": 43, "price_source": "mirror", "price_key": "mirror-chat",
+            "display": False, "notes": "mirror priced",
+        },
+        "newapi/adminui-chat": {
+            "platform": "newapi", "model_id": "adminui-chat", "served_on": ["60"],
+            "channel_type": 17, "price_source": "overlay", "price_key": "good-chat",
+            "display": False, "notes": "applied out-of-band served-via-admin-ui",
+        },
+    }
+    errs, warns = run(pass_entries)
+    # forgotten-chat triggers the A4 advisory warning only (not an error).
+    if errs:
+        failures.append(f"PASS fixture produced hard errors: {errs}")
+    if not any("forgotten-chat" in w for w in warns):
+        failures.append("PASS fixture: expected A4 advisory warning for forgotten-chat")
+
+    # --- A0: missing field / wrong type ----------------------------------------
+    errs, _ = run({"newapi/bad": {"platform": "newapi", "model_id": "good-chat"}})
+    if not any("missing required field" in e for e in errs):
+        failures.append("A0: missing-field not flagged")
+    errs, _ = run({"newapi/bad": {
+        "platform": "newapi", "model_id": "good-chat", "served_on": ["60"],
+        "channel_type": True, "price_source": "overlay", "price_key": "good-chat",
+        "display": False,
+    }})
+    if not any("must be int, got bool" in e for e in errs):
+        failures.append("A0: channel_type bool-as-int not flagged")
+
+    # --- A1: overlay price missing / zero --------------------------------------
+    errs, _ = run({"newapi/absent": {
+        "platform": "newapi", "model_id": "nope", "served_on": ["60"],
+        "channel_type": 17, "price_source": "overlay", "price_key": "nonexistent",
+        "display": False, "notes": "served-via-admin-ui",
+    }})
+    if not any("absent from" in e for e in errs):
+        failures.append("A1: missing overlay key not flagged")
+    errs, _ = run({"newapi/zero": {
+        "platform": "newapi", "model_id": "zero-chat", "served_on": ["60"],
+        "channel_type": 43, "price_source": "overlay", "price_key": "zero-chat",
+        "display": False, "notes": "served-via-admin-ui",
+    }})
+    if not any("requires" in e and "> 0" in e for e in errs):
+        failures.append("A1: $0 overlay price not flagged")
+    # mirror shadowed by a $0 overlay row
+    errs, _ = run({"newapi/mzero": {
+        "platform": "newapi", "model_id": "zero-chat", "served_on": ["60"],
+        "channel_type": 43, "price_source": "mirror", "price_key": "zero-chat",
+        "display": False, "notes": "served-via-admin-ui",
+    }})
+    if not any("shadows the mirror" in e for e in errs):
+        failures.append("A1: $0 overlay shadowing a mirror entry not flagged")
+
+    # --- A2: display=true on a no-map platform, and missing from a real map -----
+    errs, _ = run({"newapi/disp": {
+        "platform": "newapi", "model_id": "good-chat", "served_on": ["60"],
+        "channel_type": 17, "price_source": "overlay", "price_key": "good-chat",
+        "display": True, "notes": "served-via-admin-ui",
+    }})
+    if not any("has NO Go" in e for e in errs):
+        failures.append("A2: display=true on no-map platform not flagged")
+    errs, _ = run({"anthropic/disp": {
+        "platform": "anthropic", "model_id": "claude-ghost", "served_on": ["1"],
+        "channel_type": 0, "price_source": "mirror", "price_key": "claude-ghost",
+        "display": True, "notes": "served-via-admin-ui",
+    }})
+    if not any("absent from the anthropic servable-allowlist" in e for e in errs):
+        failures.append("A2: display=true absent from real map not flagged")
+
+    # --- A3: served_on with no migration (hard) vs admin-ui opt-out (warn) ------
+    errs, _ = run({"newapi/gap": {
+        "platform": "newapi", "model_id": "unmapped", "served_on": ["60"],
+        "channel_type": 17, "price_source": "overlay", "price_key": "good-chat",
+        "display": False, "notes": "known gap",
+    }})
+    if not any("#812-class gap" in e for e in errs):
+        failures.append("A3: unmapped served_on not hard-flagged")
+    errs, warns = run({"newapi/oob": {
+        "platform": "newapi", "model_id": "unmapped", "served_on": ["60"],
+        "channel_type": 17, "price_source": "overlay", "price_key": "good-chat",
+        "display": False, "notes": "applied out-of-band served-via-admin-ui",
+    }})
+    if any("#812-class gap" in e for e in errs):
+        failures.append("A3: admin-ui opt-out still hard-failed")
+    if not any("#812-class gap" in w for w in warns):
+        failures.append("A3: admin-ui opt-out did not downgrade to WARN")
+
+    # --- A3 prefix-quote: "good-chat" must NOT match "good-chat-preview" --------
+    pmig = {"tk_902.sql": 'WHERE id = 60 ... "good-chat-preview": "good-chat-preview"'}
+    errs, _ = evaluate(
+        {"entries": {"newapi/pfx": {
+            "platform": "newapi", "model_id": "good-chat", "served_on": ["60"],
+            "channel_type": 17, "price_source": "overlay", "price_key": "good-chat",
+            "display": False, "notes": "n",
+        }}},
+        overlay, allowlist, pmig,
+    )
+    if not any("#812-class gap" in e for e in errs):
+        failures.append("A3: quoted-id prefix isolation broken (matched a -preview key)")
+
+    if failures:
+        print("SELFTEST FAILED:", flush=True)
+        for f in failures:
+            print(f"  - {f}", flush=True)
+        return 1
+    print("selftest ok: A0/A1/A2/A3/A4 pass+fail fixtures all behave", flush=True)
+    return 0
+
+
+# --------------------------------------------------------------------------- main
+
+
+def main() -> int:
+    quiet = "--quiet" in sys.argv
+    if "--selftest" in sys.argv:
+        return _selftest()
+
+    for path, label in ((MANIFEST, "served-models manifest"),
+                        (OVERLAY, "pricing overlay"),
+                        (ALLOWLIST_GO, "servable-allowlist Go file")):
+        if not path.is_file():
+            print(f"  FAIL: {label} not found: {path}", flush=True)
+            return 2
+    if not MIGRATIONS_DIR.is_dir():
+        print(f"  FAIL: migrations dir not found: {MIGRATIONS_DIR}", flush=True)
+        return 2
+
+    try:
+        manifest = json.loads(MANIFEST.read_text(encoding="utf-8"))
+        overlay = json.loads(OVERLAY.read_text(encoding="utf-8"))
+    except (ValueError, OSError) as exc:
+        print(f"  FAIL: manifest/overlay unparseable: {exc}", flush=True)
+        return 2
+    try:
+        allowlist = parse_allowlist_maps(ALLOWLIST_GO.read_text(encoding="utf-8"))
+        migration_files = {
+            p.name: p.read_text(encoding="utf-8", errors="replace")
+            for p in MIGRATIONS_DIR.glob(MIGRATION_GLOB)
+        }
+    except OSError as exc:
+        print(f"  FAIL: reading allowlist/migrations: {exc}", flush=True)
+        return 2
+
+    errors, warnings = evaluate(manifest, overlay, allowlist, migration_files)
+
+    if warnings and not quiet:
+        print(f"  note: {len(warnings)} advisory warning(s):", flush=True)
+        for w in warnings:
+            print(f"    ~ {w}", flush=True)
+
+    if errors:
+        print(f"  FAIL: served-models manifest drift ({len(errors)} issue(s)):", flush=True)
+        for e in errors:
+            print(f"    - {e}", flush=True)
+        return 1
+
+    if not quiet:
+        n = len([k for k in manifest.get("entries", {}) if not k.startswith("_")])
+        print(f"  ok: {n} served-models manifest entries agree with price/display/migration",
+              flush=True)
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/scripts/preflight.sh
+++ b/scripts/preflight.sh
@@ -536,6 +536,32 @@ else
     echo "  ok: pricing overlay valid (anchors present, no \$0)"
 fi
 
+# ---- sub2api: catalog serving drift -----------------------------------------
+# Source of truth: backend/internal/service/tk_served_models.json — the THIN intent
+# manifest ("TK serves model M on platform P via an account credentials.model_mapping
+# whitelist, at price π, display=yes/no") that must AGREE with (1) the tk_*.sql
+# model_mapping migrations, (2) tk_pricing_overlay.json, and (3) the Go
+# servable-allowlist maps in pricing_catalog_supported_models_tk.go. Guards the
+# #812-class regression where a model is priced + advertised-as-intended but never
+# wired onto the serving account's model_mapping (=> empty pool 429/503). Selftest
+# first (offline fixtures), then the real cross-file agreement check. CLAUDE.md
+# §「升级原则」: a soft rule that bit us once becomes a mechanical gate.
+echo ""
+echo "=== sub2api: catalog serving drift ==="
+if ! command -v python3 >/dev/null 2>&1; then
+    echo "  FAIL: python3 not on PATH (required to validate tk_served_models.json)"
+    errors=$((errors + 1))
+elif ! python3 ./scripts/checks/catalog-serving-drift.py --selftest >/dev/null 2>&1; then
+    echo "  FAIL: catalog-serving-drift.py selftest"
+    echo "        — run: python3 scripts/checks/catalog-serving-drift.py --selftest"
+    errors=$((errors + 1))
+elif ! python3 ./scripts/checks/catalog-serving-drift.py --quiet; then
+    # catalog-serving-drift.py already printed the actionable failure.
+    errors=$((errors + 1))
+else
+    echo "  ok: served-models manifest agrees with price/display/migration"
+fi
+
 # ---- sub2api: pricing-hotfix runbook selftest -------------------------------
 # ops/pricing/apply-pricing-hotfix.py is the runbook the PricingMissingNotifier
 # Feishu card points operators at (lookup / apply channel pricing / stage

--- a/scripts/sentinels/pricing-availability.json
+++ b/scripts/sentinels/pricing-availability.json
@@ -137,6 +137,27 @@
         "TestMediaUnpricedGuard_EmptyModelDefaultIsPriced"
       ],
       "rationale": "Overwrite-protection gates for the media unpriced-reject guard: lock guard<->video-billing parity (billing semantics change must update the guard in the same change) and the empty-model fail-open premise (the OAuth default image model must stay priced in the shipped chain). Deleting these tests re-opens the silent-drift channels they close."
+    },
+    {
+      "path": "scripts/checks/catalog-serving-drift.py",
+      "must_contain": [
+        "tk_served_models.json",
+        "servable-allowlist:begin",
+        "served-via-admin-ui",
+        "#812-class gap",
+        "def _selftest("
+      ],
+      "rationale": "The served-models manifest drift guard — asserts backend/internal/service/tk_served_models.json (the THIN intent layer: 'TK serves model M on platform P via an account credentials.model_mapping whitelist, at price π, display=yes/no') AGREES with the three mechanisms it sits above: (A1) tk_pricing_overlay.json non-zero price, (A2) the Go servable-allowlist maps in pricing_catalog_supported_models_tk.go (display=true => present, parsed between the `servable-allowlist:begin/end <platform>` markers), and (A3) the tk_*.sql model_mapping migrations (served_on account => quoted model_id co-occurs with `id = <account>`). A3 is the #812-catching direction: a model priced + advertised-as-intended but never wired onto the serving account's model_mapping yields an empty pool => 429/503. The `served-via-admin-ui` literal is the reviewable A3 opt-out for mappings applied out-of-band of any migration (needed for deepseek-v4-pro/flash on account 39, whose model_mapping predates the tk_*.sql era). Pinning the script + its load-bearing literals stops a silent drop on upstream merge (the guard would otherwise just stop running with no compile error) and forces any rename of the splice markers / opt-out token to update this anchor in the same change. Wired into scripts/preflight.sh ('sub2api: catalog serving drift') and .github/workflows/upstream-merge-pr-shape.yml (Check 14) — preflight/CI parity."
+    },
+    {
+      "path": "backend/internal/service/tk_served_models.json",
+      "must_contain": [
+        "\"entries\"",
+        "\"price_source\"",
+        "\"served_on\"",
+        "\"display\""
+      ],
+      "rationale": "The served-models MANIFEST itself — the single declarative source of intent consumed by scripts/checks/catalog-serving-drift.py (now), the tokenkey-onboard-model skill (now), and a future newapi reconciler (//go:embed of this file, co-located with tk_pricing_overlay.json so the same Go package can embed both). Pinning the schema keys (entries / price_source / served_on / display) stops an upstream merge or refactor from silently truncating the manifest to an empty/legacy shape that would make the drift guard vacuously pass while the intent->migration->price agreement it encodes is lost. Co-located with the overlay so the same preflight parses both and the same package will embed both."
     }
   ]
 }


### PR DESCRIPTION
## Foundation: served-models manifest (single source of truth) + drift guard

Roots out the **#812-class drift** systematically. Today "TK serves model M on platform P via an account `model_mapping`, at price π" is split across multiple surfaces (overlay price · per-account whitelist migration · servable allowlist · group dispatch) with **no mechanical check that they agree** — #812 = priced (overlay) but not mapped (no migration) → empty-pool 429.

This PR adds a **thin intent layer ABOVE those surfaces** (it does NOT collapse overlay==whitelist):

- **`backend/internal/service/tk_served_models.json`** — declarative manifest: which TK-curated newapi long-tail models are served on which account, at what `price_source`, with what `display` eligibility. Co-located with `tk_pricing_overlay.json` so the same Go package can `//go:embed` both (future reconciler, see doc).
- **`scripts/checks/catalog-serving-drift.py`** — asserts the manifest AGREES with **(A1)** overlay/mirror price, **(A2)** the Go servable-allowlist maps, **(A3)** the `tk_*.sql` model_mapping migrations. **A3 hard-fails the priced-but-not-mapped #812 shape at preflight/CI time**, with a reviewable `served-via-admin-ui` opt-out for out-of-band (admin-UI) mappings. `--selftest` ships offline fixtures.
- Wired into `scripts/preflight.sh` + `upstream-merge-pr-shape.yml` (Check 14) + two `pricing-availability.json` sentinel anchors (so the guard can't be silently dropped on merge).
- **`docs/approved/newapi-served-models-reconciler.md`** — Phase 3 decision record (deferred): a manifest-derived newapi reconciler (net-add only, §5.x) + the explicit blocker for true-runtime pricing (refund-safety validation must move from preflight-time to write-time; `channel_model_pricing` silent-shadow precedence) + a measurable trigger condition.

> The UI "mode-flip drops the whitelist" concern was investigated and is **not a real bug** — the existing `useTkAccountNewApiPlatform.spec.ts:94-108` proves identity entries round-trip via the unconditional `modelMappings` loop. No frontend patch shipped (avoids a no-op + a dist rebuild).

**Stacked on #818** — A3 needs `tk_029` to map qwen3-8b/14b/32b, else it (correctly) hard-fails them. **Merge #818 first.**

**Checklist:** pure-insertion manifest + TK-infra edits (no upstream-shaped path touched) · `no-web-impact` · full preflight green (`catalog serving drift: ok`).

Reviewer: **Squash and merge**.

🤖 Generated with [Claude Code](https://claude.com/claude-code)