### PR TITLE
docs: de-specify prod instance type in §9 (arm64, drop t4g.small)

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -252,7 +252,7 @@ handler → service → repository → ent
 
 ### 9. Release Discipline (ARM + Tag Triggers)
 
-Production deployment (`api.tokenkey.dev`) runs on **AWS Graviton (`t4g.small`, `arm64`)**, and Release workflow is triggered by `tags: v*`. Two pitfalls have already broken prod once each — both are now **hard rules**:
+Production deployment (`api.tokenkey.dev`) runs on **AWS Graviton (`arm64`)**, and Release workflow is triggered by `tags: v*`. Two pitfalls have already broken prod once each — both are now **hard rules**:
 
 #### 9.1 `simple_release` MUST stay `false`
 


### PR DESCRIPTION
## What

CLAUDE.md §9 (Release Discipline) claimed prod runs on `t4g.small`. Prod was resized to `t4g.large` (2 vCPU / 8 GiB) on 2026-06-05 — documented in `deploy/aws/README.md § 实例规格升级` — so the line was stale.

Change: `AWS Graviton (\`t4g.small\`, \`arm64\`)` → `AWS Graviton (\`arm64\`)`. One line.

## Why de-specify instead of bumping to t4g.large

The load-bearing fact for §9's two hard rules (`simple_release=false`; no `skip-ci` on VERSION bumps) is **arm64/Graviton** — an amd64-only image on an ARM host crashes with `exec format error`. The specific instance *size* plays no role in those rules; it's incidental background that already drifted once (the resize) and would drift again on the next one. Pinning it to `t4g.large` just re-introduces the same staleness. `deploy/aws/README.md`'s resize SOP remains the single authoritative place for the current size.

The downstream "Prod and Edge Stage0 hosts today are ARM" sentence (the real claim) is unchanged.

## Scope

- Touches only `CLAUDE.md` (docs). No code, no web surface, no upstream-shaped paths.
- `deploy/aws/README.md` t4g.small mentions are intentionally left — they live in the resize SOP / rollback target / incident record and are correct there.
- `scripts/preflight.sh`: PASS.

## Context

Surfaced during a prod 24h resource audit (CPU peak 98% but avg 16% / credits never depleted; mem peak 19% of 8 GiB; DATA volume I/O comfortable). The audit found the doc said t4g.small while the instance is t4g.large.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
