### PR TITLE
fix(edge): forward 7d Sonnet sub-window to prod Edge accounts overview

### DIFF
--- a/backend/internal/handler/edge_tk_accounts_handler.go
+++ b/backend/internal/handler/edge_tk_accounts_handler.go
@@ -204,9 +204,10 @@ type edgeAccountDTO struct {
 // cell reads (utilization + reset per window); window_stats is supplied
 // frontend-side from today_stats, so it is not duplicated here.
 type edgeUsageWindows struct {
-	Source   string             `json:"source"`
-	FiveHour *edgeUsageProgress `json:"five_hour,omitempty"`
-	SevenDay *edgeUsageProgress `json:"seven_day,omitempty"`
+	Source         string             `json:"source"`
+	FiveHour       *edgeUsageProgress `json:"five_hour,omitempty"`
+	SevenDay       *edgeUsageProgress `json:"seven_day,omitempty"`
+	SevenDaySonnet *edgeUsageProgress `json:"seven_day_sonnet,omitempty"`
 }
 
 type edgeUsageProgress struct {
@@ -318,7 +319,10 @@ func toEdgeUsageWindows(u *service.UsageInfo) *edgeUsageWindows {
 	if u.SevenDay != nil {
 		w.SevenDay = &edgeUsageProgress{Utilization: u.SevenDay.Utilization, ResetsAt: u.SevenDay.ResetsAt}
 	}
-	if w.FiveHour == nil && w.SevenDay == nil {
+	if u.SevenDaySonnet != nil {
+		w.SevenDaySonnet = &edgeUsageProgress{Utilization: u.SevenDaySonnet.Utilization, ResetsAt: u.SevenDaySonnet.ResetsAt}
+	}
+	if w.FiveHour == nil && w.SevenDay == nil && w.SevenDaySonnet == nil {
 		return nil
 	}
 	return w

--- a/backend/internal/handler/edge_tk_accounts_handler_test.go
+++ b/backend/internal/handler/edge_tk_accounts_handler_test.go
@@ -198,7 +198,7 @@ func TestEdgeAccountsHandler_EnrichesRuntimeGauges(t *testing.T) {
 		fakeUsageReader{
 			today:   map[int64]*service.WindowStats{7: {Requests: 80, Tokens: 65_900_000, Cost: 36.53, UserCost: 36.53}},
 			wcost:   36.53,
-			passive: &service.UsageInfo{Source: "passive", FiveHour: &service.UsageProgress{Utilization: 2}, SevenDay: &service.UsageProgress{Utilization: 4}},
+			passive: &service.UsageInfo{Source: "passive", FiveHour: &service.UsageProgress{Utilization: 2}, SevenDay: &service.UsageProgress{Utilization: 4}, SevenDaySonnet: &service.UsageProgress{Utilization: 6}},
 		},
 	)
 	w := performEdgeAccountsRequest(t, h, "?platform=anthropic")
@@ -230,6 +230,8 @@ func TestEdgeAccountsHandler_EnrichesRuntimeGauges(t *testing.T) {
 	require.Equal(t, 2.0, got.Usage.FiveHour.Utilization)
 	require.NotNil(t, got.Usage.SevenDay)
 	require.Equal(t, 4.0, got.Usage.SevenDay.Utilization)
+	require.NotNil(t, got.Usage.SevenDaySonnet, "anthropic account must forward the 7d Sonnet sub-window to the edge overview")
+	require.Equal(t, 6.0, got.Usage.SevenDaySonnet.Utilization)
 }
 
 // OpenAI OAuth (codex) accounts must also carry the passive 5h/7d usage windows

--- a/backend/internal/web/dist/frontend-source.json
+++ b/backend/internal/web/dist/frontend-source.json
@@ -1,7 +1,7 @@
 {
   "algorithm": "sha256(git-ls-files:path,size,content)",
   "file_count": 486,
-  "hash": "8e08cfbe94a018d9e76068dc8d2ad548e936295bdde32efa4723c21de1848334",
+  "hash": "623a851c12aeb628d0695eb008948898d8bea7d5c9cd14dbb02a26dc88a9d25a",
   "schema": 1,
   "source": "frontend/"
 }

--- a/frontend/src/api/admin/edgeAccounts.ts
+++ b/frontend/src/api/admin/edgeAccounts.ts
@@ -66,6 +66,7 @@ export interface EdgeUsageWindows {
   source: string
   five_hour?: EdgeUsageProgress
   seven_day?: EdgeUsageProgress
+  seven_day_sonnet?: EdgeUsageProgress
 }
 
 export interface EdgeUsageProgress {

--- a/frontend/src/utils/__tests__/edgeAccountsTk.spec.ts
+++ b/frontend/src/utils/__tests__/edgeAccountsTk.spec.ts
@@ -1,5 +1,5 @@
 import { describe, it, expect } from 'vitest'
-import { isTempUnschedActive } from '@/utils/edgeAccounts.tk'
+import { isTempUnschedActive, toUsageInfo } from '@/utils/edgeAccounts.tk'
 import type { EdgeAccountSummary } from '@/api/admin/edgeAccounts'
 
 function acct(over: Partial<EdgeAccountSummary>): EdgeAccountSummary {
@@ -42,5 +42,29 @@ describe('isTempUnschedActive', () => {
   it('returns true while the cooldown is still in the future', () => {
     const future = new Date(Date.now() + 60 * 1000).toISOString()
     expect(isTempUnschedActive(acct({ temp_unschedulable_until: future }))).toBe(true)
+  })
+})
+
+describe('toUsageInfo', () => {
+  it('returns null when the edge reported no usage windows', () => {
+    expect(toUsageInfo(acct({ usage: undefined }))).toBeNull()
+  })
+
+  it('forwards the 7d Sonnet sub-window so the Edge overview renders the "7d S" bar', () => {
+    // Regression: the edge overview previously hard-coded seven_day_sonnet to null,
+    // so prod 总台 could not show Sonnet's 7-day window even though the edge had it.
+    const info = toUsageInfo(
+      acct({
+        usage: {
+          source: 'passive',
+          five_hour: { utilization: 52 },
+          seven_day: { utilization: 53 },
+          seven_day_sonnet: { utilization: 33, resets_at: '2026-06-22T14:00:00Z' }
+        }
+      })
+    )
+    expect(info).not.toBeNull()
+    expect(info?.seven_day_sonnet?.utilization).toBe(33)
+    expect(info?.seven_day_sonnet?.resets_at).toBe('2026-06-22T14:00:00Z')
   })
 })

--- a/frontend/src/utils/edgeAccounts.tk.ts
+++ b/frontend/src/utils/edgeAccounts.tk.ts
@@ -107,6 +107,6 @@ export function toUsageInfo(s: EdgeAccountSummary): AccountUsageInfo | null {
     updated_at: null,
     five_hour: mk(s.usage.five_hour),
     seven_day: mk(s.usage.seven_day),
-    seven_day_sonnet: null
+    seven_day_sonnet: mk(s.usage.seven_day_sonnet)
   }
 }


### PR DESCRIPTION
## 问题

运营反馈：prod 总台 **「Edge 账号」** 视图刷不出 Sonnet 7 天窗口（`7d S`）。同一账号在 **「批量编辑账号」**（直连 `/admin/accounts/:id/usage`）能看到 `7d S 33%`。

## 根因

端到端字段丢失，非前端单点 bug：

1. edge 端 `GetPassiveUsage` 本就产出 `SevenDaySonnet`（`account_usage_service.go:483`，由 active「查询」回写 passive extra）；
2. edge DTO `toEdgeUsageWindows`（`edge_tk_accounts_handler.go`）只映射 `FiveHour`/`SevenDay`，**静默丢弃 `SevenDaySonnet`**，连空窗判断都未纳入；
3. 前端 `toUsageInfo`（`edgeAccounts.tk.ts`）因此写死 `seven_day_sonnet: null`，忠实复刻后端缺失。

数据本就存在（批量编辑可见），只是在聚合到 Edge 概览的链路上被砍掉。

## 修复

| 文件 | 改动 |
|---|---|
| `edge_tk_accounts_handler.go` | DTO 加 `SevenDaySonnet` + `toEdgeUsageWindows` 映射 + 空窗 guard 纳入它 |
| `api/admin/edgeAccounts.ts` | `EdgeUsageWindows` 加 `seven_day_sonnet` |
| `utils/edgeAccounts.tk.ts` | `toUsageInfo` 映射 `seven_day_sonnet`（不再写死 null） |
| `edge_tk_accounts_handler_test.go` | 钉住 sonnet 子窗转发 |
| `edgeAccountsTk.spec.ts` | 钉住前端映射（回归用例） |

全部 TK-only 文件（`*_tk_*.go` / `*.tk.ts` / `*.ts` API / `*_test.go`），不触 upstream 面，无 upstream symbol 删除。

## 验证

- `go test -tags=unit ./internal/handler/ -run TestEdgeAccountsHandler` ✅
- 前端 `edgeAccountsTk.spec.ts` 5/5 ✅
- `pnpm typecheck` / `pnpm lint:check` ✅
- `pnpm build`（重生成 `frontend-source.json`）✅
- `scripts/preflight.sh` 全绿 ✅

## Markers

`sentinel-registry-reviewed` — 本 PR 触到 load-bearing TK 面 `edge_tk_accounts_handler.go` 且含删除行；已 review，该面 DTO 字段属纯加法扩展（新增 `SevenDaySonnet` window），无需新增 sentinel anchor。

🤖 Generated with [Claude Code](https://claude.com/claude-code)