### PR TITLE
feat(traj): extend per-key conversation export to openai / antigravity / gemini-vertex (#792 #808)

### DIFF
--- a/backend/internal/engine/provider.go
+++ b/backend/internal/engine/provider.go
@@ -56,3 +56,28 @@ func AllSchedulingPlatforms() []string {
 		domain.PlatformGrok,
 	}
 }
+
+// TrajProjectablePlatforms returns the platforms whose captured client-facing
+// wire shape the traj v2 projector faithfully reconstructs (see
+// trajectory.WireShapeForRecord). It is the SINGLE SOURCE the /auth/me
+// projectable allowlist (frontend export-chip visibility) and the per-key
+// export gate read from — never hand-list projectable platforms anywhere else.
+//
+// Derived from the wire-shape families, NOT a re-listed slice:
+//   - anthropic + kiro relay the Anthropic /v1/messages shape;
+//   - gemini (incl. vertex) and antigravity speak the Gemini contents[] shape
+//     (antigravity additionally relays /v1/messages on /antigravity/v1, which
+//     the projector dispatches per inbound endpoint);
+//   - OpenAICompatPlatforms() speak the OpenAI chat/responses shapes.
+//
+// The OpenAI-compat members are pulled from OpenAICompatPlatforms() so adding a
+// future compat platform there flows through here automatically.
+func TrajProjectablePlatforms() []string {
+	out := []string{
+		domain.PlatformAnthropic,
+		domain.PlatformKiro,
+		domain.PlatformGemini,
+		domain.PlatformAntigravity,
+	}
+	return append(out, OpenAICompatPlatforms()...)
+}

--- a/backend/internal/engine/provider_traj_test.go
+++ b/backend/internal/engine/provider_traj_test.go
@@ -1,0 +1,47 @@
+//go:build unit
+
+package engine
+
+import (
+	"testing"
+
+	"github.com/Wei-Shaw/sub2api/internal/domain"
+)
+
+// TrajProjectablePlatforms is the single source for "which platforms the traj v2
+// projector can faithfully reconstruct" (feeds the /auth/me export-chip
+// allowlist). This pins its membership and that the OpenAI-compat members are
+// derived from OpenAICompatPlatforms() rather than re-listed.
+func TestTrajProjectablePlatforms(t *testing.T) {
+	got := TrajProjectablePlatforms()
+	set := map[string]bool{}
+	for _, p := range got {
+		if set[p] {
+			t.Fatalf("duplicate platform %q in TrajProjectablePlatforms", p)
+		}
+		set[p] = true
+	}
+
+	wantPresent := []string{
+		domain.PlatformAnthropic,
+		domain.PlatformKiro,
+		domain.PlatformGemini,
+		domain.PlatformAntigravity,
+		domain.PlatformOpenAI,
+		domain.PlatformNewAPI,
+		domain.PlatformGrok,
+	}
+	for _, p := range wantPresent {
+		if !set[p] {
+			t.Errorf("TrajProjectablePlatforms missing %q", p)
+		}
+	}
+
+	// The OpenAI-compat members must flow through from OpenAICompatPlatforms() so
+	// a future compat platform is picked up automatically (no second list).
+	for _, p := range OpenAICompatPlatforms() {
+		if !set[p] {
+			t.Errorf("TrajProjectablePlatforms must include OpenAICompatPlatforms() member %q", p)
+		}
+	}
+}

--- a/backend/internal/handler/auth_handler.go
+++ b/backend/internal/handler/auth_handler.go
@@ -420,6 +420,12 @@ func (h *AuthHandler) GetCurrentUser(c *gin.Context) {
 	type UserResponse struct {
 		userProfileResponse
 		RunMode string `json:"run_mode"`
+		// TrajExportPlatforms is the server-driven allowlist of platforms whose
+		// conversation records the traj projector can reconstruct. The frontend
+		// export chip renders only for a key whose group platform is in this list
+		// (single source: engine.TrajProjectablePlatforms via the service layer),
+		// so the UI carries no hardcoded platform list of its own.
+		TrajExportPlatforms []string `json:"traj_export_platforms"`
 	}
 
 	runMode := config.RunModeStandard
@@ -430,6 +436,7 @@ func (h *AuthHandler) GetCurrentUser(c *gin.Context) {
 	response.Success(c, UserResponse{
 		userProfileResponse: userProfileResponseFromService(user, identities),
 		RunMode:             runMode,
+		TrajExportPlatforms: service.TrajProjectablePlatforms(),
 	})
 }
 

--- a/backend/internal/handler/qa_handler_traj.go
+++ b/backend/internal/handler/qa_handler_traj.go
@@ -10,7 +10,6 @@ import (
 	"strings"
 	"time"
 
-	"github.com/Wei-Shaw/sub2api/internal/domain"
 	"github.com/Wei-Shaw/sub2api/internal/observability/qa"
 	"github.com/Wei-Shaw/sub2api/internal/pkg/response"
 	middleware2 "github.com/Wei-Shaw/sub2api/internal/server/middleware"
@@ -55,12 +54,14 @@ func (h *QAHandler) ExportSelfTrajectory(c *gin.Context) {
 		SynthSessionID: strings.TrimSpace(req.SynthSessionID),
 		SynthRole:      strings.TrimSpace(req.SynthRole),
 		APIKeyID:       req.APIKeyID,
-		// The traj v2 projector only faithfully reconstructs Anthropic
-		// /v1/messages trajectories; openai/gemini blobs project to empty or
-		// garbage turns. Pin the export to anthropic so a non-anthropic key
-		// (UI already hides the entry) can't yield a misleading non-empty zip.
-		Platform: domain.PlatformAnthropic,
-		Format:   strings.TrimSpace(req.Format),
+		// No platform pin: the traj v2 projector now dispatches per record by
+		// wire shape (trajectory.WireShapeForRecord) and reconstructs anthropic /
+		// openai / gemini / antigravity / kiro / newapi faithfully, skipping
+		// non-conversation (Unknown-shape) records. A per-key export is already
+		// single-platform via APIKeyID, and the export chip is gated server-side
+		// to engine.TrajProjectablePlatforms() (see /auth/me traj_export_platforms),
+		// so a non-projectable key never reaches here with a misleading zip.
+		Format: strings.TrimSpace(req.Format),
 	}
 	// Per-key export ("导出该 Key 的对话记录") drops the trailing-24h default
 	// window and returns the key's full retained trajectory; the data set is

--- a/backend/internal/observability/qa/service_export_multiplatform_test.go
+++ b/backend/internal/observability/qa/service_export_multiplatform_test.go
@@ -1,0 +1,210 @@
+//go:build unit
+
+package qa
+
+// Multi-platform traj export (Commit D): with the handler's anthropic pin
+// removed, ExportUserTrajectoryData streams a key's records and the v2 projector
+// dispatches each conversation group by wire shape. These tests prove the
+// streaming export folds + dispatches correctly across shapes, never merges two
+// shapes into one session, splits a single newapi key's chat-vs-gemini records,
+// projects kiro via the anthropic builder, and skips non-conversation records.
+
+import (
+	"archive/zip"
+	"bytes"
+	"context"
+	"encoding/json"
+	"io"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/require"
+)
+
+// readTrajSessionsV2 reads the trajectory.jsonl out of an export zip and parses
+// each line into a generic session map.
+func readTrajSessionsV2(t *testing.T, store *memBlobStore, storageKey string) []map[string]any {
+	t.Helper()
+	blob := store.objects[storageKey]
+	require.NotEmpty(t, blob, "export zip is non-empty")
+	zr, err := zip.NewReader(bytes.NewReader(blob), int64(len(blob)))
+	require.NoError(t, err)
+	require.Len(t, zr.File, 1)
+	require.Equal(t, "trajectory.jsonl", zr.File[0].Name)
+	f, err := zr.File[0].Open()
+	require.NoError(t, err)
+	defer func() { _ = f.Close() }()
+	data, err := io.ReadAll(f)
+	require.NoError(t, err)
+
+	var out []map[string]any
+	for _, line := range strings.Split(strings.TrimSpace(string(data)), "\n") {
+		if strings.TrimSpace(line) == "" {
+			continue
+		}
+		var m map[string]any
+		require.NoError(t, json.Unmarshal([]byte(line), &m))
+		out = append(out, m)
+	}
+	return out
+}
+
+func turnsOf(t *testing.T, session map[string]any) []any {
+	t.Helper()
+	turns, _ := session["turns"].([]any)
+	return turns
+}
+
+// jsonToMap parses a JSON object string into the map[string]any blob bodies
+// expected by encodeEvidenceBlobForTest.
+func jsonToMap(t *testing.T, s string) map[string]any {
+	t.Helper()
+	var m map[string]any
+	require.NoError(t, json.Unmarshal([]byte(s), &m))
+	return m
+}
+
+// assistantText returns the assistant turn's derived text content (the `content`
+// field on assistant turns), used to tell shapes apart in the export.
+func lastAssistantText(t *testing.T, session map[string]any) string {
+	t.Helper()
+	turns := turnsOf(t, session)
+	for i := len(turns) - 1; i >= 0; i-- {
+		turn, _ := turns[i].(map[string]any)
+		if turn["role"] == "assistant" {
+			if s, ok := turn["content"].(string); ok {
+				return s
+			}
+		}
+	}
+	return ""
+}
+
+// A key carrying an openai-chat conversation + a gemini conversation + a
+// non-conversation (embeddings) record exports into exactly two sessions — one
+// per shape, correctly reconstructed, with no cross-shape merge and the
+// embeddings record skipped.
+func TestExportUserTrajectoryData_MultiPlatformShapeDispatch(t *testing.T) {
+	svc, client, store := newQAExportTestService(t)
+	ctx := context.Background()
+	now := time.Now().UTC()
+
+	chatBlob := func(req, resp string) map[string]any {
+		return map[string]any{
+			"request":  map[string]any{"path": "/v1/chat/completions", "body": jsonToMap(t, req)},
+			"response": map[string]any{"status_code": 200, "headers": map[string]any{}, "body": jsonToMap(t, resp)},
+			"stream":   map[string]any{"chunks": []any{}},
+		}
+	}
+	// openai chat: 2-call tool-use conversation under key 1.
+	mustInsertQARecordWithBlob(t, ctx, client, store,
+		qaRecordBuilder{requestID: "oa0", userID: 7, apiKeyID: 1, createdAt: now, platform: "openai", inboundEndpoint: "/v1/chat/completions"},
+		chatBlob(
+			`{"model":"gpt-5","messages":[{"role":"system","content":"sys"},{"role":"user","content":"build X"}]}`,
+			`{"choices":[{"message":{"role":"assistant","content":"step1","tool_calls":[{"id":"c1","type":"function","function":{"name":"bash","arguments":"{}"}}]},"finish_reason":"tool_calls"}]}`,
+		))
+	mustInsertQARecordWithBlob(t, ctx, client, store,
+		qaRecordBuilder{requestID: "oa1", userID: 7, apiKeyID: 1, createdAt: now.Add(time.Second), platform: "openai", inboundEndpoint: "/v1/chat/completions"},
+		chatBlob(
+			`{"model":"gpt-5","messages":[{"role":"system","content":"sys"},{"role":"user","content":"build X"},{"role":"assistant","content":null,"tool_calls":[{"id":"c1","type":"function","function":{"name":"bash","arguments":"{}"}}]},{"role":"tool","tool_call_id":"c1","content":"out"}]}`,
+			`{"choices":[{"message":{"role":"assistant","content":"OA_DONE"},"finish_reason":"stop"}]}`,
+		))
+	// gemini: single-shot conversation under the same key.
+	mustInsertQARecordWithBlob(t, ctx, client, store,
+		qaRecordBuilder{requestID: "gm0", userID: 7, apiKeyID: 1, createdAt: now.Add(2 * time.Second), platform: "gemini", inboundEndpoint: "/v1beta/models"},
+		map[string]any{
+			"request":  map[string]any{"path": "/v1beta/models", "body": jsonToMap(t, `{"contents":[{"role":"user","parts":[{"text":"hi"}]}]}`)},
+			"response": map[string]any{"status_code": 200, "headers": map[string]any{}, "body": jsonToMap(t, `{"candidates":[{"content":{"parts":[{"text":"GM_HELLO"}]},"finishReason":"STOP"}]}`)},
+			"stream":   map[string]any{"chunks": []any{}},
+		})
+	// embeddings: non-conversation record → Unknown shape → skipped.
+	mustInsertQARecordWithBlob(t, ctx, client, store,
+		qaRecordBuilder{requestID: "emb0", userID: 7, apiKeyID: 1, createdAt: now.Add(3 * time.Second), platform: "openai", inboundEndpoint: "/v1/embeddings"},
+		map[string]any{
+			"request":  map[string]any{"path": "/v1/embeddings", "body": jsonToMap(t, `{"input":"x"}`)},
+			"response": map[string]any{"status_code": 200, "headers": map[string]any{}, "body": jsonToMap(t, `{"data":[{"embedding":[0.1]}]}`)},
+			"stream":   map[string]any{"chunks": []any{}},
+		})
+
+	key1 := int64(1)
+	res, err := svc.ExportUserTrajectoryData(ctx, 7, ExportFilter{APIKeyID: &key1, Format: "v2"})
+	require.NoError(t, err)
+
+	sessions := readTrajSessionsV2(t, store, res.StorageKey)
+	require.Len(t, sessions, 2, "openai + gemini = 2 sessions; embeddings skipped, no cross-shape merge")
+
+	var openaiSession, geminiSession map[string]any
+	for _, s := range sessions {
+		switch lastAssistantText(t, s) {
+		case "OA_DONE":
+			openaiSession = s
+		case "GM_HELLO":
+			geminiSession = s
+		}
+	}
+	require.NotNil(t, openaiSession, "openai session present")
+	require.NotNil(t, geminiSession, "gemini session present (not merged into openai)")
+	require.Len(t, turnsOf(t, openaiSession), 4, "openai: user/assistant/tool/assistant")
+	require.Len(t, turnsOf(t, geminiSession), 2, "gemini: user/assistant")
+}
+
+// A single newapi key whose records span /v1/chat/completions and /v1beta/models
+// (newapi ch41 vertex) splits into two sessions of different shapes — wire shape
+// is per record, not per platform.
+func TestExportUserTrajectoryData_NewapiSplitsChatVsGemini(t *testing.T) {
+	svc, client, store := newQAExportTestService(t)
+	ctx := context.Background()
+	now := time.Now().UTC()
+
+	mustInsertQARecordWithBlob(t, ctx, client, store,
+		qaRecordBuilder{requestID: "np-chat", userID: 9, apiKeyID: 3, createdAt: now, platform: "newapi", inboundEndpoint: "/v1/chat/completions"},
+		map[string]any{
+			"request":  map[string]any{"path": "/v1/chat/completions", "body": jsonToMap(t, `{"model":"deepseek","messages":[{"role":"user","content":"q"}]}`)},
+			"response": map[string]any{"status_code": 200, "headers": map[string]any{}, "body": jsonToMap(t, `{"choices":[{"message":{"role":"assistant","content":"NP_CHAT"},"finish_reason":"stop"}]}`)},
+			"stream":   map[string]any{"chunks": []any{}},
+		})
+	mustInsertQARecordWithBlob(t, ctx, client, store,
+		qaRecordBuilder{requestID: "np-gem", userID: 9, apiKeyID: 3, createdAt: now.Add(time.Second), platform: "newapi", inboundEndpoint: "/v1beta/models"},
+		map[string]any{
+			"request":  map[string]any{"path": "/v1beta/models", "body": jsonToMap(t, `{"contents":[{"role":"user","parts":[{"text":"q"}]}]}`)},
+			"response": map[string]any{"status_code": 200, "headers": map[string]any{}, "body": jsonToMap(t, `{"candidates":[{"content":{"parts":[{"text":"NP_GEM"}]},"finishReason":"STOP"}]}`)},
+			"stream":   map[string]any{"chunks": []any{}},
+		})
+
+	key3 := int64(3)
+	res, err := svc.ExportUserTrajectoryData(ctx, 9, ExportFilter{APIKeyID: &key3, Format: "v2"})
+	require.NoError(t, err)
+	sessions := readTrajSessionsV2(t, store, res.StorageKey)
+	require.Len(t, sessions, 2, "same newapi key, two wire shapes → two sessions")
+
+	texts := map[string]bool{}
+	for _, s := range sessions {
+		texts[lastAssistantText(t, s)] = true
+	}
+	require.True(t, texts["NP_CHAT"], "newapi chat session reconstructed")
+	require.True(t, texts["NP_GEM"], "newapi gemini session reconstructed (not merged with chat)")
+}
+
+// Kiro records relay the anthropic /v1/messages shape and project via the
+// anthropic builder.
+func TestExportUserTrajectoryData_KiroProjectsViaAnthropic(t *testing.T) {
+	svc, client, store := newQAExportTestService(t)
+	ctx := context.Background()
+	now := time.Now().UTC()
+
+	mustInsertQARecordWithBlob(t, ctx, client, store,
+		qaRecordBuilder{requestID: "kiro0", userID: 11, apiKeyID: 5, createdAt: now, platform: "kiro", inboundEndpoint: "/v1/messages"},
+		map[string]any{
+			"request":  map[string]any{"path": "/v1/messages", "body": jsonToMap(t, `{"model":"claude-sonnet-4","messages":[{"role":"user","content":"hi"}]}`)},
+			"response": map[string]any{"status_code": 200, "headers": map[string]any{}, "body": jsonToMap(t, `{"id":"m","stop_reason":"end_turn","content":[{"type":"text","text":"KIRO_OK"}]}`)},
+			"stream":   map[string]any{"chunks": []any{}},
+		})
+
+	key5 := int64(5)
+	res, err := svc.ExportUserTrajectoryData(ctx, 11, ExportFilter{APIKeyID: &key5, Format: "v2"})
+	require.NoError(t, err)
+	sessions := readTrajSessionsV2(t, store, res.StorageKey)
+	require.Len(t, sessions, 1)
+	require.Equal(t, "KIRO_OK", lastAssistantText(t, sessions[0]))
+}

--- a/backend/internal/observability/qa/service_export_test.go
+++ b/backend/internal/observability/qa/service_export_test.go
@@ -110,9 +110,12 @@ func mustInsertQARecord(t *testing.T, ctx context.Context, client *dbent.Client,
 		SetRequestID(b.requestID).
 		SetUserID(b.userID).
 		SetAPIKeyID(b.apiKeyID).
-		SetPlatform("anthropic").
+		SetPlatform(b.platformOrDefault()).
 		SetCreatedAt(b.createdAt).
 		SetRetentionUntil(b.createdAt.Add(7 * 24 * time.Hour))
+	if b.inboundEndpoint != "" {
+		create = create.SetInboundEndpoint(b.inboundEndpoint)
+	}
 	if b.synthSession != "" {
 		create = create.SetSynthSessionID(b.synthSession)
 	}
@@ -134,6 +137,18 @@ type qaRecordBuilder struct {
 	synthSession string
 	synthRole    string
 	dialogSynth  bool
+	// platform / inboundEndpoint default to anthropic / "" so existing callers
+	// are unaffected; multi-platform export tests set them to drive the
+	// projector's wire-shape dispatch (WireShapeForRecord).
+	platform        string
+	inboundEndpoint string
+}
+
+func (b qaRecordBuilder) platformOrDefault() string {
+	if b.platform != "" {
+		return b.platform
+	}
+	return "anthropic"
 }
 
 type dlqOnlyBlobStore struct{}
@@ -508,10 +523,13 @@ func mustInsertQARecordWithBlob(t *testing.T, ctx context.Context, client *dbent
 		SetRequestID(b.requestID).
 		SetUserID(b.userID).
 		SetAPIKeyID(b.apiKeyID).
-		SetPlatform("anthropic").
+		SetPlatform(b.platformOrDefault()).
 		SetCreatedAt(b.createdAt).
 		SetRetentionUntil(b.createdAt.Add(7 * 24 * time.Hour)).
 		SetBlobURI("mem://" + key)
+	if b.inboundEndpoint != "" {
+		create = create.SetInboundEndpoint(b.inboundEndpoint)
+	}
 	if b.synthSession != "" {
 		create = create.SetSynthSessionID(b.synthSession)
 	}
@@ -525,9 +543,10 @@ func mustInsertQARecordWithBlob(t *testing.T, ctx context.Context, client *dbent
 	require.NoError(t, err)
 }
 
-// The traj v2 projector is Anthropic-shaped, so the traj export pins
-// Platform="anthropic"; records from other platforms (openai/gemini) must be
-// excluded even when they share the same user and API key.
+// The ExportFilter.Platform predicate (qarecord.PlatformEQ) still narrows the
+// export to one platform when a caller sets it. The traj export handler no
+// longer pins it (the projector dispatches per record by wire shape), but the
+// predicate remains available and sentinel-anchored, so this guards it.
 func TestExportUserTrajectoryData_PlatformFilterExcludesNonAnthropic(t *testing.T) {
 	svc, client, _ := newQAExportTestService(t)
 	ctx := context.Background()

--- a/backend/internal/observability/qa/service_traj_export.go
+++ b/backend/internal/observability/qa/service_traj_export.go
@@ -112,12 +112,14 @@ func (s *Service) ExportUserTrajectoryData(ctx context.Context, userID int64, fi
 		recordCount++
 		// A record continues the current group if it shares a synth_session_id
 		// (synthetic pipelines key on that, and their bodies aren't prefix chains)
-		// OR its messages extend the previous request as a prefix (real agent
-		// conversations). Otherwise it opens a new conversation, so flush.
+		// OR it continues the previous record under the same wire shape — a
+		// growing message/contents/input prefix; a wire-shape change is a hard
+		// boundary (RequestContinues is shape-aware). Otherwise it opens a new
+		// conversation, so flush.
 		if len(group) > 0 {
 			prev := group[len(group)-1]
 			continues := sameSynthSession(prev.Record, record) ||
-				trajectory.RequestMessagesContinue(prev.Blob.Request.Body, src.Blob.Request.Body)
+				trajectory.RequestContinues(prev, src)
 			if !continues {
 				if err := flush(group); err != nil {
 					return err

--- a/backend/internal/observability/qa/wire_shape_drift_test.go
+++ b/backend/internal/observability/qa/wire_shape_drift_test.go
@@ -1,0 +1,45 @@
+//go:build unit
+
+package qa
+
+// Drift guard: the trajectory projector dispatches on the NORMALIZED inbound
+// endpoint that this (qa) package stamps onto every QARecord. The two literals
+// live in different packages (trajectory cannot import qa without a cycle), so
+// this test pins the contract — if normalizeInboundEndpoint ever changes a
+// qaEndpoint* value, the projector would silently mis-dispatch (or skip) those
+// records; this test fails first instead.
+
+import (
+	"testing"
+
+	"github.com/Wei-Shaw/sub2api/ent"
+	"github.com/Wei-Shaw/sub2api/internal/domain"
+	"github.com/Wei-Shaw/sub2api/internal/observability/trajectory"
+)
+
+func TestCaptureEndpointsMapToExpectedWireShape(t *testing.T) {
+	cases := []struct {
+		name     string
+		platform string
+		endpoint string
+		want     trajectory.WireShape
+	}{
+		{"messages", domain.PlatformAnthropic, qaEndpointMessages, trajectory.WireAnthropicMessages},
+		{"chat_completions", domain.PlatformOpenAI, qaEndpointChatCompletions, trajectory.WireOpenAIChat},
+		{"responses", domain.PlatformOpenAI, qaEndpointResponses, trajectory.WireOpenAIResponses},
+		{"gemini_models", domain.PlatformGemini, qaEndpointGeminiModels, trajectory.WireGemini},
+		// Non-conversation endpoints must remain unprojectable (skip, not garbage).
+		{"embeddings", domain.PlatformOpenAI, qaEndpointEmbeddings, trajectory.WireUnknown},
+		{"images", domain.PlatformOpenAI, qaEndpointImagesGenerations, trajectory.WireUnknown},
+		{"video", domain.PlatformOpenAI, qaEndpointVideoGenerations, trajectory.WireUnknown},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			got := trajectory.WireShapeForRecord(&ent.QARecord{Platform: tc.platform, InboundEndpoint: tc.endpoint})
+			if got != tc.want {
+				t.Fatalf("capture endpoint %q (platform %q) → wire shape %q, want %q — normalizeInboundEndpoint and trajectory.WireShapeForRecord drifted",
+					tc.endpoint, tc.platform, got, tc.want)
+			}
+		})
+	}
+}

--- a/backend/internal/observability/trajectory/projection_gemini.go
+++ b/backend/internal/observability/trajectory/projection_gemini.go
@@ -1,0 +1,341 @@
+package trajectory
+
+import (
+	"encoding/base64"
+	"strings"
+
+	"github.com/Wei-Shaw/sub2api/ent"
+	"github.com/tidwall/gjson"
+)
+
+// Gemini traj v2 projection. Covers the Gemini contents[]/parts[] wire shape on
+// /v1beta ...generateContent — platforms gemini and vertex (direct), newapi
+// channel_type=41 (Vertex via the bridge), AND antigravity /v1beta (the
+// client-facing v1beta surface; the internal v1internal envelope to cloudcode-pa
+// is upstream-only and never captured client-side). antigravity /v1 records are
+// Anthropic-shaped and dispatch to buildAnthropicMessagesSession instead.
+//
+// Normalizes into the shared TrajSessionV2 vocabulary: parts with thought=true →
+// thinking (carrying thoughtSignature), functionCall → tool_use, text → text;
+// user-role functionResponse parts → tool turns; model-role contents are prior
+// assistant output and skipped.
+
+func buildGeminiSession(recs []SourceRecord, summary *ExportSummary) (TrajSessionV2, bool) {
+	sid := sessionIDForGroup(recs)
+	turns := make([]TrajTurnV2, 0, len(recs)*3)
+	prevCount := 0
+	var lastReq gjson.Result
+	assistantModel := ""
+
+	for _, rec := range recs {
+		reqBody := marshalToGJSON(rec.Blob.Request.Body)
+		lastReq = reqBody
+		contents := reqBody.Get("contents").Array()
+
+		prefixBreak := len(contents) < prevCount
+		if prefixBreak {
+			prevCount = len(contents)
+		}
+		for k := prevCount; k < len(contents); k++ {
+			c := contents[k]
+			if c.Get("role").String() == "model" {
+				continue // prior assistant response, already emitted
+			}
+			for _, turn := range geminiUserContentTurns(c) {
+				turns = append(turns, turn)
+				if turn.Role == "tool" {
+					summary.ToolResultCount++
+				}
+			}
+		}
+		prevCount = len(contents)
+
+		blocks, callMeta := reconstructGeminiAssistantTurn(rec)
+		if prefixBreak {
+			callMeta["prefix_break"] = true
+		}
+		turns = append(turns, TrajTurnV2{
+			Role:     "assistant",
+			Blocks:   blocks,
+			CallMeta: callMeta,
+			Content:  deriveText(blocks),
+		})
+		summary.ToolCallCount += countToolUse(blocks)
+		if m := upstreamOrRequestedModel(rec.Record); m != "" {
+			assistantModel = m
+		}
+	}
+
+	if len(turns) < 2 {
+		return TrajSessionV2{}, false
+	}
+	return TrajSessionV2{
+		SessionID: sid,
+		Meta:      buildGeminiMeta(recs, lastReq, assistantModel),
+		Turns:     turns,
+	}, true
+}
+
+// geminiUserContentTurns splits one user-role content into tool turns (its
+// functionResponse parts) and, if it also carries non-functionResponse parts, a
+// user turn for those parts.
+func geminiUserContentTurns(content gjson.Result) []TrajTurnV2 {
+	var toolTurns []TrajTurnV2
+	var userParts []any
+	content.Get("parts").ForEach(func(_, p gjson.Result) bool {
+		if fr := p.Get("functionResponse"); fr.Exists() {
+			id := strings.TrimSpace(fr.Get("id").String())
+			if id == "" {
+				id = strings.TrimSpace(fr.Get("name").String())
+			}
+			toolTurns = append(toolTurns, TrajTurnV2{
+				Role:      "tool",
+				ToolUseID: id,
+				Content:   jsonValue(fr.Get("response")),
+			})
+		} else {
+			userParts = append(userParts, p.Value())
+		}
+		return true
+	})
+	out := toolTurns
+	if len(userParts) > 0 {
+		out = append(out, TrajTurnV2{Role: "user", Content: userParts})
+	}
+	return out
+}
+
+func reconstructGeminiAssistantTurn(rec SourceRecord) ([]any, map[string]any) {
+	respBody := marshalToGJSON(rec.Blob.Response.Body)
+
+	callMeta := baseCallMeta(rec)
+
+	var blocks []any
+	parts := respBody.Get("candidates.0.content.parts")
+	if parts.IsArray() && len(parts.Array()) > 0 {
+		blocks = geminiBlocksFromParts(parts)
+		if fr := respBody.Get("candidates.0.finishReason"); fr.Exists() {
+			callMeta["stop_reason"] = fr.String()
+		}
+		callMeta["usage"] = geminiUsage(respBody, rec.Record)
+	} else {
+		var streamMeta map[string]any
+		blocks, streamMeta = geminiBlocksFromStream(rec.Blob.Stream.Chunks)
+		for k, v := range streamMeta {
+			if _, ok := callMeta[k]; !ok {
+				callMeta[k] = v
+			}
+		}
+		if _, ok := callMeta["usage"]; !ok {
+			callMeta["usage"] = geminiUsage(respBody, rec.Record)
+		}
+	}
+	if _, ok := callMeta["stop_reason"]; !ok {
+		callMeta["stop_reason"] = ""
+	}
+	callMeta["thinking_source"] = thinkingSource(blocks)
+	return blocks, callMeta
+}
+
+// geminiBlocksFromParts maps candidate content parts into v2 blocks (thought →
+// thinking with signature, functionCall → tool_use, text → text).
+func geminiBlocksFromParts(parts gjson.Result) []any {
+	out := []any{}
+	parts.ForEach(func(_, p gjson.Result) bool {
+		switch {
+		case p.Get("thought").Bool():
+			block := map[string]any{"type": "thinking", "thinking": p.Get("text").String()}
+			if sig := p.Get("thoughtSignature").String(); sig != "" {
+				block["signature"] = sig
+			}
+			out = append(out, block)
+		case p.Get("functionCall").Exists():
+			fc := p.Get("functionCall")
+			out = append(out, map[string]any{
+				"type":  "tool_use",
+				"id":    fc.Get("id").String(),
+				"name":  fc.Get("name").String(),
+				"input": jsonValue(fc.Get("args")),
+			})
+		case p.Get("text").Exists():
+			out = append(out, map[string]any{"type": "text", "text": p.Get("text").String()})
+		}
+		return true
+	})
+	return out
+}
+
+// geminiBlocksFromStream reassembles v2 blocks + call_meta from streamed Gemini
+// chunks. The client-facing stream is streamGenerateContent?alt=sse (`data:`
+// frames, each a partial GeminiResponse); when the client omits alt=sse the
+// stream is a JSON array instead — geminiNonSSEPayloads handles that framing so
+// non-SSE captures still reconstruct rather than projecting empty/garbage turns.
+func geminiBlocksFromStream(chunks []map[string]any) ([]any, map[string]any) {
+	payloads, sawAny := sseDataPayloads(chunks)
+	if len(payloads) == 0 && sawAny {
+		payloads = geminiNonSSEPayloads(chunks)
+	}
+	meta := map[string]any{}
+	var textB, thinkingB strings.Builder
+	signature := ""
+	var funcCalls []any
+	sawFinish := false
+
+	for _, data := range payloads {
+		if !gjson.Valid(data) {
+			continue
+		}
+		ev := gjson.Parse(data)
+		cand := ev.Get("candidates.0")
+		cand.Get("content.parts").ForEach(func(_, p gjson.Result) bool {
+			switch {
+			case p.Get("thought").Bool():
+				_, _ = thinkingB.WriteString(p.Get("text").String())
+				if s := p.Get("thoughtSignature").String(); s != "" {
+					signature = s
+				}
+			case p.Get("functionCall").Exists():
+				fc := p.Get("functionCall")
+				funcCalls = append(funcCalls, map[string]any{
+					"type":  "tool_use",
+					"id":    fc.Get("id").String(),
+					"name":  fc.Get("name").String(),
+					"input": jsonValue(fc.Get("args")),
+				})
+			case p.Get("text").Exists():
+				_, _ = textB.WriteString(p.Get("text").String())
+			}
+			return true
+		})
+		if fr := cand.Get("finishReason"); fr.Exists() && fr.String() != "" {
+			meta["stop_reason"] = fr.String()
+			sawFinish = true
+		}
+		if um := ev.Get("usageMetadata"); um.IsObject() {
+			meta["usage"] = geminiUsageFromMetadata(um, meta["usage"])
+		}
+	}
+
+	if sawAny && !sawFinish {
+		meta["truncated"] = true
+	}
+
+	blocks := make([]any, 0, 2+len(funcCalls))
+	if thinkingB.Len() > 0 {
+		block := map[string]any{"type": "thinking", "thinking": thinkingB.String()}
+		if signature != "" {
+			block["signature"] = signature
+		}
+		blocks = append(blocks, block)
+	}
+	if textB.Len() > 0 {
+		blocks = append(blocks, map[string]any{"type": "text", "text": textB.String()})
+	}
+	blocks = append(blocks, funcCalls...)
+	return blocks, meta
+}
+
+// geminiNonSSEPayloads concatenates the captured chunk bytes and, if they form a
+// JSON array (or object) — the non-alt=sse streaming framing — returns each
+// element's raw JSON so the SSE reassembler can process it uniformly. Returns
+// nil for unparseable bytes (the caller then marks the turn truncated).
+func geminiNonSSEPayloads(chunks []map[string]any) []string {
+	var sb strings.Builder
+	for _, c := range chunks {
+		raw, _ := c["raw_b64"].(string)
+		if raw == "" {
+			continue
+		}
+		if dec, err := base64.StdEncoding.DecodeString(raw); err == nil {
+			_, _ = sb.Write(dec)
+		}
+	}
+	s := strings.TrimSpace(sb.String())
+	if !gjson.Valid(s) {
+		return nil
+	}
+	parsed := gjson.Parse(s)
+	if !parsed.IsArray() {
+		return []string{s}
+	}
+	var out []string
+	parsed.ForEach(func(_, el gjson.Result) bool {
+		out = append(out, el.Raw)
+		return true
+	})
+	return out
+}
+
+func geminiUsage(respBody gjson.Result, record *ent.QARecord) map[string]any {
+	usage := map[string]any{}
+	if um := respBody.Get("usageMetadata"); um.IsObject() {
+		usage = geminiUsageFromMetadata(um, usage)
+	}
+	fillUsageFromRecord(usage, record)
+	return usage
+}
+
+// geminiUsageFromMetadata maps Gemini usageMetadata into the v2 usage shape.
+// input_tokens excludes cached tokens (matching the anthropic input semantics the
+// gateway already uses for gemini), output_tokens sums candidate + thought tokens.
+func geminiUsageFromMetadata(um gjson.Result, prev any) map[string]any {
+	usage, _ := prev.(map[string]any)
+	if usage == nil {
+		usage = map[string]any{}
+	}
+	prompt := um.Get("promptTokenCount").Int()
+	cached := um.Get("cachedContentTokenCount").Int()
+	input := prompt - cached
+	if input < 0 {
+		input = prompt
+	}
+	usage["input_tokens"] = int(input)
+	usage["output_tokens"] = int(um.Get("candidatesTokenCount").Int() + um.Get("thoughtsTokenCount").Int())
+	usage["cache_read_input_tokens"] = int(cached)
+	return usage
+}
+
+func buildGeminiMeta(recs []SourceRecord, lastReq gjson.Result, assistantModel string) TrajMetaV2 {
+	meta := TrajMetaV2{SchemaVersion: "traj/v2", AssistantModel: assistantModel}
+	if lastReq.Exists() {
+		if si := lastReq.Get("systemInstruction"); si.Exists() {
+			meta.System = geminiSystemText(si)
+		}
+		if tools := lastReq.Get("tools"); tools.IsArray() {
+			meta.ToolSchema = jsonValue(tools)
+		}
+		sampling := map[string]any{}
+		if v := lastReq.Get("model"); v.Exists() {
+			sampling["model"] = v.String()
+		}
+		gc := lastReq.Get("generationConfig")
+		if v := gc.Get("temperature"); v.Exists() {
+			sampling["temperature"] = v.Num
+		}
+		if v := gc.Get("topP"); v.Exists() {
+			sampling["top_p"] = v.Num
+		}
+		if tc := gc.Get("thinkingConfig"); tc.Exists() {
+			sampling["thinking"] = jsonValue(tc)
+		}
+		if len(sampling) > 0 {
+			meta.Sampling = sampling
+		}
+	}
+	applySynthMeta(&meta, recs)
+	return meta
+}
+
+// geminiSystemText joins the systemInstruction parts' text; falls back to the
+// raw value when the parts aren't simple text.
+func geminiSystemText(si gjson.Result) any {
+	var sb strings.Builder
+	si.Get("parts").ForEach(func(_, p gjson.Result) bool {
+		_, _ = sb.WriteString(p.Get("text").String())
+		return true
+	})
+	if sb.Len() > 0 {
+		return sb.String()
+	}
+	return jsonValue(si)
+}

--- a/backend/internal/observability/trajectory/projection_gemini_test.go
+++ b/backend/internal/observability/trajectory/projection_gemini_test.go
@@ -1,0 +1,204 @@
+package trajectory
+
+import (
+	"encoding/base64"
+	"testing"
+	"time"
+
+	"github.com/Wei-Shaw/sub2api/ent"
+)
+
+// Gemini: 2-call tool-use conversation (contents[] / candidates[].content.parts)
+// reconstructs into user / assistant(thinking+text+tool_use) / tool / assistant,
+// thoughtSignature preserved, systemInstruction → meta, usage from usageMetadata.
+func TestBuildTrajSessionsV2_Gemini(t *testing.T) {
+	base := time.Date(2026, 6, 16, 14, 0, 0, 0, time.UTC)
+	req0 := `{"systemInstruction":{"parts":[{"text":"You are Gemini"}]},"generationConfig":{"temperature":0.4},` +
+		`"contents":[{"role":"user","parts":[{"text":"build X"}]}]}`
+	resp0 := `{"candidates":[{"content":{"role":"model","parts":[` +
+		`{"text":"planning","thought":true,"thoughtSignature":"SIG"},` +
+		`{"text":"running"},` +
+		`{"functionCall":{"name":"bash","args":{"cmd":"ls"},"id":"fc_1"}}` +
+		`]},"finishReason":"STOP"}],"usageMetadata":{"promptTokenCount":50,"candidatesTokenCount":20,"cachedContentTokenCount":10,"thoughtsTokenCount":5}}`
+	req1 := `{"systemInstruction":{"parts":[{"text":"You are Gemini"}]},"contents":[` +
+		`{"role":"user","parts":[{"text":"build X"}]},` +
+		`{"role":"model","parts":[{"functionCall":{"name":"bash","args":{"cmd":"ls"},"id":"fc_1"}}]},` +
+		`{"role":"user","parts":[{"functionResponse":{"name":"bash","id":"fc_1","response":{"result":"file1"}}}]}` +
+		`]}`
+	resp1 := `{"candidates":[{"content":{"role":"model","parts":[{"text":"done"}]},"finishReason":"STOP"}],"usageMetadata":{"promptTokenCount":80,"candidatesTokenCount":3}}`
+
+	mk := func(id, req, resp string, dt time.Duration) SourceRecord {
+		b := &EvidenceBlob{}
+		b.Request.Body = mustBody(t, req)
+		b.Response.Body = mustBody(t, resp)
+		return SourceRecord{
+			Record: &ent.QARecord{RequestID: id, CreatedAt: base.Add(dt), Platform: "gemini", InboundEndpoint: "/v1beta/models", RequestedModel: "gemini-2.5-pro", TrajectoryID: strptr("traj-gem")},
+			Blob:   b,
+		}
+	}
+	sources := []SourceRecord{mk("g0", req0, resp0, 0), mk("g1", req1, resp1, time.Second)}
+
+	sessions, summary, err := BuildTrajSessionsV2(sources)
+	if err != nil {
+		t.Fatalf("err: %v", err)
+	}
+	if len(sessions) != 1 || len(sessions[0].Turns) != 4 {
+		t.Fatalf("want 1 session / 4 turns, got %d sessions: %+v", len(sessions), sessions)
+	}
+	s := sessions[0]
+	a0 := s.Turns[1]
+	if len(a0.Blocks) != 3 {
+		t.Fatalf("call0 blocks = %d: %+v", len(a0.Blocks), a0.Blocks)
+	}
+	th, _ := a0.Blocks[0].(map[string]any)
+	if th["type"] != "thinking" || th["thinking"] != "planning" || th["signature"] != "SIG" {
+		t.Errorf("thinking block wrong: %+v", th)
+	}
+	if blockType(t, a0.Blocks[2]) != "tool_use" {
+		t.Errorf("call0 block2 not tool_use: %+v", a0.Blocks[2])
+	}
+	if a0.CallMeta["stop_reason"] != "STOP" {
+		t.Errorf("stop_reason = %v", a0.CallMeta["stop_reason"])
+	}
+	usage, _ := a0.CallMeta["usage"].(map[string]any)
+	if usage["input_tokens"] != 40 || usage["output_tokens"] != 25 || usage["cache_read_input_tokens"] != 10 {
+		t.Errorf("usage (want input40/output25/cache10): %+v", usage)
+	}
+	if s.Turns[2].Role != "tool" || s.Turns[2].ToolUseID != "fc_1" {
+		t.Errorf("turn2 not tool: %+v", s.Turns[2])
+	}
+	if s.Turns[3].Role != "assistant" {
+		t.Errorf("turn3: %+v", s.Turns[3])
+	}
+	if s.Meta.System != "You are Gemini" {
+		t.Errorf("meta.system = %v", s.Meta.System)
+	}
+	if summary.ToolCallCount != 1 || summary.ToolResultCount != 1 {
+		t.Errorf("summary: %+v", summary)
+	}
+}
+
+// Gemini streamGenerateContent?alt=sse: text/thought deltas accumulate,
+// functionCall part + finishReason on the terminal chunk, usageMetadata mapped.
+func TestBuildTrajSessionsV2_GeminiStream(t *testing.T) {
+	base := time.Date(2026, 6, 16, 15, 0, 0, 0, time.UTC)
+	events := []string{
+		`{"candidates":[{"content":{"parts":[{"text":"th","thought":true}]}}]}`,
+		`{"candidates":[{"content":{"parts":[{"text":"ink","thought":true,"thoughtSignature":"SS"}]}}]}`,
+		`{"candidates":[{"content":{"parts":[{"text":"Hel"}]}}]}`,
+		`{"candidates":[{"content":{"parts":[{"text":"lo"}]}}]}`,
+		`{"candidates":[{"content":{"parts":[{"functionCall":{"name":"bash","args":{"cmd":"ls"},"id":"fc_9"}}]},"finishReason":"STOP"}],"usageMetadata":{"promptTokenCount":12,"candidatesTokenCount":6}}`,
+	}
+	b := &EvidenceBlob{}
+	b.Request.Body = mustBody(t, `{"contents":[{"role":"user","parts":[{"text":"q"}]}]}`)
+	b.Response.Body = mustBody(t, `{}`)
+	b.Stream.Chunks = sseChunks(events)
+	sources := []SourceRecord{{
+		Record: &ent.QARecord{RequestID: "gs", CreatedAt: base, Platform: "gemini", InboundEndpoint: "/v1beta/models", RequestedModel: "gemini-2.5-pro", TrajectoryID: strptr("traj-gs")},
+		Blob:   b,
+	}}
+	sessions, _, err := BuildTrajSessionsV2(sources)
+	if err != nil {
+		t.Fatalf("err: %v", err)
+	}
+	if len(sessions) != 1 || len(sessions[0].Turns) != 2 {
+		t.Fatalf("unexpected: %+v", sessions)
+	}
+	a := sessions[0].Turns[1]
+	if len(a.Blocks) != 3 {
+		t.Fatalf("blocks = %d: %+v", len(a.Blocks), a.Blocks)
+	}
+	th, _ := a.Blocks[0].(map[string]any)
+	tx, _ := a.Blocks[1].(map[string]any)
+	tu, _ := a.Blocks[2].(map[string]any)
+	input, _ := tu["input"].(map[string]any)
+	if th["thinking"] != "think" || th["signature"] != "SS" || tx["text"] != "Hello" || tu["id"] != "fc_9" || input["cmd"] != "ls" {
+		t.Errorf("stream blocks wrong: %+v", a.Blocks)
+	}
+	if a.CallMeta["stop_reason"] != "STOP" {
+		t.Errorf("stop_reason = %v", a.CallMeta["stop_reason"])
+	}
+	if a.CallMeta["truncated"] == true {
+		t.Errorf("should not be truncated (finishReason present)")
+	}
+	usage, _ := a.CallMeta["usage"].(map[string]any)
+	if usage["input_tokens"] != 12 {
+		t.Errorf("usage = %+v", usage)
+	}
+}
+
+// H6: Gemini streamed WITHOUT alt=sse is a JSON array (not data:-framed). The
+// builder must still reconstruct rather than emit empty/garbage turns.
+func TestBuildTrajSessionsV2_GeminiNonSSEStream(t *testing.T) {
+	base := time.Date(2026, 6, 16, 16, 0, 0, 0, time.UTC)
+	arr := `[{"candidates":[{"content":{"parts":[{"text":"Hello"}]}}]},` +
+		`{"candidates":[{"content":{"parts":[{"text":" world"}]},"finishReason":"STOP"}],"usageMetadata":{"promptTokenCount":5,"candidatesTokenCount":2}}]`
+	// Raw bytes are NOT "data:"-framed — emulate the non-SSE JSON-array stream.
+	b := &EvidenceBlob{}
+	b.Request.Body = mustBody(t, `{"contents":[{"role":"user","parts":[{"text":"q"}]}]}`)
+	b.Response.Body = mustBody(t, `{}`)
+	b.Stream.Chunks = []map[string]any{{"t": 0, "raw_b64": base64.StdEncoding.EncodeToString([]byte(arr))}}
+	sources := []SourceRecord{{
+		Record: &ent.QARecord{RequestID: "gns", CreatedAt: base, Platform: "gemini", InboundEndpoint: "/v1beta/models", RequestedModel: "gemini-2.5-pro", TrajectoryID: strptr("traj-gns")},
+		Blob:   b,
+	}}
+	sessions, _, err := BuildTrajSessionsV2(sources)
+	if err != nil {
+		t.Fatalf("err: %v", err)
+	}
+	if len(sessions) != 1 || len(sessions[0].Turns) != 2 {
+		t.Fatalf("unexpected: %+v", sessions)
+	}
+	a := sessions[0].Turns[1]
+	if len(a.Blocks) != 1 || blockType(t, a.Blocks[0]) != "text" {
+		t.Fatalf("blocks: %+v", a.Blocks)
+	}
+	tx, _ := a.Blocks[0].(map[string]any)
+	if tx["text"] != "Hello world" {
+		t.Errorf("non-sse text reassembly = %v", tx["text"])
+	}
+	if a.CallMeta["stop_reason"] != "STOP" || a.CallMeta["truncated"] == true {
+		t.Errorf("non-sse callMeta = %+v", a.CallMeta)
+	}
+}
+
+// antigravity dispatch: a /v1 record (anthropic-shaped) reconstructs via the
+// anthropic builder; a /v1beta record (gemini-shaped) via the gemini builder.
+func TestBuildTrajSessionsV2_AntigravityDispatch(t *testing.T) {
+	base := time.Date(2026, 6, 16, 17, 0, 0, 0, time.UTC)
+
+	// antigravity /v1 → /v1/messages → anthropic builder.
+	v1r0 := `{"model":"claude-opus-4-6","messages":[{"role":"user","content":"hi"}]}`
+	v1resp0 := `{"id":"m0","stop_reason":"tool_use","usage":{"output_tokens":2},"content":[{"type":"tool_use","id":"t1","name":"Bash","input":{"command":"ls"}}]}`
+	v1r1 := `{"model":"claude-opus-4-6","messages":[{"role":"user","content":"hi"},{"role":"assistant","content":[{"type":"tool_use","id":"t1","name":"Bash","input":{"command":"ls"}}]},{"role":"user","content":[{"type":"tool_result","tool_use_id":"t1","content":"ok"}]}]}`
+	v1resp1 := `{"id":"m1","stop_reason":"end_turn","content":[{"type":"text","text":"done"}]}`
+	mkAnth := func(id, req, resp string, dt time.Duration) SourceRecord {
+		b := &EvidenceBlob{}
+		b.Request.Body = mustBody(t, req)
+		b.Response.Body = mustBody(t, resp)
+		return SourceRecord{Record: &ent.QARecord{RequestID: id, CreatedAt: base.Add(dt), Platform: "antigravity", InboundEndpoint: "/v1/messages", TrajectoryID: strptr("ag-v1")}, Blob: b}
+	}
+	v1sessions, _, err := BuildTrajSessionsV2([]SourceRecord{mkAnth("av0", v1r0, v1resp0, 0), mkAnth("av1", v1r1, v1resp1, time.Second)})
+	if err != nil {
+		t.Fatalf("v1 err: %v", err)
+	}
+	if len(v1sessions) != 1 || len(v1sessions[0].Turns) != 4 {
+		t.Fatalf("antigravity /v1 should reconstruct via anthropic builder (4 turns), got %+v", v1sessions)
+	}
+
+	// antigravity /v1beta → /v1beta/models → gemini builder.
+	gb := &EvidenceBlob{}
+	gb.Request.Body = mustBody(t, `{"contents":[{"role":"user","parts":[{"text":"hi"}]}]}`)
+	gb.Response.Body = mustBody(t, `{"candidates":[{"content":{"parts":[{"text":"hello"}]},"finishReason":"STOP"}],"usageMetadata":{"promptTokenCount":3,"candidatesTokenCount":1}}`)
+	v1beta := []SourceRecord{{Record: &ent.QARecord{RequestID: "agb", CreatedAt: base, Platform: "antigravity", InboundEndpoint: "/v1beta/models", TrajectoryID: strptr("ag-v1beta")}, Blob: gb}}
+	gsessions, _, err := BuildTrajSessionsV2(v1beta)
+	if err != nil {
+		t.Fatalf("v1beta err: %v", err)
+	}
+	if len(gsessions) != 1 || len(gsessions[0].Turns) != 2 {
+		t.Fatalf("antigravity /v1beta should reconstruct via gemini builder (2 turns), got %+v", gsessions)
+	}
+	if tx, _ := gsessions[0].Turns[1].Blocks[0].(map[string]any); tx["text"] != "hello" {
+		t.Errorf("v1beta gemini text = %+v", gsessions[0].Turns[1].Blocks)
+	}
+}

--- a/backend/internal/observability/trajectory/projection_gemini_test.go
+++ b/backend/internal/observability/trajectory/projection_gemini_test.go
@@ -127,6 +127,29 @@ func TestBuildTrajSessionsV2_GeminiStream(t *testing.T) {
 	}
 }
 
+// Gemini stream truncated (no finishReason on any chunk) → truncated=true.
+func TestBuildTrajSessionsV2_GeminiStreamTruncated(t *testing.T) {
+	base := time.Date(2026, 6, 16, 15, 30, 0, 0, time.UTC)
+	b := &EvidenceBlob{}
+	b.Request.Body = mustBody(t, `{"contents":[{"role":"user","parts":[{"text":"q"}]}]}`)
+	b.Response.Body = mustBody(t, `{}`)
+	b.Stream.Chunks = sseChunks([]string{
+		`{"candidates":[{"content":{"parts":[{"text":"partial"}]}}]}`,
+		// no finishReason
+	})
+	sources := []SourceRecord{{
+		Record: &ent.QARecord{RequestID: "gstrunc", CreatedAt: base, Platform: "gemini", InboundEndpoint: "/v1beta/models", TrajectoryID: strptr("traj-gstrunc")},
+		Blob:   b,
+	}}
+	sessions, _, err := BuildTrajSessionsV2(sources)
+	if err != nil {
+		t.Fatalf("err: %v", err)
+	}
+	if sessions[0].Turns[1].CallMeta["truncated"] != true {
+		t.Errorf("expected truncated=true, got: %v", sessions[0].Turns[1].CallMeta["truncated"])
+	}
+}
+
 // H6: Gemini streamed WITHOUT alt=sse is a JSON array (not data:-framed). The
 // builder must still reconstruct rather than emit empty/garbage turns.
 func TestBuildTrajSessionsV2_GeminiNonSSEStream(t *testing.T) {

--- a/backend/internal/observability/trajectory/projection_openai.go
+++ b/backend/internal/observability/trajectory/projection_openai.go
@@ -1,0 +1,680 @@
+package trajectory
+
+import (
+	"encoding/base64"
+	"encoding/json"
+	"strings"
+	"time"
+
+	"github.com/Wei-Shaw/sub2api/ent"
+	"github.com/tidwall/gjson"
+)
+
+// OpenAI-compat traj v2 projection. Two wire shapes ride OpenAI-compatible
+// routes (platforms openai / newapi / grok): Chat Completions (/v1/chat/
+// completions) and the Responses API (/v1/responses, Codex). Both reconstruct
+// into the SAME TrajSessionV2 vocabulary as the anthropic builder — text /
+// thinking / tool_use blocks, user / assistant / tool turns — so the export
+// schema is uniform across platforms. reasoning_content (chat) and reasoning
+// items / summaries (responses) normalize to `thinking`; tool_calls /
+// function_call normalize to `tool_use`; tool messages / function_call_output
+// normalize to `tool` turns.
+
+// ---- shared cross-platform helpers (used by openai + gemini builders) -------
+
+// baseCallMeta seeds an assistant turn's call_meta with the fields every shape
+// carries: request_id, timestamp, and the upstream-divergence marker.
+func baseCallMeta(rec SourceRecord) map[string]any {
+	m := map[string]any{
+		"request_id": strings.TrimSpace(rec.Record.RequestID),
+		"timestamp":  rec.Record.CreatedAt.UTC().Format(time.RFC3339),
+	}
+	if rec.Blob.Request.UpstreamDivergent {
+		m["upstream_request_divergent"] = true
+	}
+	return m
+}
+
+// fillUsageFromRecord backfills usage fields from the QARecord's recorded token
+// counts when the response body / stream did not carry them.
+func fillUsageFromRecord(usage map[string]any, record *ent.QARecord) {
+	if record == nil {
+		return
+	}
+	if _, ok := usage["input_tokens"]; !ok {
+		usage["input_tokens"] = record.InputTokens
+	}
+	if _, ok := usage["output_tokens"]; !ok {
+		usage["output_tokens"] = record.OutputTokens
+	}
+	if _, ok := usage["cache_read_input_tokens"]; !ok {
+		usage["cache_read_input_tokens"] = record.CachedTokens
+	}
+}
+
+// sseDataPayloads decodes the captured base64 SSE chunks and returns every
+// `data:` payload in order, plus whether any chunk carried bytes (so a stream
+// with no terminal event can be flagged truncated).
+func sseDataPayloads(chunks []map[string]any) (payloads []string, sawAny bool) {
+	for _, chunk := range chunks {
+		raw, _ := chunk["raw_b64"].(string)
+		if raw == "" {
+			continue
+		}
+		decoded, err := base64.StdEncoding.DecodeString(raw)
+		if err != nil {
+			continue
+		}
+		sawAny = true
+		for _, line := range strings.Split(string(decoded), "\n") {
+			line = strings.TrimSpace(line)
+			if !strings.HasPrefix(line, "data:") {
+				continue
+			}
+			payloads = append(payloads, strings.TrimSpace(strings.TrimPrefix(line, "data:")))
+		}
+	}
+	return payloads, sawAny
+}
+
+// parseToolArgs decodes a tool-call arguments JSON string into a value; an
+// unparseable / empty string falls back to the raw string / empty object.
+func parseToolArgs(s string) any {
+	s = strings.TrimSpace(s)
+	if s == "" {
+		return map[string]any{}
+	}
+	var v any
+	if err := json.Unmarshal([]byte(s), &v); err != nil {
+		return s
+	}
+	return v
+}
+
+// ---- OpenAI Chat Completions ------------------------------------------------
+
+func buildOpenAIChatSession(recs []SourceRecord, summary *ExportSummary) (TrajSessionV2, bool) {
+	sid := sessionIDForGroup(recs)
+	turns := make([]TrajTurnV2, 0, len(recs)*3)
+	prevMsgCount := 0
+	var lastReq gjson.Result
+	assistantModel := ""
+
+	for _, rec := range recs {
+		reqBody := marshalToGJSON(rec.Blob.Request.Body)
+		lastReq = reqBody
+		msgs := reqBody.Get("messages").Array()
+
+		prefixBreak := len(msgs) < prevMsgCount
+		if prefixBreak {
+			prevMsgCount = len(msgs)
+		}
+		for k := prevMsgCount; k < len(msgs); k++ {
+			m := msgs[k]
+			switch m.Get("role").String() {
+			case "user":
+				turns = append(turns, TrajTurnV2{Role: "user", Content: jsonValue(m.Get("content"))})
+			case "tool", "function":
+				turns = append(turns, TrajTurnV2{
+					Role:      "tool",
+					ToolUseID: strings.TrimSpace(m.Get("tool_call_id").String()),
+					Content:   jsonValue(m.Get("content")),
+				})
+				summary.ToolResultCount++
+			case "assistant":
+				// prior response, already emitted from its own record — skip.
+			case "system", "developer":
+				// folded into meta.System — not a turn.
+			}
+		}
+		prevMsgCount = len(msgs)
+
+		blocks, callMeta := reconstructOpenAIChatAssistantTurn(rec)
+		if prefixBreak {
+			callMeta["prefix_break"] = true
+		}
+		turns = append(turns, TrajTurnV2{
+			Role:     "assistant",
+			Blocks:   blocks,
+			CallMeta: callMeta,
+			Content:  deriveText(blocks),
+		})
+		summary.ToolCallCount += countToolUse(blocks)
+		if m := upstreamOrRequestedModel(rec.Record); m != "" {
+			assistantModel = m
+		}
+	}
+
+	if len(turns) < 2 {
+		return TrajSessionV2{}, false
+	}
+	return TrajSessionV2{
+		SessionID: sid,
+		Meta:      buildOpenAIChatMeta(recs, lastReq, assistantModel),
+		Turns:     turns,
+	}, true
+}
+
+func reconstructOpenAIChatAssistantTurn(rec SourceRecord) ([]any, map[string]any) {
+	respBody := marshalToGJSON(rec.Blob.Response.Body)
+	reqBody := marshalToGJSON(rec.Blob.Request.Body)
+
+	callMeta := baseCallMeta(rec)
+	if eff := reqBody.Get("reasoning_effort"); eff.Exists() {
+		callMeta["thinking_effort"] = eff.String()
+	}
+
+	var blocks []any
+	msg := respBody.Get("choices.0.message")
+	if msg.Exists() {
+		blocks = openaiChatBlocksFromMessage(msg)
+		if fr := respBody.Get("choices.0.finish_reason"); fr.Exists() {
+			callMeta["stop_reason"] = fr.String()
+		}
+		callMeta["usage"] = openaiChatUsage(respBody, rec.Record)
+	} else {
+		var streamMeta map[string]any
+		blocks, streamMeta = openaiChatBlocksFromStream(rec.Blob.Stream.Chunks)
+		for k, v := range streamMeta {
+			if _, ok := callMeta[k]; !ok {
+				callMeta[k] = v
+			}
+		}
+		if _, ok := callMeta["usage"]; !ok {
+			callMeta["usage"] = openaiChatUsage(respBody, rec.Record)
+		}
+	}
+	if _, ok := callMeta["stop_reason"]; !ok {
+		callMeta["stop_reason"] = ""
+	}
+	callMeta["thinking_source"] = thinkingSource(blocks)
+	return blocks, callMeta
+}
+
+// openaiChatBlocksFromMessage maps a Chat Completions assistant message into v2
+// blocks (reasoning_content → thinking, content → text, tool_calls → tool_use).
+func openaiChatBlocksFromMessage(msg gjson.Result) []any {
+	out := []any{}
+	if rc := msg.Get("reasoning_content"); rc.Type == gjson.String && rc.String() != "" {
+		out = append(out, map[string]any{"type": "thinking", "thinking": rc.String()})
+	}
+	if c := msg.Get("content"); c.Type == gjson.String && c.String() != "" {
+		out = append(out, map[string]any{"type": "text", "text": c.String()})
+	}
+	msg.Get("tool_calls").ForEach(func(_, tc gjson.Result) bool {
+		out = append(out, map[string]any{
+			"type":  "tool_use",
+			"id":    tc.Get("id").String(),
+			"name":  tc.Get("function.name").String(),
+			"input": parseToolArgs(tc.Get("function.arguments").String()),
+		})
+		return true
+	})
+	return out
+}
+
+// openaiChatBlocksFromStream reassembles v2 blocks + call_meta from Chat
+// Completions SSE chunks (choices[].delta content / reasoning_content /
+// tool_calls keyed by index; finish_reason; [DONE] terminal; trailing usage).
+func openaiChatBlocksFromStream(chunks []map[string]any) ([]any, map[string]any) {
+	payloads, sawAny := sseDataPayloads(chunks)
+	meta := map[string]any{}
+	var textB, reasoningB strings.Builder
+	type tcAcc struct {
+		id, name string
+		args     strings.Builder
+	}
+	tcByIndex := map[int]*tcAcc{}
+	var tcOrder []int
+	sawTerminal := false
+
+	for _, data := range payloads {
+		if data == "[DONE]" {
+			sawTerminal = true
+			continue
+		}
+		if !gjson.Valid(data) {
+			continue
+		}
+		ev := gjson.Parse(data)
+		if u := ev.Get("usage"); u.IsObject() {
+			meta["usage"] = openaiChatStreamUsage(u, meta["usage"])
+		}
+		ev.Get("choices").ForEach(func(_, ch gjson.Result) bool {
+			d := ch.Get("delta")
+			if c := d.Get("content"); c.Type == gjson.String {
+				_, _ = textB.WriteString(c.String())
+			}
+			if rc := d.Get("reasoning_content"); rc.Type == gjson.String {
+				_, _ = reasoningB.WriteString(rc.String())
+			}
+			d.Get("tool_calls").ForEach(func(_, tc gjson.Result) bool {
+				idx := int(tc.Get("index").Int())
+				a := tcByIndex[idx]
+				if a == nil {
+					a = &tcAcc{}
+					tcByIndex[idx] = a
+					tcOrder = append(tcOrder, idx)
+				}
+				if id := tc.Get("id").String(); id != "" {
+					a.id = id
+				}
+				if nm := tc.Get("function.name").String(); nm != "" {
+					a.name = nm
+				}
+				_, _ = a.args.WriteString(tc.Get("function.arguments").String())
+				return true
+			})
+			if fr := ch.Get("finish_reason"); fr.Type == gjson.String && fr.String() != "" {
+				meta["stop_reason"] = fr.String()
+				sawTerminal = true
+			}
+			return true
+		})
+	}
+
+	if sawAny && !sawTerminal {
+		meta["truncated"] = true
+	}
+
+	blocks := make([]any, 0, 2+len(tcOrder))
+	if reasoningB.Len() > 0 {
+		blocks = append(blocks, map[string]any{"type": "thinking", "thinking": reasoningB.String()})
+	}
+	if textB.Len() > 0 {
+		blocks = append(blocks, map[string]any{"type": "text", "text": textB.String()})
+	}
+	for _, idx := range tcOrder {
+		a := tcByIndex[idx]
+		blocks = append(blocks, map[string]any{"type": "tool_use", "id": a.id, "name": a.name, "input": parseToolArgs(a.args.String())})
+	}
+	return blocks, meta
+}
+
+func openaiChatUsage(respBody gjson.Result, record *ent.QARecord) map[string]any {
+	usage := map[string]any{}
+	if u := respBody.Get("usage"); u.IsObject() {
+		usage = openaiChatStreamUsage(u, usage)
+	}
+	fillUsageFromRecord(usage, record)
+	return usage
+}
+
+func openaiChatStreamUsage(u gjson.Result, prev any) map[string]any {
+	usage, _ := prev.(map[string]any)
+	if usage == nil {
+		usage = map[string]any{}
+	}
+	if v := u.Get("prompt_tokens"); v.Exists() {
+		usage["input_tokens"] = int(v.Int())
+	}
+	if v := u.Get("completion_tokens"); v.Exists() {
+		usage["output_tokens"] = int(v.Int())
+	}
+	if v := u.Get("prompt_tokens_details.cached_tokens"); v.Exists() {
+		usage["cache_read_input_tokens"] = int(v.Int())
+	}
+	return usage
+}
+
+func buildOpenAIChatMeta(recs []SourceRecord, lastReq gjson.Result, assistantModel string) TrajMetaV2 {
+	meta := TrajMetaV2{SchemaVersion: "traj/v2", AssistantModel: assistantModel}
+	if lastReq.Exists() {
+		var systems []any
+		lastReq.Get("messages").ForEach(func(_, m gjson.Result) bool {
+			if r := m.Get("role").String(); r == "system" || r == "developer" {
+				systems = append(systems, jsonValue(m.Get("content")))
+			}
+			return true
+		})
+		switch len(systems) {
+		case 1:
+			meta.System = systems[0]
+		default:
+			if len(systems) > 1 {
+				meta.System = systems
+			}
+		}
+		if tools := lastReq.Get("tools"); tools.IsArray() {
+			meta.ToolSchema = jsonValue(tools)
+		}
+		meta.Sampling = openaiSampling(lastReq)
+	}
+	applySynthMeta(&meta, recs)
+	return meta
+}
+
+// openaiSampling extracts the sampling block shared by chat + responses
+// (responses nests effort under reasoning.effort; chat uses reasoning_effort).
+func openaiSampling(req gjson.Result) map[string]any {
+	sampling := map[string]any{}
+	if v := req.Get("model"); v.Exists() {
+		sampling["model"] = v.String()
+	}
+	if v := req.Get("temperature"); v.Exists() {
+		sampling["temperature"] = v.Num
+	}
+	if v := req.Get("top_p"); v.Exists() {
+		sampling["top_p"] = v.Num
+	}
+	if v := req.Get("reasoning_effort"); v.Exists() {
+		sampling["reasoning_effort"] = v.String()
+	} else if v := req.Get("reasoning.effort"); v.Exists() {
+		sampling["reasoning_effort"] = v.String()
+	}
+	if len(sampling) == 0 {
+		return nil
+	}
+	return sampling
+}
+
+// ---- OpenAI Responses API ---------------------------------------------------
+
+func buildOpenAIResponsesSession(recs []SourceRecord, summary *ExportSummary) (TrajSessionV2, bool) {
+	sid := sessionIDForGroup(recs)
+	turns := make([]TrajTurnV2, 0, len(recs)*3)
+	prevItemCount := 0
+	var lastReq gjson.Result
+	assistantModel := ""
+
+	for _, rec := range recs {
+		reqBody := marshalToGJSON(rec.Blob.Request.Body)
+		lastReq = reqBody
+		input := reqBody.Get("input")
+		prefixBreak := false
+
+		if input.Type == gjson.String {
+			// Single-shot string input (HTTP rejects previous_response_id, so these
+			// records never share a group — emit one user turn).
+			if s := strings.TrimSpace(input.String()); s != "" {
+				turns = append(turns, TrajTurnV2{Role: "user", Content: s})
+			}
+		} else {
+			items := input.Array()
+			prefixBreak = len(items) < prevItemCount
+			if prefixBreak {
+				prevItemCount = len(items)
+			}
+			for k := prevItemCount; k < len(items); k++ {
+				if turn, ok := responsesInputTurn(items[k]); ok {
+					turns = append(turns, turn)
+					if turn.Role == "tool" {
+						summary.ToolResultCount++
+					}
+				}
+			}
+			prevItemCount = len(items)
+		}
+
+		blocks, callMeta := reconstructOpenAIResponsesAssistantTurn(rec)
+		if prefixBreak {
+			callMeta["prefix_break"] = true
+		}
+		turns = append(turns, TrajTurnV2{
+			Role:     "assistant",
+			Blocks:   blocks,
+			CallMeta: callMeta,
+			Content:  deriveText(blocks),
+		})
+		summary.ToolCallCount += countToolUse(blocks)
+		if m := upstreamOrRequestedModel(rec.Record); m != "" {
+			assistantModel = m
+		}
+	}
+
+	if len(turns) < 2 {
+		return TrajSessionV2{}, false
+	}
+	return TrajSessionV2{
+		SessionID: sid,
+		Meta:      buildOpenAIResponsesMeta(recs, lastReq, assistantModel),
+		Turns:     turns,
+	}, true
+}
+
+// responsesInputTurn maps one Responses input item into a user/tool turn, or
+// ok=false for items that belong to a prior assistant turn (function_call,
+// reasoning) or to meta (system/developer messages).
+func responsesInputTurn(item gjson.Result) (TrajTurnV2, bool) {
+	switch item.Get("type").String() {
+	case "function_call_output":
+		return TrajTurnV2{
+			Role:      "tool",
+			ToolUseID: strings.TrimSpace(item.Get("call_id").String()),
+			Content:   jsonValue(item.Get("output")),
+		}, true
+	case "function_call", "reasoning":
+		return TrajTurnV2{}, false // prior assistant output, already emitted
+	}
+	switch item.Get("role").String() {
+	case "user":
+		return TrajTurnV2{Role: "user", Content: jsonValue(item.Get("content"))}, true
+	default:
+		// system / developer (→ meta) and assistant (prior) are not turns.
+		return TrajTurnV2{}, false
+	}
+}
+
+func reconstructOpenAIResponsesAssistantTurn(rec SourceRecord) ([]any, map[string]any) {
+	respBody := marshalToGJSON(rec.Blob.Response.Body)
+	reqBody := marshalToGJSON(rec.Blob.Request.Body)
+
+	callMeta := baseCallMeta(rec)
+	if eff := reqBody.Get("reasoning.effort"); eff.Exists() {
+		callMeta["thinking_effort"] = eff.String()
+	}
+
+	var blocks []any
+	output := respBody.Get("output")
+	if output.IsArray() && len(output.Array()) > 0 {
+		blocks = openaiResponsesBlocksFromOutput(output)
+		if st := respBody.Get("status"); st.Exists() {
+			callMeta["stop_reason"] = st.String()
+		}
+		callMeta["usage"] = openaiResponsesUsage(respBody, rec.Record)
+	} else {
+		var streamMeta map[string]any
+		blocks, streamMeta = openaiResponsesBlocksFromStream(rec.Blob.Stream.Chunks)
+		for k, v := range streamMeta {
+			if _, ok := callMeta[k]; !ok {
+				callMeta[k] = v
+			}
+		}
+		if _, ok := callMeta["usage"]; !ok {
+			callMeta["usage"] = openaiResponsesUsage(respBody, rec.Record)
+		}
+	}
+	if _, ok := callMeta["stop_reason"]; !ok {
+		callMeta["stop_reason"] = ""
+	}
+	callMeta["thinking_source"] = thinkingSource(blocks)
+	return blocks, callMeta
+}
+
+// openaiResponsesBlocksFromOutput maps response.output[] items into v2 blocks
+// (reasoning → thinking / redacted_thinking, message output_text → text,
+// function_call → tool_use).
+func openaiResponsesBlocksFromOutput(output gjson.Result) []any {
+	out := []any{}
+	output.ForEach(func(_, item gjson.Result) bool {
+		switch item.Get("type").String() {
+		case "reasoning":
+			var sb strings.Builder
+			item.Get("summary").ForEach(func(_, s gjson.Result) bool {
+				_, _ = sb.WriteString(s.Get("text").String())
+				return true
+			})
+			if sb.Len() > 0 {
+				out = append(out, map[string]any{"type": "thinking", "thinking": sb.String()})
+			} else if enc := item.Get("encrypted_content").String(); enc != "" {
+				out = append(out, map[string]any{"type": "redacted_thinking", "data": enc})
+			}
+		case "message":
+			item.Get("content").ForEach(func(_, c gjson.Result) bool {
+				if c.Get("type").String() == "output_text" {
+					out = append(out, map[string]any{"type": "text", "text": c.Get("text").String()})
+				}
+				return true
+			})
+		case "function_call":
+			out = append(out, map[string]any{
+				"type":  "tool_use",
+				"id":    item.Get("call_id").String(),
+				"name":  item.Get("name").String(),
+				"input": parseToolArgs(item.Get("arguments").String()),
+			})
+		}
+		return true
+	})
+	return out
+}
+
+// openaiResponsesBlocksFromStream reassembles v2 blocks + call_meta from
+// Responses SSE events (output_item.added declares item kinds; output_text /
+// reasoning_summary_text / function_call_arguments deltas accumulate by
+// output_index; response.completed / failed / incomplete are terminal).
+func openaiResponsesBlocksFromStream(chunks []map[string]any) ([]any, map[string]any) {
+	payloads, sawAny := sseDataPayloads(chunks)
+	meta := map[string]any{}
+	type acc struct {
+		typ              string
+		text, think, arg strings.Builder
+		callID, name     string
+	}
+	byIdx := map[int]*acc{}
+	var order []int
+	ensure := func(i int) *acc {
+		if a, ok := byIdx[i]; ok {
+			return a
+		}
+		a := &acc{}
+		byIdx[i] = a
+		order = append(order, i)
+		return a
+	}
+	sawTerminal := false
+
+	for _, data := range payloads {
+		if data == "[DONE]" {
+			sawTerminal = true
+			continue
+		}
+		if !gjson.Valid(data) {
+			continue
+		}
+		ev := gjson.Parse(data)
+		switch ev.Get("type").String() {
+		case "response.output_item.added":
+			a := ensure(int(ev.Get("output_index").Int()))
+			it := ev.Get("item")
+			switch it.Get("type").String() {
+			case "function_call":
+				a.typ = "tool_use"
+				a.callID = it.Get("call_id").String()
+				a.name = it.Get("name").String()
+			case "reasoning":
+				a.typ = "thinking"
+			case "message":
+				a.typ = "text"
+			}
+		case "response.output_text.delta":
+			a := ensure(int(ev.Get("output_index").Int()))
+			if a.typ == "" {
+				a.typ = "text"
+			}
+			_, _ = a.text.WriteString(ev.Get("delta").String())
+		case "response.reasoning_summary_text.delta":
+			a := ensure(int(ev.Get("output_index").Int()))
+			if a.typ == "" {
+				a.typ = "thinking"
+			}
+			_, _ = a.think.WriteString(ev.Get("delta").String())
+		case "response.function_call_arguments.delta":
+			a := ensure(int(ev.Get("output_index").Int()))
+			if a.typ == "" {
+				a.typ = "tool_use"
+			}
+			_, _ = a.arg.WriteString(ev.Get("delta").String())
+			if cid := ev.Get("call_id").String(); cid != "" && a.callID == "" {
+				a.callID = cid
+			}
+			if nm := ev.Get("name").String(); nm != "" && a.name == "" {
+				a.name = nm
+			}
+		case "response.completed", "response.incomplete":
+			sawTerminal = true
+			if st := ev.Get("response.status"); st.Exists() {
+				meta["stop_reason"] = st.String()
+			}
+			if u := ev.Get("response.usage"); u.IsObject() {
+				meta["usage"] = openaiResponsesStreamUsage(u, meta["usage"])
+			}
+		case "response.failed":
+			sawTerminal = true
+			meta["stop_reason"] = "failed"
+		}
+	}
+
+	if sawAny && !sawTerminal {
+		meta["truncated"] = true
+	}
+
+	blocks := make([]any, 0, len(order))
+	for _, i := range order {
+		a := byIdx[i]
+		switch a.typ {
+		case "thinking":
+			if a.think.Len() > 0 {
+				blocks = append(blocks, map[string]any{"type": "thinking", "thinking": a.think.String()})
+			}
+		case "text":
+			if a.text.Len() > 0 {
+				blocks = append(blocks, map[string]any{"type": "text", "text": a.text.String()})
+			}
+		case "tool_use":
+			blocks = append(blocks, map[string]any{"type": "tool_use", "id": a.callID, "name": a.name, "input": parseToolArgs(a.arg.String())})
+		}
+	}
+	return blocks, meta
+}
+
+func openaiResponsesUsage(respBody gjson.Result, record *ent.QARecord) map[string]any {
+	usage := map[string]any{}
+	if u := respBody.Get("usage"); u.IsObject() {
+		usage = openaiResponsesStreamUsage(u, usage)
+	}
+	fillUsageFromRecord(usage, record)
+	return usage
+}
+
+func openaiResponsesStreamUsage(u gjson.Result, prev any) map[string]any {
+	usage, _ := prev.(map[string]any)
+	if usage == nil {
+		usage = map[string]any{}
+	}
+	if v := u.Get("input_tokens"); v.Exists() {
+		usage["input_tokens"] = int(v.Int())
+	}
+	if v := u.Get("output_tokens"); v.Exists() {
+		usage["output_tokens"] = int(v.Int())
+	}
+	if v := u.Get("input_tokens_details.cached_tokens"); v.Exists() {
+		usage["cache_read_input_tokens"] = int(v.Int())
+	}
+	return usage
+}
+
+func buildOpenAIResponsesMeta(recs []SourceRecord, lastReq gjson.Result, assistantModel string) TrajMetaV2 {
+	meta := TrajMetaV2{SchemaVersion: "traj/v2", AssistantModel: assistantModel}
+	if lastReq.Exists() {
+		if instr := lastReq.Get("instructions"); instr.Type == gjson.String && instr.String() != "" {
+			meta.System = instr.String()
+		}
+		if tools := lastReq.Get("tools"); tools.IsArray() {
+			meta.ToolSchema = jsonValue(tools)
+		}
+		meta.Sampling = openaiSampling(lastReq)
+	}
+	applySynthMeta(&meta, recs)
+	return meta
+}

--- a/backend/internal/observability/trajectory/projection_openai.go
+++ b/backend/internal/observability/trajectory/projection_openai.go
@@ -327,13 +327,10 @@ func buildOpenAIChatMeta(recs []SourceRecord, lastReq gjson.Result, assistantMod
 			}
 			return true
 		})
-		switch len(systems) {
-		case 1:
+		if len(systems) == 1 {
 			meta.System = systems[0]
-		default:
-			if len(systems) > 1 {
-				meta.System = systems
-			}
+		} else if len(systems) > 1 {
+			meta.System = systems
 		}
 		if tools := lastReq.Get("tools"); tools.IsArray() {
 			meta.ToolSchema = jsonValue(tools)

--- a/backend/internal/observability/trajectory/projection_openai_test.go
+++ b/backend/internal/observability/trajectory/projection_openai_test.go
@@ -160,6 +160,54 @@ func TestBuildTrajSessionsV2_OpenAIChatStream(t *testing.T) {
 	}
 }
 
+// OpenAI Chat stream truncated mid-flight (no finish_reason, no [DONE]) →
+// call_meta.truncated=true, so a clipped capture is not taken as complete.
+func TestBuildTrajSessionsV2_OpenAIChatStreamTruncated(t *testing.T) {
+	base := time.Date(2026, 6, 16, 10, 30, 0, 0, time.UTC)
+	b := &EvidenceBlob{}
+	b.Request.Body = mustBody(t, `{"model":"gpt-5","messages":[{"role":"user","content":"q"}]}`)
+	b.Response.Body = mustBody(t, `{}`)
+	b.Stream.Chunks = sseChunks([]string{
+		`{"choices":[{"index":0,"delta":{"role":"assistant","content":"partial"}}]}`,
+		// no finish_reason chunk, no [DONE]
+	})
+	sources := []SourceRecord{{
+		Record: &ent.QARecord{RequestID: "cstrunc", CreatedAt: base, Platform: "openai", InboundEndpoint: "/v1/chat/completions", TrajectoryID: strptr("traj-cstrunc")},
+		Blob:   b,
+	}}
+	sessions, _, err := BuildTrajSessionsV2(sources)
+	if err != nil {
+		t.Fatalf("err: %v", err)
+	}
+	if sessions[0].Turns[1].CallMeta["truncated"] != true {
+		t.Errorf("expected truncated=true, got: %v", sessions[0].Turns[1].CallMeta["truncated"])
+	}
+}
+
+// OpenAI Responses stream truncated (no response.completed) → truncated=true.
+func TestBuildTrajSessionsV2_OpenAIResponsesStreamTruncated(t *testing.T) {
+	base := time.Date(2026, 6, 16, 13, 30, 0, 0, time.UTC)
+	b := &EvidenceBlob{}
+	b.Request.Body = mustBody(t, `{"model":"gpt-5-codex","input":[{"type":"message","role":"user","content":"q"}]}`)
+	b.Response.Body = mustBody(t, `{}`)
+	b.Stream.Chunks = sseChunks([]string{
+		`{"type":"response.output_item.added","output_index":0,"item":{"type":"message","role":"assistant"}}`,
+		`{"type":"response.output_text.delta","output_index":0,"delta":"partial"}`,
+		// no response.completed / failed
+	})
+	sources := []SourceRecord{{
+		Record: &ent.QARecord{RequestID: "rsptrunc", CreatedAt: base, Platform: "openai", InboundEndpoint: "/v1/responses", TrajectoryID: strptr("traj-rsptrunc")},
+		Blob:   b,
+	}}
+	sessions, _, err := BuildTrajSessionsV2(sources)
+	if err != nil {
+		t.Fatalf("err: %v", err)
+	}
+	if sessions[0].Turns[1].CallMeta["truncated"] != true {
+		t.Errorf("expected truncated=true, got: %v", sessions[0].Turns[1].CallMeta["truncated"])
+	}
+}
+
 // OpenAI Responses (Codex): input[] items + output[] items reconstruct into
 // user / assistant(thinking+text+tool_use) / tool / assistant(text), instructions
 // → meta, usage from input/output_tokens.

--- a/backend/internal/observability/trajectory/projection_openai_test.go
+++ b/backend/internal/observability/trajectory/projection_openai_test.go
@@ -1,0 +1,295 @@
+package trajectory
+
+import (
+	"encoding/base64"
+	"testing"
+	"time"
+
+	"github.com/Wei-Shaw/sub2api/ent"
+)
+
+// sseChunks turns SSE event JSON strings into captured base64 chunks (matches
+// the qa capture format: each chunk holds one `data: {...}\n\n` frame).
+func sseChunks(events []string) []map[string]any {
+	chunks := make([]map[string]any, 0, len(events))
+	for _, e := range events {
+		raw := "data: " + e + "\n\n"
+		chunks = append(chunks, map[string]any{"t": 0, "raw_b64": base64.StdEncoding.EncodeToString([]byte(raw))})
+	}
+	return chunks
+}
+
+func blockType(t *testing.T, b any) string {
+	t.Helper()
+	m, ok := b.(map[string]any)
+	if !ok {
+		t.Fatalf("block not a map: %T", b)
+	}
+	s, _ := m["type"].(string)
+	return s
+}
+
+// OpenAI Chat Completions: 2-call tool-use conversation reconstructs into
+// user / assistant(thinking+text+tool_use) / tool / assistant(text), with the
+// system message folded into meta and usage mapped from prompt/completion_tokens.
+func TestBuildTrajSessionsV2_OpenAIChat(t *testing.T) {
+	base := time.Date(2026, 6, 16, 9, 0, 0, 0, time.UTC)
+	req0 := `{"model":"gpt-5","temperature":0.7,"messages":[` +
+		`{"role":"system","content":"You are helpful"},` +
+		`{"role":"user","content":"build X"}]}`
+	resp0 := `{"choices":[{"message":{"role":"assistant","reasoning_content":"planning",` +
+		`"content":"Let me run it","tool_calls":[{"id":"call_1","type":"function","function":{"name":"bash","arguments":"{\"cmd\":\"ls\"}"}}]},` +
+		`"finish_reason":"tool_calls"}],"usage":{"prompt_tokens":50,"completion_tokens":20,"prompt_tokens_details":{"cached_tokens":10}}}`
+	req1 := `{"model":"gpt-5","messages":[` +
+		`{"role":"system","content":"You are helpful"},` +
+		`{"role":"user","content":"build X"},` +
+		`{"role":"assistant","content":null,"tool_calls":[{"id":"call_1","type":"function","function":{"name":"bash","arguments":"{\"cmd\":\"ls\"}"}}]},` +
+		`{"role":"tool","tool_call_id":"call_1","content":"file1\nfile2"}]}`
+	resp1 := `{"choices":[{"message":{"role":"assistant","content":"Done"},"finish_reason":"stop"}],"usage":{"prompt_tokens":80,"completion_tokens":5}}`
+
+	mk := func(id, req, resp string, dt time.Duration) SourceRecord {
+		b := &EvidenceBlob{}
+		b.Request.Body = mustBody(t, req)
+		b.Response.Body = mustBody(t, resp)
+		return SourceRecord{
+			Record: &ent.QARecord{RequestID: id, CreatedAt: base.Add(dt), Platform: "openai", InboundEndpoint: "/v1/chat/completions", RequestedModel: "gpt-5", TrajectoryID: strptr("traj-oa")},
+			Blob:   b,
+		}
+	}
+	sources := []SourceRecord{mk("c0", req0, resp0, 0), mk("c1", req1, resp1, time.Second)}
+
+	sessions, summary, err := BuildTrajSessionsV2(sources)
+	if err != nil {
+		t.Fatalf("err: %v", err)
+	}
+	if len(sessions) != 1 {
+		t.Fatalf("want 1 session, got %d", len(sessions))
+	}
+	s := sessions[0]
+	if len(s.Turns) != 4 {
+		t.Fatalf("want 4 turns, got %d: %+v", len(s.Turns), s.Turns)
+	}
+	if s.Turns[0].Role != "user" {
+		t.Errorf("turn0 = %q", s.Turns[0].Role)
+	}
+	a0 := s.Turns[1]
+	if a0.Role != "assistant" || len(a0.Blocks) != 3 {
+		t.Fatalf("turn1 wrong: %+v", a0)
+	}
+	if blockType(t, a0.Blocks[0]) != "thinking" || blockType(t, a0.Blocks[1]) != "text" || blockType(t, a0.Blocks[2]) != "tool_use" {
+		t.Errorf("call0 block order wrong: %+v", a0.Blocks)
+	}
+	if a0.CallMeta["stop_reason"] != "tool_calls" || a0.CallMeta["thinking_source"] != "present" {
+		t.Errorf("call0 callMeta: %+v", a0.CallMeta)
+	}
+	usage, _ := a0.CallMeta["usage"].(map[string]any)
+	if usage["input_tokens"] != 50 || usage["output_tokens"] != 20 || usage["cache_read_input_tokens"] != 10 {
+		t.Errorf("call0 usage: %+v", usage)
+	}
+	if s.Turns[2].Role != "tool" || s.Turns[2].ToolUseID != "call_1" {
+		t.Errorf("turn2 not tool: %+v", s.Turns[2])
+	}
+	if s.Turns[3].Role != "assistant" || s.Turns[3].CallMeta["stop_reason"] != "stop" {
+		t.Errorf("turn3 wrong: %+v", s.Turns[3])
+	}
+	if s.Meta.System != "You are helpful" {
+		t.Errorf("meta.system = %v", s.Meta.System)
+	}
+	if s.Meta.Sampling == nil || s.Meta.Sampling["model"] != "gpt-5" {
+		t.Errorf("meta.sampling = %+v", s.Meta.Sampling)
+	}
+	if summary.ToolCallCount != 1 || summary.ToolResultCount != 1 {
+		t.Errorf("summary: %+v", summary)
+	}
+}
+
+// OpenAI Chat streaming: content/reasoning/tool_call argument deltas reassemble
+// into thinking+text+tool_use, finish_reason → stop_reason, trailing usage chunk.
+func TestBuildTrajSessionsV2_OpenAIChatStream(t *testing.T) {
+	base := time.Date(2026, 6, 16, 10, 0, 0, 0, time.UTC)
+	events := []string{
+		`{"choices":[{"index":0,"delta":{"role":"assistant","content":""},"finish_reason":null}]}`,
+		`{"choices":[{"index":0,"delta":{"reasoning_content":"hmm"}}]}`,
+		`{"choices":[{"index":0,"delta":{"content":"Hel"}}]}`,
+		`{"choices":[{"index":0,"delta":{"content":"lo"}}]}`,
+		`{"choices":[{"index":0,"delta":{"tool_calls":[{"index":0,"id":"call_9","type":"function","function":{"name":"bash","arguments":"{\"cmd\":"}}]}}]}`,
+		`{"choices":[{"index":0,"delta":{"tool_calls":[{"index":0,"function":{"arguments":"\"ls\"}"}}]}}]}`,
+		`{"choices":[{"index":0,"delta":{},"finish_reason":"tool_calls"}]}`,
+		`{"usage":{"prompt_tokens":10,"completion_tokens":5},"choices":[]}`,
+		`[DONE]`,
+	}
+	b := &EvidenceBlob{}
+	b.Request.Body = mustBody(t, `{"model":"gpt-5","messages":[{"role":"user","content":"q"}]}`)
+	b.Response.Body = mustBody(t, `{}`)
+	b.Stream.Chunks = sseChunks(events)
+	sources := []SourceRecord{{
+		Record: &ent.QARecord{RequestID: "cs", CreatedAt: base, Platform: "newapi", InboundEndpoint: "/v1/chat/completions", RequestedModel: "gpt-5", TrajectoryID: strptr("traj-cs")},
+		Blob:   b,
+	}}
+
+	sessions, _, err := BuildTrajSessionsV2(sources)
+	if err != nil {
+		t.Fatalf("err: %v", err)
+	}
+	if len(sessions) != 1 || len(sessions[0].Turns) != 2 {
+		t.Fatalf("unexpected: %+v", sessions)
+	}
+	a := sessions[0].Turns[1]
+	if len(a.Blocks) != 3 {
+		t.Fatalf("blocks = %d: %+v", len(a.Blocks), a.Blocks)
+	}
+	th, _ := a.Blocks[0].(map[string]any)
+	if th["thinking"] != "hmm" {
+		t.Errorf("thinking = %v", th["thinking"])
+	}
+	tx, _ := a.Blocks[1].(map[string]any)
+	if tx["text"] != "Hello" {
+		t.Errorf("text = %v", tx["text"])
+	}
+	tu, _ := a.Blocks[2].(map[string]any)
+	input, _ := tu["input"].(map[string]any)
+	if tu["id"] != "call_9" || input["cmd"] != "ls" {
+		t.Errorf("tool_use = %+v", tu)
+	}
+	if a.CallMeta["stop_reason"] != "tool_calls" {
+		t.Errorf("stop_reason = %v", a.CallMeta["stop_reason"])
+	}
+	usage, _ := a.CallMeta["usage"].(map[string]any)
+	if usage["input_tokens"] != 10 {
+		t.Errorf("usage = %+v", usage)
+	}
+}
+
+// OpenAI Responses (Codex): input[] items + output[] items reconstruct into
+// user / assistant(thinking+text+tool_use) / tool / assistant(text), instructions
+// → meta, usage from input/output_tokens.
+func TestBuildTrajSessionsV2_OpenAIResponses(t *testing.T) {
+	base := time.Date(2026, 6, 16, 11, 0, 0, 0, time.UTC)
+	req0 := `{"model":"gpt-5-codex","instructions":"You are Codex","reasoning":{"effort":"high"},"input":[` +
+		`{"type":"message","role":"user","content":"build X"}]}`
+	resp0 := `{"status":"completed","output":[` +
+		`{"type":"reasoning","summary":[{"type":"summary_text","text":"planning"}]},` +
+		`{"type":"message","role":"assistant","content":[{"type":"output_text","text":"running"}]},` +
+		`{"type":"function_call","call_id":"fc_1","name":"bash","arguments":"{\"cmd\":\"ls\"}"}` +
+		`],"usage":{"input_tokens":40,"output_tokens":15,"input_tokens_details":{"cached_tokens":5}}}`
+	req1 := `{"model":"gpt-5-codex","instructions":"You are Codex","input":[` +
+		`{"type":"message","role":"user","content":"build X"},` +
+		`{"type":"function_call","call_id":"fc_1","name":"bash","arguments":"{\"cmd\":\"ls\"}"},` +
+		`{"type":"function_call_output","call_id":"fc_1","output":"file1"}]}`
+	resp1 := `{"status":"completed","output":[{"type":"message","role":"assistant","content":[{"type":"output_text","text":"done"}]}],"usage":{"input_tokens":60,"output_tokens":3}}`
+
+	mk := func(id, req, resp string, dt time.Duration) SourceRecord {
+		b := &EvidenceBlob{}
+		b.Request.Body = mustBody(t, req)
+		b.Response.Body = mustBody(t, resp)
+		return SourceRecord{
+			Record: &ent.QARecord{RequestID: id, CreatedAt: base.Add(dt), Platform: "openai", InboundEndpoint: "/v1/responses", RequestedModel: "gpt-5-codex", TrajectoryID: strptr("traj-rsp")},
+			Blob:   b,
+		}
+	}
+	sources := []SourceRecord{mk("r0", req0, resp0, 0), mk("r1", req1, resp1, time.Second)}
+
+	sessions, summary, err := BuildTrajSessionsV2(sources)
+	if err != nil {
+		t.Fatalf("err: %v", err)
+	}
+	if len(sessions) != 1 || len(sessions[0].Turns) != 4 {
+		t.Fatalf("want 1 session / 4 turns, got %d sessions: %+v", len(sessions), sessions)
+	}
+	s := sessions[0]
+	a0 := s.Turns[1]
+	if len(a0.Blocks) != 3 || blockType(t, a0.Blocks[0]) != "thinking" || blockType(t, a0.Blocks[2]) != "tool_use" {
+		t.Errorf("call0 blocks: %+v", a0.Blocks)
+	}
+	if a0.CallMeta["stop_reason"] != "completed" || a0.CallMeta["thinking_effort"] != "high" {
+		t.Errorf("call0 callMeta: %+v", a0.CallMeta)
+	}
+	usage, _ := a0.CallMeta["usage"].(map[string]any)
+	if usage["input_tokens"] != 40 || usage["output_tokens"] != 15 || usage["cache_read_input_tokens"] != 5 {
+		t.Errorf("usage: %+v", usage)
+	}
+	if s.Turns[2].Role != "tool" || s.Turns[2].ToolUseID != "fc_1" {
+		t.Errorf("turn2 not tool: %+v", s.Turns[2])
+	}
+	if s.Turns[3].Role != "assistant" {
+		t.Errorf("turn3: %+v", s.Turns[3])
+	}
+	if s.Meta.System != "You are Codex" {
+		t.Errorf("meta.system = %v", s.Meta.System)
+	}
+	if summary.ToolCallCount != 1 || summary.ToolResultCount != 1 {
+		t.Errorf("summary: %+v", summary)
+	}
+}
+
+// OpenAI Responses single-shot string input → one user turn + assistant.
+func TestBuildTrajSessionsV2_OpenAIResponsesStringInput(t *testing.T) {
+	base := time.Date(2026, 6, 16, 12, 0, 0, 0, time.UTC)
+	b := &EvidenceBlob{}
+	b.Request.Body = mustBody(t, `{"model":"gpt-5","instructions":"sys","input":"hello there"}`)
+	b.Response.Body = mustBody(t, `{"status":"completed","output":[{"type":"message","role":"assistant","content":[{"type":"output_text","text":"hi"}]}],"usage":{"input_tokens":3,"output_tokens":2}}`)
+	sources := []SourceRecord{{
+		Record: &ent.QARecord{RequestID: "rs", CreatedAt: base, Platform: "openai", InboundEndpoint: "/v1/responses", RequestedModel: "gpt-5", TrajectoryID: strptr("traj-str")},
+		Blob:   b,
+	}}
+	sessions, _, err := BuildTrajSessionsV2(sources)
+	if err != nil {
+		t.Fatalf("err: %v", err)
+	}
+	if len(sessions) != 1 || len(sessions[0].Turns) != 2 {
+		t.Fatalf("want 1 session / 2 turns, got %+v", sessions)
+	}
+	if sessions[0].Turns[0].Role != "user" || sessions[0].Turns[0].Content != "hello there" {
+		t.Errorf("user turn: %+v", sessions[0].Turns[0])
+	}
+}
+
+// OpenAI Responses streaming: output_item.added declares kinds; text/reasoning/
+// function-args deltas reassemble; response.completed is terminal with usage.
+func TestBuildTrajSessionsV2_OpenAIResponsesStream(t *testing.T) {
+	base := time.Date(2026, 6, 16, 13, 0, 0, 0, time.UTC)
+	events := []string{
+		`{"type":"response.created","response":{"id":"resp_1"}}`,
+		`{"type":"response.output_item.added","output_index":0,"item":{"type":"reasoning"}}`,
+		`{"type":"response.reasoning_summary_text.delta","output_index":0,"summary_index":0,"delta":"think"}`,
+		`{"type":"response.output_item.added","output_index":1,"item":{"type":"message","role":"assistant"}}`,
+		`{"type":"response.output_text.delta","output_index":1,"content_index":0,"delta":"Hel"}`,
+		`{"type":"response.output_text.delta","output_index":1,"content_index":0,"delta":"lo"}`,
+		`{"type":"response.output_item.added","output_index":2,"item":{"type":"function_call","call_id":"fc_9","name":"bash"}}`,
+		`{"type":"response.function_call_arguments.delta","output_index":2,"call_id":"fc_9","name":"bash","delta":"{\"cmd\":\"ls\"}"}`,
+		`{"type":"response.completed","response":{"status":"completed","usage":{"input_tokens":12,"output_tokens":6}}}`,
+	}
+	b := &EvidenceBlob{}
+	b.Request.Body = mustBody(t, `{"model":"gpt-5-codex","input":[{"type":"message","role":"user","content":"q"}]}`)
+	b.Response.Body = mustBody(t, `{}`)
+	b.Stream.Chunks = sseChunks(events)
+	sources := []SourceRecord{{
+		Record: &ent.QARecord{RequestID: "rstream", CreatedAt: base, Platform: "openai", InboundEndpoint: "/v1/responses", RequestedModel: "gpt-5-codex", TrajectoryID: strptr("traj-rstr")},
+		Blob:   b,
+	}}
+	sessions, _, err := BuildTrajSessionsV2(sources)
+	if err != nil {
+		t.Fatalf("err: %v", err)
+	}
+	if len(sessions) != 1 || len(sessions[0].Turns) != 2 {
+		t.Fatalf("unexpected: %+v", sessions)
+	}
+	a := sessions[0].Turns[1]
+	if len(a.Blocks) != 3 {
+		t.Fatalf("blocks = %d: %+v", len(a.Blocks), a.Blocks)
+	}
+	th, _ := a.Blocks[0].(map[string]any)
+	tx, _ := a.Blocks[1].(map[string]any)
+	tu, _ := a.Blocks[2].(map[string]any)
+	input, _ := tu["input"].(map[string]any)
+	if th["thinking"] != "think" || tx["text"] != "Hello" || tu["id"] != "fc_9" || input["cmd"] != "ls" {
+		t.Errorf("stream blocks wrong: %+v", a.Blocks)
+	}
+	if a.CallMeta["stop_reason"] != "completed" {
+		t.Errorf("stop_reason = %v", a.CallMeta["stop_reason"])
+	}
+	usage, _ := a.CallMeta["usage"].(map[string]any)
+	if usage["input_tokens"] != 12 {
+		t.Errorf("usage = %+v", usage)
+	}
+}

--- a/backend/internal/observability/trajectory/projection_v2.go
+++ b/backend/internal/observability/trajectory/projection_v2.go
@@ -88,9 +88,10 @@ func buildSessionForShape(recs []SourceRecord, summary *ExportSummary) (TrajSess
 		return buildOpenAIChatSession(recs, summary)
 	case WireOpenAIResponses:
 		return buildOpenAIResponsesSession(recs, summary)
-	// Commit C wires WireGemini here. Until then gemini/unknown shapes skip
-	// (the export handler still pins anthropic, so they are unreachable in prod).
+	case WireGemini:
+		return buildGeminiSession(recs, summary)
 	default:
+		// WireUnknown (non-conversation endpoint / unprojectable) — skip.
 		return TrajSessionV2{}, false
 	}
 }

--- a/backend/internal/observability/trajectory/projection_v2.go
+++ b/backend/internal/observability/trajectory/projection_v2.go
@@ -48,91 +48,142 @@ type TrajTurnV2 struct {
 }
 
 // BuildTrajSessionsV2 把多条记录聚合为按 session 的 v2 轨迹（每 session 一个对象）。
+//
+// 派发按 wire shape：groupByConversation 已把记录折成「单 shape、单会话」的组，
+// 每组交给对应 shape 的 builder（anthropic / openai-chat / openai-responses /
+// gemini）。所有 builder 产出同一 TrajSessionV2 词汇，故导出 schema 跨平台统一。
+// 无 builder 的 shape（非对话端点 / 不可投影平台）跳过，绝不投影成 garbage turn。
 func BuildTrajSessionsV2(sources []SourceRecord) ([]TrajSessionV2, ExportSummary, error) {
-	// Group by conversation via message-prefix chaining, NOT by trajectory_id.
-	// middleware.TrajectoryID() mints a fresh uuid per HTTP request, so grouping
-	// by trajectory_id (resolveSessionID) put every /v1/messages call in its own
-	// "session" and defeated the prefix-dedup below — a conversation's N calls
-	// exploded into N redundant nested-prefix lines. groupByConversation folds
-	// them back into one session. See groupByConversation.
+	// Group by conversation via prefix chaining (shape-aware), NOT by
+	// trajectory_id. middleware.TrajectoryID() mints a fresh uuid per HTTP
+	// request, so grouping by trajectory_id put every call in its own "session"
+	// and defeated the prefix-dedup — a conversation's N calls exploded into N
+	// redundant nested-prefix lines. groupByConversation folds them back into one
+	// session AND splits on wire-shape change. See groupByConversation.
 	groups := groupByConversation(sources)
 
 	sessions := make([]TrajSessionV2, 0, len(groups))
 	summary := ExportSummary{}
 	for _, recs := range groups {
-		sid := sessionIDForGroup(recs)
-
-		turns := make([]TrajTurnV2, 0, len(recs)*3)
-		prevMsgCount := 0
-		var lastReq gjson.Result
-		assistantModel := ""
-
-		for _, rec := range recs {
-			reqBody := marshalToGJSON(rec.Blob.Request.Body)
-			lastReq = reqBody
-			msgs := reqBody.Get("messages").Array()
-
-			// 前缀递增假设被打破（如长会话 context compaction 重写/缩短历史）时，
-			// 增量无法对齐——显式标记并从新基线续走，绝不静默跳过当作没发生。
-			prefixBreak := len(msgs) < prevMsgCount
-			if prefixBreak {
-				prevMsgCount = len(msgs)
-			}
-
-			for k := prevMsgCount; k < len(msgs); k++ {
-				m := msgs[k]
-				switch m.Get("role").String() {
-				case "user":
-					if trs := toolResultTurns(m); len(trs) > 0 {
-						turns = append(turns, trs...)
-						summary.ToolResultCount += len(trs)
-					} else {
-						turns = append(turns, TrajTurnV2{Role: "user", Content: jsonValue(m.Get("content"))})
-					}
-				case "assistant":
-					// 前一次调用的 response，已由其记录的 response 发出，跳过避免重复。
-				}
-			}
-			prevMsgCount = len(msgs)
-
-			blocks, callMeta := reconstructAssistantTurn(rec)
-			if prefixBreak {
-				callMeta["prefix_break"] = true
-			}
-			turns = append(turns, TrajTurnV2{
-				Role:     "assistant",
-				Blocks:   blocks,
-				CallMeta: callMeta,
-				Content:  deriveText(blocks),
-			})
-			summary.ToolCallCount += countToolUse(blocks)
-			if m := upstreamOrRequestedModel(rec.Record); m != "" {
-				assistantModel = m
-			}
-		}
-
-		if len(turns) < 2 {
+		sess, ok := buildSessionForShape(recs, &summary)
+		if !ok {
 			continue
 		}
-		sessions = append(sessions, TrajSessionV2{
-			SessionID: sid,
-			Meta:      buildMetaV2(recs, lastReq, assistantModel),
-			Turns:     turns,
-		})
+		sessions = append(sessions, sess)
 		summary.SessionCount++
 	}
 	summary.RecordCount = len(sources)
 	return sessions, summary, nil
 }
 
-// groupByConversation 把记录按「会话」聚类——同一会话的连续 /v1/messages 调用，其
-// request.messages 是严格递增前缀。按 created_at 升序遍历：当前记录的 messages 若是
-// 前一条的前缀扩展（messages[:len(prev)] 深度相等），或更短（context compaction 收缩
-// 历史），则续同会话；否则起新会话。这取代了原先按 per-request trajectory_id 分组——
+// buildSessionForShape dispatches one conversation group (already folded to a
+// single wire shape by groupByConversation) to the per-shape session builder.
+// ok=false (Unknown shape, or a session shorter than 2 turns) drops the group so
+// it is silently skipped — never projected to empty/garbage turns.
+func buildSessionForShape(recs []SourceRecord, summary *ExportSummary) (TrajSessionV2, bool) {
+	switch groupShape(recs) {
+	case WireAnthropicMessages:
+		return buildAnthropicMessagesSession(recs, summary)
+	// Commit B wires WireOpenAIChat / WireOpenAIResponses, Commit C wires
+	// WireGemini here. Until then non-anthropic shapes skip (the export handler
+	// still pins anthropic, so they are unreachable in production).
+	default:
+		return TrajSessionV2{}, false
+	}
+}
+
+// groupShape returns the wire shape of a conversation group. groupByConversation
+// guarantees every record in a group shares one shape, so the first valid
+// record's shape is the group's shape.
+func groupShape(recs []SourceRecord) WireShape {
+	for _, r := range recs {
+		if r.Record != nil {
+			return WireShapeForRecord(r.Record)
+		}
+	}
+	return WireUnknown
+}
+
+// buildAnthropicMessagesSession reconstructs one conversation group captured in
+// the Anthropic /v1/messages wire shape (also kiro and antigravity /v1, which
+// relay that same client-facing shape). This is the original, byte-for-byte v2
+// projection logic; it is the reference all other shape builders normalize into.
+//
+// 核心：已验证「调用即 message」——相邻调用的 request.messages 是严格递增前缀，
+// 故按 created_at 升序遍历，用增量取出新出现的 user/tool_result 消息成 turn，
+// 本调用的 response 成一个带 blocks + call_meta 的 assistant turn。assistant 历史
+// 消息（前一次 response）跳过，避免重复。
+func buildAnthropicMessagesSession(recs []SourceRecord, summary *ExportSummary) (TrajSessionV2, bool) {
+	sid := sessionIDForGroup(recs)
+
+	turns := make([]TrajTurnV2, 0, len(recs)*3)
+	prevMsgCount := 0
+	var lastReq gjson.Result
+	assistantModel := ""
+
+	for _, rec := range recs {
+		reqBody := marshalToGJSON(rec.Blob.Request.Body)
+		lastReq = reqBody
+		msgs := reqBody.Get("messages").Array()
+
+		// 前缀递增假设被打破（如长会话 context compaction 重写/缩短历史）时，
+		// 增量无法对齐——显式标记并从新基线续走，绝不静默跳过当作没发生。
+		prefixBreak := len(msgs) < prevMsgCount
+		if prefixBreak {
+			prevMsgCount = len(msgs)
+		}
+
+		for k := prevMsgCount; k < len(msgs); k++ {
+			m := msgs[k]
+			switch m.Get("role").String() {
+			case "user":
+				if trs := toolResultTurns(m); len(trs) > 0 {
+					turns = append(turns, trs...)
+					summary.ToolResultCount += len(trs)
+				} else {
+					turns = append(turns, TrajTurnV2{Role: "user", Content: jsonValue(m.Get("content"))})
+				}
+			case "assistant":
+				// 前一次调用的 response，已由其记录的 response 发出，跳过避免重复。
+			}
+		}
+		prevMsgCount = len(msgs)
+
+		blocks, callMeta := reconstructAssistantTurn(rec)
+		if prefixBreak {
+			callMeta["prefix_break"] = true
+		}
+		turns = append(turns, TrajTurnV2{
+			Role:     "assistant",
+			Blocks:   blocks,
+			CallMeta: callMeta,
+			Content:  deriveText(blocks),
+		})
+		summary.ToolCallCount += countToolUse(blocks)
+		if m := upstreamOrRequestedModel(rec.Record); m != "" {
+			assistantModel = m
+		}
+	}
+
+	if len(turns) < 2 {
+		return TrajSessionV2{}, false
+	}
+	return TrajSessionV2{
+		SessionID: sid,
+		Meta:      buildMetaV2(recs, lastReq, assistantModel),
+		Turns:     turns,
+	}, true
+}
+
+// groupByConversation 把记录按「会话」聚类——同一会话的连续调用，其请求消息数组
+// （anthropic/openai-chat 的 messages、gemini 的 contents、responses 的 input）是
+// 严格递增前缀。按 created_at 升序遍历：wire shape 变化即硬边界（不同平台/端点不共享
+// 会话）；同 shape 下当前记录是前一条的前缀扩展（深度相等）或更短（context compaction
+// 收缩历史）则续同会话，否则起新会话。这取代了原先按 per-request trajectory_id 分组——
 // 那让每次调用各成一个 session，把投影器的前缀去重逻辑架空。
 //
 // 局限：仅与「前一条」比较。若两个不同会话恰好共享开头前缀，可能被并到一起（罕见，
-// 且远好于今天「一个会话碎成 N 行」）。彻底解法是客户端传稳定会话 id，超出本函数范围。
+// 且远好于「一个会话碎成 N 行」）。彻底解法是客户端传稳定会话 id，超出本函数范围。
 func groupByConversation(sources []SourceRecord) [][]SourceRecord {
 	valid := make([]SourceRecord, 0, len(sources))
 	for _, s := range sources {
@@ -150,28 +201,81 @@ func groupByConversation(sources []SourceRecord) [][]SourceRecord {
 	})
 
 	var groups [][]SourceRecord
-	var prevMsgs []gjson.Result
+	var prev SourceRecord
+	havePrev := false
 	for _, s := range valid {
-		msgs := marshalToGJSON(s.Blob.Request.Body).Get("messages").Array()
-		continued := len(groups) > 0 && messagesContinue(prevMsgs, msgs)
+		continued := havePrev && recordsContinue(prev, s)
 		if continued {
 			groups[len(groups)-1] = append(groups[len(groups)-1], s)
 		} else {
 			groups = append(groups, []SourceRecord{s})
 		}
-		prevMsgs = msgs
+		prev = s
+		havePrev = true
 	}
 	return groups
 }
 
+// recordsContinue 报告 cur 是否延续 prev 所在的会话。wire shape 不同 ⇒ 硬会话边界
+// （不同平台/端点永不共享一次对话）；同 shape ⇒ 交给该 shape 的前缀谓词。
+func recordsContinue(prev, cur SourceRecord) bool {
+	if prev.Record == nil || cur.Record == nil || prev.Blob == nil || cur.Blob == nil {
+		return false
+	}
+	ps := WireShapeForRecord(prev.Record)
+	cs := WireShapeForRecord(cur.Record)
+	if ps != cs || ps == WireUnknown {
+		return false
+	}
+	return requestContinuesForShape(ps, prev.Blob.Request.Body, cur.Blob.Request.Body)
+}
+
+// RequestContinues 是 recordsContinue 的导出包装，供流式导出按 wire-shape 感知的
+// 会话边界增量 flush（无需把整批 blob 同时读进内存）。取代仅识 messages-shape 的
+// RequestMessagesContinue 用于多平台导出。
+func RequestContinues(prev, cur SourceRecord) bool {
+	return recordsContinue(prev, cur)
+}
+
+// requestContinuesForShape 在同一 wire shape 内判断前缀延续：取该 shape 的请求消息
+// 数组字段，cur 为空数组（如 responses 的 string-input、空 body）即非延续（起新会话，
+// 避免两条无前缀记录因「空前缀相等」被误并）。
+func requestContinuesForShape(shape WireShape, prevBody, curBody any) bool {
+	field := continuityField(shape)
+	if field == "" {
+		return false
+	}
+	cur := marshalToGJSON(curBody).Get(field).Array()
+	if len(cur) == 0 {
+		return false
+	}
+	prev := marshalToGJSON(prevBody).Get(field).Array()
+	return messagesContinue(prev, cur)
+}
+
+// continuityField 返回每个 wire shape 用于前缀链判定的请求消息数组字段名。
+func continuityField(shape WireShape) string {
+	switch shape {
+	case WireAnthropicMessages, WireOpenAIChat:
+		return "messages"
+	case WireGemini:
+		return "contents"
+	case WireOpenAIResponses:
+		return "input"
+	default:
+		return ""
+	}
+}
+
 // messagesContinue 报告 cur 是否延续 prev 所在的会话：cur 是 prev 的前缀扩展，
-// 或更短（context compaction 收缩了历史）。
+// 或更短（context compaction 收缩了历史）。字段无关——按 JSON 数组逐条深度比较，
+// 供各 shape（messages / contents / input）复用。
 func messagesContinue(prev, cur []gjson.Result) bool {
 	return len(cur) < len(prev) || messagesEqualPrefix(prev, cur)
 }
 
-// RequestMessagesContinue 是 messagesContinue 的导出包装，供流式导出按会话边界增量
-// flush（无需把整批记录的 blob 同时读进内存）。入参是两条记录各自的 request.body。
+// RequestMessagesContinue 是 messagesContinue 的导出包装（仅 messages-shape），
+// 保留作 sentinel 锚点与向后兼容；多平台导出改用 RequestContinues。
 func RequestMessagesContinue(prevReqBody, curReqBody any) bool {
 	prev := marshalToGJSON(prevReqBody).Get("messages").Array()
 	cur := marshalToGJSON(curReqBody).Get("messages").Array()

--- a/backend/internal/observability/trajectory/projection_v2.go
+++ b/backend/internal/observability/trajectory/projection_v2.go
@@ -84,9 +84,12 @@ func buildSessionForShape(recs []SourceRecord, summary *ExportSummary) (TrajSess
 	switch groupShape(recs) {
 	case WireAnthropicMessages:
 		return buildAnthropicMessagesSession(recs, summary)
-	// Commit B wires WireOpenAIChat / WireOpenAIResponses, Commit C wires
-	// WireGemini here. Until then non-anthropic shapes skip (the export handler
-	// still pins anthropic, so they are unreachable in production).
+	case WireOpenAIChat:
+		return buildOpenAIChatSession(recs, summary)
+	case WireOpenAIResponses:
+		return buildOpenAIResponsesSession(recs, summary)
+	// Commit C wires WireGemini here. Until then gemini/unknown shapes skip
+	// (the export handler still pins anthropic, so they are unreachable in prod).
 	default:
 		return TrajSessionV2{}, false
 	}
@@ -356,7 +359,14 @@ func buildMetaV2(recs []SourceRecord, lastReq gjson.Result, assistantModel strin
 			meta.Sampling = sampling
 		}
 	}
-	// synth/opt-in 字段（若有）。
+	applySynthMeta(&meta, recs)
+	return meta
+}
+
+// applySynthMeta folds the synth / opt-in record fields (dialog_synth,
+// synth_session_id, engineer_level, trajectory_id) into a TrajMetaV2. Shared by
+// every platform's meta builder so the synth-pipeline contract is one place.
+func applySynthMeta(meta *TrajMetaV2, recs []SourceRecord) {
 	for _, rec := range recs {
 		r := rec.Record
 		if r == nil {
@@ -375,7 +385,6 @@ func buildMetaV2(recs []SourceRecord, lastReq gjson.Result, assistantModel strin
 			meta.TrajectoryID = strings.TrimSpace(*r.TrajectoryID)
 		}
 	}
-	return meta
 }
 
 // reconstructAssistantTurn 从一条记录的 blob 重建 assistant turn 的 blocks 与 call_meta。

--- a/backend/internal/observability/trajectory/wire_shape.go
+++ b/backend/internal/observability/trajectory/wire_shape.go
@@ -1,0 +1,86 @@
+package trajectory
+
+import (
+	"strings"
+
+	"github.com/Wei-Shaw/sub2api/ent"
+	"github.com/Wei-Shaw/sub2api/internal/domain"
+)
+
+// WireShape identifies the client-facing protocol shape of a captured QARecord's
+// evidence blob. The traj v2 projector dispatches reconstruction by shape: each
+// shape parses its own request.messages / response / SSE layout but every builder
+// emits the SAME TrajSessionV2/TrajTurnV2 vocabulary (text / thinking / tool_use
+// blocks; user / assistant / tool turns), so the export schema stays uniform
+// across platforms (anthropic / openai / gemini / antigravity / kiro / newapi).
+//
+// Shape is a pure function of (platform, normalized inbound_endpoint) — both
+// already stored on every QARecord by the capture layer. It is NOT the upstream
+// shape: antigravity relays to Gemini cloudcode-pa internally, but the captured
+// client-facing blob on /antigravity/v1 is Anthropic-shaped and on
+// /antigravity/v1beta is Gemini-shaped, so antigravity reuses the anthropic /
+// gemini builders by inbound endpoint rather than needing its own.
+type WireShape string
+
+const (
+	WireAnthropicMessages WireShape = "anthropic_messages" // /v1/messages (anthropic, kiro, antigravity v1)
+	WireOpenAIChat        WireShape = "openai_chat"        // /v1/chat/completions (openai, newapi, grok)
+	WireOpenAIResponses   WireShape = "openai_responses"   // /v1/responses (Codex)
+	WireGemini            WireShape = "gemini"             // /v1beta/models ...generateContent (gemini, vertex, antigravity v1beta, newapi ch41)
+	WireUnknown           WireShape = ""                   // non-conversation (embeddings/images/video) or unprojectable
+)
+
+// Canonical normalized inbound-endpoint markers. These mirror the values
+// normalizeInboundEndpoint produces in the qa package (qaEndpointMessages, …).
+// They are public, stable Anthropic/OpenAI/Gemini API paths — external contracts,
+// not a TokenKey platform list — so matching on the literals here (the qa package
+// cannot be imported without a cycle) is robust, and a qa-package endpoint-shape
+// test (TestWireShapeMatchesCaptureEndpoints) guards against drift.
+const (
+	endpointMessages        = "/v1/messages"
+	endpointChatCompletions = "/v1/chat/completions"
+	endpointResponses       = "/v1/responses"
+	endpointGeminiModels    = "/v1beta/models"
+)
+
+// WireShapeForRecord returns the wire shape of a captured record. The normalized
+// inbound endpoint is the primary discriminator (it already disambiguates
+// newapi's chat-vs-gemini records and antigravity's v1-vs-v1beta surfaces); the
+// platform is only a fallback for records whose endpoint carries no conversation
+// marker (so a single-shape platform still projects), and otherwise Unknown so
+// the projector skips rather than emit garbage turns.
+func WireShapeForRecord(rec *ent.QARecord) WireShape {
+	if rec == nil {
+		return WireUnknown
+	}
+	return wireShapeFor(rec.Platform, rec.InboundEndpoint)
+}
+
+func wireShapeFor(platform, inboundEndpoint string) WireShape {
+	ep := strings.TrimSpace(inboundEndpoint)
+	switch {
+	case strings.Contains(ep, endpointResponses):
+		return WireOpenAIResponses
+	case strings.Contains(ep, endpointChatCompletions):
+		return WireOpenAIChat
+	case strings.Contains(ep, endpointMessages):
+		return WireAnthropicMessages
+	case strings.Contains(ep, endpointGeminiModels):
+		return WireGemini
+	}
+	// Endpoint carried no conversation marker (embeddings/images/video, or an
+	// empty/odd value). Only platforms with exactly ONE canonical conversation
+	// shape get a fallback — openai/newapi/grok speak both chat and responses, so
+	// without an endpoint marker they are Unknown (skip) rather than guessed.
+	switch platform {
+	case domain.PlatformAnthropic, domain.PlatformKiro, domain.PlatformAntigravity:
+		return WireAnthropicMessages
+	case domain.PlatformGemini:
+		return WireGemini
+	default:
+		return WireUnknown
+	}
+}
+
+// ProjectableShape reports whether the projector has a builder for this shape.
+func ProjectableShape(s WireShape) bool { return s != WireUnknown }

--- a/backend/internal/observability/trajectory/wire_shape_test.go
+++ b/backend/internal/observability/trajectory/wire_shape_test.go
@@ -1,0 +1,82 @@
+package trajectory
+
+import (
+	"testing"
+
+	"github.com/Wei-Shaw/sub2api/ent"
+)
+
+func TestWireShapeForRecord(t *testing.T) {
+	cases := []struct {
+		name     string
+		platform string
+		endpoint string
+		want     WireShape
+	}{
+		// anthropic + kiro + antigravity /v1 all relay the /v1/messages shape.
+		{"anthropic messages", "anthropic", "/v1/messages", WireAnthropicMessages},
+		{"kiro messages", "kiro", "/v1/messages", WireAnthropicMessages},
+		{"antigravity v1 normalizes to messages", "antigravity", "/v1/messages", WireAnthropicMessages},
+		// openai-compat: chat vs responses disambiguated purely by endpoint.
+		{"openai chat", "openai", "/v1/chat/completions", WireOpenAIChat},
+		{"openai responses", "openai", "/v1/responses", WireOpenAIResponses},
+		{"grok chat", "grok", "/v1/chat/completions", WireOpenAIChat},
+		// newapi splits per record: a ch41 gemini record vs a chat record under
+		// the SAME platform value — proves endpoint is the primary discriminator.
+		{"newapi chat record", "newapi", "/v1/chat/completions", WireOpenAIChat},
+		{"newapi gemini (ch41) record", "newapi", "/v1beta/models", WireGemini},
+		// gemini + antigravity /v1beta speak the Gemini contents[] shape.
+		{"gemini generateContent", "gemini", "/v1beta/models", WireGemini},
+		{"antigravity v1beta normalizes to gemini", "antigravity", "/v1beta/models", WireGemini},
+		// non-conversation endpoints are not projectable (skip, not garbage).
+		{"openai embeddings", "openai", "/v1/embeddings", WireUnknown},
+		{"openai images", "openai", "/v1/images/generations", WireUnknown},
+		{"openai video", "openai", "/v1/video/generations", WireUnknown},
+		// platform fallback for single-shape platforms with an odd/empty endpoint.
+		{"anthropic empty endpoint falls back", "anthropic", "", WireAnthropicMessages},
+		{"gemini empty endpoint falls back", "gemini", "", WireGemini},
+		// openai with no endpoint marker is ambiguous (chat vs responses) → skip.
+		{"openai empty endpoint is unknown", "openai", "", WireUnknown},
+		{"unknown platform empty endpoint", "mystery", "", WireUnknown},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			got := WireShapeForRecord(&ent.QARecord{Platform: tc.platform, InboundEndpoint: tc.endpoint})
+			if got != tc.want {
+				t.Errorf("WireShapeForRecord(%q,%q) = %q, want %q", tc.platform, tc.endpoint, got, tc.want)
+			}
+		})
+	}
+}
+
+func TestWireShapeForRecord_NilSafe(t *testing.T) {
+	if got := WireShapeForRecord(nil); got != WireUnknown {
+		t.Errorf("nil record = %q, want Unknown", got)
+	}
+}
+
+// recordsContinue / RequestContinues: a wire-shape change is a hard session
+// boundary even when the message arrays would otherwise look continuous.
+func TestRequestContinues_ShapeBoundary(t *testing.T) {
+	mk := func(platform, endpoint, body string) SourceRecord {
+		blob := &EvidenceBlob{}
+		blob.Request.Body = mustBody(t, body)
+		return SourceRecord{
+			Record: &ent.QARecord{Platform: platform, InboundEndpoint: endpoint},
+			Blob:   blob,
+		}
+	}
+	anth1 := mk("anthropic", "/v1/messages", `{"messages":[{"role":"user","content":"a"}]}`)
+	anth2 := mk("anthropic", "/v1/messages", `{"messages":[{"role":"user","content":"a"},{"role":"assistant","content":"b"},{"role":"user","content":"c"}]}`)
+	gem := mk("gemini", "/v1beta/models", `{"contents":[{"role":"user","parts":[{"text":"a"}]}]}`)
+
+	if !RequestContinues(anth1, anth2) {
+		t.Errorf("same-shape prefix extension should continue")
+	}
+	if RequestContinues(anth1, gem) {
+		t.Errorf("anthropic→gemini shape change must be a hard boundary")
+	}
+	if RequestContinues(gem, anth2) {
+		t.Errorf("gemini→anthropic shape change must be a hard boundary")
+	}
+}

--- a/backend/internal/server/api_contract_test.go
+++ b/backend/internal/server/api_contract_test.go
@@ -209,7 +209,8 @@ func TestAPIContracts(t *testing.T) {
 							"bind_start_path": "/api/v1/auth/oauth/dingtalk/bind/start?intent=bind_current_user&redirect=%2Fsettings%2Fprofile"
 						}
 					},
-					"run_mode": "standard"
+					"run_mode": "standard",
+					"traj_export_platforms": ["anthropic", "kiro", "gemini", "antigravity", "openai", "newapi", "grok"]
 				}
 			}`,
 		},

--- a/backend/internal/service/account_tk_compat_pool.go
+++ b/backend/internal/service/account_tk_compat_pool.go
@@ -80,3 +80,12 @@ func IsOpenAICompatPlatform(platform string) bool {
 func AllSchedulingPlatforms() []string {
 	return engine.AllSchedulingPlatforms()
 }
+
+// TrajProjectablePlatforms returns the platforms whose captured wire shape the
+// traj v2 projector can faithfully reconstruct, exposed to the handler layer
+// (the /auth/me projectable allowlist that gates the frontend export chip).
+// Single source lives in engine.TrajProjectablePlatforms(); this is the service
+// re-export sibling of OpenAICompatPlatforms() / AllSchedulingPlatforms() above.
+func TrajProjectablePlatforms() []string {
+	return engine.TrajProjectablePlatforms()
+}

--- a/backend/internal/web/dist/frontend-source.json
+++ b/backend/internal/web/dist/frontend-source.json
@@ -1,7 +1,7 @@
 {
   "algorithm": "sha256(git-ls-files:path,size,content)",
   "file_count": 488,
-  "hash": "fcb43b38f63035fa1e7a9a324eff7fd6037064179abe1d08cede35659fff4744",
+  "hash": "94e28905de89201f98715af3e6554aaba1fa22e6eaf7144903ad11cb622f00df",
   "schema": 1,
   "source": "frontend/"
 }

--- a/frontend/src/types/index.ts
+++ b/frontend/src/types/index.ts
@@ -89,6 +89,7 @@ export interface User {
   concurrency: number // Allowed concurrent requests
   rpm_limit?: number // User-level RPM cap (0 = unlimited); effective as fallback when group has no rpm_limit
   traj_export_enabled?: boolean // Admin-granted: allow exporting each API key's captured conversation records
+  traj_export_platforms?: string[] // Server-driven allowlist (/auth/me): platforms whose conversation records the traj projector can reconstruct; gates the export chip
   status: 'active' | 'disabled' // Account status
   allowed_groups: number[] | null // Allowed group IDs (null = all non-exclusive groups)
   balance_notify_enabled: boolean

--- a/frontend/src/views/user/KeysView.vue
+++ b/frontend/src/views/user/KeysView.vue
@@ -343,9 +343,9 @@
                 <Icon v-else name="checkCircle" size="sm" />
                 <span class="text-xs">{{ row.status === 'active' ? t('keys.disable') : t('keys.enable') }}</span>
               </button>
-              <!-- Export Conversations Button (admin-granted per-user switch; anthropic keys only — the traj projector is Anthropic-shaped) -->
+              <!-- Export Conversations Button (admin-granted per-user switch; projectable platforms only — server-driven allowlist from /auth/me, no hardcoded platform here) -->
               <button
-                v-if="canExportTraj && row.group?.platform === 'anthropic'"
+                v-if="canExportTraj && trajExportPlatforms.includes(row.group?.platform ?? '')"
                 @click="openExportPanel(row)"
                 :title="t('keys.exportTooltip')"
                 class="flex flex-col items-center gap-0.5 rounded-lg p-1.5 text-gray-500 transition-colors hover:bg-indigo-50 hover:text-indigo-600 dark:hover:bg-indigo-900/20 dark:hover:text-indigo-400"
@@ -1130,6 +1130,12 @@ const { copyToClipboard: clipboardCopy } = useClipboard()
 // Admin-granted per-user switch: only then does each key row expose the
 // conversation-record export entry (backend also enforces 403).
 const canExportTraj = computed(() => authStore.user?.traj_export_enabled === true)
+
+// Server-driven allowlist of platforms whose conversation records the traj
+// projector can reconstruct (engine.TrajProjectablePlatforms via /auth/me).
+// The chip renders only for a key whose group platform is in this list — the UI
+// holds no hardcoded platform list of its own (single source = the backend).
+const trajExportPlatforms = computed(() => authStore.user?.traj_export_platforms ?? [])
 
 const columns = computed<Column[]>(() => [
   { key: 'name', label: t('common.name'), sortable: true },

--- a/scripts/sentinels/frontend-tk.json
+++ b/scripts/sentinels/frontend-tk.json
@@ -846,9 +846,9 @@
     {
       "path": "frontend/src/views/user/KeysView.vue",
       "must_contain": [
-        "canExportTraj && row.group?.platform === 'anthropic'"
+        "canExportTraj && trajExportPlatforms.includes(row.group?.platform"
       ],
-      "rationale": "PR #792: the per-key conversation-record (traj) Export chip is gated by BOTH the admin-granted per-user switch (canExportTraj) AND anthropic-only (row.group.platform === 'anthropic'), because the traj v2 projector only reconstructs Anthropic /v1/messages. KeysView.vue is upstream-shaped; a git merge upstream/main that overwrites it back to upstream shape would silently drop the chip or its dual gate, exposing the export entry to every platform/user while still compiling."
+      "rationale": "PR #792/#808 + multi-platform: the per-key conversation-record (traj) Export chip is gated by BOTH the admin-granted per-user switch (canExportTraj) AND the server-driven projectable-platform allowlist (trajExportPlatforms, from /auth/me traj_export_platforms = engine.TrajProjectablePlatforms). The platform list is no longer hardcoded in the UI. KeysView.vue is upstream-shaped; a git merge that overwrites it back to upstream shape would silently drop the chip or its dual gate, exposing the export entry to every platform/user while still compiling."
     },
     {
       "path": "frontend/src/api/qaTraj.ts",

--- a/scripts/sentinels/trajectory.json
+++ b/scripts/sentinels/trajectory.json
@@ -48,19 +48,47 @@
     {
       "source": "backend/internal/handler/qa_handler_traj.go",
       "must_contain": [
-        "UserTrajExportEnabled",
-        "domain.PlatformAnthropic"
+        "UserTrajExportEnabled"
       ],
-      "rationale": "Per-key conversation-record (traj) export must keep BOTH gates: the admin-granted per-user switch (UserTrajExportEnabled -> 403) and the anthropic-only pin (Platform: domain.PlatformAnthropic). The traj v2 projector only faithfully reconstructs Anthropic /v1/messages; an upstream merge or refactor dropping the gate silently re-opens export to unauthorized users, and dropping the platform pin silently hands non-anthropic keys misleading non-empty garbage zips."
+      "rationale": "Per-key conversation-record (traj) export must keep the admin-granted per-user switch (UserTrajExportEnabled -> 403). An upstream merge or refactor dropping it silently re-opens export to unauthorized users. (The former anthropic-only Platform pin was removed when the projector became multi-platform; see the projection_v2.go and engine/provider.go anchors below for the wire-shape dispatch + projectable-platform single source.)"
     },
     {
       "source": "backend/internal/observability/qa/service_traj_export.go",
       "must_contain": [
         "func (s *Service) UserTrajExportEnabled",
         "qarecord.APIKeyIDEQ",
-        "qarecord.PlatformEQ"
+        "qarecord.PlatformEQ",
+        "trajectory.RequestContinues"
       ],
-      "rationale": "The export authorization helper plus the per-key (APIKeyIDEQ) and platform (PlatformEQ) scoping predicates. Losing the helper drops the 403 backstop; losing either predicate silently widens a self-export across keys or platforms beyond what the UI gate allows."
+      "rationale": "The export authorization helper, the per-key (APIKeyIDEQ) and platform (PlatformEQ) scoping predicates, and the shape-aware streaming continuation (RequestContinues). Losing the helper drops the 403 backstop; losing a predicate silently widens a self-export beyond the UI gate; reverting RequestContinues to a messages-only predicate would mis-fold non-anthropic conversations."
+    },
+    {
+      "source": "backend/internal/observability/trajectory/projection_v2.go",
+      "must_contain": [
+        "func buildSessionForShape",
+        "case WireOpenAIChat:",
+        "case WireOpenAIResponses:",
+        "case WireGemini:"
+      ],
+      "rationale": "The traj v2 projector dispatches reconstruction by wire shape so openai / gemini / antigravity / kiro / newapi export faithfully (not just anthropic). An upstream merge collapsing buildSessionForShape back to an anthropic-only projection silently regresses every non-anthropic key's export to empty/garbage; these case anchors make that revert fail CI."
+    },
+    {
+      "source": "backend/internal/observability/trajectory/wire_shape.go",
+      "must_contain": [
+        "func WireShapeForRecord",
+        "WireAnthropicMessages",
+        "WireOpenAIChat",
+        "WireOpenAIResponses",
+        "WireGemini"
+      ],
+      "rationale": "WireShapeForRecord is the single dispatch axis keyed on (platform, inbound_endpoint). Losing a shape constant or the mapping silently drops a platform from projectable export."
+    },
+    {
+      "source": "backend/internal/engine/provider.go",
+      "must_contain": [
+        "func TrajProjectablePlatforms"
+      ],
+      "rationale": "Single source for the platforms whose captured wire the projector reconstructs; surfaced to the frontend export chip via /auth/me traj_export_platforms. Removing it would orphan the chip's server-driven allowlist."
     }
   ],
   "semantic_route_contracts": [


### PR DESCRIPTION
## 做了什么

把按 API Key 的**对话记录（traj）导出**（#792 捕获/导出、#808 异步流式）从 **anthropic 专属**扩展到**所有承载对话的平台**——openai、antigravity、gemini/vertex，以及（同 wire 形态，白送的）kiro / grok / newapi。

**纯读侧改动：网关热路径与 QA 捕获完全不动。** 捕获早已为所有平台落原始 blob，只有「投影 + 导出门禁」此前与 anthropic 耦合。

## 关键事实（决定整体设计）

- **wire 形态 = `(platform, 归一化 inbound_endpoint)` 的纯函数**，二者今天就在每条 `QARecord` 上。`/antigravity/v1/messages` 归一为 `/v1/messages`、`/antigravity/v1beta/...` 归一为 gemini-models，所以 antigravity 按 endpoint 复用 anthropic / gemini 两个投影器，无需自己的投影器。
- 所有平台归一进**同一** `TrajSessionV2` 词汇（text / thinking / tool_use 块；user / assistant / tool 轮）——一份统一、训练就绪的 `.jsonl`。
- 非对话端点（embeddings/images/video）与不可投影形态 → **跳过，绝不投影成 garbage**（这正是 #792 当初 pin anthropic 的原因）。

## 提交结构（分阶段，每个提交独立全量 preflight 绿）

- **A — 地基（行为不变）**：`engine.TrajProjectablePlatforms()`（单一源，由 `OpenAICompatPlatforms()` 派生）；`trajectory.WireShape` + `WireShapeForRecord(platform, inbound_endpoint)` 派发轴；`BuildTrajSessionsV2` 改为按形态派发、anthropic 逻辑**逐字**抽取为 `buildAnthropicMessagesSession`；`groupByConversation` 改 shape-aware（形态变化即硬会话边界——修掉「gemini 记录全塌成一条 session」的隐患）。
- **B — openai**：`/v1/chat/completions` + `/v1/responses`（Codex）投影器（messages / input items、tool_calls / function_call、流式重组、reasoning→thinking）。
- **C — gemini**：`contents[]`/`parts[]` 投影器（覆盖 gemini + vertex + newapi ch41 + antigravity `/v1beta`）；同时处理 `alt=sse` 与非 SSE 的 JSON 数组流帧；antigravity `/v1` 按 endpoint 复用 anthropic builder。
- **D — 翻转开关（唯一用户可见变更）**：去掉 `Platform=anthropic` 钉；流式导出改用 shape-aware `RequestContinues`；`/auth/me` 携带 `traj_export_platforms`（服务端驱动的 chip 白名单，挂在 me 包装层而非 `dto.User`）；KeysView chip 读该清单（无硬编码 `'anthropic'`）；sentinel 锚点迁到「派发 + 可投影平台源」。
- **R-001/R-002（xj-review 自审修复）**：补 openai/gemini 流式 truncated 负向测试；`buildOpenAIChatMeta` 可读性清理。

## 单一事实来源

- 可投影平台集只在 `engine.TrajProjectablePlatforms()` 一处派生（经 service 再导出），经 `/auth/me` 下发前端；UI 不再持有任何平台清单（不碰 `gatewayPlatforms.ts`）。
- 形态派发只读已捕获的 `(platform, inbound_endpoint)`；qa 包一条 drift 测试把捕获端点钉死对齐投影器的端点标记。

## 零网关影响

不改捕获中间件、网关/relay/转发 handler、调度器、路由。`BuildTrajSessionsV2` / `RequestContinues` 无任何网关调用方（只隔离的单 worker 导出池用）。`trajectory.json` 的路由钩子锚点（捕获接线）原样不动。

## 测试

各形态投影器单测（openai chat+responses、gemini、antigravity 派发、形态边界续接、wire-shape 矩阵、可投影集成员、流式 truncated 负向）；端到端导出测试（多平台形态派发无串味、newapi 按 record 拆 chat/gemini、kiro 经 anthropic builder、embeddings 跳过）；`/auth/me` 契约 golden 已更新。`go test -tags=unit ./...`、`golangci-lint run ./...`、前端 `typecheck`/`lint:check`/qaTraj vitest、`pnpm build`（dist 重生）、完整 `scripts/preflight.sh`（generic + sub2api）：本地全绿。

## marker / 边界

- `upstream-touch-guarded` —— 本 PR 改动且含删除的 upstream 形态文件（`qa_handler_traj.go`、`service_traj_export.go`、`KeysView.vue`）全部在 `scripts/sentinels/trajectory.json` / `frontend-tk.json` 有锚点；`auth_handler.go` / `types/index.ts` 为纯插入。无 upstream 功能被删除。
- `sentinel-registry-reviewed` —— 改了 covered 面并在同 PR 内同步更新其注册表（`trajectory.json` 去掉过时的 anthropic-pin 锚点、新增「派发 + 可投影源」锚点；`frontend-tk.json` chip 锚点改为服务端驱动门）。新投影器文件（`projection_openai.go`、`projection_gemini.go`、`wire_shape.go`）非 `*_tk_*.go` hotspot，已审覆盖并经 `trajectory.json` 锚定。

合并方式：**Squash and merge**（TK 自源功能）。

🤖 Generated with [Claude Code](https://claude.com/claude-code)