### PR TITLE
docs(pricing): consolidate pricing/serving SSOT + correct channel-pricing finding

### DIFF
--- a/docs/approved/channel-pricing-refund-gate-and-runtime-pricing.md
+++ b/docs/approved/channel-pricing-refund-gate-and-runtime-pricing.md
@@ -1,0 +1,151 @@
+---
+title: Channel-Pricing Refund Gate (investigated — no live leak) + Runtime Pricing ② design
+status: approved
+approved_by: "xuejiao (design directive, this session)"
+approved_at: "2026-06-17"
+authors: [agent]
+created: 2026-06-17
+related_prs: []
+related_commits: []
+related_stories: []
+related_design: docs/approved/pricing-serving-single-source-of-truth.md, docs/approved/pricing-availability-source-of-truth.md
+supersedes: none
+---
+
+# Channel-Pricing Refund Gate (investigated) + Runtime Pricing ② design
+
+> **Headline correction.** An earlier analysis named `channel_model_pricing` "the real
+> remaining money hole" — an ungated admin writer at the top of the price-precedence stack
+> that could re-enable the video terminal-failure refund leak. **A direct code read
+> retracts that claim:** `channel_model_pricing` is structurally incapable of carrying a
+> video / per-second / thinking price today, so the leak path does not exist. The refund
+> gate is therefore **not urgent** and is **folded into ②** (runtime pricing), where the
+> channel writer first *gains* those price dimensions and the gate's invariants become
+> load-bearing alongside them. This doc records the investigation, the gate design (built &
+> verified as a prototype this session), and the ② runtime-pricing design that the gate
+> gates.
+
+## 1. The investigation — why there is no live leak
+
+The precedence + bypass facts are real and worth stating:
+
+- `channel_model_pricing` (raw-SQL, resolved in `model_pricing_resolver.go`) **WINS**
+  precedence: the overlay header says so literally (`pricing_service_tk_overlay.go:32-33`:
+  *"The DB-backed ModelPricing override … still sits above everything."*).
+- It **bypasses the preflight refund gate**: `scripts/checks/pricing-overlay.py` runs
+  CI-only against `tk_pricing_overlay.json`. It never sees a DB write.
+
+But the *dangerous* write — an ungated **video** price that re-enables the terminal-failure
+full refund — is **structurally unreachable** through the channel writer:
+
+| # | Fact | Evidence |
+| --- | --- | --- |
+| 1 | `ChannelModelPricing` has **no per-second / failure_billing / thinking** field | `channel.go:75` — only `input/output/cache_write/cache_read/image_output/per_request` |
+| 2 | `BillingMode` has **no `video`** mode | only `token / per_request / image` |
+| 3 | The resolver routes **no per-second branch**; `ResolvedPricing` has **no per-second field** | `model_pricing_resolver.go:75,139`; struct at `:16` |
+| 4 | Video cost (and its refund) is **overlay-only** | `billing_service.go:976` reads `pricing.OutputCostPerSecond` from the overlay/litellm `ModelPricing` (`pricing_service.go:84`), already gated by `pricing-overlay.py`; `openai_gateway_service_tk_video_refund.go` reverses that overlay-derived cost |
+
+The same holds for **thinking**: `ThinkingOutputPricePerToken` is sourced only from
+litellm/overlay (`billing_service.go:412`), never from a channel row.
+
+**So `channel_model_pricing` can only carry `token / per_request / image` prices today**, and
+for those the existing admin validator (`channel_service.go validatePricingBillingMode:613`)
+already enforces *mode-has-price* (`checkBillingModeRequirements`), *non-negative*
+(`checkPricesNotNegative`), and *intervals-have-prices* (`checkIntervalsHavePrices`). The
+only ungated residue is an **undercharging $0 token price** — `checkPricesNotNegative`
+allows `>= 0`, so an accidental `output_price: 0` would bill nothing. That is a **revenue
+guardrail (undercharge), not a refund leak (overcharge-then-over-refund)** — low severity,
+admin-only, and not the money-leak class the gate was framed to close.
+
+**Verdict: no live channel-pricing refund leak.** The gate is deferred into ②.
+
+## 2. The gate design (folded into ②, prototyped this session)
+
+When ② makes `channel_model_pricing` able to own video/per-second + thinking prices, the
+write path must enforce the same refund invariants the overlay enforces at preflight —
+**otherwise ② would create the leak that does not exist today.** The gate is designed and
+was prototyped (compiles clean, `go vet` clean, `TestValidateChannelRefundSafety` 15/15
+passing) so its implementability is proven; it ships **with ②**, not before.
+
+### 2.1 New columns (make the invariants expressible)
+
+Add to `channel_model_pricing` (and its `channel_account_stats_model_pricing` mirror) via a
+TK-only additive migration:
+
+| column | type | mirrors overlay field | invariant |
+| --- | --- | --- | --- |
+| `failure_billing` | text (nullable) | `failure_billing` | video mode ⇒ must equal `success_only` |
+| `output_cost_per_second` | numeric (nullable) | `output_cost_per_second` | video mode ⇒ must be `> 0` |
+| `thinking_output_cost_per_token` | numeric (nullable) | `thinking_output_cost_per_token` | when present ⇒ must be `> 0` |
+
+Nullable + additive ⇒ no backfill, §5.x-safe net-add to a TK-owned table. **Critically,
+these columns must land in the SAME change that adds the resolver branches that READ them**
+(②) — adding them standalone now would freeze dead columns into the live schema (migration
+immutability) ahead of any reader, which is why this is not a separate PR.
+
+### 2.2 Write-time validator mirroring `pricing-overlay.py`
+
+Extend the admin write path (the shared `validatePricingEntries` chokepoint reached by both
+Create and Update **and** the account-stats rules) with a refund-safety check that is a
+**1:1 port** of `pricing-overlay.py`'s anchors, so the JSON gate and the DB gate enforce
+byte-equivalent rules:
+
+- **video_generation:** `output_cost_per_second > 0` AND `failure_billing == 'success_only'`
+  — else reject with a `VIDEO_REFUND_UNSAFE` BadRequest (same message class as the preflight
+  check).
+- **thinking rate:** if `thinking_output_cost_per_token` present, must be `> 0`.
+- (existing mode-has-price / non-negative / intervals checks stay.)
+
+### 2.3 Keep the two gates from drifting
+
+Anchor the JSON gate (`pricing-overlay.py`) and the Go write-time gate so they cannot
+diverge: a sentinel pin on the validator file + a unit test asserting a charges-on-failure
+video write is rejected. (`scripts/sentinels/pricing-availability.json` + the validator's
+unit test.)
+
+## 3. ② Runtime pricing — STAGED-NEXT
+
+**Goal:** route new long-tail model prices to `channel_model_pricing` so onboarding a model
+needs **no release** — the price is a hot-added DB row, not an overlay rebuild. This is the
+true-runtime half that the served-models reconciler doc defers to here.
+
+② is the unit of work that lands **together**: (a) §2.1 columns, (b) §2.2 write-time gate,
+(c) the resolver branches that make the new columns load-bearing, (d) the media-guard teach
+below. None of these ship alone — the gate without readers is dead schema; the readers
+without the gate are the leak.
+
+### 3.1 The runtime media-unpriced guard must learn to consult channel pricing
+
+The runtime media-unpriced guard currently **fail-closed-ignores** `channel_model_pricing`
+(`openai_gateway_service_tk_media_unpriced_guard.go:47-49`: channel DB pricing "cannot be a
+model's sole price"). That assumption is exactly what ② inverts. Once a media price can live
+*only* in a DB row, the guard must **consult channel pricing before declaring a model
+unpriced** — otherwise a legitimately DB-priced media model is gated out at serve time.
+
+### 3.2 Deploy-ordering hazard (state it loudly)
+
+**MERGE ≠ DEPLOY.** The §2 gate only protects production once the *binary running in prod*
+contains it. Because ② ships the columns + readers + gate as one unit, the hazard is simpler
+than a split would be — but still real for any **operator runbook** that says "price models
+via the admin API":
+
+```
+② merged → ② deployed → operator prices a charges-on-failure video model at runtime
+```
+
+is safe **only if** the deployed binary contains §2's gate. Treat "② merged" and "②
+deployed" as separate checkpoints; do not publish a "price via admin API" runbook until the
+gate is **confirmed in the running image** — verify against live `/version` and a probe write
+that `VIDEO_REFUND_UNSAFE` actually fires in prod, not just in CI.
+
+## 4. Sequencing summary
+
+| Step | Precondition | Effect |
+| --- | --- | --- |
+| **(now)** channel pricing carries only `token/per_request/image` | — | no video/thinking path ⇒ no live refund leak; existing validator suffices |
+| **② runtime pricing** (columns + resolver + gate + media-guard, one unit) | current cadence acceptable; build when model-add frequency justifies it | new model prices via DB row, no release; gate prevents the leak ② would otherwise create |
+| **② deployed + verified** | ② merged + released + probe-confirmed in prod binary | "price via admin API" runbook may be published |
+
+Until ② is built, onboarding a model still costs an overlay rebuild for its price — a normal
+reviewed release, acceptable at current cadence. The gate is a prerequisite **of ②**, not a
+standalone batch.

--- a/docs/approved/newapi-served-models-reconciler.md
+++ b/docs/approved/newapi-served-models-reconciler.md
@@ -1,30 +1,33 @@
 ---
-title: newapi Served-Models Reconciler + Runtime-Config Decision (Phase 3, design only)
+title: newapi Served-Models Reconciler — DECIDED: do NOT build an unattended auto-sync
 status: approved
-approved_by: xuejiao (design directive, this session)
-approved_at: 2026-06-17
+approved_by: "xuejiao (design directive, this session)"
+approved_at: "2026-06-17"
 authors: [agent]
 created: 2026-06-17
+updated: 2026-06-17
 related_prs: []
 related_commits: []
 related_stories: []
-related_design: docs/approved/newapi-as-fifth-platform.md
+related_design: docs/approved/newapi-as-fifth-platform.md, docs/approved/pricing-serving-single-source-of-truth.md
 supersedes: none
 ---
 
-# newapi Served-Models Reconciler + Runtime-Config Decision (Phase 3, design only)
+# newapi Served-Models Reconciler — DECIDED: do NOT build an unattended auto-sync
 
-> Status: **APPROVED DESIGN, DEFERRED IMPLEMENTATION.** This is a decision record, not
-> a shipped feature. It depends on the keystone artifact
-> `backend/internal/service/tk_served_models.json` (the served-models MANIFEST) and its
-> drift guard `scripts/checks/catalog-serving-drift.py` (the "Foundation PR"). Build the
-> reconciler described in §1 only when the trigger in §2 fires; until then the
-> `tokenkey-onboard-model` skill + the static drift guard are the operating mechanism.
+> **DECISION CHANGED (2026-06-17).** The prior revision of this record left an
+> unattended whitelist reconciler as an "approved design, deferred implementation"
+> waiting on a churn trigger. **That stance is now reversed.** After auditing the
+> serving primitive against `account.go`, R-002, and the `BulkUpdate` JSONB semantics,
+> the decision is: **do NOT build an unattended auto-sync reconciler at all.** It is not
+> "defer until the trigger fires" — it is "this is the wrong tool, full stop." The safe
+> mechanism is human-in-the-loop: the admin "fetch upstream models" discovery button +
+> the `tokenkey-onboard-model` skill, gated by the #819 static drift guard.
 
-## 0. Context and the problem this solves
+## 0. Context (unchanged)
 
 TokenKey serves a TK-curated long-tail of `newapi` (fifth-platform) models — Qwen and
-DeepSeek families — on **two dedicated single-account groups**:
+DeepSeek families — on two dedicated single-account groups:
 
 | account | name | platform | channel_type | group |
 | --- | --- | --- | --- | --- |
@@ -33,277 +36,123 @@ DeepSeek families — on **two dedicated single-account groups**:
 
 A model is "served" on one of these accounts only when its client-facing id appears as a
 key in that account's `credentials.model_mapping` (an identity WHITELIST: `key == value`).
-Today that whitelist is set by numbered `tk_NNN_*_model_mapping*.sql` migrations
-(`tk_021`, `tk_022`, `tk_024`, `tk_027`) and by ad-hoc admin-UI edits. **Adding a model
-therefore requires a new migration** — a release — even though the price can be hot-added
-via channel pricing or the overlay.
+The #812-class regression (qwen3 dense ids priced but unmapped) motivated asking whether a
+reconciler could make "add a model" need no per-account migration. The answer below is **no
+— building it is actively harmful.** #818's `tk_029` point-fixed the gap; #819's guard
+mechanically blocks its recurrence; #820's skill is the ongoing mechanism.
 
-This is the exact failure mode behind the **#812-class regression**: `qwen3-8b`,
-`qwen3-14b`, `qwen3-32b` are priced in `tk_pricing_overlay.json` (added 2026-06-17) but
-**no migration maps them onto account 60** — the highest mapping migration is `tk_027`
-(`tk_028` only touches the `model_availability` platform CHECK for grok). The pool is
-empty for those three ids → `429`/`503` in prod, with the price present making it look
-served. `ls backend/migrations/tk_029*` returns nothing as of this writing — the gap is
-real and is what the static drift guard hard-fails on.
+## 1. DECISION: do NOT build an unattended newapi auto-sync reconciler
 
-Two questions follow, and this record answers both:
+Three independent reasons, each sufficient on its own.
 
-1. **Can we make "add a model" need no per-account migration?** → Yes, via a
-   reconciler that converges accounts 39/60 toward a canonical whitelist derived from the
-   manifest. **Recommended (§1).**
-2. **Can we make pricing truly runtime (no release at all)?** → Not yet. The refund-safety
-   validation that gates video pricing is preflight-time; moving pricing to runtime means
-   moving that validation to write-time and accepting `channel_model_pricing`'s
-   silent-shadow precedence. **Explicit blocker, DEFERRED with a measurable trigger (§2).**
+### 1.1 Reason 1 — allow-all inversion (the reconciler does the OPPOSITE of "auto-sync new models")
 
----
+`Account.IsModelSupported` (`backend/internal/service/account.go:639`):
 
-## 1. Decision: a newapi whitelist reconciler, canonical = manifest-DERIVED domain constant
-
-### 1.1 What it does
-
-A per-node `NewAPIServedModelsReconciler` modeled **byte-for-byte** on
-`backend/internal/service/antigravity_config_reconciler.go`. Each tick (and once
-immediately on boot), under a Redis leader-lock, it:
-
-1. `accounts.ListByPlatform(ctx, PlatformNewAPI)` — list this deployment's newapi accounts.
-2. For each account whose id is a manifest `served_on` target (39, 60), compute the
-   **desired** `credentials.model_mapping` = the canonical identity whitelist for that
-   account derived from the manifest.
-3. Skip-if-aligned: only accounts whose current whitelist is **missing** a desired key are
-   rewritten (drift probe; idempotent, no write thrash — same posture as
-   `antigravityCanServeExcluded` at `antigravity_config_reconciler.go:229`).
-4. `accounts.BulkUpdate(ctx, drifted, AccountBulkUpdate{Credentials: {"model_mapping": ...}})`
-   — the JSONB shallow-merge replaces the whole `model_mapping` sub-object and enqueues a
-   `scheduler_outbox` event so the change takes effect without a restart
-   (`antigravity_config_reconciler.go:277-282`).
-
-The whole point: **adding `qwen3-8b` becomes one manifest row + (its derived constant
-flowing through automatically), not a `tk_029` migration.** The reconciler closes the
-#812 gap structurally instead of per-incident.
-
-### 1.2 Canonical source: manifest-DERIVED domain constant (recommended) vs DB-backed config
-
-This is the load-bearing choice. Two candidates:
-
-**Option A — domain constant DERIVED from the embedded manifest (RECOMMENDED).**
-Mirror the proven antigravity single-source pattern exactly. There,
-`GeminiOnlyAntigravityModelMapping` is **not** a hand-maintained second list — it is
-`buildGeminiOnlyAntigravityModelMapping()` filtering `DefaultAntigravityModelMapping`
-(`constants.go:158-169`), so "adding a gemini wire id above flows into the gemini-only set
-for free." The newapi analogue:
-
-- The manifest `tk_served_models.json` is already `//go:embed`-able from
-  `backend/internal/service/` (it sits beside `tk_pricing_overlay.json`, which
-  `pricing_service_tk_overlay.go:49` already embeds with `//go:embed`).
-- A new derivation function — call it `NewAPIServedWhitelistFor(accountID int64)` —
-  parses the embedded manifest once and returns the identity whitelist
-  `{model_id: model_id}` for every entry whose `served_on` contains that account id.
-- That function IS the single source. The manifest is the only place a human edits; the
-  Go canonical whitelist is *derived*, never hand-kept. This is the same
-  "net-zero second list" discipline as the antigravity reconciler.
-
-**Option B — read a DB-backed config table at runtime (REJECTED for now).**
-Truly runtime (edit a row, no rebuild). Rejected because: (i) it duplicates intent that
-already lives in the manifest, creating a two-writer drift surface the manifest guard
-cannot see; (ii) the reconciler would then trust un-reviewed DB rows to rewrite
-`credentials.model_mapping` — a self-modifying config loop with no code-review gate; (iii)
-it buys true-runtime *whitelisting* but the **pricing** half is still release-bound (§2),
-so it solves half a problem while adding a new failure mode. Option A keeps the
-review gate (manifest PR) and the single source, at the cost of a rebuild to add a model —
-which is acceptable until the §2 trigger says otherwise.
-
-**Decision: Option A.** The manifest-derived constant is the canonical source; the
-reconciler converges DB toward it.
-
-### 1.3 §5.x framing: this is a NET-ADD reconciler, it MUST NOT delete
-
-Per CLAUDE.md §5.x (default = keep upstream capability, override; never silent-delete),
-the newapi reconciler's converge step is **add-only on the whitelist**:
-
-- It **adds** missing desired keys to `credentials.model_mapping`. It does **not** remove
-  keys the manifest omits. An operator who hand-added a model via admin-UI keeps it; the
-  reconciler never "cleans up" a key just because it is not in the manifest.
-  - This is a deliberate divergence from the antigravity reconciler, which *replaces* the
-    whole `model_mapping` (dropping claude/gpt-oss). That replace is correct there because
-    the policy is exclusionary ("gemini-only"). The newapi policy is **inclusionary**
-    ("at least serve the curated long-tail") — so it unions, never subtracts.
-  - Mechanically: read current `model_mapping`, union with the derived desired set, write
-    back only if the union differs (still idempotent / skip-if-aligned).
-- It touches **per-account DB rows only**, never a global default constant and never an
-  upstream-owned symbol. The manifest itself is TK-scoped (`SCOPE` = only the 39/60
-  long-tail; NOT the litellm catalog, NOT the four native platforms' Go allowlist maps,
-  NOT grok — grok is served by platform routing + ch48, not by a 39/60 whitelist).
-- Consequence: an upstream merge cannot regress this into a deletion, and the reconciler
-  can never empty a pool. The worst case is a no-op (manifest empty / accounts absent),
-  which is the safe direction.
-
-### 1.4 Interaction with the static drift guard
-
-The Foundation PR's `catalog-serving-drift.py` already hard-fails when a `served_on`
-entry has no migration (the #812 catcher). Once this reconciler ships, the guard's A3
-(served_on ⇒ migration) assertion **changes meaning**: a manifest row no longer needs a
-migration — it needs to be reconciled. The guard's A3 should then accept *either* a
-matching `tk_*model_mapping*.sql` **or** the row being within the reconciler's derived set
-(i.e. the reconciler is the migration). Until the reconciler ships, A3 stays migration-only
-and `qwen3-8b/14b/32b` hard-fail — which is exactly why the hotfix `tk_029` (the
-"Hotfix PR") lands first and independently of this design. **The reconciler is the
-structural fix; `tk_029` is the point fix that unblocks CI now.**
-
----
-
-## 2. The true-runtime (no-release) question: explicit blocker, DEFERRED
-
-The reconciler in §1 removes the **migration** for whitelisting, but a new model still
-needs a **rebuild** because (a) the manifest is `//go:embed`-ed and (b) its price comes
-from the `//go:embed`-ed `tk_pricing_overlay.json` or the runtime mirror. "True runtime"
-= add a model with neither a migration nor a release. That requires moving **pricing** to
-runtime, and that is blocked by a refund-safety invariant.
-
-### 2.1 The blocker: refund-safety validation is preflight-time, not write-time
-
-Video pricing carries a money-loss invariant enforced today in
-`scripts/checks/pricing-overlay.py:112-119`:
-
-```py
-if mode == "video_generation":
-    failure_billing = pricing.get("failure_billing")
-    if failure_billing != "success_only":
-        errors.append(... "a provider that charges for failed tasks breaks the
-                          terminal-failure refund — change the refund design before
-                          pricing it")
+```go
+func (a *Account) IsModelSupported(requestedModel string) bool {
+	mapping := a.GetModelMapping()
+	if len(mapping) == 0 {
+		return true // 无映射 = 允许所有
+	}
+	...
+}
 ```
 
-TokenKey refunds the user in full when a video task ends `failed`; that is loss-free
-**only if** the provider does not bill failed tasks. This is a **preflight-time** gate: a
-human prices a video model in the overlay JSON, declares `failure_billing='success_only'`,
-and CI proves it before the price can ship. It is the same class as the chat-mode
-`input/output_cost_per_token > 0` and the `thinking_output_cost_per_token > 0` anchors —
-all of which assume a human-reviewed, CI-gated edit.
+For a non-antigravity platform, an **empty** `model_mapping` means **allow-all**. An
+empty-mapping newapi account **already serves whatever the upstream channel exposes** —
+including new models the day upstream adds them, with zero TK action. Auto-populating the
+mapping does not *add* models; it **NARROWS allow-all into a snapshot-frozen restrictive
+allowlist**. The reconciler's effect is the exact opposite of its stated goal: instead of
+"auto-sync new models in," it would freeze the account to the manifest snapshot and start
+*rejecting* anything not in it. The naming ("served-models reconciler", "auto-sync") hides
+that inversion — which is precisely why it must not be built unattended.
 
-**Moving pricing to runtime deletes that gate.** A runtime admin-API price write does not
-pass through `scripts/preflight.sh`. To keep refund-safety, every check
-`pricing-overlay.py` runs at preflight (recognized mode, non-zero in the mode's fields,
-`failure_billing='success_only'` for video, positive thinking rate) would have to be
-**re-implemented as a WRITE-TIME validator in the admin pricing API** — reject the write
-at the handler before it reaches `channel_model_pricing`. That is a non-trivial,
-high-blast-radius piece of new code (a refund-correctness gate on the money path), not a
-config flip.
+### 1.2 Reason 2 — there is no trustworthy source to converge toward (R-002)
 
-### 2.2 The second cost: accepting channel_model_pricing's silent-shadow precedence
+A converging reconciler needs an authoritative desired-state. Upstream `/v1/models` is
+**not** it — per `docs/approved/pricing-availability-source-of-truth.md` §2.4 / R-002 it is
+an unvetted discovery feed that over-reports deprecated, retired, disabled, served-but-
+unpriced, and embedding-only ids. `FetchUpstreamSupportedModels`
+(`backend/internal/service/upstream_models.go:76`) returns a bare `[]string` with no pricing
+or availability tag and is deliberately not wired to `DiscoveryFilter`. An unattended
+reconciler converging toward this feed would freeze the account to a snapshot polluted with
+ids the operator must not serve — and freezing *to* a polluted snapshot is worse than the
+allow-all it replaces.
 
-Runtime pricing in this codebase means `channel_model_pricing` DB rows (raw-SQL, the
-resolver in `model_pricing_resolver.go`), which **override everything** — including the
-overlay (`pricing_service_tk_overlay.go` header: "The DB-backed ModelPricing override
-... still sits above everything"). So a runtime price is a **silent shadow over the
-overlay**: the overlay's CI-proven value can be masked by a DB row no guard ever saw. For
-refund-safety that is the dangerous direction — a runtime row could price a
-charges-on-failure video model and the preflight guard would never fire because the
-overlay still says `success_only` while the live price comes from the shadowing DB row.
-Accepting runtime pricing means **accepting that precedence and rebuilding the guard at
-the write boundary** so the shadow itself is validated.
+The antigravity reconciler (`antigravity_config_reconciler.go`) is safe **only because** it
+converges toward a **fixed code constant** (`buildGeminiOnlyAntigravityModelMapping()`,
+`constants.go:158-169`) with **zero network I/O** — a reviewed, in-repo desired-state. There
+is no equivalent trustworthy fixed desired-state for the open-ended newapi long-tail; the
+manifest is intent, not a complete account allowlist, and converging an account *to* the
+manifest would strip operator-added ids.
 
-### 2.3 Decision: DEFER, with a measurable trigger
+### 1.3 Reason 3 — `BulkUpdate` is the wrong primitive for add-only grow
 
-**Defer true-runtime pricing.** The cost is a new refund-correctness validator on the
-money path plus owning the silent-shadow precedence — both justified only by sustained
-add-model churn. The static guard + reconciler (§1) + the `tokenkey-onboard-model` skill
-cover the current cadence with full CI safety.
+`AccountRepository.BulkUpdate` (`backend/internal/repository/account_repo.go:1548`) merges
+credentials with PostgreSQL JSONB `||`:
 
-**Trigger condition (build the write-time validator + runtime pricing when ALL hold):**
+```go
+setClauses = append(setClauses,
+  "credentials = COALESCE(credentials, '{}'::jsonb) || $N::jsonb")
+```
 
-- Models are added to the manifest at a rate of **≥ 1/week sustained over a rolling
-  month** (4+ adds in 30 days). Measure from `git log` on `tk_served_models.json` +
-  `tk_pricing_overlay.json`.
-- AND at least one of those adds was a **video model** (the refund-safety arm is the
-  expensive part; if all adds are chat/overlay-priced the skill suffices indefinitely).
-- AND a release-cadence pain signal exists: an add was blocked or delayed waiting on a
-  release window (recorded in the onboarding skill's run log).
+`||` is a **top-level shallow** merge: writing `{"model_mapping": {...}}` **REPLACES the
+whole `model_mapping` sub-object**, it does not deep-merge entries into it. So the only
+write primitive available cannot do add-only grow — it clobbers. A reconciler built on it
+would either (a) read-modify-write the full union each tick (re-introducing the read-state
+trust problem and a write-thrash race with concurrent admin edits), or (b) replace and
+silently **drop operator-added ids** — a §5.x silent-deletion violation. And the values in
+`model_mapping` are **rename targets**, not boolean flags, so a generic "merge flags"
+primitive does not even model the data correctly.
 
-Until then, "add a model" = manifest PR + overlay/channel price + (`tk_029`-style migration
-OR the reconciler once it ships) — a normal reviewed release. **The skill suffices.**
+### 1.4 Cost/benefit — it is more work for less than assumed
 
----
+Estimated **3–5 days** (reconciler + canonical derivation + wire DI + cleanup edge +
+sentinel + tests, per the prior §3 checklist) for a feature that, because of Reason 1,
+**earns less than assumed**: empty-mapping accounts already serve new models for free, so
+the reconciler's net effect on a well-run account is to *restrict*, not enable. The honest
+verdict: the reconciler solves a problem the allow-all primitive already solves, while
+adding an inversion footgun, a polluted-snapshot risk, and a clobbering write.
 
-## 3. Mechanical add-a-reconciler checklist (8 steps)
+## 2. The safe alternative (already shipped, human-in-the-loop)
 
-The exact steps to land `NewAPIServedModelsReconciler`, each anchored to where the
-antigravity reconciler does the same thing. This is the future implementer's recipe.
+Adding a newapi model stays a small reviewed action, not an autonomous loop:
 
-1. **Reconciler file** — new `backend/internal/service/newapi_served_models_reconciler.go`,
-   structured as a copy of `antigravity_config_reconciler.go`: Redis leader-lock
-   (`newapi:served:reconciler:leader`, compare-and-delete release script,
-   `antigravity_config_reconciler.go:57-62`), ticker + **immediate boot pass**
-   (`Start()` runs `runOnceLocked()` before the loop, `:145-164`), `Stop()` via
-   `stopOnce`/`wg` (`:168-176`). Narrow store interface
-   `{ ListByPlatform; BulkUpdate }` (`:67-70`) so `runOnce` is unit-testable without a
-   full repo stub. Converge logic is **union, not replace** (§1.3).
+1. **Discovery** — the admin "fetch upstream models" button surfaces the upstream list run
+   through `DiscoveryFilter` (`discover_filter_tk.go`), which drops explicitly-unavailable /
+   `unreachable` ids and tags the rest `priced | missing`. A human reads the badges and
+   **confirms** — upstream is a suggestion, never an auto-apply.
+2. **Onboard** — the `tokenkey-onboard-model` skill (#820) drives the add: map the id onto
+   the account (migration or admin-UI edit), ensure a price exists (overlay 固化 or
+   `channel_model_pricing` 热更), update the manifest intent row.
+3. **Gate** — `scripts/checks/catalog-serving-drift.py` (#819) hard-fails CI if the result
+   drifts: A1 price-resolvable, A2 display⇒Go map, A3 served_on⇒migration-mapped (the #812
+   catcher). The static guard is the mechanical safety net the reconciler was supposed to
+   provide — without the inversion, the pollution, or the clobber.
 
-2. **Canonical derivation** — add `NewAPIServedWhitelistFor(accountID int64) map[string]string`
-   to a domain/service file that `//go:embed`s `tk_served_models.json`. It parses the
-   manifest once (skip `_`-prefixed metadata keys, same as
-   `pricing_service_tk_overlay.go:70`) and returns the identity whitelist for that account.
-   This is the **single source** — no hand-kept second list (the `constants.go:160`
-   `buildGeminiOnly...` discipline).
+This keeps the SERVING fact owned by the per-account `model_mapping` and the human review
+gate intact, which is the SSOT invariant in
+`docs/approved/pricing-serving-single-source-of-truth.md`.
 
-3. **Config field + default** — add
-   `gateway.scheduling.newapi_served_models_reconciler_interval_seconds` to the config
-   struct (beside `AntigravityConfigReconcilerIntervalSeconds`, `config.go:1181`) and
-   register `viper.SetDefault("gateway.scheduling.newapi_served_models_reconciler_interval_seconds", 300)`
-   (beside `config.go:2091`). `<=0` disables the goroutine (`tickInterval()` at
-   `:124-133`).
+## 3. What about true-runtime (no-release) onboarding?
 
-4. **Provider** — add `ProvideNewAPIServedModelsReconciler(accountRepo AccountRepository,
-   cfg *config.Config, redisClient *redis.Client) *NewAPIServedModelsReconciler` to
-   `service/wire.go`, modeled on `ProvideAntigravityConfigReconciler` (`wire.go:278-287`):
-   construct, `rec.Start()`, return.
+Whitelisting an id still costs a migration-or-admin-edit, and its price still costs an
+overlay rebuild **unless** the price is hot-added via `channel_model_pricing`. The path to
+true-runtime onboarding is **not** this reconciler — it is the staged ② runtime-pricing
+track, which is blocked on a refund-safety gate. See
+`docs/approved/channel-pricing-refund-gate-and-runtime-pricing.md` (PR-A gate, then
+② runtime pricing, then the deploy-ordering hazard). The reconciler does nothing to unblock
+that track and is not a prerequisite for it.
 
-5. **ProviderSet registration** — add `ProvideNewAPIServedModelsReconciler,` to
-   `service.ProviderSet` (the `wire.NewSet(...)` block, beside
-   `ProvideAntigravityConfigReconciler,` at `wire.go:645`).
+## 4. Out of scope (unchanged)
 
-6. **Cleanup edge** — add a `*service.NewAPIServedModelsReconciler` parameter to
-   `provideCleanup` in `cmd/server/wire.go` (beside `antigravityConfigReconciler` at
-   `cmd/server/wire.go:92`) AND a parallel `cleanupStep` that calls `.Stop()` (beside the
-   `AntigravityConfigReconciler` step at `cmd/server/wire.go:218-223`). This is what forces
-   wire to evaluate the side-effect provider; without the cleanup edge wire dead-codes a
-   side-effect-only service.
-
-7. **Regenerate + sentinel** — run `go generate ./cmd/server` (regenerate `wire_gen.go`;
-   committing generated churn is expected per CLAUDE.md §2/§5). Then **add a sentinel
-   entry** to `scripts/sentinels/newapi.json` pinning the new reconciler file and its
-   load-bearing symbols (`ListByPlatform(ctx, PlatformNewAPI)`,
-   `NewAPIServedWhitelistFor`, the union-not-replace marker) AND a `service/wire.go`
-   `must_contain` of `ProvideNewAPIServedModelsReconciler,` (mirroring the existing
-   `ProvideUpstreamBalanceSentinel,` sentinel at `newapi.json` lines 418-423 — guards the
-   side-effect ProviderSet member that fails silently if an upstream merge drops it). The
-   registry-update gate (`check-registry-update-gate.py`) requires this in the same PR.
-
-8. **Unit test via narrow-interface fakes** — `newapi_served_models_reconciler_test.go`
-   calling `runOnce(ctx)` directly with a fake store satisfying
-   `{ ListByPlatform; BulkUpdate }`. Cases: (a) account missing a desired key ⇒ BulkUpdate
-   called with the union; (b) account already a superset ⇒ no BulkUpdate (skip-if-aligned);
-   (c) operator-added extra key is preserved (union, not replace — the §1.3 invariant);
-   (d) non-39/60 newapi account untouched; (e) empty manifest ⇒ no-op. Run with
-   `go test -tags=unit ./internal/service/ -run Reconciler`. Then `scripts/preflight.sh`
-   for the sentinel + registry-update gates, and a full `go test -tags=unit ./...`
-   (per the local-scope discipline: never just the service package).
-
----
-
-## 4. Out of scope (recorded so the boundary is explicit)
-
-- **The four native platforms** (anthropic/openai/gemini/antigravity) — they have Go
-  servable-allowlist maps in `pricing_catalog_supported_models_tk.go` and the
-  `tokenkey-servable-model-refresh` flow; the manifest's `display` field is reserved for a
-  future curated newapi map but is `false` for every seed entry (newapi has no map; the
-  public catalog renders these via price-presence passthrough).
+- **The four native platforms** (anthropic/openai/gemini/antigravity) — Go servable-
+  allowlist maps in `pricing_catalog_supported_models_tk.go` + `tokenkey-servable-model-
+  refresh`. Not governed by 39/60 `model_mapping`.
 - **grok** — native seventh platform (#791), served by platform routing + ch48 API-key
-  relay, not by a 39/60 `model_mapping`. `grok-*` overlay rows are out of this manifest's
-  mechanism by construction.
-- **The runtime ops scan** (live `accounts.credentials.model_mapping` on prod 39/60 vs
-  manifest) — that is a read-only observability check
+  relay, not a 39/60 `model_mapping`.
+- **The runtime ops scan** — read-only observability
   (`SELECT id, credentials->'model_mapping' FROM accounts WHERE id IN (39,60) AND
-  deleted_at IS NULL`, note the soft-delete filter), never a PR gate. The static guard
-  proves intent↔price↔(migration|reconciler) agree in the repo; the ops scan proves the
-  repo agrees with live prod. Design-only here.
+  deleted_at IS NULL`), never a PR gate. Confirms repo intent matches live prod; not a
+  reconciler.

--- a/docs/approved/pricing-serving-single-source-of-truth.md
+++ b/docs/approved/pricing-serving-single-source-of-truth.md
@@ -1,0 +1,166 @@
+---
+title: Pricing & Serving — One Owner Per Fact (consolidated SSOT decision)
+status: approved
+approved_by: "xuejiao (design directive, this session)"
+approved_at: "2026-06-17"
+authors: [agent]
+created: 2026-06-17
+related_prs: []
+related_commits: []
+related_stories: []
+related_design: docs/approved/newapi-as-fifth-platform.md, docs/approved/pricing-availability-source-of-truth.md, docs/approved/newapi-served-models-reconciler.md, docs/approved/channel-pricing-refund-gate-and-runtime-pricing.md
+supersedes: none
+---
+
+# Pricing & Serving — One Owner Per Fact
+
+> **The SSOT verdict is ONE OWNER PER FACT, not "collapse everything to upstream."**
+> Two facts govern whether a model works in TokenKey, and they have two different owners:
+> **SERVING** (does this account serve this id?) and **PRICE** (what does it cost?).
+> Every drift incident in this area traces back to a third party silently claiming
+> ownership of one of those facts. This doc names the owners, rejects the two tempting
+> wrong answers, and maps the remaining work.
+
+## 1. The two facts and their owners
+
+| Fact | Question | OWNER (single source) | Thin projection / cache |
+| --- | --- | --- | --- |
+| **SERVING** | Does account N serve client-id `m`? | per-account `credentials.model_mapping` (identity whitelist `key==value`) | `tk_served_models.json` manifest — CI-time **intent** projection only, NOT runtime |
+| **PRICE** | What does `m` cost? | two-tier: `tk_pricing_overlay.json` (gated/固化) **+** `channel_model_pricing` DB (ungated/热更) | litellm-base mirror + Go fallback |
+
+**Price precedence (highest wins):**
+
+```
+channel_model_pricing (DB, raw-SQL resolver)   ← WINS over everything
+  > tk_pricing_overlay.json                     ← fill-only, never overrides a DB row
+    > litellm-base mirror
+      > Go in-code fallback
+```
+
+The overlay header states this literally (`pricing_service_tk_overlay.go:32-33`):
+*"The DB-backed ModelPricing override (model_pricing_resolver.go) still sits above
+everything."* That sentence is the whole reason PRICE has **two** writers.
+
+**Serving owner is genuinely per-account.** `Account.IsModelSupported`
+(`backend/internal/service/account.go:639`) returns `true` on an **empty** mapping —
+"无映射 = 允许所有" — for every non-antigravity platform. A populated `model_mapping` is an
+identity WHITELIST; an empty one is allow-all. This asymmetry is load-bearing for §2's
+rejection of an auto-sync reconciler and is documented in
+`docs/approved/newapi-served-models-reconciler.md`.
+
+## 2. Two wrong answers we explicitly REJECT
+
+### REJECTED: "align the whitelist to the overlay"
+
+The overlay is a PRICE source. Letting price-presence imply serving (auto-mapping every
+priced id onto an account) inverts the fact ownership: it makes the PRICE owner silently
+write the SERVING fact. This is exactly the #812-class confusion — `qwen3-8b/14b/32b` were
+priced in the overlay but not mapped onto account 60, and the price-present-looks-served
+illusion produced `429`/`503` in prod. The fix is **not** to let the price drag serving
+along; it is to keep them separate facts and let a guard assert they agree
+(A1/A3 below, shipped in #819).
+
+### REJECTED: "converge everything to upstream capability"
+
+Tempting because upstream `/v1/models` *looks* authoritative. It is not a source of truth —
+it is an **unvetted discovery feed** (`docs/approved/pricing-availability-source-of-truth.md`
+§2.4 / R-002). It over-reports:
+
+- deprecated / retired / disabled ids the operator must not serve,
+- served-but-unpriced ids (a money hole if auto-onboarded),
+- embedding-only ids that have no chat surface.
+
+`FetchUpstreamSupportedModels` (`backend/internal/service/upstream_models.go:76`) returns a
+bare `[]string` — no pricing tag, no availability tag — and is deliberately **NOT wired**
+to `DiscoveryFilter`. The discovery filter
+(`backend/internal/integration/newapi/discover_filter_tk.go`) treats the upstream list as a
+**weak suggestion** requiring human confirm: it drops explicitly-unavailable ids, drops
+`model_availability='unreachable'` ids, and tags the rest `priced | missing` so a human sees
+the gap. Converging serving to upstream would re-import every over-report and re-open the
+money hole. **Upstream is a feed into a human decision, never the decision.**
+
+## 3. What is already shipped (do not re-litigate)
+
+| PR | What landed | SSOT role |
+| --- | --- | --- |
+| **#818** | `tk_029` maps `qwen3-8b/14b/32b` onto account 60 | point-fix the #812 serving gap |
+| **#819** | `scripts/checks/catalog-serving-drift.py` (A1/A2/A3) + `tk_served_models.json` manifest (13 entries) | mechanical drift guard + intent projection |
+| **#820** | `tokenkey-onboard-model` skill + dashscope probe | the human-in-the-loop onboarding mechanism |
+
+The **#812-class drift is now mechanically blocked** by the #819 guard's three assertions:
+
+- **A1** — every catalog/manifest id is **price-resolvable** (price owner agrees).
+- **A2** — `display=true` ⇒ present in the Go servable map (display agrees with code).
+- **A3** — `served_on` ⇒ a migration maps it onto the account (serving owner agrees).
+
+A3 is the specific catcher for #812: a manifest row claiming an account serves an id, with
+no migration putting it there, hard-fails CI. The manifest is **NOT** `//go:embed`-ed — it
+is CI-time intent only; runtime serving still comes from the per-account `model_mapping`,
+which keeps the owner single.
+
+## 4. Remaining work (mapped, not all in this batch)
+
+| Track | What | Owner-fact it closes | Status |
+| --- | --- | --- | --- |
+| **FE catalog (PR-B)** | newapi whitelist picker offers the served long-tail (qwen3 dense ids) | SERVING fact *offerable* in admin UI | **this batch (PR-B)** |
+| **channel-pricing refund gate** | new columns + write-time validator on `channel_model_pricing` | would make the **PRICE** fact have ONE *enforced* owner across **both** writers | **DEFERRED into ②** — investigated, no live leak today (§4.1) |
+| **② runtime pricing** | route new long-tail prices to `channel_model_pricing` so onboarding needs no release | true-runtime PRICE; **builds the gate as part of itself** | **staged-next** (deploy-ordering hazard documented) |
+
+See `docs/approved/channel-pricing-refund-gate-and-runtime-pricing.md` for the full gate +
+② design and the investigation below.
+
+### 4.1 The channel-pricing "hole" — investigated, found INERT today (no live leak)
+
+The prior framing of this work called `channel_model_pricing` "the real remaining money
+hole": it **WINS** precedence and **bypasses** the overlay's preflight refund gate
+(`scripts/checks/pricing-overlay.py` runs CI-only against the JSON, never a DB write). The
+precedence + bypass are real. **But a direct code read retracts the "live money-leak"
+claim** — the dangerous write (an ungated *video* price re-enabling the terminal-failure
+refund leak) is **structurally unreachable** through `channel_model_pricing` today:
+
+1. **No column.** `ChannelModelPricing` (`channel.go:75`) has `input/output/cache_write/
+   cache_read/image_output/per_request` price fields only — **no `output_cost_per_second`,
+   no `failure_billing`, no thinking field.**
+2. **No billing mode.** `BillingMode` has `token / per_request / image` — **no `video`.**
+3. **No resolver branch.** `ModelPricingResolver` (`model_pricing_resolver.go:75,139`) routes
+   only `token / per_request / image`; `ResolvedPricing` (`:16`) has **no per-second field**.
+4. **Video cost is overlay-only.** `billing_service.go:976` reads `pricing.OutputCostPerSecond`
+   from the overlay/litellm `ModelPricing` (`pricing_service.go:84`) — which
+   `pricing-overlay.py` **already gates**. The video refund
+   (`openai_gateway_service_tk_video_refund.go`) reverses that overlay-derived cost. A
+   `channel_model_pricing` row never feeds video cost or its refund. Thinking rate is the
+   same story: `ThinkingOutputPricePerToken` is sourced only from litellm/overlay
+   (`billing_service.go:412`), never from a channel row.
+
+So the only price dimensions `channel_model_pricing` can actually carry are
+`token / per_request / image`, and for those the existing admin validator already enforces
+*mode-has-price* / *non-negative* / *intervals-have-prices* (`channel_service.go:613`). The
+single ungated residue is an **undercharging $0 token price** (a revenue guardrail, not a
+refund leak). **Conclusion: there is no live channel-pricing refund leak; the refund-safety
+gate is not urgent and is folded into ②**, where channel pricing first *gains* the
+video/per-second + thinking resolver paths and the gate's invariants become load-bearing
+together with them. A prototype gate (3 columns + write-time validator + 15/15 unit tests)
+was built and verified this session as proof it is implementable; it is intentionally **not
+shipped standalone** to avoid freezing dead columns into the live schema (migration
+immutability) ahead of the resolver work that makes them load-bearing.
+
+## 5. The real FE gap (one, and it is narrow)
+
+The admin-UI "drops qwen3-8b" claim is a **phantom** for account 60: pure-identity
+whitelists round-trip intact, out-of-catalog ids render as removable chips from
+`props.modelValue` and survive a save, and `addCustom` is a zero-validation escape hatch.
+The single real gap is the **picker offer set**: the newapi selector is hardcoded
+`platform='newapi'` → `newapiModels` (`frontend/src/composables/useModelWhitelist.ts`),
+which was **GPT-only**. A separate `qwenModels` array exists but is reachable only for
+`platform==='qwen'`, never for `newapi`, and it too lacked the three dense ids. So the picker
+could not *offer* `qwen3-8b/14b/32b` — an operator had to use the `addCustom` escape hatch.
+**PR-B (this batch)** teaches the newapi picker to offer the served long-tail; the deeper
+convergence (derive the picker from the backend manifest via a servable endpoint, like
+`useServableModels` for the API-backed platforms) is a follow-on, not done here.
+
+## 6. The one-line test for any future change here
+
+Before adding code, ask: **which of the two facts does this write, and is it the owner?**
+If a change makes the PRICE source write SERVING, or makes upstream `/v1/models` write
+either, it is the wrong primitive — stop. Every incident in this area is a third party
+quietly claiming a fact it does not own.


### PR DESCRIPTION
## 背景

承接 #818/#819/#820(pricing/serving SSOT 三件套已合并)。本 PR 固化收敛后的整体设计,并**纠正两处由直接读代码发现的判断错误**。docs-only,无代码改动。

## 三篇 docs

1. **`pricing-serving-single-source-of-truth.md`(新增)** — SSOT 的结论是 **one owner per fact**,不是"万物归一到上游":
   - SERVING owner = 每账号 `credentials.model_mapping`(manifest 只是 CI-time intent,非 runtime);PRICE owner = overlay(固化)+ `channel_model_pricing` DB(热更)。
   - 明确**否决**两条诱人错路:①把白名单对齐 overlay(让 price 写 serving)②把 serving 收敛到上游 `/v1/models`(未经审核的 discovery feed,over-report,R-002)。
   - A3 已机械封死 #812 类漂移。

2. **`channel-pricing-refund-gate-and-runtime-pricing.md`(新增)** — **撤回**上一轮"channel pricing 是 live 视频退款漏洞"的判断。直接读代码证明:`channel_model_pricing` **结构上无法承载** video/per-second/thinking 价(`ChannelModelPricing` 无对应列、`BillingMode` 无 video、resolver 无 per-second 分支;视频成本+退款只走 overlay,已被 `pricing-overlay.py` 守住)。因此退款安全门**不紧急,折叠进 ②(runtime pricing)**——届时 channel writer 才真正获得这些价维度,门的不变量才 load-bearing。门已做出 prototype(3 列 + 写时校验 + 15/15 单测通过)证明可实现,**故意不单发**以免把死列冻进 live schema。

3. **`newapi-served-models-reconciler.md`(更新)** — 由"approved design, deferred"翻成"**决定不建**无人值守 auto-sync reconciler":newapi 空 mapping = allow-all(自动填充反而收窄)、上游 over-report、`BulkUpdate` JSONB `||` 是 add-only 的错原语。安全替代 = admin discovery 按钮 + onboard-model skill + #819 guard。

## 取舍说明(给 reviewer)

- 原计划的 **PR-A(channel-pricing 退款门代码)不发**:对抗评审 + 直接读代码证明其"堵视频漏洞"立论为假,且会加两个没人读的死列(failure_billing / thinking)。gate 随 ② 落地。
- 配套 **PR-B**(前端 newapi picker offer qwen3 dense)单独提。

## checklist
- [x] docs-only,`no-web-impact`
- [x] approved-doc R1-R5 通过(status: approved,approved_by 非 pending)
- [x] 本地 `scripts/preflight.sh` PASS
- [x] commit message 无 bracketed skip-ci

🤖 Generated with [Claude Code](https://claude.com/claude-code)
