### PR TITLE
feat(admin): newapi model-whitelist picker offers qwen3 dense ids

### DIFF
--- a/backend/internal/web/dist/frontend-source.json
+++ b/backend/internal/web/dist/frontend-source.json
@@ -1,7 +1,7 @@
 {
   "algorithm": "sha256(git-ls-files:path,size,content)",
   "file_count": 486,
-  "hash": "623a851c12aeb628d0695eb008948898d8bea7d5c9cd14dbb02a26dc88a9d25a",
+  "hash": "20b6c49d9b671bcf431f8417d99c8d46e0ad94002ebd5f8ceaae767cb61195a8",
   "schema": 1,
   "source": "frontend/"
 }

--- a/frontend/src/composables/__tests__/useModelWhitelist.spec.ts
+++ b/frontend/src/composables/__tests__/useModelWhitelist.spec.ts
@@ -36,9 +36,24 @@ describe('useModelWhitelist', () => {
     expect(newapiModels).toContain('gpt-5.3-codex-spark')
   })
 
+  it('newapi picker offers the qwen3 dense ids (PR-B: dropdown discoverability)', () => {
+    // The newapi modal hardcodes platform='newapi', so the dropdown reads this
+    // list — before PR-B it was GPT-only and these three dense ids could only
+    // be added via the custom-model input (the drop itself was phantom).
+    // INTERIM truth lives in tk_served_models.json (backend manifest); PR-C
+    // will derive this list from a servable endpoint.
+    const newapiModels = getModelsByPlatform('newapi')
+    expect(newapiModels).toContain('qwen3-8b')
+    expect(newapiModels).toContain('qwen3-14b')
+    expect(newapiModels).toContain('qwen3-32b')
+  })
+
   it('long-tail direct providers keep static lists', () => {
     expect(getModelsByPlatform('deepseek').length).toBeGreaterThan(0)
-    expect(getModelsByPlatform('qwen').length).toBeGreaterThan(0)
+    const qwen = getModelsByPlatform('qwen')
+    expect(qwen.length).toBeGreaterThan(0)
+    // dense ids are also offered on the direct qwen platform
+    expect(qwen).toContain('qwen3-32b')
   })
 
   it('unknown platform yields an empty list (custom input is the escape hatch)', () => {

--- a/frontend/src/composables/useModelWhitelist.ts
+++ b/frontend/src/composables/useModelWhitelist.ts
@@ -9,8 +9,23 @@
 // Only newapi (channel-driven) and the long-tail direct providers below keep
 // static lists (the backend has no empirical source for those).
 
+// Qwen3 dense（非 MoE）instruct ids —— 经 newapi channel（如 dashscope /
+// 兼容聚合器）实际可服务的稠密档位。单独成组，便于同时喂给 newapi 与直连
+// qwen 两个 picker，且与 qwenModels 里已有的 MoE 档（qwen3-235b-a22b）/ qwq
+// 不重复。
+const qwen3DenseModels = [
+  'qwen3-8b', 'qwen3-14b', 'qwen3-32b'
+]
+
 // NewAPI（第五平台）—— 独立维护白名单，不与 openai 共享同一数组引用。
-// 当前内容与 openai 基本对齐，后续允许按 newapi 供应侧单独演进。
+// 当前内容与 openai 基本对齐，外加 newapi channel 侧实际可服务的 qwen3 稠密档
+// （qwen3-8b/14b/32b），后续允许按 newapi 供应侧单独演进。
+//
+// INTERIM（PR-B）：这份静态列表只是过渡形态。最终单一真值是后端 manifest
+// backend/internal/service/tk_served_models.json —— FE picker 应经一个
+// servable endpoint 从该 manifest 派生 newapi 候选模型（PR-C 的 follow-on，
+// 与 API-backed 平台经 useServableModels 自愈同构）。在那之前，新增 newapi
+// 可服务模型需手工补到这里。
 const newapiModels = [
   'gpt-3.5-turbo', 'gpt-3.5-turbo-0125', 'gpt-3.5-turbo-1106', 'gpt-3.5-turbo-16k',
   'gpt-4', 'gpt-4-turbo', 'gpt-4-turbo-preview',
@@ -27,7 +42,9 @@ const newapiModels = [
   'gpt-5.3-codex', 'gpt-5.3-codex-spark',
   'gpt-4o-audio-preview', 'gpt-4o-realtime-preview',
   // GPT Image 系列
-  'gpt-image-1', 'gpt-image-1.5', 'gpt-image-2'
+  'gpt-image-1', 'gpt-image-1.5', 'gpt-image-2',
+  // Qwen3 稠密档（经 newapi channel 可服务）
+  ...qwen3DenseModels
 ]
 
 // (claudeModels / geminiModels / antigravityModels removed — see the note above;
@@ -51,6 +68,7 @@ const qwenModels = [
   'qwen2.5-7b-instruct', 'qwen2.5-3b-instruct', 'qwen2.5-1.5b-instruct',
   'qwen2.5-coder-32b-instruct', 'qwen2.5-coder-14b-instruct', 'qwen2.5-coder-7b-instruct',
   'qwen3-235b-a22b',
+  ...qwen3DenseModels,
   'qwq-32b', 'qwq-32b-preview'
 ]
 


### PR DESCRIPTION
## 背景

承接 #818/#819/#820。落实"治本:让 qwen3-8b/14b/32b 进 catalog(UI 认、不会丢)"。

## 问题

newapi 账号的模型白名单选择器硬编码 `platform='newapi'`,下拉读静态 `newapiModels`(GPT-only)。account 60 上由 #818/tk_029 映射、#819 manifest 收录的三个 Qwen3 稠密档(qwen3-8b/14b/32b),此前**只能用 addCustom 手输**——下拉从不提供。

> 顺带澄清:之前担心的"UI 编辑保存会丢这三个"是 **phantom**。account 60 是纯 identity 白名单,round-trip 完整保留;catalog 外的 id 也以 chip 形式留存。所以这是**可发现性**缺口,不是数据丢失。

## 改动

- `useModelWhitelist.ts`:新增 `qwen3DenseModels = [qwen3-8b/14b/32b]`,spread 进 `newapiModels` 与 `qwenModels`。不动 `.vue`。
- 注释标明这是**过渡静态表**,最终单一源是后端 manifest `tk_served_models.json`,后续经 servable endpoint 派生(follow-on,见 #825 的 SSOT doc §5)。
- spec:断言两个 picker 都提供这三个 id(**11/11 green**)。
- `pnpm build` 重生嵌入式 dist 的 `frontend-source.json`(dist assets 本身 gitignored,Docker build 时从源码重建)。

## 门禁说明

**sentinel-registry-reviewed**: `useModelWhitelist.ts` 被 `scripts/sentinels/newapi.json` pin。本次仅在文件上部新增数组项 + 注释,`newapi.json` 的 5 个 must_contain anchor(`normalizeModelID` / `allowedModels: unknown[]` / `const model = normalizeModelID(item)` / `isApiBackedPlatform(platform)` / `return servableModelsFor(platform) ?? []`)**全部未触碰、依旧成立**,无需新增/修改 anchor。故以此 marker 确认 surface 已审、覆盖完整。

## checklist
- [x] `pnpm build` 通过(vue-tsc + vite build + manifest --write)
- [x] vitest `useModelWhitelist.spec.ts` 11/11 通过
- [x] frontend-dist-freshness manifest 已刷新
- [x] 本地 `scripts/preflight.sh` PASS
- [x] 纯前端 TK composable,纯插入语义 → 无需 upstream-override marker
- [x] sentinel-registry-reviewed(见上,5 anchor 完整)
- [x] commit message 无 bracketed skip-ci

🤖 Generated with [Claude Code](https://claude.com/claude-code)
