### PR TITLE
fix(ops): own empty-body upstream 404 (not_found_error) to client, out of upstream_error_rate

### DIFF
--- a/backend/internal/handler/ops_error_logger.go
+++ b/backend/internal/handler/ops_error_logger.go
@@ -1319,7 +1319,7 @@ func classifyOpsErrorLog(c *gin.Context, errType, message, code string, status i
 	// it as upstream/provider, so it stays OUT of upstream_error_rate and the
 	// provider-health P0 capacity alert. See tkUpstreamClientInducedRejection
 	// (prod P0 2026-06-05; mirrors the #602 amplifier boundary).
-	clientInducedUpstream := upstreamError && tkUpstreamClientInducedRejection(c)
+	clientInducedUpstream := upstreamError && tkUpstreamClientInducedRejection(c, errType)
 	// TK (issue #625): a client/caller disconnect mid-flight surfaces as an upstream
 	// transport error with NO upstream HTTP status (context canceled). It is
 	// caller-fault, not provider health — own it to the client so one canceling

--- a/backend/internal/handler/ops_error_logger_tk_client_induced_upstream.go
+++ b/backend/internal/handler/ops_error_logger_tk_client_induced_upstream.go
@@ -34,7 +34,7 @@ import (
 // the account-level 4xx signals (organization disabled / credit balance exhausted /
 // identity verification required) are NOT — they stay provider-owned because they
 // genuinely report account health and SHOULD keep counting toward upstream_error_rate.
-func tkUpstreamClientInducedRejection(c *gin.Context) bool {
+func tkUpstreamClientInducedRejection(c *gin.Context, clientErrType string) bool {
 	status := tkOpsUpstreamStatusCode(c)
 	// 413 request_too_large is always caller-fault: the body cleared TokenKey's
 	// local body-limit middleware (handler.request_body_limit) but exceeded the
@@ -53,7 +53,30 @@ func tkUpstreamClientInducedRejection(c *gin.Context) bool {
 	if status == 404 {
 		body, msg := tkOpsUpstreamErrorText(c)
 		combined := strings.ToLower(strings.TrimSpace(msg + "\n" + body))
-		if combined == "" || tkOpsIsAccountLevel4xx(combined) {
+		// Account-health 4xx phrases (org disabled / credit balance / identity)
+		// keep provider ownership even when wrapped in a 404 envelope.
+		if tkOpsIsAccountLevel4xx(combined) {
+			return false
+		}
+		// Positive client-facing signal: the gateway already translated this
+		// upstream 404 into a not_found_error for the caller (openai
+		// service.handleErrorResponse case 404; anthropic "Unsupported model"
+		// short-circuit). A 404 is structurally model/endpoint-not-found — the
+		// caller asked for something that does not exist — so own it to the client
+		// even when the upstream returned NO error body for the predicates below to
+		// re-confirm. Prod us3 2026-06-17 (upstream_error_rate=97% false P0): a
+		// client hammered gpt-5.5-pro on /v1/responses against a ChatGPT-OAuth
+		// (Codex) account that cannot serve it; the ChatGPT backend answered a bare
+		// 404 with an empty body, so combined=="" and — under the old
+		// `combined=="" -> return false` — every one of the 1604 requests defaulted
+		// to phase=upstream / error_owner=provider. The client-facing type is the
+		// drift-proof signal here: a masked 404 (ShouldHandleErrorCode=false ->
+		// "upstream_error", or a passthrough rule) is NOT not_found_error and stays
+		// provider, preserving the "generic 404 stays provider" contract.
+		if clientErrType == "not_found_error" {
+			return true
+		}
+		if combined == "" {
 			return false
 		}
 		// Reuse the SAME predicates the gateway uses so this metric classification

--- a/backend/internal/handler/ops_error_logger_tk_client_induced_upstream.go
+++ b/backend/internal/handler/ops_error_logger_tk_client_induced_upstream.go
@@ -60,11 +60,15 @@ func tkUpstreamClientInducedRejection(c *gin.Context, clientErrType string) bool
 		}
 		// Positive client-facing signal: the gateway already translated this
 		// upstream 404 into a not_found_error for the caller (openai
-		// service.handleErrorResponse case 404; anthropic "Unsupported model"
-		// short-circuit). A 404 is structurally model/endpoint-not-found — the
-		// caller asked for something that does not exist — so own it to the client
-		// even when the upstream returned NO error body for the predicates below to
-		// re-confirm. Prod us3 2026-06-17 (upstream_error_rate=97% false P0): a
+		// service.handleErrorResponse case 404). A 404 is structurally
+		// model/endpoint-not-found — the caller asked for something that does not
+		// exist — so own it to the client even when the upstream returned NO error
+		// body for the predicates below to re-confirm. (The anthropic
+		// Unsupported-model path emits invalid_request_error, NOT not_found_error,
+		// and is already owned via the IsAnthropicModelNotFound404 body predicate
+		// below — it does not use this branch; this branch is the openai
+		// /v1/responses empty-body case where that predicate sees "".)
+		// Prod us3 2026-06-17 (upstream_error_rate=97% false P0): a
 		// client hammered gpt-5.5-pro on /v1/responses against a ChatGPT-OAuth
 		// (Codex) account that cannot serve it; the ChatGPT backend answered a bare
 		// 404 with an empty body, so combined=="" and — under the old

--- a/backend/internal/handler/ops_error_logger_tk_client_induced_upstream_test.go
+++ b/backend/internal/handler/ops_error_logger_tk_client_induced_upstream_test.go
@@ -189,6 +189,50 @@ func TestClassifyOpsUpstreamClientInducedRejectionOwnedByClient(t *testing.T) {
 		require.Equal(t, "request", phase, "availability-gating 404 must be client-owned, out of upstream_error_rate")
 		require.Equal(t, "client", errorOwner, "must NOT be provider — otherwise it re-fires the us7 false P0")
 	})
+
+	// TK (prod us3 P0 2026-06-17, upstream_error_rate=97% false page): a client
+	// hammered gpt-5.5-pro on /v1/responses (1604× in 5 min) against a
+	// ChatGPT-OAuth (Codex) account that cannot serve that model. The ChatGPT
+	// backend answered a bare 404 with an EMPTY error body, so the upstream
+	// message/body captured on the context is "". The gateway still passed it
+	// through to the caller as not_found_error (handleErrorResponse case 404), but
+	// the empty body meant the IsAnthropicModelNotFound404 / IsOpenAICompatModelNotFound404
+	// predicates saw "" and — under the old `combined=="" -> return false` — the
+	// 404 defaulted to phase=upstream / error_owner=provider, flooding
+	// upstream_error_rate. The client-facing not_found_error type is the
+	// drift-proof signal: a 404 the gateway owned as not-found is caller-fault even
+	// with no upstream body to re-confirm.
+	t.Run("openai /v1/responses 404 with EMPTY upstream body but client-facing not_found_error is client-induced", func(t *testing.T) {
+		rec := httptest.NewRecorder()
+		c, _ := gin.CreateTestContext(rec)
+		// Production shape: only the upstream STATUS is captured; no message, no body.
+		c.Set(service.OpsUpstreamErrorsKey, []*service.OpsUpstreamErrorEvent{{
+			UpstreamStatusCode: http.StatusNotFound,
+		}})
+
+		phase, _, errorOwner, _ := classifyOpsErrorLog(c, "not_found_error", "Upstream rejected the request", "", http.StatusNotFound)
+
+		require.Equal(t, "request", phase, "empty-body 404 owned as not_found_error must be client-owned, out of upstream_error_rate")
+		require.Equal(t, "client", errorOwner, "must NOT be provider — otherwise it re-fires the us3 false P0")
+	})
+
+	// Guard the boundary: a 404 the gateway did NOT own as not-found (masked to a
+	// generic upstream_error via ShouldHandleErrorCode=false or a passthrough rule)
+	// with an empty upstream body stays provider — the empty-body default must only
+	// flip on the positive not_found_error signal, preserving the existing
+	// "generic 404 stays provider" contract for the masked path.
+	t.Run("openai 404 masked as upstream_error with empty body stays provider", func(t *testing.T) {
+		rec := httptest.NewRecorder()
+		c, _ := gin.CreateTestContext(rec)
+		c.Set(service.OpsUpstreamErrorsKey, []*service.OpsUpstreamErrorEvent{{
+			UpstreamStatusCode: http.StatusNotFound,
+		}})
+
+		phase, _, errorOwner, _ := classifyOpsErrorLog(c, "upstream_error", "Upstream gateway error", "", http.StatusInternalServerError)
+
+		require.Equal(t, "upstream", phase, "a masked 404 (upstream_error) with no not-found signal stays provider-owned")
+		require.Equal(t, "provider", errorOwner)
+	})
 }
 
 func TestClassifyOpsGenuineUpstreamErrorsStayProvider(t *testing.T) {

--- a/scripts/sentinels/gateway-tk.json
+++ b/scripts/sentinels/gateway-tk.json
@@ -2013,7 +2013,7 @@
     {
       "path": "backend/internal/handler/ops_error_logger_tk_client_induced_upstream.go",
       "must_contain": [
-        "func tkUpstreamClientInducedRejection(c *gin.Context) bool",
+        "func tkUpstreamClientInducedRejection(c *gin.Context, clientErrType string) bool",
         "func tkOpsIsAccountLevel4xx(lower string) bool",
         "if status == 413 {",
         "if status != 400 && status != 422 {",
@@ -2027,7 +2027,7 @@
       "path": "backend/internal/handler/ops_error_logger.go",
       "must_contain": [
         "routingCapacityLimited := isOpsRoutingCapacityLimited(c) || (upstreamError && tkUpstreamDownstreamCapacity(c))",
-        "clientInducedUpstream := upstreamError && tkUpstreamClientInducedRejection(c)",
+        "clientInducedUpstream := upstreamError && tkUpstreamClientInducedRejection(c, errType)",
         "clientCanceledUpstream := upstreamError && tkUpstreamClientCanceled(c)",
         "if upstreamError && !routingCapacityLimited && !clientInducedUpstream && !clientCanceledUpstream {",
         "if (clientInducedUpstream || clientCanceledUpstream) && !routingCapacityLimited {"
@@ -2085,9 +2085,10 @@
       "must_contain": [
         "if status == 404 {",
         "service.IsAnthropicModelNotFound404([]byte(body), msg)",
-        "if body == \"\" && strings.TrimSpace(events[i].Detail) != \"\" {"
+        "if body == \"\" && strings.TrimSpace(events[i].Detail) != \"\" {",
+        "if clientErrType == \"not_found_error\" {"
       ],
-      "rationale": "Path B metric truth (prod P0 2026-06-06, edge us5 upstream_error_rate=100%): an upstream 404 model-not-found is caller-fault, so tkUpstreamClientInducedRejection classifies it client-owned (phase=request) and it drops out of upstream_excl behind upstream_error_rate. It reuses the SAME service.IsAnthropicModelNotFound404 predicate as the gateway response path (B-2) so the metric classification can never drift from the client-facing 400 decision. The captured upstream status stays 404 even though the client gets a 400, so this MUST live in the classifier. An upstream merge that reverts the 404 branch to provider-owned re-fires the P0 on bad-model traffic; this sentinel pins the branch. THIRD anchor (us7 P0 2026-06-13, upstream_error_rate=48.57% false page): the 'never drift' guarantee held only while both layers saw the SAME bytes — but the Anthropic forward path records the upstream body in OpsUpstreamErrorEvent.Detail, not UpstreamResponseBody, so tkOpsUpstreamErrorText fed the predicate the human Message alone. Anthropic's availability-gating 404 ('Claude Fable 5 is not available. Please use Opus 4.8', envelope error.type=not_found_error) carries no error.type in the Message, so the predicate missed it and the 404 leaked to provider-owned while the gateway RESPONSE path (full body in hand) already returned a client 400. The Detail fallback restores input parity (Detail = same truncated body, gateway.log_upstream_error_body default true). Dropping it re-opens the message-only drift and re-fires the false P0 on any availability-gated model; this anchor pins the fallback read."
+      "rationale": "Path B metric truth (prod P0 2026-06-06, edge us5 upstream_error_rate=100%): an upstream 404 model-not-found is caller-fault, so tkUpstreamClientInducedRejection classifies it client-owned (phase=request) and it drops out of upstream_excl behind upstream_error_rate. It reuses the SAME service.IsAnthropicModelNotFound404 predicate as the gateway response path (B-2) so the metric classification can never drift from the client-facing 400 decision. The captured upstream status stays 404 even though the client gets a 400, so this MUST live in the classifier. An upstream merge that reverts the 404 branch to provider-owned re-fires the P0 on bad-model traffic; this sentinel pins the branch. THIRD anchor (us7 P0 2026-06-13, upstream_error_rate=48.57% false page): the 'never drift' guarantee held only while both layers saw the SAME bytes — but the Anthropic forward path records the upstream body in OpsUpstreamErrorEvent.Detail, not UpstreamResponseBody, so tkOpsUpstreamErrorText fed the predicate the human Message alone. Anthropic's availability-gating 404 ('Claude Fable 5 is not available. Please use Opus 4.8', envelope error.type=not_found_error) carries no error.type in the Message, so the predicate missed it and the 404 leaked to provider-owned while the gateway RESPONSE path (full body in hand) already returned a client 400. The Detail fallback restores input parity (Detail = same truncated body, gateway.log_upstream_error_body default true). Dropping it re-opens the message-only drift and re-fires the false P0 on any availability-gated model; this anchor pins the fallback read. FOURTH anchor (prod us3 P0 2026-06-17, upstream_error_rate=97% false page): a client hammered gpt-5.5-pro on /v1/responses (1604x in ~5min) routed via the openai-us3 mirror to a ChatGPT-OAuth account in a transient ~8min model-404 blip; the ChatGPT backend returned a bare 404 with an EMPTY body, so both predicates saw '' and the old `combined=='' -> return false` defaulted the 404 to provider. The gateway-translated client-facing error type (not_found_error) is the drift-proof signal — a 404 the gateway already owned as not-found is caller-fault even with no upstream body to re-confirm; a masked 404 (errType=upstream_error) stays provider. Dropping the clientErrType=='not_found_error' branch re-fires the empty-body 404 false P0; this anchor pins it."
     },
     {
       "path": "backend/internal/handler/ops_error_logger_tk_client_canceled.go",


### PR DESCRIPTION
## 核心解决的问题

**空 body 的上游 404 被误判成 provider 故障，把瞬时的单账号抖动放大成 `upstream_error_rate=97%` 的假 P0 告警。**

线上实证（prod us3，2026-06-17 17:00–17:08Z）：一个客户端在 `/v1/responses` 上猛刷 `gpt-5.5-pro`（5 分钟 1604 次，外加 `gpt-5.5` ×73），经 `openai-us3` 镜像中继落到一个 ChatGPT-OAuth(Codex) 账号，正赶上该账号 ~8 分钟的瞬时态——ChatGPT 后端对多个**有效模型**齐返 404。

只读排查（经 prod 网关、按 account_id 归因，不直打 edge）确认：

- **请求确实打到了上游**（`upstream_status_code=404`，真实 ChatGPT 后端 404），不是网关凭空合成。
- **抖动是单账号、瞬时、已自愈**：`gpt-5.5-pro` 现在在每个 openai 账号都可服务（经 prod 网关 28/28 全 200，含 `openai-us3` 镜像路 8/8）；同型的 us6 账号同窗完好。**不是**全局上游撤回、**不是** allowlist 陈旧、**不是**账号资格问题。
- ChatGPT 后端返回的是 **空 body 的裸 404**，所以请求上下文里抓到的上游 message/body 是 `""`。

旧逻辑 `tkUpstreamClientInducedRejection` 的 404 分支，只有在能用 model-not-found 谓词**正向匹配 body** 时才把 404 归客户端；空 body 命中 `combined=="" -> return false`，于是每一条都落到 `phase=upstream / error_owner=provider`，全部计入 `upstream_error_rate` → **假 P0 误告警**。

## 修复

用网关**给客户端的 error type** 作为漂移无关的正向信号：一个被网关翻译成 `not_found_error` 的 404（openai `handleErrorResponse` case 404），结构上就是「请求的模型/端点不存在」= 调用方错，**即使上游没给 body 也归客户端**。

- masked 404（`ShouldHandleErrorCode=false → upstream_error`，或 passthrough 规则）**不是** `not_found_error`，**保持 provider** —— 保留既有「generic 404 保持 provider」契约。
- 改在**平台共享**的分类器里，因此也覆盖 anthropic 的空-body 404（它原本的 body-in-Detail 谓词覆盖不到这种情况）。

## 范围

- **只动指标归因，不改路由**。关掉假告警即可，本 PR 不动调度/failover。
- 路由层韧性缺口（瞬时 404 不从 sticky 钉死的账号 failover 到健康兄弟——`isUpstreamModelNotFoundError` 同样被空/无 `model` 字样的 body 打瘫，使 openai 既有的 per-`(account×model)` 冷却+failover 不触发）**留作单独 PR**，刻意不并入本 PR。

## 测试与门禁

- +2 回归测试：us3 空-body 形态（→ client）、masked-404 边界（→ provider）。
- `go test -tags=unit ./...` 全绿；`scripts/preflight.sh` PASS；全部 sentinel PASS。
- `scripts/sentinels/gateway-tk.json`：更新两处被钉死的字面量到新签名/调用，并新增 `clientErrType == "not_found_error"` 分支锚点（附 us3 rationale）。

## Markers

- `no-web-impact` —— 纯后端。
- `upstream-touch-trivial` —— `ops_error_logger.go` 仅给一个 TK 私有 helper 调用（`tkUpstreamClientInducedRejection`）加了一个参数；未删除/重写任何上游符号。

🤖 Generated with [Claude Code](https://claude.com/claude-code)
