### PR TITLE
fix(gateway): unservable model on /v1/responses + /chat-completions fast-fails as 400 (not 429), owned to client in ops

### DIFF
--- a/backend/internal/handler/gateway_handler_chat_completions.go
+++ b/backend/internal/handler/gateway_handler_chat_completions.go
@@ -194,8 +194,14 @@ func (h *GatewayHandler) ChatCompletions(c *gin.Context) {
 		selection, err := h.gatewayService.SelectAccountWithLoadAwareness(c.Request.Context(), apiKey.GroupID, selectionSessionHash, reqModel, fs.FailedAccountIDs, "", int64(0))
 		if err != nil {
 			if len(fs.FailedAccountIDs) == 0 {
+				// TK: an unservable model NAME (e.g. "gpt"/"opus" to an anthropic group)
+				// surfaces service.ErrUnsupportedModel → 400 invalid_request_error, not an
+				// empty-pool 429 retry signal that SDKs retry-storm (no_available_accounts_tk.go).
+				// Converges this anthropic-platform compat entry point with OpenAIGateway and the
+				// native /v1/messages path; empty-pool stays 429 (#575 parity), real faults 503.
 				markOpsRoutingCapacityLimitedIfNoAvailable(c, err)
-				h.chatCompletionsErrorResponse(c, tkNoAvailableAccounts(c), "api_error", "No available accounts: "+err.Error())
+				tkStatus, tkType, tkMsg := tkSelectFailureStatusMessage(c, err, reqModel)
+				h.chatCompletionsErrorResponse(c, tkStatus, tkType, tkMsg)
 				return
 			}
 			action := fs.HandleSelectionExhausted(c.Request.Context())

--- a/backend/internal/handler/gateway_handler_responses.go
+++ b/backend/internal/handler/gateway_handler_responses.go
@@ -200,8 +200,14 @@ func (h *GatewayHandler) Responses(c *gin.Context) {
 		selection, err := h.gatewayService.SelectAccountWithLoadAwareness(requestCtx, apiKey.GroupID, sessionHash, reqModel, fs.FailedAccountIDs, "", int64(0))
 		if err != nil {
 			if len(fs.FailedAccountIDs) == 0 {
+				// TK: an unservable model NAME (e.g. "gpt"/"opus" to an anthropic group)
+				// surfaces service.ErrUnsupportedModel → 400 invalid_request_error, not an
+				// empty-pool 429 retry signal that SDKs retry-storm (no_available_accounts_tk.go).
+				// Converges this anthropic-platform compat entry point with OpenAIGateway and the
+				// native /v1/messages path; empty-pool stays 429 (#575 parity), real faults 503.
 				markOpsRoutingCapacityLimitedIfNoAvailable(c, err)
-				h.responsesErrorResponse(c, tkNoAvailableAccounts(c), "api_error", "No available accounts: "+err.Error())
+				tkStatus, tkType, tkMsg := tkSelectFailureStatusMessage(c, err, reqModel)
+				h.responsesErrorResponse(c, tkStatus, tkType, tkMsg)
 				return
 			}
 			action := fs.HandleSelectionExhausted(requestCtx)

--- a/backend/internal/handler/gateway_handler_tk_compat_unservable_model_test.go
+++ b/backend/internal/handler/gateway_handler_tk_compat_unservable_model_test.go
@@ -1,0 +1,175 @@
+package handler
+
+import (
+	"encoding/json"
+	"fmt"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+
+	"github.com/Wei-Shaw/sub2api/internal/service"
+	"github.com/gin-gonic/gin"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// TestCompatHandlersUnservableModelEnvelope pins the behavior change that wires the
+// anthropic-platform OpenAI-compat entry points — POST /v1/responses and
+// POST /v1/chat/completions served by the NATIVE GatewayHandler (an anthropic group
+// is not an OpenAI-compat platform, so gateway_tk_openai_compat_handlers.go routes
+// it to h.Gateway.Responses / h.Gateway.ChatCompletions, NOT OpenAIGateway) —
+// through tkSelectFailureStatusMessage on a first-attempt account-selection failure.
+//
+// Before the fix both handlers called tkNoAvailableAccounts unconditionally, so an
+// unservable model NAME (e.g. a Codex/OpenAI-SDK client sending model="gpt" or the
+// bare alias "opus" to an anthropic group) returned 429 + Retry-After — a retry
+// signal SDKs auto-retry-storm for a request that can never succeed (prod
+// 2026-06-13: 8x empty-pool 429 from hammering unservable names). The service layer
+// already raises service.ErrUnsupportedModel for such names (gateway_service_tk_
+// unsupported_model.go), but these two handlers ignored it. They now mirror
+// OpenAIGateway (openai_gateway_handler.go:361) and the native /v1/messages path
+// (gateway_handler.go tkWriteUnsupportedModelIfApplicable).
+//
+// The err→(status,type,msg) mapping itself is covered by TestTkSelectFailureStatusMessage;
+// these tests assert each endpoint's error ENVELOPE carries the mapped values for
+// both the unsupported-model (400, no Retry-After) and genuine empty-pool (429 +
+// Retry-After) cases — the exact two-line sequence the fix introduced per handler.
+func TestCompatHandlersUnservableModelEnvelope(t *testing.T) {
+	gin.SetMode(gin.TestMode)
+	h := &GatewayHandler{}
+
+	newCtx := func(path string) (*gin.Context, *httptest.ResponseRecorder) {
+		w := httptest.NewRecorder()
+		c, _ := gin.CreateTestContext(w)
+		c.Request = httptest.NewRequest(http.MethodPost, path, nil)
+		return c, w
+	}
+
+	// Mirrors tkWrapSelectionFailure's two terminal shapes: a pure unservable-name
+	// failure (ModelUnsupported>0, no capacity noise) wraps ErrUnsupportedModel; a
+	// capacity/empty-pool failure wraps ErrNoAvailableAccounts.
+	unsupported := fmt.Errorf("%w: gpt (total=2 eligible=0 model_unsupported=2)", service.ErrUnsupportedModel)
+	emptyPool := fmt.Errorf("%w supporting model: gpt (total=0)", service.ErrNoAvailableAccounts)
+
+	type responsesBody struct {
+		Error struct {
+			Code    string `json:"code"`
+			Message string `json:"message"`
+		} `json:"error"`
+	}
+	type ccBody struct {
+		Error struct {
+			Type    string `json:"type"`
+			Message string `json:"message"`
+		} `json:"error"`
+	}
+
+	t.Run("responses unsupported model -> 400 invalid_request_error, no Retry-After", func(t *testing.T) {
+		c, w := newCtx("/v1/responses")
+		status, errType, msg := tkSelectFailureStatusMessage(c, unsupported, "gpt")
+		h.responsesErrorResponse(c, status, errType, msg)
+
+		require.Equal(t, http.StatusBadRequest, w.Code)
+		assert.Empty(t, w.Header().Get("Retry-After"), "a request that can never succeed must NOT carry a retry hint")
+		var body responsesBody
+		require.NoError(t, json.Unmarshal(w.Body.Bytes(), &body))
+		assert.Equal(t, service.TkUnsupportedModelErrType, body.Error.Code)
+		assert.Equal(t, service.TkUnsupportedModelMessage("gpt"), body.Error.Message)
+	})
+
+	t.Run("responses empty pool -> 429 + Retry-After (preserved)", func(t *testing.T) {
+		c, w := newCtx("/v1/responses")
+		status, errType, msg := tkSelectFailureStatusMessage(c, emptyPool, "gpt")
+		h.responsesErrorResponse(c, status, errType, msg)
+
+		require.Equal(t, http.StatusTooManyRequests, w.Code)
+		assert.Equal(t, tkNoAvailableAccountsRetryAfterSeconds, w.Header().Get("Retry-After"))
+		var body responsesBody
+		require.NoError(t, json.Unmarshal(w.Body.Bytes(), &body))
+		assert.Equal(t, "api_error", body.Error.Code)
+		assert.Contains(t, body.Error.Message, "No available accounts")
+	})
+
+	t.Run("chat/completions unsupported model -> 400 invalid_request_error, no Retry-After", func(t *testing.T) {
+		c, w := newCtx("/v1/chat/completions")
+		status, errType, msg := tkSelectFailureStatusMessage(c, unsupported, "gpt")
+		h.chatCompletionsErrorResponse(c, status, errType, msg)
+
+		require.Equal(t, http.StatusBadRequest, w.Code)
+		assert.Empty(t, w.Header().Get("Retry-After"))
+		var body ccBody
+		require.NoError(t, json.Unmarshal(w.Body.Bytes(), &body))
+		assert.Equal(t, service.TkUnsupportedModelErrType, body.Error.Type)
+		assert.Equal(t, service.TkUnsupportedModelMessage("gpt"), body.Error.Message)
+	})
+
+	t.Run("chat/completions empty pool -> 429 + Retry-After (preserved)", func(t *testing.T) {
+		c, w := newCtx("/v1/chat/completions")
+		status, errType, msg := tkSelectFailureStatusMessage(c, emptyPool, "gpt")
+		h.chatCompletionsErrorResponse(c, status, errType, msg)
+
+		require.Equal(t, http.StatusTooManyRequests, w.Code)
+		assert.Equal(t, tkNoAvailableAccountsRetryAfterSeconds, w.Header().Get("Retry-After"))
+		var body ccBody
+		require.NoError(t, json.Unmarshal(w.Body.Bytes(), &body))
+		assert.Equal(t, "api_error", body.Error.Type)
+	})
+}
+
+// TestCompatHandlersUnservableModelOpsClassification verifies the SECOND cascade
+// row (ops attribution): an unservable-model 400 on these two endpoints must log as
+// a CLIENT-owned request error (phase=request, error_owner=client, error_source=
+// client_request, is_business_limited=false) — NOT a routing-capacity event (the
+// 429's mislabel) and NOT a gateway-internal error. Otherwise a client fault keeps
+// polluting the TK capacity/gateway dashboards.
+//
+// It drives the REAL ops pipeline (parseOpsErrorResponse → normalizeOpsErrorType →
+// classifyOpsErrorLog) against the actual body each writer emits, mirroring the
+// ops_error_logger.go call site (lines ~860/904/906). The /responses envelope
+// carries the error type in the `code` field (OpenAI Responses format), not `type`,
+// so this also pins the parser recovery of a known error type from `code`.
+func TestCompatHandlersUnservableModelOpsClassification(t *testing.T) {
+	gin.SetMode(gin.TestMode)
+	h := &GatewayHandler{}
+	unsupported := fmt.Errorf("%w: gpt (total=2 eligible=0 model_unsupported=2)", service.ErrUnsupportedModel)
+
+	classify := func(t *testing.T, path string, write func(c *gin.Context)) (phase, owner, source string, businessLimited bool, status int) {
+		t.Helper()
+		w := httptest.NewRecorder()
+		c, _ := gin.CreateTestContext(w)
+		c.Request = httptest.NewRequest(http.MethodPost, path, nil)
+		// Mirror the handler: markOps... must NO-OP for ErrUnsupportedModel.
+		markOpsRoutingCapacityLimitedIfNoAvailable(c, unsupported)
+		require.False(t, isOpsRoutingCapacityLimited(c), "ErrUnsupportedModel must not set the routing-capacity flag")
+		write(c)
+		status = w.Code
+		parsed := parseOpsErrorResponse(w.Body.Bytes())
+		normalizedType := normalizeOpsErrorType(parsed.ErrorType, parsed.Code)
+		phase, businessLimited, owner, source = classifyOpsErrorLog(c, normalizedType, parsed.Message, parsed.Code, status)
+		return
+	}
+
+	t.Run("chat/completions 400 -> request/client", func(t *testing.T) {
+		phase, owner, source, bl, status := classify(t, "/v1/chat/completions", func(c *gin.Context) {
+			s, ty, m := tkSelectFailureStatusMessage(c, unsupported, "gpt")
+			h.chatCompletionsErrorResponse(c, s, ty, m)
+		})
+		require.Equal(t, http.StatusBadRequest, status)
+		assert.Equal(t, "request", phase)
+		assert.Equal(t, "client", owner)
+		assert.Equal(t, "client_request", source)
+		assert.False(t, bl)
+	})
+
+	t.Run("responses 400 -> request/client (type carried in code field)", func(t *testing.T) {
+		phase, owner, source, bl, status := classify(t, "/v1/responses", func(c *gin.Context) {
+			s, ty, m := tkSelectFailureStatusMessage(c, unsupported, "gpt")
+			h.responsesErrorResponse(c, s, ty, m)
+		})
+		require.Equal(t, http.StatusBadRequest, status)
+		assert.Equal(t, "request", phase, "responses envelope carries type in `code`; ops parser must recover it")
+		assert.Equal(t, "client", owner)
+		assert.Equal(t, "client_request", source)
+		assert.False(t, bl)
+	})
+}

--- a/backend/internal/handler/gateway_handler_tk_unsupported_model.go
+++ b/backend/internal/handler/gateway_handler_tk_unsupported_model.go
@@ -35,6 +35,9 @@ func (h *GatewayHandler) tkWriteUnsupportedModelIfApplicable(c *gin.Context, err
 			zap.Error(err),
 		)
 	}
+	// Own this to the client in ops regardless of the response envelope, so a
+	// client-fault model name never reads as TK capacity/internal.
+	markOpsClientRequestRejected(c)
 	h.handleStreamingAwareError(c, http.StatusBadRequest, service.TkUnsupportedModelErrType, service.TkUnsupportedModelMessage(reqModel), streamStarted)
 	return true
 }

--- a/backend/internal/handler/no_available_accounts_tk.go
+++ b/backend/internal/handler/no_available_accounts_tk.go
@@ -72,6 +72,9 @@ func tkNoAvailableAccounts(c *gin.Context) int {
 // of the same handler disagreed (selection==nil → 429, select error → 503).
 func tkSelectFailureStatusMessage(c *gin.Context, err error, reqModel string) (int, string, string) {
 	if errors.Is(err, service.ErrUnsupportedModel) {
+		// Own this to the client in ops regardless of the response envelope
+		// (/responses carries the type in `code`, not `type`).
+		markOpsClientRequestRejected(c)
 		return http.StatusBadRequest, service.TkUnsupportedModelErrType, service.TkUnsupportedModelMessage(reqModel)
 	}
 	if isOpsNoAvailableAccountError(err) {

--- a/backend/internal/handler/ops_error_logger.go
+++ b/backend/internal/handler/ops_error_logger.go
@@ -1327,6 +1327,12 @@ func classifyOpsErrorLog(c *gin.Context, errType, message, code string, status i
 	// See tkUpstreamClientCanceled (quad P0 2026-06-06; deadline-exceeded stays
 	// provider-owned).
 	clientCanceledUpstream := upstreamError && tkUpstreamClientCanceled(c)
+	// TK: a LOCAL pre-forward client request rejection (unservable model NAME →
+	// 400 invalid_request_error, no account selected, no upstream call). Own it to
+	// the client (request phase) regardless of the response envelope, so the
+	// /responses {error:{code}} shape is not mislabeled api_error→internal→platform.
+	// See markOpsClientRequestRejected (ops_error_logger_tk_client_request_rejected.go).
+	clientRequestRejected := hasOpsClientRequestRejected(c)
 	if upstreamError && !routingCapacityLimited && !clientInducedUpstream && !clientCanceledUpstream {
 		phase = "upstream"
 	}
@@ -1335,6 +1341,9 @@ func classifyOpsErrorLog(c *gin.Context, errType, message, code string, status i
 	}
 	if clientBusinessLimited && !upstreamError && !routingCapacityLimited {
 		phase = "auth"
+	}
+	if clientRequestRejected && !upstreamError && !routingCapacityLimited {
+		phase = "request"
 	}
 	if routingCapacityLimited {
 		phase = "routing"

--- a/backend/internal/handler/ops_error_logger_tk_client_request_rejected.go
+++ b/backend/internal/handler/ops_error_logger_tk_client_request_rejected.go
@@ -1,0 +1,50 @@
+package handler
+
+import "github.com/gin-gonic/gin"
+
+// opsClientRequestRejectedKey marks a request the GATEWAY rejected LOCALLY as a
+// client request error — no account was selected and no upstream call was made.
+// Today the sole setter is the unservable-model fast-fail (service.ErrUnsupportedModel
+// → 400 invalid_request_error) emitted by tkSelectFailureStatusMessage and
+// tkWriteUnsupportedModelIfApplicable.
+//
+// Why a context flag instead of letting classifyOpsErrorLog read the response body:
+// the OpenAI-compat error writers emit DIFFERENT envelopes for the SAME logical
+// error. chatCompletionsErrorResponse writes {"error":{"type":"invalid_request_error"}}
+// (the ops parser reads `type` → phase=request → owner=client), but the native
+// responsesErrorResponse writes the OpenAI Responses shape
+// {"error":{"code":"invalid_request_error"}} with NO top-level `type`, so
+// parseOpsErrorResponse flattens it to ErrorType="api_error" →
+// classifyOpsPhase→"internal" → owner=platform. That mislabels a client fault as a
+// TK gateway error and pollutes the gateway error rate — the inverse of the
+// empty-pool 429's routing-capacity mislabel this whole change set is removing.
+//
+// The flag makes the attribution depend on what the gateway KNOWS (this is a client
+// request rejection) rather than on response-envelope archaeology, so it is correct
+// for every endpoint regardless of envelope. It mirrors the upstream-variant
+// tkUpstreamClientInducedRejection (which owns an upstream-returned client 4xx to
+// the client); this is its local, pre-forward counterpart.
+const opsClientRequestRejectedKey = "ops_client_request_rejected"
+
+// markOpsClientRequestRejected records that the gateway locally rejected this
+// request as a client error. Safe on a nil context.
+func markOpsClientRequestRejected(c *gin.Context) {
+	if c == nil {
+		return
+	}
+	c.Set(opsClientRequestRejectedKey, true)
+}
+
+// hasOpsClientRequestRejected reports whether markOpsClientRequestRejected ran for
+// this request.
+func hasOpsClientRequestRejected(c *gin.Context) bool {
+	if c == nil {
+		return false
+	}
+	v, ok := c.Get(opsClientRequestRejectedKey)
+	if !ok {
+		return false
+	}
+	marked, _ := v.(bool)
+	return marked
+}

--- a/scripts/sentinels/gateway-tk.json
+++ b/scripts/sentinels/gateway-tk.json
@@ -2714,6 +2714,39 @@
         "account.Platform != PlatformAnthropic"
       ],
       "rationale": "Anthropic model-not-found negative cache implementation (PR #817). gocache.New(ttl, cleanup) MUST stay the backing store (NOT a hand-rolled sync.Map): the go-cache janitor sweep bounds memory under an adversarial flood of distinct client-controlled bad model names — a sync.Map only evicts lazily on re-read and would leak entries for names never requested again (review R-001). The Anthropic-only guard (account.Platform != PlatformAnthropic) keeps the cache scoped to where a 404 not_found_error means the name is globally unknown (other platforms' 404 semantics differ). The cache is keyed by the POST-mapping model name so an account that remaps a typo to a valid model is never short-circuited (verified against prod data: claude-haiku-4-6 succeeds via prod model_mapping but 404s on passthrough edges)."
+    },
+    {
+      "path": "backend/internal/handler/ops_error_logger_tk_client_request_rejected.go",
+      "must_contain": [
+        "opsClientRequestRejectedKey = \"ops_client_request_rejected\"",
+        "func markOpsClientRequestRejected(c *gin.Context)",
+        "func hasOpsClientRequestRejected(c *gin.Context) bool"
+      ],
+      "rationale": "Local pre-forward client-request-rejection marker (unservable model NAME -> 400 invalid_request_error). The flag makes ops attribution depend on what the gateway KNOWS (this is a client fault) rather than on response-envelope parsing — necessary because the two OpenAI-compat error writers emit different envelopes (chatCompletionsErrorResponse uses {error:{type}}, responsesErrorResponse uses the OpenAI Responses {error:{code}} with no top-level type), so without the flag a /responses 400 is flattened to api_error->phase=internal->owner=platform and a client fault reads as a TK gateway error. Mirrors the upstream variant tkUpstreamClientInducedRejection. An upstream merge deleting this helper would silently revert the /responses client-owned attribution fix."
+    },
+    {
+      "path": "backend/internal/handler/ops_error_logger.go",
+      "must_contain": [
+        "clientRequestRejected := hasOpsClientRequestRejected(c)",
+        "if clientRequestRejected && !upstreamError && !routingCapacityLimited {"
+      ],
+      "rationale": "Injection point in classifyOpsErrorLog that owns a LOCAL pre-forward client request rejection (unservable model 400) to the client (phase=request -> owner=client) regardless of the response envelope. Sits alongside the existing clientInducedUpstream / clientCanceledUpstream hooks; an upstream merge that rewrites the phase-override ladder must keep this line or the /responses unservable-model 400 silently regresses to owner=platform and re-pollutes the gateway error rate."
+    },
+    {
+      "path": "backend/internal/handler/gateway_handler_responses.go",
+      "must_contain": [
+        "tkStatus, tkType, tkMsg := tkSelectFailureStatusMessage(c, err, reqModel)",
+        "h.responsesErrorResponse(c, tkStatus, tkType, tkMsg)"
+      ],
+      "rationale": "Anthropic-platform /v1/responses first-attempt select-failure must route through tkSelectFailureStatusMessage (unservable model -> 400 invalid_request_error) BEFORE the empty-pool 429 fast-fail, so a model NAME nobody serves is a client 400 (no SDK retry storm) not a 429 retry signal. Mirrors OpenAIGateway and the native /v1/messages path. An upstream merge reverting this back to a bare tkNoAvailableAccounts(c) call would silently reintroduce the 429 misclassification (the exact bug this fix removes)."
+    },
+    {
+      "path": "backend/internal/handler/gateway_handler_chat_completions.go",
+      "must_contain": [
+        "tkStatus, tkType, tkMsg := tkSelectFailureStatusMessage(c, err, reqModel)",
+        "h.chatCompletionsErrorResponse(c, tkStatus, tkType, tkMsg)"
+      ],
+      "rationale": "Anthropic-platform /v1/chat/completions first-attempt select-failure must route through tkSelectFailureStatusMessage (unservable model -> 400 invalid_request_error) BEFORE the empty-pool 429 fast-fail, parity with the /v1/responses companion. An upstream merge reverting this to a bare tkNoAvailableAccounts(c) call would silently reintroduce the 429 retry-storm misclassification for an unservable model name."
     }
   ]
 }


### PR DESCRIPTION
## 改了什么

对一个**不可服务的模型名**（例如 Codex/OpenAI-SDK 客户端把 `model="gpt"` 或裸别名 `"opus"` 打到 **anthropic 平台的分组**），两个 OpenAI 兼容入口此前返回空池 **429 + Retry-After**，而不是客户端 **400** —— 这是一个 SDK 会自动重试、但永远不可能成功的请求的"重试信号"。本 PR 修复在这两个端点上真正要紧的两条连锁（客户端重试风暴 + ops 看板误标）。

service 层其实**已经**抛出 `service.ErrUnsupportedModel`；原生 `/v1/messages` 以及所有 `openai`/`newapi` 兼容路径也都已把它映射成 400。唯独 `GatewayHandler.Responses`（`/v1/responses`）和 `GatewayHandler.ChatCompletions`（`/v1/chat/completions`）—— 这两个服务 **anthropic** 分组的原生 handler —— 跳过了 `ErrUnsupportedModel` 的前置判断，直接落到 `tkNoAvailableAccounts(c)`（429）。

## 修复的两条连锁

**第 1 条 —— 客户端重试风暴。** 两个 handler 现在把首次选择失败统一走已有的 `tkSelectFailureStatusMessage`（`ErrUnsupportedModel` → 400 `invalid_request_error`；空池 → 429；真实故障 → 503），与 `OpenAIGateway` 及 `/v1/messages` 收敛一致。SDK 不重试 4xx，风暴在第 1 次即终止。空池 429 + Retry-After 保留（#575 一致）。

**第 2 条 —— ops 看板误标。** 两个兼容 error writer 的报文字段**不一致**：`chatCompletionsErrorResponse` 用 `{"error":{"type":...}}`（ops parser 认 `type`），而 OpenAI-Responses 形态的 `responsesErrorResponse` 用 `{"error":{"code":...}}`、**没有**顶层 `type`。于是 `/responses` 的 400 被 ops parser 压成 `api_error → phase=internal → owner=platform` —— 客户端故障被误标成 TK **网关**错误（并计入网关错误率）。修法：新增显式的本地 `markOpsClientRequestRejected` ops 标记，由 `classifyOpsErrorLog` 据此把 400 归到客户端（`phase=request → owner=client`），**与报文格式无关**，统一作用于 `/v1/messages`、`/v1/responses`、`/v1/chat/completions` 及所有 openai 兼容路径。镜像上游变体 `tkUpstreamClientInducedRejection`。

| 连锁 | 修前（429） | 修后（400） |
|---|---|---|
| 客户端重试风暴 | SDK 对永不可能成功的请求自动重试（prod 实测 8×） | 不重试；第 1 次即终止 |
| ops 归因 | routing-capacity / `is_business_limited=true`（chat）**或** internal/platform（responses） | **两端点**统一 `request` / `owner=client` / `is_business_limited=false` |

未触及：账号冷却/池干（无上游调用 → 不冷却）、Caddy passive-health（429 正是为避开它而选；400 也安全）、计费（两者皆 $0）、per-key 预算（`/v1` 无限流器）—— 这些本就是 NONE/LOW。

## 不在本 PR 范围（follow-up）

**设计性**的空池/冷却池 429：当 anthropic 池无可调度账号（或全在冷却）时，连跨厂商名也返 429 —— 因为 `tkSelectionFailedDueToUnsupportedModel` 要求 `ModelUnsupported>0 && Unschedulable==0 && ModelRateLimited==0`（没有可测试的账号就无法证明一个名字不可服务）。针对结构性跨厂商名收紧这一点，是另一个更有风险的独立改动。

## 运营说明（prod 触发源 user_id=16）

按 **inbound endpoint** + 请求时刻的池状态判别 prod 的 429：
- `/v1/responses` 或 `/v1/chat/completions` 打到 anthropic 组、且有 ≥1 个可调度账号 → **本 bug**（本 PR 修）。
- `/v1/messages` 且池非空 → 版本落后（pre-#617）—— 部署当前 main 即可。
- 空池、任意 endpoint → 设计性 429（见上 follow-up）。

## 测试 / 验证

- 新增 `gateway_handler_tk_compat_unservable_model_test.go`：覆盖**两端点 × 两条连锁**（400 报文 + 无 Retry-After；ops 归类 → request/client）。其中 `/responses` 的 ops 子用例在加 flag **之前为红**、之后为绿。
- `go build ./...`、`golangci-lint run ./internal/handler/...`（0 issue）、全量 `go test -tags=unit ./...` —— 全绿。

## 合并门禁

- **upstream-override**：两个被改的上游形态 handler 已在 `scripts/sentinels/gateway-tk.json` 有 coverage（pin）→ 经 verified coverage 自动通过。本 PR 另加 **4 条锚点**（新 helper、`classifyOpsErrorLog` hook、两个 handler 接线）把修复钉死，防上游 merge 回退。
- `sentinel-registry-reviewed`
- `no-web-impact`（纯后端；已在 commit 声明）。

Reviewer：按 CLAUDE.md §5.y 用 **Squash and merge**（TK fix）。

🤖 Generated with [Claude Code](https://claude.com/claude-code)
