### PR TITLE
fix(gateway): debounce bodyless-403 terminal disable to avoid false-disabling healthy accounts on a transient burst (#823 follow-up)

### DIFF
--- a/backend/internal/repository/anthropic_bodyless_403_counter_integration_test.go
+++ b/backend/internal/repository/anthropic_bodyless_403_counter_integration_test.go
@@ -1,0 +1,108 @@
+//go:build integration
+
+package repository
+
+import (
+	"fmt"
+	"testing"
+
+	"github.com/Wei-Shaw/sub2api/internal/service"
+	"github.com/stretchr/testify/require"
+	"github.com/stretchr/testify/suite"
+)
+
+// AnthropicBodyless403CounterSuite 用真实 Redis 验证空 body 403 计数器的 debounce 语义：
+// 一个失败 episode 内的并发突发折叠成 1 次计数，跨 debounce 才 +1——这是防止瞬时突发把
+// 健康账号永久禁用的安全闸（R-001）。
+type AnthropicBodyless403CounterSuite struct {
+	IntegrationRedisSuite
+	cache service.AnthropicUpstreamErrorCounterCache
+}
+
+func TestAnthropicBodyless403CounterSuite(t *testing.T) {
+	suite.Run(t, new(AnthropicBodyless403CounterSuite))
+}
+
+func (s *AnthropicBodyless403CounterSuite) SetupTest() {
+	s.IntegrationRedisSuite.SetupTest()
+	s.cache = NewAnthropicUpstreamErrorCounterCache(s.rdb)
+}
+
+func (s *AnthropicBodyless403CounterSuite) key(accountID int64) string {
+	return fmt.Sprintf("%s%d", anthropicBodyless403CounterPrefix, accountID)
+}
+
+// forceElapsed 把 at 置 0，模拟「距上次计数已远超 debounce」，使下一次确定性 +1（无需 sleep）。
+func (s *AnthropicBodyless403CounterSuite) forceElapsed(accountID int64) {
+	require.NoError(s.T(), s.rdb.HSet(s.ctx, s.key(accountID), "at", 0).Err())
+}
+
+func (s *AnthropicBodyless403CounterSuite) hgetInt(accountID int64, field string) int64 {
+	v, err := s.rdb.HGet(s.ctx, s.key(accountID), field).Int64()
+	require.NoError(s.T(), err, "HGET %s", field)
+	return v
+}
+
+// 首次 → count=1，hash 落 count=1/at>0。
+func (s *AnthropicBodyless403CounterSuite) TestSeedReturnsOne() {
+	const id = int64(20)
+	count, err := s.cache.IncrementAnthropicBodyless403Count(s.ctx, id, 60, 100)
+	require.NoError(s.T(), err)
+	require.Equal(s.T(), int64(1), count)
+	require.Equal(s.T(), int64(1), s.hgetInt(id, "count"))
+	require.Positive(s.T(), s.hgetInt(id, "at"), "at must be stamped to server time")
+}
+
+// 同 episode 并发突发（debounce 窗口内）→ 不增量，保持 1。
+func (s *AnthropicBodyless403CounterSuite) TestBurstWithinDebounceDoesNotIncrement() {
+	const id = int64(21)
+	const debounce = 100
+
+	count, err := s.cache.IncrementAnthropicBodyless403Count(s.ctx, id, 60, debounce)
+	require.NoError(s.T(), err)
+	require.Equal(s.T(), int64(1), count)
+
+	// 模拟 10 个同时在途的请求各打一次空 body 403：全部落在同一 debounce 窗口内。
+	for i := 0; i < 10; i++ {
+		count, err = s.cache.IncrementAnthropicBodyless403Count(s.ctx, id, 60, debounce)
+		require.NoError(s.T(), err)
+		require.Equal(s.T(), int64(1), count, "并发突发必须折叠成 1，否则健康账号会被瞬时抖动永久禁用")
+	}
+}
+
+// 跨 debounce（不同 episode）→ 每个 episode +1。
+func (s *AnthropicBodyless403CounterSuite) TestDistinctEpisodesIncrement() {
+	const id = int64(22)
+	const debounce = 100
+
+	count, err := s.cache.IncrementAnthropicBodyless403Count(s.ctx, id, 60, debounce)
+	require.NoError(s.T(), err)
+	require.Equal(s.T(), int64(1), count)
+
+	for want := int64(2); want <= 5; want++ {
+		s.forceElapsed(id) // 模拟跨过一个冷却周期
+		count, err = s.cache.IncrementAnthropicBodyless403Count(s.ctx, id, 60, debounce)
+		require.NoError(s.T(), err)
+		require.Equal(s.T(), want, count)
+		// 同 episode 内紧接着的突发仍不重复计数。
+		count, err = s.cache.IncrementAnthropicBodyless403Count(s.ctx, id, 60, debounce)
+		require.NoError(s.T(), err)
+		require.Equal(s.T(), want, count, "episode 内突发不得重复计数")
+	}
+}
+
+// Reset 清整 key；其后重新种 baseline。
+func (s *AnthropicBodyless403CounterSuite) TestResetClearsAll() {
+	const id = int64(23)
+	_, err := s.cache.IncrementAnthropicBodyless403Count(s.ctx, id, 60, 100)
+	require.NoError(s.T(), err)
+
+	require.NoError(s.T(), s.cache.ResetAnthropicBodyless403Count(s.ctx, id))
+	exists, err := s.rdb.Exists(s.ctx, s.key(id)).Result()
+	require.NoError(s.T(), err)
+	require.Equal(s.T(), int64(0), exists, "reset must DEL the whole key")
+
+	count, err := s.cache.IncrementAnthropicBodyless403Count(s.ctx, id, 60, 100)
+	require.NoError(s.T(), err)
+	require.Equal(s.T(), int64(1), count)
+}

--- a/backend/internal/repository/anthropic_upstream_error_counter_cache.go
+++ b/backend/internal/repository/anthropic_upstream_error_counter_cache.go
@@ -58,14 +58,53 @@ func (c *anthropicUpstreamErrorCounterCache) ResetAnthropicUpstreamErrorCount(ct
 	return c.rdb.Del(ctx, key).Err()
 }
 
-func (c *anthropicUpstreamErrorCounterCache) IncrementAnthropicBodyless403Count(ctx context.Context, accountID int64, windowMinutes int) (int64, error) {
+// anthropicBodyless403IncrScript atomically counts bodyless/unstructured 403
+// EPISODES (not racing requests) via a server-side-TIME debounce gate, then
+// returns the current count. Hash fields: count = episode total in the window;
+// at = server-time seconds of the last counted increment.
+//   - First touch (no `at`) → count=1, at=now, set TTL, return 1.
+//   - now-at >= debounce → a new episode: count+1, at=now, refresh TTL.
+//   - now-at <  debounce → same episode burst: no increment (only refresh TTL),
+//     so a concurrent burst of N in-flight requests counts ONCE.
+//
+// Mirrors oauth_401_after_refresh_counter_cache.go's debounce: redis.call('TIME')
+// is deterministic across gateway replicas and avoids client clock drift;
+// effects replication requires replicate_commands() first (no-op on Redis 5+).
+var anthropicBodyless403IncrScript = redis.NewScript(`
+	redis.replicate_commands()
+	local key = KEYS[1]
+	local ttl = tonumber(ARGV[1])
+	local debounce = tonumber(ARGV[2])
+	local now = tonumber(redis.call('TIME')[1])
+
+	local stored = redis.call('HGET', key, 'count')
+	if stored == false then
+		redis.call('HSET', key, 'count', 1, 'at', now)
+		redis.call('EXPIRE', key, ttl)
+		return 1
+	end
+
+	local count = tonumber(stored)
+	local at = tonumber(redis.call('HGET', key, 'at') or '0')
+	if (now - at) >= debounce then
+		count = count + 1
+		redis.call('HSET', key, 'count', count, 'at', now)
+	end
+	redis.call('EXPIRE', key, ttl)
+	return count
+`)
+
+func (c *anthropicUpstreamErrorCounterCache) IncrementAnthropicBodyless403Count(ctx context.Context, accountID int64, windowMinutes, debounceSeconds int) (int64, error) {
 	key := fmt.Sprintf("%s%d", anthropicBodyless403CounterPrefix, accountID)
 	ttlSeconds := windowMinutes * 60
 	if ttlSeconds < 60 {
 		ttlSeconds = 60
 	}
+	if debounceSeconds < 0 {
+		debounceSeconds = 0
+	}
 
-	result, err := anthropicUpstreamErrorCounterIncrScript.Run(ctx, c.rdb, []string{key}, ttlSeconds).Int64()
+	result, err := anthropicBodyless403IncrScript.Run(ctx, c.rdb, []string{key}, ttlSeconds, debounceSeconds).Int64()
 	if err != nil {
 		return 0, fmt.Errorf("increment anthropic bodyless 403 count: %w", err)
 	}

--- a/backend/internal/service/anthropic_upstream_error_counter.go
+++ b/backend/internal/service/anthropic_upstream_error_counter.go
@@ -25,7 +25,15 @@ type AnthropicUpstreamErrorCounterCache interface {
 	// so without this terminal counter it flaps forever on the auto-recovering
 	// 3/3 ladder. Reset mirrors the error counter so a healed account does not
 	// carry stale bodyless strikes.
-	IncrementAnthropicBodyless403Count(ctx context.Context, accountID int64, windowMinutes int) (int64, error)
+	//
+	// debounceSeconds collapses a concurrent burst of bodyless 403s (many
+	// in-flight requests to the same account in one failure episode) into a
+	// SINGLE increment via a server-side-TIME gate, so the threshold counts
+	// distinct cooldown EPISODES, not racing requests. Without it a transient
+	// burst could cross the permanent-disable threshold in seconds and kill a
+	// healthy account — the same burst-vs-episode hazard the #623 escalation
+	// slot and the oauth401 same_at debounce already guard against.
+	IncrementAnthropicBodyless403Count(ctx context.Context, accountID int64, windowMinutes, debounceSeconds int) (int64, error)
 	ResetAnthropicBodyless403Count(ctx context.Context, accountID int64) error
 
 	// Tier counter tracks how many cooldowns this account has triggered in the

--- a/backend/internal/service/ratelimit_service_401_test.go
+++ b/backend/internal/service/ratelimit_service_401_test.go
@@ -152,6 +152,7 @@ type anthropicUpstreamErrorCounterCacheStub struct {
 	bodyless403Counts       []int64
 	bodyless403IncrementIDs []int64
 	bodyless403WindowMin    []int
+	bodyless403DebounceSec  []int
 	bodyless403ResetCalls   []int64
 
 	tierCounts       []int64
@@ -198,9 +199,10 @@ func (s *anthropicUpstreamErrorCounterCacheStub) ResetAnthropicUpstreamErrorCoun
 	return nil
 }
 
-func (s *anthropicUpstreamErrorCounterCacheStub) IncrementAnthropicBodyless403Count(_ context.Context, accountID int64, windowMinutes int) (int64, error) {
+func (s *anthropicUpstreamErrorCounterCacheStub) IncrementAnthropicBodyless403Count(_ context.Context, accountID int64, windowMinutes, debounceSeconds int) (int64, error) {
 	s.bodyless403IncrementIDs = append(s.bodyless403IncrementIDs, accountID)
 	s.bodyless403WindowMin = append(s.bodyless403WindowMin, windowMinutes)
+	s.bodyless403DebounceSec = append(s.bodyless403DebounceSec, debounceSeconds)
 	if s.err != nil {
 		return 0, s.err
 	}

--- a/backend/internal/service/ratelimit_service_tk_anthropic_bodyless_403.go
+++ b/backend/internal/service/ratelimit_service_tk_anthropic_bodyless_403.go
@@ -33,14 +33,19 @@ import (
 //   - **fail-open**：计数器未注入 / 出错 / 未达阈值 → 返回 false，落回既有阶梯，行为不变。
 
 const (
-	// anthropic403BodylessDisableThresholdDefault：一个窗口内累计多少次空 body 403 即判
-	// 持续拒绝并永久禁用。永久禁用不可自愈（需 ops），故偏保守——10 次足以在繁忙 edge 上
-	// ~一两个冷却周期内坐实持续 flap，又远高于单个请求的偶发瞬时 403。
-	anthropic403BodylessDisableThresholdDefault int64 = 10
-	// anthropic403BodylessWindowMinutesDefault：累计窗口。30min 覆盖 3/3 阶梯封顶 10min
-	// 冷却的 ~两到三个 re-admit 周期，使「冷却→回池→仍空 body 403」的持续 flap 能累积到
-	// 阈值，而跨窗口的零星瞬时 403 会随窗口过期清零。
-	anthropic403BodylessWindowMinutesDefault int = 30
+	// anthropic403BodylessDisableThresholdDefault：达多少个**独立冷却 EPISODE**(经
+	// debounce 折叠并发突发后)的空 body 403 即判持续拒绝并永久禁用。永久禁用不可自愈
+	// (需 ops),故按 EPISODE 计而非按请求计——5 个独立 episode(冷却→回池→仍空 body 403)
+	// 是不可能由单次瞬时基础设施抖动产生的(那只是 1 个 episode),又能在持续 flap 时于
+	// ~半小时内坐实。
+	anthropic403BodylessDisableThresholdDefault int64 = 5
+	// anthropic403BodylessWindowMinutesDefault：episode 累计窗口。60min 覆盖 3/3 阶梯
+	// 升到封顶 10min 冷却后的 ~5 个 re-admit episode,跨窗口的零星 episode 随窗口过期清零。
+	anthropic403BodylessWindowMinutesDefault int = 60
+	// anthropic403BodylessDebounceSecondsDefault：把一个失败 episode 内的并发突发(同时
+	// 在途的多个请求各打一次空 body 403)折叠成 1 次计数的去抖窗口。取 15s——小于 3/3
+	// 阶梯最短 30s 冷却(故相邻 episode 必被分开计),又远大于亚秒级并发突发(故突发折叠)。
+	anthropic403BodylessDebounceSecondsDefault int = 15
 )
 
 // tkIsUnstructuredAnthropicErrorBody 报告上游错误 body 是否为「非结构化」——空 body、
@@ -82,7 +87,7 @@ func (s *RateLimitService) tkTryEscalatePersistentBodyless403(ctx context.Contex
 	}
 
 	count, err := s.anthropicUpstreamErrorCounterCache.IncrementAnthropicBodyless403Count(
-		ctx, account.ID, anthropic403BodylessWindowMinutesDefault)
+		ctx, account.ID, anthropic403BodylessWindowMinutesDefault, anthropic403BodylessDebounceSecondsDefault)
 	if err != nil {
 		slog.Warn("anthropic_bodyless_403_counter_increment_failed", "account_id", account.ID, "error", err)
 		return false // fail-open

--- a/scripts/sentinels/gateway-tk.json
+++ b/scripts/sentinels/gateway-tk.json
@@ -235,6 +235,7 @@
         "NewAnthropicUpstreamErrorCounterCache",
         "IncrementAnthropicUpstreamErrorCount",
         "ResetAnthropicUpstreamErrorCount",
+        "anthropicBodyless403IncrScript",
         "IncrementAnthropicBodyless403Count",
         "ResetAnthropicBodyless403Count",
         "IncrementAnthropicCooldownTier(",


### PR DESCRIPTION
## 为什么(#823 的 follow-up)

#823 合并的是 3-Gap 版本,**未含审查中发现的 R-001 安全闸**。本 PR 单独补上它。

**R-001(high):** Gap A 的空 body 403 终局禁用计数器原本**按请求计、无突发去抖**。busy 账号上一次瞬时非结构化 403 抖动(高并发)会让 N 个在途请求各 +1,几秒内冲破阈值,**永久禁用一个健康账号**——正是 #810 精度线警告的「自伤式停服」,且偏离了仓库里两处既有突发护栏(#623 escalation slot、oauth401 `same_at` debounce)。

## 改了什么

给 `IncrementAnthropicBodyless403Count` 加上仓库既有的 **server-side-`TIME` 去抖**(镜像 `oauth_401_after_refresh_counter_cache.go`):一个失败 episode 内的并发突发**折叠成 1 次**计数,于是阈值改为按**独立冷却 EPISODE** 计、而非按请求计。

调参(episode 语义):
- 阈值 **5 个 episode**(原 10 次请求)
- 窗口 **60min**(原 30min)
- 去抖 **15s**(< 3/3 阶梯最短 30s 冷却 → 相邻 episode 仍分开计;≫ 亚秒并发突发 → 折叠)

瞬时单 episode 抖动 → 贡献 1 → **永不停用**;真持续 flap(5 个独立 episode)→ ~半小时内坐实禁用。

## 测试
- 新增**真 Redis 集成测试** `anthropic_bodyless_403_counter_integration_test.go`:10 请求并发突发停在 count=1、独立 episode 才 +1、reset 清零 —— stub 测不到的安全机制。
- 既有 Gap A 单元测试(经 stub 驱动 count)不变,全过。

## Sentinel
锚定去抖脚本 `anthropicBodyless403IncrScript`,防 upstream merge 静默删除突发护栏。

## 验证
- `go build ./...` ✓
- 全量 `go test -tags=unit ./...` ✓
- `go test -tags=integration`(本地无 Docker → skip,CI `test-integration` 真跑)编译 ✓
- `golangci-lint` 0 issues ✓
- `scripts/preflight.sh`(base=origin/main)PASS ✓
- `check-gateway-tk.py` 292/292 ✓

## 备注
- 纯后端(`no-web-impact`)。无 Ent / migration / wire-regen / config 改动。
- diff 仅含去抖增量(3-Gap 主体已随 #823 squash 进 main)。
- TK 自有 PR → **Squash and merge**(规则 §5.y)。

🤖 Generated with [Claude Code](https://claude.com/claude-code)
