### PR TITLE
fix(qa-export): bind qa_capture.export_storage from env (#829 follow-up)

### DIFF
--- a/backend/internal/config/config.go
+++ b/backend/internal/config/config.go
@@ -1956,6 +1956,20 @@ func setDefaults() {
 	viper.SetDefault("qa_capture.storage.secret_access_key", "")
 	viper.SetDefault("qa_capture.storage.prefix", "qa_blobs")
 	viper.SetDefault("qa_capture.storage.force_path_style", false)
+	// export_storage is the SEPARATE destination for finished export ZIPs
+	// (typically durable S3, so downloads are presigned-direct off the box rather
+	// than streamed through the gateway). These defaults are required so viper's
+	// AutomaticEnv binds the QA_CAPTURE_EXPORT_STORAGE_* env overrides — without a
+	// known key viper never reads the env, and an empty driver keeps the current
+	// behavior (export ZIPs fall back to the capture store / localfs).
+	viper.SetDefault("qa_capture.export_storage.driver", "")
+	viper.SetDefault("qa_capture.export_storage.endpoint", "")
+	viper.SetDefault("qa_capture.export_storage.region", "")
+	viper.SetDefault("qa_capture.export_storage.bucket", "")
+	viper.SetDefault("qa_capture.export_storage.access_key_id", "")
+	viper.SetDefault("qa_capture.export_storage.secret_access_key", "")
+	viper.SetDefault("qa_capture.export_storage.prefix", "")
+	viper.SetDefault("qa_capture.export_storage.force_path_style", false)
 
 	// Gateway
 	viper.SetDefault("gateway.response_header_timeout", 600) // 600秒(10分钟)等待上游响应头，LLM高负载时可能排队较久

--- a/backend/internal/config/qa_export_storage_env_test.go
+++ b/backend/internal/config/qa_export_storage_env_test.go
@@ -32,3 +32,18 @@ func TestQAExportStorageEnvBinding(t *testing.T) {
 		t.Fatalf("export_storage env partially bound: %+v", es)
 	}
 }
+
+// Backward-compat anchor: with no QA_CAPTURE_EXPORT_STORAGE_* env, the driver
+// stays empty so NewService keeps the export ZIP on the localfs capture store
+// (the SetDefault must not silently flip any deployment to S3).
+func TestQAExportStorageDefaultsToEmptyDriver(t *testing.T) {
+	viper.Reset()
+	t.Setenv("JWT_SECRET", strings.Repeat("x", 32))
+	cfg, err := Load()
+	if err != nil {
+		t.Fatalf("Load() error: %v", err)
+	}
+	if d := cfg.QACapture.ExportStorage.Driver; d != "" {
+		t.Fatalf("export_storage.driver default must stay empty (localfs fallback), got %q", d)
+	}
+}

--- a/backend/internal/config/qa_export_storage_env_test.go
+++ b/backend/internal/config/qa_export_storage_env_test.go
@@ -1,0 +1,34 @@
+package config
+
+import (
+	"strings"
+	"testing"
+
+	"github.com/spf13/viper"
+)
+
+// Prod enables S3 export_storage via docker-compose env (QA_CAPTURE_EXPORT_STORAGE_*).
+// viper.AutomaticEnv only binds nested keys it "knows" (via SetDefault / config file);
+// qa_capture.export_storage.* has no SetDefault, so this pins that env injection
+// actually reaches cfg.QACapture.ExportStorage — otherwise the S3 cutover silently
+// no-ops and the export stays localfs.
+func TestQAExportStorageEnvBinding(t *testing.T) {
+	viper.Reset()
+	t.Setenv("JWT_SECRET", strings.Repeat("x", 32))
+	t.Setenv("QA_CAPTURE_EXPORT_STORAGE_DRIVER", "s3")
+	t.Setenv("QA_CAPTURE_EXPORT_STORAGE_REGION", "us-east-1")
+	t.Setenv("QA_CAPTURE_EXPORT_STORAGE_BUCKET", "tk-test-qa-export")
+	t.Setenv("QA_CAPTURE_EXPORT_STORAGE_PREFIX", "traj-exports")
+
+	cfg, err := Load()
+	if err != nil {
+		t.Fatalf("Load() error: %v", err)
+	}
+	es := cfg.QACapture.ExportStorage
+	if es.Driver != "s3" {
+		t.Fatalf("export_storage.driver env NOT bound (got %q) — needs viper.SetDefault for the nested keys", es.Driver)
+	}
+	if es.Region != "us-east-1" || es.Bucket != "tk-test-qa-export" || es.Prefix != "traj-exports" {
+		t.Fatalf("export_storage env partially bound: %+v", es)
+	}
+}

--- a/docs/qa-export-s3-and-auto-archive.md
+++ b/docs/qa-export-s3-and-auto-archive.md
@@ -53,6 +53,55 @@ storage under a 1-day/7-day TTL is ~$0.16–0.3/mo. The S3 key layout is
 `traj-exports/<user_id>/<api_key_id>/{manual/<unix_nanos>|auto/<YYYY-MM-DD>}.zip`
 — `user_id` first so the download ownership prefix check holds.
 
+### Enabling on prod — env binding fixed here; the compose-size rollout is blocked
+
+`qa_capture.export_storage.*` now has `viper.SetDefault`s (this change,
+`internal/config/config.go`), so `QA_CAPTURE_EXPORT_STORAGE_*` binds under
+`AutomaticEnv` (`.`→`_`), regression-guarded by `TestQAExportStorageEnvBinding`.
+#829 shipped the struct + S3 driver but omitted these defaults, so a prod env
+cutover silently no-ops (reads empty → export stays localfs → the per-key
+download stays a ~30 s in-memory gateway proxy read of the whole ZIP — the
+"download does nothing" symptom on a 20k-record key). **Enabling S3 needs a
+release of an image carrying this fix (NOT a same-image restart).**
+
+⚠ **The obvious "append the 4 env to the compose `environment:` block" is blocked
+today.** Stage0 prod and edge SHARE `deploy/aws/stage0/docker-compose.yml`: edge
+Lightsail embeds it gzip|base64 into `generated-launch-script.sh`
+(`render-bootstrap.sh`), and that script is already **14290 B against the 14336 B
+Lightsail user-data cap (~46 B headroom)**. The export_storage env grows it
+~588 B → over the cap (`test_render_bootstrap` fails). The env cannot simply be
+added to the shared compose.
+
+Unblock options (operator decision before rolling out S3):
+
+1. **Move the edge launch-script payloads (compose / Caddy / bootstrap
+   gzip|base64) to SSM Parameter Store**, leaving the launch script a thin SSM
+   reference. Root-fixes the chronic edge size pressure and lets stage0 compose
+   grow freely. Largest change, durable fix. *(Recommended.)*
+2. **Decouple edge vs prod compose** (prod-only override / separate edge compose)
+   so prod-only env never inflates the edge launch script.
+3. **Inject prod-only env via an override loaded only on the EC2 path**, kept out
+   of `render-bootstrap`'s embed.
+
+Once unblocked, the rollout (each step needs operator authorization; read-only
+diagnosis: skill `tokenkey-online-log-troubleshooting`):
+
+1. **Release** an image carrying this fix (VERSION bump → tag → `release.yml`).
+2. **Provision infra**: bucket `tokenkey-prod-qa-exports` (us-east-1, Block
+   Public Access ON) + prefix-`traj-exports/` 7-day lifecycle + bucket policy
+   granting the prod instance role (`tokenkey-prod-stage0-InstanceRole-*`)
+   `s3:GetObject/PutObject/DeleteObject/ListBucket` — Principal = the resolved
+   role ARN literally (account-root + wildcard ⇒ AccessDenied; ops memory). The
+   instance role has no S3 identity policy today (mirrors pgdump's bucket-policy
+   grant), so this is the only grant; no prod-instance CFN stack update.
+3. **Set** the 4 `QA_CAPTURE_EXPORT_STORAGE_*` on prod (per the chosen unblock
+   path) and `compose ... up -d --no-deps --force-recreate --timeout 30 tokenkey`.
+4. **Verify**: the per-key `download_url` is now an `https://…s3…X-Amz-Signature…`
+   presigned URL fetched directly from S3 (sub-second), not the
+   `/api/v1/users/me/qa/traj/exports/…` gateway proxy path. Capture blobs stay
+   localfs; only the export ZIP + its download move to S3. Rollback = drop the 4
+   env + recreate.
+
 ## Opt-in: daily auto-archive cron
 
 ```yaml


### PR DESCRIPTION
## 背景

盯 prod 导出时定位到「点下载没反应」= localfs 模式下载经网关把整个 zip（20k 条记录的 TK_SMOKE anthropic key）读进内存再回传 → ~30s。彻底修需把导出 zip 切到 S3（`download_url` 变 presigned，浏览器直连 S3 秒下）。准备启用 S3 时发现 **#829 的一个使能 bug**，本 PR 先修它。

## 改了什么

- **`config.go`**：给 `qa_capture.export_storage.*` 补 `viper.SetDefault`。#829 加了 export_storage 结构 + S3 driver，却漏了这些 default —— viper `AutomaticEnv` 只绑定它「已知」的 nested key（靠 SetDefault / config 文件），所以 `QA_CAPTURE_EXPORT_STORAGE_*` env **永远绑不进** `cfg.QACapture.ExportStorage`，prod 经 env 切 S3 会**静默失效**（读空 → 仍 localfs → 下载仍 30s）。driver 默认 `""` 保持 localfs fallback，**对未配置部署零行为变更**。
- **`TestQAExportStorageEnvBinding`**：回归钉住 env 绑定（修前红、修后绿）。
- **`docs/qa-export-s3-and-auto-archive.md`**：记录 env 绑定已修，以及 prod 经共享 stage0 compose 启用 S3 **被 edge Lightsail launch-script 体积上限挡住**（edge 复用 prod compose、`render-bootstrap` 嵌入；脚本已 14290/14336 B，加 env +588B 超限）—— 附解锁选项（payload→SSM / compose 解耦）。

## 这个 PR 不做什么（实际启用 S3 的后续，需 operator 决策）

`compose env + CFN base64 + provisioning 脚本`已**回退**——因为往共享 stage0 compose 加 env 会撑爆 edge launch-script 上限（`test_render_bootstrap` 失败）。实际在 prod 启用 S3 仍需：① 发版含本修复的镜像（非同-image 重启）② 先解 edge launch-script 上限（推荐 payload 移 SSM）③ 建 bucket + bucket policy(role ARN) + lifecycle ④ deploy + 验证。详见 docs runbook。

## 边界

纯后端（`internal/config`）+ test + docs，无 web/网关/迁移改动 → `no-web-impact`。无 upstream-shaped 路径改动、无 sentinel/hotspot 触动，故无 upstream-override / registry marker 需求。

合并方式：**Squash and merge**（TK 自源 fix）。

🤖 Generated with [Claude Code](https://claude.com/claude-code)