### PR TITLE
feat(ops): 在 prod 启用 QA traj 导出 → S3（deploy-sed 注入，不碰 edge）

### DIFF
--- a/docs/qa-export-s3-and-auto-archive.md
+++ b/docs/qa-export-s3-and-auto-archive.md
@@ -53,54 +53,58 @@ storage under a 1-day/7-day TTL is ~$0.16–0.3/mo. The S3 key layout is
 `traj-exports/<user_id>/<api_key_id>/{manual/<unix_nanos>|auto/<YYYY-MM-DD>}.zip`
 — `user_id` first so the download ownership prefix check holds.
 
-### Enabling on prod — env binding fixed here; the compose-size rollout is blocked
+### Enabling on prod — env binding + deploy-sed injection (both shipped)
 
-`qa_capture.export_storage.*` now has `viper.SetDefault`s (this change,
-`internal/config/config.go`), so `QA_CAPTURE_EXPORT_STORAGE_*` binds under
-`AutomaticEnv` (`.`→`_`), regression-guarded by `TestQAExportStorageEnvBinding`.
-#829 shipped the struct + S3 driver but omitted these defaults, so a prod env
-cutover silently no-ops (reads empty → export stays localfs → the per-key
-download stays a ~30 s in-memory gateway proxy read of the whole ZIP — the
-"download does nothing" symptom on a 20k-record key). **Enabling S3 needs a
-release of an image carrying this fix (NOT a same-image restart).**
+`qa_capture.export_storage.*` has `viper.SetDefault`s (`internal/config/config.go`,
+#836), so `QA_CAPTURE_EXPORT_STORAGE_*` binds under `AutomaticEnv` (`.`→`_`),
+regression-guarded by `TestQAExportStorageEnvBinding`. #829 shipped the struct +
+S3 driver but omitted these defaults, so a prod env cutover silently no-ops (reads
+empty → export stays localfs → the per-key download stays a ~30 s in-memory
+gateway proxy read of the whole ZIP — the "download does nothing" symptom on a
+20k-record key). **Enabling S3 needs a release of an image carrying that fix (NOT
+a same-image restart).**
 
-⚠ **The obvious "append the 4 env to the compose `environment:` block" is blocked
-today.** Stage0 prod and edge SHARE `deploy/aws/stage0/docker-compose.yml`: edge
-Lightsail embeds it gzip|base64 into `generated-launch-script.sh`
-(`render-bootstrap.sh`), and that script is already **14290 B against the 14336 B
-Lightsail user-data cap (~46 B headroom)**. The export_storage env grows it
-~588 B → over the cap (`test_render_bootstrap` fails). The env cannot simply be
-added to the shared compose.
+**Why the env is NOT in the shared compose.** Stage0 prod and edge SHARE
+`deploy/aws/stage0/docker-compose.yml`: edge Lightsail embeds it gzip|base64 into
+`generated-launch-script.sh` (`render-bootstrap.sh`), and that script already sits
+**~46 B under the 14336 B Lightsail user-data cap**. The 4 export_storage vars
+(~588 B) would push it over (`test_render_bootstrap` fails). Edges are pure
+cc-relay mirrors that never capture/export QA, so they have no use for the config
+anyway — putting it in the shared compose would be paying the edge size cost for a
+prod-only feature.
 
-Unblock options (operator decision before rolling out S3):
+**How it ships instead (deploy-sed, prod-only).** `ops/stage0/deploy_via_ssm.sh`
+self-heals the 4 vars onto the LIVE prod host on every deploy — the exact
+mechanism already used for `SERVER_FRONTEND_URL`: a guarded (`grep -q`), additive,
+idempotent `.env` backfill + a `/^      - TZ=/a\` insertion of the 4 compose
+mappings, with a tagged compose backup. It is gated to the prod EC2 node
+(`INSTANCE_ID == i-*`); every edge is a Lightsail `mi-*` and gets an empty
+injection (byte-identical command list). Values default to the prod bucket but are
+env-overridable. **Credentials stay empty on purpose** — the prod instance role +
+the bucket policy below grant `s3:PutObject`, so no static keys ever land in
+`.env`. Regression-guarded by `ops/stage0/test_deploy_via_ssm_qa_export.py`
+(render-asserts both arms of the gate; on Linux also executes the two commands and
+asserts the resulting `.env` + compose).
 
-1. **Move the edge launch-script payloads (compose / Caddy / bootstrap
-   gzip|base64) to SSM Parameter Store**, leaving the launch script a thin SSM
-   reference. Root-fixes the chronic edge size pressure and lets stage0 compose
-   grow freely. Largest change, durable fix. *(Recommended.)*
-2. **Decouple edge vs prod compose** (prod-only override / separate edge compose)
-   so prod-only env never inflates the edge launch script.
-3. **Inject prod-only env via an override loaded only on the EC2 path**, kept out
-   of `render-bootstrap`'s embed.
+Rollout (each step needs operator authorization; read-only diagnosis: skill
+`tokenkey-online-log-troubleshooting`):
 
-Once unblocked, the rollout (each step needs operator authorization; read-only
-diagnosis: skill `tokenkey-online-log-troubleshooting`):
-
-1. **Release** an image carrying this fix (VERSION bump → tag → `release.yml`).
-2. **Provision infra**: bucket `tokenkey-prod-qa-exports` (us-east-1, Block
-   Public Access ON) + prefix-`traj-exports/` 7-day lifecycle + bucket policy
-   granting the prod instance role (`tokenkey-prod-stage0-InstanceRole-*`)
-   `s3:GetObject/PutObject/DeleteObject/ListBucket` — Principal = the resolved
-   role ARN literally (account-root + wildcard ⇒ AccessDenied; ops memory). The
-   instance role has no S3 identity policy today (mirrors pgdump's bucket-policy
-   grant), so this is the only grant; no prod-instance CFN stack update.
-3. **Set** the 4 `QA_CAPTURE_EXPORT_STORAGE_*` on prod (per the chosen unblock
-   path) and `compose ... up -d --no-deps --force-recreate --timeout 30 tokenkey`.
+1. **Release** an image carrying the #836 fix (VERSION bump → tag → `release.yml`).
+2. **Provision infra**: bucket `tokenkey-prod-qa-exports` (us-east-1, Block Public
+   Access ON) + prefix-`traj-exports/` 7-day lifecycle + bucket policy granting the
+   prod instance role (`tokenkey-prod-stage0-InstanceRole-*`)
+   `s3:GetObject/PutObject/DeleteObject/ListBucket` — Principal = the resolved role
+   ARN literally (account-root + wildcard ⇒ AccessDenied; ops memory). The instance
+   role has no S3 identity policy today (mirrors pgdump's bucket-policy grant), so
+   this is the only grant; no prod-instance CFN stack update.
+3. **Deploy** (e.g. `deploy-stage0` workflow): `deploy_via_ssm.sh` injects the 4
+   vars into the live host's `.env` + compose and force-recreates the container.
+   No manual SSH step — the deploy primitive is the enablement path.
 4. **Verify**: the per-key `download_url` is now an `https://…s3…X-Amz-Signature…`
    presigned URL fetched directly from S3 (sub-second), not the
    `/api/v1/users/me/qa/traj/exports/…` gateway proxy path. Capture blobs stay
    localfs; only the export ZIP + its download move to S3. Rollback = drop the 4
-   env + recreate.
+   env (+ the compose mappings) + recreate.
 
 ## Opt-in: daily auto-archive cron
 

--- a/ops/stage0/deploy_via_ssm.sh
+++ b/ops/stage0/deploy_via_ssm.sh
@@ -121,8 +121,47 @@ params_file="${OUTPUT_DIR}/ssm-params.json"
 stdout_file="${OUTPUT_DIR}/stdout.txt"
 stderr_file="${OUTPUT_DIR}/stderr.txt"
 
-jq -n --arg tag "${TAG}" '{
-  commands: [
+# --- QA trajectory export → durable S3 (prod-only) ---------------------------
+# Same mechanism as the SERVER_FRONTEND_URL backfill below: additive, guarded
+# (`grep -q`), idempotent .env + compose-mapping patches on a LIVE host, re-applied
+# on every deploy. The 4 QA_CAPTURE_EXPORT_STORAGE_* vars (~588 B) are deliberately
+# NOT in the shared stage0 compose — that file is also embedded in the edge
+# Lightsail launch script, which sits ~46 B under Lightsail's 16 KB user-data cap,
+# so adding them there breaks edge provisioning. Edges are pure cc-relay mirrors
+# that never capture/export QA trajectories, so they have no use for this config.
+# Gate on the prod signal (EC2 `i-*`; every edge is a Lightsail `mi-*`) → edges get
+# an empty array, i.e. a byte-identical command list to before this change.
+# Credentials stay EMPTY on purpose: the prod instance role + the qa-exports bucket
+# policy (Principal = prod InstanceRole ARN) grant s3:PutObject, so no static keys
+# ever land in .env. Values are env-overridable but default to the prod bucket.
+# See docs/qa-export-s3-and-auto-archive.md.
+qa_export_cmds='[]'
+if [[ "${INSTANCE_ID}" == i-* ]]; then
+  qa_export_cmds="$(jq -n \
+    --arg tag "${TAG}" \
+    --arg driver "${QA_CAPTURE_EXPORT_STORAGE_DRIVER:-s3}" \
+    --arg region "${QA_CAPTURE_EXPORT_STORAGE_REGION:-us-east-1}" \
+    --arg bucket "${QA_CAPTURE_EXPORT_STORAGE_BUCKET:-tokenkey-prod-qa-exports}" \
+    --arg prefix "${QA_CAPTURE_EXPORT_STORAGE_PREFIX:-traj-exports}" '
+    [
+      ( "qa_d=" + ($driver|@sh) + "; qa_r=" + ($region|@sh) + "; qa_b=" + ($bucket|@sh) + "; qa_p=" + ($prefix|@sh)
+        + "; for kv in \"DRIVER=$qa_d\" \"REGION=$qa_r\" \"BUCKET=$qa_b\" \"PREFIX=$qa_p\"; do"
+        + " key=\"QA_CAPTURE_EXPORT_STORAGE_${kv%%=*}\"; val=\"${kv#*=}\";"
+        + " if ! grep -q \"^${key}=\" /var/lib/tokenkey/.env; then echo \"${key}=${val}\" | sudo tee -a /var/lib/tokenkey/.env >/dev/null; echo \"ensured ${key}\";"
+        + " else echo \"${key} already present\"; fi; done" ),
+      ( "CF=/var/lib/tokenkey/docker-compose.yml; if [ -f \"$CF\" ]; then miss=0;"
+        + " for k in DRIVER REGION BUCKET PREFIX; do grep -q \"QA_CAPTURE_EXPORT_STORAGE_${k}=\" \"$CF\" || miss=1; done;"
+        + " if [ \"$miss\" = 1 ]; then sudo cp -a \"$CF\" \"$CF.qa-export-before-" + $tag + "\";"
+        + " for k in PREFIX BUCKET REGION DRIVER; do key=\"QA_CAPTURE_EXPORT_STORAGE_$k\";"
+        + " grep -q \"${key}=\" \"$CF\" || sudo sed -i '\''/^      - TZ=/a\\      - '\''\"$key\"'\''=${'\''\"$key\"'\'':-}'\'' \"$CF\"; done;"
+        + " if grep -q QA_CAPTURE_EXPORT_STORAGE_DRIVER \"$CF\"; then echo ensured-compose-QA_CAPTURE_EXPORT_STORAGE-mappings;"
+        + " else echo '\''::warning::failed to insert compose QA_CAPTURE_EXPORT_STORAGE mappings'\''; fi;"
+        + " else echo compose-QA_CAPTURE_EXPORT_STORAGE-mappings-present; fi; fi" )
+    ]')"
+fi
+
+jq -n --arg tag "${TAG}" --argjson qa_cmds "${qa_export_cmds}" '{
+  commands: ([
     "set -euo pipefail",
     ("echo === deploy stage0 to tag=" + $tag + " ==="),
     ("BACKUP=/var/lib/tokenkey/.env.before-" + $tag),
@@ -132,7 +171,8 @@ jq -n --arg tag "${TAG}" '{
     ("sudo sed -i '\''s|sub2api:[^[:space:]]*|sub2api:" + $tag + "|'\'' /var/lib/tokenkey/.env"),
     "if ! grep -q '\''^SERVER_FRONTEND_URL='\'' /var/lib/tokenkey/.env; then d=$(sed -n '\''s/^API_DOMAIN=//p'\'' /var/lib/tokenkey/.env | head -1); if [ -n \"$d\" ]; then echo \"SERVER_FRONTEND_URL=https://$d\" | sudo tee -a /var/lib/tokenkey/.env >/dev/null; echo \"ensured SERVER_FRONTEND_URL=https://$d\"; else echo \"API_DOMAIN empty; skip SERVER_FRONTEND_URL backfill\"; fi; else echo \"SERVER_FRONTEND_URL already present\"; fi",
     "if ! grep -q '\''^TOKENKEY_GHCR_KEEP_TAGS='\'' /var/lib/tokenkey/.env; then echo '\''TOKENKEY_GHCR_KEEP_TAGS=3'\'' | sudo tee -a /var/lib/tokenkey/.env >/dev/null; echo '\''ensured TOKENKEY_GHCR_KEEP_TAGS=3'\''; else echo '\''TOKENKEY_GHCR_KEEP_TAGS already present'\''; fi",
-    ("if [ -f /var/lib/tokenkey/docker-compose.yml ] && ! grep -q '\''SERVER_FRONTEND_URL'\'' /var/lib/tokenkey/docker-compose.yml; then sudo cp -a /var/lib/tokenkey/docker-compose.yml /var/lib/tokenkey/docker-compose.yml.compose-before-" + $tag + "; sudo sed -i '\''/^      - TZ=/a\\      - SERVER_FRONTEND_URL=${SERVER_FRONTEND_URL:-}'\'' /var/lib/tokenkey/docker-compose.yml; if grep -q '\''SERVER_FRONTEND_URL'\'' /var/lib/tokenkey/docker-compose.yml; then echo ensured-compose-SERVER_FRONTEND_URL-mapping; else echo '\''::warning::failed to insert compose SERVER_FRONTEND_URL mapping'\''; fi; else echo compose-SERVER_FRONTEND_URL-mapping-present-or-no-compose; fi"),
+    ("if [ -f /var/lib/tokenkey/docker-compose.yml ] && ! grep -q '\''SERVER_FRONTEND_URL'\'' /var/lib/tokenkey/docker-compose.yml; then sudo cp -a /var/lib/tokenkey/docker-compose.yml /var/lib/tokenkey/docker-compose.yml.compose-before-" + $tag + "; sudo sed -i '\''/^      - TZ=/a\\      - SERVER_FRONTEND_URL=${SERVER_FRONTEND_URL:-}'\'' /var/lib/tokenkey/docker-compose.yml; if grep -q '\''SERVER_FRONTEND_URL'\'' /var/lib/tokenkey/docker-compose.yml; then echo ensured-compose-SERVER_FRONTEND_URL-mapping; else echo '\''::warning::failed to insert compose SERVER_FRONTEND_URL mapping'\''; fi; else echo compose-SERVER_FRONTEND_URL-mapping-present-or-no-compose; fi")
+  ] + $qa_cmds + [
     "echo \"=== pull new image BEFORE drain (old container keeps serving 100% traffic) ===\"",
     "cd /var/lib/tokenkey && sudo docker compose --env-file .env pull tokenkey",
     "echo \"=== pre-drain: SIGUSR1 + wait in_flight=0 (only when outgoing container healthy) ===\"",
@@ -147,8 +187,16 @@ jq -n --arg tag "${TAG}" '{
     "echo \"=== prune stale ghcr image tags (keep newest 3 + in-use) — runs on every deploy; the tokenkey.service ExecStartPost hook only fires on full restart, so deploys never pruned and tags piled to 50+/14G per node before this ===\"; PRUNE=/usr/local/bin/tokenkey-prune-ghcr-app-tags-core.sh; [ -x \"$PRUNE\" ] || PRUNE=/usr/local/bin/tokenkey-prune-ghcr-app-tags.sh; if [ -x \"$PRUNE\" ]; then sudo env TOKENKEY_GHCR_KEEP_TAGS=3 \"$PRUNE\" || echo '\''::warning::ghcr prune failed (non-fatal)'\''; else echo '\''no ghcr prune script on box; skipping'\''; fi; sudo docker image prune -f >/dev/null 2>&1 || true",
     "cd /var/lib/tokenkey && sudo docker compose ps",
     "sudo docker logs tokenkey --since 2m 2>&1 | tail -20"
-  ]
+  ])
 }' > "${params_file}"
+
+# Render-only seam: write the SSM command document and exit before any AWS call.
+# Lets the prod-vs-edge QA-export injection be asserted deterministically in tests
+# (see ops/stage0/test_deploy_via_ssm_qa_export.py) without touching live infra.
+if [[ -n "${STAGE0_RENDER_ONLY:-}" ]]; then
+  echo "stage0_deploy_via_ssm: STAGE0_RENDER_ONLY set; wrote ${params_file} and exiting" >&2
+  exit 0
+fi
 
 eff_instance_id="${INSTANCE_ID}"
 if [[ "${INSTANCE_ID}" == mi-* && -n "${EDGE_ID:-}" ]]; then

--- a/ops/stage0/test_deploy_via_ssm_qa_export.py
+++ b/ops/stage0/test_deploy_via_ssm_qa_export.py
@@ -1,0 +1,168 @@
+#!/usr/bin/env python3
+"""Tests for the prod-only QA-export injection in ops/stage0/deploy_via_ssm.sh.
+
+deploy_via_ssm.sh self-heals the QA trajectory export config (the 4
+QA_CAPTURE_EXPORT_STORAGE_* env vars) onto a LIVE prod host on every deploy,
+mirroring the SERVER_FRONTEND_URL backfill. The vars are deliberately NOT in the
+shared stage0 compose because that file is also embedded in the edge Lightsail
+launch script, which sits ~46 B under Lightsail's 16 KB user-data cap. Edges are
+pure cc-relay mirrors that never export QA, so the injection must be gated to the
+prod EC2 (`i-*`) node and never reach a Lightsail edge (`mi-*`).
+
+The script exposes a STAGE0_RENDER_ONLY seam: it writes the SSM command document
+and exits before any AWS call, so the rendered command list can be asserted with
+no live infra. On Linux (= CI, GNU sed) we additionally execute the two injected
+commands against a fake .env + compose and assert the resulting files, proving the
+guarded, idempotent .env append + the `/^      - TZ=/a\\` compose insertion.
+
+stdlib-only; no AWS, no network.
+"""
+from __future__ import annotations
+
+import json
+import os
+import pathlib
+import platform
+import subprocess
+import tempfile
+import unittest
+
+_SCRIPT = pathlib.Path(__file__).resolve().parent / "deploy_via_ssm.sh"
+
+# Every edge in the fleet is a Lightsail managed instance (mi-*); prod is the
+# only EC2 (i-*) node. These fakes exercise both arms of the gate.
+_PROD_IID = "i-0prod000000000000"
+_EDGE_IID = "mi-0edge000000000000"
+
+
+def _render(instance_id: str, tag: str = "1.8.99", env_extra: dict | None = None):
+    """Run the script in render-only mode; return (proc, commands list)."""
+    out_dir = tempfile.mkdtemp(prefix="qa-export-render-")
+    env = {
+        **os.environ,
+        "STAGE0_RENDER_ONLY": "1",
+        "STAGE0_SSM_OUTPUT_DIR": out_dir,
+    }
+    if env_extra:
+        env.update(env_extra)
+    proc = subprocess.run(
+        ["bash", str(_SCRIPT), tag, instance_id],
+        env=env, capture_output=True, text=True, check=False,
+    )
+    params = json.loads((pathlib.Path(out_dir) / "ssm-params.json").read_text())
+    return proc, params["commands"]
+
+
+def _qa_cmds(commands: list[str]) -> list[str]:
+    return [c for c in commands if "QA_CAPTURE_EXPORT_STORAGE" in c]
+
+
+class QAExportInjectionRenderTest(unittest.TestCase):
+    def test_prod_injects_exactly_two_guarded_commands(self) -> None:
+        proc, commands = _render(_PROD_IID)
+        self.assertEqual(proc.returncode, 0, msg=proc.stderr)
+        qa = _qa_cmds(commands)
+        self.assertEqual(len(qa), 2, msg=f"expected 2 QA cmds, got {len(qa)}: {qa}")
+
+        env_cmd = next(c for c in qa if "/var/lib/tokenkey/.env" in c and "docker-compose" not in c)
+        # default prod values, supplied via @sh-quoted shell vars
+        self.assertIn("qa_d='s3'", env_cmd)
+        self.assertIn("qa_r='us-east-1'", env_cmd)
+        self.assertIn("qa_b='tokenkey-prod-qa-exports'", env_cmd)
+        self.assertIn("qa_p='traj-exports'", env_cmd)
+        # guarded + additive (must not clobber an existing value)
+        self.assertIn('grep -q "^${key}=" /var/lib/tokenkey/.env', env_cmd)
+        self.assertIn("tee -a /var/lib/tokenkey/.env", env_cmd)
+        # credentials are NEVER written to .env (instance role + bucket policy)
+        self.assertNotIn("ACCESS_KEY", env_cmd)
+        self.assertNotIn("SECRET", env_cmd)
+
+        compose_cmd = next(c for c in qa if "docker-compose.yml" in c)
+        self.assertIn("/^      - TZ=/a\\", compose_cmd)          # anchored to the TZ line
+        self.assertIn("qa-export-before-1.8.99", compose_cmd)    # tagged backup ($CF.qa-export-before-<tag>)
+        self.assertIn('grep -q "${key}=" "$CF"', compose_cmd)    # guarded insertion
+
+    def test_edge_gets_no_qa_injection(self) -> None:
+        # mi-* + EDGE_ID is the edge arm: the command list must be byte-identical
+        # to the pre-change baseline (empty injection array).
+        proc, commands = _render(_EDGE_IID, env_extra={"EDGE_ID": "us2"})
+        self.assertEqual(proc.returncode, 0, msg=proc.stderr)
+        self.assertEqual(_qa_cmds(commands), [])
+
+    def test_prod_minus_qa_equals_edge_command_count(self) -> None:
+        # The only difference between prod and edge is the 2 injected commands.
+        _, prod = _render(_PROD_IID)
+        _, edge = _render(_EDGE_IID, env_extra={"EDGE_ID": "us2"})
+        self.assertEqual(len(prod) - len(edge), 2)
+
+    def test_values_are_env_overridable(self) -> None:
+        proc, commands = _render(_PROD_IID, env_extra={
+            "QA_CAPTURE_EXPORT_STORAGE_BUCKET": "custom-bucket",
+            "QA_CAPTURE_EXPORT_STORAGE_PREFIX": "custom/prefix",
+        })
+        self.assertEqual(proc.returncode, 0, msg=proc.stderr)
+        env_cmd = next(c for c in _qa_cmds(commands) if "tee -a" in c)
+        self.assertIn("qa_b='custom-bucket'", env_cmd)
+        self.assertIn("qa_p='custom/prefix'", env_cmd)
+
+
+@unittest.skipUnless(
+    platform.system() == "Linux",
+    "compose insertion uses GNU sed `a\\` one-line syntax (prod is Linux; BSD sed differs)",
+)
+class QAExportInjectionExecuteTest(unittest.TestCase):
+    """Execute the two prod commands against a fake host and assert the result."""
+
+    def _run_prod_cmds_against(self, host: pathlib.Path) -> None:
+        _, commands = _render(_PROD_IID)
+        script = "\n".join(_qa_cmds(commands))
+        # retarget the hardcoded host paths into the temp dir; drop sudo
+        script = script.replace("/var/lib/tokenkey", str(host)).replace("sudo ", "")
+        subprocess.run(["bash", "-e", "-c", script], check=True,
+                       capture_output=True, text=True)
+
+    def test_injection_is_correct_and_idempotent(self) -> None:
+        host = pathlib.Path(tempfile.mkdtemp(prefix="qa-export-exec-"))
+        (host / ".env").write_text("APP_ENV=prod\nAPI_DOMAIN=api.tokenkey.dev\n")
+        (host / "docker-compose.yml").write_text(
+            "services:\n"
+            "  tokenkey:\n"
+            "    environment:\n"
+            "      - SERVER_FRONTEND_URL=${SERVER_FRONTEND_URL:-}\n"
+            "      - TZ=${TZ:-UTC}\n"
+            "    ports:\n"
+            '      - "8080:8080"\n'
+        )
+
+        self._run_prod_cmds_against(host)
+
+        env_txt = (host / ".env").read_text()
+        for k, v in (
+            ("DRIVER", "s3"), ("REGION", "us-east-1"),
+            ("BUCKET", "tokenkey-prod-qa-exports"), ("PREFIX", "traj-exports"),
+        ):
+            self.assertIn(f"QA_CAPTURE_EXPORT_STORAGE_{k}={v}\n", env_txt)
+
+        compose_txt = (host / "docker-compose.yml").read_text()
+        for k in ("DRIVER", "REGION", "BUCKET", "PREFIX"):
+            mapping = f"      - QA_CAPTURE_EXPORT_STORAGE_{k}=${{QA_CAPTURE_EXPORT_STORAGE_{k}:-}}\n"
+            self.assertIn(mapping, compose_txt)
+        # inserted after the TZ line, not before it
+        self.assertLess(compose_txt.index("- TZ="),
+                        compose_txt.index("QA_CAPTURE_EXPORT_STORAGE_DRIVER"))
+        self.assertTrue(list(host.glob("docker-compose.yml.qa-export-before-*")))
+
+        # second run is a no-op: exactly 4 .env lines + 4 compose mappings, no dupes.
+        # (count by line, not substring: a compose mapping mentions the prefix twice.)
+        self._run_prod_cmds_against(host)
+
+        def _qa_lines(text: str, needle: str) -> int:
+            return sum(1 for ln in text.splitlines() if needle in ln)
+
+        self.assertEqual(_qa_lines((host / ".env").read_text(), "QA_CAPTURE_EXPORT_STORAGE_"), 4)
+        self.assertEqual(
+            _qa_lines((host / "docker-compose.yml").read_text(), "- QA_CAPTURE_EXPORT_STORAGE_"), 4)
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## 背景

#836 修好了 env 绑定（`QA_CAPTURE_EXPORT_STORAGE_*` 现在能经 `AutomaticEnv` 注入），但「把这 4 个 env 直接加进共享 stage0 compose」走不通：edge Lightsail 把那份 compose gzip|base64 嵌进 launch script，而 launch script 已经贴着 14336B 用户数据上限只剩 ~46B 余量，4 个 export_storage env（~588B）会顶破上限。而且 edge 全是纯 cc-relay 镜像、从不捕获/导出 QA——为一个 prod-only 功能付 edge 体积代价本身就是错的。

经研究确认的三个改变路线的事实（决定走 deploy-sed 而非解 edge 上限）：
1. `deploy_via_ssm.sh` 升级**不刷新 host compose**（只 patch `.env` + sed 补缺失映射 + recreate）→ launch-script/CFN compose 只在实例 **CREATE** 时用。现有 prod 是单实例、不能重建 → 启用 S3 **必须**经 deploy 时改运行实例。
2. 9 个 edge 全是 cc-relay，不做 QA 导出 → edge 不需要这套 env。
3. deploy-sed 改的是运行实例的 host compose，**不碰 create-time launch-script** → 天然绕开 edge 14336B 上限。

## 实现（deploy-sed，prod-only）

完全复刻既有的 `SERVER_FRONTEND_URL` self-heal 模式：`ops/stage0/deploy_via_ssm.sh` 在每次部署时把 4 个 env self-heal 到运行中的 prod host——

- **`.env` backfill**：guarded（`grep -q`）、additive、幂等地追加 4 个 `QA_CAPTURE_EXPORT_STORAGE_*`。
- **compose 映射**：`/^      - TZ=/a\` 在 TZ 行后插入 4 个 `${VAR:-}` 映射，带打 tag 的 compose 备份。
- **prod-only 门**：gate 在 `INSTANCE_ID == i-*`（EC2=prod）；每个 edge 是 Lightsail `mi-*`，拿到**空注入**（命令列表与改动前字节一致，edge 行为不变）。
- **共享 stage0 compose 完全不动** → edge launch-script 上限永不被逼近（preflight 的 launch-script drift 检查保持绿）。
- **凭证刻意留空**：prod instance role + qa-exports bucket policy 授予 `s3:PutObject`，**没有任何静态密钥落进 `.env`**。

新增 `STAGE0_RENDER_ONLY` seam：写出 SSM 命令文档后、任何 AWS 调用前退出，让 prod/edge 门可被确定性测试。

## 测试

`ops/stage0/test_deploy_via_ssm_qa_export.py`：
- **render 断言**（全平台）：prod 恰好注入 2 条 guarded 命令、值正确、凭证为空；edge 零注入；值可被 env 覆写。
- **真实执行**（Linux/GNU sed）：把这 2 条命令对照假 `.env`+compose 真跑，断言结果文件 + 幂等性。

本地验证：macOS（render，BSD sed 跳过执行）+ debian/python 容器（GNU sed，全套含执行测试 5/5 绿）。`scripts/preflight.sh` 全绿（含 `deploy_via_ssm.sh host script parses`、launch-script drift）。

## 范围与后续

这是 S3 启用的**阶段 1（代码）**。后续操作步骤（需逐步授权）：
1. 发版携带 #836 + 本 PR 的镜像；
2. 建 `tokenkey-prod-qa-exports` 桶 + `traj-exports/` 7 天 lifecycle + bucket policy（Principal = prod InstanceRole ARN，不动实例栈，仿 pgdump 桶）；
3. 部署（`deploy-stage0`）→ `deploy_via_ssm.sh` 注入 + recreate；
4. 验证 per-key `download_url` 变成 S3 presigned（亚秒级），不再走 30s 网关代理（即「下载没反应」的根因）。

文档已更新：`docs/qa-export-s3-and-auto-archive.md`。

## drift / 合并

`check-drift.sh`：TK ahead 918 / behind 80（该 repo 常态，每日 upstream-merge agent 处理）。本 PR 只触达 TK ops 基建（`ops/stage0/`、`docs/`），与任何 upstream-shaped 路径**零重叠**，故可 out-of-order ship，不必等 upstream 合并。

无 web 改动；非 backend Go；无 upstream-override marker / sentinel 需求（preflight 已确认）。建议 **Squash and merge**（TK 自源 PR）。

🤖 Generated with [Claude Code](https://claude.com/claude-code)