### PR TITLE
feat(infra): QA traj 导出 S3 桶（扩进 tokenkey-stage0-backups，参照 pgdump 桶）

### DIFF
--- a/deploy/aws/cloudformation/stage0-backups.yaml
+++ b/deploy/aws/cloudformation/stage0-backups.yaml
@@ -9,6 +9,11 @@ Description: >
   TOKENKEY_PGDUMP_S3_URI is set in /var/lib/tokenkey/.env. Lifecycle expires
   copies after RetentionDays; no versioning (each key is a unique timestamp).
 
+  ALSO holds the QA trajectory export bucket (durable export ZIPs + presigned
+  downloads, qa_capture.export_storage) — same standalone-stack + direct-role-ARN
+  pattern, so enabling QA S3 export needs no prod-instance-stack update either.
+  See docs/qa-export-s3-and-auto-archive.md.
+
 Parameters:
   ProjectName:
     Type: String
@@ -22,6 +27,15 @@ Parameters:
     MinValue: 1
     MaxValue: 365
     Description: Days to keep each pg_dump copy before lifecycle expiry.
+  QaExportsRetentionDays:
+    Type: Number
+    Default: 7
+    MinValue: 1
+    MaxValue: 365
+    Description: >
+      Days to keep each QA trajectory export ZIP (traj-exports/ prefix) before
+      lifecycle expiry. Separate from RetentionDays so QA-export and pg_dump
+      retention can be tuned independently.
   AppInstanceRoleArn:
     Type: String
     Description: >
@@ -101,6 +115,75 @@ Resources:
             Action: 's3:ListBucket'
             Resource: !GetAtt PgdumpBackupBucket.Arn
 
+  QaExportsBucket:
+    Type: AWS::S3::Bucket
+    # Retain on stack delete so finished export ZIPs are not lost by an accidental teardown.
+    DeletionPolicy: Retain
+    UpdateReplacePolicy: Retain
+    Properties:
+      BucketName: !Sub '${ProjectName}-${Environment}-qa-exports-${AWS::AccountId}'
+      PublicAccessBlockConfiguration:
+        BlockPublicAcls: true
+        BlockPublicPolicy: true
+        IgnorePublicAcls: true
+        RestrictPublicBuckets: true
+      BucketEncryption:
+        ServerSideEncryptionConfiguration:
+          - ServerSideEncryptionByDefault:
+              SSEAlgorithm: AES256
+      VersioningConfiguration:
+        Status: Suspended
+      LifecycleConfiguration:
+        Rules:
+          - Id: expire-traj-exports
+            Status: Enabled
+            Prefix: traj-exports/
+            ExpirationInDays: !Ref QaExportsRetentionDays
+            AbortIncompleteMultipartUpload:
+              DaysAfterInitiation: 1
+
+  QaExportsBucketPolicy:
+    Type: AWS::S3::BucketPolicy
+    Properties:
+      Bucket: !Ref QaExportsBucket
+      PolicyDocument:
+        Version: '2012-10-17'
+        Statement:
+          # Enforce TLS for all access.
+          - Sid: DenyInsecureTransport
+            Effect: Deny
+            Principal: '*'
+            Action: 's3:*'
+            Resource:
+              - !GetAtt QaExportsBucket.Arn
+              - !Sub '${QaExportsBucket.Arn}/*'
+            Condition:
+              Bool:
+                'aws:SecureTransport': 'false'
+          # Same direct-role-ARN principal pattern as the pgdump grant above — a
+          # same-account resource-based grant is sufficient on its own, so the prod
+          # instance stack is never touched. The app writes export ZIPs (PutObject),
+          # signs presigned download URLs + reads them server-side (GetObject), and
+          # prunes terminal/expired exports (DeleteObject). This bucket is
+          # single-purpose (QA exports only), so object actions are granted
+          # bucket-wide rather than pinned to the env-overridable
+          # QA_CAPTURE_EXPORT_STORAGE_PREFIX (default traj-exports/).
+          - Sid: AllowAppInstanceRolePutGetDelete
+            Effect: Allow
+            Principal:
+              AWS: !Ref AppInstanceRoleArn
+            Action:
+              - 's3:PutObject'
+              - 's3:GetObject'
+              - 's3:DeleteObject'
+            Resource: !Sub '${QaExportsBucket.Arn}/*'
+          - Sid: AllowAppInstanceRoleListQaExports
+            Effect: Allow
+            Principal:
+              AWS: !Ref AppInstanceRoleArn
+            Action: 's3:ListBucket'
+            Resource: !GetAtt QaExportsBucket.Arn
+
   # NOTE — the .env SECRETS off-box (SSM SecureString, a DIFFERENT blast radius than this
   # dump bucket so the decryption keys are not co-located with the ciphertext) needs an
   # IDENTITY grant (ssm:PutParameter), because SSM Parameters have no resource policy — a
@@ -119,6 +202,16 @@ Outputs:
   PgdumpS3Uri:
     Description: Set this as TOKENKEY_PGDUMP_S3_URI in /var/lib/tokenkey/.env on the app host.
     Value: !Sub 's3://${PgdumpBackupBucket}/${Environment}/pgdump'
+  QaExportsBucketName:
+    Description: >
+      QA trajectory export bucket. Matches the QA_CAPTURE_EXPORT_STORAGE_BUCKET default
+      self-healed by ops/stage0/deploy_via_ssm.sh on the prod host.
+    Value: !Ref QaExportsBucket
+  QaExportsS3Uri:
+    Description: >
+      s3:// base for QA exports; objects land under QA_CAPTURE_EXPORT_STORAGE_PREFIX
+      (default traj-exports/), which the expire-traj-exports lifecycle rule reaps.
+    Value: !Sub 's3://${QaExportsBucket}'
   EnvSecretsSsmParam:
     Description: Set this as TOKENKEY_ENV_SECRETS_SSM in /var/lib/tokenkey/.env; SecureString holding the off-box .env secrets.
     Value: !Sub '/${ProjectName}/${Environment}/stage0/env-secrets-backup'

--- a/docs/qa-export-s3-and-auto-archive.md
+++ b/docs/qa-export-s3-and-auto-archive.md
@@ -30,13 +30,13 @@ qa_capture:
   export_storage:                        # NEW — export ZIPs go here
     driver: s3
     region: us-east-1
-    bucket: tokenkey-prod-qa-exports
+    bucket: tokenkey-prod-qa-exports-682751977094
     # access via the instance role (preferred) — leave keys empty
 ```
 
 Infra to provision first (do this in waking hours, then flip config):
 
-1. **Bucket** `tokenkey-prod-qa-exports` (us-east-1), Block Public Access ON.
+1. **Bucket** `tokenkey-prod-qa-exports-682751977094` (us-east-1), Block Public Access ON.
 2. **Lifecycle rule**: expire objects under prefix `traj-exports/` after **7
    days** (object age). This is the real expirer; the DB `expires_at` mirrors it
    for the UI.
@@ -90,7 +90,7 @@ Rollout (each step needs operator authorization; read-only diagnosis: skill
 `tokenkey-online-log-troubleshooting`):
 
 1. **Release** an image carrying the #836 fix (VERSION bump → tag → `release.yml`).
-2. **Provision infra**: bucket `tokenkey-prod-qa-exports` (us-east-1, Block Public
+2. **Provision infra**: bucket `tokenkey-prod-qa-exports-682751977094` (us-east-1, Block Public
    Access ON) + prefix-`traj-exports/` 7-day lifecycle + bucket policy granting the
    prod instance role (`tokenkey-prod-stage0-InstanceRole-*`)
    `s3:GetObject/PutObject/DeleteObject/ListBucket` — Principal = the resolved role

--- a/ops/stage0/deploy_via_ssm.sh
+++ b/ops/stage0/deploy_via_ssm.sh
@@ -141,7 +141,7 @@ if [[ "${INSTANCE_ID}" == i-* ]]; then
     --arg tag "${TAG}" \
     --arg driver "${QA_CAPTURE_EXPORT_STORAGE_DRIVER:-s3}" \
     --arg region "${QA_CAPTURE_EXPORT_STORAGE_REGION:-us-east-1}" \
-    --arg bucket "${QA_CAPTURE_EXPORT_STORAGE_BUCKET:-tokenkey-prod-qa-exports}" \
+    --arg bucket "${QA_CAPTURE_EXPORT_STORAGE_BUCKET:-tokenkey-prod-qa-exports-682751977094}" \
     --arg prefix "${QA_CAPTURE_EXPORT_STORAGE_PREFIX:-traj-exports}" '
     [
       ( "qa_d=" + ($driver|@sh) + "; qa_r=" + ($region|@sh) + "; qa_b=" + ($bucket|@sh) + "; qa_p=" + ($prefix|@sh)

--- a/ops/stage0/test_deploy_via_ssm_qa_export.py
+++ b/ops/stage0/test_deploy_via_ssm_qa_export.py
@@ -68,7 +68,7 @@ class QAExportInjectionRenderTest(unittest.TestCase):
         # default prod values, supplied via @sh-quoted shell vars
         self.assertIn("qa_d='s3'", env_cmd)
         self.assertIn("qa_r='us-east-1'", env_cmd)
-        self.assertIn("qa_b='tokenkey-prod-qa-exports'", env_cmd)
+        self.assertIn("qa_b='tokenkey-prod-qa-exports-682751977094'", env_cmd)
         self.assertIn("qa_p='traj-exports'", env_cmd)
         # guarded + additive (must not clobber an existing value)
         self.assertIn('grep -q "^${key}=" /var/lib/tokenkey/.env', env_cmd)
@@ -139,7 +139,7 @@ class QAExportInjectionExecuteTest(unittest.TestCase):
         env_txt = (host / ".env").read_text()
         for k, v in (
             ("DRIVER", "s3"), ("REGION", "us-east-1"),
-            ("BUCKET", "tokenkey-prod-qa-exports"), ("PREFIX", "traj-exports"),
+            ("BUCKET", "tokenkey-prod-qa-exports-682751977094"), ("PREFIX", "traj-exports"),
         ):
             self.assertIn(f"QA_CAPTURE_EXPORT_STORAGE_{k}={v}\n", env_txt)
 


### PR DESCRIPTION
## 背景

QA 导出 S3 启用的**阶段 2(基建)**,接 #838(deploy-sed)。你提示参照 pgdump 备份桶——这正是做法:**扩进同一个 `tokenkey-stage0-backups` 独立栈**,完全复刻 pgdump 桶的模式。

## 改动

**`deploy/aws/cloudformation/stage0-backups.yaml`**(扩既有栈):
- 新增 `QaExportsBucket`:Block Public Access、AES256、versioning suspended、`traj-exports/` 前缀 7 天 lifecycle、`AbortIncompleteMultipartUpload`。
- 新增 `QaExportsBucketPolicy`:TLS-enforce deny + 授予 prod InstanceRole `s3:PutObject/GetObject/DeleteObject` + `ListBucket`,**Principal 直接命名 role ARN**(same-account 资源型授权,自给自足 → **不动 prod 实例栈**;account-root principal 曾 AccessDenied,与 pgdump 同一教训)。桶单一用途,故对象动作授到桶级而非钉死可覆写的 `QA_CAPTURE_EXPORT_STORAGE_PREFIX`。
- 新增参数 `QaExportsRetentionDays`(默认 7),与 pgdump 的 `RetentionDays` 独立。
- 既有 pgdump 桶 `DeletionPolicy: Retain` 完全不动。

**桶名带 `${AWS::AccountId}` 后缀** `tokenkey-prod-qa-exports-682751977094`——与同模板内 pgdump 桶命名一致 + 全局唯一保证。#838 当时用的是无后缀名;本 PR 把 `deploy_via_ssm.sh` 默认值 + 测试 + doc **三处同步成后缀名**(桶名单一源)。prod 部署跑的是 **main 上的** `deploy_via_ssm.sh`(deploy-stage0 checkout HEAD 非 image tag),所以这次更新下次部署自动生效、**无需再发版**。

## 部署(合并后)

```
aws cloudformation deploy --region us-east-1 --stack-name tokenkey-stage0-backups \
  --template-file deploy/aws/cloudformation/stage0-backups.yaml \
  --parameter-overrides AppInstanceRoleArn=arn:aws:iam::682751977094:role/tokenkey-prod-stage0-InstanceRole-8WDNQenLojCf
```
加法更新(retained pgdump 桶不受影响);无 CAPABILITY_IAM(只有桶+桶策略)。

## 验证

- `aws cloudformation validate-template` OK(Capabilities=null);
- `ops/stage0/test_deploy_via_ssm_qa_export.py` 后缀名下全绿;
- `scripts/preflight.sh` PASS(含 CFN template-version gate)。

## rollout 位置

① #838 deploy-sed(已合)→ **② 本 PR 建桶 IaC** → ③ dispatch deploy-stage0(1.8.11,注入 env)→ ④ 验证 presigned 下载。③ 必须在桶建好之后(否则注入 DRIVER=s3 指向空桶导出失败)。

非 backend Go、无前端改动(`no-web-impact` 已声明);TK 基建无 upstream-override marker 需求。建议 **Squash and merge**。

🤖 Generated with [Claude Code](https://claude.com/claude-code)