### PR TITLE
fix(ops): QA-export compose 注入锚点 TZ→tokenkey 专属 SERVER_FRONTEND_URL

### DIFF
--- a/docs/qa-export-s3-and-auto-archive.md
+++ b/docs/qa-export-s3-and-auto-archive.md
@@ -76,8 +76,11 @@ prod-only feature.
 **How it ships instead (deploy-sed, prod-only).** `ops/stage0/deploy_via_ssm.sh`
 self-heals the 4 vars onto the LIVE prod host on every deploy — the exact
 mechanism already used for `SERVER_FRONTEND_URL`: a guarded (`grep -q`), additive,
-idempotent `.env` backfill + a `/^      - TZ=/a\` insertion of the 4 compose
-mappings, with a tagged compose backup. It is gated to the prod EC2 node
+idempotent `.env` backfill + a `/^      - SERVER_FRONTEND_URL=/a\` insertion of the
+4 compose mappings (anchored to the tokenkey-unique SERVER_FRONTEND_URL line, not
+the per-service `TZ` line — every service carries a `TZ` line, so a `TZ` anchor
+injected the mappings once per service), with a tagged compose backup. It is gated
+to the prod EC2 node
 (`INSTANCE_ID == i-*`); every edge is a Lightsail `mi-*` and gets an empty
 injection (byte-identical command list). Values default to the prod bucket but are
 env-overridable. **Credentials stay empty on purpose** — the prod instance role +

--- a/ops/stage0/deploy_via_ssm.sh
+++ b/ops/stage0/deploy_via_ssm.sh
@@ -135,6 +135,14 @@ stderr_file="${OUTPUT_DIR}/stderr.txt"
 # policy (Principal = prod InstanceRole ARN) grant s3:PutObject, so no static keys
 # ever land in .env. Values are env-overridable but default to the prod bucket.
 # See docs/qa-export-s3-and-auto-archive.md.
+#
+# Compose insertion anchors on the tokenkey service's SERVER_FRONTEND_URL line, NOT
+# its TZ line: every service (caddy/tokenkey/postgres/redis) carries a `- TZ=` line,
+# so `/^      - TZ=/a\` matched all of them and injected the 4 mappings once PER
+# service (harmless on postgres/redis, which ignore the env, but wrong). The first
+# 1.8.11 prod deploy did exactly that; the host compose was de-duplicated out of band.
+# SERVER_FRONTEND_URL is unique to the tokenkey service and is guaranteed present by
+# the SERVER_FRONTEND_URL backfill below, which runs earlier in this command list.
 qa_export_cmds='[]'
 if [[ "${INSTANCE_ID}" == i-* ]]; then
   qa_export_cmds="$(jq -n \
@@ -153,7 +161,7 @@ if [[ "${INSTANCE_ID}" == i-* ]]; then
         + " for k in DRIVER REGION BUCKET PREFIX; do grep -q \"QA_CAPTURE_EXPORT_STORAGE_${k}=\" \"$CF\" || miss=1; done;"
         + " if [ \"$miss\" = 1 ]; then sudo cp -a \"$CF\" \"$CF.qa-export-before-" + $tag + "\";"
         + " for k in PREFIX BUCKET REGION DRIVER; do key=\"QA_CAPTURE_EXPORT_STORAGE_$k\";"
-        + " grep -q \"${key}=\" \"$CF\" || sudo sed -i '\''/^      - TZ=/a\\      - '\''\"$key\"'\''=${'\''\"$key\"'\'':-}'\'' \"$CF\"; done;"
+        + " grep -q \"${key}=\" \"$CF\" || sudo sed -i '\''/^      - SERVER_FRONTEND_URL=/a\\      - '\''\"$key\"'\''=${'\''\"$key\"'\'':-}'\'' \"$CF\"; done;"
         + " if grep -q QA_CAPTURE_EXPORT_STORAGE_DRIVER \"$CF\"; then echo ensured-compose-QA_CAPTURE_EXPORT_STORAGE-mappings;"
         + " else echo '\''::warning::failed to insert compose QA_CAPTURE_EXPORT_STORAGE mappings'\''; fi;"
         + " else echo compose-QA_CAPTURE_EXPORT_STORAGE-mappings-present; fi; fi" )

--- a/ops/stage0/test_deploy_via_ssm_qa_export.py
+++ b/ops/stage0/test_deploy_via_ssm_qa_export.py
@@ -78,7 +78,10 @@ class QAExportInjectionRenderTest(unittest.TestCase):
         self.assertNotIn("SECRET", env_cmd)
 
         compose_cmd = next(c for c in qa if "docker-compose.yml" in c)
-        self.assertIn("/^      - TZ=/a\\", compose_cmd)          # anchored to the TZ line
+        # anchored to the tokenkey-unique SERVER_FRONTEND_URL line, NOT the per-service
+        # TZ line (every service has a TZ line → TZ anchor injected once per service).
+        self.assertIn("/^      - SERVER_FRONTEND_URL=/a\\", compose_cmd)
+        self.assertNotIn("/^      - TZ=/a\\", compose_cmd)
         self.assertIn("qa-export-before-1.8.99", compose_cmd)    # tagged backup ($CF.qa-export-before-<tag>)
         self.assertIn('grep -q "${key}=" "$CF"', compose_cmd)    # guarded insertion
 
@@ -121,17 +124,44 @@ class QAExportInjectionExecuteTest(unittest.TestCase):
         subprocess.run(["bash", "-e", "-c", script], check=True,
                        capture_output=True, text=True)
 
-    def test_injection_is_correct_and_idempotent(self) -> None:
+    @staticmethod
+    def _qa_mapping_count(lines: list[str]) -> int:
+        return sum(1 for ln in lines if "- QA_CAPTURE_EXPORT_STORAGE_" in ln)
+
+    @staticmethod
+    def _service_block(lines: list[str], name: str) -> list[str]:
+        # lines belonging to `name:` — from its 2-space header to the next service header.
+        out, inside = [], False
+        for ln in lines:
+            is_header = ln.startswith("  ") and not ln.startswith("    ") and ln.rstrip().endswith(":")
+            if is_header:
+                inside = ln.strip() == f"{name}:"
+                continue
+            if inside:
+                out.append(ln)
+        return out
+
+    def test_injection_targets_only_tokenkey_and_is_idempotent(self) -> None:
+        # EVERY service carries a `- TZ=` line, but only tokenkey has SERVER_FRONTEND_URL.
+        # The old TZ anchor injected the 4 mappings once PER service (the prod 1.8.11 bug);
+        # the SERVER_FRONTEND_URL anchor must inject them exactly once, in tokenkey only.
         host = pathlib.Path(tempfile.mkdtemp(prefix="qa-export-exec-"))
         (host / ".env").write_text("APP_ENV=prod\nAPI_DOMAIN=api.tokenkey.dev\n")
         (host / "docker-compose.yml").write_text(
             "services:\n"
+            "  caddy:\n"
+            "    environment:\n"
+            "      - TZ=${TZ:-UTC}\n"
             "  tokenkey:\n"
             "    environment:\n"
             "      - SERVER_FRONTEND_URL=${SERVER_FRONTEND_URL:-}\n"
             "      - TZ=${TZ:-UTC}\n"
-            "    ports:\n"
-            '      - "8080:8080"\n'
+            "  postgres:\n"
+            "    environment:\n"
+            "      - TZ=${TZ:-UTC}\n"
+            "  redis:\n"
+            "    environment:\n"
+            "      - TZ=${TZ:-UTC}\n"
         )
 
         self._run_prod_cmds_against(host)
@@ -143,25 +173,23 @@ class QAExportInjectionExecuteTest(unittest.TestCase):
         ):
             self.assertIn(f"QA_CAPTURE_EXPORT_STORAGE_{k}={v}\n", env_txt)
 
-        compose_txt = (host / "docker-compose.yml").read_text()
-        for k in ("DRIVER", "REGION", "BUCKET", "PREFIX"):
-            mapping = f"      - QA_CAPTURE_EXPORT_STORAGE_{k}=${{QA_CAPTURE_EXPORT_STORAGE_{k}:-}}\n"
-            self.assertIn(mapping, compose_txt)
-        # inserted after the TZ line, not before it
-        self.assertLess(compose_txt.index("- TZ="),
-                        compose_txt.index("QA_CAPTURE_EXPORT_STORAGE_DRIVER"))
+        lines = (host / "docker-compose.yml").read_text().splitlines()
+        # exactly 4 mappings total — ALL in the tokenkey block, none leaked to the
+        # other TZ-bearing services (the exact regression the anchor change fixes).
+        self.assertEqual(self._qa_mapping_count(lines), 4)
+        self.assertEqual(self._qa_mapping_count(self._service_block(lines, "tokenkey")), 4)
+        for svc in ("caddy", "postgres", "redis"):
+            self.assertEqual(self._qa_mapping_count(self._service_block(lines, svc)), 0,
+                             msg=f"QA mappings leaked into {svc}")
         self.assertTrue(list(host.glob("docker-compose.yml.qa-export-before-*")))
 
-        # second run is a no-op: exactly 4 .env lines + 4 compose mappings, no dupes.
-        # (count by line, not substring: a compose mapping mentions the prefix twice.)
+        # idempotent: a second deploy adds nothing (still 4 compose mappings + 4 .env lines).
         self._run_prod_cmds_against(host)
-
-        def _qa_lines(text: str, needle: str) -> int:
-            return sum(1 for ln in text.splitlines() if needle in ln)
-
-        self.assertEqual(_qa_lines((host / ".env").read_text(), "QA_CAPTURE_EXPORT_STORAGE_"), 4)
         self.assertEqual(
-            _qa_lines((host / "docker-compose.yml").read_text(), "- QA_CAPTURE_EXPORT_STORAGE_"), 4)
+            self._qa_mapping_count((host / "docker-compose.yml").read_text().splitlines()), 4)
+        self.assertEqual(
+            sum(1 for ln in (host / ".env").read_text().splitlines()
+                if "QA_CAPTURE_EXPORT_STORAGE_" in ln), 4)
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
## 问题(1.8.11 prod 部署暴露)

#838 的 deploy-sed 把 4 个 `QA_CAPTURE_EXPORT_STORAGE_*` compose 映射插在 `/^      - TZ=/` 后。Stage0 每个服务(caddy/tokenkey/postgres/redis)都有 `- TZ=` 行,所以 sed 匹配了**全部服务**,每个服务块都被插了一套。

1.8.11 首次 prod 部署即触发:tokenkey 拿到正确的 1 套(容器 env 已验证正确、S3 导出已 e2e 跑通),但 postgres/redis 拿到无害的重复套(那俩容器忽略未知 env,部署健康检查全过)。**prod host compose 已带外一次性去重**(仅留 tokenkey 的 4 行);本 PR 修脚本,防新实例/未来部署再犯。

## 修法

锚点改用 tokenkey **专属**的 `SERVER_FRONTEND_URL` 行:它只在 tokenkey 服务出现,且由本命令列表中更早运行的 SERVER_FRONTEND_URL backfill 保证存在。

> 注:那个 SERVER_FRONTEND_URL backfill 自身的同类潜在 bug 在 prod 上 inert(该变量在 source compose 里预置 → 其注入恒被 skip),为保持本 PR 聚焦不在此一并改。

## 测试缺口(bug 漏出的原因)

原测试 fixture 只有**单个**服务,从未复现多服务注入。现在执行测试用 **4 服务** compose(各有 TZ 行,只 tokenkey 有 SERVER_FRONTEND_URL),断言映射**恰好插一次、全在 tokenkey 块、零泄漏到 caddy/postgres/redis**——TZ 锚点下会是 16,直接抓 bug。render 测试断言锚点是 SERVER_FRONTEND_URL(且非 TZ)。

## 验证

- `bash -n`;render 显示 SERVER_FRONTEND_URL 锚点;
- debian/python 容器(GNU sed)全套 5/5 绿,含新多服务断言;
- `scripts/preflight.sh` PASS。

非 backend Go、无前端(`no-web-impact` 已声明)。建议 **Squash and merge**。

🤖 Generated with [Claude Code](https://claude.com/claude-code)