### PR TITLE
feat(qwen): onboard qwen3-235b-a22b on the Qwen group (account 60)

### DIFF
--- a/backend/internal/service/tk_pricing_overlay.json
+++ b/backend/internal/service/tk_pricing_overlay.json
@@ -964,6 +964,15 @@
     "cache_read_input_token_cost": 2.9850746268656716e-07,
     "source": "Alibaba DashScope qwen3-32b (开源版 dense) official China-mainland (Beijing) RMB list ÷ 6.7; docs/accounts/aliyun_pricing_20260612.md captured 2026-06-12. Added 2026-06-17 per customer request for the original (dense) Qwen3 8B/14B/32B models. Mirrors Alibaba's two-rate table for the SAME model id (in ¥2/M; out 非思考 ¥8/M / 思考 ¥20/M), switched by the request's enable_thinking param — output_cost_per_token = non-thinking, thinking_output_cost_per_token = thinking. enable_thinking DEFAULTS to true for open-source dense Qwen3, so billing defaults to the thinking rate when the param is absent (matches upstream). List price only — Batch (half-price)/context-cache discounts not modeled (cache_read billed at full input rate). International deployment is higher and intentionally NOT modeled; the prod account uses the China-mainland endpoint."
   },
+  "qwen3-235b-a22b": {
+    "litellm_provider": "dashscope",
+    "mode": "chat",
+    "input_cost_per_token": 2.9850746268656716e-07,
+    "output_cost_per_token": 1.1940298507462686e-06,
+    "thinking_output_cost_per_token": 2.9850746268656716e-06,
+    "cache_read_input_token_cost": 2.9850746268656716e-07,
+    "source": "Alibaba DashScope qwen3-235b-a22b (开源版 MoE, 235B total / 22B active, hybrid 非思考和思考模式) official China-mainland (Beijing) RMB list ÷ 6.7; docs/accounts/aliyun_pricing_20260612.md captured 2026-06-12 (qwen3-235b-a22b 中国内地 row). Added 2026-06-18 per customer request to surface the flagship Qwen3 model on the Qwen group (account 60), which previously listed only the smaller Qwen3 models. Mirrors Alibaba's two-rate table for the SAME model id (in ¥2/M; out 非思考 ¥8/M / 思考 ¥20/M) — coincidentally identical per-token rates to qwen3-32b — switched by the request's enable_thinking param: output_cost_per_token = non-thinking, thinking_output_cost_per_token = thinking. enable_thinking DEFAULTS to true for the open-source Qwen3 hybrid base alias, so billing defaults to the thinking rate when the param is absent (matches upstream). List price only — Batch (half-price)/context-cache discounts not modeled (cache_read billed at full input rate). International deployment is higher and intentionally NOT modeled; the prod account uses the China-mainland endpoint."
+  },
   "qwen2.5-coder-32b": {
     "litellm_provider": "dashscope",
     "mode": "chat",

--- a/backend/internal/service/tk_served_models.json
+++ b/backend/internal/service/tk_served_models.json
@@ -170,6 +170,18 @@
       "price_key": "qwen3-32b",
       "display": false,
       "notes": "Qwen account 60. Mapped by tk_029 (dense open-source identity whitelist). Priced in overlay (#812). Same provenance as qwen3-8b; #818/tk_029 closed the original #812 gap."
+    },
+    "newapi/qwen3-235b-a22b": {
+      "platform": "newapi",
+      "model_id": "qwen3-235b-a22b",
+      "served_on": [
+        "60"
+      ],
+      "channel_type": 17,
+      "price_source": "overlay",
+      "price_key": "qwen3-235b-a22b",
+      "display": false,
+      "notes": "Qwen account 60. Flagship open-source Qwen3 MoE (235B total / 22B active). Mapped by tk_032 (identity whitelist merge). Priced in overlay (added 2026-06-18, same per-token rates as qwen3-32b). Added per customer request: the Qwen group previously listed only the smaller Qwen3 models."
     }
   }
 }

--- a/backend/migrations/tk_032_qwen3_235b_a22b_model_mapping.sql
+++ b/backend/migrations/tk_032_qwen3_235b_a22b_model_mapping.sql
@@ -1,0 +1,57 @@
+-- Migration: tk_032_qwen3_235b_a22b_model_mapping
+--
+-- Advertise the flagship open-source Qwen3 MoE model on the Qwen account (id=60),
+-- so the Qwen group can serve it:
+--   - account 60 "Qwen" (Ali, channel_type=17): qwen3-235b-a22b
+--
+-- Why (prod 2026-06-18, per customer request): the Qwen group previously listed
+-- only the smaller Qwen3 models (qwen3.7-max family + qwen-max/qwen-plus via
+-- tk_027, qwen3.7-plus / qwen3.6-flash / qwen3-coder-plus via tk_024, and the
+-- dense qwen3-8b/14b/32b via tk_029). A client asked for the flagship
+-- qwen3-235b-a22b (235B total / 22B active MoE). account 60's
+-- credentials.model_mapping is an identity WHITELIST that did not list this name,
+-- so the scheduler found no account advertising it for the group -> empty pool ->
+-- fast-fail 429. DashScope serves qwen3-235b-a22b directly with account 60's key
+-- (China-mainland/Beijing endpoint), so merging it into the whitelist makes the
+-- bridge advertise + route it.
+--
+-- Pricing shipped alongside this migration (added 2026-06-18) via
+-- backend/internal/service/tk_pricing_overlay.json (qwen3-235b-a22b: in ¥2/M, out
+-- 非思考 ¥8/M / 思考 ¥20/M; all ÷6.7; coincidentally the same per-token rates as
+-- qwen3-32b; thinking-rate default because the open-source Qwen3 hybrid base alias
+-- defaults enable_thinking=true). The overlay is compile-embedded, so the
+-- whitelist add lands on an image that already prices this name -- no $0 window.
+--
+-- Merge (jsonb ||) preserves the existing identity-whitelist entries; only the one
+-- new identity key is added. Raw-SQL account mutation bypasses the Ent
+-- snapshot-refresh hooks, so enqueue a scheduler_outbox account_changed event
+-- (pattern: tk_022 / tk_024 / tk_027 / tk_029) so the running scheduler sees the
+-- change without a restart.
+--
+-- Idempotent + cross-deployment safe: guarded by (id, name, platform='newapi',
+-- channel_type=17) so re-running merges the same key (no-op) and a bare id
+-- colliding with an unrelated account in another DB cannot match.
+
+SET LOCAL lock_timeout = '5s';
+SET LOCAL statement_timeout = '10min';
+
+-- Qwen account 60: add qwen3-235b-a22b (open-source MoE, hybrid thinking).
+WITH upd_qwen AS (
+    UPDATE accounts
+    SET credentials = jsonb_set(
+            credentials,
+            '{model_mapping}',
+            COALESCE(credentials -> 'model_mapping', '{}'::jsonb) || '{
+                "qwen3-235b-a22b": "qwen3-235b-a22b"
+            }'::jsonb
+        ),
+        updated_at = NOW()
+    WHERE id = 60
+      AND name = 'Qwen'
+      AND platform = 'newapi'
+      AND channel_type = 17
+      AND deleted_at IS NULL
+    RETURNING id
+)
+INSERT INTO scheduler_outbox (event_type, account_id, group_id, payload)
+SELECT 'account_changed', id, NULL, NULL FROM upd_qwen;


### PR DESCRIPTION
## What

Surface the flagship open-source **qwen3-235b-a22b** (Qwen3 MoE, 235B total / 22B active) on the **Qwen group** (account 60, newapi platform, channel_type=17 DashScope). The group previously listed only the smaller Qwen3 models. Per customer request (2026-06-18).

## How (three-way consistent, gated by `scripts/checks/catalog-serving-drift.py`)

1. **`tk_served_models.json`** — add `newapi/qwen3-235b-a22b` (`served_on=["60"]`, `price_source=overlay`, `display=false`).
2. **`tk_pricing_overlay.json`** — add `qwen3-235b-a22b`. China-mainland (Beijing) RMB list `in ¥2/M; out 非思考 ¥8/M / 思考 ¥20/M` ÷ 6.7 (canonical CNY/USD), thinking dual-rate (`enable_thinking` defaults true for the open-source Qwen3 hybrid base alias). Source: `docs/accounts/aliyun_pricing_20260612.md` (qwen3-235b-a22b 中国内地 row). Coincidentally identical per-token rates to qwen3-32b.
3. **`migrations/tk_032_qwen3_235b_a22b_model_mapping.sql`** — merge the identity whitelist key onto account 60 (`jsonb ||`, guarded by `(id, name, platform, channel_type)`, idempotent) + `scheduler_outbox account_changed` so the running scheduler picks it up without a restart. Pattern: tk_029.

## Validation

- `scripts/checks/catalog-serving-drift.py` (selftest + live) — pass; new entry agrees on price (A1) + migration (A3).
- `scripts/checks/pricing-overlay.py` — 69 entries valid (thinking anchor present, no \$0).
- `go test -tags=unit ./internal/service/ -run 'Pricing|Overlay|ServedModel|Catalog'` — ok.
- `scripts/preflight.sh` (with sub2api checks) — PASS.

## Post-merge (not in this PR)

- Overlay price is compile-embedded → ships with the next release.
- model_mapping change lands on deploy via the migration + `scheduler_outbox`.
- **Livefire** (real 200, thinking + non-thinking) to confirm prod servability should run after deploy — pricing-ready ≠ prod-servable.

no-web-impact (backend-only: 2 TK JSON + 1 TK migration; no upstream-shaped paths touched).