### PR TITLE
feat(guards): relay-invariant test registry + platform single-source-of-truth + thinking weld

### DIFF
--- a/.github/workflows/upstream-merge-pr-shape.yml
+++ b/.github/workflows/upstream-merge-pr-shape.yml
@@ -19,6 +19,15 @@ name: Upstream Merge PR Shape
 #      docs/approved/newapi-as-fifth-platform.md: an upstream merge
 #      silently drops a TK companion file or a `case PlatformNewAPI`
 #      branch and the regression is only noticed weeks later.
+#      (Checks 4b/4d/4c/4e mirror this for kiro / grok / antigravity /
+#      relay-invariant tests respectively — same script as preflight.)
+#   4e. Every relay-invariant characterization test listed in
+#      `scripts/sentinels/relay-invariants.json` is still present after the
+#      merge. These encode deliberate TK relay behaviors (G4 cooldown scoping,
+#      kiro/grok refresh candidates, SSE stream-error 502, cooldown polarity,
+#      thinking model-reference routing) whose only durable proof is the test —
+#      PR #835's silent-deletion/override class. Deleting/gutting a pinned test
+#      fails the check; retiring a behavior means updating the registry in-PR.
 #   5. Every outward TokenKey brand surface listed in
 #      `scripts/sentinels/brand.json` is still intact after the merge,
 #      so upstream churn cannot silently revert default title / README /
@@ -246,6 +255,35 @@ jobs:
             echo "::error::Upstream merge regressed at least one grok sentinel."
             echo "::error::Per CLAUDE.md §5.x, restore the dropped file/symbol in this"
             echo "::error::merge PR. Do NOT 'fix' by deleting the sentinel entry."
+            exit 1
+          fi
+
+      - name: Check 4e — relay-invariant tests still intact after merge
+        run: |
+          # Single source of truth: scripts/sentinels/relay-invariants.json. Same
+          # script scripts/preflight.sh runs locally as the "relay-invariant test
+          # registry" check, so a green local preflight implies a green check here.
+          # Unlike the per-platform sentinels (which anchor production symbols),
+          # this pins the CHARACTERIZATION TESTS that encode deliberate TK relay
+          # behaviors: G4 5h-window cooldown scoping, kiro/grok refresh candidates,
+          # SSE stream-error 502 (not 403), org-ban / bodyless / oauth401 /
+          # usage-policy / TLS-fingerprint / request-owned-429 cooldown polarity,
+          # and thinking model-reference routing. This is the exact failure class
+          # PR #835 surfaced — an upstream rewrite silently deletes a TK behavior
+          # or overrides a deliberate TK choice with a green CI because the only
+          # proof was a test gutted in the same merge. Fix the merge to restore the
+          # behavior + its test; if a behavior was intentionally retired, update
+          # the registry in this PR (the human-review checkpoint), do NOT delete
+          # the entry to silence the check.
+          if [ ! -f ./scripts/sentinels/check-relay-invariants.py ]; then
+            echo "::error::scripts/sentinels/check-relay-invariants.py missing."
+            echo "::error::Per CLAUDE.md §5.x, this guard cannot be silently disabled."
+            exit 1
+          fi
+          if ! python3 ./scripts/sentinels/check-relay-invariants.py; then
+            echo "::error::Upstream merge deleted/gutted at least one relay-invariant test."
+            echo "::error::Restore the behavior and its characterization test in this"
+            echo "::error::merge PR. Do NOT 'fix' by deleting the registry entry."
             exit 1
           fi
 

--- a/backend/internal/engine/provider.go
+++ b/backend/internal/engine/provider.go
@@ -57,6 +57,64 @@ func AllSchedulingPlatforms() []string {
 	}
 }
 
+// apiKeyOnlySchedulingPlatforms lists scheduling platforms that authenticate
+// per-request from a static credential (api key / channel secret) and therefore
+// have NO background OAuth token to renew. They must be subtracted from
+// AllSchedulingPlatforms() to obtain the OAuth-refresh set.
+//
+// newapi is the lone member: its accounts carry a channel api key (channel_type
+// > 0), not an OAuth refresh_token, so the background refresh ticker skips them.
+func apiKeyOnlySchedulingPlatforms() []string {
+	return []string{domain.PlatformNewAPI}
+}
+
+// OAuthRefreshPlatforms is the SINGLE Go source of truth for which platforms the
+// background token-refresh ticker renews. It is a projection of
+// AllSchedulingPlatforms() minus apiKeyOnlySchedulingPlatforms(), NOT a
+// hand-maintained parallel list — adding a scheduling platform forces an
+// explicit "does it OAuth-refresh?" decision in apiKeyOnlySchedulingPlatforms().
+//
+// Two load-bearing consumers are verified against this list so a platform can
+// never silently drop out of refresh (the R-001 failure class):
+//   - repository.ListOAuthRefreshCandidates binds it as the SQL `platform =
+//     ANY($1)` filter — there is no platform literal left in the SQL for an
+//     upstream merge to reset to its four-platform default.
+//   - the registered TokenRefresher set is asserted to cover exactly this list
+//     (token_refresh_service_candidates_test.go), so dropping either a
+//     refresher registration or a platform here fails the build's tests.
+func OAuthRefreshPlatforms() []string {
+	apiKeyOnly := apiKeyOnlySchedulingPlatforms()
+	out := make([]string, 0, len(AllSchedulingPlatforms()))
+	for _, p := range AllSchedulingPlatforms() {
+		skip := false
+		for _, a := range apiKeyOnly {
+			if p == a {
+				skip = true
+				break
+			}
+		}
+		if !skip {
+			out = append(out, p)
+		}
+	}
+	return out
+}
+
+// IsOAuthRefreshPlatform reports whether the platform is renewed by the
+// background OAuth refresh ticker. Derived from OAuthRefreshPlatforms() so the
+// predicate and the SQL filter can never disagree.
+func IsOAuthRefreshPlatform(platform string) bool {
+	if platform == "" {
+		return false
+	}
+	for _, p := range OAuthRefreshPlatforms() {
+		if platform == p {
+			return true
+		}
+	}
+	return false
+}
+
 // TrajProjectablePlatforms returns the platforms whose captured client-facing
 // wire shape the traj v2 projector faithfully reconstructs (see
 // trajectory.WireShapeForRecord). It is the SINGLE SOURCE the /auth/me

--- a/backend/internal/repository/account_repo.go
+++ b/backend/internal/repository/account_repo.go
@@ -27,6 +27,7 @@ import (
 	dbpredicate "github.com/Wei-Shaw/sub2api/ent/predicate"
 	dbproxy "github.com/Wei-Shaw/sub2api/ent/proxy"
 	"github.com/Wei-Shaw/sub2api/internal/domain"
+	"github.com/Wei-Shaw/sub2api/internal/engine"
 	"github.com/Wei-Shaw/sub2api/internal/pkg/logger"
 	"github.com/Wei-Shaw/sub2api/internal/pkg/pagination"
 	"github.com/Wei-Shaw/sub2api/internal/service"
@@ -737,17 +738,21 @@ func (r *accountRepository) ListOAuthRefreshCandidates(ctx context.Context) ([]s
 	// NOT (a AND b) 在 PG 三值逻辑下会把 a 或 b 为 NULL 的行（即绝大多数
 	// 健康账号：temp_unschedulable_until=NULL）也排除，导致后台 token
 	// 刷新工作器漏掉所有正常账号 → access_token 到期后请求开始 401。
+	// TK: 平台过滤改为参数化 `= ANY($1)`，绑定值来自单一真值源
+	// engine.OAuthRefreshPlatforms()（= AllSchedulingPlatforms() 去掉仅用 api key
+	// 的 newapi）。SQL 里不再留任何平台字面量，杜绝 R-001 那类「上游重写本方法时
+	// 把名单重置回上游四平台、静默漏掉 TK 第六/七平台 kiro/grok」的回归——掉平台
+	// 必须改 engine 真值源（TK 持有、sentinel 锚定），且后台刷新器注册集会被
+	// token_refresh_service_candidates_test.go 断言覆盖该名单。kiro/grok 的
+	// OAuth access_token 短寿命（grok 默认 1h）且网关端只读 credentials 不做按需
+	// 刷新，后台刷新是其唯一续期路径，漏掉即 ~1h 后 401 掉出池且无自愈。
 	rows, err := r.sql.QueryContext(ctx, `
 		SELECT id
 		FROM accounts
 		WHERE deleted_at IS NULL
 			AND status = 'active'
 			AND type = 'oauth'
-			-- TK: kiro/grok 是 TK 专属第六/第七平台，OAuth access_token 短寿命
-			-- （grok 默认 1h）且网关端只读 credentials 不做按需刷新，后台刷新是其
-			-- 唯一续期路径。上游 ListOAuthRefreshCandidates 只认四平台（上游无 6/7），
-			-- 漏掉会让 kiro/grok 账号 ~1h 后 401 掉出池且无自愈。详见 grok/kiro sentinel。
-			AND platform IN ('anthropic', 'openai', 'gemini', 'antigravity', 'kiro', 'grok')
+			AND platform = ANY($1)
 			AND credentials ? 'refresh_token'
 			AND btrim(credentials->>'refresh_token') <> ''
 			AND (
@@ -755,7 +760,7 @@ func (r *accountRepository) ListOAuthRefreshCandidates(ctx context.Context) ([]s
 				AND temp_unschedulable_reason LIKE 'token refresh retry exhausted:%'
 			) IS NOT TRUE
 		ORDER BY priority ASC, id ASC
-	`)
+	`, pq.Array(engine.OAuthRefreshPlatforms()))
 	if err != nil {
 		return nil, err
 	}

--- a/backend/internal/repository/account_repo_temp_unsched_test.go
+++ b/backend/internal/repository/account_repo_temp_unsched_test.go
@@ -3,6 +3,7 @@ package repository
 import (
 	"context"
 	"database/sql"
+	"database/sql/driver"
 	"regexp"
 	"strings"
 	"testing"
@@ -10,6 +11,8 @@ import (
 
 	sqlmock "github.com/DATA-DOG/go-sqlmock"
 	"github.com/stretchr/testify/require"
+
+	"github.com/Wei-Shaw/sub2api/internal/engine"
 )
 
 func TestAccountRepository_SetTempUnschedulable_NoRowsAffectedDoesNotWriteOutbox(t *testing.T) {
@@ -30,11 +33,12 @@ func TestAccountRepository_ListOAuthRefreshCandidates_SQLFilter(t *testing.T) {
 	defer func() { _ = db.Close() }()
 
 	var capturedSQL string
+	var capturedArgs []any
 	mock.ExpectQuery("SELECT id").
 		WillReturnRows(sqlmock.NewRows([]string{"id"})).
 		WillDelayFor(0)
 
-	repo := newAccountRepositoryWithSQL(nil, captureQuerySQL{db: db, captured: &capturedSQL}, nil, nil)
+	repo := newAccountRepositoryWithSQL(nil, captureQuerySQL{db: db, captured: &capturedSQL, capturedArgs: &capturedArgs}, nil, nil)
 
 	accounts, err := repo.ListOAuthRefreshCandidates(context.Background())
 	require.NoError(t, err)
@@ -44,8 +48,22 @@ func TestAccountRepository_ListOAuthRefreshCandidates_SQLFilter(t *testing.T) {
 	require.Contains(t, normalized, "deleted_at IS NULL")
 	require.Contains(t, normalized, "status = 'active'")
 	require.Contains(t, normalized, "type = 'oauth'")
-	require.Contains(t, normalized, "platform IN ('anthropic', 'openai', 'gemini', 'antigravity', 'kiro', 'grok')",
-		"kiro/grok (TK platforms 6/7) must stay in the background-refresh candidate list; they have no on-demand refresh path")
+	// The platform filter is parametrized (`= ANY($1)`) and bound from the single
+	// source of truth engine.OAuthRefreshPlatforms() — there must be NO platform
+	// literal left in the SQL for an upstream merge to reset to its four-platform
+	// default (the R-001 silent-drop class). The bound arg must carry exactly the
+	// source-of-truth list, including TK platforms 6/7 (kiro/grok), which have no
+	// on-demand refresh path.
+	require.Contains(t, normalized, "platform = ANY($1)",
+		"platform filter must be parametrized from engine.OAuthRefreshPlatforms(), not a SQL literal")
+	require.NotContains(t, normalized, "platform IN (",
+		"no hand-maintained platform IN (...) literal may remain — it is the exact surface upstream silently reset in R-001")
+	require.Len(t, capturedArgs, 1, "ListOAuthRefreshCandidates must bind exactly the platform array arg")
+	boundPlatforms := pqArrayToStrings(t, capturedArgs[0])
+	require.ElementsMatch(t, engine.OAuthRefreshPlatforms(), boundPlatforms,
+		"the bound $1 platform array must equal engine.OAuthRefreshPlatforms() verbatim")
+	require.Subset(t, boundPlatforms, []string{"kiro", "grok"},
+		"TK platforms 6/7 (kiro/grok) must remain OAuth-refresh candidates")
 	require.Contains(t, normalized, "credentials ? 'refresh_token'")
 	require.Contains(t, normalized, "btrim(credentials->>'refresh_token') <> ''")
 	require.Contains(t, normalized, "temp_unschedulable_until > NOW()")
@@ -60,8 +78,9 @@ func TestAccountRepository_ListOAuthRefreshCandidates_SQLFilter(t *testing.T) {
 }
 
 type captureQuerySQL struct {
-	db       *sql.DB
-	captured *string
+	db           *sql.DB
+	captured     *string
+	capturedArgs *[]any
 }
 
 func (c captureQuerySQL) ExecContext(ctx context.Context, query string, args ...any) (sql.Result, error) {
@@ -72,7 +91,33 @@ func (c captureQuerySQL) QueryContext(ctx context.Context, query string, args ..
 	if c.captured != nil {
 		*c.captured = query
 	}
+	if c.capturedArgs != nil {
+		*c.capturedArgs = args
+	}
 	return c.db.QueryContext(ctx, query, args...)
+}
+
+// pqArrayToStrings unwraps the pq.Array(...) value bound as a SQL arg back into
+// the underlying []string so the test can assert it equals the source of truth.
+func pqArrayToStrings(t *testing.T, arg any) []string {
+	t.Helper()
+	sa, ok := arg.(interface{ Value() (driver.Value, error) })
+	require.True(t, ok, "bound arg is not a pq.Array driver.Valuer: %T", arg)
+	v, err := sa.Value()
+	require.NoError(t, err)
+	// pq.StringArray serializes to a Postgres array literal like {a,b,c}.
+	lit, ok := v.(string)
+	require.True(t, ok, "pq.Array value did not serialize to string: %T", v)
+	lit = strings.TrimSuffix(strings.TrimPrefix(lit, "{"), "}")
+	if lit == "" {
+		return nil
+	}
+	parts := strings.Split(lit, ",")
+	out := make([]string, 0, len(parts))
+	for _, p := range parts {
+		out = append(out, strings.Trim(p, `"`))
+	}
+	return out
 }
 
 func normalizeSQLWhitespace(sql string) string {

--- a/backend/internal/service/gateway_service_tk_signature_preempt.go
+++ b/backend/internal/service/gateway_service_tk_signature_preempt.go
@@ -77,7 +77,10 @@ func (s *GatewayService) applySigPreemptIfArmed(ctx context.Context, c *gin.Cont
 	if !armed {
 		return body
 	}
-	filtered := FilterThinkingBlocksForRetry(body, mappedModel)
+	// Native Anthropic relay path: key the thinking filter on the mapped
+	// upstream model (see thinking_ref_model_tk.go for why the compat path
+	// deliberately uses the original client model instead).
+	filtered := FilterThinkingBlocksForRetry(body, thinkingRefModelForAnthropicRelay(mappedModel))
 	if bytes.Equal(filtered, body) {
 		// Armed but nothing to strip — stay silent to avoid log explosion.
 		return body

--- a/backend/internal/service/gemini_messages_compat_service.go
+++ b/backend/internal/service/gemini_messages_compat_service.go
@@ -844,15 +844,20 @@ func (s *GeminiMessagesCompatService) Forward(ctx context.Context, c *gin.Contex
 				// 路径说明：本处上游是 Gemini，但被剥离的 body 是 Anthropic 格式。传 originalModel
 				// （客户端原 Anthropic model）而非 mappedModel（上游 Gemini model），让剥离逻辑按
 				// 客户端请求的 Anthropic 子协议族判定（详见 ResolveThinkingProtocol 文档）。
+				// thinkingRefModelForAnthropicCompat names the deliberate choice of
+				// originalModel over mappedModel on this Anthropic-shape→Gemini-backend
+				// path, so an upstream merge cannot silently swap it (see
+				// thinking_ref_model_tk.go).
+				compatRefModel := thinkingRefModelForAnthropicCompat(originalModel)
 				switch signatureRetryStage {
 				case 0:
 					// Stage 1: disable thinking + thinking->text
-					strippedClaudeBody = FilterThinkingBlocksForRetry(originalClaudeBody, originalModel)
+					strippedClaudeBody = FilterThinkingBlocksForRetry(originalClaudeBody, compatRefModel)
 					stageName = "thinking-only"
 					signatureRetryStage = 1
 				default:
 					// Stage 2: additionally downgrade tool_use/tool_result blocks to text
-					strippedClaudeBody = FilterSignatureSensitiveBlocksForRetry(originalClaudeBody, originalModel)
+					strippedClaudeBody = FilterSignatureSensitiveBlocksForRetry(originalClaudeBody, compatRefModel)
 					stageName = "thinking+tools"
 					signatureRetryStage = 2
 				}

--- a/backend/internal/service/thinking_ref_model_tk.go
+++ b/backend/internal/service/thinking_ref_model_tk.go
@@ -1,0 +1,58 @@
+package service
+
+// thinking_ref_model_tk.go — TokenKey weld for the "which model do the thinking
+// helpers key on?" decision.
+//
+// The upstream-owned thinking machinery (ResolveThinkingProtocol,
+// FilterThinkingBlocks, FilterThinkingBlocksForRetry, RectifyThinkingBudget,
+// ShouldRectifyThinkingSignatureError …) all take a single `modelID string`
+// argument that they treat as the "thinking-block reference model" — the model
+// whose family decides the thinking-block contract (Anthropic-strict signature
+// rules vs passback-required round-trip vs unknown/no-strip). See
+// thinking_protocol.go.
+//
+// TokenKey relays the same Anthropic /v1/messages request shape down TWO
+// structurally different paths, and the correct reference model is the OPPOSITE
+// variable on each:
+//
+//   - Native Anthropic relay (gateway_service.go / gateway_request.go /
+//     gateway_service_tk_signature_preempt.go): the upstream provider IS
+//     Anthropic, so the MAPPED upstream model (mappedModel / reqModel) is the
+//     authority on the thinking contract. Pass the mapped model.
+//
+//   - Anthropic-shaped client → non-Anthropic backend compat
+//     (gemini_messages_compat_service.go: a client speaks /v1/messages but is
+//     routed to a Gemini backend): the body being filtered is still Anthropic
+//     shape, but the MAPPED model is a Gemini model that
+//     ResolveThinkingProtocol would classify as non-strict — so it would skip
+//     the very filtering the Anthropic-dialect body requires. The ORIGINAL
+//     client model is the authority here. Pass the original model.
+//
+// These two helpers are identity functions by value, but they NAME the choice
+// so it is greppable and self-documenting: a future upstream merge that
+// silently swaps mappedModel↔originalModel at a call site has to rename the
+// helper to compile-match the path, making the inversion visible in review
+// instead of a silent behavior flip (the exact failure class the
+// relay-invariant registry guards). The behavior on both paths is pinned by
+// TestThinkingRefModel_AnthropicRelayUsesMappedModel and
+// TestThinkingRefModel_AnthropicCompatUsesOriginalModel, registered in
+// scripts/sentinels/relay-invariants.json.
+//
+// NOTE: do NOT "simplify" these to a single helper or inline them back to the
+// bare variable — the whole point is that the two paths must pick DIFFERENT
+// models and the seam must stay legible across upstream merges.
+
+// thinkingRefModelForAnthropicRelay returns the model ID the thinking helpers
+// must key on for the NATIVE Anthropic relay path: the mapped upstream model.
+func thinkingRefModelForAnthropicRelay(mappedModel string) string {
+	return mappedModel
+}
+
+// thinkingRefModelForAnthropicCompat returns the model ID the thinking helpers
+// must key on for the Anthropic-shaped-client → non-Anthropic-backend compat
+// path (e.g. gemini_messages_compat): the original client model, because the
+// thinking-block SHAPE is set by the client's Anthropic dialect, not the mapped
+// backend model.
+func thinkingRefModelForAnthropicCompat(originalModel string) string {
+	return originalModel
+}

--- a/backend/internal/service/thinking_ref_model_tk_test.go
+++ b/backend/internal/service/thinking_ref_model_tk_test.go
@@ -1,0 +1,105 @@
+package service
+
+import (
+	"encoding/json"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+)
+
+// unsignedThinkingBody is an Anthropic /v1/messages body carrying an assistant
+// thinking block with a bad signature — the shape that anthropic-strict upstream
+// rejects with a signature 400, and that the retry filter rewrites to text.
+const unsignedThinkingBody = `{
+	"model":"claude-sonnet-4-6",
+	"thinking":{"type":"enabled","budget_tokens":1024},
+	"messages":[
+		{"role":"user","content":[{"type":"text","text":"Hi"}]},
+		{"role":"assistant","content":[
+			{"type":"thinking","thinking":"Let me think...","signature":"bad_sig"},
+			{"type":"text","text":"Answer"}
+		]}
+	]
+}`
+
+func topLevelThinkingPresent(t *testing.T, body []byte) bool {
+	t.Helper()
+	var req map[string]any
+	require.NoError(t, json.Unmarshal(body, &req))
+	_, has := req["thinking"]
+	return has
+}
+
+// TestThinkingRefModel_AnthropicRelayUsesMappedModel pins the NATIVE relay path
+// invariant: the thinking helpers must key on the MAPPED upstream model. The
+// classic trap is an account mapping claude-sonnet-4-6 → a passback-required
+// upstream (deepseek): keying on the mapped model correctly SKIPS the strip
+// (preserving the passback contract), whereas keying on the original claude
+// model would wrongly strip and break that upstream.
+//
+// This is a relay-invariant registered in scripts/sentinels/relay-invariants.json.
+func TestThinkingRefModel_AnthropicRelayUsesMappedModel(t *testing.T) {
+	const originalModel = "claude-sonnet-4-6"
+	const mappedModel = "deepseek-v4-pro" // account model_mapping target
+
+	// The helper selects the mapped model verbatim.
+	require.Equal(t, mappedModel, thinkingRefModelForAnthropicRelay(mappedModel))
+
+	// Why the choice matters: the two models classify into OPPOSITE protocols.
+	require.Equal(t, ThinkingProtocolPassbackRequired, ResolveThinkingProtocol(mappedModel),
+		"mapped deepseek upstream is passback-required — thinking blocks must NOT be stripped")
+	require.Equal(t, ThinkingProtocolAnthropicStrict, ResolveThinkingProtocol(originalModel),
+		"original claude model is anthropic-strict — keying on it here would WRONGLY strip")
+
+	// Behavioral proof: keyed on the mapped model the retry filter is a no-op
+	// (passback preserved); keyed on the original model it would mutate the body.
+	relayRef := thinkingRefModelForAnthropicRelay(mappedModel)
+	keptForPassback := FilterThinkingBlocksForRetry([]byte(unsignedThinkingBody), relayRef)
+	require.Equal(t, unsignedThinkingBody, string(keptForPassback),
+		"mapped passback-required model must leave the body untouched")
+	require.True(t, topLevelThinkingPresent(t, keptForPassback),
+		"top-level thinking must survive on the passback path")
+
+	wouldStripIfInverted := FilterThinkingBlocksForRetry([]byte(unsignedThinkingBody), originalModel)
+	require.NotEqual(t, unsignedThinkingBody, string(wouldStripIfInverted),
+		"sanity: passing the ORIGINAL model (the inversion bug) would have mutated the body — "+
+			"this is exactly what keying on the mapped model prevents")
+}
+
+// TestThinkingRefModel_AnthropicCompatUsesOriginalModel pins the Gemini-compat
+// path invariant (Anthropic-shaped client → Gemini backend): the thinking
+// helpers must key on the ORIGINAL client model. The mapped model here is a
+// Gemini model that ResolveThinkingProtocol classifies as non-strict, so keying
+// on it would SKIP the very strip the Anthropic-dialect body needs, leaving an
+// unsigned thinking block that the upstream rejects with a 400.
+//
+// This is a relay-invariant registered in scripts/sentinels/relay-invariants.json.
+func TestThinkingRefModel_AnthropicCompatUsesOriginalModel(t *testing.T) {
+	const originalModel = "claude-sonnet-4-6" // client's Anthropic model
+	const mappedModel = "gemini-2.5-pro"      // actual upstream backend
+
+	// The helper selects the original client model verbatim.
+	require.Equal(t, originalModel, thinkingRefModelForAnthropicCompat(originalModel))
+
+	// Why the choice matters: only the original model is anthropic-strict; the
+	// mapped Gemini model is NOT, so keying on it would skip required filtering.
+	require.Equal(t, ThinkingProtocolAnthropicStrict, ResolveThinkingProtocol(originalModel),
+		"original claude model is anthropic-strict — the unsigned thinking block must be stripped")
+	require.NotEqual(t, ThinkingProtocolAnthropicStrict, ResolveThinkingProtocol(mappedModel),
+		"mapped gemini model is non-strict — keying on it would SKIP the strip and 400 upstream")
+
+	// Behavioral proof: keyed on the original model the retry filter rewrites the
+	// thinking block to text and drops top-level thinking; keyed on the mapped
+	// gemini model it would be a no-op (the inversion bug).
+	compatRef := thinkingRefModelForAnthropicCompat(originalModel)
+	stripped := FilterThinkingBlocksForRetry([]byte(unsignedThinkingBody), compatRef)
+	require.NotEqual(t, unsignedThinkingBody, string(stripped),
+		"original anthropic-strict model must rewrite the unsigned thinking block")
+	require.False(t, topLevelThinkingPresent(t, stripped),
+		"top-level thinking must be disabled on the compat strip path")
+
+	wouldNoOpIfInverted := FilterThinkingBlocksForRetry([]byte(unsignedThinkingBody), mappedModel)
+	require.Equal(t, unsignedThinkingBody, string(wouldNoOpIfInverted),
+		"sanity: passing the MAPPED gemini model (the inversion bug) would have left the "+
+			"unsigned thinking block in place — exactly the 400 keying on originalModel prevents")
+}

--- a/backend/internal/service/token_refresh_service_candidates_test.go
+++ b/backend/internal/service/token_refresh_service_candidates_test.go
@@ -8,6 +8,7 @@ import (
 	"time"
 
 	"github.com/Wei-Shaw/sub2api/internal/config"
+	"github.com/Wei-Shaw/sub2api/internal/engine"
 	"github.com/imroc/req/v3"
 	"github.com/stretchr/testify/require"
 )
@@ -63,13 +64,54 @@ func (r *tokenRefreshCandidateRepo) SetTempUnschedulable(_ context.Context, _ in
 	return nil
 }
 
+// isOAuthRefreshPlatform mirrors the production candidate filter. It delegates
+// to engine.IsOAuthRefreshPlatform so this test stub and repository.
+// ListOAuthRefreshCandidates' SQL `platform = ANY($1)` read the SAME single
+// source of truth (engine.OAuthRefreshPlatforms()) and can never disagree.
 func isOAuthRefreshPlatform(platform string) bool {
-	switch platform {
-	case PlatformAnthropic, PlatformOpenAI, PlatformGemini, PlatformAntigravity, PlatformKiro, PlatformGrok:
-		return true
-	default:
-		return false
+	return engine.IsOAuthRefreshPlatform(platform)
+}
+
+// TestRegisteredRefreshers_MatchOAuthRefreshSourceOfTruth welds the registered
+// TokenRefresher set to engine.OAuthRefreshPlatforms() (the SQL source of
+// truth). It is the structural kill for the R-001 silent-drop class:
+//
+//   - If a platform is in the source of truth (so its accounts are selected by
+//     ListOAuthRefreshCandidates) but NO registered refresher will refresh it,
+//     those accounts are fetched and silently skipped — they expire and 401 out
+//     of the pool with no auto-recovery (exactly R-001). This test fails.
+//   - If a refresher is registered for a platform NOT in the source of truth,
+//     the SQL never feeds it accounts — a dead registration. This test fails.
+//
+// Both directions are caught by building the REAL registered refresher set via
+// NewTokenRefreshService (not a re-listed copy) and probing each registered
+// refresher with a per-platform OAuth probe account.
+func TestRegisteredRefreshers_MatchOAuthRefreshSourceOfTruth(t *testing.T) {
+	// Construction stores deps without dereferencing them (only cfg is read),
+	// so nil collaborators are safe — CanRefresh inspects only Platform/Type.
+	svc := NewTokenRefreshService(nil, nil, nil, nil, nil, nil, nil, &config.Config{}, nil)
+	require.NotEmpty(t, svc.refreshers, "no refreshers registered")
+
+	covered := make(map[string]bool)
+	// Probe across every scheduling platform (the superset) plus a bogus one, so
+	// we detect refreshers that accept a platform outside the source of truth.
+	probeUniverse := append(engine.AllSchedulingPlatforms(), "definitely-not-a-platform")
+	for _, platform := range probeUniverse {
+		probe := &Account{Platform: platform, Type: AccountTypeOAuth}
+		for _, r := range svc.refreshers {
+			if r.CanRefresh(probe) {
+				covered[platform] = true
+			}
+		}
 	}
+
+	got := make([]string, 0, len(covered))
+	for p := range covered {
+		got = append(got, p)
+	}
+	require.ElementsMatch(t, engine.OAuthRefreshPlatforms(), got,
+		"the registered TokenRefresher set must cover EXACTLY engine.OAuthRefreshPlatforms() — "+
+			"a platform in the source of truth with no refresher (or vice versa) is the R-001 silent-drop class")
 }
 
 type tokenRefreshTestRefresher struct {

--- a/scripts/preflight.sh
+++ b/scripts/preflight.sh
@@ -458,6 +458,30 @@ else
     echo "  ok: all grok sentinels intact"
 fi
 
+# ---- sub2api: relay-invariant test registry ---------------------------------
+# Source of truth: scripts/sentinels/relay-invariants.json. Unlike the per-
+# platform sentinels above (which anchor PRODUCTION symbols against deletion),
+# this registry anchors the CHARACTERIZATION TESTS that encode deliberate,
+# TK-correct relay behaviors — G4 5h-window cooldown scoping, kiro/grok refresh
+# candidates, SSE stream-error 502 (not 403), org-ban/bodyless/oauth401/usage-
+# policy/TLS-fingerprint/request-owned-429 cooldown polarity, thinking model-
+# reference routing. PR #835 showed the failure class: an upstream rewrite
+# silently deletes a TK behavior OR overrides a deliberate TK choice with no
+# conflict, no compile error, and a green CI — because the only proof of the
+# choice was a test deleted in the same merge. Pinning each test's `func TestX(`
+# definition turns "merge deleted/gutted the test" into a red check.
+echo ""
+echo "=== sub2api: relay-invariant test registry ==="
+if ! command -v python3 >/dev/null 2>&1; then
+    echo "  FAIL: python3 not on PATH (required to read relay-invariants.json)"
+    errors=$((errors + 1))
+elif ! python3 ./scripts/sentinels/check-relay-invariants.py --quiet; then
+    # check-relay-invariants.py already printed the actionable failure.
+    errors=$((errors + 1))
+else
+    echo "  ok: all relay-invariant tests intact"
+fi
+
 # ---- sub2api: antigravity fingerprint sentinel registry ---------------------
 # Source of truth: scripts/sentinels/antigravity.json. Guards the TokenKey
 # divergences in the Antigravity (cloudcode-pa) client fingerprint that an

--- a/scripts/sentinels/check-relay-invariants.py
+++ b/scripts/sentinels/check-relay-invariants.py
@@ -1,0 +1,172 @@
+#!/usr/bin/env python3
+"""
+check-relay-invariants.py — verify that every load-bearing, TokenKey-deliberate
+relay behavior still has its characterization test present in the working tree.
+
+Reads `scripts/sentinels/relay-invariants.json` (single source of truth) and for
+each entry verifies:
+
+  1. The test file at `path` exists.
+  2. Every literal in `must_contain` (each a `func TestX(` definition prefix)
+     appears at least once in the file.
+  3. Every literal in `must_not_contain` (if any) is absent from the file.
+
+It is the same shape as check-newapi.py / check-grok.py, but the anchored
+literals are TEST FUNCTION DEFINITIONS rather than production symbols: the
+behavior these tests encode (G4 cooldown scoping, kiro/grok refresh candidates,
+SSE stream-error 502, org-ban/bodyless/oauth401/usage-policy/TLS-fingerprint/
+request-owned-429 cooldown polarity, thinking model-reference routing) is
+DELIBERATE and TK-correct, and the only durable proof of each choice is its
+test. An upstream merge that silently deletes or guts one of these tests — the
+exact failure class PR #835 surfaced — now fails this check instead of shipping
+a green CI.
+
+Exit codes:
+  0  — all relay-invariant tests intact.
+  1  — at least one test file missing or has lost a pinned test function.
+  2  — registry file missing or malformed.
+
+Usage:
+  python3 scripts/sentinels/check-relay-invariants.py
+  python3 scripts/sentinels/check-relay-invariants.py --quiet     # only failures
+  python3 scripts/sentinels/check-relay-invariants.py --json      # machine-readable
+
+Wiring:
+  - scripts/preflight.sh runs this on every PR (local pre-commit + CI preflight).
+  - .github/workflows/upstream-merge-pr-shape.yml runs the same script, so a
+    green local preflight implies a green merge-PR check.
+"""
+from __future__ import annotations
+
+import argparse
+import json
+import sys
+from pathlib import Path
+
+REPO_ROOT = Path(__file__).resolve().parent.parent.parent
+REGISTRY_PATH = REPO_ROOT / "scripts" / "sentinels" / "relay-invariants.json"
+
+
+def load_registry() -> dict:
+    if not REGISTRY_PATH.is_file():
+        print(
+            f"FATAL: registry file not found: {REGISTRY_PATH.relative_to(REPO_ROOT)}",
+            file=sys.stderr,
+        )
+        sys.exit(2)
+    try:
+        with REGISTRY_PATH.open("r", encoding="utf-8") as f:
+            data = json.load(f)
+    except json.JSONDecodeError as exc:
+        print(f"FATAL: registry file is not valid JSON: {exc}", file=sys.stderr)
+        sys.exit(2)
+    if "sentinels" not in data or not isinstance(data["sentinels"], list):
+        print("FATAL: registry missing 'sentinels' array.", file=sys.stderr)
+        sys.exit(2)
+    return data
+
+
+def check_sentinel(entry: dict) -> tuple[bool, list[str]]:
+    """Returns (ok, list_of_failure_messages)."""
+    path_str = entry.get("path")
+    if not path_str:
+        return False, ["entry missing 'path'"]
+    file_path = REPO_ROOT / path_str
+    if not file_path.is_file():
+        return False, [f"test file missing: {path_str}"]
+    must_contain = entry.get("must_contain") or []
+    must_not_contain = entry.get("must_not_contain") or []
+    if not must_contain and not must_not_contain:
+        return False, [f"entry for {path_str} pins no test function (must_contain empty)"]
+    try:
+        content = file_path.read_text(encoding="utf-8", errors="replace")
+    except OSError as exc:
+        return False, [f"cannot read {path_str}: {exc}"]
+    failures: list[str] = []
+    for needle in must_contain:
+        if needle not in content:
+            failures.append(f"missing test `{needle}` in {path_str}")
+    for needle in must_not_contain:
+        if needle in content:
+            failures.append(f"forbidden literal `{needle}` still present in {path_str}")
+    return (len(failures) == 0), failures
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("--quiet", action="store_true", help="only print failures")
+    parser.add_argument(
+        "--json",
+        action="store_true",
+        help="emit a machine-readable JSON report on stdout",
+    )
+    args = parser.parse_args()
+
+    registry = load_registry()
+    sentinels = registry["sentinels"]
+
+    results = []
+    fail_count = 0
+    for entry in sentinels:
+        ok, failures = check_sentinel(entry)
+        if not ok:
+            fail_count += 1
+        results.append(
+            {
+                "path": entry.get("path"),
+                "ok": ok,
+                "failures": failures,
+                "rationale": entry.get("rationale", ""),
+            }
+        )
+
+    if args.json:
+        json.dump(
+            {"total": len(sentinels), "failed": fail_count, "results": results},
+            sys.stdout,
+            indent=2,
+        )
+        sys.stdout.write("\n")
+    else:
+        if not args.quiet:
+            print(
+                f"relay-invariant tests: checking {len(sentinels)} entries from "
+                f"{REGISTRY_PATH.relative_to(REPO_ROOT)}"
+            )
+        for r in results:
+            if r["ok"]:
+                if not args.quiet:
+                    print(f"  ok: {r['path']}")
+            else:
+                print(f"  FAIL: {r['path']}")
+                for msg in r["failures"]:
+                    print(f"        - {msg}")
+                if r["rationale"]:
+                    print(f"        why it matters: {r['rationale']}")
+        if fail_count == 0:
+            if not args.quiet:
+                print(
+                    f"relay-invariant tests: PASS ({len(sentinels)}/{len(sentinels)} intact)"
+                )
+        else:
+            print(
+                f"relay-invariant tests: FAIL ({fail_count}/{len(sentinels)} regressed)",
+                file=sys.stderr,
+            )
+            print(
+                "  Source of truth: scripts/sentinels/relay-invariants.json",
+                file=sys.stderr,
+            )
+            print(
+                "  A pinned characterization test was deleted/renamed. If the behavior "
+                "was intentionally retired, update the registry in the SAME PR (this is "
+                "the human-review checkpoint). Otherwise restore the test — an upstream "
+                "merge silently reverted a deliberate TokenKey relay choice.",
+                file=sys.stderr,
+            )
+
+    return 0 if fail_count == 0 else 1
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/scripts/sentinels/gateway-tk.json
+++ b/scripts/sentinels/gateway-tk.json
@@ -2789,6 +2789,28 @@
         "filtered_model_rate_limited"
       ],
       "rationale": "The Layer-2 load-balance candidate loop in SelectAccountWithLoadAwareness must emit the per-gate exclusion breakdown (account_scheduling_loadbalance_no_candidates WARN carrying filtered_excluded/unschedulable/platform/model_unsupported/model_rate_limited/quota/window_cost/rpm counts) when the candidate set is empty, mirroring the Layer-1 routing breakdown. Without it an empty load-balance pool surfaces only as a bare ErrNoAvailableAccounts with no way to tell which gate emptied it (the 2026-06-18 prod opus-4-8 empty-pool incident could not be root-caused for exactly this reason). This is a TK-only insertion inside the most upstream-churned scheduling function and has no unit test guarding it, so it is a prime target for a silent auto-merge drop on the next upstream merge; this sentinel turns that into a CI failure instead of a re-opened observability blind spot."
+    },
+    {
+      "path": "backend/internal/service/thinking_ref_model_tk.go",
+      "must_contain": [
+        "func thinkingRefModelForAnthropicRelay(mappedModel string) string",
+        "func thinkingRefModelForAnthropicCompat(originalModel string) string"
+      ],
+      "rationale": "The thinking model-reference seam. The upstream-owned thinking helpers (ResolveThinkingProtocol / FilterThinkingBlocks* / RectifyThinkingBudget) take one model argument, but the correct value is the MAPPED upstream model on the native Anthropic relay path and the ORIGINAL client model on the Anthropic-shape->Gemini-backend compat path — opposite variables for the same role. These two named helpers make the per-path choice greppable so an upstream merge cannot silently swap mappedModel<->originalModel at a call site. Behavior is pinned in both directions by relay-invariants.json (thinking_ref_model_tk_test.go); this anchor guards the seam DEFINITIONS themselves against deletion."
+    },
+    {
+      "path": "backend/internal/service/gateway_service_tk_signature_preempt.go",
+      "must_contain": [
+        "thinkingRefModelForAnthropicRelay(mappedModel)"
+      ],
+      "rationale": "Wiring of the native-relay thinking-reference helper at the signature-preempt pre-filter. Anchors the injection point so a merge that rewrites applySigPreemptIfArmed cannot silently revert to passing the bare model (and thereby blur the relay-vs-compat distinction the seam exists to keep legible)."
+    },
+    {
+      "path": "backend/internal/service/gemini_messages_compat_service.go",
+      "must_contain": [
+        "thinkingRefModelForAnthropicCompat(originalModel)"
+      ],
+      "rationale": "Wiring of the compat-path thinking-reference helper in the Gemini messages-compat signature-retry. This is the ODD-ONE-OUT call site (keys on originalModel, not mappedModel); anchoring the wrapped call ensures an upstream merge cannot silently swap it to mappedModel (which would classify the gemini backend as non-strict and skip the required thinking-block strip, 400-ing the request)."
     }
   ]
 }

--- a/scripts/sentinels/grok.json
+++ b/scripts/sentinels/grok.json
@@ -39,8 +39,8 @@
     },
     {
       "path": "backend/internal/repository/account_repo.go",
-      "must_contain": ["'antigravity', 'kiro', 'grok'"],
-      "rationale": "ListOAuthRefreshCandidates' platform IN(...) list MUST include grok. The background refresh ticker is the only grok token-renewal path (the gateway reads access_token raw, no on-demand refresh) and grok OAuth access tokens default to ~1h. An upstream merge that resets this list to upstream's four platforms silently drops grok, and within ~1h every grok account 401s out of the pool with no auto-recovery. Upstream has no platform 6/7, so this list is a recurring TK-divergence conflict point."
+      "must_contain": ["platform = ANY($1)", "pq.Array(engine.OAuthRefreshPlatforms())"],
+      "rationale": "ListOAuthRefreshCandidates' platform filter MUST stay parametrized from the single source of truth: `platform = ANY($1)` bound from `pq.Array(engine.OAuthRefreshPlatforms())`. There is intentionally NO platform literal left in this SQL — the old hand-maintained `platform IN ('anthropic','openai','gemini','antigravity','kiro','grok')` literal was the exact surface an upstream merge silently reset to its four platforms (R-001), dropping grok so every grok account 401s out of the pool within ~1h with no auto-recovery (the background ticker is grok's only token-renewal path). grok membership itself is now guaranteed upstream of the SQL: engine.OAuthRefreshPlatforms() derives from engine.AllSchedulingPlatforms() (which is anchored to contain domain.PlatformGrok by the engine/provider.go sentinel) minus the apikey-only newapi. If this anchor fails, an upstream merge reverted the parametrization back to a literal — restore `= ANY($1)`, do NOT re-introduce a literal list."
     },
     {
       "path": "backend/internal/service/openai_gateway_service.go",

--- a/scripts/sentinels/kiro.json
+++ b/scripts/sentinels/kiro.json
@@ -23,9 +23,10 @@
       "path": "backend/internal/repository/account_repo.go",
       "must_contain": [
         "func (r *accountRepository) SumConcurrencyByPlatform",
-        "'antigravity', 'kiro', 'grok'"
+        "platform = ANY($1)",
+        "pq.Array(engine.OAuthRefreshPlatforms())"
       ],
-      "rationale": "Two load-bearing kiro anchors. (1) SumConcurrencyByPlatform: platform-wide schedulable Σ reader backing the kiro arm of the edge capacity endpoint (the kiro pool is not group-scoped like anthropic's \"default\"); losing it breaks ?platform=kiro capacity reads. (2) ListOAuthRefreshCandidates' platform IN(...) MUST include kiro — the background refresh ticker is the only kiro token-renewal path (gateway reads access_token raw) and an upstream merge that resets this list to upstream's four platforms silently drops kiro, so kiro accounts expire and 401 out of the pool with no auto-recovery. (account_repo.go is also a gateway-tk hotspot — dual-covered on purpose.)"
+      "rationale": "Two load-bearing kiro anchors. (1) SumConcurrencyByPlatform: platform-wide schedulable Σ reader backing the kiro arm of the edge capacity endpoint (the kiro pool is not group-scoped like anthropic's \"default\"); losing it breaks ?platform=kiro capacity reads. (2) ListOAuthRefreshCandidates' platform filter MUST stay parametrized from the single source of truth: `platform = ANY($1)` bound from `pq.Array(engine.OAuthRefreshPlatforms())`, with NO platform literal left in the SQL. The old `platform IN ('anthropic',...,'kiro','grok')` literal was the surface an upstream merge silently reset to its four platforms (R-001), dropping kiro so kiro accounts expire and 401 out of the pool with no auto-recovery (the background ticker is kiro's only token-renewal path). kiro membership is guaranteed upstream of the SQL: engine.OAuthRefreshPlatforms() derives from engine.AllSchedulingPlatforms() (anchored to contain domain.PlatformKiro by the kiro engine sentinel) minus the apikey-only newapi. (account_repo.go is also a gateway-tk hotspot — dual-covered on purpose.) If the parametrization anchor fails, an upstream merge reverted `= ANY($1)` back to a literal — restore the parametrized form, do NOT re-introduce a literal list."
     },
     {
       "path": "backend/internal/handler/edge_tk_capacity_handler_test.go",

--- a/scripts/sentinels/merge-gate-parity.json
+++ b/scripts/sentinels/merge-gate-parity.json
@@ -13,6 +13,7 @@
     "scripts/sentinels/check-terminal-events.py",
     "scripts/sentinels/check-engine-facade.py",
     "scripts/sentinels/check-pricing-availability.py",
+    "scripts/sentinels/check-relay-invariants.py",
     "scripts/sentinels/check-registry-update-gate.py",
     "scripts/checks/buffered-content-type-leak.py"
   ]

--- a/scripts/sentinels/relay-invariants.json
+++ b/scripts/sentinels/relay-invariants.json
@@ -1,0 +1,108 @@
+{
+  "version": 1,
+  "rationale": "Relay-invariant test registry. Each entry pins a load-bearing, TokenKey-DELIBERATE relay behavior to the characterization test(s) that encode it. PR #835 (80 upstream commits) showed the recurring failure class this guards: an upstream rewrite silently deletes a TK behavior (G4 5h-window cooldown class, kiro/grok refresh candidates) or overrides a deliberate TK choice (SSE stream-error 502→403) with no merge conflict, no compile error, and a green CI — because the only proof of the TK choice was a test that got deleted/gutted in the same merge. This registry makes that mechanically impossible: `must_contain` anchors each test's FUNCTION DEFINITION (`func TestX(`), so an upstream merge that removes or renames the test fails this check (run by scripts/preflight.sh AND .github/workflows/upstream-merge-pr-shape.yml). The schema is the standard sentinels/path/must_contain form (not a bespoke one) so check-registry-update-gate.py also treats these test files as covered surfaces — deleting a pinned test then additionally trips the registry-update gate. Adding a new load-bearing TK relay behavior MUST add its characterization test AND an entry here in the same commit. Conversely, if you intentionally retire a behavior, you must edit this registry in the same PR (which is the human-review checkpoint, not a rubber stamp).",
+  "sentinels": [
+    {
+      "path": "backend/internal/service/ratelimit_service_tk_model_cooldown_test.go",
+      "must_contain": [
+        "func TestG4_OverallWindow429_CoolsAccountNotModelClass(",
+        "func TestG4_PerClassSubBucket429_ModelScopedSiblingsSchedulable(",
+        "func TestG4_OpusCooled_SonnetHaikuStillSchedulable("
+      ],
+      "rationale": "G4 — Anthropic 5h/7d unified-window 429 cooldown scoping. An account-wide overall-window 429 must cool the WHOLE account, while a per-model-class sub-bucket 429 must cool only that class (opus cooled → sonnet/haiku still schedulable). This exact behavior block was silently deleted by an upstream merge once (the marquee G4 incident) and rebuilt; these TestG4_* characterization tests are its proof. Losing them lets a future merge flatten the model-class scoping back to account-wide (over-cooling) or vice versa, unnoticed."
+    },
+    {
+      "path": "backend/internal/repository/account_repo_temp_unsched_test.go",
+      "must_contain": [
+        "func TestAccountRepository_ListOAuthRefreshCandidates_SQLFilter("
+      ],
+      "rationale": "kiro/grok OAuth refresh candidates (R-001), SQL layer. Asserts the background-refresh candidate SQL filters platforms via the parametrized `= ANY($1)` bound from engine.OAuthRefreshPlatforms() with NO platform literal left in the SQL, and that the bound list still covers kiro/grok. This is the structural kill for the R-001 silent-drop: upstream reset the hand-maintained `platform IN (...)` list to its four platforms, dropping TK platforms 6/7 with a green CI because no test pinned the list."
+    },
+    {
+      "path": "backend/internal/service/token_refresh_service_candidates_test.go",
+      "must_contain": [
+        "func TestRegisteredRefreshers_MatchOAuthRefreshSourceOfTruth(",
+        "func TestTokenRefreshService_ProcessRefreshUsesOAuthRefreshCandidates("
+      ],
+      "rationale": "kiro/grok OAuth refresh candidates (R-001), service layer. The first test welds the registered TokenRefresher set to engine.OAuthRefreshPlatforms() (a platform in the source of truth with no refresher — or a refresher with no platform — fails). The second proves kiro/grok OAuth accounts remain background-refresh candidates end-to-end. Together they make the R-001 silent-drop a build failure on either side."
+    },
+    {
+      "path": "backend/internal/service/ratelimit_service_tk_anthropic_org_ban_403_test.go",
+      "must_contain": [
+        "func TestHandle403_AnthropicOrgBan_PermanentlyDisables(",
+        "func TestTryDisableAnthropicOrgBan403_MatchesOrgBan("
+      ],
+      "rationale": "Anthropic org-ban 403 → permanent disable (#810). A repeated, non-healing 403 anthropic_upstream_error is an org-level relay ban (refresh still succeeds, masking it as alive); TK permanently disables the account on the matched phrase rather than transiently cooling it forever. Losing this test lets a merge revert to transient cooldown, re-arming a dead account in the pool indefinitely."
+    },
+    {
+      "path": "backend/internal/service/ratelimit_service_tk_anthropic_bodyless_403_test.go",
+      "must_contain": [
+        "func TestRateLimitService_BodylessBan403_ThresholdPermanentlyDisables(",
+        "func TestRateLimitService_BodylessBan403_StructuredBodyNeverCounts("
+      ],
+      "rationale": "Anthropic bodyless-403 terminal counter (#832). A 403 with an EMPTY body (WAF/ban edge) counts toward a permanent-disable threshold, while a 403 with a structured error body NEVER counts (it is a normal entitlement/quota 403). This polarity is subtle and easy for a merge to invert; the tests pin both directions."
+    },
+    {
+      "path": "backend/internal/service/ratelimit_service_tk_oauth401_test.go",
+      "must_contain": [
+        "func TestRateLimitService_OAuth401_ValidTokenDisablesFirstStrike(",
+        "func TestRateLimitService_OAuth401_ValidTokenDeferredDuringClaudeIncident("
+      ],
+      "rationale": "OAuth 401 on a still-valid token → first-strike disable (#831), DEFERRED during a Claude-wide incident (#834). A 401 returned while the local access_token is provably fresh means the grant was revoked upstream, so TK disables on the first strike — EXCEPT during a declared Claude API incident, when a 401 storm is upstream-wide and disabling would drain the pool. Both the disable and the incident-defer are deliberate TK choices a merge could silently undo."
+    },
+    {
+      "path": "backend/internal/service/gateway_service_tk_beta_selfheal_test.go",
+      "must_contain": [
+        "func TestTkIsAnthropicUsagePolicyBlock("
+      ],
+      "rationale": "Anthropic usage-policy block detection. Classifies a usage-policy rejection so it is handled as a policy block (its own cooldown/advice path) rather than a generic upstream error. Losing the classifier folds usage-policy blocks back into the generic error ladder, mis-cooling and mis-alerting."
+    },
+    {
+      "path": "backend/internal/service/ratelimit_service_anthropic_consolidation_test.go",
+      "must_contain": [
+        "func TestRateLimitService_HandleUpstreamError_Anthropic403TLSFingerprintShortCooldown(",
+        "func TestRateLimitService_HandleUpstreamError_Anthropic403TLSFingerprintNotEatenBy403Rule("
+      ],
+      "rationale": "Anthropic TLS-fingerprint 403 → SHORT cooldown, not the long 403 ladder. A 403 caused by a TLS-fingerprint mismatch is transient (resolves on the next fingerprint sync) and must get a short cooldown, and must NOT be swallowed by the generic 403 permanent-disable rule. The second test guards exactly that precedence — a merge reordering the 403 rules would silently turn a recoverable fingerprint blip into a permanent disable."
+    },
+    {
+      "path": "backend/internal/service/ratelimit_service_tk_request_owned_429_test.go",
+      "must_contain": [
+        "func TestRateLimitService_HandleUpstreamError_RequestOwned429_DoesNotPenalize(",
+        "func TestRateLimitService_HandleUpstreamError_Genuine429_StillPenalizes("
+      ],
+      "rationale": "Request-owned 429 skip. A 429 whose phrase identifies it as owned by THIS request (a client-side/cancel-shaped 429, not pool saturation) must NOT penalize the account's cooldown ladder, while a genuine pool 429 still does. Losing this lets request-owned 429s smear cooldown across healthy accounts (the failover-pollution failure mode)."
+    },
+    {
+      "path": "backend/internal/service/gateway_service_tk_request_owned_429_test.go",
+      "must_contain": [
+        "func TestTkHandleAnthropicRequestOwned429_KnownPhraseShortCircuitsFirstHop(",
+        "func TestTkHandleAnthropicRequestOwned429_CapacityEnvelopesExempt("
+      ],
+      "rationale": "Request-owned 429 short-circuit at the gateway (the phrase-detection + same-text breaker that classifies a 429 as request-owned and exempts genuine capacity-envelope 429s). Paired with the ratelimit-layer test above; both layers must agree or a request-owned 429 either over- or under-penalizes."
+    },
+    {
+      "path": "backend/internal/service/gateway_streaming_test.go",
+      "must_contain": [
+        "func TestSSEStreamErrorFailover_Returns502NotForbidden("
+      ],
+      "rationale": "SSE stream-error-after-200 → 502 (Bad Gateway), NOT 403. A mid-stream upstream death is 'upstream unavailable', so it must fail over with 502 and hit the TempUnscheduleRetryableError 502 hook — not 403, which routes the event into handle403's org-ban/WAF/entitlement space and collided with the empty-body-403 fast-fail. The merge that produced #835 overrode TK's deliberate 502 (commit c7785a7e) back to upstream's 403; this test is the graft's permanent guard (the seed of this whole registry)."
+    },
+    {
+      "path": "backend/internal/service/thinking_ref_model_tk_test.go",
+      "must_contain": [
+        "func TestThinkingRefModel_AnthropicRelayUsesMappedModel(",
+        "func TestThinkingRefModel_AnthropicCompatUsesOriginalModel("
+      ],
+      "rationale": "Thinking-protocol model-reference routing. The thinking helpers key on the MAPPED upstream model on the native Anthropic relay path but the ORIGINAL client model on the Anthropic-shape→Gemini-backend compat path — opposite variables for the same semantic role. These tests pin the behavior in BOTH directions (each proves the inversion would break the other path), welding the choice named by thinking_ref_model_tk.go so a merge cannot silently swap mappedModel↔originalModel."
+    },
+    {
+      "path": "backend/internal/service/thinking_protocol_test.go",
+      "must_contain": [
+        "func TestResolveThinkingProtocol(",
+        "func TestShouldApplyRetryFiltersMirrorsPreFilter("
+      ],
+      "rationale": "Thinking-protocol classification (anthropic-strict vs passback-required vs unknown) and the pre-filter/retry-filter symmetry. This is the family-classification logic the model-reference routing above depends on; an upstream rewrite of ResolveThinkingProtocol that drops a passback-required vendor prefix (deepseek/kimi/glm/minimax-m/qwen-thinking) would silently start stripping thinking blocks those upstreams require round-tripped."
+    }
+  ]
+}


### PR DESCRIPTION
## 这个 PR 做什么、为什么

**#835 合并风险收口的第二步**（已批准计划 §Part2）。#835 那次 80 个 upstream commit 暴露了一类反复出现的缺陷：**upstream 重写某结构后，依赖旧结构的 TokenKey 行为被静默删除、或被盖回上游——没有冲突标记、没有编译错、CI 全绿。** 三轮 sweep 揪出并修掉了具体 incident（G4 五小时窗冷却、R-001 的 kiro/grok 刷新名单、SSE 流内错误 502→403 被盖回）。

本 PR 不修 incident（那些已在 #835 修完），而是**把这一缺陷类机械上焊死，让它再也无法静默发生**。纯守卫 PR，**不重写**那 13 个冷却机制（本质复杂度，逐条对应真实停摆，见计划 §不做什么）。

## 三个组件

### 1. 不可删特征测试注册表（keystone）
- 新增 `scripts/sentinels/relay-invariants.json` + `scripts/sentinels/check-relay-invariants.py`（沿用 `check-grok.py` 形状）。
- 把 **13** 条 load-bearing、TokenKey 深思熟虑的中继行为，锚定到各自的特征测试上——锚的是测试的 `func TestX(` 定义。覆盖：G4 冷却作用域、kiro/grok 刷新候选、org-ban-403、bodyless-403、oauth401-on-valid-token（含 incident 期延迟）、usage-policy、TLS 指纹冷却、request-owned-429 跳过、SSE-502、thinking 模型引用路由、thinking 协议分类。
- **merge 删掉/掏空任一被锚测试 → CI 红。** 接入 `preflight.sh`、`upstream-merge-pr-shape.yml`（新增 Check 4e）、`merge-gate-parity.json`。

### 2. 平台成员单一真值源（结构性杀 R-001 类）
- 新增 `engine.OAuthRefreshPlatforms()` —— `AllSchedulingPlatforms()` 去掉仅用 api key 的 `newapi`（是投影，不是另一份手维护名单）。
- `account_repo.go::ListOAuthRefreshCandidates` 的 SQL：`platform IN ('...')` 字面量 → 参数化 **`= ANY($1)`**，绑定值来自真值源。**SQL 里不再留任何平台字面量**——正是 R-001 里 upstream 把名单重置回四平台的那个面。
- 一个探针测试把已注册的 `TokenRefresher` 集焊死到同一份名单：掉平台时，**SQL 侧和注册侧两个方向都会编译/测试失败**。
- **上游方法签名不动**（merge 友好）；`grok.json`/`kiro.json` 的 `account_repo.go` 锚改成参数化形态。

### 3. thinking 模型引用焊死
- 新增 `thinking_ref_model_tk.go`，把「按路径选模型」这对易反转的选择命名出来——native Anthropic relay 路径用 **mapped** 上游模型，Anthropic-shape→Gemini-backend compat 路径用 **original** 客户端模型（同一语义角色、相反变量）。
- 双向特征测试钉死两条路径（各自证明：反转会打挂另一条）。
- **上游 thinking 函数签名不动**（已知 merge 冲突点）；seam + 两个注入点锚进 `gateway-tk.json`。

## 验证
- `go test -tags=unit ./...` —— 全绿（0 失败）。
- `golangci-lint --new-from-rev=origin/main` —— 0 issue。
- `scripts/preflight.sh` —— PASS（pre-commit 全量跑过）。
- **负向测试坐实有牙**：从真值源删 kiro/grok → 2 个组件 2 的测试失败；把被锚测试改名 → `check-relay-invariants.py` 失败（exit 1、有可操作提示）。

## 门禁说明
- **纯后端 / 脚本 / workflow**——无前端面（`no-web-impact`）。
- upstream-override marker 门禁：**无 upstream-shaped 路径改动**（已核），不需要 marker。
- registry-update 门禁：已满足——`relay-invariants.json` / `grok.json` / `kiro.json` / `gateway-tk.json` 均在本 PR 内更新。
- 已 rebase 到含 #845 的最新 origin/main，`gateway-tk.json` 的 trivial 追加冲突已解（#845 与本 PR 的哨兵条目都保留）。
- 合并方式按 §5.y：**Squash and merge**（TokenKey 自有 feature PR）。合并等授权。

🤖 Generated with [Claude Code](https://claude.com/claude-code)