### PR TITLE
feat(gateway): log per-filter breakdown when load-balance pool empties

### DIFF
--- a/backend/internal/service/gateway_service.go
+++ b/backend/internal/service/gateway_service.go
@@ -2262,42 +2262,76 @@ func (s *GatewayService) SelectAccountWithLoadAwareness(ctx context.Context, gro
 		"total_accounts", len(accounts),
 	)
 	candidates := make([]*Account, 0, len(accounts))
+	// TK: per-filter exclusion counters for the load-balance candidate loop.
+	// Layer 1 (model routing) already logs this breakdown; the Layer 2 path did
+	// not, so an empty load-balance pool surfaced only as a bare
+	// "no available accounts" with no way to tell WHICH gate emptied it. These
+	// counters feed the account_scheduling_loadbalance_no_candidates WARN below.
+	var filteredExcluded, filteredUnsched, filteredPlatform, filteredModelMapping,
+		filteredModelScope, filteredQuota, filteredWindowCost, filteredRPM int
 	for i := range accounts {
 		acc := &accounts[i]
 		if isExcluded(acc.ID) {
+			filteredExcluded++
 			continue
 		}
 		// Scheduler snapshots can be temporarily stale (bucket rebuild is throttled);
 		// re-check schedulability here so recently rate-limited/overloaded accounts
 		// are not selected again before the bucket is rebuilt.
 		if !s.isAccountSchedulableForSelection(acc) {
+			filteredUnsched++
 			continue
 		}
 		if !s.isAccountAllowedForPlatform(acc, platform, useMixed) {
+			filteredPlatform++
 			continue
 		}
 		if requestedModel != "" && !s.isModelSupportedByAccountWithContext(ctx, acc, requestedModel) {
+			filteredModelMapping++
 			continue
 		}
 		if !s.isAccountSchedulableForModelSelection(ctx, acc, requestedModel) {
+			filteredModelScope++
 			continue
 		}
 		// 配额检查
 		if !s.isAccountSchedulableForQuota(acc) {
+			filteredQuota++
 			continue
 		}
 		// 窗口费用检查（非粘性会话路径）
 		if !s.isAccountSchedulableForWindowCost(ctx, acc, false) {
+			filteredWindowCost++
 			continue
 		}
 		// RPM 检查（非粘性会话路径）
 		if !s.isAccountSchedulableForRPM(ctx, acc, false) {
+			filteredRPM++
 			continue
 		}
 		candidates = append(candidates, acc)
 	}
 
 	if len(candidates) == 0 {
+		// TK: emit the per-gate breakdown so an empty load-balance pool is
+		// diagnosable (which filter removed how many accounts) instead of an
+		// opaque "no available accounts". Fires only on the empty-pool error
+		// path, so it is low-volume. Mirrors the Layer 1 routing breakdown.
+		slog.Warn("account_scheduling_loadbalance_no_candidates",
+			"group_id", derefGroupID(groupID),
+			"platform", platform,
+			"model", requestedModel,
+			"session", shortSessionHash(sessionHash),
+			"total_accounts", len(accounts),
+			"filtered_excluded", filteredExcluded,
+			"filtered_unschedulable", filteredUnsched,
+			"filtered_platform", filteredPlatform,
+			"filtered_model_unsupported", filteredModelMapping,
+			"filtered_model_rate_limited", filteredModelScope,
+			"filtered_quota", filteredQuota,
+			"filtered_window_cost", filteredWindowCost,
+			"filtered_rpm", filteredRPM,
+		)
 		return nil, ErrNoAvailableAccounts
 	}
 

--- a/scripts/sentinels/gateway-tk.json
+++ b/scripts/sentinels/gateway-tk.json
@@ -2781,6 +2781,14 @@
         "h.chatCompletionsErrorResponse(c, tkStatus, tkType, tkMsg)"
       ],
       "rationale": "Anthropic-platform /v1/chat/completions first-attempt select-failure must route through tkSelectFailureStatusMessage (unservable model -> 400 invalid_request_error) BEFORE the empty-pool 429 fast-fail, parity with the /v1/responses companion. An upstream merge reverting this to a bare tkNoAvailableAccounts(c) call would silently reintroduce the 429 retry-storm misclassification for an unservable model name."
+    },
+    {
+      "path": "backend/internal/service/gateway_service.go",
+      "must_contain": [
+        "account_scheduling_loadbalance_no_candidates",
+        "filtered_model_rate_limited"
+      ],
+      "rationale": "The Layer-2 load-balance candidate loop in SelectAccountWithLoadAwareness must emit the per-gate exclusion breakdown (account_scheduling_loadbalance_no_candidates WARN carrying filtered_excluded/unschedulable/platform/model_unsupported/model_rate_limited/quota/window_cost/rpm counts) when the candidate set is empty, mirroring the Layer-1 routing breakdown. Without it an empty load-balance pool surfaces only as a bare ErrNoAvailableAccounts with no way to tell which gate emptied it (the 2026-06-18 prod opus-4-8 empty-pool incident could not be root-caused for exactly this reason). This is a TK-only insertion inside the most upstream-churned scheduling function and has no unit test guarding it, so it is a prime target for a silent auto-merge drop on the next upstream merge; this sentinel turns that into a CI failure instead of a re-opened observability blind spot."
     }
   ]
 }


### PR DESCRIPTION
## 背景

2026-06-18 prod 默认组(group_id=1)对 `claude-opus-4-8` 反复 `no available accounts`(空池 429,error_phase=routing,is_business_limited=true),但同账号同秒 haiku 仍 200、并发/RPM/session 全闲、prod 与 edge 都无 opus 冷却/上游 429。逐项排除后,空池只可能来自 `SelectAccountWithLoadAwareness` 的 Layer-2 负载均衡候选循环 —— 但**该循环落空时没有任何 per-gate 计数**,线上只剩一句 `no available accounts`,无法判断是 8 道筛子(excluded / unschedulable / platform / model-unsupported / model-rate-limited / quota / window-cost / rpm)中的哪一道清空了池。这正是本次无法定根因的直接原因。

Layer-1(模型路由)路径**已有**这个 breakdown 日志(`filtered(excluded=.. unsched=.. ...)`),但默认组没开模型路由、走的是 Layer-2 —— 所以那条好用的诊断信息用不上。

## 改动

- 给 Layer-2 候选循环加 8 个 per-gate 计数器;
- 仅在 `len(candidates)==0`(空池错误路径)时打一条结构化 WARN `account_scheduling_loadbalance_no_candidates`,带 group/platform/model/session/total + 各 gate 的过滤数。

**纯加法、不改任何调度行为**(`git diff --numstat` = 34/0),只在错误路径触发(低频)。与 Layer-1 的 breakdown 对齐。下次空池一眼可定位是哪道闸、刷了几个账号。

## 验证

- `go build ./...` ✅
- `go test -tags=unit ./...` 全绿 ✅
- `golangci-lint run ./internal/service/` 0 issues ✅
- `scripts/preflight.sh` PASS(含全部 sub2api 门禁)✅

## merge / 门禁备注

- TK feature PR → 用 **Squash and merge**。
- no-web-impact(纯后端,无前端面变更)。
- upstream-override:本 diff 为纯插入(pure-insertion),override gate 自动通过,无需 marker。

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
### 追加:upstream-merge 反向漂移防护(commit 2)

本诊断块插在 `SelectAccountWithLoadAwareness`(上游最高频改动的调度函数)内、且无 unit test 守护,是下次 `git merge upstream/main` 冲突时被 auto-merge 静默吞掉的高危目标。新增 `scripts/sentinels/gateway-tk.json` 一条锚点(`account_scheduling_loadbalance_no_candidates` + `filtered_model_rate_limited`),使该块若被合丢则 `check-gateway-tk.py` CI 失败,而非静默回到观测盲区。

- 两次 commit 对 upstream-shaped / sentinel 文件均为**纯插入**(无删除)→ upstream-override gate 自动通过、registry-update gate 豁免,无需 marker。