### PR TITLE
fix(studio): stop false-failure on generated videos + per-model duration

### DIFF
--- a/backend/internal/handler/openai_gateway_tk_video.go
+++ b/backend/internal/handler/openai_gateway_tk_video.go
@@ -370,19 +370,23 @@ func (h *OpenAIGatewayHandler) VideoFetch(c *gin.Context) {
 		_, _ = c.Writer.Write(out.RawResponse)
 	}
 
-	// On terminal status we drop the entry to bound storage; clients that
-	// need the URL must have already consumed the response body above.
-	if terminal, failed := videoTerminalOutcome(out.Status); terminal {
+	// Terminal handling. We delete the registry entry ONLY on terminal FAILURE
+	// (paired with the refund). Terminal SUCCESS is deliberately KEPT until its
+	// TTL: a Veo success body is a 10–20 MB inline base64 clip that takes ~30s to
+	// stream, and a client whose fetch is aborted mid-download (slow link, tab
+	// switch, an over-tight client timeout) must be able to RE-FETCH it. Deleting
+	// on success made that retry 404, which the Studio then rendered as a false
+	// "failed — refunded" card for a video that actually generated and was billed.
+	// Storage stays bounded by the record TTL either way.
+	if terminal, failed := videoTerminalOutcome(out.Status); terminal && failed {
 		h.videoTaskCache.Delete(c.Request.Context(), publicTaskID)
-		if failed {
-			// The user paid at submit for a video that never materialized —
-			// reverse the charge. Idempotency lives in the refund itself
-			// (usage_billing_dedup keyed by the public task id), so a concurrent
-			// poll racing this Delete cannot double-refund. Clients that never
-			// poll a failed task are never refunded (registry record expires
-			// with its TTL); openai_video_refund.* logs are the audit trail.
-			h.scheduleVideoRefundAttempt(c.Request.Context(), rec, 0)
-		}
+		// The user paid at submit for a video that never materialized — reverse
+		// the charge. Idempotency lives in the refund itself (usage_billing_dedup
+		// keyed by the public task id), so a concurrent poll racing this Delete
+		// cannot double-refund. Clients that never poll a failed task are never
+		// refunded (registry record expires with its TTL); openai_video_refund.*
+		// logs are the audit trail.
+		h.scheduleVideoRefundAttempt(c.Request.Context(), rec, 0)
 	}
 }
 

--- a/backend/internal/handler/openai_gateway_tk_video_contract_test.go
+++ b/backend/internal/handler/openai_gateway_tk_video_contract_test.go
@@ -25,12 +25,14 @@ import (
 // with videoTerminalOutcome — the refund trigger depends on it.
 func TestVideoTerminalOutcome_NewAPITaskStatusContract(t *testing.T) {
 	terminal, failed := videoTerminalOutcome(string(newapimodel.TaskStatusFailure))
-	require.True(t, terminal, "FAILURE must be terminal (registry cleanup)")
-	require.True(t, failed, "FAILURE must trigger the submit-charge refund")
+	require.True(t, terminal, "FAILURE must be terminal (stops the client poll)")
+	require.True(t, failed, "FAILURE must trigger the registry cleanup + submit-charge refund")
 
 	terminal, failed = videoTerminalOutcome(string(newapimodel.TaskStatusSuccess))
-	require.True(t, terminal, "SUCCESS must be terminal (registry cleanup)")
-	require.False(t, failed, "SUCCESS must NOT trigger a refund")
+	require.True(t, terminal, "SUCCESS must be terminal (stops the client poll)")
+	// NOTE: only FAILURE deletes the registry entry now; SUCCESS is kept until
+	// TTL so an aborted large-body fetch can re-fetch (see VideoFetch).
+	require.False(t, failed, "SUCCESS must NOT trigger a refund or registry cleanup")
 
 	for _, nonTerminal := range []string{
 		string(newapimodel.TaskStatusNotStart),

--- a/backend/internal/web/dist/frontend-source.json
+++ b/backend/internal/web/dist/frontend-source.json
@@ -1,7 +1,7 @@
 {
   "algorithm": "sha256(git-ls-files:path,size,content)",
   "file_count": 489,
-  "hash": "e65df8605831259924a81f8fabea97cf34b63a2c31a93e286cca71667540904c",
+  "hash": "a3b2264916c3653ff845f7dc5315553f5e8e720ffe89ef6bd1885ea83f8eaa7d",
   "schema": 1,
   "source": "frontend/"
 }

--- a/frontend/src/api/playground.ts
+++ b/frontend/src/api/playground.ts
@@ -34,6 +34,17 @@ export const PLAYGROUND_MAX_TOKENS_CAP = 4096
 /** Max user+assistant turns kept in browser memory. */
 export const PLAYGROUND_MAX_TURNS = 50
 export const PLAYGROUND_FETCH_TIMEOUT_MS = 60_000
+/**
+ * Video-task FETCH timeout. Must be far larger than the chat/submit timeout: a
+ * Veo terminal SUCCESS response carries the generated clip as INLINE base64
+ * (response.videos[0].bytesBase64Encoded, 10–20 MB) which takes ~30s to stream
+ * back through the gateway. The old 30s ceiling aborted exactly on that body,
+ * and because the backend deletes the registry record on terminal status, the
+ * retry then 404'd → the card showed a false "failed — refunded" for a video
+ * that actually generated (and was billed). 180s gives the large body ample
+ * headroom; processing polls return in ms and are unaffected.
+ */
+export const PLAYGROUND_VIDEO_FETCH_TIMEOUT_MS = 180_000
 
 function stripTrailingSlashes(u: string): string {
   return u.replace(/\/+$/, '')
@@ -279,5 +290,8 @@ export async function gatewayVideoFetch(
   signal?: AbortSignal
 ): Promise<unknown> {
   const url = `${stripTrailingSlashes(gatewayBaseUrl)}/v1/video/generations/${encodeURIComponent(taskId)}`
-  return gatewayRequestJSON(apiKey, url, { method: 'GET', timeoutMs: 30_000 }, signal)
+  // 180s, not 30s: the terminal SUCCESS body is a 10–20 MB inline base64 clip
+  // (see PLAYGROUND_VIDEO_FETCH_TIMEOUT_MS) — a short timeout aborts mid-download
+  // and the poll then mis-reports the (actually generated) video as failed.
+  return gatewayRequestJSON(apiKey, url, { method: 'GET', timeoutMs: PLAYGROUND_VIDEO_FETCH_TIMEOUT_MS }, signal)
 }

--- a/frontend/src/constants/__tests__/mediaTiers.tk.spec.ts
+++ b/frontend/src/constants/__tests__/mediaTiers.tk.spec.ts
@@ -5,6 +5,8 @@ import {
   pickModalityKey,
   resolveAvailableModels,
   defaultModelId,
+  videoDurationDefault,
+  VIDEO_DURATION_DEFAULT,
   MEDIA_MODELS,
   IMAGEN_IMAGE_SIZES,
   SEEDREAM_IMAGE_SIZES,
@@ -217,6 +219,54 @@ describe('capability map honesty (verified against new-api adaptors)', () => {
     expect(s).toContain('seed')
     expect(s).toContain('firstFrameImage')
     expect(s).not.toContain('negativePrompt')
+  })
+})
+
+describe('video durations (per-model discrete, never a footgun)', () => {
+  // Regression guard for the "$31.80 for a 53s Veo clip" footgun: the duration
+  // axis used to be a global 1–60s slider, so users were quoted (and pre-charged)
+  // for durations the upstream always rejects. Each video model now declares its
+  // accepted discrete seconds; this locks that invariant.
+  const videoModels = MEDIA_MODELS.filter((m) => m.modality === 'video')
+  const byId = (id: string) => MEDIA_MODELS.find((m) => m.modelId === id)!
+
+  it('every video model declares a non-empty videoDurations; image models declare none', () => {
+    expect(videoModels.length).toBeGreaterThan(0)
+    for (const m of videoModels) {
+      expect(m.videoDurations && m.videoDurations.length).toBeTruthy()
+    }
+    for (const m of MEDIA_MODELS.filter((m) => m.modality === 'image')) {
+      expect(m.videoDurations).toBeUndefined()
+    }
+  })
+
+  it('all declared durations are positive integers within a sane [1,15] ceiling (kills the >15s footgun)', () => {
+    for (const m of videoModels) {
+      for (const d of m.videoDurations!) {
+        expect(Number.isInteger(d)).toBe(true)
+        expect(d).toBeGreaterThanOrEqual(1)
+        expect(d).toBeLessThanOrEqual(15)
+      }
+    }
+  })
+
+  it('the default duration is the MAX accepted value (user directive) and is itself accepted', () => {
+    for (const m of videoModels) {
+      const def = videoDurationDefault(m.videoDurations)
+      expect(def).toBe(Math.max(...m.videoDurations!))
+      expect(m.videoDurations).toContain(def)
+    }
+  })
+
+  it('videoDurationDefault falls back to VIDEO_DURATION_DEFAULT when no durations are declared', () => {
+    expect(videoDurationDefault(undefined)).toBe(VIDEO_DURATION_DEFAULT)
+    expect(videoDurationDefault([])).toBe(VIDEO_DURATION_DEFAULT)
+  })
+
+  it('Veo 3.1 accepts exactly 4/6/8s (Vertex official); Seedance 1.0 exactly 5/10s', () => {
+    expect(byId('veo-3.1-generate-001').videoDurations).toEqual([4, 6, 8])
+    expect(byId('veo-3.1-fast-generate-001').videoDurations).toEqual([4, 6, 8])
+    expect(byId('seedance-1-0-pro-250528').videoDurations).toEqual([5, 10])
   })
 })
 

--- a/frontend/src/constants/mediaTiers.tk.ts
+++ b/frontend/src/constants/mediaTiers.tk.ts
@@ -194,9 +194,15 @@ export const VIDEO_ASPECT_PRESETS: VideoAspectPreset[] = [
   { id: '1:1', label: '1:1' },
 ]
 
-/** Video duration bounds (handlers clamp to [1,60]; default 8s). */
-export const VIDEO_DURATION_MIN = 1
-export const VIDEO_DURATION_MAX = 60
+/**
+ * Fallback video duration default (seconds) used ONLY before a model is selected
+ * or for a video model that declares no `videoDurations`. Real durations are
+ * per-model and discrete (see MediaModel.videoDurations) — the global 1–60s
+ * slider was a footgun: it let users request (and get quoted for) durations the
+ * model's UPSTREAM always rejects, e.g. a 53s Veo clip @ $0.60/s = $31.80 that
+ * Vertex hard-fails (Veo accepts only 4/6/8s). The backend still clamps to
+ * [1,60] defensively, but the UI now never offers an out-of-range value.
+ */
 export const VIDEO_DURATION_DEFAULT = 8
 
 /** Image count bounds for the n stepper. */
@@ -266,6 +272,17 @@ export interface MediaModel {
    * tier). The Studio routes it through chat and skips the size-tier cost multiplier.
    */
   flatImageBilling?: boolean
+  /**
+   * Video modality only: the DISCRETE durations (seconds) this model's UPSTREAM
+   * accepts — same "declare exactly what the upstream takes" contract as
+   * `imageSizes`/`supportedParams`. The Studio renders these as chips and never
+   * lets the user pick (or get quoted for) an out-of-range value, so a request is
+   * priced ∩ servable, never a 400/FAILURE-on-submit footgun. Per the upstream
+   * task adaptors (new-api ResolveVeoDuration / doubao) durations are passed
+   * through unvalidated, so the upstream's own accepted set is the only guard.
+   * The default selected value is the MAX of this list (videoDurationDefault).
+   */
+  videoDurations?: number[]
 }
 
 /**
@@ -373,6 +390,8 @@ export const MEDIA_MODELS: MediaModel[] = [
     modality: 'video',
     // doubao adaptor reads Seed + first-frame image; it has NO NegativePrompt field.
     supportedParams: ['seed', 'firstFrameImage'],
+    // Seedance 1.0 Pro: discrete 5s / 10s (Volcengine Ark, high confidence).
+    videoDurations: [5, 10],
   },
   {
     modelId: 'doubao-seedance-2-0-fast-260128',
@@ -382,6 +401,10 @@ export const MEDIA_MODELS: MediaModel[] = [
     vendorLabel: VOLC,
     modality: 'video',
     supportedParams: ['seed', 'firstFrameImage'],
+    // Seedance 2.0 Fast: sources conflict (4/8/12 vs 2–15); we take the cited
+    // fast-variant discrete set 4/8/12 — conservative (never offer a value the
+    // upstream rejects). TODO: verify against canonical Volcengine Ark docs.
+    videoDurations: [4, 8, 12],
   },
   {
     modelId: 'veo-3.1-fast-generate-001',
@@ -392,6 +415,9 @@ export const MEDIA_MODELS: MediaModel[] = [
     modality: 'video',
     // VeoParameters honors NegativePrompt + Seed; first-frame image supported.
     supportedParams: ['negativePrompt', 'seed', 'firstFrameImage'],
+    // Veo 3.1: discrete 4/6/8s (Vertex AI official, high confidence). With a
+    // first-frame/reference image upstream only returns 8s — not modeled here.
+    videoDurations: [4, 6, 8],
   },
   {
     modelId: 'veo-3.1-generate-001',
@@ -401,6 +427,8 @@ export const MEDIA_MODELS: MediaModel[] = [
     vendorLabel: VERTEX,
     modality: 'video',
     supportedParams: ['negativePrompt', 'seed', 'firstFrameImage'],
+    // Veo 3.1: discrete 4/6/8s (Vertex AI official, high confidence).
+    videoDurations: [4, 6, 8],
   },
 ]
 
@@ -456,6 +484,30 @@ export function resolveAvailableModels(
 export function defaultModelId(models: readonly ResolvedModel[]): string | null {
   const safe = models.find((r) => !r.model.needsApikeyAccount)
   return safe ? safe.model.modelId : null
+}
+
+/**
+ * Default selected video duration for a model: the MAX of its accepted
+ * durations (user directive — land on the longest valid clip). Falls back to
+ * VIDEO_DURATION_DEFAULT when the model declares no `videoDurations`.
+ */
+export function videoDurationDefault(durations: readonly number[] | undefined): number {
+  return durations && durations.length ? Math.max(...durations) : VIDEO_DURATION_DEFAULT
+}
+
+/**
+ * Snap a target duration to the model's NEAREST accepted value (ties → the
+ * larger). Used by the Bake-Off, where one shared duration is compared across
+ * models with DISJOINT accepted sets (e.g. Veo 4/6/8 vs Seedance 5/10 share
+ * none): each panel runs a value its own upstream accepts, never a footgun.
+ */
+export function snapVideoDuration(target: number, durations: readonly number[] | undefined): number {
+  if (!durations || !durations.length) return target
+  return durations.reduce((best, d) => {
+    const dd = Math.abs(d - target)
+    const db = Math.abs(best - target)
+    return dd < db || (dd === db && d > best) ? d : best
+  })
 }
 
 /** Advanced param bounds. */

--- a/frontend/src/views/user/studio/BakeOff.vue
+++ b/frontend/src/views/user/studio/BakeOff.vue
@@ -57,10 +57,23 @@
           </button>
         </div>
 
-        <div v-if="modality === 'video'" class="mt-3 flex items-center gap-3">
+        <!-- Shared duration is a TARGET across the compared models; chips are the
+             UNION of the selected models' accepted durations and each panel snaps
+             to its own model's nearest valid value (Veo 4/6/8 vs Seedance 5/10
+             share none), so no panel is ever submitted an out-of-range duration. -->
+        <div v-if="modality === 'video' && durationOptions.length" class="mt-3 flex flex-wrap items-center gap-2">
           <span class="text-sm font-medium text-gray-700 dark:text-dark-200">{{ t('studio.video.duration') }}</span>
-          <input v-model.number="duration" type="range" :min="VIDEO_DURATION_MIN" :max="VIDEO_DURATION_MAX" step="1" class="w-48 accent-primary-600" :disabled="running" />
-          <span class="rounded-md bg-primary-50 px-2 py-0.5 text-sm font-bold text-primary-700 tabular-nums dark:bg-primary-950/50 dark:text-primary-300">{{ duration }} s</span>
+          <button
+            v-for="d in durationOptions"
+            :key="d"
+            type="button"
+            class="rounded-lg border px-3 py-1.5 text-sm font-medium tabular-nums transition disabled:cursor-not-allowed disabled:opacity-50"
+            :class="duration === d ? 'border-primary-600 bg-primary-600 text-white' : 'border-gray-200 text-gray-600 hover:border-primary-300 dark:border-dark-600 dark:text-dark-300'"
+            :disabled="running"
+            @click="duration = d"
+          >
+            {{ d }} s
+          </button>
         </div>
 
         <div class="mt-4 flex flex-wrap items-center gap-3">
@@ -128,14 +141,14 @@
 </template>
 
 <script setup lang="ts">
-import { computed, ref } from 'vue'
+import { computed, ref, watch } from 'vue'
 import { useI18n } from 'vue-i18n'
 import { gatewayImageGenerations, gatewayVideoSubmit } from '@/api/playground'
 import { extractImageItems, extractVideoTaskId, videoStateFromFetch, extractVideoUrl } from '@/constants/playgroundMedia.tk'
 import {
-  VIDEO_DURATION_MIN,
-  VIDEO_DURATION_MAX,
   VIDEO_DURATION_DEFAULT,
+  videoDurationDefault,
+  snapVideoDuration,
   resolveAvailableModels,
   type StudioModality,
   type MediaPriceMap,
@@ -179,6 +192,8 @@ interface BakePanel {
   label: string
   vendorLabel: string
   cost: number
+  /** Video only: this model's snapped duration (seconds) actually submitted. */
+  seconds?: number
   state: 'idle' | 'processing' | 'succeeded' | 'failed'
   src?: string
   taskId?: string
@@ -216,12 +231,33 @@ function selectedResolved() {
   return models.value.filter((r) => selectedModelIds.value.includes(r.model.modelId))
 }
 
+// Union of the selected video models' accepted durations (sorted, deduped) →
+// the shared chip options. Each panel later snaps this target to its own model.
+const durationOptions = computed<number[]>(() => {
+  if (modality.value !== 'video') return []
+  const set = new Set<number>()
+  for (const r of selectedResolved()) for (const d of r.model.videoDurations ?? []) set.add(d)
+  return [...set].sort((a, b) => a - b)
+})
+
+// Keep the shared target inside the union; default to its MAX (user directive).
+watch(durationOptions, (opts) => {
+  if (opts.length && !opts.includes(duration.value)) {
+    duration.value = videoDurationDefault(opts)
+  }
+})
+
+/** Per-panel duration: the shared target snapped to THIS model's accepted set. */
+function panelSeconds(r: { model: { videoDurations?: number[] } }): number {
+  return snapVideoDuration(duration.value, r.model.videoDurations)
+}
+
 const totalCost = computed(() =>
   selectedResolved().reduce((sum, r) => {
     if (modality.value === 'image') {
       return sum + estimateImageCost({ baseImagePrice: r.baseImagePrice || 0, size: DEFAULT_IMAGE_SIZE, n: 1, rateMultiplier: props.rateMultiplier })
     }
-    return sum + estimateVideoCost({ perSecond: r.perSecond || 0, seconds: duration.value, rateMultiplier: props.rateMultiplier })
+    return sum + estimateVideoCost({ perSecond: r.perSecond || 0, seconds: panelSeconds(r), rateMultiplier: props.rateMultiplier })
   }, 0)
 )
 
@@ -231,7 +267,7 @@ const totalHold = computed(() =>
     if (modality.value === 'image') {
       return sum + estimateImageHoldCost({ baseImagePrice: r.baseImagePrice || 0, n: 1, rateMultiplier: props.rateMultiplier })
     }
-    return sum + estimateVideoCost({ perSecond: r.perSecond || 0, seconds: duration.value, rateMultiplier: props.rateMultiplier })
+    return sum + estimateVideoCost({ perSecond: r.perSecond || 0, seconds: panelSeconds(r), rateMultiplier: props.rateMultiplier })
   }, 0)
 )
 const canAfford = computed(() => totalHold.value <= props.balance)
@@ -277,7 +313,8 @@ async function run(): Promise<void> {
     cost:
       modality.value === 'image'
         ? estimateImageCost({ baseImagePrice: r.baseImagePrice || 0, size: DEFAULT_IMAGE_SIZE, n: 1, rateMultiplier: props.rateMultiplier })
-        : estimateVideoCost({ perSecond: r.perSecond || 0, seconds: duration.value, rateMultiplier: props.rateMultiplier }),
+        : estimateVideoCost({ perSecond: r.perSecond || 0, seconds: panelSeconds(r), rateMultiplier: props.rateMultiplier }),
+    seconds: modality.value === 'video' ? panelSeconds(r) : undefined,
     state: 'processing',
   }))
 
@@ -303,7 +340,7 @@ async function run(): Promise<void> {
       await Promise.all(
         panels.value.map(async (panel) => {
           try {
-            const raw = await gatewayVideoSubmit(props.apiKey, props.gatewayBase, { model: panel.servedId, prompt: text, duration: duration.value })
+            const raw = await gatewayVideoSubmit(props.apiKey, props.gatewayBase, { model: panel.servedId, prompt: text, duration: panel.seconds })
             const taskId = extractVideoTaskId(raw)
             if (!taskId) throw new Error('no_task')
             panel.taskId = taskId
@@ -315,7 +352,7 @@ async function run(): Promise<void> {
               prompt: text,
               model: panel.servedId,
               vendorLabel: panel.vendorLabel,
-              seconds: duration.value,
+              seconds: panel.seconds ?? duration.value,
               estCost: panel.cost,
               keyId: props.keyId as number,
               state,

--- a/frontend/src/views/user/studio/VideoStudio.vue
+++ b/frontend/src/views/user/studio/VideoStudio.vue
@@ -48,19 +48,23 @@
           @input="userEditedPrompt = true"
         />
         <div class="mt-3">
-          <div class="mb-2 flex items-center justify-between">
-            <span class="text-sm font-medium text-gray-700 dark:text-dark-200">{{ t('studio.video.duration') }}</span>
-            <span class="rounded-md bg-primary-50 px-2 py-0.5 text-sm font-bold text-primary-700 tabular-nums dark:bg-primary-950/50 dark:text-primary-300">{{ duration }} s</span>
+          <div class="mb-1.5 text-sm font-medium text-gray-700 dark:text-dark-200">{{ t('studio.video.duration') }}</div>
+          <!-- Per-model DISCRETE durations (chips) — the model declares exactly the
+               seconds its upstream accepts, so we never offer (or quote) an
+               out-of-range value that would hard-fail on submit. -->
+          <div class="flex flex-wrap gap-2 text-sm" data-testid="studio-video-duration">
+            <button
+              v-for="d in durations"
+              :key="d"
+              type="button"
+              class="rounded-lg border px-3 py-1.5 font-medium tabular-nums transition disabled:cursor-not-allowed disabled:opacity-50"
+              :class="duration === d ? 'border-primary-600 bg-primary-600 text-white' : 'border-gray-200 text-gray-600 hover:border-primary-300 dark:border-dark-600 dark:text-dark-300'"
+              :disabled="sending"
+              @click="duration = d"
+            >
+              {{ d }} s
+            </button>
           </div>
-          <input
-            v-model.number="duration"
-            type="range"
-            :min="VIDEO_DURATION_MIN"
-            :max="VIDEO_DURATION_MAX"
-            step="1"
-            class="w-full accent-primary-600"
-            :disabled="sending"
-          />
         </div>
         <div class="mt-3">
           <div class="mb-1.5 text-sm font-medium text-gray-700 dark:text-dark-200">{{ t('studio.video.aspect') }}</div>
@@ -248,9 +252,8 @@ import { gatewayVideoSubmit } from '@/api/playground'
 import { extractVideoTaskId, videoStateFromFetch, extractVideoUrl } from '@/constants/playgroundMedia.tk'
 import {
   VIDEO_ASPECT_PRESETS,
-  VIDEO_DURATION_MIN,
-  VIDEO_DURATION_MAX,
   VIDEO_DURATION_DEFAULT,
+  videoDurationDefault,
   SEED_MIN,
   SEED_MAX,
   resolveAvailableModels,
@@ -286,6 +289,8 @@ const selectedModelId = ref<string>('')
 const selected = computed(() => models.value.find((r) => r.model.modelId === selectedModelId.value) ?? null)
 const supports = (p: StudioParam): boolean => !!selected.value?.model.supportedParams.includes(p)
 
+// The selected model's accepted durations (chips); default lands on the MAX.
+const durations = computed<number[]>(() => selected.value?.model.videoDurations ?? [VIDEO_DURATION_DEFAULT])
 const duration = ref<number>(VIDEO_DURATION_DEFAULT)
 const aspectId = ref<string>('') // '' = auto (no aspect_ratio sent — proven zero-extra-field path)
 const prompt = ref('')
@@ -352,7 +357,19 @@ watch(
   },
   { immediate: true }
 )
-watch(selected, () => applySamplePrompt(), { immediate: true })
+watch(
+  selected,
+  () => {
+    applySamplePrompt()
+    // Keep `duration` valid for the selected model: default to the MAX accepted
+    // value, and snap any stale selection back into the model's allowed set so
+    // the estimate/quote is never for an out-of-range (guaranteed-fail) duration.
+    if (!durations.value.includes(duration.value)) {
+      duration.value = videoDurationDefault(selected.value?.model.videoDurations)
+    }
+  },
+  { immediate: true }
+)
 
 function formatElapsed(s: number): string {
   const sec = Math.max(0, Math.round(s || 0))


### PR DESCRIPTION
## 背景 / 用户反馈

用户在 Video Studio 反复生成 Veo 3.1 视频，卡片显示「失败 — 已退款」。只读线上核查（prod Caddy access log，全程零写）发现**视频其实生成成功了**：两个失败 task 的 fetch 真实序列是多次 `200 size=172`（processing）后一次 `200 size≈17–21MB dur≈30s`（成功体），随后 `404 ×3`。7 天内全部 video `ops_error_logs.upstream_status_code` 均为 null——**没有任何上游错误**（非配额、非未开通、非参数错）。

### 根因
Veo 终态 SUCCESS 把视频以 **inline base64（10–20MB）** 返回，经网关透传约 30s。而：
1. 前端 `gatewayVideoFetch` 硬编码 **30s 超时** → AbortController 恰好在这个大响应体上触发；
2. 后端 `VideoFetch` 在终态状态下**立即删除** registry 记录；
3. 前端重试 → 记录已删 → 连续 3 次 404 → poll 标 `failed`，errorMessage=「video task not found or expired」（即截图「技术详情」）。

终态是 success 非 failure，**退款不触发** → 用户被扣费但 UI 显示失败、视频也下载不回来。

## 改动

**1. 大视频假失败（用户反馈的真问题）**
- 前端：video fetch 超时 30s → 180s（`PLAYGROUND_VIDEO_FETCH_TIMEOUT_MS`），容纳 ~30s 的大 inline-base64 终态体；processing 轮询本身是 ms 级，不受影响。
- 后端：`VideoFetch` **仅在终态 FAILURE 时**删记录（配对退款）；SUCCESS 保留到 TTL，使被中断的终态 fetch 可**重取**而非 404→假失败。

**2. 时长陷阱（同屏暴露的另一个产品 bug）**
- 时长原是全局 1–60s 滑块，用户会为上游必拒的时长被报价/预扣（截图 53s Veo @ $0.60/s = $31.80，而 Veo 只接受 4/6/8s）。
- 改为目录内 **per-model 离散 chips**（Veo 4/6/8、Seedance 1.0 5/10、Seedance 2.0 fast 4/8/12），默认取**最大合法值**；同台对比把共享时长 snap 到各模型最近合法值。时长来源：Veo=Vertex 官方、Seedance 1.0=Volcengine（高置信）；Seedance 2.0 fast 各源有冲突，取最常引用的 fast 档并在注释标注待核 Ark 官方文档。
- `mediaTiers.tk.spec.ts` 锁回归：每个 video model 必须有非空、≤15s 的合法集且 default==max。

## 验证
- `go build ./...` ✓；`go test -tags=unit ./...` 全绿；`golangci-lint run ./internal/handler/...` 0 issues。
- 前端 `pnpm typecheck` / `lint:check` / `vitest`（mediaTiers + playground 共 40 测试）✓；`pnpm build` 重生成 dist + `frontend-source.json`。
- `scripts/preflight.sh` PASS。已 rebase 到 `origin/main`。

## Markers
- `no-upstream-touch`：本 PR 触及的 `frontend/src/views/user/studio/VideoStudio.vue`、`BakeOff.vue`、`frontend/src/api/playground.ts` 均为 **TokenKey 原创** 文件（已校验 `upstream/main` 上不存在），被路径启发式误判为 upstream-shaped；不存在 upstream 覆盖/回退风险。后端改动在 `*_tk_*.go` companion 内。
- `sentinel-registry-reviewed`：已审 registry-update gate 命中的 TK 热点面（`VideoStudio.vue`/`BakeOff.vue`/`playground.ts` 编辑 + `openai_gateway_tk_video.go`）——均为 UI/网关客户端的 UX 修复，非 newapi 第五平台/load-bearing 不变量，无需新增 sentinel 锚点。
- 本 PR 有前端改动，**不** 标 no-web-impact。

## 后续（非本 PR 阻塞）
- **计费核账**：受此 bug 影响、视频实际生成成功但 UI 标失败的历史扣费（本案两笔共 $9.60）建议做退款核账——属产品侧未交付。
- **更彻底方案**：后端终态成功把视频落对象存储改回 URL，从根上避免大 base64 同步透传（比单纯放宽超时更稳）。

🤖 Generated with [Claude Code](https://claude.com/claude-code)

